### PR TITLE
📚 chore(rules): promote 6 memory entries → .claude/rules/

### DIFF
--- a/.claude/rules/i18n.md
+++ b/.claude/rules/i18n.md
@@ -27,6 +27,50 @@ Why explicit format vs modern interpolation: explicit control over format-specif
 
 Canonical example: `Pastura/Pastura/Views/Components/GameHeader.swift`.
 
+## SwiftUI convenience-init label trap
+
+SwiftUI convenience-init labels (`Stepper`, `Toggle`, `Picker`, `Slider`,
+`Section`, etc.) accept `LocalizedStringKey`, not `String`. When the Swift
+literal contains `\(...)` interpolation, the **entire runtime-interpolated
+string** becomes the catalog lookup key. xcstringstool extracts the format
+template (`"Chance: %@"`) at compile time, but at runtime the lookup key
+is the literal value (`"Chance: 0.5"`) — catalog miss → English fallback,
+even when locale is `ja`.
+
+```swift
+// ✗ Silent fallback on ja locale — runtime "Chance: 0.5" misses catalog
+Stepper("Chance: \(formattedProb)", value: $prob, in: 0...1)
+
+// ✓ Label-closure form + canonical String(format:) call
+Stepper(value: $prob, in: 0...1) {
+  Text(String(format: String(localized: "Chance: %@"), formattedProb))
+}
+```
+
+Same pattern for `Toggle("...\(x)...", isOn:)`, `Picker("...\(x)...",
+selection:)`, etc. Switch to the explicit label-closure overload and
+format the string through the canonical `String(format: String(localized:))`
+path documented in § "Format-string pattern".
+
+### Why Tier 1 / Tier 2 don't catch this
+
+- **Tier 1 SwiftLint tripwire**: the literal is technically already inside
+  a "localization-aware" callsite (`Stepper`'s `LocalizedStringKey` overload),
+  so the heuristic-based unwrapped-string detector treats it as covered.
+- **Tier 2 audit (`scripts/check_i18n_potential_keys.py`)**: may or may
+  not surface depending on how Swift extracts the format string from the
+  `LocalizedStringKey` initializer. Empirically missed multiple instances
+  before PR #423 manual triage.
+
+### Detection grep
+
+```
+rg '(Stepper|Toggle|Picker|Slider|Section)\("[^"]*\\\(' --type swift
+```
+
+Run before any i18n slice that touches Editor / Settings / Form-heavy
+surfaces.
+
 ## xcstringstool sync output
 
 `scripts/xcodebuild.sh build` auto-runs `xcrun xcstringstool sync` against `Localizable.xcstrings`. For **multi-arg** keys, sync generates a catalog entry with the source key plus a positional-form `en` block:

--- a/.claude/rules/i18n.md
+++ b/.claude/rules/i18n.md
@@ -87,6 +87,63 @@ surfaces.
 
 The `en` block is Apple's disambiguated positional form, kept as a translator reference. **Add the `ja` block as a sibling under `localizations`, never replace the `en` block.** Single-arg keys (`"%@ is thinking..."`) get an empty body — insert the full `localizations.ja.stringUnit` structure.
 
+## `%arg` placeholder and partial-conversion orphans
+
+### What `%arg` means
+
+`%arg` literals in `Localizable.xcstrings` keys (e.g., `"Save failed: %arg"`,
+`""%arg" already uses this id..."`) are **Apple's auto-extracted
+placeholder** for `String(localized: "Foo \(x)")` (Swift 5.7+ interpolation
+in `String(localized:)`). They are functional at runtime, NOT bugs:
+
+| Form | Source | Catalog key | Runtime |
+|---|---|---|---|
+| A (Swift-interp) | `String(localized: "Save failed: \(error)")` | `"Save failed: %arg"` | Apple substitutes `error` into `%arg` |
+| B (Pastura convention) | `String(format: String(localized: "Save failed: %@"), error)` | `"Save failed: %@"` | `String(format:)` substitutes via `%@` |
+
+Both render identical user-visible output. Pastura prefers Form B per
+§ "Format-string pattern" — explicit format-specifier control + type
+safety (`%@` vs `%lld` catches `Int`/`String` mismatch).
+
+For multi-arg keys, sync also emits a positional-form `en` block
+(`"Foo %1$arg %2$arg"`), preserved as translator reference per
+§ "xcstringstool sync output".
+
+### The partial-conversion trap
+
+When a slice converts SOME Form-A sites to Form B but leaves others
+unconverted, the catalog ends up with BOTH `"Foo %arg"` (kept alive by
+the unconverted sites) AND `"Foo %@"` (added by converted sites). Manually
+deleting the `%arg` key from the catalog is **futile**: the next
+`xcrun xcstringstool sync` (auto-runs on `scripts/xcodebuild.sh build`)
+regenerates it, often as an empty `{}` body → trips
+`scripts/check_localization_coverage.py` (Tier 3 CI gate).
+
+**Why**: sync scans source for catalog keys. As long as ANY `String(localized:
+"Foo \(x)")` exists, the `%arg` form key is "alive" — Apple's tooling doesn't
+know it's semantically duplicate with the `%@` form.
+
+### Apply when planning a partial-scope i18n slice
+
+1. **Before plan finalization**, grep ALL sites using the same literal:
+   ```
+   rg '"Save failed' Pastura/Pastura/ --type swift
+   ```
+   If multiple files share the literal, list them in the plan.
+
+2. **Choose one**:
+   - **Bundle**: convert all sites in this PR (best when ≤ 3 extra sites).
+   - **Fill orphan**: leave the resurrected `%arg` orphan with ja-translated
+     state so coverage passes. Document residual sites in PR body as
+     "deferred to future slice".
+   - **Defer**: don't touch the literal in this PR.
+
+3. **Verify post-build**: re-run `python3 scripts/check_localization_coverage.py`
+   AFTER any `scripts/xcodebuild.sh build` — sync side-effects re-emerge between
+   commits.
+
+See PR #416 for the resurrect-via-sync mechanism in practice.
+
 ## state=new + en-only after sync
 
 Sync also leaves new entries with `state: "new"` on the en entry and no `ja` localization. `scripts/check_localization_coverage.py` fails CI on both conditions (missing `ja` AND `state != "translated"`).

--- a/.claude/rules/i18n.md
+++ b/.claude/rules/i18n.md
@@ -59,8 +59,8 @@ path documented in § "Format-string pattern".
   so the heuristic-based unwrapped-string detector treats it as covered.
 - **Tier 2 audit (`scripts/check_i18n_potential_keys.py`)**: may or may
   not surface depending on how Swift extracts the format string from the
-  `LocalizedStringKey` initializer. Empirically missed multiple instances
-  before PR #423 manual triage.
+  `LocalizedStringKey` initializer. Tier 2 empirically missed multiple
+  instances — see PR #423 for the case-study triage.
 
 ### Detection grep
 

--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -37,3 +37,25 @@ File a rolling tracking issue collecting candidate sections, then `/orchestrate`
 1. Lands additions to `.claude/rules/` (or `CLAUDE.md` for project-wide rules).
 2. Strips `Source memory: feedback_*` provenance lines from drafts before commit — repo-tracked files referring to per-user memory by name are dead links for other contributors.
 3. After PR merges, locally `command rm ~/.claude/projects/.../memory/<source>.md` — the PR can't enforce memory deletion (it's per-user / per-machine); track via the rolling issue checklist.
