### PR TITLE
✨ feat(pages): LP fade-up entrance + scroll reveal animations

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -6,6 +6,10 @@
 #   - `pages/css/lp.css`                   → `https://tyabu12.github.io/pastura/css/lp.css`
 #   - `pages/css/page.css`                 → `https://tyabu12.github.io/pastura/css/page.css`
 #     (Shared design tokens + LP layout + prose styling for legal/support)
+#   - `pages/css/anim.css`                 → `https://tyabu12.github.io/pastura/css/anim.css`
+#     (Fade-up animation stylesheet — hero entrance + scroll reveal — see #377)
+#   - `pages/js/anim.js`                   → `https://tyabu12.github.io/pastura/js/anim.js`
+#     (Vanilla-JS runtime that toggles `.is-entered` / `.is-in` on the LP — see #377)
 #   - `pages/img/app-icon.png`             → `https://tyabu12.github.io/pastura/img/app-icon.png`
 #   - `pages/img/favicon-64.png`           → `https://tyabu12.github.io/pastura/img/favicon-64.png`
 #     (Brand mark + favicon, sourced from the iOS app icon)
@@ -92,11 +96,13 @@ jobs:
         # add a new file under `pages/`, add a matching line here — silent
         # drift on this step means the new asset 404s on the deployed site.
         run: |
-          mkdir -p _site/support _site/legal/privacy-policy _site/ja/support _site/ja/legal/privacy-policy _site/css _site/img
+          mkdir -p _site/support _site/legal/privacy-policy _site/ja/support _site/ja/legal/privacy-policy _site/css _site/js _site/img
           cp pages/index.html _site/index.html
           cp pages/css/base.css _site/css/base.css
           cp pages/css/lp.css _site/css/lp.css
           cp pages/css/page.css _site/css/page.css
+          cp pages/css/anim.css _site/css/anim.css
+          cp pages/js/anim.js _site/js/anim.js
           cp pages/img/app-icon.png _site/img/app-icon.png
           cp pages/img/favicon-64.png _site/img/favicon-64.png
           cp pages/img/app-store-badge-en.svg _site/img/app-store-badge-en.svg
@@ -130,6 +136,8 @@ jobs:
             "https://tyabu12.github.io/pastura/css/base.css" \
             "https://tyabu12.github.io/pastura/css/lp.css" \
             "https://tyabu12.github.io/pastura/css/page.css" \
+            "https://tyabu12.github.io/pastura/css/anim.css" \
+            "https://tyabu12.github.io/pastura/js/anim.js" \
             "https://tyabu12.github.io/pastura/img/app-icon.png" \
             "https://tyabu12.github.io/pastura/img/favicon-64.png" \
             "https://tyabu12.github.io/pastura/img/app-store-badge-en.svg" \

--- a/pages/css/anim.css
+++ b/pages/css/anim.css
@@ -1,0 +1,86 @@
+/* Pastura LP — Fade-up animation layer (final).
+   One variant only: gentle 14px translate + opacity fade, ease-out,
+   tightened to NN/g-friendly durations (≈460ms) with a small 60ms
+   stagger. Applied to both the hero entrance (on load) and to
+   every section as it enters the viewport. Respects
+   prefers-reduced-motion. No runtime toggle — this is the final pick. */
+
+:root{
+  --anim-ease: cubic-bezier(.22,.61,.36,1); /* ease-out */
+  --anim-dur: 460ms;
+  --anim-step: 60ms;
+}
+
+/* ===== HERO entrance ===== */
+.anim-host .hero-fx{
+  opacity: 0;
+  transform: translateY(14px);
+  will-change: opacity, transform;
+  transition:
+    opacity var(--anim-dur) var(--anim-ease),
+    transform var(--anim-dur) var(--anim-ease);
+  transition-delay: calc(var(--i, 0) * var(--anim-step));
+}
+.anim-host.is-entered .hero-fx{
+  opacity: 1;
+  transform: none;
+}
+
+/* Bubbles inside the hero figure use their own stagger so the
+   conversation reads top-to-bottom even though it shares the figure's
+   reveal moment. ~120ms between bubbles after a short base delay. */
+.anim-host .hero-bubble-row{
+  opacity: 0;
+  transform: translateY(10px);
+  transition:
+    opacity 440ms var(--anim-ease),
+    transform 480ms var(--anim-ease);
+  transition-delay: calc(var(--bi, 0) * 120ms + 260ms);
+}
+.anim-host.is-entered .hero-bubble-row{
+  opacity: 1;
+  transform: none;
+}
+
+/* ===== SCROLL reveal ===== */
+.anim-host .reveal-fx{
+  opacity: 0;
+  transform: translateY(14px);
+  will-change: opacity, transform;
+  transition:
+    opacity var(--anim-dur) var(--anim-ease),
+    transform var(--anim-dur) var(--anim-ease);
+  transition-delay: calc(var(--i, 0) * var(--anim-step));
+}
+.anim-host .reveal-fx.is-in{
+  opacity: 1;
+  transform: none;
+}
+
+/* Inner children inside a section also fade up in turn — gives the
+   capability grid and FAQ a quiet rhythm without re-animating per row.
+   Stagger kicks in slightly after the parent settles. */
+.anim-host .reveal-fx .reveal-child{
+  opacity: 0;
+  transform: translateY(10px);
+  transition:
+    opacity 440ms var(--anim-ease),
+    transform 480ms var(--anim-ease);
+  transition-delay: calc(var(--i, 0) * 80ms + 180ms);
+}
+.anim-host .reveal-fx.is-in .reveal-child{
+  opacity: 1;
+  transform: none;
+}
+
+/* ===== Reduced motion ===== */
+@media (prefers-reduced-motion: reduce){
+  .anim-host .hero-fx,
+  .anim-host .reveal-fx,
+  .anim-host .reveal-fx .reveal-child,
+  .anim-host .hero-bubble-row{
+    opacity: 1 !important;
+    transform: none !important;
+    transition: none !important;
+  }
+}

