### PR TITLE
🌐 refactor(i18n): convert LLMError/SimulationError to format-string form (#426)

### DIFF
--- a/Pastura/Pastura/LLM/LLMError.swift
+++ b/Pastura/Pastura/LLM/LLMError.swift
@@ -47,20 +47,21 @@ extension LLMError: LocalizedError {
   public var errorDescription: String? {
     switch self {
     case .loadFailed(let description):
-      return String(localized: "Model load failed: \(description)")
+      return String(format: String(localized: "Model load failed: %@"), description)
     case .generationFailed(let description):
-      return String(localized: "Generation failed: \(description)")
+      return String(format: String(localized: "Generation failed: %@"), description)
     case .notLoaded:
       return String(localized: "Model not loaded")
     case .invalidResponse(let raw):
       let snippet = raw.count > 200 ? String(raw.prefix(200)) + "..." : raw
-      return String(localized: "Invalid LLM response: \(snippet)")
+      return String(format: String(localized: "Invalid LLM response: %@"), snippet)
     case .networkError(let description):
-      return String(localized: "Network error: \(description)")
+      return String(format: String(localized: "Network error: %@"), description)
     case .suspended:
       return String(localized: "Inference was suspended and will retry")
     case .invalidGrammar(let description):
-      return String(localized: "Invalid grammar for constrained decoding: \(description)")
+      return String(
+        format: String(localized: "Invalid grammar for constrained decoding: %@"), description)
     }
   }
 }

--- a/Pastura/Pastura/Models/SimulationEvent.swift
+++ b/Pastura/Pastura/Models/SimulationEvent.swift
@@ -190,10 +190,10 @@ extension SimulationError: LocalizedError {
     case .scenarioValidationFailed(let message):
       return message
     case .llmGenerationFailed(let description):
-      return String(localized: "LLM generation failed: \(description)")
+      return String(format: String(localized: "LLM generation failed: %@"), description)
     case .jsonParseFailed(let raw):
       let snippet = raw.count > 200 ? String(raw.prefix(200)) + "..." : raw
-      return String(localized: "JSON parse failed: \(snippet)")
+      return String(format: String(localized: "JSON parse failed: %@"), snippet)
     case .retriesExhausted:
       return String(
         localized: "LLM returned invalid output after retries. Try again or check model health.")

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -2307,12 +2307,12 @@
         }
       }
     },
-    "Generation failed: %arg" : {
+    "Generation failed: %@" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "生成に失敗しました: %arg"
+            "value" : "生成に失敗しました: %@"
           }
         }
       }
@@ -2417,32 +2417,32 @@
         }
       }
     },
-    "Invalid LLM response: %arg" : {
+    "Invalid LLM response: %@" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "LLM の応答が不正です: %arg"
+            "value" : "LLM の応答が不正です: %@"
           }
         }
       }
     },
-    "Invalid grammar for constrained decoding: %arg" : {
+    "Invalid grammar for constrained decoding: %@" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "制約付きデコードの文法が不正です: %arg"
+            "value" : "制約付きデコードの文法が不正です: %@"
           }
         }
       }
     },
-    "JSON parse failed: %arg" : {
+    "JSON parse failed: %@" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "JSON 解析に失敗しました: %arg"
+            "value" : "JSON 解析に失敗しました: %@"
           }
         }
       }
@@ -2457,12 +2457,12 @@
         }
       }
     },
-    "LLM generation failed: %arg" : {
+    "LLM generation failed: %@" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "LLM の生成に失敗しました: %arg"
+            "value" : "LLM の生成に失敗しました: %@"
           }
         }
       }
@@ -2610,12 +2610,12 @@
         }
       }
     },
-    "Model load failed: %arg" : {
+    "Model load failed: %@" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "モデルの読み込みに失敗しました: %arg"
+            "value" : "モデルの読み込みに失敗しました: %@"
           }
         }
       }
@@ -2700,12 +2700,12 @@
         }
       }
     },
-    "Network error: %arg" : {
+    "Network error: %@" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ネットワークエラー: %arg"
+            "value" : "ネットワークエラー: %@"
           }
         }
       }


### PR DESCRIPTION
## Summary
- Convert 7 `errorDescription` wraps from `String(localized: "...\(arg)...")` to canonical `String(format: String(localized: "...%@..."), arg)` per `.claude/rules/i18n.md` § Format-string pattern.
  - `LLMError`: `loadFailed`, `generationFailed`, `invalidResponse`, `networkError`, `invalidGrammar` (5 sites — issue summary said "8" but the listed cases sum to 7 across both files).
  - `SimulationError`: `llmGenerationFailed`, `jsonParseFailed` (2 sites).
- Catalog: rename 7 keys `%arg` → `%@` with ja translations forwarded; delete stale `%arg` orphans (required because `xcstringstool sync` does not auto-prune entries with populated `ja` values).
- Single bundled commit per `feedback_xcstrings_partial_conversion_orphan_resurrects` memory.

Rendered output is byte-identical to the previous form, so existing `.contains(...)` partial-match tests in `LLMErrorTests` / `SimulationErrorTests` pass unchanged.

## Follow-up (out of scope)
- `DataError` (`Pastura/Pastura/Data/DataError.swift`) has 5 sibling cases still using the legacy Swift-interpolation form. No partial-conversion orphan risk because its `%arg` catalog keys remain live; suitable for a separate slice.

## Test plan
- [x] `scripts/xcodebuild.sh test -skip-testing:PasturaUITests` — 1753 tests pass (24.6s wall)
- [x] `swiftlint lint --strict` — clean
- [x] `python3 scripts/check_localization_coverage.py` — 419 keys, all `ja` translated
- [x] `git diff --stat Pastura/Pastura/Resources/Localizable.xcstrings` — 14 ins / 14 del (proportional, no phantom diff)

Closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)