### PR TITLE
🌐 feat: i18n wraps in App/ResultMarkdownExporter (#340)

### DIFF
--- a/Pastura/Pastura/App/ResultMarkdownExporter.swift
+++ b/Pastura/Pastura/App/ResultMarkdownExporter.swift
@@ -102,8 +102,13 @@ struct ResultMarkdownExporter {  // swiftlint:disable:this type_body_length
 
   private func renderMarkdown(_ input: Input) -> String {
     var sections: [String] = []
+    // <!-- pastura-export v1 --> stays raw — machine-readable schema version
+    // marker (see docs/i18n/leak-detection.md § permanent carve-outs).
     sections.append("<!-- pastura-export v1 -->")
-    sections.append("# Simulation Export: \(input.scenario.name)")
+    sections.append(
+      String(
+        format: String(localized: "# Simulation Export: %@"),
+        input.scenario.name))
     sections.append(renderMetadata(input))
     sections.append(renderScenarioYAML(input))
     sections.append(renderTurnLog(input))
@@ -134,32 +139,48 @@ struct ResultMarkdownExporter {  // swiftlint:disable:this type_body_length
 
   private func renderMetadata(_ input: Input) -> String {
     let sim = input.simulation
-    let status = sim.simulationStatus?.rawValue ?? sim.status
+    let status = Self.renderStatus(sim.simulationStatus?.rawValue ?? sim.status)
     let started = Self.isoFormatter.string(from: sim.createdAt)
     let ended = Self.isoFormatter.string(from: sim.updatedAt)
     let duration = formatDuration(sim.updatedAt.timeIntervalSince(sim.createdAt))
-    let model = sim.modelIdentifier ?? "(unknown)"
-    let backend = sim.llmBackend ?? "(unknown)"
+    let unknown = String(localized: "(unknown)")
+    let model = sim.modelIdentifier ?? unknown
+    let backend = sim.llmBackend ?? unknown
     let inferenceCount = input.turns.filter { $0.agentName != nil }.count
 
-    return """
-      ## Metadata
-
-      - **Scenario**: \(input.scenario.name) (`\(input.scenario.id)`)
-      - **Status**: \(status)
-      - **Started**: \(started)
-      - **Ended**: \(ended)
-      - **Duration**: \(duration)
-      - **Model**: \(model)
-      - **Backend**: \(backend)
-      - **Device**: \(environment.deviceModel) / \(environment.osVersion)
-      - **Inference count**: \(inferenceCount)
-      """
+    // Restructured from a multi-line `"""` literal to per-line format strings
+    // so each row is an independently-extractable catalog key — multi-line
+    // string interpolation cannot carry per-line positional `%@` placeholders
+    // that translators can reorder per language. Enabling refactor for i18n,
+    // not a behavior change (line set + join semantics preserved).
+    var lines: [String] = [String(localized: "## Metadata"), ""]
+    lines.append(
+      String(
+        format: String(localized: "- **Scenario**: %@ (`%@`)"),
+        input.scenario.name, input.scenario.id))
+    lines.append(String(format: String(localized: "- **Status**: %@"), status))
+    lines.append(String(format: String(localized: "- **Started**: %@"), started))
+    lines.append(String(format: String(localized: "- **Ended**: %@"), ended))
+    lines.append(String(format: String(localized: "- **Duration**: %@"), duration))
+    lines.append(String(format: String(localized: "- **Model**: %@"), model))
+    lines.append(String(format: String(localized: "- **Backend**: %@"), backend))
+    lines.append(
+      String(
+        format: String(localized: "- **Device**: %@ / %@"),
+        environment.deviceModel, environment.osVersion))
+    lines.append(
+      String(
+        format: String(localized: "- **Inference count**: %lld"),
+        inferenceCount))
+    return lines.joined(separator: "\n")
   }
 
   private func renderScenarioYAML(_ input: Input) -> String {
+    // YAML fence + language tag stay raw — they are Markdown structure, not
+    // display text. The fenced content is the user's authored YAML, rendered
+    // verbatim.
     """
-    ## Scenario Definition
+    \(String(localized: "## Scenario Definition"))
 
     ```yaml
     \(input.scenario.yamlDefinition)
@@ -220,14 +241,18 @@ struct ResultMarkdownExporter {  // swiftlint:disable:this type_body_length
       }
     }
 
-    /// Markdown heading for this group.
+    /// Markdown heading for this group. `phaseType` (e.g. `speak_all`) is the
+    /// YAML schema identifier and stays raw; only the surrounding label is
+    /// translated.
     var heading: String {
       switch self {
       case .topLevel(let phaseType):
-        return "#### Phase: \(phaseType)"
+        return String(format: String(localized: "#### Phase: %@"), phaseType)
       case .nested(let path, let phaseType):
         let formatted = path.map { String($0) }.joined(separator: ", ")
-        return "#### Sub-phase: \(phaseType) (path [\(formatted)])"
+        return String(
+          format: String(localized: "#### Sub-phase: %@ (path [%@])"),
+          phaseType, formatted)
       }
     }
   }
@@ -244,19 +269,21 @@ struct ResultMarkdownExporter {  // swiftlint:disable:this type_body_length
         }
         // Defensive: unknown payload shape shouldn't happen, but if it does
         // we skip silently rather than crash the export.
-        return TimelineItem.codePhase(record, .summary(text: "(unreadable payload)"))
+        return TimelineItem.codePhase(
+          record, .summary(text: String(localized: "(unreadable payload)")))
       })
     timeline.sort { $0.sequenceNumber < $1.sequenceNumber }
 
+    let turnLogHeader = String(localized: "## Turn Log")
     guard !timeline.isEmpty else {
-      return "## Turn Log\n\n_No turns recorded._"
+      return "\(turnLogHeader)\n\n\(String(localized: "_No turns recorded._"))"
     }
 
-    var lines: [String] = ["## Turn Log"]
+    var lines: [String] = [turnLogHeader]
     let grouped = Dictionary(grouping: timeline, by: { $0.round })
     for round in grouped.keys.sorted() {
       lines.append("")
-      lines.append("### Round \(round)")
+      lines.append(String(format: String(localized: "### Round %lld"), round))
       let itemsInRound = (grouped[round] ?? [])
         .sorted { $0.sequenceNumber < $1.sequenceNumber }
       // Group by PhaseGroupKey within round, preserving first-seen order.
@@ -295,39 +322,50 @@ struct ResultMarkdownExporter {  // swiftlint:disable:this type_body_length
       // Legacy fallback: a TurnRecord without an agent can only appear in
       // pre-#92 databases that never existed in practice. Emit a placeholder
       // so any stray row doesn't render as a blank bullet.
-      return "- _(code phase — no agent output)_"
+      return String(localized: "- _(code phase — no agent output)_")
     }
     let output = decodeOutput(turn)
     let content = formatOutput(output, phaseType: turn.phaseType)
-    var line = "- **\(agent)**: \(content)"
+    var line = String(format: String(localized: "- **%@**: %@"), agent, content)
     // Include inner_thought as a nested bullet — the gap between outward
     // behavior and inner reasoning is often the most analyzable signal in a
     // multi-agent run (e.g. Asch-style conformity).
     if let thought = output.innerThought, !thought.isEmpty {
-      line += "\n  - 💭 _\(thought)_"
+      line += String(format: String(localized: "\n  - 💭 _%@_"), thought)
     }
     return line
   }
 
-  // swiftlint:disable:next cyclomatic_complexity
+  // swiftlint:disable:next cyclomatic_complexity function_body_length
   private func renderCodePhasePayload(_ payload: CodePhaseEventPayload) -> String {
     switch payload {
     case .elimination(let agent, let voteCount):
-      return "- **\(agent)** was eliminated (\(voteCount) votes)"
+      return String(
+        format: String(localized: "- **%@** was eliminated (%lld votes)"),
+        agent, voteCount)
     case .scoreUpdate(let scores):
       let ordered = scores.sorted { lhs, rhs in
         if lhs.value != rhs.value { return lhs.value > rhs.value }
         return lhs.key < rhs.key
       }
+      // `key: value` is a universal joiner — left raw; the surrounding label
+      // ("Scores — ") carries the localized part.
       let pairs = ordered.map { "\($0.key): \($0.value)" }.joined(separator: ", ")
-      return "- Scores — \(pairs)"
+      return String(format: String(localized: "- Scores — %@"), pairs)
     case .summary(let text):
+      // `text` is already-rendered prose from the engine; passed through verbatim.
       return "- \(text)"
     case .voteResults(let votes, let tallies):
       var lines: [String] = []
-      lines.append("- Tallies:")
+      lines.append(String(localized: "- Tallies:"))
       lines.append("")
-      lines.append("  | Candidate | Votes |")
+      // Table header — column labels translated individually so `Votes` / etc.
+      // can be reused across other tables. Separator and data rows stay raw
+      // (pure Markdown structure).
+      lines.append(
+        String(
+          format: "  | %@ | %@ |",
+          String(localized: "Candidate"), String(localized: "Votes")))
       lines.append("  |-----------|-------|")
       let orderedTallies = tallies.sorted { lhs, rhs in
         if lhs.value != rhs.value { return lhs.value > rhs.value }
@@ -337,23 +375,28 @@ struct ResultMarkdownExporter {  // swiftlint:disable:this type_body_length
         lines.append("  | \(candidate) | \(count) |")
       }
       lines.append("")
-      lines.append("- Votes:")
+      lines.append(String(localized: "- Votes:"))
       let orderedVotes = votes.sorted { $0.key < $1.key }
       for (voter, target) in orderedVotes {
+        // `voter → target` is a universal arrow joiner; kept raw.
         lines.append("  - \(voter) → \(target)")
       }
       return lines.joined(separator: "\n")
     case .pairingResult(let agent1, let action1, let agent2, let action2):
-      return "- **\(agent1)** (\(action1)) ↔ **\(agent2)** (\(action2))"
+      return String(
+        format: String(localized: "- **%@** (%@) ↔ **%@** (%@)"),
+        agent1, action1, agent2, action2)
     case .assignment(let agent, let value):
-      return "- **\(agent)** was assigned: \(value)"
+      return String(
+        format: String(localized: "- **%@** was assigned: %@"),
+        agent, value)
     case .eventInjected(let event):
       // Past results need to surface the miss explicitly so a reader
       // can tell whether the phase ran at all.
       if let event {
-        return "- 🎲 Event: \(event)"
+        return String(format: String(localized: "- 🎲 Event: %@"), event)
       }
-      return "- 🎲 No event this round"
+      return String(localized: "- 🎲 No event this round")
     }
   }
 
@@ -389,7 +432,9 @@ struct ResultMarkdownExporter {  // swiftlint:disable:this type_body_length
       !primary.isEmpty {
       return primary
     }
-    if output.fields.isEmpty { return "_(empty)_" }
+    if output.fields.isEmpty { return String(localized: "_(empty)_") }
+    // `key=value` is a debug-shape joiner for the unknown-phase-type fallback;
+    // left raw.
     let pairs = output.fields.keys.sorted().map { "\($0)=\(output.fields[$0] ?? "")" }
     return pairs.joined(separator: ", ")
   }
@@ -409,13 +454,24 @@ struct ResultMarkdownExporter {  // swiftlint:disable:this type_body_length
     let eliminatedSet = eliminatedAgents(in: payloads)
     let roster = rosterAgents(input: input, latestScores: latestScores)
 
+    let header = String(localized: "## Final Scores")
     guard !roster.isEmpty else {
-      return "## Final Scores\n\n_No score data._"
+      return "\(header)\n\n\(String(localized: "_No score data._"))"
     }
 
+    // Column labels translated individually so each label is reused across
+    // tables (`Agent`/`Status` also appear in Roster Status). Separator row
+    // stays raw — it is Markdown structure, not display text.
+    let columns = String(
+      format: "| %@ | %@ | %@ |",
+      String(localized: "Agent"),
+      String(localized: "Score"),
+      String(localized: "Status"))
     var lines: [String] = [
-      "## Final Scores", "", "| Agent | Score | Status |", "|-------|-------|--------|"
+      header, "", columns, "|-------|-------|--------|"
     ]
+    let activeLabel = String(localized: "active")
+    let eliminatedLabel = String(localized: "eliminated")
     // Sort by score desc, then by name asc for deterministic output.
     let ordered = roster.sorted { lhs, rhs in
       let lhsScore = latestScores[lhs] ?? 0
@@ -425,7 +481,8 @@ struct ResultMarkdownExporter {  // swiftlint:disable:this type_body_length
     }
     for agent in ordered {
       let score = latestScores[agent] ?? 0
-      let status = eliminatedSet.contains(agent) ? "eliminated" : "active"
+      let status = eliminatedSet.contains(agent) ? eliminatedLabel : activeLabel
+      // Data row stays raw — pure Markdown table structure.
       lines.append("| \(agent) | \(score) | \(status) |")
     }
     return lines.joined(separator: "\n")
@@ -442,13 +499,18 @@ struct ResultMarkdownExporter {  // swiftlint:disable:this type_body_length
     let eliminatedSet = eliminatedAgents(in: payloads)
     let roster = rosterAgents(input: input, latestScores: [:])
 
+    let header = String(localized: "## Roster Status")
     guard !roster.isEmpty else {
-      return "## Roster Status\n\n_No roster data._"
+      return "\(header)\n\n\(String(localized: "_No roster data._"))"
     }
 
-    var lines: [String] = [
-      "## Roster Status", "", "| Agent | Status |", "|-------|--------|"
-    ]
+    let columns = String(
+      format: "| %@ | %@ |",
+      String(localized: "Agent"),
+      String(localized: "Status"))
+    var lines: [String] = [header, "", columns, "|-------|--------|"]
+    let activeLabel = String(localized: "active")
+    let eliminatedLabel = String(localized: "eliminated")
     // Eliminated agents first (narrative interest), then by name.
     let ordered = roster.sorted { lhs, rhs in
       let lElim = eliminatedSet.contains(lhs)
@@ -457,7 +519,7 @@ struct ResultMarkdownExporter {  // swiftlint:disable:this type_body_length
       return lhs < rhs
     }
     for agent in ordered {
-      let status = eliminatedSet.contains(agent) ? "eliminated" : "active"
+      let status = eliminatedSet.contains(agent) ? eliminatedLabel : activeLabel
       lines.append("| \(agent) | \(status) |")
     }
     return lines.joined(separator: "\n")
@@ -496,14 +558,37 @@ struct ResultMarkdownExporter {  // swiftlint:disable:this type_body_length
     return Array(set)
   }
 
+  // MARK: - Status mapping
+
+  /// Maps a `SimulationStatus.rawValue` (or unknown raw string) to a
+  /// localized display label. Unknown values pass through verbatim so a
+  /// future `SimulationStatus` case renders as-is rather than crashing.
+  ///
+  /// Lives App-side (not on `Models/SimulationStatus`) because `Models/` is
+  /// `nonisolated` and excluded from `Localizable.xcstrings` per ADR-010 §4.
+  /// `static internal` (default access) so tests can validate the mapping
+  /// directly without constructing an instance.
+  static func renderStatus(_ raw: String) -> String {
+    switch raw {
+    case "running": return String(localized: "Running")
+    case "paused": return String(localized: "Paused")
+    case "completed": return String(localized: "Completed")
+    case "failed": return String(localized: "Failed")
+    case "cancelled": return String(localized: "Cancelled")
+    default: return raw
+    }
+  }
+
   // MARK: - Duration formatting
 
   private func formatDuration(_ seconds: TimeInterval) -> String {
     let total = max(Int(seconds.rounded()), 0)
     let minutes = total / 60
     let secs = total % 60
-    if minutes == 0 { return "\(secs)s" }
-    return "\(minutes)m \(secs)s"
+    if minutes == 0 {
+      return String(format: String(localized: "%llds"), secs)
+    }
+    return String(format: String(localized: "%lldm %llds"), minutes, secs)
   }
 
   // MARK: - File writing

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -1,6 +1,22 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "\n  - 💭 _%@_" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "\n  - 💭 _%@_"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "\n  - 💭 _%@_"
+          }
+        }
+      }
+    },
     "  %@: %lld votes" : {
       "localizations" : {
         "en" : {
@@ -13,6 +29,150 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "  %1$@: %2$lld 票"
+          }
+        }
+      }
+    },
+    "# Simulation Export: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# Simulation Export: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "# シミュレーション結果: %@"
+          }
+        }
+      }
+    },
+    "## Final Scores" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "## Final Scores"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "## 最終スコア"
+          }
+        }
+      }
+    },
+    "## Metadata" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "## Metadata"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "## メタデータ"
+          }
+        }
+      }
+    },
+    "## Roster Status" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "## Roster Status"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "## ロスター状況"
+          }
+        }
+      }
+    },
+    "## Scenario Definition" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "## Scenario Definition"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "## シナリオ定義"
+          }
+        }
+      }
+    },
+    "## Turn Log" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "## Turn Log"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "## ターンログ"
+          }
+        }
+      }
+    },
+    "### Round %lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "### Round %lld"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "### ラウンド %lld"
+          }
+        }
+      }
+    },
+    "#### Phase: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "#### Phase: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "#### フェーズ: %@"
+          }
+        }
+      }
+    },
+    "#### Sub-phase: %@ (path [%@])" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "#### Sub-phase: %1$@ (path [%2$@])"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "#### サブフェーズ: %@ (path [%@])"
           }
         }
       }
@@ -111,12 +271,76 @@
         }
       }
     },
+    "%lldm %llds" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lldm %2$llds"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld分%lld秒"
+          }
+        }
+      }
+    },
+    "%llds" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%llds"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld秒"
+          }
+        }
+      }
+    },
     "(no condition)" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "（条件なし）"
+          }
+        }
+      }
+    },
+    "(unknown)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(unknown)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(不明)"
+          }
+        }
+      }
+    },
+    "(unreadable payload)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(unreadable payload)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(ペイロード解読不可)"
           }
         }
       }
@@ -128,6 +352,310 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "、"
+          }
+        }
+      }
+    },
+    "- **%@** (%@) ↔ **%@** (%@)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **%1$@** (%2$@) ↔ **%3$@** (%4$@)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **%@** (%@) ↔ **%@** (%@)"
+          }
+        }
+      }
+    },
+    "- **%@** was assigned: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **%1$@** was assigned: %2$@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **%@** に割り当て: %@"
+          }
+        }
+      }
+    },
+    "- **%@** was eliminated (%lld votes)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **%1$@** was eliminated (%2$lld votes)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **%@** が脱落 (%lld 票)"
+          }
+        }
+      }
+    },
+    "- **%@**: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **%1$@**: %2$@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **%@**: %@"
+          }
+        }
+      }
+    },
+    "- **Backend**: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **Backend**: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **バックエンド**: %@"
+          }
+        }
+      }
+    },
+    "- **Device**: %@ / %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **Device**: %1$@ / %2$@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **デバイス**: %@ / %@"
+          }
+        }
+      }
+    },
+    "- **Duration**: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **Duration**: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **所要時間**: %@"
+          }
+        }
+      }
+    },
+    "- **Ended**: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **Ended**: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **終了**: %@"
+          }
+        }
+      }
+    },
+    "- **Inference count**: %lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **Inference count**: %lld"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **推論回数**: %lld"
+          }
+        }
+      }
+    },
+    "- **Model**: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **Model**: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **モデル**: %@"
+          }
+        }
+      }
+    },
+    "- **Scenario**: %@ (`%@`)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **Scenario**: %1$@ (`%2$@`)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **シナリオ**: %@ (`%@`)"
+          }
+        }
+      }
+    },
+    "- **Started**: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **Started**: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **開始**: %@"
+          }
+        }
+      }
+    },
+    "- **Status**: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **Status**: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **ステータス**: %@"
+          }
+        }
+      }
+    },
+    "- Scores — %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- Scores — %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- スコア — %@"
+          }
+        }
+      }
+    },
+    "- Tallies:" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- Tallies:"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- 集計:"
+          }
+        }
+      }
+    },
+    "- Votes:" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- Votes:"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- 投票:"
+          }
+        }
+      }
+    },
+    "- _(code phase — no agent output)_" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- _(code phase — no agent output)_"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- _(コードフェーズ — エージェント出力なし)_"
+          }
+        }
+      }
+    },
+    "- 🎲 Event: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- 🎲 Event: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- 🎲 イベント: %@"
+          }
+        }
+      }
+    },
+    "- 🎲 No event this round" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- 🎲 No event this round"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- 🎲 このラウンドはイベントなし"
           }
         }
       }
@@ -219,6 +747,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "追加済み"
+          }
+        }
+      }
+    },
+    "Agent" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agent"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エージェント"
           }
         }
       }
@@ -395,10 +939,32 @@
     },
     "Cancelled" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelled"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "キャンセル"
+            "value" : "中断"
+          }
+        }
+      }
+    },
+    "Candidate" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Candidate"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "候補者"
           }
         }
       }
@@ -525,6 +1091,12 @@
     },
     "Completed" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Completed"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1063,6 +1635,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "エクスポートに失敗しました"
+          }
+        }
+      }
+    },
+    "Failed" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "失敗"
           }
         }
       }
@@ -2037,10 +2625,16 @@
     },
     "Paused" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paused"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "一時停止中"
+            "value" : "一時停止"
           }
         }
       }
@@ -2530,8 +3124,13 @@
       }
     },
     "Running" : {
-      "extractionState" : "stale",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Running"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2647,6 +3246,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "共有シナリオに関するシナリオ報告は Pastura のメンテナ (github.com/tyabu12) が確認します。"
+          }
+        }
+      }
+    },
+    "Score" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Score"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スコア"
           }
         }
       }
@@ -2876,6 +3491,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "このモデルで始める"
+          }
+        }
+      }
+    },
+    "Status" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Status"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "状態"
           }
         }
       }
@@ -3361,10 +3992,16 @@
     },
     "Votes" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Votes"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "投票"
+            "value" : "票数"
           }
         }
       }
@@ -3486,6 +4123,86 @@
         }
       }
     },
+    "_(empty)_" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "_(empty)_"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "_(なし)_"
+          }
+        }
+      }
+    },
+    "_No roster data._" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "_No roster data._"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "_ロスターデータなし_"
+          }
+        }
+      }
+    },
+    "_No score data._" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "_No score data._"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "_スコアデータなし_"
+          }
+        }
+      }
+    },
+    "_No turns recorded._" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "_No turns recorded._"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "_ターン記録なし_"
+          }
+        }
+      }
+    },
+    "active" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "active"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アクティブ"
+          }
+        }
+      }
+    },
     "disabled" : {
       "localizations" : {
         "ja" : {
@@ -3513,6 +4230,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "例: max_score >= 10 && active_count > 1"
+          }
+        }
+      }
+    },
+    "eliminated" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "eliminated"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "脱落"
           }
         }
       }

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -948,7 +948,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "中断"
+            "value" : "キャンセル"
           }
         }
       }
@@ -2634,7 +2634,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "一時停止"
+            "value" : "一時停止中"
           }
         }
       }

--- a/Pastura/PasturaTests/App/ResultMarkdownExporterTests.swift
+++ b/Pastura/PasturaTests/App/ResultMarkdownExporterTests.swift
@@ -106,7 +106,9 @@ import Testing
     #expect(result.text.hasPrefix("<!-- pastura-export v1 -->"))
     #expect(result.text.contains("# Simulation Export: Prisoners Dilemma"))
     #expect(result.text.contains("## Metadata"))
-    #expect(result.text.contains("**Status**: completed"))
+    // `renderStatus` maps SimulationStatus.rawValue → localized capitalized
+    // form; the lowercase enum-raw is no longer surfaced verbatim.
+    #expect(result.text.contains("**Status**: Completed"))
     #expect(result.text.contains("**Started**: 2024-04-01T19:33:20Z"))
     #expect(result.text.contains("**Ended**: 2024-04-01T19:39:02Z"))
     #expect(result.text.contains("**Duration**: 5m 42s"))
@@ -267,7 +269,7 @@ import Testing
 
     let result = try exporter.export(input)
 
-    #expect(result.text.contains("**Status**: failed"))
+    #expect(result.text.contains("**Status**: Failed"))
     #expect(result.text.contains("**Inference count**: 0"))
     #expect(result.text.contains("_No turns recorded._"))
     #expect(!result.text.contains("## Final Scores"))
@@ -339,6 +341,22 @@ import Testing
   @Test func normalizeOSVersionLeavesUnfamiliarStringsUnchanged() {
     let raw = "custom-os-26.4"
     #expect(ResultMarkdownExporter.ExportEnvironment.normalizeOSVersion(raw) == raw)
+  }
+
+  @Test func renderStatusMapsCanonicalCasesToLocalizedLabels() {
+    // Asserts against literal en source strings — Swift Testing runs in the
+    // development locale (en), so `String(localized:)` resolves to the en
+    // catalog value. en-literal pin makes a future ja-locale test run fail
+    // loudly instead of silently mismatching the helper's locale-dependent
+    // output (critic Axis 6 — `String(localized:)` on both sides is tautology).
+    #expect(ResultMarkdownExporter.renderStatus("running") == "Running")
+    #expect(ResultMarkdownExporter.renderStatus("paused") == "Paused")
+    #expect(ResultMarkdownExporter.renderStatus("completed") == "Completed")
+    #expect(ResultMarkdownExporter.renderStatus("failed") == "Failed")
+    #expect(ResultMarkdownExporter.renderStatus("cancelled") == "Cancelled")
+    // Forward-compat: unknown raw values pass through verbatim so a future
+    // SimulationStatus case is rendered as-is rather than crashing.
+    #expect(ResultMarkdownExporter.renderStatus("future-case") == "future-case")
   }
 
   @Test func writesMarkdownFileToTempDirectory() throws {

--- a/Pastura/PasturaTests/App/SimulationViewModelExportTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelExportTests.swift
@@ -57,7 +57,7 @@ struct SimulationViewModelExportTests {
     let unwrapped = try #require(payload)
     #expect(unwrapped.text.contains("<!-- pastura-export v1 -->"))
     #expect(unwrapped.text.contains("# Simulation Export: Test Scenario"))
-    #expect(unwrapped.text.contains("**Status**: completed"))
+    #expect(unwrapped.text.contains("**Status**: Completed"))
     #expect(unwrapped.text.contains("hello from Alice"))
     #expect(unwrapped.fileURL.pathExtension == "md")
   }

--- a/docs/i18n/leak-detection.md
+++ b/docs/i18n/leak-detection.md
@@ -110,18 +110,25 @@ design-pending copy* (see § "Explicitly-deferred items" below), *internal
 log strings* (Logger `%public` interpolations), or *real wrap leaks*
 (e.g. `SimulationView.swift:535 loadError = "Scenario not found"`).
 
-### Explicitly-deferred items
+### Explicitly-deferred or permanent carve-outs
 
-Audit candidates that are **knowingly** un-wrapped pending a downstream
-gating event. They will keep surfacing in `check_i18n_potential_keys.py`
-output — recognize them as documented carve-outs rather than wrap leaks.
-When the gating event lands, wrap with English source strings and add
-the ja translation in the catalog at the same time.
+Audit candidates that are **knowingly** un-wrapped. Two flavours:
 
-| Item | Source location | Gating event |
-|------|-----------------|--------------|
-| `slotCopy(_:)` 3 marketing strings | `Pastura/Pastura/Views/ModelDownload/PromoCard+Helpers.swift` | `docs/design/design-system.md` §7 copy pass (spec §2 decision 13) |
-| `Character.accessibilityLabel` 4 cases (`Alice`/`Bob`/`Carol`/`Dave`) | `Pastura/Pastura/Views/Components/SheepAvatar.swift` | Preview-only after #340 bucket-3 PR — runtime application carries `.accessibilityHidden(true)` because the names are color-slot identifiers (allocated by `forAgent(position:)`), not agent display names. Re-evaluate only if a future design binds avatars to real translated identities. |
+- **Deferred** — pending a downstream gating event (design copy pass,
+  schema migration, etc.). Wrap when the gating event lands.
+- **Permanent** — structurally machine-stable tokens (Markdown
+  structure, version markers, format-string internals, user-authored
+  content rendered verbatim). External-tool stability or schema
+  contract outweighs locale display.
+
+Both keep surfacing in `check_i18n_potential_keys.py` output —
+recognize them as documented carve-outs rather than wrap leaks.
+
+| Item | Source location | Gating event / Status |
+|------|-----------------|-----------------------|
+| `slotCopy(_:)` 3 marketing strings | `Pastura/Pastura/Views/ModelDownload/PromoCard+Helpers.swift` | **Deferred** — `docs/design/design-system.md` §7 copy pass (spec §2 decision 13) |
+| `Character.accessibilityLabel` 4 cases (`Alice`/`Bob`/`Carol`/`Dave`) | `Pastura/Pastura/Views/Components/SheepAvatar.swift` | **Deferred** — Preview-only after #340 bucket-3 PR — runtime application carries `.accessibilityHidden(true)` because the names are color-slot identifiers (allocated by `forAgent(position:)`), not agent display names. Re-evaluate only if a future design binds avatars to real translated identities. |
+| `ResultMarkdownExporter` machine-stable tokens (~10 candidates) | `Pastura/Pastura/App/ResultMarkdownExporter.swift` | **Permanent** — Markdown structural tokens (`<!-- pastura-export v1 -->` version marker, table data rows, separator rows like `\|-------\|-------\|--------\|`), universal joiners (`%@: %@` score pair, `%@ → %@` vote arrow, `%@=%@` field dump), Apple OS-version normalize internals (`Version `, `iOS `, `(Build `, `(build ` — matchers for Apple's raw string format), filename / timestamp / locale-identifier internals (`%@_%@.md`, `yyyyMMdd-HHmmss`, `en_US_POSIX`), YAML scenario block (user-authored verbatim). External-tool stability over locale display per #340 slice-4 decision (PR for `App/ResultMarkdownExporter` i18n wraps). |
 
 ### Self-test
 


### PR DESCRIPTION
## Summary

Slice 4 of 9 from #340 (i18n Tier 2 leak triage). Wraps ~50 user-facing
English literals in `App/ResultMarkdownExporter.swift` so the Markdown
export reads naturally in ja-locale when shared to Notes / SNS.

- New `static renderStatus(_:)` helper maps `SimulationStatus.rawValue`
  (`completed`) → localized capitalized form (`Completed` / `完了`).
  Unknown raw passes through verbatim for forward compat. Lives App-side
  because `Models/SimulationStatus` is `nonisolated` and excluded from
  `Localizable.xcstrings` per ADR-010 §4.
- Metadata block restructured from multi-line `"""` literal to per-line
  format strings joined `"\n"`. Enabling refactor — multi-line string
  interpolation cannot carry per-line positional `%@` placeholders that
  translators can reorder per language. Behavior preserved.
- Table headers split column-by-column so `Agent`/`Score`/`Status`
  catalog keys reuse across Final Scores + Roster Status.
- 49 catalog entries added/flipped to `state: "translated"` with ja
  translations (Apple-canonical format, zero-drift after build).
- Shared status pill ja values (`一時停止中` / `キャンセル`) preserved per
  code-review feedback — `GameHeaderStatus.label` consumes the same
  `Paused` / `Cancelled` catalog keys.

## Keep-raw (permanent carve-outs)

Documented in `docs/i18n/leak-detection.md` (renamed section to
"Explicitly-deferred or permanent carve-outs"):
- `<!-- pastura-export v1 -->` machine-readable version marker
- Apple OS-version normalize internals (`Version `→`iOS `, `(Build `→`(build `)
- Universal joiners (`%@: %@` score pair, `%@ → %@` vote arrow, `%@=%@` field dump)
- Filename / timestamp / locale-identifier internals (`%@_%@.md`, `yyyyMMdd-HHmmss`, `en_US_POSIX`)
- YAML scenario block (user-authored verbatim)

## Test plan

- [x] `python3 scripts/check_localization_coverage.py` → 389 keys, all `ja` translated
- [x] `python3 scripts/check_i18n_potential_keys.py` → 21 remaining candidates for `App/ResultMarkdownExporter.swift`, all documented as permanent carve-outs
- [x] `swiftlint --strict` clean
- [x] `scripts/xcodebuild.sh test` → 1564 tests / 140 suites pass
- [x] `scripts/xcodebuild.sh build` → zero catalog drift (Apple-canonical format)
- [ ] Manual QA: open a completed simulation → tap Share Markdown → in ja-locale, verify section headers / field labels read in Japanese; in en-locale, verify backward-compat output
- [ ] Manual QA: switch device to ja-locale → start a simulation → verify the `GameHeaderStatus` pill still shows `一時停止中` / `キャンセル` (regression guard for shared keys)

Part of #340. Remaining buckets: YAMLReplayExporter, App/SimulationViewModel suite, Model selection App-side, Editor+Results, Shared Scenarios, LLM verify, InferenceStatsFormatter, Data layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)