### PR TITLE
✨ feat: Share Board report UI + pseudonymous contact (ADR-005 §6)

### DIFF
--- a/.github/ISSUE_TEMPLATE/share-board-report.yml
+++ b/.github/ISSUE_TEMPLATE/share-board-report.yml
@@ -1,0 +1,56 @@
+name: Share Board scenario report
+description: Report a concern about a scenario published on Pastura's Share Board.
+title: "[Share Board Report] "
+labels:
+  - share-board-report
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting. This form files a **public** GitHub issue —
+        everything you enter here is visible to everyone on the internet.
+
+        If you prefer a **private** report (no account required), please
+        use the Google Forms report surface from inside the Pastura app
+        instead. That path sends the report directly to the Pastura
+        maintainer and is not publicly indexed.
+
+        Reports are reviewed by the Pastura maintainer. See
+        [ADR-005 §6](../../docs/decisions/ADR-005.md) for the policy.
+
+  - type: input
+    id: scenario_id
+    attributes:
+      label: Scenario ID
+      description: The `id` field from the gallery entry (e.g. `prisoners_dilemma_v2`).
+      placeholder: "<scenario_id>"
+    validations:
+      required: true
+
+  - type: input
+    id: app_version
+    attributes:
+      label: App version (optional)
+      description: "Found in Settings inside the app. Leave blank if unknown."
+      placeholder: "e.g. 1.0.0"
+    validations:
+      required: false
+
+  - type: textarea
+    id: reason
+    attributes:
+      label: Reason
+      description: |
+        Describe the concern. Do not include personal information about
+        yourself or others in this field — GitHub issues are public.
+      placeholder: What about this scenario should we look at?
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        **Contact note:** we'll reply by @-mentioning your GitHub
+        account on this issue. Please do not paste your email address
+        or other personal contact details anywhere in this form — they
+        would be publicly indexed forever.

--- a/Pastura/Pastura/App/Router.swift
+++ b/Pastura/Pastura/App/Router.swift
@@ -29,4 +29,8 @@ enum Route: Hashable {
 
   /// Detail view for a single gallery scenario, with Try / Update action.
   case galleryScenarioDetail(scenario: GalleryScenario)
+
+  /// Settings screen — content-reporting disclosure and future
+  /// configuration surfaces.
+  case settings
 }

--- a/Pastura/Pastura/Utilities/ReportURLBuilder.swift
+++ b/Pastura/Pastura/Utilities/ReportURLBuilder.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// Builds pre-filled URLs for Share Board scenario reports.
+///
+/// Backs `ReportScenarioSheet`'s primary (Google Forms) and secondary
+/// (GitHub issue) surfaces. See `docs/gallery/share-board-reports.md`
+/// for the form configuration and ADR-005 §6.6 for the record of the
+/// chosen mechanism.
+///
+/// The Google form ID and each entry-field ID are compile-time
+/// constants. If the form is ever re-created or migrated, update the
+/// constants in the same PR that changes the form.
+nonisolated enum ReportURLBuilder {
+  // Google Forms identifiers — mirror the form configuration
+  // documented in docs/gallery/share-board-reports.md §1.1.
+  private static let googleFormID =
+    "1FAIpQLSfsZkY9-R3QxqVfdXSzsUnx3SXR-g9O7DxjdN-1-VtMjMXSAw"
+  private static let scenarioIdFieldID = "entry.149667905"
+  private static let appVersionFieldID = "entry.1904779030"
+
+  // GitHub issue identifiers.
+  private static let githubRepoPath = "tyabu12/pastura"
+  private static let githubTemplateSlug = "share-board-report.yml"
+  private static let githubLabel = "share-board-report"
+
+  /// Build the pre-filled Google Forms URL for a Share Board report.
+  ///
+  /// Opens the form in Safari with the Scenario ID and App Version
+  /// fields populated; the Reason and Email fields are left blank for
+  /// the reporter to fill on the form itself. The Email field is not
+  /// pre-fillable by Google Forms design — the form must be configured
+  /// with `Collect email addresses: Responder input` so the email
+  /// field is rendered as a user-typed field that triggers the
+  /// response-receipt auto-acknowledgement (see ADR-005 §6.3).
+  ///
+  /// - Parameters:
+  ///   - scenarioId: Gallery scenario identifier.
+  ///   - appVersion: Running app version (e.g. "1.0.0"). Empty
+  ///     strings are permitted and leave the App Version field blank.
+  /// - Returns: The pre-filled form URL, or `nil` if URL construction
+  ///   fails.
+  static func buildGoogleFormURL(scenarioId: String, appVersion: String) -> URL? {
+    guard
+      var components = URLComponents(
+        string: "https://docs.google.com/forms/d/e/\(googleFormID)/viewform")
+    else {
+      return nil
+    }
+    components.queryItems = [
+      URLQueryItem(name: "usp", value: "pp_url"),
+      URLQueryItem(name: scenarioIdFieldID, value: scenarioId),
+      URLQueryItem(name: appVersionFieldID, value: appVersion)
+    ]
+    return components.url
+  }
+
+  /// Build the pre-seeded GitHub issue URL for a Share Board report.
+  ///
+  /// Opens github.com's new-issue page with the Share Board template
+  /// selected, the title pre-filled (`[Share Board Report] <id>`), and
+  /// the `share-board-report` label attached. The reporter must be
+  /// signed into GitHub to submit — this is why this surface is the
+  /// secondary "public discussion" path, not the primary report path.
+  ///
+  /// - Parameter scenarioId: Gallery scenario identifier. Rendered
+  ///   into the pre-filled title.
+  /// - Returns: The pre-seeded issue-creation URL, or `nil` if URL
+  ///   construction fails.
+  static func buildGitHubIssueURL(scenarioId: String) -> URL? {
+    guard
+      var components = URLComponents(
+        string: "https://github.com/\(githubRepoPath)/issues/new")
+    else {
+      return nil
+    }
+    components.queryItems = [
+      URLQueryItem(name: "template", value: githubTemplateSlug),
+      URLQueryItem(name: "title", value: "[Share Board Report] \(scenarioId)"),
+      URLQueryItem(name: "labels", value: githubLabel)
+    ]
+    return components.url
+  }
+}

