### PR TITLE
📚 docs(pages): add sitemap.xml and robots.txt for SEO baseline

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -33,6 +33,14 @@
 #   - `pages/ja/legal/privacy-policy/index.html`
 #                                          → `https://pastura.app/ja/legal/privacy-policy/`
 #     (Japanese mirror of the privacy policy page)
+#   - `pages/sitemap.xml`                  → `https://pastura.app/sitemap.xml`
+#     (SEO sitemap — minimal 6-URL form. `lastmod` / `hreflang`
+#     intentionally omitted; see the file's header comment for
+#     rationale.)
+#   - `pages/robots.txt`                   → `https://pastura.app/robots.txt`
+#     (Crawler directive — `User-agent: *` + `Sitemap:` line pointing
+#     at `https://pastura.app/sitemap.xml` for discovery without
+#     requiring Search Console submission.)
 #   - `pages/CNAME`                        → `_site/CNAME` (apex custom domain)
 #     (Single line `pastura.app`. GitHub Pages reads CNAME from the
 #     deployed artifact root to persist `Settings → Pages → Custom
@@ -123,6 +131,8 @@ jobs:
           cp pages/ja/index.html _site/ja/index.html
           cp pages/ja/support/index.html _site/ja/support/index.html
           cp pages/ja/legal/privacy-policy/index.html _site/ja/legal/privacy-policy/index.html
+          cp pages/sitemap.xml _site/sitemap.xml
+          cp pages/robots.txt _site/robots.txt
           cp pages/CNAME _site/CNAME
           touch _site/.nojekyll
 
@@ -158,7 +168,9 @@ jobs:
             "https://pastura.app/legal/privacy-policy/" \
             "https://pastura.app/ja/" \
             "https://pastura.app/ja/support/" \
-            "https://pastura.app/ja/legal/privacy-policy/"; do
+            "https://pastura.app/ja/legal/privacy-policy/" \
+            "https://pastura.app/sitemap.xml" \
+            "https://pastura.app/robots.txt"; do
             echo "Checking ${url}"
             curl -fsS --retry 5 --retry-delay 5 --retry-all-errors -o /dev/null "${url}"
           done

--- a/pages/robots.txt
+++ b/pages/robots.txt
@@ -1,0 +1,8 @@
+# Allow all well-behaved crawlers. The actionable content here is
+# the Sitemap directive — Google/Bing read it as a discovery hint
+# alongside Search Console submission.
+
+User-agent: *
+Allow: /
+
+Sitemap: https://pastura.app/sitemap.xml

--- a/pages/sitemap.xml
+++ b/pages/sitemap.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  XML sitemap for https://pastura.app/ — minimal form by design.
+
+  - <lastmod> is intentionally omitted. Google ignores inaccurate lastmod
+    values entirely (John Mueller, public clarification); default-today
+    autofill is anti-pattern. With 6 rarely-updated pages, accurate
+    per-URL tracking is not worth the maintenance burden.
+  - <xhtml:link rel="alternate" hreflang="..."> is intentionally omitted.
+    All 6 HTML pages already declare hreflang (en / ja / x-default) in
+    their <head>; HTML is the single source of truth for language
+    variants. Duplicating into XML adds drift risk with no SEO gain.
+  - <changefreq> / <priority> are ignored by Google and omitted.
+
+  Add new pages here AND mirror the addition in .github/workflows/
+  deploy-pages.yml (header docstring + staging step + smoke-check loop).
+-->
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://pastura.app/</loc></url>
+  <url><loc>https://pastura.app/ja/</loc></url>
+  <url><loc>https://pastura.app/support/</loc></url>
+  <url><loc>https://pastura.app/ja/support/</loc></url>
+  <url><loc>https://pastura.app/legal/privacy-policy/</loc></url>
+  <url><loc>https://pastura.app/ja/legal/privacy-policy/</loc></url>
+</urlset>


### PR DESCRIPTION
## Summary
- Add minimal `pages/sitemap.xml` (6 URLs, no `lastmod` / `hreflang`) — see file header comment for omission rationale
- Add `pages/robots.txt` with `Sitemap:` directive for crawler discovery
- Update `.github/workflows/deploy-pages.yml` in all 3 locations (header bullets + staging `cp` + smoke-check URLs) per the workflow's silent-404 discipline

Done while Apple Developer Program enrollment is pending — pure SEO infrastructure prep. Google's own docs say a sitemap is unnecessary for sites with <500 pages + comprehensive internal linking (Pastura qualifies), but this future-proofs Search Console hreflang verification. `lastmod` is omitted because John Mueller has publicly called default-today values an anti-pattern that causes Google to ignore lastmod entirely.

## Test plan
- [x] `xmllint --noout pages/sitemap.xml` — passes (XML well-formed against sitemaps.org/schemas/sitemap/0.9)
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on deploy-pages.yml — passes
- [x] `grep sitemap deploy-pages.yml` → 5 hits, `grep robots` → 3 hits (all 3 locations updated)
- [x] Sitemap `<loc>` entries byte-match all 6 `<link rel="canonical">` href values in the HTML pages
- [ ] After merge: `deploy-pages` workflow runs and smoke-checks `https://pastura.app/sitemap.xml` + `https://pastura.app/robots.txt` (200 expected)

## Manual follow-ups (post-merge, out-of-band)
- Register `https://pastura.app/` as a property in Google Search Console (requires domain verification — cannot be automated)
- Submit `https://pastura.app/sitemap.xml` via the Sitemaps tab for faster initial indexing
- (Optional) Add a one-line "Phase 2 progress" entry to `CLAUDE.md` for the SEO baseline if PR provenance discoverability matters

Closes #472