+
+## Anti-pattern: memory refs in repo-tracked files
+
+Auto-memory at `~/.claude/projects/<workspace>/memory/` is **per-user /
+per-machine**. Any reference of the form `` memory `foo.md` `` inside a
+repo-tracked file (CLAUDE.md, CONTRIBUTING.md, ADRs, source comments,
+script header docs) is a **dead link** for everyone except the
+maintainer who wrote the memory.
+
+**Apply** — for rationale in any repo-tracked file, prefer inline summary
++ PR / issue / ADR pointer (`#410`, `ADR-007`, etc.). Memory refs are
+acceptable **only** in never-committed places (`~/.claude/CLAUDE.md`,
+conversational scratch).
+
+**Detection** — should return 0 hits:
+
+```
+rg -n 'memory `[a-z_]+\.md`' --glob '!**/memory/**' --glob '!.git/**'
+```
+
+Documented carve-outs exist where inline rationale would be too dense —
+see PR #420 for the current carve-out list and the motivating incident.

--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -51,11 +51,18 @@ maintainer who wrote the memory.
 acceptable **only** in never-committed places (`~/.claude/CLAUDE.md`,
 conversational scratch).
 
-**Detection** — should return 0 hits:
+**Detection** — new code must not add hits to this grep:
 
 ```
 rg -n 'memory `[a-z_]+\.md`' --glob '!**/memory/**' --glob '!.git/**'
 ```
 
-Documented carve-outs exist where inline rationale would be too dense —
-see PR #420 for the current carve-out list and the motivating incident.
+Known carve-outs (where inline rationale would be too dense to migrate):
+
+- `Pastura/Pastura/Views/Components/ThoughtVisibilityToggle.swift` —
+  ShapeStyle vs Color token trap rationale
+- `Pastura/PasturaTests/App/LaunchPhaseCoordinatorTests.swift` —
+  CI wallclock test bound rationale
+
+See PR #420 for the motivating incident. Long-term, both carve-outs
+should migrate to inline rationale or a public doc home.

