### PR TITLE
🔧 fix: persist TurnRecord phasePath for nested-phase lineage

### DIFF
--- a/Pastura/Pastura/App/ResultDetailTimelineBuilder.swift
+++ b/Pastura/Pastura/App/ResultDetailTimelineBuilder.swift
@@ -33,6 +33,17 @@ nonisolated enum ResultDetailTimelineBuilder {
       }
     }
 
+    /// Phase lineage path decoded from the underlying record's `phasePathJSON`.
+    /// `nil` for legacy records (pre-v6) or separators. `count > 1` means the
+    /// item comes from a sub-phase inside a conditional.
+    var phasePath: [Int]? {
+      switch self {
+      case .roundSeparator: nil
+      case .turn(let turn): turn.phasePath
+      case .codePhase(let record, _): record.phasePath
+      }
+    }
+
     fileprivate var sequenceNumber: Int {
       switch self {
       case .roundSeparator: Int.min

--- a/Pastura/Pastura/App/ResultMarkdownExporter.swift
+++ b/Pastura/Pastura/App/ResultMarkdownExporter.swift
@@ -192,12 +192,50 @@ struct ResultMarkdownExporter {  // swiftlint:disable:this type_body_length
       case .codePhase(let record, _): return record.phaseType
       }
     }
+    /// `nil` for legacy rows (pre-v6) and top-level phases; `[K, N, ...]` for nested
+    /// sub-phases inside a conditional. Mirrors the underlying record's `phasePath`.
+    var phasePath: [Int]? {
+      switch self {
+      case .turn(let turn): return turn.phasePath
+      case .codePhase(let record, _): return record.phasePath
+      }
+    }
+  }
+
+  /// Groups timeline items within a round. Legacy rows (`phasePath == nil`) and
+  /// top-level rows (`phasePath.count == 1`) collapse into one block per phaseType
+  /// to preserve the mixed-era invariant. Nested sub-phase rows (`phasePath.count > 1`)
+  /// each get their own block keyed on the exact path so sibling conditional branches
+  /// appear separately.
+  private enum PhaseGroupKey: Hashable {
+    case topLevel(phaseType: String)
+    case nested(path: [Int], phaseType: String)
+
+    init(_ item: TimelineItem) {
+      let path = item.phasePath
+      if let path, path.count > 1 {
+        self = .nested(path: path, phaseType: item.phaseType)
+      } else {
+        self = .topLevel(phaseType: item.phaseType)
+      }
+    }
+
+    /// Markdown heading for this group.
+    var heading: String {
+      switch self {
+      case .topLevel(let phaseType):
+        return "#### Phase: \(phaseType)"
+      case .nested(let path, let phaseType):
+        let formatted = path.map { String($0) }.joined(separator: ", ")
+        return "#### Sub-phase: \(phaseType) (path [\(formatted)])"
+      }
+    }
   }
 
   private func renderTurnLog(_ input: Input) -> String {
-    // Build a unified timeline. Within a `(round, phaseType)` group, items
+    // Build a unified timeline. Within a `(round, PhaseGroupKey)` group, items
     // render strictly by ascending `sequenceNumber` — agent votes always
-    // precede the tally line under the same `#### Phase: vote` header.
+    // precede the tally line under the same heading.
     var timeline: [TimelineItem] = input.turns.map { .turn($0) }
     timeline.append(
       contentsOf: input.codePhaseEvents.map { record in
@@ -221,20 +259,21 @@ struct ResultMarkdownExporter {  // swiftlint:disable:this type_body_length
       lines.append("### Round \(round)")
       let itemsInRound = (grouped[round] ?? [])
         .sorted { $0.sequenceNumber < $1.sequenceNumber }
-      // Group by phaseType within round, preserving first-seen order.
-      var phaseOrder: [String] = []
-      var byPhase: [String: [TimelineItem]] = [:]
+      // Group by PhaseGroupKey within round, preserving first-seen order.
+      var keyOrder: [PhaseGroupKey] = []
+      var byKey: [PhaseGroupKey: [TimelineItem]] = [:]
       for item in itemsInRound {
-        if byPhase[item.phaseType] == nil {
-          phaseOrder.append(item.phaseType)
-          byPhase[item.phaseType] = []
+        let key = PhaseGroupKey(item)
+        if byKey[key] == nil {
+          keyOrder.append(key)
+          byKey[key] = []
         }
-        byPhase[item.phaseType]?.append(item)
+        byKey[key]?.append(item)
       }
-      for phase in phaseOrder {
+      for key in keyOrder {
         lines.append("")
-        lines.append("#### Phase: \(phase)")
-        for item in byPhase[phase] ?? [] {
+        lines.append(key.heading)
+        for item in byKey[key] ?? [] {
           lines.append(render(item))
         }
       }

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -338,6 +338,22 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   /// the engine's execution context rather than the event shape.
   private var currentPhaseType: PhaseType?
 
+  /// Phase-path stack mirror of `currentPhaseType`, tracked via both
+  /// `.phaseStarted` (push) and `.phaseCompleted` (pop). Used to persist the
+  /// `phasePathJSON` column on `TurnRecord` / `CodePhaseEventRecord` so that
+  /// scenarios with a top-level `speak_all` AND a nested `speak_all` inside a
+  /// conditional branch keep distinct lineage in exports (#143).
+  ///
+  /// Why pop on `.phaseCompleted` (unlike `currentPhaseType`): an event
+  /// emitted in the gap between an inner sub-phase's completion and the next
+  /// `.phaseStarted` would otherwise be mis-attributed to the stale sub-phase
+  /// path. Pop only when the completed path matches the current one AND
+  /// `count > 1` — so completing a top-level phase leaves the stack empty
+  /// (matches the "no active phase" starting state) and a mismatched
+  /// `.phaseCompleted` (impossible under `SimulationRunner`'s contract, but
+  /// defensive) is a no-op.
+  private var currentPhasePath: [Int]?
+
   init(
     runner: SimulationRunner = SimulationRunner(),
     contentFilter: ContentFilter = ContentFilter(),
@@ -449,6 +465,8 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
       simId: simId, scenario: scenario, state: initialState, llm: llm)
 
     turnSequence = 0
+    currentPhaseType = nil
+    currentPhasePath = nil
 
     // Attach BEFORE loadModel so scene-phase handlers can signal suspend as
     // soon as run() is in flight.
@@ -536,10 +554,21 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
       handleRoundStarted(round: round, total: total)
     case .roundCompleted(let round, let newScores):
       handleRoundCompleted(round: round, scores: newScores)
-    case .phaseStarted(let phaseType, _):
+    case .phaseStarted(let phaseType, let phasePath):
       currentPhaseType = phaseType
+      currentPhasePath = phasePath
       logEntries.append(LogEntry(kind: .phaseStarted(phaseType: phaseType)))
-    case .phaseCompleted, .simulationPaused, .conditionalEvaluated:
+    case .phaseCompleted(_, let phasePath):
+      // Pop `currentPhasePath` back one level when the inner sub-phase's
+      // completion arrives (path matches AND count > 1) — so a subsequent
+      // event fired before the next `.phaseStarted` isn't mis-attributed to
+      // the stale inner path (#143). `currentPhaseType` intentionally still
+      // lingers: consumers that need exact phaseType attribution already
+      // read the event's own `phaseType` per `.claude/rules/engine.md`.
+      if currentPhasePath == phasePath, (currentPhasePath?.count ?? 0) > 1 {
+        currentPhasePath?.removeLast()
+      }
+    case .simulationPaused, .conditionalEvaluated:
       // No-op — `.simulationPaused` is a runner-side acknowledgement of the
       // user-initiated pause flow; the UI already reflects `isPaused` set
       // synchronously by the pause button. Background-driven suspend uses
@@ -547,8 +576,7 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
       //
       // `.conditionalEvaluated` is visible via the bracketing
       // `.phaseStarted(.conditional, _)` + inner sub-phase events; UI
-      // surfacing of the condition/result pair is deferred, and persistence
-      // waits on the follow-up TurnRecord-phase-path migration.
+      // surfacing of the condition/result pair is deferred.
       break
     case .agentOutput(let agent, let output, let phaseType):
       handleAgentOutput(agent: agent, output: output, phaseType: phaseType)
@@ -905,12 +933,26 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
         rawOutput: jsonString,
         parsedOutputJSON: jsonString,
         sequenceNumber: turnSequence,
+        phasePathJSON: encodedCurrentPhasePath(),
         createdAt: Date()
       )
       persistenceContinuation?.yield(record)
     } catch {
       print("⚠️ Failed to encode turn output: \(error)")
     }
+  }
+
+  /// JSON-encodes `currentPhasePath` as a compact `[Int]` (e.g. `"[1,0]"`)
+  /// for the `phasePathJSON` column, or returns `nil` when no phase is active
+  /// (pre-first-`.phaseStarted` events). JSONEncoder on a small `[Int]` can't
+  /// realistically fail; a throw here is treated as "unknown path" so a rare
+  /// encode failure doesn't lose the rest of the row.
+  private func encodedCurrentPhasePath() -> String? {
+    guard let path = currentPhasePath else { return nil }
+    guard let data = try? JSONEncoder().encode(path),
+      let json = String(data: data, encoding: .utf8)
+    else { return nil }
+    return json
   }
 
   private func startCodePhasePersistenceConsumer() {
@@ -953,6 +995,7 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
         phaseType: phaseType,
         sequenceNumber: turnSequence,
         payloadJSON: jsonString,
+        phasePathJSON: encodedCurrentPhasePath(),
         createdAt: Date()
       )
       continuation.yield(record)
@@ -969,6 +1012,8 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   internal func beginPersistenceForTest(simulationId: String) {
     self.simulationId = simulationId
     turnSequence = 0
+    currentPhaseType = nil
+    currentPhasePath = nil
     startPersistenceConsumer()
     startCodePhasePersistenceConsumer()
   }

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -565,7 +565,7 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
       // the stale inner path (#143). `currentPhaseType` intentionally still
       // lingers: consumers that need exact phaseType attribution already
       // read the event's own `phaseType` per `.claude/rules/engine.md`.
-      if currentPhasePath == phasePath, (currentPhasePath?.count ?? 0) > 1 {
+      if currentPhasePath == phasePath, phasePath.count > 1 {
         currentPhasePath?.removeLast()
       }
     case .simulationPaused, .conditionalEvaluated:

--- a/Pastura/Pastura/App/YAMLReplayExporter.swift
+++ b/Pastura/Pastura/App/YAMLReplayExporter.swift
@@ -316,10 +316,15 @@ nonisolated struct YAMLReplayExporter {  // swiftlint:disable:this type_body_len
   ///   the emitted YAML will then mismatch `phases[phase_index].type`
   ///   and fail a strict consistency check.
   ///
-  /// Both limitations are acceptable for Phase 2 linear presets (Word
-  /// Wolf, Prisoner's Dilemma). A future migration adding a
-  /// `phaseIndex` column to `turns` / `code_phase_events` (sourced from
-  /// `SimulationEvent.phasePath`) lifts them; tracked separately.
+  /// The `phasePathJSON` column landed in #143 so `TurnRecord.phasePath`
+  /// now carries exact lineage (e.g. `[1, 0]` for a sub-phase). This
+  /// resolver still ignores it because the YAML replay schema's
+  /// `phase_index: Int` is a flat top-level index, not a path — teaching
+  /// the schema to represent nested addresses is a separate piece of
+  /// work. For now, the cursor keeps the Phase 2 presets (Word Wolf,
+  /// Prisoner's Dilemma) round-tripping correctly; conditional-heavy
+  /// scenarios hit the documented limitations. Upgrading the schema and
+  /// switching to `phasePath`-aware resolution is tracked as a follow-up.
   private static func resolvePhaseIndices(
     scenario: Scenario, turns: [TurnRecord]
   ) -> [Int] {
@@ -352,8 +357,10 @@ nonisolated struct YAMLReplayExporter {  // swiftlint:disable:this type_body_len
       }
       // Not a top-level phase — the event originated inside a
       // `conditional`'s branch (e.g. `summarize` used in then/else).
-      // Fall back to the conditional's index so consumers can still
-      // locate the enclosing phase context.
+      // `event.phasePath` (persisted since #143) has the exact inner
+      // location, but the YAML replay schema's `phase_index` is flat,
+      // so we still fall back to the conditional's index here and let
+      // the schema upgrade lift this when it lands.
       return conditionalFallbackIndex(in: scenario.phases)
     }
   }

--- a/Pastura/Pastura/Data/DatabaseManager.swift
+++ b/Pastura/Pastura/Data/DatabaseManager.swift
@@ -101,6 +101,18 @@ nonisolated public final class DatabaseManager: Sendable {
         on: "code_phase_events",
         columns: ["simulationId", "roundNumber"])
     }
+
+    migrator.registerMigration("v6_addPhasePathToTurnsAndCodePhaseEvents") { db in
+      // Nullable TEXT with no default: existing rows read as NULL (legacy —
+      // lineage wasn't captured pre-v6). Matches `TurnRecord.phasePathJSON`
+      // and `CodePhaseEventRecord.phasePathJSON` optionals.
+      try db.alter(table: "turns") { t in
+        t.add(column: "phasePathJSON", .text)
+      }
+      try db.alter(table: "code_phase_events") { t in
+        t.add(column: "phasePathJSON", .text)
+      }
+    }
   }
 
   private static func registerV1(_ migrator: inout DatabaseMigrator) {

--- a/Pastura/Pastura/Data/Models/CodePhaseEventRecord.swift
+++ b/Pastura/Pastura/Data/Models/CodePhaseEventRecord.swift
@@ -29,6 +29,12 @@ nonisolated public struct CodePhaseEventRecord: Codable, Sendable, Equatable,
   public var sequenceNumber: Int
   /// Serialized `CodePhaseEventPayload` as JSON.
   public var payloadJSON: String
+  /// JSON-encoded `[Int]` identifying the phase's position in the scenario
+  /// (top-level K → `"[K]"`, nested sub-phase N inside conditional K → `"[K,N]"`).
+  /// `nil` for pre-v6 rows (legacy) where lineage wasn't captured. Consumers
+  /// should read the typed `phasePath` accessor rather than decoding this
+  /// string directly.
+  public var phasePathJSON: String?
   public var createdAt: Date
 
   public init(
@@ -38,6 +44,7 @@ nonisolated public struct CodePhaseEventRecord: Codable, Sendable, Equatable,
     phaseType: String,
     sequenceNumber: Int,
     payloadJSON: String,
+    phasePathJSON: String? = nil,
     createdAt: Date
   ) {
     self.id = id
@@ -46,6 +53,16 @@ nonisolated public struct CodePhaseEventRecord: Codable, Sendable, Equatable,
     self.phaseType = phaseType
     self.sequenceNumber = sequenceNumber
     self.payloadJSON = payloadJSON
+    self.phasePathJSON = phasePathJSON
     self.createdAt = createdAt
+  }
+
+  /// Typed view over `phasePathJSON`. Returns `nil` when the JSON is absent,
+  /// empty, or fails to decode — consumers treat all three as "legacy /
+  /// unknown path" and fall back to `phaseType`-only grouping.
+  public var phasePath: [Int]? {
+    guard let json = phasePathJSON, !json.isEmpty else { return nil }
+    guard let data = json.data(using: .utf8) else { return nil }
+    return try? JSONDecoder().decode([Int].self, from: data)
   }
 }

--- a/Pastura/Pastura/Data/Models/TurnRecord.swift
+++ b/Pastura/Pastura/Data/Models/TurnRecord.swift
@@ -24,6 +24,12 @@ nonisolated public struct TurnRecord: Codable, Sendable, Equatable,
   /// Monotonically increasing per simulation — the canonical ordering key.
   /// Pre-migration rows default to `0` and fall back to `createdAt` ordering.
   public var sequenceNumber: Int
+  /// JSON-encoded `[Int]` identifying the phase's position in the scenario
+  /// (top-level K → `"[K]"`, nested sub-phase N inside conditional K → `"[K,N]"`).
+  /// `nil` for pre-v6 rows (legacy) where lineage wasn't captured. Consumers
+  /// should read the typed `phasePath` accessor rather than decoding this
+  /// string directly.
+  public var phasePathJSON: String?
   public var createdAt: Date
 
   public init(
@@ -35,6 +41,7 @@ nonisolated public struct TurnRecord: Codable, Sendable, Equatable,
     rawOutput: String,
     parsedOutputJSON: String,
     sequenceNumber: Int = 0,
+    phasePathJSON: String? = nil,
     createdAt: Date
   ) {
     self.id = id
@@ -45,6 +52,16 @@ nonisolated public struct TurnRecord: Codable, Sendable, Equatable,
     self.rawOutput = rawOutput
     self.parsedOutputJSON = parsedOutputJSON
     self.sequenceNumber = sequenceNumber
+    self.phasePathJSON = phasePathJSON
     self.createdAt = createdAt
+  }
+
+  /// Typed view over `phasePathJSON`. Returns `nil` when the JSON is absent,
+  /// empty, or fails to decode — consumers treat all three as "legacy /
+  /// unknown path" and fall back to `phaseType`-only grouping.
+  public var phasePath: [Int]? {
+    guard let json = phasePathJSON, !json.isEmpty else { return nil }
+    guard let data = json.data(using: .utf8) else { return nil }
+    return try? JSONDecoder().decode([Int].self, from: data)
   }
 }

--- a/Pastura/Pastura/Views/Results/ResultDetailView.swift
+++ b/Pastura/Pastura/Views/Results/ResultDetailView.swift
@@ -144,13 +144,35 @@ struct ResultDetailView: View {
           case .roundSeparator(let round):
             roundSeparator(round)
           case .turn(let turn):
-            turnRow(turn)
+            subPhaseWrapper(item: item) { turnRow(turn) }
           case .codePhase(_, let payload):
-            codePhaseRow(payload)
+            subPhaseWrapper(item: item) { codePhaseRow(payload) }
           }
         }
       }
       .padding(.vertical, 8)
