### PR TITLE
🔍 ci: tighten i18n tripwire regex to reject == comparisons

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -46,7 +46,7 @@ custom_rules:
   # alternation. See `docs/i18n/leak-detection.md` for the full architecture.
   unwrapped_user_facing_string:
     name: "Unwrapped user-facing String"
-    regex: '(errorMessage|validationErrors|alertMessage|toastMessage|nameError|descriptionError|conditionError|promptError|outcomeAlert|deepLinkError)\s*[+=]+\s*\[?\s*"[^"]+"'
+    regex: '(errorMessage|validationErrors|alertMessage|toastMessage|nameError|descriptionError|conditionError|promptError|outcomeAlert|deepLinkError)\s*(?:=|\+=)\s*\[?\s*"[^"]+"'
     included:
       - 'Pastura/Pastura/.*\.swift'
     severity: warning

--- a/docs/i18n/leak-detection.md
+++ b/docs/i18n/leak-detection.md
@@ -34,7 +34,7 @@ The rule fires on the regex shape
 ```
 (errorMessage|validationErrors|alertMessage|toastMessage|nameError
  |descriptionError|conditionError|promptError|outcomeAlert|deepLinkError)
-\s*[+=]+\s*\[?\s*"[^"]+"
+\s*(?:=|\+=)\s*\[?\s*"[^"]+"
 ```
 
 against any file under `Pastura/Pastura/`. The 10 property names are an


### PR DESCRIPTION
## Summary
- Tighten the `unwrapped_user_facing_string` SwiftLint rule's operator class from `[+=]+` to `(?:=|\+=)` so a future `propname == "Foo"` comparison cannot falsely fire the tripwire.
- Sync the embedded regex snippet in `docs/i18n/leak-detection.md` so the doc remains the source of truth for contributors extending the alternation.

Codebase has zero current `==` sites against the alternation property names, so this is purely defensive — no in-flight false positives.

Tier 2 (real-leak triage incl. `SimulationView.swift` `loadError = "Scenario not found"`) deferred to a follow-up issue per "Tier 1 のみ" scope. Note: the issue body references line 535 for that leak; current line is 560.

Part of #311.

## Test plan
- [x] `swiftlint lint --strict` clean on this branch (no new false positives)
- [x] Positive test — temporary `errorMessage = "leak_probe"` insertion fires `unwrapped_user_facing_string` violation
- [x] Anti-FP test — temporary `if errorMessage == "..."` insertion does NOT fire under the new regex
- [x] Pre-commit hook (`swiftlint lint --strict` + `xcodebuild build`) passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)