### PR TITLE
✨ feat: Multi-model support plumbing (PR A, #203)

### DIFF
--- a/Pastura/Pastura/App/ModelManager.swift
+++ b/Pastura/Pastura/App/ModelManager.swift
@@ -366,32 +366,9 @@ final class ModelManager {
         }
       )
 
-      // Force a terminal 100% transition before SHA256 verification.
-      // Production URLSession does not guarantee a final `didWriteData` call
-      // at `received == total`, and even if it did, it could be throttled out
-      // above. Without this, the UI stalls at ~99% during the ~2 s SHA256 hash
-      // on a 3 GB file.
-      state[descriptor.id] = .downloading(progress: 1.0)
-
-      if let error = await verifyDownloadIntegrity(descriptor: descriptor) {
-        try? fileManager.removeItem(at: partialURL)
-        state[descriptor.id] = .error(error)
-        return
-      }
-
-      // Ensure Application Support directory exists before moving the file.
-      let modelDir = modelURL.deletingLastPathComponent()
-      try fileManager.createDirectory(at: modelDir, withIntermediateDirectories: true)
-
-      // Atomic rename from Caches/.download to Application Support/ final path.
-      // Same volume on iOS, so this is an atomic rename (no copy+delete).
-      if fileManager.fileExists(atPath: modelURL.path) {
-        try fileManager.removeItem(at: modelURL)
-      }
-      try fileManager.moveItem(at: partialURL, to: modelURL)
-
-      excludeFromBackup(modelURL)
-      state[descriptor.id] = .ready(modelPath: modelURL.path)
+      try await finalizeDownload(
+        descriptor: descriptor, modelURL: modelURL, partialURL: partialURL
+      )
     } catch is CancellationError {
       // Download was cancelled — keep partial file for resume
       state[descriptor.id] = .notDownloaded
@@ -399,6 +376,41 @@ final class ModelManager {
       // Keep partial .download file for resume
       state[descriptor.id] = .error(error.localizedDescription)
     }
+  }
+
+  /// Post-download finalization: force terminal 100%, verify integrity,
+  /// atomically rename the partial into Application Support, and mark the
+  /// descriptor `.ready`. Extracted from `performDownload` to keep that
+  /// function under swiftlint's function_body_length cap.
+  private func finalizeDownload(
+    descriptor: ModelDescriptor, modelURL: URL, partialURL: URL
+  ) async throws {
+    // Force a terminal 100% transition before SHA256 verification.
+    // Production URLSession does not guarantee a final `didWriteData` call
+    // at `received == total`, and even if it did, it could be throttled out
+    // above. Without this, the UI stalls at ~99% during the ~2 s SHA256 hash
+    // on a 3 GB file.
+    state[descriptor.id] = .downloading(progress: 1.0)
+
+    if let error = await verifyDownloadIntegrity(descriptor: descriptor) {
+      try? fileManager.removeItem(at: partialURL)
+      state[descriptor.id] = .error(error)
+      return
+    }
+
+    // Ensure Application Support directory exists before moving the file.
+    let modelDir = modelURL.deletingLastPathComponent()
+    try fileManager.createDirectory(at: modelDir, withIntermediateDirectories: true)
+
+    // Atomic rename from Caches/.download to Application Support/ final path.
+    // Same volume on iOS, so this is an atomic rename (no copy+delete).
+    if fileManager.fileExists(atPath: modelURL.path) {
+      try fileManager.removeItem(at: modelURL)
+    }
+    try fileManager.moveItem(at: partialURL, to: modelURL)
+
+    excludeFromBackup(modelURL)
+    state[descriptor.id] = .ready(modelPath: modelURL.path)
   }
 
   // MARK: - Private: Integrity

--- a/Pastura/Pastura/App/ModelManager.swift
+++ b/Pastura/Pastura/App/ModelManager.swift
@@ -6,7 +6,7 @@
 // widening `private` fields (`state`, `downloader`, `fileManager`,
 // `downloadTasks`) to `internal`, which weakens the class's state
 // encapsulation for a mechanical line-count win. Prefer the focused,
-// self-contained file. See LlamaCppService.swift for the same pattern.
+// self-contained class. See LlamaCppService.swift for the same pattern.
 import CryptoKit
 import Foundation
 import os
@@ -256,11 +256,17 @@ final class ModelManager {
   }
 
   /// Cancels an in-progress download for `descriptor`. The partial file is
-  /// kept for resume. No-op if no download is in flight for this descriptor.
+  /// kept for resume. No-op if no download is in flight for this descriptor
+  /// — specifically, the state transition to `.notDownloaded` only fires
+  /// when the current state is `.downloading`; `.ready` / `.error` /
+  /// `.notDownloaded` are preserved so a stray call from the UI cannot
+  /// silently flip a completed model to `.notDownloaded`.
   func cancelDownload(descriptor: ModelDescriptor) {
     downloadTasks[descriptor.id]?.cancel()
     downloadTasks[descriptor.id] = nil
-    state[descriptor.id] = .notDownloaded
+    if case .downloading = state[descriptor.id] {
+      state[descriptor.id] = .notDownloaded
+    }
   }
 
   /// Removes both the completed model file and any partial download for
@@ -271,22 +277,6 @@ final class ModelManager {
     try? fileManager.removeItem(at: modelFileURL(for: descriptor))
     try? fileManager.removeItem(at: downloadFileURL(for: descriptor))
     state[descriptor.id] = .notDownloaded
-  }
-
-  // MARK: - Convenience (active-model wrappers)
-
-  /// Starts the download for the currently-active model. No-op if no active
-  /// descriptor is resolvable (empty catalog). Preserves the old single-model
-  /// `startDownload()` call-site ergonomics.
-  func startActiveDownload() {
-    guard let descriptor = activeDescriptor else { return }
-    startDownload(descriptor: descriptor)
-  }
-
-  /// Cancels the download for the currently-active model, if any.
-  func cancelActiveDownload() {
-    guard let descriptor = activeDescriptor else { return }
-    cancelDownload(descriptor: descriptor)
   }
 
   // MARK: - Private: State Computation
@@ -478,5 +468,27 @@ final class ModelManager {
 
     let digest = hasher.finalize()
     return digest.map { String(format: "%02x", $0) }.joined()
+  }
+}
+
+// MARK: - Convenience (active-model wrappers)
+//
+// Lives in an extension so the primary class body stays under swiftlint's
+// type_body_length cap. Callers can still invoke `modelManager.startActiveDownload()`
+// / `cancelActiveDownload()` as if they were declared on the class itself.
+
+extension ModelManager {
+  /// Starts the download for the currently-active model. No-op if no active
+  /// descriptor is resolvable (empty catalog). Preserves the old single-model
+  /// `startDownload()` call-site ergonomics.
+  func startActiveDownload() {
+    guard let descriptor = activeDescriptor else { return }
+    startDownload(descriptor: descriptor)
+  }
+
+  /// Cancels the download for the currently-active model, if any.
+  func cancelActiveDownload() {
+    guard let descriptor = activeDescriptor else { return }
+    cancelDownload(descriptor: descriptor)
   }
 }

--- a/Pastura/Pastura/App/ModelManager.swift
+++ b/Pastura/Pastura/App/ModelManager.swift
@@ -1,12 +1,21 @@
+// swiftlint:disable file_length
+// Deliberately long: ModelManager owns the per-descriptor state machine,
+// download pipeline (with throttled progress), integrity verification
+// (fileSize + streaming SHA256), and filesystem layout (Application Support
+// / Caches conventions). Splitting these into separate files would require
+// widening `private` fields (`state`, `downloader`, `fileManager`,
+// `downloadTasks`) to `internal`, which weakens the class's state
+// encapsulation for a mechanical line-count win. Prefer the focused,
+// self-contained file. See LlamaCppService.swift for the same pattern.
 import CryptoKit
 import Foundation
 import os
 
