### PR TITLE
✨ feat: apply LP design system to support + privacy pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -4,7 +4,8 @@
 #     (Marketing landing page — see #345)
 #   - `pages/css/base.css`                 → `https://tyabu12.github.io/pastura/css/base.css`
 #   - `pages/css/lp.css`                   → `https://tyabu12.github.io/pastura/css/lp.css`
-#     (Shared design tokens + LP-specific layout for the landing page)
+#   - `pages/css/page.css`                 → `https://tyabu12.github.io/pastura/css/page.css`
+#     (Shared design tokens + LP layout + prose styling for legal/support)
 #   - `pages/img/app-icon.png`             → `https://tyabu12.github.io/pastura/img/app-icon.png`
 #   - `pages/img/favicon-64.png`           → `https://tyabu12.github.io/pastura/img/favicon-64.png`
 #     (Brand mark + favicon, sourced from the iOS app icon)
@@ -83,6 +84,7 @@ jobs:
           cp pages/index.html _site/index.html
           cp pages/css/base.css _site/css/base.css
           cp pages/css/lp.css _site/css/lp.css
+          cp pages/css/page.css _site/css/page.css
           cp pages/img/app-icon.png _site/img/app-icon.png
           cp pages/img/favicon-64.png _site/img/favicon-64.png
           cp pages/img/app-store-badge-en.svg _site/img/app-store-badge-en.svg
@@ -111,6 +113,7 @@ jobs:
             "https://tyabu12.github.io/pastura/" \
             "https://tyabu12.github.io/pastura/css/base.css" \
             "https://tyabu12.github.io/pastura/css/lp.css" \
+            "https://tyabu12.github.io/pastura/css/page.css" \
             "https://tyabu12.github.io/pastura/img/app-icon.png" \
             "https://tyabu12.github.io/pastura/img/favicon-64.png" \
             "https://tyabu12.github.io/pastura/img/app-store-badge-en.svg" \

--- a/pages/css/base.css
+++ b/pages/css/base.css
@@ -190,6 +190,126 @@ body {
   font-size: 18px;
 }
 
