### PR TITLE
🐛 fix(ci): correct Dependabot dependency-name for llama.swift

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@
 #                      .xcodeproj / .xcworkspace under the configured
 #                      directory, so pointing `directory: "/Pastura"`
 #                      at the parent of Pastura.xcodeproj is sufficient.
-#                      If Dependancy graph reports the SPM ecosystem as
+#                      If Dependency graph reports the SPM ecosystem as
 #                      unparseable after merge, swap `directory:` to
 #                      `/Pastura/Pastura.xcodeproj/project.xcworkspace/xcshareddata/swiftpm`
 #                      as the explicit fallback.
@@ -35,7 +35,13 @@ updates:
       # minor/patch buckets so only apparent-major bumps surface as PRs;
       # upstream llama.cpp CVE response is tracked by watching the fork
       # for new tags and reviewing manually.
-      - dependency-name: "llama.swift"
+      #
+      # Name format: github.com/<owner>/<repo>. This is the canonical
+      # form Dependabot uses for swift-ecosystem deps in PR titles,
+      # branch names, and compatibility-score badges. The Package.resolved
+      # `identity` short name (e.g. "llama.swift") does NOT match here
+      # and makes the filter a silent no-op.
+      - dependency-name: "github.com/mattt/llama.swift"
         update-types:
           - "version-update:semver-minor"
           - "version-update:semver-patch"

--- a/docs/security/release-checklist.md
+++ b/docs/security/release-checklist.md
@@ -40,24 +40,36 @@ gh api repos/tyabu12/pastura/private-vulnerability-reporting -i \
 | Vulnerability alerts | (no field; `PUT /.../vulnerability-alerts`) | `gh api -X PUT repos/tyabu12/pastura/vulnerability-alerts` |
 | Automated security fixes | (no field; `PUT /.../automated-security-fixes`) | `gh api -X PUT repos/tyabu12/pastura/automated-security-fixes` |
 
-### Settings to enable manually via UI
+### Secret-scanning sub-settings: free vs paid
 
-Two secret-scanning sub-settings are not reachable through the public
-REST API as of 2026-05. Enable them once in the UI; the verifier above
-will show their state going forward.
+Two `security_and_analysis` API fields show `disabled` after PVR /
+push-protection / dependabot-security-updates are on. Subsequent
+verification (2026-05) reveals they have different plan requirements,
+not just a UI gap:
 
-* Settings > Code security and analysis > Secret scanning >
-  **"Scan for non-provider patterns"**
-* Settings > Code security and analysis > Secret scanning >
-  **"Validity checks"** (when available for public repos)
+* **`secret_scanning_non_provider_patterns`** (UI label: "Scan for
+  non-provider patterns"): requires **GitHub Secret Protection**, a
+  paid add-on. The UI option does not surface for free public repos
+  without GHAS / Secret Protection enabled. Track this as a paid-plan
+  upgrade consideration; the field will stay `disabled` until the
+  add-on is purchased.
 
-A check of `gh api repos/tyabu12/pastura --jq '.security_and_analysis'`
-should eventually show:
+* **`secret_scanning_validity_checks`** (UI label: "Automatically
+  verify if a secret is valid by sending it to the relevant partner"):
+  free for public repositories per GitHub's docs. Enable from Settings
+  > Code security and analysis > Secret scanning. If the option does
+  not appear, try an incognito browser session (cache) and search the
+  page for `verify`; if still absent, contact GitHub support since the
+  rollout has been account-dependent historically.
+
+After enabling Validity checks, the verifier output should change to:
 
 ```json
-"secret_scanning_non_provider_patterns": {"status": "enabled"},
 "secret_scanning_validity_checks": {"status": "enabled"}
 ```
+
+(`secret_scanning_non_provider_patterns` will stay `disabled` on the
+current free plan; that is expected, not a regression.)
 
 ### Branch protection
 


### PR DESCRIPTION
## Summary

Two corrections bundled under "security baseline (PR #429) follow-up":

1. **Dependabot dependency-name** (`98f5e3d`): `.github/dependabot.yml` had `dependency-name: "llama.swift"` (Package.resolved `identity` short name). Dependabot's `swift` ecosystem uses `github.com/<owner>/<repo>` as the canonical name (verified against PR #434's title, branch name, and compatibility-score URL — all agree on `github.com/mattt/llama.swift`). The mismatch made the `semver-minor` / `semver-patch` ignore rule a silent no-op. Adds an inline anchor comment and a trivial typo fix ("Dependancy" → "Dependency").

2. **Release-checklist plan requirements** (`e0f3aca`): `docs/security/release-checklist.md` from PR #429 asserted both `secret_scanning_non_provider_patterns` and `secret_scanning_validity_checks` were UI-enable items. Verification on 2026-05-16 reveals different plan tiers:
   - `non_provider_patterns` requires the paid **GitHub Secret Protection** add-on; the UI option does not surface on free public repos. Stays `disabled` until the add-on is purchased.
   - `validity_checks` IS free for public repos; the checklist now points at the correct UI control name with incognito / GitHub-support fallback steps.

Why bundled: both are 1-file post-merge corrections of PR #429 that surfaced within the same review cycle (the doc correction was triggered by the operator confirming the `non_provider_patterns` UI did not appear, despite the checklist claiming it would). Splitting would double CI / review overhead without isolating risk.

## Test plan
- [ ] CI green (`lint-and-test`; no Swift code touched).
- [ ] Post-merge: comment `@dependabot ignore this minor version` on PR #434 (belt-and-suspenders for Dependabot's per-dep memory), then close PR #434.
- [ ] Verify on the next Dependabot monthly cycle (or sooner via `@dependabot recreate` on any open Dependabot PR) that no new `llama.swift` minor / patch PRs surface.
- [ ] (Operator-side) Try to enable Validity checks in Settings > Code security and analysis; if not visible, follow the incognito / GitHub-support fallback in `release-checklist.md`.

Closes #437.