### PR TITLE
🐛 fix: surface llama chat-template UTF-8-invalid output as LLMError

### DIFF
--- a/Pastura/Pastura/LLM/LlamaCppService+ChatTemplate.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService+ChatTemplate.swift
@@ -55,6 +55,37 @@ extension LlamaCppService {
       )
     }
 
-    return String(llamaBuffer: buffer, length: Int(written))
+    return try LlamaCppService.decodeAppliedTemplate(buffer: buffer, written: written)
+  }
+
+  /// Decodes the buffer produced by `llama_chat_apply_template` and rejects
+  /// invalid UTF-8 output as a hard failure.
+  ///
+  /// `String(llamaBuffer:length:)` falls back to `""` on invalid UTF-8 (see
+  /// `String+LlamaBuffer.swift`). For chat-template output that fallback
+  /// silently propagates an empty system+user prompt to the inference loop —
+  /// not a tolerable runtime condition. This guard turns the silent failure
+  /// into a diagnosable `LLMError.generationFailed`.
+  ///
+  /// Scope: catches the invalid-UTF-8 → empty-fallback path only. An all-NUL
+  /// buffer (`written > 0` but every byte is `0x00`) decodes to a non-empty
+  /// `"\0\0..."` string and slips through this guard; that is a different
+  /// llama.cpp bug shape and would surface downstream as a JSON parse
+  /// failure on the inference output (Issue #234 deliberately scoped this
+  /// out — see `LlamaCppServiceChatTemplateTests.allNULBufferDoesNotThrow`).
+  ///
+  /// `internal` access: exposed only as a fault-injection seam for
+  /// `LlamaCppServiceChatTemplateTests`. Not part of the public LLMService
+  /// surface; do not adopt from elsewhere in `LLM/`.
+  internal static func decodeAppliedTemplate(
+    buffer: [CChar], written: Int32
+  ) throws -> String {
+    let decoded = String(llamaBuffer: buffer, length: Int(written))
+    guard !decoded.isEmpty else {
+      throw LLMError.generationFailed(
+        description: "llama_chat_apply_template returned \(written) bytes of invalid UTF-8"
+      )
+    }
+    return decoded
   }
 }

