### PR TITLE
📝 docs: add README.md and CONTRIBUTING.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,7 +158,7 @@ Implementation order: `Models → LLM → Engine → Data → Views → App → 
 
 ### Git Conventions
 
-- **Branch:** `feature/<description>`, `fix/<description>`
+- **Branch:** `feature/<description>`, `fix/<description>`, `docs/<description>`
 - **Branch ops:** Prefer `git switch <branch>` / `git switch -c <branch>` over `git checkout`.
   Never use `git switch` with `--discard-changes`, `--force`, `-f`, or `-C` — they discard
   uncommitted work or overwrite branch refs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 > Read this file in full before starting any task.
 
+> 📝 When editing this file, see "Reference Documents" first. README.md / CONTRIBUTING.md may need parallel updates.
+
 ## Current Phase
 
 **Phase 2: Expansion** — See `docs/ROADMAP.md` for scope.
@@ -246,7 +248,7 @@ same change:
 
 - Architecture / Hard Rules / Dependency Rules → README "Architecture",
   CONTRIBUTING "Design principles" (anchor links)
-- Tech Stack versions (Yams, GRDB) → README "Tech stack"
+- Tech Stack versions and platform (Swift, iOS minimum, Yams, GRDB) → README "Tech stack"
 - Bundled models (`ModelRegistry.swift`) → README "Supported LLM models"
 - Git Conventions → CONTRIBUTING "Workflow" / "Commits"
 - Directory Structure → README "Project layout"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,8 +239,24 @@ Record architectural decisions in `docs/decisions/` as `ADR-NNN.md`.
 
 ## Reference Documents
 
-| Document                              | Content                                     |
-|---------------------------------------|---------------------------------------------|
+`README.md` and `CONTRIBUTING.md` at the project root are public-facing
+mirrors of parts of this document. When updating one of the following in
+this document (or in source), check whether the public docs need the
+same change:
+
+- Architecture / Hard Rules / Dependency Rules → README "Architecture",
+  CONTRIBUTING "Design principles" (anchor links)
+- Tech Stack versions (Yams, GRDB) → README "Tech stack"
+- Bundled models (`ModelRegistry.swift`) → README "Supported LLM models"
+- Git Conventions → CONTRIBUTING "Workflow" / "Commits"
+- Directory Structure → README "Project layout"
+- i18n workflow / ContentBlocklist procedure → CONTRIBUTING "Before
+  your first PR"
+
+| Document                              | Content                                                                       |
+|---------------------------------------|-------------------------------------------------------------------------------|
+| `README.md`                           | Public-facing developer intro (Architecture, Tech stack, Project layout, Supported models) |
+| `CONTRIBUTING.md`                     | Public-facing contributor workflow with links into CLAUDE.md anchors          |
 | `docs/ROADMAP.md`                     | Phase scope, Go/No-Go criteria              |
 | `docs/decisions/ADR-001.md`           | Phase 1 architecture decisions (12 ADRs)    |
 | `docs/decisions/ADR-002.md`           | llama.cpp interim LLM backend decision      |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,170 @@
+# Contributing to Pastura
+
+Thanks for taking the time to look. Pastura is small and primarily
+maintained by one person, so the workflow stays light.
+
+## Where to start
+
+- File a bug as a GitHub issue and include what you saw, what you
+  expected, the device, and the iOS version.
+- Feature ideas go in an issue first so we can talk through scope
+  before code lands. [`docs/ROADMAP.md`](docs/ROADMAP.md) shows what's
+  in flight and what's out of scope for the current phase.
+- Doc fixes and typos can go straight to a PR.
+
+## Project layout
+
+```
+Pastura/Pastura/   # iOS app source
+├── App/           # App state, navigation, ViewModels
+├── Engine/        # Scenario engine (phases, scoring)
+├── LLM/           # Inference backends
+├── Data/          # GRDB persistence
+├── Models/        # Domain types
+├── Views/         # SwiftUI
+└── Resources/     # Presets, demo replays, blocklist
+
+PasturaTests/      # Unit and integration tests
+PasturaUITests/    # UI tests
+
+docs/              # Roadmap, ADRs, specs, design system
+scripts/           # Build, lint, content-blocklist helpers
+pages/             # The pastura.app site
+```
+
+## Design principles
+
+Pastura is layered to make a future SPM module split painless. The
+authoritative rules live in [`CLAUDE.md`](CLAUDE.md).
+
+- [Hard Rules](CLAUDE.md#hard-rules) cover the force-unwrap policy, the
+  Engine to Data dependency ban, and required doc comments on public
+  types.
+- [Dependency Rules](CLAUDE.md#dependency-rules-strict) describe the
+  allowed import direction between layers.
+- [Swift Coding Conventions](CLAUDE.md#swift-coding-conventions) cover
+  actor isolation, error types, logger privacy, and the i18n workflow.
+
+If your change touches an architectural boundary, check
+[`docs/decisions/`](docs/decisions/) for the relevant ADR.
+
+## Workflow
+
+1. Fork the repo, then clone your fork.
+2. Create a branch named `feature/<description>`, `fix/<description>`,
+   or `docs/<description>`.
+3. Make your changes following the rules linked above.
+4. Run the test suite locally (see Testing below).
+5. Open a PR against `main` and reference the issue you're closing.
+
+`main` is push-protected, so all changes land via PR.
+
+### Commits
+
+Conventional Commits with an emoji prefix, under 72 chars on the
+subject line.
+
+```
+✨ feat(engine): add `reflect` phase type
+🐛 fix(views): pop after Editor save on iPad split view
+♻️ refactor(llm): extract grammar builder
+📝 docs(roadmap): mark Step C-1 as Done
+```
+
+The full prefix list lives in
+[`CLAUDE.md`](CLAUDE.md#git-conventions). Keep each commit focused on
+one logical change. Add a body when "why" isn't obvious from the diff.
+
+### Testing
+
+TDD is required for `Engine/` and `LLM/`. For `Data/` and `Views/`
+write tests after the fact when there's non-trivial logic to cover.
+
+```bash
+# Full test suite (slow, useful before pushing)
+scripts/xcodebuild.sh test
+
+# Single suite during red / green / refactor
+scripts/xcodebuild.sh test -only-testing PasturaTests/ScenarioLoaderTests
+```
+
+The wrapper handles simulator selection, derived-data paths, and the
+localization-catalog sync. See
+[`.claude/rules/xcodebuild-cli.md`](.claude/rules/xcodebuild-cli.md)
+for timeouts, recovery, and CI parity.
+
+## Before your first PR
+
+A few traps the project enforces with pre-commit hooks and CI. Knowing
+them up front saves a round-trip.
+
+### Pre-commit hooks
+
+`git commit` runs `swiftlint lint --strict` and a full `xcodebuild build`.
+Lint violations or compile errors block the commit. SwiftFormat and
+`swiftlint --fix` also run automatically on file edit when you use
+Claude Code's PostToolUse hook. The hooks live in
+`.claude/settings.json`.
+
+### Localization
+
+Any new user-facing English string literal (`Text("...")`, alerts,
+accessibility labels, and so on) must be wrapped in
+`String(localized: "...")` so it lands in `Localizable.xcstrings` and
+gets a Japanese translation. SwiftLint has a tripwire for this, and CI
+checks coverage. See
+[`docs/i18n/leak-detection.md`](docs/i18n/leak-detection.md) and
+[`.claude/rules/i18n.md`](.claude/rules/i18n.md).
+
+### Content blocklist
+
+The content blocklist source is `docs/blocklist/source.json`. If you
+edit it, rebuild and check.
+
+```bash
+brew install jq   # one-time
+bash scripts/build-blocklist.sh --check
+```
+
+CI runs the same `--check`. Background and policy are in
+[`docs/decisions/ADR-005.md`](docs/decisions/ADR-005.md).
+
+### Architectural changes
+
+Anything touching public protocol signatures, the Engine to LLM to Data
+direction, or `AppRouter` should land a heads-up issue first. Larger
+structural shifts usually need an ADR in `docs/decisions/` before the
+code does.
+
+## Submitting changes
+
+1. Push your branch to your fork.
+2. Open a PR against `tyabu12/pastura:main` and reference the issue
+   you're addressing (`Closes #42`).
+3. Make sure CI is green and SwiftLint is clean.
+4. The maintainer reviews and merges. Squash-merge is the default.
+
+PRs from forks may take a few days to get a first review. Pastura is
+hobby-pace at the moment, so patience is appreciated.
+
+## If you use Claude Code
+
+This repo is heavily AI-agent-friendly. A few things worth knowing if
+you have Claude Code installed.
+
+- [`CLAUDE.md`](CLAUDE.md) is loaded automatically and carries the
+  full project context.
+- The `/orchestrate` slash command (defined in
+  `.claude/skills/orchestrate/`) takes a task description and runs the
+  full plan, worktree, TDD, review, and PR loop. It's the recommended
+  entry point for non-trivial work because `main` is push-protected
+  and the Xcode project file is concurrent-edit-hostile.
+- Other skills live in `.claude/skills/`.
+
+If you don't use Claude Code, ignore this section. The fork, branch,
+PR flow above is the canonical contributor path.
+
+## License
+
+By contributing you agree your changes are released under the
+[MIT License](LICENSE), same as the rest of the project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,26 +12,6 @@ maintained by one person, so the workflow stays light.
   in flight and what's out of scope for the current phase.
 - Doc fixes and typos can go straight to a PR.
 
