### PR TITLE
🧩 feat(kmp): W3 PR-A — XCFramework Local Drop integration (#220)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,19 @@ jobs:
   lint-and-test:
     runs-on: macos-26
     timeout-minutes: 15
+    # Path B (#220 W3 PR-A): cascade-gated dependency on kmp-build-test.
+    # When kmp-build-test runs (spike-branch events), wait for its
+    # xcframework artifact. When it SKIPS (main / non-spike events),
+    # proceed without — main's pbxproj does not reference the framework
+    # until W6 GO merge. `cancelled` is deliberately excluded from the
+    # `if:` to prevent false-greens (a cancelled kmp-build-test means
+    # no artifact, but cascade would otherwise pass through). See
+    # `.claude/rules/ci-workflows.md` "Long-lived branch gating".
+    needs: kmp-build-test
+    if: |
+      always()
+      && (needs.kmp-build-test.result == 'success'
+          || needs.kmp-build-test.result == 'skipped')
     outputs:
       test-passed: ${{ steps.test.outputs.passed }}
       test-failed: ${{ steps.test.outputs.failed }}
@@ -36,6 +49,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # Step-level guard: download only when kmp-build-test actually
+      # ran and produced an artifact. On main/non-spike events the
+      # step skips silently and lint-and-test proceeds without the
+      # framework (pbxproj on main does not reference it yet).
+      - name: Download PasturaShared.xcframework (spike branch)
+        if: needs.kmp-build-test.result == 'success'
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: pasturashared-xcframework
+          path: Pastura/Frameworks/PasturaShared.xcframework/
 
       - name: Select Xcode and Simulator
         run: |
@@ -269,12 +293,26 @@ jobs:
     name: Release build (iphoneos) + ADR-005 §8 guard
     runs-on: macos-26
     timeout-minutes: 15
+    # Path B cascade-gate (#220 W3 PR-A) — see lint-and-test for the
+    # same shape and rationale.
+    needs: kmp-build-test
+    if: |
+      always()
+      && (needs.kmp-build-test.result == 'success'
+          || needs.kmp-build-test.result == 'skipped')
     env:
       DEVELOPER_DIR: /Applications/Xcode_26.4.app/Contents/Developer
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Download PasturaShared.xcframework (spike branch)
+        if: needs.kmp-build-test.result == 'success'
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: pasturashared-xcframework
+          path: Pastura/Frameworks/PasturaShared.xcframework/
 
       - name: Select Xcode
         run: xcodebuild -version
@@ -338,6 +376,33 @@ jobs:
             exit 1
           fi
           echo "OK: zero ollama symbols in Release-iphoneos binary"
+
+      # H6 capture (#220 Tier 1 — `.ipa` size delta ≤ 10 MB). Surfaces
+      # the K/N runtime + Models binary as it lands in
+      # `Pastura.app/Frameworks/PasturaShared.framework/`. Tier 2
+      # checkpoint readings feed off this. Step is conditional on the
+      # download having run — on main/non-spike events the embed is
+      # absent (pbxproj on main does not reference the framework yet).
+      - name: Capture PasturaShared.framework binary delta (H6)
+        if: needs.kmp-build-test.result == 'success'
+        run: |
+          # Portable while/read loop because `mapfile` is bash 4+ and
+          # GHA macos-* defaults to bash 3.2. See `.claude/rules/ci-workflows.md`.
+          BINS=()
+          while IFS= read -r -d '' f; do
+            BINS+=("$f")
+          done < <(find ~/Library/Developer/Xcode/DerivedData \
+            -type d \
+            -name 'PasturaShared.framework' \
+            -path '*/Build/Products/Release-iphoneos/Pastura.app/Frameworks/*' \
+            -print0)
+          if [ "${#BINS[@]}" -eq 1 ]; then
+            echo "PasturaShared.framework embedded size:"
+            du -sh "${BINS[0]}"
+          else
+            echo "::warning::Expected 1 PasturaShared.framework, found ${#BINS[@]}"
+            printf '%s\n' "${BINS[@]}"
+          fi
 
       - name: Upload Release build log (on failure)
         if: failure()
@@ -420,6 +485,21 @@ jobs:
 
       - name: Assemble PasturaShared XCFramework
         run: ./gradlew :shared:models:assemblePasturaSharedXCFramework --no-daemon --stacktrace
+
+      # Path B (#220 W3 PR-A): hand the assembled xcframework off to the
+      # downstream xcodebuild jobs (lint-and-test, release-build) via
+      # `actions/download-artifact`. Uploading the directory's CONTENTS;
+      # consumers extract into `Pastura/Frameworks/PasturaShared.xcframework/`
+      # to reconstruct the path pbxproj expects.
+      - name: Upload PasturaShared.xcframework artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pasturashared-xcframework
+          path: shared/models/build/XCFrameworks/release/PasturaShared.xcframework
+          if-no-files-found: error
+          # Short retention — this artifact only needs to flow to the
+          # same-workflow downstream jobs. Default 90d would accumulate.
+          retention-days: 1
 
       - name: Upload Gradle reports (on failure)
         if: failure()

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,10 @@ __pycache__/
 # `shared/<module>/build/` for Gradle module outputs.
 .gradle/
 local.properties
+
+# KMP XCFramework drop (Issue #220 W3 PR-A). Built by
+# `scripts/kmp/assemble-xcframework.sh` from `shared/models/`. Gitignored
+# because the binary is reproducible from `shared/` source. The pattern
+# is xcframework-specific (NOT directory-level) so `Pastura/Frameworks/README.md`
+# remains checked in.
+Pastura/Frameworks/*.xcframework

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,8 +76,8 @@ Utilities/ → depends on nothing
 
 ## Swift Coding Conventions
 
-- **Automated hooks** — split by gate type. Activate the git side once per clone with `./scripts/setup.sh`.
-  - **Git pre-commit** (`scripts/git-hooks/pre-commit`): on `git commit`, runs `swiftlint lint --strict`, `xcodebuild build`, `bash scripts/blocklist-precommit-gate.sh` (also surfaces `bash scripts/build-blocklist.sh --check` indirectly when the staged diff touches `docs/blocklist/source.json` or `Pastura/Pastura/Resources/ContentBlocklist.json` — requires `brew install jq`), and `bash scripts/gallery-precommit-gate.sh`. Fail-fast. CI mirrors the same checks.
+- **Automated hooks** — split by gate type. Activate the git side once per clone with `./scripts/setup.sh` (also assembles `PasturaShared.xcframework` for spike branch users; warns and continues if JDK 17+ is missing).
+  - **Git pre-commit** (`scripts/git-hooks/pre-commit`): on `git commit`, runs `scripts/kmp/assemble-xcframework.sh --if-missing` (KMP spike branch only; gradle UP-TO-DATE fast path ~1-2s on Swift-only commits — see Issue #220 W3 PR-A), `swiftlint lint --strict`, `xcodebuild build`, `bash scripts/blocklist-precommit-gate.sh` (also surfaces `bash scripts/build-blocklist.sh --check` indirectly when the staged diff touches `docs/blocklist/source.json` or `Pastura/Pastura/Resources/ContentBlocklist.json` — requires `brew install jq`), and `bash scripts/gallery-precommit-gate.sh`. Fail-fast. CI mirrors the same checks.
   - **Claude Code hooks** (`.claude/settings.json`): on file edit (`PostToolUse` Edit|Write), `swift-format` + `swiftlint --fix` auto-format. On `gh pr create` (`PreToolUse`), a reminder checks whether the branch has touched this file's "Phase 2 progress" — useful when migrating Phase 2 entries.
   - Why the split: Claude Code's hook `if` field fails-open on complex Bash, so commit-time gates living there would surface misleading errors on unrelated tool calls. Git's `pre-commit` fires only on `git commit` and is tight by construction.
 - **Error types:** Layer-specific — `SimulationError` (Models, co-located with `SimulationEvent`),

--- a/Pastura/Frameworks/README.md
+++ b/Pastura/Frameworks/README.md
@@ -1,0 +1,94 @@
+# Pastura/Frameworks/
+
+Drop location for `PasturaShared.xcframework`, the iOS-side artifact of
+the KMP Models layer spike (Issue #220, ADR-004 Draft).
+
+## Why this directory exists
+
+`Pastura.xcodeproj` references `PasturaShared.xcframework` at this path
+via its Framework Search Paths (`$(SRCROOT)/Frameworks`). The
+xcframework itself is **gitignored** (`.gitignore`:
+`Pastura/Frameworks/*.xcframework`) because it is reproducible from
+Kotlin source in `shared/models/`.
+
+The README is **not** gitignored — the pattern is xcframework-specific so
+this file remains discoverable in a fresh clone, documenting how to
+produce the artifact.
+
+## First-time setup
+
+After cloning the repo (and once per `git clean -fdx`):
+
+```bash
+./scripts/setup.sh                          # one-time: git hooks + KMP xcframework
+```
+
+`setup.sh` invokes `scripts/kmp/assemble-xcframework.sh --if-missing`
+internally — succeeds silently if JDK 17 is installed, prints a warning
+and continues if JDK 17 is missing (iOS-only contributors are not blocked,
+but Pastura.app builds will fail at link until the framework is present).
+
+## Daily workflow
+
+The git `pre-commit` hook runs `assemble-xcframework.sh --if-missing` as
+step 0. On Swift-only commits (no `shared/` changes), Gradle's UP-TO-DATE
+check provides a ~1-2 second fast path. On KMP-touching commits, the full
+assemble runs (typically 30 s warm, several minutes cold).
+
+To force-rebuild (e.g., after adding a Kotlin export that triggers
+"undefined symbol" at the Xcode link step):
+
+```bash
+./scripts/kmp/assemble-xcframework.sh       # no flag, always rebuilds
+```
+
+## Requirements
+
+- **JDK 17 or newer** — install via `brew install --cask temurin@17`
+  (or any later LTS — JDK 21 works). Versions below 17 are rejected
+  with an actionable message. CI pins JDK 17 for parity.
+- **gradlew** — checked into the repo at the root (no separate Gradle
+  install required).
+- **Xcode 26.x** — the iOS-side consumer; Kotlin/Native + Apple SDKs are
+  resolved by Gradle from `xcrun`.
+
+## CI coverage gap
+
+CI runs `assemblePasturaSharedXCFramework` in the `kmp-build-test` job
+(gated to the long-lived `feature/kmp-spike-models` integration branch).
+Downstream Pastura xcodebuild jobs (`lint-and-test`, `ui-test`,
+`release-build`) consume the framework via `actions/download-artifact`
+when `kmp-build-test` produced one.
+
+**What CI does NOT validate:**
+
+- **Embed & Sign correctness** for App Store submission. `release-build`
+  runs with `CODE_SIGNING_ALLOWED=NO`, which bypasses the codesign step.
+  K/N XCFrameworks differ from Swift Packages in their embed plumbing;
+  unsigned-archive CI does not exercise the path that ASC validates.
+- **H5 ASC archive dry-run** — Issue #220 Tier 1 H5 ("Archive builds and
+  uploads to ASC successfully") is deferred to W3+ / W4. Until H5 lands,
+  treat Embed & Sign correctness as unverified.
+
+**Do not infer ASC-readiness from green CI.** Future Tier 1 validation
+runs through ASC submission, not local archive.
+
+## W6 merge-PR caveat
+
+When the integration branch eventually merges into `main` (Issue #220 W6
+GO PR), the `kmp-build-test` job's gate (`base_ref ==
+'feature/kmp-spike-models'`) will not match (the merge PR has `base_ref ==
+'main'`). Downstream jobs would then run with the merged pbxproj
+referencing `Pastura/Frameworks/PasturaShared.xcframework` but no
+artifact from `kmp-build-test` — link failure at `xcodebuild build`.
+
+**W6 plan must address one of:**
+
+1. Extend `kmp-build-test`'s `if:` to also fire when `base_ref == 'main'
+   && head_ref == 'feature/kmp-spike-models'` (covers the merge PR).
+2. Add a pre-merge step that stages the xcframework before the merge runs.
+3. Restructure so `assemblePasturaSharedXCFramework` becomes
+   unconditional on `main` once integration lands.
+
+Track this in the W6 merge plan; do not let merge-day pressure surface it
+the first time.

--- a/Pastura/Pastura.xcodeproj/project.pbxproj
+++ b/Pastura/Pastura.xcodeproj/project.pbxproj
@@ -10,8 +10,24 @@
 		E0BCA52B2F83E9670025BAE6 /* Yams in Frameworks */ = {isa = PBXBuildFile; productRef = E0BCA52A2F83E9670025BAE6 /* Yams */; };
 		E0BCA52E2F83EA4C0025BAE6 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = E0BCA52D2F83EA4C0025BAE6 /* GRDB */; };
 		E0BCA53002F83EA4C0025BAE6 /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = E0BCA52F02F83EA4C0025BAE6 /* GRDB */; };
