### PR TITLE
🐛 fix: sync isPaused observation for memory-warning pause

### DIFF
--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -189,7 +189,18 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   /// co-manage `runner.isPaused` and `suspendController` so an in-flight
   /// generate is interrupted cooperatively rather than waiting for the next
   /// phase boundary (ADR-003 §10 invariant 6).
-  var isPaused: Bool { runner.isPaused }
+  ///
+  /// Manual `access(keyPath:)` / `withMutation(keyPath:)` hooks bridge this
+  /// computed property to the `@Observable` machinery: `SimulationRunner` is
+  /// a `nonisolated` class with lock-protected internal state — NOT itself
+  /// `@Observable` — so mutations of `runner.isPaused` cannot auto-trigger
+  /// the macro-synthesized change tracking. Without these hooks, SwiftUI
+  /// views reading `isPaused` would not re-render when the memory-warning
+  /// handler flips `runner.isPaused`, leaving the play/pause button stuck.
+  var isPaused: Bool {
+    access(keyPath: \.isPaused)
+    return runner.isPaused
+  }
 
   // MARK: - Background continuation state
 
@@ -407,7 +418,9 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     if let reason {
       logEntries.append(LogEntry(kind: .summary(text: reason)))
     }
-    runner.isPaused = true
+    withMutation(keyPath: \.isPaused) {
+      runner.isPaused = true
+    }
     suspendController?.requestSuspend()
   }
 
@@ -416,7 +429,9 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   /// the runner's phase-boundary checkpoint.
   func resumeSimulation() {
     lifecycleLogger.info("resumeSimulation: isPaused=\(self.isPaused)")
-    runner.isPaused = false
+    withMutation(keyPath: \.isPaused) {
+      runner.isPaused = false
+    }
     suspendController?.resume()
   }
 
@@ -426,6 +441,12 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     )
     runTask?.cancel()
     isCancelled = true
+    // Cancellation supersedes pause: without this clear, a paused-then-cancelled
+    // run would leave `isPaused == true` and leak an orange "Paused" pill into
+    // the terminal state (the header `else if` chain doesn't check `isCancelled`).
+    withMutation(keyPath: \.isPaused) {
+      runner.isPaused = false
+    }
     // Release a generate currently parked in `awaitResume()` so cancellation
     // propagates promptly from a suspended state. Idempotent per contract.
     suspendController?.resume()
@@ -449,6 +470,13 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     latestAgentOutputId = nil
     streamingSnapshot = nil
     prerevealedAgentOutputIds = []
+    // Defense against VM reuse: today production creates a fresh VM per view
+    // load, but that is not a documented invariant. A VM reused after a
+    // pause-then-cancel sequence would otherwise start the next run with
+    // `runner.isPaused == true` and show the resume icon on Round 1.
+    withMutation(keyPath: \.isPaused) {
+      runner.isPaused = false
+    }
     #if DEBUG
       inflightInferenceAttempts = [:]
       lastRawStreamingPrimary = [:]

--- a/Pastura/PasturaTests/App/SimulationViewModelLifecycleTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelLifecycleTests.swift
@@ -31,6 +31,24 @@ private func makeLifecycleSUT(
   return (sut, scenario)
 }
 
