### PR TITLE
♻️ refactor: ThoughtVisibilityToggle + Demo controlBar (1a/#273)

### DIFF
--- a/Pastura/Pastura/Views/Components/PhaseHeader.swift
+++ b/Pastura/Pastura/Views/Components/PhaseHeader.swift
@@ -66,9 +66,13 @@ public struct PhaseHeader: View {
       }
     }
     .overlay(alignment: .bottom) {
-      // 1pt bottom border per spec: rgba(60,62,48,0.07)
+      // 1pt bottom border per spec: rgba(60,62,48,0.07). `Color.ink`
+      // is the project's "warm dark ink" token (`#2D2E26`); Sim's
+      // controlBar uses the same token at the same alpha. (#273 PR 1a
+      // drift fix — was `Color.black.opacity(0.07)` until the Demo
+      // controlBar made the cross-bar drift visible.)
       Rectangle()
-        .fill(Color.black.opacity(0.07))
+        .fill(Color.ink.opacity(0.07))
         .frame(height: 1)
     }
   }

--- a/Pastura/Pastura/Views/Components/ThoughtVisibilityToggle.swift
+++ b/Pastura/Pastura/Views/Components/ThoughtVisibilityToggle.swift
@@ -48,11 +48,11 @@ struct ThoughtVisibilityToggle: View {
 
 #Preview {
   struct Wrapper: View {
-    @State private var on = true
+    @State private var isOn = true
     var body: some View {
       VStack(spacing: 16) {
-        ThoughtVisibilityToggle(isOn: $on).font(.title3)
-        Text("isOn: \(String(on))")
+        ThoughtVisibilityToggle(isOn: $isOn).font(.title3)
+        Text("isOn: \(String(isOn))")
       }
     }
   }

--- a/Pastura/Pastura/Views/Components/ThoughtVisibilityToggle.swift
+++ b/Pastura/Pastura/Views/Components/ThoughtVisibilityToggle.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+/// A toggle button that controls "show all thoughts" mode in chat-stream
+/// views (Simulation / Results / DL-time demo). On state uses the filled
+/// chat-bubble icon + moss accent; off state uses the outlined icon +
+/// muted ink. Caller provides `font` via `.font(...)` on the toggle if
+/// they want sizing larger than system default.
+///
+/// Used by `SimulationView`, `ResultDetailView`, and
+/// `ModelDownloadHostView` — see issue #273.
+struct ThoughtVisibilityToggle: View {
+  @Binding var isOn: Bool
+
+  var body: some View {
+    Button {
+      isOn.toggle()
+    } label: {
+      Image(systemName: Self.iconName(for: isOn))
+        .foregroundStyle(Self.tint(for: isOn))
+    }
+    .accessibilityLabel(Self.accessibilityLabel(for: isOn))
+  }
+
+  /// Filled chat-bubble for the "showing thoughts" state, outlined for
+  /// "hidden". Pinned by `ThoughtVisibilityToggleContractTests` to catch
+  /// accidental swaps.
+  static func iconName(for isOn: Bool) -> String {
+    isOn ? "text.bubble.fill" : "text.bubble"
+  }
+
+  /// `Color.moss` (accent) for ON, `Color.inkSecondary` (neutral muted)
+  /// for OFF. Returning a concrete `Color` (not the bare `.moss` ShapeStyle
+  /// shorthand) is intentional — see memory `feedback_shapestyle_color_token_trap.md`:
+  /// `.foregroundStyle(.muted)` silently fails for Color extension tokens.
+  static func tint(for isOn: Bool) -> Color {
+    isOn ? Color.moss : Color.inkSecondary
+  }
+
+  /// Localized accessibility label that flips between "Hide all thoughts"
+  /// (when ON) and "Show all thoughts" (when OFF). The verb pivots on
+  /// what tap-action is available next.
+  static func accessibilityLabel(for isOn: Bool) -> String {
+    isOn
+      ? String(localized: "Hide all thoughts")
+      : String(localized: "Show all thoughts")
+  }
+}
+
+#Preview {
+  struct Wrapper: View {
+    @State private var on = true
+    var body: some View {
+      VStack(spacing: 16) {
+        ThoughtVisibilityToggle(isOn: $on).font(.title3)
+        Text("isOn: \(String(on))")
+      }
+    }
+  }
+  return Wrapper()
+}

