### PR TITLE
✨ feat: align privacy + support page metadata with LP positioning

### DIFF
--- a/pages/legal/privacy-policy/index.html
+++ b/pages/legal/privacy-policy/index.html
@@ -4,14 +4,29 @@
   <meta charset="utf-8">
   <title>Pastura Privacy Policy</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Privacy policy for Pastura, an iOS app for on-device AI multi-agent simulations.">
+  <meta name="description" content="Privacy policy for Pastura, an app for on-device AI multi-agent scenarios. Currently iOS-only.">
   <meta name="theme-color" content="#FCFAF4" media="(prefers-color-scheme: light)">
   <meta name="theme-color" content="#1B1C18" media="(prefers-color-scheme: dark)">
 
   <link rel="canonical" href="https://tyabu12.github.io/pastura/legal/privacy-policy/">
+  <link rel="alternate" hreflang="en" href="https://tyabu12.github.io/pastura/legal/privacy-policy/">
+  <!-- hreflang ja intentionally omitted — /ja/ route not yet implemented -->
 
   <link rel="icon" type="image/png" sizes="64x64" href="../../img/favicon-64.png">
   <link rel="apple-touch-icon" href="../../img/app-icon.png">
+
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Pastura Privacy Policy">
+  <meta property="og:description" content="Privacy policy for Pastura, an app for on-device AI multi-agent scenarios.">
+  <meta property="og:url" content="https://tyabu12.github.io/pastura/legal/privacy-policy/">
+  <!-- Stub: app-icon (256×256) used as og:image until proper 1200×630 OGP design ships. -->
+  <meta property="og:image" content="https://tyabu12.github.io/pastura/img/app-icon.png">
+  <meta property="og:image:width" content="256">
+  <meta property="og:image:height" content="256">
+  <meta property="og:image:alt" content="Pastura app icon">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="Pastura Privacy Policy">
+  <meta name="twitter:description" content="Privacy policy for Pastura, an app for on-device AI multi-agent scenarios.">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -49,11 +64,13 @@
         <h2>Who we are</h2>
 
         <p>
-          Pastura is an iOS app for running AI multi-agent simulations entirely
-          on-device. It is developed and maintained by <strong>tyabu12</strong>
-          (an individual developer). References to "we", "us", or "Pastura" in
-          this policy refer to tyabu12 acting as the data controller for any
-          data the app might process.
+          Pastura is an app for running AI multi-agent scenarios entirely
+          on-device. Scenarios are user-authored experiments; simulations
+          are the on-device executions of those scenarios. Currently
+          iOS-only. It is developed and maintained by <strong>tyabu12</strong>
+          (an individual developer). References to "we", "us", or "Pastura"
+          in this policy refer to tyabu12 acting as the data controller for
+          any data the app might process.
         </p>
 
         <h2>Summary</h2>

--- a/pages/legal/privacy-policy/index.html
+++ b/pages/legal/privacy-policy/index.html
@@ -66,11 +66,11 @@
         <p>
           Pastura is an app for running AI multi-agent scenarios entirely
           on-device. Scenarios are user-authored experiments; simulations
-          are the on-device executions of those scenarios. Currently
-          iOS-only. It is developed and maintained by <strong>tyabu12</strong>
-          (an individual developer). References to "we", "us", or "Pastura"
-          in this policy refer to tyabu12 acting as the data controller for
-          any data the app might process.
+          are the on-device executions of those scenarios. It is developed
+          and maintained by <strong>tyabu12</strong> (an individual
+          developer) and is currently iOS-only. References to "we", "us",
+          or "Pastura" in this policy refer to tyabu12 acting as the data
+          controller for any data the app might process.
         </p>
 
         <h2>Summary</h2>

--- a/pages/support/index.html
+++ b/pages/support/index.html
@@ -4,14 +4,29 @@
   <meta charset="utf-8">
   <title>Pastura Support</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Support and feedback channel for Pastura, an iOS app for on-device AI multi-agent simulations.">
+  <meta name="description" content="Support and feedback channel for Pastura, an app for on-device AI multi-agent scenarios. Currently iOS-only.">
   <meta name="theme-color" content="#FCFAF4" media="(prefers-color-scheme: light)">
   <meta name="theme-color" content="#1B1C18" media="(prefers-color-scheme: dark)">
 
   <link rel="canonical" href="https://tyabu12.github.io/pastura/support/">
