### PR TITLE
🐛 fix: prevent _model/_context leak on double loadModel call (#114)

### DIFF
--- a/Pastura/Pastura/LLM/LlamaCppService.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService.swift
@@ -85,7 +85,23 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
 
   // MARK: - LLMService
 
+  /// Loads the GGUF model with full GPU acceleration.
+  ///
+  /// - Important: Idempotent — if a model is already loaded, it is unloaded
+  ///   before the new load. Prevents a ~3GB buffer leak when concurrent
+  ///   navigation / BG-task lifecycle races re-enter this method (issue #114).
+  ///
+  /// - Note: On double-call, the prior loaded model is freed before the new
+  ///   load is attempted. If the new load fails, the service ends in a clean
+  ///   not-loaded state — callers must not assume a prior successful load
+  ///   survives a subsequent failed `loadModel()`.
+  ///
+  /// - Note: Any attached ``SuspendController`` is preserved across the
+  ///   unload/load cycle via `defer`, matching ``reloadModel(gpuAcceleration:)``.
   public func loadModel() async throws {
+    let preservedController = suspendController
+    defer { suspendController = preservedController }
+    try await unloadModel()
     try await loadModelInternal(gpuAcceleration: .full)
   }
 

--- a/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests.swift
+++ b/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests.swift
@@ -57,6 +57,28 @@ struct LlamaCppIntegrationTests {
     #expect(!service.isModelLoaded)
   }
 
+  // MARK: - Test 1b: loadModel idempotency (issue #114)
+
+  @Test(.timeLimit(.minutes(3)))
+  func loadModelTwiceIsIdempotent() async throws {
+    // Regression test for issue #114: calling loadModel() while already loaded
+    // must free the prior _model/_context, not leak ~3GB of Gemma buffers.
+    // A memory leak is not directly assertable without Instruments, so this
+    // test verifies the happy-path invariants that lock in the defensive
+    // unload: both loads succeed, state stays consistent, and the final
+    // unload completes cleanly (a stale dangling pointer would crash here).
+    let service = makeService()
+
+    try await service.loadModel()
+    #expect(service.isModelLoaded)
+
+    try await service.loadModel()
+    #expect(service.isModelLoaded)
+
+    try await service.unloadModel()
+    #expect(!service.isModelLoaded)
+  }
+
   // MARK: - Test 2: Simple generation
 
   @Test(.timeLimit(.minutes(3)))

--- a/Pastura/PasturaTests/LLM/LlamaCppServiceTests.swift
+++ b/Pastura/PasturaTests/LLM/LlamaCppServiceTests.swift
@@ -119,6 +119,28 @@ struct LlamaCppServiceTests {
     #expect(!service.isModelLoaded)
   }
 
+  // MARK: - loadModel idempotency (issue #114)
+
+  @Test func loadModelTwiceOnInvalidPathPreservesSuspendController() async {
+    // Regression test for issue #114. Calling loadModel() while already loaded
+    // must unload the prior model first to avoid leaking ~3GB of Gemma buffers.
+    // With an invalid path both calls throw, so this test locks in the
+    // observable invariants that hold when the defensive unload path runs:
+    //   - Service ends not-loaded after each failure
+    //   - Attached SuspendController survives the unload/load cycle
+    // The actual leak-prevention path requires a loaded model — see
+    // LlamaCppIntegrationTests.loadModelTwiceIsIdempotent for that coverage.
+    let service = LlamaCppService(modelPath: "/nonexistent.gguf")
+    let controller = SuspendController()
+    await service.attachSuspendController(controller)
+
+    try? await service.loadModel()
+    try? await service.loadModel()
+
+    #expect(!service.isModelLoaded)
+    #expect(service.suspendController === controller)
+  }
+
   @Test func reloadModelUnloadsFirstEvenIfReloadFails() async throws {
     // If reload's inner load fails, the previous model should still be unloaded —
     // the caller gets a clean not-loaded state, not a partial state.


### PR DESCRIPTION
## Summary
- `LlamaCppService.loadModel()` now unloads the prior model before reloading, symmetric with `reloadModel(gpuAcceleration:)`. Prevents a ~3GB Gemma 4 E2B buffer leak when concurrent navigation / BG-task lifecycle races re-enter `loadModel()` while already loaded (issue #114).
- `SuspendController` is preserved across the unload/load cycle via `defer`, mirroring `reloadModel`'s pattern.
- Failure-path semantic change documented on `loadModel()`: if the second load fails, the service ends not-loaded — callers must not assume the prior successful load survives.

## Test plan
- [x] `PasturaTests/LlamaCppServiceTests` — full suite passes, including new `loadModelTwiceOnInvalidPathPreservesSuspendController` locking in state invariants on the defensive path.
- [x] Full `xcodebuild test` passes locally (`** TEST SUCCEEDED **`).
- [x] `swiftlint lint --strict` clean.
- [x] **Manual (required before merge)**: run the new gated integration test with a real Gemma 4 E2B model:
  ```bash
  source scripts/sim-dest.sh
  LLAMACPP_INTEGRATION=1 xcodebuild test -scheme Pastura \
    -project Pastura/Pastura.xcodeproj -destination "$DEST" \
    -only-testing PasturaTests/LlamaCppIntegrationTests/loadModelTwiceIsIdempotent
  ```
  This exercises the real leak path a unit test cannot reach.

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)