### PR TITLE
✨ feat: gallery curation tooling — add/check scripts + drift gates

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -63,6 +63,10 @@
           {
             "type": "command",
             "command": "bash $(git rev-parse --show-toplevel)/scripts/blocklist-precommit-gate.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash $(git rev-parse --show-toplevel)/scripts/gallery-precommit-gate.sh"
           }
         ]
       },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,6 +365,28 @@ jobs:
       - name: Run blocklist drift guard
         run: bash scripts/build-blocklist.sh --check
 
+  gallery-drift:
+    name: Gallery drift guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # jq + shasum are pre-installed on ubuntu-latest. PyYAML is the
+      # only third-party dep — pin major to keep the install
+      # deterministic. The script's --all mode validates yaml_sha256
+      # byte-match, size cap (256 KiB), id uniqueness across
+      # gallery.json + bundled presets, and filename-stem == id. No
+      # `|| true` wrapper — any failure must fail the job so merge-time
+      # drift cannot land silently. (GallerySeedYAMLTests inside the
+      # iOS test target is the second line of defense.)
+      - name: Install PyYAML
+        run: python3 -m pip install --quiet 'pyyaml>=6,<7'
+
+      - name: Run gallery drift guard
+        run: bash scripts/check-gallery-entry.sh --all
+
   localization-coverage:
     name: Localization coverage (ja 100%)
     runs-on: ubuntu-latest

--- a/Pastura/PasturaTests/App/Community/Gallery/GallerySeedYAMLTests.swift
+++ b/Pastura/PasturaTests/App/Community/Gallery/GallerySeedYAMLTests.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 import Testing
 
@@ -74,6 +75,42 @@ import Testing
         gallery.title (\(entry.title)) != yaml.name (\(scenario.name)) \
         for entry id=\(entry.id). \
         See ADR-008 — Route.scenarioDetail.initialName depends on this match.
