### PR TITLE
♻️ refactor: Sim fill-the-bar — title in nav bar principal slot

### DIFF
--- a/.claude/rules/navigation.md
+++ b/.claude/rules/navigation.md
@@ -160,21 +160,101 @@ surface changes in areas the automated tests do not exercise.
    exactly one screen (not all the way to root): Editor, Import,
    Simulation, Results, GalleryScenarioDetail.
 
-   **Sim's nav title is intentionally empty** (#297 PR 3, ADR-008
-   §Amendment 2026-04-29) because the `GameHeader` row 1 carries the
-   scenario name. While verifying back-gesture pops, also confirm
-   visually:
-   - Sim's nav bar **title slot** reads empty (no scenario name).
+   **Sim's nav bar uses the "fill the bar" pattern** (#312, ADR-008
+   §Amendment 2026-05-10): `.toolbarBackground(.hidden, for:
+   .navigationBar)` makes the bar's background transparent while the
+   bar itself stays in the layout (preserving the chevron + swipe-back
+   gesture); `GameHeader.titleRow` is hosted inside the bar via
+   `ToolbarItem(placement: .principal)`, and `GameHeader.metaRow`
+   mounts via `.safeAreaInset(.top)` directly below — its frosted BG
+   `.ignoresSafeArea(.container, edges: .top)` so the moss material
+   fills behind the bar AND status bar. Demo's `.fullScreenCover`
+   composition uses the unified `GameHeader.body` and is unaffected.
+
+   While verifying back-gesture pops, also confirm visually:
+
+   **Visual stack & swipe-back** (single-device baseline)
+   - Sim's nav bar **principal slot** shows leaf icon + scenario name
+     (single-line, truncating with `…` if too long) + status pill
+     ("Simulating" / "Paused" / "Completed").
    - The **back chevron** still shows the upstream `ScenarioDetail`'s
-     title (iOS uses the previous view's title for the back button,
-     not the current view's).
-   - `GameHeader` row 1 shows the scenario name on first frame
-     (driven by `Route.simulation.initialName` `RouteHint`) — no
-     visible pop-in delay between push and `loadAndRun()` finishing.
-   - VoiceOver focus on the `GameHeader` reads the combined
-     accessibility label ("Simulating, scenarioName, Round X of Y,
-     phaseLabel, …") — Sim's nav-title-empty does not leave the
-     screen unannounced.
+     title (iOS uses the previous view's title — chevron + label
+     remain Liquid-Glass-styled on iOS 26; tracked separately at
+     #342).
+   - `GameHeader.titleRow` (in the bar) shows the scenario name on
+     first frame (driven by `Route.simulation.initialName`
+     `RouteHint`) — no visible pop-in delay between push and
+     `loadAndRun()` finishing.
+   - **No transient double-title** during the push-in animation from
+     `ScenarioDetail` (the bda1f70 regression that forced 7af22d0).
+   - **Swipe-back from left edge** returns to `ScenarioDetail`. The
+     bar slot stays interactive throughout (FB13484530 — the
+     `.toolbar(.hidden)` regression — does NOT affect
+     `.toolbarBackground(.hidden)`).
+
+   **Frosted-BG continuity & scroll-edge transition**
+   - The frosted moss material visually spans status bar + nav bar
+     slot + meta-row inset as one continuous strip — no hairline at
+     the bar / inset boundary.
+   - Scroll the chat-stream from the very top to mid-conversation
+     and back. The bar's background **stays transparent**
+     throughout (no flicker between iOS's `scrollEdgeAppearance`
+     and `standardAppearance` — `.toolbarBackground(.hidden, for:
+     .navigationBar)` covers both).
+
+   **Multi-device truncation matrix** (cross-device)
+   - On a small iPhone (SE 3rd gen / 13 mini) verify the principal
+     slot fits without unexpected truncation:
+     - With each of the 4 status pills (`Simulating`, `Paused`,
+       `Completed`, `Demoing`) — the longest localized status drives
+       the worst-case width pressure.
+     - With a long Japanese scenario name (e.g.,
+       "とても長い日本語のシナリオ名で切り詰めを検証する").
+     - Title truncates with trailing `…`; status pill never
+       compresses (`.fixedSize(horizontal: true)` +
+       `.layoutPriority(1)` contract from `GameHeader.titleRow`).
+   - Run on **iOS 17.x** AND **iOS 18.x** simulator / device. iOS
+     17 is the deployment-target floor and the version where
+     FB13484530 surfaced — verify swipe-back independently on each.
+
+   **Status bar legibility against frosted moss BG**
+   - Pull-up Control Center / observe the status bar glyphs (clock,
+     battery, signal) over the GameHeader's frosted moss material.
+     Verify legibility in:
+     - **Light mode**, **Dark mode**.
+     - **Increase Contrast** accessibility setting on (Settings >
+       Accessibility > Display & Text Size > Increase Contrast).
+     - High-contrast chat content scrolled to the very top
+       (white / black bubble against the glyphs).
+   - If glyphs are hard to read in any combination, file a follow-up
+     to set `.toolbarColorScheme(.dark, for: .navigationBar)` (or
+     `preferredStatusBarStyle`) on Sim.
+
+   **VoiceOver — 3-stop traversal**
+   The split rendering crosses the UIKit ↔ SwiftUI a11y boundary;
+   the original single combined-element stop becomes 3 stops:
+
+   - **Stop 1 — back button** (system-managed): "Back, button,
+     `<ScenarioDetailViewTitle>`".
+   - **Stop 2 — title row** (combined element with `.isHeader`
+     trait): `"<status>, <scenarioName>"` — e.g., `"Simulating,
+     ワードウルフ"` or `"Completed"` (collapses to status when title
+     is empty).
+   - **Stop 3 — meta row** (combined element): `"<round>,
+     <phase>, <tok/s>"` — e.g., `"Round 2 / 5, negotiation, 16.5
+     tok/s"`. Each fragment collapses on nil; the row itself is
+     skipped when all 3 inputs are nil.
+
+   Verifications:
+   - VoiceOver swipe-right from focus on `Back` advances through the
+     two header stops in the order above before reaching the first
+     chat row.
+   - **Rotor → Headings** lands on the title row (Stop 2 carries
+     `.accessibilityAddTraits(.isHeader)`).
+   - The title-row `.isHeader` trait does not bleed into Demo's
+     unified `body` rendering (Demo's `body` re-combines into a
+     single stop with the joined label and remains a single VO
+     focus — verify on Demo screen).
 3. **Editor save → Home reload** — `EditorReloadTests` covers the
    `onChange(of: router.path.count)` pop-trigger path. Note: the trigger
    only fires when `newCount < oldCount` (a pop). Flows that finish by

--- a/.claude/rules/navigation.md
+++ b/.claude/rules/navigation.md
@@ -251,10 +251,12 @@ surface changes in areas the automated tests do not exercise.
      chat row.
    - **Rotor → Headings** lands on the title row (Stop 2 carries
      `.accessibilityAddTraits(.isHeader)`).
-   - The title-row `.isHeader` trait does not bleed into Demo's
-     unified `body` rendering (Demo's `body` re-combines into a
-     single stop with the joined label and remains a single VO
-     focus — verify on Demo screen).
+   - On Demo (unified `body` host): the `.isHeader` trait propagates
+     up via `.accessibilityElement(children: .combine)` so Demo's
+     single VO stop also responds to rotor-Headings. Semantically
+     fine — Demo's GameHeader is the screen's primary heading. Verify
+     rotor-Headings on Demo lands on the GameHeader, not on a chat
+     row.
 3. **Editor save → Home reload** — `EditorReloadTests` covers the
    `onChange(of: router.path.count)` pop-trigger path. Note: the trigger
    only fires when `newCount < oldCount` (a pop). Flows that finish by

--- a/Pastura/Pastura/Views/Components/GameHeader+Previews.swift
+++ b/Pastura/Pastura/Views/Components/GameHeader+Previews.swift
@@ -1,0 +1,108 @@
+import SwiftUI
+
+// Previews live in a sibling file because GameHeader.swift hit
+// SwiftLint's 400-line `file_length` cap after the row-split refactor
+// (#312). The preview suite is naturally self-contained — extracting
+// it keeps the main file focused on the View + helpers + a11y label
+// composition without touching public-API surface.
+
+#Preview("Demo (preset + phase, no tok/s)") {
+  VStack(spacing: 0) {
+    GameHeader(
+      scenarioName: "ワードウルフ",
+      status: .demoing,
+      round: GameHeaderRound(current: 1, total: 4),
+      phaseLabel: "個別発言",
+      extendsIntoTopSafeArea: true
+    )
+    Spacer()
+  }
+  .background(Color.screenBackground)
+}
+
+#Preview("Sim — Simulating") {
+  VStack(spacing: 0) {
+    GameHeader(
+      scenarioName: "囚人のジレンマ",
+      status: .simulating,
+      round: GameHeaderRound(current: 2, total: 5),
+      phaseLabel: "negotiation",
+      tokensPerSecond: 16.5
+    )
+    Spacer()
+  }
+  .background(Color.screenBackground)
+}
+
+#Preview("Sim — Paused") {
+  VStack(spacing: 0) {
+    GameHeader(
+      scenarioName: "囚人のジレンマ",
+      status: .paused,
+      round: GameHeaderRound(current: 2, total: 5),
+      phaseLabel: "negotiation",
+      tokensPerSecond: 12.3
+    )
+    Spacer()
+  }
+  .background(Color.screenBackground)
+}
+
+#Preview("Sim — Completed") {
+  VStack(spacing: 0) {
+    GameHeader(
+      scenarioName: "囚人のジレンマ",
+      status: .completed,
+      round: GameHeaderRound(current: 5, total: 5),
+      phaseLabel: "scoreboard"
+    )
+    Spacer()
+  }
+  .background(Color.screenBackground)
+}
+
+#Preview("First-frame fallback (initialName)") {
+  VStack(spacing: 0) {
+    GameHeader(
+      scenarioName: nil,
+      initialName: "ワードウルフ",
+      status: .simulating,
+      phaseLabel: "loading"
+    )
+    Spacer()
+  }
+  .background(Color.screenBackground)
+}
+
+// Worst-case truncation preview: longest localized status label
+// (`Simulating`) crossed with a long Japanese scenario name on the
+// narrowest iPhone form factor. Sim's `ToolbarItem(.principal)` slot
+// is even narrower than the `body`'s rendering width — this preview
+// approximates the principal-slot constraint by clamping width. If
+// the title doesn't truncate cleanly with the pill staying intact,
+// the truncation contract (`.lineLimit(1) + .truncationMode(.tail)`
+// on title; `.fixedSize + .layoutPriority(1)` on pill) has regressed.
+#Preview("Sim — narrow / long-title truncation contract") {
+  VStack(spacing: 12) {
+    ForEach(
+      [
+        GameHeaderStatus.simulating,
+        GameHeaderStatus.paused,
+        GameHeaderStatus.completed,
+        GameHeaderStatus.demoing
+      ],
+      id: \.self
+    ) { status in
+      GameHeader(
+        scenarioName: "とても長い日本語のシナリオ名で切り詰めを検証する",
+        status: status,
+        round: GameHeaderRound(current: 12, total: 100),
+        phaseLabel: "発言ラウンド",
+        tokensPerSecond: 16.5
+      )
+      .frame(width: 320)  // approximates iPhone SE principal-slot width
+    }
+    Spacer()
+  }
+  .background(Color.screenBackground)
+}

