### PR TITLE
♻️ refactor: keep reveal task alive across streaming tokens

### DIFF
--- a/Pastura/Pastura/Views/Components/AgentOutputRow.swift
+++ b/Pastura/Pastura/Views/Components/AgentOutputRow.swift
@@ -55,6 +55,11 @@ struct AgentOutputRow: View {
   @State private var showInnerThought = false
   @State private var visibleChars: Int = 0
   @State private var animationTask: Task<Void, Never>?
+  /// Monotonic counter bumped once per reveal-task creation. Used by
+  /// the task's `defer` to clear `animationTask` only when the task
+  /// completing (naturally or via cancel) is still the current one —
+  /// otherwise a stale completion could clobber a newer task's reference.
+  @State private var animationGeneration: Int = 0
 
   var body: some View {
     VStack(alignment: .leading, spacing: 6) {
@@ -199,28 +204,39 @@ struct AgentOutputRow: View {
 
     animationTask?.cancel()
     let delayNanos = UInt64(1_000_000_000.0 / cps)
-    let primaryLen = primaryText?.count ?? 0
-    // Full content string for character lookup. `showAllThoughts` may toggle
-    // mid-typing; `targetLength` controls the cap, but the underlying
-    // characters are always here. Streaming overrides are honoured via
-    // `resolvedThought` so punctuation pauses keep working while tokens
-    // arrive live.
-    let fullContent = (primaryText ?? "") + (resolvedThought ?? "")
+
+    // Bump generation so the task's `defer` can tell whether it is still
+    // the "current" task when it completes. Without this, a naturally
+    // finishing old task could null out `animationTask` after a newer
+    // task was assigned to it.
+    animationGeneration += 1
+    let myGeneration = animationGeneration
 
     onAnimatingChange?(true)
     animationTask = Task { @MainActor in
-      defer { onAnimatingChange?(false) }
-      // Re-read `targetLength` each tick so a mid-typing `showAllThoughts`
-      // flip to true extends the animation into the thought without restart.
+      defer {
+        onAnimatingChange?(false)
+        if animationGeneration == myGeneration { animationTask = nil }
+      }
+      // Re-read `targetLength`, `primaryText`, and `resolvedThought`
+      // every tick. `targetLength` covers `showAllThoughts` mid-typing
+      // flips. The other two cover live streaming growth: under
+      // ``streamingPrimary`` / ``streamingThought``, those values grow
+      // token-by-token, and a one-shot capture at task creation would
+      // leave punctuation lookup and the statement→thought boundary
+      // check running against stale text.
       while !Task.isCancelled && visibleChars < targetLength {
         try? await Task.sleep(nanoseconds: delayNanos)
         if Task.isCancelled { return }
         let newPosition = min(visibleChars + 1, targetLength)
         visibleChars = newPosition
 
+        let currentPrimaryLen = primaryText?.count ?? 0
+        let currentFullContent = (primaryText ?? "") + (resolvedThought ?? "")
+
         // Punctuation-aware pause: after revealing a sentence terminator or
         // comma, wait a little longer so the reader registers the beat.
-        let revealed = characterAt(index: newPosition - 1, in: fullContent)
+        let revealed = characterAt(index: newPosition - 1, in: currentFullContent)
         let extraMs = revealed.map(punctuationPauseMs(after:)) ?? 0
         if extraMs > 0 {
           try? await Task.sleep(nanoseconds: UInt64(extraMs) * 1_000_000)
@@ -230,7 +246,7 @@ struct AgentOutputRow: View {
         // Statement → thought boundary beat: when we've just finished the
         // primary text and there's thought still to type, insert a rhetorical
         // pause before switching to italic thought reveal.
-        if newPosition == primaryLen && primaryLen < targetLength {
+        if newPosition == currentPrimaryLen && currentPrimaryLen < targetLength {
           try? await Task.sleep(
             nanoseconds: UInt64(statementToThoughtPauseMs) * 1_000_000)
           if Task.isCancelled { return }
@@ -252,22 +268,31 @@ struct AgentOutputRow: View {
     visibleChars = targetLength
   }
 
-  /// React to a mid-stream primary / thought update. Cancels the current
-  /// reveal task (if any) and starts a fresh one, so the `fullContent`
-  /// capture inside the task always reflects the latest streaming
-  /// buffer. Skips restart entirely when target is already fully
-  /// revealed — the existing loop may have exited naturally and there
-  /// is nothing more to animate.
+  /// React to a mid-stream primary / thought update.
+  ///
+  /// The reveal task re-reads `targetLength`, `primaryText`, and
+  /// `resolvedThought` on every tick (see ``startAnimationIfNeeded``),
+  /// so a running task absorbs streaming growth without needing a
+  /// cancel/restart. The previous per-token cancel/restart was the
+  /// suspected cause of B5 thought-tail flicker: the outgoing task's
+  /// `defer` and the incoming task's initial `Task.sleep` opened a
+  /// sub-frame window where `visibleChars` did not advance.
+  ///
+  /// The gate mirrors ``handleShowAllThoughtsChange``. When the reveal
+  /// task finishes naturally between tokens (possible when `cps` exceeds
+  /// the stream rate), its `defer` clears `animationTask` via the
+  /// generation check, so the next growth tick falls into the restart
+  /// branch instead of freezing until commit.
   private func handleStreamTargetChange() {
     let target = targetLength
     if !shouldAnimate {
       visibleChars = target
       return
     }
-    if visibleChars < target {
-      animationTask?.cancel()
+    if visibleChars < target, animationTask == nil || animationTask?.isCancelled == true {
       startAnimationIfNeeded()
     }
+    // else: running task's loop picks up the new target on its next tick.
   }
 
   /// React to a mid-typing `showAllThoughts` flip on the latest row:


### PR DESCRIPTION
## Summary
- Replaces the per-token cancel+restart of the reveal `Task` in `AgentOutputRow` with alive-task gating. The running loop now absorbs streaming growth via per-tick re-reads of `primaryText` / `resolvedThought`.
- Adds a `@State` generation counter on the Task's `defer` so only the *current* task nils the reference — naturally-finished tasks no longer freeze the reveal at the next token (matters when `cps` exceeds stream rate, e.g. `.fast` + slow model).
- Addresses the B5 cancel-race hypothesis from #133. Kept as a refactor; confirmation of the flicker fix is deferred to PR#4 instrumentation.

## Scope & trade-offs
- Prefix changed from master tracker's `🐛 fix:` to `♻️ refactor:` (critic Axis 9 — structural simplification motivated by a hypothesized bug, not a confirmed fix).
- The per-tick re-read is load-bearing: the previous cancel+restart was accidentally refreshing `fullContent` / `primaryLen` captures on every token. The naive gate change alone would have broken punctuation pacing after the first token. Revised plan (shipped here) addresses this by moving captures inside the `while` loop.
- Generation counter protects `handleShowAllThoughtsChange` symmetrically — both call sites share the same restart gate.

## Manual QA checklist
- [x] `.normal` cps + long primary with `、 。 !` mix → punctuation pauses fire throughout the stream (not only in the first ~20 chars)
- [x] `.fast` cps + multi-sentence response → reveal continues until commit with no mid-stream freeze
- [x] ~~Past-results replay (`ResultDetailView`) unchanged visually~~ — N/A: `ResultDetailView` passes no `charsPerSecond` to `AgentOutputRow`, so `shouldAnimate == false` and none of the changed code paths execute. Confirmed by code-review; no visual QA needed.
- [x] Feature-flag rollback (`realtimeStreamingEnabled = false`) unchanged

## Known follow-up (out of scope, for master tracker)
Code-reviewer surfaced a **pre-existing** `onAnimatingChange` ordering race: when `startAnimationIfNeeded` cancels a prior task then immediately emits `onAnimatingChange?(true)`, the cancelled task's `defer` can later emit `onAnimatingChange?(false)` after the new task's `true`, briefly leaving the parent in a stale "false" state. Under the old per-token cancel/restart this race fired constantly (masked because the parent only cares about the final state). The new gate makes it rarer (only at loop natural completion between tokens), so behavior is strictly better here. If QA ever surfaces `latestRowIsAnimating` flakiness, the fix is to gate the defer's `onAnimatingChange?(false)` on the same generation check used for the nil-out.

## Test plan
- [x] Full unit suite passes (`xcodebuild test -skip-testing:PasturaUITests`, all tests green)
- [x] `swiftlint --strict` clean (only pre-existing `unused_import` config warning, unrelated)
- [x] Manual QA (checklist above) before merge

Refs #133 (PR#2 of the master tracker — continues the streaming-display redesign)

🤖 Generated with [Claude Code](https://claude.com/claude-code)