+		E0F1A1F12001A1F100A1F101 /* PasturaShared.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E0F1A1F12001A1F100A1F100 /* PasturaShared.xcframework */; };
+		E0F1A1F12001A1F100A1F102 /* PasturaShared.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E0F1A1F12001A1F100A1F100 /* PasturaShared.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E0FC8B882F90724F00A37916 /* LlamaSwift in Frameworks */ = {isa = PBXBuildFile; productRef = E0BCA5412F84F0000025BAE6 /* LlamaSwift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		E0F1A1F12001A1F100A1F103 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				E0F1A1F12001A1F100A1F102 /* PasturaShared.xcframework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXContainerItemProxy section */
 		E0BCA4C72F83E7E10025BAE6 /* PBXContainerItemProxy */ = {
@@ -34,6 +50,7 @@
 		E0BCA4B92F83E7DF0025BAE6 /* Pastura.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Pastura.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E0BCA4C62F83E7E10025BAE6 /* PasturaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PasturaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E0BCA4D02F83E7E10025BAE6 /* PasturaUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PasturaUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		E0F1A1F12001A1F100A1F100 /* PasturaShared.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = PasturaShared.xcframework; path = Frameworks/PasturaShared.xcframework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -72,6 +89,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E0F1A1F12001A1F100A1F101 /* PasturaShared.xcframework in Frameworks */,
 				E0FC8B882F90724F00A37916 /* LlamaSwift in Frameworks */,
 				E0BCA52B2F83E9670025BAE6 /* Yams in Frameworks */,
 				E0BCA52E2F83EA4C0025BAE6 /* GRDB in Frameworks */,
@@ -102,6 +120,7 @@
 				E0BCA4BB2F83E7DF0025BAE6 /* Pastura */,
 				E0BCA4C92F83E7E10025BAE6 /* PasturaTests */,
 				E0BCA4D32F83E7E10025BAE6 /* PasturaUITests */,
+				E0F1A1F12001A1F100A1F104 /* Frameworks */,
 				E0BCA4BA2F83E7DF0025BAE6 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -116,6 +135,14 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		E0F1A1F12001A1F100A1F104 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				E0F1A1F12001A1F100A1F100 /* PasturaShared.xcframework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -126,6 +153,7 @@
 				E0BCA4B52F83E7DF0025BAE6 /* Sources */,
 				E0BCA4B62F83E7DF0025BAE6 /* Frameworks */,
 				E0BCA4B72F83E7DF0025BAE6 /* Resources */,
+				E0F1A1F12001A1F100A1F103 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -433,6 +461,10 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 52G26234A3;
 				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Frameworks",
+				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Pastura/Info.plist;
 				INFOPLIST_KEY_BGTaskSchedulerPermittedIdentifiers = "com.tyabu12.Pastura.simulation-continuation";
@@ -469,6 +501,10 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 52G26234A3;
 				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Frameworks",
+				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Pastura/Info.plist;
 				INFOPLIST_KEY_BGTaskSchedulerPermittedIdentifiers = "com.tyabu12.Pastura.simulation-continuation";

--- a/Pastura/Pastura/KMPSpike/PasturaSharedSpike.swift
+++ b/Pastura/Pastura/KMPSpike/PasturaSharedSpike.swift
@@ -1,0 +1,162 @@
+// Issue #220 W3 PR-A scope (a) — first iOS-side consumer of the KMP
+// `PasturaShared.xcframework`. Lives outside the strict dependency-rule
+// layers (Models/LLM/Engine/Data/Views/App) because the spike intentionally
+// keeps KMP scaffolding off the production graph until W6 GO decision.
+//
+// Do NOT import this from production code. Reference from new spike-only
+// callsites only. NO-GO path deletes `Pastura/Pastura/KMPSpike/` whole.
+
+import Observation
+import PasturaShared
+
+/// Spike-scope sandbox demonstrating iOS-side consumption of the KMP
+/// `PasturaShared` Models layer (Issue #220 W3 PR-A).
+///
+/// Exercises three K/N → Swift interop surfaces per 1st pre-impl
+/// critic Axis 8 (the single-`Pairing` proposal would have biased Q9
+/// shim-LOC measurement low):
+///
+/// 1. **Data class init + property read** — `Pairing` (4 fields, two
+///    optionals exercising K/N null-vs-omit semantics).
+/// 2. **Enum case access** — `PairingStrategy.roundRobin` (Kotlin
+///    `@SerialName("round_robin")` enum, K/N exports as class-property
+///    `roundRobin` on the enum class).
+/// 3. **Nested-collection optionality** — `Phase` with
+///    `Map<String, String>?`, `List<String>?`, `List<Phase>?` fields.
+///
+/// Companion type `PasturaSharedSpikeViewModel` exercises the H8
+/// hypothesis smoke (see below).
+@MainActor
+enum PasturaSharedSpike {
+  /// Construct a `Pairing` from Swift, verifying the K/N init bridge
+  /// preserves Kotlin's argument order (`agent1`, `agent2`, then the
+  /// two `String?` action fields with null-default semantics).
+  static func samplePairing() -> Pairing {
+    Pairing(
+      agent1: "Alice",
+      agent2: "Bob",
+      action1: nil,
+      action2: nil
+    )
+  }
+
+  /// Reference the `@SerialName("round_robin")` enum case via Swift's
+  /// camelCase mapping. K/N exposes enum entries as class-readonly
+  /// properties on the enum class itself (visible via the framework
+  /// header as `@property (class, readonly) PairingStrategy *roundRobin`).
+  static let pairingStrategy: PairingStrategy = .roundRobin
+
+  /// Construct a no-op `Phase` to exercise the nested-collection
+  /// optionality (Q9 shim-LOC measurement). Phase's init exposes
+  /// every field as an explicit parameter — including all optionals
+  /// — so the spike's call site doubles as a smoke for that
+  /// surface area.
+  static func makeNoOpPhase(of type: PhaseType) -> Phase {
+    Phase(
+      type: type,
+      prompt: nil,
+      outputSchema: nil,
+      options: nil,
+      pairing: nil,
+      logic: nil,
+      template: nil,
+      source: nil,
+      target: nil,
+      excludeSelf: nil,
+      subRounds: nil,
+      condition: nil,
+      thenPhases: nil,
+      elsePhases: nil,
+      probability: nil,
+      eventVariable: nil
+    )
+  }
+}
+
+/// Minimal smoke for the H8 hypothesis (Issue #220 Tier 1 hard
+/// blocker): an `@Observable` Swift class wrapping a K/N value type
+/// must trigger SwiftUI invalidation on mutation.
+///
+/// PR-B (next session) lands the full H8 test suite covering the
+/// `access(keyPath:)` / `withMutation(keyPath:)` bridge pattern
+/// (PR #216) and edge cases (collection mutation, nested-type
+/// invalidation, async actor read-back). This file's
+/// `H8Smoke.verifyBridgeFires` is a compile-time smoke that runs
+/// the simplest case: assignment-replaces-instance.
+///
+/// **CRITICAL — escalation rule on failure**: If this smoke fails
+/// (compile error, runtime assertion fires, or
+/// `verifyBridgeFires() == false`), the failure is load-bearing R8
+/// evidence affecting the entire spike GO decision. File an
+/// `r8-observable-bridge-failure` comment on #220 with reproduction
+/// details and pause W3 PR-A pending spike re-evaluation. **Do NOT
+/// silently rescope to PR-B** — the descope ladder in ROADMAP /
+/// Issue #220 explicitly forbids it for Tier 1 hard blockers.
+@Observable
+@MainActor
+final class PasturaSharedSpikeViewModel {
+  /// `Pairing`-backed state. Mutation here must trigger SwiftUI
+  /// invalidation for downstream `@Observable` consumers.
+  var pairing: Pairing
+
+  init(pairing: Pairing = PasturaSharedSpike.samplePairing()) {
+    self.pairing = pairing
+  }
+}
+
+/// Compile-time + runtime smoke for the H8 hypothesis. Callable from
+/// `#Preview` or PR-B's full H8 test for early signal.
+@MainActor
+enum H8Smoke {
+  /// Returns `true` iff mutating `PasturaSharedSpikeViewModel.pairing`
+  /// fires `withObservationTracking`'s `onChange` closure. Returns
+  /// `false` if the observation tracker did not fire — indicating
+  /// the @Observable bridge does NOT propagate through K/N value
+  /// types and the spike's H8 hypothesis fails.
+  ///
+  /// Synchronous — `withObservationTracking`'s `onChange` fires on
+  /// the next runloop turn after mutation, but the observation
+  /// registration itself is synchronous. We register, mutate, and
+  /// then read the flag immediately because `@Observable`'s
+  /// invalidation path runs synchronously on assignment under
+  /// MainActor isolation.
+  static func verifyBridgeFires() -> Bool {
+    let viewModel = PasturaSharedSpikeViewModel()
+    // Class box: `withObservationTracking`'s `onChange` closure is
+    // `@escaping`, so under Swift 6 strict concurrency it cannot
+    // mutate a captured `var` (compile error: "mutation of captured
+    // var ... in concurrently-executing code"). Box the flag in a
+    // reference type so the closure mutates *through* the captured
+    // `let` rather than mutating the captured variable itself.
+    let signal = ObservationFireSignal()
+    withObservationTracking {
+      _ = viewModel.pairing.agent1
+    } onChange: {
+      signal.fired = true
+    }
+    // Replace the pairing instance (no in-place mutation since
+    // K/N data classes expose immutable val properties).
+    viewModel.pairing = Pairing(
+      agent1: "Alice",
+      agent2: "Bob",
+      action1: "cooperate",
+      action2: nil
+    )
+    return signal.fired
+  }
+}
+
+/// Reference-type flag for `H8Smoke.verifyBridgeFires`. Must be
+/// `nonisolated` because (a) the enclosing file uses
+/// `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` so the class would
+/// otherwise inherit MainActor isolation, and (b)
+/// `withObservationTracking`'s `onChange` is `@Sendable @escaping`,
+/// invoking from a non-MainActor context that cannot mutate a
+/// MainActor-isolated property. `@unchecked Sendable` is sound in
+/// this narrow usage because `verifyBridgeFires` itself is
+/// MainActor-isolated and the `onChange` callback is invoked
+/// synchronously on the same actor in practice — but the type
+/// system needs the explicit opt-out for the closure signature.
+nonisolated private final class ObservationFireSignal: @unchecked Sendable {
+  var fired = false
+}

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -27,6 +27,17 @@ set -euo pipefail
 # (subdirectories, submodules, etc.).
 cd "$(git rev-parse --show-toplevel)"
 
+# 0. KMP xcframework — ensure `Pastura/Frameworks/PasturaShared.xcframework`
+# is fresh before the xcodebuild build in step 2 tries to link against it
+# (Issue #220 W3 PR-A). `--if-missing` defers to Gradle's UP-TO-DATE
+# check: Swift-only commits pay ~1-2s, KMP-touching commits trigger a
+# full assemble. Exit 1 (JDK 17+ missing) is the only non-blocking case —
+# but it MUST block here at pre-commit time because xcodebuild build in
+# step 2 will fail without the framework. Failing fast with a clear
+# message is preferable to xcodebuild's "framework not found" output.
+./scripts/kmp/assemble-xcframework.sh --if-missing \
+  || { echo 'KMP xcframework assemble failed. Run scripts/kmp/assemble-xcframework.sh to diagnose.' >&2; exit 2; }
+
 # 1. SwiftLint --strict — surface lint violations before they hit CI.
 swiftlint lint --quiet --strict 2>&1 \
   || { echo 'SwiftLint violations. Fix before committing.' >&2; exit 2; }

--- a/scripts/kmp/assemble-xcframework.sh
+++ b/scripts/kmp/assemble-xcframework.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+#
+# scripts/kmp/assemble-xcframework.sh — Assemble `PasturaShared.xcframework`
+# for iOS-side consumption (Issue #220 W3 PR-A).
+#
+# Invokes Gradle's `:shared:models:assemblePasturaSharedXCFramework` task
+# (defined by `XCFramework("PasturaShared")` in `shared/models/build.gradle.kts`)
+# and atomically places the release-variant output at the gitignored path
+# `Pastura/Frameworks/PasturaShared.xcframework` where `Pastura.xcodeproj`'s
+# Framework Search Paths expect it.
+#
+# Usage:
+#   scripts/kmp/assemble-xcframework.sh             # full assemble (~1-2s when UP-TO-DATE)
+#   scripts/kmp/assemble-xcframework.sh --if-missing # same as full assemble; relies on
+#                                                    # Gradle's UP-TO-DATE check for fast path
+#
+# Exit codes:
+#   0 — success (built or already up-to-date)
+#   1 — missing tool (JDK 17 / gradlew)
+#   2 — Gradle assemble failed
+#   3 — copy / atomic-rename failed
+#
+# Design notes:
+#   - `--if-missing` does NOT short-circuit on filesystem mtime check. An
+#     earlier draft (W3 PR-A 3rd critic) used `git diff --cached --quiet
+#     shared/` plus an `Info.plist` mtime check, but both leaked silent-stale
+#     scenarios (post-`git pull` stale-Info.plist, new `.kt` file invisible
+#     to two-file mtime check). Gradle's own UP-TO-DATE check is the
+#     authoritative fast path and costs only ~1-2s on no-op invocations.
+#   - Aggregator task outputs both Debug and Release variants. We promote
+#     the Release variant to `Pastura/Frameworks/` because:
+#       (a) Pastura.app's Release config consumes the released framework
+#           (Debug builds also link release variant for spike simplicity)
+#       (b) `Debug` adds .dSYM bundles but doubles size (~2x) — not worth
+#           the disk cost for the iOS-side spike scope.
+#   - Atomic rename via `mv` (POSIX) — partial xcframework on Ctrl-C is
+#     avoided because mv on the same filesystem is atomic.
+
+set -euo pipefail
+
+# Run from repo root regardless of invocation directory.
+cd "$(git rev-parse --show-toplevel)"
+
+REPO_ROOT="$(pwd)"
+GRADLE_OUTPUT="${REPO_ROOT}/shared/models/build/XCFrameworks/release/PasturaShared.xcframework"
+TARGET_DIR="${REPO_ROOT}/Pastura/Frameworks"
+TARGET="${TARGET_DIR}/PasturaShared.xcframework"
+
+# Parse args. Only --if-missing is meaningful at the moment (kept for
+# pre-commit / setup.sh callsites that pass it explicitly), but the
+# behaviour is currently identical to no-flag invocation.
+IF_MISSING=0
+for arg in "$@"; do
+  case "$arg" in
+    --if-missing) IF_MISSING=1 ;;
+    -h|--help)
+      sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "✗ unknown argument: $arg" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# JDK probe. Gradle 9.x requires JDK 17+ for the daemon; the `jvmTarget`
+# in `shared/models/build.gradle.kts` is pinned to 17 (bytecode-only),
+# so the runtime JVM may be any LTS at-or-above 17. CI uses
+# `actions/setup-java` `java-version: 17` for parity, but local dev on
+# 17 / 21 / future LTS is supported.
+if ! command -v java >/dev/null 2>&1; then
+  echo "✗ java not found. Install Temurin 17: brew install --cask temurin@17" >&2
+  exit 1
+fi
+
+# `java -version` writes to stderr. Extract major version from
+# `openjdk version "17.0.x" ...` or `openjdk version "21" ...` formats.
+JAVA_VERSION="$(java -version 2>&1 | head -1 | sed -E 's/.*version "([0-9]+)(\.[0-9]+)?.*/\1/')"
+if ! [[ "${JAVA_VERSION:-}" =~ ^[0-9]+$ ]] || [ "${JAVA_VERSION}" -lt 17 ]; then
+  echo "✗ JDK 17 or newer required, found JDK ${JAVA_VERSION:-unknown}." >&2
+  echo "  Install: brew install --cask temurin@17" >&2
+  echo "  Or set JAVA_HOME: export JAVA_HOME=\$(/usr/libexec/java_home -v 17)" >&2
+  exit 1
+fi
+
+if [ ! -x "${REPO_ROOT}/gradlew" ]; then
+  echo "✗ gradlew not found or not executable at ${REPO_ROOT}/gradlew" >&2
+  exit 1
+fi
+
+# Always invoke Gradle — its UP-TO-DATE check is the fast path
+# (~1-2s on no-op, full build only when sources changed).
+if ! "${REPO_ROOT}/gradlew" :shared:models:assemblePasturaSharedXCFramework --quiet; then
+  echo "✗ Gradle assemble failed. Re-run without --quiet for diagnostics:" >&2
+  echo "    ${REPO_ROOT}/gradlew :shared:models:assemblePasturaSharedXCFramework --stacktrace" >&2
+  exit 2
+fi
+
+if [ ! -d "${GRADLE_OUTPUT}" ]; then
+  echo "✗ Gradle reported success but output missing: ${GRADLE_OUTPUT}" >&2
+  exit 3
+fi
+
+# Atomic rename: stage to a sibling temp dir, then `mv` over the target.
+# Removes a stale prior copy first to avoid `mv: cannot move ... into itself` semantics.
+mkdir -p "${TARGET_DIR}"
+TEMP_TARGET="${TARGET_DIR}/.PasturaShared.xcframework.tmp.$$"
+trap 'rm -rf "${TEMP_TARGET}"' EXIT
+
+# Copy the gradle output to a sibling temp path then atomically swap.
+# Pure-`mv` from gradle's build dir would tie our target to Gradle's
+# rebuild-then-delete cycle; copy-then-swap keeps the deployed framework
+# independent.
+cp -R "${GRADLE_OUTPUT}" "${TEMP_TARGET}" || { echo "✗ copy failed" >&2; exit 3; }
+rm -rf "${TARGET}"
+mv "${TEMP_TARGET}" "${TARGET}" || { echo "✗ atomic rename failed" >&2; exit 3; }
+trap - EXIT
+
+if [ "${IF_MISSING}" -eq 1 ]; then
+  # In --if-missing mode, suppress success chatter; the typical caller
+  # is pre-commit / setup.sh where silent success is preferable.
+  exit 0
+fi
+
+SIZE="$(du -sh "${TARGET}" 2>/dev/null | cut -f1)"
+echo "✓ PasturaShared.xcframework ready at ${TARGET} (${SIZE})"

