### PR TITLE
✨ feat(kmp): W3 PR-C — H8-5 async bridge + H8-4 neg + Q9 (#220)

### DIFF
--- a/Pastura/Pastura/KMPSpike/PasturaSharedSpike.swift
+++ b/Pastura/Pastura/KMPSpike/PasturaSharedSpike.swift
@@ -165,6 +165,10 @@ enum PasturaSharedSpike {
   /// in `commonMain` that return the parent type. Tracked as a W4
   /// scope item in the PR-C checkpoint.
   static func sampleTurnOutput() -> TurnOutput {
+    // TODO(#220 W4 PR-A): replace this pivot with the planned
+    // `sampleSimulationEvent()` once the Kotlin facade flattens
+    // sealed-class subtype construction (see doc-comment above for
+    // the swift_name dot-syntax limitation).
     TurnOutput(fields: ["statement": "Hello from spike", "action": "cooperate"])
   }
 }

--- a/Pastura/Pastura/KMPSpike/PasturaSharedSpike.swift
+++ b/Pastura/Pastura/KMPSpike/PasturaSharedSpike.swift
@@ -72,4 +72,99 @@ enum PasturaSharedSpike {
       eventVariable: nil
     )
   }
+
+  // MARK: - Q9 expansion (W3 PR-C)
+  //
+  // Adds 3 K/N types to the production grep surface for Q9 measurement
+  // (`grep -r 'import PasturaShared' Pastura/Pastura/`): Persona,
+  // Scenario, SimulationEvent. Picked to maximize shape variety —
+  // small required-only data class / top-level data class with nested
+  // List / sealed sum-type with nested-class case — so post-W6 GO
+  // production integration has reference patterns spanning the K/N
+  // export quirks the spike has surfaced.
+  //
+  // **Production usage routes through `ScenarioLoader`, NOT these
+  // factories.** Spike-scope only.
+
+  /// Persona is a Kotlin `data class Persona(val name: String, val
+  /// description: String)` — both fields **required Strings**, NO
+  /// Optional. Q9 measurement: minimal 2-required-arg data class
+  /// export. The Optional bridge surface is already covered by
+  /// `samplePairing`'s `action1` / `action2` (`String?` with
+  /// `null` default) — duplicating it here would be redundant.
+  ///
+  /// Persona name "Alice" is the cross-fixture convention for
+  /// spike scaffolding (see also `sampleScenario`'s persona array).
+  static func samplePersona() -> Persona {
+    Persona(name: "Alice", description: "Test persona")
+  }
+
+  /// Scenario's 11-arg init exercises the **deep nested data class**
+  /// surface — `personas: List<Persona>`, `phases: List<Phase>`,
+  /// `extraData: Map<String, AnyCodableValue>`. Kotlin defaults on
+  /// `simulationLanguage` and `extraData` DO NOT bridge to Obj-C
+  /// (K/N export collapses parameter defaults at the C boundary),
+  /// so all 11 args must be passed explicitly from Swift.
+  ///
+  /// **Q9 insight — primitive bridging**: the header declares
+  /// `agentCount:(int32_t)agentCount rounds:(int32_t)rounds`, but
+  /// K/N's Swift interop layer wraps `int32_t` as Swift `Int` (NOT
+  /// `Int32`). The Swift call site passes `Int` literals — wrapping
+  /// in `Int32(1)` would fail compilation with "cannot convert
+  /// 'Int32' to 'Int'".
+  ///
+  /// Minimum viable factory: 1 persona + 1 phase + `agentCount: 1`
+  /// satisfies the documented invariant `agentCount == personas.size`.
+  /// Adding more personas / phases would cascade additional
+  /// fixture-construction LOC without changing the K/N bridge
+  /// surface exercised.
+  static func sampleScenario() -> Scenario {
+    Scenario(
+      id: "spike-scenario",
+      name: "Spike Scenario",
+      description: "Q9 production-scaffolding fixture",
+      language: "en",
+      simulationLanguage: nil,
+      agentCount: 1,
+      rounds: 1,
+      context: "Test context",
+      personas: [samplePersona()],
+      phases: [makeNoOpPhase(of: .speakAll)],
+      extraData: [:]
+    )
+  }
+
+  /// TurnOutput is a 1-arg `data class TurnOutput(val fields:
+  /// Map<String, String>)` — exercises the **K/N
+  /// `Map<String, String>` bridge** (Swift `[String: String]` literal
+  /// auto-bridges cleanly to `NSDictionary<NSString *, NSString *>`,
+  /// unlike `Map<String, primitive>` which requires `KotlinInt` /
+  /// `KotlinBool` boxing — see `SimulationState.scores` for an
+  /// example of that boxed-primitive case).
+  ///
+  /// **Originally planned as `SimulationEvent.PhaseStarted`**, pivoted
+  /// to TurnOutput after discovering a load-bearing K/N export
+  /// limitation:
+  ///
+  /// **Spike finding — `swift_name("Foo.Bar")` dot-syntax does NOT
+  /// reach Swift compiler's nested-type / nested-init lookup**.
+  /// The header declares `__attribute__((swift_name("SimulationEvent.PhaseStarted")))`
+  /// on `@interface PasturaSharedSimulationEventPhaseStarted`,
+  /// but EVERY tried callsite fails with `type 'SimulationEvent'
+  /// has no member 'PhaseStarted'`:
+  /// - `SimulationEvent.PhaseStarted(phaseType:, phasePath:)` — fails
+  /// - `SimulationEventPhaseStarted(...)` (flat name) — fails
+  ///   (`cannot find ... in scope`; the swift_name rename hides it)
+  /// - `SimulationEvent.SimulationCompleted.shared` (singleton via
+  ///   static property) — also fails (same dot-syntax barrier)
+  ///
+  /// This is a production K/N integration blocker for any code that
+  /// needs to construct OR pattern-match sealed-class subtypes from
+  /// Swift. W4 PR-A (Kotlin facade) MUST address this — likely by
+  /// flattening sealed-class subtypes through `object` factories
+  /// in `commonMain` that return the parent type. Tracked as a W4
+  /// scope item in the PR-C checkpoint.
+  static func sampleTurnOutput() -> TurnOutput {
+    TurnOutput(fields: ["statement": "Hello from spike", "action": "cooperate"])
+  }
 }

