### PR TITLE
🔧 chore: use workspace-relative DerivedData for worktree cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,11 @@ jobs:
           source scripts/sim-dest.sh
           echo "DEST=$DEST" >> "$GITHUB_ENV"
 
+      # NOTE: CI intentionally uses the default ~/Library DerivedData path so
+      # this cache key keeps hitting. Local dev builds go to
+      # Pastura/DerivedData/ via -derivedDataPath — see CLAUDE.md
+      # "DerivedData location". If CI ever adopts -derivedDataPath, update
+      # this cache path to match (and both instances of it in this file).
       - name: Cache SPM packages
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
@@ -165,6 +170,11 @@ jobs:
           xcrun simctl boot "$SIM_UDID" || true
           xcrun simctl bootstatus "$SIM_UDID" -b
 
+      # NOTE: CI intentionally uses the default ~/Library DerivedData path so
+      # this cache key keeps hitting. Local dev builds go to
+      # Pastura/DerivedData/ via -derivedDataPath — see CLAUDE.md
+      # "DerivedData location". If CI ever adopts -derivedDataPath, update
+      # this cache path to match (and both instances of it in this file).
       - name: Cache SPM packages
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Xcode
 build/
 DerivedData/
+# Xcode writes this metadata file adjacent to workspace-relative DerivedData
+.derived-data-log-*
 Pastura/Pastura.xcodeproj/project.xcworkspace/xcuserdata/
 Pastura/Pastura.xcodeproj/xcuserdata/
 *.pbxuser

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 # Xcode
 build/
 DerivedData/
-# Xcode writes this metadata file adjacent to workspace-relative DerivedData
+
+# Xcode metadata file written as a SIBLING of workspace-relative DerivedData
+# (at Pastura/.derived-data-log-*, not inside DerivedData/), so the rule above
+# doesn't cover it.
 .derived-data-log-*
 Pastura/Pastura.xcodeproj/project.xcworkspace/xcuserdata/
 Pastura/Pastura.xcodeproj/xcuserdata/

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,6 +4,9 @@ included:
 
 excluded:
   - Pastura/Resources
+  # Workspace-relative DerivedData lands here; don't lint SPM checkouts
+  # + Xcode-generated build artifacts.
+  - Pastura/DerivedData
 
 disabled_rules:
   - line_length          # YAML-heavy string literals exceed 120 chars

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,18 +136,37 @@ Implementation order: `Models → LLM → Engine → Data → Views → App → 
 source "$(git rev-parse --show-toplevel)/scripts/sim-dest.sh"
 
 # Run all tests
-xcodebuild test -scheme Pastura -project Pastura/Pastura.xcodeproj -destination "$DEST"
+xcodebuild test -scheme Pastura -project Pastura/Pastura.xcodeproj \
+  -destination "$DEST" -derivedDataPath "$DERIVED_DATA"
 
 # Run specific test class
-xcodebuild test -scheme Pastura -project Pastura/Pastura.xcodeproj -destination "$DEST" \
+xcodebuild test -scheme Pastura -project Pastura/Pastura.xcodeproj \
+  -destination "$DEST" -derivedDataPath "$DERIVED_DATA" \
   -only-testing PasturaTests/JSONResponseParserTests
 
 # Run Ollama integration tests (requires local Ollama with target model pulled)
 # Enable OLLAMA_INTEGRATION in scheme: Edit Scheme → Run → Environment Variables → toggle ON
-xcodebuild test -scheme Pastura -project Pastura/Pastura.xcodeproj -destination "$DEST" \
+xcodebuild test -scheme Pastura -project Pastura/Pastura.xcodeproj \
+  -destination "$DEST" -derivedDataPath "$DERIVED_DATA" \
   -only-testing PasturaTests/OllamaIntegrationTests
 # These tests are automatically skipped when OLLAMA_INTEGRATION is not enabled in the scheme.
 ```
