### PR TITLE
🔧 ci: stream xcodebuild test output live via tee

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,22 +61,28 @@ jobs:
       - name: Test with Coverage
         id: test
         run: |
-          OUTPUT=$(xcodebuild test \
+          # Stream xcodebuild output to the job log via tee so per-test lines
+          # are visible live (command substitution would buffer until exit,
+          # losing all output on timeout-kill). Trailing `|| true` prevents
+          # `set -eo pipefail` (GHA default) from aborting the script before
+          # PIPESTATUS is captured.
+          xcodebuild test \
             -scheme Pastura \
             -project Pastura/Pastura.xcodeproj \
             -destination "$DEST" \
             -only-testing PasturaTests \
             -enableCodeCoverage YES \
             -resultBundlePath TestResults.xcresult \
-            -quiet \
-            CODE_SIGNING_ALLOWED=NO 2>&1) || TEST_EXIT=$?
-          echo "$OUTPUT"
+            CODE_SIGNING_ALLOWED=NO 2>&1 | tee /tmp/xctest-unit.log || true
+          TEST_EXIT=${PIPESTATUS[0]}
 
-          # xcodebuild -quiet outputs per-case lines:
+          # xcodebuild outputs per-case lines:
           #   Test case '...' passed on '...' (X.XXX seconds)
           #   Test case '...' failed on '...' (X.XXX seconds)
-          PASSED=$(echo "$OUTPUT" | grep -c "^Test case .* passed " || true)
-          FAILED=$(echo "$OUTPUT" | grep -c "^Test case .* failed " || true)
+          # `2>/dev/null || echo 0` guards against a missing log file on
+          # timeout-kill so the numeric comparisons below don't break.
+          PASSED=$(grep -c "^Test case .* passed " /tmp/xctest-unit.log 2>/dev/null || echo 0)
+          FAILED=$(grep -c "^Test case .* failed " /tmp/xctest-unit.log 2>/dev/null || echo 0)
           if [ "$PASSED" -eq 0 ] && [ "$FAILED" -eq 0 ]; then
             echo "parse_error=true" >> "$GITHUB_OUTPUT"
           else
@@ -171,7 +177,8 @@ jobs:
           # CI-only infrastructure errors like "Failed to get background
           # assertion" without masking real test failures (those fail on
           # every retry).
-          OUTPUT=$(xcodebuild test \
+          # See unit-test step for rationale on tee / PIPESTATUS / || true.
+          xcodebuild test \
             -scheme Pastura \
             -project Pastura/Pastura.xcodeproj \
             -destination "$DEST" \
@@ -179,12 +186,11 @@ jobs:
             -retry-tests-on-failure \
             -test-iterations 2 \
             -resultBundlePath UITestResults.xcresult \
-            -quiet \
-            CODE_SIGNING_ALLOWED=NO 2>&1) || TEST_EXIT=$?
-          echo "$OUTPUT"
+            CODE_SIGNING_ALLOWED=NO 2>&1 | tee /tmp/xctest-ui.log || true
+          TEST_EXIT=${PIPESTATUS[0]}
 
-          PASSED=$(echo "$OUTPUT" | grep -c "^Test case .* passed " || true)
-          FAILED=$(echo "$OUTPUT" | grep -c "^Test case .* failed " || true)
+          PASSED=$(grep -c "^Test case .* passed " /tmp/xctest-ui.log 2>/dev/null || echo 0)
+          FAILED=$(grep -c "^Test case .* failed " /tmp/xctest-ui.log 2>/dev/null || echo 0)
           if [ "$PASSED" -eq 0 ] && [ "$FAILED" -eq 0 ]; then
             echo "parse_error=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,10 +79,17 @@ jobs:
           # xcodebuild outputs per-case lines:
           #   Test case '...' passed on '...' (X.XXX seconds)
           #   Test case '...' failed on '...' (X.XXX seconds)