--- a/Pastura/PasturaTests/KMPSpike/H8AsyncBridgeTests.swift
+++ b/Pastura/PasturaTests/KMPSpike/H8AsyncBridgeTests.swift
@@ -21,11 +21,82 @@ import Observation
 import PasturaShared
 import Testing
 
+// MARK: - Sendable conformance bridge for K/N exports
+//
+// `Pairing` is a Kotlin `data class` with all-`val` String/String?
+// fields — fully immutable and thread-safe by Kotlin idiom (see
+// `shared/models/src/commonMain/kotlin/com/pastura/models/Pairing.kt`).
+// K/N's Obj-C export does not surface the Swift `Sendable` protocol, so
+// the actor-cross hop in `KNStateActor.read()` / `update(_:)` fails
+// Swift 6 strict concurrency checks without an explicit conformance.
+// The retroactive `@unchecked Sendable` here is sound (immutable
+// value-typed state) and scoped to the test target.
+//
+// **Spike insight**: production K/N integration (post-W6 GO) will need
+// the same bridge for any K/N value type crossed across actor
+// boundaries. Captured in W3 PR-C checkpoint as a W4 measurement
+// candidate — Q9 type expansion may add similar conformances for
+// Persona / Scenario / SimulationEvent if they need actor crossing.
+extension PasturaShared.Pairing: @retroactive @unchecked Sendable {}
+
 @MainActor
 @Suite(.timeLimit(.minutes(1)))
 struct H8AsyncBridgeTests {
 
-  // H8-5 runtime test added in the next commit.
+  /// H8-5: state owned by a `KNStateActor` propagates to SwiftUI
+  /// observation via the snapshot-cache pattern.
+  ///
+  /// Sequence:
+  /// 1. Construct VM with an initial `Pairing` (cache + actor seeded
+  ///    identically by `init(initial:)`).
+  /// 2. Register `withObservationTracking` on `viewModel.pairing.agent1`
+  ///    (computed getter calls `access(keyPath: \.pairing)`, registering
+  ///    the observation channel).
+  /// 3. Mutate the canonical actor state via the test-only helper —
+  ///    cache is intentionally NOT updated by this call (snapshot-cache
+  ///    contract).
+  /// 4. Call `refresh()`. The direct `await` form (no inner `Task {}`)
+  ///    keeps the actor hop and the MainActor `withMutation` in the
+  ///    same continuation; `onChange` fires synchronously inside
+  ///    `withMutation` before `refresh()` returns.
+  /// 5. Assert observation fired AND that the cache now reflects the
+  ///    new value. The cache assertion guards against a future
+  ///    regression where `refresh()` fires invalidation but forgets
+  ///    to copy the snapshot — a contract that the macro auto-
+  ///    instrumentation (if `cache` were not `@ObservationIgnored`)
+  ///    would mask.
+  @Test
+  func asyncRefreshTriggersObservation() async {
+    let signal = ObservationFireSignal()
+    let viewModel = H8AsyncBridgeViewModel(
+      initial: Pairing(
+        agent1: "Alice",
+        agent2: "Bob",
+        action1: nil,
+        action2: nil
+      )
+    )
+
+    withObservationTracking {
+      _ = viewModel.pairing.agent1
+    } onChange: {
+      signal.fired = true
+    }
+
+    let updated = Pairing(
+      agent1: "Charlie",
+      agent2: "Dave",
+      action1: nil,
+      action2: nil
+    )
+    await viewModel._testOnlyUpdateActor(updated)
+    await viewModel.refresh()
+
+    // assert A: snapshot-cache propagated the actor's new value
+    #expect(viewModel.pairing.agent1 == updated.agent1)
+    // assert B: `withMutation` fired observation through the bridge
+    #expect(signal.fired == true)
+  }
 }
 
 /// Non-`@Observable` actor backing K/N value-typed state for H8-5.

