### PR TITLE
📚 docs: document the gallery promotion channel for scenario-factory

### DIFF
--- a/.claude/skills/scenario-factory/SKILL.md
+++ b/.claude/skills/scenario-factory/SKILL.md
@@ -16,7 +16,10 @@ Non-goals:
   calls it.
 - **No content-safety screening.** The judge scores quality only; safety
   is enforced by the blocklist pre-commit gate when a scenario is later
-  promoted under `Resources/Presets/` (see the digest's promotion footer).
+  promoted to a **bundled preset** under `Resources/Presets/`. The
+  **shared-scenario gallery** channel (`docs/gallery/`) does NOT pass
+  through that gate — curate gallery content by hand. Both channels: see
+  the digest's promotion footer.
 - **No external LLM APIs.** Generation and judging are done by THIS
   session. Only the local harness (llama.cpp + bundled GGUF) burns
   inference.
@@ -162,5 +165,6 @@ Summarize for the user: per-scenario status + scores + best line of the
 night, failures with one-line causes, and where the artifacts live
 (`scenarios/<DATE>/`, `runs/<DATE>/`, digest diff). `data/factory/digest.md`
 is left modified in the working tree — committing it (and any promotion
-PR) goes through the normal `/orchestrate` flow; this skill does not
-commit or push.
+PR — bundled preset or shared-scenario gallery; see the digest's
+promotion footer for the two channels) goes through the normal
+`/orchestrate` flow; this skill does not commit or push.

--- a/data/factory/digest.md
+++ b/data/factory/digest.md
@@ -29,4 +29,7 @@ Notes: Two cycles ran on 2026-06-13 (rows merged — append_digest.py replaces s
 
 
 <!-- factory-digest:promotion -->
-Promotion: copy the winning YAML from `data/factory/scenarios/<date>/` to `Pastura/Pastura/Resources/Presets/` via an `/orchestrate` PR — landing under `Resources/` routes it through the blocklist pre-commit gate.
+Promotion has two distribution channels — pick by reach, commit via an `/orchestrate` PR either way:
+
+- **Bundled preset** (ships in the app binary): copy the winning YAML from `data/factory/scenarios/<date>/` to `Pastura/Pastura/Resources/Presets/`. Landing under `Resources/` routes it through the blocklist pre-commit gate; reaches users only on the next TestFlight / App Store build.
+- **Shared-scenario gallery** (remote — served from `main` via `raw.githubusercontent.com`, so **merge is the deploy**): copy to `docs/gallery/<slug>_v1.yaml` (rename the YAML's `id:` from `factory_<date>_<slug>` to `<slug>_v1`), then run `scripts/add-gallery-entry.sh`. The gallery does **not** pass through the blocklist gate — curate by the judge scores yourself (hold back low-coherence / low-humor runs). Full bridge: `docs/gallery/README.md` § "Promoting from the scenario factory".

--- a/docs/gallery/README.md
+++ b/docs/gallery/README.md
@@ -134,6 +134,28 @@ Gallery scenarios are public and curator-endorsed. Keep content:
 
 ## Adding a scenario
 
+### Promoting from the scenario factory
+
+If the YAML came from a `/scenario-factory` cycle
+(`data/factory/scenarios/<date>/`), it is already schema-valid and
+field-tested — skip the from-scratch drafting and bridge it to a gallery
+entry:
+
+1. Copy it to `docs/gallery/<slug>_v1.yaml` and rename the YAML's `id:`
+   from `factory_<date>_<slug>` to `<slug>_v1` (the file stem **must**
+   equal `id:` — see *Globally unique scenario ids* above).
+2. `estimated_inferences` = the run log's `run_start.estimated_inferences`
+   (`data/factory/runs/<date>/<id>.jsonl`).
+3. `category` is usually `creative` for the oogiri / comedy family.
+4. Curate by the digest's judge scores — promote high scorers, hold back
+   low-coherence or low-humor runs. The factory judge is a **quality**
+   filter, NOT a content-safety screen, and gallery YAMLs do **not** pass
+   through the blocklist gate (that gate is Presets-only). Apply the
+   *Content guidelines* above yourself.
+
+Then continue with step 2 (`add-gallery-entry.sh`) below — step 1's
+drafting is already done.
+
 ### 1. Draft the YAML
 
 Write `docs/gallery/<id>.yaml` following the existing examples. Keep


### PR DESCRIPTION
## Summary
Factory promotion has **two** distribution channels, but the docs only described the bundled-preset path. The shared-scenario **gallery** path (remote, served from `main` via `raw.githubusercontent.com` — so **merging is the deploy**) had to be rediscovered from source during the 2026-06-13 gallery promotion (PR #530). This captures it so the next promotion is a checklist, not a rediscovery.

## Changes (doc-only, 3 files)
- **`data/factory/digest.md`** promotion footer — split into **Bundled preset** vs **Shared-scenario gallery**, with the factory→gallery `id` rename (`factory_<date>_<slug>` → `<slug>_v1`) and the no-blocklist-gate caveat.
- **`docs/gallery/README.md`** — new `### Promoting from the scenario factory` subsection under *Adding a scenario* (id rename, `estimated_inferences` from the run log, `category: creative`, curate-by-judge-scores, blocklist-gate-is-Presets-only).
- **`.claude/skills/scenario-factory/SKILL.md`** — the *No content-safety screening* non-goal and Step 6 now point at both channels and note the gallery skips the blocklist gate.

## Test plan
- Doc-only; no code paths. Pre-commit hook (swiftlint + build + gates) passed.
- Verified: digest markers intact (`grep -c factory-digest:` → 2), and the cross-references resolve — footer + SKILL.md point at the README heading `### Promoting from the scenario factory`, which now exists.
- digest footer lives after `<!-- factory-digest:promotion -->`, so `append_digest.py` preserves it verbatim on future cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)