### PR TITLE
🐛 fix: exclude model data from iCloud backup and use proper directories

### DIFF
--- a/Pastura/Pastura/App/ModelManager.swift
+++ b/Pastura/Pastura/App/ModelManager.swift
@@ -67,15 +67,12 @@ final class ModelManager {
 
   // MARK: - Computed
 
-  /// Full path to the model file in the Documents directory.
+  /// Directory for the completed model file: Library/Application Support/.
+  /// Application Support persists across app updates and is not purged by the OS,
+  /// unlike Library/Caches/. The model file is excluded from iCloud backup
+  /// (isExcludedFromBackup) because it can be re-downloaded (~3 GB).
   var modelDirectoryURL: URL {
-    // Documents directory is the standard location for user-downloaded content.
-    // It persists across app updates and is backed up by iCloud (appropriate for a 3 GB file
-    // the user explicitly downloaded).
-    // Fallback to temp directory only as a safety net — .documentDirectory should always
-    // exist on iOS. Using temp would mean the model file is lost on reboot, but this
-    // path is unreachable in practice.
-    fileManager.urls(for: .documentDirectory, in: .userDomainMask).first
+    fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
       ?? fileManager.temporaryDirectory
   }
 
@@ -83,8 +80,14 @@ final class ModelManager {
     modelDirectoryURL.appendingPathComponent(Self.modelFileName)
   }
 
+  /// Partial download file stored in Library/Caches/.
+  /// Caches is appropriate because: not backed up by iCloud, and if the OS purges it
+  /// under storage pressure, the download simply restarts (resume offset = 0).
   var downloadFileURL: URL {
-    modelDirectoryURL.appendingPathComponent(Self.downloadFileName)
+    let cachesDir =
+      fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first
+      ?? fileManager.temporaryDirectory
+    return cachesDir.appendingPathComponent(Self.downloadFileName)
   }
 
   // MARK: - Init
@@ -125,6 +128,8 @@ final class ModelManager {
           return
         }
       }