+    }
+  }
+
+  /// Wraps a row with a leading indent and "↳ sub-phase" caption when the
+  /// item's `phasePath` depth is greater than 1 (i.e. it lives inside a
+  /// conditional branch). Top-level items (depth ≤ 1) pass through unchanged.
+  @ViewBuilder
+  private func subPhaseWrapper<Content: View>(
+    item: ResultDetailTimelineBuilder.Item,
+    @ViewBuilder content: () -> Content
+  ) -> some View {
+    if (item.phasePath?.count ?? 0) > 1 {
+      VStack(alignment: .leading, spacing: 2) {
+        Text("↳ sub-phase")
+          .font(.caption2)
+          .foregroundStyle(.secondary)
+          .padding(.leading, 32)
+        content()
+          .padding(.leading, 16)
+      }
+    } else {
+      content()
     }
   }
 

--- a/Pastura/Pastura/Views/Results/ResultDetailView.swift
+++ b/Pastura/Pastura/Views/Results/ResultDetailView.swift
@@ -8,7 +8,7 @@ import UIKit
 /// merged by `sequenceNumber` via `ResultDetailTimelineBuilder`, and the
 /// result is cached in `@State` to avoid re-decoding `CodePhaseEventPayload`
 /// JSON on every body re-render (e.g. when `showAllThoughts` toggles).
