### PR TITLE
✨ feat: skip streaming snapshot under .instant playback (#133)

### DIFF
--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -762,6 +762,18 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     agent: String, primary: String?, thought: String?
   ) {
     guard FeatureFlags.realtimeStreamingEnabled else { return }
+    // `.instant` playback means "do not animate reveal in any form"
+    // (ADR-002 §11.2 Axis ③). Short-circuit at the event layer — with
+    // no snapshot set, the thinking indicator persists until the
+    // canonical `.agentOutput` commit and the full output appears at
+    // once, matching the flag-off baseline. Accepted trade-offs:
+    // (a) `.instant` users lose live `handleAgentOutput` divergence
+    // telemetry (coverage: non-`.instant` users + unit/integration
+    // tests, per ADR-002 §11.2); (b) a mid-turn speed change from
+    // `.normal` / `.slow` / `.fast` → `.instant` leaves the existing
+    // snapshot in place until commit — this is an accepted limitation,
+    // not a supported toggle-responsiveness contract.
+    guard speed != .instant else { return }
     guard let primary else { return }
     // Defensive: drop the event if we somehow see a stream before
     // `.phaseStarted`. The snapshot needs a correct `phaseType` so

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -767,9 +767,13 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     // no snapshot set, the thinking indicator persists until the
     // canonical `.agentOutput` commit and the full output appears at
     // once, matching the flag-off baseline. Accepted trade-offs:
-    // (a) `.instant` users lose live `handleAgentOutput` divergence
-    // telemetry (coverage: non-`.instant` users + unit/integration
-    // tests, per ADR-002 §11.2); (b) a mid-turn speed change from
+    // (a) `.instant` users lose the live snapshot-vs-canonical
+    // divergence check in `handleAgentOutput` — it is gated on
+    // `streamingSnapshot != nil`, which never holds under `.instant`.
+    // The upstream DEBUG `detectSilentStreamReIssue` diagnostic runs
+    // at the `handleEvent` dispatch site and is unaffected. Coverage
+    // for the lost check: non-`.instant` users + unit/integration
+    // tests, per ADR-002 §11.2. (b) A mid-turn speed change from
     // `.normal` / `.slow` / `.fast` → `.instant` leaves the existing
     // snapshot in place until commit — this is an accepted limitation,
     // not a supported toggle-responsiveness contract.

--- a/Pastura/PasturaTests/App/SimulationViewModelStreamingTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelStreamingTests.swift
@@ -278,4 +278,34 @@ struct SimulationViewModelStreamingTests {
     #expect(
       sut.effectiveCharsPerSecond(forEntryId: committedId) == PlaybackSpeed.normal.charsPerSecond)
   }
+
+  /// `.instant` speed must bypass the streaming snapshot gate entirely.
+  /// Issue #133 PR#6; ADR-002 §11.2 Axis ③ (Choice 2 — event-layer).
+  @Test func instantSpeedSkipsStreamingAndPreservesThinkingIndicator() throws {
+    let (sut, scenario) = try makeSUT()
+    sut.speed = .instant
+    sut.handleEvent(
+      .phaseStarted(phaseType: .speakAll, phasePath: [0]), scenario: scenario)
+    sut.handleEvent(.inferenceStarted(agent: "Alice"), scenario: scenario)
+    #expect(sut.thinkingAgents.contains("Alice"))
+
+    sut.handleEvent(
+      .agentOutputStream(agent: "Alice", primary: "hello", thought: nil),
+      scenario: scenario)
+
+    // Gate: snapshot must stay nil; thinking indicator must persist until commit.
+    #expect(sut.streamingSnapshot == nil)
+    #expect(sut.thinkingAgents.contains("Alice"))
+
+    let output = TurnOutput(fields: ["statement": "hello"])
+    sut.handleEvent(
+      .agentOutput(agent: "Alice", output: output, phaseType: .speakAll),
+      scenario: scenario)
+
+    let committedId = try #require(sut.latestAgentOutputId)
+    // No streaming row was ever set, so pre-reveal tracking must be empty.
+    #expect(sut.prerevealedAgentOutputIds.isEmpty)
+    // `.instant.charsPerSecond` is nil by definition; pins the instant-snap invariant.
+    #expect(sut.effectiveCharsPerSecond(forEntryId: committedId) == nil)
+  }
 }


### PR DESCRIPTION
## Summary

- PR#6 of #133 — implements Axis ③ (`.instant` event-layer gate, Choice 2) per ADR-002 §11.2 (shipped via #174)
- Adds `guard speed != .instant else { return }` in `SimulationViewModel.handleAgentOutputStream` (`Pastura/Pastura/App/SimulationViewModel.swift:776`). Under `.instant`, `streamingSnapshot` stays nil and the thinking indicator holds until the canonical `.agentOutput` commit — matches the flag-off baseline and restores primary/thought reveal symmetry
- DEBUG `detectSilentStreamReIssue` (Hyp A′ diagnostic) left ungated: it runs upstream at the `handleEvent` dispatch site, so `.instant` dev sessions retain the signal
- No view-layer changes needed — `SimulationView`'s streaming row + scroll observer are already gated on `streamingSnapshot != nil`, and `effectiveCharsPerSecond` already returns nil for `.instant` via `speed.charsPerSecond == nil`

### Accepted trade-offs (documented at the guard + ADR-002 §11.2)

- `.instant` users lose the snapshot-vs-canonical divergence check in `handleAgentOutput` (that branch requires a non-nil snapshot). Coverage fallback: non-`.instant` user telemetry + unit/integration tests
- Mid-turn speed change (`.normal`/`.slow`/`.fast` → `.instant`) leaves an existing snapshot in place until commit — not a supported toggle-responsiveness contract

## Test plan

- [x] New unit test `instantSpeedSkipsStreamingAndPreservesThinkingIndicator` pins four invariants: snapshot stays nil mid-stream, thinking indicator persists until commit, `prerevealedAgentOutputIds` stays empty post-commit, `effectiveCharsPerSecond` returns nil for the committed row
- [x] Full unit suite green (`xcodebuild test -scheme Pastura -skip-testing:PasturaUITests`)
- [x] `swiftlint lint --quiet --strict` clean
- [ ] On-device QA: set speed to Max (`.instant`) on a preset, verify no streaming row appears — thinking indicator → committed row with no intermediate reveal (no double reveal, no flicker)
- [ ] Regression QA: set speed to `.slow`/`.normal`/`.fast`, verify streaming display still works unchanged

Refs #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)