### PR TITLE
📝 docs: align CLAUDE.md Phase 2 line with #422 pivot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Phase 2 progress:
 - **Simulation result export** — Markdown via Share Sheet, incl. code-phase results (#91/#98)
 - **Inference speed display** — tok/s + simulation playback UX (#99)
 - **Past results — code-phase events** — score_calc / scenario gen events in past-results viewer (#102/#113)
-- **Localization (i18n: ja/en)** — *in progress* — see ROADMAP § "Localization Plan" (#276/#277, ADR-010 stub #279, body #367, B-1a public pages #369, responsive-design migration #373, Engine dynamic localization #383, drift script + Past Results compat #386, bundled English presets + EN DL demo replays + locale-driven runtime selection #388, Step E PR1 simulation_language Engine wiring #398, Step E PR2 LLM output-language adherence enforcement #405, Step E follow-up `.languageMismatch` UI toast + drift badge #422)
+- **Localization (i18n: ja/en)** — *in progress* — see ROADMAP § "Localization Plan" (#276/#277, ADR-010 stub #279, body #367, B-1a public pages #369, responsive-design migration #373, Engine dynamic localization #383, drift script + Past Results compat #386, bundled English presets + EN DL demo replays + locale-driven runtime selection #388, Step E PR1 simulation_language Engine wiring #398, Step E PR2 LLM output-language adherence enforcement #405, Step E follow-up `.languageMismatch` UI toast + completion summary #422)
 - **Launch animation** — cold "Pastoral Drift" + warm "Breath" hybrid; per-scene `LaunchPhaseCoordinator` + Reduce Motion fallback (#412/#415)
 
 ## Language Rules


### PR DESCRIPTION
## Summary

Trailing follow-up to #446 — the Phase 2 progress line in CLAUDE.md
still recorded the original badge-based design (\`toast + drift badge\`)
from #422, but the pre-merge pivot replaced the badge with a run-end
completion-summary line. Same residual-stale-reference class as the
\`SimulationViewModel.swift\` doc-comments cleaned up in #446 — landed
separately because that PR squash-merged before this commit could be
pushed.

\`toast + drift badge #422\` → \`toast + completion summary #422\`

## Test plan

- [x] CLAUDE.md unchanged outside the 1-line update
- [x] CI green (markdown-only change)

Relates to #401, #422, #446.