--- a/.claude/rules/swift-isolation.md
+++ b/.claude/rules/swift-isolation.md
@@ -92,6 +92,6 @@ Pattern 2 (which says "auto-synth doesn't need the annotation").
    the conformance for any future nonisolated caller. Use only with
    ≥2 unrelated nonisolated call sites.
 
-Reference: `Pastura/PasturaTests/Components/ModelRowAccessibilityTests.swift`
+Reference: `Pastura/PasturaTests/Views/ModelRowAccessibilityTests.swift`
 carries `@MainActor` on the suite; `SheepAvatar.Character` keeps its
 default-MainActor isolation.

--- a/.claude/rules/swift-isolation.md
+++ b/.claude/rules/swift-isolation.md
@@ -2,10 +2,10 @@
 
 **Scope**: `nonisolated` annotation traps under `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` only. Broader actor isolation topics (`@MainActor` binding, `Sendable` conformance design, actor reentrancy) are out of scope — keep those in CLAUDE.md or a separate rule.
 
-Per CLAUDE.md, types in `Models/`, `LLM/`, `Engine/`, `Data/` are marked `nonisolated` at the type level. Conformances declared in `App/` (and any default-MainActor layer) hit MainActor inference traps in four specific patterns. The four share the same root cause (MainActor inference) but surface in two diagnostic forms:
+Per CLAUDE.md, types in `Models/`, `LLM/`, `Engine/`, `Data/` are marked `nonisolated` at the type level. Conformances declared in `App/` (and any default-MainActor layer) hit MainActor inference traps in five specific patterns. The five share the same root cause (MainActor inference) but surface in two diagnostic forms:
 
 - **Conformance-site** (Pattern 1): `conformance of '<Type>' to protocol '<Protocol>' crosses into main actor-isolated code and can cause data races` — a previously-compiling type suddenly refusing to build.
-- **Use-site** (Patterns 2–4): `Call to main actor-isolated <thing> in a synchronous nonisolated context` — fires at the test, generic collection, or Sendable closure callsite, not the declaration.
+- **Use-site** (Patterns 2–5): fires at the test, generic collection, Sendable closure callsite, or conformance-lookup callsite — not the declaration. Patterns 2–4 surface as `Call to main actor-isolated <thing> in a synchronous nonisolated context`; Pattern 5 surfaces as `main actor-isolated conformance of '<Type>' to '<Protocol>' cannot be used in nonisolated context`.
 
 Easy to miss because the diagnostic doesn't point at the type definition.
 
@@ -32,7 +32,7 @@ Reference: `Pastura/Pastura/LLM/LLMService.swift`.
 
 ## Pattern 2 — Value type with custom witness
 
-App/ value type conforming to `Hashable` / `Equatable` / `Codable` **with hand-written witness methods** (custom `static func ==`, `func hash(into:)`, `init(from:)`, `encode(to:)`) needs `nonisolated` at type level. Auto-synthesized conformances emit nonisolated witnesses regardless of enclosing isolation, so they don't need the annotation.
+App/ value type conforming to `Hashable` / `Equatable` / `Codable` **with hand-written witness methods** (custom `static func ==`, `func hash(into:)`, `init(from:)`, `encode(to:)`) needs `nonisolated` at type level. Auto-synthesized conformance **witnesses** are nonisolated regardless of enclosing isolation, so they don't need the annotation. **But conformance lookup itself can still be MainActor-isolated — see Pattern 5.**
 
 ```swift
 nonisolated struct RouteHint<T: Hashable & Sendable>: Hashable, Sendable {
@@ -69,3 +69,29 @@ nonisolated final class URLSessionModelDownloader: ModelDownloader, @unchecked S
 ```
 
 Reference: `Pastura/Pastura/App/ModelDownloader.swift` (class declaration ~L92).
