### PR TITLE
♻️ refactor: strict-throw audit of ScenarioLoader silent paths (#130)

### DIFF
--- a/Pastura/Pastura/Engine/ScenarioLoader.swift
+++ b/Pastura/Pastura/Engine/ScenarioLoader.swift
@@ -234,7 +234,7 @@ nonisolated struct ScenarioLoader: Sendable {
     let options: [String]? = try parseOptional(dict, key: "options", label: label)
 
     let target = try parseAssignTarget(dict["target"], label: label)
-    let outputSchema = parseOutputSchema(dict)
+    let outputSchema = try parseOutputSchema(dict, label: label)
     let pairing = try parsePairing(dict["pairing"], label: label)
     let logic = try parseLogic(dict["logic"], label: label)
 
@@ -287,11 +287,26 @@ nonisolated struct ScenarioLoader: Sendable {
     return phaseType
   }
 
-  private func parseOutputSchema(_ dict: [String: Any]) -> [String: String]? {
-    guard let output = dict["output"] as? [String: Any] else { return nil }
+  /// Parses the `output:` schema dict. Values must be Strings — the schema is
+  /// an LLM prompt hint, and a non-String value (e.g. `count: 1`) is a typo,
+  /// not a type-shorthand worth preserving. Previously stringified silently.
+  private func parseOutputSchema(
+    _ dict: [String: Any], label: String
+  ) throws -> [String: String]? {
+    guard let raw = dict["output"] else { return nil }
+    guard let output = raw as? [String: Any] else {
+      throw SimulationError.scenarioValidationFailed(
+        "\(label): field 'output' must be a dictionary of String values, got \(type(of: raw))"
+      )
+    }
     var result: [String: String] = [:]
     for (key, value) in output {
-      result[key] = "\(value)"
+      guard let str = value as? String else {
+        throw SimulationError.scenarioValidationFailed(
+          "\(label): output schema value for '\(key)' must be String, got \(type(of: value))"
+        )
+      }
+      result[key] = str
     }
     return result
   }

--- a/Pastura/Pastura/Engine/ScenarioLoader.swift
+++ b/Pastura/Pastura/Engine/ScenarioLoader.swift
@@ -152,7 +152,7 @@ nonisolated struct ScenarioLoader: Sendable {
       try mapPhase(raw, index: index)
     }
 
-    let extraData = collectExtraData(from: dict)
+    let extraData = try collectExtraData(from: dict)
 
     return Scenario(
       id: id, name: name, description: description,
@@ -161,13 +161,15 @@ nonisolated struct ScenarioLoader: Sendable {
     )
   }
 
-  /// Collects non-standard top-level keys as extra data.
-  private func collectExtraData(from dict: [String: Any]) -> [String: AnyCodableValue] {
+  /// Collects non-standard top-level keys as extra data. Throws on unsupported
+  /// shapes rather than silently dropping them — previously, a typo like
+  /// `count: 42` (auto-typed Int) disappeared from the returned map.
+  private func collectExtraData(
+    from dict: [String: Any]
+  ) throws -> [String: AnyCodableValue] {
     var extraData: [String: AnyCodableValue] = [:]
     for (key, value) in dict where !Self.standardKeys.contains(key) {
-      if let converted = convertToAnyCodableValue(value) {
-        extraData[key] = converted
-      }
+      extraData[key] = try convertToAnyCodableValue(value, key: key)
     }
     return extraData
   }
@@ -329,32 +331,54 @@ nonisolated struct ScenarioLoader: Sendable {
     }
   }
 
-  /// Converts a raw YAML value to ``AnyCodableValue``.
-  private func convertToAnyCodableValue(_ value: Any) -> AnyCodableValue? {
+  /// Converts a raw YAML value to ``AnyCodableValue``, throwing on unsupported
+  /// shapes rather than silently dropping the field or coercing to a surprising
+  /// string. `AnyCodableValue` is String-leaf today; extending it to carry
+  /// Int/Bool/Double is deferred to a future issue. Users wanting a numeric
+  /// scalar at the top level should quote it (`count: "42"`).
+  private static let supportedExtraDataShapes =
+    "String, [String], [String: String], or [[String: String]]"
+
+  private func convertToAnyCodableValue(
+    _ value: Any, key: String
+  ) throws -> AnyCodableValue {
     if let str = value as? String {
       return .string(str)
     }
     if let arr = value as? [Any] {
-      // Try array of dictionaries first
       if let dictArr = arr as? [[String: String]] {
         return .arrayOfDictionaries(dictArr)
       }
-      // Try array of [String: Any] and convert values to String
-      if let dictAnyArr = arr as? [[String: Any]] {
-        let converted = dictAnyArr.map { dict in
-          dict.mapValues { "\($0)" } as [String: String]
-        }
-        return .arrayOfDictionaries(converted)
+      // Array of dicts where any value isn't a String — previously stringified
+      // silently, which hid typos like `majority: 1`.
+      if arr.allSatisfy({ $0 is [String: Any] }) {
+        throw SimulationError.scenarioValidationFailed(
+          "Top-level field '\(key)': array-of-dict values must all be String. "
+            + "Quote non-string values (e.g. `majority: \"1\"`)."
+        )
       }
-      // Try string array
-      let strings = arr.compactMap { $0 as? String }
-      if strings.count == arr.count {
-        return .array(strings)
+      if arr.allSatisfy({ $0 is String }) {
+        // Unreachable when the pure-String cast above succeeded; kept for
+        // clarity against future changes to Swift's Array<Any> bridging.
+        return .array(arr.compactMap { $0 as? String })
       }
+      throw SimulationError.scenarioValidationFailed(
+        "Top-level field '\(key)': mixed-type arrays are not supported. "
+          + "Use a pure [String] or [[String: String]]."
+      )
     }
     if let dict = value as? [String: String] {
       return .dictionary(dict)
     }
-    return nil
+    if value is [String: Any] {
+      throw SimulationError.scenarioValidationFailed(
+        "Top-level field '\(key)': dictionary values must all be String. "
+          + "Quote non-string values."
+      )
+    }
+    throw SimulationError.scenarioValidationFailed(
+      "Top-level field '\(key)' has unsupported type \(type(of: value)). "
+        + "Supported shapes: \(Self.supportedExtraDataShapes)."
+    )
   }
 }

--- a/Pastura/Pastura/Engine/ScenarioLoader.swift
+++ b/Pastura/Pastura/Engine/ScenarioLoader.swift
@@ -227,11 +227,11 @@ nonisolated struct ScenarioLoader: Sendable {
   private func mapPhase(_ dict: [String: Any], label: String, depth: Int) throws -> Phase {
     let phaseType = try parsePhaseType(dict, label: label, depth: depth)
 
-    let prompt = dict["prompt"] as? String
-    let template = dict["template"] as? String
-    let source = dict["source"] as? String
-    let excludeSelf = dict["exclude_self"] as? Bool
-    let options = dict["options"] as? [String]
+    let prompt: String? = try parseOptional(dict, key: "prompt", label: label)
+    let template: String? = try parseOptional(dict, key: "template", label: label)
+    let source: String? = try parseOptional(dict, key: "source", label: label)
+    let excludeSelf: Bool? = try parseOptional(dict, key: "exclude_self", label: label)
+    let options: [String]? = try parseOptional(dict, key: "options", label: label)
 
     let target = try parseAssignTarget(dict["target"], label: label)
     let outputSchema = parseOutputSchema(dict)
@@ -239,11 +239,11 @@ nonisolated struct ScenarioLoader: Sendable {
     let logic = try parseLogic(dict["logic"], label: label)
 
     // speak_each rounds → subRounds
-    let subRounds = dict["rounds"] as? Int
+    let subRounds: Int? = try parseOptional(dict, key: "rounds", label: label)
 
     // Conditional-specific fields (`if:` expression + `then:` / `else:` sub-phase arrays).
     // Recursively descend with depth+1 so nested conditional is rejected here.
-    let condition = dict["if"] as? String
+    let condition: String? = try parseOptional(dict, key: "if", label: label)
     let thenPhases = try mapBranch(
       dict["then"], branchLabel: "then", parentLabel: label, depth: depth)
     let elsePhases = try mapBranch(

--- a/Pastura/Pastura/Engine/ScenarioLoader.swift
+++ b/Pastura/Pastura/Engine/ScenarioLoader.swift
@@ -134,12 +134,10 @@ nonisolated struct ScenarioLoader: Sendable {  // swiftlint:disable:this type_bo
     let rounds: Int = try parseRequired(dict, key: "rounds", label: "Scenario")
     let context: String = try parseRequired(dict, key: "context", label: "Scenario")
 
-    guard let personasRaw = dict["personas"] as? [[String: Any]] else {
-      throw SimulationError.scenarioValidationFailed("Missing or invalid field: personas")
-    }
-    guard let phasesRaw = dict["phases"] as? [[String: Any]] else {
-      throw SimulationError.scenarioValidationFailed("Missing or invalid field: phases")
-    }
+    let personasRaw: [[String: Any]] = try parseRequired(
+      dict, key: "personas", label: "Scenario")
+    let phasesRaw: [[String: Any]] = try parseRequired(
+      dict, key: "phases", label: "Scenario")
 
     let personas = try personasRaw.map { try mapPersona($0) }
     if personas.count != agentCount {
@@ -175,10 +173,10 @@ nonisolated struct ScenarioLoader: Sendable {  // swiftlint:disable:this type_bo
   }
 
   private func mapPersona(_ dict: [String: Any]) throws -> Persona {
-    guard let name = dict["name"] as? String else {
-      throw SimulationError.scenarioValidationFailed("Persona missing 'name'")
-    }
-    let description = dict["description"] as? String ?? ""
+    let name: String = try parseRequired(dict, key: "name", label: "Persona")
+    let description: String =
+      try parseOptional(
+        dict, key: "description", label: "Persona") ?? ""
     return Persona(name: name, description: description)
   }
 
@@ -358,8 +356,6 @@ nonisolated struct ScenarioLoader: Sendable {  // swiftlint:disable:this type_bo
         )
       }
       if arr.allSatisfy({ $0 is String }) {
-        // Unreachable when the pure-String cast above succeeded; kept for
-        // clarity against future changes to Swift's Array<Any> bridging.
         return .array(arr.compactMap { $0 as? String })
       }
       throw SimulationError.scenarioValidationFailed(

--- a/Pastura/Pastura/Engine/ScenarioLoader.swift
+++ b/Pastura/Pastura/Engine/ScenarioLoader.swift
@@ -83,29 +83,56 @@ nonisolated struct ScenarioLoader: Sendable {
     return filtered.joined(separator: "\n")
   }
 
-  /// Extracts a required string field from a YAML dictionary.
-  private func requireString(_ dict: [String: Any], key: String) throws -> String {
-    if let value = dict[key] as? String { return value }
-    if let value = dict[key] { return "\(value)" }
-    throw SimulationError.scenarioValidationFailed("Missing required field: \(key)")
+  /// Extracts a required field of exact Swift type `T` from a YAML dictionary.
+  ///
+  /// Distinguishes *missing* from *present-but-wrong-type* so users can tell
+  /// whether to add the field or re-type it. Wrong-type errors name the actual
+  /// bridged Swift type from Yams (e.g. `"String"` for quoted numbers), so a
+  /// user writing `agents: "2"` gets `"field 'agents' must be Int, got String"`
+  /// instead of a misleading `"Missing required field"`.
+  ///
+  /// No type coercion — eliminating silent-coerce is the whole point of #130.
+  private func parseRequired<T>(
+    _ dict: [String: Any], key: String, label: String
+  ) throws -> T {
+    guard let raw = dict[key] else {
+      throw SimulationError.scenarioValidationFailed(
+        "\(label): missing required field '\(key)'"
+      )
+    }
+    guard let typed = raw as? T else {
+      throw SimulationError.scenarioValidationFailed(
+        "\(label): field '\(key)' must be \(T.self), got \(type(of: raw))"
+      )
+    }
+    return typed
   }
 
-  /// Extracts a required integer field from a YAML dictionary.
-  private func requireInt(_ dict: [String: Any], key: String) throws -> Int {
-    guard let value = dict[key] as? Int else {
-      throw SimulationError.scenarioValidationFailed("Missing required field: \(key)")
+  /// Extracts an optional field of exact Swift type `T` from a YAML dictionary.
+  ///
+  /// Returns `nil` when the key is absent. Throws when present-but-wrong-type —
+  /// unlike a naive `as? T` which would silently coerce to `nil` and let the
+  /// caller's default kick in (the bug class tracked in #130).
+  private func parseOptional<T>(
+    _ dict: [String: Any], key: String, label: String
+  ) throws -> T? {
+    guard let raw = dict[key] else { return nil }
+    guard let typed = raw as? T else {
+      throw SimulationError.scenarioValidationFailed(
+        "\(label): field '\(key)' must be \(T.self), got \(type(of: raw))"
+      )
     }
-    return value
+    return typed
   }
 
   /// Maps a raw YAML dictionary to a ``Scenario`` model.
   private func mapToScenario(_ dict: [String: Any]) throws -> Scenario {
-    let id = try requireString(dict, key: "id")
-    let name = try requireString(dict, key: "name")
-    let description = try requireString(dict, key: "description")
-    let agentCount = try requireInt(dict, key: "agents")
-    let rounds = try requireInt(dict, key: "rounds")
-    let context = try requireString(dict, key: "context")
+    let id: String = try parseRequired(dict, key: "id", label: "Scenario")
+    let name: String = try parseRequired(dict, key: "name", label: "Scenario")
+    let description: String = try parseRequired(dict, key: "description", label: "Scenario")
+    let agentCount: Int = try parseRequired(dict, key: "agents", label: "Scenario")
+    let rounds: Int = try parseRequired(dict, key: "rounds", label: "Scenario")
+    let context: String = try parseRequired(dict, key: "context", label: "Scenario")
 
     guard let personasRaw = dict["personas"] as? [[String: Any]] else {
       throw SimulationError.scenarioValidationFailed("Missing or invalid field: personas")

--- a/Pastura/Pastura/Engine/ScenarioLoader.swift
+++ b/Pastura/Pastura/Engine/ScenarioLoader.swift
@@ -5,7 +5,7 @@ import Yams
 ///
 /// Uses `Yams.load(yaml:)` → `[String: Any]` with manual mapping per ADR-001.
 /// Strips code fences from LLM-generated YAML before parsing.
-nonisolated struct ScenarioLoader: Sendable {
+nonisolated struct ScenarioLoader: Sendable {  // swiftlint:disable:this type_body_length
 
   /// Standard fields that are mapped to `Scenario` properties (not collected as extraData).
   private static let standardKeys: Set<String> = [

--- a/Pastura/PasturaTests/Engine/ScenarioLoaderTests+StrictTypes.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioLoaderTests+StrictTypes.swift
@@ -1,7 +1,9 @@
+import Foundation
 import Testing
 
 @testable import Pastura
 
+// swiftlint:disable file_length
 // Extension split per `.claude/rules/testing.md` (file_length cap). A new
 // `@Suite` would race against the parent under parallel execution — extensions
 // stay on the same suite so `.serialized`/`.timeLimit` traits apply uniformly.
@@ -394,4 +396,35 @@ extension ScenarioLoaderTests {
     }
     #expect(msg.contains("'options'"))
   }
+
+  // MARK: - Shipped content safety net (#130 item 5)
+
+  /// Share Board gallery YAMLs live in `docs/gallery/` (served from GitHub raw
+  /// at runtime, not bundled). A loader refactor could break parsing without
+  /// either the preset-loader test or the app test suite noticing until a real
+  /// Share Board fetch. This pins the YAMLs to the strict loader's contract.
+  ///
+  /// Presets (`Pastura/Pastura/Resources/Presets/`) are already covered by
+  /// `PresetLoaderTests.presetYAMLsAreParseable`; preset→serialize→parse
+  /// round-trip is covered by `ScenarioSerializerTests.roundTripBokete` et al.
+  @Test func galleryYAMLsLoadUnderStrictLoader() throws {
+    let galleryDir = repoRoot().appendingPathComponent("docs/gallery")
+    for name in ["trolley_dilemma_v1", "detective_scene_v1", "asch_conformity_v1"] {
+      let url = galleryDir.appendingPathComponent("\(name).yaml")
+      let yaml = try String(contentsOf: url, encoding: .utf8)
+      let scenario = try loader.load(yaml: yaml)
+      #expect(!scenario.phases.isEmpty, "\(name): parsed but has no phases")
+    }
+  }
+}
+
+/// Resolves the repo root from this file's absolute source path. Test targets
+/// have host-filesystem access under iOS simulator, so `#filePath` works.
+/// Path walk: this file → Engine → PasturaTests → Pastura → repo root.
+private func repoRoot(file: StaticString = #filePath) -> URL {
+  URL(fileURLWithPath: "\(file)")
+    .deletingLastPathComponent()  // Engine/
+    .deletingLastPathComponent()  // PasturaTests/
+    .deletingLastPathComponent()  // Pastura/
+    .deletingLastPathComponent()  // repo root
 }

--- a/Pastura/PasturaTests/Engine/ScenarioLoaderTests+StrictTypes.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioLoaderTests+StrictTypes.swift
@@ -1,0 +1,228 @@
+import Testing
+
+@testable import Pastura
+
+// Extension split per `.claude/rules/testing.md` (file_length cap). A new
+// `@Suite` would race against the parent under parallel execution — extensions
+// stay on the same suite so `.serialized`/`.timeLimit` traits apply uniformly.
+extension ScenarioLoaderTests {
+
+  // MARK: - Scenario top-level wrong-type errors
+
+  /// Numeric id (YAML auto-type) previously coerced silently to "42".
+  /// Strict loader throws with a wrong-type message distinguishing it from
+  /// "missing field" — the prior `requireString` stringify fallback would
+  /// have hidden typos like `id: 001` (YAML 1.1 auto-types to Int 1).
+  @Test func throwsOnWrongTypeForRequiredString() throws {
+    let yaml = """
+      id: 42
+      name: Test
+      description: Test
+      agents: 2
+      rounds: 1
+      context: Context
+      personas:
+        - name: A
+          description: A
+        - name: B
+          description: B
+      phases:
+        - type: speak_all
+          prompt: "Go"
+      """
+    let error = try #require(throws: SimulationError.self) {
+      try loader.load(yaml: yaml)
+    }
+    guard case .scenarioValidationFailed(let msg) = error else {
+      Issue.record("Expected scenarioValidationFailed, got \(error)")
+      return
+    }
+    #expect(msg.contains("'id'"))
+    #expect(msg.contains("String"))
+    #expect(!msg.lowercased().contains("missing"))
+  }
+
+  /// Quoted integer (`agents: "2"`) previously threw a misleading
+  /// "Missing required field" error. Strict loader surfaces the real cause.
+  @Test func throwsOnWrongTypeForRequiredInt() throws {
+    let yaml = """
+      id: test
+      name: Test
+      description: Test
+      agents: "2"
+      rounds: 1
+      context: Context
+      personas:
+        - name: A
+          description: A
+        - name: B
+          description: B
+      phases:
+        - type: speak_all
+          prompt: "Go"
+      """
+    let error = try #require(throws: SimulationError.self) {
+      try loader.load(yaml: yaml)
+    }
+    guard case .scenarioValidationFailed(let msg) = error else {
+      Issue.record("Expected scenarioValidationFailed, got \(error)")
+      return
+    }
+    #expect(msg.contains("'agents'"))
+    #expect(msg.contains("Int"))
+    #expect(!msg.lowercased().contains("missing"))
+  }
+
+  // MARK: - Assign target parsing (strict)
+
+  /// Typo'd target string is rejected at parse time (was a silent `.all` default
+  /// before #108 / typed `AssignTarget`).
+  @Test func rejectsAssignWithUnknownTarget() {
+    let yaml = makeYAMLWithAssignTarget("randomOne")  // typo of random_one
+    #expect(throws: SimulationError.self) {
+      try loader.load(yaml: yaml)
+    }
+  }
+
+  /// Case is significant — `target: All` was previously silently treated as
+  /// the default; now rejected.
+  @Test func rejectsAssignWithCapitalizedTarget() {
+    let yaml = makeYAMLWithAssignTarget("All")
+    #expect(throws: SimulationError.self) {
+      try loader.load(yaml: yaml)
+    }
+  }
+
+  @Test func acceptsAssignWithCanonicalTargetAll() throws {
+    _ = try loader.load(yaml: makeYAMLWithAssignTarget("all"))
+  }
+
+  @Test func acceptsAssignWithCanonicalTargetRandomOne() throws {
+    _ = try loader.load(yaml: makeYAMLWithAssignTarget("random_one"))
+  }
+
+  // MARK: - Pairing / logic parsing (strict)
+
+  @Test func rejectsChooseWithUnknownPairing() {
+    let yaml = makeMinimalYAML(
+      phasesBlock: """
+        phases:
+          - type: choose
+            pairing: roundRobin
+            options: [a, b]
+        """)
+    #expect(throws: SimulationError.self) {
+      try loader.load(yaml: yaml)
+    }
+  }
+
+  @Test func rejectsScoreCalcWithUnknownLogic() {
+    let yaml = makeMinimalYAML(
+      phasesBlock: """
+        phases:
+          - type: score_calc
+            logic: made_up_logic
+        """)
+    #expect(throws: SimulationError.self) {
+      try loader.load(yaml: yaml)
+    }
+  }
+
+  // MARK: - Phase-optional field wrong-type errors (#130 item 2)
+
+  /// `rounds: "3"` (accidentally quoted in YAML) previously coerced silently
+  /// to `nil` → `subRounds` defaulted to 1 → `speak_each` ran one pass instead
+  /// of three. Strict loader now throws.
+  @Test func throwsOnQuotedSubRounds() throws {
+    let yaml = makeMinimalYAML(
+      phasesBlock: """
+        phases:
+          - type: speak_each
+            prompt: "Talk"
+            rounds: "3"
+        """)
+    let error = try #require(throws: SimulationError.self) {
+      try loader.load(yaml: yaml)
+    }
+    guard case .scenarioValidationFailed(let msg) = error else {
+      Issue.record("Expected scenarioValidationFailed, got \(error)")
+      return
+    }
+    #expect(msg.contains("'rounds'"))
+    #expect(msg.contains("Int"))
+  }
+
+  /// `exclude_self: "true"` (quoted string) previously became `nil` silently;
+  /// strict loader throws. Contrast with `exclude_self: yes` (bare) which is a
+  /// valid YAML 1.1 boolean — see `acceptsYAML11BooleanExcludeSelf`.
+  @Test func throwsOnQuotedExcludeSelf() throws {
+    let yaml = makeMinimalYAML(
+      phasesBlock: """
+        phases:
+          - type: vote
+            prompt: "Vote"
+            exclude_self: "true"
+        """)
+    let error = try #require(throws: SimulationError.self) {
+      try loader.load(yaml: yaml)
+    }
+    guard case .scenarioValidationFailed(let msg) = error else {
+      Issue.record("Expected scenarioValidationFailed, got \(error)")
+      return
+    }
+    #expect(msg.contains("'exclude_self'"))
+    #expect(msg.contains("Bool"))
+  }
+
+  /// `exclude_self: 1` (integer) also fails strictly — no 0/1 → bool coercion.
+  @Test func throwsOnIntExcludeSelf() throws {
+    let yaml = makeMinimalYAML(
+      phasesBlock: """
+        phases:
+          - type: vote
+            prompt: "Vote"
+            exclude_self: 1
+        """)
+    #expect(throws: SimulationError.self) {
+      try loader.load(yaml: yaml)
+    }
+  }
+
+  /// YAML 1.1 treats bare `yes`/`no`/`on`/`off` as booleans. Yams follows the
+  /// 1.1 spec so `exclude_self: yes` parses to `Bool(true)` — this is *not* a
+  /// silent-coerce bug, it's the canonical spelling. Pinned as a positive
+  /// test so a future "fix" doesn't break it.
+  @Test func acceptsYAML11BooleanExcludeSelf() throws {
+    let yaml = makeMinimalYAML(
+      phasesBlock: """
+        phases:
+          - type: vote
+            prompt: "Vote"
+            exclude_self: yes
+        """)
+    let scenario = try loader.load(yaml: yaml)
+    #expect(scenario.phases[0].excludeSelf == true)
+  }
+
+  /// `options` containing a non-String element previously silently dropped the
+  /// whole array. Strict loader throws so the typo surfaces to the user.
+  @Test func throwsOnMixedTypeOptions() throws {
+    let yaml = makeMinimalYAML(
+      phasesBlock: """
+        phases:
+          - type: choose
+            prompt: "Choose"
+            options:
+              - cooperate
+              - 42
+        """)
+    let error = try #require(throws: SimulationError.self) {
+      try loader.load(yaml: yaml)
+    }
+    guard case .scenarioValidationFailed(let msg) = error else {
+      Issue.record("Expected scenarioValidationFailed, got \(error)")
+      return
+    }
+    #expect(msg.contains("'options'"))
+  }
+}

--- a/Pastura/PasturaTests/Engine/ScenarioLoaderTests+StrictTypes.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioLoaderTests+StrictTypes.swift
@@ -244,6 +244,135 @@ extension ScenarioLoaderTests {
     }
   }
 
+  // MARK: - convertToAnyCodableValue strict (#130 item 4)
+
+  /// Top-level scalar extraData (`count: 42`) previously silently disappeared —
+  /// `convertToAnyCodableValue` returned nil and `collectExtraData` dropped it.
+  /// Strict loader throws naming the offending field and listing supported shapes.
+  @Test func throwsOnScalarTopLevelExtraData() throws {
+    let yaml = """
+      id: t
+      name: T
+      description: T
+      agents: 2
+      rounds: 1
+      context: C
+      personas:
+        - name: A
+          description: D
+        - name: B
+          description: D
+      phases:
+        - type: speak_all
+          prompt: "Go"
+      count: 42
+      """
+    let error = try #require(throws: SimulationError.self) {
+      try loader.load(yaml: yaml)
+    }
+    guard case .scenarioValidationFailed(let msg) = error else {
+      Issue.record("Expected scenarioValidationFailed, got \(error)")
+      return
+    }
+    #expect(msg.contains("'count'"))
+    // Error message should hint at the supported shapes so users know how to fix.
+    #expect(msg.contains("String") || msg.contains("string"))
+  }
+
+  /// Quoting the scalar works — `count: "42"` parses as `.string("42")`.
+  @Test func acceptsQuotedScalarTopLevelExtraData() throws {
+    let yaml = """
+      id: t
+      name: T
+      description: T
+      agents: 2
+      rounds: 1
+      context: C
+      personas:
+        - name: A
+          description: D
+        - name: B
+          description: D
+      phases:
+        - type: speak_all
+          prompt: "Go"
+      count: "42"
+      """
+    let scenario = try loader.load(yaml: yaml)
+    if case .string(let value) = scenario.extraData["count"] {
+      #expect(value == "42")
+    } else {
+      Issue.record("Expected .string for quoted scalar extraData")
+    }
+  }
+
+  /// Mixed-type top-level array previously silently dropped the whole field
+  /// (string-array conversion failed, `[[String: Any]]` conversion also failed,
+  /// so the function returned nil).
+  @Test func throwsOnMixedTypeExtraDataArray() throws {
+    let yaml = """
+      id: t
+      name: T
+      description: T
+      agents: 2
+      rounds: 1
+      context: C
+      personas:
+        - name: A
+          description: D
+        - name: B
+          description: D
+      phases:
+        - type: speak_all
+          prompt: "Go"
+      topics:
+        - a
+        - 42
+      """
+    let error = try #require(throws: SimulationError.self) {
+      try loader.load(yaml: yaml)
+    }
+    guard case .scenarioValidationFailed(let msg) = error else {
+      Issue.record("Expected scenarioValidationFailed, got \(error)")
+      return
+    }
+    #expect(msg.contains("'topics'"))
+  }
+
+  /// `words: [{ majority: 1, minority: 2 }]` previously stringified the Int
+  /// values silently (`"1"`, `"2"`). Strict loader throws — word-wolf preset
+  /// authors intending a numeric tag would fail to notice the coercion.
+  @Test func throwsOnNonStringValueInArrayOfDicts() throws {
+    let yaml = """
+      id: t
+      name: T
+      description: T
+      agents: 2
+      rounds: 1
+      context: C
+      personas:
+        - name: A
+          description: D
+        - name: B
+          description: D
+      phases:
+        - type: assign
+          source: words
+          target: random_one
+      words:
+        - majority: 1
+          minority: 2
+      """
+    let error = try #require(throws: SimulationError.self) {
+      try loader.load(yaml: yaml)
+    }
+    guard case .scenarioValidationFailed(let msg) = error else {
+      Issue.record("Expected scenarioValidationFailed, got \(error)")
+      return
+    }
+    #expect(msg.contains("'words'"))
+  }
+
   /// `options` containing a non-String element previously silently dropped the
   /// whole array. Strict loader throws so the typo surfaces to the user.
   @Test func throwsOnMixedTypeOptions() throws {

--- a/Pastura/PasturaTests/Engine/ScenarioLoaderTests+StrictTypes.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioLoaderTests+StrictTypes.swift
@@ -1,4 +1,3 @@
-import Foundation
 import Testing
 
 @testable import Pastura
@@ -73,6 +72,66 @@ extension ScenarioLoaderTests {
     #expect(msg.contains("'agents'"))
     #expect(msg.contains("Int"))
     #expect(!msg.lowercased().contains("missing"))
+  }
+
+  // MARK: - Personas / phases strict (#130 item 1 follow-up)
+
+  /// `personas: "alice"` (scalar instead of list-of-dict) previously threw
+  /// with "Missing or invalid field: personas" — strict loader uses the new
+  /// helper so missing vs wrong-type produce distinct messages.
+  @Test func throwsOnWrongTypeForPersonasList() throws {
+    let yaml = """
+      id: t
+      name: T
+      description: T
+      agents: 2
+      rounds: 1
+      context: C
+      personas: "alice"
+      phases:
+        - type: speak_all
+          prompt: "Go"
+      """
+    let error = try #require(throws: SimulationError.self) {
+      try loader.load(yaml: yaml)
+    }
+    guard case .scenarioValidationFailed(let msg) = error else {
+      Issue.record("Expected scenarioValidationFailed, got \(error)")
+      return
+    }
+    #expect(msg.contains("'personas'"))
+    #expect(!msg.lowercased().contains("missing"))
+  }
+
+  /// Persona with a numeric name (`- name: 42`) previously became a Scenario
+  /// whose persona name wasn't the Int the author typed — `as? String` failed
+  /// silently at the `mapPersona` boundary. Strict loader throws.
+  @Test func throwsOnWrongTypeForPersonaName() throws {
+    let yaml = """
+      id: t
+      name: T
+      description: T
+      agents: 2
+      rounds: 1
+      context: C
+      personas:
+        - name: 42
+          description: D
+        - name: B
+          description: D
+      phases:
+        - type: speak_all
+          prompt: "Go"
+      """
+    let error = try #require(throws: SimulationError.self) {
+      try loader.load(yaml: yaml)
+    }
+    guard case .scenarioValidationFailed(let msg) = error else {
+      Issue.record("Expected scenarioValidationFailed, got \(error)")
+      return
+    }
+    #expect(msg.contains("'name'"))
+    #expect(msg.contains("String"))
   }
 
   // MARK: - Assign target parsing (strict)
@@ -397,34 +456,13 @@ extension ScenarioLoaderTests {
     #expect(msg.contains("'options'"))
   }
 
-  // MARK: - Shipped content safety net (#130 item 5)
-
-  /// Share Board gallery YAMLs live in `docs/gallery/` (served from GitHub raw
-  /// at runtime, not bundled). A loader refactor could break parsing without
-  /// either the preset-loader test or the app test suite noticing until a real
-  /// Share Board fetch. This pins the YAMLs to the strict loader's contract.
-  ///
-  /// Presets (`Pastura/Pastura/Resources/Presets/`) are already covered by
-  /// `PresetLoaderTests.presetYAMLsAreParseable`; preset→serialize→parse
-  /// round-trip is covered by `ScenarioSerializerTests.roundTripBokete` et al.
-  @Test func galleryYAMLsLoadUnderStrictLoader() throws {
-    let galleryDir = repoRoot().appendingPathComponent("docs/gallery")
-    for name in ["trolley_dilemma_v1", "detective_scene_v1", "asch_conformity_v1"] {
-      let url = galleryDir.appendingPathComponent("\(name).yaml")
-      let yaml = try String(contentsOf: url, encoding: .utf8)
-      let scenario = try loader.load(yaml: yaml)
-      #expect(!scenario.phases.isEmpty, "\(name): parsed but has no phases")
-    }
-  }
-}
-
-/// Resolves the repo root from this file's absolute source path. Test targets
-/// have host-filesystem access under iOS simulator, so `#filePath` works.
-/// Path walk: this file → Engine → PasturaTests → Pastura → repo root.
-private func repoRoot(file: StaticString = #filePath) -> URL {
-  URL(fileURLWithPath: "\(file)")
-    .deletingLastPathComponent()  // Engine/
-    .deletingLastPathComponent()  // PasturaTests/
-    .deletingLastPathComponent()  // Pastura/
-    .deletingLastPathComponent()  // repo root
+  // Shipped-content coverage (#130 item 5): presets are covered by
+  // `PresetLoaderTests.presetYAMLsAreParseable`; gallery seeds by
+  // `GallerySeedYAMLTests.allSeedYAMLsParseAndValidate` — both already call
+  // `ScenarioLoader.load` and will fail under the strict loader if any
+  // shipped YAML regresses. No extra test needed here.
+  //
+  // Preset round-trip (parse → serialize → parse) is covered by
+  // `ScenarioSerializerTests.roundTripBokete` / `roundTripWordWolf` /
+  // `roundTripPrisonersDilemma` / `roundTripTargetScoreRace`.
 }

--- a/Pastura/PasturaTests/Engine/ScenarioLoaderTests+StrictTypes.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioLoaderTests+StrictTypes.swift
@@ -204,6 +204,46 @@ extension ScenarioLoaderTests {
     #expect(scenario.phases[0].excludeSelf == true)
   }
 
+  // MARK: - parseOutputSchema strict (#130 item 3)
+
+  /// `output: { count: 1 }` previously stringified `1` to `"1"` silently. The
+  /// schema is an LLM prompt hint — a non-String value is almost always a typo.
+  @Test func throwsOnNonStringOutputSchemaValue() throws {
+    let yaml = makeMinimalYAML(
+      phasesBlock: """
+        phases:
+          - type: speak_all
+            prompt: "Go"
+            output:
+              statement: string
+              count: 1
+        """)
+    let error = try #require(throws: SimulationError.self) {
+      try loader.load(yaml: yaml)
+    }
+    guard case .scenarioValidationFailed(let msg) = error else {
+      Issue.record("Expected scenarioValidationFailed, got \(error)")
+      return
+    }
+    #expect(msg.contains("output"))
+    #expect(msg.contains("'count'"))
+  }
+
+  /// `output: "string"` (scalar instead of dict) previously just skipped the
+  /// schema (no-op). Strict loader throws so users catch the mis-shape.
+  @Test func throwsOnNonDictOutputSchema() throws {
+    let yaml = makeMinimalYAML(
+      phasesBlock: """
+        phases:
+          - type: speak_all
+            prompt: "Go"
+            output: "string"
+        """)
+    #expect(throws: SimulationError.self) {
+      try loader.load(yaml: yaml)
+    }
+  }
+
   /// `options` containing a non-String element previously silently dropped the
   /// whole array. Strict loader throws so the typo surfaces to the user.
   @Test func throwsOnMixedTypeOptions() throws {

--- a/Pastura/PasturaTests/Engine/ScenarioLoaderTests.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioLoaderTests.swift
@@ -252,71 +252,6 @@ struct ScenarioLoaderTests {
     }
   }
 
