### PR TITLE
✨ feat: DL-time demo replay host view + UI components (C PR2 #169)

### DIFF
--- a/Pastura/Pastura/Views/Components/DogMark.swift
+++ b/Pastura/Pastura/Views/Components/DogMark.swift
@@ -28,80 +28,79 @@ public struct DogMark: View {
 
   public var body: some View {
     Canvas { ctx, canvasSize in
-      let s = canvasSize.width
       // All geometry is expressed as fractions of the 26-unit SVG viewBox.
-      // Multiplying by (s / 26) maps viewBox coordinates to canvas points.
-      let u = s / 26
+      // Multiplying by `unit` maps viewBox coordinates to canvas points.
+      let unit = canvasSize.width / 26
 
       // MARK: Body path — dog head/profile silhouette
       // Translated from the DOG_SIDE SVG:
       //   M5 14 Q5 9, 9 7.5 L11 5 L12.5 8 Q17 8.5, 19.5 11 Q21 12.5, 21 14.5
       //   L22 16 L20 16.5 Q18.5 19, 15 19 L10.5 19 Q7 18.5, 5.5 16 Z
       var body = Path()
-      body.move(to: CGPoint(x: 5 * u, y: 14 * u))
+      body.move(to: CGPoint(x: 5 * unit, y: 14 * unit))
       body.addQuadCurve(
-        to: CGPoint(x: 9 * u, y: 7.5 * u),
-        control: CGPoint(x: 5 * u, y: 9 * u))
-      body.addLine(to: CGPoint(x: 11 * u, y: 5 * u))
-      body.addLine(to: CGPoint(x: 12.5 * u, y: 8 * u))
+        to: CGPoint(x: 9 * unit, y: 7.5 * unit),
+        control: CGPoint(x: 5 * unit, y: 9 * unit))
+      body.addLine(to: CGPoint(x: 11 * unit, y: 5 * unit))
+      body.addLine(to: CGPoint(x: 12.5 * unit, y: 8 * unit))
       body.addQuadCurve(
-        to: CGPoint(x: 19.5 * u, y: 11 * u),
-        control: CGPoint(x: 17 * u, y: 8.5 * u))
+        to: CGPoint(x: 19.5 * unit, y: 11 * unit),
+        control: CGPoint(x: 17 * unit, y: 8.5 * unit))
       body.addQuadCurve(
-        to: CGPoint(x: 21 * u, y: 14.5 * u),
-        control: CGPoint(x: 21 * u, y: 12.5 * u))
-      body.addLine(to: CGPoint(x: 22 * u, y: 16 * u))
-      body.addLine(to: CGPoint(x: 20 * u, y: 16.5 * u))
+        to: CGPoint(x: 21 * unit, y: 14.5 * unit),
+        control: CGPoint(x: 21 * unit, y: 12.5 * unit))
+      body.addLine(to: CGPoint(x: 22 * unit, y: 16 * unit))
+      body.addLine(to: CGPoint(x: 20 * unit, y: 16.5 * unit))
       body.addQuadCurve(
-        to: CGPoint(x: 15 * u, y: 19 * u),
-        control: CGPoint(x: 18.5 * u, y: 19 * u))
-      body.addLine(to: CGPoint(x: 10.5 * u, y: 19 * u))
+        to: CGPoint(x: 15 * unit, y: 19 * unit),
+        control: CGPoint(x: 18.5 * unit, y: 19 * unit))
+      body.addLine(to: CGPoint(x: 10.5 * unit, y: 19 * unit))
       body.addQuadCurve(
-        to: CGPoint(x: 5.5 * u, y: 16 * u),
-        control: CGPoint(x: 7 * u, y: 18.5 * u))
+        to: CGPoint(x: 5.5 * unit, y: 16 * unit),
+        control: CGPoint(x: 7 * unit, y: 18.5 * unit))
       body.closeSubpath()
 
       ctx.fill(body, with: .color(.white))
       ctx.stroke(
         body,
         with: .color(Color.moss),
-        style: StrokeStyle(lineWidth: 1.3 * u, lineCap: .round, lineJoin: .round))
+        style: StrokeStyle(lineWidth: 1.3 * unit, lineCap: .round, lineJoin: .round))
 
       // MARK: Nose dot — cx=20 cy=14.8 r=1.1
       let nosePath = Path(
         ellipseIn: CGRect(
-          x: (20 - 1.1) * u, y: (14.8 - 1.1) * u,
-          width: 2.2 * u, height: 2.2 * u))
+          x: (20 - 1.1) * unit, y: (14.8 - 1.1) * unit,
+          width: 2.2 * unit, height: 2.2 * unit))
       ctx.fill(nosePath, with: .color(Color.mossInk))
 
       // MARK: Eye dot — cx=14 cy=12 r=0.9
       let eyePath = Path(
         ellipseIn: CGRect(
-          x: (14 - 0.9) * u, y: (12 - 0.9) * u,
-          width: 1.8 * u, height: 1.8 * u))
+          x: (14 - 0.9) * unit, y: (12 - 0.9) * unit,
+          width: 1.8 * unit, height: 1.8 * unit))
       ctx.fill(eyePath, with: .color(Color.mossInk))
 
       // MARK: Ear detail stroke — M9 7.5 Q8 10, 8.8 12
       var ear = Path()
-      ear.move(to: CGPoint(x: 9 * u, y: 7.5 * u))
+      ear.move(to: CGPoint(x: 9 * unit, y: 7.5 * unit))
       ear.addQuadCurve(
-        to: CGPoint(x: 8.8 * u, y: 12 * u),
-        control: CGPoint(x: 8 * u, y: 10 * u))
+        to: CGPoint(x: 8.8 * unit, y: 12 * unit),
+        control: CGPoint(x: 8 * unit, y: 10 * unit))
       ctx.stroke(
         ear,
         with: .color(Color.moss),
-        style: StrokeStyle(lineWidth: 0.9 * u, lineCap: .round))
+        style: StrokeStyle(lineWidth: 0.9 * unit, lineCap: .round))
 
       // MARK: Back / tail accent stroke — M15 16 Q17 16.5, 19 16.2
       var tail = Path()
-      tail.move(to: CGPoint(x: 15 * u, y: 16 * u))
+      tail.move(to: CGPoint(x: 15 * unit, y: 16 * unit))
       tail.addQuadCurve(
-        to: CGPoint(x: 19 * u, y: 16.2 * u),
-        control: CGPoint(x: 17 * u, y: 16.5 * u))
+        to: CGPoint(x: 19 * unit, y: 16.2 * unit),
+        control: CGPoint(x: 17 * unit, y: 16.5 * unit))
       ctx.stroke(
         tail,
         with: .color(Color.moss),
-        style: StrokeStyle(lineWidth: 0.8 * u, lineCap: .round))
+        style: StrokeStyle(lineWidth: 0.8 * unit, lineCap: .round))
     }
     .frame(width: size, height: size)
     .accessibilityHidden(true)

--- a/Pastura/Pastura/Views/Components/DogMark.swift
+++ b/Pastura/Pastura/Views/Components/DogMark.swift
@@ -1,0 +1,175 @@
+import SwiftUI
+
+/// The Pastura assistant mark — a dog (collie) profile rendered as pure SwiftUI shapes.
+///
+/// Used in two places in the demo-replay feature:
+/// - 26 pt inside `PromoCard` (body row, left of promo copy) — pass default `size`.
+/// - 44 pt inside `DLCompleteOverlay` (fullscreen completion state) — pass `size: 44`.
+///
+/// The shape is a direct SwiftUI `Canvas` translation of the `DOG_SIDE` SVG constant
+/// in `docs/design/demo-replay-reference.html` (viewBox 0 0 26 26). Path coordinates
+/// are expressed as fractions of the 26-unit viewBox, then multiplied by `(size / 26)`
+/// to scale cleanly to any target point size.
+///
+/// Colors follow `design-system.md` §2.3 Moss tokens:
+/// - Body fill: `Color.white` (explicit — the bubbleBackground token is also white but
+///   `DogMark` appears on varied surfaces, so plain white is the right semantic).
+/// - Outline / ear / tail accent: `Color.moss` (`#8A9A6C`).
+/// - Eye / nose dots: `Color.mossInk` (`#3D4030`).
+///
+/// Combine with `.pulsing()` for the Frame 4 DL-complete animation (scale 1.0 ↔ 1.06,
+/// 2.4 s ease-in-out loop). The modifier is automatically disabled when
+/// `accessibilityReduceMotion` is active.
+public struct DogMark: View {
+
+  /// Point size of the bounding square. Defaults to 26 pt (PromoBody usage).
+  /// Pass 44 for the `DLCompleteOverlay` variant.
+  public var size: CGFloat = 26
+
+  public var body: some View {
+    Canvas { ctx, canvasSize in
+      let s = canvasSize.width
+      // All geometry is expressed as fractions of the 26-unit SVG viewBox.
+      // Multiplying by (s / 26) maps viewBox coordinates to canvas points.
+      let u = s / 26
+
+      // MARK: Body path — dog head/profile silhouette
+      // Translated from the DOG_SIDE SVG:
+      //   M5 14 Q5 9, 9 7.5 L11 5 L12.5 8 Q17 8.5, 19.5 11 Q21 12.5, 21 14.5
+      //   L22 16 L20 16.5 Q18.5 19, 15 19 L10.5 19 Q7 18.5, 5.5 16 Z
+      var body = Path()
+      body.move(to: CGPoint(x: 5 * u, y: 14 * u))
+      body.addQuadCurve(
+        to: CGPoint(x: 9 * u, y: 7.5 * u),
+        control: CGPoint(x: 5 * u, y: 9 * u))
+      body.addLine(to: CGPoint(x: 11 * u, y: 5 * u))
+      body.addLine(to: CGPoint(x: 12.5 * u, y: 8 * u))
+      body.addQuadCurve(
+        to: CGPoint(x: 19.5 * u, y: 11 * u),
+        control: CGPoint(x: 17 * u, y: 8.5 * u))
+      body.addQuadCurve(
+        to: CGPoint(x: 21 * u, y: 14.5 * u),
+        control: CGPoint(x: 21 * u, y: 12.5 * u))
+      body.addLine(to: CGPoint(x: 22 * u, y: 16 * u))
+      body.addLine(to: CGPoint(x: 20 * u, y: 16.5 * u))
+      body.addQuadCurve(
+        to: CGPoint(x: 15 * u, y: 19 * u),
+        control: CGPoint(x: 18.5 * u, y: 19 * u))
+      body.addLine(to: CGPoint(x: 10.5 * u, y: 19 * u))
+      body.addQuadCurve(
+        to: CGPoint(x: 5.5 * u, y: 16 * u),
+        control: CGPoint(x: 7 * u, y: 18.5 * u))
+      body.closeSubpath()
+
+      ctx.fill(body, with: .color(.white))
+      ctx.stroke(
+        body,
+        with: .color(Color.moss),
+        style: StrokeStyle(lineWidth: 1.3 * u, lineCap: .round, lineJoin: .round))
+
+      // MARK: Nose dot — cx=20 cy=14.8 r=1.1
+      let nosePath = Path(
+        ellipseIn: CGRect(
+          x: (20 - 1.1) * u, y: (14.8 - 1.1) * u,
+          width: 2.2 * u, height: 2.2 * u))
+      ctx.fill(nosePath, with: .color(Color.mossInk))
+
+      // MARK: Eye dot — cx=14 cy=12 r=0.9
+      let eyePath = Path(
+        ellipseIn: CGRect(
+          x: (14 - 0.9) * u, y: (12 - 0.9) * u,
+          width: 1.8 * u, height: 1.8 * u))
+      ctx.fill(eyePath, with: .color(Color.mossInk))
+
+      // MARK: Ear detail stroke — M9 7.5 Q8 10, 8.8 12
+      var ear = Path()
+      ear.move(to: CGPoint(x: 9 * u, y: 7.5 * u))
+      ear.addQuadCurve(
+        to: CGPoint(x: 8.8 * u, y: 12 * u),
+        control: CGPoint(x: 8 * u, y: 10 * u))
+      ctx.stroke(
+        ear,
+        with: .color(Color.moss),
+        style: StrokeStyle(lineWidth: 0.9 * u, lineCap: .round))
+
+      // MARK: Back / tail accent stroke — M15 16 Q17 16.5, 19 16.2
+      var tail = Path()
+      tail.move(to: CGPoint(x: 15 * u, y: 16 * u))
+      tail.addQuadCurve(
+        to: CGPoint(x: 19 * u, y: 16.2 * u),
+        control: CGPoint(x: 17 * u, y: 16.5 * u))
+      ctx.stroke(
+        tail,
+        with: .color(Color.moss),
+        style: StrokeStyle(lineWidth: 0.8 * u, lineCap: .round))
+    }
+    .frame(width: size, height: size)
+    .accessibilityHidden(true)
+  }
+}
+
+// MARK: - Pulsing modifier
+
+/// Internal wrapper that reads `accessibilityReduceMotion` from the environment
+/// and applies the pulse animation only when motion is not restricted.
+///
+/// Split into a separate struct so the `@Environment` property wrapper can be
+/// declared at struct scope — SwiftUI does not allow `@Environment` inside a
+/// closure or a generic helper function directly.
+private struct PulsingModifier: ViewModifier {
+
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @State private var pulsing = false
+
+  func body(content: Content) -> some View {
+    content
+      .scaleEffect(pulsing ? 1.06 : 1.0)
+      .onAppear {
+        guard !reduceMotion else { return }
+        withAnimation(
+          // 2.4 s ease-in-out that repeats and auto-reverses (1.0 ↔ 1.06 loop).
+          .easeInOut(duration: 2.4).repeatForever(autoreverses: true)
+        ) {
+          pulsing = true
+        }
+      }
+  }
+}
+
+extension View {
+  /// Applies a gentle scale pulse (1.0 ↔ 1.06, 2.4 s ease-in-out loop).
+  ///
+  /// Automatically disabled when `accessibilityReduceMotion` is `true` —
+  /// the view stays at scale 1.0 with no animation.
+  public func pulsing() -> some View {
+    modifier(PulsingModifier())
+  }
+}
+
+// MARK: - Previews
+
+#Preview("Sizes") {
+  HStack(spacing: 24) {
+    VStack(spacing: 6) {
+      DogMark(size: 26)
+      Text("26 pt")
+        .font(.caption2)
+        .foregroundStyle(Color.muted)
+    }
+    VStack(spacing: 6) {
+      DogMark(size: 44)
+      Text("44 pt")
+        .font(.caption2)
+        .foregroundStyle(Color.muted)
+    }
+  }
+  .padding(24)
+  .background(Color.screenBackground)
+}
+
+#Preview("Pulsing") {
+  DogMark(size: 44)
+    .pulsing()
+    .padding(40)
+    .background(Color.screenBackground)
+}