+      // Best-effort: re-apply on every launch as a safety net in case a prior attempt failed.
+      excludeFromBackup(modelFileURL)
       state = .ready(modelPath: modelFileURL.path)
     } else {
       state = .notDownloaded
@@ -198,13 +203,18 @@ final class ModelManager {
         return
       }
 
-      // Atomic rename from .download to final path
-      // Remove existing file at destination if present (e.g., corrupt from prior attempt)
+      // Ensure Application Support directory exists before moving the file.
+      let modelDir = modelFileURL.deletingLastPathComponent()
+      try fileManager.createDirectory(at: modelDir, withIntermediateDirectories: true)
+
+      // Atomic rename from Caches/.download to Application Support/ final path.
+      // Same volume on iOS, so this is an atomic rename (no copy+delete).
       if fileManager.fileExists(atPath: modelFileURL.path) {
         try fileManager.removeItem(at: modelFileURL)
       }
       try fileManager.moveItem(at: downloadFileURL, to: modelFileURL)
 
+      excludeFromBackup(modelFileURL)
       state = .ready(modelPath: modelFileURL.path)
     } catch is CancellationError {
       // Download was cancelled — keep partial file for resume
@@ -220,6 +230,18 @@ final class ModelManager {
     downloadTask?.cancel()
     downloadTask = nil
     state = .notDownloaded
+  }
+
+  // MARK: - Backup Exclusion
+
+  /// Marks a file as excluded from iCloud backup.
+  /// Best-effort: failure is non-fatal because the file is still usable,
+  /// and checkModelStatus() re-applies on every launch as a safety net.
+  private func excludeFromBackup(_ url: URL) {
+    var mutableURL = url
+    var values = URLResourceValues()
+    values.isExcludedFromBackup = true
+    try? mutableURL.setResourceValues(values)
   }
 
   // MARK: - Download Integrity

--- a/Pastura/PasturaTests/App/ModelManagerTests.swift
+++ b/Pastura/PasturaTests/App/ModelManagerTests.swift
@@ -79,11 +79,13 @@ struct ModelManagerTests {
   }
 
   @Test("checkModelStatus sets ready when model file exists")
-  func modelReady() {
+  func modelReady() throws {
     let sut = makeSUT()
 
     // Place a dummy file at the model path
     let modelPath = sut.modelFileURL
+    try FileManager.default.createDirectory(
+      at: modelPath.deletingLastPathComponent(), withIntermediateDirectories: true)
     FileManager.default.createFile(atPath: modelPath.path, contents: Data("test".utf8))
     defer { try? FileManager.default.removeItem(at: modelPath) }
 
@@ -164,10 +166,12 @@ struct ModelManagerTests {
   // MARK: - Delete
 
   @Test("deleteModel removes files and sets state to notDownloaded")
-  func deleteModel() {
+  func deleteModel() throws {
     let sut = makeSUT()
 
     // Create model file
+    try FileManager.default.createDirectory(
+      at: sut.modelFileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
     FileManager.default.createFile(atPath: sut.modelFileURL.path, contents: Data("test".utf8))
     sut.checkModelStatus()
     #expect(sut.state == .ready(modelPath: sut.modelFileURL.path))

--- a/Pastura/PasturaTests/App/ModelManagerTests.swift
+++ b/Pastura/PasturaTests/App/ModelManagerTests.swift
@@ -178,6 +178,63 @@ struct ModelManagerTests {
     #expect(!FileManager.default.fileExists(atPath: sut.modelFileURL.path))
   }
 
+  // MARK: - Storage Location
+
+  @Test("modelFileURL is in Application Support directory")
+  func modelFileInApplicationSupport() {
+    let sut = makeSUT()
+    #expect(sut.modelFileURL.path.contains("Application Support"))
+    #expect(!sut.modelFileURL.path.contains("Documents"))
+  }
+
+  @Test("downloadFileURL is in Caches directory")
+  func downloadFileInCaches() {
+    let sut = makeSUT()
+    #expect(sut.downloadFileURL.path.contains("Caches"))
+    #expect(!sut.downloadFileURL.path.contains("Documents"))
+  }
+
+  // MARK: - iCloud Backup Exclusion
+
+  @Test("checkModelStatus sets isExcludedFromBackup on existing model file")
+  func checkModelStatusExcludesFromBackup() throws {
+    let sut = makeSUT()
+
+    // Create the model directory and file
+    let modelDir = sut.modelFileURL.deletingLastPathComponent()
+    try FileManager.default.createDirectory(at: modelDir, withIntermediateDirectories: true)
+    FileManager.default.createFile(atPath: sut.modelFileURL.path, contents: Data("test".utf8))
+    defer { try? FileManager.default.removeItem(at: sut.modelFileURL) }
+
+    sut.checkModelStatus()
+
+    let values = try sut.modelFileURL.resourceValues(forKeys: [.isExcludedFromBackupKey])
+    #expect(values.isExcludedFromBackup == true)
+  }
+
+  @Test("downloadModel sets isExcludedFromBackup on completed model file")
+  func downloadSetsExcludeFromBackup() async throws {
+    let sut = makeSUT(
+      downloader: MockModelDownloader(statusCode: 200, simulateBytes: 100)
+    )
+    sut.checkModelStatus()
+    #expect(sut.state == .notDownloaded)
+
+    await sut.downloadModel()
+    defer {
+      try? FileManager.default.removeItem(at: sut.modelFileURL)
+      try? FileManager.default.removeItem(at: sut.downloadFileURL)
+    }
+
+    guard case .ready = sut.state else {
+      Issue.record("Expected .ready but got \(sut.state)")
+      return
+    }
+
+    let values = try sut.modelFileURL.resourceValues(forKeys: [.isExcludedFromBackupKey])
+    #expect(values.isExcludedFromBackup == true)
+  }
+
   // MARK: - Edge Cases
 
   @Test("checkModelStatus boundary: ~7.5 GB (8 GB device) is supported")


### PR DESCRIPTION
## Summary
- Move GGUF model file from Documents/ to Library/Application Support/ with `isExcludedFromBackup`
- Move partial download file to Library/Caches/ (not backed up, OS may purge under pressure)
- Prevents ~3 GB of re-downloadable data from consuming iCloud storage

## Test plan
- [x] New tests verify modelFileURL is in Application Support
- [x] New tests verify downloadFileURL is in Caches
- [x] New tests verify isExcludedFromBackup is set after checkModelStatus and download
- [x] Full test suite passes with no regressions

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)