### PR TITLE
📝 docs: ADR-010 stub for Localization (Status: Proposed)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,6 +247,7 @@ Record architectural decisions in `docs/decisions/` as `ADR-NNN.md`.
 | `docs/decisions/ADR-007.md`           | DL-time demo replay — iOS lifecycle (#152)  |
 | `docs/decisions/ADR-008.md`           | Route identity vs render-time hints (`RouteHint<T>` pattern, #245) |
 | `docs/decisions/ADR-009.md`           | View testing strategy (no ViewInspector / snapshot; #269) |
+| `docs/decisions/ADR-010.md`           | Localization (i18n: ja/en) — pre-Step A stub (Status: Proposed; #279) |
 | `docs/specs/pastura-mvp-spec-v0_3.md` | MVP specification                                         |
 | `docs/specs/demo-replay-spec.md`      | DL-time demo replay — data format + component design (#152) |
 | `docs/specs/demo-replay-ui.md`        | DL-time demo replay — visual / behaviour spec (#164)        |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,13 +8,14 @@
 Phase 1 MVP shipped via TestFlight (conditional Go, 2026-04-13).
 If a requested feature is listed under Phase 3, do not implement it — reference the roadmap and defer.
 
-Completed in Phase 2 so far:
+Phase 2 progress:
 - **Visual Scenario Editor** — dual-mode form + YAML (#83)
 - **Background execution** — iOS 26 BGContinuedProcessingTask + CPU inference (#84)
 - **Share Board** — read-only curated scenario gallery (#87/#93)
 - **Simulation result export** — Markdown via Share Sheet, incl. code-phase results (#91/#98)
 - **Inference speed display** — tok/s + simulation playback UX (#99)
 - **Past results — code-phase events** — score_calc / scenario gen events in past-results viewer (#102/#113)
+- **Localization (i18n: ja/en)** — *in progress* — see ROADMAP § "Localization Plan" (#276/#277, ADR-010 stub #279)
 
 ## Language Rules
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -177,10 +177,10 @@ A short follow-up PR creates `docs/decisions/ADR-010.md` (Status: Proposed) with
 
 1. Scenario YAML language field name (`language`) and default value
 2. Phase 1 backward-compat rule (missing field ⇒ implicit `ja`)
-3. Engine hardcoded-Japanese strategy (X: `Localizable.xcstrings`-based / Y: dynamic per `scenario.language`) — body confirms which; the stub records "TBD in body"
-4. Engine layer is excluded from Step A's `Localizable.xcstrings`; `nonisolated` is retained
+3. Engine hardcoded-Japanese strategy: **Y (dynamic per `scenario.language`)**. X (`Localizable.xcstrings`-based) was rejected because Step C-1 retains `nonisolated` on Engine types — keeping the strategy choice consistent with the existing dependency-rule constraint. The body PR specifies the per-site translation table; the stub fixes the strategy only.
+4. Engine layer is excluded from Step A's `Localizable.xcstrings`; `nonisolated` is retained.
 
-The stub PR also adds a "Localization in progress" line to CLAUDE.md "Completed in Phase 2 so far" and refines this dependency graph if the early decisions shift it.
+The stub PR also renames CLAUDE.md "Completed in Phase 2 so far" → "Phase 2 progress" so the section can carry mixed-status entries, and adds a `Localization (i18n: ja/en) — in progress` entry under it. This dependency graph is refined in the same PR if the early decisions shift it.
 
 ### Phase 2 → Phase 3 Go Criteria
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -129,7 +129,7 @@ i18n is split into staged Steps so the harder design questions (per-language YAM
 ```
 ROADMAP merge (this PR)
   → Pre-ADR-010 stub PR
-        + CLAUDE.md "Completed in Phase 2 so far" line
+        + CLAUDE.md "Phase 2 progress" entry
         + dependency-graph corrections (this section, if needed)
   → Step A (A-1 / A-2 PR split recommended) + Step B-1a (parallel)
   → Step B-1b (after A — UI must be English to capture screenshots)

--- a/docs/decisions/ADR-010.md
+++ b/docs/decisions/ADR-010.md
@@ -105,8 +105,9 @@ The body PR closes these:
 
 ## References
 
-- Tracking issue: [#276](https://github.com/tyabu12/pastura/issues/276)
+- Localization tracking issue: [#276](https://github.com/tyabu12/pastura/issues/276)
 - ROADMAP promotion PR: [#277](https://github.com/tyabu12/pastura/pull/277)
+- This stub's tracking issue: [#279](https://github.com/tyabu12/pastura/issues/279)
 - ROADMAP § "Localization Plan" — full Step table and dependency graph
 - Step C-1 will produce the body that supersedes this stub's
   Open Questions.

--- a/docs/decisions/ADR-010.md
+++ b/docs/decisions/ADR-010.md
@@ -1,0 +1,112 @@
+# ADR-010: Localization (i18n: ja / en) — Pre-Step A Stub
+
+> **Status:** Proposed
+> **Date:** 2026-04-29
+> **Context:** Phase 2. The Localization Plan promotion (#276 / PR #277)
+> introduced 7 sequential Steps (A → E) for shipping English UI on the
+> App Store. Step A (UI shell + error message i18n) needs four narrow
+> decisions to wire its YAML schema and backward-compat without
+> ambiguity. This stub captures only those four decisions; the body PR
+> (Step C-1) extends this ADR in place — per-language YAML file design,
+> scenario ID aliasing, `simulation_language` schema, and the
+> per-Engine-site translation table — and flips Status to Accepted.
+> Operational rule: `docs/ROADMAP.md` § "Localization Plan".
+
+> **Lifecycle note:** When Step C-1's body PR confirms the remaining
+> decisions, it edits this ADR in place and flips Status to Accepted
+> (not via Amendment section). The CLAUDE.md "ADR editability window"
+> rule covers Accepted-not-yet-shipped; this stub extends the same
+> in-place pattern to the Proposed → Accepted transition.
+
+---
+
+## Decision
+
+The minimum decisions Step A needs:
+
+1. **Scenario YAML language field name and default.** The field is named
+   `language` and accepts an ISO 639-1 lowercase code (`ja`, `en`).
+   No default literal in the schema — absence triggers the
+   backward-compat rule below.
+
+2. **Phase 1 backward-compat rule.** When `language` is absent from a
+   scenario YAML, the loader assumes `ja` (Phase 1 shipped Japanese-only
+   presets and authored scenarios; assuming `ja` preserves Past Results
+   and bundled-preset behavior without migration).
+
+3. **Engine hardcoded-Japanese strategy: Y (dynamic per
+   `scenario.language`).** The Engine layer reads `scenario.language` at
+   build / runtime and emits the appropriate language for prompt
+   strings, default phase outputs, and scoring summaries. X
+   (`Localizable.xcstrings`-based) is rejected: Step A's `String(localized:)`
+   wrapping pattern resolves to the *device locale* via `Bundle.main`,
+   not to a per-scenario language, and `Localizable.xcstrings` would
+   couple Engine string resolution to the UI Bundle — incompatible with
+   running an `en` scenario on a `ja` device. The body PR specifies the
+   per-site translation table (~10 sites: `PromptBuilder`,
+   `SpeakAllHandler`, `SpeakEachHandler`, `VoteHandler` defaults,
+   `WordwolfJudgeLogic` summaries).
+
+4. **Engine layer is excluded from Step A's `Localizable.xcstrings`.**
+   Step A's xcstrings sweep stops at the Views/ + App/ boundary. The
+   Engine retains `nonisolated` per the project Dependency Rules and
+   handles its own language switching via decision 3 in Step C-1.
+
+## Why this shape
+
+Decisions 1, 2, 4 unblock Step A's YAML wrapping and `Localizable.xcstrings`
+scoping; without them Step A would either over-reach into Engine code or
+ship a YAML schema the body PR has to migrate. Decision 3 is included
+(rather than deferred) because the X / Y choice is forced by Step C-1's
+already-committed `nonisolated` retention — `Localizable.xcstrings` lookup
+would couple to the UI Bundle's preferred-localization, which cannot
+satisfy "run `en` scenario on `ja` device." Recording Y at the stub level
+prevents the body PR from re-litigating it.
+
+## Alternatives Considered
+
+| | Approach | Verdict |
+|---|---|---|
+| α | Engine uses `Localizable.xcstrings` + `String(localized:)` | Rejected — `Bundle.main` resolves to device locale, not `scenario.language`; breaks cross-language simulation (Step E goal). |
+| **β** | **Engine emits language dynamically per `scenario.language`** | **Accepted** as decision 3. |
+| γ | Stub records decision 3 as "TBD in body" | Rejected — Step C-1's `nonisolated` retention already eliminates α; deferring just shifts the same conclusion to the body PR. |
+
+## Consequences
+
+- **Pro:** Step A is unblocked. The YAML schema (`language` field), the
+  backward-compat path (`ja` on absence), and the xcstrings scoping
+  boundary (Views/App only) are all defined.
+- **Pro:** Body ADR-010 (Step C-1) inherits a stable foundation — only
+  per-language YAML file layout, scenario ID aliasing, `simulation_language`
+  schema, and the per-Engine-site translation table remain.
+- **Con:** Loaders / validators referencing this stub will need a small
+  follow-up when the body PR formalizes the per-language YAML file
+  layout (e.g. `prisoners_dilemma_en.yaml`). The stub does not specify
+  filename conventions.
+
+## Open Questions (deferred to Step C-1 body PR)
+
+The body PR closes these:
+
+- Per-language YAML file layout — single-file with `language:` field vs
+  per-language files (`*_en.yaml`); ROADMAP §C-1 leans toward the
+  per-language file approach but the stub does not pin it.
+- Scenario ID treatment across languages — independent IDs with
+  curation-metadata aliasing vs shared ID with language suffix; ROADMAP
+  §C-2 references "alias or migration confirmed in ADR-010" as the
+  Past Results compat target.
+- `simulation_language` field schema — parse-only in Step C-1, wired to
+  Engine override in Step E.
+- `ContentFilter` behavior across languages — confirmed in ROADMAP
+  §C-1 as "full-set application regardless of UI locale", to be made
+  normative in the body PR.
+- Per-Engine-site translation table — the ~10 sites enumerated in
+  ROADMAP §C-1 need their `ja` / `en` strings tabulated.
+
+## References
+
+- Tracking issue: [#276](https://github.com/tyabu12/pastura/issues/276)
+- ROADMAP promotion PR: [#277](https://github.com/tyabu12/pastura/pull/277)
+- ROADMAP § "Localization Plan" — full Step table and dependency graph
+- Step C-1 will produce the body that supersedes this stub's
+  Open Questions.


### PR DESCRIPTION
## Summary

- Adds `docs/decisions/ADR-010.md` (Status: Proposed) capturing the four
  minimum decisions Step A of the Localization Plan needs to unblock —
  YAML `language` field, missing-field-⇒-`ja` backward-compat, Engine
  dynamic-language strategy (Option Y confirmed), and Engine exclusion
  from Step A's xcstrings sweep.
- Resolves a ROADMAP-internal inconsistency surfaced during plan critic:
  line 180 said decision 3 was "TBD in body" while line 150 (Step C-1)
  already implied Y via `nonisolated` retention. Decision 3 is now fixed
  to Y at the stub level.
- Renames CLAUDE.md "Completed in Phase 2 so far" → "Phase 2 progress"
  so the section can carry mixed-status entries, and adds a
  `Localization (i18n: ja/en) — in progress` entry.
- Includes follow-up commit addressing code-reviewer Warning + 2 Suggestions
  (ROADMAP L132 rename-sync miss, CLAUDE.md Reference Documents table row
  for ADR-010, ADR-010 References symmetry with #279).

## Test plan

- [x] Documentation-only PR; no Swift code touched
- [x] Pre-commit hook (swiftlint + xcodebuild build) passed on each commit
- [x] Critic reviewed before implementation — Critical resolved (ROADMAP
      decision 3 inconsistency) + 4 Warnings addressed in plan
- [x] code-reviewer (Opus) PASS; 1 Warning + 2 Suggestions addressed in
      follow-up commit
- [x] Manual: `Reference Documents` table renders cleanly with new ADR-010 row
- [x] Manual: `ROADMAP § "Localization Plan"` dependency graph still references
      the renamed CLAUDE.md section consistently
- [x] Manual: ADR-010 follows ADR-008 / ADR-009 structural conventions; deviations
      (Lifecycle note, Open Questions section) are intentional for Status: Proposed

Closes #279