### PR TITLE
🔧 ci: add Release-iphoneos build job + ADR-005 §8 symbol guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,91 @@ jobs:
           path: UITestResults.xcresult
           retention-days: 7
 
+  # Enforces ADR-005 §8.5 on every PR: `OllamaService` must not link into the
+  # Release-iphoneos binary (App-Store-submission target). Runs in parallel
+  # with lint-and-test and ui-test. See ADR-005 §8 and docs/decisions/ADR-005.md.
+  release-build:
+    name: Release build (iphoneos) + ADR-005 §8 guard
+    runs-on: macos-26
+    timeout-minutes: 15
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.4.app/Contents/Developer
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Select Xcode
+        run: xcodebuild -version
+
+      # Same key/path as lint-and-test / ui-test — shared warm SPM cache.
+      # See the lint-and-test Cache step for the rationale on CI staying on
+      # the default ~/Library DerivedData path.
+      - name: Cache SPM packages
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData/**/SourcePackages
+          key: spm-${{ runner.os }}-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: spm-${{ runner.os }}-
+
+      # Deliberately NO `|| true` / PIPESTATUS dance here, unlike the
+      # unit/UI test steps above. Those steps must continue past xcodebuild
+      # failure to parse log output for the sticky PR comment; this step
+      # only needs the binary for the symbol grep. With GHA's default
+      # `bash -eo pipefail`, a non-zero xcodebuild exit short-circuits the
+      # `tee` pipeline naturally — that is the intended behaviour here.
+      # -sdk iphoneos (not iphonesimulator) because Release-simulator still
+      # defines targetEnvironment(simulator), which would pull OllamaService
+      # back in and make the guard fire vacuously.
+      - name: Release build
+        run: |
+          xcodebuild build \
+            -scheme Pastura \
+            -project Pastura/Pastura.xcodeproj \
+            -configuration Release \
+            -sdk iphoneos \
+            CODE_SIGNING_ALLOWED=NO 2>&1 | tee /tmp/release-build.log
+
+      - name: Verify ADR-005 §8 — OllamaService excluded
+        run: |
+          # Locate the Release-iphoneos binary. xcodebuild uses the default
+          # ~/Library/... DerivedData on CI (see Cache step). Multiple matches
+          # would indicate a cache-layout bug — fail loudly rather than pick one.
+          # Portable while/read loop because `mapfile` is bash 4+ and GHA
+          # macOS runners default to /bin/bash 3.2 (Apple GPLv3 avoidance).
+          BINS=()
+          while IFS= read -r -d '' f; do
+            BINS+=("$f")
+          done < <(find ~/Library/Developer/Xcode/DerivedData \
+            -type f \
+            -path '*/Build/Products/Release-iphoneos/Pastura.app/Pastura' \
+            -print0)
+          if [ "${#BINS[@]}" -ne 1 ]; then
+            echo "::error::Expected exactly 1 Release binary, found ${#BINS[@]}"
+            printf '%s\n' "${BINS[@]}"
+            exit 1
+          fi
+          BIN="${BINS[0]}"
+          echo "Checking $BIN"
+          # Demangle before grep: failure output stays human-readable and the
+          # check catches future helpers like OllamaClient / ollamaBridge that
+          # a narrower match would miss. Matches ADR-005 §8.5.
+          MATCHES=$(nm -a "$BIN" | xcrun swift-demangle | grep -i ollama || true)
+          if [ -n "$MATCHES" ]; then
+            echo "::error::ollama symbols leaked into Release binary (ADR-005 §8)"
+            echo "$MATCHES"
+            exit 1
+          fi
+          echo "OK: zero ollama symbols in Release-iphoneos binary"
+
+      - name: Upload Release build log (on failure)
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: release-build-log
+          path: /tmp/release-build.log
+          retention-days: 7
+
   coverage:
     name: Coverage
     needs: lint-and-test
@@ -256,7 +341,7 @@ jobs:
   # Do NOT change the trigger to pull_request_target.
   pr-comment:
     name: PR Comment
-    needs: [lint-and-test, ui-test]
+    needs: [lint-and-test, ui-test, release-build]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: >-
@@ -270,6 +355,7 @@ jobs:
         env:
           UNIT_JOB_RESULT: ${{ needs.lint-and-test.result }}
           UI_JOB_RESULT: ${{ needs.ui-test.result }}
