### PR TITLE
📝 docs: stale #275 refs + xcb-cli flag override rule

### DIFF
--- a/.claude/rules/xcodebuild-cli.md
+++ b/.claude/rules/xcodebuild-cli.md
@@ -43,6 +43,24 @@ form because hooks execute as direct shell processes and bypass the
 permission gate (and the heuristic). The asymmetry between allowlist
 entries and hook commands is intentional.
 
+### Re-passing wrapper-supplied flags
+
+The wrapper auto-supplies `-scheme`, `-project`, `-destination`, and
+`-derivedDataPath`. Their override semantics differ:
+
+| Flag | Re-pass via `[args]`? |
+|------|------------------------|
+| `-scheme` | **Rejected** — `error: option '-scheme' may only be provided once` |
+| `-project` | **Rejected** — same |
+| `-derivedDataPath` | **Rejected** — same |
+| `-destination` | **Accepted** — last-wins, intentional override per wrapper §"Mode-specific behavior" |
+
+xcodebuild prints the rejection error followed by its full usage page
+(exit 64). The error line lands between the wrapper's xtrace and the
+usage page, so it is easy to miss — the failure looks like a wrapper
+bug. Forward only what the wrapper does not supply: typically just
+`-only-testing` / `-skip-testing` / `--tail N`.
+
 ## When to use what
 
 | Scope | Command |

--- a/.claude/rules/xcodebuild-cli.md
+++ b/.claude/rules/xcodebuild-cli.md
@@ -53,13 +53,14 @@ The wrapper auto-supplies `-scheme`, `-project`, `-destination`, and
 | `-scheme` | **Rejected** — `error: option '-scheme' may only be provided once` |
 | `-project` | **Rejected** — same |
 | `-derivedDataPath` | **Rejected** — same |
-| `-destination` | **Accepted** — last-wins, intentional override per wrapper §"Mode-specific behavior" |
+| `-destination` | **Accepted** — last-wins, intentional override per wrapper §"Caller passthrough / flag override" |
 
 xcodebuild prints the rejection error followed by its full usage page
 (exit 64). The error line lands between the wrapper's xtrace and the
 usage page, so it is easy to miss — the failure looks like a wrapper
 bug. Forward only what the wrapper does not supply: typically just
-`-only-testing` / `-skip-testing` / `--tail N`.
+`-only-testing` / `-skip-testing` / `--tail N` (the last is wrapper-only,
+consumed before xcodebuild is invoked).
 
 ## When to use what
 

