### PR TITLE
🌐 feat: thought-toggle a11y label + hide SheepAvatar from VO (#340)

### DIFF
--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -1373,6 +1373,16 @@
         }
       }
     },
+    "Hide thought" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "思考を隠す"
+          }
+        }
+      }
+    },
     "Import" : {
       "localizations" : {
         "ja" : {
@@ -2729,6 +2739,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "思考をすべて表示"
+          }
+        }
+      }
+    },
+    "Show thought" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "思考を表示"
           }
         }
       }

--- a/Pastura/Pastura/Views/Components/AgentOutputRow.swift
+++ b/Pastura/Pastura/Views/Components/AgentOutputRow.swift
@@ -451,7 +451,8 @@ struct AgentOutputRow: View {
       // collapse semantic to VoiceOver so the label reads the way
       // a Button would.
       .accessibilityAddTraits(.isButton)
-      .accessibilityLabel(showInnerThought ? "Hide thought" : "Show thought")
+      .accessibilityLabel(
+        Self.thoughtToggleAccessibilityLabel(showInnerThought: showInnerThought))
   }
 
   /// Thought body — pre-measured concat driven by the unified reveal
@@ -472,6 +473,19 @@ struct AgentOutputRow: View {
       .foregroundStyle(Color.muted)
       .thoughtLeftRule()
       .transition(.opacity.combined(with: .move(edge: .top)))
+  }
+
+  // MARK: - Pure helpers (extracted for unit-test reach per ADR-009)
+
+  /// Per-row thought-toggle VoiceOver label. Singular form, intentionally
+  /// distinct from the global toggle's plural "Hide / Show all thoughts"
+  /// (`ThoughtVisibilityToggle.accessibilityLabel(for:)`) so a screen-reader
+  /// user can tell whether the next tap collapses just this row or every
+  /// row on screen.
+  static func thoughtToggleAccessibilityLabel(showInnerThought: Bool) -> String {
+    showInnerThought
+      ? String(localized: "Hide thought")
+      : String(localized: "Show thought")
   }
 
   // MARK: - Derived lengths

--- a/Pastura/Pastura/Views/Components/SheepAvatar.swift
+++ b/Pastura/Pastura/Views/Components/SheepAvatar.swift
@@ -115,7 +115,16 @@ public struct SheepAvatar: View {
         style: StrokeStyle(lineWidth: unit, lineCap: .round))
     }
     .frame(width: size, height: size)
-    .accessibilityLabel(character.accessibilityLabel)
+    // Decorative reinforcement of the adjacent `Text(agent)` in
+    // `AgentOutputRow.body` (see L208–211). `Character.accessibilityLabel`
+    // is the **color-slot canonical name** ("Alice"/"Bob"/"Carol"/"Dave"),
+    // allocated by `forAgent(name:position:)` from `position` first — so
+    // for a user-authored agent named `"Tomoko"` at position 0 it would
+    // announce "Alice. Tomoko." next to `Text(agent)`. Hiding the avatar
+    // from VoiceOver lets the agent's actual display name carry identity
+    // without the color-slot dissonance, and avoids committing the
+    // canonical names as translatable personal names in the i18n catalog.
+    .accessibilityHidden(true)
   }
 
   private struct WoolCircle {
@@ -218,6 +227,13 @@ extension SheepAvatar.Character {
     }
   }
 
