### PR TITLE
📝 docs: codify View testing strategy in .claude/rules/

### DIFF
--- a/.claude/rules/view-testing.md
+++ b/.claude/rules/view-testing.md
@@ -1,0 +1,104 @@
+# View Testing Strategy
+
+Pastura's Views/ + UI test footprint is deliberately narrow. Logic that
+*could* live in a View is extracted to a unit-testable target (ViewModel,
+formatter, validator, computed display state); UI tests are reserved for
+navigation-integration regressions. ViewInspector and snapshot-testing
+libraries are not used.
+
+## What to do
+
+### View → unit-test (logic surface extraction)
+
+When adding a new View, identify its **logic surface** and put that into
+a unit test in `Pastura/PasturaTests/Views/`, following the existing
+patterns:
+
+| Pattern | Existing example |
+|---------|------------------|
+| Public init contract pin (call-site pinning) | `AgentOutputRowContractTests` |
+| Pure layout / geometry helpers | `SheepAvatarTests`, `ChatBubbleTests` |
+| Form validation rules | `PersonaEditorSheetValidationTests`, `PhaseEditorSheetValidationTests` |
+| Display-name / label formatting | `PhaseTypeLabelTests` |
+| Design token constants | `DesignTokensTests` |
+| Route dispatch / ready-handoff branching | `DemoReplayHostViewTests` |
+
+Tests instantiate the View struct directly when needed (no SwiftUI host
+infrastructure), but assert against pure-logic properties / computed
+values — never rendered output.
+
+### UI test — navigation-integration boundary only
+
+Add a UI test in `Pastura/PasturaUITests/` only when the regression
+target is a navigation-integration boundary that pure logic cannot
+cover. The current 3 tests model the bar:
+
+| Test | Boundary it covers |
+|------|---------------------|
+| `NavigationRegressionTests` | gallery install → run-sim push, AppRouter `pushIfOnTop` guard |
+| `BackGestureTests` | Home → Detail swipe-back pop-by-one |
+| `EditorReloadTests` | editor save → Home `onChange(of: router.path.count)` reload trigger |
+
+Frame-level / animation-timing bugs (e.g. overlay flash, default-value
+flash, animation race) are **not** in scope for automated tests — they
+fall to manual QA + code-review gatekeeping. See PR #252, #249, #150
+for the cost-of-investigation pattern.
+
+## What NOT to do
+
+### Do not introduce ViewInspector
+
+Concrete reasons:
+- ViewInspector breaks on every Xcode major; current Xcode 26 has a
+  community-fix-pending status, with several SwiftUI navigation / list
+  / animation / presentation APIs already on the unsupported list.
+- Tests written against the ViewInspector API leak SwiftUI internals
+  (view-tree shape, modifier ordering) into the test, so changes to the
+  View body force test churn even when behavior is unchanged.
+
+### Do not introduce swift-snapshot-testing
+
+Concrete reasons:
+- Snapshot diffs are flaky across simulator GPU / renderer / iOS-version
+  variation, and re-recording on each Xcode update is mandatory churn.
+- Pastura already has CI time pressure (#250 / #189 — parallel-testing
+  cascade); a snapshot suite adds another category of pre-merge friction
+  without catching the timing-class bugs that dominate Phase 2 fix
+  history.
+
+### Do not chase 100% Views/ coverage
+
+Phase 2 fix-commit analysis (2026-04-27 audit, 10 representative
+commits): **50%** were already preventable by existing infra (Sendable
+compile-time, `withObservationTracking`, ViewModel unit tests, parser
+tests); **30%** are timing/animation bugs neither ViewInspector nor
+snapshot testing reliably catches; **20%** are domain-logic bugs in
+ViewModels that surface visibly. Adding a thick Views/ test layer would
+move the frontier on roughly 0% of these categories.
+
+CLAUDE.md "UI tests are not required for MVP" remains in effect; Phase 2
+has not changed that policy.
+
+## When to revisit
+
+This rule should be re-evaluated if any of the following becomes true:
+
+- Apple ships a stable, first-party SwiftUI inspection API (e.g., a
+  hypothetical `View.inspect()` shipped in the standard SDK).
+- The frame/timing bug ratio (category (b) above) climbs above 50% over
+  3+ consecutive months — this would shift the cost/benefit math toward
+  snapshot testing despite its flakiness.
+- A specific high-value flow becomes too complex for ViewModel-level
+  testing alone (e.g., a user-visible regression that was fundamentally
+  unreachable from the VM layer).
+
+## Cross-references
+
+- `navigation.md` — the QA scenarios list naming what manual coverage
+  remains for the routes UI tests don't exercise.
+- `testing.md` — overall testing priority order
+  (JSONResponseParser → ScenarioLoader → TemplateExpander → PhaseHandlers
+  → ScoreCalcHandler) and `MockLLMService` deterministic-test pattern.
+- `docs/decisions/ADR-001.md` — Architecture Overview; the layer
+  diagram explains why most testable logic lives in Engine / App below
+  the View boundary.

