### PR TITLE
🐛 fix: enforce canonical fields inside conditional branches

### DIFF
--- a/Pastura/Pastura/Engine/ScenarioValidator.swift
+++ b/Pastura/Pastura/Engine/ScenarioValidator.swift
@@ -87,23 +87,47 @@ nonisolated struct ScenarioValidator: Sendable {
     return result
   }
 
-  /// Enforces ``ScenarioConventions/primaryField(for:)`` for LLM phases.
+  /// Enforces ``ScenarioConventions/primaryField(for:)`` for LLM phases,
+  /// recursing into `conditional` branches so canonical-field violations
+  /// inside `then:` / `else:` sub-phases are caught at commit time.
   /// Code phases are exempt (the conventions table returns `nil` and the
-  /// loop skips them).
+  /// per-phase check returns early). Termination is trivial: `.conditional`
+  /// is depth-1 by both `validateConditionalPhase` and the YAML parser
+  /// (`ScenarioLoader.mapPhase`), so the recursion bottoms out after one
+  /// descent.
   private func validateCanonicalPrimaryFields(_ scenario: Scenario) throws {
     for (index, phase) in scenario.phases.enumerated() {
-      guard let canonical = ScenarioConventions.primaryField(for: phase.type) else {
-        continue
-      }
-      let schema = phase.outputSchema ?? [:]
-      if schema[canonical] == nil {
-        throw SimulationError.scenarioValidationFailed(
-          String(
-            localized:
-              "Phase \(index + 1) (\(phase.type.rawValue)) requires field '\(canonical)' in output."
-          )
+      let label = "Phase \(index + 1)"
+      try validateCanonicalPrimaryField(in: phase, label: label)
+      try validateBranchCanonicalFields(
+        phase.thenPhases, parentLabel: label, branchLabel: "then")
+      try validateBranchCanonicalFields(
+        phase.elsePhases, parentLabel: label, branchLabel: "else")
+    }
+  }
+
+  private func validateCanonicalPrimaryField(in phase: Phase, label: String) throws {
+    guard let canonical = ScenarioConventions.primaryField(for: phase.type) else {
+      return
+    }
+    let schema = phase.outputSchema ?? [:]
+    if schema[canonical] == nil {
+      throw SimulationError.scenarioValidationFailed(
+        String(
+          localized:
+            "\(label) (\(phase.type.rawValue)) requires field '\(canonical)' in output."
         )
-      }
+      )
+    }
+  }
+
+  private func validateBranchCanonicalFields(
+    _ phases: [Phase]?, parentLabel: String, branchLabel: String
+  ) throws {
+    guard let phases else { return }
+    for (subIndex, subPhase) in phases.enumerated() {
+      try validateCanonicalPrimaryField(
+        in: subPhase, label: "\(parentLabel) \(branchLabel)[\(subIndex + 1)]")
     }
   }
 

--- a/Pastura/Pastura/Engine/ScenarioValidator.swift
+++ b/Pastura/Pastura/Engine/ScenarioValidator.swift
@@ -99,10 +99,14 @@ nonisolated struct ScenarioValidator: Sendable {
     for (index, phase) in scenario.phases.enumerated() {
       let label = "Phase \(index + 1)"
       try validateCanonicalPrimaryField(in: phase, label: label)
+      // Mirror `validateBranch`'s label shape so sub-phase errors carry
+      // the parent's "(conditional)" annotation — keeps a single mental
+      // template across all branch-related validator messages.
+      let parentLabel = "\(label) (\(phase.type.rawValue))"
       try validateBranchCanonicalFields(
-        phase.thenPhases, parentLabel: label, branchLabel: "then")
+        phase.thenPhases, parentLabel: parentLabel, branchLabel: "then")
       try validateBranchCanonicalFields(
-        phase.elsePhases, parentLabel: label, branchLabel: "else")
+        phase.elsePhases, parentLabel: parentLabel, branchLabel: "else")
     }
   }
 

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -59,6 +59,16 @@
         }
       }
     },