+
+## Pattern 5 — Auto-synth Equatable / Hashable conformance lookup on default-MainActor type
+
+App/ value type (struct / enum) under default-MainActor isolation with
+**auto-synthesized** `Equatable` / `Hashable` conformance: the synthesized
+**witnesses** are nonisolated (per Pattern 2), but the **conformance
+lookup** itself is MainActor-isolated. A `nonisolated` caller of `==` /
+`hashValue` triggers `main actor-isolated conformance of '<Type>' to
+'Equatable' cannot be used in nonisolated context`.
+
+Diagnostic fires at the **use site** (e.g., `#expect(x == .alice)` in
+a nonisolated test), not the declaration. Easy to mis-attribute as
+Pattern 2 (which says "auto-synth doesn't need the annotation").
+
+### Fix order
+
+1. **Mark the test suite `@MainActor`** — smallest scope. MainActor can
+   still call nonisolated methods, so the suite continues to exercise
+   the production nonisolated callers correctly. This is Pastura's default.
+2. **Mark the enum / extension `nonisolated`** — broader scope, releases
+   the conformance for any future nonisolated caller. Use only with
+   ≥2 unrelated nonisolated call sites.
+
+Reference: `Pastura/PasturaTests/Components/ModelRowAccessibilityTests.swift`
+carries `@MainActor` on the suite; `SheepAvatar.Character` keeps its
+default-MainActor isolation.

--- a/.claude/rules/swiftui-traps.md
+++ b/.claude/rules/swiftui-traps.md
@@ -43,3 +43,37 @@ VM `init()` default arguments run **in tests too**. Fixture-driven tests that pr
 ### Detection rule
 
 If adding `Foo` to `VMInit` would cause `VMInit(repo: …)` (no `foo:` arg) to behave differently in tests, push the default down to the View. Pure-data services (config readers, immutable repositories) don't have this problem.
