### PR TITLE
🔒 chore: declare ITSAppUsesNonExemptEncryption=NO (ADR-005 drift)

### DIFF
--- a/Pastura/Pastura.xcodeproj/project.pbxproj
+++ b/Pastura/Pastura.xcodeproj/project.pbxproj
@@ -435,6 +435,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Pastura/Info.plist;
 				INFOPLIST_KEY_BGTaskSchedulerPermittedIdentifiers = "com.tyabu12.Pastura.simulation-continuation";
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -469,6 +470,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Pastura/Info.plist;
 				INFOPLIST_KEY_BGTaskSchedulerPermittedIdentifiers = "com.tyabu12.Pastura.simulation-continuation";
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/docs/decisions/ADR-005.md
+++ b/docs/decisions/ADR-005.md
@@ -955,7 +955,19 @@ answer for:
 - **Encryption export compliance (ITSAppUsesNonExemptEncryption).**
   Pastura uses only standard TLS (URLSession defaults) for gallery
   fetches and model download; the on-device LLM performs no crypto.
-  `Info.plist` sets `ITSAppUsesNonExemptEncryption = NO`.
+  `project.pbxproj` declares
+  `INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO` for both Debug
+  and Release, which Xcode merges into the built `Info.plist` as a
+  boolean `<false/>`. This declaration is predicated on the "uses
+  only Apple-provided TLS" path. If a future feature introduces
+  (a) custom ciphers, (b) non-Apple crypto primitives, (c) E2EE
+  key material beyond CryptoKit / CommonCrypto defaults, or
+  (d) at-rest content encryption with custom key management,
+  re-evaluate whether the §740.17(b) mass-market exemption still
+  applies and whether an annual self-classification report (BIS,
+  with NSA notification) is required. See Apple's
+  [Complying with encryption export regulations](https://developer.apple.com/documentation/security/complying-with-encryption-export-regulations)
+  for the authoritative mapping.
 - **IDFA / ATT.** Pastura does no tracking across apps or websites;
   the App Tracking Transparency framework is not used and no IDFA is
   collected.
@@ -1015,6 +1027,7 @@ when work starts" marker and are created during the relevant sprint.
 | 5 | `ContentFilter.defaultPatterns` expansion methodology (§5.2) | Not filed — on-demand | tyabu12 | None (ongoing) | Triggered by telemetry, App Review citation, or user report |
 | 6 | Fallback handling 13+ → 16+ (§3.3) | Not filed — conditional | tyabu12 | Conditional (fires only on rejection) | Created reactively if Apple rejects the 13+ target |
 | 7 | ADR-006 Cloud API disclosure/consent implementation | Forthcoming ADR, not a sub-issue | tyabu12 | Cloud API feature (not submission) | Principles from §7 bind this work |
+| 8 | Declare `ITSAppUsesNonExemptEncryption = NO` in build config | [#159](https://github.com/tyabu12/pastura/issues/159) | tyabu12 | None (doc-vs-code drift) | Filed 2026-04-20; §8.6 |
 
 The master index is the canonical list — individual ADR sections reference
 it by row number when pointing at follow-up work.


### PR DESCRIPTION
## Summary
- Add `INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO` to Debug and Release configs so App Store Connect stops prompting for the encryption declaration on every archive.
- Amend ADR-005 §8.6 to reflect the actual configuration path (pbxproj → merged Info.plist) and add re-evaluation triggers for future crypto changes (custom ciphers, non-Apple primitives, E2EE key material, at-rest custom key mgmt).
- Append row 8 to ADR-005 §9.2 master index tracking this doc-vs-code drift fix.

## Test plan
- [x] Debug build → `plutil -extract ITSAppUsesNonExemptEncryption xml1` on merged Info.plist returns `<false/>` (boolean)
- [x] Release build → same `<false/>` boolean (archive-config parity)
- [x] `BGTaskSchedulerPermittedIdentifiers` intact in both configs (no regression)
- [x] Full unit suite: 729 total, 0 failed, 11 skipped (Ollama integration)
- [x] `swiftlint lint --quiet --strict` clean
- [ ] (Post-merge) Next TestFlight archive upload: App Store Connect does not prompt for encryption declaration

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)