### PR TITLE
✨ feat(pages): expand LP FAQ with device, speed, heat questions

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -512,10 +512,26 @@
           <p class="faq-a">Yes. No server bill, no subscription.</p>
         </div>
         <div class="faq-item reveal-child" style="--i: 1">
+          <h3 class="faq-q">Which iPhones can run it?</h3>
+          <p class="faq-a">iPhone 15 Pro or newer, on iOS 17+. On-device models need about 8 GB of RAM, so iPhone 15 (non-Pro) and earlier are out of scope for now.</p>
+        </div>
+        <div class="faq-item reveal-child" style="--i: 2">
           <h3 class="faq-q">Why iOS only?</h3>
           <p class="faq-a">iOS for now, due to development bandwidth. Android is on the list.</p>
         </div>
-        <div class="faq-item reveal-child" style="--i: 2">
+        <div class="faq-item reveal-child" style="--i: 3">
+          <h3 class="faq-q">Can I talk to the agents myself?</h3>
+          <p class="faq-a">No, by design. Pastura is a window, not a chat app. The moment you join in, you reshape what you came to observe.</p>
+        </div>
+        <div class="faq-item reveal-child" style="--i: 4">
+          <h3 class="faq-q">How fast does it run?</h3>
+          <p class="faq-a">Inference runs on the Metal GPU. On an iPhone 16e with Gemma 4 E2B, we measure roughly 9 to 16 tok/s. Anything above about 10 tok/s reads comfortably in practice. A live tok/s readout in the app shows exactly how fast your device is going.</p>
+        </div>
+        <div class="faq-item reveal-child" style="--i: 5">
+          <h3 class="faq-q">What about battery and heat?</h3>
+          <p class="faq-a">Local inference uses the SoC, so it isn&rsquo;t free. Pastura watches the thermal state and auto-paces inference when the device warms up, though some heat is unavoidable during longer sessions.</p>
+        </div>
+        <div class="faq-item reveal-child" style="--i: 6">
           <h3 class="faq-q">Want another model supported?</h3>
           <p class="faq-a">Tell us on the <a href="support/">Support page</a>. We can&rsquo;t promise to add every request, but your input shapes what ships next.</p>
         </div>

--- a/pages/index.html
+++ b/pages/index.html
@@ -521,7 +521,7 @@
         </div>
         <div class="faq-item reveal-child" style="--i: 3">
           <h3 class="faq-q">Can I talk to the agents myself?</h3>
-          <p class="faq-a">No, by design. Pastura is a window, not a chat app. The moment you join in, you reshape what you came to observe.</p>
+          <p class="faq-a">No, by design. Pastura isn&rsquo;t a chat app for talking to an LLM, but an app for watching LLM agents. Once you join in, the agents react to you, and the natural exchange between them disappears.</p>
         </div>
         <div class="faq-item reveal-child" style="--i: 4">
           <h3 class="faq-q">How fast does it run?</h3>

--- a/pages/ja/index.html
+++ b/pages/ja/index.html
@@ -514,10 +514,26 @@
           <p class="faq-a">はい。サーバー料金もサブスクリプションもありません。</p>
         </div>
         <div class="faq-item reveal-child" style="--i: 1">
+          <h3 class="faq-q">どの iPhone で動きますか？</h3>
+          <p class="faq-a">iPhone 15 Pro 以降、iOS 17 以上です。オンデバイスのモデルが約 8 GB の RAM を要するため、iPhone 15（無印）以前は現在のところ対象外です。</p>
+        </div>
+        <div class="faq-item reveal-child" style="--i: 2">
           <h3 class="faq-q">なぜ iOS だけなんですか？</h3>
           <p class="faq-a">開発の都合上、今のところ iOS のみです。Android もいずれ対応予定です。</p>
         </div>