+
+## SwiftUI drag & drop inside List / Form
+
+`.dropDestination(for:action:isTargeted:)`'s **`isTargeted` closure never
+fires** inside `List` / `Form` rows on iOS 17–26 (FB12980427 / FB21980712,
+unfixed by Apple as of 2026-04). The drop action fires on release, but
+hover feedback is silent. macOS works correctly. `DropDelegate.dropEntered`
+/ `dropExited` are reported to work in `List` but empirically also failed
+in `Form` rows on iOS 26 simulator.
+
+Apple's `.onMove(perform:)` is **deliberately single-`ForEach` only** —
+moving items between two `ForEach` instances is not supported by design
+([Apple Dev Forums thread/674393](https://developer.apple.com/forums/thread/674393)).
+HIG has no cross-collection drag pattern; Apple's documented alternative
+is the **context-menu "Move to X" action**.
+
+### Apply
+
+Answer first, before designing:
+
+- Same-collection reorder? → `.onMove` works.
+- Cross-collection move? → **prefer context menu**. Drag will fight the platform.
+- Hover indicator on `List` / `Form`? → cannot be delivered natively on current
+  iOS. Switch to `ScrollView` + `LazyVStack` (loses List chrome) or drop the
+  indicator requirement.
+
+For the workflow lesson "research platform support BEFORE plan / critic,
+not after a full PR cycle" see #144.
+
+### Sources
+
+- [Apple Dev Forums thread/674393](https://developer.apple.com/forums/thread/674393) (cross-section drag)
+- [Apple Dev Forums thread/730367](https://developer.apple.com/forums/thread/730367) (dropDestination in List)
+- [HIG — Drag and drop](https://developer.apple.com/design/human-interface-guidelines/drag-and-drop)

--- a/.claude/rules/xcodebuild-cli.md
+++ b/.claude/rules/xcodebuild-cli.md
@@ -159,11 +159,45 @@ run — see Recovery below.
   → `xcrun simctl erase <UDID>` + retry **once**. Persistent failures
   are real bugs (signing / plist / app-state regression), not flakes.
 
-**Within-process clone cascade (flake recognition)**:
+## CI flake catalog (auto-retried by `ci-retry.yml`)
 
-If `xcodebuild test` reports 200-330 tests "failed (0.000 seconds)" all on
-the same simulator clone PID — that's a within-process clone crash, not a
-real failure. Real failures show assertion output + measurable wall-clock
-+ are not single-PID-wide. **Re-run once before diagnosing**; the suite
-typically passes cleanly on retry. Do NOT "fix" the listed tests. Root
-cause investigation: [#189](https://github.com/tyabu12/pastura/issues/189).
+`.github/workflows/ci-retry.yml` auto-retries failed UI test jobs
+(workflow_run-triggered; max 3 attempts on main / 2 on PR; gated on
+ui-test failure). For known flake classes below, first check
+`run_attempt` on the failed CI run before manual intervention. Auto-retry
+covers all three; manual `gh run rerun --failed <run_id>` is only needed
+if auto-retry exhausted.
+
+| Class | Failure message | Distinguishing signal | xcodebuild built-in retry recovers? |
+|---|---|---|---|
+| **Within-process clone cascade** | 200-330 tests "failed (0.000 seconds)" same simulator clone PID | Single-PID, no assertion output, no wall-clock | Yes (passes on retry) |
+| **App-launch timeout** | `Failed to launch ...: Timed out while launching application via Xcode` / `Timed out while requesting launch progress` | Other UI tests in same run launched the same `Pastura.app` and passed | **No** — retry exhausts at launch phase; xcresult shows "Failed after 2 retries" |
+| **Runner-init Accessibility** | `Test runner failed to initialize ... Timed out while loading Accessibility` | xcresult: 0 test cases executed (runner never booted); zero `Test case ... passed` lines | **No** — `-retry-tests-on-failure -test-iterations 2` presupposes runner booted |
+
+**All three are distinct from the `FBSOpenApplicationServiceErrorDomain
+Code=1` pattern documented in § "Agent session guardrails" → Recovery
+(`simctl erase <UDID>` + retry once on the FBSOpen marker).** That pattern
+is the runner already booted + app explicitly rejected, recoverable by
+erasing the simulator. The three flakes above are infra-pressure failures
+on the GHA macos-26 runner (suspected root cause: Accessibility framework
+load + within-process clone pressure under constrained VM).
+
+### When to escalate
+
+- **First failed CI run**: check `run_attempt` — if 1, let `ci-retry.yml`
+  fire automatically (no manual action).
+- **After auto-retry exhausted** (attempt 3 on main / 2 on PR): manually
+  `gh run rerun --failed <run_id>` once.
+- **If THAT also fails the same way**: escalate to real-bug investigation.
+  Real signing / Info.plist / app-init regressions fail across runs with
+  the SAME failure message at the SAME stage — they do NOT recover from
+  `gh run rerun` without a code change.
+
+If ALL UI tests in a run fail at launch (not just some), treat as a real
+bug rather than flake.
+
+Tracked indirectly by [#189](https://github.com/tyabu12/pastura/issues/189)
+(parallel-testing OOM cascade — related runner-pressure pattern, separate
+root cause). Auto-retry workflow: `.github/workflows/ci-retry.yml`. Local
+re-run prescription for within-process clone class: "Re-run once before
+diagnosing — do NOT 'fix' the listed tests."


### PR DESCRIPTION
## Summary

Second-round promotion of per-user auto-memory knowledge into `.claude/rules/`. Mirrors PR #460 (1st round) shape. 6 sections across 5 rule files:

- `swiftui-traps.md` — append "SwiftUI drag & drop inside List / Form" (FB12980427 / FB21980712, cross-collection move via context menu per Apple HIG)
- `swift-isolation.md` — add Pattern 5 (auto-synth Equatable/Hashable conformance lookup on default-MainActor type) + disambiguate Pattern 2 wording with cross-link; lead taxonomy bumped "four" → "five" patterns
- `i18n.md` — add 2 sections: SwiftUI convenience-init label trap (Stepper/Toggle/Picker \`LocalizedStringKey\` runtime-interpolation lookup); \`%arg\` placeholder + partial-conversion orphan resurrects (xcstringstool sync side effects)
- `xcodebuild-cli.md` — restructure: replace within-process clone cascade block (PR #460) with table-driven CI flake catalog covering 3 classes (within-process clone + app-launch timeout + runner-init Accessibility), all auto-retried by \`ci-retry.yml\`
- `knowledge-layering.md` — append "Anti-pattern: memory refs in repo-tracked files" section, closing the loop on the existing knowledge-tier table

Critic ran 2 rounds pre-impl (round-2 user-requested); applied 10 findings across \`(#NNN)\` discipline, item compression, cross-ref wording. Code-reviewer (Opus) PASSED with 1 Warning + 1 Suggestion — both fixed in the final commit (path correction + bare-attribution → pointer rephrase).

8 per-user memory entries to be deleted locally after merge.

## Test plan

- [x] Sweep \`rg "memory \\\`[a-z_]+\\.md\\\`" --glob '!**/memory/**' --glob '!.git/**'\` → 2 hits, both pre-existing carve-outs (not introduced by this PR)
- [x] Sweep \`rg "Source memory: " .claude/rules/\` → 1 hit, false positive (procedural rule text)
- [x] \`(#NNN)\` discipline audit per \`context-budget.md\` — pre-existing \`(#31373)\` legitimate upstream pointer; all new refs are where-to-find-context pointers
- [x] Cross-reference verification: FBSOpen marker (verbatim match in Recovery section); ModelRowAccessibilityTests.swift path corrected to \`Views/\`
- [x] Restructure fidelity: 5/5 original within-process clone block claims preserved in new table form
- [x] Pre-commit hook (swiftlint + xcodebuild build + blocklist + gallery) passed
- [x] Required CI checks green

Closes #461