--- a/.claude/rules/view-testing.md
+++ b/.claude/rules/view-testing.md
@@ -1,104 +1,38 @@
+---
+paths:
+  - "Pastura/PasturaTests/**"
+  - "Pastura/PasturaUITests/**"
+  - "Pastura/Pastura/Views/**"
+---
+
 # View Testing Strategy
 
-Pastura's Views/ + UI test footprint is deliberately narrow. Logic that
-*could* live in a View is extracted to a unit-testable target (ViewModel,
-formatter, validator, computed display state); UI tests are reserved for
-navigation-integration regressions. ViewInspector and snapshot-testing
-libraries are not used.
+Decision record: [ADR-009](../../docs/decisions/ADR-009.md). Operational
+rule below.
 
-## What to do
+## Rule
 
-### View → unit-test (logic surface extraction)
+1. **Extract View logic to unit-tests.** When adding a new View,
+   identify its logic surface (validation rules, formatting, computed
+   display state) and put that into a unit test in
+   `Pastura/PasturaTests/Views/` following the existing patterns
+   (`AgentOutputRowContractTests`, `PersonaEditorSheetValidationTests`,
+   `DesignTokensTests`, etc.). Assert against pure-logic properties,
+   never rendered output.
 
-When adding a new View, identify its **logic surface** and put that into
-a unit test in `Pastura/PasturaTests/Views/`, following the existing
-patterns:
+2. **UI tests for the navigation-integration boundary only.** Add to
+   `Pastura/PasturaUITests/` only when the regression target cannot be
+   reached from pure logic. The existing 3 model the bar:
+   `NavigationRegressionTests`, `BackGestureTests`, `EditorReloadTests`.
 
-| Pattern | Existing example |
-|---------|------------------|
-| Public init contract pin (call-site pinning) | `AgentOutputRowContractTests` |
-| Pure layout / geometry helpers | `SheepAvatarTests`, `ChatBubbleTests` |
-| Form validation rules | `PersonaEditorSheetValidationTests`, `PhaseEditorSheetValidationTests` |
-| Display-name / label formatting | `PhaseTypeLabelTests` |
-| Design token constants | `DesignTokensTests` |
-| Route dispatch / ready-handoff branching | `DemoReplayHostViewTests` |
+3. **Do NOT introduce ViewInspector or swift-snapshot-testing.** Both
+   add third-party-library risk (Xcode-major refresh cadence) and CI
+   flakiness without catching the timing-class bugs that dominate
+   Phase 2 fix history. Full rationale in ADR-009.
 
-Tests instantiate the View struct directly when needed (no SwiftUI host
-infrastructure), but assert against pure-logic properties / computed
-values — never rendered output.
+4. **Frame / animation-timing bugs are not in scope** for automated
+   tests. Defer to manual QA + code-review gatekeeping. PRs #252, #249,
+   #150 are case-study patterns.
 
