### PR TITLE
🧪 test: streaming display diagnostic instrumentation (#133)

### DIFF
--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -266,6 +266,18 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     // conflate interleaved agents. If Phase 3 ever parallelises `speak_all`,
     // this dict becomes racy and must be reworked.
     private var inflightInferenceAttempts: [String: Int] = [:]
+
+    // Previous-raw-primary tracker for Hyp A' (silent stream re-issue).
+    // `LLMCaller.consumeStreamWithSuspendRetry` re-issues the stream on
+    // `.suspended` without firing `.inferenceStarted` — visually identical
+    // to a parse retry (streaming row's text restarts) but invisible to
+    // the attempt counter above. We catch it by remembering the last raw
+    // `primary` per agent and logging when the next one is neither an
+    // extension nor a shrink-to-prefix (i.e. content diverged).
+    //
+    // Uses raw (pre-ContentFilter) primary so filter rewrites like
+    // "fuck" → "***" aren't mistaken for a reset.
+    private var lastRawStreamingPrimary: [String: String] = [:]
   #endif
   // Non-private so `@testable import` can seed persistence without invoking `run()`.
   internal var simulationId: String?
@@ -423,6 +435,7 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     prerevealedAgentOutputIds = []
     #if DEBUG
       inflightInferenceAttempts = [:]
+      lastRawStreamingPrimary = [:]
     #endif
     scores = Dictionary(uniqueKeysWithValues: scenario.personas.map { ($0.name, 0) })
     eliminated = Dictionary(uniqueKeysWithValues: scenario.personas.map { ($0.name, false) })
@@ -540,6 +553,19 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     case .agentOutput(let agent, let output, let phaseType):
       handleAgentOutput(agent: agent, output: output, phaseType: phaseType)
     case .agentOutputStream(let agent, let primary, let thought):
+      #if DEBUG
+        // Hyp A' signal: detect stream restart that didn't go through
+        // `.inferenceStarted` (LLMCaller suspend-resume re-issue path).
+        if let newPrimary = primary, !newPrimary.isEmpty,
+          let existing = lastRawStreamingPrimary[agent],
+          !newPrimary.hasPrefix(existing),
+          !existing.hasPrefix(newPrimary) {
+          Self.streamingDiagLogger.info(
+            "streamReset agent=\(agent, privacy: .public) oldLen=\(existing.count) newLen=\(newPrimary.count)"
+          )
+        }
+        if let newPrimary = primary { lastRawStreamingPrimary[agent] = newPrimary }
+      #endif
       handleAgentOutputStream(agent: agent, primary: primary, thought: thought)
     case .simulationCompleted:
       isCompleted = true
@@ -561,6 +587,11 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
             "retry agent=\(agent, privacy: .public) attempt=\(attempt)"
           )
         }
+        // Clear raw-primary tracker so the retry's new stream doesn't
+        // double-log as a streamReset — parse retry is owned by the
+        // attempt counter above; streamReset measures the *silent*
+        // re-issue path (suspend-resume) that bypasses this event.
+        lastRawStreamingPrimary[agent] = nil
       #endif
     case .inferenceCompleted(let agent, let seconds, let tokens):
       thinkingAgents.remove(agent)
@@ -650,6 +681,7 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
         )
       }
       inflightInferenceAttempts[agent] = nil
+      lastRawStreamingPrimary[agent] = nil
     #endif
     let filtered = contentFilter.filter(output)
     // Divergence telemetry: compare the last streamed snapshot against

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -245,6 +245,28 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   // routine state transitions and `error` for unexpected paths so device logs
   // stay readable.
   let lifecycleLogger = Logger(subsystem: "com.pastura", category: "SimulationVM")
+
+  #if DEBUG
+    // Streaming-display diagnostic logger for #133 PR#4 device-run sessions.
+    // Shared across VM + `AgentOutputRow`; filter Console.app with
+    // `subsystem:com.pastura category:StreamingDiag` to surface the 2 signals
+    // feeding PR#5 ADR pivot-path decision (Hyp A retry / Hyp B recycle).
+    // `.info` level so it shows without `log config` overrides on-device.
+    static let streamingDiagLogger = Logger(
+      subsystem: "com.pastura", category: "StreamingDiag")
+
+    // Per-agent in-flight attempt counter for Hyp A (parse-retry silent
+    // transition). `LLMCaller.call` emits `.inferenceStarted` +
+    // `.inferenceCompleted` *per attempt* inside its retry loop — so clearing
+    // on `.inferenceCompleted` would collapse the retry signal. We instead
+    // clear on `.agentOutput` (per-turn commit) and on `run()` entry.
+    //
+    // Load-bearing assumption: ADR-002 §6 — the Engine runs inferences
+    // sequentially, so a single `[String: Int]` keyed on agent name cannot
+    // conflate interleaved agents. If Phase 3 ever parallelises `speak_all`,
+    // this dict becomes racy and must be reworked.
+    private var inflightInferenceAttempts: [String: Int] = [:]
+  #endif
   // Non-private so `@testable import` can seed persistence without invoking `run()`.
   internal var simulationId: String?
 
@@ -399,6 +421,9 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     latestAgentOutputId = nil
     streamingSnapshot = nil
     prerevealedAgentOutputIds = []
+    #if DEBUG
+      inflightInferenceAttempts = [:]
+    #endif
     scores = Dictionary(uniqueKeysWithValues: scenario.personas.map { ($0.name, 0) })
     eliminated = Dictionary(uniqueKeysWithValues: scenario.personas.map { ($0.name, false) })
     totalRounds = scenario.rounds
@@ -526,6 +551,17 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
       // A new inference starts: any leftover snapshot from a previous
       // attempt (parse retry, different agent) must not linger in the UI.
       streamingSnapshot = nil
