### PR TITLE
🔧 chore: gate sim-dest.sh on concurrent xcodebuild test

### DIFF
--- a/.claude/rules/xcodebuild-cli.md
+++ b/.claude/rules/xcodebuild-cli.md
@@ -41,6 +41,29 @@ This keeps GUI and CLI builds sharing one cache per worktree and makes
   CI ever starts passing `-derivedDataPath`, update both cache paths in
   `.github/workflows/ci.yml` in the same PR.
 
+### Concurrent-session simulator gate
+
+`sim-dest.sh` blocks at `source` time if another `xcodebuild test` with a
+UDID-pinned iOS Simulator destination (`...,id=<UDID>`) is already running
+on this machine — poll every 5s, jitter 1.0–5.0s before claiming, 15-min
+timeout. This avoids same-UDID clone/boot/teardown collisions across
+concurrent worktree sessions, which otherwise produce 200+ 0.000s "failed"
+cascades. The match pattern intentionally requires `,id=` so the pre-commit
+`xcodebuild build -destination 'generic/platform=iOS Simulator'` hook does
+not trigger the gate (build-only invocations don't book a simulator).
+
+Override with `PASTURA_SKIP_SIM_WAIT=1 source scripts/sim-dest.sh ...`:
+
+- when intentionally running parallel suites on distinct simulators, or
+- when sourcing only to inspect `$DEST` (e.g., for `xcrun simctl` /
+  `xcodebuild -showBuildSettings`) without running tests.
+
+If the gate consistently times out and you don't recall starting another
+test run, the busy PID is likely a stale `xcodebuild`/`testmanagerd`/
+`XCTRunner` from a prior timeout-killed run — see **Recovery** below for
+the `pgrep` + `pkill` flow. The timeout error message itself includes
+the recovery commands.
+
 ### Running xcodebuild from an agent session
 
 `xcodebuild test` takes minutes. A few operational guardrails to avoid

--- a/scripts/sim-dest.sh
+++ b/scripts/sim-dest.sh
@@ -92,7 +92,77 @@ export DERIVED_DATA="$_simdest_repo_root/Pastura/DerivedData"
 echo "Selected simulator: $_simdest_name ($_simdest_os) [id=$_simdest_udid]"
 echo "DerivedData path: $DERIVED_DATA"
 
+# Wait for any other in-flight `xcodebuild test` against an iOS Simulator
+# to finish before returning. Concurrent test runs against the same
+# simulator UDID corrupt clone/boot/teardown state: when one sim clone
+# crashes mid-suite, the run reports 200+ 0.000s "failed" cascades that
+# look like a real regression but disappear on re-run.
+# Override with PASTURA_SKIP_SIM_WAIT=1 when intentional parallelism is
+# wanted (e.g. distinct simulators per worktree).
+_simdest_wait_for_simulator() {
+  if [ "${PASTURA_SKIP_SIM_WAIT:-}" = "1" ]; then
+    return 0
+  fi
+  # Match only UDID-pinned destinations (`...,id=<UDID>`). This is the form
+  # sim-dest.sh produces and the only one that actually clones/boots/tears
+  # down a simulator. Excludes `generic/platform=iOS Simulator` (used by
+  # the pre-commit `xcodebuild build` hook) and any other non-booting form.
+  local pattern='xcodebuild.*-destination.*platform=iOS Simulator,id='
+  local poll_interval=5
+  local timeout_s=900
+  local elapsed=0
+  local notified=0
+  local busy_pids jitter
+  while :; do
+    # Exclude $$ and $PPID to avoid self-trigger: when sim-dest.sh is
+    # sourced from `sh -c "source ... && xcodebuild test ..."`, the
+    # wrapping shell's own argv contains the pattern, so pgrep -f matches
+    # it. $$ inside the function resolves to that wrapping shell's PID
+    # (not pgrep's subshell). $PPID covers a one-deeper nesting (e.g.
+    # `bash -c "sh -c '... && xcodebuild ...'"`), where the grandparent
+    # also carries the pattern in its argv.
+    busy_pids=$(pgrep -f "$pattern" 2>/dev/null | grep -vE "^($$|$PPID)\$" || true)
+    if [ -n "$busy_pids" ]; then
+      if [ "$notified" -eq 0 ]; then
+        echo "Another xcodebuild test detected (pids: $(echo "$busy_pids" | tr '\n' ' ')); waiting up to ${timeout_s}s. Set PASTURA_SKIP_SIM_WAIT=1 to bypass." >&2
+        notified=1
+      fi
+      sleep "$poll_interval"
+      elapsed=$((elapsed + poll_interval))
+      if [ "$elapsed" -ge "$timeout_s" ]; then
+        echo "Error: timed out after ${timeout_s}s waiting for in-flight xcodebuild test." >&2
+        echo "  Likely cause: a stale xcodebuild/testmanagerd/XCTRunner from a prior timeout-killed run." >&2
+        echo "  Inspect:  pgrep -af 'xcodebuild.*-destination.*platform=iOS Simulator,id='" >&2
+        echo "  Recover:  pkill -f 'xcodebuild test'   (only after confirming the PID is yours and stale)" >&2
+        echo "  Bypass:   PASTURA_SKIP_SIM_WAIT=1 source scripts/sim-dest.sh" >&2
+        return 1
+      fi
+      continue
+    fi
+    # Random jitter (1.0–5.0s, 1 decimal) before claiming the simulator,
+    # then re-check. Reduces thundering-herd when multiple waiters detect
+    # the same "clear" moment after a competing run finishes.
+    jitter=$(python3 -c "import random; print(f'{random.uniform(1.0, 5.0):.1f}')" 2>/dev/null) || jitter="2.5"
+    sleep "$jitter"
+    busy_pids=$(pgrep -f "$pattern" 2>/dev/null | grep -vE "^($$|$PPID)\$" || true)
+    if [ -z "$busy_pids" ]; then
+      return 0
+    fi
+    if [ "$notified" -eq 1 ]; then
+      echo "Another session entered during jitter window; resuming wait..." >&2
+    fi
+  done
+}
+
+if ! _simdest_wait_for_simulator; then
+  unset _simdest_result _simdest_udid _simdest_name _simdest_os _simdest_errfile _simdest_repo_root
+  unset -f _simdest_wait_for_simulator
+  eval "$_simdest_old_opts"
+  return 1 2>/dev/null || exit 1
+fi
+
 unset _simdest_result _simdest_udid _simdest_name _simdest_os _simdest_errfile _simdest_repo_root
+unset -f _simdest_wait_for_simulator
 eval "$_simdest_old_opts"
 # return when sourced, exit when executed directly
 return 0 2>/dev/null || exit 0


### PR DESCRIPTION
## Summary

- Block `sim-dest.sh` at `source` time when another `xcodebuild test` against a UDID-pinned iOS Simulator is in flight on this machine — soft-serializes test runs across concurrent worktree sessions to avoid same-UDID clone/boot/teardown collisions that otherwise produce 200+ 0.000s "failed" cascades on the unaffected suite.
- Match pattern is intentionally tight (`xcodebuild.*-destination.*platform=iOS Simulator,id=`) so the pre-commit `xcodebuild build -destination 'generic/platform=iOS Simulator'` hook does **not** trigger the gate (build-only invocations don't book a simulator).
- Override env var `PASTURA_SKIP_SIM_WAIT=1` for intentional parallel runs on distinct simulators or pure `$DEST` inspection.

## Design notes

- Poll every 5s, with a 1.0–5.0s random jitter (1 decimal, via `python3`) before claiming the simulator after a "clear" detection. The jitter re-check window mitigates the thundering-herd race when multiple waiters become unblocked simultaneously.
- 15-min timeout. Error message inlines the `pgrep` + `pkill` recovery flow so stale-process scenarios (timeout-killed `xcodebuild`/`testmanagerd`/`XCTRunner` outliving their parent shell) are actionable on the spot.
- Self-trigger guard: filters `$$` and `$PPID` so wrapping shells like `sh -c "source ... && xcodebuild test ..."` whose own argv carries the gate pattern don't false-trigger the wait.
- **Soft serialization, not a true lock.** A sub-second jitter window remains where two waiters can theoretically pass the re-check simultaneously. Acceptable trade-off vs. lockfile complexity; current baseline is "always collides".

## Test plan (manual, 4 cases)

- [x] **Case 1: bypass** — `PASTURA_SKIP_SIM_WAIT=1 source scripts/sim-dest.sh` → exports `DEST` + `DERIVED_DATA` immediately, no wait.
- [x] **Case 2: generic destination no-trigger** — Synthetic process with argv `xcodebuild build -scheme Pastura -destination generic/platform=iOS Simulator -quiet` running → `source sim-dest.sh` does NOT enter wait (returns in jitter window only). Verified the new `,id=` pattern matches 0 against this argv vs. 1 for the old broad pattern.
- [x] **Case 3: UDID-pinned trigger** — Synthetic process with argv `xcodebuild test -scheme Pastura -destination platform=iOS Simulator,id=DEADBEEF-FAKE` running → `source sim-dest.sh` enters wait, prints "detected" message, exits cleanly with status 0 after the synthetic process is killed.
- [x] **Case 4: self-trigger guard** — `sh -c "source scripts/sim-dest.sh && true xcodebuild test -destination 'platform=iOS Simulator,id=dummy'"` → no false-trigger; `PROCEEDED` is printed, confirming `$$`/`$PPID` filter handles wrapper shells whose argv contains the pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)