### PR TITLE
♻️ refactor: apply design tokens to AgentOutputRow (B1)

### DIFF
--- a/Pastura/Pastura/Views/Components/AgentOutputRow.swift
+++ b/Pastura/Pastura/Views/Components/AgentOutputRow.swift
@@ -147,8 +147,10 @@ struct AgentOutputRow: View {
     let splitIdx = fullText.index(fullText.startIndex, offsetBy: revealed)
     let visible = fullText[..<splitIdx]
     let hidden = fullText[splitIdx...]
+    // Why: `.textStyle(_:)` on the concatenated `Text + Text` — uniform
+    // lineSpacing/tracking keeps the concat trick stable (see type doc).
     return (Text(visible) + Text(hidden).foregroundStyle(.clear))
-      .font(.body)
+      .textStyle(Typography.bodyBubble)
       // Streaming grows `streamingPrimary` token-by-token; SwiftUI would
       // otherwise animate the Text's string change implicitly and the
       // re-laid-out glyphs cross-fade visibly. Keyed on `streamingPrimary`
@@ -182,9 +184,8 @@ struct AgentOutputRow: View {
     let visible = fullText[..<splitIdx]
     let hidden = fullText[splitIdx...]
     return (Text(visible) + Text(hidden).foregroundStyle(.clear))
-      .font(.caption)
-      .italic()
-      .foregroundStyle(.secondary)
+      .textStyle(Typography.thinkingBody)
+      .foregroundStyle(Color.muted)
       .padding(.leading, 8)
   }
 
@@ -203,15 +204,14 @@ struct AgentOutputRow: View {
         Text(showInnerThought ? "Hide thought" : "Show thought")
       }
       .font(.caption)
-      .foregroundStyle(.secondary)
+      .foregroundStyle(Color.muted)
     }
     .buttonStyle(.plain)
 
     if showInnerThought {
       Text(fullText)
-        .font(.caption)
-        .foregroundStyle(.secondary)
-        .italic()
+        .textStyle(Typography.thinkingBody)
+        .foregroundStyle(Color.muted)
         .padding(.leading, 8)
         .transition(.opacity.combined(with: .move(edge: .top)))
     }