+    "%arg (%arg) requires field '%arg' in output." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$arg (%2$arg) requires field '%3$arg' in output."
+          }
+        }
+      }
+    },
     "%arg actions" : {
       "localizations" : {
         "ja" : {
@@ -1978,6 +1988,7 @@
       }
     },
     "Phase %arg (%arg) requires field '%arg' in output." : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -63,8 +63,14 @@
       "localizations" : {
         "en" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$arg (%2$arg) requires field '%3$arg' in output."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$arg（%2$arg）には output に '%3$arg' フィールドが必要です。"
           }
         }
       }

--- a/Pastura/PasturaTests/App/Community/Gallery/GallerySeedYAMLTests.swift
+++ b/Pastura/PasturaTests/App/Community/Gallery/GallerySeedYAMLTests.swift
@@ -38,6 +38,42 @@ import Testing
     }
   }
 
+  /// Strict commit-time check on every gallery entry. Companion to
+  /// `allSeedYAMLsParseAndValidate` (which uses the lenient runtime
+  /// `validate(_:)`). A canonical-field omission inside a `then:` /
+  /// `else:` branch would compile, parse, and run, but block any user
+  /// who clones the gallery scenario via "Use as Template" → Save.
+  /// The recursion landed in #343 closes the historical gap where
+  /// `validateCanonicalPrimaryFields` walked top-level phases only.
+  @Test func allSeedYAMLsPassValidateForCommit() throws {
+    let loader = ScenarioLoader()
+    let validator = ScenarioValidator()
+
+    let galleryDir = Self.repoRoot().appendingPathComponent("docs/gallery")
+    let files = try FileManager.default.contentsOfDirectory(
+      atPath: galleryDir.path
+    ).filter { $0.hasSuffix(".yaml") }
+
+    #expect(files.count >= 3, "Expected at least 3 seed gallery YAMLs")
+
+    for name in files {
+      let yaml = try String(
+        contentsOf: galleryDir.appendingPathComponent(name), encoding: .utf8)
+      let scenario: Scenario
+      do {
+        scenario = try loader.load(yaml: yaml)
+      } catch {
+        Issue.record("Failed to load \(name): \(error)")
+        continue
+      }
+      do {
+        _ = try validator.validateForCommit(scenario)
+      } catch {
+        Issue.record("Commit-time validation failed for \(name): \(error)")
+      }
+    }
+  }
+
   /// Pins the curation invariant that every gallery entry's `title`
   /// matches the corresponding YAML's `name:` field.
   ///

--- a/Pastura/PasturaTests/App/PresetLoaderTests.swift
+++ b/Pastura/PasturaTests/App/PresetLoaderTests.swift
@@ -112,4 +112,33 @@ struct PresetLoaderTests {
       }
     }
   }
+
+  /// Regression guard for the "speak_all missing statement" bug class
+  /// (#318 / #343). Asserts every bundled preset survives the strict
+  /// commit-time gate — the same gate `ScenarioEditorViewModel.save()`
+  /// runs when a user clones a preset via "Use as Template" and saves.
+  /// A canonical-field omission slipping into a preset YAML would block
+  /// that flow on every cloned copy.
+  @Test func presetYAMLsPassValidateForCommit() throws {
+    let loader = ScenarioLoader()
+    let validator = ScenarioValidator()
+    let bundle = Bundle(for: DatabaseManager.self)
+
+    // Phantom-pass guard — if `presetFileNames` is ever emptied or the
+    // bundle resource group is misnamed, an empty iteration would
+    // trivially pass without auditing anything.
+    #expect(PresetLoader.presetFileNames.count >= 4)
+
+    for fileName in PresetLoader.presetFileNames {
+      guard let url = bundle.url(forResource: fileName, withExtension: "yaml") else {
+        Issue.record("Missing preset: \(fileName).yaml")
+        continue
+      }
+      let yaml = try String(contentsOf: url, encoding: .utf8)
+      let scenario = try loader.load(yaml: yaml)
+      #expect(throws: Never.self) {
+        _ = try validator.validateForCommit(scenario)
+      }
+    }
+  }
 }

