### PR TITLE
🌐 refactor(i18n): convert DataError to format-string form (#435)

### DIFF
--- a/Pastura/Pastura/Data/DataError.swift
+++ b/Pastura/Pastura/Data/DataError.swift
@@ -34,17 +34,17 @@ extension DataError: LocalizedError {
   public var errorDescription: String? {
     switch self {
     case .databaseOpenFailed(let description):
-      return String(localized: "Database open failed: \(description)")
+      return String(format: String(localized: "Database open failed: %@"), description)
     case .migrationFailed(let description):
-      return String(localized: "Database migration failed: \(description)")
+      return String(format: String(localized: "Database migration failed: %@"), description)
     case .recordNotFound(let type, let id):
-      return String(localized: "Record not found: \(type) id=\(id)")
+      return String(format: String(localized: "Record not found: %@ id=%@"), type, id)
     case .encodingFailed(let description):
-      return String(localized: "Encoding failed: \(description)")
+      return String(format: String(localized: "Encoding failed: %@"), description)
     case .decodingFailed(let description):
-      return String(localized: "Decoding failed: \(description)")
+      return String(format: String(localized: "Decoding failed: %@"), description)
     case .readonly(let id):
-      return String(localized: "Record is read-only: id=\(id)")
+      return String(format: String(localized: "Record is read-only: id=%@"), id)
     }
   }
 }

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -1498,32 +1498,32 @@
         }
       }
     },
-    "Database migration failed: %arg" : {
+    "Database migration failed: %@" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "データベースのマイグレーションに失敗しました: %arg"
+            "value" : "データベースのマイグレーションに失敗しました: %@"
           }
         }
       }
     },
-    "Database open failed: %arg" : {
+    "Database open failed: %@" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "データベースのオープンに失敗しました: %arg"
+            "value" : "データベースのオープンに失敗しました: %@"
           }
         }
       }
     },
-    "Decoding failed: %arg" : {
+    "Decoding failed: %@" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "デコードに失敗しました: %arg"
+            "value" : "デコードに失敗しました: %@"
           }
         }
       }
@@ -1821,12 +1821,12 @@
         }
       }
     },
-    "Encoding failed: %arg" : {
+    "Encoding failed: %@" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "エンコードに失敗しました: %arg"
+            "value" : "エンコードに失敗しました: %@"
           }
         }
       }
@@ -3308,22 +3308,28 @@
         }
       }
     },
-    "Record is read-only: id=%arg" : {
+    "Record is read-only: id=%@" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "レコードは読み取り専用です: id=%arg"
+            "value" : "レコードは読み取り専用です: id=%@"
           }
         }
       }
     },
-    "Record not found: %arg id=%arg" : {
+    "Record not found: %@ id=%@" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Record not found: %1$@ id=%2$@"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "レコードが見つかりません: %arg id=%arg"
+            "value" : "レコードが見つかりません: %1$@ id=%2$@"
           }
         }
       }


### PR DESCRIPTION
## Summary
- Convert 6 `errorDescription` wraps in `Pastura/Pastura/Data/DataError.swift` from `String(localized: \"...\(arg)...\")` to canonical `String(format: String(localized: \"...%@...\"), arg)` per `.claude/rules/i18n.md` § Format-string pattern.
- Catalog: rename 6 keys `%arg` → `%@` (`Database open failed`, `Database migration failed`, `Encoding failed`, `Decoding failed`, `Record is read-only: id=`, `Record not found: …`); ja translations forwarded with placeholder shape updated. Multi-arg `.recordNotFound` uses disambiguated positional `%1$@ id=%2$@` in both `en` and `ja` blocks per Apple `xcstringstool sync` output and PR #430 precedent.
- Delete 6 stale `%arg` orphans manually — `xcstringstool sync` does NOT auto-prune entries with populated `ja` (memory `reference_xcstringstool_sync_auto_prune`).
- Single bundled commit per memory `feedback_xcstrings_partial_conversion_orphan_resurrects` — partial conversion would resurrect the old `%arg` keys as empty `{}` orphans on the next sync.

Rendered output stays byte-identical (`String(format: \"%@\", x)` vs `\"\(x)\"`), so the existing 7 `DataErrorLocalizedErrorTests` `.contains(...)` assertions pass unchanged. Closes the i18n format-string convention slice begun in #426 — `DataError` was the last `LocalizedError`-conforming type still on the legacy interpolation form.

## Test plan
- [x] `scripts/xcodebuild.sh test -skip-testing:PasturaUITests` — 1753 tests pass (23.2s wall, full unit suite)
- [x] `swiftlint lint --strict` — clean
- [x] `python3 scripts/check_localization_coverage.py` — 419 keys, all `ja` translated, all `state: translated`
- [x] `git diff --stat Pastura/Pastura/Resources/Localizable.xcstrings` — 18+ / 12− (proportional, no phantom format drift)
- [x] Subagent code-reviewer (Opus) — PASS, 0 issues

Closes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)