--- a/Pastura/Pastura/Views/DesignTokens+SwiftUI.swift
+++ b/Pastura/Pastura/Views/DesignTokens+SwiftUI.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+
+// SwiftUI-facing helpers for the Pastura design system.
+//
+// Kept separate from `DesignTokens.swift` so the token data sits in one file
+// and the SwiftUI bindings (`Color` aliases, `View.textStyle(_:)`) in another
+// — eases the future SPM split (tokens module vs UI module).
+
+// MARK: - Color extension (SwiftUI-facing aliases)
+
+extension Color {
+  // §2.1 Backgrounds
+  static let page = PasturaPalette.page.color
+  static let screenBackground = PasturaPalette.screenBackground.color
+  static let bubbleBackground = PasturaPalette.bubbleBackground.color
+  static let promoBackground = PasturaPalette.promoBackground.color
+  static let promoBorder = PasturaPalette.promoBorder.color
+
+  // §2.2 Ink
+  static let ink = PasturaPalette.ink.color
+  static let inkSecondary = PasturaPalette.inkSecondary.color
+  static let muted = PasturaPalette.muted.color
+  static let rule = PasturaPalette.rule.color
+
+  // §2.3 Moss
+  static let moss = PasturaPalette.moss.color
+  static let mossDark = PasturaPalette.mossDark.color
+  static let mossInk = PasturaPalette.mossInk.color
+  static let mossSoft = PasturaPalette.mossSoft.color
+
+  // §2.4 Meta L1
+  static let metaBaseL1 = PasturaPalette.metaBaseL1.color
+  static let metaStrongL1 = PasturaPalette.metaStrongL1.color
+  static let metaDotOnL1 = PasturaPalette.metaDotOnL1.color
+
+  // §2.4 Meta L2
+  static let metaBaseL2 = PasturaPalette.metaBaseL2.color
+  static let metaStrongL2 = PasturaPalette.metaStrongL2.color
+  static let metaDotOnL2 = PasturaPalette.metaDotOnL2.color
+
+  // §2.4 Meta L3 (default)
+  static let metaBaseL3 = PasturaPalette.metaBaseL3.color
+  static let metaStrongL3 = PasturaPalette.metaStrongL3.color
+  static let metaDotOnL3 = PasturaPalette.metaDotOnL3.color
+
+  // §2.4 Meta L4
+  static let metaBaseL4 = PasturaPalette.metaBaseL4.color
+  static let metaStrongL4 = PasturaPalette.metaStrongL4.color
+  static let metaDotOnL4 = PasturaPalette.metaDotOnL4.color
+
+  // §2.5 Avatars
+  static let avatarAlice = PasturaPalette.avatarAlice.color
+  static let avatarBob = PasturaPalette.avatarBob.color
+  static let avatarCarol = PasturaPalette.avatarCarol.color
+  static let avatarDave = PasturaPalette.avatarDave.color
+  static let avatarEar = PasturaPalette.avatarEar.color
+  static let avatarEarInner = PasturaPalette.avatarEarInner.color
+  static let avatarNose = PasturaPalette.avatarNose.color
+  static let avatarEye = PasturaPalette.avatarEye.color
+  static let avatarHighlight = PasturaPalette.avatarHighlight.color
+}
+
+// MARK: - View modifier
+
+extension View {
+  /// Applies a ``PasturaTextStyle`` by combining `.font`, `.lineSpacing`,
+  /// `.tracking`, and `.textCase` in one call.
+  ///
+  /// Prefer this over manually chaining those four modifiers at each callsite —
+  /// keeps the token intent (one `Typography.*` reference) visible and avoids
+  /// forgetting a modifier (e.g. `.textCase(.uppercase)` on `tagPhase`).
+  ///
+  /// Applied to the result of a `Text + Text` concatenation, `.lineSpacing` and
+  /// `.tracking` cover both halves uniformly — load-bearing for callsites like
+  /// `AgentOutputRow.primaryView` that use the concat trick for reflow-stable
+  /// typing reveals.
+  func textStyle(_ style: PasturaTextStyle) -> some View {
+    self
+      .font(style.font)
+      .lineSpacing(style.lineSpacingPoints)
+      .tracking(style.trackingPoints)
+      .textCase(style.textCase)
+  }
+}

--- a/Pastura/Pastura/Views/DesignTokens.swift
+++ b/Pastura/Pastura/Views/DesignTokens.swift
@@ -345,81 +345,8 @@ enum Radius {
   static let dot: CGFloat = .infinity
 }
 