--- a/scripts/kmp/assemble-xcframework.sh
+++ b/scripts/kmp/assemble-xcframework.sh
@@ -46,6 +46,18 @@ GRADLE_OUTPUT="${REPO_ROOT}/shared/models/build/XCFrameworks/release/PasturaShar
 TARGET_DIR="${REPO_ROOT}/Pastura/Frameworks"
 TARGET="${TARGET_DIR}/PasturaShared.xcframework"
 
+# Branch-switch guard (Issue #220 W3 PR-A code-reviewer Warning #1):
+# the KMP module is gated to `feature/kmp-spike-models` and its child
+# branches. If a contributor runs `setup.sh` while on a spike branch
+# (activating the pre-commit hook with KMP step 0), then switches to
+# `main` or a non-spike branch, `shared/models/` is absent from that
+# ref and gradle would fail with "task not found". Silent no-op
+# instead — consistent with `scripts/xcodebuild.sh` handling missing
+# xcstrings sync via sentinel + exit 0.
+if [ ! -f "${REPO_ROOT}/shared/models/build.gradle.kts" ]; then
+  exit 0
+fi
+
 # Parse args. Only --if-missing is meaningful at the moment (kept for
 # pre-commit / setup.sh callsites that pass it explicitly), but the
 # behaviour is currently identical to no-flag invocation.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -29,5 +29,40 @@ cd "$(git rev-parse --show-toplevel)"
 
 git config core.hooksPath scripts/git-hooks
 echo "✓ git hooks activated (core.hooksPath = scripts/git-hooks)"