--- a/Pastura/PasturaTests/Engine/ScenarioValidatorTests+Commit.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioValidatorTests+Commit.swift
@@ -148,6 +148,52 @@ extension ScenarioValidatorTests {
     _ = try validator.validate(scenario)
   }
 
+  // MARK: - Conditional sub-phases (canonical-field check recurses depth-1)
+
+  @Test func validateForCommit_rejectsSpeakAllInsideThenBranchMissingStatement() {
+    // Regression: `validateCanonicalPrimaryFields` originally walked only
+    // `scenario.phases` and ignored `thenPhases` / `elsePhases`. A
+    // conditional branch with a misnamed canonical field would slip past
+    // the commit gate and recreate the exact "speak_all missing statement"
+    // bug class #318 was meant to prevent. Recursion is depth-1 by validator
+    // construction so termination is trivial.
+    let nested = Phase(
+      type: .speakAll, prompt: "Inner.",
+      outputSchema: ["appeal": "string"])
+    let conditional = Phase(
+      type: .conditional, condition: "max_score >= 1",
+      thenPhases: [nested])
+    let scenario = makeScenario(agents: 2, rounds: 1, phases: [conditional])
+    #expect(throws: SimulationError.self) {
+      try validator.validateForCommit(scenario)
+    }
+  }
+
+  @Test func validateForCommit_rejectsVoteInsideElseBranchMissingVoteField() {
+    let nested = Phase(
+      type: .vote, prompt: "Vote.",
+      outputSchema: ["target": "string"])
+    let conditional = Phase(
+      type: .conditional, condition: "max_score >= 1",
+      thenPhases: [Phase(type: .summarize, template: "ok")],
+      elsePhases: [nested])
+    let scenario = makeScenario(agents: 2, rounds: 1, phases: [conditional])
+    #expect(throws: SimulationError.self) {
+      try validator.validateForCommit(scenario)
+    }
+  }
+
+  @Test func validateForCommit_acceptsSpeakAllInsideThenBranchWithStatement() throws {
+    let nested = Phase(
+      type: .speakAll, prompt: "Inner.",
+      outputSchema: ["statement": "string"])
+    let conditional = Phase(
+      type: .conditional, condition: "max_score >= 1",
+      thenPhases: [nested])
+    let scenario = makeScenario(agents: 2, rounds: 1, phases: [conditional])
+    _ = try validator.validateForCommit(scenario)
+  }
+
   // MARK: - Error message includes phase index + canonical field name
 
   @Test func validateForCommit_errorMentionsPhaseAndCanonicalField() {


### PR DESCRIPTION
## Summary
- `ScenarioValidator.validateCanonicalPrimaryFields` was top-level only — a `speak_all` without `statement` (or analogous canonical-field omission) inside a `conditional` branch slipped past the commit gate, recreating the exact "speak_all missing statement" bug class #318 was supposed to prevent. Recursion is depth-1 (validator + parser both reject nested conditional, terminates after one descent).
- Sub-phase errors now read `"Phase 1 (conditional) then[1] (speak_all) requires field 'statement' in output."` — mirrors `validateBranch` / `validateAssignPhaseShape`'s sibling format.
- Added regression-guard audit tests asserting every bundled preset (4) and every gallery YAML (4) passes the strict commit-time gate, with phantom-pass guards (`count >= 4` / `count >= 3`) so an emptied source can't silently pass.

Closes #343.

## Test plan
- [x] `xcodebuild test` (1489 tests) — green
- [x] `swiftlint --strict` — clean (only pre-existing config warning)
- [x] `python3 scripts/check_localization_coverage.py` — 329 keys, all \`ja\` translated
- [x] New tests verified TDD-style (red → green) for the validator recursion change
- [ ] CI: full unit suite + UI tests + localization-coverage gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)