--- a/Pastura/PasturaTests/KMPSpike/H8AsyncBridgeTests.swift
+++ b/Pastura/PasturaTests/KMPSpike/H8AsyncBridgeTests.swift
@@ -1,0 +1,165 @@
+// H8 hypothesis async surface (Issue #220 W3 PR-C).
+//
+// Verifies that an `@Observable` Swift class bridging Kotlin/Native (K/N)
+// value-typed state to SwiftUI invalidation works ACROSS an actor
+// boundary — the snapshot-cache pattern documented in PR #216
+// (`SimulationViewModel.isPaused` ↔ `SimulationRunner.isPaused`)
+// translated to a Sendable backing actor.
+//
+// H8-5 surface: async actor read-back. The 4 mutation surfaces already
+// proven in W3 PR-B (`H8BridgeTests.swift`) — H8-1 scalar, H8-2
+// collection, H8-3 enum, H8-4 `access`/`withMutation` bridge — covered
+// only synchronous mutation. H8-5 closes the orthogonal axis: state
+// owned by an `actor` that the `@Observable` VM reads asynchronously,
+// where the VM's sync getter contract requires a local snapshot cache.
+//
+// CRITICAL escalation rule: if any test fails, file
+// `r8-observable-bridge-failure` comment on Issue #220 and pause spike —
+// Tier 1 hard blocker. Do NOT silently rescope.
+
+import Observation
+import PasturaShared
+import Testing
+
+@MainActor
+@Suite(.timeLimit(.minutes(1)))
+struct H8AsyncBridgeTests {
+
+  // H8-5 runtime test added in the next commit.
+}
+
+/// Non-`@Observable` actor backing K/N value-typed state for H8-5.
+/// The `@Observable` VM bridges to this actor via a snapshot cache —
+/// see `H8AsyncBridgeViewModel` for the pattern.
+///
+// MARK: - Why `actor`, not `final class`?
+//
+// Intentionally an `actor`, not a `final class @unchecked Sendable`. The
+// `final class` shape would trip `swift-isolation.md` Pattern 4 if any
+// future maintainer adds a sync accessor: under
+// `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, a `Sendable`-conforming
+// class with sync methods silently binds to MainActor, breaking the
+// `nonisolated` callers that need to await it. Actors carry their own
+// explicit isolation; sync vs async methods don't shift the isolation
+// the way they do on classes.
+private actor KNStateActor {
+  private var state: Pairing
+
+  init(initial: Pairing) {
+    self.state = initial
+  }
+
+  func read() -> Pairing {
+    state
+  }
+
+  func update(_ newValue: Pairing) {
+    state = newValue
+  }
+}
+
+/// `@Observable` test fixture exposing K/N value-typed state owned by
+/// an `actor`. Snapshot-cache pattern: VM owns a local `cache` (sync
+/// getter returns it), `refresh()` reads from the actor and triggers
+/// SwiftUI invalidation via `withMutation`.
+///
+/// Three load-bearing pinnings (each identified by pre-impl critic):
+///
+/// 1. **`@ObservationIgnored private var cache: Pairing`** — the
+///    `@Observable` macro instruments ALL stored `var` properties at
+///    the type level, regardless of access level. Without
+///    `@ObservationIgnored`, the macro would generate a redundant
+///    auto-observation channel on `cache` itself, making H8-5 silently
+///    collapse to a duplicate of H8-1 (which already proved scalar
+///    macro instrumentation works) — testing nothing about actor
+///    read-back. The annotation makes `cache` purely backing storage;
+///    the only observation channel is the computed `var pairing`
+///    going through `access` / `withMutation`.
+///
+/// 2. **Computed getter, NO setter exposed** — callers must go
+///    through `refresh()` to update state. A macro-stored
+///    `var pairing: Pairing` would auto-instrument the setter and
+///    let consumers write directly, bypassing the actor (silent cache
+///    desync). The snapshot-cache contract is "actor is canonical,
+///    cache is derived" — only `refresh()` propagates actor changes
+///    to cache.
+///
+/// 3. **Direct `await` in `refresh()`, NO inner `Task { }`** —
+///    spawning a detached `Task` lets `refresh()` return before the
+///    `withMutation` block runs, breaking `@Test` determinism. The
+///    direct-await form keeps the actor hop and the MainActor
+///    mutation in the same continuation; `withMutation` fires
+///    synchronously on the resumed MainActor before `refresh()`
+///    returns.
+@Observable
+@MainActor
+private final class H8AsyncBridgeViewModel {
+
+  /// Local snapshot of the actor's state. `@ObservationIgnored` opts
+  /// it out of macro instrumentation — observation goes through the
+  /// computed `var pairing` only. See type-level doc-comment §1.
+  @ObservationIgnored private var cache: Pairing
+
+  /// Backing actor — the canonical store. Production callers MUST NOT
+  /// reach into the actor directly; the snapshot-cache contract is
+  /// that `cache` mirrors the actor's state after `refresh()`, and
+  /// any other write path desyncs them. Test-only mutation goes
+  /// through `_testOnlyUpdateActor(_:)`.
+  ///
+  /// `@ObservationIgnored` is technically redundant on `let` (the
+  /// macro instruments `var` only) but signals intent and
+  /// future-proofs against a refactor swapping `let` → `var`.
+  @ObservationIgnored private let stateActor: KNStateActor
+
+  /// Computed property exposing the cached snapshot to SwiftUI
+  /// observation. `access(keyPath: \.pairing)` registers the
+  /// observation channel on read; the matching `withMutation` in
+  /// `refresh()` fires invalidation on write.
+  var pairing: Pairing {
+    access(keyPath: \.pairing)
+    return cache
+  }
+
+  /// Cache + actor MUST be seeded identically at init to preserve
+  /// snapshot-cache consistency. Subsequent `refresh()` keeps them
+  /// in sync; until the first `refresh()`, `cache` and the actor's
+  /// state are equal by construction.
+  init(initial: Pairing) {
+    self.cache = initial
+    self.stateActor = KNStateActor(initial: initial)
+  }
+
+  /// Read the actor's canonical state and propagate to the local
+  /// snapshot via `withMutation`. Direct `await` (NOT inner
+  /// `Task { }`) is load-bearing for test determinism — see
+  /// type-level doc-comment §3.
+  func refresh() async {
+    let snapshot = await stateActor.read()
+    withMutation(keyPath: \.pairing) {
+      self.cache = snapshot
+    }
+  }
+
+  /// Test-only helper: forwards to `stateActor.update(_:)` without
+  /// triggering `refresh()`. Production code MUST NOT use this
+  /// path — the snapshot-cache contract requires `refresh()` after
+  /// every actor mutation. The leading underscore + `_testOnly`
+  /// prefix signals "do not call from production".
+  func _testOnlyUpdateActor(_ newValue: Pairing) async {
+    await stateActor.update(newValue)
+  }
+}
+
+/// Class-box workaround for `withObservationTracking`'s `onChange`
+/// closure (`@Sendable @escaping`). Mirrors the same-named helper in
+/// `H8BridgeTests.swift` — Swift's file-scoped `private` doesn't cross
+/// files, so this declaration must live here too. Extracting to a
+/// shared `KMPSpike/TestSupport.swift` is deferred to spike cleanup
+/// (W6 GO/NO-GO path).
+///
+/// `@unchecked Sendable` is sound: only the test author writes into
+/// this box, and Observation's dispatch fires `onChange` synchronously
+/// on the mutating call under `@MainActor` isolation.
+private final class ObservationFireSignal: @unchecked Sendable {
+  var fired = false
+}