--- a/Pastura/Pastura/Views/Components/GameHeader.swift
+++ b/Pastura/Pastura/Views/Components/GameHeader.swift
@@ -5,24 +5,42 @@ import SwiftUI
 /// deferred — see #297).
 ///
 /// Two-row layout:
-/// - **Row 1** — leaf icon + scenario title (`titleScenario`, 16pt) +
-///   `GameHeaderStatus` pill (always visible).
-/// - **Row 2** — `ROUND X / Y` (`metaRound`, mono UPPER) + `·`
-///   separator + phase name (`metaInline`) + `Spacer` + tok/s
+/// - **Row 1** (`titleRow`) — leaf icon + scenario title (`titleScenario`,
+///   16pt, single-line truncating) + `GameHeaderStatus` pill (always
+///   visible, fixed-size, layout-priority protected).
+/// - **Row 2** (`metaRow`) — `ROUND X / Y` (`metaRound`, mono UPPER) +
+///   `·` separator + phase name (`metaInline`) + `Spacer` + tok/s
 ///   (`metaInline`, right-aligned). Each fragment is conditional —
-///   nil/missing inputs collapse the corresponding piece.
+///   nil/missing inputs collapse the corresponding piece. The whole
+///   row collapses when all three are nil.
 ///
 /// First-frame correctness for the title comes from ADR-008's
 /// `RouteHint<String>` pattern: `scenarioName` (the loaded VM value,
 /// authoritative once available) falls back to `initialName` (the
-/// push-time hint) and then to an empty string while loading. This
-/// sink replaces `.navigationTitle()`'s previous role on
-/// `SimulationView` — see ADR-008 §Amendment.
+/// push-time hint) and then to an empty string while loading.
 ///
