### PR TITLE
🐛 fix: word_wolf preset uses random_one for dict word source

### DIFF
--- a/Pastura/Pastura/Resources/Presets/word_wolf.yaml
+++ b/Pastura/Pastura/Resources/Presets/word_wolf.yaml
@@ -46,7 +46,7 @@ personas:
 phases:
   - type: assign
     source: words
-    target: all
+    target: random_one
 
   - type: speak_each
     prompt: >

--- a/Pastura/PasturaTests/App/PresetLoaderTests.swift
+++ b/Pastura/PasturaTests/App/PresetLoaderTests.swift
@@ -63,6 +63,36 @@ struct PresetLoaderTests {
     }
   }
 
+  /// Regression test for the word_wolf bug: an `assign` phase whose `source`
+  /// resolves to `.arrayOfDictionaries` in `scenario.extraData` MUST use
+  /// `target: "random_one"`. Using `target: "all"` produces empty assignments
+  /// because the handler expects a flat array when distributing to all agents.
+  @Test func assignPhaseWithDictSourceMustUseRandomOneTarget() throws {
+    let loader = ScenarioLoader()
+    let bundle = Bundle(for: DatabaseManager.self)
+
+    for fileName in PresetLoader.presetFileNames {
+      guard let url = bundle.url(forResource: fileName, withExtension: "yaml") else {
+        continue  // Missing file is caught by presetYAMLsAreParseable
+      }
+      let yaml = try String(contentsOf: url, encoding: .utf8)
+      let scenario = try loader.load(yaml: yaml)
+
+      for (index, phase) in scenario.phases.enumerated() {
+        guard phase.type == .assign, let sourceKey = phase.source else {
+          continue
+        }
+        let extraValue = scenario.extraData[sourceKey]
+        if case .arrayOfDictionaries = extraValue {
+          #expect(
+            phase.target == "random_one",
+            "\(fileName).yaml phase[\(index)]: assign with arrayOfDictionaries source '\(sourceKey)' must use target 'random_one', got '\(phase.target ?? "nil")'"
+          )
+        }
+      }
+    }
+  }
+
   @Test func presetYAMLsAreParseable() throws {
     let loader = ScenarioLoader()
     let bundle = Bundle(for: DatabaseManager.self)


### PR DESCRIPTION
## Summary
- Word Wolf's `assign` phase used `target: all` with a `{majority, minority}` dict source. `AssignHandler.assignAll` doesn't handle `.arrayOfDictionaries` and fell through to `item = \"\"`, so every agent received an empty string — no wolf, no topic differentiation.
- One-line YAML fix: `target: all` → `target: random_one`. The `assignRandomOne` path already correctly handles the dict source.
- Added an invariant-framed regression test that iterates all bundled presets: if an `assign` phase's source resolves to `.arrayOfDictionaries`, `target` must be `random_one`. Catches this class of bug for any future preset.

## Test plan
- [x] `xcodebuild test -scheme Pastura` — full suite green
- [x] `swiftlint lint --strict` — clean
- [x] New test `assignPhaseWithDictSourceMustUseRandomOneTarget` fails on pre-fix YAML (`target: all`) and passes after fix
- [x] Manual: run Word Wolf on simulator, confirm export shows `**X** was assigned: りんご` / `みかん` and conversations reference the concrete words

## Notes
- TestFlight migration not needed (single TestFlight user today — known and accepted).
- Follow-up: defensive guard in `AssignHandler.assignAll` that rejects `arrayOfDictionaries` with a diagnostic. Deferred here per CLAUDE.md scope rule; will be filed as a separate issue, useful before #83 (Visual Scenario Editor) lets users author YAML.

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)