--- a/Pastura/Pastura/Views/Community/ShareBoard/GalleryScenarioDetailView.swift
+++ b/Pastura/Pastura/Views/Community/ShareBoard/GalleryScenarioDetailView.swift
@@ -16,6 +16,7 @@ struct GalleryScenarioDetailView: View {
   @State private var viewModel: ShareBoardViewModel?
   @State private var isWorking = false
   @State private var outcomeAlert: OutcomeAlert?
+  @State private var isReportSheetPresented = false
 
   var body: some View {
     Group {
@@ -35,6 +36,23 @@ struct GalleryScenarioDetailView: View {
     }
     .alert(item: $outcomeAlert) { alert in
       Alert(title: Text(alert.title), message: Text(alert.message))
+    }
+    .toolbar {
+      ToolbarItem(placement: .primaryAction) {
+        Menu {
+          Button {
+            isReportSheetPresented = true
+          } label: {
+            Label("Report this scenario", systemImage: "exclamationmark.bubble")
+          }
+          .accessibilityIdentifier("galleryDetail.reportMenuItem")
+        } label: {
+          Label("More", systemImage: "ellipsis.circle")
+        }
+      }
+    }
+    .sheet(isPresented: $isReportSheetPresented) {
+      ReportScenarioSheet(scenario: scenario)
     }
   }
 

--- a/Pastura/Pastura/Views/Community/ShareBoard/ReportScenarioSheet.swift
+++ b/Pastura/Pastura/Views/Community/ShareBoard/ReportScenarioSheet.swift
@@ -1,0 +1,133 @@
+import SwiftUI
+
+/// Presentation surface for "Report this scenario" from Share Board.
+///
+/// Uses progressive disclosure: the primary action opens a pre-filled
+/// Google Forms report in Safari (no account required); a secondary
+/// link opens a GitHub issue for reporters who prefer public
+/// discussion. Text entry happens on the external page — this sheet
+/// is a metadata display and launching pad only.
+///
+/// See ADR-005 §6 for the policy rationale, and
+/// `docs/gallery/share-board-reports.md` for operational details.
+struct ReportScenarioSheet: View {
+  let scenario: GalleryScenario
+
+  @Environment(\.openURL) private var openURL
+  @Environment(\.dismiss) private var dismiss
+
+  var body: some View {
+    NavigationStack {
+      ScrollView {
+        VStack(alignment: .leading, spacing: 20) {
+          scenarioMetadata
+          introCopy
+          primarySection
+          Divider()
+          secondarySection
+        }
+        .padding()
+      }
+      .navigationTitle("Report scenario")
+      .navigationBarTitleDisplayMode(.inline)
+      .toolbar {
+        ToolbarItem(placement: .cancellationAction) {
+          Button("Cancel") { dismiss() }
+        }
+      }
+    }
+    .presentationDetents([.medium, .large])
+  }
+
+  // MARK: - Sections
+
+  private var scenarioMetadata: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      Text(scenario.title)
+        .font(.headline)
+      Text("id: \(scenario.id)")
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .textSelection(.enabled)
+    }
+    .padding(12)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(Color.secondary.opacity(0.1), in: RoundedRectangle(cornerRadius: 8))
+  }
+
+  private var introCopy: some View {
+    Text(
+      "Reports are reviewed by the Pastura maintainer. "
+        + "You'll receive a confirmation email when your report is received."
+    )
+    .font(.body)
+    .foregroundStyle(.secondary)
+  }
+
+  private var primarySection: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      Button(action: openReportForm) {
+        HStack {
+          Image(systemName: "paperplane.fill")
+          Text("Open Report Form")
+        }
+        .frame(maxWidth: .infinity)
+      }
+      .buttonStyle(.borderedProminent)
+      .controlSize(.large)
+      .accessibilityIdentifier("reportSheet.openFormButton")
+
+      Text("No account required.")
+        .font(.caption)
+        .foregroundStyle(.secondary)
+      Text(
+        "Opens Google Forms in Safari. Your report is processed by Google "
+          + "under their privacy policy."
+      )
+      .font(.caption2)
+      .foregroundStyle(.secondary)
+    }
+  }
+
+  private var secondarySection: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      Text("Prefer public discussion?")
+        .font(.footnote)
+
+      Button(action: openGitHubIssue) {
+        HStack {
+          Image(systemName: "arrow.up.right.square")
+          Text("Open on GitHub")
+        }
+      }
+      .buttonStyle(.bordered)
+      .accessibilityIdentifier("reportSheet.openGitHubButton")
+
+      Text("Requires a GitHub account. The resulting issue is public.")
+        .font(.caption)
+        .foregroundStyle(.secondary)
+    }
+  }
+
+  // MARK: - Actions
+
+  private func openReportForm() {
+    guard
+      let url = ReportURLBuilder.buildGoogleFormURL(
+        scenarioId: scenario.id, appVersion: appVersion)
+    else { return }
+    openURL(url)
+    dismiss()
+  }
+
+  private func openGitHubIssue() {
+    guard let url = ReportURLBuilder.buildGitHubIssueURL(scenarioId: scenario.id)
+    else { return }
+    openURL(url)
+    dismiss()
+  }
+
+  private var appVersion: String {
+    (Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String) ?? ""
+  }
+}

