### PR TITLE
✨ feat: scenario-factory skill — generate→run→judge→digest cycle

### DIFF
--- a/.claude/skills/scenario-factory/SKILL.md
+++ b/.claude/skills/scenario-factory/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: scenario-factory
+description: Run one scenario-factory cycle — generate 3 fresh scenario YAMLs, execute each on pastura-harness with real local-LLM inference, judge the transcripts in-session, and append the committed digest. Use when the user asks to run the scenario factory, run a factory cycle, generate and field-test new scenarios, or dogfood scenarios overnight.
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash
+---
+
+# /scenario-factory
+
+One full factory cycle: **generate → run → judge → digest** (ADR-013
+Phase 2, #521). Run from the repository root.
+
+Non-goals:
+
+- **No scheduled execution.** This skill never registers itself as a
+  Routine / cron — invocation is manual or via a Phase 3 routine that
+  calls it.
+- **No content-safety screening.** The judge scores quality only; safety
+  is enforced by the blocklist pre-commit gate when a scenario is later
+  promoted under `Resources/Presets/` (see the digest's promotion footer).
+- **No external LLM APIs.** Generation and judging are done by THIS
+  session. Only the local harness (llama.cpp + bundled GGUF) burns
+  inference.
+
+## Constants
+
+- `MODEL`: `~/Models/gemma-4-E2B-it-Q4_K_M.gguf` (sha256 matches the
+  `ModelRegistry` pin)
+- `DATE`: today as `YYYY-MM-DD`; `DATESTAMP`: `YYYYMMDD`
+- Generated YAMLs: `data/factory/scenarios/<DATE>/` (gitignored; kept
+  local for later promotion — do NOT write into `runs/`, that is the
+  harness output dir)
+- Run logs: `data/factory/runs/<DATE>/<id>.jsonl` (gitignored; harness
+  stderr lands in a `.stderr.log` sidecar next to each log)
+- Digest: `data/factory/digest.md` (committed — the cycle's only
+  repo-visible artifact)
+- Per-run timeout: `600` seconds (not the harness default 1800 — bounds a
+  wedged run at 2 attempts × 600 s)
+- Helper scripts: `.claude/skills/scenario-factory/scripts/`
+
+## Step 0 — Preflight
+
+1. `ls ~/Models/gemma-4-E2B-it-Q4_K_M.gguf` — abort with a clear message
+   if the model is missing.
+2. `command -v jq` — required by the run wrapper.
+3. `swift build` once to warm the harness build (incremental afterwards).
+   A build failure aborts the cycle — report it, do not generate.
+
+## Step 1 — Read the digest (dedup)
+
+Read `data/factory/digest.md`. Collect every past scenario **id, name,
+theme, and comment** from the section tables. The new batch must not
+repeat: same premise, same persona cast, or a theme judged ≤2 on humor
+twice in a row. Low-scoring past entries are signals about what NOT to
+generate again; high scorers indicate directions worth varying further.
+
+## Step 2 — Generate 3 scenario YAMLs
+
+Write 3 files to `data/factory/scenarios/<DATE>/<id>.yaml` with
+`id: factory_<DATESTAMP>_<slug>` (snake_case slug, also the filename).
+
+Theme: the **oogiri / comedy family** (current factory focus). Use the
+bundled preset `Pastura/Pastura/Resources/Presets/bokete.yaml` as the
+schema and tone reference, but vary the *format*, not just the topics —
+e.g. constrained-form bokete (kigo / counting / forbidden-word rules),
+role-mismatch interviews, deadpan product pitches, escalating excuse
+battles. Each of the 3 scenarios should differ from the other 2 AND from
+digest history in premise or mechanics, not merely in topic strings.
+
+Schema requirements (ScenarioLoader — all required):
+
+- `id`, `name`, `description`, `language: ja`, `agents`, `rounds`,
+  `context`, `personas` (name + description each; count == `agents`),
+  `phases`
+- Agents 2–10, rounds ≤ 30. Personas need distinct comedic stances
+  (the bokete preset's 【立場】/【目的】+ example-line format works well).
+- LLM phases (`speak_all` / `speak_each` / `vote` / `choose`) need
+  `prompt` + `output` field maps; `vote` needs `exclude_self` thought
+  through; scoring usually wants a `score_calc` (logic: `vote_tally`)
+  and a `summarize`.
+- Plain YAML only — no markdown fences in the file.
+
+Inference budget — compute BEFORE writing each file:
+
+```
+per round: speak_all = agents | speak_each = agents × sub_rounds
+           vote = agents     | choose = agents × 2 (round_robin) / agents
+           code phases (assign / score_calc / eliminate / summarize /
+           event_inject) = 0 | conditional = max(then, else)
+total = per-round sum × rounds   →  target ≤ 50 (hard block > 100)
+```
+
+A bokete-shaped scenario (5 agents, 2 rounds, speak_all + vote) costs 20
+and runs ≈ 4 min; keep the whole batch ≤ ~120 total so the cycle fits the
+night budget even with retries.
+
+## Step 3 — Run each scenario on the harness
+
+Sequentially (one model in RAM at a time), for each generated YAML:
+
+```bash
+bash .claude/skills/scenario-factory/scripts/run_scenario.sh \
+  data/factory/scenarios/<DATE>/<id>.yaml \
+  ~/Models/gemma-4-E2B-it-Q4_K_M.gguf \
+  data/factory/runs/<DATE>/<id>.jsonl 600
+```
+
+The wrapper prints one JSON status line (`status`: `ok` / `failed` /
+`config_error`) and **always exits 0** — parse the line, record it, and
+move to the next scenario regardless of outcome. Crash tolerance is the
+contract (#253: a known llama.cpp SIGABRT kills a fraction of runs;
+events up to the crash survive in the JSONL):
+
+- `failed` → keep the partial JSONL + `.stderr.log` for diagnosis; do NOT
+  retry in-cycle (the harness already retried once internally).
+- `config_error` → the generated YAML itself is broken (schema or >100
+  inference estimate). Fix the YAML once and re-run that scenario once;
+  if it config-errors again, record and move on.
+
+Use a generous Bash timeout (≥ 900 000 ms) or `run_in_background` per
+run; expect ~4–10 min each.
+
+## Step 4 — Judge in-session
+
+For each run with `status == ok`:
+
+```bash
+python3 .claude/skills/scenario-factory/scripts/format_transcript.py \
+  data/factory/runs/<DATE>/<id>.jsonl
+```
+
+Read the transcript and score the rubric — each axis 1–5 plus a one-line
+comment per scenario:
+
+| Axis | What 5 looks like | What 1 looks like |
+|---|---|---|
+| (a) coherence | Outputs consistently honor premise & personas | Agents ignore the setting |
+| (b) interaction | Agents react to each other; votes track content | Parallel monologues |
+| (c) breakdown_free | No format breaks, language drift, or nonsense loops | Frequent breakdowns |
+| (d) humor | Genuinely funny lines a human would quote | Flat or incoherent |
+
+Failed runs get **no scores** — record the status and the wrapper's
+`error` (skim the partial transcript only to classify the failure for
+the comment). The judge is a quality filter, not a safety screen.
+
+## Step 5 — Append the digest
+
+1. Write the results JSON (schema documented in `append_digest.py`'s
+   docstring: date / model / notes / per-scenario id, name, theme, yaml,
+   run_log, status, attempts, duration_sec, scores, comment, error) to a
+   temp file.
+2. ```bash
+   python3 .claude/skills/scenario-factory/scripts/append_digest.py \
+     --results /tmp/factory_results_<DATE>.json \
+     --digest data/factory/digest.md
+   ```
+3. Verify: `grep -c 'factory-digest:' data/factory/digest.md` must print
+   `2` (both markers survived), and the new `## <DATE>` section exists.
+
+## Step 6 — Report
+
+Summarize for the user: per-scenario status + scores + best line of the
+night, failures with one-line causes, and where the artifacts live
+(`scenarios/<DATE>/`, `runs/<DATE>/`, digest diff). `data/factory/digest.md`
+is left modified in the working tree — committing it (and any promotion
+PR) goes through the normal `/orchestrate` flow; this skill does not
+commit or push.

--- a/.claude/skills/scenario-factory/scripts/append_digest.py
+++ b/.claude/skills/scenario-factory/scripts/append_digest.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Append one factory-cycle section to the committed digest, date-idempotently.
+
+usage: append_digest.py --results <results.json> --digest <digest.md>
+
+The digest must contain both marker comments:
+
+  <!-- factory-digest:sections -->    new sections inserted directly below
+                                      (newest first)
+  <!-- factory-digest:promotion -->   promotion footer; never modified
+
+If a section for the same date already exists between the markers it is
+REPLACED (so re-running a partially-failed cycle is safe) and a warning
+goes to stderr. Missing markers are a hard error — never blind-append.
+
+Results JSON schema (composed by the /scenario-factory session):
+
+{
+  "date": "YYYY-MM-DD",
+  "model": "gemma-4-E2B-it-Q4_K_M",
+  "notes": "optional free text",
+  "scenarios": [
+    {
+      "id": "factory_20260613_example",
+      "name": "...", "theme": "...",
+      "yaml": "data/factory/scenarios/2026-06-13/....yaml",
+      "run_log": "data/factory/runs/2026-06-13/....jsonl",
+      "status": "ok|failed|config_error",
+      "attempts": 1, "duration_sec": 123.4,
+      "scores": {"coherence": 4, "interaction": 3,
+                 "breakdown_free": 5, "humor": 2},   // null when not ok
+      "comment": "one-line judge comment",
+      "error": null
+    }
+  ]
+}
+"""
+
+import argparse
+import json
+import re
+import sys
+
+SECTIONS_MARKER = "<!-- factory-digest:sections -->"
+PROMOTION_MARKER = "<!-- factory-digest:promotion -->"
+RUBRIC_KEYS = ["coherence", "interaction", "breakdown_free", "humor"]
+
+
+def cell(value):
+    """Escape a markdown table cell; em-dash for absent values."""
+    if value is None or value == "":
+        return "–"
+    return str(value).replace("|", "\\|").replace("\n", " ")
+
+
+def render_section(results):
+    scenarios = results.get("scenarios", [])
+    counts = {"ok": 0, "failed": 0, "config_error": 0}
+    for s in scenarios:
+        counts[s.get("status", "failed")] = counts.get(s.get("status", "failed"), 0) + 1
+
+    lines = [
+        f"## {results['date']}",
+        "",
+        f"Model: {results.get('model', '?')} | Scenarios: {len(scenarios)} "
+        f"(ok {counts['ok']} / failed {counts['failed']} / "
+        f"config_error {counts['config_error']})",
+        "",
+        "| id | name | theme | status | (a) coherence | (b) interaction "
+        "| (c) breakdown-free | (d) humor | comment |",
+        "|---|---|---|---|---|---|---|---|---|",
+    ]
+    for s in scenarios:
+        scores = s.get("scores") or {}
+        comment = s.get("comment") or ""
+        if s.get("status") != "ok" and s.get("error"):
+            comment = f"{comment} error: {s['error']}".strip()
+        row = [
+            cell(s.get("id")), cell(s.get("name")), cell(s.get("theme")),
+            cell(s.get("status")),
+        ]
+        row += [cell(scores.get(k)) for k in RUBRIC_KEYS]
+        row.append(cell(comment))
+        lines.append("| " + " | ".join(row) + " |")
+    if results.get("notes"):
+        lines += ["", f"Notes: {results['notes']}"]
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--results", required=True)
+    parser.add_argument("--digest", required=True)
+    args = parser.parse_args()
+
+    with open(args.results, encoding="utf-8") as f:
+        results = json.load(f)
+    if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", results.get("date", "")):
+        print(f"results.date must be YYYY-MM-DD, got: {results.get('date')!r}",
+              file=sys.stderr)
+        return 1
+
+    with open(args.digest, encoding="utf-8") as f:
+        digest = f.read()
+    for marker in (SECTIONS_MARKER, PROMOTION_MARKER):
+        if digest.count(marker) != 1:
+            print(f"digest must contain exactly one '{marker}'", file=sys.stderr)
+            return 1
+    if digest.index(SECTIONS_MARKER) > digest.index(PROMOTION_MARKER):
+        print("sections marker must precede promotion marker", file=sys.stderr)
+        return 1
+
+    head, _, tail = digest.partition(SECTIONS_MARKER)
+    body, _, footer = tail.partition(PROMOTION_MARKER)
+
+    # Date idempotency: drop an existing same-date section (everything from
+    # its `## <date>` heading up to the next `## ` heading or body end).
+    pattern = re.compile(
+        rf"^## {re.escape(results['date'])}\n.*?(?=^## |\Z)",
+        re.DOTALL | re.MULTILINE)
+    body, replaced = pattern.subn("", body)
+    if replaced:
+        print(f"warning: replaced existing section for {results['date']}",
+              file=sys.stderr)
+
+    section = render_section(results)
+    body = "\n\n" + section + "\n" + body.strip("\n") + ("\n\n" if body.strip("\n") else "\n")
+
+    with open(args.digest, "w", encoding="utf-8") as f:
+        f.write(head + SECTIONS_MARKER + body + PROMOTION_MARKER + footer)
+
+    action = "replaced" if replaced else "appended"
+    print(f"{action} section {results['date']} "
+          f"({len(results.get('scenarios', []))} scenario(s)) in {args.digest}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/scenario-factory/scripts/format_transcript.py
+++ b/.claude/skills/scenario-factory/scripts/format_transcript.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""JSONL run log -> markdown transcript for the in-session judge.
+
+usage: format_transcript.py <run.jsonl>
+
+Tolerates the #253 crash shape: unparseable lines (e.g. a truncated final
+line from a mid-write SIGABRT) are skipped and counted, and a missing
+run_end is reported in the Result section instead of raising. Inference
+progress events are omitted as judge-irrelevant noise.
+"""
+
+import json
+import sys
+
+# Noise for a quality judgement; timings live in the raw JSONL if needed.
+SKIPPED_EVENTS = {"inference_started", "inference_completed"}
+
+
+def fmt_scores(scores):
+    return ", ".join(f"{k}: {v}" for k, v in sorted(scores.items()))
+
+
+def render_event(line, out):
+    event = line.get("event", "?")
+    if event in SKIPPED_EVENTS:
+        return
+    if event == "round_started":
+        out.append(f"\n### Round {line.get('round')}/{line.get('total_rounds')}\n")
+    elif event == "round_completed":
+        out.append(f"[round_completed] scores: {fmt_scores(line.get('scores', {}))}")
+    elif event in ("phase_started", "phase_completed"):
+        pass  # phase boundaries are implied by the outputs themselves
+    elif event == "agent_output":
+        fields = line.get("fields") or {}
+        out.append(f"**{line.get('agent')}** ({line.get('phase_type')}):")
+        # statement first — it is the user-visible utterance.
+        for key in sorted(fields, key=lambda k: (k != "statement", k)):
+            out.append(f"- {key}: {fields[key]}")
+        if not fields and line.get("raw_text"):
+            out.append(f"- raw_text: {line['raw_text']}")
+        out.append("")
+    elif event == "assignment":
+        out.append(f"[assignment] {line.get('agent')} ← {line.get('value')}")
+    elif event == "vote_results":
+        votes = line.get("votes", {})
+        tallies = line.get("tallies", {})
+        vote_str = ", ".join(f"{k}→{v}" for k, v in sorted(votes.items()))
+        out.append(f"[vote_results] {vote_str} | tallies: {fmt_scores(tallies)}")
+    elif event == "score_update":
+        out.append(f"[score_update] {fmt_scores(line.get('scores', {}))}")
+    elif event == "summary":
+        out.append(f"[summary] {line.get('value')}")
+    elif event == "pairing_result":
+        out.append(
+            f"[pairing] {line.get('agent')}({line.get('action1')}) vs "
+            f"{line.get('agent2')}({line.get('action2')})")
+    elif event == "elimination":
+        out.append(
+            f"[elimination] {line.get('agent')} ({line.get('vote_count')} votes)")
+    elif event == "language_mismatch":
+        out.append(
+            f"[language_mismatch] {line.get('agent')}: detected "
+            f"{line.get('detected')}, expected {line.get('expected')}")
+    elif event == "error":
+        out.append(f"⚠ [error] {line.get('error')}")
+    elif event == "simulation_completed":
+        pass  # run_end carries the outcome
+    else:
+        out.append(f"[{event}] {json.dumps(line, ensure_ascii=False)}")
+
+
+def main():
+    if len(sys.argv) != 2:
+        print(__doc__.strip(), file=sys.stderr)
+        return 2
+    path = sys.argv[1]
+
+    run_start = None
+    run_end = None
+    events = []
+    skipped = 0
+    try:
+        with open(path, encoding="utf-8") as f:
+            for raw in f:
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    line = json.loads(raw)
+                except json.JSONDecodeError:
+                    skipped += 1
+                    continue
+                kind = line.get("type")
+                if kind == "run_start":
+                    run_start = line
+                elif kind == "run_end":
+                    run_end = line
+                elif kind == "event":
+                    events.append(line)
+    except OSError as e:
+        print(f"cannot read {path}: {e}", file=sys.stderr)
+        return 2
+
+    out = []
+    if run_start:
+        out.append(
+            f"# {run_start.get('scenario_name')} "
+            f"({run_start.get('scenario_id')}) — run {run_start.get('run_id')}")
+        out.append(
+            f"- date: {run_start.get('date')} | language: "
+            f"{run_start.get('language')} | model: {run_start.get('model')} | "
+            f"timeout: {run_start.get('timeout_sec')}s | est. inferences: "
+            f"{run_start.get('estimated_inferences')}")
+    else:
+        out.append(f"# (run_start missing) — {path}")
+
+    current_attempt = None
+    for line in events:
+        attempt = line.get("attempt")
+        if attempt != current_attempt:
+            current_attempt = attempt
+            out.append(f"\n## Attempt {attempt}\n")
+        render_event(line, out)
+
+    out.append("\n## Result\n")
+    if run_end:
+        out.append(
+            f"status={run_end.get('status')} attempts={run_end.get('attempts')} "
+            f"duration={run_end.get('duration_sec')}s")
+        if run_end.get("error"):
+            out.append(f"error: {run_end['error']}")
+    else:
+        out.append(
+            f"⚠ run_end missing — process died mid-run (#253). "
+            f"{len(events)} event(s) captured before death.")
+    if skipped:
+        out.append(f"\n_({skipped} unparseable line(s) skipped)_")
+
+    print("\n".join(out))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/scenario-factory/scripts/run_scenario.sh
+++ b/.claude/skills/scenario-factory/scripts/run_scenario.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+# Crash-tolerant single-scenario runner for the /scenario-factory skill.
+#
+# usage:
+#   run_scenario.sh <scenario.yaml> <model.gguf> <out.jsonl> [timeout_sec]
+#   run_scenario.sh --classify <out.jsonl> <exit_code>
+#
+# Run from the repository root (Package.swift must be in the cwd).
+# Emits exactly one JSON status line on stdout. Harness stderr goes to
+# `<out-minus-.jsonl>.stderr.log` — llama.cpp parser-internal errors only
+# surface there, not in the JSONL (see #253 diagnostics).
+#
+# Status contract, pinned to the real harness behavior
+# (tools/harness/Sources/pastura-harness/Main.swift, issue #521):
+#
+#   config_error  harness exit 2 (CLI / YAML-load / model-path error — no
+#                 run JSONL is written), swift build failure, or
+#                 run_start.estimated_inferences > 100 (run killed early
+#                 instead of burning a full model-load cycle)
+#   failed        any other non-zero exit — #253 SIGABRT arrives as 134
+#                 (128+SIGABRT) — OR run_end line absent / truncated OR
+#                 run_end.status != "ok"
+#   ok            exit 0 AND run_end.status == "ok"
+#
+# This script exits 0 even when the run fails (the status line carries the
+# result) — one bad scenario must never abort the nightly batch. Usage
+# errors exit 2.
+#
+# --classify reruns only the classification against an existing JSONL +
+# exit code; used by tests/run_tests.sh (no Swift toolchain, no model).
+
+set -u
+
+HARD_BLOCK=100          # ScenarioValidator hard limit (est. inferences)
+RUN_START_WAIT_SEC=90   # run_start poll budget; build is done beforehand
+
+usage() {
+  cat >&2 <<'EOF'
+usage: run_scenario.sh <scenario.yaml> <model.gguf> <out.jsonl> [timeout_sec]
+       run_scenario.sh --classify <out.jsonl> <exit_code>
+EOF
+  exit 2
+}
+
+# Prints the last parseable run_end line (compact JSON), or nothing.
+# `fromjson?` skips unparseable lines, so a truncated final line from a
+# mid-write crash cannot break the scan.
+last_run_end() {
+  [ -f "$1" ] || return 0
+  jq -Rc 'fromjson? | select(.type == "run_end")' "$1" 2>/dev/null | tail -1
+}
+
+# Prints run_start.estimated_inferences, or nothing.
+run_start_estimate() {
+  [ -f "$1" ] || return 0
+  jq -Rr 'fromjson? | select(.type == "run_start") | .estimated_inferences' \
+    "$1" 2>/dev/null | head -1
+}
+
+# emit <status> <exit_code> <scenario> <out> <run_end_json> <est> <error>
+emit() {
+  jq -cn \
+    --arg status "$1" \
+    --argjson exit_code "$2" \
+    --arg scenario "$3" \
+    --arg out "$4" \
+    --argjson run_end "${5:-null}" \
+    --argjson estimated_inferences "${6:-null}" \
+    --arg error "${7:-}" \
+    '{status: $status, exit_code: $exit_code, scenario: $scenario, out: $out,
+      run_end: $run_end, estimated_inferences: $estimated_inferences,
+      error: (if $error == "" then null else $error end)}'
+}
+
+# classify <out.jsonl> <exit_code> <scenario> [error]
+classify() {
+  local out=$1 exit_code=$2 scenario=$3 err=${4:-}
+  local run_end est status
+  run_end=$(last_run_end "$out")
+  est=$(run_start_estimate "$out")
+
+  if [ "$exit_code" -eq 2 ]; then
+    status="config_error"
+  elif [ -n "$est" ] && [ "$est" -gt "$HARD_BLOCK" ]; then
+    status="config_error"
+    err=${err:-"estimated_inferences ($est) exceeds hard block ($HARD_BLOCK)"}
+  elif [ "$exit_code" -ne 0 ] || [ -z "$run_end" ]; then
+    status="failed"
+    if [ -z "$run_end" ]; then
+      err=${err:-"run_end line missing — process died mid-run (#253)"}
+    fi
+  elif [ "$(printf '%s' "$run_end" | jq -r '.status')" = "ok" ]; then
+    status="ok"
+  else
+    status="failed"
+  fi
+
+  emit "$status" "$exit_code" "$scenario" "$out" \
+    "${run_end:-null}" "${est:-null}" "$err"
+}
+
+command -v jq >/dev/null 2>&1 || { echo "jq is required (brew install jq)" >&2; exit 2; }
+
+if [ "${1:-}" = "--classify" ]; then
+  [ $# -eq 3 ] || usage
+  case "$3" in *[!0-9]*) usage ;; esac
+  classify "$2" "$3" "(classify-only)"
+  exit 0
+fi
+
+[ $# -ge 3 ] && [ $# -le 4 ] || usage
+SCENARIO=$1
+MODEL=$2
+OUT=$3
+TIMEOUT=${4:-600}
+[ -f Package.swift ] || { echo "run from the repository root (Package.swift not found)" >&2; exit 2; }
+
+mkdir -p "$(dirname "$OUT")"
+STDERR_LOG="${OUT%.jsonl}.stderr.log"
+
+# Build first so the run_start poll below measures the harness, not the
+# compiler. A build failure is an environment problem, not a run failure.
+if ! BUILD_OUT=$(swift build 2>&1); then
+  emit "config_error" 1 "$SCENARIO" "$OUT" null null \
+    "swift build failed: $(printf '%s' "$BUILD_OUT" | tail -3 | tr '\n' ' ')"
+  exit 0
+fi
+BIN="$(swift build --show-bin-path)/pastura-harness"
+
+"$BIN" --scenario "$SCENARIO" --model "$MODEL" --out "$OUT" \
+  --timeout "$TIMEOUT" --quiet 2>"$STDERR_LOG" &
+PID=$!
+
+# Fast-abort: run_start (with the inference estimate) is written before
+# model load, so an oversized generated scenario can be killed in seconds
+# instead of after a full run.
+OVERSIZE=""
+for _ in $(seq 1 "$RUN_START_WAIT_SEC"); do
+  kill -0 "$PID" 2>/dev/null || break
+  EST=$(run_start_estimate "$OUT")
+  if [ -n "$EST" ]; then
+    if [ "$EST" -gt "$HARD_BLOCK" ]; then
+      OVERSIZE=1
+      kill "$PID" 2>/dev/null
+    fi
+    break
+  fi
+  sleep 1
+done
+
+wait "$PID"
+EXIT_CODE=$?
+
+if [ -n "$OVERSIZE" ]; then
+  EST=$(run_start_estimate "$OUT")
+  emit "config_error" "$EXIT_CODE" "$SCENARIO" "$OUT" null "${EST:-null}" \
+    "estimated_inferences ($EST) exceeds hard block ($HARD_BLOCK) — killed before run"
+  exit 0
+fi
+
+classify "$OUT" "$EXIT_CODE" "$SCENARIO"

--- a/.claude/skills/scenario-factory/scripts/run_scenario.sh
+++ b/.claude/skills/scenario-factory/scripts/run_scenario.sh
@@ -126,6 +126,13 @@ if ! BUILD_OUT=$(swift build 2>&1); then
   exit 0
 fi
 BIN="$(swift build --show-bin-path)/pastura-harness"
+if [ ! -x "$BIN" ]; then
+  # Guard against bin-path/config drift — a missing binary must read as an
+  # environment problem, not get misattributed to a #253 crash.
+  emit "config_error" 1 "$SCENARIO" "$OUT" null null \
+    "harness binary not found at $BIN (build/config drift?)"
+  exit 0
+fi
 
 "$BIN" --scenario "$SCENARIO" --model "$MODEL" --out "$OUT" \
   --timeout "$TIMEOUT" --quiet 2>"$STDERR_LOG" &
@@ -151,6 +158,9 @@ done
 wait "$PID"
 EXIT_CODE=$?
 
+# Ordering invariant: this OVERSIZE branch MUST precede classify — it
+# overrides the SIGTERM exit code (143) from our own fast-abort kill,
+# which classify would otherwise mislabel as a failed run.
 if [ -n "$OVERSIZE" ]; then
   EST=$(run_start_estimate "$OUT")
   emit "config_error" "$EXIT_CODE" "$SCENARIO" "$OUT" null "${EST:-null}" \

--- a/.claude/skills/scenario-factory/tests/fixtures/digest_seed.md
+++ b/.claude/skills/scenario-factory/tests/fixtures/digest_seed.md
@@ -1,0 +1,9 @@
+# Scenario Factory Digest
+
+Test copy of the digest seed — keep the marker structure in sync with
+`data/factory/digest.md`.
+
+<!-- factory-digest:sections -->
+
+<!-- factory-digest:promotion -->
+Promotion: copy the winning YAML from `data/factory/scenarios/<date>/` to `Pastura/Pastura/Resources/Presets/` via an `/orchestrate` PR — landing under `Resources/` routes it through the blocklist pre-commit gate.

--- a/.claude/skills/scenario-factory/tests/fixtures/results_sample.json
+++ b/.claude/skills/scenario-factory/tests/fixtures/results_sample.json
@@ -1,0 +1,33 @@
+{
+  "date": "2026-06-13",
+  "model": "gemma-4-E2B-it-Q4_K_M",
+  "notes": "fixture cycle for append_digest tests",
+  "scenarios": [
+    {
+      "id": "factory_20260613_test_ok",
+      "name": "テスト大喜利",
+      "theme": "大喜利",
+      "yaml": "data/factory/scenarios/2026-06-13/factory_20260613_test_ok.yaml",
+      "run_log": "data/factory/runs/2026-06-13/factory_20260613_test_ok.jsonl",
+      "status": "ok",
+      "attempts": 1,
+      "duration_sec": 9.4,
+      "scores": {"coherence": 4, "interaction": 3, "breakdown_free": 5, "humor": 2},
+      "comment": "設定は一貫、ボケの幅 | は狭め",
+      "error": null
+    },
+    {
+      "id": "factory_20260613_test_crash",
+      "name": "クラッシュ再現",
+      "theme": "大喜利",
+      "yaml": "data/factory/scenarios/2026-06-13/factory_20260613_test_crash.yaml",
+      "run_log": "data/factory/runs/2026-06-13/factory_20260613_test_crash.jsonl",
+      "status": "failed",
+      "attempts": null,
+      "duration_sec": null,
+      "scores": null,
+      "comment": "",
+      "error": "run_end line missing — process died mid-run (#253)"
+    }
+  ]
+}

--- a/.claude/skills/scenario-factory/tests/fixtures/run_crash_truncated.jsonl
+++ b/.claude/skills/scenario-factory/tests/fixtures/run_crash_truncated.jsonl
@@ -1,0 +1,4 @@
+{"date":"2026-06-13T01:00:00Z","estimated_inferences":20,"language":"ja","model":"gemma-4-E2B-it-Q4_K_M","run_id":"20260613-010000-bbbb","scenario_id":"factory_test_crash","scenario_name":"クラッシュ再現","timeout_sec":600,"type":"run_start"}
+{"attempt":1,"event":"round_started","round":1,"t":0.5,"total_rounds":2,"type":"event"}
+{"agent":"シュール子","attempt":1,"event":"agent_output","fields":{"statement":"宇宙の裏側ではこれが普通"},"phase_type":"speak_all","t":6.1,"type":"event"}
+{"agent":"あるある先生","attempt":1,"event":"agent_out

--- a/.claude/skills/scenario-factory/tests/fixtures/run_error.jsonl
+++ b/.claude/skills/scenario-factory/tests/fixtures/run_error.jsonl
@@ -1,0 +1,6 @@
+{"date":"2026-06-13T02:00:00Z","estimated_inferences":20,"language":"ja","model":"gemma-4-E2B-it-Q4_K_M","run_id":"20260613-020000-cccc","scenario_id":"factory_test_error","scenario_name":"リトライ枯渇","timeout_sec":600,"type":"run_start"}
+{"attempt":1,"event":"round_started","round":1,"t":0.5,"total_rounds":1,"type":"event"}
+{"attempt":1,"error":"retriesExhausted","event":"error","t":120.0,"type":"event"}
+{"attempt":2,"event":"round_started","round":1,"t":0.5,"total_rounds":1,"type":"event"}
+{"attempt":2,"error":"retriesExhausted","event":"error","t":118.3,"type":"event"}
+{"attempts":2,"duration_sec":361.2,"error":"retriesExhausted","run_id":"20260613-020000-cccc","status":"error","type":"run_end"}

--- a/.claude/skills/scenario-factory/tests/fixtures/run_ok.jsonl
+++ b/.claude/skills/scenario-factory/tests/fixtures/run_ok.jsonl
@@ -1,0 +1,12 @@
+{"date":"2026-06-13T00:00:00Z","estimated_inferences":20,"language":"ja","model":"gemma-4-E2B-it-Q4_K_M","run_id":"20260613-000000-aaaa","scenario_id":"factory_test_ok","scenario_name":"テスト大喜利","timeout_sec":600,"type":"run_start"}
+{"attempt":1,"event":"round_started","round":1,"t":0.5,"total_rounds":1,"type":"event"}
+{"agent":"ツッコミ太郎","attempt":1,"event":"assignment","t":0.6,"type":"event","value":"スーツを着た猫の写真"}
+{"agent":"ツッコミ太郎","attempt":1,"event":"inference_started","t":0.7,"type":"event"}
+{"agent":"ツッコミ太郎","attempt":1,"duration_seconds":4.2,"event":"inference_completed","t":4.9,"token_count":31,"type":"event"}
+{"agent":"ツッコミ太郎","attempt":1,"event":"agent_output","fields":{"inner_thought":"短く切るのが俺の流儀","statement":"お前が議事録だろ"},"phase_type":"speak_all","t":5.0,"type":"event"}
+{"attempt":1,"event":"vote_results","t":9.0,"tallies":{"ツッコミ太郎":2},"type":"event","votes":{"シュール子":"ツッコミ太郎","あるある先生":"ツッコミ太郎"}}
+{"attempt":1,"event":"score_update","scores":{"ツッコミ太郎":2},"t":9.1,"type":"event"}
+{"attempt":1,"event":"summary","t":9.15,"type":"event","value":"ラウンド1結果: ツッコミ太郎 2点"}
+{"attempt":1,"event":"round_completed","round":1,"scores":{"ツッコミ太郎":2},"t":9.2,"type":"event"}
+{"attempt":1,"event":"simulation_completed","t":9.3,"type":"event"}
+{"attempts":1,"duration_sec":9.4,"error":null,"run_id":"20260613-000000-aaaa","status":"ok","type":"run_end"}

--- a/.claude/skills/scenario-factory/tests/fixtures/run_oversize.jsonl
+++ b/.claude/skills/scenario-factory/tests/fixtures/run_oversize.jsonl
@@ -1,0 +1,1 @@
+{"date":"2026-06-13T03:00:00Z","estimated_inferences":120,"language":"ja","model":"gemma-4-E2B-it-Q4_K_M","run_id":"20260613-030000-dddd","scenario_id":"factory_test_oversize","scenario_name":"推論数超過","timeout_sec":600,"type":"run_start"}

--- a/.claude/skills/scenario-factory/tests/run_tests.sh
+++ b/.claude/skills/scenario-factory/tests/run_tests.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Self-test for the scenario-factory helper scripts. No Swift toolchain or
+# model needed — exercises classification (--classify), transcript
+# formatting, and digest appending against fixtures, including the #253
+# crash shape (truncated JSONL, no run_end).
+#
+# usage: bash .claude/skills/scenario-factory/tests/run_tests.sh
+set -eu
+cd "$(dirname "$0")"
+SCRIPTS=../scripts
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+check_status() { # <label> <jsonl> <exit_code> <expected_status>
+  local got
+  got=$(bash "$SCRIPTS/run_scenario.sh" --classify "$2" "$3" | jq -r '.status')
+  [ "$got" = "$4" ] || fail "$1: expected status=$4, got $got"
+}
+
+# --- run_scenario.sh --classify -------------------------------------------
+check_status "ok run" fixtures/run_ok.jsonl 0 ok
+# #253 SIGABRT: shell sees 134, last line truncated, no run_end
+check_status "SIGABRT crash" fixtures/run_crash_truncated.jsonl 134 failed
+# harness-internal failure: run_end present with status=error, exit 1
+check_status "retries exhausted" fixtures/run_error.jsonl 1 failed
+# clean exit but missing run_end (writer died) must still be failed
+check_status "exit 0 without run_end" fixtures/run_crash_truncated.jsonl 0 failed
+# config error: exit 2, no JSONL ever written
+check_status "config error" "$TMP/never_written.jsonl" 2 config_error
+# oversized estimate in run_start → config_error regardless of exit code
+check_status "oversize estimate" fixtures/run_oversize.jsonl 143 config_error
+
+ERR=$(bash "$SCRIPTS/run_scenario.sh" --classify fixtures/run_crash_truncated.jsonl 134 | jq -r '.error')
+echo "$ERR" | grep -q "#253" || fail "crash error should reference #253, got: $ERR"
+
+# --- format_transcript.py ---------------------------------------------------
+T=$(python3 "$SCRIPTS/format_transcript.py" fixtures/run_ok.jsonl)
+echo "$T" | grep -q "テスト大喜利" || fail "transcript: scenario name missing"
+echo "$T" | grep -q "お前が議事録だろ" || fail "transcript: statement missing"
+echo "$T" | grep -q "status=ok" || fail "transcript: run_end status missing"
+echo "$T" | grep -q "inference_started" && fail "transcript: noise events not skipped"
+
+T=$(python3 "$SCRIPTS/format_transcript.py" fixtures/run_crash_truncated.jsonl)
+echo "$T" | grep -q "run_end missing" || fail "transcript: crash shape not reported"
+echo "$T" | grep -q "1 unparseable line" || fail "transcript: truncated line not counted"
+
+# --- append_digest.py -------------------------------------------------------
+cp fixtures/digest_seed.md "$TMP/digest.md"
+python3 "$SCRIPTS/append_digest.py" \
+  --results fixtures/results_sample.json --digest "$TMP/digest.md" >/dev/null
+grep -q "^## 2026-06-13$" "$TMP/digest.md" || fail "digest: section heading missing"
+grep -q "factory_20260613_test_ok" "$TMP/digest.md" || fail "digest: ok row missing"
+grep -q '設定は一貫、ボケの幅 \\| は狭め' "$TMP/digest.md" || fail "digest: pipe not escaped in comment"
+grep -q "factory-digest:promotion" "$TMP/digest.md" || fail "digest: promotion marker lost"
+tail -1 "$TMP/digest.md" | grep -q "^Promotion:" || fail "digest: promotion line no longer last"
+
+# date idempotency: re-append replaces, never duplicates
+python3 "$SCRIPTS/append_digest.py" \
+  --results fixtures/results_sample.json --digest "$TMP/digest.md" >/dev/null 2>"$TMP/warn"
+COUNT=$(grep -c "^## 2026-06-13$" "$TMP/digest.md")
+[ "$COUNT" -eq 1 ] || fail "digest: re-append duplicated the section ($COUNT)"
+grep -q "warning: replaced" "$TMP/warn" || fail "digest: replace warning missing"
+
+# corrupted digest (no markers) must hard-error, not blind-append
+echo "# broken" > "$TMP/broken.md"
+if python3 "$SCRIPTS/append_digest.py" \
+  --results fixtures/results_sample.json --digest "$TMP/broken.md" 2>/dev/null; then
+  fail "digest: missing markers should be a hard error"
+fi
+
+echo "ALL TESTS PASSED"

--- a/.claude/skills/scenario-factory/tests/run_tests.sh
+++ b/.claude/skills/scenario-factory/tests/run_tests.sh
@@ -30,6 +30,7 @@ check_status "exit 0 without run_end" fixtures/run_crash_truncated.jsonl 0 faile
 check_status "config error" "$TMP/never_written.jsonl" 2 config_error
 # oversized estimate in run_start → config_error regardless of exit code
 check_status "oversize estimate" fixtures/run_oversize.jsonl 143 config_error
+check_status "oversize estimate (clean exit)" fixtures/run_oversize.jsonl 0 config_error
 
 ERR=$(bash "$SCRIPTS/run_scenario.sh" --classify fixtures/run_crash_truncated.jsonl 134 | jq -r '.error')
 echo "$ERR" | grep -q "#253" || fail "crash error should reference #253, got: $ERR"

--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,7 @@ fastlane/test_output
 __pycache__/
 *.pyc
 
-# Scenario-factory raw run logs (ADR-013 / #515) — digest is committed, raw is not.
+# Scenario-factory raw run logs and generated candidate YAMLs (ADR-013 /
+# #515 / #521) — digest is committed, raw artifacts are local-only.
 data/factory/runs/
+data/factory/scenarios/

--- a/data/factory/digest.md
+++ b/data/factory/digest.md
@@ -12,5 +12,18 @@ by the blocklist pre-commit gate at promotion time.
 
 <!-- factory-digest:sections -->
 
+## 2026-06-13
+
+Model: gemma-4-E2B-it-Q4_K_M | Scenarios: 3 (ok 3 / failed 0 / config_error 0)
+
+| id | name | theme | status | (a) coherence | (b) interaction | (c) breakdown-free | (d) humor | comment |
+|---|---|---|---|---|---|---|---|---|
+| factory_20260613_kinku_bokete | 禁句大喜利 | 制約付き大喜利（禁句ルール） | ok | 4 | 3 | 5 | 3 | 禁句はほぼ回避され制約が機能。当事者ヅラ子のみ一人称芸を放棄。ミニマリスト省吾「バッテリー切れか」が今夜のベスト |
+| factory_20260613_iiwake_battle | 言い訳エスカレーション | 順番制エスカレーション大喜利（speak_each） | ok | 4 | 5 | 3 | 4 | speak_each の前話者参照が明確に機能（差別化発言）。ただし R1 で開き直りマコが自票で 4 点獲得、R2 でお題取り違え（「遅刻ではなく」）。昇格第一候補 |
+| factory_20260613_shinya_tsuhan | 深夜の通販バトル | なりきりプレゼン大喜利（深夜通販） | ok | 2 | 3 | 2 | 3 | ペルソナ溶解が顕著（節約担当ヨシ江まで宇宙波動を語り全員霊感堂化）。R2 自票 2 件。「1〜2文」指示も無視され冗長。5 人ペルソナは芸風の言語的差別化が要強化 |
+
+Notes: First factory cycle (E2E verification for #521). 3/3 runs ok, no #253 crash tonight. Engine finding: self-votes despite exclude_self were tallied 3 times across 2 scenarios (iiwake R1, tsuhan R2 ×2) — VoteHandler seems not to reject votes outside the candidates list; tracked as a follow-up issue. One JSON-parse retry in tsuhan (auto-recovered).
+
+
 <!-- factory-digest:promotion -->
 Promotion: copy the winning YAML from `data/factory/scenarios/<date>/` to `Pastura/Pastura/Resources/Presets/` via an `/orchestrate` PR — landing under `Resources/` routes it through the blocklist pre-commit gate.

--- a/data/factory/digest.md
+++ b/data/factory/digest.md
@@ -22,7 +22,7 @@ Model: gemma-4-E2B-it-Q4_K_M | Scenarios: 3 (ok 3 / failed 0 / config_error 0)
 | factory_20260613_iiwake_battle | 言い訳エスカレーション | 順番制エスカレーション大喜利（speak_each） | ok | 4 | 5 | 3 | 4 | speak_each の前話者参照が明確に機能（差別化発言）。ただし R1 で開き直りマコが自票で 4 点獲得、R2 でお題取り違え（「遅刻ではなく」）。昇格第一候補 |
 | factory_20260613_shinya_tsuhan | 深夜の通販バトル | なりきりプレゼン大喜利（深夜通販） | ok | 2 | 3 | 2 | 3 | ペルソナ溶解が顕著（節約担当ヨシ江まで宇宙波動を語り全員霊感堂化）。R2 自票 2 件。「1〜2文」指示も無視され冗長。5 人ペルソナは芸風の言語的差別化が要強化 |
 
-Notes: First factory cycle (E2E verification for #521). 3/3 runs ok, no #253 crash tonight. Engine finding: self-votes despite exclude_self were tallied 3 times across 2 scenarios (iiwake R1, tsuhan R2 ×2) — VoteHandler seems not to reject votes outside the candidates list; follow-up issue not yet filed (issue TBD). One JSON-parse retry in tsuhan (auto-recovered).
+Notes: First factory cycle (E2E verification for #521). 3/3 runs ok, no #253 crash tonight. Engine finding: self-votes despite exclude_self were tallied 3 times across 2 scenarios (iiwake R1, tsuhan R2 ×2) — VoteHandler seems not to reject votes outside the candidates list; tracked in #524. One JSON-parse retry in tsuhan (auto-recovered).
 
 
 <!-- factory-digest:promotion -->

--- a/data/factory/digest.md
+++ b/data/factory/digest.md
@@ -1,0 +1,16 @@
+# Scenario Factory Digest
+
+Committed output of the `/scenario-factory` skill (ADR-013 Phase 2,
+#521): one section per cycle date, newest first, written by
+`.claude/skills/scenario-factory/scripts/append_digest.py` — not by
+hand. Raw run logs and generated YAMLs stay local-only (gitignored
+`data/factory/runs/` and `data/factory/scenarios/`).
+
+Judge scores cover quality (coherence / interaction / breakdown-free /
+humor) only — they are NOT a content-safety screen; safety is enforced
+by the blocklist pre-commit gate at promotion time.
+
+<!-- factory-digest:sections -->
+
+<!-- factory-digest:promotion -->
+Promotion: copy the winning YAML from `data/factory/scenarios/<date>/` to `Pastura/Pastura/Resources/Presets/` via an `/orchestrate` PR — landing under `Resources/` routes it through the blocklist pre-commit gate.

--- a/data/factory/digest.md
+++ b/data/factory/digest.md
@@ -22,7 +22,7 @@ Model: gemma-4-E2B-it-Q4_K_M | Scenarios: 3 (ok 3 / failed 0 / config_error 0)
 | factory_20260613_iiwake_battle | 言い訳エスカレーション | 順番制エスカレーション大喜利（speak_each） | ok | 4 | 5 | 3 | 4 | speak_each の前話者参照が明確に機能（差別化発言）。ただし R1 で開き直りマコが自票で 4 点獲得、R2 でお題取り違え（「遅刻ではなく」）。昇格第一候補 |
 | factory_20260613_shinya_tsuhan | 深夜の通販バトル | なりきりプレゼン大喜利（深夜通販） | ok | 2 | 3 | 2 | 3 | ペルソナ溶解が顕著（節約担当ヨシ江まで宇宙波動を語り全員霊感堂化）。R2 自票 2 件。「1〜2文」指示も無視され冗長。5 人ペルソナは芸風の言語的差別化が要強化 |
 
-Notes: First factory cycle (E2E verification for #521). 3/3 runs ok, no #253 crash tonight. Engine finding: self-votes despite exclude_self were tallied 3 times across 2 scenarios (iiwake R1, tsuhan R2 ×2) — VoteHandler seems not to reject votes outside the candidates list; tracked as a follow-up issue. One JSON-parse retry in tsuhan (auto-recovered).
+Notes: First factory cycle (E2E verification for #521). 3/3 runs ok, no #253 crash tonight. Engine finding: self-votes despite exclude_self were tallied 3 times across 2 scenarios (iiwake R1, tsuhan R2 ×2) — VoteHandler seems not to reject votes outside the candidates list; follow-up issue not yet filed (issue TBD). One JSON-parse retry in tsuhan (auto-recovered).
 
 
 <!-- factory-digest:promotion -->


### PR DESCRIPTION
## Summary
- New repo-managed `/scenario-factory` skill (ADR-013 Phase 2): one cycle = generate 3 schema-compliant oogiri-family scenario YAMLs (digest-driven dedup) → run each on `pastura-harness` → judge in-session against a 4-axis rubric → append the committed digest. SKILL.md is 166 lines; deterministic processing lives in bundled scripts.
- `run_scenario.sh`: crash-tolerant wrapper pinned to the real harness contract — exit 2 → `config_error`; any other non-zero (incl. #253 SIGABRT = 134) or absent/truncated `run_end` → `failed`-and-continue; `run_start.estimated_inferences` > 100 → early kill. Harness stderr captured to a sidecar log.
- `format_transcript.py` (JSONL → judge-readable markdown, truncation-tolerant) and `append_digest.py` (date-idempotent, marker-anchored, promotion footer preserved). Self-tested via `tests/run_tests.sh` incl. the truncated crash-shape fixture.
- Digest seed `data/factory/digest.md` + first real cycle section; `data/factory/scenarios/` joins `runs/` in `.gitignore`. Promotion routes through `Resources/Presets/` so the blocklist pre-commit gate screens content (the in-session judge is quality-only).
- Non-goals: no scheduled execution (Phase 3 registers the Routine), no external LLM APIs.

## Test plan
- [x] `bash .claude/skills/scenario-factory/tests/run_tests.sh` — classification (ok / SIGABRT-134 / run_end-missing / exit-2 / oversize ×2), transcript formatting incl. crash shape, digest append + date-idempotent replace + marker-loss hard error
- [x] Manual full cycle on Gemma 4 E2B Q4_K_M: 3/3 runs ok (105–249 s each), judge + digest append verified end-to-end; digest replace path exercised in production by the review-fix re-append
- [x] `swiftlint lint --strict` clean; no Swift source touched

## Findings from the first cycle
Self-votes despite `exclude_self: true` were tallied 3 times across 2 scenarios — `VoteHandler` appears not to validate the parsed vote against the candidates list (digest Notes, issue TBD pending operator approval).

Closes #521

🤖 Generated with [Claude Code](https://claude.com/claude-code)