### PR TITLE
🌐 feat: i18n wraps in Views/ModelDownload + multi-model PromoCard total size

### DIFF
--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -17,6 +17,22 @@
         }
       }
     },
+    "%.1f GB / %.1f GB" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$.1f GB / %2$.1f GB"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$.1f GB / %2$.1f GB"
+          }
+        }
+      }
+    },
     "%@ assigned: %@" : {
       "localizations" : {
         "en" : {
@@ -133,6 +149,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "概要"
+          }
+        }
+      }
+    },
+    "About %lld min left" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "残り約 %lld 分"
           }
         }
       }
@@ -618,6 +644,17 @@
         }
       }
     },
+    "DL" : {
+      "comment" : "Status abbreviation in PromoCard meta row. Intentionally identical en/ja — kept short to fit the dot-progress strip.",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DL"
+          }
+        }
+      }
+    },
     "Database migration failed: %arg" : {
       "localizations" : {
         "ja" : {
@@ -786,6 +823,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ダウンロードに失敗しました"
+          }
+        }
+      }
+    },
+    "Download interrupted" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダウンロードが中断しました"
           }
         }
       }
@@ -1533,6 +1580,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "サブフェーズを長押しすると、もう一方のブランチの末尾に移動します。"
+          }
+        }
+      }
+    },
+    "Model Setup" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "モデルセットアップ"
           }
         }
       }
@@ -2646,6 +2703,16 @@
         }
       }
     },
+    "Setup complete" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "準備ができました"
+          }
+        }
+      }
+    },
     "Shared Scenarios" : {
       "localizations" : {
         "ja" : {
@@ -2703,6 +2770,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "社会心理学"
+          }
+        }
+      }
+    },
+    "Soon" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "まもなく"
           }
         }
       }
@@ -2869,6 +2946,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "+ をタップして YAML シナリオをインポート"
+          }
+        }
+      }
+    },
+    "Tap anywhere to begin" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タップして開始"
           }
         }
       }

--- a/Pastura/Pastura/Views/DesignTokens.swift
+++ b/Pastura/Pastura/Views/DesignTokens.swift
@@ -309,13 +309,13 @@ enum Typography {
     lineHeight: 1.2, letterSpacingEm: 0,
     isItalic: false, textCase: nil)
 
-  /// meta/eta — 残り約4分 (mono medium)
+  /// meta/eta — "About 4 min left" (mono medium)
   static let metaEta = PasturaTextStyle(
     size: 10, weight: .medium, design: .monospaced,
     lineHeight: 1.3, letterSpacingEm: 0,
     isItalic: false, textCase: nil)
 
-  /// status/complete — 準備ができました
+  /// status/complete — "Setup complete"
   static let statusComplete = PasturaTextStyle(
     size: 16, weight: .medium, design: .default,
     lineHeight: 1.4, letterSpacingEm: 0.22,

--- a/Pastura/Pastura/Views/ModelDownload/DLCompleteOverlay.swift
+++ b/Pastura/Pastura/Views/ModelDownload/DLCompleteOverlay.swift
@@ -3,8 +3,8 @@ import SwiftUI
 /// Fullscreen overlay shown while `ReplayViewModel.state == .transitioning`.
 ///
 /// Per `demo-replay-ui.md` §DLCompleteOverlay: ultra-thin material
-/// background + pulsing 44 pt dog mark + "準備ができました" +
-/// "tap anywhere to begin". The hint text is now load-bearing — the
+/// background + pulsing 44 pt dog mark + "Setup complete" +
+/// "Tap anywhere to begin". The hint text is now load-bearing — the
 /// overlay waits for a user tap before transitioning to `HomeView` so
 /// the user gets a clear "setup complete" beat instead of waking up on
 /// the home screen mid-task. (Spec §2 decision 6 / 8 originally
@@ -44,10 +44,10 @@ struct DLCompleteOverlay: View {
       VStack(spacing: Spacing.s) {
         DogMark(size: 44)
           .pulsing()
-        Text("準備ができました")
+        Text(String(localized: "Setup complete"))
           .textStyle(Typography.statusComplete)
           .foregroundStyle(Color.mossInk)
-        Text("tap anywhere to begin")
+        Text(String(localized: "Tap anywhere to begin"))
           .textStyle(Typography.statusHint)
           .foregroundStyle(Color.muted)
       }

--- a/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+StateFallbacks.swift
+++ b/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+StateFallbacks.swift
@@ -90,7 +90,7 @@ extension ModelDownloadHostView {
         Spacer()
       }
       .padding()
-      .navigationTitle("Model Setup")
+      .navigationTitle(String(localized: "Model Setup"))
     }
   }
 

