### PR TITLE
📚 docs: capitalize "faq" → "FAQ" in README intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You write a YAML scenario (or build it in the visual editor), pick a
 local LLM, and watch the agents talk, vote, and score themselves.
 Nothing leaves the device.
 
-For the product story, design philosophy, and faq, head to
+For the product story, design philosophy, and FAQ, head to
 [pastura.app](https://pastura.app) instead.
 
 ## Architecture


### PR DESCRIPTION
Closes #535

First end-to-end dummy task for the overnight Issue Queue (Phase 3 verification). Deliberately trivial, docs-only.

## Acceptance criteria → diff → verification

| Acceptance criterion | How the diff satisfies it | Verification |
|---|---|---|
| In `README.md`, "faq" in the intro line is changed to "FAQ" | One-word edit at `README.md:28`: `…design philosophy, and faq, head to` → `…design philosophy, and FAQ, head to` | `git diff origin/main...HEAD` shows a single `-`/`+` line; visual inspection |
| No other content in `README.md` is modified | Diff is one line changed, one insertion / one deletion | `git diff --stat`: `1 file changed, 1 insertion(+), 1 deletion(-)` — untestable beyond diff inspection (docs change) |

## Judgment calls

- None. The change is a literal one-word capitalization matching the issue's exact wording. Surrounding sentence, the `[pastura.app]` link, punctuation, and line wrapping are untouched per `### Out of scope`.

## Tests

- Docs-only change — no Swift touched, so the xcodebuild suite was skipped per the skill's Step 3.3 (docs-only changes skip xcodebuild).
- Mandatory `code-reviewer` (Opus) review: **PASS** (0 Critical / 0 Warning / 0 Suggestion) — confirmed scope adherence (only README.md, only the intended word) and Conventional-Commits compliance.