--- a/pages/index.html
+++ b/pages/index.html
@@ -37,6 +37,26 @@
 
   <link rel="stylesheet" href="css/base.css">
   <link rel="stylesheet" href="css/lp.css">
+  <!-- anim.css MUST load last so its `opacity:0; transform: translateY(...)`
+       baselines override any cascade above. The runtime in js/anim.js toggles
+       .is-entered / .is-in to play the fade-up. -->
+  <link rel="stylesheet" href="css/anim.css">
+  <script src="js/anim.js" defer></script>
+  <noscript>
+    <!-- JS-disabled visitors would otherwise sit at opacity:0 forever
+         (anim.css's baseline). Reset to the final state with explicit
+         per-selector overrides so the cascade specificity matches
+         anim.css's @media (prefers-reduced-motion: reduce) block. -->
+    <style>
+      .anim-host .hero-fx,
+      .anim-host .reveal-fx,
+      .anim-host .reveal-fx .reveal-child,
+      .anim-host .hero-bubble-row {
+        opacity: 1 !important;
+        transform: none !important;
+      }
+    </style>
+  </noscript>
 
   <script type="application/ld+json">
   {
@@ -50,7 +70,7 @@
   }
   </script>
 </head>
-<body>
+<body class="anim-host">
   <a class="skip-link" href="#main">Skip to content</a>
 
   <header role="banner" class="lp-header">
@@ -81,9 +101,9 @@
                The JA mirror at /ja/ uses 「AI観測」 — a stargazing portmanteau coined
                for the JA side — to preserve the wordplay. Both Hero h1s are
                hand-crafted per language; do not machine-translate either. -->
-          <h1 id="hero-h" class="display">AIgazing.<br>Like stargazing,<br>but for local LLMs.</h1>
-          <p class="lead">Pastura is a closed pasture for AI agents on your device. Watch as the agents act out the scenarios you&rsquo;ve written.</p>
-          <div class="badges">
+          <h1 id="hero-h" class="display hero-fx" style="--i: 0">AIgazing.<br>Like stargazing,<br>but for local LLMs.</h1>
+          <p class="lead hero-fx" style="--i: 1">Pastura is a closed pasture for AI agents on your device. Watch as the agents act out the scenarios you&rsquo;ve written.</p>
+          <div class="badges hero-fx" style="--i: 2">
             <button type="button" aria-disabled="true"
                     class="appstore-cta"
                     aria-label="Pastura on the App Store — coming soon">
@@ -94,7 +114,7 @@
           </div>
         </div>
 
-        <figure class="lp-hero-figure">
+        <figure class="lp-hero-figure hero-fx" style="--i: 3">
           <figcaption class="lp-hero-figure-head">
             <span class="sr-only">Sample run: </span>
             <span class="leaf" aria-hidden="true"></span>
@@ -102,7 +122,7 @@
             <span class="live" aria-hidden="true"><span class="live-dot"></span>SIMULATING</span>
           </figcaption>
 
-          <div class="bubble-row">
+          <div class="bubble-row hero-bubble-row" style="--bi: 0">
             <svg class="sheep" data-tone="alice" viewBox="0 0 28 28" aria-hidden="true" focusable="false">
               <circle class="wool" cx="14" cy="15" r="8"/>
               <circle class="wool" cx="9"  cy="13" r="3.2"/>
@@ -132,7 +152,7 @@
             </div>
           </div>
 
-          <div class="bubble-row">
+          <div class="bubble-row hero-bubble-row" style="--bi: 1">
             <svg class="sheep" data-tone="bob" viewBox="0 0 28 28" aria-hidden="true" focusable="false">
               <circle class="wool" cx="14" cy="15" r="8"/>
               <circle class="wool" cx="9"  cy="13" r="3.2"/>
@@ -162,7 +182,7 @@
             </div>
           </div>
 
-          <div class="bubble-row">
+          <div class="bubble-row hero-bubble-row" style="--bi: 2">
             <svg class="sheep" data-tone="dave" viewBox="0 0 28 28" aria-hidden="true" focusable="false">
               <circle class="wool" cx="14" cy="15" r="8"/>
               <circle class="wool" cx="9"  cy="13" r="3.2"/>
@@ -197,7 +217,7 @@
     </section>
 
     <!-- ===== What is Pastura ===== -->
-    <section class="lp-section alt alt-both compact" aria-labelledby="what-h">
+    <section class="lp-section alt alt-both compact reveal-fx" aria-labelledby="what-h">
       <div class="lp-content">
         <p class="eyebrow section-eyebrow">What is Pastura</p>
         <h2 id="what-h" class="display-sm what-h">
@@ -212,14 +232,14 @@
     </section>
 
     <!-- ===== The observation journey ===== -->
-    <section id="usage" class="lp-section" aria-labelledby="journey-h">
+    <section id="usage" class="lp-section reveal-fx" aria-labelledby="journey-h">
       <div class="lp-content">
         <p class="eyebrow section-eyebrow">Usage</p>
         <h2 id="journey-h" class="section-title">
           Three small acts. One quiet afternoon.
         </h2>
 
-        <div class="lp-journey-act">
+        <div class="lp-journey-act reveal-child" style="--i: 0">
           <div class="num" aria-hidden="true">01</div>
           <div>
             <h3><span class="sr-only">Step 01. </span>Choose a model. Wait once.</h3>
@@ -252,7 +272,7 @@
           </div>
         </div>
 
-        <div class="lp-journey-act">
+        <div class="lp-journey-act reveal-child" style="--i: 1">
           <div class="num" aria-hidden="true">02</div>
           <div>
             <h3><span class="sr-only">Step 02. </span>Pick or write the scenario.</h3>
@@ -298,7 +318,7 @@
           </div>
         </div>
 
-        <div class="lp-journey-act">
+        <div class="lp-journey-act reveal-child" style="--i: 2">
           <div class="num" aria-hidden="true">03</div>
           <div>
             <h3><span class="sr-only">Step 03. </span>Step back. Observe.</h3>
@@ -378,14 +398,14 @@
     <!-- Features are intentionally 5 items. Background execution
          (Phase 2 #84) is omitted from the public LP per the design
          handoff — confirm with the design owner before re-adding. -->
-    <section id="features" class="lp-section alt" aria-labelledby="cap-h">
+    <section id="features" class="lp-section alt reveal-fx" aria-labelledby="cap-h">
       <div class="lp-content">
         <p class="eyebrow section-eyebrow">Features</p>
         <h2 id="cap-h" class="section-title">
           What it does, in plain terms.
         </h2>
         <ul class="lp-cap-grid">
-          <li class="cap-item">
+          <li class="cap-item reveal-child" style="--i: 0">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" class="cap-glyph" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
               <rect x="4" y="3" width="16" height="18" rx="1.5"/>
               <path d="M8 8h8M8 12h8M8 16h5"/>
@@ -394,7 +414,7 @@
             <p class="cap-lead">Write the world before pressing play.</p>
             <p>Define personas, phases, and win conditions in a form. Or toggle to YAML for direct control. Scenarios are re-runnable like code.</p>
           </li>
-          <li class="cap-item">
+          <li class="cap-item reveal-child" style="--i: 1">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" class="cap-glyph" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
               <path d="M5 8h11l-3-3M19 16H8l3 3"/>
             </svg>
@@ -402,7 +422,7 @@
             <p class="cap-lead">Local models, your choice.</p>
             <p>Ships with Gemma 4 E2B and Qwen 3 4B today, around 3 GB each. More models on the way. Pick one, switch any time. All run on-device, no servers between you and the inference.</p>
           </li>
-          <li class="cap-item">
+          <li class="cap-item reveal-child" style="--i: 2">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" class="cap-glyph" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
               <circle cx="6" cy="12" r="2.4"/>
               <circle cx="18" cy="6" r="2.4"/>
@@ -413,7 +433,7 @@
             <p class="cap-lead">Browse what others wrote.</p>
             <p>A curated gallery of community scenarios. Preview, import in one tap, replay on your chosen model. Official picks for now; community submissions land in a later phase.</p>
           </li>
-          <li class="cap-item">
+          <li class="cap-item reveal-child" style="--i: 3">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" class="cap-glyph" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
               <path d="M5 12v7c0 .5.5 1 1 1h12c.5 0 1-.5 1-1v-7"/>
               <path d="M12 3v12"/>
@@ -423,7 +443,7 @@
             <p class="cap-lead">Take the conversation with you.</p>
             <p>Export observation logs in Markdown. Paste into a notebook, commit to a repo, share as a gist. The transcript is yours to keep, paste, or share.</p>
           </li>
-          <li class="cap-item">
+          <li class="cap-item reveal-child" style="--i: 4">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" class="cap-glyph" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
               <path d="M12 3l8 3v6c0 5-4 8-8 9-4-1-8-4-8-9V6z"/>
               <path d="M9 12l2 2 4-4"/>
@@ -437,7 +457,7 @@
     </section>
 
     <!-- ===== Why on-device ===== -->
-    <section class="lp-section" aria-labelledby="why-h">
+    <section class="lp-section reveal-fx" aria-labelledby="why-h">
       <div class="lp-content">
         <p class="eyebrow section-eyebrow">Why on-device</p>
         <h2 id="why-h" class="display-sm why-h">
@@ -465,7 +485,7 @@
          Placed between Why on-device and FAQ so the contemplative
          mode flows alongside the on-device thought rather than
          jumping from FAQ's Q&A list into a meditative coda. -->
-    <section class="lp-section alt alt-both compact" aria-labelledby="picture-h">
+    <section class="lp-section alt alt-both compact reveal-fx" aria-labelledby="picture-h">
       <div class="lp-content">
         <p class="eyebrow section-eyebrow">A bigger picture</p>
         <h2 id="picture-h" class="display-sm">
@@ -481,21 +501,21 @@
     </section>
 
     <!-- ===== FAQ ===== -->
-    <section id="faq" class="lp-section alt" aria-labelledby="faq-h">
+    <section id="faq" class="lp-section alt reveal-fx" aria-labelledby="faq-h">
       <div class="lp-content">
         <p class="eyebrow section-eyebrow">FAQ</p>
         <h2 id="faq-h" class="section-title">
           Common questions, frequently asked.
         </h2>
-        <div class="faq-item">
+        <div class="faq-item reveal-child" style="--i: 0">
           <h3 class="faq-q">Is it free?</h3>
           <p class="faq-a">Yes. No server bill, no subscription.</p>
         </div>
-        <div class="faq-item">
+        <div class="faq-item reveal-child" style="--i: 1">
           <h3 class="faq-q">Why iOS only?</h3>
           <p class="faq-a">iOS for now, due to development bandwidth. Android is on the list.</p>
         </div>
-        <div class="faq-item">
+        <div class="faq-item reveal-child" style="--i: 2">
           <h3 class="faq-q">Want another model supported?</h3>
           <p class="faq-a">Tell us on the <a href="support/">Support page</a>. We can&rsquo;t promise to add every request, but your input shapes what ships next.</p>
         </div>
@@ -504,7 +524,7 @@
 
   </main>
 
-  <footer role="contentinfo" class="lp-footer">
+  <footer role="contentinfo" class="lp-footer reveal-fx">
     <div class="foot-grid">
       <div>
         <a href="./" class="brand">

--- a/pages/ja/index.html
+++ b/pages/ja/index.html
@@ -37,6 +37,26 @@
 
   <link rel="stylesheet" href="../css/base.css">
   <link rel="stylesheet" href="../css/lp.css">
+  <!-- anim.css MUST load last so its `opacity:0; transform: translateY(...)`
+       baselines override any cascade above. The runtime in ../js/anim.js toggles
+       .is-entered / .is-in to play the fade-up. -->
+  <link rel="stylesheet" href="../css/anim.css">
+  <script src="../js/anim.js" defer></script>
+  <noscript>
+    <!-- JS-disabled visitors would otherwise sit at opacity:0 forever
+         (anim.css's baseline). Reset to the final state with explicit
+         per-selector overrides so the cascade specificity matches
+         anim.css's @media (prefers-reduced-motion: reduce) block. -->
+    <style>
+      .anim-host .hero-fx,
+      .anim-host .reveal-fx,
+      .anim-host .reveal-fx .reveal-child,
+      .anim-host .hero-bubble-row {
+        opacity: 1 !important;
+        transform: none !important;
+      }
+    </style>
+  </noscript>
 
   <script type="application/ld+json">
   {
@@ -50,7 +70,7 @@
   }
   </script>
 </head>
-<body>
+<body class="anim-host">
   <a class="skip-link" href="#main">本文へスキップ</a>
 
   <header role="banner" class="lp-header">
@@ -81,9 +101,9 @@
                天体観測のもじりという原語の意図を保つため Hero と Bigger picture の
                2 セクションでのみ使用し、Features / FAQ では具体語に切り替える
                (EN の AIgazing と同じ配置ルール)。 -->
-          <h1 id="hero-h" class="display">AI 観測。<br>天体観測のように、<br>ローカル LLM を眺める。</h1>
-          <p class="lead">Pastura は端末の中で動く、AI エージェントたちの閉じた牧場。<br>あなたの書いたシナリオをエージェント達が演じる。</p>
-          <div class="badges">
+          <h1 id="hero-h" class="display hero-fx" style="--i: 0">AI 観測。<br>天体観測のように、<br>ローカル LLM を眺める。</h1>
+          <p class="lead hero-fx" style="--i: 1">Pastura は端末の中で動く、AI エージェントたちの閉じた牧場。<br>あなたの書いたシナリオをエージェント達が演じる。</p>
+          <div class="badges hero-fx" style="--i: 2">
             <button type="button" aria-disabled="true"
                     class="appstore-cta"
                     aria-label="Pastura を App Store で、近日公開">
@@ -94,7 +114,7 @@
           </div>
         </div>
 
-        <figure class="lp-hero-figure">
+        <figure class="lp-hero-figure hero-fx" style="--i: 3">
           <figcaption class="lp-hero-figure-head">
             <span class="sr-only">サンプル実行：</span>
             <span class="leaf" aria-hidden="true"></span>
@@ -102,7 +122,7 @@
             <span class="live" aria-hidden="true"><span class="live-dot"></span>実行中</span>
           </figcaption>
 
-          <div class="bubble-row">
+          <div class="bubble-row hero-bubble-row" style="--bi: 0">
             <svg class="sheep" data-tone="alice" viewBox="0 0 28 28" aria-hidden="true" focusable="false">
               <circle class="wool" cx="14" cy="15" r="8"/>
               <circle class="wool" cx="9"  cy="13" r="3.2"/>
@@ -132,7 +152,7 @@
             </div>
           </div>
 
-          <div class="bubble-row">
+          <div class="bubble-row hero-bubble-row" style="--bi: 1">
             <svg class="sheep" data-tone="bob" viewBox="0 0 28 28" aria-hidden="true" focusable="false">
               <circle class="wool" cx="14" cy="15" r="8"/>
               <circle class="wool" cx="9"  cy="13" r="3.2"/>
@@ -162,7 +182,7 @@
             </div>
           </div>
 
-          <div class="bubble-row">
+          <div class="bubble-row hero-bubble-row" style="--bi: 2">
             <svg class="sheep" data-tone="dave" viewBox="0 0 28 28" aria-hidden="true" focusable="false">
               <circle class="wool" cx="14" cy="15" r="8"/>
               <circle class="wool" cx="9"  cy="13" r="3.2"/>
@@ -197,7 +217,7 @@
     </section>
 
     <!-- ===== What is Pastura ===== -->
-    <section class="lp-section alt alt-both compact" aria-labelledby="what-h">
+    <section class="lp-section alt alt-both compact reveal-fx" aria-labelledby="what-h">
       <div class="lp-content">
         <p class="eyebrow section-eyebrow">Pastura とは</p>
         <h2 id="what-h" class="display-sm what-h">
@@ -212,7 +232,7 @@
     </section>
 
     <!-- ===== The usage journey ===== -->
-    <section id="usage" class="lp-section" aria-labelledby="journey-h">
+    <section id="usage" class="lp-section reveal-fx" aria-labelledby="journey-h">
       <div class="lp-content">
         <p class="eyebrow section-eyebrow">使い方</p>
         <h2 id="journey-h" class="section-title">
@@ -220,7 +240,7 @@
         </h2>
 
 
-        <div class="lp-journey-act">
+        <div class="lp-journey-act reveal-child" style="--i: 0">
           <div class="num" aria-hidden="true">01</div>
           <div>
             <h3><span class="sr-only">Step 01. </span>LLM のモデルを選び、しばし待つ。</h3>
@@ -256,7 +276,7 @@
           </div>
         </div>
 
-        <div class="lp-journey-act">
+        <div class="lp-journey-act reveal-child" style="--i: 1">
           <div class="num" aria-hidden="true">02</div>
           <div>
             <h3><span class="sr-only">Step 02. </span>シナリオを選ぶか、書く。</h3>
@@ -303,7 +323,7 @@
           </div>
         </div>
 
-        <div class="lp-journey-act">
+        <div class="lp-journey-act reveal-child" style="--i: 2">
           <div class="num" aria-hidden="true">03</div>
           <div>
             <h3><span class="sr-only">Step 03. </span>一歩下がって、エージェントの会話を観察。</h3>
@@ -381,14 +401,14 @@
     <!-- ===== Features ===== -->
     <!-- 5 項目構成は EN 版と同じ。BG 実行 (Phase 2 #84) は public LP から
          意図的に除外（デザイン引き継ぎ準拠）。再追加前にデザインオーナーへ確認。 -->
-    <section id="features" class="lp-section alt" aria-labelledby="cap-h">
+    <section id="features" class="lp-section alt reveal-fx" aria-labelledby="cap-h">
       <div class="lp-content">
         <p class="eyebrow section-eyebrow">機能</p>
         <h2 id="cap-h" class="section-title">
           Pastura の特徴
         </h2>
         <ul class="lp-cap-grid">
-          <li class="cap-item">
+          <li class="cap-item reveal-child" style="--i: 0">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" class="cap-glyph" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
               <rect x="4" y="3" width="16" height="18" rx="1.5"/>
               <path d="M8 8h8M8 12h8M8 16h5"/>
@@ -397,7 +417,7 @@
             <p class="cap-lead">推論する前に、世界を書く。</p>
             <p>ペルソナ、フェーズ、勝利条件をフォームで定義。YAMLで直接編集もできる。コードのように何度でも再実行できる。</p>
           </li>
-          <li class="cap-item">
+          <li class="cap-item reveal-child" style="--i: 1">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" class="cap-glyph" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
               <path d="M5 8h11l-3-3M19 16H8l3 3"/>
             </svg>
@@ -405,7 +425,7 @@
             <p class="cap-lead">ローカルモデルを選ぼう。</p>
             <p>現在は Gemma 4 E2B と Qwen 3 4B をサポート。それぞれ約 3 GB。他のモデルも準備中。好きなモデルを選んで、いつでも切り替えられる。サーバー不要で、すべて端末内で動く。</p>
           </li>
-          <li class="cap-item">
+          <li class="cap-item reveal-child" style="--i: 2">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" class="cap-glyph" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
               <circle cx="6" cy="12" r="2.4"/>
               <circle cx="18" cy="6" r="2.4"/>
@@ -416,7 +436,7 @@
             <p class="cap-lead">ほかの人が書いたものを、覗く。</p>
             <p>コミュニティシナリオの厳選ギャラリー。プレビューして、ワンタップでインポート、選んだモデルで再生できる。今はオフィシャルなシナリオのみ。共有シナリオへの投稿機能は将来対応予定。</p>
           </li>
-          <li class="cap-item">
+          <li class="cap-item reveal-child" style="--i: 3">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" class="cap-glyph" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
               <path d="M5 12v7c0 .5.5 1 1 1h12c.5 0 1-.5 1-1v-7"/>
               <path d="M12 3v12"/>
@@ -426,7 +446,7 @@
             <p class="cap-lead">会話を持ち出し。</p>
             <p>観察ログを Markdown でエクスポート。ノートブックに貼る、リポジトリにコミットする、gist で共有する。記録はあなたの自由に使って。</p>
           </li>
-          <li class="cap-item">
+          <li class="cap-item reveal-child" style="--i: 4">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" class="cap-glyph" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
               <path d="M12 3l8 3v6c0 5-4 8-8 9-4-1-8-4-8-9V6z"/>
               <path d="M9 12l2 2 4-4"/>
@@ -440,7 +460,7 @@
     </section>
 
     <!-- ===== Why on-device ===== -->
-    <section class="lp-section" aria-labelledby="why-h">
+    <section class="lp-section reveal-fx" aria-labelledby="why-h">
       <div class="lp-content">
         <p class="eyebrow section-eyebrow">なぜローカル処理か</p>
         <h2 id="why-h" class="display-sm why-h">
@@ -467,7 +487,7 @@
          思索」のサンドイッチ構造を可視化する。FAQ の Q&A から瞑想的な
          コーダへ飛ぶより、Why on-device の思索的流れに繋がるよう、
          Why on-device と FAQ のあいだに配置。 -->
-    <section class="lp-section alt alt-both compact" aria-labelledby="picture-h">
+    <section class="lp-section alt alt-both compact reveal-fx" aria-labelledby="picture-h">
       <div class="lp-content">
         <p class="eyebrow section-eyebrow">より大きな視野で</p>
         <h2 id="picture-h" class="display-sm">
@@ -483,21 +503,21 @@
     </section>
 
     <!-- ===== FAQ ===== -->
-    <section id="faq" class="lp-section alt" aria-labelledby="faq-h">
+    <section id="faq" class="lp-section alt reveal-fx" aria-labelledby="faq-h">
       <div class="lp-content">
         <p class="eyebrow section-eyebrow">FAQ</p>
         <h2 id="faq-h" class="section-title">
           みんな気になる、よくある質問。
         </h2>
-        <div class="faq-item">
+        <div class="faq-item reveal-child" style="--i: 0">
           <h3 class="faq-q">無料ですか？</h3>
           <p class="faq-a">はい。サーバー料金もサブスクリプションもありません。</p>
         </div>
-        <div class="faq-item">
+        <div class="faq-item reveal-child" style="--i: 1">
           <h3 class="faq-q">なぜ iOS だけなんですか？</h3>
           <p class="faq-a">開発の都合上、今のところ iOS のみです。Android もいずれ対応予定です。</p>
         </div>
-        <div class="faq-item">
+        <div class="faq-item reveal-child" style="--i: 2">
           <h3 class="faq-q">ほかの LLM モデルの追加はできますか？</h3>
           <p class="faq-a"><a href="support/">サポートページ</a>で要望を出してください。必ず対応するとは約束できませんが、ご意見は参考にします。</p>
         </div>
@@ -506,7 +526,7 @@
 
   </main>
 
-  <footer role="contentinfo" class="lp-footer">
+  <footer role="contentinfo" class="lp-footer reveal-fx">
     <div class="foot-grid">
       <div>
         <a href="./" class="brand">

--- a/pages/js/anim.js
+++ b/pages/js/anim.js
@@ -1,0 +1,106 @@
+/* Pastura LP — fade-up animation runtime.
+   Vanilla port of handoff_animations/anim-app.reference.jsx. Drives:
+   • .hero-fx entrance on page load via .is-entered on the host
+   • .reveal-fx scroll reveal via IntersectionObserver → .is-in
+   Honours prefers-reduced-motion (CSS handles the reset; JS skips
+   the observer wiring so the final state shows immediately).
+
+   Defensive fallbacks layered for static-page robustness:
+   • Missing IntersectionObserver → reveal everything immediately.
+   • Stalled script execution → setTimeout safety net (1200ms) so a
+     hiccupped CDN can't strand visitors at opacity:0.
+   The CSS keeps elements at opacity:0 until JS toggles classes, so
+   every path that returns without revealing must call revealAll(). */
+
+(function () {
+  "use strict";
+
+  function ready(fn) {
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", fn, { once: true });
+    } else {
+      fn();
+    }
+  }
+
+  ready(function () {
+    var host = document.querySelector(".anim-host");
+    if (!host) return;
+
+    var revealed = false;
+    function revealAll() {
+      if (revealed) return;
+      revealed = true;
+      host.classList.add("is-entered");
+      var targets = host.querySelectorAll(".reveal-fx");
+      for (var i = 0; i < targets.length; i++) {
+        targets[i].classList.add("is-in");
+      }
+    }
+
+    // 1200ms safety net — if anything below throws or the script
+    // never reaches the IO wiring, force the final state so the
+    // page is at least readable.
+    var safetyTimer = setTimeout(revealAll, 1200);
+
+    var prm =
+      window.matchMedia &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    if (prm) {
+      clearTimeout(safetyTimer);
+      revealAll();
+      return;
+    }
+
+    // Force a frame so the initial (opacity:0) state paints before
+    // .is-entered flips it on — otherwise the transition can miss.
+    requestAnimationFrame(function () {
+      requestAnimationFrame(function () {
+        host.classList.add("is-entered");
+      });
+    });
+
+    var targets = host.querySelectorAll(".reveal-fx");
+
+    if (!("IntersectionObserver" in window)) {
+      // Old browser — graceful degrade: show everything immediately,
+      // skip the entrance transition.
+      clearTimeout(safetyTimer);
+      for (var j = 0; j < targets.length; j++) {
+        targets[j].classList.add("is-in");
+      }
+      return;
+    }
+
+    var io = new IntersectionObserver(
+      function (entries) {
+        for (var k = 0; k < entries.length; k++) {
+          if (entries[k].isIntersecting) {
+            entries[k].target.classList.add("is-in");
+            io.unobserve(entries[k].target);
+          }
+        }
+      },
+      { rootMargin: "0px 0px -8% 0px", threshold: 0.06 }
+    );
+
+    // Anything already on screen at mount → reveal without waiting.
+    // rootMargin: "0px 0px -8% 0px" biases the observer against
+    // already-visible content, so above-the-fold sections must take
+    // the immediate path or they never fire.
+    var viewportH = window.innerHeight;
+    for (var m = 0; m < targets.length; m++) {
+      var rect = targets[m].getBoundingClientRect();
+      if (rect.top < viewportH * 0.92 && rect.bottom > 0) {
+        targets[m].classList.add("is-in");
+      } else {
+        io.observe(targets[m]);
+      }
+    }
+
+    // We made it through the wiring successfully — cancel the safety
+    // net so we don't double-add classes (no-op but spares the cycles).
+    clearTimeout(safetyTimer);
+  });
+})();


### PR DESCRIPTION
## Summary

Introduces fade-up entrance + scroll-reveal animations on the public landing page (EN + JA mirror), wiring up the user-supplied motion handoff (`handoff_animations/{anim.css,anim-app.reference.jsx,PROMPT.md,README.md}`). LP copy is unchanged. Motion-spec values (durations, easings, staggers, thresholds) are frozen per the handoff PROMPT — no improvisation.

**What the page does now:**
- Hero items (h1 / lead / badges / figure) fade up in reading order on load (~600ms total).
- The 3 hero conversation bubbles cascade top-to-bottom inside the figure (120ms stagger after a 260ms base delay).
- Every section below the hero (and the footer) reveals via `IntersectionObserver` as it crosses ~92% of the viewport, one-shot.
- Repeated children inside reveal sections (3 journey-acts, 5 cap-items, 3 faq-items) cascade with an 80ms stagger after the parent settles.
- Reduced-motion users get the final state immediately, no transitions.
- JS-disabled users get the final state via `<noscript>` reset.

## Implementation notes

5 focused commits:
1. `pages/css/anim.css` — verbatim drop-in from the handoff (86 lines).
2. `pages/js/anim.js` — vanilla port of the reference React effect (106 lines). Includes the handoff-prescribed double-rAF, the load-mount immediate-reveal branch for above-the-fold sections (critic Axis 2 — without this, `rootMargin: "0px 0px -8% 0px"` biases against already-visible content), an `IntersectionObserver` feature-detect fallback for old browsers, and a 1200ms `setTimeout` safety net so a stalled script load can't strand visitors at `opacity:0`.
3. `pages/index.html` — class/style additions only: `anim-host` on body, `hero-fx` + `--i 0..3` on hero items, `hero-bubble-row` + `--bi 0..2` on the 3 hero bubbles, `reveal-fx` on 6 sections + footer, `reveal-child` + `--i idx` on journey-acts/cap-items/faq-items. `anim.css` loads AFTER `lp.css` so its `opacity:0` baseline wins the cascade. Includes a `<noscript>` reset block covering all 4 affected selector families.
4. `pages/ja/index.html` — mechanical mirror of (3). EN and JA are structurally parallel at handoff time (verified by critic Axis 4 and by the reviewer's `--i`/`--bi` diff check — empty output).
5. `.github/workflows/deploy-pages.yml` — 4 sites updated per the workflow's own discipline note: header-comment inventory (L8–12), `mkdir -p _site/js`, explicit `cp` lines for both new assets, smoke-check `curl` URLs for both.

## Pre-merge review trail

- **Critic (Opus, pre-implementation):** 1 Critical (load-mount detect) + 3 Warnings (noscript content, deploy workflow 4-site sweep, CSS load order) — all addressed in the implementation. Phase-scope warning (LP motion not in ROADMAP Phase 2 features table) acknowledged here: this is user-authorized polish alongside the active i18n LP work (#369, #374); not a Phase 2 feature.
- **code-reviewer (Opus, post-implementation):** PASS — 0 issues, 2 non-blocking nits (intentionally left as-is). All 10 verification axes pass: EN/JA stagger parity, no copy changes, anim.css verbatim, JS port semantics, CSS cascade order, noscript completeness, `hero-bubble-row` scoped to hero only, deploy workflow all 4 sites, ES5 compatibility, repo conventions.

## Test plan

- [x] **Fresh load** — hero items fade up in reading order, total under 1s.
- [x] **Scroll** — each section reveals once as it enters the viewport; no re-trigger on scroll-back.
- [ ] **Above-the-fold sections** — "What is Pastura" strip (immediately below the hero) reveals during the entrance, not stuck at `opacity:0`. (Critic Axis 2.)
- [ ] **Reduce Motion** — Settings → Accessibility → Reduce Motion ON. Reload → everything in final state, no transitions.
- [ ] **JS disabled** — disable JS in browser dev tools. Reload → all content fully visible (noscript reset).
- [ ] **JA mirror** — repeat the above on `/ja/`, verify identical timing.
- [ ] **Smoke-check** — confirm CI's `Smoke-check deployed URLs` step hits both new URLs (`/css/anim.css`, `/js/anim.js`) without 404.
- [ ] **Cross-browser** — Safari + Chrome desktop. Spot-check mobile Safari iOS 17+ (handoff specifies composite-only animations should hold 60fps).

Closes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)
