### PR TITLE
✨ feat: DL-time demo replay — VM + Source + tests (C PR1 #169)

### DIFF
--- a/Pastura/Pastura/App/BundledDemoReplaySource.swift
+++ b/Pastura/Pastura/App/BundledDemoReplaySource.swift
@@ -1,0 +1,191 @@
+import Foundation
+import Yams
+import os
+
+/// Wrapping ``ReplaySource`` that loads pre-recorded demos shipped in
+/// the app bundle, verifies their `preset_ref.yaml_sha256` against the
+/// currently-shipped preset, and silent-skips on any mismatch or
+/// unsupported-schema failure per spec §3.3 / §3.5.
+///
+/// Spec: `docs/specs/demo-replay-spec.md` §4.4.
+///
+/// **Preset-only resolution (spec §7.2).** Only bundled presets are
+/// acceptable `preset_ref.id` targets — gallery scenarios live in the
+/// DB and are structurally unreachable from ``BundledPresetResolver``,
+/// so a gallery entry whose id happens to collide with a bundled
+/// preset cannot shadow the preset from a demo replay's perspective.
+///
+/// **Silent-skip posture (spec §3.3).** Drift at runtime (a demo
+/// referencing a preset whose bytes no longer match the recorded
+/// SHA) logs a diagnostic and drops the demo from the rotation. A
+/// louder error would be worse than a shorter rotation on the
+/// ambient DL-time surface — the CI drift guard (Issue #170) catches
+/// mismatches at build time as the primary defence.
+nonisolated public final class BundledDemoReplaySource: ReplaySource {
+
+  // MARK: - Stored
+
+  private let inner: YAMLReplaySource
+
+  // MARK: - ReplaySource
+
+  public var scenario: Scenario { inner.scenario }
+  public func events() -> AsyncStream<SimulationEvent> { inner.events() }
+  public func plannedEvents() -> [PacedEvent] { inner.plannedEvents() }
+
+  // MARK: - Init
+
+  private init(inner: YAMLReplaySource) {
+    self.inner = inner
+  }
+
+  // MARK: - Logging
+
+  private static let logger = Logger(
+    subsystem: "com.tyabu12.Pastura", category: "BundledDemoReplaySource")
+
+  // MARK: - Bundle loading
+
+  /// Enumerates demo YAMLs under `Resources/DemoReplays/` in `bundle`,
+  /// validates each, and returns the subset that passed all checks.
+  ///
+  /// Silent-skip cases (all logged via `os.Logger` at `notice` level):
+  /// - `DemoReplays/` directory absent from the bundle (Phase 2 default
+  ///   state before Issue #170 populates it — returns `[]`).
+  /// - YAML file unreadable as UTF-8.
+  /// - YAML malformed / missing `preset_ref.id` or `yaml_sha256`.
+  /// - `preset_ref.id` not a shipped preset (unknown, gallery-only,
+  ///   or typo).
+  /// - `preset_ref.yaml_sha256` does not match the resolved preset's
+  ///   current bytes — drift per spec §3.3.
+  /// - Demo's `schema_version` unsupported — `YAMLReplaySource` throws
+  ///   `YAMLReplaySourceError.unsupportedSchemaVersion`; wrapper
+  ///   catches per spec §3.5.
+  public static func loadAll(
+    bundle: Bundle = .main,
+    presetResolver: any PresetResolver = BundledPresetResolver(),
+    config: ReplayPlaybackConfig = .demoDefault
+  ) -> [BundledDemoReplaySource] {
+    let yamls = enumerateDemoYAMLs(bundle: bundle)
+    return loadFromYAMLs(yamls, presetResolver: presetResolver, config: config)
+  }
+
+  /// Test seam: construct from an already-enumerated list of
+  /// `(filename, yaml-contents)` pairs. Production callers go through
+  /// ``loadAll(bundle:presetResolver:config:)``.
+  internal static func loadFromYAMLs(
+    _ yamls: [(name: String, contents: String)],
+    presetResolver: any PresetResolver,
+    config: ReplayPlaybackConfig
+  ) -> [BundledDemoReplaySource] {
+    yamls.compactMap { yaml in
+      loadOne(
+        name: yaml.name, contents: yaml.contents,
+        presetResolver: presetResolver, config: config)
+    }
+  }
+
+  /// Loads a single demo YAML. Returns nil on any validation failure,
+  /// logging the reason.
+  ///
+  /// swiftlint:disable:next function_body_length
+  private static func loadOne(
+    name: String, contents: String,
+    presetResolver: any PresetResolver,
+    config: ReplayPlaybackConfig
+  ) -> BundledDemoReplaySource? {
+    // Parse just `preset_ref` first — we need its `id` to resolve the
+    // scenario and its `yaml_sha256` for drift verification before
+    // handing off to `YAMLReplaySource`'s stricter validation.
+    let presetRef: (id: String, sha256: String)
+    do {
+      guard let parsed = try parsePresetRef(yaml: contents) else {
+        logger.notice("Demo replay '\(name, privacy: .public)' missing preset_ref — skipping.")
+        return nil
+      }
+      presetRef = parsed
+    } catch {
+      logger.notice(
+        "Demo replay '\(name, privacy: .public)' malformed YAML: \(error.localizedDescription, privacy: .public) — skipping."
+      )
+      return nil
+    }
+
+    // Resolve the preset the demo claims to target.
+    let resolved: ResolvedPreset?
+    do {
+      resolved = try presetResolver.resolvePreset(id: presetRef.id)
+    } catch {
+      logger.notice(
+        "Demo replay '\(name, privacy: .public)' preset resolver failed for id '\(presetRef.id, privacy: .public)': \(error.localizedDescription, privacy: .public) — skipping."
+      )
+      return nil
+    }
+    guard let resolvedPreset = resolved else {
+      logger.notice(
+        "Demo replay '\(name, privacy: .public)' preset id '\(presetRef.id, privacy: .public)' not found in shipped presets — skipping."
+      )
+      return nil
+    }
+
+    // SHA drift check (spec §3.3).
+    guard resolvedPreset.sha256 == presetRef.sha256 else {
+      logger.notice(
+        "Demo replay '\(name, privacy: .public)' SHA mismatch for preset '\(presetRef.id, privacy: .public)' (recorded \(presetRef.sha256, privacy: .public) vs resolved \(resolvedPreset.sha256, privacy: .public)) — skipping."
+      )
+      return nil
+    }
+
+    // Hand off to `YAMLReplaySource` for full validation (schema
+    // version, turns, code_phase_events). Spec §3.5 mandates silent
+    // skip on `unsupportedSchemaVersion`.
+    do {
+      let inner = try YAMLReplaySource(
+        yaml: contents, scenario: resolvedPreset.scenario, config: config)
+      return BundledDemoReplaySource(inner: inner)
+    } catch YAMLReplaySourceError.unsupportedSchemaVersion(let version) {
+      logger.notice(
+        "Demo replay '\(name, privacy: .public)' unsupported schema version \(version ?? -1, privacy: .public) — skipping."
+      )
+      return nil
+    } catch {
+      logger.notice(
+        "Demo replay '\(name, privacy: .public)' YAMLReplaySource rejected it: \(error.localizedDescription, privacy: .public) — skipping."
+      )
+      return nil
+    }
+  }
+
+  private static func enumerateDemoYAMLs(bundle: Bundle) -> [(name: String, contents: String)] {
+    // `urls(forResourcesWithExtension:subdirectory:)` returns nil when
+    // the directory doesn't exist in the bundle. Phase 2 default: no
+    // `DemoReplays/` shipped until Issue #170 populates it, so `[]`
+    // triggers the host view's §5.3 progress-bar-only fallback.
+    guard
+      let urls = bundle.urls(
+        forResourcesWithExtension: "yaml", subdirectory: "DemoReplays")
+    else {
+      return []
+    }
+    return urls.compactMap { url in
+      guard let contents = try? String(contentsOf: url, encoding: .utf8) else {
+        logger.notice(
+          "Demo replay at '\(url.path, privacy: .public)' not readable as UTF-8 — skipping."
+        )
+        return nil
+      }
+      return (name: url.deletingPathExtension().lastPathComponent, contents: contents)
+    }
+  }
+
+  private static func parsePresetRef(yaml: String) throws -> (id: String, sha256: String)? {
+    guard let root = try Yams.load(yaml: yaml) as? [String: Any] else { return nil }
+    guard let presetRef = root["preset_ref"] as? [String: Any] else { return nil }
+    guard let identifier = presetRef["id"] as? String,
+      let sha256 = presetRef["yaml_sha256"] as? String
+    else {
+      return nil
+    }
+    return (id: identifier, sha256: sha256)
+  }
+}

--- a/Pastura/Pastura/App/PresetResolver.swift
+++ b/Pastura/Pastura/App/PresetResolver.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// A bundled preset resolved to its parsed ``Scenario`` + integrity
+/// SHA-256 as stored at load time.
+///
+/// Spec: `docs/specs/demo-replay-spec.md` §3.3.
+///
+/// Returned by ``PresetResolver/resolvePreset(id:)``. The `sha256`
+/// field is computed via ``ReplayHashing/sha256Hex(_:)`` so it is
+/// bit-for-bit identical to what ``YAMLReplayExporter`` wrote into a
+/// recorded demo's `preset_ref.yaml_sha256` at curation time — the
+/// drift guard compares these two values.
+nonisolated public struct ResolvedPreset: Sendable, Equatable {
+  public let scenario: Scenario
+  /// Lowercase hex SHA-256 of the scenario's YAML source. Symmetric
+  /// with ``YAMLReplayExporter``'s `preset_ref.yaml_sha256` emission.
+  public let sha256: String
+
+  public init(scenario: Scenario, sha256: String) {
+    self.scenario = scenario
+    self.sha256 = sha256
+  }
+}
+
+/// Resolves a `preset_ref.id` (spec §3.2) to a shipped preset and
+/// its integrity SHA-256. Used by ``BundledDemoReplaySource`` to
+/// honour the spec §3.3 drift guard and spec §7.2 "preset-only, no
+/// gallery shadowing" rule.
+///
+/// Conforming types **must** resolve only against shipped presets —
+/// never against `ScenarioRepository`, which also holds
+/// gallery-imported scenarios and would expose the collision-shadowing
+/// risk named in spec §7.2. The default implementation
+/// ``BundledPresetResolver`` enforces this structurally by reading
+/// exclusively from `Bundle.main`.
+nonisolated public protocol PresetResolver: Sendable {
+  /// Returns the resolved preset for `id`, or `nil` if no shipped
+  /// preset with that id exists in the resolver's source.
+  ///
+  /// Throws when a preset file is found but cannot be decoded as
+  /// UTF-8 or parsed as a valid ``Scenario`` — these are
+  /// build-integrity failures (the curator shipped a corrupt file),
+  /// distinct from the "unknown id" miss case which is normal.
+  ///
+  /// Silent-skip semantics for drift are the **wrapper**'s concern
+  /// (``BundledDemoReplaySource`` catches and logs); callers that
+  /// want an actionable diagnostic (future
+  /// `UserSimulationReplaySource`, spec §4.5) receive the throw.
+  func resolvePreset(id: String) throws -> ResolvedPreset?
+}
+
+/// Production ``PresetResolver`` that reads shipped presets from the
+/// app's main bundle.
+///
+/// **Gallery shadowing is structurally impossible**: this type reads
+/// exclusively from `Bundle.main.url(forResource:withExtension:)` —
+/// it does not touch ``ScenarioRepository`` and therefore cannot see
+/// user-imported gallery scenarios that might collide on id. This
+/// matches spec §7.2's mitigation requirement.
+nonisolated public final class BundledPresetResolver: PresetResolver {
+  /// Reads the bundled YAML for `id` and returns its contents. Returns
+  /// `nil` when no file exists; throws when decode fails.
+  ///
+  /// Stored as a closure so tests can inject fixture-driven readers
+  /// without writing real `Bundle` resources. Production callers use
+  /// ``init(bundle:)`` which wires `Bundle.url(forResource:)`.
+  private let yamlReader: @Sendable (String) throws -> String?
+
+  /// Constructs a resolver backed by `bundle` (default `.main`).
+  public init(bundle: Bundle = .main) {
+    self.yamlReader = { id in
+      guard let url = bundle.url(forResource: id, withExtension: "yaml") else {
+        return nil
+      }
+      return try String(contentsOf: url, encoding: .utf8)
+    }
+  }
+
+  /// Test-only initialiser injecting a custom YAML reader. Used by
+  /// ``BundledPresetResolverTests`` to avoid touching `Bundle.main`
+  /// in assertions about SHA + parse behaviour.
+  internal init(yamlReader: @escaping @Sendable (String) throws -> String?) {
+    self.yamlReader = yamlReader
+  }
+
+  public func resolvePreset(id: String) throws -> ResolvedPreset? {
+    guard let yaml = try yamlReader(id) else { return nil }
+    let scenario = try ScenarioLoader().load(yaml: yaml)
+    let sha256 = ReplayHashing.sha256Hex(yaml)
+    return ResolvedPreset(scenario: scenario, sha256: sha256)
+  }
+}

--- a/Pastura/Pastura/App/ReplayHashing.swift
+++ b/Pastura/Pastura/App/ReplayHashing.swift
@@ -1,0 +1,32 @@
+import CryptoKit
+import Foundation
+
+/// Shared SHA-256 helper for replay-schema integrity checks.
+///
+/// Spec: `docs/specs/demo-replay-spec.md` §3.3 (preset drift detection).
+///
+/// Symmetry is load-bearing: ``YAMLReplayExporter`` writes
+/// `preset_ref.yaml_sha256` by hashing the scenario's YAML string at
+/// export time, and ``BundledPresetResolver`` re-hashes the bundled
+/// preset YAML at load time to verify the demo still matches. Both
+/// sides **must** hash the same bytes — i.e. `Data(string.utf8)` of the
+/// UTF-8-decoded YAML, not the raw file bytes — otherwise a BOM or
+/// CRLF difference on disk would silent-skip every bundled demo in
+/// production.
+///
+/// Kept as a namespace enum (not a free function) so the call sites
+/// read as `ReplayHashing.sha256Hex(yaml)` — signalling "replay
+/// hashing" rather than "generic SHA-256" at the point of use.
+nonisolated enum ReplayHashing {
+  /// Returns the lowercase hex representation of `SHA-256(source.utf8)`.
+  ///
+  /// Both ``YAMLReplayExporter`` (for `preset_ref.yaml_sha256` emission)
+  /// and ``BundledPresetResolver`` (for drift verification against
+  /// shipped presets) route through this single entry point. Do not
+  /// introduce a parallel hashing path — the E1 round-trip tests +
+  /// spec §3.3 invariant depend on bit-for-bit agreement.
+  static func sha256Hex(_ source: String) -> String {
+    let digest = SHA256.hash(data: Data(source.utf8))
+    return digest.map { String(format: "%02x", $0) }.joined()
+  }
+}

--- a/Pastura/Pastura/App/ReplaySource.swift
+++ b/Pastura/Pastura/App/ReplaySource.swift
@@ -1,5 +1,45 @@
 import Foundation
 
+/// A planned event ready for consumer-driven playback.
+///
+/// Spec: `docs/specs/demo-replay-spec.md` §4.6.
+///
+/// Wraps a ``SimulationEvent`` with the minimum classification a consumer
+/// needs to pick a pre-yield delay bucket (``ReplayPlaybackConfig`` fields
+/// `turnDelayMs` / `codePhaseDelayMs`). Lifecycle events synthesised from
+/// YAML metadata carry ``Kind/lifecycle`` and **must** be yielded with
+/// zero delay — otherwise the consumer sleeps before announcing the
+/// round/phase, which reads wrong.
+///
+/// Introduced in Issue #169 (C-track PR1) so ``ReplayViewModel`` can own
+/// `Task.sleep` per ADR-007 §3.4's resume-from-position contract — the
+/// original ``ReplaySource/events()`` API bakes delays into the producer
+/// task and cannot surface `remainingDelayMs` to the consumer.
+nonisolated public struct PacedEvent: Sendable, Equatable {
+  /// Classifies the event so the consumer can pick the right delay bucket.
+  public enum Kind: Sendable, Equatable {
+    /// LLM-phase agent output (`.agentOutput`). Pre-yield delay =
+    /// `ReplayPlaybackConfig.turnDelayMs / speedMultiplier`.
+    case turn
+    /// Code-phase result (`.scoreUpdate` / `.elimination` / `.summary` /
+    /// `.voteResults` / `.pairingResult` / `.assignment`). Pre-yield
+    /// delay = `ReplayPlaybackConfig.codePhaseDelayMs / speedMultiplier`.
+    case codePhase
+    /// Synthesised round/phase boundary (`.roundStarted` / `.phaseStarted`).
+    /// Pre-yield delay = 0 — the marker fires alongside the event it
+    /// precedes rather than adding its own sleep.
+    case lifecycle
+  }
+
+  public let kind: Kind
+  public let event: SimulationEvent
+
+  public init(kind: Kind, event: SimulationEvent) {
+    self.kind = kind
+    self.event = event
+  }
+}
+
 /// A source of pre-recorded ``SimulationEvent``s replayed back to the UI.
 ///
 /// Spec: `docs/specs/demo-replay-spec.md` §4.3.
@@ -30,5 +70,47 @@ nonisolated public protocol ReplaySource: Sendable {
   ///
   /// A fresh stream is returned per call so the same source can be played
   /// back multiple times (required for the loop behaviour in spec §4.9).
+  ///
+  /// - Note: Retained for the E1 primitive contract and round-trip tests
+  ///   against ``YAMLReplayExporter``. VM consumers needing
+  ///   resume-from-position (ADR-007 §3.4) **must** use
+  ///   ``plannedEvents()`` instead — this streaming form bakes pacing
+  ///   into the producer task and cannot surface `remainingDelayMs` to
+  ///   the consumer. The two APIs emit different event sequences: this
+  ///   one does NOT include synthesised `.roundStarted` / `.phaseStarted`
+  ///   markers, while ``plannedEvents()`` does.
   func events() -> AsyncStream<SimulationEvent>
+
+  /// Returns the full replay plan as a chronologically-ordered array,
+  /// including synthesised `.roundStarted` / `.phaseStarted` lifecycle
+  /// events. Consumers own pacing — each ``PacedEvent`` carries a
+  /// ``PacedEvent/Kind`` so the consumer can pick the right delay bucket
+  /// from ``ReplayPlaybackConfig``.
+  ///
+  /// Stable across calls: the returned array's identity + order is
+  /// memoised inside the source at construction time (required for
+  /// resume-from-position: `eventCursor` in a paused state indexes into
+  /// this array, so two calls must produce equal indexing).
+  ///
+  /// Events are merged from YAML `turns` and `code_phase_events` sections
+  /// into a single chronological order keyed by `(round, phase_index)`
+  /// with stable secondary ordering by source position. Inside each
+  /// scenario, the first event of a new round carries a preceding
+  /// synthesised `.roundStarted`; the first event of a new phase
+  /// (within a round) carries a preceding synthesised `.phaseStarted`.
+  ///
+  /// **Intentionally NOT synthesised:**
+  /// - `.roundCompleted(round:scores:)` — the YAML schema has no slot
+  ///   for per-round score snapshots (spec §3.2). A consumer that
+  ///   needs a running scoreboard reads `.scoreUpdate` events.
+  /// - `.simulationCompleted` — stream-end is signalled by the array
+  ///   finishing; a synthesised terminator would race with the
+  ///   consumer's own end-of-iteration detection.
+  ///
+  /// **Known fidelity gap** (matches ``YAMLReplayExporter`` limitation,
+  /// see that type's `resolvePhaseIndices` doc): `.phaseStarted.phasePath`
+  /// is flattened to `[phaseIndex]`. Sub-phases inside a `conditional`
+  /// resolve to the outer conditional's index. Acceptable for Phase 2
+  /// linear presets (Word Wolf, Prisoner's Dilemma).
+  func plannedEvents() -> [PacedEvent]
 }

--- a/Pastura/Pastura/App/ReplayViewModel.swift
+++ b/Pastura/Pastura/App/ReplayViewModel.swift
@@ -1,0 +1,334 @@
+import Foundation
+
+/// View model driving the DL-time demo replay screen.
+///
+/// Spec: `docs/specs/demo-replay-spec.md` §4.2 + §4.9.
+/// Lifecycle: `docs/decisions/ADR-007.md` §3.3 + §3.4.
+///
+/// Consumes one or more ``ReplaySource``s via ``ReplaySource/plannedEvents()``
+/// (**not** ``ReplaySource/events()``) so the VM can own `Task.sleep` and
+/// honour ADR-007 §3.4's resume-from-position contract — the streaming
+/// `events()` API bakes pacing into the producer task and cannot surface
+/// `remainingDelayMs`.
+///
+/// **Persistence absence is enforced by construction (spec §4.2).** The
+/// initialiser takes no repository, no DB writer, no EventStore-style
+/// sink. A replayed demo cannot pollute the production `turns` /
+/// `simulations` tables because the wiring to write them simply does not
+/// exist on this path. Do not add a persistence parameter without
+/// revising the spec.
+///
+/// **ContentFilter scope is narrow by design (spec §3.4, ADR-005 §5.1).**
+/// Filtering is applied only to user-visible LLM-generated text:
+/// `.agentOutput.output.fields.values`, `.summary.text`,
+/// `.assignment.value`, `.pairingResult.action1/2`. Structured
+/// identifiers (persona names in `.elimination.agent`, `.voteResults`,
+/// `.scoreUpdate`) pass through unchanged — filtering them would
+/// corrupt persona names that happen to contain blocklist substrings.
+/// `.agentOutputStream` is not emitted by replay (spec §4.7) so is not
+/// in scope.
+///
+/// **Sync-risk with ``SimulationViewModel``:** The live VM's
+/// `handleEvent` (see `SimulationViewModel.swift`) is the canonical
+/// event→view-state transform. Events that `YAMLReplaySource.plannedEvents()`
+/// can currently emit — `.roundStarted`, `.phaseStarted`, `.agentOutput`,
+/// `.scoreUpdate`, `.elimination`, `.summary`, `.voteResults`,
+/// `.pairingResult`, `.assignment` — should mirror the live VM's
+/// filtering and state-update rules. When the live VM adds filtering
+/// to a new case, check whether ``YAMLReplaySource/plannedEvents()``
+/// can emit it; if yes, mirror the filter here; if no, leave alone.
+@Observable
+@MainActor
+final class ReplayViewModel {
+
+  // MARK: - Public state
+
+  /// Playback state machine per spec §4.9. Observed by the host view
+  /// for transition wiring (e.g. fading to the setup-complete screen
+  /// on `.transitioning`).
+  nonisolated enum State: Sendable, Equatable {
+    /// Constructed but not yet started. ``start()`` transitions out.
+    case idle
+    /// Actively playing `sources[sourceIndex]` with `eventCursor` as
+    /// the index into that source's `plannedEvents()` that will be
+    /// published *next* (cursor = 0 means "about to publish event 0").
+    case playing(sourceIndex: Int, eventCursor: Int)
+    /// Paused while backgrounded. `remainingDelayMs` is how much of
+    /// the pre-yield sleep for `plannedEvents()[eventCursor]` was
+    /// still outstanding when the pause fired. On resume, the VM
+    /// sleeps exactly that many milliseconds (scaled by
+    /// `speedMultiplier`) before publishing the paused event.
+    case paused(sourceIndex: Int, eventCursor: Int, remainingDelayMs: Int)
+    /// Transitioning to the setup-complete screen. ``downloadComplete()``
+    /// drives this; the host view's `.transition` animation keys off
+    /// state identity.
+    case transitioning
+  }
+
+  private(set) var state: State = .idle
+
+  /// Most-recent `.phaseStarted.phaseType`. Drives the phase-header
+  /// view's label (e.g. "発言ラウンド 1"). Reset when `start()` is
+  /// invoked.
+  private(set) var currentPhase: PhaseType?
+
+  /// Most-recent `.roundStarted.round`. Paired with
+  /// ``currentTotalRounds`` for the phase-header's "round N/M" label.
+  private(set) var currentRound: Int?
+
+  /// Most-recent `.roundStarted.totalRounds`. See ``currentRound``.
+  private(set) var currentTotalRounds: Int?
+
+  /// Filtered agent-output events in publish order. Consumed by the
+  /// host view's chat-stream component (``AgentOutputRow``). The
+  /// array grows append-only within a source; on source rotation
+  /// (Item 4), the consumer decides whether to clear it for a fresh
+  /// demo or carry over the log.
+  private(set) var agentOutputs: [AgentOutputEntry] = []
+
+  /// One rendered agent output suitable for `AgentOutputRow`.
+  nonisolated struct AgentOutputEntry: Sendable, Equatable, Identifiable {
+    public let id: UUID
+    public let agent: String
+    public let output: TurnOutput
+    public let phaseType: PhaseType
+
+    public init(
+      id: UUID = UUID(), agent: String, output: TurnOutput, phaseType: PhaseType
+    ) {
+      self.id = id
+      self.agent = agent
+      self.output = output
+      self.phaseType = phaseType
+    }
+  }
+
+  // MARK: - Dependencies
+
+  private let sources: [any ReplaySource]
+  private let config: ReplayPlaybackConfig
+  private let contentFilter: ContentFilter
+
+  // MARK: - Internal state
+
+  /// Running playback task. Cancelled on `.paused` / `.transitioning`
+  /// entry. `nil` while `.idle`, `.paused`, or `.transitioning`.
+  private var streamTask: Task<Void, Never>?
+
+  /// When non-nil, the VM is currently sleeping for a pre-yield delay
+  /// and this Instant names when the sleep will finish. `onBackground()`
+  /// reads this to compute `remainingDelayMs` before cancelling the
+  /// stream task.
+  private var currentSleepDeadline: ContinuousClock.Instant?
+
+  // MARK: - Init
+
+  /// Constructs a replay VM.
+  ///
+  /// - Parameters:
+  ///   - sources: Non-empty list of replay sources. Spec §5.3
+  ///     fallback (zero demos playable) is a wrapper concern
+  ///     (``BundledDemoReplaySource``); by the time sources reach the
+  ///     VM they are already validated.
+  ///   - config: Playback pacing + loop policy (spec §4.6). The VM
+  ///     reads `turnDelayMs` / `codePhaseDelayMs` / `speedMultiplier`
+  ///     for per-event sleeps and `loopBehaviour` / `onComplete` for
+  ///     end-of-source behaviour (loop rotation lands in a follow-up
+  ///     commit on this branch).
+  ///   - contentFilter: Filter instance applied to user-visible text
+  ///     at render time (spec §3.4).
+  ///
+  /// - Note: **Spec §4.2 invariant** — no repository, no DB writer, no
+  ///   EventStore-style sink parameter. Adding one requires revising
+  ///   the spec.
+  init(
+    sources: [any ReplaySource],
+    config: ReplayPlaybackConfig = .demoDefault,
+    contentFilter: ContentFilter = ContentFilter()
+  ) {
+    self.sources = sources
+    self.config = config
+    self.contentFilter = contentFilter
+  }
+
+  // MARK: - Transition methods
+
+  /// Begins playback from the first source, first event.
+  ///
+  /// No-op if already playing or transitioning. Resets observable
+  /// state so a second `.idle → .playing` cycle gets a clean slate.
+  func start() {
+    guard case .idle = state else { return }
+    guard !sources.isEmpty else { return }
+    agentOutputs = []
+    currentPhase = nil
+    currentRound = nil
+    currentTotalRounds = nil
+    let startIndex = 0
+    state = .playing(sourceIndex: startIndex, eventCursor: 0)
+    launchPlayback(sourceIndex: startIndex, startCursor: 0, firstSleepOverrideMs: nil)
+  }
+
+  /// Pauses playback at the current position with the remaining
+  /// pre-yield delay captured for accurate resumption (ADR-007 §3.4).
+  ///
+  /// Called by the host view's `scenePhase` observer when the scene
+  /// drops below `.active`. No-op if not currently `.playing`.
+  func onBackground() {
+    guard case .playing(let sourceIndex, let cursor) = state else { return }
+    let remaining = remainingDelayMs()
+    streamTask?.cancel()
+    streamTask = nil
+    currentSleepDeadline = nil
+    state = .paused(
+      sourceIndex: sourceIndex, eventCursor: cursor, remainingDelayMs: remaining)
+  }
+
+  /// Resumes playback from the paused position, sleeping exactly the
+  /// remaining delay before publishing the next event.
+  ///
+  /// Called by the host view's `scenePhase` observer when the scene
+  /// returns to `.active`. No-op if not currently `.paused`.
+  func onForeground() {
+    guard case .paused(let sourceIndex, let cursor, let remainingMs) = state
+    else { return }
+    state = .playing(sourceIndex: sourceIndex, eventCursor: cursor)
+    launchPlayback(
+      sourceIndex: sourceIndex, startCursor: cursor,
+      firstSleepOverrideMs: remainingMs)
+  }
+
+  /// Transitions to `.transitioning` and tears down the active
+  /// stream task. Called when the download-complete signal arrives
+  /// — the host view then owns the animated hand-off (ADR-007 §3.3
+  /// case (d)).
+  ///
+  /// Safe from any source state except `.idle` and `.transitioning`.
+  func downloadComplete() {
+    switch state {
+    case .idle, .transitioning:
+      return
+    case .playing, .paused:
+      streamTask?.cancel()
+      streamTask = nil
+      currentSleepDeadline = nil
+      state = .transitioning
+    }
+  }
+
+  // MARK: - Playback task
+
+  private func launchPlayback(
+    sourceIndex: Int, startCursor: Int, firstSleepOverrideMs: Int?
+  ) {
+    streamTask?.cancel()
+    streamTask = Task { [weak self] in
+      await self?.runPlayback(
+        sourceIndex: sourceIndex, startCursor: startCursor,
+        firstSleepOverrideMs: firstSleepOverrideMs)
+    }
+  }
+
+  private func runPlayback(
+    sourceIndex: Int, startCursor: Int, firstSleepOverrideMs: Int?
+  ) async {
+    let source = sources[sourceIndex]
+    let plan = source.plannedEvents()
+    var cursor = startCursor
+    var overrideMs = firstSleepOverrideMs
+    while cursor < plan.count {
+      if Task.isCancelled { return }
+      let paced = plan[cursor]
+      let delayMs: Int
+      if let override = overrideMs {
+        delayMs = override
+        overrideMs = nil
+      } else {
+        delayMs = scaledDelay(for: paced.kind)
+      }
+      if delayMs > 0 {
+        let deadline = ContinuousClock.now.advanced(by: .milliseconds(delayMs))
+        currentSleepDeadline = deadline
+        try? await Task.sleep(until: deadline)
+        currentSleepDeadline = nil
+      }
+      if Task.isCancelled { return }
+      apply(paced.event)
+      cursor += 1
+      // Only advance observable cursor if we're still playing (not
+      // backgrounded mid-publish). Guards against a stale state
+      // update stomping a just-set `.paused`.
+      if case .playing(let idx, _) = state, idx == sourceIndex {
+        state = .playing(sourceIndex: sourceIndex, eventCursor: cursor)
+      }
+    }
+    // Source finished. Rotation to next source lands in a follow-up
+    // commit; for Item 3 a single source ending simply returns and
+    // leaves the VM in `.playing(cursor: plan.count)`.
+  }
+
+  // MARK: - Render-time state updates
+
+  /// Applies `event` to observable state with narrow ContentFilter
+  /// scope. Mirror of the live ``SimulationViewModel/handleEvent(_:)``
+  /// for the subset of events ``YAMLReplaySource/plannedEvents()``
+  /// can emit — see the sync-risk note in this file's header.
+  private func apply(_ event: SimulationEvent) {
+    switch event {
+    case .roundStarted(let round, let totalRounds):
+      currentRound = round
+      currentTotalRounds = totalRounds
+
+    case .phaseStarted(let phaseType, _):
+      currentPhase = phaseType
+
+    case .agentOutput(let agent, let output, let phaseType):
+      let filtered = contentFilter.filter(output)
+      agentOutputs.append(
+        AgentOutputEntry(agent: agent, output: filtered, phaseType: phaseType))
+
+    case .summary, .scoreUpdate, .elimination, .voteResults,
+      .pairingResult, .assignment:
+      // Code-phase events currently have no observable state surface
+      // in PR1 — the host view's scoreboard / results strip is the
+      // PR2 concern. ContentFilter is still applied in a follow-up
+      // commit when those surfaces land. For now these events update
+      // nothing visible; rendering them is a no-op here.
+      return
+
+    case .roundCompleted, .phaseCompleted, .simulationCompleted,
+      .simulationPaused, .conditionalEvaluated, .agentOutputStream,
+      .inferenceStarted, .inferenceCompleted, .error:
+      // Never emitted by `YAMLReplaySource.plannedEvents()` (see the
+      // sync-risk note in the header). A `.error` in particular would
+      // signal primitive-level breakage; replay's own failure surface
+      // goes through the state machine, not the event stream.
+      return
+    }
+  }
+
+  // MARK: - Pacing helpers
+
+  private func scaledDelay(for kind: PacedEvent.Kind) -> Int {
+    let speed = max(config.speedMultiplier, 0.001)
+    switch kind {
+    case .turn:
+      return Int(Double(config.turnDelayMs) / speed)
+    case .codePhase:
+      return Int(Double(config.codePhaseDelayMs) / speed)
+    case .lifecycle:
+      return 0
+    }
+  }
+
+  /// Computes the outstanding sleep in milliseconds given
+  /// ``currentSleepDeadline``. Returns 0 when not currently sleeping
+  /// (i.e. the VM is between events).
+  private func remainingDelayMs() -> Int {
+    guard let deadline = currentSleepDeadline else { return 0 }
+    let remaining = deadline - ContinuousClock.now
+    let (seconds, attoseconds) = remaining.components
+    let milliseconds = Int(seconds) * 1000 + Int(attoseconds / 1_000_000_000_000_000)
+    return max(0, milliseconds)
+  }
+}

--- a/Pastura/Pastura/App/ReplayViewModel.swift
+++ b/Pastura/Pastura/App/ReplayViewModel.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import Foundation
 
 /// View model driving the DL-time demo replay screen.
@@ -230,28 +231,43 @@ final class ReplayViewModel {
   }
 
   private func runPlayback(
+    sourceIndex startIndex: Int, startCursor: Int, firstSleepOverrideMs: Int?
+  ) async {
+    var sourceIndex = startIndex
+    var cursor = startCursor
+    var overrideMs = firstSleepOverrideMs
+    while !Task.isCancelled {
+      await playSource(
+        sourceIndex: sourceIndex, startCursor: cursor,
+        firstSleepOverrideMs: overrideMs)
+      overrideMs = nil
+      if Task.isCancelled { return }
+      switch advanceAfterSource(currentIndex: sourceIndex) {
+      case .continue(let nextIndex):
+        sourceIndex = nextIndex
+        cursor = 0
+      case .stop:
+        return
+      }
+    }
+  }
+
+  /// Iterates through a single source's plannedEvents starting at
+  /// `startCursor`, sleeping before each event and publishing on
+  /// schedule. Returns when the source ends, the task is cancelled,
+  /// or the VM transitions out of `.playing(sourceIndex, ...)`.
+  private func playSource(
     sourceIndex: Int, startCursor: Int, firstSleepOverrideMs: Int?
   ) async {
-    let source = sources[sourceIndex]
-    let plan = source.plannedEvents()
+    let plan = sources[sourceIndex].plannedEvents()
     var cursor = startCursor
     var overrideMs = firstSleepOverrideMs
     while cursor < plan.count {
       if Task.isCancelled { return }
       let paced = plan[cursor]
-      let delayMs: Int
-      if let override = overrideMs {
-        delayMs = override
-        overrideMs = nil
-      } else {
-        delayMs = scaledDelay(for: paced.kind)
-      }
-      if delayMs > 0 {
-        let deadline = ContinuousClock.now.advanced(by: .milliseconds(delayMs))
-        currentSleepDeadline = deadline
-        try? await Task.sleep(until: deadline)
-        currentSleepDeadline = nil
-      }
+      let delayMs = overrideMs ?? scaledDelay(for: paced.kind)
+      overrideMs = nil
+      await sleepOrYield(milliseconds: delayMs)
       if Task.isCancelled { return }
       apply(paced.event)
       cursor += 1
@@ -262,9 +278,79 @@ final class ReplayViewModel {
         state = .playing(sourceIndex: sourceIndex, eventCursor: cursor)
       }
     }
-    // Source finished. Rotation to next source lands in a follow-up
-    // commit; for Item 3 a single source ending simply returns and
-    // leaves the VM in `.playing(cursor: plan.count)`.
+  }
+
+  /// Pre-yield sleep policy for a planned event. Lifecycle events (and
+  /// high-speed configs where non-lifecycle delays round to 0ms) yield
+  /// via `Task.yield()` instead of sleeping — a tight publish loop
+  /// without either would starve observer polls (`scenePhase` forwards,
+  /// test `waitForState` predicates, etc.).
+  private func sleepOrYield(milliseconds: Int) async {
+    if milliseconds > 0 {
+      let deadline = ContinuousClock.now.advanced(by: .milliseconds(milliseconds))
+      currentSleepDeadline = deadline
+      try? await Task.sleep(until: deadline)
+      currentSleepDeadline = nil
+    } else {
+      await Task.yield()
+    }
+  }
+
+  /// Rotation / stop decision after a source finishes its plan.
+  /// Separate from `runPlayback` both to keep that function's
+  /// complexity within swiftlint's bounds and because the policy
+  /// (loop-forever vs stop-after-last × transition-signal vs stop)
+  /// reads cleaner as a single switch.
+  private enum AdvanceAction {
+    /// Keep playing; `nextIndex` is the source to play next.
+    case `continue`(nextIndex: Int)
+    /// Stop the playback task. State has already been set to its
+    /// terminal value (`.idle` or `.playing(lastIndex, plan.count)`).
+    case stop
+  }
+
+  private func advanceAfterSource(currentIndex: Int) -> AdvanceAction {
+    let isLastSource = currentIndex == sources.count - 1
+    switch config.loopBehaviour {
+    case .loop:
+      let nextIndex = (currentIndex + 1) % sources.count
+      resetPerDemoState()
+      if case .playing = state {
+        state = .playing(sourceIndex: nextIndex, eventCursor: 0)
+      }
+      return .continue(nextIndex: nextIndex)
+    case .stopAfterLast where !isLastSource:
+      // Advance to next source without wrap-around. Spec §4.6:
+      // `.stopAfterLast` plays each source once in order.
+      let nextIndex = currentIndex + 1
+      resetPerDemoState()
+      if case .playing = state {
+        state = .playing(sourceIndex: nextIndex, eventCursor: 0)
+      }
+      return .continue(nextIndex: nextIndex)
+    case .stopAfterLast:
+      // Last source finished — honour `onComplete`.
+      switch config.onComplete {
+      case .awaitTransitionSignal:
+        // Hold at `.playing(lastIndex, plan.count)` until the
+        // download-complete signal arrives. Default DL-demo uses
+        // `.loop + .awaitTransitionSignal`; this branch is for
+        // single-pass replays that still want hold-on-done.
+        return .stop
+      case .stopPlayback:
+        // Future user-replay surface (spec §4.5). Revert to `.idle`
+        // so the UI can offer a restart.
+        state = .idle
+        return .stop
+      }
+    }
+  }
+
+  private func resetPerDemoState() {
+    agentOutputs = []
+    currentPhase = nil
+    currentRound = nil
+    currentTotalRounds = nil
   }
 
   // MARK: - Render-time state updates

--- a/Pastura/Pastura/App/YAMLReplayExporter.swift
+++ b/Pastura/Pastura/App/YAMLReplayExporter.swift
@@ -1,5 +1,4 @@
 // swiftlint:disable file_length
-import CryptoKit
 import Foundation
 
 /// Errors produced by ``YAMLReplayExporter``.
@@ -547,9 +546,16 @@ nonisolated struct YAMLReplayExporter {  // swiftlint:disable:this type_body_len
 
   // MARK: - SHA-256
 
+  /// Exporter-side alias for ``ReplayHashing/sha256Hex(_:)``.
+  ///
+  /// Both sides of the spec §3.3 drift guard (exporter producing
+  /// `preset_ref.yaml_sha256`, resolver re-hashing the shipped preset
+  /// YAML at load time) **must** use the same algorithm on the same
+  /// bytes — see ``ReplayHashing`` for the invariant. Keeping this
+  /// alias lets existing callers stay byte-identical while the
+  /// implementation lives in one place.
   static func sha256Hex(_ source: String) -> String {
-    let digest = SHA256.hash(data: Data(source.utf8))
-    return digest.map { String(format: "%02x", $0) }.joined()
+    ReplayHashing.sha256Hex(source)
   }
 
   // MARK: - Date formatting

--- a/Pastura/Pastura/App/YAMLReplaySource.swift
+++ b/Pastura/Pastura/App/YAMLReplaySource.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import Foundation
 import Yams
 
@@ -61,10 +62,31 @@ nonisolated public final class YAMLReplaySource: ReplaySource {
     let event: SimulationEvent
   }
 
+  /// Chronological-merge entry used only during init to build
+  /// ``pacedPlan``. Carries the `(round, phase_index, phase_type)`
+  /// coordinates plus a stable secondary sort key so `turns` /
+  /// `code_phase_events` can be merged while preserving within-section
+  /// source order.
+  private struct ChronologicalEntry: Sendable {
+    let round: Int
+    let phaseIndex: Int
+    let phaseType: PhaseType
+    let sourceOrder: Int
+    let paceKind: PacedEvent.Kind
+    let event: SimulationEvent
+  }
+
   // MARK: - Stored state
 
   private let scenarioValue: Scenario
   private let plan: [PlannedEvent]
+  /// Chronologically-sorted ``PacedEvent`` array with synthesised
+  /// `.roundStarted` / `.phaseStarted` lifecycle events. Computed once
+  /// at init and returned verbatim by ``plannedEvents()``; stability
+  /// across calls is structural (`let`), which
+  /// ``ReplaySource/plannedEvents()``'s contract depends on for
+  /// resume-from-position.
+  private let pacedPlan: [PacedEvent]
   private let config: ReplayPlaybackConfig
 
   public var scenario: Scenario { scenarioValue }
@@ -101,19 +123,38 @@ nonisolated public final class YAMLReplaySource: ReplaySource {
 
     let personas = Set(scenario.personas.map(\.name))
     var plan: [PlannedEvent] = []
+    var chronological: [ChronologicalEntry] = []
 
     let turns = (root["turns"] as? [[String: Any]]) ?? []
-    for raw in turns {
-      plan.append(try Self.planTurn(raw, allowedAgents: personas))
+    for (idx, raw) in turns.enumerated() {
+      let parsed = try Self.parseTurn(raw, allowedAgents: personas)
+      plan.append(PlannedEvent(kind: .turn, event: parsed.event))
+      chronological.append(
+        ChronologicalEntry(
+          round: parsed.round, phaseIndex: parsed.phaseIndex,
+          phaseType: parsed.phaseType, sourceOrder: idx,
+          paceKind: .turn, event: parsed.event))
     }
 
     let codeEvents = (root["code_phase_events"] as? [[String: Any]]) ?? []
-    for raw in codeEvents {
-      plan.append(try Self.planCodePhaseEvent(raw))
+    for (idx, raw) in codeEvents.enumerated() {
+      let parsed = try Self.parseCodePhaseEvent(raw)
+      plan.append(PlannedEvent(kind: .codePhase, event: parsed.event))
+      chronological.append(
+        ChronologicalEntry(
+          round: parsed.round, phaseIndex: parsed.phaseIndex,
+          phaseType: parsed.phaseType,
+          // `+ turns.count` keeps turn source-order strictly below
+          // code-event source-order for a stable tie-break when two
+          // entries land at the same (round, phase_index).
+          sourceOrder: idx + turns.count,
+          paceKind: .codePhase, event: parsed.event))
     }
 
     self.scenarioValue = scenario
     self.plan = plan
+    self.pacedPlan = Self.buildPacedPlan(
+      entries: chronological, totalRounds: scenario.rounds)
     self.config = config
   }
 
@@ -142,7 +183,68 @@ nonisolated public final class YAMLReplaySource: ReplaySource {
     }
   }
 
-  // MARK: - YAML loading
+  public func plannedEvents() -> [PacedEvent] { pacedPlan }
+
+  // MARK: - Paced plan construction
+
+  /// Merges turn + code-phase entries chronologically by
+  /// `(round, phase_index, sourceOrder)` and inserts synthesised
+  /// `.roundStarted` / `.phaseStarted` lifecycle markers ahead of the
+  /// first event of each new round / phase boundary.
+  ///
+  /// Explicitly NOT synthesised (see ``ReplaySource/plannedEvents()``
+  /// doc for rationale): `.roundCompleted`, `.simulationCompleted`.
+  private static func buildPacedPlan(
+    entries: [ChronologicalEntry], totalRounds: Int
+  ) -> [PacedEvent] {
+    let sorted = entries.sorted { lhs, rhs in
+      if lhs.round != rhs.round { return lhs.round < rhs.round }
+      if lhs.phaseIndex != rhs.phaseIndex { return lhs.phaseIndex < rhs.phaseIndex }
+      return lhs.sourceOrder < rhs.sourceOrder
+    }
+    var result: [PacedEvent] = []
+    var lastRound: Int?
+    var lastPhaseIndex: Int?
+    var lastPhaseType: PhaseType?
+    for entry in sorted {
+      if lastRound != entry.round {
+        result.append(
+          PacedEvent(
+            kind: .lifecycle,
+            event: .roundStarted(round: entry.round, totalRounds: totalRounds)))
+        lastRound = entry.round
+        // Force a phaseStarted synthesis on round transition even if the
+        // phase coordinates happen to match the previous round's last
+        // phase — semantically a new round's first phase starts fresh.
+        lastPhaseIndex = nil
+        lastPhaseType = nil
+      }
+      if lastPhaseIndex != entry.phaseIndex || lastPhaseType != entry.phaseType {
+        result.append(
+          PacedEvent(
+            kind: .lifecycle,
+            // `phasePath: [phaseIndex]` is flattened per the known
+            // fidelity gap documented in ``ReplaySource/plannedEvents()``
+            // (matches ``YAMLReplayExporter.resolvePhaseIndices`` scope).
+            event: .phaseStarted(phaseType: entry.phaseType, phasePath: [entry.phaseIndex])))
+        lastPhaseIndex = entry.phaseIndex
+        lastPhaseType = entry.phaseType
+      }
+      result.append(PacedEvent(kind: entry.paceKind, event: entry.event))
+    }
+    return result
+  }
+}
+
+// MARK: - YAML parsing helpers
+//
+// Moved into an extension so `type_body_length` counts only the primary
+// class body — the decode helpers are glue around Yams' `[String: Any]`
+// shape and don't belong on the main class's conceptual surface.
+
+extension YAMLReplaySource {
+
+  // MARK: YAML loading
 
   private static func loadYAML(_ data: Data) throws -> Any? {
     guard let text = String(data: data, encoding: .utf8) else {
@@ -159,9 +261,27 @@ nonisolated public final class YAMLReplaySource: ReplaySource {
 
   // MARK: - Planning: turns
 
-  private static func planTurn(
+  /// Parsed turn carrying the chronological coordinates needed to
+  /// build ``pacedPlan`` alongside the existing ``PlannedEvent``.
+  private struct ParsedTurn: Sendable {
+    let round: Int
+    let phaseIndex: Int
+    let phaseType: PhaseType
+    let event: SimulationEvent
+  }
+
+  /// Parsed code-phase event with the same coordinate shape as
+  /// ``ParsedTurn``.
+  private struct ParsedCodeEvent: Sendable {
+    let round: Int
+    let phaseIndex: Int
+    let phaseType: PhaseType
+    let event: SimulationEvent
+  }
+
+  private static func parseTurn(
     _ raw: [String: Any], allowedAgents: Set<String>
-  ) throws -> PlannedEvent {
+  ) throws -> ParsedTurn {
     guard let phaseTypeRaw = raw["phase_type"] as? String else {
       throw YAMLReplaySourceError.missingRequiredField("phase_type")
     }
@@ -175,8 +295,15 @@ nonisolated public final class YAMLReplaySource: ReplaySource {
       throw YAMLReplaySourceError.unknownAgent(agent)
     }
     let fields = try Self.decodeStringMap(raw["fields"], field: "fields")
-    return PlannedEvent(
-      kind: .turn,
+    // `round` / `phase_index` default to 0 if absent so a malformed or
+    // older-schema YAML still parses — the drift guard and consistency
+    // check live at the CI level (spec §3.3), not at load time.
+    let round = (raw["round"] as? Int) ?? 0
+    let phaseIndex = (raw["phase_index"] as? Int) ?? 0
+    return ParsedTurn(
+      round: round,
+      phaseIndex: phaseIndex,
+      phaseType: phaseType,
       event: .agentOutput(
         agent: agent, output: TurnOutput(fields: fields),
         phaseType: phaseType))
@@ -217,16 +344,39 @@ nonisolated public final class YAMLReplaySource: ReplaySource {
 
   // MARK: - Planning: code_phase_events
 
-  private static func planCodePhaseEvent(
+  private static func parseCodePhaseEvent(
     _ raw: [String: Any]
-  ) throws -> PlannedEvent {
+  ) throws -> ParsedCodeEvent {
     let summary = (raw["summary"] as? String) ?? ""
-    if let payload = raw["payload"] as? [String: Any],
-      let event = try decodePayloadStanza(payload, summary: summary) {
-      return PlannedEvent(kind: .codePhase, event: event)
+    let round = (raw["round"] as? Int) ?? 0
+    let phaseIndex = (raw["phase_index"] as? Int) ?? 0
+    // `phase_type` is denormalised on code-phase entries in the YAML
+    // (spec §3.2). Unknown values are treated as planning-level drift
+    // and rejected via ``unknownPhaseType`` — symmetric with turns.
+    let phaseType: PhaseType
+    if let raw = raw["phase_type"] as? String {
+      guard let parsed = PhaseType(rawValue: raw) else {
+        throw YAMLReplaySourceError.unknownPhaseType(raw)
+      }
+      phaseType = parsed
+    } else {
+      // Missing `phase_type` on code events is tolerated (older writers
+      // may have omitted it). Default to `.scoreCalc` so the lifecycle
+      // synthesis has a stable label; consumers that rely on the exact
+      // type for rendering will re-derive from `phasePath` against the
+      // scenario if needed.
+      phaseType = .scoreCalc
     }
-    // Fallback: no structured payload — surface as a narrative summary.
-    return PlannedEvent(kind: .codePhase, event: .summary(text: summary))
+    let event: SimulationEvent
+    if let payload = raw["payload"] as? [String: Any],
+      let decoded = try decodePayloadStanza(payload, summary: summary) {
+      event = decoded
+    } else {
+      // Fallback: no structured payload — surface as a narrative summary.
+      event = .summary(text: summary)
+    }
+    return ParsedCodeEvent(
+      round: round, phaseIndex: phaseIndex, phaseType: phaseType, event: event)
   }
 
   /// Decodes a `payload:` stanza as emitted by ``YAMLReplayExporter``.

--- a/Pastura/PasturaTests/App/BundledDemoReplaySourceTests.swift
+++ b/Pastura/PasturaTests/App/BundledDemoReplaySourceTests.swift
@@ -1,0 +1,225 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+@Suite(.timeLimit(.minutes(1)))
+struct BundledDemoReplaySourceTests {
+
+  // MARK: - Fixtures
+
+  /// Minimal scenario YAML with 2 personas + 1 speak_all phase —
+  /// matches the shape the fixture demo YAML targets.
+  static let presetYAML = """
+    id: wf
+    name: Preset
+    description: ''
+    agents: 2
+    rounds: 1
+    context: ''
+    personas:
+      - name: Alice
+        description: ''
+      - name: Bob
+        description: ''
+    phases:
+      - type: speak_all
+        prompt: say
+        output:
+          statement: string
+    """
+
+  /// Stub `PresetResolver` that returns a single in-memory preset.
+  /// Use this in tests that drive the resolver happy-path; the real
+  /// `BundledPresetResolver` reads from `Bundle.main`, which we want
+  /// to avoid coupling to here.
+  struct StubPresetResolver: PresetResolver {
+    let id: String
+    let yaml: String
+    let shouldThrow: Bool
+
+    init(id: String, yaml: String, shouldThrow: Bool = false) {
+      self.id = id
+      self.yaml = yaml
+      self.shouldThrow = shouldThrow
+    }
+
+    func resolvePreset(id: String) throws -> ResolvedPreset? {
+      if shouldThrow { throw StubResolverError() }
+      guard id == self.id else { return nil }
+      let scenario = try ScenarioLoader().load(yaml: yaml)
+      return ResolvedPreset(scenario: scenario, sha256: ReplayHashing.sha256Hex(yaml))
+    }
+  }
+
+  struct StubResolverError: Error {}
+
+  static func validDemoYAML(sha256: String, id: String = "wf") -> String {
+    """
+    schema_version: 1
+    preset_ref:
+      id: \(id)
+      yaml_sha256: \(sha256)
+    turns:
+      - round: 1
+        phase_index: 0
+        phase_type: speak_all
+        agent: Alice
+        fields: { statement: 'hi' }
+    """
+  }
+
+  static let testConfig = ReplayPlaybackConfig(
+    speedMultiplier: 100.0,
+    turnDelayMs: 20,
+    codePhaseDelayMs: 5,
+    loopBehaviour: .stopAfterLast,
+    onComplete: .awaitTransitionSignal)
+
+  // MARK: - Happy path
+
+  @Test func loadsValidDemoWhenShaMatches() throws {
+    let correctSHA = ReplayHashing.sha256Hex(Self.presetYAML)
+    let resolver = StubPresetResolver(id: "wf", yaml: Self.presetYAML)
+    let yamls = [
+      (name: "demo1", contents: Self.validDemoYAML(sha256: correctSHA))
+    ]
+    let sources = BundledDemoReplaySource.loadFromYAMLs(
+      yamls, presetResolver: resolver, config: Self.testConfig)
+    #expect(sources.count == 1)
+    #expect(sources[0].scenario.id == "wf")
+    // plannedEvents should produce the synthesised lifecycle + turn.
+    let plan = sources[0].plannedEvents()
+    #expect(plan.count == 3)
+  }
+
+  // MARK: - Silent-skip paths (spec §3.3 / §3.5)
+
+  @Test func skipsDemoWithShaMismatch() throws {
+    let resolver = StubPresetResolver(id: "wf", yaml: Self.presetYAML)
+    let yamls = [
+      (
+        name: "drift",
+        contents: Self.validDemoYAML(sha256: "deadbeef" + String(repeating: "00", count: 28))
+      )
+    ]
+    let sources = BundledDemoReplaySource.loadFromYAMLs(
+      yamls, presetResolver: resolver, config: Self.testConfig)
+    #expect(sources.isEmpty)
+  }
+
+  @Test func skipsDemoWithUnsupportedSchemaVersion() throws {
+    let correctSHA = ReplayHashing.sha256Hex(Self.presetYAML)
+    let resolver = StubPresetResolver(id: "wf", yaml: Self.presetYAML)
+    let yaml = """
+      schema_version: 9999
+      preset_ref:
+        id: wf
+        yaml_sha256: \(correctSHA)
+      turns: []
+      """
+    let sources = BundledDemoReplaySource.loadFromYAMLs(
+      [(name: "future", contents: yaml)],
+      presetResolver: resolver, config: Self.testConfig)
+    #expect(sources.isEmpty)
+  }
+
+  @Test func skipsDemoMissingSchemaVersion() throws {
+    let correctSHA = ReplayHashing.sha256Hex(Self.presetYAML)
+    let resolver = StubPresetResolver(id: "wf", yaml: Self.presetYAML)
+    // Spec §3.5 — missing schema_version treated as drift. Source
+    // throws `YAMLReplaySourceError.unsupportedSchemaVersion(nil)`,
+    // wrapper silent-skips.
+    let yaml = """
+      preset_ref:
+        id: wf
+        yaml_sha256: \(correctSHA)
+      turns: []
+      """
+    let sources = BundledDemoReplaySource.loadFromYAMLs(
+      [(name: "noversion", contents: yaml)],
+      presetResolver: resolver, config: Self.testConfig)
+    #expect(sources.isEmpty)
+  }
+
+  @Test func skipsDemoWithUnknownPresetId() throws {
+    let correctSHA = ReplayHashing.sha256Hex(Self.presetYAML)
+    let resolver = StubPresetResolver(id: "wf", yaml: Self.presetYAML)
+    let yamls = [
+      (name: "orphan", contents: Self.validDemoYAML(sha256: correctSHA, id: "other"))
+    ]
+    let sources = BundledDemoReplaySource.loadFromYAMLs(
+      yamls, presetResolver: resolver, config: Self.testConfig)
+    #expect(sources.isEmpty)
+  }
+
+  @Test func skipsDemoWithMissingPresetRef() throws {
+    let resolver = StubPresetResolver(id: "wf", yaml: Self.presetYAML)
+    let yaml = """
+      schema_version: 1
+      turns: []
+      """
+    let sources = BundledDemoReplaySource.loadFromYAMLs(
+      [(name: "nopresetref", contents: yaml)],
+      presetResolver: resolver, config: Self.testConfig)
+    #expect(sources.isEmpty)
+  }
+
+  @Test func skipsDemoWithMalformedYAML() throws {
+    let resolver = StubPresetResolver(id: "wf", yaml: Self.presetYAML)
+    let yamls = [
+      (name: "garbage", contents: "\t\tnot: [valid: yaml::")
+    ]
+    let sources = BundledDemoReplaySource.loadFromYAMLs(
+      yamls, presetResolver: resolver, config: Self.testConfig)
+    #expect(sources.isEmpty)
+  }
+
+  @Test func skipsWhenResolverThrows() throws {
+    let resolver = StubPresetResolver(id: "wf", yaml: Self.presetYAML, shouldThrow: true)
+    let correctSHA = ReplayHashing.sha256Hex(Self.presetYAML)
+    let yamls = [
+      (name: "demo", contents: Self.validDemoYAML(sha256: correctSHA))
+    ]
+    let sources = BundledDemoReplaySource.loadFromYAMLs(
+      yamls, presetResolver: resolver, config: Self.testConfig)
+    #expect(sources.isEmpty)
+  }
+
+  // MARK: - Heterogeneous input
+
+  @Test func validDemosLoadWhileInvalidOnesSkip() throws {
+    let correctSHA = ReplayHashing.sha256Hex(Self.presetYAML)
+    let resolver = StubPresetResolver(id: "wf", yaml: Self.presetYAML)
+    let yamls = [
+      (name: "good", contents: Self.validDemoYAML(sha256: correctSHA)),
+      (name: "drift", contents: Self.validDemoYAML(sha256: String(repeating: "a", count: 64))),
+      (name: "other", contents: Self.validDemoYAML(sha256: correctSHA, id: "nope")),
+      (name: "good2", contents: Self.validDemoYAML(sha256: correctSHA))
+    ]
+    let sources = BundledDemoReplaySource.loadFromYAMLs(
+      yamls, presetResolver: resolver, config: Self.testConfig)
+    // Only the two validated demos survive; the drift + unknown-id
+    // entries silent-skip.
+    #expect(sources.count == 2)
+  }
+
+  // MARK: - Empty-bundle fallback
+
+  @Test func emptyInputReturnsEmptySourcesArray() throws {
+    let resolver = StubPresetResolver(id: "wf", yaml: Self.presetYAML)
+    let sources = BundledDemoReplaySource.loadFromYAMLs(
+      [], presetResolver: resolver, config: Self.testConfig)
+    #expect(sources.isEmpty)
+  }
+
+  @Test func bundleWithoutDemoReplaysDirectoryReturnsEmpty() throws {
+    // Real `Bundle.main` during tests has no `DemoReplays/` subdir
+    // — Phase 2 default pre-#170. This exercises the production
+    // enumeration path and asserts the §5.3 fallback trigger.
+    let resolver = StubPresetResolver(id: "wf", yaml: Self.presetYAML)
+    let sources = BundledDemoReplaySource.loadAll(
+      bundle: .main, presetResolver: resolver, config: Self.testConfig)
+    #expect(sources.isEmpty)
+  }
+}

--- a/Pastura/PasturaTests/App/DemoReplayIntegrationTests.swift
+++ b/Pastura/PasturaTests/App/DemoReplayIntegrationTests.swift
@@ -1,0 +1,270 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+/// End-to-end integration: `BundledDemoReplaySource.loadFromYAMLs` →
+/// `ReplayViewModel` → observed state sequence.
+///
+/// Exercises the composition of PR1's new types against hand-written
+/// fixture YAMLs shaped like the real demo-replay schema. Complements
+/// the unit suites (which cover each type in isolation) by asserting
+/// that wiring them together produces the expected visible behaviour:
+/// lifecycle events get synthesised, ContentFilter is applied at the
+/// VM layer, source rotation happens, and the paused→resumed path
+/// lands on the right cursor.
+///
+/// `.serialized` per `.claude/rules/testing.md` — VM spawns playback
+/// tasks; a parallel runner could cleanup-race against this suite.
+@Suite("DemoReplayIntegration", .serialized, .timeLimit(.minutes(1)))
+@MainActor
+struct DemoReplayIntegrationTests {
+
+  // MARK: - Fixtures
+
+  static let wordWolfPresetYAML = """
+    id: word_wolf
+    name: Word Wolf
+    description: ''
+    agents: 3
+    rounds: 1
+    context: ''
+    personas:
+      - name: Alice
+        description: ''
+      - name: Bob
+        description: ''
+      - name: Carol
+        description: ''
+    phases:
+      - type: speak_all
+        prompt: say
+        output:
+          statement: string
+    """
+
+  static let prisonersDilemmaPresetYAML = """
+    id: prisoners_dilemma
+    name: Prisoner's Dilemma
+    description: ''
+    agents: 2
+    rounds: 1
+    context: ''
+    personas:
+      - name: Alice
+        description: ''
+      - name: Bob
+        description: ''
+    phases:
+      - type: speak_all
+        prompt: choose
+        output:
+          statement: string
+    """
+
+  static func wordWolfDemoYAML() -> String {
+    let sha = ReplayHashing.sha256Hex(wordWolfPresetYAML)
+    return """
+      schema_version: 1
+      preset_ref:
+        id: word_wolf
+        yaml_sha256: \(sha)
+      turns:
+        - round: 1
+          phase_index: 0
+          phase_type: speak_all
+          agent: Alice
+          fields: { statement: 'I think the word is cat' }
+        - round: 1
+          phase_index: 0
+          phase_type: speak_all
+          agent: Bob
+          fields: { statement: 'shit I disagree' }
+        - round: 1
+          phase_index: 0
+          phase_type: speak_all
+          agent: Carol
+          fields: { statement: 'let me think' }
+      """
+  }
+
+  static func prisonersDilemmaDemoYAML() -> String {
+    let sha = ReplayHashing.sha256Hex(prisonersDilemmaPresetYAML)
+    return """
+      schema_version: 1
+      preset_ref:
+        id: prisoners_dilemma
+        yaml_sha256: \(sha)
+      turns:
+        - round: 1
+          phase_index: 0
+          phase_type: speak_all
+          agent: Alice
+          fields: { statement: 'cooperate' }
+        - round: 1
+          phase_index: 0
+          phase_type: speak_all
+          agent: Bob
+          fields: { statement: 'defect' }
+      """
+  }
+
+  struct MultiPresetResolver: PresetResolver {
+    let presets: [String: String]
+
+    func resolvePreset(id: String) throws -> ResolvedPreset? {
+      guard let yaml = presets[id] else { return nil }
+      let scenario = try ScenarioLoader().load(yaml: yaml)
+      return ResolvedPreset(scenario: scenario, sha256: ReplayHashing.sha256Hex(yaml))
+    }
+  }
+
+  static let resolver = MultiPresetResolver(presets: [
+    "word_wolf": wordWolfPresetYAML,
+    "prisoners_dilemma": prisonersDilemmaPresetYAML
+  ])
+
+  /// Single-pass config: `.stopAfterLast + .awaitTransitionSignal` so
+  /// the test observes a deterministic end state (both demos played
+  /// once, VM holds at `.playing(1, lastCursor)`). Fixture size
+  /// bounded to ~ 5 events per demo × 2 demos = 10 events total,
+  /// well under the 20-event cap from the plan.
+  static let integrationConfig = ReplayPlaybackConfig(
+    speedMultiplier: 100.0,
+    turnDelayMs: 20,
+    codePhaseDelayMs: 5,
+    loopBehaviour: .stopAfterLast,
+    onComplete: .awaitTransitionSignal)
+
+  static func makeSources() -> [BundledDemoReplaySource] {
+    let yamls = [
+      (name: "word_wolf_demo", contents: wordWolfDemoYAML()),
+      (name: "prisoners_dilemma_demo", contents: prisonersDilemmaDemoYAML())
+    ]
+    return BundledDemoReplaySource.loadFromYAMLs(
+      yamls, presetResolver: resolver, config: integrationConfig)
+  }
+
+  static func waitForState(
+    _ viewModel: ReplayViewModel, timeout: Duration = .seconds(5),
+    predicate: @MainActor (ReplayViewModel.State) -> Bool
+  ) async {
+    let deadline = ContinuousClock.now.advanced(by: timeout)
+    while ContinuousClock.now < deadline {
+      if predicate(viewModel.state) { return }
+      try? await Task.sleep(for: .milliseconds(5))
+    }
+  }
+
+  // MARK: - Integration tests
+
+  @Test func bothDemosLoadSuccessfullyFromFixtures() throws {
+    let sources = Self.makeSources()
+    #expect(sources.count == 2)
+    #expect(sources[0].scenario.id == "word_wolf")
+    #expect(sources[1].scenario.id == "prisoners_dilemma")
+  }
+
+  @Test func endToEndPlaysAllDemosInOrder() async throws {
+    let sources = Self.makeSources()
+    let viewModel = ReplayViewModel(
+      sources: sources, config: Self.integrationConfig,
+      contentFilter: ContentFilter())
+    viewModel.start()
+    // With `.stopAfterLast + .awaitTransitionSignal`, the VM should
+    // play source 0 (3 turns), rotate to source 1 (2 turns), then
+    // hold at `.playing(1, 4)` (2 lifecycle + 2 turns for source 1).
+    await Self.waitForState(viewModel) { state in
+      if case .playing(let idx, let cursor) = state, idx == 1, cursor >= 4 {
+        return true
+      }
+      return false
+    }
+    if case .playing(let idx, _) = viewModel.state {
+      #expect(idx == 1, "Expected to land on source 1 after rotation")
+    } else {
+      Issue.record("Expected held .playing(1, _), got \(viewModel.state)")
+    }
+    // Source 1's final agentOutputs should only reflect its own
+    // turns — source 0's were cleared by `resetPerDemoState()`.
+    #expect(viewModel.agentOutputs.count == 2)
+    #expect(viewModel.agentOutputs[0].agent == "Alice")
+    #expect(viewModel.agentOutputs[1].agent == "Bob")
+  }
+
+  @Test func contentFilterAppliedToAgentOutputsThroughFullPipeline() async throws {
+    // Single-demo VM: avoids rotation resetting `agentOutputs` while
+    // we're trying to read Bob's turn. Uses the word_wolf fixture
+    // whose second turn contains a blocklist substring ("shit").
+    let yamls = [
+      (name: "ww", contents: Self.wordWolfDemoYAML())
+    ]
+    let sources = BundledDemoReplaySource.loadFromYAMLs(
+      yamls, presetResolver: Self.resolver, config: Self.integrationConfig)
+    let viewModel = ReplayViewModel(
+      sources: sources, config: Self.integrationConfig,
+      contentFilter: ContentFilter())
+    viewModel.start()
+    // Word_wolf has 3 turns. `.stopAfterLast + .awaitTransitionSignal`
+    // + single source means the VM holds at `.playing(0, 5)` (2
+    // lifecycle + 3 turns) without rotating.
+    await Self.waitForState(viewModel) { _ in viewModel.agentOutputs.count == 3 }
+    let bobOutput = viewModel.agentOutputs[1].output.statement ?? ""
+    #expect(!bobOutput.lowercased().contains("shit"))
+    #expect(bobOutput.contains("***"))
+    // Persona names pass through untouched (narrow-scope invariant).
+    #expect(viewModel.agentOutputs[1].agent == "Bob")
+  }
+
+  @Test func downloadCompleteMidPlaybackTransitionsCleanly() async throws {
+    let sources = Self.makeSources()
+    let viewModel = ReplayViewModel(
+      sources: sources, config: Self.integrationConfig,
+      contentFilter: ContentFilter())
+    viewModel.start()
+    // Wait until at least the first source has started publishing,
+    // so we exercise the "transition from mid-playback" path rather
+    // than the "transition from idle" no-op.
+    await Self.waitForState(viewModel) { _ in viewModel.agentOutputs.count >= 1 }
+    viewModel.downloadComplete()
+    #expect(viewModel.state == .transitioning)
+  }
+
+  @Test func pauseAndResumeLandsOnSameCursor() async throws {
+    // Slower pacing so the pause catches mid-sleep — otherwise 100×
+    // collapses the sleep to 0 and we observe a boundary pause that
+    // happens to have remainingDelayMs == 0.
+    let slowConfig = ReplayPlaybackConfig(
+      speedMultiplier: 1.0, turnDelayMs: 150, codePhaseDelayMs: 50,
+      loopBehaviour: .stopAfterLast, onComplete: .awaitTransitionSignal)
+    let yamls = [
+      (name: "ww", contents: Self.wordWolfDemoYAML())
+    ]
+    let sources = BundledDemoReplaySource.loadFromYAMLs(
+      yamls, presetResolver: Self.resolver, config: slowConfig)
+    let viewModel = ReplayViewModel(
+      sources: sources, config: slowConfig, contentFilter: ContentFilter())
+    viewModel.start()
+    // Wait for at least one agent output, then pause.
+    await Self.waitForState(viewModel) { _ in viewModel.agentOutputs.count >= 1 }
+    viewModel.onBackground()
+    guard case .paused(let sourceIndex, let cursor, _) = viewModel.state else {
+      Issue.record("Expected .paused after onBackground, got \(viewModel.state)")
+      return
+    }
+    let pausedOutputs = viewModel.agentOutputs.count
+    viewModel.onForeground()
+    // Resume from same position — state returns to .playing at the
+    // captured (sourceIndex, cursor).
+    if case .playing(let rIdx, let rCursor) = viewModel.state {
+      #expect(rIdx == sourceIndex)
+      #expect(rCursor == cursor)
+    } else {
+      Issue.record("Expected .playing after onForeground, got \(viewModel.state)")
+    }
+    // Playback eventually completes the remaining 2 turns (word_wolf
+    // has 3 total). Final agentOutputs should be 3.
+    await Self.waitForState(viewModel) { _ in viewModel.agentOutputs.count == 3 }
+    #expect(viewModel.agentOutputs.count >= pausedOutputs)
+  }
+}

--- a/Pastura/PasturaTests/App/PresetResolverTests.swift
+++ b/Pastura/PasturaTests/App/PresetResolverTests.swift
@@ -1,0 +1,126 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+@Suite(.timeLimit(.minutes(1)))
+struct PresetResolverTests {
+
+  // MARK: - Fixture
+
+  /// Minimal valid scenario YAML used by tests that don't need to
+  /// exercise the real bundled presets. Matches ``ScenarioLoader``'s
+  /// required fields.
+  private static let fixtureYAML = """
+    id: fx
+    name: Fixture
+    description: ''
+    agents: 2
+    rounds: 1
+    context: ''
+    personas:
+      - name: Alice
+        description: ''
+      - name: Bob
+        description: ''
+    phases:
+      - type: speak_all
+        prompt: say
+        output:
+          statement: string
+    """
+
+  // MARK: - resolvePreset
+
+  @Test func returnsNilForUnknownId() throws {
+    let resolver = BundledPresetResolver(yamlReader: { _ in nil })
+    #expect(try resolver.resolvePreset(id: "nonexistent") == nil)
+  }
+
+  @Test func parsesScenarioAndHashesYAML() throws {
+    let resolver = BundledPresetResolver(yamlReader: { id in
+      id == "fx" ? Self.fixtureYAML : nil
+    })
+    let resolved = try resolver.resolvePreset(id: "fx")
+    #expect(resolved != nil)
+    #expect(resolved?.scenario.id == "fx")
+    #expect(resolved?.scenario.personas.count == 2)
+    // Sanity: SHA is lowercase hex of the expected length (SHA-256 = 64 chars).
+    #expect(resolved?.sha256.count == 64)
+    if let sha = resolved?.sha256 {
+      #expect(sha == sha.lowercased())
+    }
+  }
+
+  @Test func sha256IsDeterministicAcrossCalls() throws {
+    let resolver = BundledPresetResolver(yamlReader: { _ in Self.fixtureYAML })
+    let first = try resolver.resolvePreset(id: "any")
+    let second = try resolver.resolvePreset(id: "any")
+    #expect(first?.sha256 == second?.sha256)
+  }
+
+  @Test func throwsWhenReaderSurfacesDecodeFailure() throws {
+    struct ReaderError: Error, Equatable {}
+    let resolver = BundledPresetResolver(yamlReader: { _ in throw ReaderError() })
+    #expect(throws: ReaderError.self) {
+      _ = try resolver.resolvePreset(id: "any")
+    }
+  }
+
+  @Test func throwsWhenYAMLCannotBeParsedAsScenario() throws {
+    let resolver = BundledPresetResolver(yamlReader: { _ in
+      "not valid scenario yaml"
+    })
+    #expect(throws: (any Error).self) {
+      _ = try resolver.resolvePreset(id: "any")
+    }
+  }
+
+  // MARK: - SHA symmetry with YAMLReplayExporter
+
+  @Test func sha256MatchesYAMLReplayExporterForSamePreset() throws {
+    // Spec §3.3's drift guard relies on the exporter (writing
+    // `preset_ref.yaml_sha256`) and the resolver (re-hashing at load
+    // time) agreeing bit-for-bit. If these drift, every bundled demo
+    // silent-skips in production. This test pins the invariant.
+    let yaml = Self.fixtureYAML
+    let resolver = BundledPresetResolver(yamlReader: { _ in yaml })
+    let resolved = try resolver.resolvePreset(id: "any")
+    let exporterSHA = YAMLReplayExporter.sha256Hex(yaml)
+    #expect(resolved?.sha256 == exporterSHA)
+  }
+
+  @Test func sha256MatchesSharedReplayHashingHelper() throws {
+    // Belt-and-braces: both sides route through `ReplayHashing`, so
+    // hashing the same string twice at the Swift level must also agree.
+    let yaml = Self.fixtureYAML
+    let resolver = BundledPresetResolver(yamlReader: { _ in yaml })
+    let resolved = try resolver.resolvePreset(id: "any")
+    #expect(resolved?.sha256 == ReplayHashing.sha256Hex(yaml))
+  }
+
+  // MARK: - Bundle.main production path (real shipped presets)
+
+  @Test func resolvesRealBundledPresetFromBundleMain() throws {
+    // Word Wolf ships bundled with the app — verify the production
+    // `Bundle.main` path actually finds a preset. If this breaks,
+    // either the bundle layout regressed or Bundle.main resolution
+    // changed in the test host.
+    let resolver = BundledPresetResolver()
+    let resolved = try resolver.resolvePreset(id: "word_wolf")
+    #expect(resolved != nil)
+    #expect(resolved?.scenario.id == "word_wolf")
+    // Exporter round-trip: the sha we compute at load time must equal
+    // what `YAMLReplayExporter.sha256Hex` would emit for the same
+    // bundled YAML string.
+    if let resolved {
+      let bundledURL = Bundle.main.url(forResource: "word_wolf", withExtension: "yaml")
+      if let url = bundledURL {
+        let bundledYAML = try String(contentsOf: url, encoding: .utf8)
+        #expect(resolved.sha256 == YAMLReplayExporter.sha256Hex(bundledYAML))
+      } else {
+        Issue.record("Bundle.main could not locate word_wolf.yaml — bundle layout regression?")
+      }
+    }
+  }
+}

--- a/Pastura/PasturaTests/App/ReplayViewModelTests+ContentFilter.swift
+++ b/Pastura/PasturaTests/App/ReplayViewModelTests+ContentFilter.swift
@@ -1,0 +1,104 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+// ContentFilter scope tests for `ReplayViewModel` — split from
+// `ReplayViewModelTests.swift` to stay under the 250-line
+// `type_body_length` cap. Extension (not new `@Suite`) per
+// `.claude/rules/testing.md`: a second suite would race against the
+// first on shared test-process state.
+extension ReplayViewModelTests {
+
+  // MARK: - ContentFilter narrow scope
+
+  @Test func filtersAgentOutputFieldValues() async throws {
+    let yaml = """
+      schema_version: 1
+      turns:
+        - round: 1
+          phase_index: 0
+          phase_type: speak_all
+          agent: Alice
+          fields: { statement: 'oh shit that hurt' }
+      """
+    let source = try YAMLReplaySource(
+      yaml: yaml, scenario: Self.makeScenario(), config: Self.fastConfig)
+    let viewModel = ReplayViewModel(
+      sources: [source], config: Self.fastConfig, contentFilter: ContentFilter())
+    viewModel.start()
+    await Self.waitForState(viewModel) { _ in viewModel.agentOutputs.count >= 1 }
+    #expect(viewModel.agentOutputs.count == 1)
+    // Default ContentFilter has "shit" in its blocklist — confirm it
+    // was filtered in the rendered output.
+    let statement = viewModel.agentOutputs[0].output.statement ?? ""
+    #expect(!statement.lowercased().contains("shit"))
+    #expect(statement.contains("***"))
+  }
+
+  @Test func doesNotFilterAgentNameThroughElimination() async throws {
+    // Round-trip asserting the VM's filter scope: even when a persona
+    // name is a blocklist literal, the `.elimination.agent` field must
+    // pass through untouched. We can't observe `.elimination` on the
+    // VM's `agentOutputs` directly (that event goes through `apply()`
+    // into a no-op branch in PR1) — instead we verify that the
+    // scenario's personas stay referable by name in `agentOutputs`
+    // after filtering. Concretely: a persona named "Shit" publishing
+    // a `.agentOutput` should have `entry.agent == "Shit"` — only
+    // `entry.output.fields.values` is filtered.
+    let scenarioWithColliderYAML = """
+      id: ts
+      name: Test
+      description: ''
+      agents: 2
+      rounds: 1
+      context: ''
+      personas:
+        - name: Shit
+          description: ''
+        - name: Alice
+          description: ''
+      phases:
+        - type: speak_all
+          prompt: say
+          output:
+            statement: string
+      """
+    let scenario = try ScenarioLoader().load(yaml: scenarioWithColliderYAML)
+    let yaml = """
+      schema_version: 1
+      turns:
+        - round: 1
+          phase_index: 0
+          phase_type: speak_all
+          agent: Shit
+          fields: { statement: 'clean content' }
+      """
+    let source = try YAMLReplaySource(
+      yaml: yaml, scenario: scenario, config: Self.fastConfig)
+    let filter = ContentFilter(blockedPatterns: ["shit"], replacement: "XXX")
+    let viewModel = ReplayViewModel(
+      sources: [source], config: Self.fastConfig, contentFilter: filter)
+    viewModel.start()
+    await Self.waitForState(viewModel) { _ in viewModel.agentOutputs.count >= 1 }
+    // Persona name survives; only `fields.*` values route through the
+    // filter. "clean content" has no blocked substring so it stays
+    // verbatim.
+    #expect(viewModel.agentOutputs[0].agent == "Shit")
+    #expect(viewModel.agentOutputs[0].output.statement == "clean content")
+  }
+
+  // MARK: - Persistence absence (spec §4.2)
+
+  @Test func constructorAcceptsNoPersistenceParameters() throws {
+    // This test's mere existence is the contract: the public init
+    // signature is `(sources:config:contentFilter:)` — no repository,
+    // no DB writer, no EventStore-style sink. If a future change tries
+    // to add one, this file will fail to compile in an obvious place,
+    // prompting a spec §4.2 revisit.
+    let source = try Self.makeSource()
+    _ = ReplayViewModel(
+      sources: [source], config: Self.fastConfig,
+      contentFilter: ContentFilter())
+  }
+}

--- a/Pastura/PasturaTests/App/ReplayViewModelTests+Rotation.swift
+++ b/Pastura/PasturaTests/App/ReplayViewModelTests+Rotation.swift
@@ -1,0 +1,206 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+// Source-rotation + loop-behaviour tests for `ReplayViewModel`.
+// Sibling-file extension per `.claude/rules/testing.md`.
+extension ReplayViewModelTests {
+
+  // MARK: - Fixtures
+
+  fileprivate static func makeTwoSources() throws -> [YAMLReplaySource] {
+    let yaml1 = """
+      schema_version: 1
+      turns:
+        - round: 1
+          phase_index: 0
+          phase_type: speak_all
+          agent: Alice
+          fields: { statement: 'demo 1 alice' }
+      """
+    let yaml2 = """
+      schema_version: 1
+      turns:
+        - round: 1
+          phase_index: 0
+          phase_type: speak_all
+          agent: Bob
+          fields: { statement: 'demo 2 bob' }
+      """
+    let scenario = try makeScenario()
+    return [
+      try YAMLReplaySource(yaml: yaml1, scenario: scenario, config: fastConfig),
+      try YAMLReplaySource(yaml: yaml2, scenario: scenario, config: fastConfig)
+    ]
+  }
+
+  /// Rotation-observable pacing: 150 ms per turn event at 1× speed.
+  /// Each source plays in ~150 ms, so between-source observation
+  /// windows are comfortably larger than the test poll interval
+  /// (5 ms). Faster configs (see `fastConfig` in the main suite file)
+  /// collapse delays to 0 ms + `Task.yield()` which makes rotation
+  /// cycle sub-ms — rotation assertions race against the poll loop.
+  fileprivate static let stopConfig = ReplayPlaybackConfig(
+    speedMultiplier: 1.0,
+    turnDelayMs: 150,
+    codePhaseDelayMs: 50,
+    loopBehaviour: .stopAfterLast,
+    onComplete: .stopPlayback)
+
+  fileprivate static let holdConfig = ReplayPlaybackConfig(
+    speedMultiplier: 1.0,
+    turnDelayMs: 150,
+    codePhaseDelayMs: 50,
+    loopBehaviour: .stopAfterLast,
+    onComplete: .awaitTransitionSignal)
+
+  fileprivate static let loopConfig = ReplayPlaybackConfig(
+    speedMultiplier: 1.0,
+    turnDelayMs: 150,
+    codePhaseDelayMs: 50,
+    loopBehaviour: .loop,
+    onComplete: .awaitTransitionSignal)
+
+  // MARK: - Source rotation
+
+  @Test func rotatesToNextSourceOnStreamEndWithLoop() async throws {
+    let sources = try Self.makeTwoSources()
+    let viewModel = ReplayViewModel(
+      sources: sources, config: Self.loopConfig,
+      contentFilter: ContentFilter())
+    viewModel.start()
+    // Wait until the VM has rotated from source 0 to source 1.
+    await Self.waitForState(viewModel) { state in
+      if case .playing(let idx, _) = state { return idx >= 1 }
+      return false
+    }
+    if case .playing(let idx, _) = viewModel.state {
+      #expect(idx == 1)
+    } else {
+      Issue.record("Expected .playing on source 1 after rotation, got \(viewModel.state)")
+    }
+  }
+
+  @Test func rotationClearsPerDemoObservableState() async throws {
+    // Uses `holdConfig` (stopAfterLast + awaitTransitionSignal) rather
+    // than `loopConfig`, so the test observes a deterministic
+    // source-0 → source-1 transition without racing against loop
+    // wraparound. After rotation completes the VM holds at
+    // `.playing(1, 3)` — agentOutputs is source 1's only.
+    let sources = try Self.makeTwoSources()
+    let viewModel = ReplayViewModel(
+      sources: sources, config: Self.holdConfig,
+      contentFilter: ContentFilter())
+    viewModel.start()
+    // Wait until the VM has hit source 1's final cursor (3 events =
+    // 2 lifecycle + 1 turn). At that point rotation has happened and
+    // source 1's turn has published.
+    await Self.waitForState(viewModel, timeout: .seconds(5)) { state in
+      if case .playing(let idx, let cursor) = state, idx == 1, cursor >= 3 {
+        return true
+      }
+      return false
+    }
+    // agentOutputs must be source 1's only — rotation's
+    // `resetPerDemoState()` cleared source 0's entry.
+    #expect(viewModel.agentOutputs.count == 1)
+    #expect(viewModel.agentOutputs[0].output.statement == "demo 2 bob")
+  }
+
+  @Test func loopWrapsAroundAfterLastSource() async throws {
+    // Two sources, .loop config. The VM should visit idx 0 → 1 → 0
+    // (wrap-around) within the wall-clock budget. We track the
+    // source-index progression to distinguish the initial play of
+    // source 0 from the wrap-around play of source 0.
+    let sources = try Self.makeTwoSources()
+    let viewModel = ReplayViewModel(
+      sources: sources, config: Self.loopConfig,
+      contentFilter: ContentFilter())
+    viewModel.start()
+    // Step 1: wait for the VM to reach source 1 (end of first cycle
+    // through source 0).
+    await Self.waitForState(viewModel, timeout: .seconds(5)) { state in
+      if case .playing(let idx, _) = state { return idx >= 1 }
+      return false
+    }
+    // Step 2: wait for wrap-around — the VM must leave source 1 and
+    // return to source 0. Watch for the transition itself (idx goes
+    // from 1 back to 0) rather than a content match, which can race
+    // against the loop cycle.
+    var sawSource1 = false
+    await Self.waitForState(viewModel, timeout: .seconds(5)) { state in
+      guard case .playing(let idx, _) = state else { return false }
+      if idx == 1 { sawSource1 = true }
+      return sawSource1 && idx == 0
+    }
+    if case .playing(let idx, _) = viewModel.state {
+      #expect(idx == 0, "wrap-around to source 0 expected, got idx=\(idx)")
+    } else {
+      Issue.record("Expected wrap-around to source 0, got \(viewModel.state)")
+    }
+  }
+
+  // MARK: - stopAfterLast terminal states
+
+  @Test func stopAfterLastWithStopPlaybackReturnsToIdle() async throws {
+    let sources = try Self.makeTwoSources()
+    let viewModel = ReplayViewModel(
+      sources: sources, config: Self.stopConfig,
+      contentFilter: ContentFilter())
+    viewModel.start()
+    // Wait for terminal .idle state.
+    await Self.waitForState(viewModel, timeout: .seconds(5)) { state in
+      state == .idle
+    }
+    #expect(viewModel.state == .idle)
+  }
+
+  @Test func stopAfterLastWithAwaitTransitionHoldsUntilDownloadComplete() async throws {
+    let sources = try Self.makeTwoSources()
+    let viewModel = ReplayViewModel(
+      sources: sources, config: Self.holdConfig,
+      contentFilter: ContentFilter())
+    viewModel.start()
+    // Wait for the VM to reach the last source's plan-end state.
+    // With 2 sources × 1 turn + 2 lifecycle = 3 events per source,
+    // the final resting cursor on the last source is 3.
+    await Self.waitForState(viewModel, timeout: .seconds(5)) { state in
+      if case .playing(let idx, let cursor) = state, idx == 1, cursor >= 3 {
+        return true
+      }
+      return false
+    }
+    if case .playing(let idx, _) = viewModel.state {
+      #expect(idx == 1)
+    } else {
+      Issue.record("Expected .playing held on last source, got \(viewModel.state)")
+    }
+    // Now the transition signal arrives — VM moves to .transitioning.
+    viewModel.downloadComplete()
+    #expect(viewModel.state == .transitioning)
+  }
+
+  // MARK: - Infinite loop guarded by downloadComplete
+
+  @Test func loopConfigDoesNotTerminateWithoutDownloadComplete() async throws {
+    let sources = try Self.makeTwoSources()
+    let viewModel = ReplayViewModel(
+      sources: sources, config: Self.loopConfig,
+      contentFilter: ContentFilter())
+    viewModel.start()
+    // Give the loop time to rotate a few times.
+    try await Task.sleep(for: .milliseconds(300))
+    // Must still be playing — loop config does not surface a
+    // terminal state without an external signal.
+    switch viewModel.state {
+    case .playing:
+      break  // expected
+    default:
+      Issue.record(
+        "Loop config must not terminate without downloadComplete, got \(viewModel.state)")
+    }
+    viewModel.downloadComplete()
+    #expect(viewModel.state == .transitioning)
+  }
+}

--- a/Pastura/PasturaTests/App/ReplayViewModelTests.swift
+++ b/Pastura/PasturaTests/App/ReplayViewModelTests.swift
@@ -64,12 +64,18 @@ struct ReplayViewModelTests {
   /// Fast pacing: 100× speed collapses the nominal 1200 ms turn delay
   /// to ~12 ms — tests still observe the state machine transitions
   /// without paying human-scale wait times.
+  ///
+  /// Uses `.stopAfterLast + .awaitTransitionSignal` so the VM HOLDS at
+  /// `.playing(lastIndex, plan.count)` after the single source's plan
+  /// is exhausted — otherwise most tests below would race against
+  /// premature termination. Rotation-specific tests override with
+  /// their own config (see `ReplayViewModelTests+Rotation.swift`).
   static let fastConfig = ReplayPlaybackConfig(
     speedMultiplier: 100.0,
     turnDelayMs: 20,
     codePhaseDelayMs: 5,
     loopBehaviour: .stopAfterLast,
-    onComplete: .stopPlayback)
+    onComplete: .awaitTransitionSignal)
 
   static func makeSource(yaml: String = threeTurnYAML) throws -> YAMLReplaySource {
     try YAMLReplaySource(yaml: yaml, scenario: makeScenario(), config: fastConfig)

--- a/Pastura/PasturaTests/App/ReplayViewModelTests.swift
+++ b/Pastura/PasturaTests/App/ReplayViewModelTests.swift
@@ -1,0 +1,262 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+/// Swift Testing suite for ``ReplayViewModel``.
+///
+/// `.serialized` per `.claude/rules/testing.md` — the VM spawns a
+/// `Task` + consumes `AsyncStream`-style async work, so parallel
+/// execution with other VM-spawning tests would risk cleanup races on
+/// the shared test process.
+@Suite("ReplayViewModel", .serialized, .timeLimit(.minutes(1)))
+@MainActor
+struct ReplayViewModelTests {
+
+  // MARK: - Fixtures
+
+  static let scenarioYAML = """
+    id: ts
+    name: Test
+    description: ''
+    agents: 2
+    rounds: 1
+    context: ''
+    personas:
+      - name: Alice
+        description: ''
+      - name: Bob
+        description: ''
+    phases:
+      - type: speak_all
+        prompt: say
+        output:
+          statement: string
+    """
+
+  /// Three-turn demo: Alice speaks, Bob speaks, Alice speaks again.
+  /// Plus lifecycle synthesis → 5 total PacedEvents (roundStarted,
+  /// phaseStarted, 3 turns).
+  static let threeTurnYAML = """
+    schema_version: 1
+    turns:
+      - round: 1
+        phase_index: 0
+        phase_type: speak_all
+        agent: Alice
+        fields: { statement: 'hello' }
+      - round: 1
+        phase_index: 0
+        phase_type: speak_all
+        agent: Bob
+        fields: { statement: 'hi there' }
+      - round: 1
+        phase_index: 0
+        phase_type: speak_all
+        agent: Alice
+        fields: { statement: 'nice to meet you' }
+    """
+
+  static func makeScenario() throws -> Scenario {
+    try ScenarioLoader().load(yaml: scenarioYAML)
+  }
+
+  /// Fast pacing: 100× speed collapses the nominal 1200 ms turn delay
+  /// to ~12 ms — tests still observe the state machine transitions
+  /// without paying human-scale wait times.
+  static let fastConfig = ReplayPlaybackConfig(
+    speedMultiplier: 100.0,
+    turnDelayMs: 20,
+    codePhaseDelayMs: 5,
+    loopBehaviour: .stopAfterLast,
+    onComplete: .stopPlayback)
+
+  static func makeSource(yaml: String = threeTurnYAML) throws -> YAMLReplaySource {
+    try YAMLReplaySource(yaml: yaml, scenario: makeScenario(), config: fastConfig)
+  }
+
+  static func makeVM(yaml: String = threeTurnYAML) throws -> ReplayViewModel {
+    let source = try makeSource(yaml: yaml)
+    return ReplayViewModel(
+      sources: [source], config: fastConfig, contentFilter: ContentFilter())
+  }
+
+  /// Polls `state` on the main actor until `predicate` is true or the
+  /// timeout elapses. Returns when the predicate matches.
+  static func waitForState(
+    _ viewModel: ReplayViewModel, timeout: Duration = .seconds(2),
+    predicate: @MainActor (ReplayViewModel.State) -> Bool
+  ) async {
+    let deadline = ContinuousClock.now.advanced(by: timeout)
+    while ContinuousClock.now < deadline {
+      if predicate(viewModel.state) { return }
+      try? await Task.sleep(for: .milliseconds(5))
+    }
+  }
+
+  // MARK: - Initial state
+
+  @Test func initialStateIsIdle() throws {
+    let viewModel = try Self.makeVM()
+    #expect(viewModel.state == .idle)
+    #expect(viewModel.currentPhase == nil)
+    #expect(viewModel.currentRound == nil)
+    #expect(viewModel.currentTotalRounds == nil)
+    #expect(viewModel.agentOutputs.isEmpty)
+  }
+
+  // MARK: - start() and basic playback
+
+  @Test func startTransitionsFromIdleToPlaying() throws {
+    let viewModel = try Self.makeVM()
+    viewModel.start()
+    // The state machine moves synchronously to `.playing(0, 0)` before
+    // the first sleep; subsequent `playing(..., N)` steps happen as
+    // the playback task runs.
+    if case .playing(let idx, _) = viewModel.state {
+      #expect(idx == 0)
+    } else {
+      Issue.record("Expected .playing immediately after start(), got \(viewModel.state)")
+    }
+  }
+
+  @Test func startIsNoOpWhenAlreadyPlaying() throws {
+    let viewModel = try Self.makeVM()
+    viewModel.start()
+    let firstState = viewModel.state
+    viewModel.start()
+    #expect(viewModel.state == firstState)
+  }
+
+  @Test func playbackEventuallyReachesPlanEnd() async throws {
+    let viewModel = try Self.makeVM()
+    viewModel.start()
+    // 3 turns + 2 lifecycle = 5 events in the plan.
+    await Self.waitForState(viewModel) { state in
+      if case .playing(_, let cursor) = state { return cursor >= 5 }
+      return false
+    }
+    if case .playing(_, let cursor) = viewModel.state {
+      #expect(cursor == 5)
+    } else {
+      Issue.record("Expected .playing at plan end, got \(viewModel.state)")
+    }
+  }
+
+  @Test func agentOutputsAccumulateInPublishOrder() async throws {
+    let viewModel = try Self.makeVM()
+    viewModel.start()
+    await Self.waitForState(viewModel) { _ in viewModel.agentOutputs.count == 3 }
+    #expect(viewModel.agentOutputs.count == 3)
+    #expect(viewModel.agentOutputs[0].agent == "Alice")
+    #expect(viewModel.agentOutputs[1].agent == "Bob")
+    #expect(viewModel.agentOutputs[2].agent == "Alice")
+    #expect(viewModel.agentOutputs[0].output.statement == "hello")
+  }
+
+  @Test func lifecycleEventsUpdateObservableState() async throws {
+    let viewModel = try Self.makeVM()
+    viewModel.start()
+    await Self.waitForState(viewModel) { _ in viewModel.currentPhase != nil }
+    #expect(viewModel.currentPhase == .speakAll)
+    #expect(viewModel.currentRound == 1)
+    // Scenario yaml declares `rounds: 1`.
+    #expect(viewModel.currentTotalRounds == 1)
+  }
+
+  // MARK: - onBackground / onForeground
+
+  @Test func onBackgroundTransitionsPlayingToPaused() async throws {
+    // Slow pacing (1× speed) so we can catch the VM mid-sleep. The
+    // turnDelayMs=20ms scaled by 1× = 20ms per event. Calling
+    // onBackground immediately after start should catch the first
+    // sleep in progress.
+    let slowConfig = ReplayPlaybackConfig(
+      speedMultiplier: 1.0, turnDelayMs: 200, codePhaseDelayMs: 50,
+      loopBehaviour: .stopAfterLast, onComplete: .stopPlayback)
+    let source = try YAMLReplaySource(
+      yaml: Self.threeTurnYAML, scenario: Self.makeScenario(),
+      config: slowConfig)
+    let viewModel = ReplayViewModel(sources: [source], config: slowConfig)
+    viewModel.start()
+    // Sleep briefly so the playback task begins its first sleep.
+    try await Task.sleep(for: .milliseconds(20))
+    viewModel.onBackground()
+    if case .paused(let idx, let cursor, let remaining) = viewModel.state {
+      #expect(idx == 0)
+      // Cursor is 0 (we haven't published the first roundStarted yet
+      // because lifecycle delay is 0 — actually 0-delay "sleeps"
+      // complete immediately, so cursor may have advanced past the 2
+      // lifecycle events by the time we grab state). Just assert the
+      // state shape.
+      #expect(cursor >= 0)
+      #expect(remaining >= 0)
+    } else {
+      Issue.record("Expected .paused, got \(viewModel.state)")
+    }
+  }
+
+  @Test func onBackgroundFromIdleIsNoOp() throws {
+    let viewModel = try Self.makeVM()
+    viewModel.onBackground()
+    #expect(viewModel.state == .idle)
+  }
+
+  @Test func onForegroundResumesFromPausedPosition() async throws {
+    let viewModel = try Self.makeVM()
+    viewModel.start()
+    // Wait for some progress.
+    await Self.waitForState(viewModel) { _ in viewModel.agentOutputs.count >= 1 }
+    viewModel.onBackground()
+    guard case .paused(let idx, let cursor, _) = viewModel.state else {
+      Issue.record("Expected .paused after onBackground, got \(viewModel.state)")
+      return
+    }
+    viewModel.onForeground()
+    // Resume moves back to .playing at the same (sourceIndex, cursor).
+    if case .playing(let rIdx, let rCursor) = viewModel.state {
+      #expect(rIdx == idx)
+      #expect(rCursor == cursor)
+    } else {
+      Issue.record("Expected .playing after onForeground, got \(viewModel.state)")
+    }
+    // Playback eventually reaches the plan end.
+    await Self.waitForState(viewModel) { state in
+      if case .playing(_, let cursor) = state { return cursor >= 5 }
+      return false
+    }
+    #expect(viewModel.agentOutputs.count == 3)
+  }
+
+  @Test func onForegroundFromIdleIsNoOp() throws {
+    let viewModel = try Self.makeVM()
+    viewModel.onForeground()
+    #expect(viewModel.state == .idle)
+  }
+
+  // MARK: - downloadComplete()
+
+  @Test func downloadCompleteFromPlayingTransitions() async throws {
+    let viewModel = try Self.makeVM()
+    viewModel.start()
+    await Self.waitForState(viewModel) { _ in viewModel.agentOutputs.count >= 1 }
+    viewModel.downloadComplete()
+    #expect(viewModel.state == .transitioning)
+  }
+
+  @Test func downloadCompleteFromPausedTransitions() async throws {
+    let viewModel = try Self.makeVM()
+    viewModel.start()
+    await Self.waitForState(viewModel) { _ in viewModel.agentOutputs.count >= 1 }
+    viewModel.onBackground()
+    #expect({ if case .paused = viewModel.state { return true } else { return false } }())
+    viewModel.downloadComplete()
+    #expect(viewModel.state == .transitioning)
+  }
+
+  @Test func downloadCompleteFromIdleIsNoOp() throws {
+    let viewModel = try Self.makeVM()
+    viewModel.downloadComplete()
+    #expect(viewModel.state == .idle)
+  }
+}

--- a/Pastura/PasturaTests/App/YAMLReplaySourceTests+PlannedEvents.swift
+++ b/Pastura/PasturaTests/App/YAMLReplaySourceTests+PlannedEvents.swift
@@ -1,0 +1,366 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+// Tests for ``YAMLReplaySource.plannedEvents()`` — the VM-driven-pacing API
+// introduced in Issue #169 (C-track PR1) alongside synthesised
+// `.roundStarted` / `.phaseStarted` lifecycle events.
+//
+// Split from `YAMLReplaySourceTests.swift` to stay under the 400-line
+// `file_length` cap. Extension + sibling-file pattern — NOT a new
+// `@Suite` — because a second suite would race against the original on
+// shared state (see `.claude/rules/testing.md`).
+extension YAMLReplaySourceTests {
+
+  // MARK: - Multi-round / multi-phase fixture
+
+  /// 2-round, 2-phase scenario: `speak_all` (LLM phase) then `score_calc`
+  /// (code phase). Used for lifecycle synthesis + chronological merge
+  /// assertions.
+  fileprivate static let twoRoundScenarioYAML = """
+    id: ts2
+    name: Test2
+    description: ''
+    agents: 2
+    rounds: 2
+    context: ''
+    personas:
+      - name: Alice
+        description: ''
+      - name: Bob
+        description: ''
+    phases:
+      - type: speak_all
+        prompt: say
+        output:
+          statement: string
+      - type: score_calc
+        rule: constant
+        value: 1
+    """
+
+  fileprivate func makeTwoRoundScenario() throws -> Scenario {
+    try ScenarioLoader().load(yaml: Self.twoRoundScenarioYAML)
+  }
+
+  // MARK: - plannedEvents() — basic shape
+
+  @Test func plannedEventsReturnsTurnAndCodePhaseKinds() throws {
+    let yaml = """
+      schema_version: 1
+      turns:
+        - round: 1
+          phase_index: 0
+          phase_type: speak_all
+          agent: Alice
+          fields: { statement: 'hi' }
+      code_phase_events:
+        - round: 1
+          phase_index: 1
+          phase_type: score_calc
+          summary: 'tick'
+          payload:
+            kind: scoreUpdate
+            scores: { Alice: 1 }
+      """
+    let source = try YAMLReplaySource(
+      yaml: yaml, scenario: makeTwoRoundScenario(), config: fastConfig)
+
+    let paced = source.plannedEvents()
+
+    // Expected chronological order with lifecycle synthesis:
+    //   [roundStarted(1), phaseStarted(speak_all, [0]), agentOutput(Alice),
+    //    phaseStarted(score_calc, [1]), scoreUpdate]
+    #expect(paced.count == 5)
+    #expect(paced[0].kind == .lifecycle)
+    #expect(paced[1].kind == .lifecycle)
+    #expect(paced[2].kind == .turn)
+    #expect(paced[3].kind == .lifecycle)
+    #expect(paced[4].kind == .codePhase)
+  }
+
+  // MARK: - Lifecycle synthesis: .roundStarted
+
+  @Test func plannedEventsSynthesizesRoundStartedOnFirstEvent() throws {
+    let yaml = """
+      schema_version: 1
+      turns:
+        - round: 1
+          phase_index: 0
+          phase_type: speak_all
+          agent: Alice
+          fields: { statement: 'hi' }
+      """
+    let source = try YAMLReplaySource(
+      yaml: yaml, scenario: makeScenario(), config: fastConfig)
+
+    let paced = source.plannedEvents()
+
+    #expect(paced.count >= 1)
+    if case .roundStarted(let round, let total) = paced[0].event {
+      #expect(round == 1)
+      // `totalRounds` comes from `scenario.rounds`, not the YAML — the
+      // YAML has no `total_rounds` field.
+      #expect(total == 1)
+      #expect(paced[0].kind == .lifecycle)
+    } else {
+      Issue.record("Expected first event to be synthesised .roundStarted, got \(paced[0].event)")
+    }
+  }
+
+  @Test func plannedEventsSynthesizesRoundStartedOnRoundTransition() throws {
+    let yaml = """
+      schema_version: 1
+      turns:
+        - round: 1
+          phase_index: 0
+          phase_type: speak_all
+          agent: Alice
+          fields: { statement: 'r1' }
+        - round: 2
+          phase_index: 0
+          phase_type: speak_all
+          agent: Alice
+          fields: { statement: 'r2' }
+      """
+    let source = try YAMLReplaySource(
+      yaml: yaml, scenario: makeTwoRoundScenario(), config: fastConfig)
+
+    let paced = source.plannedEvents()
+
+    // Expected:
+    //   [roundStarted(1,2), phaseStarted(speak_all,[0]), agentOutput(r1),
+    //    roundStarted(2,2), phaseStarted(speak_all,[0]), agentOutput(r2)]
+    #expect(paced.count == 6)
+    if case .roundStarted(let round, _) = paced[3].event {
+      #expect(round == 2)
+      #expect(paced[3].kind == .lifecycle)
+    } else {
+      Issue.record("Expected .roundStarted(2) at index 3, got \(paced[3].event)")
+    }
+  }
+
+  // MARK: - Lifecycle synthesis: .phaseStarted
+
+  @Test func plannedEventsSynthesizesPhaseStartedOnPhaseTransition() throws {
+    let yaml = """
+      schema_version: 1
+      turns:
+        - round: 1
+          phase_index: 0
+          phase_type: speak_all
+          agent: Alice
+          fields: { statement: 'hi' }
+      code_phase_events:
+        - round: 1
+          phase_index: 1
+          phase_type: score_calc
+          summary: 'tick'
+          payload:
+            kind: scoreUpdate
+            scores: { Alice: 1 }
+      """
+    let source = try YAMLReplaySource(
+      yaml: yaml, scenario: makeTwoRoundScenario(), config: fastConfig)
+
+    let paced = source.plannedEvents()
+
+    // phaseStarted(speak_all, [0]) precedes the agentOutput;
+    // phaseStarted(score_calc, [1]) precedes the scoreUpdate.
+    if case .phaseStarted(let phaseType, let path) = paced[1].event {
+      #expect(phaseType == .speakAll)
+      #expect(path == [0])
+      #expect(paced[1].kind == .lifecycle)
+    } else {
+      Issue.record("Expected .phaseStarted(speakAll,[0]) at index 1, got \(paced[1].event)")
+    }
+    if case .phaseStarted(let phaseType, let path) = paced[3].event {
+      #expect(phaseType == .scoreCalc)
+      #expect(path == [1])
+      #expect(paced[3].kind == .lifecycle)
+    } else {
+      Issue.record("Expected .phaseStarted(scoreCalc,[1]) at index 3, got \(paced[3].event)")
+    }
+  }
+
+  // MARK: - Explicit exclusions (do NOT synthesise)
+
+  @Test func plannedEventsDoesNotSynthesizeRoundCompleted() throws {
+    // Two rounds → if `.roundCompleted` were synthesised we'd see one
+    // after each round's last event. The YAML schema has no slot for
+    // per-round `scores` snapshots (spec §3.2), so synthesising it from
+    // thin air would require heuristic score-accumulation which is worse
+    // than absence.
+    let yaml = """
+      schema_version: 1
+      turns:
+        - round: 1
+          phase_index: 0
+          phase_type: speak_all
+          agent: Alice
+          fields: { statement: 'r1' }
+        - round: 2
+          phase_index: 0
+          phase_type: speak_all
+          agent: Alice
+          fields: { statement: 'r2' }
+      """
+    let source = try YAMLReplaySource(
+      yaml: yaml, scenario: makeTwoRoundScenario(), config: fastConfig)
+
+    for paced in source.plannedEvents() {
+      if case .roundCompleted = paced.event {
+        Issue.record(
+          "plannedEvents() must NOT synthesise .roundCompleted (no per-round score slot in schema §3.2). Got \(paced.event)"
+        )
+      }
+    }
+  }
+
+  @Test func plannedEventsDoesNotSynthesizeSimulationCompleted() throws {
+    let yaml = """
+      schema_version: 1
+      turns:
+        - round: 1
+          phase_index: 0
+          phase_type: speak_all
+          agent: Alice
+          fields: { statement: 'hi' }
+      """
+    let source = try YAMLReplaySource(
+      yaml: yaml, scenario: makeScenario(), config: fastConfig)
+
+    for paced in source.plannedEvents() {
+      if case .simulationCompleted = paced.event {
+        Issue.record(
+          "plannedEvents() must NOT synthesise .simulationCompleted (array-end signals completion)."
+        )
+      }
+    }
+  }
+
+  // MARK: - Memoisation invariant
+
+  @Test func plannedEventsIsStableAcrossCalls() throws {
+    let yaml = """
+      schema_version: 1
+      turns:
+        - round: 1
+          phase_index: 0
+          phase_type: speak_all
+          agent: Alice
+          fields: { statement: 'hi' }
+        - round: 1
+          phase_index: 0
+          phase_type: speak_all
+          agent: Bob
+          fields: { statement: 'yo' }
+      """
+    let source = try YAMLReplaySource(
+      yaml: yaml, scenario: makeScenario(), config: fastConfig)
+
+    let first = source.plannedEvents()
+    let second = source.plannedEvents()
+
+    // Stability is load-bearing: `ReplayViewModel.State.paused` stores an
+    // `eventCursor` index into this array; two calls must produce an
+    // identical indexing or resume-from-position breaks silently.
+    #expect(first == second)
+  }
+
+  // MARK: - Chronological merge
+
+  @Test func plannedEventsMergesTurnsAndCodeEventsChronologically() throws {
+    // Intentionally orders YAML sections NON-chronologically: round 2
+    // turns come before round 1's code event in the document, but the
+    // planner must merge them by (round, phase_index).
+    let yaml = """
+      schema_version: 1
+      turns:
+        - round: 1
+          phase_index: 0
+          phase_type: speak_all
+          agent: Alice
+          fields: { statement: 'r1' }
+        - round: 2
+          phase_index: 0
+          phase_type: speak_all
+          agent: Alice
+          fields: { statement: 'r2' }
+      code_phase_events:
+        - round: 1
+          phase_index: 1
+          phase_type: score_calc
+          summary: 'r1 score'
+          payload:
+            kind: scoreUpdate
+            scores: { Alice: 1 }
+        - round: 2
+          phase_index: 1
+          phase_type: score_calc
+          summary: 'r2 score'
+          payload:
+            kind: scoreUpdate
+            scores: { Alice: 2 }
+      """
+    let source = try YAMLReplaySource(
+      yaml: yaml, scenario: makeTwoRoundScenario(), config: fastConfig)
+
+    let paced = source.plannedEvents()
+
+    // Expected chronological sequence:
+    //   round 1: roundStarted(1), phaseStarted(speak_all,[0]),
+    //            agentOutput(r1), phaseStarted(score_calc,[1]),
+    //            scoreUpdate(r1)
+    //   round 2: roundStarted(2), phaseStarted(speak_all,[0]),
+    //            agentOutput(r2), phaseStarted(score_calc,[1]),
+    //            scoreUpdate(r2)
+    #expect(paced.count == 10)
+
+    // Verify round 1's scoreUpdate comes BEFORE round 2's agentOutput.
+    var sawR1Score = false
+    var sawR2Turn = false
+    for paced in paced {
+      if case .scoreUpdate(let scores) = paced.event, scores["Alice"] == 1 {
+        sawR1Score = true
+      }
+      if case .agentOutput(_, let output, _) = paced.event,
+        output.statement == "r2" {
+        #expect(sawR1Score, "r1 scoreUpdate must come before r2 agentOutput")
+        sawR2Turn = true
+      }
+    }
+    #expect(sawR2Turn)
+  }
+
+  // MARK: - events() backward compatibility
+
+  @Test func eventsStreamDoesNotEmitLifecycleEvents() async throws {
+    // The existing streaming `events()` API must keep its E1 contract:
+    // only the user-recorded events in their declared order, no
+    // synthesised lifecycle markers. `plannedEvents()` is the API for
+    // lifecycle-aware consumers.
+    let yaml = """
+      schema_version: 1
+      turns:
+        - round: 1
+          phase_index: 0
+          phase_type: speak_all
+          agent: Alice
+          fields: { statement: 'hi' }
+      """
+    let source = try YAMLReplaySource(
+      yaml: yaml, scenario: makeScenario(), config: fastConfig)
+
+    var collected: [SimulationEvent] = []
+    for await event in source.events() { collected.append(event) }
+
+    #expect(collected.count == 1)
+    if case .agentOutput = collected[0] {
+      // expected
+    } else {
+      Issue.record("Expected .agentOutput from events(), got \(collected[0])")
+    }
+  }
+}

--- a/Pastura/PasturaTests/App/YAMLReplaySourceTests.swift
+++ b/Pastura/PasturaTests/App/YAMLReplaySourceTests.swift
@@ -8,7 +8,12 @@ struct YAMLReplaySourceTests {
 
   // MARK: - Fixture scenario
 
-  private static let scenarioYAML = """
+  // Access modifier: `internal` (default) — sibling-file extensions
+  // cannot see `private` members (see `.claude/rules/testing.md`).
+  // This suite's fixture helpers are reused by
+  // `YAMLReplaySourceTests+PlannedEvents.swift`.
+
+  static let scenarioYAML = """
     id: ts
     name: Test
     description: ''
@@ -27,13 +32,13 @@ struct YAMLReplaySourceTests {
           statement: string
     """
 
-  private func makeScenario() throws -> Scenario {
+  func makeScenario() throws -> Scenario {
     try ScenarioLoader().load(yaml: Self.scenarioYAML)
   }
 
   /// Speed up replay for tests — 100× means a 1200 ms nominal delay
   /// finishes in 12 ms, keeping the suite well under the 1-minute cap.
-  private var fastConfig: ReplayPlaybackConfig {
+  var fastConfig: ReplayPlaybackConfig {
     ReplayPlaybackConfig(
       speedMultiplier: 100.0,
       loopBehaviour: .stopAfterLast,


### PR DESCRIPTION
## Summary

PR1 of 3 for #169 — DL-time demo replay screen's VM + Source primitives only.

- `ReplayViewModel` — `@Observable @MainActor` state machine (idle / playing / paused / transitioning) with VM-owned pacing honouring ADR-007 §3.4 resume-from-position (`remainingDelayMs` captured via `ContinuousClock`). Persistence-free init (spec §4.2).
- `BundledDemoReplaySource` — bundle wrapper enumerating `Resources/DemoReplays/*.yaml`, verifying SHA via `PresetResolver`, silent-skip per spec §3.3 / §3.5.
- `PresetResolver` + `BundledPresetResolver` — preset-only id resolution (spec §7.2, no gallery shadowing — reads only `Bundle.main`).
- `ReplayHashing.sha256Hex` — shared helper; `YAMLReplayExporter` now delegates so the drift guard (exporter writes ↔ resolver re-hashes) is bit-for-bit symmetric.
- `YAMLReplaySource.plannedEvents()` — new API widening. Synthesises `.roundStarted` / `.phaseStarted` from YAML `round` / `phase_index` metadata (previously dropped); `PacedEvent.Kind = .turn / .codePhase / .lifecycle`. Existing `events()` contract unchanged.

**Out of PR1 scope** (follow-up PRs):
- Host view (`DemoReplayHostView`) + SwiftUI components → PR2
- `PasturaApp.swift` 1-line diff per ADR-007 §5.1 → PR3
- Bundle populate + CI drift guard → #170 (D track)

## Review pedigree

2 rounds of critic pre-impl (2 Critical + 6 Warning → all addressed). Code-reviewer post-impl: PASS.

## Test plan (verified locally)

- [x] `xcodebuild test -skip-testing:PasturaUITests` — **841 pass / 0 fail** on iPhone 17 Pro (iOS 26.4)
- [x] Swift 6 concurrency compile-clean (`@MainActor` VM, `nonisolated` source primitives, `Sendable` everywhere) — build succeeded under `-swift-version 6`
- [x] `swiftlint lint --quiet --strict` — green across the whole project
- [x] Exporter round-trip tests still pass (YAMLReplayRoundTripTests 4/4, YAMLReplayExporterTests 20/20)
- [x] `Bundle.main` integration: `PresetResolverTests.resolvesRealBundledPresetFromBundleMain` resolves shipped `word_wolf.yaml` and its SHA matches `YAMLReplayExporter.sha256Hex(bundledYAML)` for the same bytes

## Reviewer checklist (CI-gated)

- [ ] CI `swiftlint --strict` green
- [ ] CI full test suite green (macos-26 runner)
- [ ] Manual spot-check: read `ReplayViewModel.runPlayback` / `advanceAfterSource` for state-machine correctness against ADR-007 §3.4

Closes #169 partially — PR2/PR3 complete the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)