### PR TITLE
🐛 fix: round-trip extraData through Visual Scenario Editor (#129)

### DIFF
--- a/Pastura/Pastura/App/ScenarioEditorViewModel.swift
+++ b/Pastura/Pastura/App/ScenarioEditorViewModel.swift
@@ -145,6 +145,13 @@ final class ScenarioEditorViewModel {
   private let serializer = ScenarioSerializer()
   private let validator = ScenarioValidator()
 
+  /// Stores top-level YAML keys that the visual editor has no UI for.
+  ///
+  /// Captured in `populateFromScenario` so `buildScenario` can pass them
+  /// through unchanged — preventing a silent data loss on every visual-mode save
+  /// for scenarios with custom fields (e.g. bokete `topics`, word_wolf `words`).
+  private var carriedExtraData: [String: AnyCodableValue] = [:]
+
   init(repository: any ScenarioRepository) {
     self.repository = repository
   }
@@ -356,7 +363,8 @@ final class ScenarioEditorViewModel {
       rounds: rounds,
       context: context,
       personas: personas.map { $0.toPersona() },
-      phases: phases.map { $0.toPhase() }
+      phases: phases.map { $0.toPhase() },
+      extraData: carriedExtraData
     )
   }
 
@@ -370,5 +378,6 @@ final class ScenarioEditorViewModel {
     context = scenario.context
     personas = scenario.personas.map { EditablePersona(from: $0) }
     phases = scenario.phases.map { EditablePhase(from: $0) }
+    carriedExtraData = scenario.extraData
   }
 }

