### PR TITLE
🧹 chore: tidy up config-doctor warns + slim CLAUDE.md

### DIFF
--- a/.claude/rules/llm.md
+++ b/.claude/rules/llm.md
@@ -29,7 +29,7 @@ unannotated.
 
 ### Example
 
-`Pastura/LLM/LLMService.swift` has both patterns:
+`Pastura/Pastura/LLM/LLMService.swift` has both patterns:
 
 ```swift
 extension LLMService {

--- a/.claude/rules/xcodebuild-cli.md
+++ b/.claude/rules/xcodebuild-cli.md
@@ -1,0 +1,83 @@
+# xcodebuild CLI Rules
+
+Extracted from CLAUDE.md to keep the top-level project file lean. Always-loaded
+— see CLAUDE.md "Context-Specific Rules" for the loading-mode rationale.
+
+## Test Execution
+
+```bash
+source "$(git rev-parse --show-toplevel)/scripts/sim-dest.sh"
+
+# Run all tests
+xcodebuild test -scheme Pastura -project Pastura/Pastura.xcodeproj \
+  -destination "$DEST" -derivedDataPath "$DERIVED_DATA"
+
+# Run specific test class
+xcodebuild test -scheme Pastura -project Pastura/Pastura.xcodeproj \
+  -destination "$DEST" -derivedDataPath "$DERIVED_DATA" \
+  -only-testing PasturaTests/JSONResponseParserTests
+
+# Run Ollama integration tests (requires local Ollama with target model pulled)
+# Enable OLLAMA_INTEGRATION in scheme: Edit Scheme → Run → Environment Variables → toggle ON
+xcodebuild test -scheme Pastura -project Pastura/Pastura.xcodeproj \
+  -destination "$DEST" -derivedDataPath "$DERIVED_DATA" \
+  -only-testing PasturaTests/OllamaIntegrationTests
+# These tests are automatically skipped when OLLAMA_INTEGRATION is not enabled in the scheme.
+```
+
+### DerivedData location
+
+`sim-dest.sh` exports `DERIVED_DATA` pointing at `Pastura/DerivedData/` inside
+the current worktree. Always pass `-derivedDataPath "$DERIVED_DATA"` to
+`xcodebuild` so the CLI matches the Xcode.app Workspace-relative layout
+configured in `project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings`.
+This keeps GUI and CLI builds sharing one cache per worktree and makes
+`git worktree remove` auto-clean all build artifacts. Two gotchas:
+
+- **Pass `-derivedDataPath` with a space**, not `=`. The `=` form is silently
+  ignored by `xcodebuild` (known since Xcode 15.4).
+- **CI is intentionally left on the default `~/Library/...` path** so its
+  existing SPM cache (`actions/cache` keyed on that path) keeps hitting. If
+  CI ever starts passing `-derivedDataPath`, update both cache paths in
+  `.github/workflows/ci.yml` in the same PR.
+
+### Running xcodebuild from an agent session
+
+`xcodebuild test` takes minutes. A few operational guardrails to avoid
+burning wall-clock and orphaning processes:
+
+**Prevention (do this up-front):**
+
+- Narrow scope whenever possible — `-only-testing PasturaTests/<Suite>`.
+- If the change doesn't touch UI code, add `-skip-testing:PasturaUITests`
+  (UI tests are not required for MVP; CI will still cover them).
+- Always pass an explicit bash `timeout` — the default 120s is shorter
+  than even a focused suite. Guideline: `timeout: 180000` (3 min) for a
+  single suite, `timeout: 600000` (10 min) for the full unit suite,
+  `timeout: 900000` (15 min) when UI tests are included.
+- For runs expected to exceed 5 minutes, prefer `run_in_background: true`
+  and poll with Monitor / BashOutput rather than blocking the session.
+- When piping through `tail` (e.g. `xcodebuild ... 2>&1 | tail -80`), the
+  pipe's exit code is `tail`'s, not `xcodebuild`'s — a failed build reports
+  `exit code 0`. Grep the tailed output for `** BUILD|TEST SUCCEEDED/FAILED **`
+  or `xcodebuild: error:` before trusting the harness exit code, or use
+  `set -o pipefail`. When the SUCCEEDED marker has been trimmed off entirely,
+  extract the verdict from the xcresult bundle: `xcrun xcresulttool get test-results summary --path "$XCRESULT" --format json`.
+
+**Recovery (if a run hangs or a retry immediately stalls):**
+
+- The session's bash timeout kills the shell wrapper, but spawned
+  `xcodebuild` / `testmanagerd` / `XCTRunner` processes can outlive it
+  and keep the simulator destination busy. Subsequent `xcodebuild test`
+  calls then queue behind them and appear to hang.
+- Before killing, **read the full command lines** so you don't clobber a
+  concurrent run from another worktree:
+  `pgrep -af "xcodebuild|XCTRunner|testmanagerd"`.
+- Only if you're sure every listed process belongs to your session:
+  `pkill -f "xcodebuild test"`; then reset the simulator with
+  `xcrun simctl shutdown "$(echo "$DEST" | sed -n 's/.*id=//p')"`.
+- If UI tests fail with
+  `FBSOpenApplicationServiceErrorDomain Code=1 — com.tyabu12.PasturaUITests.xctrunner`,
+  try `xcrun simctl erase <UDID>` + retry **once**. Persistent failures
+  are real bugs (signing, plist, or app-state regression), not flakes —
+  do not swallow them.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -82,7 +82,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo '{\"hookSpecificOutput\":{\"additionalContext\":\"Reminder: This is Pastura (Swift/iOS). Follow CLAUDE.md hard rules. No force unwrap (!), no Engine→Data imports, TDD mandatory.\"}}'"
+            "command": "echo '{\"hookSpecificOutput\":{\"additionalContext\":\"Reminder: This is Pastura (Swift/iOS). Follow CLAUDE.md hard rules. No force unwrap (!), no Engine→Data imports, TDD mandatory for Engine/LLM layers.\"}}'"
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,12 +247,19 @@ Pastura/
 
 ## Context-Specific Rules
 
-See `.claude/rules/` for detailed rules loaded automatically when editing Engine, LLM, Models, Data, or Resources files.
+`.claude/rules/` contains detailed rules with two loading modes:
 
-`navigation.md` documents the `AppRouter` pattern: programmatic root-stack
-navigation goes through `router.push(_:)` / `router.pushIfOnTop(expected:next:)`,
-and `navigationDestination(item:|isPresented:)` is forbidden inside views
-pushed onto the root stack. Sheet-owned NavigationStacks are exempt.
+**Path-scoped** (loaded only when editing matching files):
+
+- `engine.md` — Engine + LLM source (`Pastura/Pastura/Engine/**`, `Pastura/Pastura/LLM/**`)
+- `models-and-data.md` — Models + Data source (`Pastura/Pastura/Models/**`, `Pastura/Pastura/Data/**`)
+- `presets.md` — Bundled scenario YAML (`Pastura/Pastura/Resources/**`)
+- `testing.md` — Test target (`Pastura/PasturaTests/**`)
+
+**Always-loaded** (no frontmatter `paths:` — relevant from any layer):
+
+- `llm.md` — LLM-layer traps (e.g., `nonisolated` protocol-default impls that build escaping closures) can fire from any conformer, including types added in `App/` or test targets, so the rule must stay visible regardless of which file is being edited.
+- `navigation.md` — `AppRouter` pattern: programmatic root-stack navigation goes through `router.push(_:)` / `router.pushIfOnTop(expected:next:)`, and `navigationDestination(item:|isPresented:)` is forbidden inside views pushed onto the root stack. Sheet-owned NavigationStacks are exempt. Always-loaded because view-placement decisions can originate from any feature directory.
 
 ## File Naming
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,82 +140,8 @@ Implementation order: `Models → LLM → Engine → Data → Views → App → 
 
 ### Test Execution
 
-```bash
-source "$(git rev-parse --show-toplevel)/scripts/sim-dest.sh"
-
-# Run all tests
-xcodebuild test -scheme Pastura -project Pastura/Pastura.xcodeproj \
-  -destination "$DEST" -derivedDataPath "$DERIVED_DATA"
-
-# Run specific test class
-xcodebuild test -scheme Pastura -project Pastura/Pastura.xcodeproj \
-  -destination "$DEST" -derivedDataPath "$DERIVED_DATA" \
-  -only-testing PasturaTests/JSONResponseParserTests
-
-# Run Ollama integration tests (requires local Ollama with target model pulled)
-# Enable OLLAMA_INTEGRATION in scheme: Edit Scheme → Run → Environment Variables → toggle ON
-xcodebuild test -scheme Pastura -project Pastura/Pastura.xcodeproj \
-  -destination "$DEST" -derivedDataPath "$DERIVED_DATA" \
-  -only-testing PasturaTests/OllamaIntegrationTests
-# These tests are automatically skipped when OLLAMA_INTEGRATION is not enabled in the scheme.
-```
-
-#### DerivedData location
-
-`sim-dest.sh` exports `DERIVED_DATA` pointing at `Pastura/DerivedData/` inside
-the current worktree. Always pass `-derivedDataPath "$DERIVED_DATA"` to
-`xcodebuild` so the CLI matches the Xcode.app Workspace-relative layout
-configured in `project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings`.
-This keeps GUI and CLI builds sharing one cache per worktree and makes
-`git worktree remove` auto-clean all build artifacts. Two gotchas:
-
-- **Pass `-derivedDataPath` with a space**, not `=`. The `=` form is silently
-  ignored by `xcodebuild` (known since Xcode 15.4).
-- **CI is intentionally left on the default `~/Library/...` path** so its
-  existing SPM cache (`actions/cache` keyed on that path) keeps hitting. If
-  CI ever starts passing `-derivedDataPath`, update both cache paths in
-  `.github/workflows/ci.yml` in the same PR.
-
-#### Running xcodebuild from an agent session
-
-`xcodebuild test` takes minutes. A few operational guardrails to avoid
-burning wall-clock and orphaning processes:
-
-**Prevention (do this up-front):**
-
-- Narrow scope whenever possible — `-only-testing PasturaTests/<Suite>`.
-- If the change doesn't touch UI code, add `-skip-testing:PasturaUITests`
-  (UI tests are not required for MVP; CI will still cover them).
-- Always pass an explicit bash `timeout` — the default 120s is shorter
-  than even a focused suite. Guideline: `timeout: 180000` (3 min) for a
-  single suite, `timeout: 600000` (10 min) for the full unit suite,
-  `timeout: 900000` (15 min) when UI tests are included.
-- For runs expected to exceed 5 minutes, prefer `run_in_background: true`
-  and poll with Monitor / BashOutput rather than blocking the session.
-- When piping through `tail` (e.g. `xcodebuild ... 2>&1 | tail -80`), the
-  pipe's exit code is `tail`'s, not `xcodebuild`'s — a failed build reports
-  `exit code 0`. Grep the tailed output for `** BUILD|TEST SUCCEEDED/FAILED **`
-  or `xcodebuild: error:` before trusting the harness exit code, or use
-  `set -o pipefail`. When the SUCCEEDED marker has been trimmed off entirely,
-  extract the verdict from the xcresult bundle: `xcrun xcresulttool get test-results summary --path "$XCRESULT" --format json`.
-
-**Recovery (if a run hangs or a retry immediately stalls):**
-
-- The session's bash timeout kills the shell wrapper, but spawned
-  `xcodebuild` / `testmanagerd` / `XCTRunner` processes can outlive it
-  and keep the simulator destination busy. Subsequent `xcodebuild test`
-  calls then queue behind them and appear to hang.
-- Before killing, **read the full command lines** so you don't clobber a
-  concurrent run from another worktree:
-  `pgrep -af "xcodebuild|XCTRunner|testmanagerd"`.
-- Only if you're sure every listed process belongs to your session:
-  `pkill -f "xcodebuild test"`; then reset the simulator with
-  `xcrun simctl shutdown "$(echo "$DEST" | sed -n 's/.*id=//p')"`.
-- If UI tests fail with
-  `FBSOpenApplicationServiceErrorDomain Code=1 — com.tyabu12.PasturaUITests.xctrunner`,
-  try `xcrun simctl erase <UDID>` + retry **once**. Persistent failures
-  are real bugs (signing, plist, or app-state regression), not flakes —
-  do not swallow them.
+See `.claude/rules/xcodebuild-cli.md` for the full xcodebuild CLI playbook
+(test execution commands, DerivedData layout, agent-session timeout/recovery).
 
 ## Directory Structure
 
@@ -260,6 +186,7 @@ Pastura/
 
 - `llm.md` — LLM-layer traps (e.g., `nonisolated` protocol-default impls that build escaping closures) can fire from any conformer, including types added in `App/` or test targets, so the rule must stay visible regardless of which file is being edited.
 - `navigation.md` — `AppRouter` pattern: programmatic root-stack navigation goes through `router.push(_:)` / `router.pushIfOnTop(expected:next:)`, and `navigationDestination(item:|isPresented:)` is forbidden inside views pushed onto the root stack. Sheet-owned NavigationStacks are exempt. Always-loaded because view-placement decisions can originate from any feature directory.
+- `xcodebuild-cli.md` — xcodebuild CLI playbook (test commands, DerivedData layout, timeout/recovery for agent sessions). Always-loaded because xcodebuild gotchas surface during worktree switches and CI debugging, not only when editing test files.
 
 ## File Naming
 


### PR DESCRIPTION
## Summary

- `/config-doctor:check` で見つかった 3件の WARN を一括解消。
- CLAUDE.md (287→221 行) スリム化として xcodebuild CLI playbook を
  `.claude/rules/xcodebuild-cli.md` (always-loaded) に切り出し。
- always-loaded 群の理由を CLAUDE.md "Context-Specific Rules" 節に明記。

## Changes

| Commit | What |
|--------|------|
| 📝 docs: fix path typo in llm.md rule | `Pastura/LLM/LLMService.swift` → `Pastura/Pastura/LLM/LLMService.swift` |
| 🔧 chore: scope TDD reminder to Engine/LLM layers | SessionStart compact フック文言を緩和 |
| 📝 docs: split Context-Specific Rules by loading mode | path-scoped vs always-loaded を 2層構造で表記、各 always-loaded に 1文の理由 |
| 📝 docs: extract xcodebuild CLI playbook to a dedicated rule | 3節を新ファイルへ移設 |

## Notes

- **Lossless extraction**: `.claude/rules/xcodebuild-cli.md` の本文は CLAUDE.md 該当節と byte-identical (code-reviewer が awk+diff で確認)。唯一の機械的編集は heading 階層の正規化 (H3→H2 / H4→H3) — 単独ファイルとして読みやすくするため。
- **Net token cost = 0**: 元々 CLAUDE.md (always-loaded) にあった内容を always-loaded ルールに移しただけ。利益は人間側の readability 向上のみ。
- **Reviewer = Opus**: `.claude/{rules,settings}` + CLAUDE.md の coupling rule で起用。本質は doc-only なので今後同種 PR は Sonnet 既定でもよい。
- **対応見送り (config-doctor 別 WARN)**:
  - Tech Stack 表の llama.swift バージョン省略 — 「pinned」表記は Package.resolved を真実の源にする設計判断と読める。
  - orchestrate skill の `EnterWorktree`/`ExitWorktree` — 実在する Claude Code ツール。config-doctor 側の reference list drift。
- **フォローアップ材料**: ADR-002.md に同種のパス省略 13箇所、`engine.md` タイトル `# Engine Design Rules` と scope (Engine + LLM) のミスマッチ — いずれも shipped 済み ADR / pre-existing で今回スコープ外。

## Test plan

- [x] \`swiftlint lint --quiet --strict\` 通過
- [x] CLAUDE.md 内の cross-reference 健全性確認 (外部リンクなし)
- [x] frontmatter mapping verification (path-scoped 4件 / always-loaded 3件 すべて正しい)
- [x] xcodebuild-cli.md と CLAUDE.md 元節の byte-identical 検証

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)