--- a/Pastura/Pastura/Views/Components/PhaseHeader.swift
+++ b/Pastura/Pastura/Views/Components/PhaseHeader.swift
@@ -1,0 +1,93 @@
+import SwiftUI
+
+/// A sticky header displayed at the top of the demo replay chat stream.
+///
+/// Shows the preset name as a small uppercase tag and the current phase label
+/// as a larger title, with a right-aligned "DEMO中" status badge. A subtle
+/// tinted material background and a 1pt bottom border separate the header from
+/// the scrolling content beneath it.
+///
+/// ```swift
+/// PhaseHeader(presetName: "WORD WOLF", phaseLabel: "発言ラウンド 1")
+/// ```
+public struct PhaseHeader: View {
+
+  /// The scenario preset name displayed as an uppercase tag (e.g. "WORD WOLF").
+  public let presetName: String
+
+  /// The human-readable phase label displayed below the preset tag (e.g. "発言ラウンド 1").
+  public let phaseLabel: String
+
+  public var body: some View {
+    HStack(alignment: .center, spacing: 0) {
+      // MARK: Left area — diamond ornament + text stack
+      HStack(alignment: .center, spacing: Spacing.xs) {
+        // A 6pt square rotated 45° renders as a diamond. No dedicated shape
+        // exists in SwiftUI for a filled diamond, so this is the idiomatic approach.
+        Rectangle()
+          .fill(Color.moss.opacity(0.7))
+          .frame(width: 6, height: 6)
+          .rotationEffect(.degrees(45))
+
+        VStack(alignment: .leading, spacing: 3) {
+          Text(presetName)
+            .textStyle(Typography.tagPhase)
+            .foregroundStyle(Color.moss)
+
+          Text(phaseLabel)
+            .textStyle(Typography.titlePhase)
+            .foregroundStyle(Color.ink)
+        }
+      }
+
+      Spacer(minLength: Spacing.xs)
+
+      // MARK: Right area — DEMO中 badge
+      Text("DEMO中")
+        .textStyle(Typography.metaLabel)
+        .foregroundStyle(Color.moss)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+        .background(
+          RoundedRectangle(cornerRadius: Radius.button)
+            .fill(Color.moss.opacity(0.1))
+        )
+    }
+    .padding(.vertical, 10)
+    // 10pt vertical is intentional per spec — falls between xs(8) and s(12);
+    // no exact token exists so the literal is used here.
+    .padding(.horizontal, Spacing.l)
+    .background {
+      ZStack {
+        // Tint layer beneath the material — approximates "screenBackground at 78%"
+        Color.screenBackground.opacity(0.78)
+        // Blur layer on top for the frosted-glass effect
+        Rectangle().fill(.ultraThinMaterial)
+      }
+    }
+    .overlay(alignment: .bottom) {
+      // 1pt bottom border per spec: rgba(60,62,48,0.07)
+      Rectangle()
+        .fill(Color.black.opacity(0.07))
+        .frame(height: 1)
+    }
+  }
+}
+
+// MARK: - Previews
+
+#Preview("Default") {
+  VStack(spacing: 0) {
+    PhaseHeader(presetName: "WORD WOLF", phaseLabel: "発言ラウンド 1")
+    Spacer()
+  }
+  .background(Color.screenBackground)
+}
+
+#Preview("Long phase label") {
+  VStack(spacing: 0) {
+    PhaseHeader(presetName: "PRISONERS DILEMMA", phaseLabel: "協議フェーズ 1 / 3")
+    Spacer()
+  }
+  .background(Color.screenBackground)
+}

--- a/Pastura/Pastura/Views/Components/SheepAvatar.swift
+++ b/Pastura/Pastura/Views/Components/SheepAvatar.swift
@@ -28,77 +28,81 @@ public struct SheepAvatar: View {
 
   public var body: some View {
     Canvas { ctx, canvasSize in
-      let s = canvasSize.width
       // All geometry is expressed as fractions of the 28-unit SVG viewBox.
-      // Multiplying by (s / 28) maps viewBox coordinates to canvas points.
-      let u = s / 28
+      // Multiplying by `unit` maps viewBox coordinates to canvas points.
+      let unit = canvasSize.width / 28
 
       // --- Wool body (five circles forming a cloud silhouette) ---
       let bodyColor = character.bodyColor
-      let woolCircles: [(CGFloat, CGFloat, CGFloat)] = [
-        (14, 15, 8),
-        (9, 13, 3.2),
-        (19, 13, 3.2),
-        (11, 18, 3),
-        (17, 18, 3)
+      let woolCircles: [WoolCircle] = [
+        WoolCircle(centerX: 14, centerY: 15, radius: 8),
+        WoolCircle(centerX: 9, centerY: 13, radius: 3.2),
+        WoolCircle(centerX: 19, centerY: 13, radius: 3.2),
+        WoolCircle(centerX: 11, centerY: 18, radius: 3),
+        WoolCircle(centerX: 17, centerY: 18, radius: 3)
       ]
-      for (cx, cy, r) in woolCircles {
-        var path = Path(
+      for circle in woolCircles {
+        let path = Path(
           ellipseIn: CGRect(
-            x: (cx - r) * u, y: (cy - r) * u,
-            width: r * 2 * u, height: r * 2 * u))
+            x: (circle.centerX - circle.radius) * unit,
+            y: (circle.centerY - circle.radius) * unit,
+            width: circle.radius * 2 * unit,
+            height: circle.radius * 2 * unit))
         ctx.fill(path, with: .color(bodyColor))
-        // Prevent canvas from reusing path variable across iterations.
-        path = Path()
-        _ = path
       }
 
       // --- Face oval (character-specific darker shade) ---
       let facePath = Path(
         ellipseIn: CGRect(
-          x: (14 - 4) * u, y: (15.5 - 4.2) * u,
-          width: 8 * u, height: 8.4 * u))
+          x: (14 - 4) * unit, y: (15.5 - 4.2) * unit,
+          width: 8 * unit, height: 8.4 * unit))
       ctx.fill(facePath, with: .color(character.faceColor))
 
       // --- Eyes (two dark circles) ---
       let eyeColor = Color.avatarEye
-      for cx in [CGFloat(12.6), 15.4] {
+      for eyeCenterX in [CGFloat(12.6), 15.4] {
         let eyePath = Path(
           ellipseIn: CGRect(
-            x: (cx - 0.7) * u, y: (14.8 - 0.7) * u,
-            width: 1.4 * u, height: 1.4 * u))
+            x: (eyeCenterX - 0.7) * unit, y: (14.8 - 0.7) * unit,
+            width: 1.4 * unit, height: 1.4 * unit))
         ctx.fill(eyePath, with: .color(eyeColor))
       }
 
       // --- Highlight dot (top-left of face; adds cartoon sheen) ---
       let highlightPath = Path(
         ellipseIn: CGRect(
-          x: (11.6 - 0.5) * u, y: (13.5 - 0.5) * u,
-          width: 1.0 * u, height: 1.0 * u))
+          x: (11.6 - 0.5) * unit, y: (13.5 - 0.5) * unit,
+          width: 1.0 * unit, height: 1.0 * unit))
       ctx.fill(highlightPath, with: .color(Color.avatarHighlight))
 
       // --- Horns (two short curved strokes) ---
       let hornColor = character.hornColor
       var leftHorn = Path()
-      leftHorn.move(to: CGPoint(x: 10.5 * u, y: 11.5 * u))
+      leftHorn.move(to: CGPoint(x: 10.5 * unit, y: 11.5 * unit))
       leftHorn.addQuadCurve(
-        to: CGPoint(x: 11 * u, y: 9.5 * u),
-        control: CGPoint(x: 10 * u, y: 10 * u))
+        to: CGPoint(x: 11 * unit, y: 9.5 * unit),
+        control: CGPoint(x: 10 * unit, y: 10 * unit))
       ctx.stroke(
         leftHorn, with: .color(hornColor),
-        style: StrokeStyle(lineWidth: u, lineCap: .round))
+        style: StrokeStyle(lineWidth: unit, lineCap: .round))
 
       var rightHorn = Path()
