### PR TITLE
✨ feat(pages): configure pastura.app apex custom domain

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -33,6 +33,11 @@
 #   - `pages/ja/legal/privacy-policy/index.html`
 #                                          → `https://tyabu12.github.io/pastura/ja/legal/privacy-policy/`
 #     (Japanese mirror of the privacy policy page)
+#   - `pages/CNAME`                        → `_site/CNAME` (apex custom domain)
+#     (Single line `pastura.app`. GitHub Pages reads CNAME from the
+#     deployed artifact root to persist `Settings → Pages → Custom
+#     domain` across deploys — omission would wipe the custom-domain
+#     binding on the next deploy.)
 #
 # Precondition: Settings → Pages → Source = "GitHub Actions" (NOT
 # "Deploy from a branch", which would publish the entire `pages/` tree
@@ -112,6 +117,7 @@ jobs:
           cp pages/ja/index.html _site/ja/index.html
           cp pages/ja/support/index.html _site/ja/support/index.html
           cp pages/ja/legal/privacy-policy/index.html _site/ja/legal/privacy-policy/index.html
+          cp pages/CNAME _site/CNAME
           touch _site/.nojekyll
 
       - name: Upload artifact

--- a/pages/CNAME
+++ b/pages/CNAME
@@ -1,0 +1,1 @@
+pastura.app


### PR DESCRIPTION
## Summary

- Add `pages/CNAME` containing `pastura.app` (1 line, bare apex domain)
- Wire `pages/CNAME` into `.github/workflows/deploy-pages.yml`'s explicit-`cp` staging list (otherwise GitHub Pages wipes the custom-domain binding on the next deploy)

## Deferred follow-ups

The apex domain strips the `/pastura/` project-pages path prefix. ~46 hardcoded `tyabu12.github.io/pastura/*` references remain across `pages/**`, `SettingsView.swift:76`, `docs/ROADMAP.md`, `ADR-005`, and the workflow's own smoke-check URL list. GitHub's 301 redirect from the old host keeps these working in the meantime, so the sweep is **split into a follow-up PR** (tracking: #390). The apex switch is reversible (remove CNAME → revert), so the split factoring is appropriate.

## Order of operations (post-merge — user-side, not part of this PR)

1. Merge this PR — `CNAME` lands in the Pages artifact.
2. ` Settings → Pages → Custom domain ` → enter `pastura.app`.
3. Configure DNS: apex A records pointing at GitHub Pages IPs, or ALIAS/ANAME if the DNS provider supports it.
4. Wait for Let's Encrypt cert provisioning, then enable " Enforce HTTPS ".

⚠️ Reversing steps 1 and 2 (registering custom-domain in UI before CNAME-in-artifact lands) can cause the next deploy to wipe the binding.

## Test plan

- [ ] CI: \`Deploy Pages\` workflow run succeeds on \`main\` post-merge
- [ ] Manual: after step 2 above, \` Settings → Pages → Custom domain \` shows \`pastura.app\` with green checkmark
- [ ] Manual: after DNS + HTTPS provisioning, \`https://pastura.app/\` serves the LP (200) and \`https://tyabu12.github.io/pastura/\` issues 301 to \`https://pastura.app/\`

Closes #389