### PR TITLE
📚 chore(rules): promote xcodebuild test env-var trap → xcodebuild-cli.md (#468)

### DIFF
--- a/.claude/rules/xcodebuild-cli.md
+++ b/.claude/rules/xcodebuild-cli.md
@@ -73,9 +73,15 @@ consumed before xcodebuild is invoked).
 | CI full run | `.github/workflows/ci.yml` (bypasses wrapper) |
 
 Skip UI tests with `-skip-testing:PasturaUITests` when the change
-does not touch UI (UI tests are not required for MVP). Ollama
-integration tests require `OLLAMA_INTEGRATION` env var enabled in the
-scheme; otherwise auto-skipped.
+does not touch UI (UI tests are not required for MVP). Integration
+tests (Ollama / Llama) require their `*_INTEGRATION` env var enabled
+**in the scheme** (`LaunchAction > EnvironmentVariables` inherited by
+`TestAction` via `shouldUseLaunchSchemeArgsEnv="YES"`). CLI env vars
+passed to `scripts/xcodebuild.sh test` (or bare `xcodebuild test`) are
+NOT forwarded to the test runner subprocess — that path silently
+skips the suite while xcodebuild still prints `TEST SUCCEEDED`.
+Toggle in Xcode UI, or temporarily flip `isEnabled="YES"` in the XML
+before running — revert before commit.
 
 ## --tail (built-in, pipefail-safe)
 


### PR DESCRIPTION
## Summary

Promote the `xcodebuild test` CLI-env-var-propagation trap from per-user memory into the always-loaded `.claude/rules/xcodebuild-cli.md`. Same shape as PR #460 / #462 / #465 promotions — concept-level register per `feedback_rules_concept_register.md` ("細かいルールよりコンセプトだけ書いてあれば OK").

Expand the existing "Skip UI tests / integration" paragraph (L75–78) from an OLLAMA-only note to a concept-level rule covering both Ollama / Llama integration suites. Captures:

- **WHY** — xcodebuild does not auto-forward CLI env vars to the test runner subprocess
- **INVARIANT** — toggle in the scheme's `LaunchAction > EnvironmentVariables` (inherited by `TestAction` via `shouldUseLaunchSchemeArgsEnv="YES"`), not on the CLI
- **POINTER** — failure mode signature is silent suite skip + `** TEST SUCCEEDED **` (easy to mistake for a pass)

Pre-impl critic (Opus) returned 2 Warnings + 1 Info — all 3 adopted:

- Cite `scripts/xcodebuild.sh test` wrapper alongside bare `xcodebuild test` — the wrapper is this file's own canonical invocation (L19)
- Append "revert before commit" for the `isEnabled="YES"` XML toggle, mirroring ADR-002 L1267 ("Remember to revert before commit")
- Trim 2nd bold span — keep only `**in the scheme**` as the load-bearing invariant

Code-reviewer (Opus) PASSED with 0 Critical / 0 Warning / 1 Suggestion (non-blocking stylistic). Verified all 4 load-bearing facts (`shouldUseLaunchSchemeArgsEnv="YES"` at scheme L30, both env vars present in scheme L81/L91, wrapper form consistent with L17/L70, "Ollama / Llama" parenthetical matches both integration test files' suite gates).

Post-merge local cleanup (out of PR — per-user / per-machine action per `.claude/rules/knowledge-layering.md` §Procedure step 3):

- `command rm ~/.claude/projects/-Users-tyabu12-Work-pastura/memory/feedback_xcodebuild_test_env_vars_need_scheme.md`
- Strip MEMORY.md L82 index line for that entry

## Test plan

- [x] Diff scope confirmed markdown-only (`.claude/rules/xcodebuild-cli.md` — single file, 1 hunk, +9/-3)
- [x] SwiftLint sanity check (only pre-existing config warning, no new violations)
- [x] No Swift code touched → full xcodebuild suite intentionally skipped (doc-only PR per `feedback_doc_only_pr_merge_on_infra_flake.md`)
- [x] All load-bearing facts in new wording verified against current main (scheme XML, wrapper form, env-var existence)
- [x] No collision with adjacent paragraphs (`## --tail` L80, `## Wrapper behavior` L94)
- [x] Required CI checks green

Closes #468