-      rightHorn.move(to: CGPoint(x: 17.5 * u, y: 11.5 * u))
+      rightHorn.move(to: CGPoint(x: 17.5 * unit, y: 11.5 * unit))
       rightHorn.addQuadCurve(
-        to: CGPoint(x: 17 * u, y: 9.5 * u),
-        control: CGPoint(x: 18 * u, y: 10 * u))
+        to: CGPoint(x: 17 * unit, y: 9.5 * unit),
+        control: CGPoint(x: 18 * unit, y: 10 * unit))
       ctx.stroke(
         rightHorn, with: .color(hornColor),
-        style: StrokeStyle(lineWidth: u, lineCap: .round))
+        style: StrokeStyle(lineWidth: unit, lineCap: .round))
     }
     .frame(width: size, height: size)
     .accessibilityLabel(character.accessibilityLabel)
+  }
+
+  private struct WoolCircle {
+    let centerX: CGFloat
+    let centerY: CGFloat
+    let radius: CGFloat
   }
 }
 

--- a/Pastura/Pastura/Views/Components/SheepAvatar.swift
+++ b/Pastura/Pastura/Views/Components/SheepAvatar.swift
@@ -1,0 +1,193 @@
+import SwiftUI
+
+/// A sheep-head avatar used in the demo replay chat rows and simulation view.
+///
+/// Rendered as pure SwiftUI shapes — no image assets — so it scales cleanly
+/// to any ``size`` and costs nothing at bundle time.
+///
+/// ```swift
+/// SheepAvatar(character: .alice)               // 42 pt default
+/// SheepAvatar(character: .dave, size: 32)      // smaller variant
+/// ```
+public struct SheepAvatar: View {
+
+  /// The four named sheep characters, each with a distinct wool color.
+  public enum Character: CaseIterable {
+    /// Alice — cream wool. Gentle first voice.
+    case alice
+    /// Bob — sage wool. Agreeable / calm.
+    case bob
+    /// Carol — pink wool. Observer.
+    case carol
+    /// Dave — slate wool. Wolf / central figure.
+    case dave
+  }
+
+  public let character: Character
+  public var size: CGFloat = 42
+
+  public var body: some View {
+    Canvas { ctx, canvasSize in
+      let s = canvasSize.width
+      // All geometry is expressed as fractions of the 28-unit SVG viewBox.
+      // Multiplying by (s / 28) maps viewBox coordinates to canvas points.
+      let u = s / 28
+
+      // --- Wool body (five circles forming a cloud silhouette) ---
+      let bodyColor = character.bodyColor
+      let woolCircles: [(CGFloat, CGFloat, CGFloat)] = [
+        (14, 15, 8),
+        (9, 13, 3.2),
+        (19, 13, 3.2),
+        (11, 18, 3),
+        (17, 18, 3)
+      ]
+      for (cx, cy, r) in woolCircles {
+        var path = Path(
+          ellipseIn: CGRect(
+            x: (cx - r) * u, y: (cy - r) * u,
+            width: r * 2 * u, height: r * 2 * u))
+        ctx.fill(path, with: .color(bodyColor))
+        // Prevent canvas from reusing path variable across iterations.
+        path = Path()
+        _ = path
+      }
+
+      // --- Face oval (character-specific darker shade) ---
+      let facePath = Path(
+        ellipseIn: CGRect(
+          x: (14 - 4) * u, y: (15.5 - 4.2) * u,
+          width: 8 * u, height: 8.4 * u))
+      ctx.fill(facePath, with: .color(character.faceColor))
+
+      // --- Eyes (two dark circles) ---
+      let eyeColor = Color.avatarEye
+      for cx in [CGFloat(12.6), 15.4] {
+        let eyePath = Path(
+          ellipseIn: CGRect(
+            x: (cx - 0.7) * u, y: (14.8 - 0.7) * u,
+            width: 1.4 * u, height: 1.4 * u))
+        ctx.fill(eyePath, with: .color(eyeColor))
+      }
+
+      // --- Highlight dot (top-left of face; adds cartoon sheen) ---
+      let highlightPath = Path(
+        ellipseIn: CGRect(
+          x: (11.6 - 0.5) * u, y: (13.5 - 0.5) * u,
+          width: 1.0 * u, height: 1.0 * u))
+      ctx.fill(highlightPath, with: .color(Color.avatarHighlight))
+
+      // --- Horns (two short curved strokes) ---
+      let hornColor = character.hornColor
+      var leftHorn = Path()
+      leftHorn.move(to: CGPoint(x: 10.5 * u, y: 11.5 * u))
+      leftHorn.addQuadCurve(
+        to: CGPoint(x: 11 * u, y: 9.5 * u),
+        control: CGPoint(x: 10 * u, y: 10 * u))
+      ctx.stroke(
+        leftHorn, with: .color(hornColor),
+        style: StrokeStyle(lineWidth: u, lineCap: .round))
+
+      var rightHorn = Path()
+      rightHorn.move(to: CGPoint(x: 17.5 * u, y: 11.5 * u))
+      rightHorn.addQuadCurve(
+        to: CGPoint(x: 17 * u, y: 9.5 * u),
+        control: CGPoint(x: 18 * u, y: 10 * u))
+      ctx.stroke(
+        rightHorn, with: .color(hornColor),
+        style: StrokeStyle(lineWidth: u, lineCap: .round))
+    }
+    .frame(width: size, height: size)
+    .accessibilityLabel(character.accessibilityLabel)
+  }
+}
+
+// MARK: - Character helpers
+
+extension SheepAvatar.Character {
+
+  /// Wool / body fill — matches the per-character `avatarAlice/Bob/Carol/Dave` token.
+  var bodyColor: Color {
+    switch self {
+    case .alice: return Color.avatarAlice
+    case .bob: return Color.avatarBob
+    case .carol: return Color.avatarCarol
+    case .dave: return Color.avatarDave
+    }
+  }
+
+  /// Face oval fill — a darker accent derived from the HTML reference.
+  /// No dedicated token exists for these; the values mirror the reference
+  /// prototype's `sheepAvatar()` color map.
+  var faceColor: Color {
+    switch self {
+    case .alice:
+      return Color(.sRGB, red: 0xC9 / 255.0, green: 0xA9 / 255.0, blue: 0x79 / 255.0, opacity: 1)
+    case .bob:
+      return Color(.sRGB, red: 0x8A / 255.0, green: 0x9A / 255.0, blue: 0x6C / 255.0, opacity: 1)
+    case .carol:
+      return Color(.sRGB, red: 0xB8 / 255.0, green: 0x87 / 255.0, blue: 0x7C / 255.0, opacity: 1)
+    case .dave:
+      return Color(.sRGB, red: 0x6B / 255.0, green: 0x68 / 255.0, blue: 0x58 / 255.0, opacity: 1)
+    }
+  }
+
+  /// Horn stroke color — darker shade of the body; mirrors reference prototype.
+  var hornColor: Color {
+    switch self {
+    case .alice:
+      return Color(.sRGB, red: 0xB2 / 255.0, green: 0x93 / 255.0, blue: 0x64 / 255.0, opacity: 1)
+    case .bob:
+      return Color(.sRGB, red: 0x6F / 255.0, green: 0x7F / 255.0, blue: 0x54 / 255.0, opacity: 1)
+    case .carol:
+      return Color(.sRGB, red: 0x9C / 255.0, green: 0x6E / 255.0, blue: 0x64 / 255.0, opacity: 1)
+    case .dave:
+      return Color(.sRGB, red: 0x4F / 255.0, green: 0x4C / 255.0, blue: 0x3F / 255.0, opacity: 1)
+    }
+  }
+
+  var accessibilityLabel: String {
+    switch self {
+    case .alice: return "Alice"
+    case .bob: return "Bob"
+    case .carol: return "Carol"
+    case .dave: return "Dave"
+    }
+  }
+}
+
+// MARK: - Previews
+
+#Preview("All characters") {
+  HStack(spacing: 16) {
+    ForEach(SheepAvatar.Character.allCases, id: \.accessibilityLabel) { character in
+      VStack(spacing: 4) {
+        SheepAvatar(character: character)
+        Text(character.accessibilityLabel)
+          .textStyle(Typography.captionName)
+          .foregroundStyle(Color.inkSecondary)
+      }
+    }
+  }
+  .padding()
+  .background(Color.screenBackground)
+}
+
+#Preview("Multiple sizes") {
+  HStack(spacing: 20) {
+    VStack(spacing: 4) {
+      SheepAvatar(character: .alice, size: 32)
+      Text("32").textStyle(Typography.captionName).foregroundStyle(Color.muted)
+    }
+    VStack(spacing: 4) {
+      SheepAvatar(character: .alice, size: 42)
+      Text("42").textStyle(Typography.captionName).foregroundStyle(Color.muted)
+    }
+    VStack(spacing: 4) {
+      SheepAvatar(character: .alice, size: 56)
+      Text("56").textStyle(Typography.captionName).foregroundStyle(Color.muted)
+    }
+  }
+  .padding()
+  .background(Color.screenBackground)
+}

--- a/Pastura/Pastura/Views/ModelDownload/DemoReplayHostView.swift
+++ b/Pastura/Pastura/Views/ModelDownload/DemoReplayHostView.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+
+/// Host view for the DL-time demo replay feature.
+///
+/// Replaces `ModelDownloadView` in the `.needsModelDownload` slot (wiring
+/// lands in PR3). Decides between the demo host body and the plain
+/// `ModelDownloadView` fallback based on cellular reachability, model
+/// state, bundled demo count, and whether replay has already started —
+/// see ``fallbackBranch(state:demosCount:replayHadStarted:isCellular:)``.
+///
+/// The chat stream binding and lifecycle (`.task`, scene-phase bridge,
+/// `DLCompleteOverlay`) are added in items 6/7 of PR2.
+struct DemoReplayHostView: View {
+  let modelManager: ModelManager
+
+  /// Minimum number of validated bundled demos required to render the
+  /// demo host. Below this floor we defer to `ModelDownloadView` — the
+  /// rotation loop is unsatisfying with a single demo (spec §5.2).
+  static let minPlayableDemoCount = 2
+
+  @State private var replayVM: ReplayViewModel?
+  @State private var replayHadStarted: Bool = false
+  @State private var isCellular: Bool = false
+  @State private var sources: [any ReplaySource] = []
+
+  var body: some View {
+    switch Self.fallbackBranch(
+      state: modelManager.state,
+      demosCount: sources.count,
+      replayHadStarted: replayHadStarted,
+      isCellular: isCellular) {
+    case .modelDownload:
+      ModelDownloadView(modelManager: modelManager)
+    case .demoHost:
+      demoHostBody
+    }
+  }
+
+  @ViewBuilder
+  private var demoHostBody: some View {
+    // Placeholder — chat stream (item 6), lifecycle + DLCompleteOverlay
+    // (item 7) land in follow-up commits of PR2.
+    Color.screenBackground
+      .ignoresSafeArea()
+  }
+
+  // MARK: - Fallback decision
+
+  enum Branch: Equatable {
+    case modelDownload
+    case demoHost
+  }
+
+  /// Routes between the plain download UI and the demo host.
+  ///
+  /// Cellular acts as a conservative safety net (ADR-007 §3.3 (c) Option
+  /// A — full cellular modal UX is tracked as #191). Below the
+  /// minimum-playable floor we defer to `ModelDownloadView` so a single
+  /// surviving demo doesn't render with a nil VM. On `.error` we keep
+  /// replay alive only if it had already started, mirroring ADR-007
+  /// §3.3 (b) — the progress bar area swaps to inline retry inside
+  /// `PromoCard` while playback continues.
+  static func fallbackBranch(
+    state: ModelState,
+    demosCount: Int,
+    replayHadStarted: Bool,
+    isCellular: Bool
+  ) -> Branch {
+    if isCellular { return .modelDownload }
+    switch state {
+    case .checking, .unsupportedDevice, .notDownloaded:
+      return .modelDownload
+    case .downloading:
+      return demosCount >= minPlayableDemoCount ? .demoHost : .modelDownload
+    case .error:
+      return replayHadStarted ? .demoHost : .modelDownload
+    case .ready:
+      return .demoHost
+    }
+  }
+}
+
+// MARK: - Previews
+
+// Only the default (checking) preview is exercised at skeleton time:
+// `ModelManager.state` is `private(set)`, so seeding arbitrary states
+// for preview would require a production seam. Richer preview variants
+// land once item 7 wires the real `.task { }` load; for now the
+// `fallbackBranch` decision is covered by unit tests in item 8.
+#Preview {
+  DemoReplayHostView(modelManager: ModelManager())
+}