--- a/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+ControlBar.swift
+++ b/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+ControlBar.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+
+extension ModelDownloadHostView {
+
+  /// Sim-style frosted controlBar for the DL-time demo. Mirrors
+  /// `SimulationView.controlBar` shape so users learn the layout
+  /// before reaching the live simulation (issue #273).
+  ///
+  /// **Disabled-mirror layout** — Pause and Speed are visually
+  /// present but `.disabled(true)` and styled with `Color.disabledText`
+  /// (design-system §2.7 — Interactive States); only
+  /// `ThoughtVisibilityToggle` is interactive. PR 1b enables Pause /
+  /// Speed by adding a user-driven pause / resume API to
+  /// `ReplayViewModel`; at that point `.disabled(true)` is removed
+  /// and the controls wire to the new API. Until then, the disabled
+  /// layout serves as tutorial preview.
+  ///
+  /// Does **not** apply `.ignoresSafeArea(.container, edges: .bottom)`
+  /// (unlike `SimulationView.controlBar`). The host's
+  /// `.safeAreaInset(edge: .bottom)` already absorbs the bottom region
+  /// for `PromoCard`; adding the ignore would extend tint into the
+  /// inset region with unpredictable interaction with the
+  /// PromoCard layer (#273 critic Axis 2).
+  ///
+  /// `.buttonStyle(.plain)` is used on the disabled controls to
+  /// suppress the system's default button decoration so the explicit
+  /// `Color.disabledText` token is the dominant rendered color rather
+  /// than the system's accent-tint × disabled-opacity composite.
+  @ViewBuilder
+  func controlBar() -> some View {
+    HStack(spacing: 16) {
+      pausePreviewButton
+      speedPreviewButton
+
+      Spacer()
+
+      ThoughtVisibilityToggle(isOn: $showAllThoughts)
+        .font(.title3)
+    }
+    .padding(.horizontal)
+    .padding(.vertical, 10)
+    .background {
+      ZStack {
+        Color.screenBackground.opacity(0.78)
+        Rectangle().fill(.ultraThinMaterial)
+      }
+    }
+    .overlay(alignment: .top) {
+      Rectangle().fill(Color.ink.opacity(0.07)).frame(height: 1)
+    }
+  }
+
+  /// Disabled "preview" Pause button — same icon as Sim's running-state
+  /// Pause (`pause.fill`). PR 1b wires the action to
+  /// `replayVM?.userPause()` and removes `.disabled(true)`.
+  @ViewBuilder
+  private var pausePreviewButton: some View {
+    Button {
+    } label: {
+      Image(systemName: "pause.fill").font(.title3)
+    }
+    .buttonStyle(.plain)
+    .foregroundStyle(Color.disabledText)
+    .disabled(true)
+    .accessibilityLabel(
+      String(localized: "Pause (available during simulation)"))
+  }
+
+  /// Disabled "preview" Speed picker — same label structure as Sim's
+  /// `speedOrExportControl` Menu (gauge icon + value + chevron). Static
+  /// `1×` since `ReplayViewModel` runs at a fixed `speedMultiplier`.
+  /// PR 1b replaces this with a real `Menu` over `PlaybackSpeed.allCases`.
+  @ViewBuilder
+  private var speedPreviewButton: some View {
+    Button {
+    } label: {
+      HStack(spacing: 4) {
+        Image(systemName: "gauge.with.dots.needle.50percent")
+        Text(verbatim: "1×")
+        Image(systemName: "chevron.down").font(.caption2)
+      }
+      .textStyle(Typography.titlePhase)
+    }
+    .buttonStyle(.plain)
+    .foregroundStyle(Color.disabledText)
+    .disabled(true)
+    .accessibilityLabel(
+      String(localized: "Playback speed (available during simulation)"))
+  }
+}

--- a/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView.swift
+++ b/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView.swift
@@ -84,6 +84,13 @@ struct ModelDownloadHostView: View {
   @State private var replayHadStarted: Bool = false
   @State private var sources: [any ReplaySource] = []
   @State private var isShowingCancelConfirmation: Bool = false
+  /// Whether agent thought lines (`▸ THINKING`) are expanded across the
+  /// chat stream. Default `true` mirrors the Sim / Results state and the
+  /// `docs/specs/demo-replay-ui.md` §163-165 amendment in this PR
+  /// (project-wide "expanded by default"). Module-internal (drops
+  /// `private`) so the sibling `+ControlBar.swift` extension can bind
+  /// to it via `$showAllThoughts`.
+  @State var showAllThoughts: Bool = true
   /// Re-entry guard for `handleModelStateChange`: `.onChange(of: currentState)`
   /// only fires on inequality, but a defensive same-value re-emit by
   /// `ModelManager` (or a future refactor) would otherwise dispatch the
@@ -221,7 +228,7 @@ struct ModelDownloadHostView: View {
                 agent: entry.agent,
                 output: entry.output,
                 phaseType: entry.phaseType,
-                showAllThoughts: true,
+                showAllThoughts: showAllThoughts,
                 isLatest: entry.id == viewModel.agentOutputs.last?.id,
                 charsPerSecond: 60,
                 agentPosition: agentPosition(for: entry.agent, viewModel: viewModel)
@@ -246,6 +253,13 @@ struct ModelDownloadHostView: View {
           }
         }
       }
