### PR TITLE
📝 docs: note sim-dest.sh resets caller set -e (xcodebuild-cli rule)

### DIFF
--- a/.claude/rules/xcodebuild-cli.md
+++ b/.claude/rules/xcodebuild-cli.md
@@ -137,6 +137,17 @@ another test run, the busy PID is likely a stale
 `xcodebuild`/`testmanagerd`/`XCTRunner` from a prior timeout-killed
 run — see Recovery below.
 
+### Sourcing it in a script clears your `set -e`
+
+`sim-dest.sh` saves the caller's shell options on entry and restores that
+saved snapshot on every exit path. In practice this leaves errexit **off**
+after the `source` even if you ran `set -e` before it, so later failures
+keep running instead of aborting. **Re-assert `set -euo pipefail`
+immediately after sourcing.** Only scripts that source `sim-dest.sh`
+directly are at risk — child-process invokers (`ui-tour.sh` →
+`xcodebuild.sh`) are unaffected. Reference re-assert:
+`scripts/motion-capture.sh`.
+
 ## Agent session guardrails
 
 **Prevention**:


### PR DESCRIPTION
## Summary
- Promote a shell gotcha found while building `scripts/motion-capture.sh` (#534) into the always-loaded `.claude/rules/xcodebuild-cli.md`.
- `source scripts/sim-dest.sh` restores the caller's saved shell-options snapshot on every exit path, leaving `errexit` **off** after the source even if `set -e` was on before it — later failures then run on silently instead of aborting.
- New subsection (near the simulator-gate section that already covers sim-dest.sh): the symptom, the fix (re-assert `set -euo pipefail` right after sourcing), and `scripts/motion-capture.sh` as the reference. Concept-level — no line numbers / internal-var tokens (drift-safe); the `ui-tour.sh` negative example is a half-clause.

## Test plan
- Doc-only. Mechanism verified against `scripts/sim-dest.sh` (snapshot on entry / restore via `eval` on each exit path) and empirically reproduced (parent errexit-on → off after sourcing).
- `ui-tour.sh` unaffected claim confirmed (grep finds no sim-dest in it; it invokes `xcodebuild.sh` as a child process).
- Pre-impl critic + code-reviewer (Opus) both PASS, no Critical/Warning.

Closes #536