+          RELEASE_JOB_RESULT: ${{ needs.release-build.result }}
           TEST_PASSED: ${{ needs.lint-and-test.outputs.test-passed }}
           TEST_FAILED: ${{ needs.lint-and-test.outputs.test-failed }}
           TEST_PARSE_ERROR: ${{ needs.lint-and-test.outputs.test-parse-error }}
@@ -285,14 +371,16 @@ jobs:
             echo ""
 
             # Job-level failure banner
-            for job_result in "$UNIT_JOB_RESULT" "$UI_JOB_RESULT"; do
+            for job_result in "$UNIT_JOB_RESULT" "$UI_JOB_RESULT" "$RELEASE_JOB_RESULT"; do
               if [ "$job_result" = "skipped" ] || [ "$job_result" = "cancelled" ]; then
                 echo "> One or more CI jobs were ${job_result}."
                 echo ""
                 break
               fi
             done
-            if [ "$UNIT_JOB_RESULT" = "failure" ] || [ "$UI_JOB_RESULT" = "failure" ]; then
+            if [ "$UNIT_JOB_RESULT" = "failure" ] \
+                || [ "$UI_JOB_RESULT" = "failure" ] \
+                || [ "$RELEASE_JOB_RESULT" = "failure" ]; then
               echo "> **CI job failed.** See [CI logs](${CI_RUN_URL}) for details."
               echo ""
             fi
@@ -306,6 +394,20 @@ jobs:
               echo "SwiftLint: **FAILED**"
             else
               echo "SwiftLint: did not run"
+            fi
+
+            # Release build (ADR-005 §8 submission-blocker gate — surfaced
+            # here so a silent regression is visible on the PR, not only in
+            # the Actions tab)
+            echo ""
+            echo "### Release Build (ADR-005 §8 guard)"
+            echo ""
+            if [ "$RELEASE_JOB_RESULT" = "success" ]; then
+              echo "Release-iphoneos symbol guard: **passed**"
+            elif [ "$RELEASE_JOB_RESULT" = "failure" ]; then
+              echo "Release-iphoneos symbol guard: **FAILED** — see [CI logs](${CI_RUN_URL})"
+            else
+              echo "Release-iphoneos symbol guard: did not run"
             fi
 
             # Test results — unit + UI shown separately so a slow UI suite

--- a/docs/decisions/ADR-005.md
+++ b/docs/decisions/ADR-005.md
@@ -918,24 +918,22 @@ the Ollama OpenAI-compatible endpoint when running in iOS Simulator)
 must be excluded from release archives — both as call sites and as
 linkable symbols.
 