-echo "  Pre-commit gates: swiftlint, xcodebuild build, blocklist, gallery"
+echo "  Pre-commit gates: KMP xcframework (--if-missing), swiftlint,"
+echo "                    xcodebuild build, blocklist, gallery"
 echo "  Bypass (discouraged): \`git commit --no-verify\` — CLAUDE.md prohibits."
+
+# KMP XCFramework first-build (Issue #220 — spike scope; gates the
+# Pastura.app build because pbxproj references `PasturaShared.xcframework`
+# from `Pastura/Frameworks/`). The wrapper's `--if-missing` is gradle-UP-TO-DATE-backed.
+#
+# Exit code branching:
+#   - 0: success / already up-to-date — continue silently.
+#   - 1: missing tool (JDK 17+ / gradlew) — warn but DO NOT block
+#        bootstrap. iOS-only contributors should be able to run
+#        `./scripts/setup.sh` without installing JDK 17 (they just
+#        can't build Pastura.app until they do, which is fine — the
+#        hooks themselves are activated above and that's the main
+#        purpose of setup.sh).
+#   - 2 / 3 / other: real failure — propagate the error, abort bootstrap.
+#
+# `|| rc=$?` captures the exit code under `set -e` without aborting the
+# script. The `case` statement then branches on the captured rc.
+rc=0
+./scripts/kmp/assemble-xcframework.sh --if-missing || rc=$?
+case "$rc" in
+  0)
+    echo "✓ PasturaShared.xcframework ready"
+    ;;
+  1)
+    echo "⚠️  JDK 17+ not found — KMP build skipped." >&2
+    echo "   Install Temurin 17 to enable Pastura.app builds:" >&2
+    echo "     brew install --cask temurin@17" >&2
+    echo "   (Git hooks above were activated successfully.)" >&2
+    ;;
+  *)
+    echo "✗ KMP wrapper failed (exit $rc). Fix before continuing." >&2
+    exit "$rc"
+    ;;
+esac


