### PR TITLE
📝 docs: skip delegation when overhead exceeds work in /orchestrate

### DIFF
--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -63,7 +63,8 @@ After fetching the issue, check for an existing plan comment:
    Assign a **complexity label** to each item:
    - 🟢 **simple** — Delegated to a Sonnet subagent. Criteria: existing pattern reuse (e.g., new Handler mirroring an existing one), test-only changes following an existing test pattern, type/error case additions, doc comments, minor fixes.
    - 🔴 **complex** — Implemented by the orchestrator (Opus) directly. Criteria: new design patterns, actor isolation / Sendable design decisions, changes spanning multiple layers, work near dependency rule boundaries (Engine ↔ Data), or any item requiring non-obvious architectural judgment.
-   - **Default to 🔴 when in doubt or when the work is small.** Misclassifying a complex task as simple wastes a Sonnet attempt + Opus fallback; the reverse just costs extra Opus tokens. Even those tokens aren't worth it when subagent prompt + verify overhead likely exceeds the implementation itself (e.g. single-line edits, short doc tweaks).
+   - **When in doubt, classify as 🔴.** Misclassifying a complex item as simple wastes a Sonnet attempt + Opus fallback; the reverse just costs extra Opus tokens.
+   - **Skip delegation when overhead exceeds the work.** Promote a 🟢 item to 🔴 when subagent prompt + verify overhead likely exceeds the implementation itself — e.g. single-line edits, short doc tweaks. This forces Opus reviewer via the Coupling Rule below — intended, since the orchestrator is implementing the item directly.
 
    ```
    - [ ] 1. 🟢 <description> (`<primary-file-path>`)
@@ -204,7 +205,7 @@ For each unit of work (let `K` = the current plan item number), check the item's
 
 ### 🔴 Complex items — Orchestrator implements directly
 
-1. Write test first (TDD mandatory per CLAUDE.md).
+1. Write test first (TDD mandatory per CLAUDE.md). Skip for documentation-only or test-only items (mirrors the 🟢 branch's escape at the Sonnet prompt below).
 2. Run targeted tests — confirm failure:
    ```bash
    source "$(git rev-parse --show-toplevel)/scripts/sim-dest.sh"

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -63,7 +63,8 @@ After fetching the issue, check for an existing plan comment:
    Assign a **complexity label** to each item:
    - 🟢 **simple** — Delegated to a Sonnet subagent. Criteria: existing pattern reuse (e.g., new Handler mirroring an existing one), test-only changes following an existing test pattern, type/error case additions, doc comments, minor fixes.
    - 🔴 **complex** — Implemented by the orchestrator (Opus) directly. Criteria: new design patterns, actor isolation / Sendable design decisions, changes spanning multiple layers, work near dependency rule boundaries (Engine ↔ Data), or any item requiring non-obvious architectural judgment.
-   - **When in doubt, classify as 🔴.** Misclassifying a complex task as simple wastes tokens on a failed Sonnet attempt + Opus fallback. The reverse (Opus doing a simple task) has no downside beyond cost.
+   - **When in doubt, classify as 🔴.** Misclassifying a complex task as simple wastes tokens on a failed Sonnet attempt + Opus fallback. The reverse just costs extra Opus tokens (and even that's bounded by the override below).
+   - **Skip delegation when it costs more than the work.** Promote a 🟢 item to 🔴 if the subagent prompt + verify overhead likely exceeds the implementation itself — e.g. single-line edits, short doc tweaks.
 
    ```
    - [ ] 1. 🟢 <description> (`<primary-file-path>`)

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -357,7 +357,6 @@ gh pr create --base "$BASE_BRANCH" --assignee "@me" --label "$LABEL" \
 ...
 ## Test plan
 ...
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
 IMPLEMENT_PR_BODY
 )"
 ```

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -63,8 +63,7 @@ After fetching the issue, check for an existing plan comment:
    Assign a **complexity label** to each item:
    - 🟢 **simple** — Delegated to a Sonnet subagent. Criteria: existing pattern reuse (e.g., new Handler mirroring an existing one), test-only changes following an existing test pattern, type/error case additions, doc comments, minor fixes.
    - 🔴 **complex** — Implemented by the orchestrator (Opus) directly. Criteria: new design patterns, actor isolation / Sendable design decisions, changes spanning multiple layers, work near dependency rule boundaries (Engine ↔ Data), or any item requiring non-obvious architectural judgment.
-   - **When in doubt, classify as 🔴.** Misclassifying a complex task as simple wastes tokens on a failed Sonnet attempt + Opus fallback. The reverse just costs extra Opus tokens (and even that's bounded by the override below).
-   - **Skip delegation when it costs more than the work.** Promote a 🟢 item to 🔴 if the subagent prompt + verify overhead likely exceeds the implementation itself — e.g. single-line edits, short doc tweaks.
+   - **Default to 🔴 when in doubt or when the work is small.** Misclassifying a complex task as simple wastes a Sonnet attempt + Opus fallback; the reverse just costs extra Opus tokens. Even those tokens aren't worth it when subagent prompt + verify overhead likely exceeds the implementation itself (e.g. single-line edits, short doc tweaks).
 
    ```
    - [ ] 1. 🟢 <description> (`<primary-file-path>`)


### PR DESCRIPTION
## Summary
- Add an override clause to `/orchestrate` Step 1: promote 🟢-eligible items to 🔴 (orchestrator implements inline) when subagent prompt + verify overhead likely exceeds the implementation itself.
- Judgment-based, no fixed threshold — examples: single-line edits, short doc tweaks.
- Reword the existing "When in doubt" tiebreaker so the previous "Opus doing a simple task has no downside beyond cost" claim no longer contradicts the new override.

## Test plan
- [ ] Doc-only change; no automated test coverage applies.
- [ ] Confirm next `/orchestrate` invocation surfaces the new bullet in Step 1's complexity-label section.

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)