### PR TITLE
⚙️ ci: add coverage badge job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,9 +71,8 @@ jobs:
         run: |
           if [ -d TestResults.xcresult ]; then
             xcrun xccov view --report TestResults.xcresult
-            PCT=$(xcrun xccov view --report --json TestResults.xcresult \
-              | jq -r '.lineCoverage * 100 | . * 100 | round / 100')
             xcrun xccov view --report --json TestResults.xcresult > coverage.json
+            PCT=$(python3 -c "import sys,json; print(round(json.load(sys.stdin)['lineCoverage']*10000)/100)" < coverage.json)
             PCT=${PCT:-0.00}
             if ! [[ "$PCT" =~ ^[0-9]+\.[0-9]+$ ]]; then
               PCT=0.00


### PR DESCRIPTION
## Summary

- Extract coverage % from xccov JSON report as a job output from `lint-and-test`
- Add `coverage` job that runs on main pushes only and updates a Gist-based dynamic badge via `schneegans/dynamic-badges-action`
- Uses python3 (always available on macOS runners) instead of jq for JSON parsing

## Prerequisites

- [x] Create `GIST_SECRET` repository secret (PAT with gist scope)

## Test plan

- [ ] Push to main → verify `coverage` job runs and gist badge updates
- [x] Open a PR → verify `coverage` job is skipped (main-only condition)
- [ ] Verify `lint-and-test` output includes `coverage-pct` with valid percentage

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)