### PR TITLE
✨ feat: replay user pause/resume + demo controlBar enable (PR 1b/#273)

### DIFF
--- a/Pastura/Pastura/App/PlaybackSpeed.swift
+++ b/Pastura/Pastura/App/PlaybackSpeed.swift
@@ -18,16 +18,22 @@ import Foundation
 /// `SimulationViewModel` is `@MainActor` and consumes this type
 /// freely — no isolation friction for value-type enums.
 ///
-/// **Two consumers, two pacing models:**
+/// **Two consumers, two pacing models — properties are NOT
+/// universally consumed:**
 /// - Sim uses ``charsPerSecond`` (typing animation) and
 ///   ``interEventDelayMs`` (non-agent inter-event delay).
 /// - Replay uses ``multiplier`` to scale ``ReplayPlaybackConfig``'s
-///   `turnDelayMs` / `codePhaseDelayMs`. ``.instant`` should be
-///   handled by an explicit early-return at each delay-scaling
-///   callsite (see ``ReplayViewModel.scaledDelay(for:)`` and
-///   ``YAMLReplaySource``); the sentinel value below is provided
-///   only so that arithmetic-only paths happen to compute zero, not
-///   as the load-bearing way to get instant pacing.
+///   `turnDelayMs` / `codePhaseDelayMs`. Replay does **not** consume
+///   ``charsPerSecond`` (no typing animation on replay) nor
+///   ``interEventDelayMs`` (its turn vs. codePhase distinction is
+///   richer than Sim's flat 120ms-or-zero gap). Don't extend replay
+///   pacing through the Sim-side properties; add a replay-side
+///   property here if a new pacing dimension is needed.
+/// - ``.instant`` should be handled by an explicit early-return at
+///   each delay-scaling callsite (see ``ReplayViewModel/scaledDelay(for:)``
+///   and ``YAMLReplaySource``); the sentinel ``multiplier`` value is
+///   provided only so that arithmetic-only paths happen to compute
+///   zero, not as the load-bearing way to get instant pacing.
 nonisolated public enum PlaybackSpeed:
   String, CaseIterable, Identifiable, Sendable, Equatable {
   case slow

--- a/Pastura/Pastura/App/PlaybackSpeed.swift
+++ b/Pastura/Pastura/App/PlaybackSpeed.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// Playback speed tiers shared by the live simulation
+/// (``SimulationViewModel``) and the DL-time demo replay
+/// (``ReplayViewModel``). Pinned to four user-visible buckets:
+/// `x0.5` / `x1` / `x1.5` / `Max`.
+///
+/// **Why public:** promoted from internal (was file-scoped in
+/// `SimulationViewModel.swift` pre-#290) to public to fit
+/// ``ReplayPlaybackConfig``'s public boundary. The enum's cases are
+/// now part of the public API surface — adding or renaming a case is
+/// SemVer-relevant per the CLAUDE.md "future SPM module extraction"
+/// goal.
+///
+/// **Why `nonisolated`:** referenced by ``ReplayPlaybackConfig`` (a
+/// `nonisolated public struct`); a MainActor-defaulted enum would
+/// force the surrounding struct's `Sendable` conformance to break.
+/// `SimulationViewModel` is `@MainActor` and consumes this type
+/// freely — no isolation friction for value-type enums.
+///
+/// **Two consumers, two pacing models:**
+/// - Sim uses ``charsPerSecond`` (typing animation) and
+///   ``interEventDelayMs`` (non-agent inter-event delay).
+/// - Replay uses ``multiplier`` to scale ``ReplayPlaybackConfig``'s
+///   `turnDelayMs` / `codePhaseDelayMs`. ``.instant`` should be
+///   handled by an explicit early-return at each delay-scaling
+///   callsite (see ``ReplayViewModel.scaledDelay(for:)`` and
+///   ``YAMLReplaySource``); the sentinel value below is provided
+///   only so that arithmetic-only paths happen to compute zero, not
+///   as the load-bearing way to get instant pacing.
+nonisolated public enum PlaybackSpeed:
+  String, CaseIterable, Identifiable, Sendable, Equatable {
+  case slow
+  case normal
+  case fast
+  case instant
+
+  public var id: String { rawValue }
+
+  /// Characters revealed per second during typing animation.
+  /// `nil` means "render full text immediately" (`.instant`).
+  /// Sim-only — replay does not animate typing.
+  public var charsPerSecond: Double? {
+    switch self {
+    case .slow: 15
+    case .normal: 30
+    case .fast: 45
+    case .instant: nil
+    }
+  }
+
+  /// Delay inserted between consumed simulation events other than
+  /// agent outputs (agent outputs are paced by the typing animation
+  /// instead). Keeps round separators and phase labels on-screen long
+  /// enough to read. Sim-only.
+  public var interEventDelayMs: Int {
+    switch self {
+    case .slow, .normal, .fast: 120
+    case .instant: 0
+    }
+  }
+
+  /// Multiplier applied to ``ReplayPlaybackConfig``'s `turnDelayMs` /
+  /// `codePhaseDelayMs` to derive the per-event sleep in
+  /// ``ReplayViewModel.scaledDelay(for:)``. Replay-only.
+  ///
+  /// `.instant` returns `.infinity` so arithmetic paths (`base / multiplier`)
+  /// happen to yield zero, but **do not rely on this** — every
+  /// delay-scaling consumer should special-case `.instant` with an
+  /// explicit early-return for symmetry and to avoid IEEE-754-dependent
+  /// behavior. The sentinel exists for defense-in-depth.
+  public var multiplier: Double {
+    switch self {
+    case .slow: 0.5
+    case .normal: 1.0
+    case .fast: 1.5
+    case .instant: .infinity
+    }
+  }
+
+  public var label: String {
+    switch self {
+    case .slow: "x0.5"
+    case .normal: "x1"
+    case .fast: "x1.5"
+    case .instant: "Max"
+    }
+  }
+}

--- a/Pastura/Pastura/App/ReplayPlaybackConfig.swift
+++ b/Pastura/Pastura/App/ReplayPlaybackConfig.swift
@@ -10,16 +10,25 @@ import Foundation
 /// (Phase 2.5+, spec §4.5) can pick the appropriate preset without
 /// introducing a second config type.
 nonisolated public struct ReplayPlaybackConfig: Sendable, Equatable {
-  /// Multiplier applied to the per-event delay before each yield.
-  /// `1.0` plays at the nominal rhythm; values < 1.0 slow playback
-  /// (e.g. `0.5` doubles a 1200 ms nominal gap to 2400 ms), values
-  /// > 1.0 speed it up. `demoDefault` fixes this at 1.0 per spec §2
-  /// decision 5; test fixtures commonly use `100.0` to fast-forward.
-  public var speedMultiplier: Double
+  /// Speed tier applied to ``turnDelayMs`` / ``codePhaseDelayMs`` via
+  /// ``PlaybackSpeed/multiplier``. `.normal` plays at the nominal
+  /// rhythm; `.slow` doubles delays, `.fast` shortens them by 1/1.5×;
+  /// `.instant` collapses the per-event sleep to 0ms (every consumer
+  /// special-cases `.instant` rather than relying on the sentinel
+  /// `.infinity` multiplier).
+  ///
+  /// Replaces the `speedMultiplier: Double` knob (#290 / PR 1b of
+  /// #273): Sim and replay now share the same `.slow / .normal /
+  /// .fast / .instant` vocabulary, eliminating the replay-only
+  /// coefficient.
+  ///
+  /// Test fixtures: `100.0` → `.instant`; `1.0` → `.normal`. See
+  /// `ReplayViewModelTests.fastConfig` for the canonical example.
+  public var playbackSpeed: PlaybackSpeed
 
   /// Nominal delay inserted before each agent turn (`agentOutput`
-  /// event). At 1× speed this is the perceived "one agent speaks,
-  /// next agent reacts" rhythm of a live simulation.
+  /// event). At ``PlaybackSpeed/normal`` this is the perceived "one
+  /// agent speaks, next agent reacts" rhythm of a live simulation.
   ///
   /// Stored on the config — not on each recorded event — because
   /// per-event pacing would baker per-turn LLM inference time into
@@ -57,27 +66,27 @@ nonisolated public struct ReplayPlaybackConfig: Sendable, Equatable {
   }
 
   public init(
-    speedMultiplier: Double,
+    playbackSpeed: PlaybackSpeed = .normal,
     turnDelayMs: Int = 1200,
     codePhaseDelayMs: Int = 500,
     loopBehaviour: LoopBehaviour,
     onComplete: CompletionAction
   ) {
-    self.speedMultiplier = speedMultiplier
+    self.playbackSpeed = playbackSpeed
     self.turnDelayMs = turnDelayMs
     self.codePhaseDelayMs = codePhaseDelayMs
     self.loopBehaviour = loopBehaviour
     self.onComplete = onComplete
   }
 
-  /// Preset for the DL-time demo host: 1× speed, loop forever, wait for
-  /// the download-complete transition signal.
+  /// Preset for the DL-time demo host: nominal speed, loop forever,
+  /// wait for the download-complete transition signal.
   ///
-  /// Speed history: originally 2× per spec §2 decision 5, revised to 1×
-  /// when #170 manual QA on bundled demos found 2× too fast to follow.
-  /// Spec §2 decision 5 was updated in the same PR.
+  /// Speed history: originally 2× per spec §2 decision 5, revised to
+  /// `.normal` (1×) when #170 manual QA on bundled demos found 2× too
+  /// fast to follow. Spec §2 decision 5 was updated in the same PR.
   public static let demoDefault = ReplayPlaybackConfig(
-    speedMultiplier: 1.0,
+    playbackSpeed: .normal,
     loopBehaviour: .loop,
     onComplete: .awaitTransitionSignal)
 }

--- a/Pastura/Pastura/App/ReplaySource.swift
+++ b/Pastura/Pastura/App/ReplaySource.swift
@@ -19,11 +19,13 @@ nonisolated public struct PacedEvent: Sendable, Equatable {
   /// Classifies the event so the consumer can pick the right delay bucket.
   public enum Kind: Sendable, Equatable {
     /// LLM-phase agent output (`.agentOutput`). Pre-yield delay =
-    /// `ReplayPlaybackConfig.turnDelayMs / speedMultiplier`.
+    /// `ReplayPlaybackConfig.turnDelayMs / playbackSpeed.multiplier`
+    /// (consumer also early-returns 0 when `playbackSpeed == .instant`).
     case turn
     /// Code-phase result (`.scoreUpdate` / `.elimination` / `.summary` /
     /// `.voteResults` / `.pairingResult` / `.assignment`). Pre-yield
-    /// delay = `ReplayPlaybackConfig.codePhaseDelayMs / speedMultiplier`.
+    /// delay = `ReplayPlaybackConfig.codePhaseDelayMs /
+    /// playbackSpeed.multiplier` (`.instant` short-circuits to 0).
     case codePhase
     /// Synthesised round/phase boundary (`.roundStarted` / `.phaseStarted`).
     /// Pre-yield delay = 0 — the marker fires alongside the event it

--- a/Pastura/Pastura/App/ReplayViewModel.swift
+++ b/Pastura/Pastura/App/ReplayViewModel.swift
@@ -123,8 +123,17 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
 
   /// User-selectable playback speed. Initialized from
   /// ``ReplayPlaybackConfig/playbackSpeed`` and writable at runtime
-  /// (Demo controlBar's Speed Menu binds directly here, mirroring
+  /// (Demo controlBar's Speed Menu assigns to it directly, mirroring
   /// ``SimulationViewModel/speed``).
+  ///
+  /// **Plain `var` (intentionally not `private(set)`) for Sim parity.**
+  /// Every other observable property on this VM is `private(set) var`
+  /// (`state`, `currentPhase`, `currentRound`, …) and routes mutation
+  /// through explicit transition methods. `playbackSpeed` instead
+  /// matches ``SimulationViewModel/speed`` — the UI assigns directly
+  /// (`viewModel.playbackSpeed = .fast`) over `PlaybackSpeed.allCases`.
+  /// All four cases are valid; no validation guard is required, so a
+  /// dedicated `setPlaybackSpeed(_:)` would only add API surface.
   ///
   /// **Next-event reflection only.** A speed change does not interrupt
   /// the in-flight `Task.sleep`; it takes effect at the next call to
@@ -285,6 +294,13 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
   ///   load-bearing.
   /// - From `.idle`, `.transitioning`, `.paused(.user)`: no-op.
   func userPause() {
+    // CASE-EXHAUSTIVE on `PauseReason`: each new reason added to
+    // ``PauseReason`` must make an explicit choice here between
+    // "user-pause overrides this reason" (current behavior for
+    // `.scenePhase`) vs. "user-pause is no-op against this reason."
+    // The current intuition is "newer pause reasons are less sticky
+    // than .user", but the compiler will force the decision when a
+    // third case lands.
     switch state {
     case .playing(let sourceIndex, let cursor):
       let remaining = remainingDelayMs()

--- a/Pastura/Pastura/App/ReplayViewModel.swift
+++ b/Pastura/Pastura/App/ReplayViewModel.swift
@@ -66,8 +66,10 @@ final class ReplayViewModel {
     /// Paused. `remainingDelayMs` is how much of the pre-yield sleep
     /// for `plannedEvents()[eventCursor]` was still outstanding when
     /// the pause fired. On resume, the VM sleeps exactly that many
-    /// milliseconds (scaled by `speedMultiplier`) before publishing
-    /// the paused event.
+    /// milliseconds (computed at the speed *active when the pause was
+    /// captured*, not the current ``playbackSpeed`` — see that
+    /// property's doc-comment for the worked example) before
+    /// publishing the paused event.
     ///
     /// `reason` distinguishes scene-phase auto-pauses from explicit
     /// user-driven pauses; see ``PauseReason``. The two reasons share
@@ -118,6 +120,23 @@ final class ReplayViewModel {
 
   /// Most-recent `.roundStarted.totalRounds`. See ``currentRound``.
   private(set) var currentTotalRounds: Int?
+
+  /// User-selectable playback speed. Initialized from
+  /// ``ReplayPlaybackConfig/playbackSpeed`` and writable at runtime
+  /// (Demo controlBar's Speed Menu binds directly here, mirroring
+  /// ``SimulationViewModel/speed``).
+  ///
+  /// **Next-event reflection only.** A speed change does not interrupt
+  /// the in-flight `Task.sleep`; it takes effect at the next call to
+  /// ``scaledDelay(for:)``. Worst-case latency: `turnDelayMs / .slow.multiplier`
+  /// = ~2400ms with the default 1200ms turn delay. Example: at
+  /// `.normal`, paused with `remainingDelayMs == 600` (computed at
+  /// `.normal` rate); user changes to `.slow`; the resumed event still
+  /// sleeps 600ms — the new `.slow` rate applies starting at event N+1.
+  /// This matches ``SimulationViewModel``'s general inter-event-sleep
+  /// behavior; recompute-on-change was deferred as the simpler mirror
+  /// is acceptable for the Demo screen.
+  var playbackSpeed: PlaybackSpeed
 
   /// Filtered agent-output events in publish order. Consumed by the
   /// host view's chat-stream component (``AgentOutputRow``). The
@@ -171,10 +190,12 @@ final class ReplayViewModel {
   ///     (``BundledDemoReplaySource``); by the time sources reach the
   ///     VM they are already validated.
   ///   - config: Playback pacing + loop policy (spec §4.6). The VM
-  ///     reads `turnDelayMs` / `codePhaseDelayMs` / `speedMultiplier`
+  ///     reads `turnDelayMs` / `codePhaseDelayMs` / `playbackSpeed`
   ///     for per-event sleeps and `loopBehaviour` / `onComplete` for
   ///     end-of-source behaviour (loop rotation lands in a follow-up
-  ///     commit on this branch).
+  ///     commit on this branch). `config.playbackSpeed` seeds
+  ///     ``playbackSpeed``, which is the runtime-mutable knob the UI
+  ///     binds against; `config` itself stays immutable.
   ///   - contentFilter: Filter instance applied to user-visible text
   ///     at render time (spec §3.4).
   ///
@@ -189,6 +210,7 @@ final class ReplayViewModel {
     self.sources = sources
     self.config = config
     self.contentFilter = contentFilter
+    self.playbackSpeed = config.playbackSpeed
   }
 
   // MARK: - Transition methods
@@ -502,8 +524,18 @@ final class ReplayViewModel {
 
   // MARK: - Pacing helpers
 
+  /// Per-event sleep in milliseconds. Reads ``playbackSpeed`` (the
+  /// runtime-mutable VM state, not `config.playbackSpeed`) so a Speed
+  /// Menu change reflects on the next call.
+  ///
+  /// `.instant` short-circuits to 0ms before the multiplier division —
+  /// symmetric with the early-return in ``YAMLReplaySource``. The
+  /// `.infinity` sentinel on `.instant.multiplier` would arithmetically
+  /// produce 0 too, but explicit early-return avoids depending on
+  /// IEEE-754 division semantics.
   private func scaledDelay(for kind: PacedEvent.Kind) -> Int {
-    let speed = max(config.speedMultiplier, 0.001)
+    if playbackSpeed == .instant { return 0 }
+    let speed = max(playbackSpeed.multiplier, 0.001)
     switch kind {
     case .turn:
       return Int(Double(config.turnDelayMs) / speed)

--- a/Pastura/Pastura/App/ReplayViewModel.swift
+++ b/Pastura/Pastura/App/ReplayViewModel.swift
@@ -63,16 +63,46 @@ final class ReplayViewModel {
     /// the index into that source's `plannedEvents()` that will be
     /// published *next* (cursor = 0 means "about to publish event 0").
     case playing(sourceIndex: Int, eventCursor: Int)
-    /// Paused while backgrounded. `remainingDelayMs` is how much of
-    /// the pre-yield sleep for `plannedEvents()[eventCursor]` was
-    /// still outstanding when the pause fired. On resume, the VM
-    /// sleeps exactly that many milliseconds (scaled by
-    /// `speedMultiplier`) before publishing the paused event.
-    case paused(sourceIndex: Int, eventCursor: Int, remainingDelayMs: Int)
+    /// Paused. `remainingDelayMs` is how much of the pre-yield sleep
+    /// for `plannedEvents()[eventCursor]` was still outstanding when
+    /// the pause fired. On resume, the VM sleeps exactly that many
+    /// milliseconds (scaled by `speedMultiplier`) before publishing
+    /// the paused event.
+    ///
+    /// `reason` distinguishes scene-phase auto-pauses from explicit
+    /// user-driven pauses; see ``PauseReason``. The two reasons share
+    /// the same payload but have different resume semantics:
+    /// ``onForeground()`` resumes only `.scenePhase`; ``userResume()``
+    /// resumes only `.user`. `.user` is **sticky** across scene-phase
+    /// transitions (a backgrounded user-paused VM stays paused on
+    /// foreground return).
+    case paused(
+      sourceIndex: Int, eventCursor: Int, remainingDelayMs: Int,
+      reason: PauseReason)
     /// Transitioning to the setup-complete screen. ``downloadComplete()``
     /// drives this; the host view's `.transition` animation keys off
     /// state identity.
     case transitioning
+  }
+
+  /// Discriminator on ``State/paused`` distinguishing automatic
+  /// scene-phase pauses from explicit user-driven pauses. Resume
+  /// semantics fork on this tag — see ``onForeground()`` and
+  /// ``userResume()``.
+  ///
+  /// Modeled as a tag on `.paused` rather than a 5th `State` case to
+  /// avoid doubling transition logic for the two reasons; the
+  /// resume-from-position invariant
+  /// (`firstSleepOverrideMs = remainingDelayMs`) is identical for both.
+  nonisolated enum PauseReason: Sendable, Equatable {
+    /// App auto-paused on backgrounding. Cleared by ``onForeground()``
+    /// (auto-resume).
+    case scenePhase
+    /// User explicitly tapped Pause. Cleared only by ``userResume()`` —
+    /// scene-phase transitions never clear `.user`. Sticky-by-design so
+    /// that backgrounding + foregrounding does not silently override
+    /// the user's pause intent.
+    case user
   }
 
   private(set) var state: State = .idle
@@ -183,7 +213,10 @@ final class ReplayViewModel {
   /// pre-yield delay captured for accurate resumption (ADR-007 §3.4).
   ///
   /// Called by the host view's `scenePhase` observer when the scene
-  /// drops below `.active`. No-op if not currently `.playing`.
+  /// drops below `.active`. Only triggers from `.playing` — a VM
+  /// already paused (either reason) stays put. In particular, a
+  /// ``State/paused``(``PauseReason/user``) VM stays user-paused
+  /// through the BG cycle so foreground does not auto-resume.
   func onBackground() {
     guard case .playing(let sourceIndex, let cursor) = state else { return }
     let remaining = remainingDelayMs()
@@ -191,21 +224,86 @@ final class ReplayViewModel {
     streamTask = nil
     currentSleepDeadline = nil
     state = .paused(
-      sourceIndex: sourceIndex, eventCursor: cursor, remainingDelayMs: remaining)
+      sourceIndex: sourceIndex, eventCursor: cursor, remainingDelayMs: remaining,
+      reason: .scenePhase)
   }
 
   /// Resumes playback from the paused position, sleeping exactly the
   /// remaining delay before publishing the next event.
   ///
   /// Called by the host view's `scenePhase` observer when the scene
-  /// returns to `.active`. No-op if not currently `.paused`.
+  /// returns to `.active`. Auto-resumes only from
+  /// ``State/paused``(``PauseReason/scenePhase``). User-driven pauses
+  /// (``PauseReason/user``) are sticky — the user must call
+  /// ``userResume()`` to leave them.
   func onForeground() {
-    guard case .paused(let sourceIndex, let cursor, let remainingMs) = state
+    guard
+      case .paused(let sourceIndex, let cursor, let remainingMs, .scenePhase) =
+        state
     else { return }
     state = .playing(sourceIndex: sourceIndex, eventCursor: cursor)
     launchPlayback(
       sourceIndex: sourceIndex, startCursor: cursor,
       firstSleepOverrideMs: remainingMs)
+  }
+
+  /// Pauses playback at the user's explicit request. Sticky across
+  /// scene-phase transitions — ``onForeground()`` will NOT auto-resume
+  /// from the resulting `.paused(.user)`; the caller must invoke
+  /// ``userResume()``.
+  ///
+  /// Reason precedence:
+  /// - From `.playing`: captures `remainingDelayMs` (mirroring
+  ///   ``onBackground()``) and transitions to `.paused(.user)`.
+  /// - From `.paused(.scenePhase)`: race-safety override — promotes the
+  ///   reason to `.user`, preserving `remainingDelayMs`. A subsequent
+  ///   ``onForeground()`` then no-ops, so the user's intent wins over
+  ///   the implicit scene-phase auto-resume. The UI is normally hidden
+  ///   during scene-phase pause so this branch is defense-in-depth, not
+  ///   load-bearing.
+  /// - From `.idle`, `.transitioning`, `.paused(.user)`: no-op.
+  func userPause() {
+    switch state {
+    case .playing(let sourceIndex, let cursor):
+      let remaining = remainingDelayMs()
+      streamTask?.cancel()
+      streamTask = nil
+      currentSleepDeadline = nil
+      state = .paused(
+        sourceIndex: sourceIndex, eventCursor: cursor,
+        remainingDelayMs: remaining, reason: .user)
+    case .paused(let sourceIndex, let cursor, let remainingMs, .scenePhase):
+      state = .paused(
+        sourceIndex: sourceIndex, eventCursor: cursor,
+        remainingDelayMs: remainingMs, reason: .user)
+    case .idle, .transitioning, .paused(_, _, _, .user):
+      return
+    }
+  }
+
+  /// Resumes playback from a user-driven pause. No-op from any other
+  /// state — including `.paused(.scenePhase)` (the UI is normally
+  /// hidden during scene-phase pause; the scenePhase observer's
+  /// ``onForeground()`` is the canonical resume path for that reason).
+  func userResume() {
+    guard
+      case .paused(let sourceIndex, let cursor, let remainingMs, .user) = state
+    else { return }
+    state = .playing(sourceIndex: sourceIndex, eventCursor: cursor)
+    launchPlayback(
+      sourceIndex: sourceIndex, startCursor: cursor,
+      firstSleepOverrideMs: remainingMs)
+  }
+
+  /// `true` when the VM is currently paused due to an explicit
+  /// ``userPause()``. Drives the controlBar's Pause button icon flip
+  /// (`pause.fill` ↔ `play.fill`) in the DL-time demo host view.
+  /// Scene-phase pauses do NOT make this `true` — the UI is normally
+  /// hidden then anyway, but the boundary is meaningful for the
+  /// transient FG-redraw frame after `.scenePhase` auto-resume.
+  var isUserPaused: Bool {
+    if case .paused(_, _, _, .user) = state { return true }
+    return false
   }
 
   /// Transitions to `.transitioning` and tears down the active

--- a/Pastura/Pastura/App/ReplayViewModel.swift
+++ b/Pastura/Pastura/App/ReplayViewModel.swift
@@ -49,7 +49,7 @@ import Foundation
 /// can emit it; if yes, mirror the filter here; if no, leave alone.
 @Observable
 @MainActor
-final class ReplayViewModel {
+final class ReplayViewModel {  // swiftlint:disable:this type_body_length
 
   // MARK: - Public state
 

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -32,56 +32,6 @@ struct LogEntry: Identifiable {
   }
 }
 
-/// Typing-animation speed tiers for simulation playback.
-///
-/// Rates are calibrated for Japanese text (higher information density per
-/// character than English) and match contemporary Switch/PS visual-novel
-/// conventions: x0.5 / x1 / x1.5 / Max. `x1` ≈ 30 char/sec feels natural for
-/// mixed kana/kanji content; Ren'Py's 40 char/sec default is slightly too
-/// fast on real devices.
-///
-/// Controls (1) per-character typing rate for agent outputs and (2) a small
-/// delay between non-agentOutput events so phase/round transitions remain
-/// perceptible. `.instant` skips both for developer-style rapid playback.
-enum PlaybackSpeed: String, CaseIterable, Identifiable {
-  case slow
-  case normal
-  case fast
-  case instant
-
-  var id: String { rawValue }
-
-  /// Characters revealed per second during typing animation.
-  /// `nil` means "render full text immediately" (`.instant`).
-  var charsPerSecond: Double? {
-    switch self {
-    case .slow: 15
-    case .normal: 30
-    case .fast: 45
-    case .instant: nil
-    }
-  }
-
-  /// Delay inserted between consumed simulation events other than agent
-  /// outputs (agent outputs are paced by the typing animation instead).
-  /// Keeps round separators and phase labels on-screen long enough to read.
-  var interEventDelayMs: Int {
-    switch self {
-    case .slow, .normal, .fast: 120
-    case .instant: 0
-    }
-  }
-
-  var label: String {
-    switch self {
-    case .slow: "x0.5"
-    case .normal: "x1"
-    case .fast: "x1.5"
-    case .instant: "Max"
-    }
-  }
-}
-
 /// ViewModel for the live simulation execution screen.
 ///
 /// Consumes `AsyncStream<SimulationEvent>` from `SimulationRunner`, applies

--- a/Pastura/Pastura/App/YAMLReplayExporter.swift
+++ b/Pastura/Pastura/App/YAMLReplayExporter.swift
@@ -131,8 +131,9 @@ nonisolated struct YAMLReplayExporter {  // swiftlint:disable:this type_body_len
       scenario: scenario, events: sortedEvents)
 
     let totalTurns = sortedTurns.filter { $0.agentName != nil }.count
-    // Nominal duration at 1× playback using the `demoDefault` pacing.
-    // Actual playback time = this / `ReplayPlaybackConfig.speedMultiplier`.
+    // Nominal duration at `.normal` playback using the `demoDefault` pacing.
+    // Actual playback time = this / `playbackSpeed.multiplier` (`.instant`
+    // collapses to ~0 via consumer early-return).
     let pacing = ReplayPlaybackConfig.demoDefault
     let estimatedDurationMs =
       totalTurns * pacing.turnDelayMs

--- a/Pastura/Pastura/App/YAMLReplaySource.swift
+++ b/Pastura/Pastura/App/YAMLReplaySource.swift
@@ -172,13 +172,22 @@ nonisolated public final class YAMLReplaySource: ReplaySource {
     let plan = self.plan
     let turnDelay = config.turnDelayMs
     let codePhaseDelay = config.codePhaseDelayMs
-    let speed = max(config.speedMultiplier, 0.001)
+    let playbackSpeed = config.playbackSpeed
+    // `.instant` short-circuits per-event sleeps to 0 — symmetric with
+    // the early-return in `ReplayViewModel.scaledDelay(for:)`. The
+    // sentinel `.infinity` multiplier on `.instant` would arithmetically
+    // produce 0 too, but the explicit branch avoids depending on
+    // IEEE-754 division semantics.
+    let speed = max(playbackSpeed.multiplier, 0.001)
     return AsyncStream { continuation in
       let task = Task {
         for planned in plan {
           if Task.isCancelled { break }
           let baseDelay = planned.kind == .turn ? turnDelay : codePhaseDelay
-          let sleepMs = Int(Double(baseDelay) / speed)
+          let sleepMs: Int = {
+            if playbackSpeed == .instant { return 0 }
+            return Int(Double(baseDelay) / speed)
+          }()
           if sleepMs > 0 {
             try? await Task.sleep(for: .milliseconds(sleepMs))
           }

--- a/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+ControlBar.swift
+++ b/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+ControlBar.swift
@@ -4,16 +4,18 @@ extension ModelDownloadHostView {
 
   /// Sim-style frosted controlBar for the DL-time demo. Mirrors
   /// `SimulationView.controlBar` shape so users learn the layout
-  /// before reaching the live simulation (issue #273).
+  /// before reaching the live simulation (issue #273 / PR 1a).
   ///
-  /// **Disabled-mirror layout** — Pause and Speed are visually
-  /// present but `.disabled(true)` and styled with `Color.disabledText`
-  /// (design-system §2.7 — Interactive States); only
-  /// `ThoughtVisibilityToggle` is interactive. PR 1b enables Pause /
-  /// Speed by adding a user-driven pause / resume API to
-  /// `ReplayViewModel`; at that point `.disabled(true)` is removed
-  /// and the controls wire to the new API. Until then, the disabled
-  /// layout serves as tutorial preview.
+  /// All three controls are interactive (PR 1b / #290):
+  /// - Pause toggles via `viewModel.userPause()` / `userResume()`,
+  ///   icon flips between `pause.fill` and `play.fill` based on
+  ///   ``ReplayViewModel/isUserPaused``.
+  /// - Speed Menu binds directly to ``ReplayViewModel/playbackSpeed``
+  ///   over `PlaybackSpeed.allCases`, matching Sim's pattern at
+  ///   `SimulationView.swift:434`.
+  /// - Thought toggle remains bound to `showAllThoughts` (Sim and
+  ///   Replay diverge here — Sim's is a per-VM property, Demo's is a
+  ///   View-local `@State`).
   ///
   /// Does **not** apply `.ignoresSafeArea(.container, edges: .bottom)`
   /// (unlike `SimulationView.controlBar`). The host's
@@ -21,16 +23,11 @@ extension ModelDownloadHostView {
   /// for `PromoCard`; adding the ignore would extend tint into the
   /// inset region with unpredictable interaction with the
   /// PromoCard layer (#273 critic Axis 2).
-  ///
-  /// `.buttonStyle(.plain)` is used on the disabled controls to
-  /// suppress the system's default button decoration so the explicit
-  /// `Color.disabledText` token is the dominant rendered color rather
-  /// than the system's accent-tint × disabled-opacity composite.
   @ViewBuilder
-  func controlBar() -> some View {
+  func controlBar(viewModel: ReplayViewModel) -> some View {
     HStack(spacing: 16) {
-      pausePreviewButton
-      speedPreviewButton
+      pauseButton(viewModel: viewModel)
+      speedMenu(viewModel: viewModel)
 
       Spacer()
 
@@ -50,41 +47,58 @@ extension ModelDownloadHostView {
     }
   }
 
-  /// Disabled "preview" Pause button — same icon as Sim's running-state
-  /// Pause (`pause.fill`). PR 1b wires the action to
-  /// `replayVM?.userPause()` and removes `.disabled(true)`.
+  /// Pause / Resume button. Action toggles via
+  /// ``ReplayViewModel/isUserPaused``; icon mirrors the same flag
+  /// (`play.fill` while user-paused, otherwise `pause.fill`).
+  /// Scene-phase pause does **not** flip the icon — the UI is hidden
+  /// during BG anyway, but the boundary is meaningful for the
+  /// transient redraw frame on FG return.
   @ViewBuilder
-  private var pausePreviewButton: some View {
+  private func pauseButton(viewModel: ReplayViewModel) -> some View {
     Button {
+      if viewModel.isUserPaused {
+        viewModel.userResume()
+      } else {
+        viewModel.userPause()
+      }
     } label: {
-      Image(systemName: "pause.fill").font(.title3)
+      Image(systemName: viewModel.isUserPaused ? "play.fill" : "pause.fill")
+        .font(.title3)
     }
     .buttonStyle(.plain)
-    .foregroundStyle(Color.disabledText)
-    .disabled(true)
     .accessibilityLabel(
-      String(localized: "Pause (available during simulation)"))
+      viewModel.isUserPaused
+        ? String(localized: "Resume playback")
+        : String(localized: "Pause playback"))
   }
 
-  /// Disabled "preview" Speed picker — same label structure as Sim's
-  /// `speedOrExportControl` Menu (gauge icon + value + chevron). Static
-  /// `1×` since `ReplayViewModel` runs at a fixed `speedMultiplier`.
-  /// PR 1b replaces this with a real `Menu` over `PlaybackSpeed.allCases`.
+  /// Speed Menu — drives ``ReplayViewModel/playbackSpeed`` over
+  /// `PlaybackSpeed.allCases`. Mirrors `SimulationView.speedOrExportControl`'s
+  /// Menu-with-explicit-buttons pattern (`SimulationView.swift:433`)
+  /// rather than `Picker.pickerStyle(.menu)` to avoid the iOS 17/18
+  /// reparenting warnings + label-wrap quirks documented there.
   @ViewBuilder
-  private var speedPreviewButton: some View {
-    Button {
+  private func speedMenu(viewModel: ReplayViewModel) -> some View {
+    Menu {
+      ForEach(PlaybackSpeed.allCases) { speed in
+        Button {
+          viewModel.playbackSpeed = speed
+        } label: {
+          if speed == viewModel.playbackSpeed {
+            Label(speed.label, systemImage: "checkmark")
+          } else {
+            Text(speed.label)
+          }
+        }
+      }
     } label: {
       HStack(spacing: 4) {
         Image(systemName: "gauge.with.dots.needle.50percent")
-        Text(verbatim: "1×")
+        Text(viewModel.playbackSpeed.label)
         Image(systemName: "chevron.down").font(.caption2)
       }
       .textStyle(Typography.titlePhase)
     }
-    .buttonStyle(.plain)
-    .foregroundStyle(Color.disabledText)
-    .disabled(true)
-    .accessibilityLabel(
-      String(localized: "Playback speed (available during simulation)"))
+    .accessibilityLabel(String(localized: "Playback speed"))
   }
 }

--- a/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView.swift
+++ b/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView.swift
@@ -255,10 +255,10 @@ struct ModelDownloadHostView: View {
 
       // Sim-style frosted controlBar (#273): mirrors `SimulationView.controlBar`
       // shape so users learn the layout before reaching the live simulation.
-      // Pause / Speed are visible-but-disabled placeholders (PR 1b enables them
-      // via a new `ReplayViewModel.userPause()` API); only the thought toggle
-      // is interactive in the demo.
-      controlBar()
+      // Pause / Speed / Toggle all interactive — Pause drives
+      // `viewModel.userPause()`/`userResume()`, Speed binds to
+      // `viewModel.playbackSpeed` (#290).
+      controlBar(viewModel: viewModel)
     }
     .background(Color.screenBackground.ignoresSafeArea())
     // PromoCard lives in the bottom safe area instead of a ZStack overlay:

--- a/Pastura/PasturaTests/App/BundledDemoReplaySourceTests.swift
+++ b/Pastura/PasturaTests/App/BundledDemoReplaySourceTests.swift
@@ -78,7 +78,7 @@ struct BundledDemoReplaySourceTests {
   }
 
   static let testConfig = ReplayPlaybackConfig(
-    speedMultiplier: 100.0,
+    playbackSpeed: .instant,
     turnDelayMs: 20,
     codePhaseDelayMs: 5,
     loopBehaviour: .stopAfterLast,

--- a/Pastura/PasturaTests/App/DemoReplayIntegrationTests.swift
+++ b/Pastura/PasturaTests/App/DemoReplayIntegrationTests.swift
@@ -130,7 +130,7 @@ struct DemoReplayIntegrationTests {
   /// bounded to ~ 5 events per demo × 2 demos = 10 events total,
   /// well under the 20-event cap from the plan.
   static let integrationConfig = ReplayPlaybackConfig(
-    speedMultiplier: 100.0,
+    playbackSpeed: .instant,
     turnDelayMs: 20,
     codePhaseDelayMs: 5,
     loopBehaviour: .stopAfterLast,
@@ -268,11 +268,12 @@ struct DemoReplayIntegrationTests {
   }
 
   @Test func pauseAndResumeLandsOnSameCursor() async throws {
-    // Slower pacing so the pause catches mid-sleep — otherwise 100×
-    // collapses the sleep to 0 and we observe a boundary pause that
-    // happens to have remainingDelayMs == 0.
+    // Slower pacing (`.normal`) so the pause catches mid-sleep —
+    // otherwise `.instant` collapses the sleep to 0 and we observe a
+    // boundary pause that happens to have remainingDelayMs == 0.
     let slowConfig = ReplayPlaybackConfig(
-      speedMultiplier: 1.0, turnDelayMs: 150, codePhaseDelayMs: 50,
+      playbackSpeed: .normal,
+      turnDelayMs: 150, codePhaseDelayMs: 50,
       loopBehaviour: .stopAfterLast, onComplete: .awaitTransitionSignal)
     let yamls = [
       (name: "ww", contents: Self.wordWolfDemoYAML())

--- a/Pastura/PasturaTests/App/DemoReplayIntegrationTests.swift
+++ b/Pastura/PasturaTests/App/DemoReplayIntegrationTests.swift
@@ -244,8 +244,11 @@ struct DemoReplayIntegrationTests {
     await Self.waitForState(viewModel) { _ in viewModel.agentOutputs.count >= 1 }
 
     viewModel.onBackground()
-    guard case .paused(let pausedIdx, let pausedCursor, _) = viewModel.state else {
-      Issue.record("Expected .paused after onBackground(), got \(viewModel.state)")
+    guard
+      case .paused(let pausedIdx, let pausedCursor, _, .scenePhase) =
+        viewModel.state
+    else {
+      Issue.record("Expected .paused(.scenePhase) after onBackground(), got \(viewModel.state)")
       return
     }
 
@@ -282,8 +285,11 @@ struct DemoReplayIntegrationTests {
     // Wait for at least one agent output, then pause.
     await Self.waitForState(viewModel) { _ in viewModel.agentOutputs.count >= 1 }
     viewModel.onBackground()
-    guard case .paused(let sourceIndex, let cursor, _) = viewModel.state else {
-      Issue.record("Expected .paused after onBackground, got \(viewModel.state)")
+    guard
+      case .paused(let sourceIndex, let cursor, _, .scenePhase) =
+        viewModel.state
+    else {
+      Issue.record("Expected .paused(.scenePhase) after onBackground, got \(viewModel.state)")
       return
     }
     let pausedOutputs = viewModel.agentOutputs.count

--- a/Pastura/PasturaTests/App/PlaybackSpeedTests.swift
+++ b/Pastura/PasturaTests/App/PlaybackSpeedTests.swift
@@ -31,4 +31,15 @@ struct PlaybackSpeedTests {
     #expect(PlaybackSpeed.fast.label == "x1.5")
     #expect(PlaybackSpeed.instant.label == "Max")
   }
+
+  @Test func multiplierValues() {
+    // Replay-side scaling. `.instant` returns `.infinity` as a sentinel
+    // — every consumer special-cases `.instant` with an explicit
+    // early-return, so the sentinel is defense-in-depth, not the
+    // load-bearing path.
+    #expect(PlaybackSpeed.slow.multiplier == 0.5)
+    #expect(PlaybackSpeed.normal.multiplier == 1.0)
+    #expect(PlaybackSpeed.fast.multiplier == 1.5)
+    #expect(PlaybackSpeed.instant.multiplier == .infinity)
+  }
 }

--- a/Pastura/PasturaTests/App/ReplayViewModelTests+Rotation.swift
+++ b/Pastura/PasturaTests/App/ReplayViewModelTests+Rotation.swift
@@ -42,21 +42,21 @@ extension ReplayViewModelTests {
   /// collapse delays to 0 ms + `Task.yield()` which makes rotation
   /// cycle sub-ms — rotation assertions race against the poll loop.
   fileprivate static let stopConfig = ReplayPlaybackConfig(
-    speedMultiplier: 1.0,
+    playbackSpeed: .normal,
     turnDelayMs: 150,
     codePhaseDelayMs: 50,
     loopBehaviour: .stopAfterLast,
     onComplete: .stopPlayback)
 
   fileprivate static let holdConfig = ReplayPlaybackConfig(
-    speedMultiplier: 1.0,
+    playbackSpeed: .normal,
     turnDelayMs: 150,
     codePhaseDelayMs: 50,
     loopBehaviour: .stopAfterLast,
     onComplete: .awaitTransitionSignal)
 
   fileprivate static let loopConfig = ReplayPlaybackConfig(
-    speedMultiplier: 1.0,
+    playbackSpeed: .normal,
     turnDelayMs: 150,
     codePhaseDelayMs: 50,
     loopBehaviour: .loop,

--- a/Pastura/PasturaTests/App/ReplayViewModelTests+Speed.swift
+++ b/Pastura/PasturaTests/App/ReplayViewModelTests+Speed.swift
@@ -1,0 +1,135 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+/// Tests pinning the runtime-mutable `playbackSpeed` API on
+/// ``ReplayViewModel`` introduced in #290.
+///
+/// Key invariants:
+/// - The VM seeds `playbackSpeed` from `config.playbackSpeed` at init.
+/// - The property is plain `@Observable var` (Sim-style); writes
+///   reflect at the **next** call to `scaledDelay(for:)` — the
+///   in-flight `Task.sleep` is NOT recomputed.
+/// - `.instant` early-returns 0ms before the multiplier division so
+///   the `.infinity` sentinel in `PlaybackSpeed.multiplier` is never
+///   load-bearing.
+extension ReplayViewModelTests {
+
+  // MARK: - Initialization
+
+  @Test func playbackSpeedSeededFromConfig() throws {
+    let config = ReplayPlaybackConfig(
+      playbackSpeed: .fast,
+      loopBehaviour: .stopAfterLast, onComplete: .stopPlayback)
+    let source = try YAMLReplaySource(
+      yaml: Self.threeTurnYAML, scenario: Self.makeScenario(),
+      config: config)
+    let viewModel = ReplayViewModel(sources: [source], config: config)
+    #expect(viewModel.playbackSpeed == .fast)
+  }
+
+  @Test func playbackSpeedDefaultsToNormalUnderDemoDefault() throws {
+    let source = try YAMLReplaySource(
+      yaml: Self.threeTurnYAML, scenario: Self.makeScenario(),
+      config: .demoDefault)
+    let viewModel = ReplayViewModel(sources: [source], config: .demoDefault)
+    #expect(viewModel.playbackSpeed == .normal)
+  }
+
+  // MARK: - Runtime mutation
+
+  @Test func playbackSpeedIsWritable() throws {
+    let viewModel = try Self.makeVM()
+    viewModel.playbackSpeed = .slow
+    #expect(viewModel.playbackSpeed == .slow)
+    viewModel.playbackSpeed = .instant
+    #expect(viewModel.playbackSpeed == .instant)
+  }
+
+  // MARK: - Next-event reflection (the canonical UX pin)
+
+  @Test func instantCollapsesAllSubsequentEventsToFastPlayback() async throws {
+    // Start at `.normal` with deliberately slow per-event delays so
+    // the first event takes a measurable amount of time. Then flip to
+    // `.instant` mid-flight; the remaining events should arrive in
+    // close to zero wall time, demonstrating that next-event speed
+    // change is honored.
+    let config = ReplayPlaybackConfig(
+      playbackSpeed: .normal,
+      turnDelayMs: 200, codePhaseDelayMs: 50,
+      loopBehaviour: .stopAfterLast, onComplete: .awaitTransitionSignal)
+    let source = try YAMLReplaySource(
+      yaml: Self.threeTurnYAML, scenario: Self.makeScenario(),
+      config: config)
+    let viewModel = ReplayViewModel(sources: [source], config: config)
+    viewModel.start()
+    // Wait for the first agent output (proving 1+ events have flowed
+    // at the slow rate).
+    await Self.waitForState(viewModel) { _ in viewModel.agentOutputs.count >= 1 }
+    // Flip to instant — remaining 2 turns should now fly past.
+    let mark = ContinuousClock.now
+    viewModel.playbackSpeed = .instant
+    await Self.waitForState(viewModel) { _ in viewModel.agentOutputs.count == 3 }
+    let elapsed = ContinuousClock.now - mark
+    // Two remaining turns at `.instant` (0ms each + Task.yield) should
+    // resolve well under the at-`.normal` per-event delay (200ms).
+    // Generous upper bound for CI; lower bound omitted because it'd
+    // need to be 0 — too tight to assert.
+    #expect(elapsed < .seconds(2))
+  }
+
+  @Test func instantSpeedFromIdleProducesAllEventsRapidly() async throws {
+    // From a fresh start at `.instant`, the full 5-event plan
+    // (3 turns + 2 lifecycle) should resolve fast — pinning that
+    // `.instant` short-circuits scaledDelay() before the multiplier
+    // division (no IEEE-754 dependency).
+    let viewModel = try Self.makeVM()  // fastConfig is `.instant`
+    let mark = ContinuousClock.now
+    viewModel.start()
+    await Self.waitForState(viewModel) { _ in viewModel.agentOutputs.count == 3 }
+    let elapsed = ContinuousClock.now - mark
+    // 3 turns + 2 lifecycle events at `.instant` collapse to a series
+    // of `Task.yield()`s. Generous bound for CI.
+    #expect(elapsed < .seconds(2))
+  }
+
+  // MARK: - Resume preserves the speed-at-pause-time semantic
+
+  @Test func resumeAfterPauseUsesCapturedRemainingDelay() async throws {
+    // The `playbackSpeed` doc-comment promises: a speed change AFTER
+    // pause does NOT recompute the captured `remainingDelayMs`. Pin
+    // that invariant: pause at `.normal`, switch to `.fast`, resume —
+    // the resumed sleep is the one captured at `.normal`. We don't
+    // assert exact wall-clock; we assert the resumed cursor lands
+    // unchanged (which it would whether the sleep recomputed or not),
+    // PLUS that no crash / state corruption occurs.
+    let config = ReplayPlaybackConfig(
+      playbackSpeed: .normal,
+      turnDelayMs: 200, codePhaseDelayMs: 50,
+      loopBehaviour: .stopAfterLast, onComplete: .awaitTransitionSignal)
+    let source = try YAMLReplaySource(
+      yaml: Self.threeTurnYAML, scenario: Self.makeScenario(),
+      config: config)
+    let viewModel = ReplayViewModel(sources: [source], config: config)
+    viewModel.start()
+    try await Task.sleep(for: .milliseconds(20))
+    viewModel.userPause()
+    guard
+      case .paused(let pausedIdx, let pausedCursor, _, .user) = viewModel.state
+    else {
+      Issue.record("Expected .paused(.user), got \(viewModel.state)")
+      return
+    }
+    // Change speed while paused — this must not crash or rewrite the
+    // captured remainingDelayMs.
+    viewModel.playbackSpeed = .fast
+    viewModel.userResume()
+    if case .playing(let rIdx, let rCursor) = viewModel.state {
+      #expect(rIdx == pausedIdx)
+      #expect(rCursor == pausedCursor)
+    } else {
+      Issue.record("Expected .playing after userResume(), got \(viewModel.state)")
+    }
+  }
+}

--- a/Pastura/PasturaTests/App/ReplayViewModelTests+Speed.swift
+++ b/Pastura/PasturaTests/App/ReplayViewModelTests+Speed.swift
@@ -76,7 +76,10 @@ extension ReplayViewModelTests {
     // resolve well under the at-`.normal` per-event delay (200ms).
     // Generous upper bound for CI; lower bound omitted because it'd
     // need to be 0 — too tight to assert.
-    #expect(elapsed < .seconds(2))
+    // Generous upper bound for CI under code coverage (per
+    // `feedback_ci_wallclock_test_bounds.md`); the signal-to-noise is
+    // in "did all events arrive at all," not in the exact budget.
+    #expect(elapsed < .seconds(30))
   }
 
   @Test func instantSpeedFromIdleProducesAllEventsRapidly() async throws {
@@ -91,7 +94,10 @@ extension ReplayViewModelTests {
     let elapsed = ContinuousClock.now - mark
     // 3 turns + 2 lifecycle events at `.instant` collapse to a series
     // of `Task.yield()`s. Generous bound for CI.
-    #expect(elapsed < .seconds(2))
+    // Generous upper bound for CI under code coverage (per
+    // `feedback_ci_wallclock_test_bounds.md`); the signal-to-noise is
+    // in "did all events arrive at all," not in the exact budget.
+    #expect(elapsed < .seconds(30))
   }
 
   // MARK: - Resume preserves the speed-at-pause-time semantic

--- a/Pastura/PasturaTests/App/ReplayViewModelTests+UserPause.swift
+++ b/Pastura/PasturaTests/App/ReplayViewModelTests+UserPause.swift
@@ -1,0 +1,230 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+/// Tests pinning the user-driven pause / resume API and its coexistence
+/// with scene-phase pause (`onBackground` / `onForeground`).
+///
+/// `.user` reason is **sticky**: scene-phase transitions never clear it.
+/// Specifically, `onForeground()` resumes only from `.paused(.scenePhase)`,
+/// not from `.paused(.user)`. The user must explicitly call `userResume()`
+/// to leave a user-driven pause.
+///
+/// Tests live in a sibling `extension` per `.claude/rules/testing.md` —
+/// adding a new `@Suite` would race the original on shared static fixtures
+/// (scenario YAML, fastConfig).
+extension ReplayViewModelTests {
+
+  // MARK: - userPause from .playing
+
+  @Test func userPauseFromPlayingTransitionsToPausedUser() async throws {
+    let viewModel = try Self.makeVM()
+    viewModel.start()
+    await Self.waitForState(viewModel) { _ in viewModel.agentOutputs.count >= 1 }
+    viewModel.userPause()
+    if case .paused(_, _, _, let reason) = viewModel.state {
+      #expect(reason == .user)
+    } else {
+      Issue.record("Expected .paused(.user), got \(viewModel.state)")
+    }
+  }
+
+  @Test func userPausePreservesSourceAndCursorPosition() async throws {
+    let viewModel = try Self.makeVM()
+    viewModel.start()
+    await Self.waitForState(viewModel) { _ in viewModel.agentOutputs.count >= 1 }
+    guard case .playing(let playingIdx, let playingCursor) = viewModel.state else {
+      Issue.record("Expected .playing before userPause(), got \(viewModel.state)")
+      return
+    }
+    viewModel.userPause()
+    if case .paused(let pausedIdx, let pausedCursor, _, .user) = viewModel.state {
+      #expect(pausedIdx == playingIdx)
+      #expect(pausedCursor == playingCursor)
+    } else {
+      Issue.record("Expected .paused(.user) preserving position, got \(viewModel.state)")
+    }
+  }
+
+  // MARK: - userResume from .paused(.user)
+
+  @Test func userResumeFromPausedUserResumesPlayback() async throws {
+    let viewModel = try Self.makeVM()
+    viewModel.start()
+    await Self.waitForState(viewModel) { _ in viewModel.agentOutputs.count >= 1 }
+    viewModel.userPause()
+    guard case .paused(let pausedIdx, let pausedCursor, _, .user) = viewModel.state
+    else {
+      Issue.record("Expected .paused(.user), got \(viewModel.state)")
+      return
+    }
+    viewModel.userResume()
+    if case .playing(let rIdx, let rCursor) = viewModel.state {
+      #expect(rIdx == pausedIdx)
+      #expect(rCursor == pausedCursor)
+    } else {
+      Issue.record("Expected .playing after userResume(), got \(viewModel.state)")
+    }
+  }
+
+  // MARK: - .user is sticky across scene-phase transitions
+
+  @Test func onForegroundFromPausedUserIsNoOp() async throws {
+    // The user pauses, app goes background, then comes back to foreground.
+    // Without the .user-sticky rule, onForeground() would auto-resume —
+    // surprising the user who explicitly paused.
+    let viewModel = try Self.makeVM()
+    viewModel.start()
+    await Self.waitForState(viewModel) { _ in viewModel.agentOutputs.count >= 1 }
+    viewModel.userPause()
+    guard case .paused(_, _, _, .user) = viewModel.state else {
+      Issue.record("Expected .paused(.user), got \(viewModel.state)")
+      return
+    }
+    viewModel.onForeground()
+    if case .paused(_, _, _, let reason) = viewModel.state {
+      #expect(reason == .user)
+    } else {
+      Issue.record("Expected .paused(.user) preserved, got \(viewModel.state)")
+    }
+  }
+
+  @Test func onBackgroundFromPausedUserIsNoOp() async throws {
+    let viewModel = try Self.makeVM()
+    viewModel.start()
+    await Self.waitForState(viewModel) { _ in viewModel.agentOutputs.count >= 1 }
+    viewModel.userPause()
+    let stateBefore = viewModel.state
+    viewModel.onBackground()
+    #expect(viewModel.state == stateBefore)
+  }
+
+  // MARK: - userPause from .paused(.scenePhase) — race-safety override
+
+  @Test func userPauseFromPausedScenePhaseOverridesToUser() async throws {
+    // Scene-phase pause first (simulating background), then user calls
+    // userPause(). Even though the UI is normally hidden during BG,
+    // the race-safety override promotes reason to .user so the
+    // subsequent foreground does NOT auto-resume.
+    let viewModel = try Self.makeVM()
+    viewModel.start()
+    await Self.waitForState(viewModel) { _ in viewModel.agentOutputs.count >= 1 }
+    viewModel.onBackground()
+    guard case .paused(_, _, _, .scenePhase) = viewModel.state else {
+      Issue.record("Expected .paused(.scenePhase), got \(viewModel.state)")
+      return
+    }
+    viewModel.userPause()
+    if case .paused(_, _, _, let reason) = viewModel.state {
+      #expect(reason == .user)
+    } else {
+      Issue.record("Expected .paused(.user) after override, got \(viewModel.state)")
+    }
+    // Foreground arrives after the user-pause — must NOT auto-resume.
+    viewModel.onForeground()
+    if case .paused(_, _, _, .user) = viewModel.state {
+      // expected
+    } else {
+      Issue.record("Expected .paused(.user) preserved, got \(viewModel.state)")
+    }
+  }
+
+  // MARK: - Defensive no-ops on .paused(.scenePhase) / .idle / .transitioning
+
+  @Test func userResumeFromPausedScenePhaseIsNoOp() async throws {
+    let viewModel = try Self.makeVM()
+    viewModel.start()
+    await Self.waitForState(viewModel) { _ in viewModel.agentOutputs.count >= 1 }
+    viewModel.onBackground()
+    let stateBefore = viewModel.state
+    viewModel.userResume()
+    #expect(viewModel.state == stateBefore)
+  }
+
+  @Test func userPauseFromIdleIsNoOp() throws {
+    let viewModel = try Self.makeVM()
+    viewModel.userPause()
+    #expect(viewModel.state == .idle)
+  }
+
+  @Test func userResumeFromIdleIsNoOp() throws {
+    let viewModel = try Self.makeVM()
+    viewModel.userResume()
+    #expect(viewModel.state == .idle)
+  }
+
+  @Test func userPauseFromTransitioningIsNoOp() async throws {
+    let viewModel = try Self.makeVM()
+    viewModel.start()
+    await Self.waitForState(viewModel) { _ in viewModel.agentOutputs.count >= 1 }
+    viewModel.downloadComplete()
+    #expect(viewModel.state == .transitioning)
+    viewModel.userPause()
+    #expect(viewModel.state == .transitioning)
+  }
+
+  @Test func userResumeFromTransitioningIsNoOp() async throws {
+    let viewModel = try Self.makeVM()
+    viewModel.start()
+    await Self.waitForState(viewModel) { _ in viewModel.agentOutputs.count >= 1 }
+    viewModel.downloadComplete()
+    #expect(viewModel.state == .transitioning)
+    viewModel.userResume()
+    #expect(viewModel.state == .transitioning)
+  }
+
+  // MARK: - isUserPaused observability
+
+  @Test func isUserPausedTracksReasonAccurately() async throws {
+    let viewModel = try Self.makeVM()
+    #expect(viewModel.isUserPaused == false)  // .idle
+
+    viewModel.start()
+    await Self.waitForState(viewModel) { _ in viewModel.agentOutputs.count >= 1 }
+    #expect(viewModel.isUserPaused == false)  // .playing
+
+    viewModel.onBackground()
+    guard case .paused(_, _, _, .scenePhase) = viewModel.state else {
+      Issue.record("Expected .paused(.scenePhase), got \(viewModel.state)")
+      return
+    }
+    #expect(viewModel.isUserPaused == false)  // .paused(.scenePhase)
+
+    viewModel.onForeground()
+    #expect(viewModel.isUserPaused == false)  // back to .playing
+
+    await Self.waitForState(viewModel) { _ in viewModel.agentOutputs.count >= 2 }
+    viewModel.userPause()
+    #expect(viewModel.isUserPaused == true)  // .paused(.user)
+
+    viewModel.userResume()
+    #expect(viewModel.isUserPaused == false)  // back to .playing
+  }
+
+  // MARK: - Regression — existing scenePhase round-trip still works
+
+  @Test func onForegroundFromPausedScenePhaseStillAutoResumes() async throws {
+    // Critic Axis 5 regression coverage: confirms the unchanged
+    // `.paused(.scenePhase) → onForeground → .playing` path survives the
+    // PauseReason addition. Existing tests at ReplayViewModelTests.swift
+    // (onForegroundResumesFromPausedPosition) cover the same path under
+    // the renamed pattern; this one re-asserts it from the user-pause
+    // suite for clarity.
+    let viewModel = try Self.makeVM()
+    viewModel.start()
+    await Self.waitForState(viewModel) { _ in viewModel.agentOutputs.count >= 1 }
+    viewModel.onBackground()
+    guard case .paused(let idx, let cursor, _, .scenePhase) = viewModel.state else {
+      Issue.record("Expected .paused(.scenePhase), got \(viewModel.state)")
+      return
+    }
+    viewModel.onForeground()
+    if case .playing(let rIdx, let rCursor) = viewModel.state {
+      #expect(rIdx == idx)
+      #expect(rCursor == cursor)
+    } else {
+      Issue.record("Expected .playing after onForeground(.scenePhase), got \(viewModel.state)")
+    }
+  }
+}

--- a/Pastura/PasturaTests/App/ReplayViewModelTests.swift
+++ b/Pastura/PasturaTests/App/ReplayViewModelTests.swift
@@ -61,9 +61,11 @@ struct ReplayViewModelTests {
     try ScenarioLoader().load(yaml: scenarioYAML)
   }
 
-  /// Fast pacing: 100× speed collapses the nominal 1200 ms turn delay
-  /// to ~12 ms — tests still observe the state machine transitions
-  /// without paying human-scale wait times.
+  /// Fast pacing: `.instant` collapses every per-event sleep to 0 —
+  /// tests still observe the state machine transitions without paying
+  /// human-scale wait times. (Pre-#290 used `speedMultiplier: 100.0`
+  /// for ~12 ms turns; the new shape is strictly faster but no test
+  /// here pins on the residual delay.)
   ///
   /// Uses `.stopAfterLast + .awaitTransitionSignal` so the VM HOLDS at
   /// `.playing(lastIndex, plan.count)` after the single source's plan
@@ -71,7 +73,7 @@ struct ReplayViewModelTests {
   /// premature termination. Rotation-specific tests override with
   /// their own config (see `ReplayViewModelTests+Rotation.swift`).
   static let fastConfig = ReplayPlaybackConfig(
-    speedMultiplier: 100.0,
+    playbackSpeed: .instant,
     turnDelayMs: 20,
     codePhaseDelayMs: 5,
     loopBehaviour: .stopAfterLast,
@@ -173,12 +175,12 @@ struct ReplayViewModelTests {
   // MARK: - onBackground / onForeground
 
   @Test func onBackgroundTransitionsPlayingToPaused() async throws {
-    // Slow pacing (1× speed) so we can catch the VM mid-sleep. The
-    // turnDelayMs=20ms scaled by 1× = 20ms per event. Calling
-    // onBackground immediately after start should catch the first
-    // sleep in progress.
+    // Slow pacing (`.normal` = 1×) so we can catch the VM mid-sleep.
+    // turnDelayMs=200ms × 1.0 = 200ms per event; calling onBackground
+    // ~20ms after start catches the first sleep in progress.
     let slowConfig = ReplayPlaybackConfig(
-      speedMultiplier: 1.0, turnDelayMs: 200, codePhaseDelayMs: 50,
+      playbackSpeed: .normal,
+      turnDelayMs: 200, codePhaseDelayMs: 50,
       loopBehaviour: .stopAfterLast, onComplete: .stopPlayback)
     let source = try YAMLReplaySource(
       yaml: Self.threeTurnYAML, scenario: Self.makeScenario(),

--- a/Pastura/PasturaTests/App/ReplayViewModelTests.swift
+++ b/Pastura/PasturaTests/App/ReplayViewModelTests.swift
@@ -188,7 +188,8 @@ struct ReplayViewModelTests {
     // Sleep briefly so the playback task begins its first sleep.
     try await Task.sleep(for: .milliseconds(20))
     viewModel.onBackground()
-    if case .paused(let idx, let cursor, let remaining) = viewModel.state {
+    if case .paused(let idx, let cursor, let remaining, let reason) =
+      viewModel.state {
       #expect(idx == 0)
       // Cursor is 0 (we haven't published the first roundStarted yet
       // because lifecycle delay is 0 — actually 0-delay "sleeps"
@@ -197,6 +198,9 @@ struct ReplayViewModelTests {
       // state shape.
       #expect(cursor >= 0)
       #expect(remaining >= 0)
+      // onBackground() always tags pauses as `.scenePhase`; assertion
+      // strengthening per critic Axis 2 (PR 1b).
+      #expect(reason == .scenePhase)
     } else {
       Issue.record("Expected .paused, got \(viewModel.state)")
     }
@@ -214,8 +218,9 @@ struct ReplayViewModelTests {
     // Wait for some progress.
     await Self.waitForState(viewModel) { _ in viewModel.agentOutputs.count >= 1 }
     viewModel.onBackground()
-    guard case .paused(let idx, let cursor, _) = viewModel.state else {
-      Issue.record("Expected .paused after onBackground, got \(viewModel.state)")
+    guard case .paused(let idx, let cursor, _, .scenePhase) = viewModel.state
+    else {
+      Issue.record("Expected .paused(.scenePhase) after onBackground, got \(viewModel.state)")
       return
     }
     viewModel.onForeground()

--- a/Pastura/PasturaTests/App/YAMLReplayRoundTripTests.swift
+++ b/Pastura/PasturaTests/App/YAMLReplayRoundTripTests.swift
@@ -83,7 +83,7 @@ struct YAMLReplayRoundTripTests {
 
   private var fastConfig: ReplayPlaybackConfig {
     ReplayPlaybackConfig(
-      speedMultiplier: 100.0,
+      playbackSpeed: .instant,
       loopBehaviour: .stopAfterLast,
       onComplete: .stopPlayback)
   }

--- a/Pastura/PasturaTests/App/YAMLReplaySourceTests.swift
+++ b/Pastura/PasturaTests/App/YAMLReplaySourceTests.swift
@@ -37,11 +37,11 @@ struct YAMLReplaySourceTests {
     try ScenarioLoader().load(yaml: Self.scenarioYAML)
   }
 
-  /// Speed up replay for tests — 100× means a 1200 ms nominal delay
-  /// finishes in 12 ms, keeping the suite well under the 1-minute cap.
+  /// Speed up replay for tests — `.instant` collapses every per-event
+  /// sleep to 0, keeping the suite well under the 1-minute cap.
   var fastConfig: ReplayPlaybackConfig {
     ReplayPlaybackConfig(
-      speedMultiplier: 100.0,
+      playbackSpeed: .instant,
       loopBehaviour: .stopAfterLast,
       onComplete: .stopPlayback)
   }
@@ -301,8 +301,8 @@ struct YAMLReplaySourceTests {
   @Test func pacingIsSourcedFromConfigNotYAML() async throws {
     // The YAML carries NO delay hint. The source derives per-event
     // sleep from `ReplayPlaybackConfig.turnDelayMs` /
-    // `codePhaseDelayMs` scaled by `speedMultiplier`. A tiny delay
-    // here keeps the test fast; doubling it doubles wall time.
+    // `codePhaseDelayMs` scaled by `playbackSpeed.multiplier`. A tiny
+    // delay here keeps the test fast; doubling it doubles wall time.
     let yaml = """
       schema_version: 1
       turns:
@@ -318,7 +318,8 @@ struct YAMLReplaySourceTests {
           fields: { statement: 'hi' }
       """
     let slowConfig = ReplayPlaybackConfig(
-      speedMultiplier: 1.0, turnDelayMs: 60, codePhaseDelayMs: 20,
+      playbackSpeed: .normal,
+      turnDelayMs: 60, codePhaseDelayMs: 20,
       loopBehaviour: .stopAfterLast, onComplete: .stopPlayback)
     let source = try YAMLReplaySource(
       yaml: yaml, scenario: makeScenario(), config: slowConfig)

--- a/docs/specs/demo-replay-spec.md
+++ b/docs/specs/demo-replay-spec.md
@@ -162,10 +162,10 @@ metadata:
   recorded_with_model: gemma4_e2b_q4km
   content_filter_applied: true   # §3.4 — curator asserts record-time ContentFilter coverage
   total_turns: 12
-  estimated_duration_ms: 90000   # nominal 1× playback duration using
+  estimated_duration_ms: 90000   # nominal `.normal` playback duration using
                                  # `ReplayPlaybackConfig.demoDefault`
-                                 # pacing; divide by speedMultiplier
-                                 # for actual wall time
+                                 # pacing; divide by playbackSpeed.multiplier
+                                 # (`.instant` collapses to ~0) for actual wall time
   captured_by: tyabu12           # pseudonymous identifier; §6 stash flow
 
 turns:
@@ -207,7 +207,8 @@ Notes on field choices:
   a separate schema layer.
 - **Inter-event pacing lives on the consumer, not the YAML.** Replay
   cadence (`turnDelayMs`, `codePhaseDelayMs`) is set via
-  `ReplayPlaybackConfig` and scaled by `speedMultiplier`. Baking a
+  `ReplayPlaybackConfig` and scaled by `playbackSpeed.multiplier`
+  (`.instant` short-circuits to 0 via consumer early-return). Baking a
   per-event `delay_ms_before` into the recording would bake LLM-
   inference wait time into the replay — dead time the viewer should
   never experience. If a future demo needs a dramatic in-sequence
@@ -443,7 +444,7 @@ Known future concerns to flag now (tracked in §7 Risks):
 
 ```swift
 public struct ReplayPlaybackConfig: Sendable {
-  public var speedMultiplier: Double          // delays are divided by this
+  public var playbackSpeed: PlaybackSpeed     // .slow / .normal / .fast / .instant
   public var loopBehaviour: LoopBehaviour     // .loop / .stopAfterLast
   public var onComplete: CompletionAction     // .awaitTransitionSignal / .stopPlayback
 
@@ -454,14 +455,20 @@ public struct ReplayPlaybackConfig: Sendable {
   }
 
   public static let demoDefault = ReplayPlaybackConfig(
-    speedMultiplier: 1.0,
+    playbackSpeed: .normal,
     loopBehaviour: .loop,
     onComplete: .awaitTransitionSignal)
 }
 ```
 
-The DL-time demo uses `demoDefault` (1× per decision 5). Future
-user-replay would use `.stopAfterLast` + `.stopPlayback` + a
+`PlaybackSpeed` is the shared enum used by both the live simulation
+and replay (extracted to `App/PlaybackSpeed.swift` in #290). Replay
+reads `playbackSpeed.multiplier` to scale `turnDelayMs` /
+`codePhaseDelayMs`; `.instant` is special-cased at every consumer to
+short-circuit to 0ms.
+
+The DL-time demo uses `demoDefault` (`.normal` per decision 5).
+Future user-replay would use `.stopAfterLast` + `.stopPlayback` + a
 user-selectable speed.
 
 ### 4.7 View integration — shared render components


### PR DESCRIPTION
## Summary

- `ReplayViewModel.State.paused` extended with `PauseReason` discriminator (`.scenePhase | .user`); new `userPause()` / `userResume()` / `isUserPaused`. `.user` is sticky across scene-phase transitions (foreground does not auto-resume user pauses).
- `PlaybackSpeed` extracted to `App/PlaybackSpeed.swift` (`nonisolated public`, shared by Sim + Replay). Replay-specific `speedMultiplier: Double` removed; `ReplayPlaybackConfig.playbackSpeed: PlaybackSpeed` is now the single speed knob.
- `.instant` short-circuits to 0ms at every consumer (`ReplayViewModel.scaledDelay`, `YAMLReplaySource.events()`) via explicit early-return — the sentinel `.infinity` multiplier is defense-in-depth, not load-bearing.
- Demo controlBar Pause/Speed wired to the new APIs; `.disabled(true)` / `Color.disabledText` removed.

Splits PR 1b of #273 (already closed; deferred section). Plan + critic-derived design decisions documented on issue #290.

## Test plan

- [x] Full unit suite passes (1351 tests, `-skip-testing:PasturaUITests`)
- [x] `swiftlint lint --quiet --strict` clean
- [x] Code-reviewer (Opus): PASS, Warning + 3 suggestions addressed
- [x] Manual QA — Demo replay (cold launch via multi-model picker download flow):
  - Speed Menu: select `.slow` / `.fast` / `.instant`; verify next-event reflection (worst-case ~2400ms latency at `.slow → .instant` accepted)
  - Pause: tap → icon flips to `play.fill`, playback halts; tap Resume → icon flips back, playback continues from cursor
  - Background app while user-paused → return foreground → still paused (no auto-resume)
  - Background app while playing → return foreground → resumes (existing scenePhase path)
  - `.instant` collapses turn delay to 0ms — events fly past
- [ ] CI green

Closes #290