-struct ResultDetailView: View {
+struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
   let simulationId: String
 
   @Environment(AppDependencies.self) private var dependencies

--- a/Pastura/PasturaTests/App/ResultDetailTimelineBuilderTests.swift
+++ b/Pastura/PasturaTests/App/ResultDetailTimelineBuilderTests.swift
@@ -221,6 +221,55 @@ struct ResultDetailTimelineBuilderTests {
     }
   }
 
+  // MARK: - phasePath accessor
+
+  @Test
+  func itemPhasePathPassesThroughFromUnderlyingRecord() throws {
+    // TurnRecord with a nested path [1, 0] (sub-phase of conditional)
+    let nestedTurn = TurnRecord(
+      id: "t-nested", simulationId: "sim1",
+      roundNumber: 1, phaseType: "speak",
+      agentName: "Alice", rawOutput: "{}",
+      parsedOutputJSON: "{}", sequenceNumber: 1,
+      phasePathJSON: "[1,0]",
+      createdAt: Date(timeIntervalSince1970: 1)
+    )
+    // CodePhaseEventRecord with a top-level path [2]
+    let event = CodePhaseEventRecord(
+      id: "e-top", simulationId: "sim1",
+      roundNumber: 1, phaseType: "score_calc",
+      sequenceNumber: 2,
+      payloadJSON: "{\"type\":\"scoreUpdate\",\"scores\":{}}",
+      phasePathJSON: "[2]",
+      createdAt: Date(timeIntervalSince1970: 2)
+    )
+    // Legacy TurnRecord without phasePathJSON
+    let legacyTurn = makeTurn(round: 1, seq: 3)
+
+    let result = ResultDetailTimelineBuilder.build(
+      turns: [nestedTurn, legacyTurn], events: [event])
+
+    // Expected: sep(1), turn(seq=1), codePhase(seq=2), turn(seq=3)
+    #expect(result.count == 4)
+    if case .turn(let turn) = result[1] {
+      #expect(turn.sequenceNumber == 1)
+      #expect(result[1].phasePath == [1, 0])
+    } else {
+      Issue.record("result[1] not turn(nestedTurn)")
+    }
+    if case .codePhase = result[2] {
+      #expect(result[2].phasePath == [2])
+    } else {
+      Issue.record("result[2] not codePhase")
+    }
+    if case .turn(let turn) = result[3] {
+      #expect(turn.sequenceNumber == 3)
+      #expect(result[3].phasePath == nil)
+    } else {
+      Issue.record("result[3] not turn(legacyTurn)")
+    }
+  }
+
   // MARK: - Item identifiable
 
   @Test