-/// Sim opts out of `extendsIntoTopSafeArea` (default `false`) because
-/// its NavigationStack-pushed nav bar already paints the top safe
-/// area; Demo opts in (`true`) because it presents inside
-/// `.fullScreenCover` with no system nav bar above it.
+/// ## Rendering modes
+///
+/// - **Unified `body`** — Demo's `ModelDownloadHostView` path. Both
+///   rows render together inside a single frosted-material container,
+///   `extendsIntoTopSafeArea: true` so the moss-tinted material fills
+///   behind the status bar / Dynamic Island. VoiceOver reads as a
+///   single combined element.
+/// - **Split `titleRow` / `metaRow`** — Sim's "fill the bar" path
+///   (ADR-008 §Amendment 2026-05-10). Title row is hosted inside the
+///   system nav bar via `ToolbarItem(placement: .principal)`; meta
+///   row is mounted via `.safeAreaInset(edge: .top)` directly below.
+///   The system bar's background is hidden via
+///   `.toolbarBackground(.hidden, for: .navigationBar)` so the chevron
+///   stays interactive (preserving swipe-back gesture and the upstream
+///   view's title as the back-button label) while the 44pt slot is
+///   reclaimed by the title row's content. VoiceOver traversal becomes
+///   3-stop: back-button → title row → meta row → first chat row. The
+///   caller is responsible for providing frosted-material backgrounds
+///   per row in this mode (the sub-views render content only).
+///
+/// `extendsIntoTopSafeArea` applies only to the unified `body`; the
+/// split sub-views ignore it (the host decides their containment).
 public struct GameHeader: View {
 
   /// Resolved scenario title (authoritative). Pass `nil` while the
@@ -46,9 +64,9 @@ public struct GameHeader: View {
   /// fragment — Demo passes nil per the "no synthetic numbers"
   /// product principle.
   public let tokensPerSecond: Double?
-  /// When `true`, the frosted background extends behind the top
-  /// safe area (status bar / Dynamic Island). See type doc-comment
-  /// for Demo / Sim guidance.
+  /// When `true`, the unified `body`'s frosted background extends
+  /// behind the top safe area (status bar / Dynamic Island). Has no
+  /// effect on `titleRow` / `metaRow` when used as split sub-views.
   public let extendsIntoTopSafeArea: Bool
 
   public init(
@@ -92,6 +110,39 @@ public struct GameHeader: View {
     String(format: "%.1f tok/s", value)
   }
 
+  /// VoiceOver label for the title row (status + scenario name).
+  /// Status comes first so the user hears the screen state before
+  /// the scenario identity — matches the original combined-label
+  /// ordering. Empty title (both `scenarioName` and `initialName` nil
+  /// or empty string) collapses to status-only.
+  static func titleAccessibilityLabel(
+    scenarioName: String?, initialName: String?, status: GameHeaderStatus
+  ) -> String {
+    let title = resolveDisplayedTitle(
+      scenarioName: scenarioName, initialName: initialName)
+    var parts: [String] = [status.label]
+    if !title.isEmpty { parts.append(title) }
+    return parts.joined(separator: String(localized: ", "))
+  }
+
+  /// VoiceOver label for the meta row (round + phase + tok/s).
+  /// Returns the empty string when all three inputs are nil — caller
+  /// can guard on `isEmpty` to skip applying the label when the row
+  /// itself is collapsed. Locale-aware separator (`, ` en / `、` ja).
+  static func metaAccessibilityLabel(
+    round: GameHeaderRound?, phaseLabel: String?, tokensPerSecond: Double?
+  ) -> String {
+    var parts: [String] = []
+    if let round {
+      parts.append(formatRoundLabel(current: round.current, total: round.total))
+    }
+    if let phaseLabel { parts.append(phaseLabel) }
+    if let tokensPerSecond {
+      parts.append(formatTokensPerSecond(tokensPerSecond))
+    }
+    return parts.joined(separator: String(localized: ", "))
+  }
+
   // MARK: - Layout
 
   private var displayedTitle: String {
@@ -104,22 +155,25 @@ public struct GameHeader: View {
     round != nil || phaseLabel != nil || tokensPerSecond != nil
   }
 
-  /// Combined accessibility label so VoiceOver reads the header as
-  /// one focusable element rather than fragmenting across icon /
-  /// title / pill / meta-row pieces. The list separator is itself
-  /// localized (en `, ` / ja `、`) so VO honours the locale's natural
-  /// punctuation when pausing between fragments.
-  private var accessibilityLabelText: String {
-    var parts: [String] = [status.label]
-    if !displayedTitle.isEmpty { parts.append(displayedTitle) }
-    if let round {
-      parts.append(Self.formatRoundLabel(current: round.current, total: round.total))
-    }
-    if let phaseLabel { parts.append(phaseLabel) }
-    if let tokensPerSecond {
-      parts.append(Self.formatTokensPerSecond(tokensPerSecond))
-    }
-    return parts.joined(separator: String(localized: ", "))
+  private var titleA11yLabel: String {
+    Self.titleAccessibilityLabel(
+      scenarioName: scenarioName, initialName: initialName, status: status)
+  }
+
+  private var metaA11yLabel: String {
+    Self.metaAccessibilityLabel(
+      round: round, phaseLabel: phaseLabel, tokensPerSecond: tokensPerSecond)
+  }
+
+  /// Combined label for the unified `body` rendering — preserves the
+  /// pre-split single-stop UX (Demo path). The split sub-views own
+  /// their own labels independently when hosted in different
+  /// containers (Sim path).
+  private var combinedAccessibilityLabel: String {
+    let title = titleA11yLabel
+    let meta = metaA11yLabel
+    if meta.isEmpty { return title }
+    return "\(title)\(String(localized: ", "))\(meta)"
   }
 
   // Local layout constants — the GameHeader has its own dimensional
@@ -152,23 +206,51 @@ public struct GameHeader: View {
         .frame(height: 1)
     }
     .accessibilityElement(children: .combine)
-    .accessibilityLabel(accessibilityLabelText)
+    .accessibilityLabel(combinedAccessibilityLabel)
   }
 
-  private var titleRow: some View {
+  /// Title row — leaf icon + scenario name + status pill. Renders
+  /// content only (no background); caller wraps with material as
+  /// needed when used as a split sub-view.
+  ///
+  /// Layout contract (Sim's `ToolbarItem(.principal)` placement is
+  /// width-constrained on small iPhones — see ADR-008 §Amendment
+  /// 2026-05-10):
+  /// - Title shrinks first via `.lineLimit(1) + .truncationMode(.tail)`.
+  ///   No `.minimumScaleFactor` — the design system's load-bearing
+  ///   fixed sizes (see `PasturaTextStyle.font`) preclude runtime
+  ///   font scaling.
+  /// - Status pill protected via `.fixedSize(horizontal: true) +
+  ///   .layoutPriority(1)` so the pill never compresses; the title
+  ///   yields the available width.
+  /// - Carries `.accessibilityAddTraits(.isHeader)` so the rotor
+  ///   "Headings" navigation can jump to it on Sim and Demo alike.
+  var titleRow: some View {
     HStack(alignment: .center, spacing: Spacing.xs) {
       LeafIcon()
         .frame(width: 9, height: 9)
       Text(displayedTitle)
         .textStyle(Typography.titleScenario)
         .foregroundStyle(Color.ink)
+        .lineLimit(1)
+        .truncationMode(.tail)
       Spacer(minLength: Spacing.xs)
       statusPill
+        .fixedSize(horizontal: true, vertical: false)
+        .layoutPriority(1)
     }
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(titleA11yLabel)
+    .accessibilityAddTraits(.isHeader)
   }
 
+  /// Meta row — ROUND + phase + tok/s. Renders content only (no
+  /// background). Caller is responsible for collapsing the row entirely
+  /// when `hasMetaRow == false` is preferred — when used as a split
+  /// sub-view the placement (e.g., `.safeAreaInset`) decides whether
+  /// to mount this view at all.
   @ViewBuilder
-  private var metaRow: some View {
+  var metaRow: some View {
     HStack(alignment: .center, spacing: Self.metaRowSpacing) {
       if let round {
         Text(Self.formatRoundLabel(current: round.current, total: round.total))
@@ -194,6 +276,8 @@ public struct GameHeader: View {
           .monospacedDigit()
       }
     }
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(metaA11yLabel)
   }
 
   private var statusPill: some View {
@@ -237,72 +321,5 @@ private struct GameHeaderTopSafeAreaExtension: ViewModifier {
   }
 }
 
-// MARK: - Previews
-
-#Preview("Demo (preset + phase, no tok/s)") {
-  VStack(spacing: 0) {
-    GameHeader(
-      scenarioName: "ワードウルフ",
-      status: .demoing,
-      round: GameHeaderRound(current: 1, total: 4),
-      phaseLabel: "個別発言",
-      extendsIntoTopSafeArea: true
-    )
-    Spacer()
-  }
-  .background(Color.screenBackground)
-}
-
-#Preview("Sim — Simulating") {
-  VStack(spacing: 0) {
-    GameHeader(
-      scenarioName: "囚人のジレンマ",
-      status: .simulating,
-      round: GameHeaderRound(current: 2, total: 5),
-      phaseLabel: "negotiation",
-      tokensPerSecond: 16.5
-    )
-    Spacer()
-  }
-  .background(Color.screenBackground)
-}
-
-#Preview("Sim — Paused") {
-  VStack(spacing: 0) {
-    GameHeader(
-      scenarioName: "囚人のジレンマ",
-      status: .paused,
-      round: GameHeaderRound(current: 2, total: 5),
-      phaseLabel: "negotiation",
-      tokensPerSecond: 12.3
-    )
-    Spacer()
-  }
-  .background(Color.screenBackground)
-}
-
-#Preview("Sim — Completed") {
-  VStack(spacing: 0) {
-    GameHeader(
-      scenarioName: "囚人のジレンマ",
-      status: .completed,
-      round: GameHeaderRound(current: 5, total: 5),
-      phaseLabel: "scoreboard"
-    )
-    Spacer()
-  }
-  .background(Color.screenBackground)
-}
-
-#Preview("First-frame fallback (initialName)") {
-  VStack(spacing: 0) {
-    GameHeader(
-      scenarioName: nil,
-      initialName: "ワードウルフ",
-      status: .simulating,
-      phaseLabel: "loading"
-    )
-    Spacer()
-  }
-  .background(Color.screenBackground)
-}
+// Previews live in `GameHeader+Previews.swift` (sibling file) — the
+// file_length cap was forcing a split after the row-split refactor.

--- a/Pastura/Pastura/Views/Components/GameHeader.swift
+++ b/Pastura/Pastura/Views/Components/GameHeader.swift
@@ -150,8 +150,10 @@ public struct GameHeader: View {
   }
 
   /// Whether row 2 has any visible fragment. Row collapses entirely
-  /// when none of ROUND / phase / tok/s is present.
-  private var hasMetaRow: Bool {
+  /// when none of ROUND / phase / tok/s is present. Exposed so the
+  /// split-rendering host (Sim's `safeAreaInset`) can guard whether
+  /// to mount `metaRow` at all.
+  var hasMetaRow: Bool {
     round != nil || phaseLabel != nil || tokensPerSecond != nil
   }
 

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -364,6 +364,15 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
           .padding(.horizontal, 18)
           .padding(.top, 4)
           .padding(.bottom, 8)
+      } else {
+        // Pre-load and post-completion states can land here with all
+        // three meta-row inputs nil. The inset must still have positive
+        // layout height for its frosted background's
+        // `.ignoresSafeArea(.container, edges: .top)` to anchor and
+        // paint behind the (transparent) nav bar — otherwise the
+        // principal-slot title would sit naked over scrolling chat
+        // content. A 1pt invisible spacer is the minimal anchor.
+        Color.clear.frame(height: 1)
       }
     }
     .frame(maxWidth: .infinity, alignment: .leading)

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -47,20 +47,27 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
         ProgressView(String(localized: "Loading scenario..."))
       }
     }
