### PR TITLE
🐛 fix: resolve simulator by UDID to avoid OS version mismatch (#46)

### DIFF
--- a/scripts/sim-dest.sh
+++ b/scripts/sim-dest.sh
@@ -28,6 +28,7 @@ SIMULATOR_NAMES=(
 
 # Resolve the first matching simulator's UDID, name, and runtime via JSON.
 # python3 is available on all macOS systems with Xcode.
+_simdest_errfile=$(mktemp)
 _simdest_result=$(python3 -c "
 import json, subprocess, sys, re
 
@@ -38,25 +39,27 @@ raw = subprocess.check_output(
 )
 data = json.loads(raw)
 
+# Sort runtimes in reverse so newest OS is preferred for each device name
 for name in priority:
-    for runtime_id, devices in data.get('devices', {}).items():
-        for device in devices:
+    for runtime_id in sorted(data.get('devices', {}).keys(), reverse=True):
+        for device in data['devices'][runtime_id]:
             if device['name'] == name:
-                # Extract human-readable OS version from runtime identifier
-                # e.g. com.apple.CoreSimulator.SimRuntime.iOS-26-4 -> iOS 26.4
                 m = re.search(r'iOS-(\d+)-(\d+)', runtime_id)
                 os_ver = f'iOS {m.group(1)}.{m.group(2)}' if m else runtime_id
                 print(f\"{device['udid']}|{name}|{os_ver}\")
                 sys.exit(0)
 
 sys.exit(1)
-" "${SIMULATOR_NAMES[@]}" 2>/dev/null) || true
+" "${SIMULATOR_NAMES[@]}" 2>"$_simdest_errfile") || true
 
 if [ -z "$_simdest_result" ]; then
   echo "Error: No available iOS Simulator found. Tried: ${SIMULATOR_NAMES[*]}" >&2
+  [ -s "$_simdest_errfile" ] && echo "Details:" >&2 && cat "$_simdest_errfile" >&2
+  rm -f "$_simdest_errfile"
   eval "$_simdest_old_opts"
   return 1 2>/dev/null || exit 1
 fi
+rm -f "$_simdest_errfile"
 
 _simdest_udid=$(echo "$_simdest_result" | cut -d'|' -f1)
 _simdest_name=$(echo "$_simdest_result" | cut -d'|' -f2)
@@ -65,6 +68,7 @@ _simdest_os=$(echo "$_simdest_result" | cut -d'|' -f3)
 export DEST="platform=iOS Simulator,id=$_simdest_udid"
 echo "Selected simulator: $_simdest_name ($_simdest_os) [id=$_simdest_udid]"
 
+unset _simdest_result _simdest_udid _simdest_name _simdest_os _simdest_errfile
 eval "$_simdest_old_opts"
 # return when sourced, exit when executed directly
 return 0 2>/dev/null || exit 0


### PR DESCRIPTION
## Summary
- Switch `sim-dest.sh` from name-based to UDID-based simulator resolution, avoiding `OS:latest` mismatch on Xcode 26 (iPhone 16 has only iOS 26.3, not 26.4)
- Update simulator priority list for Xcode 26 (add iPhone 17e/16e, keep legacy as fallback)
- Improve diagnostics: show device name + OS version + UDID; surface python3 errors on failure

## Test plan
- [ ] `source scripts/sim-dest.sh` outputs UDID-based destination with correct device/OS info
- [ ] `xcodebuild test -destination "$DEST"` resolves successfully (no "Unable to find device" error)
- [ ] Full test suite passes (248 tests)
- [ ] CI passes with the updated script

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)