--- a/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView.swift
+++ b/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView.swift
@@ -265,27 +265,27 @@ struct ModelDownloadHostView: View {
       }
 
       // Sim-style frosted controlBar (#273): mirrors `SimulationView.controlBar`
-      // shape so users learn the layout before reaching the live simulation.
-      // Pause / Speed / Toggle all interactive — Pause drives
-      // `viewModel.userPause()`/`userResume()`, Speed binds to
-      // `viewModel.playbackSpeed` (#290).
+      // shape so users learn the layout before the live simulation. Pause /
+      // Speed / Toggle interactive — Pause → `viewModel.userPause()`/
+      // `userResume()`, Speed → `viewModel.playbackSpeed` (#290).
       controlBar(viewModel: viewModel)
     }
     .background(Color.screenBackground.ignoresSafeArea())
-    // PromoCard lives in the bottom safe area instead of a ZStack overlay:
-    // that way the ScrollView's viewport shrinks to exclude the card's
-    // footprint, so `scrollTo(lastId, anchor: .bottom)` lands the newest
-    // message at the visible bottom — above the card, not hidden beneath
-    // it. The previous `.padding(.bottom, 160)` approach reserved scroll
-    // content space but did NOT shrink the viewport, so the anchor still
-    // slid the last message under the overlay.
-    .safeAreaInset(edge: .bottom, spacing: Spacing.l) {
-      PromoCard(
-        modelState: currentState,
-        replayHadStarted: replayHadStarted,
-        onRetry: { modelManager.startDownload(descriptor: descriptor) },
-        onCancel: triggerCancelConfirmation)
-    }
+    .safeAreaInset(edge: .bottom, spacing: Spacing.l) { promoCardInset }
+  }
+
+  /// PromoCard lives in the bottom safe area (not a ZStack overlay) so the
+  /// ScrollView viewport shrinks to exclude the card's footprint;
+  /// `scrollTo(lastId, anchor: .bottom)` then lands the newest message
+  /// above the card. The earlier `.padding(.bottom, 160)` reserved space
+  /// but didn't shrink the viewport — the anchor slid under the overlay.
+  private var promoCardInset: some View {
+    PromoCard(
+      modelState: currentState,
+      replayHadStarted: replayHadStarted,
+      totalBytes: descriptor.fileSize,
+      onRetry: { modelManager.startDownload(descriptor: descriptor) },
+      onCancel: triggerCancelConfirmation)
   }
 
   // Module-internal so the sibling `+GameHeader.swift` extension can
