### PR TITLE
⚙️ chore: add xcodebuild pre-commit hook to catch compile errors

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -40,7 +40,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "swiftlint lint --quiet --strict"
+            "command": "cd $(git rev-parse --show-toplevel) && swiftlint lint --quiet --strict"
+          },
+          {
+            "type": "command",
+            "command": "cd $(git rev-parse --show-toplevel) && xcodebuild build -scheme Pastura -project Pastura/Pastura.xcodeproj -destination 'generic/platform=iOS Simulator' -quiet 2>&1 || (echo 'Build failed. Fix compile errors before committing.' >&2 && exit 2)"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Add `xcodebuild build` as a PreToolUse hook on `git commit` to catch compile errors before committing
- Scope existing `swiftlint` hook to repo root via `git rev-parse --show-toplevel` for worktree safety
- Use `-quiet` and `generic/platform=iOS Simulator` to keep output minimal and environment-independent

## Design decisions
- `xcodebuild build` instead of `swift test` to keep TDD cycles fast (`/implement` already runs tests explicitly)
- Exit code 2 on failure blocks the commit and surfaces compiler errors via stderr
- Success produces no output (no context window pollution)

## Test plan
- [ ] Introduce a compile error in a Swift file → `git commit` should be blocked with error details
- [ ] Commit valid code → swiftlint + build should pass silently
- [ ] Verify build logs don't appear in context on success

Closes #N/A — developer workflow improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)