--- a/Pastura/PasturaTests/App/ResultMarkdownExporterTests+PhasePath.swift
+++ b/Pastura/PasturaTests/App/ResultMarkdownExporterTests+PhasePath.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+// Sibling extension of `ResultMarkdownExporterTests` (see `.claude/rules/testing.md`
+// "Splitting a Suite Across Files"). The original suite carries
+// `.timeLimit(.minutes(1))` and `@MainActor`; these tests inherit both via the
+// extension and the shared fixtures (`makeTurn`, `makeSimulation`, …).
+extension ResultMarkdownExporterTests {
+
+  @Test func nestedAndTopLevelSamePhaseTypeProduceTwoDistinctHeadings() throws {
+    // path [0] → top-level, path [1,0] → nested sub-phase; same phaseType "speak_all"
+    // must produce two separate headings rather than collapsing into one.
+    let exporter = makeExporter()
+    let topLevel = makeTurn(
+      round: 1, seq: 1, phase: "speak_all",
+      agent: "Alice", fields: ["statement": "top level"],
+      phasePathJSON: "[0]")
+    let nested = makeTurn(
+      round: 1, seq: 2, phase: "speak_all",
+      agent: "Bob", fields: ["statement": "nested sub-phase"],
+      phasePathJSON: "[1,0]")
+    let input = ResultMarkdownExporter.Input(
+      simulation: makeSimulation(),
+      scenario: makeScenario(),
+      turns: [topLevel, nested],
+      state: makeState())
+
+    let result = try exporter.export(input)
+
+    #expect(result.text.contains("#### Phase: speak_all"))
+    #expect(result.text.contains("#### Sub-phase: speak_all (path [1, 0])"))
+    // Alice belongs under the top-level heading, Bob under the sub-phase heading.
+    let topRange = result.text.range(of: "#### Phase: speak_all")
+    let subRange = result.text.range(of: "#### Sub-phase: speak_all (path [1, 0])")
+    let aliceRange = result.text.range(of: "**Alice**")
+    let bobRange = result.text.range(of: "**Bob**")
+    #expect(topRange != nil && subRange != nil)
+    #expect(aliceRange != nil && bobRange != nil)
+    // Top-level heading should appear before the sub-phase heading (first-seen order).
+    if let top = topRange, let sub = subRange {
+      #expect(top.lowerBound < sub.lowerBound)
+    }
+    // Alice should appear before the sub-phase heading (she's in the top-level block).
+    if let alice = aliceRange, let sub = subRange {
+      #expect(alice.lowerBound < sub.lowerBound)
+    }
+    // Bob should appear after the sub-phase heading.
+    if let bob = bobRange, let sub = subRange {
+      #expect(bob.lowerBound > sub.lowerBound)
+    }
+  }
+
+  @Test func mixedEraLegacyAndTopLevelSamePhaseTypeGroupTogether() throws {
+    // Legacy (nil path) and v6 top-level ([0]) for the same phaseType must
+    // render under a single "#### Phase: speak_all" heading in sequence order.
+    let exporter = makeExporter()
+    let legacy = makeTurn(
+      round: 1, seq: 1, phase: "speak_all",
+      agent: "Alice", fields: ["statement": "legacy turn"],
+      phasePathJSON: nil)
+    let newTopLevel = makeTurn(
+      round: 1, seq: 2, phase: "speak_all",
+      agent: "Bob", fields: ["statement": "v6 turn"],
+      phasePathJSON: "[0]")
+    let input = ResultMarkdownExporter.Input(
+      simulation: makeSimulation(),
+      scenario: makeScenario(),
+      turns: [legacy, newTopLevel],
+      state: makeState())
+
+    let result = try exporter.export(input)
+
+    // Exactly one top-level heading for speak_all — not two.
+    let occurrences = result.text.components(separatedBy: "#### Phase: speak_all").count - 1
+    #expect(occurrences == 1)
+    // Both agents appear; Alice (legacy, seq=1) before Bob (v6, seq=2).
+    let aliceRange = result.text.range(of: "**Alice**")
+    let bobRange = result.text.range(of: "**Bob**")
+    #expect(aliceRange != nil && bobRange != nil)
+    if let alice = aliceRange, let bob = bobRange {
+      #expect(alice.lowerBound < bob.lowerBound)
+    }
+    // No sub-phase heading should appear.
+    #expect(!result.text.contains("#### Sub-phase:"))
+  }
+
+  @Test func orphanSubPhaseRendersWithoutParentHeading() throws {
+    // A conditional sub-phase turn (path [0,0]) without a top-level parent
+    // persisted must render as "#### Sub-phase: speak_all (path [0, 0])".
+    // No "#### Phase: speak_all" heading is expected.
+    let exporter = makeExporter()
+    let subPhaseTurn = makeTurn(
+      round: 1, seq: 1, phase: "speak_all",
+      agent: "Alice", fields: ["statement": "from sub-phase"],
+      phasePathJSON: "[0,0]")
+    let input = ResultMarkdownExporter.Input(
+      simulation: makeSimulation(),
+      scenario: makeScenario(),
+      turns: [subPhaseTurn],
+      state: makeState())
+
+    let result = try exporter.export(input)
+
+    #expect(result.text.contains("#### Sub-phase: speak_all (path [0, 0])"))
+    #expect(!result.text.contains("#### Phase: speak_all"))
+  }
+}

