### PR TITLE
📝 docs: defer Cloud API to Phase 3, add multi-model support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,7 +257,7 @@ Record architectural decisions in `docs/decisions/` as `ADR-NNN.md`.
 | `docs/decisions/ADR-003.md`           | BG execution (iOS 26 BGContinuedProcessingTask) |
 | `docs/decisions/ADR-004.md`           | Multi-platform strategy (Draft)             |
 | `docs/decisions/ADR-005.md`           | Content safety architecture (App Store review) |
-| `docs/decisions/ADR-006.md`           | Cloud API implementation details (reserved — not yet written; see ADR-005 §7.5) |
+| `docs/decisions/ADR-006.md`           | Cloud API implementation details (Phase 3; reserved — not yet written; see ADR-005 §7.5) |
 | `docs/decisions/ADR-007.md`           | DL-time demo replay — iOS lifecycle (#152)  |
 | `docs/specs/pastura-mvp-spec-v0_3.md` | MVP specification                                         |
 | `docs/specs/demo-replay-spec.md`      | DL-time demo replay — data format + component design (#152) |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Pastura — Product Roadmap
 
-> Last updated: 2026-04-19
+> Last updated: 2026-04-21
 > This document defines phase boundaries and scope. When in doubt whether a feature
 > belongs in the current phase, check here first.
 
@@ -83,7 +83,6 @@ creation observed. Decision: ship to App Store to gauge wider public reaction.
 |------------------------------------------|----------|-------------|------------------------------------------|
 | Visual scenario editor (dual-mode)       | High     | Done        | Form + block UI with YAML mode toggle (#83) |
 | Background execution (iOS 26)            | High     | Done        | BGContinuedProcessingTask + CPU inference in background (#84) |
-| In-app scenario generation (Cloud API)   | High     | Planned     | Claude/Gemini API for natural language → YAML |
 | Real-time LLM token streaming            | High     | Done        | Token-by-token streaming via `LLMService.generateStream`; `LLMCaller` drains snapshots and emits partial events. ContentFilter applied to streaming snapshots (#119/#132/#140); reveal task kept alive across tokens (#147). |
 | `conditional` phase type                 | Medium   | Done        | Nested-branch phase + Visual Editor support; includes `target_score_race` preset and conditional endings in `word_wolf` / `detective_scene` (#126/#141). |
 | `event_inject` phase type                | Medium   | Planned     | Random event injection mid-simulation    |
@@ -94,7 +93,7 @@ creation observed. Decision: ship to App Store to gauge wider public reaction.
 | Past results — code-phase event display  | Medium   | Done        | Score_calc / scenario gen events shown in past-results viewer (#102/#113) |
 | YAML simulation replay primitive         | Medium   | Planned     | Past Results YAML exporter + `YAMLReplaySource` importer primitive. Foundation for DL demo replay and future user-replay (spec §4.4 / §4.5). Replay gallery / Share Board integration deferred to Phase 3. Resumes spec §6.1 Candidate A (#164). |
 | DL-time demo replay                      | Medium   | Planned     | Bundled YAML replays during model download; see ADR-007, `docs/specs/demo-replay-spec.md` (data/arch), `docs/specs/demo-replay-ui.md` (visual/behaviour), and `docs/design/design-system.md` (tokens). Non-blocking for App Store submission; implementation follows #148/#149 closure (#152). |
-| E4B model switching                      | Low      | Planned     | Higher quality option for 12GB+ devices  |
+| Multi-model support (Qwen / E4B / other) | Medium   | Planned     | Additional on-device models for device-class fit + cross-model experimentation via the `LLMService` abstraction (ADR-001 §7 / ADR-002). Complements the offline-first story and provides "same scenario, different model" depth without cloud-cost / API-key risk. |
 | Inference speed display                  | Low      | Done        | tok/s display + simulation playback UX (#99) |
 
 ### Technical Debt to Address
@@ -116,6 +115,7 @@ creation observed. Decision: ship to App Store to gauge wider public reaction.
 | Feature                              | Notes                                      |
 |--------------------------------------|--------------------------------------------|
 | Scenario marketplace                 | Browse, rate, download community scenarios |
+| In-app scenario generation (Cloud API)| Claude/Gemini API for natural language → YAML. Deferred from Phase 2 (2026-04-21) to avoid cost-runaway / API-key-leakage risk during initial App Store release, and to share server-side infrastructure (identity, rate-limit, quota) with the marketplace. Gated on ADR-006; engineering beyond API-contract exploration is out of scope until ADR-006 merges (ADR-005 §7.5, §10). |
 | Scenario rankings / popular templates| Trending, most-run, highest-rated          |
 | Simulation result auto-summary       | LLM-generated summary of what happened     |
 | Relationship graph visualization     | Agent interaction network diagram          |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -119,8 +119,8 @@ creation observed. Decision: ship to App Store to gauge wider public reaction.
 | Scenario rankings / popular templates| Trending, most-run, highest-rated          |
 | Simulation result auto-summary       | LLM-generated summary of what happened     |
 | Relationship graph visualization     | Agent interaction network diagram          |
-| Android support                      | Direction under evaluation — see [ADR-004 (Draft)](decisions/ADR-004.md). Current lean: KMP-shared Engine + native Jetpack Compose UI + LiteRT-LM Kotlin SDK. |
-| PC companion app                     | Form factor decided at Phase 3.2 — KMP-shared Engine + Compose Desktop is the current lean (see ADR-004). |
+| Android support                      | Direction under evaluation — see [ADR-004 (Draft)](decisions/ADR-004.md). Current lean: KMP-shared Engine + native Jetpack Compose UI + **llama.cpp via a KMP binding, unified with iOS during Phase 3.0** (ADR-004 §3.6). Synchronised LiteRT-LM migration once iOS Swift SDK + GPU ships. |
+| PC companion app                     | Form factor decided at Phase 3.2 — KMP-shared Engine + Compose Desktop is the current lean (see ADR-004). LLM backend unified with iOS / Android during Phase 3.0 (llama.cpp via a KMP binding; ADR-004 §3.6). |
 | Localization (English)               | Expand beyond Japanese-speaking users      |
 | Early-termination phase type         | `conditional` branches but does not stop a simulation early — `rounds` still governs the loop. A new phase type (working name `terminate` / `break`) would let a branch signal "end the simulation now, run the remaining phases, then skip unrun rounds." Keeps `conditional` purely about evaluation + branching; termination is orthogonal. See PR #141 discussion. |
 
@@ -133,7 +133,12 @@ Phase 1: iOS only (Swift + SwiftUI)
 Phase 2: iOS + background execution (iOS 26)
 Phase 3: iOS + Android + Desktop via KMP shared Engine (direction under evaluation)
          See ADR-004 (Draft) — platform-specific UI (SwiftUI / Compose / Compose Desktop)
-         and platform-specific LLM actuals (llama.cpp → LiteRT-LM Swift; LiteRT-LM Kotlin)
+         and unified llama.cpp LLM backend across all platforms
+         during Phase 3.0 (via a llama.cpp KMP binding on Android / Desktop;
+         ADR-004 §3.6). Migration to LiteRT-LM deferred until Google's
+         iOS Swift SDK + GPU ships; at that point synchronised migration
+         across platforms is the default, with per-platform timing
+         reconsiderable after Phase 3.0 stabilises (ADR-002 §8.1).
          Final decision at Phase 2 → Phase 3 transition.
 ```
 

--- a/docs/decisions/ADR-002.md
+++ b/docs/decisions/ADR-002.md
@@ -304,6 +304,16 @@ When LiteRT-LM Swift SDK ships with iOS GPU support:
 
 The `LLMService` protocol was specifically designed for this swap (ADR-001 §7).
 
+### 8.1 Cross-platform migration synchronisation — pointer (2026-04-22)
+
+ADR-004 §3.6 (Draft) proposes that Phase 3 starts with unified
+llama.cpp across all platforms, and that migration to LiteRT-LM — when
+the §8 trigger fires — is synchronised across platforms during
+Phase 3.0 rather than iOS-first. This ADR-002 section will be written
+in full (with its own constraints and rationale) only when ADR-004 is
+accepted; until then, ADR-002's Accepted §8 migration plan remains
+iOS-scoped as originally committed.
+
 ### Monitoring
 
 Track these for migration readiness:

--- a/docs/decisions/ADR-004.md
+++ b/docs/decisions/ADR-004.md
@@ -309,9 +309,11 @@ from the same main branch.
 This ADR moves from Draft to Accepted when all of the following are true at the
 Phase 2 Go/No-Go review:
 
-- [ ] Phase 2 High Priority items shipped or explicitly descoped
-      (in-app scenario generation, real-time LLM token streaming are the
-      remaining ones as of 2026-04-17).
+- [ ] Phase 2 High Priority items shipped or explicitly descoped.
+      As of 2026-04-21: visual editor (#83), BG execution (#84), and
+      real-time LLM token streaming are Done. In-app scenario generation
+      (Cloud API) has been deferred to Phase 3 per the 2026-04-21
+      ROADMAP update — it no longer blocks Phase 2 exit.
 - [ ] A 1-day KMP PoC has built a single Engine phase handler in `commonMain`
       and exercised it from a small iOS harness, to validate that SKIE (or
       vanilla interop) reaches the ergonomics this ADR assumes.

--- a/docs/decisions/ADR-004.md
+++ b/docs/decisions/ADR-004.md
@@ -32,17 +32,23 @@
 
 ### 1.2 Current ROADMAP assumption
 
-`docs/ROADMAP.md` Phase 3 lists:
+`docs/ROADMAP.md` Phase 3 lists (as of 2026-04-22):
 
-- Android support → Kotlin + LiteRT-LM Android SDK (native)
-- PC companion app → Python CLI or Tauri/Electron GUI
+- Android support → KMP-shared Engine + native Jetpack Compose UI +
+  llama.cpp via a KMP binding (unified with iOS during Phase 3.0;
+  see §3.6). The specific binding is not yet selected — Llamatik is
+  one candidate, to be re-assessed at implementation time.
+- PC companion app → KMP-shared Engine + Compose Desktop + same
+  unified llama.cpp backend (same binding choice as Android).
 
-with a footnote under *Platform Expansion Strategy*:
-> Future: KMP shared Engine, platform-specific UI and LLM layers.
+with a footnote under *Platform Expansion Strategy* that enshrines the
+unified-llama.cpp direction and the synchronized LiteRT-LM migration
+trigger.
 
-The footnote already hints at KMP-for-logic, native-per-platform-UI as the long-term
-direction. This ADR formalises that direction and rejects the alternative of full-UI
-unification.
+This ADR formalises the KMP-for-logic + native-per-platform-UI direction
+and rejects the alternative of full-UI unification (Option B). The
+original 2026-04-17 draft also leaned toward LiteRT-LM Kotlin SDK on
+Android; §3.6 records the 2026-04-22 revision to unified llama.cpp.
 
 ### 1.3 Why decide now vs defer
 
@@ -68,10 +74,11 @@ commonMain (Kotlin)     Engine / Models / LLMService interface
    ├── iosMain           Swift ↔ Kotlin bridge (SKIE), LlamaCppService
    │                     Views: SwiftUI (unchanged from Phase 1/2)
    │
-   ├── androidMain       LiteRT-LM Kotlin SDK or Llamatik-wrapped llama.cpp
+   ├── androidMain       A llama.cpp KMP binding as Android `actual`
+   │                     (binding TBD at implementation time; see §3.6)
    │                     Views: Jetpack Compose (native)
    │
-   └── desktopMain       LiteRT-LM JVM / Llamatik on Desktop
+   └── desktopMain       Same KMP binding as Android (see §3.6)
                          Views: Compose Desktop (or native per-OS if needed)
 ```
 
@@ -80,9 +87,14 @@ commonMain (Kotlin)     Engine / Models / LLMService interface
   `sealed class` → exhaustive `switch`).
 - Android side: fresh Jetpack Compose app reading the same Engine.
 - Desktop side: Compose Desktop reading the same Engine. No Python CLI.
-- LLM is `expect`/`actual`: iOS keeps the Swift LlamaCppService (and swaps to
-  LiteRT-LM Swift SDK when it ships — aligned with ADR-002 §8); Android uses
-  LiteRT-LM Kotlin SDK directly.
+- LLM is `expect`/`actual` with a **unified llama.cpp backend across every
+  platform during Phase 3.0** (see §3.6 for rationale). iOS keeps the
+  Swift `LlamaCppService`; Android and Desktop use a llama.cpp KMP
+  binding (specific binding TBD — Llamatik is one candidate). Migration
+  to LiteRT-LM is deferred until Google's LiteRT-LM Swift SDK ships with
+  iOS GPU support — at that point synchronised migration across
+  platforms is the Phase 3.0 default, with per-platform timing
+  reconsiderable once Phase 3.0 stabilises (see §3.6 and §8).
 
 ### Option B — KMP + Compose Multiplatform (UI unified across iOS/Android/Desktop)
 
@@ -139,7 +151,7 @@ references cover UI portions, not long-running on-device inference.
 
 | Concern                                  | A                      | B                     | C                      |
 |------------------------------------------|------------------------|-----------------------|------------------------|
-| Android LLM backend                      | LiteRT-LM Kotlin (stable)| Same                  | LiteRT-LM Kotlin       |
+| Android LLM backend                      | llama.cpp via a KMP binding (matches iOS; see §3.6) | Same                  | LiteRT-LM Kotlin       |
 | UX matches platform conventions          | Native Compose         | Compose MP (can look iOS-like or Material) | Native Compose |
 | Engine behaviour consistent with iOS     | ✅ same binary          | ✅ same binary         | ❌ separate impl, drift risk |
 | Time to first Android beta               | Shorter (reuse Engine) | Longer (port UI first) | Longest (port everything) |
@@ -174,6 +186,124 @@ ADR-002.
 
 Option A has a smaller blast radius on every adverse scenario.
 
+### 3.6 LLM backend within Option A — unified llama.cpp direction (2026-04-22)
+
+Option A's `expect`/`actual` structure leaves a sub-decision: what
+backend does each platform's `actual` use? The original 2026-04-17
+draft leaned toward *iOS → llama.cpp* + *Android → LiteRT-LM Kotlin
+SDK* (different backends per platform). This section revises the lean
+to **unified llama.cpp across every platform during Phase 3.0**, with
+synchronised migration to LiteRT-LM once the LiteRT-LM Swift SDK + iOS
+GPU ships (ADR-002 §8 / §8.1).
+
+**Scope of the rationale below: Phase 3.0 launch triage, not a
+permanent architecture principle.** After Phase 3.0 stabilises (the
+first App Store release cycle and the first Play Store closed-track
+cycle both complete), per-platform migration timing may be
+reconsidered — see the *Post-Phase-3.0* note at the end of this
+subsection.
+
+**Why the revision:**
+
+1. **Reduce cross-platform behavioural differences during Phase 3.0
+   launch.** Different backends produce different sampling behaviour,
+   different chat-template handling, different quantization rounding,
+   and different streaming edge cases. During the initial Android beta
+   — when bug reports land and the team has no way to rule out
+   "Android-specific backend bug" without reproducing on both —
+   platform-symmetric backends make triage cheaper. This is a
+   **launch-phase triage heuristic, not a load-bearing architecture
+   principle**: the Engine / Views / App layers already absorb
+   platform differences via the `LLMService` protocol, and the
+   symmetry benefit is specifically about launch-phase bug triage
+   efficiency, which decays as both platforms stabilise.
+
+   *Caveat on "unified":* this means **same llama.cpp C API**, not
+   same Kotlin / Swift wrapper. iOS uses mattt/llama.swift (ADR-002
+   §2); Android / Desktop use a separate KMP binding. Version skew
+   between the two wrappers is a residual risk that the symmetry
+   does not eliminate on its own — operational discipline is to pin
+   both wrappers to the same llama.cpp upstream tag in each Phase 3
+   release train.
+
+2. **Single migration event instead of two.** The original lean
+   required validating Android's LiteRT-LM migration separately from
+   iOS's future LiteRT-LM migration — two Phase-0-scale validation
+   rounds (JSON stability × 8 phase types × 3 presets, sampling
+   re-tuning, thermal re-profiling). Unified approach collapses them
+   into one when the iOS trigger fires.
+
+3. **Deferred migration, not avoided.** If LiteRT-LM Swift SDK + iOS
+   GPU never ships, Pastura accepts indefinite llama.cpp as the
+   backend. Known costs of that outcome:
+
+   - No access to LiteRT-LM-only model formats (e.g. any future
+     Gemma Nano tiers, Google-first multimodal releases).
+   - NPU acceleration paths on flagship Android remain unreachable
+     through llama.cpp.
+   - Any future Google-exclusive modalities (vision, speech) would
+     require a separate backend decision at that time.
+
+   These costs are judged acceptable during Phase 3.0 because:
+   (a) the `LLMService` protocol (ADR-001 §7) keeps a future backend
+   switch cheap, (b) Phase 3.0's scope targets a functional cross-
+   platform release rather than best-in-class performance on every
+   device tier, and (c) chasing best-in-class per-device performance
+   at launch would introduce backend-specific instability and
+   maintenance burden that conflicts with Pastura's stability
+   preference.
+
+4. **GGUF format uniform during Phase 3.0** — one model file, one
+   download URL, one compatibility matrix, one validation cycle.
+   Aligns with the Phase 2 *Multi-model support (Qwen / E4B / other)*
+   commitment, which leans on the GGUF ecosystem's breadth versus
+   LiteRT-LM's curated list.
+
+5. **Pragmatic Phase 3.0 test coverage.** The Pastura author does not
+   currently own an Android device; minimising the iOS / Android
+   dependency delta compresses the test matrix during the initial
+   Android beta.
+
+**Trade-offs accepted:**
+
+- **Android NPU acceleration deferred.** Flagship Android devices
+  (Snapdragon 8 Elite / Dimensity 9500 / Pixel Tensor G3+) can reach
+  prefill-phase speedups via LiteRT-LM NPU paths that llama.cpp
+  cannot target. Prefill is ~20–35 % of simulation wall-clock on iOS
+  (ADR-002 §5); a 5–10× prefill speedup on Android NPU would
+  translate to roughly 2–4 min saved per ~10–20 min simulation run.
+  Magnitude is not yet measured for Pastura's workload on Android —
+  re-evaluated at Phase 3.0 against on-device measurements. Absent
+  that data, the loss should not be pre-judged as "bounded".
+- **Android GPU path is non-trivial.** The current candidate KMP
+  binding (Llamatik) is CPU-only as of writing; upstream llama.cpp
+  has a Qualcomm-contributed OpenCL backend for Adreno (2024-11)
+  which may be integrable but needs validation. Fallback: CPU-only
+  initial Android launch (matches the ~9.7 tok/s CPU baseline
+  ADR-002 §1 cites for E4B on modern iPhone — usable but suboptimal).
+- **KMP binding selection is deferred.** Llamatik is named as one
+  candidate throughout this ADR, but its production-readiness,
+  upstream-tracking cadence, and maintenance bus factor have not
+  been investigated. The specific binding is to be selected at Phase
+  3.1 implementation start; Llamatik is one candidate among others
+  to survey at that time.
+
+**Post-Phase-3.0 (informational):**
+
+Once Phase 3.0 stabilises, the "synchronise migrations across
+platforms" rule of thumb becomes reconsiderable per-platform. If, for
+example, Android stabilises on llama.cpp well before the LiteRT-LM
+Swift SDK ships, migrating Android to LiteRT-LM Kotlin SDK ahead of
+iOS may become worth the parallel-backend cost. The trigger is
+intentionally left as "situational re-assessment" rather than a
+defined gate — the launch-phase triage benefit decays with stability,
+and forcing a concrete threshold now would be speculative.
+
+§3.4's conclusion is unchanged: Option A still aligns strictly with
+ADR-002's migration plan. The revision is a narrowing of "which
+backend does Option A's `actual` pick for Phase 3.0" — not a
+divergence from the protocol abstraction ADR-002 §8 relies on.
+
 ---
 
 ## 4. Decision (tentative — see §8)
@@ -198,6 +328,13 @@ gating criteria in §8. Until then this ADR stays **Draft**.
 - The proposal to "skip native-Kotlin Android to avoid waste" is honoured at the Engine layer
   (where it is real waste) without forcing it at the UI layer (where it would destroy
   existing value).
+- **Unified llama.cpp backend during Phase 3.0 (§3.6)** — cross-
+  platform behavioural differences in LLM output, sampling, and
+  streaming are reduced at the llama.cpp C API level (subject to
+  wrapper-version pinning discipline, §3.6 point 1 caveat). Migration
+  to LiteRT-LM happens synchronously across platforms when the
+  trigger fires. Post-Phase-3.0, per-platform migration timing may
+  be reconsidered.
 
 ### 5.2 Negative
 
@@ -209,6 +346,11 @@ gating criteria in §8. Until then this ADR stays **Draft**.
   as of 2026-03).
 - Two UI codebases long-term (SwiftUI + Jetpack Compose). Feature parity maintenance
   is manual.
+- **Unified llama.cpp direction (§3.6)** defers Android NPU acceleration
+  (Snapdragon / Dimensity / Tensor TPU) during Phase 3.0. Android users
+  on flagship NPU devices see CPU or OpenCL performance instead of
+  their hardware's best path; the magnitude of this loss on Pastura's
+  workload is not yet measured on Android.
 
 ### 5.3 Rejected: Option B rationale
 
@@ -262,7 +404,13 @@ Assumes Option A is ratified at the Phase 2 Go/No-Go gate.
 ### Phase 3.1 — Android beta
 
 5. Android Jetpack Compose app consuming the KMP module.
-6. LiteRT-LM Kotlin SDK as the Android `actual` for `LLMService`.
+6. **A llama.cpp KMP binding as the Android `actual` for `LLMService`**
+   — unified with the iOS `actual` per §3.6. Specific binding selected
+   at Phase 3.1 implementation start; Llamatik is one candidate to
+   survey at that time. GGUF model loaded from the same distribution
+   as iOS. GPU strategy (CPU-only vs upstream OpenCL backend for
+   Adreno) decided at implementation time based on the chosen
+   binding's then-current acceleration surface.
 7. Android-specific UI: Material 3 navigation, no AppRouter port
    (Compose Navigation is its own idiom).
 8. Release to closed Play Store track for feedback — mirrors the Phase 1
@@ -271,7 +419,9 @@ Assumes Option A is ratified at the Phase 2 Go/No-Go gate.
 ### Phase 3.2 — Desktop companion
 
 9. Compose Desktop app consuming the KMP module.
-10. LiteRT-LM JVM as the desktop `actual` for `LLMService`.
+10. **A llama.cpp KMP binding as the Desktop `actual` for `LLMService`**
+    — unified with iOS / Android per §3.6 (same binding choice as
+    step 6).
 11. Desktop-specific UI adjustments (keyboard-first, no sheet detents).
 
 No iOS changes are required at any of these steps — the iOS app keeps shipping
@@ -317,9 +467,13 @@ Phase 2 Go/No-Go review:
 - [ ] A 1-day KMP PoC has built a single Engine phase handler in `commonMain`
       and exercised it from a small iOS harness, to validate that SKIE (or
       vanilla interop) reaches the ergonomics this ADR assumes.
-- [ ] LiteRT-LM Swift SDK status is re-checked. If Swift SDK has shipped, the
-      iOS-side `actual` can target it directly. If not, llama.cpp stays the
-      iOS `actual` per ADR-002 §8.
+- [ ] LiteRT-LM Swift SDK + iOS GPU status is re-checked (ADR-002 §8
+      trigger). Per §3.6, Phase 3 starts with unified llama.cpp across
+      all platforms regardless of SDK status at the gate review; the
+      check only determines whether the synchronised migration is a
+      near-term Phase 3.x item (if shipped) or remains indefinitely
+      deferred (if not). Post-Phase-3.0 reconsideration remains
+      allowed per §3.6.
 - [ ] No new iOS-only feature landed in Phase 2 that would break the
       "Engine has no iOS dependencies" invariant.
 

--- a/docs/decisions/ADR-005.md
+++ b/docs/decisions/ADR-005.md
@@ -59,20 +59,24 @@ gaps. Each is owned by one of the sections below:
 | No shift-left input validation on user-authored persona / goals / phase prompts | §4 |
 | `ContentFilter` policy is undocumented — partial-prefix leakage during streaming has no stated allowance | §5 |
 | Share Board has no reporting mechanism or reviewer identity disclosure | §6 |
-| Planned Cloud API (`docs/ROADMAP.md` Phase 2) has no disclosure/consent principles committed | §7 |
+| Planned Cloud API (`docs/ROADMAP.md` Phase 3) has no disclosure/consent principles committed | §7 |
 | `PrivacyInfo.xcprivacy` does not exist (Apple hard requirement since 2024-05) | §9 |
 
 ### 1.3 Why decide now
 
 The full-review clock is bounded by Phase 2 exit. Several of these decisions
-are load-bearing for in-flight Phase 2 work:
+are load-bearing for in-flight Phase 2 work, and one is load-bearing for
+Phase 3 Cloud API planning:
 
-- Cloud API scenario generation (ADR-006, planned) needs consent-architecture
-  principles *before* implementation to avoid rework.
 - Visual Scenario Editor (shipped #83) will need `ScenarioContentValidator`
   wired in — design settled here so the sub-issue has a clean target.
 - `PrivacyInfo.xcprivacy` blocks every TestFlight archive upload on iOS 17+;
   it cannot wait until submission week.
+- Cloud API scenario generation (ADR-006, Phase 3 per 2026-04-21 ROADMAP
+  update) needs consent-architecture principles committed *before* ADR-006
+  implementation detail work begins, so that ADR-006 inherits a stable
+  envelope rather than re-opening disclosure decisions under schedule
+  pressure.
 
 ---
 
@@ -772,8 +776,9 @@ for absences >5 days, reviewer identity as in §6.4.
 ### 7.1 Scope
 
 This section commits principles for the planned Cloud API feature
-(`docs/ROADMAP.md` Phase 2 — in-app scenario generation that sends
-natural-language input to Claude or Gemini and receives YAML back).
+(`docs/ROADMAP.md` Phase 3 — in-app scenario generation that sends
+natural-language input to Claude or Gemini and receives YAML back;
+deferred from Phase 2 on 2026-04-21 per ROADMAP update).
 Implementation specifics — concrete consent-screen wording, BYOK vs
 maintainer-provided keys, retry / rate-limit policy, which provider to
 ship with first — live in **ADR-006** (forthcoming). This ADR's
@@ -872,8 +877,8 @@ steps 1/3 does not require re-layout when the provider changes.
   distribution model.
 - Retry policy, rate-limit handling, and offline fallback.
 - Caching / telemetry policy for cloud requests.
-- Which provider ships first, and whether Phase 2 supports a single
-  provider or multiple at launch.
+- Which provider ships first, and whether the initial Phase 3 release
+  supports a single provider or multiple at launch.
 - Any consent-bundling (e.g. "enable all cloud features" affordance)
   — if introduced, must preserve per-feature revocation from §7.3.1.
 
@@ -968,7 +973,7 @@ If a reviewer objects, the escalation path is:
 
 **Risk.** Pastura's marketing and in-app copy emphasise "runs
 on-device, no cloud, your data stays local". A reviewer may ask for
-evidence — especially once Phase 2 adds the Cloud API feature that
+evidence — especially once Phase 3 adds the Cloud API feature that
 *does* send data off-device for specific opt-in flows.
 
 **Posture.**
@@ -1192,7 +1197,7 @@ the suffix.
   §8.3 for on-device inference engine.
 - `docs/decisions/ADR-003.md` — BG execution and on-device inference;
   cited in §8.3 and §8.4 as the canonical on-device-claim record.
-- `docs/ROADMAP.md` — Phase 2 Cloud API feature entry; cited in §7.1.
+- `docs/ROADMAP.md` — Phase 3 Cloud API feature entry; cited in §7.1.
 - `docs/gallery/README.md` — Share Board trust model and curation
   rules; cited in §6.1.
 - `Pastura/Pastura/App/ContentFilter.swift` — current filter

--- a/docs/decisions/ADR-007.md
+++ b/docs/decisions/ADR-007.md
@@ -72,9 +72,10 @@ ADR.
 
 Phase placement rationale:
 
-- Earlier than ADR-006 Cloud API (which needs significant design +
-  server work) because demo-replay leverages Phase 2 deliverables
-  already in tree (Past Results Viewer pattern, AgentOutputRow).
+- Earlier than ADR-006 Cloud API (moved to Phase 3 on 2026-04-21 —
+  needs significant design + server work) because demo-replay leverages
+  Phase 2 deliverables already in tree (Past Results Viewer pattern,
+  AgentOutputRow).
 - After #148/#149 because those touch `PasturaApp.swift` and
   `AppDependencies.swift`; sequencing demo-replay after their merge
   avoids three-way merge conflicts on the init path.


### PR DESCRIPTION
## Summary

Two threads of Phase-2/3 scope refinement:

### Thread 1: Cloud API deferral

- Move **In-app scenario generation (Cloud API)** from Phase 2 to Phase 3. Rationale:
  cost-runaway risk (no server-side quota yet) and API-key-leakage risk (no server proxy yet)
  are both too large to absorb during the initial App Store release window, and both require
  server-side infrastructure (identity, rate-limit, quota) that is better built once — shared
  with the Phase 3 marketplace — than bolted on for one feature.
- Upgrade **E4B model switching** (Low) → **Multi-model support (Qwen / E4B / other)** (Medium).
  Keeps Phase 2's "lower barriers + expand capabilities" story intact via the offline-first
  `LLMService` abstraction (ADR-001 §7 / ADR-002), and gives users "same scenario, different
  model" depth — aligned with the Surume-app product vision — without cloud-cost / key-leak
  risk.

### Thread 2: ADR-004 unified llama.cpp direction (Phase 3.0 scope)

- ADR-004 §3.6 (new) records the Phase 3 LLM-backend sub-decision: **unified llama.cpp
  across iOS / Android / Desktop during Phase 3.0**, with synchronised migration to
  LiteRT-LM once the LiteRT-LM Swift SDK + iOS GPU ships. Replaces the original 2026-04-17
  lean of *iOS llama.cpp + Android LiteRT-LM Kotlin* (different backends per platform).
- Framed as a **launch-phase triage heuristic**, not a load-bearing architecture
  principle. Post-Phase-3.0 (first App Store + Play Store closed-track cycles complete),
  per-platform migration timing may be reconsidered.
- Naming discipline: "a llama.cpp KMP binding" rather than "Llamatik" — the specific
  binding is to be selected at Phase 3.1 implementation start.
- Trade-offs named explicitly: Android NPU acceleration deferred (prefill speedup
  magnitude unmeasured on Android — not pre-judged as "bounded"); Android GPU path
  non-trivial; KMP-binding selection deferred.
- Cross-platform "unified" clarified: same llama.cpp C API, not same wrapper — with
  operational commitment to pin both wrappers to the same upstream tag per release train.
- ADR-002 §8.1 kept as a minimal pointer so the Accepted document does not carry
  Draft-owned rationale.

### Knock-on edits (both threads)

- `ADR-005` §1.2 / §1.3 / §7.1 / §7.5 / §8.4 / §10 references — Phase 2 Cloud API → Phase 3.
- `ADR-004` §1.2 / §2 / §3.3 / §5.1 / §5.2 / §6 / §8 — consistent with §3.6 scoping.
- `ADR-007` phase-placement note references Cloud API's Phase 3 move.
- `CLAUDE.md` Reference Documents row for ADR-006 notes "Phase 3".
- `ROADMAP.md` Platform Expansion Strategy + Phase 3 Android / PC rows — unified-llama.cpp
  direction, Phase 3.0 scope.

## Review history

- **Thread 1**: code-reviewer pass — no blockers, 3 fyi items addressed in-commit.
- **Thread 2**: critic pass 1 — 7 Warning findings. All addressed. critic pass 2 — 2
  minor polish Warnings, 1 addressed (§8 gating internal consistency), 1 deferred
  (cosmetic §3.6 sub-structure, critic called it "optional / current form acceptable").

## Test plan

- [x] `rg 'Phase 2 Cloud API|Phase 2 — in-app scenario|Phase 2 adds the Cloud API'`
      returns zero hits.
- [x] Llamatik is consistently framed as "one candidate" in Option A / §3.6 / §6 /
      ROADMAP. Only residual named mentions are in Option B (rejected) and §9 References.
- [x] `load-bearing principle`, `NPU loss is bounded`, `structurally eliminated`,
      `that's fine — llama.cpp keeps improving` — all removed from §3.6.
- [x] ADR-002 §8.1 does not declare any constraint; only points at the Draft ADR-004.
- [ ] Reviewer sanity-check: does the Phase 3 Cloud API deferral + Phase 3.0 unified
      llama.cpp direction read as a coherent set of Phase 2/3 boundary decisions, or
      as two unrelated threads that should be split into separate PRs?

🤖 Generated with [Claude Code](https://claude.com/claude-code)