### PR DESCRIPTION
Part of #220 W3 PR-A. First iOS-side consumption of the KMP `PasturaShared.xcframework` produced by `:shared:models` (W1/W2 scaffolding + Models port). Plan comment: [#220 4492924087](https://github.com/tyabu12/pastura/issues/220#issuecomment-4492924087).

## Summary

- **Wrapper script** `scripts/kmp/assemble-xcframework.sh` invokes `:shared:models:assemblePasturaSharedXCFramework` and atomically promotes the release-variant output to gitignored `Pastura/Frameworks/PasturaShared.xcframework`. `--if-missing` defers fast path to Gradle's UP-TO-DATE check.
- **Bootstrap + pre-commit integration**: `scripts/setup.sh` calls the wrapper with warn-not-fail on JDK 17+ absence (iOS-only contributors not blocked). Pre-commit step 0 fails fast with clear message if assemble fails (because xcodebuild build in step 2 would otherwise fail at link).
- **CI Path B** (artifact handoff): `kmp-build-test` uploads xcframework as artifact; `lint-and-test` and `release-build` consume via `actions/download-artifact@v7.0.0` with cascade-gate `if: always() && (... 'success' || ... 'skipped')` — handles all 4 CI scenarios (push to spike / PR INTO spike / PR FROM spike / push to main). `release-build` also captures H6 binary delta via `du -sh PasturaShared.framework`. `ui-test` deliberately unchanged (its inverse `if:` already excludes spike-branch events).
- **Pastura.xcodeproj XCFramework wiring**: 36 LOC across 9 sections (UUIDs prefixed `E0F1A1F1...`) — file reference + link build file + Embed & Sign copy phase + Frameworks group + `FRAMEWORK_SEARCH_PATHS = $(PROJECT_DIR)/Frameworks` for Debug + Release.
- **Sandbox Swift consumer** `Pastura/Pastura/KMPSpike/PasturaSharedSpike.swift`: references `Pairing` (data class), `PairingStrategy.roundRobin` (enum interop), `Phase` (nested-collection optionality) for Q9 shim-LOC measurement (~150 LOC, well under 300 LOC budget). Includes ~15-line minimal H8 smoke (`@Observable` wrapper + `withObservationTracking`) — compile-time signal that the K/N + `@Observable` pattern composes.