+
+#### DerivedData location
+
+`sim-dest.sh` exports `DERIVED_DATA` pointing at `Pastura/DerivedData/` inside
+the current worktree. Always pass `-derivedDataPath "$DERIVED_DATA"` to
+`xcodebuild` so the CLI matches the Xcode.app Workspace-relative layout
+configured in `project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings`.
+This keeps GUI and CLI builds sharing one cache per worktree and makes
+`git worktree remove` auto-clean all build artifacts. Two gotchas:
+
+- **Pass `-derivedDataPath` with a space**, not `=`. The `=` form is silently
+  ignored by `xcodebuild` (known since Xcode 15.4).
+- **CI is intentionally left on the default `~/Library/...` path** so its
+  existing SPM cache (`actions/cache` keyed on that path) keeps hitting. If
+  CI ever starts passing `-derivedDataPath`, update both cache paths in
+  `.github/workflows/ci.yml` in the same PR.
 
 #### Running xcodebuild from an agent session
 

--- a/Pastura/Pastura.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/Pastura/Pastura.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildLocationStyle</key>
+	<string>UseAppPreferences</string>
+	<key>CustomBuildLocationType</key>
+	<string>RelativeToDerivedData</string>
+	<key>DerivedDataCustomLocation</key>
+	<string>DerivedData</string>
+	<key>DerivedDataLocationStyle</key>
+	<string>WorkspaceRelativePath</string>
+</dict>
+</plist>

--- a/scripts/sim-dest.sh
+++ b/scripts/sim-dest.sh
@@ -76,14 +76,23 @@ _simdest_name=$(echo "$_simdest_result" | cut -d'|' -f2)
 _simdest_os=$(echo "$_simdest_result" | cut -d'|' -f3)
 
 export DEST="platform=iOS Simulator,id=$_simdest_udid"
+
 # Matches the Xcode.app GUI's Workspace-relative DerivedData layout
 # (Pastura/DerivedData/), so the CLI and GUI share one build cache per
 # worktree. Removing a worktree therefore cleans both.
-export DERIVED_DATA="$(git rev-parse --show-toplevel)/Pastura/DerivedData"
+# Guard: if sourced from outside a git worktree, fail loud and restore
+# the caller's shell options before returning (otherwise set -e would
+# abort the script with pipefail still active in the caller's shell).
+_simdest_repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "Error: scripts/sim-dest.sh must be sourced from inside the git worktree." >&2
+  eval "$_simdest_old_opts"
+  return 1 2>/dev/null || exit 1
+}
+export DERIVED_DATA="$_simdest_repo_root/Pastura/DerivedData"
 echo "Selected simulator: $_simdest_name ($_simdest_os) [id=$_simdest_udid]"
 echo "DerivedData path: $DERIVED_DATA"
 
-unset _simdest_result _simdest_udid _simdest_name _simdest_os _simdest_errfile
+unset _simdest_result _simdest_udid _simdest_name _simdest_os _simdest_errfile _simdest_repo_root
 eval "$_simdest_old_opts"
 # return when sourced, exit when executed directly
 return 0 2>/dev/null || exit 0

--- a/scripts/sim-dest.sh
+++ b/scripts/sim-dest.sh
@@ -1,10 +1,20 @@
 #!/bin/bash
-# Resolve a usable iOS Simulator destination for xcodebuild.
-# Sources into the caller's shell and exports DEST.
+# Resolve a usable iOS Simulator destination for xcodebuild and export a
+# workspace-relative DerivedData path. Sources into the caller's shell and
+# exports DEST and DERIVED_DATA.
 #
 # Usage:
 #   source scripts/sim-dest.sh
