### PR TITLE
⚡ perf: throttle download progress callback in ModelManager

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -15,6 +15,52 @@ concurrent Task/AsyncStream cleanup. This applies to integration tests that cons
 Individual unit tests (e.g., handler tests with `MockLLMService`) are safe to run
 in parallel because they await the handler directly without AsyncStream.
 
+## Splitting a Suite Across Files (file_length 400-line cap)
+
+When a `*Tests.swift` file exceeds swiftlint's 400-line `file_length` limit,
+split by adding an `extension` of the suite struct in a sibling file named
+`<Name>Tests+<Feature>.swift` (Apple's `Type+Feature.swift` convention).
+
+**DO NOT** create a new `@Suite` for the split. Swift Testing runs `@Suite`s
+in parallel by default — `.serialized` only orders tests *within* a suite,
+not across them. A new suite that touches shared state (filesystem paths
+under `Application Support` / `Caches`, in-process singletons, etc.) will
+race against the original. Local runs may squeak through on faster machines;
+CI's slower runner is where the race surfaces.
+
+**Pattern:**
+
+```swift
+// ModelManagerTests.swift — original suite, slimmed under 400 lines
+@Suite("ModelManager", .serialized, .timeLimit(.minutes(1)))
+@MainActor
+struct ModelManagerTests {
+  func makeSUT(...) -> ModelManager { ... }   // NOT `private` — see below
+  @Test func ...
+}
+
+// ModelManagerTests+ProgressRegression.swift — sibling
+extension ModelManagerTests {
+  @Test func downloadCompletesWhenDownloaderSkipsTerminalProgress() async {
+    let sut = makeSUT(...)   // Calls into the original file's helper
+  }
+}
+```
+
+**Access modifier:** Helpers the extension calls (`makeSUT`, etc.) must be
+at **internal** access (default — drop `private`). `private` members are
+only visible to extensions in the *same file*; sibling-file extensions
+cannot see them. Widening to module-internal is contained because the test
+target is its own module.
+
+**Helpers** (mocks, observation collectors) live at file scope in the new
+sibling file — they don't need to be members of the suite struct.
+
+**History:** PR #157 (Issue #72) introduced this rule after the throttle
+regression test was originally split into a standalone `@Suite`. The new
+suite raced against `ModelManagerTests/modelNotDownloaded()` on the shared
+model file path; it passed locally but failed on CI.
+
 ## `.timeLimit` Trait on Every Suite (CI-Hang Diagnostic)
 
 Every Swift Testing suite under `Pastura/PasturaTests/` **must** carry

--- a/Pastura/Pastura/App/ModelManager.swift
+++ b/Pastura/Pastura/App/ModelManager.swift
@@ -1,5 +1,6 @@
 import CryptoKit
 import Foundation
+import os
 
 /// State of the on-device LLM model.
 public enum ModelState: Equatable, Sendable {
@@ -177,12 +178,25 @@ final class ModelManager {
 
     state = .downloading(progress: resumeOffset > 0 ? 0.01 : 0.0)
 
+    // Throttle UI updates to ~10 Hz (100ms). URLSession's `didWriteData`
+    // callback fires hundreds of times per second on a 3 GB download; without
+    // throttling, every tick spawned a `Task { @MainActor }` and saturated the
+    // MainActor scheduler for the entire multi-minute download.
+    //
+    // Wrapped in `OSAllocatedUnfairLock` because two callsites mutate it:
+    // production URLSession's serial delegate queue (off-MainActor) and
+    // `MockModelDownloader` in tests (on MainActor).
+    let throttle = OSAllocatedUnfairLock<ProgressThrottle>(initialState: ProgressThrottle())
+    let expectedSize = expectedFileSize
+
     do {
       try await downloader.download(
         from: Self.modelURL,
         resumeOffset: resumeOffset,
         to: downloadFileURL,
         progressHandler: { [weak self] bytesReceived, totalBytes in
+          let shouldEmit = throttle.withLock { $0.shouldEmit(now: .now) }
+          guard shouldEmit else { return }
           Task { @MainActor [weak self] in
             guard let self else { return }
             let progress: Double
@@ -190,13 +204,20 @@ final class ModelManager {
               progress = Double(bytesReceived) / Double(totalBytes)
             } else {
               // Content-Length unknown — estimate from expected file size (~3.1 GB)
-              let estimatedTotal = Double(max(expectedFileSize, 3_100_000_000))
+              let estimatedTotal = Double(max(expectedSize, 3_100_000_000))
               progress = min(Double(bytesReceived) / estimatedTotal, 0.99)
             }
             self.state = .downloading(progress: min(progress, 1.0))
           }
         }
       )
+
+      // Force a terminal 100% transition before SHA256 verification.
+      // Production URLSession does not guarantee a final `didWriteData` call
+      // at `received == total`, and even if it did, it could be throttled out
+      // above. Without this, the UI stalls at ~99% during the ~2s SHA256 hash
+      // on a 3 GB file.
+      state = .downloading(progress: 1.0)
 
       if let error = await verifyDownloadIntegrity() {
         try? fileManager.removeItem(at: downloadFileURL)

--- a/Pastura/Pastura/App/ProgressThrottle.swift
+++ b/Pastura/Pastura/App/ProgressThrottle.swift
@@ -1,0 +1,54 @@
+/// Decides whether a frequently-fired progress callback should propagate to the UI.
+///
+/// Designed for use by `ModelManager` to throttle URLSession download-progress
+/// callbacks (which fire hundreds of times per second for a 3 GB file) down to
+/// ~10 Hz, preventing MainActor saturation during long downloads.
+///
+/// **Usage pattern — why `OSAllocatedUnfairLock`:**
+/// The caller must wrap `ProgressThrottle` inside an `OSAllocatedUnfairLock` rather
+/// than relying on the struct's value-type copy semantics. Two distinct callsites
+/// require this protection:
+/// - **Production** URLSession download delegate: the delegate callbacks arrive on
+///   URLSession's internal serial queue (not MainActor), so a lock guards mutation
+///   against any concurrent resume/cancel calls.
+/// - **`MockModelDownloader`** in `@MainActor`-isolated tests: the mock drives
+///   progress from MainActor, but a future refactor could move it off; the lock
+///   makes the invariant explicit and keeps the test callsite identical to production.
+///
+/// Uses `ContinuousClock.Instant` (monotonic) rather than `Date` because wall-clock
+/// time can step backwards under NTP correction — a risk over a multi-minute download.
+nonisolated struct ProgressThrottle {
+  /// Default minimum interval between accepted emissions: 100 ms ≈ 10 UI updates/sec.
+  ///
+  /// 10 Hz is visually smooth for a progress bar while keeping MainActor scheduling
+  /// overhead negligible compared to the actual download throughput work.
+  static let defaultInterval: Duration = .milliseconds(100)
+
+  private let interval: Duration
+  private var lastAccepted: ContinuousClock.Instant?
+
+  init(interval: Duration = Self.defaultInterval) {
+    self.interval = interval
+  }
+
+  /// Returns `true` if the caller should emit a progress update at `now`.
+  ///
+  /// - The **first call always returns `true`** so the initial byte-arrival update
+  ///   reaches the UI immediately.
+  /// - Subsequent calls within `interval` of the last accepted timestamp return `false`.
+  /// - Subsequent calls ≥ `interval` after the last accepted timestamp return `true`
+  ///   and update the stored timestamp. Skipped calls do **not** advance the timestamp
+  ///   — the window is measured from the last *accepted* call, not the last call.
+  mutating func shouldEmit(now: ContinuousClock.Instant) -> Bool {
+    guard let last = lastAccepted else {
+      // First call — always accept.
+      lastAccepted = now
+      return true
+    }
+    guard now >= last + interval else {
+      return false
+    }
+    lastAccepted = now
+    return true
+  }
+}

--- a/Pastura/Pastura/App/ProgressThrottle.swift
+++ b/Pastura/Pastura/App/ProgressThrottle.swift
@@ -5,15 +5,11 @@
 /// ~10 Hz, preventing MainActor saturation during long downloads.
 ///
 /// **Usage pattern — why `OSAllocatedUnfairLock`:**
-/// The caller must wrap `ProgressThrottle` inside an `OSAllocatedUnfairLock` rather
-/// than relying on the struct's value-type copy semantics. Two distinct callsites
-/// require this protection:
-/// - **Production** URLSession download delegate: the delegate callbacks arrive on
-///   URLSession's internal serial queue (not MainActor), so a lock guards mutation
-///   against any concurrent resume/cancel calls.
-/// - **`MockModelDownloader`** in `@MainActor`-isolated tests: the mock drives
-///   progress from MainActor, but a future refactor could move it off; the lock
-///   makes the invariant explicit and keeps the test callsite identical to production.
+/// The caller must wrap `ProgressThrottle` inside an `OSAllocatedUnfairLock` so the
+/// closure that reads it can safely cross actor boundaries via `@Sendable` capture.
+/// In production, the URLSession download delegate invokes the closure from
+/// URLSession's internal serial queue (not MainActor); the lock makes that mutation
+/// safe to share with the MainActor-isolated `ModelManager` that owns the lock.
 ///
 /// Uses `ContinuousClock.Instant` (monotonic) rather than `Date` because wall-clock
 /// time can step backwards under NTP correction — a risk over a multi-minute download.

--- a/Pastura/PasturaTests/App/ModelManagerProgressTests.swift
+++ b/Pastura/PasturaTests/App/ModelManagerProgressTests.swift
@@ -69,7 +69,11 @@ struct ModelManagerProgressTests {
       try? FileManager.default.removeItem(at: sut.downloadFileURL)
     }
 
-    // Drain any pending observer Tasks so the final transitions are recorded.
+    // Let the `StateSnapshots` re-arm Tasks settle. Progress callbacks were
+    // already drained when `downloadModel()` returned, but the `withObservationTracking`
+    // re-arm hops through `Task { @MainActor }`, so a few yields ensure any
+    // post-`.ready` snapshot is recorded before we read `snapshots.progresses`.
+    // Five yields is empirical headroom over the typical one-or-two it takes.
     for _ in 0..<5 { await Task.yield() }
 
     guard case .ready = sut.state else {

--- a/Pastura/PasturaTests/App/ModelManagerProgressTests.swift
+++ b/Pastura/PasturaTests/App/ModelManagerProgressTests.swift
@@ -1,0 +1,117 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+// MARK: - Mock
+
+/// Mock that emits ONLY sub-1.0 progress callbacks and never a terminal
+/// `received == total` callback. Mirrors production `URLSessionDownloadDelegate`
+/// behavior: `didWriteData` is not guaranteed to fire one final time at 100%
+/// after the last chunk — completion arrives via `didCompleteWithError(nil)`.
+struct SubOneProgressMockDownloader: ModelDownloader, Sendable {
+  let simulateBytes: Int64
+
+  init(simulateBytes: Int64 = 1000) {
+    self.simulateBytes = simulateBytes
+  }
+
+  func download(
+    from url: URL,
+    resumeOffset: Int64,
+    to destination: URL,
+    progressHandler: @Sendable @escaping (Int64, Int64) -> Void
+  ) async throws {
+    let data = Data(repeating: 0x42, count: Int(simulateBytes))
+    try data.write(to: destination)
+    // Emit only a mid-progress callback — never terminal 100%.
+    progressHandler(simulateBytes / 2, simulateBytes)
+  }
+}
+
+// MARK: - Tests
+
+// Shares filesystem paths with the main suite, so serialize.
+@Suite("ModelManager Progress", .serialized, .timeLimit(.minutes(1)))
+@MainActor
+struct ModelManagerProgressTests {
+
+  @Test(
+    "downloadModel reaches 100% even when downloader skips terminal callback"
+  )
+  func downloadCompletesWhenDownloaderSkipsTerminalProgress() async {
+    // Production URLSession does not guarantee a terminal `didWriteData` call;
+    // ModelManager must explicitly bring `state` to 1.0 before SHA256 verification
+    // so the user sees 100% rather than stalling at the last sub-1.0 sample
+    // during the ~2 s SHA256 hash on a 3 GB file.
+    let sut = ModelManager(
+      downloader: SubOneProgressMockDownloader(simulateBytes: 1000),
+      // Skip size validation — the mock writes 1000 bytes, not the production 3.1 GB.
+      expectedFileSize: 0,
+      // Use SHA256 verification to exercise the post-download path that
+      // includes the explicit `state = .downloading(progress: 1.0)` transition.
+      expectedSHA256: "9a5670771141349931d69d6eb982faa01def544dc17a161ef83b3277fb7c0c3c"
+    )
+    // Pre-clean leftover files from any parallel suite (ModelManagerTests shares
+    // these paths). Swift Testing runs suites in parallel by default; `.serialized`
+    // only orders tests *within* a suite.
+    try? FileManager.default.removeItem(at: sut.modelFileURL)
+    try? FileManager.default.removeItem(at: sut.downloadFileURL)
+    sut.checkModelStatus()
+    #expect(sut.state == .notDownloaded)
+
+    let snapshots = StateSnapshots()
+    snapshots.startObserving(sut)
+
+    await sut.downloadModel()
+    defer {
+      try? FileManager.default.removeItem(at: sut.modelFileURL)
+      try? FileManager.default.removeItem(at: sut.downloadFileURL)
+    }
+
+    // Drain any pending observer Tasks so the final transitions are recorded.
+    for _ in 0..<5 { await Task.yield() }
+
+    guard case .ready = sut.state else {
+      Issue.record("Expected .ready but got \(sut.state)")
+      return
+    }
+
+    let progresses = snapshots.progresses
+    #expect(
+      progresses.contains(where: { $0 >= 0.999 }),
+      "Expected progress to reach 1.0 before .ready; observed \(progresses)"
+    )
+  }
+}
+
+// MARK: - Helpers
+
+/// Re-arming `withObservationTracking` collector for `ModelManager.state`.
+/// Each fired change records the current progress value (if any) and re-arms
+/// tracking for the next change. Lives on MainActor because it reads/writes
+/// `ModelManager.state`.
+@MainActor
+private final class StateSnapshots {
+  private(set) var progresses: [Double] = []
+
+  func startObserving(_ manager: ModelManager) {
+    record(manager.state)
+    withObservationTracking {
+      _ = manager.state
+    } onChange: { [weak self, weak manager] in
+      // onChange fires synchronously on the mutating actor; re-arm via a Task
+      // so the next mutation is captured.
+      Task { @MainActor [weak self, weak manager] in
+        guard let self, let manager else { return }
+        self.startObserving(manager)
+      }
+    }
+  }
+
+  private func record(_ state: ModelState) {
+    if case .downloading(let progress) = state {
+      progresses.append(progress)
+    }
+  }
+}

--- a/Pastura/PasturaTests/App/ModelManagerTests+ProgressRegression.swift
+++ b/Pastura/PasturaTests/App/ModelManagerTests+ProgressRegression.swift
@@ -29,12 +29,15 @@ struct SubOneProgressMockDownloader: ModelDownloader, Sendable {
   }
 }
 
-// MARK: - Tests
+// MARK: - Test (joins the serialized `ModelManagerTests` suite)
 
-// Shares filesystem paths with the main suite, so serialize.
-@Suite("ModelManager Progress", .serialized, .timeLimit(.minutes(1)))
-@MainActor
-struct ModelManagerProgressTests {
+// Extending the suite struct from a separate file keeps this file under
+// swiftlint's 400-line cap while letting the new test run *inside* the
+// existing `.serialized` suite. A standalone `@Suite` would race against
+// `ModelManagerTests` on shared filesystem paths because Swift Testing
+// runs suites in parallel by default — `.serialized` only orders tests
+// *within* a suite.
+extension ModelManagerTests {
 
   @Test(
     "downloadModel reaches 100% even when downloader skips terminal callback"
@@ -44,19 +47,12 @@ struct ModelManagerProgressTests {
     // ModelManager must explicitly bring `state` to 1.0 before SHA256 verification
     // so the user sees 100% rather than stalling at the last sub-1.0 sample
     // during the ~2 s SHA256 hash on a 3 GB file.
-    let sut = ModelManager(
+    let sut = makeSUT(
       downloader: SubOneProgressMockDownloader(simulateBytes: 1000),
-      // Skip size validation — the mock writes 1000 bytes, not the production 3.1 GB.
-      expectedFileSize: 0,
       // Use SHA256 verification to exercise the post-download path that
       // includes the explicit `state = .downloading(progress: 1.0)` transition.
       expectedSHA256: "9a5670771141349931d69d6eb982faa01def544dc17a161ef83b3277fb7c0c3c"
     )
-    // Pre-clean leftover files from any parallel suite (ModelManagerTests shares
-    // these paths). Swift Testing runs suites in parallel by default; `.serialized`
-    // only orders tests *within* a suite.
-    try? FileManager.default.removeItem(at: sut.modelFileURL)
-    try? FileManager.default.removeItem(at: sut.downloadFileURL)
     sut.checkModelStatus()
     #expect(sut.state == .notDownloaded)
 

--- a/Pastura/PasturaTests/App/ModelManagerTests.swift
+++ b/Pastura/PasturaTests/App/ModelManagerTests.swift
@@ -35,30 +35,6 @@ struct MockModelDownloader: ModelDownloader, Sendable {
   }
 }
 
-/// Mock that emits ONLY sub-1.0 progress callbacks and never a terminal
-/// `received == total` callback. Mirrors production `URLSessionDownloadDelegate`
-/// behavior: `didWriteData` is not guaranteed to fire one final time at 100%
-/// after the last chunk — completion arrives via `didCompleteWithError(nil)`.
-struct SubOneProgressMockDownloader: ModelDownloader, Sendable {
-  let simulateBytes: Int64
-
-  init(simulateBytes: Int64 = 1000) {
-    self.simulateBytes = simulateBytes
-  }
-
-  func download(
-    from url: URL,
-    resumeOffset: Int64,
-    to destination: URL,
-    progressHandler: @Sendable @escaping (Int64, Int64) -> Void
-  ) async throws {
-    let data = Data(repeating: 0x42, count: Int(simulateBytes))
-    try data.write(to: destination)
-    // Emit only a mid-progress callback — never terminal 100%.
-    progressHandler(simulateBytes / 2, simulateBytes)
-  }
-}
-
 // MARK: - Tests
 
 // Download tests share filesystem paths (Documents directory), so serialize to avoid races.
@@ -355,76 +331,4 @@ struct ModelManagerTests {
     }
   }
 
-  // MARK: - Terminal Progress
-
-  @Test(
-    "downloadModel transitions to ready and reaches 100% even when downloader skips terminal callback"
-  )
-  func downloadCompletesWhenDownloaderSkipsTerminalProgress() async {
-    // Production URLSession does not guarantee a terminal `didWriteData` call;
-    // ModelManager must explicitly bring `state` to 1.0 before SHA256 verification
-    // so the user sees 100% rather than stalling at the last sub-1.0 sample
-    // during the ~2s SHA256 hash on a 3 GB file.
-    let sut = makeSUT(
-      downloader: SubOneProgressMockDownloader(simulateBytes: 1000),
-      // Use SHA256 verification to exercise the post-download path that
-      // includes the explicit `state = .downloading(progress: 1.0)` transition.
-      expectedSHA256: "9a5670771141349931d69d6eb982faa01def544dc17a161ef83b3277fb7c0c3c"
-    )
-    sut.checkModelStatus()
-    #expect(sut.state == .notDownloaded)
-
-    // Snapshot state changes via re-arming Observation tracking.
-    let snapshots = StateSnapshots()
-    snapshots.startObserving(sut)
-
-    await sut.downloadModel()
-    defer {
-      try? FileManager.default.removeItem(at: sut.modelFileURL)
-      try? FileManager.default.removeItem(at: sut.downloadFileURL)
-    }
-
-    // Drain any pending observer Tasks so the final transitions are recorded.
-    for _ in 0..<5 { await Task.yield() }
-
-    guard case .ready = sut.state else {
-      Issue.record("Expected .ready but got \(sut.state)")
-      return
-    }
-
-    let progresses = snapshots.progresses
-    #expect(
-      progresses.contains(where: { $0 >= 0.999 }),
-      "Expected progress to reach 1.0 before .ready; observed \(progresses)"
-    )
-  }
-}
-
-/// Re-arming `withObservationTracking` collector for `ModelManager.state`.
-/// Each fired change records the current progress value (if any) and re-arms
-/// tracking for the next change. Lives on MainActor because it reads/writes
-/// `ModelManager.state`.
-@MainActor
-private final class StateSnapshots {
-  private(set) var progresses: [Double] = []
-
-  func startObserving(_ manager: ModelManager) {
-    record(manager.state)
-    withObservationTracking {
-      _ = manager.state
-    } onChange: { [weak self, weak manager] in
-      // onChange fires synchronously on the mutating actor; re-arm via a Task
-      // so the next mutation is captured.
-      Task { @MainActor [weak self, weak manager] in
-        guard let self, let manager else { return }
-        self.startObserving(manager)
-      }
-    }
-  }
-
-  private func record(_ state: ModelState) {
-    if case .downloading(let progress) = state {
-      progresses.append(progress)
-    }
-  }
 }

--- a/Pastura/PasturaTests/App/ModelManagerTests.swift
+++ b/Pastura/PasturaTests/App/ModelManagerTests.swift
@@ -35,6 +35,30 @@ struct MockModelDownloader: ModelDownloader, Sendable {
   }
 }
 
+/// Mock that emits ONLY sub-1.0 progress callbacks and never a terminal
+/// `received == total` callback. Mirrors production `URLSessionDownloadDelegate`
+/// behavior: `didWriteData` is not guaranteed to fire one final time at 100%
+/// after the last chunk — completion arrives via `didCompleteWithError(nil)`.
+struct SubOneProgressMockDownloader: ModelDownloader, Sendable {
+  let simulateBytes: Int64
+
+  init(simulateBytes: Int64 = 1000) {
+    self.simulateBytes = simulateBytes
+  }
+
+  func download(
+    from url: URL,
+    resumeOffset: Int64,
+    to destination: URL,
+    progressHandler: @Sendable @escaping (Int64, Int64) -> Void
+  ) async throws {
+    let data = Data(repeating: 0x42, count: Int(simulateBytes))
+    try data.write(to: destination)
+    // Emit only a mid-progress callback — never terminal 100%.
+    progressHandler(simulateBytes / 2, simulateBytes)
+  }
+}
+
 // MARK: - Tests
 
 // Download tests share filesystem paths (Documents directory), so serialize to avoid races.
@@ -328,6 +352,79 @@ struct ModelManagerTests {
       // Success — no SHA256 check performed
     } else {
       Issue.record("Expected .ready but got \(sut.state)")
+    }
+  }
+
+  // MARK: - Terminal Progress
+
+  @Test(
+    "downloadModel transitions to ready and reaches 100% even when downloader skips terminal callback"
+  )
+  func downloadCompletesWhenDownloaderSkipsTerminalProgress() async {
+    // Production URLSession does not guarantee a terminal `didWriteData` call;
+    // ModelManager must explicitly bring `state` to 1.0 before SHA256 verification
+    // so the user sees 100% rather than stalling at the last sub-1.0 sample
+    // during the ~2s SHA256 hash on a 3 GB file.
+    let sut = makeSUT(
+      downloader: SubOneProgressMockDownloader(simulateBytes: 1000),
+      // Use SHA256 verification to exercise the post-download path that
+      // includes the explicit `state = .downloading(progress: 1.0)` transition.
+      expectedSHA256: "9a5670771141349931d69d6eb982faa01def544dc17a161ef83b3277fb7c0c3c"
+    )
+    sut.checkModelStatus()
+    #expect(sut.state == .notDownloaded)
+
+    // Snapshot state changes via re-arming Observation tracking.
+    let snapshots = StateSnapshots()
+    snapshots.startObserving(sut)
+
+    await sut.downloadModel()
+    defer {
+      try? FileManager.default.removeItem(at: sut.modelFileURL)
+      try? FileManager.default.removeItem(at: sut.downloadFileURL)
+    }
+
+    // Drain any pending observer Tasks so the final transitions are recorded.
+    for _ in 0..<5 { await Task.yield() }
+
+    guard case .ready = sut.state else {
+      Issue.record("Expected .ready but got \(sut.state)")
+      return
+    }
+
+    let progresses = snapshots.progresses
+    #expect(
+      progresses.contains(where: { $0 >= 0.999 }),
+      "Expected progress to reach 1.0 before .ready; observed \(progresses)"
+    )
+  }
+}
+
+/// Re-arming `withObservationTracking` collector for `ModelManager.state`.
+/// Each fired change records the current progress value (if any) and re-arms
+/// tracking for the next change. Lives on MainActor because it reads/writes
+/// `ModelManager.state`.
+@MainActor
+private final class StateSnapshots {
+  private(set) var progresses: [Double] = []
+
+  func startObserving(_ manager: ModelManager) {
+    record(manager.state)
+    withObservationTracking {
+      _ = manager.state
+    } onChange: { [weak self, weak manager] in
+      // onChange fires synchronously on the mutating actor; re-arm via a Task
+      // so the next mutation is captured.
+      Task { @MainActor [weak self, weak manager] in
+        guard let self, let manager else { return }
+        self.startObserving(manager)
+      }
+    }
+  }
+
+  private func record(_ state: ModelState) {
+    if case .downloading(let progress) = state {
+      progresses.append(progress)
     }
   }
 }

--- a/Pastura/PasturaTests/App/ModelManagerTests.swift
+++ b/Pastura/PasturaTests/App/ModelManagerTests.swift
@@ -42,7 +42,9 @@ struct MockModelDownloader: ModelDownloader, Sendable {
 @MainActor
 struct ModelManagerTests {
 
-  private func makeSUT(
+  // Internal (not `private`) so sibling test files extending this suite
+  // (e.g., `ModelManagerTests+ProgressRegression.swift`) can construct an SUT.
+  func makeSUT(
     downloader: any ModelDownloader = MockModelDownloader(),
     physicalMemory: UInt64 = 8 * 1024 * 1024 * 1024,
     expectedFileSize: Int64 = 0,

--- a/Pastura/PasturaTests/App/ProgressThrottleTests.swift
+++ b/Pastura/PasturaTests/App/ProgressThrottleTests.swift
@@ -1,0 +1,93 @@
+import Testing
+
+@testable import Pastura
+
+@Suite(.timeLimit(.minutes(1)))
+struct ProgressThrottleTests {
+
+  // MARK: - First call
+
+  @Test func firstCallAlwaysReturnsTrue() {
+    var throttle = ProgressThrottle()
+    let now = ContinuousClock.now
+    #expect(throttle.shouldEmit(now: now) == true)
+  }
+
+  @Test func firstCallWithCustomIntervalAlwaysReturnsTrue() {
+    var throttle = ProgressThrottle(interval: .milliseconds(50))
+    let now = ContinuousClock.now
+    #expect(throttle.shouldEmit(now: now) == true)
+  }
+
+  // MARK: - Within interval
+
+  @Test func secondCallWithinIntervalReturnsFalse() {
+    var throttle = ProgressThrottle()
+    let now = ContinuousClock.now
+    _ = throttle.shouldEmit(now: now)
+    // 50ms < 100ms default interval
+    #expect(throttle.shouldEmit(now: now + .milliseconds(50)) == false)
+  }
+
+  // MARK: - Boundary semantics (>= interval)
+
+  @Test func secondCallExactlyAtIntervalReturnsTrue() {
+    var throttle = ProgressThrottle()
+    let now = ContinuousClock.now
+    _ = throttle.shouldEmit(now: now)
+    // Exactly at the default 100ms interval — >= semantics means accepted.
+    #expect(throttle.shouldEmit(now: now + .milliseconds(100)) == true)
+  }
+
+  @Test func secondCallPastIntervalReturnsTrue() {
+    var throttle = ProgressThrottle()
+    let now = ContinuousClock.now
+    _ = throttle.shouldEmit(now: now)
+    // 150ms > 100ms default interval
+    #expect(throttle.shouldEmit(now: now + .milliseconds(150)) == true)
+  }
+
+  // MARK: - Window resets after accepted call
+
+  @Test func windowResetsAfterAcceptedCall() {
+    var throttle = ProgressThrottle()
+    let now = ContinuousClock.now
+    // t=0: accepted (first call)
+    _ = throttle.shouldEmit(now: now)
+    // t=100ms: accepted (>= interval since t=0)
+    _ = throttle.shouldEmit(now: now + .milliseconds(100))
+    // t=150ms: within interval of t=100ms — should be rejected
+    #expect(throttle.shouldEmit(now: now + .milliseconds(150)) == false)
+  }
+
+  // MARK: - Skipped calls don't advance timestamp
+
+  @Test func skippedCallsDoNotAdvanceStoredTimestamp() {
+    var throttle = ProgressThrottle()
+    let now = ContinuousClock.now
+    // t=0: accepted (first call)
+    _ = throttle.shouldEmit(now: now)
+    // t=50ms: skipped (within interval of t=0)
+    _ = throttle.shouldEmit(now: now + .milliseconds(50))
+    // t=100ms: should be accepted (>= interval since t=0, the last accepted)
+    #expect(throttle.shouldEmit(now: now + .milliseconds(100)) == true)
+  }
+
+  // MARK: - Custom interval
+
+  @Test func customIntervalAcceptsAtBoundary() {
+    var throttle = ProgressThrottle(interval: .milliseconds(50))
+    let now = ContinuousClock.now
+    _ = throttle.shouldEmit(now: now)
+    // Exactly at 50ms — accepted under custom interval
+    #expect(throttle.shouldEmit(now: now + .milliseconds(50)) == true)
+  }
+
+  @Test func customIntervalRejectsJustBeforeBoundary() {
+    var throttle = ProgressThrottle(interval: .milliseconds(50))
+    let now = ContinuousClock.now
+    _ = throttle.shouldEmit(now: now)
+    // 49ms < 50ms custom interval — rejected
+    #expect(throttle.shouldEmit(now: now + .milliseconds(49)) == false)
+  }
+}


### PR DESCRIPTION
## Summary
- `URLSession.didWriteData` fires hundreds of times per second during a 3 GB model download; the previous code spawned a fresh `Task { @MainActor }` per tick, saturating the MainActor scheduler for the entire multi-minute download.
- Add `ProgressThrottle` (~10 Hz / 100 ms, monotonic `ContinuousClock`) wrapped in `OSAllocatedUnfairLock`, and gate the MainActor hop on it.
- Force `state = .downloading(progress: 1.0)` after `download()` returns and before SHA256 verification — production URLSession doesn't guarantee a terminal `received == total` callback, and SHA256 hashing of 3 GB takes ~2 s, so without this the UI would stall at the last sub-1.0 sample.

## Test plan
- [x] `ProgressThrottleTests` (9 cases): first-call / within-interval / boundary / past-interval / window-reset / skipped-doesn't-advance / custom-interval
- [x] `ModelManagerProgressTests/downloadCompletesWhenDownloaderSkipsTerminalProgress` — uses a mock that emits no terminal callback; asserts the user-visible 100 % is still reached
- [x] Full unit suite passes (`xcodebuild test ... -skip-testing:PasturaUITests`)
- [x] `swiftlint --strict` clean
- [x] Manual verification on device during a real model download — observe smooth progress and a 100 % UI before the SHA256 verify step

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)