### PR TITLE
♻️ refactor: extract shared pre-decode helper for LlamaCppService

### DIFF
--- a/Pastura/Pastura/LLM/LlamaCppService+PrepareGeneration.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService+PrepareGeneration.swift
@@ -1,0 +1,103 @@
+import Foundation
+import LlamaSwift
+
+// MARK: - Pre-decode preparation
+
+/// Outputs of ``LlamaCppService/prepareGeneration(model:context:system:user:schema:)``.
+/// `vocab` is needed in the autoregressive loop (`llama_vocab_is_eog`,
+/// piece decoding); `sampler` is the configured chain (penalties → top_k →
+/// top_p → grammar → temperature → dist). The caller owns the sampler's
+/// lifetime — see the precondition note on the helper itself.
+nonisolated struct PreparedGeneration {
+  /// Optional to match the upstream `llama_model_get_vocab` return type
+  /// and the existing `tokenize` / `decodePiece` / `decodePieceRaw`
+  /// signatures, which all accept `OpaquePointer?` directly without a
+  /// nil check at the use site.
+  let vocab: OpaquePointer?
+  let sampler: UnsafeMutablePointer<llama_sampler>
+}
+
+extension LlamaCppService {
+  /// Shared pre-decode pipeline for ``runGeneration`` (non-streaming) and
+  /// ``runStreamGeneration`` (streaming). Runs: vocab derive → chat
+  /// template apply → tokenize → context-size bound check → KV cache
+  /// clear → prefill → grammar build → sampler chain create.
+  ///
+  /// **Preconditions** (load-bearing — caller responsibilities not
+  /// re-checked here):
+  /// 1. Caller holds ``generatingGuard`` via
+  ///    ``acquireGenerateGuard(caller:)`` (ADR-002 §6 sequential-access
+  ///    contract). The guard prevents `unloadModel` from freeing
+  ///    `model` / `context` between this call and the caller's inference
+  ///    loop.
+  /// 2. Caller has already verified `isModelLoaded` and captured `model`
+  ///    / `context` from `_model` / `_context` after that check. This
+  ///    helper accepts the captured pointers directly because the
+  ///    private storage is not visible to sibling-file extensions.
+  ///
+  /// **Sampler ownership** — the returned `sampler` is owned by the
+  /// caller. Pair every successful return with
+  /// `defer { llama_sampler_free(prepared.sampler) }` in the caller's
+  /// scope. The helper does NOT install its own defer because Swift's
+  /// `defer` only fires at the helper's scope exit, which would free
+  /// the sampler before the caller's inference loop runs.
+  ///
+  /// **Grammar wire-up** — both calling paths get grammar through this
+  /// single seam when `schema` is non-nil. If a third call path is
+  /// added, route it through this helper rather than reconstructing the
+  /// sampler inline; missing grammar wire-up on the streaming path was
+  /// the regression class Critic Axis 3 flagged when this helper was
+  /// proposed (see issue #428 for the dedup rationale).
+  ///
+  /// - Throws: ``LLMError/generationFailed(description:)`` when the
+  ///   prompt token count exceeds the context size; whatever
+  ///   ``applyChatTemplate``, ``tokenize``, ``prefill``, or
+  ///   ``createSampler`` throw.
+  func prepareGeneration(
+    model: OpaquePointer,
+    context: OpaquePointer,
+    system: String,
+    user: String,
+    schema: OutputSchema?
+  ) throws -> PreparedGeneration {
+    let vocab = llama_model_get_vocab(model)
+
+    let formattedPrompt = try applyChatTemplate(system: system, user: user)
+    let tokens = try tokenize(vocab: vocab, text: formattedPrompt, addSpecial: true)
+
+    let nCtx = Int(llama_n_ctx(context))
+    guard tokens.count <= nCtx else {
+      throw LLMError.generationFailed(
+        description: String(
+          format: String(localized: "Prompt (%lld tokens) exceeds context size (%lld)"),
+          tokens.count, nCtx)
+      )
+    }
+
+    // Clear KV cache for independent inference (each generate() call is self-contained).
+    llama_memory_clear(llama_get_memory(context), true)
+
+    try prefill(context: context, tokens: tokens)
+
+    // Build grammar once per call when a schema is requested.
+    let grammarString = try schema.map { try GBNFGrammarBuilder().build(from: $0) }
+
+    // Keep `createSampler` as the LAST step in this helper. The sampler
+    // is freed by the caller's `defer { llama_sampler_free(...) }`; any
+    // step added after this and before the return would leak the sampler
+    // if it throws.
+    let sampler = try createSampler(grammarString: grammarString, vocab: vocab)
+
+    return PreparedGeneration(vocab: vocab, sampler: sampler)
+  }
+
+  /// Shared empty-output postcondition for both `runGeneration` paths.
+  /// Centralizing the throw keeps the catalog key
+  /// `"Model generated no output tokens"` at a single source location.
+  func assertNonEmptyOutput(_ text: String) throws {
+    guard !text.isEmpty else {
+      throw LLMError.generationFailed(
+        description: String(localized: "Model generated no output tokens"))
+    }
+  }
+}

