### PR TITLE
🐛 fix: prevent default-value flash on async-loaded screens

### DIFF
--- a/.claude/rules/navigation.md
+++ b/.claude/rules/navigation.md
@@ -97,6 +97,52 @@ When reviewing changes that touch navigation:
       should be empty.
 - [ ] No new properties on `AppRouter` beyond navigation-path management.
 
+## Render-time hints — `RouteHint`
+
+Some `Route` cases need to carry **render-time hints** (e.g.
+`initialName: String?` for the navigation title to show
+synchronously at push time, before the destination view's async load
+completes). Such hints are NOT navigation identity — they affect
+display only. Wrap them in `RouteHint<T>`
+(`Pastura/Pastura/App/RouteHint.swift`) so the auto-synthesized
+`Hashable` on `Route` continues to use only identity-bearing fields:
+
+```swift
+case scenarioDetail(
+  scenarioId: String,
+  initialName: RouteHint<String> = .init()
+)
+```
+
+Why this matters: a plain `String?` hint would make
+`.scenarioDetail("x")` (default-nil) and
+`.scenarioDetail("x", "Foo")` compare unequal, silently breaking
+`pushIfOnTop` guards that callers naturally write without the hint.
+`RouteHint`'s `==` is always `true` and `hash(into:)` is a no-op,
+so identity is preserved on `scenarioId` alone.
+
+⚠️ `RouteHint`'s identity-neutrality is **load-bearing**. Do NOT
+treat `RouteHint("Foo") == RouteHint("Bar")` as `.value`
+interchangeability — always read `.value` from the specific instance
+you hold. The type's header doc-comment carries this warning.
+
+When reviewing a new `Route` case:
+
+- [ ] Identity-bearing fields (e.g. ids) are plain associated values.
+- [ ] Render-time-only fields (placeholders, animation params) are
+      wrapped in `RouteHint<T>`.
+- [ ] If the case adds `RouteHint`, the destination resolver in
+      `HomeView.routeDestination(_:)` extracts `.value` to pass to
+      the destination view.
+- [ ] If a callsite pushes with a hint, the source-of-truth for the
+      hint value is documented (e.g. gallery curation invariant —
+      see `GallerySeedYAMLTests.galleryTitleMatchesYAMLName`).
+
+Decision record: [ADR-008](../../docs/decisions/ADR-008.md). Type
+definition + standalone tests:
+[`RouteHint.swift`](../../Pastura/Pastura/App/RouteHint.swift),
+[`RouteHintTests.swift`](../../Pastura/PasturaTests/App/RouteHintTests.swift).
+
 ## QA scenarios
 
 `PasturaUITests` covers scenarios 1 and 3 end-to-end and scenario 2 on

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,6 +241,7 @@ Record architectural decisions in `docs/decisions/` as `ADR-NNN.md`.
 | `docs/decisions/ADR-005.md`           | Content safety architecture (App Store review) |
 | `docs/decisions/ADR-006.md`           | Cloud API implementation details (Phase 3; reserved — not yet written; see ADR-005 §7.5) |
 | `docs/decisions/ADR-007.md`           | DL-time demo replay — iOS lifecycle (#152)  |
+| `docs/decisions/ADR-008.md`           | Route identity vs render-time hints (`RouteHint<T>` pattern, #245) |
 | `docs/specs/pastura-mvp-spec-v0_3.md` | MVP specification                                         |
 | `docs/specs/demo-replay-spec.md`      | DL-time demo replay — data format + component design (#152) |
 | `docs/specs/demo-replay-ui.md`        | DL-time demo replay — visual / behaviour spec (#164)        |

--- a/Pastura/Pastura/App/RouteHint.swift
+++ b/Pastura/Pastura/App/RouteHint.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+// MARK: - RouteHint
+//
+// ⚠️ IDENTITY-NEUTRAL by design. Two `RouteHint` values with different
+//    `.value` compare equal under `==` and hash to the same bucket.
+//    DO NOT treat `==` between RouteHints as `.value` interchangeability —
+//    always read `.value` from the specific instance you hold.
+//
+// Why this exists: `Route` enum cases sometimes need to carry render-time
+// hints (e.g. an `initialName` to show in the navigation title before the
+// destination view's async load completes). Putting such hints into normal
+// associated values pollutes the enum's auto-synthesized Hashable: two
+// pushes with the same `scenarioId` but different hints would compare
+// unequal, silently breaking `AppRouter.pushIfOnTop(expected:next:)`
+// guards that callers naturally write without specifying the hint.
+//
+// `RouteHint<T>`'s `==` is always `true` and `hash(into:)` is a no-op,
+// so embedding `RouteHint<T>` inside an enum case lets the enum's
+// auto-synthesized Hashable continue to use only the *identity-bearing*
+// associated values (e.g. `scenarioId`) for equality.
+//
+// See `docs/decisions/ADR-008.md` for the full rationale (alternatives
+// considered, KMP / state-restoration impact). Operational rule lives in
+// `.claude/rules/navigation.md` § "Render-time hints — RouteHint".
+
+/// A render-time hint that does NOT participate in `Equatable` /
+/// `Hashable` identity.
+///
+/// Wrap render-only state — placeholder strings, animation parameters,
+/// presentation flags — in `RouteHint<T>` when adding it as an
+/// associated value of a `Route` (or any other Hashable enum) so that
+/// the enum's identity remains solely about *where in the navigation
+/// tree* we are, not *what hint we happened to carry on this push*.
+///
+/// The wrapped `value` is read normally via `.value`; only `==` and
+/// `hashValue` are blind to it.
+///
+/// ```swift
+/// enum Route: Hashable {
+///   case scenarioDetail(
+///     scenarioId: String,
+///     initialName: RouteHint<String> = .init()
+///   )
+/// }
+///
+/// // These two compare ==, hash to the same bucket:
+/// let a = Route.scenarioDetail(scenarioId: "x", initialName: .init("Foo"))
+/// let b = Route.scenarioDetail(scenarioId: "x", initialName: .init())
+/// // a == b  →  true (intentional)
+///
+/// // ⚠️ But their `.value` differs — never substitute one for the other
+/// // when reading the hint:
+/// // case .scenarioDetail(_, let hint): hint.value  // "Foo" vs nil
+/// ```
+// `nonisolated` because `Hashable`'s `==` / `hash(into:)` requirements
+// are nonisolated; under `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`,
+// custom impls would inherit MainActor and crash the conformance.
+// `Route` enum gets this for free via auto-synthesized Hashable;
+// `RouteHint` provides explicit impls so it must opt out of the default.
+nonisolated struct RouteHint<T: Hashable & Sendable>: Hashable, Sendable {
+  /// The wrapped value. Read this directly — `==` is identity-neutral
+  /// and gives no information about whether `.value` is set.
+  let value: T?
+
+  init(_ value: T? = nil) {
+    self.value = value
+  }
+
+  // Identity-neutral: every RouteHint compares equal to every other
+  // RouteHint of the same generic type.
+  static func == (lhs: Self, rhs: Self) -> Bool { true }
+
+  // Identity-neutral: contributes nothing to the hash. The Hashable
+  // contract `a == b → a.hashValue == b.hashValue` is satisfied because
+  // every pair compares equal and every pair contributes the same
+  // (zero) bits to the hasher.
+  func hash(into hasher: inout Hasher) {}
+}

--- a/Pastura/Pastura/App/RouteHint.swift
+++ b/Pastura/Pastura/App/RouteHint.swift
@@ -53,12 +53,13 @@ import Foundation
 /// // when reading the hint:
 /// // case .scenarioDetail(_, let hint): hint.value  // "Foo" vs nil
 /// ```
-// `nonisolated` because `Hashable`'s `==` / `hash(into:)` requirements
-// are nonisolated; under `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`,
-// custom impls would inherit MainActor and crash the conformance.
-// `Route` enum gets this for free via auto-synthesized Hashable;
-// `RouteHint` provides explicit impls so it must opt out of the default.
 nonisolated struct RouteHint<T: Hashable & Sendable>: Hashable, Sendable {
+  // `nonisolated` (above) is required because `Hashable`'s `==` /
+  // `hash(into:)` are nonisolated; under
+  // `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` the custom impls below
+  // would otherwise inherit MainActor and crash the conformance. Route
+  // enum sidesteps this via auto-synthesized Hashable.
+
   /// The wrapped value. Read this directly — `==` is identity-neutral
   /// and gives no information about whether `.value` is set.
   let value: T?

--- a/Pastura/Pastura/App/Router.swift
+++ b/Pastura/Pastura/App/Router.swift
@@ -28,7 +28,15 @@ enum Route: Hashable {
   case editor(editingId: String? = nil, templateYAML: String? = nil)
 
   /// Live simulation execution screen.
-  case simulation(scenarioId: String)
+  ///
+  /// `initialName` mirrors `.scenarioDetail` — render-time hint for
+  /// the navigation title so the bar shows the scenario name from the
+  /// first frame of the push, before `loadAndRun()` completes.
+  /// Identity-neutral via `RouteHint<String>` (ADR-008).
+  case simulation(
+    scenarioId: String,
+    initialName: RouteHint<String> = .init()
+  )
 
   /// Past simulation results list for a scenario.
   case results(scenarioId: String)

--- a/Pastura/Pastura/App/Router.swift
+++ b/Pastura/Pastura/App/Router.swift
@@ -6,7 +6,19 @@ import Foundation
 /// Used with `NavigationStack(path:)` for programmatic navigation.
 enum Route: Hashable {
   /// Scenario detail screen.
-  case scenarioDetail(scenarioId: String)
+  ///
+  /// `initialName` is a render-time hint used to display the scenario
+  /// name in the navigation title from the first frame of the push,
+  /// before `ScenarioDetailViewModel.load(...)` completes its DB +
+  /// YAML parse. Wrapped in `RouteHint<String>` so the value does
+  /// **not** participate in `Route` Hashable identity — `pushIfOnTop`
+  /// guards comparing two `.scenarioDetail` values match on
+  /// `scenarioId` regardless of whether the hint differs.
+  /// See `docs/decisions/ADR-008.md` for the full rationale.
+  case scenarioDetail(
+    scenarioId: String,
+    initialName: RouteHint<String> = .init()
+  )
 
   /// YAML import screen. Pass an existing scenario ID to edit.
   case importScenario(editingId: String? = nil)

--- a/Pastura/Pastura/Views/Community/ShareBoard/GalleryScenarioDetailView.swift
+++ b/Pastura/Pastura/Views/Community/ShareBoard/GalleryScenarioDetailView.swift
@@ -29,11 +29,18 @@ struct GalleryScenarioDetailView: View {
     }
     .navigationTitle(scenario.title)
     .task {
+      // Defer assignment until `load()` completes so the action button
+      // never renders "Try this scenario" between VM creation and the
+      // installed-snapshot refresh landing — already-installed users
+      // would otherwise see "Try" briefly before it switches to "Update"
+      // / "Open local copy". Guard prevents re-creation under `.task`
+      // re-fire.
+      guard viewModel == nil else { return }
       let newViewModel = ShareBoardViewModel(
         galleryService: dependencies.galleryService,
         repository: dependencies.scenarioRepository)
-      viewModel = newViewModel
       await newViewModel.load()
+      viewModel = newViewModel
     }
     .alert(item: $outcomeAlert) { alert in
       Alert(title: Text(alert.title), message: Text(alert.message))

--- a/Pastura/Pastura/Views/Community/ShareBoard/GalleryScenarioDetailView.swift
+++ b/Pastura/Pastura/Views/Community/ShareBoard/GalleryScenarioDetailView.swift
@@ -180,10 +180,20 @@ struct GalleryScenarioDetailView: View {
   /// Push only when this view is still on top of the path. Guards against
   /// pushing onto an unrelated screen if the user popped back during the
   /// async install.
+  ///
+  /// `initialName` is sourced from the gallery curation `scenario.title`
+  /// rather than the freshly-saved local `ScenarioRecord.name`. The
+  /// `gallery.title == yaml.name` invariant is enforced by
+  /// `GallerySeedYAMLTests` so the two values match at install time;
+  /// if the invariant is ever violated, the title would briefly show the
+  /// gallery curation string before snapping to the YAML name on load.
   private func pushToInstalled(scenarioId: String) {
     router.pushIfOnTop(
       expected: .galleryScenarioDetail(scenario: scenario),
-      next: .scenarioDetail(scenarioId: scenarioId))
+      next: .scenarioDetail(
+        scenarioId: scenarioId,
+        initialName: .init(scenario.title)
+      ))
   }
 }
 

--- a/Pastura/Pastura/Views/Home/HomeView.swift
+++ b/Pastura/Pastura/Views/Home/HomeView.swift
@@ -46,9 +46,16 @@ struct HomeView: View {
       }
     }
     .task {
-      viewModel = HomeViewModel(repository: dependencies.scenarioRepository)
-      await viewModel?.loadScenarios()
-      await viewModel?.refreshGalleryUpdateBadges(using: dependencies.galleryService)
+      // Defer assignment until both `loadScenarios()` and
+      // `refreshGalleryUpdateBadges()` complete so gallery update badges
+      // appear together with the row that owns them — otherwise the list
+      // shows first and badges pop in a frame later. Guard prevents
+      // re-creation under `.task` re-fire.
+      guard viewModel == nil else { return }
+      let newViewModel = HomeViewModel(repository: dependencies.scenarioRepository)
+      await newViewModel.loadScenarios()
+      await newViewModel.refreshGalleryUpdateBadges(using: dependencies.galleryService)
+      viewModel = newViewModel
     }
     // Refresh the list whenever the user navigates back to root.
     // `.task` only runs on initial mount; pushed views like the editor

--- a/Pastura/Pastura/Views/Home/HomeView.swift
+++ b/Pastura/Pastura/Views/Home/HomeView.swift
@@ -137,7 +137,15 @@ struct HomeView: View {
   private func scenarioRow(
     _ scenario: ScenarioRecord, hasGalleryUpdate: Bool = false
   ) -> some View {
-    NavigationLink(value: Route.scenarioDetail(scenarioId: scenario.id)) {
+    // initialName supplies the scenario name to navigationTitle from
+    // the first frame of the push, before ScenarioDetailViewModel
+    // finishes loading. Identity-neutral via RouteHint (ADR-008).
+    NavigationLink(
+      value: Route.scenarioDetail(
+        scenarioId: scenario.id,
+        initialName: .init(scenario.name)
+      )
+    ) {
       scenarioRowLabel(scenario, hasGalleryUpdate: hasGalleryUpdate)
     }
     .accessibilityIdentifier("home.scenarioListCell.\(scenario.id)")
@@ -174,8 +182,8 @@ struct HomeView: View {
   @ViewBuilder
   private func routeDestination(_ route: Route) -> some View {
     switch route {
-    case .scenarioDetail(let scenarioId):
-      ScenarioDetailView(scenarioId: scenarioId)
+    case .scenarioDetail(let scenarioId, let initialName):
+      ScenarioDetailView(scenarioId: scenarioId, initialName: initialName.value)
     case .importScenario(let editingId):
       ImportView(editingId: editingId)
     case .editor(let editingId, let templateYAML):

--- a/Pastura/Pastura/Views/Home/HomeView.swift
+++ b/Pastura/Pastura/Views/Home/HomeView.swift
@@ -188,8 +188,8 @@ struct HomeView: View {
       ImportView(editingId: editingId)
     case .editor(let editingId, let templateYAML):
       editorView(editingId: editingId, templateYAML: templateYAML)
-    case .simulation(let scenarioId):
-      SimulationView(scenarioId: scenarioId)
+    case .simulation(let scenarioId, let initialName):
+      SimulationView(scenarioId: scenarioId, initialName: initialName.value)
     case .results(let scenarioId):
       ResultsView(scenarioId: scenarioId)
     case .resultDetail(let simulationId):

--- a/Pastura/Pastura/Views/Import/ImportView.swift
+++ b/Pastura/Pastura/Views/Import/ImportView.swift
@@ -22,10 +22,17 @@ struct ImportView: View {
     .navigationTitle(editingId != nil ? "Edit Scenario" : "Import Scenario")
     .navigationBarTitleDisplayMode(.inline)
     .task {
-      viewModel = ImportViewModel(repository: dependencies.scenarioRepository)
+      // Defer assignment until loadForEditing completes so the TextEditor
+      // never renders the default empty `yamlText` between VM creation and
+      // the DB read landing. Mirrors the `ScenarioEditorHost` pattern in
+      // HomeView.swift. Guard prevents re-creation under `.task` re-fire
+      // (iPad multitasking, scenePhase transitions).
+      guard viewModel == nil else { return }
+      let newViewModel = ImportViewModel(repository: dependencies.scenarioRepository)
       if let editingId {
-        await viewModel?.loadForEditing(scenarioId: editingId)
+        await newViewModel.loadForEditing(scenarioId: editingId)
       }
+      viewModel = newViewModel
     }
   }
 

--- a/Pastura/Pastura/Views/ScenarioDetail/ScenarioDetailView.swift
+++ b/Pastura/Pastura/Views/ScenarioDetail/ScenarioDetailView.swift
@@ -3,6 +3,13 @@ import SwiftUI
 /// Displays scenario metadata, personas, phases, and a launch button.
 struct ScenarioDetailView: View {
   let scenarioId: String
+  /// Render-time hint for the navigation title — supplied by callers
+  /// that already have the scenario name in memory (e.g., HomeView's
+  /// list rows, GalleryScenarioDetailView post-install) so the title
+  /// is correct from the first frame of the push, before the view
+  /// model finishes loading. `nil` falls back to the empty-string
+  /// placeholder. See ADR-008.
+  var initialName: String?
 
   @Environment(AppDependencies.self) private var dependencies
   @Environment(\.dismiss) private var dismiss
@@ -27,12 +34,12 @@ struct ScenarioDetailView: View {
         ProgressView()
       }
     }
-    // Empty fallback during the brief load window (~30–80ms) — the
-    // `.navigationTitle` modifier sits outside the `if let viewModel`
-    // gate so it evaluates while the body shows ProgressView. Showing
-    // "Scenario" there would be a misleading flash before the real
-    // scenario name lands; an empty title is the lesser evil.
-    .navigationTitle(viewModel?.scenario?.name ?? "")
+    // 3-tier fallback (ADR-008): loaded scenario name (authoritative,
+    // wins after VM load completes) → push-time `initialName` hint
+    // (covers the ~30–80ms load window when callers supplied it) →
+    // empty string (defensive default for callers that didn't supply
+    // a hint; "Scenario" would be a misleading flash).
+    .navigationTitle(viewModel?.scenario?.name ?? initialName ?? "")
     .navigationBarTitleDisplayMode(.large)
     .toolbar {
       if let record = viewModel?.record, !record.isPreset {

--- a/Pastura/Pastura/Views/ScenarioDetail/ScenarioDetailView.swift
+++ b/Pastura/Pastura/Views/ScenarioDetail/ScenarioDetailView.swift
@@ -84,7 +84,7 @@ struct ScenarioDetailView: View {
       personasSection(scenario: scenario)
       phasesSection(scenario: scenario)
       validationSection(viewModel: viewModel)
-      actionsSection(viewModel: viewModel)
+      actionsSection(scenario: scenario, viewModel: viewModel)
     }
   }
 
@@ -177,9 +177,19 @@ struct ScenarioDetailView: View {
     }
   }
 
-  private func actionsSection(viewModel: ScenarioDetailViewModel) -> some View {
+  private func actionsSection(
+    scenario: Scenario, viewModel: ScenarioDetailViewModel
+  ) -> some View {
     Section {
-      NavigationLink(value: Route.simulation(scenarioId: scenarioId)) {
+      // initialName supplies the scenario name to SimulationView's
+      // navigationTitle from the first frame, before loadAndRun()
+      // re-parses the YAML. Identity-neutral via RouteHint (ADR-008).
+      NavigationLink(
+        value: Route.simulation(
+          scenarioId: scenarioId,
+          initialName: .init(scenario.name)
+        )
+      ) {
         Label("Run Simulation", systemImage: "play.fill")
       }
       .disabled(!viewModel.canRun)

--- a/Pastura/Pastura/Views/ScenarioDetail/ScenarioDetailView.swift
+++ b/Pastura/Pastura/Views/ScenarioDetail/ScenarioDetailView.swift
@@ -27,7 +27,12 @@ struct ScenarioDetailView: View {
         ProgressView()
       }
     }
-    .navigationTitle(viewModel?.scenario?.name ?? "Scenario")
+    // Empty fallback during the brief load window (~30–80ms) — the
+    // `.navigationTitle` modifier sits outside the `if let viewModel`
+    // gate so it evaluates while the body shows ProgressView. Showing
+    // "Scenario" there would be a misleading flash before the real
+    // scenario name lands; an empty title is the lesser evil.
+    .navigationTitle(viewModel?.scenario?.name ?? "")
     .navigationBarTitleDisplayMode(.large)
     .toolbar {
       if let record = viewModel?.record, !record.isPreset {

--- a/Pastura/Pastura/Views/ScenarioDetail/ScenarioDetailView.swift
+++ b/Pastura/Pastura/Views/ScenarioDetail/ScenarioDetailView.swift
@@ -48,9 +48,16 @@ struct ScenarioDetailView: View {
       }
     }
     .task {
-      viewModel = ScenarioDetailViewModel(repository: dependencies.scenarioRepository)
-      await viewModel?.load(scenarioId: scenarioId)
-      await viewModel?.refreshGalleryStatus(using: dependencies.galleryService)
+      // Defer assignment until both `load()` and `refreshGalleryStatus()`
+      // complete so the gallery banner never flips from
+      // "From Share Board (read-only)" to "Update available" mid-render.
+      // Guard prevents re-creation under `.task` re-fire.
+      guard viewModel == nil else { return }
+      let newViewModel = ScenarioDetailViewModel(
+        repository: dependencies.scenarioRepository)
+      await newViewModel.load(scenarioId: scenarioId)
+      await newViewModel.refreshGalleryStatus(using: dependencies.galleryService)
+      viewModel = newViewModel
     }
   }
 

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -10,6 +10,12 @@ import UIKit
 /// Live simulation execution screen with real-time log, controls, and scoreboard.
 struct SimulationView: View {  // swiftlint:disable:this type_body_length
   let scenarioId: String
+  /// Render-time hint for the navigation title — supplied by the
+  /// caller (`ScenarioDetailView`'s Run Simulation push) so the title
+  /// is correct from the first frame of the push, before
+  /// `loadAndRun()` re-parses the YAML. `nil` falls back to the
+  /// empty-string placeholder. See ADR-008.
+  var initialName: String?
 
   @Environment(\.scenePhase) private var scenePhase
   @Environment(AppDependencies.self) private var dependencies
@@ -41,9 +47,11 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
         ProgressView("Loading scenario...")
       }
     }
-    // Empty fallback during `loadAndRun()` so the inline title doesn't
-    // flash "Simulation" before the real scenario name lands.
-    .navigationTitle(scenario?.name ?? "")
+    // 3-tier fallback (ADR-008): loaded scenario name (authoritative,
+    // wins after loadAndRun completes) → push-time `initialName` hint
+    // → empty string (defensive default; "Simulation" would be a
+    // misleading flash if ever reached).
+    .navigationTitle(scenario?.name ?? initialName ?? "")
     .navigationBarTitleDisplayMode(.inline)
     .task {
       await loadAndRun()

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -41,7 +41,9 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
         ProgressView("Loading scenario...")
       }
     }
-    .navigationTitle(scenario?.name ?? "Simulation")
+    // Empty fallback during `loadAndRun()` so the inline title doesn't
+    // flash "Simulation" before the real scenario name lands.
+    .navigationTitle(scenario?.name ?? "")
     .navigationBarTitleDisplayMode(.inline)
     .task {
       await loadAndRun()

--- a/Pastura/PasturaTests/App/AppRouterTests.swift
+++ b/Pastura/PasturaTests/App/AppRouterTests.swift
@@ -117,6 +117,41 @@ import Testing
     #expect(router.path == [.shareBoard, .scenarioDetail(scenarioId: "x")])
   }
 
+  // MARK: - RouteHint identity-neutrality (ADR-008)
+
+  @Test func pushIfOnTopMatchesIdenticalScenarioIdRegardlessOfHint() {
+    // Pins the contract: `RouteHint<String>` initialName is identity-
+    // neutral, so `expected` and `top` need only agree on `scenarioId`.
+    // Future code paths that omit the hint when constructing `expected`
+    // (or pass a different hint than what was actually pushed) must
+    // still match.
+    let router = AppRouter()
+    router.push(.scenarioDetail(scenarioId: "x", initialName: .init("Foo")))
+
+    let pushed = router.pushIfOnTop(
+      expected: .scenarioDetail(scenarioId: "x"),  // initialName defaulted (nil)
+      next: .simulation(scenarioId: "x"))
+
+    #expect(pushed)
+    #expect(router.path.count == 2)
+    #expect(router.path.last == .simulation(scenarioId: "x"))
+  }
+
+  @Test func pushIfOnTopFailsWhenScenarioIdDiffers() {
+    // Symmetric pin: scenarioId remains the identity-bearing field.
+    // Two `.scenarioDetail` values with different ids must never match,
+    // regardless of whether their hints agree.
+    let router = AppRouter()
+    router.push(.scenarioDetail(scenarioId: "x", initialName: .init("Foo")))
+
+    let pushed = router.pushIfOnTop(
+      expected: .scenarioDetail(scenarioId: "y", initialName: .init("Foo")),
+      next: .simulation(scenarioId: "y"))
+
+    #expect(!pushed)
+    #expect(router.path.count == 1)
+  }
+
   // MARK: - Helpers
 
   private func makeGalleryScenario(id: String) -> GalleryScenario {

--- a/Pastura/PasturaTests/App/Community/Gallery/GallerySeedYAMLTests.swift
+++ b/Pastura/PasturaTests/App/Community/Gallery/GallerySeedYAMLTests.swift
@@ -37,6 +37,47 @@ import Testing
     }
   }
 
+  /// Pins the curation invariant that every gallery entry's `title`
+  /// matches the corresponding YAML's `name:` field.
+  ///
+  /// `Route.scenarioDetail.initialName` is sourced from `scenario.title`
+  /// at install time (`GalleryScenarioDetailView.pushToInstalled`) so
+  /// the navigation bar shows a synchronously-known title from the
+  /// first frame of the push (ADR-008). Once the local
+  /// `ScenarioDetailViewModel` finishes loading, the bar transitions
+  /// to `viewModel.scenario.name` (= the YAML's `name:`). If the two
+  /// strings ever diverge — even by a single Unicode whitespace —
+  /// the user observes a content→content title flash on install.
+  /// Failing this test loudly is cheaper than the alternative
+  /// (extra DB read in `pushToInstalled` to source the name from
+  /// the freshly-saved local record).
+  @Test func galleryTitleMatchesYAMLName() throws {
+    let loader = ScenarioLoader()
+    let galleryDir = Self.repoRoot().appendingPathComponent("docs/gallery")
+    let indexURL = galleryDir.appendingPathComponent("gallery.json")
+    let indexData = try Data(contentsOf: indexURL)
+    let index = try JSONDecoder().decode(GalleryIndex.self, from: indexData)
+
+    #expect(!index.scenarios.isEmpty, "gallery.json has no scenarios")
+
+    for entry in index.scenarios {
+      // `yamlURL` in the seed JSON is a relative file name (e.g.
+      // `asch_conformity_v1.yaml`); resolve against the seed dir.
+      let yamlPath =
+        galleryDir
+        .appendingPathComponent(entry.yamlURL.lastPathComponent)
+      let yaml = try String(contentsOf: yamlPath, encoding: .utf8)
+      let scenario = try loader.load(yaml: yaml)
+      #expect(
+        entry.title == scenario.name,
+        """
+        gallery.title (\(entry.title)) != yaml.name (\(scenario.name)) \
+        for entry id=\(entry.id). \
+        See ADR-008 — Route.scenarioDetail.initialName depends on this match.
+        """)
+    }
+  }
+
   /// Resolve the repo root relative to this test file. `#filePath` expands
   /// at compile time to the absolute source path; we walk up until we find
   /// the directory that contains `docs/gallery`.

--- a/Pastura/PasturaTests/App/RouteHintTests.swift
+++ b/Pastura/PasturaTests/App/RouteHintTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+@Suite(.timeLimit(.minutes(1)))
+struct RouteHintTests {
+
+  // MARK: - Standalone identity-neutral contract
+
+  @Test func differentValuesCompareEqual() {
+    let a = RouteHint<String>("Foo")
+    let b = RouteHint<String>("Bar")
+    #expect(a == b)
+  }
+
+  @Test func nilValueComparesEqualToNonNil() {
+    let nilHint = RouteHint<String>()
+    let setHint = RouteHint<String>("Foo")
+    #expect(nilHint == setHint)
+  }
+
+  @Test func differentValuesProduceEqualHash() {
+    let a = RouteHint<String>("Foo")
+    let b = RouteHint<String>("Bar")
+    #expect(a.hashValue == b.hashValue)
+  }
+
+  @Test func valueIsReadable() {
+    // Identity-neutral `==` does NOT mean values are interchangeable;
+    // `.value` must remain readable for hint consumers.
+    let hint = RouteHint<String>("Foo")
+    #expect(hint.value == "Foo")
+    let empty = RouteHint<String>()
+    #expect(empty.value == nil)
+  }
+
+  // MARK: - Auto-synthesis interaction inside an enum
+
+  // Mirrors the Route shape `case scenarioDetail(scenarioId: String,
+  // initialName: RouteHint<String>)`. Verifies the production code path:
+  // when an enum auto-synthesizes Hashable across one identity-bearing
+  // value (`scenarioId`) and one identity-neutral hint, equality and hash
+  // depend on the identity-bearing value only.
+  private enum TestRoute: Hashable {
+    case detail(id: String, hint: RouteHint<String>)
+    case other(id: String, hint: RouteHint<Int>)
+  }
+
+  @Test func enumDifferingOnlyByHintValueComparesEqual() {
+    let withHint = TestRoute.detail(id: "x", hint: .init("Foo"))
+    let withoutHint = TestRoute.detail(id: "x", hint: .init())
+    #expect(withHint == withoutHint)
+  }
+
+  @Test func enumDifferingByIdComparesUnequal() {
+    let idX = TestRoute.detail(id: "x", hint: .init("Foo"))
+    let idY = TestRoute.detail(id: "y", hint: .init("Foo"))
+    #expect(idX != idY)
+  }
+
+  @Test func enumDifferingOnlyByHintProducesEqualHash() {
+    let withHint = TestRoute.detail(id: "x", hint: .init("Foo"))
+    let withoutHint = TestRoute.detail(id: "x", hint: .init())
+    #expect(withHint.hashValue == withoutHint.hashValue)
+  }
+
+  @Test func enumWithDifferentCasesIsDistinguishedByDiscriminator() {
+    // Different cases must still compare unequal even when both carry
+    // identity-neutral hints — the case discriminator carries identity.
+    let detail = TestRoute.detail(id: "x", hint: .init())
+    let other = TestRoute.other(id: "x", hint: .init())
+    #expect(detail != other)
+  }
+}

--- a/Pastura/PasturaTests/App/RouteHintTests.swift
+++ b/Pastura/PasturaTests/App/RouteHintTests.swift
@@ -9,9 +9,9 @@ struct RouteHintTests {
   // MARK: - Standalone identity-neutral contract
 
   @Test func differentValuesCompareEqual() {
-    let a = RouteHint<String>("Foo")
-    let b = RouteHint<String>("Bar")
-    #expect(a == b)
+    let foo = RouteHint<String>("Foo")
+    let bar = RouteHint<String>("Bar")
+    #expect(foo == bar)
   }
 
   @Test func nilValueComparesEqualToNonNil() {
@@ -21,9 +21,9 @@ struct RouteHintTests {
   }
 
   @Test func differentValuesProduceEqualHash() {
-    let a = RouteHint<String>("Foo")
-    let b = RouteHint<String>("Bar")
-    #expect(a.hashValue == b.hashValue)
+    let foo = RouteHint<String>("Foo")
+    let bar = RouteHint<String>("Bar")
+    #expect(foo.hashValue == bar.hashValue)
   }
 
   @Test func valueIsReadable() {

--- a/docs/decisions/ADR-008.md
+++ b/docs/decisions/ADR-008.md
@@ -1,0 +1,97 @@
+# ADR-008: Route Identity vs Render-Time Hints
+
+> **Status:** Accepted
+> **Date:** 2026-04-26
+> **Context:** Phase 2. After PR #249 items 1–5 fixed view-body flash
+> via deferred `@State viewModel` assignment, residual title-bar
+> pop-in remained: `.navigationTitle` is preference-propagated and
+> updates after `.task`-triggered loads complete, so a `.large` title
+> bar slides in empty for ~30–80ms before the scenario name appears.
+> Operational rule lives in `.claude/rules/navigation.md`
+> § "Render-time hints — RouteHint".
+
+---
+
+## Decision
+
+Introduce `RouteHint<T: Hashable & Sendable>` — a value-type wrapper
+whose `==` is always `true` and whose `hash(into:)` is a no-op — and
+embed it as the type of any `Route` enum associated value that carries
+**render-time hints** (placeholders, animation params) rather than
+**navigation identity**. The wrapped value is read normally via
+`.value`; only `==` and `hashValue` are blind to it. The first
+consumers are `Route.scenarioDetail.initialName` and
+`Route.simulation.initialName`, both `RouteHint<String>`.
+
+Title binding becomes a 3-tier fallback: loaded view-model name →
+push-time `initialName` hint → empty defensive default.
+
+## Why this shape
+
+`Route` already conforms to `Hashable` for `NavigationStack(path:)`
+diffing and `AppRouter.pushIfOnTop(expected:next:)` guards. Adding a
+plain `String?` `initialName` to a case would make
+`Route.scenarioDetail(scenarioId: "x")` (default-nil) and
+`Route.scenarioDetail(scenarioId: "x", initialName: "Foo")` compare
+unequal under auto-synthesized `Hashable`. Future `pushIfOnTop`
+callers that omit the hint when constructing `expected` would silently
+fail their guards — a class of bug PR #93 already paid for once.
+
+`RouteHint`'s identity-neutral `==` lets `Route`'s auto-synthesized
+`Hashable` keep working unchanged: `scenarioId` continues to drive
+identity, the hint participates only in display.
+
+## Alternatives Considered
+
+| | Approach | Pro | Con | Verdict |
+|---|---|---|---|---|
+| α | Manual `==` / `hash(into:)` on `Route` ignoring the hint | Familiar Swift idiom | Boilerplate scales with `Route` case count; switch update easy to forget when adding cases | Rejected — maintenance cost grows with future `Route` additions |
+| **β** | **`RouteHint<T>` identity-neutral wrapper** | One-time type definition; future routes reuse the pattern; intent encoded in the type system | Pastura-specific idiom (~10 lines + doc); slight call-site verbosity (`.init(name)`) | **Accepted** |
+| γ | Cache layer in `AppDependencies` keyed by scenario id | `Route` stays untouched; Apple HIG-faithful | Responsibility scattered across cache holder / populator / invalidator; mutable state needs Sendable design; cache invalidation surface | Rejected — sub-system overhead disproportionate to the problem |
+
+Detailed evaluation in PR #249 discussion (responsibility split,
+testability, type safety, code discoverability, Phase 3 scalability,
+Apple HIG alignment, Sendable, NavigationStack semantics, state
+restoration, idiom familiarity).
+
+## Consequences
+
+- **Pro: identity-neutral by construction.** `pushIfOnTop` callers
+  may omit the hint when constructing `expected`; the guard still
+  matches as long as `scenarioId` (the identity-bearing field) does.
+  Pinned by `AppRouterTests.pushIfOnTopMatchesIdenticalScenarioIdRegardlessOfHint`
+  and `pushIfOnTopFailsWhenScenarioIdDiffers`.
+- **Pro: future-additive.** New `Route` cases that need a render-time
+  hint declare it as `RouteHint<T>` instead of plain `T`; auto-
+  synthesized `Hashable` continues to use only identity-bearing
+  fields. No per-case `==` boilerplate.
+- **Con: documentation load-bearing.** A reviewer expecting
+  Equatable-equal-implies-interchangeable will be surprised that
+  `RouteHint<String>("Foo") == RouteHint<String>("Bar")` while
+  `.value` differs. The type's header doc-comment carries the
+  warning explicitly.
+- **Con: nonisolated requirement.** Under
+  `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, the custom `==` /
+  `hash(into:)` would otherwise inherit MainActor and fail the
+  nonisolated `Hashable` conformance. `RouteHint` is therefore
+  declared `nonisolated` at the type level. `Route` itself remains
+  unannotated because its auto-synthesized `Hashable` does not have
+  this issue.
+- **Access modifier:** `RouteHint` is `internal`, matching `Route`'s
+  current access level. If `Route` is ever promoted to `public` for
+  SPM extraction of `App/`, `RouteHint` must follow.
+- **State restoration (future):** Adding `Codable` to `Route` would
+  require choosing whether to encode `RouteHint`'s `.value`. Encoding
+  it preserves the title across app-kill / restoration; not encoding
+  it surfaces the original placeholder briefly on restore. Either is
+  defensible; revisit if state restoration is added.
+
+## References
+
+- `Pastura/Pastura/App/RouteHint.swift` — type definition with the
+  load-bearing identity-neutrality warning.
+- `Pastura/Pastura/App/Router.swift` — `Route.scenarioDetail` /
+  `.simulation` use sites.
+- `.claude/rules/navigation.md` § "Render-time hints — RouteHint" —
+  auto-loaded operational rule for future navigation work.
+- PR #249 — implementation + extended discussion.


### PR DESCRIPTION
## Summary

Eliminate "flash of default value" UX bugs across multiple SwiftUI screens. Two phases of fixes:

**Phase 1 (items 1–5) — view body content flash:**
- Defer `@State viewModel` assignment until async load completes in 4 Views (Import, GalleryScenarioDetail, ScenarioDetail, Home), mirroring the existing `ScenarioEditorHost` pattern. Each `.task` body adds `guard viewModel == nil` for `.task` re-fire idempotency. Eliminates ~30–80ms flashes of default state (empty TextEditor, "Try" button on installed gallery rows, gallery banner switching, gallery update badges popping in).
- Drop default-string nav title placeholder for `ScenarioDetailView` and `SimulationView` (`?? "Scenario"` / `?? "Simulation"` → `?? ""`) — `.navigationTitle` evaluates outside the `if let viewModel` gate.

**Phase 2 (items 6–10) — nav title bar flash:**
After Phase 1 landed, residual title-bar pop-in remained: `.navigationTitle` is preference-propagated and updates after `.task` loads complete, so `.large` mode title bar slid in empty for ~30–80ms before the scenario name appeared. Approach D-1: plumb `initialName` through `Route` so the title is known synchronously at push time.
- Introduce **`RouteHint<T>`** identity-neutral wrapper (`==` always true, `hash(into:)` no-op) so `Route` enum's auto-synthesized Hashable continues to use only identity-bearing fields (`scenarioId`) — `pushIfOnTop` guards work even when callers omit the hint.
- Plumb `initialName: RouteHint<String>` through `Route.scenarioDetail` and `Route.simulation`. Push sites supply: HomeView (`scenario.name`), GalleryScenarioDetailView (`scenario.title` — depends on the curation invariant `gallery.title == yaml.name`, enforced by a new test), ScenarioDetailView's Run Simulation (`scenario.name`).
- 3-tier title fallback: `viewModel?.scenario?.name ?? initialName ?? ""` (loaded → push-time hint → defensive empty).
- ADR-008 captures the decision rationale (β over α / γ alternatives). `.claude/rules/navigation.md` gains an auto-loaded "Render-time hints — RouteHint" section. CLAUDE.md Reference Documents table updated.

## Test plan

**Automated (run via CI):**
- `RouteHintTests` (8 tests) — standalone `==` / hash contract + auto-synthesis embedded in enum
- `AppRouterTests` (2 new tests) — `pushIfOnTopMatchesIdenticalScenarioIdRegardlessOfHint`, `pushIfOnTopFailsWhenScenarioIdDiffers`
- `GallerySeedYAMLTests` (1 new test) — `galleryTitleMatchesYAMLName` strict invariant
- `NavigationRegressionTests`, `EditorReloadTests`, `BackGestureTests` — existing UI regression coverage
- Full PasturaTests suite — verified passing locally

**Manual QA:**
- [ ] Cold start → Home: gallery update badges appear together with rows (no pop-in)
- [x] Tap Edit on user scenario → ImportView opens with YAML pre-filled (no empty TextEditor flash)
- [x] Open Share Board → tap an already-installed scenario → button reads "Update" / "Open local copy" immediately (no "Try this scenario" flash)
- [ ] Open a gallery-sourced scenario detail with available update → banner reads "Update available from Share Board" without first showing "From Share Board (read-only)"
- [x] Tap into any scenario detail → title bar shows the scenario name from the first frame of the push (no empty / "Scenario" flash)
- [x] Tap Run Simulation → title bar shows the scenario name from the first frame (no empty / "Simulation" flash)
- [ ] iPad multitasking spot-check: split-view focus changes don't double-load the deferred-VM views

Closes #245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)