### PR TITLE
🌐 i18n: Tier 2 wraps in Views/Simulation + loadError alternation

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -46,7 +46,7 @@ custom_rules:
   # alternation. See `docs/i18n/leak-detection.md` for the full architecture.
   unwrapped_user_facing_string:
     name: "Unwrapped user-facing String"
-    regex: '(errorMessage|validationErrors|alertMessage|toastMessage|nameError|descriptionError|conditionError|promptError|outcomeAlert|deepLinkError)\s*(?:=|\+=)\s*\[?\s*"[^"]+"'
+    regex: '(errorMessage|validationErrors|alertMessage|toastMessage|nameError|descriptionError|conditionError|promptError|outcomeAlert|deepLinkError|loadError)\s*(?:=|\+=)\s*\[?\s*"[^"]+"'
     included:
       - 'Pastura/Pastura/.*\.swift'
     severity: warning

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -1,12 +1,80 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "  %@: %lld votes" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "  %1$@: %2$lld votes"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "  %1$@: %2$lld 票"
+          }
+        }
+      }
+    },
+    "%@ assigned: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ assigned: %2$@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ に %2$@ を割り当て"
+          }
+        }
+      }
+    },
+    "%@ eliminated (%lld votes)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ eliminated (%2$lld votes)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ 脱落 (%2$lld 票)"
+          }
+        }
+      }
+    },
+    "%@ is thinking..." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ は考え中..."
+          }
+        }
+      }
+    },
     "%arg actions" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%arg のアクション"
+          }
+        }
+      }
+    },
+    "%lld pts" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 点"
           }
         }
       }
@@ -208,6 +276,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "作者"
+          }
+        }
+      }
+    },
+    "Background continuation" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "バックグラウンド継続"
           }
         }
       }
@@ -1798,6 +1876,16 @@
         }
       }
     },
+    "Pastura simulation" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pastura シミュレーション"
+          }
+        }
+      }
+    },
     "Pause (available during simulation)" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -2319,6 +2407,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "実行中"
+          }
+        }
+      }
+    },
+    "Running in background" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "バックグラウンドで実行中"
           }
         }
       }
@@ -3194,6 +3292,16 @@
         }
       }
     },
+    "disabled" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無効"
+          }
+        }
+      }
+    },
     "e.g. max_score >= 10" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -3211,6 +3319,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "例: max_score >= 10 && active_count > 1"
+          }
+        }
+      }
+    },
+    "enabled" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有効"
           }
         }
       }

--- a/Pastura/Pastura/Views/Simulation/ScoreboardSheet.swift
+++ b/Pastura/Pastura/Views/Simulation/ScoreboardSheet.swift
@@ -25,7 +25,7 @@ struct ScoreboardSheet: View {
 
             Spacer()
 
-            Text("\(entry.score) pts")
+            Text(String(format: String(localized: "%lld pts"), entry.score))
               .textStyle(Typography.bodyBubble)
               .monospacedDigit()
               .foregroundStyle(entry.isEliminated ? Color.muted : Color.ink)

--- a/Pastura/Pastura/Views/Simulation/SimulationView+Background.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView+Background.swift
@@ -15,8 +15,8 @@ extension SimulationView {
         viewModel.disableBackgroundContinuation()
       } else {
         viewModel.enableBackgroundContinuation(
-          title: "Pastura simulation",
-          subtitle: scenario?.name ?? "Running in background"
+          title: String(localized: "Pastura simulation"),
+          subtitle: scenario?.name ?? String(localized: "Running in background")
         )
       }
     } label: {
@@ -30,7 +30,9 @@ extension SimulationView {
       // はデザインシステムの飽和色禁則（§1）と Pastura パレット非準拠で置換。
       .foregroundStyle(viewModel.isBackgroundContinuationEnabled ? Color.mossDark : Color.muted)
     }
-    .accessibilityLabel("Background continuation")
-    .accessibilityValue(viewModel.isBackgroundContinuationEnabled ? "enabled" : "disabled")
+    .accessibilityLabel(String(localized: "Background continuation"))
+    .accessibilityValue(
+      viewModel.isBackgroundContinuationEnabled
+        ? String(localized: "enabled") : String(localized: "disabled"))
   }
 }

--- a/Pastura/Pastura/Views/Simulation/SimulationView+LogEntries.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView+LogEntries.swift
@@ -17,13 +17,13 @@ extension SimulationView {
     HStack(spacing: 4) {
       Image(systemName: "xmark.circle.fill")
         .foregroundStyle(Color.inkSecondary)
-      Text("\(agent) eliminated (\(voteCount) votes)")
+      Text(String(format: String(localized: "%@ eliminated (%lld votes)"), agent, voteCount))
         .textStyle(Typography.titlePhase)
     }
   }
 
   func assignmentEntry(agent: String, value: String) -> some View {
-    Text("\(agent) assigned: \(value)")
+    Text(String(format: String(localized: "%@ assigned: %@"), agent, value))
       .textStyle(Typography.metaValue)
       .foregroundStyle(Color.muted)
   }