--- a/Pastura/PasturaTests/App/ResultMarkdownExporterTests.swift
+++ b/Pastura/PasturaTests/App/ResultMarkdownExporterTests.swift
@@ -6,12 +6,17 @@ import Testing
 @Suite(.timeLimit(.minutes(1))) @MainActor struct ResultMarkdownExporterTests {  // swiftlint:disable:this type_body_length
 
   // MARK: - Fixtures
+  //
+  // Helpers are at internal access (not `private`) so the
+  // `ResultMarkdownExporterTests+PhasePath.swift` sibling extension can reuse
+  // them. `private` members aren't visible to cross-file extensions — see
+  // `.claude/rules/testing.md` "Splitting a Suite Across Files".
 
-  private let createdAt = Date(timeIntervalSince1970: 1_712_000_000)  // 2024-04-01T19:33:20Z
-  private let updatedAt = Date(timeIntervalSince1970: 1_712_000_342)  // +5m 42s
-  private let exportAt = Date(timeIntervalSince1970: 1_713_000_000)  // 2024-04-13T08:53:20Z
+  let createdAt = Date(timeIntervalSince1970: 1_712_000_000)  // 2024-04-01T19:33:20Z
+  let updatedAt = Date(timeIntervalSince1970: 1_712_000_342)  // +5m 42s
+  let exportAt = Date(timeIntervalSince1970: 1_713_000_000)  // 2024-04-13T08:53:20Z
 
-  private func makeScenario(
+  func makeScenario(
     id: String = "s1",
     name: String = "Prisoners Dilemma",
     yaml: String = "name: Prisoners Dilemma\nrounds: 2\n"
@@ -21,7 +26,7 @@ import Testing
       isPreset: true, createdAt: Date(), updatedAt: Date())
   }
 
-  private func makeSimulation(
+  func makeSimulation(
     id: String = "sim1",
     scenarioId: String = "s1",
     status: SimulationStatus = .completed,
@@ -37,7 +42,7 @@ import Testing
       modelIdentifier: modelIdentifier, llmBackend: llmBackend)
   }
 
-  private func makeTurn(
+  func makeTurn(
     round: Int,
     seq: Int,
     phase: String,
@@ -62,7 +67,7 @@ import Testing
       createdAt: Date())
   }
 
-  private func makeState(
+  func makeState(
     scores: [String: Int] = ["Alice": 5, "Bob": 3],
     eliminated: [String: Bool] = [:]
   ) -> SimulationState {
@@ -77,7 +82,7 @@ import Testing
       currentRound: 2)
   }
 
-  private func makeExporter(
+  func makeExporter(
     filter: ContentFilter = ContentFilter(blockedPatterns: [])
   ) -> ResultMarkdownExporter {
     ResultMarkdownExporter(
@@ -354,102 +359,7 @@ import Testing
   }
 
   // MARK: - Phase path grouping
-
-  @Test func nestedAndTopLevelSamePhaseTypeProduceTwoDistinctHeadings() throws {
-    // path [0] → top-level, path [1,0] → nested sub-phase; same phaseType "speak_all"
-    // must produce two separate headings rather than collapsing into one.
-    let exporter = makeExporter()
-    let topLevel = makeTurn(
-      round: 1, seq: 1, phase: "speak_all",
-      agent: "Alice", fields: ["statement": "top level"],
-      phasePathJSON: "[0]")
-    let nested = makeTurn(
-      round: 1, seq: 2, phase: "speak_all",
-      agent: "Bob", fields: ["statement": "nested sub-phase"],
-      phasePathJSON: "[1,0]")
-    let input = ResultMarkdownExporter.Input(
-      simulation: makeSimulation(),
-      scenario: makeScenario(),
-      turns: [topLevel, nested],
-      state: makeState())
-
-    let result = try exporter.export(input)
-
-    #expect(result.text.contains("#### Phase: speak_all"))
-    #expect(result.text.contains("#### Sub-phase: speak_all (path [1, 0])"))
-    // Alice belongs under the top-level heading, Bob under the sub-phase heading.
-    let topLevelRange = result.text.range(of: "#### Phase: speak_all")
-    let subPhaseRange = result.text.range(of: "#### Sub-phase: speak_all (path [1, 0])")
-    let aliceRange = result.text.range(of: "**Alice**")
-    let bobRange = result.text.range(of: "**Bob**")
-    #expect(topLevelRange != nil && subPhaseRange != nil)
-    #expect(aliceRange != nil && bobRange != nil)
-    // Top-level heading should appear before the sub-phase heading (first-seen order).
-    if let tl = topLevelRange, let sp = subPhaseRange {
-      #expect(tl.lowerBound < sp.lowerBound)
-    }
-    // Alice should appear before the sub-phase heading (she's in the top-level block).
-    if let a = aliceRange, let sp = subPhaseRange {
-      #expect(a.lowerBound < sp.lowerBound)
-    }
-    // Bob should appear after the sub-phase heading.
-    if let b = bobRange, let sp = subPhaseRange {
-      #expect(b.lowerBound > sp.lowerBound)
-    }
-  }
-
-  @Test func mixedEraLegacyAndTopLevelSamePhaseTypeGroupTogether() throws {
-    // Legacy (nil path) and v6 top-level ([0]) for the same phaseType must
-    // render under a single "#### Phase: speak_all" heading in sequence order.
-    let exporter = makeExporter()
-    let legacy = makeTurn(
-      round: 1, seq: 1, phase: "speak_all",
-      agent: "Alice", fields: ["statement": "legacy turn"],
-      phasePathJSON: nil)
-    let newTopLevel = makeTurn(
-      round: 1, seq: 2, phase: "speak_all",
-      agent: "Bob", fields: ["statement": "v6 turn"],
-      phasePathJSON: "[0]")
-    let input = ResultMarkdownExporter.Input(
-      simulation: makeSimulation(),
-      scenario: makeScenario(),
-      turns: [legacy, newTopLevel],
-      state: makeState())
-
-    let result = try exporter.export(input)
-
-    // Exactly one top-level heading for speak_all — not two.
-    let occurrences = result.text.components(separatedBy: "#### Phase: speak_all").count - 1
-    #expect(occurrences == 1)
-    // Both agents appear; Alice (legacy, seq=1) before Bob (v6, seq=2).
-    let aliceRange = result.text.range(of: "**Alice**")
-    let bobRange = result.text.range(of: "**Bob**")
-    #expect(aliceRange != nil && bobRange != nil)
-    if let a = aliceRange, let b = bobRange {
-      #expect(a.lowerBound < b.lowerBound)
-    }
-    // No sub-phase heading should appear.
-    #expect(!result.text.contains("#### Sub-phase:"))
-  }
-
-  @Test func orphanSubPhaseRendersWithoutParentHeading() throws {
-    // A conditional sub-phase turn (path [0,0]) without a top-level parent
-    // persisted must render as "#### Sub-phase: speak_all (path [0, 0])".
-    // No "#### Phase: speak_all" heading is expected.
-    let exporter = makeExporter()
-    let subPhaseTurn = makeTurn(
-      round: 1, seq: 1, phase: "speak_all",
-      agent: "Alice", fields: ["statement": "from sub-phase"],
-      phasePathJSON: "[0,0]")
-    let input = ResultMarkdownExporter.Input(
-      simulation: makeSimulation(),
-      scenario: makeScenario(),
-      turns: [subPhaseTurn],
-      state: makeState())
-
-    let result = try exporter.export(input)
-
-    #expect(result.text.contains("#### Sub-phase: speak_all (path [0, 0])"))
-    #expect(!result.text.contains("#### Phase: speak_all"))
-  }
+  //
+  // Split into sibling file `ResultMarkdownExporterTests+PhasePath.swift` to
+  // stay under the 400-line file_length cap. See `.claude/rules/testing.md`.
 }

--- a/Pastura/PasturaTests/App/ResultMarkdownExporterTests.swift
+++ b/Pastura/PasturaTests/App/ResultMarkdownExporterTests.swift
@@ -42,7 +42,8 @@ import Testing
     seq: Int,
     phase: String,
     agent: String?,
-    fields: [String: String]
+    fields: [String: String],
+    phasePathJSON: String? = nil
   ) -> TurnRecord {
     let json =
       (try? JSONEncoder().encode(TurnOutput(fields: fields))).flatMap {
@@ -57,6 +58,7 @@ import Testing
       rawOutput: json,
       parsedOutputJSON: json,
       sequenceNumber: seq,
+      phasePathJSON: phasePathJSON,
       createdAt: Date())
   }
 
@@ -349,5 +351,105 @@ import Testing
     #expect(contents == result.text)
     #expect(result.fileURL.lastPathComponent.hasSuffix(".md"))
     #expect(result.fileURL.lastPathComponent.contains("test-scenario"))
+  }
+
+  // MARK: - Phase path grouping
+
+  @Test func nestedAndTopLevelSamePhaseTypeProduceTwoDistinctHeadings() throws {
+    // path [0] → top-level, path [1,0] → nested sub-phase; same phaseType "speak_all"
+    // must produce two separate headings rather than collapsing into one.
+    let exporter = makeExporter()
+    let topLevel = makeTurn(
+      round: 1, seq: 1, phase: "speak_all",
+      agent: "Alice", fields: ["statement": "top level"],
+      phasePathJSON: "[0]")
+    let nested = makeTurn(
+      round: 1, seq: 2, phase: "speak_all",
+      agent: "Bob", fields: ["statement": "nested sub-phase"],
+      phasePathJSON: "[1,0]")
+    let input = ResultMarkdownExporter.Input(
+      simulation: makeSimulation(),
+      scenario: makeScenario(),
+      turns: [topLevel, nested],
+      state: makeState())
+
+    let result = try exporter.export(input)
+
+    #expect(result.text.contains("#### Phase: speak_all"))
+    #expect(result.text.contains("#### Sub-phase: speak_all (path [1, 0])"))
+    // Alice belongs under the top-level heading, Bob under the sub-phase heading.
+    let topLevelRange = result.text.range(of: "#### Phase: speak_all")
+    let subPhaseRange = result.text.range(of: "#### Sub-phase: speak_all (path [1, 0])")
+    let aliceRange = result.text.range(of: "**Alice**")
+    let bobRange = result.text.range(of: "**Bob**")
+    #expect(topLevelRange != nil && subPhaseRange != nil)
+    #expect(aliceRange != nil && bobRange != nil)
+    // Top-level heading should appear before the sub-phase heading (first-seen order).
+    if let tl = topLevelRange, let sp = subPhaseRange {
+      #expect(tl.lowerBound < sp.lowerBound)
+    }
+    // Alice should appear before the sub-phase heading (she's in the top-level block).
+    if let a = aliceRange, let sp = subPhaseRange {
+      #expect(a.lowerBound < sp.lowerBound)
+    }
+    // Bob should appear after the sub-phase heading.
+    if let b = bobRange, let sp = subPhaseRange {
+      #expect(b.lowerBound > sp.lowerBound)
+    }
+  }
+
+  @Test func mixedEraLegacyAndTopLevelSamePhaseTypeGroupTogether() throws {
+    // Legacy (nil path) and v6 top-level ([0]) for the same phaseType must
+    // render under a single "#### Phase: speak_all" heading in sequence order.
+    let exporter = makeExporter()
+    let legacy = makeTurn(
+      round: 1, seq: 1, phase: "speak_all",
+      agent: "Alice", fields: ["statement": "legacy turn"],
+      phasePathJSON: nil)
+    let newTopLevel = makeTurn(
+      round: 1, seq: 2, phase: "speak_all",
+      agent: "Bob", fields: ["statement": "v6 turn"],
+      phasePathJSON: "[0]")
+    let input = ResultMarkdownExporter.Input(
+      simulation: makeSimulation(),
+      scenario: makeScenario(),
+      turns: [legacy, newTopLevel],
+      state: makeState())
+
+    let result = try exporter.export(input)
+
+    // Exactly one top-level heading for speak_all — not two.
+    let occurrences = result.text.components(separatedBy: "#### Phase: speak_all").count - 1
+    #expect(occurrences == 1)
+    // Both agents appear; Alice (legacy, seq=1) before Bob (v6, seq=2).
+    let aliceRange = result.text.range(of: "**Alice**")
+    let bobRange = result.text.range(of: "**Bob**")
+    #expect(aliceRange != nil && bobRange != nil)
+    if let a = aliceRange, let b = bobRange {
+      #expect(a.lowerBound < b.lowerBound)
+    }
+    // No sub-phase heading should appear.
+    #expect(!result.text.contains("#### Sub-phase:"))
+  }
+
+  @Test func orphanSubPhaseRendersWithoutParentHeading() throws {
+    // A conditional sub-phase turn (path [0,0]) without a top-level parent
+    // persisted must render as "#### Sub-phase: speak_all (path [0, 0])".
+    // No "#### Phase: speak_all" heading is expected.
+    let exporter = makeExporter()
+    let subPhaseTurn = makeTurn(
+      round: 1, seq: 1, phase: "speak_all",
+      agent: "Alice", fields: ["statement": "from sub-phase"],
+      phasePathJSON: "[0,0]")
+    let input = ResultMarkdownExporter.Input(
+      simulation: makeSimulation(),
+      scenario: makeScenario(),
+      turns: [subPhaseTurn],
+      state: makeState())
+
+    let result = try exporter.export(input)
+
+    #expect(result.text.contains("#### Sub-phase: speak_all (path [0, 0])"))
+    #expect(!result.text.contains("#### Phase: speak_all"))
   }
 }

