### PR TITLE
🐛 fix: prefill Qwen 3 assistant turn to dodge grammar crash

### DIFF
--- a/Pastura/Pastura/App/ModelRegistry.swift
+++ b/Pastura/Pastura/App/ModelRegistry.swift
@@ -52,7 +52,15 @@ enum ModelRegistry {
     stopSequence: "<|im_end|>",
     minRAM: 6_500_000_000,
     modelInfoURL: unsafeURL("https://huggingface.co/Qwen/Qwen3-4B-GGUF"),
-    systemPromptSuffix: "/no_think"
+    systemPromptSuffix: "/no_think",
+    // Prefill the assistant turn with the empty-thinking marker so Qwen 3
+    // bypasses thinking mode entirely. Issue #366 — without this, Qwen
+    // emits `<think>` (token 151667) as its first sampled token and the
+    // GBNF grammar sampler crashes on `accept_token` (uncaught C++ exception).
+    // The `/no_think` system suffix above is a soft training hint that does
+    // not prevent the leading `<think>` token; the prefill is the load-bearing
+    // fix. `/no_think` stays as belt-and-suspenders.
+    assistantPrefix: "<think>\n\n</think>\n\n"
   )
 
   /// Full production catalog, ordered by display preference (Gemma first, Qwen second).

--- a/Pastura/Pastura/LLM/LlamaCppService+ChatTemplate.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService+ChatTemplate.swift
@@ -55,7 +55,23 @@ extension LlamaCppService {
       )
     }
 
-    return try LlamaCppService.decodeAppliedTemplate(buffer: buffer, written: written)
+    let decoded = try LlamaCppService.decodeAppliedTemplate(buffer: buffer, written: written)
+
+    // Assistant-turn prefill. `llama_chat_apply_template` (called with
+    // `add_ass: true` above) ends the formatted prompt at the assistant
+    // role marker (e.g., `<|im_start|>assistant\n`). For Qwen 3, the Jinja
+    // chat template would also emit `<think>\n\n</think>\n\n` here when
+    // `enable_thinking=false`, but the C-API simplified template does NOT
+    // perform that prefill — so we do it explicitly. Without this, Qwen
+    // emits `<think>` (token 151667) as its first generated token, which
+    // the GBNF grammar's `root` rule cannot accept; `llama_grammar_accept_token`
+    // throws `std::runtime_error: Unexpected empty grammar stack`, crashing
+    // the process via an uncaught C++ exception (Issue #366). `nil`-default
+    // for models that need no prefill (Gemma).
+    if let assistantPrefix {
+      return decoded + assistantPrefix
+    }
+    return decoded
   }
 
   /// Decodes the buffer produced by `llama_chat_apply_template` and rejects

--- a/Pastura/Pastura/LLM/LlamaCppService.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService.swift
@@ -92,6 +92,15 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
   /// suffix.
   let systemPromptSuffix: String?
 
+  /// Optional text appended to the formatted prompt after the chat template's
+  /// assistant-role marker — i.e., prefilled into the assistant turn so the
+  /// model continues from this text instead of generating it.
+  ///
+  /// Used by Qwen 3 (`"<think>\n\n</think>\n\n"`) to bypass thinking mode and
+  /// avoid the GBNF grammar crash on the leading `<think>` special token
+  /// (Issue #366). `nil` for models that need no prefill (Gemma).
+  let assistantPrefix: String?
+
   private let loadedState: OSAllocatedUnfairLock<Bool>
   // Synchronizing fence for the sequential-access contract (ADR-002 §6).
   // generate() / generateStream() acquire this via acquireGenerateGuard
@@ -163,16 +172,21 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
   ///   - modelIdentifier: Human-readable label for exports / replay metadata.
   ///   - systemPromptSuffix: Optional suffix appended to the system prompt
   ///     at `applyChatTemplate` (e.g., `/no_think` for Qwen 3).