+      #if DEBUG
+        inflightInferenceAttempts[agent, default: 0] += 1
+        let attempt = inflightInferenceAttempts[agent] ?? 0
+        // Noise-gate: only log retries (attempt ≥ 2). First attempts are every
+        // turn and would drown the signal.
+        if attempt >= 2 {
+          Self.streamingDiagLogger.info(
+            "retry agent=\(agent, privacy: .public) attempt=\(attempt)"
+          )
+        }
+      #endif
     case .inferenceCompleted(let agent, let seconds, let tokens):
       thinkingAgents.remove(agent)
       handleInferenceCompleted(durationSeconds: seconds, tokenCount: tokens)
@@ -603,6 +639,18 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   }
 
   private func handleAgentOutput(agent: String, output: TurnOutput, phaseType: PhaseType) {
+    #if DEBUG
+      // Turn-commit: emit final tally if it required retries, then clear.
+      // The clear has to sit here (not in `.inferenceCompleted`) because
+      // LLMCaller emits `.inferenceCompleted` per attempt; `.agentOutput`
+      // is the unique "this turn is done" signal.
+      if let total = inflightInferenceAttempts[agent], total > 1 {
+        Self.streamingDiagLogger.info(
+          "committed agent=\(agent, privacy: .public) totalAttempts=\(total)"
+        )
+      }
+      inflightInferenceAttempts[agent] = nil
+    #endif
     let filtered = contentFilter.filter(output)
     // Divergence telemetry: compare the last streamed snapshot against
     // the canonical parser result for the same inference. A mismatch

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -554,17 +554,7 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
       handleAgentOutput(agent: agent, output: output, phaseType: phaseType)
     case .agentOutputStream(let agent, let primary, let thought):
       #if DEBUG
-        // Hyp A' signal: detect stream restart that didn't go through
-        // `.inferenceStarted` (LLMCaller suspend-resume re-issue path).
-        if let newPrimary = primary, !newPrimary.isEmpty,
-          let existing = lastRawStreamingPrimary[agent],
-          !newPrimary.hasPrefix(existing),
-          !existing.hasPrefix(newPrimary) {
-          Self.streamingDiagLogger.info(
-            "streamReset agent=\(agent, privacy: .public) oldLen=\(existing.count) newLen=\(newPrimary.count)"
-          )
-        }
-        if let newPrimary = primary { lastRawStreamingPrimary[agent] = newPrimary }
+        detectSilentStreamReIssue(agent: agent, primary: primary)
       #endif
       handleAgentOutputStream(agent: agent, primary: primary, thought: thought)
     case .simulationCompleted:
@@ -731,6 +721,43 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   /// pre-streaming flow (thinking indicator → committed row at
   /// `.agentOutput`). LLMCaller still produces the events but they
   /// become no-ops here; the cost is negligible.
+  #if DEBUG
+    /// Hyp A' signal: detect stream restart that didn't go through
+    /// `.inferenceStarted` (LLMCaller `consumeStreamWithSuspendRetry`
+    /// re-issue path on `.suspended`).
+    ///
+    /// Two sub-patterns — normal appending never hits either:
+    ///  - "diverge" — new is neither an extension nor a prefix-shrink
+    ///    of existing. Fires when the re-issued stream produces
+    ///    different text (non-deterministic LLM).
+    ///  - "shrink"  — new is a strict prefix of existing (`new.count <
+    ///    existing.count` AND `existing.hasPrefix(new)`). Fires on
+    ///    the first chunk of a re-issue when Gemma is deterministic
+    ///    enough to regenerate the same tokens — content goes
+    ///    backwards to "H" / "He" / ... before climbing back.
+    /// Partial parser shouldn't emit non-monotone primaries within a
+    /// single stream iteration, so shrink is a strong re-issue signal.
+    ///
+    /// Uses raw (pre-ContentFilter) primary so filter rewrites like
+    /// `"fuck" → "***"` aren't mistaken for resets.
+    private func detectSilentStreamReIssue(agent: String, primary: String?) {
+      guard let newPrimary = primary, !newPrimary.isEmpty else { return }
+      if let existing = lastRawStreamingPrimary[agent] {
+        let diverge =
+          !newPrimary.hasPrefix(existing) && !existing.hasPrefix(newPrimary)
+        let shrink =
+          newPrimary.count < existing.count && existing.hasPrefix(newPrimary)
+        if diverge || shrink {
+          let kind = diverge ? "diverge" : "shrink"
+          Self.streamingDiagLogger.info(
+            "streamReset agent=\(agent, privacy: .public) type=\(kind, privacy: .public) oldLen=\(existing.count) newLen=\(newPrimary.count)"
+          )
+        }
+      }
+      lastRawStreamingPrimary[agent] = newPrimary
+    }
+  #endif
+
   private func handleAgentOutputStream(
     agent: String, primary: String?, thought: String?
   ) {

--- a/Pastura/Pastura/Views/Components/AgentOutputRow+Diagnostic.swift
+++ b/Pastura/Pastura/Views/Components/AgentOutputRow+Diagnostic.swift
@@ -1,0 +1,39 @@
+#if DEBUG
+
+  import Foundation
+  import os
+
+  /// DEBUG-only diagnostic helpers for #133 PR#4 (streaming display
+  /// redesign). Isolated so the surface is easy to remove / revisit once
+  /// PR#5 ADR chooses a pivot path.
+  ///
+  /// Emissions feed the `StreamingDiag` category under `com.pastura` —
+  /// see `SimulationViewModel.streamingDiagLogger`. Filter Console.app with
+  /// `subsystem:com.pastura category:StreamingDiag` during device-run
+  /// sessions.
+  extension AgentOutputRow {
+    /// Emit a lifecycle breadcrumb for Hyp B (LazyVStack `@State` recycle).
+    /// A second `onAppear` with a different `debugInstanceID` for the same
+    /// `debugRowID` indicates the row was torn down and rebuilt — and a
+    /// non-zero `visibleChars` prior to that re-appear that resets to 0 is
+    /// the observable symptom.
+    func logDebugLifecycle(event: String) {
+      let streaming = streamingPrimary != nil || streamingThought != nil
+      SimulationViewModel.streamingDiagLogger.info(
+        "\(event, privacy: .public) rowID=\(self.debugRowID ?? "nil", privacy: .public) agent=\(self.agent, privacy: .public) phase=\(self.phaseType.rawValue, privacy: .public) visibleChars=\(self.visibleChars) target=\(self.targetLength) streaming=\(streaming) instance=\(self.debugInstanceID.uuidString, privacy: .public)"
+      )
+    }
+
+    /// Emit on every streaming-growth notification, before the gate in
+    /// `handleStreamTargetChange`. `taskNil=true` or `taskCancelled=true`
+    /// during an active stream flags the cancel-race surface PR#147 +
+    /// PR#150 targeted; shouldn't reproduce in this PR's device runs, but
+    /// the signal stays visible if it does.
+    func logStreamTargetChange(newTarget: Int) {
+      SimulationViewModel.streamingDiagLogger.info(
+        "streamTargetChange rowID=\(self.debugRowID ?? "nil", privacy: .public) agent=\(self.agent, privacy: .public) visibleChars=\(self.visibleChars) newTarget=\(newTarget) taskNil=\(self.animationTask == nil) taskCancelled=\(self.animationTask?.isCancelled == true)"
+      )
+    }
+  }
+
+#endif

--- a/Pastura/Pastura/Views/Components/AgentOutputRow.swift
+++ b/Pastura/Pastura/Views/Components/AgentOutputRow.swift
@@ -1,9 +1,5 @@
 import SwiftUI
 
-#if DEBUG
-  import os
-#endif
-
 /// Displays a single agent's output with an optional inner thought and an
 /// LLM-chat-style typing animation for the latest row.
 ///
@@ -68,27 +64,16 @@ struct AgentOutputRow: View {
   /// ``streamingPrimary``.
   var streamingThought: String?
 
-  /// Row-identity tag surfaced in `#if DEBUG` diagnostics (StreamingDiag
-  /// category). `nil` in release — the param itself is non-gated so call
-  /// sites don't need conditional compilation. Pass `entry.id.uuidString`
-  /// for committed rows or `"stream-<agent>"` for the in-flight row.
-  /// Consumed only by the onAppear / onDisappear / handleStreamTargetChange
-  /// log sites so #133 PR#4 device-run sessions can distinguish "same
-  /// entry recycled" from "different entry shown in the same slot."
+  /// Row-identity tag for #133 PR#4 `StreamingDiag` logs — see
+  /// `AgentOutputRow+Diagnostic.swift` for the consumers.
   var debugRowID: String?
 
   @State private var showInnerThought = false
-  @State private var visibleChars: Int = 0
-  @State private var animationTask: Task<Void, Never>?
-  #if DEBUG
-    /// Per-`@State`-lifecycle UUID for the row. Fresh value on every
-    /// `@State` reinitialisation (e.g., `LazyVStack` recycles the view off
-    /// and on screen) — Hypothesis B evidence. Correlate with `debugRowID`:
-    /// same `debugRowID` but different `debugInstanceID` on successive
-    /// `.onAppear` = the view was torn down and rebuilt, and `visibleChars`
-    /// reset to 0 is the observable symptom.
-    @State private var debugInstanceID = UUID()
-  #endif
+  @State var visibleChars: Int = 0
+  @State var animationTask: Task<Void, Never>?
+  /// Fresh UUID per `@State` reinitialisation; different value on successive
+  /// `.onAppear` for the same `debugRowID` = LazyVStack recycle evidence.
+  @State var debugInstanceID = UUID()
   /// Monotonic counter bumped once per reveal-task creation. The task's
   /// `defer` uses it to skip both the `animationTask` nil-out and the
   /// `onAnimatingChange?(false)` notification when a newer task has
@@ -126,7 +111,9 @@ struct AgentOutputRow: View {
     .fixedSize(horizontal: false, vertical: true)
     .padding(.vertical, 4)
     .onAppear {
-      logDebugLifecycle(event: "onAppear")
+      #if DEBUG
+        logDebugLifecycle(event: "onAppear")
+      #endif
       startAnimationIfNeeded()
     }
     .onChange(of: isLatest) { _, newValue in
@@ -143,7 +130,9 @@ struct AgentOutputRow: View {
     .onChange(of: streamingPrimary) { _, _ in handleStreamTargetChange() }
     .onChange(of: streamingThought) { _, _ in handleStreamTargetChange() }
     .onDisappear {
-      logDebugLifecycle(event: "onDisappear")
+      #if DEBUG
+        logDebugLifecycle(event: "onDisappear")
+      #endif
       animationTask?.cancel()
     }
   }
@@ -232,7 +221,7 @@ struct AgentOutputRow: View {
 
   /// Total characters the counter should cover: primary plus thought when
   /// thoughts are globally visible. Button-toggle reveal bypasses this.
-  private var targetLength: Int {
+  var targetLength: Int {
     let primary = primaryText?.count ?? 0
     let thought = showAllThoughts ? (resolvedThought?.count ?? 0) : 0
     return primary + thought
@@ -349,13 +338,7 @@ struct AgentOutputRow: View {
   private func handleStreamTargetChange() {
     let target = targetLength
     #if DEBUG
-      // Emit before the gate so the device log shows every streaming-growth
-      // notification regardless of whether it triggers a task restart.
-      let taskNil = animationTask == nil
-      let taskCancelled = animationTask?.isCancelled == true
-      SimulationViewModel.streamingDiagLogger.info(
-        "streamTargetChange rowID=\(self.debugRowID ?? "nil", privacy: .public) agent=\(self.agent, privacy: .public) visibleChars=\(self.visibleChars) newTarget=\(target) taskNil=\(taskNil) taskCancelled=\(taskCancelled)"
-      )
+      logStreamTargetChange(newTarget: target)
     #endif
     if !shouldAnimate {
       visibleChars = target
@@ -414,18 +397,4 @@ struct AgentOutputRow: View {
   private var resolvedThought: String? {
     streamingThought ?? output.innerThought
   }
-
-  #if DEBUG
-    /// Emit a lifecycle breadcrumb for #133 PR#4 Hyp B (LazyVStack `@State`
-    /// recycle) investigation. Reads `debugInstanceID` into a local so the
-    /// log line carries a stable UUID for the current `@State` lifetime; a
-    /// second onAppear with a different UUID for the same `debugRowID`
-    /// indicates the row was torn down and rebuilt.
-    private func logDebugLifecycle(event: String) {
-      let streaming = streamingPrimary != nil || streamingThought != nil
-      SimulationViewModel.streamingDiagLogger.info(
-        "\(event, privacy: .public) rowID=\(self.debugRowID ?? "nil", privacy: .public) agent=\(self.agent, privacy: .public) phase=\(self.phaseType.rawValue, privacy: .public) visibleChars=\(self.visibleChars) target=\(self.targetLength) streaming=\(streaming) instance=\(self.debugInstanceID.uuidString, privacy: .public)"
-      )
-    }
-  #endif
 }

--- a/Pastura/Pastura/Views/Components/AgentOutputRow.swift
+++ b/Pastura/Pastura/Views/Components/AgentOutputRow.swift
@@ -1,5 +1,9 @@
 import SwiftUI
 
+#if DEBUG
+  import os
+#endif
+
 /// Displays a single agent's output with an optional inner thought and an
 /// LLM-chat-style typing animation for the latest row.
 ///
@@ -64,9 +68,27 @@ struct AgentOutputRow: View {
   /// ``streamingPrimary``.
   var streamingThought: String?
 
+  /// Row-identity tag surfaced in `#if DEBUG` diagnostics (StreamingDiag
+  /// category). `nil` in release — the param itself is non-gated so call
+  /// sites don't need conditional compilation. Pass `entry.id.uuidString`
+  /// for committed rows or `"stream-<agent>"` for the in-flight row.
+  /// Consumed only by the onAppear / onDisappear / handleStreamTargetChange
+  /// log sites so #133 PR#4 device-run sessions can distinguish "same
+  /// entry recycled" from "different entry shown in the same slot."
+  var debugRowID: String?
+
   @State private var showInnerThought = false
   @State private var visibleChars: Int = 0
   @State private var animationTask: Task<Void, Never>?
+  #if DEBUG
+    /// Per-`@State`-lifecycle UUID for the row. Fresh value on every
+    /// `@State` reinitialisation (e.g., `LazyVStack` recycles the view off
+    /// and on screen) — Hypothesis B evidence. Correlate with `debugRowID`:
+    /// same `debugRowID` but different `debugInstanceID` on successive
+    /// `.onAppear` = the view was torn down and rebuilt, and `visibleChars`
+    /// reset to 0 is the observable symptom.
+    @State private var debugInstanceID = UUID()
+  #endif
   /// Monotonic counter bumped once per reveal-task creation. The task's
   /// `defer` uses it to skip both the `animationTask` nil-out and the
   /// `onAnimatingChange?(false)` notification when a newer task has
@@ -103,7 +125,10 @@ struct AgentOutputRow: View {
     .frame(maxWidth: .infinity, alignment: .leading)
     .fixedSize(horizontal: false, vertical: true)
     .padding(.vertical, 4)
-    .onAppear { startAnimationIfNeeded() }
+    .onAppear {
+      logDebugLifecycle(event: "onAppear")
+      startAnimationIfNeeded()
+    }
     .onChange(of: isLatest) { _, newValue in
       if !newValue { snapToFull() }
     }
@@ -117,7 +142,10 @@ struct AgentOutputRow: View {
     // also kick it back on.
     .onChange(of: streamingPrimary) { _, _ in handleStreamTargetChange() }
     .onChange(of: streamingThought) { _, _ in handleStreamTargetChange() }
-    .onDisappear { animationTask?.cancel() }
+    .onDisappear {
+      logDebugLifecycle(event: "onDisappear")
+      animationTask?.cancel()
+    }
   }
 
   // MARK: - Subviews
@@ -320,6 +348,15 @@ struct AgentOutputRow: View {
   /// branch instead of freezing until commit.
   private func handleStreamTargetChange() {
     let target = targetLength
+    #if DEBUG
+      // Emit before the gate so the device log shows every streaming-growth
+      // notification regardless of whether it triggers a task restart.
+      let taskNil = animationTask == nil
+      let taskCancelled = animationTask?.isCancelled == true
+      SimulationViewModel.streamingDiagLogger.info(
+        "streamTargetChange rowID=\(self.debugRowID ?? "nil", privacy: .public) agent=\(self.agent, privacy: .public) visibleChars=\(self.visibleChars) newTarget=\(target) taskNil=\(taskNil) taskCancelled=\(taskCancelled)"
+      )
+    #endif
     if !shouldAnimate {
       visibleChars = target
       return
@@ -377,4 +414,18 @@ struct AgentOutputRow: View {
   private var resolvedThought: String? {
     streamingThought ?? output.innerThought
   }
+
+  #if DEBUG
+    /// Emit a lifecycle breadcrumb for #133 PR#4 Hyp B (LazyVStack `@State`
+    /// recycle) investigation. Reads `debugInstanceID` into a local so the
+    /// log line carries a stable UUID for the current `@State` lifetime; a
+    /// second onAppear with a different UUID for the same `debugRowID`
+    /// indicates the row was torn down and rebuilt.
+    private func logDebugLifecycle(event: String) {
+      let streaming = streamingPrimary != nil || streamingThought != nil
+      SimulationViewModel.streamingDiagLogger.info(
+        "\(event, privacy: .public) rowID=\(self.debugRowID ?? "nil", privacy: .public) agent=\(self.agent, privacy: .public) phase=\(self.phaseType.rawValue, privacy: .public) visibleChars=\(self.visibleChars) target=\(self.targetLength) streaming=\(streaming) instance=\(self.debugInstanceID.uuidString, privacy: .public)"
+      )
+    }
+  #endif
 }

--- a/Pastura/Pastura/Views/Components/AgentOutputRow.swift
+++ b/Pastura/Pastura/Views/Components/AgentOutputRow.swift
@@ -69,10 +69,10 @@ struct AgentOutputRow: View {
   var debugRowID: String?
 
   @State private var showInnerThought = false
+  // Internal-only so `AgentOutputRow+Diagnostic.swift` can read — mutation surface is the animation-control methods below.
   @State var visibleChars: Int = 0
   @State var animationTask: Task<Void, Never>?
-  /// Fresh UUID per `@State` reinitialisation; different value on successive
-  /// `.onAppear` for the same `debugRowID` = LazyVStack recycle evidence.
+  /// Fresh UUID per `@State` recreation → LazyVStack recycle evidence (#133 Hyp B).
   @State var debugInstanceID = UUID()
   /// Monotonic counter bumped once per reveal-task creation. The task's
   /// `defer` uses it to skip both the `animationTask` nil-out and the

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -152,7 +152,8 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
                 isLatest: false,
                 charsPerSecond: viewModel.speed.charsPerSecond,
                 streamingPrimary: snapshot.primary,
-                streamingThought: snapshot.thought
+                streamingThought: snapshot.thought,
+                debugRowID: "stream-\(snapshot.agent)"
               )
               .padding(.horizontal)
               .id("streaming-\(snapshot.agent)")
@@ -334,7 +335,8 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
         onAnimatingChange: { animating in
           guard isLatest else { return }
           latestRowIsAnimating = animating
-        }
+        },
+        debugRowID: entry.id.uuidString
       )
       .padding(.horizontal)
     case .phaseStarted(let phaseType):

--- a/scripts/analyze-streaming-diag.sh
+++ b/scripts/analyze-streaming-diag.sh
@@ -45,7 +45,7 @@ summarise() {
   local total_lines diag_lines
   total_lines=$(wc -l <"$log" | tr -d ' ')
   diag_lines=$(grep -cE \
-    'retry agent=|committed agent=|onAppear rowID=|onDisappear rowID=|streamTargetChange rowID=' \
+    'retry agent=|committed agent=|streamReset agent=|onAppear rowID=|onDisappear rowID=|streamTargetChange rowID=' \
     "$log" || true)
   echo "  file lines:        $total_lines"
   echo "  diagnostic lines:  $diag_lines"
@@ -73,6 +73,30 @@ summarise() {
     echo "  → Hyp A: REPRODUCED"
   else
     echo "  → Hyp A: not reproduced this session"
+  fi
+  echo ""
+
+  # ── Hyp A': silent stream re-issue (suspend-resume path) ───
+  echo "── Hyp A' — silent stream re-issue (suspend-resume bypasses .inferenceStarted) ──"
+  local reset_count
+  reset_count=$(grep -cE 'streamReset agent=' "$log" || true)
+  echo "  streamReset log lines:  $reset_count"
+  if [ "$reset_count" != "0" ]; then
+    echo "  per-agent reset counts:"
+    grep -oE 'streamReset agent=[^ ]+' "$log" |
+      sort | uniq -c | sort -rn | sed 's/^/    /'
+    echo ""
+    echo "  first 5 occurrences:"
+    grep -E 'streamReset agent=' "$log" |
+      head -5 |
+      sed -E 's/^.*\[com\.pastura:StreamingDiag\] //' |
+      sed 's/^/    /'
+    echo ""
+    echo "  → Hyp A': REPRODUCED (raw partial replaced with content that's"
+    echo "     neither an extension nor a prefix-shrink → LLMCaller's"
+    echo "     consumeStreamWithSuspendRetry re-issued the stream)"
+  else
+    echo "  → Hyp A': not reproduced this session"
   fi
   echo ""
 
@@ -187,8 +211,12 @@ cat <<'VERDICT'
 ======================================================
   PR#5 ADR pivot matrix (fill in from above)
   ----------------------------------------------------
-    A reproduced AND B reproduced → pivot (a) full C′
-    only A reproduced             → pivot (b) retry-UX
-    neither reproduced            → pivot (c) Option 0
+    A reproduced AND B reproduced  → pivot (a) full C′
+    only A reproduced              → pivot (b) retry-UX
+    neither reproduced             → pivot (c) Option 0
+
+  Note: Hyp A' (silent stream re-issue) is orthogonal to the above.
+  If A' reproduces but A / B don't, the fix lives in BG suspend/resume
+  UX (related to #84 / #135), not in the #133 display-redesign axes.
 ======================================================
 VERDICT

--- a/scripts/analyze-streaming-diag.sh
+++ b/scripts/analyze-streaming-diag.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# analyze-streaming-diag.sh — parse #133 PR#4 device-run log captures.
+#
+# Summarises the three signals PR#5 ADR needs to pivot on:
+#   (A)  parse-retry     — `retry agent=X attempt=N` + `committed … totalAttempts=N`
+#   (B)  LazyVStack @State recycle — same `rowID` across ≥2 distinct `instance` UUIDs
+#   (B5) cancel-race residual      — `streamTargetChange … taskNil=true|taskCancelled=true`
+#
+# Both A and B reproduce → PR#5 pivot (a) full C′ (trailing slot + state hoist).
+# Only A reproduces      → pivot (b) retry-UX fix; skip state hoist + trailing slot.
+# Neither reproduces     → pivot (c) Option 0, close #133.
+#
+# Usage:
+#   scripts/analyze-streaming-diag.sh <session.log> [more.log ...]
+#
+# Accepts either a Console.app "Save As plain text" export or a
+# `log stream --predicate 'subsystem == "com.pastura" AND category == "StreamingDiag"'`
+# redirect. The parser matches on the message-body prefixes our Logger
+# emits, so the surrounding column layout doesn't matter.
+
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+  cat >&2 <<USAGE
+Usage: $0 <session.log> [more.log ...]
+
+Each <session.log> is a plain-text capture of the com.pastura /
+StreamingDiag category. See the PR description for capture steps.
+USAGE
+  exit 1
+fi
+
+summarise() {
+  local log="$1"
+
+  echo "======================================================"
+  echo "  Session: $log"
+  echo "======================================================"
+
+  if ! [ -f "$log" ]; then
+    echo "  ⚠️  File not found, skipping." >&2
+    return
+  fi
+
+  local total_lines diag_lines
+  total_lines=$(wc -l <"$log" | tr -d ' ')
+  diag_lines=$(grep -cE \
+    'retry agent=|committed agent=|onAppear rowID=|onDisappear rowID=|streamTargetChange rowID=' \
+    "$log" || true)
+  echo "  file lines:        $total_lines"
+  echo "  diagnostic lines:  $diag_lines"
+  if [ "$diag_lines" = "0" ]; then
+    echo "  ⚠️  No diagnostic lines found — wrong file, or filter mismatch." >&2
+    echo ""
+    return
+  fi
+  echo ""
+
+  # ── Hyp A: parse-retry ─────────────────────────────────────
+  echo "── Hyp A — parse-retry (silent re-fire of .inferenceStarted) ──"
+  local retry_count
+  retry_count=$(grep -cE 'retry agent=' "$log" || true)
+  echo "  retry log lines (attempt ≥ 2):  $retry_count"
+  if [ "$retry_count" != "0" ]; then
+    echo "  per-agent retry attempts:"
+    grep -oE 'retry agent=[^ ]+ attempt=[0-9]+' "$log" |
+      sort | uniq -c | sort -rn | sed 's/^/    /'
+    echo ""
+    echo "  committed turns that required retry:"
+    grep -oE 'committed agent=[^ ]+ totalAttempts=[0-9]+' "$log" |
+      sort | uniq -c | sort -rn | sed 's/^/    /'
+    echo ""
+    echo "  → Hyp A: REPRODUCED"
+  else
+    echo "  → Hyp A: not reproduced this session"
+  fi
+  echo ""
+
+  # ── Hyp B: LazyVStack @State recycle ───────────────────────
+  echo "── Hyp B — LazyVStack @State recycle ─────────────────────────"
+  local recycles
+  recycles=$(
+    {
+      grep 'onAppear rowID=' "$log" || true
+    } |
+      sed -E 's/.*rowID=([^ ]+).*instance=([^ ]+).*/\1 \2/' |
+      sort -u |
+      awk '{ print $1 }' |
+      sort | uniq -c |
+      awk '$1 >= 2 { print $0 }'
+  )
+  if [ -z "$recycles" ]; then
+    echo "  0 rowIDs with ≥2 distinct instance UUIDs"
+    echo "  → Hyp B: not reproduced this session"
+  else
+    echo "  rowIDs with ≥2 distinct instance UUIDs (count, rowID):"
+    echo "$recycles" | sed 's/^/    /'
+    echo ""
+    echo "  → Hyp B: REPRODUCED — timelines:"
+    echo "$recycles" | awk '{ print $2 }' | while read -r row; do
+      echo "    ── $row ──"
+      grep "rowID=$row " "$log" |
+        sed -E 's/^.*\[com\.pastura:StreamingDiag\] //' |
+        grep -E '^(onAppear|onDisappear|streamTargetChange)' |
+        sed 's/^/      /'
+    done
+  fi
+  echo ""
+
+  # ── B5 residual: cancel-race ───────────────────────────────
+  echo "── B5 residual — cancel-race (expected 0 after PR#147+#150) ──"
+  local race_count
+  race_count=$(
+    {
+      grep 'streamTargetChange' "$log" || true
+    } | grep -cE 'taskNil=true|taskCancelled=true' || true
+  )
+  echo "  streamTargetChange with taskNil=true OR taskCancelled=true: $race_count"
+  if [ "$race_count" != "0" ]; then
+    echo "  first 5 occurrences:"
+    {
+      grep 'streamTargetChange' "$log" || true
+    } | grep -E 'taskNil=true|taskCancelled=true' |
+      head -5 |
+      sed -E 's/^.*\[com\.pastura:StreamingDiag\] //' |
+      sed 's/^/    /'
+    echo ""
+    echo "  → B5 residual detected — investigate before assuming PR#147+#150 closed it"
+  else
+    echo "  → B5 residual: clean"
+  fi
+  echo ""
+}
+
+for log in "$@"; do
+  summarise "$log"
+done
+
+cat <<'VERDICT'
+======================================================
+  PR#5 ADR pivot matrix (fill in from above)
+  ----------------------------------------------------
+    A reproduced AND B reproduced → pivot (a) full C′
+    only A reproduced             → pivot (b) retry-UX
+    neither reproduced            → pivot (c) Option 0
+======================================================
+VERDICT

--- a/scripts/analyze-streaming-diag.sh
+++ b/scripts/analyze-streaming-diag.sh
@@ -78,10 +78,15 @@ summarise() {
 
   # ── Hyp A': silent stream re-issue (suspend-resume path) ───
   echo "── Hyp A' — silent stream re-issue (suspend-resume bypasses .inferenceStarted) ──"
-  local reset_count
+  local reset_count diverge_count shrink_count
   reset_count=$(grep -cE 'streamReset agent=' "$log" || true)
-  echo "  streamReset log lines:  $reset_count"
+  diverge_count=$(grep -cE 'streamReset .*type=diverge' "$log" || true)
+  shrink_count=$(grep -cE 'streamReset .*type=shrink' "$log" || true)
+  echo "  streamReset total:               $reset_count"
+  echo "    type=shrink  (new is strict prefix of existing): $shrink_count"
+  echo "    type=diverge (new not prefix-related):           $diverge_count"
   if [ "$reset_count" != "0" ]; then
+    echo ""
     echo "  per-agent reset counts:"
     grep -oE 'streamReset agent=[^ ]+' "$log" |
       sort | uniq -c | sort -rn | sed 's/^/    /'
@@ -92,9 +97,10 @@ summarise() {
       sed -E 's/^.*\[com\.pastura:StreamingDiag\] //' |
       sed 's/^/    /'
     echo ""
-    echo "  → Hyp A': REPRODUCED (raw partial replaced with content that's"
-    echo "     neither an extension nor a prefix-shrink → LLMCaller's"
-    echo "     consumeStreamWithSuspendRetry re-issued the stream)"
+    echo "  → Hyp A': REPRODUCED — LLMCaller's consumeStreamWithSuspendRetry"
+    echo "     re-issued the stream without firing .inferenceStarted."
+    echo "     shrink = deterministic re-issue (same tokens regenerated);"
+    echo "     diverge = non-deterministic re-issue (different content)."
   else
     echo "  → Hyp A': not reproduced this session"
   fi

--- a/scripts/analyze-streaming-diag.sh
+++ b/scripts/analyze-streaming-diag.sh
@@ -108,27 +108,74 @@ summarise() {
   echo ""
 
   # ── B5 residual: cancel-race ───────────────────────────────
-  echo "── B5 residual — cancel-race (expected 0 after PR#147+#150) ──"
-  local race_count
-  race_count=$(
-    {
-      grep 'streamTargetChange' "$log" || true
-    } | grep -cE 'taskNil=true|taskCancelled=true' || true
+  # Split streamTargetChange events into 4 buckets:
+  #   (a) no_op:       visibleChars >= newTarget (target shrunk or fully revealed; reveal loop idle)
+  #   (b) continuing:  visibleChars < newTarget AND task running (ideal post-PR#147)
+  #   (c) restart_nil: visibleChars < newTarget AND taskNil=true (task finished between tokens; normal)
+  #   (d) restart_cancelled: visibleChars < newTarget AND taskCancelled=true (B5 residual — should be 0)
+  #
+  # (d) is the only bucket that directly indicates the cancel-race PR#147+#150 targeted.
+  # High (c) is expected when cps > stream rate (task catches up and exits between tokens).
+  # Flicker is subjective — watch the device; the script only bounds the race surface.
+  echo "── B5 residual — cancel-race surface (see script comment for buckets) ──"
+  awk '
+    /streamTargetChange/ {
+      vc = 0; nt = 0; tn = "false"; tc = "false"
+      for (i = 1; i <= NF; i++) {
+        if ($i ~ /^visibleChars=/)   { split($i, a, "="); vc = a[2] + 0 }
+        if ($i ~ /^newTarget=/)      { split($i, a, "="); nt = a[2] + 0 }
+        if ($i ~ /^taskNil=/)        { split($i, a, "="); tn = a[2] }
+        if ($i ~ /^taskCancelled=/)  { split($i, a, "="); tc = a[2] }
+      }
+      total++
+      if (vc >= nt)            { noop++ }
+      else if (tc == "true")   { rcancelled++ }
+      else if (tn == "true")   { rnil++ }
+      else                     { cont++ }
+    }
+    END {
+      printf "  total streamTargetChange events: %d\n", total+0
+      printf "    (a) no-op (visibleChars >= newTarget):           %d\n", noop+0
+      printf "    (b) continuing (task still revealing; ideal):    %d\n", cont+0
+      printf "    (c) restart from nil (normal post-PR#147):       %d\n", rnil+0
+      printf "    (d) restart from cancelled (B5 residual signal): %d\n", rcancelled+0
+    }
+  ' "$log"
+  local rcancelled_count
+  rcancelled_count=$(
+    awk '
+      /streamTargetChange/ && /taskCancelled=true/ {
+        for (i = 1; i <= NF; i++) {
+          if ($i ~ /^visibleChars=/) { split($i, a, "="); vc = a[2] + 0 }
+          if ($i ~ /^newTarget=/)    { split($i, a, "="); nt = a[2] + 0 }
+        }
+        if (vc < nt) c++
+      }
+      END { print c+0 }
+    ' "$log"
   )
-  echo "  streamTargetChange with taskNil=true OR taskCancelled=true: $race_count"
-  if [ "$race_count" != "0" ]; then
-    echo "  first 5 occurrences:"
-    {
-      grep 'streamTargetChange' "$log" || true
-    } | grep -E 'taskNil=true|taskCancelled=true' |
-      head -5 |
+  if [ "$rcancelled_count" != "0" ]; then
+    echo ""
+    echo "  ⚠️  (d) is non-zero — investigate. First 5 occurrences:"
+    awk '
+      /streamTargetChange/ && /taskCancelled=true/ {
+        for (i = 1; i <= NF; i++) {
+          if ($i ~ /^visibleChars=/) { split($i, a, "="); vc = a[2] + 0 }
+          if ($i ~ /^newTarget=/)    { split($i, a, "="); nt = a[2] + 0 }
+        }
+        if (vc < nt) print
+      }
+    ' "$log" | head -5 |
       sed -E 's/^.*\[com\.pastura:StreamingDiag\] //' |
       sed 's/^/    /'
-    echo ""
-    echo "  → B5 residual detected — investigate before assuming PR#147+#150 closed it"
+    echo "  → B5 residual: REPRODUCED (cancel-race surface still exercised)"
   else
-    echo "  → B5 residual: clean"
+    echo "  → B5 residual: clean (cancel-race surface not triggered this session)"
   fi
+  echo ""
+  echo "  Note: flicker is a subjective visual signal. Low (d) == cancel-race race"
+  echo "        surface wasn't exercised, but doesn't prove absence of flicker from"
+  echo "        other causes. Watch the device during the session."
   echo ""
 }
 


### PR DESCRIPTION
## Summary

- **#133 PR#4 / master-tracker diagnostic instrumentation.** `#if DEBUG`-gated telemetry on the two hypotheses PR#5 ADR needs to distinguish (Hyp A = parse-retry silent transition, Hyp B = `LazyVStack` `@State` recycle). Zero behavior change in Release; helpers isolated in a sidecar file so removal after PR#5's pivot-path decision is a single-file delete.
- **Hyp A — retry counter** (`SimulationViewModel`). Per-agent attempt dict, incremented on `.inferenceStarted` and cleared on `.agentOutput` commit. Chose `.agentOutput` (not `.inferenceCompleted`) because `LLMCaller.call` emits `.inferenceCompleted` **per retry attempt** inside its loop (`LLMCaller.swift:60,70`), so clearing there would collapse the signal. Noise-gated: logs only when `attempt ≥ 2` and on committed totals `> 1`.
- **Hyp B — row lifecycle + stream-target** (`AgentOutputRow` + new `+Diagnostic.swift` sidecar extension). Adds `debugRowID: String?` prop + `@State var debugInstanceID: UUID`. `.onAppear`/`.onDisappear`/`handleStreamTargetChange` emit into the `StreamingDiag` category. A re-appear with a *different* `debugInstanceID` for the *same* `debugRowID` is the positive Hyp B signal.
- **`scripts/analyze-streaming-diag.sh`** — log parser that turns session captures into a pivot-decision report.

## Design decisions (critic + code-reviewer fed)

- **No per-tick `visibleChars` log.** Master tracker originally listed it as "B5 validation," but B5 cancel-race was fixed deterministically in PR#147 + PR#150 — tick trace is vestigial and ~13k lines/sim at `.fast` cps would drown the higher-level signals.
- **Sidecar extension file** (`AgentOutputRow+Diagnostic.swift`, entire body `#if DEBUG`-wrapped). Keeps the main file under the 400-line `file_length` budget and makes the diagnostic surface removable as one file.
- **Internal promotion on a small subset of `@State`** (`visibleChars`, `animationTask`, `targetLength`, `debugInstanceID`). Required for the sidecar extension to read them; mutation surface still lives inside `AgentOutputRow` itself. Flagged with a one-line MARK note near the declarations.
- **`.info` log level, not `.debug`** — critic Axis 4. `.debug` requires a `log config` override to surface in Console.app; `.info` ships visible by default for quicker device-run sessions.

## How to capture on device

1. Build & run on device (Xcode `Cmd+R` or TestFlight debug build).
2. **Console.app** (recommended) → attach the device under **Devices** → search bar: `subsystem:com.pastura category:StreamingDiag` → **Start** → run preset → **Action → Save As… → Plain Text** to `session1.log`.
   *Or CLI:*
   ```bash
   log stream --device <UDID> \
     --predicate 'subsystem == "com.pastura" AND category == "StreamingDiag"' \
     > session1.log
   ```
3. Repeat for `session2.log` (master-tracker timebox = 2 sessions).

## How to analyse

```bash
scripts/analyze-streaming-diag.sh session1.log session2.log
```

Output is a multi-section report with per-session Hyp A retry counts, Hyp B recycle candidates (+ per-rowID timelines), and B5 residual counts. The report ends with a pivot-matrix reminder for the PR#5 ADR verdict.

| Signal | Hyp | Raw log pattern |
|---|---|---|
| Retry | A | `retry agent=X attempt=2` followed by `committed agent=X totalAttempts=2` |
| **Silent stream re-issue** | **A′** | `streamReset agent=X oldLen=N newLen=M` (raw partial replaced with divergent content — suspend-resume re-issue bypassing `.inferenceStarted`) |
| Recycle | B | Two successive `onAppear` lines for the same `rowID=<uuid>` with different `instance=<uuid>` values |
| Cancel-race residual | B5 | `streamTargetChange` with `taskCancelled=true` AND `visibleChars < newTarget` (bucket (d) in analyzer output) |

Decision matrix (both sessions combined):
- **Hyp A and Hyp B both reproduce** → pivot (a) full C′ (PR#7 state hoist + PR#8a/b trailing slot).
- **Only Hyp A reproduces** → pivot (b) ship retry-UX fix; skip state hoist + trailing slot.
- **Neither reproduces** → pivot (c) Option 0, close #133.
- **Hyp A′ reproduces** (orthogonal to A/B/B5): fix lives in BG suspend-resume UX (related to #84 / #135), not in the #133 display-redesign axes.

## Test plan

- [x] Full unit-test suite (`** TEST SUCCEEDED **`, all existing streaming tests pass — no XCTest additions, DEBUG-only `os.Logger` output isn't observable from XCTest).
- [x] `swiftlint --strict` clean.
- [x] Release build compiles (`-configuration Release`, confirms all DEBUG gates hold).
- [x] `analyze-streaming-diag.sh` smoke-tested on synthetic logs (reproduced / clean / missing-file / wrong-category / multi-session).
- [x] Device run session 1 — record via `analyze-streaming-diag.sh`.
- [ ] Device run session 2 — cross-check; feed both reports into PR#5 ADR.

## References

- Master tracker: https://github.com/tyabu12/pastura/issues/133#issuecomment-4274137067
- PR#4 plan comment: https://github.com/tyabu12/pastura/issues/133#issuecomment-4276211432
- Preceding shipped: PR#140 (PR#1 ContentFilter), PR#147+#150 (PR#2 reveal-stability), PR#154 (PR#3 layout-stability)

🤖 Generated with [Claude Code](https://claude.com/claude-code)