--- a/Pastura/Pastura/Views/ModelDownload/DemoReplayHostView.swift
+++ b/Pastura/Pastura/Views/ModelDownload/DemoReplayHostView.swift
@@ -144,11 +144,28 @@ struct DemoReplayHostView: View {
 
   private func currentPhaseLabel(viewModel: ReplayViewModel) -> String {
     guard let phase = viewModel.currentPhase else { return "" }
-    let base = phase.rawValue
+    let name = Self.phaseDisplayName(phase)
     if let round = viewModel.currentRound {
-      return "\(base) \(round)"
+      return "\(name)ラウンド \(round)"
     }
-    return base
+    return name
+  }
+
+  /// Human-readable Japanese label for a phase type. Keeps `PhaseType` free
+  /// of view-layer formatting concerns; final wording follows the copy pass
+  /// per spec §2 decision 13.
+  private static func phaseDisplayName(_ phase: PhaseType) -> String {
+    switch phase {
+    case .speakAll: return "発言"
+    case .speakEach: return "個別発言"
+    case .vote: return "投票"
+    case .choose: return "選択"
+    case .scoreCalc: return "スコア計算"
+    case .assign: return "割当"
+    case .eliminate: return "脱落"
+    case .summarize: return "要約"
+    case .conditional: return "条件分岐"
+    }
   }
 
   // MARK: - Lifecycle

--- a/Pastura/Pastura/Views/ModelDownload/DemoReplayHostView.swift
+++ b/Pastura/Pastura/Views/ModelDownload/DemoReplayHostView.swift
@@ -70,10 +70,10 @@ struct DemoReplayHostView: View {
 
   @ViewBuilder
   private var demoHostBody: some View {
-    if let vm = replayVM {
-      chatStream(vm: vm)
+    if let viewModel = replayVM {
+      chatStream(viewModel: viewModel)
         .overlay {
-          if vm.state == .transitioning {
+          if viewModel.state == .transitioning {
             DLCompleteOverlay()
           }
         }
@@ -86,25 +86,25 @@ struct DemoReplayHostView: View {
     }
   }
 
-  private func chatStream(vm: ReplayViewModel) -> some View {
+  private func chatStream(viewModel: ReplayViewModel) -> some View {
     ZStack(alignment: .bottom) {
       Color.screenBackground.ignoresSafeArea()
 
       VStack(spacing: 0) {
         PhaseHeader(
-          presetName: currentPresetName(vm: vm).uppercased(),
-          phaseLabel: currentPhaseLabel(vm: vm))
+          presetName: currentPresetName(viewModel: viewModel).uppercased(),
+          phaseLabel: currentPhaseLabel(viewModel: viewModel))
 
         ScrollViewReader { proxy in
           ScrollView {
             LazyVStack(alignment: .leading, spacing: 14) {
-              ForEach(vm.agentOutputs) { entry in
+              ForEach(viewModel.agentOutputs) { entry in
                 AgentOutputRow(
                   agent: entry.agent,
                   output: entry.output,
                   phaseType: entry.phaseType,
                   showAllThoughts: true,
-                  isLatest: entry.id == vm.agentOutputs.last?.id,
+                  isLatest: entry.id == viewModel.agentOutputs.last?.id,
                   charsPerSecond: 60
                 )
                 .id(entry.id)
@@ -117,10 +117,10 @@ struct DemoReplayHostView: View {
             .padding(.bottom, 160)
             .animation(
               reduceMotion ? nil : .easeOut(duration: 0.7),
-              value: vm.agentOutputs.count)
+              value: viewModel.agentOutputs.count)
           }
-          .onChange(of: vm.agentOutputs.count) { _, _ in
-            guard let lastId = vm.agentOutputs.last?.id else { return }
+          .onChange(of: viewModel.agentOutputs.count) { _, _ in
+            guard let lastId = viewModel.agentOutputs.last?.id else { return }
             withAnimation(reduceMotion ? nil : .easeOut(duration: 0.3)) {
               proxy.scrollTo(lastId, anchor: .bottom)
             }
@@ -135,17 +135,17 @@ struct DemoReplayHostView: View {
     }
   }
 
-  private func currentPresetName(vm: ReplayViewModel) -> String {
-    guard case .playing(let sourceIndex, _) = vm.state,
+  private func currentPresetName(viewModel: ReplayViewModel) -> String {
+    guard case .playing(let sourceIndex, _) = viewModel.state,
       sourceIndex < sources.count
     else { return "" }
     return sources[sourceIndex].scenario.name
   }
 
-  private func currentPhaseLabel(vm: ReplayViewModel) -> String {
-    guard let phase = vm.currentPhase else { return "" }
+  private func currentPhaseLabel(viewModel: ReplayViewModel) -> String {
+    guard let phase = viewModel.currentPhase else { return "" }
     let base = phase.rawValue
-    if let round = vm.currentRound {
+    if let round = viewModel.currentRound {
       return "\(base) \(round)"
     }
     return base
@@ -167,19 +167,19 @@ struct DemoReplayHostView: View {
     sources = loaded
     guard loaded.count >= Self.minPlayableDemoCount else { return }
 
-    let vm = ReplayViewModel(sources: loaded)
-    replayVM = vm
-    vm.start()
+    let viewModel = ReplayViewModel(sources: loaded)
+    replayVM = viewModel
+    viewModel.start()
     replayHadStarted = true
   }
 
   private func handleScenePhase(_ phase: ScenePhase) {
-    guard let vm = replayVM else { return }
+    guard let viewModel = replayVM else { return }
     switch phase {
     case .background, .inactive:
-      vm.onBackground()
+      viewModel.onBackground()
     case .active:
-      vm.onForeground()
+      viewModel.onForeground()
     @unknown default:
       break
     }

--- a/Pastura/Pastura/Views/ModelDownload/DemoReplayHostView.swift
+++ b/Pastura/Pastura/Views/ModelDownload/DemoReplayHostView.swift
@@ -8,8 +8,8 @@ import SwiftUI
 /// state, bundled demo count, and whether replay has already started —
 /// see ``fallbackBranch(state:demosCount:replayHadStarted:isCellular:)``.
 ///
-/// The chat stream binding and lifecycle (`.task`, scene-phase bridge,
-/// `DLCompleteOverlay`) are added in items 6/7 of PR2.
+/// Lifecycle (`.task`, scene-phase bridge, `DLCompleteOverlay`) is
+/// added in item 7 of PR2.
 struct DemoReplayHostView: View {
   let modelManager: ModelManager
 
@@ -17,6 +17,8 @@ struct DemoReplayHostView: View {
   /// demo host. Below this floor we defer to `ModelDownloadView` — the
   /// rotation loop is unsatisfying with a single demo (spec §5.2).
   static let minPlayableDemoCount = 2
+
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
   @State private var replayVM: ReplayViewModel?
   @State private var replayHadStarted: Bool = false
@@ -38,10 +40,79 @@ struct DemoReplayHostView: View {
 
   @ViewBuilder
   private var demoHostBody: some View {
-    // Placeholder — chat stream (item 6), lifecycle + DLCompleteOverlay
-    // (item 7) land in follow-up commits of PR2.
-    Color.screenBackground
-      .ignoresSafeArea()
+    if let vm = replayVM {
+      chatStream(vm: vm)
+    } else {
+      // VM is nil until item 7 wires the `.task { }` load + start. Keeps
+      // the fallbackBranch contract: if the host routed here but no VM
+      // exists, render an empty background instead of crashing.
+      Color.screenBackground.ignoresSafeArea()
+    }
+  }
+
+  private func chatStream(vm: ReplayViewModel) -> some View {
+    ZStack(alignment: .bottom) {
+      Color.screenBackground.ignoresSafeArea()
+
+      VStack(spacing: 0) {
+        PhaseHeader(
+          presetName: currentPresetName(vm: vm).uppercased(),
+          phaseLabel: currentPhaseLabel(vm: vm))
+
+        ScrollViewReader { proxy in
+          ScrollView {
+            LazyVStack(alignment: .leading, spacing: 14) {
+              ForEach(vm.agentOutputs) { entry in
+                AgentOutputRow(
+                  agent: entry.agent,
+                  output: entry.output,
+                  phaseType: entry.phaseType,
+                  showAllThoughts: true,
+                  isLatest: entry.id == vm.agentOutputs.last?.id,
+                  charsPerSecond: 60
+                )
+                .id(entry.id)
+                .transition(reduceMotion ? .identity : .opacity)
+              }
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 8)
+            // Space for the PromoCard overlay (bottom: 22pt + card height).
+            .padding(.bottom, 160)
+            .animation(
+              reduceMotion ? nil : .easeOut(duration: 0.7),
+              value: vm.agentOutputs.count)
+          }
+          .onChange(of: vm.agentOutputs.count) { _, _ in
+            guard let lastId = vm.agentOutputs.last?.id else { return }
+            withAnimation(reduceMotion ? nil : .easeOut(duration: 0.3)) {
+              proxy.scrollTo(lastId, anchor: .bottom)
+            }
+          }
+        }
+      }
+
+      PromoCard(
+        modelState: modelManager.state,
+        replayHadStarted: replayHadStarted,
+        onRetry: { modelManager.startDownload() })
+    }
+  }
+
+  private func currentPresetName(vm: ReplayViewModel) -> String {
+    guard case .playing(let sourceIndex, _) = vm.state,
+      sourceIndex < sources.count
+    else { return "" }
+    return sources[sourceIndex].scenario.name
+  }
+
+  private func currentPhaseLabel(vm: ReplayViewModel) -> String {
+    guard let phase = vm.currentPhase else { return "" }
+    let base = phase.rawValue
+    if let round = vm.currentRound {
+      return "\(base) \(round)"
+    }
+    return base
   }
 
   // MARK: - Fallback decision

--- a/Pastura/Pastura/Views/ModelDownload/DemoReplayHostView.swift
+++ b/Pastura/Pastura/Views/ModelDownload/DemoReplayHostView.swift
@@ -1,3 +1,4 @@
+import Network
 import SwiftUI
 
 /// Host view for the DL-time demo replay feature.
@@ -8,8 +9,24 @@ import SwiftUI
 /// state, bundled demo count, and whether replay has already started —
 /// see ``fallbackBranch(state:demosCount:replayHadStarted:isCellular:)``.
 ///
-/// Lifecycle (`.task`, scene-phase bridge, `DLCompleteOverlay`) is
-/// added in item 7 of PR2.
+/// Lifecycle:
+/// - On first appearance, `.task { }` runs a 1-shot `NWPathMonitor`
+///   check. If cellular, the view stays in the fallback branch (Option A
+///   safety net — full modal UX is #191). Otherwise it enumerates
+///   bundled demos via `BundledDemoReplaySource.loadAll(...)`, and if
+///   at least `minPlayableDemoCount` demos validate, constructs a
+///   `ReplayViewModel` and calls `start()`.
+/// - `scenePhase` is bridged to `onBackground() / onForeground()`
+///   per ADR-007 §3.3 (a).
+/// - `ModelState.ready` triggers `downloadComplete()` on the VM, which
+///   flips its state to `.transitioning`; `DLCompleteOverlay` then fades
+///   in over the chat stream.
+///
+/// `.task` is safe to leave on the outer view body: `AppState` does not
+/// change on `ModelManager.state` transitions within the
+/// `.needsModelDownload` slot (see `PasturaApp.swift`), so the view's
+/// SwiftUI identity is preserved and `.task` runs exactly once per
+/// host-view mount.
 struct DemoReplayHostView: View {
   let modelManager: ModelManager
 
@@ -18,6 +35,7 @@ struct DemoReplayHostView: View {
   /// rotation loop is unsatisfying with a single demo (spec §5.2).
   static let minPlayableDemoCount = 2
 
+  @Environment(\.scenePhase) private var scenePhase
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
   @State private var replayVM: ReplayViewModel?
@@ -26,6 +44,18 @@ struct DemoReplayHostView: View {
   @State private var sources: [any ReplaySource] = []
 
   var body: some View {
+    currentView
+      .task { await initialLoad() }
+      .onChange(of: scenePhase) { _, newPhase in
+        handleScenePhase(newPhase)
+      }
+      .onChange(of: modelManager.state) { _, newState in
+        handleModelStateChange(newState)
+      }
+  }
+
+  @ViewBuilder
+  private var currentView: some View {
     switch Self.fallbackBranch(
       state: modelManager.state,
       demosCount: sources.count,
@@ -42,10 +72,16 @@ struct DemoReplayHostView: View {
   private var demoHostBody: some View {
     if let vm = replayVM {
       chatStream(vm: vm)
+        .overlay {
+          if vm.state == .transitioning {
+            DLCompleteOverlay()
+          }
+        }
     } else {
-      // VM is nil until item 7 wires the `.task { }` load + start. Keeps
-      // the fallbackBranch contract: if the host routed here but no VM
-      // exists, render an empty background instead of crashing.
+      // Until `.task { }` resolves the cellular check + finishes loading
+      // sources, render an empty background. The fallbackBranch routes
+      // away from the demo host before this nil state is reached once
+      // `isCellular`/`sources` update.
       Color.screenBackground.ignoresSafeArea()
     }
   }
@@ -115,6 +151,65 @@ struct DemoReplayHostView: View {
     return base
   }
 
+  // MARK: - Lifecycle
+
+  private func initialLoad() async {
+    // 1-shot cellular check. Option A safety net — if cellular, we skip
+    // loading demos entirely and let the fallback branch route to the
+    // plain `ModelDownloadView`. Full modal UX tracked as #191.
+    let cellular = await Self.isCellularNow()
+    isCellular = cellular
+    guard !cellular else { return }
+
+    let loaded = BundledDemoReplaySource.loadAll()
+    // `loadAll` enumerates `Resources/DemoReplays/*.yaml` — currently
+    // empty pre-#170, so the typical result on main is `[]`.
+    sources = loaded
+    guard loaded.count >= Self.minPlayableDemoCount else { return }
+
+    let vm = ReplayViewModel(sources: loaded)
+    replayVM = vm
+    vm.start()
+    replayHadStarted = true
+  }
+
+  private func handleScenePhase(_ phase: ScenePhase) {
+    guard let vm = replayVM else { return }
+    switch phase {
+    case .background, .inactive:
+      vm.onBackground()
+    case .active:
+      vm.onForeground()
+    @unknown default:
+      break
+    }
+  }
+
+  private func handleModelStateChange(_ newState: ModelState) {
+    if case .ready = newState {
+      replayVM?.downloadComplete()
+    }
+  }
+
+  /// Reads the current network path once via `NWPathMonitor`. Treats
+  /// any "expensive" path as cellular — this covers personal hotspot
+  /// and metered Wi-Fi in addition to literal cellular, which is the
+  /// desired conservative posture for a 3 GB download safety net.
+  private static func isCellularNow() async -> Bool {
+    let (stream, continuation) = AsyncStream.makeStream(of: Bool.self)
+    let monitor = NWPathMonitor()
+    monitor.pathUpdateHandler = { path in
+      continuation.yield(path.isExpensive)
+      continuation.finish()
+    }
+    monitor.start(queue: .global(qos: .userInitiated))
+    defer { monitor.cancel() }
+    for await isCellular in stream {
+      return isCellular
+    }
+    return false
+  }
+
   // MARK: - Fallback decision
 
   enum Branch: Equatable {
@@ -151,13 +246,66 @@ struct DemoReplayHostView: View {
   }
 }
 
+// MARK: - DLCompleteOverlay
+
+/// Fullscreen overlay shown while `ReplayViewModel.state == .transitioning`.
+///
+/// Per `demo-replay-ui.md` §DLCompleteOverlay: ultra-thin material
+/// background + pulsing 44 pt dog mark + "準備ができました" +
+/// "tap anywhere to begin". Spec §2 decision 6 / 8 makes the transition
+/// auto-only — the hint text is visual only and no tap handler is wired.
+///
+/// Fade-in is `.easeOut(2.4s, delay: 0.2s)` by default. Under
+/// `accessibilityReduceMotion`, the overlay is shown at full opacity
+/// immediately and the dog mark does not pulse (handled inside
+/// `DogMark.pulsing()`).
+private struct DLCompleteOverlay: View {
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @State private var hasAppeared = false
+
+  var body: some View {
+    ZStack {
+      Rectangle()
+        .fill(.ultraThinMaterial)
+        .ignoresSafeArea()
+
+      VStack(spacing: Spacing.s) {
+        DogMark(size: 44)
+          .pulsing()
+        Text("準備ができました")
+          .textStyle(Typography.statusComplete)
+          .foregroundStyle(Color.mossInk)
+        Text("tap anywhere to begin")
+          .textStyle(Typography.statusHint)
+          .foregroundStyle(Color.muted)
+      }
+    }
+    .opacity(hasAppeared || reduceMotion ? 1 : 0)
+    .onAppear {
+      guard !reduceMotion else {
+        hasAppeared = true
+        return
+      }
+      withAnimation(.easeOut(duration: 2.4).delay(0.2)) {
+        hasAppeared = true
+      }
+    }
+  }
+}
+
 // MARK: - Previews
 
-// Only the default (checking) preview is exercised at skeleton time:
-// `ModelManager.state` is `private(set)`, so seeding arbitrary states
-// for preview would require a production seam. Richer preview variants
-// land once item 7 wires the real `.task { }` load; for now the
-// `fallbackBranch` decision is covered by unit tests in item 8.
+// The outer view exercises the default (`.checking` → fallback) path.
+// `ModelManager.state` is `private(set)`, so richer variants would
+// require a production seam; the `fallbackBranch` pure function is
+// unit-tested instead (item 8).
 #Preview {
   DemoReplayHostView(modelManager: ModelManager())
+}
+
+#Preview("DLCompleteOverlay") {
+  ZStack {
+    Color.screenBackground.ignoresSafeArea()
+    DLCompleteOverlay()
+  }
 }

--- a/Pastura/Pastura/Views/ModelDownload/PromoCard.swift
+++ b/Pastura/Pastura/Views/ModelDownload/PromoCard.swift
@@ -261,29 +261,37 @@ struct PromoCard: View {
   /// the last foreground anchor, and the current time. All inputs are
   /// explicit so the caller can unit-test wrap-around, BG pauses, and
   /// resume continuity without `@State` or a live clock.
-  static func computeSlotState(
+  nonisolated static func computeSlotState(
     previousSlot: Int,
     foregroundElapsed: TimeInterval,
     lastAnchor: Date?,
     now: Date,
     slotDuration: TimeInterval
-  ) -> (slot: Int, foregroundElapsed: TimeInterval, lastAnchor: Date?) {
+  ) -> SlotRotationState {
     let inflight = lastAnchor.map { now.timeIntervalSince($0) } ?? 0
     let totalInSlot = foregroundElapsed + inflight
     if totalInSlot >= slotDuration {
       // Slot advances; accumulator resets. The anchor only advances to `now`
       // when foregrounded (nil anchor means BG and stays nil).
-      return (
+      return SlotRotationState(
         slot: (previousSlot + 1) % 3,
         foregroundElapsed: 0,
-        lastAnchor: lastAnchor == nil ? nil : now
-      )
+        lastAnchor: lastAnchor == nil ? nil : now)
     }
-    return (
+    return SlotRotationState(
       slot: previousSlot,
       foregroundElapsed: foregroundElapsed,
-      lastAnchor: lastAnchor
-    )
+      lastAnchor: lastAnchor)
+  }
+
+  /// Return value of ``computeSlotState(previousSlot:foregroundElapsed:lastAnchor:now:slotDuration:)``.
+  ///
+  /// Explicitly `nonisolated` so the pure rotation math is testable from a
+  /// nonisolated test suite without hopping the main actor.
+  nonisolated struct SlotRotationState: Equatable, Sendable {
+    let slot: Int
+    let foregroundElapsed: TimeInterval
+    let lastAnchor: Date?
   }
 
   /// Slot copy (draft) from `docs/design/design-system.md` §7.

--- a/Pastura/Pastura/Views/ModelDownload/PromoCard.swift
+++ b/Pastura/Pastura/Views/ModelDownload/PromoCard.swift
@@ -1,0 +1,336 @@
+import Combine
+import SwiftUI
+
+/// Promotional card shown at the bottom of the demo replay screen while
+/// the model downloads. Three responsibilities:
+///
+/// 1. DL progress (8 dots + percent + size + ETA) driven by `ModelState`.
+/// 2. Rotating body copy (slots A → B → C → A …) driven by an independent
+///    foreground-accumulated timer. Background time is excluded per
+///    `demo-replay-ui.md` §PromoCard: "BG 復帰時の挙動: 位置継続".
+/// 3. Inline retry affordance when `.error` arrives *after* replay has
+///    started, per ADR-007 §3.3 (b) — the progress area swaps to an
+///    error message + retry button while the body copy keeps rotating.
+struct PromoCard: View {
+
+  let modelState: ModelState
+  let replayHadStarted: Bool
+  let onRetry: () -> Void
+
+  @Environment(\.scenePhase) private var scenePhase
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+  @State private var currentSlot: Int = 0
+  @State private var foregroundElapsed: TimeInterval = 0
+  @State private var lastForegroundAnchor: Date? = Date()
+  @State private var downloadStartDate: Date?
+
+  /// Provisional 20 s / slot; the spec marks this as "暫定値" to be tuned
+  /// during the copy pass.
+  private static let slotDuration: TimeInterval = 20
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      metaRow
+      bodyRow
+    }
+    .background(cardBackground)
+    .clipShape(RoundedRectangle(cornerRadius: Radius.promo))
+    .overlay(alignment: .leading) { leftAccent }
+    .overlay {
+      RoundedRectangle(cornerRadius: Radius.promo)
+        .strokeBorder(Color.promoBorder, lineWidth: 1)
+    }
+    .shadow(
+      color: PasturaShadows.tight.color.color,
+      radius: PasturaShadows.tight.radius,
+      x: PasturaShadows.tight.x, y: PasturaShadows.tight.y
+    )
+    .shadow(
+      color: PasturaShadows.soft.color.color,
+      radius: PasturaShadows.soft.radius,
+      x: PasturaShadows.soft.x, y: PasturaShadows.soft.y
+    )
+    .padding(.horizontal, 14)
+    .padding(.bottom, 22)
+    .onReceive(
+      // `.common` mode is paused by iOS while the app is backgrounded, which
+      // naturally aligns with the spec's foreground-only rotation policy.
+      Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+    ) { now in
+      tick(now: now)
+    }
+    .onChange(of: scenePhase) { _, newPhase in
+      handleScenePhase(newPhase)
+    }
+    .onChange(of: modelState) { _, newState in
+      handleModelStateChange(newState)
+    }
+  }
+
+  // MARK: - Meta row (DL progress OR inline retry)
+
+  @ViewBuilder
+  private var metaRow: some View {
+    if case .error(let message) = modelState, replayHadStarted {
+      retryView(message: message)
+    } else if case .downloading(let progress) = modelState {
+      progressView(progress: progress)
+    } else {
+      // Not expected under the host's `fallbackBranch` — render empty
+      // to keep the card height stable if this ever flickers.
+      Color.clear.frame(height: 0)
+    }
+  }
+
+  @ViewBuilder
+  private func progressView(progress: Double) -> some View {
+    let pct = Int(progress * 100)
+    let dotsLit = Int((progress * 8).rounded())
+    let downloadedGB = progress * 3.0
+    let etaMinutes = computeEtaMinutes(progress: progress)
+
+    VStack(alignment: .leading, spacing: 3) {
+      HStack(spacing: 6) {
+        Text("DL")
+          .textStyle(Typography.metaLabel)
+          .foregroundStyle(Color.metaBaseL3)
+
+        HStack(spacing: 2.5) {
+          ForEach(0..<8, id: \.self) { idx in
+            Circle()
+              .fill(idx < dotsLit ? Color.metaDotOnL3 : Color.moss.opacity(0.38))
+              .frame(width: 4, height: 4)
+              // 600 ms cubic-bezier(.4,0,.2,1) per spec §animation. Dot light-up
+              // is a state indicator, not decorative motion — kept even under
+              // `reduceMotion` per PR plan.
+              .animation(
+                .timingCurve(0.4, 0, 0.2, 1, duration: 0.6),
+                value: dotsLit)
+          }
+        }
+
+        Text("\(pct)%")
+          .textStyle(Typography.metaValue)
+          .foregroundStyle(Color.metaBaseL3)
+
+        Text("·")
+          .textStyle(Typography.metaValue)
+          .foregroundStyle(Color.metaBaseL3.opacity(0.6))
+
+        Text(String(format: "%.1f GB / 3.0 GB", downloadedGB))
+          .textStyle(Typography.metaValue)
+          .foregroundStyle(Color.metaBaseL3)
+
+        Spacer(minLength: 0)
+      }
+
+      if pct < 100, let etaText = Self.formatEta(minutes: etaMinutes) {
+        Text(etaText)
+          .textStyle(Typography.metaEta)
+          .foregroundStyle(Color.metaStrongL3)
+          .padding(.leading, 2)
+      }
+    }
+    .padding(.horizontal, 14)
+    .padding(.top, 8)
+    .padding(.bottom, 7)
+    .accessibilityElement(children: .combine)
+    .accessibilityAddTraits(.updatesFrequently)
+  }
+
+  @ViewBuilder
+  private func retryView(message: String) -> some View {
+    HStack(alignment: .center, spacing: Spacing.s) {
+      VStack(alignment: .leading, spacing: 2) {
+        Text("ダウンロードが中断しました")
+          .textStyle(Typography.metaEta)
+          .foregroundStyle(Color.metaStrongL3)
+        Text(message)
+          .textStyle(Typography.metaValue)
+          .foregroundStyle(Color.metaBaseL3)
+          .lineLimit(2)
+      }
+      Spacer(minLength: 0)
+      Button(action: onRetry) {
+        Text("もう一度試す")
+          .textStyle(Typography.metaLabel)
+          .foregroundStyle(Color.white)
+          .padding(.horizontal, 10)
+          .padding(.vertical, 5)
+          .background(
+            RoundedRectangle(cornerRadius: Radius.button)
+              .fill(Color.moss))
+      }
+      .buttonStyle(.plain)
+    }
+    .padding(.horizontal, 14)
+    .padding(.top, 8)
+    .padding(.bottom, 7)
+  }
+
+  // MARK: - Body row (dog mark + rotating copy)
+
+  private var bodyRow: some View {
+    HStack(alignment: .top, spacing: 12) {
+      DogMark(size: 26)
+      Text(Self.slotCopy(currentSlot))
+        .textStyle(Typography.bodyPromo)
+        .foregroundStyle(Color.ink)
+        .fixedSize(horizontal: false, vertical: true)
+        .transition(.opacity)
+        .id(currentSlot)  // forces cross-fade on slot change
+      Spacer(minLength: 0)
+    }
+    .padding(.horizontal, 14)
+    .padding(.top, 11)
+    .padding(.bottom, 13)
+    .animation(
+      // 400 ms ease-in-out cross-fade; instant under `reduceMotion`.
+      reduceMotion ? nil : .easeInOut(duration: 0.4),
+      value: currentSlot)
+  }
+
+  // MARK: - Decorative layers
+
+  private var cardBackground: some View {
+    RoundedRectangle(cornerRadius: Radius.promo)
+      .fill(Color.promoBackground)
+  }
+
+  private var leftAccent: some View {
+    Rectangle()
+      .fill(Color.moss)
+      .frame(width: 3)
+      .clipShape(
+        UnevenRoundedRectangle(
+          topLeadingRadius: Radius.promo,
+          bottomLeadingRadius: Radius.promo))
+  }
+
+  // MARK: - Behavior
+
+  private func tick(now: Date) {
+    let next = Self.computeSlotState(
+      previousSlot: currentSlot,
+      foregroundElapsed: foregroundElapsed,
+      lastAnchor: lastForegroundAnchor,
+      now: now,
+      slotDuration: Self.slotDuration)
+    if next.slot != currentSlot {
+      currentSlot = next.slot
+    }
+    foregroundElapsed = next.foregroundElapsed
+    lastForegroundAnchor = next.lastAnchor
+  }
+
+  private func handleScenePhase(_ phase: ScenePhase) {
+    let now = Date()
+    switch phase {
+    case .background, .inactive:
+      if let anchor = lastForegroundAnchor {
+        foregroundElapsed += now.timeIntervalSince(anchor)
+      }
+      lastForegroundAnchor = nil
+    case .active:
+      if lastForegroundAnchor == nil {
+        lastForegroundAnchor = now
+      }
+    @unknown default:
+      break
+    }
+  }
+
+  private func handleModelStateChange(_ newState: ModelState) {
+    if case .downloading = newState, downloadStartDate == nil {
+      downloadStartDate = Date()
+    }
+  }
+
+  private func computeEtaMinutes(progress: Double) -> Int? {
+    guard let start = downloadStartDate, progress >= 0.01 else { return nil }
+    let elapsed = Date().timeIntervalSince(start)
+    let total = elapsed / progress
+    let remaining = max(0, total - elapsed)
+    return Int(remaining / 60)
+  }
+
+  // MARK: - Pure helpers (testable)
+
+  /// Computes the next slot rotation state from the current accumulator,
+  /// the last foreground anchor, and the current time. All inputs are
+  /// explicit so the caller can unit-test wrap-around, BG pauses, and
+  /// resume continuity without `@State` or a live clock.
+  static func computeSlotState(
+    previousSlot: Int,
+    foregroundElapsed: TimeInterval,
+    lastAnchor: Date?,
+    now: Date,
+    slotDuration: TimeInterval
+  ) -> (slot: Int, foregroundElapsed: TimeInterval, lastAnchor: Date?) {
+    let inflight = lastAnchor.map { now.timeIntervalSince($0) } ?? 0
+    let totalInSlot = foregroundElapsed + inflight
+    if totalInSlot >= slotDuration {
+      // Slot advances; accumulator resets. The anchor only advances to `now`
+      // when foregrounded (nil anchor means BG and stays nil).
+      return (
+        slot: (previousSlot + 1) % 3,
+        foregroundElapsed: 0,
+        lastAnchor: lastAnchor == nil ? nil : now
+      )
+    }
+    return (
+      slot: previousSlot,
+      foregroundElapsed: foregroundElapsed,
+      lastAnchor: lastAnchor
+    )
+  }
+
+  /// Slot copy (draft) from `docs/design/design-system.md` §7.
+  /// Final wording is gated on the copy pass per spec §2 decision 13.
+  static func slotCopy(_ slot: Int) -> String {
+    switch slot % 3 {
+    case 0: return "AIエージェントが、あなたのiPhoneの中で対話します"
+    case 1: return "少しだけお待ちください。その間、他のエージェントたちの様子をどうぞ"
+    default: return "このアプリは広告もログインもなく、あなたの端末だけで静かに動きます"
+    }
+  }
+
+  /// `残り約N分` when minutes > 0, `まもなく` when <= 0, nil to hide.
+  static func formatEta(minutes: Int?) -> String? {
+    guard let minutes = minutes else { return nil }
+    return minutes <= 0 ? "まもなく" : "残り約\(minutes)分"
+  }
+}
+
+// MARK: - Previews
+
+#Preview("Downloading 35%") {
+  PromoCard(
+    modelState: .downloading(progress: 0.35),
+    replayHadStarted: true,
+    onRetry: {}
+  )
+  .padding(.vertical, 40)
+  .background(Color.screenBackground)
+}
+
+#Preview("Downloading 95%") {
+  PromoCard(
+    modelState: .downloading(progress: 0.95),
+    replayHadStarted: true,
+    onRetry: {}
+  )
+  .padding(.vertical, 40)
+  .background(Color.screenBackground)
+}
+
+#Preview("Error after start (retry)") {
+  PromoCard(
+    modelState: .error("ネットワーク接続が切れました"),
+    replayHadStarted: true,
+    onRetry: {}
+  )
+  .padding(.vertical, 40)
+  .background(Color.screenBackground)
+}

--- a/Pastura/Pastura/Views/ModelDownload/PromoCard.swift
+++ b/Pastura/Pastura/Views/ModelDownload/PromoCard.swift
@@ -63,7 +63,7 @@ struct PromoCard: View {
     .onChange(of: scenePhase) { _, newPhase in
       handleScenePhase(newPhase)
     }
-    .onChange(of: modelState) { _, newState in
+    .onChange(of: modelState, initial: true) { _, newState in
       handleModelStateChange(newState)
     }
   }

--- a/Pastura/PasturaTests/App/DemoReplayIntegrationTests.swift
+++ b/Pastura/PasturaTests/App/DemoReplayIntegrationTests.swift
@@ -230,6 +230,40 @@ struct DemoReplayIntegrationTests {
     #expect(viewModel.state == .transitioning)
   }
 
+  @Test func startThenPauseResumeThenDownloadComplete() async throws {
+    // Drives the full DemoReplayHostView lifecycle chain end-to-end across
+    // ≥ 2 sources: start → some outputs → background → assert .paused →
+    // foreground → assert .playing → downloadComplete → assert .transitioning.
+    let sources = Self.makeSources()
+    let viewModel = ReplayViewModel(
+      sources: sources, config: Self.integrationConfig,
+      contentFilter: ContentFilter())
+    viewModel.start()
+
+    // Wait until at least one agent output so playback is in-flight.
+    await Self.waitForState(viewModel) { _ in viewModel.agentOutputs.count >= 1 }
+
+    viewModel.onBackground()
+    guard case .paused(let pausedIdx, let pausedCursor, _) = viewModel.state else {
+      Issue.record("Expected .paused after onBackground(), got \(viewModel.state)")
+      return
+    }
+
+    viewModel.onForeground()
+    // Resume synchronously restores .playing at the same position.
+    if case .playing(let rIdx, let rCursor) = viewModel.state {
+      #expect(rIdx == pausedIdx)
+      #expect(rCursor == pausedCursor)
+    } else {
+      Issue.record("Expected .playing after onForeground(), got \(viewModel.state)")
+      return
+    }
+
+    // Simulate download completing while playback is running.
+    viewModel.downloadComplete()
+    #expect(viewModel.state == .transitioning)
+  }
+
   @Test func pauseAndResumeLandsOnSameCursor() async throws {
     // Slower pacing so the pause catches mid-sleep — otherwise 100×
     // collapses the sleep to 0 and we observe a boundary pause that

--- a/Pastura/PasturaTests/Views/DemoReplayHostViewTests.swift
+++ b/Pastura/PasturaTests/Views/DemoReplayHostViewTests.swift
@@ -1,0 +1,295 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+// MARK: - DemoReplayHostView.fallbackBranch
+
+// `DemoReplayHostView` is a View (implicitly @MainActor). `Branch` and
+// `fallbackBranch` are declared inside it, so their Equatable conformance
+// is also @MainActor-bound. The suite must run on the main actor.
+@Suite("DemoReplayHostView", .serialized, .timeLimit(.minutes(1)))
+@MainActor
+struct DemoReplayHostViewTests {
+
+  // MARK: - fallbackBranch: cellular takes priority
+
+  @Test func cellularReturnsFallback_regardlessOfState() {
+    // Cellular is the Option A safety net — overrides every other condition.
+    let result = DemoReplayHostView.fallbackBranch(
+      state: .downloading(progress: 0.5),
+      demosCount: 10,
+      replayHadStarted: true,
+      isCellular: true)
+    #expect(result == .modelDownload)
+  }
+
+  @Test func cellularReturnsFallback_evenWhenReady() {
+    let result = DemoReplayHostView.fallbackBranch(
+      state: .ready(modelPath: "x"),
+      demosCount: 5,
+      replayHadStarted: true,
+      isCellular: true)
+    #expect(result == .modelDownload)
+  }
+
+  // MARK: - fallbackBranch: pre-download states always fall back
+
+  @Test func checkingReturnsFallback() {
+    let result = DemoReplayHostView.fallbackBranch(
+      state: .checking,
+      demosCount: 10,
+      replayHadStarted: true,
+      isCellular: false)
+    #expect(result == .modelDownload)
+  }
+
+  @Test func unsupportedDeviceReturnsFallback() {
+    let result = DemoReplayHostView.fallbackBranch(
+      state: .unsupportedDevice,
+      demosCount: 10,
+      replayHadStarted: true,
+      isCellular: false)
+    #expect(result == .modelDownload)
+  }
+
+  @Test func notDownloadedReturnsFallback() {
+    let result = DemoReplayHostView.fallbackBranch(
+      state: .notDownloaded,
+      demosCount: 10,
+      replayHadStarted: true,
+      isCellular: false)
+    #expect(result == .modelDownload)
+  }
+
+  // MARK: - fallbackBranch: .downloading with floor enforcement (spec §5.2)
+
+  @Test func downloadingWithZeroDemosReturnsFallback() {
+    let result = DemoReplayHostView.fallbackBranch(
+      state: .downloading(progress: 0.5),
+      demosCount: 0,
+      replayHadStarted: false,
+      isCellular: false)
+    #expect(result == .modelDownload)
+  }
+
+  @Test func downloadingWithOneDemoReturnsFallback_belowFloor() {
+    // spec §5.2: a single surviving demo is below the minPlayableDemoCount
+    // floor (2). The rotation loop would be unsatisfying — defer to fallback.
+    let result = DemoReplayHostView.fallbackBranch(
+      state: .downloading(progress: 0.5),
+      demosCount: 1,
+      replayHadStarted: false,
+      isCellular: false)
+    #expect(result == .modelDownload)
+  }
+
+  @Test func downloadingWithTwoDemosReturnsDemoHost_atFloor() {
+    let result = DemoReplayHostView.fallbackBranch(
+      state: .downloading(progress: 0.5),
+      demosCount: 2,
+      replayHadStarted: false,
+      isCellular: false)
+    #expect(result == .demoHost)
+  }
+
+  @Test func downloadingWithFiveDemosReturnsDemoHost() {
+    let result = DemoReplayHostView.fallbackBranch(
+      state: .downloading(progress: 0.1),
+      demosCount: 5,
+      replayHadStarted: false,
+      isCellular: false)
+    #expect(result == .demoHost)
+  }
+
+  // MARK: - fallbackBranch: .error respects replayHadStarted (ADR-007 §3.3 (b))
+
+  @Test func errorBeforeReplayStartedReturnsFallback() {
+    let result = DemoReplayHostView.fallbackBranch(
+      state: .error("network timeout"),
+      demosCount: 5,
+      replayHadStarted: false,
+      isCellular: false)
+    #expect(result == .modelDownload)
+  }
+
+  @Test func errorAfterReplayStartedReturnsDemoHost() {
+    // Inline retry affordance in PromoCard keeps playback alive.
+    let result = DemoReplayHostView.fallbackBranch(
+      state: .error("network timeout"),
+      demosCount: 5,
+      replayHadStarted: true,
+      isCellular: false)
+    #expect(result == .demoHost)
+  }
+
+  // MARK: - fallbackBranch: .ready
+
+  @Test func readyReturnsDemoHost() {
+    let result = DemoReplayHostView.fallbackBranch(
+      state: .ready(modelPath: "x"),
+      demosCount: 0,
+      replayHadStarted: false,
+      isCellular: false)
+    #expect(result == .demoHost)
+  }
+}
+
+// MARK: - PromoCard.computeSlotState
+
+@Suite("PromoCard.computeSlotState", .serialized, .timeLimit(.minutes(1)))
+struct PromoCardComputeSlotStateTests {
+
+  let now = Date(timeIntervalSince1970: 1_000_000)
+
+  // MARK: - Slot stays when not enough time has passed
+
+  @Test func stillInsideSlot_slotUnchanged() {
+    // foregroundElapsed=10, inflight=5 → total=15 < slotDuration=20
+    let anchor = now.addingTimeInterval(-5)
+    let result = PromoCard.computeSlotState(
+      previousSlot: 0,
+      foregroundElapsed: 10,
+      lastAnchor: anchor,
+      now: now,
+      slotDuration: 20)
+    #expect(result.slot == 0)
+    #expect(result.foregroundElapsed == 10)
+    #expect(result.lastAnchor == anchor)
+  }
+
+  // MARK: - Slot advances exactly at boundary
+
+  @Test func exactlyAtBoundary_slotAdvances() {
+    // foregroundElapsed=0, inflight=20 → total=20 == slotDuration=20
+    let anchor = now.addingTimeInterval(-20)
+    let result = PromoCard.computeSlotState(
+      previousSlot: 0,
+      foregroundElapsed: 0,
+      lastAnchor: anchor,
+      now: now,
+      slotDuration: 20)
+    #expect(result.slot == 1)
+    #expect(result.foregroundElapsed == 0)
+    // Anchor resets to `now` when foregrounded.
+    #expect(result.lastAnchor == now)
+  }
+
+  // MARK: - Background pause: anchor nil, no advancement
+
+  @Test func bgPauseMidSlot_slotUnchanged_elapsedPreserved() {
+    // lastAnchor = nil → inflight = 0. No time accumulates while BG.
+    let result = PromoCard.computeSlotState(
+      previousSlot: 1,
+      foregroundElapsed: 10,
+      lastAnchor: nil,
+      now: now,
+      slotDuration: 20)
+    #expect(result.slot == 1)
+    #expect(result.foregroundElapsed == 10)
+    #expect(result.lastAnchor == nil)
+  }
+
+  @Test func bgPause_withInsufficientForegroundElapsed_slotUnchanged() {
+    // foregroundElapsed=10 < slotDuration=20, anchor=nil (BG) → inflight=0.
+    // total = 10 < 20 → slot does not advance.
+    let result = PromoCard.computeSlotState(
+      previousSlot: 0,
+      foregroundElapsed: 10,
+      lastAnchor: nil,
+      now: now,
+      slotDuration: 20)
+    #expect(result.slot == 0)
+    #expect(result.foregroundElapsed == 10)
+    #expect(result.lastAnchor == nil)
+  }
+
+  // MARK: - Resume after BG: anchor set to now, inflight accumulates
+
+  @Test func resumeAfterBG_slotAdvancesWhenTotalReachesDuration() {
+    // Simulates: BG with foregroundElapsed=15 accumulated, then FG sets
+    // lastAnchor=now. After 5s inflight (anchor = now - 5), total = 20.
+    let anchor = now.addingTimeInterval(-5)
+    let result = PromoCard.computeSlotState(
+      previousSlot: 0,
+      foregroundElapsed: 15,
+      lastAnchor: anchor,
+      now: now,
+      slotDuration: 20)
+    #expect(result.slot == 1)
+    #expect(result.foregroundElapsed == 0)
+    #expect(result.lastAnchor == now)
+  }
+
+  @Test func resumeAfterBG_slotDoesNotAdvanceWhenInsufficientInflight() {
+    // BG accumulated foregroundElapsed=15, but only 3s inflight after FG.
+    // total = 18 < 20 → no advance.
+    let anchor = now.addingTimeInterval(-3)
+    let result = PromoCard.computeSlotState(
+      previousSlot: 2,
+      foregroundElapsed: 15,
+      lastAnchor: anchor,
+      now: now,
+      slotDuration: 20)
+    #expect(result.slot == 2)
+    #expect(result.foregroundElapsed == 15)
+    #expect(result.lastAnchor == anchor)
+  }
+
+  // MARK: - Wrap-around 0 → 1 → 2 → 0
+
+  @Test func wrapAround_threeAdvancements_returnToSlotZero() {
+    // Each call represents a tick exactly at the boundary (inflight = slotDuration).
+    // Call 1: 0 → 1
+    var anchor: Date? = now.addingTimeInterval(-20)
+    let r1 = PromoCard.computeSlotState(
+      previousSlot: 0, foregroundElapsed: 0,
+      lastAnchor: anchor, now: now, slotDuration: 20)
+    #expect(r1.slot == 1)
+
+    // Call 2: 1 → 2 (reset anchor to now, then advance again 20s later)
+    let now2 = now.addingTimeInterval(20)
+    anchor = r1.lastAnchor  // = now after slot advance
+    let r2 = PromoCard.computeSlotState(
+      previousSlot: r1.slot, foregroundElapsed: r1.foregroundElapsed,
+      lastAnchor: anchor, now: now2, slotDuration: 20)
+    #expect(r2.slot == 2)
+
+    // Call 3: 2 → 0 (mod 3 wrap-around)
+    let now3 = now2.addingTimeInterval(20)
+    anchor = r2.lastAnchor  // = now2 after slot advance
+    let r3 = PromoCard.computeSlotState(
+      previousSlot: r2.slot, foregroundElapsed: r2.foregroundElapsed,
+      lastAnchor: anchor, now: now3, slotDuration: 20)
+    #expect(r3.slot == 0)
+  }
+
+  // MARK: - Wrap-around with BG in the middle
+
+  @Test func wrapAroundWithBGInMiddle_anchorStaysNilThroughSlotBoundary() {
+    // Slot 1 accumulated 30s foreground, goes BG (anchor=nil).
+    // While BG a tick fires: total = foregroundElapsed + 0 = 30 >= slotDuration=20.
+    // Slot should advance to 2, anchor must stay nil (BG).
+    let result = PromoCard.computeSlotState(
+      previousSlot: 1,
+      foregroundElapsed: 30,
+      lastAnchor: nil,
+      now: now,
+      slotDuration: 20)
+    #expect(result.slot == 2)
+    #expect(result.foregroundElapsed == 0)
+    #expect(result.lastAnchor == nil, "Anchor must remain nil while backgrounded")
+
+    // Simulate FG return: `handleScenePhase(.active)` sets anchor = now.
+    // After slotDuration inflight, slot advances again (2 → 0).
+    let fgNow = now.addingTimeInterval(20)
+    let r2 = PromoCard.computeSlotState(
+      previousSlot: result.slot,
+      foregroundElapsed: result.foregroundElapsed,
+      lastAnchor: fgNow.addingTimeInterval(-20),  // anchor set at FG return
+      now: fgNow,
+      slotDuration: 20)
+    #expect(r2.slot == 0)
+    #expect(r2.lastAnchor == fgNow)
+  }
+}

--- a/Pastura/PasturaTests/Views/DemoReplayHostViewTests.swift
+++ b/Pastura/PasturaTests/Views/DemoReplayHostViewTests.swift
@@ -242,26 +242,26 @@ struct PromoCardComputeSlotStateTests {
     // Each call represents a tick exactly at the boundary (inflight = slotDuration).
     // Call 1: 0 → 1
     var anchor: Date? = now.addingTimeInterval(-20)
-    let r1 = PromoCard.computeSlotState(
+    let result1 = PromoCard.computeSlotState(
       previousSlot: 0, foregroundElapsed: 0,
       lastAnchor: anchor, now: now, slotDuration: 20)
-    #expect(r1.slot == 1)
+    #expect(result1.slot == 1)
 
     // Call 2: 1 → 2 (reset anchor to now, then advance again 20s later)
     let now2 = now.addingTimeInterval(20)
-    anchor = r1.lastAnchor  // = now after slot advance
-    let r2 = PromoCard.computeSlotState(
-      previousSlot: r1.slot, foregroundElapsed: r1.foregroundElapsed,
+    anchor = result1.lastAnchor  // = now after slot advance
+    let result2 = PromoCard.computeSlotState(
+      previousSlot: result1.slot, foregroundElapsed: result1.foregroundElapsed,
       lastAnchor: anchor, now: now2, slotDuration: 20)
-    #expect(r2.slot == 2)
+    #expect(result2.slot == 2)
 
     // Call 3: 2 → 0 (mod 3 wrap-around)
     let now3 = now2.addingTimeInterval(20)
-    anchor = r2.lastAnchor  // = now2 after slot advance
-    let r3 = PromoCard.computeSlotState(
-      previousSlot: r2.slot, foregroundElapsed: r2.foregroundElapsed,
+    anchor = result2.lastAnchor  // = now2 after slot advance
+    let result3 = PromoCard.computeSlotState(
+      previousSlot: result2.slot, foregroundElapsed: result2.foregroundElapsed,
       lastAnchor: anchor, now: now3, slotDuration: 20)
-    #expect(r3.slot == 0)
+    #expect(result3.slot == 0)
   }
 
   // MARK: - Wrap-around with BG in the middle
@@ -283,13 +283,13 @@ struct PromoCardComputeSlotStateTests {
     // Simulate FG return: `handleScenePhase(.active)` sets anchor = now.
     // After slotDuration inflight, slot advances again (2 → 0).
     let fgNow = now.addingTimeInterval(20)
-    let r2 = PromoCard.computeSlotState(
+    let result2 = PromoCard.computeSlotState(
       previousSlot: result.slot,
       foregroundElapsed: result.foregroundElapsed,
       lastAnchor: fgNow.addingTimeInterval(-20),  // anchor set at FG return
       now: fgNow,
       slotDuration: 20)
-    #expect(r2.slot == 0)
-    #expect(r2.lastAnchor == fgNow)
+    #expect(result2.slot == 0)
+    #expect(result2.lastAnchor == fgNow)
   }
 }


### PR DESCRIPTION
## Summary

PR2 of 3 for #169 (DL-time demo replay). Builds the View layer on top of PR1's
VM + Source primitives (#186). Ships 3 shared components (`SheepAvatar`,
`DogMark`, `PhaseHeader`) + 2 feature-local views (`PromoCard`,
`DemoReplayHostView` with `DLCompleteOverlay`) + tests. The demo host
is fully self-contained but not yet reachable from the app entry point —
PR3 does the 1-line `ModelDownloadView → DemoReplayHostView` swap in
`PasturaApp.swift`.

Plan went through 2 rounds of critic review and 1 code review. All Critical
items resolved; cellular ADR-007 §3.3(c) compliance is implemented as a
conservative safety net (demo skipped on cellular) with the full modal UX
tracked as #191.

## What's in it

- **Shared visual components** (`Views/Components/`):
  - `SheepAvatar` — 42 pt canvas-drawn sheep with 4 character variants (Alice/Bob/Carol/Dave).
  - `DogMark` — 26 pt / 44 pt assistant mark + `.pulsing()` modifier (2.4 s ease-in-out), reduce-motion gated.
  - `PhaseHeader` — sticky header with preset tag + phase title + "DEMO中" badge.
- **Feature-local views** (`Views/ModelDownload/`):
  - `PromoCard` — 8-dot DL progress + Slot A/B/C rotation (20 s, foreground-accumulated, BG-pause semantics per spec §PromoCard) + inline retry affordance on `.error` post-start (ADR-007 §3.3 (b)). Pure `computeSlotState(...)` fn extracted for unit test.
  - `DemoReplayHostView` — orchestrator. `.task { }` runs once per mount: 1-shot `NWPathMonitor` cellular check + `BundledDemoReplaySource.loadAll()` + VM construction + `start()` if `>= 2` demos. ScenePhase bridged to `onBackground / onForeground`. `ModelState.ready` triggers `downloadComplete()`. `DLCompleteOverlay` (private nested) fades in at `.transitioning`, pulsing dog mark + "準備ができました" + "tap anywhere to begin" (draft copy). Pure `fallbackBranch(state:demosCount:replayHadStarted:isCellular:)` fn extracted for unit test.
- **Tests**:
  - `PasturaTests/Views/DemoReplayHostViewTests.swift` — 12 cases on `fallbackBranch` (covers spec §5.2 min-playable floor + cellular safety net + error state branching) + 8 cases on `computeSlotState` (wrap-around, BG pause, resume continuity).
  - `PasturaTests/App/DemoReplayIntegrationTests.swift` — appended `startThenPauseResumeThenDownloadComplete` covering the full VM lifecycle on ≥ 2 sources (existing tests had pause/resume and downloadComplete separately).

## Design choices (confirmed)

- **Cellular safety net (Option A)** — demo skipped on cellular; user sees plain `ModelDownloadView`. Full ADR-007 §3.3(c) modal UX is #191.
- **Minimum playable floor** — `minPlayableDemoCount = 2` per spec §5.2. `demosCount < 2` routes to `ModelDownloadView` (avoids nil-VM render post-#170 if one demo survives SHA drift).
- **Reduce-motion** — gates DogMark pulse, DLCompleteOverlay fade, chat bubble fade-in, slot cross-fade. DL-dot 600 ms light-up kept (state indicator).
- **Error-during-replay** — playback keeps running; progress meta row swaps to retry button inside PromoCard. `{ modelManager.startDownload() }` wiring; note `startDownload()` resets progress to 0, so "resumes from where it left off" is not fully honored — follow-up candidate.
- **`.task { }` re-run safety** — `AppState` is stable under `ModelManager.state` transitions inside `.needsModelDownload`, so the host view's SwiftUI identity is preserved and `.task` runs exactly once per mount.
- **SheepAvatar face/horn colors** — inlined per-character hex values because the token set targets the alternate `sheepSvg()` style (ears+nose). The HTML reference's `sheepAvatar()` function is the authoritative source for the 4 character variants used here. Noted in the file's doc comment.

## Follow-ups

- **PR3**: `PasturaApp.swift` 1-line swap `ModelDownloadView → DemoReplayHostView`. Merge sequencing: PR3 should land *after or with* #191's cellular modal to fully honor ADR-007 §3.3(c). This PR's safety net keeps PR3 merge-safe regardless.
- **#191**: Cellular confirmation modal (ADR-007 §3.3(c)) — upgrades the Option A safety net to the full modal + Wi-Fi advisory UX.
- **#170**: Populate `Resources/DemoReplays/` with real demo YAML (CI drift guard).
- `lastKnownProgress` sticky for DL dots during `.error` (so retry doesn't visually reset to 0%).

## Test plan

Automated:
- [x] `xcodebuild test` full suite (serial, 759 tests) — PASS locally.
- [x] `swiftlint lint --strict` — clean.

Manual QA (do after PR3 wires the host view into app entry):
- [ ] Cold launch with model not downloaded → plain `ModelDownloadView` (until demos populate #170).
- [ ] Once demos populate: cold launch → PhaseHeader + ChatStream + PromoCard visible during DL.
- [ ] Background the app mid-playback → VM pauses, slot rotation freezes. Foreground → resumes from same cursor, same slot elapsed carried over.
- [ ] Kill network during DL → `.error` state, PromoCard shows "もう一度試す" button, chat stream keeps playing.
- [ ] DL completes → `DLCompleteOverlay` fades in with pulsing dog mark + "準備ができました".
- [ ] Enable iOS Reduce Motion → pulse stops, fade-in instant, bubble fade-in instant, slot cross-fade instant.
- [ ] Put device on cellular before cold launch → plain `ModelDownloadView` (no demo playback — Option A safety net).

Related PRs / issues:
- Builds on: #186 (PR1 VM+Source), #173 (design tokens), #176 (B1 AgentOutputRow token-ization).
- Tracks: #169 (feature umbrella), #170 (real demo YAML populate), #191 (cellular modal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)