### PR TITLE
✨ feat: Settings → Privacy Policy link (#233)

### DIFF
--- a/Pastura/Pastura/Views/Settings/SettingsView.swift
+++ b/Pastura/Pastura/Views/Settings/SettingsView.swift
@@ -20,6 +20,8 @@ import os
 /// `simulationActivityRegistry.isActive == false` at the UI layer so
 /// the service is never torn down mid-inference.
 struct SettingsView: View {
+  @Environment(\.openURL) private var openURL
+
   #if !targetEnvironment(simulator)
     @Environment(ModelManager.self) private var modelManager
     @Environment(AppDependencies.self) private var dependencies
@@ -44,6 +46,24 @@ struct SettingsView: View {
         contentReportingBody
       } header: {
         Text("Content reporting")
+      }
+      Section {
+        Button {
+          guard let url = URL(string: "https://tyabu12.github.io/pastura/legal/privacy-policy/")
+          else { return }
+          openURL(url)
+        } label: {
+          HStack {
+            Text(String(localized: "Privacy Policy"))
+              .foregroundStyle(.primary)
+            Spacer()
+            Image(systemName: "arrow.up.right.square")
+              .foregroundStyle(.secondary)
+          }
+        }
+        .accessibilityIdentifier("settings.privacyPolicyLink")
+      } header: {
+        Text("About")
       }
     }
     .navigationTitle("Settings")

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -113,7 +113,7 @@ First App Store submission depends on a set of cross-cutting blockers tracked in
 - [x] Host the policy at `https://tyabu12.github.io/pastura/legal/privacy-policy/` via GitHub Pages
 - [ ] Register the URL in App Store Connect → App Information → Privacy Policy URL
 - [ ] Answer the App Privacy Details questionnaire ("Data Not Collected", per `PrivacyInfo.xcprivacy`)
-- [ ] Add in-app Settings → "Privacy Policy" link (Guideline 5.1.1: "easily accessible")
+- [x] Add in-app Settings → "Privacy Policy" link (Guideline 5.1.1: "easily accessible")
 
 Custom EULA is intentionally deferred — Apple's [Standard EULA](https://www.apple.com/legal/internet-services/itunes/dev/stdeula/) auto-applies; revisit if Phase 3 introduces server-side data flows (gated on ADR-006).
 


### PR DESCRIPTION
## Summary

- Adds an "About" section to `SettingsView` with a **Privacy Policy** row that opens the hosted policy at `https://tyabu12.github.io/pastura/legal/privacy-policy/` via `@Environment(\.openURL)`.
- Required by App Store [Guideline 5.1.1](https://developer.apple.com/app-store/review/guidelines/#5.1.1) ("easily accessible"). The policy text + hosting shipped in #237 + the Pages restructure; this PR closes the **in-app reachability** item only.
- Ticks `docs/ROADMAP.md` line 116 to reflect completion.

## Implementation notes

- Pattern mirrors `Pastura/Pastura/Views/Community/ShareBoard/ReportScenarioSheet.swift`: `@Environment(\.openURL)` + `guard let url = URL(string:) else { return }` (no force-unwrap per Hard Rule #1) + trailing `arrow.up.right.square` icon to signal external navigation + `accessibilityIdentifier("settings.privacyPolicyLink")`.
- New "Privacy Policy" label string wrapped in `String(localized:)` for i18n prep. The new section header `Text("About")` left bare to match the existing in-file convention (`Text("Models")` / `Text("Content reporting")` are also bare); broader header-localization cleanup deferred to a separate PR.
- URL kept inline as a static literal — `Utilities/LegalURLs.swift` extraction considered and rejected per YAGNI (`ReportURLBuilder` exists because it composes URLs with arguments; this is a single static constant with no composition logic).

## Remaining items in #233 (out of scope)

- Register the URL in App Store Connect → App Information → Privacy Policy URL (manual user-side ASC action)
- Answer the App Privacy Details questionnaire ("Data Not Collected") (manual user-side ASC action)

`Part of #233` — NOT `Closes #233` since the two ASC-side items above remain open.

## Test plan

- [x] Pre-commit hooks: `swiftlint --strict` + `xcodebuild build` passed on both commits
- [x] Full local test suite: `scripts/test-full.sh` → `** TEST SUCCEEDED **` (3 UI tests + unit suite)
- [x] `code-reviewer` (Sonnet) review: PASS, 0 Critical, 1 Warning (header localization — defensible defer per existing file convention), 1 Suggestion (URL extraction — YAGNI)
- [ ] Manual smoke (post-merge): launch app on simulator → tap Settings → scroll to "About" → tap "Privacy Policy" → confirm Safari opens to `https://tyabu12.github.io/pastura/legal/privacy-policy/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)