### PR TITLE
📝 docs: disambiguate two streaming telemetries (#133)

### DIFF
--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -674,12 +674,23 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
       lastRawStreamingPrimary[agent] = nil
     #endif
     let filtered = contentFilter.filter(output)
-    // Divergence telemetry: compare the last streamed snapshot against
-    // the canonical parser result for the same inference. A mismatch
-    // here means the partial extractor showed the user something that
-    // the canonical parse later contradicted — exactly the failure
-    // mode the critic flagged. Debug-level so it stays available for
-    // future investigation without polluting production logs.
+    // Snapshot-vs-canonical divergence telemetry: compare the last
+    // streamed snapshot against the canonical parser result for the
+    // same inference. A mismatch here means the partial extractor
+    // showed the user something that the canonical parse later
+    // contradicted — exactly the failure mode the critic flagged.
+    // Debug-level so it stays available for future investigation
+    // without polluting production logs.
+    //
+    // Distinct from the DEBUG `detectSilentStreamReIssue` diagnostic
+    // (Hyp A′, runs at the `handleEvent` dispatch site): that
+    // one measures *silent stream re-issue* via raw-primary
+    // monotonicity across events. This check measures
+    // *snapshot-vs-canonical* agreement at commit, is gated on
+    // `streamingSnapshot != nil`, and is therefore silenced under
+    // `.instant` (snapshot stays nil per ADR-002 §11.2 Axis ③). The
+    // dispatch-site diagnostic runs above the `.instant` gate and
+    // fires for all speeds — they do not substitute for one another.
     if let snapshot = streamingSnapshot, snapshot.agent == agent {
       let canonicalPrimary = filtered.primaryText(for: phaseType) ?? ""
       if !canonicalPrimary.hasPrefix(snapshot.primary) {
@@ -740,6 +751,13 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     ///
     /// Uses raw (pre-ContentFilter) primary so filter rewrites like
     /// `"fuck" → "***"` aren't mistaken for resets.
+    ///
+    /// Distinct from the "stream divergence" debug log in
+    /// ``handleAgentOutput(agent:output:phaseType:)`` — see the comment
+    /// block at that call site for the full comparison. Summary: that
+    /// one checks snapshot-vs-canonical at commit (silenced under
+    /// `.instant`); this one checks raw-primary monotonicity at the
+    /// dispatch site (runs for all speeds).
     private func detectSilentStreamReIssue(agent: String, primary: String?) {
       guard let newPrimary = primary, !newPrimary.isEmpty else { return }
       if let existing = lastRawStreamingPrimary[agent] {

--- a/docs/decisions/ADR-002.md
+++ b/docs/decisions/ADR-002.md
@@ -530,10 +530,16 @@ Axis ① outcome. It is equally valid under Option 0 (selected) and C′
 circuits, not *how* the streaming row is structured.
 
 Accepted trade-off (unchanged from master tracker): `.instant` users
-lose live `handleAgentOutput` divergence telemetry. Alternative
-coverage remains: (a) `.normal`/`.fast` user telemetry (majority),
-(b) Ollama integration tests enforcing partial-prefix invariant,
-(c) `PartialOutputExtractor` unit tests.
+lose the live **snapshot-vs-canonical divergence check** in
+`handleAgentOutput` — that branch requires a non-nil
+`streamingSnapshot`, which never holds under `.instant`. The upstream
+DEBUG `detectSilentStreamReIssue` diagnostic (Hyp A′ signal; runs at
+the `handleEvent` dispatch site, above the `.instant` gate) is
+distinct from this check and unaffected by the gate — it continues
+to fire for all speeds. Alternative coverage for the lost
+snapshot-vs-canonical check: (a) `.normal`/`.fast` user telemetry
+(majority), (b) Ollama integration tests enforcing partial-prefix
+invariant, (c) `PartialOutputExtractor` unit tests.
 
 #### Resolution of master-tracker "Decisions pending"
 


### PR DESCRIPTION
## Summary

Two telemetry mechanisms in `SimulationViewModel` both use "divergence" terminology and have been repeatedly confused — most recently by the code-reviewer on PR #177, which flagged a false-positive Warning because the two telemetries are distinct but the naming doesn't say so.

| Telemetry | Where | Log line | Gating |
|---|---|---|---|
| Snapshot-vs-canonical divergence check | `handleAgentOutput` (non-DEBUG) | `lifecycleLogger.debug("stream divergence: ...")` | `streamingSnapshot != nil` → silenced under `.instant` |
| `detectSilentStreamReIssue` (Hyp A′) | Dispatch site of `.agentOutputStream` (DEBUG-only) | `streamingDiagLogger.info("streamReset type=diverge\|shrink ...")` | Runs above the `.instant` gate → fires for all speeds |

### Changes

- **`docs/decisions/ADR-002.md` §11.2 Axis ③** — tighten the "Accepted trade-off" paragraph: specify that it is the *snapshot-vs-canonical* check that is lost, and explicitly call out that the Hyp A′ dispatch-site diagnostic is unaffected.
- **`Pastura/Pastura/App/SimulationViewModel.swift` `handleAgentOutput` comment** — add a cross-reference block (11 lines) explaining the local distinction between the two checks, with a pointer to ADR-002 §11.2 Axis ③ for the trade-off rationale. This is the non-DEBUG default-reading path, so it gets the detailed note.
- **`Pastura/Pastura/App/SimulationViewModel.swift` `detectSilentStreamReIssue` doc-comment** — add a short reciprocal cross-reference back to the `handleAgentOutput` block. Symmetric in intent without duplicating content.

## Test plan

- [x] `swiftlint lint --quiet --strict` clean
- [x] Pure docs/comments change — no code behavior modified, so no unit-test impact
- [x] Code-reviewed the diff locally before commit (found 1 minor wording Suggestion, addressed)

Refs #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)