-### UI test — navigation-integration boundary only
-
-Add a UI test in `Pastura/PasturaUITests/` only when the regression
-target is a navigation-integration boundary that pure logic cannot
-cover. The current 3 tests model the bar:
-
-| Test | Boundary it covers |
-|------|---------------------|
-| `NavigationRegressionTests` | gallery install → run-sim push, AppRouter `pushIfOnTop` guard |
-| `BackGestureTests` | Home → Detail swipe-back pop-by-one |
-| `EditorReloadTests` | editor save → Home `onChange(of: router.path.count)` reload trigger |
-
-Frame-level / animation-timing bugs (e.g. overlay flash, default-value
-flash, animation race) are **not** in scope for automated tests — they
-fall to manual QA + code-review gatekeeping. See PR #252, #249, #150
-for the cost-of-investigation pattern.
-
-## What NOT to do
-
-### Do not introduce ViewInspector
-
-Concrete reasons:
-- ViewInspector breaks on every Xcode major; current Xcode 26 has a
-  community-fix-pending status, with several SwiftUI navigation / list
-  / animation / presentation APIs already on the unsupported list.
-- Tests written against the ViewInspector API leak SwiftUI internals
-  (view-tree shape, modifier ordering) into the test, so changes to the
-  View body force test churn even when behavior is unchanged.
-
-### Do not introduce swift-snapshot-testing
-
-Concrete reasons:
-- Snapshot diffs are flaky across simulator GPU / renderer / iOS-version
-  variation, and re-recording on each Xcode update is mandatory churn.
-- Pastura already has CI time pressure (#250 / #189 — parallel-testing
-  cascade); a snapshot suite adds another category of pre-merge friction
-  without catching the timing-class bugs that dominate Phase 2 fix
-  history.
-
-### Do not chase 100% Views/ coverage
-
-Phase 2 fix-commit analysis (2026-04-27 audit, 10 representative
-commits): **50%** were already preventable by existing infra (Sendable
-compile-time, `withObservationTracking`, ViewModel unit tests, parser
-tests); **30%** are timing/animation bugs neither ViewInspector nor
-snapshot testing reliably catches; **20%** are domain-logic bugs in
-ViewModels that surface visibly. Adding a thick Views/ test layer would
-move the frontier on roughly 0% of these categories.
-
-CLAUDE.md "UI tests are not required for MVP" remains in effect; Phase 2
-has not changed that policy.
-
-## When to revisit
-
-This rule should be re-evaluated if any of the following becomes true:
-
-- Apple ships a stable, first-party SwiftUI inspection API (e.g., a
-  hypothetical `View.inspect()` shipped in the standard SDK).
-- The frame/timing bug ratio (category (b) above) climbs above 50% over
-  3+ consecutive months — this would shift the cost/benefit math toward
-  snapshot testing despite its flakiness.
-- A specific high-value flow becomes too complex for ViewModel-level
-  testing alone (e.g., a user-visible regression that was fundamentally
-  unreachable from the VM layer).
-
-## Cross-references
-
-- `navigation.md` — the QA scenarios list naming what manual coverage
-  remains for the routes UI tests don't exercise.
-- `testing.md` — overall testing priority order
-  (JSONResponseParser → ScenarioLoader → TemplateExpander → PhaseHandlers
-  → ScoreCalcHandler) and `MockLLMService` deterministic-test pattern.
-- `docs/decisions/ADR-001.md` — Architecture Overview; the layer
-  diagram explains why most testable logic lives in Engine / App below
-  the View boundary.
+Full Why + alternatives + revisit triggers:
+[ADR-009](../../docs/decisions/ADR-009.md).

--- a/.claude/rules/view-testing.md
+++ b/.claude/rules/view-testing.md
@@ -3,6 +3,7 @@ paths:
   - "Pastura/PasturaTests/**"
   - "Pastura/PasturaUITests/**"
   - "Pastura/Pastura/Views/**"
