### PR TITLE
🧪 test: add .timeLimit diagnostic + fix SuspendController cancel race

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -45,10 +45,15 @@ Apply to both suite forms:
 **Exceptions (document inline when skipping):**
 
 - Integration suites gated out of CI by env var (`OLLAMA_INTEGRATION`,
-  `LLAMACPP_INTEGRATION`) already carry per-test `.timeLimit(.minutes(2-5))`
-  sized for real-LLM inference. A blanket suite-level 1-minute cap would be
-  resolved as the tighter bound and silently break local integration runs.
-- Helper-only files (no `@Test` / `@Suite` declarations) don't need the trait.
+  `LLAMACPP_INTEGRATION`) are exempt from the suite-level 1-minute cap
+  because it would be resolved as the tighter bound and silently break
+  local integration runs against real LLMs. Each `@Test` in these suites
+  **must** carry its own `.timeLimit(.minutes(2-5))` sized for real-LLM
+  inference — without a per-test bound, a hung integration test would be
+  unbounded by *both* rules. (See `OllamaIntegrationTests.swift` and
+  `LlamaCppIntegrationTests.swift` for the current shape.)
+- Helper-only files (no `@Test` / `@Suite` declarations, e.g.
+  `EngineTestHelpers.swift`) don't need the trait.
 
 **If a unit test legitimately needs more than 1 minute:** override at the
 `@Test` level (`@Test(.timeLimit(.minutes(N))) func ...`). Swift Testing

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -15,6 +15,51 @@ concurrent Task/AsyncStream cleanup. This applies to integration tests that cons
 Individual unit tests (e.g., handler tests with `MockLLMService`) are safe to run
 in parallel because they await the handler directly without AsyncStream.
 
+## `.timeLimit` Trait on Every Suite (CI-Hang Diagnostic)
+
+Every Swift Testing suite under `Pastura/PasturaTests/` **must** carry
+`.timeLimit(.minutes(1))` (Swift Testing's minimum; `.seconds` is not supported).
+A hung test then fails individually at the 1-minute boundary with a
+`failed (timed out)` line naming the specific test, instead of silently
+eating the CI job's 15-minute wall-clock and corrupting the xcresult bundle.
+This is a load-bearing diagnostic — do not remove it from existing suites,
+and do not skip it when adding new ones.
+
+Apply to both suite forms:
+
+- **Explicit `@Suite(...)`**: include the trait alongside any existing traits.
+  ```swift
+  @Suite(.timeLimit(.minutes(1)))                              struct FooTests { ... }
+  @Suite(.serialized, .timeLimit(.minutes(1)))                 struct BarTests { ... }
+  @Suite(.serialized, .timeLimit(.minutes(1))) @MainActor      struct BazTests { ... }
+  @Suite("Display Name", .serialized, .timeLimit(.minutes(1))) struct QuxTests { ... }
+  ```
+- **Implicit suite** (`struct XxxTests` with `@Test` methods and no `@Suite`):
+  Swift Testing treats it as an implicit suite; without the attribute there
+  is no place to hang the trait. Promote to explicit `@Suite`:
+  ```swift
+  @Suite(.timeLimit(.minutes(1)))
+  struct XxxTests { @Test ... }
+  ```
+
+**Exceptions (document inline when skipping):**
+
+- Integration suites gated out of CI by env var (`OLLAMA_INTEGRATION`,
+  `LLAMACPP_INTEGRATION`) already carry per-test `.timeLimit(.minutes(2-5))`
+  sized for real-LLM inference. A blanket suite-level 1-minute cap would be
+  resolved as the tighter bound and silently break local integration runs.
+- Helper-only files (no `@Test` / `@Suite` declarations) don't need the trait.
+
+**If a unit test legitimately needs more than 1 minute:** override at the
+`@Test` level (`@Test(.timeLimit(.minutes(N))) func ...`). Swift Testing
+resolves the tightest-bound among suite + test traits, so a per-test widen
+is unusual — consider first whether the test is doing too much (split it,
+mock heavier work, etc.).
+
+**History:** PR #134 (Issue #131) introduced this rule after a
+cancel-before-store race in `SuspendController.awaitResume()` silently
+hung one test for 15 minutes on CI. See `memory/project_ci_timeout_investigation.md`.
+
 ## `-only-testing` and Swift Testing
 
 When using `-only-testing` with `xcodebuild`, prefer **suite-level** targeting

--- a/Pastura/Pastura/LLM/SuspendController.swift
+++ b/Pastura/Pastura/LLM/SuspendController.swift
@@ -35,8 +35,9 @@ import os
 /// - **Idempotent resume.** ``resume()`` is safe to call multiple times, including when
 ///   no suspend has been requested. This is essential for cleanup paths
 ///   (cancellation, `defer` blocks) that may race with normal resume.
-/// - **Cancellation honored.** If the awaiting task is cancelled, the continuation is
-///   resumed and ``awaitResume()`` returns. Callers detect cancellation via
+/// - **Cancellation honored at any point.** If the awaiting task is cancelled — before
+///   ``awaitResume()`` is entered, between entry and installing the continuation, or
+///   while parked — ``awaitResume()`` returns promptly. Callers detect cancellation via
 ///   `Task.checkCancellation()` or `Task.isCancelled` after the await.
 nonisolated public final class SuspendController: @unchecked Sendable {
   // @unchecked Sendable: all mutable state protected by OSAllocatedUnfairLock.
@@ -103,8 +104,9 @@ nonisolated public final class SuspendController: @unchecked Sendable {
   /// Suspends the calling task until ``resume()`` is called, or returns immediately
   /// if the controller is not in a suspended state.
   ///
-  /// Cancellation: if the owning `Task` is cancelled while parked, the continuation
-  /// is resumed via the cancellation handler and this method returns normally.
+  /// Cancellation: if the owning `Task` is cancelled at any point — before this
+  /// method is entered, between entry and installing the continuation, or while
+  /// parked — the continuation is resumed and this method returns promptly.
   /// Callers should subsequently check `Task.isCancelled` (or call
   /// `Task.checkCancellation()`) to distinguish cancellation from a normal resume.
   ///
@@ -128,18 +130,32 @@ nonisolated public final class SuspendController: @unchecked Sendable {
         }
         if resumeNow {
           continuation.resume()
+          return
+        }
+        // The cancellation handler may have fired BEFORE the continuation was
+        // installed — `withTaskCancellationHandler` documents that if the Task
+        // is already cancelled at entry, `onCancel` runs synchronously while
+        // the body still runs normally. In that case onCancel saw
+        // `.suspended(nil)` and no-op'd; without this check the just-installed
+        // continuation would park forever. Self-resume to close the race.
+        if Task.isCancelled {
+          extractStoredContinuation()?.resume()
         }
       }
     } onCancel: {
-      // Extract stored continuation under lock, resume outside.
-      // Leave state as `.suspended(nil)` so a subsequent resume() doesn't crash
-      // trying to resume a nil or already-resumed continuation.
-      let continuation: CheckedContinuation<Void, Never>? = state.withLock { state in
-        guard case .suspended(let stored) = state, let cont = stored else { return nil }
-        state = .suspended(nil)
-        return cont
-      }
-      continuation?.resume()
+      extractStoredContinuation()?.resume()
+    }
+  }
+
+  /// Atomically extracts the currently-stored awaiter continuation (if any) and
+  /// transitions state to `.suspended(nil)` so subsequent `resume()` / cancel
+  /// paths do not attempt to resume the same continuation twice. Caller must
+  /// invoke `resume()` on the returned continuation outside any lock.
+  private func extractStoredContinuation() -> CheckedContinuation<Void, Never>? {
+    state.withLock { state in
+      guard case .suspended(let stored) = state, let cont = stored else { return nil }
+      state = .suspended(nil)
+      return cont
     }
   }
 }