+  <link rel="alternate" hreflang="en" href="https://tyabu12.github.io/pastura/support/">
+  <!-- hreflang ja intentionally omitted — /ja/ route not yet implemented -->
 
   <link rel="icon" type="image/png" sizes="64x64" href="../img/favicon-64.png">
   <link rel="apple-touch-icon" href="../img/app-icon.png">
+
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Pastura Support">
+  <meta property="og:description" content="Support and feedback channel for Pastura, an app for on-device AI multi-agent scenarios.">
+  <meta property="og:url" content="https://tyabu12.github.io/pastura/support/">
+  <!-- Stub: app-icon (256×256) used as og:image until proper 1200×630 OGP design ships. -->
+  <meta property="og:image" content="https://tyabu12.github.io/pastura/img/app-icon.png">
+  <meta property="og:image:width" content="256">
+  <meta property="og:image:height" content="256">
+  <meta property="og:image:alt" content="Pastura app icon">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="Pastura Support">
+  <meta name="twitter:description" content="Support and feedback channel for Pastura, an app for on-device AI multi-agent scenarios.">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -42,9 +57,9 @@
         <h1>Pastura Support</h1>
 
         <p class="lead">
-          Pastura is an iOS app for running AI multi-agent simulations
-          fully on-device. This page is the support and feedback channel
-          for the app.
+          Pastura is an app for running AI multi-agent scenarios fully
+          on-device. Currently iOS-only. This page is the support and
+          feedback channel for the app.
         </p>
 
         <h2>Contact the maintainer</h2>


### PR DESCRIPTION
## Summary

- Align high-level descriptions in `pages/legal/privacy-policy/index.html` and `pages/support/index.html` with the LP's positioning (`pages/index.html`): "iOS app for AI multi-agent simulations" → "an app for AI multi-agent scenarios. Currently iOS-only." Plain "app" rather than "mobile app" because iPad is already a first-class target (`TARGETED_DEVICE_FAMILY = "1,2"`).
- Add Open Graph + Twitter Card + `hreflang="en"` meta tags to both pages (LP had them; legal/support did not), so these URLs render proper preview cards when shared.
- Add a one-line definition in privacy's "Who we are" disambiguating **scenarios** (user-authored experiments) vs **simulations** (on-device executions of those scenarios), so the body's existing technical usage of "simulations" stays well-defined.

## Why

- "iOS app" hardcoded in these pages was a stronger commitment than the LP's own positioning, which localizes "iOS" to `schema.org operatingSystem` and the FAQ only. Plain "app" + "Currently iOS-only." stays forward-compatible with whatever ADR-004 (Draft) eventually accepts, without committing to platforms beyond what the LP FAQ already says ("Android is on the list").
- "simulations" in high-level copy mismatched the LP's "scenarios" vocabulary. The new defining sentence resolves the noun-mixing inside the privacy policy without rewriting the technical body (SQLite "Past simulation results", "Running simulations you have configured", etc.).
- Privacy/support URLs are shared (support tickets, App Store reviewer comms, etc.) but had no OG/Twitter cards, so previews fell back to a bare URL. Parity with the LP set fixes that.

## Intentionally NOT changed

- `<title>` tags
- Children's privacy "rated 13+ on the App Store"
- `PrivacyInfo.xcprivacy` references and "App Store privacy nutrition label"
- Body usage of "simulations" for the on-device execution mechanism
- "International users" / "Future changes (Cloud API)" sections

All accurate for the iOS-only present and better revised together at the actual Android launch PR alongside their Google Play counterparts (Data safety section, "Teen" rating, etc.).

## Test plan

- [x] Serve `pages/` locally (`python3 -m http.server` from `pages/`) and verify the rendered privacy + support pages look correct in light + dark mode
- [x] Paste each page URL into a sharing-debug tool (Twitter Card Validator / Facebook Sharing Debugger) — confirm og:image, og:title, og:description render and the 256×256 app-icon stub appears as expected
- [ ] Google's Rich Results Test or "View source" snippet preview — confirm meta description previews correctly
- [ ] Visually scan for em-dash leakage in user-visible copy — confirmed clean (em-dashes appear only inside HTML comments matching the LP convention)
- [ ] Diff against LP `pages/index.html` for OG/Twitter tag parity — 11 tags present in identical order

Closes #361