### PR TITLE
📝 docs: ADR-004 multiplatform strategy (draft) + Phase 2 status refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,5 +197,7 @@ Record architectural decisions in `docs/decisions/` as `ADR-NNN.md`.
 | `docs/ROADMAP.md`                     | Phase scope, Go/No-Go criteria              |
 | `docs/decisions/ADR-001.md`           | Phase 1 architecture decisions (12 ADRs)    |
 | `docs/decisions/ADR-002.md`           | llama.cpp interim LLM backend decision      |
+| `docs/decisions/ADR-003.md`           | BG execution (iOS 26 BGContinuedProcessingTask) |
+| `docs/decisions/ADR-004.md`           | Multi-platform strategy (Draft)             |
 | `docs/specs/pastura-mvp-spec-v0_3.md` | MVP specification                                         |
 | `docs/prototype/among_them_prototype.py` | Python prototype (reference implementation) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,9 @@ If a requested feature is listed under Phase 3, do not implement it — referenc
 Completed in Phase 2 so far:
 - **Visual Scenario Editor** — dual-mode form + YAML (#83)
 - **Background execution** — iOS 26 BGContinuedProcessingTask + CPU inference (#84)
+- **Share Board** — read-only curated scenario gallery (#87/#93)
+- **Simulation result export** — Markdown via Share Sheet, incl. code-phase results (#91/#98)
+- **Inference speed display** — tok/s + simulation playback UX (#99)
 
 ## Language Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ Completed in Phase 2 so far:
 - **Share Board** — read-only curated scenario gallery (#87/#93)
 - **Simulation result export** — Markdown via Share Sheet, incl. code-phase results (#91/#98)
 - **Inference speed display** — tok/s + simulation playback UX (#99)
+- **Past results — code-phase events** — score_calc / scenario gen events in past-results viewer (#102/#113)
 
 ## Language Rules
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -91,6 +91,7 @@ creation observed. Decision: ship to App Store to gauge wider public reaction.
 | Custom score_calc logic                  | Medium   | Planned     | User-defined scoring expressions         |
 | Scenario sharing (Share Board)           | Medium   | Done (read-only) | Read-only curated gallery shipped (#87/#93). User submissions / ratings deferred to Phase 3 marketplace. |
 | Simulation result export (Markdown)      | Medium   | Done        | Share Sheet export including code-phase results (#91/#98) |
+| Past results — code-phase event display  | Medium   | Done        | Score_calc / scenario gen events shown in past-results viewer (#102/#113) |
 | E4B model switching                      | Low      | Planned     | Higher quality option for 12GB+ devices  |
 | Inference speed display                  | Low      | Done        | tok/s display + simulation playback UX (#99) |
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Pastura — Product Roadmap
 
-> Last updated: 2026-04-14
+> Last updated: 2026-04-17
 > This document defines phase boundaries and scope. When in doubt whether a feature
 > belongs in the current phase, check here first.
 
@@ -89,9 +89,10 @@ creation observed. Decision: ship to App Store to gauge wider public reaction.
 | `event_inject` phase type                | Medium   | Planned     | Random event injection mid-simulation    |
 | `reflect` phase type                     | Medium   | Planned     | Agent self-reflection / memory compaction|
 | Custom score_calc logic                  | Medium   | Planned     | User-defined scoring expressions         |
-| Scenario sharing (Share Board)           | Medium   | In progress | Read-only curated gallery (#87). User submissions / ratings / share sheet deferred to Phase 3 marketplace. |
+| Scenario sharing (Share Board)           | Medium   | Done (read-only) | Read-only curated gallery shipped (#87/#93). User submissions / ratings deferred to Phase 3 marketplace. |
+| Simulation result export (Markdown)      | Medium   | Done        | Share Sheet export including code-phase results (#91/#98) |
 | E4B model switching                      | Low      | Planned     | Higher quality option for 12GB+ devices  |
-| Inference speed display                  | Low      | Planned     | tok/s, time per inference in UI          |
+| Inference speed display                  | Low      | Done        | tok/s display + simulation playback UX (#99) |
 
 ### Technical Debt to Address
 - Evaluate SPM module split (if file count > 100)
@@ -115,8 +116,8 @@ creation observed. Decision: ship to App Store to gauge wider public reaction.
 | Scenario rankings / popular templates| Trending, most-run, highest-rated          |
 | Simulation result auto-summary       | LLM-generated summary of what happened     |
 | Relationship graph visualization     | Agent interaction network diagram          |
-| Android support                      | Kotlin + LiteRT-LM Android SDK            |
-| PC companion app                     | Python CLI or Tauri/Electron GUI           |
+| Android support                      | Direction under evaluation — see [ADR-004 (Draft)](decisions/ADR-004.md). Current lean: KMP-shared Engine + native Jetpack Compose UI + LiteRT-LM Kotlin SDK. |
+| PC companion app                     | Form factor decided at Phase 3.2 — KMP-shared Engine + Compose Desktop is the current lean (see ADR-004). |
 | Localization (English)               | Expand beyond Japanese-speaking users      |
 
 ---
@@ -126,9 +127,10 @@ creation observed. Decision: ship to App Store to gauge wider public reaction.
 ```
 Phase 1: iOS only (Swift + SwiftUI)
 Phase 2: iOS + background execution (iOS 26)
-Phase 3: iOS + Android (Kotlin, LiteRT-LM Android SDK)
-         PC via Python CLI (already exists as prototype)
-Future:  KMP shared Engine, platform-specific UI and LLM layers
+Phase 3: iOS + Android + Desktop via KMP shared Engine (direction under evaluation)
+         See ADR-004 (Draft) — platform-specific UI (SwiftUI / Compose / Compose Desktop)
+         and platform-specific LLM actuals (llama.cpp → LiteRT-LM Swift; LiteRT-LM Kotlin)
+         Final decision at Phase 2 → Phase 3 transition.
 ```
 
 ## Scope Decision Quick Reference

--- a/docs/decisions/ADR-004.md
+++ b/docs/decisions/ADR-004.md
@@ -1,0 +1,345 @@
+# ADR-004: Multi-platform Strategy — Android / Desktop Expansion
+
+> **Status:** Draft
+> **Date:** 2026-04-17
+> **Context:** Phase 3 — Android + PC (Windows/macOS) expansion is planned.
+> The current ROADMAP assumes native-per-platform (Kotlin Android + Python/Tauri PC).
+> A question was raised on whether a cross-platform framework should replace that path.
+
+> **Note on finality:** This ADR is intentionally kept in **Draft** until Phase 2
+> finishes and the Go/No-Go evaluation for Phase 3 is made. See §8 for the
+> gating criteria. The purpose of keeping this document in the repo now is to
+> surface the trade-offs and recommended direction *before* implementation work
+> on any multi-platform scaffolding starts.
+
+---
+
+## 1. Context
+
+### 1.1 Current state
+
+- Phase 1 MVP shipped via TestFlight (2026-04-13, Conditional Go). iOS only, Swift + SwiftUI.
+- Phase 2 in progress. On-device LLM runs via llama.cpp (ADR-002); LiteRT-LM Swift SDK is the
+  announced migration target but not yet shipped by Google as of 2026-04.
+- Engine/Models/LLM/Data layers are already designed for portability:
+  strict dependency rules (CLAUDE.md), `nonisolated` actor isolation,
+  `LLMService` protocol abstraction (ADR-001 §7), no iOS-specific imports below
+  the App/Views layer.
+- Views/App layer has significant SwiftUI investment: `AppRouter` navigation pattern,
+  sheet-owned NavigationStack conventions (`.claude/rules/navigation.md`),
+  `SimulationView` real-time log rendering, `ScenarioEditorView` dual-mode form,
+  Share Board gallery, Markdown export via Share Sheet.
+
+### 1.2 Current ROADMAP assumption
+
+`docs/ROADMAP.md` Phase 3 lists:
+
+- Android support → Kotlin + LiteRT-LM Android SDK (native)
+- PC companion app → Python CLI or Tauri/Electron GUI
+
+with a footnote under *Platform Expansion Strategy*:
+> Future: KMP shared Engine, platform-specific UI and LLM layers.
+
+The footnote already hints at KMP-for-logic, native-per-platform-UI as the long-term
+direction. This ADR formalises that direction and rejects the alternative of full-UI
+unification.
+
+### 1.3 Why decide now vs defer
+
+Decision is **formally deferred to Phase 2 completion** (§8), but the analysis is
+committed now because:
+
+- A proposal to skip "Kotlin-native Android" in Phase 3 and go directly to
+  "KMP + Compose Multiplatform" was raised.
+- Evaluating the proposal requires surfacing the constraints early so that Phase 2
+  work (LLM streaming protocol, BG execution contract) does not paint us into a corner.
+- The critic review of the proposal (2026-04-17) flagged four Critical issues —
+  captured here so future decisions have the argument trail.
+
+---
+
+## 2. Options Considered
+
+### Option A — KMP shared Engine, native UI per platform (recommended direction)
+
+```
+commonMain (Kotlin)     Engine / Models / LLMService interface
+   │
+   ├── iosMain           Swift ↔ Kotlin bridge (SKIE), LlamaCppService
+   │                     Views: SwiftUI (unchanged from Phase 1/2)
+   │
+   ├── androidMain       LiteRT-LM Kotlin SDK or Llamatik-wrapped llama.cpp
+   │                     Views: Jetpack Compose (native)
+   │
+   └── desktopMain       LiteRT-LM JVM / Llamatik on Desktop
+                         Views: Compose Desktop (or native per-OS if needed)
+```
+
+- iOS side: no rewrite. SwiftUI views consume Kotlin via SKIE
+  (`Flow<SimulationEvent>` → `AsyncSequence`, `suspend fun` → `async/await`,
+  `sealed class` → exhaustive `switch`).
+- Android side: fresh Jetpack Compose app reading the same Engine.
+- Desktop side: Compose Desktop reading the same Engine. No Python CLI.
+- LLM is `expect`/`actual`: iOS keeps the Swift LlamaCppService (and swaps to
+  LiteRT-LM Swift SDK when it ships — aligned with ADR-002 §8); Android uses
+  LiteRT-LM Kotlin SDK directly.
+
+### Option B — KMP + Compose Multiplatform (UI unified across iOS/Android/Desktop)
+
+```
+commonMain (Kotlin)     Engine / Models / LLMService interface
+                         Compose Multiplatform Views (shared)
+   │
+   ├── iosMain           Llamatik (llama.cpp KMP wrapper) or bridge to Swift SDK
+   ├── androidMain       LiteRT-LM Kotlin SDK
+   └── desktopMain       LiteRT-LM JVM
+```
+
+- Single UI codebase. iOS SwiftUI views are rewritten in Compose.
+- Compose Multiplatform for iOS reached Stable in 2025-05 (v1.8.0), proven in
+  Netflix / Cash App / McDonald's at least for UI portions.
+
+### Option C — Native-per-platform (current ROADMAP)
+
+- iOS: Swift + SwiftUI (unchanged).
+- Android: Kotlin + Jetpack Compose, with Engine logic re-implemented in Kotlin.
+- PC: Python CLI, later Tauri/Electron GUI.
+- No code sharing between platforms above the YAML scenario format.
+
+---
+
+## 3. Analysis
+
+### 3.1 Code share surface
+
+| Layer       | Option A                 | Option B                 | Option C        |
+|-------------|--------------------------|--------------------------|-----------------|
+| Engine      | Shared (KMP commonMain)  | Shared (KMP commonMain)  | Duplicated      |
+| Models      | Shared                   | Shared                   | Duplicated      |
+| LLMService  | expect/actual            | expect/actual            | Per-platform    |
+| Views       | Per-platform (native)    | Shared (Compose MP)      | Per-platform    |
+| Navigation  | Per-platform             | Shared (Compose Navigation) | Per-platform |
+
+### 3.2 iOS investment preservation
+
+| Concern                                          | A    | B    | C    |
+|--------------------------------------------------|------|------|------|
+| Existing SwiftUI views (18 files)                | Keep | Rewrite | Keep |
+| `AppRouter` pattern (`.claude/rules/navigation.md`) | Keep | Re-derive for Compose Nav | Keep |
+| `fileImporter` / ShareLink / sheet detents       | Keep | Re-bridge / reimplement   | Keep |
+| ADR-002 Metal-buffer invalidation handling       | Keep (Swift) | Needs Compose MP PoC | Keep |
+| ADR-003 Suspend/Resume contract (iOS-specific)   | Keep (Swift, calls shared Engine) | Must re-express in Kotlin/Compose | Keep |
+
+Option B requires verifying Compose Multiplatform for iOS on *Pastura-specific*
+workloads — multi-minute on-device LLM inference, iOS 26 `BGContinuedProcessingTask`,
+Metal context lifecycle, `thermalState` monitoring — before committing. Netflix/Cash App
+references cover UI portions, not long-running on-device inference.
+
+### 3.3 Android parity
+
+| Concern                                  | A                      | B                     | C                      |
+|------------------------------------------|------------------------|-----------------------|------------------------|
+| Android LLM backend                      | LiteRT-LM Kotlin (stable)| Same                  | LiteRT-LM Kotlin       |
+| UX matches platform conventions          | Native Compose         | Compose MP (can look iOS-like or Material) | Native Compose |
+| Engine behaviour consistent with iOS     | ✅ same binary          | ✅ same binary         | ❌ separate impl, drift risk |
+| Time to first Android beta               | Shorter (reuse Engine) | Longer (port UI first) | Longest (port everything) |
+
+Option C's Engine duplication is the main reason KMP is worth adopting at all:
+diverging Engine behaviour between iOS and Android is how cross-platform regressions
+ship. Option A eliminates that without forcing UI unification.
+
+### 3.4 LLM migration path (ADR-002 §8 continuity)
+
+ADR-002 §8 plans a drop-in swap `LlamaCppService` → `LiteRTLMService` (Swift) once the
+LiteRT-LM Swift SDK ships with iOS GPU support.
+
+- Option A: unchanged. `LLMService` is already a protocol; the Swift `actual` on
+  iOS still gets replaced exactly as ADR-002 describes.
+- Option B: the LLM layer moves to KMP. The ADR-002 migration target becomes
+  "Kotlin calling Swift SDK via expect/actual" — novel, under-documented, and
+  introduces a second unknown on top of "Swift SDK ships".
+- Option C: same as A for iOS; Android is separate.
+
+Option A aligns strictly with ADR-002's migration plan. Option B requires amending
+ADR-002.
+
+### 3.5 Risk of getting locked in
+
+| Scenario                              | A impact                | B impact                |
+|---------------------------------------|-------------------------|-------------------------|
+| SKIE becomes unmaintained             | Swap for manual Swift interop (annoying but contained to the iOS bridge) | Same + UI still Compose MP |
+| Compose MP iOS regresses on iOS N+1   | No impact               | Blocks entire iOS build |
+| Android adoption disappoints          | Retreat cheap (Android app stays parked, iOS untouched) | iOS still tied to Compose MP tooling |
+| iOS ships a major SwiftUI feature (e.g. new Live Activity API) | Available immediately via SwiftUI | Wait for Compose MP bridge |
+
+Option A has a smaller blast radius on every adverse scenario.
+
+---
+
+## 4. Decision (tentative — see §8)
+
+**Recommend Option A** (KMP shared Engine, native UI per platform) when Phase 3 begins.
+
+Formally adopt this decision at the Phase 2 → Phase 3 transition, subject to the
+gating criteria in §8. Until then this ADR stays **Draft**.
+
+---
+
+## 5. Consequences
+
+### 5.1 Positive
+
+- Phase 1/2 SwiftUI investment is preserved — ~36 View/App files, `AppRouter` regime,
+  sheet conventions, Share Board UI, Markdown export all survive unchanged.
+- ADR-002 §8 migration plan survives unchanged.
+- ADR-003 iOS Suspend/Resume contract survives unchanged (it is VM-layer and iOS-specific).
+- Android ships faster than Option C because Engine/Models/ScenarioLoader/Phase handlers
+  do not need to be re-implemented in Kotlin.
+- The proposal to "skip native-Kotlin Android to avoid waste" is honoured at the Engine layer
+  (where it is real waste) without forcing it at the UI layer (where it would destroy
+  existing value).
+
+### 5.2 Negative
+
+- Requires Kotlin port of Engine/Models. Estimated surface: Engine phase handlers (~8),
+  ScenarioLoader + validator, JSONResponseParser, TemplateExpander, ScoreCalcHandler.
+  Non-trivial but tractable because these layers already avoid iOS dependencies.
+- Introduces SKIE as a dev-time dependency on the iOS side. SKIE is maintained by
+  Touchlab but has occasional Kotlin-version skew (e.g. 0.10.6 supports Kotlin 2.2.10
+  as of 2026-03).
+- Two UI codebases long-term (SwiftUI + Jetpack Compose). Feature parity maintenance
+  is manual.
+
+### 5.3 Rejected: Option B rationale
+
+Rejected at the Draft stage for four reasons raised in the 2026-04-17 critic review:
+
+1. **ROADMAP premise conflict.** The existing Platform Expansion Strategy footnote
+   explicitly says "platform-specific UI". "Unified UI" is a new premise that has
+   not been justified against the existing design intent.
+2. **Phase ordering violation.** Committing to a full-UI rewrite before Phase 2's
+   Go/No-Go evaluation short-circuits the Go/No-Go gate structure Pastura has used
+   since Phase 1.
+3. **Compose MP × Pastura workload unverified.** Compose MP for iOS Stable proves
+   "it works for typical UI apps". It does not prove coexistence with
+   `BGContinuedProcessingTask`, Metal buffer lifecycle (ADR-002 §7), `thermalState`
+   monitoring, or multi-minute foreground inference. No public Compose MP reference
+   app exercises this combination.
+4. **No forcing function.** Phase 3 begins months from now. Compose MP 1.9/2.0 and
+   the LiteRT-LM Swift SDK will both move before then. Locking in now produces a
+   decision that will likely be reopened.
+
+If all four concerns are resolved between now and the Phase 2 Go/No-Go review,
+Option B can be reconsidered at that gate.
+
+### 5.4 Rejected: Option C rationale
+
+Rejected because Engine duplication between iOS and Android is a drift risk that
+buys nothing. Phase 1/2 Engine code is already factored so that a KMP port is
+strictly cheaper than a rewrite. Option A captures Option C's UI benefits without
+paying Option C's Engine cost.
+
+---
+
+## 6. Migration Plan (tentative)
+
+Assumes Option A is ratified at the Phase 2 Go/No-Go gate.
+
+### Phase 3.0 — Preparation (before any Android work)
+
+1. Introduce a `Shared/` KMP Gradle module in a sibling folder to `Pastura/`.
+   Keep the Xcode project unchanged; the KMP module produces an `.xcframework`
+   consumed by Swift like any other framework.
+2. Port `Models/` first (pure value types, no iOS deps). Swift keeps its copy
+   as an `actual` typealias to the Kotlin types via SKIE, or keeps its own
+   definitions with a Kotlin↔Swift converter — decide based on SKIE ergonomics
+   for the specific types.
+3. Port `Engine/` phase handlers, `ScenarioLoader`, `TemplateExpander`,
+   `JSONResponseParser`, `ScoreCalcHandler` to `commonMain`.
+4. Swift `LlamaCppService` becomes the iOS `actual` for a `commonMain`
+   `expect class LLMService`. No behaviour change.
+
+### Phase 3.1 — Android beta
+
+5. Android Jetpack Compose app consuming the KMP module.
+6. LiteRT-LM Kotlin SDK as the Android `actual` for `LLMService`.
+7. Android-specific UI: Material 3 navigation, no AppRouter port
+   (Compose Navigation is its own idiom).
+8. Release to closed Play Store track for feedback — mirrors the Phase 1
+   TestFlight approach.
+
+### Phase 3.2 — Desktop companion
+
+9. Compose Desktop app consuming the KMP module.
+10. LiteRT-LM JVM as the desktop `actual` for `LLMService`.
+11. Desktop-specific UI adjustments (keyboard-first, no sheet detents).
+
+No iOS changes are required at any of these steps — the iOS app keeps shipping
+from the same main branch.
+
+### Checkpoints that can abort or redirect
+
+- After step 3 (Engine port): if Kotlin expressiveness for the Engine's
+  `AsyncStream<SimulationEvent>` pattern is awkward, reassess.
+- After step 5 (Android beta): if Play Store reception is weak,
+  pause Phase 3.2 and reassess Desktop form factor.
+
+---
+
+## 7. Open Questions
+
+1. **SKIE adoption trade-off.** SKIE dramatically improves Swift ergonomics but
+   couples the iOS build to a specific Kotlin version. Do we accept that tight
+   coupling, or use vanilla Kotlin/Native interop (verbose on the Swift side)?
+2. **Models duplication vs sharing.** `Models/` types are currently Swift
+   `public` with `Sendable`. Sharing via KMP may require re-expressing them as
+   Kotlin data classes; Swift then consumes the generated types. Worth prototyping
+   on a small type (e.g. `SimulationEvent`) before committing.
+3. **Share Board data contract.** If the curated gallery moves to a server
+   (Phase 3 marketplace territory), the server-side contract should be defined
+   in the KMP shared module too.
+4. **Desktop LLM model distribution.** Gemma 4 E2B Q4_K_M is ~3.1 GB. Does the
+   desktop app ship with it bundled, download-on-first-run, or reuse a user's
+   existing Ollama/llama.cpp install? Not answered here — tracked for Phase 3.2.
+
+---
+
+## 8. Gating Criteria for Phase 2 → Phase 3 Transition
+
+This ADR moves from Draft to Accepted when all of the following are true at the
+Phase 2 Go/No-Go review:
+
+- [ ] Phase 2 High Priority items shipped or explicitly descoped
+      (in-app scenario generation, real-time LLM token streaming are the
+      remaining ones as of 2026-04-17).
+- [ ] A 1-day KMP PoC has built a single Engine phase handler in `commonMain`
+      and exercised it from a small iOS harness, to validate that SKIE (or
+      vanilla interop) reaches the ergonomics this ADR assumes.
+- [ ] LiteRT-LM Swift SDK status is re-checked. If Swift SDK has shipped, the
+      iOS-side `actual` can target it directly. If not, llama.cpp stays the
+      iOS `actual` per ADR-002 §8.
+- [ ] No new iOS-only feature landed in Phase 2 that would break the
+      "Engine has no iOS dependencies" invariant.
+
+If any criterion fails, this ADR stays Draft and Phase 3 starts with Engine
+duplication deferred — no commitment to multi-platform beyond what the data
+supports.
+
+---
+
+## 9. References
+
+- [ADR-001 §7](ADR-001.md) — `LLMService` protocol design
+- [ADR-001 §12](ADR-001.md) — Platform strategy section
+- [ADR-002](ADR-002.md) — llama.cpp interim backend; §8 migration plan to LiteRT-LM
+- [ADR-003](ADR-003.md) — BG execution (iOS-specific; unaffected by Option A)
+- [`docs/ROADMAP.md`](../ROADMAP.md) — Phase 3 planned features and Platform
+  Expansion Strategy footnote
+- [`.claude/rules/navigation.md`](../../.claude/rules/navigation.md) — `AppRouter`
+  pattern that Option A preserves and Option B would require replacing
+- [Compose Multiplatform 1.8.0 (iOS Stable) — JetBrains Blog, 2025-05](https://blog.jetbrains.com/kotlin/2025/05/compose-multiplatform-1-8-0-released-compose-multiplatform-for-ios-is-stable-and-production-ready/)
+- [LiteRT-LM Overview — Google AI Edge](https://ai.google.dev/edge/litert-lm/overview)
+- [LiteRT-LM Kotlin README](https://github.com/google-ai-edge/LiteRT-LM/blob/main/kotlin/README.md)
+- [SKIE — Swift Kotlin Interface Enhancer (Touchlab)](https://skie.touchlab.co/)
+- [Llamatik — KMP on-device LLM](https://github.com/ferranpons/llamatik)
+- [Kotlin Multiplatform — SwiftUI interop docs](https://kotlinlang.org/docs/multiplatform/compose-swiftui-integration.html)


### PR DESCRIPTION
## Summary

- **ADR-004 (Draft)** — Captures the Phase 3 multi-platform direction: KMP-shared Engine with platform-native UI (SwiftUI on iOS / Jetpack Compose on Android / Compose Desktop on desktop), rather than full UI unification via Compose Multiplatform. Status stays **Draft** — final adoption gated on the Phase 2 → Phase 3 Go/No-Go review (§8 gating criteria).
- **Phase 2 status refresh** — ROADMAP and CLAUDE.md synced with shipped work that hadn't been reflected: Share Board read-only (#87/#93), Simulation result Markdown export (#91/#98, new row), Inference speed display (#99).
- **Phase 3 pointers** — Android / PC rows and the Platform Expansion Strategy footnote now reference ADR-004 instead of the old native-only description.

## Why Draft (not Accepted)

The proposal to skip native-Kotlin Android in Phase 3 and go directly to KMP + Compose Multiplatform full unification was critic-reviewed on 2026-04-17 and flagged with 4 Critical concerns:

1. ROADMAP premise conflict — existing footnote explicitly says "platform-specific UI"
2. Phase ordering — committing UI rewrite before Phase 2 Go/No-Go gate breaks the decision structure
3. Compose MP × Pastura workload unverified — long-running on-device LLM + `BGContinuedProcessingTask` + Metal buffer lifecycle + `thermalState` has no public reference
4. No forcing function — Phase 3 starts months from now; Compose MP and LiteRT-LM Swift SDK will both move before then

ADR-004 records these as the rejection rationale for Option B, then recommends Option A (KMP Engine + native UI) as the lean for when Phase 3 starts.

## Test plan

- [x] `git diff` review — all hunks intentional
- [x] Relative links in ADR-004 verified (`ADR-001.md`, `ADR-002.md`, `ADR-003.md`, `../ROADMAP.md`, `../../.claude/rules/navigation.md`)
- [x] ROADMAP links to `decisions/ADR-004.md` verified from `docs/ROADMAP.md` location
- [ ] Reviewer check: Phase 2 status table matches reality (no further completed items missed)
- [ ] Reviewer check: ADR-004 §8 gating criteria list is complete / correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)