### PR TITLE
✨ feat: export simulation results to Markdown via Share Sheet

### DIFF
--- a/Pastura/Pastura/App/ResultMarkdownExporter.swift
+++ b/Pastura/Pastura/App/ResultMarkdownExporter.swift
@@ -71,8 +71,20 @@ struct ResultMarkdownExporter {
     sections.append(renderMetadata(input))
     sections.append(renderScenarioYAML(input))
     sections.append(renderTurnLog(input))
-    sections.append(renderFinalScores(input))
+    if hasMeaningfulScoreData(input.state) {
+      sections.append(renderFinalScores(input))
+    }
     return sections.joined(separator: "\n\n") + "\n"
+  }
+
+  // Observation-only scenarios (e.g. pure speak_each / Asch conformity) have
+  // no scoring phase — state.scores is still initialized with 0 per agent, so
+  // suppressing the "Final Scores" section requires a semantic check rather
+  // than an emptiness check.
+  private func hasMeaningfulScoreData(_ state: SimulationState) -> Bool {
+    state.scores.values.contains(where: { $0 != 0 })
+      || state.eliminated.values.contains(true)
+      || !state.voteResults.isEmpty
   }
 
   private func renderMetadata(_ input: Input) -> String {

--- a/Pastura/Pastura/App/ResultMarkdownExporter.swift
+++ b/Pastura/Pastura/App/ResultMarkdownExporter.swift
@@ -152,7 +152,14 @@ struct ResultMarkdownExporter {
     }
     let output = decodeOutput(turn)
     let content = formatOutput(output, phaseType: turn.phaseType)
-    return "- **\(agent)**: \(content)"
+    var line = "- **\(agent)**: \(content)"
+    // Include inner_thought as a nested bullet — the gap between outward
+    // behavior and inner reasoning is often the most analyzable signal in a
+    // multi-agent run (e.g. Asch-style conformity).
+    if let thought = output.innerThought, !thought.isEmpty {
+      line += "\n  - 💭 _\(thought)_"
+    }
+    return line
   }
 
   private func decodeOutput(_ turn: TurnRecord) -> TurnOutput {

--- a/Pastura/Pastura/App/ResultMarkdownExporter.swift
+++ b/Pastura/Pastura/App/ResultMarkdownExporter.swift
@@ -1,0 +1,249 @@
+import Foundation
+
+/// Formats a completed simulation into a Markdown document for external sharing
+/// (Claude analysis, SNS, experiment logging) and writes it to a temp file URL.
+///
+/// The exporter is intentionally a `@MainActor`-default type in the App layer
+/// — it composes records produced on background threads with `ContentFilter`
+/// (also App-layer), and is invoked from SwiftUI views. For long renders, call
+/// it inside `offMain { ... }` from the caller side.
+///
+/// ContentFilter is applied as a **whole-string pass** on the final rendered
+/// Markdown, not per-field, so YAML content, persona names, and conversation
+/// log prose are all covered in one sweep.
+struct ResultMarkdownExporter {
+  /// Environment metadata captured at export time.
+  struct ExportEnvironment: Sendable {
+    /// `UIDevice.current.model` value (e.g. "iPhone").
+    let deviceModel: String
+    /// `ProcessInfo.processInfo.operatingSystemVersionString` value.
+    let osVersion: String
+  }
+
+  /// The exporter's output — both the Markdown text and a temp-file URL for
+  /// sharing. `Identifiable` so it can drive `.sheet(item:)` directly.
+  struct ExportedResult: Identifiable, Sendable {
+    let id = UUID()
+    let text: String
+    let fileURL: URL
+  }
+
+  /// Bundled inputs describing the simulation to export.
+  struct Input {
+    let simulation: SimulationRecord
+    let scenario: ScenarioRecord
+    let turns: [TurnRecord]
+    let state: SimulationState
+  }
+
+  private let contentFilter: ContentFilter
+  private let environment: ExportEnvironment
+  private let now: Date
+  private let fileManager: FileManager
+
+  init(
+    contentFilter: ContentFilter,
+    environment: ExportEnvironment,
+    now: Date = Date(),
+    fileManager: FileManager = .default
+  ) {
+    self.contentFilter = contentFilter
+    self.environment = environment
+    self.now = now
+    self.fileManager = fileManager
+  }
+
+  /// Renders the input as Markdown, applies `ContentFilter`, writes to a temp
+  /// `.md` file, and returns both the text and URL.
+  func export(_ input: Input) throws -> ExportedResult {
+    let raw = renderMarkdown(input)
+    let filtered = contentFilter.filter(raw)
+    let url = try writeToTempFile(text: filtered, scenarioName: input.scenario.name)
+    return ExportedResult(text: filtered, fileURL: url)
+  }
+
+  // MARK: - Rendering
+
+  private func renderMarkdown(_ input: Input) -> String {
+    var sections: [String] = []
+    sections.append("<!-- pastura-export v1 -->")
+    sections.append("# Simulation Export: \(input.scenario.name)")
+    sections.append(renderMetadata(input))
+    sections.append(renderScenarioYAML(input))
+    sections.append(renderTurnLog(input))
+    sections.append(renderFinalScores(input))
+    return sections.joined(separator: "\n\n") + "\n"
+  }
+
+  private func renderMetadata(_ input: Input) -> String {
+    let sim = input.simulation
+    let status = sim.simulationStatus?.rawValue ?? sim.status
+    let started = Self.isoFormatter.string(from: sim.createdAt)
+    let ended = Self.isoFormatter.string(from: sim.updatedAt)
+    let duration = formatDuration(sim.updatedAt.timeIntervalSince(sim.createdAt))
+    let model = sim.modelIdentifier ?? "(unknown)"
+    let backend = sim.llmBackend ?? "(unknown)"
+    let inferenceCount = input.turns.filter { $0.agentName != nil }.count
+
+    return """
+      ## Metadata
+
+      - **Scenario**: \(input.scenario.name) (`\(input.scenario.id)`)
+      - **Status**: \(status)
+      - **Started**: \(started)
+      - **Ended**: \(ended)
+      - **Duration**: \(duration)
+      - **Model**: \(model)
+      - **Backend**: \(backend)
+      - **Device**: \(environment.deviceModel) / \(environment.osVersion)
+      - **Inference count**: \(inferenceCount)
+      """
+  }
+
+  private func renderScenarioYAML(_ input: Input) -> String {
+    """
+    ## Scenario Definition
+
+    ```yaml
+    \(input.scenario.yamlDefinition)
+    ```
+    """
+  }
+
+  private func renderTurnLog(_ input: Input) -> String {
+    guard !input.turns.isEmpty else {
+      return "## Turn Log\n\n_No turns recorded._"
+    }
+
+    var lines: [String] = ["## Turn Log"]
+    // Group turns by round while preserving sequenceNumber order within each round.
+    let sorted = input.turns.sorted { $0.sequenceNumber < $1.sequenceNumber }
+    let grouped = Dictionary(grouping: sorted, by: { $0.roundNumber })
+    for round in grouped.keys.sorted() {
+      lines.append("")
+      lines.append("### Round \(round)")
+      let turnsInRound = grouped[round] ?? []
+      // Group by phase within round, preserving first-seen order.
+      var phaseOrder: [String] = []
+      var byPhase: [String: [TurnRecord]] = [:]
+      for turn in turnsInRound {
+        if byPhase[turn.phaseType] == nil {
+          phaseOrder.append(turn.phaseType)
+          byPhase[turn.phaseType] = []
+        }
+        byPhase[turn.phaseType]?.append(turn)
+      }
+      for phase in phaseOrder {
+        lines.append("")
+        lines.append("#### Phase: \(phase)")
+        for turn in byPhase[phase] ?? [] {
+          lines.append(renderTurnLine(turn))
+        }
+      }
+    }
+    return lines.joined(separator: "\n")
+  }
+
+  private func renderTurnLine(_ turn: TurnRecord) -> String {
+    guard let agent = turn.agentName else {
+      // Code phase turn — no agent, no LLM output to render. Emit a placeholder
+      // so the phase's presence is still visible in the log.
+      return "- _(code phase — no agent output)_"
+    }
+    let output = decodeOutput(turn)
+    let content = formatOutput(output, phaseType: turn.phaseType)
+    return "- **\(agent)**: \(content)"
+  }
+
+  private func decodeOutput(_ turn: TurnRecord) -> TurnOutput {
+    guard
+      let data = turn.parsedOutputJSON.data(using: .utf8),
+      let output = try? JSONDecoder().decode(TurnOutput.self, from: data)
+    else {
+      return TurnOutput(fields: [:])
+    }
+    return output
+  }
+
+  // Picks the most natural field for display per phase. Falls back to a JSON
+  // dump of all fields if none of the common ones are present — keeps unknown
+  // phase types readable without requiring exporter changes.
+  private func formatOutput(_ output: TurnOutput, phaseType: String) -> String {
+    if let statement = output.statement, !statement.isEmpty { return statement }
+    if let vote = output.vote, !vote.isEmpty { return "→ \(vote)" }
+    if let action = output.action, !action.isEmpty { return "(action: \(action))" }
+    if let declaration = output.declaration, !declaration.isEmpty { return declaration }
+    if output.fields.isEmpty { return "_(empty)_" }
+    let pairs = output.fields.keys.sorted().map { "\($0)=\(output.fields[$0] ?? "")" }
+    return pairs.joined(separator: ", ")
+  }
+
+  private func renderFinalScores(_ input: Input) -> String {
+    let scores = input.state.scores
+    guard !scores.isEmpty else {
+      return "## Final Scores\n\n_No score data._"
+    }
+    var lines: [String] = [
+      "## Final Scores", "", "| Agent | Score | Status |", "|-------|-------|--------|"
+    ]
+    let ordered = scores.sorted { lhs, rhs in
+      if lhs.value != rhs.value { return lhs.value > rhs.value }
+      return lhs.key < rhs.key
+    }
+    for (agent, score) in ordered {
+      let eliminated = input.state.eliminated[agent] == true
+      let status = eliminated ? "eliminated" : "active"
+      lines.append("| \(agent) | \(score) | \(status) |")
+    }
+    return lines.joined(separator: "\n")
+  }
+
+  // MARK: - Duration formatting
+
+  private func formatDuration(_ seconds: TimeInterval) -> String {
+    let total = max(Int(seconds.rounded()), 0)
+    let minutes = total / 60
+    let secs = total % 60
+    if minutes == 0 { return "\(secs)s" }
+    return "\(minutes)m \(secs)s"
+  }
+
+  // MARK: - File writing
+
+  private func writeToTempFile(text: String, scenarioName: String) throws -> URL {
+    let sanitized = Self.sanitizeFilename(scenarioName)
+    let timestamp = Self.timestampFormatter.string(from: now)
+    let filename = "\(sanitized)_\(timestamp).md"
+    let url = fileManager.temporaryDirectory.appendingPathComponent(filename)
+    try text.write(to: url, atomically: true, encoding: .utf8)
+    return url
+  }
+
+  /// Public so tests can validate the rule directly.
+  static func sanitizeFilename(_ name: String) -> String {
+    // Keep Unicode letters/digits, underscore, and hyphen; replace anything else
+    // with underscore so Japanese / emoji scenario names produce usable filenames.
+    let allowed = CharacterSet.letters.union(.decimalDigits).union(CharacterSet(charactersIn: "_-"))
+    let mapped = name.unicodeScalars.map { allowed.contains($0) ? Character($0) : "_" }
+    let collapsed = String(mapped)
+    let trimmed = collapsed.isEmpty ? "export" : collapsed
+    // Cap length to keep temp paths reasonable on all filesystems.
+    return String(trimmed.prefix(50))
+  }
+
+  // MARK: - Formatters
+
+  private static let isoFormatter: ISO8601DateFormatter = {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime]
+    return formatter
+  }()
+
+  private static let timestampFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    formatter.dateFormat = "yyyyMMdd-HHmmss"
+    return formatter
+  }()
+}

