### PR TITLE
♻️ refactor: migrate ad-hoc system colors to DesignTokens (#244)

### DIFF
--- a/Pastura/Pastura/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Pastura/Pastura/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,6 +1,15 @@
 {
   "colors" : [
     {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x6C",
+          "green" : "0x9A",
+          "red" : "0x8A"
+        }
+      },
       "idiom" : "universal"
     }
   ],

--- a/Pastura/Pastura/PasturaApp.swift
+++ b/Pastura/Pastura/PasturaApp.swift
@@ -179,7 +179,7 @@ private struct RootView: View {
         VStack(spacing: 16) {
           Image(systemName: "exclamationmark.triangle")
             .font(.largeTitle)
-            .foregroundStyle(.red)
+            .foregroundStyle(Color.danger)
           Text("Initialization Failed")
             .font(.headline)
           Text(message)

--- a/Pastura/Pastura/Views/Editor/PhaseEditorSheet+ConditionalSection.swift
+++ b/Pastura/Pastura/Views/Editor/PhaseEditorSheet+ConditionalSection.swift
@@ -70,6 +70,7 @@ extension PhaseEditorSheet {
               .font(.caption)
           }
         }
+        .buttonStyle(.plain)
         .contextMenu {
           Button {
             phase.moveSubPhase(id: subPhase.id, to: branch == .then ? .else : .then)

--- a/Pastura/Pastura/Views/Editor/PhaseEditorSheet.swift
+++ b/Pastura/Pastura/Views/Editor/PhaseEditorSheet.swift
@@ -98,9 +98,11 @@ struct PhaseEditorSheet: View {
           HStack {
             Text(type.rawValue)
             if type.requiresLLM {
+              // `info` here is a quiet category badge for LLM-required phase types,
+              // not a notification — see design-system §2.6 for the alert-family scope.
               Text("LLM")
                 .font(.caption2)
-                .foregroundStyle(.purple)
+                .foregroundStyle(Color.info)
             }
           }
           .tag(type)

--- a/Pastura/Pastura/Views/Editor/ScenarioEditorView.swift
+++ b/Pastura/Pastura/Views/Editor/ScenarioEditorView.swift
@@ -255,7 +255,7 @@ struct ScenarioEditorView: View {
       ForEach(viewModel.validationErrors, id: \.self) { error in
         HStack(spacing: 6) {
           Image(systemName: "exclamationmark.triangle.fill")
-            .foregroundStyle(.yellow)
+            .foregroundStyle(Color.warning)
           Text(error)
             .font(.caption)
         }
@@ -264,7 +264,7 @@ struct ScenarioEditorView: View {
     .padding(.horizontal)
     .padding(.vertical, 8)
     .frame(maxWidth: .infinity, alignment: .leading)
-    .background(.red.opacity(0.1))
+    .background(Color.dangerSoft)
   }
 
   // MARK: - Mode Binding

--- a/Pastura/Pastura/Views/Editor/ScenarioEditorView.swift
+++ b/Pastura/Pastura/Views/Editor/ScenarioEditorView.swift
@@ -183,6 +183,7 @@ struct ScenarioEditorView: View {
             }
           }
         }
+        .buttonStyle(.plain)
       }
       .onDelete { indexSet in
         viewModel.personas.remove(atOffsets: indexSet)

--- a/Pastura/Pastura/Views/Import/ImportView.swift
+++ b/Pastura/Pastura/Views/Import/ImportView.swift
@@ -66,7 +66,7 @@ struct ImportView: View {
         ForEach(viewModel.validationErrors, id: \.self) { error in
           Label(error, systemImage: "xmark.circle.fill")
             .font(.caption)
-            .foregroundStyle(.red)
+            .foregroundStyle(Color.dangerInk)
         }
       }
       .padding(.horizontal)
@@ -74,7 +74,7 @@ struct ImportView: View {
     } else if viewModel.isValid {
       Label("Valid scenario", systemImage: "checkmark.circle.fill")
         .font(.caption)
-        .foregroundStyle(.green)
+        .foregroundStyle(Color.successInk)
         .padding(.horizontal)
         .padding(.vertical, 8)
     }

--- a/Pastura/Pastura/Views/ModelDownload/ModelDownloadView.swift
+++ b/Pastura/Pastura/Views/ModelDownload/ModelDownloadView.swift
@@ -72,7 +72,7 @@ struct ModelDownloadView: View {
     VStack(spacing: 16) {
       Image(systemName: "exclamationmark.triangle.fill")
         .font(.system(size: 48))
-        .foregroundStyle(.orange)
+        .foregroundStyle(Color.warning)
       Text("Unsupported Device")
         .font(.title2.bold())
       Text(
@@ -91,7 +91,7 @@ struct ModelDownloadView: View {
     VStack(spacing: 16) {
       Image(systemName: "arrow.down.circle")
         .font(.system(size: 48))
-        .foregroundStyle(.blue)
+        .foregroundStyle(Color.moss)
       Text("Download AI Model")
         .font(.title2.bold())
       VStack(spacing: 4) {
@@ -120,7 +120,7 @@ struct ModelDownloadView: View {
     VStack(spacing: 16) {
       Image(systemName: "arrow.down.circle")
         .font(.system(size: 48))
-        .foregroundStyle(.blue)
+        .foregroundStyle(Color.moss)
         .symbolEffect(.pulse)
       Text("Downloading Model...")
         .font(.title2.bold())
@@ -141,7 +141,10 @@ struct ModelDownloadView: View {
           modelManager.cancelDownload(descriptor: descriptor)
         }
       }
-      .foregroundStyle(.red)
+      // Neutral cancel per design-system §2.6: `inkSecondary` text on a plain
+      // (no-border) button. The §2.6 "rule border" requirement applies only
+      // when a border is rendered; default-style Button has none.
+      .foregroundStyle(Color.inkSecondary)
     }
   }
 
@@ -149,7 +152,7 @@ struct ModelDownloadView: View {
     VStack(spacing: 16) {
       Image(systemName: "checkmark.circle.fill")
         .font(.system(size: 48))
-        .foregroundStyle(.green)
+        .foregroundStyle(Color.success)
       Text("Model Ready")
         .font(.title2.bold())
     }
@@ -159,7 +162,7 @@ struct ModelDownloadView: View {
     VStack(spacing: 16) {
       Image(systemName: "exclamationmark.triangle.fill")
         .font(.system(size: 48))
-        .foregroundStyle(.red)
+        .foregroundStyle(Color.danger)
       Text("Download Failed")
         .font(.title2.bold())
       Text(message)

--- a/Pastura/Pastura/Views/ScenarioDetail/ScenarioDetailView.swift
+++ b/Pastura/Pastura/Views/ScenarioDetail/ScenarioDetailView.swift
@@ -137,9 +137,11 @@ struct ScenarioDetailView: View {
           Text(phase.type.rawValue)
             .font(.subheadline.monospaced())
           if phase.type.requiresLLM {
+            // `info` here is a quiet category badge for LLM-required phases, not a
+            // notification — see design-system §2.6 for the alert-family scope.
             Image(systemName: "brain")
               .font(.caption)
-              .foregroundStyle(.purple)
+              .foregroundStyle(Color.info)
           }
         }
       }
@@ -151,7 +153,7 @@ struct ScenarioDetailView: View {
     if let error = viewModel.validationError {
       Section {
         Label(error, systemImage: "xmark.circle.fill")
-          .foregroundStyle(.red)
+          .foregroundStyle(Color.dangerInk)
       }
     }
   }

--- a/Pastura/Pastura/Views/Settings/ModelSettingsRow.swift
+++ b/Pastura/Pastura/Views/Settings/ModelSettingsRow.swift
@@ -93,7 +93,7 @@ struct ModelSettingsRow: View {
     case .error(let message):
       Text(String(localized: "Error: \(message)"))
         .font(.footnote)
-        .foregroundStyle(.red)
+        .foregroundStyle(Color.dangerInk)
         .lineLimit(2)
     }
   }

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -111,7 +111,7 @@ Pastura 唯一のブランド色。用途別に4段階。
 
 **運用ルール（牧歌トーンの維持）：**
 
-- **Cancel ボタンは赤くしない。** 文字 `inkSecondary` (`#5A5A55`) / 背景透明 / ボーダー `rule` (`#E0DBCE`) で中立に。
+- **Cancel ボタンは赤くしない。** 文字 `inkSecondary` (`#5A5A55`)、背景透明、ボーダー `rule` (`#E0DBCE`) で中立に。ボーダー指定はカスタムスタイルやチップで枠線を描く場合に適用し、枠線を描かないプレーンな `Button("Cancel")` には不要。
 - **破壊確認ダイアログのプライマリボタン**: `danger` 文字 / `dangerSoft` 背景 / 同色ボーダー（iOS の system destructive role が許す範囲で）。
 - **トースト**: 1pt のアクセント左ボーダー + `*Soft` 背景 + 14pt 角丸（promo card と同じ造形）。
 


### PR DESCRIPTION
## Summary

Migrate 15 ad-hoc system-color usages to DesignTokens defined in `DesignTokens+ExtendedPalette.swift` (§2.6 alert family + §2.7 interactive states), and tint the AccentColor asset to brand moss (`#8A9A6C`).

- **Commit 1** — AccentColor → moss: auto-tints all `.borderedProminent`, NavigationLink chevrons, Toggles, Pickers, `Color.accentColor` direct refs, and `.foregroundStyle(.tint)` to moss in one shot.
- **Commit 2** — 15 token swaps across 9 view files + 3 `// why:` comments at the judgment-call sites (`.purple` → `Color.info` for LLM-phase indicator; neutral Cancel mapping per §2.6).
- **Commit 3** — Add `.buttonStyle(.plain)` to two Editor row Buttons (persona row in `ScenarioEditorView`, sub-phase row in `PhaseEditorSheet+ConditionalSection`) to stop SwiftUI from auto-tinting the entire label to the (now-moss) accent. Surface regression: persona text rendered moss after the AccentColor flip; matches the read-only `ScenarioDetailView`'s ink color now.
- **Commit 4** — Refine `docs/design/design-system.md` §2.6 line 114: clarify that the `rule` border applies only when a border is actually rendered (custom styles / chip-shaped controls), so plain `Button("Cancel")` doesn't need a border spec. Resolves Reviewer Suggestion 2 from the original review.

No new tokens introduced — all targets exist since #238.

### Notable mappings (Commit 2)

- LLM-phase indicators (`.purple`) → `Color.info` as a quiet category badge (alert-family stretch documented at each callsite per §2.6).
- ModelDownload Cancel button (`.red`) → `Color.inkSecondary` for neutral cancel per §2.6; the "rule border" requirement applies only when a border is rendered.
- Editor validation banner background (`.red.opacity(0.1)`) → `Color.dangerSoft` (token already pre-blended; §2.6 documented recipe).

### Auto-cascade — no source edit needed

These follow AccentColor automatically; documented for review awareness:

- `Color.accentColor` direct refs at `Views/Home/HomeView.swift:151-152`, `Views/Community/ShareBoard/ShareBoardView.swift:159,163`
- `.foregroundStyle(.tint)` at `Views/ScenarioDetail/ScenarioDetailView.swift:81`
- `.tint` ShapeStyle at `Views/Community/ShareBoard/ShareBoardView.swift:130,158,163`
- All `.borderedProminent` buttons (ImportView, ModelDownloadView×2, GalleryScenarioDetailView, ReportScenarioSheet, ShareBoardView, PasturaApp init-failure Retry)
- NavigationLink chevrons / Toggles / Pickers throughout

SwiftUI hierarchical foreground styles (`.secondary`, `.primary`, `.tertiary`) deliberately retained — they auto-adapt to color scheme.

### Out of scope (per Issue audit)

- Dark mode trait switching (§2.9 tokens defined but not applied)
- Time-of-Day ambient (§2.10) application
- Chart palette (§2.11) application

## Test plan

- [x] Full unit test suite: 1128 passed / 0 failed (after one local-sim flake re-run on each round)
- [x] `swiftlint lint --quiet --strict`: clean
- [x] Reviewer Suggestion 2 (Cancel-button §2.6 alignment) — addressed via Commit 4
- [ ] Manual visual QA after merge — confirm intended cascade + parity:
  - Settings → Models error state
  - ModelDownloadView all 5 sub-states
  - ScenarioDetailView with validation error + LLM-requiring phase
  - ScenarioEditorView with validation banner (verify `dangerSoft` opacity reads right per Reviewer Suggestion 1)
  - **Editor → Personas list: text reads ink/black, matches ScenarioDetailView's read-only persona section**
  - **Editor → conditional phase → sub-phase rows: text ink, chevron secondary; long-press still opens "Move to Other Branch" context menu (navigation.md QA scenario 5)**
  - ImportView error/success states
  - PhaseEditorSheet picker (LLM tag color)
  - HomeView Capsule update badge (auto-cascade)
  - Any `.borderedProminent` to confirm moss tint

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)