--- a/Pastura/Pastura/Views/Home/HomeView.swift
+++ b/Pastura/Pastura/Views/Home/HomeView.swift
@@ -21,6 +21,12 @@ struct HomeView: View {
       }
       .navigationTitle("Pastura")
       .toolbar {
+        ToolbarItem(placement: .topBarLeading) {
+          NavigationLink(value: Route.settings) {
+            Label("Settings", systemImage: "gearshape")
+          }
+          .accessibilityIdentifier("home.settingsButton")
+        }
         ToolbarItem(placement: .primaryAction) {
           Menu {
             NavigationLink(value: Route.editor()) {
@@ -177,6 +183,8 @@ struct HomeView: View {
       ShareBoardView()
     case .galleryScenarioDetail(let scenario):
       GalleryScenarioDetailView(scenario: scenario)
+    case .settings:
+      SettingsView()
     }
   }
 

--- a/Pastura/Pastura/Views/Settings/SettingsView.swift
+++ b/Pastura/Pastura/Views/Settings/SettingsView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+/// Settings screen hosting static informational copy for the Pastura app.
+///
+/// Phase-2 scope is deliberately minimal: only the Content reporting
+/// section (ADR-005 §6.4 reviewer identity + brief mechanism
+/// description). About / version / Cloud-API consent controls are
+/// future work; this file will gain sections as those features land.
+///
+/// Pushed onto the root `NavigationStack` via `Route.settings`. Per
+/// `.claude/rules/navigation.md`, this view must NOT add
+/// `navigationDestination(item:|isPresented:)` modifiers.
+struct SettingsView: View {
+  var body: some View {
+    List {
+      Section {
+        contentReportingBody
+      } header: {
+        Text("Content reporting")
+      }
+    }
+    .navigationTitle("Settings")
+    .navigationBarTitleDisplayMode(.inline)
+  }
+
+  private var contentReportingBody: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Text(
+        "Reports about scenarios on the Share Board are reviewed by "
+          + "the Pastura maintainer (github.com/tyabu12)."
+      )
+      .font(.body)
+
+      Text(
+        "To report a scenario: open it from the Share Board, tap "
+          + "the More menu, and choose Report this scenario."
+      )
+      .font(.body)
+      .foregroundStyle(.secondary)
+
+      Text("You'll receive a confirmation email when your report is received.")
+        .font(.footnote)
+        .foregroundStyle(.secondary)
+    }
+    .padding(.vertical, 4)
+  }
+}

--- a/Pastura/PasturaTests/ReportURLBuilderTests.swift
+++ b/Pastura/PasturaTests/ReportURLBuilderTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+@Suite(.timeLimit(.minutes(1)))
+struct ReportURLBuilderTests {
+  // MARK: - Google Forms URL
+
+  @Test
+  func googleFormURLBuildsWithExpectedHostAndPath() throws {
+    let url = try #require(
+      ReportURLBuilder.buildGoogleFormURL(scenarioId: "prisoners_dilemma", appVersion: "1.0.0"))
+    #expect(url.scheme == "https")
+    #expect(url.host == "docs.google.com")
+    #expect(url.path.hasPrefix("/forms/d/e/"))
+    #expect(url.path.hasSuffix("/viewform"))
+  }
+
+  @Test
+  func googleFormURLIncludesPreFillMarker() throws {
+    let url = try #require(
+      ReportURLBuilder.buildGoogleFormURL(scenarioId: "any", appVersion: ""))
+    let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+    let items = components.queryItems ?? []
+    #expect(items.contains { $0.name == "usp" && $0.value == "pp_url" })
+  }
+
+  @Test
+  func googleFormURLEmbedsScenarioIdAndAppVersionValues() throws {
+    let url = try #require(
+      ReportURLBuilder.buildGoogleFormURL(scenarioId: "test_scenario", appVersion: "1.2.3"))
+    let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+    let values = Set((components.queryItems ?? []).compactMap { $0.value })
+    #expect(values.contains("test_scenario"))
+    #expect(values.contains("1.2.3"))
+  }
+
+  @Test
+  func googleFormURLRoundTripsSpecialCharacters() throws {
+    // Spaces, slash, and ampersand all require percent-encoding in
+    // query values. Confirm the builder produces a URL whose parsed
+    // queryItems decode back to the exact input.
+    let tricky = "id with spaces/slash&amp"
+    let url = try #require(
+      ReportURLBuilder.buildGoogleFormURL(scenarioId: tricky, appVersion: ""))
+    let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+    let match = components.queryItems?.first { $0.value == tricky }
+    #expect(match != nil)
+  }
+
+  @Test
+  func googleFormURLRoundTripsMultiByteCharacters() throws {
+    let japanese = "日本語_シナリオ"
+    let url = try #require(
+      ReportURLBuilder.buildGoogleFormURL(scenarioId: japanese, appVersion: ""))
+    let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+    let match = components.queryItems?.first { $0.value == japanese }
+    #expect(match != nil)
+  }
+
+  @Test
+  func googleFormURLAcceptsEmptyAppVersion() throws {
+    let url = try #require(
+      ReportURLBuilder.buildGoogleFormURL(scenarioId: "x", appVersion: ""))
+    let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+    // App version field is still present but with empty value — form
+    // renders an empty field rather than a pre-filled one.
+    let entryNames = (components.queryItems ?? []).map { $0.name }.filter {
+      $0.hasPrefix("entry.")
+    }
+    #expect(entryNames.count == 2)
+  }
+
+  // MARK: - GitHub issue URL
+
+  @Test
+  func gitHubIssueURLBuildsWithExpectedHostAndPath() throws {
+    let url = try #require(ReportURLBuilder.buildGitHubIssueURL(scenarioId: "x"))
+    #expect(url.scheme == "https")
+    #expect(url.host == "github.com")
+    #expect(url.path == "/tyabu12/pastura/issues/new")
+  }
+
+  @Test
+  func gitHubIssueURLCarriesTemplateTitleAndLabel() throws {
+    let url = try #require(
+      ReportURLBuilder.buildGitHubIssueURL(scenarioId: "prisoners_dilemma_v2"))
+    let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+    let items = components.queryItems ?? []
+    #expect(items.contains { $0.name == "template" && $0.value == "share-board-report.yml" })
+    #expect(items.contains { $0.name == "labels" && $0.value == "share-board-report" })
+    #expect(
+      items.contains {
+        $0.name == "title" && $0.value == "[Share Board Report] prisoners_dilemma_v2"
+      })
+  }
+
+  @Test
+  func gitHubIssueURLRoundTripsMultiByteScenarioId() throws {
+    let japanese = "日本語_シナリオ"
+    let url = try #require(ReportURLBuilder.buildGitHubIssueURL(scenarioId: japanese))
+    let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+    let match = components.queryItems?.first {
+      $0.name == "title" && $0.value == "[Share Board Report] \(japanese)"
+    }
+    #expect(match != nil)
+  }
+}

