### PR TITLE
📝 docs: require end-to-end run before merging gallery scenarios (#96)

### DIFF
--- a/docs/gallery/README.md
+++ b/docs/gallery/README.md
@@ -90,7 +90,19 @@ Gallery scenarios are public and curator-endorsed. Keep content:
    shasum -a 256 docs/gallery/<id>.yaml
    ```
 5. Add an entry to `gallery.json` with the hash, URL, and metadata.
-6. Open a PR. The scenario becomes available in the app after merge —
+6. **Run end-to-end before merging.** Push the feature branch, run a
+   Debug build (so `PASTURA_GALLERY_BASE_URL` takes effect — see *Testing
+   changes from a feature branch* below), and open the scenario from
+   Share Board. Either (a) on a physical device with the bundled
+   llama.cpp model already downloaded, or (b) in the iOS Simulator
+   pointing at a local Ollama with the recommended model pulled. Run a
+   full simulation and read the output. Confirm: rounds reach a
+   meaningful conclusion (no truncation), agent personas come through
+   clearly, and total inferences match the `estimated_inferences`
+   ballpark. (Content-filter triggers are an authoring-time concern —
+   see the *Content guidelines* bullet above and
+   `App/ContentFilter.swift`.)
+7. Open a PR. The scenario becomes available in the app after merge —
    the app uses ETag-conditional GET, so users pick up the update on
    their next Share Board visit.
 


### PR DESCRIPTION
## Summary
- Adds a **"Run end-to-end before merging"** step to the gallery curation checklist in `docs/gallery/README.md`.
- Directly motivated by `detective_scene_v1` shipping with a truncated-after-Round-1 experience despite `GallerySeedYAMLTests` passing — structural validation alone doesn't catch curator-quality regressions.
- Incorporates critic review: explicit *push the branch* prerequisite, Debug-build requirement for `PASTURA_GALLERY_BASE_URL`, two concrete LLM backend paths (on-device llama.cpp / Simulator + Ollama). NG-word item dropped in favor of the existing *Content guidelines* bullet + `App/ContentFilter.swift` cross-reference to avoid asking curators to confirm an absence they can't visually observe.

## Follow-up
- Re-curate `detective_scene_v1` (bump rounds, add a final summarize/vote phase so discussion converges) — separate PR per critic's scope recommendation.

## Test plan
- [x] Verified the new step flows cleanly in the numbered list (1 → 7).
- [x] Confirmed the *Testing changes from a feature branch* section the new step references still exists at the same heading text.
- [ ] (Post-merge) Apply the new rule to the `detective_scene_v1` fix PR as the first worked example.

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)