### PR TITLE
📚 docs: ADR-013 — headless macOS simulation harness (Proposed)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,6 +284,7 @@ same change:
 | `docs/decisions/ADR-010.md`           | Localization (i18n: ja/en) — ADR body for Step C-1 design (Status: Proposed; stub #279, body #367) |
 | `docs/decisions/ADR-011.md`           | 6 GB RAM tier — selection criteria + Phase 2 deferral (no-go for Gemma 3 1B IT; mechanism-contract prerequisites for future candidates; #477 / PR #480 / #483) |
 | `docs/decisions/ADR-012.md`           | YAML strategy post-kaml — snakeyaml-engine-kmp adoption for the shared Models layer (kaml archived; #220 D3 / T9; ADR-008 number drift) |
+| `docs/decisions/ADR-013.md`           | Headless macOS simulation harness — SwiftPM source reuse for the scenario factory (Status: Proposed; #515) |
 | `docs/specs/pastura-mvp-spec-v0_3.md` | MVP specification                                         |
 | `docs/specs/demo-replay-spec.md`      | DL-time demo replay — data format + component design (#152) |
 | `docs/specs/demo-replay-ui.md`        | DL-time demo replay — visual / behaviour spec (#164)        |

--- a/docs/decisions/ADR-013.md
+++ b/docs/decisions/ADR-013.md
@@ -1,0 +1,215 @@
+# ADR-013: Headless macOS Simulation Harness — SwiftPM Source Reuse for the Scenario Factory
+
+> **Status:** Proposed
+> **Date:** 2026-06-13
+> **Context:** The operator wants a nightly "scenario factory" pipeline
+> (scenario generation → headless simulation run → LLM-as-judge scoring →
+> digest) running on a Mac, using otherwise-idle Claude Max capacity.
+> Secondary goals: judge-scored run logs as LP / release-announcement
+> material, a reusable regression-test foundation, and real-data input for
+> context-compression experiments. The pipeline's prerequisite is a way to
+> execute Pastura simulations **without the iOS UI**. This ADR decides that
+> execution mechanism only — the generation / judging pipeline, scheduling,
+> and log schema are out of scope (see §6). Originating issue:
+> [#515](https://github.com/tyabu12/pastura/issues/515).
+
+---
+
+## 1. Decision
+
+1. **Add a repo-root `Package.swift`** defining a SwiftPM package that
+   compiles the existing `Engine/`, `LLM/`, and `Models/` sources for
+   macOS via **path-based targets** — the iOS app's source files are
+   reused in place; nothing is duplicated or extracted.
+2. **Target shape** (validated by a scratch build on 2026-06-13, Swift
+   6.3.2 toolchain, `swift-tools-version: 6.2`):
+   - `PasturaSafeSampler` (Obj-C++): path
+     `Pastura/Pastura/LLM/SafeSampler/`, `publicHeadersPath: "."`.
+     SwiftPM rejects mixed-language targets, so the two Obj-C++ files
+     must live in their own target (and therefore their own directory —
+     core change C1 in §4). `SafeSampler.mm` deliberately declares
+     `llama_sampler_sample` via a manual `extern "C"` prototype instead
+     of including `llama.h` (`SafeSampler.mm:26-37`), so this target
+     needs **no** dependency on llama.cpp headers; the symbol resolves at
+     link time.
+   - `PasturaCore` (Swift): path `Pastura/Pastura`, `sources: ["Models",
+     "LLM", "Engine"]`, `exclude: ["LLM/SafeSampler"]`; depends on
+     `PasturaSafeSampler`, Yams 6.2.2, and LlamaSwift. Swift settings:
+     `.defaultIsolation(MainActor.self)` (mirrors the app target's
+     `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`),
+     `.swiftLanguageMode(.v6)`, and `.define("PASTURA_HARNESS_BUILD")`
+     (consumed by core change C3).
+   - `pastura-harness` (executable): new additive sources under
+     `tools/harness/` (a new directory; SwiftPM target paths must be
+     package-root-relative, which is why the package manifest sits at the
+     repo root). Depends on `PasturaCore` only.
+3. **LLM backend: the existing `LlamaCppService`, unchanged.** The pinned
+   `mattt/llama.swift` 2.8694.0 declares `.macOS(.v13)` and its bundled
+   llama.cpp b8694 xcframework ships a `macos-arm64_x86_64` slice with
+   Metal (verified in the artifact's `Info.plist`). The harness passes an
+   absolute GGUF path via `--model` — `LlamaCppService.init` already takes
+   `modelPath: String` with no Bundle assumptions
+   (`LLM/LlamaCppService.swift:188`).
+4. **Four minimal core changes** (§4) ship in the Phase 1 implementation
+   PR. **This ADR's PR is docs-only**; none of the changes below are made
+   here.
+
+## 2. Scope & phase relationship
+
+The harness is an **internal developer-tooling track orthogonal to the
+product phases**. It is not Phase 2 product scope, not a Phase 2
+completion gate, and not a platform expansion (see the ADR-004 relation
+in §5). It does not appear in `docs/ROADMAP.md`; this ADR plus issue
+#515 are its discoverable home for future scope-reference lookups.
+
+## 3. Why this shape
+
+### Evidence that source reuse works (measured, not assumed)
+
+A scratch SwiftPM package (outside the repo, sources copied) was built on
+2026-06-13:
+
+- All 69 Swift sources across `Models/`, `LLM/`, `Engine/` compiled for
+  macOS arm64 and linked against the llama.cpp macOS slice. The three
+  layers import only Foundation / os / Yams / LlamaSwift; SwiftUI,
+  UIKit, and BackgroundTasks are confined to `App/` and `Views/`.
+- A smoke CLI loaded `Resources/Presets/prisoners_dilemma.yaml` through
+  `ScenarioLoader` on macOS and printed name / personas / rounds /
+  `estimateInferenceCount` (= 45) correctly.
+- The Engine entry point is already harness-shaped:
+  `SimulationRunner.run(scenario:llm:suspendController:) ->
+  AsyncStream<SimulationEvent>` (`Engine/SimulationRunner.swift:108`).
+  Note for Phase 1: `suspendController` has no default — the harness
+  constructs a `SuspendController()` and simply never requests
+  suspension (suspend/resume is App-layer orchestration per ADR-003).
+
+This *exercises* the ADR-001 layering — it proves Engine/LLM/Models are
+iOS-independent — but it does **not** realize per-layer SPM module
+extraction: the three layers compile as one module here, exactly as they
+do in the app target. Inter-layer import boundaries remain enforced by
+convention + review in both builds. A per-layer target split stays a
+future option (§6).
+
+### Alternatives rejected
+
+- **B — macOS/CLI target inside `Pastura.xcodeproj`.** Touches
+  `project.pbxproj`, the highest-contention file across concurrent
+  sessions, and adds risk surface to App Store release preparation. Also
+  binds a tool that should build with `swift build` to `xcodebuild`.
+- **C — iOS Simulator + automation (`simctl` / XCUITest).** Rejected
+  hard: the iOS Simulator cannot run quantized inference at all —
+  simulator Metal reports 0 MiB free and the CPU fallback hits
+  `GGML_ASSERT` → SIGABRT (`.claude/rules/engine.md` § "iOS Simulator
+  cannot run quantized inference", PR #463). On top of that:
+  UI-automation flakiness (see the CI flake catalog in
+  `.claude/rules/xcodebuild-cli.md`) and awkward log extraction.
+- **D — Ollama-backend-only harness.** A different runtime and
+  quantization than the shipping on-device backend, so dogfooding
+  fidelity is lost. `OllamaService` remains available in debug builds
+  (already `#if DEBUG || targetEnvironment(simulator)`-gated) as an
+  optional secondary backend, but llama.cpp + the shipping GGUF is the
+  primary.
+
+## 4. Required core changes (Phase 1 PR, not this one)
+
+All four were validated in the scratch build; app behavior is
+bit-identical in every case.
+
+- **C1 — Move `LLM/SafeSampler.h` + `LLM/SafeSampler.mm` into
+  `LLM/SafeSampler/`** (pure `git mv`;
+  `PBXFileSystemSynchronizedRootGroup` auto-includes, no pbxproj edit)
+  and update the import in `Pastura/Pastura/Pastura-Bridging-Header.h:12`
+  to `"LLM/SafeSampler/SafeSampler.h"`. Reason: the Obj-C++ SwiftPM
+  target needs a dedicated directory (Decision 2).
+- **C2 — Add a guarded import to `LLM/SafeSampler.swift`:**
+  `#if canImport(PasturaSafeSampler) import PasturaSafeSampler #endif`.
+  In the app target the module does not exist (the bridging header
+  supplies the symbols), so the app build is unaffected.
+- **C3 — Change the `SafeSamplerTestHooks` gate in `LLM/SafeSampler.swift`
+  from `#if DEBUG` to `#if DEBUG && !PASTURA_HARNESS_BUILD`.** Reason:
+  SwiftPM `cxxSettings` defines do not propagate to the Swift clang
+  importer, so the `#ifdef DEBUG`-gated C declarations in `SafeSampler.h`
+  are invisible to the package's Swift compile. The hooks exist solely
+  for `PasturaTests/LLM/SafeSamplerTests.swift`; the harness build loses
+  nothing (the production `SafeSampler.sample` path is fully compiled).
+  The flag is never defined in the app target.
+- **C4 — Make `ScenarioLoader` public** (`Engine/ScenarioLoader.swift:13`,
+  currently internal): `public` on the struct, `load(yaml:)`, and
+  `static estimateInferenceCount`, plus an **added** explicit
+  `public init() {}` (no init exists today; the synthesized one is
+  internal). Same treatment for `ScenarioValidator`
+  (`Engine/ScenarioValidator.swift:9`) if the harness validates
+  programmatically. This is the SPM-extraction access-modifier prep
+  CLAUDE.md already anticipates; Hard Rule 3 (doc comments on public
+  types) applies to the newly-public surface.
+
+Model parameters: `LlamaCppService.init` also requires `stopSequence`,
+`modelIdentifier`, and `systemPromptSuffix`. These live on
+`ModelDescriptor` (Models layer, already public) — but the curated
+descriptor list `ModelRegistry` is an internal App-layer enum
+(`App/ModelRegistry.swift:23`), outside the package. Recommended default
+for Phase 1: the harness declares its own `ModelDescriptor` literal
+mirroring the Gemma 4 E2B entry (with a cross-reference comment);
+promoting `ModelRegistry` out of `App/` is **not** required (§6).
+
+## 5. Consequences & relations to existing ADRs
+
+- **Dual build paths must both stay green.** The xcodeproj and the
+  root `Package.swift` compile the same sources, and the harness is the
+  *sole* consumer of `PASTURA_HARNESS_BUILD` and of the package manifest
+  — an iOS-only PR can break the harness build silently, surfacing only
+  at the next nightly run. Phase 1 must pick one of: (a) a CI
+  `swift build` job with the llama.cpp artifact cached (recommended
+  default — but the unpacked xcframework is 555 MB / 101 MB for the
+  macOS slice, and the CI time budget is ≤ 10 min, so measure before
+  committing), or (b) a documented manual pre-merge harness-build check.
+  Recorded as an open question with default (a) in §6.
+- **ContentFilter is intentionally not applied.** ContentFilter is an
+  App-layer policy scoped to *user-visible display surfaces* (ADR-005
+  §5.1: "Every user-visible display surface of LLM output MUST pass
+  through `ContentFilter` before rendering"). Harness output is
+  internal-only operator
+  material and is not such a surface, so §5.1 does not reach it. Any
+  promotion of harness output to a user-facing surface (LP copy, preset
+  YAML, release notes) goes through operator review first; nothing here
+  licenses other surfaces to skip the filter.
+- **ADR-001:** consistent — the harness consumes the documented
+  Engine/LLM/Models layering and its `AsyncStream<SimulationEvent>`
+  contract; it exercises (not realizes) the SPM-extraction preparation.
+- **ADR-002:** same pinned backend package; the macOS slice of the same
+  xcframework. No backend divergence. If the LiteRT-LM migration
+  (ADR-002 §8) replaces `LlamaCppService`, the harness follows the
+  `LLMService` protocol seam like every other consumer.
+- **ADR-003:** silent — suspend/resume is App-layer iOS lifecycle
+  orchestration; the harness runs to completion or is killed.
+- **ADR-004:** orthogonal — an internal dev tool on the existing Swift
+  codebase, not a platform expansion; the KMP shared-Models direction is
+  untouched.
+- **ADR-010:** scenarios fed to the harness must carry the mandatory
+  `language:` field; `Scenario.engineLanguage` resolution already lives
+  in the core layers, so the harness inherits it for free.
+- **ADR-012:** Yams stays the Swift-side YAML parser; the harness uses
+  `ScenarioLoader` + Yams exactly as the app does.
+- **Phase 1 review note:** the implementation PR touches `LLM/` sources,
+  the bridging header, access modifiers across layers, and a new build
+  manifest — Opus-required review territory despite the mechanical look
+  of the `git mv`.
+
+## 6. Out of scope / open questions
+
+Out of scope for this ADR (designed in later phases of #515):
+
+- The scenario-factory skill (generation / judging pipeline, digest
+  format, JSONL log schema) and its scheduling.
+- Regression-suite CI integration of the harness.
+
+Open questions for the Phase 1 PR:
+
+1. **CI guard for the package build** — recommended default: cached
+   `swift build` job; fall back to a documented manual check if the
+   cache cost breaks the ≤ 10 min CI budget.
+2. **Descriptor sourcing** — recommended default: harness-local
+   `ModelDescriptor` literal; revisit promoting `ModelRegistry` only if
+   the harness grows multi-model needs.
+3. **Per-layer SwiftPM target split** (true module-boundary enforcement)
+   — future option, explicitly *not* part of Phase 1.


### PR DESCRIPTION
## Summary

- Phase 0 deliverable for the scenario-factory initiative: decide the headless execution mechanism (ADR-013, Status: Proposed)
- Decision: repo-root SwiftPM package reusing Engine/LLM/Models sources in place; executable `pastura-harness`; llama.cpp backend via the existing `LlamaCppService` (macOS slice of the pinned xcframework)
- Validated by a scratch macOS build (all 69 core Swift sources compiled + linked; smoke CLI loaded `prisoners_dilemma.yaml`); 4 minimal core changes enumerated and deferred to the Phase 1 implementation PR
- Alternatives rejected: xcodeproj macOS target / iOS Simulator automation / Ollama-only backend
- Registers ADR-013 in CLAUDE.md Reference Documents table

## Test plan

- Docs-only — pre-commit gates (swiftlint --strict, xcodebuild build) passed; code-reviewer verified every file:line citation and quoted heading against the worktree

Closes #515

🤖 Generated with [Claude Code](https://claude.com/claude-code)