--- a/Pastura/Pastura/App/ResultMarkdownExporter.swift
+++ b/Pastura/Pastura/App/ResultMarkdownExporter.swift
@@ -16,8 +16,18 @@ struct ResultMarkdownExporter {
   struct ExportEnvironment: Sendable {
     /// `UIDevice.current.model` value (e.g. "iPhone").
     let deviceModel: String
-    /// `ProcessInfo.processInfo.operatingSystemVersionString` value.
+    /// Normalized OS version string — `"iOS 26.4 (build 23E246)"` style.
+    /// Apply `normalizeOSVersion(_:)` to the raw
+    /// `ProcessInfo.operatingSystemVersionString` before constructing.
     let osVersion: String
+
+    /// Rewrites Apple's `"Version X.Y (Build ABC)"` into `"iOS X.Y (build ABC)"`
+    /// so exported metadata reads naturally. Safe on strings that don't match
+    /// the pattern — they pass through unchanged.
+    static func normalizeOSVersion(_ raw: String) -> String {
+      raw.replacingOccurrences(of: "Version ", with: "iOS ")
+        .replacingOccurrences(of: "(Build ", with: "(build ")
+    }
   }
 
   /// The exporter's output — both the Markdown text and a temp-file URL for

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -127,7 +127,8 @@ final class SimulationViewModel {
     let simId = UUID().uuidString
     simulationId = simId
     let initialState = SimulationState.initial(for: scenario)
-    await createSimulationRecord(simId: simId, scenario: scenario, state: initialState)
+    await createSimulationRecord(
+      simId: simId, scenario: scenario, state: initialState, llm: llm)
 
     turnSequence = 0
 
@@ -268,7 +269,7 @@ final class SimulationViewModel {
   // MARK: - Persistence
 
   private func createSimulationRecord(
-    simId: String, scenario: Scenario, state: SimulationState
+    simId: String, scenario: Scenario, state: SimulationState, llm: any LLMService
   ) async {
     do {
       let stateJSON = try JSONEncoder().encode(state)
@@ -281,7 +282,9 @@ final class SimulationViewModel {
         stateJSON: String(data: stateJSON, encoding: .utf8) ?? "{}",
         configJSON: nil,
         createdAt: Date(),
-        updatedAt: Date()
+        updatedAt: Date(),
+        modelIdentifier: llm.modelIdentifier,
+        llmBackend: llm.backendIdentifier
       )
       try await offMain { [simulationRepository] in
         try simulationRepository.save(record)

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -43,7 +43,7 @@ enum PlaybackSpeed: Double, CaseIterable, Identifiable {
 /// Consumes `AsyncStream<SimulationEvent>` from `SimulationRunner`, applies
 /// `ContentFilter`, persists turn records, and manages pause/resume + LLM lifecycle.
 @Observable
-final class SimulationViewModel {
+final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   // MARK: - Published State
 
   private(set) var logEntries: [LogEntry] = []
@@ -339,14 +339,15 @@ final class SimulationViewModel {
 
   // MARK: - Export
 
+  private struct ExportRecords: Sendable {
+    let simulation: SimulationRecord
+    let scenario: ScenarioRecord
+    let turns: [TurnRecord]
+  }
+
   /// Fetches the current simulation's records and renders them as a Markdown
-  /// export payload. Returns `nil` when the simulation is not in a state that
-  /// produces meaningful output (no `simulationId`, status not `.completed`,
-  /// or `scenarioRepository` was not injected).
-  ///
-  /// Intentionally runs fetches sequentially on a single `offMain` hop — the
-  /// three reads touch different tables but share the same `DatabaseQueue`, so
-  /// parallelism would not win over the serial writer.
+  /// export payload. Returns `nil` when the simulation is not started, not
+  /// `.completed`, or when `scenarioRepository` was not injected.
   func fetchExportPayload(
     exportEnvironment: ResultMarkdownExporter.ExportEnvironment
   ) async throws -> ResultMarkdownExporter.ExportedResult? {
@@ -354,29 +355,28 @@ final class SimulationViewModel {
     let simulationRepository = self.simulationRepository
     let turnRepository = self.turnRepository
 
-    let payload: (simulation: SimulationRecord, scenario: ScenarioRecord, turns: [TurnRecord])? =
-      try await offMain {
-        guard
-          let sim = try simulationRepository.fetchById(simId),
-          let scenario = try scenarioRepository.fetchById(sim.scenarioId)
-        else {
-          return nil
-        }
-        let turns = try turnRepository.fetchBySimulationId(simId)
-        return (sim, scenario, turns)
+    let records: ExportRecords? = try await offMain {
+      guard
+        let sim = try simulationRepository.fetchById(simId),
+        let scenario = try scenarioRepository.fetchById(sim.scenarioId)
+      else {
+        return nil
       }
+      let turns = try turnRepository.fetchBySimulationId(simId)
+      return ExportRecords(simulation: sim, scenario: scenario, turns: turns)
+    }
 
-    guard let payload, payload.simulation.simulationStatus == .completed else { return nil }
+    guard let records, records.simulation.simulationStatus == .completed else { return nil }
 
-    let state = decodeState(from: payload.simulation) ?? SimulationState()
+    let state = decodeState(from: records.simulation) ?? SimulationState()
     let exporter = ResultMarkdownExporter(
       contentFilter: contentFilter,
       environment: exportEnvironment)
     return try exporter.export(
       ResultMarkdownExporter.Input(
-        simulation: payload.simulation,
-        scenario: payload.scenario,
-        turns: payload.turns,
+        simulation: records.simulation,
+        scenario: records.scenario,
+        turns: records.turns,
         state: state))
   }
 

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -71,6 +71,7 @@ final class SimulationViewModel {
   private let contentFilter: ContentFilter
   private let simulationRepository: any SimulationRepository
   private let turnRepository: any TurnRepository
+  private let scenarioRepository: (any ScenarioRepository)?
   private var simulationId: String?
 
   /// Holds the currently running simulation task for cancellation support.
@@ -92,12 +93,14 @@ final class SimulationViewModel {
     runner: SimulationRunner = SimulationRunner(),
     contentFilter: ContentFilter = ContentFilter(),
     simulationRepository: any SimulationRepository,
-    turnRepository: any TurnRepository
+    turnRepository: any TurnRepository,
+    scenarioRepository: (any ScenarioRepository)? = nil
   ) {
     self.runner = runner
     self.contentFilter = contentFilter
     self.simulationRepository = simulationRepository
     self.turnRepository = turnRepository
+    self.scenarioRepository = scenarioRepository
   }
 
   // MARK: - Simulation Lifecycle
@@ -332,6 +335,54 @@ final class SimulationViewModel {
     } catch {
       print("⚠️ Failed to encode turn output: \(error)")
     }
+  }
+
+  // MARK: - Export
+
+  /// Fetches the current simulation's records and renders them as a Markdown
+  /// export payload. Returns `nil` when the simulation is not in a state that
+  /// produces meaningful output (no `simulationId`, status not `.completed`,
+  /// or `scenarioRepository` was not injected).
+  ///
+  /// Intentionally runs fetches sequentially on a single `offMain` hop — the
+  /// three reads touch different tables but share the same `DatabaseQueue`, so
+  /// parallelism would not win over the serial writer.
+  func fetchExportPayload(
+    exportEnvironment: ResultMarkdownExporter.ExportEnvironment
+  ) async throws -> ResultMarkdownExporter.ExportedResult? {
+    guard let simId = simulationId, let scenarioRepository else { return nil }
+    let simulationRepository = self.simulationRepository
+    let turnRepository = self.turnRepository
+
+    let payload: (simulation: SimulationRecord, scenario: ScenarioRecord, turns: [TurnRecord])? =
+      try await offMain {
+        guard
+          let sim = try simulationRepository.fetchById(simId),
+          let scenario = try scenarioRepository.fetchById(sim.scenarioId)
+        else {
+          return nil
+        }
+        let turns = try turnRepository.fetchBySimulationId(simId)
+        return (sim, scenario, turns)
+      }
+
+    guard let payload, payload.simulation.simulationStatus == .completed else { return nil }
+
+    let state = decodeState(from: payload.simulation) ?? SimulationState()
+    let exporter = ResultMarkdownExporter(
+      contentFilter: contentFilter,
+      environment: exportEnvironment)
+    return try exporter.export(
+      ResultMarkdownExporter.Input(
+        simulation: payload.simulation,
+        scenario: payload.scenario,
+        turns: payload.turns,
+        state: state))
+  }
+
+  private func decodeState(from record: SimulationRecord) -> SimulationState? {
+    guard let data = record.stateJSON.data(using: .utf8) else { return nil }
+    return try? JSONDecoder().decode(SimulationState.self, from: data)
   }
 
   /// Persist the terminal status decided by the caller. `.paused` is NOT passed

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -144,7 +144,7 @@ final class SimulationViewModel {
       try await llm.loadModel()
     } catch {
       errorMessage = "Failed to load LLM: \(error.localizedDescription)"
-      await finalizeSimulationStatus()
+      await finalizeSimulationStatus(.failed)
       return
     }
 
@@ -165,7 +165,19 @@ final class SimulationViewModel {
 
     // Cleanup
     try? await llm.unloadModel()
-    await finalizeSimulationStatus()
+
+    // Pick the terminal status: cancellation intent trumps normal end, but an
+    // error (event-pipeline or persistence) beats both — a broken run is objectively
+    // failed even if the user also pressed cancel.
+    let terminal: SimulationStatus
+    if errorMessage != nil {
+      terminal = .failed
+    } else if isCancelled {
+      terminal = .cancelled
+    } else {
+      terminal = .completed
+    }
+    await finalizeSimulationStatus(terminal)
   }
 
   // MARK: - Event Handling
@@ -319,11 +331,10 @@ final class SimulationViewModel {
     }
   }
 
-  /// Mark the simulation as completed regardless of success or error outcome.
-  /// Errors are recorded in `stateJSON`; `.paused` is reserved for user-initiated pause.
-  private func finalizeSimulationStatus() async {
+  /// Persist the terminal status decided by the caller. `.paused` is NOT passed
+  /// here — it is reserved for the pause/resume flow in `runner.isPaused`.
+  private func finalizeSimulationStatus(_ status: SimulationStatus) async {
     guard let simId = simulationId else { return }
-    let status: SimulationStatus = .completed
     do {
       try await offMain { [simulationRepository] in
         try simulationRepository.updateStatus(simId, status: status)

--- a/Pastura/Pastura/Data/DatabaseManager.swift
+++ b/Pastura/Pastura/Data/DatabaseManager.swift
@@ -97,5 +97,12 @@ nonisolated public final class DatabaseManager: Sendable {
         t.add(column: "sequenceNumber", .integer).notNull().defaults(to: 0)
       }
     }
+
+    migrator.registerMigration("v3_addModelInfoToSimulations") { db in
+      try db.alter(table: "simulations") { t in
+        t.add(column: "modelIdentifier", .text)
+        t.add(column: "llmBackend", .text)
+      }
+    }
   }
 }

--- a/Pastura/Pastura/Data/Models/SimulationRecord.swift
+++ b/Pastura/Pastura/Data/Models/SimulationRecord.swift
@@ -22,6 +22,12 @@ nonisolated public struct SimulationRecord: Codable, Sendable, Equatable,
   public var configJSON: String?
   public var createdAt: Date
   public var updatedAt: Date
+  /// Human-readable label for the LLM model that ran this simulation (e.g.
+  /// `"Gemma 4 E2B (Q4_K_M)"`). Nil for rows created before the v3 migration.
+  public var modelIdentifier: String?
+  /// Human-readable label for the LLM backend runtime (e.g. `"llama.cpp"`,
+  /// `"Ollama"`). Nil for rows created before the v3 migration.
+  public var llmBackend: String?
 
   public init(
     id: String,
@@ -32,7 +38,9 @@ nonisolated public struct SimulationRecord: Codable, Sendable, Equatable,
     stateJSON: String,
     configJSON: String?,
     createdAt: Date,
-    updatedAt: Date
+    updatedAt: Date,
+    modelIdentifier: String? = nil,
+    llmBackend: String? = nil
   ) {
     self.id = id
     self.scenarioId = scenarioId
@@ -43,6 +51,8 @@ nonisolated public struct SimulationRecord: Codable, Sendable, Equatable,
     self.configJSON = configJSON
     self.createdAt = createdAt
     self.updatedAt = updatedAt
+    self.modelIdentifier = modelIdentifier
+    self.llmBackend = llmBackend
   }
 
   /// Type-safe accessor for the simulation status.

--- a/Pastura/Pastura/LLM/LLMService.swift
+++ b/Pastura/Pastura/LLM/LLMService.swift
@@ -28,4 +28,14 @@ nonisolated public protocol LLMService: Sendable {
   /// - Throws: ``LLMError/notLoaded`` if model is not loaded,
   ///           ``LLMError/generationFailed(description:)`` on inference failure.
   func generate(system: String, user: String) async throws -> String
+
+  /// Human-readable label for the currently-loaded model (e.g.
+  /// `"Gemma 4 E2B (Q4_K_M)"`, `"gemma4:e2b"`, `"mock"`). Intended for
+  /// display / export metadata — **not** a stable parse key.
+  var modelIdentifier: String { get }
+
+  /// Human-readable label for the backend runtime driving inference (e.g.
+  /// `"llama.cpp"`, `"Ollama"`, `"mock"`). Intended for display / export
+  /// metadata — **not** a stable parse key.
+  var backendIdentifier: String { get }
 }

--- a/Pastura/Pastura/LLM/LlamaCppService.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService.swift
@@ -116,6 +116,11 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
     loadedState.withLock { $0 }
   }
 
+  // Hardcoded in MVP because this service is wired only to the bundled Gemma 4 E2B
+  // Q4_K_M GGUF. When multiple models ship, read from GGUF metadata at loadModel().
+  public let modelIdentifier = "Gemma 4 E2B (Q4_K_M)"
+  public let backendIdentifier = "llama.cpp"
+
   public func generate(system: String, user: String) async throws -> String {
     try await throttleIfOverheating()
 

--- a/Pastura/Pastura/LLM/MockLLMService.swift
+++ b/Pastura/Pastura/LLM/MockLLMService.swift
@@ -36,6 +36,9 @@ nonisolated public final class MockLLMService: LLMService, @unchecked Sendable {
     state.withLock { $0.isModelLoaded }
   }
 
+  public let modelIdentifier = "mock"
+  public let backendIdentifier = "mock"
+
   public func generate(system: String, user: String) async throws -> String {
     try state.withLock { mutableState in
       guard mutableState.isModelLoaded else { throw LLMError.notLoaded }

--- a/Pastura/Pastura/LLM/OllamaService.swift
+++ b/Pastura/Pastura/LLM/OllamaService.swift
@@ -61,6 +61,9 @@ nonisolated public final class OllamaService: LLMService, @unchecked Sendable {
     loadedState.withLock { $0 }
   }
 
+  public var modelIdentifier: String { modelName }
+  public let backendIdentifier = "Ollama"
+
   public func generate(system: String, user: String) async throws -> String {
     guard isModelLoaded else { throw LLMError.notLoaded }
 

--- a/Pastura/Pastura/Models/SimulationStatus.swift
+++ b/Pastura/Pastura/Models/SimulationStatus.swift
@@ -8,6 +8,16 @@ nonisolated public enum SimulationStatus: String, Codable, Sendable {
   /// The simulation is paused and can be resumed.
   case paused
 
-  /// The simulation has finished executing all rounds.
+  /// The simulation has finished all rounds successfully.
   case completed
+
+  /// The simulation ended due to an error (LLM load failure, event-pipeline error, etc.).
+  /// The error message is surfaced via `SimulationViewModel.errorMessage`; this case
+  /// disambiguates failed runs from clean completions at the DB level.
+  case failed
+
+  /// The simulation was cancelled before natural completion — user-initiated or
+  /// memory-warning induced. Distinguished from `.paused` (resumable) and `.failed`
+  /// (errored).
+  case cancelled
 }

--- a/Pastura/Pastura/Views/Components/ShareSheet.swift
+++ b/Pastura/Pastura/Views/Components/ShareSheet.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+import UIKit
+
+/// A SwiftUI wrapper around `UIActivityViewController` for the iOS share sheet.
+///
+/// `activityItems` is typed as `[Any]` to accept heterogeneous payloads — callers
+/// commonly pass `[String, URL]` so messaging activities receive the text body
+/// while file-oriented activities (Save to Files, AirDrop) pick up the URL.
+/// See Apple's documentation for `UIActivityViewController` for the list of
+/// types each built-in activity accepts.
+struct ShareSheet: UIViewControllerRepresentable {
+  let activityItems: [Any]
+
+  func makeUIViewController(context: Context) -> UIActivityViewController {
+    UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
+  }
+
+  func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {
+    // No dynamic updates needed — the sheet's contents are fixed once presented.
+  }
+}

--- a/Pastura/Pastura/Views/Results/ResultDetailView.swift
+++ b/Pastura/Pastura/Views/Results/ResultDetailView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 /// Replays a past simulation by displaying its turn records as a read-only log.
 struct ResultDetailView: View {
@@ -6,9 +7,19 @@ struct ResultDetailView: View {
 
   @Environment(AppDependencies.self) private var dependencies
   @State private var turns: [TurnRecord] = []
+  @State private var simulation: SimulationRecord?
+  @State private var scenario: ScenarioRecord?
   @State private var isLoading = true
   @State private var showDebug = false
   @State private var showAllThoughts = false
+  @State private var exportPayload: ResultMarkdownExporter.ExportedResult?
+  @State private var isExporting = false
+  @State private var exportError: String?
+
+  private var canExport: Bool {
+    !isExporting && simulation?.simulationStatus == .completed
+      && scenario != nil
+  }
 
   var body: some View {
     Group {
@@ -29,6 +40,18 @@ struct ResultDetailView: View {
     .toolbar {
       ToolbarItem(placement: .primaryAction) {
         Button {
+          Task { await triggerExport() }
+        } label: {
+          if isExporting {
+            ProgressView()
+          } else {
+            Image(systemName: "square.and.arrow.up")
+          }
+        }
+        .disabled(!canExport)
+      }
+      ToolbarItem(placement: .secondaryAction) {
+        Button {
           showDebug.toggle()
         } label: {
           Image(systemName: showDebug ? "ladybug.fill" : "ladybug")
@@ -44,8 +67,22 @@ struct ResultDetailView: View {
         }
       }
     }
+    .sheet(item: $exportPayload) { payload in
+      ShareSheet(activityItems: [payload.text, payload.fileURL])
+    }
+    .alert(
+      "Export failed",
+      isPresented: Binding(
+        get: { exportError != nil },
+        set: { if !$0 { exportError = nil } }
+      )
+    ) {
+      Button("OK", role: .cancel) { exportError = nil }
+    } message: {
+      Text(exportError ?? "")
+    }
     .task {
-      await loadTurns()
+      await loadData()
     }
   }
 
@@ -134,16 +171,54 @@ struct ResultDetailView: View {
     return output
   }
 
-  private func loadTurns() async {
+  private func loadData() async {
     let turnRepo = dependencies.turnRepository
+    let simRepo = dependencies.simulationRepository
+    let scenarioRepo = dependencies.scenarioRepository
     let simId = simulationId
     do {
-      turns = try await offMain {
-        try turnRepo.fetchBySimulationId(simId)
-      }
+      let fetched: (turns: [TurnRecord], sim: SimulationRecord?, scenario: ScenarioRecord?) =
+        try await offMain {
+          let sim = try simRepo.fetchById(simId)
+          let scenario = try sim.flatMap { try scenarioRepo.fetchById($0.scenarioId) }
+          let turns = try turnRepo.fetchBySimulationId(simId)
+          return (turns, sim, scenario)
+        }
+      self.turns = fetched.turns
+      self.simulation = fetched.sim
+      self.scenario = fetched.scenario
     } catch {
-      turns = []
+      self.turns = []
     }
-    isLoading = false
+    self.isLoading = false
+  }
+
+  private func triggerExport() async {
+    guard let simulation, let scenario else { return }
+    isExporting = true
+    defer { isExporting = false }
+
+    let env = ResultMarkdownExporter.ExportEnvironment(
+      deviceModel: UIDevice.current.model,
+      osVersion: ProcessInfo.processInfo.operatingSystemVersionString)
+    let exporter = ResultMarkdownExporter(
+      contentFilter: ContentFilter(),
+      environment: env)
+    let state = decodeState(from: simulation) ?? SimulationState()
+
+    do {
+      let result = try exporter.export(
+        ResultMarkdownExporter.Input(
+          simulation: simulation, scenario: scenario,
+          turns: turns, state: state))
+      self.exportPayload = result
+    } catch {
+      self.exportError = error.localizedDescription
+    }
+  }
+
+  private func decodeState(from record: SimulationRecord) -> SimulationState? {
+    guard let data = record.stateJSON.data(using: .utf8) else { return nil }
+    return try? JSONDecoder().decode(SimulationState.self, from: data)
   }
 }

--- a/Pastura/Pastura/Views/Results/ResultDetailView.swift
+++ b/Pastura/Pastura/Views/Results/ResultDetailView.swift
@@ -206,7 +206,8 @@ struct ResultDetailView: View {
 
     let env = ResultMarkdownExporter.ExportEnvironment(
       deviceModel: UIDevice.current.model,
-      osVersion: ProcessInfo.processInfo.operatingSystemVersionString)
+      osVersion: ResultMarkdownExporter.ExportEnvironment.normalizeOSVersion(
+        ProcessInfo.processInfo.operatingSystemVersionString))
     let exporter = ResultMarkdownExporter(
       contentFilter: ContentFilter(),
       environment: env)

--- a/Pastura/Pastura/Views/Results/ResultDetailView.swift
+++ b/Pastura/Pastura/Views/Results/ResultDetailView.swift
@@ -171,21 +171,27 @@ struct ResultDetailView: View {
     return output
   }
 
+  /// Bundle returned from the single `offMain` DB hop — struct avoids an N-tuple.
+  private struct LoadedData: Sendable {
+    let turns: [TurnRecord]
+    let simulation: SimulationRecord?
+    let scenario: ScenarioRecord?
+  }
+
   private func loadData() async {
     let turnRepo = dependencies.turnRepository
     let simRepo = dependencies.simulationRepository
     let scenarioRepo = dependencies.scenarioRepository
     let simId = simulationId
     do {
-      let fetched: (turns: [TurnRecord], sim: SimulationRecord?, scenario: ScenarioRecord?) =
-        try await offMain {
-          let sim = try simRepo.fetchById(simId)
-          let scenario = try sim.flatMap { try scenarioRepo.fetchById($0.scenarioId) }
-          let turns = try turnRepo.fetchBySimulationId(simId)
-          return (turns, sim, scenario)
-        }
+      let fetched: LoadedData = try await offMain {
+        let sim = try simRepo.fetchById(simId)
+        let scenario = try sim.flatMap { try scenarioRepo.fetchById($0.scenarioId) }
+        let turns = try turnRepo.fetchBySimulationId(simId)
+        return LoadedData(turns: turns, simulation: sim, scenario: scenario)
+      }
       self.turns = fetched.turns
-      self.simulation = fetched.sim
+      self.simulation = fetched.simulation
       self.scenario = fetched.scenario
     } catch {
       self.turns = []

--- a/Pastura/Pastura/Views/Simulation/SimulationView+LogEntries.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView+LogEntries.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+
+// Helpers factored out of SimulationView so that the main file stays under
+// SwiftLint's file-length ceiling. These render individual log-entry kinds
+// used by the live simulation screen.
+extension SimulationView {
+  func eliminationEntry(agent: String, voteCount: Int) -> some View {
+    HStack(spacing: 4) {
+      Image(systemName: "xmark.circle.fill")
+        .foregroundStyle(.red)
+      Text("\(agent) eliminated (\(voteCount) votes)")
+        .font(.subheadline)
+    }
+    .padding(.horizontal)
+  }
+
+  func assignmentEntry(agent: String, value: String) -> some View {
+    Text("\(agent) assigned: \(value)")
+      .font(.caption)
+      .foregroundStyle(.secondary)
+      .padding(.horizontal)
+  }
+
+  func summaryEntry(text: String) -> some View {
+    Text(text)
+      .font(.subheadline)
+      .foregroundStyle(.secondary)
+      .padding(.horizontal)
+  }
+
+  func voteResultsEntry(tallies: [String: Int]) -> some View {
+    VStack(alignment: .leading, spacing: 2) {
+      Text("Vote Results")
+        .font(.caption.bold())
+      ForEach(tallies.sorted(by: { $0.value > $1.value }), id: \.key) { name, count in
+        Text("  \(name): \(count) votes")
+          .font(.caption)
+      }
+    }
+    .foregroundStyle(.secondary)
+    .padding(.horizontal)
+  }
+
+  func pairingResultEntry(
+    agent1: String, act1: String, agent2: String, act2: String
+  ) -> some View {
+    HStack {
+      Text("\(agent1)(\(act1))")
+      Text("vs")
+        .foregroundStyle(.secondary)
+      Text("\(agent2)(\(act2))")
+    }
+    .font(.subheadline)
+    .padding(.horizontal)
+  }
+
+  func roundSeparator(_ text: String) -> some View {
+    HStack {
+      Rectangle().fill(.secondary.opacity(0.3)).frame(height: 1)
+      Text(text)
+        .font(.caption.bold())
+        .foregroundStyle(.secondary)
+      Rectangle().fill(.secondary.opacity(0.3)).frame(height: 1)
+    }
+    .padding(.horizontal)
+    .padding(.vertical, 4)
+  }
+
+  func scoresSummary(_ scores: [String: Int]) -> some View {
+    HStack(spacing: 8) {
+      ForEach(scores.sorted(by: { $0.value > $1.value }).prefix(5), id: \.key) { name, score in
+        Text("\(name):\(score)")
+          .font(.caption.monospacedDigit())
+      }
+    }
+    .foregroundStyle(.secondary)
+    .padding(.horizontal)
+  }
+}

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 /// Live simulation execution screen with real-time log, controls, and scoreboard.
 struct SimulationView: View {
@@ -10,6 +11,9 @@ struct SimulationView: View {
   @State private var scenario: Scenario?
   @State private var showScoreboard = false
   @State private var loadError: String?
+  @State private var exportPayload: ResultMarkdownExporter.ExportedResult?
+  @State private var exportError: String?
+  @State private var isExporting = false
 
   var body: some View {
     Group {
@@ -44,6 +48,20 @@ struct SimulationView: View {
       // Memory warning: cancel simulation to free model memory (ADR-002 §7).
       // Cancellation triggers stream termination → for-await exit → unloadModel.
       viewModel?.cancelSimulation()
+    }
+    .sheet(item: $exportPayload) { payload in
+      ShareSheet(activityItems: [payload.text, payload.fileURL])
+    }
+    .alert(
+      "Export failed",
+      isPresented: Binding(
+        get: { exportError != nil },
+        set: { if !$0 { exportError = nil } }
+      )
+    ) {
+      Button("OK", role: .cancel) { exportError = nil }
+    } message: {
+      Text(exportError ?? "")
     }
   }
 
@@ -191,14 +209,31 @@ struct SimulationView: View {
       }
       .disabled(!viewModel.isRunning || viewModel.isCompleted)
 
-      // Speed
-      Picker("Speed", selection: Bindable(viewModel).speed) {
-        ForEach(PlaybackSpeed.allCases) { speed in
-          Text(speed.label).tag(speed)
+      // Speed picker while running; swapped with an export button once the
+      // simulation is completed because playback speed is no longer relevant.
+      if viewModel.isCompleted {
+        Button {
+          Task { await triggerExport(viewModel: viewModel) }
+        } label: {
+          if isExporting {
+            ProgressView()
+              .frame(width: 150)
+          } else {
+            Label("Export", systemImage: "square.and.arrow.up")
+              .font(.title3)
+              .frame(width: 150)
+          }
         }
+        .disabled(isExporting)
+      } else {
+        Picker("Speed", selection: Bindable(viewModel).speed) {
+          ForEach(PlaybackSpeed.allCases) { speed in
+            Text(speed.label).tag(speed)
+          }
+        }
+        .pickerStyle(.segmented)
+        .frame(width: 150)
       }
-      .pickerStyle(.segmented)
-      .frame(width: 150)
 
       Spacer()
 
@@ -253,7 +288,8 @@ struct SimulationView: View {
 
       let simViewModel = SimulationViewModel(
         simulationRepository: deps.simulationRepository,
-        turnRepository: deps.turnRepository
+        turnRepository: deps.turnRepository,
+        scenarioRepository: deps.scenarioRepository
       )
       viewModel = simViewModel
 
@@ -265,6 +301,21 @@ struct SimulationView: View {
       await runTask.value
     } catch {
       loadError = error.localizedDescription
+    }
+  }
+
+  private func triggerExport(viewModel: SimulationViewModel) async {
+    isExporting = true
+    defer { isExporting = false }
+
+    let env = ResultMarkdownExporter.ExportEnvironment(
+      deviceModel: UIDevice.current.model,
+      osVersion: ProcessInfo.processInfo.operatingSystemVersionString)
+    do {
+      let payload = try await viewModel.fetchExportPayload(exportEnvironment: env)
+      exportPayload = payload
+    } catch {
+      exportError = error.localizedDescription
     }
   }
 }

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -314,7 +314,8 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
 
     let env = ResultMarkdownExporter.ExportEnvironment(
       deviceModel: UIDevice.current.model,
-      osVersion: ProcessInfo.processInfo.operatingSystemVersionString)
+      osVersion: ResultMarkdownExporter.ExportEnvironment.normalizeOSVersion(
+        ProcessInfo.processInfo.operatingSystemVersionString))
     do {
       let payload = try await viewModel.fetchExportPayload(exportEnvironment: env)
       exportPayload = payload

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import UIKit
 
 /// Live simulation execution screen with real-time log, controls, and scoreboard.
-struct SimulationView: View {
+struct SimulationView: View {  // swiftlint:disable:this type_body_length
   let scenarioId: String
 
   @Environment(\.scenePhase) private var scenePhase
@@ -198,6 +198,32 @@ struct SimulationView: View {
 
   // MARK: - Controls
 
+  @ViewBuilder
+  private func speedOrExportControl(viewModel: SimulationViewModel) -> some View {
+    if viewModel.isCompleted {
+      Button {
+        Task { await triggerExport(viewModel: viewModel) }
+      } label: {
+        if isExporting {
+          ProgressView().frame(width: 150)
+        } else {
+          Label("Export", systemImage: "square.and.arrow.up")
+            .font(.title3)
+            .frame(width: 150)
+        }
+      }
+      .disabled(isExporting)
+    } else {
+      Picker("Speed", selection: Bindable(viewModel).speed) {
+        ForEach(PlaybackSpeed.allCases) { speed in
+          Text(speed.label).tag(speed)
+        }
+      }
+      .pickerStyle(.segmented)
+      .frame(width: 150)
+    }
+  }
+
   private func controlBar(viewModel: SimulationViewModel) -> some View {
     HStack(spacing: 16) {
       // Pause/Resume
@@ -211,29 +237,7 @@ struct SimulationView: View {
 
       // Speed picker while running; swapped with an export button once the
       // simulation is completed because playback speed is no longer relevant.
-      if viewModel.isCompleted {
-        Button {
-          Task { await triggerExport(viewModel: viewModel) }
-        } label: {
-          if isExporting {
-            ProgressView()
-              .frame(width: 150)
-          } else {
-            Label("Export", systemImage: "square.and.arrow.up")
-              .font(.title3)
-              .frame(width: 150)
-          }
-        }
-        .disabled(isExporting)
-      } else {
-        Picker("Speed", selection: Bindable(viewModel).speed) {
-          ForEach(PlaybackSpeed.allCases) { speed in
-            Text(speed.label).tag(speed)
-          }
-        }
-        .pickerStyle(.segmented)
-        .frame(width: 150)
-      }
+      speedOrExportControl(viewModel: viewModel)
 
       Spacer()
 
@@ -320,79 +324,4 @@ struct SimulationView: View {
   }
 }
 
-// MARK: - Log Entry Helpers
-
-extension SimulationView {
-  private func eliminationEntry(agent: String, voteCount: Int) -> some View {
-    HStack(spacing: 4) {
-      Image(systemName: "xmark.circle.fill")
-        .foregroundStyle(.red)
-      Text("\(agent) eliminated (\(voteCount) votes)")
-        .font(.subheadline)
-    }
-    .padding(.horizontal)
-  }
-
-  private func assignmentEntry(agent: String, value: String) -> some View {
-    Text("\(agent) assigned: \(value)")
-      .font(.caption)
-      .foregroundStyle(.secondary)
-      .padding(.horizontal)
-  }
-
-  private func summaryEntry(text: String) -> some View {
-    Text(text)
-      .font(.subheadline)
-      .foregroundStyle(.secondary)
-      .padding(.horizontal)
-  }
-
-  private func voteResultsEntry(tallies: [String: Int]) -> some View {
-    VStack(alignment: .leading, spacing: 2) {
-      Text("Vote Results")
-        .font(.caption.bold())
-      ForEach(tallies.sorted(by: { $0.value > $1.value }), id: \.key) { name, count in
-        Text("  \(name): \(count) votes")
-          .font(.caption)
-      }
-    }
-    .foregroundStyle(.secondary)
-    .padding(.horizontal)
-  }
-
-  private func pairingResultEntry(
-    agent1: String, act1: String, agent2: String, act2: String
-  ) -> some View {
-    HStack {
-      Text("\(agent1)(\(act1))")
-      Text("vs")
-        .foregroundStyle(.secondary)
-      Text("\(agent2)(\(act2))")
-    }
-    .font(.subheadline)
-    .padding(.horizontal)
-  }
-
-  private func roundSeparator(_ text: String) -> some View {
-    HStack {
-      Rectangle().fill(.secondary.opacity(0.3)).frame(height: 1)
-      Text(text)
-        .font(.caption.bold())
-        .foregroundStyle(.secondary)
-      Rectangle().fill(.secondary.opacity(0.3)).frame(height: 1)
-    }
-    .padding(.horizontal)
-    .padding(.vertical, 4)
-  }
-
-  private func scoresSummary(_ scores: [String: Int]) -> some View {
-    HStack(spacing: 8) {
-      ForEach(scores.sorted(by: { $0.value > $1.value }).prefix(5), id: \.key) { name, score in
-        Text("\(name):\(score)")
-          .font(.caption.monospacedDigit())
-      }
-    }
-    .foregroundStyle(.secondary)
-    .padding(.horizontal)
-  }
-}
+// Log-entry helpers live in SimulationView+LogEntries.swift.

--- a/Pastura/PasturaTests/App/ResultMarkdownExporterTests.swift
+++ b/Pastura/PasturaTests/App/ResultMarkdownExporterTests.swift
@@ -244,7 +244,29 @@ import Testing
     #expect(result.text.contains("**Status**: failed"))
     #expect(result.text.contains("**Inference count**: 0"))
     #expect(result.text.contains("_No turns recorded._"))
-    #expect(result.text.contains("_No score data._"))
+    #expect(!result.text.contains("## Final Scores"))
+  }
+
+  @Test func suppressesFinalScoresForObservationOnlyScenario() throws {
+    // Pure speak_each / observation scenarios have no score_calc phase, so
+    // all-zero scores mean "no scoring happened" rather than "everyone scored 0".
+    // Rendering a Final Scores table of all 0s would be misleading noise.
+    let exporter = makeExporter()
+    let input = ResultMarkdownExporter.Input(
+      simulation: makeSimulation(),
+      scenario: makeScenario(),
+      turns: [
+        makeTurn(
+          round: 1, seq: 1, phase: "speak_each",
+          agent: "Alice", fields: ["statement": "hello"])
+      ],
+      state: makeState(
+        scores: ["Alice": 0, "Bob": 0],
+        eliminated: ["Alice": false, "Bob": false]))
+
+    let result = try exporter.export(input)
+
+    #expect(!result.text.contains("## Final Scores"))
   }
 
   @Test func codePhaseTurnRendersWithoutAgentHeader() throws {

--- a/Pastura/PasturaTests/App/ResultMarkdownExporterTests.swift
+++ b/Pastura/PasturaTests/App/ResultMarkdownExporterTests.swift
@@ -141,6 +141,27 @@ import Testing
     #expect(result.text.contains("**Inference count**: 1"))
   }
 
+  @Test func rendersInnerThoughtAsNestedBullet() throws {
+    let exporter = makeExporter()
+    let turn = makeTurn(
+      round: 1, seq: 1, phase: "speak_each",
+      agent: "Alice",
+      fields: [
+        "statement": "I pick A.",
+        "inner_thought": "Actually I believe B but am going along"
+      ])
+    let input = ResultMarkdownExporter.Input(
+      simulation: makeSimulation(),
+      scenario: makeScenario(),
+      turns: [turn],
+      state: makeState())
+
+    let result = try exporter.export(input)
+
+    #expect(result.text.contains("- **Alice**: I pick A."))
+    #expect(result.text.contains("  - 💭 _Actually I believe B but am going along_"))
+  }
+
   @Test func rendersVoteTurn() throws {
     let exporter = makeExporter()
     let turn = makeTurn(

--- a/Pastura/PasturaTests/App/ResultMarkdownExporterTests.swift
+++ b/Pastura/PasturaTests/App/ResultMarkdownExporterTests.swift
@@ -3,7 +3,7 @@ import Testing
 
 @testable import Pastura
 
-@Suite @MainActor struct ResultMarkdownExporterTests {
+@Suite @MainActor struct ResultMarkdownExporterTests {  // swiftlint:disable:this type_body_length
 
   // MARK: - Fixtures
 
@@ -302,6 +302,17 @@ import Testing
 
   @Test func sanitizeFilenameHandlesEmptyInput() {
     #expect(ResultMarkdownExporter.sanitizeFilename("") == "export")
+  }
+
+  @Test func normalizeOSVersionRewritesAppleFormat() {
+    let normalized = ResultMarkdownExporter.ExportEnvironment.normalizeOSVersion(
+      "Version 26.4 (Build 23E246)")
+    #expect(normalized == "iOS 26.4 (build 23E246)")
+  }
+
+  @Test func normalizeOSVersionLeavesUnfamiliarStringsUnchanged() {
+    let raw = "custom-os-26.4"
+    #expect(ResultMarkdownExporter.ExportEnvironment.normalizeOSVersion(raw) == raw)
   }
 
   @Test func writesMarkdownFileToTempDirectory() throws {

--- a/Pastura/PasturaTests/App/ResultMarkdownExporterTests.swift
+++ b/Pastura/PasturaTests/App/ResultMarkdownExporterTests.swift
@@ -1,0 +1,280 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+@Suite @MainActor struct ResultMarkdownExporterTests {
+
+  // MARK: - Fixtures
+
+  private let createdAt = Date(timeIntervalSince1970: 1_712_000_000)  // 2024-04-01T19:33:20Z
+  private let updatedAt = Date(timeIntervalSince1970: 1_712_000_342)  // +5m 42s
+  private let exportAt = Date(timeIntervalSince1970: 1_713_000_000)  // 2024-04-13T08:53:20Z
+
+  private func makeScenario(
+    id: String = "s1",
+    name: String = "Prisoners Dilemma",
+    yaml: String = "name: Prisoners Dilemma\nrounds: 2\n"
+  ) -> ScenarioRecord {
+    ScenarioRecord(
+      id: id, name: name, yamlDefinition: yaml,
+      isPreset: true, createdAt: Date(), updatedAt: Date())
+  }
+
+  private func makeSimulation(
+    id: String = "sim1",
+    scenarioId: String = "s1",
+    status: SimulationStatus = .completed,
+    modelIdentifier: String? = "Gemma 4 E2B (Q4_K_M)",
+    llmBackend: String? = "llama.cpp"
+  ) -> SimulationRecord {
+    SimulationRecord(
+      id: id, scenarioId: scenarioId,
+      status: status.rawValue,
+      currentRound: 2, currentPhaseIndex: 0,
+      stateJSON: "{}", configJSON: nil,
+      createdAt: createdAt, updatedAt: updatedAt,
+      modelIdentifier: modelIdentifier, llmBackend: llmBackend)
+  }
+
+  private func makeTurn(
+    round: Int,
+    seq: Int,
+    phase: String,
+    agent: String?,
+    fields: [String: String]
+  ) -> TurnRecord {
+    let json =
+      (try? JSONEncoder().encode(TurnOutput(fields: fields))).flatMap {
+        String(data: $0, encoding: .utf8)
+      } ?? "{}"
+    return TurnRecord(
+      id: UUID().uuidString,
+      simulationId: "sim1",
+      roundNumber: round,
+      phaseType: phase,
+      agentName: agent,
+      rawOutput: json,
+      parsedOutputJSON: json,
+      sequenceNumber: seq,
+      createdAt: Date())
+  }
+
+  private func makeState(
+    scores: [String: Int] = ["Alice": 5, "Bob": 3],
+    eliminated: [String: Bool] = [:]
+  ) -> SimulationState {
+    SimulationState(
+      scores: scores,
+      eliminated: eliminated,
+      conversationLog: [],
+      lastOutputs: [:],
+      voteResults: [:],
+      pairings: [],
+      variables: [:],
+      currentRound: 2)
+  }
+
+  private func makeExporter(
+    filter: ContentFilter = ContentFilter(blockedPatterns: [])
+  ) -> ResultMarkdownExporter {
+    ResultMarkdownExporter(
+      contentFilter: filter,
+      environment: .init(deviceModel: "iPhone", osVersion: "Version 17.5"),
+      now: exportAt)
+  }
+
+  // MARK: - Tests
+
+  @Test func includesVersionMarkerAndMetadataHeader() throws {
+    let exporter = makeExporter()
+    let input = ResultMarkdownExporter.Input(
+      simulation: makeSimulation(),
+      scenario: makeScenario(),
+      turns: [],
+      state: makeState())
+
+    let result = try exporter.export(input)
+
+    #expect(result.text.hasPrefix("<!-- pastura-export v1 -->"))
+    #expect(result.text.contains("# Simulation Export: Prisoners Dilemma"))
+    #expect(result.text.contains("## Metadata"))
+    #expect(result.text.contains("**Status**: completed"))
+    #expect(result.text.contains("**Started**: 2024-04-01T19:33:20Z"))
+    #expect(result.text.contains("**Ended**: 2024-04-01T19:39:02Z"))
+    #expect(result.text.contains("**Duration**: 5m 42s"))
+    #expect(result.text.contains("**Model**: Gemma 4 E2B (Q4_K_M)"))
+    #expect(result.text.contains("**Backend**: llama.cpp"))
+    #expect(result.text.contains("**Device**: iPhone / Version 17.5"))
+  }
+
+  @Test func includesScenarioYAMLFence() throws {
+    let exporter = makeExporter()
+    let input = ResultMarkdownExporter.Input(
+      simulation: makeSimulation(),
+      scenario: makeScenario(yaml: "name: Test\nrounds: 1\n"),
+      turns: [],
+      state: makeState())
+
+    let result = try exporter.export(input)
+
+    #expect(result.text.contains("## Scenario Definition"))
+    #expect(result.text.contains("```yaml\nname: Test\nrounds: 1\n\n```"))
+  }
+
+  @Test func rendersSpeakAllTurn() throws {
+    let exporter = makeExporter()
+    let turn = makeTurn(
+      round: 1, seq: 1, phase: "speak_all",
+      agent: "Alice", fields: ["statement": "Hello from Alice"])
+    let input = ResultMarkdownExporter.Input(
+      simulation: makeSimulation(),
+      scenario: makeScenario(),
+      turns: [turn],
+      state: makeState())
+
+    let result = try exporter.export(input)
+
+    #expect(result.text.contains("### Round 1"))
+    #expect(result.text.contains("#### Phase: speak_all"))
+    #expect(result.text.contains("- **Alice**: Hello from Alice"))
+    #expect(result.text.contains("**Inference count**: 1"))
+  }
+
+  @Test func rendersVoteTurn() throws {
+    let exporter = makeExporter()
+    let turn = makeTurn(
+      round: 1, seq: 1, phase: "vote",
+      agent: "Alice", fields: ["vote": "Bob"])
+    let input = ResultMarkdownExporter.Input(
+      simulation: makeSimulation(),
+      scenario: makeScenario(),
+      turns: [turn],
+      state: makeState())
+
+    let result = try exporter.export(input)
+
+    #expect(result.text.contains("#### Phase: vote"))
+    #expect(result.text.contains("- **Alice**: → Bob"))
+  }
+
+  @Test func appliesContentFilterToRenderedMarkdown() throws {
+    // Applies to everything — including persona names in YAML and turn output.
+    let filter = ContentFilter(blockedPatterns: ["死ね"], replacement: "***")
+    let exporter = makeExporter(filter: filter)
+    let yaml = "personas:\n  - name: 死ね太郎\n"
+    let turn = makeTurn(
+      round: 1, seq: 1, phase: "speak_all",
+      agent: "死ね太郎", fields: ["statement": "死ね and hi"])
+    let input = ResultMarkdownExporter.Input(
+      simulation: makeSimulation(),
+      scenario: makeScenario(yaml: yaml),
+      turns: [turn],
+      state: makeState(scores: ["死ね太郎": 1]))
+
+    let result = try exporter.export(input)
+
+    #expect(!result.text.contains("死ね"))
+    #expect(result.text.contains("***"))
+  }
+
+  @Test func includesFinalScoresSection() throws {
+    let exporter = makeExporter()
+    let input = ResultMarkdownExporter.Input(
+      simulation: makeSimulation(),
+      scenario: makeScenario(),
+      turns: [],
+      state: makeState(
+        scores: ["Alice": 10, "Bob": 3],
+        eliminated: ["Bob": true]))
+
+    let result = try exporter.export(input)
+
+    #expect(result.text.contains("## Final Scores"))
+    #expect(result.text.contains("| Alice | 10 | active |"))
+    #expect(result.text.contains("| Bob | 3 | eliminated |"))
+  }
+
+  @Test func unknownModelAndBackendFallBackToPlaceholder() throws {
+    let exporter = makeExporter()
+    let input = ResultMarkdownExporter.Input(
+      simulation: makeSimulation(modelIdentifier: nil, llmBackend: nil),
+      scenario: makeScenario(),
+      turns: [],
+      state: makeState())
+
+    let result = try exporter.export(input)
+
+    #expect(result.text.contains("**Model**: (unknown)"))
+    #expect(result.text.contains("**Backend**: (unknown)"))
+  }
+
+  @Test func zeroTurnRunRendersMinimally() throws {
+    // Simulates a run that errored at LLM load before any inference fired.
+    let exporter = makeExporter()
+    let input = ResultMarkdownExporter.Input(
+      simulation: makeSimulation(status: .failed),
+      scenario: makeScenario(),
+      turns: [],
+      state: makeState(scores: [:]))
+
+    let result = try exporter.export(input)
+
+    #expect(result.text.contains("**Status**: failed"))
+    #expect(result.text.contains("**Inference count**: 0"))
+    #expect(result.text.contains("_No turns recorded._"))
+    #expect(result.text.contains("_No score data._"))
+  }
+
+  @Test func codePhaseTurnRendersWithoutAgentHeader() throws {
+    let exporter = makeExporter()
+    let turn = makeTurn(
+      round: 1, seq: 1, phase: "score_calc",
+      agent: nil, fields: [:])
+    let input = ResultMarkdownExporter.Input(
+      simulation: makeSimulation(),
+      scenario: makeScenario(),
+      turns: [turn],
+      state: makeState())
+
+    let result = try exporter.export(input)
+
+    #expect(result.text.contains("#### Phase: score_calc"))
+    #expect(result.text.contains("_(code phase — no agent output)_"))
+    // Code-phase turn should NOT count toward inference count.
+    #expect(result.text.contains("**Inference count**: 0"))
+  }
+
+  @Test func sanitizesFilenameForNonAsciiScenarioName() {
+    let name = "囚人のジレンマ / テスト"
+    let sanitized = ResultMarkdownExporter.sanitizeFilename(name)
+    #expect(sanitized == "囚人のジレンマ___テスト")
+  }
+
+  @Test func sanitizeFilenameTruncatesLongNames() {
+    let name = String(repeating: "a", count: 120)
+    let sanitized = ResultMarkdownExporter.sanitizeFilename(name)
+    #expect(sanitized.count == 50)
+  }
+
+  @Test func sanitizeFilenameHandlesEmptyInput() {
+    #expect(ResultMarkdownExporter.sanitizeFilename("") == "export")
+  }
+
+  @Test func writesMarkdownFileToTempDirectory() throws {
+    let exporter = makeExporter()
+    let input = ResultMarkdownExporter.Input(
+      simulation: makeSimulation(),
+      scenario: makeScenario(name: "test-scenario"),
+      turns: [],
+      state: makeState())
+
+    let result = try exporter.export(input)
+    defer { try? FileManager.default.removeItem(at: result.fileURL) }
+
+    let contents = try String(contentsOf: result.fileURL, encoding: .utf8)
+    #expect(contents == result.text)
+    #expect(result.fileURL.lastPathComponent.hasSuffix(".md"))
+    #expect(result.fileURL.lastPathComponent.contains("test-scenario"))
+  }
+}

--- a/Pastura/PasturaTests/App/SimulationViewModelExportTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelExportTests.swift
@@ -1,0 +1,114 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+@Suite(.serialized) @MainActor
+struct SimulationViewModelExportTests {
+
+  private let env = ResultMarkdownExporter.ExportEnvironment(
+    deviceModel: "iPhone", osVersion: "Version 17.5")
+
+  @Test func fetchExportPayloadReturnsNilWhenSimulationHasNotStarted() async throws {
+    let db = try DatabaseManager.inMemory()
+    let simRepo = GRDBSimulationRepository(dbWriter: db.dbWriter)
+    let turnRepo = GRDBTurnRepository(dbWriter: db.dbWriter)
+    let scenarioRepo = GRDBScenarioRepository(dbWriter: db.dbWriter)
+
+    let sut = SimulationViewModel(
+      simulationRepository: simRepo,
+      turnRepository: turnRepo,
+      scenarioRepository: scenarioRepo)
+
+    let payload = try await sut.fetchExportPayload(exportEnvironment: env)
+    #expect(payload == nil)
+  }
+
+  @Test func fetchExportPayloadReturnsPayloadAfterSuccessfulRun() async throws {
+    let db = try DatabaseManager.inMemory()
+    let simRepo = GRDBSimulationRepository(dbWriter: db.dbWriter)
+    let turnRepo = GRDBTurnRepository(dbWriter: db.dbWriter)
+    let scenarioRepo = GRDBScenarioRepository(dbWriter: db.dbWriter)
+    try scenarioRepo.save(
+      ScenarioRecord(
+        id: "test", name: "Test Scenario",
+        yamlDefinition: "name: Test Scenario\n",
+        isPreset: false, createdAt: Date(), updatedAt: Date()))
+
+    let sut = SimulationViewModel(
+      simulationRepository: simRepo,
+      turnRepository: turnRepo,
+      scenarioRepository: scenarioRepo)
+    sut.speed = .fastest
+
+    let mock = MockLLMService(responses: [
+      #"{"statement": "hello from Alice"}"#,
+      #"{"statement": "hello from Bob"}"#
+    ])
+    let scenario = makeTestScenario(
+      agentNames: ["Alice", "Bob"],
+      rounds: 1,
+      phases: [Phase(type: .speakAll, prompt: "Speak", outputSchema: ["statement": "string"])]
+    )
+
+    await sut.run(scenario: scenario, llm: mock)
+
+    let payload = try await sut.fetchExportPayload(exportEnvironment: env)
+    let unwrapped = try #require(payload)
+    #expect(unwrapped.text.contains("<!-- pastura-export v1 -->"))
+    #expect(unwrapped.text.contains("# Simulation Export: Test Scenario"))
+    #expect(unwrapped.text.contains("**Status**: completed"))
+    #expect(unwrapped.text.contains("hello from Alice"))
+    #expect(unwrapped.fileURL.pathExtension == "md")
+  }
+
+  @Test func fetchExportPayloadReturnsNilForFailedRun() async throws {
+    let db = try DatabaseManager.inMemory()
+    let simRepo = GRDBSimulationRepository(dbWriter: db.dbWriter)
+    let turnRepo = GRDBTurnRepository(dbWriter: db.dbWriter)
+    let scenarioRepo = GRDBScenarioRepository(dbWriter: db.dbWriter)
+    try scenarioRepo.save(
+      ScenarioRecord(
+        id: "test", name: "Test",
+        yamlDefinition: "", isPreset: false,
+        createdAt: Date(), updatedAt: Date()))
+
+    let sut = SimulationViewModel(
+      simulationRepository: simRepo,
+      turnRepository: turnRepo,
+      scenarioRepository: scenarioRepo)
+    sut.speed = .fastest
+
+    let scenario = makeTestScenario(agentNames: ["Alice", "Bob"], rounds: 1)
+    await sut.run(scenario: scenario, llm: FailingLLMService())
+
+    let payload = try await sut.fetchExportPayload(exportEnvironment: env)
+    #expect(payload == nil)
+  }
+
+  @Test func fetchExportPayloadReturnsNilWhenScenarioRepoNotInjected() async throws {
+    let db = try DatabaseManager.inMemory()
+    let simRepo = GRDBSimulationRepository(dbWriter: db.dbWriter)
+    let turnRepo = GRDBTurnRepository(dbWriter: db.dbWriter)
+    let scenarioRepo = GRDBScenarioRepository(dbWriter: db.dbWriter)
+    try scenarioRepo.save(
+      ScenarioRecord(
+        id: "test", name: "Test",
+        yamlDefinition: "", isPreset: false,
+        createdAt: Date(), updatedAt: Date()))
+
+    let sut = SimulationViewModel(
+      simulationRepository: simRepo,
+      turnRepository: turnRepo)  // no scenarioRepository
+    sut.speed = .fastest
+
+    let mock = MockLLMService(responses: [#"{"statement": "hi"}"#, #"{"statement": "hi"}"#])
+    let scenario = makeTestScenario(
+      agentNames: ["Alice", "Bob"], rounds: 1,
+      phases: [Phase(type: .speakAll, prompt: "Speak", outputSchema: ["statement": "string"])])
+    await sut.run(scenario: scenario, llm: mock)
+
+    let payload = try await sut.fetchExportPayload(exportEnvironment: env)
+    #expect(payload == nil)
+  }
+}

--- a/Pastura/PasturaTests/App/SimulationViewModelLifecycleTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelLifecycleTests.swift
@@ -205,7 +205,7 @@ struct SimulationViewModelLifecycleTests {
     #expect(sims.first?.simulationStatus == .completed)
   }
 
-  @Test func runMarksStatusCompletedOnEngineError() async throws {
+  @Test func runMarksStatusFailedOnEngineError() async throws {
     let db = try DatabaseManager.inMemory()
     let simRepo = GRDBSimulationRepository(dbWriter: db.dbWriter)
     let turnRepo = GRDBTurnRepository(dbWriter: db.dbWriter)
@@ -232,10 +232,10 @@ struct SimulationViewModelLifecycleTests {
     #expect(sut.errorMessage != nil)
     let sims = try simRepo.fetchByScenarioId("test")
     #expect(sims.count == 1)
-    #expect(sims.first?.simulationStatus == .completed)
+    #expect(sims.first?.simulationStatus == .failed)
   }
 
-  @Test func runMarksStatusCompletedOnLLMLoadFailure() async throws {
+  @Test func runMarksStatusFailedOnLLMLoadFailure() async throws {
     let db = try DatabaseManager.inMemory()
     let simRepo = GRDBSimulationRepository(dbWriter: db.dbWriter)
     let turnRepo = GRDBTurnRepository(dbWriter: db.dbWriter)
@@ -256,7 +256,7 @@ struct SimulationViewModelLifecycleTests {
     #expect(sut.errorMessage != nil)
     let sims = try simRepo.fetchByScenarioId("test")
     #expect(sims.count == 1)
-    #expect(sims.first?.simulationStatus == .completed)
+    #expect(sims.first?.simulationStatus == .failed)
   }
 
   // MARK: - Multi-Phase E2E Tests

--- a/Pastura/PasturaTests/App/SimulationViewModelLifecycleTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelLifecycleTests.swift
@@ -34,6 +34,8 @@ private func makeLifecycleSUT(
 /// LLM service that always fails on loadModel, for testing error paths.
 nonisolated struct FailingLLMService: LLMService, Sendable {
   var isModelLoaded: Bool { false }
+  var modelIdentifier: String { "failing-mock" }
+  var backendIdentifier: String { "mock" }
   func loadModel() async throws { throw LLMError.notLoaded }
   func unloadModel() async throws {}
   func generate(system: String, user: String) async throws -> String {

--- a/Pastura/PasturaTests/App/SimulationViewModelLifecycleTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelLifecycleTests.swift
@@ -205,6 +205,8 @@ struct SimulationViewModelLifecycleTests {
     let sims = try simRepo.fetchByScenarioId("test")
     #expect(sims.count == 1)
     #expect(sims.first?.simulationStatus == .completed)
+    #expect(sims.first?.modelIdentifier == "mock")
+    #expect(sims.first?.llmBackend == "mock")
   }
 
   @Test func runMarksStatusFailedOnEngineError() async throws {

--- a/Pastura/PasturaTests/Data/SimulationRecordTests.swift
+++ b/Pastura/PasturaTests/Data/SimulationRecordTests.swift
@@ -70,6 +70,54 @@ import Testing
     #expect(fetched?.simulationStatus == .paused)
   }
 
+  @Test func modelIdentifierAndLLMBackendRoundTrip() throws {
+    let manager = try makeManagerWithScenario()
+    let now = Date()
+    var record = SimulationRecord(
+      id: "sim1", scenarioId: "s1",
+      status: SimulationStatus.completed.rawValue,
+      currentRound: 5, currentPhaseIndex: 0,
+      stateJSON: "{}", configJSON: nil,
+      createdAt: now, updatedAt: now,
+      modelIdentifier: "Gemma 4 E2B (Q4_K_M)",
+      llmBackend: "llama.cpp")
+
+    try manager.dbWriter.write { db in
+      try record.insert(db)
+    }
+
+    let fetched = try manager.dbWriter.read { db in
+      try SimulationRecord.fetchOne(db, key: "sim1")
+    }
+
+    #expect(fetched?.modelIdentifier == "Gemma 4 E2B (Q4_K_M)")
+    #expect(fetched?.llmBackend == "llama.cpp")
+  }
+
+  @Test func modelIdentifierAndLLMBackendDefaultToNil() throws {
+    // Rows inserted without explicit model metadata (e.g., created before the v3 migration
+    // on TestFlight devices) decode with nil for both new fields and round-trip cleanly.
+    let manager = try makeManagerWithScenario()
+    let now = Date()
+    var record = SimulationRecord(
+      id: "sim1", scenarioId: "s1",
+      status: SimulationStatus.completed.rawValue,
+      currentRound: 0, currentPhaseIndex: 0,
+      stateJSON: "{}", configJSON: nil,
+      createdAt: now, updatedAt: now)
+
+    try manager.dbWriter.write { db in
+      try record.insert(db)
+    }
+
+    let fetched = try manager.dbWriter.read { db in
+      try SimulationRecord.fetchOne(db, key: "sim1")
+    }
+
+    #expect(fetched?.modelIdentifier == nil)
+    #expect(fetched?.llmBackend == nil)
+  }
+
   @Test func cascadeDeleteFromScenario() throws {
     let manager = try makeManagerWithScenario()
     let now = Date()


### PR DESCRIPTION
## Summary
- Adds a Share button that exports a finished simulation as Markdown (metadata + full YAML + per-round turn log + final scores) and opens the iOS Share Sheet. Covers both SimulationView (end-of-run) and ResultDetailView (history browse).
- Introduces `SimulationStatus.failed` / `.cancelled` so the export gate can tell a real completion apart from an errored or cancelled run.
- Persists `modelIdentifier` / `llmBackend` on each simulation (GRDB migration v3 + new `LLMService` properties) so the exported header reflects the backend that actually ran the sim.
- Follow-up polish based on real-device check: include `inner_thought` as a nested bullet in each turn, suppress the `Final Scores` section for observation-only scenarios, and normalize the OS version string to `"iOS X.Y (build ABC)"`.

## Known limitation (tracked in #92)

On-device verification with the `word_wolf` preset revealed that code-phase results (`eliminate` / `score_calc` / `summarize`) do **not** appear in the export. Root cause: `SimulationViewModel` only persists `.agentOutput` events as `TurnRecord`s; code-phase events are rendered in the live UI but not stored, so the exporter has no data to render. Follow-up #92 tracks the fix.

This limitation is out of scope for this PR — the current change still delivers a usable Markdown export for LLM-spoken content (speak_all / speak_each / vote / choose), which is the majority of analysis value.

## Test plan
- [ ] `xcodebuild test` — all suites green (16 `ResultMarkdownExporterTests` + 4 `SimulationViewModelExportTests`)
- [ ] `swiftlint lint --strict` — no violations
- [ ] Manual simulator run: complete a `prisoners_dilemma` preset → Speed picker swaps to Share button → tap and verify:
  - [ ] **Copy**: pastes the full Markdown (not just a URL string)
  - [ ] **Save to Files**: writes a `.md` file with the full contents
  - [ ] **AirDrop** / **Messages**: receives both text and file cleanly
- [x] Navigate Results tab → completed run → toolbar Share button works the same (verified on device)
- [x] `inner_thought`, normalized device string, and Final Scores suppression all behave as expected on device
- [x] Force an LLM-load failure → Share button stays disabled in Result detail, Speed picker is not replaced in SimulationView
- [x] Paste export into Claude Web and ask for an analysis — response should be substantive

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)