### PR TITLE
📚 docs: record LiteRT-LM migration trigger fired (ADR-002 + ADR-004)

### DIFF
--- a/docs/decisions/ADR-002.md
+++ b/docs/decisions/ADR-002.md
@@ -4,6 +4,7 @@
 > **Date:** 2026-04-08
 > **Context:** Phase 1 MVP requires on-device LLM inference for TestFlight distribution.
 > LiteRT-LM Swift SDK is not yet released; its C API lacks iOS GPU support.
+> **Migration trigger:** Fired 2026-06-11 (LiteRT-LM v0.12.0 — Swift SDK + iOS Metal GPU). Decision remains in force pending the migration evaluation (#496). See §8.2.
 
 ## Summary
 
@@ -29,6 +30,14 @@ Migrate to LiteRT-LM when the official Swift SDK ships with iOS GPU support.
   CPU-only mode yields ~9.7 tok/s for E4B (the larger 4B variant) on iPhone — usable but suboptimal.
 - AI Edge Gallery iOS app exists on App Store (uses LiteRT-LM C/C++ API internally)
   but its source code is not public ([gallery Issue #420](https://github.com/google-ai-edge/gallery/issues/420)).
+
+> **Update (2026-06-11):** The status table's `Swift | In Dev ("Coming Soon")` row and
+> the "no SwiftPM package", "GPU inference unavailable on iOS", and "iOS prebuilts
+> missing" claims above were the state *as of 2026-04-08*. LiteRT-LM
+> v0.12.0 (2026-05-18) resolved all three — an official SwiftPM package with iOS Metal
+> GPU now ships — firing the §8 migration trigger. The bullets are retained as the
+> original decision rationale; see §8.2 for the current state and the migration
+> evaluation (#496).
 
 Reference: [Zenn article on LiteRT-LM iOS integration](https://zenn.dev/yoshitetsu/articles/ac05dc4a71650d)
 documents the C API build process (Bazel, 609 static libs, 360 MB unified archive, `-force_load`,
@@ -314,11 +323,49 @@ in full (with its own constraints and rationale) only when ADR-004 is
 accepted; until then, ADR-002's Accepted §8 migration plan remains
 iOS-scoped as originally committed.
 
+### 8.2 Migration trigger fired — evaluation in progress (2026-06-11)
+
+The §8 trigger condition (*"LiteRT-LM Swift SDK ships with iOS GPU
+support"*) is **met**. The condition was first satisfied by LiteRT-LM
+**v0.12.0 (released 2026-05-18)**, which ships an official Swift API via
+SwiftPM (`github.com/google-ai-edge/LiteRT-LM`, minimum `0.12.0`) with
+**Metal GPU acceleration** on iOS (`EngineConfig(backend: .gpu)`). This
+ADR records the trigger on **2026-06-11**, verified against the
+[Swift API documentation](https://developers.google.com/edge/litert-lm/swift)
+(last updated 2026-06-01) and the v0.12.0 release notes. Two later
+releases already exist — v0.13.0 (2026-06-02) added macOS support to the
+same Swift package, and v0.13.1 (2026-06-03) is the latest — but v0.12.0
+is the first version meeting the trigger, so it is cited as the trigger
+version. The macOS addition is relevant to the ADR-004 cross-platform
+story, not to the iOS trigger.
+
+This does **not** by itself change the Accepted decision: llama.cpp
+remains the active production backend until the migration evaluation
+completes. The evaluation — PoC `LiteRTLMService` behind the
+`LLMService` protocol (ADR-001 §7), real-device tok/s benchmark vs the
+current llama.cpp Metal backend, an iOS deployment-target check against
+Pastura's iOS 17.0 floor, the GGUF → `.litertlm` model path, streaming
+parity (§10), and a 0.x-semver API-stability assessment — is tracked in
+**#496**.
+
+Reframing of the §8 monitoring pointers:
+
+- [LiteRT-LM Issue #1050](https://github.com/google-ai-edge/LiteRT-LM/issues/1050)
+  remains **OPEN but no longer blocks the iOS trigger**. Its scope is a
+  third party source-building GPU accelerator plugins / language bindings
+  for cross-platform distribution and hitting ABI mismatches — not the
+  official prebuilt SwiftPM package Pastura consumes. It stays relevant
+  only to the source-build / KMP cross-platform path (ADR-004 §3.6).
+- §8.1 records that the iOS-first-vs-synchronised-KMP **sequencing
+  remains open** pending ADR-004 acceptance (still Draft); it does not yet
+  settle that question. The #496 evaluation must resolve the sequencing
+  before any migration begins.
+
 ### Monitoring
 
 Track these for migration readiness:
-- [LiteRT-LM releases](https://github.com/google-ai-edge/LiteRT-LM/releases) — watch for Swift SDK
-- [LiteRT-LM Issue #1050](https://github.com/google-ai-edge/LiteRT-LM/issues/1050) — iOS GPU prebuilts
+- [LiteRT-LM releases](https://github.com/google-ai-edge/LiteRT-LM/releases) — ✅ Swift SDK + iOS GPU shipped (v0.12.0, 2026-05-18); evaluation tracked in #496 (see §8.2)
+- [LiteRT-LM Issue #1050](https://github.com/google-ai-edge/LiteRT-LM/issues/1050) — source-build GPU plugins (cross-platform / KMP only; does not block the iOS official SwiftPM path — see §8.2)
 - [Gallery Issue #420](https://github.com/google-ai-edge/gallery/issues/420) — iOS source code
 
 ---

--- a/docs/decisions/ADR-004.md
+++ b/docs/decisions/ADR-004.md
@@ -304,6 +304,20 @@ ADR-002's migration plan. The revision is a narrowing of "which
 backend does Option A's `actual` pick for Phase 3.0" — not a
 divergence from the protocol abstraction ADR-002 §8 relies on.
 
+**Update (2026-06-11) — iOS trigger fired:** LiteRT-LM v0.12.0
+(2026-05-18) shipped the official Swift SDK with iOS Metal GPU,
+satisfying the "Swift SDK + iOS GPU ships" condition this section
+treats as future (ADR-002 §8.2). This does **not** revise the §3.6
+lean — the unified-llama.cpp-first rationale rests on launch-phase
+triage symmetry, not on LiteRT-LM's unavailability. What changes: the
+point-3 "if it never ships" branch is now moot for iOS, and the
+Post-Phase-3.0 sequencing question (iOS-first vs synchronised) is live
+rather than hypothetical. The cross-platform binding question
+(source-built LiteRT-LM GPU plugins / ABI — LiteRT-LM #1050) stays the
+relevant blocker for the KMP path. The iOS-side evaluation is tracked
+in #496; resolve the sequencing when this ADR is formally adopted at
+the Phase 2 → Phase 3 transition.
+
 ---
 
 ## 4. Decision (tentative — see §8)


### PR DESCRIPTION
## Summary

Records across the two ADRs that reference the LiteRT-LM migration trigger that it has **fired**: LiteRT-LM **v0.12.0 (2026-05-18)** shipped an official Swift API via SwiftPM with **iOS Metal GPU** (`EngineConfig(backend: .gpu)`), satisfying the original *"migrate when the Swift SDK ships with iOS GPU support"* condition.

Documentation-only. The Accepted decision is **unchanged** — llama.cpp remains the active production backend until the migration evaluation (#496) completes.

### ADR-002 (the trigger record)
- **Status block**: `Migration trigger: Fired 2026-06-11` marker (Status itself stays `Accepted`).
- **New §8.2** "Migration trigger fired — evaluation in progress": records the trigger (v0.12.0), distinguishes release date (2026-05-18) from ADR-record date (2026-06-11), notes v0.13.x exists (macOS — ADR-004 relevance only), routes the go/no-go to #496, and records the iOS-first-vs-synchronized-KMP sequencing as open pending ADR-004 acceptance.
- **§1 reconciliation**: a dated Update note reframes the now-stale "no SwiftPM / iOS GPU unavailable / prebuilts missing" claims (and the status-table `Swift` row) as the state *as of 2026-04-08*, retained as original rationale.
- **§8 Monitoring list**: Swift SDK ✅ shipped; LiteRT-LM #1050 reframed as source-build / KMP scope only.

### ADR-004 §3.6 (the KMP backend pointer)
- A light dated **Update** note so the next person touching the KMP backend direction factors in the now-shipped iOS SDK. Explicitly does **not** revise the §3.6 unified-llama.cpp-first lean (that rests on launch-phase triage symmetry, not LiteRT-LM availability) — it flags that the "if it never ships" branch is moot for iOS and the sequencing question is now live, tracked in #496.

### Verification
All fact-claims verified 2026-06-11 via `gh release view` (v0.11.0–v0.13.1) and the [official Swift API docs](https://developers.google.com/edge/litert-lm/swift) (updated 2026-06-01). Cross-references (ADR-001 §7, ADR-004 §3.6, ADR-002 §8.1/§10/§8.2) confirmed to resolve.

## Test plan
- Documentation-only; no code or tests changed.
- Pre-commit hook (swiftlint + build) passed.
- Plan critic (pre-impl) + Opus `code-reviewer` (PASS, 0 critical / 0 warning) run via `/orchestrate`.

See #496 (LiteRT-LM migration evaluation — kept open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
