### PR TITLE
🧹 chore(tests): merge duplicate DataErrorTests suites

### DIFF
--- a/Pastura/PasturaTests/Data/DataErrorTests.swift
+++ b/Pastura/PasturaTests/Data/DataErrorTests.swift
@@ -4,7 +4,24 @@ import Testing
 @testable import Pastura
 
 @Suite(.timeLimit(.minutes(1)))
-struct DataErrorLocalizedErrorTests {
+struct DataErrorTests {
+  // MARK: - Equatable / Error conformance
+
+  @Test func casesAreEquatable() {
+    let error1 = DataError.databaseOpenFailed(description: "fail")
+    let error2 = DataError.databaseOpenFailed(description: "fail")
+    #expect(error1 == error2)
+
+    let notFound1 = DataError.recordNotFound(type: "Scenario", id: "123")
+    let notFound2 = DataError.recordNotFound(type: "Scenario", id: "456")
+    #expect(notFound1 != notFound2)
+  }
+
+  @Test func conformsToError() {
+    let error: any Error = DataError.encodingFailed(description: "bad json")
+    #expect(error is DataError)
+  }
+
   // MARK: - LocalizedError conformance
 
   @Test func conformsToLocalizedError() {

--- a/Pastura/PasturaTests/Data/DatabaseManagerTests.swift
+++ b/Pastura/PasturaTests/Data/DatabaseManagerTests.swift
@@ -89,21 +89,3 @@ import Testing
     }
   }
 }
-
-@Suite(.timeLimit(.minutes(1))) struct DataErrorTests {
-
-  @Test func casesAreEquatable() {
-    let error1 = DataError.databaseOpenFailed(description: "fail")
-    let error2 = DataError.databaseOpenFailed(description: "fail")
-    #expect(error1 == error2)
-
-    let notFound1 = DataError.recordNotFound(type: "Scenario", id: "123")
-    let notFound2 = DataError.recordNotFound(type: "Scenario", id: "456")
-    #expect(notFound1 != notFound2)
-  }
-
-  @Test func conformsToError() {
-    let error: any Error = DataError.encodingFailed(description: "bad json")
-    #expect(error is DataError)
-  }
-}


### PR DESCRIPTION
## Summary

- Two `struct DataErrorTests` declarations coexisted in `Pastura/PasturaTests/Data/` — 2 tests in `DatabaseManagerTests.swift` and 7 (renamed `DataErrorLocalizedErrorTests`) in `DataErrorTests.swift`.
- `xcodebuild test -only-testing PasturaTests/DataErrorTests` silently resolved to only the 2-test struct (Swift Testing name-resolution trap), reporting `** TEST SUCCEEDED **` while the 7-test suite never ran. Observed during PR #441 session.
- Fix: move the 2 tests into `DataErrorTests.swift`, rename the absorbing suite to `DataErrorTests`. All 9 tests preserved verbatim — no behavior change, no production code touched.

## Test plan

- [x] `scripts/xcodebuild.sh test -only-testing PasturaTests/DataErrorTests` reports `Test run with 9 tests in 1 suite passed` (was 2 before)
- [x] Full unit suite (`-skip-testing:PasturaUITests`): 1768 tests / 159 suites pass
- [x] `swiftlint lint --quiet --strict` clean
- [x] `@Suite(.timeLimit(.minutes(1)))` trait preserved on the merged suite
- [x] No GRDB import dragged into `DataErrorTests.swift` (moved tests use only `DataError` constructors)
- [x] `DatabaseManagerTests.swift` retains its 5 original tests with unchanged imports

Closes #445