--- a/Pastura/PasturaTests/App/SimulationViewModelCodePhasePersistenceTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelCodePhasePersistenceTests.swift
@@ -209,4 +209,110 @@ struct SimulationViewModelCodePhasePersistenceTests {
     #expect(records.count == 1)
     #expect(records.first?.roundNumber == 0)
   }
+
+  // MARK: - phasePath lineage (#143)
+
+  @Test func topLevelPhaseStartedPersistsPathOnAgentOutput() async throws {
+    let sut = try makeSUT()
+    sut.model.handleEvent(.roundStarted(round: 1, totalRounds: 1), scenario: sut.scenario)
+    sut.model.handleEvent(
+      .phaseStarted(phaseType: .speakAll, phasePath: [0]), scenario: sut.scenario)
+    sut.model.handleEvent(
+      .agentOutput(
+        agent: "Alice",
+        output: TurnOutput(fields: ["statement": "hi"]),
+        phaseType: .speakAll),
+      scenario: sut.scenario)
+
+    await sut.model.finishPersistenceForTest()
+
+    let turns = try sut.turnRepo.fetchBySimulationId(sut.simId)
+    #expect(turns.count == 1)
+    #expect(turns.first?.phasePath == [0])
+  }
+
+  @Test func topLevelPhaseStartedPersistsPathOnCodePhaseEvent() async throws {
+    let sut = try makeSUT()
+    sut.model.handleEvent(.roundStarted(round: 1, totalRounds: 1), scenario: sut.scenario)
+    sut.model.handleEvent(
+      .phaseStarted(phaseType: .scoreCalc, phasePath: [2]), scenario: sut.scenario)
+    sut.model.handleEvent(
+      .scoreUpdate(scores: ["Alice": 1]), scenario: sut.scenario)
+
+    await sut.model.finishPersistenceForTest()
+
+    let records = try sut.codeRepo.fetchBySimulationId(sut.simId)
+    #expect(records.count == 1)
+    #expect(records.first?.phasePath == [2])
+  }
+
+  @Test func nestedSubPhasePersistsInnerPath() async throws {
+    // Mimics ConditionalHandler: outer conditional phaseStarted, then inner
+    // sub-phase phaseStarted at [outer, inner], then agent output.
+    let sut = try makeSUT()
+    sut.model.handleEvent(.roundStarted(round: 1, totalRounds: 1), scenario: sut.scenario)
+    sut.model.handleEvent(
+      .phaseStarted(phaseType: .conditional, phasePath: [1]), scenario: sut.scenario)
+    sut.model.handleEvent(
+      .phaseStarted(phaseType: .speakAll, phasePath: [1, 0]), scenario: sut.scenario)
+    sut.model.handleEvent(
+      .agentOutput(
+        agent: "Alice",
+        output: TurnOutput(fields: ["statement": "sub"]),
+        phaseType: .speakAll),
+      scenario: sut.scenario)
+
+    await sut.model.finishPersistenceForTest()
+
+    let turns = try sut.turnRepo.fetchBySimulationId(sut.simId)
+    #expect(turns.count == 1)
+    #expect(turns.first?.phasePath == [1, 0])
+  }
+
+  @Test func phasePathPopsOnInnerPhaseCompleted() async throws {
+    // Critical test (critic axis 4): after the inner sub-phase completes, a
+    // subsequent event — still inside the outer conditional but before any
+    // new .phaseStarted — must be attributed to the outer path [1], NOT the
+    // stale inner [1, 0]. Without the pop, the "exact parallel to
+    // currentPhaseType" would inherit the documented shadowing bug.
+    let sut = try makeSUT()
+    sut.model.handleEvent(.roundStarted(round: 1, totalRounds: 1), scenario: sut.scenario)
+    sut.model.handleEvent(
+      .phaseStarted(phaseType: .conditional, phasePath: [1]), scenario: sut.scenario)
+    sut.model.handleEvent(
+      .phaseStarted(phaseType: .summarize, phasePath: [1, 0]), scenario: sut.scenario)
+    sut.model.handleEvent(
+      .summary(text: "inner"), scenario: sut.scenario)
+    sut.model.handleEvent(
+      .phaseCompleted(phaseType: .summarize, phasePath: [1, 0]), scenario: sut.scenario)
+    // Hypothetical tail emission from the outer conditional bracket — path
+    // should be [1], not the stale inner [1, 0].
+    sut.model.handleEvent(
+      .summary(text: "outer tail"), scenario: sut.scenario)
+
+    await sut.model.finishPersistenceForTest()
+
+    let records = try sut.codeRepo.fetchBySimulationId(sut.simId)
+    let inner = try #require(records.first { $0.payloadJSON.contains("inner") })
+    let outer = try #require(records.first { $0.payloadJSON.contains("outer tail") })
+    #expect(inner.phasePath == [1, 0])
+    #expect(outer.phasePath == [1])
+  }
+
+  @Test func phasePathNilBeforeFirstPhaseStarted() async throws {
+    // Defensive: events that fire before any .phaseStarted (e.g., round-zero
+    // validator warnings) must store phasePathJSON = nil, not an empty array
+    // or a stale value from a previous run.
+    let sut = try makeSUT()
+    sut.model.handleEvent(.roundStarted(round: 1, totalRounds: 1), scenario: sut.scenario)
+    sut.model.handleEvent(
+      .scoreUpdate(scores: ["Alice": 1]), scenario: sut.scenario)
+
+    await sut.model.finishPersistenceForTest()
+
+    let records = try sut.codeRepo.fetchBySimulationId(sut.simId)
+    #expect(records.count == 1)
+    #expect(records.first?.phasePathJSON == nil)
+    #expect(records.first?.phasePath == nil)
+  }
 }