@@ -44,7 +44,7 @@ extension SimulationView {
         .textStyle(Typography.metaLabel)
         .foregroundStyle(Color.inkSecondary)
       ForEach(tallies.sorted(by: { $0.value > $1.value }), id: \.key) { name, count in
-        Text("  \(name): \(count) votes")
+        Text(String(format: String(localized: "  %@: %lld votes"), name, count))
           .textStyle(Typography.metaValue)
       }
     }

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -39,7 +39,7 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
         simulationContent(viewModel: viewModel)
       } else if let loadError {
         ContentUnavailableView(
-          "Error",
+          String(localized: "Error"),
           systemImage: "exclamationmark.triangle",
           description: Text(loadError)
         )
@@ -185,7 +185,7 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
                 HStack(spacing: 8) {
                   ProgressView()
                     .scaleEffect(0.7)
-                  Text("\(agent) is thinking...")
+                  Text(String(format: String(localized: "%@ is thinking..."), agent))
                     .textStyle(Typography.thinkingBody)
                     .foregroundStyle(Color.muted)
                 }
@@ -348,7 +348,9 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
       PhaseTypeLabel(phaseType: phaseType)
         .padding(.top, 4)
     case .roundStarted(let round, let total):
-      roundSeparator("Round \(round)/\(total)")
+      // Reuses the `Round %lld / %lld` key already wired into GameHeader
+      // so the round-separator label and header label stay translation-aligned.
+      roundSeparator(String(format: String(localized: "Round %lld / %lld"), round, total))
     case .roundCompleted(_, let scores), .scoreUpdate(let scores):
       scoresSummary(scores)
     case .error(let message):
@@ -521,7 +523,7 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
           try deps.scenarioRepository.fetchById(scenarioId)
         })
       else {
-        loadError = "Scenario not found"
+        loadError = String(localized: "Scenario not found")
         return
       }
 

--- a/docs/i18n/leak-detection.md
+++ b/docs/i18n/leak-detection.md
@@ -33,15 +33,18 @@ The rule fires on the regex shape
 
 ```
 (errorMessage|validationErrors|alertMessage|toastMessage|nameError
- |descriptionError|conditionError|promptError|outcomeAlert|deepLinkError)
+ |descriptionError|conditionError|promptError|outcomeAlert|deepLinkError
+ |loadError)
 \s*(?:=|\+=)\s*\[?\s*"[^"]+"
 ```
 
-against any file under `Pastura/Pastura/`. The 10 property names are an
-**empirical** list, drawn from the PR #288 audit and the four
-`SimulationViewModel*.swift` wraps fixed in PR #299. The narrow scope is
-the entire point: widening to all `String` assignments re-introduces the
-noise floor that PR #288's analysis was unable to cut through.
+against any file under `Pastura/Pastura/`. The 11 property names are an
+**empirical** list, drawn from the PR #288 audit, the four
+`SimulationViewModel*.swift` wraps fixed in PR #299, and the
+`SimulationView.loadError` Tier 2 leak surfaced in #311. The narrow
+scope is the entire point: widening to all `String` assignments
+re-introduces the noise floor that PR #288's analysis was unable to
+cut through.
 
 ### What it cannot catch (by design)
 


### PR DESCRIPTION
## Summary

- Wraps **11 unwrapped English literals** in `Views/Simulation/` (`SimulationView.swift`, `SimulationView+LogEntries.swift`, `SimulationView+Background.swift`, `ScoreboardSheet.swift`) so they reach `Localizable.xcstrings` and acquire `ja` translations. 10 new keys + 3 reuse existing entries (`Error`, `Round %lld / %lld`, `Scenario not found`).
- Extends the **Tier 1 SwiftLint regex** (`unwrapped_user_facing_string`) with `loadError` per the doc's Extension protocol — empirical motivation was `SimulationView.swift:524 loadError = "Scenario not found"`, the canonical Tier 2 leak from issue #311's audit.
- **VoiceOver consistency**: `accessibilityLabel("Background continuation")` plus `accessibilityValue("enabled" / "disabled")` are wrapped together so the BG-continuation toggle label/value pair is fully translated (per critic Axis 5).

## Notable visual change

`Round 1/3` → `Round 1 / 3` in the round-separator log row (and the underlying ja translation `ラウンド 1 / 3`). This is **deliberate** — the new code reuses the existing `"Round %lld / %lld"` translation key already wired into `GameHeader.formatRoundLabel`, unifying the header label and the log marker so both surfaces stay translation-aligned. Saves a second translator round-trip.

## Catalog edit workflow

Per memory `feedback_xcstrings_json_roundtrip_trap.md`:

1. Wrap literals in source.
2. Run `scripts/xcodebuild.sh build` → `xcstringstool sync` extends the catalog with Apple-canonical formatting (avoids the `: ` vs ` : ` separator drift that produces a multi-thousand-line phantom diff).
3. Add `ja` translations via `Edit`-tool exact match on the new entries only — never rewrite or pretty-print the full file.

## Out of scope (deferred to follow-up)

#340 tracks the remaining ~625 audit candidates across `App/`, `Data/`, `LLM/`, `Views/{Components, Results, Editor, ModelDownload, Community}`, and `InferenceStatsFormatter.swift` (technical-abbreviation policy decision: `tok/s` / `s`).

## Test plan

- [x] `scripts/xcodebuild.sh test -skip-testing:PasturaUITests` — 1481 tests / 137 suites pass
- [x] `python3 scripts/check_localization_coverage.py` — 328 keys, all `ja` translated (Tier 3 CI gate green)
- [x] `python3 scripts/check_i18n_potential_keys.py` on `Views/Simulation/` — 24 → 13 candidates (remaining 13 are all triaged-NOT-leak: combiners, identifiers, internal logging, deferred `InferenceStatsFormatter`)
- [x] `swiftlint --strict` on touched files — clean
- [x] **Tier 1 alternation positive test** — temporary `loadError = "leak_test"` insert → rule fires (warning); reverted
- [x] **Tier 1 alternation negative test** — `loadError == "Foo"` (comparison form) → rule does NOT fire, confirming #322's `(?:=|\+=)` defensive tighten still holds
- [ ] Manual QA on simulator: launch a simulation, trigger BG-continuation toggle (iOS 26+, on a build with LlamaCppService backend), tap the scoreboard sheet, simulate an unknown scenario id (deep-link to `pastura://scenario/<bogus-id>`) to surface the wrapped `Error` / `Scenario not found` content

Closes #311
Part of #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)