+/// One-shot boolean flag safely settable from `withObservationTracking`'s
+/// `@Sendable` onChange closure and readable from MainActor test code.
+/// Used only by `pauseSimulationInvalidatesIsPausedObservation`.
+final class FiredFlag: @unchecked Sendable {
+  private let lock = NSLock()
+  private var fired = false
+  var value: Bool {
+    lock.lock()
+    defer { lock.unlock() }
+    return fired
+  }
+  func fire() {
+    lock.lock()
+    fired = true
+    lock.unlock()
+  }
+}
+
 /// LLM service that always fails on loadModel, for testing error paths.
 nonisolated struct FailingLLMService: LLMService, Sendable {
   var isModelLoaded: Bool { false }
@@ -557,6 +575,61 @@ struct SimulationViewModelLifecycleTests {
     // DB row reflects the truth: the run completed, not failed.
     let sims = try simRepo.fetchByScenarioId("test")
     #expect(sims.first?.simulationStatus == .completed)
+  }
+
+  @Test func pauseSimulationInvalidatesIsPausedObservation() async throws {
+    // Regression test for the memory-warning pause UI desync: `isPaused` is
+    // a computed property that reads `runner.isPaused`, but `SimulationRunner`
+    // is not `@Observable` — so a plain `runner.isPaused = true` does not
+    // invalidate observers. The fix wraps the getter with `access(keyPath:)`
+    // and the mutation with `withMutation(keyPath:)`; this test guards that
+    // wiring against future refactors that strip either hook.
+    //
+    // Caveats on `withObservationTracking`:
+    // - It is one-shot — `onChange` fires exactly once per registration. A
+    //   naive "fires twice on pause+resume" extension would need to re-arm.
+    // - `onChange` fires synchronously *before* the mutation commits, so
+    //   reading `sut.isPaused` inside `onChange` returns the OLD value.
+    //   Both the "fired at all" and "new value" assertions must live
+    //   AFTER the mutating call, not inside `onChange`.
+    let (sut, _) = try makeLifecycleSUT()
+    sut.speed = .instant
+
+    let mock = MockLLMService(responses: [
+      #"{"statement": "first"}"#,
+      #"{"statement": "second"}"#
+    ])
+    let scenario = makeTestScenario(
+      agentNames: ["Alice", "Bob"],
+      rounds: 1,
+      phases: [Phase(type: .speakAll, prompt: "Speak", outputSchema: ["statement": "string"])]
+    )
+
+    let runTask = Task { await sut.run(scenario: scenario, llm: mock) }
+    sut.runTask = runTask
+
+    // Wait for run() to attach the SuspendController — proxy for "run is
+    // in-flight" so `pauseSimulation` does not early-return on `!isRunning`.
+    while sut.suspendController == nil {
+      await Task.yield()
+    }
+
+    let fired = FiredFlag()
+    withObservationTracking {
+      _ = sut.isPaused
+    } onChange: {
+      fired.fire()
+    }
+
+    sut.pauseSimulation(reason: "test observation")
+
+    #expect(fired.value == true, "pauseSimulation must invalidate isPaused observers")
+    #expect(sut.isPaused == true)
+
+    // Clean shutdown — resume so runTask completes rather than getting torn
+    // down by test-suite teardown mid-park.
+    sut.resumeSimulation()
+    await runTask.value
   }
 
   @Test func runClearsSuspendControllerOnExit() async throws {


### PR DESCRIPTION
## Summary

- Memory-warning pause path flipped `runner.isPaused = true` but didn't invalidate `@Observable` observers → play/pause button stuck until an unrelated re-render (e.g. scene-phase change) re-read the value.
- Bridge observation manually via `access(keyPath:)` + `withMutation(keyPath:)`. `runner.isPaused` remains the single source of truth (runner reads it internally under its own lock).
- Also clear `runner.isPaused` in `cancelSimulation` (cancel supersedes pause — prevents stale "Paused" pill) and in `run()` state-reset (defense-in-depth for VM-reuse refactors).
- **Incidental repair**: `.onChange(of: viewModel.isPaused)` at `SimulationView.swift:91` — which calls `memoryThrottle.reset()` — was silently inert pre-fix because `isPaused` never invalidated observers. Now works correctly; fewer spurious escalation-to-cancel after pause→resume.

## Test plan

- [x] New `pauseSimulationInvalidatesIsPausedObservation` regression test (`withObservationTracking` asserts `onChange` fires on `pauseSimulation()`); confirmed red before fix, green after.
- [x] Existing `pauseAndResumeMidRunCompletesNormally` continues to pass (invariant contract preserved).
- [x] Full unit suite: 1031 passed / 0 failed.
- [x] `swiftlint --strict`: clean.
- [ ] Manual on device/simulator: run inference, trigger memory warning (Debug → Simulate Memory Warning in simulator), verify play/pause button flips to play icon immediately.

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)