### PR TITLE
📝 chore: draft privacy policy + App Store release-prep checklist

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -105,6 +105,18 @@ creation observed. Decision: ship to App Store to gauge wider public reaction.
 - **Remote model manifest** — currently `ModelRegistry` pins each entry's download URL, file size, and SHA-256 at compile time (originally tracked in #82). On-device-only inference + iOS sandboxing neutralizes the supply-chain exfiltration side; the residual risk (a crafted GGUF exploiting llama.cpp's parser) is shared with every on-device GGUF and not specific to dynamic metadata. Dynamic fetch (HuggingFace API) would let model updates ship without an app release but introduces non-determinism across users and a runtime dependency on a network call before download. Revisit when the model-update cadence makes the app-update tax meaningful.
 - **Model switch deferred-apply UX** — Settings → Models currently swaps the active model instantly in UserDefaults; the actual model load happens at the next `SimulationViewModel.run()`. For users on the slowest devices this can produce a perceptible first-run latency spike after switching. Polish follow-up (#203): surface the load cost explicitly via a confirmation UI, or pre-warm the new model on switch.
 
+### App Store Release Prep
+
+First App Store submission depends on a set of cross-cutting blockers tracked in [ADR-005 §9.2](decisions/ADR-005.md#92-sub-issue-master-index) (content safety, encryption declaration, support URL, privacy manifest, etc.). Privacy policy work was not captured when ADR-005 was first written and is tracked separately in #233:
+
+- [x] Draft privacy policy (`docs/legal/privacy-policy.md`)
+- [ ] Host the policy at `https://tyabu12.github.io/pastura/legal/privacy-policy/` via GitHub Pages
+- [ ] Register the URL in App Store Connect → App Information → Privacy Policy URL
+- [ ] Answer the App Privacy Details questionnaire ("Data Not Collected", per `PrivacyInfo.xcprivacy`)
+- [ ] Add in-app Settings → "Privacy Policy" link (Guideline 5.1.1: "easily accessible")
+
+Custom EULA is intentionally deferred — Apple's [Standard EULA](https://www.apple.com/legal/internet-services/itunes/dev/stdeula/) auto-applies; revisit if Phase 3 introduces server-side data flows (gated on ADR-006).
+
 ---
 
 ## Phase 3: Community

--- a/docs/legal/privacy-policy.md
+++ b/docs/legal/privacy-policy.md
@@ -15,9 +15,9 @@ as the data controller for any data the app might process.
 **Pastura does not collect, transmit, sell, or share your personal data.**
 
 All AI simulations run on your device using a local large language model
-([llama.cpp](https://github.com/ggerganov/llama.cpp)). Your scenarios,
-simulation history, and preferences never leave the device through any
-mechanism we control. Pastura's App Store privacy nutrition label is
+executed via the [llama.cpp](https://github.com/ggerganov/llama.cpp)
+inference runtime. Your scenarios, simulation history, and preferences
+never leave the device through any mechanism we control. Pastura's App Store privacy nutrition label is
 **"Data Not Collected"**.
 
 ## Data we do not collect
@@ -49,8 +49,9 @@ sandbox and is never transmitted off the device by Pastura:
 
 The required-reason API declarations in our
 [`PrivacyInfo.xcprivacy`](https://github.com/tyabu12/pastura/blob/main/Pastura/Pastura/PrivacyInfo.xcprivacy)
-reflect these uses: `UserDefaults` for app functionality (Apple reason code `CA92.1`)
-and `FileTimestamp` for files inside the app sandbox (`C617.1`). No tracking
+reflect these uses: the `UserDefaults` API is declared with reason `CA92.1`
+("app functionality") and the `FileTimestamp` API with reason `C617.1`
+("files inside the app sandbox"). No tracking
 domains are declared (`NSPrivacyTrackingDomains` is empty); `NSPrivacyTracking`
 is `false`.
 
@@ -63,8 +64,8 @@ Pastura's AI inference is fully on-device, but the app makes a small number
 of outbound network requests when you choose to use specific features:
 
 - **Curated scenario gallery** — when you open the in-app Share Board, the
-  app fetches a JSON index of curated scenarios from GitHub Pages
-  (`tyabu12.github.io`).
+  app fetches a JSON index of curated scenarios from GitHub-hosted content
+  at `raw.githubusercontent.com`.
 - **LLM model download** — when you install or switch a model, the app
   downloads the model file from Hugging Face
   (`huggingface.co`).

--- a/docs/legal/privacy-policy.md
+++ b/docs/legal/privacy-policy.md
@@ -1,0 +1,152 @@
+# Pastura Privacy Policy
+
+**Effective date:** 2026-04-25
+**Last updated:** 2026-04-25
+
+## Who we are
+
+Pastura is an iOS app for running AI multi-agent simulations entirely on-device.
+It is developed and maintained by **tyabu12** (an individual developer).
+References to "we", "us", or "Pastura" in this policy refer to tyabu12 acting
+as the data controller for any data the app might process.
+
+## Summary
+
+**Pastura does not collect, transmit, sell, or share your personal data.**
+
+All AI simulations run on your device using a local large language model
+([llama.cpp](https://github.com/ggerganov/llama.cpp)). Your scenarios,
+simulation history, and preferences never leave the device through any
+mechanism we control. Pastura's App Store privacy nutrition label is
+**"Data Not Collected"**.
+
+## Data we do not collect
+
+We do not collect, request, log, or transmit any of the following:
+
+- Names, email addresses, phone numbers, or other contact information
+- Account credentials (Pastura has no account system)
+- Device identifiers (IDFA, IDFV) for advertising or tracking purposes
+- Location data (GPS, IP-based, or otherwise)
+- Contacts, photos, calendar, or other personal data on your device
+- Behavioural analytics, crash reports, telemetry, or usage statistics
+- Health, financial, or biometric data
+
+Pastura ships with no third-party analytics, advertising, attribution, or
+crash-reporting SDKs.
+
+## Data that stays on your device
+
+The following information is created or stored locally inside the app's
+sandbox and is never transmitted off the device by Pastura:
+
+| Local data                            | Purpose                                                   |
+|---------------------------------------|-----------------------------------------------------------|
+| Scenario YAML you author or import    | Running simulations you have configured                   |
+| Past simulation results (SQLite)      | Letting you revisit and export your simulation history    |
+| App preferences (UserDefaults)        | Remembering your active model, playback speed, and similar settings |
+| Downloaded LLM model files            | Performing on-device inference                            |
+
+The required-reason API declarations in our
+[`PrivacyInfo.xcprivacy`](https://github.com/tyabu12/pastura/blob/main/Pastura/Pastura/PrivacyInfo.xcprivacy)
+reflect these uses: `UserDefaults` for app functionality (Apple reason code `CA92.1`)
+and `FileTimestamp` for files inside the app sandbox (`C617.1`). No tracking
+domains are declared (`NSPrivacyTrackingDomains` is empty); `NSPrivacyTracking`
+is `false`.
+
+You can erase all of this local data at any time by deleting the app from
+your device.
+
+## Network connections Pastura makes
+
+Pastura's AI inference is fully on-device, but the app makes a small number
+of outbound network requests when you choose to use specific features:
+
+- **Curated scenario gallery** — when you open the in-app Share Board, the
+  app fetches a JSON index of curated scenarios from GitHub Pages
+  (`tyabu12.github.io`).
+- **LLM model download** — when you install or switch a model, the app
+  downloads the model file from Hugging Face
+  (`huggingface.co`).
+
+These services see your IP address and a standard `User-Agent` string under
+their own privacy policies (see
+[GitHub Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement)
+and [Hugging Face Privacy Policy](https://huggingface.co/privacy)).
+Pastura does not log, store, share, or otherwise process the metadata of
+these requests on its side.
+
+## Tracking and advertising
+
+Pastura does not use any tracking technologies, advertising identifiers,
+attribution SDKs, fingerprinting, or cross-app/cross-site tracking. We do
+not show ads. We do not participate in any data broker or advertising
+network.
+
+## Children's privacy
+
+Pastura is rated **13+** on the App Store and is not directed to children
+under 13. We do not knowingly collect personal information from children
+under 13. Because we do not collect personal information from anyone, no
+specific COPPA notice or verifiable parental consent flow is needed; if a
+child under 13 uses the app, no personal data leaves the device through
+Pastura.
+
+In jurisdictions where the GDPR-K age of digital consent is set higher
+than 13 (most EU member states use 16), the same no-collection commitment
+applies to all users regardless of age.
+
+## International users
+
+We do not collect or process personal data, so most regional privacy laws
+(GDPR, UK GDPR, Japan's APPI, California's CCPA/CPRA, and similar regimes)
+have nothing for us to act on. Specifically:
+
+- **GDPR / UK GDPR** — we are not a controller or processor of personal
+  data within the meaning of Article 4, because no identifiable personal
+  data is collected.
+- **APPI (Japan)** — we do not collect or hold 個人情報 (personal information)
+  as defined in the Act.
+- **CCPA / CPRA (California)** — we do not collect, sell, or share
+  personal information of California residents.
+
+If you nonetheless wish to exercise a right granted by your local law
+(such as a data subject access request), please contact us via the channel
+below; we will respond by confirming that we hold no data about you.
+
+## Future changes (Cloud API)
+
+Pastura currently runs entirely on-device. Future versions may offer
+**optional, opt-in** features that send specific user-authored content
+(such as scenario prompts) to a named third-party AI provider for
+processing. If such a feature is introduced:
+
+- This policy will be revised to name the provider, list the data
+  transmitted, identify the legal basis for processing, and link to
+  the provider's privacy policy — **before** the feature ships.
+- The feature will require explicit user consent; running on-device
+  will remain the default.
+
+Any future revision will be announced via the channels described in
+"Changes to this policy" below.
+
+## How to contact us
+
+Use the support form at **<https://tyabu12.github.io/pastura/support/>**
+for any privacy-related questions, including requests to confirm what (if
+any) data we hold about you.
+
+## Changes to this policy
+
+We will revise this policy as Pastura's data practices evolve (notably
+when any optional cloud feature is introduced). When we do:
+
+- The "Last updated" date at the top of this document will change.
+- Material changes will be summarised in the corresponding TestFlight or
+  App Store release notes.
+- The latest version is always available at
+  <https://tyabu12.github.io/pastura/legal/privacy-policy/>.
+
+Continued use of Pastura after a revision means you accept the revised
+policy. If you do not agree with a change, please stop using the app and
+delete it from your device.


### PR DESCRIPTION
## Summary

- Adds `docs/legal/privacy-policy.md` — first-pass App Store privacy policy reflecting Pastura's on-device-only footprint ("Data Not Collected" nutrition label, 13+ rating per ADR-005 §3.2, no analytics/ads/crash-reporter SDKs, gallery + model-download outbound paths disclosed honestly, non-committal Cloud API forward-look anchored to ADR-006).
- Adds an "App Store Release Prep" subsection to `docs/ROADMAP.md` Phase 2 — pre-pins the candidate hosted URL `https://tyabu12.github.io/pastura/legal/privacy-policy/` and cross-links ADR-005 §9.2 rather than duplicating its rows.

Hosting (GitHub Pages structure / `index.html` vs Jekyll auto-render), the in-app Settings link, and the App Store Connect questionnaire are intentional follow-ups under #233.

## Test plan

- [x] Markdown renders on github.com (visual check via `gh pr diff`)
- [x] Factual claims verified against HEAD: `PrivacyInfo.xcprivacy` (CA92.1 / C617.1), `URLSessionGalleryService.swift` (gallery host = `raw.githubusercontent.com`), `ModelRegistry.swift` (HuggingFace), ADR-005 §3.2 (13+), §6.7 (Support URL)
- [x] No third-party analytics / advertising / crash-reporter SDKs (`grep`-confirmed across `Pastura/Pastura/`)
- [x] ROADMAP `decisions/ADR-005.md#92-sub-issue-master-index` anchor verified

## Notes

- Critic (pre-implementation, Opus) caught 2 Critical + 6 Warning items, all resolved before first commit. Code-reviewer (Opus, iteration 1) caught 1 Critical (gallery host name) + 2 Warning (llama.cpp / UserDefaults wording); all addressed in `d51bf83`. Iteration 2: PASS.
- Out of scope (deliberate, follow-ups under #233): GitHub Pages hosting setup, in-app Settings link, App Store Connect questionnaire answers, custom EULA (deferred until Phase 3 Cloud API per ADR-006).
- Issue #233 body was patched separately to fix `§10` → `§9.2` references (ADR-005's last section is §9, not §10).

Part of #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)