### PR TITLE
🔧 fix: use let for non-mutated GRDB record variables

### DIFF
--- a/Pastura/Pastura/Data/ScenarioRepository.swift
+++ b/Pastura/Pastura/Data/ScenarioRepository.swift
@@ -31,7 +31,7 @@ nonisolated public final class GRDBScenarioRepository: ScenarioRepository, Senda
   public func save(_ record: ScenarioRecord) throws {
     try dbWriter.write { db in
       // save = insert or replace (upsert)
-      var mutable = record
+      let mutable = record
       try mutable.save(db)
     }
   }

--- a/Pastura/Pastura/Data/SimulationRepository.swift
+++ b/Pastura/Pastura/Data/SimulationRepository.swift
@@ -41,7 +41,7 @@ nonisolated public final class GRDBSimulationRepository: SimulationRepository, S
 
   public func save(_ record: SimulationRecord) throws {
     try dbWriter.write { db in
-      var mutable = record
+      let mutable = record
       try mutable.save(db)
     }
   }

--- a/Pastura/Pastura/Data/TurnRepository.swift
+++ b/Pastura/Pastura/Data/TurnRepository.swift
@@ -34,14 +34,14 @@ nonisolated public final class GRDBTurnRepository: TurnRepository, Sendable {
 
   public func save(_ record: TurnRecord) throws {
     try dbWriter.write { db in
-      var mutable = record
+      let mutable = record
       try mutable.insert(db)
     }
   }
 
   public func saveBatch(_ records: [TurnRecord]) throws {
     try dbWriter.write { db in
-      for var record in records {
+      for record in records {
         try record.insert(db)
       }
     }


### PR DESCRIPTION
## Summary
- Change `var` to `let` for GRDB record variables in `ScenarioRepository`, `SimulationRepository`, and `TurnRepository`
- Records use TEXT primary keys (UUIDs), so `save()`/`insert()` never mutate the receiver
- Silences 4 Xcode "variable was never mutated" warnings

## Test plan
- [x] Full test suite passes (all tests green)
- [x] swiftlint: 0 violations
- [x] code-reviewer: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)