--- a/Pastura/PasturaTests/App/AppRouterTests.swift
+++ b/Pastura/PasturaTests/App/AppRouterTests.swift
@@ -4,7 +4,7 @@ import Testing
 @testable import Pastura
 
 @MainActor
-@Suite struct AppRouterTests {
+@Suite(.timeLimit(.minutes(1))) struct AppRouterTests {
 
   @Test func startsEmpty() {
     let router = AppRouter()

--- a/Pastura/PasturaTests/App/Community/Gallery/GallerySeedYAMLTests.swift
+++ b/Pastura/PasturaTests/App/Community/Gallery/GallerySeedYAMLTests.swift
@@ -6,7 +6,7 @@ import Testing
 /// Smoke test: every YAML committed under `docs/gallery/` must parse via
 /// `ScenarioLoader` and pass `ScenarioValidator`. Guards against shipping
 /// a gallery entry that the app rejects at Try time.
-@Suite struct GallerySeedYAMLTests {
+@Suite(.timeLimit(.minutes(1))) struct GallerySeedYAMLTests {
 
   @Test func allSeedYAMLsParseAndValidate() throws {
     let loader = ScenarioLoader()

--- a/Pastura/PasturaTests/App/Community/Gallery/GalleryServiceTests.swift
+++ b/Pastura/PasturaTests/App/Community/Gallery/GalleryServiceTests.swift
@@ -8,7 +8,7 @@ import Testing
 ///
 /// `.serialized` because MockURLProtocol shares static handler state across
 /// tests. Each test sets its own handler before exercising the service.
-@Suite(.serialized) struct GalleryServiceTests {
+@Suite(.serialized, .timeLimit(.minutes(1))) struct GalleryServiceTests {
 
   // MARK: - Fixtures
 

--- a/Pastura/PasturaTests/App/Community/Gallery/ReadonlyEnforcementTests.swift
+++ b/Pastura/PasturaTests/App/Community/Gallery/ReadonlyEnforcementTests.swift
@@ -7,7 +7,7 @@ import Testing
 /// three editor entry points. Each test seeds a gallery row, then drives
 /// the relevant VM and asserts the gate fires with a user-visible error.
 @MainActor
-@Suite struct ReadonlyEnforcementTests {
+@Suite(.timeLimit(.minutes(1))) struct ReadonlyEnforcementTests {
 
   private static let validYAML = """
     id: gallery_test

--- a/Pastura/PasturaTests/App/Community/Gallery/ShareBoardViewModelTests.swift
+++ b/Pastura/PasturaTests/App/Community/Gallery/ShareBoardViewModelTests.swift
@@ -5,7 +5,7 @@ import Testing
 @testable import Pastura
 
 @MainActor
-@Suite struct ShareBoardViewModelTests {
+@Suite(.timeLimit(.minutes(1))) struct ShareBoardViewModelTests {
 
   // MARK: - Fixtures
 

--- a/Pastura/PasturaTests/App/ContentFilterTests.swift
+++ b/Pastura/PasturaTests/App/ContentFilterTests.swift
@@ -2,6 +2,7 @@ import Testing
 
 @testable import Pastura
 
+@Suite(.timeLimit(.minutes(1)))
 struct ContentFilterTests {
   @Test func filterReplacesBlockedJapaneseWords() {
     let filter = ContentFilter(blockedPatterns: ["殺す", "死ね"])

--- a/Pastura/PasturaTests/App/HomeViewModelGalleryBadgeTests.swift
+++ b/Pastura/PasturaTests/App/HomeViewModelGalleryBadgeTests.swift
@@ -4,7 +4,7 @@ import Testing
 @testable import Pastura
 
 @MainActor
-@Suite struct HomeViewModelGalleryBadgeTests {
+@Suite(.timeLimit(.minutes(1))) struct HomeViewModelGalleryBadgeTests {
 
   private func makeRepo() throws -> GRDBScenarioRepository {
     let manager = try DatabaseManager.inMemory()

--- a/Pastura/PasturaTests/App/HomeViewModelTests.swift
+++ b/Pastura/PasturaTests/App/HomeViewModelTests.swift
@@ -3,6 +3,7 @@ import Testing
 
 @testable import Pastura
 
+@Suite(.timeLimit(.minutes(1)))
 @MainActor
 struct HomeViewModelTests {
   @Test func loadScenariosPopulatesPresetsAndUserLists() async throws {

--- a/Pastura/PasturaTests/App/ImportViewModelTests.swift
+++ b/Pastura/PasturaTests/App/ImportViewModelTests.swift
@@ -3,6 +3,7 @@ import Testing
 
 @testable import Pastura
 
+@Suite(.timeLimit(.minutes(1)))
 @MainActor
 struct ImportViewModelTests {
   private static let validYAML = """

--- a/Pastura/PasturaTests/App/MemoryWarningThrottleTests.swift
+++ b/Pastura/PasturaTests/App/MemoryWarningThrottleTests.swift
@@ -6,6 +6,7 @@ import Testing
 /// Pure-value tests for the memoryWarning policy. Independently testable so
 /// we can exercise edge cases (burst firing, escalation window boundaries,
 /// already-paused, BG branch) without synthesizing SwiftUI scenePhase.
+@Suite(.timeLimit(.minutes(1)))
 struct MemoryWarningThrottleTests {
 
   // MARK: - Already-paused no-op

--- a/Pastura/PasturaTests/App/ModelManagerTests.swift
+++ b/Pastura/PasturaTests/App/ModelManagerTests.swift
@@ -38,7 +38,7 @@ struct MockModelDownloader: ModelDownloader, Sendable {
 // MARK: - Tests
 
 // Download tests share filesystem paths (Documents directory), so serialize to avoid races.
-@Suite("ModelManager", .serialized)
+@Suite("ModelManager", .serialized, .timeLimit(.minutes(1)))
 @MainActor
 struct ModelManagerTests {
 

--- a/Pastura/PasturaTests/App/PlaybackSpeedTests.swift
+++ b/Pastura/PasturaTests/App/PlaybackSpeedTests.swift
@@ -2,6 +2,7 @@ import Testing
 
 @testable import Pastura
 
+@Suite(.timeLimit(.minutes(1)))
 @MainActor
 struct PlaybackSpeedTests {
   @Test func allCasesEnumerated() {

--- a/Pastura/PasturaTests/App/PresetLoaderTests.swift
+++ b/Pastura/PasturaTests/App/PresetLoaderTests.swift
@@ -3,6 +3,7 @@ import Testing
 
 @testable import Pastura
 
+@Suite(.timeLimit(.minutes(1)))
 struct PresetLoaderTests {
   @Test func loadPresetsCreatesRecordsInEmptyDB() throws {
     let db = try DatabaseManager.inMemory()

--- a/Pastura/PasturaTests/App/ResultDetailExportAssemblerTests.swift
+++ b/Pastura/PasturaTests/App/ResultDetailExportAssemblerTests.swift
@@ -3,7 +3,7 @@ import Testing
 
 @testable import Pastura
 
-@Suite
+@Suite(.timeLimit(.minutes(1)))
 struct ResultDetailExportAssemblerTests {
 
   // MARK: - Fixtures

--- a/Pastura/PasturaTests/App/ResultDetailTimelineBuilderTests.swift
+++ b/Pastura/PasturaTests/App/ResultDetailTimelineBuilderTests.swift
@@ -3,7 +3,7 @@ import Testing
 
 @testable import Pastura
 
-@Suite
+@Suite(.timeLimit(.minutes(1)))
 struct ResultDetailTimelineBuilderTests {
 
   // MARK: - Fixtures

--- a/Pastura/PasturaTests/App/ResultMarkdownExporterCodePhaseTests.swift
+++ b/Pastura/PasturaTests/App/ResultMarkdownExporterCodePhaseTests.swift
@@ -3,7 +3,7 @@ import Testing
 
 @testable import Pastura
 
-@Suite @MainActor
+@Suite(.timeLimit(.minutes(1))) @MainActor
 struct ResultMarkdownExporterCodePhaseTests {  // swiftlint:disable:this type_body_length
 
   // MARK: - Fixtures

--- a/Pastura/PasturaTests/App/ResultMarkdownExporterTests.swift
+++ b/Pastura/PasturaTests/App/ResultMarkdownExporterTests.swift
@@ -3,7 +3,7 @@ import Testing
 
 @testable import Pastura
 
-@Suite @MainActor struct ResultMarkdownExporterTests {  // swiftlint:disable:this type_body_length
+@Suite(.timeLimit(.minutes(1))) @MainActor struct ResultMarkdownExporterTests {  // swiftlint:disable:this type_body_length
 
   // MARK: - Fixtures
 

--- a/Pastura/PasturaTests/App/ResultMarkdownExporterWordWolfTests.swift
+++ b/Pastura/PasturaTests/App/ResultMarkdownExporterWordWolfTests.swift
@@ -8,7 +8,7 @@ import Testing
 /// Models a realistic Word Wolf round (assign → speak → vote → eliminate →
 /// score_calc/judge verdict → summarize) to defend the four Acceptance
 /// Criteria from #92 in a single integration-style test.
-@Suite @MainActor
+@Suite(.timeLimit(.minutes(1))) @MainActor
 struct ResultMarkdownExporterWordWolfTests {
 
   private let createdAt = Date(timeIntervalSince1970: 1_712_000_000)

--- a/Pastura/PasturaTests/App/ResultsViewModelTests.swift
+++ b/Pastura/PasturaTests/App/ResultsViewModelTests.swift
@@ -54,6 +54,7 @@ private func seedScenarioWithSimulation(
 
 // MARK: - Tests
 
+@Suite(.timeLimit(.minutes(1)))
 @MainActor
 struct ResultsViewModelTests {
 

--- a/Pastura/PasturaTests/App/ScenarioDetailViewModelTests.swift
+++ b/Pastura/PasturaTests/App/ScenarioDetailViewModelTests.swift
@@ -3,6 +3,7 @@ import Testing
 
 @testable import Pastura
 
+@Suite(.timeLimit(.minutes(1)))
 @MainActor
 struct ScenarioDetailViewModelTests {
   private static let validYAML = """

--- a/Pastura/PasturaTests/App/ScenarioEditorViewModelTests.swift
+++ b/Pastura/PasturaTests/App/ScenarioEditorViewModelTests.swift
@@ -3,6 +3,7 @@ import Testing
 
 @testable import Pastura
 
+@Suite(.timeLimit(.minutes(1)))
 @MainActor
 struct ScenarioEditorViewModelTests {
   private static let validYAML = """

--- a/Pastura/PasturaTests/App/SimulationViewModelBackgroundTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelBackgroundTests.swift
@@ -11,7 +11,7 @@ import Testing
 /// inferences safety is covered indirectly by SimulationRunnerTests
 /// (pausesBetweenPhasesNotOnlyBetweenRounds) and LlamaCppServiceTests
 /// (reloadModelFailureKeepsNotLoaded).
-@Suite(.serialized)
+@Suite(.serialized, .timeLimit(.minutes(1)))
 @MainActor
 struct SimulationViewModelBackgroundTests {
 

--- a/Pastura/PasturaTests/App/SimulationViewModelCodePhasePersistenceTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelCodePhasePersistenceTests.swift
@@ -6,7 +6,7 @@ import Testing
 /// Tests persistence of code-phase events to `code_phase_events` table,
 /// plus the shared `sequenceNumber` invariant across turns and code-phase
 /// tables.
-@Suite(.serialized) @MainActor
+@Suite(.serialized, .timeLimit(.minutes(1))) @MainActor
 // swiftlint:disable:next type_name
 struct SimulationViewModelCodePhasePersistenceTests {
 

--- a/Pastura/PasturaTests/App/SimulationViewModelExportTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelExportTests.swift
@@ -3,7 +3,7 @@ import Testing
 
 @testable import Pastura
 
-@Suite(.serialized) @MainActor
+@Suite(.serialized, .timeLimit(.minutes(1))) @MainActor
 struct SimulationViewModelExportTests {
 
   private let env = ResultMarkdownExporter.ExportEnvironment(

--- a/Pastura/PasturaTests/App/SimulationViewModelLifecycleTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelLifecycleTests.swift
@@ -46,7 +46,7 @@ nonisolated struct FailingLLMService: LLMService, Sendable {
 // MARK: - Lifecycle Integration Tests
 
 /// Lifecycle tests use real SimulationRunner + MockLLMService, requiring serialized execution.
-@Suite(.serialized)
+@Suite(.serialized, .timeLimit(.minutes(1)))
 @MainActor
 // swiftlint:disable:next type_body_length
 struct SimulationViewModelLifecycleTests {

--- a/Pastura/PasturaTests/App/SimulationViewModelTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelTests.swift
@@ -33,6 +33,7 @@ private func makeSUT(
 
 // MARK: - Event Handling Tests
 
+@Suite(.timeLimit(.minutes(1)))
 @MainActor
 struct SimulationViewModelTests {
 

--- a/Pastura/PasturaTests/Data/CodePhaseEventRecordTests.swift
+++ b/Pastura/PasturaTests/Data/CodePhaseEventRecordTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 @testable import Pastura
 
-@Suite struct CodePhaseEventRecordTests {
+@Suite(.timeLimit(.minutes(1))) struct CodePhaseEventRecordTests {
   private func makeManagerWithSimulation() throws -> DatabaseManager {
     let manager = try DatabaseManager.inMemory()
     let now = Date()

--- a/Pastura/PasturaTests/Data/CodePhaseEventRepositoryTests.swift
+++ b/Pastura/PasturaTests/Data/CodePhaseEventRepositoryTests.swift
@@ -3,7 +3,7 @@ import Testing
 
 @testable import Pastura
 
-@Suite struct CodePhaseEventRepositoryTests {
+@Suite(.timeLimit(.minutes(1))) struct CodePhaseEventRepositoryTests {
 
   private func makeRepo() throws -> GRDBCodePhaseEventRepository {
     let manager = try DatabaseManager.inMemory()

--- a/Pastura/PasturaTests/Data/DataIntegrationTests.swift
+++ b/Pastura/PasturaTests/Data/DataIntegrationTests.swift
@@ -5,7 +5,7 @@ import Testing
 
 /// End-to-end test exercising the full Data layer workflow
 /// as the App layer would use it.
-@Suite struct DataIntegrationTests {
+@Suite(.timeLimit(.minutes(1))) struct DataIntegrationTests {
 
   private struct Repos {
     let manager: DatabaseManager

--- a/Pastura/PasturaTests/Data/DatabaseManagerTests.swift
+++ b/Pastura/PasturaTests/Data/DatabaseManagerTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 @testable import Pastura
 
-@Suite struct DatabaseManagerTests {
+@Suite(.timeLimit(.minutes(1))) struct DatabaseManagerTests {
 
   @Test func inMemoryCreatesWithoutError() throws {
     // Verifies that inMemory() doesn't throw and returns a usable manager
@@ -90,7 +90,7 @@ import Testing
   }
 }
 
-@Suite struct DataErrorTests {
+@Suite(.timeLimit(.minutes(1))) struct DataErrorTests {
 
   @Test func casesAreEquatable() {
     let error1 = DataError.databaseOpenFailed(description: "fail")

--- a/Pastura/PasturaTests/Data/DatabaseMigrationTests.swift
+++ b/Pastura/PasturaTests/Data/DatabaseMigrationTests.swift
@@ -9,7 +9,7 @@ import Testing
 /// Exercises `DatabaseManager.makeMigrator()` by migrating up to a specific
 /// version, seeding realistic data, then applying the next migration and
 /// asserting existing rows survive.
-@Suite struct DatabaseMigrationTests {
+@Suite(.timeLimit(.minutes(1))) struct DatabaseMigrationTests {
 
   private func makeQueue() throws -> DatabaseQueue {
     var config = Configuration()

--- a/Pastura/PasturaTests/Data/ScenarioRecordTests.swift
+++ b/Pastura/PasturaTests/Data/ScenarioRecordTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 @testable import Pastura
 
-@Suite struct ScenarioRecordTests {
+@Suite(.timeLimit(.minutes(1))) struct ScenarioRecordTests {
 
   private func makeManager() throws -> DatabaseManager {
     try DatabaseManager.inMemory()

--- a/Pastura/PasturaTests/Data/ScenarioRepositoryTests.swift
+++ b/Pastura/PasturaTests/Data/ScenarioRepositoryTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 @testable import Pastura
 
-@Suite struct ScenarioRepositoryTests {
+@Suite(.timeLimit(.minutes(1))) struct ScenarioRepositoryTests {
 
   private func makeRepo() throws -> GRDBScenarioRepository {
     let manager = try DatabaseManager.inMemory()

--- a/Pastura/PasturaTests/Data/SimulationRecordTests.swift
+++ b/Pastura/PasturaTests/Data/SimulationRecordTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 @testable import Pastura
 
-@Suite struct SimulationRecordTests {
+@Suite(.timeLimit(.minutes(1))) struct SimulationRecordTests {
 
   private func makeManagerWithScenario() throws -> DatabaseManager {
     let manager = try DatabaseManager.inMemory()

--- a/Pastura/PasturaTests/Data/SimulationRepositoryTests.swift
+++ b/Pastura/PasturaTests/Data/SimulationRepositoryTests.swift
@@ -3,7 +3,7 @@ import Testing
 
 @testable import Pastura
 
-@Suite struct SimulationRepositoryTests {
+@Suite(.timeLimit(.minutes(1))) struct SimulationRepositoryTests {
 
   private func makeRepos() throws -> (
     scenario: GRDBScenarioRepository, simulation: GRDBSimulationRepository

--- a/Pastura/PasturaTests/Data/TurnRecordTests.swift
+++ b/Pastura/PasturaTests/Data/TurnRecordTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 @testable import Pastura
 
-@Suite struct TurnRecordTests {
+@Suite(.timeLimit(.minutes(1))) struct TurnRecordTests {
 
   /// Creates an in-memory DB with a scenario and simulation already inserted.
   private func makeManagerWithSimulation() throws -> DatabaseManager {

--- a/Pastura/PasturaTests/Data/TurnRepositoryTests.swift
+++ b/Pastura/PasturaTests/Data/TurnRepositoryTests.swift
@@ -3,7 +3,7 @@ import Testing
 
 @testable import Pastura
 
-@Suite struct TurnRepositoryTests {
+@Suite(.timeLimit(.minutes(1))) struct TurnRepositoryTests {
 
   /// Returns a TurnRepository backed by an in-memory DB with seeded scenario and simulation.
   private func makeTurnRepo() throws -> GRDBTurnRepository {

--- a/Pastura/PasturaTests/Engine/LLMCallerTests.swift
+++ b/Pastura/PasturaTests/Engine/LLMCallerTests.swift
@@ -4,6 +4,7 @@ import os
 
 @testable import Pastura
 
+@Suite(.timeLimit(.minutes(1)))
 struct LLMCallerTests {
   let caller = LLMCaller()
 

--- a/Pastura/PasturaTests/Engine/PhaseDispatcherTests.swift
+++ b/Pastura/PasturaTests/Engine/PhaseDispatcherTests.swift
@@ -2,6 +2,7 @@ import Testing
 
 @testable import Pastura
 
+@Suite(.timeLimit(.minutes(1)))
 struct PhaseDispatcherTests {
   let dispatcher = PhaseDispatcher()
 

--- a/Pastura/PasturaTests/Engine/Phases/AssignHandlerTests.swift
+++ b/Pastura/PasturaTests/Engine/Phases/AssignHandlerTests.swift
@@ -2,6 +2,7 @@ import Testing
 
 @testable import Pastura
 
+@Suite(.timeLimit(.minutes(1)))
 struct AssignHandlerTests {
   let handler = AssignHandler()
 

--- a/Pastura/PasturaTests/Engine/Phases/ChooseHandlerTests.swift
+++ b/Pastura/PasturaTests/Engine/Phases/ChooseHandlerTests.swift
@@ -2,6 +2,7 @@ import Testing
 
 @testable import Pastura
 
+@Suite(.timeLimit(.minutes(1)))
 struct ChooseHandlerTests {
   let handler = ChooseHandler()
 

--- a/Pastura/PasturaTests/Engine/Phases/EliminateHandlerTests.swift
+++ b/Pastura/PasturaTests/Engine/Phases/EliminateHandlerTests.swift
@@ -2,6 +2,7 @@ import Testing
 
 @testable import Pastura
 
+@Suite(.timeLimit(.minutes(1)))
 struct EliminateHandlerTests {
   let handler = EliminateHandler()
 

--- a/Pastura/PasturaTests/Engine/Phases/SpeakAllHandlerTests.swift
+++ b/Pastura/PasturaTests/Engine/Phases/SpeakAllHandlerTests.swift
@@ -2,6 +2,7 @@ import Testing
 
 @testable import Pastura
 
+@Suite(.timeLimit(.minutes(1)))
 struct SpeakAllHandlerTests {
   let handler = SpeakAllHandler()
 

--- a/Pastura/PasturaTests/Engine/Phases/SpeakEachHandlerTests.swift
+++ b/Pastura/PasturaTests/Engine/Phases/SpeakEachHandlerTests.swift
@@ -2,6 +2,7 @@ import Testing
 
 @testable import Pastura
 
+@Suite(.timeLimit(.minutes(1)))
 struct SpeakEachHandlerTests {
   let handler = SpeakEachHandler()
 

--- a/Pastura/PasturaTests/Engine/Phases/SummarizeHandlerTests.swift
+++ b/Pastura/PasturaTests/Engine/Phases/SummarizeHandlerTests.swift
@@ -2,6 +2,7 @@ import Testing
 
 @testable import Pastura
 
+@Suite(.timeLimit(.minutes(1)))
 struct SummarizeHandlerTests {
   let handler = SummarizeHandler()
 

--- a/Pastura/PasturaTests/Engine/Phases/VoteHandlerTests.swift
+++ b/Pastura/PasturaTests/Engine/Phases/VoteHandlerTests.swift
@@ -2,6 +2,7 @@ import Testing
 
 @testable import Pastura
 
+@Suite(.timeLimit(.minutes(1)))
 struct VoteHandlerTests {
   let handler = VoteHandler()
 

--- a/Pastura/PasturaTests/Engine/PromptBuilderTests.swift
+++ b/Pastura/PasturaTests/Engine/PromptBuilderTests.swift
@@ -3,6 +3,7 @@ import Testing
 
 @testable import Pastura
 
+@Suite(.timeLimit(.minutes(1)))
 struct PromptBuilderTests {
   let builder = PromptBuilder()
 

--- a/Pastura/PasturaTests/Engine/ScenarioLoaderTests.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioLoaderTests.swift
@@ -3,6 +3,7 @@ import Testing
 @testable import Pastura
 
 // swiftlint:disable file_length
+@Suite(.timeLimit(.minutes(1)))
 // swiftlint:disable:next type_body_length
 struct ScenarioLoaderTests {
   let loader = ScenarioLoader()

--- a/Pastura/PasturaTests/Engine/ScenarioSerializerTests.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioSerializerTests.swift
@@ -3,6 +3,7 @@ import Testing
 
 @testable import Pastura
 
+@Suite(.timeLimit(.minutes(1)))
 struct ScenarioSerializerTests {
   let serializer = ScenarioSerializer()
   let loader = ScenarioLoader()

--- a/Pastura/PasturaTests/Engine/ScenarioValidatorTests.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioValidatorTests.swift
@@ -2,6 +2,7 @@ import Testing
 
 @testable import Pastura
 
+@Suite(.timeLimit(.minutes(1)))
 struct ScenarioValidatorTests {
   let validator = ScenarioValidator()
 

--- a/Pastura/PasturaTests/Engine/ScoringLogic/PrisonersDilemmaLogicTests.swift
+++ b/Pastura/PasturaTests/Engine/ScoringLogic/PrisonersDilemmaLogicTests.swift
@@ -2,6 +2,7 @@ import Testing
 
 @testable import Pastura
 
+@Suite(.timeLimit(.minutes(1)))
 struct PrisonersDilemmaLogicTests {
   let logic = PrisonersDilemmaLogic()
 

--- a/Pastura/PasturaTests/Engine/ScoringLogic/VoteTallyLogicTests.swift
+++ b/Pastura/PasturaTests/Engine/ScoringLogic/VoteTallyLogicTests.swift
@@ -2,6 +2,7 @@ import Testing
 
 @testable import Pastura
 
+@Suite(.timeLimit(.minutes(1)))
 struct VoteTallyLogicTests {
   let logic = VoteTallyLogic()
 

--- a/Pastura/PasturaTests/Engine/ScoringLogic/WordwolfJudgeLogicTests.swift
+++ b/Pastura/PasturaTests/Engine/ScoringLogic/WordwolfJudgeLogicTests.swift
@@ -2,6 +2,7 @@ import Testing
 
 @testable import Pastura
 
+@Suite(.timeLimit(.minutes(1)))
 struct WordwolfJudgeLogicTests {
   let logic = WordwolfJudgeLogic()
 

--- a/Pastura/PasturaTests/Engine/SimulationRunnerTests.swift
+++ b/Pastura/PasturaTests/Engine/SimulationRunnerTests.swift
@@ -6,7 +6,7 @@ import Testing
 
 // Serialized: SimulationRunner tests create Tasks and AsyncStreams that can
 // interfere with each other when run in parallel on the simulator.
-@Suite(.serialized)
+@Suite(.serialized, .timeLimit(.minutes(1)))
 // swiftlint:disable:next type_body_length
 struct SimulationRunnerTests {
 

--- a/Pastura/PasturaTests/LLM/JSONResponseParserTests.swift
+++ b/Pastura/PasturaTests/LLM/JSONResponseParserTests.swift
@@ -2,6 +2,7 @@ import Testing
 
 @testable import Pastura
 
+@Suite(.timeLimit(.minutes(1)))
 struct JSONResponseParserTests {
   let parser = JSONResponseParser()
 

--- a/Pastura/PasturaTests/LLM/LLMErrorTests.swift
+++ b/Pastura/PasturaTests/LLM/LLMErrorTests.swift
@@ -2,6 +2,7 @@ import Testing
 
 @testable import Pastura
 
+@Suite(.timeLimit(.minutes(1)))
 struct LLMErrorTests {
   // MARK: - Equatable
 

--- a/Pastura/PasturaTests/LLM/LlamaCppServiceTests.swift
+++ b/Pastura/PasturaTests/LLM/LlamaCppServiceTests.swift
@@ -7,7 +7,7 @@ import Testing
 /// These tests validate lifecycle, error paths, and protocol conformance
 /// without requiring a real GGUF model file. Tests that call `loadModel()`
 /// use a non-existent path, which exercises the C API error handling.
-@Suite(.serialized)
+@Suite(.serialized, .timeLimit(.minutes(1)))
 struct LlamaCppServiceTests {
 
   // MARK: - Protocol conformance

--- a/Pastura/PasturaTests/LLM/MockLLMServiceTests.swift
+++ b/Pastura/PasturaTests/LLM/MockLLMServiceTests.swift
@@ -2,6 +2,7 @@ import Testing
 
 @testable import Pastura
 
+@Suite(.timeLimit(.minutes(1)))
 struct MockLLMServiceTests {
   // MARK: - Basic sequence behavior
 

--- a/Pastura/PasturaTests/LLM/OllamaServiceTests.swift
+++ b/Pastura/PasturaTests/LLM/OllamaServiceTests.swift
@@ -39,7 +39,7 @@ private final class MockURLProtocol: URLProtocol, @unchecked Sendable {
 
 // MARK: - Tests
 
-@Suite(.serialized)
+@Suite(.serialized, .timeLimit(.minutes(1)))
 struct OllamaServiceTests {
   private func makeSession() -> URLSession {
     let config = URLSessionConfiguration.ephemeral

--- a/Pastura/PasturaTests/LLM/SuspendControllerTests.swift
+++ b/Pastura/PasturaTests/LLM/SuspendControllerTests.swift
@@ -138,6 +138,30 @@ struct SuspendControllerTests {
     #expect(!controller.isSuspendRequested())
   }
 
+  @Test func awaitResumeBailsOutWhenTaskIsAlreadyCancelledAtEntry() async {
+    // Regression: `withTaskCancellationHandler` fires `onCancel` synchronously
+    // when the Task is already cancelled at entry, but the body still runs
+    // normally. If onCancel sees the pre-install state (.suspended(nil)) it
+    // no-ops — and the subsequently-installed continuation parks forever.
+    // The fix is a post-install Task.isCancelled self-check in awaitResume.
+    //
+    // This test is timing-independent: the yield-loop guarantees the child
+    // observes cancellation BEFORE entering awaitResume.
+    let controller = SuspendController()
+    controller.requestSuspend()
+
+    let awaitTask = Task<Void, Never> {
+      // Wait until cancellation is observable before calling awaitResume.
+      while !Task.isCancelled {
+        await Task.yield()
+      }
+      await controller.awaitResume()
+    }
+
+    awaitTask.cancel()
+    await awaitTask.value  // must not hang
+  }
+
   // MARK: - Lifecycle cycling
 
   @Test func requestSuspendAfterResumeStartsNewCycle() async throws {

--- a/Pastura/PasturaTests/LLM/SuspendControllerTests.swift
+++ b/Pastura/PasturaTests/LLM/SuspendControllerTests.swift
@@ -9,7 +9,7 @@ import os
 /// Serialized because several tests spawn child `Task`s that wait on the
 /// controller; concurrent execution of unrelated tests is still fine, but
 /// interleaving inside this suite risks flaky timings.
-@Suite(.serialized)
+@Suite(.serialized, .timeLimit(.minutes(1)))
 struct SuspendControllerTests {
 
   // MARK: - Initial state

--- a/Pastura/PasturaTests/Models/AnyCodableValueTests.swift
+++ b/Pastura/PasturaTests/Models/AnyCodableValueTests.swift
@@ -3,6 +3,7 @@ import Testing
 
 @testable import Pastura
 
+@Suite(.timeLimit(.minutes(1)))
 struct AnyCodableValueTests {
   @Test func stringRoundTrip() throws {
     let original = AnyCodableValue.string("hello")

--- a/Pastura/PasturaTests/Models/CodePhaseEventPayloadTests.swift
+++ b/Pastura/PasturaTests/Models/CodePhaseEventPayloadTests.swift
@@ -3,6 +3,7 @@ import Testing
 
 @testable import Pastura
 
+@Suite(.timeLimit(.minutes(1)))
 struct CodePhaseEventPayloadTests {
   private func roundTrip(_ payload: CodePhaseEventPayload) throws -> CodePhaseEventPayload {
     let data = try JSONEncoder().encode(payload)

--- a/Pastura/PasturaTests/Models/GalleryScenarioTests.swift
+++ b/Pastura/PasturaTests/Models/GalleryScenarioTests.swift
@@ -3,7 +3,7 @@ import Testing
 
 @testable import Pastura
 
-@Suite struct GalleryScenarioTests {
+@Suite(.timeLimit(.minutes(1))) struct GalleryScenarioTests {
 
   // MARK: - Fixtures
 

--- a/Pastura/PasturaTests/Models/PhaseTypeTests.swift
+++ b/Pastura/PasturaTests/Models/PhaseTypeTests.swift
@@ -3,6 +3,7 @@ import Testing
 
 @testable import Pastura
 
+@Suite(.timeLimit(.minutes(1)))
 struct PhaseTypeTests {
   @Test func rawValues() {
     #expect(PhaseType.speakAll.rawValue == "speak_all")

--- a/Pastura/PasturaTests/Models/ScoreCalcLogicTests.swift
+++ b/Pastura/PasturaTests/Models/ScoreCalcLogicTests.swift
@@ -3,6 +3,7 @@ import Testing
 
 @testable import Pastura
 
+@Suite(.timeLimit(.minutes(1)))
 struct ScoreCalcLogicTests {
   @Test func rawValues() {
     #expect(ScoreCalcLogic.prisonersDilemma.rawValue == "prisoners_dilemma")

--- a/Pastura/PasturaTests/Models/SimulationStateTests.swift
+++ b/Pastura/PasturaTests/Models/SimulationStateTests.swift
@@ -3,6 +3,7 @@ import Testing
 
 @testable import Pastura
 
+@Suite(.timeLimit(.minutes(1)))
 struct SimulationStateTests {
   @Test func codableRoundTrip() throws {
     let entry = ConversationEntry(

--- a/Pastura/PasturaTests/Models/TurnOutputTests.swift
+++ b/Pastura/PasturaTests/Models/TurnOutputTests.swift
@@ -3,6 +3,7 @@ import Testing
 
 @testable import Pastura
 
+@Suite(.timeLimit(.minutes(1)))
 struct TurnOutputTests {
   @Test func typedAccessorsReturnCorrectValues() {
     let output = TurnOutput(fields: [

--- a/Pastura/PasturaTests/PasturaTests.swift
+++ b/Pastura/PasturaTests/PasturaTests.swift
@@ -8,6 +8,7 @@
 import Testing
 @testable import Pastura
 
+@Suite(.timeLimit(.minutes(1)))
 struct PasturaTests {
 
     @Test func example() async throws {

--- a/Pastura/PasturaTests/Utilities/TypingPunctuationTests.swift
+++ b/Pastura/PasturaTests/Utilities/TypingPunctuationTests.swift
@@ -2,6 +2,7 @@ import Testing
 
 @testable import Pastura
 
+@Suite(.timeLimit(.minutes(1)))
 struct TypingPunctuationTests {
   @Test func sentenceTerminatorsGet300ms() {
     #expect(punctuationPauseMs(after: "。") == 300)


### PR DESCRIPTION
## Summary

- **Fix**: `SuspendController.awaitResume()` had a cancel-before-store race — when `withTaskCancellationHandler` entered with an already-cancelled Task, `onCancel` fired synchronously while state was `.suspended(nil)` (no continuation yet), no-op'd, and the subsequently-installed continuation parked forever. Added a post-install `Task.isCancelled` self-check and factored the pop-and-clear logic into `extractStoredContinuation()`.
- **Diagnostic**: applied Swift Testing's `.timeLimit(.minutes(1))` trait to every `@Suite` in `Pastura/PasturaTests/` (33 rewrites + 37 additions across 69 files). A future hang will now fail as a named `failed (timed out)` line within 1 minute instead of silently eating the 15-min CI wall-clock.

## Background — CI hang root cause

Per memory `project_ci_timeout_investigation.md`, main's `lint-and-test` has been intermittently hitting its 15-min wall-clock since 2026-04-15. Canonical repro: [run 24571620197](https://github.com/tyabu12/pastura/actions/runs/24571620197).

Phase 1 of the original plan was to ship only the diagnostic trait so Phase 2 could observe the hang on CI. Instead, the diagnostic caught the culprit on the **very first local run**:

```
Test case 'LLMCallerTests/cancellationDuringAwaitResumeBailsOut()' failed (60.000 seconds)
```

The exact 60.000 s = `.timeLimit(.minutes(1))` boundary, proving the hang is deterministic (not flaky), and the test name self-describes the broken code path: cooperative cancellation not propagating through `awaitResume`.

Folding the fix into this PR (per user approval) so main returns to green immediately rather than shipping the diagnostic with a known-failing test.

## Race analysis

Apple's [`withTaskCancellationHandler(operation:onCancel:)`](https://developer.apple.com/documentation/swift/withtaskcancellationhandler) docs:
> If cancellation occurs before the operation runs, the cancellation handler runs, but the operation runs normally without being cancelled.

Timing of the hang:
1. Task enters `awaitResume` after catching `LLMError.suspended` — `Task.isCancelled` is already true.
2. `onCancel` fires synchronously while state is `.suspended(nil)` (pre-install) → guard fails → no-op.
3. Body runs, installs continuation into `.suspended(cont)`, parks forever.

Fix ensures the continuation self-resumes if cancellation was missed:

```swift
// after state.withLock stores the continuation:
if Task.isCancelled {
  extractStoredContinuation()?.resume()
}
```

All four cancel-arrival windows covered (pre-entry, between-entry-and-install, between-install-and-park, after-park). Lock mutual exclusion ensures no double-resume: `onCancel` and the self-check both call `extractStoredContinuation()`, which atomically pops-and-nils under the lock.

## Test plan

- [x] Full unit suite: 565 passed, 0 failed (net +1 from new regression test)
- [x] Previously-hanging `LLMCallerTests.cancellationDuringAwaitResumeBailsOut()` now passes in <0.1 s
- [x] New `awaitResumeBailsOutWhenTaskIsAlreadyCancelledAtEntry()` uses yield-loop pattern for timing-independent determinism; passes in 0.000 s
- [x] Existing `cancellationReleasesAwaitResume()` (post-park cancel) and `resumeAfterCancellationIsSafe()` (double-resume guard) still green
- [x] SwiftLint `--strict` passes
- [x] Integration suites (`OllamaIntegrationTests`, `LlamaCppIntegrationTests`) untouched — keep per-test `.timeLimit(.minutes(2-5))` for real-LLM inference
- [ ] CI green on this PR (target: ~6 min vs current 15-min timeouts)

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)