--- a/docs/decisions/ADR-005.md
+++ b/docs/decisions/ADR-005.md
@@ -58,7 +58,7 @@ gaps. Each is owned by one of the sections below:
 | No explicit age-rating strategy (2025-07 questionnaire reorganisation unanswered) | §3 |
 | No shift-left input validation on user-authored persona / goals / phase prompts | §4 |
 | `ContentFilter` policy is undocumented — partial-prefix leakage during streaming has no stated allowance | §5 |
-| Share Board has no reporting mechanism, SLA, or reviewer identity disclosure | §6 |
+| Share Board has no reporting mechanism or reviewer identity disclosure | §6 |
 | Planned Cloud API (`docs/ROADMAP.md` Phase 2) has no disclosure/consent principles committed | §7 |
 | `PrivacyInfo.xcprivacy` does not exist (Apple hard requirement since 2024-05) | §9 |
 
@@ -615,47 +615,76 @@ provide a reporting mechanism anyway:
 ### 6.2 Mechanism
 
 The Share Board reporting mechanism is a **pseudonymous contact
-channel**. Two acceptable implementations (the final choice is a UI
-sub-issue, either is permitted by this ADR):
+channel**. Three surface types were evaluated during ADR drafting; the
+chosen mechanism is a progressive-disclosure pair combining the first
+two:
 