+  - "Pastura/Pastura/App/**ViewModel.swift"
 ---
 
 # View Testing Strategy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,7 @@ pages/                           # Public HTML deployed via .github/workflows/de
 - `llm.md` — LLM-layer traps (e.g., `nonisolated` protocol-default impls that build escaping closures) can fire from any conformer, including types added in `App/` or test targets, so the rule must stay visible regardless of which file is being edited.
 - `navigation.md` — `AppRouter` pattern: programmatic root-stack navigation goes through `router.push(_:)` / `router.pushIfOnTop(expected:next:)`, and `navigationDestination(item:|isPresented:)` is forbidden inside views pushed onto the root stack. Sheet-owned NavigationStacks are exempt. Always-loaded because view-placement decisions can originate from any feature directory.
 - `xcodebuild-cli.md` — xcodebuild CLI playbook (test commands, DerivedData layout, timeout/recovery for agent sessions). Always-loaded because xcodebuild gotchas surface during worktree switches and CI debugging, not only when editing test files.
+- `view-testing.md` — View testing strategy: extract logic to unit-tests, narrow UI integration tests, do NOT introduce ViewInspector / snapshot testing libraries. Always-loaded because the question "should I add a snapshot test for this?" can arise from any feature directory and the answer is no without first revisiting the rule.
 
 ## File Naming
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,7 +210,7 @@ pages/                           # Public HTML deployed via .github/workflows/de
 - `models-and-data.md` — Models + Data source (`Pastura/Pastura/Models/**`, `Pastura/Pastura/Data/**`)
 - `presets.md` — Bundled scenario YAML (`Pastura/Pastura/Resources/**`)
 - `testing.md` — Test target (`Pastura/PasturaTests/**`)
-- `view-testing.md` — View test strategy: extract logic to unit-tests, narrow UI integration tests, no ViewInspector / snapshot (`Pastura/PasturaTests/**`, `Pastura/PasturaUITests/**`, `Pastura/Pastura/Views/**`). Decision record: [ADR-009](docs/decisions/ADR-009.md).
+- `view-testing.md` — View test strategy: extract logic to unit-tests, narrow UI integration tests, no ViewInspector / snapshot (`Pastura/PasturaTests/**`, `Pastura/PasturaUITests/**`, `Pastura/Pastura/Views/**`, `Pastura/Pastura/App/**ViewModel.swift`). Decision record: [ADR-009](docs/decisions/ADR-009.md).
 
 **Always-loaded** (no frontmatter `paths:` — relevant from any layer):
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,13 +210,13 @@ pages/                           # Public HTML deployed via .github/workflows/de
 - `models-and-data.md` — Models + Data source (`Pastura/Pastura/Models/**`, `Pastura/Pastura/Data/**`)
 - `presets.md` — Bundled scenario YAML (`Pastura/Pastura/Resources/**`)
 - `testing.md` — Test target (`Pastura/PasturaTests/**`)
+- `view-testing.md` — View test strategy: extract logic to unit-tests, narrow UI integration tests, no ViewInspector / snapshot (`Pastura/PasturaTests/**`, `Pastura/PasturaUITests/**`, `Pastura/Pastura/Views/**`). Decision record: [ADR-009](docs/decisions/ADR-009.md).
 
 **Always-loaded** (no frontmatter `paths:` — relevant from any layer):
 
 - `llm.md` — LLM-layer traps (e.g., `nonisolated` protocol-default impls that build escaping closures) can fire from any conformer, including types added in `App/` or test targets, so the rule must stay visible regardless of which file is being edited.
 - `navigation.md` — `AppRouter` pattern: programmatic root-stack navigation goes through `router.push(_:)` / `router.pushIfOnTop(expected:next:)`, and `navigationDestination(item:|isPresented:)` is forbidden inside views pushed onto the root stack. Sheet-owned NavigationStacks are exempt. Always-loaded because view-placement decisions can originate from any feature directory.
 - `xcodebuild-cli.md` — xcodebuild CLI playbook (test commands, DerivedData layout, timeout/recovery for agent sessions). Always-loaded because xcodebuild gotchas surface during worktree switches and CI debugging, not only when editing test files.
-- `view-testing.md` — View testing strategy: extract logic to unit-tests, narrow UI integration tests, do NOT introduce ViewInspector / snapshot testing libraries. Always-loaded because the question "should I add a snapshot test for this?" can arise from any feature directory and the answer is no without first revisiting the rule.
 
 ## File Naming
 
