### PR TITLE
🐛 fix(docs): correct validity_checks plan tier (also paid)

### DIFF
--- a/docs/security/release-checklist.md
+++ b/docs/security/release-checklist.md
@@ -40,36 +40,39 @@ gh api repos/tyabu12/pastura/private-vulnerability-reporting -i \
 | Vulnerability alerts | (no field; `PUT /.../vulnerability-alerts`) | `gh api -X PUT repos/tyabu12/pastura/vulnerability-alerts` |
 | Automated security fixes | (no field; `PUT /.../automated-security-fixes`) | `gh api -X PUT repos/tyabu12/pastura/automated-security-fixes` |
 
-### Secret-scanning sub-settings: free vs paid
+### Secret-scanning sub-settings: Secret Protection (paid) features
 
-Two `security_and_analysis` API fields show `disabled` after PVR /
-push-protection / dependabot-security-updates are on. Subsequent
-verification (2026-05) reveals they have different plan requirements,
-not just a UI gap:
+Several `security_and_analysis` API fields beyond the base toggle
+require **GitHub Secret Protection**, a paid add-on. The familiar
+"Secret scanning is free for public repositories" headline applies
+only to the base `secret_scanning` + `secret_scanning_push_protection`
+toggles; everything listed below requires Secret Protection. Verified
+2026-05 against GitHub's Secret Protection product page (which lists
+Validity checks as a Secret Protection feature) and against the
+canonical paid-gate signal, namely that
+`PATCH security_and_analysis[X][status]=enabled` returns 200 OK but
+the field stays `disabled` on subsequent GET.
 
-* **`secret_scanning_non_provider_patterns`** (UI label: "Scan for
-  non-provider patterns"): requires **GitHub Secret Protection**, a
-  paid add-on. The UI option does not surface for free public repos
-  without GHAS / Secret Protection enabled. Track this as a paid-plan
-  upgrade consideration; the field will stay `disabled` until the
-  add-on is purchased.
+* **`secret_scanning_non_provider_patterns`** covers generic /
+  non-provider secret detection (UI label: "Scan for non-provider
+  patterns").
 
-* **`secret_scanning_validity_checks`** (UI label: "Automatically
-  verify if a secret is valid by sending it to the relevant partner"):
-  free for public repositories per GitHub's docs. Enable from Settings
-  > Code security and analysis > Secret scanning. If the option does
-  not appear, try an incognito browser session (cache) and search the
-  page for `verify`; if still absent, contact GitHub support since the
-  rollout has been account-dependent historically.
+* **`secret_scanning_validity_checks`** covers liveness verification
+  of detected secrets via partner APIs (UI label: "Automatically
+  verify if a secret is valid by sending it to the relevant
+  partner").
 
-After enabling Validity checks, the verifier output should change to:
+* **`secret_scanning_ai_detection`** is Copilot-powered generic
+  pattern detection.
 
-```json
-"secret_scanning_validity_checks": {"status": "enabled"}
-```
+* **`secret_scanning_delegated_alert_dismissal`** and
+  **`secret_scanning_delegated_bypass`** are org-level delegated
+  workflows.
 
-(`secret_scanning_non_provider_patterns` will stay `disabled` on the
-current free plan; that is expected, not a regression.)
+All of the above will stay `disabled` on Pastura's current free plan;
+that is expected, not a regression. Track Secret Protection adoption
+as a paid-plan consideration alongside Apple Developer Program
+registration (see § 2 below).
 
 ### Branch protection
 


### PR DESCRIPTION
## Summary
Third-round correction of `docs/security/release-checklist.md`'s "Secret-scanning sub-settings" section.

- PR #429 introduced it, classifying both `validity_checks` and `non_provider_patterns` as UI-enable items.
- PR #440 corrected `non_provider_patterns` to paid, but incorrectly kept `validity_checks` as free.
- This PR corrects `validity_checks` to paid (GitHub Secret Protection required), reshapes the section to a single paid-features list, and removes the invalid "After enabling..." narrative + JSON block.

## Verification triangulation
- Operator: UI option "Automatically verify..." does not surface in `Settings > Code security and analysis` for `tyabu12/pastura` (free public, no GHAS).
- GitHub Secret Protection product page: lists Validity checks as a Secret Protection feature.
- API gate signal: `PATCH security_and_analysis[secret_scanning_validity_checks][status]=enabled` returns 200 OK but `disabled` persists on subsequent GET.

## Section structure change
- Title: "free vs paid" → "Secret Protection (paid) features" (only base `secret_scanning` + push-protection remain free).
- Adds inline "Verified 2026-05" preamble framing that the popular "Secret scanning is free for public repositories" headline applies only to the base toggle + push protection.
- Enumerates the paid surface: `non_provider_patterns`, `validity_checks`, `ai_detection`, `delegated_alert_dismissal`, `delegated_bypass`.
- Removes "After enabling Validity checks..." narrative + JSON expectations.

## Test plan
- [x] CI green (`lint-and-test`; docs-only).
- [x] **Squash-merge** using this PR's title + body as the final commit message source. The individual commit body contains a non-load-bearing memory-filename reference (flagged by code-reviewer, accepted as squash-mitigated since squash uses PR title/body, not individual commit body).

Closes #442.