+        """)
+    }
+  }
+
+  /// Pins the curation invariant that every gallery entry's
+  /// `yaml_sha256` matches the byte-level SHA-256 of the YAML file at
+  /// `yamlURL`. A drifted hash silently ships and fails at install
+  /// time on user devices ("YAML hash mismatch") because
+  /// `URLSessionGalleryService` rejects body-vs-hash mismatches before
+  /// any partial write reaches the local DB. Catching the drift here
+  /// — at PR CI time — closes the hole that `--no-verify` commits and
+  /// GitHub-UI merges leave open in the script-side pre-commit gate.
+  @Test func galleryYAMLHashMatchesIndex() throws {
+    let galleryDir = Self.repoRoot().appendingPathComponent("docs/gallery")
+    let indexURL = galleryDir.appendingPathComponent("gallery.json")
+    let indexData = try Data(contentsOf: indexURL)
+    let index = try JSONDecoder().decode(GalleryIndex.self, from: indexData)
+
+    #expect(!index.scenarios.isEmpty, "gallery.json has no scenarios")
+
+    for entry in index.scenarios {
+      let yamlPath =
+        galleryDir
+        .appendingPathComponent(entry.yamlURL.lastPathComponent)
+      let yamlData = try Data(contentsOf: yamlPath)
+      let actualHex =
+        SHA256.hash(data: yamlData)
+        .map { String(format: "%02x", $0) }
+        .joined()
+      #expect(
+        actualHex == entry.yamlSHA256,
+        """
+        gallery.json entry id=\(entry.id) yaml_sha256=\(entry.yamlSHA256) \
+        does not match SHA-256 of \(entry.yamlURL.lastPathComponent) \
+        (actual=\(actualHex)). Run scripts/check-gallery-entry.sh --all \
+        to identify drifted entries.
         """)
     }
   }

--- a/docs/gallery/README.md
+++ b/docs/gallery/README.md
@@ -55,13 +55,18 @@ new case to the Swift enum before shipping a JSON that uses it.
 
 Gallery scenario ids **MUST NOT** collide with:
 
-- Bundled presets: `prisoners_dilemma`, `bokete`, `word_wolf`.
+- Bundled presets — see `Pastura/Pastura/App/PresetLoader.swift`
+  `presetFileNames` for the current list (each entry's stem is the
+  scenario id). `scripts/check-gallery-entry.sh` enumerates this
+  directory at runtime and fails the commit on collision, so this
+  README does not need to track additions to the bundle.
 - Any other gallery scenario id, current or historical.
 
 The iOS app refuses to install a gallery scenario whose id matches an
 existing local row with a different source. The fix is to rename the
-gallery scenario (append `_v2`, `_alt`, etc.), regenerate its hash, and
-update `gallery.json`.
+gallery scenario (append `_v2`, `_alt`, etc.) and re-run
+`scripts/add-gallery-entry.sh` (or, when editing `gallery.json` by
+hand, regenerate the SHA-256 and update the entry).
 
 ### Suffix versioning
 
@@ -81,30 +86,94 @@ Gallery scenarios are public and curator-endorsed. Keep content:
 
 ## Adding a scenario
 
-1. Draft a YAML following the existing examples. Keep it under 256 KiB
-   (the app's per-YAML size cap).
-2. Pick a unique id per the rules above.
-3. Commit the YAML to `docs/gallery/<id>.yaml`.
-4. Compute the SHA-256:
-   ```sh
-   shasum -a 256 docs/gallery/<id>.yaml
-   ```
-5. Add an entry to `gallery.json` with the hash, URL, and metadata.
-6. **Run end-to-end before merging.** Push the feature branch, run a
-   Debug build (so `PASTURA_GALLERY_BASE_URL` takes effect — see *Testing
-   changes from a feature branch* below), and open the scenario from
-   Share Board. Either (a) on a physical device with the bundled
-   llama.cpp model already downloaded, or (b) in the iOS Simulator
-   pointing at a local Ollama with the recommended model pulled. Run a
-   full simulation and read the output. Confirm: rounds reach a
-   meaningful conclusion (no truncation), agent personas come through
-   clearly, and total inferences match the `estimated_inferences`
-   ballpark. (Content-filter triggers are an authoring-time concern —
-   see the *Content guidelines* bullet above and
-   `App/ContentFilter.swift`.)
-7. Open a PR. The scenario becomes available in the app after merge —
-   the app uses ETag-conditional GET, so users pick up the update on
-   their next Share Board visit.
+### 1. Draft the YAML
+
+Write `docs/gallery/<id>.yaml` following the existing examples. Keep
+it under 256 KiB (the app's per-YAML size cap, enforced by both the
+add script and `URLSessionGalleryService.yamlSizeLimit`). Pick an id
+that satisfies *Globally unique scenario ids* above; the file stem
+**must** equal the YAML's `id:` field — the gallery resolver
+round-trips on `yaml_url.lastPathComponent → file`, and the add
+script refuses a stem-vs-id mismatch.
+
+### 2. Run `scripts/add-gallery-entry.sh`
+
+```sh
+bash scripts/add-gallery-entry.sh docs/gallery/<id>.yaml
+```
+
+The script:
+
+- Parses `id`, `name`, `description` from the YAML.
+- Computes `shasum -a 256` and emits the canonical hex.
+- Bumps top-level `updated_at` to today (UTC, midnight) — guarded by a
+  `max(now, existing)` monotonicity check that warns on backward clock
+  skew.
+- Prompts for the four non-derivable fields, with choice lists read
+  from the Swift sources at runtime so this README does not duplicate
+  enums or model-registry contents:
+  - `category` — see `GalleryCategory.allCases` in
+    `Pastura/Pastura/Models/GalleryScenario.swift`
+  - `recommended_model` — see `ModelRegistry.catalog` in
+    `Pastura/Pastura/App/ModelRegistry.swift`
+  - `estimated_inferences` — positive integer (rough total LLM calls)
+  - `added_at` — defaults to today, override with `--added-at YYYY-MM-DD`
+- Writes `gallery.json` atomically (tmp + mv) and re-runs
+  `scripts/check-gallery-entry.sh --all` as a post-write gate. Any
+  failure restores the byte-identical original.
+
+`bash scripts/add-gallery-entry.sh --help` prints the full flag list
+including `--non-interactive` (CI scripting) and `--description`
+(override the YAML's description for a shorter card-friendly summary).
+
+### 3. Run the scenario end-to-end before merging
+
+Push the feature branch, run a Debug build (so
+`PASTURA_GALLERY_BASE_URL` takes effect — see *Testing changes from a
+feature branch* below), and open the scenario from Share Board.
+Either (a) on a physical device with the bundled llama.cpp model
+already downloaded, or (b) in the iOS Simulator pointing at a local
+Ollama with the recommended model pulled. Run a full simulation and
+read the output. Confirm: rounds reach a meaningful conclusion (no
+truncation), agent personas come through clearly, and total
+inferences match the `estimated_inferences` ballpark.
+(Content-filter triggers are an authoring-time concern — see the
+*Content guidelines* bullet above and `App/ContentFilter.swift`.)
+
+### 4. Open a PR
+
+The scenario becomes available in the app after merge — the app uses
+ETag-conditional GET, so users pick up the update on their next Share
+Board visit.
+
+### What enforces this contract
+
+Three independent gates catch drift between the YAML and its
+`gallery.json` entry:
+
+1. **`scripts/check-gallery-entry.sh`** — runs as a pre-commit hook
+   when the staged diff touches `docs/gallery/<id>.yaml` or
+   `gallery.json`. Validates SHA-256 byte-match, size cap, id
+   uniqueness across `gallery.json` + bundled presets, and
+   `<stem>.yaml ↔ id: <stem>`.
+2. **CI `gallery-drift` job** — re-runs the same check on every PR
+   (catches `--no-verify` commits and PRs landed via the GitHub web
+   UI that bypass the local hook).
+3. **`PasturaTests/.../GallerySeedYAMLTests.swift`** — pins the
+   yaml_sha256, title==name, recommended_model ∈ ModelRegistry, and
+   category enum invariants in the iOS test suite. Runs on every PR.
+
+### Manual fallback (when the script can't be used)
+
+If `scripts/add-gallery-entry.sh` is unavailable for some reason
+(missing PyYAML, bash unavailable, etc.), the manual flow is:
+
+1. Compute `shasum -a 256 docs/gallery/<id>.yaml | awk '{print $1}'`.
+2. Add an entry to `gallery.json` with the hash, `yaml_url:
+   <stem>.yaml`, and the four prompted fields above. Bump top-level
+   `updated_at` to today UTC at midnight (`YYYY-MM-DDT00:00:00Z`).
+3. Run `bash scripts/check-gallery-entry.sh --all` before committing —
+   it catches every error the script would have caught.
 
 ## Files in this directory
 

--- a/docs/gallery/gallery.json
+++ b/docs/gallery/gallery.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-04-29T00:00:00Z",
+  "updated_at": "2026-05-09T00:00:00Z",
   "scenarios": [
     {
       "id": "asch_conformity_v1",
@@ -47,7 +47,7 @@
       "recommended_model": "gemma-4-e2b-q4-k-m",
       "estimated_inferences": 20,
       "yaml_url": "kinoko_takenoko_v1.yaml",
-      "yaml_sha256": "3435529e567252f95c78a3020ae3d7038270296a04d0ef2a58ecba4a583c1549",
+      "yaml_sha256": "7c34fd00ab7e5e946d901664d839d91ba18a18fda987954eb5daa70aca8db785",
       "added_at": "2026-04-29"
     }
   ]

--- a/scripts/add-gallery-entry.sh
+++ b/scripts/add-gallery-entry.sh
@@ -1,0 +1,313 @@
+#!/usr/bin/env bash
+# scripts/add-gallery-entry.sh — Add a new entry to docs/gallery/gallery.json
+# safely. Eliminates the three error-prone hand-edits that PR #300 +
+# PR #318 left behind:
+#
+#   1. shasum -a 256 → copy/paste 64-hex                   (now automated)
+#   2. updated_at bump                                     (now automated)
+#   3. byte-equal gallery.json[].title == YAML name:       (now automated)
+#
+# Usage:
+#   bash scripts/add-gallery-entry.sh <yaml-path> [flags]
+#
+# Required positional:
+#   <yaml-path>                 path to docs/gallery/<id>.yaml — file
+#                                must already be committed/staged
+#
+# Optional flags (each suppresses the corresponding interactive prompt):
+#   --category <slug>           one of GalleryCategory.allCases raw
+#                                values (social_psychology, game_theory,
+#                                ethics, roleplay, creative, experimental)
+#   --recommended-model <id>    e.g. gemma-4-e2b-q4-k-m
+#   --estimated-inferences <n>  positive integer
+#   --added-at <YYYY-MM-DD>     defaults to today (UTC)
+#   --description <text>        overrides YAML description for the
+#                                gallery card (e.g. shorter summary)
+#   --author <handle>           defaults to gh api user → git config user.name
+#   --non-interactive           fail if any required field is missing
+#                                (no prompts, no confirmation)
+#
+# Failure modes — chosen behavior:
+#
+#   (a) Re-run with same id: REJECT (pre-check on .scenarios[].id).
+#       This script is for new entries; edit gallery.json directly to
+#       update an existing entry.
+#   (b) YAML id != filename stem: REJECT. The Swift gallery resolver
+#       round-trips on yaml_url.lastPathComponent → file. Rename one
+#       or the other and re-run.
+#   (c) updated_at monotonicity: bumps to max(now, existing). When
+#       local clock is behind existing (NTP rollback / CI runner skew),
+#       a stderr WARNING fires and updated_at does NOT advance — keeps
+#       monotonic ordering. Verify `date -u` if you see this.
+#   (d) Atomic write: jq writes to gallery.json.tmp; the original is
+#       moved aside, the new file installed, then check-gallery-entry.sh
+#       --all runs as a post-validate gate. Any failure restores the
+#       backup, leaving the working tree byte-identical to entry.
+#   (e) Trailing newline: jq emits a trailing newline by default,
+#       matching the existing gallery.json. Re-run does not double-newline.
+#   (f) BOM-prefixed YAML: PyYAML accepts BOM and SHA-256 is byte-level
+#       so the hash matches downloaded content. No special handling.
+#
+# Choice lists at prompts are read from the Swift sources at runtime
+# (Pastura/Pastura/Models/GalleryScenario.swift,
+# Pastura/Pastura/App/ModelRegistry.swift) so this script does not
+# duplicate the enum / registry. The Swift suite
+# (GallerySeedYAMLTests) is the enforcement mechanism — these prompts
+# are UX only and accept any string.
+
+set -euo pipefail
+
+# --- Dependency check ------------------------------------------------------
+
+for dep in jq python3 shasum awk basename date wc; do
+  if ! command -v "$dep" >/dev/null 2>&1; then
+    echo "ERROR: missing dependency: $dep" >&2
+    exit 1
+  fi
+done
+if ! python3 -c "import yaml" 2>/dev/null; then
+  echo "ERROR: PyYAML not available — install via 'python3 -m pip install pyyaml'" >&2
+  exit 1
+fi
+
+ROOT="$(git rev-parse --show-toplevel)"
+GALLERY_DIR="$ROOT/docs/gallery"
+GALLERY_JSON="$GALLERY_DIR/gallery.json"
+CHECK_SCRIPT="$ROOT/scripts/check-gallery-entry.sh"
+MAX_BYTES=$((256 * 1024))
+
+# --- Argument parsing ------------------------------------------------------
+
+YAML_PATH=""
+CATEGORY=""
+RECOMMENDED_MODEL=""
+ESTIMATED_INFERENCES=""
+ADDED_AT=""
+DESCRIPTION_OVERRIDE=""
+AUTHOR=""
+NON_INTERACTIVE=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --category) CATEGORY="$2"; shift 2 ;;
+    --recommended-model) RECOMMENDED_MODEL="$2"; shift 2 ;;
+    --estimated-inferences) ESTIMATED_INFERENCES="$2"; shift 2 ;;
+    --added-at) ADDED_AT="$2"; shift 2 ;;
+    --description) DESCRIPTION_OVERRIDE="$2"; shift 2 ;;
+    --author) AUTHOR="$2"; shift 2 ;;
+    --non-interactive) NON_INTERACTIVE=1; shift ;;
+    -h|--help) awk '/^# Usage/{p=1} /^set -/{exit} p' "$0" | sed 's/^# \?//'; exit 0 ;;
+    -*) echo "Unknown flag: $1" >&2; exit 1 ;;
+    *)
+      if [ -z "$YAML_PATH" ]; then
+        YAML_PATH="$1"
+      else
+        echo "Unexpected positional argument: $1" >&2
+        exit 1
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$YAML_PATH" ]; then
+  echo "Usage: $0 <yaml-path> [--category ...] [--recommended-model ...] ..." >&2
+  echo "       $0 --help" >&2
+  exit 1
+fi
+
+if [ ! -f "$YAML_PATH" ]; then
+  echo "ERROR: file not found: $YAML_PATH" >&2
+  exit 1
+fi
+
+YAML_PATH="$(cd "$(dirname "$YAML_PATH")" && pwd)/$(basename "$YAML_PATH")"
+YAML_BASENAME="$(basename "$YAML_PATH")"
+YAML_STEM="$(basename "$YAML_PATH" .yaml)"
+
+# --- Derive from YAML ------------------------------------------------------
+
+YAML_ID="$(python3 -c "import sys, yaml; print(yaml.safe_load(open(sys.argv[1]))['id'])" "$YAML_PATH")"
+YAML_NAME="$(python3 -c "import sys, yaml; print(yaml.safe_load(open(sys.argv[1]))['name'])" "$YAML_PATH")"
+YAML_DESC="$(python3 -c "import sys, yaml; d = yaml.safe_load(open(sys.argv[1])).get('description', ''); print((d or '').strip())" "$YAML_PATH")"
+YAML_SHA="$(shasum -a 256 "$YAML_PATH" | awk '{print $1}')"
+YAML_SIZE="$(wc -c < "$YAML_PATH" | awk '{print $1}')"
+
+if [ "$YAML_ID" != "$YAML_STEM" ]; then
+  echo "ERROR: filename stem '$YAML_STEM' does not match YAML id '$YAML_ID'." >&2
+  echo "       Rename one or the other so the gallery resolver's round-trip works." >&2
+  exit 1
+fi
+
+if [ "$YAML_SIZE" -gt "$MAX_BYTES" ]; then
+  echo "ERROR: YAML size ${YAML_SIZE} bytes exceeds 256 KiB cap (URLSessionGalleryService.yamlSizeLimit)" >&2
+  exit 1
+fi
+
+# --- Pre-check: refuse if id already in gallery.json -----------------------
+
+EXISTING="$(jq -r --arg id "$YAML_ID" '.scenarios[] | select(.id == $id) | .id' "$GALLERY_JSON")"
+if [ -n "$EXISTING" ]; then
+  echo "ERROR: id '$YAML_ID' already exists in gallery.json." >&2
+  echo "       This script is for adding new entries. Edit gallery.json directly to update." >&2
+  exit 1
+fi
+
+# --- Prompt for non-derivable fields ---------------------------------------
+
+list_categories() {
+  grep -E '^[[:space:]]*case [a-zA-Z]+[[:space:]]*=[[:space:]]*"[a-z_]+"' \
+    "$ROOT/Pastura/Pastura/Models/GalleryScenario.swift" \
+    | sed -E 's/.*=[[:space:]]*"([^"]+)".*/\1/'
+}
+
+list_models() {
+  grep -E 'id:[[:space:]]*"[^"]+"' \
+    "$ROOT/Pastura/Pastura/App/ModelRegistry.swift" \
+    | sed -E 's/.*id:[[:space:]]*"([^"]+)".*/\1/' \
+    | sort -u
+}
+
+prompt_required() {
+  local label="$1"; shift
+  local var_name="$1"
+  local current="${!var_name}"
+  if [ -n "$current" ]; then
+    return
+  fi
+  if [ "$NON_INTERACTIVE" = "1" ]; then
+    echo "ERROR: --non-interactive but $label is missing" >&2
+    exit 1
+  fi
+  printf "%s: " "$label" >&2
+  local value
+  read -r value < /dev/tty
+  if [ -z "$value" ]; then
+    echo "ERROR: $label cannot be empty" >&2
+    exit 1
+  fi
+  printf -v "$var_name" '%s' "$value"
+}
+
+if [ -z "$CATEGORY" ] && [ "$NON_INTERACTIVE" != "1" ]; then
+  echo "Categories (from GalleryScenario.swift):" >&2
+  list_categories | sed 's/^/  - /' >&2
+fi
+prompt_required "category" CATEGORY
+
+if [ -z "$RECOMMENDED_MODEL" ] && [ "$NON_INTERACTIVE" != "1" ]; then
+  echo "Recommended models (from ModelRegistry.swift):" >&2
+  list_models | sed 's/^/  - /' >&2
+fi
+prompt_required "recommended_model" RECOMMENDED_MODEL
+
+prompt_required "estimated_inferences" ESTIMATED_INFERENCES
+case "$ESTIMATED_INFERENCES" in
+  ''|*[!0-9]*)
+    echo "ERROR: estimated_inferences must be a positive integer" >&2
+    exit 1
+    ;;
+esac
+
+if [ -z "$ADDED_AT" ]; then
+  ADDED_AT="$(date -u +%Y-%m-%d)"
+fi
+
+if [ -z "$DESCRIPTION_OVERRIDE" ]; then
+  DESCRIPTION="$YAML_DESC"
+else
+  DESCRIPTION="$DESCRIPTION_OVERRIDE"
+fi
+if [ -z "$DESCRIPTION" ]; then
+  echo "ERROR: description is empty (YAML lacks description: and no --description override given)" >&2
+  exit 1
+fi
+
+if [ -z "$AUTHOR" ]; then
+  AUTHOR="$(gh api user --jq .login 2>/dev/null || git config user.name 2>/dev/null || echo "")"
+  if [ -z "$AUTHOR" ] && [ "$NON_INTERACTIVE" != "1" ]; then
+    prompt_required "author" AUTHOR
+  fi
+fi
+if [ -z "$AUTHOR" ]; then
+  echo "ERROR: author is empty (gh+git fallback failed and --non-interactive blocked the prompt)" >&2
+  exit 1
+fi
+
+# --- updated_at monotonicity ----------------------------------------------
+
+NOW_UTC="$(date -u +%Y-%m-%dT00:00:00Z)"
+EXISTING_UPDATED_AT="$(jq -r '.updated_at' "$GALLERY_JSON")"
+# Lexicographic comparison works for fixed-format ISO-8601 strings.
+if [ "$EXISTING_UPDATED_AT" \> "$NOW_UTC" ]; then
+  echo "WARNING: existing updated_at ($EXISTING_UPDATED_AT) is later than today ($NOW_UTC)." >&2
+  echo "         Local clock skew? Verify 'date -u' and re-run if needed." >&2
+  echo "         updated_at will NOT advance — keeping monotonic ordering." >&2
+  UPDATED_AT="$EXISTING_UPDATED_AT"
+else
+  UPDATED_AT="$NOW_UTC"
+fi
+
+# --- Build new entry & confirm --------------------------------------------
+
+NEW_ENTRY=$(jq -n \
+  --arg id "$YAML_ID" \
+  --arg title "$YAML_NAME" \
+  --arg category "$CATEGORY" \
+  --arg description "$DESCRIPTION" \
+  --arg author "$AUTHOR" \
+  --arg recommended_model "$RECOMMENDED_MODEL" \
+  --argjson estimated_inferences "$ESTIMATED_INFERENCES" \
+  --arg yaml_url "$YAML_BASENAME" \
+  --arg yaml_sha256 "$YAML_SHA" \
+  --arg added_at "$ADDED_AT" \
+  '{
+    id: $id,
+    title: $title,
+    category: $category,
+    description: $description,
+    author: $author,
+    recommended_model: $recommended_model,
+    estimated_inferences: $estimated_inferences,
+    yaml_url: $yaml_url,
+    yaml_sha256: $yaml_sha256,
+    added_at: $added_at
+  }')
+
+if [ "$NON_INTERACTIVE" != "1" ]; then
+  echo "" >&2
+  echo "About to add to $GALLERY_JSON:" >&2
+  echo "$NEW_ENTRY" | jq . >&2
+  echo "" >&2
+  echo "  updated_at: $UPDATED_AT" >&2
+  printf "Proceed? [y/N]: " >&2
+  read -r confirm < /dev/tty
+  if [ "$confirm" != "y" ] && [ "$confirm" != "Y" ]; then
+    echo "Aborted." >&2
+    exit 0
+  fi
+fi
+
+# --- Atomic write + post-validate -----------------------------------------
+
+TMP="$GALLERY_JSON.tmp"
+jq --argjson new "$NEW_ENTRY" --arg updated_at "$UPDATED_AT" \
+  '.updated_at = $updated_at | .scenarios += [$new]' \
+  "$GALLERY_JSON" > "$TMP"
+
+BACKUP="$GALLERY_JSON.bak.$$"
+mv "$GALLERY_JSON" "$BACKUP"
+mv "$TMP" "$GALLERY_JSON"
+
+if ! bash "$CHECK_SCRIPT" --all; then
+  echo "" >&2
+  echo "ERROR: post-write validation failed; restoring previous gallery.json" >&2
+  mv "$BACKUP" "$GALLERY_JSON"
+  exit 1
+fi
+
+rm "$BACKUP"
+echo ""
+echo "Added entry id=$YAML_ID to docs/gallery/gallery.json (updated_at=$UPDATED_AT)"
+echo "Next: review the diff, run a Debug build with PASTURA_GALLERY_BASE_URL"
+echo "      pointing at your branch, and confirm the scenario installs cleanly."

--- a/scripts/add-gallery-entry.sh
+++ b/scripts/add-gallery-entry.sh
@@ -121,7 +121,14 @@ if [ ! -f "$YAML_PATH" ]; then
   exit 1
 fi
 
-YAML_PATH="$(cd "$(dirname "$YAML_PATH")" && pwd)/$(basename "$YAML_PATH")"
+# Canonicalize to absolute (no symlink resolution needed — basename
+# and jq lookups only care about identity, not realpath). Avoids the
+# `$(cd "$(dirname …)" && pwd)` form that Claude Code's permission
+# heuristic flags (anthropics/claude-code#31373).
+case "$YAML_PATH" in
+  /*) ;;
+  *) YAML_PATH="$PWD/$YAML_PATH" ;;
+esac
 YAML_BASENAME="$(basename "$YAML_PATH")"
 YAML_STEM="$(basename "$YAML_PATH" .yaml)"
 

--- a/scripts/check-gallery-entry.sh
+++ b/scripts/check-gallery-entry.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# scripts/check-gallery-entry.sh — Validate gallery YAML entries against
+# docs/gallery/gallery.json without writing.
+#
+# Usage:
+#   bash scripts/check-gallery-entry.sh --all
+#       Validates every entry in docs/gallery/gallery.json + id
+#       uniqueness across gallery + bundled presets.
+#   bash scripts/check-gallery-entry.sh docs/gallery/<id>.yaml
+#       Validates a single YAML against its gallery.json entry plus the
+#       cross-source uniqueness check. Use this from
+#       add-gallery-entry.sh as a pre/post-write gate.
+#
+# Validations enforced here:
+#   - YAML SHA-256 byte-match with gallery.json yaml_sha256
+#   - YAML file size <= 256 KiB (matches URLSessionGalleryService.yamlSizeLimit)
+#   - id uniqueness across gallery.json + Pastura/Pastura/Resources/Presets/*.yaml
+#   - YAML filename stem == id field inside the YAML
+#
+# Validations covered elsewhere (kept here as a maintainer signpost so
+# the next contributor does not duplicate them in bash):
+#   - GalleryCategory enum membership          → GalleryCategory.allCases
+#   - recommended_model in ModelRegistry       → GallerySeedYAMLTests
+#                                                .recommendedModelMatchesRegistry
+#   - title byte-equal to YAML name            → GallerySeedYAMLTests
+#                                                .galleryTitleMatchesYAMLName
+#   - YAML parse + ScenarioValidator pass      → GallerySeedYAMLTests
+#                                                .allSeedYAMLsParseAndValidate
+#   - yaml_sha256 byte-match (this script duplicates it; the Swift test
+#     is the durable defense against --no-verify and GitHub-UI merges)
+#                                              → GallerySeedYAMLTests
+#                                                .galleryYAMLHashMatchesIndex
+#
+# Exit code: 0 on success, 1 on any violation. Failures aggregate so a
+# single --all run reports every drift.
+
+set -euo pipefail
+
+# --- Dependency check ------------------------------------------------------
+
+# Fail loudly with install hints, not an opaque "command not found"
+# mid-pipe. shasum + awk + jq are present on macOS by default and on
+# ubuntu-latest GHA runners; PyYAML must be installed explicitly on CI.
+for dep in jq python3 shasum awk basename wc; do
+  if ! command -v "$dep" >/dev/null 2>&1; then
+    echo "ERROR: missing dependency: $dep" >&2
+    exit 1
+  fi
+done
+if ! python3 -c "import yaml" 2>/dev/null; then
+  echo "ERROR: PyYAML not available — install via 'python3 -m pip install pyyaml'" >&2
+  exit 1
+fi
+
+ROOT="$(git rev-parse --show-toplevel)"
+GALLERY_DIR="$ROOT/docs/gallery"
+GALLERY_JSON="$GALLERY_DIR/gallery.json"
+PRESETS_DIR="$ROOT/Pastura/Pastura/Resources/Presets"
+MAX_BYTES=$((256 * 1024))
+
+FAILURES=0
+
+fail() {
+  echo "FAIL: $1" >&2
+  FAILURES=$((FAILURES + 1))
+}
+
+# --- Field readers ---------------------------------------------------------
+
+# Parse YAML id via PyYAML — robust against folded scalars / comments /
+# quote variations that grep-based extraction would mishandle.
+yaml_id() {
+  python3 -c "import sys, yaml; print(yaml.safe_load(open(sys.argv[1]))['id'])" "$1"
+}
+
+# Lowercase hex SHA-256 — matches URLSessionGalleryService's runtime
+# format and gallery.json.yaml_sha256. shasum is BSD perl on macOS and
+# perl-based on ubuntu — output format is identical (`<hex>  <file>`).
+yaml_sha256() {
+  shasum -a 256 "$1" | awk '{print $1}'
+}
+
+file_size() {
+  wc -c < "$1" | awk '{print $1}'
+}
+
+# Concatenated id stream from gallery.json + every bundled preset YAML.
+# Uniqueness is checked at runtime by `sort | uniq -d`.
+all_known_ids() {
+  jq -r '.scenarios[].id' "$GALLERY_JSON"
+  for f in "$PRESETS_DIR"/*.yaml; do
+    [ -f "$f" ] || continue
+    yaml_id "$f"
+  done
+}
+
+# --- Per-entry validation --------------------------------------------------
+
+check_entry() {
+  local yaml_path="$1"
+  local expected_id="$2"
+  local expected_sha="$3"
+
+  local actual_id
+  actual_id="$(yaml_id "$yaml_path")"
+  local file_stem
+  file_stem="$(basename "$yaml_path" .yaml)"
+
+  if [ "$actual_id" != "$expected_id" ]; then
+    fail "id mismatch — gallery.json id=$expected_id but YAML id=$actual_id ($yaml_path)"
+  fi
+  if [ "$file_stem" != "$actual_id" ]; then
+    fail "filename stem != id — file stem=$file_stem but YAML id=$actual_id ($yaml_path). Rename one or the other so they match."
+  fi
+  local actual_sha
+  actual_sha="$(yaml_sha256 "$yaml_path")"
+  if [ "$actual_sha" != "$expected_sha" ]; then
+    fail "yaml_sha256 mismatch for id=$expected_id — gallery.json=$expected_sha but actual=$actual_sha ($yaml_path)"
+  fi
+  local size
+  size="$(file_size "$yaml_path")"
+  if [ "$size" -gt "$MAX_BYTES" ]; then
+    fail "size ${size} bytes exceeds 256 KiB cap (id=$expected_id, $yaml_path)"
+  fi
+}
+
+check_id_uniqueness() {
+  local dups
+  dups="$(all_known_ids | sort | uniq -d)"
+  if [ -n "$dups" ]; then
+    while IFS= read -r dup; do
+      fail "duplicate id across gallery.json + bundled presets: $dup"
+    done <<< "$dups"
+  fi
+}
+
+# --- Mode dispatch ---------------------------------------------------------
+
+MODE="${1:-}"
+if [ -z "$MODE" ]; then
+  echo "Usage: $0 --all" >&2
+  echo "       $0 docs/gallery/<id>.yaml" >&2
+  exit 1
+fi
+
+if [ "$MODE" = "--all" ]; then
+  check_id_uniqueness
+  while IFS=$'\t' read -r entry_id entry_url entry_sha; do
+    yaml_path="$GALLERY_DIR/$(basename "$entry_url")"
+    if [ ! -f "$yaml_path" ]; then
+      fail "yaml file missing for id=$entry_id — expected $yaml_path"
+      continue
+    fi
+    check_entry "$yaml_path" "$entry_id" "$entry_sha"
+  done < <(jq -r '.scenarios[] | [.id, .yaml_url, .yaml_sha256] | @tsv' "$GALLERY_JSON")
+else
+  yaml_path="$MODE"
+  if [ ! -f "$yaml_path" ]; then
+    echo "ERROR: file not found: $yaml_path" >&2
+    exit 1
+  fi
+  yaml_basename="$(basename "$yaml_path")"
+  entry_json="$(jq -r --arg base "$yaml_basename" \
+    '.scenarios[] | select((.yaml_url | split("/") | last) == $base)' \
+    "$GALLERY_JSON")"
+  if [ -z "$entry_json" ]; then
+    fail "no gallery.json entry references yaml_url=$yaml_basename — add the entry first or fix the filename"
+  else
+    expected_id="$(echo "$entry_json" | jq -r '.id')"
+    expected_sha="$(echo "$entry_json" | jq -r '.yaml_sha256')"
+    check_entry "$yaml_path" "$expected_id" "$expected_sha"
+  fi
+  check_id_uniqueness
+fi
+
+if [ "$FAILURES" -gt 0 ]; then
+  echo "" >&2
+  echo "$FAILURES failure(s) detected." >&2
+  exit 1
+fi
+echo "OK: gallery validation passed."

--- a/scripts/gallery-precommit-gate.sh
+++ b/scripts/gallery-precommit-gate.sh
@@ -17,6 +17,11 @@ set -euo pipefail
 ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
 
+# Strict regex: only the flat docs/gallery/ directory triggers. If a
+# future contributor adds a subdirectory under docs/gallery/ (e.g.
+# archive/), the gate will silently skip it — relax to
+# `^docs/gallery/.*\.(yaml|json)$` then, and let check-gallery-entry.sh
+# ignore irrelevant siblings. Today the directory is flat by design.
 if ! git diff --cached --name-only | grep -qE '^docs/gallery/([^/]+\.yaml|gallery\.json)$'; then
   exit 0
 fi

--- a/scripts/gallery-precommit-gate.sh
+++ b/scripts/gallery-precommit-gate.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# gallery-precommit-gate.sh — Pre-commit gate for the gallery drift
+# check. Runs `check-gallery-entry.sh --all` only when the staged diff
+# touches docs/gallery/<id>.yaml or docs/gallery/gallery.json.
+#
+# README.md and share-board-reports.md edits in the same directory are
+# intentionally NOT triggers — they are not the published manifest and
+# the check has nothing to validate against them.
+#
+# Why a separate script instead of inlining in .claude/settings.json:
+# the gate's grep regex uses characters (alternation, escapes) that
+# tangle with JSON-string escaping rules. A standalone script keeps
+# settings.json readable and makes the gate testable.
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+if ! git diff --cached --name-only | grep -qE '^docs/gallery/([^/]+\.yaml|gallery\.json)$'; then
+  exit 0
+fi
+
+bash scripts/check-gallery-entry.sh --all


### PR DESCRIPTION
## Summary
- Adds `scripts/add-gallery-entry.sh` + `scripts/check-gallery-entry.sh` that
  automate sha256, updated_at bump, and title==name byte-equality — the
  three error-prone hand-edits PR #300 + #318 left behind.
- Wires the check into a 4th `.claude/settings.json` PreToolUse(git commit)
  hook + a new `gallery-drift` CI job so manifest drift fails the commit
  AND the PR run, not at install time on user devices.
- Pins the `yaml_sha256` invariant in `GallerySeedYAMLTests`.
- Fixes a P0 kinoko_takenoko `gallery.json` hash drift left by PR #318:
  the new test caught it on first run (production install was failing
  silently with "YAML hash mismatch" for users tapping Try on kinoko).

## Plan deviations from Issue
- Issue says "NO changes to `GallerySeedYAMLTests`" — overridden per
  Critic finding C1: a 5-line CryptoKit assertion is the only defense
  that catches drift via `--no-verify` commits and GitHub-UI merges.
  PR #318 left a real hash drift in `main` that this assertion exposed.
- Issue scope did not include README §54-72 fix — added per Critic C2
  (preset list omitted `target_score_race` after PR #313); replaced the
  hardcoded list with a forward-reference to `PresetLoader.presetFileNames`.

## Test plan
- [x] `swiftlint lint --quiet --strict` passes
- [x] Full Pastura test suite passes locally (** TEST SUCCEEDED **)
- [x] CI `gallery-drift` job runs and passes
- [x] CI `blocklist-drift` job still passes (no shared infra changes)
- [x] Pre-commit hook: commit touching only `README.md` → hook exits 0 silently
- [x] Pre-commit hook: commit touching `gallery.json` → hook runs check
- [x] `add-gallery-entry.sh` end-to-end against a synthetic YAML works
- [x] `add-gallery-entry.sh` rejects: existing id, filename!=id, missing deps
- [x] `add-gallery-entry.sh` `updated_at` monotonicity warning fires on backward clock

Closes #303