--- a/Pastura/PasturaTests/LLM/LlamaCppServiceChatTemplateTests.swift
+++ b/Pastura/PasturaTests/LLM/LlamaCppServiceChatTemplateTests.swift
@@ -1,0 +1,84 @@
+import Testing
+
+@testable import Pastura
+
+/// Unit tests for the chat-template UTF-8 validation seam in
+/// ``LlamaCppService/decodeAppliedTemplate(buffer:written:)``.
+///
+/// The test target is the small `internal static` helper extracted from
+/// ``LlamaCppService.applyChatTemplate(system:user:)`` for fault-injection
+/// purposes — coercing the real `llama_chat_apply_template` C function into
+/// emitting invalid UTF-8 would require a real GGUF model and a hostile
+/// template fixture. The helper is pure (`(buffer, written) -> String`),
+/// so we exercise the production validation path directly.
+@Suite(.timeLimit(.minutes(1)))
+struct LlamaCppServiceChatTemplateTests {
+
+  // MARK: - Happy path
+
+  @Test func validUTF8BufferReturnsDecodedString() throws {
+    // "<|user|>hello<|end|>" — a plausibly-shaped (truncated) chat-template output.
+    let utf8: [CChar] = [
+      0x3C, 0x7C, 0x75, 0x73, 0x65, 0x72, 0x7C, 0x3E,  // "<|user|>"
+      0x68, 0x65, 0x6C, 0x6C, 0x6F  // "hello"
+    ]
+    let result = try LlamaCppService.decodeAppliedTemplate(
+      buffer: utf8, written: Int32(utf8.count))
+    #expect(result == "<|user|>hello")
+  }
+
+  // MARK: - Bug fix — invalid UTF-8 must throw
+
+  @Test func invalidUTF8BufferThrowsGenerationFailed() {
+    // 0xFF is invalid as the leading byte of any UTF-8 sequence. The
+    // underlying `String(llamaBuffer:length:)` returns "" in this case
+    // (per its `?? ""` fallback). Pre-fix, `applyChatTemplate` propagated
+    // that "" silently to the inference loop. Post-fix, the helper must
+    // throw `LLMError.generationFailed` so the failure is diagnosable.
+    let invalidBuffer: [CChar] = [
+      CChar(bitPattern: 0x68),  // 'h'
+      CChar(bitPattern: 0xFF),  // invalid UTF-8 lead byte
+      CChar(bitPattern: 0x69)  // 'i'
+    ]
+    #expect(throws: LLMError.self) {
+      _ = try LlamaCppService.decodeAppliedTemplate(
+        buffer: invalidBuffer, written: 3)
+    }
+  }
+
+  @Test func invalidUTF8ErrorDescriptionMentionsByteCount() {
+    let invalidBuffer: [CChar] = [
+      CChar(bitPattern: 0xFF),
+      CChar(bitPattern: 0xFE)
+    ]
+    do {
+      _ = try LlamaCppService.decodeAppliedTemplate(
+        buffer: invalidBuffer, written: 2)
+      Issue.record("expected throw, got success")
+    } catch let error as LLMError {
+      // Partial-match per project convention (CLAUDE.md "Error message i18n prep").
+      let description = error.errorDescription ?? ""
+      #expect(description.contains("invalid UTF-8"))
+      #expect(description.contains("2"))
+    } catch {
+      Issue.record("expected LLMError, got \(error)")
+    }
+  }
+
+  // MARK: - Boundary documentation (out-of-scope cases)
+
+  /// Documents that NUL-padded output is NOT covered by the new guard.
+  /// `String(bytes: [0x00, 0x00], encoding: .utf8)` returns `"\0\0"` — a
+  /// non-empty string, so `decoded.isEmpty` does not fire. Issue #234 scope
+  /// is the invalid-UTF-8 → empty-fallback path; an all-NUL output is a
+  /// different llama.cpp bug shape that would surface downstream as a JSON
+  /// parse failure on the inference output. Tracking that case is out of
+  /// scope here.
+  @Test func allNULBufferDoesNotThrow() throws {
+    let nulBuffer: [CChar] = [0x00, 0x00, 0x00]
+    let result = try LlamaCppService.decodeAppliedTemplate(
+      buffer: nulBuffer, written: 3)
+    // Returned as-is — the guard intentionally does not catch this.
+    #expect(!result.isEmpty)
+  }
+}


### PR DESCRIPTION
## Summary
- `String(llamaBuffer:length:)` falls back to `""` on invalid UTF-8 — at the `applyChatTemplate` callsite that silently propagated an empty system+user prompt into the inference loop. Now thrown as `LLMError.generationFailed`.
- Extract `internal static func decodeAppliedTemplate(buffer:written:)` as a fault-injection seam for unit testing (coercing the real C function into emitting invalid UTF-8 would require a hostile model fixture).
- All-NUL output is a different llama.cpp bug shape; intentionally out of scope (documented in code + test).

## Convention note
Issue body suggested `String(localized:)` wrapping at the throw site, but the existing 3 throws in `LlamaCppService+ChatTemplate.swift` (L22/L43/L53) all pass plain English `description:` strings — the localization wrap happens once at `LLMError.errorDescription`. New throw matches existing file convention rather than adding a single inconsistent wrap.

## Test plan
- [x] `PasturaTests/LlamaCppServiceChatTemplateTests` (4 cases: happy path, invalid UTF-8 throws, error description contains byte count, all-NUL boundary doc)
- [x] `swiftlint --strict` clean
- [x] LlamaCpp + LLMError targeted suite (54 tests) green
- [ ] Full unit suite — local runs hit recorded sim-clone flake; CI will validate definitively

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)