### PR TITLE
📝 docs: add @Observable bridge convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,12 @@ Utilities/ → depends on nothing
   Protocol-extension default implementations may additionally need explicit `nonisolated`
   when their body builds escaping closures — see `.claude/rules/llm.md`.
 - **"Why" comments:** Non-obvious choices must have a comment explaining **why**, not what.
+- **Observable bridge for non-`@Observable` state:** When an `@Observable` class exposes
+  a computed property that reads mutable state from a `nonisolated` class / actor,
+  bridge observation manually — `access(keyPath: \.prop)` in the getter and
+  `withMutation(keyPath: \.prop)` around every write. Without this, SwiftUI observers
+  don't get invalidated when the underlying state changes. Example:
+  `SimulationViewModel.isPaused` bridges to `SimulationRunner.isPaused` (PR #216).
 
 ## Tech Stack
 


### PR DESCRIPTION
## Summary

- Adds a Swift Coding Convention entry to `CLAUDE.md` about bridging `@Observable` observation when a computed property reads mutable state from a `nonisolated` class / actor.
- Driven by PR #216 — `SimulationViewModel.isPaused` bridging to `SimulationRunner.isPaused`. Documented so the same trap doesn't get rediscovered when multi-model support (#203) and Phase 3 KMP add more VM↔Engine boundary properties.
- Docs-only change; no code, no tests.

## Test plan

- [x] Diff visual review — entry matches the style of adjacent Swift Coding Conventions (No force unwrap, Default Actor Isolation, "Why" comments).
- [x] Markdown renders correctly on GitHub (regular list item, no syntax issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)