### PR TITLE
🔒 chore: add PrivacyInfo.xcprivacy manifest

### DIFF
--- a/Pastura/Pastura/PrivacyInfo.xcprivacy
+++ b/Pastura/Pastura/PrivacyInfo.xcprivacy
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Adds Apple's `PrivacyInfo.xcprivacy` (required since 2024-05 for App Store Connect upload). Closes the submission blocker tracked in ADR-005 §9 / #149.
- Declares two required-reason API categories covering Pastura's app-code usage:
  - `UserDefaults` → `CA92.1` — `FeatureFlags.swift` reads own-app defaults via `UserDefaults.standard`.
  - `FileTimestamp` → `C617.1` — `ModelManager.attributesOfItem(atPath:)` on app-container files. Apple's scanner flags the selector itself (stat-family) even for `.size`-only reads per Apple DTS / TN3183.
- `NSPrivacyCollectedDataTypes = []` (Phase 2 on-device only; revisit when ADR-006 Cloud API ships).
- `NSPrivacyTracking = false`, `NSPrivacyTrackingDomains = []`.

## Notes
- Xcode 16 `PBXFileSystemSynchronizedRootGroup` auto-includes the file — no `project.pbxproj` edit.
- Embedded dependencies: GRDB ships its own manifest; Yams and llama.swift audited and don't hit required-reason APIs. App-level manifest covers app-code only.
- ADR-005 §8.6 / `ITSAppUsesNonExemptEncryption` Info.plist drift is a separate submission concern — not included here.

## Test plan
- [x] `plutil -lint` on the manifest — structurally valid.
- [x] Debug build succeeded; `plutil -p <built>.app/PrivacyInfo.xcprivacy` confirms bundle-root placement with correct content.
- [x] Full unit test suite (skip-UITests) ran; no regressions.
- [x] SwiftLint clean (no Swift code touched).
- [ ] **Requires real archive upload to verify ITMS acceptance** — local tooling cannot validate reason-code semantics.

Closes #149. Refs ADR-005 §9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)