### PR TITLE
✨ feat: scenario editor — unified phase drag UI (#144)

### DIFF
--- a/.claude/rules/navigation.md
+++ b/.claude/rules/navigation.md
@@ -121,14 +121,60 @@ Run these whenever the navigation surface changes:
    sees the view is no longer on top, and no spurious push to
    `ScenarioDetailView` occurs. (Backgrounding the app does **not** pop
    views, so it does not exercise this guard.)
-5. **Conditional phase — nested sub-phase editor** — In the scenario editor,
-   add a `conditional` phase, tap it to open `PhaseEditorSheet`, enter a
-   condition, tap **Add sub-phase** inside the Then branch. Expected: a
-   nested `PhaseEditorSheet` presents with the `conditional` option
-   *absent* from the type picker (depth-1 UI enforcement). Change the
-   sub-phase type, save, return to the outer editor. Save the outer
-   phase and confirm the top-level scenario list shows the condition
-   summary with `then:N else:M` counts. The nested sheet is sheet-owned,
-   so its own NavigationStack is fine — this QA just confirms that the
-   presentation chain (outer sheet → inner sheet) dismisses cleanly
-   without leaking `.conditional` into nested depths.
+5. **Conditional phase — nested sub-phase editor + sub-phase drag** —
+   In the scenario editor, add a `conditional` phase, tap it to open
+   `PhaseEditorSheet`, enter a condition, tap **Add sub-phase** inside
+   the Then branch. Expected: a nested `PhaseEditorSheet` presents with
+   the `conditional` option *absent* from the type picker (depth-1 UI
+   enforcement). Change the sub-phase type, save, return to the outer
+   editor. Save the outer phase and confirm the top-level scenario list
+   shows the condition summary with `then:N else:M` counts. The nested
+   sheet is sheet-owned, so its own NavigationStack is fine — this QA
+   just confirms that the presentation chain (outer sheet → inner
+   sheet) dismisses cleanly without leaking `.conditional` into nested
+   depths.
+
+   Drag UX — add 2–3 sub-phases to each branch, then verify all of:
+   - **Within-branch reorder** — long-press the drag handle of any
+     sub-phase and drag up/down within the same branch. Expected:
+     top-edge insertion line appears under the hovered row, release
+     completes the move.
+   - **Cross-branch drag** — drag a sub-phase from Then into Else (or
+     vice versa). Expected: Else rows highlight the insertion line as
+     the drag enters, release inserts the sub-phase into the target
+     branch at the hovered index.
+   - **Drop into empty branch** — delete all Else sub-phases so the
+     branch shows the dashed "No sub-phases yet" placeholder, then
+     drag a Then sub-phase into the placeholder. Expected: placeholder
+     text switches to "Drop here" on hover, release inserts into Else.
+   - **Tap-to-edit + swipe-to-delete still work** — tap the content
+     area of any row → opens nested editor. Swipe left on any row →
+     reveals Delete action. These must coexist with drag without
+     gesture swallowing.
+   - **Context menu move actions** — long-press the content area (not
+     the handle) of any sub-phase. Expected: "Move Up", "Move Down",
+     "Move to Then/Else Branch" options. Boundary items are disabled
+     (no Move Up on first row, no Move Down on last row).
+   - **Depth-2 nested sheets have no branches** — the nested sheet
+     opened by editing a sub-phase does not contain Then/Else sections
+     (since `.conditional` is filtered out), so this drag feature does
+     not apply at that depth. Confirm no drag affordances appear.
+
+6. **Top-level phase list — drag reorder + context menu** — In the
+   scenario editor at the top level, add 3+ phases to a scenario.
+   Verify:
+   - **Drag handle reorder** — long-press the `line.3.horizontal`
+     handle on any row and drag to reorder. Expected: top-edge
+     insertion line under the hovered row, release completes the move.
+     Tap-to-edit (on the content area) and swipe-to-delete must still
+     work.
+   - **Context menu** — long-press the content area (not the handle)
+     of any phase. Expected: "Move Up" / "Move Down" actions with
+     boundary items disabled.
+   - **Empty list drop target renders** — remove all phases so the
+     dashed "No phases yet" placeholder appears, then add a phase via
+     the Add Phase button and confirm the list repopulates. The empty
+     placeholder also serves as a drop target, but since sub-phases
+     and top-level phases are never on screen together, cross-surface
+     drag is blocked by construction (distinct `Transferable` payload
+     types); no interactive test is needed.

--- a/Pastura/Pastura/App/EditablePhase.swift
+++ b/Pastura/Pastura/App/EditablePhase.swift
@@ -11,6 +11,11 @@ import Foundation
 /// `.conditional` out of the type picker when `PhaseEditorSheet` is opened
 /// for a nested phase.
 struct EditablePhase: Identifiable, Sendable {
+  /// Which branch of a `conditional` phase a sub-phase belongs to.
+  enum Branch: String, Codable, Sendable, CaseIterable {
+    case then
+    case `else`
+  }
   let id = UUID()
   var type: PhaseType
   var prompt: String
@@ -77,6 +82,57 @@ struct EditablePhase: Identifiable, Sendable {
     self.elsePhases = phase.elsePhases?.map { EditablePhase(from: $0) } ?? []
   }
 
+  /// Moves a sub-phase identified by `id` into `branch` at `destinationIndex`.
+  ///
+  /// **Destination-index convention:** `destinationIndex` is the *final* index
+  /// in the destination array after the move — i.e. where the item ends up
+  /// after insertion. This differs from SwiftUI's `.onMove(fromOffsets:toOffset:)`
+  /// which uses a pre-removal index.
+  ///
+  /// **Clamp behaviour:**
+  /// - Cross-branch: clamp to `destinationBranch.count` (before insert).
+  /// - Within-branch: after the item is removed the array shrinks by one;
+  ///   clamp to `count - 1` (post-removal length).
+  /// - If `destinationIndex < 0`, clamp to `0`.
+  ///
+  /// **Unknown UUID:** no-op — no mutation, no crash.
+  mutating func moveSubPhase(id sourceId: UUID, to branch: Branch, at destinationIndex: Int) {
+    // Locate the item in either branch.
+    let inThen = thenPhases.firstIndex(where: { $0.id == sourceId })
+    let inElse = elsePhases.firstIndex(where: { $0.id == sourceId })
+
+    guard let sourceIndex = inThen ?? inElse else { return }
+    let sourceBranch: Branch = inThen != nil ? .then : .else
+
+    if sourceBranch == branch {
+      // Within-branch move: remove first, then insert at clamped destination.
+      var array = sourceBranch == .then ? thenPhases : elsePhases
+      let item = array.remove(at: sourceIndex)
+      // After removal the array is one shorter; clamp into the reduced range.
+      let clampedDest = Swift.max(0, Swift.min(destinationIndex, array.count))
+      array.insert(item, at: clampedDest)
+      if sourceBranch == .then {
+        thenPhases = array
+      } else {
+        elsePhases = array
+      }
+    } else {
+      // Cross-branch move.
+      var source = sourceBranch == .then ? thenPhases : elsePhases
+      var dest = branch == .then ? thenPhases : elsePhases
+      let item = source.remove(at: sourceIndex)
+      let clampedDest = Swift.max(0, Swift.min(destinationIndex, dest.count))
+      dest.insert(item, at: clampedDest)
+      if sourceBranch == .then {
+        thenPhases = source
+        elsePhases = dest
+      } else {
+        elsePhases = source
+        thenPhases = dest
+      }
+    }
+  }
+
   func toPhase() -> Phase {
     let trimmedTarget = target.trimmingCharacters(in: .whitespacesAndNewlines)
     let trimmedCondition = condition.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -98,5 +154,23 @@ struct EditablePhase: Identifiable, Sendable {
       thenPhases: thenPhases.isEmpty ? nil : thenPhases.map { $0.toPhase() },
       elsePhases: elsePhases.isEmpty ? nil : elsePhases.map { $0.toPhase() }
     )
+  }
+}
+
+extension Array where Element == EditablePhase {
+  /// Moves the phase with `id` to `destinationIndex` within this array.
+  ///
+  /// **Destination-index convention:** `destinationIndex` is the *final* index
+  /// after the move — where the item ends up after insertion. After removal the
+  /// array shrinks by one; `destinationIndex` is clamped to the post-removal
+  /// count (i.e. the last valid insertion index). If `destinationIndex < 0`,
+  /// clamp to `0`.
+  ///
+  /// **Unknown UUID:** no-op — no mutation, no crash.
+  mutating func movePhase(id sourceId: UUID, to destinationIndex: Int) {
+    guard let sourceIndex = firstIndex(where: { $0.id == sourceId }) else { return }
+    let item = remove(at: sourceIndex)
+    let clampedDest = Swift.max(0, Swift.min(destinationIndex, count))
+    insert(item, at: clampedDest)
   }
 }

--- a/Pastura/Pastura/App/PhaseDragPayload.swift
+++ b/Pastura/Pastura/App/PhaseDragPayload.swift
@@ -1,0 +1,30 @@
+import CoreTransferable
+import Foundation
+import UniformTypeIdentifiers
+
+/// Drag payload for a sub-phase within a `conditional` phase's branch.
+///
+/// `id` is sheet-session-scoped — it matches `EditablePhase.id` which is
+/// assigned at editor-session time and is **not** persisted to disk. Never
+/// serialize this value to a durable store.
+struct SubPhaseDragPayload: Codable, Transferable {
+  let id: UUID
+  let sourceBranch: EditablePhase.Branch
+
+  static var transferRepresentation: some TransferRepresentation {
+    CodableRepresentation(contentType: .data)
+  }
+}
+
+/// Drag payload for a top-level phase in the scenario editor.
+///
+/// `id` is sheet-session-scoped — it matches `EditablePhase.id` which is
+/// assigned at editor-session time and is **not** persisted to disk. Never
+/// serialize this value to a durable store.
+struct TopLevelPhaseDragPayload: Codable, Transferable {
+  let id: UUID
+
+  static var transferRepresentation: some TransferRepresentation {
+    CodableRepresentation(contentType: .data)
+  }
+}

--- a/Pastura/Pastura/Views/Editor/PhaseBlockRow.swift
+++ b/Pastura/Pastura/Views/Editor/PhaseBlockRow.swift
@@ -3,31 +3,43 @@ import SwiftUI
 /// A compact card row representing a single phase in the scenario editor's phase list.
 ///
 /// Displays a drag handle, the phase type badge, and a brief content summary.
+/// The `handle` and `content` subviews are exposed separately so the drag-
+/// enabled row in the scenario editor can attach `.draggable` to the handle
+/// alone, leaving tap + context-menu long-press gestures on the content.
 struct PhaseBlockRow: View {
   let phase: EditablePhase
 
   var body: some View {
     HStack(spacing: 10) {
-      // Drag handle
-      Image(systemName: "line.3.horizontal")
-        .foregroundStyle(.secondary)
-        .frame(width: 20)
-
-      // Phase type badge
-      PhaseTypeLabel(phaseType: phase.type)
-
-      // Content summary
-      Text(summary)
-        .font(.subheadline)
-        .foregroundStyle(.secondary)
-        .lineLimit(1)
-        .truncationMode(.tail)
-
+      handle
+      content
       Spacer()
     }
     .padding(.vertical, 8)
     .padding(.horizontal, 12)
     .background(.background, in: RoundedRectangle(cornerRadius: 10))
+  }
+
+  /// Drag-handle icon. Exposed separately so callers that want to scope
+  /// `.draggable` to the handle (instead of the whole row) can attach the
+  /// modifier here.
+  var handle: some View {
+    Image(systemName: "line.3.horizontal")
+      .foregroundStyle(.secondary)
+      .frame(width: 20)
+      .accessibilityHidden(true)
+  }
+
+  /// Non-handle portion of the row — phase type badge + content summary.
+  var content: some View {
+    HStack(spacing: 10) {
+      PhaseTypeLabel(phaseType: phase.type)
+      Text(summary)
+        .font(.subheadline)
+        .foregroundStyle(.secondary)
+        .lineLimit(1)
+        .truncationMode(.tail)
+    }
   }
 
   /// A brief human-readable summary of the phase content.

--- a/Pastura/Pastura/Views/Editor/PhaseEditorSheet+SubPhaseDrag.swift
+++ b/Pastura/Pastura/Views/Editor/PhaseEditorSheet+SubPhaseDrag.swift
@@ -216,6 +216,10 @@ private struct BranchTailDropZone: View {
     }
   }
 
+  private var branchName: String {
+    branch == .then ? "Then" : "Else"
+  }
+
   private var emptyBranchPlaceholder: some View {
     HStack {
       Spacer()
@@ -233,11 +237,7 @@ private struct BranchTailDropZone: View {
           style: StrokeStyle(lineWidth: 1, dash: [4])
         )
     )
-    .accessibilityLabel(
-      branch == .then
-        ? "Then branch, empty. Drop sub-phases here."
-        : "Else branch, empty. Drop sub-phases here."
-    )
+    .accessibilityLabel("\(branchName) branch, empty. Drop sub-phases here.")
   }
 
   private var tailHitStrip: some View {

--- a/Pastura/Pastura/Views/Editor/PhaseEditorSheet+SubPhaseDrag.swift
+++ b/Pastura/Pastura/Views/Editor/PhaseEditorSheet+SubPhaseDrag.swift
@@ -1,0 +1,255 @@
+import SwiftUI
+
+// Drag/drop + context-menu UI for the conditional-phase editor's
+// `then` / `else` sub-phase branches.
+//
+// Why this lives in a sibling file:
+// - `PhaseEditorSheet.swift` already approaches SwiftLint's `file_length`
+//   warning threshold; splitting keeps both files under 400 lines.
+// - The drag pieces (row view, tail drop zone, context-menu actions) are
+//   a cohesive feature cluster that does not need to interleave with the
+//   non-conditional phase type sections above.
+//
+// Design notes:
+// - Drag is scoped to the `line.3.horizontal` handle image — NOT the whole
+//   row — so that `.contextMenu` (also long-press-activated) and
+//   `.onTapGesture` (tap-to-edit) don't fight `.draggable` for the same
+//   gesture. `.onDelete` (swipe) continues to work because it's applied to
+//   the outer `ForEach`, independent of row content.
+// - `.dropDestination(for:isTargeted:)` returns visual feedback through
+//   per-row `isTargeted` state so the user sees a top-edge insertion line
+//   at the hovered row. The branch's tail zone uses the same mechanism.
+// - Within-branch reorder and cross-branch move go through the same
+//   `EditablePhase.moveSubPhase(id:to:at:)` contract: row-level drops
+//   insert at the hovered row's index, tail drops insert at `count`.
+
+extension PhaseEditorSheet {
+  @ViewBuilder
+  func branchSection(
+    title: String,
+    branch: EditablePhase.Branch
+  ) -> some View {
+    Section(title) {
+      ForEach(subPhases(in: branch)) { subPhase in
+        SubPhaseRowView(
+          phase: $phase,
+          subPhase: subPhase,
+          branch: branch,
+          onEdit: {
+            editingSubPhase = SubPhaseEditContext(branch: branch, phase: subPhase)
+          }
+        )
+      }
+      .onDelete { indexSet in
+        removeSubPhases(at: indexSet, in: branch)
+      }
+
+      BranchTailDropZone(phase: $phase, branch: branch)
+
+      Button {
+        addSubPhase(to: branch)
+      } label: {
+        Label("Add sub-phase", systemImage: "plus.circle")
+      }
+    }
+  }
+
+  private func subPhases(in branch: EditablePhase.Branch) -> [EditablePhase] {
+    branch == .then ? phase.thenPhases : phase.elsePhases
+  }
+
+  private func removeSubPhases(at indexSet: IndexSet, in branch: EditablePhase.Branch) {
+    switch branch {
+    case .then: phase.thenPhases.remove(atOffsets: indexSet)
+    case .else: phase.elsePhases.remove(atOffsets: indexSet)
+    }
+  }
+
+  private func addSubPhase(to branch: EditablePhase.Branch) {
+    let newPhase = EditablePhase()
+    switch branch {
+    case .then: phase.thenPhases.append(newPhase)
+    case .else: phase.elsePhases.append(newPhase)
+    }
+    editingSubPhase = SubPhaseEditContext(branch: branch, phase: newPhase)
+  }
+}
+
+/// One row in a conditional phase's `then` / `else` branch.
+///
+/// Owns its own `isTargeted` state so only the hovered row shows the
+/// top-edge insertion indicator. `@Binding var phase` propagates move
+/// mutations back to the parent editor so branch arrays update in place.
+private struct SubPhaseRowView: View {
+  @Binding var phase: EditablePhase
+  let subPhase: EditablePhase
+  let branch: EditablePhase.Branch
+  let onEdit: () -> Void
+
+  @State private var isTargeted = false
+
+  private var phases: [EditablePhase] {
+    branch == .then ? phase.thenPhases : phase.elsePhases
+  }
+
+  private var index: Int {
+    phases.firstIndex(where: { $0.id == subPhase.id }) ?? 0
+  }
+
+  private var totalCount: Int {
+    phases.count
+  }
+
+  var body: some View {
+    HStack(spacing: 10) {
+      Image(systemName: "line.3.horizontal")
+        .foregroundStyle(.secondary)
+        .frame(width: 20)
+        .accessibilityHidden(true)
+        .draggable(SubPhaseDragPayload(id: subPhase.id, sourceBranch: branch)) {
+          HStack(spacing: 6) {
+            Image(systemName: "line.3.horizontal")
+              .foregroundStyle(.secondary)
+            Text(subPhase.type.rawValue)
+              .font(.body.monospaced())
+          }
+          .padding(8)
+          .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 6))
+        }
+
+      HStack {
+        Text(subPhase.type.rawValue)
+          .font(.body.monospaced())
+          .foregroundStyle(.primary)
+        Spacer()
+        Image(systemName: "chevron.right")
+          .foregroundStyle(.secondary)
+          .font(.caption)
+      }
+      .contentShape(Rectangle())
+      .onTapGesture { onEdit() }
+    }
+    .contentShape(Rectangle())
+    .overlay(alignment: .top) {
+      if isTargeted {
+        Rectangle()
+          .fill(.tint)
+          .frame(height: 2)
+      }
+    }
+    .dropDestination(for: SubPhaseDragPayload.self) { payloads, _ in
+      guard let payload = payloads.first else { return false }
+      phase.moveSubPhase(id: payload.id, to: branch, at: index)
+      return true
+    } isTargeted: {
+      isTargeted = $0
+    }
+    .accessibilityLabel(accessibilityText)
+    .accessibilityHint("Long-press for move options, tap to edit.")
+    .contextMenu { contextMenuButtons }
+  }
+
+  private var accessibilityText: String {
+    let branchName = branch == .then ? "Then branch" : "Else branch"
+    return "\(branchName), item \(index + 1) of \(totalCount), \(subPhase.type.rawValue)"
+  }
+
+  @ViewBuilder
+  private var contextMenuButtons: some View {
+    Button {
+      phase.moveSubPhase(id: subPhase.id, to: branch, at: index - 1)
+    } label: {
+      Label("Move Up", systemImage: "arrow.up")
+    }
+    .disabled(index == 0)
+
+    Button {
+      phase.moveSubPhase(id: subPhase.id, to: branch, at: index + 1)
+    } label: {
+      Label("Move Down", systemImage: "arrow.down")
+    }
+    .disabled(index >= totalCount - 1)
+
+    let other: EditablePhase.Branch = branch == .then ? .else : .then
+    let otherLabel = other == .then ? "Move to Then Branch" : "Move to Else Branch"
+    Button {
+      let targetCount = other == .then ? phase.thenPhases.count : phase.elsePhases.count
+      phase.moveSubPhase(id: subPhase.id, to: other, at: targetCount)
+    } label: {
+      Label(otherLabel, systemImage: "arrow.left.arrow.right")
+    }
+  }
+}
+
+/// Drop target that sits at the end of a branch so users can drop a
+/// sub-phase after the last existing row — or into an empty branch.
+///
+/// Shows a dashed-border "Drop here" placeholder when the branch is
+/// empty (both for discoverability and to communicate the drop target
+/// even when no hover is active). When non-empty, the zone collapses to
+/// a slim strip that only draws the insertion line while hovered.
+private struct BranchTailDropZone: View {
+  @Binding var phase: EditablePhase
+  let branch: EditablePhase.Branch
+
+  @State private var isTargeted = false
+
+  private var phases: [EditablePhase] {
+    branch == .then ? phase.thenPhases : phase.elsePhases
+  }
+
+  var body: some View {
+    Group {
+      if phases.isEmpty {
+        emptyBranchPlaceholder
+      } else {
+        tailHitStrip
+      }
+    }
+    .contentShape(Rectangle())
+    .dropDestination(for: SubPhaseDragPayload.self) { payloads, _ in
+      guard let payload = payloads.first else { return false }
+      phase.moveSubPhase(id: payload.id, to: branch, at: phases.count)
+      return true
+    } isTargeted: {
+      isTargeted = $0
+    }
+  }
+
+  private var emptyBranchPlaceholder: some View {
+    HStack {
+      Spacer()
+      Text(isTargeted ? "Drop here" : "No sub-phases yet")
+        .font(.caption)
+        .foregroundStyle(isTargeted ? Color.accentColor : .secondary)
+      Spacer()
+    }
+    .frame(minHeight: 32)
+    .padding(.vertical, 6)
+    .background(
+      RoundedRectangle(cornerRadius: 6)
+        .stroke(
+          isTargeted ? Color.accentColor : Color.secondary.opacity(0.4),
+          style: StrokeStyle(lineWidth: 1, dash: [4])
+        )
+    )
+    .accessibilityLabel(
+      branch == .then
+        ? "Then branch, empty. Drop sub-phases here."
+        : "Else branch, empty. Drop sub-phases here."
+    )
+  }
+
+  private var tailHitStrip: some View {
+    Color.clear
+      .frame(maxWidth: .infinity, minHeight: 12)
+      .overlay(alignment: .top) {
+        if isTargeted {
+          Rectangle()
+            .fill(.tint)
+            .frame(height: 2)
+        }
+      }
+      .accessibilityHidden(true)
+  }
+}