--- a/Pastura/Pastura/App/ModelDownloader.swift
+++ b/Pastura/Pastura/App/ModelDownloader.swift
@@ -41,9 +41,12 @@ public protocol ModelDownloader: Sendable {
 /// in-process retry resumes — the URL protocol's internal byte-position tracking
 /// + ETag validation are preserved transparently.
 ///
-/// **Out of scope:** cross-session resume (cache is in-memory only). If the user
-/// force-kills the app mid-download, the next launch starts from byte zero. See
-/// Issue #275 for the follow-up that would persist the blob to disk.
+/// **Out of scope:** persisting the `NSURLSessionDownloadTaskResumeData` blob
+/// across app launches. Cross-session resume itself works via the explicit
+/// `Range:` header fallback (`ModelManager.performDownload` reads the on-disk
+/// `.download` partial size and passes it as `resumeOffset`), but the
+/// OS-managed ETag / If-Range validation that the cached blob preserves is
+/// bypassed on relaunch. No open Issue currently tracks blob persistence.
 ///
 /// ## Actor isolation
 ///
@@ -239,8 +242,7 @@ nonisolated final class URLSessionModelDownloader: ModelDownloader, @unchecked S
       // invariant violation. `ModelManager.performDownload` only passes
       // resumeOffset > 0 when `partialURL` exists, and there is no
       // concurrent deletion path before merge — this branch is dead under
-      // current callers. Throwing surfaces a future violation (e.g.,
-      // Issue #275 cross-session resume from disk-cached metadata) rather
+      // current callers. Throwing surfaces a future violation rather
       // than silently writing a head-truncated file that would fail the
       // subsequent SHA256 check without self-recovery.
       // `URLError(.badServerResponse)` matches the existing transport-error

--- a/Pastura/PasturaTests/App/URLSessionModelDownloaderTests.swift
+++ b/Pastura/PasturaTests/App/URLSessionModelDownloaderTests.swift
@@ -295,7 +295,7 @@ struct URLSessionModelDownloaderTests {
     // (`ModelManager.performDownload` computes `resumeOffset` only when
     // `partialURL` exists); the precondition guard surfaces it as an
     // explicit throw rather than silently writing a head-truncated file.
-    // Regression target for Issue #275 cross-session resume follow-up.
+    // Regression target for any future cross-session resume work.
     CapturingMockURLProtocol.responseProvider = { _ in
       .success(
         statusCode: 206,

--- a/scripts/xcodebuild.sh
+++ b/scripts/xcodebuild.sh
@@ -15,10 +15,17 @@
 # triggers an approval dialog regardless of the allowlist
 # (anthropics/claude-code#31373).
 #
+# Caller passthrough / flag override:
+#
 # Subcommand maps directly to xcodebuild's; remaining args forward
-# verbatim via "$@". xcodebuild honors the last value for repeated
+# verbatim via "$@". xcodebuild honors the last value for many repeated
 # single-value flags, so caller passthrough wins on duplicates (e.g.
 # override the destination: `... test -destination 'platform=iOS Simulator,name=...'`).
+# Note: `-scheme`, `-project`, and `-derivedDataPath` are exceptions —
+# xcodebuild rejects duplicates with `error: option 'X' may only be
+# provided once`. Re-pass only `-destination` from the wrapper-supplied
+# set; see `.claude/rules/xcodebuild-cli.md` §"Re-passing wrapper-supplied
+# flags" for the full table.
 #
 # Mode-specific behavior:
 #


### PR DESCRIPTION
## Summary

Two docs-only follow-ups uncovered post-PR #330 merge.

## Changes (3 commits)

- **`1c8d9ef`** 📝 docs: drop stale Issue #275 refs from ModelDownloader
  - `ModelDownloader.swift:44-46` rewritten — drops broken `#275` "follow-up
    tracker" pointer AND corrects the "force-kill = byte zero" inaccuracy
    (cross-session resume actually works via explicit Range fallback; what's
    missing is durable resumeData blob persistence)
  - `ModelDownloader.swift:242-243` parenthetical example dropped
  - `URLSessionModelDownloaderTests.swift:298` test comment updated
  - Per memory `feedback_drift_lead_sentence.md` — both inaccuracies fixed
    in one rewrite, not patched piecewise

- **`b957bf7`** 📝 docs: document wrapper flag override semantics in
  xcodebuild-cli rule
  - Adds "Re-passing wrapper-supplied flags" section. Investigated
    flag-by-flag with `xcodebuild -showBuildSettings`:
    `-scheme`/`-project`/`-derivedDataPath` reject duplicate (exit 64);
    `-destination` accepts last-wins (documented contract).

- **`4b98ba1`** ✏️ docs: tighten xcb-cli rule cross-reference + wrapper note
  - PR-diff reviewer caught: rule's `§"Mode-specific behavior"` cross-ref
    was misdirected. Adds named heading `"Caller passthrough / flag
    override"` to wrapper docstring + corrects the overstated "honors the
    last value for repeated single-value flags" claim with explicit
    exceptions note.

## Critic + reviewer adjustments incorporated

- **Pre-impl critic** raised 1 Critical + 4 Warnings; all addressed before
  implementation (investigated `xcodebuild -showBuildSettings` flag-by-flag,
  3rd site found via `rg` audit, `-destination` override preserved, lead
  sentence locked at plan time).
- **PR-diff code review**: PASS with 1 Warning + 1 Suggestion, both fixed
  in `4b98ba1`.

## Test plan

- [x] swiftlint --strict clean
- [x] No production code semantics changed (comment-only edits in Swift)
- [x] `rg -n '275'` audit confirms no remaining Issue refs (only ADR-002
       numeric coincidence)
- [x] Cross-references between rule doc + wrapper agree on both sides
- [ ] CI green

Closes #335.

🤖 Generated with [Claude Code](https://claude.com/claude-code)