-    // Empty navigation title — `GameHeader` (#297 PR 3) now carries
-    // the scenario name on row 1, and surfacing the same value in the
-    // nav bar would duplicate it. The 3-tier fallback chain
-    // (loaded VM name → push-time `initialName` hint → empty string)
-    // moved into `GameHeader`'s `scenarioName` / `initialName`
-    // arguments — see `headerBar(viewModel:)`. ADR-008 §Amendment
-    // 2026-04-29 records the sink pivot.
+    // "Fill the bar" pattern (#312, ADR-008 §Amendment 2026-05-10).
+    // The system nav bar stays in the layout (preserving swipe-back
+    // gesture and the chevron + back-button label that reads the
+    // upstream `ScenarioDetail`'s title), but its background is
+    // hidden so the GameHeader's frosted material — extended into
+    // the top safe area from the meta-row inset below — fills the
+    // 44pt slot continuously. Row 1 of the GameHeader (title +
+    // status pill) is hosted inside the bar via `ToolbarItem`
+    // (`.principal`) so the previously-empty 44pt is now reclaimed
+    // by useful content. Row 2 (round + phase + tok/s) mounts via
+    // `.safeAreaInset(.top)` directly below.
     //
-    // Back chevron continues to read the upstream `ScenarioDetail`
-    // view's title (iOS uses the previous view's title, not the
-    // current view's, for the back-button label) so popping back
-    // remains discoverable.
+    // bda1f70 attempted to reclaim the 44pt by hiding the bar
+    // entirely (`.toolbar(.hidden, for: .navigationBar)`) and was
+    // reverted in 7af22d0 because that API has a known iOS 17.x bug
+    // (FB13484530) that disables the interactive pop gesture. The
+    // background-only `.toolbarBackground(.hidden, ...)` used here
+    // does NOT share that bug — the bar remains in the hierarchy.
     .navigationTitle("")
     .navigationBarTitleDisplayMode(.inline)
+    .toolbarBackground(.hidden, for: .navigationBar)
     .task {
       await loadAndRun()
     }
