### PR TITLE
🔒 feat: security baseline (SECURITY.md, Dependabot, CodeQL)

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -15,7 +15,7 @@ suspected vulnerabilities. Public reports give attackers time to exploit
 the issue before a fix is available.
 
 If GitHub PVR is unavailable to you, contact the maintainer at
-`tyabu1212@gmail.com` with a subject line beginning `[Pastura security]`.
+`developer@pastura.app` with a subject line beginning `[Pastura security]`.
 
 ### What to include
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -49,13 +49,14 @@ let us know your planned date so we can align the fix release.
 ## Supported Versions
 
 Pastura is pre-release. Only the latest commit on the `main` branch is
-maintained. Earlier branches, forks, and any TestFlight build older than
-the current `main` are out of support.
+maintained. Earlier commits, branches, forks, and any sideloaded build
+older than the current `main` are out of support. Pastura is not yet
+distributed via TestFlight or the App Store.
 
 | Version | Supported |
 |---------|-----------|
 | `main` (latest) | Yes |
-| Older commits / branches / forks | No |
+| Older commits / branches / forks / sideloaded builds | No |
 
 Once Pastura ships its first tagged release, this table will track at
 least the current minor release.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,105 @@
+# Security Policy
+
+Thank you for helping keep Pastura and its users safe. This document
+explains how to report a vulnerability and what to expect once you do.
+
+## Reporting a Vulnerability
+
+Please report security issues **privately** via GitHub's Private
+Vulnerability Reporting:
+
+[**Report a vulnerability**](https://github.com/tyabu12/pastura/security/advisories/new)
+
+Do not open a public issue, pull request, or discussion thread for
+suspected vulnerabilities. Public reports give attackers time to exploit
+the issue before a fix is available.
+
+If GitHub PVR is unavailable to you, contact the maintainer at
+`tyabu1212@gmail.com` with a subject line beginning `[Pastura security]`.
+
+### What to include
+
+A good report contains, at a minimum:
+
+1. A short description of the issue and its security impact.
+2. The Pastura commit SHA (or release tag) on which the issue reproduces.
+3. Steps to reproduce, including any required scenario YAML, model
+   selection, or device configuration.
+4. Your proposed severity (informational / low / medium / high / critical)
+   and a one-line rationale.
+5. Any proof-of-concept output you are willing to share. Do NOT include
+   third-party user data.
+
+## What to Expect
+
+Pastura is maintained by a single developer outside of business hours. The
+following targets are realistic upper bounds, not service-level
+guarantees.
+
+| Phase | Target |
+|-------|--------|
+| Acknowledgment of the report | 7 days |
+| Initial triage and severity assessment | 14 days |
+| Fix proposal (or out-of-scope decision) | 30 days |
+| Public disclosure after fix lands | 90 days from triage, or sooner if you prefer |
+
+We follow coordinated disclosure. If you intend to publish your findings,
+let us know your planned date so we can align the fix release.
+
+## Supported Versions
+
+Pastura is pre-release. Only the latest commit on the `main` branch is
+maintained. Earlier branches, forks, and any TestFlight build older than
+the current `main` are out of support.
+
+| Version | Supported |
+|---------|-----------|
+| `main` (latest) | Yes |
+| Older commits / branches / forks | No |
+
+Once Pastura ships its first tagged release, this table will track at
+least the current minor release.
+
+## Scope
+
+### In scope
+
+* Pastura iOS source code (`Pastura/Pastura/**`).
+* CI and build infrastructure (`.github/workflows/**`, `scripts/**`).
+* Public web pages (`pages/**`) served from `pastura.app`.
+* Scenario engine logic and the LLM inference layer's invocation of
+  third-party libraries (Yams, GRDB, llama.cpp via mattt/llama.swift).
+
+### Out of scope
+
+* Vulnerabilities in third-party dependencies themselves. Please report
+  those to the upstream project (Yams, GRDB.swift, llama.cpp,
+  mattt/llama.swift). Pastura will update its pinned versions once an
+  upstream fix is released.
+* Issues that require physical device access or a jailbroken device.
+* Bugs in the iOS operating system or Apple frameworks.
+* Denial-of-service via maliciously crafted scenario YAML supplied by the
+  device user to their own device. Scenario YAML executes only with the
+  user's explicit action, on-device, with no network exfiltration path.
+* Social-engineering, phishing, or reports that require the attacker to
+  already have the device unlocked.
+
+## Pastura's Security Posture (for context)
+
+Knowing how Pastura is built may help you assess impact:
+
+* Pastura runs entirely on the user's device. Scenarios, prompts, agent
+  outputs, and inference all stay local.
+* Pastura ships no analytics, no telemetry, no crash reporters, no
+  advertising or attribution SDKs. The only network activity is the
+  one-time model download from publicly listed URLs (see
+  `App/ModelRegistry.swift`).
+* Pastura has no user accounts and no authentication. There is no server
+  component to compromise.
+* See `docs/decisions/ADR-005.md` for content-safety architecture and
+  `pages/legal/privacy-policy/` for the public privacy policy.
+
+## Acknowledgments
+
+Reporters who follow this policy and request credit will be acknowledged
+in the security advisory that lands the fix.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,8 +2,16 @@
 #
 # Two ecosystems are tracked:
 #   1. swift           SPM dependencies declared in the Xcode project
-#                      (Yams, GRDB, mattt/llama.swift). Dependabot reads
-#                      Pastura/Pastura.xcodeproj/.../Package.resolved.
+#                      (Yams, GRDB, mattt/llama.swift). Per GitHub's
+#                      2026-03-31 changelog, Dependabot auto-discovers
+#                      Xcode-managed Package.resolved files inside any
+#                      .xcodeproj / .xcworkspace under the configured
+#                      directory, so pointing `directory: "/Pastura"`
+#                      at the parent of Pastura.xcodeproj is sufficient.
+#                      If Dependancy graph reports the SPM ecosystem as
+#                      unparseable after merge, swap `directory:` to
+#                      `/Pastura/Pastura.xcodeproj/project.xcworkspace/xcshareddata/swiftpm`
+#                      as the explicit fallback.
 #   2. github-actions  Actions referenced by .github/workflows/*.yml.
 #
 # Cadence is monthly. With a single maintainer, weekly PRs create more

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+# Dependabot version updates for Pastura.
+#
+# Two ecosystems are tracked:
+#   1. swift           SPM dependencies declared in the Xcode project
+#                      (Yams, GRDB, mattt/llama.swift). Dependabot reads
+#                      Pastura/Pastura.xcodeproj/.../Package.resolved.
+#   2. github-actions  Actions referenced by .github/workflows/*.yml.
+#
+# Cadence is monthly. With a single maintainer, weekly PRs create more
+# review noise than security benefit. CVE patches still flow through
+# Dependabot security updates, which are configured separately under
+# Settings > Code security and analysis and are not gated by this file.
+
+version: 2
+updates:
+  - package-ecosystem: "swift"
+    directory: "/Pastura"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "⬆️ chore(deps)"
+    ignore:
+      # mattt/llama.swift tags are date-encoded (e.g. 2.8694.0) rather
+      # than semver. Dependabot's semver comparator cannot reliably
+      # classify a tag bump as patch / minor / major. Suppress the noisy
+      # minor/patch buckets so only apparent-major bumps surface as PRs;
+      # upstream llama.cpp CVE response is tracked by watching the fork
+      # for new tags and reviewing manually.
+      - dependency-name: "llama.swift"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "⬆️ chore(ci)"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,11 +58,11 @@ jobs:
 
       - name: Build Pastura
         # CodeQL traces this xcodebuild invocation to populate its Swift
-        # database. The wrapper handles simulator destination resolution
-        # and DerivedData pinning, matching the project's other CI jobs.
-        run: |
-          source scripts/sim-dest.sh
-          scripts/xcodebuild.sh build
+        # database. The wrapper handles DerivedData pinning, matching
+        # the project's other CI jobs. The `build` subcommand uses a
+        # generic iOS-Simulator destination and bypasses the simulator
+        # gate, so sourcing scripts/sim-dest.sh is unnecessary here.
+        run: scripts/xcodebuild.sh build
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@458d36d7d4f47d0dd16ca424c1d3cda0060f1360 # v3.35.5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,70 @@
+# CodeQL static analysis for Pastura's Swift source.
+#
+# Trigger choice: weekly schedule + manual dispatch only.
+#
+# We intentionally do NOT run on push or pull_request. A full Swift
+# CodeQL pass requires a macOS runner with Xcode and a real
+# `xcodebuild build` (autobuild is not reliable against the wrapper-
+# managed simulator destination Pastura uses). Empirically that adds
+# 8 to 15 minutes of CI wall-clock, which would push the lint-and-test
+# job's contribution past the project's ~10-minute target and bump up
+# against the 20-minute "blocks merge" line (see CLAUDE.md / project
+# memory on CI time budget).
+#
+# Trade-off: findings now arrive with up to a 7-day lag. For a
+# pre-release codebase with zero installs and a single maintainer this
+# is acceptable. Before tagging the first public release, dispatch a
+# manual run (Actions tab > CodeQL > Run workflow) to refresh signal
+# on the exact release commit. If Pastura adopts parallel-suite CI
+# (#189) and lint-and-test drops well below the budget, revisit
+# adding a `pull_request` trigger gated to `Pastura/Pastura/**`
+# changes.
+
+name: CodeQL
+
+on:
+  schedule:
+    # Sunday 17:23 UTC. Off-peak; minute is randomized off the hour
+    # boundary per GitHub Actions scheduling guidance.
+    - cron: "23 17 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze Swift
+    runs-on: macos-26
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@458d36d7d4f47d0dd16ca424c1d3cda0060f1360 # v3.35.5
+        with:
+          languages: swift
+          build-mode: manual
+
+      - name: Build Pastura
+        # CodeQL traces this xcodebuild invocation to populate its Swift
+        # database. The wrapper handles simulator destination resolution
+        # and DerivedData pinning, matching the project's other CI jobs.
+        run: |
+          source scripts/sim-dest.sh
+          scripts/xcodebuild.sh build
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@458d36d7d4f47d0dd16ca424c1d3cda0060f1360 # v3.35.5
+        with:
+          category: "/language:swift"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@458d36d7d4f47d0dd16ca424c1d3cda0060f1360 # v3.35.5
+        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           languages: swift
           build-mode: manual
@@ -65,6 +65,6 @@ jobs:
         run: scripts/xcodebuild.sh build
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@458d36d7d4f47d0dd16ca424c1d3cda0060f1360 # v3.35.5
+        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           category: "/language:swift"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,6 @@
 # CodeQL static analysis for Pastura's Swift source.
 #
-# Trigger choice: weekly schedule + manual dispatch only.
+# Trigger choice: daily schedule + manual dispatch only.
 #
 # We intentionally do NOT run on push or pull_request. A full Swift
 # CodeQL pass requires a macOS runner with Xcode and a real
@@ -11,22 +11,24 @@
 # against the 20-minute "blocks merge" line (see CLAUDE.md / project
 # memory on CI time budget).
 #
-# Trade-off: findings now arrive with up to a 7-day lag. For a
-# pre-release codebase with zero installs and a single maintainer this
-# is acceptable. Before tagging the first public release, dispatch a
-# manual run (Actions tab > CodeQL > Run workflow) to refresh signal
-# on the exact release commit. If Pastura adopts parallel-suite CI
-# (#189) and lint-and-test drops well below the budget, revisit
-# adding a `pull_request` trigger gated to `Pastura/Pastura/**`
-# changes.
+# Daily cadence is free for public repos (Standard GitHub-hosted runners
+# bill at $0 for public repositories), so the previous weekly cadence
+# was leaving signal-lag on the table. Findings now arrive with up to a
+# 24-hour lag. Before tagging the first public release, still dispatch
+# a manual run (Actions tab > CodeQL > Run workflow) so the exact
+# release commit is analyzed even if scheduled drift skipped it. If
+# Pastura starts receiving external PRs regularly, revisit adding a
+# `pull_request` trigger gated to `Pastura/Pastura/**` changes (with
+# `if:` on author_association to avoid running it for owner PRs).
 
 name: CodeQL
 
 on:
   schedule:
-    # Sunday 17:23 UTC. Off-peak; minute is randomized off the hour
-    # boundary per GitHub Actions scheduling guidance.
-    - cron: "23 17 * * 0"
+    # 18:05 UTC daily = 03:05 JST. Off-peak globally; minute offset
+    # picked via $RANDOM to avoid the 0/15/30/45 boundaries where
+    # GitHub Actions schedulers congest worldwide.
+    - cron: "5 18 * * *"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -73,10 +73,12 @@ on:
       - '.github/workflows/deploy-pages.yml'
   workflow_dispatch:
 
+# Workflow-level permissions are minimal. Only the `deploy` job needs
+# write access to Pages and the OIDC token; declaring those at job level
+# keeps the default-token contract narrow per
+# https://docs.github.com/en/actions/reference/security/secure-use
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -86,6 +88,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,4 +280,5 @@ same change:
 | `docs/specs/demo-replay-mockup-prompt.md` | Claude Design prompt for the DL-time demo visual exploration |
 | `docs/design/design-system.md`        | Cross-screen design system (tokens, philosophy, components) |
 | `docs/design/demo-replay-reference.html` | DL-time demo visual reference prototype (HTML)             |
+| `docs/security/release-checklist.md`  | Operator security checklist (GitHub settings, iOS pre-submission audit, recurring review) |
 | `docs/prototype/among_them_prototype.py` | Python prototype (reference implementation) |

--- a/docs/security/release-checklist.md
+++ b/docs/security/release-checklist.md
@@ -1,0 +1,181 @@
+# Security Release Checklist
+
+A consolidated checklist for the security-sensitive work that lives
+outside the codebase. Three sections:
+
+1. [GitHub repository settings](#1-github-repository-settings).
+   One-time configuration kept current; commands are idempotent.
+2. [iOS pre-submission audit](#2-ios-pre-submission-audit).
+   Runs on the eve of an App Store submission (Phase 3, requires Apple
+   Developer Program registration).
+3. [Recurring review](#3-recurring-review). Periodic operator tasks.
+
+The aim is to leave a paper trail of *what* should be true, *how* to
+verify, and *how* to remediate. Re-run the verifier on each release.
+
+---
+
+## 1. GitHub repository settings
+
+These settings are GitHub-side state, not files in this repo. Some
+were enabled when introducing this checklist (PR #425); others remain
+manual because the REST API path is undocumented or restricted.
+
+### Current state verifier
+
+```bash
+gh api repos/tyabu12/pastura --jq '.security_and_analysis'
+gh api repos/tyabu12/pastura/private-vulnerability-reporting -i \
+  | head -1  # Expect: HTTP/2.0 204 No Content (enabled)
+```
+
+### Settings to keep enabled
+
+| Setting | API field | How to enable |
+|---------|-----------|---------------|
+| Secret scanning | `secret_scanning.status = enabled` | UI: Settings > Code security |
+| Secret scanning push protection | `secret_scanning_push_protection.status = enabled` | UI: Settings > Code security |
+| Dependabot security updates | `dependabot_security_updates.status = enabled` | UI: Settings > Code security |
+| Private Vulnerability Reporting | (no field; `PUT /.../private-vulnerability-reporting`) | `gh api -X PUT repos/tyabu12/pastura/private-vulnerability-reporting` |
+| Vulnerability alerts | (no field; `PUT /.../vulnerability-alerts`) | `gh api -X PUT repos/tyabu12/pastura/vulnerability-alerts` |
+| Automated security fixes | (no field; `PUT /.../automated-security-fixes`) | `gh api -X PUT repos/tyabu12/pastura/automated-security-fixes` |
+
+### Settings to enable manually via UI
+
+Two secret-scanning sub-settings are not reachable through the public
+REST API as of 2026-05. Enable them once in the UI; the verifier above
+will show their state going forward.
+
+* Settings > Code security and analysis > Secret scanning >
+  **"Scan for non-provider patterns"**
+* Settings > Code security and analysis > Secret scanning >
+  **"Validity checks"** (when available for public repos)
+
+A check of `gh api repos/tyabu12/pastura --jq '.security_and_analysis'`
+should eventually show:
+
+```json
+"secret_scanning_non_provider_patterns": {"status": "enabled"},
+"secret_scanning_validity_checks": {"status": "enabled"}
+```
+
+### Branch protection
+
+`main` is protected via a ruleset (NOT a classic branch-protection
+rule). Verify with:
+
+```bash
+gh api repos/tyabu12/pastura/rules/branches/main \
+  --jq '.[] | {type, parameters}'
+```
+
+Expected rule types: `deletion`, `non_fast_forward`, `pull_request`
+(with `required_approving_review_count` >= 0; the solo-maintainer
+baseline is 0; raise once a second maintainer is onboarded),
+`required_status_checks` (must include `lint-and-test`).
+
+---
+
+## 2. iOS pre-submission audit
+
+Run this section in the same week as an App Store or TestFlight
+external-tester submission. Many items are confirmed continuously by
+CI (SwiftLint, the i18n leak audit, the no-force-unwrap rule), but the
+release pass cross-checks them.
+
+> Phase note: Pastura's Apple Developer Program registration is not yet
+> in place at the time of writing. This section is dormant until that
+> registration unlocks Phase 3 release work. See
+> `project_pastura_distribution_status.md` for context.
+
+### 2.1 Privacy Manifest
+
+* `Pastura/Pastura/PrivacyInfo.xcprivacy` must declare every reason code
+  used by required-reason APIs (`file timestamps`, `UserDefaults`,
+  `disk space`, `active keyboard`, `system boot time`).
+* If a new SDK or framework is added, audit the `PrivacyInfo.xcprivacy`
+  inside the framework bundle for required-reason matches.
+* Confirm `NSPrivacyTracking = false` (Pastura ships no trackers).
+
+### 2.2 App Transport Security (ATS)
+
+* `Info.plist` MUST NOT contain `NSAllowsArbitraryLoads = true`.
+* No `NSExceptionDomains` entries should weaken HTTPS for production
+  hosts. Dev-only ATS exceptions (e.g., for local Ollama testing) belong
+  in the dev scheme, not the release scheme.
+
+Quick check:
+
+```bash
+plutil -p Pastura/Pastura/Info.plist | grep -i "AllowsArbitrary\|ExceptionDomains"
+```
+
+### 2.3 Hardcoded secrets sweep
+
+CI runs secret scanning continuously, but do a release-eve scan to
+catch additions since the last release:
+
+```bash
+gh api repos/tyabu12/pastura/secret-scanning/alerts \
+  --jq '.[] | select(.state == "open") | {number, secret_type, locations_url}'
+```
+
+Confirm no API keys, credentials, or auth tokens are embedded in
+`Resources/`, `Models/`, or scenario YAML files.
+
+### 2.4 Network destinations
+
+Pastura's only outbound network is the model download. Cross-check:
+
+* `App/ModelRegistry.swift` URLs are HTTPS and point to known publishers
+  (Hugging Face, Kaggle).
+* `Info.plist` does not declare any `NSAppTransportSecurity` overrides.
+* The privacy policy at `pages/legal/privacy-policy/` accurately reflects
+  the model-download host list.
+
+### 2.5 Account deletion
+
+Pastura has no user accounts. This row is a placeholder until that
+changes. If you add an account-creation flow, Apple requires an in-app
+account-deletion flow as a hard gate.
+
+---
+
+## 3. Recurring review
+
+### 3.1 Dependabot PRs
+
+Triage on the first weekday of each month after the new Dependabot PRs
+land. Three buckets:
+
+* **Yams, GRDB**: read upstream changelog, run the full test suite
+  through `scripts/xcodebuild.sh test`, merge.
+* **llama.swift**: read upstream `mattt/llama.swift` and the matching
+  `ggerganov/llama.cpp` release notes. Run an end-to-end inference
+  smoke test before merging. Date-encoded tags mean even apparent-patch
+  bumps can include large upstream movement.
+* **GitHub Actions bumps**: verify the bumped action is still SHA-pinned
+  by Dependabot's PR (Dependabot preserves the comment-style version
+  marker); skim release notes for breaking changes.
+
+### 3.2 CodeQL findings
+
+Run `gh api repos/tyabu12/pastura/code-scanning/alerts \
+  --jq '.[] | select(.state == "open") | {number, rule: .rule.id, severity: .rule.severity}'`
+on the first weekday of each month. The weekly schedule means findings
+may be up to seven days old; that is acceptable for a pre-release
+codebase.
+
+For the first public release: dispatch a manual CodeQL run (Actions tab
+> CodeQL > Run workflow) against the exact release commit and resolve
+all findings of severity `error` or `high` before tagging.
+
+### 3.3 Secret-scanning open alerts
+
+```bash
+gh api repos/tyabu12/pastura/secret-scanning/alerts \
+  --jq '.[] | select(.state == "open")'
+```
+
+Should return an empty array. Investigate any non-empty result the same
+day.

--- a/docs/security/release-checklist.md
+++ b/docs/security/release-checklist.md
@@ -162,9 +162,10 @@ land. Three buckets:
 
 Run `gh api repos/tyabu12/pastura/code-scanning/alerts \
   --jq '.[] | select(.state == "open") | {number, rule: .rule.id, severity: .rule.severity}'`
-on the first weekday of each month. The weekly schedule means findings
-may be up to seven days old; that is acceptable for a pre-release
-codebase.
+on the first weekday of each month. The daily schedule means findings
+arrive within 24 hours of landing on `main`; that is acceptable for a
+pre-release codebase, and the workflow runs free against the public
+repository's unlimited GitHub-hosted runner minutes.
 
 For the first public release: dispatch a manual CodeQL run (Actions tab
 > CodeQL > Run workflow) against the exact release commit and resolve


### PR DESCRIPTION
## Summary
Developer-account-independent security hygiene baseline:
- `.github/SECURITY.md` — public security policy with PVR-based reporting.
- `.github/dependabot.yml` — SPM + github-actions monthly version updates; llama.swift minor/patch suppressed (date-encoded tags).
- `.github/workflows/codeql.yml` — Swift CodeQL on weekly schedule + `workflow_dispatch`. Header comment documents the CI-budget trade-off.
- `.github/workflows/deploy-pages.yml` — `pages: write` / `id-token: write` moved from top-level to the `deploy` job; workflow-level retains only `contents: read`.
- `docs/security/release-checklist.md` — operator checklist (GitHub settings, iOS pre-submission audit marked Phase 3, recurring review). Linked from `CLAUDE.md`.

## Manual GitHub-side action taken
Enabled Private Vulnerability Reporting (`gh api -X PUT repos/tyabu12/pastura/private-vulnerability-reporting`) so the SECURITY.md CTA is live on merge.

Secret scanning non-provider patterns + validity checks: the REST PATCH for these sub-settings did not take effect; `release-checklist.md` captures the UI-enable steps as a follow-up.

## Out-of-scope guardrails (intentionally untouched)
- `ci.yml` `pull_request` vs `pull_request_target` trigger semantics.
- `coverage` job's fork-PR `if:` guard against `GIST_SECRET`.
- `pr-comment` job's `permissions: pull-requests: write`.
- Existing third-party Action SHA pinning across `ci.yml` / `deploy-pages.yml` (already complete).
- `ci.yml` top-level `permissions: contents: read` (already correct).

iOS App Store submission audit (Privacy Manifest, ATS, account deletion) is deferred to Phase 3 / pre-submission. Surfaced as checklist entries in `docs/security/release-checklist.md` § 2.

## Test plan
- [ ] CI green on this PR (`lint-and-test` is the required check; no Swift code touched).
- [ ] Post-merge: verify Dependabot opens its first SPM scan within ~24 h at Insights > Dependency graph. If the SPM ecosystem is unparseable, swap `directory:` per the fallback documented in `dependabot.yml`'s header comment.
- [ ] Post-merge: trigger a manual `CodeQL` run from the Actions tab to verify the Swift build path works end-to-end before relying on the weekly schedule.
- [ ] Post-merge: enable secret-scanning "non-provider patterns" + "validity checks" from the Settings UI per `docs/security/release-checklist.md` § 1.

Closes #425.