-          # `2>/dev/null || echo 0` guards against a missing log file on
-          # timeout-kill so the numeric comparisons below don't break.
-          PASSED=$(grep -c "^Test case .* passed " /tmp/xctest-unit.log 2>/dev/null || echo 0)
-          FAILED=$(grep -c "^Test case .* failed " /tmp/xctest-unit.log 2>/dev/null || echo 0)
+          # `|| true` swallows grep's exit-1 on zero matches and exit-2 on
+          # missing file (timeout-kill case). Do NOT use `|| echo 0` here —
+          # grep -c already prints "0" on zero matches, so appending another
+          # "0" via echo yields a two-line "0\n0" value that corrupts
+          # `$GITHUB_OUTPUT` and breaks the numeric comparison below. The
+          # `:-0` default covers the missing-file case where grep produced no
+          # stdout at all.
+          PASSED=$(grep -c "^Test case .* passed " /tmp/xctest-unit.log 2>/dev/null || true)
+          FAILED=$(grep -c "^Test case .* failed " /tmp/xctest-unit.log 2>/dev/null || true)
+          PASSED=${PASSED:-0}
+          FAILED=${FAILED:-0}
           if [ "$PASSED" -eq 0 ] && [ "$FAILED" -eq 0 ]; then
             echo "parse_error=true" >> "$GITHUB_OUTPUT"
           else
@@ -189,8 +196,10 @@ jobs:
             CODE_SIGNING_ALLOWED=NO 2>&1 | tee /tmp/xctest-ui.log || true
           TEST_EXIT=${PIPESTATUS[0]}
 
-          PASSED=$(grep -c "^Test case .* passed " /tmp/xctest-ui.log 2>/dev/null || echo 0)
-          FAILED=$(grep -c "^Test case .* failed " /tmp/xctest-ui.log 2>/dev/null || echo 0)
+          PASSED=$(grep -c "^Test case .* passed " /tmp/xctest-ui.log 2>/dev/null || true)
+          FAILED=$(grep -c "^Test case .* failed " /tmp/xctest-ui.log 2>/dev/null || true)
+          PASSED=${PASSED:-0}
+          FAILED=${FAILED:-0}
           if [ "$PASSED" -eq 0 ] && [ "$FAILED" -eq 0 ]; then
             echo "parse_error=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Summary

- Replace `OUTPUT=$(xcodebuild ... 2>&1)` command-substitution buffering with `xcodebuild ... | tee /tmp/xctest-<unit|ui>.log` so per-test lines stream to the GHA log live. On a 15-min step timeout the subshell would be killed and the buffered `$OUTPUT` discarded — leaving zero diagnostic info.
- Use `|| true` + `TEST_EXIT=${PIPESTATUS[0]}` so GHA's default `set -eo pipefail` doesn't abort before we read xcodebuild's exit.
- Drop `-quiet` so `Test case ... started` markers are visible — on a hang they are the only signal pointing at the offending test.
- Count pass/fail from the log file with `grep -c ... || true` + `${VAR:-0}` (NOT `|| echo 0`, which double-counts on zero matches and corrupts `$GITHUB_OUTPUT`).
- Applied identically to both `lint-and-test` and `ui-test` jobs.

Commit `60b3259` fixes a regression introduced while writing this patch that was caught in review — verified locally across the three cases (file missing, file empty, file with N matches).

## Test plan

- [ ] CI run on this PR: per-test lines appear in the live `Test with Coverage` / `Test PasturaUITests` logs while the step runs.
- [ ] `test-passed` / `test-failed` outputs in the PR comment still match xcodebuild's own summary (unchanged pass count, unchanged format).
- [ ] Confirm no step-output corruption: the CI Report PR comment renders cleanly.
- [ ] Manual follow-up (optional): locally induce a timeout (`sleep 1000` in one test) and confirm the hanging test's "Test case ... started" line appears in the streamed log.

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)