@@ -139,13 +146,6 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
     viewModel: SimulationViewModel
   ) -> some View {
     VStack(spacing: 0) {
-      // Header bar
-      headerBar(viewModel: viewModel)
-        .accessibilityElement(children: .contain)
-        .accessibilityIdentifier("simulation.header")
-
-      Divider()
-
       // Log
       ScrollViewReader { proxy in
         ScrollView {
@@ -261,6 +261,24 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
         modelReloadingOverlay
       }
     }
+    // "Fill the bar" — title row goes into the system nav bar's
+    // principal slot (reclaiming the previously-empty 44pt strip);
+    // meta row mounts via `safeAreaInset(.top)` with frosted BG
+    // extending up behind the (transparent) bar for visual
+    // continuity. See ADR-008 §Amendment 2026-05-10.
+    .toolbar {
+      ToolbarItem(placement: .principal) {
+        makeHeader(viewModel: viewModel)
+          .titleRow
+          // Pin a non-collapsing identity for the toolbar item so
+          // SwiftUI doesn't re-create / re-animate it on every
+          // VM-driven status change.
+          .accessibilityIdentifier("simulation.header.title")
+      }
+    }
+    .safeAreaInset(edge: .top, spacing: 0) {
+      headerMetaInset(viewModel: viewModel)
+    }
   }
 
   private var modelReloadingOverlay: some View {
@@ -284,31 +302,32 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
 
   // MARK: - Header
 
-  /// Sim composition of the shared `GameHeader` (#297 PR 3 — header
-  /// content unification). Demo's `+GameHeader.swift` extension uses
-  /// the same component on the DL-time replay screen. See
-  /// `Views/Components/GameHeader.swift` for the contract.
+  /// Sim composition of the shared `GameHeader`. Sim uses the
+  /// **split** rendering — title row hosted in `ToolbarItem(.principal)`,
+  /// meta row mounted via `safeAreaInset(.top)`. Demo's
+  /// `+GameHeader.swift` extension uses the unified `body` instead
+  /// (it's hosted in `.fullScreenCover` with no nav bar above).
+  /// See `Views/Components/GameHeader.swift` for the rendering-modes
+  /// contract and ADR-008 §Amendment 2026-05-10 for the "fill the
+  /// bar" pivot rationale.
   ///
-  /// Sim passes:
-  /// - `scenarioName` / `initialName` — the same 3-tier fallback chain
-  ///   that previously fed `.navigationTitle()`. ADR-008 §Amendment
-  ///   2026-04-29 documents the sink pivot.
+  /// Inputs:
+  /// - `scenarioName` / `initialName` — the 3-tier fallback chain.
+  ///   ADR-008 §Amendment 2026-04-29 documents the sink pivot from
+  ///   `.navigationTitle()` to GameHeader's row 1.
   /// - `round` — `viewModel.headerRound` (`GameHeaderRound?`). Real
-  ///   game-rounds from `.roundStarted` events; the VM colocates the
-  ///   pair-or-nothing guard (`totalRounds > 0`) so the call site
-  ///   doesn't re-derive it (#313). Suppressed (nil) until the first
-  ///   `.roundStarted` lands so the ROUND fragment doesn't flash a
-  ///   stale `0/0` between scenario load and first round.
+  ///   game-rounds from `.roundStarted` events; pair-or-nothing
+  ///   guard lives on the VM (#313). Suppressed (nil) until the
+  ///   first `.roundStarted` lands so ROUND doesn't flash a stale
+  ///   `0/0` between scenario load and first round.
   /// - `phaseLabel` — formatted from `viewModel.currentPhase`.
   /// - `tokensPerSecond` — `averageTokensPerSecond` (live moving
-  ///   average). Drops the inference-duration display the legacy
-  ///   PhaseHeader trailing slot carried (`InferenceStatsFormatter`'s
-  ///   `"12.4 tok/s • 1.8s"`) — the new design has only one mono slot
-  ///   on row 2 for inference rate.
-  /// - `extendsIntoTopSafeArea: false` — Sim's NavigationStack-pushed
-  ///   nav bar already paints the top safe area; opting in would
-  ///   double the frosted material.
-  private func headerBar(viewModel: SimulationViewModel) -> some View {
+  ///   average).
+  /// - `extendsIntoTopSafeArea: false` — irrelevant for the split
+  ///   rendering (the unified `body` is not used). Sim's frosted
+  ///   continuity comes from `headerMetaInset`'s background ignoring
+  ///   the top safe area.
+  private func makeHeader(viewModel: SimulationViewModel) -> GameHeader {
     GameHeader(
       scenarioName: scenario?.name,
       initialName: initialName,
@@ -318,6 +337,50 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
       tokensPerSecond: viewModel.averageTokensPerSecond,
       extendsIntoTopSafeArea: false
     )
+  }
+
+  /// Meta-row inset content + frosted background that fills behind
+  /// the (transparent) nav bar via `.ignoresSafeArea(.container,
+  /// edges: .top)`. Always renders the BG strip (even when the meta
+  /// row collapses to empty for late-load / completion states), so
+  /// the principal-slot title above always sits over a frosted
+  /// surface — the visual unification that addresses #312's
+  /// cramped-stream finding.
+  ///
+  /// Padding: 18pt horizontal matches `GameHeader.headerInsets`
+  /// (HEADER_UPDATE.md design hand-off); vertical is asymmetric
+  /// (small top, full bottom) because the principal slot above
+  /// already provides the title row's vertical breathing room.
+  /// Bottom 1pt overlay rule mirrors the unified `body`'s
+  /// `Color.ink.opacity(0.07)` divider so split and unified
+  /// renderings share the same delineation against the chat stream.
+  private func headerMetaInset(
+    viewModel: SimulationViewModel
+  ) -> some View {
+    let header = makeHeader(viewModel: viewModel)
+    return Group {
+      if header.hasMetaRow {
+        header.metaRow
+          .padding(.horizontal, 18)
+          .padding(.top, 4)
+          .padding(.bottom, 8)
+      }
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background {
+      ZStack {
+        Color.screenBackground.opacity(0.78)
+        Rectangle().fill(.ultraThinMaterial)
+      }
+      .ignoresSafeArea(.container, edges: .top)
+    }
+    .overlay(alignment: .bottom) {
+      Rectangle()
+        .fill(Color.ink.opacity(0.07))
+        .frame(height: 1)
+    }
+    .accessibilityElement(children: .contain)
+    .accessibilityIdentifier("simulation.header.meta")
   }
 
   // MARK: - Log Entries

--- a/Pastura/PasturaTests/Views/GameHeaderContractTests.swift
+++ b/Pastura/PasturaTests/Views/GameHeaderContractTests.swift
@@ -115,4 +115,77 @@ struct GameHeaderContractTests {
     )
     #expect(header.round == GameHeaderRound(current: 2, total: 5))
   }
+
+  // MARK: - titleAccessibilityLabel composition (#312)
+
+  @Test func titleAccessibilityLabelPutsStatusFirst() {
+    // VoiceOver should announce screen state before identity.
+    let label = GameHeader.titleAccessibilityLabel(
+      scenarioName: "X", initialName: nil, status: .simulating)
+    #expect(label.hasPrefix("Simulating"))
+  }
+
+  @Test func titleAccessibilityLabelJoinsStatusAndTitleWithSeparator() {
+    // The `, ` separator is `String(localized: ", ")` — en resolves to ", ".
+    let label = GameHeader.titleAccessibilityLabel(
+      scenarioName: "Word Wolf", initialName: nil, status: .simulating)
+    #expect(label == "Simulating, Word Wolf")
+  }
+
+  @Test func titleAccessibilityLabelFallsBackToInitialName() {
+    let label = GameHeader.titleAccessibilityLabel(
+      scenarioName: nil, initialName: "WW Hint", status: .demoing)
+    #expect(label == "Demoing, WW Hint")
+  }
+
+  @Test func titleAccessibilityLabelCollapsesEmptyTitle() {
+    // Both nil → title is empty → no trailing separator, status only.
+    let label = GameHeader.titleAccessibilityLabel(
+      scenarioName: nil, initialName: nil, status: .completed)
+    #expect(label == "Completed")
+  }
+
+  @Test func titleAccessibilityLabelTreatsEmptyScenarioNameAsTitle() {
+    // `scenarioName: ""` wins over `initialName` per `resolveDisplayedTitle`
+    // contract (mirrors `emptyScenarioNameStillBeatsInitialName` above).
+    // Empty title → collapses to status only.
+    let label = GameHeader.titleAccessibilityLabel(
+      scenarioName: "", initialName: "WW Hint", status: .simulating)
+    #expect(label == "Simulating")
+  }
+
+  // MARK: - metaAccessibilityLabel composition (#312)
+
+  @Test func metaAccessibilityLabelReturnsEmptyWhenAllNil() {
+    let label = GameHeader.metaAccessibilityLabel(
+      round: nil, phaseLabel: nil, tokensPerSecond: nil)
+    #expect(label == "")
+  }
+
+  @Test func metaAccessibilityLabelIncludesRoundOnly() {
+    let label = GameHeader.metaAccessibilityLabel(
+      round: GameHeaderRound(current: 2, total: 5),
+      phaseLabel: nil, tokensPerSecond: nil)
+    #expect(label == "Round 2 / 5")
+  }
+
+  @Test func metaAccessibilityLabelIncludesPhaseOnly() {
+    let label = GameHeader.metaAccessibilityLabel(
+      round: nil, phaseLabel: "negotiation", tokensPerSecond: nil)
+    #expect(label == "negotiation")
+  }
+
+  @Test func metaAccessibilityLabelIncludesTokensOnly() {
+    // 16.5 — exactly representable as a half (16 + 0.5), platform-stable.
+    let label = GameHeader.metaAccessibilityLabel(
+      round: nil, phaseLabel: nil, tokensPerSecond: 16.5)
+    #expect(label == "16.5 tok/s")
+  }
+
+  @Test func metaAccessibilityLabelJoinsAllThreeWithSeparator() {
+    let label = GameHeader.metaAccessibilityLabel(
+      round: GameHeaderRound(current: 2, total: 5),
+      phaseLabel: "negotiation", tokensPerSecond: 16.5)
+    #expect(label == "Round 2 / 5, negotiation, 16.5 tok/s")
+  }
 }

--- a/docs/decisions/ADR-008.md
+++ b/docs/decisions/ADR-008.md
@@ -208,8 +208,9 @@ the `GameHeader`, making the chat-stream uncomfortably cramped — the
 44pt was structurally retained for a discoverability invariant
 (chevron) but not contributing any user-facing content.
 
-A first attempt (PR-tree commits `bda1f70`, reverted in `7af22d0`)
-hid the bar entirely via
+A first attempt within #312's history (a feature-branch commit and
+its revert, since dropped from the merged tree — see #312's
+discussion for archaeology) hid the bar entirely via
 `.toolbar(.hidden, for: .navigationBar)` + `extendsIntoTopSafeArea: true`
 on the GameHeader. That recovered the 44pt but introduced two
 load-bearing regressions, only reproducible on physical devices:
@@ -353,9 +354,9 @@ of change):
 ### References (amendment)
 
 - Issue #312 — refactor: reclaim Sim nav bar 44pt overhead while
