### PR TITLE
👷 ci: auto-retry ui-test runner-init flakes (main 3, PR 2)

### DIFF
--- a/.github/workflows/ci-retry.yml
+++ b/.github/workflows/ci-retry.yml
@@ -1,0 +1,88 @@
+# Interim auto-retry for CI failures dominated by ui-test runner-init flakes
+# (issue #444). The ui-test job intermittently fails with "The test runner
+# failed to initialize for UI testing. (Underlying Error: Timed out while
+# loading Accessibility.)" before any individual test runs, so xcodebuild's
+# `-retry-tests-on-failure -test-iterations 2` (which presupposes the runner
+# booted) cannot recover. Manual `gh run rerun --failed` recovers in ~9/10
+# cases (memory feedback_ci_uitest_launch_timeout_flake.md).
+#
+# Attempt arithmetic (workflow_run.run_attempt is the attempt that just
+# completed-as-failed):
+#   main push: rerun while attempt < 3 → up to 3 total (initial + 2 retries)
+#   pull_request: rerun while attempt < 2 → up to 2 total (initial + 1 retry)
+# Off-by-one here either disables the retry entirely or creates an unbounded
+# loop, so guard arithmetic carefully on edits.
+#
+# Selective gating: only retry when the `ui-test` job is among the failed
+# jobs. Whole-run rerun would amplify cost when a real lint regression
+# coincides with the flake (worst case: 25 min ui-test budget burned to
+# rediscover lint fail) and would erode signal quality.
+#
+# Fork-PR caveat: GITHUB_TOKEN on workflow_run from a fork PR is read-only
+# for `actions:` scope, so `gh run rerun` will silently fail. Retry is
+# best-effort for fork PRs by design — first-party PR retries cover the
+# common case.
+
+name: CI Retry
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+# Defends against duplicate webhook delivery for the same workflow_run.
+# Keyed by the failed run's id so unrelated retries don't serialize.
+concurrency:
+  group: ci-retry-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  rerun:
+    name: Rerun failed CI jobs
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+    if: >-
+      github.event.workflow_run.conclusion == 'failure'
+      && (
+        (github.event.workflow_run.event == 'push'
+          && github.event.workflow_run.head_branch == 'main'
+          && github.event.workflow_run.run_attempt < 3)
+        || (github.event.workflow_run.event == 'pull_request'
+          && github.event.workflow_run.run_attempt < 2)
+      )
+    steps:
+      - name: Check whether ui-test was among the failed jobs
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          # Only retry when ui-test failed. Other failures (lint regression,
+          # ADR-005 §8 leak, drift guards) are deterministic — re-running
+          # them would mask signal and burn CI minutes.
+          UI_TEST_FAILED=$(gh run view "$RUN_ID" --json jobs \
+            --jq '[.jobs[] | select(.name == "ui-test" and .conclusion == "failure")] | length')
+          echo "ui_test_failed=$UI_TEST_FAILED" >> "$GITHUB_OUTPUT"
+          echo "ui-test failed-job count: $UI_TEST_FAILED"
+
+      - name: Rerun failed jobs
+        if: steps.check.outputs.ui_test_failed != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          EVENT: ${{ github.event.workflow_run.event }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          echo "Triggering rerun for run $RUN_ID (attempt=$ATTEMPT, event=$EVENT, branch=$BRANCH)"
+          # `--failed` reruns failed jobs AND any jobs that depend on them,
+          # so `pr-comment` (depends on ui-test) re-fires and the sticky CI
+          # report comment reflects the retry outcome.
+          gh run rerun --failed "$RUN_ID"

--- a/.github/workflows/ci-retry.yml
+++ b/.github/workflows/ci-retry.yml
@@ -35,6 +35,8 @@ permissions:
 
 # Defends against duplicate webhook delivery for the same workflow_run.
 # Keyed by the failed run's id so unrelated retries don't serialize.
+# Second invocation sees state mutated by the first (rerun already in
+# flight) → `gh run rerun` no-ops or errors; either way no cascade.
 concurrency:
   group: ci-retry-${{ github.event.workflow_run.id }}
   cancel-in-progress: false
@@ -46,6 +48,10 @@ jobs:
     timeout-minutes: 5
     permissions:
       actions: write
+    # `conclusion == 'failure'` deliberately excludes `cancelled` (manual
+    # stop), `timed_out` (legitimately stuck — retry would just re-hit the
+    # timeout), and `action_required` (waiting on approval). Do not
+    # broaden to `!= 'success'`.
     if: >-
       github.event.workflow_run.conclusion == 'failure'
       && (

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,14 @@ If your change touches an architectural boundary, check
 
 `main` is push-protected, so all changes land via PR.
 
+On PRs and `main`, CI auto-reruns the `ui-test` job on intermittent
+runner-init failures (up to 2 total attempts on PRs, 3 on `main`). Other
+failures fall through unchanged. If attempt 2 turns the run green after
+attempt 1 failed, that is the retry firing as designed; the latest
+attempt holds the real verdict. See
+[`.github/workflows/ci-retry.yml`](.github/workflows/ci-retry.yml) for
+the trigger and gating logic.
+
 ### Commits
 
 Conventional Commits with an emoji prefix, under 72 chars on the


### PR DESCRIPTION
## Summary
- `workflow_run`-triggered auto-retry for CI runs where `ui-test` is among the failed jobs
- `main` push: max 3 attempts (initial + 2 retries); pull_request: max 2 attempts (initial + 1 retry)
- Selective gating: lint / ADR-005 §8 leak / drift-guard failures fall through without retry

## Background
ui-test has been failing 15% of the time on main (3/20 recent runs) with "The test runner failed to initialize for UI testing. (Underlying Error: Timed out while loading Accessibility.)" — a runner-init flake the existing `-retry-tests-on-failure -test-iterations 2` cannot recover from. Manual `gh run rerun --failed` already worked in ~9/10 cases; this PR automates it within bounded attempt counts.

## Design notes
- Trigger: `workflow_run` on `CI` completion. Uses default-branch workflow file, so first effective from main post-merge.
- Branch detection: `event == 'push' && head_branch == 'main'` (the AND defends against a fork PR with a branch literally named `main`).
- `run_attempt` arithmetic: rerun while `<3` for main, `<2` for PR. Off-by-one would either disable retry or create an unbounded loop, so guarded carefully.
- Selective: `gh run view --json jobs --jq` pre-check filters out non-ui-test failures to preserve signal and bound worst-case CI minutes.
- Concurrency: self-group keyed by `workflow_run.id` defends against duplicate webhook delivery.
- `conclusion == 'failure'` deliberately excludes `cancelled` / `timed_out` / `action_required`.
- Fork-PR retries are intentionally best-effort (`GITHUB_TOKEN` is read-only for `actions:` on fork-origin `workflow_run`).

## Test plan
- [x] `actionlint .github/workflows/ci-retry.yml` PASS locally
- [x] Plan-stage critic (Opus) Critical + main Warnings addressed (selective gating, two-condition branch detection, self-concurrency group)
- [x] code-reviewer (Opus) PASS with 0 Critical / 0 Warning; 2 minor suggestions incorporated
- [ ] Post-merge: next ui-test failure on `main` triggers automatic attempt 2
- [ ] Post-merge: ui-test failure on a PR triggers exactly 1 retry (attempt 2)
- [ ] Lint-only or release-build-only failure does NOT trigger retry (selective gating)

Closes #444