### PR TITLE
📚 docs: promote xcstrings catalog traps into i18n.md (round 5)

### DIFF
--- a/.claude/rules/i18n.md
+++ b/.claude/rules/i18n.md
@@ -87,6 +87,8 @@ surfaces.
 
 The `en` block is Apple's disambiguated positional form, kept as a translator reference. **Add the `ja` block as a sibling under `localizations`, never replace the `en` block.** Single-arg keys (`"%@ is thinking..."`) get an empty body — insert the full `localizations.ja.stringUnit` structure.
 
+Empty-body (`"Key" : { }`, no `localizations` block at all) is in fact the dominant *freshly-extracted* shape: multi-arg keys land empty too on first extract, **before** a later sync settles them into the positional-`en` form shown above. So don't grep `state : "new"` to find new keys — that misses the empty-body shape. `git diff` the catalog and treat any newly-added key (empty-body OR `state:"new"`) as needing a `ja` block.
+
 ## `%arg` placeholder and partial-conversion orphans
 
 ### What `%arg` means
@@ -165,6 +167,28 @@ Editing `Localizable.xcstrings` programmatically via Python `json.loads(...)` + 
 - **For programmatic batch edits**: pass `separators=(',', ' : ')` to `json.dumps` so output matches Apple format. Verify by running `xcrun xcstringstool sync` after — should produce zero further drift.
 
 Sanity check after any catalog edit: `git diff --stat Pastura/Pastura/Resources/Localizable.xcstrings` should be proportional to the change. 1000+ lines for a 1–3 key edit means format mismatch.
+
+## Batch ja-fill — preserve shared keys
+
+A Python script that fills `ja` across many catalog keys at once will **silently overwrite** an existing `ja` value. The hazard: short status nouns (`Paused`, `Cancelled`, `Completed` are exact `GameHeaderStatus.label` keys) are not exporter-exclusive — `GameHeaderStatus.label` drives the live status pill on Sim / Demo screens. An export-scoped slice that re-fills one of these shifts the *other* surface's copy without touching its code.
+
+`scripts/check_localization_coverage.py` does **not** catch this: it validates *presence + state + non-emptiness + extractionState*, never *value correctness*. A wrong-but-translated `ja` passes the gate clean, so the drift reaches main silently (caught only by a code-reviewer reading the catalog diff).
+
+**Before a batch ja-fill:** grep every target key's consumers —
+`rg 'String\(localized: "KEY")' Pastura/Pastura --type swift`. A key with ≥2 consumers on different surfaces is **shared**: reuse its prior `ja` verbatim, or split into export-only keys. Make the script idempotent — skip the overwrite when `state == "translated"` and `value` is non-empty. See #382 (a `Paused` ja value shifted under an unrelated export wrap).
+
+## Merge conflicts in the catalog
+
+When parallel PRs add **alphabetically-adjacent** keys, `git merge` produces conflict markers that do **not** respect JSON key boundaries — they land mid-block, splitting both sides' keys across several `<<<<<<< / ======= / >>>>>>>` regions. Cause: the catalog's repeated structure (`"localizations" : { "en" : { "stringUnit" … } }`) gives git's line-level aligner many short anchor matches, so it picks alignment that minimizes line count, not key boundaries.
+
+Don't repair each region in isolation — the markers are line-aligned, not key-aligned. Read the full conflicted span (previous resolved key → next resolved key), then **reconstruct the whole region**: all ours-added + theirs-added + unchanged keys, sorted alphabetically (xcstringstool's canonical order), as a single Edit. Verify with `python3 -c "import json; json.load(open('Pastura/Pastura/Resources/Localizable.xcstrings'))"` + `check_localization_coverage.py`. See #409.
+
+## Sync side-effects safe to ignore at plan time
+
+`scripts/xcodebuild.sh build` auto-runs `xcstringstool sync`, which has two harmless side-effects worth not over-handling:
+
+- **Empty ja-as-source orphans are auto-pruned.** Wrapping a Japanese-hardcoded literal (`Text("準備ができました")` → `String(localized: "Ready")`) leaves the old `"準備ができました" : { }` orphan — but the next sync drops it automatically. Skip the explicit `xcstrings-prune-stale.py` step in a plan when the orphans are empty `{ }`. (Prune is still needed for `extractionState: "stale"` entries that carry populated `localizations` — Apple keeps those for translator reference.)
+- **Trailing LF is stripped.** Sync rewrites the file ending without a final newline. Cosmetic — Xcode and xcstringstool tolerate either form, CI is green either way; ignore unless code review flags it (then `printf '\n' >> …xcstrings`).
 
 ## Audit triage — `.accessibilityLabel` candidates
 


### PR DESCRIPTION
## Summary
Promotes the actionable half of #512's deferred clusters — 4 `Localizable.xcstrings` trap memories + 1 already-covered nuance — into the path-scoped `.claude/rules/i18n.md`, drafted at concept-level register (WHY + invariant + pointer).

- **Batch ja-fill — preserve shared keys**: `Paused`/`Cancelled`/`Completed` are exact `GameHeaderStatus.label` keys shared across Sim/Demo surfaces; the coverage gate validates presence/state/non-emptiness/extractionState, never value correctness, so a batch overwrite drifts silently (see #382).
- **Merge conflicts in the catalog**: git's line-aligner splits markers mid-JSON-block on alphabetically-adjacent keys; reconstruct the whole region (see #409).
- **Sync side-effects safe to ignore**: empty ja-as-source auto-prune + trailing-LF strip.
- Clarified that empty-body is the dominant *freshly-extracted* shape (multi-arg too), distinct from the settled positional-`en` form.

KMP cluster stays gated (`shared/` absent on main, #501 OPEN) — #512 remains open as the tracker.

## Test plan
- Documentation-only (`.claude/rules/i18n.md`, +24 lines); no Swift change.
- Rule-writing self-check executed against main: 4 PR cites MERGED; coverage-gate value-drift claim verified against `check_localization_coverage.py` source; `GameHeaderStatus.label` shared-key claim verified; zero pre-existing coverage of the 4 topics.
- code-reviewer (Opus): PASS, 0 issues.

See #512.

🤖 Generated with [Claude Code](https://claude.com/claude-code)