+
+      // Sim-style frosted controlBar (#273): mirrors `SimulationView.controlBar`
+      // shape so users learn the layout before reaching the live simulation.
+      // Pause / Speed are visible-but-disabled placeholders (PR 1b enables them
+      // via a new `ReplayViewModel.userPause()` API); only the thought toggle
+      // is interactive in the demo.
+      controlBar()
     }
     .background(Color.screenBackground.ignoresSafeArea())
     // PromoCard lives in the bottom safe area instead of a ZStack overlay:

--- a/Pastura/Pastura/Views/Results/ResultDetailView.swift
+++ b/Pastura/Pastura/Views/Results/ResultDetailView.swift
@@ -101,12 +101,13 @@ struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
         .disabled(!canExportYAML)
       }
       ToolbarItem(placement: .secondaryAction) {
-        Button {
-          showAllThoughts.toggle()
-        } label: {
-          Image(systemName: showAllThoughts ? "text.bubble.fill" : "text.bubble")
-            .foregroundStyle(showAllThoughts ? Color.moss : Color.inkSecondary)
-        }
+        // Currently the only `.secondaryAction` — renders inline. If a future
+        // toolbar change adds a second `.secondaryAction`, SwiftUI promotes
+        // both items to an overflow Menu where the moss tint inside
+        // `ThoughtVisibilityToggle` (`.foregroundStyle(Color.moss)`) may flatten
+        // to the system menu accent and stop communicating ON/OFF state.
+        // Revisit placement (e.g., move to `.primaryAction`) before that lands.
+        ThoughtVisibilityToggle(isOn: $showAllThoughts)
       }
     }
     .sheet(item: $exportPayload) { payload in

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -493,14 +493,11 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
 
       Spacer()
 
-      // Thought visibility toggle
-      Button {
-        viewModel.showAllThoughts.toggle()
-      } label: {
-        Image(systemName: viewModel.showAllThoughts ? "text.bubble.fill" : "text.bubble")
-          .font(.title3)
-          .foregroundStyle(viewModel.showAllThoughts ? Color.moss : Color.inkSecondary)
-      }
+      // Thought visibility toggle — uses ThoughtVisibilityToggle from Components
+      // for parity with Results / Demo (issue #273).
+      @Bindable var viewModel = viewModel
+      ThoughtVisibilityToggle(isOn: $viewModel.showAllThoughts)
+        .font(.title3)
 
       // Background continuation toggle (iOS 26+ with LlamaCppService only)
       if #available(iOS 26, *), viewModel.canEnableBackgroundContinuation {

--- a/Pastura/PasturaTests/Views/ThoughtVisibilityToggleContractTests.swift
+++ b/Pastura/PasturaTests/Views/ThoughtVisibilityToggleContractTests.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+import Testing
+
+@testable import Pastura
+
+@MainActor
+@Suite(.timeLimit(.minutes(1)))
+struct ThoughtVisibilityToggleContractTests {
+
+  // MARK: - iconName(for:)
+
+  @Test func iconNameForOnStateIsFilledBubble() {
+    #expect(ThoughtVisibilityToggle.iconName(for: true) == "text.bubble.fill")
+  }
+
+  @Test func iconNameForOffStateIsOutlinedBubble() {
+    #expect(ThoughtVisibilityToggle.iconName(for: false) == "text.bubble")
+  }
+
+  // MARK: - tint(for:)
+
+  @Test func tintForOnStateIsMoss() {
+    #expect(ThoughtVisibilityToggle.tint(for: true) == Color.moss)
+  }
+
+  @Test func tintForOffStateIsInkSecondary() {
+    #expect(ThoughtVisibilityToggle.tint(for: false) == Color.inkSecondary)
+  }
+
+  // MARK: - accessibilityLabel(for:)
+
+  @Test func accessibilityLabelForOnStateContainsHide() {
+    let label = ThoughtVisibilityToggle.accessibilityLabel(for: true)
+    #expect(!label.isEmpty)
+    #expect(label.contains("Hide"))
+  }
+
+  @Test func accessibilityLabelForOffStateContainsShow() {
+    let label = ThoughtVisibilityToggle.accessibilityLabel(for: false)
+    #expect(!label.isEmpty)
+    #expect(label.contains("Show"))
+  }
+
+  @Test func accessibilityLabelsForOnAndOffAreDifferent() {
+    let onLabel = ThoughtVisibilityToggle.accessibilityLabel(for: true)
+    let offLabel = ThoughtVisibilityToggle.accessibilityLabel(for: false)
+    #expect(onLabel != offLabel)
+  }
+}

--- a/docs/specs/demo-replay-ui.md
+++ b/docs/specs/demo-replay-ui.md
@@ -162,7 +162,24 @@ ZStack(alignment: .top) {
 #### THINKING（内なる思考）
 - 折りたたみ時: `▸ THINKING` のみ（8.5pt / モノスペース / `#b1ac92` / letterSpacing 0.22em）
 - 展開時: 左に1.5pt縦線（`#d4cba8`）、本文は 10.5pt / `#8a876f` / italic / line-height 1.7
-- タップでトグル（実装推奨）
+- **デフォルトは展開**。タップでトグル（折りたたみ ↔ 展開）。
+
+> **2026-04-29 amendment (#273)** — `showAllThoughts` のデフォルトは
+> 3 画面共通で `true`（展開）に統一。Demo / Simulation / Results すべて
+> 同じ初期表示を共有し、ユーザーは各画面の `ThoughtVisibilityToggle`
+> ボタン（`Views/Components/ThoughtVisibilityToggle.swift`）で折り
+> 畳み / 展開を切り替える。
+>
+> 当初仕様（`▸ THINKING` 折りたたみが default）からの逸脱は、3G 環境
+> で DL に 10+ 分かかる前提下で demo 画面が長時間滞在画面となること、
+> Sim / Results でも「何が起きているか」を即座に見せる方が UX が良い
+> ことを根拠とする (#273 issue body 参照)。狭く感じるユーザーには
+> toggle で折り畳む選択肢を残す。
+>
+> **Demo 固有の補足**: PR 1a 時点では Demo controlBar の Pause / Speed
+> は disabled-mirror (Sim controlBar の見た目を踏襲、機能は未配線)。
+> PR 1b で `ReplayViewModel` に user-pause / resume API を追加し
+> enable する。
 
 #### アバター
 - 42pt 丸。「羊」シルエット（SVGで実装済み、詳細は HTML 参照）


### PR DESCRIPTION
## Summary
- Extract `ThoughtVisibilityToggle` component (`Views/Components/`) shared by Sim / Results / Demo. Logic-contract-pinned by `ThoughtVisibilityToggleContractTests` (icon pair, `Color.moss` / `Color.inkSecondary` tokens, accessibility labels) under ADR-009.
- Add a Sim-style frosted controlBar to the DL-time demo with **disabled-mirror layout** — Pause / Speed visible-but-disabled (`Color.disabledText` per design-system §2.7), only the thought toggle is interactive. PR 1b (separate future issue) enables Pause / Speed by adding a user-pause API to `ReplayViewModel`.
- 1-line `PhaseHeader` border color drift fix: `Color.black.opacity(0.07)` → `Color.ink.opacity(0.07)` to match Sim's controlBar token (drift became visible once the Demo controlBar landed in this PR).
- Spec amend `docs/specs/demo-replay-ui.md` §THINKING — project-wide `showAllThoughts: true` (展開) default, 3-screen unified.

## Test plan
- [x] `ThoughtVisibilityToggleContractTests` (7 tests) pass — pins icon pair, tint tokens, accessibility label contract under ADR-009 (no rendering / no ViewInspector).
- [x] `ModelDownloadHostViewTests` (10 tests) pass — no regression in demo dispatch / cellular / overlay flows.
- [x] Full unit suite passes via `scripts/test-full.sh -skip-testing:PasturaUITests`.
- [x] `swiftlint lint --quiet --strict` clean.
- [ ] **Manual QA pre-merge** (iPhone 15+ home-indicator sim): trigger `.needsModelDownload`, confirm controlBar↔PromoCard junction has no cream-colored seam (`safeAreaInset(spacing: Spacing.l)` gap — verify it doesn't read as a layout artifact). [#273 critic Axis 2]
- [ ] **Manual QA pre-merge**: 3-screen toggle behavior — flip on/off in Sim (during simulation), Results (past-result viewer), Demo (during DL replay) — confirm thought rows expand / collapse smoothly.

## Out of scope (handled in follow-ups)
- **PR 1b** — `ReplayViewModel` user-pause/resume API + Demo Pause / Speed enable. Separate future issue.
- **PR 2** — `PhaseHeader` generic化 + Sim header rewrite + chat-stream token alignment. Tracked in original #273.

Part of #273.

🤖 Generated with [Claude Code](https://claude.com/claude-code)