### PR TITLE
✨ feat: cross-branch sub-phase move via context menu (#144)

### DIFF
--- a/.claude/rules/navigation.md
+++ b/.claude/rules/navigation.md
@@ -126,17 +126,52 @@ surface changes in areas the automated tests do not exercise.
    sees the view is no longer on top, and no spurious push to
    `ScenarioDetailView` occurs. (Backgrounding the app does **not** pop
    views, so it does not exercise this guard.)
-5. **Conditional phase — nested sub-phase editor** — In the scenario editor,
-   add a `conditional` phase, tap it to open `PhaseEditorSheet`, enter a
-   condition, tap **Add sub-phase** inside the Then branch. Expected: a
-   nested `PhaseEditorSheet` presents with the `conditional` option
-   *absent* from the type picker (depth-1 UI enforcement). Change the
-   sub-phase type, save, return to the outer editor. Save the outer
-   phase and confirm the top-level scenario list shows the condition
-   summary with `then:N else:M` counts. The nested sheet is sheet-owned,
-   so its own NavigationStack is fine — this QA just confirms that the
-   presentation chain (outer sheet → inner sheet) dismisses cleanly
-   without leaking `.conditional` into nested depths.
+5. **Conditional phase — nested sub-phase editor + cross-branch move** —
+   In the scenario editor, add a `conditional` phase, tap it to open
+   `PhaseEditorSheet`, enter a condition, tap **Add sub-phase** inside
+   the Then branch. Expected: a nested `PhaseEditorSheet` presents with
+   the `conditional` option *absent* from the type picker (depth-1 UI
+   enforcement). Change the sub-phase type, save, return to the outer
+   editor. Save the outer phase and confirm the top-level scenario list
+   shows the condition summary with `then:N else:M` counts. The nested
+   sheet is sheet-owned, so its own NavigationStack is fine — this QA
+   just confirms that the presentation chain (outer sheet → inner sheet)
+   dismisses cleanly without leaking `.conditional` into nested depths.
+
+   **Cross-branch move via context menu** — add 2 sub-phases each to
+   Then and Else (so both branches are non-empty). Verify all of:
+   - **Footer hint present** — each branch section shows
+     "Long-press a sub-phase to move it to the other branch." under
+     the last row, so the affordance is discoverable for users who
+     don't already know long-press opens context menus.
+   - **Context menu action** — long-press any sub-phase row. Expected:
+     a single "Move to Then Branch" (for rows in Else) or "Move to Else
+     Branch" (for rows in Then) menu item with the
+     `arrow.left.arrow.right` icon. Tap it.
+   - **Count invariants** — source branch shrinks by exactly one row,
+     target branch grows by exactly one row. The moved sub-phase
+     appears at the *end* of the target branch (tail-append by design;
+     within-branch reordering uses the drag handle / `.onMove`).
+   - **Round-trip persistence** — after moving, tap the moved row to
+     open the nested `PhaseEditorSheet`, edit any field, save. Expected:
+     the edit persists in the *new* branch, not the original one.
+     Then save the outer phase and reopen the scenario; confirm the
+     scenario-list summary shows the updated `then:N else:M` counts
+     and that reloading the scenario (including YAML round-trip if
+     toggling to YAML mode) preserves the branch membership.
+   - **Tap-to-edit still works** — tapping (not long-pressing) a
+     sub-phase row still opens the nested editor normally; the context
+     menu should not steal tap gestures.
+   - **Within-branch reorder still works** — the drag handle (if shown)
+     or explicit edit-mode reorder via `.onMove` still works; the
+     context menu should not interfere with long-press-to-drag for
+     `.onMove`.
+   - **Depth-2 nested sheets have no branches** — the nested
+     `PhaseEditorSheet` opened by editing a sub-phase does not contain
+     Then/Else sections (since `.conditional` is filtered from the
+     type picker), so the footer hint and context-menu "Move to Other
+     Branch" action do not appear at that depth. Confirm no spurious
+     context-menu items leak into the nested sheet.
 6. **Deep Link — cold start** — With Pastura fully terminated, tap a
    `pastura://scenario/<id>` link from Safari / Messages / another app.
    Expected: Pastura launches, waits for initialization + model-download

--- a/Pastura/Pastura/App/EditablePhase.swift
+++ b/Pastura/Pastura/App/EditablePhase.swift
@@ -77,6 +77,32 @@ struct EditablePhase: Identifiable, Sendable {
     self.elsePhases = phase.elsePhases?.map { EditablePhase(from: $0) } ?? []
   }
 
+  /// Identifies which branch of a conditional phase to target.
+  enum Branch: String, Sendable, CaseIterable {
+    case then
+    case `else`
+  }
+
+  /// Moves the sub-phase with the given `id` from whichever branch it
+  /// currently lives in to the end of `destination`. Always tail-appends
+  /// by design — within-branch position adjustment uses SwiftUI's
+  /// `.onMove` in the editor. No-op when:
+  /// - the id isn't found in either branch (e.g., deep nested sub-phase)
+  /// - the id is already in `destination` (source == destination)
+  mutating func moveSubPhase(id sourceId: UUID, to destination: Branch) {
+    // Shallow scan only — depth-1 is enforced at the editor layer.
+    if let index = thenPhases.firstIndex(where: { $0.id == sourceId }) {
+      guard destination == .else else { return }
+      let moved = thenPhases.remove(at: index)
+      elsePhases.append(moved)
+    } else if let index = elsePhases.firstIndex(where: { $0.id == sourceId }) {
+      guard destination == .then else { return }
+      let moved = elsePhases.remove(at: index)
+      thenPhases.append(moved)
+    }
+    // If not found in either branch, no-op.
+  }
+
   func toPhase() -> Phase {
     let trimmedTarget = target.trimmingCharacters(in: .whitespacesAndNewlines)
     let trimmedCondition = condition.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Pastura/Pastura/App/EditablePhase.swift
+++ b/Pastura/Pastura/App/EditablePhase.swift
@@ -88,7 +88,8 @@ struct EditablePhase: Identifiable, Sendable {
   /// by design — within-branch position adjustment uses SwiftUI's
   /// `.onMove` in the editor. No-op when:
   /// - the id isn't found in either branch (e.g., deep nested sub-phase)
-  /// - the id is already in `destination` (source == destination)
+  /// - the id is already in `destination` (moving to the branch it
+  ///   currently lives in)
   mutating func moveSubPhase(id sourceId: UUID, to destination: Branch) {
     // Shallow scan only — depth-1 is enforced at the editor layer.
     if let index = thenPhases.firstIndex(where: { $0.id == sourceId }) {

--- a/Pastura/Pastura/Views/Editor/PhaseEditorSheet+ConditionalSection.swift
+++ b/Pastura/Pastura/Views/Editor/PhaseEditorSheet+ConditionalSection.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+
+// Conditional-phase UI for `PhaseEditorSheet`: the condition field plus
+// the Then / Else branch sections with their `.contextMenu`-based
+// cross-branch move action.
+//
+// Split out from `PhaseEditorSheet.swift` to keep that file under
+// SwiftLint's `file_length` limit. Accesses `phase` and
+// `editingSubPhase` from the parent struct — both intentionally
+// internal so this extension can drive nested-sheet presentation.
+
+extension PhaseEditorSheet {
+  var conditionalSection: some View {
+    Group {
+      Section {
+        TextField(
+          "e.g. max_score >= 10",
+          text: $phase.condition,
+          axis: .vertical
+        )
+        .font(.body.monospaced())
+        .textInputAutocapitalization(.never)
+        .autocorrectionDisabled()
+      } header: {
+        Text("Condition")
+      } footer: {
+        Text(
+          "Single comparison: lhs OP rhs where OP is one of ==, !=, <, <=, >, >=. "
+            + "Identifiers: current_round, total_rounds, max_score, min_score, "
+            + "eliminated_count, active_count, vote_winner, scores.<Name>, "
+            + "or any template variable. Wrap string literals in double quotes."
+        )
+        .font(.caption)
+      }
+
+      branchSection(
+        title: "Then branch (condition true)",
+        phases: $phase.thenPhases,
+        branch: .then
+      )
+      branchSection(
+        title: "Else branch (condition false)",
+        phases: $phase.elsePhases,
+        branch: .else
+      )
+    }
+  }
+
+  @ViewBuilder
+  fileprivate func branchSection(
+    title: String,
+    phases: Binding<[EditablePhase]>,
+    branch: EditablePhase.Branch
+  ) -> some View {
+    Section {
+      ForEach(phases.wrappedValue) { subPhase in
+        Button {
+          editingSubPhase = SubPhaseEditContext(branch: branch, phase: subPhase)
+        } label: {
+          HStack {
+            Text(subPhase.type.rawValue)
+              .font(.body.monospaced())
+              .foregroundStyle(.primary)
+            Spacer()
+            Image(systemName: "chevron.right")
+              .foregroundStyle(.secondary)
+              .font(.caption)
+          }
+        }
+        .contextMenu {
+          Button {
+            phase.moveSubPhase(id: subPhase.id, to: branch == .then ? .else : .then)
+          } label: {
+            Label(
+              branch == .then ? "Move to Else Branch" : "Move to Then Branch",
+              systemImage: "arrow.left.arrow.right"
+            )
+          }
+        }
+      }
+      .onDelete { indexSet in
+        phases.wrappedValue.remove(atOffsets: indexSet)
+      }
+      .onMove { source, destination in
+        // Within-branch reorder via .onMove. Cross-branch move is exposed
+        // via the .contextMenu on each row.
+        phases.wrappedValue.move(fromOffsets: source, toOffset: destination)
+      }
+
+      Button {
+        let newPhase = EditablePhase()
+        phases.wrappedValue.append(newPhase)
+        editingSubPhase = SubPhaseEditContext(branch: branch, phase: newPhase)
+      } label: {
+        Label("Add sub-phase", systemImage: "plus.circle")
+      }
+    } header: {
+      Text(title)
+    } footer: {
+      Text("Long-press a sub-phase to move it to the other branch.")
+        .font(.caption)
+    }
+  }
+}

--- a/Pastura/Pastura/Views/Editor/PhaseEditorSheet+ConditionalSection.swift
+++ b/Pastura/Pastura/Views/Editor/PhaseEditorSheet+ConditionalSection.swift
@@ -46,6 +46,9 @@ extension PhaseEditorSheet {
     }
   }
 
+  // `branchSection` is `fileprivate` so it must stay co-located with its
+  // sole caller (`conditionalSection`). If either is moved back to the
+  // main file, both must move together.
   @ViewBuilder
   fileprivate func branchSection(
     title: String,
@@ -97,7 +100,7 @@ extension PhaseEditorSheet {
     } header: {
       Text(title)
     } footer: {
-      Text("Long-press a sub-phase to move it to the other branch.")
+      Text("Long-press a sub-phase to move it to the end of the other branch.")
         .font(.caption)
     }
   }

--- a/Pastura/Pastura/Views/Editor/PhaseEditorSheet.swift
+++ b/Pastura/Pastura/Views/Editor/PhaseEditorSheet.swift
@@ -1,16 +1,11 @@
 import SwiftUI
 
-/// Which branch of a conditional phase a nested sub-phase editor is editing.
-/// Lifted to file scope to satisfy SwiftLint's nesting rule (types nested
-/// deeper than 1 level are disallowed).
-private enum ConditionalBranch { case then, `else` }
-
 /// Identifies which branch's sub-phase is currently being edited via a
 /// nested `PhaseEditorSheet`. `.sheet(item:)` drives the presentation;
 /// `onSave` on the nested sheet writes back to the right branch.
 private struct SubPhaseEditContext: Identifiable {
   let id = UUID()
-  let branch: ConditionalBranch
+  let branch: EditablePhase.Branch
   var phase: EditablePhase
 }
 
@@ -222,9 +217,9 @@ struct PhaseEditorSheet: View {
   private func branchSection(
     title: String,
     phases: Binding<[EditablePhase]>,
-    branch: ConditionalBranch
+    branch: EditablePhase.Branch
   ) -> some View {
-    Section(title) {
+    Section {
       ForEach(phases.wrappedValue) { subPhase in
         Button {
           editingSubPhase = SubPhaseEditContext(branch: branch, phase: subPhase)
@@ -239,13 +234,24 @@ struct PhaseEditorSheet: View {
               .font(.caption)
           }
         }
+        .contextMenu {
+          Button {
+            let other: EditablePhase.Branch = (branch == .then ? .else : .then)
+            phase.moveSubPhase(id: subPhase.id, to: other)
+          } label: {
+            Label(
+              branch == .then ? "Move to Else Branch" : "Move to Then Branch",
+              systemImage: "arrow.left.arrow.right"
+            )
+          }
+        }
       }
       .onDelete { indexSet in
         phases.wrappedValue.remove(atOffsets: indexSet)
       }
       .onMove { source, destination in
-        // Within-branch reorder only — cross-branch drag is deliberately
-        // unsupported in v1 (tracked as a follow-up).
+        // Within-branch reorder via .onMove. Cross-branch move is exposed
+        // via the .contextMenu on each row.
         phases.wrappedValue.move(fromOffsets: source, toOffset: destination)
       }
 
@@ -256,6 +262,11 @@ struct PhaseEditorSheet: View {
       } label: {
         Label("Add sub-phase", systemImage: "plus.circle")
       }
+    } header: {
+      Text(title)
+    } footer: {
+      Text("Long-press a sub-phase to move it to the other branch.")
+        .font(.caption)
     }
   }
 

--- a/Pastura/Pastura/Views/Editor/PhaseEditorSheet.swift
+++ b/Pastura/Pastura/Views/Editor/PhaseEditorSheet.swift
@@ -3,7 +3,11 @@ import SwiftUI
 /// Identifies which branch's sub-phase is currently being edited via a
 /// nested `PhaseEditorSheet`. `.sheet(item:)` drives the presentation;
 /// `onSave` on the nested sheet writes back to the right branch.
-private struct SubPhaseEditContext: Identifiable {
+///
+/// Module-internal (rather than file-private) because the conditional-
+/// section UI lives in a sibling extension file and needs to construct
+/// these contexts.
+struct SubPhaseEditContext: Identifiable {
   let id = UUID()
   let branch: EditablePhase.Branch
   var phase: EditablePhase
@@ -29,7 +33,9 @@ struct PhaseEditorSheet: View {
 
   @State private var newOutputFieldName: String = ""
   @State private var newOptionText: String = ""
-  @State private var editingSubPhase: SubPhaseEditContext?
+  // Internal (not private) so the sibling conditional-section extension
+  // can present the nested editor from the "Add sub-phase" button.
+  @State var editingSubPhase: SubPhaseEditContext?
 
   var body: some View {
     NavigationStack {
@@ -177,98 +183,9 @@ struct PhaseEditorSheet: View {
     }
   }
 
-  private var conditionalSection: some View {
-    Group {
-      Section {
-        TextField(
-          "e.g. max_score >= 10",
-          text: $phase.condition,
-          axis: .vertical
-        )
-        .font(.body.monospaced())
-        .textInputAutocapitalization(.never)
-        .autocorrectionDisabled()
-      } header: {
-        Text("Condition")
-      } footer: {
-        Text(
-          "Single comparison: lhs OP rhs where OP is one of ==, !=, <, <=, >, >=. "
-            + "Identifiers: current_round, total_rounds, max_score, min_score, "
-            + "eliminated_count, active_count, vote_winner, scores.<Name>, "
-            + "or any template variable. Wrap string literals in double quotes."
-        )
-        .font(.caption)
-      }
-
-      branchSection(
-        title: "Then branch (condition true)",
-        phases: $phase.thenPhases,
-        branch: .then
-      )
-      branchSection(
-        title: "Else branch (condition false)",
-        phases: $phase.elsePhases,
-        branch: .else
-      )
-    }
-  }
-
-  @ViewBuilder
-  private func branchSection(
-    title: String,
-    phases: Binding<[EditablePhase]>,
-    branch: EditablePhase.Branch
-  ) -> some View {
-    Section {
-      ForEach(phases.wrappedValue) { subPhase in
-        Button {
-          editingSubPhase = SubPhaseEditContext(branch: branch, phase: subPhase)
-        } label: {
-          HStack {
-            Text(subPhase.type.rawValue)
-              .font(.body.monospaced())
-              .foregroundStyle(.primary)
-            Spacer()
-            Image(systemName: "chevron.right")
-              .foregroundStyle(.secondary)
-              .font(.caption)
-          }
-        }
-        .contextMenu {
-          Button {
-            let other: EditablePhase.Branch = (branch == .then ? .else : .then)
-            phase.moveSubPhase(id: subPhase.id, to: other)
-          } label: {
-            Label(
-              branch == .then ? "Move to Else Branch" : "Move to Then Branch",
-              systemImage: "arrow.left.arrow.right"
-            )
-          }
-        }
-      }
-      .onDelete { indexSet in
-        phases.wrappedValue.remove(atOffsets: indexSet)
-      }
-      .onMove { source, destination in
-        // Within-branch reorder via .onMove. Cross-branch move is exposed
-        // via the .contextMenu on each row.
-        phases.wrappedValue.move(fromOffsets: source, toOffset: destination)
-      }
-
-      Button {
-        let newPhase = EditablePhase()
-        phases.wrappedValue.append(newPhase)
-        editingSubPhase = SubPhaseEditContext(branch: branch, phase: newPhase)
-      } label: {
-        Label("Add sub-phase", systemImage: "plus.circle")
-      }
-    } header: {
-      Text(title)
-    } footer: {
-      Text("Long-press a sub-phase to move it to the other branch.")
-        .font(.caption)
-    }
-  }
+  // `conditionalSection` and its `branchSection` helper live in
+  // `PhaseEditorSheet+ConditionalSection.swift` (sibling extension file)
+  // to keep this file under SwiftLint's `file_length` limit.
 
   // MARK: - Type-Specific Sections
 

--- a/Pastura/PasturaTests/App/EditablePhaseSubPhaseMoveTests.swift
+++ b/Pastura/PasturaTests/App/EditablePhaseSubPhaseMoveTests.swift
@@ -57,9 +57,9 @@ struct EditablePhaseSubPhaseMoveTests {
     #expect(sut.elsePhases.map(\.id) == [phaseD.id, phaseF.id])
   }
 
-  // MARK: - Same-branch no-op
+  // MARK: - Same-branch no-op (then → then)
 
-  @Test func moveSubPhaseToSameBranchIsNoOp() {
+  @Test func moveSubPhaseToSameBranchIsNoOpThen() {
     let phaseA = makeSpeakPhase()
     let phaseB = makeSpeakPhase()
     let phaseC = makeSpeakPhase()
@@ -73,6 +73,27 @@ struct EditablePhaseSubPhaseMoveTests {
     let beforeElse = sut.elsePhases.map(\.id)
 
     sut.moveSubPhase(id: phaseB.id, to: .then)
+
+    #expect(sut.thenPhases.map(\.id) == beforeThen)
+    #expect(sut.elsePhases.map(\.id) == beforeElse)
+  }
+
+  // MARK: - Same-branch no-op (else → else)
+
+  @Test func moveSubPhaseToSameBranchIsNoOpElse() {
+    let phaseA = makeSpeakPhase()
+    let phaseB = makeSpeakPhase()
+    let phaseC = makeSpeakPhase()
+
+    var sut = makeConditionalPhase(
+      thenPhases: [],
+      elsePhases: [phaseA, phaseB, phaseC]
+    )
+
+    let beforeThen = sut.thenPhases.map(\.id)
+    let beforeElse = sut.elsePhases.map(\.id)
+
+    sut.moveSubPhase(id: phaseB.id, to: .else)
 
     #expect(sut.thenPhases.map(\.id) == beforeThen)
     #expect(sut.elsePhases.map(\.id) == beforeElse)

--- a/Pastura/PasturaTests/App/EditablePhaseSubPhaseMoveTests.swift
+++ b/Pastura/PasturaTests/App/EditablePhaseSubPhaseMoveTests.swift
@@ -1,0 +1,165 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+@Suite(.timeLimit(.minutes(1)))
+@MainActor
+struct EditablePhaseSubPhaseMoveTests {
+  // MARK: - Helpers
+
+  private func makeConditionalPhase(
+    thenPhases: [EditablePhase] = [],
+    elsePhases: [EditablePhase] = []
+  ) -> EditablePhase {
+    EditablePhase(type: .conditional, thenPhases: thenPhases, elsePhases: elsePhases)
+  }
+
+  private func makeSpeakPhase() -> EditablePhase {
+    EditablePhase(type: .speakAll)
+  }
+
+  // MARK: - then → else
+
+  @Test func moveSubPhaseFromThenToElse() {
+    let phaseA = makeSpeakPhase()
+    let phaseB = makeSpeakPhase()
+    let phaseC = makeSpeakPhase()
+    let phaseD = makeSpeakPhase()
+
+    var sut = makeConditionalPhase(
+      thenPhases: [phaseA, phaseB, phaseC],
+      elsePhases: [phaseD]
+    )
+
+    sut.moveSubPhase(id: phaseB.id, to: .else)
+
+    #expect(sut.thenPhases.map(\.id) == [phaseA.id, phaseC.id])
+    #expect(sut.elsePhases.map(\.id) == [phaseD.id, phaseB.id])
+  }
+
+  // MARK: - else → then
+
+  @Test func moveSubPhaseFromElseToThen() {
+    let phaseA = makeSpeakPhase()
+    let phaseD = makeSpeakPhase()
+    let phaseE = makeSpeakPhase()
+    let phaseF = makeSpeakPhase()
+
+    var sut = makeConditionalPhase(
+      thenPhases: [phaseA],
+      elsePhases: [phaseD, phaseE, phaseF]
+    )
+
+    sut.moveSubPhase(id: phaseE.id, to: .then)
+
+    #expect(sut.thenPhases.map(\.id) == [phaseA.id, phaseE.id])
+    #expect(sut.elsePhases.map(\.id) == [phaseD.id, phaseF.id])
+  }
+
+  // MARK: - Same-branch no-op
+
+  @Test func moveSubPhaseToSameBranchIsNoOp() {
+    let phaseA = makeSpeakPhase()
+    let phaseB = makeSpeakPhase()
+    let phaseC = makeSpeakPhase()
+
+    var sut = makeConditionalPhase(
+      thenPhases: [phaseA, phaseB, phaseC],
+      elsePhases: []
+    )
+
+    let beforeThen = sut.thenPhases.map(\.id)
+    let beforeElse = sut.elsePhases.map(\.id)
+
+    sut.moveSubPhase(id: phaseB.id, to: .then)
+
+    #expect(sut.thenPhases.map(\.id) == beforeThen)
+    #expect(sut.elsePhases.map(\.id) == beforeElse)
+  }
+
+  // MARK: - Unknown UUID no-op
+
+  @Test func moveSubPhaseWithUnknownIdIsNoOp() {
+    let phaseA = makeSpeakPhase()
+    let phaseB = makeSpeakPhase()
+    let phaseC = makeSpeakPhase()
+
+    var sut = makeConditionalPhase(
+      thenPhases: [phaseA, phaseB, phaseC],
+      elsePhases: []
+    )
+
+    let beforeThen = sut.thenPhases.map(\.id)
+    let beforeElse = sut.elsePhases.map(\.id)
+
+    sut.moveSubPhase(id: UUID(), to: .else)
+
+    #expect(sut.thenPhases.map(\.id) == beforeThen)
+    #expect(sut.elsePhases.map(\.id) == beforeElse)
+  }
+
+  // MARK: - Count invariants
+
+  @Test func moveSubPhaseUpdatesCountsCorrectly() {
+    let phases = (0..<3).map { _ in makeSpeakPhase() }
+    let elsePhases = (0..<2).map { _ in makeSpeakPhase() }
+
+    var sut = makeConditionalPhase(
+      thenPhases: phases,
+      elsePhases: elsePhases
+    )
+
+    let initialThenCount = sut.thenPhases.count  // 3
+    let initialElseCount = sut.elsePhases.count  // 2
+
+    sut.moveSubPhase(id: phases[0].id, to: .else)
+
+    #expect(sut.thenPhases.count == initialThenCount - 1)
+    #expect(sut.elsePhases.count == initialElseCount + 1)
+  }
+
+  // MARK: - ID preservation
+
+  @Test func moveSubPhasePreservesId() {
+    let phaseA = makeSpeakPhase()
+    let phaseB = makeSpeakPhase()
+
+    var sut = makeConditionalPhase(
+      thenPhases: [phaseA, phaseB],
+      elsePhases: []
+    )
+
+    let originalId = phaseB.id
+
+    sut.moveSubPhase(id: phaseB.id, to: .else)
+
+    #expect(sut.elsePhases.last?.id == originalId)
+  }
+
+  // MARK: - Deep sub-phase no-op
+
+  @Test func moveDeepSubPhaseIsNoOpAtTopLevel() {
+    let deepPhase = makeSpeakPhase()
+    let innerConditional = makeConditionalPhase(
+      thenPhases: [deepPhase],
+      elsePhases: []
+    )
+
+    var sut = makeConditionalPhase(
+      thenPhases: [innerConditional],
+      elsePhases: []
+    )
+
+    let beforeThen = sut.thenPhases.map(\.id)
+    let beforeElse = sut.elsePhases.map(\.id)
+
+    // Deep phase id should NOT be moveable via top-level moveSubPhase
+    sut.moveSubPhase(id: deepPhase.id, to: .else)
+
+    #expect(sut.thenPhases.map(\.id) == beforeThen)
+    #expect(sut.elsePhases.map(\.id) == beforeElse)
+    // The deep phase must still exist in thenPhases[0].thenPhases
+    #expect(sut.thenPhases.first?.thenPhases.first?.id == deepPhase.id)
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a long-press **"Move to Other Branch"** context-menu action on each sub-phase row in a conditional phase's Then / Else branches. Tail-appends to the destination branch — within-branch position adjustment still uses `.onMove`.
- Pivoted from PR #195's drag-based approach after discovering:
  1. SwiftUI `.dropDestination(isTargeted:)` is silently broken inside `Form`/`List` rows on iOS 17–26 ([FB12980427](https://developer.apple.com/forums/thread/730367)); and
  2. Apple's own guidance for cross-collection moves is context menu, not drag ([Apple Developer Forums thread/674393](https://developer.apple.com/forums/thread/674393)).
  See issue #144 comments for the full pivot rationale.
- Preserves all existing editor polish: `.onMove` for within-branch reorder (Apple's insertion line + autoscroll + rotor a11y), `.onDelete` for swipe-to-delete, tap to open nested editor. No drag machinery added.

## Key design
- **Pure move helper**: `EditablePhase.moveSubPhase(id:to:)` does a shallow scan of `thenPhases` / `elsePhases` and tail-appends to the destination. No-op on unknown id, same-branch target, or deep-nested id. 8 unit tests cover the contract (including id preservation and depth-2 defense).
- **Discoverability**: each branch section gets a footer "Long-press a sub-phase to move it to the end of the other branch." so users who aren't already fluent with iOS long-press menus see the affordance.
- **File-size hygiene**: `conditionalSection` + `branchSection` moved to a sibling extension file (`PhaseEditorSheet+ConditionalSection.swift`) so the main file stays under SwiftLint's `file_length` warning. Requires widening `SubPhaseEditContext` and `editingSubPhase` from file-private to module-internal (rationale documented inline).

## Test plan
- [x] 8 unit tests on `EditablePhase.moveSubPhase(id:to:)` — then↔else, same-branch no-ops (both branches), unknown UUID no-op, count invariants, id preservation, deep sub-phase no-op
- [x] `swiftlint --strict` clean
- [x] Full test suite `** TEST SUCCEEDED **` (parallel-disabled to work around an unrelated Clone 1 simulator flake; behavior on CI is unaffected)
- [ ] **Manual simulator QA (pending before merge)** — per updated `.claude/rules/navigation.md` QA #5:
  - [ ] Footer hint visible on both Then and Else branch sections
  - [ ] Long-press reveals "Move to Then/Else Branch" context-menu action (label switches by branch, `arrow.left.arrow.right` icon)
  - [ ] Selecting the action: source branch count −1, target branch count +1, moved row appears at end of target branch
  - [ ] Tap moved phase → nested editor → edit → save → verify edit persists in the *new* branch (not the original)
  - [ ] Save outer phase → reopen scenario → YAML round-trip preserves branch membership
  - [ ] Tap-to-edit and `.onMove` (drag handle) still work alongside context menu
  - [ ] Depth-2 nested editor has no Then/Else branches (no spurious context-menu item)

## Follow-ups (reviewer suggestions)
- None flagged as blocker. Reviewer's "consider extracting a shared generic row helper" only becomes relevant if a third similar drag/move surface appears.

Closes #144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)