### PR TITLE
♻️ refactor: introduce GameHeaderRound value-type wrapper (#313)

### DIFF
--- a/Pastura/Pastura/App/ReplayViewModel.swift
+++ b/Pastura/Pastura/App/ReplayViewModel.swift
@@ -268,6 +268,23 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
     return cachedTotalPhaseCount > 0 ? cachedTotalPhaseCount : nil
   }
 
+  /// Round-counter pair for `GameHeader`'s row-2 ROUND fragment.
+  /// Re-uses ``currentPhaseIndex`` and ``totalPhaseCount`` so the
+  /// pair-or-nothing semantic is satisfied automatically: both are
+  /// gated on `.playing` AND a positive backing value, so the wrapper
+  /// collapses to `nil` whenever either piece is missing — including
+  /// the brief post-`start()` window where `cachedTotalPhaseCount` has
+  /// pre-computed but `phaseProgress` is still `0` (no `.phaseStarted`
+  /// consumed yet).
+  ///
+  /// Demo's call site passes `viewModel.headerRound` directly into
+  /// `GameHeader.init` instead of the pre-#313 two-Optional-Int form.
+  var headerRound: GameHeaderRound? {
+    guard let current = currentPhaseIndex, let total = totalPhaseCount
+    else { return nil }
+    return GameHeaderRound(current: current, total: total)
+  }
+
   /// `GameHeaderStatus` for the trailing pill. `.demoing` while
   /// playing or in the brief `.transitioning` fade; `.paused` while
   /// paused (any reason). `.idle` defaults to `.demoing` —

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -228,6 +228,20 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     return .simulating
   }
 
+  /// Round-counter pair for `GameHeader`'s row-2 ROUND fragment.
+  /// `nil` until the first `.roundStarted` event lands (`totalRounds`
+  /// stays at its initial `0` until then), so the fragment doesn't
+  /// flash a stale `0/0` between scenario load and first round.
+  ///
+  /// The pair-or-nothing invariant lives here — at the source of truth
+  /// for round state — rather than at the call site. `SimulationView`
+  /// passes `viewModel.headerRound` directly into `GameHeader.init`
+  /// without re-deriving the guard.
+  var headerRound: GameHeaderRound? {
+    guard totalRounds > 0 else { return nil }
+    return GameHeaderRound(current: currentRound, total: totalRounds)
+  }
+
   // MARK: - Background continuation state
 
   /// Whether the user has enabled background simulation continuation.

