### PR TITLE
✨ feat(engine): ADR-010 Step E PR1 — wire `simulation_language` via `Scenario.engineLanguage`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,6 +403,20 @@ jobs:
       - name: Verify Localizable.xcstrings ja coverage
         run: python3 scripts/check_localization_coverage.py
 
+  engine-language-axis:
+    name: Engine language-axis guard (ADR-010 D5 / D8)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # Bash + grep only — both pre-installed on ubuntu-latest. The script
+      # blocks future regressions of the `scenario.language` → Engine
+      # dispatch antipattern; see docs/decisions/ADR-010.md § D5, D7, D8.
+      - name: Run Engine language-axis guard
+        run: bash scripts/check_engine_language_axis.sh
+
   coverage:
     name: Coverage
     needs: lint-and-test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Phase 2 progress:
 - **Simulation result export** — Markdown via Share Sheet, incl. code-phase results (#91/#98)
 - **Inference speed display** — tok/s + simulation playback UX (#99)
 - **Past results — code-phase events** — score_calc / scenario gen events in past-results viewer (#102/#113)
-- **Localization (i18n: ja/en)** — *in progress* — see ROADMAP § "Localization Plan" (#276/#277, ADR-010 stub #279, body #367, B-1a public pages #369, responsive-design migration #373, Engine dynamic localization #383, drift script + Past Results compat #386, bundled English presets + EN DL demo replays + locale-driven runtime selection #388)
+- **Localization (i18n: ja/en)** — *in progress* — see ROADMAP § "Localization Plan" (#276/#277, ADR-010 stub #279, body #367, B-1a public pages #369, responsive-design migration #373, Engine dynamic localization #383, drift script + Past Results compat #386, bundled English presets + EN DL demo replays + locale-driven runtime selection #388, Step E PR1 simulation_language Engine wiring #398)
 
 ## Language Rules
 

--- a/Pastura/Pastura/Engine/LanguageDispatch.swift
+++ b/Pastura/Pastura/Engine/LanguageDispatch.swift
@@ -1,23 +1,26 @@
 import Foundation
 
-/// Selects the literal matching `scenario.language` for Engine-side
-/// per-site translation (ADR-010 D7).
+/// Selects the literal matching the effective Engine language for
+/// per-site translation (ADR-010 D7). Callers pass
+/// `scenario.engineLanguage` (D5 / D6 row 1), which resolves
+/// `simulationLanguage ?? language`.
 ///
 /// Two-arm shape per ADR-010 Fallback rule (line 514–528):
-/// `scenario.language` is mandatory (`ScenarioLoader` rejects absence)
-/// and validator-gated to `{"ja", "en"}`, so the `default` arm covers
-/// `"ja"` without a third defensive arm. No `@unknown default` —
-/// that attribute is enum-only (SE-0192) and inapplicable to `String`
-/// switches.
+/// `scenario.language` and `scenario.simulationLanguage` are both
+/// validator-gated to `{"ja", "en"}` (the latter also accepts `nil`),
+/// so the resolved string is effectively `{"ja", "en"}` and the
+/// `default` arm covers `"ja"` without a third defensive arm. No
+/// `@unknown default` — that attribute is enum-only (SE-0192) and
+/// inapplicable to `String` switches.
 ///
-/// **Layer note (D8 normative):** Engine reads `scenario.language` only,
-/// never `Bundle.main.preferredLocalizations`. This helper is intentionally
-/// independent of `String(localized:)`, which would resolve against device
-/// locale and break the cross-language goal in Step E.
+/// **Layer note (D8 normative):** Engine reads `scenario.engineLanguage`
+/// only, never `Bundle.main.preferredLocalizations`. This helper is
+/// intentionally independent of `String(localized:)`, which would
+/// resolve against device locale and break the cross-language goal.
 ///
-/// The `ja` / `en` parameter names match `scenario.language` values
-/// verbatim so callsites read as a Translation Table row (`identifier_name`
-/// rule excludes both per `.swiftlint.yml`).
+/// The `ja` / `en` parameter names match the resolved language values
+/// verbatim so callsites read as a Translation Table row
+/// (`identifier_name` rule excludes both per `.swiftlint.yml`).
 nonisolated func pickLanguage(_ language: String, ja: String, en: String) -> String {
   switch language {
   case "en":

--- a/Pastura/Pastura/Engine/Phases/ChooseHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/ChooseHandler.swift
@@ -16,7 +16,7 @@ nonisolated struct ChooseHandler: PhaseHandler {
     let promptTemplate =
       context.phase.prompt
       ?? pickLanguage(
-        context.scenario.language,
+        context.scenario.engineLanguage,
         ja: "選択してください。",
         en: "Make a choice.")
     let options = context.phase.options ?? []
@@ -83,7 +83,7 @@ nonisolated struct ChooseHandler: PhaseHandler {
     variables["opponent_name"] = opponent.name
     variables["scoreboard"] = promptBuilder.formatScoreboard(state.scores)
     variables["conversation_log"] = promptBuilder.formatConversationLog(
-      state.conversationLog, language: context.scenario.language)
+      state.conversationLog, language: context.scenario.engineLanguage)
     let userPrompt = promptBuilder.expandTemplate(promptTemplate, variables: variables)
 
     let output = try await llmCaller.call(
@@ -114,7 +114,7 @@ nonisolated struct ChooseHandler: PhaseHandler {
       var variables = state.variables
       variables["scoreboard"] = promptBuilder.formatScoreboard(state.scores)
       variables["conversation_log"] = promptBuilder.formatConversationLog(
-        state.conversationLog, language: context.scenario.language)
+        state.conversationLog, language: context.scenario.engineLanguage)
       let userPrompt = promptBuilder.expandTemplate(promptTemplate, variables: variables)
 
       let output = try await llmCaller.call(

--- a/Pastura/Pastura/Engine/Phases/ScoreCalcHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/ScoreCalcHandler.swift
@@ -22,7 +22,7 @@ nonisolated struct ScoreCalcHandler: PhaseHandler {
       VoteTallyLogic().calculate(state: &state, emitter: context.emitter)
     case .wordwolfJudge:
       WordwolfJudgeLogic().calculate(
-        state: &state, language: context.scenario.language, emitter: context.emitter)
+        state: &state, language: context.scenario.engineLanguage, emitter: context.emitter)
     }
   }
 }

--- a/Pastura/Pastura/Engine/Phases/SpeakAllHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/SpeakAllHandler.swift
@@ -15,7 +15,7 @@ nonisolated struct SpeakAllHandler: PhaseHandler {
     let promptTemplate =
       context.phase.prompt
       ?? pickLanguage(
-        context.scenario.language,
+        context.scenario.engineLanguage,
         ja: "あなたの意見を述べてください。",
         en: "Share your opinion.")
 
@@ -29,7 +29,7 @@ nonisolated struct SpeakAllHandler: PhaseHandler {
       var variables = state.variables
       variables["scoreboard"] = promptBuilder.formatScoreboard(state.scores)
       variables["conversation_log"] = promptBuilder.formatConversationLog(
-        state.conversationLog, language: context.scenario.language)
+        state.conversationLog, language: context.scenario.engineLanguage)
       let userPrompt = promptBuilder.expandTemplate(promptTemplate, variables: variables)
 
       let output = try await llmCaller.call(

--- a/Pastura/Pastura/Engine/Phases/SpeakEachHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/SpeakEachHandler.swift
@@ -16,7 +16,7 @@ nonisolated struct SpeakEachHandler: PhaseHandler {
     let promptTemplate =
       context.phase.prompt
       ?? pickLanguage(
-        context.scenario.language,
+        context.scenario.engineLanguage,
         ja: "これまでの会話: {conversation_log}\nあなたの番です。",
         en: "Conversation so far: {conversation_log}\nYour turn.")
 
@@ -31,7 +31,7 @@ nonisolated struct SpeakEachHandler: PhaseHandler {
         var variables = state.variables
         variables["scoreboard"] = promptBuilder.formatScoreboard(state.scores)
         variables["conversation_log"] = promptBuilder.formatConversationLog(
-          state.conversationLog, language: context.scenario.language)
+          state.conversationLog, language: context.scenario.engineLanguage)
         let userPrompt = promptBuilder.expandTemplate(promptTemplate, variables: variables)
 
         let output = try await llmCaller.call(

--- a/Pastura/Pastura/Engine/Phases/SummarizeHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/SummarizeHandler.swift
@@ -14,7 +14,7 @@ nonisolated struct SummarizeHandler: PhaseHandler {
     let template =
       context.phase.template
       ?? pickLanguage(
-        context.scenario.language,
+        context.scenario.engineLanguage,
         ja: "ラウンド {current_round} 完了",
         en: "Round {current_round} complete")
 

--- a/Pastura/Pastura/Engine/Phases/VoteHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/VoteHandler.swift
@@ -16,7 +16,7 @@ nonisolated struct VoteHandler: PhaseHandler {
     let promptTemplate =
       context.phase.prompt
       ?? pickLanguage(
-        context.scenario.language,
+        context.scenario.engineLanguage,
         ja: "最も怪しいと思う人に投票してください。",
         en: "Vote for the person you find most suspicious.")
     let excludeSelf = context.phase.excludeSelf ?? true
@@ -42,7 +42,7 @@ nonisolated struct VoteHandler: PhaseHandler {
       var variables = state.variables
       variables["scoreboard"] = promptBuilder.formatScoreboard(state.scores)
       variables["conversation_log"] = promptBuilder.formatConversationLog(
-        state.conversationLog, language: context.scenario.language)
+        state.conversationLog, language: context.scenario.engineLanguage)
       variables["candidates"] = candidates.joined(separator: ", ")
       let userPrompt = promptBuilder.expandTemplate(promptTemplate, variables: variables)
 

--- a/Pastura/Pastura/Engine/PromptBuilder.swift
+++ b/Pastura/Pastura/Engine/PromptBuilder.swift
@@ -35,7 +35,9 @@ nonisolated struct PromptBuilder: Sendable {
   /// Serializes structured conversation entries into a plain text string for prompt injection.
   ///
   /// Empty-log placeholder is `"（まだなし）"` (ja) / `"(none yet)"` (en),
-  /// chosen via `scenario.language`. ADR-010 D7 Translation Table.
+  /// chosen via the effective Engine language (callers pass
+  /// `scenario.engineLanguage`, ADR-010 D5 / D6 row 1). ADR-010 D7
+  /// Translation Table.
   func formatConversationLog(_ entries: [ConversationEntry], language: String) -> String {
     if entries.isEmpty {
       return pickLanguage(language, ja: "（まだなし）", en: "(none yet)")
@@ -65,7 +67,8 @@ nonisolated struct PromptBuilder: Sendable {
   /// (target-language output, no empty fields, single-line JSON), output
   /// format specification, and phase-specific constraints (options for
   /// choose, candidate list for vote). All user-facing strings dispatch
-  /// on `scenario.language` per ADR-010 D7.
+  /// on `scenario.engineLanguage` per ADR-010 D7 (the override-aware
+  /// resolver defined in D5 / D6 row 1).
   func buildSystemPrompt(
     scenario: Scenario,
     persona: Persona,
@@ -73,7 +76,7 @@ nonisolated struct PromptBuilder: Sendable {
     state: SimulationState
   ) -> String {
     var sections: [String] = []
-    let language = scenario.language
+    let language = scenario.engineLanguage
 
     // Header
     sections.append(
@@ -126,7 +129,7 @@ nonisolated struct PromptBuilder: Sendable {
     phase: Phase,
     state: SimulationState
   ) -> String {
-    let language = scenario.language
+    let language = scenario.engineLanguage
     var rules = pickLanguage(
       language,
       ja: """

--- a/Pastura/Pastura/Engine/ScenarioLoader.swift
+++ b/Pastura/Pastura/Engine/ScenarioLoader.swift
@@ -18,13 +18,6 @@ nonisolated struct ScenarioLoader: Sendable {  // swiftlint:disable:this type_bo
     "agents", "rounds", "context", "personas", "phases"
   ]
 
-  /// Accepted values for `language` (D1) and `simulation_language` (D5).
-  ///
-  /// Engine output dispatch (`Pastura/Pastura/Engine/PromptBuilder.swift` and
-  /// friends) treats `scenario.language` as effectively this set per ADR-010
-  /// Fallback rule — `String` is the storage type, the validator owns the gate.
-  private static let acceptedLanguages: Set<String> = ["ja", "en"]
-
   // MARK: - Loading
 
   /// Parse a YAML string into a ``Scenario`` model.
@@ -172,16 +165,16 @@ nonisolated struct ScenarioLoader: Sendable {  // swiftlint:disable:this type_bo
     let name: String = try parseRequired(dict, key: "name", label: "Scenario")
     let description: String = try parseRequired(dict, key: "description", label: "Scenario")
     let language: String = try parseRequired(dict, key: "language", label: "Scenario")
-    guard Self.acceptedLanguages.contains(language) else {
-      let allowed = Self.acceptedLanguages.sorted().joined(separator: ", ")
+    guard Scenario.acceptedLanguages.contains(language) else {
+      let allowed = Scenario.acceptedLanguages.sorted().joined(separator: ", ")
       throw SimulationError.scenarioValidationFailed(
         "Scenario: field 'language' must be one of {\(allowed)}, got '\(language)'"
       )
     }
     let simulationLanguage: String? = try parseOptional(
       dict, key: "simulation_language", label: "Scenario")
-    if let simulationLanguage, !Self.acceptedLanguages.contains(simulationLanguage) {
-      let allowed = Self.acceptedLanguages.sorted().joined(separator: ", ")
+    if let simulationLanguage, !Scenario.acceptedLanguages.contains(simulationLanguage) {
+      let allowed = Scenario.acceptedLanguages.sorted().joined(separator: ", ")
       throw SimulationError.scenarioValidationFailed(
         "Scenario: field 'simulation_language' must be one of {\(allowed)} or absent, "
           + "got '\(simulationLanguage)'"

--- a/Pastura/Pastura/Engine/ScenarioValidator.swift
+++ b/Pastura/Pastura/Engine/ScenarioValidator.swift
@@ -17,12 +17,6 @@ nonisolated struct ScenarioValidator: Sendable {
     let estimatedInferences: Int
   }
 
-  /// Accepted values for `Scenario.language` and `Scenario.simulationLanguage`
-  /// (ADR-010 D1 / D5). Mirrors `ScenarioLoader`'s private set — kept
-  /// duplicated for layer locality, same intentional parallel as
-  /// `validateConditionalPhase` ↔ `mapPhase`.
-  private static let acceptedLanguages: Set<String> = ["ja", "en"]
-
   /// Validates a scenario against execution limits.
   ///
   /// - Parameter scenario: The scenario to validate.
@@ -31,15 +25,15 @@ nonisolated struct ScenarioValidator: Sendable {
   func validate(_ scenario: Scenario) throws -> ValidationResult {
     // Language values (ADR-010 D1 / D5 — programmatic-construction path
     // gate, mirrors `ScenarioLoader`'s YAML-parse path).
-    if !Self.acceptedLanguages.contains(scenario.language) {
-      let allowed = Self.acceptedLanguages.sorted().joined(separator: ", ")
+    if !Scenario.acceptedLanguages.contains(scenario.language) {
+      let allowed = Scenario.acceptedLanguages.sorted().joined(separator: ", ")
       throw SimulationError.scenarioValidationFailed(
         "Scenario: field 'language' must be one of {\(allowed)}, got '\(scenario.language)'"
       )
     }
     if let simulationLanguage = scenario.simulationLanguage,
-      !Self.acceptedLanguages.contains(simulationLanguage) {
-      let allowed = Self.acceptedLanguages.sorted().joined(separator: ", ")
+      !Scenario.acceptedLanguages.contains(simulationLanguage) {
+      let allowed = Scenario.acceptedLanguages.sorted().joined(separator: ", ")
       throw SimulationError.scenarioValidationFailed(
         "Scenario: field 'simulationLanguage' must be one of {\(allowed)} or nil, "
           + "got '\(simulationLanguage)'"

--- a/Pastura/Pastura/Engine/ScoringLogic/WordwolfJudgeLogic.swift
+++ b/Pastura/Pastura/Engine/ScoringLogic/WordwolfJudgeLogic.swift
@@ -3,9 +3,11 @@ import Foundation
 /// Word wolf judge scoring logic.
 ///
 /// Checks if the most-voted agent matches `state.variables["wolf_name"]`.
-/// Emits a summary describing the result in `scenario.language` (ADR-010
-/// D7 / D8 — scenario-language-bound, so `String(format:)` is used with
-/// literal English / Japanese rather than `String(localized:)`).
+/// Emits a summary describing the result in the caller-supplied effective
+/// Engine language (the caller — `ScoreCalcHandler` — passes
+/// `scenario.engineLanguage`, ADR-010 D5 / D6 row 1). ADR-010 D7 / D8 —
+/// scenario-language-bound, so `String(format:)` is used with literal
+/// English / Japanese rather than `String(localized:)`.
 nonisolated struct WordwolfJudgeLogic: Sendable {
 
   func calculate(

--- a/Pastura/Pastura/Models/Scenario.swift
+++ b/Pastura/Pastura/Models/Scenario.swift
@@ -9,6 +9,15 @@ import Foundation
 /// Scenarios are parsed from YAML via `ScenarioLoader` in the Engine layer
 /// using manual mapping (`Yams.load()` → `[String: Any]`).
 nonisolated public struct Scenario: Codable, Sendable, Equatable {
+  /// Accepted values for ``language`` (D1) and ``simulationLanguage`` (D5).
+  ///
+  /// Single source of truth — both ``ScenarioLoader`` (YAML path) and
+  /// ``ScenarioValidator`` (programmatic-construction path) gate against
+  /// this set. Adding a third language (Phase 3+) is new-ADR scope per
+  /// ADR-010 Out-of-Scope; extending this set is the first concrete step
+  /// but never sufficient on its own.
+  public static let acceptedLanguages: Set<String> = ["ja", "en"]
+
   /// Unique identifier for the scenario (from YAML `id` field).
   public let id: String
 

--- a/Pastura/Pastura/Models/Scenario.swift
+++ b/Pastura/Pastura/Models/Scenario.swift
@@ -38,11 +38,38 @@ nonisolated public struct Scenario: Codable, Sendable, Equatable {
 
   /// Optional Engine override language for cross-language simulation.
   ///
-  /// When non-nil, Step E will use this to drive Engine output instead of
-  /// ``language`` — enabling "run an `en` scenario on a `ja` device with
-  /// `simulation_language: ja`." Parsed and validated in Step C-1, but
-  /// **not propagated to the Engine until Step E**. See ADR-010 D5.
+  /// When non-nil, the Engine reads from this instead of ``language`` —
+  /// enabling "run an `en` scenario on a `ja` device with
+  /// `simulation_language: ja`." Resolved via ``engineLanguage`` at every
+  /// Engine site; never read directly outside that single resolve point.
+  /// See ADR-010 D5.
   public let simulationLanguage: String?
+
+  /// Engine-consumer resolver for cross-language simulation (ADR-010 D6
+  /// row 1). Returns ``simulationLanguage`` when set, falling through to
+  /// ``language`` otherwise.
+  ///
+  /// **Do not use as a generic resolver.** D6 defines four consumer rows,
+  /// each with its own resolver:
+  ///
+  /// - **Engine** (prompt / scoring / default text): `engineLanguage`
+  ///   (this property)
+  /// - **New scenario creation seed** (Editor): `LocaleResolver.deviceDefault()`
+  /// - **Preset / gallery initial selection** (picker): `LocaleResolver.deviceDefault()`
+  /// - **UI shell** (`Localizable.xcstrings`): `Bundle.main.preferredLocalizations`
+  ///
+  /// UI / Editor / Picker callsites **MUST** continue using their own D6
+  /// resolvers; reading ``engineLanguage`` from those layers silently
+  /// bypasses device-locale priority. Two Engine-adjacent sites also
+  /// stay on ``language`` (authoring axis), not ``engineLanguage``
+  /// (runtime axis):
+  ///
+  /// - ``ScenarioValidator`` validates the authoring `language` field.
+  /// - ``ScenarioSerializer`` writes the authoring `language` back to YAML.
+  ///
+  /// `scripts/check_engine_language_axis.sh` enforces the Engine-side
+  /// boundary in CI; cross-layer misuse is caught by code review.
+  public var engineLanguage: String { simulationLanguage ?? language }
 
   /// Expected number of agents. Must match `personas.count`.
   public let agentCount: Int

--- a/Pastura/PasturaTests/Engine/EnginePathLanguageTests.swift
+++ b/Pastura/PasturaTests/Engine/EnginePathLanguageTests.swift
@@ -161,14 +161,13 @@ struct EnginePathLanguageTests {
     #expect(!hasJapanese, "English prompt must not contain Japanese codepoints: \(prompt)")
   }
 
-  // MARK: - simulationLanguage does NOT affect Engine in C-1 (DoD #6 boundary, Step E)
+  // MARK: - simulationLanguage override drives PromptBuilder (ADR-010 D5 / D6 row 1)
 
-  @Test func promptBuilderIgnoresSimulationLanguageInC1() {
-    // Build with language: "ja", simulationLanguage: "en".
-    // Engine MUST still emit Japanese (simulationLanguage wiring deferred to Step E).
+  /// Helper: build a prompt for an arbitrary `(language, simulationLanguage)` pair.
+  private func makeOverridePrompt(language: String, simulationLanguage: String?) -> String {
     let scenario = ScenarioFixture.make(
-      language: "ja",
-      simulationLanguage: "en",
+      language: language,
+      simulationLanguage: simulationLanguage,
       phases: [
         Phase(
           type: .speakAll,
@@ -179,13 +178,42 @@ struct EnginePathLanguageTests {
     let persona = scenario.personas[0]
     let phase = scenario.phases[0]
     let state = SimulationState.initial(for: scenario)
-    let prompt = PromptBuilder().buildSystemPrompt(
+    return PromptBuilder().buildSystemPrompt(
       scenario: scenario, persona: persona, phase: phase, state: state)
+  }
 
-    // Must contain Japanese (language: "ja" drives Engine in C-1)
+  /// Canonical Step E case: a Japanese-authored scenario rendered in English via
+  /// `simulation_language: en`. Engine MUST emit English; Japanese MUST be absent.
+  @Test func promptBuilderHonorsSimulationLanguageOverrideJaToEn() {
+    let prompt = makeOverridePrompt(language: "ja", simulationLanguage: "en")
+    #expect(prompt.contains("You are a participant in a simulation"))
+    #expect(prompt.contains("## Scenario"))
+    #expect(!prompt.contains("あなたはシミュレーション"))
+    #expect(!prompt.contains("## シナリオ"))
+  }
+
+  /// Reverse direction: English-authored scenario rendered in Japanese via
+  /// `simulation_language: ja`.
+  @Test func promptBuilderHonorsSimulationLanguageOverrideEnToJa() {
+    let prompt = makeOverridePrompt(language: "en", simulationLanguage: "ja")
     #expect(prompt.contains("あなたはシミュレーション"))
-    // Must NOT contain English header (simulationLanguage not yet wired)
+    #expect(prompt.contains("## シナリオ"))
     #expect(!prompt.contains("You are a participant in a simulation"))
+    #expect(!prompt.contains("## Scenario"))
+  }
+
+  /// Regression guard: with no override, `language` still drives the Engine.
+  /// Without this, an `engineLanguage` implementation that always read
+  /// `simulationLanguage` (forgetting the `?? language` fallback) would
+  /// pass the override tests but silently break every existing scenario.
+  @Test func promptBuilderFallsThroughToLanguageWhenSimulationLanguageNil() {
+    let jaPrompt = makeOverridePrompt(language: "ja", simulationLanguage: nil)
+    #expect(jaPrompt.contains("あなたはシミュレーション"))
+    #expect(!jaPrompt.contains("You are a participant in a simulation"))
+
+    let enPrompt = makeOverridePrompt(language: "en", simulationLanguage: nil)
+    #expect(enPrompt.contains("You are a participant in a simulation"))
+    #expect(!enPrompt.contains("あなたはシミュレーション"))
   }
 }
 

--- a/Pastura/PasturaTests/Engine/Phases/ChooseHandlerTests.swift
+++ b/Pastura/PasturaTests/Engine/Phases/ChooseHandlerTests.swift
@@ -170,4 +170,77 @@ struct ChooseHandlerTests {
     // No pairings in individual mode
     #expect(state.pairings.isEmpty)
   }
+
+  // MARK: - simulationLanguage override (ADR-010 Step E)
+
+  @Test func chooseHonorsSimulationLanguageOverride_jaToEn() async throws {
+    // Scenario: ja authoring, en simulation override. prompt:nil forces fallback.
+    // The captured prompt must contain the English fallback, not the Japanese one.
+    let mock = MockLLMService(responses: [
+      #"{"action": "cooperate"}"#,
+      #"{"action": "betray"}"#
+    ])
+    try await mock.loadModel()
+
+    let scenario = ScenarioFixture.make(
+      language: "ja",
+      simulationLanguage: "en",
+      personas: [
+        Persona(name: "Alice", description: "A test persona"),
+        Persona(name: "Bob", description: "A test persona")
+      ],
+      phases: [
+        Phase(
+          type: .choose, prompt: nil,
+          outputSchema: ["action": "string"],
+          options: ["cooperate", "betray"]
+        )
+      ]
+    )
+    var state = SimulationState.initial(for: scenario)
+    state.currentRound = 1
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    let prompt = mock.capturedPrompts[0].user
+    #expect(prompt.contains("Make a choice"))
+    #expect(!prompt.contains("選択してください"))
+  }
+
+  @Test func chooseHonorsSimulationLanguageOverride_enToJa() async throws {
+    // Reverse: en authoring, ja simulation override. Captured prompt must contain Japanese.
+    let mock = MockLLMService(responses: [
+      #"{"action": "cooperate"}"#,
+      #"{"action": "betray"}"#
+    ])
+    try await mock.loadModel()
+
+    let scenario = ScenarioFixture.make(
+      language: "en",
+      simulationLanguage: "ja",
+      personas: [
+        Persona(name: "Alice", description: "A test persona"),
+        Persona(name: "Bob", description: "A test persona")
+      ],
+      phases: [
+        Phase(
+          type: .choose, prompt: nil,
+          outputSchema: ["action": "string"],
+          options: ["cooperate", "betray"]
+        )
+      ]
+    )
+    var state = SimulationState.initial(for: scenario)
+    state.currentRound = 1
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    let prompt = mock.capturedPrompts[0].user
+    #expect(prompt.contains("選択してください"))
+    #expect(!prompt.contains("Make a choice"))
+  }
 }

--- a/Pastura/PasturaTests/Engine/Phases/SpeakAllHandlerTests.swift
+++ b/Pastura/PasturaTests/Engine/Phases/SpeakAllHandlerTests.swift
@@ -116,4 +116,65 @@ struct SpeakAllHandlerTests {
 
     #expect(state.lastOutputs["Alice"]?.statement == "test output")
   }
+
+  // MARK: - simulationLanguage override (ADR-010 Step E)
+
+  @Test func speakAllHonorsSimulationLanguageOverride_jaToEn() async throws {
+    // Scenario: ja authoring, en simulation override. prompt:nil forces fallback.
+    // The captured prompt must contain the English fallback, not the Japanese one.
+    let mock = MockLLMService(responses: [
+      #"{"statement": "hello"}"#,
+      #"{"statement": "world"}"#
+    ])
+    try await mock.loadModel()
+
+    let scenario = ScenarioFixture.make(
+      language: "ja",
+      simulationLanguage: "en",
+      personas: [
+        Persona(name: "Alice", description: "A test persona"),
+        Persona(name: "Bob", description: "A test persona")
+      ],
+      phases: [Phase(type: .speakAll, prompt: nil, outputSchema: ["statement": "string"])]
+    )
+    var state = SimulationState.initial(for: scenario)
+    state.currentRound = 1
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    let prompt = mock.capturedPrompts[0].user
+    #expect(prompt.contains("Share your opinion"))
+    #expect(!prompt.contains("あなたの意見"))
+  }
+
+  @Test func speakAllHonorsSimulationLanguageOverride_enToJa() async throws {
+    // Reverse: en authoring, ja simulation override. Captured prompt must contain Japanese.
+    let mock = MockLLMService(responses: [
+      #"{"statement": "hello"}"#,
+      #"{"statement": "world"}"#
+    ])
+    try await mock.loadModel()
+
+    let scenario = ScenarioFixture.make(
+      language: "en",
+      simulationLanguage: "ja",
+      personas: [
+        Persona(name: "Alice", description: "A test persona"),
+        Persona(name: "Bob", description: "A test persona")
+      ],
+      phases: [Phase(type: .speakAll, prompt: nil, outputSchema: ["statement": "string"])]
+    )
+    var state = SimulationState.initial(for: scenario)
+    state.currentRound = 1
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    let prompt = mock.capturedPrompts[0].user
+    #expect(prompt.contains("あなたの意見"))
+    #expect(!prompt.contains("Share your opinion"))
+  }
 }

--- a/Pastura/PasturaTests/Engine/Phases/SpeakEachHandlerTests.swift
+++ b/Pastura/PasturaTests/Engine/Phases/SpeakEachHandlerTests.swift
@@ -107,4 +107,65 @@ struct SpeakEachHandlerTests {
 
     #expect(mock.generateCallCount == 1)
   }
+
+  // MARK: - simulationLanguage override (ADR-010 Step E)
+
+  @Test func speakEachHonorsSimulationLanguageOverride_jaToEn() async throws {
+    // Scenario: ja authoring, en simulation override. prompt:nil forces fallback.
+    // The captured prompt must contain the English fallback, not the Japanese one.
+    let mock = MockLLMService(responses: [
+      #"{"statement": "hello"}"#,
+      #"{"statement": "world"}"#
+    ])
+    try await mock.loadModel()
+
+    let scenario = ScenarioFixture.make(
+      language: "ja",
+      simulationLanguage: "en",
+      personas: [
+        Persona(name: "Alice", description: "A test persona"),
+        Persona(name: "Bob", description: "A test persona")
+      ],
+      phases: [Phase(type: .speakEach, prompt: nil, outputSchema: ["statement": "string"])]
+    )
+    var state = SimulationState.initial(for: scenario)
+    state.currentRound = 1
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    let prompt = mock.capturedPrompts[0].user
+    #expect(prompt.contains("Conversation so far"))
+    #expect(!prompt.contains("これまでの会話"))
+  }
+
+  @Test func speakEachHonorsSimulationLanguageOverride_enToJa() async throws {
+    // Reverse: en authoring, ja simulation override. Captured prompt must contain Japanese.
+    let mock = MockLLMService(responses: [
+      #"{"statement": "hello"}"#,
+      #"{"statement": "world"}"#
+    ])
+    try await mock.loadModel()
+
+    let scenario = ScenarioFixture.make(
+      language: "en",
+      simulationLanguage: "ja",
+      personas: [
+        Persona(name: "Alice", description: "A test persona"),
+        Persona(name: "Bob", description: "A test persona")
+      ],
+      phases: [Phase(type: .speakEach, prompt: nil, outputSchema: ["statement": "string"])]
+    )
+    var state = SimulationState.initial(for: scenario)
+    state.currentRound = 1
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    let prompt = mock.capturedPrompts[0].user
+    #expect(prompt.contains("これまでの会話"))
+    #expect(!prompt.contains("Conversation so far"))
+  }
 }

--- a/Pastura/PasturaTests/Engine/Phases/SummarizeHandlerTests.swift
+++ b/Pastura/PasturaTests/Engine/Phases/SummarizeHandlerTests.swift
@@ -190,4 +190,55 @@ struct SummarizeHandlerTests {
     #expect(summaries.count == 1)
     #expect(summaries[0] == "Alice(cooperate)")
   }
+
+  // MARK: - simulationLanguage override (ADR-010 Step E)
+
+  @Test func summarizeHonorsSimulationLanguageOverride_jaToEn() async throws {
+    // Scenario: ja authoring, en simulation override. template:nil forces fallback.
+    // After {current_round} expansion, the summary must contain the English fallback.
+    let mock = MockLLMService(responses: [])
+    let scenario = ScenarioFixture.make(
+      language: "ja",
+      simulationLanguage: "en",
+      phases: [Phase(type: .summarize, template: nil)]
+    )
+    var state = SimulationState.initial(for: scenario)
+    state.currentRound = 2
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    let summaries = collector.events.compactMap { event -> String? in
+      if case .summary(let text) = event { return text }
+      return nil
+    }
+    #expect(summaries.count == 1)
+    #expect(summaries[0].contains("Round"))
+    #expect(!summaries[0].contains("ラウンド"))
+  }
+
+  @Test func summarizeHonorsSimulationLanguageOverride_enToJa() async throws {
+    // Reverse: en authoring, ja simulation override. Summary must contain Japanese.
+    let mock = MockLLMService(responses: [])
+    let scenario = ScenarioFixture.make(
+      language: "en",
+      simulationLanguage: "ja",
+      phases: [Phase(type: .summarize, template: nil)]
+    )
+    var state = SimulationState.initial(for: scenario)
+    state.currentRound = 2
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    let summaries = collector.events.compactMap { event -> String? in
+      if case .summary(let text) = event { return text }
+      return nil
+    }
+    #expect(summaries.count == 1)
+    #expect(summaries[0].contains("ラウンド"))
+    #expect(!summaries[0].contains("Round"))
+  }
 }

--- a/Pastura/PasturaTests/Engine/Phases/VoteHandlerTests.swift
+++ b/Pastura/PasturaTests/Engine/Phases/VoteHandlerTests.swift
@@ -127,4 +127,65 @@ struct VoteHandlerTests {
     #expect(state.voteResults["NonExistent"] == 1)
     #expect(state.voteResults["Alice"] == 1)
   }
+
+  // MARK: - simulationLanguage override (ADR-010 Step E)
+
+  @Test func voteHonorsSimulationLanguageOverride_jaToEn() async throws {
+    // Scenario: ja authoring, en simulation override. prompt:nil forces fallback.
+    // The captured prompt must contain the English fallback, not the Japanese one.
+    let mock = MockLLMService(responses: [
+      #"{"vote": "Bob"}"#,
+      #"{"vote": "Alice"}"#
+    ])
+    try await mock.loadModel()
+
+    let scenario = ScenarioFixture.make(
+      language: "ja",
+      simulationLanguage: "en",
+      personas: [
+        Persona(name: "Alice", description: "A test persona"),
+        Persona(name: "Bob", description: "A test persona")
+      ],
+      phases: [Phase(type: .vote, prompt: nil, outputSchema: ["vote": "string"])]
+    )
+    var state = SimulationState.initial(for: scenario)
+    state.currentRound = 1
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    let prompt = mock.capturedPrompts[0].user
+    #expect(prompt.contains("Vote for the person"))
+    #expect(!prompt.contains("最も怪しい"))
+  }
+
+  @Test func voteHonorsSimulationLanguageOverride_enToJa() async throws {
+    // Reverse: en authoring, ja simulation override. Captured prompt must contain Japanese.
+    let mock = MockLLMService(responses: [
+      #"{"vote": "Bob"}"#,
+      #"{"vote": "Alice"}"#
+    ])
+    try await mock.loadModel()
+
+    let scenario = ScenarioFixture.make(
+      language: "en",
+      simulationLanguage: "ja",
+      personas: [
+        Persona(name: "Alice", description: "A test persona"),
+        Persona(name: "Bob", description: "A test persona")
+      ],
+      phases: [Phase(type: .vote, prompt: nil, outputSchema: ["vote": "string"])]
+    )
+    var state = SimulationState.initial(for: scenario)
+    state.currentRound = 1
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    let prompt = mock.capturedPrompts[0].user
+    #expect(prompt.contains("最も怪しい"))
+    #expect(!prompt.contains("Vote for the person"))
+  }
 }

--- a/Pastura/PasturaTests/Engine/ScoringLogic/WordwolfJudgeLogicTests.swift
+++ b/Pastura/PasturaTests/Engine/ScoringLogic/WordwolfJudgeLogicTests.swift
@@ -43,4 +43,36 @@ struct WordwolfJudgeLogicTests {
     }
     #expect(summaries[0].contains("投票結果がありません"))
   }
+
+  // MARK: - English language path (ADR-010 Step E)
+
+  @Test func majorityWinsInEnglish() {
+    var state = SimulationState()
+    state.voteResults = ["Wolf": 3, "Other": 1]
+    state.variables["wolf_name"] = "Wolf"
+    let collector = EventCollector()
+    logic.calculate(state: &state, language: "en", emitter: collector.emit)
+    let summaries = collector.events.compactMap { event -> String? in
+      if case .summary(let text) = event { return text }
+      return nil
+    }
+    #expect(summaries.count == 1)
+    #expect(summaries[0].contains("Majority wins"))
+    #expect(!summaries[0].contains("多数派の勝ち"))
+  }
+
+  @Test func wolfWinsInEnglish() {
+    var state = SimulationState()
+    state.voteResults = ["Innocent": 3, "Wolf": 1]
+    state.variables["wolf_name"] = "Wolf"
+    let collector = EventCollector()
+    logic.calculate(state: &state, language: "en", emitter: collector.emit)
+    let summaries = collector.events.compactMap { event -> String? in
+      if case .summary(let text) = event { return text }
+      return nil
+    }
+    #expect(summaries.count == 1)
+    #expect(summaries[0].contains("The wolf wins"))
+    #expect(!summaries[0].contains("ウルフの勝ち"))
+  }
 }

--- a/Pastura/PasturaTests/Models/ScenarioTests.swift
+++ b/Pastura/PasturaTests/Models/ScenarioTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+/// Unit tests for the pure-logic surface of ``Scenario``.
+///
+/// ``Scenario.engineLanguage`` is the single Engine-consumer resolver
+/// per ADR-010 D5 + D6 row 1 — the override Site E PR1 wires through
+/// PromptBuilder / phase handlers / scoring summaries. These tests
+/// pin the precedence shape (`simulationLanguage ?? language`) so
+/// future amendments must update both the property and the tests
+/// together.
+@Suite(.timeLimit(.minutes(1)))
+struct ScenarioTests {
+
+  // MARK: - engineLanguage precedence (ADR-010 D5 / D6 row 1)
+
+  @Test func engineLanguageReturnsLanguageWhenSimulationLanguageNil() {
+    let scenario = ScenarioFixture.make(language: "ja", simulationLanguage: nil)
+    #expect(scenario.engineLanguage == "ja")
+  }
+
+  @Test func engineLanguageReturnsLanguageWhenSimulationLanguageNilEn() {
+    let scenario = ScenarioFixture.make(language: "en", simulationLanguage: nil)
+    #expect(scenario.engineLanguage == "en")
+  }
+
+  @Test func engineLanguageOverridesWhenSimulationLanguageSet() {
+    // The canonical Step E case: en scenario rendered in ja for cross-language sim.
+    let scenario = ScenarioFixture.make(language: "en", simulationLanguage: "ja")
+    #expect(scenario.engineLanguage == "ja")
+  }
+
+  @Test func engineLanguageOverridesReverse() {
+    let scenario = ScenarioFixture.make(language: "ja", simulationLanguage: "en")
+    #expect(scenario.engineLanguage == "en")
+  }
+
+  // MARK: - acceptedLanguages contract (ADR-010 D1)
+
+  @Test func acceptedLanguagesPinsJaAndEn() {
+    #expect(Scenario.acceptedLanguages == ["ja", "en"])
+  }
+}

--- a/docs/decisions/ADR-010.md
+++ b/docs/decisions/ADR-010.md
@@ -170,31 +170,71 @@ This reuses the column that the inline doc on
 `ScenarioRecord.swift:30-34` already named for "future namespacing
 schemes or multi-source provenance" — D4 makes that future concrete.
 
-### D5. `simulation_language` schema — definition only, Engine wiring deferred to Step E
+### D5. `simulation_language` schema + Engine wiring via `Scenario.engineLanguage`
 
-**(closes stub Open Question)** `simulation_language` is parsed and
-schema-validated in Step C-1 but **not passed to the Engine** until
-Step E. Storage shape: an optional sibling on `Scenario` —
-`public let simulationLanguage: String?` — accepting `"ja"`, `"en"`,
-or absent (`nil`).
+**(closes stub Open Question; Engine wiring implemented in Step E PR1)**
+`simulation_language` is parsed and schema-validated in Step C-1 and
+**propagated to the Engine in Step E PR1**. Storage shape: an optional
+sibling on `Scenario` — `public let simulationLanguage: String?` —
+accepting `"ja"`, `"en"`, or absent (`nil`).
 
-Step C-1 loader behavior:
+Step C-1 loader behavior (shipped in PR #383):
 - Parse top-level YAML key `simulation_language` if present.
 - Validate against `{ja, en, nil}`; reject other values with a
   `SimulationError` matching the existing validation idiom.
 - Store on `Scenario.simulationLanguage`.
-- **Do not propagate to PromptBuilder / Handlers** — the Engine's
-  language is `scenario.language` only.
 
-Step E will wire the override at the Engine entry point: when
-`simulationLanguage != nil`, prompt generation and default fallbacks
-use it instead of `scenario.language`, enabling "run an `en` scenario
-on a `ja` device with `simulation_language: ja` for cross-language
-output validation."
+Step E PR1 Engine wiring:
 
-The field exists in the schema in C-1 (not just docs) so that the YAML
-loader does not reject it as unknown — preventing a forward-compat
-break when Step E adds wiring.
+The override resolves at a **single Models-layer point**:
+
+```swift
+extension Scenario {
+  /// Engine-consumer resolver per D6 row 1.
+  public var engineLanguage: String { simulationLanguage ?? language }
+}
+```
+
+Every Engine site in the D7 Translation Table reads
+`scenario.engineLanguage` (or `context.scenario.engineLanguage` from
+inside a `PhaseHandler`) instead of `scenario.language`. The previous
+`scenario.language` reads in `PromptBuilder`, the 6 LLM phase handlers,
+`ScoreCalcHandler`, and `WordwolfJudgeLogic` flip to
+`engineLanguage` in PR1.
+
+The resolver is named `engineLanguage` (not `effectiveLanguage`) to
+encode single-consumer scope in the name — D6 has four consumer rows,
+each with a different resolver, and a generic `effectiveLanguage`
+would invite misuse from UI / Editor / Picker callsites that **must**
+continue using their own D6 resolvers (device locale-derived,
+preset-variant selection, etc.).
+
+Two authoring-axis Engine sites are intentionally **excluded** from
+the rename and continue reading `scenario.language` directly:
+
+- `ScenarioValidator` validates the **authoring** language field —
+  the `simulation_language` override has its own validator path and
+  doesn't substitute for `language` in validation.
+- `ScenarioSerializer` writes the authoring `language` field back to
+  YAML — round-tripping must preserve the file's declared language,
+  not the runtime override.
+
+A CI script (`scripts/check_engine_language_axis.sh`) verifies that
+no Engine file outside the two authoring-axis allow-listed sites uses
+`scenario.language` / `context.scenario.language` in `pickLanguage(`
+or `formatConversationLog(language:` argument position. The script
+locks D8's Engine-deps guarantee + this D5 wiring into a CI-checked
+shape rather than relying on PR-review-only enforcement.
+
+**D8 invariant preserved**: `Scenario.engineLanguage` is a pure
+`String`-typed computed property; resolving it imports zero
+`Foundation.Bundle` / `Foundation.Locale` / `LocaleResolver` symbols.
+Engine continues to read only `Scenario` fields.
+
+LLM output-language **adherence enforcement** (the LLM actually
+*emits* in the requested language) remains Out-of-Scope in PR1; it
+ships in Step E PR2 alongside the `LanguageDetector` protocol +
+benchmark harness + measurable DoD thresholds.
 
 ### D6. Language resolution priority — scoped by consumer
 

--- a/scripts/check_engine_language_axis.sh
+++ b/scripts/check_engine_language_axis.sh
@@ -48,11 +48,14 @@ EXCLUDES=(
   --exclude=ScenarioSerializer.swift
 )
 
-# Find every matching line, then filter out `///` doc-comment lines.
+# Find every matching line, then filter out comment-only lines.
 # `grep -E` output is `path:line:content`; we look for `:` then optional
-# whitespace then `///` to skip those.
+# whitespace then `//` (covers both `///` doc-comments and regular `//`
+# inline notes that legitimately mention the authoring field). Lines
+# where code precedes the comment (`let x = scenario.language  // ...`)
+# do NOT match this filter, so they still trip the guard as intended.
 raw=$(grep -rEn "${EXCLUDES[@]}" "$PATTERN" "$ENGINE_DIR" 2>/dev/null || true)
-violations=$(printf '%s\n' "$raw" | grep -vE ':[[:space:]]*///' || true)
+violations=$(printf '%s\n' "$raw" | grep -vE ':[[:space:]]*//' || true)
 
 # Trim a stray empty line so `-n "$violations"` is reliable.
 violations=$(printf '%s' "$violations" | sed '/^$/d')

--- a/scripts/check_engine_language_axis.sh
+++ b/scripts/check_engine_language_axis.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# check_engine_language_axis.sh — ADR-010 D5 / D8 Engine boundary guard.
+#
+# Engine output-language dispatch reads `scenario.engineLanguage`
+# (= `simulationLanguage ?? language`), NOT `scenario.language` directly.
+# Reading `scenario.language` at a dispatch callsite silently breaks the
+# `simulation_language` override — the regression this script blocks.
+#
+# Allow-list (authoring-axis files — they intentionally read `.language`):
+#   - ScenarioValidator.swift: validates the authoring `language` field
+#   - ScenarioSerializer.swift: writes the authoring `language` to YAML
+#
+# Rule: under Pastura/Pastura/Engine/, every code reference to
+# `scenario.language` outside the allow-list is a violation. Doc-comment
+# lines (`///` prefix) are excluded — they describe the field at the
+# Models layer in passing and are not dispatch sites.
+#
+# The check is intentionally line-oriented for grep portability; this
+# also means a multi-line `pickLanguage(\n  scenario.language, ...)` is
+# caught at the `scenario.language` line itself rather than at the call
+# helper. Either match shape would trip the same regression.
+#
+# Exit codes: 0 clean, 1 violation, 2 misuse.
+#
+# Reference: docs/decisions/ADR-010.md § D5, D6 row 1, D7, D8.
+
+set -euo pipefail
+
+if [[ "${1-}" == "--help" || "${1-}" == "-h" ]]; then
+  sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+  exit 0
+fi
+
+ENGINE_DIR="Pastura/Pastura/Engine"
+if [[ ! -d "$ENGINE_DIR" ]]; then
+  echo "error: $ENGINE_DIR not found — run from the repo root." >&2
+  exit 2
+fi
+
+# Match `scenario.language` with word boundaries so `scenario.languageCode`
+# (hypothetical future field) does not trip the check.
+PATTERN='\bscenario\.language\b'
+
+# Allow-listed filenames (just the basename — grep's --exclude matches that).
+EXCLUDES=(
+  --exclude=ScenarioValidator.swift
+  --exclude=ScenarioSerializer.swift
+)
+
+# Find every matching line, then filter out `///` doc-comment lines.
+# `grep -E` output is `path:line:content`; we look for `:` then optional
+# whitespace then `///` to skip those.
+raw=$(grep -rEn "${EXCLUDES[@]}" "$PATTERN" "$ENGINE_DIR" 2>/dev/null || true)
+violations=$(printf '%s\n' "$raw" | grep -vE ':[[:space:]]*///' || true)
+
+# Trim a stray empty line so `-n "$violations"` is reliable.
+violations=$(printf '%s' "$violations" | sed '/^$/d')
+
+if [[ -n "$violations" ]]; then
+  cat >&2 <<EOF
+❌ ADR-010 D5 / D8 violation: Engine code reads scenario.language at a
+   non-doc-comment position outside the authoring-axis allow-list.
+   Use scenario.engineLanguage (or context.scenario.engineLanguage from
+   inside a PhaseHandler) so the simulation_language override propagates
+   per D6 row 1.
+
+   See docs/decisions/ADR-010.md § D5, D7, D8 for the rule and rationale.
+
+EOF
+  echo "$violations" >&2
+  cat >&2 <<EOF
+
+If the new usage is authoring-axis (validating or serializing the
+declared 'language' field, not selecting Engine output language), add
+the file to the EXCLUDES array in this script with a comment explaining
+why the authoring axis applies.
+EOF
+  exit 1
+fi
+
+echo "✓ Engine language-axis dispatch clean ($ENGINE_DIR; allow-list: ScenarioValidator, ScenarioSerializer)."


### PR DESCRIPTION
## Summary

Wires the ADR-010 D5 `simulation_language` override into the Engine. Step C-1 (#383) parses + validates the schema on `Scenario.simulationLanguage: String?`, but the field has been a no-op at runtime — this PR makes it actually flip Engine output.

- New `Scenario.engineLanguage` Models-layer computed property — the **single Engine-consumer resolver** per D6 row 1 (`simulationLanguage ?? language`). Load-bearing doc-comment spells out all four D6 consumer rows + the two authoring-axis allow-listed sites (`ScenarioValidator` / `ScenarioSerializer`).
- `scenario.language` → `scenario.engineLanguage` flipped at every D7 Translation Table dispatch site: 2 sites in `PromptBuilder`, 6 phase handlers (`SpeakAll`, `SpeakEach`, `Vote`, `Choose`, `Summarize`, `ScoreCalc`), and `WordwolfJudgeLogic` (via its caller).
- `acceptedLanguages` set hoisted from duplicate `private static` in `ScenarioLoader` + `ScenarioValidator` to a single `Scenario.acceptedLanguages` (Models, `public static`).
- New CI guard `scripts/check_engine_language_axis.sh` (ADR-010 D5 / D8) blocks future regressions of the `scenario.language` → dispatch antipattern. Wired into `.github/workflows/ci.yml` as `engine-language-axis`. Self-tested: clean → 0, multi-line `pickLanguage(\n  context.scenario.language, ...)` regression → 1 with clear message.
- ADR-010 D5 in-place edit (per memory `feedback_adr_editability_window`): "Engine wiring deferred to Step E" replaced with the implementation contract.

## Step E PR split — what's NOT in this PR

PR2 (follow-up) will add LLM output-language **adherence enforcement** + benchmark harness:

- `LanguageDetector` protocol + Apple `NLLanguageRecognizer` impl (App layer per D8 boundary)
- `LLMCaller` retry-on-mismatch + new `SimulationEvent.languageMismatch` warning case
- `LanguageAdherenceBenchmark` test target gated on `LANGUAGE_ADHERENCE_BENCHMARK=1` env var
- ADR-010 Out-of-Scope / DoD in-place edit (lock N / M thresholds + detector spec)

Also explicitly deferred:

- Past Results cross-language consumer (#392) — independent UX + Repository design cycle; schema invariant already pinned in PR #388.
- `ScenarioRecord` / `SimulationRecord` `language` column — no GRDB v3; no current Past Results consumer reads language.

## Why E-1 ships before E-2's adherence enforcement

- Verified zero shipped YAML sets `simulation_language` — bundled presets / gallery / demo replays use sibling-file `_en` / `_ja` per D3, not the override. `grep -r "simulation_language" Pastura/Pastura/Resources docs/gallery` → no hits.
- Install-base ≈ 0 per memory `project_pastura_distribution_status` (Apple Developer Program 未登録, TestFlight install reset already required between Phase 1 → Phase 2).
- Without the detector, output-language adherence is best-effort — see ADR-010 Out-of-Scope L721. Best-effort is acceptable for E-1 because no production scenario exercises the override yet.

## Critic findings (Step 1b) — all addressed inline

- **Axis 2** → named `engineLanguage` (not `effectiveLanguage`) to encode single-consumer scope.
- **Axis 3** → doc-comments updated in `PromptBuilder`, `LanguageDispatch`, `WordwolfJudgeLogic`.
- **Axis 4** → CI guard script (item 6).
- **Axis 6** → flipped test renamed (no `InStepE` ADR-step labeling); symmetric `_jaToEn` + `_enToJa` per handler; nil-override regression guard.
- **Axis 1 + 7** → these PR body notes.

## Code-reviewer (Opus) verdict

PASS — 0 critical, 0 warnings, 1 suggestion landed (script comment-filter widened from `///` to `//`), 1 skipped (test parameterization, aesthetic-only).

## Test plan

- [x] `scripts/xcodebuild.sh test -skip-testing:PasturaUITests` → 1634 tests / 145 suites passed.
- [x] `swiftlint lint --quiet --strict` → clean (config warning unchanged from main).
- [x] `bash scripts/check_engine_language_axis.sh` → 0 (clean state).
- [x] Self-test injection of `context.scenario.engineLanguage` → `context.scenario.language` regression → script exits 1 with named callsite + remediation message.
- [x] New cross-language regression tests fail without the rename, pass with it (TDD red→green verified per commit).
- [x] CI must show new `engine-language-axis` job green alongside existing drift guards.

## Related

See #397.

- ADR-010 — D1, D5, D6 row 1, D7 Translation Table, D8 Engine deps guarantee, Out-of-Scope L715-733
- ROADMAP § "Localization Plan" Step E
- Step C-1: PR #383 (Engine dynamic localization). Step D: PR #393 (EN bundled presets + DL Demo Replays + locale-driven runtime selection).
- Deferred follow-ups: #392 (Past Results cross-language consumer), Step E PR2 (detector + benchmark).

🤖 Generated with [Claude Code](https://claude.com/claude-code)