### PR TITLE
♻️ refactor: rename captureResumeData → updateResumeDataFromError

### DIFF
--- a/Pastura/Pastura/App/ModelDownloader.swift
+++ b/Pastura/Pastura/App/ModelDownloader.swift
@@ -47,7 +47,7 @@ public protocol ModelDownloader: Sendable {
 ///
 /// ## Actor isolation
 ///
-/// `nonisolated` at type level so the synchronous accessors (`captureResumeData`,
+/// `nonisolated` at type level so the synchronous accessors (`updateResumeDataFromError`,
 /// `cachedResumeData`) can be invoked from any executor. Without this, the
 /// project-wide `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` would bind the class
 /// to MainActor and break tests that exercise the cache lifecycle from the
@@ -187,7 +187,7 @@ nonisolated final class URLSessionModelDownloader: ModelDownloader, @unchecked S
       try mergeIntoDestination(
         result: result, resumeOffset: resumeOffset, destination: destination)
     } catch {
-      captureResumeData(from: error, for: url)
+      updateResumeDataFromError(error, for: url)
       throw error
     }
   }
@@ -256,12 +256,12 @@ nonisolated final class URLSessionModelDownloader: ModelDownloader, @unchecked S
   /// from the `catch` block in `download(...)`. Tests construct an `NSError`
   /// with a known resumeData blob to verify cache lifecycle without depending
   /// on Apple's internal heuristic for when resumeData is populated.