--- a/Pastura/Pastura/Engine/ScenarioValidator.swift
+++ b/Pastura/Pastura/Engine/ScenarioValidator.swift
@@ -81,10 +81,18 @@ nonisolated struct ScenarioValidator: Sendable {
 
       let phaseLabel = "Phase \(index + 1) (assign)"
 
-      // Shape validation requires both a source key and a resolved value.
-      // Skip if source is nil or key is absent from extraData (Visual Editor compat).
-      guard let sourceKey = phase.source, let sourceValue = scenario.extraData[sourceKey] else {
-        continue
+      // Phases without a `source` reference persona indices instead of extraData
+      // — nothing to shape-check.
+      guard let sourceKey = phase.source else { continue }
+
+      // The Visual Editor now round-trips extraData (#129), so a missing key
+      // here means the scenario YAML genuinely lacks the referenced field —
+      // the assign would silently no-op at runtime. Surface it early.
+      guard let sourceValue = scenario.extraData[sourceKey] else {
+        throw SimulationError.scenarioValidationFailed(
+          "\(phaseLabel): source '\(sourceKey)' not found in scenario data. "
+            + "Add a top-level '\(sourceKey)' field to the scenario YAML."
+        )
       }
 
       let effectiveTarget = phase.target ?? .all

--- a/Pastura/PasturaTests/App/ScenarioEditorViewModelTests.swift
+++ b/Pastura/PasturaTests/App/ScenarioEditorViewModelTests.swift
@@ -5,6 +5,7 @@ import Testing
 
 @Suite(.timeLimit(.minutes(1)))
 @MainActor
+// swiftlint:disable:next type_body_length
 struct ScenarioEditorViewModelTests {
   private static let validYAML = """
     id: editor_test

--- a/Pastura/PasturaTests/App/ScenarioEditorViewModelTests.swift
+++ b/Pastura/PasturaTests/App/ScenarioEditorViewModelTests.swift
@@ -203,6 +203,172 @@ struct ScenarioEditorViewModelTests {
     #expect(sut.personas.count == 2)
   }
 
+  // MARK: - extraData Round-Trip
+
+  /// Verifies that `.array` extraData (bokete-shaped `topics` list) survives a
+  /// visual-edit round-trip via switchToYAMLMode → ScenarioLoader.
+  @Test func loadFromTemplatePreservesArrayExtraData() throws {
+    let yaml = """
+      id: bokete_test
+      name: Bokete Test
+      description: Bokete-shaped scenario
+      agents: 2
+      rounds: 1
+      context: Context
+      topics:
+        - Photo A
+        - Photo B
+        - Photo C
+      personas:
+        - name: Alice
+          description: Agent A
+        - name: Bob
+          description: Agent B
+      phases:
+        - type: assign
+          source: topics
+          target: random_one
+      """
+    let sut = try makeSUT()
+    sut.loadFromTemplate(yaml: yaml)
+
+    sut.switchToYAMLMode()
+    let reloaded = try ScenarioLoader().load(yaml: sut.yamlText)
+
+    #expect(reloaded.extraData["topics"] == .array(["Photo A", "Photo B", "Photo C"]))
+  }
+
+  /// Verifies that `.arrayOfDictionaries` extraData (word_wolf-shaped `words` list) survives
+  /// a visual-edit round-trip.
+  @Test func loadFromTemplatePreservesArrayOfDictionariesExtraData() throws {
+    let yaml = """
+      id: word_wolf_test
+      name: Word Wolf Test
+      description: Word-wolf-shaped scenario
+      agents: 2
+      rounds: 1
+      context: Context
+      words:
+        - majority: dog
+          minority: cat
+      personas:
+        - name: Alice
+          description: Agent A
+        - name: Bob
+          description: Agent B
+      phases:
+        - type: assign
+          source: words
+          target: random_one
+      """
+    let sut = try makeSUT()
+    sut.loadFromTemplate(yaml: yaml)
+
+    sut.switchToYAMLMode()
+    let reloaded = try ScenarioLoader().load(yaml: sut.yamlText)
+
+    #expect(
+      reloaded.extraData["words"] == .arrayOfDictionaries([["majority": "dog", "minority": "cat"]])
+    )
+  }
+
+  /// Verifies that a `.string` extraData value survives a visual-edit round-trip.
+  @Test func loadFromTemplatePreservesStringExtraData() throws {
+    let yaml = """
+      id: string_extra_test
+      name: String Extra Test
+      description: Scenario with string extraData
+      agents: 2
+      rounds: 1
+      context: Context
+      topic: "Hello"
+      personas:
+        - name: Alice
+          description: Agent A
+        - name: Bob
+          description: Agent B
+      phases:
+        - type: speak_all
+          prompt: "Say something"
+          output:
+            statement: string
+      """
+    let sut = try makeSUT()
+    sut.loadFromTemplate(yaml: yaml)
+
+    sut.switchToYAMLMode()
+    let reloaded = try ScenarioLoader().load(yaml: sut.yamlText)
+
+    #expect(reloaded.extraData["topic"] == .string("Hello"))
+  }
+
+  /// Verifies that a `.dictionary` extraData value survives a visual-edit round-trip.
+  @Test func loadFromTemplatePreservesDictionaryExtraData() throws {
+    let yaml = """
+      id: dict_extra_test
+      name: Dict Extra Test
+      description: Scenario with dictionary extraData
+      agents: 2
+      rounds: 1
+      context: Context
+      config:
+        key1: value1
+        key2: value2
+      personas:
+        - name: Alice
+          description: Agent A
+        - name: Bob
+          description: Agent B
+      phases:
+        - type: speak_all
+          prompt: "Say something"
+          output:
+            statement: string
+      """
+    let sut = try makeSUT()
+    sut.loadFromTemplate(yaml: yaml)
+
+    sut.switchToYAMLMode()
+    let reloaded = try ScenarioLoader().load(yaml: sut.yamlText)
+
+    #expect(reloaded.extraData["config"] == .dictionary(["key1": "value1", "key2": "value2"]))
+  }
+
+  /// Verifies that extraData survives the full visual→YAML→visual→YAML mode cycle.
+  @Test func modeSwitchPreservesExtraData() throws {
+    let yaml = """
+      id: roundtrip_test
+      name: Round-Trip Test
+      description: Mode-switch round-trip
+      agents: 2
+      rounds: 1
+      context: Context
+      topics:
+        - Alpha
+        - Beta
+      personas:
+        - name: Alice
+          description: Agent A
+        - name: Bob
+          description: Agent B
+      phases:
+        - type: assign
+          source: topics
+          target: random_one
+      """
+    let sut = try makeSUT()
+    sut.loadFromTemplate(yaml: yaml)
+
+    // visual → YAML → visual → YAML
+    sut.switchToYAMLMode()
+    let switched = sut.switchToVisualMode()
+    #expect(switched)
+    sut.switchToYAMLMode()
+
+    let reloaded = try ScenarioLoader().load(yaml: sut.yamlText)
+    #expect(reloaded.extraData["topics"] == .array(["Alpha", "Beta"]))
+  }
+
   // MARK: - Helpers
 
   private func makeSUT() throws -> ScenarioEditorViewModel {

--- a/Pastura/PasturaTests/Engine/ScenarioValidatorTests.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioValidatorTests.swift
@@ -113,10 +113,18 @@ struct ScenarioValidatorTests {
     _ = try validator.validate(scenario)
   }
 
-  @Test func acceptsAssignAllWithMissingSourceKey() throws {
-    // Visual Editor compat: extraData is empty, skip shape check
+  @Test func rejectsAssignAllWhenSourceKeyMissingFromExtraData() throws {
     let scenario = makeAssignScenario(target: .all, source: "topics", extraData: [:])
-    _ = try validator.validate(scenario)
+    do {
+      _ = try validator.validate(scenario)
+      Issue.record("Expected validation to throw")
+    } catch let SimulationError.scenarioValidationFailed(message) {
+      #expect(message.contains("Phase 1 (assign)"))
+      #expect(message.contains("'topics'"))
+      #expect(message.contains("not found"))
+    } catch {
+      Issue.record("Unexpected error: \(error)")
+    }
   }
 
   @Test func acceptsAssignAllWithNilSource() throws {
@@ -202,10 +210,18 @@ struct ScenarioValidatorTests {
     }
   }
 
-  @Test func acceptsAssignRandomOneWithMissingSourceKey() throws {
-    // Visual Editor compat: extraData is empty, skip shape check
+  @Test func rejectsAssignRandomOneWhenSourceKeyMissingFromExtraData() throws {
     let scenario = makeAssignScenario(target: .randomOne, source: "words", extraData: [:])
-    _ = try validator.validate(scenario)
+    do {
+      _ = try validator.validate(scenario)
+      Issue.record("Expected validation to throw")
+    } catch let SimulationError.scenarioValidationFailed(message) {
+      #expect(message.contains("Phase 1 (assign)"))
+      #expect(message.contains("'words'"))
+      #expect(message.contains("not found"))
+    } catch {
+      Issue.record("Unexpected error: \(error)")
+    }
   }
 
   // MARK: - Helpers


### PR DESCRIPTION
## Summary

- Fix `ScenarioEditorViewModel.buildScenario()` silently dropping `extraData` on save — it now round-trips through `carriedExtraData`, populated in `populateFromScenario` and passed into the `Scenario` initializer (Option A from #129).
- Tighten `ScenarioValidator.validatePhases`: an `assign` phase declaring a `source` key that isn't in `extraData` now fails validation with an actionable error ("source 'X' not found in scenario data. Add a top-level 'X' field to the scenario YAML.") instead of silently no-opping at runtime.
- Keeps "`source` is nil → skip" — assign phases without a source legitimately reference persona indices.

## Behavior change worth calling out

Any pre-existing user-authored / imported scenario that had an `assign` phase with a `source` pointing at a missing top-level field would previously have been accepted by the validator and silently no-op'd at runtime. After this PR it fails validation with a surfaced error. This is the intended hardening — the prior path was explicitly labeled "Visual Editor compat" to work around the bug this PR fixes. Shipped presets (`bokete.yaml`, `word_wolf.yaml`) are unaffected. Gallery seeds don't use `assign`.

## Out of scope (deferred)

- AC (3) tail — simplifying `invalidAssignTargetErrors()`. That workaround is about target-string validation (free-text TextField), not `extraData`, and will simplify naturally when the visual editor replaces the target TextField with a Picker.
- YAML-mode direct edits to top-level fields still won't be persisted unless the user switches modes once (pre-existing sharp edge, symmetric across all fields, not an `extraData`-specific bug).

## Test plan

- [x] `PasturaTests/ScenarioEditorViewModelTests` — 5 new tests covering `.string` / `.array` / `.dictionary` / `.arrayOfDictionaries` plus a full visual→YAML→visual→YAML round-trip.
- [x] `PasturaTests/ScenarioValidatorTests` — two lenient tests flipped to expect the new error; error message assertions pin the phase label, source key, and "not found" text.
- [x] Full unit suite (`-skip-testing:PasturaUITests`) — `TEST SUCCEEDED`.
- [x] `swiftlint --strict` — clean.
- [ ] Manual QA: open `word_wolf` / `bokete` in the Visual Editor, save without changes, confirm `extraData` survives in the saved YAML.

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)