### PR TITLE
🐛 fix: NavigationRegressionTests canary on simulation.header.meta (#348)

### DIFF
--- a/Pastura/PasturaUITests/NavigationRegressionTests.swift
+++ b/Pastura/PasturaUITests/NavigationRegressionTests.swift
@@ -79,13 +79,21 @@ final class NavigationRegressionTests: XCTestCase {
     wait(for: [enabledExpectation], timeout: 10)
     runSimulation.tap()
 
-    // Canary assertion: SimulationView header is the first element that
-    // renders after the route transition, BEFORE any LLM inference. If the
-    // regression returns, this times out because the stack either stays on
-    // ScenarioDetailView or re-pushes it.
-    let simulationHeader = app.otherElements["simulation.header"]
+    // Canary assertion: SimulationView's meta-row inset is the always-
+    // rendered surface after the route transition, BEFORE any LLM
+    // inference (its `safeAreaInset(.top)` falls through to a 1pt spacer
+    // when `hasMetaRow == false`, so the identifier exists from first
+    // frame — see `SimulationView.headerMetaInset`). The split-header
+    // refactor in #344 moved the title row into `ToolbarItem(.principal)`
+    // (UIKit-bridged tree placement), so we anchor on the meta inset
+    // instead of the previously-unified `simulation.header`. Using
+    // `descendants(matching:)` keeps the query immune to UIKit/SwiftUI
+    // tree-placement quirks. If the PR #93 regression returns, this
+    // times out because the stack either stays on ScenarioDetailView or
+    // re-pushes it.
+    let simulationHeader = app.descendants(matching: .any)["simulation.header.meta"]
     XCTAssertTrue(
       simulationHeader.waitForExistence(timeout: 10),
-      "SimulationView header did not appear — navigation regression suspected.")
+      "SimulationView meta-row inset did not appear — navigation regression suspected.")
   }
 }


### PR DESCRIPTION
## Summary
- Anchor `NavigationRegressionTests.testGalleryInstallThenRunSimulationReachesSimulationView`'s canary on `simulation.header.meta` instead of the now-removed combined `simulation.header` accessibilityIdentifier (split into `.title` + `.meta` by #344's "fill the bar" refactor).
- Use `app.descendants(matching: .any)[…]` to keep the query immune to UIKit/SwiftUI tree-placement quirks across iOS versions.
- The meta-row inset is the always-rendered surface (`safeAreaInset(.top)` falls through to a 1pt spacer when `hasMetaRow == false`, with the identifier on the outer Group), so the canary fires from first frame in every state.
- PR #93 routing-regression discriminating power preserved — `simulation.header.meta` is unique to SimulationView; a stack stuck on / re-pushing ScenarioDetailView still fails the canary.

## Test plan
- [ ] CI `ui-test` job passes `testGalleryInstallThenRunSimulationReachesSimulationView` on the next run (the failure has been deterministic since #344).
- [ ] Sibling UI tests (`BackGestureTests`, `EditorReloadTests`) still pass.
- [ ] Test duration returns to the ~10–30s baseline (was anomalous 130–294s while the canary was timing out).

Closes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)