--- a/Pastura/PasturaTests/KMPSpike/H8AsyncBridgeTests.swift
+++ b/Pastura/PasturaTests/KMPSpike/H8AsyncBridgeTests.swift
@@ -89,7 +89,7 @@ struct H8AsyncBridgeTests {
       action1: nil,
       action2: nil
     )
-    await viewModel._testOnlyUpdateActor(updated)
+    await viewModel.testOnlyUpdateActor(updated)
     await viewModel.refresh()
 
     // assert A: snapshot-cache propagated the actor's new value
@@ -99,11 +99,7 @@ struct H8AsyncBridgeTests {
   }
 }
 
-/// Non-`@Observable` actor backing K/N value-typed state for H8-5.
-/// The `@Observable` VM bridges to this actor via a snapshot cache —
-/// see `H8AsyncBridgeViewModel` for the pattern.
-///
-// MARK: - Why `actor`, not `final class`?
+// MARK: - KNStateActor
 //
 // Intentionally an `actor`, not a `final class @unchecked Sendable`. The
 // `final class` shape would trip `swift-isolation.md` Pattern 4 if any
@@ -113,6 +109,10 @@ struct H8AsyncBridgeTests {
 // `nonisolated` callers that need to await it. Actors carry their own
 // explicit isolation; sync vs async methods don't shift the isolation
 // the way they do on classes.
+
+/// Non-`@Observable` actor backing K/N value-typed state for H8-5.
+/// The `@Observable` VM bridges to this actor via a snapshot cache —
+/// see `H8AsyncBridgeViewModel` for the pattern.
 private actor KNStateActor {
   private var state: Pairing
 
@@ -212,11 +212,12 @@ private final class H8AsyncBridgeViewModel {
   }
 
   /// Test-only helper: forwards to `stateActor.update(_:)` without
-  /// triggering `refresh()`. Production code MUST NOT use this
-  /// path — the snapshot-cache contract requires `refresh()` after
-  /// every actor mutation. The leading underscore + `_testOnly`
-  /// prefix signals "do not call from production".
-  func _testOnlyUpdateActor(_ newValue: Pairing) async {
+  /// triggering `refresh()`. Production code MUST NOT use this path —
+  /// the snapshot-cache contract requires `refresh()` after every
+  /// actor mutation. The `testOnly` prefix signals "do not call from
+  /// production" via naming convention (leading underscore would be
+  /// stronger but SwiftLint's `identifier_name` rule rejects it).
+  func testOnlyUpdateActor(_ newValue: Pairing) async {
     await stateActor.update(newValue)
   }
 }

--- a/Pastura/PasturaTests/KMPSpike/H8AsyncBridgeTests.swift
+++ b/Pastura/PasturaTests/KMPSpike/H8AsyncBridgeTests.swift
@@ -32,6 +32,12 @@ import Testing
 // The retroactive `@unchecked Sendable` here is sound (immutable
 // value-typed state) and scoped to the test target.
 //
+// **SOLE DECLARATION** of `Pairing: Sendable` in the test target —
+// adding a duplicate in another file will fail to link with
+// "redundant conformance" error. W4 PR-A (Kotlin facade work) is the
+// natural place to upstream this conformance to a `commonMain`-side
+// declaration, at which point this extension should be removed.
+//
 // **Spike insight**: production K/N integration (post-W6 GO) will need
 // the same bridge for any K/N value type crossed across actor
 // boundaries. Captured in W3 PR-C checkpoint as a W4 measurement

--- a/Pastura/PasturaTests/KMPSpike/H8BridgeTests.swift
+++ b/Pastura/PasturaTests/KMPSpike/H8BridgeTests.swift
@@ -141,6 +141,45 @@ struct H8BridgeTests {
 
     #expect(signal.fired == true)
   }
+
+  /// H8-4 negative control: bypass `withMutation` and assert observation
+  /// does NOT fire. Closes the gap left by H8-4 (which proved the bridge
+  /// is *sufficient*) by also proving it is *necessary* — writing
+  /// `bridgeHolder.pairing` directly, without going through
+  /// `withMutation`, must produce no SwiftUI invalidation. Without this,
+  /// the H8-4 contract could be satisfied vacuously (e.g., if the macro
+  /// were instrumenting the bridge holder by some other route).
+  ///
+  /// Two assertions together close the gap:
+  /// - **assert A**: the bypass actually mutated holder state. Guards
+  ///   against a no-op `unsafeBypassMutation` false-positive — without
+  ///   this, a method body that did nothing would also "pass" assert B.
+  /// - **assert B**: the bypass did NOT fire observation. Locks the
+  ///   `access`/`withMutation` pair as the only legitimate channel.
+  @Test
+  func bridgeBypassDoesNotTriggerObservation() {
+    let signal = ObservationFireSignal()
+    let viewModel = H8BridgeTestViewModel()
+
+    withObservationTracking {
+      _ = viewModel.bridgedPairing.agent1
+    } onChange: {
+      signal.fired = true
+    }
+
+    let bypassed = Pairing(
+      agent1: "Mallory",
+      agent2: "Niaj",
+      action1: nil,
+      action2: nil
+    )
+    viewModel.unsafeBypassMutation(bypassed)
+
+    // assert A: bypass DID mutate holder state (rule out no-op false-positive)
+    #expect(viewModel.bridgedPairing.agent1 == bypassed.agent1)
+    // assert B: bypass DID NOT fire observation (bridge necessity proof)
+    #expect(signal.fired == false)
+  }
 }
 
 /// `@Observable` test fixture wrapping K/N value types. Lives in the test
@@ -208,6 +247,22 @@ final class H8BridgeTestViewModel {
     self.phases = phases
     self.phaseType = phaseType
     self.bridgeHolder = KNStateHolder(pairing: bridgedPairing)
+  }
+
+  /// H8-4 negative control helper: writes `bridgeHolder.pairing` directly,
+  /// bypassing the `access(keyPath:)` / `withMutation(keyPath:)` channel
+  /// that `bridgedPairing`'s setter invokes. Test-only — production code
+  /// MUST go through `bridgedPairing`'s setter to preserve SwiftUI
+  /// invalidation.
+  ///
+  /// Implementation note: this method writes ONLY `bridgeHolder.pairing`
+  /// and touches NOTHING else on `self`. Mutating any other macro-tracked
+  /// property (e.g., `pairing`, `phases`, `phaseType`) would fire
+  /// observation through that other channel and false-positive
+  /// `bridgeBypassDoesNotTriggerObservation`. The narrow body is
+  /// load-bearing for the negative control's validity.
+  func unsafeBypassMutation(_ newValue: Pairing) {
+    bridgeHolder.pairing = newValue
   }
 }
 