## Tier 2 readings (local, warm konan + gradle cache)

| Metric | Value | Target | Status |
|---|---|---|---|
| `assemblePasturaSharedXCFramework` cold (xcframework absent) | 2m 20s | n/a | baseline |
| `assemble-xcframework.sh --if-missing` warm | 1.4–2.2s | < 5s pre-commit | ✅ |
| `PasturaShared.xcframework` size on disk | 23 MB (3 archs) | n/a | baseline |
| `PasturaShared.framework` embedded (universal sim slice) | 7.5 MB | n/a | iphoneos arm64 only will be ~3-4 MB |
| `Pastura.app/Pastura` binary delta (consumer added vs baseline) | 0 bytes | n/a | K/N symbols resolve via dyld, not statically inlined |
| `xcodebuild build` (Debug-iphonesimulator, warm SPM) | 21s cold xcframework / 10s warm | n/a | baseline |
| `PasturaTests` suite | 1791 / 161 / 16.4s | flat from W2 (1774) — +17 absorbed from main rebase | ✅ no regression |
| `jvmTest` | 153 / 0.196s | flat from W2 PR-B | ✅ UP-TO-DATE |
| Compile error readability (Tier 4) | 4 / 5 | qualitative | Swift 6 strict-concurrency diagnostics precise + actionable; took 2 iterations on H8 closure capture to land green (initial @escaping var capture → reference-type box → nonisolated box) |