-  keeping swipe-back.
-- `bda1f70` — attempted full bar-hide.
-- `7af22d0` — revert.
+  keeping swipe-back. Branch history (now squashed / dropped) holds
+  the full-bar-hide attempt and its revert; #312's discussion
+  preserves the rationale.
 - WWDC25 sessions 256 / 323 — Liquid Glass + new SwiftUI design
   system (context for the iOS 26 styling concern surfaced at #342).
 - FB13484530 — Apple Feedback for the

--- a/docs/decisions/ADR-008.md
+++ b/docs/decisions/ADR-008.md
@@ -179,7 +179,10 @@ sinks but identical semantics (push-time first-frame placeholder).
   would match exactly). Rejected because it removes the back chevron
   — back navigation would require swipe-back gesture only, which is
   less discoverable. `.navigationTitle("")` keeps the chevron visible
-  while erasing the duplicate text.
+  while erasing the duplicate text. *Refined by §Amendment 2026-05-10
+  — the empty-title approach was further found to leave a 44pt
+  unused strip above the GameHeader (cramped chat-stream on small
+  iPhones); see below for the "fill the bar" refinement.*
 
 ### References (amendment)
 
@@ -191,3 +194,183 @@ sinks but identical semantics (push-time first-frame placeholder).
   — Demo's parallel composition (does not use `RouteHint` because
   Demo is presented as a `.fullScreenCover`, not pushed onto a
   `NavigationStack`, so there is no push-time hint to plumb).
