### PR TITLE
✨ feat: reviewer-model decision in /orchestrate

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -58,6 +58,23 @@ Utilities/ -> depends on nothing
 - Test coverage for new public types/functions
 - No exposed secrets or API keys
 
+### Pastura-specific Trap Cheat Sheet (Warning)
+
+Footguns documented from prior incidents. Check each change against these **in addition** to the general rules above — none of these are caught by `swiftlint` or `swift build` alone.
+
+- **ShapeStyle vs Color tokens** — `.foregroundStyle(.muted)` fails to compile when `.muted` is a project `Color` extension. Use `.foregroundStyle(Color.muted)` (explicit `Color.` prefix). Applies to any `Color` extension consumed via `ShapeStyle`-expecting modifiers.
+- **`nonisolated` protocol default impls** — When an extension on a `nonisolated` protocol provides a default implementation whose body builds escaping closures (`AsyncThrowingStream { continuation in ... }`, standalone `Task { }`, `continuation.onTermination = ...`), the default impl itself must be marked `nonisolated`. Otherwise MainActor inference breaks conformance at conforming types with a cryptic "crosses into main actor-isolated code" diagnostic. See `.claude/rules/llm.md`.
+- **Test suite `.timeLimit` trait** — Every `@Suite` in `PasturaTests/` must carry `.timeLimit(.minutes(1))`. Load-bearing CI-hang diagnostic (PR #134) — do not remove even when a suite "looks fine". New suites without the trait are a Warning.
+- **Test suite serialization** — Suites touching `SimulationRunner` or other global-state consumers must use `@Suite(.serialized)`. Missing serialization causes race-flake between parallel test cases.
+- **Error i18n prep** — Error types' `errorDescription` literals must be wrapped in `String(localized:)` for future translation readiness. Test assertions should use `.contains(localizedSubstring)` rather than equality on the rendered string. Check `LLMError`, `DataError`, `SimulationError`, and any new `LocalizedError` addition.
+- **Navigation root-stack scope** — `navigationDestination(item:|isPresented:)` MUST NOT appear inside any view that gets pushed onto the root `NavigationStack`. Sheet-owned NavigationStacks are exempt. See `.claude/rules/navigation.md`. Also: `router.path` must not be mutated outside `AppRouter` itself — grep check: `rg 'router\.path\s*(=[^=]|\.append|\.removeLast|\.removeAll|\.insert|\.remove\b)' Pastura --glob '!**/AppRouter*'` should return nothing.
+- **SwiftUI `.sheet(item:)` source type** — the binding must be `Optional<SomeIdentifiableModel>`. Never use `Int: Identifiable` or other primitive wrappers — use a real model type.
+- **ViewModel ownership** — do not instantiate `@Observable` ViewModels inside factory functions that get re-invoked per body evaluation. Host them with `@State` (or equivalent) in the owning view.
+- **Wall-clock test bounds need CI headroom** — CI with code coverage runs ~20× slower than local. Upper bounds in wall-clock timing assertions must be ≥ 30s, or (preferred) inject an observable and assert on it instead of polling.
+- **PlistBuddy output ambiguity** — Bool `false` and string `"NO"` render identically via PlistBuddy `Print`. Use `plutil -extract <key> xml1 - -- <plist>` when the type distinction matters (App Store Connect flags, CFBundle keys, entitlements).
+
+Sources: `.claude/rules/{llm,navigation,testing}.md`, MEMORY.md feedback entries. If a reviewer encounters a new footgun that generalizes, propose adding it here as part of the review output.
+
 ## Output Format
 
 ```

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -38,7 +38,7 @@ After fetching the issue, check for an existing plan comment:
 2. If a plan comment is found:
    - Set `RESUMING=true`, `ISSUE_NUMBER=N`, and capture `COMMENT_ID`.
    - Parse checkboxes: count `- [x]` (done) vs `- [ ]` (remaining). Identify `NEXT_ITEM` (first unchecked item number).
-   - Extract `TASK_TYPE` and branch name from the `## Metadata` section in the comment.
+   - Extract `TASK_TYPE`, branch name, and `REVIEWER_MODEL` from the `## Metadata` section in the comment. If `Reviewer` is absent from Metadata (e.g., older plan comment pre-dating this field), default `REVIEWER_MODEL=opus`.
    - Derive `SLUG` from the branch name.
    - If **all items are already checked**: ensure you are on the feature branch or in the correct worktree, then report "All {TOTAL} items already complete. Proceeding to review." and **skip to Step 4** directly.
    - Report to user: "Found existing plan on issue #N. {DONE}/{TOTAL} items complete. Resuming from item {NEXT_ITEM}."
@@ -70,7 +70,38 @@ After fetching the issue, check for an existing plan comment:
    ...
    ```
    Present this plan to the user. Store internally as `PLAN_BODY` for Issue attachment in Step 2.
-4. **Ask: "Proceed with this plan?"** — For single-commit fixes, combine G1 and G2 into one confirmation, but still run Step 1b (critic review) before creating the worktree.
+4. **Assign a reviewer model** for the PR as a whole (single choice, not per-item). This determines which model runs the `code-reviewer` subagent at Step 4. Criteria:
+
+   **Opus required if any plan item touches:**
+   - Dependency rule boundaries (Engine ↔ LLM ↔ Data ↔ Models interrelations)
+   - Actor isolation / `Sendable` / `@MainActor` / `nonisolated` design
+   - Public protocol signatures or access modifier changes
+   - AppRouter / navigation routing (`Route` enum, `router.push` callsites)
+   - `App/` layer changes touching BG execution, `SimulationViewModel`, or `AppRouter`
+   - Decision records (`docs/decisions/ADR-*.md`) or architectural specs (`docs/specs/**`)
+   - CI / build infrastructure (`.github/workflows/**`, `scripts/**`)
+   - Project tooling (`CLAUDE.md`, `.claude/{skills,agents,rules}/**`)
+   - Content safety surface (ADR-005 related: `ContentFilter`, `PrivacyInfo.xcprivacy`, `Info.plist`)
+   - LLM backend code or prompt templates
+   - Design system foundations (`docs/design/design-system.md`, `DesignTokens*.swift`)
+
+   **Sonnet reviewer acceptable if the change is strictly one of:**
+   - New `@Test` cases in an **existing** suite following the file's existing pattern (not new suites, new helpers, or trait changes like `.timeLimit` / `.serialized`)
+   - Documentation updates (`docs/ROADMAP.md`, `docs/examples/**`, `docs/gallery/**`, `docs/prototype/**`, doc comments)
+   - Simple refactor within a single file without crossing layer boundaries
+   - Design token **application** (existing token to existing View only — new token additions are Opus-required)
+   - Fix-only PRs where the cause is already diagnosed and localized
+
+   **Coupling rule:** If **any** plan item is labeled 🔴, the reviewer MUST be Opus — even if the target paths look Sonnet-eligible. This prevents the "all-🟢-plus-Sonnet-reviewer" configuration from putting Opus-implemented work through a Sonnet review.
+
+   **When in doubt, pick Opus.** Subtle convention violations (ShapeStyle+Color token trap, `nonisolated` gaps, i18n `String(localized:)` omissions, missing `@Suite(.timeLimit(.minutes(1)))` on new test suites) cost more than an over-zealous Opus review.
+
+   Record the decision in the `## Metadata` block of the plan comment (see Step 2a) as:
+   ```
+   - **Reviewer**: Opus (reason: touches Engine/ dependency boundary)
+   ```
+   The user may override at G1. Resumed sessions recover the decision from `## Metadata` (see Step 0).
+5. **Ask: "Proceed with this plan?"** — For single-commit fixes, combine G1 and G2 into one confirmation, but still run Step 1b (critic review) before creating the worktree.
 
 After user approval, proceed to Step 1b (mandatory critic review).
 
@@ -80,7 +111,7 @@ After user approval, proceed to Step 1b (mandatory critic review).
 
 After the user approves the plan (G1), launch a `critic` subagent via the Agent tool to review the plan for blind spots.
 
-> **Agent prompt:** "Review the following implementation plan for the Pastura project. Focus on: scope creep beyond current phase, dependency rule violations in the planned file locations, missing edge cases, integration risks with existing modules, and assumptions not validated against the codebase.
+> **Agent prompt:** "Review the following implementation plan for the Pastura project. Focus on: scope creep beyond current phase, dependency rule violations in the planned file locations, missing edge cases, integration risks with existing modules, and assumptions not validated against the codebase. If the plan declares a reviewer-model choice, include an axis evaluating whether that choice matches the actual sensitivity of the touched paths.
 >
 > Task: {TASK_DESCRIPTION}
 >
@@ -119,6 +150,7 @@ Note: This is a mandatory review step between G1 and G2. The flow is G1 → Step
   ## Metadata
   - **Type**: {TASK_TYPE}
   - **Branch**: `{TASK_TYPE}/{SLUG}`
+  - **Reviewer**: {REVIEWER_MODEL} (reason: {REVIEWER_RATIONALE})
   PASTURA_PLAN
   )" --jq '.id')
   ```
@@ -262,7 +294,11 @@ After all implementation, run full verification directly from the main session:
 
 ## Step 4: Review — Gate G3
 
-Launch a `code-reviewer` subagent via the Agent tool to review all changes on the feature branch:
+Launch a `code-reviewer` subagent via the Agent tool to review all changes on the feature branch. Pass `model: $REVIEWER_MODEL` (resolved from the plan's `## Metadata` — via Step 0 on resumption, or via Step 1 on a fresh run; defaults to Opus if absent). The Agent tool's `model` parameter takes precedence over the agent frontmatter's `model: opus`, so no changes to `.claude/agents/code-reviewer.md` are required.
+
+```
+Agent(subagent_type: "code-reviewer", model: $REVIEWER_MODEL, description: "...", prompt: "...")
+```
 
 > **Agent prompt:** "Review all code changes on this feature branch. Run `git diff {DEFAULT_BRANCH}...HEAD` to see the full diff (all commits since branching, not just uncommitted changes). Read every changed file in full for context. Evaluate against your complete checklist (Hard Rules, Dependency Rules, Access Modifiers, Swift 6 Concurrency, Code Quality). Output your review in your standard format."
 

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -38,8 +38,9 @@ After fetching the issue, check for an existing plan comment:
 2. If a plan comment is found:
    - Set `RESUMING=true`, `ISSUE_NUMBER=N`, and capture `COMMENT_ID`.
    - Parse checkboxes: count `- [x]` (done) vs `- [ ]` (remaining). Identify `NEXT_ITEM` (first unchecked item number).
-   - Extract `TASK_TYPE`, branch name, and `REVIEWER_MODEL` from the `## Metadata` section in the comment. If `Reviewer` is absent from Metadata (e.g., older plan comment pre-dating this field), default `REVIEWER_MODEL=opus`.
+   - Extract `TASK_TYPE`, branch name, and `REVIEWER_MODEL` from the `## Metadata` section in the comment. **Normalize `REVIEWER_MODEL` to lowercase** (`opus` / `sonnet`) when binding — Metadata records it title-case (`Opus` / `Sonnet`) for readability, but downstream Agent calls use lowercase. If `Reviewer` is absent from Metadata (e.g., older plan comment pre-dating this field), default `REVIEWER_MODEL=opus`.
    - Derive `SLUG` from the branch name.
+   - **Coupling re-check**: if the resumed plan contains any `🔴` item but `REVIEWER_MODEL=sonnet` (e.g., from a post-plan Metadata edit that bypassed the Step 1 coupling rule), warn the user and offer to upgrade to Opus before continuing. Reason: Opus-implemented items should never be Sonnet-reviewed.
    - If **all items are already checked**: ensure you are on the feature branch or in the correct worktree, then report "All {TOTAL} items already complete. Proceeding to review." and **skip to Step 4** directly.
    - Report to user: "Found existing plan on issue #N. {DONE}/{TOTAL} items complete. Resuming from item {NEXT_ITEM}."
    - **Skip Step 1 and Step 1b entirely** → proceed to Step 2.
@@ -85,7 +86,7 @@ After fetching the issue, check for an existing plan comment:
    - LLM backend code or prompt templates
    - Design system foundations (`docs/design/design-system.md`, `DesignTokens*.swift`)
 
-   **Sonnet reviewer acceptable if the change is strictly one of:**
+   **Sonnet reviewer acceptable** — the change must be strictly a subset of the 🟢 simple-item criteria above (existing pattern reuse, test-only changes following an existing pattern, type/error case additions, doc comments, minor fixes), AND none of the items match the Opus-required list. Concretely, the most common Sonnet-acceptable shapes are:
    - New `@Test` cases in an **existing** suite following the file's existing pattern (not new suites, new helpers, or trait changes like `.timeLimit` / `.serialized`)
    - Documentation updates (`docs/ROADMAP.md`, `docs/examples/**`, `docs/gallery/**`, `docs/prototype/**`, doc comments)
    - Simple refactor within a single file without crossing layer boundaries
@@ -100,8 +101,8 @@ After fetching the issue, check for an existing plan comment:
    ```
    - **Reviewer**: Opus (reason: touches Engine/ dependency boundary)
    ```
-   The user may override at G1. Resumed sessions recover the decision from `## Metadata` (see Step 0).
-5. **Ask: "Proceed with this plan?"** — For single-commit fixes, combine G1 and G2 into one confirmation, but still run Step 1b (critic review) before creating the worktree.
+   Store the rationale string as `REVIEWER_RATIONALE` (the `(reason: ...)` tail) for use in the Step 2a template. The user may override at G1. Resumed sessions recover the decision from `## Metadata` (see Step 0).
+5. **Ask: "Proceed with this plan and reviewer-model choice?"** — present both the plan checkboxes and the proposed `Reviewer:` decision so the user can override the reviewer at G1. For single-commit fixes, combine G1 and G2 into one confirmation, but still run Step 1b (critic review) before creating the worktree.
 
 After user approval, proceed to Step 1b (mandatory critic review).
 
@@ -297,8 +298,10 @@ After all implementation, run full verification directly from the main session:
 Launch a `code-reviewer` subagent via the Agent tool to review all changes on the feature branch. Pass `model: $REVIEWER_MODEL` (resolved from the plan's `## Metadata` — via Step 0 on resumption, or via Step 1 on a fresh run; defaults to Opus if absent). The Agent tool's `model` parameter takes precedence over the agent frontmatter's `model: opus`, so no changes to `.claude/agents/code-reviewer.md` are required.
 
 ```
-Agent(subagent_type: "code-reviewer", model: $REVIEWER_MODEL, description: "...", prompt: "...")
+Agent(subagent_type: "code-reviewer", model: "$REVIEWER_MODEL", description: "...", prompt: "...")
 ```
+
+`$REVIEWER_MODEL` is the lowercase form (`opus` / `sonnet`) bound at Step 0 / Step 1 — the surrounding quotes match the Step 3 Sonnet-delegation convention (`Agent(model: "sonnet")`).
 
 > **Agent prompt:** "Review all code changes on this feature branch. Run `git diff {DEFAULT_BRANCH}...HEAD` to see the full diff (all commits since branching, not just uncommitted changes). Read every changed file in full for context. Evaluate against your complete checklist (Hard Rules, Dependency Rules, Access Modifiers, Swift 6 Concurrency, Code Quality). Output your review in your standard format."
 

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -127,8 +127,6 @@ Handle the critic's output:
 
 *Skipped when `RESUMING=true`* (plan was already approved and critiqued in a prior session).
 
-Note: This is a mandatory review step between G1 and G2. The flow is G1 → Step 1b (critic) → G2 → G3 → G4.
-
 ## Step 2: Issue + Worktree — Gate G2
 
 **Precondition:** Step 1b critic review completed (or `RESUMING=true`).
@@ -204,7 +202,7 @@ Follow the plan from Step 1 (or the resumed plan from the Issue). **If `RESUMING
 
 For each unit of work (let `K` = the current plan item number), check the item's complexity label:
 
-### 🔴 Complex items — Orchestrator implements directly (current flow)
+### 🔴 Complex items — Orchestrator implements directly
 
 1. Write test first (TDD mandatory per CLAUDE.md).
 2. Run targeted tests — confirm failure:
@@ -275,8 +273,6 @@ Launch a subagent via `Agent(model: "sonnet")` **without `isolation`** (shares t
 
 Note: `git commit` is NOT in the permissions allowlist — each commit triggers user approval (intentional security gate).
 
-SwiftLint runs automatically via PreToolUse hook on `git commit`.
-
 After all implementation, run full verification directly from the main session:
 
 1. Run the full test suite:
@@ -295,7 +291,7 @@ After all implementation, run full verification directly from the main session:
 
 ## Step 4: Review — Gate G3
 
-Launch a `code-reviewer` subagent via the Agent tool to review all changes on the feature branch. Pass `model: $REVIEWER_MODEL` (resolved from the plan's `## Metadata` — via Step 0 on resumption, or via Step 1 on a fresh run; defaults to Opus if absent). The Agent tool's `model` parameter takes precedence over the agent frontmatter's `model: opus`, so no changes to `.claude/agents/code-reviewer.md` are required.
+Launch a `code-reviewer` subagent via the Agent tool to review all changes on the feature branch. Pass `model: $REVIEWER_MODEL` (resolved from the plan's `## Metadata` — via Step 0 on resumption, or via Step 1 on a fresh run; defaults to Opus if absent). The Agent tool's `model` parameter takes precedence over the agent frontmatter's `model: opus`. The agent's checklist was enriched with a Pastura-specific trap cheat sheet in this same PR to keep the Sonnet-reviewer path safe.
 
 ```
 Agent(subagent_type: "code-reviewer", model: "$REVIEWER_MODEL", description: "...", prompt: "...")
@@ -326,7 +322,6 @@ Agent(subagent_type: "code-reviewer", model: "$REVIEWER_MODEL", description: "..
 ```
 
 Show the final review report. **Ask: "Create PR?"**
-- If unresolved after 3 iterations, present outstanding issues and let the user decide whether to proceed or continue fixing.
 
 ## Step 5: PR Creation — Gate G4
 
@@ -351,11 +346,9 @@ Present PR draft (title + body + label) for user review:
 - Title: Emoji prefix + Conventional format, under 70 chars (same emoji convention as CLAUDE.md commits)
 - Body: Summary bullets + test plan + `Closes #N` (always present — Issue is always created)
 - Label: from the table above
-- Assignee: always `@me`
 
 **Ask: "Create this PR?"**
 
-Use HEREDOC with distinctive delimiter:
 ```bash
 gh pr create --base "$BASE_BRANCH" --assignee "@me" --label "$LABEL" \
   --title "..." --body "$(cat <<'IMPLEMENT_PR_BODY'
@@ -372,16 +365,10 @@ Push the branch first: `git push -u origin <branch>`. Then create the PR.
 
 After creation:
 - Print the PR URL.
-- "Wait for all required status checks to pass, then **merge manually**. Auto-merge is disabled."
+- "Wait for all required status checks to pass, then **merge manually**."
 
-## Step 6: Cleanup & Abandonment
+## Step 6: Cleanup
 
 **After merge** (guidance only — do NOT auto-execute):
 1. `ExitWorktree` with action `"remove"`
 2. `git checkout <default-branch> && git pull`
-3. Remote branch: GitHub may auto-delete; if not, `git push origin --delete <branch>`
-
-**To abandon** (no PR, or after PR created but want to cancel):
-1. If PR exists: `gh pr close <number>`
-2. `ExitWorktree` with action `"remove"`
-3. If already pushed: `git push origin --delete <branch>`

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -40,7 +40,7 @@ After fetching the issue, check for an existing plan comment:
    - Parse checkboxes: count `- [x]` (done) vs `- [ ]` (remaining). Identify `NEXT_ITEM` (first unchecked item number).
    - Extract `TASK_TYPE`, branch name, and `REVIEWER_MODEL` from the `## Metadata` section in the comment. **Normalize `REVIEWER_MODEL` to lowercase** (`opus` / `sonnet`) when binding — Metadata records it title-case (`Opus` / `Sonnet`) for readability, but downstream Agent calls use lowercase. If `Reviewer` is absent from Metadata (e.g., older plan comment pre-dating this field), default `REVIEWER_MODEL=opus`.
    - Derive `SLUG` from the branch name.
-   - **Coupling re-check**: if the resumed plan contains any `🔴` item but `REVIEWER_MODEL=sonnet` (e.g., from a post-plan Metadata edit that bypassed the Step 1 coupling rule), warn the user and offer to upgrade to Opus before continuing. Reason: Opus-implemented items should never be Sonnet-reviewed.
+   - **Coupling re-check**: if the resumed plan contains any `🔴` item but `REVIEWER_MODEL=sonnet` (e.g., from a post-plan Metadata edit that bypassed the Step 1 coupling rule), warn the user and offer to upgrade to Opus before continuing — that is, before proceeding to Step 2 in the normal flow, or before the Step 4 review when all items are already complete. Reason: Opus-implemented items should never be Sonnet-reviewed.
    - If **all items are already checked**: ensure you are on the feature branch or in the correct worktree, then report "All {TOTAL} items already complete. Proceeding to review." and **skip to Step 4** directly.
    - Report to user: "Found existing plan on issue #N. {DONE}/{TOTAL} items complete. Resuming from item {NEXT_ITEM}."
    - **Skip Step 1 and Step 1b entirely** → proceed to Step 2.
@@ -155,7 +155,7 @@ Note: This is a mandatory review step between G1 and G2. The flow is G1 → Step
   PASTURA_PLAN
   )" --jq '.id')
   ```
-  Set `ISSUE_NUMBER=N`.
+  Set `ISSUE_NUMBER=N`. When emitting `{REVIEWER_MODEL}` into Metadata, title-case the value (`Opus` / `Sonnet`) for readability — Step 0's parser normalizes back to lowercase on read.
 
 **Otherwise** (new task — always create issue, because checkpoint sync and resumption require a `COMMENT_ID` on a real Issue):
 - Determine `LABEL` from `TASK_TYPE` using the label mapping table in Step 5.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Completed in Phase 2 so far:
 
 ## Language Rules
 
-- Conversation with user: **Japanese**
+- Conversation: **Match the user's language.** No project-level pin — defer to the operator's personal CLAUDE.md if a default is configured.
 - Code, commit messages, comments, documentation: **English**
 
 ## Project Overview
@@ -75,6 +75,7 @@ Utilities/ → depends on nothing
 - **Automated hooks** (`.claude/settings.json`): On file edit (`PostToolUse` Edit|Write), `swift-format` + `swiftlint --fix` auto-format. On `git commit` (`PreToolUse`), `swiftlint lint --strict` + `xcodebuild build` run and block the commit on lint violations or compile errors.
 - **Error types:** Layer-specific — `SimulationError` (Models, co-located with `SimulationEvent`),
   `LLMError` (LLM), `DataError` (Data). App layer catches and maps to UI presentation.
+- **Error message i18n prep:** On `LocalizedError`-conforming types (`SimulationError`, `LLMError`, `DataError`, ...), wrap `errorDescription` literals in `String(localized: "...")`. Tests assert via `.contains(...)` partial matching, not equality. Keeps the current English-only scope while making future translation additive.
 - **Swift 6 Concurrency:** `Sendable` for cross-actor types, `@MainActor` for UI state,
   `AsyncStream` over callbacks. Engine/LLM work runs on non-main actors or default executor.
 - **Default Actor Isolation:** Project uses `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`.
@@ -104,7 +105,7 @@ Utilities/ → depends on nothing
 | LLM (target)       | LiteRT-LM iOS SDK (planned)  |           |
 | LLM (dev)          | Ollama via OpenAI-compat API  |           |
 | LLM (test)         | MockLLMService                |           |
-| LLM model          | Gemma 4 E2B Q4_K_M (GGUF)    | ~3.1 GB   |
+| LLM models         | Runtime-selectable GGUF (see `App/ModelRegistry.swift`) | ~2.5–3.1 GB each |
 
 LLM backend: llama.cpp is the interim backend for TestFlight (Metal GPU, on-device).
 Migrate to LiteRT-LM when Swift SDK + iOS GPU support ships.
@@ -135,6 +136,7 @@ Implementation order: `Models → LLM → Engine → Data → Views → App → 
 - **Commits:** Conventional Commits with emoji prefix, under 72 chars.
   `✨ feat:`, `🐛 fix:`, `♻️ refactor:` — add body when "why" isn't obvious.
 - **Small and focused** — one logical change per commit.
+- **Closing issues in multi-PR splits:** GitHub auto-closes on any `Closes #N` / `Fixes #N` match in the PR body, ignoring qualifiers like "partially" or "PR1 of 3". In non-final PRs of a split, reference without a close-directive keyword (`See #N`, `Part of #N`, `Relates to #N`). Only the final PR should carry `Closes #N`. If auto-close fires by accident on a non-final PR, recover immediately: `gh issue reopen <N> --comment "still tracking remaining scope: ..."`.
 
 ### Test Execution
 
@@ -190,6 +192,12 @@ burning wall-clock and orphaning processes:
   `timeout: 900000` (15 min) when UI tests are included.
 - For runs expected to exceed 5 minutes, prefer `run_in_background: true`
   and poll with Monitor / BashOutput rather than blocking the session.
+- When piping through `tail` (e.g. `xcodebuild ... 2>&1 | tail -80`), the
+  pipe's exit code is `tail`'s, not `xcodebuild`'s — a failed build reports
+  `exit code 0`. Grep the tailed output for `** BUILD|TEST SUCCEEDED/FAILED **`
+  or `xcodebuild: error:` before trusting the harness exit code, or use
+  `set -o pipefail`. When the SUCCEEDED marker has been trimmed off entirely,
+  extract the verdict from the xcresult bundle: `xcrun xcresulttool get test-results summary --path "$XCRESULT" --format json`.
 
 **Recovery (if a run hangs or a retry immediately stalls):**
 
@@ -225,13 +233,16 @@ Pastura/
 ├── Views/             # SwiftUI screens
 │   ├── Home/
 │   ├── ScenarioDetail/
-│   ├── Import/
+│   ├── Editor/
 │   ├── Simulation/
 │   ├── Results/
-│   └── Components/
+│   ├── Components/    # shared UI building blocks
+│   └── ...            # additional screens (Community, Import, Settings, ModelDownload, ModelSelection)
 ├── Utilities/
 └── Resources/
-    └── Presets/        # Bundled YAML scenarios
+    ├── Presets/              # Bundled YAML scenarios
+    ├── DemoReplays/          # DL-time demo playback (ADR-007)
+    └── ContentBlocklist.txt  # ADR-005 content safety
 ```
 
 ## Context-Specific Rules
@@ -252,6 +263,8 @@ pushed onto the root stack. Sheet-owned NavigationStacks are exempt.
 ## Decision Records
 
 Record architectural decisions in `docs/decisions/` as `ADR-NNN.md`.
+
+**Editability window**: For recently-Accepted ADRs whose decisions have not yet shipped in code, prefer **in-place edits** when implementation planning surfaces a refinement. Use `§N. Amendment YYYY-MM-DD` sections only after the ADR's decisions have been implemented — Amendment text doubles reviewer overhead on every cross-section read.
 
 ## Reference Documents
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ Utilities/ → depends on nothing
 
 ## Swift Coding Conventions
 
-- **Formatting:** `swift-format` + `swiftlint --fix` auto-applied via hooks on every file edit.
+- **Automated hooks** (`.claude/settings.json`): On file edit (`PostToolUse` Edit|Write), `swift-format` + `swiftlint --fix` auto-format. On `git commit` (`PreToolUse`), `swiftlint lint --strict` + `xcodebuild build` run and block the commit on lint violations or compile errors.
 - **Error types:** Layer-specific — `SimulationError` (Models, co-located with `SimulationEvent`),
   `LLMError` (LLM), `DataError` (Data). App layer catches and maps to UI presentation.
 - **Swift 6 Concurrency:** `Sendable` for cross-actor types, `@MainActor` for UI state,


### PR DESCRIPTION
## Summary

- Extend `/orchestrate` skill to decide the `code-reviewer` subagent model (Sonnet/Opus) at plan time via criteria, recorded in the Issue plan `## Metadata`, enforced at Step 4 via `Agent(model:)` override.
- Criteria-based mirrors the existing 🟢/🔴 pattern (no curated path-glob list); includes an **"any 🔴 ⇒ Opus reviewer" coupling rule** to prevent compounding downshifts.
- **`.claude/agents/code-reviewer.md` gets a Pastura-specific trap cheat sheet** (ShapeStyle+Color, `nonisolated` gaps, `@Suite` `.timeLimit`/`.serialized`, i18n `String(localized:)`, AppRouter navigation scope, `.sheet(item:)` typing, ViewModel ownership, wall-clock test bounds, PlistBuddy rendering). Bundled with the mechanism change so the Sonnet-reviewer path is safe from the moment it ships.
- **Housekeeping** — trimmed 10 redundant passages in SKILL.md (387 → 374 lines, critic-reviewed), expanded the CLAUDE.md Automated hooks bullet to cover both hook lifecycle points (edit-time + pre-commit), and ran a 4-area CLAUDE.md audit bundled here as a Claude Code configuration pass:
  - **Memory promotion**: 4 project-wide rules moved from memory to CLAUDE.md (ADR editability window, `Closes #N` multi-PR splits, `xcodebuild|tail` exit-code trap + `xcresulttool` recovery, Error message i18n prep). Long-form retained in memory as change log.
  - **Tech Stack**: model row abstracted (multiple GGUF models now; point at `App/ModelRegistry.swift`).
  - **Directory Structure**: `Views/` updated with main-flow screens + `...` note; `Resources/` now lists `DemoReplays/` (ADR-007) and `ContentBlocklist.txt` (ADR-005).
  - **Language Rules**: "Conversation with user: Japanese" was a personal setting in a contributor-facing file → replaced with neutral "Match the user's language" breadcrumb. Japanese default moved to operator's `~/.claude/CLAUDE.md` separately.

Edits in `SKILL.md` (5 coordinated): Step 0 resumption parser + coupling re-check + case normalization, Step 1 criteria + coupling rule + `REVIEWER_RATIONALE` binding, Step 1b critic prompt, Step 2a Metadata template, Step 4 `Agent(model:)` override.

## Test plan

- [x] `swiftlint --strict` + `xcodebuild build` via pre-commit hooks passed on each of 7 commits
- [x] Self-dogfooded: this PR was orchestrated through `/orchestrate` itself; the new criteria self-consistently selected Opus reviewer (`.claude/skills/**` matches "Project tooling")
- [x] `code-reviewer` invoked with explicit `model: "opus"` (2-iteration review/fix loop), verifying the Agent tool's `model:` override end-to-end
- [x] CLAUDE.md housekeeping critic-reviewed before apply (Critical on language silent-delete → breadcrumb preserved)
- N/A Swift test suite — zero Swift files changed; markdown edits only

## Follow-up (separate Issue, deferred)

- First intentionally Sonnet-reviewed dogfood PR (small doc fix) to empirically exercise the Sonnet reviewer branch end-to-end. Safe to defer: the cheat sheet (this PR) is the blocking safety prerequisite.

## Accepted residual risk

Resumption scope expansion: `REVIEWER_MODEL=sonnet` from a prior session can persist when resumed work expands into sensitive paths. Mitigated in the common case by the 🔴 coupling re-check on resumption. If realized in practice, add a narrow mechanical denylist as a follow-up.

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)