@@ -243,6 +243,7 @@ Record architectural decisions in `docs/decisions/` as `ADR-NNN.md`.
 | `docs/decisions/ADR-006.md`           | Cloud API implementation details (Phase 3; reserved — not yet written; see ADR-005 §7.5) |
 | `docs/decisions/ADR-007.md`           | DL-time demo replay — iOS lifecycle (#152)  |
 | `docs/decisions/ADR-008.md`           | Route identity vs render-time hints (`RouteHint<T>` pattern, #245) |
+| `docs/decisions/ADR-009.md`           | View testing strategy (no ViewInspector / snapshot; #269) |
 | `docs/specs/pastura-mvp-spec-v0_3.md` | MVP specification                                         |
 | `docs/specs/demo-replay-spec.md`      | DL-time demo replay — data format + component design (#152) |
 | `docs/specs/demo-replay-ui.md`        | DL-time demo replay — visual / behaviour spec (#164)        |

--- a/docs/decisions/ADR-009.md
+++ b/docs/decisions/ADR-009.md
@@ -41,7 +41,16 @@ by which test infrastructure (if any) could have prevented each:
 |---|---|---|
 | **(a) Already preventable by existing infra** | **50%** | `#225` Sendable compile-time; `#216` `withObservationTracking`; `#146` LocalizedError; `#140` ContentFilter streaming snapshot; `#199` parser validation |
 | **(b) Frame / animation-timing bugs** | 30% | `#252` overlay handoff; `#249` default-value flash; `#150` task-generation race |
-| **(c) Domain-logic bugs surfacing in View** | 20% | `#136` YAML round-trip; `#191` cellular gate launch race |
+| **(c) Domain-logic bugs surfacing in View** | 20% | `#136` YAML round-trip; `#188` `TurnRecord.phasePath` persistence for nested phases |
+
+> **Note on bucket (a):** This combines compile-time prevention
+> (`#225` Swift 6 Sendable enforcement) and runtime test-infra prevention
+> (`#216` / `#146` / `#140` / `#199` — observation tests, error
+> conformance, parser validation); the grouping is "preventable without
+> snapshot/ViewInspector", regardless of mechanism. Bucket sizes are
+> over a non-randomly-selected sample of 10 commits judged
+> representative of Phase 2 churn — treat as directional, not
+> statistical.
 
 Adding a thick Views/ test layer would move the frontier on ≈0% of these:
 (a) is already covered; (b) needs a SwiftUI host running with
@@ -107,7 +116,10 @@ failures) without catching the timing-class bugs that dominate (b).
 
 ## Revisit Triggers
 
-Re-evaluate this decision if any of the following becomes true:
+Re-evaluate this decision if any of the following becomes true.
+*These triggers require ad-hoc human audit — there is no automated
+metric collection. Surface them at Phase boundaries or when post-mortem
+analysis suggests they may be active.*
 
 1. **Apple ships a stable, first-party SwiftUI inspection API** (e.g.,
    a hypothetical `View.inspect()` in the standard SDK). Removes the
@@ -118,6 +130,10 @@ Re-evaluate this decision if any of the following becomes true:
 3. **A specific high-value flow becomes unreachable from the VM layer
    for two consecutive PRs.** Indicates the extract-to-VM strategy has
    hit a fundamental limit for that flow.
+4. **ViewInspector ships full Xcode-N support within 1 month of Xcode-N
+   GA for two consecutive Xcode majors.** Indicates the library's
+   maintenance posture has changed and the (α) rejection — based on the
+   recurring lag against Xcode majors — should be re-evaluated.
 
 ## References
 

--- a/docs/decisions/ADR-009.md
+++ b/docs/decisions/ADR-009.md
@@ -1,0 +1,132 @@
+# ADR-009: View Testing Strategy
+
+> **Status:** Accepted
+> **Date:** 2026-04-29
+> **Context:** Phase 2. Quality audit (2026-04-27) flagged "Views 18%
+> test coverage / 3 UI tests" as a top tech-debt item; the follow-up
+> Phase 2 fix-commit analysis downgraded it to low priority. This ADR
+> records the decision so future audits do not re-investigate the same
+> false positive.
+> Operational rule lives in `.claude/rules/view-testing.md`.
+
+---
+
+## Decision
+
+Pastura's Views/ + UI test footprint is deliberately narrow:
+
+1. Logic that *could* live in a View is **extracted to a unit-testable
+   target** (ViewModel, formatter, validator, computed display state) and
+   tested in `Pastura/PasturaTests/Views/` against pure-logic properties
+   — never rendered output.
+2. UI tests in `Pastura/PasturaUITests/` are **reserved for
+   navigation-integration regressions** that pure logic cannot cover
+   (currently `NavigationRegressionTests`, `BackGestureTests`,
+   `EditorReloadTests`).
+3. **Frame-level / animation-timing bugs are not in scope** for automated
+   tests — they fall to manual QA + code-review gatekeeping.
+4. **Do not introduce ViewInspector or swift-snapshot-testing libraries.**
+
+CLAUDE.md "UI tests are not required for MVP" remains in effect; Phase 2
+has not changed that policy.
+
+## Why this shape
+
+### Phase 2 fix-commit analysis (2026-04-27 audit)
+
+10 representative Views/App fix commits since 2026-02-01 were classified
+by which test infrastructure (if any) could have prevented each:
+
+| Category | Share | Examples |
+|---|---|---|
+| **(a) Already preventable by existing infra** | **50%** | `#225` Sendable compile-time; `#216` `withObservationTracking`; `#146` LocalizedError; `#140` ContentFilter streaming snapshot; `#199` parser validation |
+| **(b) Frame / animation-timing bugs** | 30% | `#252` overlay handoff; `#249` default-value flash; `#150` task-generation race |
+| **(c) Domain-logic bugs surfacing in View** | 20% | `#136` YAML round-trip; `#191` cellular gate launch race |
+
+Adding a thick Views/ test layer would move the frontier on ≈0% of these:
+(a) is already covered; (b) needs a SwiftUI host running with
+frame-precision timing — neither ViewInspector nor snapshot diffs reach
+this reliably; (c) belongs in ViewModel / Engine tests, not View tests.
+
+### ViewInspector vs Pastura's release cadence
+
+ViewInspector is the leading runtime-introspection library for SwiftUI
+tests. As of 2026-04 it has a documented "unsupported APIs" list against
+the Xcode 26.2 SDK that includes many navigation, list, animation, and
+presentation modifiers. Each Xcode major has historically required a
+community fix before ViewInspector tests compile again.
+
+Pastura tracks Apple's release cadence closely (Phase 2 already targets
+iOS 26 `BGContinuedProcessingTask`). Adopting ViewInspector would couple
+the test suite to a third-party library on a fix-pending status against
+the SDK we depend on — a recurring blocker every Xcode major.
+
+Tests written against ViewInspector also leak SwiftUI internals
+(view-tree shape, modifier ordering) into the test, forcing churn when
+the View body is restructured for non-behavioral reasons.
+
+### swift-snapshot-testing vs CI flakiness
+
+swift-snapshot-testing compares rendered output to a stored reference
+image. In iOS simulator contexts, snapshot diffs are flaky across
+simulator GPU / Metal renderer differences, iOS minor-version
+font-metric / rendering subpixel changes, and mandatory re-recording on
+Xcode updates.
+
+Pastura already has CI time pressure: #189 documented OOM cascades from
+parallel testing under wall-clock load, mitigated by serializing tests
+(#250). A snapshot suite would introduce a new category of pre-merge
+friction (re-record cycles, diff inspection, simulator-specific
+failures) without catching the timing-class bugs that dominate (b).
+
+## Alternatives Considered
+
+| | Approach | Pro | Con | Verdict |
+|---|---|---|---|---|
+| α | Adopt ViewInspector for runtime view introspection | Test SwiftUI behavior directly; idiomatic for the community | Each Xcode major forces a community-fix wait; tests leak view-tree internals; current Xcode 26 status fix-pending | Rejected |
+| β | Adopt swift-snapshot-testing for visual regression | Catches layout regressions automatically | Flaky across simulator/iOS variation; mandatory re-record cycle; does not catch (b) timing bugs that dominate fixes | Rejected |
+| γ | Pursue 100% Views/ coverage with thick UI tests | Highest theoretical coverage | UI test job already at 12 min / 25 min budget; does not catch (b); duplicates (a) work | Rejected |
+| **δ** | **Extract View logic to unit-tests + narrow UI tests at navigation boundary** | Reuses Pastura's existing `App/` testability; matches what (a) category fixes already validate; zero third-party deps | Frame/timing bugs (~30%) not auto-caught — manual QA + code review gates required | **Accepted** |
+
+## Consequences
+
+- **Pro: zero third-party test dependencies for View work.** Test target
+  stays compatible with new Xcode releases without waiting on community
+  fixes.
+- **Pro: existing `App/` testability is the leverage point.** New Views/
+  work is routed through `ViewModel` extraction, which keeps the View
+  layer thin and testable from below.
+- **Pro: CI footprint stable.** No new test category to add to the
+  parallel-testing-disabled budget (#189).
+- **Con: frame/timing bugs require manual QA and reviewer vigilance.**
+  Mitigation: #252 / #249 / #150 in commit history serve as case
+  studies; reviewers know to look for animation-timing regressions in
+  code review.
+- **Con: a high-value flow that genuinely requires SwiftUI host testing
+  has no on-ramp.** Mitigation: revisit triggers below.
+
+## Revisit Triggers
+
+Re-evaluate this decision if any of the following becomes true:
+
+1. **Apple ships a stable, first-party SwiftUI inspection API** (e.g.,
+   a hypothetical `View.inspect()` in the standard SDK). Removes the
+   third-party-library risk that drives the ViewInspector rejection.
+2. **The (b) frame/timing bug ratio climbs above 50% over 3+ consecutive
+   months.** Shifts the cost/benefit math toward snapshot testing
+   despite its flakiness.
+3. **A specific high-value flow becomes unreachable from the VM layer
+   for two consecutive PRs.** Indicates the extract-to-VM strategy has
+   hit a fundamental limit for that flow.
+
+## References
+
+- `.claude/rules/view-testing.md` — operational rule that codifies the
+  decision
+- `.claude/rules/testing.md` — testing mechanics (parallelism,
+  `.timeLimit`, `MockLLMService`) — adjacent topic
+- `.claude/rules/navigation.md` — navigation QA scenarios that complement
+  the 3 UI tests
+- [ADR-001](ADR-001.md) — Architecture Overview (thin View layer
+  rationale)
+- #266 / #269 — sister cleanup PRs from the 2026-04-27 audit cycle


### PR DESCRIPTION
## Summary

3-layer documentation of Pastura's View testing strategy, designed to preempt recurring "Views 18% / UI 3 tests = missing infra" false positives in quality audits.

- **`docs/decisions/ADR-009.md`** (new) — full rationale: Phase 2 fix-commit analysis (50% already preventable / 30% timing-class / 20% domain), ViewInspector vs Xcode-major cadence, snapshot-testing CI flakiness, alternatives table (α/β/γ rejected, δ accepted), revisit triggers.
- **`.claude/rules/view-testing.md`** — slim operational rule (~30 lines) path-scoped to `PasturaTests/**`, `PasturaUITests/**`, `Pastura/Pastura/Views/**`. Links to ADR-009 for the Why.
- **`CLAUDE.md`** — Context-Specific Rules entry moved from Always-loaded to Path-scoped; ADR-009 added to Reference Documents table.

## Loaded-cost change

| Scenario | Before | After |
|---|---|---|
| Every session | ~700 tokens (always-loaded view-testing.md) | ~30 tokens (CLAUDE.md pointer) |
| Editing tests / Views | included above | ~200 tokens (slim rule fires) |

## Test plan
- N/A — doc-only PR

## Sister cleanup
- PR #266 — Why-comments on `file_length` disables (same audit cycle)
- #264 — Logger migration (same audit)

Closes #269