+/* ----- Cross-page chrome (header / footer / language toggle) -----
+   Shared by the landing page (pages/index.html) and prose pages
+   (pages/support/, pages/legal/privacy-policy/). LP-specific bits
+   like .lp-nav-links and the anchor menu live in lp.css instead. */
+
+.lp-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 24px 56px;
+}
+.lp-nav {
+  display: flex;
+  gap: 36px;
+  align-items: center;
+  color: var(--ink-2);
+  font-size: 14px;
+}
+.lp-nav a {
+  color: inherit;
+  text-decoration: none;
+}
+
+@media (max-width: 768px) {
+  .lp-header {
+    padding: 16px 20px;
+  }
+}
+
+.lp-footer {
+  border-top: 1px solid var(--rule);
+  padding: 48px 56px 40px;
+  background: var(--page);
+}
+.foot-grid {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr 1fr;
+  gap: 32px;
+}
+.foot-link {
+  display: block;
+  color: var(--ink-2);
+  text-decoration: none;
+  font-size: 14px;
+  line-height: 2;
+}
+.foot-h {
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 0 0 12px;
+}
+.foot-tag {
+  margin: 16px 0 24px;
+  max-width: 340px;
+  font-size: 14px;
+}
+.foot-base {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 48px;
+  padding-top: 24px;
+  border-top: 1px solid var(--rule);
+  font-size: 12px;
+  color: var(--muted);
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.foot-copy {
+  flex: 1;
+  min-width: 0;
+}
+.foot-note {
+  margin: 12px 0 0;
+  font-size: 11px;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+@media (max-width: 768px) {
+  .lp-footer {
+    padding: 36px 20px;
+  }
+  .foot-grid {
+    grid-template-columns: 1fr;
+    gap: 24px;
+  }
+}
+
+.lang-toggle {
+  display: inline-flex;
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 11px;
+  overflow: hidden;
+}
+.lang-toggle button {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: var(--ink-2);
+  font: inherit;
+  letter-spacing: 0.18em;
+  padding: 6px 12px;
+  cursor: pointer;
+}
+.lang-toggle button.on,
+.lang-toggle button[aria-pressed="true"] {
+  background: var(--ink);
+  color: var(--screen-bg);
+}
+.lang-toggle button[aria-disabled="true"] {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
 /* ----- Sheep avatar (SVG) -----
    Mirrors Pastura/Pastura/Views/Components/SheepAvatar.swift — 28-unit
    viewBox, five wool circles, face oval, two eyes, highlight dot, two

--- a/pages/css/lp.css
+++ b/pages/css/lp.css
@@ -2,24 +2,10 @@
    Loaded after pages/css/base.css. Responsive contract: desktop is
    the default; mobile values via @media (max-width: 768px). */
 
-/* ----- Header ----- */
-.lp-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 24px 56px;
-}
-.lp-nav {
-  display: flex;
-  gap: 36px;
-  align-items: center;
-  color: var(--ink-2);
-  font-size: 14px;
-}
-.lp-nav a {
-  color: inherit;
-  text-decoration: none;
-}
+/* ----- Header anchor menu (LP-only) -----
+   .lp-header / .lp-nav / .lang-toggle are shared chrome in base.css.
+   The anchor-link strip (.lp-nav-links) is LP-only because the
+   prose pages have no in-page sections to link to. */
 .lp-nav-links {
   display: inline-flex;
   align-items: center;
@@ -27,9 +13,6 @@
 }
 
 @media (max-width: 768px) {
-  .lp-header {
-    padding: 16px 20px;
-  }
   /* Hide anchor nav links on mobile — only the LangToggle stays */
   .lp-nav-links {
     display: none;
@@ -102,13 +85,6 @@
 .why-lead {
   margin: 0 0 32px;
   max-width: 560px;
-}
-
-/* Footer brand description tagline (under brand mark) */
-.foot-tag {
-  margin: 16px 0 24px;
-  max-width: 340px;
-  font-size: 14px;
 }
 
 /* ----- Content max-width wrappers -----
@@ -507,90 +483,5 @@
   color: var(--moss-ink);
 }
 
-/* ----- Footer ----- */
-.lp-footer {
-  border-top: 1px solid var(--rule);
-  padding: 48px 56px 40px;
-  background: var(--page);
-}
-.foot-grid {
-  display: grid;
-  grid-template-columns: 1.4fr 1fr 1fr;
-  gap: 32px;
-}
-.foot-link {
-  display: block;
-  color: var(--ink-2);
-  text-decoration: none;
-  font-size: 14px;
-  line-height: 2;
-}
-.foot-h {
-  font-family: "JetBrains Mono", ui-monospace, monospace;
-  font-size: 10px;
-  letter-spacing: 0.22em;
-  text-transform: uppercase;
-  color: var(--muted);
-  margin: 0 0 12px;
-}
-.foot-base {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-top: 48px;
-  padding-top: 24px;
-  border-top: 1px solid var(--rule);
-  font-size: 12px;
-  color: var(--muted);
-  gap: 16px;
-  flex-wrap: wrap;
-}
-.foot-copy {
-  flex: 1;
-  min-width: 0;
-}
-.foot-note {
-  margin: 12px 0 0;
-  font-size: 11px;
-  color: var(--muted);
-  line-height: 1.6;
-}
-
-@media (max-width: 768px) {
-  .lp-footer {
-    padding: 36px 20px;
-  }
-  .foot-grid {
-    grid-template-columns: 1fr;
-    gap: 24px;
-  }
-}
-
-/* ----- Language toggle ----- */
-.lang-toggle {
-  display: inline-flex;
-  border: 1px solid var(--rule);
-  border-radius: 6px;
-  font-family: "JetBrains Mono", ui-monospace, monospace;
-  font-size: 11px;
-  overflow: hidden;
-}
-.lang-toggle button {
-  appearance: none;
-  background: transparent;
-  border: 0;
-  color: var(--ink-2);
-  font: inherit;
-  letter-spacing: 0.18em;
-  padding: 6px 12px;
-  cursor: pointer;
-}
-.lang-toggle button.on,
-.lang-toggle button[aria-pressed="true"] {
-  background: var(--ink);
-  color: var(--screen-bg);
-}
-.lang-toggle button[aria-disabled="true"] {
-  cursor: not-allowed;
-  opacity: 0.55;
-}
+/* .lp-footer + .foot-* + .lang-toggle moved to base.css — shared by
+   prose pages (pages/support/, pages/legal/privacy-policy/). */

--- a/pages/css/lp.css
+++ b/pages/css/lp.css
@@ -1,6 +1,8 @@
-/* Pastura Landing Page — LP-specific layout & sections.
-   Loaded after pages/css/base.css. Responsive contract: desktop is
-   the default; mobile values via @media (max-width: 768px). */
+/* Pastura Landing Page — LP-only layout (hero, journey acts,
+   capabilities, FAQ, anchor menu). Shared page chrome (header /
+   footer / language toggle) lives in pages/css/base.css.
+   Loaded after pages/css/base.css. Responsive contract: desktop
+   is the default; mobile values via @media (max-width: 768px). */
 
 /* ----- Header anchor menu (LP-only) -----
    .lp-header / .lp-nav / .lang-toggle are shared chrome in base.css.

--- a/pages/css/page.css
+++ b/pages/css/page.css
@@ -1,0 +1,174 @@
+/* Pastura Pages — prose-page styles for legal/ and support/.
+   Loaded after pages/css/base.css. Uses ONLY tokens declared in
+   base.css — no new --* custom properties. Mirrors lp.css's
+   responsive contract: desktop default, mobile values via
+   @media (max-width: 768px). */
+
+/* ----- Shell & layout ----- */
+
+/* Top-level wrapper: flex column so the footer always sticks to
+   the bottom even on short-content pages. */
+.page-shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+/* <main> content area: flex: 1 consumes remaining vertical space
+   inside the .page-shell flex column, pushing .lp-footer to the
+   bottom on short pages. */
+.page-main {
+  flex: 1;
+  padding: 80px 56px;
+}
+
+@media (max-width: 768px) {
+  .page-main {
+    padding: 48px 24px;
+  }
+}
+
+/* Inner prose wrapper: caps reading width and centres the content. */
+.page-prose {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+/* ----- Prose typography ----- */
+
+.page-prose h1 {
+  font-size: 32px;
+  font-weight: 600;
+  line-height: 1.22;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+  text-wrap: balance;
+  border-bottom: 1px solid var(--rule);
+  padding-bottom: 12px;
+  margin: 0 0 12px;
+}
+
+.page-prose h2 {
+  font-size: 22px;
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--ink);
+  margin: 48px 0 16px;
+}
+
+.page-prose h3 {
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1.4;
+  color: var(--ink);
+  margin: 32px 0 10px;
+}
+
+.page-prose p {
+  font-size: 16px;
+  line-height: 1.7;
+  color: var(--ink-2);
+  text-wrap: pretty;
+  margin: 0 0 16px;
+}
+
+.page-prose ul,
+.page-prose ol {
+  color: var(--ink-2);
+  line-height: 1.7;
+  margin: 0 0 16px;
+  padding-left: 1.5em;
+}
+
+.page-prose li + li {
+  margin-top: 6px;
+}
+
+.page-prose a {
+  color: var(--moss-dark);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.page-prose a:hover {
+  color: var(--moss-ink);
+}
+
+.page-prose strong {
+  color: var(--ink);
+  font-weight: 600;
+}
+
+.page-prose hr {
+  margin: 40px 0 24px;
+  border: 0;
+  border-top: 1px solid var(--rule);
+}
+
+/* ----- Inline code ----- */
+
+.page-prose code {
+  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, monospace;
+  background: var(--page);
+  border: 1px solid var(--rule);
+  padding: 0.1em 0.4em;
+  border-radius: 4px;
+  font-size: 0.92em;
+  color: var(--moss-ink);
+}
+
+/* ----- Table ----- */
+
+.page-prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 16px 0 20px;
+  font-size: 14px;
+}
+
+.page-prose th,
+.page-prose td {
+  border: 1px solid var(--rule);
+  padding: 10px 14px;
+  text-align: left;
+  vertical-align: top;
+  color: var(--ink-2);
+  line-height: 1.6;
+}
+
+.page-prose th {
+  background: var(--page);
+  color: var(--ink);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+/* ----- Utility class overrides inside .page-prose ----- */
+
+/* .lead (from base.css): add bottom rhythm when it follows the h1. */
+.page-prose .lead {
+  margin: 0 0 24px;
+}
+
+/* .meta (from base.css): bottom rhythm for the "Effective date /
+   Last updated" block at the top of the privacy policy. */
+.page-prose .meta {
+  margin: 0 0 32px;
+  line-height: 1.7;
+}
+
+/* ----- Responsive type scaling ----- */
+
+@media (max-width: 768px) {
+  .page-prose h1 {
+    font-size: 24px;
+  }
+
+  .page-prose h2 {
+    font-size: 19px;
+  }
+
+  .page-prose h3 {
+    font-size: 15px;
+  }
+}

--- a/pages/legal/privacy-policy/index.html
+++ b/pages/legal/privacy-policy/index.html
@@ -1,362 +1,328 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <title>Pastura Privacy Policy</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Privacy policy for Pastura, an iOS app for on-device AI multi-agent simulations.">
-  <style>
-    :root {
-      color-scheme: light dark;
-    }
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
-      line-height: 1.6;
-      max-width: 720px;
-      margin: 2rem auto;
-      padding: 0 1rem 4rem;
-    }
-    h1 {
-      border-bottom: 1px solid #ddd;
-      padding-bottom: 0.5rem;
-    }
-    h2 {
-      margin-top: 2.5rem;
-    }
-    h3 {
-      margin-top: 1.5rem;
-    }
-    a {
-      color: #0366d6;
-    }
-    @media (prefers-color-scheme: dark) {
-      a {
-        color: #58a6ff;
-      }
-      h1 {
-        border-bottom-color: #30363d;
-      }
-    }
-    hr {
-      margin: 2.5rem 0 1rem;
-      border: 0;
-      border-top: 1px solid #ddd;
-    }
-    @media (prefers-color-scheme: dark) {
-      hr {
-        border-top-color: #30363d;
-      }
-    }
-    .lead {
-      font-size: 1.05em;
-    }
-    .meta {
-      color: #666;
-      font-size: 0.95em;
-    }
-    @media (prefers-color-scheme: dark) {
-      .meta {
-        color: #8b949e;
-      }
-    }
-    code {
-      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-      background: rgba(175, 184, 193, 0.2);
-      padding: 0.1em 0.35em;
-      border-radius: 4px;
-      font-size: 0.92em;
-    }
-    table {
-      border-collapse: collapse;
-      width: 100%;
-      margin: 1rem 0;
-    }
-    th, td {
-      border: 1px solid #ddd;
-      padding: 0.5rem 0.75rem;
-      text-align: left;
-      vertical-align: top;
-    }
-    th {
-      background: rgba(175, 184, 193, 0.15);
-    }
-    @media (prefers-color-scheme: dark) {
-      th, td {
-        border-color: #30363d;
-      }
-    }
-    footer {
-      margin-top: 3rem;
-      font-size: 0.9em;
-      color: #666;
-    }
-    @media (prefers-color-scheme: dark) {
-      footer {
-        color: #8b949e;
-      }
-    }
-  </style>
+  <meta name="theme-color" content="#FCFAF4" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#1B1C18" media="(prefers-color-scheme: dark)">
+
+  <link rel="canonical" href="https://tyabu12.github.io/pastura/legal/privacy-policy/">
+
+  <link rel="icon" type="image/png" sizes="64x64" href="../../img/favicon-64.png">
+  <link rel="apple-touch-icon" href="../../img/app-icon.png">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;600&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
+
+  <link rel="stylesheet" href="../../css/base.css">
+  <link rel="stylesheet" href="../../css/page.css">
 </head>
 <body>
-  <main>
-    <h1>Pastura Privacy Policy</h1>
+  <a class="skip-link" href="#main">Skip to content</a>
 
-    <p class="meta">
-      <strong>Effective date:</strong> 2026-04-25<br>
-      <strong>Last updated:</strong> 2026-04-25
-    </p>
+  <div class="page-shell">
+    <header role="banner" class="lp-header">
+      <a href="../../" class="brand">
+        <img class="icon" src="../../img/app-icon.png" alt="" aria-hidden="true" width="36" height="36">
+        <span class="brand-name">Pastura</span>
+      </a>
+      <nav aria-label="Primary" class="lp-nav">
+        <div class="lang-toggle" role="group" aria-label="Language">
+          <button type="button" aria-pressed="true" lang="en" class="on">EN</button>
+          <button type="button" aria-disabled="true" lang="ja" tabindex="-1">JA</button>
+        </div>
+      </nav>
+    </header>
 
-    <h2>Who we are</h2>
+    <main id="main" class="page-main">
+      <div class="page-prose">
+        <h1>Pastura Privacy Policy</h1>
 
-    <p>
-      Pastura is an iOS app for running AI multi-agent simulations entirely
-      on-device. It is developed and maintained by <strong>tyabu12</strong>
-      (an individual developer). References to "we", "us", or "Pastura" in
-      this policy refer to tyabu12 acting as the data controller for any
-      data the app might process.
-    </p>
+        <p class="meta">
+          <strong>Effective date:</strong> 2026-04-25<br>
+          <strong>Last updated:</strong> 2026-04-25
+        </p>
 
-    <h2>Summary</h2>
+        <h2>Who we are</h2>
 
-    <p class="lead">
-      <strong>Pastura does not collect, transmit, sell, or share your personal data.</strong>
-    </p>
+        <p>
+          Pastura is an iOS app for running AI multi-agent simulations entirely
+          on-device. It is developed and maintained by <strong>tyabu12</strong>
+          (an individual developer). References to "we", "us", or "Pastura" in
+          this policy refer to tyabu12 acting as the data controller for any
+          data the app might process.
+        </p>
 
-    <p>
-      All AI simulations run on your device using a local large language
-      model executed via the
-      <a href="https://github.com/ggerganov/llama.cpp">llama.cpp</a>
-      inference runtime. Your scenarios, simulation history, and preferences
-      never leave the device through any mechanism we control. Pastura's App
-      Store privacy nutrition label is <strong>"Data Not Collected"</strong>.
-    </p>
+        <h2>Summary</h2>
 
-    <h2>Data we do not collect</h2>
+        <p class="lead">
+          <strong>Pastura does not collect, transmit, sell, or share your personal data.</strong>
+        </p>
 
-    <p>We do not collect, request, log, or transmit any of the following:</p>
+        <p>
+          All AI simulations run on your device using a local large language
+          model executed via the
+          <a href="https://github.com/ggerganov/llama.cpp">llama.cpp</a>
+          inference runtime. Your scenarios, simulation history, and preferences
+          never leave the device through any mechanism we control. Pastura's App
+          Store privacy nutrition label is <strong>"Data Not Collected"</strong>.
+        </p>
 
-    <ul>
-      <li>Names, email addresses, phone numbers, or other contact information</li>
-      <li>Account credentials (Pastura has no account system)</li>
-      <li>Device identifiers (IDFA, IDFV) for advertising or tracking purposes</li>
-      <li>Location data (GPS, IP-based, or otherwise)</li>
-      <li>Contacts, photos, calendar, or other personal data on your device</li>
-      <li>Behavioural analytics, crash reports, telemetry, or usage statistics</li>
-      <li>Health, financial, or biometric data</li>
-    </ul>
+        <h2>Data we do not collect</h2>
 
-    <p>
-      Pastura ships with no third-party analytics, advertising, attribution,
-      or crash-reporting SDKs.
-    </p>
+        <p>We do not collect, request, log, or transmit any of the following:</p>
 
-    <h2>Data that stays on your device</h2>
+        <ul>
+          <li>Names, email addresses, phone numbers, or other contact information</li>
+          <li>Account credentials (Pastura has no account system)</li>
+          <li>Device identifiers (IDFA, IDFV) for advertising or tracking purposes</li>
+          <li>Location data (GPS, IP-based, or otherwise)</li>
+          <li>Contacts, photos, calendar, or other personal data on your device</li>
+          <li>Behavioural analytics, crash reports, telemetry, or usage statistics</li>
+          <li>Health, financial, or biometric data</li>
+        </ul>
 
-    <p>
-      The following information is created or stored locally inside the
-      app's sandbox and is never transmitted off the device by Pastura:
-    </p>
+        <p>
+          Pastura ships with no third-party analytics, advertising, attribution,
+          or crash-reporting SDKs.
+        </p>
 
-    <table>
-      <thead>
-        <tr>
-          <th>Local data</th>
-          <th>Purpose</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>Scenario YAML you author or import</td>
-          <td>Running simulations you have configured</td>
-        </tr>
-        <tr>
-          <td>Past simulation results (SQLite)</td>
-          <td>Letting you revisit and export your simulation history</td>
-        </tr>
-        <tr>
-          <td>App preferences (UserDefaults)</td>
-          <td>Remembering your active model, playback speed, and similar settings</td>
-        </tr>
-        <tr>
-          <td>Downloaded LLM model files</td>
-          <td>Performing on-device inference</td>
-        </tr>
-      </tbody>
-    </table>
+        <h2>Data that stays on your device</h2>
 
-    <p>
-      The required-reason API declarations in our
-      <a href="https://github.com/tyabu12/pastura/blob/main/Pastura/Pastura/PrivacyInfo.xcprivacy"><code>PrivacyInfo.xcprivacy</code></a>
-      reflect these uses: the <code>UserDefaults</code> API is declared with
-      reason <code>CA92.1</code> ("app functionality") and the
-      <code>FileTimestamp</code> API with reason <code>C617.1</code>
-      ("files inside the app sandbox"). No tracking domains are declared
-      (<code>NSPrivacyTrackingDomains</code> is empty);
-      <code>NSPrivacyTracking</code> is <code>false</code>.
-    </p>
+        <p>
+          The following information is created or stored locally inside the
+          app's sandbox and is never transmitted off the device by Pastura:
+        </p>
 
-    <p>
-      You can erase all of this local data at any time by deleting the app
-      from your device.
-    </p>
+        <table>
+          <thead>
+            <tr>
+              <th>Local data</th>
+              <th>Purpose</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Scenario YAML you author or import</td>
+              <td>Running simulations you have configured</td>
+            </tr>
+            <tr>
+              <td>Past simulation results (SQLite)</td>
+              <td>Letting you revisit and export your simulation history</td>
+            </tr>
+            <tr>
+              <td>App preferences (UserDefaults)</td>
+              <td>Remembering your active model, playback speed, and similar settings</td>
+            </tr>
+            <tr>
+              <td>Downloaded LLM model files</td>
+              <td>Performing on-device inference</td>
+            </tr>
+          </tbody>
+        </table>
 
-    <h2>Network connections Pastura makes</h2>
+        <p>
+          The required-reason API declarations in our
+          <a href="https://github.com/tyabu12/pastura/blob/main/Pastura/Pastura/PrivacyInfo.xcprivacy"><code>PrivacyInfo.xcprivacy</code></a>
+          reflect these uses: the <code>UserDefaults</code> API is declared with
+          reason <code>CA92.1</code> ("app functionality") and the
+          <code>FileTimestamp</code> API with reason <code>C617.1</code>
+          ("files inside the app sandbox"). No tracking domains are declared
+          (<code>NSPrivacyTrackingDomains</code> is empty);
+          <code>NSPrivacyTracking</code> is <code>false</code>.
+        </p>
 
-    <p>
-      Pastura's AI inference is fully on-device, but the app makes a small
-      number of outbound network requests when you choose to use specific
-      features:
-    </p>
+        <p>
+          You can erase all of this local data at any time by deleting the app
+          from your device.
+        </p>
 
-    <ul>
-      <li>
-        <strong>Curated scenario gallery</strong> — when you open the in-app
-        Shared Scenarios, the app fetches a JSON index of curated scenarios from
-        GitHub-hosted content at <code>raw.githubusercontent.com</code>.
-      </li>
-      <li>
-        <strong>LLM model download</strong> — when you install or switch a
-        model, the app downloads the model file from Hugging Face
-        (<code>huggingface.co</code>).
-      </li>
-    </ul>
+        <h2>Network connections Pastura makes</h2>
 
-    <p>
-      These services see your IP address and a standard
-      <code>User-Agent</code> string under their own privacy policies (see
-      <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement">GitHub Privacy Statement</a>
-      and
-      <a href="https://huggingface.co/privacy">Hugging Face Privacy Policy</a>).
-      Pastura does not log, store, share, or otherwise process the metadata
-      of these requests on its side.
-    </p>
+        <p>
+          Pastura's AI inference is fully on-device, but the app makes a small
+          number of outbound network requests when you choose to use specific
+          features:
+        </p>
 
-    <h2>Tracking and advertising</h2>
+        <ul>
+          <li>
+            <strong>Curated scenario gallery</strong> — when you open the in-app
+            Shared Scenarios, the app fetches a JSON index of curated scenarios from
+            GitHub-hosted content at <code>raw.githubusercontent.com</code>.
+          </li>
+          <li>
+            <strong>LLM model download</strong> — when you install or switch a
+            model, the app downloads the model file from Hugging Face
+            (<code>huggingface.co</code>).
+          </li>
+        </ul>
 
-    <p>
-      Pastura does not use any tracking technologies, advertising
-      identifiers, attribution SDKs, fingerprinting, or
-      cross-app/cross-site tracking. We do not show ads. We do not
-      participate in any data broker or advertising network.
-    </p>
+        <p>
+          These services see your IP address and a standard
+          <code>User-Agent</code> string under their own privacy policies (see
+          <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement">GitHub Privacy Statement</a>
+          and
+          <a href="https://huggingface.co/privacy">Hugging Face Privacy Policy</a>).
+          Pastura does not log, store, share, or otherwise process the metadata
+          of these requests on its side.
+        </p>
 
-    <h2>Children's privacy</h2>
+        <h2>Tracking and advertising</h2>
 
-    <p>
-      Pastura is rated <strong>13+</strong> on the App Store and is not
-      directed to children under 13. We do not knowingly collect personal
-      information from children under 13. Because we do not collect
-      personal information from anyone, no specific COPPA notice or
-      verifiable parental consent flow is needed; if a child under 13
-      uses the app, no personal data leaves the device through Pastura.
-    </p>
+        <p>
+          Pastura does not use any tracking technologies, advertising
+          identifiers, attribution SDKs, fingerprinting, or
+          cross-app/cross-site tracking. We do not show ads. We do not
+          participate in any data broker or advertising network.
+        </p>
 
-    <p>
-      In jurisdictions where the GDPR-K age of digital consent is set
-      higher than 13 (most EU member states use 16), the same
-      no-collection commitment applies to all users regardless of age.
-    </p>
+        <h2>Children's privacy</h2>
 
-    <h2>International users</h2>
+        <p>
+          Pastura is rated <strong>13+</strong> on the App Store and is not
+          directed to children under 13. We do not knowingly collect personal
+          information from children under 13. Because we do not collect
+          personal information from anyone, no specific COPPA notice or
+          verifiable parental consent flow is needed; if a child under 13
+          uses the app, no personal data leaves the device through Pastura.
+        </p>
 
-    <p>
-      We do not collect or process personal data, so most regional privacy
-      laws (GDPR, UK GDPR, Japan's APPI, California's CCPA/CPRA, and
-      similar regimes) have nothing for us to act on. Specifically:
-    </p>
+        <p>
+          In jurisdictions where the GDPR-K age of digital consent is set
+          higher than 13 (most EU member states use 16), the same
+          no-collection commitment applies to all users regardless of age.
+        </p>
 
-    <ul>
-      <li>
-        <strong>GDPR / UK GDPR</strong> — we are not a controller or
-        processor of personal data within the meaning of Article 4,
-        because no identifiable personal data is collected.
-      </li>
-      <li>
-        <strong>APPI (Japan)</strong> — we do not collect or hold
-        個人情報 (personal information) as defined in the Act.
-      </li>
-      <li>
-        <strong>CCPA / CPRA (California)</strong> — we do not collect,
-        sell, or share personal information of California residents.
-      </li>
-    </ul>
+        <h2>International users</h2>
 
-    <p>
-      If you nonetheless wish to exercise a right granted by your local
-      law (such as a data subject access request), please contact us via
-      the channel below; we will respond by confirming that we hold no
-      data about you.
-    </p>
+        <p>
+          We do not collect or process personal data, so most regional privacy
+          laws (GDPR, UK GDPR, Japan's APPI, California's CCPA/CPRA, and
+          similar regimes) have nothing for us to act on. Specifically:
+        </p>
 
-    <h2>Future changes (Cloud API)</h2>
+        <ul>
+          <li>
+            <strong>GDPR / UK GDPR</strong> — we are not a controller or
+            processor of personal data within the meaning of Article 4,
+            because no identifiable personal data is collected.
+          </li>
+          <li>
+            <strong>APPI (Japan)</strong> — we do not collect or hold
+            個人情報 (personal information) as defined in the Act.
+          </li>
+          <li>
+            <strong>CCPA / CPRA (California)</strong> — we do not collect,
+            sell, or share personal information of California residents.
+          </li>
+        </ul>
 
-    <p>
-      Pastura currently runs entirely on-device. Future versions may
-      offer <strong>optional, opt-in</strong> features that send specific
-      user-authored content (such as scenario prompts) to a named
-      third-party AI provider for processing. If such a feature is
-      introduced:
-    </p>
+        <p>
+          If you nonetheless wish to exercise a right granted by your local
+          law (such as a data subject access request), please contact us via
+          the channel below; we will respond by confirming that we hold no
+          data about you.
+        </p>
 
-    <ul>
-      <li>
-        This policy will be revised to name the provider, list the data
-        transmitted, identify the legal basis for processing, and link to
-        the provider's privacy policy — <strong>before</strong> the
-        feature ships.
-      </li>
-      <li>
-        The feature will require explicit user consent; running on-device
-        will remain the default.
-      </li>
-    </ul>
+        <h2>Future changes (Cloud API)</h2>
 
-    <p>
-      Any future revision will be announced via the channels described in
-      "Changes to this policy" below.
-    </p>
+        <p>
+          Pastura currently runs entirely on-device. Future versions may
+          offer <strong>optional, opt-in</strong> features that send specific
+          user-authored content (such as scenario prompts) to a named
+          third-party AI provider for processing. If such a feature is
+          introduced:
+        </p>
 
-    <h2>How to contact us</h2>
+        <ul>
+          <li>
+            This policy will be revised to name the provider, list the data
+            transmitted, identify the legal basis for processing, and link to
+            the provider's privacy policy — <strong>before</strong> the
+            feature ships.
+          </li>
+          <li>
+            The feature will require explicit user consent; running on-device
+            will remain the default.
+          </li>
+        </ul>
 
-    <p>
-      Use the support form at
-      <strong><a href="https://tyabu12.github.io/pastura/support/">https://tyabu12.github.io/pastura/support/</a></strong>
-      for any privacy-related questions, including requests to confirm
-      what (if any) data we hold about you.
-    </p>
+        <p>
+          Any future revision will be announced via the channels described in
+          "Changes to this policy" below.
+        </p>
 
-    <h2>Changes to this policy</h2>
+        <h2>How to contact us</h2>
 
-    <p>
-      We will revise this policy as Pastura's data practices evolve
-      (notably when any optional cloud feature is introduced). When we do:
-    </p>
+        <p>
+          Use the support form at
+          <strong><a href="https://tyabu12.github.io/pastura/support/">https://tyabu12.github.io/pastura/support/</a></strong>
+          for any privacy-related questions, including requests to confirm
+          what (if any) data we hold about you.
+        </p>
 
-    <ul>
-      <li>The "Last updated" date at the top of this document will change.</li>
-      <li>
-        Material changes will be summarised in the corresponding TestFlight
-        or App Store release notes.
-      </li>
-      <li>
-        The latest version is always available at
-        <a href="https://tyabu12.github.io/pastura/legal/privacy-policy/">https://tyabu12.github.io/pastura/legal/privacy-policy/</a>.
-      </li>
-    </ul>
+        <h2>Changes to this policy</h2>
 
-    <p>
-      Continued use of Pastura after a revision means you accept the
-      revised policy. If you do not agree with a change, please stop
-      using the app and delete it from your device.
-    </p>
+        <p>
+          We will revise this policy as Pastura's data practices evolve
+          (notably when any optional cloud feature is introduced). When we do:
+        </p>
 
-    <footer>
-      <hr>
-      <p>
-        Source code and release notes:
-        <a href="https://github.com/tyabu12/pastura">github.com/tyabu12/pastura</a>
-      </p>
+        <ul>
+          <li>The "Last updated" date at the top of this document will change.</li>
+          <li>
+            Material changes will be summarised in the corresponding TestFlight
+            or App Store release notes.
+          </li>
+          <li>
+            The latest version is always available at
+            <a href="https://tyabu12.github.io/pastura/legal/privacy-policy/">https://tyabu12.github.io/pastura/legal/privacy-policy/</a>.
+          </li>
+        </ul>
+
+        <p>
+          Continued use of Pastura after a revision means you accept the
+          revised policy. If you do not agree with a change, please stop
+          using the app and delete it from your device.
+        </p>
+      </div>
+    </main>
+
+    <footer role="contentinfo" class="lp-footer">
+      <div class="foot-grid">
+        <div>
+          <a href="../../" class="brand">
+            <img class="icon" src="../../img/app-icon.png" alt="" aria-hidden="true" width="36" height="36">
+            <span class="brand-name">Pastura</span>
+          </a>
+          <p class="body foot-tag">
+            An AI you observe, not operate. On-device, offline, no cloud calls.
+          </p>
+        </div>
+        <div>
+          <h3 class="foot-h">Product</h3>
+          <a class="foot-link" href="../../#watch">Observe</a>
+          <a class="foot-link" href="../../#capabilities">Capabilities</a>
+          <a class="foot-link" href="../../#faq">FAQ</a>
+        </div>
+        <div>
+          <h3 class="foot-h">Resources</h3>
+          <a class="foot-link" href="../../support/">Support</a>
+          <a class="foot-link" href="https://github.com/tyabu12/pastura" rel="noopener">GitHub</a>
+        </div>
+      </div>
+      <div class="foot-base">
+        <span class="foot-copy">© 2026 Pastura</span>
+        <div class="lang-toggle" role="group" aria-label="Language">
+          <button type="button" aria-pressed="true" lang="en" class="on">EN</button>
+          <button type="button" aria-disabled="true" lang="ja" tabindex="-1">JA</button>
+        </div>
+      </div>
     </footer>
-  </main>
+  </div>
 </body>
 </html>

--- a/pages/support/index.html
+++ b/pages/support/index.html
@@ -1,135 +1,129 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <title>Pastura Support</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Support and feedback channel for Pastura, an iOS app for on-device AI multi-agent simulations.">
-  <style>
-    :root {
-      color-scheme: light dark;
-    }
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
-      line-height: 1.6;
-      max-width: 640px;
-      margin: 2rem auto;
-      padding: 0 1rem 4rem;
-    }
-    h1 {
-      border-bottom: 1px solid #ddd;
-      padding-bottom: 0.5rem;
-    }
-    h2 {
-      margin-top: 2.5rem;
-    }
-    h3 {
-      margin-top: 1.5rem;
-    }
-    a {
-      color: #0366d6;
-    }
-    @media (prefers-color-scheme: dark) {
-      a {
-        color: #58a6ff;
-      }
-      h1 {
-        border-bottom-color: #30363d;
-      }
-    }
-    hr {
-      margin: 2.5rem 0 1rem;
-      border: 0;
-      border-top: 1px solid #ddd;
-    }
-    @media (prefers-color-scheme: dark) {
-      hr {
-        border-top-color: #30363d;
-      }
-    }
-    .lead {
-      font-size: 1.05em;
-    }
-    .cta {
-      display: inline-block;
-      padding: 0.5rem 1rem;
-      border: 1px solid currentColor;
-      border-radius: 6px;
-      text-decoration: none;
-    }
-    footer {
-      margin-top: 3rem;
-      font-size: 0.9em;
-      color: #666;
-    }
-    @media (prefers-color-scheme: dark) {
-      footer {
-        color: #8b949e;
-      }
-    }
-  </style>
+  <meta name="theme-color" content="#FCFAF4" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#1B1C18" media="(prefers-color-scheme: dark)">
+
+  <link rel="canonical" href="https://tyabu12.github.io/pastura/support/">
+
+  <link rel="icon" type="image/png" sizes="64x64" href="../img/favicon-64.png">
+  <link rel="apple-touch-icon" href="../img/app-icon.png">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;600&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
+
+  <link rel="stylesheet" href="../css/base.css">
+  <link rel="stylesheet" href="../css/page.css">
 </head>
 <body>
-  <main>
-    <h1>Pastura Support</h1>
+  <a class="skip-link" href="#main">Skip to content</a>
 
-    <p class="lead">
-      Pastura is an iOS app for running AI multi-agent simulations
-      fully on-device. This page is the support and feedback channel
-      for the app.
-    </p>
+  <div class="page-shell">
+    <header role="banner" class="lp-header">
+      <a href="../" class="brand">
+        <img class="icon" src="../img/app-icon.png" alt="" aria-hidden="true" width="36" height="36">
+        <span class="brand-name">Pastura</span>
+      </a>
+      <nav aria-label="Primary" class="lp-nav">
+        <div class="lang-toggle" role="group" aria-label="Language">
+          <button type="button" aria-pressed="true" lang="en" class="on">EN</button>
+          <button type="button" aria-disabled="true" lang="ja" tabindex="-1">JA</button>
+        </div>
+      </nav>
+    </header>
 
-    <h2>Contact the maintainer</h2>
+    <main id="main" class="page-main">
+      <div class="page-prose">
+        <h1>Pastura Support</h1>
 
-    <p>
-      Use the contact form below to send feedback, bug reports, or
-      questions. For general feedback, leave the Scenario ID field
-      blank.
-    </p>
+        <p class="lead">
+          Pastura is an iOS app for running AI multi-agent simulations
+          fully on-device. This page is the support and feedback channel
+          for the app.
+        </p>
 
-    <p>
-      <a class="cta" href="https://docs.google.com/forms/d/e/1FAIpQLSfsZkY9-R3QxqVfdXSzsUnx3SXR-g9O7DxjdN-1-VtMjMXSAw/viewform">Open the contact form</a>
-    </p>
+        <h2>Contact the maintainer</h2>
 
-    <p>
-      You will receive an automatic acknowledgement at the email
-      address you provide on the form. The maintainer reviews
-      submissions and replies as needed.
-    </p>
+        <p>
+          Use the contact form below to send feedback, bug reports, or
+          questions. For general feedback, leave the Scenario ID field
+          blank.
+        </p>
 
-    <h3>Prefer a public tracker?</h3>
+        <p>
+          <a href="https://docs.google.com/forms/d/e/1FAIpQLSfsZkY9-R3QxqVfdXSzsUnx3SXR-g9O7DxjdN-1-VtMjMXSAw/viewform">Open the contact form</a>
+        </p>
 
-    <p>
-      You can also file a
-      <a href="https://github.com/tyabu12/pastura/issues/new">GitHub issue</a>
-      on the project repository. This requires a GitHub account and
-      is public.
-    </p>
+        <p>
+          You will receive an automatic acknowledgement at the email
+          address you provide on the form. The maintainer reviews
+          submissions and replies as needed.
+        </p>
 
-    <h2>Reporting a Shared Scenarios entry</h2>
+        <h3>Prefer a public tracker?</h3>
 
-    <p>
-      To report a specific scenario shown in the in-app Shared Scenarios,
-      use the <strong>Report</strong> button on the scenario's detail
-      sheet inside the app. The in-app flow pre-fills the scenario
-      identifier automatically; the destination is the same contact
-      form above.
-    </p>
+        <p>
+          You can also file a
+          <a href="https://github.com/tyabu12/pastura/issues/new">GitHub issue</a>
+          on the project repository. This requires a GitHub account and
+          is public.
+        </p>
 
-    <p>
-      Reports indicating clear policy violations are hidden from the
-      gallery during triage. Triage is performed by the Pastura
-      maintainer. The full report-handling policy is documented in
-      <a href="https://github.com/tyabu12/pastura/blob/main/docs/decisions/ADR-005.md#6-shared-scenario-report-mechanism">ADR-005 §6</a>.
-    </p>
+        <h2>Reporting a Shared Scenarios entry</h2>
 
-    <footer>
-      <hr>
-      <p>
-        Source code and release notes:
-        <a href="https://github.com/tyabu12/pastura">github.com/tyabu12/pastura</a>
-      </p>
+        <p>
+          To report a specific scenario shown in the in-app Shared Scenarios,
+          use the <strong>Report</strong> button on the scenario's detail
+          sheet inside the app. The in-app flow pre-fills the scenario
+          identifier automatically; the destination is the same contact
+          form above.
+        </p>
+
+        <p>
+          Reports indicating clear policy violations are hidden from the
+          gallery during triage. Triage is performed by the Pastura
+          maintainer. The full report-handling policy is documented in
+          <a href="https://github.com/tyabu12/pastura/blob/main/docs/decisions/ADR-005.md#6-shared-scenario-report-mechanism">ADR-005 §6</a>.
+        </p>
+      </div>
+    </main>
+
+    <footer role="contentinfo" class="lp-footer">
+      <div class="foot-grid">
+        <div>
+          <a href="../" class="brand">
+            <img class="icon" src="../img/app-icon.png" alt="" aria-hidden="true" width="36" height="36">
+            <span class="brand-name">Pastura</span>
+          </a>
+          <p class="body foot-tag">
+            An AI you observe, not operate. On-device, offline, no cloud calls.
+          </p>
+        </div>
+        <div>
+          <h3 class="foot-h">Product</h3>
+          <a class="foot-link" href="../#watch">Observe</a>
+          <a class="foot-link" href="../#capabilities">Capabilities</a>
+          <a class="foot-link" href="../#faq">FAQ</a>
+        </div>
+        <div>
+          <h3 class="foot-h">Resources</h3>
+          <a class="foot-link" href="../legal/privacy-policy/">Privacy Policy</a>
+          <a class="foot-link" href="https://github.com/tyabu12/pastura" rel="noopener">GitHub</a>
+        </div>
+      </div>
+      <div class="foot-base">
+        <span class="foot-copy">© 2026 Pastura</span>
+        <div class="lang-toggle" role="group" aria-label="Language">
+          <button type="button" aria-pressed="true" lang="en" class="on">EN</button>
+          <button type="button" aria-disabled="true" lang="ja" tabindex="-1">JA</button>
+        </div>
+      </div>
     </footer>
-  </main>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- `pages/support/index.html` と `pages/legal/privacy-policy/index.html` を inline `<style>` から LP (`pages/index.html`) と同じ Pastura デザインシステムに移行。新規 `pages/css/page.css` で prose タイポグラフィ / テーブル / inline `<code>` 装飾を**既存トークンのみ**で構築 (新規 `--*` 宣言ゼロ)。
- レビュー指摘を反映し、`.lp-header` / `.lp-footer` / `.foot-*` / `.lang-toggle` などのページ横断 chrome を `lp.css` → `base.css` に再配置。`base.css` ヘッダコメントが当初から示唆していたアーキテクチャ意図 (「lp/* typography tier ... consumable by future redesigns of pages/legal/ and pages/support/」) に整合。LP 側は `lp.css` を引き続き読み込むため挙動変化なし。
- `.github/workflows/deploy-pages.yml` の明示ステージング + smoke-check に `page.css` を追加 (workflow は意図的に recursive cp ではないため、追加しないと本番 404)。

ポリシー本文 (Effective date / `CA92.1` / `C617.1` / `NSPrivacyTracking` / GitHub Privacy Statement / Hugging Face / ADR-005 §6 リンク等) は完全に保持された構造変更のみ。

## Test plan

- [ ] `file://` で 3 ページを開き、ヘッダ・フッタ・タイポグラフィが LP と統一されていることを目視確認
  - `pages/index.html` (LP — 回帰確認)
  - `pages/support/index.html`
  - `pages/legal/privacy-policy/index.html`
- [ ] iOS Safari (実機 / シミュレータ) でモバイル表示確認 (`@media (max-width: 768px)` 反映、`.lang-toggle` がはみ出さない)
- [ ] Light / Dark モード両方で `--moss-*` / `--ink` / `--page` のコントラストが読みやすいことを確認
- [ ] PR マージ後、`deploy-pages` ワークフローの smoke-check が `https://tyabu12.github.io/pastura/css/page.css` を 200 で取得することを確認
- [ ] デプロイ後にプライバシーポリシーのテーブル (`<table>`) が `--rule` border + `--page` th 背景で正しく描画されることをデバイス上で確認
- [ ] 旧フッターにあった GitHub source-code リンクが新 `.lp-footer` の Resources セクションに引き継がれていることを確認

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)