-#   xcodebuild test ... -destination "$DEST"
+#   xcodebuild test ... -destination "$DEST" -derivedDataPath "$DERIVED_DATA"
+#
+# Why DERIVED_DATA: Xcode.app honors Workspace-relative DerivedData via
+# xcshareddata/WorkspaceSettings.xcsettings, but `xcodebuild` CLI ignores
+# that file entirely. Passing -derivedDataPath keeps CLI test runs aligned
+# with the GUI layout (Pastura/DerivedData/) so `git worktree remove`
+# auto-cleans all build artifacts.
+#
+# NOTE: pass -derivedDataPath with a SPACE separator, not `=`. The `=` form
+# is silently ignored by xcodebuild (known since Xcode 15.4).
 #
 # Uses UDID-based destination to avoid OS version mismatch when
 # xcodebuild defaults to OS:latest (e.g., iPhone 16 has only iOS 26.3
@@ -66,7 +76,12 @@ _simdest_name=$(echo "$_simdest_result" | cut -d'|' -f2)
 _simdest_os=$(echo "$_simdest_result" | cut -d'|' -f3)
 
 export DEST="platform=iOS Simulator,id=$_simdest_udid"
+# Matches the Xcode.app GUI's Workspace-relative DerivedData layout
+# (Pastura/DerivedData/), so the CLI and GUI share one build cache per
+# worktree. Removing a worktree therefore cleans both.
+export DERIVED_DATA="$(git rev-parse --show-toplevel)/Pastura/DerivedData"
 echo "Selected simulator: $_simdest_name ($_simdest_os) [id=$_simdest_udid]"
+echo "DerivedData path: $DERIVED_DATA"
 
 unset _simdest_result _simdest_udid _simdest_name _simdest_os _simdest_errfile
 eval "$_simdest_old_opts"


### PR DESCRIPTION
## Summary
- Switch DerivedData from `~/Library/.../DerivedData/Pastura-<hash>/` to workspace-relative `Pastura/DerivedData/` via `xcshareddata/WorkspaceSettings.xcsettings` so `git worktree remove` auto-cleans build artifacts
- Align `xcodebuild` CLI with the GUI location: `scripts/sim-dest.sh` exports `DERIVED_DATA`, CLAUDE.md requires `-derivedDataPath "$DERIVED_DATA"` (CLI ignores WorkspaceSettings.xcsettings — known Apple behavior)
- Exclude repo-internal `Pastura/DerivedData` from SwiftLint and ignore the `.derived-data-log-*` metadata file Xcode writes adjacent to it
- Harden `sim-dest.sh` to fail cleanly when sourced outside a git worktree

## Motivation
Issue-per-worktree development was orphaning ~4.8GB of DerivedData under `~/Library/...` across stale worktrees, hitting disk-full twice daily. Workspace-relative DerivedData ties the build cache to the worktree lifecycle.

## Scope
- **GUI**: Xcode.app builds land in `Pastura/DerivedData/` via `WorkspaceSettings.xcsettings`
- **CLI**: `xcodebuild` respects `-derivedDataPath` (passed via `DERIVED_DATA` env var)
- **CI**: Intentionally unchanged — keeps using `~/Library/...` so existing `actions/cache` SPM key keeps hitting. Cross-reference comments added to `ci.yml` to prevent future silent divergence.

## Test plan
- [x] Full unit test suite (skip UITests) passed with new `-derivedDataPath` flag
- [x] `swiftlint --strict --quiet` passes (with `Pastura/DerivedData` excluded)
- [x] GUI build verified — DerivedData resolves to `<worktree>/Pastura/DerivedData/`
- [x] `sim-dest.sh` edge case: sourced outside git repo fails loud without breaking caller shell
- [x] `git check-ignore` confirms `Pastura/.derived-data-log-*` is ignored
- [x] First Xcode.app build after pulling triggers one-time SPM re-resolve (expected, noted in commit 1)

## Follow-up (out of this PR)
- Clean existing orphaned `~/Library/.../DerivedData/Pastura-*` folders (~4.8GB) — requires worktree-to-DerivedData mapping, tracked separately.

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)