### PR TITLE
🐛 fix: auto-rename branch after EnterWorktree in implement skill

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -154,7 +154,11 @@ Note: This is a mandatory review step between G1 and G2. The flow is G1 → Step
 2. **Ask: "Create worktree and start?"**
 3. Call `EnterWorktree` with `name: "{TASK_TYPE}/{SLUG}"`.
    - On failure: suggest alternative name or cleanup. Check `git ls-remote --heads origin <branch>` for remote collisions too; append `-2` suffix if needed.
-4. Verify: `git branch --show-current`.
+4. Rename the branch to the conventional format (EnterWorktree sanitizes `/` to `+` and prepends `worktree-`):
+   ```bash
+   git branch -m "$(git branch --show-current)" "{TASK_TYPE}/{SLUG}"
+   ```
+5. Verify: `git branch --show-current`.
 
 ## Step 3: Implementation (TDD)
 


### PR DESCRIPTION
## Summary
- Add `git branch -m` step in the implement skill's worktree setup to rename the branch from EnterWorktree's sanitized format (`worktree-chore+slug`) to the conventional format (`chore/slug`)

## Context
EnterWorktree sanitizes `/` to `+` and prepends `worktree-`, so `name: "chore/centralize-sim-dest"` produces branch `worktree-chore+centralize-sim-dest`. This required manual renaming every time.

## Test plan
- [ ] Run `/implement` with a new task and verify the branch name is `{type}/{slug}` after worktree creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)