### PR TITLE
✨ feat: include code-phase results in Markdown exports

### DIFF
--- a/Pastura/Pastura/App/AppDependencies.swift
+++ b/Pastura/Pastura/App/AppDependencies.swift
@@ -12,6 +12,7 @@ final class AppDependencies: @unchecked Sendable {
   let scenarioRepository: any ScenarioRepository
   let simulationRepository: any SimulationRepository
   let turnRepository: any TurnRepository
+  let codePhaseEventRepository: any CodePhaseEventRepository
 
   /// The LLM service used for simulation execution.
   /// Defaults to `OllamaService` for development.
@@ -32,6 +33,7 @@ final class AppDependencies: @unchecked Sendable {
     self.scenarioRepository = GRDBScenarioRepository(dbWriter: writer)
     self.simulationRepository = GRDBSimulationRepository(dbWriter: writer)
     self.turnRepository = GRDBTurnRepository(dbWriter: writer)
+    self.codePhaseEventRepository = GRDBCodePhaseEventRepository(dbWriter: writer)
     self.llmService = llmService ?? OllamaService()
     self.galleryService = galleryService ?? URLSessionGalleryService()
   }

--- a/Pastura/Pastura/App/ResultMarkdownExporter.swift
+++ b/Pastura/Pastura/App/ResultMarkdownExporter.swift
@@ -43,7 +43,28 @@ struct ResultMarkdownExporter {
     let simulation: SimulationRecord
     let scenario: ScenarioRecord
     let turns: [TurnRecord]
+    let codePhaseEvents: [CodePhaseEventRecord]
+    /// Agent name roster used for the Final Scores / Roster Status section.
+    /// Authoritative over code-phase event contents — events may omit agents
+    /// that never scored, but every persona should appear in the roster.
+    let personas: [String]
     let state: SimulationState
+
+    init(
+      simulation: SimulationRecord,
+      scenario: ScenarioRecord,
+      turns: [TurnRecord],
+      codePhaseEvents: [CodePhaseEventRecord] = [],
+      personas: [String] = [],
+      state: SimulationState
+    ) {
+      self.simulation = simulation
+      self.scenario = scenario
+      self.turns = turns
+      self.codePhaseEvents = codePhaseEvents
+      self.personas = personas
+      self.state = state
+    }
   }
 
   private let contentFilter: ContentFilter
@@ -81,20 +102,29 @@ struct ResultMarkdownExporter {
     sections.append(renderMetadata(input))
     sections.append(renderScenarioYAML(input))
     sections.append(renderTurnLog(input))
-    if hasMeaningfulScoreData(input.state) {
-      sections.append(renderFinalScores(input))
+
+    // Bifurcated final-section gating (events are authoritative; the section
+    // is independent of `SimulationState.scores` so it stays correct even when
+    // `stateJSON` has not been kept in sync during the run).
+    // - scoreUpdate event present → Final Scores table (scores + status).
+    // - elimination event present only → Roster Status (status-only, no
+    //   misleading all-zero score table for scenarios like Word Wolf).
+    // - neither → omit entirely (observation-only scenarios).
+    let payloads = decodedPayloads(input.codePhaseEvents)
+    let hasScoreUpdate = payloads.contains { payload in
+      if case .scoreUpdate = payload { return true }
+      return false
+    }
+    let hasElimination = payloads.contains { payload in
+      if case .elimination = payload { return true }
+      return false
+    }
+    if hasScoreUpdate {
+      sections.append(renderFinalScores(input, payloads: payloads))
+    } else if hasElimination {
+      sections.append(renderRosterStatus(input, payloads: payloads))
     }
     return sections.joined(separator: "\n\n") + "\n"
-  }
-
-  // Observation-only scenarios (e.g. pure speak_each / Asch conformity) have
-  // no scoring phase — state.scores is still initialized with 0 per agent, so
-  // suppressing the "Final Scores" section requires a semantic check rather
-  // than an emptiness check.
-  private func hasMeaningfulScoreData(_ state: SimulationState) -> Bool {
-    state.scores.values.contains(where: { $0 != 0 })
-      || state.eliminated.values.contains(true)
-      || !state.voteResults.isEmpty
   }
 
   private func renderMetadata(_ input: Input) -> String {
@@ -132,44 +162,95 @@ struct ResultMarkdownExporter {
     """
   }
 
+  /// Unified timeline item for merge-sorted rendering. `TurnRecord` and
+  /// `CodePhaseEventRecord` share `sequenceNumber` across both tables, so
+  /// combining them restores the original event arrival order.
+  private enum TimelineItem {
+    case turn(TurnRecord)
+    case codePhase(CodePhaseEventRecord, CodePhaseEventPayload)
+
+    var round: Int {
+      switch self {
+      case .turn(let t): return t.roundNumber
+      case .codePhase(let r, _): return r.roundNumber
+      }
+    }
+    var sequenceNumber: Int {
+      switch self {
+      case .turn(let t): return t.sequenceNumber
+      case .codePhase(let r, _): return r.sequenceNumber
+      }
+    }
+    var phaseType: String {
+      switch self {
+      case .turn(let t): return t.phaseType
+      case .codePhase(let r, _): return r.phaseType
+      }
+    }
+  }
+
   private func renderTurnLog(_ input: Input) -> String {
-    guard !input.turns.isEmpty else {
+    // Build a unified timeline. Within a `(round, phaseType)` group, items
+    // render strictly by ascending `sequenceNumber` — agent votes always
+    // precede the tally line under the same `#### Phase: vote` header.
+    var timeline: [TimelineItem] = input.turns.map { .turn($0) }
+    timeline.append(
+      contentsOf: input.codePhaseEvents.map { record in
+        if let payload = decodePayload(record) {
+          return TimelineItem.codePhase(record, payload)
+        }
+        // Defensive: unknown payload shape shouldn't happen, but if it does
+        // we skip silently rather than crash the export.
+        return TimelineItem.codePhase(record, .summary(text: "(unreadable payload)"))
+      })
+    timeline.sort { $0.sequenceNumber < $1.sequenceNumber }
+
+    guard !timeline.isEmpty else {
       return "## Turn Log\n\n_No turns recorded._"
     }
 
     var lines: [String] = ["## Turn Log"]
-    // Group turns by round while preserving sequenceNumber order within each round.
-    let sorted = input.turns.sorted { $0.sequenceNumber < $1.sequenceNumber }
-    let grouped = Dictionary(grouping: sorted, by: { $0.roundNumber })
+    let grouped = Dictionary(grouping: timeline, by: { $0.round })
     for round in grouped.keys.sorted() {
       lines.append("")
       lines.append("### Round \(round)")
-      let turnsInRound = grouped[round] ?? []
-      // Group by phase within round, preserving first-seen order.
+      let itemsInRound = (grouped[round] ?? [])
+        .sorted { $0.sequenceNumber < $1.sequenceNumber }
+      // Group by phaseType within round, preserving first-seen order.
       var phaseOrder: [String] = []
-      var byPhase: [String: [TurnRecord]] = [:]
-      for turn in turnsInRound {
-        if byPhase[turn.phaseType] == nil {
-          phaseOrder.append(turn.phaseType)
-          byPhase[turn.phaseType] = []
+      var byPhase: [String: [TimelineItem]] = [:]
+      for item in itemsInRound {
+        if byPhase[item.phaseType] == nil {
+          phaseOrder.append(item.phaseType)
+          byPhase[item.phaseType] = []
         }
-        byPhase[turn.phaseType]?.append(turn)
+        byPhase[item.phaseType]?.append(item)
       }
       for phase in phaseOrder {
         lines.append("")
         lines.append("#### Phase: \(phase)")
-        for turn in byPhase[phase] ?? [] {
-          lines.append(renderTurnLine(turn))
+        for item in byPhase[phase] ?? [] {
+          lines.append(render(item))
         }
       }
     }
     return lines.joined(separator: "\n")
   }
 
+  private func render(_ item: TimelineItem) -> String {
+    switch item {
+    case .turn(let turn):
+      return renderTurnLine(turn)
+    case .codePhase(_, let payload):
+      return renderCodePhasePayload(payload)
+    }
+  }
+
   private func renderTurnLine(_ turn: TurnRecord) -> String {
     guard let agent = turn.agentName else {
-      // Code phase turn — no agent, no LLM output to render. Emit a placeholder
-      // so the phase's presence is still visible in the log.
+      // Legacy fallback: a TurnRecord without an agent can only appear in
+      // pre-#92 databases that never existed in practice. Emit a placeholder
+      // so any stray row doesn't render as a blank bullet.
       return "- _(code phase — no agent output)_"
     }
     let output = decodeOutput(turn)
@@ -182,6 +263,57 @@ struct ResultMarkdownExporter {
       line += "\n  - 💭 _\(thought)_"
     }
     return line
+  }
+
+  private func renderCodePhasePayload(_ payload: CodePhaseEventPayload) -> String {
+    switch payload {
+    case .elimination(let agent, let voteCount):
+      return "- **\(agent)** was eliminated (\(voteCount) votes)"
+    case .scoreUpdate(let scores):
+      let ordered = scores.sorted { lhs, rhs in
+        if lhs.value != rhs.value { return lhs.value > rhs.value }
+        return lhs.key < rhs.key
+      }
+      let pairs = ordered.map { "\($0.key): \($0.value)" }.joined(separator: ", ")
+      return "- Scores — \(pairs)"
+    case .summary(let text):
+      return "- \(text)"
+    case .voteResults(let votes, let tallies):
+      var lines: [String] = []
+      lines.append("- Tallies:")
+      lines.append("")
+      lines.append("  | Candidate | Votes |")
+      lines.append("  |-----------|-------|")
+      let orderedTallies = tallies.sorted { lhs, rhs in
+        if lhs.value != rhs.value { return lhs.value > rhs.value }
+        return lhs.key < rhs.key
+      }
+      for (candidate, count) in orderedTallies {
+        lines.append("  | \(candidate) | \(count) |")
+      }
+      lines.append("")
+      lines.append("- Votes:")
+      let orderedVotes = votes.sorted { $0.key < $1.key }
+      for (voter, target) in orderedVotes {
+        lines.append("  - \(voter) → \(target)")
+      }
+      return lines.joined(separator: "\n")
+    case .pairingResult(let a1, let act1, let a2, let act2):
+      return "- **\(a1)** (\(act1)) ↔ **\(a2)** (\(act2))"
+    case .assignment(let agent, let value):
+      return "- **\(agent)** was assigned: \(value)"
+    }
+  }
+
+  private func decodePayload(_ record: CodePhaseEventRecord) -> CodePhaseEventPayload? {
+    guard let data = record.payloadJSON.data(using: .utf8) else { return nil }
+    return try? JSONDecoder().decode(CodePhaseEventPayload.self, from: data)
+  }
+
+  private func decodedPayloads(
+    _ records: [CodePhaseEventRecord]
+  ) -> [CodePhaseEventPayload] {
+    records.compactMap { decodePayload($0) }
   }
 
   private func decodeOutput(_ turn: TurnRecord) -> TurnOutput {
@@ -207,24 +339,106 @@ struct ResultMarkdownExporter {
     return pairs.joined(separator: ", ")
   }
 
-  private func renderFinalScores(_ input: Input) -> String {
-    let scores = input.state.scores
-    guard !scores.isEmpty else {
+  /// Renders "Final Scores" from the latest `.scoreUpdate` payload merged
+  /// onto the persona roster. Agents not present in the payload default to
+  /// 0 — the roster is authoritative so the table always covers all personas.
+  ///
+  /// Events are the source of truth here, independent of
+  /// `SimulationState.stateJSON`. This stays correct even if continuous
+  /// state persistence (pause/resume) lands later — events are append-only,
+  /// state is just a snapshot.
+  private func renderFinalScores(
+    _ input: Input, payloads: [CodePhaseEventPayload]
+  ) -> String {
+    let latestScores = latestScoreUpdate(in: payloads)
+    let eliminatedSet = eliminatedAgents(in: payloads)
+    let roster = rosterAgents(input: input, latestScores: latestScores)
+
+    guard !roster.isEmpty else {
       return "## Final Scores\n\n_No score data._"
     }
+
     var lines: [String] = [
       "## Final Scores", "", "| Agent | Score | Status |", "|-------|-------|--------|"
     ]
-    let ordered = scores.sorted { lhs, rhs in
-      if lhs.value != rhs.value { return lhs.value > rhs.value }
-      return lhs.key < rhs.key
+    // Sort by score desc, then by name asc for deterministic output.
+    let ordered = roster.sorted { lhs, rhs in
+      let lhsScore = latestScores[lhs] ?? 0
+      let rhsScore = latestScores[rhs] ?? 0
+      if lhsScore != rhsScore { return lhsScore > rhsScore }
+      return lhs < rhs
     }
-    for (agent, score) in ordered {
-      let eliminated = input.state.eliminated[agent] == true
-      let status = eliminated ? "eliminated" : "active"
+    for agent in ordered {
+      let score = latestScores[agent] ?? 0
+      let status = eliminatedSet.contains(agent) ? "eliminated" : "active"
       lines.append("| \(agent) | \(score) | \(status) |")
     }
     return lines.joined(separator: "\n")
+  }
+
+  /// Renders "Roster Status" when elimination events exist but no score
+  /// updates were emitted (e.g., Word Wolf — `wordwolf_judge` announces the
+  /// winner via `.summary` and drops elimination events without a score
+  /// delta). Shows active/eliminated per persona without a misleading
+  /// all-zero score column.
+  private func renderRosterStatus(
+    _ input: Input, payloads: [CodePhaseEventPayload]
+  ) -> String {
+    let eliminatedSet = eliminatedAgents(in: payloads)
+    let roster = rosterAgents(input: input, latestScores: [:])
+
+    guard !roster.isEmpty else {
+      return "## Roster Status\n\n_No roster data._"
+    }
+
+    var lines: [String] = [
+      "## Roster Status", "", "| Agent | Status |", "|-------|--------|"
+    ]
+    // Eliminated agents first (narrative interest), then by name.
+    let ordered = roster.sorted { lhs, rhs in
+      let lElim = eliminatedSet.contains(lhs)
+      let rElim = eliminatedSet.contains(rhs)
+      if lElim != rElim { return lElim && !rElim }
+      return lhs < rhs
+    }
+    for agent in ordered {
+      let status = eliminatedSet.contains(agent) ? "eliminated" : "active"
+      lines.append("| \(agent) | \(status) |")
+    }
+    return lines.joined(separator: "\n")
+  }
+
+  private func latestScoreUpdate(
+    in payloads: [CodePhaseEventPayload]
+  ) -> [String: Int] {
+    // payloads are in event-arrival order (caller passes `decodedPayloads`
+    // which preserves the fetched order, and the repository orders by
+    // sequenceNumber). The last scoreUpdate is authoritative for final values.
+    for payload in payloads.reversed() {
+      if case .scoreUpdate(let scores) = payload { return scores }
+    }
+    return [:]
+  }
+
+  private func eliminatedAgents(
+    in payloads: [CodePhaseEventPayload]
+  ) -> Set<String> {
+    var agents: Set<String> = []
+    for payload in payloads {
+      if case .elimination(let agent, _) = payload { agents.insert(agent) }
+    }
+    return agents
+  }
+
+  /// Union of `input.personas` and agents that appear in `latestScores`.
+  /// `input.personas` is authoritative; extra scored agents are included
+  /// defensively so a broken roster never hides data.
+  private func rosterAgents(
+    input: Input, latestScores: [String: Int]
+  ) -> [String] {
+    var set = Set(input.personas)
+    set.formUnion(latestScores.keys)
+    return Array(set)
   }
 
   // MARK: - Duration formatting

--- a/Pastura/Pastura/App/ResultMarkdownExporter.swift
+++ b/Pastura/Pastura/App/ResultMarkdownExporter.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import Foundation
 
 /// Formats a completed simulation into a Markdown document for external sharing
@@ -11,7 +12,7 @@ import Foundation
 /// ContentFilter is applied as a **whole-string pass** on the final rendered
 /// Markdown, not per-field, so YAML content, persona names, and conversation
 /// log prose are all covered in one sweep.
-struct ResultMarkdownExporter {
+struct ResultMarkdownExporter {  // swiftlint:disable:this type_body_length
   /// Environment metadata captured at export time.
   struct ExportEnvironment: Sendable {
     /// `UIDevice.current.model` value (e.g. "iPhone").
@@ -171,20 +172,20 @@ struct ResultMarkdownExporter {
 
     var round: Int {
       switch self {
-      case .turn(let t): return t.roundNumber
-      case .codePhase(let r, _): return r.roundNumber
+      case .turn(let turn): return turn.roundNumber
+      case .codePhase(let record, _): return record.roundNumber
       }
     }
     var sequenceNumber: Int {
       switch self {
-      case .turn(let t): return t.sequenceNumber
-      case .codePhase(let r, _): return r.sequenceNumber
+      case .turn(let turn): return turn.sequenceNumber
+      case .codePhase(let record, _): return record.sequenceNumber
       }
     }
     var phaseType: String {
       switch self {
-      case .turn(let t): return t.phaseType
-      case .codePhase(let r, _): return r.phaseType
+      case .turn(let turn): return turn.phaseType
+      case .codePhase(let record, _): return record.phaseType
       }
     }
   }
@@ -298,8 +299,8 @@ struct ResultMarkdownExporter {
         lines.append("  - \(voter) → \(target)")
       }
       return lines.joined(separator: "\n")
-    case .pairingResult(let a1, let act1, let a2, let act2):
-      return "- **\(a1)** (\(act1)) ↔ **\(a2)** (\(act2))"
+    case .pairingResult(let agent1, let action1, let agent2, let action2):
+      return "- **\(agent1)** (\(action1)) ↔ **\(agent2)** (\(action2))"
     case .assignment(let agent, let value):
       return "- **\(agent)** was assigned: \(value)"
     }

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -458,6 +458,7 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     let simulation: SimulationRecord
     let scenario: ScenarioRecord
     let turns: [TurnRecord]
+    let codePhaseEvents: [CodePhaseEventRecord]
   }
 
   /// Fetches the current simulation's records and renders them as a Markdown
@@ -469,6 +470,7 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     guard let simId = simulationId, let scenarioRepository else { return nil }
     let simulationRepository = self.simulationRepository
     let turnRepository = self.turnRepository
+    let codePhaseEventRepository = self.codePhaseEventRepository
 
     let records: ExportRecords? = try await offMain {
       guard
@@ -478,10 +480,23 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
         return nil
       }
       let turns = try turnRepository.fetchBySimulationId(simId)
-      return ExportRecords(simulation: sim, scenario: scenario, turns: turns)
+      let codeEvents = try codePhaseEventRepository?.fetchBySimulationId(simId) ?? []
+      return ExportRecords(
+        simulation: sim, scenario: scenario,
+        turns: turns, codePhaseEvents: codeEvents)
     }
 
     guard let records, records.simulation.simulationStatus == .completed else { return nil }
+
+    // Parse personas from the scenario YAML. Exports stay usable even when
+    // the YAML fails to parse — the Final Scores / Roster Status section is
+    // simply omitted rather than aborting the whole export.
+    let personas: [String] = {
+      guard
+        let scenario = try? ScenarioLoader().load(yaml: records.scenario.yamlDefinition)
+      else { return [] }
+      return scenario.personas.map(\.name)
+    }()
 
     let state = decodeState(from: records.simulation) ?? SimulationState()
     let exporter = ResultMarkdownExporter(
@@ -492,6 +507,8 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
         simulation: records.simulation,
         scenario: records.scenario,
         turns: records.turns,
+        codePhaseEvents: records.codePhaseEvents,
+        personas: personas,
         state: state))
   }
 

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import Foundation
 
 /// A single displayable entry in the simulation log.
@@ -98,9 +99,10 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   /// routed to exactly one stream and increments this counter exactly once
   /// on MainActor — a single yield per event guarantees strict total order
   /// for merge-sort at export time.
-  // TODO(resume): when pause/resume lands, re-initialize from
-  // `MAX(sequenceNumber)` across both tables so resumed runs do not collide
-  // with existing persisted rows.
+  ///
+  /// TODO(resume): when pause/resume lands, re-initialize from
+  /// `MAX(sequenceNumber)` across both tables so resumed runs do not collide
+  /// with existing persisted rows.
   private var turnSequence = 0
 
   init(

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -415,7 +415,13 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     guard let continuation = codePhasePersistenceContinuation else { return }
     do {
       let data = try JSONEncoder().encode(payload)
-      let jsonString = String(data: data, encoding: .utf8) ?? "{}"
+      // JSONEncoder always produces valid UTF-8, so the conversion can't fail
+      // in practice. Bail out instead of falling back to "{}" so a bogus
+      // payload does not reserve a sequenceNumber slot.
+      guard let jsonString = String(data: data, encoding: .utf8) else {
+        print("⚠️ Failed to stringify code-phase payload JSON")
+        return
+      }
       turnSequence += 1
       let record = CodePhaseEventRecord(
         id: UUID().uuidString,

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -105,6 +105,13 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   /// with existing persisted rows.
   private var turnSequence = 0
 
+  /// The phase currently executing, tracked via `.phaseStarted` events.
+  /// `.summary` has multiple emitters (`SummarizeHandler` and scoring logics
+  /// like `wordwolf_judge` that live inside `ScoreCalcHandler`), so the
+  /// phaseType column of the persisted `CodePhaseEventRecord` must come from
+  /// the engine's execution context rather than the event shape.
+  private var currentPhaseType: PhaseType?
+
   init(
     runner: SimulationRunner = SimulationRunner(),
     contentFilter: ContentFilter = ContentFilter(),
@@ -218,6 +225,7 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     case .roundCompleted(let round, let newScores):
       handleRoundCompleted(round: round, scores: newScores)
     case .phaseStarted(let phaseType, _):
+      currentPhaseType = phaseType
       logEntries.append(LogEntry(kind: .phaseStarted(phaseType: phaseType)))
     case .phaseCompleted, .simulationPaused:
       break
@@ -239,41 +247,45 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
 
   /// Handles score, vote, and other code-phase result events. Each branch
   /// updates UI state AND persists a `CodePhaseEventRecord` so exports can
-  /// reconstruct per-phase outcomes. See `persistCodePhaseEvent(phaseType:payload:)`
-  /// for the persistence path.
+  /// reconstruct per-phase outcomes.
+  ///
+  /// The persisted `phaseType` column uses `currentPhaseType` (tracked from
+  /// `.phaseStarted`) with a per-event fallback. This is essential for
+  /// `.summary`, which fires from both `SummarizeHandler` and scoring logics
+  /// like `wordwolf_judge` inside `ScoreCalcHandler` — hard-coding would
+  /// bucket the judge verdict into the wrong phase in exports.
   private func handleOutputEvent(_ event: SimulationEvent) {
     switch event {
     case .scoreUpdate(let newScores):
       handleScoreUpdate(scores: newScores)
       persistCodePhaseEvent(
-        phaseType: PhaseType.scoreCalc.rawValue,
+        phaseType: currentPhaseType?.rawValue ?? PhaseType.scoreCalc.rawValue,
         payload: .scoreUpdate(scores: newScores))
     case .elimination(let agent, let voteCount):
       handleElimination(agent: agent, voteCount: voteCount)
       persistCodePhaseEvent(
-        phaseType: PhaseType.eliminate.rawValue,
+        phaseType: currentPhaseType?.rawValue ?? PhaseType.eliminate.rawValue,
         payload: .elimination(agent: agent, voteCount: voteCount))
     case .assignment(let agent, let value):
       logEntries.append(LogEntry(kind: .assignment(agent: agent, value: value)))
       persistCodePhaseEvent(
-        phaseType: PhaseType.assign.rawValue,
+        phaseType: currentPhaseType?.rawValue ?? PhaseType.assign.rawValue,
         payload: .assignment(agent: agent, value: value))
     case .summary(let text):
       logEntries.append(LogEntry(kind: .summary(text: text)))
       // `.summary` also fires for validator warnings (before the first round
       // starts, currentRound == 0) and early-termination (after the round
-      // loop exits). Export intentionally drops pre-round warnings — they are
-      // diagnostic, not part of the scenario's narrative. Early-termination
-      // summaries inherit the last-started round number and are persisted.
+      // loop exits). Export intentionally drops pre-round warnings — they
+      // are diagnostic, not part of the scenario's narrative.
       if currentRound > 0 {
         persistCodePhaseEvent(
-          phaseType: PhaseType.summarize.rawValue,
+          phaseType: currentPhaseType?.rawValue ?? PhaseType.summarize.rawValue,
           payload: .summary(text: text))
       }
     case .voteResults(let votes, let tallies):
       logEntries.append(LogEntry(kind: .voteResults(votes: votes, tallies: tallies)))
       persistCodePhaseEvent(
-        phaseType: PhaseType.vote.rawValue,
+        phaseType: currentPhaseType?.rawValue ?? PhaseType.vote.rawValue,
         payload: .voteResults(votes: votes, tallies: tallies))
     case .pairingResult(let agent1, let act1, let agent2, let act2):
       logEntries.append(
@@ -282,7 +294,7 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
             agent1: agent1, action1: act1, agent2: agent2, action2: act2
           )))
       persistCodePhaseEvent(
-        phaseType: PhaseType.choose.rawValue,
+        phaseType: currentPhaseType?.rawValue ?? PhaseType.choose.rawValue,
         payload: .pairingResult(
           agent1: agent1, action1: act1, agent2: agent2, action2: act2))
     default:

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -71,8 +71,10 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   private let contentFilter: ContentFilter
   private let simulationRepository: any SimulationRepository
   private let turnRepository: any TurnRepository
+  private let codePhaseEventRepository: (any CodePhaseEventRepository)?
   private let scenarioRepository: (any ScenarioRepository)?
-  private var simulationId: String?
+  // Non-private so `@testable import` can seed persistence without invoking `run()`.
+  internal var simulationId: String?
 
   /// Holds the currently running simulation task for cancellation support.
   /// Set by the caller (SimulationView) after launching `run()` in a Task.
@@ -85,8 +87,20 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   private var persistenceContinuation: AsyncStream<TurnRecord>.Continuation?
   private var persistenceTask: Task<Void, Never>?
 
-  /// Per-simulation sequence counter for deterministic TurnRecord ordering.
-  /// Incremented synchronously on MainActor — no lock needed.
+  // Parallel queue for code-phase events. Drained alongside the turns queue
+  // before `.completed` status is persisted so exporters can fetch complete
+  // data immediately after `run()` returns.
+  private var codePhasePersistenceContinuation: AsyncStream<CodePhaseEventRecord>.Continuation?
+  private var codePhasePersistenceTask: Task<Void, Never>?
+
+  /// Per-simulation sequence counter for deterministic ordering of BOTH
+  /// `TurnRecord` (agent output) and `CodePhaseEventRecord`. Each event is
+  /// routed to exactly one stream and increments this counter exactly once
+  /// on MainActor — a single yield per event guarantees strict total order
+  /// for merge-sort at export time.
+  // TODO(resume): when pause/resume lands, re-initialize from
+  // `MAX(sequenceNumber)` across both tables so resumed runs do not collide
+  // with existing persisted rows.
   private var turnSequence = 0
 
   init(
@@ -94,12 +108,14 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     contentFilter: ContentFilter = ContentFilter(),
     simulationRepository: any SimulationRepository,
     turnRepository: any TurnRepository,
+    codePhaseEventRepository: (any CodePhaseEventRepository)? = nil,
     scenarioRepository: (any ScenarioRepository)? = nil
   ) {
     self.runner = runner
     self.contentFilter = contentFilter
     self.simulationRepository = simulationRepository
     self.turnRepository = turnRepository
+    self.codePhaseEventRepository = codePhaseEventRepository
     self.scenarioRepository = scenarioRepository
   }
 
@@ -135,11 +151,13 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
 
     turnSequence = 0
 
-    // Start serial persistence consumer before any events can arrive.
+    // Start both persistence consumers before any events can arrive.
     startPersistenceConsumer()
+    startCodePhasePersistenceConsumer()
     // Guarantee cleanup in ALL exit paths (LLM load failure, cancellation, etc.)
     defer {
       persistenceContinuation?.finish()
+      codePhasePersistenceContinuation?.finish()
       isRunning = false
     }
 
@@ -162,10 +180,14 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
       handleEvent(event, scenario: scenario)
     }
 
-    // Drain persistence queue before marking simulation as completed.
-    // finish() is idempotent; defer also calls it for early-return paths.
+    // Drain BOTH persistence queues before marking simulation as completed.
+    // `fetchExportPayload` guards on `.completed`, so unflushed writes would
+    // race the export. finish() is idempotent; defer also calls it for
+    // early-return paths.
     persistenceContinuation?.finish()
+    codePhasePersistenceContinuation?.finish()
     await persistenceTask?.value
+    await codePhasePersistenceTask?.value
 
     // Cleanup
     try? await llm.unloadModel()
@@ -213,25 +235,54 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     }
   }
 
-  /// Handles score, vote, and other output-related events.
+  /// Handles score, vote, and other code-phase result events. Each branch
+  /// updates UI state AND persists a `CodePhaseEventRecord` so exports can
+  /// reconstruct per-phase outcomes. See `persistCodePhaseEvent(phaseType:payload:)`
+  /// for the persistence path.
   private func handleOutputEvent(_ event: SimulationEvent) {
     switch event {
     case .scoreUpdate(let newScores):
       handleScoreUpdate(scores: newScores)
+      persistCodePhaseEvent(
+        phaseType: PhaseType.scoreCalc.rawValue,
+        payload: .scoreUpdate(scores: newScores))
     case .elimination(let agent, let voteCount):
       handleElimination(agent: agent, voteCount: voteCount)
+      persistCodePhaseEvent(
+        phaseType: PhaseType.eliminate.rawValue,
+        payload: .elimination(agent: agent, voteCount: voteCount))
     case .assignment(let agent, let value):
       logEntries.append(LogEntry(kind: .assignment(agent: agent, value: value)))
+      persistCodePhaseEvent(
+        phaseType: PhaseType.assign.rawValue,
+        payload: .assignment(agent: agent, value: value))
     case .summary(let text):
       logEntries.append(LogEntry(kind: .summary(text: text)))
+      // `.summary` also fires for validator warnings (before the first round
+      // starts, currentRound == 0) and early-termination (after the round
+      // loop exits). Export intentionally drops pre-round warnings — they are
+      // diagnostic, not part of the scenario's narrative. Early-termination
+      // summaries inherit the last-started round number and are persisted.
+      if currentRound > 0 {
+        persistCodePhaseEvent(
+          phaseType: PhaseType.summarize.rawValue,
+          payload: .summary(text: text))
+      }
     case .voteResults(let votes, let tallies):
       logEntries.append(LogEntry(kind: .voteResults(votes: votes, tallies: tallies)))
+      persistCodePhaseEvent(
+        phaseType: PhaseType.vote.rawValue,
+        payload: .voteResults(votes: votes, tallies: tallies))
     case .pairingResult(let agent1, let act1, let agent2, let act2):
       logEntries.append(
         LogEntry(
           kind: .pairingResult(
             agent1: agent1, action1: act1, agent2: agent2, action2: act2
           )))
+      persistCodePhaseEvent(
+        phaseType: PhaseType.choose.rawValue,
+        payload: .pairingResult(
+          agent1: agent1, action1: act1, agent2: agent2, action2: act2))
     default:
       break
     }
@@ -335,6 +386,70 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     } catch {
       print("⚠️ Failed to encode turn output: \(error)")
     }
+  }
+
+  private func startCodePhasePersistenceConsumer() {
+    // If no repository was injected, skip starting the consumer — yields
+    // from `persistCodePhaseEvent` become no-ops because the continuation
+    // stays nil. This keeps existing call sites (pre-#92 constructors) working.
+    guard let codePhaseRepo = codePhaseEventRepository else { return }
+    let (stream, continuation) = AsyncStream<CodePhaseEventRecord>.makeStream()
+    codePhasePersistenceContinuation = continuation
+    codePhasePersistenceTask = Task.detached {
+      for await record in stream {
+        do {
+          try codePhaseRepo.save(record)
+        } catch {
+          print("⚠️ Failed to persist code-phase event: \(error)")
+        }
+      }
+    }
+  }
+
+  private func persistCodePhaseEvent(
+    phaseType: String, payload: CodePhaseEventPayload
+  ) {
+    guard let simId = simulationId else { return }
+    guard let continuation = codePhasePersistenceContinuation else { return }
+    do {
+      let data = try JSONEncoder().encode(payload)
+      let jsonString = String(data: data, encoding: .utf8) ?? "{}"
+      turnSequence += 1
+      let record = CodePhaseEventRecord(
+        id: UUID().uuidString,
+        simulationId: simId,
+        roundNumber: currentRound,
+        phaseType: phaseType,
+        sequenceNumber: turnSequence,
+        payloadJSON: jsonString,
+        createdAt: Date()
+      )
+      continuation.yield(record)
+    } catch {
+      print("⚠️ Failed to encode code-phase payload: \(error)")
+    }
+  }
+
+  // MARK: - Test Seams
+
+  /// Initializes persistence without invoking `run()`, so unit tests can
+  /// exercise `handleEvent` directly and assert DB contents. Pair with
+  /// `finishPersistenceForTest()` to drain both queues before assertions.
+  internal func beginPersistenceForTest(simulationId: String) {
+    self.simulationId = simulationId
+    turnSequence = 0
+    startPersistenceConsumer()
+    startCodePhasePersistenceConsumer()
+  }
+
+  /// Drains both persistence queues synchronously with the caller. Use after
+  /// `beginPersistenceForTest(simulationId:)` and a series of `handleEvent`
+  /// calls before querying the DB.
+  internal func finishPersistenceForTest() async {
+    persistenceContinuation?.finish()
+    codePhasePersistenceContinuation?.finish()
+    await persistenceTask?.value
+    await codePhasePersistenceTask?.value
   }
 
   // MARK: - Export

--- a/Pastura/Pastura/Data/CodePhaseEventRepository.swift
+++ b/Pastura/Pastura/Data/CodePhaseEventRepository.swift
@@ -1,0 +1,84 @@
+import Foundation
+import GRDB
+
+/// Repository for persisting and retrieving code-phase event records.
+///
+/// Mirrors `TurnRepository` in shape so callers can treat the two tables
+/// symmetrically when merging events for export rendering.
+nonisolated public protocol CodePhaseEventRepository: Sendable {
+  /// Saves a single record.
+  func save(_ record: CodePhaseEventRecord) throws
+
+  /// Saves multiple records in a single transaction.
+  func saveBatch(_ records: [CodePhaseEventRecord]) throws
+
+  /// Fetches all records for a simulation, ordered by `sequenceNumber`
+  /// ascending (with `createdAt` as a stable tiebreaker).
+  func fetchBySimulationId(_ simulationId: String) throws -> [CodePhaseEventRecord]
+
+  /// Fetches records for a specific simulation and round number, ordered by
+  /// `sequenceNumber` ascending. Leverages `idx_code_phase_events_simulation_round`.
+  func fetchBySimulationAndRound(
+    _ simulationId: String, round: Int
+  ) throws -> [CodePhaseEventRecord]
+
+  /// Deletes all records for a given simulation.
+  func deleteBySimulationId(_ simulationId: String) throws
+}
+
+/// GRDB-backed implementation of `CodePhaseEventRepository`.
+nonisolated public final class GRDBCodePhaseEventRepository: CodePhaseEventRepository, Sendable {
+  private let dbWriter: any DatabaseWriter
+
+  public init(dbWriter: any DatabaseWriter) {
+    self.dbWriter = dbWriter
+  }
+
+  public func save(_ record: CodePhaseEventRecord) throws {
+    try dbWriter.write { db in
+      try record.insert(db)
+    }
+  }
+
+  public func saveBatch(_ records: [CodePhaseEventRecord]) throws {
+    try dbWriter.write { db in
+      for record in records {
+        try record.insert(db)
+      }
+    }
+  }
+
+  public func fetchBySimulationId(
+    _ simulationId: String
+  ) throws -> [CodePhaseEventRecord] {
+    try dbWriter.read { db in
+      try CodePhaseEventRecord
+        .filter(Column("simulationId") == simulationId)
+        .order(Column("sequenceNumber").asc, Column("createdAt").asc)
+        .fetchAll(db)
+    }
+  }
+
+  public func fetchBySimulationAndRound(
+    _ simulationId: String, round: Int
+  ) throws -> [CodePhaseEventRecord] {
+    try dbWriter.read { db in
+      try CodePhaseEventRecord
+        .filter(
+          Column("simulationId") == simulationId
+            && Column("roundNumber") == round
+        )
+        .order(Column("sequenceNumber").asc, Column("createdAt").asc)
+        .fetchAll(db)
+    }
+  }
+
+  public func deleteBySimulationId(_ simulationId: String) throws {
+    try dbWriter.write { db in
+      _ =
+        try CodePhaseEventRecord
+        .filter(Column("simulationId") == simulationId)
+        .deleteAll(db)
+    }
+  }
+}

--- a/Pastura/Pastura/Data/DatabaseManager.swift
+++ b/Pastura/Pastura/Data/DatabaseManager.swift
@@ -58,6 +58,7 @@ nonisolated public final class DatabaseManager: Sendable {
     return config
   }
 
+  // swiftlint:disable:next function_body_length
   private static func registerMigrations(_ migrator: inout DatabaseMigrator) {
     registerV1(&migrator)
 

--- a/Pastura/Pastura/Data/DatabaseManager.swift
+++ b/Pastura/Pastura/Data/DatabaseManager.swift
@@ -58,7 +58,6 @@ nonisolated public final class DatabaseManager: Sendable {
     return config
   }
 
-  // swiftlint:disable:next function_body_length
   private static func registerMigrations(_ migrator: inout DatabaseMigrator) {
     registerV1(&migrator)
 

--- a/Pastura/Pastura/Data/DatabaseManager.swift
+++ b/Pastura/Pastura/Data/DatabaseManager.swift
@@ -83,6 +83,24 @@ nonisolated public final class DatabaseManager: Sendable {
         t.add(column: "sourceHash", .text)
       }
     }
+
+    migrator.registerMigration("v5_createCodePhaseEventsTable") { db in
+      try db.create(table: "code_phase_events") { t in
+        t.primaryKey("id", .text)
+        t.column("simulationId", .text).notNull()
+          .references("simulations", onDelete: .cascade)
+        t.column("roundNumber", .integer).notNull()
+        t.column("phaseType", .text).notNull()
+        t.column("sequenceNumber", .integer).notNull()
+        t.column("payloadJSON", .text).notNull()
+        t.column("createdAt", .datetime).notNull()
+      }
+
+      try db.create(
+        index: "idx_code_phase_events_simulation_round",
+        on: "code_phase_events",
+        columns: ["simulationId", "roundNumber"])
+    }
   }
 
   private static func registerV1(_ migrator: inout DatabaseMigrator) {

--- a/Pastura/Pastura/Data/Models/CodePhaseEventRecord.swift
+++ b/Pastura/Pastura/Data/Models/CodePhaseEventRecord.swift
@@ -1,0 +1,51 @@
+import Foundation
+import GRDB
+
+/// Database record type for the `code_phase_events` table.
+///
+/// Each record represents one code-phase result (elimination, score update,
+/// summary, vote tally, pairing outcome, or assignment) persisted as
+/// `CodePhaseEventPayload` JSON. Unlike `TurnRecord`, these rows are not
+/// tied to an agent's LLM output — they capture deterministic outcomes
+/// emitted by phase handlers so exports and analyses can reconstruct the
+/// round-by-round narrative without replaying events.
+///
+/// `sequenceNumber` is shared with `TurnRecord` within a simulation:
+/// `SimulationViewModel` increments a single counter per event and routes
+/// the record to the appropriate table. This guarantees a strict total
+/// order across both tables for merge-sort at export time.
+nonisolated public struct CodePhaseEventRecord: Codable, Sendable, Equatable,
+  FetchableRecord, PersistableRecord {
+  public static let databaseTableName = "code_phase_events"
+
+  public var id: String
+  public var simulationId: String
+  public var roundNumber: Int
+  /// The originating phase type (e.g., "eliminate", "score_calc", "summarize",
+  /// "vote", "choose", "assign"). Stored as raw string for forward compat.
+  public var phaseType: String
+  /// Canonical ordering key, shared with `TurnRecord.sequenceNumber`
+  /// across the same `simulationId`.
+  public var sequenceNumber: Int
+  /// Serialized `CodePhaseEventPayload` as JSON.
+  public var payloadJSON: String
+  public var createdAt: Date
+
+  public init(
+    id: String,
+    simulationId: String,
+    roundNumber: Int,
+    phaseType: String,
+    sequenceNumber: Int,
+    payloadJSON: String,
+    createdAt: Date
+  ) {
+    self.id = id
+    self.simulationId = simulationId
+    self.roundNumber = roundNumber
+    self.phaseType = phaseType
+    self.sequenceNumber = sequenceNumber
+    self.payloadJSON = payloadJSON
+    self.createdAt = createdAt
+  }
+}

--- a/Pastura/Pastura/Models/CodePhaseEventPayload.swift
+++ b/Pastura/Pastura/Models/CodePhaseEventPayload.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Serializable payload for a code-phase event persisted in `code_phase_events`.
+///
+/// Mirrors the code-phase cases of `SimulationEvent` for durable storage.
+/// The App layer consumes `SimulationEvent`s from the Engine and maps them
+/// into this type before writing to the database, so the exporter and other
+/// consumers can reconstruct per-phase results without replaying events.
+///
+/// Wire-format stability: adding new cases is backward-compatible under
+/// Swift's default `Codable` synthesis for enums (new outer keys are
+/// simply unknown to old decoders, which isn't an issue here since readers
+/// ship with producers). Renaming or removing a case requires a data
+/// migration that rewrites existing `payloadJSON` rows.
+nonisolated public enum CodePhaseEventPayload: Codable, Sendable, Equatable {
+  /// An agent was eliminated as the result of an `eliminate` phase.
+  case elimination(agent: String, voteCount: Int)
+
+  /// Scores were updated by a `score_calc` phase.
+  case scoreUpdate(scores: [String: Int])
+
+  /// A textual summary was produced by `summarize` or a scoring logic
+  /// (e.g., `wordwolf_judge` verdicts surface here).
+  case summary(text: String)
+
+  /// Voting concluded. `votes` maps voter → target; `tallies` maps
+  /// candidate → received vote count.
+  case voteResults(votes: [String: String], tallies: [String: Int])
+
+  /// One pair's outcome in a `choose` phase with round-robin pairing.
+  case pairingResult(agent1: String, action1: String, agent2: String, action2: String)
+
+  /// A value was assigned to an agent by an `assign` phase
+  /// (e.g., wolf/villager role in Word Wolf).
+  case assignment(agent: String, value: String)
+}

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -293,6 +293,7 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
       let simViewModel = SimulationViewModel(
         simulationRepository: deps.simulationRepository,
         turnRepository: deps.turnRepository,
+        codePhaseEventRepository: deps.codePhaseEventRepository,
         scenarioRepository: deps.scenarioRepository
       )
       viewModel = simViewModel

--- a/Pastura/PasturaTests/App/ResultMarkdownExporterCodePhaseTests.swift
+++ b/Pastura/PasturaTests/App/ResultMarkdownExporterCodePhaseTests.swift
@@ -327,4 +327,9 @@ struct ResultMarkdownExporterCodePhaseTests {  // swiftlint:disable:this type_bo
     #expect(!result.text.contains("## Final Scores"))
     #expect(!result.text.contains("## Roster Status"))
   }
+
+  // The Word Wolf end-to-end fixture lives in
+  // `ResultMarkdownExporterWordWolfTests.swift` to keep this file under
+  // `file_length`. It models a realistic Word Wolf round and defends the
+  // four Acceptance Criteria from #92.
 }

--- a/Pastura/PasturaTests/App/ResultMarkdownExporterCodePhaseTests.swift
+++ b/Pastura/PasturaTests/App/ResultMarkdownExporterCodePhaseTests.swift
@@ -1,0 +1,330 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+@Suite @MainActor
+struct ResultMarkdownExporterCodePhaseTests {  // swiftlint:disable:this type_body_length
+
+  // MARK: - Fixtures
+
+  private let createdAt = Date(timeIntervalSince1970: 1_712_000_000)
+  private let updatedAt = Date(timeIntervalSince1970: 1_712_000_342)
+  private let exportAt = Date(timeIntervalSince1970: 1_713_000_000)
+
+  private func makeScenario(
+    id: String = "s1",
+    name: String = "Test",
+    yaml: String = "name: Test\n"
+  ) -> ScenarioRecord {
+    ScenarioRecord(
+      id: id, name: name, yamlDefinition: yaml,
+      isPreset: false, createdAt: Date(), updatedAt: Date())
+  }
+
+  private func makeSimulation() -> SimulationRecord {
+    SimulationRecord(
+      id: "sim1", scenarioId: "s1",
+      status: SimulationStatus.completed.rawValue,
+      currentRound: 1, currentPhaseIndex: 0,
+      stateJSON: "{}", configJSON: nil,
+      createdAt: createdAt, updatedAt: updatedAt,
+      modelIdentifier: "test", llmBackend: "mock")
+  }
+
+  private func makeState() -> SimulationState {
+    SimulationState(
+      scores: [:], eliminated: [:], conversationLog: [],
+      lastOutputs: [:], voteResults: [:], pairings: [],
+      variables: [:], currentRound: 1)
+  }
+
+  private func makeCodePhaseEvent(
+    id: String = UUID().uuidString,
+    round: Int = 1,
+    phaseType: String,
+    seq: Int,
+    payload: CodePhaseEventPayload
+  ) -> CodePhaseEventRecord {
+    let data = (try? JSONEncoder().encode(payload)) ?? Data("{}".utf8)
+    let json = String(data: data, encoding: .utf8) ?? "{}"
+    return CodePhaseEventRecord(
+      id: id, simulationId: "sim1",
+      roundNumber: round, phaseType: phaseType,
+      sequenceNumber: seq, payloadJSON: json,
+      createdAt: Date())
+  }
+
+  private func makeTurn(
+    round: Int, seq: Int, phase: String,
+    agent: String?, fields: [String: String]
+  ) -> TurnRecord {
+    let json =
+      (try? JSONEncoder().encode(TurnOutput(fields: fields))).flatMap {
+        String(data: $0, encoding: .utf8)
+      } ?? "{}"
+    return TurnRecord(
+      id: UUID().uuidString, simulationId: "sim1",
+      roundNumber: round, phaseType: phase,
+      agentName: agent, rawOutput: json,
+      parsedOutputJSON: json, sequenceNumber: seq,
+      createdAt: Date())
+  }
+
+  private func makeExporter() -> ResultMarkdownExporter {
+    ResultMarkdownExporter(
+      contentFilter: ContentFilter(blockedPatterns: []),
+      environment: .init(deviceModel: "iPhone", osVersion: "Version 17.5"),
+      now: exportAt)
+  }
+
+  private func input(
+    turns: [TurnRecord] = [],
+    events: [CodePhaseEventRecord] = [],
+    personas: [String] = []
+  ) -> ResultMarkdownExporter.Input {
+    ResultMarkdownExporter.Input(
+      simulation: makeSimulation(),
+      scenario: makeScenario(),
+      turns: turns,
+      codePhaseEvents: events,
+      personas: personas,
+      state: makeState())
+  }
+
+  // MARK: - Per-phase renderers
+
+  @Test func rendersEliminationEvent() throws {
+    let exporter = makeExporter()
+    let event = makeCodePhaseEvent(
+      phaseType: "eliminate", seq: 1,
+      payload: .elimination(agent: "Bob", voteCount: 2))
+
+    let result = try exporter.export(input(events: [event]))
+
+    #expect(result.text.contains("#### Phase: eliminate"))
+    #expect(result.text.contains("**Bob** was eliminated (2 votes)"))
+  }
+
+  @Test func rendersScoreUpdateEvent() throws {
+    let exporter = makeExporter()
+    let event = makeCodePhaseEvent(
+      phaseType: "score_calc", seq: 1,
+      payload: .scoreUpdate(scores: ["Alice": 5, "Bob": -1]))
+
+    let result = try exporter.export(input(events: [event]))
+
+    #expect(result.text.contains("#### Phase: score_calc"))
+    #expect(result.text.contains("Alice: 5"))
+    #expect(result.text.contains("Bob: -1"))
+  }
+
+  @Test func rendersSummaryEventVerbatim() throws {
+    let exporter = makeExporter()
+    let event = makeCodePhaseEvent(
+      phaseType: "summarize", seq: 1,
+      payload: .summary(text: "多数派の勝ち！"))
+
+    let result = try exporter.export(input(events: [event]))
+
+    #expect(result.text.contains("#### Phase: summarize"))
+    #expect(result.text.contains("多数派の勝ち！"))
+  }
+
+  @Test func rendersVoteResultsWithTalliesAndVoterMap() throws {
+    let exporter = makeExporter()
+    let event = makeCodePhaseEvent(
+      phaseType: "vote", seq: 1,
+      payload: .voteResults(
+        votes: ["Alice": "Bob", "Bob": "Alice", "Charlie": "Bob"],
+        tallies: ["Alice": 1, "Bob": 2]))
+
+    let result = try exporter.export(input(events: [event]))
+
+    // Tally table
+    #expect(result.text.contains("| Bob | 2 |"))
+    #expect(result.text.contains("| Alice | 1 |"))
+    // Voter → target list
+    #expect(result.text.contains("Alice → Bob"))
+    #expect(result.text.contains("Bob → Alice"))
+    #expect(result.text.contains("Charlie → Bob"))
+  }
+
+  @Test func rendersPairingResultEvent() throws {
+    let exporter = makeExporter()
+    let event = makeCodePhaseEvent(
+      phaseType: "choose", seq: 1,
+      payload: .pairingResult(
+        agent1: "Alice", action1: "cooperate",
+        agent2: "Bob", action2: "betray"))
+
+    let result = try exporter.export(input(events: [event]))
+
+    #expect(result.text.contains("#### Phase: choose"))
+    #expect(result.text.contains("Alice"))
+    #expect(result.text.contains("Bob"))
+    #expect(result.text.contains("cooperate"))
+    #expect(result.text.contains("betray"))
+  }
+
+  @Test func rendersAssignmentEvent() throws {
+    let exporter = makeExporter()
+    let event = makeCodePhaseEvent(
+      phaseType: "assign", seq: 1,
+      payload: .assignment(agent: "Alice", value: "wolf"))
+
+    let result = try exporter.export(input(events: [event]))
+
+    #expect(result.text.contains("#### Phase: assign"))
+    #expect(result.text.contains("**Alice** was assigned: wolf"))
+  }
+
+  // MARK: - Merge-sort ordering
+
+  @Test func mergesTurnsAndEventsBySequenceNumber() throws {
+    let exporter = makeExporter()
+    // Vote phase: 3 agent votes then tallies result.
+    let turn1 = makeTurn(
+      round: 1, seq: 1, phase: "vote",
+      agent: "Alice", fields: ["vote": "Bob"])
+    let turn2 = makeTurn(
+      round: 1, seq: 2, phase: "vote",
+      agent: "Bob", fields: ["vote": "Alice"])
+    let turn3 = makeTurn(
+      round: 1, seq: 3, phase: "vote",
+      agent: "Charlie", fields: ["vote": "Bob"])
+    let tallyEvent = makeCodePhaseEvent(
+      phaseType: "vote", seq: 4,
+      payload: .voteResults(
+        votes: ["Alice": "Bob", "Bob": "Alice", "Charlie": "Bob"],
+        tallies: ["Alice": 1, "Bob": 2]))
+
+    let result = try exporter.export(
+      input(turns: [turn1, turn2, turn3], events: [tallyEvent]))
+
+    // Agent votes must appear before tally line in the output.
+    let aliceIdx = try #require(result.text.range(of: "- **Alice**: → Bob")?.lowerBound)
+    let bobIdx = try #require(result.text.range(of: "- **Bob**: → Alice")?.lowerBound)
+    let charlieIdx = try #require(
+      result.text.range(of: "- **Charlie**: → Bob")?.lowerBound)
+    let tallyIdx = try #require(result.text.range(of: "| Bob | 2 |")?.lowerBound)
+    #expect(aliceIdx < bobIdx)
+    #expect(bobIdx < charlieIdx)
+    #expect(charlieIdx < tallyIdx)
+  }
+
+  // MARK: - Bifurcated Final Scores / Roster Status gating
+
+  @Test func finalScoresRendersWhenScoreUpdatePresent() throws {
+    let exporter = makeExporter()
+    let event = makeCodePhaseEvent(
+      phaseType: "score_calc", seq: 1,
+      payload: .scoreUpdate(scores: ["Alice": 10, "Bob": 3]))
+
+    let result = try exporter.export(
+      input(events: [event], personas: ["Alice", "Bob"]))
+
+    #expect(result.text.contains("## Final Scores"))
+    #expect(result.text.contains("| Alice | 10 | active |"))
+    #expect(result.text.contains("| Bob | 3 | active |"))
+  }
+
+  @Test func finalScoresWithPartialScoresFillsZeroForMissingPersonas() throws {
+    let exporter = makeExporter()
+    let event = makeCodePhaseEvent(
+      phaseType: "score_calc", seq: 1,
+      payload: .scoreUpdate(scores: ["Alice": 5]))
+
+    let result = try exporter.export(
+      input(events: [event], personas: ["Alice", "Bob", "Charlie"]))
+
+    #expect(result.text.contains("## Final Scores"))
+    #expect(result.text.contains("| Alice | 5 | active |"))
+    #expect(result.text.contains("| Bob | 0 | active |"))
+    #expect(result.text.contains("| Charlie | 0 | active |"))
+  }
+
+  @Test func finalScoresReflectsEliminationStatus() throws {
+    let exporter = makeExporter()
+    let scoreEvent = makeCodePhaseEvent(
+      phaseType: "score_calc", seq: 1,
+      payload: .scoreUpdate(scores: ["Alice": 10, "Bob": 3]))
+    let elimEvent = makeCodePhaseEvent(
+      phaseType: "eliminate", seq: 2,
+      payload: .elimination(agent: "Bob", voteCount: 2))
+
+    let result = try exporter.export(
+      input(
+        events: [scoreEvent, elimEvent],
+        personas: ["Alice", "Bob"]))
+
+    #expect(result.text.contains("| Alice | 10 | active |"))
+    #expect(result.text.contains("| Bob | 3 | eliminated |"))
+  }
+
+  @Test func finalScoresRendersWhenAllScoresZero() throws {
+    // A scoring scenario that ran score_calc but produced all zeros (rare but
+    // legitimate) should still render — the presence of a scoreUpdate event
+    // proves scoring happened.
+    let exporter = makeExporter()
+    let event = makeCodePhaseEvent(
+      phaseType: "score_calc", seq: 1,
+      payload: .scoreUpdate(scores: ["Alice": 0, "Bob": 0]))
+
+    let result = try exporter.export(
+      input(events: [event], personas: ["Alice", "Bob"]))
+
+    #expect(result.text.contains("## Final Scores"))
+    #expect(result.text.contains("| Alice | 0 | active |"))
+  }
+
+  @Test func rosterStatusRendersWhenOnlyEliminationPresent() throws {
+    // Word Wolf-style: wordwolf_judge emits summary, eliminate emits elimination,
+    // but no scoreUpdate — show status without a misleading all-zero score table.
+    let exporter = makeExporter()
+    let elim = makeCodePhaseEvent(
+      phaseType: "eliminate", seq: 1,
+      payload: .elimination(agent: "Charlie", voteCount: 3))
+
+    let result = try exporter.export(
+      input(events: [elim], personas: ["Alice", "Bob", "Charlie"]))
+
+    // Roster Status section renders.
+    #expect(result.text.contains("## Roster Status"))
+    // NO misleading all-zero Final Scores.
+    #expect(!result.text.contains("## Final Scores"))
+    #expect(!result.text.contains("| Alice | 0 |"))
+    // Per-agent status present.
+    #expect(result.text.contains("Charlie"))
+    #expect(result.text.contains("eliminated"))
+    #expect(result.text.contains("Alice"))
+    #expect(result.text.contains("active"))
+  }
+
+  @Test func omitsBothSectionsWhenNoScoreOrEliminationEvents() throws {
+    let exporter = makeExporter()
+    // Only a summary event — no scoring, no elimination.
+    let summary = makeCodePhaseEvent(
+      phaseType: "summarize", seq: 1,
+      payload: .summary(text: "ended"))
+
+    let result = try exporter.export(
+      input(events: [summary], personas: ["Alice", "Bob"]))
+
+    #expect(!result.text.contains("## Final Scores"))
+    #expect(!result.text.contains("## Roster Status"))
+  }
+
+  @Test func omitsBothSectionsForObservationOnlyScenario() throws {
+    let exporter = makeExporter()
+    let turn = makeTurn(
+      round: 1, seq: 1, phase: "speak_each",
+      agent: "Alice", fields: ["statement": "hi"])
+
+    let result = try exporter.export(
+      input(turns: [turn], events: [], personas: ["Alice", "Bob"]))
+
+    #expect(!result.text.contains("## Final Scores"))
+    #expect(!result.text.contains("## Roster Status"))
+  }
+}

--- a/Pastura/PasturaTests/App/ResultMarkdownExporterTests.swift
+++ b/Pastura/PasturaTests/App/ResultMarkdownExporterTests.swift
@@ -201,19 +201,38 @@ import Testing
 
   @Test func includesFinalScoresSection() throws {
     let exporter = makeExporter()
+    let scoreEvent = makeCodePhaseEventForFinalScoresFixture(
+      seq: 1, payload: .scoreUpdate(scores: ["Alice": 10, "Bob": 3]))
+    let elimEvent = makeCodePhaseEventForFinalScoresFixture(
+      seq: 2, payload: .elimination(agent: "Bob", voteCount: 2))
     let input = ResultMarkdownExporter.Input(
       simulation: makeSimulation(),
       scenario: makeScenario(),
       turns: [],
-      state: makeState(
-        scores: ["Alice": 10, "Bob": 3],
-        eliminated: ["Bob": true]))
+      codePhaseEvents: [scoreEvent, elimEvent],
+      personas: ["Alice", "Bob"],
+      state: makeState())
 
     let result = try exporter.export(input)
 
     #expect(result.text.contains("## Final Scores"))
     #expect(result.text.contains("| Alice | 10 | active |"))
     #expect(result.text.contains("| Bob | 3 | eliminated |"))
+  }
+
+  private func makeCodePhaseEventForFinalScoresFixture(
+    seq: Int, payload: CodePhaseEventPayload
+  ) -> CodePhaseEventRecord {
+    let json =
+      (try? JSONEncoder().encode(payload)).flatMap {
+        String(data: $0, encoding: .utf8)
+      } ?? "{}"
+    return CodePhaseEventRecord(
+      id: UUID().uuidString, simulationId: "sim1",
+      roundNumber: 2,
+      phaseType: "score_calc",
+      sequenceNumber: seq, payloadJSON: json,
+      createdAt: Date())
   }
 
   @Test func unknownModelAndBackendFallBackToPlaceholder() throws {

--- a/Pastura/PasturaTests/App/ResultMarkdownExporterWordWolfTests.swift
+++ b/Pastura/PasturaTests/App/ResultMarkdownExporterWordWolfTests.swift
@@ -1,0 +1,200 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+/// End-to-end Word Wolf fixture for the Markdown exporter.
+///
+/// Models a realistic Word Wolf round (assign → speak → vote → eliminate →
+/// score_calc/judge verdict → summarize) to defend the four Acceptance
+/// Criteria from #92 in a single integration-style test.
+@Suite @MainActor
+struct ResultMarkdownExporterWordWolfTests {
+
+  private let createdAt = Date(timeIntervalSince1970: 1_712_000_000)
+  private let updatedAt = Date(timeIntervalSince1970: 1_712_000_342)
+  private let exportAt = Date(timeIntervalSince1970: 1_713_000_000)
+
+  private func makeExporter() -> ResultMarkdownExporter {
+    ResultMarkdownExporter(
+      contentFilter: ContentFilter(blockedPatterns: []),
+      environment: .init(deviceModel: "iPhone", osVersion: "Version 17.5"),
+      now: exportAt)
+  }
+
+  private func makeSimulation() -> SimulationRecord {
+    SimulationRecord(
+      id: "sim1", scenarioId: "s1",
+      status: SimulationStatus.completed.rawValue,
+      currentRound: 1, currentPhaseIndex: 0,
+      stateJSON: "{}", configJSON: nil,
+      createdAt: createdAt, updatedAt: updatedAt,
+      modelIdentifier: "test", llmBackend: "mock")
+  }
+
+  private func makeScenario() -> ScenarioRecord {
+    ScenarioRecord(
+      id: "s1", name: "Word Wolf",
+      yamlDefinition: "name: Word Wolf\n",
+      isPreset: true, createdAt: Date(), updatedAt: Date())
+  }
+
+  private func makeState() -> SimulationState {
+    SimulationState(
+      scores: [:], eliminated: [:], conversationLog: [],
+      lastOutputs: [:], voteResults: [:], pairings: [],
+      variables: [:], currentRound: 1)
+  }
+
+  private func makeCodePhaseEvent(
+    round: Int, phaseType: String, seq: Int,
+    payload: CodePhaseEventPayload
+  ) -> CodePhaseEventRecord {
+    let json =
+      (try? JSONEncoder().encode(payload)).flatMap {
+        String(data: $0, encoding: .utf8)
+      } ?? "{}"
+    return CodePhaseEventRecord(
+      id: UUID().uuidString, simulationId: "sim1",
+      roundNumber: round, phaseType: phaseType,
+      sequenceNumber: seq, payloadJSON: json,
+      createdAt: Date())
+  }
+
+  private func makeTurn(
+    round: Int, seq: Int, phase: String,
+    agent: String?, fields: [String: String]
+  ) -> TurnRecord {
+    let json =
+      (try? JSONEncoder().encode(TurnOutput(fields: fields))).flatMap {
+        String(data: $0, encoding: .utf8)
+      } ?? "{}"
+    return TurnRecord(
+      id: UUID().uuidString, simulationId: "sim1",
+      roundNumber: round, phaseType: phase,
+      agentName: agent, rawOutput: json,
+      parsedOutputJSON: json, sequenceNumber: seq,
+      createdAt: Date())
+  }
+
+  // swiftlint:disable:next function_body_length
+  @Test func wordWolfRoundExportSatisfiesAllAcceptanceCriteria() throws {
+    let exporter = makeExporter()
+    let personas = ["Alice", "Bob", "Charlie"]
+
+    var seq = 0
+    func nextSeq() -> Int {
+      seq += 1
+      return seq
+    }
+
+    // assign phase: each persona gets a role.
+    let assignAlice = makeCodePhaseEvent(
+      round: 1, phaseType: "assign", seq: nextSeq(),
+      payload: .assignment(agent: "Alice", value: "wolf"))
+    let assignBob = makeCodePhaseEvent(
+      round: 1, phaseType: "assign", seq: nextSeq(),
+      payload: .assignment(agent: "Bob", value: "villager"))
+    let assignCharlie = makeCodePhaseEvent(
+      round: 1, phaseType: "assign", seq: nextSeq(),
+      payload: .assignment(agent: "Charlie", value: "villager"))
+
+    // speak_all phase: each agent speaks.
+    let speakAlice = makeTurn(
+      round: 1, seq: nextSeq(), phase: "speak_all",
+      agent: "Alice", fields: ["statement": "I think it's a cat."])
+    let speakBob = makeTurn(
+      round: 1, seq: nextSeq(), phase: "speak_all",
+      agent: "Bob", fields: ["statement": "Mine has fluffy fur."])
+    let speakCharlie = makeTurn(
+      round: 1, seq: nextSeq(), phase: "speak_all",
+      agent: "Charlie", fields: ["statement": "Mine purrs a lot."])
+
+    // vote phase: agents vote, then tallies emit.
+    let voteAlice = makeTurn(
+      round: 1, seq: nextSeq(), phase: "vote",
+      agent: "Alice", fields: ["vote": "Charlie"])
+    let voteBob = makeTurn(
+      round: 1, seq: nextSeq(), phase: "vote",
+      agent: "Bob", fields: ["vote": "Alice"])
+    let voteCharlie = makeTurn(
+      round: 1, seq: nextSeq(), phase: "vote",
+      agent: "Charlie", fields: ["vote": "Alice"])
+    let voteResultsEvent = makeCodePhaseEvent(
+      round: 1, phaseType: "vote", seq: nextSeq(),
+      payload: .voteResults(
+        votes: ["Alice": "Charlie", "Bob": "Alice", "Charlie": "Alice"],
+        tallies: ["Alice": 2, "Charlie": 1]))
+
+    // eliminate phase: most-voted agent (Alice — the wolf) is eliminated.
+    let eliminationEvent = makeCodePhaseEvent(
+      round: 1, phaseType: "eliminate", seq: nextSeq(),
+      payload: .elimination(agent: "Alice", voteCount: 2))
+
+    // score_calc phase (wordwolf_judge): emits a summary verdict, no scores.
+    let judgeSummary = makeCodePhaseEvent(
+      round: 1, phaseType: "score_calc", seq: nextSeq(),
+      payload: .summary(text: "多数派の勝ち！ お題は『犬』、ウルフは『猫』"))
+
+    // summarize phase: round wrap-up summary.
+    let roundSummary = makeCodePhaseEvent(
+      round: 1, phaseType: "summarize", seq: nextSeq(),
+      payload: .summary(text: "Round 1 ends. The wolf was discovered."))
+
+    let turns = [speakAlice, speakBob, speakCharlie, voteAlice, voteBob, voteCharlie]
+    let events = [
+      assignAlice, assignBob, assignCharlie,
+      voteResultsEvent, eliminationEvent, judgeSummary, roundSummary
+    ]
+
+    let input = ResultMarkdownExporter.Input(
+      simulation: makeSimulation(),
+      scenario: makeScenario(),
+      turns: turns,
+      codePhaseEvents: events,
+      personas: personas,
+      state: makeState())
+    let result = try exporter.export(input)
+
+    // (i) "X was assigned: wolf" visible.
+    #expect(result.text.contains("**Alice** was assigned: wolf"))
+    #expect(result.text.contains("**Bob** was assigned: villager"))
+
+    // (ii) Both summaries appear under their respective phaseType headers.
+    let scoreCalcRange = try #require(
+      result.text.range(of: "#### Phase: score_calc"))
+    let summarizeRange = try #require(
+      result.text.range(of: "#### Phase: summarize"))
+    let judgeRange = try #require(result.text.range(of: "多数派の勝ち"))
+    let wrapRange = try #require(result.text.range(of: "Round 1 ends"))
+    // Judge verdict falls under score_calc, round wrap under summarize.
+    #expect(scoreCalcRange.upperBound < judgeRange.lowerBound)
+    #expect(judgeRange.upperBound <= summarizeRange.lowerBound)
+    #expect(summarizeRange.upperBound < wrapRange.lowerBound)
+
+    // (iii) Roster Status renders, Alice eliminated, others active.
+    #expect(result.text.contains("## Roster Status"))
+    #expect(result.text.contains("| Alice | eliminated |"))
+    #expect(result.text.contains("| Bob | active |"))
+    #expect(result.text.contains("| Charlie | active |"))
+
+    // (iv) NO misleading all-zero score table (Word Wolf never emits scoreUpdate).
+    #expect(!result.text.contains("## Final Scores"))
+    #expect(!result.text.contains("| Alice | 0 |"))
+    #expect(!result.text.contains("| Bob | 0 |"))
+
+    // (v) Vote phase ordering: agent votes appear before tally line.
+    let aliceVoteRange = try #require(
+      result.text.range(of: "- **Alice**: → Charlie"))
+    let tallyRange = try #require(result.text.range(of: "| Alice | 2 |"))
+    #expect(aliceVoteRange.upperBound < tallyRange.lowerBound)
+
+    // (vi) AC roll-up: each Phase header is present.
+    #expect(result.text.contains("#### Phase: assign"))
+    #expect(result.text.contains("#### Phase: speak_all"))
+    #expect(result.text.contains("#### Phase: vote"))
+    #expect(result.text.contains("#### Phase: eliminate"))
+    #expect(result.text.contains("#### Phase: score_calc"))
+    #expect(result.text.contains("#### Phase: summarize"))
+  }
+}

--- a/Pastura/PasturaTests/App/SimulationViewModelCodePhasePersistenceTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelCodePhasePersistenceTests.swift
@@ -7,10 +7,11 @@ import Testing
 /// plus the shared `sequenceNumber` invariant across turns and code-phase
 /// tables.
 @Suite(.serialized) @MainActor
+// swiftlint:disable:next type_name
 struct SimulationViewModelCodePhasePersistenceTests {
 
   private struct SUT {
-    let vm: SimulationViewModel
+    let model: SimulationViewModel
     let scenario: Scenario
     let turnRepo: GRDBTurnRepository
     let codeRepo: GRDBCodePhaseEventRepository
@@ -38,14 +39,14 @@ struct SimulationViewModelCodePhasePersistenceTests {
         createdAt: Date(), updatedAt: Date()))
 
     let scenario = makeTestScenario(agentNames: ["Alice", "Bob"], rounds: 1)
-    let vm = SimulationViewModel(
+    let model = SimulationViewModel(
       simulationRepository: simRepo,
       turnRepository: turnRepo,
       codePhaseEventRepository: codeRepo)
-    vm.beginPersistenceForTest(simulationId: simId)
+    model.beginPersistenceForTest(simulationId: simId)
 
     return SUT(
-      vm: vm, scenario: scenario,
+      model: model, scenario: scenario,
       turnRepo: turnRepo, codeRepo: codeRepo, simId: simId)
   }
 
@@ -58,20 +59,20 @@ struct SimulationViewModelCodePhasePersistenceTests {
 
   @Test func persistsAllSixCodePhaseEventTypes() async throws {
     let sut = try makeSUT()
-    sut.vm.handleEvent(.roundStarted(round: 1, totalRounds: 1), scenario: sut.scenario)
+    sut.model.handleEvent(.roundStarted(round: 1, totalRounds: 1), scenario: sut.scenario)
 
-    sut.vm.handleEvent(.assignment(agent: "Alice", value: "wolf"), scenario: sut.scenario)
-    sut.vm.handleEvent(.scoreUpdate(scores: ["Alice": 1]), scenario: sut.scenario)
-    sut.vm.handleEvent(.elimination(agent: "Bob", voteCount: 2), scenario: sut.scenario)
-    sut.vm.handleEvent(.summary(text: "round summary"), scenario: sut.scenario)
-    sut.vm.handleEvent(
+    sut.model.handleEvent(.assignment(agent: "Alice", value: "wolf"), scenario: sut.scenario)
+    sut.model.handleEvent(.scoreUpdate(scores: ["Alice": 1]), scenario: sut.scenario)
+    sut.model.handleEvent(.elimination(agent: "Bob", voteCount: 2), scenario: sut.scenario)
+    sut.model.handleEvent(.summary(text: "round summary"), scenario: sut.scenario)
+    sut.model.handleEvent(
       .voteResults(votes: ["Alice": "Bob"], tallies: ["Bob": 1]),
       scenario: sut.scenario)
-    sut.vm.handleEvent(
+    sut.model.handleEvent(
       .pairingResult(agent1: "A", action1: "c", agent2: "B", action2: "d"),
       scenario: sut.scenario)
 
-    await sut.vm.finishPersistenceForTest()
+    await sut.model.finishPersistenceForTest()
 
     let records = try sut.codeRepo.fetchBySimulationId(sut.simId)
     #expect(records.count == 6)
@@ -93,38 +94,38 @@ struct SimulationViewModelCodePhasePersistenceTests {
 
   @Test func interleavedAgentAndCodeEventsHaveStrictlyMonotonicSequence() async throws {
     let sut = try makeSUT()
-    sut.vm.handleEvent(.roundStarted(round: 1, totalRounds: 1), scenario: sut.scenario)
+    sut.model.handleEvent(.roundStarted(round: 1, totalRounds: 1), scenario: sut.scenario)
 
     // Interleave: agent, code, agent, code, agent, code
-    sut.vm.handleEvent(
+    sut.model.handleEvent(
       .agentOutput(
         agent: "Alice",
         output: TurnOutput(fields: ["vote": "Bob"]),
         phaseType: .vote),
       scenario: sut.scenario)
-    sut.vm.handleEvent(
+    sut.model.handleEvent(
       .voteResults(votes: ["Alice": "Bob"], tallies: ["Bob": 1]),
       scenario: sut.scenario)
-    sut.vm.handleEvent(
+    sut.model.handleEvent(
       .agentOutput(
         agent: "Bob",
         output: TurnOutput(fields: ["vote": "Alice"]),
         phaseType: .vote),
       scenario: sut.scenario)
-    sut.vm.handleEvent(
+    sut.model.handleEvent(
       .elimination(agent: "Bob", voteCount: 1),
       scenario: sut.scenario)
-    sut.vm.handleEvent(
+    sut.model.handleEvent(
       .agentOutput(
         agent: "Alice",
         output: TurnOutput(fields: ["statement": "done"]),
         phaseType: .summarize),
       scenario: sut.scenario)
-    sut.vm.handleEvent(
+    sut.model.handleEvent(
       .summary(text: "Alice won"),
       scenario: sut.scenario)
 
-    await sut.vm.finishPersistenceForTest()
+    await sut.model.finishPersistenceForTest()
 
     let turns = try sut.turnRepo.fetchBySimulationId(sut.simId)
     let codeEvents = try sut.codeRepo.fetchBySimulationId(sut.simId)
@@ -143,16 +144,16 @@ struct SimulationViewModelCodePhasePersistenceTests {
   @Test func summaryAtRoundZeroIsNotPersistedButAppearsInLog() async throws {
     let sut = try makeSUT()
     // currentRound is 0 before roundStarted fires.
-    sut.vm.handleEvent(.summary(text: "⚠️ validator warning"), scenario: sut.scenario)
+    sut.model.handleEvent(.summary(text: "⚠️ validator warning"), scenario: sut.scenario)
 
-    await sut.vm.finishPersistenceForTest()
+    await sut.model.finishPersistenceForTest()
 
     let records = try sut.codeRepo.fetchBySimulationId(sut.simId)
     #expect(records.isEmpty)
 
     // But UI log still shows it.
     #expect(
-      sut.vm.logEntries.contains { entry in
+      sut.model.logEntries.contains { entry in
         if case .summary(let text) = entry.kind { return text.contains("validator") }
         return false
       })
@@ -164,9 +165,9 @@ struct SimulationViewModelCodePhasePersistenceTests {
     // to surface the issue in exports.
     let sut = try makeSUT()
 
-    sut.vm.handleEvent(.scoreUpdate(scores: ["Alice": 1]), scenario: sut.scenario)
+    sut.model.handleEvent(.scoreUpdate(scores: ["Alice": 1]), scenario: sut.scenario)
 
-    await sut.vm.finishPersistenceForTest()
+    await sut.model.finishPersistenceForTest()
 
     let records = try sut.codeRepo.fetchBySimulationId(sut.simId)
     #expect(records.count == 1)

--- a/Pastura/PasturaTests/App/SimulationViewModelCodePhasePersistenceTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelCodePhasePersistenceTests.swift
@@ -1,0 +1,175 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+/// Tests persistence of code-phase events to `code_phase_events` table,
+/// plus the shared `sequenceNumber` invariant across turns and code-phase
+/// tables.
+@Suite(.serialized) @MainActor
+struct SimulationViewModelCodePhasePersistenceTests {
+
+  private struct SUT {
+    let vm: SimulationViewModel
+    let scenario: Scenario
+    let turnRepo: GRDBTurnRepository
+    let codeRepo: GRDBCodePhaseEventRepository
+    let simId: String
+  }
+
+  private func makeSUT() throws -> SUT {
+    let db = try DatabaseManager.inMemory()
+    let simRepo = GRDBSimulationRepository(dbWriter: db.dbWriter)
+    let turnRepo = GRDBTurnRepository(dbWriter: db.dbWriter)
+    let scenarioRepo = GRDBScenarioRepository(dbWriter: db.dbWriter)
+    let codeRepo = GRDBCodePhaseEventRepository(dbWriter: db.dbWriter)
+
+    try scenarioRepo.save(
+      ScenarioRecord(
+        id: "test", name: "Test", yamlDefinition: "",
+        isPreset: false, createdAt: Date(), updatedAt: Date()))
+
+    let simId = "sim1"
+    try simRepo.save(
+      SimulationRecord(
+        id: simId, scenarioId: "test",
+        status: "running", currentRound: 1, currentPhaseIndex: 0,
+        stateJSON: "{}", configJSON: nil,
+        createdAt: Date(), updatedAt: Date()))
+
+    let scenario = makeTestScenario(agentNames: ["Alice", "Bob"], rounds: 1)
+    let vm = SimulationViewModel(
+      simulationRepository: simRepo,
+      turnRepository: turnRepo,
+      codePhaseEventRepository: codeRepo)
+    vm.beginPersistenceForTest(simulationId: simId)
+
+    return SUT(
+      vm: vm, scenario: scenario,
+      turnRepo: turnRepo, codeRepo: codeRepo, simId: simId)
+  }
+
+  private func decodePayload(_ json: String) throws -> CodePhaseEventPayload {
+    let data = Data(json.utf8)
+    return try JSONDecoder().decode(CodePhaseEventPayload.self, from: data)
+  }
+
+  // MARK: - Basic persistence of each code-phase event type
+
+  @Test func persistsAllSixCodePhaseEventTypes() async throws {
+    let sut = try makeSUT()
+    sut.vm.handleEvent(.roundStarted(round: 1, totalRounds: 1), scenario: sut.scenario)
+
+    sut.vm.handleEvent(.assignment(agent: "Alice", value: "wolf"), scenario: sut.scenario)
+    sut.vm.handleEvent(.scoreUpdate(scores: ["Alice": 1]), scenario: sut.scenario)
+    sut.vm.handleEvent(.elimination(agent: "Bob", voteCount: 2), scenario: sut.scenario)
+    sut.vm.handleEvent(.summary(text: "round summary"), scenario: sut.scenario)
+    sut.vm.handleEvent(
+      .voteResults(votes: ["Alice": "Bob"], tallies: ["Bob": 1]),
+      scenario: sut.scenario)
+    sut.vm.handleEvent(
+      .pairingResult(agent1: "A", action1: "c", agent2: "B", action2: "d"),
+      scenario: sut.scenario)
+
+    await sut.vm.finishPersistenceForTest()
+
+    let records = try sut.codeRepo.fetchBySimulationId(sut.simId)
+    #expect(records.count == 6)
+
+    let payloads = try records.map { try decodePayload($0.payloadJSON) }
+    #expect(payloads.contains(.assignment(agent: "Alice", value: "wolf")))
+    #expect(payloads.contains(.scoreUpdate(scores: ["Alice": 1])))
+    #expect(payloads.contains(.elimination(agent: "Bob", voteCount: 2)))
+    #expect(payloads.contains(.summary(text: "round summary")))
+    #expect(
+      payloads.contains(
+        .voteResults(votes: ["Alice": "Bob"], tallies: ["Bob": 1])))
+    #expect(
+      payloads.contains(
+        .pairingResult(agent1: "A", action1: "c", agent2: "B", action2: "d")))
+  }
+
+  // MARK: - Shared sequence number across tables
+
+  @Test func interleavedAgentAndCodeEventsHaveStrictlyMonotonicSequence() async throws {
+    let sut = try makeSUT()
+    sut.vm.handleEvent(.roundStarted(round: 1, totalRounds: 1), scenario: sut.scenario)
+
+    // Interleave: agent, code, agent, code, agent, code
+    sut.vm.handleEvent(
+      .agentOutput(
+        agent: "Alice",
+        output: TurnOutput(fields: ["vote": "Bob"]),
+        phaseType: .vote),
+      scenario: sut.scenario)
+    sut.vm.handleEvent(
+      .voteResults(votes: ["Alice": "Bob"], tallies: ["Bob": 1]),
+      scenario: sut.scenario)
+    sut.vm.handleEvent(
+      .agentOutput(
+        agent: "Bob",
+        output: TurnOutput(fields: ["vote": "Alice"]),
+        phaseType: .vote),
+      scenario: sut.scenario)
+    sut.vm.handleEvent(
+      .elimination(agent: "Bob", voteCount: 1),
+      scenario: sut.scenario)
+    sut.vm.handleEvent(
+      .agentOutput(
+        agent: "Alice",
+        output: TurnOutput(fields: ["statement": "done"]),
+        phaseType: .summarize),
+      scenario: sut.scenario)
+    sut.vm.handleEvent(
+      .summary(text: "Alice won"),
+      scenario: sut.scenario)
+
+    await sut.vm.finishPersistenceForTest()
+
+    let turns = try sut.turnRepo.fetchBySimulationId(sut.simId)
+    let codeEvents = try sut.codeRepo.fetchBySimulationId(sut.simId)
+
+    #expect(turns.count == 3)
+    #expect(codeEvents.count == 3)
+
+    let allSequences =
+      (turns.map(\.sequenceNumber) + codeEvents.map(\.sequenceNumber))
+      .sorted()
+    #expect(allSequences == [1, 2, 3, 4, 5, 6])
+  }
+
+  // MARK: - round == 0 summary skip
+
+  @Test func summaryAtRoundZeroIsNotPersistedButAppearsInLog() async throws {
+    let sut = try makeSUT()
+    // currentRound is 0 before roundStarted fires.
+    sut.vm.handleEvent(.summary(text: "⚠️ validator warning"), scenario: sut.scenario)
+
+    await sut.vm.finishPersistenceForTest()
+
+    let records = try sut.codeRepo.fetchBySimulationId(sut.simId)
+    #expect(records.isEmpty)
+
+    // But UI log still shows it.
+    #expect(
+      sut.vm.logEntries.contains { entry in
+        if case .summary(let text) = entry.kind { return text.contains("validator") }
+        return false
+      })
+  }
+
+  @Test func otherCodePhaseEventsAtRoundZeroArePersisted() async throws {
+    // Only .summary is suppressed at round==0 (validator warning / early-term);
+    // other events would be genuine bugs if they fired pre-round, so persist them
+    // to surface the issue in exports.
+    let sut = try makeSUT()
+
+    sut.vm.handleEvent(.scoreUpdate(scores: ["Alice": 1]), scenario: sut.scenario)
+
+    await sut.vm.finishPersistenceForTest()
+
+    let records = try sut.codeRepo.fetchBySimulationId(sut.simId)
+    #expect(records.count == 1)
+    #expect(records.first?.roundNumber == 0)
+  }
+}

--- a/Pastura/PasturaTests/App/SimulationViewModelCodePhasePersistenceTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelCodePhasePersistenceTests.swift
@@ -159,6 +159,42 @@ struct SimulationViewModelCodePhasePersistenceTests {
       })
   }
 
+  // MARK: - currentPhaseType tracking
+
+  @Test func summaryInheritsActivePhaseTypeNotHardcodedSummarize() async throws {
+    // wordwolf_judge emits .summary INSIDE the score_calc phase; a separate
+    // SummarizeHandler emits .summary inside the summarize phase. Both must
+    // be persisted under the phase that actually emitted them so the exporter
+    // groups them correctly.
+    let sut = try makeSUT()
+    sut.model.handleEvent(.roundStarted(round: 1, totalRounds: 1), scenario: sut.scenario)
+
+    // score_calc phase: judge verdict summary
+    sut.model.handleEvent(
+      .phaseStarted(phaseType: .scoreCalc, phaseIndex: 0), scenario: sut.scenario)
+    sut.model.handleEvent(
+      .summary(text: "多数派の勝ち！"), scenario: sut.scenario)
+    sut.model.handleEvent(
+      .phaseCompleted(phaseType: .scoreCalc, phaseIndex: 0), scenario: sut.scenario)
+
+    // summarize phase: round wrap summary
+    sut.model.handleEvent(
+      .phaseStarted(phaseType: .summarize, phaseIndex: 1), scenario: sut.scenario)
+    sut.model.handleEvent(
+      .summary(text: "Round 1 ends."), scenario: sut.scenario)
+
+    await sut.model.finishPersistenceForTest()
+
+    let records = try sut.codeRepo.fetchBySimulationId(sut.simId)
+    #expect(records.count == 2)
+    let judgeRecord = try #require(
+      records.first { $0.payloadJSON.contains("多数派の勝ち") })
+    let wrapRecord = try #require(
+      records.first { $0.payloadJSON.contains("Round 1 ends") })
+    #expect(judgeRecord.phaseType == "score_calc")
+    #expect(wrapRecord.phaseType == "summarize")
+  }
+
   @Test func otherCodePhaseEventsAtRoundZeroArePersisted() async throws {
     // Only .summary is suppressed at round==0 (validator warning / early-term);
     // other events would be genuine bugs if they fired pre-round, so persist them

--- a/Pastura/PasturaTests/Data/CodePhaseEventRecordTests.swift
+++ b/Pastura/PasturaTests/Data/CodePhaseEventRecordTests.swift
@@ -1,0 +1,126 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Pastura
+
+@Suite struct CodePhaseEventRecordTests {
+  private func makeManagerWithSimulation() throws -> DatabaseManager {
+    let manager = try DatabaseManager.inMemory()
+    let now = Date()
+    try manager.dbWriter.write { db in
+      var scenario = ScenarioRecord(
+        id: "s1", name: "Test", yamlDefinition: "yaml",
+        isPreset: false, createdAt: now, updatedAt: now)
+      try scenario.insert(db)
+
+      var sim = SimulationRecord(
+        id: "sim1", scenarioId: "s1",
+        status: "running", currentRound: 1, currentPhaseIndex: 0,
+        stateJSON: "{}", configJSON: nil,
+        createdAt: now, updatedAt: now)
+      try sim.insert(db)
+    }
+    return manager
+  }
+
+  @Test func insertAndFetchBySimulationId() throws {
+    let manager = try makeManagerWithSimulation()
+    let now = Date()
+    let payloadJSON = String(
+      data: try JSONEncoder().encode(
+        CodePhaseEventPayload.elimination(agent: "Alice", voteCount: 2)),
+      encoding: .utf8)!
+
+    try manager.dbWriter.write { db in
+      var record = CodePhaseEventRecord(
+        id: "c1", simulationId: "sim1",
+        roundNumber: 1, phaseType: "eliminate",
+        sequenceNumber: 5,
+        payloadJSON: payloadJSON,
+        createdAt: now)
+      try record.insert(db)
+    }
+
+    let records = try manager.dbWriter.read { db in
+      try CodePhaseEventRecord
+        .filter(Column("simulationId") == "sim1")
+        .fetchAll(db)
+    }
+
+    #expect(records.count == 1)
+    #expect(records.first?.phaseType == "eliminate")
+    #expect(records.first?.sequenceNumber == 5)
+    #expect(records.first?.payloadJSON == payloadJSON)
+  }
+
+  @Test func fetchBySimulationAndRound() throws {
+    let manager = try makeManagerWithSimulation()
+    let now = Date()
+
+    try manager.dbWriter.write { db in
+      for (i, round) in [1, 1, 2].enumerated() {
+        var record = CodePhaseEventRecord(
+          id: "c\(i)", simulationId: "sim1",
+          roundNumber: round, phaseType: "score_calc",
+          sequenceNumber: i + 1,
+          payloadJSON: #"{"scoreUpdate":{"scores":{"Alice":1}}}"#,
+          createdAt: now)
+        try record.insert(db)
+      }
+    }
+
+    let round1 = try manager.dbWriter.read { db in
+      try CodePhaseEventRecord
+        .filter(Column("simulationId") == "sim1" && Column("roundNumber") == 1)
+        .fetchAll(db)
+    }
+
+    #expect(round1.count == 2)
+  }
+
+  @Test func cascadeDeleteFromSimulation() throws {
+    let manager = try makeManagerWithSimulation()
+    let now = Date()
+
+    try manager.dbWriter.write { db in
+      var record = CodePhaseEventRecord(
+        id: "c1", simulationId: "sim1",
+        roundNumber: 1, phaseType: "eliminate",
+        sequenceNumber: 1,
+        payloadJSON: "{}",
+        createdAt: now)
+      try record.insert(db)
+
+      try db.execute(sql: "DELETE FROM simulations WHERE id = ?", arguments: ["sim1"])
+
+      let count = try CodePhaseEventRecord.fetchCount(db)
+      #expect(count == 0)
+    }
+  }
+
+  @Test func orderingBySequenceNumber() throws {
+    let manager = try makeManagerWithSimulation()
+    let now = Date()
+
+    try manager.dbWriter.write { db in
+      for (id, seq) in [("c3", 3), ("c1", 1), ("c2", 2)] {
+        var record = CodePhaseEventRecord(
+          id: id, simulationId: "sim1",
+          roundNumber: 1, phaseType: "score_calc",
+          sequenceNumber: seq,
+          payloadJSON: "{}", createdAt: now)
+        try record.insert(db)
+      }
+    }
+
+    let sorted = try manager.dbWriter.read { db in
+      try CodePhaseEventRecord
+        .filter(Column("simulationId") == "sim1")
+        .order(Column("sequenceNumber"))
+        .fetchAll(db)
+    }
+
+    #expect(sorted.map { $0.id } == ["c1", "c2", "c3"])
+  }
+}

--- a/Pastura/PasturaTests/Data/CodePhaseEventRepositoryTests.swift
+++ b/Pastura/PasturaTests/Data/CodePhaseEventRepositoryTests.swift
@@ -1,0 +1,110 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+@Suite struct CodePhaseEventRepositoryTests {
+
+  private func makeRepo() throws -> GRDBCodePhaseEventRepository {
+    let manager = try DatabaseManager.inMemory()
+    let scenarioRepo = GRDBScenarioRepository(dbWriter: manager.dbWriter)
+    let simRepo = GRDBSimulationRepository(dbWriter: manager.dbWriter)
+
+    try scenarioRepo.save(
+      ScenarioRecord(
+        id: "s1", name: "Test", yamlDefinition: "yaml",
+        isPreset: false, createdAt: Date(), updatedAt: Date()))
+    try simRepo.save(
+      SimulationRecord(
+        id: "sim1", scenarioId: "s1",
+        status: "running", currentRound: 1, currentPhaseIndex: 0,
+        stateJSON: "{}", configJSON: nil,
+        createdAt: Date(), updatedAt: Date()))
+
+    return GRDBCodePhaseEventRepository(dbWriter: manager.dbWriter)
+  }
+
+  private func makeRecord(
+    id: String = "c1",
+    simulationId: String = "sim1",
+    roundNumber: Int = 1,
+    phaseType: String = "eliminate",
+    sequenceNumber: Int = 1,
+    createdAt: Date = Date()
+  ) -> CodePhaseEventRecord {
+    CodePhaseEventRecord(
+      id: id, simulationId: simulationId,
+      roundNumber: roundNumber, phaseType: phaseType,
+      sequenceNumber: sequenceNumber,
+      payloadJSON: #"{"summary":{"text":"hi"}}"#,
+      createdAt: createdAt)
+  }
+
+  @Test func saveAndFetchBySimulationId() throws {
+    let repo = try makeRepo()
+    try repo.save(makeRecord(id: "c1"))
+    try repo.save(makeRecord(id: "c2", sequenceNumber: 2))
+
+    let records = try repo.fetchBySimulationId("sim1")
+    #expect(records.count == 2)
+  }
+
+  @Test func fetchBySimulationIdReturnsOrderedBySequenceNumber() throws {
+    let repo = try makeRepo()
+    // Insert out of order to prove ordering is by sequenceNumber.
+    try repo.save(makeRecord(id: "c3", sequenceNumber: 3))
+    try repo.save(makeRecord(id: "c1", sequenceNumber: 1))
+    try repo.save(makeRecord(id: "c2", sequenceNumber: 2))
+
+    let records = try repo.fetchBySimulationId("sim1")
+    #expect(records.map(\.id) == ["c1", "c2", "c3"])
+  }
+
+  @Test func fetchBySimulationIdReturnsEmptyForMissing() throws {
+    let repo = try makeRepo()
+    let records = try repo.fetchBySimulationId("nonexistent")
+    #expect(records.isEmpty)
+  }
+
+  @Test func saveBatchInsertsMultipleRecords() throws {
+    let repo = try makeRepo()
+    let records = (1...4).map { i in
+      makeRecord(id: "c\(i)", sequenceNumber: i)
+    }
+
+    try repo.saveBatch(records)
+
+    let fetched = try repo.fetchBySimulationId("sim1")
+    #expect(fetched.count == 4)
+  }
+
+  @Test func fetchBySimulationAndRound() throws {
+    let repo = try makeRepo()
+    try repo.save(makeRecord(id: "c1", roundNumber: 1, sequenceNumber: 1))
+    try repo.save(makeRecord(id: "c2", roundNumber: 1, sequenceNumber: 2))
+    try repo.save(makeRecord(id: "c3", roundNumber: 2, sequenceNumber: 3))
+
+    let round1 = try repo.fetchBySimulationAndRound("sim1", round: 1)
+    #expect(round1.count == 2)
+
+    let round2 = try repo.fetchBySimulationAndRound("sim1", round: 2)
+    #expect(round2.count == 1)
+
+    let round3 = try repo.fetchBySimulationAndRound("sim1", round: 3)
+    #expect(round3.isEmpty)
+  }
+
+  @Test func deleteBySimulationIdRemovesAllRecords() throws {
+    let repo = try makeRepo()
+    try repo.saveBatch([
+      makeRecord(id: "c1", sequenceNumber: 1),
+      makeRecord(id: "c2", sequenceNumber: 2),
+      makeRecord(id: "c3", sequenceNumber: 3)
+    ])
+
+    try repo.deleteBySimulationId("sim1")
+
+    let records = try repo.fetchBySimulationId("sim1")
+    #expect(records.isEmpty)
+  }
+}

--- a/Pastura/PasturaTests/Models/CodePhaseEventPayloadTests.swift
+++ b/Pastura/PasturaTests/Models/CodePhaseEventPayloadTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+struct CodePhaseEventPayloadTests {
+  private func roundTrip(_ payload: CodePhaseEventPayload) throws -> CodePhaseEventPayload {
+    let data = try JSONEncoder().encode(payload)
+    return try JSONDecoder().decode(CodePhaseEventPayload.self, from: data)
+  }
+
+  @Test func eliminationRoundTrip() throws {
+    let original = CodePhaseEventPayload.elimination(agent: "Alice", voteCount: 3)
+    #expect(try roundTrip(original) == original)
+  }
+
+  @Test func scoreUpdateRoundTrip() throws {
+    let original = CodePhaseEventPayload.scoreUpdate(scores: [
+      "Alice": 2, "Bob": -1, "Charlie": 0
+    ])
+    #expect(try roundTrip(original) == original)
+  }
+
+  @Test func summaryRoundTrip() throws {
+    let original = CodePhaseEventPayload.summary(text: "Round 1 ended. お疲れさま。")
+    #expect(try roundTrip(original) == original)
+  }
+
+  @Test func voteResultsRoundTrip() throws {
+    let original = CodePhaseEventPayload.voteResults(
+      votes: ["Alice": "Bob", "Bob": "Alice", "Charlie": "Bob"],
+      tallies: ["Alice": 1, "Bob": 2]
+    )
+    #expect(try roundTrip(original) == original)
+  }
+
+  @Test func pairingResultRoundTrip() throws {
+    let original = CodePhaseEventPayload.pairingResult(
+      agent1: "Alice", action1: "cooperate",
+      agent2: "Bob", action2: "betray"
+    )
+    #expect(try roundTrip(original) == original)
+  }
+
+  @Test func assignmentRoundTrip() throws {
+    let original = CodePhaseEventPayload.assignment(agent: "Alice", value: "wolf")
+    #expect(try roundTrip(original) == original)
+  }
+
+  @Test func differentCasesAreNotEqual() {
+    let a = CodePhaseEventPayload.summary(text: "hello")
+    let b = CodePhaseEventPayload.elimination(agent: "hello", voteCount: 1)
+    #expect(a != b)
+  }
+}

--- a/Pastura/PasturaTests/Models/CodePhaseEventPayloadTests.swift
+++ b/Pastura/PasturaTests/Models/CodePhaseEventPayloadTests.swift
@@ -48,8 +48,8 @@ struct CodePhaseEventPayloadTests {
   }
 
   @Test func differentCasesAreNotEqual() {
-    let a = CodePhaseEventPayload.summary(text: "hello")
-    let b = CodePhaseEventPayload.elimination(agent: "hello", voteCount: 1)
-    #expect(a != b)
+    let lhs = CodePhaseEventPayload.summary(text: "hello")
+    let rhs = CodePhaseEventPayload.elimination(agent: "hello", voteCount: 1)
+    #expect(lhs != rhs)
   }
 }


### PR DESCRIPTION
## Summary
- Persist code-phase events (elimination / scoreUpdate / summary / voteResults / pairingResult / assignment) to a new `code_phase_events` table (v5 migration) so exports can reconstruct round-by-round narratives that the LLM-output-only `turns` table couldn't capture.
- Merge turns + code-phase events by `sequenceNumber` in the exporter; render each event with phase-aware formatting (e.g., `**X** was eliminated`, vote tallies + voter→target list, verbatim summary text).
- Bifurcate the final summary section: scoreUpdate present → Final Scores table (events authoritative, persona roster from `ScenarioLoader`); only elimination → Roster Status (no misleading all-zero scores for Word Wolf); neither → omit.

## Test plan
- [x] `PasturaTests/CodePhaseEventPayloadTests` — 6-case Codable round trip
- [x] `PasturaTests/CodePhaseEventRecordTests` — CRUD, sequenceNumber ordering, FK cascade
- [x] `PasturaTests/CodePhaseEventRepositoryTests` — repository operations
- [x] `PasturaTests/SimulationViewModelCodePhasePersistenceTests` — interleaved monotonicity, round==0 `.summary` skip, phaseType tracking (judge verdict under score_calc vs round wrap under summarize)
- [x] `PasturaTests/ResultMarkdownExporterCodePhaseTests` — per-payload renderers, bifurcated gating, partial scoreUpdate fills missing personas with 0
- [x] `PasturaTests/ResultMarkdownExporterWordWolfTests` — full Word Wolf round E2E
- [x] Full test suite passes; SwiftLint clean
- [x] On-device verification with Word Wolf / Prisoners Dilemma / Asch scenarios

## Follow-up
Pre-existing bugs surfaced by the richer export (out of scope for this PR):
- #100 — Word Wolf preset assigns empty word (`target: all` should be `target: random_one`)
- #101 — `SummarizeHandler` leaves `{scoreboard}` / `{vote_results}` unresolved in templates

Planned enhancements:
- #102 — Display code-phase events in `ResultDetailView` (keeps the in-app past-results view agent-only today; export is the source of truth for now)
- #104 — Continuously persist `SimulationState` for pause/resume (includes `turnSequence` re-init on resume)

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)