+  ///   - assistantPrefix: Optional text prefilled into the assistant turn
+  ///     after the chat template's assistant-role marker (e.g.,
+  ///     `"<think>\n\n</think>\n\n"` for Qwen 3 to disable thinking mode).
   public init(
     modelPath: String,
     stopSequence: String,
     modelIdentifier: String,
-    systemPromptSuffix: String?
+    systemPromptSuffix: String?,
+    assistantPrefix: String? = nil
   ) {
     self.modelPath = modelPath
     self.stopSequence = stopSequence
     self.modelIdentifier = modelIdentifier
     self.systemPromptSuffix = systemPromptSuffix
+    self.assistantPrefix = assistantPrefix
     self.loadedState = OSAllocatedUnfairLock(initialState: false)
     // Install llama.cpp's C-runtime log capture once — routes grammar
     // parse errors ("invalid character", "expected ::=", etc.) into

--- a/Pastura/Pastura/Models/ModelDescriptor.swift
+++ b/Pastura/Pastura/Models/ModelDescriptor.swift
@@ -48,6 +48,24 @@ nonisolated public struct ModelDescriptor: Sendable, Hashable {
   /// that need no suffix.
   public let systemPromptSuffix: String?
 
+  /// Optional text appended to the formatted prompt *after* the chat template's
+  /// assistant-role marker (i.e., prefilled into the assistant turn).
+  ///
+  /// Used by Qwen 3 to disable thinking mode via the official
+  /// `"<think>\n\n</think>\n\n"` prefill — equivalent to what the Jinja chat
+  /// template would emit under `enable_thinking=false`. llama.cpp's C-API
+  /// `llama_chat_apply_template` is the simplified non-Jinja implementation and
+  /// does not perform this prefill automatically, so we append it post-template.
+  ///
+  /// Without this prefill, Qwen 3 emits `<think>` (token 151667) as its first
+  /// generated token, which the GBNF grammar's `root` rule cannot accept —
+  /// `llama_grammar_accept_token` throws `std::runtime_error: Unexpected empty
+  /// grammar stack`, crashing the process via an uncaught C++ exception
+  /// (Issue #366).
+  ///
+  /// `nil` for models that need no prefill (Gemma 4 E2B).
+  public let assistantPrefix: String?
+
   /// Returns `true` iff `name` matches `^[A-Za-z0-9._-]+\.gguf$`.
   ///
   /// Use this to validate a candidate filename before constructing a `ModelDescriptor`.
@@ -71,7 +89,8 @@ nonisolated public struct ModelDescriptor: Sendable, Hashable {
     stopSequence: String,
     minRAM: UInt64,
     modelInfoURL: URL,
-    systemPromptSuffix: String?
+    systemPromptSuffix: String?,
+    assistantPrefix: String? = nil
   ) {
     precondition(
       Self.isValidFileName(fileName),
@@ -89,6 +108,7 @@ nonisolated public struct ModelDescriptor: Sendable, Hashable {
     self.minRAM = minRAM
     self.modelInfoURL = modelInfoURL
     self.systemPromptSuffix = systemPromptSuffix
+    self.assistantPrefix = assistantPrefix
   }
 }
 

--- a/Pastura/Pastura/PasturaApp.swift
+++ b/Pastura/Pastura/PasturaApp.swift
@@ -409,7 +409,8 @@ private struct RootView: View {
         modelPath: modelPath,
         stopSequence: descriptor.stopSequence,
         modelIdentifier: descriptor.displayName,
-        systemPromptSuffix: descriptor.systemPromptSuffix
+        systemPromptSuffix: descriptor.systemPromptSuffix,
+        assistantPrefix: descriptor.assistantPrefix
       )
       let deps = try AppDependencies.production(llmService: llm)
       // Register BG task handler early so iOS 26+ can launch us in background.

--- a/Pastura/Pastura/Views/Settings/SettingsView.swift
+++ b/Pastura/Pastura/Views/Settings/SettingsView.swift
@@ -300,7 +300,8 @@ struct SettingsView: View {
         modelPath: modelPath,
         stopSequence: descriptor.stopSequence,
         modelIdentifier: descriptor.displayName,
-        systemPromptSuffix: descriptor.systemPromptSuffix
+        systemPromptSuffix: descriptor.systemPromptSuffix,
+        assistantPrefix: descriptor.assistantPrefix
       )
       dependencies.regenerateLLMService(newService)
     }

--- a/Pastura/PasturaTests/App/ModelRegistryTests.swift
+++ b/Pastura/PasturaTests/App/ModelRegistryTests.swift
@@ -41,6 +41,19 @@ struct ModelRegistryTests {
       ModelRegistry.qwen34B.sha256
         == "7485fe6f11af29433bc51cab58009521f205840f5b4ae3a32fa7f92e8534fdf5")
     #expect(ModelRegistry.qwen34B.systemPromptSuffix == "/no_think")
+    // Issue #366 — without this prefill, Qwen 3 emits `<think>` as its first
+    // generated token and the GBNF grammar sampler crashes via uncaught C++
+    // exception. The exact string is load-bearing (matches the Qwen 3 Jinja
+    // chat template's `enable_thinking=false` output).
+    #expect(ModelRegistry.qwen34B.assistantPrefix == "<think>\n\n</think>\n\n")
+  }
+
+  /// Gemma must NOT carry an `assistantPrefix` — the bridge between the
+  /// chat template and Gemma's training assumes the assistant turn starts
+  /// empty. A non-nil prefix here would silently change Gemma's generation
+  /// surface.
+  @Test func gemma_hasNoAssistantPrefix() {
+    #expect(ModelRegistry.gemma4E2B.assistantPrefix == nil)
   }
 
   // findCollisions testability — covers the uniqueness check without

--- a/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests+Qwen.swift
+++ b/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests+Qwen.swift
@@ -50,20 +50,31 @@ private enum QwenConfig {
 /// - Test (a) fails → the Q4_K_M quantization is incompatible with
 ///   llama.cpp's chatml fallback path. Revise plan to add a
 ///   `chatTemplateOverride` field on `ModelDescriptor`.
-/// - Test (b) fails → `/no_think` in the system prompt does not suppress
-///   thinking mode. Try moving the suffix to the user message
-///   (introduce `PromptSuffixPosition` enum) OR raise `maxTokens` per
-///   descriptor so the JSON survives the thinking prefix.
+/// - Test (b) fails → the `<think>\n\n</think>\n\n` assistant prefill
+///   (`ModelDescriptor.assistantPrefix`) is being dropped or has the wrong
+///   shape. Confirm `LlamaCppService.applyChatTemplate` appends the prefix
+///   to the formatted prompt after `llama_chat_apply_template`. The
+///   `/no_think` system suffix is a soft training hint and is not the
+///   load-bearing mechanism — do NOT debug this test by altering the
+///   suffix. History: Issue #366 — without the prefill, Qwen 3 emits
+///   `<think>` (token 151667) as its first generated token, crashing
+///   the grammar sampler.
+/// - Test (c) fails → schema-constrained generation hit the grammar-sampler
+///   crash that motivated the prefill. The whole process terminates
+///   (uncaught C++ exception); test (c) regresses test-process side too.
 extension LlamaCppIntegrationTests {
 
   // MARK: - Helpers
 
   private func makeQwenService() -> LlamaCppService {
+    // Mirror `ModelRegistry.qwen34B` — keep `/no_think` and the prefill in
+    // lockstep with production so integration regressions track real builds.
     LlamaCppService(
       modelPath: QwenConfig.modelPath,
       stopSequence: "<|im_end|>",
       modelIdentifier: "Qwen 3 4B (Q4_K_M)",
-      systemPromptSuffix: "/no_think"
+      systemPromptSuffix: "/no_think",
+      assistantPrefix: "<think>\n\n</think>\n\n"
     )
   }
 
@@ -128,11 +139,58 @@ extension LlamaCppIntegrationTests {
 
     #expect(
       !result.contains("<think>"),
-      "Qwen emitted <think> block despite /no_think suffix. Raw: \(result)"
+      "Qwen emitted <think> block despite assistant prefill. Raw: \(result)"
     )
     #expect(
       !result.contains("</think>"),
-      "Qwen emitted </think> close tag despite /no_think suffix. Raw: \(result)"
+      "Qwen emitted </think> close tag despite assistant prefill. Raw: \(result)"
+    )
+  }
+
+  // MARK: - Test (c): Schema-constrained generate does NOT crash on <think>
+
+  /// Verifies that schema-constrained generation does not regress the
+  /// grammar-sampler crash that motivated `assistantPrefix` (Issue #366).
+  ///
+  /// Without the `<think>\n\n</think>\n\n` prefill, Qwen 3 emits `<think>`
+  /// (token 151667) as its first generated token. The GBNF grammar's `root`
+  /// rule cannot accept that piece, so `llama_grammar_accept_token` throws
+  /// `std::runtime_error: Unexpected empty grammar stack` — an uncaught C++
+  /// exception that terminates the test process. A regression here will
+  /// take down the whole test runner, not just this test; if you see the
+  /// xctest harness exit without reporting, this is the prime suspect.
+  ///
+  /// This test exercises the same code path as Engine's
+  /// `speak_all` / `choose` handlers when they wire GBNF grammar through
+  /// `LLMService.generate(system:user:schema:)`.
+  @Test(
+    "Qwen: schema-constrained generate does not crash on <think>",
+    .enabled(if: QwenConfig.isEnabled),
+    .timeLimit(.minutes(3))
+  )
+  func qwenWithGrammarDoesNotCrash() async throws {
+    let service = makeQwenService()
+    try await service.loadModel()
+    defer { Task { try? await service.unloadModel() } }
+
+    let schema = OutputSchema(fields: [
+      OutputSchema.Field(name: "statement", kind: .string)
+    ])
+
+    // Reaching this `#expect` means no C++ exception terminated the process.
+    let result = try await service.generate(
+      system: """
+        You are a character in a game. Respond ONLY with a JSON object.
+        Required format: {"statement": "your statement here"}
+        """,
+      user: "Introduce yourself briefly.",
+      schema: schema
+    )
+
+    #expect(!result.isEmpty, "Qwen produced empty output under grammar")
+    #expect(
+      result.contains("{") && result.contains("}"),
+      "Qwen output is not JSON-shaped under grammar. Raw: \(result)"
     )
   }
 }