-## Project layout
-
-```
-Pastura/Pastura/   # iOS app source
-├── App/           # App state, navigation, ViewModels
-├── Engine/        # Scenario engine (phases, scoring)
-├── LLM/           # Inference backends
-├── Data/          # GRDB persistence
-├── Models/        # Domain types
-├── Views/         # SwiftUI
-└── Resources/     # Presets, demo replays, blocklist
-
-PasturaTests/      # Unit and integration tests
-PasturaUITests/    # UI tests
-
-docs/              # Roadmap, ADRs, specs, design system
-scripts/           # Build, lint, content-blocklist helpers
-pages/             # The pastura.app site
-```
-
 ## Design principles
 
 Pastura is layered to make a future SPM module split painless. The

--- a/README.md
+++ b/README.md
@@ -2,13 +2,8 @@
 
 # 🐑 Pastura
 
-**Running local LLM multi-agent simulations on-device.**
-
-AIgazing.\
-Like stargazing,\
-but for local LLMs.
-
-Pastura is a closed pasture for AI agents on your device. Watch as the agents act out the scenarios you've written.
+*AIgazing. Like stargazing, but for local LLMs.*  
+Running local LLM multi-agent simulations on-device.
 
 [![CI](https://github.com/tyabu12/pastura/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/tyabu12/pastura/actions/workflows/ci.yml)
 
@@ -19,6 +14,8 @@ Pastura is a closed pasture for AI agents on your device. Watch as the agents ac
 > preparation.
 
 ## What is Pastura
+
+Pastura is a closed pasture for AI agents on your device. Watch as the agents act out the scenarios you've written.
 
 You write a YAML scenario (or build it in the visual editor), pick a
 local LLM, and watch the agents talk, vote, and score themselves.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,142 @@
+<div align="center">
+
+# 🐑 Pastura
+
+**iOS app for running AI multi-agent simulations on-device.**
+
+Local LLMs, scenario YAML, no servers.\
+For the user-facing pitch, see [pastura.app](https://pastura.app).
+
+[![CI](https://github.com/tyabu12/pastura/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/tyabu12/pastura/actions/workflows/ci.yml)
+
+</div>
+
+> 🚧 Pastura is under active development. The YAML format and on-device
+> data layout may still change. The first App Store submission is in
+> preparation.
+
+## What's in this repo
+
+You write a YAML scenario (or build it in the visual editor), pick a
+local LLM, and watch the agents talk, vote, and score themselves.
+Nothing leaves the device.
+
+This README is for people who want to read or modify the source code.
+For the product story, design philosophy, and screenshots, head to
+[pastura.app](https://pastura.app) instead.
+
+## Architecture
+
+The app is split into five layers.
+
+```
+Views → App / ViewModel → Engine + Data → LLM → Models
+```
+
+- **Models** has no dependencies and holds the YAML and domain types.
+- **Engine** consumes **LLM** and **Models** only. It never imports
+  **Data**.
+- **Data** persists turn records into SQLite via GRDB.
+- **LLM** abstracts the inference backend behind `LLMService`.
+- **Views** and **App** are SwiftUI.
+
+The full layer diagram and rationale live in
+[`docs/decisions/ADR-001.md`](docs/decisions/ADR-001.md). The strict
+dependency direction is preparation for a future SPM module split.
+
+## Tech stack
+
+| Component        | Choice                                            |
+|------------------|---------------------------------------------------|
+| Language         | Swift 6                                           |
+| UI               | SwiftUI                                           |
+| Minimum iOS      | 17.0                                              |
+| YAML parser      | [Yams](https://github.com/jpsim/Yams) 6.2.1       |
+| Local SQLite     | [GRDB](https://github.com/groue/GRDB.swift) 7.10  |
+| LLM (current)    | llama.cpp via [llama.swift](https://github.com/mattt/llama.swift) |
+| LLM (planned)    | LiteRT-LM iOS SDK                                 |
+| LLM (dev)        | Ollama via OpenAI-compatible API                  |
+| LLM (testing)    | `MockLLMService`                                  |
+| Bundled models   | Gemma 4 E2B (~3 GB), Qwen 3 4B Q4_K_M (~2.5 GB)   |
+
+The LLM backend choice and the planned LiteRT-LM migration are recorded
+in [`docs/decisions/ADR-002.md`](docs/decisions/ADR-002.md).
+
+## Prerequisites
+
+- macOS with Xcode 16 or later.
+- An iPhone 15 Pro or newer for on-device testing. The bundled models
+  need around 8 GB of RAM. The simulator works for everything except
+  real LLM inference, which falls back to a mock.
+
+## Build and run
+
+Open the project in Xcode and Run.
+
+```bash
+open Pastura/Pastura.xcodeproj
+```
+
+From the command line:
+
+```bash
+# Test
+scripts/xcodebuild.sh test
+
+# Build only (no tests)
+scripts/xcodebuild.sh build
+
+# Narrow to a single suite during TDD
+scripts/xcodebuild.sh test -only-testing PasturaTests/SimulationRunnerTests
+```
+
+The wrapper takes care of simulator selection, derived-data paths, and
+the localization-catalog sync step. See
+[`.claude/rules/xcodebuild-cli.md`](.claude/rules/xcodebuild-cli.md) for
+the full playbook.
+
+## Project layout
+
+```
+Pastura/Pastura/
+├── PasturaApp.swift
+├── App/         # App state, navigation, ViewModels
+├── Engine/      # Scenario engine (phases, scoring)
+├── LLM/         # Inference backends (llama.cpp, Ollama, Mock)
+├── Data/        # GRDB / SQLite persistence
+├── Models/      # Domain types, depends on nothing
+├── Views/       # SwiftUI screens and components
+├── Utilities/
+└── Resources/   # Bundled presets, demo replays, blocklist
+
+PasturaTests/    # Unit and integration tests
+PasturaUITests/  # UI tests
+
+docs/
+├── ROADMAP.md          # Phase scope and Go / No-Go criteria
+├── decisions/          # Architecture Decision Records
+├── specs/              # Feature specifications
+├── design/             # Design system, reference assets
+├── i18n/               # Localization workflow
+└── blocklist/          # ContentBlocklist source + build script
+
+pages/                  # The pastura.app site (deployed via GitHub Pages)
+scripts/                # Build, lint, content-blocklist helpers
+```
+
+## Documentation
+
+- [`docs/ROADMAP.md`](docs/ROADMAP.md) for phase status and what ships
+  next.
+- [`docs/decisions/`](docs/decisions/) for Architecture Decision Records
+  (ADR-001 through ADR-010).
+- [`docs/specs/`](docs/specs/) for MVP and feature specifications.
+- [`docs/design/design-system.md`](docs/design/design-system.md) for
+  design tokens, components, and philosophy.
+- [`CLAUDE.md`](CLAUDE.md) for hard rules, Swift conventions, and the
+  context AI agents use. Humans can read it too.
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) for sending a PR.
+
+## License
+
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -2,10 +2,13 @@
 
 # 🐑 Pastura
 
-**iOS app for running AI multi-agent simulations on-device.**
+**Running local LLM multi-agent simulations on-device.**
 
-Local LLMs, scenario YAML, no servers.\
-For the user-facing pitch, see [pastura.app](https://pastura.app).
+AIgazing.\
+Like stargazing,\
+but for local LLMs.
+
+Pastura is a closed pasture for AI agents on your device. Watch as the agents act out the scenarios you've written.
 
 [![CI](https://github.com/tyabu12/pastura/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/tyabu12/pastura/actions/workflows/ci.yml)
 
@@ -15,14 +18,13 @@ For the user-facing pitch, see [pastura.app](https://pastura.app).
 > data layout may still change. The first App Store submission is in
 > preparation.
 
-## What's in this repo
+## What is Pastura
 
 You write a YAML scenario (or build it in the visual editor), pick a
 local LLM, and watch the agents talk, vote, and score themselves.
 Nothing leaves the device.
 
-This README is for people who want to read or modify the source code.
-For the product story, design philosophy, and screenshots, head to
+For the product story, design philosophy, and faq, head to
 [pastura.app](https://pastura.app) instead.
 
 ## Architecture
@@ -46,32 +48,42 @@ dependency direction is preparation for a future SPM module split.
 
 ## Tech stack
 
-| Component        | Choice                                            |
-|------------------|---------------------------------------------------|
-| Language         | Swift 6                                           |
-| UI               | SwiftUI                                           |
-| Minimum iOS      | 17.0                                              |
-| YAML parser      | [Yams](https://github.com/jpsim/Yams) 6.2.1       |
-| Local SQLite     | [GRDB](https://github.com/groue/GRDB.swift) 7.10  |
-| LLM (current)    | llama.cpp via [llama.swift](https://github.com/mattt/llama.swift) |
-| LLM (planned)    | LiteRT-LM iOS SDK                                 |
-| LLM (dev)        | Ollama via OpenAI-compatible API                  |
-| LLM (testing)    | `MockLLMService`                                  |
-| Bundled models   | Gemma 4 E2B (~3 GB), Qwen 3 4B Q4_K_M (~2.5 GB)   |
+- **Language and platform**
+  - Swift 6.x
+  - SwiftUI
+  - iOS 17.0 minimum deployment target
+- **Libraries**
+  - [Yams](https://github.com/jpsim/Yams) 6.2.1 for YAML parsing
+  - [GRDB](https://github.com/groue/GRDB.swift) 7.10 for SQLite
+- **LLM backends** (selected per build configuration)
+  - **`LlamaCppService`** via [llama.swift](https://github.com/mattt/llama.swift). On-device llama.cpp with Metal GPU. The shipping backend for Release builds.
+  - **LiteRT-LM iOS SDK**. Planned target backend, blocked on Google's Swift SDK + GPU support. See [ADR-002](docs/decisions/ADR-002.md).
+  - **`OllamaService`** via OpenAI-compatible API. Used in Debug builds and on the Simulator.
+  - **`MockLLMService`**. Deterministic stub for unit tests only.
 
-The LLM backend choice and the planned LiteRT-LM migration are recorded
-in [`docs/decisions/ADR-002.md`](docs/decisions/ADR-002.md).
+## Supported LLM models
+
+Bundled in
+[`Pastura/Pastura/App/ModelRegistry.swift`](Pastura/Pastura/App/ModelRegistry.swift).
+Both are GGUF Q4_K_M quants, downloaded on first launch.
+
+| Model                                                                | Vendor  | Size    | Notes                                                       |
+|----------------------------------------------------------------------|---------|---------|-------------------------------------------------------------|
+| [Gemma 4 E2B](https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF)    | Google  | ~3.1 GB | Default. Conversational, plays well with most scenarios.    |
+| [Qwen 3 4B](https://huggingface.co/Qwen/Qwen3-4B-GGUF)               | Alibaba | ~2.5 GB | Reasoning-leaning. Good for scenarios that need deduction.  |
+
+Add more by appending a `ModelDescriptor` to `ModelRegistry.catalog`.
+The descriptor pins download URL, file size, and SHA-256 at compile
+time. The trade-offs are documented in
+[ADR-002](docs/decisions/ADR-002.md).
 
 ## Prerequisites
 
-- macOS with a recent Xcode that supports Swift 6. CI runs on
-  `macos-26`; see [`.github/workflows/ci.yml`](.github/workflows/ci.yml)
-  for the exact configuration.
-- An iPhone 15 Pro or newer for on-device testing. The bundled models
-  need around 8 GB of RAM, which rules out iPhone 15 (non-Pro) and
-  earlier. The simulator builds against an Ollama dev backend instead,
-  which exercises the engine and UI without on-device inference.
-  `MockLLMService` is reserved for unit tests.
+- Swift 6 (Xcode that supports it; CI runs on `macos-26`)
+- iOS 17.0 deployment target
+- iPhone 15 Pro or newer for on-device LLM testing (around 8 GB RAM)
+- Optional: install [Ollama](https://ollama.com) locally if you want
+  non-mock LLM inference in Debug or on the Simulator
 
 ## Build and run
 
@@ -102,30 +114,29 @@ the full playbook.
 ## Project layout
 
 ```
-Pastura/Pastura/
-├── PasturaApp.swift
-├── App/         # App state, navigation, ViewModels
-├── Engine/      # Scenario engine (phases, scoring)
-├── LLM/         # Inference backends (llama.cpp, Ollama, Mock)
-├── Data/        # GRDB / SQLite persistence
-├── Models/      # Domain types, depends on nothing
-├── Views/       # SwiftUI screens and components
-├── Utilities/
-└── Resources/   # Bundled presets, demo replays, blocklist
-
-PasturaTests/    # Unit and integration tests
-PasturaUITests/  # UI tests
-
-docs/
-├── ROADMAP.md          # Phase scope and Go / No-Go criteria
-├── decisions/          # Architecture Decision Records
-├── specs/              # Feature specifications
-├── design/             # Design system, reference assets
-├── i18n/               # Localization workflow
-└── blocklist/          # ContentBlocklist source + build script
-
-pages/                  # The pastura.app site (deployed via GitHub Pages)
-scripts/                # Build, lint, content-blocklist helpers
+pastura/
+├── Pastura/
+│   ├── Pastura/             # iOS app source
+│   │   ├── PasturaApp.swift
+│   │   ├── App/             # App state, navigation, ViewModels
+│   │   ├── Engine/          # Scenario engine (phases, scoring)
+│   │   ├── LLM/             # Inference backends (llama.cpp, Ollama, Mock)
+│   │   ├── Data/            # GRDB / SQLite persistence
+│   │   ├── Models/          # Domain types, depends on nothing
+│   │   ├── Views/           # SwiftUI screens and components
+│   │   ├── Utilities/
+│   │   └── Resources/       # Bundled presets, demo replays, blocklist
+│   ├── PasturaTests/        # Unit and integration tests
+│   └── PasturaUITests/      # UI tests
+├── docs/
+│   ├── ROADMAP.md           # Phase scope and Go / No-Go criteria
+│   ├── decisions/           # Architecture Decision Records
+│   ├── specs/               # Feature specifications
+│   ├── design/              # Design system, reference assets
+│   ├── i18n/                # Localization workflow
+│   └── blocklist/           # ContentBlocklist source + build script
+├── pages/                   # The pastura.app site (deployed via GitHub Pages)
+└── scripts/                 # Build, lint, content-blocklist helpers
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Running local LLM multi-agent simulations on-device.
 </div>
 
 > 🚧 Pastura is under active development. The YAML format and on-device
-> data layout may still change. The first App Store submission is in
-> preparation.
+> data layout may still change. Not yet on the App Store or TestFlight.
+> Clone and run from Xcode to try it.
 
 ## What is Pastura
 
@@ -78,7 +78,9 @@ time. The trade-offs are documented in
 
 - Swift 6 (Xcode that supports it; CI runs on `macos-26`)
 - iOS 17.0 deployment target
-- iPhone 15 Pro or newer for on-device LLM testing (around 8 GB RAM)
+- iPhone with ~8 GB RAM for on-device LLM testing. `ModelRegistry.swift`
+  declares a 6.5 GB `minRAM` floor; in practice that's iPhone 15 Pro,
+  the iPhone 16 family (including 16e), or newer.
 - [Ollama](https://ollama.com) (optional) if you want non-mock LLM
   inference in Debug or on the Simulator
 
@@ -140,8 +142,7 @@ pastura/
 
 - [`docs/ROADMAP.md`](docs/ROADMAP.md) for phase status and what ships
   next.
-- [`docs/decisions/`](docs/decisions/) for Architecture Decision Records
-  (ADR-001 through ADR-010).
+- [`docs/decisions/`](docs/decisions/) for Architecture Decision Records.
 - [`docs/specs/`](docs/specs/) for MVP and feature specifications.
 - [`docs/design/design-system.md`](docs/design/design-system.md) for
   design tokens, components, and philosophy.

--- a/README.md
+++ b/README.md
@@ -64,10 +64,14 @@ in [`docs/decisions/ADR-002.md`](docs/decisions/ADR-002.md).
 
 ## Prerequisites
 
-- macOS with Xcode 16 or later.
+- macOS with a recent Xcode that supports Swift 6. CI runs on
+  `macos-26`; see [`.github/workflows/ci.yml`](.github/workflows/ci.yml)
+  for the exact configuration.
 - An iPhone 15 Pro or newer for on-device testing. The bundled models
-  need around 8 GB of RAM. The simulator works for everything except
-  real LLM inference, which falls back to a mock.
+  need around 8 GB of RAM, which rules out iPhone 15 (non-Pro) and
+  earlier. The simulator builds against an Ollama dev backend instead,
+  which exercises the engine and UI without on-device inference.
+  `MockLLMService` is reserved for unit tests.
 
 ## Build and run
 

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ time. The trade-offs are documented in
 - Swift 6 (Xcode that supports it; CI runs on `macos-26`)
 - iOS 17.0 deployment target
 - iPhone 15 Pro or newer for on-device LLM testing (around 8 GB RAM)
-- Optional: install [Ollama](https://ollama.com) locally if you want
-  non-mock LLM inference in Debug or on the Simulator
+- [Ollama](https://ollama.com) (optional) if you want non-mock LLM
+  inference in Debug or on the Simulator
 
 ## Build and run
 


### PR DESCRIPTION
## Summary

- Add `README.md` aimed at developers landing on GitHub. Hero block uses the LP italic tagline as the opening note; "Tech stack" is a hierarchical list so LLM backends group together at one level; new "Supported LLM models" section enumerates the GGUF quants currently in `ModelRegistry.catalog` (Gemma 4 E2B, Qwen 3 4B); Project layout is a single tree rooted at the repo so `Pastura/Pastura/`, `PasturaTests/`, `docs/`, `pages/`, `scripts/` are visibly siblings.
- Add `CONTRIBUTING.md` with the fork → branch → PR human flow as the primary path. Hard Rules / Dependency Rules link into `CLAUDE.md` rather than duplicating, so the two can't drift. "Before your first PR" surfaces the `String(localized:)` rule, ContentBlocklist build, and pre-commit hook expectations. `/orchestrate` is in an optional "If you use Claude Code" section. No project-layout duplication; the README's tree is the single source.
- Distribution language stays accurate: states present-tense "Not yet on the App Store or TestFlight. Clone and run from Xcode to try it." instead of forward-looking framing, matching the actual install-base-zero state (Apple Developer Program is unregistered).
- Device requirement is grounded in code: cites `ModelRegistry.swift`'s 6.5 GB `minRAM` floor with iPhone 15 Pro / iPhone 16 family / 16e as concrete examples, rather than the misleading "iPhone 15 Pro or newer" shorthand (which excludes iPhone 16 non-Pro at 8 GB).
- CLAUDE.md Git Conventions now list `docs/<description>` alongside `feature/` and `fix/` so README, CONTRIBUTING, and the canonical rules agree.

## Test plan

- [ ] README and CONTRIBUTING render correctly on the PR preview tab (hero block centers, tree is monospace, badges resolve).
- [ ] All referenced paths (`docs/decisions/ADR-001.md`, `docs/i18n/leak-detection.md`, `scripts/build-blocklist.sh`, `Pastura/Pastura/App/ModelRegistry.swift`, etc.) resolve as links.
- [ ] All `CLAUDE.md#...` anchors (`#hard-rules`, `#dependency-rules-strict`, `#swift-coding-conventions`, `#git-conventions`) resolve.
- [ ] CI is green.

Closes #402