-// MARK: - Color extension (SwiftUI-facing aliases)
-
-extension Color {
-  // §2.1 Backgrounds
-  static let page = PasturaPalette.page.color
-  static let screenBackground = PasturaPalette.screenBackground.color
-  static let bubbleBackground = PasturaPalette.bubbleBackground.color
-  static let promoBackground = PasturaPalette.promoBackground.color
-  static let promoBorder = PasturaPalette.promoBorder.color
-
-  // §2.2 Ink
-  static let ink = PasturaPalette.ink.color
-  static let inkSecondary = PasturaPalette.inkSecondary.color
-  static let muted = PasturaPalette.muted.color
-  static let rule = PasturaPalette.rule.color
-
-  // §2.3 Moss
-  static let moss = PasturaPalette.moss.color
-  static let mossDark = PasturaPalette.mossDark.color
-  static let mossInk = PasturaPalette.mossInk.color
-  static let mossSoft = PasturaPalette.mossSoft.color
-
-  // §2.4 Meta L1
-  static let metaBaseL1 = PasturaPalette.metaBaseL1.color
-  static let metaStrongL1 = PasturaPalette.metaStrongL1.color
-  static let metaDotOnL1 = PasturaPalette.metaDotOnL1.color
-
-  // §2.4 Meta L2
-  static let metaBaseL2 = PasturaPalette.metaBaseL2.color
-  static let metaStrongL2 = PasturaPalette.metaStrongL2.color
-  static let metaDotOnL2 = PasturaPalette.metaDotOnL2.color
-
-  // §2.4 Meta L3 (default)
-  static let metaBaseL3 = PasturaPalette.metaBaseL3.color
-  static let metaStrongL3 = PasturaPalette.metaStrongL3.color
-  static let metaDotOnL3 = PasturaPalette.metaDotOnL3.color
-
-  // §2.4 Meta L4
-  static let metaBaseL4 = PasturaPalette.metaBaseL4.color
-  static let metaStrongL4 = PasturaPalette.metaStrongL4.color
-  static let metaDotOnL4 = PasturaPalette.metaDotOnL4.color
-
-  // §2.5 Avatars
-  static let avatarAlice = PasturaPalette.avatarAlice.color
-  static let avatarBob = PasturaPalette.avatarBob.color
-  static let avatarCarol = PasturaPalette.avatarCarol.color
-  static let avatarDave = PasturaPalette.avatarDave.color
-  static let avatarEar = PasturaPalette.avatarEar.color
-  static let avatarEarInner = PasturaPalette.avatarEarInner.color
-  static let avatarNose = PasturaPalette.avatarNose.color
-  static let avatarEye = PasturaPalette.avatarEye.color
-  static let avatarHighlight = PasturaPalette.avatarHighlight.color
-}
-
-// MARK: - View modifier
-
-extension View {
-  /// Applies a ``PasturaTextStyle`` by combining `.font`, `.lineSpacing`,
-  /// `.tracking`, and `.textCase` in one call.
-  ///
-  /// Prefer this over manually chaining those four modifiers at each callsite —
-  /// keeps the token intent (one `Typography.*` reference) visible and avoids
-  /// forgetting a modifier (e.g. `.textCase(.uppercase)` on `tagPhase`).
-  ///
-  /// Applied to the result of a `Text + Text` concatenation, `.lineSpacing` and
-  /// `.tracking` cover both halves uniformly — load-bearing for callsites like
-  /// `AgentOutputRow.primaryView` that use the concat trick for reflow-stable
-  /// typing reveals.
-  func textStyle(_ style: PasturaTextStyle) -> some View {
-    self
-      .font(style.font)
-      .lineSpacing(style.lineSpacingPoints)
-      .tracking(style.trackingPoints)
-      .textCase(style.textCase)
-  }
-}
+// SwiftUI-facing helpers (`Color.*` aliases, `View.textStyle(_:)`) live in
+// `DesignTokens+SwiftUI.swift` — split to keep this file under the 400-line
+// cap and to ease the future SPM split (tokens module vs UI module).
 
 // swiftlint:enable identifier_name

