### PR TITLE
🐛 fix: vote prompts missing {candidates} allow self-votes (word_wolf, bokete)

### DIFF
--- a/Pastura/Pastura/Resources/Presets/bokete.yaml
+++ b/Pastura/Pastura/Resources/Presets/bokete.yaml
@@ -65,6 +65,7 @@ phases:
       {conversation_log}
 
       自分以外で一番面白いと思うボケに投票してください。
+      投票先は必ず以下の名前のいずれかを正確に書いてください: {candidates}
     output:
       vote: string
       reason: string

--- a/Pastura/Pastura/Resources/Presets/word_wolf.yaml
+++ b/Pastura/Pastura/Resources/Presets/word_wolf.yaml
@@ -70,6 +70,7 @@ phases:
       {conversation_log}
 
       少数派（ウルフ）だと思う人に投票してください。
+      投票先は必ず以下の名前のいずれかを正確に書いてください: {candidates}
     output:
       vote: string
       reason: string


### PR DESCRIPTION
## Summary
- vote phase を持つ全 preset (`word_wolf.yaml`, `bokete.yaml`) の投票プロンプトに `{candidates}` を追加
- 根本原因: VoteHandler は `exclude_self: true` の効果を反映した候補者リストを `variables["candidates"]` に書き込むが、YAML 側で参照していなかったため LLM に届かず自己投票が発生していた (word_wolf で実機再現)
- `prisoners_dilemma.yaml` は vote phase を持たないため対象外 (確認済)
- 文言は `.claude/rules/presets.md` の bokete パターン (line 133) と揃える

## Test plan
- [ ] 実機 (iPhone) で Word Wolf を **3 ラウンド**実行し、投票フェーズで自己投票が 0 件であることを確認
- [ ] 実機で Bokete を 1 ラウンド実行し、投票先が全員他参加者であることを確認 (regression check)
- [ ] 各ラウンドの投票先を記録 (エージェント名 → 投票先)
- [x] 全ユニットテスト (xcodebuild test) 通過
- [x] SwiftLint strict 通過

## Notes
- スコープを word_wolf のみから全 preset の同種バグに拡大 (bokete も実機では自己投票リスクがあった)
- Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)