--- a/Pastura/PasturaTests/Data/CodePhaseEventRecordTests.swift
+++ b/Pastura/PasturaTests/Data/CodePhaseEventRecordTests.swift
@@ -123,4 +123,49 @@ import Testing
 
     #expect(sorted.map { $0.id } == ["c1", "c2", "c3"])
   }
+
+  @Test func phasePathJSONRoundTrip() throws {
+    let manager = try makeManagerWithSimulation()
+    let now = Date()
+
+    try manager.dbWriter.write { db in
+      var record = CodePhaseEventRecord(
+        id: "c1", simulationId: "sim1",
+        roundNumber: 1, phaseType: "summarize",
+        sequenceNumber: 1,
+        payloadJSON: #"{"summary":{"text":"hi"}}"#,
+        phasePathJSON: "[2,0]",
+        createdAt: now)
+      try record.insert(db)
+    }
+
+    let fetched = try manager.dbWriter.read { db in
+      try CodePhaseEventRecord.fetchOne(db, key: "c1")
+    }
+
+    #expect(fetched?.phasePathJSON == "[2,0]")
+    #expect(fetched?.phasePath == [2, 0])
+  }
+
+  @Test func phasePathDefaultsToNilForLegacyCallers() throws {
+    let manager = try makeManagerWithSimulation()
+    let now = Date()
+
+    try manager.dbWriter.write { db in
+      var record = CodePhaseEventRecord(
+        id: "c1", simulationId: "sim1",
+        roundNumber: 1, phaseType: "score_calc",
+        sequenceNumber: 1,
+        payloadJSON: "{}",
+        createdAt: now)
+      try record.insert(db)
+    }
+
+    let fetched = try manager.dbWriter.read { db in
+      try CodePhaseEventRecord.fetchOne(db, key: "c1")
+    }
+
+    #expect(fetched?.phasePathJSON == nil)
+    #expect(fetched?.phasePath == nil)
+  }
 }

