### PR TITLE
🔧 chore: mirror CI parallel-testing workaround locally (#250)

### DIFF
--- a/.claude/rules/xcodebuild-cli.md
+++ b/.claude/rules/xcodebuild-cli.md
@@ -5,14 +5,33 @@ Extracted from CLAUDE.md to keep the top-level project file lean. Always-loaded
 
 ## Test Execution
 
+### When to use what
+
+| Scope | Command | Parallel testing |
+|---|---|---|
+| TDD red/green cycle (single class / method) | `xcodebuild test ... -only-testing PasturaTests/<Class>` (direct) | n/a (single class — no benefit) |
+| Pre-PR full local run | `scripts/test-full.sh` | **OFF** (forced — see below) |
+| CI full run | `.github/workflows/ci.yml` | **OFF** (already applied — see [#189](https://github.com/tyabu12/pastura/issues/189)) |
+
+`scripts/test-full.sh` is a thin wrapper that sources `sim-dest.sh` and runs
+`xcodebuild test` with `-parallel-testing-enabled NO` injected before any
+forwarded args. It mirrors the CI workaround for the within-process
+simulator-clone crash cascade — local Apple Silicon runs reproduce the
+cascade at ~50% frequency on the full suite, so any pre-PR full run should
+go through the wrapper. Root-cause investigation continues in
+[#189](https://github.com/tyabu12/pastura/issues/189); this is the
+symptom-level mitigation. TDD-focused runs (`-only-testing PasturaTests/<Class>`)
+are unaffected by the cascade and should bypass the wrapper for speed.
+
 ```bash
 source "$(git rev-parse --show-toplevel)/scripts/sim-dest.sh"
 
-# Run all tests
-xcodebuild test -scheme Pastura -project Pastura/Pastura.xcodeproj \
-  -destination "$DEST" -derivedDataPath "$DERIVED_DATA"
+# Pre-PR full local run (parallel testing forced OFF)
+scripts/test-full.sh
+# Forwards extra args verbatim — narrow scope, skip UI tests, etc.
+scripts/test-full.sh -skip-testing:PasturaUITests
 
-# Run specific test class
+# Run specific test class (TDD cycle — direct invocation, no wrapper)
 xcodebuild test -scheme Pastura -project Pastura/Pastura.xcodeproj \
   -destination "$DEST" -derivedDataPath "$DERIVED_DATA" \
   -only-testing PasturaTests/JSONResponseParserTests

--- a/scripts/test-full.sh
+++ b/scripts/test-full.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Run the full Pastura test suite locally with parallel testing disabled.
+#
+# Usage:
+#   scripts/test-full.sh                                # full unit suite
+#   scripts/test-full.sh -only-testing PasturaTests/Foo # narrow scope
+#   scripts/test-full.sh -skip-testing:PasturaUITests   # skip UI tests
+#
+# Why -parallel-testing-enabled NO:
+# Mirrors the CI workaround for the within-process simulator-clone crash
+# cascade (200+ tests reporting failed at 0.000s on a single clone PID).
+# CI applied this in .github/workflows/ci.yml; local Apple Silicon runs
+# also reproduce at ~50% frequency (PR #246 session). Root-cause work
+# stays in #189 — this wrapper only mirrors the symptom-level workaround.
+#
+# Args after the wrapper's fixed flags are forwarded verbatim via "$@".
+# xcodebuild honors the last value for repeated single-value flags, so
+# user passthrough (e.g. -parallel-testing-enabled YES to test the bug)
+# wins on duplicates. No flag parsing happens here.
+#
+# This wrapper streams xcodebuild output directly to the terminal — no
+# tee, no log file. The exit code is xcodebuild's exit code unmodified.
+
+set -euo pipefail
+
+# shellcheck source=scripts/sim-dest.sh
+source "$(git rev-parse --show-toplevel)/scripts/sim-dest.sh"
+
+set -x
+xcodebuild test \
+  -scheme Pastura \
+  -project Pastura/Pastura.xcodeproj \
+  -destination "$DEST" \
+  -derivedDataPath "$DERIVED_DATA" \
+  -parallel-testing-enabled NO \
+  "$@"


### PR DESCRIPTION
## Summary
- Add `scripts/test-full.sh` thin wrapper that sources `sim-dest.sh` and forces `-parallel-testing-enabled NO`, mirroring the CI workaround for the within-process simulator-clone crash cascade (~50% repro on local Apple Silicon, PR #246 session).
- Document the entry-point map in `.claude/rules/xcodebuild-cli.md`: TDD direct / pre-PR full = wrapper / CI = already OFF. Replaces the higher-traffic "Run all tests" example to prevent conflicting guidance.
- Memory `feedback_local_sim_flaky_crash.md` (out-of-repo) updated to point at the new wrapper as the canonical full-run path.

Root-cause investigation continues in #189; this PR is symptom-level mitigation only.

## Test plan
- [x] `scripts/test-full.sh -only-testing PasturaTests/JSONResponseParserTests` → 41 tests passed; DerivedData resolved to `Pastura/DerivedData/...` (worktree-relative); concurrent-session gate did not self-trigger.
- [x] **3 consecutive full-suite runs green** via `scripts/test-full.sh -skip-testing:PasturaUITests`; 0.000s cascade count = 0 across all runs (Issue Acceptance criterion #1 met).
- [x] `set -x` trace prints the xcodebuild invocation including `-parallel-testing-enabled NO` before exec — flag application is deterministically observable.

Closes #250.