### PR TITLE
✨ feat: xcodebuild.sh — add --tail N to cap output without external pipe

### DIFF
--- a/.claude/rules/xcodebuild-cli.md
+++ b/.claude/rules/xcodebuild-cli.md
@@ -18,6 +18,7 @@ NOT use the wrapper — see the table below.
 | TDD red/green cycle (single class) | `scripts/xcodebuild.sh test -only-testing PasturaTests/<Class>` |
 | Pre-PR full local run | `scripts/xcodebuild.sh test` |
 | Build only (no tests) | `scripts/xcodebuild.sh build` |
+| Cap output for context-window budget | `scripts/xcodebuild.sh <cmd> --tail N [args]` (built-in flag; preserves xcodebuild's exit code via `pipefail`; use instead of external `\| tail`) |
 | CI full run | `.github/workflows/ci.yml` (uses `xcodebuild test ... -parallel-testing-enabled NO` inline; CI's SPM cache key depends on `~/Library/...` so it intentionally bypasses the wrapper — see [#189](https://github.com/tyabu12/pastura/issues/189)) |
 
 ### Canonical invocation
@@ -25,8 +26,14 @@ NOT use the wrapper — see the table below.
 **Always invoke via the absolute path resolved by `git rev-parse`:**
 
 ```bash
-"$(git rev-parse --show-toplevel)/scripts/xcodebuild.sh" <subcommand> [args]
+"$(git rev-parse --show-toplevel)/scripts/xcodebuild.sh" <subcommand> [--tail N] [args]
 ```
+
+`--tail N` is a wrapper-only flag (xcodebuild itself uses single-dash
+flags, so `--`-prefixed names are unambiguous). Accepted at any position
+among the args and consumed before forwarding the rest to xcodebuild;
+duplicates follow xcodebuild's own repeated-flag convention (last wins).
+See **Running xcodebuild from an agent session** below for when to use it.
 
 This matches `sim-dest.sh`'s convention and is the only form the Bash
 allowlist (`Bash("$(git rev-parse --show-toplevel)/scripts/xcodebuild.sh"*)`)
@@ -79,6 +86,12 @@ xcb="$(git rev-parse --show-toplevel)/scripts/xcodebuild.sh"
 
 # Build only (no tests) — type-check verification after refactor
 "$xcb" build
+
+# Cap output for context-window budget — `--tail N` is built-in,
+# pipefail-safe (preserves xcodebuild's exit code), and accepted at
+# any position. Use instead of external `| tail`.
+"$xcb" build --tail 30
+"$xcb" test -only-testing PasturaTests/JSONResponseParserTests --tail 80
 
 # Run Ollama integration tests (requires local Ollama with target model pulled)
 # Enable OLLAMA_INTEGRATION in scheme: Edit Scheme → Run → Environment Variables → toggle ON
@@ -153,13 +166,24 @@ burning wall-clock and orphaning processes:
   `timeout: 900000` (15 min) when UI tests are included.
 - For runs expected to exceed 5 minutes, prefer `run_in_background: true`
   and poll with Monitor / BashOutput rather than blocking the session.
-- When piping through `tail` (e.g.
-  `"$(git rev-parse --show-toplevel)/scripts/xcodebuild.sh" test ... 2>&1 | tail -80`),
-  the pipe's exit code is `tail`'s, not the wrapper's — a failed build reports `exit code 0`.
-  Grep the tailed output for `** BUILD|TEST SUCCEEDED/FAILED **` or
-  `xcodebuild: error:` before trusting the harness exit code, or use
-  `set -o pipefail`. When the SUCCEEDED marker has been trimmed off
-  entirely, extract the verdict from the xcresult bundle:
+- For context-window-capped output, prefer the built-in `--tail N`
+  flag over an external `| tail`:
+  `"$(git rev-parse --show-toplevel)/scripts/xcodebuild.sh" test ... --tail 80`.
+  The flag is pipefail-safe (preserves xcodebuild's exit code), accepts
+  its value anywhere among the args, and suppresses `set -x` xtrace so
+  the visible window stays focused on build output. External `| tail`
+  defeats `pipefail` — a failed build reports `exit code 0` to the
+  harness, silently masking failures (see memory
+  `feedback_xcodebuild_pipefail.md` for the original incident).
+- For pattern filtering, external `| grep` is still acceptable, but
+  note that any external pipe (grep, tail, head) replaces the wrapper's
+  exit code with the last command's. Treat the harness exit-code
+  notification as informational only when piping externally — verify
+  success by grepping the output for `** BUILD SUCCEEDED **` /
+  `** TEST SUCCEEDED **` (or the corresponding FAILED markers), or use
+  caller-side `set -o pipefail`. When the SUCCEEDED marker has been
+  trimmed off entirely (long suites past `--tail` budget), extract the
+  verdict from the xcresult bundle:
   `xcrun xcresulttool get test-results summary --path "$XCRESULT" --format json`.
 
 **Recovery (if a run hangs or a retry immediately stalls):**

--- a/scripts/xcodebuild.sh
+++ b/scripts/xcodebuild.sh
@@ -6,10 +6,11 @@
 #   "$(git rev-parse --show-toplevel)/scripts/xcodebuild.sh" test -only-testing PasturaTests/Foo
 #   "$(git rev-parse --show-toplevel)/scripts/xcodebuild.sh" test -skip-testing:PasturaUITests
 #   "$(git rev-parse --show-toplevel)/scripts/xcodebuild.sh" build
+#   "$(git rev-parse --show-toplevel)/scripts/xcodebuild.sh" build --tail 30
 #
 # Shorter convenience alias for interactive shells:
 #   xcb="$(git rev-parse --show-toplevel)/scripts/xcodebuild.sh"
-#   "$xcb" test -only-testing PasturaTests/Foo
+#   "$xcb" test -only-testing PasturaTests/Foo --tail 80
 #
 # Subcommand maps directly to xcodebuild's; remaining args forward
 # verbatim via "$@". xcodebuild honors the last value for repeated
@@ -38,12 +39,26 @@
 #   worktree-local Pastura/DerivedData/ alongside test runs.
 #
 # Streams output directly to the terminal — no tee, no log file. Exit
-# code is xcodebuild's exit code unmodified (xcodebuild is the last
-# statement under `set -e`). For context-window-sized output in agent
-# sessions, pipe externally:
+# code is xcodebuild's exit code (preserved through `pipefail` when
+# `--tail` is used; `set -x` xtrace is suppressed in `--tail` mode so
+# the visible window stays focused on build output).
 #
-#   "$xcb" test ...  2>&1 | grep -E 'error:|TEST|passed|failed' | tail -30
-#   "$xcb" build ... 2>&1 | grep -E 'error:|warning:|BUILD'    | head -30
+# For context-window-capped output in agent sessions, prefer the
+# built-in `--tail N` flag — accepted at any position, consumed before
+# forwarding to xcodebuild, last-wins on duplicates:
+#
+#   "$xcb" build --tail 30
+#   "$xcb" test --tail 80
+#   "$xcb" test -only-testing PasturaTests/Foo --tail 30
+#
+# External `| grep` for pattern-filtering still works. Do NOT pipe
+# through external `| tail` — it defeats `pipefail`, so a failed
+# xcodebuild reports exit 0 to the harness (see memory
+# `feedback_xcodebuild_pipefail.md` for the original incident). Use
+# the built-in flag instead.
+#
+#   "$xcb" test  ... 2>&1 | grep -E 'error:|TEST|passed|failed'
+#   "$xcb" build ... 2>&1 | grep -E 'error:|warning:|BUILD'
 
 set -euo pipefail
 
@@ -54,12 +69,51 @@ set -euo pipefail
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
 if [[ $# -eq 0 ]]; then
-  echo 'Usage: "$(git rev-parse --show-toplevel)/scripts/xcodebuild.sh" <test|build> [args...]' >&2
+  echo 'Usage: "$(git rev-parse --show-toplevel)/scripts/xcodebuild.sh" <test|build> [--tail N] [args...]' >&2
   exit 2
 fi
 
 cmd=$1
 shift
+
+# Parse wrapper-only `--tail N` / `--tail=N` flags. xcodebuild uses
+# single-dash flags (e.g. `-only-testing`), so `--`-prefixed names are
+# unambiguously ours. Accepted at any position among the args; the value
+# is validated as a positive integer BEFORE `shift 2`, so a missing or
+# non-numeric value fails cleanly under `set -u` instead of producing a
+# confusing shift-past-end abort. Duplicate `--tail` follows xcodebuild's
+# own repeated-flag convention: last value wins.
+tail_n=""
+forwarded=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tail)
+      if [[ ! "${2-}" =~ ^[1-9][0-9]*$ ]]; then
+        echo "--tail requires a positive integer (e.g. --tail 30)" >&2
+        exit 2
+      fi
+      tail_n=$2
+      shift 2
+      ;;
+    --tail=*)
+      tail_val=${1#--tail=}
+      if [[ ! "$tail_val" =~ ^[1-9][0-9]*$ ]]; then
+        echo "--tail= requires a positive integer (e.g. --tail=30)" >&2
+        exit 2
+      fi
+      tail_n=$tail_val
+      shift
+      ;;
+    *)
+      forwarded+=("$1")
+      shift
+      ;;
+  esac
+done
+# Reset positional params to the forwarded args. Empty-array `+`
+# expansion mirrors `extra_flags` below — bare `"${arr[@]}"` would trip
+# `set -u` on macOS bash 3.2 when forwarded[] is empty.
+set -- ${forwarded[@]+"${forwarded[@]}"}
 
 case "$cmd" in
   test)
@@ -86,14 +140,29 @@ else
   destination="$DEST"
 fi
 
-set -x
+# Build the xcodebuild command as an array so the two execution paths
+# (with / without `--tail`) share a single source of truth.
 # `${extra_flags[@]+"${extra_flags[@]}"}` survives `set -u` when the
 # array is empty (macOS bash 3.2 quirk: bare `"${arr[@]}"` expansion
 # trips `nounset` for zero-length arrays).
-xcodebuild "$cmd" \
-  -scheme Pastura \
-  -project "$REPO_ROOT/Pastura/Pastura.xcodeproj" \
-  -destination "$destination" \
-  -derivedDataPath "$DERIVED_DATA" \
-  ${extra_flags[@]+"${extra_flags[@]}"} \
+xcb_cmd=(
+  xcodebuild "$cmd"
+  -scheme Pastura
+  -project "$REPO_ROOT/Pastura/Pastura.xcodeproj"
+  -destination "$destination"
+  -derivedDataPath "$DERIVED_DATA"
+  ${extra_flags[@]+"${extra_flags[@]}"}
   "$@"
+)
+
+if [[ -n "$tail_n" ]]; then
+  # Internal `| tail` preserves xcodebuild's exit code via `set -o
+  # pipefail` (top of script). We deliberately suppress `set -x` here:
+  # its multi-line xtrace would fold into `2>&1` and compete with build
+  # output for the visible tail window, pushing real `error:` lines off
+  # the bottom — the exact regression `--tail` exists to prevent.
+  "${xcb_cmd[@]}" 2>&1 | tail -n "$tail_n"
+else
+  set -x
+  "${xcb_cmd[@]}"
+fi


### PR DESCRIPTION
## Summary

- `scripts/xcodebuild.sh` に `--tail N` / `--tail=N` オプションを追加。エージェントセッションでの **allowlist 摩擦** と **pipefail トラップ** (memory: `feedback_xcodebuild_pipefail.md` / PR#3 of #133) を同時に解消。
- 内部パイプ `xcodebuild ... 2>&1 | tail -n N` がスクリプト先頭の `set -o pipefail` 下で実行されるため、xcodebuild の exit code が透過する。
- **Critical 修正**: `--tail` モード時に `set -x` を抑制。これがないと multi-line xtrace が `2>&1 | tail` に折り込まれ、本物の `error:` 行が visible window から押し出されて、このオプションが解決すべき問題を再生産していた (plan critic で発見)。

## Test plan

- [x] 検証マトリクス 7 ケース + 4 bonus を worktree 内で実行 (全 PASS)
  - `xcb build --tail 5` / `--tail=10` / 前置 / 後置 / 既存形式 (no --tail)
  - エラー系: `--tail` (値欠落) / `--tail abc` / `--tail 0` / `--tail=abc`
  - `pipefail` 透過: `xcb build --tail 10 -scheme NonExistent` → exit 64 ✓
  - xtrace 抑制: `--tail` モードで `grep -cE '^\+ '` = 0 ✓
  - 既存挙動維持: 素の `xcb build` で xtrace あり / 全ストリーム / exit 透過 ✓
- [x] code-reviewer (Opus) PASS — 0 Critical / 0 Warning
- [x] pre-commit hook (`swiftlint --strict` + `xcodebuild build`) 通過

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)