### PR TITLE
🧪 test: back-gesture + editor reload UI tests (#109 #110)

### DIFF
--- a/.claude/rules/navigation.md
+++ b/.claude/rules/navigation.md
@@ -97,24 +97,29 @@ When reviewing changes that touch navigation:
       should be empty.
 - [ ] No new properties on `AppRouter` beyond navigation-path management.
 
-## Manual QA scenarios (no UI test target yet)
+## QA scenarios
 
-Run these whenever the navigation surface changes:
+`PasturaUITests` covers scenarios 1 and 3 end-to-end and scenario 2 on
+its primary route. Run the manual steps below whenever the navigation
+surface changes in areas the automated tests do not exercise.
 
-1. **Share Board → Try → Run Simulation** — From Home, tap Share Board, pick a
-   gallery scenario, tap **Try this scenario**, wait for install, then tap
-   **Run Simulation** on the pushed scenario detail. Expected: SimulationView
-   appears. Regression symptom: ScenarioDetailView re-pushes itself.
-2. **Back gesture from any depth** — Swipe back from each of:
-   ScenarioDetail, Editor, Import, Simulation, Results, GalleryScenarioDetail.
-   Expected: each pop returns one screen, not all the way to root.
-3. **Editor save → return to Home** — From Home, open New Scenario, save,
-   confirm Home reloads with the new scenario showing (the
-   `onChange(of: router.path.count)` reload trigger). Note: the trigger
+1. **Share Board → Try → Run Simulation** — Automated by
+   `NavigationRegressionTests.testGalleryInstallThenRunSimulationReachesSimulationView`
+   (PR #105). Regression symptom: ScenarioDetailView re-pushes itself.
+   Re-run the manual flow only if the `--ui-test` DI path diverges from
+   production (e.g., gallery install side effects that depend on a real
+   network).
+2. **Back gesture** — `BackGestureTests` covers the Home → ScenarioDetail
+   route automatically. Manually verify the remaining routes still pop
+   exactly one screen (not all the way to root): Editor, Import,
+   Simulation, Results, GalleryScenarioDetail.
+3. **Editor save → Home reload** — `EditorReloadTests` covers the
+   `onChange(of: router.path.count)` pop-trigger path. Note: the trigger
    only fires when `newCount < oldCount` (a pop). Flows that finish by
    pushing forward — e.g. editor save then push to the new scenario's
    detail — bypass this reload; if such a flow is added, surface the
-   write through the ViewModel rather than relying on the pop-trigger.
+   write through the ViewModel rather than relying on the pop-trigger,
+   and extend `EditorReloadTests` (or add a sibling) to cover it.
 4. **Swipe-back during Try** — Tap Try, immediately swipe back to dismiss
    `GalleryScenarioDetailView` while the install is still running. Expected:
    install completes in the background, the gallery's `pushIfOnTop` guard

--- a/Pastura/Pastura/App/AppDependencies.swift
+++ b/Pastura/Pastura/App/AppDependencies.swift
@@ -30,13 +30,27 @@ final class AppDependencies: @unchecked Sendable {
   /// Service that fetches the remote Share Board (gallery) index and YAMLs.
   let galleryService: any GalleryService
 
+  #if DEBUG
+    /// YAML pre-filled into the scenario editor when the Home screen's
+    /// "New Scenario" menu is tapped under `--ui-test`. `nil` in all other
+    /// builds and flows. Populated by `setupUITestState()` from the
+    /// `--ui-test-editor-seed-yaml` launch argument; consumed by `HomeView`
+    /// so test code does not read `CommandLine.arguments` from a view.
+    ///
+    /// DEBUG-gated to match the existing UITestSupport surface
+    /// (`StubGalleryService`, `StubScenarioSeeder`) and to keep
+    /// Release-iphoneos binaries free of UI-test plumbing per ADR-005 §8.
+    let uiTestEditorSeedYAML: String?
+  #endif
+
   private let databaseManager: DatabaseManager
 
   init(
     databaseManager: DatabaseManager,
     llmService: (any LLMService)? = nil,
     backgroundManager: BackgroundSimulationManager = BackgroundSimulationManager(),
-    galleryService: (any GalleryService)? = nil
+    galleryService: (any GalleryService)? = nil,
+    uiTestEditorSeedYAML: String? = nil
   ) {
     self.databaseManager = databaseManager
     let writer = databaseManager.dbWriter
@@ -58,6 +72,9 @@ final class AppDependencies: @unchecked Sendable {
     }
     self.backgroundManager = backgroundManager
     self.galleryService = galleryService ?? URLSessionGalleryService()
+    #if DEBUG
+      self.uiTestEditorSeedYAML = uiTestEditorSeedYAML
+    #endif
   }
 
   #if DEBUG || targetEnvironment(simulator)
@@ -87,13 +104,15 @@ final class AppDependencies: @unchecked Sendable {
   /// Creates a test/preview instance with in-memory storage.
   static func inMemory(
     llmService: (any LLMService)? = nil,
-    galleryService: (any GalleryService)? = nil
+    galleryService: (any GalleryService)? = nil,
+    uiTestEditorSeedYAML: String? = nil
   ) throws -> AppDependencies {
     let manager = try DatabaseManager.inMemory()
     return AppDependencies(
       databaseManager: manager,
       llmService: llmService,
-      galleryService: galleryService
+      galleryService: galleryService,
+      uiTestEditorSeedYAML: uiTestEditorSeedYAML
     )
   }
 

--- a/Pastura/Pastura/App/UITestSupport/StubScenarioSeeder.swift
+++ b/Pastura/Pastura/App/UITestSupport/StubScenarioSeeder.swift
@@ -1,0 +1,105 @@
+#if DEBUG
+
+  import Foundation
+
+  /// UI-test-only seeding helpers.
+  ///
+  /// Two orthogonal responsibilities:
+  /// 1. ``seed(into:)`` — inserts a known `ScenarioRecord` into the in-memory
+  ///    DB so `HomeView` shows at least one tappable row. Used by
+  ///    ``BackGestureTests`` and ``EditorReloadTests`` for a deterministic
+  ///    "before" count.
+  /// 2. ``editorSeedYAML`` — a minimal YAML string passed to
+  ///    `Route.editor(templateYAML:)` via `AppDependencies.uiTestEditorSeedYAML`.
+  ///    Pre-verified to pass both `ScenarioValidator` and
+  ///    `ScenarioContentValidator` after `ScenarioEditorViewModel.loadFromTemplate`'s
+  ///    UUID regeneration (see `StubScenarioSeederTests`).
+  ///
+  /// Distinct from ``StubGalleryService/canaryYAML`` (id `ui_test_canary`,
+  /// used by the Share Board install-flow canary) — the seeds here use
+  /// `ui_test_home_seed` / `ui_test_editor_reload_seed` to keep provenance
+  /// obvious to future maintainers.
+  nonisolated public enum StubScenarioSeeder {
+    /// Scenario id for the Home-list seed row. Stable so tests can target
+    /// `home.scenarioListCell.ui_test_home_seed` by identifier.
+    public static let homeSeedScenarioId = "ui_test_home_seed"
+
+    /// Human-readable name for the Home-list seed row. Distinct from any
+    /// preset or gallery fixture so UI tests can query it unambiguously.
+    public static let homeSeedScenarioName = "UITest Home Seed"
+
+    /// Scenario name carried by ``editorSeedYAML``. `EditorReloadTests`
+    /// asserts this label appears on Home after the editor save → pop →
+    /// reload chain.
+    public static let editorSeedScenarioName = "UITest Editor Reload Seed"
+
+    /// Inserts the Home-list seed scenario into the repository.
+    ///
+    /// Idempotent per `ScenarioRepository.save` semantics (full-row upsert).
+    /// Called from `setupUITestState()` before the `.ready` transition.
+    public static func seed(into repository: any ScenarioRepository) async throws {
+      let now = Date()
+      let record = ScenarioRecord(
+        id: homeSeedScenarioId,
+        name: homeSeedScenarioName,
+        yamlDefinition: homeSeedYAML,
+        isPreset: false,
+        createdAt: now,
+        updatedAt: now
+      )
+      try await offMain { try repository.save(record) }
+    }
+
+    // NOTE: YAML is indentation-sensitive; do not reflow these multi-line
+    // literals (the closing `"""` column is the baseline). swift-format
+    // preserves multi-line strings but editor refactors can break them —
+    // `StubScenarioSeederTests` catches any such regression quickly.
+
+    /// YAML backing the Home-list seed row. Minimal but valid — parses
+    /// through `ScenarioLoader`, satisfies `ScenarioValidator` (2 personas,
+    /// 1 phase, rounds ≤ 30), and passes `ScenarioContentValidator`
+    /// (English-only non-blocklisted text).
+    static let homeSeedYAML: String = """
+      id: ui_test_home_seed
+      name: UITest Home Seed
+      description: Seed scenario shown on the Home list under --ui-test.
+      agents: 2
+      rounds: 1
+      context: UI test seed scenario for navigation coverage.
+      personas:
+        - name: Alice
+          description: First seeded persona.
+        - name: Bob
+          description: Second seeded persona.
+      phases:
+        - type: speak_all
+          prompt: Say hello.
+          output:
+            statement: string
+      """
+
+    /// YAML pre-filled into the scenario editor when
+    /// `--ui-test-editor-seed-yaml` is present. Must round-trip through
+    /// `loadFromTemplate → save` (loader regenerates the id to a fresh UUID;
+    /// the name stays stable for assertion).
+    public static let editorSeedYAML: String = """
+      id: ui_test_editor_reload_seed
+      name: UITest Editor Reload Seed
+      description: Seed YAML pre-filled into the editor for #110.
+      agents: 2
+      rounds: 1
+      context: UI test seed scenario for editor save reload coverage.
+      personas:
+        - name: Carol
+          description: First editor-seed persona.
+        - name: Dave
+          description: Second editor-seed persona.
+      phases:
+        - type: speak_all
+          prompt: Say hello.
+          output:
+            statement: string
+      """
+  }
+
+#endif

--- a/Pastura/Pastura/PasturaApp.swift
+++ b/Pastura/Pastura/PasturaApp.swift
@@ -135,7 +135,14 @@ private struct RootView: View {
       do {
         let llm = MockLLMService(responses: [])
         let gallery = StubGalleryService.uiTestPreset()
-        let deps = try AppDependencies.inMemory(llmService: llm, galleryService: gallery)
+        let editorSeedYAML =
+          CommandLine.arguments.contains("--ui-test-editor-seed-yaml")
+          ? StubScenarioSeeder.editorSeedYAML : nil
+        let deps = try AppDependencies.inMemory(
+          llmService: llm,
+          galleryService: gallery,
+          uiTestEditorSeedYAML: editorSeedYAML
+        )
         try await StubScenarioSeeder.seed(into: deps.scenarioRepository)
         appState = .ready(deps)
       } catch {

--- a/Pastura/Pastura/PasturaApp.swift
+++ b/Pastura/Pastura/PasturaApp.swift
@@ -136,6 +136,7 @@ private struct RootView: View {
         let llm = MockLLMService(responses: [])
         let gallery = StubGalleryService.uiTestPreset()
         let deps = try AppDependencies.inMemory(llmService: llm, galleryService: gallery)
+        try await StubScenarioSeeder.seed(into: deps.scenarioRepository)
         appState = .ready(deps)
       } catch {
         appState = .error("UI test setup failed: \(error.localizedDescription)")

--- a/Pastura/Pastura/Views/Home/HomeView.swift
+++ b/Pastura/Pastura/Views/Home/HomeView.swift
@@ -29,7 +29,7 @@ struct HomeView: View {
         }
         ToolbarItem(placement: .primaryAction) {
           Menu {
-            NavigationLink(value: Route.editor()) {
+            NavigationLink(value: newScenarioRoute()) {
               Label("New Scenario", systemImage: "doc.badge.plus")
             }
             .accessibilityIdentifier("home.newScenarioButton")
@@ -194,6 +194,21 @@ struct HomeView: View {
       editingId: editingId,
       templateYAML: templateYAML
     )
+  }
+
+  /// Resolves the destination for the toolbar "New Scenario" menu item.
+  ///
+  /// Under `--ui-test-editor-seed-yaml`, `AppDependencies.uiTestEditorSeedYAML`
+  /// carries a pre-verified template so `EditorReloadTests` can exercise
+  /// the editor → save → Home reload path without typing YAML through
+  /// XCUITest. Production always returns the empty editor.
+  private func newScenarioRoute() -> Route {
+    #if DEBUG
+      if let seed = dependencies.uiTestEditorSeedYAML {
+        return .editor(templateYAML: seed)
+      }
+    #endif
+    return .editor()
   }
 }
 

--- a/Pastura/PasturaTests/App/StubScenarioSeederTests.swift
+++ b/Pastura/PasturaTests/App/StubScenarioSeederTests.swift
@@ -23,25 +23,27 @@
     @Test func testEditorSeedYAMLRoundTripsThroughLoadFromTemplateThenSave() async throws {
       let db = try DatabaseManager.inMemory()
       let repository = GRDBScenarioRepository(dbWriter: db.dbWriter)
-      let vm = ScenarioEditorViewModel(repository: repository)
+      let viewModel = ScenarioEditorViewModel(repository: repository)
 
-      vm.loadFromTemplate(yaml: StubScenarioSeeder.editorSeedYAML)
+      viewModel.loadFromTemplate(yaml: StubScenarioSeeder.editorSeedYAML)
 
       #expect(
-        vm.validationErrors.isEmpty,
-        "validationErrors after loadFromTemplate: \(vm.validationErrors)")
+        viewModel.validationErrors.isEmpty,
+        "validationErrors after loadFromTemplate: \(viewModel.validationErrors)")
 
-      let ok = await vm.save()
-      #expect(ok, "save() returned false; errors: \(vm.validationErrors)")
+      let didSave = await viewModel.save()
+      #expect(didSave, "save() returned false; errors: \(viewModel.validationErrors)")
 
       let savedId = try #require(
-        vm.savedScenarioId, "savedScenarioId should be non-nil after a successful save")
+        viewModel.savedScenarioId, "savedScenarioId should be non-nil after a successful save")
 
       let record = try repository.fetchById(savedId)
       let unwrapped = try #require(record, "fetchById(\(savedId)) returned nil")
       #expect(unwrapped.name == StubScenarioSeeder.editorSeedScenarioName)
 
-      #expect(vm.validationErrors.isEmpty, "validationErrors after save: \(vm.validationErrors)")
+      #expect(
+        viewModel.validationErrors.isEmpty,
+        "validationErrors after save: \(viewModel.validationErrors)")
     }
 
     // MARK: - home seed YAML

--- a/Pastura/PasturaTests/App/StubScenarioSeederTests.swift
+++ b/Pastura/PasturaTests/App/StubScenarioSeederTests.swift
@@ -1,0 +1,81 @@
+#if DEBUG
+
+  import Foundation
+  import Testing
+
+  @testable import Pastura
+
+  /// Unit tests for ``StubScenarioSeeder`` fixtures.
+  ///
+  /// Validates that `editorSeedYAML` and `homeSeedYAML` remain well-formed
+  /// across refactors. Running in-process (~100 ms) catches YAML indentation
+  /// drift or validator regressions long before the slow UI-test target would.
+  @Suite(.timeLimit(.minutes(1)))
+  @MainActor
+  struct StubScenarioSeederTests {
+
+    // MARK: - editor seed YAML
+
+    /// `editorSeedYAML` must load cleanly and save successfully through the
+    /// full `ScenarioEditorViewModel` pipeline — the same path the UI test
+    /// exercises end-to-end. Guards against fixture drift silently breaking the
+    /// UI test.
+    @Test func testEditorSeedYAMLRoundTripsThroughLoadFromTemplateThenSave() async throws {
+      let db = try DatabaseManager.inMemory()
+      let repository = GRDBScenarioRepository(dbWriter: db.dbWriter)
+      let vm = ScenarioEditorViewModel(repository: repository)
+
+      vm.loadFromTemplate(yaml: StubScenarioSeeder.editorSeedYAML)
+
+      #expect(
+        vm.validationErrors.isEmpty,
+        "validationErrors after loadFromTemplate: \(vm.validationErrors)")
+
+      let ok = await vm.save()
+      #expect(ok, "save() returned false; errors: \(vm.validationErrors)")
+
+      let savedId = try #require(
+        vm.savedScenarioId, "savedScenarioId should be non-nil after a successful save")
+
+      let record = try repository.fetchById(savedId)
+      let unwrapped = try #require(record, "fetchById(\(savedId)) returned nil")
+      #expect(unwrapped.name == StubScenarioSeeder.editorSeedScenarioName)
+
+      #expect(vm.validationErrors.isEmpty, "validationErrors after save: \(vm.validationErrors)")
+    }
+
+    // MARK: - home seed YAML
+
+    /// `homeSeedYAML` must be parseable and valid — mirrors what
+    /// `StubScenarioSeeder.seed(into:)` inserts, so the home-list row would
+    /// survive an editor round-trip if it ever needed to.
+    @Test func testHomeSeedYAMLParsesAndPassesValidation() throws {
+      let scenario = try ScenarioLoader().load(yaml: StubScenarioSeeder.homeSeedYAML)
+
+      _ = try ScenarioValidator().validate(scenario)
+
+      let contentFindings = ScenarioContentValidator().validate(scenario)
+      #expect(contentFindings.isEmpty, "Content validation findings: \(contentFindings)")
+    }
+
+    // MARK: - repository persistence
+
+    /// `seed(into:)` must persist the home-list row with the expected id and
+    /// name so UI tests can address the cell by stable accessibility identifier.
+    @Test func testSeededScenarioPersistsToRepository() async throws {
+      let db = try DatabaseManager.inMemory()
+      let repository = GRDBScenarioRepository(dbWriter: db.dbWriter)
+
+      try await StubScenarioSeeder.seed(into: repository)
+
+      let record = try repository.fetchById(StubScenarioSeeder.homeSeedScenarioId)
+      let unwrapped = try #require(
+        record,
+        "fetchById(\(StubScenarioSeeder.homeSeedScenarioId)) returned nil after seed"
+      )
+      #expect(unwrapped.name == StubScenarioSeeder.homeSeedScenarioName)
+      #expect(unwrapped.isPreset == false)
+    }
+  }
+
+#endif

