### PR TITLE
✨ feat(kmp): W4 PR-A — Kotlin facade + H4 measurement (#220)

### DIFF
--- a/Pastura/Pastura/KMPSpike/PasturaSharedSpike.swift
+++ b/Pastura/Pastura/KMPSpike/PasturaSharedSpike.swift
@@ -23,6 +23,21 @@ import PasturaShared
 /// 3. **Nested-collection optionality** — `Phase` with
 ///    `Map<String, String>?`, `List<String>?`, `List<Phase>?` fields.
 ///
+/// **All types are spelled with the explicit `PasturaShared.` module
+/// qualifier.** Pastura's own `Models/` layer defines Swift native
+/// `Pairing`, `PairingStrategy`, `Phase`, `PhaseType`, `Persona`,
+/// `Scenario`, `TurnOutput`, and `SimulationEvent` — without
+/// qualification, the unqualified names resolve to the same-module
+/// Swift types, NOT the K/N exports. W3 PR-A/B/C originally left
+/// these unqualified; W4 PR-A Item 1 verification discovered they
+/// were silently exercising Pastura's native Swift types, so the
+/// spike's "validates K/N integration" evidence was hollow. Each
+/// callsite is now explicitly qualified to ensure K/N code paths
+/// actually run; this also makes the swift_name dot-syntax barrier
+/// (which IS real on flat mangled names — `swift_name` hides them)
+/// invisible to the spike, leaving sealed-class subtype access as
+/// the only K/N-specific concern.
+///
 /// H8 hypothesis verification (`@Observable` Swift class wrapping K/N
 /// value types triggers SwiftUI invalidation) lives in the test target
 /// as `PasturaTests/KMPSpike/H8BridgeTests.swift` (W3 PR-B). The earlier
@@ -32,8 +47,8 @@ enum PasturaSharedSpike {
   /// Construct a `Pairing` from Swift, verifying the K/N init bridge
   /// preserves Kotlin's argument order (`agent1`, `agent2`, then the
   /// two `String?` action fields with null-default semantics).
-  static func samplePairing() -> Pairing {
-    Pairing(
+  static func samplePairing() -> PasturaShared.Pairing {
+    PasturaShared.Pairing(
       agent1: "Alice",
       agent2: "Bob",
       action1: nil,
@@ -45,15 +60,16 @@ enum PasturaSharedSpike {
   /// camelCase mapping. K/N exposes enum entries as class-readonly
   /// properties on the enum class itself (visible via the framework
   /// header as `@property (class, readonly) PairingStrategy *roundRobin`).
-  static let pairingStrategy: PairingStrategy = .roundRobin
+  static let pairingStrategy: PasturaShared.PairingStrategy =
+    PasturaShared.PairingStrategy.roundRobin
 
   /// Construct a no-op `Phase` to exercise the nested-collection
   /// optionality (Q9 shim-LOC measurement). Phase's init exposes
   /// every field as an explicit parameter — including all optionals
   /// — so the spike's call site doubles as a smoke for that
   /// surface area.
-  static func makeNoOpPhase(of type: PhaseType) -> Phase {
-    Phase(
+  static func makeNoOpPhase(of type: PasturaShared.PhaseType) -> PasturaShared.Phase {
+    PasturaShared.Phase(
       type: type,
       prompt: nil,
       outputSchema: nil,
@@ -73,13 +89,13 @@ enum PasturaSharedSpike {
     )
   }
 
-  // MARK: - Q9 expansion (W3 PR-C)
+  // MARK: - Q9 expansion (W3 PR-C, extended W4 PR-A)
   //
-  // Adds 3 K/N types to the production grep surface for Q9 measurement
+  // Adds K/N types to the production grep surface for Q9 measurement
   // (`grep -r 'import PasturaShared' Pastura/Pastura/`): Persona,
-  // Scenario, SimulationEvent. Picked to maximize shape variety —
-  // small required-only data class / top-level data class with nested
-  // List / sealed sum-type with nested-class case — so post-W6 GO
+  // Scenario, TurnOutput, SimulationEvent. Picked to maximize shape
+  // variety — small required-only data class / top-level data class with
+  // nested List / sealed sum-type with nested-class case — so post-W6 GO
   // production integration has reference patterns spanning the K/N
   // export quirks the spike has surfaced.
   //
@@ -95,8 +111,8 @@ enum PasturaSharedSpike {
   ///
   /// Persona name "Alice" is the cross-fixture convention for
   /// spike scaffolding (see also `sampleScenario`'s persona array).
-  static func samplePersona() -> Persona {
-    Persona(name: "Alice", description: "Test persona")
+  static func samplePersona() -> PasturaShared.Persona {
+    PasturaShared.Persona(name: "Alice", description: "Test persona")
   }
 
   /// Scenario's 11-arg init exercises the **deep nested data class**
@@ -118,8 +134,8 @@ enum PasturaSharedSpike {
   /// Adding more personas / phases would cascade additional
   /// fixture-construction LOC without changing the K/N bridge
   /// surface exercised.
-  static func sampleScenario() -> Scenario {
-    Scenario(
+  static func sampleScenario() -> PasturaShared.Scenario {
+    PasturaShared.Scenario(
       id: "spike-scenario",
       name: "Spike Scenario",
       description: "Q9 production-scaffolding fixture",
@@ -129,7 +145,7 @@ enum PasturaSharedSpike {
       rounds: 1,
       context: "Test context",
       personas: [samplePersona()],
-      phases: [makeNoOpPhase(of: .speakAll)],
+      phases: [makeNoOpPhase(of: PasturaShared.PhaseType.speakAll)],
       extraData: [:]
     )
   }
@@ -141,34 +157,54 @@ enum PasturaSharedSpike {
   /// unlike `Map<String, primitive>` which requires `KotlinInt` /
   /// `KotlinBool` boxing — see `SimulationState.scores` for an
   /// example of that boxed-primitive case).
+  static func sampleTurnOutput() -> PasturaShared.TurnOutput {
+    PasturaShared.TurnOutput(fields: ["statement": "Hello from spike", "action": "cooperate"])
+  }
+
+  /// SimulationEvent is the canonical sealed-class spike fixture —
+  /// constructed via direct dot-syntax against the swift_name-named
+  /// subtype, with explicit `PasturaShared.` module qualification.
   ///
-  /// **Originally planned as `SimulationEvent.PhaseStarted`**, pivoted
-  /// to TurnOutput after discovering a load-bearing K/N export
-  /// limitation:
+  /// **The fix is qualification, NOT a Kotlin facade.** W4 PR-A Item 1
+  /// re-diagnosed PR-C's documented "swift_name dot-syntax barrier"
+  /// finding — the actual root cause is **Swift module shadowing**:
   ///
-  /// **Spike finding — `swift_name("Foo.Bar")` dot-syntax does NOT
-  /// reach Swift compiler's nested-type / nested-init lookup**.
-  /// The header declares `__attribute__((swift_name("SimulationEvent.PhaseStarted")))`
-  /// on `@interface PasturaSharedSimulationEventPhaseStarted`,
-  /// but EVERY tried callsite fails with `type 'SimulationEvent'
-  /// has no member 'PhaseStarted'`:
-  /// - `SimulationEvent.PhaseStarted(phaseType:, phasePath:)` — fails
-  /// - `SimulationEventPhaseStarted(...)` (flat name) — fails
-  ///   (`cannot find ... in scope`; the swift_name rename hides it)
-  /// - `SimulationEvent.SimulationCompleted.shared` (singleton via
-  ///   static property) — also fails (same dot-syntax barrier)
+  /// `Pastura/Pastura/Models/SimulationEvent.swift` defines a Swift
+  /// `enum SimulationEvent` with associated-value cases. Within the
+  /// Pastura/ target the unqualified name resolves to that enum, not
+  /// to PasturaShared's K/N-exported `@interface SimulationEvent`. The
+  /// Swift enum has no `PhaseStarted` nested type — hence the error
+  /// `type 'SimulationEvent' has no member 'PhaseStarted'`. PR-C had
+  /// inferred this was a K/N export barrier and pivoted to TurnOutput
+  /// rather than discovering the qualification fix.
   ///
-  /// This is a production K/N integration blocker for any code that
-  /// needs to construct OR pattern-match sealed-class subtypes from
-  /// Swift. W4 PR-A (Kotlin facade) MUST address this — likely by
-  /// flattening sealed-class subtypes through `object` factories
-  /// in `commonMain` that return the parent type. Tracked as a W4
-  /// scope item in the PR-C checkpoint.
-  static func sampleTurnOutput() -> TurnOutput {
-    // TODO(#220 W4 PR-A): replace this pivot with the planned
-    // `sampleSimulationEvent()` once the Kotlin facade flattens
-    // sealed-class subtype construction (see doc-comment above for
-    // the swift_name dot-syntax limitation).
-    TurnOutput(fields: ["statement": "Hello from spike", "action": "cooperate"])
+  /// Verified-working access surface (locked into
+  /// `Pastura/PasturaTests/KMPSpike/KNDotSyntaxAccessTests.swift` as a
+  /// regression guard for the K/N export shape):
+  ///
+  /// - `PasturaShared.SimulationEvent.SimulationCompleted.shared` —
+  ///   sealed-class `object` singleton via swift_name dot-syntax.
+  /// - `PasturaShared.SimulationEvent.PhaseStarted(phaseType:, phasePath:)`
+  ///   — sealed-class data-class subtype constructor.
+  /// - `event as? PasturaShared.SimulationEvent.PhaseStarted` —
+  ///   subtype-cast pattern match for production consumers.
+  ///
+  /// The genuine K/N export limitation is the flat-mangled-name path
+  /// (`PasturaSharedSimulationEventPhaseStarted(...)`) which `swift_name`
+  /// correctly hides — intentional, not a regression. Production K/N
+  /// integration in the Pastura/ target therefore does NOT need
+  /// `commonMain` facade objects for sealed-class subtypes; consumers
+  /// disambiguate locally via `PasturaShared.` qualification.
+  static func sampleSimulationEvent() -> PasturaShared.SimulationEvent {
+    // Note the explicit `PasturaShared.` module qualifier on BOTH the return
+    // type and the constructor — Pastura's own `Models/SimulationEvent.swift`
+    // (a Swift `enum`) shadows the K/N-exported class of the same name when
+    // unqualified, and Swift's `Pastura.SimulationEvent` enum has no nested
+    // `PhaseStarted` type. The qualifier picks the K/N class explicitly so
+    // its swift_name dot-syntax nested types are visible.
+    PasturaShared.SimulationEvent.PhaseStarted(
+      phaseType: PasturaShared.PhaseType.speakAll,
+      phasePath: [0]
+    )
   }
 }

--- a/Pastura/PasturaTests/KMPSpike/H4PerformanceTests.swift
+++ b/Pastura/PasturaTests/KMPSpike/H4PerformanceTests.swift
@@ -1,0 +1,255 @@
+// H4 hypothesis — encode/canonicalize performance measurement —
+// Issue #220 W4 PR-A Item 3.
+//
+// ## Methodology
+//
+// **These three @Test methods are 3 DISTINCT METRICS, not 3 paths of the
+// same transform. DO NOT cross-compare their `mean` / `median` values.**
+//
+// Each path measures a different input shape AND a different transform
+// scope; comparing one to another would be category error. Read each
+// individually to answer its own question, then triangulate against
+// H6 ≤10MB / W6 GO/NO-GO criteria:
+//
+// 1. **`canonicalize-stage-only`** — pre-encode a K/N Scenario to JSON
+//    tree OUTSIDE the measure loop, measure `Canonicalizer.canonicalize`
+//    on the tree. Answers: "what's the cost of the cross-language
+//    wire-shape normalizer alone?"
+//
+// 2. **`kn-encode-only`** — measure `ScenarioCodec.encodeToString` end-
+//    to-end on a K/N Scenario. Answers: "what's the cost of crossing the
+//    K/N FFI to encode a Scenario into its JSON wire shape?"
+//
+// 3. **`swift-yams-roundtrip`** — measure `Yams.YAMLEncoder().encode` +
+//    `Yams.YAMLDecoder().decode` on a Swift native `Pastura.Scenario`.
+//    Answers: "what's the cost of Pastura's existing Swift-side Codable
+//    + Yams baseline for the same conceptual workload?" — useful as a
+//    sanity-check anchor for the K/N numbers above.
+//
+// ## Fixture rationale
+//
+// 5 personas + 10 phases (`largeScenarioFixtureKMP` /
+// `largeScenarioFixtureSwift`). Distinct from Q9's 1 persona + 1 phase
+// in `PasturaSharedSpike.sampleScenario()`. **Do NOT retroactively
+// recompute Q9 LOC ratios against this fixture** — different size class,
+// different concern (Q9 = shim-LOC surface measurement, H4 = perf cost on
+// production-shape scenario).
+//
+// ## Measurement discipline
+//
+// - warm-up 10 iterations before sample collection (drains JIT noise)
+// - sample 50 iterations (n=50 trades signal stability vs CI cost)
+// - `ContinuousClock` (Swift 5.7+) — monotonic, attosecond resolution
+// - aggregate-then-print: ONE `print` per @Test (NOT per-sample dump)
+// - output format: `[H4-DIRECT] path=<name> mean=Xms median=Yms stddev=Zms n=50`
+//   parse-able by future ADR-004 amendment writers via grep on `[H4-DIRECT]`
+//
+// **`print` is intentional, not `Issue.record` or `#expect`** — per W3
+// PR-C 2nd critic Critical Axis 6: these tests must NOT fail when slow.
+// They're measurement-only — H6 ≤10MB and ADR-004 amendment consume the
+// raw numbers, not pass/fail status. Tests assert only that the
+// measurement ran (samples.count == 50).
+
+import Foundation
+import Pastura
+import PasturaShared
+import Testing
+import Yams
+
+@Suite(.timeLimit(.minutes(1)))
+@MainActor
+struct H4PerformanceTests {
+
+  // MARK: - Fixtures (5 personas + 10 phases, K/N + Swift parallel)
+
+  private static let largeScenarioFixtureKMP: PasturaShared.Scenario = {
+    let personas: [PasturaShared.Persona] = (1...5).map { idx in
+      PasturaShared.Persona(name: "Agent\(idx)", description: "Persona \(idx) for H4 fixture")
+    }
+    let phases: [PasturaShared.Phase] = (1...10).map { _ in
+      PasturaShared.Phase(
+        type: PasturaShared.PhaseType.speakAll,
+        prompt: "Phase prompt for H4 fixture",
+        outputSchema: nil,
+        options: nil,
+        pairing: nil,
+        logic: nil,
+        template: nil,
+        source: nil,
+        target: nil,
+        excludeSelf: nil,
+        subRounds: nil,
+        condition: nil,
+        thenPhases: nil,
+        elsePhases: nil,
+        probability: nil,
+        eventVariable: nil
+      )
+    }
+    return PasturaShared.Scenario(
+      id: "h4-fixture-kmp",
+      name: "H4 measurement fixture",
+      description: "5 personas / 10 phases — H4 perf measurement",
+      language: "en",
+      simulationLanguage: nil,
+      agentCount: 5,
+      rounds: 1,
+      context: "H4 fixture context",
+      personas: personas,
+      phases: phases,
+      extraData: [:]
+    )
+  }()
+
+  private static let largeScenarioFixtureSwift: Pastura.Scenario = {
+    let personas: [Pastura.Persona] = (1...5).map { idx in
+      Pastura.Persona(name: "Agent\(idx)", description: "Persona \(idx) for H4 fixture")
+    }
+    let phases: [Pastura.Phase] = (1...10).map { _ in
+      Pastura.Phase(
+        type: .speakAll,
+        prompt: "Phase prompt for H4 fixture",
+        outputSchema: nil,
+        options: nil,
+        pairing: nil,
+        logic: nil,
+        template: nil,
+        source: nil,
+        target: nil,
+        excludeSelf: nil,
+        subRounds: nil,
+        condition: nil,
+        thenPhases: nil,
+        elsePhases: nil,
+        probability: nil,
+        eventVariable: nil
+      )
+    }
+    return Pastura.Scenario(
+      id: "h4-fixture-swift",
+      name: "H4 measurement fixture",
+      description: "5 personas / 10 phases — H4 perf measurement",
+      language: "en",
+      simulationLanguage: nil,
+      agentCount: 5,
+      rounds: 1,
+      context: "H4 fixture context",
+      personas: personas,
+      phases: phases,
+      extraData: [:]
+    )
+  }()
+
+  // MARK: - Measurement helpers
+
+  private static let warmupCount = 10
+  private static let sampleCount = 50
+
+  /// `ContinuousClock.Duration` → milliseconds. Duration's
+  /// `components.attoseconds` resolves to attosecond precision; 1 ms
+  /// = 1e15 attoseconds.
+  private static func milliseconds(_ duration: Duration) -> Double {
+    let seconds = Double(duration.components.seconds)
+    let attoseconds = Double(duration.components.attoseconds)
+    return seconds * 1_000 + attoseconds / 1e15
+  }
+
+  /// Population stats — mean, median, sample standard deviation.
+  private static func computeStats(
+    _ samples: [Double]
+  ) -> (mean: Double, median: Double, stddev: Double) {
+    let count = Double(samples.count)
+    let mean = samples.reduce(0, +) / count
+    let sorted = samples.sorted()
+    let median = sorted[sorted.count / 2]
+    let variance = samples.reduce(0) { $0 + pow($1 - mean, 2) } / count
+    return (mean, median, sqrt(variance))
+  }
+
+  private static func reportStats(path: String, samples: [Double]) {
+    let stats = computeStats(samples)
+    let line = String(
+      format: "[H4-DIRECT] path=%@ mean=%.3fms median=%.3fms stddev=%.3fms n=%lld",
+      path, stats.mean, stats.median, stats.stddev, Int64(samples.count)
+    )
+    print(line)
+  }
+
+  // MARK: - Path 1 — Canonicalize stage only
+
+  @Test func h4Path1CanonicalizeStageOnly() {
+    let scenario = Self.largeScenarioFixtureKMP
+    // Pre-encode OUTSIDE the measure loop — this path isolates the
+    // canonicalize-stage cost from any encode work.
+    let tree = ScenarioCodec.shared.encodeToJsonElement(scenario: scenario)
+    let canonicalizer = Canonicalizer.shared
+
+    let clock = ContinuousClock()
+    for _ in 0..<Self.warmupCount {
+      _ = canonicalizer.canonicalize(tree: tree, polymorphicDiscriminatorValues: Set<String>())
+    }
+
+    var samples: [Double] = []
+    samples.reserveCapacity(Self.sampleCount)
+    for _ in 0..<Self.sampleCount {
+      let elapsed = clock.measure {
+        _ = canonicalizer.canonicalize(tree: tree, polymorphicDiscriminatorValues: Set<String>())
+      }
+      samples.append(Self.milliseconds(elapsed))
+    }
+
+    Self.reportStats(path: "canonicalize-stage-only", samples: samples)
+    #expect(samples.count == Self.sampleCount)
+  }
+
+  // MARK: - Path 2 — K/N encode end-to-end
+
+  @Test func h4Path2KNEncodeOnly() {
+    let scenario = Self.largeScenarioFixtureKMP
+    let codec = ScenarioCodec.shared
+
+    let clock = ContinuousClock()
+    for _ in 0..<Self.warmupCount {
+      _ = codec.encodeToString(scenario: scenario)
+    }
+
+    var samples: [Double] = []
+    samples.reserveCapacity(Self.sampleCount)
+    for _ in 0..<Self.sampleCount {
+      let elapsed = clock.measure {
+        _ = codec.encodeToString(scenario: scenario)
+      }
+      samples.append(Self.milliseconds(elapsed))
+    }
+
+    Self.reportStats(path: "kn-encode-only", samples: samples)
+    #expect(samples.count == Self.sampleCount)
+  }
+
+  // MARK: - Path 3 — Swift native Yams roundtrip
+
+  @Test func h4Path3SwiftYamsRoundtrip() throws {
+    let scenario = Self.largeScenarioFixtureSwift
+    let encoder = YAMLEncoder()
+    let decoder = YAMLDecoder()
+
+    let clock = ContinuousClock()
+    for _ in 0..<Self.warmupCount {
+      let yaml = try encoder.encode(scenario)
+      _ = try decoder.decode(Pastura.Scenario.self, from: yaml)
+    }
+
+    var samples: [Double] = []
+    samples.reserveCapacity(Self.sampleCount)
+    for _ in 0..<Self.sampleCount {
+      let elapsed = try clock.measure {
+        let yaml = try encoder.encode(scenario)
+        _ = try decoder.decode(Pastura.Scenario.self, from: yaml)
+      }
+      samples.append(Self.milliseconds(elapsed))
+    }
+
+    Self.reportStats(path: "swift-yams-roundtrip", samples: samples)
+    #expect(samples.count == Self.sampleCount)
+  }
+}

--- a/Pastura/PasturaTests/KMPSpike/H4PerformanceTests.swift
+++ b/Pastura/PasturaTests/KMPSpike/H4PerformanceTests.swift
@@ -155,15 +155,19 @@ struct H4PerformanceTests {
   }
 
   /// Population stats — mean, median, sample standard deviation.
-  private static func computeStats(
-    _ samples: [Double]
-  ) -> (mean: Double, median: Double, stddev: Double) {
+  private struct Stats {
+    let mean: Double
+    let median: Double
+    let stddev: Double
+  }
+
+  private static func computeStats(_ samples: [Double]) -> Stats {
     let count = Double(samples.count)
     let mean = samples.reduce(0, +) / count
     let sorted = samples.sorted()
     let median = sorted[sorted.count / 2]
     let variance = samples.reduce(0) { $0 + pow($1 - mean, 2) } / count
-    return (mean, median, sqrt(variance))
+    return Stats(mean: mean, median: median, stddev: sqrt(variance))
   }
 
   private static func reportStats(path: String, samples: [Double]) {

--- a/Pastura/PasturaTests/KMPSpike/H4PerformanceTests.swift
+++ b/Pastura/PasturaTests/KMPSpike/H4PerformanceTests.swift
@@ -203,7 +203,12 @@ struct H4PerformanceTests {
     }
 
     Self.reportStats(path: "canonicalize-stage-only", samples: samples)
-    #expect(samples.count == Self.sampleCount)
+    // `count == sampleCount` catches a future refactor that conditionally
+    // skips appends; `contains { $0 > 0 }` catches an all-zero outcome
+    // that would signal the measure closure was elided (functionally
+    // unreachable today but guards against compiler optimization
+    // surprises in tighter Release builds).
+    #expect(samples.count == Self.sampleCount && samples.contains { $0 > 0 })
   }
 
   // MARK: - Path 2 — K/N encode end-to-end
@@ -227,7 +232,7 @@ struct H4PerformanceTests {
     }
 
     Self.reportStats(path: "kn-encode-only", samples: samples)
-    #expect(samples.count == Self.sampleCount)
+    #expect(samples.count == Self.sampleCount && samples.contains { $0 > 0 })
   }
 
   // MARK: - Path 3 — Swift native Yams roundtrip
@@ -254,6 +259,6 @@ struct H4PerformanceTests {
     }
 
     Self.reportStats(path: "swift-yams-roundtrip", samples: samples)
-    #expect(samples.count == Self.sampleCount)
+    #expect(samples.count == Self.sampleCount && samples.contains { $0 > 0 })
   }
 }

--- a/Pastura/PasturaTests/KMPSpike/KNDotSyntaxAccessTests.swift
+++ b/Pastura/PasturaTests/KMPSpike/KNDotSyntaxAccessTests.swift
@@ -1,0 +1,89 @@
+// K/N sealed-class subtype dot-syntax access regression guard —
+// Issue #220 W4 PR-A Item 1.
+//
+// Locks the empirical finding that K/N's swift_name dot-syntax DOES export
+// sealed-class subtypes accessibly from Swift. PR-C documented a
+// "swift_name dot-syntax barrier" inline (never runtime-tested); W4 PR-A
+// Item 1 re-diagnosed it as **Swift module shadowing** in the Pastura/
+// target (`Pastura.SimulationEvent` Swift enum vs PasturaShared's K/N
+// class), not a K/N export defect — the fix is `PasturaShared.` module
+// qualification at the call site, not a Kotlin facade.
+//
+// This suite runs in PasturaTests/, which does NOT import the Pastura
+// module and therefore has no shadowing — so unqualified names resolve
+// directly to PasturaShared's K/N exports. That makes it a clean
+// regression-guard surface for the K/N export shape itself. The companion
+// production-side proof (using the `PasturaShared.` qualifier under
+// shadowing) lives in `Pastura/Pastura/KMPSpike/PasturaSharedSpike.swift`
+// — both surfaces must keep working for the dot-syntax pattern to remain
+// load-bearing for production K/N integration.
+//
+// Verified shapes:
+//
+//  - SimulationEvent.SimulationCompleted.shared   (sealed-class `object` singleton)
+//  - SimulationError.Cancelled.shared             (same shape, separate sealed class)
+//  - SimulationEvent.PhaseStarted(...)            (sealed-class data-class subtype constructor)
+//  - event as? SimulationEvent.PhaseStarted       (subtype-cast pattern match)
+//
+// The one path that genuinely fails is the FLAT MANGLED NAME form
+// (`SimulationEventPhaseStarted(...)`, `SimulationErrorCancelled.shared`) —
+// `swift_name` correctly hides it. That is intentional K/N behaviour, not a
+// regression, so this suite asserts only the dot-syntax-works direction.
+
+import PasturaShared
+import Testing
+
+@Suite(.timeLimit(.minutes(1)))
+@MainActor
+struct KNDotSyntaxAccessTests {
+
+  // MARK: - sealed-class `object` singleton access via .shared
+
+  @Test func simulationEventSimulationCompletedShared() {
+    let first: SimulationEvent = SimulationEvent.SimulationCompleted.shared
+    let second: SimulationEvent = SimulationEvent.SimulationCompleted.shared
+    #expect(first === second, "Singleton `.shared` must return the same instance across accesses")
+  }
+
+  @Test func simulationErrorObjectSingletonsAccessible() {
+    let cancelled: SimulationError = SimulationError.Cancelled.shared
+    let modelNotLoaded: SimulationError = SimulationError.ModelNotLoaded.shared
+    let retriesExhausted: SimulationError = SimulationError.RetriesExhausted.shared
+
+    // Distinct singleton classes — pointer-distinct.
+    #expect(cancelled !== modelNotLoaded)
+    #expect(modelNotLoaded !== retriesExhausted)
+    #expect(cancelled !== retriesExhausted)
+
+    // Same .shared call twice → same pointer.
+    #expect(SimulationError.Cancelled.shared === SimulationError.Cancelled.shared)
+  }
+
+  // MARK: - sealed-class data class subtype construction via dot-syntax
+
+  @Test func simulationEventPhaseStartedConstructor() {
+    let event: SimulationEvent = SimulationEvent.PhaseStarted(
+      phaseType: PhaseType.speakAll, phasePath: [0]
+    )
+    // Pattern match — sealed-class subtype is exposed as a Swift Obj-C class,
+    // so the production-side pattern-match path is `as?` cast (not Swift
+    // `switch case .x` which is enum-only).
+    guard let started = event as? SimulationEvent.PhaseStarted else {
+      Issue.record("`as?` cast rejected a SimulationEvent.PhaseStarted constructed via dot-syntax")
+      return
+    }
+    #expect(started.phaseType == PhaseType.speakAll)
+    #expect(started.phasePath == [0])
+  }
+
+  @Test func simulationErrorScenarioValidationFailedConstructor() {
+    let err: SimulationError = SimulationError.ScenarioValidationFailed(message: "test-msg")
+    guard let failed = err as? SimulationError.ScenarioValidationFailed else {
+      Issue.record(
+        "`as?` cast rejected a SimulationError.ScenarioValidationFailed constructed via dot-syntax"
+      )
+      return
+    }
+    #expect(failed.message == "test-msg")
+  }
+}

--- a/Pastura/PasturaTests/KMPSpike/KNDotSyntaxAccessTests.swift
+++ b/Pastura/PasturaTests/KMPSpike/KNDotSyntaxAccessTests.swift
@@ -72,7 +72,13 @@ struct KNDotSyntaxAccessTests {
       Issue.record("`as?` cast rejected a SimulationEvent.PhaseStarted constructed via dot-syntax")
       return
     }
-    #expect(started.phaseType == PhaseType.speakAll)
+    // `===` expresses singleton identity directly — Kotlin enum entries
+    // export as class-readonly singletons, so reference identity is the
+    // load-bearing relation. `==` would also pass via `isEqual:` →
+    // Kotlin `equals`, but adds an unnecessary equality-conformance hop.
+    #expect(started.phaseType === PhaseType.speakAll)
+    // Array element compare goes through Foundation bridge (NSArray of
+    // boxed KotlinInt vs Swift `[Int]` literal); keep `==`.
     #expect(started.phasePath == [0])
   }
 

--- a/shared/models/src/commonMain/kotlin/com/pastura/models/ScenarioCodec.kt
+++ b/shared/models/src/commonMain/kotlin/com/pastura/models/ScenarioCodec.kt
@@ -1,0 +1,50 @@
+package com.pastura.models
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * Swift-callable facade for kotlinx.serialization encoding of [Scenario] —
+ * Issue #220 W4 PR-A.
+ *
+ * **Why this exists:** kotlinx.serialization's top-level encode operations
+ * (`Json.encodeToString<T>(value)`, `Json.encodeToJsonElement<T>(value)`)
+ * rely on `reified` type parameters resolved at compile time. Kotlin/Native's
+ * Swift export collapses `reified` generics — the Swift caller cannot
+ * invoke them directly. The explicit-serializer overloads
+ * (`Json.encodeToString(serializer, value)`) ARE exported but require
+ * passing the serializer instance, which is ergonomically heavy from Swift.
+ *
+ * This object exposes concrete-type signatures the Swift consumer can call
+ * without touching either reified generics or KSerializer types.
+ *
+ * **encode-only by design** (W4 PR-A scope decision per W3 PR-C plan v4
+ * Option γ-prime): the W4 H4 measurement only exercises the encode path;
+ * Swift→K/N decode is NOT on the production iOS graph (YAML → `Scenario`
+ * decoding stays Swift-side via `ScenarioLoader`). Adding a decode surface
+ * here would be premature — W4 PR-C snakeyaml validation work may need it,
+ * in which case it lands then.
+ *
+ * **Json instance choice:** `Json` (companion object — kotlinx-serialization
+ * default settings) matches existing `commonTest/` usage. No custom
+ * configuration (`isLenient`, `ignoreUnknownKeys`) — production scenarios
+ * use strict schemas and the spike's measurement should reflect that.
+ */
+public object ScenarioCodec {
+
+    /**
+     * Encode [scenario] to the canonical [JsonElement] tree.
+     *
+     * Returned tree is suitable as input to [Canonicalizer.canonicalize] for
+     * cross-language wire-shape comparison (PR-B harness pattern).
+     */
+    public fun encodeToJsonElement(scenario: Scenario): JsonElement =
+        Json.encodeToJsonElement(Scenario.serializer(), scenario)
+
+    /**
+     * Encode [scenario] to a JSON string (default kotlinx-serialization
+     * compact form — no pretty-printing).
+     */
+    public fun encodeToString(scenario: Scenario): String =
+        Json.encodeToString(Scenario.serializer(), scenario)
+}


### PR DESCRIPTION
## Summary

- Pivoted at Item 1 verification: PR-C's "swift_name dot-syntax barrier" was empirically Swift module shadowing, not a K/N export defect. Both planned `Factory` `commonMain` files were dropped.
- Adds `ScenarioCodec` (genuine reified-generics K/N workaround), `KNDotSyntaxAccessTests` regression guard, and `H4PerformanceTests` 3-path encode measurement (NOT cross-comparable).
- Fixes pre-existing W3 PR-A/B/C silent issue: 5 `sample*` functions returned `Pastura.*` Swift native types instead of K/N types (Q9 evidence was hollow). All callsites now `PasturaShared.`-qualified.

## What's in this PR

| Commit | Item | Notes |
|---|---|---|
| `e8ee468` | 🔴 Atomic — `ScenarioCodec.kt` + `KNDotSyntaxAccessTests.swift` + `PasturaSharedSpike.swift` updates | 5 sample* qualified, `sampleSimulationEvent` added, narrative rewritten |
| `4588dc0` | 🔴 H4 3-path perf measurement | 5+10 fixture, warmup 10 + sample 50, `ContinuousClock`, aggregate print |
| `22366e4` | 🎨 Stats struct refactor | swiftlint `large_tuple` compliance |
| `1b2a5ff` | 🎨 Tighten H4 assertions + `===` for enum | Address code-reviewer Suggestions 1+2 |

## W4 PR-A Item 1 — 3 discoveries

1. **K/N swift_name dot-syntax exports sealed-class subtypes accessibly** — `SimulationEvent.SimulationCompleted.shared` (singleton), `SimulationEvent.PhaseStarted(...)` (data-class subtype constructor), and `event as? SimulationEvent.PhaseStarted` (pattern match) all compile + run correctly. PR-C documented these as "failed" inline but never empirically tested.
2. **The actual barrier is Swift module shadowing** — `Pastura.SimulationEvent` Swift `enum` shadows the K/N class with the same unqualified name. Fix: explicit `PasturaShared.` qualifier at the call site, NOT a `commonMain` facade.
3. **W3 PR-A/B/C `sample*` functions silently exercised zero K/N code paths** — all 5 returned `Pastura.*` Swift native types (same shadowing). Q9 "spike validates K/N integration" evidence was hollow until this PR fixed all 5 callsites.

Full Pivot summary: [Issue #220 plan comment](https://github.com/tyabu12/pastura/issues/220#issuecomment-4537983161).

## H4 measurement results (local M-series simulator, debug)

| Path | mean | median | stddev |
|---|---|---|---|
| `canonicalize-stage-only` | 0.008ms | 0.007ms | 0.001ms |
| `kn-encode-only` | 0.009ms | 0.009ms | 0.001ms |
| `swift-yams-roundtrip` | 1.931ms | 1.924ms | 0.030ms |

⚠️ These are **3 distinct metrics, NOT cross-comparable** — see `H4PerformanceTests.swift` § Methodology header. Each answers a separate question. CI numbers will differ (these are local reference points only).

K/N FFI overhead is sub-millisecond — H6 ≤10MB / W6 GO/NO-GO viability signal positive.

## Deviations from W3 PR-C checkpoint

- **Sendable upstream** (PR-C Watch item #1 marked "MUST upstream to commonMain"): deferred to W4 PR-D / W5 reserve per user scope decision. `extension PasturaShared.Pairing: @retroactive @unchecked Sendable` remains in `H8AsyncBridgeTests.swift` test target only.
- **Kotlin facade scope**: original plan (`SimulationEventFactory.kt` + `SimulationErrorFactory.kt`) dropped after Item 1 verification overturned the premise. Only `ScenarioCodec.kt` landed.
- **Q9 expansion**: lifted to 8/21 (`sampleSimulationEvent` added; 5 existing `sample*` now actually exercise K/N).

## Decode dependency note

`ScenarioCodec` is encode-only. If W4 PR-C (snakeyaml validation) needs Swift→K/N decode, add a `decodeFromString(json:)` companion in that PR.

## Test plan

- [x] All 4 `KNDotSyntaxAccessTests` pass (singleton, multi-object, data-class subtype constructor, pattern-match cast)
- [x] All 3 `H4PerformanceTests` print `[H4-DIRECT]` lines and pass
- [x] Full unit suite (skip UI): 1809 / 166 suites / 16.6s green (+7 tests vs PR-C baseline 1802 / 164 / 17.7s)
- [x] `swiftlint --strict` clean
- [x] xcframework rebuilt; new symbols (`ScenarioCodec` only) verified in `PasturaShared.h`

Part of #220