+
+## Amendment 2026-05-10 — "Fill the bar": Sim hosts the title row inside `ToolbarItem(.principal)`
+
+### Context
+
+§Amendment 2026-04-29 ended on
+`.navigationTitle("")` + `.navigationBarTitleDisplayMode(.inline)` —
+the system nav bar stayed visible (preserving back-chevron + swipe-back)
+but its title slot was empty. Real-device QA on smaller iPhones
+(SE / 13 mini) found this left a ~44pt visually-empty strip above
+the `GameHeader`, making the chat-stream uncomfortably cramped — the
+44pt was structurally retained for a discoverability invariant
+(chevron) but not contributing any user-facing content.
+
+A first attempt (PR-tree commits `bda1f70`, reverted in `7af22d0`)
+hid the bar entirely via
+`.toolbar(.hidden, for: .navigationBar)` + `extendsIntoTopSafeArea: true`
+on the GameHeader. That recovered the 44pt but introduced two
+load-bearing regressions, only reproducible on physical devices:
+
+1. **Swipe-back gesture lost.** `.toolbar(.hidden, for:)` is iOS
+   17.x bug FB13484530 — it disables
+   `interactivePopGestureRecognizer` inside `NavigationStack`. The
+   user is stranded; the in-stream cancel button becomes the only
+   exit. iOS 18+ replacement `.toolbarVisibility(.hidden, ...)` shares
+   the same bug surface (the bug is on bar *removal*, not the
+   modifier name).
+2. **Transient double scenario-title during push animation.** During
+   the slide-in from `ScenarioDetailView`, the bar momentarily
+   rendered with the upstream title visible as the back-button label
+   before the `.toolbar(.hidden)` modifier applied on body update —
+   producing a several-second visual duplicate against `GameHeader`'s
+   row 1 title. Reproduced 2/2 on device.
+
+### Industry pattern (research)
+
+Production iOS chat / messaging apps — Messages, Slack, Telegram,
+WhatsApp, Discord, X — *all* keep the system nav bar present on
+chat-detail screens (~44pt with chevron + edge-swipe back). They
+**reclaim** the slot by *occupying* it: a custom title view
+(UIKit `titleView` / SwiftUI `ToolbarItem(.principal)`) carries the
+contact / channel / chat identity inside the bar's content area. The
+44pt is no longer "empty" — it carries useful content. Apple HIG
+explicitly steers full-bar-hide toward immersive content (media,
+full-takeover) rather than chat / list screens, and reserves
+`.fullScreenCover` for "focused-task modals" rather than hierarchical
+navigation.
+
+### Decision
+
+Adopt the "fill the bar" pattern:
+
+- `SimulationView` applies `.toolbarBackground(.hidden, for: .navigationBar)`.
+  This hides only the bar's background material; the bar itself stays
+  in the layout, the chevron stays interactive, and swipe-back is
+  preserved (the FB13484530 bug surface is on bar *removal*, not
+  background-only transparency).
+- Row 1 of the GameHeader (`titleRow` — leaf icon + scenario name +
+  status pill) renders inside the bar via
+  `ToolbarItem(placement: .principal)`. The previously-empty 44pt
+  is now reclaimed by useful content.
+- Row 2 (`metaRow` — round + phase + tok/s) mounts via
+  `safeAreaInset(edge: .top)` directly below the bar. Its frosted
+  background uses `.ignoresSafeArea(.container, edges: .top)` to
+  extend up *behind* the (transparent) bar AND the status bar,
+  providing visual continuity so the chevron + title row sit over a
+  unified frosted moss surface.
+- `GameHeader` is refactored so `titleRow` and `metaRow` are
+  separately renderable (Sim's split path), while the unified `body`
+  remains for Demo's `.fullScreenCover` host (no nav bar above —
+  unified rendering is correct there).
+
+### Accepted trade-offs
+
+These are explicit trade-offs against the prior single-element design:
+
+- **VoiceOver becomes 3-stop traversal**: back-button → `titleRow` →
+  `metaRow` → first chat row. Previously the unified `body` exposed
+  one combined-element stop. The split crosses the UIKit
+  (toolbar) ↔ SwiftUI (`safeAreaInset`) accessibility boundary, which
+  cannot be merged into a single VO element. To compensate, each
+  sub-view carries its own `.accessibilityElement(children: .combine)`
+  with a curated combined label
+  (`titleAccessibilityLabel` = status + scenario name;
+  `metaAccessibilityLabel` = round + phase + tok/s), and the title
+  row gains `.accessibilityAddTraits(.isHeader)` so rotor "Headings"
+  navigation can land directly on it. Demo's unified `body` still
+  re-combines into a single stop with the joined label —
+  Demo's VoiceOver UX is unchanged.
+
+- **Title truncation only — no font shrinkage**: the principal slot
+  is narrower than the GameHeader's row width on iPhone SE / 13 mini
+  (chevron + back-button label consume the leading side). The title
+  uses `.lineLimit(1) + .truncationMode(.tail)` *without*
+  `.minimumScaleFactor`, so long Japanese scenario names truncate
+  with `…` rather than shrink. This preserves the design system's
+  load-bearing fixed-size invariant
+  (`PasturaTextStyle.font` = `Font.system(size:)`, not Dynamic
+  Type aware — see `docs/design/design-system.md`). The status pill
+  is protected via
+  `.fixedSize(horizontal: true, vertical: false)` + `.layoutPriority(1)`
+  so the title is always the element that yields when width is
+  tight.
+
+- **System back button retains iOS 26 Liquid Glass styling**. The
+  chevron + back-button label render with iOS 26's translucent
+  glass-capsule treatment, which contrasts with Pastura's flat /
+  moss / frosted aesthetic. This visual incongruity is bounded
+  (leading-side only) and out of scope for this amendment; tracked
+  as a separate Phase 2 / 3 follow-up at #342 (replace all system
+  Liquid Glass controls with design-system customs).
+
+### Verification matrix
+
+Real-device QA (the simulator did not surface the bda1f70
+regressions, so device verification is load-bearing for this class
+of change):
+
+- ✅ iOS device — swipe-back gesture from Sim returns to ScenarioDetail
+- ✅ Frosted-BG visual continuity (no hairline / discontinuity at the
+  bar / `safeAreaInset` boundary)
+- ✅ Principal slot — leaf + scenario name + status pill fits without
+  truncation on tested device; long names truncate cleanly with `…`
+- ✅ ScrollEdge / standard appearance transition — chat-stream scroll
+  from start to mid-conversation, no flicker on the bar background
+- ✅ Status bar glyph contrast against frosted moss BG (Light + Dark)
+- ✅ No transient double-title during the push-in animation from
+  ScenarioDetail
+- Manual QA matrix (long names, status pills, light/dark, Increase
+  Contrast, multi-iOS) detailed in `.claude/rules/navigation.md`
+  scenario 2.
+
+### What was considered and rejected
+
+- **`.fullScreenCover` for Sim** (matching Demo's presentation
+  context). Apple HIG explicitly steers cover toward "focused-task
+  modals" — chat-streaming inside a hierarchical scenario flow
+  doesn't fit. Switching would lose `AppRouter` integration and
+  hierarchical-back semantics (cover dismissal is a vertical
+  swipe-down, not a back gesture). Hence rejected.
+- **UIKit Introspect to re-enable `interactivePopGestureRecognizer`
+  while keeping `.toolbar(.hidden, ...)`** (a `UIViewControllerRepresentable`
+  that walks up to the parent `UINavigationController` and clears
+  the gesture's delegate). The pattern works but requires
+  per-iOS-major-version revalidation; siteline/swiftui-introspect's
+  open issue #499 (NavigationStack + `searchable` interaction
+  breakage on iOS 26) illustrates the maintenance cost. The
+  "fill the bar" pattern needs no escape hatch and matches what
+  production chat apps do — strictly preferable.
+- **Trim `GameHeader.headerInsets` vertical padding** as a marginal
+  reclaim (e.g., 12 → 8 top, 10 → 6 bottom). Cross-cuts Demo's
+  hand-off-pinned dimensional spec; only saves a few points
+  (`<10pt`) which is structurally orthogonal to the 44pt bar slot.
+  Out of scope here; available as a separate design-system tweak
+  if Phase 2 visual QA flags a residual need.
+
+### References (amendment)
+
+- Issue #312 — refactor: reclaim Sim nav bar 44pt overhead while
+  keeping swipe-back.
+- `bda1f70` — attempted full bar-hide.
+- `7af22d0` — revert.
+- WWDC25 sessions 256 / 323 — Liquid Glass + new SwiftUI design
+  system (context for the iOS 26 styling concern surfaced at #342).
+- FB13484530 — Apple Feedback for the
+  `.toolbar(.hidden, for: .navigationBar)` + `interactivePopGestureRecognizer`
+  regression on iOS 17.x.
+- Issue #342 — follow-up: replace Liquid Glass system controls with
+  Pastura design-system customs.
+- `Pastura/Pastura/Views/Components/GameHeader.swift` — split-rendering
+  refactor (`titleRow`, `metaRow`, `titleAccessibilityLabel`,
+  `metaAccessibilityLabel`, `hasMetaRow` exposed).
+- `Pastura/Pastura/Views/Simulation/SimulationView.swift` —
+  `makeHeader(viewModel:)` + `headerMetaInset(viewModel:)` +
+  `.toolbarBackground(.hidden, for: .navigationBar)` +
+  `ToolbarItem(.principal)` + `.safeAreaInset(.top)`.
+- `Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+GameHeader.swift`
+  — Demo's `.fullScreenCover` composition continues to use the
+  unified `body` and is unaffected by this amendment.
+- `.claude/rules/navigation.md` § QA scenario 2 — manual QA matrix.


### PR DESCRIPTION
## Summary

Reclaims the previously-empty ~44pt strip above SimulationView's `GameHeader` by adopting the iOS / production-app standard "fill the bar" pattern (Apple HIG; Messages, Slack, Telegram, WhatsApp, Discord, X). The system nav bar stays in the layout (preserving the chevron + swipe-back gesture and the upstream `ScenarioDetail`'s back-button label) but its **background** is hidden via `.toolbarBackground(.hidden, for: .navigationBar)`. `GameHeader.titleRow` (leaf icon + scenario name + status pill) is now hosted inside the bar via `ToolbarItem(placement: .principal)`, and `GameHeader.metaRow` (round + phase + tok/s) mounts via `.safeAreaInset(.top)` directly below — its frosted background uses `.ignoresSafeArea(.container, edges: .top)` so the moss material fills behind the bar AND status bar for visual continuity.