@@ -358,7 +358,7 @@ struct ModelDownloadHostView: View {
       hasReplayVM: replayVM != nil) {
     case .fireOnComplete:
       // Settings cover: dismiss immediately. The overlay's
-      // "tap anywhere to begin" copy is meaningless here — the user
+      // "Tap anywhere to begin" copy is meaningless here — the user
       // returns to the Settings list, not a fresh app session.
       onComplete?()
     case .fireOnReady(let awaitsTap) where awaitsTap:

--- a/Pastura/Pastura/Views/ModelDownload/PromoCard+Helpers.swift
+++ b/Pastura/Pastura/Views/ModelDownload/PromoCard+Helpers.swift
@@ -47,6 +47,13 @@ extension PromoCard {
 
   /// Slot copy (draft) from `docs/design/design-system.md` §7.
   /// Final wording is gated on the copy pass per spec §2 decision 13.
+  ///
+  /// Intentionally NOT routed through `String(localized:)` — these
+  /// strings are listed under `docs/i18n/leak-detection.md`
+  /// § "Explicitly-deferred items" so the Tier 2 audit recognizes
+  /// them as a documented carve-out, not a wrap leak. When the copy
+  /// pass lands, wrap with English source strings and add ja
+  /// translations in the catalog at the same time.
   static func slotCopy(_ slot: Int) -> String {
     switch slot % 3 {
     case 0: return "AIエージェントが、あなたのiPhoneの中で対話します"
@@ -55,10 +62,13 @@ extension PromoCard {
     }
   }
 
-  /// `残り約N分` when minutes > 0, `まもなく` when <= 0, nil to hide.
+  /// `About N min left` when minutes > 0, `Soon` when <= 0, nil to hide.
+  /// Localized via `Localizable.xcstrings`; ja maps to `残り約 N 分` / `まもなく`.
   static func formatEta(minutes: Int?) -> String? {
     guard let minutes = minutes else { return nil }
-    return minutes <= 0 ? "まもなく" : "残り約\(minutes)分"
+    return minutes <= 0
+      ? String(localized: "Soon")
+      : String(format: String(localized: "About %lld min left"), minutes)
   }
 
   /// Detects the "resume burst" — `URLSession`'s first `didWriteData` callback

--- a/Pastura/Pastura/Views/ModelDownload/PromoCard+Previews.swift
+++ b/Pastura/Pastura/Views/ModelDownload/PromoCard+Previews.swift
@@ -7,6 +7,7 @@ import SwiftUI
   PromoCard(
     modelState: .downloading(progress: 0.35),
     replayHadStarted: true,
+    totalBytes: ModelRegistry.gemma4E2B.fileSize,
     onRetry: {}
   )
   .padding(.vertical, 40)
@@ -17,6 +18,7 @@ import SwiftUI
   PromoCard(
     modelState: .downloading(progress: 0.35),
     replayHadStarted: true,
+    totalBytes: ModelRegistry.gemma4E2B.fileSize,
     onRetry: {},
     onCancel: {}
   )
@@ -28,6 +30,7 @@ import SwiftUI
   PromoCard(
     modelState: .downloading(progress: 0.95),
     replayHadStarted: true,
+    totalBytes: ModelRegistry.gemma4E2B.fileSize,
     onRetry: {}
   )
   .padding(.vertical, 40)
@@ -38,6 +41,7 @@ import SwiftUI
   PromoCard(
     modelState: .error("ネットワーク接続が切れました"),
     replayHadStarted: true,
+    totalBytes: ModelRegistry.gemma4E2B.fileSize,
     onRetry: {}
   )
   .padding(.vertical, 40)
@@ -48,6 +52,7 @@ import SwiftUI
   PromoCard(
     modelState: .error("ネットワーク接続が切れました"),
     replayHadStarted: true,
+    totalBytes: ModelRegistry.gemma4E2B.fileSize,
     onRetry: {},
     onCancel: {}
   )

--- a/Pastura/Pastura/Views/ModelDownload/PromoCard.swift
+++ b/Pastura/Pastura/Views/ModelDownload/PromoCard.swift
@@ -20,6 +20,13 @@ struct PromoCard: View {
 
   let modelState: ModelState
   let replayHadStarted: Bool
+  /// Total file size of the model being downloaded, in bytes. Drives both
+  /// the `downloadedGB = progress * totalGB` calculation and the `/ X.X GB`
+  /// denominator. Sourced from `ModelDescriptor.fileSize` by the host.
+  /// Non-defaulted so production callsites must thread the active
+  /// descriptor — previously the file hardcoded `3.0` GB, which under-
+  /// or over-reported for any non-Gemma model.
+  let totalBytes: Int64
   let onRetry: () -> Void
   /// When set, renders a small `X` button at the trailing edge of the
   /// progress / retry row. When `nil`, no cancel affordance is shown
@@ -29,14 +36,21 @@ struct PromoCard: View {
   init(
     modelState: ModelState,
     replayHadStarted: Bool,
+    totalBytes: Int64,
     onRetry: @escaping () -> Void,
     onCancel: (() -> Void)? = nil
   ) {
     self.modelState = modelState
     self.replayHadStarted = replayHadStarted
+    self.totalBytes = totalBytes
     self.onRetry = onRetry
     self.onCancel = onCancel
   }
+
+  /// Total size in decimal GB (bytes / 1e9), matching the CLAUDE.md
+  /// tech-stack table convention. Decimal not binary because the catalog
+  /// figures are stated as `~2.5–3.1 GB each` (decimal).
+  private var totalGB: Double { Double(totalBytes) / 1_000_000_000 }
 
   @Environment(\.scenePhase) private var scenePhase
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -113,12 +127,12 @@ struct PromoCard: View {
   private func progressView(progress: Double) -> some View {
     let pct = Int(progress * 100)
     let dotsLit = Int((progress * 8).rounded())
-    let downloadedGB = progress * 3.0
+    let downloadedGB = progress * totalGB
     let etaMinutes = computeEtaMinutes(progress: progress)
 
     VStack(alignment: .leading, spacing: 3) {
       HStack(spacing: 6) {
-        Text("DL")
+        Text(String(localized: "DL"))
           .textStyle(Typography.metaLabel)
           .foregroundStyle(Color.metaBaseL3)
 
@@ -144,7 +158,7 @@ struct PromoCard: View {
           .textStyle(Typography.metaValue)
           .foregroundStyle(Color.metaBaseL3.opacity(0.6))
 
-        Text(String(format: "%.1f GB / 3.0 GB", downloadedGB))
+        Text(String(format: String(localized: "%.1f GB / %.1f GB"), downloadedGB, totalGB))
           .textStyle(Typography.metaValue)
           .foregroundStyle(Color.metaBaseL3)
 
@@ -202,7 +216,7 @@ struct PromoCard: View {
   private func retryView(message: String) -> some View {
     HStack(alignment: .center, spacing: Spacing.s) {
       VStack(alignment: .leading, spacing: 2) {
-        Text("ダウンロードが中断しました")
+        Text(String(localized: "Download interrupted"))
           .textStyle(Typography.metaEta)
           .foregroundStyle(Color.metaStrongL3)
         Text(message)
@@ -212,7 +226,7 @@ struct PromoCard: View {
       }
       Spacer(minLength: 0)
       Button(action: onRetry) {
-        Text("リトライ")
+        Text(String(localized: "Retry"))
           .textStyle(Typography.metaLabel)
           .foregroundStyle(Color.white)
           .padding(.horizontal, 10)

--- a/docs/i18n/leak-detection.md
+++ b/docs/i18n/leak-detection.md
@@ -105,10 +105,22 @@ Internally:
 
 Empirically the filters drop ~42% of raw extractions on the current
 codebase (1108 → 647 candidates). The reviewer is expected to triage
-the remainder against the actual call site to decide *intentional Japanese
-marketing copy* (e.g. PromoCard `ダウンロードが中断しました`), *internal log
-strings* (Logger `%public` interpolations), or *real wrap leaks* (e.g.
-`SimulationView.swift:535 loadError = "Scenario not found"`).
+the remainder against the actual call site to decide *intentional
+design-pending copy* (see § "Explicitly-deferred items" below), *internal
+log strings* (Logger `%public` interpolations), or *real wrap leaks*
+(e.g. `SimulationView.swift:535 loadError = "Scenario not found"`).
+
+### Explicitly-deferred items
+
+Audit candidates that are **knowingly** un-wrapped pending a downstream
+gating event. They will keep surfacing in `check_i18n_potential_keys.py`
+output — recognize them as documented carve-outs rather than wrap leaks.
+When the gating event lands, wrap with English source strings and add
+the ja translation in the catalog at the same time.
+
+| Item | Source location | Gating event |
+|------|-----------------|--------------|
+| `slotCopy(_:)` 3 marketing strings | `Pastura/Pastura/Views/ModelDownload/PromoCard+Helpers.swift` | `docs/design/design-system.md` §7 copy pass (spec §2 decision 13) |
 
 ### Self-test
 


### PR DESCRIPTION
## Summary

Bucket 2 of 9 from #340 — Tier 2 i18n leak triage for `Views/ModelDownload/` (bucket 1 was #341 / Views/Simulation). Bundles a multi-model size-display fix because canonicalizing the existing `"%.1f GB / 3.0 GB"` Gemma-only literal into the i18n catalog would have created a 2-PR follow-up.

- **i18n wraps (8 user-facing literals)**: `DLCompleteOverlay` (`Setup complete`, `Tap anywhere to begin`), `ModelDownloadHostView+StateFallbacks` (`Model Setup`), `PromoCard` (`DL`, `%.1f GB / %.1f GB`, `Download interrupted`, `Retry`), `PromoCard+Helpers.formatEta` (`Soon`, `About %lld min left`). All 8 routed through `String(localized:)`; ja translations added in `Localizable.xcstrings` with `state: "translated"` on both en + ja.
- **Multi-model size fix bundled**: `PromoCard` gains a non-defaulted `totalBytes: Int64` init param sourced from `ModelDescriptor.fileSize`. Format becomes `String(format: String(localized: "%.1f GB / %.1f GB"), downloadedGB, totalGB)` with positional `%1$.1f / %2$.1f` form in the catalog. Visible UX change: Qwen 3 4B (`/ 2.5 GB`) and Gemma 4 E2B (`/ 3.1 GB`) now show their actual totals instead of the prior hardcoded `/ 3.0 GB`.
- **`slotCopy(_:)` deferred** per `design-system.md` §7 copy pass (spec §2 decision 13). Documented as "Explicitly-deferred items" in `docs/i18n/leak-detection.md` so future Tier 2 audits recognize the carve-out.
- Doc-comments at `DLCompleteOverlay.swift:6` + `DesignTokens.swift:312`/`:318` updated to reference English source. `ModelDownloadHostView` extracted `promoCardInset` helper to keep `chatStream` body under `function_body_length` and the file at the `file_length` cap (400 lines).

Audit confirms clean drop: `Views/ModelDownload` candidates went from 24 → 15 (the 15 remaining are slotCopy ×3, Logger noise ×6, format-only `%arg%%` ×2, identifiers / fixture names ×4 — all known carve-outs).

Part of #340.

## Test plan

- [x] CI: `localization-coverage` (Tier 3) green
- [x] CI: `swiftlint --strict` green  
- [x] CI: full unit suite (`PasturaTests`) green — locally 1554 tests / 140 suites pass
- [ ] Manual: launch on simulator with locale=ja → Setup complete / Tap anywhere to begin / Model Setup / Download interrupted / Retry / Soon / About N min left all render in Japanese
- [ ] Manual: launch with locale=en → all render in English; PromoCard meta row shows `X.X GB / 3.1 GB` (Gemma) — verify using `defaults write -g AppleLanguages -array en` then relaunch sim
- [ ] Manual (when Qwen multi-model lands in production): PromoCard shows `X.X GB / 2.5 GB` for Qwen — verifies `totalBytes: descriptor.fileSize` plumbing reaches the displayed denominator

## References

- #340 — parent issue (8 buckets remain after this)
- #341 — bucket 1 (Views/Simulation, merged)
- `docs/i18n/leak-detection.md` — three-tier architecture + new "Explicitly-deferred items" subsection
- `.claude/rules/i18n.md` — format-string pattern, multi-arg positional form, en+ja state flip workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)