### PR TITLE
🐛 fix: hookSpecificOutput schema in .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -71,7 +71,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd $(git rev-parse --show-toplevel) && git diff main...HEAD --name-only | grep -q CLAUDE.md || echo '{\"hookSpecificOutput\":{\"warning\":\"CLAUDE.md not modified in this branch. Check if implementation progress needs updating.\"}}'"
+            "command": "cd $(git rev-parse --show-toplevel) && git diff main...HEAD --name-only | grep -q CLAUDE.md || echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"CLAUDE.md not modified in this branch. Check if implementation progress needs updating.\"}}'"
           }
         ]
       }
@@ -82,7 +82,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo '{\"hookSpecificOutput\":{\"additionalContext\":\"Reminder: This is Pastura (Swift/iOS). Follow CLAUDE.md hard rules. No force unwrap (!), no Engine→Data imports, TDD mandatory for Engine/LLM layers.\"}}'"
+            "command": "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"SessionStart\",\"additionalContext\":\"Reminder: This is Pastura (Swift/iOS). Follow CLAUDE.md hard rules. No force unwrap (!), no Engine→Data imports, TDD mandatory for Engine/LLM layers.\"}}'"
           }
         ]
       }
@@ -93,7 +93,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo '{\"hookSpecificOutput\":{\"additionalContext\":\"Before exiting: (1) Check if any memory files need to be created or updated based on this session. (2) Share any concerns, observations, or suggestions you noticed during this session but did not have a chance to mention.\"}}'"
+            "command": "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"Before exiting: (1) Check if any memory files need to be created or updated based on this session. (2) Share any concerns, observations, or suggestions you noticed during this session but did not have a chance to mention.\"}}'"
           }
         ]
       },


### PR DESCRIPTION
## Summary
- `/compact` triggered `Hook JSON output validation failed — hookSpecificOutput is missing required field "hookEventName"`. Three hooks in `.claude/settings.json` emitted JSON missing the required `hookEventName` field per [official schema](https://code.claude.com/docs/en/hooks).
- Added `hookEventName` to `SessionStart:compact`, `PostToolUse:ExitWorktree`, and `PreToolUse:Bash(gh pr create*)`.
- Replaced the invalid `"warning"` field in `PreToolUse:Bash(gh pr create*)` with `additionalContext`, mirroring prior fix #29 that addressed the same issue in `PostToolUse:ExitWorktree`.

## Test plan
- [x] `jq . .claude/settings.json` — JSON syntax valid
- [x] Each hook command piped through `bash | jq .` — emits valid JSON with `hookEventName` matching the parent event key
- [x] Code review (Opus): PASS, 0 critical / 0 warning
- [ ] Post-merge: run `/compact` and confirm no validation error
- [ ] Post-merge: run `gh pr create` from a CLAUDE.md-clean branch and confirm advisory `additionalContext` surfaces (vs. silent failure)

Closes #316