### PR TITLE
🛡️ fix: add runtime concurrent access guard for LlamaCppService (#71)

### DIFF
--- a/Pastura/Pastura/LLM/LlamaCppService.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService.swift
@@ -7,8 +7,9 @@ import os
 /// Loads a GGUF model file from disk and runs inference locally.
 /// Designed for TestFlight production use with Gemma 4 E2B.
 ///
-/// - Important: Not safe for concurrent `generate`/`unloadModel` calls.
+/// - Important: Not safe for concurrent `generate`/`loadModel`/`unloadModel` calls.
 ///   The Engine executes inferences sequentially, so this is fine in practice.
+///   A runtime guard (`precondition`) detects violations in both Debug and Release builds.
 nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable {
   // @unchecked Sendable: isModelLoaded flag protected by OSAllocatedUnfairLock.
   // C pointers use nonisolated(unsafe) — Engine calls generate() sequentially via
@@ -28,6 +29,9 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
   private static let batchSize: Int = 512
 
   private let loadedState: OSAllocatedUnfairLock<Bool>
+  // Runtime guard for the sequential access contract (ADR-002 §6).
+  // Catches concurrent generate(), or load/unload during active generation.
+  private let generatingGuard = OSAllocatedUnfairLock<Bool>(initialState: false)
   // Sequential access only — protected by concurrency contract, not by lock
   nonisolated(unsafe) private var _model: OpaquePointer?
   nonisolated(unsafe) private var _context: OpaquePointer?
@@ -52,6 +56,11 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
   // MARK: - LLMService
 
   public func loadModel() async throws {
+    precondition(
+      !generatingGuard.withLock({ $0 }),
+      "loadModel() called during active generate() — see ADR-002 §6"
+    )
+
     // llama_backend_init is internally ref-counted — safe to call multiple times
     llama_backend_init()
 
@@ -79,6 +88,13 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
   }
 
   public func unloadModel() async throws {
+    // TODO: When didReceiveMemoryWarning handler is implemented, it must await
+    // simulation task completion before calling unloadModel() — see ADR-002 §7.
+    precondition(
+      !generatingGuard.withLock({ $0 }),
+      "unloadModel() called during active generate() — see ADR-002 §6"
+    )
+
     let wasLoaded = loadedState.withLock { loaded -> Bool in
       let was = loaded
       loaded = false
@@ -111,6 +127,16 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
     guard isModelLoaded, let model = _model, let context = _context else {
       throw LLMError.notLoaded
     }
+
+    // Runtime enforcement of sequential access contract (ADR-002 §6).
+    // Fires in both Debug and Release — concurrent generate() would cause use-after-free.
+    let wasGenerating = generatingGuard.withLock { flag -> Bool in
+      let was = flag
+      flag = true
+      return was
+    }
+    precondition(!wasGenerating, "Concurrent generate() call detected — see ADR-002 §6")
+    defer { generatingGuard.withLock { $0 = false } }
 
     let vocab = llama_model_get_vocab(model)
 

--- a/Pastura/Pastura/LLM/LlamaCppService.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService.swift
@@ -56,10 +56,7 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
   // MARK: - LLMService
 
   public func loadModel() async throws {
-    precondition(
-      !generatingGuard.withLock({ $0 }),
-      "loadModel() called during active generate() — see ADR-002 §6"
-    )
+    precondition(!generatingGuard.withLock({ $0 }), "loadModel() during generate() — ADR-002 §6")
 
     // llama_backend_init is internally ref-counted — safe to call multiple times
     llama_backend_init()
@@ -88,12 +85,8 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
   }
 
   public func unloadModel() async throws {
-    // TODO: When didReceiveMemoryWarning handler is implemented, it must await
-    // simulation task completion before calling unloadModel() — see ADR-002 §7.
-    precondition(
-      !generatingGuard.withLock({ $0 }),
-      "unloadModel() called during active generate() — see ADR-002 §6"
-    )
+    // TODO: didReceiveMemoryWarning must await simulation completion before calling this (ADR-002 §7).
+    precondition(!generatingGuard.withLock({ $0 }), "unloadModel() during generate() — ADR-002 §6")
 
     let wasLoaded = loadedState.withLock { loaded -> Bool in
       let was = loaded
@@ -129,13 +122,13 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
     }
 
     // Runtime enforcement of sequential access contract (ADR-002 §6).
-    // Fires in both Debug and Release — concurrent generate() would cause use-after-free.
+    // Concurrent generate() would cause use-after-free of C pointers.
     let wasGenerating = generatingGuard.withLock { flag -> Bool in
       let was = flag
       flag = true
       return was
     }
-    precondition(!wasGenerating, "Concurrent generate() call detected — see ADR-002 §6")
+    precondition(!wasGenerating, "Concurrent generate() detected — ADR-002 §6")
     defer { generatingGuard.withLock { $0 = false } }
 
     let vocab = llama_model_get_vocab(model)

--- a/Pastura/Pastura/LLM/LlamaCppService.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService.swift
@@ -15,6 +15,10 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
   // C pointers use nonisolated(unsafe) — Engine calls generate() sequentially via
   // `for await` on a single AsyncStream, and loadModel()/unloadModel() bracket the
   // stream lifetime, guaranteeing no concurrent access to C pointers (ADR-002 §6).
+  //
+  // NOTE: Class body is at the SwiftLint type_body_length limit (250 lines).
+  // Future additions should extract helpers into private extensions or separate files
+  // (e.g., tokenization, sampler setup, or chat template logic).
 
   private let modelPath: String
   private let logger = Logger(subsystem: "com.pastura", category: "LlamaCppService")
@@ -123,6 +127,9 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
 
     // Runtime enforcement of sequential access contract (ADR-002 §6).
     // Concurrent generate() would cause use-after-free of C pointers.
+    // IMPORTANT: This guard is intentionally placed after the isModelLoaded check above.
+    // Calls that fail with .notLoaded must not touch the flag — otherwise the flag
+    // stays true and the next sequential call would be falsely flagged as concurrent.
     let wasGenerating = generatingGuard.withLock { flag -> Bool in
       let was = flag
       flag = true

--- a/Pastura/PasturaTests/LLM/LlamaCppServiceTests.swift
+++ b/Pastura/PasturaTests/LLM/LlamaCppServiceTests.swift
@@ -65,4 +65,32 @@ struct LlamaCppServiceTests {
       try await service.generate(system: "sys", user: "usr")
     }
   }
+
+  // MARK: - Concurrent access guard (no false positives)
+
+  @Test func guardAllowsSequentialGenerateCalls() async {
+    let service = LlamaCppService(modelPath: "/nonexistent.gguf")
+    // Sequential generate() calls should not trigger the guard.
+    // Both throw notLoaded (no model loaded), but the guard itself must not fire.
+    await #expect(throws: LLMError.notLoaded) {
+      try await service.generate(system: "sys", user: "usr")
+    }
+    await #expect(throws: LLMError.notLoaded) {
+      try await service.generate(system: "sys", user: "usr")
+    }
+  }
+
+  @Test func guardAllowsLoadUnloadCycle() async throws {
+    let service = LlamaCppService(modelPath: "/nonexistent.gguf")
+    // load (fails) → generate (fails) → unload → generate (fails)
+    // None of these overlap, so the guard must not fire.
+    try? await service.loadModel()
+    await #expect(throws: LLMError.notLoaded) {
+      try await service.generate(system: "sys", user: "usr")
+    }
+    try await service.unloadModel()
+    await #expect(throws: LLMError.notLoaded) {
+      try await service.generate(system: "sys", user: "usr")
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Adds `OSAllocatedUnfairLock<Bool>` guard (`generatingGuard`) to `LlamaCppService` that enforces the sequential access contract (ADR-002 §6) at runtime
- Uses `precondition` (fires in both Debug and Release) to detect: concurrent `generate()` calls, and `loadModel()`/`unloadModel()` called during active generation
- Prevents silent use-after-free of C pointers (`_model`, `_context`) which could cause memory corruption or non-deterministic crashes

## Test plan

- [ ] All existing `LlamaCppServiceTests` pass (lifecycle, error paths, conformance)
- [ ] New `guardAllowsSequentialGenerateCalls` — verifies no false positive on back-to-back `generate()` calls
- [ ] New `guardAllowsLoadUnloadCycle` — verifies no false positive on load → generate → unload → generate lifecycle
- [ ] Full test suite passes: `xcodebuild test -scheme Pastura`
- [ ] SwiftLint clean: `swiftlint lint --quiet --strict`

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)