--- a/Pastura/PasturaUITests/BackGestureTests.swift
+++ b/Pastura/PasturaUITests/BackGestureTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+
+/// Verifies that the interactive back gesture (edge-pan from left) pops exactly
+/// one level off the root NavigationStack — Home → ScenarioDetail → back to Home.
+/// We use a coordinate-based press-drag rather than `swipeRight()` because iOS 17+
+/// simulators do not reliably trigger the interactive-pop gesture with the latter.
+/// Regression: any accidental `navigationDestination(item:|isPresented:)` inside a
+/// pushed view can intercept the gesture and leave an orphaned entry on the stack.
+@MainActor
+final class BackGestureTests: XCTestCase {
+  override func setUpWithError() throws {
+    continueAfterFailure = false
+  }
+
+  override func tearDownWithError() throws {
+    // Explicitly terminate so the simulator releases the app process before
+    // the next test class launches a fresh one. Helps avoid "Failed to get
+    // background assertion" infrastructure errors on resource-tight CI
+    // simulators.
+    XCUIApplication().terminate()
+  }
+
+  func testBackGestureFromScenarioDetailReturnsToHome() throws {
+    let app = XCUIApplication()
+    app.launchArguments = ["--ui-test"]
+    app.launch()
+
+    // Wait for Home to finish initializing.
+    XCTAssertTrue(
+      app.navigationBars["Pastura"].waitForExistence(timeout: 10),
+      "Home did not appear within 10s.")
+
+    // Tap the seeded scenario cell to push ScenarioDetailView.
+    let scenarioCell = app.buttons["home.scenarioListCell.ui_test_home_seed"]
+    XCTAssertTrue(
+      scenarioCell.waitForExistence(timeout: 5),
+      "Seed scenario cell missing — StubScenarioSeeder fixture may be wrong.")
+    scenarioCell.tap()
+
+    // ScenarioDetailView uses List (renders as a collectionView in XCUI).
+    let detailList = app.collectionViews.firstMatch
+    XCTAssertTrue(
+      detailList.waitForExistence(timeout: 10),
+      "ScenarioDetailView did not appear after tapping the scenario cell.")
+
+    // Perform the interactive-pop edge-pan from the left edge.
+    // Coordinate-based drag is required — swipeRight() does not trigger
+    // UINavigationController's interactivePopGestureRecognizer on iOS 17+.
+    let start = app.coordinate(withNormalizedOffset: CGVector(dx: 0.0, dy: 0.5))
+    let end = app.coordinate(withNormalizedOffset: CGVector(dx: 0.8, dy: 0.5))
+    start.press(forDuration: 0.15, thenDragTo: end)
+
+    // Home nav bar must return — confirming we popped exactly one level.
+    XCTAssertTrue(
+      app.navigationBars["Pastura"].waitForExistence(timeout: 5),
+      "Home nav bar did not reappear after back gesture — interactive-pop regression suspected.")
+  }
+}

