### PR TITLE
🐛 fix: LocalizedError conformance for Pastura error enums (#138)

### DIFF
--- a/Pastura/Pastura/App/Community/Gallery/GalleryService.swift
+++ b/Pastura/Pastura/App/Community/Gallery/GalleryService.swift
@@ -53,3 +53,23 @@ nonisolated public enum GalleryServiceError: Error, Sendable, Equatable {
   /// The cached file exists but could not be decoded (corrupted or schema shift).
   case corruptedCache
 }
+
+/// Provides human-readable descriptions so UI alert handlers can show
+/// `error.localizedDescription` without mapping each case manually.
+extension GalleryServiceError: LocalizedError {
+  public var errorDescription: String? {
+    switch self {
+    case .responseTooLarge(let limit):
+      return String(localized: "Gallery response exceeds size limit (\(limit) bytes)")
+    case .hashMismatch(let expected, let actual):
+      return String(
+        localized: "Gallery scenario hash mismatch (expected \(expected), got \(actual))")
+    case .invalidResponse:
+      return String(localized: "Gallery response was malformed")
+    case .unexpectedStatus(let code):
+      return String(localized: "Gallery server returned unexpected status \(code)")
+    case .corruptedCache:
+      return String(localized: "Gallery cache is corrupted")
+    }
+  }
+}

--- a/Pastura/Pastura/App/Community/Gallery/GalleryService.swift
+++ b/Pastura/Pastura/App/Community/Gallery/GalleryService.swift
@@ -60,7 +60,9 @@ extension GalleryServiceError: LocalizedError {
   public var errorDescription: String? {
     switch self {
     case .responseTooLarge(let limit):
-      return String(localized: "Gallery response exceeds size limit (\(limit) bytes)")
+      let formatted = ByteCountFormatter.string(
+        fromByteCount: Int64(limit), countStyle: .file)
+      return String(localized: "Gallery response exceeds size limit (\(formatted))")
     case .hashMismatch(let expected, let actual):
       return String(
         localized: "Gallery scenario hash mismatch (expected \(expected), got \(actual))")

--- a/Pastura/Pastura/Data/DataError.swift
+++ b/Pastura/Pastura/Data/DataError.swift
@@ -27,3 +27,24 @@ nonisolated public enum DataError: Error, Sendable, Equatable {
   /// are writable only via the gallery Try/Update flow.
   case readonly(id: String)
 }
+
+/// Provides human-readable descriptions so UI alert handlers can show
+/// `error.localizedDescription` without mapping each case manually.
+extension DataError: LocalizedError {
+  public var errorDescription: String? {
+    switch self {
+    case .databaseOpenFailed(let description):
+      return String(localized: "Database open failed: \(description)")
+    case .migrationFailed(let description):
+      return String(localized: "Database migration failed: \(description)")
+    case .recordNotFound(let type, let id):
+      return String(localized: "Record not found: \(type) id=\(id)")
+    case .encodingFailed(let description):
+      return String(localized: "Encoding failed: \(description)")
+    case .decodingFailed(let description):
+      return String(localized: "Decoding failed: \(description)")
+    case .readonly(let id):
+      return String(localized: "Record is read-only: id=\(id)")
+    }
+  }
+}

--- a/Pastura/Pastura/Engine/ErrorReadability.swift
+++ b/Pastura/Pastura/Engine/ErrorReadability.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Returns the most human-readable description of an arbitrary `Error`.
+///
+/// Prefers ``LocalizedError/errorDescription`` when the error conforms,
+/// falling back to `String(describing:)` otherwise. Used at the Engine wrap
+/// points where foreign errors (typically `LLMError` or validator throws)
+/// are bridged into ``SimulationError``-typed associated-value strings. Using
+/// `"\(error)"` there loses the inner message because it stringifies the
+/// whole enum case (`generationFailed(description: "...")`) instead of just
+/// the meaningful text.
+///
+/// Foundation-only — Engine layer dependency rules (depends on LLM + Models)
+/// are preserved.
+nonisolated func readableDescription(_ error: Error) -> String {
+  if let localized = (error as? LocalizedError)?.errorDescription {
+    return localized
+  }
+  return String(describing: error)
+}

--- a/Pastura/Pastura/Engine/LLMCaller.swift
+++ b/Pastura/Pastura/Engine/LLMCaller.swift
@@ -59,7 +59,8 @@ nonisolated struct LLMCaller: Sendable {
         emitter(
           .inferenceCompleted(
             agent: agentName, durationSeconds: seconds, tokenCount: nil))
-        throw SimulationError.llmGenerationFailed(description: "\(error)")
+        throw SimulationError.llmGenerationFailed(
+          description: readableDescription(error))
       }
 
       let seconds = elapsedSeconds(since: startTime)

--- a/Pastura/Pastura/Engine/LLMCaller.swift
+++ b/Pastura/Pastura/Engine/LLMCaller.swift
@@ -59,8 +59,7 @@ nonisolated struct LLMCaller: Sendable {
         emitter(
           .inferenceCompleted(
             agent: agentName, durationSeconds: seconds, tokenCount: nil))
-        throw SimulationError.llmGenerationFailed(
-          description: readableDescription(error))
+        throw SimulationError.llmGenerationFailed(description: readableDescription(error))
       }
 
       let seconds = elapsedSeconds(since: startTime)

--- a/Pastura/Pastura/Engine/SimulationRunner.swift
+++ b/Pastura/Pastura/Engine/SimulationRunner.swift
@@ -148,7 +148,10 @@ nonisolated public final class SimulationRunner: @unchecked Sendable {
         emitter(.summary(text: "⚠️ \(warning)"))
       }
     } catch {
-      emitter(.error(error as? SimulationError ?? .scenarioValidationFailed("\(error)")))
+      emitter(
+        .error(
+          error as? SimulationError
+            ?? .scenarioValidationFailed(readableDescription(error))))
       return
     }
 
@@ -289,7 +292,9 @@ nonisolated public final class SimulationRunner: @unchecked Sendable {
         try await handler.execute(context: phaseContext, state: &state)
       } catch {
         ctx.emitter(
-          .error(error as? SimulationError ?? .llmGenerationFailed(description: "\(error)")))
+          .error(
+            error as? SimulationError
+              ?? .llmGenerationFailed(description: readableDescription(error))))
         return true
       }
 

--- a/Pastura/Pastura/LLM/LLMError.swift
+++ b/Pastura/Pastura/LLM/LLMError.swift
@@ -30,3 +30,25 @@ nonisolated public enum LLMError: Error, Sendable, Equatable {
   /// consuming retry budget.
   case suspended
 }
+
+/// Provides human-readable descriptions so UI alert handlers can show
+/// `error.localizedDescription` without mapping each case manually.
+extension LLMError: LocalizedError {
+  public var errorDescription: String? {
+    switch self {
+    case .loadFailed(let description):
+      return String(localized: "Model load failed: \(description)")
+    case .generationFailed(let description):
+      return String(localized: "Generation failed: \(description)")
+    case .notLoaded:
+      return String(localized: "Model not loaded")
+    case .invalidResponse(let raw):
+      let snippet = raw.count > 200 ? String(raw.prefix(200)) + "..." : raw
+      return String(localized: "Invalid LLM response: \(snippet)")
+    case .networkError(let description):
+      return String(localized: "Network error: \(description)")
+    case .suspended:
+      return String(localized: "Inference was suspended and will retry")
+    }
+  }
+}

--- a/Pastura/Pastura/Models/SimulationEvent.swift
+++ b/Pastura/Pastura/Models/SimulationEvent.swift
@@ -122,3 +122,26 @@ nonisolated public enum SimulationError: Error, Sendable, Equatable {
   /// The simulation was cancelled via Task cancellation.
   case cancelled
 }
+
+/// Provides human-readable descriptions so UI alert handlers can show
+/// `error.localizedDescription` without mapping each case manually.
+extension SimulationError: LocalizedError {
+  public var errorDescription: String? {
+    switch self {
+    case .scenarioValidationFailed(let message):
+      return message
+    case .llmGenerationFailed(let description):
+      return String(localized: "LLM generation failed: \(description)")
+    case .jsonParseFailed(let raw):
+      let snippet = raw.count > 200 ? String(raw.prefix(200)) + "..." : raw
+      return String(localized: "JSON parse failed: \(snippet)")
+    case .retriesExhausted:
+      return String(
+        localized: "LLM returned invalid output after retries. Try again or check model health.")
+    case .modelNotLoaded:
+      return String(localized: "Model not loaded")
+    case .cancelled:
+      return String(localized: "Simulation cancelled")
+    }
+  }
+}

--- a/Pastura/PasturaTests/App/Community/Gallery/GalleryServiceErrorTests.swift
+++ b/Pastura/PasturaTests/App/Community/Gallery/GalleryServiceErrorTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+@Suite(.timeLimit(.minutes(1)))
+struct GalleryServiceErrorTests {
+  // MARK: - LocalizedError conformance
+
+  @Test func conformsToLocalizedError() {
+    #expect((GalleryServiceError.invalidResponse as Any) is LocalizedError)
+  }
+
+  // MARK: - errorDescription per case
+
+  @Test func responseTooLargeDescription() {
+    // Use a value with no digit grouping so locale doesn't affect the check.
+    let error = GalleryServiceError.responseTooLarge(limit: 999)
+    #expect(error.errorDescription?.contains("999") ?? false)
+  }
+
+  @Test func hashMismatchDescription() {
+    let error = GalleryServiceError.hashMismatch(expected: "abc", actual: "def")
+    #expect(error.errorDescription?.contains("abc") ?? false)
+    #expect(error.errorDescription?.contains("def") ?? false)
+  }
+
+  @Test func invalidResponseDescription() {
+    let error = GalleryServiceError.invalidResponse
+    #expect(error.errorDescription?.contains("malformed") ?? false)
+  }
+
+  @Test func unexpectedStatusDescription() {
+    let error = GalleryServiceError.unexpectedStatus(500)
+    #expect(error.errorDescription?.contains("500") ?? false)
+  }
+
+  @Test func corruptedCacheDescription() {
+    let error = GalleryServiceError.corruptedCache
+    #expect(error.errorDescription?.contains("corrupt") ?? false)
+  }
+}

--- a/Pastura/PasturaTests/App/Community/Gallery/GalleryServiceErrorTests.swift
+++ b/Pastura/PasturaTests/App/Community/Gallery/GalleryServiceErrorTests.swift
@@ -14,9 +14,11 @@ struct GalleryServiceErrorTests {
   // MARK: - errorDescription per case
 
   @Test func responseTooLargeDescription() {
-    // Use a value with no digit grouping so locale doesn't affect the check.
-    let error = GalleryServiceError.responseTooLarge(limit: 999)
-    #expect(error.errorDescription?.contains("999") ?? false)
+    // Byte count is formatted via ByteCountFormatter (locale-aware,
+    // human-friendly units), so assert the locale-invariant literal
+    // fragment rather than the numeric output.
+    let error = GalleryServiceError.responseTooLarge(limit: 1_500_000)
+    #expect(error.errorDescription?.contains("size limit") ?? false)
   }
 
   @Test func hashMismatchDescription() {

--- a/Pastura/PasturaTests/App/ScenarioEditorViewModelTests.swift
+++ b/Pastura/PasturaTests/App/ScenarioEditorViewModelTests.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import Foundation
 import Testing
 

--- a/Pastura/PasturaTests/App/ScenarioEditorViewModelTests.swift
+++ b/Pastura/PasturaTests/App/ScenarioEditorViewModelTests.swift
@@ -186,6 +186,44 @@ struct ScenarioEditorViewModelTests {
     #expect(!sut.validationErrors.isEmpty)
   }
 
+  @Test func saveSurfacesSourceNotFoundValidationMessage() async throws {
+    let sut = try makeSUT()
+    // YAML with an `assign` phase referencing a non-existent `topics` source.
+    // Mirrors the real-world reproduction from issue #138: user removes
+    // `topics:` from bokete.yaml and hits Save.
+    let yamlMissingTopics = """
+      id: missing_topics_test
+      name: Missing Topics Test
+      description: triggers validator's missing-source path
+      agents: 2
+      rounds: 1
+      context: Context
+      personas:
+        - name: Alice
+          description: Agent A
+        - name: Bob
+          description: Agent B
+      phases:
+        - type: assign
+          source: topics
+          target: all
+        - type: speak_all
+          prompt: "Say something"
+          output:
+            statement: string
+      """
+    sut.yamlText = yamlMissingTopics
+    sut.editorMode = .yaml
+
+    let saved = await sut.save()
+
+    #expect(saved == false)
+    let firstError = sut.validationErrors.first ?? ""
+    #expect(firstError.contains("source 'topics' not found"))
+    // Regression guard for #138: the cryptic NSError fallback must not appear.
+    #expect(!firstError.contains("SimulationError error"))
+  }
+
   // MARK: - Loading for Edit
 
   @Test func loadExistingScenarioPopulatesFields() async throws {

--- a/Pastura/PasturaTests/Data/DataErrorTests.swift
+++ b/Pastura/PasturaTests/Data/DataErrorTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+@Suite(.timeLimit(.minutes(1)))
+struct DataErrorLocalizedErrorTests {
+  // MARK: - LocalizedError conformance
+
+  @Test func conformsToLocalizedError() {
+    #expect((DataError.readonly(id: "x") as Any) is LocalizedError)
+  }
+
+  // MARK: - errorDescription per case
+
+  @Test func databaseOpenFailedDescription() {
+    let error = DataError.databaseOpenFailed(description: "file missing")
+    #expect(error.errorDescription?.contains("open failed") ?? false)
+    #expect(error.errorDescription?.contains("file missing") ?? false)
+  }
+
+  @Test func migrationFailedDescription() {
+    let error = DataError.migrationFailed(description: "v2 schema conflict")
+    #expect(error.errorDescription?.contains("migration failed") ?? false)
+    #expect(error.errorDescription?.contains("v2 schema conflict") ?? false)
+  }
+
+  @Test func recordNotFoundDescription() {
+    let error = DataError.recordNotFound(type: "ScenarioRecord", id: "abc-123")
+    #expect(error.errorDescription?.contains("ScenarioRecord") ?? false)
+    #expect(error.errorDescription?.contains("abc-123") ?? false)
+  }
+
+  @Test func encodingFailedDescription() {
+    let error = DataError.encodingFailed(description: "nil value")
+    #expect(error.errorDescription?.contains("Encoding failed") ?? false)
+    #expect(error.errorDescription?.contains("nil value") ?? false)
+  }
+
+  @Test func decodingFailedDescription() {
+    let error = DataError.decodingFailed(description: "unexpected key")
+    #expect(error.errorDescription?.contains("Decoding failed") ?? false)
+    #expect(error.errorDescription?.contains("unexpected key") ?? false)
+  }
+
+  @Test func readonlyDescription() {
+    let error = DataError.readonly(id: "scenario-42")
+    #expect(error.errorDescription?.contains("read-only") ?? false)
+    #expect(error.errorDescription?.contains("scenario-42") ?? false)
+  }
+}

--- a/Pastura/PasturaTests/Engine/ErrorReadabilityTests.swift
+++ b/Pastura/PasturaTests/Engine/ErrorReadabilityTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+@Suite(.timeLimit(.minutes(1)))
+struct ErrorReadabilityTests {
+  // MARK: - Helper direct behavior
+
+  @Test func prefersLocalizedErrorDescription() {
+    struct LocalizedFake: LocalizedError {
+      var errorDescription: String? { "human readable message" }
+    }
+    let result = readableDescription(LocalizedFake())
+    #expect(result.contains("human readable"))
+  }
+
+  @Test func fallsBackWhenLocalizedErrorReturnsNil() {
+    struct LocalizedNil: LocalizedError {
+      var errorDescription: String? { nil }
+    }
+    // Falls through to String(describing:), which prints the type name for an
+    // empty struct — we only assert the helper doesn't crash and returns
+    // something non-empty.
+    let result = readableDescription(LocalizedNil())
+    #expect(!result.isEmpty)
+  }
+
+  @Test func fallsBackToStringDescribingForPlainError() {
+    enum PlainError: Error { case boom }
+    let result = readableDescription(PlainError.boom)
+    #expect(result.contains("boom"))
+  }
+
+  // MARK: - Wrap-chain semantics at the Engine boundary
+
+  // These tests assert that the helper preserves the inner error's meaningful
+  // text when Engine wraps foreign errors into SimulationError. They inspect
+  // the wrapped case's associated-value String directly rather than reading
+  // `wrapped.localizedDescription` — that final surfacing step depends on
+  // SimulationError adopting LocalizedError (landed in a subsequent commit)
+  // and is exercised via the per-enum `errorDescription` tests. Keeping this
+  // test focused on the helper's contribution makes it immune to the
+  // conformance rollout order.
+
+  @Test func wrapChainCarriesInnerLLMErrorText() {
+    let inner = LLMError.generationFailed(description: "connection timeout")
+    let wrapped = SimulationError.llmGenerationFailed(
+      description: readableDescription(inner))
+    guard case .llmGenerationFailed(let desc) = wrapped else {
+      Issue.record("expected .llmGenerationFailed case")
+      return
+    }
+    #expect(desc.contains("connection timeout"))
+  }
+
+  @Test func wrapChainCarriesLocalizedErrorText() {
+    enum ValidatorThrown: LocalizedError {
+      case missingSource(String)
+      var errorDescription: String? {
+        switch self {
+        case .missingSource(let name): return "source '\(name)' not found"
+        }
+      }
+    }
+    let inner = ValidatorThrown.missingSource("topics")
+    let wrapped = SimulationError.scenarioValidationFailed(
+      readableDescription(inner))
+    guard case .scenarioValidationFailed(let desc) = wrapped else {
+      Issue.record("expected .scenarioValidationFailed case")
+      return
+    }
+    #expect(desc.contains("source 'topics' not found"))
+    // Prefers LocalizedError.errorDescription over the raw enum form —
+    // guards against a regression to `"\(error)"` stringification.
+    #expect(!desc.contains("missingSource("))
+  }
+}

--- a/Pastura/PasturaTests/Engine/ErrorReadabilityTests.swift
+++ b/Pastura/PasturaTests/Engine/ErrorReadabilityTests.swift
@@ -52,6 +52,9 @@ struct ErrorReadabilityTests {
       return
     }
     #expect(desc.contains("connection timeout"))
+    // Regression guard: preferring LocalizedError.errorDescription strips the
+    // enum-case wrapper. Falling back to `"\(error)"` would leak it.
+    #expect(!desc.contains("generationFailed("))
   }
 
   @Test func wrapChainCarriesLocalizedErrorText() {

--- a/Pastura/PasturaTests/LLM/LLMErrorTests.swift
+++ b/Pastura/PasturaTests/LLM/LLMErrorTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 
 @testable import Pastura
@@ -65,5 +66,58 @@ struct LLMErrorTests {
   @Test func conformsToError() {
     let error: any Error = LLMError.notLoaded
     #expect(error is LLMError)
+  }
+
+  // MARK: - LocalizedError
+
+  @Test func conformsToLocalizedError() {
+    #expect((LLMError.notLoaded as Any) is LocalizedError)
+  }
+
+  @Test func loadFailedErrorDescription() {
+    let error = LLMError.loadFailed(description: "disk read error")
+    #expect(error.errorDescription?.contains("disk read error") == true)
+    #expect(error.errorDescription?.contains("load") == true)
+  }
+
+  @Test func generationFailedErrorDescription() {
+    let error = LLMError.generationFailed(description: "timeout")
+    #expect(error.errorDescription?.contains("timeout") == true)
+    #expect(error.errorDescription?.contains("Generation") == true)
+  }
+
+  @Test func notLoadedErrorDescription() {
+    let error = LLMError.notLoaded
+    #expect(error.errorDescription?.contains("not loaded") == true)
+  }
+
+  @Test func invalidResponseErrorDescriptionShortRaw() {
+    let raw = "bad json"
+    let error = LLMError.invalidResponse(raw: raw)
+    #expect(error.errorDescription?.contains("bad json") == true)
+    #expect(error.errorDescription?.contains("Invalid") == true)
+  }
+
+  @Test func invalidResponseErrorDescriptionTruncatesLongRaw() {
+    let raw = String(repeating: "x", count: 300)
+    let error = LLMError.invalidResponse(raw: raw)
+    let description = error.errorDescription ?? ""
+    #expect(description.contains("...") == true)
+    // Prefix of raw included in the description (first 200 chars), plus "..." = 203 chars max for the raw portion
+    let prefix200 = String(raw.prefix(200))
+    #expect(description.contains(prefix200) == true)
+  }
+
+  @Test func networkErrorErrorDescription() {
+    let error = LLMError.networkError(description: "connection refused")
+    #expect(error.errorDescription?.contains("connection refused") == true)
+    #expect(error.errorDescription?.contains("Network") == true)
+  }
+
+  @Test func suspendedErrorDescription() {
+    let error = LLMError.suspended
+    // The suspended case is cooperative, not fatal — description should reflect that
+    let description = error.errorDescription ?? ""
+    #expect(description.contains("suspend") == true || description.contains("retry") == true)
   }
 }

--- a/Pastura/PasturaTests/Models/SimulationErrorTests.swift
+++ b/Pastura/PasturaTests/Models/SimulationErrorTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+@Suite(.timeLimit(.minutes(1)))
+struct SimulationErrorTests {
+  // MARK: - LocalizedError conformance
+
+  @Test func conformsToLocalizedError() {
+    #expect((SimulationError.modelNotLoaded as Any) is LocalizedError)
+  }
+
+  // MARK: - errorDescription per case
+
+  @Test func scenarioValidationFailedDescription() {
+    let message = "invalid phase type"
+    let error = SimulationError.scenarioValidationFailed(message)
+    #expect(error.errorDescription?.contains("invalid phase type") ?? false)
+  }
+
+  @Test func llmGenerationFailedDescription() {
+    let error = SimulationError.llmGenerationFailed(description: "timeout")
+    #expect(error.errorDescription?.contains("generation failed") ?? false)
+    #expect(error.errorDescription?.contains("timeout") ?? false)
+  }
+
+  @Test func jsonParseFailedDescription() {
+    let raw = String(repeating: "x", count: 50)
+    let error = SimulationError.jsonParseFailed(raw: raw)
+    #expect(error.errorDescription?.contains("parse failed") ?? false)
+    #expect(error.errorDescription?.contains(raw) ?? false)
+  }
+
+  @Test func retriesExhaustedDescription() {
+    let error = SimulationError.retriesExhausted
+    #expect(error.errorDescription?.contains("retries") ?? false)
+  }
+
+  @Test func modelNotLoadedDescription() {
+    let error = SimulationError.modelNotLoaded
+    #expect(error.errorDescription?.contains("not loaded") ?? false)
+  }
+
+  @Test func cancelledDescription() {
+    let error = SimulationError.cancelled
+    #expect(error.errorDescription?.contains("cancelled") ?? false)
+  }
+
+  // MARK: - jsonParseFailed truncation
+
+  @Test func jsonParseFailedTruncatesLongRaw() {
+    let longRaw = String(repeating: "a", count: 300)
+    let error = SimulationError.jsonParseFailed(raw: longRaw)
+    let description = error.errorDescription ?? ""
+    // Truncated to 200 chars + "..."
+    #expect(description.contains("..."))
+    // The raw portion should not exceed 200 + "..." = 203 chars past the prefix
+    let prefix = "JSON parse failed: "
+    let rawPortion =
+      description.hasPrefix(prefix)
+      ? String(description.dropFirst(prefix.count))
+      : description
+    #expect(rawPortion.count <= 203)
+  }
+
+  @Test func jsonParseFailedDoesNotTruncateShortRaw() {
+    let shortRaw = String(repeating: "b", count: 100)
+    let error = SimulationError.jsonParseFailed(raw: shortRaw)
+    let description = error.errorDescription ?? ""
+    #expect(!description.contains("..."))
+    #expect(description.contains(shortRaw))
+  }
+}


### PR DESCRIPTION
## Summary
- Add `LocalizedError` conformance to 4 Pastura-owned error enums (`SimulationError`, `LLMError`, `DataError`, `GalleryServiceError`) so UI callsites reading `error.localizedDescription` surface meaningful text instead of `"(Pastura.XxxError error N.)"`.
- Replace `"\(error)"` stringification at 3 Engine wrap sites (`LLMCaller.swift:62`, `SimulationRunner.swift:151`, `SimulationRunner.swift:292` — the last missed in the original issue analysis; fire path for every LLM-phase handler throw) with a `readableDescription(_:)` helper that prefers `LocalizedError.errorDescription`.
- Integration test in `ScenarioEditorViewModel` proves the end-to-end fix: saving YAML whose `assign` phase references a missing `source:` key now surfaces `"source 'topics' not found"` in `validationErrors.first`, not the NSError fallback.
- Future i18n prep: every English literal in `errorDescription` wrapped in `String(localized: "...")` — adding a String Catalog later is a pure additive change.

Closes #138.

## Test plan
- [x] New `PasturaTests/Engine/ErrorReadabilityTests.swift` — helper + wrap-chain guards (including negative assertion against `"\(error)"` regression)
- [x] New `PasturaTests/Models/SimulationErrorTests.swift` — per-case `errorDescription` + 200-char truncation
- [x] Extended `PasturaTests/LLM/LLMErrorTests.swift` — per-case coverage including `.suspended`
- [x] New `PasturaTests/Data/DataErrorTests.swift` — per-case coverage
- [x] New `PasturaTests/App/Community/Gallery/GalleryServiceErrorTests.swift` — per-case coverage
- [x] `ScenarioEditorViewModelTests.saveSurfacesSourceNotFoundValidationMessage` — integration guard with explicit `!contains("SimulationError error")` regression check
- [x] Full unit suite green locally (99s)
- [x] `swiftlint lint --strict` clean
- [x] Manual QA: `bokete` Visual Editor → YAML mode → delete `topics:` → Save → Alert shows `"Phase 1 (assign): source 'topics' not found..."`
- [x] Manual QA: same flow with `word_wolf` deleting `words:` — same fix applies

## Commits
1. `♻️ refactor: helper for readable error descriptions at Engine wrap sites` (no-regress)
2. `✨ feat: add LocalizedError conformance to SimulationError`
3. `✨ feat: add LocalizedError conformance to LLMError`
4. `✨ feat: add LocalizedError conformance to DataError`
5. `✨ feat: add LocalizedError conformance to GalleryServiceError`
6. `🧪 test: integration guard for #138 missing-source message surfacing`
7. `🎨 style: appease SwiftLint on file+function length`
8. `✨ feat: format byte limit + tighten wrap-chain assertion` (code-reviewer follow-ups)

## Notes
- `ByteCountFormatter` used for `responseTooLarge` limit display (per code-review warning).
- Truncation (200 chars + `...`) applied to `jsonParseFailed` / `invalidResponse` raw snippets to prevent runaway Alert height + limit leakage of persona/scenario content on Share-export.
- `TurnOutputError` intentionally out of scope (never reaches UI directly — always wrapped via `LLMCaller`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)