CI Q4-warm / Q4-cold will be measured at PR merge time. Documented exception: Q4-cold during Kotlin/Gradle version bump may temporarily exceed the 20min ceiling per Path B's serialization (kmp-build-test critical-path-locked); recurring bumps would trigger CI optimization follow-up.

## Process notes

- **Critic passes**: 4 (Opus). Pass 1 → 2C/6W → revised. Pass 2 → 2C (different)/6W → revised. Pass 3 → 2 NEW C/6W → revised. Pass 4 → 0C/3W → READY. Net 8 Critical findings closed.
- **Code-reviewer**: 1 pass (Opus). NEEDS_FIX → 1 Warning (branch-switching footgun: pre-commit hook fails on non-spike branches with missing `shared/models/`). Fixed via wrapper-level guard (`7fc325e`) — single point of fix covers both pre-commit and setup.sh callers.
- **T12 rebase**: `feature/kmp-spike-models` rebased onto `origin/main` cleanly (4 commits replayed, force-with-lease push, no conflicts). Pastura.xcodeproj on main was untouched by the 11 commits since W2 PR-B merge.

## What's deferred to subsequent W3 PRs / W4

- W3 PR-B: full H8 bridge test suite (`access`/`withMutation` pattern across K/N boundary per [PR #216 pattern](https://github.com/tyabu12/pastura/pull/216), mutation-triggers-invalidation assertion, edge cases like collection / nested-type / async actor read-back).
- W3 PR-C / W4: H4 iOS device smoke (`prisoners_dilemma.yaml` end-to-end with KMP Models + MockLLMService), H5 ASC archive dry-run (the actual Embed & Sign validation — local + CI both use `CODE_SIGNING_ALLOWED=NO`), `snakeyaml-engine-kmp` W3 upstream-activity re-check.
- W6 GO PR caveat: `kmp-build-test`'s `if:` gate currently doesn't fire on `base_ref == 'main'`. The merge PR will need either gate extension to match `base_ref == 'main' && head_ref == 'feature/kmp-spike-models'`, or pre-merge xcframework cache-stage step. Tracked in `Pastura/Frameworks/README.md` "W6 merge-PR caveat" section.

## Test plan

- [x] Local `scripts/xcodebuild.sh build` succeeds with xcframework embed.
- [x] Local `scripts/xcodebuild.sh test -only-testing PasturaTests` — 1791 tests pass / 0 failures.
- [x] Local `./gradlew :shared:models:jvmTest` — UP-TO-DATE (no regression).
- [x] `scripts/kmp/assemble-xcframework.sh --if-missing` exits 0 silently when `shared/models/` is absent (branch-switch guard).
- [x] `scripts/kmp/assemble-xcframework.sh --if-missing` warm rerun ~1.4-2.2s on spike branch.
- [x] `actionlint .github/workflows/ci.yml` exit 0.
- [x] `plutil -lint Pastura/Pastura.xcodeproj/project.pbxproj` OK.
- [ ] CI Path B end-to-end: `kmp-build-test` uploads xcframework → `lint-and-test` + `release-build` download + build with framework. (Verified by this PR's CI run.)
- [ ] H6 binary delta capture in `release-build` job: `du -sh PasturaShared.framework` value visible in CI log. (Verified by this PR's CI run.)

## Reviewer checklist focus

- Wrapper script contract correctness (exit codes, branch-switch guard, atomic rename).
- pbxproj edits — UUID hygiene (`E0F1A1F1...` prefix uniqueness), Embed & Sign settings (`dstSubfolderSpec = 10`, `CodeSignOnCopy` attribute), Frameworks group placement.
- CI cascade-gate semantics — verify the `if: always() && (... 'success' || ... 'skipped')` shape and step-level `if: == 'success'` together cover all 4 event scenarios without silent-skip on main.
- `KMPSpike/PasturaSharedSpike.swift` — `nonisolated final class @unchecked Sendable ObservationFireSignal` soundness for the H8 smoke capture under Swift 6 strict concurrency.

## ASC validation gap (durable note)

CI's `release-build` runs with `CODE_SIGNING_ALLOWED=NO`, so Embed & Sign correctness for ASC submission is NOT validated by this PR's CI run. H5 ASC archive dry-run (deferred to W3 PR-C / W4) is the actual validation path. Documented in `Pastura/Frameworks/README.md` "CI coverage" section. Local `xcodebuild archive` smoke is infeasible — Apple Developer Program is not registered for this project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)