### PR TITLE
🐛 fix: nonisolate avatar layout helpers for Sendable closures

### DIFF
--- a/Pastura/Pastura/Views/Components/ChatBubble.swift
+++ b/Pastura/Pastura/Views/Components/ChatBubble.swift
@@ -153,7 +153,13 @@ struct AvatarSlot: View {
 /// Shared layout values for composing chat rows. Exposed as a namespace
 /// (rather than spreading constants across individual primitives) so
 /// consumers + tests reference a single authoritative source.
-enum ChatBubbleLayout {
+///
+/// `nonisolated` because these constants are read from `@Sendable`
+/// closures (e.g. `.alignmentGuide(.top)` in `AgentOutputRow`) under
+/// Swift 6's stricter inference; the namespace holds only pure
+/// `CGFloat` values, so the type-level marker is safe and prevents
+/// future call sites from re-tripping the same warning.
+nonisolated enum ChatBubbleLayout {
   /// Avatar diameter — `design-system.md` §5.2. Bumped from 42pt to
   /// 48pt in #171 so the sheep silhouette reads more clearly on
   /// ~390pt iPhone widths. Both docs (`design-system.md` §5.2 +

--- a/Pastura/Pastura/Views/Components/DogMark.swift
+++ b/Pastura/Pastura/Views/Components/DogMark.swift
@@ -33,7 +33,11 @@ public struct DogMark: View {
   /// surrounding text can use `.alignmentGuide(.top) { _ in
   /// DogMark.visibleTopInset(forSize: size) }`. Kept on the component
   /// so the `y = 5` invariant lives next to the path that encodes it.
-  public static func visibleTopInset(forSize size: CGFloat) -> CGFloat {
+  ///
+  /// `nonisolated` because `.alignmentGuide(.top)` takes a `@Sendable`
+  /// closure under Swift 6's stricter inference; without it the call
+  /// crosses MainActor isolation and warns at the call site.
+  nonisolated public static func visibleTopInset(forSize size: CGFloat) -> CGFloat {
     size * 5.0 / 26.0
   }
 

--- a/Pastura/Pastura/Views/Components/SheepAvatar.swift
+++ b/Pastura/Pastura/Views/Components/SheepAvatar.swift
@@ -37,7 +37,11 @@ public struct SheepAvatar: View {
   /// Kept on the component so the `y = 7` invariant lives next to the
   /// wool-circle geometry that encodes it — mirrors `DogMark`'s
   /// `visibleTopInset(forSize:)` pattern.
-  public static func visibleTopInset(forSize size: CGFloat) -> CGFloat {
+  ///
+  /// `nonisolated` because `.alignmentGuide(.top)` takes a `@Sendable`
+  /// closure under Swift 6's stricter inference; without it the call
+  /// crosses MainActor isolation and warns at the call site.
+  nonisolated public static func visibleTopInset(forSize size: CGFloat) -> CGFloat {
     size * 7.0 / 28.0
   }
 

--- a/Pastura/Pastura/Views/ModelDownload/PromoCard.swift
+++ b/Pastura/Pastura/Views/ModelDownload/PromoCard.swift
@@ -199,7 +199,11 @@ struct PromoCard: View {
 
   /// Point size of the dog mark in the promo body row. Spec §PromoCard
   /// body structure (`demo-replay-ui.md` §PromoCard) pins this at 26 pt.
-  private static let dogSize: CGFloat = 26
+  ///
+  /// `nonisolated` because it is read inside a `.alignmentGuide(.top)`
+  /// `@Sendable` closure (line 182); pure value, safe to publish across
+  /// isolation domains.
+  nonisolated private static let dogSize: CGFloat = 26
 
   // MARK: - Decorative layers
 


### PR DESCRIPTION
## Summary
- Mark `SheepAvatar.visibleTopInset(forSize:)`, `DogMark.visibleTopInset(forSize:)`, `ChatBubbleLayout` enum, and `PromoCard.dogSize` as `nonisolated` to silence Swift 6 Sendable-inference warnings at `AgentOutputRow.swift:234` (×2) and `PromoCard.swift:182`.
- All four targets are pure values / pure arithmetic — `nonisolated` is trivially safe.
- Each new marker carries a one-line "Why" comment per CLAUDE.md convention.

## Test plan
- [x] `xcodebuild build` succeeds with no remaining Sendable-closure warnings on the touched call sites
- [x] No behavior change — existing `ChatBubbleTests`, `SheepAvatarTests`, `DemoReplayHostViewTests+Layout` continue to read the constants unchanged
- [ ] CI green

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)