### PR TITLE
📝 docs: correct comments from PR #182 post-merge followup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,15 +72,17 @@ jobs:
           # `set -eo pipefail` (GHA default) from aborting the script before
           # PIPESTATUS is captured.
           #
-          # `-parallel-testing-enabled NO` — EXPERIMENTAL (#182). Disables
-          # multi-simulator-clone parallelism to test the resource-exhaustion
-          # hypothesis for the signal-trap cascade first observed on `main`
-          # post-#186 (e650f13). Symptoms: trivial unit tests taking ~3.1s
-          # each on CI (vs <10 ms locally), followed by a test-host crash
-          # that marks hundreds of queued tests as "signal trap". If this
-          # flag stabilises CI, the fix is likely a targeted
-          # `-parallel-testing-worker-count 2` rather than full
-          # serialisation — revisit once we have a passing baseline.
+          # `-parallel-testing-enabled NO` — workaround for CI OOM cascade
+          # first observed on `main` post-#186 (sha e650f13). Multiple
+          # simulator clones on the macos-26 runner (~7 GB RAM) pushed the
+          # test host over the OOM threshold; symptoms were trivial unit
+          # tests taking ~3.1 s each (vs <10 ms locally) followed by a
+          # host kill that marked 262–736 queued tests as "signal trap".
+          # With this flag, `lint-and-test` completes in ~8 min — well
+          # within the 10-min budget (CLAUDE.md). Root-cause investigation
+          # is tracked in #189; when that lands, revisit whether to restore
+          # full parallelism or settle on a targeted
+          # `-parallel-testing-worker-count N`.
           xcodebuild test \
             -scheme Pastura \
             -project Pastura/Pastura.xcodeproj \

--- a/Pastura/PasturaTests/App/ModelManagerTests.swift
+++ b/Pastura/PasturaTests/App/ModelManagerTests.swift
@@ -58,14 +58,25 @@ struct ModelManagerTests {
       expectedSHA256: expectedSHA256
     )
     // Proactively wipe residual files at the shared Application Support /
-    // Caches paths. The `.serialized` suite's per-test `defer { removeItem }`
-    // blocks are declared AFTER `await sut.downloadModel()` — if any
-    // download-triggering test crashes (signal trap) before that defer
-    // registers, the model file leaks and every subsequent `.notDownloaded`
-    // assertion in the suite fails spuriously. Observed on CI post-#186
-    // (macos-26 runner under parallel-suite scheduling pressure).
+    // Caches paths. Each per-test `defer { removeItem }` is declared AFTER
+    // `await sut.downloadModel()` — if a download-triggering test crashes
+    // before its defer registers, the model file leaks and every
+    // subsequent `.notDownloaded` assertion in the suite fails
+    // spuriously. The upstream cleanup here breaks that cascade so the
+    // actual failing test surfaces cleanly. Per-test defers are kept as
+    // defense-in-depth for the same-test window and are intentional — do
+    // not remove them as "redundant".
+    //
+    // First observed on CI post-#186 (sha e650f13) on the macos-26
+    // runner; the underlying CI host-kill is unrelated to filesystem
+    // state (CI OOM; root cause tracked in #189).
     try? FileManager.default.removeItem(at: sut.modelFileURL)
     try? FileManager.default.removeItem(at: sut.downloadFileURL)
+    // Loud guard: surface permission / sandbox oddities that `try?` would
+    // otherwise swallow. A silent no-op here would let the cascade recur
+    // invisibly.
+    #expect(!FileManager.default.fileExists(atPath: sut.modelFileURL.path))
+    #expect(!FileManager.default.fileExists(atPath: sut.downloadFileURL.path))
     return sut
   }
 


### PR DESCRIPTION
## Summary

Followup to #187 (#182). Tightens two comments and adds two guard assertions that landed with the Support URL PR but drifted from what we now understand about the CI issue.

## Changes

- **`ci.yml`**: reframe the `-parallel-testing-enabled NO` comment from "EXPERIMENTAL" to "workaround for CI OOM cascade" and reference the root-cause tracking issue #189. Adds the measured ~8 min baseline so future readers can judge whether re-enabling parallelism is worth revisiting.
- **`ModelManagerTests.makeSUT()` comment**: drop the speculative "parallel-suite scheduling pressure" causal claim. Critic verified the new #186 suites (`ReplayViewModelTests`, `DemoReplayIntegrationTests`) don't share filesystem state with ModelManager, so the original comment pointed the next debugger at the wrong layer. Rewritten to cleanly separate the cascade-break mechanism (correct and load-bearing) from the CI host-kill cause (OOM, tracked separately).
- **Two unaddressed code-review suggestions from #182**:
  - `#expect(!fileExists(...))` after the cleanup so silent permission / sandbox no-ops fail loudly instead of letting the cascade recur invisibly.
  - One-line note that the per-test `defer { removeItem }` blocks elsewhere in `ModelManagerTests` are intentional defense-in-depth for the same-test window, not redundant.

Behavioural no-op for the cleanup logic and the CI flag — only the comments and two new `#expect` guards change.

## Test plan

- [x] Local `ModelManagerTests` pass with the new `#expect` guards inside `makeSUT()`.
- [x] CI remains green with the same `-parallel-testing-enabled NO` workaround.
- [ ] Future work tracked in #189 (restore parallel testing once OOM root cause is understood).

Closes nothing (tracking issue #189 remains open by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)