+  /// Color-slot canonical name. Preview-only at runtime: the chat-row
+  /// `SheepAvatar` carries `.accessibilityHidden(true)` so VoiceOver
+  /// announces only `Text(agent)`. The previews below still consume this
+  /// as a `ForEach` identity key and visible label, so the getter stays.
+  /// Treat as a stable identifier rather than a user-facing string — i18n
+  /// wrap deferred per `docs/i18n/leak-detection.md` § "Explicitly-deferred
+  /// items".
   var accessibilityLabel: String {
     switch self {
     case .alice: return "Alice"

--- a/Pastura/PasturaTests/Views/AgentOutputRowContractTests.swift
+++ b/Pastura/PasturaTests/Views/AgentOutputRowContractTests.swift
@@ -269,4 +269,28 @@ struct AgentOutputRowContractTests {
   // file `AgentOutputRowContractTests+ThoughtSectionGate.swift` per
   // `.claude/rules/testing.md` § "Splitting a Suite Across Files" (this
   // file crossed the 400-line `file_length` cap when the gate landed).
+
+  // MARK: - thoughtToggleAccessibilityLabel(showInnerThought:)
+
+  @Test func thoughtToggleAccessibilityLabelOnStateContainsHide() {
+    let label = AgentOutputRow.thoughtToggleAccessibilityLabel(
+      showInnerThought: true)
+    #expect(!label.isEmpty)
+    #expect(label.contains("Hide"))
+  }
+
+  @Test func thoughtToggleAccessibilityLabelOffStateContainsShow() {
+    let label = AgentOutputRow.thoughtToggleAccessibilityLabel(
+      showInnerThought: false)
+    #expect(!label.isEmpty)
+    #expect(label.contains("Show"))
+  }
+
+  @Test func thoughtToggleAccessibilityLabelsForOnAndOffDiffer() {
+    let onLabel = AgentOutputRow.thoughtToggleAccessibilityLabel(
+      showInnerThought: true)
+    let offLabel = AgentOutputRow.thoughtToggleAccessibilityLabel(
+      showInnerThought: false)
+    #expect(onLabel != offLabel)
+  }
 }

--- a/docs/i18n/leak-detection.md
+++ b/docs/i18n/leak-detection.md
@@ -121,6 +121,7 @@ the ja translation in the catalog at the same time.
 | Item | Source location | Gating event |
 |------|-----------------|--------------|
 | `slotCopy(_:)` 3 marketing strings | `Pastura/Pastura/Views/ModelDownload/PromoCard+Helpers.swift` | `docs/design/design-system.md` §7 copy pass (spec §2 decision 13) |
+| `Character.accessibilityLabel` 4 cases (`Alice`/`Bob`/`Carol`/`Dave`) | `Pastura/Pastura/Views/Components/SheepAvatar.swift` | Preview-only after #340 bucket-3 PR — runtime application carries `.accessibilityHidden(true)` because the names are color-slot identifiers (allocated by `forAgent(position:)`), not agent display names. Re-evaluate only if a future design binds avatars to real translated identities. |
 
 ### Self-test
 


### PR DESCRIPTION
## Summary

Slice 3 of 9 from #340 (i18n Tier 2 leak triage for `Views/Components/`).
Of 19 audit candidates, 1 was a real wrap leak and 1 was an a11y design
issue surfaced during triage; the remaining 17 are documented false
positives (Logger / `#Preview` / format-only / already-wrapped / test
hooks).

**Code wraps + a11y fix:**

- `AgentOutputRow.swift` — extract static helper
  `thoughtToggleAccessibilityLabel(showInnerThought:)` wrapping `"Hide
  thought"` / `"Show thought"` in `String(localized:)`. Mirrors the
  shape of `ThoughtVisibilityToggle.accessibilityLabel(for:)`. Singular
  form intentionally distinct from the plural global toggle so a VO
  user can tell whether the next tap collapses just this row or every
  row.
- `SheepAvatar.swift` — replace runtime
  `.accessibilityLabel(character.accessibilityLabel)` with
  `.accessibilityHidden(true)`. `Character.accessibilityLabel` returns
  the color-slot canonical name (`"Alice"`/`"Bob"`/`"Carol"`/`"Dave"`),
  allocated by `forAgent(name:position:)` from `position` first — so an
  agent named `Tomoko` at position 0 would have VoiceOver announce
  `"Alice. Tomoko."`. The adjacent `Text(agent)` in
  `AgentOutputRow.body` already carries identity; the avatar is
  decorative reinforcement. Doc-comment on the getter updated to mark
  it Preview-only at runtime (it stays as `#Preview` ForEach id and
  visible Text).

**Catalog:** 2 new keys (`Hide thought` / `Show thought`) with `ja`
blocks at `state: "translated"` (`思考を隠す` / `思考を表示`). Auto-sync landed
empty-body shapes per memory `feedback_xcstrings_autosync_empty_body.md`;
patched to canonical en+ja form via Edit (no `json.dumps` round-trip).

**Tests:** 3 contract tests in `AgentOutputRowContractTests` mirroring
`ThoughtVisibilityToggleContractTests` (partial-match per i18n testing
convention). Suite carries `@Suite(.timeLimit(.minutes(1)))` at L42.

**Doc:** `docs/i18n/leak-detection.md` § "Explicitly-deferred items"
gains a row for `SheepAvatar.Character.accessibilityLabel` — re-evaluate
only if a future design binds avatars to real translated identities.

## Triage — false positives skipped

| Line | Reason |
|---|---|
| `AgentOutputRow.swift:258, 286` | `logDebugLifecycle(event: "onAppear"/"onDisappear")` Logger arg |
| `AgentOutputRow+Diagnostic.swift:23, 34` | `#if DEBUG` Logger interpolation |
| `DogMark.swift:165, 169, 175, 184` | `#Preview` section labels |
| `SheepAvatar.swift:239–242` (was 223–226 pre-edit) | `Character.accessibilityLabel` cases; Preview-only after this PR |
| `SheepAvatar.swift:249, 264` | `#Preview` section labels |
| `ThoughtVisibilityToggle.swift:58` | `#Preview` debug Text |
| `GameHeader.swift:110` | `"%.1f tok/s"` intentionally non-localized (technical unit) |
| `GameHeader.swift:178` | already wrapped via `String(localized: ", ")` concat |
| `PasturaBackButton.swift:66` | `accessibilityIdentifier` test hook |

## Test plan

- [x] `python3 scripts/check_localization_coverage.py` — 345 keys, all `ja` translated
- [x] `python3 scripts/check_i18n_potential_keys.py | grep Views/Components` — only documented false positives remain
- [x] `rg '\.accessibilityLabel\(' Pastura/Pastura/Views/Components/` — SheepAvatar runtime label is gone
- [x] `swiftlint lint --quiet --strict` — clean
- [x] `scripts/xcodebuild.sh test -only-testing PasturaTests/AgentOutputRowContractTests` — 21 tests pass (incl. 3 new)
- [x] `scripts/xcodebuild.sh test` — full unit + UI suite passes
- [ ] **Manual VoiceOver QA**: on AgentOutputRow with a mixed-name scenario (e.g., one agent named `Tomoko` at position 0), confirm VO announces only `"Tomoko"`, NOT `"Alice. Tomoko."` — avatar should be skipped during VO traversal

Part of #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)