### PR TITLE
📝 docs: align README GRDB version to 7.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ dependency direction is preparation for a future SPM module split.
 ### Libraries
 
 - [Yams](https://github.com/jpsim/Yams) 6.2.2 for YAML parsing
-- [GRDB](https://github.com/groue/GRDB.swift) 7.11 for SQLite
+- [GRDB](https://github.com/groue/GRDB.swift) 7.11.0 for SQLite
 
 ### LLM backends
 


### PR DESCRIPTION
Closes #540

Aligns the README Tech stack GRDB entry to the patch-level version so it
matches `Package.resolved` and the CLAUDE.md Tech Stack table, per the
README mirror rule in CLAUDE.md § Reference Documents.

## Acceptance criteria

| Criterion | How the diff satisfies it | Coverage |
|---|---|---|
| README Libraries entry "GRDB ... 7.11 for SQLite" reads "...7.11.0 for SQLite" | `README.md:61` changed `7.11` → `7.11.0`; nothing else on the line | Visible in the 1-line diff |
| No other line in README.md, and no other file, is modified | `git diff --stat`: 1 file changed, 1 insertion, 1 deletion | Single-commit branch, clean tree |

## Out of scope (honored)

- No file other than `README.md` touched (CLAUDE.md / Package.resolved untouched).
- No other library version string altered (Yams 6.2.2 left as-is).
- No surrounding prose or links restructured.

## Judgment calls

None — the change is exactly the one-line edit the acceptance criteria specify.

## Test results

Docs-only change; no Swift touched, so xcodebuild was skipped per the
queue-consumer docs-only path. Mandatory code-reviewer pass: **PASS**
(0 findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
