### PR TITLE
🌐 feat(settings): localize Privacy Policy link by UI shell locale

### DIFF
--- a/Pastura/Pastura/Views/Settings/SettingsView.swift
+++ b/Pastura/Pastura/Views/Settings/SettingsView.swift
@@ -73,8 +73,7 @@ struct SettingsView: View {
       #endif
       Section {
         Button {
-          guard let url = URL(string: "https://pastura.app/legal/privacy-policy/")
-          else { return }
+          guard let url = localizedPrivacyPolicyURL() else { return }
           openURL(url)
         } label: {
           HStack {
@@ -306,4 +305,29 @@ struct SettingsView: View {
       dependencies.regenerateLLMService(newService)
     }
   #endif
+}
+
+/// Returns the Privacy Policy URL appropriate for the device's UI shell locale.
+///
+/// Per ADR-010 D6, the UI-shell consumer reads `Bundle.main.preferredLocalizations`
+/// directly (Apple's standard `String(localized:)` resolution). `LocaleResolver` is
+/// deliberately NOT used here: its D2 scope is new-data creation seeds and
+/// multi-variant selection of stored content, not external URL routing for the
+/// shell itself. Routing the Privacy Policy link via `Bundle.main.preferredLocalizations`
+/// keeps `LocaleResolver`'s narrow D2 scope intact and matches the D6 prescription.
+///
+/// Japanese (`"ja"`) routes to `https://pastura.app/ja/legal/privacy-policy/`
+/// (mirrored at `pages/ja/legal/privacy-policy/`); every other locale falls
+/// through to the English page at `https://pastura.app/legal/privacy-policy/`.
+///
+/// - Parameter preferredLocalizations: Injectable for unit tests. Production callers
+///   pass `Bundle.main.preferredLocalizations` (the default).
+internal func localizedPrivacyPolicyURL(
+  preferredLocalizations: [String] = Bundle.main.preferredLocalizations
+) -> URL? {
+  let path =
+    preferredLocalizations.first == "ja"
+    ? "https://pastura.app/ja/legal/privacy-policy/"
+    : "https://pastura.app/legal/privacy-policy/"
+  return URL(string: path)
 }

--- a/Pastura/PasturaTests/Views/SettingsViewLocalizedURLTests.swift
+++ b/Pastura/PasturaTests/Views/SettingsViewLocalizedURLTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+/// Pins the UI-shell-locale routing of the Settings → Privacy Policy
+/// external link (#396). Per ADR-010 D6 (UI shell consumer), routing
+/// reads `Bundle.main.preferredLocalizations` directly — `LocaleResolver`
+/// is deliberately not used here (its D2 scope is new-data creation +
+/// multi-variant selection, not external URL routing). The `ja` page
+/// mirrors at `pages/ja/legal/privacy-policy/`; every other locale
+/// falls through to the English page.
+@MainActor
+@Suite(.timeLimit(.minutes(1)))
+struct SettingsViewLocalizedURLTests {
+
+  @Test func jaLocaleResolvesToJapanesePage() {
+    let url = localizedPrivacyPolicyURL(preferredLocalizations: ["ja"])
+    #expect(url?.absoluteString == "https://pastura.app/ja/legal/privacy-policy/")
+  }
+
+  @Test func enLocaleResolvesToEnglishPage() {
+    let url = localizedPrivacyPolicyURL(preferredLocalizations: ["en"])
+    #expect(url?.absoluteString == "https://pastura.app/legal/privacy-policy/")
+  }
+
+  @Test func unsupportedLocaleFallsBackToEnglishPage() {
+    let url = localizedPrivacyPolicyURL(preferredLocalizations: ["fr"])
+    #expect(url?.absoluteString == "https://pastura.app/legal/privacy-policy/")
+  }
+
+  @Test func emptyPreferredLocalizationsFallsBackToEnglishPage() {
+    let url = localizedPrivacyPolicyURL(preferredLocalizations: [])
+    #expect(url?.absoluteString == "https://pastura.app/legal/privacy-policy/")
+  }
+}


### PR DESCRIPTION
## Summary

- Settings → Privacy Policy ボタンを device UI shell ロケールに応じて ja/en 振り分け (#396)
- `ja` → `https://pastura.app/ja/legal/privacy-policy/`（既に公開済の日本語ミラー）、それ以外は既存の英語ページ
- 調査の結果、アプリ→pastura.app の外部リンクは現時点でこの 1 箇所のみ。他に同種の問題なし

## Why this resolver shape

ADR-010 D6 で **UI-shell consumer** は `Bundle.main.preferredLocalizations` を直接読むと規定されている。`LocaleResolver.deviceDefault()` は意図的に避けた — D2 scope は「新規データ作成 seed + multi-variant selection of stored content」で、外部 URL routing は scope 外。critic の Path (a) 採用。

## Test plan

- [x] `SettingsViewLocalizedURLTests` 新規追加（4 ケース: `ja` / `en` / `fr` / `[]` → 期待 URL）
- [x] フル unit test suite (1619 tests / 145 suites) pass
- [x] `swiftlint --strict` clean
- [ ] 手動 QA: ja ロケール端末で Settings → プライバシーポリシー → 日本語ページが Safari で開くこと
- [ ] 手動 QA: en ロケール端末で同ボタンが英語ページを開くこと

## Future-proofing note

現時点で `pastura.app` への外部リンクは本 1 箇所のみのため、専用ヘルパー (`LocalizedExternalURLs.localizedURL(path:)` 等) への抽出は YAGNI で見送り。2 個目の callsite が追加されたタイミングがリファクタの引き金。

Closes #396