### PR TITLE
✨ feat: design tokens foundation (color / font / spacing / radius)

### DIFF
--- a/Pastura/Pastura/Views/DesignTokens.swift
+++ b/Pastura/Pastura/Views/DesignTokens.swift
@@ -1,20 +1,17 @@
 import SwiftUI
 
-// swiftlint:disable identifier_name file_length
+// swiftlint:disable identifier_name
 
-/// Single-source-of-truth tokens for the Pastura design system.
-///
-/// Canonical source: `docs/design/design-system.md` §2 (colors), §3 (typography),
-/// §4 (spacing, radii, shadows). If a token value here disagrees with that doc,
-/// the doc wins — fix this file, not the doc.
-///
-/// Organized in three namespaces:
-/// - ``PasturaPalette`` — color tokens as structural `(r, g, b, opacity)` tuples.
-/// - ``PasturaShadows`` — two-layer shadow recipe from §4.3.
-/// - `Color` extension — SwiftUI-facing flat aliases (`Color.page`, `Color.moss`, …).
-///
-/// Typography, Spacing, and Radius tokens are defined in sibling sections below
-/// (added by follow-up commits on the same issue).
+// Single-source-of-truth tokens for the Pastura design system.
+//
+// Canonical source: `docs/design/design-system.md` §2 (colors), §3 (typography),
+// §4 (spacing, radii, shadows). If a token value here disagrees with that doc,
+// the doc wins — fix this file, not the doc.
+//
+// Organized in layered namespaces (see individual doc comments below):
+//   - PasturaPalette / PasturaShadows — structural tokens (test-readable).
+//   - Typography + Spacing + Radius   — layout + type scales.
+//   - Color extension                 — SwiftUI-facing flat aliases.
 
 // MARK: - §2 Color tokens
 
@@ -394,4 +391,4 @@ extension Color {
   static let avatarHighlight = PasturaPalette.avatarHighlight.color
 }
 
-// swiftlint:enable identifier_name file_length
+// swiftlint:enable identifier_name

--- a/Pastura/Pastura/Views/DesignTokens.swift
+++ b/Pastura/Pastura/Views/DesignTokens.swift
@@ -189,6 +189,114 @@ enum PasturaShadows {
     radius: 26, x: 0, y: 12)
 }
 
