### PR TITLE
📚 docs: bump Yams 6.2.1→6.2.2 and GRDB 7.10→7.11 in docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,8 +109,8 @@ Utilities/ → depends on nothing
 | Language           | Swift                         | 6.x       |
 | UI                 | SwiftUI                       |           |
 | Min iOS            | 17.0                          |           |
-| YAML parser        | Yams                          | 6.2.1     |
-| SQLite             | GRDB                          | 7.10.0    |
+| YAML parser        | Yams                          | 6.2.2     |
+| SQLite             | GRDB                          | 7.11.0    |
 | LLM (TestFlight)   | llama.cpp via mattt/llama.swift | pinned   |
 | LLM (target)       | LiteRT-LM iOS SDK (planned)  |           |
 | LLM (dev)          | Ollama via OpenAI-compat API  |           |

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ dependency direction is preparation for a future SPM module split.
 
 ### Libraries
 
-- [Yams](https://github.com/jpsim/Yams) 6.2.1 for YAML parsing
-- [GRDB](https://github.com/groue/GRDB.swift) 7.10 for SQLite
+- [Yams](https://github.com/jpsim/Yams) 6.2.2 for YAML parsing
+- [GRDB](https://github.com/groue/GRDB.swift) 7.11 for SQLite
 
 ### LLM backends
 


### PR DESCRIPTION
## Summary
- Dependabot bumps (#488 Yams, #489 GRDB) advanced Package.resolved to Yams 6.2.2 / GRDB 7.11.0; docs still cited Yams 6.2.1 / GRDB 7.10.
- Synced CLAUDE.md Tech Stack table and README.md Libraries section.
- Per-file format preserved: CLAUDE.md `7.11.0` (3-part), README `7.11` (2-part).

## Scope completeness (negative check)
- grep confirmed CONTRIBUTING.md and docs/ROADMAP.md carry no Yams/GRDB version strings.
- docs/security/release-checklist.md mentions the libs without versions — correctly out of scope.
- ADR-001 §3 ("GRDB v7.10.0") and docs/specs/demo-replay-spec.md ("Yams 6.2.1") are the only other versioned references — deliberately left as point-in-time decision records.
- Package.resolved is read-only verification evidence, not hand-edited.

## Test plan
- Doc-only (Markdown). No Swift changes; pre-commit swiftlint/build no-op.
- Verified new strings match Package.resolved pins; no residual `6.2.1`/`7.10`.

Closes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)