### PR DESCRIPTION
## Summary

W3 PR-C of Issue #220 (KMP spike): closes the H8 hypothesis surface (5/5 surfaces verified) and expands Q9 production scaffolding. PR target is `feature/kmp-spike-models` (integration branch).

- **H8-5** async actor read-back (snapshot-cache pattern) verified GREEN — bridges K/N value-typed state owned by an `actor` to `@Observable` SwiftUI invalidation via `withMutation`.
- **H8-4 negative control** proves bridge **necessity** (bypassing `withMutation` produces no observation fire). Closes [PR #474 code-reviewer Suggestion 2](https://github.com/tyabu12/pastura/pull/474).
- **Q9 expansion** adds Persona / Scenario / TurnOutput factories to `PasturaSharedSpike` for production-scaffolding grep measurement.
- Two **spike findings** discovered at implementation time, beyond the 3 pre-impl critic rounds — both documented inline and forwarded to W4 PR-A.

H8 hypothesis is now 5/5 GREEN — **Tier 1 hard blocker positive across the full hypothesis**. R8 / spike-pause escalation rule remains armed but does not fire.

Plan v4: [Issue #220 comment 4528314039](https://github.com/tyabu12/pastura/issues/220#issuecomment-4528314039) (incorporates findings from 3 pre-impl critic rounds — 1 → 3 → 2 verdicts converged on `Option γ-prime`, H4 deferred to W4 PR-A).

## What's in this PR

| Commit | Item | Result |
|---|---|---|
| `5f8522f` | 🔴 H8-4 negative control test | ✅ `signal.fired == false` after bypass; state mutation verified |
| `15ed39f` | 🔴 H8-5 scaffold (actor + VM, compile-only) | ✅ build green |
| `852a695` | 🔴 H8-5 runtime test + retroactive Sendable conformance | ✅ `asyncRefreshTriggersObservation` 0.002s |
| `84325b5` | 🔴 Q9 expansion (Persona/Scenario/TurnOutput) | ✅ build green |
| `6db14ee` | ♻️ SwiftLint fixes (identifier_name + orphaned_doc_comment) | ✅ swiftlint --strict clean |
| `a4160b8` | 📚 Act on code-reviewer Suggestions 1 + 3 | ✅ doc-only, no test surface change |

Full unit suite: **1802 tests / 164 suites / 17.7s** (PR-B baseline 1800 / 163 / 19.6s — +2 tests + 1 suite as planned).

## Spike findings

Two issues surfaced at implementation time that the 3 pre-impl critic rounds did NOT catch. Both required reading the actual K/N export headers + Kotlin source to identify.

### 1. K/N `Pairing` is non-`Sendable` (actor-cross hop blocker)

K/N's Obj-C export does NOT surface the Swift `Sendable` protocol — `@interface PasturaSharedPairing : PasturaSharedBase` carries no Sendable conformance. Any code that hops K/N value types across an actor boundary fails Swift 6 strict-concurrency checks:

```
Sending 'snapshot' risks causing data races
Non-Sendable 'Pairing'-typed result can not be returned
  from actor-isolated instance method 'read()'
  to main actor-isolated context
```

**Resolution**: `extension PasturaShared.Pairing: @retroactive @unchecked Sendable {}` declared once at the test target file scope. Sound because `Pairing` is a Kotlin `data class` with all-`val` String/String? fields (fully immutable). Captured inline as the **SOLE declaration** in the test target so a future W4 PR-A spike doesn't duplicate-conform.

**W4 PR-A action item**: upstream this conformance into a `commonMain`-side declaration (eliminating the retroactive form). Any K/N value type that crosses actor boundaries in production will need the same treatment.

### 2. `swift_name("Foo.Bar")` dot-syntax does NOT reach Swift compiler's nested-type lookup

Originally planned Q9 third type was `SimulationEvent.PhaseStarted` (per 3rd pre-impl critic recommendation, to exercise the sealed-class subtype bridge + `[KotlinInt]` boxing). At implementation time, **every attempted call site failed** with `type 'SimulationEvent' has no member 'PhaseStarted'`:

| Attempted call site | Result |
|---|---|
| `SimulationEvent.PhaseStarted(phaseType:, phasePath:)` | ❌ nested-init lookup unreachable |
| `SimulationEventPhaseStarted(...)` (flat name) | ❌ `cannot find ... in scope` (swift_name rename hides pre-rename name) |
| `SimulationEvent.SimulationCompleted.shared` (singleton via static) | ❌ same dot-syntax barrier on type lookup |

The header declares `__attribute__((swift_name("SimulationEvent.PhaseStarted")))` but Swift's nested-type / nested-init resolution doesn't follow the dot-syntax across the K/N export boundary. **This is a production K/N integration blocker** for any code that needs to construct OR pattern-match Kotlin sealed-class subtypes from Swift.

**Resolution for PR-C**: pivoted Q9 third type to `TurnOutput` (1-arg `Map<String, String>` data class — clean Swift bridge, captures `[String: String]` ↔ `NSDictionary<NSString *, NSString *>` interop surface). Pivot decision documented inline at `sampleTurnOutput()`.

**W4 PR-A action item**: address via Kotlin `object` factories in `commonMain` that flatten sealed-class subtypes:

```kotlin
object SimulationEventFactory {
  fun phaseStarted(phaseType: PhaseType, phasePath: List<Int>): SimulationEvent =
    SimulationEvent.PhaseStarted(phaseType, phasePath)
}
```

Without this, production iOS-side consumers cannot construct sealed-class subtypes at all — the `samplePairing` precedent (which works) relies on K/N enums exporting entries as **class-properties**, a different surface from sealed-class subtype access.

The original `[KotlinInt]` boxing insight from the 3rd critic still applies for any future `List<primitive>` bridge call site; captured inline at the `sampleTurnOutput()` doc-comment as forwarded knowledge for W4 PR-A.

## Test plan

- [x] `scripts/xcodebuild.sh test -only-testing PasturaTests/H8BridgeTests` — 5 tests pass (4 W3 PR-B + 1 H8-4 neg)
- [x] `scripts/xcodebuild.sh test -only-testing PasturaTests/H8AsyncBridgeTests` — 1 test pass (H8-5 runtime)
- [x] `scripts/xcodebuild.sh test -skip-testing:PasturaUITests` — 1802 / 164 / 17.7s pass
- [x] `swiftlint lint --quiet --strict` — clean (only pre-existing `unused_import` config nag warning, no violations)
- [x] code-reviewer (Opus, Step 4) — PASS, 0 Critical / 0 Warning / 3 Suggestion (Suggestions 1 + 3 reflected in commit `a4160b8`; Suggestion 2 deferred per reviewer note)
- [x] T12 rebase check: 10 ahead / 5 behind `origin/main`; PR target is `feature/kmp-spike-models` (not main), and the 5 behind commits are docs/refactor outside KMP scope. Rebase not required for PR-C.
- [ ] Manual reviewer: confirm doc-comments track actual code shape (the 3-round critic process identified each "load-bearing" pin — aspirational-but-untrue comments are worse than missing ones).

## W4 PR sketch

Surfacing here per [3rd critic Axis 14](https://github.com/tyabu12/pastura/issues/220#issuecomment-4528314039) so reviewers can give directional feedback before W4 work begins. Subject to refinement at W4 plan time.

- **W4 PR-A**: Kotlin facade work — `shared/models/src/commonMain/kotlin/com/pastura/models/ScenarioCodec.kt` (`object ScenarioCodec { fun encodeToJsonElement; fun encodeToString }`) + `object SimulationEventFactory` (per finding #2 above) + upstream of `Pairing: Sendable` (per finding #1) + H4 3-path Swift-side perf measurement (canonicalize tree-only / K/N encodeToString / Yams roundtrip, each separate `@Test` with non-failing output channel — `print` or `#expect(true, Comment(...))`, NOT `Issue.record` per pre-impl critic Critical Axis 6). ~300-400 LOC, `shared/` touched → CI kmp-build-test cold path ~15-17min.
- **W4 PR-B**: H5 binary footprint live measurement — `.github/workflows/ci.yml` release-build job に `du -sh Pastura.app` step 追加 + ASC iphoneos release size posted to GitHub Actions summary. ~100 LOC. Required H6 ≤10 MB GO/NO-GO 判定 input.
- **W4 PR-C**: snakeyaml validation surface — Kotlin SnakeYAML 経由 YAML parse 結果と Swift Yams equivalence harness. May extend to W5 if scope grows. ~200 LOC.
- **W4 PR-D (optional)**: Q9 拡張追加 5-7 型 (if W4 measurement で 3 型では formal close 不可と判明したとき). ~150 LOC.

Part of #220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)