### PR TITLE
🐛 fix: YAML-mode save uses pasted YAML, not empty visual state

### DIFF
--- a/Pastura/Pastura/App/ScenarioEditorViewModel.swift
+++ b/Pastura/Pastura/App/ScenarioEditorViewModel.swift
@@ -166,21 +166,11 @@ final class ScenarioEditorViewModel {
     validationErrors = []
     isValid = false
 
-    let scenario: Scenario
-    if editorMode == .yaml {
-      let trimmed = yamlText.trimmingCharacters(in: .whitespacesAndNewlines)
-      guard !trimmed.isEmpty else {
-        validationErrors = [String(localized: "YAML is empty")]
-        return
-      }
-      do {
-        scenario = try loader.load(yaml: trimmed)
-      } catch {
-        validationErrors = [error.localizedDescription]
-        return
-      }
-    } else {
-      // Visual mode: check basic fields first
+    // Mode-specific pre-checks (visual: field UX errors, YAML: empty guard).
+    // Materialization itself is delegated to currentScenario() below so that
+    // save() and validate() share one mode-dispatch funnel — see #336 for the
+    // drift bug that motivated centralizing this.
+    if editorMode == .visual {
       if scenarioName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
         validationErrors.append(String(localized: "Scenario name is required"))
       }
@@ -193,12 +183,22 @@ final class ScenarioEditorViewModel {
       if phases.isEmpty {
         validationErrors.append(String(localized: "At least one phase is required"))
       }
-
       validationErrors.append(contentsOf: invalidAssignTargetErrors())
-
       if !validationErrors.isEmpty { return }
+    } else {
+      let trimmed = yamlText.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !trimmed.isEmpty else {
+        validationErrors = [String(localized: "YAML is empty")]
+        return
+      }
+    }
 
-      scenario = buildScenario()
+    let scenario: Scenario
+    do {
+      scenario = try currentScenario().scenario
+    } catch {
+      validationErrors = [error.localizedDescription]
+      return
     }
 
     do {
@@ -217,8 +217,10 @@ final class ScenarioEditorViewModel {
 
   /// Saves the current scenario to the repository.
   ///
-  /// Serializes visual state to YAML if in visual mode. Checks for
-  /// preset collision before saving.
+  /// Materializes the scenario via `currentScenario()` so save honors whichever
+  /// mode the user last touched. YAML mode persists the user's exact text
+  /// (comments, key order); visual mode re-serializes the canonical form.
+  /// Checks for preset collision before saving.
   /// - Returns: `true` if save succeeded.
   func save() async -> Bool {
     validate()
@@ -226,33 +228,23 @@ final class ScenarioEditorViewModel {
     isSaving = true
     defer { isSaving = false }
 
-    let scenario = buildScenario()
-    let yaml = serializer.serialize(scenario)
+    let scenario: Scenario
+    let yaml: String
+    do {
+      (scenario, yaml) = try currentScenario()
+    } catch {
+      // Defensive: validate() already proved currentScenario() succeeds for
+      // the current state under @MainActor (no concurrent yamlText mutation).
+      // Keep the catch as belt-and-braces so a future loader change cannot
+      // crash the editor.
+      validationErrors = [error.localizedDescription]
+      return false
+    }
 
     guard runCommitTimeValidation(scenario) else { return false }
 
     do {
-      // Check for preset collision
-      if let existing = try await offMain({ [repository] in
-        try repository.fetchById(scenario.id)
-      }) {
-        if existing.isPreset {
-          validationErrors = [
-            String(localized: "Cannot overwrite preset scenario '\(existing.name)'")
-          ]
-          return false
-        }
-        if existing.sourceType == ScenarioSourceType.gallery {
-          validationErrors = [
-            String(
-              localized:
-                "Cannot overwrite gallery scenario '\(existing.name)'. Use Shared Scenarios to update, or delete the local copy first."
-            )
-          ]
-          return false
-        }
-      }
-
+      guard try await checkNoOverwriteCollision(scenarioId: scenario.id) else { return false }
       let record = ScenarioRecord(
         id: scenario.id,
         name: scenario.name,
@@ -272,6 +264,32 @@ final class ScenarioEditorViewModel {
       ]
       return false
     }
+  }
+
+  /// Rejects overwrites of preset and gallery-sourced scenarios with mode-specific
+  /// error messages. Returns `true` when the id is free or refers to a user-owned
+  /// scenario the editor may overwrite.
+  private func checkNoOverwriteCollision(scenarioId: String) async throws -> Bool {
+    let existing = try await offMain { [repository] in
+      try repository.fetchById(scenarioId)
+    }
+    guard let existing else { return true }
+    if existing.isPreset {
+      validationErrors = [
+        String(localized: "Cannot overwrite preset scenario '\(existing.name)'")
+      ]
+      return false
+    }
+    if existing.sourceType == ScenarioSourceType.gallery {
+      validationErrors = [
+        String(
+          localized:
+            "Cannot overwrite gallery scenario '\(existing.name)'. Use Shared Scenarios to update, or delete the local copy first."
+        )
+      ]
+      return false
+    }
+    return true
   }
 
   // MARK: - Private
@@ -307,6 +325,30 @@ final class ScenarioEditorViewModel {
       }
     }
     return errors
+  }
+
+  /// Returns the scenario plus its persistable YAML for the active editor mode.
+  ///
+  /// Single materialization point shared by `save()` and `validate()` so the
+  /// mode dispatch lives in one place. Adding new callsites (preview, export,
+  /// share) routes them through the same funnel and prevents silently reading
+  /// from the wrong side — the drift class that produced #336.
+  ///
+  /// - YAML mode: parses `yamlText` and persists the user's *exact* text so
+  ///   author-supplied comments and key order survive. Re-serializing would
+  ///   normalize them away.
+  /// - Visual mode: builds from typed fields and serializes canonically (the
+  ///   visual editor has no place to surface raw text artifacts anyway).
+  private func currentScenario() throws -> (scenario: Scenario, yaml: String) {
+    switch editorMode {
+    case .yaml:
+      let trimmed = yamlText.trimmingCharacters(in: .whitespacesAndNewlines)
+      let parsed = try loader.load(yaml: trimmed)
+      return (parsed, trimmed)
+    case .visual:
+      let scenario = buildScenario()
+      return (scenario, serializer.serialize(scenario))
+    }
   }
 
   /// Builds a ``Scenario`` from the current visual editor state.

--- a/Pastura/PasturaTests/App/ScenarioEditorViewModelTests.swift
+++ b/Pastura/PasturaTests/App/ScenarioEditorViewModelTests.swift
@@ -187,6 +187,104 @@ struct ScenarioEditorViewModelTests {
     #expect(!sut.validationErrors.isEmpty)
   }
 
+  /// Issue #336: paste valid YAML in YAML mode and save without toggling Visual.
+  /// Pre-fix, `save()` called `buildScenario()` regardless of mode → empty visual
+  /// fields → `runCommitTimeValidation` surfaced the misleading
+  /// "Agent count (0) is below minimum of 2" error even though the pasted YAML
+  /// declared `agents: 2`.
+  @Test func yamlModeSavePersistsWithoutToggle() async throws {
+    let (sut, repo) = try makeSUTWithRepo()
+    sut.yamlText = Self.validYAML
+    sut.editorMode = .yaml
+
+    let success = await sut.save()
+
+    #expect(success)
+    #expect(sut.savedScenarioId == "editor_test")
+    #expect(sut.validationErrors.isEmpty)
+    let record = try repo.fetchById("editor_test")
+    #expect(record?.name == "Editor Test")
+    let reloaded = try ScenarioLoader().load(yaml: record?.yamlDefinition ?? "")
+    #expect(reloaded.agentCount == 2)
+    #expect(reloaded.personas.count == 2)
+  }
+
+  /// YAML-mode save persists the user's exact text. The canonical serializer
+  /// (used in visual-mode save) strips comments and normalizes key order, so
+  /// pasting an authored YAML and saving must NOT round-trip through it.
+  @Test func yamlModeSavePreservesUserText() async throws {
+    let (sut, repo) = try makeSUTWithRepo()
+    let yamlWithComment = """
+      # custom comment from author
+      id: comment_preservation_test
+      name: Comment Preservation Test
+      description: Tests comment survival on save
+      agents: 2
+      rounds: 1
+      context: Context
+      personas:
+        - name: Alice
+          description: Agent A
+        - name: Bob
+          description: Agent B
+      phases:
+        - type: speak_all
+          prompt: "Say something"
+          output:
+            statement: string
+      """
+    sut.yamlText = yamlWithComment
+    sut.editorMode = .yaml
+
+    let success = await sut.save()
+
+    #expect(success)
+    let record = try repo.fetchById("comment_preservation_test")
+    let saved = record?.yamlDefinition ?? ""
+    // Canonical serializer would strip this comment line.
+    #expect(saved.contains("# custom comment from author"))
+  }
+
+  /// Regression for #336's underlying drift class. extraData (e.g. bokete `topics`)
+  /// must survive a YAML-mode-direct save (no Visual toggle). Pre-fix, save() went
+  /// through `buildScenario()` → empty visual state, so this would fail with the
+  /// agentCount=0 error before extraData ever entered the picture. Post-fix, this
+  /// test guards against a future "simplify by routing both modes through
+  /// buildScenario()" refactor that would silently re-introduce the bug.
+  @Test func yamlModeSavePreservesExtraData() async throws {
+    let (sut, repo) = try makeSUTWithRepo()
+    let boketeYAML = """
+      id: bokete_yaml_save_test
+      name: Bokete Save Test
+      description: Tests extraData survival on YAML-mode save
+      agents: 2
+      rounds: 1
+      context: Context
+      topics:
+        - Photo A
+        - Photo B
+        - Photo C
+      personas:
+        - name: Alice
+          description: Agent A
+        - name: Bob
+          description: Agent B
+      phases:
+        - type: assign
+          source: topics
+          target: all
+      """
+    sut.yamlText = boketeYAML
+    sut.editorMode = .yaml
+
+    let success = await sut.save()
+
+    #expect(success)
+    let record = try repo.fetchById("bokete_yaml_save_test")
+    let reloaded = try ScenarioLoader().load(yaml: record?.yamlDefinition ?? "")
+    #expect(reloaded.extraData["topics"] == .array(["Photo A", "Photo B", "Photo C"]))
+  }
+
   @Test func saveSurfacesSourceNotFoundValidationMessage() async throws {
     let sut = try makeSUT()
     // YAML with an `assign` phase referencing a non-existent `topics` source.


### PR DESCRIPTION
## Summary

- `ScenarioEditorViewModel.save()` called `buildScenario()` regardless of `editorMode`, so a fresh paste-and-save in YAML mode (without first toggling Visual to populate visual fields) materialized an empty scenario and surfaced the misleading "Agent count (0) is below minimum of 2" error.
- Extract a shared `currentScenario()` helper. `save()` and `validate()` both materialize through it so future callsites (preview, export, share) cannot silently regress to reading from the wrong side. YAML mode persists the user's exact text — re-serialization would normalize comments and key order — while visual mode keeps canonical-form serialization.
- Larger refactor — making `yamlText` the single source of truth and eliminating the `carriedExtraData` band-aid — is tracked separately as #338.

## Test plan

- [x] New `yamlModeSavePersistsWithoutToggle` — pastes valid YAML, saves, asserts persisted record round-trips back to a 2-agent scenario (#336 reproduction).
- [x] New `yamlModeSavePreservesUserText` — saves YAML with an author comment (`# custom comment from author`), asserts the comment survives in `record.yamlDefinition` (canonical serializer would strip it).
- [x] New `yamlModeSavePreservesExtraData` — saves bokete-shaped `topics:` array directly from YAML mode (no Visual toggle), asserts `extraData["topics"]` survives the round-trip via persisted YAML.
- [x] All 23 tests in `ScenarioEditorViewModelTests` pass.
- [x] Full unit suite passes (1484 tests, 137 suites).
- [x] `swiftlint lint --strict` clean.
- [x] **Manual QA**: Home → New Scenario → toggle YAML → paste any preset YAML (e.g. `target_score_race.yaml`) → tap Save without toggling Visual → expect successful save, no "Agent count (0)" error.
- [x] **Manual QA (regression)**: Visual-mode save still works (load a preset, edit a field in Visual mode, save).
- [x] **Manual QA (extraData)**: Open `bokete.yaml` preset → toggle YAML → tap Save (without Visual toggle) → reopen → confirm `topics:` list is preserved.

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)