### PR TITLE
📝 docs: automation trigger for the factory→gallery bridge

### DIFF
--- a/docs/gallery/README.md
+++ b/docs/gallery/README.md
@@ -156,6 +156,11 @@ entry:
 Then continue with step 2 (`add-gallery-entry.sh`) below — step 1's
 drafting is already done.
 
+> **Automation trigger:** if you have hand-run this bridge ≥3 times, or
+> the factory becomes a scheduled Routine, graduate steps 1–3 to
+> `scripts/promote-factory-to-gallery.sh` (curation stays manual — the
+> script takes an explicit slug). Tracked in #542.
+
 ### 1. Draft the YAML
 
 Write `docs/gallery/<id>.yaml` following the existing examples. Keep


### PR DESCRIPTION
## Summary
The `docs/gallery/README.md` § "Promoting from the scenario factory" steps (added in #539) are hand-run today. This adds a one-line **automation trigger** so the helper-script idea — tracked in #542 — surfaces at the moment of friction (when someone is reading these steps to do a manual promotion), instead of living only in a backlog issue that's easy to forget.

Trigger condition: **≥3 hand-runs** of the bridge, or the factory becoming a **scheduled Routine**.

## Why a doc-line + issue (two layers)
- **#542** (the issue) holds the spec + graduation condition — durable, but passive.
- **This README line** fires the reminder in-context — high signal, but needs a home for the spec.

Together: reading the promotion steps → see the trigger → jump to #542.

## Test plan
- Doc-only, one paragraph. No code paths. Pre-commit hook passed.
- `#542` reference resolves (issue is open).

Relates to #542.

🤖 Generated with [Claude Code](https://claude.com/claude-code)