-  /// Numeric id (YAML auto-type) previously coerced silently to "42".
-  /// Under strict loader: throws with wrong-type message distinguishing
-  /// this from "missing field".
-  @Test func throwsOnWrongTypeForRequiredString() throws {
-    let yaml = """
-      id: 42
-      name: Test
-      description: Test
-      agents: 2
-      rounds: 1
-      context: Context
-      personas:
-        - name: A
-          description: A
-        - name: B
-          description: B
-      phases:
-        - type: speak_all
-          prompt: "Go"
-      """
-    let error = try #require(throws: SimulationError.self) {
-      try loader.load(yaml: yaml)
-    }
-    guard case .scenarioValidationFailed(let msg) = error else {
-      Issue.record("Expected scenarioValidationFailed, got \(error)")
-      return
-    }
-    #expect(msg.contains("'id'"))
-    #expect(msg.contains("String"))
-    // "missing" would imply the field is absent; must not appear here.
-    #expect(!msg.lowercased().contains("missing"))
-  }
-
-  /// Quoted integer (`agents: "2"`) previously threw a misleading
-  /// "Missing required field" error. Under strict loader: throws with
-  /// wrong-type message that names the actual bridged type.
-  @Test func throwsOnWrongTypeForRequiredInt() throws {
-    let yaml = """
-      id: test
-      name: Test
-      description: Test
-      agents: "2"
-      rounds: 1
-      context: Context
-      personas:
-        - name: A
-          description: A
-        - name: B
-          description: B
-      phases:
-        - type: speak_all
-          prompt: "Go"
-      """
-    let error = try #require(throws: SimulationError.self) {
-      try loader.load(yaml: yaml)
-    }
-    guard case .scenarioValidationFailed(let msg) = error else {
-      Issue.record("Expected scenarioValidationFailed, got \(error)")
-      return
-    }
-    #expect(msg.contains("'agents'"))
-    #expect(msg.contains("Int"))
-    #expect(!msg.lowercased().contains("missing"))
-  }
-
   @Test func throwsOnInvalidPhaseType() {
     let yaml = """
       id: test
@@ -420,62 +355,6 @@ struct ScenarioLoaderTests {
     #expect(ScenarioLoader.estimateInferenceCount(scenario) == 10)
   }
 
-  // MARK: - Assign target parsing (strict)
-
-  /// Typo'd target string is rejected at parse time (was a silent .all default
-  /// before #108 / typed AssignTarget).
-  @Test func rejectsAssignWithUnknownTarget() {
-    let yaml =
-      makeYAMLWithAssignTarget("randomOne")  // typo of random_one
-    #expect(throws: SimulationError.self) {
-      try loader.load(yaml: yaml)
-    }
-  }
-
-  /// Case is significant — `target: All` was previously silently treated as
-  /// the default; now rejected.
-  @Test func rejectsAssignWithCapitalizedTarget() {
-    let yaml = makeYAMLWithAssignTarget("All")
-    #expect(throws: SimulationError.self) {
-      try loader.load(yaml: yaml)
-    }
-  }
-
-  @Test func acceptsAssignWithCanonicalTargetAll() throws {
-    _ = try loader.load(yaml: makeYAMLWithAssignTarget("all"))
-  }
-
-  @Test func acceptsAssignWithCanonicalTargetRandomOne() throws {
-    _ = try loader.load(yaml: makeYAMLWithAssignTarget("random_one"))
-  }
-
-  // MARK: - Pairing / logic parsing (strict)
-
-  @Test func rejectsChooseWithUnknownPairing() {
-    let yaml = makeMinimalYAML(
-      phasesBlock: """
-        phases:
-          - type: choose
-            pairing: roundRobin
-            options: [a, b]
-        """)
-    #expect(throws: SimulationError.self) {
-      try loader.load(yaml: yaml)
-    }
-  }
-
-  @Test func rejectsScoreCalcWithUnknownLogic() {
-    let yaml = makeMinimalYAML(
-      phasesBlock: """
-        phases:
-          - type: score_calc
-            logic: made_up_logic
-        """)
-    #expect(throws: SimulationError.self) {
-      try loader.load(yaml: yaml)
-    }
-  }
-
   @Test func estimatesZeroForCodePhases() {
     let scenario = Scenario(
       id: "t", name: "T", description: "T", agentCount: 5, rounds: 3, context: "C",
@@ -492,7 +371,7 @@ struct ScenarioLoaderTests {
 
   // MARK: - Test Helpers
 
-  private func makeYAMLWithAssignTarget(_ target: String) -> String {
+  func makeYAMLWithAssignTarget(_ target: String) -> String {
     """
     id: t
     name: T
@@ -514,7 +393,7 @@ struct ScenarioLoaderTests {
     """
   }
 
-  private func makeMinimalYAML(phasesBlock: String) -> String {
+  func makeMinimalYAML(phasesBlock: String) -> String {
     """
     id: t
     name: T

--- a/Pastura/PasturaTests/Engine/ScenarioLoaderTests.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioLoaderTests.swift
@@ -252,6 +252,71 @@ struct ScenarioLoaderTests {
     }
   }
 
+  /// Numeric id (YAML auto-type) previously coerced silently to "42".
+  /// Under strict loader: throws with wrong-type message distinguishing
+  /// this from "missing field".
+  @Test func throwsOnWrongTypeForRequiredString() throws {
+    let yaml = """
+      id: 42
+      name: Test
+      description: Test
+      agents: 2
+      rounds: 1
+      context: Context
+      personas:
+        - name: A
+          description: A
+        - name: B
+          description: B
+      phases:
+        - type: speak_all
+          prompt: "Go"
+      """
+    let error = try #require(throws: SimulationError.self) {
+      try loader.load(yaml: yaml)
+    }
+    guard case .scenarioValidationFailed(let msg) = error else {
+      Issue.record("Expected scenarioValidationFailed, got \(error)")
+      return
+    }
+    #expect(msg.contains("'id'"))
+    #expect(msg.contains("String"))
+    // "missing" would imply the field is absent; must not appear here.
+    #expect(!msg.lowercased().contains("missing"))
+  }
+
+  /// Quoted integer (`agents: "2"`) previously threw a misleading
+  /// "Missing required field" error. Under strict loader: throws with
+  /// wrong-type message that names the actual bridged type.
+  @Test func throwsOnWrongTypeForRequiredInt() throws {
+    let yaml = """
+      id: test
+      name: Test
+      description: Test
+      agents: "2"
+      rounds: 1
+      context: Context
+      personas:
+        - name: A
+          description: A
+        - name: B
+          description: B
+      phases:
+        - type: speak_all
+          prompt: "Go"
+      """
+    let error = try #require(throws: SimulationError.self) {
+      try loader.load(yaml: yaml)
+    }
+    guard case .scenarioValidationFailed(let msg) = error else {
+      Issue.record("Expected scenarioValidationFailed, got \(error)")
+      return
+    }
+    #expect(msg.contains("'agents'"))
+    #expect(msg.contains("Int"))
+    #expect(!msg.lowercased().contains("missing"))
+  }
+
   @Test func throwsOnInvalidPhaseType() {
     let yaml = """
       id: test


### PR DESCRIPTION
## Summary

Audit + fix of `ScenarioLoader` silent-nil / silent-coerce paths called
out in #130. Unified philosophy under the zero-backward-compat / pre-release
judgment: **present-but-wrong-type always throws; missing is nil (optional)
or throws (required)**. No type coercion anywhere.

Six commits, one per audit item + review fixes:
1. `parseRequired<T>` / `parseOptional<T>` generic helpers; migrate `id` / `name` / `description` / `agents` / `rounds` / `context`
2. Phase-optional fields (`prompt` / `template` / `source` / `exclude_self` / `options` / `rounds` / `if`) + test file split into extension
3. `parseOutputSchema` strict on non-String schema values
4. `convertToAnyCodableValue` strict on unsupported shapes; error text lists supported shapes
5. Gallery YAML safety-net (superseded in commit 6 — already covered by `GallerySeedYAMLTests`)
6. Review feedback: `personas` / `phases` / `name` strict-throw; drop duplicated test; fix misleading comment

## Behavior change (zero-compat)

Any previously-silent coerce is now a surfaced error. Canonical YAML (all shipped presets + gallery seeds) continues to parse unchanged — covered by `PresetLoaderTests.presetYAMLsAreParseable`, `GallerySeedYAMLTests.allSeedYAMLsParseAndValidate`, and `ScenarioSerializerTests.roundTrip*`.

Examples of newly-thrown errors (previously silent):
- `id: 42` → `"Scenario: field 'id' must be String, got Int"`
- `agents: "2"` → wrong-type instead of misleading "Missing required field"
- `rounds: "3"` inside `speak_each` → throws instead of defaulting `subRounds` to 1
- `exclude_self: "true"` (quoted) → throws; bare `exclude_self: yes` (YAML-1.1 Bool) still works and is pinned by a positive test
- `options: [cooperate, 42]` → throws instead of dropping the whole list
- `output: { count: 1 }` → throws instead of stringifying `1` to `"1"`
- `count: 42` top-level → throws listing supported extraData shapes
- `words: [{ majority: 1 }]` → throws instead of silently stringifying the Int

## Out of scope (deferred)

- Extending `AnyCodableValue` with `.int` / `.bool` / `.double` cases — future issue; users wanting a numeric top-level scalar should quote it (`count: "42"`)
- `displayName(for:)` helper to format `Array<String>` as "list of strings" in error messages
- Second-level extension-file split for extraData-shape tests

## Test plan

- [x] `PasturaTests/ScenarioLoaderTests` (30 tests, incl. 13 new strict-type tests) — passes
- [x] Full unit suite (`-skip-testing:PasturaUITests`) — passes (after flaky-sim re-run per memory note 38)
- [x] `swiftlint --strict` — clean
- [x] Preset + gallery YAMLs continue to load clean under strict loader
- [ ] Manual: open a preset in Visual Editor, save, re-open — extraData round-trips (already covered by #136 but worth a spot-check)

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)