### PR TITLE
🧹 chore: sweep remaining #C/#B1 placeholders missed by #329 (#327)

### DIFF
--- a/Pastura/Pastura/App/YAMLReplayExporter.swift
+++ b/Pastura/Pastura/App/YAMLReplayExporter.swift
@@ -244,8 +244,8 @@ nonisolated struct YAMLReplayExporter {  // swiftlint:disable:this type_body_len
   /// Serialises a ``CodePhaseEventPayload`` as a `payload:` stanza with
   /// a `kind` discriminator. Added in E1 beyond the spec §3.2 example
   /// so structured payloads survive round-trip — the bare `summary:`
-  /// field would force #C to parse narrative strings back into structured
-  /// data, which is lossy by construction.
+  /// field would force downstream consumers to parse narrative strings
+  /// back into structured data, which is lossy by construction.
   private func renderPayloadStanza(
     _ payload: CodePhaseEventPayload?, filter: ContentFilter
   ) -> [String] {

--- a/Pastura/Pastura/App/YAMLReplaySource.swift
+++ b/Pastura/Pastura/App/YAMLReplaySource.swift
@@ -13,8 +13,8 @@ import Yams
 /// Errors produced by ``YAMLReplaySource``.
 ///
 /// Spec §3.5 mandates "silent skip" on unknown `schema_version`. That
-/// policy is enforced by the **wrapper** source (future
-/// `BundledDemoReplaySource`, #C), not the primitive — callers
+/// policy is enforced by the **wrapper** source
+/// (``BundledDemoReplaySource``), not the primitive — callers
 /// implementing user-visible replay flows can surface the same errors
 /// as actionable diagnostics instead of swallowing them.
 nonisolated public enum YAMLReplaySourceError: Error, Equatable {
@@ -38,7 +38,7 @@ nonisolated public enum YAMLReplaySourceError: Error, Equatable {
 /// ``SimulationEvent`` sequence back out via ``events()``.
 ///
 /// Shipped as part of the Phase 2 E1 "YAML simulation replay primitive"
-/// (Issue #167). The DL-time `BundledDemoReplaySource` (#C) and future
+/// (Issue #167). The DL-time ``BundledDemoReplaySource`` and the future
 /// `UserSimulationReplaySource` (Phase 2.5+, spec §4.5) compose on top
 /// of this type.
 ///

--- a/Pastura/Pastura/Views/DesignTokens.swift
+++ b/Pastura/Pastura/Views/DesignTokens.swift
@@ -104,7 +104,7 @@ enum PasturaPalette {
 
   // L3 is the documented default. Consumers hard-code `L3` unless they have
   // an explicit reason to override — environment-based preset switching is
-  // deferred to #B1/#C.
+  // not yet implemented.
   static let metaBaseL1 = PasturaColorValue(hex: 0x8A8B76)
   static let metaStrongL1 = PasturaColorValue(hex: 0x5D6848)
   static let metaDotOnL1 = PasturaColorValue(hex: 0x8A9A6C)
@@ -214,7 +214,7 @@ enum PasturaShadows {
 // MARK: - §3 Typography tokens
 
 /// Pastura text style descriptor. Data-only — application to SwiftUI `Text`
-/// lives in consumer sites (first is #B1 `AgentOutputRow` refactor).
+/// lives in consumer sites (e.g. ``AgentOutputRow``).
 ///
 /// SwiftUI `Font` alone cannot carry line-height, letter-spacing, italic, or
 /// text-case; callers combine `font` with `.lineSpacing(lineSpacingPoints)`,
@@ -252,7 +252,8 @@ struct PasturaTextStyle: Sendable, Equatable {
 
 /// Pastura typography scale. See `design-system.md` §3. Apply at callsites
 /// via `.font(style.font).lineSpacing(style.lineSpacingPoints).tracking(style.trackingPoints)
-/// .textCase(style.textCase)` — a `View.textStyle(_:)` modifier is deferred to #B1.
+/// .textCase(style.textCase)`, or use the ``View/textStyle(_:)`` modifier to
+/// apply all four at once.
 enum Typography {
   /// title/phase — フェーズ見出し
   static let titlePhase = PasturaTextStyle(


### PR DESCRIPTION
## Summary
- Follow-up to PR #329 — pattern grep `rg '#[A-Z]{1,3}[0-9]?\b' Pastura/Pastura --type swift` surfaces 6 sites; #329 fixed 3, this PR fixes the remaining 3 + 2 additional `#B1` sites the original keyword-grep missed.
- Site of note: `DesignTokens.swift:255` was **factually wrong** ("`View.textStyle(_:)` deferred to #B1") — the modifier ships at `DesignTokens+SwiftUI.swift:139` and is in active use (4 callsites in `AgentOutputRow.swift` alone).
- Asymmetric DocC link handling preserved: shipped types use double-backticks (`` ``BundledDemoReplaySource`` ``, `` ``View/textStyle(_:)`` ``); unshipped types keep single-backticks (`UserSimulationReplaySource (Phase 2.5+, spec §4.5)`).

**Tooling lesson**: Original PR #329 used keyword grep (`future caller|future use|...`) which doesn't match `(#C)` shape. Future placeholder sweeps should start from the pattern grep `rg '#[A-Z]{1,3}[0-9]?\b'` — captured in the commit message for `git log` archaeology.

## Test plan
- [x] Pre-commit hook ran SwiftLint + `xcodebuild build` successfully
- [x] `rg '#[A-Z]{1,3}[0-9]?\b' Pastura/Pastura --type swift` returns zero matches post-edit
- [x] Code-reviewer (Opus) PASS — verified each rewrite against shipped state (`AgentOutputRow.swift` `.textStyle(...)` callsites, `DesignTokens+SwiftUI.swift:139` `View.textStyle(_:)` modifier exists, `BundledDemoReplaySource` 17 references)
- [ ] CI green

Closes #327.