### PR TITLE
📝 docs: enforce /orchestrate as implementation entry point

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,11 +138,12 @@ mention it. Match the user's language; English baseline:
 GitHub-side actions that produce no local commit are out of scope — issue
 management, PR comments/reviews on others' PRs, label/milestone edits,
 workflow dispatch, release creation, draft-state toggles, merging an
-already-opened PR. When in doubt, default to `/orchestrate`.
+already-opened PR. Local read-only sync (`git fetch`, `git pull` on the
+default branch, `gh pr checkout`) is similarly out of scope. When in
+doubt, default to `/orchestrate`.
 
 The rule does not re-trigger for actions taken from inside `/orchestrate`
-itself or from a sub-agent it dispatches (Step 3 implementer, Step 4
-reviewer).
+itself or from any sub-agent it dispatches.
 
 ### TDD Approach
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,30 @@ UI tests are not required for MVP.
 
 ## Development Workflow
 
+### Implementation Entry Point
+
+`/orchestrate` is the only entry point for file edits, commits, branch
+creation, and pushes in this repository.
+
+**Why:** `main` is push-protected (PR required), and concurrent sessions
+collide on shared files (`Pastura.xcodeproj/project.pbxproj`, DerivedData,
+generated assets) without worktree isolation.
+
+When the conversation transitions from discussion or investigation toward
+such work, announce `/orchestrate` and start it — even if the user didn't
+mention it. Match the user's language; English baseline:
+
+> "Switching to `/orchestrate` for the implementation."
+
+GitHub-side actions that produce no local commit are out of scope — issue
+management, PR comments/reviews on others' PRs, label/milestone edits,
+workflow dispatch, release creation, draft-state toggles, merging an
+already-opened PR. When in doubt, default to `/orchestrate`.
+
+The rule does not re-trigger for actions taken from inside `/orchestrate`
+itself or from a sub-agent it dispatches (Step 3 implementer, Step 4
+reviewer).
+
 ### TDD Approach
 
 Engine and LLM layer: test-first (write failing test → minimal implementation → refactor).


### PR DESCRIPTION
## Summary
- Add `### Implementation Entry Point` under `## Development Workflow` in
  `CLAUDE.md`, making `/orchestrate` the mandatory entry point for any
  file edit, commit, branch creation, or push in this repository.
- Carve out GitHub-side metadata workflows (issue management, label/release
  ops, PR comments/reviews on others' PRs, draft toggles, merging) — these
  produce no local commit and remain free.
- Recursion-guard sentence so actions taken from inside `/orchestrate` or
  its dispatched sub-agents (Step 3 implementer, Step 4 reviewer) don't
  re-trigger the rule.

## Test plan
- [x] Section placed inside `## Development Workflow`, immediately before
      `### TDD Approach`.
- [x] No conflict with `## Language Rules` (English baseline + match-user's-language).
- [x] No conflict with `## Hard Rules`, `## Confirmation Policy`,
      `### Git Conventions`.
- [x] Markdown hygiene (heading depth, blank-line spacing) matches sibling
      subsections.
- [x] Commit message follows Conventional Commits + emoji (`📝 docs:`).

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)