--- a/Pastura/PasturaTests/Data/TurnRecordTests.swift
+++ b/Pastura/PasturaTests/Data/TurnRecordTests.swift
@@ -123,4 +123,77 @@ import Testing
       #expect(count == 0)
     }
   }
+
+  @Test func phasePathJSONRoundTrip() throws {
+    let manager = try makeManagerWithSimulation()
+    let now = Date()
+
+    try manager.dbWriter.write { db in
+      var turn = TurnRecord(
+        id: "t1", simulationId: "sim1",
+        roundNumber: 1, phaseType: "speak_all",
+        agentName: "Alice", rawOutput: "raw",
+        parsedOutputJSON: "{}",
+        phasePathJSON: "[1,0]",
+        createdAt: now)
+      try turn.insert(db)
+    }
+
+    let fetched = try manager.dbWriter.read { db in
+      try TurnRecord.fetchOne(db, key: "t1")
+    }
+
+    #expect(fetched?.phasePathJSON == "[1,0]")
+    #expect(fetched?.phasePath == [1, 0])
+  }
+
+  @Test func phasePathDefaultsToNilForLegacyCallers() throws {
+    let manager = try makeManagerWithSimulation()
+    let now = Date()
+
+    // Constructor with no phasePathJSON — matches every existing call site.
+    try manager.dbWriter.write { db in
+      var turn = TurnRecord(
+        id: "t1", simulationId: "sim1",
+        roundNumber: 1, phaseType: "speak_all",
+        agentName: "Alice", rawOutput: "raw",
+        parsedOutputJSON: "{}", createdAt: now)
+      try turn.insert(db)
+    }
+
+    let fetched = try manager.dbWriter.read { db in
+      try TurnRecord.fetchOne(db, key: "t1")
+    }
+
+    #expect(fetched?.phasePathJSON == nil)
+    #expect(fetched?.phasePath == nil)
+  }
+
+  @Test func phasePathDecoderHandlesEdgeCases() {
+    // Empty / NULL / malformed all decode to nil — single source of truth for
+    // consumer fallback ("legacy row = unknown path").
+    let base = TurnRecord(
+      id: "t", simulationId: "sim", roundNumber: 1, phaseType: "speak_all",
+      agentName: "A", rawOutput: "", parsedOutputJSON: "{}", createdAt: Date())
+
+    var withNil = base
+    withNil.phasePathJSON = nil
+    #expect(withNil.phasePath == nil)
+
+    var withEmpty = base
+    withEmpty.phasePathJSON = ""
+    #expect(withEmpty.phasePath == nil)
+
+    var withMalformed = base
+    withMalformed.phasePathJSON = "not-json"
+    #expect(withMalformed.phasePath == nil)
+
+    var withTopLevel = base
+    withTopLevel.phasePathJSON = "[2]"
+    #expect(withTopLevel.phasePath == [2])
+
+    var withNested = base
+    withNested.phasePathJSON = "[0,3]"
+    #expect(withNested.phasePath == [0, 3])
+  }
 }


### PR DESCRIPTION
## Summary

- Persist `phasePathJSON` (the `[Int]` lineage from `SimulationEvent.phasePath`) on `turns` and `code_phase_events` so scenarios with a top-level `speak_all` + a conditional-nested `speak_all` no longer collapse into one indistinguishable section in exports.
- `SimulationViewModel` pushes `currentPhasePath` on `.phaseStarted` and pops on `.phaseCompleted` (when path matches and `count > 1`), closing the shadowing gap the critic flagged as Critical — a code-phase event in the gap between an inner sub-phase's completion and the next `.phaseStarted` now attributes to the outer path.
- Markdown exporter groups by `PhaseGroupKey` (`.topLevel` / `.nested`) → produces `#### Phase: X` for top-level + legacy, and `#### Sub-phase: X (path [K, N])` for nested. Mixed-era invariant (legacy `NULL` + new `[0]`) preserved.
- Past-results viewer indents sub-phase rows with a `↳ sub-phase` caption.
- Rewrote stale `YAMLReplayExporter` drift comments that promised this migration would lift their limitations (comment-only).

## Test plan

- [x] Unit: v6 migration round-trip on both tables (`TurnRecordTests.phasePathJSONRoundTrip`, `CodePhaseEventRecordTests.phasePathJSONRoundTrip`)
- [x] Unit: legacy rows read as `phasePath == nil` (`phasePathDefaultsToNilForLegacyCallers` ×2, `phasePathDecoderHandlesEdgeCases`)
- [x] Unit: VM encodes top-level / nested paths into both record types (`topLevelPhaseStartedPersistsPathOn{Agent,CodePhase}`, `nestedSubPhasePersistsInnerPath`)
- [x] Unit: pop-on-completion prevents sub-phase leak (`phasePathPopsOnInnerPhaseCompleted`)
- [x] Unit: pre-first-`.phaseStarted` events persist with `phasePathJSON == nil` (`phasePathNilBeforeFirstPhaseStarted`)
- [x] Unit: exporter disambiguates nested vs top-level, preserves mixed-era identity, renders orphan sub-phase (`nestedAndTopLevelSamePhaseTypeProduceTwoDistinctHeadings`, `mixedEraLegacyAndTopLevelSamePhaseTypeGroupTogether`, `orphanSubPhaseRendersWithoutParentHeading`)
- [x] Unit: timeline builder exposes `phasePath` pass-through (`itemPhasePathPassesThroughFromUnderlyingRecord`)
- [x] Full suite: \`xcodebuild test\` → \`TEST SUCCEEDED\`
- [x] \`swiftlint lint --quiet --strict\` clean
- [x] Manual QA: export a \`conditional\`-containing scenario and confirm Markdown has a \`#### Sub-phase:\` block
- [x] Manual QA: open an older completed simulation from past-results and confirm rows still render (legacy NULL path = no indent)

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)