-/// State of the on-device LLM model.
+/// State of a single on-device LLM model.
 public enum ModelState: Equatable, Sendable {
   /// Checking device compatibility and model file status.
   case checking
-  /// Device does not meet minimum RAM requirement (8 GB).
+  /// Device does not meet minimum RAM requirement (shared 6.5 GB floor in Phase 2).
   case unsupportedDevice
   /// Model is not downloaded. If a partial `.download` file exists, resume is possible.
   case notDownloaded
@@ -18,78 +27,122 @@ public enum ModelState: Equatable, Sendable {
   case error(String)
 }
 
-/// Manages the on-device LLM model lifecycle: device check, download, storage, and deletion.
+/// Manages on-device LLM model lifecycle: device check, download, storage, deletion.
 ///
-/// Lives in the App layer because it depends on HTTP (URLSession), filesystem (FileManager),
-/// and device capabilities (ProcessInfo) — all App-level concerns. `LlamaCppService` receives
-/// the model path via its constructor; it never imports this class.
+/// Multi-model aware. State is tracked per-descriptor so multiple models can coexist
+/// on disk; only one is loaded in memory at a time (the "active" model, persisted in
+/// UserDefaults). View call-sites that operate on the active model can use the
+/// `active*` convenience wrappers (`activeState`, `startActiveDownload`, ...).
+///
+/// Download policy: **sequential** — at most one descriptor is `.downloading` at
+/// any time. Concurrent download attempts are rejected to avoid network/CPU
+/// contention (two 3 GB GGUF downloads would saturate cellular and run two
+/// off-MainActor SHA256 hashes).
+///
+/// ### State machine (per-descriptor)
+///
+/// | Action                | idle / `.notDownloaded` | `.downloading`                 | `.ready`                      | `.error`      |
+/// |-----------------------|-------------------------|--------------------------------|-------------------------------|---------------|
+/// | `startDownload(d)`    | → `.downloading`†       | no-op (own descriptor)         | no-op (already done)          | → `.downloading` |
+/// | `cancelDownload(d)`   | no-op                   | → `.notDownloaded`, keep partial | no-op                       | no-op         |
+/// | `deleteModel(d)`      | remove partial if any, → `.notDownloaded` | cancel + remove partial, → `.notDownloaded` | remove file, → `.notDownloaded` | remove file + partial, → `.notDownloaded` |
+/// | `setActiveModel(id)`  | validate id ∈ catalog, write UserDefaults — does not touch state dict |
+///
+/// †: `startDownload` is also rejected (no-op) if ANY descriptor is already
+/// `.downloading` (sequential-download policy).
+///
+/// Lives in the App layer because it depends on HTTP (URLSession), filesystem
+/// (FileManager), and device capabilities (ProcessInfo) — all App-level concerns.
+/// `LlamaCppService` receives a model path via its constructor; it never imports
+/// this class.
 @Observable
 final class ModelManager {
   // MARK: - Constants
 
-  static let modelFileName = "gemma-4-E2B-it-Q4_K_M.gguf"
-  static let downloadFileName = "gemma-4-E2B-it-Q4_K_M.gguf.download"
-  static let modelURL: URL = {
-    guard
-      let url = URL(
-        string:
-          // ggml-org repo only has Q8_0/f16; Q4_K_M is provided by unsloth.
-          // Pinned to commit SHA to prevent silent breakage when upstream re-uploads the file.
-          "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/f064409f340b34190993560b2168133e5dbae558/gemma-4-E2B-it-Q4_K_M.gguf"
-      )
-    else {
-      preconditionFailure("Invalid hardcoded model URL")
-    }
-    return url
-  }()
-  /// Minimum physical memory reported by ProcessInfo to allow model download.
+  /// Minimum physical memory reported by ProcessInfo to allow any model download.
   /// iOS reports ~7.4–7.6 GB on 8 GB devices (kernel reserves ~0.5 GB)
   /// and ~5.4–5.6 GB on 6 GB devices. 6.5 GiB cleanly separates the two tiers.
+  ///
+  /// Phase 2 uses a shared floor across all catalog descriptors. `ModelDescriptor.minRAM`
+  /// is reserved for Phase 3 tier-auto (where a lighter model targets 6 GB devices).
   static let minimumRAM: UInt64 = 6_500_000_000
-  /// Expected file size for integrity check (Q4_K_M GGUF from HuggingFace LFS metadata).
-  /// Set to 0 to skip size validation.
-  static let modelFileSize: Int64 = 3_106_735_776
-  /// SHA256 hash of the model file (lowercase hex), from HuggingFace LFS metadata
-  /// (unsloth/gemma-4-E2B-it-GGUF, `oid` field). nil to skip hash verification.
-  static let modelSHA256: String? =
-    "ac0069ebccd39925d836f24a88c0f0c858d20578c29b21ab7cedce66ee576845"
+
+  /// UserDefaults key for the persisted active model id.
+  static let activeModelIDKey = "com.pastura.activeModelID"
 
   // MARK: - Published State
 
-  private(set) var state: ModelState = .checking
+  /// Per-descriptor state, keyed by `ModelDescriptor.id`. Populated at init with
+  /// `.checking` for every catalog entry; `checkModelStatus()` resolves each.
+  private(set) var state: [ModelID: ModelState]
+
+  /// Currently-active model's id. Persisted in UserDefaults under `activeModelIDKey`.
+  /// Falls back to `ModelRegistry.defaultInitialModelID` if no persisted value
+  /// exists or the persisted id is not in the current catalog.
+  private(set) var activeModelID: ModelID
 
   // MARK: - Dependencies
 
   private let downloader: any ModelDownloader
   private let fileManager: FileManager
   private let physicalMemory: UInt64
-  private let expectedFileSize: Int64
-  private let expectedSHA256: String?
-  private var downloadTask: Task<Void, Never>?
+  private let userDefaults: UserDefaults
+  let catalog: [ModelDescriptor]
+  private var downloadTasks: [ModelID: Task<Void, Never>] = [:]
 
-  // MARK: - Computed
+  // MARK: - Paths
 
-  /// Directory for the completed model file: Library/Application Support/.
+  /// Directory for completed model files: Library/Application Support/.
   /// Application Support persists across app updates and is not purged by the OS,
-  /// unlike Library/Caches/. The model file is excluded from iCloud backup
-  /// (isExcludedFromBackup) because it can be re-downloaded (~3 GB).
+  /// unlike Library/Caches/. Files are excluded from iCloud backup
+  /// (isExcludedFromBackup) because they can be re-downloaded (~3 GB each).
   var modelDirectoryURL: URL {
     fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
       ?? fileManager.temporaryDirectory
   }
 
-  var modelFileURL: URL {
-    modelDirectoryURL.appendingPathComponent(Self.modelFileName)
-  }
-
-  /// Partial download file stored in Library/Caches/.
+  /// Directory for partial downloads: Library/Caches/.
   /// Caches is appropriate because: not backed up by iCloud, and if the OS purges it
   /// under storage pressure, the download simply restarts (resume offset = 0).
-  var downloadFileURL: URL {
-    let cachesDir =
-      fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first
+  var cachesDirectoryURL: URL {
+    fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first
       ?? fileManager.temporaryDirectory
-    return cachesDir.appendingPathComponent(Self.downloadFileName)
+  }
+
+  /// Absolute file URL for the completed model corresponding to `descriptor`.
+  func modelFileURL(for descriptor: ModelDescriptor) -> URL {
+    modelDirectoryURL.appendingPathComponent(descriptor.fileName)
+  }
+
+  /// Absolute file URL for the partial download corresponding to `descriptor`.
+  /// Naming convention is `<fileName>.download`, which preserves the legacy Gemma
+  /// partial-file path (`gemma-4-E2B-it-Q4_K_M.gguf.download`) automatically.
+  func downloadFileURL(for descriptor: ModelDescriptor) -> URL {
+    cachesDirectoryURL.appendingPathComponent(descriptor.fileName + ".download")
+  }
+
+  // MARK: - Convenience (active model)
+
+  /// The `ModelDescriptor` matching `activeModelID`, or `nil` if the catalog is empty.
+  /// `nil` is only expected during test setup with an empty catalog — production
+  /// `ModelRegistry.catalog` always contains at least one entry.
+  var activeDescriptor: ModelDescriptor? {
+    catalog.first(where: { $0.id == activeModelID })
+  }
+
+  /// State of the currently-active model. `.checking` if the active id is not in
+  /// the state dict (should not happen post-`checkModelStatus`).
+  var activeState: ModelState {
+    state[activeModelID] ?? .checking
+  }
+
+  /// Whether any catalog descriptor is currently downloading. Used by
+  /// `startDownload` to enforce the sequential-download policy.
+  var isAnyDownloadInProgress: Bool {
+    state.values.contains {
+      if case .downloading = $0 { return true }
+      return false
+    }
   }
 
   // MARK: - Init
@@ -98,85 +151,182 @@ final class ModelManager {
     downloader: any ModelDownloader = URLSessionModelDownloader(),
     fileManager: FileManager = .default,
     physicalMemory: UInt64 = ProcessInfo.processInfo.physicalMemory,
-    expectedFileSize: Int64 = modelFileSize,
-    expectedSHA256: String? = modelSHA256
+    userDefaults: UserDefaults = .standard,
+    catalog: [ModelDescriptor] = ModelRegistry.catalog
   ) {
     self.downloader = downloader
     self.fileManager = fileManager
     self.physicalMemory = physicalMemory
-    self.expectedFileSize = expectedFileSize
-    self.expectedSHA256 = expectedSHA256
+    self.userDefaults = userDefaults
+    self.catalog = catalog
+    self.activeModelID = Self.resolveInitialActiveID(
+      persistedID: userDefaults.string(forKey: Self.activeModelIDKey),
+      catalog: catalog
+    )
+
+    // Seed all catalog descriptors with `.checking` so `activeState` is well-defined
+    // before the first `checkModelStatus()`.
+    var initial: [ModelID: ModelState] = [:]
+    for descriptor in catalog {
+      initial[descriptor.id] = .checking
+    }
+    self.state = initial
+  }
+
+  /// Resolves which descriptor id should be active at init time.
+  ///
+  /// Resolution order:
+  /// 1. Persisted UserDefaults value, if it's present in `catalog`
+  /// 2. `ModelRegistry.defaultInitialModelID`, if it's present in `catalog`
+  /// 3. First descriptor in `catalog` (covers test catalogs that exclude the default)
+  /// 4. Empty string (only reached with an empty catalog — not a production scenario)
+  ///
+  /// Exposed as `static` so it can be unit-tested in isolation.
+  static func resolveInitialActiveID(
+    persistedID: String?,
+    catalog: [ModelDescriptor]
+  ) -> ModelID {
+    if let persistedID, catalog.contains(where: { $0.id == persistedID }) {
+      return persistedID
+    }
+    if catalog.contains(where: { $0.id == ModelRegistry.defaultInitialModelID }) {
+      return ModelRegistry.defaultInitialModelID
+    }
+    return catalog.first?.id ?? ""
   }
 
   // MARK: - Public Methods
 
-  /// Checks device compatibility and model file status. Sets `state` accordingly.
+  /// Resolves each catalog descriptor's state by inspecting the filesystem.
+  /// Sets every descriptor to `.unsupportedDevice` if `physicalMemory < minimumRAM`.
   func checkModelStatus() {
     guard physicalMemory >= Self.minimumRAM else {
-      state = .unsupportedDevice
-      return
-    }
-
-    if fileManager.fileExists(atPath: modelFileURL.path) {
-      // Only check file size (not SHA256) at launch — hashing 3 GB blocks the UI for ~2s.
-      // SHA256 is verified once during download; corruption after download is unlikely.
-      if expectedFileSize > 0 {
-        let attrs = try? fileManager.attributesOfItem(atPath: modelFileURL.path)
-        let fileSize = attrs?[.size] as? Int64 ?? 0
-        if fileSize != expectedFileSize {
-          // Corrupt or incomplete file at final path — remove it
-          try? fileManager.removeItem(at: modelFileURL)
-          state = .notDownloaded
-          return
-        }
+      for descriptor in catalog {
+        state[descriptor.id] = .unsupportedDevice
       }
-      // Best-effort: re-apply on every launch as a safety net in case a prior attempt failed.
-      excludeFromBackup(modelFileURL)
-      state = .ready(modelPath: modelFileURL.path)
-    } else {
-      state = .notDownloaded
+      return
+    }
+    for descriptor in catalog {
+      state[descriptor.id] = computeState(for: descriptor)
     }
   }
 
-  /// Starts downloading the model file from HuggingFace. Stores the task for cancellation.
-  func startDownload() {
-    // Allow download from .notDownloaded or .error states only
-    switch state {
+  /// Sets the active model to `id` and persists it in UserDefaults. No-op if
+  /// `id` is not in the current catalog — callers should validate first.
+  ///
+  /// **Important**: This does not trigger LLMService regeneration — that is
+  /// orchestrated by AppDependencies in PR B. Callers must also ensure no
+  /// simulation is currently running (enforced via SimulationActivityRegistry
+  /// in PR B), or the running simulation's LLMService may be unloaded mid-flight.
+  func setActiveModel(_ id: ModelID) {
+    guard catalog.contains(where: { $0.id == id }) else { return }
+    activeModelID = id
+    userDefaults.set(id, forKey: Self.activeModelIDKey)
+  }
+
+  /// Starts downloading `descriptor`. Rejected (no-op) if any descriptor is
+  /// already `.downloading` (sequential-download policy) or if `descriptor`'s
+  /// current state is not `.notDownloaded` / `.error`.
+  func startDownload(descriptor: ModelDescriptor) {
+    guard !isAnyDownloadInProgress else { return }
+    let currentState = state[descriptor.id] ?? .checking
+    switch currentState {
     case .notDownloaded, .error:
       break
     default:
       return
     }
-
-    // Set state synchronously to prevent re-entry before the Task body runs.
-    state = .downloading(progress: 0)
-    downloadTask = Task { await performDownload() }
+    // Set synchronously to prevent re-entry before the Task body runs.
+    state[descriptor.id] = .downloading(progress: 0)
+    downloadTasks[descriptor.id] = Task { await performDownload(descriptor: descriptor) }
   }
 
-  /// Downloads the model file. Supports resume from partial downloads.
-  func downloadModel() async {
-    // Allow download from .notDownloaded or .error states only
-    switch state {
+  /// Async variant of `startDownload`. Same gating semantics; awaits the
+  /// download directly rather than storing the Task.
+  func downloadModel(descriptor: ModelDescriptor) async {
+    guard !isAnyDownloadInProgress else { return }
+    let currentState = state[descriptor.id] ?? .checking
+    switch currentState {
     case .notDownloaded, .error:
       break
     default:
       return
     }
-
-    await performDownload()
+    await performDownload(descriptor: descriptor)
   }
 
-  private func performDownload() async {
+  /// Cancels an in-progress download for `descriptor`. The partial file is
+  /// kept for resume. No-op if no download is in flight for this descriptor.
+  func cancelDownload(descriptor: ModelDescriptor) {
+    downloadTasks[descriptor.id]?.cancel()
+    downloadTasks[descriptor.id] = nil
+    state[descriptor.id] = .notDownloaded
+  }
+
+  /// Removes both the completed model file and any partial download for
+  /// `descriptor`. Cancels an in-flight download for the same descriptor first.
+  func deleteModel(descriptor: ModelDescriptor) {
+    downloadTasks[descriptor.id]?.cancel()
+    downloadTasks[descriptor.id] = nil
+    try? fileManager.removeItem(at: modelFileURL(for: descriptor))
+    try? fileManager.removeItem(at: downloadFileURL(for: descriptor))
+    state[descriptor.id] = .notDownloaded
+  }
+
+  // MARK: - Convenience (active-model wrappers)
+
+  /// Starts the download for the currently-active model. No-op if no active
+  /// descriptor is resolvable (empty catalog). Preserves the old single-model
+  /// `startDownload()` call-site ergonomics.
+  func startActiveDownload() {
+    guard let descriptor = activeDescriptor else { return }
+    startDownload(descriptor: descriptor)
+  }
+
+  /// Cancels the download for the currently-active model, if any.
+  func cancelActiveDownload() {
+    guard let descriptor = activeDescriptor else { return }
+    cancelDownload(descriptor: descriptor)
+  }
+
+  // MARK: - Private: State Computation
+
+  private func computeState(for descriptor: ModelDescriptor) -> ModelState {
+    let fileURL = modelFileURL(for: descriptor)
+    guard fileManager.fileExists(atPath: fileURL.path) else {
+      return .notDownloaded
+    }
+    // Only check file size (not SHA256) at launch — hashing ~3 GB blocks the UI
+    // for ~2 s. SHA256 is verified once at download time.
+    if descriptor.fileSize > 0 {
+      let attrs = try? fileManager.attributesOfItem(atPath: fileURL.path)
+      let fileSize = attrs?[.size] as? Int64 ?? 0
+      if fileSize != descriptor.fileSize {
+        try? fileManager.removeItem(at: fileURL)
+        return .notDownloaded
+      }
+    }
+    // Best-effort: re-apply on every launch as a safety net in case a prior attempt failed.
+    excludeFromBackup(fileURL)
+    return .ready(modelPath: fileURL.path)
+  }
+
+  // MARK: - Private: Download
+
+  private func performDownload(descriptor: ModelDescriptor) async {
+    let modelURL = modelFileURL(for: descriptor)
+    let partialURL = downloadFileURL(for: descriptor)
+
     // Determine resume offset from existing partial download
     let resumeOffset: Int64
-    if fileManager.fileExists(atPath: downloadFileURL.path) {
-      let attrs = try? fileManager.attributesOfItem(atPath: downloadFileURL.path)
+    if fileManager.fileExists(atPath: partialURL.path) {
+      let attrs = try? fileManager.attributesOfItem(atPath: partialURL.path)
       resumeOffset = attrs?[.size] as? Int64 ?? 0
     } else {
       resumeOffset = 0
     }
 
-    state = .downloading(progress: resumeOffset > 0 ? 0.01 : 0.0)
+    state[descriptor.id] = .downloading(progress: resumeOffset > 0 ? 0.01 : 0.0)
 
     // Throttle UI updates to ~10 Hz (100ms). URLSession's `didWriteData`
     // callback fires hundreds of times per second on a 3 GB download; without
@@ -187,13 +337,14 @@ final class ModelManager {
     // production URLSession's serial delegate queue (off-MainActor) and
     // `MockModelDownloader` in tests (on MainActor).
     let throttle = OSAllocatedUnfairLock<ProgressThrottle>(initialState: ProgressThrottle())
-    let expectedSize = expectedFileSize
+    let expectedSize = descriptor.fileSize
+    let descriptorID = descriptor.id
 
     do {
       try await downloader.download(
-        from: Self.modelURL,
+        from: descriptor.downloadURL,
         resumeOffset: resumeOffset,
-        to: downloadFileURL,
+        to: partialURL,
         progressHandler: { [weak self] bytesReceived, totalBytes in
           let shouldEmit = throttle.withLock { $0.shouldEmit(now: .now) }
           guard shouldEmit else { return }
@@ -203,11 +354,14 @@ final class ModelManager {
             if totalBytes > 0 {
               progress = Double(bytesReceived) / Double(totalBytes)
             } else {
-              // Content-Length unknown — estimate from expected file size (~3.1 GB)
+              // Content-Length unknown — estimate from expected file size.
+              // 3.1 GB lower-bound matches the Phase-2 Gemma size; Qwen (2.5 GB)
+              // will show slightly pessimistic progress when Content-Length is
+              // absent, which is acceptable for a rare edge case.
               let estimatedTotal = Double(max(expectedSize, 3_100_000_000))
               progress = min(Double(bytesReceived) / estimatedTotal, 0.99)
             }
-            self.state = .downloading(progress: min(progress, 1.0))
+            self.state[descriptorID] = .downloading(progress: min(progress, 1.0))
           }
         }
       )
@@ -215,50 +369,77 @@ final class ModelManager {
       // Force a terminal 100% transition before SHA256 verification.
       // Production URLSession does not guarantee a final `didWriteData` call
       // at `received == total`, and even if it did, it could be throttled out
-      // above. Without this, the UI stalls at ~99% during the ~2s SHA256 hash
+      // above. Without this, the UI stalls at ~99% during the ~2 s SHA256 hash
       // on a 3 GB file.
-      state = .downloading(progress: 1.0)
+      state[descriptor.id] = .downloading(progress: 1.0)
 
-      if let error = await verifyDownloadIntegrity() {
-        try? fileManager.removeItem(at: downloadFileURL)
-        state = .error(error)
+      if let error = await verifyDownloadIntegrity(descriptor: descriptor) {
+        try? fileManager.removeItem(at: partialURL)
+        state[descriptor.id] = .error(error)
         return
       }
 
       // Ensure Application Support directory exists before moving the file.
-      let modelDir = modelFileURL.deletingLastPathComponent()
+      let modelDir = modelURL.deletingLastPathComponent()
       try fileManager.createDirectory(at: modelDir, withIntermediateDirectories: true)
 
       // Atomic rename from Caches/.download to Application Support/ final path.
       // Same volume on iOS, so this is an atomic rename (no copy+delete).
-      if fileManager.fileExists(atPath: modelFileURL.path) {
-        try fileManager.removeItem(at: modelFileURL)
+      if fileManager.fileExists(atPath: modelURL.path) {
+        try fileManager.removeItem(at: modelURL)
       }
-      try fileManager.moveItem(at: downloadFileURL, to: modelFileURL)
+      try fileManager.moveItem(at: partialURL, to: modelURL)
 
-      excludeFromBackup(modelFileURL)
-      state = .ready(modelPath: modelFileURL.path)
+      excludeFromBackup(modelURL)
+      state[descriptor.id] = .ready(modelPath: modelURL.path)
     } catch is CancellationError {
       // Download was cancelled — keep partial file for resume
-      state = .notDownloaded
+      state[descriptor.id] = .notDownloaded
     } catch {
       // Keep partial .download file for resume
-      state = .error(error.localizedDescription)
+      state[descriptor.id] = .error(error.localizedDescription)
     }
   }
 
-  /// Cancels an in-progress download. The partial file is kept for resume.
-  func cancelDownload() {
-    downloadTask?.cancel()
-    downloadTask = nil
-    state = .notDownloaded
+  // MARK: - Private: Integrity
+
+  /// Validates file size and SHA256 hash of the downloaded partial file.
+  /// Returns an error message if verification fails, or `nil` if the file is valid.
+  private func verifyDownloadIntegrity(descriptor: ModelDescriptor) async -> String? {
+    let partialURL = downloadFileURL(for: descriptor)
+
+    // Validate file size if the descriptor provides one (0 = skip, used only in tests)
+    if descriptor.fileSize > 0 {
+      let attrs = try? fileManager.attributesOfItem(atPath: partialURL.path)
+      let fileSize = attrs?[.size] as? Int64 ?? 0
+      if fileSize != descriptor.fileSize {
+        return "Downloaded file size mismatch (expected \(descriptor.fileSize), got \(fileSize))"
+      }
+    }
+
+    // Validate SHA256 if provided (empty string = skip, used only in tests).
+    // Runs off MainActor to avoid UI freeze on large files (~2 s for 3 GB).
+    guard !descriptor.sha256.isEmpty else { return nil }
+
+    let actualSHA256: String
+    do {
+      actualSHA256 = try await Task.detached {
+        try Self.computeSHA256(of: partialURL)
+      }.value
+    } catch {
+      return "Failed to verify download: \(error.localizedDescription)"
+    }
+    if actualSHA256 != descriptor.sha256 {
+      return "Download verification failed. The file may be corrupted — please try again."
+    }
+    return nil
   }
 
-  // MARK: - Backup Exclusion
+  // MARK: - Private: Backup Exclusion + SHA256
 
   /// Marks a file as excluded from iCloud backup.
   /// Best-effort: failure is non-fatal because the file is still usable,
-  /// and checkModelStatus() re-applies on every launch as a safety net.
+  /// and `checkModelStatus()` re-applies on every launch as a safety net.
   private func excludeFromBackup(_ url: URL) {
     var mutableURL = url
     var values = URLResourceValues()
@@ -266,45 +447,10 @@ final class ModelManager {
     try? mutableURL.setResourceValues(values)
   }
 
-  // MARK: - Download Integrity
-
-  /// Validates file size and SHA256 hash of the downloaded file.
-  /// Returns an error message if verification fails, or nil if the file is valid.
-  private func verifyDownloadIntegrity() async -> String? {
-    // Validate file size if expected size is known
-    if expectedFileSize > 0 {
-      let attrs = try? fileManager.attributesOfItem(atPath: downloadFileURL.path)
-      let fileSize = attrs?[.size] as? Int64 ?? 0
-      if fileSize != expectedFileSize {
-        return "Downloaded file size mismatch (expected \(expectedFileSize), got \(fileSize))"
-      }
-    }
-
-    // Validate SHA256 hash if expected hash is known.
-    // Runs off MainActor to avoid UI freeze on large files (~2s for 3 GB).
-    if let expectedSHA256 {
-      let downloadURL = downloadFileURL
-      let actualSHA256: String
-      do {
-        actualSHA256 = try await Task.detached {
-          try Self.computeSHA256(of: downloadURL)
-        }.value
-      } catch {
-        return "Failed to verify download: \(error.localizedDescription)"
-      }
-      if actualSHA256 != expectedSHA256 {
-        return "Download verification failed. The file may be corrupted — please try again."
-      }
-    }
-
-    return nil
-  }
-
-  // MARK: - SHA256
-
-  /// Computes SHA256 of a file using streaming reads to avoid loading the full file into memory.
-  /// Returns lowercase hex string. Marked `nonisolated` because ModelManager inherits MainActor
-  /// isolation and hashing a 3 GB file on MainActor would freeze the UI.
+  /// Computes SHA256 of a file using streaming reads to avoid loading the full
+  /// file into memory. Returns lowercase hex string. Marked `nonisolated` because
+  /// ModelManager inherits MainActor isolation and hashing a 3 GB file on MainActor
+  /// would freeze the UI.
   nonisolated static func computeSHA256(of fileURL: URL) throws -> String {
     let handle = try FileHandle(forReadingFrom: fileURL)
     defer { try? handle.close() }
@@ -320,12 +466,5 @@ final class ModelManager {
 
     let digest = hasher.finalize()
     return digest.map { String(format: "%02x", $0) }.joined()
-  }
-
-  /// Removes both the model file and any partial download from disk.
-  func deleteModel() {
-    try? fileManager.removeItem(at: modelFileURL)
-    try? fileManager.removeItem(at: downloadFileURL)
-    state = .notDownloaded
   }
 }

--- a/Pastura/Pastura/App/ModelRegistry.swift
+++ b/Pastura/Pastura/App/ModelRegistry.swift
@@ -37,7 +37,7 @@ enum ModelRegistry {
     systemPromptSuffix: nil
   )
 
-  nonisolated static let qwen3_4B: ModelDescriptor = ModelDescriptor(
+  nonisolated static let qwen34B: ModelDescriptor = ModelDescriptor(
     id: "qwen-3-4b-q4-k-m",
     displayName: "Qwen 3 4B (Q4_K_M)",
     vendor: "Alibaba",
@@ -55,7 +55,7 @@ enum ModelRegistry {
   )
 
   /// Full production catalog, ordered by display preference (Gemma first, Qwen second).
-  nonisolated static let catalog: [ModelDescriptor] = [gemma4E2B, qwen3_4B]
+  nonisolated static let catalog: [ModelDescriptor] = [gemma4E2B, qwen34B]
 
   /// ID of the model selected by default for new users (first-run onboarding fallback).
   nonisolated static let defaultInitialModelID: ModelID = gemma4E2B.id

--- a/Pastura/Pastura/App/ModelRegistry.swift
+++ b/Pastura/Pastura/App/ModelRegistry.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+/// Force-constructs a URL from a string literal. Fatal error if the literal is malformed.
+/// Acceptable because the input is a compile-time constant that we control — NOT user input.
+nonisolated private func unsafeURL(_ string: String) -> URL {
+  guard let url = URL(string: string) else {
+    preconditionFailure("Malformed URL literal: \(string)")
+  }
+  return url
+}
+
+/// Static catalog of on-device LLM models shipped with Pastura.
+///
+/// Entries are constructed at compile time from known-good HuggingFace metadata
+/// (pinned commit SHA, file size, SHA-256). This keeps model downloads
+/// deterministic across app versions and users — see Issue #82 for the
+/// deferred "dynamic metadata" alternative.
+///
+/// `ModelManager` consumes this catalog to resolve per-model file paths,
+/// download URLs, and integrity checks. `LlamaCppService` consumes individual
+/// descriptors for prompt-format hints (`stopSequence`, `systemPromptSuffix`).
+enum ModelRegistry {
+  nonisolated static let gemma4E2B: ModelDescriptor = ModelDescriptor(
+    id: "gemma-4-e2b-q4-k-m",
+    displayName: "Gemma 4 E2B (Q4_K_M)",
+    vendor: "Google",
+    vendorURL: unsafeURL("https://deepmind.google"),
+    downloadURL: unsafeURL(
+      "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/f064409f340b34190993560b2168133e5dbae558/gemma-4-E2B-it-Q4_K_M.gguf"
+    ),
+    fileName: "gemma-4-E2B-it-Q4_K_M.gguf",
+    fileSize: 3_106_735_776,
+    sha256: "ac0069ebccd39925d836f24a88c0f0c858d20578c29b21ab7cedce66ee576845",
+    stopSequence: "<|im_end|>",
+    minRAM: 6_500_000_000,
+    modelInfoURL: unsafeURL("https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF"),
+    systemPromptSuffix: nil
+  )
+
+  nonisolated static let qwen3_4B: ModelDescriptor = ModelDescriptor(
+    id: "qwen-3-4b-q4-k-m",
+    displayName: "Qwen 3 4B (Q4_K_M)",
+    vendor: "Alibaba",
+    vendorURL: unsafeURL("https://qwenlm.github.io"),
+    downloadURL: unsafeURL(
+      "https://huggingface.co/Qwen/Qwen3-4B-GGUF/resolve/bc640142c66e1fdd12af0bd68f40445458f3869b/Qwen3-4B-Q4_K_M.gguf"
+    ),
+    fileName: "Qwen3-4B-Q4_K_M.gguf",
+    fileSize: 2_497_280_256,
+    sha256: "7485fe6f11af29433bc51cab58009521f205840f5b4ae3a32fa7f92e8534fdf5",
+    stopSequence: "<|im_end|>",
+    minRAM: 6_500_000_000,
+    modelInfoURL: unsafeURL("https://huggingface.co/Qwen/Qwen3-4B-GGUF"),
+    systemPromptSuffix: "/no_think"
+  )
+
+  /// Full production catalog, ordered by display preference (Gemma first, Qwen second).
+  nonisolated static let catalog: [ModelDescriptor] = [gemma4E2B, qwen3_4B]
+
+  /// ID of the model selected by default for new users (first-run onboarding fallback).
+  nonisolated static let defaultInitialModelID: ModelID = gemma4E2B.id
+
+  /// Returns diagnostic reasons if `catalog` contains duplicate `id` or `fileName` values.
+  /// Empty result means the catalog is valid. Exposed for testability; `validateNoCollisions`
+  /// wraps this in a precondition.
+  nonisolated static func findCollisions(in catalog: [ModelDescriptor]) -> [String] {
+    var reasons: [String] = []
+
+    var seenIDs: [ModelID: Int] = [:]
+    var seenFileNames: [String: Int] = [:]
+
+    for (index, descriptor) in catalog.enumerated() {
+      if let previousIndex = seenIDs[descriptor.id] {
+        reasons.append(
+          "Duplicate id \"\(descriptor.id)\" at indices \(previousIndex) and \(index)")
+      } else {
+        seenIDs[descriptor.id] = index
+      }
+
+      if let previousIndex = seenFileNames[descriptor.fileName] {
+        reasons.append(
+          "Duplicate fileName \"\(descriptor.fileName)\" at indices \(previousIndex) and \(index)"
+        )
+      } else {
+        seenFileNames[descriptor.fileName] = index
+      }
+    }
+
+    return reasons
+  }
+
+  /// Precondition-checks the production catalog for duplicate `id` / `fileName` values.
+  /// Call once at app launch (future Item — this PR only provides the API).
+  nonisolated static func validateNoCollisions() {
+    let reasons = findCollisions(in: catalog)
+    precondition(
+      reasons.isEmpty,
+      "ModelRegistry catalog collisions: \(reasons.joined(separator: ", "))"
+    )
+  }
+}

--- a/Pastura/Pastura/LLM/LLMService.swift
+++ b/Pastura/Pastura/LLM/LLMService.swift
@@ -61,9 +61,12 @@ nonisolated public protocol LLMService: Sendable {
   ///   suspend signals. Pass `nil` to detach.
   func attachSuspendController(_ controller: SuspendController?) async
 
-  /// Human-readable label for the currently-loaded model (e.g.
-  /// `"Gemma 4 E2B (Q4_K_M)"`, `"gemma4:e2b"`, `"mock"`). Intended for
-  /// display / export metadata — **not** a stable parse key.
+  /// Human-readable label for the currently-loaded model — implementations
+  /// typically derive this from backend-specific metadata (e.g. a
+  /// `ModelDescriptor.displayName` for on-device services, a backend tag
+  /// like `"gemma4:e2b"` for remote services, or a test sentinel like
+  /// `"mock"`). Intended for display / export metadata — **not** a stable
+  /// parse key.
   var modelIdentifier: String { get }
 
   /// Human-readable label for the backend runtime driving inference (e.g.

--- a/Pastura/Pastura/LLM/LlamaCppService+ChatTemplate.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService+ChatTemplate.swift
@@ -5,11 +5,17 @@ import LlamaSwift
 
 extension LlamaCppService {
   func applyChatTemplate(system: String, user: String) throws -> String {
+    // Append the descriptor's optional suffix to the system prompt. Used today
+    // to inject `/no_think` for Qwen 3 (disables thinking mode so the model
+    // emits JSON directly instead of wrapping in `<think>...</think>` blocks
+    // that would starve the `maxTokens` budget before the JSON appears).
+    let effectiveSystem = systemPromptSuffix.map { "\(system)\n\($0)" } ?? system
+
     // Build llama_chat_message array using C strings
     guard
       let systemRole = strdup("system"),
       let userRole = strdup("user"),
-      let systemContent = strdup(system),
+      let systemContent = strdup(effectiveSystem),
       let userContent = strdup(user)
     else {
       throw LLMError.generationFailed(

--- a/Pastura/Pastura/LLM/LlamaCppService.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService.swift
@@ -85,20 +85,25 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
 
   /// Creates a llama.cpp service.
   ///
+  /// All parameters are required — callers must provide explicit per-descriptor
+  /// values (via `ModelDescriptor.stopSequence` / `.displayName` /
+  /// `.systemPromptSuffix`). This avoids silently running Qwen with Gemma's
+  /// defaults if a call-site forgets to thread the descriptor through.
+  /// Test code can construct via a file-scope helper (see
+  /// `LlamaCppServiceTests`) to centralize the Gemma-shaped test values.
+  ///
   /// - Parameters:
   ///   - modelPath: Absolute path to the GGUF model file on disk (provided by
   ///     `ModelManager.modelFileURL(for:).path` at the call-site).
-  ///   - stopSequence: Per-model stop sentinel (e.g., `<|im_end|>`). Defaults
-  ///     to the Gemma/Qwen value to keep existing test call-sites ergonomic
-  ///     without changing their construction shape.
+  ///   - stopSequence: Per-model stop sentinel (e.g., `<|im_end|>`).
   ///   - modelIdentifier: Human-readable label for exports / replay metadata.
   ///   - systemPromptSuffix: Optional suffix appended to the system prompt
   ///     at `applyChatTemplate` (e.g., `/no_think` for Qwen 3).
   public init(
     modelPath: String,
-    stopSequence: String = "<|im_end|>",
-    modelIdentifier: String = "Gemma 4 E2B (Q4_K_M)",
-    systemPromptSuffix: String? = nil
+    stopSequence: String,
+    modelIdentifier: String,
+    systemPromptSuffix: String?
   ) {
     self.modelPath = modelPath
     self.stopSequence = stopSequence
@@ -395,7 +400,7 @@ extension LlamaCppService {
 
       if let range = outputText.range(of: stopSequence) {
         outputText = String(outputText[..<range.lowerBound])
-        logger.debug("<|im_end|> stop sequence detected — ending generation early")
+        logger.debug("\(self.stopSequence) stop sequence detected — ending generation early")
         break
       }
 
@@ -555,7 +560,7 @@ extension LlamaCppService {
           through: beforeStop.count, continuation: continuation)
         emittedCharCount = beforeStop.count
         decodedText = beforeStop
-        logger.debug("<|im_end|> stop sequence detected — ending stream early")
+        logger.debug("\(self.stopSequence) stop sequence detected — ending stream early")
         break
       }
 

--- a/Pastura/Pastura/LLM/LlamaCppService.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService.swift
@@ -39,10 +39,19 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
   static let repeatPenalty: Float = 1.1
   static let contextSize: UInt32 = 8_192
   static let batchSize: Int = 512
-  // String-based, not token-ID, because Gemma 4 E2B tokenizes <|im_end|> into
-  // 6 subword tokens — single-token ID matching is impossible for this model.
-  // TODO: Consider adding <|im_start|> if hallucinated turn starts are observed (#65)
-  static let stopSequence = "<|im_end|>"
+  // Per-instance stop sequence (was `static` pre-multi-model). String-based,
+  // not token-ID, because Gemma 4 E2B tokenizes `<|im_end|>` into 6 subword
+  // tokens — single-token ID matching is impossible for this model. Gemma
+  // and Qwen 3 both use `<|im_end|>`; future models may differ (read from
+  // descriptor at construction time).
+  // TODO: Consider adding `<|im_start|>` if hallucinated turn starts are observed (#65)
+  let stopSequence: String
+
+  /// Optional suffix appended to the system prompt at chat-template assembly.
+  /// Used for models that require prompt-level mode control (e.g., Qwen's
+  /// `/no_think` to disable thinking mode). `nil` for models that need no
+  /// suffix.
+  let systemPromptSuffix: String?
 
   private let loadedState: OSAllocatedUnfairLock<Bool>
   // Runtime guard for the sequential access contract (ADR-002 §6).
@@ -76,9 +85,25 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
 
   /// Creates a llama.cpp service.
   ///
-  /// - Parameter modelPath: Absolute path to the GGUF model file on disk.
-  public init(modelPath: String) {
+  /// - Parameters:
+  ///   - modelPath: Absolute path to the GGUF model file on disk (provided by
+  ///     `ModelManager.modelFileURL(for:).path` at the call-site).
+  ///   - stopSequence: Per-model stop sentinel (e.g., `<|im_end|>`). Defaults
+  ///     to the Gemma/Qwen value to keep existing test call-sites ergonomic
+  ///     without changing their construction shape.
+  ///   - modelIdentifier: Human-readable label for exports / replay metadata.
+  ///   - systemPromptSuffix: Optional suffix appended to the system prompt
+  ///     at `applyChatTemplate` (e.g., `/no_think` for Qwen 3).
+  public init(
+    modelPath: String,
+    stopSequence: String = "<|im_end|>",
+    modelIdentifier: String = "Gemma 4 E2B (Q4_K_M)",
+    systemPromptSuffix: String? = nil
+  ) {
     self.modelPath = modelPath
+    self.stopSequence = stopSequence
+    self.modelIdentifier = modelIdentifier
+    self.systemPromptSuffix = systemPromptSuffix
     self.loadedState = OSAllocatedUnfairLock(initialState: false)
   }
 
@@ -200,9 +225,10 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
     suspendController = controller
   }
 
-  // Hardcoded in MVP because this service is wired only to the bundled Gemma 4 E2B
-  // Q4_K_M GGUF. When multiple models ship, read from GGUF metadata at loadModel().
-  public let modelIdentifier = "Gemma 4 E2B (Q4_K_M)"
+  /// Injected at init from `ModelDescriptor.displayName`. Intended for
+  /// display / export metadata (past-results viewer, Markdown export,
+  /// YAML replay) — not a stable parse key.
+  public let modelIdentifier: String
   public let backendIdentifier = "llama.cpp"
 
   /// Maps a non-zero `llama_decode` result to either ``LLMError/suspended``
@@ -367,7 +393,7 @@ extension LlamaCppService {
         }
       #endif
 
-      if let range = outputText.range(of: Self.stopSequence) {
+      if let range = outputText.range(of: stopSequence) {
         outputText = String(outputText[..<range.lowerBound])
         logger.debug("<|im_end|> stop sequence detected — ending generation early")
         break
@@ -522,7 +548,7 @@ extension LlamaCppService {
       }
 
       // Stop-sequence match: flush everything before it, terminate.
-      if let range = decodedText.range(of: Self.stopSequence) {
+      if let range = decodedText.range(of: stopSequence) {
         let beforeStop = String(decodedText[..<range.lowerBound])
         Self.emitDelta(
           from: beforeStop, alreadyEmitted: emittedCharCount,
@@ -538,7 +564,7 @@ extension LlamaCppService {
       // one char; `<|` holds back two; the next iteration either
       // completes the match (handled above) or disambiguates, at which
       // point holdback drops to zero and the queued chars flush.
-      let holdback = Self.stopSequenceHoldbackLength(in: decodedText)
+      let holdback = stopSequenceHoldbackLength(in: decodedText)
       let safeCount = decodedText.count - holdback
       if safeCount > emittedCharCount {
         Self.emitDelta(
@@ -626,7 +652,7 @@ extension LlamaCppService {
   /// common case, producing immediate emission and zero UX lag. Capped
   /// at `stopSequence.count - 1` because a full match is handled
   /// directly by the caller.
-  fileprivate static func stopSequenceHoldbackLength(in decoded: String) -> Int {
+  fileprivate func stopSequenceHoldbackLength(in decoded: String) -> Int {
     let stop = stopSequence
     let maxLen = min(decoded.count, stop.count - 1)
     if maxLen == 0 { return 0 }

--- a/Pastura/Pastura/Models/ModelDescriptor.swift
+++ b/Pastura/Pastura/Models/ModelDescriptor.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// Stable string identifier for an on-device LLM model (e.g., `"gemma-4-e2b-q4-k-m"`).
+public typealias ModelID = String
+
+/// Immutable descriptor for an on-device LLM model (download URL, integrity metadata,
+/// prompt-format hints). Used by `ModelManager` and `LlamaCppService` to parameterize
+/// per-model behavior. Held in a static catalog (`ModelRegistry`) — not persisted.
+nonisolated public struct ModelDescriptor: Sendable, Hashable {
+  /// Stable identifier for the model (e.g., `"gemma-4-e2b-q4-k-m"`).
+  public let id: ModelID
+
+  /// Human-readable name shown in the UI (e.g., `"Gemma 4 E2B (Q4_K_M)"`).
+  public let displayName: String
+
+  /// Model publisher name (e.g., `"Google"`, `"Alibaba"`).
+  public let vendor: String
+
+  /// Vendor's website URL.
+  public let vendorURL: URL
+
+  /// Direct download URL for the GGUF model file.
+  public let downloadURL: URL
+
+  /// On-disk filename (e.g., `"gemma-4-E2B-it-Q4_K_M.gguf"`).
+  ///
+  /// Must match `^[A-Za-z0-9._-]+\.gguf$`. Validated at init time via `precondition`.
+  public let fileName: String
+
+  /// Expected file size in bytes, used to verify download completeness.
+  public let fileSize: Int64
+
+  /// Lowercase hex SHA-256 digest for integrity verification after download.
+  public let sha256: String
+
+  /// Generation stop sentinel appended by the model's tokenizer
+  /// (e.g., `"<|im_end|>"` for Gemma/Llama chat format).
+  public let stopSequence: String
+
+  /// Minimum physical RAM required to load and run the model (bytes).
+  public let minRAM: UInt64
+
+  /// HuggingFace model page or equivalent documentation URL.
+  public let modelInfoURL: URL
+
+  /// Optional suffix appended to the system prompt for models that require it
+  /// (e.g., `"/no_think"` for Qwen thinking-mode suppression). `nil` for models
+  /// that need no suffix.
+  public let systemPromptSuffix: String?
+
+  /// Returns `true` iff `name` matches `^[A-Za-z0-9._-]+\.gguf$`.
+  ///
+  /// Use this to validate a candidate filename before constructing a `ModelDescriptor`.
+  public static func isValidFileName(_ name: String) -> Bool {
+    let pattern = #"^[A-Za-z0-9._-]+\.gguf$"#
+    return name.range(of: pattern, options: .regularExpression) != nil
+  }
+
+  /// Creates a new `ModelDescriptor` with all fields.
+  ///
+  /// - Precondition: `fileName` must match `^[A-Za-z0-9._-]+\.gguf$`.
+  public init(
+    id: ModelID,
+    displayName: String,
+    vendor: String,
+    vendorURL: URL,
+    downloadURL: URL,
+    fileName: String,
+    fileSize: Int64,
+    sha256: String,
+    stopSequence: String,
+    minRAM: UInt64,
+    modelInfoURL: URL,
+    systemPromptSuffix: String?
+  ) {
+    precondition(
+      Self.isValidFileName(fileName),
+      "ModelDescriptor.fileName must match ^[A-Za-z0-9._-]+\\.gguf$ (got: \(fileName))"
+    )
+    self.id = id
+    self.displayName = displayName
+    self.vendor = vendor
+    self.vendorURL = vendorURL
+    self.downloadURL = downloadURL
+    self.fileName = fileName
+    self.fileSize = fileSize
+    self.sha256 = sha256
+    self.stopSequence = stopSequence
+    self.minRAM = minRAM
+    self.modelInfoURL = modelInfoURL
+    self.systemPromptSuffix = systemPromptSuffix
+  }
+}

--- a/Pastura/Pastura/PasturaApp.swift
+++ b/Pastura/Pastura/PasturaApp.swift
@@ -285,6 +285,10 @@ private struct RootView: View {
         return
       }
     #endif
+    // Fail-fast on catalog collisions at the earliest possible point so
+    // duplicate ids / fileNames crash in dev rather than corrupting
+    // ModelManager.state lookups or filesystem paths silently at runtime.
+    ModelRegistry.validateNoCollisions()
     #if targetEnvironment(simulator)
       // On simulator, use OllamaService directly — no model download needed.
       do {
@@ -312,16 +316,22 @@ private struct RootView: View {
   }
 
   private func finalizeInit(modelPath: String) async {
+    // `activeDescriptor` is guaranteed non-nil by `ModelManager.resolveInitialActiveID`
+    // (it always returns a catalog id when the catalog is non-empty, and
+    // `ModelRegistry.validateNoCollisions()` in `initialize()` rejects an empty
+    // production catalog upstream). Surface a fatal error rather than silently
+    // falling back to hardcoded Gemma values so future regressions in the
+    // catalog wiring fail loudly.
+    guard let descriptor = modelManager.activeDescriptor else {
+      appState = .error("No active model descriptor resolvable from catalog")
+      return
+    }
     do {
-      // Build LlamaCppService with per-descriptor parameters. If the active
-      // descriptor cannot be resolved (only reachable with an empty catalog —
-      // not a production scenario), fall back to init defaults.
-      let descriptor = modelManager.activeDescriptor
       let llm = LlamaCppService(
         modelPath: modelPath,
-        stopSequence: descriptor?.stopSequence ?? "<|im_end|>",
-        modelIdentifier: descriptor?.displayName ?? "Gemma 4 E2B (Q4_K_M)",
-        systemPromptSuffix: descriptor?.systemPromptSuffix
+        stopSequence: descriptor.stopSequence,
+        modelIdentifier: descriptor.displayName,
+        systemPromptSuffix: descriptor.systemPromptSuffix
       )
       let deps = try AppDependencies.production(llmService: llm)
       // Register BG task handler early so iOS 26+ can launch us in background.

--- a/Pastura/Pastura/PasturaApp.swift
+++ b/Pastura/Pastura/PasturaApp.swift
@@ -313,7 +313,16 @@ private struct RootView: View {
 
   private func finalizeInit(modelPath: String) async {
     do {
-      let llm = LlamaCppService(modelPath: modelPath)
+      // Build LlamaCppService with per-descriptor parameters. If the active
+      // descriptor cannot be resolved (only reachable with an empty catalog —
+      // not a production scenario), fall back to init defaults.
+      let descriptor = modelManager.activeDescriptor
+      let llm = LlamaCppService(
+        modelPath: modelPath,
+        stopSequence: descriptor?.stopSequence ?? "<|im_end|>",
+        modelIdentifier: descriptor?.displayName ?? "Gemma 4 E2B (Q4_K_M)",
+        systemPromptSuffix: descriptor?.systemPromptSuffix
+      )
       let deps = try AppDependencies.production(llmService: llm)
       // Register BG task handler early so iOS 26+ can launch us in background.
       deps.backgroundManager.register()

--- a/Pastura/Pastura/PasturaApp.swift
+++ b/Pastura/Pastura/PasturaApp.swift
@@ -124,7 +124,7 @@ private struct RootView: View {
 
       case .needsModelDownload:
         DemoReplayHostView(modelManager: modelManager)
-          .onChange(of: modelManager.state) { _, newState in
+          .onChange(of: modelManager.activeState) { _, newState in
             if case .ready(let modelPath) = newState {
               Task { await finalizeInit(modelPath: modelPath) }
             }
@@ -299,7 +299,7 @@ private struct RootView: View {
       }
     #else
       modelManager.checkModelStatus()
-      switch modelManager.state {
+      switch modelManager.activeState {
       case .ready(let modelPath):
         await finalizeInit(modelPath: modelPath)
       case .unsupportedDevice, .notDownloaded, .error:

--- a/Pastura/Pastura/Views/ModelDownload/DemoReplayHostView.swift
+++ b/Pastura/Pastura/Views/ModelDownload/DemoReplayHostView.swift
@@ -49,7 +49,7 @@ struct DemoReplayHostView: View {
       .onChange(of: scenePhase) { _, newPhase in
         handleScenePhase(newPhase)
       }
-      .onChange(of: modelManager.state) { _, newState in
+      .onChange(of: modelManager.activeState) { _, newState in
         handleModelStateChange(newState)
       }
   }
@@ -57,7 +57,7 @@ struct DemoReplayHostView: View {
   @ViewBuilder
   private var currentView: some View {
     switch Self.fallbackBranch(
-      state: modelManager.state,
+      state: modelManager.activeState,
       demosCount: sources.count,
       replayHadStarted: replayHadStarted,
       isCellular: isCellular) {
@@ -129,9 +129,9 @@ struct DemoReplayHostView: View {
       }
 
       PromoCard(
-        modelState: modelManager.state,
+        modelState: modelManager.activeState,
         replayHadStarted: replayHadStarted,
-        onRetry: { modelManager.startDownload() })
+        onRetry: { modelManager.startActiveDownload() })
     }
   }
 

--- a/Pastura/Pastura/Views/ModelDownload/ModelDownloadView.swift
+++ b/Pastura/Pastura/Views/ModelDownload/ModelDownloadView.swift
@@ -21,7 +21,7 @@ struct ModelDownloadView: View {
 
   @ViewBuilder
   private var content: some View {
-    switch modelManager.state {
+    switch modelManager.activeState {
     case .checking:
       ProgressView("Checking device...")
 
@@ -82,7 +82,7 @@ struct ModelDownloadView: View {
         .foregroundStyle(.secondary)
         .multilineTextAlignment(.center)
       Button {
-        modelManager.startDownload()
+        modelManager.startActiveDownload()
       } label: {
         Label("Download Model", systemImage: "arrow.down.circle.fill")
           .frame(maxWidth: .infinity)
@@ -109,7 +109,7 @@ struct ModelDownloadView: View {
         .font(.caption)
         .foregroundStyle(.secondary)
       Button("Cancel") {
-        modelManager.cancelDownload()
+        modelManager.cancelActiveDownload()
       }
       .foregroundStyle(.red)
     }
@@ -137,7 +137,7 @@ struct ModelDownloadView: View {
         .foregroundStyle(.secondary)
         .multilineTextAlignment(.center)
       Button {
-        modelManager.startDownload()
+        modelManager.startActiveDownload()
       } label: {
         Label("Retry", systemImage: "arrow.clockwise")
           .frame(maxWidth: .infinity)

--- a/Pastura/PasturaTests/App/ModelManagerTests+MultiModel.swift
+++ b/Pastura/PasturaTests/App/ModelManagerTests+MultiModel.swift
@@ -15,9 +15,9 @@ extension ModelManagerTests {
 
   @Test("state dict seeds an entry for every catalog descriptor at init")
   func stateSeedsAllCatalogDescriptors() {
-    let d1 = makeTestDescriptor(id: "a", fileName: "a.gguf")
-    let d2 = makeTestDescriptor(id: "b", fileName: "b.gguf")
-    let sut = makeSUT(catalog: [d1, d2])
+    let first = makeTestDescriptor(id: "a", fileName: "a.gguf")
+    let second = makeTestDescriptor(id: "b", fileName: "b.gguf")
+    let sut = makeSUT(catalog: [first, second])
     #expect(sut.state["a"] == .checking)
     #expect(sut.state["b"] == .checking)
     #expect(sut.state.count == 2)
@@ -25,9 +25,9 @@ extension ModelManagerTests {
 
   @Test("unsupportedDevice state applies to every catalog descriptor")
   func unsupportedDeviceAppliesToAllCatalogDescriptors() {
-    let d1 = makeTestDescriptor(id: "a", fileName: "a.gguf")
-    let d2 = makeTestDescriptor(id: "b", fileName: "b.gguf")
-    let sut = makeSUT(physicalMemory: 5_500_000_000, catalog: [d1, d2])
+    let first = makeTestDescriptor(id: "a", fileName: "a.gguf")
+    let second = makeTestDescriptor(id: "b", fileName: "b.gguf")
+    let sut = makeSUT(physicalMemory: 5_500_000_000, catalog: [first, second])
     sut.checkModelStatus()
     #expect(sut.state["a"] == .unsupportedDevice)
     #expect(sut.state["b"] == .unsupportedDevice)
@@ -105,14 +105,14 @@ extension ModelManagerTests {
 
   @Test("startDownload is rejected when another descriptor is already downloading")
   func sequentialDownloadPolicyRejectsSecondStart() async {
-    let d1 = makeTestDescriptor(id: "a", fileName: "a.gguf")
-    let d2 = makeTestDescriptor(id: "b", fileName: "b.gguf")
-    let sut = makeSUT(catalog: [d1, d2])
+    let first = makeTestDescriptor(id: "a", fileName: "a.gguf")
+    let second = makeTestDescriptor(id: "b", fileName: "b.gguf")
+    let sut = makeSUT(catalog: [first, second])
     defer {
-      sut.cancelDownload(descriptor: d1)
-      for d in [d1, d2] {
-        try? FileManager.default.removeItem(at: sut.modelFileURL(for: d))
-        try? FileManager.default.removeItem(at: sut.downloadFileURL(for: d))
+      sut.cancelDownload(descriptor: first)
+      for descriptor in [first, second] {
+        try? FileManager.default.removeItem(at: sut.modelFileURL(for: descriptor))
+        try? FileManager.default.removeItem(at: sut.downloadFileURL(for: descriptor))
       }
     }
 
@@ -121,12 +121,12 @@ extension ModelManagerTests {
     #expect(sut.state["b"] == .notDownloaded)
 
     // Start A — synchronously transitions to .downloading BEFORE the Task runs
-    sut.startDownload(descriptor: d1)
+    sut.startDownload(descriptor: first)
     #expect(sut.isAnyDownloadInProgress)
 
     // Attempt B — must be rejected (policy guard), state stays .notDownloaded
     let bStateBefore = sut.state["b"]
-    sut.startDownload(descriptor: d2)
+    sut.startDownload(descriptor: second)
     #expect(sut.state["b"] == bStateBefore)
   }
 
@@ -135,9 +135,9 @@ extension ModelManagerTests {
   @Test("setActiveModel accepts known id and persists to UserDefaults")
   func setActiveModelPersistsKnownID() {
     let defaults = Self.isolatedUserDefaults()
-    let d1 = makeTestDescriptor(id: "a", fileName: "a.gguf")
-    let d2 = makeTestDescriptor(id: "b", fileName: "b.gguf")
-    let sut = makeSUT(catalog: [d1, d2], userDefaults: defaults)
+    let first = makeTestDescriptor(id: "a", fileName: "a.gguf")
+    let second = makeTestDescriptor(id: "b", fileName: "b.gguf")
+    let sut = makeSUT(catalog: [first, second], userDefaults: defaults)
 
     sut.setActiveModel("b")
     #expect(sut.activeModelID == "b")
@@ -146,9 +146,9 @@ extension ModelManagerTests {
 
   @Test("setActiveModel ignores unknown id (activeModelID unchanged)")
   func setActiveModelIgnoresUnknownID() {
-    let d1 = makeTestDescriptor(id: "a", fileName: "a.gguf")
-    let d2 = makeTestDescriptor(id: "b", fileName: "b.gguf")
-    let sut = makeSUT(catalog: [d1, d2])
+    let first = makeTestDescriptor(id: "a", fileName: "a.gguf")
+    let second = makeTestDescriptor(id: "b", fileName: "b.gguf")
+    let sut = makeSUT(catalog: [first, second])
     let initialActive = sut.activeModelID
 
     sut.setActiveModel("non-existent")
@@ -158,11 +158,11 @@ extension ModelManagerTests {
   @Test("init resumes persisted activeModelID when it maps to the catalog")
   func initResumesPersistedActiveID() {
     let defaults = Self.isolatedUserDefaults()
-    let d1 = makeTestDescriptor(id: "a", fileName: "a.gguf")
-    let d2 = makeTestDescriptor(id: "b", fileName: "b.gguf")
+    let first = makeTestDescriptor(id: "a", fileName: "a.gguf")
+    let second = makeTestDescriptor(id: "b", fileName: "b.gguf")
     defaults.set("b", forKey: ModelManager.activeModelIDKey)
 
-    let sut = makeSUT(catalog: [d1, d2], userDefaults: defaults)
+    let sut = makeSUT(catalog: [first, second], userDefaults: defaults)
     #expect(sut.activeModelID == "b")
   }
 
@@ -170,9 +170,9 @@ extension ModelManagerTests {
 
   @Test("resolveInitialActiveID returns persisted id when present in catalog")
   func resolveInitialActiveID_prefersPersistedValid() {
-    let d1 = makeTestDescriptor(id: "a", fileName: "a.gguf")
-    let d2 = makeTestDescriptor(id: "b", fileName: "b.gguf")
-    let id = ModelManager.resolveInitialActiveID(persistedID: "b", catalog: [d1, d2])
+    let first = makeTestDescriptor(id: "a", fileName: "a.gguf")
+    let second = makeTestDescriptor(id: "b", fileName: "b.gguf")
+    let id = ModelManager.resolveInitialActiveID(persistedID: "b", catalog: [first, second])
     #expect(id == "b")
   }
 
@@ -187,9 +187,9 @@ extension ModelManagerTests {
 
   @Test("resolveInitialActiveID falls back to catalog.first when default is not in catalog")
   func resolveInitialActiveID_fallsBackToFirstWhenDefaultAbsent() {
-    let d1 = makeTestDescriptor(id: "test-x", fileName: "test-x.gguf")
-    let d2 = makeTestDescriptor(id: "test-y", fileName: "test-y.gguf")
-    let id = ModelManager.resolveInitialActiveID(persistedID: nil, catalog: [d1, d2])
+    let first = makeTestDescriptor(id: "test-x", fileName: "test-x.gguf")
+    let second = makeTestDescriptor(id: "test-y", fileName: "test-y.gguf")
+    let id = ModelManager.resolveInitialActiveID(persistedID: nil, catalog: [first, second])
     #expect(id == "test-x")
   }
 

--- a/Pastura/PasturaTests/App/ModelManagerTests+MultiModel.swift
+++ b/Pastura/PasturaTests/App/ModelManagerTests+MultiModel.swift
@@ -1,0 +1,201 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+// MARK: - Tests (joins the serialized `ModelManagerTests` suite)
+//
+// Multi-descriptor specific coverage: state seeding, shared RAM floor across
+// descriptors, Gemma legacy filename compat, sequential download policy,
+// active-model persistence, and `resolveInitialActiveID` resolution logic.
+
+extension ModelManagerTests {
+
+  // MARK: - State Seeding
+
+  @Test("state dict seeds an entry for every catalog descriptor at init")
+  func stateSeedsAllCatalogDescriptors() {
+    let d1 = makeTestDescriptor(id: "a", fileName: "a.gguf")
+    let d2 = makeTestDescriptor(id: "b", fileName: "b.gguf")
+    let sut = makeSUT(catalog: [d1, d2])
+    #expect(sut.state["a"] == .checking)
+    #expect(sut.state["b"] == .checking)
+    #expect(sut.state.count == 2)
+  }
+
+  @Test("unsupportedDevice state applies to every catalog descriptor")
+  func unsupportedDeviceAppliesToAllCatalogDescriptors() {
+    let d1 = makeTestDescriptor(id: "a", fileName: "a.gguf")
+    let d2 = makeTestDescriptor(id: "b", fileName: "b.gguf")
+    let sut = makeSUT(physicalMemory: 5_500_000_000, catalog: [d1, d2])
+    sut.checkModelStatus()
+    #expect(sut.state["a"] == .unsupportedDevice)
+    #expect(sut.state["b"] == .unsupportedDevice)
+  }
+
+  // MARK: - Gemma Legacy Compat
+  //
+  // Upgrade contract: existing TestFlight users have a fully-downloaded
+  // Gemma 4 E2B (Q4_K_M) at `Application Support/gemma-4-E2B-it-Q4_K_M.gguf`
+  // (and possibly a partial `.download` in Caches/). The multi-model refactor
+  // must NOT force these users to re-download 3.1 GB.
+
+  @Test("Gemma legacy fileName resolves to Application Support path")
+  func gemmaLegacyModelFileURLPath() {
+    let descriptor = makeTestDescriptor(fileName: "gemma-4-E2B-it-Q4_K_M.gguf")
+    let sut = makeSUT(catalog: [descriptor])
+    let modelURL = sut.modelFileURL(for: descriptor)
+    #expect(modelURL.lastPathComponent == "gemma-4-E2B-it-Q4_K_M.gguf")
+    #expect(modelURL.path.contains("Application Support"))
+  }
+
+  @Test("Gemma legacy partial filename resolves to Caches/<name>.download")
+  func gemmaLegacyDownloadFileURLPath() {
+    let descriptor = makeTestDescriptor(fileName: "gemma-4-E2B-it-Q4_K_M.gguf")
+    let sut = makeSUT(catalog: [descriptor])
+    let downloadURL = sut.downloadFileURL(for: descriptor)
+    #expect(downloadURL.lastPathComponent == "gemma-4-E2B-it-Q4_K_M.gguf.download")
+    #expect(downloadURL.path.contains("Caches"))
+  }
+
+  @Test("Gemma legacy completed file is auto-recognized as .ready without re-download")
+  func gemmaLegacyCompletedFileAutoRecognized() throws {
+    let descriptor = makeTestDescriptor(
+      fileName: "gemma-4-E2B-it-Q4_K_M.gguf",
+      fileSize: 100
+    )
+    let sut = makeSUT(catalog: [descriptor])
+
+    // Pre-populate a file matching the exact legacy filename and size
+    let modelURL = sut.modelFileURL(for: descriptor)
+    try FileManager.default.createDirectory(
+      at: modelURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+    try Data(repeating: 0x42, count: 100).write(to: modelURL)
+    defer { try? FileManager.default.removeItem(at: modelURL) }
+
+    sut.checkModelStatus()
+
+    // State resolves to .ready WITHOUT invoking a download. This is the
+    // load-bearing assertion — if this ever regresses, every existing
+    // TestFlight user faces a 3.1 GB re-download on upgrade.
+    #expect(sut.state[descriptor.id] == .ready(modelPath: modelURL.path))
+  }
+
+  @Test("Gemma legacy completed file with size mismatch is removed (not re-blessed)")
+  func gemmaLegacyCompletedFileWithWrongSizeIsRejected() throws {
+    let descriptor = makeTestDescriptor(
+      fileName: "gemma-4-E2B-it-Q4_K_M.gguf",
+      fileSize: 100
+    )
+    let sut = makeSUT(catalog: [descriptor])
+
+    // Place a file of the wrong size — simulates a corrupted / truncated legacy file
+    let modelURL = sut.modelFileURL(for: descriptor)
+    try FileManager.default.createDirectory(
+      at: modelURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+    try Data(repeating: 0x42, count: 42).write(to: modelURL)
+
+    sut.checkModelStatus()
+
+    #expect(sut.state[descriptor.id] == .notDownloaded)
+    #expect(!FileManager.default.fileExists(atPath: modelURL.path))
+  }
+
+  // MARK: - Sequential Download Policy
+
+  @Test("startDownload is rejected when another descriptor is already downloading")
+  func sequentialDownloadPolicyRejectsSecondStart() async {
+    let d1 = makeTestDescriptor(id: "a", fileName: "a.gguf")
+    let d2 = makeTestDescriptor(id: "b", fileName: "b.gguf")
+    let sut = makeSUT(catalog: [d1, d2])
+    defer {
+      sut.cancelDownload(descriptor: d1)
+      for d in [d1, d2] {
+        try? FileManager.default.removeItem(at: sut.modelFileURL(for: d))
+        try? FileManager.default.removeItem(at: sut.downloadFileURL(for: d))
+      }
+    }
+
+    sut.checkModelStatus()
+    #expect(sut.state["a"] == .notDownloaded)
+    #expect(sut.state["b"] == .notDownloaded)
+
+    // Start A — synchronously transitions to .downloading BEFORE the Task runs
+    sut.startDownload(descriptor: d1)
+    #expect(sut.isAnyDownloadInProgress)
+
+    // Attempt B — must be rejected (policy guard), state stays .notDownloaded
+    let bStateBefore = sut.state["b"]
+    sut.startDownload(descriptor: d2)
+    #expect(sut.state["b"] == bStateBefore)
+  }
+
+  // MARK: - setActiveModel
+
+  @Test("setActiveModel accepts known id and persists to UserDefaults")
+  func setActiveModelPersistsKnownID() {
+    let defaults = Self.isolatedUserDefaults()
+    let d1 = makeTestDescriptor(id: "a", fileName: "a.gguf")
+    let d2 = makeTestDescriptor(id: "b", fileName: "b.gguf")
+    let sut = makeSUT(catalog: [d1, d2], userDefaults: defaults)
+
+    sut.setActiveModel("b")
+    #expect(sut.activeModelID == "b")
+    #expect(defaults.string(forKey: ModelManager.activeModelIDKey) == "b")
+  }
+
+  @Test("setActiveModel ignores unknown id (activeModelID unchanged)")
+  func setActiveModelIgnoresUnknownID() {
+    let d1 = makeTestDescriptor(id: "a", fileName: "a.gguf")
+    let d2 = makeTestDescriptor(id: "b", fileName: "b.gguf")
+    let sut = makeSUT(catalog: [d1, d2])
+    let initialActive = sut.activeModelID
+
+    sut.setActiveModel("non-existent")
+    #expect(sut.activeModelID == initialActive)
+  }
+
+  @Test("init resumes persisted activeModelID when it maps to the catalog")
+  func initResumesPersistedActiveID() {
+    let defaults = Self.isolatedUserDefaults()
+    let d1 = makeTestDescriptor(id: "a", fileName: "a.gguf")
+    let d2 = makeTestDescriptor(id: "b", fileName: "b.gguf")
+    defaults.set("b", forKey: ModelManager.activeModelIDKey)
+
+    let sut = makeSUT(catalog: [d1, d2], userDefaults: defaults)
+    #expect(sut.activeModelID == "b")
+  }
+
+  // MARK: - resolveInitialActiveID (static)
+
+  @Test("resolveInitialActiveID returns persisted id when present in catalog")
+  func resolveInitialActiveID_prefersPersistedValid() {
+    let d1 = makeTestDescriptor(id: "a", fileName: "a.gguf")
+    let d2 = makeTestDescriptor(id: "b", fileName: "b.gguf")
+    let id = ModelManager.resolveInitialActiveID(persistedID: "b", catalog: [d1, d2])
+    #expect(id == "b")
+  }
+
+  @Test("resolveInitialActiveID falls back to defaultInitialModelID when persisted is unknown")
+  func resolveInitialActiveID_fallsBackToDefault() {
+    let id = ModelManager.resolveInitialActiveID(
+      persistedID: "unknown",
+      catalog: ModelRegistry.catalog
+    )
+    #expect(id == ModelRegistry.defaultInitialModelID)
+  }
+
+  @Test("resolveInitialActiveID falls back to catalog.first when default is not in catalog")
+  func resolveInitialActiveID_fallsBackToFirstWhenDefaultAbsent() {
+    let d1 = makeTestDescriptor(id: "test-x", fileName: "test-x.gguf")
+    let d2 = makeTestDescriptor(id: "test-y", fileName: "test-y.gguf")
+    let id = ModelManager.resolveInitialActiveID(persistedID: nil, catalog: [d1, d2])
+    #expect(id == "test-x")
+  }
+
+  @Test("resolveInitialActiveID returns empty string for empty catalog")
+  func resolveInitialActiveID_emptyCatalogReturnsEmpty() {
+    let id = ModelManager.resolveInitialActiveID(persistedID: "anything", catalog: [])
+    #expect(id == "")
+  }
+}

--- a/Pastura/PasturaTests/App/ModelManagerTests+ProgressRegression.swift
+++ b/Pastura/PasturaTests/App/ModelManagerTests+ProgressRegression.swift
@@ -47,22 +47,26 @@ extension ModelManagerTests {
     // ModelManager must explicitly bring `state` to 1.0 before SHA256 verification
     // so the user sees 100% rather than stalling at the last sub-1.0 sample
     // during the ~2 s SHA256 hash on a 3 GB file.
+    //
+    // Use SHA256 verification (via descriptor) to exercise the post-download
+    // path that includes the explicit `state = .downloading(progress: 1.0)`
+    // transition before verification begins.
+    let expectedHash = "9a5670771141349931d69d6eb982faa01def544dc17a161ef83b3277fb7c0c3c"
+    let descriptor = makeTestDescriptor(sha256: expectedHash)
     let sut = makeSUT(
       downloader: SubOneProgressMockDownloader(simulateBytes: 1000),
-      // Use SHA256 verification to exercise the post-download path that
-      // includes the explicit `state = .downloading(progress: 1.0)` transition.
-      expectedSHA256: "9a5670771141349931d69d6eb982faa01def544dc17a161ef83b3277fb7c0c3c"
+      catalog: [descriptor]
     )
     sut.checkModelStatus()
-    #expect(sut.state == .notDownloaded)
+    #expect(sut.activeState == .notDownloaded)
 
-    let snapshots = StateSnapshots()
+    let snapshots = StateSnapshots(descriptorID: descriptor.id)
     snapshots.startObserving(sut)
 
-    await sut.downloadModel()
+    await sut.downloadModel(descriptor: descriptor)
     defer {
-      try? FileManager.default.removeItem(at: sut.modelFileURL)
-      try? FileManager.default.removeItem(at: sut.downloadFileURL)
+      try? FileManager.default.removeItem(at: sut.modelFileURL(for: descriptor))
+      try? FileManager.default.removeItem(at: sut.downloadFileURL(for: descriptor))
     }
 
     // Let the `StateSnapshots` re-arm Tasks settle. Progress callbacks were
@@ -72,8 +76,8 @@ extension ModelManagerTests {
     // Five yields is empirical headroom over the typical one-or-two it takes.
     for _ in 0..<5 { await Task.yield() }
 
-    guard case .ready = sut.state else {
-      Issue.record("Expected .ready but got \(sut.state)")
+    guard case .ready = sut.activeState else {
+      Issue.record("Expected .ready but got \(sut.activeState)")
       return
     }
 
@@ -87,18 +91,23 @@ extension ModelManagerTests {
 
 // MARK: - Helpers
 
-/// Re-arming `withObservationTracking` collector for `ModelManager.state`.
-/// Each fired change records the current progress value (if any) and re-arms
-/// tracking for the next change. Lives on MainActor because it reads/writes
-/// `ModelManager.state`.
+/// Re-arming `withObservationTracking` collector for a specific descriptor's
+/// state in `ModelManager.state`. Each fired change records the current
+/// progress value (if any) and re-arms tracking for the next change. Lives
+/// on MainActor because it reads `ModelManager.state`.
 @MainActor
 private final class StateSnapshots {
   private(set) var progresses: [Double] = []
+  let descriptorID: ModelID
+
+  init(descriptorID: ModelID) {
+    self.descriptorID = descriptorID
+  }
 
   func startObserving(_ manager: ModelManager) {
-    record(manager.state)
+    record(manager.state[descriptorID])
     withObservationTracking {
-      _ = manager.state
+      _ = manager.state[descriptorID]
     } onChange: { [weak self, weak manager] in
       // onChange fires synchronously on the mutating actor; re-arm via a Task
       // so the next mutation is captured.
@@ -109,7 +118,7 @@ private final class StateSnapshots {
     }
   }
 
-  private func record(_ state: ModelState) {
+  private func record(_ state: ModelState?) {
     if case .downloading(let progress) = state {
       progresses.append(progress)
     }

--- a/Pastura/PasturaTests/App/ModelManagerTests+SHA256.swift
+++ b/Pastura/PasturaTests/App/ModelManagerTests+SHA256.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+// MARK: - Tests (joins the serialized `ModelManagerTests` suite)
+//
+// Sibling-file extension per .claude/rules/testing.md. A standalone `@Suite`
+// would race against `ModelManagerTests` on shared filesystem paths because
+// Swift Testing runs suites in parallel by default — `.serialized` only
+// orders tests *within* a suite.
+
+extension ModelManagerTests {
+
+  @Test("computeSHA256 returns correct hash for known data")
+  func computeSHA256ReturnsCorrectHash() throws {
+    let tempFile = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString)
+    let data = Data(repeating: 0x42, count: 1000)
+    try data.write(to: tempFile)
+    defer { try? FileManager.default.removeItem(at: tempFile) }
+
+    let hash = try ModelManager.computeSHA256(of: tempFile)
+    // Precomputed: SHA256 of 1000 bytes of 0x42
+    #expect(hash == "9a5670771141349931d69d6eb982faa01def544dc17a161ef83b3277fb7c0c3c")
+  }
+
+  @Test("downloadModel transitions to ready when SHA256 matches")
+  func downloadSuccessWithMatchingSHA256() async {
+    // MockModelDownloader writes 1000 bytes of 0x42
+    let expectedHash = "9a5670771141349931d69d6eb982faa01def544dc17a161ef83b3277fb7c0c3c"
+    let descriptor = makeTestDescriptor(sha256: expectedHash)
+    let sut = makeSUT(
+      downloader: MockModelDownloader(simulateBytes: 1000),
+      catalog: [descriptor]
+    )
+    sut.checkModelStatus()
+    #expect(sut.activeState == .notDownloaded)
+
+    await sut.downloadModel(descriptor: descriptor)
+    defer {
+      try? FileManager.default.removeItem(at: sut.modelFileURL(for: descriptor))
+      try? FileManager.default.removeItem(at: sut.downloadFileURL(for: descriptor))
+    }
+
+    if case .ready = sut.activeState {
+      // Success
+    } else {
+      Issue.record("Expected .ready but got \(sut.activeState)")
+    }
+  }
+
+  @Test("downloadModel transitions to error when SHA256 mismatches")
+  func downloadFailureWithMismatchingSHA256() async {
+    let wrongHash = "0000000000000000000000000000000000000000000000000000000000000000"
+    let descriptor = makeTestDescriptor(sha256: wrongHash)
+    let sut = makeSUT(
+      downloader: MockModelDownloader(simulateBytes: 1000),
+      catalog: [descriptor]
+    )
+    sut.checkModelStatus()
+    #expect(sut.activeState == .notDownloaded)
+
+    await sut.downloadModel(descriptor: descriptor)
+    let downloadURL = sut.downloadFileURL(for: descriptor)
+    defer {
+      try? FileManager.default.removeItem(at: sut.modelFileURL(for: descriptor))
+      try? FileManager.default.removeItem(at: downloadURL)
+    }
+
+    if case .error(let message) = sut.activeState {
+      #expect(message.contains("verification failed"))
+    } else {
+      Issue.record("Expected .error but got \(sut.activeState)")
+    }
+
+    // .download file should be deleted on mismatch
+    #expect(!FileManager.default.fileExists(atPath: downloadURL.path))
+  }
+
+  @Test("downloadModel skips SHA256 verification when descriptor sha256 is empty")
+  func downloadSuccessWithEmptySHA256() async {
+    let descriptor = makeTestDescriptor(sha256: "")  // empty = skip
+    let sut = makeSUT(
+      downloader: MockModelDownloader(simulateBytes: 100),
+      catalog: [descriptor]
+    )
+    sut.checkModelStatus()
+    #expect(sut.activeState == .notDownloaded)
+
+    await sut.downloadModel(descriptor: descriptor)
+    defer {
+      try? FileManager.default.removeItem(at: sut.modelFileURL(for: descriptor))
+      try? FileManager.default.removeItem(at: sut.downloadFileURL(for: descriptor))
+    }
+
+    if case .ready = sut.activeState {
+      // Success — no SHA256 check performed
+    } else {
+      Issue.record("Expected .ready but got \(sut.activeState)")
+    }
+  }
+}

--- a/Pastura/PasturaTests/App/ModelManagerTests.swift
+++ b/Pastura/PasturaTests/App/ModelManagerTests.swift
@@ -42,140 +42,198 @@ struct MockModelDownloader: ModelDownloader, Sendable {
 @MainActor
 struct ModelManagerTests {
 
-  // Internal (not `private`) so sibling test files extending this suite
-  // (e.g., `ModelManagerTests+ProgressRegression.swift`) can construct an SUT.
+  // MARK: - SUT Helpers
+  //
+  // Helpers are `internal` (not `private`) so sibling-file extensions
+  // (`ModelManagerTests+ProgressRegression.swift`, `ModelManagerTests+MultiModel.swift`)
+  // can call them. Per .claude/rules/testing.md — widening to module-internal
+  // is contained because the test target is its own module.
+
+  /// Default filename for the test Gemma descriptor. Matches the legacy constant
+  /// `gemma-4-E2B-it-Q4_K_M.gguf` to exercise upgrade-compat paths on the
+  /// standard test SUT.
+  static let testGemmaFileName = "gemma-4-E2B-it-Q4_K_M.gguf"
+
+  /// Convenience factory for a minimal `ModelDescriptor` suitable for most
+  /// tests. `fileSize: 0` / `sha256: ""` skip size / SHA validation — pass
+  /// explicit values to exercise the validation paths.
+  func makeTestDescriptor(
+    id: ModelID = "test-gemma",
+    fileName: String = testGemmaFileName,
+    fileSize: Int64 = 0,
+    sha256: String = "",
+    systemPromptSuffix: String? = nil
+  ) -> ModelDescriptor {
+    ModelDescriptor(
+      id: id,
+      displayName: "Test Model",
+      vendor: "Test Vendor",
+      vendorURL: URL(string: "https://example.com")!,
+      downloadURL: URL(string: "https://example.com/\(fileName)")!,
+      fileName: fileName,
+      fileSize: fileSize,
+      sha256: sha256,
+      stopSequence: "<|im_end|>",
+      minRAM: 6_500_000_000,
+      modelInfoURL: URL(string: "https://example.com")!,
+      systemPromptSuffix: systemPromptSuffix
+    )
+  }
+
+  /// Builds a per-test isolated `UserDefaults` instance. The returned suite
+  /// writes to disk but uses a unique name so no test leaks state to another.
+  static func isolatedUserDefaults() -> UserDefaults {
+    let name = "ModelManagerTests-\(UUID().uuidString)"
+    // Safe: `UserDefaults(suiteName:)` only returns nil for reserved names
+    // ("NSGlobalDomain", "NSRegistrationDomain"); a UUID-based name never collides.
+    return UserDefaults(suiteName: name) ?? .standard
+  }
+
   func makeSUT(
     downloader: any ModelDownloader = MockModelDownloader(),
     physicalMemory: UInt64 = 8 * 1024 * 1024 * 1024,
-    expectedFileSize: Int64 = 0,
-    expectedSHA256: String? = nil
+    catalog: [ModelDescriptor]? = nil,
+    userDefaults: UserDefaults? = nil
   ) -> ModelManager {
+    let finalCatalog = catalog ?? [makeTestDescriptor()]
+    let finalDefaults = userDefaults ?? Self.isolatedUserDefaults()
     let sut = ModelManager(
       downloader: downloader,
       fileManager: .default,
       physicalMemory: physicalMemory,
-      expectedFileSize: expectedFileSize,
-      expectedSHA256: expectedSHA256
+      userDefaults: finalDefaults,
+      catalog: finalCatalog
     )
     // Proactively wipe residual files at the shared Application Support /
     // Caches paths. Each per-test `defer { removeItem }` is declared AFTER
-    // `await sut.downloadModel()` — if a download-triggering test crashes
-    // before its defer registers, the model file leaks and every
-    // subsequent `.notDownloaded` assertion in the suite fails
-    // spuriously. The upstream cleanup here breaks that cascade so the
-    // actual failing test surfaces cleanly. Per-test defers are kept as
-    // defense-in-depth for the same-test window and are intentional — do
-    // not remove them as "redundant".
+    // `await sut.downloadModel(...)` — if a download-triggering test crashes
+    // before its defer registers, the model file leaks and every subsequent
+    // `.notDownloaded` assertion in the suite fails spuriously. The upstream
+    // cleanup here breaks that cascade so the actual failing test surfaces
+    // cleanly. Per-test defers are kept as defense-in-depth for the same-test
+    // window and are intentional — do not remove them as "redundant".
     //
-    // First observed on CI post-#186 (sha e650f13) on the macos-26
-    // runner; the underlying CI host-kill is unrelated to filesystem
-    // state (CI OOM; root cause tracked in #189).
-    try? FileManager.default.removeItem(at: sut.modelFileURL)
-    try? FileManager.default.removeItem(at: sut.downloadFileURL)
-    // Loud guard: surface permission / sandbox oddities that `try?` would
-    // otherwise swallow. A silent no-op here would let the cascade recur
-    // invisibly.
-    #expect(!FileManager.default.fileExists(atPath: sut.modelFileURL.path))
-    #expect(!FileManager.default.fileExists(atPath: sut.downloadFileURL.path))
+    // First observed on CI post-#186 (sha e650f13) on the macos-26 runner.
+    for descriptor in finalCatalog {
+      try? FileManager.default.removeItem(at: sut.modelFileURL(for: descriptor))
+      try? FileManager.default.removeItem(at: sut.downloadFileURL(for: descriptor))
+      // Loud guard: surface permission / sandbox oddities that `try?` would
+      // otherwise swallow.
+      #expect(!FileManager.default.fileExists(atPath: sut.modelFileURL(for: descriptor).path))
+      #expect(!FileManager.default.fileExists(atPath: sut.downloadFileURL(for: descriptor).path))
+    }
     return sut
   }
 
   // MARK: - Device Check
 
-  @Test("checkModelStatus sets unsupportedDevice when RAM < 7 GB threshold")
+  @Test("checkModelStatus sets unsupportedDevice when RAM < 6.5 GB threshold")
   func unsupportedDevice() {
     // 5.5 GB simulates what iOS reports on a 6 GB device
     let sut = makeSUT(physicalMemory: 5_500_000_000)
     sut.checkModelStatus()
-    #expect(sut.state == .unsupportedDevice)
+    #expect(sut.activeState == .unsupportedDevice)
   }
 
   @Test("checkModelStatus sets notDownloaded when model file does not exist")
   func modelNotDownloaded() {
     let sut = makeSUT()
     sut.checkModelStatus()
-    #expect(sut.state == .notDownloaded)
+    #expect(sut.activeState == .notDownloaded)
   }
 
   @Test("checkModelStatus sets ready when model file exists")
   func modelReady() throws {
-    let sut = makeSUT()
+    let descriptor = makeTestDescriptor()
+    let sut = makeSUT(catalog: [descriptor])
 
     // Place a dummy file at the model path
-    let modelPath = sut.modelFileURL
+    let modelPath = sut.modelFileURL(for: descriptor)
     try FileManager.default.createDirectory(
       at: modelPath.deletingLastPathComponent(), withIntermediateDirectories: true)
     FileManager.default.createFile(atPath: modelPath.path, contents: Data("test".utf8))
     defer { try? FileManager.default.removeItem(at: modelPath) }
 
     sut.checkModelStatus()
-    #expect(sut.state == .ready(modelPath: modelPath.path))
+    #expect(sut.activeState == .ready(modelPath: modelPath.path))
   }
 
   // MARK: - Download
 
   @Test("downloadModel transitions from notDownloaded to ready on success")
   func downloadSuccess() async {
+    let descriptor = makeTestDescriptor()
     let sut = makeSUT(
-      downloader: MockModelDownloader(simulateBytes: 100)
+      downloader: MockModelDownloader(simulateBytes: 100),
+      catalog: [descriptor]
     )
     sut.checkModelStatus()
-    #expect(sut.state == .notDownloaded)
+    #expect(sut.activeState == .notDownloaded)
 
-    await sut.downloadModel()
+    await sut.downloadModel(descriptor: descriptor)
     defer {
-      try? FileManager.default.removeItem(at: sut.modelFileURL)
-      try? FileManager.default.removeItem(at: sut.downloadFileURL)
+      try? FileManager.default.removeItem(at: sut.modelFileURL(for: descriptor))
+      try? FileManager.default.removeItem(at: sut.downloadFileURL(for: descriptor))
     }
 
-    if case .ready = sut.state {
+    if case .ready = sut.activeState {
       // Success
     } else {
-      Issue.record("Expected .ready but got \(sut.state)")
+      Issue.record("Expected .ready but got \(sut.activeState)")
     }
   }
 
   @Test("downloadModel transitions to error on download failure")
   func downloadFailure() async {
+    let descriptor = makeTestDescriptor()
     let sut = makeSUT(
-      downloader: MockModelDownloader(error: URLError(.notConnectedToInternet))
+      downloader: MockModelDownloader(error: URLError(.notConnectedToInternet)),
+      catalog: [descriptor]
     )
     sut.checkModelStatus()
-    #expect(sut.state == .notDownloaded)
+    #expect(sut.activeState == .notDownloaded)
 
-    await sut.downloadModel()
+    await sut.downloadModel(descriptor: descriptor)
 
-    if case .error = sut.state {
+    if case .error = sut.activeState {
       // Expected
     } else {
-      Issue.record("Expected .error but got \(sut.state)")
+      Issue.record("Expected .error but got \(sut.activeState)")
     }
   }
 
   @Test("downloadModel is no-op when state is unsupportedDevice")
   func downloadNoOpWhenUnsupported() async {
-    let sut = makeSUT(physicalMemory: 4 * 1024 * 1024 * 1024)
+    let descriptor = makeTestDescriptor()
+    let sut = makeSUT(
+      physicalMemory: 4 * 1024 * 1024 * 1024,
+      catalog: [descriptor]
+    )
     sut.checkModelStatus()
-    #expect(sut.state == .unsupportedDevice)
+    #expect(sut.activeState == .unsupportedDevice)
 
-    await sut.downloadModel()
-    #expect(sut.state == .unsupportedDevice)
+    await sut.downloadModel(descriptor: descriptor)
+    #expect(sut.activeState == .unsupportedDevice)
   }
 
   @Test("downloadModel retries from error state")
   func downloadRetryFromError() async {
-    let sut = makeSUT(downloader: MockModelDownloader(error: URLError(.timedOut)))
+    let descriptor = makeTestDescriptor()
+    let sut = makeSUT(
+      downloader: MockModelDownloader(error: URLError(.timedOut)),
+      catalog: [descriptor]
+    )
     sut.checkModelStatus()
-    await sut.downloadModel()
+    await sut.downloadModel(descriptor: descriptor)
 
-    guard case .error = sut.state else {
+    guard case .error = sut.activeState else {
       Issue.record("Expected .error after first download attempt")
       return
     }
 
     // Second call also fails (same downloader), but verifies it proceeds from .error
-    await sut.downloadModel()
-    if case .error = sut.state {
+    await sut.downloadModel(descriptor: descriptor)
+    if case .error = sut.activeState {
       // Expected
     } else {
       Issue.record("Expected .error on retry with failing downloader")
@@ -185,76 +243,87 @@ struct ModelManagerTests {
   // MARK: - Delete
 
   @Test("deleteModel removes files and sets state to notDownloaded")
-  func deleteModel() throws {
-    let sut = makeSUT()
+  func deleteModelRemovesFiles() throws {
+    let descriptor = makeTestDescriptor()
+    let sut = makeSUT(catalog: [descriptor])
 
     // Create model file
+    let modelURL = sut.modelFileURL(for: descriptor)
     try FileManager.default.createDirectory(
-      at: sut.modelFileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
-    FileManager.default.createFile(atPath: sut.modelFileURL.path, contents: Data("test".utf8))
+      at: modelURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+    FileManager.default.createFile(atPath: modelURL.path, contents: Data("test".utf8))
     sut.checkModelStatus()
-    #expect(sut.state == .ready(modelPath: sut.modelFileURL.path))
+    #expect(sut.activeState == .ready(modelPath: modelURL.path))
 
-    sut.deleteModel()
+    sut.deleteModel(descriptor: descriptor)
 
-    #expect(sut.state == .notDownloaded)
-    #expect(!FileManager.default.fileExists(atPath: sut.modelFileURL.path))
+    #expect(sut.activeState == .notDownloaded)
+    #expect(!FileManager.default.fileExists(atPath: modelURL.path))
   }
 
   // MARK: - Storage Location
 
   @Test("modelFileURL is in Application Support directory")
   func modelFileInApplicationSupport() {
-    let sut = makeSUT()
-    #expect(sut.modelFileURL.path.contains("Application Support"))
-    #expect(!sut.modelFileURL.path.contains("Documents"))
+    let descriptor = makeTestDescriptor()
+    let sut = makeSUT(catalog: [descriptor])
+    let modelURL = sut.modelFileURL(for: descriptor)
+    #expect(modelURL.path.contains("Application Support"))
+    #expect(!modelURL.path.contains("Documents"))
   }
 
   @Test("downloadFileURL is in Caches directory")
   func downloadFileInCaches() {
-    let sut = makeSUT()
-    #expect(sut.downloadFileURL.path.contains("Caches"))
-    #expect(!sut.downloadFileURL.path.contains("Documents"))
+    let descriptor = makeTestDescriptor()
+    let sut = makeSUT(catalog: [descriptor])
+    let downloadURL = sut.downloadFileURL(for: descriptor)
+    #expect(downloadURL.path.contains("Caches"))
+    #expect(!downloadURL.path.contains("Documents"))
   }
 
   // MARK: - iCloud Backup Exclusion
 
   @Test("checkModelStatus sets isExcludedFromBackup on existing model file")
   func checkModelStatusExcludesFromBackup() throws {
-    let sut = makeSUT()
+    let descriptor = makeTestDescriptor()
+    let sut = makeSUT(catalog: [descriptor])
 
     // Create the model directory and file
-    let modelDir = sut.modelFileURL.deletingLastPathComponent()
+    let modelURL = sut.modelFileURL(for: descriptor)
+    let modelDir = modelURL.deletingLastPathComponent()
     try FileManager.default.createDirectory(at: modelDir, withIntermediateDirectories: true)
-    FileManager.default.createFile(atPath: sut.modelFileURL.path, contents: Data("test".utf8))
-    defer { try? FileManager.default.removeItem(at: sut.modelFileURL) }
+    FileManager.default.createFile(atPath: modelURL.path, contents: Data("test".utf8))
+    defer { try? FileManager.default.removeItem(at: modelURL) }
 
     sut.checkModelStatus()
 
-    let values = try sut.modelFileURL.resourceValues(forKeys: [.isExcludedFromBackupKey])
+    let values = try modelURL.resourceValues(forKeys: [.isExcludedFromBackupKey])
     #expect(values.isExcludedFromBackup == true)
   }
 
   @Test("downloadModel sets isExcludedFromBackup on completed model file")
   func downloadSetsExcludeFromBackup() async throws {
+    let descriptor = makeTestDescriptor()
     let sut = makeSUT(
-      downloader: MockModelDownloader(simulateBytes: 100)
+      downloader: MockModelDownloader(simulateBytes: 100),
+      catalog: [descriptor]
     )
     sut.checkModelStatus()
-    #expect(sut.state == .notDownloaded)
+    #expect(sut.activeState == .notDownloaded)
 
-    await sut.downloadModel()
+    await sut.downloadModel(descriptor: descriptor)
+    let modelURL = sut.modelFileURL(for: descriptor)
     defer {
-      try? FileManager.default.removeItem(at: sut.modelFileURL)
-      try? FileManager.default.removeItem(at: sut.downloadFileURL)
+      try? FileManager.default.removeItem(at: modelURL)
+      try? FileManager.default.removeItem(at: sut.downloadFileURL(for: descriptor))
     }
 
-    guard case .ready = sut.state else {
-      Issue.record("Expected .ready but got \(sut.state)")
+    guard case .ready = sut.activeState else {
+      Issue.record("Expected .ready but got \(sut.activeState)")
       return
     }
 
-    let values = try sut.modelFileURL.resourceValues(forKeys: [.isExcludedFromBackupKey])
+    let values = try modelURL.resourceValues(forKeys: [.isExcludedFromBackupKey])
     #expect(values.isExcludedFromBackup == true)
   }
 
@@ -262,96 +331,10 @@ struct ModelManagerTests {
 
   @Test("checkModelStatus boundary: ~7.5 GB (8 GB device) is supported")
   func realWorld8GBDevice() {
-    // iOS reports ~7.5 GB on 8 GB devices; must pass the 7 GB threshold
+    // iOS reports ~7.5 GB on 8 GB devices; must pass the 6.5 GB threshold
     let sut = makeSUT(physicalMemory: 7_500_000_000)
     sut.checkModelStatus()
-    #expect(sut.state != .unsupportedDevice)
-  }
-
-  // MARK: - SHA256
-
-  @Test("computeSHA256 returns correct hash for known data")
-  func computeSHA256ReturnsCorrectHash() throws {
-    let tempFile = FileManager.default.temporaryDirectory
-      .appendingPathComponent(UUID().uuidString)
-    let data = Data(repeating: 0x42, count: 1000)
-    try data.write(to: tempFile)
-    defer { try? FileManager.default.removeItem(at: tempFile) }
-
-    let hash = try ModelManager.computeSHA256(of: tempFile)
-    // Precomputed: SHA256 of 1000 bytes of 0x42
-    #expect(hash == "9a5670771141349931d69d6eb982faa01def544dc17a161ef83b3277fb7c0c3c")
-  }
-
-  @Test("downloadModel transitions to ready when SHA256 matches")
-  func downloadSuccessWithMatchingSHA256() async {
-    // MockModelDownloader writes 1000 bytes of 0x42
-    let expectedHash = "9a5670771141349931d69d6eb982faa01def544dc17a161ef83b3277fb7c0c3c"
-    let sut = makeSUT(
-      downloader: MockModelDownloader(simulateBytes: 1000),
-      expectedSHA256: expectedHash
-    )
-    sut.checkModelStatus()
-    #expect(sut.state == .notDownloaded)
-
-    await sut.downloadModel()
-    defer {
-      try? FileManager.default.removeItem(at: sut.modelFileURL)
-      try? FileManager.default.removeItem(at: sut.downloadFileURL)
-    }
-
-    if case .ready = sut.state {
-      // Success
-    } else {
-      Issue.record("Expected .ready but got \(sut.state)")
-    }
-  }
-
-  @Test("downloadModel transitions to error when SHA256 mismatches")
-  func downloadFailureWithMismatchingSHA256() async {
-    let wrongHash = "0000000000000000000000000000000000000000000000000000000000000000"
-    let sut = makeSUT(
-      downloader: MockModelDownloader(simulateBytes: 1000),
-      expectedSHA256: wrongHash
-    )
-    sut.checkModelStatus()
-    #expect(sut.state == .notDownloaded)
-
-    await sut.downloadModel()
-    defer {
-      try? FileManager.default.removeItem(at: sut.modelFileURL)
-      try? FileManager.default.removeItem(at: sut.downloadFileURL)
-    }
-
-    if case .error(let message) = sut.state {
-      #expect(message.contains("verification failed"))
-    } else {
-      Issue.record("Expected .error but got \(sut.state)")
-    }
-
-    // .download file should be deleted on mismatch
-    #expect(!FileManager.default.fileExists(atPath: sut.downloadFileURL.path))
-  }
-
-  @Test("downloadModel skips SHA256 verification when expectedSHA256 is nil")
-  func downloadSuccessWithNilSHA256() async {
-    let sut = makeSUT(
-      downloader: MockModelDownloader(simulateBytes: 100)
-    )
-    sut.checkModelStatus()
-    #expect(sut.state == .notDownloaded)
-
-    await sut.downloadModel()
-    defer {
-      try? FileManager.default.removeItem(at: sut.modelFileURL)
-      try? FileManager.default.removeItem(at: sut.downloadFileURL)
-    }
-
-    if case .ready = sut.state {
-      // Success — no SHA256 check performed
-    } else {
-      Issue.record("Expected .ready but got \(sut.state)")
-    }
+    #expect(sut.activeState != .unsupportedDevice)
   }
 
 }

--- a/Pastura/PasturaTests/App/ModelRegistryTests.swift
+++ b/Pastura/PasturaTests/App/ModelRegistryTests.swift
@@ -36,11 +36,11 @@ struct ModelRegistryTests {
   }
 
   @Test func qwen_integrityMetadataMatchesFetchedValues() {
-    #expect(ModelRegistry.qwen3_4B.fileSize == 2_497_280_256)
+    #expect(ModelRegistry.qwen34B.fileSize == 2_497_280_256)
     #expect(
-      ModelRegistry.qwen3_4B.sha256
+      ModelRegistry.qwen34B.sha256
         == "7485fe6f11af29433bc51cab58009521f205840f5b4ae3a32fa7f92e8534fdf5")
-    #expect(ModelRegistry.qwen3_4B.systemPromptSuffix == "/no_think")
+    #expect(ModelRegistry.qwen34B.systemPromptSuffix == "/no_think")
   }
 
   // findCollisions testability — covers the uniqueness check without
@@ -58,23 +58,23 @@ struct ModelRegistryTests {
 
   @Test func findCollisions_detectsDuplicateFileNames() {
     // Fabricate two descriptors with same fileName but different ids
-    let a = ModelRegistry.gemma4E2B
+    let base = ModelRegistry.gemma4E2B
     // Reconstruct Qwen but forced to use Gemma's fileName → fileName collision
     let qwenAsGemmaFile = ModelDescriptor(
-      id: ModelRegistry.qwen3_4B.id,
-      displayName: ModelRegistry.qwen3_4B.displayName,
-      vendor: ModelRegistry.qwen3_4B.vendor,
-      vendorURL: ModelRegistry.qwen3_4B.vendorURL,
-      downloadURL: ModelRegistry.qwen3_4B.downloadURL,
+      id: ModelRegistry.qwen34B.id,
+      displayName: ModelRegistry.qwen34B.displayName,
+      vendor: ModelRegistry.qwen34B.vendor,
+      vendorURL: ModelRegistry.qwen34B.vendorURL,
+      downloadURL: ModelRegistry.qwen34B.downloadURL,
       fileName: ModelRegistry.gemma4E2B.fileName,  // ← collision
-      fileSize: ModelRegistry.qwen3_4B.fileSize,
-      sha256: ModelRegistry.qwen3_4B.sha256,
-      stopSequence: ModelRegistry.qwen3_4B.stopSequence,
-      minRAM: ModelRegistry.qwen3_4B.minRAM,
-      modelInfoURL: ModelRegistry.qwen3_4B.modelInfoURL,
-      systemPromptSuffix: ModelRegistry.qwen3_4B.systemPromptSuffix
+      fileSize: ModelRegistry.qwen34B.fileSize,
+      sha256: ModelRegistry.qwen34B.sha256,
+      stopSequence: ModelRegistry.qwen34B.stopSequence,
+      minRAM: ModelRegistry.qwen34B.minRAM,
+      modelInfoURL: ModelRegistry.qwen34B.modelInfoURL,
+      systemPromptSuffix: ModelRegistry.qwen34B.systemPromptSuffix
     )
-    let reasons = ModelRegistry.findCollisions(in: [a, qwenAsGemmaFile])
+    let reasons = ModelRegistry.findCollisions(in: [base, qwenAsGemmaFile])
     #expect(!reasons.isEmpty)
     #expect(reasons.contains(where: { $0.contains("fileName") }))
   }

--- a/Pastura/PasturaTests/App/ModelRegistryTests.swift
+++ b/Pastura/PasturaTests/App/ModelRegistryTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+@Suite(.timeLimit(.minutes(1)))
+struct ModelRegistryTests {
+  // Production catalog integrity
+  @Test func catalog_hasExpectedModels() {
+    let ids = ModelRegistry.catalog.map(\.id)
+    #expect(ids == ["gemma-4-e2b-q4-k-m", "qwen-3-4b-q4-k-m"])
+  }
+
+  @Test func catalog_passesValidateNoCollisions() {
+    // If this triggers the precondition, the test process crashes —
+    // which is the correct signal. A successful run proves the catalog is valid.
+    ModelRegistry.validateNoCollisions()
+  }
+
+  @Test func defaultInitialModelID_isGemma() {
+    #expect(ModelRegistry.defaultInitialModelID == "gemma-4-e2b-q4-k-m")
+  }
+
+  // Gemma upgrade-compat contract: filename must match the legacy constant
+  // currently in ModelManager.swift. Changing this value without a migration
+  // would force existing TestFlight users to re-download 3.1 GB.
+  @Test func gemma_fileName_matchesLegacyConstant() {
+    #expect(ModelRegistry.gemma4E2B.fileName == "gemma-4-E2B-it-Q4_K_M.gguf")
+  }
+
+  @Test func gemma_integrityMetadataMatchesLegacyConstants() {
+    #expect(ModelRegistry.gemma4E2B.fileSize == 3_106_735_776)
+    #expect(
+      ModelRegistry.gemma4E2B.sha256
+        == "ac0069ebccd39925d836f24a88c0f0c858d20578c29b21ab7cedce66ee576845")
+  }
+
+  @Test func qwen_integrityMetadataMatchesFetchedValues() {
+    #expect(ModelRegistry.qwen3_4B.fileSize == 2_497_280_256)
+    #expect(
+      ModelRegistry.qwen3_4B.sha256
+        == "7485fe6f11af29433bc51cab58009521f205840f5b4ae3a32fa7f92e8534fdf5")
+    #expect(ModelRegistry.qwen3_4B.systemPromptSuffix == "/no_think")
+  }
+
+  // findCollisions testability — covers the uniqueness check without
+  // relying on a preconditioned call site.
+  @Test func findCollisions_emptyForProductionCatalog() {
+    #expect(ModelRegistry.findCollisions(in: ModelRegistry.catalog).isEmpty)
+  }
+
+  @Test func findCollisions_detectsDuplicateIDs() {
+    let duplicated = [ModelRegistry.gemma4E2B, ModelRegistry.gemma4E2B]
+    let reasons = ModelRegistry.findCollisions(in: duplicated)
+    #expect(!reasons.isEmpty)
+    #expect(reasons.contains(where: { $0.contains("id") }))
+  }
+
+  @Test func findCollisions_detectsDuplicateFileNames() {
+    // Fabricate two descriptors with same fileName but different ids
+    let a = ModelRegistry.gemma4E2B
+    // Reconstruct Qwen but forced to use Gemma's fileName → fileName collision
+    let qwenAsGemmaFile = ModelDescriptor(
+      id: ModelRegistry.qwen3_4B.id,
+      displayName: ModelRegistry.qwen3_4B.displayName,
+      vendor: ModelRegistry.qwen3_4B.vendor,
+      vendorURL: ModelRegistry.qwen3_4B.vendorURL,
+      downloadURL: ModelRegistry.qwen3_4B.downloadURL,
+      fileName: ModelRegistry.gemma4E2B.fileName,  // ← collision
+      fileSize: ModelRegistry.qwen3_4B.fileSize,
+      sha256: ModelRegistry.qwen3_4B.sha256,
+      stopSequence: ModelRegistry.qwen3_4B.stopSequence,
+      minRAM: ModelRegistry.qwen3_4B.minRAM,
+      modelInfoURL: ModelRegistry.qwen3_4B.modelInfoURL,
+      systemPromptSuffix: ModelRegistry.qwen3_4B.systemPromptSuffix
+    )
+    let reasons = ModelRegistry.findCollisions(in: [a, qwenAsGemmaFile])
+    #expect(!reasons.isEmpty)
+    #expect(reasons.contains(where: { $0.contains("fileName") }))
+  }
+}

--- a/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests+Qwen.swift
+++ b/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests+Qwen.swift
@@ -1,0 +1,138 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+// MARK: - Configuration
+
+/// Reads Qwen-specific integration test settings from environment variables.
+private enum QwenConfig {
+  /// Gate: tests run only when `LLAMACPP_INTEGRATION=1` AND
+  /// `LLAMACPP_QWEN_MODEL_PATH` is set to an absolute path.
+  /// Both conditions together prevent the Qwen tests from accidentally running
+  /// with Gemma's `LLAMACPP_MODEL_PATH` and producing false negatives.
+  static var isEnabled: Bool {
+    guard ProcessInfo.processInfo.environment["LLAMACPP_INTEGRATION"] == "1" else {
+      return false
+    }
+    guard let path = ProcessInfo.processInfo.environment["LLAMACPP_QWEN_MODEL_PATH"],
+      !path.isEmpty
+    else {
+      return false
+    }
+    return true
+  }
+
+  /// Absolute path to the Qwen 3 4B Q4_K_M GGUF file. Empty string when the
+  /// env var is unset; `isEnabled` guards actual consumption.
+  static var modelPath: String {
+    ProcessInfo.processInfo.environment["LLAMACPP_QWEN_MODEL_PATH"] ?? ""
+  }
+}
+
+// MARK: - Tests (joins the serialized `LlamaCppIntegrationTests` suite)
+
+/// Pre-implementation verification for Qwen 3 4B Q4_K_M — gates PR B of
+/// the multi-model support work (#203). These tests must pass against a
+/// local Qwen GGUF before PR B's user-facing UI is implemented.
+///
+/// Run with:
+/// ```
+/// source scripts/sim-dest.sh
+/// LLAMACPP_INTEGRATION=1 \
+///   LLAMACPP_QWEN_MODEL_PATH=/path/to/Qwen3-4B-Q4_K_M.gguf \
+///   xcodebuild test -scheme Pastura -project Pastura/Pastura.xcodeproj \
+///   -destination "$DEST" \
+///   -only-testing PasturaTests/LlamaCppIntegrationTests
+/// ```
+///
+/// Failure playbook:
+/// - Test (a) fails → the Q4_K_M quantization is incompatible with
+///   llama.cpp's chatml fallback path. Revise plan to add a
+///   `chatTemplateOverride` field on `ModelDescriptor`.
+/// - Test (b) fails → `/no_think` in the system prompt does not suppress
+///   thinking mode. Try moving the suffix to the user message
+///   (introduce `PromptSuffixPosition` enum) OR raise `maxTokens` per
+///   descriptor so the JSON survives the thinking prefix.
+extension LlamaCppIntegrationTests {
+
+  // MARK: - Helpers
+
+  private func makeQwenService() -> LlamaCppService {
+    LlamaCppService(
+      modelPath: QwenConfig.modelPath,
+      stopSequence: "<|im_end|>",
+      modelIdentifier: "Qwen 3 4B (Q4_K_M)",
+      systemPromptSuffix: "/no_think"
+    )
+  }
+
+  // MARK: - Test (a): Qwen GGUF loads and generates
+
+  /// Verifies that Qwen 3 4B Q4_K_M loads through `LlamaCppService` without
+  /// chat-template or sampler surprises. Generating a short, JSON-shaped
+  /// response proves the full pipeline (load → tokenize → sample → stop →
+  /// decode → stop-sentinel match) works for this model.
+  @Test(
+    "Qwen: loads and produces non-empty output",
+    .enabled(if: QwenConfig.isEnabled),
+    .timeLimit(.minutes(3))
+  )
+  func qwenLoadsAndGenerates() async throws {
+    let service = makeQwenService()
+    try await service.loadModel()
+    defer { Task { try? await service.unloadModel() } }
+
+    let result = try await service.generate(
+      system: "Reply with JSON only: {\"greeting\": \"hello\"}",
+      user: "Say hello."
+    )
+
+    #expect(!result.isEmpty, "Qwen generated empty output")
+    #expect(result.count > 5, "Qwen output suspiciously short: \(result)")
+    // Output should not contain leaked <|im_end|> — same contract as Gemma
+    #expect(
+      !result.contains("<|im_end|>"),
+      "Qwen output contains <|im_end|> — stop sequence detection failed. Raw: \(result)"
+    )
+  }
+
+  // MARK: - Test (b): /no_think suppresses thinking
+
+  /// Verifies that `systemPromptSuffix="/no_think"` injected via
+  /// `applyChatTemplate` actually suppresses Qwen 3's thinking-mode output
+  /// (`<think>...</think>` blocks). Without this, a thinking-mode Qwen
+  /// generation can emit hundreds of thought tokens before the JSON, which
+  /// exhausts `maxTokens=1000` and produces empty/truncated parses.
+  ///
+  /// A failure here means the descriptor-level suffix is being dropped,
+  /// applied to the wrong role, or not recognized by the model — any of
+  /// which warrants plan revision before shipping PR B.
+  @Test(
+    "Qwen: /no_think system suffix prevents <think> blocks",
+    .enabled(if: QwenConfig.isEnabled),
+    .timeLimit(.minutes(3))
+  )
+  func qwenNoThinkSuppressesThinking() async throws {
+    let service = makeQwenService()
+    try await service.loadModel()
+    defer { Task { try? await service.unloadModel() } }
+
+    let result = try await service.generate(
+      system: """
+        You are a character in a game. Respond ONLY with a JSON object.
+        Required format: {"statement": "your statement here"}
+        """,
+      user: "Introduce yourself briefly."
+    )
+
+    #expect(
+      !result.contains("<think>"),
+      "Qwen emitted <think> block despite /no_think suffix. Raw: \(result)"
+    )
+    #expect(
+      !result.contains("</think>"),
+      "Qwen emitted </think> close tag despite /no_think suffix. Raw: \(result)"
+    )
+  }
+}

--- a/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests.swift
+++ b/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests.swift
@@ -40,7 +40,12 @@ struct LlamaCppIntegrationTests {
   // MARK: - Helpers
 
   private func makeService() -> LlamaCppService {
-    LlamaCppService(modelPath: LlamaCppConfig.modelPath)
+    LlamaCppService(
+      modelPath: LlamaCppConfig.modelPath,
+      stopSequence: "<|im_end|>",
+      modelIdentifier: "Gemma 4 E2B (Q4_K_M)",
+      systemPromptSuffix: nil
+    )
   }
 
   // MARK: - Test 1: Load/unload lifecycle

--- a/Pastura/PasturaTests/LLM/LlamaCppServiceTests.swift
+++ b/Pastura/PasturaTests/LLM/LlamaCppServiceTests.swift
@@ -2,6 +2,19 @@ import Testing
 
 @testable import Pastura
 
+/// File-scope helper for constructing a `LlamaCppService` with test-shaped
+/// values. Production code must provide all four parameters explicitly (via
+/// a `ModelDescriptor`); this helper centralizes the values that the lifecycle
+/// / error-path tests don't depend on so each test call-site stays terse.
+private func makeTestService(modelPath: String = "/nonexistent.gguf") -> LlamaCppService {
+  LlamaCppService(
+    modelPath: modelPath,
+    stopSequence: "<|im_end|>",
+    modelIdentifier: "test-model",
+    systemPromptSuffix: nil
+  )
+}
+
 /// Unit tests for ``LlamaCppService``.
 ///
 /// These tests validate lifecycle, error paths, and protocol conformance
@@ -13,21 +26,21 @@ struct LlamaCppServiceTests {
   // MARK: - Protocol conformance
 
   @Test func conformsToLLMService() {
-    let service: any LLMService = LlamaCppService(modelPath: "/nonexistent.gguf")
+    let service: any LLMService = makeTestService()
     #expect(service is LlamaCppService)
   }
 
   // MARK: - Initial state
 
   @Test func initialStateIsNotLoaded() {
-    let service = LlamaCppService(modelPath: "/nonexistent.gguf")
+    let service = makeTestService()
     #expect(!service.isModelLoaded)
   }
 
   // MARK: - generate() before load
 
   @Test func throwsNotLoadedBeforeLoadModel() async {
-    let service = LlamaCppService(modelPath: "/nonexistent.gguf")
+    let service = makeTestService()
     await #expect(throws: LLMError.notLoaded) {
       try await service.generate(system: "sys", user: "usr")
     }
@@ -39,7 +52,7 @@ struct LlamaCppServiceTests {
   /// stream via `finish(throwing:)` — not silently end. A missing model is
   /// the cheapest way to exercise this without a real GGUF file.
   @Test func generateStreamPropagatesNotLoadedBeforeLoadModel() async {
-    let service = LlamaCppService(modelPath: "/nonexistent.gguf")
+    let service = makeTestService()
     await #expect(throws: LLMError.notLoaded) {
       for try await _ in service.generateStream(system: "sys", user: "usr") {}
     }
@@ -48,14 +61,14 @@ struct LlamaCppServiceTests {
   // MARK: - loadModel with invalid path
 
   @Test func loadModelWithInvalidPathThrowsLoadFailed() async {
-    let service = LlamaCppService(modelPath: "/nonexistent.gguf")
+    let service = makeTestService()
     await #expect(throws: LLMError.self) {
       try await service.loadModel()
     }
   }
 
   @Test func loadModelFailureKeepsNotLoaded() async {
-    let service = LlamaCppService(modelPath: "/nonexistent.gguf")
+    let service = makeTestService()
     try? await service.loadModel()
     #expect(!service.isModelLoaded)
   }
@@ -63,7 +76,7 @@ struct LlamaCppServiceTests {
   // MARK: - unloadModel safety
 
   @Test func unloadModelWhenNotLoadedIsSafe() async throws {
-    let service = LlamaCppService(modelPath: "/nonexistent.gguf")
+    let service = makeTestService()
     try await service.unloadModel()
     #expect(!service.isModelLoaded)
   }
@@ -71,7 +84,7 @@ struct LlamaCppServiceTests {
   // MARK: - generate after unload
 
   @Test func generateAfterUnloadThrowsNotLoaded() async throws {
-    let service = LlamaCppService(modelPath: "/nonexistent.gguf")
+    let service = makeTestService()
     try await service.unloadModel()
     await #expect(throws: LLMError.notLoaded) {
       try await service.generate(system: "sys", user: "usr")
@@ -81,7 +94,7 @@ struct LlamaCppServiceTests {
   // MARK: - Concurrent access guard (no false positives)
 
   @Test func guardAllowsSequentialGenerateCalls() async {
-    let service = LlamaCppService(modelPath: "/nonexistent.gguf")
+    let service = makeTestService()
     // Sequential generate() calls should not trigger the guard.
     // Both throw notLoaded (no model loaded), but the guard itself must not fire.
     await #expect(throws: LLMError.notLoaded) {
@@ -93,7 +106,7 @@ struct LlamaCppServiceTests {
   }
 
   @Test func guardAllowsLoadUnloadCycle() async throws {
-    let service = LlamaCppService(modelPath: "/nonexistent.gguf")
+    let service = makeTestService()
     // load (fails) → generate (fails) → unload → generate (fails)
     // None of these overlap, so the guard must not fire.
     try? await service.loadModel()
@@ -109,20 +122,20 @@ struct LlamaCppServiceTests {
   // MARK: - reloadModel(gpuAcceleration:)
 
   @Test func reloadModelWithInvalidPathThrowsLoadFailed() async {
-    let service = LlamaCppService(modelPath: "/nonexistent.gguf")
+    let service = makeTestService()
     await #expect(throws: LLMError.self) {
       try await service.reloadModel(gpuAcceleration: .none)
     }
   }
 
   @Test func reloadModelFailureKeepsNotLoaded() async {
-    let service = LlamaCppService(modelPath: "/nonexistent.gguf")
+    let service = makeTestService()
     try? await service.reloadModel(gpuAcceleration: .none)
     #expect(!service.isModelLoaded)
   }
 
   @Test func reloadModelWhenNotLoadedBehavesLikeLoad() async {
-    let service = LlamaCppService(modelPath: "/nonexistent.gguf")
+    let service = makeTestService()
     // Reload before initial load should attempt load (fails on invalid path).
     // State must remain not-loaded on failure.
     await #expect(throws: LLMError.self) {
@@ -142,7 +155,7 @@ struct LlamaCppServiceTests {
     //   - Attached SuspendController survives the unload/load cycle
     // The actual leak-prevention path requires a loaded model — see
     // LlamaCppIntegrationTests.loadModelTwiceIsIdempotent for that coverage.
-    let service = LlamaCppService(modelPath: "/nonexistent.gguf")
+    let service = makeTestService()
     let controller = SuspendController()
     await service.attachSuspendController(controller)
 
@@ -156,7 +169,7 @@ struct LlamaCppServiceTests {
   @Test func reloadModelUnloadsFirstEvenIfReloadFails() async throws {
     // If reload's inner load fails, the previous model should still be unloaded —
     // the caller gets a clean not-loaded state, not a partial state.
-    let service = LlamaCppService(modelPath: "/nonexistent.gguf")
+    let service = makeTestService()
     try? await service.loadModel()  // fails, but tests atomicity
     try? await service.reloadModel(gpuAcceleration: .none)
     #expect(!service.isModelLoaded)
@@ -174,7 +187,7 @@ struct LlamaCppServiceTests {
     // of crashing. Here we exercise the path by calling unloadModel on an
     // unloaded service: the fast path returns immediately without any guard
     // check that could crash.
-    let service = LlamaCppService(modelPath: "/nonexistent.gguf")
+    let service = makeTestService()
     // Multiple back-to-back unloads must be safe (the first exits early via
     // the `guard wasLoaded` check; the second sees isModelLoaded==false).
     try await service.unloadModel()
@@ -187,7 +200,7 @@ struct LlamaCppServiceTests {
     // while generatingGuard is true, and proceed once it clears. Uses the
     // DEBUG-only setGeneratingForTesting hook to simulate an in-flight generate
     // without actually running one (which would require a real model file).
-    let service = LlamaCppService(modelPath: "/nonexistent.gguf")
+    let service = makeTestService()
     service.setGeneratingForTesting(true)
 
     let unloadTask = Task<Bool, Error> {
@@ -209,14 +222,14 @@ struct LlamaCppServiceTests {
   // MARK: - SuspendController attachment
 
   @Test func attachSuspendControllerStoresReference() async {
-    let service = LlamaCppService(modelPath: "/nonexistent.gguf")
+    let service = makeTestService()
     let controller = SuspendController()
     await service.attachSuspendController(controller)
     #expect(service.suspendController === controller)
   }
 
   @Test func attachSuspendControllerReplacesPreviousReference() async {
-    let service = LlamaCppService(modelPath: "/nonexistent.gguf")
+    let service = makeTestService()
     let first = SuspendController()
     let second = SuspendController()
     await service.attachSuspendController(first)
@@ -225,7 +238,7 @@ struct LlamaCppServiceTests {
   }
 
   @Test func attachSuspendControllerNilDetaches() async {
-    let service = LlamaCppService(modelPath: "/nonexistent.gguf")
+    let service = makeTestService()
     await service.attachSuspendController(SuspendController())
     await service.attachSuspendController(nil)
     #expect(service.suspendController == nil)
@@ -235,7 +248,7 @@ struct LlamaCppServiceTests {
     // Even if reload throws (invalid path), the previously attached controller
     // must still be in place — the App layer's reference must survive the
     // unload/load cycle without any explicit re-attach.
-    let service = LlamaCppService(modelPath: "/nonexistent.gguf")
+    let service = makeTestService()
     let controller = SuspendController()
     await service.attachSuspendController(controller)
 
@@ -251,7 +264,7 @@ struct LlamaCppServiceTests {
   // MARK: - Reactive suspend mapping (decodeFailureError)
 
   @Test func decodeFailureWithoutControllerReturnsGenerationFailed() {
-    let service = LlamaCppService(modelPath: "/nonexistent.gguf")
+    let service = makeTestService()
     // No controller attached at all — every non-zero decode is fatal.
     let mapped = service.decodeFailureError(-3)
     if case .generationFailed = mapped { /* OK */
@@ -261,7 +274,7 @@ struct LlamaCppServiceTests {
   }
 
   @Test func decodeFailureWithoutSuspendRequestReturnsGenerationFailed() async {
-    let service = LlamaCppService(modelPath: "/nonexistent.gguf")
+    let service = makeTestService()
     await service.attachSuspendController(SuspendController())
     // Controller exists but no suspend was requested → still fatal.
     let mapped = service.decodeFailureError(2)
@@ -272,7 +285,7 @@ struct LlamaCppServiceTests {
   }
 
   @Test func decodeFailureWithSuspendRequestReturnsSuspended() async {
-    let service = LlamaCppService(modelPath: "/nonexistent.gguf")
+    let service = makeTestService()
     let controller = SuspendController()
     await service.attachSuspendController(controller)
     controller.requestSuspend()
@@ -289,7 +302,7 @@ struct LlamaCppServiceTests {
     // generate is still in flight — that would free C pointers still in use
     // (use-after-free). Verifies the Task.detached sleep pattern isn't
     // short-circuited by cancellation.
-    let service = LlamaCppService(modelPath: "/nonexistent.gguf")
+    let service = makeTestService()
     service.setGeneratingForTesting(true)
 
     let unloadTask = Task<Bool, Error> {

--- a/Pastura/PasturaTests/Models/ModelDescriptorTests.swift
+++ b/Pastura/PasturaTests/Models/ModelDescriptorTests.swift
@@ -87,15 +87,15 @@ struct ModelDescriptorTests {
   // MARK: - Hashable
 
   @Test func hashable_equalDescriptorsHashEqual() {
-    let a = makeDescriptor()
-    let b = makeDescriptor()
-    #expect(a == b)
-    #expect(a.hashValue == b.hashValue)
+    let lhs = makeDescriptor()
+    let rhs = makeDescriptor()
+    #expect(lhs == rhs)
+    #expect(lhs.hashValue == rhs.hashValue)
   }
 
   @Test func hashable_differentIDsHashDiffer() {
-    let a = makeDescriptor(id: "model-a")
-    let b = makeDescriptor(id: "model-b")
-    #expect(a != b)
+    let lhs = makeDescriptor(id: "model-a")
+    let rhs = makeDescriptor(id: "model-b")
+    #expect(lhs != rhs)
   }
 }

--- a/Pastura/PasturaTests/Models/ModelDescriptorTests.swift
+++ b/Pastura/PasturaTests/Models/ModelDescriptorTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+@Suite(.timeLimit(.minutes(1)))
+struct ModelDescriptorTests {
+  // MARK: - Helpers
+
+  /// Returns a valid `ModelDescriptor` for use across multiple tests.
+  func makeDescriptor(id: ModelID = "gemma-4-e2b-q4-k-m") -> ModelDescriptor {
+    ModelDescriptor(
+      id: id,
+      displayName: "Gemma 4 E2B (Q4_K_M)",
+      vendor: "Google",
+      vendorURL: URL(string: "https://deepmind.google")!,
+      downloadURL: URL(string: "https://example.com/gemma-4-E2B-it-Q4_K_M.gguf")!,
+      fileName: "gemma-4-E2B-it-Q4_K_M.gguf",
+      fileSize: 3_100_000_000,
+      sha256: "abc123def456",
+      stopSequence: "<|im_end|>",
+      minRAM: 6_000_000_000,
+      modelInfoURL: URL(string: "https://huggingface.co/google/gemma-4-e2b")!,
+      systemPromptSuffix: nil
+    )
+  }
+
+  // MARK: - isValidFileName
+
+  @Test func isValidFileName_acceptsValidNames() {
+    #expect(ModelDescriptor.isValidFileName("gemma-4-E2B-it-Q4_K_M.gguf"))
+    #expect(ModelDescriptor.isValidFileName("qwen3-4b.gguf"))
+    #expect(ModelDescriptor.isValidFileName("a.gguf"))
+    #expect(ModelDescriptor.isValidFileName("UPPERCASE.gguf"))
+    #expect(ModelDescriptor.isValidFileName("dots.in.name.gguf"))
+    #expect(ModelDescriptor.isValidFileName("with_underscores.gguf"))
+  }
+
+  @Test func isValidFileName_rejectsInvalidNames() {
+    #expect(!ModelDescriptor.isValidFileName(""))
+    #expect(!ModelDescriptor.isValidFileName("no_extension"))
+    #expect(!ModelDescriptor.isValidFileName("wrong_extension.bin"))
+    #expect(!ModelDescriptor.isValidFileName("../escape.gguf"))
+    #expect(!ModelDescriptor.isValidFileName("has/slash.gguf"))
+    #expect(!ModelDescriptor.isValidFileName("has space.gguf"))
+    #expect(!ModelDescriptor.isValidFileName("has:colon.gguf"))
+    // No base name — just the extension
+    #expect(!ModelDescriptor.isValidFileName(".gguf"))
+  }
+
+  // MARK: - Construction
+
+  @Test func construction_setsAllFields() {
+    let vendorURL = URL(string: "https://deepmind.google")!
+    let downloadURL = URL(string: "https://example.com/gemma-4-E2B-it-Q4_K_M.gguf")!
+    let modelInfoURL = URL(string: "https://huggingface.co/google/gemma-4-e2b")!
+
+    let descriptor = ModelDescriptor(
+      id: "gemma-4-e2b-q4-k-m",
+      displayName: "Gemma 4 E2B (Q4_K_M)",
+      vendor: "Google",
+      vendorURL: vendorURL,
+      downloadURL: downloadURL,
+      fileName: "gemma-4-E2B-it-Q4_K_M.gguf",
+      fileSize: 3_100_000_000,
+      sha256: "abc123def456",
+      stopSequence: "<|im_end|>",
+      minRAM: 6_000_000_000,
+      modelInfoURL: modelInfoURL,
+      systemPromptSuffix: "/no_think"
+    )
+
+    #expect(descriptor.id == "gemma-4-e2b-q4-k-m")
+    #expect(descriptor.displayName == "Gemma 4 E2B (Q4_K_M)")
+    #expect(descriptor.vendor == "Google")
+    #expect(descriptor.vendorURL == vendorURL)
+    #expect(descriptor.downloadURL == downloadURL)
+    #expect(descriptor.fileName == "gemma-4-E2B-it-Q4_K_M.gguf")
+    #expect(descriptor.fileSize == 3_100_000_000)
+    #expect(descriptor.sha256 == "abc123def456")
+    #expect(descriptor.stopSequence == "<|im_end|>")
+    #expect(descriptor.minRAM == 6_000_000_000)
+    #expect(descriptor.modelInfoURL == modelInfoURL)
+    #expect(descriptor.systemPromptSuffix == "/no_think")
+  }
+
+  // MARK: - Hashable
+
+  @Test func hashable_equalDescriptorsHashEqual() {
+    let a = makeDescriptor()
+    let b = makeDescriptor()
+    #expect(a == b)
+    #expect(a.hashValue == b.hashValue)
+  }
+
+  @Test func hashable_differentIDsHashDiffer() {
+    let a = makeDescriptor(id: "model-a")
+    let b = makeDescriptor(id: "model-b")
+    #expect(a != b)
+  }
+}


### PR DESCRIPTION
## Summary

Phase 2 multi-model support — **PR A (plumbing, no user-visible change)**.
Introduces per-descriptor plumbing so **PR B** (ModelPickerView +
SimulationActivityRegistry + SettingsView models section) can plug in
without touching the core types again.

- New types: `ModelDescriptor` (Models/), `ModelRegistry` (App/)
- `ModelManager.state` → `[ModelID: ModelState]`; per-descriptor paths
  preserve the existing Gemma file (`gemma-4-E2B-it-Q4_K_M.gguf` and
  its `.download` partial) so existing TestFlight users do NOT
  re-download 3.1 GB
- `LlamaCppService.init` requires `stopSequence` / `modelIdentifier` /
  `systemPromptSuffix` explicitly; `systemPromptSuffix` appended in
  `applyChatTemplate` so Qwen's `/no_think` ships descriptor-first
- Qwen 3 4B Q4_K_M added to catalog
- Qwen pre-verification integration scaffold (env-gated
  `LLAMACPP_INTEGRATION=1` + `LLAMACPP_QWEN_MODEL_PATH`) gates PR B

Part of #203 (do NOT close on merge — PR B and PR C follow).

## Test plan

- [x] 963 unit tests pass (`** TEST SUCCEEDED **`, full suite minus UI)
- [x] `swiftlint lint --quiet --strict` clean
- [x] Gemma legacy regression tests (completed file + `.download` resume)
- [x] Multi-descriptor state seeding / sequential-download policy /
      active id persistence / `resolveInitialActiveID` resolution matrix
- [x] `findCollisions` detects duplicate ids and fileNames
- [x] Code-reviewer pass (see commit `07d8bd0` for follow-ups)
- [x] **Manual Qwen smoke test** before PR B starts:
      `LLAMACPP_INTEGRATION=1 LLAMACPP_QWEN_MODEL_PATH=/path/to/Qwen3-4B-Q4_K_M.gguf`
      — `qwenLoadsAndGenerates` + `qwenNoThinkSuppressesThinking` must
      pass. Failure playbook in the +Qwen.swift header

## Scope boundaries (intentionally deferred)

- ModelPickerView / SettingsView Models section /
  SimulationActivityRegistry / active-switch UI → **PR B**
- ROADMAP update + close Issue #82 → **PR C**

🤖 Generated with [Claude Code](https://claude.com/claude-code)