### PR TITLE
🔧 fix: drop unused Int return from ModelDownloader.download()

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,41 @@ xcodebuild test -scheme Pastura -project Pastura/Pastura.xcodeproj -destination 
 # These tests are automatically skipped when OLLAMA_INTEGRATION is not enabled in the scheme.
 ```
 
+#### Running xcodebuild from an agent session
+
+`xcodebuild test` takes minutes. A few operational guardrails to avoid
+burning wall-clock and orphaning processes:
+
+**Prevention (do this up-front):**
+
+- Narrow scope whenever possible — `-only-testing PasturaTests/<Suite>`.
+- If the change doesn't touch UI code, add `-skip-testing:PasturaUITests`
+  (UI tests are not required for MVP; CI will still cover them).
+- Always pass an explicit bash `timeout` — the default 120s is shorter
+  than even a focused suite. Guideline: `timeout: 180000` (3 min) for a
+  single suite, `timeout: 600000` (10 min) for the full unit suite,
+  `timeout: 900000` (15 min) when UI tests are included.
+- For runs expected to exceed 5 minutes, prefer `run_in_background: true`
+  and poll with Monitor / BashOutput rather than blocking the session.
+
+**Recovery (if a run hangs or a retry immediately stalls):**
+
+- The session's bash timeout kills the shell wrapper, but spawned
+  `xcodebuild` / `testmanagerd` / `XCTRunner` processes can outlive it
+  and keep the simulator destination busy. Subsequent `xcodebuild test`
+  calls then queue behind them and appear to hang.
+- Before killing, **read the full command lines** so you don't clobber a
+  concurrent run from another worktree:
+  `pgrep -af "xcodebuild|XCTRunner|testmanagerd"`.
+- Only if you're sure every listed process belongs to your session:
+  `pkill -f "xcodebuild test"`; then reset the simulator with
+  `xcrun simctl shutdown "$(echo "$DEST" | sed -n 's/.*id=//p')"`.
+- If UI tests fail with
+  `FBSOpenApplicationServiceErrorDomain Code=1 — com.tyabu12.PasturaUITests.xctrunner`,
+  try `xcrun simctl erase <UDID>` + retry **once**. Persistent failures
+  are real bugs (signing, plist, or app-state regression), not flakes —
+  do not swallow them.
+
 ## Directory Structure
 
 ```

--- a/Pastura/Pastura/App/ModelDownloader.swift
+++ b/Pastura/Pastura/App/ModelDownloader.swift
@@ -15,13 +15,12 @@ public protocol ModelDownloader: Sendable {
   ///   - destination: The local file path to write to (caller manages temp naming).
   ///   - progressHandler: Called periodically with (bytesWritten, totalBytes).
   ///     `totalBytes` is -1 if the server did not provide Content-Length.
-  /// - Returns: The HTTP status code (206 for partial, 200 for full).
   func download(
     from url: URL,
     resumeOffset: Int64,
     to destination: URL,
     progressHandler: @Sendable @escaping (Int64, Int64) -> Void
-  ) async throws -> Int
+  ) async throws
 }
 
 /// Production downloader using delegate-based `URLSession` + `URLSessionDownloadTask`.
@@ -44,7 +43,7 @@ final class URLSessionModelDownloader: ModelDownloader, @unchecked Sendable {
     resumeOffset: Int64,
     to destination: URL,
     progressHandler: @Sendable @escaping (Int64, Int64) -> Void
-  ) async throws -> Int {
+  ) async throws {
     var request = URLRequest(url: url)
     if resumeOffset > 0 {
       request.setValue("bytes=\(resumeOffset)-", forHTTPHeaderField: "Range")
@@ -102,8 +101,6 @@ final class URLSessionModelDownloader: ModelDownloader, @unchecked Sendable {
       }
       try? fileManager.removeItem(at: tempURL)
     }
-
-    return statusCode
   }
 }
 

