### PR TITLE
🐛 fix: use additionalContext in PostToolUse ExitWorktree hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -75,7 +75,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo '{\"hookSpecificOutput\":{\"warning\":\"Before exiting: (1) Check if any memory files need to be created or updated based on this session. (2) Share any concerns, observations, or suggestions you noticed during this session but did not have a chance to mention.\"}}'"
+            "command": "echo '{\"hookSpecificOutput\":{\"additionalContext\":\"Before exiting: (1) Check if any memory files need to be created or updated based on this session. (2) Share any concerns, observations, or suggestions you noticed during this session but did not have a chance to mention.\"}}'"
           }
         ]
       },


### PR DESCRIPTION
## Summary
- PostToolUse hook for ExitWorktree used `warning` key in `hookSpecificOutput`, which is only supported for PreToolUse
- Changed to `additionalContext` so the session-exit reminder is actually delivered to Claude

## Test plan
- [ ] Next session using ExitWorktree: verify the reminder appears in Claude's context

🤖 Generated with [Claude Code](https://claude.com/claude-code)