--- a/Pastura/PasturaUITests/EditorReloadTests.swift
+++ b/Pastura/PasturaUITests/EditorReloadTests.swift
@@ -1,0 +1,113 @@
+import XCTest
+
+/// Verifies the Editor → Save → auto-pop → Home reload path (#110).
+///
+/// Flow under test:
+///   1. Launch with `--ui-test` (seeds Home list) and `--ui-test-editor-seed-yaml`
+///      (makes "New Scenario" open the editor pre-filled with the seed YAML).
+///   2. Tap the "+" toolbar button to open the Add menu, then tap "New Scenario".
+///   3. The editor opens pre-filled via `Route.editor(templateYAML:)`. Tap Save.
+///   4. On successful save, the editor's `dismiss()` pops the root stack.
+///   5. `HomeView.onChange(of: router.path.count)` fires and reloads user scenarios.
+///   6. Assert the saved scenario's name appears on Home.
+///
+/// Why label-based assertion (not id-based):
+///   `ScenarioEditorViewModel.loadFromTemplate` regenerates the scenario id to a
+///   fresh UUID, so the `home.scenarioListCell.<id>` accessibility identifier is
+///   unknowable from the test side. The scenario *name* ("UITest Editor Reload Seed")
+///   is preserved verbatim by `loadFromTemplate`, so querying a `staticText` with
+///   that label is reliable and unambiguous.
+@MainActor
+final class EditorReloadTests: XCTestCase {
+  override func setUpWithError() throws {
+    continueAfterFailure = false
+  }
+
+  override func tearDownWithError() throws {
+    // Explicitly terminate so the simulator releases the app process before
+    // the next test class launches a fresh one. Helps avoid "Failed to get
+    // background assertion" infrastructure errors on resource-tight CI
+    // simulators.
+    XCUIApplication().terminate()
+  }
+
+  func testEditorSavePopsAndReloadsHome() throws {
+    let app = XCUIApplication()
+    app.launchArguments = ["--ui-test", "--ui-test-editor-seed-yaml"]
+    app.launch()
+
+    // Wait for Home to finish initializing.
+    XCTAssertTrue(
+      app.navigationBars["Pastura"].waitForExistence(timeout: 10),
+      "Home did not appear within 10s.")
+
+    // Sanity check: the editor-seed scenario name is NOT yet on Home (it hasn't
+    // been saved through the editor yet — only the home-seed row is present).
+    // Mirrors StubScenarioSeeder.editorSeedScenarioName
+    let editorSeedName = "UITest Editor Reload Seed"
+    XCTAssertFalse(
+      app.staticTexts[editorSeedName].exists,
+      "Editor seed scenario should not be on Home before editor save.")
+
+    // Open the Add menu via the "+" toolbar button.
+    let addButton = app.buttons["Add"]
+    XCTAssertTrue(addButton.waitForExistence(timeout: 5), "Add toolbar button missing.")
+    addButton.tap()
+
+    // Tap "New Scenario" from the menu.
+    // Use .firstMatch in case accessibility surfaces the NavigationLink label
+    // as both a button and a label element simultaneously.
+    let newScenarioItem = app.buttons["home.newScenarioButton"]
+    var menuTapAttempts = 0
+    while !newScenarioItem.exists && menuTapAttempts < 2 {
+      // Menu may not have fully expanded — re-tap the Add button and retry.
+      if menuTapAttempts > 0 {
+        addButton.tap()
+      }
+      menuTapAttempts += 1
+    }
+    XCTAssertTrue(
+      newScenarioItem.waitForExistence(timeout: 5),
+      "New Scenario menu item missing — menu may not have opened.")
+    newScenarioItem.tap()
+
+    // Wait for the editor to appear. The editor Form renders as a collectionView
+    // in XCUI. If the template YAML was pre-filled, the editor nav title matches
+    // editorSeedScenarioName; use that as the primary appearance check.
+    let editorNavBar = app.navigationBars[editorSeedName]
+    let editorForm = app.collectionViews.firstMatch
+    let editorAppeared =
+      editorNavBar.waitForExistence(timeout: 10) || editorForm.waitForExistence(timeout: 5)
+    XCTAssertTrue(editorAppeared, "Editor did not appear within 10s.")
+
+    // Sanity check: Save button exists (implying the editor loaded correctly).
+    let saveButton = app.buttons["editor.saveButton"]
+    XCTAssertTrue(
+      saveButton.waitForExistence(timeout: 5),
+      "editor.saveButton missing — editor may not have loaded the seed YAML.")
+
+    // Wait for the Save button to become enabled (guards against the brief
+    // `.disabled(viewModel.isSaving)` window during any async validation).
+    let enabledExpectation = XCTNSPredicateExpectation(
+      predicate: NSPredicate(format: "isEnabled == true"),
+      object: saveButton)
+    wait(for: [enabledExpectation], timeout: 10)
+    saveButton.tap()
+
+    // After a successful save, the editor calls `dismiss()`, which pops the root
+    // NavigationStack. `HomeView.onChange(of: router.path.count)` then fires
+    // and reloads user scenarios from the repository.
+    XCTAssertTrue(
+      app.navigationBars["Pastura"].waitForExistence(timeout: 10),
+      "Home nav bar did not reappear after editor save — dismiss/pop may have failed.")
+
+    // Assert the saved scenario appears on Home by label. The id was regenerated
+    // to a UUID by loadFromTemplate, so we cannot use the accessibility id.
+    // Mirrors StubScenarioSeeder.editorSeedScenarioName
+    let savedRow = app.staticTexts[editorSeedName]
+    XCTAssertTrue(
+      savedRow.waitForExistence(timeout: 10),
+      "'\(editorSeedName)' did not appear on Home after editor save — "
+        + "onChange(of: router.path.count) reload may not have fired.")
+  }
+}