--- a/Pastura/PasturaTests/App/ModelManagerTests.swift
+++ b/Pastura/PasturaTests/App/ModelManagerTests.swift
@@ -8,14 +8,11 @@ import Testing
 
 /// A test double for `ModelDownloader` that returns immediately or throws.
 struct MockModelDownloader: ModelDownloader, Sendable {
-  let result: @Sendable () throws -> Int
+  let result: @Sendable () throws -> Void
   let simulateBytes: Int64
 
-  init(
-    statusCode: Int = 200,
-    simulateBytes: Int64 = 1000
-  ) {
-    self.result = { statusCode }
+  init(simulateBytes: Int64 = 1000) {
+    self.result = {}
     self.simulateBytes = simulateBytes
   }
 
@@ -29,13 +26,12 @@ struct MockModelDownloader: ModelDownloader, Sendable {
     resumeOffset: Int64,
     to destination: URL,
     progressHandler: @Sendable @escaping (Int64, Int64) -> Void
-  ) async throws -> Int {
-    let statusCode = try result()
+  ) async throws {
+    try result()
     // Write dummy bytes to the destination to simulate a completed download
     let data = Data(repeating: 0x42, count: Int(simulateBytes))
     try data.write(to: destination)
     progressHandler(simulateBytes, simulateBytes)
-    return statusCode
   }
 }
 
@@ -98,7 +94,7 @@ struct ModelManagerTests {
   @Test("downloadModel transitions from notDownloaded to ready on success")
   func downloadSuccess() async {
     let sut = makeSUT(
-      downloader: MockModelDownloader(statusCode: 200, simulateBytes: 100)
+      downloader: MockModelDownloader(simulateBytes: 100)
     )
     sut.checkModelStatus()
     #expect(sut.state == .notDownloaded)
@@ -219,7 +215,7 @@ struct ModelManagerTests {
   @Test("downloadModel sets isExcludedFromBackup on completed model file")
   func downloadSetsExcludeFromBackup() async throws {
     let sut = makeSUT(
-      downloader: MockModelDownloader(statusCode: 200, simulateBytes: 100)
+      downloader: MockModelDownloader(simulateBytes: 100)
     )
     sut.checkModelStatus()
     #expect(sut.state == .notDownloaded)
@@ -269,7 +265,7 @@ struct ModelManagerTests {
     // MockModelDownloader writes 1000 bytes of 0x42
     let expectedHash = "9a5670771141349931d69d6eb982faa01def544dc17a161ef83b3277fb7c0c3c"
     let sut = makeSUT(
-      downloader: MockModelDownloader(statusCode: 200, simulateBytes: 1000),
+      downloader: MockModelDownloader(simulateBytes: 1000),
       expectedSHA256: expectedHash
     )
     sut.checkModelStatus()
@@ -292,7 +288,7 @@ struct ModelManagerTests {
   func downloadFailureWithMismatchingSHA256() async {
     let wrongHash = "0000000000000000000000000000000000000000000000000000000000000000"
     let sut = makeSUT(
-      downloader: MockModelDownloader(statusCode: 200, simulateBytes: 1000),
+      downloader: MockModelDownloader(simulateBytes: 1000),
       expectedSHA256: wrongHash
     )
     sut.checkModelStatus()
@@ -317,7 +313,7 @@ struct ModelManagerTests {
   @Test("downloadModel skips SHA256 verification when expectedSHA256 is nil")
   func downloadSuccessWithNilSHA256() async {
     let sut = makeSUT(
-      downloader: MockModelDownloader(statusCode: 200, simulateBytes: 100)
+      downloader: MockModelDownloader(simulateBytes: 100)
     )
     sut.checkModelStatus()
     #expect(sut.state == .notDownloaded)


### PR DESCRIPTION
## Summary
- Change `ModelDownloader.download()` return type from `Int` → `Void`. The HTTP status code was advertised as API output but had zero consumers (prod + tests alike) — only used internally by `URLSessionModelDownloader` to branch between move/append for partial content.
- Also fixes the unused-return warning at `ModelManager.performDownload()` that Issue #69 originally flagged, without resorting to `@discardableResult`.
- Simplifies `MockModelDownloader` by dropping the dead `statusCode` param; updates 5 mock callsites in `ModelManagerTests`.
- **docs:** adds an "agent-session guardrails" subsection to CLAUDE.md's Test Execution — prevention (narrow scope, `-skip-testing:PasturaUITests`, explicit timeouts, background+Monitor) + worktree-safe orphan recovery. Prompted by operational issues hit during this PR's work.

## Rationale
Return value had no future use case in sight, so judged by "are we going to use this?" rather than "how small is the diff?" — `-> Void` is more honest than papering over with `@discardableResult`.

## Test plan
- [x] `xcodebuild test -only-testing PasturaTests/ModelManagerTests` — all pass
- [x] Full unit test suite — 504 tests pass locally
- [x] `swiftlint lint --quiet --strict` clean
- [x] First CI run: only `SimulationRunnerTests/pausesBetweenPhasesNotOnlyBetweenRounds` failed — unrelated to this PR's changes. Known flake tracked in #124 (also flaked on main CI, run 24524943383).

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)