--- a/Pastura/Pastura/LLM/LlamaCppService.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService.swift
@@ -471,34 +471,14 @@ extension LlamaCppService {
       throw LLMError.notLoaded
     }
 
-    let vocab = llama_model_get_vocab(model)
-
-    // Apply chat template to format system+user into model-native format
-    let formattedPrompt = try applyChatTemplate(system: system, user: user)
-
-    // Tokenize the formatted prompt
-    let tokens = try tokenize(vocab: vocab, text: formattedPrompt, addSpecial: true)
-
-    let nCtx = Int(llama_n_ctx(context))
-    guard tokens.count <= nCtx else {
-      throw LLMError.generationFailed(
-        description: String(
-          format: String(localized: "Prompt (%lld tokens) exceeds context size (%lld)"),
-          tokens.count, nCtx)
-      )
-    }
-
-    // Clear KV cache for independent inference (each generate() call is self-contained)
-    llama_memory_clear(llama_get_memory(context), true)
-
-    // Prefill: process prompt tokens
-    try prefill(context: context, tokens: tokens)
-
-    // Set up sampler chain. Grammar (if any) is built once per call
-    // and fed to `createSampler`; it lives only for this generation.
-    let grammarString = try schema.map { try GBNFGrammarBuilder().build(from: $0) }
-    let sampler = try createSampler(grammarString: grammarString, vocab: vocab)
-    defer { llama_sampler_free(sampler) }
+    // Shared pre-decode pipeline (see `LlamaCppService+PrepareGeneration.swift`
+    // for the load-bearing precondition / sampler-ownership notes — issue #428).
+    let prepared = try prepareGeneration(
+      model: model, context: context,
+      system: system, user: user, schema: schema)
+    defer { llama_sampler_free(prepared.sampler) }
+    let vocab = prepared.vocab
+    let sampler = prepared.sampler
 
     // Auto-regressive generation loop with string-based stop detection.
     // Tokens are decoded incrementally so we can detect <|im_end|> even when
@@ -567,10 +547,7 @@ extension LlamaCppService {
       }
     }
 
