### PR TITLE
🐛 fix: PreToolUse matcher を tool name only に統一し if field 採用

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -50,27 +50,26 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Bash(git commit*)",
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
+            "if": "Bash(git commit*)",
             "command": "cd $(git rev-parse --show-toplevel) && swiftlint lint --quiet --strict 2>&1 || (echo 'SwiftLint violations. Fix before committing.' >&2 && exit 2)"
           },
           {
             "type": "command",
+            "if": "Bash(git commit*)",
             "command": "PASTURA_SKIP_XCSTRINGS_SYNC=1 \"$(git rev-parse --show-toplevel)/scripts/xcodebuild.sh\" build -quiet 2>&1 || (echo 'Build failed. Fix compile errors before committing.' >&2 && exit 2)"
           },
           {
             "type": "command",
+            "if": "Bash(git commit*)",
             "command": "bash $(git rev-parse --show-toplevel)/scripts/blocklist-precommit-gate.sh"
-          }
-        ]
-      },
-      {
-        "matcher": "Bash(gh pr create*)",
-        "hooks": [
+          },
           {
             "type": "command",
+            "if": "Bash(gh pr create*)",
             "command": "cd $(git rev-parse --show-toplevel) && git diff main...HEAD --name-only | grep -q CLAUDE.md || echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"CLAUDE.md not modified in this branch. Check if implementation progress needs updating.\"}}'"
           }
         ]


### PR DESCRIPTION
## Summary

- `.claude/settings.json` の PreToolUse `matcher` が公式仕様 (tool name only) と不一致で、Claude Code v2.1.85 以降ずっと no-op だった bug を修正
- 旧 `"matcher": "Bash(git commit*)"` は **permission rule 専用文法** を matcher field に誤用 → `(`, `)`, `*` が regex メタ文字として評価され、tool name `Bash` の literal match に失敗
- v2.1.85+ の `if` field を採用し、公式 [hooks-guide](https://code.claude.com/docs/en/hooks-guide.md) example の verbatim 形 (`{ "matcher": "Bash", "hooks": [{ "if": "Bash(git *)", ... }] }`) に揃える
- 修正対象 4 hook (swiftlint --strict / xcodebuild build / blocklist gate / gh pr create CLAUDE.md drift) を `matcher: "Bash"` 単一ブロックに統合、各 hook に対応する `if` を付与
- PostToolUse `Edit\|Write` / `ExitWorktree`、SessionStart `compact` は tool name matcher で正常動作中につき据え置き

## How this slipped through

直前の PR #318 で発覚: pre-commit hook で local block されるべき swiftlint --strict 違反 3 件 (function_body_length / identifier_name / file_length) が pre-commit hook をすり抜けて push まで到達 → CI で初めて検知、追加 commit で修正する形になった。

実証実験 (#319 issue 参照): `HookTestProbe.swift` で deliberate identifier_name 違反を仕込み、heredoc / 単純 `-m` 両形式で commit attempt → 両方 block されず exit 0。手動 `swiftlint --quiet --strict` は exit 2 → hook が fire していないことが確定。

## In-session verification の structural limit

Claude Code は session 開始時に main repo 直下の `.claude/settings.json` を cache するため、worktree 内で settings を編集しても走行中の session には反映されない。end-to-end の commit-block test は **PR merge 後の fresh session で manual** に行うしかない (Test plan 最終項目)。

代替検証 (この PR 内で完了):
- ✅ `jq . .claude/settings.json` で JSON 文法 valid
- ✅ matcher = `"Bash"` + `if` 形式が公式 example と verbatim 一致
- ✅ Hook command 単体 (`swiftlint --quiet --strict`) は deliberate violation で exit 2 を返す (pipefail mask に注意 — `... | tail` 経由だと tail の 0 で隠れる、memory `feedback_xcodebuild_pipefail.md`)

## Test plan

- [x] `jq . .claude/settings.json` で JSON 文法 valid 確認
- [x] PreToolUse 構造が公式 example と verbatim match 確認
- [x] Hook command 単体動作 (`swiftlint --quiet --strict`) が deliberate violation で exit 2 確認
- [ ] **Manual (post-merge required)**: PR merge → 本 repo で **新規 Claude Code session を開始** → deliberate な swiftlint 違反を含む dummy file を `git commit` で attempt → exit 2 で block されること、stderr に `'SwiftLint violations. Fix before committing.'` が出ることを確認
- [ ] **Manual (post-merge optional)**: 同様に `gh pr create` 試行 → CLAUDE.md 未編集なら `additionalContext: "CLAUDE.md not modified..."` reminder が表示されることを確認

## Out of scope

- v2.1.85+ 最小 Claude Code バージョン注記を CLAUDE.md に追加: 単一 contributor pre-launch のため省略 (issue #319 plan critic Axis 2 で議論、user 判断)。後続 contributor が増えた段階で follow-up issue として対応

Closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)