--- a/Pastura/Pastura/Views/DesignTokens.swift
+++ b/Pastura/Pastura/Views/DesignTokens.swift
@@ -207,6 +207,11 @@ struct PasturaTextStyle: Sendable, Equatable {
 
   /// SwiftUI `Font` built from size / weight / design (+ italic modifier).
   var font: Font {
+    // Why: `Font.system(size:weight:design:)` is a fixed-size font, not Dynamic
+    // Type aware. This is a deliberate trade-off per `docs/design/design-system.md`
+    // — the scale's precise size/line-height values are load-bearing for the
+    // Pastura visual voice. When Dynamic Type support is revived, route
+    // `Font.system(size:relativeTo:)` through this single computed property.
     let base = Font.system(size: size, weight: weight, design: design)
     return isItalic ? base.italic() : base
   }
@@ -392,6 +397,29 @@ extension Color {
   static let avatarNose = PasturaPalette.avatarNose.color
   static let avatarEye = PasturaPalette.avatarEye.color
   static let avatarHighlight = PasturaPalette.avatarHighlight.color
+}
+
+// MARK: - View modifier
+
+extension View {
+  /// Applies a ``PasturaTextStyle`` by combining `.font`, `.lineSpacing`,
+  /// `.tracking`, and `.textCase` in one call.
+  ///
+  /// Prefer this over manually chaining those four modifiers at each callsite —
+  /// keeps the token intent (one `Typography.*` reference) visible and avoids
+  /// forgetting a modifier (e.g. `.textCase(.uppercase)` on `tagPhase`).
+  ///
+  /// Applied to the result of a `Text + Text` concatenation, `.lineSpacing` and
+  /// `.tracking` cover both halves uniformly — load-bearing for callsites like
+  /// `AgentOutputRow.primaryView` that use the concat trick for reflow-stable
+  /// typing reveals.
+  func textStyle(_ style: PasturaTextStyle) -> some View {
+    self
+      .font(style.font)
+      .lineSpacing(style.lineSpacingPoints)
+      .tracking(style.trackingPoints)
+      .textCase(style.textCase)
+  }
 }
 
 // swiftlint:enable identifier_name

--- a/Pastura/PasturaTests/Views/DesignTokensTests.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests.swift
@@ -179,6 +179,18 @@ struct DesignTokensTests {
     #expect(approxEqual(Double(style.trackingPoints), 9.5 * 0.22))
   }
 
+  @Test func thinkingBodyLineSpacingDerivedFromLineHeight() {
+    // thinking/body: 10.5pt × (1.7 − 1.0) = 7.35pt
+    let style = Typography.thinkingBody
+    #expect(approxEqual(Double(style.lineSpacingPoints), 10.5 * 0.7))
+  }
+
+  @Test func thinkingBodyTrackingDerivedFromLetterSpacing() {
+    // thinking/body: 10.5pt × 0.02em = 0.21pt
+    let style = Typography.thinkingBody
+    #expect(approxEqual(Double(style.trackingPoints), 10.5 * 0.02))
+  }
+
   // MARK: - §4 Spacing
 
   @Test func spacingScaleMatchesSpec() {


### PR DESCRIPTION
## Summary

Closes #168. Applies the design tokens from #166/#173 to the shared
`AgentOutputRow`, flowing through to SimulationView (2 callsites) and
ResultDetailView (1 callsite) in one refactor. Public signature
unchanged.

- New `View.textStyle(_:)` modifier combines `.font` / `.lineSpacing` /
  `.tracking` / `.textCase` into one call (the piece PR #173 deferred
  to B1).
- Primary speech body → `Typography.bodyBubble`; thought display →
  `Typography.thinkingBody` (italic baked in) + `Color.muted` (closer
  match to reference HTML `.b-inner` #8a876f than `inkSecondary`).
- Show/Hide thought button kept on system `.caption` (no §3 token for
  a control label) but color unified with the thought via `.muted`.
- `PasturaTextStyle.font` gains a Dynamic Type breadcrumb for the
  deliberate fixed-size trade-off and the single-point migration path.
- DesignTokens.swift split — SwiftUI-facing `Color` aliases + the new
  `View.textStyle(_:)` extension moved to `DesignTokens+SwiftUI.swift`
  (keeps both files under the 400-line cap + pre-aligns with the
  future SPM tokens/UI module split).
- Concat-trick invariant preserved: `.textStyle(_:)` is applied to the
  concatenated `Text + Text` so visible/hidden halves share
  lineSpacing/tracking uniformly (load-bearing for reflow-stable
  streaming reveal per #133).

Critic pre-impl found 6 Warnings (no Critical) — all adopted:
dropped the speculative `Text.textStyle(_:)` variant, resolved color
against `demo-replay-reference.html`, added `thinkingBody` derivation
tests, Dynamic Type breadcrumb, concat-trick Why comment.
Code-reviewer on the finished branch: **PASS**.

## Test plan

- [x] `xcodebuild test -skip-testing:PasturaUITests` — `** TEST SUCCEEDED **`
- [x] `swiftlint lint --quiet --strict` — clean
- [x] Manual QA: Simulation golden path (speech / THINKING auto-reveal / vote), Past Results same, #133 streaming scenario (rapid token arrival crossing a line-wrap boundary) — **requires human verification; not run from the agent session**
- [x] CI green (required checks only; auto-merge disabled per CLAUDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)