--- a/Pastura/PasturaTests/LLM/LlamaCppServiceChatTemplateTests.swift
+++ b/Pastura/PasturaTests/LLM/LlamaCppServiceChatTemplateTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 
 @testable import Pastura
@@ -63,6 +64,61 @@ struct LlamaCppServiceChatTemplateTests {
     } catch {
       Issue.record("expected LLMError, got \(error)")
     }
+  }
+
+  // MARK: - Assistant-turn prefill (#366)
+
+  /// Helper: build a `LlamaCppService` configured purely for the chat-template
+  /// path. `applyChatTemplate` does not touch the model context or sampler, so
+  /// `modelPath` can be empty — no `loadModel()` is required.
+  private static func makeService(assistantPrefix: String?) -> LlamaCppService {
+    LlamaCppService(
+      modelPath: "",
+      stopSequence: "<|im_end|>",
+      modelIdentifier: "ChatTemplate Test Service",
+      systemPromptSuffix: nil,
+      assistantPrefix: assistantPrefix
+    )
+  }
+
+  /// Gemma regression pin: with `assistantPrefix == nil`, the formatted prompt
+  /// must NOT carry a stray `<think>` block (i.e., behavior is byte-identical
+  /// to the pre-fix output for the Gemma path). Asserting absence of `<think>`
+  /// is the simplest invariant — full byte-identity is implied because the
+  /// new branch only appends a string when `assistantPrefix` is non-nil.
+  @Test func gemmaPathDoesNotAppendThinkBlock() throws {
+    let service = Self.makeService(assistantPrefix: nil)
+    let prompt = try service.applyChatTemplate(
+      system: "You are a test fixture.", user: "Say hi.")
+    #expect(!prompt.contains("<think>"))
+    #expect(!prompt.contains("</think>"))
+  }
+
+  /// Qwen prefill: with `assistantPrefix == "<think>\n\n</think>\n\n"`, the
+  /// formatted prompt must end with that exact suffix. Anchoring at the suffix
+  /// catches the easy ordering regression where someone moves the append to
+  /// before the chat-template marker — that would still contain the substring
+  /// but break the actual Jinja-equivalent semantics.
+  @Test func qwenPrefixIsAppendedAsSuffix() throws {
+    let service = Self.makeService(assistantPrefix: "<think>\n\n</think>\n\n")
+    let prompt = try service.applyChatTemplate(
+      system: "You are a test fixture.", user: "Say hi.")
+    #expect(
+      prompt.hasSuffix("<think>\n\n</think>\n\n"),
+      "Expected prompt to end with the prefill; got tail: \(prompt.suffix(50))"
+    )
+  }
+
+  /// Cross-check: the prefill text must appear EXACTLY ONCE in the formatted
+  /// prompt. If it appears twice, something duplicated it — e.g., a future
+  /// regression where both the system suffix and the assistant prefix wire
+  /// `<think>` content.
+  @Test func qwenPrefixAppearsExactlyOnce() throws {
+    let service = Self.makeService(assistantPrefix: "<think>\n\n</think>\n\n")
+    let prompt = try service.applyChatTemplate(
+      system: "You are a test fixture.", user: "Say hi.")
+    let occurrences = prompt.components(separatedBy: "<think>").count - 1
+    #expect(occurrences == 1, "Expected exactly 1 <think> occurrence, got \(occurrences)")
   }
 
   // MARK: - Boundary documentation (out-of-scope cases)