-        <div class="faq-item reveal-child" style="--i: 2">
+        <div class="faq-item reveal-child" style="--i: 3">
+          <h3 class="faq-q">自分は会話に参加できないんですか？</h3>
+          <p class="faq-a">はい、あえてそうしています。Pastura はチャットではなく、眺めるための窓。観察に入った瞬間、見たかったものは形を変えてしまうから。</p>
+        </div>
+        <div class="faq-item reveal-child" style="--i: 4">
+          <h3 class="faq-q">シミュレーションの速度はどのくらい？</h3>
+          <p class="faq-a">推論は Metal GPU 上で走ります。iPhone 16e で Gemma 4 E2B を使った実測では 9〜16 tok/s 程度。およそ 10 tok/s 以上あれば、ストレスなく会話を読めます。アプリ内のリアルタイム tok/s 表示で、今どのくらいの速度で動いているかも確認できます。</p>
+        </div>
+        <div class="faq-item reveal-child" style="--i: 5">
+          <h3 class="faq-q">バッテリーや発熱は大丈夫ですか？</h3>
+          <p class="faq-a">ローカル推論は SoC を使うので、消費はゼロではありません。Pastura は発熱状態を見て自動的にペースを落としますが、長めのセッションでは多少の発熱は避けられません。</p>
+        </div>
+        <div class="faq-item reveal-child" style="--i: 6">
           <h3 class="faq-q">ほかの LLM モデルの追加はできますか？</h3>
           <p class="faq-a"><a href="support/">サポートページ</a>で要望を出してください。必ず対応するとは約束できませんが、ご意見は参考にします。</p>
         </div>

--- a/pages/ja/index.html
+++ b/pages/ja/index.html
@@ -119,7 +119,7 @@
             <span class="sr-only">サンプル実行：</span>
             <span class="leaf" aria-hidden="true"></span>
             <span class="label">ワードウルフ・ラウンド 1</span>
-            <span class="live" aria-hidden="true"><span class="live-dot"></span>実行中</span>
+            <span class="live" aria-hidden="true"><span class="live-dot"></span>シミュレーション中</span>
           </figcaption>
 
           <div class="bubble-row hero-bubble-row" style="--bi: 0">

--- a/pages/ja/index.html
+++ b/pages/ja/index.html
@@ -523,7 +523,7 @@
         </div>
         <div class="faq-item reveal-child" style="--i: 3">
           <h3 class="faq-q">自分は会話に参加できないんですか？</h3>
-          <p class="faq-a">はい、あえてそうしています。Pastura はチャットではなく、眺めるための窓。観察に入った瞬間、見たかったものは形を変えてしまうから。</p>
+          <p class="faq-a">はい、あえてそうしています。Pastura は LLM とのチャットではなく、LLM エージェントを眺めるアプリ。人が入ると、エージェント同士の素のやり取りは見られなくなってしまいます。</p>
         </div>
         <div class="faq-item reveal-child" style="--i: 4">
           <h3 class="faq-q">シミュレーションの速度はどのくらい？</h3>


### PR DESCRIPTION
## Summary
- LP FAQ を 3 → 7 項目に拡充: デバイス要件 / 観察専用の設計意図 /
  シミュレーション速度 (Metal GPU + tok/s 読み取りを soft-mention) /
  電池・発熱
- EN (`pages/index.html`) と JA (`pages/ja/index.html`) を同期更新
- 新規 EN コピーは em-dash 回避、`isn't` を `&rsquo;` でエンティティ化
- 新規 JA コピーは Latin 周辺 half-width スペース慣習を適用
  (`どの iPhone で` 等)
- 7 つの `.faq-item` を `--i: 0..6` で振り直し

新並び順: Free → Devices → iOS only → Talk to agents → Speed →
Battery → Models

## Test plan
- [ ] `pages/index.html` をブラウザで開き、7 項目の Q&A が新並び順で
      表示されることを確認
- [ ] `pages/ja/index.html` で同様確認、EN と意味的に対応していること
- [ ] スクロールリビールが 7 項目目 (`--i: 6`, 計算上 660ms 遅延) まで
      スムーズに到達すること (Step 1b critic Axis 4 で要視覚 QA)
- [ ] デスクトップ / モバイル幅で見切れがないこと
- [ ] フッター・ヘッダーの `#faq` リンクでスクロール先が変わらないこと

## Critic / Reviewer notes
- Step 1b critic: 3 Warnings (Axis 4: stagger, Axis 5: typography,
  Axis 6: thermal claim) — すべて解消済み。Critic レポートは Issue
  #379 のプランコメント参照
- Step 4 code-reviewer (Opus): PASS, 0 issues, 2 informational
  suggestions (durability hedging / 視覚 QA リマインダ。コード変更不要)

Closes #379