### PR TITLE
📚 docs: ADR-004 Accepted (Conditional GO) + ADR-012 YAML (#220 W5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,7 +271,7 @@ same change:
 | `docs/decisions/ADR-001.md`           | Phase 1 architecture decisions (12 ADRs)    |
 | `docs/decisions/ADR-002.md`           | llama.cpp interim LLM backend decision      |
 | `docs/decisions/ADR-003.md`           | BG execution (iOS 26 BGContinuedProcessingTask) |
-| `docs/decisions/ADR-004.md`           | Multi-platform strategy (Draft)             |
+| `docs/decisions/ADR-004.md`           | Multi-platform strategy — Accepted (Conditional GO) on #220 KMP spike; §9 GO/NO-GO synthesis (H5/H7 distribution-verification deferred) |
 | `docs/decisions/ADR-005.md`           | Content safety architecture (App Store review) |
 | `docs/decisions/ADR-006.md`           | Cloud API implementation details (Phase 3; reserved — not yet written; see ADR-005 §7.5) |
 | `docs/decisions/ADR-007.md`           | DL-time demo replay — iOS lifecycle (#152)  |
@@ -279,6 +279,7 @@ same change:
 | `docs/decisions/ADR-009.md`           | View testing strategy (no ViewInspector / snapshot; #269) |
 | `docs/decisions/ADR-010.md`           | Localization (i18n: ja/en) — ADR body for Step C-1 design (Status: Proposed; stub #279, body #367) |
 | `docs/decisions/ADR-011.md`           | 6 GB RAM tier — selection criteria + Phase 2 deferral (no-go for Gemma 3 1B IT; mechanism-contract prerequisites for future candidates; #477 / PR #480 / #483) |
+| `docs/decisions/ADR-012.md`           | YAML strategy post-kaml — snakeyaml-engine-kmp adoption for the shared Models layer (kaml archived; #220 D3 / T9; ADR-008 number drift) |
 | `docs/specs/pastura-mvp-spec-v0_3.md` | MVP specification                                         |
 | `docs/specs/demo-replay-spec.md`      | DL-time demo replay — data format + component design (#152) |
 | `docs/specs/demo-replay-ui.md`        | DL-time demo replay — visual / behaviour spec (#164)        |

--- a/docs/decisions/ADR-004.md
+++ b/docs/decisions/ADR-004.md
@@ -1,16 +1,25 @@
 # ADR-004: Multi-platform Strategy — Android / Desktop Expansion
 
-> **Status:** Draft
-> **Date:** 2026-04-17
+> **Status:** Accepted — Conditional GO (KMP Models spike #220; H5/H7 distribution-verification pending — see §9.2)
+> **Date:** 2026-04-17 (drafted) · 2026-06-11 (accepted on #220 spike evidence)
 > **Context:** Phase 3 — Android + PC (Windows/macOS) expansion is planned.
 > The current ROADMAP assumes native-per-platform (Kotlin Android + Python/Tauri PC).
 > A question was raised on whether a cross-platform framework should replace that path.
 
-> **Note on finality:** This ADR is intentionally kept in **Draft** until Phase 2
-> finishes and the Go/No-Go evaluation for Phase 3 is made. See §8 for the
-> gating criteria. The purpose of keeping this document in the repo now is to
-> surface the trade-offs and recommended direction *before* implementation work
-> on any multi-platform scaffolding starts.
+> **Acceptance note (2026-06-11).** Superseding the original Draft hold: the KMP
+> Models spike (#220) supplied the GO/NO-GO evidence §8 required, validating
+> Option A's load-bearing assumption that Pastura's Models layer ports to Kotlin
+> Multiplatform with production-grade Swift interop, binary footprint, and
+> SwiftUI observation. Verdict = **Conditional GO** — every *Models-layer-
+> testable* Tier-1 hypothesis passed; two *distribution-pipeline* Tier-1
+> blockers (H5 ASC archive upload, H7 Kotlin-crash symbolication) are deferred
+> as **executable-but-unexecuted** post-merge actions (§9.2), not structural KMP
+> blockers. Option A (the architecture) is hereby **Accepted**; the *start* of
+> Phase 3 implementation still gates on the Phase 2 → Phase 3 criteria in §8.
+> Full synthesis — including the canonical-vs-checkpoint hypothesis-numbering
+> reconciliation and the honest Tier-2 tally — is in §9. The 2026-04-17 draft
+> already *recommended* Option A; the spike converts that recommendation into a
+> ratified, evidence-backed choice.
 
 ---
 
@@ -306,12 +315,19 @@ divergence from the protocol abstraction ADR-002 §8 relies on.
 
 ---
 
-## 4. Decision (tentative — see §8)
+## 4. Decision
 
-**Recommend Option A** (KMP shared Engine, native UI per platform) when Phase 3 begins.
+**Adopt Option A** (KMP shared Engine, native UI per platform) for Phase 3.
 
-Formally adopt this decision at the Phase 2 → Phase 3 transition, subject to the
-gating criteria in §8. Until then this ADR stays **Draft**.
+Ratified at the Phase 2 → Phase 3 gate on the strength of the #220 KMP Models
+spike (§9), as a **Conditional GO**: every Models-layer-testable Tier-1
+hypothesis is green and the spike over-delivered against §8's KMP-PoC gating
+criterion (full Models layer ported, not a single handler). Two
+distribution-pipeline Tier-1 blockers (H5 ASC archive upload, H7 crash
+symbolication) remain **executable-but-unexecuted** and are carried as named
+post-merge actions (§9.2) — they are ASC-onboarding tasks, not KMP-capability
+gaps. Phase 3 implementation *starts* once the remaining §8 criteria (Phase 2
+completion) clear; the architecture choice itself is no longer tentative.
 
 ---
 
@@ -464,9 +480,17 @@ Phase 2 Go/No-Go review:
       real-time LLM token streaming are Done. In-app scenario generation
       (Cloud API) has been deferred to Phase 3 per the 2026-04-21
       ROADMAP update — it no longer blocks Phase 2 exit.
-- [ ] A 1-day KMP PoC has built a single Engine phase handler in `commonMain`
-      and exercised it from a small iOS harness, to validate that SKIE (or
-      vanilla interop) reaches the ergonomics this ADR assumes.
+- [x] **Met and exceeded by the #220 KMP Models spike (§9).** Rather than a
+      1-day single-handler PoC, the spike ported the *entire* Models layer
+      (17 files / 21 types) to `commonMain` and exercised it from real iOS
+      consumption — validating semantic Codable equivalence (JSON + YAML),
+      binary footprint (4.1 MB framework, §9.1 H6), and the `@Observable`
+      SwiftUI bridge (§9.1 H8). Two scope caveats: (a) the spike validated the
+      **Models** layer, not an Engine phase handler — Engine remains the
+      Phase 3.0 port (§9.6); (b) it used **direct K/N interop, not SKIE**
+      (#220 D2), so the ergonomics finding is for vanilla interop within the
+      Q9 shim budget; SKIE-vs-vanilla (§7 Q1) stays deferred to the Engine
+      migration.
 - [ ] LiteRT-LM Swift SDK + iOS GPU status is re-checked (ADR-002 §8
       trigger). Per §3.6, Phase 3 starts with unified llama.cpp across
       all platforms regardless of SDK status at the gate review; the
@@ -477,13 +501,180 @@ Phase 2 Go/No-Go review:
 - [ ] No new iOS-only feature landed in Phase 2 that would break the
       "Engine has no iOS dependencies" invariant.
 
-If any criterion fails, this ADR stays Draft and Phase 3 starts with Engine
-duplication deferred — no commitment to multi-platform beyond what the data
-supports.
+The KMP-PoC criterion above is satisfied by the #220 spike (§9), which moves
+this ADR from Draft to **Accepted — Conditional GO**. The remaining criteria
+gate the *timing* of Phase 3 start, not the Option A architecture choice. If a
+remaining criterion regresses (e.g. a new iOS-only Engine dependency lands),
+Phase 3 start slips, but the KMP Models evidence in §9 stands and Option A is
+not reopened by that slip alone.
 
 ---
 
-## 9. References
+## 9. Spike Validation (#220) — GO/NO-GO Synthesis (2026-06-11)
+
+This section records the outcome of the KMP Models Layer Validation spike
+(#220), the evidence that moved §4 from "recommend" to "adopt", and the named
+deferrals attached to the **Conditional GO**. Numeric readings trace to the
+spike's weekly checkpoint comments on #220 (W1–W4); checkpoint comment IDs are
+cited inline.
+
+### 9.0 Hypothesis numbering — canonical vs. checkpoint (read this first)
+
+⚠️ **Two numbering schemes appear in the #220 record; this ADR uses the
+canonical one.** Issue #220's "GO/NO-GO Criteria" section is the canonical
+source: **H5 = ASC archive upload**, **H6 = `.ipa` size ≤ 10 MB**, **H7 =
+Kotlin-crash symbolication**. The W4 PR-B checkpoint
+([#220 comment 4567187252](https://github.com/tyabu12/pastura/issues/220#issuecomment-4567187252))
+*relabelled* its binary-footprint readings as "H5" (Pastura.app 31 MB) and
+"H6" (PasturaShared.framework 4.1 MB) — a labelling that diverges from the
+canonical numbering. **In this ADR, the footprint evidence (4.1 MB framework)
+maps to canonical H6 (≤ 10 MB); canonical H5 (ASC archive upload) and
+canonical H7 (crash symbolication) were never executed and are DEFER (§9.2).**
+A reader cross-checking the immutable checkpoint comments must apply this
+mapping — the checkpoint's "H5 ✅ 31 MB" is a footprint reading, not an ASC
+upload. (There is **no H3** in the hypothesis table; the original H1/H2/H3
+framing resolved to H2 + Tier-4 during the spike.)
+
+### 9.1 Tier-1 hard blockers — results (canonical numbering)
+
+| H | Canonical definition (#220) | Result | Evidence |
+|---|---|---|---|
+| **H1** | All `Models/` types (17 files / 21 types, ~1020 LOC) represented in KMP, no Swift-only fallback | ✅ **PASS** | W2 PR-A: 17 files / 21 types ported to `commonMain` |
+| **H2** | Semantic Codable roundtrip equivalence across preset fixtures (canonicalized, not byte-identical) | ✅ **PASS** | JSON axis: W2 PR-B `CanonicalEquivalenceTests`. YAML axis: W4 PR-C ([4639563985](https://github.com/tyabu12/pastura/issues/220#issuecomment-4639563985)) — 4 presets, **zero divergence** |
+| **H4** | `prisoners_dilemma` executes to completion on iOS **device** with KMP Models + `MockLLMService`, identical `SimulationEvent` sequence vs Swift baseline | ⚠️ **N/A (proxied)** | Literal H4 needs the **Engine**, which is out of a Models-only spike's scope (#220 Non-goal). Proxied by H2 (semantic equivalence, GREEN) + encode-perf sub-ms (W4 PR-A: K/N encode ≈ 9 µs, canonicalize ≈ 8 µs, n=50). Literal on-device event-sequence equivalence → Phase 3.0 Engine port. **Not claimed as a pass.** |
+| **H5** | Archive builds + uploads to ASC; processing succeeds (no invalid-binary rejection) | ⛔ **DEFER** | **Never executed** — CI `release-build` runs `CODE_SIGNING_ALLOWED=NO` (W3 PR-A), which does not validate ASC submission. See §9.2 |
+| **H6** | `.ipa` size increase ≤ 10 MB vs Swift-only baseline | ✅ **PASS** | W4 PR-B ([4567187252](https://github.com/tyabu12/pastura/issues/220#issuecomment-4567187252)): PasturaShared.framework = **4.1 MB build-products** (41 % of ceiling, 5.9 MB headroom). Build-products over-estimates ASC delivery, so this is conservative |
+| **H7** | Intentional Kotlin crash → symbolicated frames in Xcode Organizer Crashes view (via K/N dSYM) | ⛔ **DEFER** | **Never executed** — appears in no checkpoint; requires a distributed (TestFlight) build. See §9.2 |
+| **H8** | `@Observable`-bridged VM reads a K/N-backed Models property; mutation triggers SwiftUI invalidation | ✅ **PASS** | W3: `@Observable` bridge test 5/5 GREEN (closes the PR #216 `access`/`withMutation` interaction hole) |
+
+**Tier-1 reading:** 4 PASS (H1, H2, H6, H8), 1 proxied-N/A (H4), 2 DEFER (H5,
+H7). Every hypothesis a **Models-only** spike can test is green; the two
+DEFERs and the H4 proxy are all consequences of scope boundaries (Engine not
+ported) or distribution-pipeline onboarding (below) — none is a KMP-capability
+failure.
+
+### 9.2 The H5/H7 deferral — named post-merge actions
+
+H5 and H7 are **executable-but-unexecuted**, not structural blockers:
+
+- Apple Developer Program is **enrolled** as of 2026-06; no build has yet been
+  uploaded to App Store Connect (no app record created). So H5/H7 are not
+  blocked by missing infrastructure — they are unrun measurement tasks.
+- **H5** needs: register bundle ID `app.pastura.Pastura`, create the ASC app
+  record, distribution signing (Xcode automatic), then Archive → upload →
+  observe processing. No public-submission metadata is required to validate
+  processing. Est. ~30–60 min.
+- **H7** builds on H5 + a TestFlight-distributed build carrying an intentional
+  Kotlin crash + K/N dSYM upload, then observe the Organizer Crashes view.
+  Heavier (crash-report propagation can take hours).
+- Both fold naturally into the Phase 2 App Store launch ASC-onboarding work,
+  which is required regardless of this spike.
+
+**Carry these as the GO's named conditions.** #220's Exit Criteria define a
+clean GO as "Tier 1 all pass"; this is a **Conditional GO** that explicitly
+carves out H5/H7 as distribution-verification actions, per operator decision
+(2026-06-11). The Conditional GO is voided (→ re-evaluate) only if H5 surfaces
+an ASC invalid-binary rejection of the K/N XCFramework (risk R7) or H7 shows
+K/N frames do not symbolicate — neither of which any spike evidence predicts.
+
+### 9.3 Tier-2 quality gates — honest tally
+
+#220 sets GO at "Tier-2 ≥ 80 % pass" across 11 gate checkboxes. **The literal
+≥ 80 % threshold is not mechanically demonstrated**, because several gates
+were not measured within the Models-only spike — *not measured*, not *failed*.
+
+| Gate | Target | Status | Reading / source |
+|---|---|---|---|
+| Q1-cold | clean build ≤ 25 min | ✅ PASS | W1: cold konan+gradle KMP job 4m27s, huge headroom |
+| Q1-warm | ≤ 2.0× Swift baseline | 🟡 PARTIAL | CI warm deltas absorbed by existing `lint-and-test`; no isolated 5-run distribution captured |
+| Q2 | incremental build ≤ 20 s | ◻️ NOT MEASURED | local-dev metric, not captured |
+| Q3 | `jvmTest` ≤ 10 s, all Models suites ported | ✅ PASS | W4 PR-C: **159 tests / 27 classes**, simulator-free (the spike's primary parallelism motivation) |
+| Q4-warm | full CI ≤ 12 min warm | ✅ PASS* | W4 PR-C: 11m20s warm (KMP job 4m36s). *Some runs 13–15 min on `lint-and-test` variance |
+| Q4-cold | full CI ≤ 20 min cold | ✅ PASS | W3: ~7m30s cold-cache slowest-job, 14+ min headroom |
+| Q5 | SwiftLint + swift-format hooks functional | ✅ PASS | W3 PR-A: `setup.sh` / pre-commit integration intact |
+| Q6 | SwiftUI Previews with KMP types | ◻️ NOT MEASURED | deferred in W3 (out of PR-A scope); never picked up |
+| Q7 | debugger steps into Kotlin source | ◻️ NOT MEASURED | dev-time interop nicety, not exercised |
+| Q8 | crash symbolicated in debug runs | ◻️ NOT MEASURED | tied to the deferred H7 crash path |
+| Q9 | Swift interop shim ≤ 300 LOC total | 🟡 PARTIAL | 8/21 K/N types exercised; shim well under budget on that surface, but 13/21 types not yet exercised — full-Models shim total is a projection |
+
+**Tally:** 5 PASS (Q1-cold, Q3, Q4-warm, Q4-cold, Q5), 2 PARTIAL (Q1-warm,
+Q9), 4 NOT MEASURED (Q2, Q6, Q7, Q8). Measured-pass ≈ **5/11 (≈ 45 %)**, or
+**7/11 (≈ 64 %)** counting partials — **below the literal 80 % gate**.
+
+**Honest framing:** the verdict is a **Conditional GO on the measured Tier-2
+subset** — every gate that *was* measured passes or partially passes, and the
+4 unmeasured gates are local-developer-ergonomics (Q2/Q6/Q7) plus crash
+symbolication (Q8, which rides on the deferred H7), none of them KMP
+viability blockers. The spike's headline Tier-2 motivation — simulator-free
+business-logic test execution (Q3) — is firmly green. The operator judged the
+measured evidence sufficient for Conditional GO; the unmeasured gates join
+H5/H7 as post-merge / Phase-3.0-entry verification, not silent passes.
+
+### 9.4 Tier-3 migration-cost observations (O1–O5)
+
+The spike did not separately tally O1–O5 as discrete metrics; the W2 Models
+port is itself the dataset. The load-bearing figure for Phase 3.0 estimation
+is the actual Models-layer porting effort: ~3 focused days (W1 scaffold +
+W2 PR-A bulk port + W2 PR-B equivalence harness), the remainder of the ~8-day
+cumulative spike burn being one-time integration / CI / measurement
+infrastructure that Phase 3.0 inherits rather than repeats. O2 (Kotlin LOC ÷
+Swift LOC) landed near 1.0 — the 17 files / 21 types ported without structural
+blow-up. No "Swift-expressible but not Kotlin-expressible" Models pattern (O3)
+blocked the port; the documented friction points (K/N `@unchecked Sendable`
+retroactivity, sealed-class Swift module shadowing) are interop-shim items, not
+expressiveness gaps.
+
+### 9.5 Tier-4 learning capture (qualitative)
+
+- **YAML roundtrip fidelity** — GREEN (W4 PR-C); recorded in [ADR-012](ADR-012.md).
+- **`SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` × K/N** — K/N exported classes
+  lack Swift `Sendable`; actor cross-hops need `@retroactive @unchecked
+  Sendable` (sound for all-`val` data classes). Currently confined to a test
+  target; upstreaming to `commonMain` is a post-spike item.
+- **Sealed-class Swift access** — K/N sealed-class subtypes ARE reachable via
+  dot-syntax; the real friction is Swift module shadowing, resolved by a
+  `PasturaShared.` qualifier at the call site (W4 PR-A). Production K/N
+  integration does **not** need `commonMain` facade objects for this.
+
+### 9.6 Phase 3.0 work-breakdown estimate (effort-multiplier projection only)
+
+Per #220 Exit Criteria (GO requires a Phase 3.0 breakdown). **Scope of this
+estimate: effort sizing only.** Binding selection, SKIE-vs-vanilla interop, and
+the Android NPU path remain deferred to implementation time per §3.6, §6, and
+§7 — this breakdown does not reopen them.
+
+Using the #220 O4 multipliers (Engine ≈ 5× Models effort, Data ≈ 3× Models
+effort) on the measured ~3-day Models port:
+
+| Phase 3.0 layer | Rough effort | Basis |
+|---|---|---|
+| Models (done in spike) | ~3 days | measured |
+| Engine port (`commonMain`) | ~3 weeks (≈ 5×) | 8 phase handlers + `ScenarioLoader` + `TemplateExpander` + `JSONResponseParser` + `ScoreCalcHandler`; `AsyncStream<SimulationEvent>` ergonomics is the named checkpoint risk (§6) |
+| Data port (if shared) | ~2 weeks (≈ 3×) | GRDB has no KMP equivalent — Data sharing may stay Swift-side; sizing assumes a KMP persistence abstraction, which itself needs a separate decision |
+| Interop hardening | ~1 week | SKIE evaluation (§7 Q1) + Sendable `commonMain` upstream + Q9 shim budget re-measure on the full Engine surface |
+
+These are order-of-magnitude planning inputs, not committed estimates; the
+PR-sequence skeleton and binding/SKIE/NPU decisions belong to the separate
+Phase 3.0 planning issue (#220 Post-Spike Actions).
+
+### 9.7 W6 merge-PR gate landmine + remaining spike close-out
+
+Two items carry to W6 (the spike's final week, hard-stop 2026-07-09):
+
+1. **`kmp-build-test` CI gate does not fire on `base_ref == 'main'`.** The
+   integration branch's CI condition skips the KMP build/test job on PRs whose
+   base is `main`. The **final integration → main merge PR** would therefore
+   land the KMP module with its tests *skipped*. This must be fixed in the W6
+   merge-PR (adjust the `if:` condition) before merge, or the GO ships
+   unverified KMP code to `main`.
+2. **Rebase + final merge.** `feature/kmp-spike-models` rebases onto `main`
+   before the W6 merge (the spike's `shared/` directory isolates conflict
+   surface). H5/H7 execution (§9.2) is sequenced into the same launch-prep
+   window.
+
+---
+
+## 10. References
 
 - [ADR-001 §7](ADR-001.md) — `LLMService` protocol design
 - [ADR-001 §12](ADR-001.md) — Platform strategy section
@@ -499,3 +690,5 @@ supports.
 - [SKIE — Swift Kotlin Interface Enhancer (Touchlab)](https://skie.touchlab.co/)
 - [Llamatik — KMP on-device LLM](https://github.com/ferranpons/llamatik)
 - [Kotlin Multiplatform — SwiftUI interop docs](https://kotlinlang.org/docs/multiplatform/compose-swiftui-integration.html)
+- [ADR-012](ADR-012.md) — YAML strategy post-kaml (snakeyaml-engine-kmp); the shared Models layer's YAML codec decision validated by the same spike
+- [Issue #220](https://github.com/tyabu12/pastura/issues/220) — KMP Models Layer Validation spike; GO/NO-GO criteria + W1–W4 checkpoint evidence synthesized in §9

--- a/docs/decisions/ADR-004.md
+++ b/docs/decisions/ADR-004.md
@@ -532,8 +532,9 @@ maps to canonical H6 (≤ 10 MB); canonical H5 (ASC archive upload) and
 canonical H7 (crash symbolication) were never executed and are DEFER (§9.2).**
 A reader cross-checking the immutable checkpoint comments must apply this
 mapping — the checkpoint's "H5 ✅ 31 MB" is a footprint reading, not an ASC
-upload. (There is **no H3** in the hypothesis table; the original H1/H2/H3
-framing resolved to H2 + Tier-4 during the spike.)
+upload. (There is **no H3** in the hypothesis table — verifiable in #220's
+GO/NO-GO Criteria; the W4 PR-C checkpoint (4639563985) notes the earlier
+informal "H1/H2/H3" framing resolved to H2 + Tier-4.)
 
 ### 9.1 Tier-1 hard blockers — results (canonical numbering)
 
@@ -541,7 +542,7 @@ framing resolved to H2 + Tier-4 during the spike.)
 |---|---|---|---|
 | **H1** | All `Models/` types (17 files / 21 types, ~1020 LOC) represented in KMP, no Swift-only fallback | ✅ **PASS** | W2 PR-A: 17 files / 21 types ported to `commonMain` |
 | **H2** | Semantic Codable roundtrip equivalence across preset fixtures (canonicalized, not byte-identical) | ✅ **PASS** | JSON axis: W2 PR-B `CanonicalEquivalenceTests`. YAML axis: W4 PR-C ([4639563985](https://github.com/tyabu12/pastura/issues/220#issuecomment-4639563985)) — 4 presets, **zero divergence** |
-| **H4** | `prisoners_dilemma` executes to completion on iOS **device** with KMP Models + `MockLLMService`, identical `SimulationEvent` sequence vs Swift baseline | ⚠️ **N/A (proxied)** | Literal H4 needs the **Engine**, which is out of a Models-only spike's scope (#220 Non-goal). Proxied by H2 (semantic equivalence, GREEN) + encode-perf sub-ms (W4 PR-A: K/N encode ≈ 9 µs, canonicalize ≈ 8 µs, n=50). Literal on-device event-sequence equivalence → Phase 3.0 Engine port. **Not claimed as a pass.** |
+| **H4** | `prisoners_dilemma` executes to completion on iOS **device** with KMP Models + `MockLLMService`, identical `SimulationEvent` sequence vs Swift baseline | ⚠️ **N/A (proxied)** | Literal H4 needs the **Engine**, which is out of a Models-only spike's scope (#220 Non-goal). Proxied by H2 (semantic equivalence, GREEN) + encode-perf sub-ms (W4 PR-A, M-series **simulator / debug build**: K/N encode ≈ 9 µs, canonicalize ≈ 8 µs, n=50). Literal on-device event-sequence equivalence → Phase 3.0 Engine port. **Not claimed as a pass.** |
 | **H5** | Archive builds + uploads to ASC; processing succeeds (no invalid-binary rejection) | ⛔ **DEFER** | **Never executed** — CI `release-build` runs `CODE_SIGNING_ALLOWED=NO` (W3 PR-A), which does not validate ASC submission. See §9.2 |
 | **H6** | `.ipa` size increase ≤ 10 MB vs Swift-only baseline | ✅ **PASS** | W4 PR-B ([4567187252](https://github.com/tyabu12/pastura/issues/220#issuecomment-4567187252)): PasturaShared.framework = **4.1 MB build-products** (41 % of ceiling, 5.9 MB headroom). Build-products over-estimates ASC delivery, so this is conservative |
 | **H7** | Intentional Kotlin crash → symbolicated frames in Xcode Organizer Crashes view (via K/N dSYM) | ⛔ **DEFER** | **Never executed** — appears in no checkpoint; requires a distributed (TestFlight) build. See §9.2 |
@@ -590,25 +591,28 @@ were not measured within the Models-only spike — *not measured*, not *failed*.
 | Q2 | incremental build ≤ 20 s | ◻️ NOT MEASURED | local-dev metric, not captured |
 | Q3 | `jvmTest` ≤ 10 s, all Models suites ported | ✅ PASS | W4 PR-C: **159 tests / 27 classes**, simulator-free (the spike's primary parallelism motivation) |
 | Q4-warm | full CI ≤ 12 min warm | ✅ PASS* | W4 PR-C: 11m20s warm (KMP job 4m36s). *Some runs 13–15 min on `lint-and-test` variance |
-| Q4-cold | full CI ≤ 20 min cold | ✅ PASS | W3: ~7m30s cold-cache slowest-job, 14+ min headroom |
+| Q4-cold | full CI ≤ 20 min, full cache miss | 🟡 PARTIAL | W3 PR-A ([4493897557](https://github.com/tyabu12/pastura/issues/220#issuecomment-4493897557)): measured **17m40s** (warm konan, post-Path-B artifact serialization), only ~2m20s under the ceiling; **true cold konan would breach 20 min** (Watch #3) — needs a konan pre-warm step or a version-bump exception. Tracked for the W6 merge (§9.7) |
 | Q5 | SwiftLint + swift-format hooks functional | ✅ PASS | W3 PR-A: `setup.sh` / pre-commit integration intact |
 | Q6 | SwiftUI Previews with KMP types | ◻️ NOT MEASURED | deferred in W3 (out of PR-A scope); never picked up |
 | Q7 | debugger steps into Kotlin source | ◻️ NOT MEASURED | dev-time interop nicety, not exercised |
 | Q8 | crash symbolicated in debug runs | ◻️ NOT MEASURED | tied to the deferred H7 crash path |
 | Q9 | Swift interop shim ≤ 300 LOC total | 🟡 PARTIAL | 8/21 K/N types exercised; shim well under budget on that surface, but 13/21 types not yet exercised — full-Models shim total is a projection |
 
-**Tally:** 5 PASS (Q1-cold, Q3, Q4-warm, Q4-cold, Q5), 2 PARTIAL (Q1-warm,
-Q9), 4 NOT MEASURED (Q2, Q6, Q7, Q8). Measured-pass ≈ **5/11 (≈ 45 %)**, or
+**Tally:** 4 PASS (Q1-cold, Q3, Q4-warm, Q5), 3 PARTIAL (Q1-warm, Q4-cold,
+Q9), 4 NOT MEASURED (Q2, Q6, Q7, Q8). Measured-pass ≈ **4/11 (≈ 36 %)**, or
 **7/11 (≈ 64 %)** counting partials — **below the literal 80 % gate**.
 
 **Honest framing:** the verdict is a **Conditional GO on the measured Tier-2
 subset** — every gate that *was* measured passes or partially passes, and the
 4 unmeasured gates are local-developer-ergonomics (Q2/Q6/Q7) plus crash
 symbolication (Q8, which rides on the deferred H7), none of them KMP
-viability blockers. The spike's headline Tier-2 motivation — simulator-free
-business-logic test execution (Q3) — is firmly green. The operator judged the
-measured evidence sufficient for Conditional GO; the unmeasured gates join
-H5/H7 as post-merge / Phase-3.0-entry verification, not silent passes.
+viability blockers. Two of the partials carry real watches: **Q4-cold** breaches
+the 20-min CI ceiling under full cache miss (konan pre-warm needed — §9.7), and
+**Q9**'s shim budget is proven on only 8/21 types. The spike's headline Tier-2
+motivation — simulator-free business-logic test execution (Q3) — is firmly
+green. The operator judged the measured evidence sufficient for Conditional GO;
+the unmeasured gates and the two watched partials join H5/H7 as post-merge /
+Phase-3.0-entry verification, not silent passes.
 
 ### 9.4 Tier-3 migration-cost observations (O1–O5)
 

--- a/docs/decisions/ADR-012.md
+++ b/docs/decisions/ADR-012.md
@@ -1,0 +1,106 @@
+# ADR-012: YAML Parsing Strategy for the Shared Models Layer — snakeyaml-engine-kmp (post-kaml)
+
+> **Status:** Accepted
+> **Date:** 2026-06-11 (recorded). Decision locked at KMP-spike Day-1
+> (#220 D3, ~2026-04-23, issue filing); cross-language fidelity validated
+> GREEN in W4 PR-C (2026-06-07, PR #491).
+> **Context:** The KMP Models spike (#220, under [ADR-004](ADR-004.md)) needs
+> a multiplatform YAML 1.2 parser for the shared `Models/` layer
+> (`commonMain` + `iosMain` + `jvmMain`). The Swift side parses preset YAML
+> with Yams; the Kotlin side needs an equivalent. **kaml**
+> (`charleskorn/kaml`) — the de-facto kotlinx-serialization YAML library —
+> was archived by its maintainer on 2025-11-30 (read-only, no longer
+> maintained), forcing a parser-selection decision.
+
+> **Number note:** #220 T9 reserved this record as "ADR-008". That number was
+> taken by [ADR-008](ADR-008.md) (RouteHint) before this record was written,
+> so it lands as ADR-012. A future reader chasing an "ADR-008 YAML"
+> reference from #220 should land here.
+
+---
+
+## Decision
+
+1. **Adopt `snakeyaml-engine-kmp`** (maven `it.krzeminski:snakeyaml-engine-kmp`,
+   pinned `4.0.1`) as the YAML 1.2 parser for the shared Models layer.
+2. **Isolate it behind a `YamlCodec` interface** — a single commonMain file
+   (`shared/models/src/commonMain/kotlin/com/pastura/models/YamlCodec.kt`)
+   exposing `decode(yaml: String): JsonElement`. The concrete
+   `SnakeYamlEngineCodec` `object` is the only binding to the library, so the
+   swap cost on abandonment is confined to one file.
+3. **Fallback plan (risk R1):** if snakeyaml-engine-kmp is abandoned, parse
+   YAML in Swift (Yams) and pass JSON to Kotlin — the JSON tree is already
+   the canonical cross-language interchange shape, so the Kotlin side would
+   lose only its independent YAML-parse path, not the model layer itself.
+
+## Why this shape
+
+### Why not kaml
+
+- **Archived.** `charleskorn/kaml` went read-only on 2025-11-30; the
+  maintainer states they no longer use or maintain it and welcome forks.
+  Founding a Phase-3 multi-platform layer on an unmaintained dependency is a
+  standing liability.
+- **JVM-only in practice — the decisive reason.** Even pre-archival, kaml
+  fully supports only Kotlin/JVM; non-JVM targets are not supported
+  (`charleskorn/kaml#232`), and JS/Wasm are flagged "highly experimental."
+  The spike needs `iosMain` (Kotlin/Native), which kaml could not serve
+  **regardless of its maintenance status**. The archival merely removes any
+  "wait for it to improve" option.
+
+### Why snakeyaml-engine-kmp
+
+- **Genuine multiplatform.** Its `Load` API is exposed in `commonMain` across
+  JVM + Native (iOS) + JS + Wasm, so a single commonMain implementation
+  suffices — **no `expect`/`actual`** (the library does the multiplatform
+  lift). Confirmed in the `YamlCodec.kt` header doc and the absence of any
+  `iosMain` codec source.
+- **Tree-shaped output.** It decodes YAML to an untyped tree, which the codec
+  maps to a kotlinx `JsonElement` — matching the spike's canonical
+  interchange format consumed by the W2 PR-B canonicalizer.
+- **Maintained.** The spike's W0 + W3 prerequisites gated on upstream
+  activity (≥1 commit in the trailing 3 months on
+  `krzema12/snakeyaml-engine-kmp`); both checks cleared.
+
+### Why the YamlCodec abstraction (D3)
+
+The interface is the **mechanism that makes R1 cheap**: a future swap (to a
+maintained fork, or to the Swift-side fallback) replaces one file's
+`SnakeYamlEngineCodec` binding, not call sites scattered through the Models
+layer. This is a mechanism contract, not a pinned-library bet
+(`.claude/rules/adr-writing.md` § "Mechanism contract over pinned model
+thresholds" — same shape, applied to a dependency rather than a model gate).
+
+## Validation
+
+- **Tier-4 YAML fidelity — GREEN (W4 PR-C, PR #491).**
+  snakeyaml-engine-kmp parses all 4 base preset YAMLs to a canonical
+  `JsonElement` tree byte-identical to Swift `Yams` — **zero cross-language
+  divergence**. The Swift-side Yams fallback (Decision 3) is therefore not
+  needed on fidelity grounds; it remains a maintenance-risk contingency only.
+- **Latent edge (not a current divergence):** `X.0` float-text rendering
+  differs between Swift `JSONSerialization` (`"2"`) and Kotlin
+  (`JsonPrimitive(2.0).content` → `"2.0"`). No current preset has an `X.0`
+  float (`probability: 0.5` renders identically on both sides), so this is a
+  **latent** RED that would surface *legitimately* if such a preset is added —
+  not a flake. (W4 PR-C Spike Finding #4.)
+
+## Consequences
+
+- The Models layer's YAML dependency is a single maintained library behind a
+  one-file abstraction; the Phase-3 swap cost is bounded.
+- This decision is **independent of the KMP GO/NO-GO outcome.** Per #220
+  Post-Spike Actions, the YAML-strategy record is preserved whether the spike
+  is GO or NO-GO — the kaml-archival problem and its resolution outlive the
+  KMP question.
+- No Swift-side change: the iOS app keeps parsing preset YAML with Yams;
+  snakeyaml-engine-kmp lives entirely in the Kotlin shared module.
+
+## Related
+
+- Issue #220 — KMP Models spike (D3 parser decision, T9 record deliverable, R1 abandonment risk)
+- [ADR-004](ADR-004.md) — Multi-platform strategy; this codec serves its shared Models layer
+- [ADR-008](ADR-008.md) — RouteHint; holds the number #220 T9 originally reserved for this record
+- W4 PR-C / PR #491 — cross-language YAML fidelity validation (GREEN)
+- [`charleskorn/kaml`](https://github.com/charleskorn/kaml) — archived 2025-11-30 (the displaced library; non-JVM targets unsupported per `#232`)
+- [`krzema12/snakeyaml-engine-kmp`](https://github.com/krzema12/snakeyaml-engine-kmp) — adopted parser (maven `it.krzeminski:snakeyaml-engine-kmp`)

--- a/docs/decisions/ADR-012.md
+++ b/docs/decisions/ADR-012.md
@@ -102,5 +102,5 @@ thresholds" — same shape, applied to a dependency rather than a model gate).
 - [ADR-004](ADR-004.md) — Multi-platform strategy; this codec serves its shared Models layer
 - [ADR-008](ADR-008.md) — RouteHint; holds the number #220 T9 originally reserved for this record
 - W4 PR-C / PR #491 — cross-language YAML fidelity validation (GREEN)
-- [`charleskorn/kaml`](https://github.com/charleskorn/kaml) — archived 2025-11-30 (the displaced library; non-JVM targets unsupported per `#232`)
+- [`charleskorn/kaml`](https://github.com/charleskorn/kaml) — archived 2025-11-30 (the displaced library; non-JVM targets unsupported per [`charleskorn/kaml#232`](https://github.com/charleskorn/kaml/issues/232))
 - [`krzema12/snakeyaml-engine-kmp`](https://github.com/krzema12/snakeyaml-engine-kmp) — adopted parser (maven `it.krzeminski:snakeyaml-engine-kmp`)


### PR DESCRIPTION
## Summary
- Amends **ADR-004** Draft → **Accepted (Conditional GO)** on #220 KMP Models
  spike evidence; adds §9 GO/NO-GO synthesis.
- Adds **ADR-012** — YAML strategy post-kaml (snakeyaml-engine-kmp).
- Registers ADR-012 + updates ADR-004 status in CLAUDE.md.

Verdict = **Conditional GO** (operator-owned): Models-layer Tier-1 green
(H1/H2/H6/H8), H4 proxied, **H5/H7 deferred** as executable-but-unexecuted
ASC-onboarding actions. Tier-2 honest tally: 4/11 measured-pass (unmeasured ≠
failed) — Conditional GO on the measured subset.

## For reviewers
- §9.0 reconciles canonical (#220) vs checkpoint hypothesis numbering — the
  immutable W4 PR-B checkpoint relabels footprint as "H5/H6".
- Pre-impl + PR-diff `critic` (Opus) both run; `code-reviewer` (Opus) PASS.
- W6 carry-forward documented (§9.7): `kmp-build-test` `if:`-gate fix + rebase
  + H5/H7 execution + final main merge.

## Scope / merge
- **docs-only** (3 files: ADR-004, ADR-012, CLAUDE.md). Target =
  `feature/kmp-spike-models` (integration). **Part of #220** — final main
  merge is W6 (no `Closes`).

## Test plan
- No code change; CI `lint-and-test` + KMP build (no Swift/`shared/` touched →
  expected green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