-- **In-app form → GitHub issue** (preferred). The report button in
-  Share Board opens a sheet that collects scenario id + user-supplied
-  reason, and files a public GitHub issue via a pre-seeded URL (no
-  authentication required; users need a GitHub account to submit).
-- **Project email alias**. A dedicated pseudonymous address (e.g.
-  `pastura-report@<project-domain>`) routed to the maintainer. An
-  in-app "Copy report email" button + `mailto:` link provides the
-  surface.
+- **In-app form → web form service (primary, chosen).** The report
+  button in Share Board opens a sheet that displays scenario metadata
+  and opens a pre-filled web form (Google Forms, concretely) in
+  Safari. The form collects reason + an email address for response
+  receipts; no reporter account is required. The response receipt is
+  what delivers the immediate auto-acknowledgement referenced in §6.3.
+- **In-app form → GitHub issue (secondary, chosen).** A second-tier
+  link opens a pre-seeded GitHub issue URL; requires a GitHub account
+  to submit. Positioned in the UI as the public-trackability path for
+  users who prefer public discussion — not the default.
+- **Project email alias (evaluated, not chosen).** A dedicated
+  pseudonymous address (e.g. `pastura-report@<project-domain>`) routed
+  to the maintainer via `mailto:`. Rejected for Pastura because it
+  requires owning a project domain and still exposes the alias to
+  reporters; a web form service covers the same need while hiding the
+  destination.
 
-Either surface is acceptable for ADR-005. What is **NOT** acceptable:
+What is **NOT** acceptable as any surface:
 
 - The maintainer's personal email (`tyabu1212@gmail.com` or similar).
   Published personal email creates a long-term disclosure Pastura cannot
-  retract.
+  retract. (Using the personal mailbox as the private backing store
+  behind a web-form service is fine — it is not published.)
 - A contact link that requires the reporter to have a paid service
-  account (e.g. Linear, Notion). GitHub issue filing is the highest bar
-  acceptable.
+  account (e.g. Linear, Notion). GitHub issue filing is the highest
+  bar acceptable and is intentionally the secondary path, not the
+  primary.
 
-### 6.3 SLA
+### 6.3 Response commitments
 
-**Target: first response within 48 hours of report receipt, best-effort.**
+Pastura is a solo-maintainer app. What satisfies Apple §1.2's "timely
+responses" standard here is the combination of an immediate automated
+acknowledgement + a documented internal target + a fast path for
+clearly violating content — **not** a user-visible numeric SLA. A
+concrete number surfaced in the app that the maintainer may miss
+during long absences is worse for reviewer trust than an honest
+"we'll review as needed" paired with a receipt that always fires.
 
-The 48-hour target is not a guarantee:
+- **Immediate auto-acknowledgement.** The chosen web-form service
+  (Google Forms) sends a response receipt to the reporter as soon as
+  the submission lands, independent of maintainer availability. This
+  is the "timely" signal reviewers observe at submission test time.
+  The auto-ack is contingent on the reporter providing an email
+  address; the form design makes email a required field so the
+  receipt always fires in the normal path.
+- **Internal target: first human response within 7 days, best-effort.**
+  This is the maintainer-facing commitment for governance purposes;
+  it is **not surfaced in user-visible copy**. Tracked in the
+  operations doc (`docs/gallery/share-board-reports.md`).
+- **Fast path for clearly violating content.** If a report's text
+  makes the violation obvious from the form alone (slur, personal
+  attack, impersonation), the gallery entry is **hidden within 72
+  hours of receipt** — removed from `gallery.json` in a hot-fix
+  commit — pending fuller triage. This bound is low enough to meet
+  from a phone during travel.
+- **Vacation-mode auto-acknowledgement for extended absence.** Before
+  any planned absence longer than **5 days**, the maintainer overrides
+  the default response-receipt text with a variant stating the
+  expected return date. This is the only surface where a specific
+  date becomes user-visible.
 
