### PR TITLE
✨ feat: wire DemoReplayHostView into .needsModelDownload (C PR3 #169)

### DIFF
--- a/Pastura/Pastura/PasturaApp.swift
+++ b/Pastura/Pastura/PasturaApp.swift
@@ -123,7 +123,7 @@ private struct RootView: View {
           }
 
       case .needsModelDownload:
-        ModelDownloadView(modelManager: modelManager)
+        DemoReplayHostView(modelManager: modelManager)
           .onChange(of: modelManager.state) { _, newState in
             if case .ready(let modelPath) = newState {
               Task { await finalizeInit(modelPath: modelPath) }


### PR DESCRIPTION
## Summary

- Completes the 3-PR split of #169 (DL-time demo replay) by performing the 1-line `ModelDownloadView` → `DemoReplayHostView` swap in `PasturaApp.swift` per ADR-007 §5.1's explicit prescription.
- Outer `.onChange(of: modelManager.state)` → `finalizeInit(modelPath:)` wiring preserved verbatim; `DemoReplayHostView` owns the VM / overlay transition, `RootView` owns `AppState`. SwiftUI supports both observers firing on the same state mutation — they target disjoint state (VM vs AppState) with no ordering hazard.
- Pre-#170 (Resources/DemoReplays/ empty), `fallbackBranch` returns `.modelDownload` for every state so user-visible behavior is equivalent to the prior direct `ModelDownloadView` mount. Rotation + `DLCompleteOverlay` activate on-device once #170 populates the bundle.

## Test plan

Automated (green locally — full unit suite + `swiftlint --strict`):

- [x] `xcodebuild test -scheme Pastura -skip-testing:PasturaUITests` → `** TEST SUCCEEDED **`
- [x] `swiftlint lint --quiet --strict` → clean

Manual QA (device build required — simulator skips `.needsModelDownload`):

- [x] Cold-launch device with no downloaded model → plain `ModelDownloadView` appears (pre-#170 empty-bundle fallback equivalence).
- [ ] Trigger DL completion → `appState` transitions to `.ready(deps)` → `HomeView` mounts (`finalizeInit` path unchanged).
- [ ] Simulator build (`#if targetEnvironment(simulator)`) → `.needsModelDownload` skipped entirely; no regression.
- [x] BG/FG scene-phase transition during DL → no crash (`replayVM == nil` pre-#170 makes VM bridge a no-op).

## Known follow-ups (not addressed here — ADR-007 §5.1 binds this PR to exactly 1 line)

- **#191** — full cellular confirmation modal UX (ADR-007 §3.3 (c)). PR2 landed a conservative Option A safety net (`isCellular → .modelDownload`) so this PR is mergeable standalone.
- **#170** — populate `Resources/DemoReplays/*.yaml` + CI drift guard. Until this lands, the host view stays in `.modelDownload` fallback regardless of state.
- **Overlay visibility timing gap** — `DLCompleteOverlay` has a 2.4s fade-in (`DemoReplayHostView.swift:306`) but `finalizeInit` completes in ~200-500ms on a warm device. The overlay may be near-invisible before `RootView` dismounts the host view. ADR-007 §3.3 (d) implies a sequential "animated hand-off plays then finalizeInit runs" contract the current code doesn't enforce. Will file a separate follow-up issue with options: (a) `overlayMinDisplayMs` delay in outer `.onChange`, (b) shorten fade to ADR-007's stated 400-800ms band, (c) overlay lives above the AppState transition.

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)