### PR TITLE
📚 chore(rules): promote 5 memory entries → .claude/rules/ (3rd round)

### DIFF
--- a/.claude/rules/adr-writing.md
+++ b/.claude/rules/adr-writing.md
@@ -1,0 +1,36 @@
+---
+paths:
+  - "docs/decisions/**"
+---
+
+# ADR Writing Concepts
+
+ADRs are dense with fact-claims and decisions that downstream PRs and future ADRs inherit. Two concepts to preserve when drafting.
+
+For new ADRs (NNN-numbered files), prefer the `/write-adr` skill (`.claude/skills/write-adr/SKILL.md`) — it handles auto-numbering, structure scaffold, and the review loop. The two concepts below apply at draft time inside the skill AND when amending existing ADRs (the skill's scope is new-file creation only).
+
+## 1. Verify fact-claims at write time, not at review time
+
+ADR / spec / decision-record bodies have **higher fact-claim density** than ordinary prose. Citations (`file:line`, `.claude/rules/` section names, Swift / Apple SDK behavior) are *load-bearing for the decision*. A wrong citation propagates: the next implementer copy-pastes from the ADR, and subsequent ADRs build on a false premise.
+
+Before committing a fact-claim line:
+
+- Citing `file:line`? — Read the line.
+- Citing a `.claude/rules/*.md` or `CLAUDE.md` section? — Read the section.
+- Asserting Swift / language / SDK behavior? — confirm via existing-code grep hit or an authoritative source. Memory-based "Swift can do X" is not enough for ADR text.
+- Bringing in a citation that wasn't in the source plan (new rule / pattern / spec)? — Read it.
+
+The 5–10 minute investment per commit prevents the kind of 3-review-round cycle that landed 4 fact-errors in ADR-010 body (see #370).
+
+Pairs with `knowledge-layering.md` § "Rule-writing self-check" — different surface, same shape: execute every load-bearing assertion before commit.
+
+## 2. Mechanism contract over pinned model thresholds
+
+When drafting a DoD criterion that reads `≥ N% on model X`, default to a **mechanism contract** framing instead of pinning the threshold.
+
+- **Pinned threshold** — clear gate, but binds the ADR to one backend; every future model adoption (LiteRT-LM, new quantization, Qwen / Gemma swap) requires ADR amendment + re-measurement against the threshold.
+- **Mechanism contract** — define the detector + retry + event + harness. The ADR survives model swaps. Per-model adherence becomes a run-time judgement read off harness output, not an ADR-amendment question.
+
+Pastura's roadmap includes multi-model and LiteRT-LM migration, so default toward mechanism contracts. Pin only when the criterion is **single-model-by-design** (e.g., "this ships for Gemma E2B only").
+
+If a plan surfaces a quantitative gate, surface the trade-off to the user at plan time rather than silently committing one framing. See #405 (ADR-010 D5) for the case that collapsed an `if M ≥ 80% pin else fork to PR3` contingency by pivoting to mechanism contract.

--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -66,3 +66,24 @@ Known carve-outs (where inline rationale would be too dense to migrate):
 
 See PR #420 for the motivating incident. Long-term, both carve-outs
 should migrate to inline rationale or a public doc home.
+
+## Rule-writing self-check
+
+When adding a `.claude/rules/` section (or `CLAUDE.md` content) that includes an **executable assertion** — a grep command with an asserted hit count, a cited `file:line`, a `(PR #N)` claim, a cross-doc heading anchor — execute it against current main state **before commit**.
+
+Pre-impl critic and code-reviewer reviews have repeatedly missed this class: they evaluate the *content* of the rule but rarely run the *check* the rule itself prescribes. The writer is the only one who reliably can.
+
+### Apply
+
+For each load-bearing assertion in the draft:
+
+1. Paste the command (`rg`, `find`, `gh pr view`) into Bash from the current worktree.
+2. Compare observed output to what the rule asserts.
+3. Reconcile divergence one of three ways:
+   - **Sweep** — fix the violations in this PR if cheap.
+   - **Reframe** — change the assertion to match observed state. The "Anti-pattern: memory refs" section above is itself an example: "new code must not add hits" + an inline carve-out list, rather than "should return 0 hits".
+   - **Inline carve-out** — enumerate existing violations with `file:line`.
+
+This applies to **non-grep claims** too: cited file paths (`find` to confirm existence), `(PR #N)` claims about PR body content (`gh pr view N` to verify), heading anchors in cross-doc refs (`grep` for the exact heading).
+
+A 30-second self-check prevents 1–2 extra critic / code-reviewer rounds. Motivating incident: PR #462 round-3 critic.

--- a/.claude/rules/lp-content.md
+++ b/.claude/rules/lp-content.md
@@ -1,0 +1,33 @@
+---
+paths:
+  - "pages/**"
+---
+
+# Pastura LP Content Concepts
+
+The LP at `pages/` (EN at root, JA mirror at `pages/ja/`) is largely settled. Two concepts to preserve when editing.
+
+## 1. AIgazing / AI観測 — the genre word
+
+Pastura's positioning rests on a single coined word: **AIgazing** (EN, AI + stargazing) and **「AI観測」** (JA, coined to echo 「天体観測」).
+
+The word lives in two zones only:
+
+- **Hero strip** — h1 + meta tags + adjacent HTML comment documenting the cross-locale wordplay
+- **Bigger picture** coda — eyebrow + h2 between Why on-device and FAQ
+
+Everywhere else (Capabilities cards, FAQ, footer, Why on-device body) uses concrete terms like `on-device` / 「ローカル」. The thought → concrete → thought sandwich is intentional.
+
+The two Hero h1s are **hand-crafted per language**, NOT machine-translated. Preserve the wordplay rather than back-translating.
+
+See #358 (EN rebrand) / #374 (JA mirror) for the design discussion.
+
+## 2. Voice — em-dash and prose colon
+
+Em-dash (`—`) and `Feature: explanation` colon-as-prose-separator are the most-cited markers of LLM-generated copy in 2025–2026. NEW LP copy should not pattern-match.
+
+- **Existing em-dashes in legacy LP prose are the LP's stylistic signature — keep them.** The rule fires on new additions only.
+- For new content, prefer comma / period split / parenthesis over em-dash, and period + new sentence over prose colons.
+- Hyphens (`on-device`, `non-trivial`) and colons before code blocks / bullet lists are not the same trap.
+
+The same voice rule extends to `README.md` / `CONTRIBUTING.md` additions, but this rule auto-loads on LP edits only — apply by writer judgement when editing project-root public docs.

--- a/.claude/skills/write-adr/SKILL.md
+++ b/.claude/skills/write-adr/SKILL.md
@@ -10,6 +10,8 @@ argument-hint: "<title>"
 
 Generate an Architecture Decision Record for: $ARGUMENTS
 
+See `.claude/rules/adr-writing.md` for the concepts that govern ADR drafting — fact-claim verification and mechanism contract over pinned thresholds. Apply both at draft time, not just at review time.
+
 ## Instructions
 
 1. Determine the next ADR number by listing `docs/decisions/` and finding the highest existing number + 1.
@@ -63,8 +65,8 @@ Notes:
 After writing the ADR:
 
 1. Launch 2 parallel subagents to review the document (read-only — subagents must not modify any files):
-   - Agent 1 (Accuracy): Verify the ADR's Context and Decision sections accurately reflect the actual codebase and relevant docs. Check that the Options table includes all discussed alternatives with clear reasons for rejection. Confirm filename follows `ADR-NNN.md`.
-   - Agent 2 (Clarity): Review as a future reader — is the rationale self-contained? Could someone unfamiliar with the discussion understand the "why"? Are Trade-offs complete (both benefits and costs)?
+   - Agent 1 (Accuracy): Apply `.claude/rules/adr-writing.md` § 1 — verify every cited `file:line` / rule section / SDK assertion before approving. Check that the Options table includes all discussed alternatives with clear reasons for rejection. Confirm filename follows `ADR-NNN.md`.
+   - Agent 2 (Clarity): Review as a future reader — is the rationale self-contained? Could someone unfamiliar with the discussion understand the "why"? Are Trade-offs complete (both benefits and costs)? If the Decision section contains a DoD criterion like `≥ N% on model X`, flag it for mechanism-contract vs. pinned-threshold reconsideration per `.claude/rules/adr-writing.md` § 2.
 2. If issues are found, revise the ADR and re-verify.
 3. Repeat until no new issues. Hard limit: 3 iterations. Stop after 3 even if issues remain and report them as unresolved.
 4. Report the final ADR with iteration count.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,8 +217,10 @@ pages/                           # Public HTML deployed via .github/workflows/de
 
 **Path-scoped** (loaded only when editing matching files):
 
+- `adr-writing.md` — ADR drafting concepts: fact-claim verification at write time, mechanism contract over pinned model thresholds (`docs/decisions/**`)
 - `engine.md` — Engine + LLM source (`Pastura/Pastura/Engine/**`, `Pastura/Pastura/LLM/**`)
 - `i18n.md` — Localization workflow: `String(format: String(localized:))` format-string pattern, `xcstringstool` sync output (multi-arg en blocks, state=new + en-only), catalog editing traps (don't `json.dumps` round-trip) (`Pastura/Pastura/**/*.swift`, `Pastura/Pastura/Resources/Localizable.xcstrings`)
+- `lp-content.md` — Public LP content concepts: AIgazing / AI観測 genre-word zoning (Hero + Bigger picture only), em-dash / prose-colon voice rule for new copy (`pages/**`)
 - `models-and-data.md` — Models + Data source (`Pastura/Pastura/Models/**`, `Pastura/Pastura/Data/**`)
 - `presets.md` — Bundled scenario YAML (`Pastura/Pastura/Resources/**`)
 - `testing.md` — Test target (`Pastura/PasturaTests/**`)


### PR DESCRIPTION
## Summary

Third-round promotion of per-user auto-memory knowledge into `.claude/rules/`. Same shape as PR #460 (1st round) / PR #462 (2nd round). 3 concept clusters across 2 new rule files + 1 existing rule + 1 skill + CLAUDE.md inventory:

- NEW `.claude/rules/lp-content.md` (path-scoped `pages/**`) — AIgazing / AI観測 genre-word zoning + em-dash / prose-colon voice rule for new LP copy (sources: 2 memories)
- NEW `.claude/rules/adr-writing.md` (path-scoped `docs/decisions/**`) — fact-claim verification at write time + mechanism contract over pinned model thresholds (sources: 2 memories)
- `.claude/rules/knowledge-layering.md` — append "Rule-writing self-check" section, closing the loop on rule additions that include executable assertions (sources: 1 memory)
- `.claude/skills/write-adr/SKILL.md` — insert top-level pointer to the new rule + compact Review Loop Agent 1 / Agent 2 prompts (Agent 1 now points to `adr-writing.md` § 1 rather than restating the verification discipline inline)
- `CLAUDE.md` — register the 2 new path-scoped rules in `## Context-Specific Rules` inventory

Concept-level register per writer direction ("細かいルールよりコンセプトだけ書いてあれば OK") — drafts deliberately compact, no exhaustive lists or grep commands.

Critic (Opus) ran pre-impl with 3 Warnings, all adopted in the implementation:
- Added Step 5 — CLAUDE.md inventory update
- Compacted SKILL.md Agent 1 prompt to a pointer (defers to path-scoped rule auto-load)
- Quoted `paths:` glob values to match existing convention

Code-reviewer (Opus) PASSED with 0 Critical / 0 Warning / 0 Suggestion. Executable-check verification log covered 18 load-bearing assertions across the 5 files — all consistent with current main. The new "Rule-writing self-check" section was applied recursively (writer executed self-check before commit) and passed.

5 per-user memory entries to be deleted locally after merge (PR cannot enforce per-user memory deletion):

- `feedback_lp_em_dash_avoidance.md`
- `project_aigazing_lp_positioning.md`
- `feedback_adr_factclaim_verify.md`
- `feedback_adr_mechanism_vs_threshold.md`
- `feedback_new_rule_self_check.md`

## Test plan

- [x] Sweep `rg "memory \`[a-z_]+\.md\`" --glob '!**/memory/**' --glob '!.git/**'` → 2 hits, both pre-existing carve-outs in `knowledge-layering.md` (not introduced by this PR)
- [x] Em-dash counts: `pages/index.html`=24 (legacy, kept per rule), `pages/ja/index.html`=0, `README.md`=0, `CONTRIBUTING.md`=0 — rule consistency verified
- [x] Section anchors `#usage` / `#features` / `#faq` present in both EN + JA LP (6 hits each, header + footer × 3)
- [x] AIgazing / AI観測 confined to Hero + Bigger picture zones — no Capabilities / FAQ / footer / Why-on-device leaks
- [x] PR citations (#358 / #374 / #370 / #405 / #420 / #462) all verified via `gh pr view`
- [x] `knowledge-layering.md` section ordering — new section appears AFTER "Anti-pattern: memory refs" so the cross-ref "the section above" is valid
- [x] `SKILL.md` Agent 1 / Agent 2 prompts point to `adr-writing.md` § 1 / § 2 — both sections exist in the new rule file added by this PR
- [x] `CLAUDE.md` Path-scoped inventory entries alphabetically ordered
- [x] `paths:` glob values quoted to match existing 6 path-scoped rules
- [x] No `Source memory: feedback_*` provenance lines leak into committed files (PR #420 / #460 lesson)
- [x] No bare `(PR #N)` historical attributions added (`context-budget.md`)
- [x] Required CI checks green

Closes #464