--- a/Pastura/PasturaTests/Models/ModelDescriptorTests.swift
+++ b/Pastura/PasturaTests/Models/ModelDescriptorTests.swift
@@ -67,7 +67,8 @@ struct ModelDescriptorTests {
       stopSequence: "<|im_end|>",
       minRAM: 6_000_000_000,
       modelInfoURL: modelInfoURL,
-      systemPromptSuffix: "/no_think"
+      systemPromptSuffix: "/no_think",
+      assistantPrefix: "<think>\n\n</think>\n\n"
     )
 
     #expect(descriptor.id == "gemma-4-e2b-q4-k-m")
@@ -82,6 +83,15 @@ struct ModelDescriptorTests {
     #expect(descriptor.minRAM == 6_000_000_000)
     #expect(descriptor.modelInfoURL == modelInfoURL)
     #expect(descriptor.systemPromptSuffix == "/no_think")
+    #expect(descriptor.assistantPrefix == "<think>\n\n</think>\n\n")
+  }
+
+  /// `assistantPrefix` is optional with a `nil` default to keep construction
+  /// ergonomic for the common Gemma-shaped case. Verifies that omitting the
+  /// argument lands as `nil`, not as a fault.
+  @Test func construction_assistantPrefixDefaultsToNil() {
+    let descriptor = makeDescriptor()
+    #expect(descriptor.assistantPrefix == nil)
   }
 
   // MARK: - Hashable


