### PR TITLE
✨ feat: gallery — recommended-model actions + banner (2/2)

### DIFF
--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -642,6 +642,16 @@
         }
       }
     },
+    "Download recommended model" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "推奨モデルをダウンロード"
+          }
+        }
+      }
+    },
     "Downloading %arg on cellular may use significant data. Wi-Fi is recommended." : {
       "localizations" : {
         "ja" : {
@@ -968,6 +978,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ファイル"
+          }
+        }
+      }
+    },
+    "Finish the current simulation before switching models." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "モデルを切り替える前に実行中のシミュレーションを終了してください。"
           }
         }
       }
@@ -2523,6 +2543,16 @@
         }
       }
     },
+    "Switch to recommended model" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "推奨モデルに切り替える"
+          }
+        }
+      }
+    },
     "THINKING" : {
       "localizations" : {
         "ja" : {
@@ -2929,6 +2959,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "このシミュレーションを終了したら開きます"
+          }
+        }
+      }
+    },
+    "Will run on %arg, not the recommended %arg" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Will run on %1$arg, not the recommended %2$arg"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "推奨モデル %2$arg ではなく %1$arg で実行されます"
           }
         }
       }

--- a/Pastura/Pastura/Views/Community/ShareBoard/GalleryScenarioDetailView+RecommendedModel.swift
+++ b/Pastura/Pastura/Views/Community/ShareBoard/GalleryScenarioDetailView+RecommendedModel.swift
@@ -14,6 +14,10 @@ extension GalleryScenarioDetailView {
     let status = recommendedModelStatus
     switch status {
     case .matched, .unknownModel, .unsupportedDevice:
+      // `EmptyView()` in a `List` collapses to nothing — no Section is
+      // emitted, no divider, no row spacing. The consuming site at
+      // `GalleryScenarioDetailView.content(viewModel:)` always calls this
+      // computed property, so the suppression must be at this layer.
       EmptyView()
     case .switchAvailable(let isLocked):
       Section {

--- a/Pastura/Pastura/Views/Community/ShareBoard/GalleryScenarioDetailView+RecommendedModel.swift
+++ b/Pastura/Pastura/Views/Community/ShareBoard/GalleryScenarioDetailView+RecommendedModel.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+
+/// Recommended-model affordances split out of `GalleryScenarioDetailView`
+/// to satisfy SwiftLint's `type_body_length` cap. See
+/// `RecommendedModelStatus` for the pure-logic classifier these helpers
+/// consume.
+extension GalleryScenarioDetailView {
+  /// Mismatch banner + optional Switch / Download button. Empty for
+  /// `.matched` / `.unknownModel` / `.unsupportedDevice` so the gallery
+  /// stays silent when there is no actionable mismatch (forward-compat
+  /// for newer-id gallery feeds and 6 GB device suppression).
+  @ViewBuilder
+  var recommendedModelSection: some View {
+    let status = recommendedModelStatus
+    switch status {
+    case .matched, .unknownModel, .unsupportedDevice:
+      EmptyView()
+    case .switchAvailable(let isLocked):
+      Section {
+        mismatchBanner
+        switchButton(isLocked: isLocked)
+      } footer: {
+        if isLocked {
+          // Gallery-specific single-sentence variant of the Settings copy.
+          // The Settings version's second sentence ("Downloads and deletes
+          // of other models remain available.") is contextual to the
+          // Settings → Models section UX and dangles in gallery context.
+          Text(
+            String(localized: "Finish the current simulation before switching models."))
+        }
+      }
+    case .downloadAvailable(let otherDownloadInFlight):
+      Section {
+        mismatchBanner
+        downloadButton(disabled: otherDownloadInFlight)
+      }
+    case .downloading:
+      Section {
+        mismatchBanner
+      }
+    }
+  }
+
+  /// Snapshot the inputs into the pure-logic classifier. Re-evaluated on
+  /// every render — `ModelManager` is `@Observable`, so its `state` /
+  /// `activeModelID` mutations invalidate this view automatically.
+  var recommendedModelStatus: RecommendedModelStatus {
+    // Sourced via `#if` rather than a hardcoded literal so simulator parity
+    // is preserved without `#if`-stripping the affordance section. The
+    // pure-logic helper accepts the parameter form so unit tests cover
+    // both branches.
+    #if targetEnvironment(simulator)
+      let isSimulator = true
+    #else
+      let isSimulator = false
+    #endif
+    return RecommendedModelStatus.compute(
+      recommendedID: scenario.recommendedModel,
+      activeID: modelManager.activeModelID,
+      state: modelManager.state,
+      isSimulationActive: dependencies.simulationActivityRegistry.isActive,
+      isSimulator: isSimulator)
+  }
+
+  fileprivate var mismatchBanner: some View {
+    let recommendedDisplay =
+      ModelRegistry.lookup(id: scenario.recommendedModel)?.displayName
+      ?? scenario.recommendedModel
+    let activeDisplay =
+      ModelRegistry.lookup(id: modelManager.activeModelID)?.displayName
+      ?? modelManager.activeModelID
+    return Label {
+      Text(
+        String(
+          localized:
+            "Will run on \(activeDisplay), not the recommended \(recommendedDisplay)")
+      )
+      .font(.footnote)
+      .foregroundStyle(.secondary)
+    } icon: {
+      Image(systemName: "exclamationmark.triangle")
+        .foregroundStyle(Color.warning)
+    }
+  }
+
+  fileprivate func switchButton(isLocked: Bool) -> some View {
+    Button {
+      modelManager.setActiveModel(scenario.recommendedModel)
+    } label: {
+      Text(String(localized: "Switch to recommended model"))
+        .frame(maxWidth: .infinity)
+    }
+    .buttonStyle(.bordered)
+    .disabled(isLocked)
+    .accessibilityIdentifier("galleryDetail.switchModelButton")
+  }
+
+  fileprivate func downloadButton(disabled: Bool) -> some View {
+    Button {
+      // Guarded by `.downloadAvailable` status, which is only emitted
+      // when `ModelRegistry.lookup` resolves — so the lookup here is a
+      // defensive no-op on unreachable paths, not a user-visible branch.
+      guard let descriptor = ModelRegistry.lookup(id: scenario.recommendedModel) else {
+        return
+      }
+      // `startDownload` enforces cellular consent + sequential-DL
+      // policy + per-state gating internally via `evaluateStartGates`;
+      // do NOT duplicate those checks here.
+      modelManager.startDownload(descriptor: descriptor)
+    } label: {
+      Text(String(localized: "Download recommended model"))
+        .frame(maxWidth: .infinity)
+    }
+    .buttonStyle(.bordered)
+    .disabled(disabled || isWorking)
+    .accessibilityIdentifier("galleryDetail.downloadRecommendedButton")
+  }
+}

--- a/Pastura/Pastura/Views/Community/ShareBoard/GalleryScenarioDetailView.swift
+++ b/Pastura/Pastura/Views/Community/ShareBoard/GalleryScenarioDetailView.swift
@@ -11,11 +11,16 @@ import SwiftUI
 struct GalleryScenarioDetailView: View {
   let scenario: GalleryScenario
 
-  @Environment(AppDependencies.self) private var dependencies
+  // `dependencies` / `modelManager` / `isWorking` drop `private` so the
+  // sibling extension in `GalleryScenarioDetailView+RecommendedModel.swift`
+  // can read them. Same pattern as `.claude/rules/testing.md`'s sibling-file
+  // extension guidance — `private` blocks cross-file extension access.
+  @Environment(AppDependencies.self) var dependencies
   @Environment(AppRouter.self) private var router
+  @Environment(ModelManager.self) var modelManager
   @Environment(\.lastDeepLinkedScenarioId) private var lastDeepLinkedScenarioId
   @State private var viewModel: ShareBoardViewModel?
-  @State private var isWorking = false
+  @State var isWorking = false
   @State private var outcomeAlert: OutcomeAlert?
   @State private var isReportSheetPresented = false
 
@@ -110,6 +115,7 @@ struct GalleryScenarioDetailView: View {
           String(localized: "Est. inferences"), value: "\(scenario.estimatedInferences)")
         LabeledContent(String(localized: "Added"), value: scenario.addedAt)
       }
+      recommendedModelSection
       Section {
         actionButton(viewModel: viewModel)
       } footer: {

--- a/Pastura/Pastura/Views/Community/ShareBoard/RecommendedModelStatus.swift
+++ b/Pastura/Pastura/Views/Community/ShareBoard/RecommendedModelStatus.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+/// Classifies how `GalleryScenarioDetailView` should render its
+/// recommended-model affordances given a snapshot of model-manager state.
+///
+/// Surface map (see PR2 of #302 for context):
+/// - `matched`, `unknownModel`, `unsupportedDevice` → no banner, no affordance
+/// - `downloading` → banner only (informational; user can't intervene from gallery)
+/// - `switchAvailable`, `downloadAvailable` → banner + affordance button
+///
+/// Pure-logic enum: lives in Views/ for proximity to the consuming view but
+/// `compute(...)` takes a value-typed snapshot so the test suite is fully
+/// deterministic without mocking `ModelManager`.
+///
+/// Marked `nonisolated` so `compute(...)` and `Equatable` conformance are
+/// callable from test code without a `MainActor` context — same pattern as
+/// `InferenceStatsFormatter` (pure helper in Views/ with no SwiftUI dependency).
+nonisolated enum RecommendedModelStatus: Equatable {
+  /// Active model already matches the recommendation, OR no actionable
+  /// mismatch (simulator builds, transient `.checking` state).
+  case matched
+
+  /// Recommended model is on disk but not active. `isLocked` is `true`
+  /// when a simulation is in flight (mirrors `ModelSettingsRow.isSwitchLocked`).
+  case switchAvailable(isLocked: Bool)
+
+  /// Recommended model is not on disk. `otherDownloadInFlight` is `true`
+  /// when another descriptor is currently downloading (sequential-DL
+  /// policy disables a fresh tap; mirrors
+  /// `SettingsView.isOtherDownloading(excluding:)`).
+  case downloadAvailable(otherDownloadInFlight: Bool)
+
+  /// Recommended model is currently downloading. Banner is informational —
+  /// no gallery-side affordance because intervention happens from
+  /// Settings → Models cover.
+  case downloading
+
+  /// Device fails the 6.5 GB minimum-RAM floor. Phase 2 leaves these users
+  /// fully unsupported; gallery suppresses both banner and affordance.
+  case unsupportedDevice
+
+  /// `ModelRegistry.lookup(id: recommendedID)` returned nil — forward-compat
+  /// case for an older app reading a newer `gallery.json` whose model id
+  /// is unknown to this build. Suppress UI; PR1's "Unknown model (id)"
+  /// display fallback handles the read-only surface.
+  case unknownModel
+
+  /// Pure classifier. Rule order is the contract — tests pin one rule per case.
+  static func compute(
+    recommendedID: ModelID,
+    activeID: ModelID,
+    state: [ModelID: ModelState],
+    isSimulationActive: Bool,
+    isSimulator: Bool
+  ) -> RecommendedModelStatus {
+    // Rule 1: simulator suppresses all affordances; PR1 display fallback
+    // still renders. Param form (vs `#if`-strip) keeps the path testable.
+    if isSimulator { return .matched }
+
+    // Rule 2: forward-compat — unknown id from a newer gallery.json
+    // degrades to PR1's "Unknown model (rawId)" display only.
+    guard ModelRegistry.lookup(id: recommendedID) != nil else { return .unknownModel }
+
+    let recommendedState = state[recommendedID] ?? .checking
+
+    // Rule 3: device-class mismatch — Phase 2 leaves 6 GB devices unsupported.
+    if case .unsupportedDevice = recommendedState { return .unsupportedDevice }
+
+    // Rule 4: short-circuit before .downloading so an active-model
+    // re-download (rare but reachable) doesn't fire a noise banner.
+    if recommendedID == activeID { return .matched }
+
+    // Rule 5: in-flight download — banner only.
+    if case .downloading = recommendedState { return .downloading }
+
+    // Rule 6: needs download. `otherDownloadInFlight` derived from sibling
+    // states (excluding self, but self is .notDownloaded/.error here so
+    // the contains check is naturally exclusive).
+    switch recommendedState {
+    case .notDownloaded, .error:
+      let otherInFlight = state.values.contains { state in
+        if case .downloading = state { return true }
+        return false
+      }
+      return .downloadAvailable(otherDownloadInFlight: otherInFlight)
+    default:
+      break
+    }
+
+    // Rule 7: ready and != active → switch is available; lock if a sim is running.
+    if case .ready = recommendedState {
+      return .switchAvailable(isLocked: isSimulationActive)
+    }
+
+    // Rule 8: .checking transient (or any unanticipated future state) —
+    // conservative: no affordance, no banner.
+    return .matched
+  }
+}

--- a/Pastura/PasturaTests/Views/RecommendedModelStatusTests.swift
+++ b/Pastura/PasturaTests/Views/RecommendedModelStatusTests.swift
@@ -1,0 +1,142 @@
+import Testing
+
+@testable import Pastura
+
+@Suite(.timeLimit(.minutes(1)))
+struct RecommendedModelStatusTests {
+  // Real registry ids — must match ModelRegistry catalog entries.
+  let gemma = "gemma-4-e2b-q4-k-m"
+  let qwen = "qwen-3-4b-q4-k-m"
+  let unknown = "future-model-v9-q4-k-m"
+
+  // MARK: - Rule 1: simulator suppresses all affordances
+
+  @Test func rule1_simulatorAlwaysReturnsMatched() {
+    // Even with a clearly-actionable state, isSimulator: true → .matched
+    let status = RecommendedModelStatus.compute(
+      recommendedID: gemma, activeID: qwen,
+      state: [gemma: .ready(modelPath: "/tmp/g"), qwen: .ready(modelPath: "/tmp/q")],
+      isSimulationActive: false, isSimulator: true)
+    #expect(status == .matched)
+  }
+
+  // MARK: - Rule 2: unknown registry id
+
+  @Test func rule2_unknownRegistryIDReturnsUnknownModel() {
+    let status = RecommendedModelStatus.compute(
+      recommendedID: unknown, activeID: gemma,
+      state: [gemma: .ready(modelPath: "/tmp/g")],
+      isSimulationActive: false, isSimulator: false)
+    #expect(status == .unknownModel)
+  }
+
+  // MARK: - Rule 3: unsupported device
+
+  @Test func rule3_unsupportedDeviceReturnsUnsupportedDevice() {
+    let status = RecommendedModelStatus.compute(
+      recommendedID: qwen, activeID: gemma,
+      state: [qwen: .unsupportedDevice, gemma: .ready(modelPath: "/tmp/g")],
+      isSimulationActive: false, isSimulator: false)
+    #expect(status == .unsupportedDevice)
+  }
+
+  // MARK: - Rule 4: active matches recommended → matched regardless of state
+
+  @Test func rule4_activeMatchesRecommendedReturnsMatched_evenWhileDownloading() {
+    // recommendedID == activeID, but the state entry says .downloading —
+    // Rule 4 fires before Rule 5, so we get .matched not .downloading.
+    let status = RecommendedModelStatus.compute(
+      recommendedID: gemma, activeID: gemma,
+      state: [gemma: .downloading(progress: 0.5)],
+      isSimulationActive: false, isSimulator: false)
+    #expect(status == .matched)
+  }
+
+  @Test func rule4_activeMatchesRecommendedReturnsMatched_whenReady() {
+    let status = RecommendedModelStatus.compute(
+      recommendedID: gemma, activeID: gemma,
+      state: [gemma: .ready(modelPath: "/tmp/g")],
+      isSimulationActive: false, isSimulator: false)
+    #expect(status == .matched)
+  }
+
+  // MARK: - Rule 5: recommended is downloading
+
+  @Test func rule5_recommendedDownloadingReturnsDownloading() {
+    let status = RecommendedModelStatus.compute(
+      recommendedID: qwen, activeID: gemma,
+      state: [qwen: .downloading(progress: 0.3), gemma: .ready(modelPath: "/tmp/g")],
+      isSimulationActive: false, isSimulator: false)
+    #expect(status == .downloading)
+  }
+
+  // MARK: - Rule 6: recommended needs download
+
+  @Test func rule6_recommendedNotDownloadedReturnsDownloadAvailable_noOtherInFlight() {
+    let status = RecommendedModelStatus.compute(
+      recommendedID: qwen, activeID: gemma,
+      state: [qwen: .notDownloaded, gemma: .ready(modelPath: "/tmp/g")],
+      isSimulationActive: false, isSimulator: false)
+    #expect(status == .downloadAvailable(otherDownloadInFlight: false))
+  }
+
+  @Test func rule6_recommendedNotDownloadedReturnsDownloadAvailable_otherInFlight() {
+    // gemma is .downloading (another descriptor in flight) while qwen is .notDownloaded
+    let status = RecommendedModelStatus.compute(
+      recommendedID: qwen, activeID: gemma,
+      state: [qwen: .notDownloaded, gemma: .downloading(progress: 0.7)],
+      isSimulationActive: false, isSimulator: false)
+    #expect(status == .downloadAvailable(otherDownloadInFlight: true))
+  }
+
+  @Test func rule6_recommendedErroredReturnsDownloadAvailable() {
+    let status = RecommendedModelStatus.compute(
+      recommendedID: qwen, activeID: gemma,
+      state: [qwen: .error("checksum mismatch"), gemma: .ready(modelPath: "/tmp/g")],
+      isSimulationActive: false, isSimulator: false)
+    #expect(status == .downloadAvailable(otherDownloadInFlight: false))
+  }
+
+  // MARK: - Rule 7: recommended is ready and not active
+
+  @Test func rule7_recommendedReadyReturnsSwitchAvailable_unlocked() {
+    let status = RecommendedModelStatus.compute(
+      recommendedID: qwen, activeID: gemma,
+      state: [qwen: .ready(modelPath: "/tmp/q"), gemma: .ready(modelPath: "/tmp/g")],
+      isSimulationActive: false, isSimulator: false)
+    #expect(status == .switchAvailable(isLocked: false))
+  }
+
+  @Test func rule7_recommendedReadyReturnsSwitchAvailable_locked() {
+    // Simulation is active → switch affordance is locked.
+    let status = RecommendedModelStatus.compute(
+      recommendedID: qwen, activeID: gemma,
+      state: [qwen: .ready(modelPath: "/tmp/q"), gemma: .ready(modelPath: "/tmp/g")],
+      isSimulationActive: true, isSimulator: false)
+    #expect(status == .switchAvailable(isLocked: true))
+  }
+
+  // MARK: - Rule 8: transient .checking falls back to matched
+
+  @Test func rule8_checkingFallsBackToMatched() {
+    let status = RecommendedModelStatus.compute(
+      recommendedID: qwen, activeID: gemma,
+      state: [qwen: .checking, gemma: .ready(modelPath: "/tmp/g")],
+      isSimulationActive: false, isSimulator: false)
+    #expect(status == .matched)
+  }
+
+  // MARK: - Equatable payload axes
+
+  @Test func equatable_switchAvailableLockBoolsAreDistinct() {
+    #expect(
+      RecommendedModelStatus.switchAvailable(isLocked: true)
+        != .switchAvailable(isLocked: false))
+  }
+
+  @Test func equatable_downloadAvailableInFlightBoolsAreDistinct() {
+    #expect(
+      RecommendedModelStatus.downloadAvailable(otherDownloadInFlight: true)
+        != .downloadAvailable(otherDownloadInFlight: false))
+  }
+}

--- a/Pastura/PasturaTests/Views/RecommendedModelStatusTests.swift
+++ b/Pastura/PasturaTests/Views/RecommendedModelStatusTests.swift
@@ -40,6 +40,19 @@ struct RecommendedModelStatusTests {
     #expect(status == .unsupportedDevice)
   }
 
+  @Test func rule3_unsupportedDeviceWinsOverRule4_evenIfActiveMatchesRecommended() {
+    // Pins Rule 3 (.unsupportedDevice) precedence over Rule 4 (active==recommended).
+    // The two cases produce the same surface map today (no banner, no affordance)
+    // but the distinction matters: a future copy revision for `.unsupportedDevice`
+    // ("This device cannot run the recommended model") would silently revert
+    // to `.matched` if the rule order ever flipped. This test guards that.
+    let status = RecommendedModelStatus.compute(
+      recommendedID: gemma, activeID: gemma,
+      state: [gemma: .unsupportedDevice],
+      isSimulationActive: false, isSimulator: false)
+    #expect(status == .unsupportedDevice)
+  }
+
   // MARK: - Rule 4: active matches recommended → matched regardless of state
 
   @Test func rule4_activeMatchesRecommendedReturnsMatched_evenWhileDownloading() {


### PR DESCRIPTION
## Summary
- Adds Switch / Download / mismatch-warning affordances to `GalleryScenarioDetailView` when the scenario's `recommendedModel` differs from `ModelManager.activeModelID`.
- Pure-logic `RecommendedModelStatus` classifier handles all 6 surface cases (matched, switchAvailable, downloadAvailable, downloading, unsupportedDevice, unknownModel) with deterministic snapshot-input unit tests.
- Cellular consent + sequential-DL guards inherited from `ModelManager.evaluateStartGates` — no duplication.

PR2 of 2 for #302. PR1 (#306, merged) shipped the typing + curation invariant + display fallback; PR2 ships the action surface.

## Why
Surfaced by the Critic Axis 7 review during #300. Users with only Qwen 3 4B downloaded who tap a Gemma-recommended scenario got no path to (a) switch, (b) download, or (c) confirm what model the simulation would run on.

## Forward-compat & device suppression
- `gallery.json` is fetched from `raw.githubusercontent.com`. An older app reading a newer feed whose `recommended_model` is unknown to its `ModelRegistry` silently degrades to PR1's "Unknown model (rawId)" display — no banner, no broken button.
- 6 GB devices (`physicalMemory < minimumRAM`) suppress all affordances + banner (Phase 2 leaves them unsupported; banner without remedy is user-hostile).
- Simulator builds suppress affordances (gallery display fallback still renders).

## Test plan
**Automated**: 15 unit tests in `RecommendedModelStatusTests` covering 8 rules + Equatable payload axes + Rule 3 vs Rule 4 precedence guard. Full suite: 1357 passed, 0 failed, 14 skipped (env-gated integrations).

**Manual QA**:
- [ ] 6-cell state matrix: active==recommended × {ready, notDownloaded, downloading} ∪ active!=recommended × {ready, notDownloaded, downloading}
- [ ] Simulation-running gate: start a sim, navigate to a scenario whose recommended ≠ active → "Switch" is disabled with gallery-specific footer hint
- [ ] Sequential-DL gate: start a Download from Settings → Models, navigate to another scenario → "Download recommended model" disabled
- [ ] Cellular gate (cellular + no prior consent): tap "Download recommended model" → scene-level confirmation dialog presents (not duplicated)
- [ ] Cellular dialog + deep link: dialog up triggered from gallery, open \`pastura://scenario/<id>\` → toast appears, no navigation under dialog
- [ ] Forward-compat unknown id: future-id like \`future-model-v9\` → "Unknown model (future-model-v9)" display, no buttons
- [ ] Unsupported-device suppression: on 6 GB device → display only, no affordances
- [ ] Switch happy path: Gemma + Qwen both \`.ready\`, Qwen active, tap "Switch" on Gemma-recommended scenario → Active badge moves, banner disappears

Closes #302