### PR TITLE
📝 docs: App Store Connect Support URL landing page (#182)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,11 +71,22 @@ jobs:
           # losing all output on timeout-kill). Trailing `|| true` prevents
           # `set -eo pipefail` (GHA default) from aborting the script before
           # PIPESTATUS is captured.
+          #
+          # `-parallel-testing-enabled NO` — EXPERIMENTAL (#182). Disables
+          # multi-simulator-clone parallelism to test the resource-exhaustion
+          # hypothesis for the signal-trap cascade first observed on `main`
+          # post-#186 (e650f13). Symptoms: trivial unit tests taking ~3.1s
+          # each on CI (vs <10 ms locally), followed by a test-host crash
+          # that marks hundreds of queued tests as "signal trap". If this
+          # flag stabilises CI, the fix is likely a targeted
+          # `-parallel-testing-worker-count 2` rather than full
+          # serialisation — revisit once we have a passing baseline.
           xcodebuild test \
             -scheme Pastura \
             -project Pastura/Pastura.xcodeproj \
             -destination "$DEST" \
             -only-testing PasturaTests \
+            -parallel-testing-enabled NO \
             -enableCodeCoverage YES \
             -resultBundlePath TestResults.xcresult \
             CODE_SIGNING_ALLOWED=NO 2>&1 | tee /tmp/xctest-unit.log || true

--- a/.github/workflows/deploy-support-page.yml
+++ b/.github/workflows/deploy-support-page.yml
@@ -1,0 +1,68 @@
+# Deploys docs/support/ to GitHub Pages so the App Store Connect Support URL
+# (`https://tyabu12.github.io/pastura/support/`) has a dedicated landing page.
+# See issue #182 and ADR-005 §6 / §9.2 row #9.
+#
+# Precondition: Settings → Pages → Source = "GitHub Actions" (NOT
+# "Deploy from a branch", which would publish the entire docs/ tree).
+#
+# Only `docs/support/` is staged — the rest of `docs/` (ADRs, specs,
+# prototype code) stays out of the published artifact. The workflow also
+# writes a `.nojekyll` file so a future Source-setting regression back to
+# branch-based Pages cannot start running the HTML through Jekyll.
+#
+# Concurrency group `pages` is GitHub's documented convention for Pages
+# deploys — any future Pages workflow in this repo must share it so
+# deploys serialize correctly. `cancel-in-progress: false` is deliberate:
+# cancelling a Pages deploy mid-flight can leave the site in an
+# inconsistent state.
+
+name: Deploy Support Page
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/support/**'
+      - '.github/workflows/deploy-support-page.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Configure Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - name: Stage artifact
+        # Targeted copy — never `cp -r docs/support _site/support` because
+        # that would also publish any sibling drafts or editor detritus
+        # (e.g. .DS_Store) that may live alongside index.html.
+        run: |
+          mkdir -p _site/support
+          cp docs/support/index.html _site/support/index.html
+          touch _site/.nojekyll
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: _site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/deploy-support-page.yml
+++ b/.github/workflows/deploy-support-page.yml
@@ -53,6 +53,9 @@ jobs:
         # Targeted copy — never `cp -r docs/support _site/support` because
         # that would also publish any sibling drafts or editor detritus
         # (e.g. .DS_Store) that may live alongside index.html.
+        # If you add more files under docs/support/ (favicon, split CSS,
+        # additional pages), list them explicitly here — silent drift on
+        # this step means the new asset 404s on the deployed site.
         run: |
           mkdir -p _site/support
           cp docs/support/index.html _site/support/index.html

--- a/Pastura/Pastura/Utilities/ReportURLBuilder.swift
+++ b/Pastura/Pastura/Utilities/ReportURLBuilder.swift
@@ -33,6 +33,14 @@ nonisolated enum ReportURLBuilder {
   /// field is rendered as a user-typed field that triggers the
   /// response-receipt auto-acknowledgement (see ADR-005 §6.3).
   ///
+  /// The same underlying form co-tenants as the §1.5 general-contact
+  /// surface reached from the App Store Connect Support URL landing
+  /// page (`docs/support/index.html`, #182). That path links the bare
+  /// form URL with no pre-fill, and the Scenario ID field is
+  /// configured as optional so general-feedback submissions can leave
+  /// it blank. This builder always pre-fills both fields — the
+  /// in-app path is unaffected by the optional configuration.
+  ///
   /// - Parameters:
   ///   - scenarioId: Gallery scenario identifier.
   ///   - appVersion: Running app version (e.g. "1.0.0"). Empty

--- a/Pastura/PasturaTests/App/ModelManagerTests.swift
+++ b/Pastura/PasturaTests/App/ModelManagerTests.swift
@@ -50,13 +50,23 @@ struct ModelManagerTests {
     expectedFileSize: Int64 = 0,
     expectedSHA256: String? = nil
   ) -> ModelManager {
-    ModelManager(
+    let sut = ModelManager(
       downloader: downloader,
       fileManager: .default,
       physicalMemory: physicalMemory,
       expectedFileSize: expectedFileSize,
       expectedSHA256: expectedSHA256
     )
+    // Proactively wipe residual files at the shared Application Support /
+    // Caches paths. The `.serialized` suite's per-test `defer { removeItem }`
+    // blocks are declared AFTER `await sut.downloadModel()` — if any
+    // download-triggering test crashes (signal trap) before that defer
+    // registers, the model file leaks and every subsequent `.notDownloaded`
+    // assertion in the suite fails spuriously. Observed on CI post-#186
+    // (macos-26 runner under parallel-suite scheduling pressure).
+    try? FileManager.default.removeItem(at: sut.modelFileURL)
+    try? FileManager.default.removeItem(at: sut.downloadFileURL)
+    return sut
   }
 
   // MARK: - Device Check

--- a/docs/decisions/ADR-005.md
+++ b/docs/decisions/ADR-005.md
@@ -765,6 +765,37 @@ response receipts, 7-day internal best-effort target (not surfaced in
 app), 72-hour fast-path for violating content, vacation-mode auto-ack
 for absences >5 days, reviewer identity as in §6.4.
 
+### 6.7 App Store Connect §1.5 Support URL co-tenancy
+
+§1.5 "Developer Information" requires a Support URL on every App
+Store submission. Pastura satisfies this with a dedicated landing
+page (`docs/support/index.html`, deployed to
+`https://tyabu12.github.io/pastura/support/`) rather than linking
+the raw GitHub repo — iOS reviewers reject repo-only Support URLs
+(the quick-rss precedent cited in #182).
+
+The landing page co-tenants the §6 Google Form as the general-contact
+surface:
+
+- Scenario ID is configured as optional on the form — the in-app
+  path (§6.2) always pre-fills it via `ReportURLBuilder`; the §1.5
+  path links the bare form URL and leaves it blank.
+- The form title, description, and Scenario ID helper copy
+  acknowledge the dual use so neither reviewers nor general-feedback
+  senders are confused by scenario-scoped wording.
+- The confirmation template (`share-board-reports.md` §2.1) is
+  worded neutrally ("Thanks for your message…") so it works for
+  both report and general-feedback cases while preserving the §1.2
+  "timely" acknowledgement signal.
+
+§1.5 and §1.2 remain conceptually distinct — §1.5 is the generic
+developer contact, §1.2 is the UGC report channel. They share the
+surface (one form) but not the framing. The separation matters for
+compliance-claim bookkeeping: if Apple ever challenges one, the
+other is not automatically implicated.
+
+Tracked in §9.2 row #9 (#182).
+
 ---
 
 ## 7. Cloud API Disclosure / Consent Principles
@@ -1113,11 +1144,12 @@ when work starts" marker and are created during the relevant sprint.
 | 1 | Wrap `OllamaService` out of release binaries; `nm` audit | [#148](https://github.com/tyabu12/pastura/issues/148) | tyabu12 | **Submission** | Filed 2026-04-19; §8.5 |
 | 2 | Create `PrivacyInfo.xcprivacy` with required-reason APIs | [#149](https://github.com/tyabu12/pastura/issues/149) | tyabu12 | **Submission** | Filed 2026-04-19; §1 gap, §9 |
 | 3 | Implement `ScenarioContentValidator` (§4) + migrate `ContentFilter` to shared bundled blocklist (§4.4) | [#180](https://github.com/tyabu12/pastura/issues/180) | tyabu12 | Soft — defense-in-depth complement to §5 filter | §5 filter is the backstop; §4 is preferred but not submission-blocking |
-| 4 | Share Board report UI (§6) + pseudonymous contact surface | [#178](https://github.com/tyabu12/pastura/issues/178) | tyabu12 | Soft — §1.2 does not strictly apply to curated content, but defensive posture recommended before review | §1.5 contact info separately handled via App Store Connect support URL |
+| 4 | Share Board report UI (§6) + pseudonymous contact surface | [#178](https://github.com/tyabu12/pastura/issues/178) | tyabu12 | Soft — §1.2 does not strictly apply to curated content, but defensive posture recommended before review | The §6 Google Form also co-tenants as the §1.5 general-contact surface via the Support URL landing page — see §6.7 and row #9 |
 | 5 | Blocklist (`ContentBlocklist.txt`) expansion methodology (§5.2 / §4.4) | Not filed — on-demand | tyabu12 | None (ongoing) | Triggered by telemetry, App Review citation, or user report. Additions are data-only edits to the bundled resource once item #3 lands. |
 | 6 | Fallback handling 13+ → 16+ (§3.3) | Not filed — conditional | tyabu12 | Conditional (fires only on rejection) | Created reactively if Apple rejects the 13+ target |
 | 7 | ADR-006 Cloud API disclosure/consent implementation | Forthcoming ADR, not a sub-issue | tyabu12 | Cloud API feature (not submission) | Principles from §7 bind this work |
 | 8 | Declare `ITSAppUsesNonExemptEncryption = NO` in build config | [#159](https://github.com/tyabu12/pastura/issues/159) | tyabu12 | None (doc-vs-code drift) | Filed 2026-04-20; §8.6 |
+| 9 | App Store Connect Support URL landing page (§6.7) | [#182](https://github.com/tyabu12/pastura/issues/182) | tyabu12 | **Submission** | Filed 2026-04-21; `docs/support/index.html` deployed to `https://tyabu12.github.io/pastura/support/` |
 
 The master index is the canonical list — individual ADR sections reference
 it by row number when pointing at follow-up work.

--- a/docs/gallery/share-board-reports.md
+++ b/docs/gallery/share-board-reports.md
@@ -21,6 +21,13 @@ compliance — the response receipt delivers the immediate
 auto-acknowledgement that the reviewer observes at submission test
 time. Misconfiguring any of the below breaks that compliance claim.
 
+This form also co-tenants as the §1.5 general-contact surface reached
+from the App Store Connect Support URL landing page
+(`docs/support/index.html`, #182). General feedback — no scenario
+context — is a legitimate second use. The form's title, description,
+and Scenario ID helper copy all signal this; keep them in sync when
+editing.
+
 **Settings → Responses:**
 
 | Setting | Required value | Why |
@@ -35,9 +42,9 @@ time. Misconfiguring any of the below breaks that compliance claim.
 | # | Type | Label | Required | Note |
 |---|------|-------|----------|------|
 | auto | Email | Email | yes (enforced) | Auto-added by Responder input. Not pre-fillable by URL parameter (Google design). |
-| 1 | Short answer | Scenario ID | yes | Pre-filled by the app via URL parameter. |
-| 2 | Short answer | App Version | no | Pre-filled by the app. |
-| 3 | Paragraph | Reason | yes | User writes the report body. |
+| 1 | Short answer | Scenario ID | **no** | Pre-filled by the app via URL parameter when reporting from Share Board. Left blank on the §1.5 general-contact path. Helper text: "Auto-filled when reporting from the app. Leave blank for general feedback." |
+| 2 | Short answer | App Version | no | Pre-filled by the app. Blank on the §1.5 path. |
+| 3 | Paragraph | Reason | yes | User writes the report body or feedback text. |
 
 **Settings → Presentation → Confirmation message:** see §2.1.
 
@@ -65,15 +72,15 @@ response-receipt email.
 
 **English:**
 
-> Thanks for your report. We've received it and will review as
-> needed. If the content clearly violates policy, it will be hidden
-> from the gallery during triage.
+> Thanks for your message. We've received it and will respond as
+> needed. Share Board reports indicating clear policy violations are
+> hidden from the gallery during triage.
 
 **Japanese:**
 
-> 報告ありがとうございます。受領し、必要に応じて確認します。
-> 明らかな policy 違反が確認できた場合は、triage 中にギャラリーから
-> 該当シナリオを非表示にします。
+> ご連絡ありがとうございます。受領し、必要に応じて返信します。
+> Share Board の通報で明らかな policy 違反が確認できた場合は、triage
+> 中にギャラリーから該当シナリオを非表示にします。
 
 ### 2.2 Vacation-mode confirmation message
 
@@ -84,19 +91,20 @@ appears (ADR-005 §6.3).
 
 **Template (English):**
 
-> Thanks for your report. We've received it.
+> Thanks for your message. We've received it.
 >
 > Note: the maintainer is currently away through **YYYY-MM-DD** and
-> will resume reviewing reports after that date. Reports indicating
-> clearly policy-violating content may still be actioned before then.
+> will resume reviewing after that date. Share Board reports
+> indicating clearly policy-violating content may still be actioned
+> before then.
 
 **Template (Japanese):**
 
-> 報告ありがとうございます。受領しました。
+> ご連絡ありがとうございます。受領しました。
 >
 > メンテナ不在期間: **YYYY-MM-DD** まで。復帰後に順次確認します。
-> 明らかな policy 違反が確認できる場合は、不在期間中でも対応する
-> ことがあります。
+> Share Board の通報で明らかな policy 違反が確認できる場合は、不在
+> 期間中でも対応することがあります。
 
 **Procedure:**
 

--- a/docs/support/index.html
+++ b/docs/support/index.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Pastura Support</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Support and feedback channel for Pastura, an iOS app for on-device AI multi-agent simulations.">
+  <style>
+    :root {
+      color-scheme: light dark;
+    }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+      line-height: 1.6;
+      max-width: 640px;
+      margin: 2rem auto;
+      padding: 0 1rem 4rem;
+    }
+    h1 {
+      border-bottom: 1px solid #ddd;
+      padding-bottom: 0.5rem;
+    }
+    h2 {
+      margin-top: 2.5rem;
+    }
+    h3 {
+      margin-top: 1.5rem;
+    }
+    a {
+      color: #0366d6;
+    }
+    @media (prefers-color-scheme: dark) {
+      a {
+        color: #58a6ff;
+      }
+      h1 {
+        border-bottom-color: #30363d;
+      }
+    }
+    hr {
+      margin: 2.5rem 0 1rem;
+      border: 0;
+      border-top: 1px solid #ddd;
+    }
+    @media (prefers-color-scheme: dark) {
+      hr {
+        border-top-color: #30363d;
+      }
+    }
+    .lead {
+      font-size: 1.05em;
+    }
+    .cta {
+      display: inline-block;
+      padding: 0.5rem 1rem;
+      border: 1px solid currentColor;
+      border-radius: 6px;
+      text-decoration: none;
+    }
+    footer {
+      margin-top: 3rem;
+      font-size: 0.9em;
+      color: #666;
+    }
+    @media (prefers-color-scheme: dark) {
+      footer {
+        color: #8b949e;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Pastura Support</h1>
+
+    <p class="lead">
+      Pastura is an iOS app for running AI multi-agent simulations
+      fully on-device. This page is the support and feedback channel
+      for the app.
+    </p>
+
+    <h2>Contact the maintainer</h2>
+
+    <p>
+      Use the contact form below to send feedback, bug reports, or
+      questions. For general feedback, leave the Scenario ID field
+      blank.
+    </p>
+
+    <p>
+      <a class="cta" href="https://docs.google.com/forms/d/e/1FAIpQLSfsZkY9-R3QxqVfdXSzsUnx3SXR-g9O7DxjdN-1-VtMjMXSAw/viewform">Open the contact form</a>
+    </p>
+
+    <p>
+      You will receive an automatic acknowledgement at the email
+      address you provide on the form. The maintainer reviews
+      submissions and replies as needed.
+    </p>
+
+    <h3>Prefer a public tracker?</h3>
+
+    <p>
+      You can also file a
+      <a href="https://github.com/tyabu12/pastura/issues/new/choose">GitHub issue</a>
+      on the project repository. This requires a GitHub account and
+      is public.
+    </p>
+
+    <h2>Reporting a Share Board scenario</h2>
+
+    <p>
+      To report a specific scenario shown in the in-app Share Board,
+      use the <strong>Report</strong> button on the scenario's detail
+      sheet inside the app. The in-app flow pre-fills the scenario
+      identifier automatically; the destination is the same contact
+      form above.
+    </p>
+
+    <p>
+      Reports indicating clear policy violations are hidden from the
+      gallery during triage. Triage is performed by the Pastura
+      maintainer. The full report-handling policy is documented in
+      <a href="https://github.com/tyabu12/pastura/blob/main/docs/decisions/ADR-005.md#6-share-board-report-mechanism">ADR-005 §6</a>.
+    </p>
+
+    <footer>
+      <hr>
+      <p>
+        Source code and release notes:
+        <a href="https://github.com/tyabu12/pastura">github.com/tyabu12/pastura</a>
+      </p>
+    </footer>
+  </main>
+</body>
+</html>

--- a/docs/support/index.html
+++ b/docs/support/index.html
@@ -101,7 +101,7 @@
 
     <p>
       You can also file a
-      <a href="https://github.com/tyabu12/pastura/issues/new/choose">GitHub issue</a>
+      <a href="https://github.com/tyabu12/pastura/issues/new">GitHub issue</a>
       on the project repository. This requires a GitHub account and
       is public.
     </p>


### PR DESCRIPTION
## Summary
- Stand up `https://tyabu12.github.io/pastura/support/` as the App Store §1.5 Support URL destination, satisfying Apple's dedicated-feedback-page requirement (quick-rss precedent for iOS).
- Co-tenant the §6 Share Board Google Form as the §1.5 general-contact surface (Scenario ID now optional on the form); document the policy in ADR-005 §6.7 and §9.2 row #9.
- Deploy only `docs/support/` via a scoped GitHub Actions workflow — ADRs, specs, and prototype code under `docs/` stay off the public site.

## Precondition (one-time, manual post-merge)
**Settings → Pages → Source = "GitHub Actions"** — NOT "Deploy from a branch → /docs" (the latter would publish the entire `docs/` tree).

## Test plan
- [x] After merge + Pages Source flip, confirm the workflow run succeeds.
- [x] Visit `https://tyabu12.github.io/pastura/support/` and verify the page renders.
- [x] Click through each link:
  - [x] "Open the contact form" opens the Google Form with Scenario ID blank.
  - [x] "GitHub issue" opens the blank new-issue page.
  - [x] ADR-005 §6 anchor resolves correctly.
  - [x] Repository link resolves.
- [x] Submit a test form entry leaving Scenario ID blank; confirm the response-receipt email arrives.
- [x] In-app Share Board report path still pre-fills Scenario ID as before (no regression).
- [ ] Paste the deployed URL into App Store Connect "Support URL" at next submission.

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)