### PR TITLE
🔒 chore: exclude OllamaService from release binaries (ADR-005 §8)

### DIFF
--- a/Pastura/Pastura/App/AppDependencies.swift
+++ b/Pastura/Pastura/App/AppDependencies.swift
@@ -15,7 +15,11 @@ final class AppDependencies: @unchecked Sendable {
   let codePhaseEventRepository: any CodePhaseEventRepository
 
   /// The LLM service used for simulation execution.
-  /// Defaults to `OllamaService` for development.
+  ///
+  /// Callers must pass an explicit `llmService` in Release-iphoneos builds
+  /// (see ADR-005 §8 — dev-only backends like `OllamaService` are excluded
+  /// from App-Store-review-bound binaries). The `nil`-fallback construction
+  /// is only available in Debug or Simulator builds.
   let llmService: any LLMService
 
   /// Manager for iOS 26+ background simulation continuation.
@@ -40,17 +44,35 @@ final class AppDependencies: @unchecked Sendable {
     self.simulationRepository = GRDBSimulationRepository(dbWriter: writer)
     self.turnRepository = GRDBTurnRepository(dbWriter: writer)
     self.codePhaseEventRepository = GRDBCodePhaseEventRepository(dbWriter: writer)
-    self.llmService = llmService ?? OllamaService()
+    if let llmService {
+      self.llmService = llmService
+    } else {
+      // ADR-005 §8: `OllamaService` ships only in Debug / Simulator builds.
+      // In Release-iphoneos the fallback is unreachable by construction —
+      // `production(llmService:)` is the only caller and requires the arg.
+      #if DEBUG || targetEnvironment(simulator)
+        self.llmService = OllamaService()
+      #else
+        preconditionFailure("AppDependencies requires an explicit llmService in Release builds")
+      #endif
+    }
     self.backgroundManager = backgroundManager
     self.galleryService = galleryService ?? URLSessionGalleryService()
   }
 
-  /// Creates a production instance with persistent SQLite storage.
-  static func production() throws -> AppDependencies {
-    let dbPath = Self.databasePath()
-    let manager = try DatabaseManager.persistent(at: dbPath)
-    return AppDependencies(databaseManager: manager)
-  }
+  #if DEBUG || targetEnvironment(simulator)
+    /// Creates a production instance with persistent SQLite storage and the
+    /// default `OllamaService` LLM backend.
+    ///
+    /// Gated to Debug / Simulator per ADR-005 §8 — Release-iphoneos callers
+    /// must use `production(llmService:)` with a shipping backend (e.g.
+    /// `LlamaCppService`).
+    static func production() throws -> AppDependencies {
+      let dbPath = Self.databasePath()
+      let manager = try DatabaseManager.persistent(at: dbPath)
+      return AppDependencies(databaseManager: manager)
+    }
+  #endif
 
   /// Creates a production instance with a specific LLM service.
   ///

--- a/Pastura/Pastura/LLM/OllamaService.swift
+++ b/Pastura/Pastura/LLM/OllamaService.swift
@@ -1,193 +1,201 @@
-import Foundation
-import os
+// ADR-005 §8: dev-only backends must not ship in App-Store-Connect-review-bound
+// binaries. The whole file is gated so `OllamaService` symbols are absent from
+// Release-iphoneos archives while remaining available for Debug (on-device
+// developer builds + unit tests) and any simulator build.
+#if DEBUG || targetEnvironment(simulator)
 
-/// LLM service connecting to Ollama via its OpenAI-compatible chat API.
-///
-/// For development and Simulator use only. Connects to a local or network
-/// Ollama instance. Not included in production builds.
-///
-/// - Important: Not safe for concurrent `generate`/`unloadModel` calls.
-///   The Engine executes inferences sequentially, so this is fine in practice.
-nonisolated public final class OllamaService: LLMService, @unchecked Sendable {
-  // @unchecked Sendable: mutable state is protected by OSAllocatedUnfairLock.
+  import Foundation
+  import os
 
-  private let baseURL: URL
-  private let modelName: String
-  private let session: URLSession
-  private let loadedState: OSAllocatedUnfairLock<Bool>
-
-  // Hardcoded defaults matching Python prototype
-  private static let temperature: Double = 0.8
-  private static let maxTokens: Int = 1000
-
-  /// Creates an Ollama service.
+  /// LLM service connecting to Ollama via its OpenAI-compatible chat API.
   ///
-  /// - Parameters:
-  ///   - baseURL: The Ollama API base URL. Defaults to `http://localhost:11434`.
-  ///   - modelName: The Ollama model name. Defaults to `"gemma4:e2b"`.
-  ///   - session: URLSession to use for requests. Injectable for testing.
-  public init(
-    baseURL: URL? = nil,
-    modelName: String = "gemma4:e2b",
-    session: URLSession = .shared
-  ) {
-    // Avoid force unwrap by using a static default
-    self.baseURL =
-      baseURL
-      ?? {
-        guard let url = URL(string: "http://localhost:11434") else {
-          preconditionFailure("Static default URL literal is invalid")
-        }
-        return url
-      }()
-    self.modelName = modelName
-    self.session = session
-    self.loadedState = OSAllocatedUnfairLock(initialState: false)
-  }
-
-  /// Marks the service as ready for inference.
+  /// For development and Simulator use only. Connects to a local or network
+  /// Ollama instance. Not included in production builds.
   ///
-  /// Does not verify server connectivity — errors surface on first ``generate(system:user:)`` call.
-  /// Callers must not call ``unloadModel()`` concurrently with ``generate(system:user:)``.
-  public func loadModel() async throws {
-    loadedState.withLock { $0 = true }
-  }
+  /// - Important: Not safe for concurrent `generate`/`unloadModel` calls.
+  ///   The Engine executes inferences sequentially, so this is fine in practice.
+  nonisolated public final class OllamaService: LLMService, @unchecked Sendable {
+    // @unchecked Sendable: mutable state is protected by OSAllocatedUnfairLock.
 
-  public func unloadModel() async throws {
-    loadedState.withLock { $0 = false }
-  }
+    private let baseURL: URL
+    private let modelName: String
+    private let session: URLSession
+    private let loadedState: OSAllocatedUnfairLock<Bool>
 
-  public var isModelLoaded: Bool {
-    loadedState.withLock { $0 }
-  }
+    // Hardcoded defaults matching Python prototype
+    private static let temperature: Double = 0.8
+    private static let maxTokens: Int = 1000
 
-  public var modelIdentifier: String { modelName }
-  public let backendIdentifier = "Ollama"
-
-  public func generate(system: String, user: String) async throws -> String {
-    guard isModelLoaded else { throw LLMError.notLoaded }
-
-    let request = try buildRequest(system: system, user: user)
-
-    let data: Data
-    let response: URLResponse
-    do {
-      (data, response) = try await session.data(for: request)
-    } catch {
-      throw LLMError.networkError(description: String(describing: error))
+    /// Creates an Ollama service.
+    ///
+    /// - Parameters:
+    ///   - baseURL: The Ollama API base URL. Defaults to `http://localhost:11434`.
+    ///   - modelName: The Ollama model name. Defaults to `"gemma4:e2b"`.
+    ///   - session: URLSession to use for requests. Injectable for testing.
+    public init(
+      baseURL: URL? = nil,
+      modelName: String = "gemma4:e2b",
+      session: URLSession = .shared
+    ) {
+      // Avoid force unwrap by using a static default
+      self.baseURL =
+        baseURL
+        ?? {
+          guard let url = URL(string: "http://localhost:11434") else {
+            preconditionFailure("Static default URL literal is invalid")
+          }
+          return url
+        }()
+      self.modelName = modelName
+      self.session = session
+      self.loadedState = OSAllocatedUnfairLock(initialState: false)
     }
 
-    guard let httpResponse = response as? HTTPURLResponse else {
-      throw LLMError.networkError(description: "Non-HTTP response received")
+    /// Marks the service as ready for inference.
+    ///
+    /// Does not verify server connectivity — errors surface on first ``generate(system:user:)`` call.
+    /// Callers must not call ``unloadModel()`` concurrently with ``generate(system:user:)``.
+    public func loadModel() async throws {
+      loadedState.withLock { $0 = true }
     }
 
-    try mapHTTPStatus(httpResponse)
+    public func unloadModel() async throws {
+      loadedState.withLock { $0 = false }
+    }
 
-    return try extractContent(from: data)
-  }
+    public var isModelLoaded: Bool {
+      loadedState.withLock { $0 }
+    }
 
-  // MARK: - Request Building
+    public var modelIdentifier: String { modelName }
+    public let backendIdentifier = "Ollama"
 
-  private func buildRequest(system: String, user: String) throws -> URLRequest {
-    let url = baseURL.appendingPathComponent("v1/chat/completions")
-    var request = URLRequest(url: url)
-    request.httpMethod = "POST"
-    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    public func generate(system: String, user: String) async throws -> String {
+      guard isModelLoaded else { throw LLMError.notLoaded }
 
-    let body: [String: Any] = [
-      "model": modelName,
-      "messages": [
-        ["role": "system", "content": system],
-        ["role": "user", "content": user]
-      ],
-      "temperature": Self.temperature,
-      "max_tokens": Self.maxTokens
-    ]
+      let request = try buildRequest(system: system, user: user)
 
-    request.httpBody = try JSONSerialization.data(withJSONObject: body)
-    return request
-  }
+      let data: Data
+      let response: URLResponse
+      do {
+        (data, response) = try await session.data(for: request)
+      } catch {
+        throw LLMError.networkError(description: String(describing: error))
+      }
 
-  // MARK: - Response Handling
+      guard let httpResponse = response as? HTTPURLResponse else {
+        throw LLMError.networkError(description: "Non-HTTP response received")
+      }
 
-  /// Map HTTP status codes to appropriate LLMError cases.
-  private func mapHTTPStatus(_ response: HTTPURLResponse) throws {
-    switch response.statusCode {
-    case 200...299:
-      return
-    case 400...499:
-      throw LLMError.generationFailed(
-        description: "HTTP \(response.statusCode): client error")
-    default:
-      throw LLMError.networkError(
-        description: "HTTP \(response.statusCode): server error")
+      try mapHTTPStatus(httpResponse)
+
+      return try extractContent(from: data)
+    }
+
+    // MARK: - Request Building
+
+    private func buildRequest(system: String, user: String) throws -> URLRequest {
+      let url = baseURL.appendingPathComponent("v1/chat/completions")
+      var request = URLRequest(url: url)
+      request.httpMethod = "POST"
+      request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+      let body: [String: Any] = [
+        "model": modelName,
+        "messages": [
+          ["role": "system", "content": system],
+          ["role": "user", "content": user]
+        ],
+        "temperature": Self.temperature,
+        "max_tokens": Self.maxTokens
+      ]
+
+      request.httpBody = try JSONSerialization.data(withJSONObject: body)
+      return request
+    }
+
+    // MARK: - Response Handling
+
+    /// Map HTTP status codes to appropriate LLMError cases.
+    private func mapHTTPStatus(_ response: HTTPURLResponse) throws {
+      switch response.statusCode {
+      case 200...299:
+        return
+      case 400...499:
+        throw LLMError.generationFailed(
+          description: "HTTP \(response.statusCode): client error")
+      default:
+        throw LLMError.networkError(
+          description: "HTTP \(response.statusCode): server error")
+      }
+    }
+
+    /// Extract the content string from the OpenAI-compatible response.
+    private func extractContent(from data: Data) throws -> String {
+      guard
+        let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+        let choices = json["choices"] as? [[String: Any]],
+        let firstChoice = choices.first,
+        let message = firstChoice["message"] as? [String: Any],
+        let content = message["content"] as? String
+      else {
+        let raw = String(data: data, encoding: .utf8) ?? "<binary>"
+        throw LLMError.invalidResponse(raw: raw)
+      }
+      return content
+    }
+
+    /// Extract content and `usage.completion_tokens` from the response.
+    /// `completion_tokens` is optional in practice: some Ollama versions / models
+    /// omit or zero the `usage` block on the OpenAI-compat endpoint, so we return
+    /// `nil` rather than substituting a fake value that would bias tok/s averages.
+    fileprivate func extractGenerationResult(from data: Data) throws -> GenerationResult {
+      guard
+        let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+        let choices = json["choices"] as? [[String: Any]],
+        let firstChoice = choices.first,
+        let message = firstChoice["message"] as? [String: Any],
+        let content = message["content"] as? String
+      else {
+        let raw = String(data: data, encoding: .utf8) ?? "<binary>"
+        throw LLMError.invalidResponse(raw: raw)
+      }
+      let usage = json["usage"] as? [String: Any]
+      let tokens = (usage?["completion_tokens"] as? Int).flatMap { $0 > 0 ? $0 : nil }
+      return GenerationResult(text: content, completionTokens: tokens)
     }
   }
 
-  /// Extract the content string from the OpenAI-compatible response.
-  private func extractContent(from data: Data) throws -> String {
-    guard
-      let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-      let choices = json["choices"] as? [[String: Any]],
-      let firstChoice = choices.first,
-      let message = firstChoice["message"] as? [String: Any],
-      let content = message["content"] as? String
-    else {
-      let raw = String(data: data, encoding: .utf8) ?? "<binary>"
-      throw LLMError.invalidResponse(raw: raw)
+  // MARK: - Generation (metrics-aware)
+
+  extension OllamaService {
+    /// Token-count-aware counterpart to ``generate(system:user:)``. Reads
+    /// `usage.completion_tokens` when the server provides it; otherwise reports
+    /// `nil` (Ollama's OpenAI-compat endpoint historically has inconsistent
+    /// `usage` reporting across versions).
+    public func generateWithMetrics(
+      system: String, user: String
+    ) async throws -> GenerationResult {
+      guard isModelLoaded else { throw LLMError.notLoaded }
+
+      let request = try buildRequest(system: system, user: user)
+
+      let data: Data
+      let response: URLResponse
+      do {
+        (data, response) = try await session.data(for: request)
+      } catch {
+        throw LLMError.networkError(description: String(describing: error))
+      }
+
+      guard let httpResponse = response as? HTTPURLResponse else {
+        throw LLMError.networkError(description: "Non-HTTP response received")
+      }
+
+      try mapHTTPStatus(httpResponse)
+
+      return try extractGenerationResult(from: data)
     }
-    return content
   }
 
-  /// Extract content and `usage.completion_tokens` from the response.
-  /// `completion_tokens` is optional in practice: some Ollama versions / models
-  /// omit or zero the `usage` block on the OpenAI-compat endpoint, so we return
-  /// `nil` rather than substituting a fake value that would bias tok/s averages.
-  fileprivate func extractGenerationResult(from data: Data) throws -> GenerationResult {
-    guard
-      let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-      let choices = json["choices"] as? [[String: Any]],
-      let firstChoice = choices.first,
-      let message = firstChoice["message"] as? [String: Any],
-      let content = message["content"] as? String
-    else {
-      let raw = String(data: data, encoding: .utf8) ?? "<binary>"
-      throw LLMError.invalidResponse(raw: raw)
-    }
-    let usage = json["usage"] as? [String: Any]
-    let tokens = (usage?["completion_tokens"] as? Int).flatMap { $0 > 0 ? $0 : nil }
-    return GenerationResult(text: content, completionTokens: tokens)
-  }
-}
-
-// MARK: - Generation (metrics-aware)
-
-extension OllamaService {
-  /// Token-count-aware counterpart to ``generate(system:user:)``. Reads
-  /// `usage.completion_tokens` when the server provides it; otherwise reports
-  /// `nil` (Ollama's OpenAI-compat endpoint historically has inconsistent
-  /// `usage` reporting across versions).
-  public func generateWithMetrics(
-    system: String, user: String
-  ) async throws -> GenerationResult {
-    guard isModelLoaded else { throw LLMError.notLoaded }
-
-    let request = try buildRequest(system: system, user: user)
-
-    let data: Data
-    let response: URLResponse
-    do {
-      (data, response) = try await session.data(for: request)
-    } catch {
-      throw LLMError.networkError(description: String(describing: error))
-    }
-
-    guard let httpResponse = response as? HTTPURLResponse else {
-      throw LLMError.networkError(description: "Non-HTTP response received")
-    }
-
-    try mapHTTPStatus(httpResponse)
-
-    return try extractGenerationResult(from: data)
-  }
-}
+#endif


### PR DESCRIPTION
## Summary
- Wrap `OllamaService.swift` in `#if DEBUG || targetEnvironment(simulator)` so the dev-only Ollama backend is absent from App-Store-Connect-review-bound archives (ADR-005 §8).
- Gate `AppDependencies` nil-fallback path and `production()` (no-arg) helper with the same build condition; Release builds must now pass an explicit `llmService`.
- Debug / Simulator behavior is unchanged — unit tests and the existing `PasturaApp.swift:89` simulator path remain intact.

## Test plan
- [x] Full unit test suite passes (simulator/DEBUG)
- [x] `swiftlint lint --strict` clean
- [x] Release-iphoneos build succeeds (`xcodebuild build -configuration Release -sdk iphoneos CODE_SIGNING_ALLOWED=NO`)
- [x] `nm -a Pastura.app/Pastura | grep "OllamaService"` empty (raw + `swift-demangle`)

## Follow-up
- Lock in the invariant with a CI step that runs a Release build + `nm` grep — filed separately (out of scope for this PR).

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)