-  func captureResumeData(from error: any Error, for url: URL) {
+  func updateResumeDataFromError(_ error: any Error, for url: URL) {
     let nsError = error as NSError
     let fresh = nsError.userInfo[NSURLSessionDownloadTaskResumeData] as? Data
     Self.logger.notice(
       """
-      captureResumeData url=\(url.absoluteString, privacy: .public) \
+      updateResumeDataFromError url=\(url.absoluteString, privacy: .public) \
       freshBlob=\(fresh?.count ?? -1, privacy: .public)bytes \
       errorDomain=\(nsError.domain, privacy: .public) \
       errorCode=\(nsError.code, privacy: .public)

--- a/Pastura/PasturaTests/App/URLSessionModelDownloaderTests.swift
+++ b/Pastura/PasturaTests/App/URLSessionModelDownloaderTests.swift
@@ -67,10 +67,10 @@ class CapturingMockURLProtocol: URLProtocol, @unchecked Sendable {
 @Suite("URLSessionModelDownloader", .serialized, .timeLimit(.minutes(1)))
 struct URLSessionModelDownloaderTests {
 
-  // MARK: captureResumeData (cache lifecycle, pure logic)
+  // MARK: updateResumeDataFromError (cache lifecycle, pure logic)
 
-  @Test("captureResumeData stores blob when error has NSURLSessionDownloadTaskResumeData")
-  func captureResumeDataStoresBlob() {
+  @Test("updateResumeDataFromError stores blob when error has NSURLSessionDownloadTaskResumeData")
+  func updateResumeDataFromErrorStoresBlob() {
     let downloader = URLSessionModelDownloader()
     let url = URL(string: "https://example.com/model.gguf")!
     let blob = Data("opaque-resume-blob".utf8)
@@ -80,27 +80,28 @@ struct URLSessionModelDownloaderTests {
       userInfo: [NSURLSessionDownloadTaskResumeData: blob]
     )
 
-    downloader.captureResumeData(from: error, for: url)
+    downloader.updateResumeDataFromError(error, for: url)
 
     #expect(downloader.cachedResumeData(for: url) == blob)
   }
 
-  @Test("captureResumeData leaves cache empty when error lacks resumeData and no prior blob")
-  func captureResumeDataNoBlobNoPrior() {
+  @Test(
+    "updateResumeDataFromError leaves cache empty when error lacks resumeData and no prior blob")
+  func updateResumeDataFromErrorNoBlobNoPrior() {
     let downloader = URLSessionModelDownloader()
     let url = URL(string: "https://example.com/model.gguf")!
     let error = NSError(
       domain: NSURLErrorDomain, code: NSURLErrorCannotConnectToHost, userInfo: [:])
 
-    downloader.captureResumeData(from: error, for: url)
+    downloader.updateResumeDataFromError(error, for: url)
 
     #expect(downloader.cachedResumeData(for: url) == nil)
   }
 
   @Test(
-    "captureResumeData clears stale prior blob when error lacks fresh resumeData"
+    "updateResumeDataFromError clears stale prior blob when error lacks fresh resumeData"
   )
-  func captureResumeDataClearsStaleOnNonResumableError() {
+  func updateResumeDataFromErrorClearsStaleOnNonResumableError() {
     // Scenario: attempt 1 timed out with resumeData → blob A cached. Attempt 2
     // failed with a non-resumable error (e.g., 5xx, DNS, badServerResponse) so
     // Apple did not supply a fresh blob. Blob A's referenced URLSession temp
@@ -111,37 +112,37 @@ struct URLSessionModelDownloaderTests {
     let url = URL(string: "https://example.com/model.gguf")!
 
     let blobA = Data("blob-A".utf8)
-    downloader.captureResumeData(
-      from: NSError(
+    downloader.updateResumeDataFromError(
+      NSError(
         domain: NSURLErrorDomain, code: NSURLErrorTimedOut,
         userInfo: [NSURLSessionDownloadTaskResumeData: blobA]),
       for: url)
     #expect(downloader.cachedResumeData(for: url) == blobA)
 
     // Attempt 2 — error without resumeData. Should clear blob A.
-    downloader.captureResumeData(
-      from: NSError(
+    downloader.updateResumeDataFromError(
+      NSError(
         domain: NSURLErrorDomain, code: NSURLErrorBadServerResponse, userInfo: [:]),
       for: url)
 
     #expect(downloader.cachedResumeData(for: url) == nil)
   }
 
-  @Test("captureResumeData overwrites prior blob for same URL (last wins)")
-  func captureResumeDataLastWins() {
+  @Test("updateResumeDataFromError overwrites prior blob for same URL (last wins)")
+  func updateResumeDataFromErrorLastWins() {
     let downloader = URLSessionModelDownloader()
     let url = URL(string: "https://example.com/model.gguf")!
 
     let first = Data("first".utf8)
     let second = Data("second".utf8)
 
-    downloader.captureResumeData(
-      from: NSError(
+    downloader.updateResumeDataFromError(
+      NSError(
         domain: NSURLErrorDomain, code: NSURLErrorTimedOut,
         userInfo: [NSURLSessionDownloadTaskResumeData: first]),
       for: url)
-    downloader.captureResumeData(
-      from: NSError(
+    downloader.updateResumeDataFromError(
+      NSError(
         domain: NSURLErrorDomain, code: NSURLErrorTimedOut,
         userInfo: [NSURLSessionDownloadTaskResumeData: second]),
       for: url)
@@ -149,8 +150,8 @@ struct URLSessionModelDownloaderTests {
     #expect(downloader.cachedResumeData(for: url) == second)
   }
 
-  @Test("captureResumeData scopes by URL (different URLs are independent)")
-  func captureResumeDataScopesByURL() {
+  @Test("updateResumeDataFromError scopes by URL (different URLs are independent)")
+  func updateResumeDataFromErrorScopesByURL() {
     let downloader = URLSessionModelDownloader()
     let urlA = URL(string: "https://example.com/a.gguf")!
     let urlB = URL(string: "https://example.com/b.gguf")!
@@ -158,13 +159,13 @@ struct URLSessionModelDownloaderTests {
     let blobA = Data("blobA".utf8)
     let blobB = Data("blobB".utf8)
 
-    downloader.captureResumeData(
-      from: NSError(
+    downloader.updateResumeDataFromError(
+      NSError(
         domain: NSURLErrorDomain, code: NSURLErrorTimedOut,
         userInfo: [NSURLSessionDownloadTaskResumeData: blobA]),
       for: urlA)
-    downloader.captureResumeData(
-      from: NSError(
+    downloader.updateResumeDataFromError(
+      NSError(
         domain: NSURLErrorDomain, code: NSURLErrorTimedOut,
         userInfo: [NSURLSessionDownloadTaskResumeData: blobB]),
       for: urlB)


### PR DESCRIPTION
## Summary

Pure mechanical rename of `URLSessionModelDownloader.captureResumeData(from:for:)` to `updateResumeDataFromError(_:for:)`. PR #278 ([ae58e16](https://github.com/tyabu12/pastura/commit/ae58e16)) expanded this method's responsibility from "save resume-data blob from error" to "save fresh blob OR clear stale blob from cache". The docstring was updated, but the name still suggested save-only — risking misreads.

The new name conveys both-save-and-clear semantics via `FromError` while dropping the redundant `Cache` noun (`URLSessionModelDownloader` itself is the cache).

The `from:` argument label is dropped because `…FromError` grammatically incorporates the preposition (Swift API guidelines: omit needless words).

**No behavior change.**

## Notes

- **Console.app log token also renames** at `ModelDownloader.swift:264`: `captureResumeData url=...` → `updateResumeDataFromError url=...`. Archived QA logs predating this rename use the old token.

## Test plan

- [x] `scripts/test-full.sh` — full unit + UI suite passed (parallel testing OFF)
- [x] `swiftlint lint --quiet --strict` — clean on changed files
- [x] `code-reviewer` (Sonnet) — PASS, 0 issues
- [x] `git grep captureResumeData` — empty (no leftovers in source / docs / `.claude/` / CI)

Closes #283