### PR TITLE
🐛 fix: keep DL demo identity state (avatar / scenarioName / ROUND) stable on pause (#355)

### DIFF
--- a/.claude/rules/navigation.md
+++ b/.claude/rules/navigation.md
@@ -319,6 +319,14 @@ surface changes in areas the automated tests do not exercise.
      which spans `.playing` + `.paused`. Also verify the speaker
      sheep avatar colors do not shift between pre-pause and paused
      state — same root cause, same regression guard.
+   - **Demo pause — Stop 3 must keep ROUND fragment** (#355 follow-up):
+     while paused, Stop 3 should still announce the ROUND piece
+     (e.g., `"Round 1 / 1, 個別発言"`), NOT collapse to just the phase
+     label. Originally `currentPhaseIndex` / `totalPhaseCount` were
+     gated `.playing`-only per #297 PR3 — re-evaluated as conflating
+     playback state with identity state. The `status` pill flipping
+     to `"Paused"` is the user signal for pause; ROUND, scenarioName,
+     and avatar colors all stay put.
 3. **Editor save → Home reload** — `EditorReloadTests` covers the
    `onChange(of: router.path.count)` pop-trigger path. Note: the trigger
    only fires when `newCount < oldCount` (a pop). Flows that finish by

--- a/.claude/rules/navigation.md
+++ b/.claude/rules/navigation.md
@@ -310,6 +310,15 @@ surface changes in areas the automated tests do not exercise.
      fine — Demo's GameHeader is the screen's primary heading. Verify
      rotor-Headings on Demo lands on the GameHeader, not on a chat
      row.
+   - **Demo pause — Stop 2 must keep scenarioName** (#355 regression
+     guard): tap the controlBar's pause button on Demo and re-traverse
+     the header. Stop 2 should announce `"Paused, <scenarioName>"`
+     (e.g., `"Paused, ワードウルフ"`), NOT `"Paused"` (collapsed). The
+     prior `currentPresetName`-on-`.playing`-only gating made it
+     collapse; the fix routes through `ReplayViewModel.currentSourceIndex`
+     which spans `.playing` + `.paused`. Also verify the speaker
+     sheep avatar colors do not shift between pre-pause and paused
+     state — same root cause, same regression guard.
 3. **Editor save → Home reload** — `EditorReloadTests` covers the
    `onChange(of: router.path.count)` pop-trigger path. Note: the trigger
    only fires when `newCount < oldCount` (a pop). Flows that finish by

--- a/Pastura/Pastura/App/ReplayViewModel.swift
+++ b/Pastura/Pastura/App/ReplayViewModel.swift
@@ -301,6 +301,35 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
 
   // MARK: - Public computed properties (GameHeader integration)
 
+  /// Currently-active source index — the identity of "which demo is on
+  /// screen right now," independent of playback progress. Returns the
+  /// `sourceIndex` for BOTH `.playing` and `.paused`; `nil` for `.idle`
+  /// and `.transitioning` where no source is active.
+  ///
+  /// **Contrast with the `.playing`-only gated properties below**
+  /// (`currentPhaseIndex`, `totalPhaseCount`, `headerRound`). Those
+  /// intentionally collapse on pause per #297 PR3 so the GameHeader's
+  /// ROUND fragment hides during pause. `currentSourceIndex` is the
+  /// inverse — pausing must NOT change which source the user is
+  /// viewing, otherwise position-based render state (sheep-avatar
+  /// colors, scenario name in the header) flickers between pause and
+  /// resume (regression fixed in #355).
+  ///
+  /// **Prefer this over external `if case .playing(let i, _) = state`
+  /// pattern-matching** when only source identity is needed —
+  /// `.paused(sourceIndex: i, ...)` carries the same identity. The
+  /// `.playing`-only habit is precisely the bug class this property
+  /// guards against.
+  var currentSourceIndex: Int? {
+    switch state {
+    case .playing(let sourceIndex, _),
+      .paused(let sourceIndex, _, _, _):
+      return sourceIndex
+    case .idle, .transitioning:
+      return nil
+    }
+  }
+
   /// 1-based phase index within the currently-playing source. Increments
   /// on each consumed `.phaseStarted`. `nil` outside `.playing` so the
   /// GameHeader's ROUND fragment collapses during `.idle` /

--- a/Pastura/Pastura/App/ReplayViewModel.swift
+++ b/Pastura/Pastura/App/ReplayViewModel.swift
@@ -301,25 +301,27 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
 
   // MARK: - Public computed properties (GameHeader integration)
 
-  /// Currently-active source index — the identity of "which demo is on
-  /// screen right now," independent of playback progress. Returns the
-  /// `sourceIndex` for BOTH `.playing` and `.paused`; `nil` for `.idle`
-  /// and `.transitioning` where no source is active.
+  /// Currently-active source index — "which demo is on screen right
+  /// now." Returns the `sourceIndex` for BOTH `.playing` and `.paused`;
+  /// `nil` for `.idle` and `.transitioning` where no source is active.
   ///
-  /// **Contrast with the `.playing`-only gated properties below**
-  /// (`currentPhaseIndex`, `totalPhaseCount`, `headerRound`). Those
-  /// intentionally collapse on pause per #297 PR3 so the GameHeader's
-  /// ROUND fragment hides during pause. `currentSourceIndex` is the
-  /// inverse — pausing must NOT change which source the user is
-  /// viewing, otherwise position-based render state (sheep-avatar
-  /// colors, scenario name in the header) flickers between pause and
-  /// resume (regression fixed in #355).
+  /// **Canonical identity gate for the GameHeader surface.** The four
+  /// computed properties below (``currentPhaseIndex``,
+  /// ``totalPhaseCount``, ``headerRound``, and the identity reads on
+  /// the host view side — `currentPresetName` and `agentPosition`) all
+  /// gate on this, so the GameHeader's scenario name, ROUND fragment,
+  /// and sheep-avatar colors stay stable across pause / resume. The
+  /// `status` pill (.paused vs .demoing) is the user signal for
+  /// pause; the other fragments preserve position context.
+  ///
+  /// **History**: #297 PR3 originally had ROUND collapse on pause
+  /// (`.playing`-only gate); #355 found avatar colors and scenario
+  /// name flickered for the same reason; the follow-up unified all
+  /// identity reads onto this gate (#355 PR body).
   ///
   /// **Prefer this over external `if case .playing(let i, _) = state`
   /// pattern-matching** when only source identity is needed —
-  /// `.paused(sourceIndex: i, ...)` carries the same identity. The
-  /// `.playing`-only habit is precisely the bug class this property
-  /// guards against.
+  /// `.paused(sourceIndex: i, ...)` carries the same identity.
   var currentSourceIndex: Int? {
     switch state {
     case .playing(let sourceIndex, _),
@@ -330,10 +332,12 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
     }
   }
 
-  /// 1-based phase index within the currently-playing source. Increments
-  /// on each consumed `.phaseStarted`. `nil` outside `.playing` so the
-  /// GameHeader's ROUND fragment collapses during `.idle` /
-  /// `.transitioning` / `.paused` (per #297 PR 3 spec).
+  /// 1-based phase index within the active source. Increments on each
+  /// consumed `.phaseStarted`. `nil` while no source is active
+  /// (`.idle` / `.transitioning`) so the GameHeader's ROUND fragment
+  /// collapses uniformly with the rest of the identity surface; stays
+  /// visible across `.paused` so the user keeps position context
+  /// (re-evaluation of #297 PR3 spec — see ``currentSourceIndex``).
   ///
   /// Distinct from ``currentRound`` (real game-rounds from
   /// `.roundStarted` events). Demo's GameHeader displays this
@@ -341,25 +345,27 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
   /// across multiple phases, leaving the real round counter stuck
   /// at `1/1` for the entire demo.
   var currentPhaseIndex: Int? {
-    guard case .playing = state else { return nil }
+    guard currentSourceIndex != nil else { return nil }
     return phaseProgress > 0 ? phaseProgress : nil
   }
 
-  /// Total `.phaseStarted` event count for the currently-playing
-  /// source. Re-derived on `.loop` rotation against the new source's
-  /// `plannedEvents()`. `nil` outside `.playing` so the GameHeader's
-  /// ROUND fragment collapses uniformly with ``currentPhaseIndex``.
+  /// Total `.phaseStarted` event count for the active source.
+  /// Re-derived on `.loop` rotation against the new source's
+  /// `plannedEvents()`. `nil` while no source is active so the
+  /// GameHeader's ROUND fragment collapses uniformly with
+  /// ``currentPhaseIndex``; stays visible across `.paused`.
   var totalPhaseCount: Int? {
-    guard case .playing = state else { return nil }
+    guard currentSourceIndex != nil else { return nil }
     return cachedTotalPhaseCount > 0 ? cachedTotalPhaseCount : nil
   }
 
   /// Round-counter pair for `GameHeader`'s row-2 ROUND fragment.
   /// Re-uses ``currentPhaseIndex`` and ``totalPhaseCount`` so the
-  /// pair-or-nothing semantic is satisfied automatically: both are
-  /// gated on `.playing` AND a positive backing value, so the wrapper
-  /// collapses to `nil` whenever either piece is missing — including
-  /// the brief post-`start()` window where `cachedTotalPhaseCount` has
+  /// pair-or-nothing semantic is satisfied automatically: both gate on
+  /// ``currentSourceIndex`` (non-nil for `.playing` + `.paused`) AND a
+  /// positive backing value, so the wrapper collapses to `nil`
+  /// whenever either piece is missing — including the brief
+  /// post-`start()` window where `cachedTotalPhaseCount` has
   /// pre-computed but `phaseProgress` is still `0` (no `.phaseStarted`
   /// consumed yet).
   ///

--- a/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView.swift
+++ b/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView.swift
@@ -291,21 +291,21 @@ struct ModelDownloadHostView: View {
   // Module-internal so the sibling `+GameHeader.swift` extension can
   // call this helper. `private` only reaches same-file extensions.
   func currentPresetName(viewModel: ReplayViewModel) -> String {
-    guard case .playing(let sourceIndex, _) = viewModel.state,
+    guard let sourceIndex = viewModel.currentSourceIndex,
       sourceIndex < sources.count
     else { return "" }
     return sources[sourceIndex].scenario.name
   }
 
-  /// Agent's zero-based index in the currently-playing replay's agent
-  /// list, used by ``AvatarSlot`` for position-priority avatar color
-  /// assignment. Returns `nil` when no replay is active or the agent
-  /// isn't in the current source's `agents` list; the row then falls
-  /// back to the name-based avatar resolution.
+  /// Agent's zero-based index in the current replay's agent list, used
+  /// by ``AvatarSlot`` for position-priority avatar color assignment.
+  /// Returns `nil` when no replay is active or the agent isn't in the
+  /// current source's `agents` list; the row then falls back to the
+  /// name-based avatar resolution.
   private func agentPosition(
     for agentName: String, viewModel: ReplayViewModel
   ) -> Int? {
-    guard case .playing(let sourceIndex, _) = viewModel.state,
+    guard let sourceIndex = viewModel.currentSourceIndex,
       sourceIndex < sources.count
     else { return nil }
     return sources[sourceIndex].scenario.personas.firstIndex(where: { $0.name == agentName })

--- a/Pastura/PasturaTests/App/ReplayViewModelTests+PhaseProgression.swift
+++ b/Pastura/PasturaTests/App/ReplayViewModelTests+PhaseProgression.swift
@@ -136,41 +136,48 @@ extension ReplayViewModelTests {
     #expect(viewModel.totalPhaseCount == 1)
   }
 
-  // MARK: - Pause hides ROUND fragment
+  // MARK: - Pause keeps ROUND fragment visible (#355 follow-up)
 
-  @Test func userPauseHidesPhaseCountsAndFlipsStatusToPaused() async throws {
+  @Test func userPauseKeepsPhaseCountsAndFlipsStatusToPaused() async throws {
     let viewModel = try Self.makeVM()
     viewModel.start()
     await Self.waitForCondition { viewModel.currentPhaseIndex != nil }
     viewModel.userPause()
-    // Both fragments collapse during pause so the GameHeader's row 2
-    // ROUND piece disappears uniformly across all paused reasons
-    // (per #297 spec).
-    #expect(viewModel.currentPhaseIndex == nil)
-    #expect(viewModel.totalPhaseCount == nil)
+    // ROUND fragment stays put so the user retains the position
+    // context while paused. Status pill flips to `.paused` to make
+    // the pause-vs-play distinction obvious without dropping ROUND
+    // visibility. Original #297 PR3 spec collapsed both fragments;
+    // re-evaluated in #355 follow-up — the collapse was conflating
+    // playback state with identity state (cf. #355 avatar-color
+    // and scenarioName regressions, same root cause).
+    #expect(viewModel.currentPhaseIndex == 1)
+    #expect(viewModel.totalPhaseCount == 1)
     #expect(viewModel.status == .paused)
   }
 
-  @Test func scenePhasePauseAlsoHidesPhaseCounts() async throws {
+  @Test func scenePhasePauseAlsoKeepsPhaseCounts() async throws {
     let viewModel = try Self.makeVM()
     viewModel.start()
     await Self.waitForCondition { viewModel.currentPhaseIndex != nil }
     viewModel.onBackground()
-    #expect(viewModel.currentPhaseIndex == nil)
-    #expect(viewModel.totalPhaseCount == nil)
+    // Same rule applies on the scene-phase auto-pause path — the
+    // UI is normally hidden during BG anyway, but the boundary is
+    // meaningful for the transient FG-redraw frame.
+    #expect(viewModel.currentPhaseIndex == 1)
+    #expect(viewModel.totalPhaseCount == 1)
     #expect(viewModel.status == .paused)
   }
 
-  // MARK: - Resume restores ROUND fragment
+  // MARK: - Resume flips status without changing ROUND values
 
-  @Test func userResumeRestoresPhaseCountsAndStatus() async throws {
+  @Test func userResumeKeepsPhaseCountsAndFlipsStatusBackToDemoing() async throws {
     let viewModel = try Self.makeVM()
     viewModel.start()
     await Self.waitForCondition { viewModel.currentPhaseIndex != nil }
     viewModel.userPause()
     viewModel.userResume()
-    // Pause does not reset the underlying counter, so resume restores
-    // the same currentPhaseIndex value and the cached total.
+    // Underlying counter is unchanged across the pause / resume
+    // round-trip; the visible difference is only the status pill.
     #expect(viewModel.currentPhaseIndex == 1)
     #expect(viewModel.totalPhaseCount == 1)
     #expect(viewModel.status == .demoing)
@@ -256,11 +263,22 @@ extension ReplayViewModelTests {
     #expect(viewModel.headerRound == GameHeaderRound(current: 1, total: 1))
   }
 
-  @Test func headerRoundIsNilDuringPause() async throws {
+  @Test func headerRoundStaysAvailableDuringPause() async throws {
     let viewModel = try Self.makeVM()
     viewModel.start()
     await Self.waitForCondition { viewModel.currentPhaseIndex != nil }
     viewModel.userPause()
-    #expect(viewModel.headerRound == nil)
+    // Mirrors `userPauseKeepsPhaseCountsAndFlipsStatusToPaused` —
+    // headerRound is the GameHeader-facing pair wrapper and inherits
+    // the new `.playing` + `.paused` policy automatically.
+    #expect(viewModel.headerRound == GameHeaderRound(current: 1, total: 1))
+  }
+
+  @Test func headerRoundStaysAvailableDuringScenePhasePause() async throws {
+    let viewModel = try Self.makeVM()
+    viewModel.start()
+    await Self.waitForCondition { viewModel.currentPhaseIndex != nil }
+    viewModel.onBackground()
+    #expect(viewModel.headerRound == GameHeaderRound(current: 1, total: 1))
   }
 }

--- a/Pastura/PasturaTests/App/ReplayViewModelTests.swift
+++ b/Pastura/PasturaTests/App/ReplayViewModelTests.swift
@@ -272,4 +272,75 @@ struct ReplayViewModelTests {
     viewModel.downloadComplete()
     #expect(viewModel.state == .idle)
   }
+
+  // MARK: - currentSourceIndex (identity-state surface)
+  //
+  // Regression suite for #355: `currentSourceIndex` must return the
+  // active source index across BOTH `.playing` and `.paused` so the
+  // host view's position-based render state (sheep-avatar colors,
+  // GameHeader scenario name) does not flicker on user pause / resume.
+  // Contrast with `currentPhaseIndex` / `totalPhaseCount` / `headerRound`,
+  // which intentionally collapse on pause (#297 PR3).
+
+  @Test func currentSourceIndexIsNilWhileIdle() throws {
+    let viewModel = try Self.makeVM()
+    #expect(viewModel.currentSourceIndex == nil)
+  }
+
+  @Test func currentSourceIndexReturnsIndexWhilePlaying() throws {
+    let viewModel = try Self.makeVM()
+    viewModel.start()
+    #expect(viewModel.currentSourceIndex == 0)
+  }
+
+  @Test func currentSourceIndexReturnsIndexWhilePausedByScenePhase() async throws {
+    // Mirrors `onBackgroundTransitionsPlayingToPaused` setup so we
+    // reliably land in `.paused(.scenePhase)` with a valid sourceIndex.
+    let slowConfig = ReplayPlaybackConfig(
+      playbackSpeed: .normal,
+      turnDelayMs: 200, codePhaseDelayMs: 50,
+      loopBehaviour: .stopAfterLast, onComplete: .stopPlayback)
+    let source = try YAMLReplaySource(
+      yaml: Self.threeTurnYAML, scenario: Self.makeScenario(),
+      config: slowConfig)
+    let viewModel = ReplayViewModel(sources: [source], config: slowConfig)
+    viewModel.start()
+    try await Task.sleep(for: .milliseconds(20))
+    viewModel.onBackground()
+    guard case .paused(_, _, _, .scenePhase) = viewModel.state else {
+      Issue.record("Expected .paused(.scenePhase), got \(viewModel.state)")
+      return
+    }
+    #expect(viewModel.currentSourceIndex == 0)
+  }
+
+  @Test func currentSourceIndexReturnsIndexWhilePausedByUser() async throws {
+    // `.user` pauses are the path the controlBar drives — the actual
+    // bug surface in #355. `PauseReason` must not change identity.
+    let slowConfig = ReplayPlaybackConfig(
+      playbackSpeed: .normal,
+      turnDelayMs: 200, codePhaseDelayMs: 50,
+      loopBehaviour: .stopAfterLast, onComplete: .stopPlayback)
+    let source = try YAMLReplaySource(
+      yaml: Self.threeTurnYAML, scenario: Self.makeScenario(),
+      config: slowConfig)
+    let viewModel = ReplayViewModel(sources: [source], config: slowConfig)
+    viewModel.start()
+    try await Task.sleep(for: .milliseconds(20))
+    viewModel.userPause()
+    guard case .paused(_, _, _, .user) = viewModel.state else {
+      Issue.record("Expected .paused(.user), got \(viewModel.state)")
+      return
+    }
+    #expect(viewModel.currentSourceIndex == 0)
+  }
+
+  @Test func currentSourceIndexIsNilWhileTransitioning() async throws {
+    let viewModel = try Self.makeVM()
+    viewModel.start()
+    await Self.waitForState(viewModel) { _ in viewModel.agentOutputs.count >= 1 }
+    viewModel.downloadComplete()
+    #expect(viewModel.state == .transitioning)
+    #expect(viewModel.currentSourceIndex == nil)
+  }
 }


### PR DESCRIPTION
## Summary

DL-time demo replay: tapping play/pause caused three visible regressions, all rooted in the same `.playing`-only state-machine guards. The fixes route everything through a new ``ReplayViewModel.currentSourceIndex`` gate that spans both `.playing` and `.paused`.

1. **Speaker sheep avatar colors shifted on every pause/resume.** `ModelDownloadHostView.agentPosition()` returned `nil` while paused; `SheepAvatar.Character.forAgent(name, position: nil)` fell through from the position branch to a UTF-8 byte-sum hash for the Japanese persona names in bundled demos, producing fresh bucket assignments per pause.
2. **GameHeader scenario name collapsed during pause.** Same `.playing`-only gate on `currentPresetName()`.
3. **GameHeader ROUND fragment collapsed during pause.** `currentPhaseIndex` / `totalPhaseCount` / `headerRound` gated `.playing`-only per #297 PR3 spec — re-evaluated as the same identity-vs-progress conflation. The `status` pill flipping to `"Paused"` is the user signal for pause; ROUND, scenarioName, phaseLabel, and sheep avatars all preserve position context.

`.idle` and `.transitioning` continue to collapse all identity fragments — the brief fade before the DL-complete overlay handoff has no meaningful position context.

## Test plan

- [x] 5 new `currentSourceIndex` tests cover all 4 `State` cases including both `PauseReason` variants
- [x] 3 updated `+PhaseProgression` tests pin the new "ROUND stays visible on pause" policy + 1 new headerRound scene-phase pause test
- [x] Full unit test suite (1517 tests) passes
- [x] swiftlint `--strict` clean
- [x] code-reviewer (Opus) PASS across both review rounds (avatar/scenarioName then ROUND)
- [x] Manual QA: play DL demo, pause/resume several times — sheep colors stable, GameHeader scenario name + ROUND visible while paused (status pill shows `"Paused"`)
- [ ] Manual QA (VoiceOver): Stop 2 announces `"Paused, <scenarioName>"`, Stop 3 announces `"Round 1 / 1, <phase>"` while paused — per the updated `.claude/rules/navigation.md` scenario 2

Closes #355