-**Current state (disclaimer).** As of this ADR's merge, HEAD does
-*not* satisfy this policy in full:
+**Enforcement status.** This policy is in force. [Issue #148](https://github.com/tyabu12/pastura/issues/148)
+(filed 2026-04-19) was closed by [PR #155](https://github.com/tyabu12/pastura/pull/155),
+which wrapped `OllamaService.swift` and its fallback in
+`AppDependencies.swift` under `#if DEBUG || targetEnvironment(simulator)`.
+Release-iphoneos archives no longer link the Ollama symbols, and the
+[Issue #160](https://github.com/tyabu12/pastura/issues/160) CI job
+(see *Verification method* below) re-checks this on every PR so a
+regression cannot reach TestFlight silently.
 
-- `PasturaApp.swift:89` already gates `OllamaService` instantiation
-  behind `#if targetEnvironment(simulator)`, so release builds do not
-  *construct* Ollama at runtime.
-- `AppDependencies.swift:43` retains `OllamaService()` as a fallback
-  default in the production initialisation path, and
-  `OllamaService.swift` is unconditionally compiled. A release-
-  configuration archive therefore still links the Ollama symbols even
-  though nothing constructs them.
-
-This is a documented deviation permitted under §2.5's scope framing,
-conditional on **tracked remediation**: [Issue #148](https://github.com/tyabu12/pastura/issues/148)
-(filed 2026-04-19) owns the file-level `#if` wrap and the binary-
-level audit (`nm` / `otool`) required to satisfy the policy. #148 is
-a hard blocker for the first App Store submission — ADR-005 merging
-does not relax that blocker.
+For historical reference — as of this ADR's initial merge, HEAD did
+*not* satisfy the policy: `OllamaService.swift` was compiled
+unconditionally and retained as a fallback in `AppDependencies.swift:43`,
+so release archives still linked Ollama symbols even though
+`PasturaApp.swift:89` gated runtime construction behind
+`#if targetEnvironment(simulator)`. That gap was the rationale for
+#148 and is closed as of #155.
 
 **Verification method.** Release archives are audited with:
 
@@ -1053,11 +1051,12 @@ for later:
   assume AI output is folded into the existing categories (mature
   themes, profanity, etc.). If a future App Store Connect update
   introduces an AI-specific question, §3 must be revisited.
-- **OllamaService binary-level exclusion verification.** §8.5's `nm`
-  grep is the documented method; whether additional symbol auditing
-  (e.g. `otool -L` for linked frameworks) is required depends on how
-  `OllamaService.swift` is ultimately wrapped. #148 owns the final
-  method.
+- **OllamaService binary-level exclusion verification.** Resolved:
+  §8.5's `nm | xcrun swift-demangle | grep` is now the canonical
+  method and runs on every PR via the `release-build` CI job (#160).
+  Framework-level auditing (`otool -L`) remains unnecessary — the
+  file-level wrap from #155 removes the only dev-only backend; no
+  dev-only frameworks are linked.
 - **Japanese-corpus wordlist canonical source.** §4.4 lists LDNOOBW
   as a candidate only for English; no canonical Japanese blocklist
   exists. The implementation sub-issue (#3 in the master index) will

--- a/docs/decisions/ADR-005.md
+++ b/docs/decisions/ADR-005.md
@@ -937,11 +937,26 @@ level audit (`nm` / `otool`) required to satisfy the policy. #148 is
 a hard blocker for the first App Store submission — ADR-005 merging
 does not relax that blocker.
 
-**Verification method.** Per #148, release archives are audited with:
+**Verification method.** Release archives are audited with:
 
 ```sh
-nm -a Pastura.app/Pastura | grep -i ollama   # expect: no output
+nm -a Pastura.app/Pastura | xcrun swift-demangle | grep -i ollama
+# expect: no output
 ```
+
+Demangling is applied before the grep so failure output is human-
+readable and the check also catches future dev-only helpers whose
+mangled symbol differs from `OllamaService` (e.g. `OllamaClient`,
+`ollamaBridge`). The raw mangled form already contains the literal
+`Ollama` substring, so undoing the demangle step would not loosen
+the check — the demangle only improves diagnostics.
+
+This check runs automatically on every PR via the `release-build`
+job in `.github/workflows/ci.yml`, which builds `-configuration
+Release -sdk iphoneos` (the App-Store-submission target) and fails
+the CI run if any match surfaces. Release-simulator is intentionally
+not exercised: it still defines `targetEnvironment(simulator)` and
+would pull `OllamaService` back in, making the guard vacuous.
 
 If symbols remain after the wrap, the sub-issue captures the
 additional guard needed (e.g. `MockLLMService` / `LlamaCppService`


### PR DESCRIPTION
## Summary
- Add a `release-build` CI job that builds Pastura in Release-iphoneos and fails if any `ollama` symbol survives in the App-Store-submission binary (ADR-005 §8.5). Runs in parallel with `lint-and-test` and `ui-test`, shares the existing SPM cache, and uploads the xcodebuild log on failure.
- Wire the result into the sticky PR comment (needs list, failure banner, dedicated "Release Build (ADR-005 §8 guard)" status section).
- Update ADR-005 §8.5 + §9.3 so the spec matches the enforcement: published verification command now includes `xcrun swift-demangle`, and the prior "Current state (disclaimer)" paragraph is replaced with an "Enforcement status" paragraph citing #155 closure and the #160 CI check.

## Test plan
- [x] CI: `release-build` job green on this PR against current `main` HEAD (zero `ollama` symbols).
- [x] CI: `lint-and-test` and `ui-test` still green (no regression from `pr-comment` needs-list change).
- [ ] **Guard-fires verification (AC)**: push a disposable side branch that removes the `#if DEBUG || targetEnvironment(simulator)` wrap from `Pastura/LLM/OllamaService.swift`, confirm CI goes red, paste the failing run URL into #160 before merge. (Link will be added here and to #160.)
- [ ] Sticky PR comment renders a "Release Build (ADR-005 §8 guard)" section with the correct pass / fail / did-not-run state.

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)