--- a/Pastura/Pastura/Views/Editor/PhaseEditorSheet.swift
+++ b/Pastura/Pastura/Views/Editor/PhaseEditorSheet.swift
@@ -1,16 +1,11 @@
 import SwiftUI
 
-/// Which branch of a conditional phase a nested sub-phase editor is editing.
-/// Lifted to file scope to satisfy SwiftLint's nesting rule (types nested
-/// deeper than 1 level are disallowed).
-private enum ConditionalBranch { case then, `else` }
-
 /// Identifies which branch's sub-phase is currently being edited via a
 /// nested `PhaseEditorSheet`. `.sheet(item:)` drives the presentation;
 /// `onSave` on the nested sheet writes back to the right branch.
 private struct SubPhaseEditContext: Identifiable {
   let id = UUID()
-  let branch: ConditionalBranch
+  let branch: EditablePhase.Branch
   var phase: EditablePhase
 }
 
@@ -221,7 +216,7 @@ struct PhaseEditorSheet: View {
   private func branchSection(
     title: String,
     phases: Binding<[EditablePhase]>,
-    branch: ConditionalBranch
+    branch: EditablePhase.Branch
   ) -> some View {
     Section(title) {
       ForEach(phases.wrappedValue) { subPhase in

--- a/Pastura/Pastura/Views/Editor/PhaseEditorSheet.swift
+++ b/Pastura/Pastura/Views/Editor/PhaseEditorSheet.swift
@@ -3,7 +3,11 @@ import SwiftUI
 /// Identifies which branch's sub-phase is currently being edited via a
 /// nested `PhaseEditorSheet`. `.sheet(item:)` drives the presentation;
 /// `onSave` on the nested sheet writes back to the right branch.
-private struct SubPhaseEditContext: Identifiable {
+///
+/// Module-internal (rather than file-private) because
+/// `PhaseEditorSheet+SubPhaseDrag.swift` creates instances when the user
+/// adds a new sub-phase via the drag-enabled editor.
+struct SubPhaseEditContext: Identifiable {
   let id = UUID()
   let branch: EditablePhase.Branch
   var phase: EditablePhase
@@ -29,7 +33,10 @@ struct PhaseEditorSheet: View {
 
   @State private var newOutputFieldName: String = ""
   @State private var newOptionText: String = ""
-  @State private var editingSubPhase: SubPhaseEditContext?
+  // Internal (not private) so the sibling extension in
+  // `PhaseEditorSheet+SubPhaseDrag.swift` can present the nested editor
+  // when adding a new sub-phase.
+  @State var editingSubPhase: SubPhaseEditContext?
 
   var body: some View {
     NavigationStack {
@@ -199,59 +206,14 @@ struct PhaseEditorSheet: View {
         .font(.caption)
       }
 
-      branchSection(
-        title: "Then branch (condition true)",
-        phases: $phase.thenPhases,
-        branch: .then
-      )
-      branchSection(
-        title: "Else branch (condition false)",
-        phases: $phase.elsePhases,
-        branch: .else
-      )
+      branchSection(title: "Then branch (condition true)", branch: .then)
+      branchSection(title: "Else branch (condition false)", branch: .else)
     }
   }
 
-  @ViewBuilder
-  private func branchSection(
-    title: String,
-    phases: Binding<[EditablePhase]>,
-    branch: EditablePhase.Branch
-  ) -> some View {
-    Section(title) {
-      ForEach(phases.wrappedValue) { subPhase in
-        Button {
-          editingSubPhase = SubPhaseEditContext(branch: branch, phase: subPhase)
-        } label: {
-          HStack {
-            Text(subPhase.type.rawValue)
-              .font(.body.monospaced())
-              .foregroundStyle(.primary)
-            Spacer()
-            Image(systemName: "chevron.right")
-              .foregroundStyle(.secondary)
-              .font(.caption)
-          }
-        }
-      }
-      .onDelete { indexSet in
-        phases.wrappedValue.remove(atOffsets: indexSet)
-      }
-      .onMove { source, destination in
-        // Within-branch reorder only — cross-branch drag is deliberately
-        // unsupported in v1 (tracked as a follow-up).
-        phases.wrappedValue.move(fromOffsets: source, toOffset: destination)
-      }
-
-      Button {
-        let newPhase = EditablePhase()
-        phases.wrappedValue.append(newPhase)
-        editingSubPhase = SubPhaseEditContext(branch: branch, phase: newPhase)
-      } label: {
-        Label("Add sub-phase", systemImage: "plus.circle")
-      }
-    }
-  }
+  // `branchSection(title:branch:)` and its drag helpers live in
+  // `PhaseEditorSheet+SubPhaseDrag.swift` (sibling extension file) to keep
+  // this file under SwiftLint's `file_length` limit.
 
   // MARK: - Type-Specific Sections
 

--- a/Pastura/Pastura/Views/Editor/ScenarioEditorView+PhaseDrag.swift
+++ b/Pastura/Pastura/Views/Editor/ScenarioEditorView+PhaseDrag.swift
@@ -1,0 +1,161 @@
+import SwiftUI
+
+// Drag/drop + context-menu row for the top-level scenario phase list.
+//
+// Mirrors the sub-phase drag architecture in
+// `PhaseEditorSheet+SubPhaseDrag.swift`:
+// - Drag is scoped to the `line.3.horizontal` handle image (not the full
+//   row) so `.contextMenu` (long-press) and `.onTapGesture` (tap-to-edit)
+//   don't contend with `.draggable` for the same gesture.
+// - `.dropDestination` draws a top-edge insertion line while hovered,
+//   inserting at the hovered row's index.
+// - `PhaseListTailDropZone` handles drops at the end of the list.
+//
+// A separate payload type (`TopLevelPhaseDragPayload`) prevents cross-layer
+// contamination: a sub-phase payload cannot be dropped onto a top-level
+// row — and vice versa — because `.dropDestination(for:)` filters by
+// Transferable type.
+
+/// One row in the scenario editor's top-level phase list.
+///
+/// Owns its own `isTargeted` state so only the hovered row shows the
+/// top-edge insertion indicator.
+struct PhaseRowView: View {
+  @Binding var phases: [EditablePhase]
+  let phase: EditablePhase
+  let onEdit: () -> Void
+
+  @State private var isTargeted = false
+
+  private var index: Int {
+    phases.firstIndex(where: { $0.id == phase.id }) ?? 0
+  }
+
+  private var totalCount: Int {
+    phases.count
+  }
+
+  var body: some View {
+    let blockRow = PhaseBlockRow(phase: phase)
+    HStack(spacing: 10) {
+      blockRow.handle
+        .draggable(TopLevelPhaseDragPayload(id: phase.id)) {
+          HStack(spacing: 6) {
+            Image(systemName: "line.3.horizontal")
+              .foregroundStyle(.secondary)
+            PhaseTypeLabel(phaseType: phase.type)
+          }
+          .padding(8)
+          .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 6))
+        }
+      blockRow.content
+        .contentShape(Rectangle())
+        .onTapGesture { onEdit() }
+      Spacer()
+    }
+    .padding(.vertical, 8)
+    .padding(.horizontal, 12)
+    .background(.background, in: RoundedRectangle(cornerRadius: 10))
+    .overlay(alignment: .top) {
+      if isTargeted {
+        Rectangle()
+          .fill(.tint)
+          .frame(height: 2)
+      }
+    }
+    .dropDestination(for: TopLevelPhaseDragPayload.self) { payloads, _ in
+      guard let payload = payloads.first else { return false }
+      phases.movePhase(id: payload.id, to: index)
+      return true
+    } isTargeted: {
+      isTargeted = $0
+    }
+    .accessibilityLabel(accessibilityText)
+    .accessibilityHint("Long-press for move options, tap to edit.")
+    .contextMenu { contextMenuButtons }
+  }
+
+  private var accessibilityText: String {
+    "Phase \(index + 1) of \(totalCount), \(phase.type.rawValue)"
+  }
+
+  @ViewBuilder
+  private var contextMenuButtons: some View {
+    Button {
+      phases.movePhase(id: phase.id, to: index - 1)
+    } label: {
+      Label("Move Up", systemImage: "arrow.up")
+    }
+    .disabled(index == 0)
+
+    Button {
+      phases.movePhase(id: phase.id, to: index + 1)
+    } label: {
+      Label("Move Down", systemImage: "arrow.down")
+    }
+    .disabled(index >= totalCount - 1)
+  }
+}
+
+/// Drop target that sits at the end of the top-level phase list so users
+/// can drop a phase after the last existing row — or into an empty list.
+///
+/// When the list is empty, expands into a dashed-border "Drop here"
+/// placeholder so the target is discoverable. When non-empty, collapses
+/// to a slim strip that only draws the insertion line while hovered.
+struct PhaseListTailDropZone: View {
+  @Binding var phases: [EditablePhase]
+
+  @State private var isTargeted = false
+
+  var body: some View {
+    Group {
+      if phases.isEmpty {
+        emptyListPlaceholder
+      } else {
+        tailHitStrip
+      }
+    }
+    .contentShape(Rectangle())
+    .dropDestination(for: TopLevelPhaseDragPayload.self) { payloads, _ in
+      guard let payload = payloads.first else { return false }
+      phases.movePhase(id: payload.id, to: phases.count)
+      return true
+    } isTargeted: {
+      isTargeted = $0
+    }
+  }
+
+  private var emptyListPlaceholder: some View {
+    HStack {
+      Spacer()
+      Text(isTargeted ? "Drop here" : "No phases yet")
+        .font(.caption)
+        .foregroundStyle(isTargeted ? Color.accentColor : .secondary)
+      Spacer()
+    }
+    .frame(minHeight: 32)
+    .padding(.vertical, 6)
+    .background(
+      RoundedRectangle(cornerRadius: 6)
+        .stroke(
+          isTargeted ? Color.accentColor : Color.secondary.opacity(0.4),
+          style: StrokeStyle(lineWidth: 1, dash: [4])
+        )
+    )
+    .accessibilityLabel("Phase list empty. Drop phases here.")
+  }
+
+  private var tailHitStrip: some View {
+    Color.clear
+      .frame(maxWidth: .infinity, minHeight: 12)
+      .overlay(alignment: .top) {
+        if isTargeted {
+          Rectangle()
+            .fill(.tint)
+            .frame(height: 2)
+        }
+      }
+      .accessibilityHidden(true)
+  }
+}

--- a/Pastura/Pastura/Views/Editor/ScenarioEditorView.swift
+++ b/Pastura/Pastura/Views/Editor/ScenarioEditorView.swift
@@ -204,19 +204,17 @@ struct ScenarioEditorView: View {
   private var phasesSection: some View {
     Section {
       ForEach(viewModel.phases) { phase in
-        Button {
-          editingPhase = phase
-        } label: {
-          PhaseBlockRow(phase: phase)
-        }
-        .buttonStyle(.plain)
+        PhaseRowView(
+          phases: $viewModel.phases,
+          phase: phase,
+          onEdit: { editingPhase = phase }
+        )
       }
       .onDelete { indexSet in
         viewModel.phases.remove(atOffsets: indexSet)
       }
-      .onMove { source, destination in
-        viewModel.phases.move(fromOffsets: source, toOffset: destination)
-      }
+
+      PhaseListTailDropZone(phases: $viewModel.phases)
 
       Button {
         showNewPhaseSheet = true
@@ -233,6 +231,9 @@ struct ScenarioEditorView: View {
       }
     }
   }
+  // `PhaseRowView` / `PhaseListTailDropZone` live in
+  // `ScenarioEditorView+PhaseDrag.swift` (sibling file) — separated to
+  // keep this file under SwiftLint's `file_length` limit.
 
   // MARK: - YAML Editor
 

--- a/Pastura/PasturaTests/App/EditablePhaseSubPhaseMoveTests.swift
+++ b/Pastura/PasturaTests/App/EditablePhaseSubPhaseMoveTests.swift
@@ -1,0 +1,168 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+@Suite(.timeLimit(.minutes(1)))
+@MainActor
+struct EditablePhaseSubPhaseMoveTests {
+  // MARK: - Helpers
+
+  private func makePhase(type: PhaseType = .speakAll) -> EditablePhase {
+    EditablePhase(type: type)
+  }
+
+  private func makeConditional(
+    thenPhases: [EditablePhase] = [],
+    elsePhases: [EditablePhase] = []
+  ) -> EditablePhase {
+    EditablePhase(type: .conditional, thenPhases: thenPhases, elsePhases: elsePhases)
+  }
+
+  // MARK: - moveSubPhase within-branch forward
+
+  @Test func moveSubPhaseWithinBranchForward() {
+    let a = makePhase()
+    let b = makePhase()
+    let c = makePhase()
+    var sut = makeConditional(thenPhases: [a, b, c])
+
+    sut.moveSubPhase(id: a.id, to: .then, at: 2)
+
+    #expect(sut.thenPhases.map(\.id) == [b.id, c.id, a.id])
+  }
+
+  // MARK: - moveSubPhase within-branch backward
+
+  @Test func moveSubPhaseWithinBranchBackward() {
+    let a = makePhase()
+    let b = makePhase()
+    let c = makePhase()
+    var sut = makeConditional(thenPhases: [a, b, c])
+
+    sut.moveSubPhase(id: c.id, to: .then, at: 0)
+
+    #expect(sut.thenPhases.map(\.id) == [c.id, a.id, b.id])
+  }
+
+  // MARK: - moveSubPhase same-branch onto self (no-op)
+
+  @Test func moveSubPhaseSameBranchOntoSelf() {
+    let a = makePhase()
+    let b = makePhase()
+    let c = makePhase()
+    var sut = makeConditional(thenPhases: [a, b, c])
+
+    sut.moveSubPhase(id: b.id, to: .then, at: 1)
+
+    #expect(sut.thenPhases.map(\.id) == [a.id, b.id, c.id])
+  }
+
+  // MARK: - moveSubPhase cross-branch
+
+  @Test func moveSubPhaseCrossBranch() {
+    let a = makePhase()
+    let b = makePhase()
+    let c = makePhase()
+    let d = makePhase()
+    let e = makePhase()
+    var sut = makeConditional(thenPhases: [a, b, c], elsePhases: [d, e])
+
+    sut.moveSubPhase(id: b.id, to: .else, at: 1)
+
+    #expect(sut.thenPhases.map(\.id) == [a.id, c.id])
+    #expect(sut.elsePhases.map(\.id) == [d.id, b.id, e.id])
+  }
+
+  // MARK: - moveSubPhase cross-branch into empty target
+
+  @Test func moveSubPhaseCrossBranchIntoEmptyTarget() {
+    let a = makePhase()
+    let b = makePhase()
+    let c = makePhase()
+    var sut = makeConditional(thenPhases: [a, b, c], elsePhases: [])
+
+    sut.moveSubPhase(id: a.id, to: .else, at: 0)
+
+    #expect(sut.thenPhases.map(\.id) == [b.id, c.id])
+    #expect(sut.elsePhases.map(\.id) == [a.id])
+  }
+
+  // MARK: - destination index > count clamps to end
+
+  @Test func moveSubPhaseDestinationIndexClampsToEnd() {
+    let a = makePhase()
+    let b = makePhase()
+    let c = makePhase()
+    var sut = makeConditional(thenPhases: [a, b, c])
+
+    sut.moveSubPhase(id: a.id, to: .then, at: 99)
+
+    #expect(sut.thenPhases.map(\.id) == [b.id, c.id, a.id])
+  }
+
+  // MARK: - unknown UUID is a no-op
+
+  @Test func moveSubPhaseUnknownUUIDIsNoOp() {
+    let a = makePhase()
+    let b = makePhase()
+    let c = makePhase()
+    var sut = makeConditional(thenPhases: [a, b, c])
+
+    sut.moveSubPhase(id: UUID(), to: .then, at: 0)
+
+    #expect(sut.thenPhases.map(\.id) == [a.id, b.id, c.id])
+  }
+
+  // MARK: - SubPhaseDragPayload round-trip
+
+  @Test func subPhaseDragPayloadRoundTrip() throws {
+    let id = UUID()
+    let original = SubPhaseDragPayload(id: id, sourceBranch: .then)
+
+    let data = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(SubPhaseDragPayload.self, from: data)
+
+    #expect(decoded.id == original.id)
+    #expect(decoded.sourceBranch == original.sourceBranch)
+  }
+
+  // MARK: - Array<EditablePhase>.movePhase within-list forward
+
+  @Test func arrayMovePhaseForward() {
+    let a = makePhase()
+    let b = makePhase()
+    let c = makePhase()
+    var phases = [a, b, c]
+
+    phases.movePhase(id: a.id, to: 2)
+
+    #expect(phases.map(\.id) == [b.id, c.id, a.id])
+  }
+
+  // MARK: - Array<EditablePhase>.movePhase within-list backward
+
+  @Test func arrayMovePhaseBackward() {
+    let a = makePhase()
+    let b = makePhase()
+    let c = makePhase()
+    var phases = [a, b, c]
+
+    phases.movePhase(id: c.id, to: 0)
+
+    #expect(phases.map(\.id) == [c.id, a.id, b.id])
+  }
+
+  // MARK: - Array<EditablePhase>.movePhase unknown UUID is a no-op
+
+  @Test func arrayMovePhaseUnknownUUIDIsNoOp() {
+    let a = makePhase()
+    let b = makePhase()
+    let c = makePhase()
+    var phases = [a, b, c]
+
+    phases.movePhase(id: UUID(), to: 0)
+
+    #expect(phases.map(\.id) == [a.id, b.id, c.id])
+  }
+}

--- a/Pastura/PasturaTests/App/EditablePhaseSubPhaseMoveTests.swift
+++ b/Pastura/PasturaTests/App/EditablePhaseSubPhaseMoveTests.swift
@@ -22,96 +22,99 @@ struct EditablePhaseSubPhaseMoveTests {
   // MARK: - moveSubPhase within-branch forward
 
   @Test func moveSubPhaseWithinBranchForward() {
-    let a = makePhase()
-    let b = makePhase()
-    let c = makePhase()
-    var sut = makeConditional(thenPhases: [a, b, c])
+    let phaseA = makePhase()
+    let phaseB = makePhase()
+    let phaseC = makePhase()
+    var sut = makeConditional(thenPhases: [phaseA, phaseB, phaseC])
 
-    sut.moveSubPhase(id: a.id, to: .then, at: 2)
+    sut.moveSubPhase(id: phaseA.id, to: .then, at: 2)
 
-    #expect(sut.thenPhases.map(\.id) == [b.id, c.id, a.id])
+    #expect(sut.thenPhases.map(\.id) == [phaseB.id, phaseC.id, phaseA.id])
   }
 
   // MARK: - moveSubPhase within-branch backward
 
   @Test func moveSubPhaseWithinBranchBackward() {
-    let a = makePhase()
-    let b = makePhase()
-    let c = makePhase()
-    var sut = makeConditional(thenPhases: [a, b, c])
+    let phaseA = makePhase()
+    let phaseB = makePhase()
+    let phaseC = makePhase()
+    var sut = makeConditional(thenPhases: [phaseA, phaseB, phaseC])
 
-    sut.moveSubPhase(id: c.id, to: .then, at: 0)
+    sut.moveSubPhase(id: phaseC.id, to: .then, at: 0)
 
-    #expect(sut.thenPhases.map(\.id) == [c.id, a.id, b.id])
+    #expect(sut.thenPhases.map(\.id) == [phaseC.id, phaseA.id, phaseB.id])
   }
 
   // MARK: - moveSubPhase same-branch onto self (no-op)
 
   @Test func moveSubPhaseSameBranchOntoSelf() {
-    let a = makePhase()
-    let b = makePhase()
-    let c = makePhase()
-    var sut = makeConditional(thenPhases: [a, b, c])
+    let phaseA = makePhase()
+    let phaseB = makePhase()
+    let phaseC = makePhase()
+    var sut = makeConditional(thenPhases: [phaseA, phaseB, phaseC])
 
-    sut.moveSubPhase(id: b.id, to: .then, at: 1)
+    sut.moveSubPhase(id: phaseB.id, to: .then, at: 1)
 
-    #expect(sut.thenPhases.map(\.id) == [a.id, b.id, c.id])
+    #expect(sut.thenPhases.map(\.id) == [phaseA.id, phaseB.id, phaseC.id])
   }
 
   // MARK: - moveSubPhase cross-branch
 
   @Test func moveSubPhaseCrossBranch() {
-    let a = makePhase()
-    let b = makePhase()
-    let c = makePhase()
-    let d = makePhase()
-    let e = makePhase()
-    var sut = makeConditional(thenPhases: [a, b, c], elsePhases: [d, e])
+    let phaseA = makePhase()
+    let phaseB = makePhase()
+    let phaseC = makePhase()
+    let phaseD = makePhase()
+    let phaseE = makePhase()
+    var sut = makeConditional(
+      thenPhases: [phaseA, phaseB, phaseC],
+      elsePhases: [phaseD, phaseE]
+    )
 
-    sut.moveSubPhase(id: b.id, to: .else, at: 1)
+    sut.moveSubPhase(id: phaseB.id, to: .else, at: 1)
 
-    #expect(sut.thenPhases.map(\.id) == [a.id, c.id])
-    #expect(sut.elsePhases.map(\.id) == [d.id, b.id, e.id])
+    #expect(sut.thenPhases.map(\.id) == [phaseA.id, phaseC.id])
+    #expect(sut.elsePhases.map(\.id) == [phaseD.id, phaseB.id, phaseE.id])
   }
 
   // MARK: - moveSubPhase cross-branch into empty target
 
   @Test func moveSubPhaseCrossBranchIntoEmptyTarget() {
-    let a = makePhase()
-    let b = makePhase()
-    let c = makePhase()
-    var sut = makeConditional(thenPhases: [a, b, c], elsePhases: [])
+    let phaseA = makePhase()
+    let phaseB = makePhase()
+    let phaseC = makePhase()
+    var sut = makeConditional(thenPhases: [phaseA, phaseB, phaseC], elsePhases: [])
 
-    sut.moveSubPhase(id: a.id, to: .else, at: 0)
+    sut.moveSubPhase(id: phaseA.id, to: .else, at: 0)
 
-    #expect(sut.thenPhases.map(\.id) == [b.id, c.id])
-    #expect(sut.elsePhases.map(\.id) == [a.id])
+    #expect(sut.thenPhases.map(\.id) == [phaseB.id, phaseC.id])
+    #expect(sut.elsePhases.map(\.id) == [phaseA.id])
   }
 
   // MARK: - destination index > count clamps to end
 
   @Test func moveSubPhaseDestinationIndexClampsToEnd() {
-    let a = makePhase()
-    let b = makePhase()
-    let c = makePhase()
-    var sut = makeConditional(thenPhases: [a, b, c])
+    let phaseA = makePhase()
+    let phaseB = makePhase()
+    let phaseC = makePhase()
+    var sut = makeConditional(thenPhases: [phaseA, phaseB, phaseC])
 
-    sut.moveSubPhase(id: a.id, to: .then, at: 99)
+    sut.moveSubPhase(id: phaseA.id, to: .then, at: 99)
 
-    #expect(sut.thenPhases.map(\.id) == [b.id, c.id, a.id])
+    #expect(sut.thenPhases.map(\.id) == [phaseB.id, phaseC.id, phaseA.id])
   }
 
   // MARK: - unknown UUID is a no-op
 
   @Test func moveSubPhaseUnknownUUIDIsNoOp() {
-    let a = makePhase()
-    let b = makePhase()
-    let c = makePhase()
-    var sut = makeConditional(thenPhases: [a, b, c])
+    let phaseA = makePhase()
+    let phaseB = makePhase()
+    let phaseC = makePhase()
+    var sut = makeConditional(thenPhases: [phaseA, phaseB, phaseC])
 
     sut.moveSubPhase(id: UUID(), to: .then, at: 0)
 
-    #expect(sut.thenPhases.map(\.id) == [a.id, b.id, c.id])
+    #expect(sut.thenPhases.map(\.id) == [phaseA.id, phaseB.id, phaseC.id])
   }
 
   // MARK: - SubPhaseDragPayload round-trip
@@ -130,39 +133,39 @@ struct EditablePhaseSubPhaseMoveTests {
   // MARK: - Array<EditablePhase>.movePhase within-list forward
 
   @Test func arrayMovePhaseForward() {
-    let a = makePhase()
-    let b = makePhase()
-    let c = makePhase()
-    var phases = [a, b, c]
+    let phaseA = makePhase()
+    let phaseB = makePhase()
+    let phaseC = makePhase()
+    var phases = [phaseA, phaseB, phaseC]
 
-    phases.movePhase(id: a.id, to: 2)
+    phases.movePhase(id: phaseA.id, to: 2)
 
-    #expect(phases.map(\.id) == [b.id, c.id, a.id])
+    #expect(phases.map(\.id) == [phaseB.id, phaseC.id, phaseA.id])
   }
 
   // MARK: - Array<EditablePhase>.movePhase within-list backward
 
   @Test func arrayMovePhaseBackward() {
-    let a = makePhase()
-    let b = makePhase()
-    let c = makePhase()
-    var phases = [a, b, c]
+    let phaseA = makePhase()
+    let phaseB = makePhase()
+    let phaseC = makePhase()
+    var phases = [phaseA, phaseB, phaseC]
 
-    phases.movePhase(id: c.id, to: 0)
+    phases.movePhase(id: phaseC.id, to: 0)
 
-    #expect(phases.map(\.id) == [c.id, a.id, b.id])
+    #expect(phases.map(\.id) == [phaseC.id, phaseA.id, phaseB.id])
   }
 
   // MARK: - Array<EditablePhase>.movePhase unknown UUID is a no-op
 
   @Test func arrayMovePhaseUnknownUUIDIsNoOp() {
-    let a = makePhase()
-    let b = makePhase()
-    let c = makePhase()
-    var phases = [a, b, c]
+    let phaseA = makePhase()
+    let phaseB = makePhase()
+    let phaseC = makePhase()
+    var phases = [phaseA, phaseB, phaseC]
 
     phases.movePhase(id: UUID(), to: 0)
 
-    #expect(phases.map(\.id) == [a.id, b.id, c.id])
+    #expect(phases.map(\.id) == [phaseA.id, phaseB.id, phaseC.id])
   }
 }

--- a/Pastura/PasturaTests/App/EditablePhaseSubPhaseMoveTests.swift
+++ b/Pastura/PasturaTests/App/EditablePhaseSubPhaseMoveTests.swift
@@ -104,6 +104,19 @@ struct EditablePhaseSubPhaseMoveTests {
     #expect(sut.thenPhases.map(\.id) == [phaseB.id, phaseC.id, phaseA.id])
   }
 
+  // MARK: - negative destination index clamps to start
+
+  @Test func moveSubPhaseNegativeDestinationIndexClampsToStart() {
+    let phaseA = makePhase()
+    let phaseB = makePhase()
+    let phaseC = makePhase()
+    var sut = makeConditional(thenPhases: [phaseA, phaseB, phaseC])
+
+    sut.moveSubPhase(id: phaseC.id, to: .then, at: -5)
+
+    #expect(sut.thenPhases.map(\.id) == [phaseC.id, phaseA.id, phaseB.id])
+  }
+
   // MARK: - unknown UUID is a no-op
 
   @Test func moveSubPhaseUnknownUUIDIsNoOp() {


### PR DESCRIPTION
## Summary
- Replaces SwiftUI `.onMove` with a unified `.draggable` + `.dropDestination` system across both the scenario editor's top-level phase list AND the conditional phase editor's then/else sub-phase branches.
- Adds cross-branch drag for conditional sub-phases (the ask in #144), with within-branch reorder preserved through the same drag mechanism.
- **Scope expansion beyond #144** — migrates the top-level phase list too (user-approved), to avoid a mental-model split between the two editor surfaces.

## Key design
- **Handle-scoped drag** — `.draggable` attaches to the `line.3.horizontal` handle only, not the full row. Sidesteps the `.draggable` vs `.contextMenu` long-press conflict. Tap-to-edit and swipe-to-delete remain on the content area.
- **Distinct payload types** — `SubPhaseDragPayload` vs `TopLevelPhaseDragPayload`, both `Transferable` via `CodableRepresentation(contentType: .data)` (no custom UTType, nothing to register in Info.plist). Type separation prevents cross-layer drops by construction.
- **Accessibility fallback** — `.contextMenu` with Move Up / Move Down / Move to Other Branch, surfaced via the VoiceOver Actions rotor. Positional `.accessibilityLabel` replaces the rotor announcements `.onMove` provided.
- **Drop-indicator visualization** — `isTargeted`-bound top-edge insertion line on hovered rows; dashed "Drop here" placeholder on empty branch/list for discoverability.
- **Pure move logic** — `EditablePhase.moveSubPhase(id:to:at:)` and `Array<EditablePhase>.movePhase(id:to:)` are pure functions with 12 unit tests; the drag UI is a thin wrapper.

## Test plan
- [x] Unit tests for `moveSubPhase` — within-branch forward/backward, same-branch onto self no-op, cross-branch, empty target append, positive/negative destination clamp, unknown UUID no-op
- [x] Unit test for `SubPhaseDragPayload` Codable round-trip
- [x] Unit tests for `Array<EditablePhase>.movePhase` — within-list forward/backward, unknown UUID no-op
- [x] `swiftlint --strict` clean
- [x] Full test suite `** TEST SUCCEEDED **`
- [ ] **Manual simulator QA (pending before merge)** — per `.claude/rules/navigation.md` QA #5 + #6:
  - [ ] Sub-phase within-branch drag
  - [ ] Sub-phase cross-branch drag (then ↔ else)
  - [ ] Drop into empty branch (dashed placeholder)
  - [ ] Tap-to-edit + swipe-delete coexist with drag
  - [ ] Context menu Move Up/Down/Move to Other Branch (boundary-disabled)
  - [ ] Top-level phase drag reorder
  - [ ] Depth-2 nested sheets have no branches (drag not applicable)

## Follow-ups (reviewer suggestions, deferred)
- `SubPhaseDragPayload.sourceBranch` is payload metadata not consumed at drop sites — keep as documentation or wire into a same-branch short-circuit later.
- `.draggable`/`.dropDestination` doesn't autoscroll in `Form`. Acceptable for current branch sizes (< 10 rows); revisit if scenarios grow.
- Shared `DragReorderableRow<Payload>` helper to deduplicate the sub-phase and top-level row architectures — worth doing if a 3rd use case emerges.

Closes #144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)