### PR TITLE
🧪 test: stabilize flaky SimulationRunnerTests pause test

### DIFF
--- a/Pastura/Pastura/Engine/SimulationRunner.swift
+++ b/Pastura/Pastura/Engine/SimulationRunner.swift
@@ -17,11 +17,11 @@ nonisolated public final class SimulationRunner: @unchecked Sendable {
   private struct PauseState: Sendable {
     var isPaused = false
     var resumeContinuation: CheckedContinuation<Void, Never>?
-    /// Set by `resumeOnce()` when called in the narrow window after the runner
-    /// emits `.simulationPaused` but before it stores its continuation.
+    /// Set by `resumeOnce()` whenever no continuation is currently stored.
     /// The next store attempt inside `checkPaused` consumes this flag and
     /// short-circuits without suspending — mirrors the existing
-    /// `Task.isCancelled` race handling.
+    /// `Task.isCancelled` race handling. Covers both the emit-before-store
+    /// window and any pre-arm from outside an active pause cycle.
     var pendingResume = false
   }
 
@@ -57,10 +57,11 @@ nonisolated public final class SimulationRunner: @unchecked Sendable {
     ///
     /// Resumes the stored continuation (if one is waiting) so the runner progresses
     /// to the next `checkPaused` call, where `isPaused == true` makes it pause again.
-    /// If called in the window after `.simulationPaused` has been emitted but before
-    /// the continuation is stored, records a `pendingResume` flag that the next
-    /// store attempt consumes via short-circuit — closes the same race the existing
-    /// `Task.isCancelled` handling already covers.
+    /// If no continuation is currently stored — either because the runner has
+    /// emitted `.simulationPaused` but not yet stored, or because this is a
+    /// pre-arm before the runner reaches any checkpoint — records a `pendingResume`
+    /// flag that the next store attempt consumes via short-circuit, closing the
+    /// same race the existing `Task.isCancelled` handling already covers.
     ///
     /// Lets tests step through pause checkpoints deterministically instead of
     /// relying on `isPaused = false; isPaused = true` toggle timing, which races
@@ -219,6 +220,10 @@ nonisolated public final class SimulationRunner: @unchecked Sendable {
           // If resumeOnce() fired between emit and here, no continuation was
           // stored for it to extract — it set pendingResume instead. Consume
           // it now and short-circuit, mirroring the isCancelled handling below.
+          // Order vs. isCancelled: consuming pendingResume first is safe
+          // because the outer `if Task.isCancelled` at the bottom of the
+          // function still fires, so a cancel that races a pendingResume is
+          // not lost — just observed one statement later.
           if state.pendingResume {
             state.pendingResume = false
             return true

--- a/Pastura/Pastura/Engine/SimulationRunner.swift
+++ b/Pastura/Pastura/Engine/SimulationRunner.swift
@@ -17,6 +17,12 @@ nonisolated public final class SimulationRunner: @unchecked Sendable {
   private struct PauseState: Sendable {
     var isPaused = false
     var resumeContinuation: CheckedContinuation<Void, Never>?
+    /// Set by `resumeOnce()` when called in the narrow window after the runner
+    /// emits `.simulationPaused` but before it stores its continuation.
+    /// The next store attempt inside `checkPaused` consumes this flag and
+    /// short-circuits without suspending — mirrors the existing
+    /// `Task.isCancelled` race handling.
+    var pendingResume = false
   }
 
   private let pauseState = OSAllocatedUnfairLock(initialState: PauseState())
@@ -33,6 +39,11 @@ nonisolated public final class SimulationRunner: @unchecked Sendable {
       // lock during executor enqueue (lock-discipline best practice).
       let cont: CheckedContinuation<Void, Never>? = pauseState.withLock { state in
         state.isPaused = newValue
+        // Clear stale pendingResume on unpause so it can't leak into the
+        // next pause cycle if the user re-pauses later.
+        if !newValue {
+          state.pendingResume = false
+        }
         guard !newValue, let pending = state.resumeContinuation else { return nil }
         state.resumeContinuation = nil
         return pending
@@ -40,6 +51,32 @@ nonisolated public final class SimulationRunner: @unchecked Sendable {
       cont?.resume()
     }
   }
+
+  #if DEBUG
+    /// Test-only: advance exactly one pause checkpoint without clearing `isPaused`.
+    ///
+    /// Resumes the stored continuation (if one is waiting) so the runner progresses
+    /// to the next `checkPaused` call, where `isPaused == true` makes it pause again.
+    /// If called in the window after `.simulationPaused` has been emitted but before
+    /// the continuation is stored, records a `pendingResume` flag that the next
+    /// store attempt consumes via short-circuit — closes the same race the existing
+    /// `Task.isCancelled` handling already covers.
+    ///
+    /// Lets tests step through pause checkpoints deterministically instead of
+    /// relying on `isPaused = false; isPaused = true` toggle timing, which races
+    /// with the runner task on multi-core executors.
+    internal func resumeOnce() {
+      let cont: CheckedContinuation<Void, Never>? = pauseState.withLock { state in
+        guard let pending = state.resumeContinuation else {
+          state.pendingResume = true
+          return nil
+        }
+        state.resumeContinuation = nil
+        return pending
+      }
+      cont?.resume()
+    }
+  #endif
 
   /// Runs a simulation and returns an `AsyncStream` of events.
   ///
@@ -177,6 +214,13 @@ nonisolated public final class SimulationRunner: @unchecked Sendable {
       await withCheckedContinuation { continuation in
         let shouldResumeNow = ctx.pauseState.withLock { state in
           if !state.isPaused {
+            return true
+          }
+          // If resumeOnce() fired between emit and here, no continuation was
+          // stored for it to extract — it set pendingResume instead. Consume
+          // it now and short-circuit, mirroring the isCancelled handling below.
+          if state.pendingResume {
+            state.pendingResume = false
             return true
           }
           state.resumeContinuation = continuation

--- a/Pastura/PasturaTests/Engine/SimulationRunnerTests.swift
+++ b/Pastura/PasturaTests/Engine/SimulationRunnerTests.swift
@@ -215,70 +215,74 @@ struct SimulationRunnerTests {
     #expect(pausedEvents.count == 1)
   }
 
-  @Test func pausesBetweenPhasesNotOnlyBetweenRounds() async throws {
-    // 2 agents, 1 round, 2 speak_all phases → 4 mock responses total
-    let mock = MockLLMService(responses: [
-      #"{"statement": "p0-alice"}"#,
-      #"{"statement": "p0-bob"}"#,
-      #"{"statement": "p1-alice"}"#,
-      #"{"statement": "p1-bob"}"#
-    ])
-    try await mock.loadModel()
+  #if DEBUG
+    @Test func pausesBetweenPhasesNotOnlyBetweenRounds() async throws {
+      // Uses `resumeOnce()` to advance one pause checkpoint at a time without
+      // ever clearing `isPaused`. The previous sleep-based toggle
+      // (isPaused = false; isPaused = true) raced with the runner task on
+      // multi-core CI, occasionally losing a pause event — see Issue #124.
+      // Staying paused throughout closes that race: the runner sees
+      // `isPaused == true` at every checkpoint deterministically.
+      //
+      // 2 agents, 1 round, 2 speak_all phases → 4 mock responses total
+      let mock = MockLLMService(responses: [
+        #"{"statement": "p0-alice"}"#,
+        #"{"statement": "p0-bob"}"#,
+        #"{"statement": "p1-alice"}"#,
+        #"{"statement": "p1-bob"}"#
+      ])
+      try await mock.loadModel()
 
-    let scenario = makeTestScenario(
-      agentNames: ["Alice", "Bob"],
-      rounds: 1,
-      phases: [
-        Phase(type: .speakAll, prompt: "Phase 0", outputSchema: ["statement": "string"]),
-        Phase(type: .speakAll, prompt: "Phase 1", outputSchema: ["statement": "string"])
-      ]
-    )
+      let scenario = makeTestScenario(
+        agentNames: ["Alice", "Bob"],
+        rounds: 1,
+        phases: [
+          Phase(type: .speakAll, prompt: "Phase 0", outputSchema: ["statement": "string"]),
+          Phase(type: .speakAll, prompt: "Phase 1", outputSchema: ["statement": "string"])
+        ]
+      )
 
-    let runner = SimulationRunner()
-    runner.isPaused = true
+      let runner = SimulationRunner()
+      runner.isPaused = true
 
-    let stream = runner.run(scenario: scenario, llm: mock, suspendController: SuspendController())
-    async let allEvents = collectAllEvents(stream)
+      let stream = runner.run(scenario: scenario, llm: mock, suspendController: SuspendController())
 
-    // Pause 1: round boundary — wait for runner to reach it
-    try await Task.sleep(for: .milliseconds(50))
-
-    // Resume + immediately re-pause: cooperative concurrency means the
-    // runner task is enqueued but hasn't executed yet, so it will see
-    // isPaused=true at the next checkpoint (executePhases phaseIndex 0).
-    runner.isPaused = false
-    runner.isPaused = true
-    try await Task.sleep(for: .milliseconds(50))
-
-    // Resume + immediately re-pause: runner executes phase 0 (fast mock),
-    // then hits checkPaused at phaseIndex 1.
-    runner.isPaused = false
-    runner.isPaused = true
-    try await Task.sleep(for: .milliseconds(100))
-
-    // Final resume — let simulation complete
-    runner.isPaused = false
-
-    let events = await allEvents
-
-    let pausedEvents = events.compactMap { event -> (Int, Int)? in
-      if case .simulationPaused(let round, let phaseIndex) = event {
-        return (round, phaseIndex)
+      // Single-consumer drain: the test task is the sole iterator of the stream.
+      // Each `.simulationPaused` drives the next step; the 3rd pause releases
+      // `isPaused` so the runner can complete.
+      var events: [SimulationEvent] = []
+      var pauseCount = 0
+      for await event in stream {
+        events.append(event)
+        if case .simulationPaused = event {
+          pauseCount += 1
+          if pauseCount < 3 {
+            runner.resumeOnce()
+          } else {
+            runner.isPaused = false
+          }
+        }
       }
-      return nil
-    }
 
-    // 3 pause events:
-    // 1. Round boundary (round: 1, phaseIndex: 0)
-    // 2. Before phase 0 in executePhases (round: 1, phaseIndex: 0)
-    // 3. Before phase 1 in executePhases (round: 1, phaseIndex: 1)
-    #expect(pausedEvents.count == 3, "Expected 3 pause events, got \(pausedEvents)")
-    #expect(
-      pausedEvents.contains { $0 == (1, 1) },
-      "Should pause before phase 1 with phaseIndex=1, got \(pausedEvents)"
-    )
-    #expect(events.contains { if case .simulationCompleted = $0 { true } else { false } })
-  }
+      let pausedEvents = events.compactMap { event -> (Int, Int)? in
+        if case .simulationPaused(let round, let phaseIndex) = event {
+          return (round, phaseIndex)
+        }
+        return nil
+      }
+
+      // 3 pause events:
+      // 1. Round boundary (round: 1, phaseIndex: 0)
+      // 2. Before phase 0 in executePhases (round: 1, phaseIndex: 0)
+      // 3. Before phase 1 in executePhases (round: 1, phaseIndex: 1)
+      #expect(pausedEvents.count == 3, "Expected 3 pause events, got \(pausedEvents)")
+      #expect(
+        pausedEvents.contains { $0 == (1, 1) },
+        "Should pause before phase 1 with phaseIndex=1, got \(pausedEvents)"
+      )
+      #expect(events.contains { if case .simulationCompleted = $0 { true } else { false } })
+    }
+  #endif
 
   @Test func fullPrisonersDilemmaIntegration() async throws {
     let mock = MockLLMService(responses: [

--- a/Pastura/PasturaTests/Engine/SimulationRunnerTests.swift
+++ b/Pastura/PasturaTests/Engine/SimulationRunnerTests.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import Foundation
 import Testing
 
@@ -280,6 +281,55 @@ struct SimulationRunnerTests {
         pausedEvents.contains { $0 == (1, 1) },
         "Should pause before phase 1 with phaseIndex=1, got \(pausedEvents)"
       )
+      #expect(events.contains { if case .simulationCompleted = $0 { true } else { false } })
+    }
+
+    @Test func resumeOncePreArmShortCircuitsFirstCheckpoint() async throws {
+      // Pre-arming `pendingResume` via `resumeOnce()` BEFORE the runner reaches
+      // any checkpoint exercises the short-circuit branch in `checkPaused` that
+      // the main pause test only coincidentally hits. If the short-circuit
+      // logic were broken, the runner would block forever waiting for a
+      // continuation that was never stored and this test would hang.
+      let mock = MockLLMService(responses: [
+        #"{"statement": "alice"}"#,
+        #"{"statement": "bob"}"#
+      ])
+      try await mock.loadModel()
+
+      let scenario = makeTestScenario(
+        agentNames: ["Alice", "Bob"],
+        rounds: 1,
+        phases: [Phase(type: .speakAll, prompt: "Speak", outputSchema: ["statement": "string"])]
+      )
+
+      let runner = SimulationRunner()
+      runner.isPaused = true
+      // Sets pendingResume — the first `checkPaused` store attempt consumes it
+      // without ever suspending the runner task.
+      runner.resumeOnce()
+
+      let stream = runner.run(scenario: scenario, llm: mock, suspendController: SuspendController())
+
+      var events: [SimulationEvent] = []
+      var pauseCount = 0
+      for await event in stream {
+        events.append(event)
+        if case .simulationPaused = event {
+          pauseCount += 1
+          // First pause consumed pendingResume; subsequent pauses need a
+          // normal resume driver. The phase 0 checkpoint is the only other.
+          if pauseCount == 1 {
+            runner.resumeOnce()
+          } else {
+            runner.isPaused = false
+          }
+        }
+      }
+
+      // Two pause events (round boundary + phase 0) both emitted; simulation
+      // completed. The first fired through the pendingResume short-circuit,
+      // the second through the normal stored-continuation path.
+      #expect(pauseCount == 2)
       #expect(events.contains { if case .simulationCompleted = $0 { true } else { false } })
     }
   #endif


### PR DESCRIPTION
## Summary
- Eliminate multi-core race in `pausesBetweenPhasesNotOnlyBetweenRounds` by rewriting to event-driven synchronization; drop all `Task.sleep`-based timing
- Add internal `#if DEBUG` `resumeOnce()` helper on `SimulationRunner` that advances one pause checkpoint without clearing `isPaused`, plus `pendingResume` flag on `PauseState` mirroring the existing `Task.isCancelled` short-circuit to cover the emit-before-store window
- Add dedicated `resumeOncePreArmShortCircuitsFirstCheckpoint` test covering the short-circuit branch (the main pause test only hits the straight-through branch coincidentally)

## Test plan
- [x] 10 consecutive local runs of the previously-flaky test complete in ≤6ms each
- [x] Full `xcodebuild test` suite passes (unit + UI)
- [x] `swiftlint --strict` passes
- [x] `emitsPausedEventOnlyOnce` and `cancellationDuringPauseDoesNotHang` still pass (untouched pause semantics)

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)