### PR TITLE
♻️ refactor: PhaseHeader generic + chat-stream token align (2/#273)

### DIFF
--- a/Pastura/Pastura/Views/Components/ChatBubble.swift
+++ b/Pastura/Pastura/Views/Components/ChatBubble.swift
@@ -168,10 +168,17 @@ nonisolated enum ChatBubbleLayout {
   /// Horizontal gap between avatar column and bubble column — matches
   /// reference HTML `.bubble { gap: 10px }`.
   static let avatarTextGap: CGFloat = 10
-  /// Vertical gap between stacked bubbles — matches reference HTML
-  /// `.stream { gap: 14px }`. Consumers using `LazyVStack(spacing:)`
-  /// should pass this value.
-  static let bubbleSpacing: CGFloat = 14
+  /// Vertical gap between stacked bubbles. Tightened project-wide
+  /// from the original 14pt (which still appears in the reference
+  /// HTML at `docs/design/demo-replay-reference.html` `.stream { gap: 14px }`)
+  /// to 8pt in #273 PR 2 so Sim/Results — which surface long
+  /// simulation logs — fit more turns per viewport. Demo's loop also
+  /// benefits since its ~3 visible turns no longer need the wider
+  /// pacing. Consumers using `LazyVStack(spacing:)` should pass this
+  /// value rather than a literal so a future re-tuning flows through
+  /// all three chat-stream surfaces in one place. Pinned by
+  /// `ChatBubbleTests` and `ModelDownloadHostViewTests+Layout`.
+  static let bubbleSpacing: CGFloat = 8
 }
 
 // MARK: - View conveniences

--- a/Pastura/Pastura/Views/Components/PhaseHeader.swift
+++ b/Pastura/Pastura/Views/Components/PhaseHeader.swift
@@ -25,6 +25,11 @@ public struct PhaseHeader<Leading: View, Trailing: View>: View {
   /// to fit Demo's natural typography stack (tagPhase ~9.5pt + 3pt
   /// spacing + titlePhase ~13pt ≈ 25.5pt) with comfort margin.
   /// Pinned by `PhaseHeaderContractTests`.
+  ///
+  /// Computed (not stored) because Swift forbids static stored
+  /// properties on generic types — `PhaseHeader<Leading, Trailing>`
+  /// has two type parameters, so the per-instantiation storage rule
+  /// kicks in. Behavior is identical to a `let`.
   public static var minLeadingHeight: CGFloat { 32 }
 
   /// When `true`, the frosted background extends behind the top

--- a/Pastura/Pastura/Views/Components/PhaseHeader.swift
+++ b/Pastura/Pastura/Views/Components/PhaseHeader.swift
@@ -1,57 +1,62 @@
 import SwiftUI
 
-/// A sticky header displayed at the top of the demo replay chat stream.
-///
-/// Shows the preset name as a small uppercase tag and the current phase label
-/// as a larger title, with a right-aligned "DEMO中" status badge. A subtle
-/// tinted material background and a 1pt bottom border separate the header from
-/// the scrolling content beneath it.
+/// Sticky frosted bar rendered at the top of chat-stream surfaces
+/// (DL-time demo, live simulation, past-result replay). The component
+/// itself owns only the chrome — material background, bottom border,
+/// height-parity floor, and consistent vertical/horizontal padding —
+/// while leading and trailing content are caller-composed via slot
+/// closures. Demo packs a diamond + uppercase preset tag + phase
+/// label into `leading` and a "DEMO中" badge into `trailing`; Sim
+/// packs `Round X/Y` into `leading` and inference-stats + status
+/// badge into `trailing`.
 ///
 /// ```swift
-/// PhaseHeader(presetName: "WORD WOLF", phaseLabel: "発言ラウンド 1")
+/// PhaseHeader(extendsIntoTopSafeArea: true) {
+///   HStack { /* diamond + 2-line VStack */ }
+/// } trailing: {
+///   Text("DEMO中") /* badge */
+/// }
 /// ```
-public struct PhaseHeader: View {
+public struct PhaseHeader<Leading: View, Trailing: View>: View {
 
-  /// The scenario preset name displayed as an uppercase tag (e.g. "WORD WOLF").
-  public let presetName: String
+  /// Floor applied to the leading slot so a single-line caller
+  /// (Sim's `Round X/Y`) and a 2-line caller (Demo's preset tag +
+  /// phase label) render at the same total header height. Pinned
+  /// to fit Demo's natural typography stack (tagPhase ~9.5pt + 3pt
+  /// spacing + titlePhase ~13pt ≈ 25.5pt) with comfort margin.
+  /// Pinned by `PhaseHeaderContractTests`.
+  public static var minLeadingHeight: CGFloat { 32 }
 
-  /// The human-readable phase label displayed below the preset tag (e.g. "発言ラウンド 1").
-  public let phaseLabel: String
+  /// When `true`, the frosted background extends behind the top
+  /// safe area (status bar / Dynamic Island). Demo opts in because
+  /// it presents inside `.fullScreenCover` / `.needsModelDownload`
+  /// slot with no system nav bar above it. Sim/Results stay at the
+  /// default `false` because their NavigationStack-pushed nav bar
+  /// already paints the top safe area with `.ultraThinMaterial`,
+  /// and adding a second frosted layer beneath risks doubled blur.
+  public let extendsIntoTopSafeArea: Bool
+
+  let leading: () -> Leading
+  let trailing: () -> Trailing
+
+  public init(
+    extendsIntoTopSafeArea: Bool = false,
+    @ViewBuilder leading: @escaping () -> Leading,
+    @ViewBuilder trailing: @escaping () -> Trailing
+  ) {
+    self.extendsIntoTopSafeArea = extendsIntoTopSafeArea
+    self.leading = leading
+    self.trailing = trailing
+  }
 
   public var body: some View {
     HStack(alignment: .center, spacing: 0) {
-      // MARK: Left area — diamond ornament + text stack
-      HStack(alignment: .center, spacing: Spacing.xs) {
-        // A 6pt square rotated 45° renders as a diamond. No dedicated shape
-        // exists in SwiftUI for a filled diamond, so this is the idiomatic approach.
-        Rectangle()
-          .fill(Color.moss.opacity(0.7))
-          .frame(width: 6, height: 6)
-          .rotationEffect(.degrees(45))
-
-        VStack(alignment: .leading, spacing: 3) {
-          Text(presetName)
-            .textStyle(Typography.tagPhase)
-            .foregroundStyle(Color.moss)
-
-          Text(phaseLabel)
-            .textStyle(Typography.titlePhase)
-            .foregroundStyle(Color.ink)
-        }
-      }
+      leading()
+        .frame(minHeight: Self.minLeadingHeight, alignment: .leading)
 
       Spacer(minLength: Spacing.xs)
 
-      // MARK: Right area — DEMO中 badge
-      Text("DEMO中")
-        .textStyle(Typography.metaLabel)
-        .foregroundStyle(Color.moss)
-        .padding(.horizontal, 6)
-        .padding(.vertical, 3)
-        .background(
-          RoundedRectangle(cornerRadius: Radius.button)
-            .fill(Color.moss.opacity(0.1))
-        )
+      trailing()
     }
     .padding(.vertical, 10)
     // 10pt vertical is intentional per spec — falls between xs(8) and s(12);
@@ -64,13 +69,14 @@ public struct PhaseHeader: View {
         // Blur layer on top for the frosted-glass effect
         Rectangle().fill(.ultraThinMaterial)
       }
+      // Conditional safe-area extension: see `extendsIntoTopSafeArea` doc.
+      // Applied inside `.background { }` so only the chrome layer extends —
+      // the foreground HStack stays within the safe area.
+      .modifier(TopSafeAreaExtensionModifier(enabled: extendsIntoTopSafeArea))
     }
     .overlay(alignment: .bottom) {
       // 1pt bottom border per spec: rgba(60,62,48,0.07). `Color.ink`
-      // is the project's "warm dark ink" token (`#2D2E26`); Sim's
-      // controlBar uses the same token at the same alpha. (#273 PR 1a
-      // drift fix — was `Color.black.opacity(0.07)` until the Demo
-      // controlBar made the cross-bar drift visible.)
+      // is the project's "warm dark ink" token (`#2D2E26`).
       Rectangle()
         .fill(Color.ink.opacity(0.07))
         .frame(height: 1)
@@ -78,19 +84,72 @@ public struct PhaseHeader: View {
   }
 }
 
+// MARK: - Helpers
+
+/// Conditionally applies `.ignoresSafeArea(.container, edges: .top)`.
+/// `ViewModifier` form keeps the conditional out of the view-builder
+/// path so the type system doesn't infer two divergent body shapes.
+private struct TopSafeAreaExtensionModifier: ViewModifier {
+  let enabled: Bool
+
+  func body(content: Content) -> some View {
+    if enabled {
+      content.ignoresSafeArea(.container, edges: .top)
+    } else {
+      content
+    }
+  }
+}
+
 // MARK: - Previews
 
-#Preview("Default") {
+#Preview("Demo (preset tag + phase label + DEMO中 badge)") {
   VStack(spacing: 0) {
-    PhaseHeader(presetName: "WORD WOLF", phaseLabel: "発言ラウンド 1")
+    PhaseHeader(extendsIntoTopSafeArea: true) {
+      HStack(alignment: .center, spacing: Spacing.xs) {
+        Rectangle()
+          .fill(Color.moss.opacity(0.7))
+          .frame(width: 6, height: 6)
+          .rotationEffect(.degrees(45))
+        VStack(alignment: .leading, spacing: 3) {
+          Text("WORD WOLF")
+            .textStyle(Typography.tagPhase)
+            .foregroundStyle(Color.moss)
+          Text("発言ラウンド 1")
+            .textStyle(Typography.titlePhase)
+            .foregroundStyle(Color.ink)
+        }
+      }
+    } trailing: {
+      Text("DEMO中")
+        .textStyle(Typography.metaLabel)
+        .foregroundStyle(Color.moss)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+        .background(
+          RoundedRectangle(cornerRadius: Radius.button)
+            .fill(Color.moss.opacity(0.1))
+        )
+    }
     Spacer()
   }
   .background(Color.screenBackground)
 }
 
-#Preview("Long phase label") {
+#Preview("Sim (Round X/Y + status)") {
   VStack(spacing: 0) {
-    PhaseHeader(presetName: "PRISONERS DILEMMA", phaseLabel: "協議フェーズ 1 / 3")
+    PhaseHeader {
+      Text("Round 2/5")
+        .textStyle(Typography.metaEta)
+        .monospacedDigit()
+    } trailing: {
+      HStack(spacing: 4) {
+        ProgressView().scaleEffect(0.7)
+        Text("Running")
+          .textStyle(Typography.titlePhase)
+          .foregroundStyle(Color.inkSecondary)
+      }
+    }
     Spacer()
   }
   .background(Color.screenBackground)

--- a/Pastura/Pastura/Views/Components/ThoughtVisibilityToggle.swift
+++ b/Pastura/Pastura/Views/Components/ThoughtVisibilityToggle.swift
@@ -2,9 +2,9 @@ import SwiftUI
 
 /// A toggle button that controls "show all thoughts" mode in chat-stream
 /// views (Simulation / Results / DL-time demo). On state uses the filled
-/// chat-bubble icon + moss accent; off state uses the outlined icon +
-/// muted ink. Caller provides `font` via `.font(...)` on the toggle if
-/// they want sizing larger than system default.
+/// eye icon + moss accent; off state uses the slashed eye icon + muted
+/// ink. Caller provides `font` via `.font(...)` on the toggle if they
+/// want sizing larger than system default.
 ///
 /// Used by `SimulationView`, `ResultDetailView`, and
 /// `ModelDownloadHostView` — see issue #273.
@@ -21,11 +21,14 @@ struct ThoughtVisibilityToggle: View {
     .accessibilityLabel(Self.accessibilityLabel(for: isOn))
   }
 
-  /// Filled chat-bubble for the "showing thoughts" state, outlined for
-  /// "hidden". Pinned by `ThoughtVisibilityToggleContractTests` to catch
-  /// accidental swaps.
+  /// Filled eye for the "showing thoughts" state, slashed eye for
+  /// "hidden". Switched from `text.bubble.fill` / `text.bubble` in
+  /// #273 PR 2 — real-device QA after PR 1a found the eye family
+  /// communicates the show / hide affordance more directly than the
+  /// chat-bubble outline. Pinned by
+  /// `ThoughtVisibilityToggleContractTests` to catch accidental swaps.
   static func iconName(for isOn: Bool) -> String {
-    isOn ? "text.bubble.fill" : "text.bubble"
+    isOn ? "eye.fill" : "eye.slash"
   }
 
   /// `Color.moss` (accent) for ON, `Color.inkSecondary` (neutral muted)

--- a/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+PhaseHeader.swift
+++ b/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+PhaseHeader.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+/// Demo-side composition of the shared `PhaseHeader` component. Lifted
+/// into a sibling file so the host view's `chatStream(_:)` body and
+/// the host file itself stay under SwiftLint's `function_body_length`
+/// and `file_length` ceilings.
+///
+/// `extendsIntoTopSafeArea: true` is intentional — the demo is
+/// presented inside `.fullScreenCover` / the `.needsModelDownload`
+/// slot with no system nav bar above it, so the frosted material
+/// needs to fill behind the status bar / Dynamic Island. Sim/Results
+/// stay at the default `false` because their NavigationStack-pushed
+/// nav bar already paints the top safe area. See
+/// `Views/Components/PhaseHeader.swift` for the contract.
+extension ModelDownloadHostView {
+
+  @ViewBuilder
+  func phaseHeader(viewModel: ReplayViewModel) -> some View {
+    PhaseHeader(extendsIntoTopSafeArea: true) {
+      HStack(alignment: .center, spacing: Spacing.xs) {
+        // A 6pt square rotated 45° renders as a diamond. No dedicated shape
+        // exists in SwiftUI for a filled diamond, so this is the idiomatic approach.
+        Rectangle()
+          .fill(Color.moss.opacity(0.7))
+          .frame(width: 6, height: 6)
+          .rotationEffect(.degrees(45))
+
+        VStack(alignment: .leading, spacing: 3) {
+          Text(currentPresetName(viewModel: viewModel).uppercased())
+            .textStyle(Typography.tagPhase)
+            .foregroundStyle(Color.moss)
+
+          Text(currentPhaseLabel(viewModel: viewModel))
+            .textStyle(Typography.titlePhase)
+            .foregroundStyle(Color.ink)
+        }
+      }
+    } trailing: {
+      Text("DEMO中")
+        .textStyle(Typography.metaLabel)
+        .foregroundStyle(Color.moss)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+        .background(
+          RoundedRectangle(cornerRadius: Radius.button)
+            .fill(Color.moss.opacity(0.1))
+        )
+    }
+  }
+}

--- a/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView.swift
+++ b/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView.swift
@@ -217,9 +217,10 @@ struct ModelDownloadHostView: View {
       ScrollViewReader { proxy in
         ScrollView {
           // `spacing` uses the ChatBubbleLayout.bubbleSpacing token so a
-          // future design-system tweak flows through both the demo screen
-          // and the live SimulationView in one place. Reference HTML
-          // `.stream { gap: 14px }`.
+          // future design-system tweak flows through Demo / Sim / Results
+          // in one place. Production value is 8pt project-wide (#273 PR 2);
+          // see the token's docstring for the historical 14pt prototype
+          // reference and the divergence rationale.
           LazyVStack(alignment: .leading, spacing: ChatBubbleLayout.bubbleSpacing) {
             ForEach(viewModel.agentOutputs) { entry in
               AgentOutputRow(

--- a/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView.swift
+++ b/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView.swift
@@ -212,40 +212,7 @@ struct ModelDownloadHostView: View {
 
   private func chatStream(viewModel: ReplayViewModel) -> some View {
     VStack(spacing: 0) {
-      // Demo opts into `extendsIntoTopSafeArea: true` because there
-      // is no system nav bar above the cover — the frosted material
-      // needs to fill behind the status bar / Dynamic Island region
-      // to match Sim/Results' nav-bar-painted look.
-      PhaseHeader(extendsIntoTopSafeArea: true) {
-        HStack(alignment: .center, spacing: Spacing.xs) {
-          // A 6pt square rotated 45° renders as a diamond. No dedicated shape
-          // exists in SwiftUI for a filled diamond, so this is the idiomatic approach.
-          Rectangle()
-            .fill(Color.moss.opacity(0.7))
-            .frame(width: 6, height: 6)
-            .rotationEffect(.degrees(45))
-
-          VStack(alignment: .leading, spacing: 3) {
-            Text(currentPresetName(viewModel: viewModel).uppercased())
-              .textStyle(Typography.tagPhase)
-              .foregroundStyle(Color.moss)
-
-            Text(currentPhaseLabel(viewModel: viewModel))
-              .textStyle(Typography.titlePhase)
-              .foregroundStyle(Color.ink)
-          }
-        }
-      } trailing: {
-        Text("DEMO中")
-          .textStyle(Typography.metaLabel)
-          .foregroundStyle(Color.moss)
-          .padding(.horizontal, 6)
-          .padding(.vertical, 3)
-          .background(
-            RoundedRectangle(cornerRadius: Radius.button)
-              .fill(Color.moss.opacity(0.1))
-          )
-      }
+      phaseHeader(viewModel: viewModel)
 
       ScrollViewReader { proxy in
         ScrollView {
@@ -309,7 +276,9 @@ struct ModelDownloadHostView: View {
     }
   }
 
-  private func currentPresetName(viewModel: ReplayViewModel) -> String {
+  // Module-internal so the sibling `+PhaseHeader.swift` extension can
+  // call this helper. `private` only reaches same-file extensions.
+  func currentPresetName(viewModel: ReplayViewModel) -> String {
     guard case .playing(let sourceIndex, _) = viewModel.state,
       sourceIndex < sources.count
     else { return "" }

--- a/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView.swift
+++ b/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView.swift
@@ -212,9 +212,40 @@ struct ModelDownloadHostView: View {
 
   private func chatStream(viewModel: ReplayViewModel) -> some View {
     VStack(spacing: 0) {
-      PhaseHeader(
-        presetName: currentPresetName(viewModel: viewModel).uppercased(),
-        phaseLabel: currentPhaseLabel(viewModel: viewModel))
+      // Demo opts into `extendsIntoTopSafeArea: true` because there
+      // is no system nav bar above the cover — the frosted material
+      // needs to fill behind the status bar / Dynamic Island region
+      // to match Sim/Results' nav-bar-painted look.
+      PhaseHeader(extendsIntoTopSafeArea: true) {
+        HStack(alignment: .center, spacing: Spacing.xs) {
+          // A 6pt square rotated 45° renders as a diamond. No dedicated shape
+          // exists in SwiftUI for a filled diamond, so this is the idiomatic approach.
+          Rectangle()
+            .fill(Color.moss.opacity(0.7))
+            .frame(width: 6, height: 6)
+            .rotationEffect(.degrees(45))
+
+          VStack(alignment: .leading, spacing: 3) {
+            Text(currentPresetName(viewModel: viewModel).uppercased())
+              .textStyle(Typography.tagPhase)
+              .foregroundStyle(Color.moss)
+
+            Text(currentPhaseLabel(viewModel: viewModel))
+              .textStyle(Typography.titlePhase)
+              .foregroundStyle(Color.ink)
+          }
+        }
+      } trailing: {
+        Text("DEMO中")
+          .textStyle(Typography.metaLabel)
+          .foregroundStyle(Color.moss)
+          .padding(.horizontal, 6)
+          .padding(.vertical, 3)
+          .background(
+            RoundedRectangle(cornerRadius: Radius.button)
+              .fill(Color.moss.opacity(0.1))
+          )
+      }
 
       ScrollViewReader { proxy in
         ScrollView {

--- a/Pastura/Pastura/Views/Results/ResultDetailView+CodePhaseRows.swift
+++ b/Pastura/Pastura/Views/Results/ResultDetailView+CodePhaseRows.swift
@@ -11,6 +11,14 @@ import SwiftUI
 // names, action labels, summary text, assignment values, vote targets) is
 // passed through `contentFilter` to match the exporter's whole-string filter
 // pass. Vote counts and scores are pure integers and don't need filtering.
+//
+// Per-row `.padding(.horizontal)` was stripped from every helper here in
+// #273 PR 2 — `ResultDetailView.timelineLog` now applies a container-level
+// `.padding(.horizontal, 20)` once on its parent `LazyVStack`, matching
+// the strategy already in `SimulationView+LogEntries.swift`. Without the
+// strip, code-phase rows would render at ~36pt-inset (20pt container +
+// ~16pt per-row default) while turn rows render at 20pt-inset, which is
+// exactly the cross-row misalignment this refactor was meant to eliminate.
 extension ResultDetailView {
 
   @ViewBuilder
@@ -39,7 +47,6 @@ extension ResultDetailView {
       Text("\(filtered(agent)) eliminated (\(voteCount) votes)")
         .textStyle(Typography.titlePhase)
     }
-    .padding(.horizontal)
   }
 
   private func scoreUpdateRow(scores: [String: Int]) -> some View {
@@ -52,14 +59,12 @@ extension ResultDetailView {
       .textStyle(Typography.metaValue)
       .monospacedDigit()
       .foregroundStyle(Color.muted)
-      .padding(.horizontal)
   }
 
   private func summaryRow(text: String) -> some View {
     Text(filtered(text))
       .textStyle(Typography.bodyBubble)
       .foregroundStyle(Color.inkSecondary)
-      .padding(.horizontal)
   }
 
   private func voteResultsRow(
@@ -87,7 +92,6 @@ extension ResultDetailView {
       }
     }
     .foregroundStyle(Color.muted)
-    .padding(.horizontal)
   }
 
   private func pairingRow(
@@ -99,14 +103,12 @@ extension ResultDetailView {
       Text("\(filtered(agent2))(\(filtered(action2)))")
     }
     .textStyle(Typography.titlePhase)
-    .padding(.horizontal)
   }
 
   private func assignmentRow(agent: String, value: String) -> some View {
     Text("\(filtered(agent)) assigned: \(filtered(value))")
       .textStyle(Typography.metaValue)
       .foregroundStyle(Color.muted)
-      .padding(.horizontal)
   }
 
   // The miss case (`event == nil`) renders an explicit "no event"
@@ -118,12 +120,10 @@ extension ResultDetailView {
       Text("Event: \(filtered(event))")
         .textStyle(Typography.bodyBubble)
         .foregroundStyle(Color.inkSecondary)
-        .padding(.horizontal)
     } else {
       Text("No event this round")
         .textStyle(Typography.metaValue)
         .foregroundStyle(Color.muted)
-        .padding(.horizontal)
     }
   }
 

--- a/Pastura/Pastura/Views/Results/ResultDetailView.swift
+++ b/Pastura/Pastura/Views/Results/ResultDetailView.swift
@@ -145,7 +145,7 @@ struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
 
   private var timelineLog: some View {
     ScrollView {
-      LazyVStack(alignment: .leading, spacing: 8) {
+      LazyVStack(alignment: .leading, spacing: ChatBubbleLayout.bubbleSpacing) {
         ForEach(items) { item in
           switch item {
           case .roundSeparator(let round):
@@ -157,6 +157,11 @@ struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
           }
         }
       }
+      // Container-level horizontal padding (20pt, matching Demo
+      // strategy) replaces the per-row `.padding(.horizontal)` on
+      // `roundSeparator` / `turnRow` / legacy fallback. See #273
+      // PR 2 — chat-stream token alignment across Demo / Sim / Results.
+      .padding(.horizontal, 20)
       .padding(.vertical, 8)
     }
   }
@@ -199,7 +204,6 @@ struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
         .foregroundStyle(Color.inkSecondary)
       Rectangle().fill(Color.rule).frame(height: 1)
     }
-    .padding(.horizontal)
     .padding(.vertical, 4)
   }
 
@@ -214,7 +218,6 @@ struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
         showAllThoughts: showAllThoughts,
         agentPosition: agentOrder.firstIndex(of: agentName)
       )
-      .padding(.horizontal)
     } else {
       // Pre-#92 fallback: TurnRecord without agentName. Newer code phases
       // emit CodePhaseEventRecord rows instead, so this path is only hit
@@ -227,7 +230,6 @@ struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
           .textStyle(Typography.metaValue)
           .foregroundStyle(Color.inkSecondary)
       }
-      .padding(.horizontal)
     }
   }
 

--- a/Pastura/Pastura/Views/Simulation/InferenceStatsFormatter.swift
+++ b/Pastura/Pastura/Views/Simulation/InferenceStatsFormatter.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Formats the inference-stats label rendered in the simulation
+/// header (e.g. `"12.4 tok/s • 1.8s"`).
+///
+/// Pure helper extracted from `SimulationView` so the nil-empty
+/// branch can be unit-tested without instantiating the view per
+/// ADR-009. Returns `nil` when both inputs are nil so callers can
+/// short-circuit and render nothing instead of an all-dash string.
+nonisolated enum InferenceStatsFormatter {
+
+  /// Returns a `"<tps> tok/s • <duration>s"` string when at least
+  /// one input is non-nil; nil otherwise. Individually-nil inputs
+  /// render as `—`, matching the original inline formatter.
+  static func format(durationSeconds: Double?, tokensPerSecond: Double?) -> String? {
+    guard durationSeconds != nil || tokensPerSecond != nil else { return nil }
+    let tpsPart = tokensPerSecond.map { String(format: "%.1f tok/s", $0) } ?? "— tok/s"
+    let durationPart = durationSeconds.map { String(format: "%.1fs", $0) } ?? "—"
+    return "\(tpsPart) • \(durationPart)"
+  }
+}

--- a/Pastura/Pastura/Views/Simulation/SimulationView+LogEntries.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView+LogEntries.swift
@@ -3,6 +3,15 @@ import SwiftUI
 // Helpers factored out of SimulationView so that the main file stays under
 // SwiftLint's file-length ceiling. These render individual log-entry kinds
 // used by the live simulation screen.
+//
+// Per-row `.padding(.horizontal)` was stripped from every helper here in
+// #273 PR 2 — the parent `LazyVStack` now applies a container-level
+// `.padding(.horizontal, 20)` once, matching Demo's strategy and unifying
+// chat-stream gutters across Demo / Sim / Results. `roundSeparator` is
+// included in the strip; its horizontal rule now spans the container's
+// 20pt-inset width rather than the prior system-default ~16pt-inset width
+// (4pt-narrower per side, accepted as part of the design-system
+// unification).
 extension SimulationView {
   func eliminationEntry(agent: String, voteCount: Int) -> some View {
     HStack(spacing: 4) {
@@ -11,21 +20,18 @@ extension SimulationView {
       Text("\(agent) eliminated (\(voteCount) votes)")
         .textStyle(Typography.titlePhase)
     }
-    .padding(.horizontal)
   }
 
   func assignmentEntry(agent: String, value: String) -> some View {
     Text("\(agent) assigned: \(value)")
       .textStyle(Typography.metaValue)
       .foregroundStyle(Color.muted)
-      .padding(.horizontal)
   }
 
   func summaryEntry(text: String) -> some View {
     Text(text)
       .textStyle(Typography.bodyBubble)
       .foregroundStyle(Color.inkSecondary)
-      .padding(.horizontal)
   }
 
   func voteResultsEntry(tallies: [String: Int]) -> some View {
@@ -43,7 +49,6 @@ extension SimulationView {
       }
     }
     .foregroundStyle(Color.muted)
-    .padding(.horizontal)
   }
 
   func pairingResultEntry(
@@ -56,7 +61,6 @@ extension SimulationView {
       Text("\(agent2)(\(act2))")
     }
     .textStyle(Typography.titlePhase)
-    .padding(.horizontal)
   }
 
   /// Live row for `event_inject` phase results.
@@ -73,12 +77,10 @@ extension SimulationView {
           .textStyle(Typography.bodyBubble)
           .foregroundStyle(Color.inkSecondary)
       }
-      .padding(.horizontal)
     } else {
       Text("No event this round")
         .textStyle(Typography.metaValue)
         .foregroundStyle(Color.muted)
-        .padding(.horizontal)
     }
   }
 
@@ -94,7 +96,6 @@ extension SimulationView {
         .foregroundStyle(Color.inkSecondary)
       Rectangle().fill(Color.rule).frame(height: 1)
     }
-    .padding(.horizontal)
     .padding(.vertical, 4)
   }
 
@@ -107,6 +108,5 @@ extension SimulationView {
       }
     }
     .foregroundStyle(Color.muted)
-    .padding(.horizontal)
   }
 }

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -141,7 +141,7 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
       // Log
       ScrollViewReader { proxy in
         ScrollView {
-          LazyVStack(alignment: .leading, spacing: 8) {
+          LazyVStack(alignment: .leading, spacing: ChatBubbleLayout.bubbleSpacing) {
             ForEach(viewModel.logEntries) { entry in
               logEntryView(entry, viewModel: viewModel)
                 .id(entry.id)
@@ -166,7 +166,6 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
                 agentPosition: scenario?.personas.firstIndex(where: { $0.name == snapshot.agent }),
                 debugRowID: "stream-\(snapshot.agent)"
               )
-              .padding(.horizontal)
               .id("streaming-\(snapshot.agent)")
             }
 
@@ -182,7 +181,6 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
                     .textStyle(Typography.thinkingBody)
                     .foregroundStyle(Color.muted)
                 }
-                .padding(.horizontal)
               }
             }
 
@@ -194,6 +192,12 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
               .frame(height: 1)
               .id(Self.bottomSentinelID)
           }
+          // Container-level horizontal padding (20pt, matching Demo
+          // strategy) replaces the per-row `.padding(.horizontal)` on
+          // each log entry / thinking indicator / streaming row. See
+          // #273 PR 2 — chat-stream token alignment across Demo / Sim
+          // / Results.
+          .padding(.horizontal, 20)
           .padding(.vertical, 8)
         }
         .onChange(of: viewModel.logEntries.count) { _, _ in
@@ -351,10 +355,8 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
         agentPosition: scenario?.personas.firstIndex(where: { $0.name == agent }),
         debugRowID: entry.id.uuidString
       )
-      .padding(.horizontal)
     case .phaseStarted(let phaseType):
       PhaseTypeLabel(phaseType: phaseType)
-        .padding(.horizontal)
         .padding(.top, 4)
     case .roundStarted(let round, let total):
       roundSeparator("Round \(round)/\(total)")
@@ -364,7 +366,6 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
       Label(message, systemImage: "exclamationmark.triangle.fill")
         .textStyle(Typography.titlePhase)
         .foregroundStyle(Color.inkSecondary)
-        .padding(.horizontal)
     default:
       secondaryLogEntryView(entry)
     }

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -273,76 +273,58 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
   // MARK: - Header
 
   private func headerBar(viewModel: SimulationViewModel) -> some View {
-    HStack {
+    PhaseHeader {
       if viewModel.totalRounds > 0 {
         Text("Round \(viewModel.currentRound)/\(viewModel.totalRounds)")
           .textStyle(Typography.metaEta)
           .monospacedDigit()
       }
-
-      Spacer()
-
-      inferenceStatsLabel(viewModel: viewModel)
-
-      if viewModel.isCompleted {
-        Label("Completed", systemImage: "checkmark.circle.fill")
-          .textStyle(Typography.titlePhase)
-          // §2.3: moss-dark の用途として「ステータスラベル（Completed 等）」が
-          // enumerate されている。moss は fills/borders 系、moss-ink は完了
-          // タイトル（大型表示）。ここはヘッダー右肩のインライン状態表示
-          // なので moss-dark が用途的に正解。ResultsView の statusBadge も
-          // 同じ理由で moss-dark に揃えてある。
-          .foregroundStyle(Color.mossDark)
-      } else if viewModel.isPaused {
-        Label("Paused", systemImage: "pause.circle.fill")
-          .textStyle(Typography.titlePhase)
-          .foregroundStyle(Color.inkSecondary)
-      } else if viewModel.isRunning {
-        HStack(spacing: 4) {
-          ProgressView()
-            .scaleEffect(0.7)
-          Text("Running")
-            .textStyle(Typography.titlePhase)
-            .foregroundStyle(Color.inkSecondary)
-        }
+    } trailing: {
+      HStack(spacing: Spacing.xs) {
+        inferenceStatsLabel(viewModel: viewModel)
+        statusBadge(viewModel: viewModel)
       }
-    }
-    .padding(.horizontal)
-    .padding(.vertical, 8)
-    .background {
-      ZStack {
-        Color.screenBackground.opacity(0.78)
-        Rectangle().fill(.ultraThinMaterial)
-      }
-    }
-    .overlay(alignment: .bottom) {
-      Rectangle()
-        .fill(Color.ink.opacity(0.07))
-        .frame(height: 1)
     }
   }
 
   @ViewBuilder
   private func inferenceStatsLabel(viewModel: SimulationViewModel) -> some View {
-    let duration = viewModel.lastInferenceDurationSeconds
-    let tps = viewModel.averageTokensPerSecond
-    if duration != nil || tps != nil {
+    if let text = InferenceStatsFormatter.format(
+      durationSeconds: viewModel.lastInferenceDurationSeconds,
+      tokensPerSecond: viewModel.averageTokensPerSecond) {
       HStack(spacing: 4) {
         Image(systemName: "speedometer")
-        Text(formatInferenceStats(durationSeconds: duration, tokensPerSecond: tps))
-          .monospacedDigit()
+        Text(text).monospacedDigit()
       }
       .textStyle(Typography.metaValue)
       .foregroundStyle(Color.muted)
     }
   }
 
-  private func formatInferenceStats(
-    durationSeconds: Double?, tokensPerSecond: Double?
-  ) -> String {
-    let tpsPart = tokensPerSecond.map { String(format: "%.1f tok/s", $0) } ?? "— tok/s"
-    let durationPart = durationSeconds.map { String(format: "%.1fs", $0) } ?? "—"
-    return "\(tpsPart) • \(durationPart)"
+  @ViewBuilder
+  private func statusBadge(viewModel: SimulationViewModel) -> some View {
+    if viewModel.isCompleted {
+      Label("Completed", systemImage: "checkmark.circle.fill")
+        .textStyle(Typography.titlePhase)
+        // §2.3: moss-dark の用途として「ステータスラベル（Completed 等）」が
+        // enumerate されている。moss は fills/borders 系、moss-ink は完了
+        // タイトル（大型表示）。ここはヘッダー右肩のインライン状態表示
+        // なので moss-dark が用途的に正解。ResultsView の statusBadge も
+        // 同じ理由で moss-dark に揃えてある。
+        .foregroundStyle(Color.mossDark)
+    } else if viewModel.isPaused {
+      Label("Paused", systemImage: "pause.circle.fill")
+        .textStyle(Typography.titlePhase)
+        .foregroundStyle(Color.inkSecondary)
+    } else if viewModel.isRunning {
+      HStack(spacing: 4) {
+        ProgressView()
+          .scaleEffect(0.7)
+        Text("Running")
+          .textStyle(Typography.titlePhase)
+          .foregroundStyle(Color.inkSecondary)
+      }
+    }
   }
 
   // MARK: - Log Entries

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -455,7 +455,8 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
   }
 
   private func controlBar(viewModel: SimulationViewModel) -> some View {
-    HStack(spacing: 16) {
+    let isPauseDisabled = !viewModel.isRunning || viewModel.isCompleted
+    return HStack(spacing: 16) {
       // Pause/Resume
       Button {
         if viewModel.isPaused {
@@ -464,10 +465,15 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
           viewModel.pauseSimulation()
         }
       } label: {
+        // Explicit `Color.disabledText` (design-system §2.7) when
+        // disabled, matching Demo's controlBar (#273 PR 1a). Enabled
+        // state uses `Color.ink` for the icon color rather than the
+        // system tint so the bar's color story stays in our palette.
         Image(systemName: viewModel.isPaused ? "play.fill" : "pause.fill")
           .font(.title3)
+          .foregroundStyle(isPauseDisabled ? Color.disabledText : Color.ink)
       }
-      .disabled(!viewModel.isRunning || viewModel.isCompleted)
+      .disabled(isPauseDisabled)
 
       // Speed picker while running; swapped with an export button once the
       // simulation is completed because playback speed is no longer relevant.

--- a/Pastura/PasturaTests/Views/ChatBubbleTests.swift
+++ b/Pastura/PasturaTests/Views/ChatBubbleTests.swift
@@ -70,9 +70,14 @@ struct ChatBubbleTests {
     #expect(ChatBubbleLayout.avatarTextGap == 10)
   }
 
-  @Test func bubbleSpacingMatchesReferenceHTML() {
-    // Reference HTML `.stream { gap: 14px }` — inter-bubble vertical.
-    #expect(ChatBubbleLayout.bubbleSpacing == 14)
+  @Test func bubbleSpacingPinsToCurrentValue() {
+    // Tightened from the reference HTML's 14px to 8pt project-wide
+    // in #273 PR 2 so Sim/Results' long simulation logs fit more
+    // turns per viewport. The reference HTML at
+    // `docs/design/demo-replay-reference.html` retains 14px as a
+    // historical visual prototype; this assert pins the production
+    // value, NOT the prototype value.
+    #expect(ChatBubbleLayout.bubbleSpacing == 8)
   }
 
   // MARK: - AvatarSlot wiring

--- a/Pastura/PasturaTests/Views/InferenceStatsFormatterTests.swift
+++ b/Pastura/PasturaTests/Views/InferenceStatsFormatterTests.swift
@@ -1,0 +1,39 @@
+import Testing
+
+@testable import Pastura
+
+/// Pure-formatter tests for the inference-stats label string used in
+/// `SimulationView`'s frosted header. The formatter returns `nil`
+/// when both inputs are nil (lets the caller short-circuit and
+/// render nothing); otherwise it emits the existing
+/// `"<tps> tok/s • <duration>s"` layout with `—` placeholders for
+/// individually-nil inputs.
+@Suite(.timeLimit(.minutes(1)))
+struct InferenceStatsFormatterTests {
+
+  @Test func returnsNilWhenBothInputsNil() {
+    #expect(
+      InferenceStatsFormatter.format(durationSeconds: nil, tokensPerSecond: nil) == nil)
+  }
+
+  // Inputs use exactly-representable IEEE-754 values (halves) so
+  // the `%.1f` rounding output is deterministic across platforms —
+  // 1.85 rounds platform-dependently to 1.8 or 1.9.
+  @Test func formatsBothPopulated() {
+    #expect(
+      InferenceStatsFormatter.format(durationSeconds: 1.5, tokensPerSecond: 12.5)
+        == "12.5 tok/s • 1.5s")
+  }
+
+  @Test func emitsDashWhenDurationNil() {
+    #expect(
+      InferenceStatsFormatter.format(durationSeconds: nil, tokensPerSecond: 12.5)
+        == "12.5 tok/s • —")
+  }
+
+  @Test func emitsDashWhenTokensPerSecondNil() {
+    #expect(
+      InferenceStatsFormatter.format(durationSeconds: 1.5, tokensPerSecond: nil)
+        == "— tok/s • 1.5s")
+  }
+}

--- a/Pastura/PasturaTests/Views/ModelDownloadHostViewTests+Layout.swift
+++ b/Pastura/PasturaTests/Views/ModelDownloadHostViewTests+Layout.swift
@@ -22,11 +22,14 @@ extension ModelDownloadHostViewTests {
   // MARK: - ChatBubbleLayout — reference HTML values
 
   @Test func demoChatStreamUsesCanonicalBubbleSpacing() {
-    // Reference HTML `.stream { gap: 14px }`. The demo screen's
-    // `LazyVStack(spacing: ChatBubbleLayout.bubbleSpacing)` must agree
-    // — a mismatch would make bubbles visually cramped or loose vs the
-    // prototype the design was signed off against.
-    #expect(ChatBubbleLayout.bubbleSpacing == 14)
+    // Tightened from the reference HTML's 14px to 8pt project-wide
+    // in #273 PR 2 — Sim/Results' tighter spacing wins so long
+    // simulation logs fit more turns per viewport, and Demo's loop
+    // adopts the same value. The demo screen's
+    // `LazyVStack(spacing: ChatBubbleLayout.bubbleSpacing)` must
+    // continue to consume the token (not a literal) so the unified
+    // value flows through.
+    #expect(ChatBubbleLayout.bubbleSpacing == 8)
   }
 
   @Test func demoChatStreamUsesCanonicalAvatarSize() {

--- a/Pastura/PasturaTests/Views/PhaseHeaderContractTests.swift
+++ b/Pastura/PasturaTests/Views/PhaseHeaderContractTests.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+import Testing
+
+@testable import Pastura
+
+/// Logic-only contract tests for `PhaseHeader` per ADR-009 (no
+/// rendered-output assertions). Pins design-decision constants that
+/// would silently regress under a refactor: the `minLeadingHeight`
+/// floor (header height parity between Demo's 2-line leading and
+/// Sim's single-line leading) and the `extendsIntoTopSafeArea`
+/// default (Demo opts in; Sim/Results stay safe under the system
+/// nav bar).
+@MainActor
+@Suite(.timeLimit(.minutes(1)))
+struct PhaseHeaderContractTests {
+
+  // MARK: - minLeadingHeight
+
+  @Test func minLeadingHeightIsPinnedTo32() {
+    // 32pt fits Demo's 2-line typography stack (tagPhase ~9.5pt +
+    // 3pt spacing + titlePhase ~13pt ≈ 25.5pt natural) with comfort
+    // margin. Pinning catches a silent shrink that would let Sim's
+    // single-line leading drop the header height below Demo's.
+    #expect(PhaseHeader<EmptyView, EmptyView>.minLeadingHeight == 32)
+  }
+
+  // MARK: - extendsIntoTopSafeArea default
+
+  @Test func extendsIntoTopSafeAreaDefaultsToFalse() {
+    // Sim/Results are NavigationStack-pushed — the system nav bar
+    // already paints the top safe area with `.ultraThinMaterial`,
+    // so a default-true would risk doubled blur. Demo (no nav bar)
+    // opts in explicitly via `extendsIntoTopSafeArea: true` to fill
+    // the status bar / Dynamic Island region with matching frosted
+    // material.
+    let header = PhaseHeader(leading: { EmptyView() }, trailing: { EmptyView() })
+    #expect(header.extendsIntoTopSafeArea == false)
+  }
+
+  @Test func extendsIntoTopSafeAreaCanBeOverridden() {
+    let header = PhaseHeader(
+      extendsIntoTopSafeArea: true,
+      leading: { EmptyView() },
+      trailing: { EmptyView() })
+    #expect(header.extendsIntoTopSafeArea == true)
+  }
+}

--- a/Pastura/PasturaTests/Views/ThoughtVisibilityToggleContractTests.swift
+++ b/Pastura/PasturaTests/Views/ThoughtVisibilityToggleContractTests.swift
@@ -9,12 +9,12 @@ struct ThoughtVisibilityToggleContractTests {
 
   // MARK: - iconName(for:)
 
-  @Test func iconNameForOnStateIsFilledBubble() {
-    #expect(ThoughtVisibilityToggle.iconName(for: true) == "text.bubble.fill")
+  @Test func iconNameForOnStateIsFilledEye() {
+    #expect(ThoughtVisibilityToggle.iconName(for: true) == "eye.fill")
   }
 
-  @Test func iconNameForOffStateIsOutlinedBubble() {
-    #expect(ThoughtVisibilityToggle.iconName(for: false) == "text.bubble")
+  @Test func iconNameForOffStateIsSlashedEye() {
+    #expect(ThoughtVisibilityToggle.iconName(for: false) == "eye.slash")
   }
 
   // MARK: - tint(for:)

--- a/docs/specs/demo-replay-ui.md
+++ b/docs/specs/demo-replay-ui.md
@@ -144,7 +144,19 @@ ZStack(alignment: .top) {
 ### ChatStream（Frame 1/2/3）
 
 - padding: `top 8pt, horizontal 20pt, bottom 16pt`
-- バブル間の spacing: 14pt
+- バブル間の spacing: 8pt
+
+> **2026-04-29 amendment (#273)** — バブル間 spacing は当初の 14pt
+> （reference HTML `.stream { gap: 14px }` 由来）から **8pt に縮小**
+> された。Sim / Results が長いシミュレーションログを表示する際に
+> ターン数を viewport により多く収めるため、Sim/Results のより
+> タイトな pacing 側に合わせる方向で 3 画面共通の値とした。Demo の
+> ループも視認性に問題ないことを確認済み。reference HTML
+> (`docs/design/demo-replay-reference.html`) は当時の visual
+> prototype として 14px のまま保存し、本番値は
+> `Pastura/Pastura/Views/Components/ChatBubble.swift` の
+> `ChatBubbleLayout.bubbleSpacing` (= 8pt) を参照する。
+
 - 各バブルは **横並び HStack** ：
   - アバター（42pt 丸、色はキャラごと、下記）
   - 縦 VStack：


### PR DESCRIPTION
## Summary

- `PhaseHeader` を generic-slot 化（`@ViewBuilder leading/trailing`）+ `minLeadingHeight: 32pt` で Demo (2-line) と Sim (1-line) のヘッダー高さを揃え + `extendsIntoTopSafeArea: Bool` (default `false`) パラメトリックで Demo の status bar 領域だけフロスト延伸
- Sim の `headerBar` を `PhaseHeader` に移行 + `inferenceStatsLabel` の formatter を pure helper `InferenceStatsFormatter` に切り出し（ADR-009 logic-only test 4 ケース）
- Sim controlBar Pause を disabled 時 `Color.disabledText` token に統一（Demo controlBar との parity）
- `ChatBubbleLayout.bubbleSpacing` 14→8pt にプロジェクト全体で縮小（Sim/Results 寄り）+ 行個別 `.padding(.horizontal)` を全 22 箇所撤去 + container `.padding(.horizontal, 20)` 集約
- `ThoughtVisibilityToggle` のアイコンを `text.bubble` 系 → `eye` 系に swap (PR 1a 実機 QA フィードバック)
- spec amend (`docs/specs/demo-replay-ui.md` §147) + 既存テスト 2 件の値・名前更新

## Test plan

- [x] `scripts/test-full.sh -skip-testing:PasturaUITests` — 1331 unit tests pass (local)
- [x] `swiftlint lint --strict` clean
- [x] Manual QA — pre/post screenshot 4 ケース:
  - Sim Running, stats nil (ターン 1 開始直後)
  - Sim Running, stats populated (ターン 2 以降)
  - Sim Completed
  - iPhone SE 幅 (375pt) でケース 2
- [x] Manual QA — Demo: status bar / Dynamic Island 領域がフロストで塗られていること
- [x] Manual QA — Demo: chat 表示・toggle 動作 (eye icon に変わっている)
- [x] Manual QA — Results: sub-phase indent (conditional シナリオ) + code-phase 行の左揃え (turn 行と同じ 20pt 起点)
- [x] Manual QA — Sim: Pause ボタンの色 (enabled = ink, disabled = disabledText)
- [x] Manual QA — `Round X/Y` separator が container の 20pt-inset で描画 (4pt-narrower per side が許容範囲)

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)