### PR DESCRIPTION
## Summary
- Prefill the assistant turn with `<think>\n\n</think>\n\n` for Qwen 3 to
  bypass thinking mode — equivalent to the Jinja chat template's
  `enable_thinking=false` output. llama.cpp's C-API `llama_chat_apply_template`
  is the non-Jinja simplified path and does not perform this prefill on its own.
- Without it, Qwen 3 emits `<think>` (token 151667) as its first generated
  token under GBNF grammar constraint; `llama_grammar_accept_token` cannot
  advance state and throws `std::runtime_error: Unexpected empty grammar stack`,
  terminating the process via an uncaught C++ exception.
- Adds `ModelDescriptor.assistantPrefix: String?` plumbed through
  `LlamaCppService.applyChatTemplate`. Gemma stays unchanged (`nil`). `/no_think`
  system suffix kept as belt-and-suspenders.

## Test plan
- [x] New unit tests in `LlamaCppServiceChatTemplateTests` — Gemma `nil`
      regression pin, Qwen suffix anchoring, exactly-once occurrence
- [x] `ModelRegistryTests.qwen_integrityMetadataMatchesFetchedValues` pins
      the exact prefill string; `gemma_hasNoAssistantPrefix` pins Gemma `nil`
- [x] Full local unit suite: 1553 tests in 140 suites passed (15.4s)
- [x] swiftlint --strict: no violations
- [x] Manual: run a simulation on Qwen 3 4B device-side and confirm no crash
- [ ] (Optional, gated) Run integration test (c) against a local Qwen GGUF:
      `LLAMACPP_INTEGRATION=1 LLAMACPP_QWEN_MODEL_PATH=/path/to/Qwen3-4B-Q4_K_M.gguf`

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)