A previous attempt (`bda1f70`, reverted in `7af22d0`) hid the bar entirely via `.toolbar(.hidden, for: .navigationBar)` + `extendsIntoTopSafeArea: true`; that hit the iOS 17.x FB13484530 bug (disables `interactivePopGestureRecognizer`) plus a transient double-title regression during the push-in animation. `.toolbarBackground(.hidden, ...)` does NOT share the FB13484530 surface — the bar remains in the hierarchy, only its background material is nullified.

### Structural changes

- `GameHeader.swift` refactored: `titleRow` and `metaRow` exposed as separately-renderable internal computed sub-views; unified `body` retained for Demo's `.fullScreenCover` host (no nav bar above).
- `titleAccessibilityLabel` / `metaAccessibilityLabel` static helpers extracted from the prior `accessibilityLabelText` so each split sub-view carries its own combined VoiceOver label.
- `titleRow` carries `.accessibilityAddTraits(.isHeader)` for rotor "Headings" navigation. Demo's body element inherits the trait via `.combine` (semantically correct — the GameHeader is the screen's primary heading).
- Layout contracts pinned for the principal-slot constraint on small iPhones: title gets `.lineLimit(1) + .truncationMode(.tail)` only (no `.minimumScaleFactor` — preserves design-system fixed-size invariant per `PasturaTextStyle.font`); status pill gets `.fixedSize(horizontal: true) + .layoutPriority(1)` so the title is always the element that yields when width is tight.
- `headerMetaInset` falls back to a 1pt `Color.clear` spacer when `hasMetaRow == false` (pre-load / completion states with all three meta inputs nil) to ensure the inset's frosted BG retains positive layout height for `.ignoresSafeArea` to anchor — otherwise the principal-slot title would sit naked over scrolling chat content.

### Accepted trade-offs (documented in ADR-008 §Amendment 2026-05-10)

- **VoiceOver becomes 3-stop traversal**: back-button → title row → meta row → first chat row. Previously a single combined-element stop. The split crosses the UIKit (toolbar) ↔ SwiftUI (`safeAreaInset`) accessibility boundary — these cannot merge into one element. Each sub-view's curated combined label keeps the user announcement coherent.
- **Title truncation only — no font shrinkage**: long Japanese scenario names truncate with `…` rather than scale down. Status pill is protected so the title yields first under width pressure.
- **iOS 26 Liquid Glass on the system back button**: chevron + back-button label retain iOS 26's translucent glass-capsule treatment. Bounded (leading-side only) and tracked separately at #342 (replace all system Liquid Glass controls with design-system customs).

### Documentation

- `docs/decisions/ADR-008.md` — new §Amendment 2026-05-10 with research-citation rationale, accepted trade-offs, rejected alternatives (`.fullScreenCover`, UIKit Introspect, `headerInsets` trim), and forward-pointer from §Amendment 2026-04-29's `.toolbar(.hidden)` rejected-alternative bullet.
- `.claude/rules/navigation.md` § QA scenario 2 — new visual / a11y / multi-device QA matrix with concrete VoiceOver utterance expectations per stop.

## Test plan

Automated:
- [x] `GameHeaderContractTests` — 23/23 pass (10 new tests pin the `titleAccessibilityLabel` / `metaAccessibilityLabel` static helpers including status-first ordering, fallback chain, locale-aware separator, nil-collapse semantics).
- [x] Full unit test suite — 1491 tests in 137 suites, **TEST SUCCEEDED** locally.
- [x] `swiftlint --strict` clean.

Manual (real-device QA, completed pre-merge):
- [x] Swipe-back from Sim returns to ScenarioDetail (FB13484530-class regression NOT triggered)
- [x] Frosted-BG visual continuity at the bar / `safeAreaInset` boundary (no hairline)
- [x] Principal slot — leaf + scenario name + status pill fits without truncation on tested device; long names truncate with `…`
- [x] ScrollEdge / standard appearance transition — no flicker on chat-stream scroll start ↔ deep
- [x] Status bar glyph contrast against frosted moss BG (Light + Dark)
- [x] No transient double-title during the push-in animation from ScenarioDetail

Pending follow-up (deferred):
- [ ] iOS 17.x device verification (deployment-target floor where FB13484530 originated). Also tracked at `.claude/rules/navigation.md` QA scenario 2's new multi-device matrix.
- [ ] Long Japanese scenario name × 4 status pills truncation visual on iPhone SE / 13 mini.
- [ ] VoiceOver 3-stop traversal verification — concrete utterances per stop.
- [ ] iOS 26 Liquid Glass system controls aesthetic divergence — see #342.

Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)