+// MARK: - §3 Typography tokens
+
+/// Pastura text style descriptor. Data-only — application to SwiftUI `Text`
+/// lives in consumer sites (first is #B1 `AgentOutputRow` refactor).
+///
+/// SwiftUI `Font` alone cannot carry line-height, letter-spacing, italic, or
+/// text-case; callers combine `font` with `.lineSpacing(lineSpacingPoints)`,
+/// `.tracking(trackingPoints)`, and `.textCase(textCase)` where applicable.
+struct PasturaTextStyle: Sendable, Equatable {
+  let size: CGFloat
+  let weight: Font.Weight
+  let design: Font.Design
+  /// Unitless line-height ratio from the doc (e.g. 1.3, 1.65).
+  let lineHeight: Double
+  /// Letter-spacing in em from the doc (e.g. 0.22).
+  let letterSpacingEm: Double
+  let isItalic: Bool
+  let textCase: Text.Case?
+
+  /// SwiftUI `Font` built from size / weight / design (+ italic modifier).
+  var font: Font {
+    let base = Font.system(size: size, weight: weight, design: design)
+    return isItalic ? base.italic() : base
+  }
+
+  /// Additional leading in points for `.lineSpacing(_:)`.
+  /// Derived from CSS-style `line-height` × `size`, minus the font's intrinsic
+  /// single leading (`size`): `size × (lineHeight − 1)`.
+  var lineSpacingPoints: CGFloat { size * CGFloat(lineHeight - 1.0) }
+
+  /// Tracking in points for `.tracking(_:)`. `size × letterSpacingEm`.
+  var trackingPoints: CGFloat { size * CGFloat(letterSpacingEm) }
+}
+
+enum Typography {
+  /// title/phase — フェーズ見出し
+  static let titlePhase = PasturaTextStyle(
+    size: 13, weight: .semibold, design: .default,
+    lineHeight: 1.3, letterSpacingEm: 0.02,
+    isItalic: false, textCase: nil)
+
+  /// tag/phase — フェーズタグ (UPPER, mono)
+  static let tagPhase = PasturaTextStyle(
+    size: 9.5, weight: .semibold, design: .monospaced,
+    lineHeight: 1.2, letterSpacingEm: 0.22,
+    isItalic: false, textCase: .uppercase)
+
+  /// body/bubble — 発言本文
+  static let bodyBubble = PasturaTextStyle(
+    size: 13, weight: .regular, design: .default,
+    lineHeight: 1.65, letterSpacingEm: 0,
+    isItalic: false, textCase: nil)
+
+  /// body/promo — プロモ文
+  static let bodyPromo = PasturaTextStyle(
+    size: 12, weight: .regular, design: .default,
+    lineHeight: 1.65, letterSpacingEm: 0,
+    isItalic: false, textCase: nil)
+
+  /// caption/name — アバター下の名前
+  static let captionName = PasturaTextStyle(
+    size: 10.5, weight: .regular, design: .default,
+    lineHeight: 1.3, letterSpacingEm: 0.04,
+    isItalic: false, textCase: nil)
+
+  /// thinking/body — 内なる思考 (italic)
+  static let thinkingBody = PasturaTextStyle(
+    size: 10.5, weight: .regular, design: .default,
+    lineHeight: 1.7, letterSpacingEm: 0.02,
+    isItalic: true, textCase: nil)
+
+  /// thinking/tag — REASON/THINKING ラベル (mono UPPER)
+  static let thinkingTag = PasturaTextStyle(
+    size: 8.5, weight: .regular, design: .monospaced,
+    lineHeight: 1.2, letterSpacingEm: 0.22,
+    isItalic: false, textCase: .uppercase)
+
+  /// meta/label — "DL" ラベル (mono semibold)
+  static let metaLabel = PasturaTextStyle(
+    size: 9, weight: .semibold, design: .monospaced,
+    lineHeight: 1.2, letterSpacingEm: 0.06,
+    isItalic: false, textCase: nil)
+
+  /// meta/value — `35%`, `1.0 GB` (mono)
+  static let metaValue = PasturaTextStyle(
+    size: 9, weight: .regular, design: .monospaced,
+    lineHeight: 1.2, letterSpacingEm: 0,
+    isItalic: false, textCase: nil)
+
+  /// meta/eta — 残り約4分 (mono medium)
+  static let metaEta = PasturaTextStyle(
+    size: 10, weight: .medium, design: .monospaced,
+    lineHeight: 1.3, letterSpacingEm: 0,
+    isItalic: false, textCase: nil)
+
+  /// status/complete — 準備ができました
+  static let statusComplete = PasturaTextStyle(
+    size: 16, weight: .medium, design: .default,
+    lineHeight: 1.4, letterSpacingEm: 0.22,
+    isItalic: false, textCase: nil)
+
+  /// status/hint — tap anywhere to begin (mono)
+  static let statusHint = PasturaTextStyle(
+    size: 11, weight: .regular, design: .monospaced,
+    lineHeight: 1.2, letterSpacingEm: 0.1,
+    isItalic: false, textCase: nil)
+}
+
 // MARK: - Color extension (SwiftUI-facing aliases)
 
 extension Color {

--- a/Pastura/Pastura/Views/DesignTokens.swift
+++ b/Pastura/Pastura/Views/DesignTokens.swift
@@ -1,0 +1,246 @@
+import SwiftUI
+
+// swiftlint:disable identifier_name file_length
+
+/// Single-source-of-truth tokens for the Pastura design system.
+///
+/// Canonical source: `docs/design/design-system.md` §2 (colors), §3 (typography),
+/// §4 (spacing, radii, shadows). If a token value here disagrees with that doc,
+/// the doc wins — fix this file, not the doc.
+///
+/// Organized in three namespaces:
+/// - ``PasturaPalette`` — color tokens as structural `(r, g, b, opacity)` tuples.
+/// - ``PasturaShadows`` — two-layer shadow recipe from §4.3.
+/// - `Color` extension — SwiftUI-facing flat aliases (`Color.page`, `Color.moss`, …).
+///
+/// Typography, Spacing, and Radius tokens are defined in sibling sections below
+/// (added by follow-up commits on the same issue).
+
+// MARK: - §2 Color tokens
+
+/// A single color token, stored as sRGB components so tests can verify values
+/// against the canonical hex in `design-system.md` without round-tripping
+/// through `Color.Resolved` (which is linear-light and lossy).
+///
+/// Construct from a 24-bit hex literal via ``init(hex:opacity:)`` — keeps the
+/// source aligned with the doc's `#RRGGBB` notation.
+struct PasturaColorValue: Sendable, Equatable {
+  let red: Double
+  let green: Double
+  let blue: Double
+  let opacity: Double
+
+  /// Build a token from a 24-bit sRGB hex integer (e.g. `0xF3EFE7`).
+  /// Opacity defaults to 1; pass a fractional value for `rgba(...)` tokens
+  /// like §2.5's avatar highlight.
+  init(hex: UInt32, opacity: Double = 1.0) {
+    self.red = Double((hex >> 16) & 0xFF) / 255.0
+    self.green = Double((hex >> 8) & 0xFF) / 255.0
+    self.blue = Double(hex & 0xFF) / 255.0
+    self.opacity = opacity
+  }
+
+  /// Build a token from raw 0...1 sRGB components. Used for §4.3 shadow tints
+  /// specified as `rgba(90, 100, 60, ...)` where a hex literal would obscure
+  /// the source numbers.
+  init(red: Double, green: Double, blue: Double, opacity: Double) {
+    self.red = red
+    self.green = green
+    self.blue = blue
+    self.opacity = opacity
+  }
+
+  /// Materialize as an sRGB `Color`. Explicit `.sRGB` color space (not the
+  /// default) is load-bearing: it ensures consumers and test round-trips agree
+  /// on the color space without relying on device-default assumptions.
+  var color: Color {
+    Color(.sRGB, red: red, green: green, blue: blue, opacity: opacity)
+  }
+}
+
+/// Canonical Pastura color palette. See `design-system.md` §2.
+///
+/// Test suites read components directly (`PasturaPalette.page.red` etc.); view
+/// code typically uses the `Color.*` aliases in the `Color` extension below.
+enum PasturaPalette {
+
+  // MARK: §2.1 Backgrounds / Surfaces
+
+  /// Outside the app surface (workbench / outside Safe Area).
+  static let page = PasturaColorValue(hex: 0xF3EFE7)
+  /// App body background — crisp wool-color.
+  static let screenBackground = PasturaColorValue(hex: 0xFCFAF4)
+  /// Speech bubble background.
+  static let bubbleBackground = PasturaColorValue(hex: 0xFFFFFF)
+  /// Promo / banner background.
+  static let promoBackground = PasturaColorValue(hex: 0xFBFAF2)
+  /// Promo / banner border.
+  static let promoBorder = PasturaColorValue(hex: 0xE4E7D2)
+
+  // MARK: §2.2 Ink
+
+  /// Primary body text. Intentionally not pure black.
+  static let ink = PasturaColorValue(hex: 0x2D2E26)
+  /// Subtext / section labels.
+  static let inkSecondary = PasturaColorValue(hex: 0x5A5A55)
+  /// Meta info / footnotes.
+  static let muted = PasturaColorValue(hex: 0x8A8A83)
+  /// Rule / divider lines.
+  static let rule = PasturaColorValue(hex: 0xE0DBCE)
+
+  // MARK: §2.3 Moss Accent — Pastura's only brand color, 4 steps
+
+  /// Leaf icon, promo left border (3pt).
+  static let moss = PasturaColorValue(hex: 0x8A9A6C)
+  /// DL progress dot (lit), accent links.
+  static let mossDark = PasturaColorValue(hex: 0x6B7852)
+  /// Dog outline, completion title.
+  static let mossInk = PasturaColorValue(hex: 0x3D4030)
+  /// THINKING left-rule, gentle dividers.
+  static let mossSoft = PasturaColorValue(hex: 0xD4CBA8)
+
+  // MARK: §2.4 Meta Contrast Presets (DL progress)
+
+  // L3 is the documented default. Consumers hard-code `L3` unless they have
+  // an explicit reason to override — environment-based preset switching is
+  // deferred to #B1/#C.
+  static let metaBaseL1 = PasturaColorValue(hex: 0x8A8B76)
+  static let metaStrongL1 = PasturaColorValue(hex: 0x5D6848)
+  static let metaDotOnL1 = PasturaColorValue(hex: 0x8A9A6C)
+
+  static let metaBaseL2 = PasturaColorValue(hex: 0x6A6D5A)
+  static let metaStrongL2 = PasturaColorValue(hex: 0x3D4530)
+  static let metaDotOnL2 = PasturaColorValue(hex: 0x7A8A5C)
+
+  static let metaBaseL3 = PasturaColorValue(hex: 0x4A4E3D)
+  static let metaStrongL3 = PasturaColorValue(hex: 0x2D2E26)
+  static let metaDotOnL3 = PasturaColorValue(hex: 0x6B7852)
+
+  static let metaBaseL4 = PasturaColorValue(hex: 0x2D2E26)
+  static let metaStrongL4 = PasturaColorValue(hex: 0x1A1B15)
+  static let metaDotOnL4 = PasturaColorValue(hex: 0x556340)
+
+  // MARK: §2.5 Avatar palette (sheep characters)
+
+  /// Alice — cream. Gentle first voice.
+  static let avatarAlice = PasturaColorValue(hex: 0xF2E3C8)
+  /// Bob — sage. Agreeable / calm.
+  static let avatarBob = PasturaColorValue(hex: 0xD9E2C6)
+  /// Carol — pink. Observer.
+  static let avatarCarol = PasturaColorValue(hex: 0xEBD4D4)
+  /// Dave — slate. Wolf / central figure.
+  static let avatarDave = PasturaColorValue(hex: 0xD0D7DC)
+
+  /// Shared avatar ear color.
+  static let avatarEar = PasturaColorValue(hex: 0xE8D9BC)
+  /// Inner ear tint.
+  static let avatarEarInner = PasturaColorValue(hex: 0xD4C19E)
+  /// Avatar nose.
+  static let avatarNose = PasturaColorValue(hex: 0x3D4030)
+  /// Avatar eye.
+  static let avatarEye = PasturaColorValue(hex: 0x2D2E26)
+  /// Translucent highlight (rgba(255,255,255,.6)).
+  static let avatarHighlight = PasturaColorValue(hex: 0xFFFFFF, opacity: 0.6)
+}
+
+// MARK: - §4.3 Shadow tokens
+
+/// A single shadow layer matching SwiftUI's `.shadow(color:radius:x:y:)` shape.
+///
+/// CSS source (`design-system.md` §4.3) uses a negative spread on the second
+/// layer (`-12px`). SwiftUI's built-in `.shadow` has no spread parameter, so
+/// the spread is dropped; the visual approximation is close enough for the
+/// soft-shadow use case. If the exact spread matters for a specific surface,
+/// reach for a custom `.background { ... }` mask — but do not add spread
+/// handling to this token type without revisiting design-system.md §4.3 first.
+struct PasturaShadow: Sendable, Equatable {
+  let color: PasturaColorValue
+  let radius: CGFloat
+  let x: CGFloat
+  let y: CGFloat
+}
+
+/// Two-layer moss-tinted shadow recipe from `design-system.md` §4.3.
+///
+/// Apply by stacking both `.shadow(...)` modifiers on the same view:
+/// ```
+/// view
+///   .shadow(
+///     color: PasturaShadows.tight.color.color,
+///     radius: PasturaShadows.tight.radius,
+///     x: PasturaShadows.tight.x,
+///     y: PasturaShadows.tight.y)
+///   .shadow(
+///     color: PasturaShadows.soft.color.color,
+///     radius: PasturaShadows.soft.radius,
+///     x: PasturaShadows.soft.x,
+///     y: PasturaShadows.soft.y)
+/// ```
+enum PasturaShadows {
+  /// Inner tight layer — `0 1px 2px rgba(90,100,60,.04)`.
+  static let tight = PasturaShadow(
+    color: PasturaColorValue(
+      red: 90.0 / 255.0, green: 100.0 / 255.0, blue: 60.0 / 255.0, opacity: 0.04),
+    radius: 2, x: 0, y: 1)
+  /// Outer soft layer — `0 12px 26px -12px rgba(90,100,60,.2)` (spread dropped).
+  static let soft = PasturaShadow(
+    color: PasturaColorValue(
+      red: 90.0 / 255.0, green: 100.0 / 255.0, blue: 60.0 / 255.0, opacity: 0.2),
+    radius: 26, x: 0, y: 12)
+}
+
+// MARK: - Color extension (SwiftUI-facing aliases)
+
+extension Color {
+  // §2.1 Backgrounds
+  static let page = PasturaPalette.page.color
+  static let screenBackground = PasturaPalette.screenBackground.color
+  static let bubbleBackground = PasturaPalette.bubbleBackground.color
+  static let promoBackground = PasturaPalette.promoBackground.color
+  static let promoBorder = PasturaPalette.promoBorder.color
+
+  // §2.2 Ink
+  static let ink = PasturaPalette.ink.color
+  static let inkSecondary = PasturaPalette.inkSecondary.color
+  static let muted = PasturaPalette.muted.color
+  static let rule = PasturaPalette.rule.color
+
+  // §2.3 Moss
+  static let moss = PasturaPalette.moss.color
+  static let mossDark = PasturaPalette.mossDark.color
+  static let mossInk = PasturaPalette.mossInk.color
+  static let mossSoft = PasturaPalette.mossSoft.color
+
+  // §2.4 Meta L1
+  static let metaBaseL1 = PasturaPalette.metaBaseL1.color
+  static let metaStrongL1 = PasturaPalette.metaStrongL1.color
+  static let metaDotOnL1 = PasturaPalette.metaDotOnL1.color
+
+  // §2.4 Meta L2
+  static let metaBaseL2 = PasturaPalette.metaBaseL2.color
+  static let metaStrongL2 = PasturaPalette.metaStrongL2.color
+  static let metaDotOnL2 = PasturaPalette.metaDotOnL2.color
+
+  // §2.4 Meta L3 (default)
+  static let metaBaseL3 = PasturaPalette.metaBaseL3.color
+  static let metaStrongL3 = PasturaPalette.metaStrongL3.color
+  static let metaDotOnL3 = PasturaPalette.metaDotOnL3.color
+
+  // §2.4 Meta L4
+  static let metaBaseL4 = PasturaPalette.metaBaseL4.color
+  static let metaStrongL4 = PasturaPalette.metaStrongL4.color
+  static let metaDotOnL4 = PasturaPalette.metaDotOnL4.color
+
+  // §2.5 Avatars
+  static let avatarAlice = PasturaPalette.avatarAlice.color
+  static let avatarBob = PasturaPalette.avatarBob.color
+  static let avatarCarol = PasturaPalette.avatarCarol.color
+  static let avatarDave = PasturaPalette.avatarDave.color
+  static let avatarEar = PasturaPalette.avatarEar.color
+  static let avatarEarInner = PasturaPalette.avatarEarInner.color
+  static let avatarNose = PasturaPalette.avatarNose.color
+  static let avatarEye = PasturaPalette.avatarEye.color
+  static let avatarHighlight = PasturaPalette.avatarHighlight.color
+}
+
+// swiftlint:enable identifier_name file_length

--- a/Pastura/Pastura/Views/DesignTokens.swift
+++ b/Pastura/Pastura/Views/DesignTokens.swift
@@ -297,6 +297,49 @@ enum Typography {
     isItalic: false, textCase: nil)
 }
 
