### PR TITLE
🐛 fix: scope onAnimatingChange defer to current task generation

### DIFF
--- a/Pastura/Pastura/Views/Components/AgentOutputRow.swift
+++ b/Pastura/Pastura/Views/Components/AgentOutputRow.swift
@@ -55,10 +55,14 @@ struct AgentOutputRow: View {
   @State private var showInnerThought = false
   @State private var visibleChars: Int = 0
   @State private var animationTask: Task<Void, Never>?
-  /// Monotonic counter bumped once per reveal-task creation. Used by
-  /// the task's `defer` to clear `animationTask` only when the task
-  /// completing (naturally or via cancel) is still the current one —
-  /// otherwise a stale completion could clobber a newer task's reference.
+  /// Monotonic counter bumped once per reveal-task creation. The task's
+  /// `defer` uses it to skip both the `animationTask` nil-out and the
+  /// `onAnimatingChange?(false)` notification when a newer task has
+  /// already replaced it — otherwise a stale completion could clobber
+  /// the reference, or flip the parent's animating-state back to `false`
+  /// while the newer task is still revealing (`SimulationView` gates
+  /// its thinking-indicator visibility and `scrollToBottom` on the
+  /// parent-side `latestRowIsAnimating` flag).
   @State private var animationGeneration: Int = 0
 
   var body: some View {
@@ -215,8 +219,12 @@ struct AgentOutputRow: View {
     onAnimatingChange?(true)
     animationTask = Task { @MainActor in
       defer {
-        onAnimatingChange?(false)
-        if animationGeneration == myGeneration { animationTask = nil }
+        // Gated on generation so a superseded task doesn't clobber the
+        // newer task's reference or animating-state signal.
+        if animationGeneration == myGeneration {
+          onAnimatingChange?(false)
+          animationTask = nil
+        }
       }
       // Re-read `targetLength`, `primaryText`, and `resolvedThought`
       // every tick. `targetLength` covers `showAllThoughts` mid-typing


### PR DESCRIPTION
## Summary
Moves `onAnimatingChange?(false)` inside the existing generation check in the reveal-task's `defer`. Prevents a superseded old task from flipping the parent's animating-state back to `false` after the new task has already signalled `true`.

Post-merge follow-up to #147, addressing code-reviewer Suggestion 1.

## Why now (not deferred to PR#4 instrumentation)
The earlier "observe first" suggestion was over-cautious. The race is deterministic per code-reading, fix cost is 1 statement moved, and measurement is valuable only when a fix is risky / ambiguous / costly — none apply here.

## Case table
| # | Scenario | Before | After |
|---|---|---|---|
| 1 | Natural finish, no successor | ✓ `false` | ✓ `false` (gen matches) |
| 2 | External cancel, no new task | ✓ `false` | ✓ `false` (gen matches) |
| 3 | **Cancel + immediate new task** | ❌ stale `false` after new `true` | ✓ suppressed |
| 4 | Natural finish + restart on next token | ✓ `false → true` | ✓ same |
| 5 | Target-shrink (`handleShowAllThoughtsChange`) | ✓ `false` | ✓ `false` (gen matches) |

Strictly better in #3, equivalent in others. No constructible breakage surface.

## Visible symptom if race fires (pre-fix)
`SimulationView`:
- Line 164: thinking-agents indicator visible when `!latestRowIsAnimating`
- Lines 193, 196-198: `scrollToBottom` fires on `!latestRowIsAnimating`

Stale `false` during reveal → 1-frame thinking-indicator flash and/or spurious scroll jump mid-reveal.

## Test plan
- [x] Full unit suite passes (`xcodebuild test -skip-testing:PasturaUITests`, all green)
- [x] `swiftlint --strict` clean (only pre-existing `unused_import` config warning)
- [x] Manual QA: run streaming simulation, watch for thinking-indicator flicker / spurious scroll during reveal

Refs #133 (post-PR#147 follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)