### PR TITLE
🛡️ fix: assign phase silent-drop + type-safe AssignTarget enum (#108)

### DIFF
--- a/Pastura/Pastura/App/ScenarioEditorViewModel.swift
+++ b/Pastura/Pastura/App/ScenarioEditorViewModel.swift
@@ -82,13 +82,14 @@ struct EditablePhase: Identifiable, Sendable {
     self.logic = phase.logic
     self.template = phase.template ?? ""
     self.source = phase.source ?? ""
-    self.target = phase.target ?? ""
+    self.target = phase.target?.rawValue ?? ""
     self.excludeSelf = phase.excludeSelf ?? false
     self.subRounds = phase.subRounds
   }
 
   func toPhase() -> Phase {
-    Phase(
+    let trimmedTarget = target.trimmingCharacters(in: .whitespacesAndNewlines)
+    return Phase(
       type: type,
       prompt: prompt.isEmpty ? nil : prompt,
       outputSchema: outputFields.isEmpty ? nil : outputFields,
@@ -97,7 +98,9 @@ struct EditablePhase: Identifiable, Sendable {
       logic: logic,
       template: template.isEmpty ? nil : template,
       source: source.isEmpty ? nil : source,
-      target: target.isEmpty ? nil : target,
+      // Invalid strings silently nil here — the editor's `validate()` surfaces
+      // a user-visible error before this point so typos don't reach the engine.
+      target: trimmedTarget.isEmpty ? nil : AssignTarget(rawValue: trimmedTarget),
       excludeSelf: excludeSelf ? true : nil,
       subRounds: subRounds
     )
@@ -256,6 +259,9 @@ final class ScenarioEditorViewModel {
       if phases.isEmpty {
         validationErrors.append("At least one phase is required")
       }
+
+      validationErrors.append(contentsOf: invalidAssignTargetErrors())
+
       if !validationErrors.isEmpty { return }
 
       scenario = buildScenario()
@@ -323,6 +329,22 @@ final class ScenarioEditorViewModel {
   }
 
   // MARK: - Private
+
+  /// Visual editor uses a free-text TextField for `target` (#83 will replace
+  /// with a Picker). Surface typos as user-visible errors so they do not silently
+  /// nil through `EditablePhase.toPhase()` and reach the engine as `.all`.
+  private func invalidAssignTargetErrors() -> [String] {
+    var errors: [String] = []
+    for (idx, phase) in phases.enumerated() where phase.type == .assign {
+      let trimmed = phase.target.trimmingCharacters(in: .whitespacesAndNewlines)
+      if !trimmed.isEmpty, AssignTarget(rawValue: trimmed) == nil {
+        errors.append(
+          "Phase \(idx + 1) (assign): unknown target '\(trimmed)'. Use 'all' or 'random_one'."
+        )
+      }
+    }
+    return errors
+  }
 
   /// Builds a ``Scenario`` from the current visual editor state.
   private func buildScenario() -> Scenario {

--- a/Pastura/Pastura/Engine/Phases/AssignHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/AssignHandler.swift
@@ -29,6 +29,11 @@ nonisolated struct AssignHandler: PhaseHandler {
   }
 
   /// Assigns minority value to one random agent, majority to the rest.
+  ///
+  /// Precondition: `sourceData` is `.arrayOfDictionaries`. `ScenarioValidator`
+  /// rejects mismatched shapes upstream — the `guard` fall-through is a no-op
+  /// safety net for scenarios constructed in tests or future code paths that
+  /// bypass validation.
   private func assignRandomOne(
     active: [Persona],
     sourceData: AnyCodableValue?,
@@ -57,6 +62,11 @@ nonisolated struct AssignHandler: PhaseHandler {
   }
 
   /// Assigns the same round-indexed item to all agents.
+  ///
+  /// Precondition: `sourceData` is `.array` or `.string`. `ScenarioValidator`
+  /// rejects `.arrayOfDictionaries` / `.dictionary` upstream — the `default`
+  /// branch's empty-string fallback is a no-op safety net for scenarios
+  /// constructed in tests or future code paths that bypass validation.
   private func assignAll(
     active: [Persona],
     sourceData: AnyCodableValue?,

--- a/Pastura/Pastura/Engine/Phases/AssignHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/AssignHandler.swift
@@ -12,16 +12,17 @@ nonisolated struct AssignHandler: PhaseHandler {
     state: inout SimulationState
   ) async throws {
     let sourceKey = context.phase.source ?? ""
-    let target = context.phase.target ?? "all"
     let sourceData = context.scenario.extraData[sourceKey]
 
     let active = context.scenario.personas.filter { state.eliminated[$0.name] != true }
 
-    if target == "random_one" {
+    // nil target → .all matches the documented default at the type's doc comment.
+    switch context.phase.target ?? .all {
+    case .randomOne:
       assignRandomOne(
         active: active, sourceData: sourceData, state: &state, emitter: context.emitter
       )
-    } else {
+    case .all:
       assignAll(
         active: active, sourceData: sourceData, state: &state, emitter: context.emitter
       )

--- a/Pastura/Pastura/Engine/ScenarioLoader.swift
+++ b/Pastura/Pastura/Engine/ScenarioLoader.swift
@@ -149,6 +149,17 @@ nonisolated struct ScenarioLoader: Sendable {
     return Persona(name: name, description: description)
   }
 
+  /// Strict-throw on unknown, mirroring PhaseType. See issue #108.
+  private func parseAssignTarget(_ raw: Any?, phaseIndex: Int) throws -> AssignTarget? {
+    guard let targetStr = raw as? String else { return nil }
+    guard let parsed = AssignTarget(rawValue: targetStr) else {
+      throw SimulationError.scenarioValidationFailed(
+        "Phase \(phaseIndex) has invalid target: '\(targetStr)'. Use 'all' or 'random_one'."
+      )
+    }
+    return parsed
+  }
+
   private func mapPhase(_ dict: [String: Any], index: Int) throws -> Phase {
     guard let typeString = dict["type"] as? String else {
       throw SimulationError.scenarioValidationFailed("Phase \(index) missing 'type'")
@@ -162,9 +173,10 @@ nonisolated struct ScenarioLoader: Sendable {
     let prompt = dict["prompt"] as? String
     let template = dict["template"] as? String
     let source = dict["source"] as? String
-    let target = dict["target"] as? String
     let excludeSelf = dict["exclude_self"] as? Bool
     let options = dict["options"] as? [String]
+
+    let target = try parseAssignTarget(dict["target"], phaseIndex: index)
 
     // output → outputSchema
     var outputSchema: [String: String]?

--- a/Pastura/Pastura/Engine/ScenarioLoader.swift
+++ b/Pastura/Pastura/Engine/ScenarioLoader.swift
@@ -160,6 +160,27 @@ nonisolated struct ScenarioLoader: Sendable {
     return parsed
   }
 
+  private func parsePairing(_ raw: Any?, phaseIndex: Int) throws -> PairingStrategy? {
+    guard let str = raw as? String else { return nil }
+    guard let parsed = PairingStrategy(rawValue: str) else {
+      throw SimulationError.scenarioValidationFailed(
+        "Phase \(phaseIndex) has invalid pairing: '\(str)'. Use 'round_robin'."
+      )
+    }
+    return parsed
+  }
+
+  private func parseLogic(_ raw: Any?, phaseIndex: Int) throws -> ScoreCalcLogic? {
+    guard let str = raw as? String else { return nil }
+    guard let parsed = ScoreCalcLogic(rawValue: str) else {
+      let allowed = ScoreCalcLogic.allCases.map(\.rawValue).joined(separator: ", ")
+      throw SimulationError.scenarioValidationFailed(
+        "Phase \(phaseIndex) has invalid logic: '\(str)'. Expected one of: \(allowed)."
+      )
+    }
+    return parsed
+  }
+
   private func mapPhase(_ dict: [String: Any], index: Int) throws -> Phase {
     guard let typeString = dict["type"] as? String else {
       throw SimulationError.scenarioValidationFailed("Phase \(index) missing 'type'")
@@ -187,17 +208,8 @@ nonisolated struct ScenarioLoader: Sendable {
       }
     }
 
-    // pairing
-    var pairing: PairingStrategy?
-    if let pairingStr = dict["pairing"] as? String {
-      pairing = PairingStrategy(rawValue: pairingStr)
-    }
-
-    // logic
-    var logic: ScoreCalcLogic?
-    if let logicStr = dict["logic"] as? String {
-      logic = ScoreCalcLogic(rawValue: logicStr)
-    }
+    let pairing = try parsePairing(dict["pairing"], phaseIndex: index)
+    let logic = try parseLogic(dict["logic"], phaseIndex: index)
 
     // speak_each rounds → subRounds
     let subRounds = dict["rounds"] as? Int

--- a/Pastura/Pastura/Engine/ScenarioSerializer.swift
+++ b/Pastura/Pastura/Engine/ScenarioSerializer.swift
@@ -97,7 +97,7 @@ nonisolated struct ScenarioSerializer: Sendable {
     }
 
     if let target = phase.target {
-      lines.append("    target: \(target)")
+      lines.append("    target: \(target.rawValue)")
     }
 
     if let excludeSelf = phase.excludeSelf {

--- a/Pastura/Pastura/Engine/ScenarioValidator.swift
+++ b/Pastura/Pastura/Engine/ScenarioValidator.swift
@@ -70,18 +70,16 @@ nonisolated struct ScenarioValidator: Sendable {
     return ValidationResult(warnings: warnings, estimatedInferences: estimated)
   }
 
+  /// Per-phase semantic checks beyond execution-limit validation.
+  ///
+  /// Today only `assign` phases need this: the target/source shape combination
+  /// must produce a usable assignment. Unknown `target` values are caught
+  /// earlier by `ScenarioLoader` (compile-time enforced via `AssignTarget`).
   private func validatePhases(_ scenario: Scenario) throws {
     for (index, phase) in scenario.phases.enumerated() {
       guard phase.type == .assign else { continue }
 
       let phaseLabel = "Phase \(index + 1) (assign)"
-
-      let target = phase.target
-      if let target, target != "all", target != "random_one" {
-        throw SimulationError.scenarioValidationFailed(
-          "\(phaseLabel): unknown target '\(target)'. Use 'all' or 'random_one'."
-        )
-      }
 
       // Shape validation requires both a source key and a resolved value.
       // Skip if source is nil or key is absent from extraData (Visual Editor compat).
@@ -89,9 +87,12 @@ nonisolated struct ScenarioValidator: Sendable {
         continue
       }
 
-      let effectiveTarget = target ?? "all"
+      let effectiveTarget = phase.target ?? .all
 
-      if effectiveTarget == "all" {
+      // Exhaustive switches on AssignTarget and AnyCodableValue: adding a case
+      // forces a validation decision here — do not paper over with `default:`.
+      switch effectiveTarget {
+      case .all:
         switch sourceValue {
         case .array, .string:
           break
@@ -102,7 +103,7 @@ nonisolated struct ScenarioValidator: Sendable {
               + "Use target: all only for a flat list of strings or a single string."
           )
         }
-      } else {
+      case .randomOne:
         switch sourceValue {
         case .arrayOfDictionaries:
           break

--- a/Pastura/Pastura/Engine/ScenarioValidator.swift
+++ b/Pastura/Pastura/Engine/ScenarioValidator.swift
@@ -2,8 +2,10 @@ import Foundation
 
 /// Validates a ``Scenario`` against execution limits before running.
 ///
-/// Enforces agent count (2–10), round count (≤30), and estimated inference
-/// count (warn >50, error >100) to prevent runaway simulations.
+/// Enforces agent count (2–10), round count (≤30), estimated inference
+/// count (warn >50, error >100), and phase-field semantics (e.g.,
+/// assign-phase target/source compatibility) to prevent runaway or
+/// misconfigured simulations.
 nonisolated struct ScenarioValidator: Sendable {
 
   /// The result of scenario validation.
@@ -56,6 +58,8 @@ nonisolated struct ScenarioValidator: Sendable {
       )
     }
 
+    try validatePhases(scenario)
+
     var warnings: [String] = []
     if estimated > 50 {
       warnings.append(
@@ -64,5 +68,51 @@ nonisolated struct ScenarioValidator: Sendable {
     }
 
     return ValidationResult(warnings: warnings, estimatedInferences: estimated)
+  }
+
+  private func validatePhases(_ scenario: Scenario) throws {
+    for (index, phase) in scenario.phases.enumerated() {
+      guard phase.type == .assign else { continue }
+
+      let phaseLabel = "Phase \(index + 1) (assign)"
+
+      let target = phase.target
+      if let target, target != "all", target != "random_one" {
+        throw SimulationError.scenarioValidationFailed(
+          "\(phaseLabel): unknown target '\(target)'. Use 'all' or 'random_one'."
+        )
+      }
+
+      // Shape validation requires both a source key and a resolved value.
+      // Skip if source is nil or key is absent from extraData (Visual Editor compat).
+      guard let sourceKey = phase.source, let sourceValue = scenario.extraData[sourceKey] else {
+        continue
+      }
+
+      let effectiveTarget = target ?? "all"
+
+      if effectiveTarget == "all" {
+        switch sourceValue {
+        case .array, .string:
+          break
+        case .arrayOfDictionaries, .dictionary:
+          throw SimulationError.scenarioValidationFailed(
+            "\(phaseLabel): source '\(sourceKey)' contains grouped values (e.g., majority/minority pairs). "
+              + "Use target: random_one to distribute these. "
+              + "Use target: all only for a flat list of strings or a single string."
+          )
+        }
+      } else {
+        switch sourceValue {
+        case .arrayOfDictionaries:
+          break
+        case .array, .string, .dictionary:
+          throw SimulationError.scenarioValidationFailed(
+            "\(phaseLabel): source '\(sourceKey)' must be a list of grouped values "
+              + "(e.g., majority/minority pairs) when target is random_one."
+          )
+        }
+      }
+    }
   }
 }

--- a/Pastura/Pastura/Models/AssignTarget.swift
+++ b/Pastura/Pastura/Models/AssignTarget.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Distribution mode for `assign` phases — controls how a source value is mapped
+/// to active agents.
+///
+/// - `all` (default when omitted in YAML): every active agent receives the same
+///   round-indexed item from the source. Source must be a flat list of strings or
+///   a single string.
+/// - `randomOne`: one randomly-chosen agent receives the `minority` value, the
+///   rest receive `majority`. Source must be a list of `{majority, minority}`
+///   dictionaries (e.g., word wolf topic sets).
+nonisolated public enum AssignTarget: String, Codable, Sendable, CaseIterable {
+  case all
+  case randomOne = "random_one"
+}

--- a/Pastura/Pastura/Models/Phase.swift
+++ b/Pastura/Pastura/Models/Phase.swift
@@ -33,8 +33,8 @@ nonisolated public struct Phase: Codable, Sendable, Equatable {
   /// References a top-level field in the scenario definition.
   public let source: String?
 
-  /// Target specification for `assign` phases (e.g., `"all"`).
-  public let target: String?
+  /// Target specification for `assign` phases. `nil` defaults to `.all`.
+  public let target: AssignTarget?
 
   /// Whether agents are excluded from voting for themselves in `vote` phases.
   public let excludeSelf: Bool?
@@ -51,7 +51,7 @@ nonisolated public struct Phase: Codable, Sendable, Equatable {
     logic: ScoreCalcLogic? = nil,
     template: String? = nil,
     source: String? = nil,
-    target: String? = nil,
+    target: AssignTarget? = nil,
     excludeSelf: Bool? = nil,
     subRounds: Int? = nil
   ) {

--- a/Pastura/PasturaTests/App/PresetLoaderTests.swift
+++ b/Pastura/PasturaTests/App/PresetLoaderTests.swift
@@ -85,8 +85,8 @@ struct PresetLoaderTests {
         let extraValue = scenario.extraData[sourceKey]
         if case .arrayOfDictionaries = extraValue {
           #expect(
-            phase.target == "random_one",
-            "\(fileName).yaml phase[\(index)]: assign with arrayOfDictionaries source '\(sourceKey)' must use target 'random_one', got '\(phase.target ?? "nil")'"
+            phase.target == .randomOne,
+            "\(fileName).yaml phase[\(index)]: assign with arrayOfDictionaries source '\(sourceKey)' must use target 'random_one', got '\(phase.target?.rawValue ?? "nil")'"
           )
         }
       }

--- a/Pastura/PasturaTests/Engine/Phases/AssignHandlerTests.swift
+++ b/Pastura/PasturaTests/Engine/Phases/AssignHandlerTests.swift
@@ -9,7 +9,7 @@ struct AssignHandlerTests {
     let mock = MockLLMService(responses: [])
     let scenario = makeTestScenario(
       agentNames: ["Alice", "Bob"],
-      phases: [Phase(type: .assign, source: "topics", target: "all")],
+      phases: [Phase(type: .assign, source: "topics", target: .all)],
       extraData: ["topics": .array(["Topic A", "Topic B"])]
     )
     var state = SimulationState.initial(for: scenario)
@@ -28,7 +28,7 @@ struct AssignHandlerTests {
     let mock = MockLLMService(responses: [])
     let scenario = makeTestScenario(
       agentNames: ["Alice"],
-      phases: [Phase(type: .assign, source: "topics", target: "all")],
+      phases: [Phase(type: .assign, source: "topics", target: .all)],
       extraData: ["topics": .array(["First", "Second", "Third"])]
     )
     var state = SimulationState.initial(for: scenario)
@@ -45,7 +45,7 @@ struct AssignHandlerTests {
     let mock = MockLLMService(responses: [])
     let scenario = makeTestScenario(
       agentNames: ["Alice", "Bob", "Charlie"],
-      phases: [Phase(type: .assign, source: "words", target: "random_one")],
+      phases: [Phase(type: .assign, source: "words", target: .randomOne)],
       extraData: [
         "words": .arrayOfDictionaries([
           ["majority": "りんご", "minority": "みかん"]
@@ -76,7 +76,7 @@ struct AssignHandlerTests {
     let mock = MockLLMService(responses: [])
     let scenario = makeTestScenario(
       agentNames: ["Alice", "Bob"],
-      phases: [Phase(type: .assign, source: "topics", target: "all")],
+      phases: [Phase(type: .assign, source: "topics", target: .all)],
       extraData: ["topics": .array(["Topic"])]
     )
     var state = SimulationState.initial(for: scenario)

--- a/Pastura/PasturaTests/Engine/ScenarioLoaderTests.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioLoaderTests.swift
@@ -2,6 +2,7 @@ import Testing
 
 @testable import Pastura
 
+// swiftlint:disable file_length
 // swiftlint:disable:next type_body_length
 struct ScenarioLoaderTests {
   let loader = ScenarioLoader()
@@ -128,7 +129,7 @@ struct ScenarioLoaderTests {
     let assign = scenario.phases[5]
     #expect(assign.type == .assign)
     #expect(assign.source == "words")
-    #expect(assign.target == "random_one")
+    #expect(assign.target == .randomOne)
 
     // eliminate phase
     let eliminate = scenario.phases[6]
@@ -353,6 +354,35 @@ struct ScenarioLoaderTests {
     #expect(ScenarioLoader.estimateInferenceCount(scenario) == 10)
   }
 
+  // MARK: - Assign target parsing (strict)
+
+  /// Typo'd target string is rejected at parse time (was a silent .all default
+  /// before #108 / typed AssignTarget).
+  @Test func rejectsAssignWithUnknownTarget() {
+    let yaml =
+      makeYAMLWithAssignTarget("randomOne")  // typo of random_one
+    #expect(throws: SimulationError.self) {
+      try loader.load(yaml: yaml)
+    }
+  }
+
+  /// Case is significant — `target: All` was previously silently treated as
+  /// the default; now rejected.
+  @Test func rejectsAssignWithCapitalizedTarget() {
+    let yaml = makeYAMLWithAssignTarget("All")
+    #expect(throws: SimulationError.self) {
+      try loader.load(yaml: yaml)
+    }
+  }
+
+  @Test func acceptsAssignWithCanonicalTargetAll() throws {
+    _ = try loader.load(yaml: makeYAMLWithAssignTarget("all"))
+  }
+
+  @Test func acceptsAssignWithCanonicalTargetRandomOne() throws {
+    _ = try loader.load(yaml: makeYAMLWithAssignTarget("random_one"))
+  }
+
   @Test func estimatesZeroForCodePhases() {
     let scenario = Scenario(
       id: "t", name: "T", description: "T", agentCount: 5, rounds: 3, context: "C",
@@ -368,6 +398,28 @@ struct ScenarioLoaderTests {
   }
 
   // MARK: - Test Helpers
+
+  private func makeYAMLWithAssignTarget(_ target: String) -> String {
+    """
+    id: t
+    name: T
+    description: T
+    agents: 2
+    rounds: 1
+    context: C
+    personas:
+      - name: A
+        description: D
+      - name: B
+        description: D
+    phases:
+      - type: assign
+        source: topics
+        target: \(target)
+    topics:
+      - x
+    """
+  }
 
   private func makeMinimalYAML() -> String {
     """

--- a/Pastura/PasturaTests/Engine/ScenarioLoaderTests.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioLoaderTests.swift
@@ -383,6 +383,33 @@ struct ScenarioLoaderTests {
     _ = try loader.load(yaml: makeYAMLWithAssignTarget("random_one"))
   }
 
+  // MARK: - Pairing / logic parsing (strict)
+
+  @Test func rejectsChooseWithUnknownPairing() {
+    let yaml = makeMinimalYAML(
+      phasesBlock: """
+        phases:
+          - type: choose
+            pairing: roundRobin
+            options: [a, b]
+        """)
+    #expect(throws: SimulationError.self) {
+      try loader.load(yaml: yaml)
+    }
+  }
+
+  @Test func rejectsScoreCalcWithUnknownLogic() {
+    let yaml = makeMinimalYAML(
+      phasesBlock: """
+        phases:
+          - type: score_calc
+            logic: made_up_logic
+        """)
+    #expect(throws: SimulationError.self) {
+      try loader.load(yaml: yaml)
+    }
+  }
+
   @Test func estimatesZeroForCodePhases() {
     let scenario = Scenario(
       id: "t", name: "T", description: "T", agentCount: 5, rounds: 3, context: "C",
@@ -418,6 +445,23 @@ struct ScenarioLoaderTests {
         target: \(target)
     topics:
       - x
+    """
+  }
+
+  private func makeMinimalYAML(phasesBlock: String) -> String {
+    """
+    id: t
+    name: T
+    description: T
+    agents: 2
+    rounds: 1
+    context: C
+    personas:
+      - name: A
+        description: D
+      - name: B
+        description: D
+    \(phasesBlock)
     """
   }
 

--- a/Pastura/PasturaTests/Engine/ScenarioSerializerTests.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioSerializerTests.swift
@@ -40,7 +40,7 @@ struct ScenarioSerializerTests {
       ],
       phases: [
         // assign: source + target
-        Phase(type: .assign, source: "words", target: "random_one"),
+        Phase(type: .assign, source: "words", target: .randomOne),
         // speak_each: prompt + outputSchema + subRounds
         Phase(
           type: .speakEach,

--- a/Pastura/PasturaTests/Engine/ScenarioValidatorTests.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioValidatorTests.swift
@@ -93,6 +93,110 @@ struct ScenarioValidatorTests {
     }
   }
 
+  // MARK: - Assign phase: target validation
+
+  @Test func rejectsAssignWithUnknownTarget() {
+    let scenario = makeAssignScenario(target: "randomOne", source: nil, extraData: [:])
+    #expect(throws: SimulationError.self) {
+      try validator.validate(scenario)
+    }
+  }
+
+  // MARK: - Assign phase: target "all" (or nil) shape checks
+
+  @Test func acceptsAssignAllWithStringSource() throws {
+    let scenario = makeAssignScenario(
+      target: "all", source: "topic",
+      extraData: ["topic": .string("Hi")]
+    )
+    _ = try validator.validate(scenario)
+  }
+
+  @Test func acceptsAssignAllWithArraySource() throws {
+    let scenario = makeAssignScenario(
+      target: "all", source: "topics",
+      extraData: ["topics": .array(["A", "B"])]
+    )
+    _ = try validator.validate(scenario)
+  }
+
+  @Test func acceptsAssignAllWithMissingSourceKey() throws {
+    // Visual Editor compat: extraData is empty, skip shape check
+    let scenario = makeAssignScenario(target: "all", source: "topics", extraData: [:])
+    _ = try validator.validate(scenario)
+  }
+
+  @Test func acceptsAssignAllWithNilSource() throws {
+    // Visual Editor compat: no source specified, skip shape check
+    let scenario = makeAssignScenario(target: "all", source: nil, extraData: [:])
+    _ = try validator.validate(scenario)
+  }
+
+  @Test func acceptsAssignWithDefaultTarget() throws {
+    // nil target defaults to "all" behaviour; valid array source should pass
+    let scenario = makeAssignScenario(
+      target: nil, source: "topics",
+      extraData: ["topics": .array(["A", "B"])]
+    )
+    _ = try validator.validate(scenario)
+  }
+
+  @Test func rejectsAssignAllWithArrayOfDictionariesSource() {
+    let scenario = makeAssignScenario(
+      target: "all", source: "words",
+      extraData: ["words": .arrayOfDictionaries([["majority": "x", "minority": "y"]])]
+    )
+    #expect(throws: SimulationError.self) {
+      try validator.validate(scenario)
+    }
+  }
+
+  @Test func rejectsAssignAllWithDictionarySource() {
+    let scenario = makeAssignScenario(
+      target: "all", source: "w",
+      extraData: ["w": .dictionary(["a": "b"])]
+    )
+    #expect(throws: SimulationError.self) {
+      try validator.validate(scenario)
+    }
+  }
+
+  // MARK: - Assign phase: target "random_one" shape checks
+
+  @Test func acceptsAssignRandomOneWithArrayOfDictionariesSource() throws {
+    let scenario = makeAssignScenario(
+      target: "random_one", source: "words",
+      extraData: ["words": .arrayOfDictionaries([["majority": "x", "minority": "y"]])]
+    )
+    _ = try validator.validate(scenario)
+  }
+
+  @Test func rejectsAssignRandomOneWithArraySource() {
+    let scenario = makeAssignScenario(
+      target: "random_one", source: "topics",
+      extraData: ["topics": .array(["A", "B"])]
+    )
+    #expect(throws: SimulationError.self) {
+      try validator.validate(scenario)
+    }
+  }
+
+  @Test func rejectsAssignRandomOneWithStringSource() {
+    let scenario = makeAssignScenario(
+      target: "random_one", source: "topic",
+      extraData: ["topic": .string("Hi")]
+    )
+    #expect(throws: SimulationError.self) {
+      try validator.validate(scenario)
+    }
+  }
+
+  @Test func acceptsAssignRandomOneWithMissingSourceKey() throws {
+    // Visual Editor compat: extraData is empty, skip shape check
+    let scenario = makeAssignScenario(target: "random_one", source: "words", extraData: [:])
+    _ = try validator.validate(scenario)
+  }
+
   // MARK: - Helpers
 
   private func makeScenario(agents: Int, rounds: Int, phases: [Phase]) -> Scenario {
@@ -101,6 +205,20 @@ struct ScenarioValidatorTests {
       agentCount: agents, rounds: rounds, context: "Context",
       personas: (0..<agents).map { Persona(name: "A\($0)", description: "D") },
       phases: phases
+    )
+  }
+
+  private func makeAssignScenario(
+    target: String?,
+    source: String?,
+    extraData: [String: AnyCodableValue]
+  ) -> Scenario {
+    Scenario(
+      id: "test", name: "Test", description: "Test",
+      agentCount: 2, rounds: 1, context: "Context",
+      personas: [Persona(name: "A", description: "D"), Persona(name: "B", description: "D")],
+      phases: [Phase(type: .assign, source: source, target: target)],
+      extraData: extraData
     )
   }
 }

--- a/Pastura/PasturaTests/Engine/ScenarioValidatorTests.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioValidatorTests.swift
@@ -93,20 +93,12 @@ struct ScenarioValidatorTests {
     }
   }
 
-  // MARK: - Assign phase: target validation
-
-  @Test func rejectsAssignWithUnknownTarget() {
-    let scenario = makeAssignScenario(target: "randomOne", source: nil, extraData: [:])
-    #expect(throws: SimulationError.self) {
-      try validator.validate(scenario)
-    }
-  }
-
   // MARK: - Assign phase: target "all" (or nil) shape checks
+  // Unknown-target rejection now lives in ScenarioLoaderTests (caught at parse).
 
   @Test func acceptsAssignAllWithStringSource() throws {
     let scenario = makeAssignScenario(
-      target: "all", source: "topic",
+      target: .all, source: "topic",
       extraData: ["topic": .string("Hi")]
     )
     _ = try validator.validate(scenario)
@@ -114,7 +106,7 @@ struct ScenarioValidatorTests {
 
   @Test func acceptsAssignAllWithArraySource() throws {
     let scenario = makeAssignScenario(
-      target: "all", source: "topics",
+      target: .all, source: "topics",
       extraData: ["topics": .array(["A", "B"])]
     )
     _ = try validator.validate(scenario)
@@ -122,18 +114,18 @@ struct ScenarioValidatorTests {
 
   @Test func acceptsAssignAllWithMissingSourceKey() throws {
     // Visual Editor compat: extraData is empty, skip shape check
-    let scenario = makeAssignScenario(target: "all", source: "topics", extraData: [:])
+    let scenario = makeAssignScenario(target: .all, source: "topics", extraData: [:])
     _ = try validator.validate(scenario)
   }
 
   @Test func acceptsAssignAllWithNilSource() throws {
     // Visual Editor compat: no source specified, skip shape check
-    let scenario = makeAssignScenario(target: "all", source: nil, extraData: [:])
+    let scenario = makeAssignScenario(target: .all, source: nil, extraData: [:])
     _ = try validator.validate(scenario)
   }
 
   @Test func acceptsAssignWithDefaultTarget() throws {
-    // nil target defaults to "all" behaviour; valid array source should pass
+    // nil target defaults to .all behaviour; valid array source should pass
     let scenario = makeAssignScenario(
       target: nil, source: "topics",
       extraData: ["topics": .array(["A", "B"])]
@@ -143,7 +135,7 @@ struct ScenarioValidatorTests {
 
   @Test func rejectsAssignAllWithArrayOfDictionariesSource() {
     let scenario = makeAssignScenario(
-      target: "all", source: "words",
+      target: .all, source: "words",
       extraData: ["words": .arrayOfDictionaries([["majority": "x", "minority": "y"]])]
     )
     #expect(throws: SimulationError.self) {
@@ -153,7 +145,7 @@ struct ScenarioValidatorTests {
 
   @Test func rejectsAssignAllWithDictionarySource() {
     let scenario = makeAssignScenario(
-      target: "all", source: "w",
+      target: .all, source: "w",
       extraData: ["w": .dictionary(["a": "b"])]
     )
     #expect(throws: SimulationError.self) {
@@ -161,11 +153,29 @@ struct ScenarioValidatorTests {
     }
   }
 
+  /// User-facing error must include 1-based phase index and source key
+  /// — these end up in editor / import UI verbatim.
+  @Test func rejectAssignAllWithBadShapeIncludesPhaseIndexAndSourceKey() {
+    let scenario = makeAssignScenario(
+      target: .all, source: "words",
+      extraData: ["words": .arrayOfDictionaries([["majority": "x", "minority": "y"]])]
+    )
+    do {
+      _ = try validator.validate(scenario)
+      Issue.record("Expected validation to throw")
+    } catch let SimulationError.scenarioValidationFailed(message) {
+      #expect(message.contains("Phase 1 (assign)"))
+      #expect(message.contains("'words'"))
+    } catch {
+      Issue.record("Unexpected error: \(error)")
+    }
+  }
+
   // MARK: - Assign phase: target "random_one" shape checks
 
   @Test func acceptsAssignRandomOneWithArrayOfDictionariesSource() throws {
     let scenario = makeAssignScenario(
-      target: "random_one", source: "words",
+      target: .randomOne, source: "words",
       extraData: ["words": .arrayOfDictionaries([["majority": "x", "minority": "y"]])]
     )
     _ = try validator.validate(scenario)
@@ -173,7 +183,7 @@ struct ScenarioValidatorTests {
 
   @Test func rejectsAssignRandomOneWithArraySource() {
     let scenario = makeAssignScenario(
-      target: "random_one", source: "topics",
+      target: .randomOne, source: "topics",
       extraData: ["topics": .array(["A", "B"])]
     )
     #expect(throws: SimulationError.self) {
@@ -183,7 +193,7 @@ struct ScenarioValidatorTests {
 
   @Test func rejectsAssignRandomOneWithStringSource() {
     let scenario = makeAssignScenario(
-      target: "random_one", source: "topic",
+      target: .randomOne, source: "topic",
       extraData: ["topic": .string("Hi")]
     )
     #expect(throws: SimulationError.self) {
@@ -193,7 +203,7 @@ struct ScenarioValidatorTests {
 
   @Test func acceptsAssignRandomOneWithMissingSourceKey() throws {
     // Visual Editor compat: extraData is empty, skip shape check
-    let scenario = makeAssignScenario(target: "random_one", source: "words", extraData: [:])
+    let scenario = makeAssignScenario(target: .randomOne, source: "words", extraData: [:])
     _ = try validator.validate(scenario)
   }
 
@@ -209,7 +219,7 @@ struct ScenarioValidatorTests {
   }
 
   private func makeAssignScenario(
-    target: String?,
+    target: AssignTarget?,
     source: String?,
     extraData: [String: AnyCodableValue]
   ) -> Scenario {


### PR DESCRIPTION
## Summary

Fixes #108 — `AssignHandler.assignAll` silently distributed empty strings to all agents when `extraData[source]` was `.arrayOfDictionaries` or `.dictionary`; `assignRandomOne` silently returned for non-`.arrayOfDictionaries` shapes. Both failure modes are now rejected before the simulation starts, and the root cause (stringly-typed `Phase.target`) is eliminated by moving to a typed `AssignTarget` enum.

### What changed

1. **`ScenarioValidator.validatePhases(_:)`** now rejects assign-phase target/source shape mismatches at validation time with user-facing errors that include the phase index and source key.
2. **`AssignHandler`** gained precondition doc comments; control flow is now `switch target ?? .all` over enum cases rather than string comparison.
3. **New `AssignTarget` enum** (`Models/AssignTarget.swift`) replaces the stringly-typed `Phase.target: String?` field, eliminating the magic-string duplication between validator and handler that created this bug class in the first place.
4. **`ScenarioLoader`** strict-throws on unknown target strings (mirroring the existing `PhaseType` pattern), and commit 5 extends the same strict-throw treatment to `PairingStrategy` and `ScoreCalcLogic` — both previously silent-nil'd on unknown values, the same anti-pattern.
5. **`ScenarioEditorViewModel.validate()`** pre-validates the TextField-bound `target` string so typos surface as user-visible errors, preserving the error path for Visual Editor users (#83 will replace the TextField with a Picker).

### Behavior change for hand-edited YAML

Non-canonical casing (`target: All`) and typo'd enum values (`pairing: roundRobin`, `logic: made_up`) are now rejected at load time instead of silently falling through. Shipped presets use canonical values and are unaffected. Tests added to lock in the case-strict + typo-strict behavior.

### Public API change

`Phase.target: String?` → `AssignTarget?`. No external consumers today (single-binary app); flagging for SPM-prep visibility.

## Test plan

- [x] ScenarioValidatorTests — shape-mismatch rejection for both `.all` and `.randomOne`; error-message content assertion
- [x] ScenarioLoaderTests — unknown target / capitalized target / unknown pairing / unknown logic all throw at parse
- [x] AssignHandlerTests — existing behavior preserved through enum switch
- [x] ScenarioSerializerTests — enum round-trips via `rawValue`
- [x] ScenarioEditorViewModelTests — visual-mode save path
- [x] PresetLoaderTests — shipped presets (bokete / word_wolf / prisoners_dilemma) unchanged
- [x] SimulationRunnerTests / SimulationViewModelTests — integration unchanged
- [x] `swiftlint lint --quiet --strict` — clean

Note: full test suite could not complete locally due to an unrelated iOS Simulator launch hang. Targeted run across all touched suites (222 tests) passes. CI will run the full suite.

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)