+// MARK: - §4 Spacing + Radius tokens
+
+/// Pastura spacing scale. See `design-system.md` §4.1.
+///
+/// 4pt-based scale with deliberate mid-values (14, 20) — design-system.md
+/// emphasizes softness over strict 8-multiples. Use descriptive aliases at
+/// callsites (e.g. `Spacing.bubbleGap`) when the number alone obscures intent.
+enum Spacing {
+  /// 4pt — smallest step (tight gutters, ornament spacing).
+  static let xxs: CGFloat = 4
+  /// 8pt — compact row gap.
+  static let xs: CGFloat = 8
+  /// 12pt — promo inner rhythm.
+  static let s: CGFloat = 12
+  /// 14pt — bubble / card rhythm (the "soft" mid-value).
+  static let m: CGFloat = 14
+  /// 20pt — block separation.
+  static let l: CGFloat = 20
+  /// 32pt — section separation.
+  static let xl: CGFloat = 32
+  /// 48pt — screen-level breathing room.
+  static let xxl: CGFloat = 48
+}
+
+/// Pastura corner-radius scale. See `design-system.md` §4.2.
+///
+/// `dot` is `.infinity` (SwiftUI circle semantics via
+/// `.clipShape(.circle)` or `RoundedRectangle(cornerRadius: .infinity)`).
+enum Radius {
+  /// iPhone body inner radius (follows device corner).
+  static let deviceInner: CGFloat = 31
+  /// Bubble tail corner (upper-left of tailed bubble).
+  static let bubbleTail: CGFloat = 4
+  /// Bubble body (non-tail corners).
+  static let bubbleBody: CGFloat = 14
+  /// Promo card.
+  static let promo: CGFloat = 14
+  /// Vote / action button.
+  static let button: CGFloat = 8
+  /// Full circle — DL progress dots and similar.
+  static let dot: CGFloat = .infinity
+}
+
 // MARK: - Color extension (SwiftUI-facing aliases)
 
 extension Color {

--- a/Pastura/Pastura/Views/DesignTokens.swift
+++ b/Pastura/Pastura/Views/DesignTokens.swift
@@ -220,6 +220,9 @@ struct PasturaTextStyle: Sendable, Equatable {
   var trackingPoints: CGFloat { size * CGFloat(letterSpacingEm) }
 }
 
+/// Pastura typography scale. See `design-system.md` §3. Apply at callsites
+/// via `.font(style.font).lineSpacing(style.lineSpacingPoints).tracking(style.trackingPoints)
+/// .textCase(style.textCase)` — a `View.textStyle(_:)` modifier is deferred to #B1.
 enum Typography {
   /// title/phase — フェーズ見出し
   static let titlePhase = PasturaTextStyle(

--- a/Pastura/PasturaTests/Views/DesignTokensTests.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests.swift
@@ -179,6 +179,29 @@ struct DesignTokensTests {
     #expect(approxEqual(Double(style.trackingPoints), 9.5 * 0.22))
   }
 
+  // MARK: - §4 Spacing
+
+  @Test func spacingScaleMatchesSpec() {
+    #expect(Spacing.xxs == 4)
+    #expect(Spacing.xs == 8)
+    #expect(Spacing.s == 12)
+    #expect(Spacing.m == 14)
+    #expect(Spacing.l == 20)
+    #expect(Spacing.xl == 32)
+    #expect(Spacing.xxl == 48)
+  }
+
+  // MARK: - §4 Radius
+
+  @Test func radiusScaleMatchesSpec() {
+    #expect(Radius.deviceInner == 31)
+    #expect(Radius.bubbleTail == 4)
+    #expect(Radius.bubbleBody == 14)
+    #expect(Radius.promo == 14)
+    #expect(Radius.button == 8)
+    #expect(Radius.dot == .infinity)
+  }
+
   // MARK: - Helpers
 
   private func approxEqual(_ lhs: Double, _ rhs: Double, tolerance: Double = 0.001) -> Bool {

--- a/Pastura/PasturaTests/Views/DesignTokensTests.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests.swift
@@ -134,6 +134,51 @@ struct DesignTokensTests {
     #expect(shadow.radius == 2)
   }
 
+  // MARK: - §3 Typography
+
+  @Test func titlePhaseMatchesSpec() {
+    let style = Typography.titlePhase
+    #expect(style.size == 13)
+    #expect(style.weight == .semibold)
+    #expect(style.design == .default)
+    #expect(approxEqual(style.lineHeight, 1.3))
+    #expect(approxEqual(style.letterSpacingEm, 0.02))
+    #expect(style.isItalic == false)
+    #expect(style.textCase == nil)
+  }
+
+  @Test func tagPhaseIsMonoUpper() {
+    let style = Typography.tagPhase
+    #expect(style.design == .monospaced)
+    #expect(style.textCase == .uppercase)
+    #expect(approxEqual(style.letterSpacingEm, 0.22))
+  }
+
+  @Test func thinkingBodyIsItalic() {
+    let style = Typography.thinkingBody
+    #expect(style.isItalic == true)
+    #expect(approxEqual(style.lineHeight, 1.7))
+  }
+
+  @Test func metaValueIsMonoRegular() {
+    let style = Typography.metaValue
+    #expect(style.design == .monospaced)
+    #expect(style.weight == .regular)
+    #expect(style.size == 9)
+  }
+
+  @Test func lineSpacingPointsDerivedFromLineHeight() {
+    // body/bubble: 13pt × (1.65 − 1.0) = 8.45pt
+    let style = Typography.bodyBubble
+    #expect(approxEqual(Double(style.lineSpacingPoints), 13 * 0.65))
+  }
+
+  @Test func trackingPointsDerivedFromLetterSpacing() {
+    // tag/phase: 9.5pt × 0.22 = 2.09pt
+    let style = Typography.tagPhase
+    #expect(approxEqual(Double(style.trackingPoints), 9.5 * 0.22))
+  }
+
   // MARK: - Helpers
 
   private func approxEqual(_ lhs: Double, _ rhs: Double, tolerance: Double = 0.001) -> Bool {

--- a/Pastura/PasturaTests/Views/DesignTokensTests.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests.swift
@@ -1,0 +1,142 @@
+import SwiftUI
+import Testing
+
+@testable import Pastura
+
+@MainActor
+@Suite(.timeLimit(.minutes(1)))
+struct DesignTokensTests {
+
+  // MARK: - §2.1 Backgrounds
+
+  @Test func pageBackgroundMatchesSpec() {
+    let token = PasturaPalette.page
+    #expect(approxEqual(token.red, 0xF3 / 255.0))
+    #expect(approxEqual(token.green, 0xEF / 255.0))
+    #expect(approxEqual(token.blue, 0xE7 / 255.0))
+    #expect(approxEqual(token.opacity, 1.0))
+  }
+
+  @Test func screenBackgroundMatchesSpec() {
+    let token = PasturaPalette.screenBackground
+    #expect(approxEqual(token.red, 0xFC / 255.0))
+    #expect(approxEqual(token.green, 0xFA / 255.0))
+    #expect(approxEqual(token.blue, 0xF4 / 255.0))
+    #expect(approxEqual(token.opacity, 1.0))
+  }
+
+  @Test func bubbleBackgroundIsPureWhite() {
+    let token = PasturaPalette.bubbleBackground
+    #expect(approxEqual(token.red, 1.0))
+    #expect(approxEqual(token.green, 1.0))
+    #expect(approxEqual(token.blue, 1.0))
+  }
+
+  // MARK: - §2.2 Ink
+
+  @Test func inkPrimaryIsNotPureBlack() {
+    let token = PasturaPalette.ink
+    #expect(approxEqual(token.red, 0x2D / 255.0))
+    #expect(approxEqual(token.green, 0x2E / 255.0))
+    #expect(approxEqual(token.blue, 0x26 / 255.0))
+    #expect(token.red > 0)
+    #expect(token.green > 0)
+    #expect(token.blue > 0)
+  }
+
+  @Test func mutedMatchesSpec() {
+    let token = PasturaPalette.muted
+    #expect(approxEqual(token.red, 0x8A / 255.0))
+    #expect(approxEqual(token.green, 0x8A / 255.0))
+    #expect(approxEqual(token.blue, 0x83 / 255.0))
+  }
+
+  // MARK: - §2.3 Moss Accent
+
+  @Test func mossPrimaryMatchesSpec() {
+    let token = PasturaPalette.moss
+    #expect(approxEqual(token.red, 0x8A / 255.0))
+    #expect(approxEqual(token.green, 0x9A / 255.0))
+    #expect(approxEqual(token.blue, 0x6C / 255.0))
+  }
+
+  @Test func mossDarkMatchesSpec() {
+    let token = PasturaPalette.mossDark
+    #expect(approxEqual(token.red, 0x6B / 255.0))
+    #expect(approxEqual(token.green, 0x78 / 255.0))
+    #expect(approxEqual(token.blue, 0x52 / 255.0))
+  }
+
+  // MARK: - §2.4 Meta Contrast Presets
+
+  @Test func metaL3IsTheDocumentedDefault() {
+    let base = PasturaPalette.metaBaseL3
+    #expect(approxEqual(base.red, 0x4A / 255.0))
+    #expect(approxEqual(base.green, 0x4E / 255.0))
+    #expect(approxEqual(base.blue, 0x3D / 255.0))
+
+    let strong = PasturaPalette.metaStrongL3
+    #expect(approxEqual(strong.red, 0x2D / 255.0))
+    #expect(approxEqual(strong.green, 0x2E / 255.0))
+    #expect(approxEqual(strong.blue, 0x26 / 255.0))
+
+    let dotOn = PasturaPalette.metaDotOnL3
+    #expect(approxEqual(dotOn.red, 0x6B / 255.0))
+    #expect(approxEqual(dotOn.green, 0x78 / 255.0))
+    #expect(approxEqual(dotOn.blue, 0x52 / 255.0))
+  }
+
+  @Test func metaContrastRangesFromL1ToL4() {
+    // L1 is the lightest (highest R/G/B on base), L4 the darkest — verify the gradient
+    // exists, without locking every hex (those are covered by L3 above).
+    #expect(PasturaPalette.metaBaseL1.red > PasturaPalette.metaBaseL2.red)
+    #expect(PasturaPalette.metaBaseL2.red > PasturaPalette.metaBaseL3.red)
+    #expect(PasturaPalette.metaBaseL3.red > PasturaPalette.metaBaseL4.red)
+  }
+
+  // MARK: - §2.5 Avatars
+
+  @Test func aliceCreamMatchesSpec() {
+    let token = PasturaPalette.avatarAlice
+    #expect(approxEqual(token.red, 0xF2 / 255.0))
+    #expect(approxEqual(token.green, 0xE3 / 255.0))
+    #expect(approxEqual(token.blue, 0xC8 / 255.0))
+  }
+
+  @Test func avatarHighlightIsTranslucentWhite() {
+    let token = PasturaPalette.avatarHighlight
+    #expect(approxEqual(token.red, 1.0))
+    #expect(approxEqual(token.green, 1.0))
+    #expect(approxEqual(token.blue, 1.0))
+    #expect(approxEqual(token.opacity, 0.6))
+  }
+
+  // MARK: - §4.3 Shadow
+
+  @Test func softShadowIsMossTinted() {
+    let shadow = PasturaShadows.soft
+    // rgba(90,100,60,.2): moss-tinted, not neutral black
+    #expect(approxEqual(shadow.color.red, 90 / 255.0))
+    #expect(approxEqual(shadow.color.green, 100 / 255.0))
+    #expect(approxEqual(shadow.color.blue, 60 / 255.0))
+    #expect(approxEqual(shadow.color.opacity, 0.2))
+    #expect(shadow.y == 12)
+    #expect(shadow.radius == 26)
+  }
+
+  @Test func tightShadowIsMossTinted() {
+    let shadow = PasturaShadows.tight
+    #expect(approxEqual(shadow.color.red, 90 / 255.0))
+    #expect(approxEqual(shadow.color.green, 100 / 255.0))
+    #expect(approxEqual(shadow.color.blue, 60 / 255.0))
+    #expect(approxEqual(shadow.color.opacity, 0.04))
+    #expect(shadow.y == 1)
+    #expect(shadow.radius == 2)
+  }
+
+  // MARK: - Helpers
+
+  private func approxEqual(_ lhs: Double, _ rhs: Double, tolerance: Double = 0.001) -> Bool {
+    abs(lhs - rhs) < tolerance
+  }
+}


### PR DESCRIPTION
## Summary

Closes #166. Mirrors `docs/design/design-system.md` §2–§4 into Swift tokens so future UI work (#B1 AgentOutputRow token-ization, #C DL demo replay) can consume a single source. Purely additive — no existing views touched.

- **Colors (§2)** — backgrounds / ink / moss / meta L1–L4 (flat, L3 documented default) / avatar palette incl. translucent highlight.
- **Shadows (§4.3)** — two-layer moss-tinted recipe (CSS `-12px` spread dropped; SwiftUI `.shadow` lacks the parameter — documented in `PasturaShadow`).
- **Typography (§3)** — 12 scales as `PasturaTextStyle` descriptors carrying size / weight / design + line-height + letter-spacing + italic + textCase. Data-only; `View.textStyle(_:)` modifier deferred to #B1.
- **Spacing / Radius (§4.1–§4.2)** — scales + `Radius.dot = .infinity` for circles.

Decisions recorded in the plan comment on #166. Critic review landed 8 warnings pre-impl (all adopted), code-reviewer on the finished branch returned PASS with one cosmetic doc-comment suggestion that's now in.

## Test plan

- [x] `xcodebuild test ... -only-testing PasturaTests/DesignTokensTests` — 21 tests pass
- [x] Full unit suite — `** TEST SUCCEEDED **`
- [x] `swiftlint lint --quiet --strict` — clean (EXIT 0)
- [ ] CI green (required-checks only; auto-merge disabled per CLAUDE.md)
- [ ] Manual: none — no UI surface changed, tokens are not applied to any view yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)