### PR TITLE
🔧 chore: inherit session model in harness skills (Fable 5)

### DIFF
--- a/.claude/rules/subagent-usage.md
+++ b/.claude/rules/subagent-usage.md
@@ -22,8 +22,24 @@ Per-model output cap:
 | Opus 4.x | **32,000** |
 | Sonnet 4.x | **64,000** |
 | Haiku 4.x | 8,192 |
+| Fable 5 | **undocumented** — see note below |
 
 Raising frontmatter `maxTurns` does not help — the cap is on output tokens, not turns.
+
+**Fable 5's subagent cap is undocumented** (as of 2026-06-11; revalidate
+via the #24055 tracker above). `fable` is a valid `Agent(model:)` /
+frontmatter alias ([sub-agents docs](https://code.claude.com/docs/en/sub-agents.md)),
+but until its cap is verified, treat a `fable` override as a quality
+lever only — Sonnet's 64K remains the only known **budget** escape
+valve (§3).
+
+`code-reviewer.md` / `critic.md` keep explicit `model: opus` frontmatter
+deliberately — the `SCOPE_TOO_LARGE` bail-outs (§4) and the §2 budgets
+are calibrated to Opus's 32K cap. Skills (`/orchestrate`, `/write-adr`)
+instead omit `model:` and inherit the session model
+([model-config docs](https://code.claude.com/docs/en/model-config.md)) —
+a skill-level pin would downgrade the main loop whenever the session
+runs a stronger model.
 
 ## 2. Caller-side scope discipline
 

--- a/.claude/rules/subagent-usage.md
+++ b/.claude/rules/subagent-usage.md
@@ -26,20 +26,14 @@ Per-model output cap:
 
 Raising frontmatter `maxTurns` does not help — the cap is on output tokens, not turns.
 
-**Fable 5's subagent cap is undocumented** (as of 2026-06-11; revalidate
-via the #24055 tracker above). `fable` is a valid `Agent(model:)` /
-frontmatter alias ([sub-agents docs](https://code.claude.com/docs/en/sub-agents.md)),
-but until its cap is verified, treat a `fable` override as a quality
-lever only — Sonnet's 64K remains the only known **budget** escape
-valve (§3).
-
-`code-reviewer.md` / `critic.md` keep explicit `model: opus` frontmatter
-deliberately — the `SCOPE_TOO_LARGE` bail-outs (§4) and the §2 budgets
-are calibrated to Opus's 32K cap. Skills (`/orchestrate`, `/write-adr`)
-instead omit `model:` and inherit the session model
-([model-config docs](https://code.claude.com/docs/en/model-config.md)) —
-a skill-level pin would downgrade the main loop whenever the session
-runs a stronger model.
+**Fable 5 note**: `fable` is a valid `Agent(model:)` / frontmatter
+alias, but its subagent cap is undocumented (2026-06-11) — treat a
+`fable` override as a quality lever; Sonnet 64K stays the only known
+**budget** escape valve (§3). `code-reviewer.md` / `critic.md` keep
+`model: opus` deliberately (§2 / §4 are 32K-calibrated); skills omit
+`model:` and inherit the session model (a pin would downgrade the main
+loop). Docs: [sub-agents](https://code.claude.com/docs/en/sub-agents.md),
+[model-config](https://code.claude.com/docs/en/model-config.md).
 
 ## 2. Caller-side scope discipline
 

--- a/.claude/rules/subagent-usage.md
+++ b/.claude/rules/subagent-usage.md
@@ -32,7 +32,8 @@ alias, but its subagent cap is undocumented (2026-06-11) — treat a
 **budget** escape valve (§3). `code-reviewer.md` / `critic.md` keep
 `model: opus` deliberately (§2 / §4 are 32K-calibrated); skills omit
 `model:` and inherit the session model (a pin would downgrade the main
-loop). Docs: [sub-agents](https://code.claude.com/docs/en/sub-agents.md),
+loop; re-pin only if the session model ever drops below Opus-class).
+Docs: [sub-agents](https://code.claude.com/docs/en/sub-agents.md),
 [model-config](https://code.claude.com/docs/en/model-config.md).
 
 ## 2. Caller-side scope discipline

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: orchestrate
 description: Orchestrate feature implementation from plan to PR — worktree isolation, TDD, review, and PR creation.
-model: opus
 allowed-tools: Read, Grep, Glob, Bash, Agent, Write, Edit, EnterWorktree, ExitWorktree
 argument-hint: "[description | issue-number | phase N]"
 ---

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -39,7 +39,7 @@ After fetching the issue, check for an existing plan comment:
    - Parse checkboxes: count `- [x]` (done) vs `- [ ]` (remaining). Identify `NEXT_ITEM` (first unchecked item number).
    - Extract `TASK_TYPE`, branch name, and `REVIEWER_MODEL` from the `## Metadata` section in the comment. **Normalize `REVIEWER_MODEL` to lowercase** (`opus` / `sonnet`) when binding — Metadata records it title-case (`Opus` / `Sonnet`) for readability, but downstream Agent calls use lowercase. If `Reviewer` is absent from Metadata (e.g., older plan comment pre-dating this field), default `REVIEWER_MODEL=opus`.
    - Derive `SLUG` from the branch name.
-   - **Coupling re-check**: if the resumed plan contains any `🔴` item but `REVIEWER_MODEL=sonnet` (e.g., from a post-plan Metadata edit that bypassed the Step 1 coupling rule), warn the user and offer to upgrade to Opus before continuing — that is, before proceeding to Step 2 in the normal flow, or before the Step 4 review when all items are already complete. Reason: Opus-implemented items should never be Sonnet-reviewed.
+   - **Coupling re-check**: if the resumed plan contains any `🔴` item but `REVIEWER_MODEL=sonnet` (e.g., from a post-plan Metadata edit that bypassed the Step 1 coupling rule), warn the user and offer to upgrade to Opus before continuing — that is, before proceeding to Step 2 in the normal flow, or before the Step 4 review when all items are already complete. Reason: orchestrator-implemented items should never be Sonnet-reviewed.
    - If **all items are already checked**: ensure you are on the feature branch or in the correct worktree, then report "All {TOTAL} items already complete. Proceeding to review." and **skip to Step 4** directly.
    - Report to user: "Found existing plan on issue #N. {DONE}/{TOTAL} items complete. Resuming from item {NEXT_ITEM}."
    - **Skip Step 1 and Step 1b entirely** → proceed to Step 2.
@@ -61,8 +61,8 @@ After fetching the issue, check for an existing plan comment:
 3. Format the plan as a numbered checkbox list (each item = one planned commit).
    Assign a **complexity label** to each item:
    - 🟢 **simple** — Delegated to a Sonnet subagent. Criteria: existing pattern reuse (e.g., new Handler mirroring an existing one), test-only changes following an existing test pattern, type/error case additions, doc comments, minor fixes.
-   - 🔴 **complex** — Implemented by the orchestrator (Opus) directly. Criteria: new design patterns, actor isolation / Sendable design decisions, changes spanning multiple layers, work near dependency rule boundaries (Engine ↔ Data), or any item requiring non-obvious architectural judgment.
-   - **When in doubt, classify as 🔴.** Misclassifying a complex item as simple wastes a Sonnet attempt + Opus fallback; the reverse just costs extra Opus tokens.
+   - 🔴 **complex** — Implemented by the orchestrator (session model) directly. Criteria: new design patterns, actor isolation / Sendable design decisions, changes spanning multiple layers, work near dependency rule boundaries (Engine ↔ Data), or any item requiring non-obvious architectural judgment.
+   - **When in doubt, classify as 🔴.** Misclassifying a complex item as simple wastes a Sonnet attempt + orchestrator fallback; the reverse just costs extra orchestrator tokens.
    - **Skip delegation when overhead exceeds the work.** Promote a 🟢 item to 🔴 when subagent prompt + verify overhead likely exceeds the implementation itself — e.g. single-line edits, short doc tweaks. This forces Opus reviewer via the Coupling Rule below — intended, since the orchestrator is implementing the item directly.
 
    ```
@@ -93,7 +93,7 @@ After fetching the issue, check for an existing plan comment:
    - Design token **application** (existing token to existing View only — new token additions are Opus-required)
    - Fix-only PRs where the cause is already diagnosed and localized
 
-   **Coupling rule:** If **any** plan item is labeled 🔴, the reviewer MUST be Opus — even if the target paths look Sonnet-eligible. This prevents the "all-🟢-plus-Sonnet-reviewer" configuration from putting Opus-implemented work through a Sonnet review.
+   **Coupling rule:** If **any** plan item is labeled 🔴, the reviewer MUST be Opus — even if the target paths look Sonnet-eligible. This prevents the "all-🟢-plus-Sonnet-reviewer" configuration from putting orchestrator-implemented work through a Sonnet review.
 
    **When in doubt, pick Opus.** Subtle convention violations (ShapeStyle+Color token trap, `nonisolated` gaps, i18n `String(localized:)` omissions, missing `@Suite(.timeLimit(.minutes(1)))` on new test suites) cost more than an over-zealous Opus review.
 
@@ -269,7 +269,7 @@ Subagent invocation budget is governed by `.claude/rules/subagent-usage.md` — 
 4. Commit (Conventional Commits + emoji per CLAUDE.md). The commit triggers the user approval gate.
 5. Sync checkpoint to GitHub Issue (same `gh api` PATCH as the complex flow above).
 
-**Fallback:** If the Sonnet subagent reports test failure (could not make tests pass), **Opus takes over immediately** — do not retry with Sonnet. Read the Sonnet error output to understand what was attempted. Then handle partial changes:
+**Fallback:** If the Sonnet subagent reports test failure (could not make tests pass), **the orchestrator takes over immediately** — do not retry with Sonnet. Read the Sonnet error output to understand what was attempted. Then handle partial changes:
 - Run `git stash -u` to save all of Sonnet's work including untracked new files (recoverable via `git stash pop` if needed later).
 - Complete the item directly using the 🔴 complex-item flow.
 
@@ -293,7 +293,7 @@ After all implementation, run full verification directly from the main session:
 
 ## Step 4: Review — Gate G3
 
-Launch a `code-reviewer` subagent via the Agent tool to review all changes on the feature branch. Pass `model: $REVIEWER_MODEL` (resolved from the plan's `## Metadata` — via Step 0 on resumption, or via Step 1 on a fresh run; defaults to Opus if absent). The Agent tool's `model` parameter takes precedence over the agent frontmatter's `model: opus`. The agent's checklist was enriched with a Pastura-specific trap cheat sheet in this same PR to keep the Sonnet-reviewer path safe.
+Launch a `code-reviewer` subagent via the Agent tool to review all changes on the feature branch. Pass `model: $REVIEWER_MODEL` (resolved from the plan's `## Metadata` — via Step 0 on resumption, or via Step 1 on a fresh run; defaults to Opus if absent). The Agent tool's `model` parameter takes precedence over the agent frontmatter's `model: opus`. The agent's checklist carries a Pastura-specific trap cheat sheet to keep the Sonnet-reviewer path safe.
 
 ```
 Agent(subagent_type: "code-reviewer", model: "$REVIEWER_MODEL", description: "...", prompt: "...")

--- a/.claude/skills/write-adr/SKILL.md
+++ b/.claude/skills/write-adr/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: write-adr
 description: Generate an Architecture Decision Record and save it to docs/decisions/.
-model: opus
 allowed-tools: Read, Grep, Glob, Write, Edit, Agent
 argument-hint: "<title>"
 ---


### PR DESCRIPTION
## Summary
- Remove `model: opus` frontmatter from `/orchestrate` and `/write-adr` so they inherit the session model. The pins were no-ops when Opus was the top model; with the session default now Claude Fable 5, they actively downgraded the main loop during skill execution (skill frontmatter `model:` switches the main-loop model — [model-config docs](https://code.claude.com/docs/en/model-config.md)).
- Reword implementer-sense "Opus" in the orchestrate body to "orchestrator (session model)". The reviewer scheme is deliberately untouched: `REVIEWER_MODEL` stays opus/sonnet, the Coupling rule and Opus-required path list are unchanged, and 🟢 items still delegate to a Sonnet subagent.
- `.claude/rules/subagent-usage.md`: add Fable 5 to the subagent output-cap table (cap undocumented as of 2026-06-11; revalidate via anthropics/claude-code#24055, still open) and record why `code-reviewer` / `critic` keep their `model: opus` pins (SCOPE_TOO_LARGE machinery is calibrated to the Opus 32K cap) while skills inherit. A `fable` override stays a quality lever, not budget headroom — Sonnet 64K remains the only known escape valve.

## Test plan
- [x] Markdown/tooling-only change — no Swift sources touched; pre-commit build + `swiftlint lint --strict` passed on every commit
- [x] Grep verified: remaining "Opus" in `orchestrate/SKILL.md` is reviewer-sense only (REVIEWER_MODEL binding, Coupling rule, Opus-required list); implementer-sense occurrences are zero
- [x] External facts verified 2026-06-11: `fable` is a valid Agent-tool / frontmatter alias (live tool schema + [sub-agents docs](https://code.claude.com/docs/en/sub-agents.md)); #24055 still open
- [x] code-reviewer (Opus): PASS, 0 issues

Closes #498

🤖 Generated with [Claude Code](https://claude.com/claude-code)