-    guard !outputText.isEmpty else {
-      throw LLMError.generationFailed(
-        description: String(localized: "Model generated no output tokens"))
-    }
+    try assertNonEmptyOutput(outputText)
 
     #if DEBUG
       if let collector = traceCollector {
@@ -638,7 +615,7 @@ extension LlamaCppService {
   /// `schema` reaches here via `generateStream`; it is unused in Item 2
   /// but kept in the signature so Item 4 can wire `createSampler`
   /// without reshaping the call chain again.
-  fileprivate func runStreamGeneration(  // swiftlint:disable:this function_body_length cyclomatic_complexity
+  fileprivate func runStreamGeneration(  // swiftlint:disable:this function_body_length
     system: String, user: String, schema: OutputSchema?,
     continuation: AsyncThrowingStream<LLMStreamChunk, Error>.Continuation
   ) async throws {
@@ -658,29 +635,17 @@ extension LlamaCppService {
       throw LLMError.notLoaded
     }
 
-    let vocab = llama_model_get_vocab(model)
-    let formattedPrompt = try applyChatTemplate(system: system, user: user)
-    let tokens = try tokenize(vocab: vocab, text: formattedPrompt, addSpecial: true)
-
-    let nCtx = Int(llama_n_ctx(context))
-    guard tokens.count <= nCtx else {
-      throw LLMError.generationFailed(
-        description: String(
-          format: String(localized: "Prompt (%lld tokens) exceeds context size (%lld)"),
-          tokens.count, nCtx)
-      )
-    }
-
-    llama_memory_clear(llama_get_memory(context), true)
-    try prefill(context: context, tokens: tokens)
-
-    // Grammar-constrained sampling: build once per stream invocation
-    // (matching the non-streaming path in `runGeneration`). Missing
-    // wire-up here would silently bypass grammar on the streaming
-    // path — the regression scenario Critic Axis 3 flagged.
-    let grammarString = try schema.map { try GBNFGrammarBuilder().build(from: $0) }
-    let sampler = try createSampler(grammarString: grammarString, vocab: vocab)
-    defer { llama_sampler_free(sampler) }
+    // Shared pre-decode pipeline (see `LlamaCppService+PrepareGeneration.swift`).
+    // Grammar wire-up: both `runGeneration` and `runStreamGeneration`
+    // build the sampler through this single helper, so a non-nil
+    // `schema` constrains both paths uniformly — the regression class
+    // a previous Critic Axis 3 flagged on the streaming path (issue #428).
+    let prepared = try prepareGeneration(
+      model: model, context: context,
+      system: system, user: user, schema: schema)
+    defer { llama_sampler_free(prepared.sampler) }
+    let vocab = prepared.vocab
+    let sampler = prepared.sampler
 
     // Byte-level accumulation so UTF-8 characters split across pieces
     // (common for CJK / emoji) never emit as partial replacement
@@ -769,10 +734,7 @@ extension LlamaCppService {
       emittedCharCount = decodedText.count
     }
 
-    guard !decodedText.isEmpty else {
-      throw LLMError.generationFailed(
-        description: String(localized: "Model generated no output tokens"))
-    }
+    try assertNonEmptyOutput(decodedText)
 
     #if DEBUG
       if let collector = traceCollector {


### PR DESCRIPTION
## Summary
- Centralize ~25 lines of pre-decode setup (vocab derive → chat template → tokenize → context-size bound check → KV clear → prefill → grammar build → sampler chain create) shared by `runGeneration` and `runStreamGeneration` into a new `LlamaCppService+PrepareGeneration.swift` sibling extension.
- Centralize two `String(localized:)` literal duplicates (`Prompt … exceeds context size …`, `Model generated no output tokens`) at a single source location each — zero diff in `Localizable.xcstrings`.
- Remove the `cyclomatic_complexity` swiftlint suppression from `runStreamGeneration` (post-refactor body no longer trips it). `function_body_length` markers retained — 70 / 86 line bodies still exceed `--strict`'s 50-line warning.

**ADR-002 §6 ordering preserved**: throttle → `acquireGenerateGuard` → defer-clear → load-check + `_model` / `_context` capture stays at each caller (private state not reachable from sibling-file extension). Helper accepts captured pointers as parameters. Sampler `defer { llama_sampler_free(…) }` stays at caller; helper's last operation is `createSampler` so a future post-sampler throwing step would not leak (inline guard comment in the helper enforces this contract).

**Grammar wire-up regression context** (was inline at `runStreamGeneration:678-680` before this PR — _"Missing wire-up here would silently bypass grammar on the streaming path"_) is moved into the new helper's doc comment so the both-paths-via-one-helper invariant has a single source of truth.

## Test plan
- [x] `scripts/xcodebuild.sh build` — green
- [x] `scripts/xcodebuild.sh test -skip-testing:PasturaUITests` — 1790 tests in 161 suites passed in 20s
- [x] `swiftlint lint --strict` — clean
- [x] `git diff Pastura/Pastura/Resources/Localizable.xcstrings` — empty (no catalog churn)
- [ ] CI: full unit + UI suite

Closes #428