--- a/Pastura/Pastura/Views/Components/GameHeader.swift
+++ b/Pastura/Pastura/Views/Components/GameHeader.swift
@@ -35,12 +35,10 @@ public struct GameHeader: View {
   /// Always-visible trailing pill. See `GameHeaderStatus` for the
   /// 7-case shape and color groupings.
   public let status: GameHeaderStatus
-  /// Round-counter numerator. ROUND fragment renders only when both
-  /// `currentRound` and `totalRounds` are non-nil.
-  public let currentRound: Int?
-  /// Round-counter denominator. ROUND fragment renders only when
-  /// both `currentRound` and `totalRounds` are non-nil.
-  public let totalRounds: Int?
+  /// Round-counter pair. ROUND fragment renders only when non-nil;
+  /// the pair-or-nothing semantic is enforced by `GameHeaderRound`
+  /// itself (#313) so callers cannot construct a partial pair.
+  public let round: GameHeaderRound?
   /// Current phase label — already-localized display string from the
   /// caller (e.g., `"発言ラウンド 1"`). Nil hides the phase fragment.
   public let phaseLabel: String?
@@ -57,8 +55,7 @@ public struct GameHeader: View {
     scenarioName: String?,
     initialName: String? = nil,
     status: GameHeaderStatus,
-    currentRound: Int? = nil,
-    totalRounds: Int? = nil,
+    round: GameHeaderRound? = nil,
     phaseLabel: String? = nil,
     tokensPerSecond: Double? = nil,
     extendsIntoTopSafeArea: Bool = false
@@ -66,8 +63,7 @@ public struct GameHeader: View {
     self.scenarioName = scenarioName
     self.initialName = initialName
     self.status = status
-    self.currentRound = currentRound
-    self.totalRounds = totalRounds
+    self.round = round
     self.phaseLabel = phaseLabel
     self.tokensPerSecond = tokensPerSecond
     self.extendsIntoTopSafeArea = extendsIntoTopSafeArea
@@ -105,9 +101,7 @@ public struct GameHeader: View {
   /// Whether row 2 has any visible fragment. Row collapses entirely
   /// when none of ROUND / phase / tok/s is present.
   private var hasMetaRow: Bool {
-    (currentRound != nil && totalRounds != nil)
-      || phaseLabel != nil
-      || tokensPerSecond != nil
+    round != nil || phaseLabel != nil || tokensPerSecond != nil
   }
 
   /// Combined accessibility label so VoiceOver reads the header as
@@ -118,8 +112,8 @@ public struct GameHeader: View {
   private var accessibilityLabelText: String {
     var parts: [String] = [status.label]
     if !displayedTitle.isEmpty { parts.append(displayedTitle) }
-    if let currentRound, let totalRounds {
-      parts.append(Self.formatRoundLabel(current: currentRound, total: totalRounds))
+    if let round {
+      parts.append(Self.formatRoundLabel(current: round.current, total: round.total))
     }
     if let phaseLabel { parts.append(phaseLabel) }
     if let tokensPerSecond {
@@ -176,8 +170,8 @@ public struct GameHeader: View {
   @ViewBuilder
   private var metaRow: some View {
     HStack(alignment: .center, spacing: Self.metaRowSpacing) {
-      if let currentRound, let totalRounds {
-        Text(Self.formatRoundLabel(current: currentRound, total: totalRounds))
+      if let round {
+        Text(Self.formatRoundLabel(current: round.current, total: round.total))
           .textStyle(Typography.metaRound)
           .foregroundStyle(Color.mossDark)
           .monospacedDigit()
@@ -250,8 +244,7 @@ private struct GameHeaderTopSafeAreaExtension: ViewModifier {
     GameHeader(
       scenarioName: "ワードウルフ",
       status: .demoing,
-      currentRound: 1,
-      totalRounds: 4,
+      round: GameHeaderRound(current: 1, total: 4),
       phaseLabel: "個別発言",
       extendsIntoTopSafeArea: true
     )
@@ -265,8 +258,7 @@ private struct GameHeaderTopSafeAreaExtension: ViewModifier {
     GameHeader(
       scenarioName: "囚人のジレンマ",
       status: .simulating,
-      currentRound: 2,
-      totalRounds: 5,
+      round: GameHeaderRound(current: 2, total: 5),
       phaseLabel: "negotiation",
       tokensPerSecond: 16.5
     )
@@ -280,8 +272,7 @@ private struct GameHeaderTopSafeAreaExtension: ViewModifier {
     GameHeader(
       scenarioName: "囚人のジレンマ",
       status: .paused,
-      currentRound: 2,
-      totalRounds: 5,
+      round: GameHeaderRound(current: 2, total: 5),
       phaseLabel: "negotiation",
       tokensPerSecond: 12.3
     )
@@ -295,8 +286,7 @@ private struct GameHeaderTopSafeAreaExtension: ViewModifier {
     GameHeader(
       scenarioName: "囚人のジレンマ",
       status: .completed,
-      currentRound: 5,
-      totalRounds: 5,
+      round: GameHeaderRound(current: 5, total: 5),
       phaseLabel: "scoreboard"
     )
     Spacer()

--- a/Pastura/Pastura/Views/Components/GameHeaderRound.swift
+++ b/Pastura/Pastura/Views/Components/GameHeaderRound.swift
@@ -1,0 +1,34 @@
+/// Round-counter pair consumed by `GameHeader`'s row-2 ROUND fragment.
+///
+/// Wraps the `current` / `total` integers as a single optional value so the
+/// pair-or-nothing semantic is encoded in the type system: a caller cannot
+/// construct "current without total" or vice versa. Replaces the previous
+/// `currentRound: Int? + totalRounds: Int?` parameters whose mutual
+/// requirement was only enforced at the test-input level (#313).
+///
+/// Lives next to `GameHeaderStatus` in `Views/Components/` because it is a
+/// presentation shape, not a domain entity — the wrapper only describes how
+/// the header should display a round counter, not what a round means in the
+/// scenario engine. If a future caller in `Engine/` or `Models/` needs
+/// round-pair semantics, lift to `Models/` then; today there is no such
+/// caller. The peer-type naming (`GameHeader<Concept>` rather than a bare
+/// `Round`) mirrors the existing `GameHeaderStatus` convention and avoids a
+/// generic-name collision in the global namespace.
+///
+/// `Sendable` is annotated ahead of need so the type can cross actor
+/// boundaries cleanly when (a) a future ViewModel-side construction path
+/// emerges, or (b) the `Views/Components/` directory is extracted into its
+/// own SPM module. Today no producer crosses isolation, but two `let Int`
+/// fields are trivially safe so the conformance is free.
+public struct GameHeaderRound: Sendable, Equatable {
+  /// Round-counter numerator (1-based; matches `formatRoundLabel`'s
+  /// `Round %lld / %lld` source key).
+  public let current: Int
+  /// Round-counter denominator.
+  public let total: Int
+
+  public init(current: Int, total: Int) {
+    self.current = current
+    self.total = total
+  }
+}

--- a/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+GameHeader.swift
+++ b/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+GameHeader.swift
@@ -16,8 +16,9 @@ import SwiftUI
 ///
 /// Demo passes:
 /// - `scenarioName` — preset display name (e.g. "ワードウルフ")
-/// - ROUND fragment — pseudo `currentPhaseIndex` / `totalPhaseCount`
-///   from `ReplayViewModel`. Demo's preset scenarios use a single
+/// - `round` — `viewModel.headerRound` (`GameHeaderRound?`). The
+///   pseudo-ROUND derives from `currentPhaseIndex` / `totalPhaseCount`
+///   inside the VM (#313). Demo's preset scenarios use a single
 ///   game-round across multiple phases, so the real `currentRound`
 ///   sits at 1/1 the whole time; the pseudo-ROUND walks every phase
 ///   for visible progression.
@@ -34,8 +35,7 @@ extension ModelDownloadHostView {
     GameHeader(
       scenarioName: currentPresetName(viewModel: viewModel),
       status: viewModel.status,
-      currentRound: viewModel.currentPhaseIndex,
-      totalRounds: viewModel.totalPhaseCount,
+      round: viewModel.headerRound,
       phaseLabel: phaseDisplayLabel(viewModel: viewModel),
       tokensPerSecond: nil,
       extendsIntoTopSafeArea: true

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -293,8 +293,10 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
   /// - `scenarioName` / `initialName` — the same 3-tier fallback chain
   ///   that previously fed `.navigationTitle()`. ADR-008 §Amendment
   ///   2026-04-29 documents the sink pivot.
-  /// - `currentRound` / `totalRounds` — real game-rounds from
-  ///   `.roundStarted` events. Suppressed (nil) until the first
+  /// - `round` — `viewModel.headerRound` (`GameHeaderRound?`). Real
+  ///   game-rounds from `.roundStarted` events; the VM colocates the
+  ///   pair-or-nothing guard (`totalRounds > 0`) so the call site
+  ///   doesn't re-derive it (#313). Suppressed (nil) until the first
   ///   `.roundStarted` lands so the ROUND fragment doesn't flash a
   ///   stale `0/0` between scenario load and first round.
   /// - `phaseLabel` — formatted from `viewModel.currentPhase`.
@@ -311,8 +313,7 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
       scenarioName: scenario?.name,
       initialName: initialName,
       status: viewModel.status,
-      currentRound: viewModel.totalRounds > 0 ? viewModel.currentRound : nil,
-      totalRounds: viewModel.totalRounds > 0 ? viewModel.totalRounds : nil,
+      round: viewModel.headerRound,
       phaseLabel: Self.phaseDisplayLabel(for: viewModel.currentPhase),
       tokensPerSecond: viewModel.averageTokensPerSecond,
       extendsIntoTopSafeArea: false

--- a/Pastura/PasturaTests/App/ReplayViewModelTests+PhaseProgression.swift
+++ b/Pastura/PasturaTests/App/ReplayViewModelTests+PhaseProgression.swift
@@ -226,4 +226,41 @@ extension ReplayViewModelTests {
     #expect(viewModel.currentPhaseIndex == nil || viewModel.currentPhaseIndex == 1)
     #expect(viewModel.status == .demoing)
   }
+
+  // MARK: - headerRound (GameHeader pair wrapper, #313)
+
+  @Test func headerRoundIsNilPreStart() throws {
+    let viewModel = try Self.makeVM()
+    #expect(viewModel.headerRound == nil)
+  }
+
+  @Test func headerRoundIsNilBetweenStartAndFirstPhaseStarted() async throws {
+    // `start()` sets `cachedTotalPhaseCount` synchronously but
+    // `phaseProgress` stays at `0` until the playback task consumes
+    // the first `.phaseStarted`. The wrapper must collapse to nil in
+    // that intermediate window — proving it doesn't leak a partial
+    // pair (`current: nil, total: 1`) to the GameHeader.
+    let viewModel = try Self.makeVM()
+    viewModel.start()
+    // totalPhaseCount is non-nil immediately, but currentPhaseIndex
+    // is still nil → headerRound must be nil.
+    #expect(viewModel.totalPhaseCount == 1)
+    #expect(viewModel.currentPhaseIndex == nil)
+    #expect(viewModel.headerRound == nil)
+  }
+
+  @Test func headerRoundReflectsPhaseConsumption() async throws {
+    let viewModel = try Self.makeVM()
+    viewModel.start()
+    await Self.waitForCondition { viewModel.currentPhaseIndex != nil }
+    #expect(viewModel.headerRound == GameHeaderRound(current: 1, total: 1))
+  }
+
+  @Test func headerRoundIsNilDuringPause() async throws {
+    let viewModel = try Self.makeVM()
+    viewModel.start()
+    await Self.waitForCondition { viewModel.currentPhaseIndex != nil }
+    viewModel.userPause()
+    #expect(viewModel.headerRound == nil)
+  }
 }

--- a/Pastura/PasturaTests/App/SimulationViewModelTests+HeaderRound.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelTests+HeaderRound.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+// `headerRound` GameHeader-integration tests for `SimulationViewModel`
+// (#313). Sibling-file extension of `SimulationViewModelTests` per
+// `.claude/rules/testing.md` — splitting to a fresh `@Suite` would race
+// against the parent suite on shared state (in-memory DB seed, etc.).
+extension SimulationViewModelTests {
+
+  // MARK: - headerRound (GameHeader integration)
+
+  @Test func headerRoundIsNilBeforeRoundStarted() throws {
+    // Pre-`.roundStarted`, `totalRounds == 0` (the initial value), so
+    // the pair-or-nothing guard suppresses the ROUND fragment. Pinning
+    // this prevents a regression where the stored 0/0 leaks into the
+    // header.
+    let (sut, _) = try makeSUT()
+    #expect(sut.headerRound == nil)
+  }
+
+  @Test func headerRoundReflectsRoundStartedEvent() throws {
+    let (sut, scenario) = try makeSUT()
+
+    sut.handleEvent(.roundStarted(round: 1, totalRounds: 3), scenario: scenario)
+
+    #expect(sut.headerRound == GameHeaderRound(current: 1, total: 3))
+  }
+
+  @Test func headerRoundUpdatesAcrossMultipleRounds() throws {
+    let (sut, scenario) = try makeSUT()
+
+    sut.handleEvent(.roundStarted(round: 1, totalRounds: 3), scenario: scenario)
+    sut.handleEvent(.roundStarted(round: 2, totalRounds: 3), scenario: scenario)
+
+    #expect(sut.headerRound == GameHeaderRound(current: 2, total: 3))
+  }
+}

--- a/Pastura/PasturaTests/App/SimulationViewModelTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelTests.swift
@@ -6,8 +6,12 @@ import Testing
 // MARK: - Test Helpers
 
 /// Creates a configured SimulationViewModel for testing with in-memory DB.
+///
+/// Internal (not `private`) so sibling-file extensions of
+/// `SimulationViewModelTests` can call it. See
+/// `.claude/rules/testing.md` § "Splitting a Suite Across Files".
 @MainActor
-private func makeSUT(
+func makeSUT(
   contentFilter: ContentFilter = ContentFilter(blockedPatterns: ["badword"])
 ) throws -> (sut: SimulationViewModel, scenario: Scenario) {
   let db = try DatabaseManager.inMemory()
@@ -379,32 +383,5 @@ struct SimulationViewModelTests {
 
     #expect(sut.isPaused == false, "Guard should prevent isPaused mutation")
     #expect(sut.logEntries.isEmpty, "Guard should prevent reason from being logged")
-  }
-
-  // MARK: - headerRound (GameHeader integration)
-
-  @Test func headerRoundIsNilBeforeRoundStarted() throws {
-    // Pre-`.roundStarted`, `totalRounds == 0` (the initial value), so the
-    // pair-or-nothing guard suppresses the ROUND fragment. Pinning this
-    // prevents a regression where the stored 0/0 leaks into the header.
-    let (sut, _) = try makeSUT()
-    #expect(sut.headerRound == nil)
-  }
-
-  @Test func headerRoundReflectsRoundStartedEvent() throws {
-    let (sut, scenario) = try makeSUT()
-
-    sut.handleEvent(.roundStarted(round: 1, totalRounds: 3), scenario: scenario)
-
-    #expect(sut.headerRound == GameHeaderRound(current: 1, total: 3))
-  }
-
-  @Test func headerRoundUpdatesAcrossMultipleRounds() throws {
-    let (sut, scenario) = try makeSUT()
-
-    sut.handleEvent(.roundStarted(round: 1, totalRounds: 3), scenario: scenario)
-    sut.handleEvent(.roundStarted(round: 2, totalRounds: 3), scenario: scenario)
-
-    #expect(sut.headerRound == GameHeaderRound(current: 2, total: 3))
   }
 }

--- a/Pastura/PasturaTests/App/SimulationViewModelTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelTests.swift
@@ -380,4 +380,31 @@ struct SimulationViewModelTests {
     #expect(sut.isPaused == false, "Guard should prevent isPaused mutation")
     #expect(sut.logEntries.isEmpty, "Guard should prevent reason from being logged")
   }
+
+  // MARK: - headerRound (GameHeader integration)
+
+  @Test func headerRoundIsNilBeforeRoundStarted() throws {
+    // Pre-`.roundStarted`, `totalRounds == 0` (the initial value), so the
+    // pair-or-nothing guard suppresses the ROUND fragment. Pinning this
+    // prevents a regression where the stored 0/0 leaks into the header.
+    let (sut, _) = try makeSUT()
+    #expect(sut.headerRound == nil)
+  }
+
+  @Test func headerRoundReflectsRoundStartedEvent() throws {
+    let (sut, scenario) = try makeSUT()
+
+    sut.handleEvent(.roundStarted(round: 1, totalRounds: 3), scenario: scenario)
+
+    #expect(sut.headerRound == GameHeaderRound(current: 1, total: 3))
+  }
+
+  @Test func headerRoundUpdatesAcrossMultipleRounds() throws {
+    let (sut, scenario) = try makeSUT()
+
+    sut.handleEvent(.roundStarted(round: 1, totalRounds: 3), scenario: scenario)
+    sut.handleEvent(.roundStarted(round: 2, totalRounds: 3), scenario: scenario)
+
+    #expect(sut.headerRound == GameHeaderRound(current: 2, total: 3))
+  }
 }

--- a/Pastura/PasturaTests/Views/GameHeaderContractTests.swift
+++ b/Pastura/PasturaTests/Views/GameHeaderContractTests.swift
@@ -90,31 +90,29 @@ struct GameHeaderContractTests {
 
   @Test func acceptsAllNilMetaInputs() {
     // Pin the contract: caller can pass nil for every row-2 slot
-    // without crashing. The view will render only row 1.
+    // without crashing. The view will render only row 1. After #313
+    // the ROUND fragment is gated on a single `round: GameHeaderRound?`,
+    // so the partial-pair test (`currentRound` without `totalRounds`)
+    // became unrepresentable and was removed.
     let header = GameHeader(
       scenarioName: "X", status: .completed,
-      currentRound: nil, totalRounds: nil,
-      phaseLabel: nil, tokensPerSecond: nil
+      round: nil, phaseLabel: nil, tokensPerSecond: nil
     )
     #expect(header.scenarioName == "X")
-    #expect(header.currentRound == nil)
-    #expect(header.totalRounds == nil)
+    #expect(header.round == nil)
     #expect(header.phaseLabel == nil)
     #expect(header.tokensPerSecond == nil)
   }
 
-  // MARK: - Partial ROUND inputs (one of currentRound/totalRounds nil)
+  // MARK: - Round wrapper round-trip (#313)
 
-  @Test func acceptsCurrentRoundWithoutTotalRounds() {
-    // Documented behavior: `formatRoundLabel` is only called when both
-    // are non-nil. Passing one without the other doesn't crash; the
-    // ROUND fragment is suppressed. Pinned at the input level here;
-    // visual suppression is verified manually.
+  @Test func roundWrapperRoundTripsThroughInit() {
+    // Pin the contract that `init`'s `round` parameter survives
+    // unchanged onto the public `round` property.
     let header = GameHeader(
       scenarioName: "X", status: .simulating,
-      currentRound: 2, totalRounds: nil
+      round: GameHeaderRound(current: 2, total: 5)
     )
-    #expect(header.currentRound == 2)
-    #expect(header.totalRounds == nil)
+    #expect(header.round == GameHeaderRound(current: 2, total: 5))
   }
 }

--- a/Pastura/PasturaTests/Views/GameHeaderRoundTests.swift
+++ b/Pastura/PasturaTests/Views/GameHeaderRoundTests.swift
@@ -1,0 +1,36 @@
+import Testing
+
+@testable import Pastura
+
+@MainActor
+@Suite(.timeLimit(.minutes(1)))
+struct GameHeaderRoundTests {
+
+  // MARK: - Equatable semantics (synthesized)
+
+  @Test func identicalPairsAreEqual() {
+    let lhs = GameHeaderRound(current: 2, total: 5)
+    let rhs = GameHeaderRound(current: 2, total: 5)
+    #expect(lhs == rhs)
+  }
+
+  @Test func differingCurrentBreaksEquality() {
+    #expect(GameHeaderRound(current: 1, total: 5) != GameHeaderRound(current: 2, total: 5))
+  }
+
+  @Test func differingTotalBreaksEquality() {
+    #expect(GameHeaderRound(current: 2, total: 5) != GameHeaderRound(current: 2, total: 6))
+  }
+
+  // MARK: - Field accessibility
+
+  @Test func currentAndTotalAreReadable() {
+    // Pin the public field shape — `current` and `total` (singular pair),
+    // not `currentRound` / `totalRounds` (the source caller's plural names).
+    // The wrapper deliberately drops the "Round" suffix from each field
+    // because the surrounding type already names the concept.
+    let round = GameHeaderRound(current: 3, total: 7)
+    #expect(round.current == 3)
+    #expect(round.total == 7)
+  }
+}


### PR DESCRIPTION
## Summary

- Replaces `GameHeader`'s `currentRound: Int? + totalRounds: Int?` pair with a single `round: GameHeaderRound?` so the pair-or-nothing semantic is type-enforced — partial pairs become unrepresentable at the call-site.
- Adds `headerRound: GameHeaderRound?` computed properties on `SimulationViewModel` and `ReplayViewModel`, colocating the pair-or-nothing guard with each VM's source of truth (extends #313's literal scope per critic's Top Action #1 — completes the invariant lift the issue begins).
- Naming deviates from the issue's literal `Round` proposal: uses `GameHeaderRound` to match the existing `GameHeaderStatus` peer-type convention and avoid global-namespace collision (a future Engine/Models `Round` primitive would otherwise be forced to disambiguate).

## Test plan

- [x] New `GameHeaderRoundTests` — 4 tests pinning `Equatable` synthesis + field shape (`current` / `total`, singular pair).
- [x] New tests in `SimulationViewModelTests+HeaderRound` (3) and `ReplayViewModelTests+PhaseProgression` (4) covering: pre-start `nil`, partial-pair intermediate window (Replay only — `cachedTotalPhaseCount` set but `phaseProgress == 0`), populated value, paused `nil`.
- [x] Updated `GameHeaderContractTests` — `acceptsAllNilMetaInputs` survives, `roundWrapperRoundTripsThroughInit` replaces the deleted `acceptsCurrentRoundWithoutTotalRounds` (partial-pair is unrepresentable post-refactor).
- [x] Full unit test suite — 1450 tests, 0 failures.
- [x] `swiftlint lint --strict` clean (no errors / no new warnings).
- [x] Manual: launch Sim, verify ROUND fragment renders post first `.roundStarted` (no `0/0` flash between scenario load and first round).
- [x] Manual: launch DL-time demo, verify pseudo-ROUND walks each phase.
- [x] Manual: VoiceOver header read still includes `Round X / Y` fragment when applicable.

## Notes

- `SimulationViewModelTests.swift` crossed the 400-line `file_length` cap when the headerRound tests landed in commit 2 (the pre-commit lint hook didn't catch it on that commit — to be investigated separately). Commit 4 splits those tests into a sibling-extension file (`SimulationViewModelTests+HeaderRound.swift`) per `.claude/rules/testing.md` and widens the `makeSUT` helper from `private` to internal so the extension can call it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #313.