### PR TITLE
✨ feat: shift-left input validation (ADR-005 §4)

### DIFF
--- a/Pastura/Pastura/App/ContentBlocklist.swift
+++ b/Pastura/Pastura/App/ContentBlocklist.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Shared blocklist resource used by both ``ScenarioContentValidator`` (input
+/// validation) and ``ContentFilter`` (output filtering).
+///
+/// Per ADR-005 §4.4, the bundled file at
+/// `Pastura/Pastura/Resources/ContentBlocklist.txt` is the single source of
+/// truth for content-safety patterns. Production callers use
+/// ``defaultPatterns``; tests inject an alternate bundle via ``load(from:)``,
+/// mirroring the ``PresetLoader`` pattern so the `.main` default path is
+/// never evaluated under the XCTest host without the host-app bundle present.
+///
+/// Declared `nonisolated` so ``ContentFilter`` (itself `nonisolated + Sendable`)
+/// can access ``defaultPatterns`` without crossing a MainActor boundary under
+/// the project's `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`.
+nonisolated enum ContentBlocklist {
+  /// Patterns loaded from the app bundle at first access.
+  ///
+  /// Evaluated lazily by Swift's `static let` semantics. A missing or
+  /// unreadable resource triggers ``preconditionFailure`` — a
+  /// build-configuration bug should fail fast at launch rather than
+  /// silently degrade the filter to an empty list.
+  static let defaultPatterns: [String] = load(from: .main)
+
+  /// Loads the blocklist from the given bundle.
+  ///
+  /// - Parameter bundle: Bundle to load from. Production uses `.main`;
+  ///   tests pass `Bundle(for: DatabaseManager.self)` (matching
+  ///   ``PresetLoader``'s test pattern) to point at the host-app bundle.
+  /// - Returns: Parsed pattern list.
+  static func load(from bundle: Bundle) -> [String] {
+    guard
+      let url = bundle.url(forResource: "ContentBlocklist", withExtension: "txt"),
+      let text = try? String(contentsOf: url, encoding: .utf8)
+    else {
+      preconditionFailure(
+        "ContentBlocklist.txt missing or unreadable in bundle \(bundle.bundleIdentifier ?? "<unknown>")"
+      )
+    }
+    return parse(text)
+  }
+
+  /// Parses the raw blocklist text into a pattern array.
+  ///
+  /// Extracted from ``load(from:)`` so the parser can be unit-tested with
+  /// inline fixtures without a bundle round-trip.
+  ///
+  /// - Blank lines are skipped.
+  /// - Lines beginning with `#` are treated as comments and skipped.
+  /// - Leading and trailing whitespace on each line is trimmed before
+  ///   the comment / blank check.
+  static func parse(_ text: String) -> [String] {
+    text.split(separator: "\n", omittingEmptySubsequences: false)
+      .map { $0.trimmingCharacters(in: .whitespaces) }
+      .filter { !$0.isEmpty && !$0.hasPrefix("#") }
+  }
+}

--- a/Pastura/Pastura/App/ContentFilter.swift
+++ b/Pastura/Pastura/App/ContentFilter.swift
@@ -19,8 +19,9 @@ nonisolated final class ContentFilter: Sendable {
   ///
   /// - Parameters:
   ///   - blockedPatterns: Words/phrases to filter. Matched case-insensitively.
+  ///     Defaults to the shared bundled blocklist (see ``ContentBlocklist``).
   ///   - replacement: Replacement text for blocked content. Defaults to "***".
-  init(blockedPatterns: [String] = ContentFilter.defaultPatterns, replacement: String = "***") {
+  init(blockedPatterns: [String] = ContentBlocklist.defaultPatterns, replacement: String = "***") {
     self.blockedPatterns = blockedPatterns
     self.replacement = replacement
   }
@@ -45,21 +46,4 @@ nonisolated final class ContentFilter: Sendable {
     let filtered = output.fields.mapValues { filter($0) }
     return TurnOutput(fields: filtered)
   }
-
-  // MARK: - Default Patterns
-
-  /// Minimum NG word list for App Store compliance.
-  ///
-  /// This is intentionally a small starter set. Expand as needed based on
-  /// App Store review feedback and user reports.
-  static let defaultPatterns: [String] = [
-    // Violence
-    "殺す", "殺害", "殺人",
-    // Slurs / hate speech (Japanese)
-    "死ね",
-    // Profanity (English, common)
-    "fuck", "shit", "asshole",
-    // Discrimination
-    "ガイジ", "キチガイ"
-  ]
 }

--- a/Pastura/Pastura/App/ImportViewModel.swift
+++ b/Pastura/Pastura/App/ImportViewModel.swift
@@ -14,6 +14,7 @@ final class ImportViewModel {
   private let repository: any ScenarioRepository
   private let loader = ScenarioLoader()
   private let validator = ScenarioValidator()
+  private let contentValidator = ScenarioContentValidator()
 
   init(repository: any ScenarioRepository) {
     self.repository = repository
@@ -33,6 +34,11 @@ final class ImportViewModel {
     do {
       let scenario = try loader.load(yaml: trimmed)
       _ = try validator.validate(scenario)
+      let contentFindings = contentValidator.validate(scenario)
+      if !contentFindings.isEmpty {
+        validationErrors = contentFindings
+        return
+      }
       isValid = true
     } catch {
       validationErrors = [error.localizedDescription]

--- a/Pastura/Pastura/App/ScenarioContentValidator.swift
+++ b/Pastura/Pastura/App/ScenarioContentValidator.swift
@@ -1,0 +1,139 @@
+import Foundation
+
+/// Rejects scenario content whose user-authored text fields contain
+/// patterns from the shared blocklist.
+///
+/// Input-side counterpart to ``ContentFilter`` in ADR-005's
+/// defense-in-depth model. Invoked from MainActor ViewModels
+/// (`ImportViewModel`, `ScenarioEditorViewModel`) after structural
+/// validation succeeds. Unlike ``ContentFilter``, findings are surfaced
+/// as user-facing messages the author can act on — the validator never
+/// rewrites its input, and no message echoes the matched term (ADR-005
+/// §4.7).
+///
+/// MainActor-bound per ADR-005 §4.6 (uses the project-default
+/// `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`). All callers today are
+/// MainActor ViewModels on user-input paths; if an off-main caller
+/// materialises, promote to `nonisolated + Sendable` as a local change.
+final class ScenarioContentValidator {
+  private let blockedPatterns: [String]
+
+  /// Creates a validator with the given blocklist.
+  ///
+  /// - Parameter blockedPatterns: Words/phrases to reject at authoring
+  ///   time. Matched case- and diacritic-insensitively. Defaults to the
+  ///   shared bundled blocklist (see ``ContentBlocklist``).
+  init(blockedPatterns: [String] = ContentBlocklist.defaultPatterns) {
+    self.blockedPatterns = blockedPatterns
+  }
+
+  /// Walks all user-authored text fields of the scenario and returns
+  /// one user-facing message per field that contains a blocked pattern.
+  ///
+  /// Walk order mirrors ADR-005 §4.3's target-fields table:
+  /// scenario → personas → phases, recursing into `thenPhases` /
+  /// `elsePhases` for `conditional` phases. The recursion walks
+  /// defensively beyond the depth-1 rule that `ScenarioValidator`
+  /// structurally enforces.
+  func validate(_ scenario: Scenario) -> [String] {
+    var findings: [String] = []
+
+    if containsBlockedPattern(scenario.name) {
+      findings.append(
+        String(localized: "Scenario name contains a term that is not allowed")
+      )
+    }
+    if containsBlockedPattern(scenario.description) {
+      findings.append(
+        String(localized: "Scenario description contains a term that is not allowed")
+      )
+    }
+
+    for (index, persona) in scenario.personas.enumerated() {
+      findings.append(contentsOf: personaFindings(persona, index: index))
+    }
+
+    for (index, phase) in scenario.phases.enumerated() {
+      findings.append(contentsOf: phaseFindings(phase, position: "\(index + 1)"))
+    }
+
+    return findings
+  }
+
+  // MARK: - Private
+
+  private func personaFindings(_ persona: Persona, index: Int) -> [String] {
+    var findings: [String] = []
+    let position = index + 1
+    let nameIsClean = !containsBlockedPattern(persona.name)
+
+    if !nameIsClean {
+      findings.append(
+        String(localized: "Persona \(position) name contains a term that is not allowed")
+      )
+    }
+    if containsBlockedPattern(persona.description) {
+      if nameIsClean {
+        findings.append(
+          String(
+            localized:
+              "Persona '\(persona.name)' description contains a term that is not allowed"
+          )
+        )
+      } else {
+        findings.append(
+          String(
+            localized: "Persona \(position) description contains a term that is not allowed"
+          )
+        )
+      }
+    }
+    return findings
+  }
+
+  private func phaseFindings(_ phase: Phase, position: String) -> [String] {
+    var findings: [String] = []
+
+    if let prompt = phase.prompt, containsBlockedPattern(prompt) {
+      findings.append(
+        String(localized: "Phase \(position) prompt contains a term that is not allowed")
+      )
+    }
+    if let template = phase.template, containsBlockedPattern(template) {
+      findings.append(
+        String(localized: "Phase \(position) template contains a term that is not allowed")
+      )
+    }
+    if let condition = phase.condition, containsBlockedPattern(condition) {
+      findings.append(
+        String(localized: "Phase \(position) condition contains a term that is not allowed")
+      )
+    }
+
+    if let thenPhases = phase.thenPhases {
+      for (index, subPhase) in thenPhases.enumerated() {
+        findings.append(
+          contentsOf: phaseFindings(subPhase, position: "\(position).then.\(index + 1)")
+        )
+      }
+    }
+    if let elsePhases = phase.elsePhases {
+      for (index, subPhase) in elsePhases.enumerated() {
+        findings.append(
+          contentsOf: phaseFindings(subPhase, position: "\(position).else.\(index + 1)")
+        )
+      }
+    }
+
+    return findings
+  }
+
+  private func containsBlockedPattern(_ text: String) -> Bool {
+    for pattern in blockedPatterns {
+      if text.range(of: pattern, options: [.caseInsensitive, .diacriticInsensitive]) != nil {
+        return true
+      }
+    }
+    return false
+  }
+}

--- a/Pastura/Pastura/App/ScenarioContentValidator.swift
+++ b/Pastura/Pastura/App/ScenarioContentValidator.swift
@@ -129,11 +129,8 @@ final class ScenarioContentValidator {
   }
 
   private func containsBlockedPattern(_ text: String) -> Bool {
-    for pattern in blockedPatterns {
-      if text.range(of: pattern, options: [.caseInsensitive, .diacriticInsensitive]) != nil {
-        return true
-      }
+    blockedPatterns.contains { pattern in
+      text.range(of: pattern, options: [.caseInsensitive, .diacriticInsensitive]) != nil
     }
-    return false
   }
 }

--- a/Pastura/Pastura/App/ScenarioContentValidator.swift
+++ b/Pastura/Pastura/App/ScenarioContentValidator.swift
@@ -73,6 +73,10 @@ final class ScenarioContentValidator {
       )
     }
     if containsBlockedPattern(persona.description) {
+      // Why: ADR-005 §4.7 requires findings to never echo the matched term.
+      // When the name itself is a blocked term, interpolating it into the
+      // description message would leak the pattern — fall back to positional
+      // form instead.
       if nameIsClean {
         findings.append(
           String(

--- a/Pastura/Pastura/App/ScenarioEditorViewModel.swift
+++ b/Pastura/Pastura/App/ScenarioEditorViewModel.swift
@@ -66,6 +66,7 @@ final class ScenarioEditorViewModel {
   private let loader = ScenarioLoader()
   private let serializer = ScenarioSerializer()
   private let validator = ScenarioValidator()
+  private let contentValidator = ScenarioContentValidator()
 
   /// Stores top-level YAML keys that the visual editor has no UI for.
   ///
@@ -198,7 +199,11 @@ final class ScenarioEditorViewModel {
 
     do {
       _ = try validator.validate(scenario)
-      isValid = true
+      let contentFindings = contentValidator.validate(scenario)
+      validationErrors.append(contentsOf: contentFindings)
+      if validationErrors.isEmpty {
+        isValid = true
+      }
     } catch {
       validationErrors = [error.localizedDescription]
     }

--- a/Pastura/Pastura/Resources/ContentBlocklist.txt
+++ b/Pastura/Pastura/Resources/ContentBlocklist.txt
@@ -1,0 +1,27 @@
+# Shared content blocklist (ADR-005 §4.4).
+#
+# Loaded by both ScenarioContentValidator (input validation, §4) and
+# ContentFilter (output filtering, §5). Single source of truth — edit here
+# to extend the blocklist without touching Swift.
+#
+# Format: one pattern per line. Blank lines and lines beginning with `#`
+# are skipped; leading and trailing whitespace is trimmed. Matching is
+# case-insensitive and diacritic-insensitive (see ContentFilter /
+# ScenarioContentValidator).
+
+# Violence
+殺す
+殺害
+殺人
+
+# Slurs / hate speech (Japanese)
+死ね
+
+# Profanity (English, common)
+fuck
+shit
+asshole
+
+# Discrimination
+ガイジ
+キチガイ

--- a/Pastura/PasturaTests/App/ContentBlocklistTests.swift
+++ b/Pastura/PasturaTests/App/ContentBlocklistTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+@Suite(.timeLimit(.minutes(1)))
+struct ContentBlocklistTests {
+  @Test func loadFromBundleReturnsNonEmpty() {
+    let patterns = ContentBlocklist.load(from: Bundle(for: DatabaseManager.self))
+    #expect(!patterns.isEmpty)
+  }
+
+  @Test func loadFromBundleStripsCommentsAndBlanks() {
+    let patterns = ContentBlocklist.load(from: Bundle(for: DatabaseManager.self))
+    #expect(!patterns.contains(where: { $0.hasPrefix("#") }))
+    #expect(!patterns.contains(""))
+  }
+
+  @Test func loadFromBundlePatternsHaveNoWhitespace() {
+    let patterns = ContentBlocklist.load(from: Bundle(for: DatabaseManager.self))
+    for pattern in patterns {
+      #expect(
+        pattern == pattern.trimmingCharacters(in: .whitespaces),
+        "Pattern '\(pattern)' has untrimmed whitespace"
+      )
+    }
+  }
+
+  @Test func parseSkipsCommentLines() {
+    let text = """
+      # leading comment
+      fuck
+      # mid comment
+      shit
+      """
+    #expect(ContentBlocklist.parse(text) == ["fuck", "shit"])
+  }
+
+  @Test func parseSkipsBlankLines() {
+    let text = """
+      fuck
+
+      shit
+
+      """
+    #expect(ContentBlocklist.parse(text) == ["fuck", "shit"])
+  }
+
+  @Test func parseTrimsWhitespace() {
+    let text = "  fuck  \n\tshit\t"
+    #expect(ContentBlocklist.parse(text) == ["fuck", "shit"])
+  }
+
+  @Test func parseHandlesEmptyInput() {
+    #expect(ContentBlocklist.parse("") == [])
+  }
+
+  @Test func parseHandlesCommentOnlyInput() {
+    #expect(ContentBlocklist.parse("# only a comment") == [])
+  }
+}

--- a/Pastura/PasturaTests/App/ContentFilterTests.swift
+++ b/Pastura/PasturaTests/App/ContentFilterTests.swift
@@ -49,8 +49,4 @@ struct ContentFilterTests {
     let filter = ContentFilter(blockedPatterns: ["bad"])
     #expect(filter.filter("bad bad bad") == "*** *** ***")
   }
-
-  @Test func defaultPatternsAreNotEmpty() {
-    #expect(!ContentFilter.defaultPatterns.isEmpty)
-  }
 }

--- a/Pastura/PasturaTests/App/ImportViewModelTests.swift
+++ b/Pastura/PasturaTests/App/ImportViewModelTests.swift
@@ -101,4 +101,38 @@ struct ImportViewModelTests {
   @Test func scenarioGenerationPromptIsNotEmpty() {
     #expect(!ImportViewModel.scenarioGenerationPrompt.isEmpty)
   }
+
+  // MARK: - Content Validation
+
+  @Test func validateRejectsBlockedPersonaDescription() throws {
+    let db = try DatabaseManager.inMemory()
+    let repo = GRDBScenarioRepository(dbWriter: db.dbWriter)
+    let viewModel = ImportViewModel(repository: repo)
+
+    // Uses the default bundled blocklist — "殺す" is present in ContentBlocklist.txt.
+    viewModel.yamlText = """
+      id: blocked_content_test
+      name: Blocked Content Test
+      description: A test
+      agents: 2
+      rounds: 1
+      context: Context
+      personas:
+        - name: Alice
+          description: 殺す
+        - name: Bob
+          description: Agent B
+      phases:
+        - type: speak_all
+          prompt: "Say something"
+          output:
+            statement: string
+      """
+    viewModel.validate()
+
+    #expect(viewModel.isValid == false)
+    #expect(!viewModel.validationErrors.isEmpty)
+    #expect(
+      viewModel.validationErrors.contains { $0.contains("Alice") && $0.contains("description") })
+  }
 }

--- a/Pastura/PasturaTests/App/ScenarioContentValidatorTests.swift
+++ b/Pastura/PasturaTests/App/ScenarioContentValidatorTests.swift
@@ -1,0 +1,222 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+@Suite(.timeLimit(.minutes(1)))
+@MainActor
+struct ScenarioContentValidatorTests {
+  private func makeScenario(
+    name: String = "ok",
+    description: String = "ok",
+    personas: [Persona] = [Persona(name: "Alice", description: "ok")],
+    phases: [Phase] = []
+  ) -> Scenario {
+    Scenario(
+      id: "test",
+      name: name,
+      description: description,
+      agentCount: personas.count,
+      rounds: 1,
+      context: "",
+      personas: personas,
+      phases: phases
+    )
+  }
+
+  // MARK: - Baseline
+
+  @Test func cleanScenarioProducesNoFindings() {
+    let validator = ScenarioContentValidator(blockedPatterns: ["forbidden"])
+    #expect(validator.validate(makeScenario()).isEmpty)
+  }
+
+  @Test func emptyBlocklistNeverProducesFindings() {
+    let validator = ScenarioContentValidator(blockedPatterns: [])
+    let scenario = makeScenario(
+      name: "killer",
+      description: "殺す fuck",
+      personas: [Persona(name: "bad", description: "also bad")],
+      phases: [Phase(type: .speakAll, prompt: "bad things")]
+    )
+    #expect(validator.validate(scenario).isEmpty)
+  }
+
+  // MARK: - Scenario-level fields
+
+  @Test func scenarioNameBlockedTermDetected() {
+    let validator = ScenarioContentValidator(blockedPatterns: ["forbidden"])
+    let findings = validator.validate(makeScenario(name: "totally forbidden"))
+    #expect(findings.count == 1)
+    #expect(findings[0].contains("Scenario name"))
+  }
+
+  @Test func scenarioDescriptionBlockedTermDetected() {
+    let validator = ScenarioContentValidator(blockedPatterns: ["forbidden"])
+    let findings = validator.validate(makeScenario(description: "very forbidden"))
+    #expect(findings.count == 1)
+    #expect(findings[0].contains("Scenario description"))
+  }
+
+  // MARK: - Persona fields
+
+  @Test func personaNameBlockedTermDetectedWithoutEchoingMatch() {
+    let validator = ScenarioContentValidator(blockedPatterns: ["forbiddenname"])
+    let findings = validator.validate(
+      makeScenario(personas: [Persona(name: "forbiddenname", description: "ok")])
+    )
+    #expect(findings.count == 1)
+    #expect(findings[0].contains("Persona 1 name"))
+    #expect(!findings[0].contains("forbiddenname"))
+  }
+
+  @Test func personaDescriptionUsesNameWhenNameIsClean() {
+    let validator = ScenarioContentValidator(blockedPatterns: ["forbidden"])
+    let findings = validator.validate(
+      makeScenario(personas: [Persona(name: "Alice", description: "forbidden vibes")])
+    )
+    #expect(findings.count == 1)
+    #expect(findings[0].contains("Alice"))
+    #expect(findings[0].contains("description"))
+  }
+
+  @Test func personaDescriptionFallsBackToPositionWhenNameAlsoMatches() {
+    let validator = ScenarioContentValidator(blockedPatterns: ["forbidden"])
+    let findings = validator.validate(
+      makeScenario(personas: [Persona(name: "forbidden", description: "also forbidden")])
+    )
+    // Two findings — one for name, one for description
+    #expect(findings.count == 2)
+    for message in findings {
+      #expect(!message.contains("forbidden"), "Finding leaked matched term: '\(message)'")
+    }
+  }
+
+  // MARK: - Phase fields
+
+  @Test func phasePromptBlockedTermDetected() {
+    let validator = ScenarioContentValidator(blockedPatterns: ["forbidden"])
+    let phase = Phase(type: .speakAll, prompt: "do forbidden things")
+    let findings = validator.validate(makeScenario(phases: [phase]))
+    #expect(findings.count == 1)
+    #expect(findings[0].contains("Phase 1"))
+    #expect(findings[0].contains("prompt"))
+  }
+
+  @Test func phaseTemplateBlockedTermDetected() {
+    let validator = ScenarioContentValidator(blockedPatterns: ["forbidden"])
+    let phase = Phase(type: .summarize, template: "summary: forbidden content")
+    let findings = validator.validate(makeScenario(phases: [phase]))
+    #expect(findings.count == 1)
+    #expect(findings[0].contains("template"))
+  }
+
+  @Test func phaseConditionBlockedTermDetected() {
+    let validator = ScenarioContentValidator(blockedPatterns: ["forbidden"])
+    let phase = Phase(type: .conditional, condition: "score.forbidden == 1")
+    let findings = validator.validate(makeScenario(phases: [phase]))
+    #expect(findings.count == 1)
+    #expect(findings[0].contains("condition"))
+  }
+
+  // MARK: - Conditional sub-phase recursion (ADR-005 §4.3)
+
+  @Test func conditionalSubPhaseThenBranchDetected() {
+    let validator = ScenarioContentValidator(blockedPatterns: ["forbidden"])
+    let subPhase = Phase(type: .speakAll, prompt: "do forbidden things")
+    let outer = Phase(
+      type: .conditional,
+      condition: "cleanCondition",
+      thenPhases: [subPhase]
+    )
+    let findings = validator.validate(makeScenario(phases: [outer]))
+    #expect(findings.count == 1)
+    #expect(findings[0].contains("Phase 1.then.1"))
+    #expect(findings[0].contains("prompt"))
+  }
+
+  @Test func conditionalSubPhaseElseBranchDetected() {
+    let validator = ScenarioContentValidator(blockedPatterns: ["forbidden"])
+    let subPhase = Phase(type: .speakAll, prompt: "do forbidden things")
+    let outer = Phase(
+      type: .conditional,
+      condition: "cleanCondition",
+      elsePhases: [subPhase]
+    )
+    let findings = validator.validate(makeScenario(phases: [outer]))
+    #expect(findings.count == 1)
+    #expect(findings[0].contains("Phase 1.else.1"))
+  }
+
+  @Test func conditionalBothBranchesDetectedIndependently() {
+    let validator = ScenarioContentValidator(blockedPatterns: ["forbidden"])
+    let outer = Phase(
+      type: .conditional,
+      condition: "cleanCondition",
+      thenPhases: [Phase(type: .speakAll, prompt: "forbidden then")],
+      elsePhases: [Phase(type: .speakAll, prompt: "forbidden else")]
+    )
+    let findings = validator.validate(makeScenario(phases: [outer]))
+    #expect(findings.count == 2)
+    #expect(findings.contains { $0.contains("then.1") })
+    #expect(findings.contains { $0.contains("else.1") })
+  }
+
+  @Test func conditionalSubPhaseTemplateAndConditionAlsoWalked() {
+    let validator = ScenarioContentValidator(blockedPatterns: ["forbidden"])
+    let outer = Phase(
+      type: .conditional,
+      condition: "cleanCondition",
+      thenPhases: [
+        Phase(type: .summarize, template: "forbidden template"),
+        Phase(type: .conditional, condition: "forbidden condition")
+      ]
+    )
+    let findings = validator.validate(makeScenario(phases: [outer]))
+    #expect(findings.count == 2)
+    #expect(findings.contains { $0.contains("Phase 1.then.1") && $0.contains("template") })
+    #expect(findings.contains { $0.contains("Phase 1.then.2") && $0.contains("condition") })
+  }
+
+  // MARK: - Matching semantics
+
+  @Test func caseInsensitiveMatching() {
+    let validator = ScenarioContentValidator(blockedPatterns: ["forbidden"])
+    let findings = validator.validate(makeScenario(name: "TOTALLY FORBIDDEN"))
+    #expect(findings.count == 1)
+  }
+
+  @Test func diacriticInsensitiveMatching() {
+    let validator = ScenarioContentValidator(blockedPatterns: ["café"])
+    let findings = validator.validate(makeScenario(name: "I like CAFE"))
+    #expect(findings.count == 1)
+  }
+
+  // MARK: - Invariant: no matched-term echo
+
+  @Test func findingsNeverEchoTheMatchedPattern() {
+    let badWord = "forbiddenword"
+    let validator = ScenarioContentValidator(blockedPatterns: [badWord])
+    let scenario = makeScenario(
+      name: "a forbiddenword is here",
+      description: "forbiddenword in description",
+      personas: [Persona(name: "Alice", description: "with forbiddenword inside")],
+      phases: [
+        Phase(type: .speakAll, prompt: "says forbiddenword"),
+        Phase(
+          type: .conditional,
+          condition: "cleanCondition",
+          thenPhases: [Phase(type: .speakAll, prompt: "nested forbiddenword")]
+        )
+      ]
+    )
+    let findings = validator.validate(scenario)
+    #expect(!findings.isEmpty)
+    for finding in findings {
+      #expect(
+        !finding.contains(badWord),
+        "Finding leaked matched term: '\(finding)'"
+      )
+    }
+  }
+}

--- a/Pastura/PasturaTests/App/ScenarioContentValidatorTests.swift
+++ b/Pastura/PasturaTests/App/ScenarioContentValidatorTests.swift
@@ -192,6 +192,15 @@ struct ScenarioContentValidatorTests {
     #expect(findings.count == 1)
   }
 
+  @Test func diacriticInsensitiveMatchingReverseDirection() {
+    // Symmetric case: blocklist pattern without diacritics, input with them.
+    // The bundled .txt may or may not be NFC-normalised and user input is
+    // independent of that — matching must fold both directions.
+    let validator = ScenarioContentValidator(blockedPatterns: ["naive"])
+    let findings = validator.validate(makeScenario(name: "How NAÏVE"))
+    #expect(findings.count == 1)
+  }
+
   // MARK: - Invariant: no matched-term echo
 
   @Test func findingsNeverEchoTheMatchedPattern() {

--- a/Pastura/PasturaTests/App/ScenarioEditorViewModelTests.swift
+++ b/Pastura/PasturaTests/App/ScenarioEditorViewModelTests.swift
@@ -409,6 +409,61 @@ struct ScenarioEditorViewModelTests {
     #expect(reloaded.extraData["topics"] == .array(["Alpha", "Beta"]))
   }
 
+  // MARK: - Content Validation
+
+  @Test func validateRejectsBlockedPersonaDescriptionInVisualMode() throws {
+    let sut = try makeSUT()
+    sut.scenarioId = "content_test"
+    sut.scenarioName = "Content Test"
+    sut.scenarioDescription = "A test"
+    sut.agentCount = 2
+    sut.rounds = 1
+    sut.context = "Context"
+    // Uses the default bundled blocklist — "殺す" is present in ContentBlocklist.txt.
+    sut.personas = [
+      EditablePersona(name: "Alice", description: "殺す"),
+      EditablePersona(name: "Bob", description: "Agent B")
+    ]
+    sut.phases = [
+      EditablePhase(type: .speakAll, prompt: "Go", outputFields: ["statement": "string"])
+    ]
+
+    sut.validate()
+
+    #expect(sut.isValid == false)
+    #expect(!sut.validationErrors.isEmpty)
+    #expect(sut.validationErrors.contains { $0.contains("Alice") && $0.contains("description") })
+  }
+
+  @Test func validateRejectsBlockedPersonaDescriptionInYAMLMode() throws {
+    let sut = try makeSUT()
+    sut.yamlText = """
+      id: content_yaml_test
+      name: Content YAML Test
+      description: A test
+      agents: 2
+      rounds: 1
+      context: Context
+      personas:
+        - name: Alice
+          description: 殺す
+        - name: Bob
+          description: Agent B
+      phases:
+        - type: speak_all
+          prompt: "Say something"
+          output:
+            statement: string
+      """
+    sut.editorMode = .yaml
+
+    sut.validate()
+
+    #expect(sut.isValid == false)
+    #expect(!sut.validationErrors.isEmpty)
+    #expect(sut.validationErrors.contains { $0.contains("Alice") && $0.contains("description") })
+  }
+
   // MARK: - Helpers
 
   private func makeSUT() throws -> ScenarioEditorViewModel {

--- a/docs/decisions/ADR-005.md
+++ b/docs/decisions/ADR-005.md
@@ -160,8 +160,8 @@ Apple's announcement flags AI features explicitly:
 
 For Pastura this means the questionnaire is not answered from *current
 scenarios only* — it must account for realistic LLM output under the
-blocklist Pastura ships (`ContentFilter.defaultPatterns` and the future
-input-validator wordlist, §4).
+blocklist Pastura ships (the shared `ContentBlocklist.txt` introduced
+in §4.4).
 
 ### 3.2 Target: 13+
 
@@ -220,9 +220,9 @@ fallback fires):
   text so users opt into the experience knowingly.
 - Info.plist / entitlements: typically no change; age rating is an App
   Store Connect concern, not a bundle concern.
-- `ContentFilter.defaultPatterns`: consider tightening *only if* the
-  16+ bump was driven by a specific pattern class; 16+ acceptance does
-  not *require* filter changes.
+- `ContentBlocklist.txt`: consider tightening *only if* the 16+ bump
+  was driven by a specific pattern class; 16+ acceptance does not
+  *require* filter changes.
 
 No fallback sub-issue is pre-filed because 13+ is the intended submission
 tier; a fallback-handling sub-issue will be opened only if a reviewer
@@ -1150,8 +1150,8 @@ for later:
 - **Japanese-corpus wordlist canonical source.** §4.4 lists LDNOOBW
   as a candidate only for English; no canonical Japanese blocklist
   exists. The implementation sub-issue (#3 in the master index) will
-  either curate a project-owned list seeded from
-  `ContentFilter.defaultPatterns` or adopt a third-party list once
+  either curate a project-owned list seeded from the starter set
+  shipped in `ContentBlocklist.txt` or adopt a third-party list once
   one is identified.
 - **Telemetry for filter hit rate.** §5.6 notes telemetry is
   considered but deferred. A future decision on whether filter hits

--- a/docs/decisions/ADR-005.md
+++ b/docs/decisions/ADR-005.md
@@ -352,11 +352,40 @@ suffices), `logic` / `source` / `target` (identifiers). Adding a field to
 this list later is additive and does not break existing validated
 scenarios (the validator is permissive if the wordlist does not match).
 
+**Recursion into `conditional` sub-phases.** For phases of type
+`conditional`, the validator recurses into `thenPhases` / `elsePhases`
+and applies the same field walk to every sub-phase. Nested `conditional`
+is structurally disallowed by `Engine/ScenarioValidator` (depth-1 UI
+enforcement; see `.claude/rules/navigation.md` Manual QA #5), but the
+content walker does not rely on that invariant — nested sub-phases are a
+natural hiding place for jailbreak-prompt content, so the walk is
+defensive by design.
+
 ### 4.4 Wordlist bundling strategy
 
-The validator matches against a curated blocklist bundled in
-`Pastura/Pastura/Resources/` (precise filename and format decided in the
-implementation sub-issue).
+The blocklist is a single shared resource bundled at
+`Pastura/Pastura/Resources/ContentBlocklist.txt`. Both
+`ScenarioContentValidator` (input validation, §4.2) and `ContentFilter`
+(output filtering, §5) load from this file by default, with
+`init(blockedPatterns:)` injection available on both types for test
+isolation. The bundled file is plain text — one pattern per line,
+`#`-prefixed and blank lines skipped — chosen over JSON / plist for the
+minimal-file-size, audit-as-data tradeoff; a richer serialisation can be
+introduced later without breaking the type contract.
+
+Rationale for sharing the list across layers:
+
+- Both layers block the same kinds of content. Divergence (e.g. a
+  jailbreak-phrase list that would only make sense at authoring time)
+  is speculative today and can be added via `init(blockedPatterns:)`
+  injection if it materialises.
+- A single source of truth eliminates drift between input and output.
+  Without sharing, a synchronisation invariant ("output list ⊆ input
+  list") would need to be enforced by test; the shared file makes that
+  invariant structural rather than convention-enforced.
+- Non-technical audit of the blocklist touches one file, not two.
+  Maintainer edits to `ContentBlocklist.txt` are reviewable as data,
+  not code.
 
 **Selection criteria** (final list chosen in the sub-issue — not in this
 ADR):
@@ -364,19 +393,22 @@ ADR):
 - English coverage: [LDNOOBW](https://github.com/LDNOOBW/List-of-Dirty-Naughty-Obscene-and-Otherwise-Bad-Words)
   is one candidate — widely used, but weighted toward en-US profanity and
   misses slang drift. Evaluated alongside alternatives (maintained en
-  corpora, curated Pastura-specific subset derived from
-  `ContentFilter.defaultPatterns`).
+  corpora, curated Pastura-specific subset).
 - Japanese coverage: no canonical ja-equivalent to LDNOOBW exists. The
   sub-issue will either curate a project-owned list seeded from the
-  existing `ContentFilter.defaultPatterns` (ja entries: 殺す, 死ね, etc.)
-  or adopt a third-party list once one is identified.
-- Both lists must be reviewed by the maintainer before bundling — wrapper
-  of a third-party list without audit is rejected (ja/en word lists have
-  historically included false positives for benign use).
+  pre-existing output-filter starter list (`殺す`, `死ね`, etc.) or
+  adopt a third-party list once one is identified.
+- Both lists must be reviewed by the maintainer before bundling —
+  wrapper of a third-party list without audit is rejected (ja/en word
+  lists have historically included false positives for benign use).
 
-**Explicitly out of scope for this ADR:** which files, what serialisation
-format, whether lists are embedded in source or bundled as resources,
-case / diacritic normalisation details. All live in the sub-issue.
+**Missing-resource posture.** If the bundled file is absent at runtime,
+loading is a hard failure (`preconditionFailure`), not a silent fallback
+to an empty list. This is a build-configuration class of bug that is
+cheaper to catch at app launch than to diagnose later as "the filter
+appears to be off". Test callers inject their own bundle pointer
+(mirroring the `PresetLoader` pattern) so the production default path is
+never evaluated under the XCTest host.
 
 ### 4.5 Invocation points
 
@@ -495,11 +527,11 @@ blocked patterns were visible during streaming and replaced only at
 commit; the policy in §5.1 is the commitment this ADR makes to keep that
 coverage intact going forward.
 
-The filter's blocklist (`ContentFilter.defaultPatterns` in
-`Pastura/Pastura/App/ContentFilter.swift:55-64`) is intentionally small
-— a starter set tuned for the initial submission. §9 registers blocklist
-expansion as a follow-up concern; policy does not prescribe the list
-contents.
+The filter's blocklist is the shared resource introduced in §4.4
+(`Pastura/Pastura/Resources/ContentBlocklist.txt`) — intentionally
+small, a starter set tuned for the initial submission. §9 registers
+blocklist expansion as a follow-up concern; policy does not prescribe
+the list contents.
 
 ### 5.3 Partial-prefix leakage
 
@@ -1080,9 +1112,9 @@ when work starts" marker and are created during the relevant sprint.
 |---|-----------|----------------|-------|-------------|-------|
 | 1 | Wrap `OllamaService` out of release binaries; `nm` audit | [#148](https://github.com/tyabu12/pastura/issues/148) | tyabu12 | **Submission** | Filed 2026-04-19; §8.5 |
 | 2 | Create `PrivacyInfo.xcprivacy` with required-reason APIs | [#149](https://github.com/tyabu12/pastura/issues/149) | tyabu12 | **Submission** | Filed 2026-04-19; §1 gap, §9 |
-| 3 | Implement `ScenarioContentValidator` (§4) + wordlist bundling (§4.4) | To be filed when work starts | tyabu12 | Soft — defense-in-depth complement to §5 filter | §5 filter is the backstop; §4 is preferred but not submission-blocking |
+| 3 | Implement `ScenarioContentValidator` (§4) + migrate `ContentFilter` to shared bundled blocklist (§4.4) | [#180](https://github.com/tyabu12/pastura/issues/180) | tyabu12 | Soft — defense-in-depth complement to §5 filter | §5 filter is the backstop; §4 is preferred but not submission-blocking |
 | 4 | Share Board report UI (§6) + pseudonymous contact surface | [#178](https://github.com/tyabu12/pastura/issues/178) | tyabu12 | Soft — §1.2 does not strictly apply to curated content, but defensive posture recommended before review | §1.5 contact info separately handled via App Store Connect support URL |
-| 5 | `ContentFilter.defaultPatterns` expansion methodology (§5.2) | Not filed — on-demand | tyabu12 | None (ongoing) | Triggered by telemetry, App Review citation, or user report |
+| 5 | Blocklist (`ContentBlocklist.txt`) expansion methodology (§5.2 / §4.4) | Not filed — on-demand | tyabu12 | None (ongoing) | Triggered by telemetry, App Review citation, or user report. Additions are data-only edits to the bundled resource once item #3 lands. |
 | 6 | Fallback handling 13+ → 16+ (§3.3) | Not filed — conditional | tyabu12 | Conditional (fires only on rejection) | Created reactively if Apple rejects the 13+ target |
 | 7 | ADR-006 Cloud API disclosure/consent implementation | Forthcoming ADR, not a sub-issue | tyabu12 | Cloud API feature (not submission) | Principles from §7 bind this work |
 | 8 | Declare `ITSAppUsesNonExemptEncryption = NO` in build config | [#159](https://github.com/tyabu12/pastura/issues/159) | tyabu12 | None (doc-vs-code drift) | Filed 2026-04-20; §8.6 |
@@ -1165,6 +1197,8 @@ the suffix.
   rules; cited in §6.1.
 - `Pastura/Pastura/App/ContentFilter.swift` — current filter
   implementation; cited in §5 and §4.6 (actor-isolation contrast).
+- `Pastura/Pastura/Resources/ContentBlocklist.txt` — shared blocklist
+  bundle for input validator and output filter; cited in §4.4, §5.2.
 - `Pastura/Pastura/App/SimulationViewModel.swift:671-684` — streaming
   snapshot filter application; cited in §5.5.
 - `Pastura/Pastura/App/ImportViewModel.swift:23` and


### PR DESCRIPTION
## Summary

- Implement ADR-005 §4 (Shift-left Input Validation): new `ScenarioContentValidator` (MainActor-bound) wired into `ImportViewModel.validate()` and `ScenarioEditorViewModel.validate()`, rejecting user-authored content that matches a shared blocklist **before** the LLM sees it.
- Unify the blocklist into a single bundled resource at `Pastura/Pastura/Resources/ContentBlocklist.txt`, read by both `ScenarioContentValidator` (input) and `ContentFilter` (output). Eliminates drift between the two layers by construction — maintainer blocklist audits touch one file, not two.
- Recurse into `thenPhases` / `elsePhases` for `conditional` phases. Nested sub-phases are the natural hiding place for jailbreak prompts and were the top-priority critic add during planning.
- In-place ADR edits to §4.3 / §4.4 / §5.2 / §9 reflect the unified-resource design; the rest of ADR-005 is untouched.

## Design notes

- `ContentBlocklist.swift` is a `nonisolated enum` with an injectable `load(from: Bundle) -> [String]` API and `static let defaultPatterns = load(from: .main)` convenience. Missing resource triggers `preconditionFailure` (fail-fast over silent degradation, per ADR §4.4).
- Tests inject `Bundle(for: DatabaseManager.self)` to mirror `PresetLoader`'s pattern; `ContentFilterTests.filterPreservesCleanText` / `filterHandlesEmptyString` empirically confirm the `.main` default path works under the XCTest host.
- Error messages follow ADR §4.7: identify the field, never echo the matched term. When a persona name itself is blocked, description findings fall back to positional form to avoid leaking the pattern.

## Preset audit (§4 pre-merge gate)

Grep of all 4 bundled presets (`prisoners_dilemma`, `bokete`, `word_wolf`, `target_score_race`) against the current blocklist returned zero hits. Editor round-trip on presets is safe.

## Test plan

- [x] `xcodebuild test -scheme Pastura` (full unit suite, UI tests skipped) → `** TEST SUCCEEDED **`
- [x] `swiftlint --strict` clean (only pre-existing `unused_import` config-position warning)
- [x] New test coverage: `ContentBlocklistTests` (bundle load + parser), `ScenarioContentValidatorTests` (per-field detection, nested then/else, case/diacritic folding both directions, no-matched-term-echo invariant), `ImportViewModelTests` / `ScenarioEditorViewModelTests` (integration — end-to-end via default bundled blocklist)
- [x] G3 code review PASS (0 critical, 0 warning, 3 suggestions — 2 applied, 1 noted as out-of-scope for current blocklist size)

Closes #180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)