### PR TITLE
📚 docs: clarify ScenarioEditor dual-buffer + funnel invariant (#338)

### DIFF
--- a/.claude/rules/scenario-editor.md
+++ b/.claude/rules/scenario-editor.md
@@ -29,12 +29,13 @@ the mode dispatch and silently re-introduces the #336 drift class.
 rg 'buildScenario\(\)' Pastura/Pastura/App/ScenarioEditorViewModel.swift
 ```
 
-Should return ≤3 hits (callsites from `switchToYAMLMode()` and
+Should return **exactly 3 hits** (callsites from `switchToYAMLMode()` and
 `currentScenario()`, plus the `private func buildScenario()` declaration).
-Hit-count assertion — line numbers drift on any insertion. A 4th hit means
-a new consumer is reading visual state directly: either route through
+Hit-count assertion — line numbers drift on any insertion. **>3** means a
+new consumer is reading visual state directly: either route through
 `currentScenario()`, or treat it as a named re-evaluation trigger for #338
-(the source-of-truth shift was deliberately deferred).
+(the source-of-truth shift was deliberately deferred). **<3** means a
+sanctioned callsite was dropped — same re-evaluation gate applies.
 
 ## Related
 

--- a/.claude/rules/scenario-editor.md
+++ b/.claude/rules/scenario-editor.md
@@ -1,0 +1,42 @@
+---
+paths:
+  - "Pastura/Pastura/App/ScenarioEditor*"
+  - "Pastura/Pastura/Views/Editor/**"
+  - "Pastura/PasturaTests/App/ScenarioEditorViewModel*"
+---
+
+# ScenarioEditor — Funnel Invariant
+
+`ScenarioEditorViewModel` holds a **dual buffer**: visual fields and
+`yamlText` are independent, each the source of truth for whichever mode
+the user last touched. Visual edits do not normalize the user's YAML
+(preserving comments, key order); YAML edits do not parse on every
+keystroke. The two sides reconcile at materialization via the private
+`currentScenario()` funnel. PR #336 introduced it after `save()` silently
+materialized from empty visual fields when the user had only ever touched
+YAML mode (`"Agent count (0)"` error).
+
+## Invariant
+
+Every new callsite that needs a `(Scenario, yaml)` pair from the editor —
+save, export, preview, share — MUST route through `currentScenario()`.
+Reading `buildScenario()` or `serializer.serialize(...)` directly bypasses
+the mode dispatch and silently re-introduces the #336 drift class.
+
+## PR review grep
+
+```
+rg 'buildScenario\(\)' Pastura/Pastura/App/ScenarioEditorViewModel.swift
+```
+
+Should return ≤3 hits (callsites from `switchToYAMLMode()` and
+`currentScenario()`, plus the `private func buildScenario()` declaration).
+Hit-count assertion — line numbers drift on any insertion. A 4th hit means
+a new consumer is reading visual state directly: either route through
+`currentScenario()`, or treat it as a named re-evaluation trigger for #338
+(the source-of-truth shift was deliberately deferred).
+
+## Related
+
+- PR #336 — drift bug fixed via the funnel
+- Issue #338 — deferred source-of-truth refactor; this rule is the safety net

--- a/Pastura/Pastura/App/ScenarioEditorViewModel.swift
+++ b/Pastura/Pastura/App/ScenarioEditorViewModel.swift
@@ -32,8 +32,14 @@ struct EditablePersona: Identifiable, Sendable {
 /// ViewModel for the dual-mode scenario editor (visual form + raw YAML).
 ///
 /// Manages editor state for both modes and handles mode switching,
-/// validation, template loading, and save flow. YAML is the source of truth:
-/// visual edits are serialized to YAML on mode switch and on save.
+/// validation, template loading, and save flow. State is intentionally a
+/// **dual buffer**: visual fields and `yamlText` are independent, and each
+/// is the source of truth for whichever mode the user last touched.
+/// `currentScenario()` is the single mode-dispatch funnel that materializes
+/// either side into a persistable `(Scenario, yaml)` pair — see PR #336 for
+/// the drift class this funnel resolves. New save / export / preview / share
+/// callsites MUST route through `currentScenario()`; see
+/// `.claude/rules/scenario-editor.md`.
 @Observable
 final class ScenarioEditorViewModel {
 
@@ -82,6 +88,13 @@ final class ScenarioEditorViewModel {
   /// Captured in `populateFromScenario` so `buildScenario` can pass them
   /// through unchanged — preventing a silent data loss on every visual-mode save
   /// for scenarios with custom fields (e.g. bokete `topics`, word_wolf `words`).
+  ///
+  /// Load-bearing for engine correctness — `scenario.extraData` is read at
+  /// runtime by `AssignHandler.execute`, `EventInjectHandler.execute`,
+  /// `ScenarioValidator.validateAssignPhaseShape`, and
+  /// `ScenarioValidator.validateEventInjectShape`. Removing the carry would
+  /// silently drop these fields on every visual-mode save, breaking scenarios
+  /// that depend on them.
   private var carriedExtraData: [String: AnyCodableValue] = [:]
 
   init(repository: any ScenarioRepository) {

--- a/Pastura/Pastura/App/ScenarioEditorViewModel.swift
+++ b/Pastura/Pastura/App/ScenarioEditorViewModel.swift
@@ -31,15 +31,12 @@ struct EditablePersona: Identifiable, Sendable {
 
 /// ViewModel for the dual-mode scenario editor (visual form + raw YAML).
 ///
-/// Manages editor state for both modes and handles mode switching,
-/// validation, template loading, and save flow. State is intentionally a
-/// **dual buffer**: visual fields and `yamlText` are independent, and each
-/// is the source of truth for whichever mode the user last touched.
-/// `currentScenario()` is the single mode-dispatch funnel that materializes
-/// either side into a persistable `(Scenario, yaml)` pair — see PR #336 for
-/// the drift class this funnel resolves. New save / export / preview / share
-/// callsites MUST route through `currentScenario()`; see
-/// `.claude/rules/scenario-editor.md`.
+/// State is intentionally a **dual buffer**: visual fields and `yamlText`
+/// are independent, each the source of truth for whichever mode the user
+/// last touched. `currentScenario()` is the single mode-dispatch funnel
+/// that materializes a `(Scenario, yaml)` pair — see PR #336 for the drift
+/// class it resolves. New save / export / preview / share callsites MUST
+/// route through `currentScenario()`; see `.claude/rules/scenario-editor.md`.
 @Observable
 final class ScenarioEditorViewModel {
 
@@ -83,18 +80,14 @@ final class ScenarioEditorViewModel {
   private let validator = ScenarioValidator()
   private let contentValidator = ScenarioContentValidator()
 
-  /// Stores top-level YAML keys that the visual editor has no UI for.
-  ///
-  /// Captured in `populateFromScenario` so `buildScenario` can pass them
-  /// through unchanged — preventing a silent data loss on every visual-mode save
-  /// for scenarios with custom fields (e.g. bokete `topics`, word_wolf `words`).
+  /// Top-level YAML keys without a Visual UI, captured by
+  /// `populateFromScenario` so `buildScenario` passes them through on
+  /// visual-mode save (bokete `topics`, word_wolf `words`, …).
   ///
   /// Load-bearing for engine correctness — `scenario.extraData` is read at
-  /// runtime by `AssignHandler.execute`, `EventInjectHandler.execute`,
-  /// `ScenarioValidator.validateAssignPhaseShape`, and
-  /// `ScenarioValidator.validateEventInjectShape`. Removing the carry would
-  /// silently drop these fields on every visual-mode save, breaking scenarios
-  /// that depend on them.
+  /// runtime by `AssignHandler.execute`, `EventInjectHandler.execute`, and
+  /// `ScenarioValidator.{validateAssignPhaseShape,validateEventInjectShape}`.
+  /// Removing the carry would silently drop these fields on visual-mode save.
   private var carriedExtraData: [String: AnyCodableValue] = [:]
 
   init(repository: any ScenarioRepository) {

--- a/Pastura/PasturaTests/App/ScenarioEditorViewModelTests.swift
+++ b/Pastura/PasturaTests/App/ScenarioEditorViewModelTests.swift
@@ -288,6 +288,52 @@ struct ScenarioEditorViewModelTests {
     #expect(reloaded.extraData["topics"] == .array(["Photo A", "Photo B", "Photo C"]))
   }
 
+  /// Visual-mode equivalent of `yamlModeSavePreservesExtraData` above. Save in
+  /// `.visual` mode routes through `currentScenario()` → `buildScenario()`, which
+  /// reads `carriedExtraData` to pass through fields the visual editor has no UI
+  /// for. Reverting the funnel to bypass `buildScenario()` — or removing
+  /// `carriedExtraData` — would silently drop extraData on every visual-mode save.
+  /// Tripwire for the funnel invariant; see `.claude/rules/scenario-editor.md`.
+  @Test func visualModeSavePreservesExtraData() async throws {
+    let (sut, repo) = try makeSUTWithRepo()
+    let boketeYAML = """
+      id: bokete_visual_save_test
+      language: ja
+      name: Bokete Visual Save Test
+      description: Tests extraData survival on visual-mode save via carriedExtraData
+      agents: 2
+      rounds: 1
+      context: Context
+      topics:
+        - Photo A
+        - Photo B
+        - Photo C
+      personas:
+        - name: Alice
+          description: Agent A
+        - name: Bob
+          description: Agent B
+      phases:
+        - type: assign
+          source: topics
+          target: all
+      """
+    sut.loadFromTemplate(yaml: boketeYAML)
+    // editorMode is .visual by default; populateFromScenario captures `topics`
+    // into carriedExtraData. No mode switch — save() must go through the
+    // .visual branch of currentScenario() → buildScenario().
+    #expect(sut.editorMode == .visual)
+
+    let success = await sut.save()
+
+    #expect(success)
+    // loadFromTemplate generates a new UUID-based id; resolve via savedScenarioId.
+    let savedId = try #require(sut.savedScenarioId)
+    let record = try repo.fetchById(savedId)
+    let reloaded = try ScenarioLoader().load(yaml: record?.yamlDefinition ?? "")
+    #expect(reloaded.extraData["topics"] == .array(["Photo A", "Photo B", "Photo C"]))
+  }
+
   @Test func saveSurfacesSourceNotFoundValidationMessage() async throws {
     let sut = try makeSUT()
     // YAML with an `assign` phase referencing a non-existent `topics` source.


### PR DESCRIPTION
## Summary

Issue #338 原文 (`yamlText` を single source of truth に shift) を現状調査した結果、
- `buildScenario()` が visual fields 直読は事実だが `carriedExtraData` は band-aid ではなく **engine の load-bearing surface** (`AssignHandler.execute`, `EventInjectHandler.execute`, `ScenarioValidator.validateAssign{PhaseShape,EventInjectShape}` が `scenario.extraData` を runtime 直読)
- #336 の症状は `currentScenario()` funnel で既に解消、残るのは drift class の **将来の再発リスク**
- 700–1000 line full refactor は ADR-011 + perf test + QA matrix を prereq として要求、Phase 2 完了優先度と競合

ゼロベース reframe して **Option C = minimum safety** に着地:

1. `ScenarioEditorViewModel` doc を実態 (dual-buffer + funnel) と整合
2. `.claude/rules/scenario-editor.md` 新規 — 「新規 save / export / preview / share callsite は `currentScenario()` 経由」を path-scoped 規則化 + grep-based PR check (`rg 'buildScenario\(\)'` が exactly 3 hits)
3. Visual-mode `save()` + extraData の regression test 1 件追加 (既存 `yamlModeSavePreservesExtraData` の対称形)

#338 は close せず **leave open / Deferred / Phase 3**。再評価 trigger は本 PR の rule に明文化 (4th direct consumer 追加 or YAML-as-source-of-truth が documented refactor goal になった時)。

See #338 (deferred). Refs #336 (drift bug fixed via funnel).

## Test plan

- [x] `scripts/xcodebuild.sh test --tail 30 -skip-testing:PasturaUITests` — 1791 tests / 161 suites pass
- [x] `swiftlint lint --quiet --strict` clean (ScenarioEditorViewModel.swift は 400 line ぴったり)
- [x] `rg 'buildScenario\(\)' Pastura/Pastura/App/ScenarioEditorViewModel.swift` → exact 3 hits (rule の grep self-check)
- [x] Pre-impl critic 2 pass (Critical 解消、Warning すべて取り込み)
- [x] Code-reviewer (Opus) PASS — 1 suggestion (rule grep `≤3` → `exactly 3`) 取り込み済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)