### PR TITLE
🛡️ docs: ADR-005 content safety architecture for App Store review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,5 +256,6 @@ Record architectural decisions in `docs/decisions/` as `ADR-NNN.md`.
 | `docs/decisions/ADR-002.md`           | llama.cpp interim LLM backend decision      |
 | `docs/decisions/ADR-003.md`           | BG execution (iOS 26 BGContinuedProcessingTask) |
 | `docs/decisions/ADR-004.md`           | Multi-platform strategy (Draft)             |
+| `docs/decisions/ADR-005.md`           | Content safety architecture (App Store review) |
 | `docs/specs/pastura-mvp-spec-v0_3.md` | MVP specification                                         |
 | `docs/prototype/among_them_prototype.py` | Python prototype (reference implementation) |

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -670,10 +670,12 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     thinkingAgents.remove(agent)
     // Match the filtering that `handleAgentOutput` applies at commit — the
     // in-flight snapshot is a user-visible display surface, so it must
-    // pass through ContentFilter for App Store compliance. A partial
-    // prefix of a blocked pattern still displays raw until the pattern
-    // completes (e.g. "fu" then "fuck" → "***"); that residual leakage
-    // is inherent to streaming and tracked in #133.
+    // pass through ContentFilter for App Store compliance (policy owner:
+    // ADR-005 §5). A partial prefix of a blocked pattern still displays
+    // raw until the pattern completes (e.g. "fu" then "fuck" → "***");
+    // that residual leakage is an accepted risk per ADR-005 §5.3, with
+    // the eventual mechanical fix (if any) riding on the streaming-
+    // display refactor tracked in #133.
     streamingSnapshot = StreamingSnapshot(
       agent: agent,
       primary: contentFilter.filter(primary),

--- a/docs/decisions/ADR-005.md
+++ b/docs/decisions/ADR-005.md
@@ -808,7 +808,159 @@ implementation.
 
 ## 8. LLM-App-Specific Review Risks
 
-*(Section stub — filled in subsequent commit.)*
+This section enumerates risks that surface specifically because Pastura
+is an LLM-driven app. The preceding sections establish policy; this
+section lists the review-time conversations the maintainer should be
+prepared to have and the Pastura posture for each.
+
+### 8.1 Jailbreak via user-authored input fields
+
+**Risk.** A reviewer authors a persona, goal, or phase prompt designed
+to coerce the LLM into producing policy-violating output (slurs,
+explicit content, harmful instructions). The app then renders that
+output, which could appear under Apple's "objectionable content" lens
+regardless of whether the user authored the prompt.
+
+**Posture.**
+
+- §4's `ScenarioContentValidator` is the primary defense, rejecting
+  clearly policy-violating input at authoring time.
+- §5's `ContentFilter` is the backstop, replacing matched patterns in
+  every display surface.
+- Neither layer eliminates the risk — both are static blocklists, and
+  a sufficiently clever prompt can elicit output that neither layer
+  catches. The age-rating strategy in §3 (13+ first, 16+ fallback)
+  absorbs the remaining uncertainty: Pastura is not claiming to be an
+  app where the LLM cannot produce any mature content.
+
+### 8.2 AI-generated content disclosure
+
+**Risk.** Apple reviewers (and users) encounter content the LLM
+generated and assume it was authored by the app vendor. Absent clear
+labelling, this is an "AI-generated content" transparency concern.
+
+**Posture.**
+
+- Simulation log surfaces are visually framed as simulation output,
+  not maintainer-authored content — the UI already makes the
+  per-agent role clear (`AgentOutputRow` shows agent name + phase
+  type).
+- Onboarding copy (updated as part of the implementation sub-issue for
+  §6 reporting mechanism) explicitly states that agents are LLM-driven
+  and outputs are generated on the fly.
+- Markdown export retains agent attribution so shared outputs do not
+  look like human-authored text divorced from their simulation
+  context.
+
+### 8.3 §2.5.2 model download (weights vs. executable code)
+
+**Risk.** [App Store Review Guidelines §2.5.2](https://developer.apple.com/app-store/review/guidelines/#software-requirements)
+(accessed 2026-04-19) prohibits apps from downloading "code which
+introduces or changes features or functionality". The guideline does
+not explicitly address ML model weights. The Gemma 4 E2B GGUF file
+(~3.1 GB) is downloaded at runtime on first use and is a plausible
+reviewer question.
+
+**Posture.**
+
+Pastura's position: **the GGUF file is data, not executable code.** The
+inference engine (llama.cpp via `mattt/llama.swift`) ships with the
+app binary; the downloaded weights parametrise an already-shipped
+feature rather than introducing a new one. Supporting points:
+
+- The app's inference capability is present in v1 of the binary. A
+  user who declines the download cannot run simulations, but the app
+  still renders fully (the Settings and past-results screens work
+  without weights).
+- The download path is explicit: users see a "Download AI model" flow
+  with size disclosure; it is not silent code injection.
+- This pattern is industry-standard for on-device LLM apps (AI Edge
+  Gallery, MLC-LLM, and others ship with the same model-as-data
+  framing and are on the App Store).
+- ADR-003 (BG execution) is the reference for how the app handles the
+  download and first-run model warm-up.
+
+If a reviewer objects, the escalation path is:
+
+1. Respond with the above framing in App Review Resolution Center.
+2. If rejected, ship a future release that bundles a smaller fallback
+   model inside the binary so the download becomes a quality upgrade
+   rather than a functionality unlock.
+
+### 8.4 On-device claim evidence
+
+**Risk.** Pastura's marketing and in-app copy emphasise "runs
+on-device, no cloud, your data stays local". A reviewer may ask for
+evidence — especially once Phase 2 adds the Cloud API feature that
+*does* send data off-device for specific opt-in flows.
+
+**Posture.**
+
+- ADR-003 (BG execution + on-device inference via llama.cpp) is the
+  canonical record of the on-device claim. The binary links
+  `llama.cpp` and does not require network access to run a
+  simulation.
+- When the Cloud API feature (ADR-006) ships, marketing language must
+  be updated to "runs on-device by default; optional cloud-assisted
+  features require explicit opt-in per §7". The on-device claim must
+  not be defended as unqualified once any cloud feature ships.
+- Network request auditing: the app's entitlements do include network
+  access (for Share Board gallery fetches, model download, and future
+  cloud features). Reviewers can observe this; Pastura's response is
+  to point at the specific feature each request serves, none of which
+  is hidden from the user.
+
+### 8.5 Dev-only backend exclusion (Ollama)
+
+**Policy.** Development-only LLM backends MUST NOT ship in App-Store-
+Connect-review-bound binaries. Concretely, `OllamaService` (used via
+the Ollama OpenAI-compatible endpoint when running in iOS Simulator)
+must be excluded from release archives — both as call sites and as
+linkable symbols.
+
+**Current state (disclaimer).** As of this ADR's merge, HEAD does
+*not* satisfy this policy in full:
+
+- `PasturaApp.swift:89` already gates `OllamaService` instantiation
+  behind `#if targetEnvironment(simulator)`, so release builds do not
+  *construct* Ollama at runtime.
+- `AppDependencies.swift:43` retains `OllamaService()` as a fallback
+  default in the production initialisation path, and
+  `OllamaService.swift` is unconditionally compiled. A release-
+  configuration archive therefore still links the Ollama symbols even
+  though nothing constructs them.
+
+This is a documented deviation permitted under §2.5's scope framing,
+conditional on **tracked remediation**: [Issue #148](https://github.com/tyabu12/pastura/issues/148)
+(filed 2026-04-19) owns the file-level `#if` wrap and the binary-
+level audit (`nm` / `otool`) required to satisfy the policy. #148 is
+a hard blocker for the first App Store submission — ADR-005 merging
+does not relax that blocker.
+
+**Verification method.** Per #148, release archives are audited with:
+
+```sh
+nm -a Pastura.app/Pastura | grep -i ollama   # expect: no output
+```
+
+If symbols remain after the wrap, the sub-issue captures the
+additional guard needed (e.g. `MockLLMService` / `LlamaCppService`
+references that pull Ollama types in unexpectedly).
+
+### 8.6 Non-risks (worth recording)
+
+Items that reviewers might ask about but that Pastura has a firm
+answer for:
+
+- **Encryption export compliance (ITSAppUsesNonExemptEncryption).**
+  Pastura uses only standard TLS (URLSession defaults) for gallery
+  fetches and model download; the on-device LLM performs no crypto.
+  `Info.plist` sets `ITSAppUsesNonExemptEncryption = NO`.
+- **IDFA / ATT.** Pastura does no tracking across apps or websites;
+  the App Tracking Transparency framework is not used and no IDFA is
+  collected.
+- **In-app purchase / subscription.** Phase 2 has no paid surface.
+  Future monetisation (Phase 3+) is out of scope for this ADR.
 
 ---
 

--- a/docs/decisions/ADR-005.md
+++ b/docs/decisions/ADR-005.md
@@ -469,7 +469,7 @@ Surfaces in scope today:
    `handleAgentOutput` in `SimulationViewModel`.
 2. In-flight streaming snapshot (`StreamingSnapshot.primary` and
    `.thought`) — filtered by `handleAgentOutputStream` at
-   `SimulationViewModel.swift:671-682` after PR #140.
+   `SimulationViewModel.swift:671-684` after PR #140.
 3. Markdown export (simulation result → Share Sheet) — filtered before
    serialisation.
 4. Past-results viewer — persists the already-filtered `parsedOutputJSON`
@@ -563,7 +563,7 @@ content safety. Any streaming-path change that ships under #133 MUST
 preserve the invariant stated in §5.1; it does not get to relax it in
 exchange for UX improvements.
 
-The in-code reference at `SimulationViewModel.swift:676` ("tracked in
+The in-code reference at `SimulationViewModel.swift:678` ("tracked in
 #133") describes the UX-side work that may *incidentally* reduce
 partial-prefix leakage if the refactor changes how tokens are buffered.
 That statement remains factually correct after this ADR, with the
@@ -995,9 +995,11 @@ Accepting this ADR has the following immediate consequences:
 Two changes to repo-level documentation ship with this ADR:
 
 - `CLAUDE.md` reference table gains a row for `ADR-005.md`.
-- `SimulationViewModel.swift:669-676` comment is re-cited in a
-  trailing commit to reflect the §5.5 ownership split (ADR-005 owns
-  the policy; #133 is UX refactor bound by the policy).
+- `SimulationViewModel.swift:671-678` streaming-snapshot filter comment
+  is re-cited in a trailing commit: it now anchors the filtering policy
+  to ADR-005 §5 (policy owner) and frames partial-prefix leakage as an
+  accepted risk per §5.3, while keeping the existing #133 reference as
+  the UX-refactor tracking pointer.
 
 ### 9.2 Sub-issue master index
 
@@ -1073,7 +1075,11 @@ accessed 2026-04-19 unless otherwise noted.
   `PrivacyInfo.xcprivacy` structure and required-reason APIs. Cited in
   §9.2 item 2.
 
-**Pastura internal.**
+**Pastura internal.** Line numbers below are accurate as of the ADR
+accept date (2026-04-19); unrelated refactors will shift them. Cited
+positions are the authoritative reference — when line numbers drift,
+grep for the cited identifier or section heading rather than trusting
+the suffix.
 
 - `CLAUDE.md` — Hard rules, dependency rules, ContentFilter location.
 - `docs/decisions/ADR-001.md` — Architecture overview; §Architecture
@@ -1087,7 +1093,7 @@ accessed 2026-04-19 unless otherwise noted.
   rules; cited in §6.1.
 - `Pastura/Pastura/App/ContentFilter.swift` — current filter
   implementation; cited in §5 and §4.6 (actor-isolation contrast).
-- `Pastura/Pastura/App/SimulationViewModel.swift:669-682` — streaming
+- `Pastura/Pastura/App/SimulationViewModel.swift:671-684` — streaming
   snapshot filter application; cited in §5.5.
 - `Pastura/Pastura/App/ImportViewModel.swift:23` and
   `Pastura/Pastura/App/ScenarioEditorViewModel.swift:160` — validator

--- a/docs/decisions/ADR-005.md
+++ b/docs/decisions/ADR-005.md
@@ -291,7 +291,162 @@ per-region action is required for the initial submission.
 
 ## 4. Shift-left Input Validation
 
-*(Section stub — filled in subsequent commit.)*
+### 4.1 Problem
+
+`ContentFilter` catches inappropriate content at *output* time — after the
+LLM has generated it, before UI display. Nothing today catches
+inappropriate content at *input* time: a user-authored scenario whose
+persona descriptions, goals, or phase prompts contain slurs or explicit
+material is accepted by `ScenarioLoader` and `Engine/ScenarioValidator`
+(both are correctness checks, not content checks) and flows straight into
+the LLM prompt.
+
+Phase 2's Visual Scenario Editor (#83) makes the gap more conspicuous —
+editing a scenario inline means the user can iterate on content that the
+app will then render back to the user, with only `ContentFilter` between
+them. App Store review is increasingly likely to surface a "what stops a
+user from prompting the LLM to produce X via the editor?" question.
+
+### 4.2 Location decision: `App/ScenarioContentValidator` (new)
+
+Introduce a new component **`ScenarioContentValidator`** at
+`Pastura/Pastura/App/ScenarioContentValidator.swift`, alongside the
+existing `ContentFilter.swift`.
+
+Rationale:
+
+- **Co-location with `ContentFilter`.** Both are content-safety policy
+  artifacts — one at input, one at output. Keeping them in the same
+  directory makes the filter/validator pair discoverable and ensures
+  future blocklist or locale changes touch one place.
+- **Consistent with ADR-001's layer model.** Filtering-layer logic
+  belongs in `App/` because `ContentFilter` is already there per the
+  architecture diagram (ADR-001 §Architecture Overview). `App/` depends
+  on everything, so bringing in `Models/Scenario` and `Models/Persona`
+  for field access is allowed.
+- **Name distinguished from `Engine/ScenarioValidator`.** The Engine
+  validator (`Pastura/Pastura/Engine/ScenarioValidator.swift`) performs
+  *structural* validation — phase references, branch shape,
+  score-expression grammar. Content validation is a separate concern
+  owned by `App/`, so the `ScenarioContentValidator` name avoids
+  collision and makes the separation visible at the file level.
+
+### 4.3 Target fields
+
+The validator runs over all user-authored text fields that will be
+rendered to the user or injected into an LLM prompt:
+
+| Model | Field | Rationale |
+|-------|-------|-----------|
+| `Scenario` | `name` | Displayed in lists, imports, share metadata |
+| `Scenario` | `description` | Displayed in scenario detail view |
+| `Persona` | `name` | Rendered in simulation log + prompt headers |
+| `Persona` | `description` | Injected into LLM system prompt — the highest-leverage field for jailbreak attempts |
+| `Phase` | `prompt` | LLM prompt template; may contain user-authored role instructions |
+| `Phase` | `template` (`summarize` phases) | Rendered in simulation output |
+| `Phase` | `condition` (`conditional` phases) | Identifier/value grammar — content risk is low but validator runs for uniformity |
+
+Fields that are *not* in scope: `outputSchema` keys (grammar-constrained),
+`options` for `choose` phases (short literal tokens; structural check
+suffices), `logic` / `source` / `target` (identifiers). Adding a field to
+this list later is additive and does not break existing validated
+scenarios (the validator is permissive if the wordlist does not match).
+
+### 4.4 Wordlist bundling strategy
+
+The validator matches against a curated blocklist bundled in
+`Pastura/Pastura/Resources/` (precise filename and format decided in the
+implementation sub-issue).
+
+**Selection criteria** (final list chosen in the sub-issue — not in this
+ADR):
+
+- English coverage: [LDNOOBW](https://github.com/LDNOOBW/List-of-Dirty-Naughty-Obscene-and-Otherwise-Bad-Words)
+  is one candidate — widely used, but weighted toward en-US profanity and
+  misses slang drift. Evaluated alongside alternatives (maintained en
+  corpora, curated Pastura-specific subset derived from
+  `ContentFilter.defaultPatterns`).
+- Japanese coverage: no canonical ja-equivalent to LDNOOBW exists. The
+  sub-issue will either curate a project-owned list seeded from the
+  existing `ContentFilter.defaultPatterns` (ja entries: 殺す, 死ね, etc.)
+  or adopt a third-party list once one is identified.
+- Both lists must be reviewed by the maintainer before bundling — wrapper
+  of a third-party list without audit is rejected (ja/en word lists have
+  historically included false positives for benign use).
+
+**Explicitly out of scope for this ADR:** which files, what serialisation
+format, whether lists are embedded in source or bundled as resources,
+case / diacritic normalisation details. All live in the sub-issue.
+
+### 4.5 Invocation points
+
+The validator runs in the ViewModel `validate()` methods, immediately
+after structural validation succeeds and before `isValid` is set:
+
+- `ImportViewModel.validate()` — on the YAML-import flow
+  (`Pastura/Pastura/App/ImportViewModel.swift:23`).
+- `ScenarioEditorViewModel.validate()` — on the Visual Editor / YAML-mode
+  save flow (`Pastura/Pastura/App/ScenarioEditorViewModel.swift:160`).
+
+Both existing `validate()` methods already accumulate `validationErrors:
+[String]`; content-validator findings append to the same array and use
+the same error-display surface. This means no new UI work — the
+existing error banner in `ImportView` / `ScenarioEditorView` already
+displays the messages.
+
+Sequence (for both ViewModels):
+
+1. Structural check via `ScenarioLoader` + `Engine/ScenarioValidator`.
+   If it fails, stop — content validator is not invoked.
+2. If structural check passes, run `ScenarioContentValidator` over the
+   target fields listed in §4.3. Findings produce user-facing messages
+   in `validationErrors`.
+3. Set `isValid` based on the combined result.
+
+### 4.6 Actor isolation
+
+`ScenarioContentValidator` is **MainActor-bound** (uses the project
+default `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, so no explicit
+annotation needed). It is invoked synchronously from MainActor
+ViewModels on user-input paths; there are no anticipated cross-actor
+callers.
+
+Contrast with `ContentFilter` (`Pastura/Pastura/App/ContentFilter.swift:11`)
+which is declared `nonisolated final class ContentFilter: Sendable` — the
+reason `ContentFilter` is `nonisolated + Sendable` is that it runs from
+background streaming tasks (in `SimulationViewModel` output paths), not
+because filtering-layer policy is inherently `nonisolated`. That decision
+does not transfer to `ScenarioContentValidator`: MainActor-only callers
+do not need Sendable conformance, and keeping it MainActor-bound matches
+its actual usage without paying the "what does background access look
+like?" cost.
+
+If a future feature needs to run the validator off-main (e.g. bulk
+import, background gallery scan), promoting it to `nonisolated +
+Sendable` is a local change at that time — the decision is recorded here
+so the sub-issue does not re-derive it.
+
+### 4.7 Failure surface
+
+Content-validator findings are user-facing. The error text must:
+
+- Identify the field (e.g. "Persona 'Alice' description contains a term
+  that is not allowed").
+- Not echo the matched term back into the UI.
+- Be localisable (wrap message literals in `String(localized:)` per the
+  project's error-localisation convention, see memory
+  `project_error_localization_prep.md`).
+
+The validator does not silently rewrite input — unlike `ContentFilter`,
+which replaces matches with `***`. At input time the user is authoring
+content and can fix it; a silent rewrite would hide what happened.
+
+### 4.8 Implementation tracking
+
+`ScenarioContentValidator` type creation, wordlist selection, wordlist
+bundling, and ViewModel wire-up are **implementation concerns** and live
+in a sub-issue filed after this ADR merges (see §9 master index).
+Deferred here to keep ADR-005 at the policy layer per §2.3.
 
 ---
 

--- a/docs/decisions/ADR-005.md
+++ b/docs/decisions/ADR-005.md
@@ -55,7 +55,7 @@ gaps. Each is owned by one of the sections below:
 
 | Gap | Owner |
 |-----|-------|
-| No explicit age-rating strategy (2025-01 questionnaire reorganisation unanswered) | §3 |
+| No explicit age-rating strategy (2025-07 questionnaire reorganisation unanswered) | §3 |
 | No shift-left input validation on user-authored persona / goals / phase prompts | §4 |
 | `ContentFilter` policy is undocumented — partial-prefix leakage during streaming has no stated allowance | §5 |
 | Share Board has no reporting mechanism, SLA, or reviewer identity disclosure | §6 |
@@ -84,13 +84,16 @@ revisited in this ADR.
 
 ### 2.1 Age rating tiers
 
-- **12+** — first-target rating for initial submission.
-- **17+** — fallback if Apple review rejects 12+ (trigger conditions in §3).
+Under Apple's 2025-07 age-rating reorganisation (five global tiers:
+4+ / 9+ / 13+ / 16+ / 18+), Pastura targets:
+
+- **13+** — first-target rating for initial submission.
+- **16+** — fallback if Apple review rejects 13+ (trigger conditions in §3).
 - **9+** — Phase 3 stretch goal, out of scope for this ADR.
 
-Comparison points: ChatGPT iOS = 13+, Claude iOS = 18+. Apple's 2025-01
-age-tier reorganisation is assumed to be in effect; §3 verifies the tier
-labels against the current App Store Connect questionnaire.
+Comparison points: ChatGPT iOS = 13+, Claude iOS = 18+. Tier labels and
+questionnaire mechanics are pinned in §3 against Apple's published
+definitions (accessed 2026-04-19).
 
 ### 2.2 UGC scope
 
@@ -137,7 +140,152 @@ with tracked remediation work.
 
 ## 3. Age Rating Strategy
 
-*(Section stub — filled in subsequent commit.)*
+### 3.1 Context
+
+Apple's age-rating system was reorganised on **2025-07-24** (developer
+deadline for updated questionnaire responses: **2026-01-31**). The five
+global tiers are **4+ / 9+ / 13+ / 16+ / 18+**; regional variations exist
+(Korea: 12+ / 15+ / 19+; Australia: 15+ / R18+). Global tier labels are
+used throughout this ADR.
+
+Apple's announcement flags AI features explicitly:
+
+> "You must consider how all app features, including AI assistants and
+> chatbot functionality, impact the frequency of sensitive content
+> appearing within your app to make sure it receives the appropriate
+> rating."
+>
+> — [Updated age ratings in App Store Connect, 2025-07-24](https://developer.apple.com/news/?id=ks775ehf)
+> (accessed 2026-04-19)
+
+For Pastura this means the questionnaire is not answered from *current
+scenarios only* — it must account for realistic LLM output under the
+blocklist Pastura ships (`ContentFilter.defaultPatterns` and the future
+input-validator wordlist, §4).
+
+### 3.2 Target: 13+
+
+First-target rating on submission is **13+**.
+
+Rationale:
+
+- Pastura's LLM generates role-play dialog covering mild conflict
+  (social-deduction and dilemma scenarios). Even with `ContentFilter`
+  blocking profanity and slurs, "infrequent mature or suggestive themes"
+  is the honest frequency for an AI app whose output is not pinned to a
+  fixed script.
+- Bundled presets (Prisoner's Dilemma, Word Wolf) include elimination /
+  voting-off mechanics that map to "infrequent cartoon or fantasy
+  violence" at most.
+- Claiming lower than 13+ (e.g. 9+) requires answering "None" to every
+  13+-trigger category, including "infrequent sexual content or nudity"
+  and "infrequent realistic violence". For a general-purpose LLM wrapper
+  those claims are fragile — one Apple reviewer hitting a user-authored
+  edge-case scenario the blocklist does not cover would invalidate the
+  claim and force re-submission.
+- 13+ matches peer LLM apps (ChatGPT iOS = 13+). Claude iOS sits at 18+
+  but positions itself for adult-oriented workflows Pastura does not
+  pursue.
+
+### 3.3 Fallback: 16+
+
+Fallback rating if Apple rejects 13+ at review: **16+**.
+
+Under the 2025-07 system, 16+ is triggered by any of:
+
+| 16+ trigger | Pastura relevance |
+|-------------|-------------------|
+| Unrestricted web access | Not applicable — Pastura has no embedded browser; LLM generation is not "unrestricted web access" per Apple's definition. Planned Cloud API (ADR-006) is a specific-endpoint API call, not browsing. |
+| Frequent medical or treatment information | Not applicable unless users systematically author medical scenarios — theoretically possible but not the product's stated use. |
+| Frequent mature or suggestive themes | **The realistic fallback trigger.** If reviewers encounter scenarios that generate repeated suggestive content despite `ContentFilter`, the frequency shifts from "infrequent" to "frequent". |
+
+**Fallback trigger conditions** (any one is sufficient to fire the
+fallback):
+
+1. Apple reviewer reports that bundled presets or the scenario-template
+   library generate suggestive content more than infrequently.
+2. Apple classifies user-authored scenarios as a vector that elevates the
+   effective frequency of sensitive-content categories.
+3. A tester (TestFlight or public App Review) submits an output example
+   that we cannot defensibly classify as "infrequent".
+
+**Fallback impact summary** (categories only — specific keys and values
+belong to implementation and live in the tracking sub-issue if the
+fallback fires):
+
+- App Store Connect questionnaire: re-answer the affected category as
+  "Frequent" (mature or suggestive themes primarily).
+- Marketing metadata: update the age-rating display on the listing.
+- Onboarding copy: strengthen the "what this app generates" disclosure
+  text so users opt into the experience knowingly.
+- Info.plist / entitlements: typically no change; age rating is an App
+  Store Connect concern, not a bundle concern.
+- `ContentFilter.defaultPatterns`: consider tightening *only if* the
+  16+ bump was driven by a specific pattern class; 16+ acceptance does
+  not *require* filter changes.
+
+No fallback sub-issue is pre-filed because 13+ is the intended submission
+tier; a fallback-handling sub-issue will be opened only if a reviewer
+objection materialises.
+
+### 3.4 Stretch: 9+ (Phase 3)
+
+9+ is a stretch target that would require:
+
+- A substantially stronger input validator (§4) precluding scenario
+  topics likely to produce 13+-trigger content.
+- Possibly a curated-only scenario library with no user YAML import,
+  which conflicts with the Phase 2 Visual Scenario Editor product bet.
+
+Phase 3 will reconsider 9+ if user research shows a younger audience is
+valuable enough to trade scenario-authoring flexibility. Out of scope for
+this ADR.
+
+### 3.5 Questionnaire answers (first submission, 13+ target)
+
+Answers Pastura will submit under the 2025-07 questionnaire for the 13+
+target. Rows labelled **AI-inclusive** incorporate expected LLM output
+frequency per the Apple guidance quoted in §3.1.
+
+| Category | Sub-item | Answer |
+|----------|----------|--------|
+| **In-app Controls** | Parental Controls | None |
+| | Age Assurance | None |
+| **Capabilities** | Unrestricted Web Access | No |
+| | User-Generated Content | No (curated Share Board; user-authored scenarios stay local to the device) |
+| | Messaging and Chat | No |
+| | Advertising | No |
+| **Mature Themes** | Profanity / Crude Humor | **Infrequent** (AI-inclusive — `ContentFilter` catches the starter blocklist; residual slang may slip) |
+| | Horror / Fear Themes | None |
+| | Alcohol / Tobacco / Drugs | None |
+| **Medical or Wellness** | Medical or Treatment Information | None |
+| | Health / Wellness Topics | None |
+| **Sexuality or Nudity** | Mature or Suggestive Themes | **Infrequent** (AI-inclusive — user-authored scenarios may touch on mature themes) |
+| | Sexual Content or Nudity | None |
+| | Graphic Sexual Content and Nudity | None |
+| **Violence** | Cartoon or Fantasy Violence | **Infrequent** (elimination / voting-off in bundled presets) |
+| | Realistic Violence | None |
+| | Prolonged Graphic or Sadistic Realistic Violence | None |
+| | Guns or Other Weapons | None |
+| **Chance-Based** | Gambling | None |
+| | Simulated Gambling | None |
+| | Contests | None |
+| | Loot Boxes | None |
+
+The three "Infrequent" answers (profanity, mature/suggestive themes,
+cartoon violence) combine to a **13+** rating under Apple's current
+calculator; no 16+ or 18+ trigger fires.
+
+### 3.6 Regional variations
+
+For Japan (Pastura's primary market in Phase 2), global tier labels
+apply. For regions with their own tables, Apple maps automatically:
+
+- Korea: 13+ → 15+
+- Australia: 16+ → 15+ (fallback label only; does not affect 13+ target)
+
+These are surfaced in App Store Connect at submission time; no manual
+per-region action is required for the initial submission.
 
 ---
 

--- a/docs/decisions/ADR-005.md
+++ b/docs/decisions/ADR-005.md
@@ -1,0 +1,176 @@
+# ADR-005: Content Safety Architecture for App Store Review
+
+> **Status:** Accepted
+> **Date:** 2026-04-19
+> **Context:** Phase 2 Go criteria include clearing Apple's full App Store review
+> (not only TestFlight Beta Review). Pastura's on-device LLM architecture raises
+> content-safety questions that Apple's review process is known to probe:
+> age-tier positioning, user-input sanitisation, output filtering, UGC reporting
+> flows, and third-party AI disclosure. This ADR pins the decisions needed to
+> enter review with a defensible posture, and scopes which details are deferred
+> to ADR-006 (Cloud API) and sub-issues.
+
+---
+
+## Summary
+
+This ADR establishes Pastura's content-safety architecture for App Store
+submission. It covers six decision areas — age rating strategy, shift-left
+input validation, defense-in-depth output filtering, Share Board reporting,
+Cloud API disclosure/consent principles, and LLM-app-specific review risks —
+and registers submission-blocking follow-up work in §9.
+
+The ADR intentionally stays at the **policy layer**: concrete implementation
+(the `ScenarioContentValidator` type, wordlist contents, `#if` build
+conditions, `PrivacyInfo.xcprivacy` contents, consent-screen wording) lives
+in sub-issues and, for Cloud API specifics, ADR-006.
+
+---
+
+## 1. Context
+
+### 1.1 Current state
+
+Pastura's content-safety surface as of 2026-04 consists of:
+
+- **Output filtering** — `ContentFilter` (`Pastura/Pastura/App/ContentFilter.swift`),
+  applied between Engine output and UI display. PR #140 closed a
+  streaming-snapshot filter-bypass gap, so in-flight streamed text now passes
+  through the filter before reaching the display surface.
+- **Structural scenario validation** — `Engine/ScenarioValidator` rejects
+  malformed YAML (phase references, score expressions). This is a correctness
+  check, not a content-safety check.
+- **Call-site gating of dev-only backend** — `OllamaService` is instantiated
+  only inside `#if targetEnvironment(simulator)` at `PasturaApp.swift:89`,
+  but the type itself is unconditionally compiled and linked into release
+  builds (see §8 and sub-issue #148).
+- **Share Board** — read-only curated gallery (see `docs/gallery/README.md`).
+  All visible scenarios are authored or audited by the project maintainer;
+  there is currently no user-to-user submission flow.
+
+### 1.2 Gaps
+
+Relative to App Store full-review expectations, the current state has six
+gaps. Each is owned by one of the sections below:
+
+| Gap | Owner |
+|-----|-------|
+| No explicit age-rating strategy (2025-01 questionnaire reorganisation unanswered) | §3 |
+| No shift-left input validation on user-authored persona / goals / phase prompts | §4 |
+| `ContentFilter` policy is undocumented — partial-prefix leakage during streaming has no stated allowance | §5 |
+| Share Board has no reporting mechanism, SLA, or reviewer identity disclosure | §6 |
+| Planned Cloud API (`docs/ROADMAP.md` Phase 2) has no disclosure/consent principles committed | §7 |
+| `PrivacyInfo.xcprivacy` does not exist (Apple hard requirement since 2024-05) | §9 |
+
+### 1.3 Why decide now
+
+The full-review clock is bounded by Phase 2 exit. Several of these decisions
+are load-bearing for in-flight Phase 2 work:
+
+- Cloud API scenario generation (ADR-006, planned) needs consent-architecture
+  principles *before* implementation to avoid rework.
+- Visual Scenario Editor (shipped #83) will need `ScenarioContentValidator`
+  wired in — design settled here so the sub-issue has a clean target.
+- `PrivacyInfo.xcprivacy` blocks every TestFlight archive upload on iOS 17+;
+  it cannot wait until submission week.
+
+---
+
+## 2. Pre-decisions and Scope
+
+The following were settled before ADR drafting (Issue #145 discussion and
+prior critic review) and are recorded here as constraints, not decisions
+revisited in this ADR.
+
+### 2.1 Age rating tiers
+
+- **12+** — first-target rating for initial submission.
+- **17+** — fallback if Apple review rejects 12+ (trigger conditions in §3).
+- **9+** — Phase 3 stretch goal, out of scope for this ADR.
+
+Comparison points: ChatGPT iOS = 13+, Claude iOS = 18+. Apple's 2025-01
+age-tier reorganisation is assumed to be in effect; §3 verifies the tier
+labels against the current App Store Connect questionnaire.
+
+### 2.2 UGC scope
+
+Share Board is **curated-only** for Phase 2. All scenarios originate from the
+maintainer, not from end users. User-to-user scenario sharing is deferred to
+a later ADR if demand materialises.
+
+This scoping narrows Apple Review Guidelines §1.2 (User-Generated Content)
+applicability — see §6.
+
+### 2.3 ADR-005 vs ADR-006 split
+
+This ADR (ADR-005) commits to **principles** for Cloud API disclosure and
+consent. ADR-006 (forthcoming) will commit to **implementation specifics**:
+provider-specific disclosure wording, BYOK vs maintainer-provided keys,
+consent modal UI, retry / rate-limit policy.
+
+ADR-005's principles are intentionally general enough to survive a provider
+swap (Claude ↔ Gemini ↔ future); ADR-006 may refine or extend but must not
+contradict the principles in §7.
+
+### 2.4 Ollama dev-backend policy stance
+
+`OllamaService` is a developer-only backend used via Ollama's
+OpenAI-compatible endpoint when running in iOS Simulator. Its inclusion in
+release binaries is a compliance risk (unused network-capable code paths in
+a prod-bound archive). Policy is stated in §8; current-state disclaimer and
+remediation plan are in §8 / §9.
+
+### 2.5 ADR scope framing
+
+ADR-005 decisions **bind App-Store-Connect-review-bound builds** — that is,
+any archive submitted to TestFlight public testing or App Store full review.
+Development builds, simulator builds, and pre-review internal TestFlight
+lanes may deviate from these decisions **only when the deviation is tracked
+via a named sub-issue with a `blocker-for: submission` designation in §9's
+master index**.
+
+This framing distinguishes "the policy is X" (normative) from "HEAD
+currently does Y" (descriptive), and lets Accepted-status decisions coexist
+with tracked remediation work.
+
+---
+
+## 3. Age Rating Strategy
+
+*(Section stub — filled in subsequent commit.)*
+
+---
+
+## 4. Shift-left Input Validation
+
+*(Section stub — filled in subsequent commit.)*
+
+---
+
+## 5. Defense-in-depth Output Filter Policy
+
+*(Section stub — filled in subsequent commit.)*
+
+---
+
+## 6. Share Board Report Mechanism
+
+*(Section stub — filled in subsequent commit.)*
+
+---
+
+## 7. Cloud API Disclosure / Consent Principles
+
+*(Section stub — filled in subsequent commit.)*
+
+---
+
+## 8. LLM-App-Specific Review Risks
+
+*(Section stub — filled in subsequent commit.)*
+
+---
+
+## 9. Consequences, Open Questions, References
+
+*(Section stub — filled in subsequent commit.)*

--- a/docs/decisions/ADR-005.md
+++ b/docs/decisions/ADR-005.md
@@ -452,7 +452,132 @@ Deferred here to keep ADR-005 at the policy layer per §2.3.
 
 ## 5. Defense-in-depth Output Filter Policy
 
-*(Section stub — filled in subsequent commit.)*
+§4's input validator reduces the *probability* of policy-violating content
+entering the LLM. It cannot eliminate it — LLMs generate outputs
+unconstrained by input, and user-authored prompts can circumvent any
+static blocklist. The output filter is the defense-in-depth layer that
+catches whatever the input layer misses.
+
+### 5.1 Policy
+
+**Every user-visible display surface of LLM output MUST pass through
+`ContentFilter` before rendering.**
+
+Surfaces in scope today:
+
+1. Committed `AgentOutputRow` / turn records — filtered at commit time by
+   `handleAgentOutput` in `SimulationViewModel`.
+2. In-flight streaming snapshot (`StreamingSnapshot.primary` and
+   `.thought`) — filtered by `handleAgentOutputStream` at
+   `SimulationViewModel.swift:671-682` after PR #140.
+3. Markdown export (simulation result → Share Sheet) — filtered before
+   serialisation.
+4. Past-results viewer — persists the already-filtered `parsedOutputJSON`
+   from `TurnRecord`; no additional filtering required at read time.
+
+Surfaces **intentionally not filtered**:
+
+- `TurnRecord.rawOutput` — the unfiltered LLM response, preserved for
+  debugging and future blocklist tuning. Not rendered in the UI in
+  release builds; debug-mode visibility is an App-Store-review risk
+  tracked under §8.
+
+The policy is binding regardless of build configuration (debug /
+TestFlight / App Store) — there is no configuration flag that disables
+the filter on a display surface.
+
+### 5.2 Current implementation
+
+As of PR #140 (merged 2026-04-19), `ContentFilter` is applied on the
+streaming path (surface 2 above) — closing a regression introduced by
+PR #132 where in-flight snapshots bypassed the filter. Before PR #140,
+blocked patterns were visible during streaming and replaced only at
+commit; the policy in §5.1 is the commitment this ADR makes to keep that
+coverage intact going forward.
+
+The filter's blocklist (`ContentFilter.defaultPatterns` in
+`Pastura/Pastura/App/ContentFilter.swift:55-64`) is intentionally small
+— a starter set tuned for the initial submission. §9 registers blocklist
+expansion as a follow-up concern; policy does not prescribe the list
+contents.
+
+### 5.3 Partial-prefix leakage
+
+During streaming, the filter matches only on completed patterns. If a
+user's LLM starts emitting "f… u… c… k", the characters display raw as
+they stream and are replaced with `***` only once the full pattern
+completes in a single snapshot update. This residual **partial-prefix
+leakage** is a known consequence of:
+
+- Per-token streaming granularity (the snapshot is updated on every
+  token, so the filter sees a mid-pattern prefix).
+- Japanese-corpus requirements that reject word-boundary buffering as a
+  mitigation (Issue #133 invariant #1 — breaking on word boundaries
+  destroys the streaming UX in languages without inter-word whitespace).
+
+**Pastura accepts partial-prefix leakage as a residual risk.** The
+rationale:
+
+- The leakage window is ~100-500 ms per occurrence (time from first
+  matching prefix character to full-pattern completion).
+- The full pattern is never committed or persisted — committed
+  `AgentOutputRow` + `TurnRecord.parsedOutputJSON` go through the filter
+  before storage.
+- Mitigating the leakage fully requires either language-aware tokenised
+  buffering or a classifier-based filter; both are out of scope for
+  Phase 2 (Foundation Models framework etc. are Phase 3 considerations,
+  see Issue #145 body).
+
+### 5.4 Reconsideration triggers
+
+The partial-prefix acceptance is **not permanent**. Any of the following
+re-opens the decision:
+
+1. **Apple App Review citation.** If a reviewer flags a specific
+   observed leakage on a submission, the acceptance is revoked and a
+   mitigation sub-issue is filed before the next submission.
+2. **User report via the Share Board reporting channel (§6).** If a
+   report surfaces a concrete example, the acceptance is revisited and
+   the blocklist / streaming behaviour adjusted.
+3. **Availability of an on-device classifier suitable for streaming.**
+   When Foundation Models framework or equivalent ships with latency /
+   memory suitable for per-token filtering, the trade-off changes and a
+   new decision is made.
+
+Reconsideration produces either an updated acceptance (with the new
+trigger recorded) or a mitigation sub-issue. Silent continuation of the
+current posture after a trigger fires is not acceptable.
+
+### 5.5 Invariant ownership vs #133
+
+ADR-005 **is the owner** of the filtering-policy invariant: every
+user-visible display surface of LLM output passes through
+`ContentFilter`. This ownership is explicit so that future changes to
+the streaming path, the output export pipeline, or the past-results
+viewer have a single document to check against.
+
+**Issue #133 is not the compliance owner.** #133 is a streaming-display
+UX refactor ("redesign streaming display — address line-break jitter +
+clean up pseudo-typing coupling") — its motivation is UX quality, not
+content safety. Any streaming-path change that ships under #133 MUST
+preserve the invariant stated in §5.1; it does not get to relax it in
+exchange for UX improvements.
+
+The in-code reference at `SimulationViewModel.swift:676` ("tracked in
+#133") describes the UX-side work that may *incidentally* reduce
+partial-prefix leakage if the refactor changes how tokens are buffered.
+That statement remains factually correct after this ADR, with the
+ownership clarified: leakage *acceptance* is ADR-005's decision; the
+*eventual mechanical fix* (if any) rides along with #133's refactor.
+
+### 5.6 Out of scope
+
+- `TurnRecord.rawOutput` visibility in debug mode — owned by §8.
+- Blocklist contents and expansion methodology — tracked as a follow-up
+  in §9.
+- Classifier-based filter design — Phase 3+, not in this ADR.
+- Post-filter telemetry (what does the filter catch in practice) —
+  considered but deferred; no telemetry sub-issue is pre-filed.
 
 ---
 

--- a/docs/decisions/ADR-005.md
+++ b/docs/decisions/ADR-005.md
@@ -583,7 +583,110 @@ ownership clarified: leakage *acceptance* is ADR-005's decision; the
 
 ## 6. Share Board Report Mechanism
 
-*(Section stub — filled in subsequent commit.)*
+### 6.1 Scope of App Store Review §1.2
+
+[App Store Review Guidelines §1.2](https://developer.apple.com/app-store/review/guidelines/)
+(User-Generated Content, accessed 2026-04-19) requires apps carrying UGC to
+provide:
+
+> - A method for filtering objectionable material from being posted to the app
+> - A mechanism to report offensive content and timely responses to concerns
+> - The ability to block abusive users from the service
+> - Published contact information so users can easily reach you
+
+**Share Board is curated, not user-generated.** Per
+`docs/gallery/README.md`, gallery content is fetched from a repository
+only the maintainer can push to; there is no user-to-user submission
+flow in Phase 2. Strict §1.2 therefore does not apply — §1.2 governs
+*user-submitted* content, and §1.2.1 Creator Content (the closest
+adjacent clause) covers apps where a creator community posts into the
+app, which Pastura also does not have.
+
+That said, the **defensive posture** for full App Store review is to
+provide a reporting mechanism anyway:
+
+- Reviewers may not distinguish "curated gallery" from "UGC marketplace"
+  on first pass and will look for a report button.
+- Curated content can still be wrong (stale, unintentionally offensive,
+  targeted at a real person) — users should have a recourse.
+- §1.5 "Contact information" applies unconditionally regardless of §1.2
+  applicability; providing a report path satisfies both.
+
+### 6.2 Mechanism
+
+The Share Board reporting mechanism is a **pseudonymous contact
+channel**. Two acceptable implementations (the final choice is a UI
+sub-issue, either is permitted by this ADR):
+
+- **In-app form → GitHub issue** (preferred). The report button in
+  Share Board opens a sheet that collects scenario id + user-supplied
+  reason, and files a public GitHub issue via a pre-seeded URL (no
+  authentication required; users need a GitHub account to submit).
+- **Project email alias**. A dedicated pseudonymous address (e.g.
+  `pastura-report@<project-domain>`) routed to the maintainer. An
+  in-app "Copy report email" button + `mailto:` link provides the
+  surface.
+
+Either surface is acceptable for ADR-005. What is **NOT** acceptable:
+
+- The maintainer's personal email (`tyabu1212@gmail.com` or similar).
+  Published personal email creates a long-term disclosure Pastura cannot
+  retract.
+- A contact link that requires the reporter to have a paid service
+  account (e.g. Linear, Notion). GitHub issue filing is the highest bar
+  acceptable.
+
+### 6.3 SLA
+
+**Target: first response within 48 hours of report receipt, best-effort.**
+
+The 48-hour target is not a guarantee:
+
+- Apple's §1.2 wording ("timely responses") does not pin a specific SLA;
+  48 hours is Pastura's internal commitment, chosen to be ambitious but
+  defensible for a solo-maintainer app.
+- When the maintainer is unavailable (travel, illness, personal leave),
+  a **vacation-mode auto-acknowledgement** is set on the reporting
+  channel indicating the expected response window. The auto-ack is
+  mandatory before any planned absence longer than 72 hours.
+- If a report clearly indicates policy-violating content, the gallery
+  entry is **hidden immediately** (removed from `gallery.json` in a
+  hot-fix commit) pending triage; full triage and response follow
+  within 48 hours where possible.
+
+Where a 48-hour first response cannot be met, the auto-acknowledgement
++ clearly-documented response window satisfies the "timely" standard.
+
+### 6.4 Reviewer identity
+
+The report channel discloses **who acts on reports** without exposing
+the maintainer's personal identity beyond what is already public
+elsewhere:
+
+- Public posture: "Reports are triaged by the Pastura maintainer"
+  (pseudonymous acknowledgement is sufficient per §1.2, which does not
+  require legal-name disclosure).
+- Already-public linkage: the maintainer's GitHub handle (`tyabu12`) is
+  visible on every commit in this repository; this is acknowledged as
+  the public identity and no additional disclosure is added.
+- Legal-name disclosure (e.g. business contact on the App Store
+  listing): handled at the App Store Connect level under the developer
+  account profile, not in the in-app report UI.
+
+### 6.5 Blocking abusive users
+
+§1.2's "ability to block abusive users" requirement does not apply to a
+curated-only Share Board — there are no users to block because users do
+not submit. If Phase 3 introduces user-to-user scenario sharing, this
+requirement becomes live and a new ADR revisits the reporting surface.
+
+### 6.6 Implementation tracking
+
+Concrete UI (report sheet, `mailto:` copy, auto-ack template), the
+chosen email alias, and the GitHub issue template live in a
+post-ADR-merge sub-issue (see §9 master index). This ADR commits to:
+pseudonymous channel, 48h best-effort SLA, reviewer identity as above,
+vacation-mode auto-ack.
 
 ---
 

--- a/docs/decisions/ADR-005.md
+++ b/docs/decisions/ADR-005.md
@@ -692,7 +692,117 @@ vacation-mode auto-ack.
 
 ## 7. Cloud API Disclosure / Consent Principles
 
-*(Section stub — filled in subsequent commit.)*
+### 7.1 Scope
+
+This section commits principles for the planned Cloud API feature
+(`docs/ROADMAP.md` Phase 2 — in-app scenario generation that sends
+natural-language input to Claude or Gemini and receives YAML back).
+Implementation specifics — concrete consent-screen wording, BYOK vs
+maintainer-provided keys, retry / rate-limit policy, which provider to
+ship with first — live in **ADR-006** (forthcoming). This ADR's
+principles are load-bearing: ADR-006 may refine or extend but must not
+contradict them.
+
+### 7.2 Apple and regulatory baseline
+
+[App Store Review Guidelines §5.1.2(i)](https://developer.apple.com/app-store/review/guidelines/#data-collection-and-storage)
+(accessed 2026-04-19) states:
+
+> "Unless otherwise permitted by law, you may not use, transmit, or
+> share someone's personal data without first obtaining their
+> permission. (...) **You must clearly disclose where personal data
+> will be shared with third parties, including with third-party AI,
+> and obtain explicit permission before doing so.**"
+
+The "third-party AI" language binds any feature that sends
+user-authored text to an external LLM. GDPR Art. 13 (information to be
+provided at collection) and Japan APPI Art. 21 (identification of data
+recipients) attach at the same surface — disclosure must identify the
+recipient, not just "a third party".
+
+The principles below operationalise these requirements.
+
+### 7.3 Two-layer model
+
+Pastura structures Cloud API disclosure and consent as **two distinct
+layers** with different constraints:
+
+#### UX layer (provider-agnostic)
+
+The user-facing *controls* — entry-point buttons, settings toggles,
+feature names — do not mention specific providers. Three principles:
+
+1. **Per-feature explicit consent.** Each feature that sends user-
+   authored text to an external LLM requires its own opt-in. Consent
+   is not global; enabling "scenario generation" does not auto-enable
+   any future cloud-assisted feature. New cloud features ship
+   opt-in-off by default.
+2. **Revocable via Settings.** Every consent granted via a feature
+   surface is revocable from a unified Settings surface. Revocation
+   takes effect immediately — pending in-flight requests MAY complete
+   but no new request is issued after revocation.
+3. **Component reuse / button copy neutral.** Feature entry points
+   use provider-neutral language ("Generate with AI", "Enable AI
+   scenario generation"). This is a reuse and churn-reduction concern
+   — it lets Pastura swap providers (Claude ↔ Gemini ↔ future)
+   without re-laying-out the UI for every touchpoint. It does **not**
+   legally displace provider identification.
+
+#### Disclosure layer (provider-explicit)
+
+The user-facing *disclosures* — consent screen copy, Privacy Manifest,
+App Privacy Details, privacy policy — **MUST name the current
+provider**. Required on every surface where a legally-binding
+disclosure attaches:
+
+- **Consent screen body** shown before first use: identifies the
+  specific provider (e.g. "Your prompt will be sent to Anthropic
+  (Claude) for processing. Anthropic processes the request under
+  their privacy policy: <link>.").
+- **Privacy Manifest** (`PrivacyInfo.xcprivacy`, tracked in §9): lists
+  the third-party destination under `NSPrivacyCollectedDataTypes` or
+  the appropriate category.
+- **App Privacy Details** ("nutrition label" in App Store Connect):
+  names the third-party recipient under data-collection disclosures.
+- **In-app privacy policy** (or linked URL): identifies the provider
+  with enough specificity to satisfy GDPR Art. 13 and APPI Art. 21.
+
+When the shipped provider changes, all four disclosure surfaces are
+updated in the same release as the provider swap — this is a hard
+release gate for any provider change, not a follow-up.
+
+### 7.4 How the layers interact
+
+The two layers are **not** in tension. Button copy neutrality in the
+UX layer is a code-organisation and consistency concern; legally
+required disclosures live entirely in the disclosure layer. A user
+exploring a Cloud-API-enabled feature encounters, in order:
+
+1. Provider-neutral button / toggle ("Generate with AI" — UX layer).
+2. Consent screen that identifies the provider explicitly before the
+   first request is sent (disclosure layer).
+3. Settings entry to revoke consent, provider-neutral (UX layer).
+4. Privacy policy / Privacy Manifest / App Privacy Details, all naming
+   the provider (disclosure layer).
+
+The user at step 2 cannot miss who the third party is; the UI at
+steps 1/3 does not require re-layout when the provider changes.
+
+### 7.5 What is deferred to ADR-006
+
+- Concrete wording of each consent screen and its localisations.
+- BYOK vs maintainer-provided-key decision and its pricing /
+  distribution model.
+- Retry policy, rate-limit handling, and offline fallback.
+- Caching / telemetry policy for cloud requests.
+- Which provider ships first, and whether Phase 2 supports a single
+  provider or multiple at launch.
+- Any consent-bundling (e.g. "enable all cloud features" affordance)
+  — if introduced, must preserve per-feature revocation from §7.3.1.
+
+ADR-006 is a blocker for shipping the Cloud API feature; this ADR is
+not. ADR-005 merging does not itself authorise cloud-feature
+implementation.
 
 ---
 

--- a/docs/decisions/ADR-005.md
+++ b/docs/decisions/ADR-005.md
@@ -966,4 +966,137 @@ answer for:
 
 ## 9. Consequences, Open Questions, References
 
-*(Section stub — filled in subsequent commit.)*
+### 9.1 Consequences
+
+Accepting this ADR has the following immediate consequences:
+
+- **Submission pathway clarified.** The two named submission blockers
+  ([#148 Ollama wrap](https://github.com/tyabu12/pastura/issues/148)
+  and [#149 PrivacyInfo.xcprivacy](https://github.com/tyabu12/pastura/issues/149))
+  become explicit pre-submission gates. No App Store Connect submission
+  is opened until both are resolved.
+- **Engineering backlog seeded.** Four follow-up work items (see master
+  index below) are surfaced with owners and blocker-for status; at
+  least the two blockers-for-submission items are pre-filed so the
+  ADR's normative text aligns with actual tracked work.
+- **§5 filtering policy is now binding** on every new display surface.
+  Future work that adds a user-visible rendering of LLM output (e.g.
+  Markdown preview, quick-glance widget) must wire `ContentFilter`
+  before merging; a review checklist item can be added in a later
+  tightening pass.
+- **Cloud API work is gated on ADR-006.** §7's principles bound ADR-006
+  but do not authorise implementation. Engineering work on Cloud API
+  beyond API-contract exploration is out of scope until ADR-006
+  merges.
+- **Age-rating fallback path is defined but not triggered.** §3.3's
+  fallback (13+ → 16+) has explicit triggers; a fallback-handling
+  sub-issue is filed only if a trigger fires.
+
+Two changes to repo-level documentation ship with this ADR:
+
+- `CLAUDE.md` reference table gains a row for `ADR-005.md`.
+- `SimulationViewModel.swift:669-676` comment is re-cited in a
+  trailing commit to reflect the §5.5 ownership split (ADR-005 owns
+  the policy; #133 is UX refactor bound by the policy).
+
+### 9.2 Sub-issue master index
+
+Submission blockers are pre-filed; other follow-up items carry a "file
+when work starts" marker and are created during the relevant sprint.
+
+| # | Work item | Tracking issue | Owner | Blocker for | Notes |
+|---|-----------|----------------|-------|-------------|-------|
+| 1 | Wrap `OllamaService` out of release binaries; `nm` audit | [#148](https://github.com/tyabu12/pastura/issues/148) | tyabu12 | **Submission** | Filed 2026-04-19; §8.5 |
+| 2 | Create `PrivacyInfo.xcprivacy` with required-reason APIs | [#149](https://github.com/tyabu12/pastura/issues/149) | tyabu12 | **Submission** | Filed 2026-04-19; §1 gap, §9 |
+| 3 | Implement `ScenarioContentValidator` (§4) + wordlist bundling (§4.4) | To be filed when work starts | tyabu12 | Soft — defense-in-depth complement to §5 filter | §5 filter is the backstop; §4 is preferred but not submission-blocking |
+| 4 | Share Board report UI (§6) + pseudonymous contact surface | To be filed when work starts | tyabu12 | Soft — §1.2 does not strictly apply to curated content, but defensive posture recommended before review | §1.5 contact info separately handled via App Store Connect support URL |
+| 5 | `ContentFilter.defaultPatterns` expansion methodology (§5.2) | Not filed — on-demand | tyabu12 | None (ongoing) | Triggered by telemetry, App Review citation, or user report |
+| 6 | Fallback handling 13+ → 16+ (§3.3) | Not filed — conditional | tyabu12 | Conditional (fires only on rejection) | Created reactively if Apple rejects the 13+ target |
+| 7 | ADR-006 Cloud API disclosure/consent implementation | Forthcoming ADR, not a sub-issue | tyabu12 | Cloud API feature (not submission) | Principles from §7 bind this work |
+
+The master index is the canonical list — individual ADR sections reference
+it by row number when pointing at follow-up work.
+
+### 9.3 Open questions (unverified claims and deferred decisions)
+
+Claims in the source issue (#145) that could not be pinned against a
+primary Apple source during drafting, or decisions deliberately left
+for later:
+
+- **Effective date of §5.1.2(i)'s "third-party AI" language.** Issue
+  #145 states "2025-11 施行". The guideline text is in force as of
+  access date 2026-04-19, but the specific effective date of the
+  "third-party AI" sub-clause could not be verified against an Apple
+  announcement. This ADR treats the clause as currently binding
+  (sufficient for Pastura's compliance work).
+- **AI-chatbot questionnaire sub-items.** Apple's 2025-07
+  announcement flags that developers must account for AI output in
+  frequency answers, but does not publish a separate AI-specific
+  questionnaire sub-item visible in App Store Connect. §3.5's answers
+  assume AI output is folded into the existing categories (mature
+  themes, profanity, etc.). If a future App Store Connect update
+  introduces an AI-specific question, §3 must be revisited.
+- **OllamaService binary-level exclusion verification.** §8.5's `nm`
+  grep is the documented method; whether additional symbol auditing
+  (e.g. `otool -L` for linked frameworks) is required depends on how
+  `OllamaService.swift` is ultimately wrapped. #148 owns the final
+  method.
+- **Japanese-corpus wordlist canonical source.** §4.4 lists LDNOOBW
+  as a candidate only for English; no canonical Japanese blocklist
+  exists. The implementation sub-issue (#3 in the master index) will
+  either curate a project-owned list seeded from
+  `ContentFilter.defaultPatterns` or adopt a third-party list once
+  one is identified.
+- **Telemetry for filter hit rate.** §5.6 notes telemetry is
+  considered but deferred. A future decision on whether filter hits
+  / validator rejections are logged (and with what privacy model)
+  would inform blocklist expansion in item #5. Not filed because the
+  privacy trade-off is non-trivial and the current blocklist is small
+  enough to tune by inspection.
+
+### 9.4 References
+
+**Apple — App Store Review Guidelines and Developer News.** All
+accessed 2026-04-19 unless otherwise noted.
+
+- [App Store Review Guidelines](https://developer.apple.com/app-store/review/guidelines/) —
+  §1.2 (UGC), §2.5.2 (executable code), §5.1.2(i) (Data use and
+  sharing, including third-party AI disclosure). Cited across §5, §6,
+  §7, §8.
+- [Updated age ratings in App Store Connect](https://developer.apple.com/news/?id=ks775ehf) —
+  2025-07-24 announcement of the 4+/9+/13+/16+/18+ tier system and
+  AI-chatbot guidance. Cited in §3.
+- [Age ratings values and definitions](https://developer.apple.com/help/app-store-connect/reference/app-information/age-ratings-values-and-definitions/) —
+  Full questionnaire categories and tier-trigger mapping. Cited in
+  §3.5.
+- [Privacy manifest files](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files) —
+  `PrivacyInfo.xcprivacy` structure and required-reason APIs. Cited in
+  §9.2 item 2.
+
+**Pastura internal.**
+
+- `CLAUDE.md` — Hard rules, dependency rules, ContentFilter location.
+- `docs/decisions/ADR-001.md` — Architecture overview; §Architecture
+  diagram informs §4.2's location rationale.
+- `docs/decisions/ADR-002.md` — llama.cpp interim backend; cited in
+  §8.3 for on-device inference engine.
+- `docs/decisions/ADR-003.md` — BG execution and on-device inference;
+  cited in §8.3 and §8.4 as the canonical on-device-claim record.
+- `docs/ROADMAP.md` — Phase 2 Cloud API feature entry; cited in §7.1.
+- `docs/gallery/README.md` — Share Board trust model and curation
+  rules; cited in §6.1.
+- `Pastura/Pastura/App/ContentFilter.swift` — current filter
+  implementation; cited in §5 and §4.6 (actor-isolation contrast).
+- `Pastura/Pastura/App/SimulationViewModel.swift:669-682` — streaming
+  snapshot filter application; cited in §5.5.
+- `Pastura/Pastura/App/ImportViewModel.swift:23` and
+  `Pastura/Pastura/App/ScenarioEditorViewModel.swift:160` — validator
+  invocation sites for §4.5.
+- `Pastura/Pastura/App/AppDependencies.swift:43` — current Ollama
+  default; cited in §8.5.
+- `Pastura/Pastura/Engine/ScenarioValidator.swift` — structural
+  validator; name collision avoided by §4.2.
+- PR #140 — streaming filter gap closure; cited in §5.2.
+- Issue #133 — streaming display UX refactor; ownership split in §5.5.
+- Issue #145 — ADR-005 design work origin.
+- Issues #148, #149 — submission blockers pre-filed for this ADR.


### PR DESCRIPTION
## Summary

- Land ADR-005 (Accepted) documenting Pastura's content-safety posture for full App Store review: age rating (13+ target / 16+ fallback under Apple's 2025-07 tier system), shift-left input validation design, defense-in-depth output filter policy, Share Board reporting, Cloud API disclosure/consent principles, and LLM-app-specific review risks.
- Pre-file two submission-blocking sub-issues referenced from ADR-005 §9 master index: #148 (Ollama dev-backend exclusion) and #149 (PrivacyInfo.xcprivacy creation).
- Re-cite the #133 comment in `SimulationViewModel.swift` to anchor filtering-policy ownership to ADR-005 §5 while preserving the UX-refactor pointer to #133.
- Add an ADR-005 row to the Reference Documents table in CLAUDE.md.

## Scope notes

- ADR-005 is policy-level only — no Swift implementation ships in this PR. The single Swift edit is a 6-line comment update required because ADR-005 invalidates the prior "tracked in #133" authority framing. All implementation (ScenarioContentValidator, wordlist selection, PrivacyInfo.xcprivacy, Ollama `#if` wrap, Share Board report UI) is deferred to sub-issues tracked in §9.2.
- Cloud API details (ADR-006, forthcoming) are bounded by §7 principles but NOT authorised by this ADR; shipping the feature requires ADR-006 to merge first.

## Test plan

- [x] SwiftLint `--strict` from repo root: 0 violations
- [x] Two-stage critic review on plan (pre-implementation): 2 Critical + 6 Warning raised on v1, all addressed in v2; Critical 0 on v2
- [x] code-reviewer on full branch diff: PASS (0 critical / 0 warning / 3 suggestions — all addressed in the final citation-normalisation commit)
- [x] Apple official sources (App Store Review Guidelines, Developer News 2025-07 age rating, Privacy Manifest docs) verified at access date 2026-04-19
- [x] Pre-filed sub-issues #148 and #149 exist and reference ADR-005

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)