### PR TITLE
🐛 fix: apply ContentFilter to streaming snapshot (#133)

### DIFF
--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -663,10 +663,16 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     // Past the opening quote — the streaming row now has real content.
     // Remove the "thinking" indicator (the live row takes over display).
     thinkingAgents.remove(agent)
+    // Match the filtering that `handleAgentOutput` applies at commit — the
+    // in-flight snapshot is a user-visible display surface, so it must
+    // pass through ContentFilter for App Store compliance. A partial
+    // prefix of a blocked pattern still displays raw until the pattern
+    // completes (e.g. "fu" then "fuck" → "***"); that residual leakage
+    // is inherent to streaming and tracked in #133.
     streamingSnapshot = StreamingSnapshot(
       agent: agent,
-      primary: primary,
-      thought: thought,
+      primary: contentFilter.filter(primary),
+      thought: thought.map { contentFilter.filter($0) },
       phaseType: phaseType
     )
   }

--- a/Pastura/PasturaTests/App/SimulationViewModelStreamingTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelStreamingTests.swift
@@ -70,6 +70,41 @@ struct SimulationViewModelStreamingTests {
     #expect(sut.streamingSnapshot?.phaseType == .speakAll)
   }
 
+  // Regression: #132 landed the streaming path but bypassed ContentFilter
+  // at snapshot construction — blocked patterns were visible during
+  // streaming even though the committed AgentOutputRow filtered them.
+  // App Store compliance requires displayed output to pass through the
+  // filter, including the in-flight snapshot. Issue #133 PR#1.
+  @Test func agentOutputStreamAppliesContentFilter() throws {
+    let (sut, scenario) = try makeSUT(
+      contentFilter: ContentFilter(blockedPatterns: ["fuck"], replacement: "***"))
+    sut.handleEvent(
+      .phaseStarted(phaseType: .speakAll, phaseIndex: 0), scenario: scenario)
+    sut.handleEvent(
+      .agentOutputStream(
+        agent: "Alice", primary: "what the fuck", thought: "fuck it"),
+      scenario: scenario)
+
+    #expect(sut.streamingSnapshot?.primary == "what the ***")
+    #expect(sut.streamingSnapshot?.thought == "*** it")
+  }
+
+  // Guard against a future refactor that normalises `thought` to "" via
+  // `thought ?? ""` before filtering — that would clobber the signal
+  // `AgentOutputRow` uses to decide whether to render the inner-thought
+  // reveal gate.
+  @Test func agentOutputStreamPreservesNilThought() throws {
+    let (sut, scenario) = try makeSUT(
+      contentFilter: ContentFilter(blockedPatterns: ["fuck"], replacement: "***"))
+    sut.handleEvent(
+      .phaseStarted(phaseType: .speakAll, phaseIndex: 0), scenario: scenario)
+    sut.handleEvent(
+      .agentOutputStream(agent: "Alice", primary: "hello", thought: nil),
+      scenario: scenario)
+
+    #expect(sut.streamingSnapshot?.thought == nil)
+  }
+
   @Test func agentOutputStreamProgressivelyUpdatesSnapshot() throws {
     let (sut, scenario) = try makeSUT()
     sut.handleEvent(


### PR DESCRIPTION
## Summary

- `SimulationViewModel.handleAgentOutputStream` bypassed `ContentFilter` — blocked patterns were visible during streaming while the committed `AgentOutputRow` filtered them. Regression from #132; App Store compliance requires every display surface (including partial-stream) to pass through the filter.
- Apply `contentFilter.filter(_:)` to both `primary` and `thought` immediately before `StreamingSnapshot` init (after the existing `realtimeStreamingEnabled` / `primary` / `phaseType` guards, so the rollback path still short-circuits).
- Residual partial-prefix leakage (a blocked pattern's strict prefix can display before the pattern completes) is inherent to streaming; word-boundary buffering was rejected for the Japanese corpus per the #133 master tracker.

## Notes

- **Filter site** — `ContentFilter` lives in `App/` and `PartialOutputExtractor` in `LLM/`; filtering at the extractor boundary (mentioned as an alternative in #133's invariant #1) would force `LLM → App` dependency, violating CLAUDE.md Hard Rule #2. Snapshot-construction is the only compliant site.
- **Divergence telemetry** at `handleAgentOutput:608-615` now compares filtered-vs-filtered. A false-positive `debug` log can fire during filter-boundary straddles (`"fu"` streamed raw → `"***"` after the pattern completes); debug-level only, acceptable noise.

## Test plan

- [x] `PasturaTests/SimulationViewModelStreamingTests` — new `agentOutputStreamAppliesContentFilter` and `agentOutputStreamPreservesNilThought` tests added; both pass. Full unit suite green locally.
- [x] `swiftlint lint --quiet --strict` clean.
- [x] Manual QA on-device: `prisoners_dilemma` with a scenario containing a blocked pattern in agent speech, observe filtered display during streaming (matches post-commit state).

Refs #133 (PR#1 of 8 in the master tracker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)