### PR TITLE
✨ feat: scenario deep link (pastura:// URL scheme) (#88)

### DIFF
--- a/.claude/rules/navigation.md
+++ b/.claude/rules/navigation.md
@@ -132,3 +132,39 @@ Run these whenever the navigation surface changes:
    so its own NavigationStack is fine — this QA just confirms that the
    presentation chain (outer sheet → inner sheet) dismisses cleanly
    without leaking `.conditional` into nested depths.
+6. **Deep Link — cold start** — With Pastura fully terminated, tap a
+   `pastura://scenario/<id>` link from Safari / Messages / another app.
+   Expected: Pastura launches, waits for initialization + model-download
+   completion (if the model isn't already resolved), then pushes the
+   gallery scenario detail with a **"Opened from an external link"**
+   banner at the top. Tapping **Try this scenario** installs via the
+   normal flow. Invalid id (not present in the curated gallery) shows
+   the **"Scenario Not Found"** alert — never an install prompt.
+7. **Deep Link — initialization or model download in progress** —
+   Open a `pastura://` link while `RootView` is still showing
+   `ProgressView("Initializing...")` or `ModelDownloadView`. Expected:
+   an **informational toast** appears at the bottom ("Opening shared
+   scenario after setup…" / "Will open once the model finishes
+   downloading"). Drain fires automatically when `.ready` transitions.
+8. **Deep Link — during a running simulation** — Start a simulation,
+   wait for generation to be in flight, then open a `pastura://` link
+   from an external app. Expected: **toast** ("Will open when you exit
+   this simulation"). The simulation does **not** halt. Back-swipe out
+   of `SimulationView`; the deep link drain fires immediately and
+   pushes the gallery detail on top of the popped stack. Running
+   under BG continuation (toggle on) must not change this — the link
+   still only drains once the simulation screen is no longer on top.
+9. **Deep Link — during an editor / scoreboard / report sheet** —
+   Open any sheet gated by `.deepLinkGated()` (phase editor, persona
+   editor, scoreboard, report), then open a `pastura://` link.
+   Expected: the sheet stays up with no visible toast (iOS sheets
+   present in their own context and occlude the overlay). Dismiss the
+   sheet — the drain fires immediately and the gallery detail pushes
+   onto the underlying stack. User work in the sheet must **not** be
+   discarded by the deep link arrival.
+10. **Deep Link — iPad multi-window** — On iPad, open two Pastura
+    windows (drag from dock), bring one to focus, then open a
+    `pastura://` link from another app. Expected: only the focused
+    window handles the link (iOS routes `.onOpenURL` to the active
+    scene). The second window's `AppRouter` and `DeepLinkGate` remain
+    untouched. Swapping focus after handling does not replay the URL.

--- a/Pastura/Pastura/App/DeepLink/DeepLinkGate.swift
+++ b/Pastura/Pastura/App/DeepLink/DeepLinkGate.swift
@@ -1,0 +1,64 @@
+import Foundation
+import SwiftUI
+
+/// Per-scene observable coordinating Deep Link queueing.
+///
+/// `sheetPresentationCount` is incremented by the `.deepLinkGated()` view
+/// modifier whenever a gated sheet's content appears, and decremented on
+/// disappear. The `RootView` consults `isSheetActive` (and its own other
+/// signals — app state, router path) to decide whether to drain a
+/// `pendingURL` or keep it queued and show a blocking-reason toast.
+///
+/// The gate intentionally does **not** track app state or router
+/// navigation depth — those signals live at `RootView` where they're
+/// naturally observable. Keeping this type small makes it cheap to
+/// inject and keeps the "one responsibility per observable" rule.
+@Observable @MainActor
+public final class DeepLinkGate {
+  /// How many gated sheets are currently on-screen. Counter semantics so
+  /// nested/stacked sheets (e.g. a report sheet over a phase editor)
+  /// don't prematurely release the gate when the inner one dismisses.
+  public var sheetPresentationCount: Int = 0
+
+  /// The most recently received Deep Link URL that is waiting for a
+  /// navigable state. "Most-recent-wins" — if a new URL arrives while
+  /// one is pending, it replaces the old one.
+  public var pendingURL: URL?
+
+  public init() {}
+
+  /// True while any `.deepLinkGated()`-marked sheet is on-screen.
+  public var isSheetActive: Bool { sheetPresentationCount > 0 }
+}
+
+/// Attach to a sheet's content view so its presentation lifetime is
+/// counted by the scene-level `DeepLinkGate`.
+///
+/// Usage:
+/// ```swift
+/// .sheet(isPresented: $showing) {
+///   PhaseEditorSheet(...)
+///     .deepLinkGated()
+/// }
+/// ```
+///
+/// The modifier reads `DeepLinkGate` from the environment; the parent
+/// scene MUST inject it via `.environment(gate)` at or above the sheet
+/// presenter. Forgetting to inject is a programmer error — the
+/// environment lookup falls back to a dummy gate and the counter never
+/// propagates to the real one. Sheet content should always be wrapped.
+extension View {
+  public func deepLinkGated() -> some View {
+    modifier(DeepLinkGatedModifier())
+  }
+}
+
+private struct DeepLinkGatedModifier: ViewModifier {
+  @Environment(DeepLinkGate.self) private var gate
+
+  func body(content: Content) -> some View {
+    content
+      .onAppear { gate.sheetPresentationCount += 1 }
+      .onDisappear { gate.sheetPresentationCount -= 1 }
+  }
+}

--- a/Pastura/Pastura/App/DeepLink/DeepLinkResolver.swift
+++ b/Pastura/Pastura/App/DeepLink/DeepLinkResolver.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// Outcome of resolving a deep-link scenario id against the gallery index.
+///
+/// `nonisolated` so the synthesized `Equatable`/`Sendable` conformances
+/// don't inherit the project-wide `@MainActor` default — the resolver is
+/// async and must be usable from any isolation context.
+nonisolated public enum DeepLinkResolution: Equatable, Sendable {
+  /// The id was found in either the local cache or a fresh gallery fetch.
+  case found(GalleryScenario)
+
+  /// The id is authoritatively not in the gallery we could reach.
+  /// This includes the cases: fresh fetch succeeded and lacks the id, or
+  /// the only available (stale) cache lacks the id and refresh failed.
+  case notFound
+
+  /// No cached gallery available and the network fetch also failed.
+  /// The id might exist in the remote gallery — we just couldn't confirm.
+  case networkAndCacheMiss
+
+  /// The local cache is corrupted and the refresh attempt also failed.
+  /// Distinguished from `networkAndCacheMiss` so the UI can suggest the
+  /// explicit "open Share Board to refresh" recovery path.
+  case corruptedCache
+}
+
+/// Resolves a deep-link scenario id to a `GalleryScenario` by consulting
+/// the curated gallery index. Cache-first to stay responsive on launch,
+/// falling through to a network refresh only when the cache doesn't
+/// contain the id.
+///
+/// The resolver enforces Pastura's deep-link trust boundary: an id is
+/// only ever accepted when the gallery index (local or fresh) lists it,
+/// so a deep link cannot smuggle in unreviewed content.
+nonisolated public struct DeepLinkResolver {
+  private let galleryService: any GalleryService
+
+  public init(galleryService: any GalleryService) {
+    self.galleryService = galleryService
+  }
+
+  /// Look up `id` in the gallery index. See `DeepLinkResolution` for the
+  /// possible outcomes.
+  public func resolve(id: String) async -> DeepLinkResolution {
+    // Cache first — the hot path for users who have recently opened
+    // Share Board or HomeView (both refresh the cache behind the scenes).
+    var cachedIndex: GalleryIndex?
+    var cacheWasCorrupted = false
+    do {
+      cachedIndex = try galleryService.loadCachedIndex()
+    } catch {
+      // Any cache-read error is treated as "no usable cache", with the
+      // corrupted variant tracked separately so we can surface a
+      // distinct UI hint if the network also fails.
+      cacheWasCorrupted = true
+    }
+
+    if let cached = cachedIndex,
+      let scenario = cached.scenarios.first(where: { $0.id == id }) {
+      return .found(scenario)
+    }
+
+    // Cache miss (or corrupted). Go to the network.
+    let freshIndex: GalleryIndex?
+    do {
+      freshIndex = try await galleryService.refreshIndex()
+    } catch {
+      if cacheWasCorrupted {
+        return .corruptedCache
+      }
+      // A stale cache we successfully read, that doesn't contain the id,
+      // is authoritative enough: the maintainer's last-known gallery did
+      // not include it. An empty cache + network failure gives us nothing.
+      return cachedIndex == nil ? .networkAndCacheMiss : .notFound
+    }
+
+    if let fresh = freshIndex {
+      if let scenario = fresh.scenarios.first(where: { $0.id == id }) {
+        return .found(scenario)
+      }
+      return .notFound
+    }
+
+    // refreshIndex returned nil → 304 Not Modified. The cache we already
+    // checked is authoritative; since we didn't find the id above, it's
+    // either a .notFound or — if cache was unavailable — we have nothing.
+    if cacheWasCorrupted {
+      return .corruptedCache
+    }
+    return cachedIndex != nil ? .notFound : .networkAndCacheMiss
+  }
+}

--- a/Pastura/Pastura/App/DeepLink/DeepLinkURL.swift
+++ b/Pastura/Pastura/App/DeepLink/DeepLinkURL.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// A parsed deep-link URL for the Pastura app.
+///
+/// Supported URL shape: `pastura://scenario/<id>`
+/// where `id` matches `^[a-z0-9_]+$` and is 1–128 characters.
+nonisolated public enum DeepLinkURL: Equatable, Sendable {
+  case scenario(id: String)
+
+  /// Allowed characters in a scenario id.
+  private static let allowedIdCharacters: Set<Character> = {
+    let lower = "abcdefghijklmnopqrstuvwxyz"
+    let digits = "0123456789"
+    return Set((lower + digits + "_").map { $0 })
+  }()
+
+  /// Parse a URL. Returns nil if the URL does not conform to the
+  /// `pastura://scenario/<id>` shape described in the Acceptance criteria:
+  /// - scheme must be `pastura` (case-insensitive)
+  /// - host must be `scenario` (lowercase exact)
+  /// - path must be a single segment `/<id>` with no extra segments
+  /// - id must match `^[a-z0-9_]+$` and be 1–128 characters
+  /// - no query or fragment allowed
+  public static func parse(_ url: URL) -> DeepLinkURL? {
+    guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+      return nil
+    }
+
+    // Scheme: case-insensitive "pastura"
+    guard components.scheme?.lowercased() == "pastura" else { return nil }
+
+    // Host: case-sensitive "scenario"
+    guard components.host == "scenario" else { return nil }
+
+    // No query or fragment
+    guard components.query == nil, components.fragment == nil else { return nil }
+
+    // Path must be a single segment: "/<id>"
+    // URLComponents.path includes the leading slash.
+    let path = components.path
+    let pathComponents = path.split(separator: "/", omittingEmptySubsequences: false)
+    // After splitting "/<id>" we get ["", "<id>"]. Extra segments or empty id are rejected.
+    guard pathComponents.count == 2 else { return nil }
+    let id = String(pathComponents[1])
+
+    // Validate id
+    guard isValidID(id) else { return nil }
+
+    return .scenario(id: id)
+  }
+
+  private static func isValidID(_ id: String) -> Bool {
+    guard !id.isEmpty, id.count <= 128 else { return false }
+    return id.allSatisfy { allowedIdCharacters.contains($0) }
+  }
+}

--- a/Pastura/Pastura/App/DeepLink/LastDeepLinkedScenarioIdKey.swift
+++ b/Pastura/Pastura/App/DeepLink/LastDeepLinkedScenarioIdKey.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+/// Environment key carrying the scenario id most recently opened via
+/// Deep Link for the current scene. `GalleryScenarioDetailView` reads
+/// this to decide whether to render a "Opened from external link"
+/// banner. The key is scoped to `RootView` and reset on pop-to-root so
+/// the banner doesn't falsely appear when the user revisits the same
+/// scenario through Share Board.
+///
+/// The value is `Optional<String>` rather than a richer "source" enum
+/// because navigation state lives on `AppRouter.Route` and must stay
+/// navigation-only (see `.claude/rules/navigation.md`). Source
+/// attribution is side-channel UI state propagated via this key.
+private struct LastDeepLinkedScenarioIdKey: EnvironmentKey {
+  static let defaultValue: String? = nil
+}
+
+extension EnvironmentValues {
+  var lastDeepLinkedScenarioId: String? {
+    get { self[LastDeepLinkedScenarioIdKey.self] }
+    set { self[LastDeepLinkedScenarioIdKey.self] = newValue }
+  }
+}

--- a/Pastura/Pastura/Info.plist
+++ b/Pastura/Pastura/Info.plist
@@ -6,5 +6,16 @@
 	<array>
 		<string>com.tyabu12.Pastura.simulation-continuation</string>
 	</array>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.tyabu12.pastura.scenario</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>pastura</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/Pastura/Pastura/PasturaApp.swift
+++ b/Pastura/Pastura/PasturaApp.swift
@@ -6,7 +6,9 @@ struct PasturaApp: App {
     // RootView lives inside WindowGroup so each scene (iPad multi-window,
     // iPhone single window) gets its own @State — including its own
     // AppRouter / NavigationStack path. App-struct-level @State would be
-    // shared across all scenes.
+    // shared across all scenes. Deep Link state (`DeepLinkGate`, pending
+    // URL, last-deep-linked id) is likewise per-scene so iOS routing a
+    // `pastura://` URL to the active scene doesn't leak into others.
     WindowGroup {
       RootView()
     }
@@ -28,15 +30,90 @@ private enum AppState {
   case error(String)
 }
 
+/// Equatable projection of `AppState` for use with `.onChange` — the
+/// underlying enum carries an `AppDependencies` reference which is not
+/// meaningfully Equatable and whose identity we don't want to compare on.
+private enum AppStateKind: Equatable {
+  case initializing
+  case needsModelDownload
+  case ready
+  case error
+}
+
+/// Reason a Deep Link is queued rather than routed immediately. Drives
+/// the toast message shown while the URL is pending.
+private enum DeepLinkBlockReason: Equatable {
+  case initializing
+  case modelDownload
+  case error
+  case sheetPresented
+  case simulationActive
+
+  var toastText: String {
+    switch self {
+    case .initializing:
+      return String(localized: "Opening shared scenario after setup…")
+    case .modelDownload:
+      return String(localized: "Will open once the model finishes downloading")
+    case .error:
+      return String(localized: "Will open after retrying setup")
+    case .sheetPresented:
+      return String(localized: "Close this sheet to open the shared scenario")
+    case .simulationActive:
+      return String(localized: "Will open when you exit this simulation")
+    }
+  }
+}
+
+/// Identifiable error payload for the root-level Deep Link alert.
+private struct DeepLinkErrorAlert: Identifiable {
+  let id = UUID()
+  let title: String
+  let message: String
+}
+
 /// Per-scene root view. Owns the model-download state machine, the
-/// dependency container, and the `AppRouter` that drives the root
-/// `NavigationStack`'s path.
+/// dependency container, the `AppRouter` that drives the root
+/// `NavigationStack`'s path, and the Deep Link coordination state.
 private struct RootView: View {
   @State private var appState: AppState = .initializing
   @State private var modelManager = ModelManager()
   @State private var router = AppRouter()
+  @State private var gate = DeepLinkGate()
+  @State private var lastDeepLinkedScenarioId: String?
+  @State private var deepLinkError: DeepLinkErrorAlert?
 
   var body: some View {
+    ZStack {
+      mainContent
+      deepLinkToast
+    }
+    .onOpenURL { handleOpenURL($0) }
+    // Drain triggers: fire whenever any signal that gates navigability
+    // changes. `tryDrain` itself re-checks all preconditions, so spurious
+    // triggers are cheap.
+    .onChange(of: appStateKind) { _, _ in tryDrain() }
+    .onChange(of: gate.sheetPresentationCount) { _, _ in tryDrain() }
+    .onChange(of: router.path) { _, _ in tryDrain() }
+    .onChange(of: gate.pendingURL) { _, new in
+      if new != nil { tryDrain() }
+    }
+    // Reset source-attribution when the user pops all the way back. Any
+    // subsequent visit to the same gallery scenario detail (via Share
+    // Board, for instance) should not show the "Opened from external
+    // link" banner.
+    .onChange(of: router.path.isEmpty) { _, isEmpty in
+      if isEmpty { lastDeepLinkedScenarioId = nil }
+    }
+    .alert(item: $deepLinkError) { alert in
+      Alert(title: Text(alert.title), message: Text(alert.message))
+    }
+  }
+
+  // MARK: - Content
+
+  @ViewBuilder
+  private var mainContent: some View {
     Group {
       switch appState {
       case .initializing:
@@ -57,6 +134,8 @@ private struct RootView: View {
         HomeView()
           .environment(dependencies)
           .environment(router)
+          .environment(gate)
+          .environment(\.lastDeepLinkedScenarioId, lastDeepLinkedScenarioId)
 
       case .error(let message):
         VStack(spacing: 16) {
@@ -78,6 +157,126 @@ private struct RootView: View {
       }
     }
   }
+
+  @ViewBuilder
+  private var deepLinkToast: some View {
+    // Sheet-presented case: iOS presents sheets in their own presentation
+    // context so this overlay is visually occluded — acceptable because
+    // the user dismisses the sheet and the drain fires immediately.
+    // Init / modelDownload / error / simulation-active cases render over
+    // the RootView's content and are visible.
+    if gate.pendingURL != nil, let reason = deepLinkBlockReason {
+      VStack {
+        Spacer()
+        Text(reason.toastText)
+          .font(.footnote)
+          .padding(.horizontal, 16)
+          .padding(.vertical, 10)
+          .background(.thinMaterial, in: Capsule())
+          .shadow(radius: 4, y: 2)
+          .padding(.bottom, 32)
+          .transition(.move(edge: .bottom).combined(with: .opacity))
+      }
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+      .animation(.easeInOut(duration: 0.2), value: reason)
+      .allowsHitTesting(false)
+    }
+  }
+
+  // MARK: - Deep Link coordination
+
+  private var appStateKind: AppStateKind {
+    switch appState {
+    case .initializing: return .initializing
+    case .needsModelDownload: return .needsModelDownload
+    case .ready: return .ready
+    case .error: return .error
+    }
+  }
+
+  private var deepLinkBlockReason: DeepLinkBlockReason? {
+    switch appState {
+    case .initializing: return .initializing
+    case .needsModelDownload: return .modelDownload
+    case .error: return .error
+    case .ready:
+      if gate.isSheetActive { return .sheetPresented }
+      if isSimulationOnTop { return .simulationActive }
+      return nil
+    }
+  }
+
+  private var isSimulationOnTop: Bool {
+    if case .some(.simulation) = router.path.last { return true }
+    return false
+  }
+
+  private func handleOpenURL(_ url: URL) {
+    guard DeepLinkURL.parse(url) != nil else {
+      deepLinkError = DeepLinkErrorAlert(
+        title: String(localized: "Unsupported Link"),
+        message: String(localized: "This link doesn't match Pastura's expected format.")
+      )
+      return
+    }
+    // Most-recent-wins: a newer URL replaces any older pending one.
+    gate.pendingURL = url
+    // Call drain synchronously as well so a drainable URL clears before
+    // the toast would render. `.onChange` would pick it up otherwise,
+    // but with a one-frame flash during state propagation.
+    tryDrain()
+  }
+
+  private func tryDrain() {
+    guard let url = gate.pendingURL else { return }
+    guard case .ready(let deps) = appState else { return }
+    guard !gate.isSheetActive else { return }
+    guard !isSimulationOnTop else { return }
+    guard let parsed = DeepLinkURL.parse(url) else {
+      gate.pendingURL = nil
+      return
+    }
+    // Clear before the async work so the pendingURL `.onChange` doesn't
+    // refire the drain for the same URL. A URL arriving during the
+    // resolve will replace this cleared slot and be picked up after.
+    gate.pendingURL = nil
+
+    Task { @MainActor in
+      let resolver = DeepLinkResolver(galleryService: deps.galleryService)
+      switch parsed {
+      case .scenario(let id):
+        let result = await resolver.resolve(id: id)
+        applyResolution(result, requestedId: id)
+      }
+    }
+  }
+
+  private func applyResolution(_ result: DeepLinkResolution, requestedId: String) {
+    switch result {
+    case .found(let scenario):
+      lastDeepLinkedScenarioId = scenario.id
+      router.push(.galleryScenarioDetail(scenario: scenario))
+    case .notFound:
+      deepLinkError = DeepLinkErrorAlert(
+        title: String(localized: "Scenario Not Found"),
+        message: String(
+          localized: "This scenario isn't in the gallery anymore.")
+      )
+    case .networkAndCacheMiss:
+      deepLinkError = DeepLinkErrorAlert(
+        title: String(localized: "Could Not Reach Gallery"),
+        message: String(localized: "Check your connection and try again.")
+      )
+    case .corruptedCache:
+      deepLinkError = DeepLinkErrorAlert(
+        title: String(localized: "Gallery Cache Corrupted"),
+        message: String(
+          localized: "Open Share Board to refresh, then try the link again.")
+      )
+    }
+  }
+
+  // MARK: - Lifecycle
 
   private func initialize() async {
     #if DEBUG

--- a/Pastura/Pastura/Views/Community/ShareBoard/GalleryScenarioDetailView.swift
+++ b/Pastura/Pastura/Views/Community/ShareBoard/GalleryScenarioDetailView.swift
@@ -54,6 +54,7 @@ struct GalleryScenarioDetailView: View {
     }
     .sheet(isPresented: $isReportSheetPresented) {
       ReportScenarioSheet(scenario: scenario)
+        .deepLinkGated()
     }
   }
 

--- a/Pastura/Pastura/Views/Community/ShareBoard/GalleryScenarioDetailView.swift
+++ b/Pastura/Pastura/Views/Community/ShareBoard/GalleryScenarioDetailView.swift
@@ -13,6 +13,7 @@ struct GalleryScenarioDetailView: View {
 
   @Environment(AppDependencies.self) private var dependencies
   @Environment(AppRouter.self) private var router
+  @Environment(\.lastDeepLinkedScenarioId) private var lastDeepLinkedScenarioId
   @State private var viewModel: ShareBoardViewModel?
   @State private var isWorking = false
   @State private var outcomeAlert: OutcomeAlert?
@@ -56,11 +57,28 @@ struct GalleryScenarioDetailView: View {
     }
   }
 
+  private var wasOpenedFromDeepLink: Bool {
+    lastDeepLinkedScenarioId == scenario.id
+  }
+
   // MARK: - Content
 
   @ViewBuilder
   private func content(viewModel: ShareBoardViewModel) -> some View {
     List {
+      if wasOpenedFromDeepLink {
+        Section {
+          Label {
+            Text("Opened from an external link")
+              .font(.footnote)
+              .foregroundStyle(.secondary)
+          } icon: {
+            Image(systemName: "link")
+              .foregroundStyle(.secondary)
+          }
+        }
+        .listRowBackground(Color.clear)
+      }
       Section {
         VStack(alignment: .leading, spacing: 8) {
           Text(scenario.title).font(.title2.bold())

--- a/Pastura/Pastura/Views/Editor/PhaseEditorSheet.swift
+++ b/Pastura/Pastura/Views/Editor/PhaseEditorSheet.swift
@@ -70,6 +70,7 @@ struct PhaseEditorSheet: View {
           },
           availableTypes: PhaseType.allCases.filter { $0 != .conditional }
         )
+        .deepLinkGated()
       }
     }
   }

--- a/Pastura/Pastura/Views/Editor/ScenarioEditorView.swift
+++ b/Pastura/Pastura/Views/Editor/ScenarioEditorView.swift
@@ -60,6 +60,7 @@ struct ScenarioEditorView: View {
         viewModel.personas.append(EditablePersona(name: name, description: description))
         viewModel.agentCount = viewModel.personas.count
       }
+      .deepLinkGated()
     }
     .sheet(item: $editingPersona) { persona in
       PersonaEditorSheet(
@@ -71,11 +72,13 @@ struct ScenarioEditorView: View {
           viewModel.personas[idx].description = newDescription
         }
       }
+      .deepLinkGated()
     }
     .sheet(isPresented: $showNewPhaseSheet) {
       PhaseEditorSheet(phase: EditablePhase()) { phase in
         viewModel.phases.append(phase)
       }
+      .deepLinkGated()
     }
     .sheet(item: $editingPhase) { phase in
       PhaseEditorSheet(phase: phase) { updated in
@@ -83,6 +86,7 @@ struct ScenarioEditorView: View {
           viewModel.phases[idx] = updated
         }
       }
+      .deepLinkGated()
     }
   }
 

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -231,6 +231,7 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
     .sheet(isPresented: $showScoreboard) {
       ScoreboardSheet(scores: viewModel.scores, eliminated: viewModel.eliminated)
         .presentationDetents([.medium])
+        .deepLinkGated()
     }
     .overlay {
       if viewModel.isReloadingModel {

--- a/Pastura/PasturaTests/App/DeepLink/DeepLinkGateTests.swift
+++ b/Pastura/PasturaTests/App/DeepLink/DeepLinkGateTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+@Suite(.timeLimit(.minutes(1)))
+@MainActor
+struct DeepLinkGateTests {
+  // MARK: - Initial state
+
+  @Test func freshGateHasZeroCount() {
+    let gate = DeepLinkGate()
+    #expect(gate.sheetPresentationCount == 0)
+  }
+
+  @Test func freshGateHasNoPendingURL() {
+    let gate = DeepLinkGate()
+    #expect(gate.pendingURL == nil)
+  }
+
+  @Test func freshGateIsNotSheetActive() {
+    let gate = DeepLinkGate()
+    #expect(gate.isSheetActive == false)
+  }
+
+  // MARK: - Increment
+
+  @Test func incrementMakesSheetActive() {
+    let gate = DeepLinkGate()
+    gate.sheetPresentationCount += 1
+    #expect(gate.isSheetActive == true)
+  }
+
+  // MARK: - Nested increment / decrement
+
+  @Test func nestedIncrementRemainsActiveAfterOneDecrement() {
+    let gate = DeepLinkGate()
+    gate.sheetPresentationCount += 1
+    gate.sheetPresentationCount += 1
+    gate.sheetPresentationCount -= 1
+    #expect(gate.isSheetActive == true)
+  }
+
+  @Test func nestedIncrementBecomesInactiveAfterBothDecrements() {
+    let gate = DeepLinkGate()
+    gate.sheetPresentationCount += 1
+    gate.sheetPresentationCount += 1
+    gate.sheetPresentationCount -= 1
+    gate.sheetPresentationCount -= 1
+    #expect(gate.isSheetActive == false)
+  }
+
+  // MARK: - pendingURL most-recent-wins
+
+  @Test func pendingURLReplacedByLatest() throws {
+    let gate = DeepLinkGate()
+    let first = try #require(URL(string: "pastura://scenario/abc"))
+    let second = try #require(URL(string: "pastura://scenario/xyz"))
+
+    gate.pendingURL = first
+    gate.pendingURL = second
+
+    #expect(gate.pendingURL == second)
+  }
+}

--- a/Pastura/PasturaTests/App/DeepLink/DeepLinkResolverTests.swift
+++ b/Pastura/PasturaTests/App/DeepLink/DeepLinkResolverTests.swift
@@ -1,0 +1,146 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+@Suite(.timeLimit(.minutes(1))) struct DeepLinkResolverTests {
+
+  // MARK: - Fixtures
+
+  private static func makeScenario(id: String) -> GalleryScenario {
+    GalleryScenario(
+      id: id,
+      title: "Scenario \(id)",
+      category: .experimental,
+      description: "test fixture",
+      author: "test",
+      recommendedModel: "mock",
+      estimatedInferences: 1,
+      // swiftlint:disable:next force_unwrapping
+      yamlURL: URL(string: "https://example.com/\(id).yaml")!,
+      yamlSHA256: String(repeating: "0", count: 64),
+      addedAt: "2026-04-22")
+  }
+
+  private static func makeIndex(_ scenarios: [GalleryScenario]) -> GalleryIndex {
+    GalleryIndex(version: 1, updatedAt: "2026-04-22T00:00:00Z", scenarios: scenarios)
+  }
+
+  // MARK: - Tests
+
+  @Test func cacheHitReturnsFoundWithoutRefresh() async {
+    let target = Self.makeScenario(id: "asch_v1")
+    let service = MockGalleryService()
+    service.cachedIndex = Self.makeIndex([target])
+    service.refreshResult = .success(Self.makeIndex([]))  // would be observable if called
+
+    let resolver = DeepLinkResolver(galleryService: service)
+    let result = await resolver.resolve(id: "asch_v1")
+
+    #expect(result == .found(target))
+    #expect(service.refreshCallCount == 0, "refresh must not be called when cache has the id")
+  }
+
+  @Test func afterRefreshReturnsFoundWhenCacheMisses() async {
+    let target = Self.makeScenario(id: "asch_v1")
+    let service = MockGalleryService()
+    service.cachedIndex = nil
+    service.refreshResult = .success(Self.makeIndex([target]))
+
+    let resolver = DeepLinkResolver(galleryService: service)
+    let result = await resolver.resolve(id: "asch_v1")
+
+    #expect(result == .found(target))
+    #expect(service.refreshCallCount == 1)
+  }
+
+  @Test func notFoundWhenFreshIndexLacksId() async {
+    let service = MockGalleryService()
+    service.cachedIndex = nil
+    service.refreshResult = .success(Self.makeIndex([Self.makeScenario(id: "other")]))
+
+    let resolver = DeepLinkResolver(galleryService: service)
+    let result = await resolver.resolve(id: "asch_v1")
+
+    #expect(result == .notFound)
+  }
+
+  @Test func notFoundWhenRefreshFailsButStaleCacheWithoutId() async {
+    let service = MockGalleryService()
+    service.cachedIndex = Self.makeIndex([Self.makeScenario(id: "other")])
+    service.refreshResult = .failure(GalleryServiceError.invalidResponse)
+
+    let resolver = DeepLinkResolver(galleryService: service)
+    let result = await resolver.resolve(id: "asch_v1")
+
+    // Stale cache authoritatively says the id isn't in the gallery we know about.
+    #expect(result == .notFound)
+  }
+
+  @Test func networkAndCacheMissWhenBothUnavailable() async {
+    let service = MockGalleryService()
+    service.cachedIndex = nil
+    service.refreshResult = .failure(GalleryServiceError.invalidResponse)
+
+    let resolver = DeepLinkResolver(galleryService: service)
+    let result = await resolver.resolve(id: "asch_v1")
+
+    #expect(result == .networkAndCacheMiss)
+  }
+
+  @Test func corruptedCacheRecoversViaSuccessfulRefresh() async {
+    let target = Self.makeScenario(id: "asch_v1")
+    let service = MockGalleryService()
+    service.cachedIndexError = GalleryServiceError.corruptedCache
+    service.refreshResult = .success(Self.makeIndex([target]))
+
+    let resolver = DeepLinkResolver(galleryService: service)
+    let result = await resolver.resolve(id: "asch_v1")
+
+    #expect(result == .found(target))
+  }
+
+  @Test func corruptedCacheReturnsErrorWhenRefreshAlsoFails() async {
+    let service = MockGalleryService()
+    service.cachedIndexError = GalleryServiceError.corruptedCache
+    service.refreshResult = .failure(GalleryServiceError.invalidResponse)
+
+    let resolver = DeepLinkResolver(galleryService: service)
+    let result = await resolver.resolve(id: "asch_v1")
+
+    #expect(result == .corruptedCache)
+  }
+}
+
+// MARK: - MockGalleryService
+
+/// Deterministic in-memory `GalleryService` for resolver tests.
+///
+/// Tracks refresh call count so tests can assert the cache-hit fast path
+/// avoids the network entirely. Deliberately separate from the
+/// `MockGalleryService` in `ShareBoardViewModelTests.swift` — that one is
+/// `private` to its test file and carries ViewModel-specific hooks.
+private final class MockGalleryService: GalleryService, @unchecked Sendable {
+  var cachedIndex: GalleryIndex?
+  var cachedIndexError: Error?
+  var refreshResult: Result<GalleryIndex?, Error> = .success(nil)
+  private(set) var refreshCallCount = 0
+
+  func loadCachedIndex() throws -> GalleryIndex? {
+    if let error = cachedIndexError { throw error }
+    return cachedIndex
+  }
+
+  func refreshIndex() async throws -> GalleryIndex? {
+    refreshCallCount += 1
+    switch refreshResult {
+    case .success(let value): return value
+    case .failure(let error): throw error
+    }
+  }
+
+  func fetchScenarioYAML(from url: URL, expectedSHA256: String) async throws -> String {
+    // Resolver does not fetch YAML; placeholder for protocol conformance.
+    throw GalleryServiceError.unexpectedStatus(404)
+  }
+}

--- a/Pastura/PasturaTests/App/DeepLink/DeepLinkURLTests.swift
+++ b/Pastura/PasturaTests/App/DeepLink/DeepLinkURLTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+@Suite(.timeLimit(.minutes(1))) struct DeepLinkURLTests {
+
+  // MARK: - Accept cases
+
+  @Test func acceptCases() {
+    let cases: [(String, DeepLinkURL)] = [
+      ("pastura://scenario/asch_conformity_v1", .scenario(id: "asch_conformity_v1")),
+      ("pastura://scenario/foo", .scenario(id: "foo")),
+      ("pastura://scenario/abc123", .scenario(id: "abc123")),
+      ("pastura://scenario/a", .scenario(id: "a")),
+      ("pastura://scenario/a_b_c", .scenario(id: "a_b_c")),
+      ("pastura://scenario/123", .scenario(id: "123")),
+      ("PASTURA://scenario/foo", .scenario(id: "foo")),  // scheme case-insensitive
+      ("Pastura://scenario/foo", .scenario(id: "foo"))  // scheme case-insensitive
+    ]
+    for (urlString, expected) in cases {
+      // swiftlint:disable:next force_unwrapping
+      let url = URL(string: urlString)!
+      let result = DeepLinkURL.parse(url)
+      #expect(result == expected, "Expected \(expected) for \(urlString)")
+    }
+  }
+
+  @Test func accept128CharId() {
+    let id = String(repeating: "a", count: 128)
+    // swiftlint:disable:next force_unwrapping
+    let url = URL(string: "pastura://scenario/\(id)")!
+    let result = DeepLinkURL.parse(url)
+    #expect(result == .scenario(id: id))
+  }
+
+  // MARK: - Reject cases
+
+  @Test func rejectCases() {
+    let urlStrings: [String] = [
+      // Wrong scheme
+      "http://scenario/foo",
+      "pastur://scenario/foo",
+      // Wrong/missing host
+      "pastura:///foo",
+      "pastura://Scenario/foo",
+      "pastura://other/foo",
+      // Empty id
+      "pastura://scenario/",
+      "pastura://scenario",
+      // Id charset violations
+      "pastura://scenario/Asch",
+      "pastura://scenario/asch-v1",
+      "pastura://scenario/asch.v1",
+      "pastura://scenario/asch%20v1",
+      // Extra path segments
+      "pastura://scenario/foo/bar",
+      // Query or fragment
+      "pastura://scenario/foo?x=1",
+      "pastura://scenario/foo#bar"
+    ]
+    for urlString in urlStrings {
+      // URL(string:) may fail for some malformed strings; treat nil URL as nil parse
+      let url = URL(string: urlString)
+      let result = url.flatMap { DeepLinkURL.parse($0) }
+      #expect(result == nil, "Expected nil for \(urlString)")
+    }
+  }
+
+  @Test func rejectSpaceInId() {
+    // "asch v1" — space makes URL(string:) fail or percent-encode the space
+    // Test both the raw form and percent-encoded form
+    if let url = URL(string: "pastura://scenario/asch%20v1") {
+      #expect(DeepLinkURL.parse(url) == nil)
+    }
+  }
+
+  @Test func rejectDoubleDots() {
+    // swiftlint:disable:next force_unwrapping
+    let url = URL(string: "pastura://scenario/..")!
+    #expect(DeepLinkURL.parse(url) == nil)
+  }
+
+  @Test func reject129CharId() {
+    let id = String(repeating: "a", count: 129)
+    // swiftlint:disable:next force_unwrapping
+    let url = URL(string: "pastura://scenario/\(id)")!
+    #expect(DeepLinkURL.parse(url) == nil)
+  }
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Pastura — Product Roadmap
 
-> Last updated: 2026-04-21
+> Last updated: 2026-04-22
 > This document defines phase boundaries and scope. When in doubt whether a feature
 > belongs in the current phase, check here first.
 
@@ -89,6 +89,7 @@ creation observed. Decision: ship to App Store to gauge wider public reaction.
 | `reflect` phase type                     | Medium   | Planned     | Agent self-reflection / memory compaction|
 | Custom score_calc logic                  | Medium   | Planned     | User-defined scoring expressions         |
 | Scenario sharing (Share Board)           | Medium   | Done (read-only) | Read-only curated gallery shipped (#87/#93). User submissions / ratings deferred to Phase 3 marketplace. |
+| Scenario deep link (`pastura://` scheme) | Medium   | Done        | 1-tap install from external contexts (SNS, QR, blog). IDs resolved through the curated gallery index only — no arbitrary URL fetch, no auto-execute. Preview via `GalleryScenarioDetailView` with external-link origin banner (#88). Universal Links / QR code generation deferred. |
 | Simulation result export (Markdown)      | Medium   | Done        | Share Sheet export including code-phase results (#91/#98) |
 | Past results — code-phase event display  | Medium   | Done        | Score_calc / scenario gen events shown in past-results viewer (#102/#113) |
 | YAML simulation replay primitive         | Medium   | Planned     | Past Results YAML exporter + `YAMLReplaySource` importer primitive. Foundation for DL demo replay and future user-replay (spec §4.4 / §4.5). Replay gallery / Share Board integration deferred to Phase 3. Resumes spec §6.1 Candidate A (#164). |


### PR DESCRIPTION
## Summary
- Registers the `pastura://scenario/<id>` URL scheme so external contexts (SNS, Discord/Slack, QR codes, blog posts) can open Pastura directly to a curated gallery scenario preview — one-tap install from anywhere.
- Trust boundary identical to Share Board: ids must resolve through the curated `gallery.json` (maintainer-managed). No arbitrary URL fetch, no auto-execution — preview reuses `GalleryScenarioDetailView` with a subtle "Opened from an external link" banner.
- Unified queue-and-toast UX for blocking app states (initialization, model download, active simulation, gated sheets) so a deep-link tap never disrupts user work in progress.

## Test plan
- [x] `PasturaTests/DeepLinkURLTests` — parser accept/reject matrix incl. 128-char boundary
- [x] `PasturaTests/DeepLinkResolverTests` — 7 outcome cases (cache hit / fresh refresh / notFound / stale-cache notFound / networkAndCacheMiss / corrupted-cache recovery / corrupted-cache error)
- [x] `PasturaTests/DeepLinkGateTests` — counter + pendingURL most-recent-wins
- [x] Full unit suite passes (skip UI)
- [x] `swiftlint --strict` clean
- [x] **Manual QA (required before merge)** — see `.claude/rules/navigation.md` scenarios 6–10: cold start, init / model DL in progress, mid-simulation, gated sheet, iPad multi-window
- [x] Manual: scheme routing with `xcrun simctl openurl booted pastura://scenario/<known_id>`

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)