### PR DESCRIPTION
## Summary

- `BackGestureTests` — exercises the interactive-pop gesture on the
  Home → ScenarioDetail route (#109 representative route). Uses an
  explicit coordinate-based left-edge `press(forDuration:thenDragTo:)`
  rather than `swipeRight()`, which does not reliably trigger
  `UINavigationController.interactivePopGestureRecognizer` on iOS 17+
  simulators.
- `EditorReloadTests` — exercises `HomeView.onChange(of: router.path.count)`
  via the Editor → Save → auto-pop → Home reload chain (#110). Asserts
  by scenario name, not accessibility id, because
  `ScenarioEditorViewModel.loadFromTemplate` regenerates the scenario
  id to a fresh UUID.
- `StubScenarioSeeder` — new `App/UITestSupport/` helper that seeds a
  known `ScenarioRecord` into the in-memory DB and exposes an editor
  seed YAML consumed via `--ui-test-editor-seed-yaml`. Wired into
  `setupUITestState()` and `HomeView`'s "New Scenario" menu through a
  DEBUG-gated `AppDependencies.uiTestEditorSeedYAML: String?` (avoids
  reading `CommandLine.arguments` directly from a view).
- `StubScenarioSeederTests` — unit tests that round-trip both fixtures
  through loader → validator → save so YAML drift is caught in ~100ms
  rather than by the slow UI-test target.
- `.claude/rules/navigation.md` — QA section rewritten so the lead
  sentences reflect current automation coverage (scenarios 1 and 3
  fully automated; scenario 2 automated for the primary route).

## Scope intentionally deferred

- Full swipe-back coverage of Editor / Import / Simulation / Results /
  GalleryScenarioDetail routes — remains under manual QA.
- CI job redesign — the current 25-min `ui-test` budget has headroom.

## Test plan

- [x] `PasturaTests` full suite — `** TEST SUCCEEDED **`
- [x] `PasturaUITests` full suite (3/3) — `** TEST SUCCEEDED **`
- [x] `swiftlint lint --strict` clean
- [x] code-reviewer agent — PASS (0 critical, 0 warning)
- [x] CI green on macos-26 runner

Closes #110
Addresses #109 — representative route only; full route coverage
remains manual per scope above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)