-- Apple's §1.2 wording ("timely responses") does not pin a specific SLA;
-  48 hours is Pastura's internal commitment, chosen to be ambitious but
-  defensible for a solo-maintainer app.
-- When the maintainer is unavailable (travel, illness, personal leave),
-  a **vacation-mode auto-acknowledgement** is set on the reporting
-  channel indicating the expected response window. The auto-ack is
-  mandatory before any planned absence longer than 72 hours.
-- If a report clearly indicates policy-violating content, the gallery
-  entry is **hidden immediately** (removed from `gallery.json` in a
-  hot-fix commit) pending triage; full triage and response follow
-  within 48 hours where possible.
-
-Where a 48-hour first response cannot be met, the auto-acknowledgement
-+ clearly-documented response window satisfies the "timely" standard.
+User-facing copy in the app (Settings, Report sheet) does not state
+any specific response-time number. The internal 7-day target and the
+72-hour fast-path live in this ADR and in the operations doc — not in
+the app binary — so honest operational reality governs without
+setting expectations the app cannot reliably meet.
 
 ### 6.4 Reviewer identity
 
@@ -682,11 +711,27 @@ requirement becomes live and a new ADR revisits the reporting surface.
 
 ### 6.6 Implementation tracking
 
-Concrete UI (report sheet, `mailto:` copy, auto-ack template), the
-chosen email alias, and the GitHub issue template live in a
-post-ADR-merge sub-issue (see §9 master index). This ADR commits to:
-pseudonymous channel, 48h best-effort SLA, reviewer identity as above,
-vacation-mode auto-ack.
+The chosen concrete mechanism (tracked in issue #178):
+
+- **In-app sheet**: `ReportScenarioSheet` with progressive disclosure
+  — primary **Open Report Form** button opens a pre-filled Google
+  Forms URL in Safari; secondary **Open on GitHub** link opens a
+  pre-seeded issue URL for users who prefer public discussion.
+- **URL construction**: `Pastura/Pastura/Utilities/ReportURLBuilder.swift`
+  — Google form ID and entry field IDs are compile-time constants.
+- **GitHub issue template**: `.github/ISSUE_TEMPLATE/share-board-report.yml`
+  mirrors the Google Form's field set; no "reporter contact" field is
+  collected (public-tracker PII hygiene).
+- **Operational procedure**: `docs/gallery/share-board-reports.md` —
+  form configuration requirements, auto-ack templates (EN + JA),
+  vacation-mode text, triage playbook, gallery hot-fix procedure.
+- **Settings surface**: `SettingsView` exposes reviewer-identity and
+  report-mechanism copy per §6.4; no SLA number is shown.
+
+This ADR commits to: pseudonymous channel, immediate auto-ack via
+response receipts, 7-day internal best-effort target (not surfaced in
+app), 72-hour fast-path for violating content, vacation-mode auto-ack
+for absences >5 days, reviewer identity as in §6.4.
 
 ---
 
@@ -1036,7 +1081,7 @@ when work starts" marker and are created during the relevant sprint.
 | 1 | Wrap `OllamaService` out of release binaries; `nm` audit | [#148](https://github.com/tyabu12/pastura/issues/148) | tyabu12 | **Submission** | Filed 2026-04-19; §8.5 |
 | 2 | Create `PrivacyInfo.xcprivacy` with required-reason APIs | [#149](https://github.com/tyabu12/pastura/issues/149) | tyabu12 | **Submission** | Filed 2026-04-19; §1 gap, §9 |
 | 3 | Implement `ScenarioContentValidator` (§4) + wordlist bundling (§4.4) | To be filed when work starts | tyabu12 | Soft — defense-in-depth complement to §5 filter | §5 filter is the backstop; §4 is preferred but not submission-blocking |
-| 4 | Share Board report UI (§6) + pseudonymous contact surface | To be filed when work starts | tyabu12 | Soft — §1.2 does not strictly apply to curated content, but defensive posture recommended before review | §1.5 contact info separately handled via App Store Connect support URL |
+| 4 | Share Board report UI (§6) + pseudonymous contact surface | [#178](https://github.com/tyabu12/pastura/issues/178) | tyabu12 | Soft — §1.2 does not strictly apply to curated content, but defensive posture recommended before review | §1.5 contact info separately handled via App Store Connect support URL |
 | 5 | `ContentFilter.defaultPatterns` expansion methodology (§5.2) | Not filed — on-demand | tyabu12 | None (ongoing) | Triggered by telemetry, App Review citation, or user report |
 | 6 | Fallback handling 13+ → 16+ (§3.3) | Not filed — conditional | tyabu12 | Conditional (fires only on rejection) | Created reactively if Apple rejects the 13+ target |
 | 7 | ADR-006 Cloud API disclosure/consent implementation | Forthcoming ADR, not a sub-issue | tyabu12 | Cloud API feature (not submission) | Principles from §7 bind this work |

--- a/docs/gallery/share-board-reports.md
+++ b/docs/gallery/share-board-reports.md
@@ -1,0 +1,182 @@
+# Share Board Report Handling
+
+Operational procedure for Share Board scenario reports, per
+[ADR-005 §6](../decisions/ADR-005.md).
+
+This document is **maintainer-facing**. User-visible copy in the app
+does not state any specific response-time number — this is intentional
+(see ADR-005 §6.3). Keep the internal commitments tracked here only.
+
+## 1. Reporting channel configuration
+
+Two surfaces are exposed to users from `ReportScenarioSheet`:
+
+1. **Primary — Google Forms.** Private report destination.
+2. **Secondary — GitHub issue.** Public discussion path (opt-in).
+
+### 1.1 Google Form required settings
+
+The form is the load-bearing surface for Apple §1.2 "timely responses"
+compliance — the response receipt delivers the immediate
+auto-acknowledgement that the reviewer observes at submission test
+time. Misconfiguring any of the below breaks that compliance claim.
+
+**Settings → Responses:**
+
+| Setting | Required value | Why |
+|---------|----------------|-----|
+| Collect email addresses | **Responder input** | User types email, no Google account required. `Verified` would force Google sign-in. |
+| Response receipts | **Always** | Auto-ack on every submission is the §1.2 "timely" signal. `If requested by respondent` is NOT acceptable. |
+| Limit to 1 response | **Off** | `On` forces Google sign-in. |
+| Restrict to users in org | **Off** | GWS-only would reject non-org users. |
+
+**Form fields (in order):**
+
+| # | Type | Label | Required | Note |
+|---|------|-------|----------|------|
+| auto | Email | Email | yes (enforced) | Auto-added by Responder input. Not pre-fillable by URL parameter (Google design). |
+| 1 | Short answer | Scenario ID | yes | Pre-filled by the app via URL parameter. |
+| 2 | Short answer | App Version | no | Pre-filled by the app. |
+| 3 | Paragraph | Reason | yes | User writes the report body. |
+
+**Settings → Presentation → Confirmation message:** see §2.1.
+
+The form ID and each field's `entry.xxxxxxx` parameter ID must be
+mirrored as compile-time constants in
+`Pastura/Pastura/Utilities/ReportURLBuilder.swift`. When the form is
+ever re-created or migrated, update those constants in the same PR
+that changes the form.
+
+### 1.2 GitHub issue template
+
+Located at `.github/ISSUE_TEMPLATE/share-board-report.yml`. Issues
+filed via this template carry the `share-board-report` label.
+
+Reporter contact is **not collected** — reply via @-mention on the
+issue (the GitHub author is visible in the issue header). This keeps
+the public tracker free of PII.
+
+## 2. Response templates
+
+### 2.1 Normal-mode confirmation message
+
+Shown to the reporter on the form success page and in the
+response-receipt email.
+
+**English:**
+
+> Thanks for your report. We've received it and will review as
+> needed. If the content clearly violates policy, it will be hidden
+> from the gallery during triage.
+
+**Japanese:**
+
+> 報告ありがとうございます。受領し、必要に応じて確認します。
+> 明らかな policy 違反が確認できた場合は、triage 中にギャラリーから
+> 該当シナリオを非表示にします。
+
+### 2.2 Vacation-mode confirmation message
+
+Before any planned absence longer than **5 days**, override the
+confirmation message with a variant that states the expected return
+date. This is the **only** user-visible surface where a specific date
+appears (ADR-005 §6.3).
+
+**Template (English):**
+
+> Thanks for your report. We've received it.
+>
+> Note: the maintainer is currently away through **YYYY-MM-DD** and
+> will resume reviewing reports after that date. Reports indicating
+> clearly policy-violating content may still be actioned before then.
+
+**Template (Japanese):**
+
+> 報告ありがとうございます。受領しました。
+>
+> メンテナ不在期間: **YYYY-MM-DD** まで。復帰後に順次確認します。
+> 明らかな policy 違反が確認できる場合は、不在期間中でも対応する
+> ことがあります。
+
+**Procedure:**
+
+1. Google Forms → Settings → Presentation → Confirmation message →
+   paste the vacation-mode template with the actual return date.
+2. On return, revert the confirmation message back to the normal
+   text in §2.1.
+
+### 2.3 First human response
+
+Sent privately by the maintainer after triage (email reply or GitHub
+issue comment). Not templated — respond in the tone and language of
+the original report. Internal target: within **7 days** of submission,
+best-effort (ADR-005 §6.3). Not surfaced in the app.
+
+## 3. Triage playbook
+
+For each incoming report (Google Forms inbox **or** GitHub issue):
+
+1. **Classify:**
+   - **Clearly violating** — slur, personal attack on an identifiable
+     real person, explicit sexual content, impersonation. Proceed to
+     §4 (gallery hot-fix).
+   - **Borderline / substantive** — policy question, quality concern,
+     metadata error. Reply with judgment; no hide needed.
+   - **Spam / test** — ignore; optionally close the GitHub issue or
+     mark the Google Forms row as resolved in the spreadsheet view.
+2. **Acknowledge** where needed — GitHub issues do NOT auto-ack, so
+   leave a short comment confirming receipt. Google Forms submissions
+   are already acked by the response receipt.
+3. **Hide** per §4 (within 72h of receipt for clearly-violating
+   reports).
+4. **Close the loop** — private reply to the reporter within the
+   internal 7-day target where applicable.
+
+## 4. Gallery hot-fix procedure
+
+A clearly-violating report must result in the offending scenario being
+hidden from `docs/gallery/gallery.json` **within 72 hours of receipt**
+(ADR-005 §6.3). Do this from a phone (GitHub mobile / web) during
+travel if necessary — the bound is designed to be met without desktop
+access.
+
+### 4.1 Fast procedure
+
+1. Open `docs/gallery/gallery.json` on github.com.
+2. Tap the pencil (Edit) icon.
+3. Remove the offending scenario's object from the `scenarios` array,
+   including its trailing comma.
+4. Commit directly to `main` with a clear message, e.g.
+   `🐛 fix: hide share-board scenario <id> pending triage`.
+5. Users pick up the removal on their next Share Board visit via the
+   existing ETag-conditional GET (see [`README.md`](README.md)).
+
+The scenario's YAML at `docs/gallery/<id>.yaml` can remain in the
+repo; the app does not fetch YAMLs that are not referenced by the
+index. Cleaning up the YAML is a follow-up, not part of the 72-hour
+bound.
+
+### 4.2 Follow-up
+
+- **Permanent removal:** delete `docs/gallery/<id>.yaml` in a
+  follow-up commit.
+- **Restore after triage (false-positive):** re-add the entry to
+  `gallery.json`. If the scenario was re-authored during the hide
+  window, bump the id with a `_v2` suffix so installed copies with
+  the old hash don't silently clash (see the "Suffix versioning"
+  section of [`README.md`](README.md)).
+
+## 5. Internal response target
+
+- **First human response:** within 7 days of report receipt,
+  best-effort. ADR-005 §6.3.
+- **Violating-content hide:** within 72 hours of receipt.
+- Neither is surfaced in user-visible app copy.
+
+## 6. References
+
+- [ADR-005 §6](../decisions/ADR-005.md) — Share Board Report Mechanism
+- [`docs/gallery/README.md`](README.md) — Gallery curation + trust model
+- [`.github/ISSUE_TEMPLATE/share-board-report.yml`](../../.github/ISSUE_TEMPLATE/share-board-report.yml)
+- [`Pastura/Pastura/Utilities/ReportURLBuilder.swift`](../../Pastura/Pastura/Utilities/ReportURLBuilder.swift)
+- [`Pastura/Pastura/Views/Community/ShareBoard/ReportScenarioSheet.swift`](../../Pastura/Pastura/Views/Community/ShareBoard/ReportScenarioSheet.swift)


### PR DESCRIPTION
## Summary
- Implements ADR-005 §6 Share Board report mechanism — progressive-
  disclosure UX: primary Google Forms (no account) + secondary
  GitHub issue (public discussion) paths. Text entry on external
  pages only; in-app sheet is a metadata display + launcher.
- New minimal `SettingsView` (gear in HomeView top-leading) exposing
  §6.4 reviewer-identity + brief report-mechanism copy.
- ADR §6 amended: Google Forms chosen as primary; §6.3 "SLA"
  reframed to "Response commitments" (internal 7-day, 72h fast-path,
  5-day vacation-mode; no user-visible SLA numbers).
- Maintainer-facing operations doc at
  `docs/gallery/share-board-reports.md` — binding Google Form
  configuration, auto-ack templates (EN+JA), triage playbook,
  gallery hot-fix procedure.
- GitHub issue template at
  `.github/ISSUE_TEMPLATE/share-board-report.yml` — no reporter-
  contact field (public-tracker PII hygiene).

## Test plan
- [x] \`xcodebuild test\` — all unit tests pass; 9 new
      ReportURLBuilderTests cover URL shape, query-item embedding,
      special-character and multi-byte round-trip, empty app-version
      handling
- [x] \`swiftlint lint --strict\` clean on new code
- [x] Manual QA: Home → gear → Settings → back
- [x] Manual QA: Share Board → gallery scenario → More → Report this
      scenario; verify primary opens Google Forms in Safari with
      scenario id pre-filled and Email field visible as required;
      secondary opens pre-filled GitHub issue URL
- [x] Manual QA: submit a test report; confirm response-receipt
      email arrives (validates §1.1 config is correct)

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)