### PR TITLE
✨ feat: consistency-audit skill (docs/ADR drift detection)

### DIFF
--- a/.claude/skills/consistency-audit/SKILL.md
+++ b/.claude/skills/consistency-audit/SKILL.md
@@ -39,9 +39,10 @@ safe to run unattended.
    auto-fix PR. The issue body MUST carry a **confidence score** and a
    **counter-evidence / "why this might be wrong"** section.
 3. **The auto-fix path edits authoritative-source-computed values only — never
-   free-form prose.** This is the bound that makes the omitted code-review
-   (below) safe. Any future detector that wants to auto-fix something
-   non-mechanical re-introduces a mandatory `code-reviewer` pass.
+   free-form prose — and the edit is spliced at the detected token's exact
+   offset, not by a free-text replace.** This is the bound that makes the
+   omitted code-review (below) safe. Any future detector that wants to auto-fix
+   something non-mechanical re-introduces a mandatory `code-reviewer` pass.
 4. **Backpressure.** Generators must cap their own work-in-progress so the
    review queue never floods (see WIP cap below).
 5. **Manual-first.** The detector is dry-run by default; only act after a human

--- a/.claude/skills/consistency-audit/SKILL.md
+++ b/.claude/skills/consistency-audit/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: consistency-audit
+description: Detect mechanically-verifiable documentation/ADR drift and act on it — open a docs-fix Draft PR for fixes whose value is uniquely determined by an authoritative source, or file an issue (with confidence + counter-evidence) for drift that needs human judgment. Use when the user asks to run the consistency audit, audit the docs, check for doc/ADR drift, or run the nightly brush-up consistency pass.
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash
+---
+
+# /consistency-audit
+
+One consistency pass: **detect → triage → act**. The detector
+(`scripts/audit_docs.py`) is read-only and prints JSON; this skill consumes
+that JSON and decides what to do with each finding class. Run from the
+repository root of the current checkout.
+
+This is the first generator of the "nightly brush-up automation" family. Its
+**Output Contract** (below) is the reusable part — later generators (i18n
+parity, code analysis, scenario fuzzing) inherit the same gating so they stay
+safe to run unattended.
+
+## Non-goals
+
+- **No scheduled execution.** Invocation is manual. The skill never registers
+  itself. Scheduling lands in a later PR, *after* the operator has validated
+  precision by hand. Until then, the skill's `git push` / `gh pr create` /
+  `gh issue create` calls are NOT on the permission allowlist and will prompt
+  — that human gate is intentional during manual rollout.
+- **No merging, no issue closing.** The human reviews each Draft PR; merging
+  closes nothing automatically here.
+- **No digest yet.** Run history (a `data/audit/digest.md`) is deferred to the
+  scheduling PR, where unattended runs actually need a trail.
+
+## Output Contract (reusable across the brush-up family)
+
+1. **Mechanically-verifiable fix → docs-fix Draft PR.** A finding is
+   auto-fixable only when the correct value is *uniquely determined by an
+   authoritative source* (e.g. a dependency version from `Package.resolved`).
+   Batch all such fixes from one run into a **single** `audit/<date>` Draft PR.
+2. **Detected-but-judgment → issue only.** Anything where the fix needs a human
+   decision (which target did a dead link mean?) is filed as an issue, never an
+   auto-fix PR. The issue body MUST carry a **confidence score** and a
+   **counter-evidence / "why this might be wrong"** section.
+3. **The auto-fix path edits authoritative-source-computed values only — never
+   free-form prose.** This is the bound that makes the omitted code-review
+   (below) safe. Any future detector that wants to auto-fix something
+   non-mechanical re-introduces a mandatory `code-reviewer` pass.
+4. **Backpressure.** Generators must cap their own work-in-progress so the
+   review queue never floods (see WIP cap below).
+5. **Manual-first.** The detector is dry-run by default; only act after a human
+   has eyeballed the dry-run output at least once for a given repo state.
+
+### Why no `code-reviewer` pass here
+
+queue-consumer makes code review mandatory because it writes arbitrary code.
+This skill's auto-fix path writes *only* a version string computed from an
+authoritative source, the PR is always **Draft**, and a human merges it — so
+the human merge IS the review gate, and there is nothing for a reviewer to
+assess on a one-token version swap. The safety rests on the Draft + human-merge
+invariant and Contract rule 3, NOT on the diff being small. If rule 3 is ever
+relaxed, restore the `code-reviewer` pass.
+
+## Constants
+
+- Detector: `.claude/skills/consistency-audit/scripts/audit_docs.py`
+- Auto-fix PR branch: `audit/docs-<YYYYMMDD>` (collision fallback `-2`, `-3`, …)
+- WIP cap: **5** open `audit/*` Draft PRs. At or above the cap, skip the
+  auto-fix PR step entirely (still report). Tune by editing this number.
+- Label: `documentation` (for both PRs and issues)
+
+## Hard rules (non-negotiable)
+
+1. **Never push to main. Never force push.** All pushes are
+   `git push -u origin audit/...`. A PreToolUse guard hook also blocks
+   `--force` shapes and `gh pr ready`.
+2. **PRs are always Draft.** `--draft` is the first flag of `gh pr create`.
+   Never run `gh pr ready`.
+3. **Never close an issue.** Closing happens through the human's merge.
+4. **Conservative detection wins.** Prefer a miss over a wrong flag — a wrong
+   auto-fix PR or a false issue is worse than a missed inconsistency.
+
+## Step 0 — Preflight (abort on any failure)
+
+1. `gh auth status` succeeds.
+2. `python3` and `jq` are available.
+3. Label exists: `gh label list` contains `documentation`.
+4. `git fetch origin main` (any auto-fix branch is cut from `origin/main`).
+5. Working tree clean (`git status --porcelain` empty) — a dirty tree means a
+   prior run died mid-way; abort and report rather than mixing changes.
+
+## Step 1 — Detect (dry-run)
+
+```bash
+python3 .claude/skills/consistency-audit/scripts/audit_docs.py --repo-root . > /tmp/audit.json
+```
+
+Read `/tmp/audit.json`. It has `auto_fixable` and `needs_judgment` arrays.
+**This is the manual precision-check point** — on the first run for a given
+repo state, an operator should sanity-read the findings before acting. If both
+arrays are empty, report "no drift" and stop.
+
+## Step 2 — WIP cap
+
+```bash
+OPEN_AUDIT=$(gh pr list --state open --json isDraft,headRefName \
+  --jq '[.[] | select(.isDraft and (.headRefName | startswith("audit/")))] | length')
+```
+
+If `OPEN_AUDIT >= 5`, **skip Step 3** (do not open another auto-fix PR) and say
+so in the report — the queue is full; merge or close existing `audit/*` PRs
+first. Step 4 (issues) still runs.
+
+## Step 3 — Auto-fixable → one Draft PR
+
+Only if `auto_fixable` is non-empty AND under the WIP cap:
+
+1. Branch from the fetched base:
+   `git switch -c audit/docs-<YYYYMMDD> origin/main` (fallback `-2` on collision).
+2. Apply exactly the mechanical edits:
+   ```bash
+   python3 .claude/skills/consistency-audit/scripts/audit_docs.py --repo-root . --fix > /tmp/audit_fixed.json
+   ```
+3. Verify the drift is gone: re-run the detector (no `--fix`) and confirm
+   `auto_fixable` is now empty. If not, abort and report — do not open a PR.
+4. Commit: `📝 docs: sync drifted references (consistency-audit)`.
+5. Push and open a Draft PR:
+   ```bash
+   git push -u origin audit/docs-<YYYYMMDD>
+   gh pr create --draft --base main --label documentation \
+     --title "📝 docs: sync drifted version references" --body ...
+   ```
+   PR body: one row per fix — `file:line`, what changed (old → new), and the
+   authoritative source — plus a line stating the diff is machine-generated,
+   Draft, and awaits human merge (the review gate; see Output Contract).
+
+## Step 4 — needs_judgment → issues
+
+For each `needs_judgment` finding (already deduped by target):
+
+1. **Dedup across runs:** search open issues for the target; skip if one
+   exists. `gh issue list --state open --search "<target> in:title"`.
+2. File an issue (`--label documentation`) whose body has:
+   - **Locations**: every `file:line` the target is referenced from.
+   - **Confidence**: how sure the detector is this is a real problem.
+   - **Counter-evidence / why this might be wrong**: e.g. the target may be an
+     intentionally-absent path, a generated artifact, or a moved file whose
+     correct new location only a human knows.
+   - **Suggested action**, explicitly left for a human to decide.
+
+Never auto-fix these — the whole point is the fix needs judgment.
+
+## Step 5 — Report
+
+Summarize to the user / transcript: auto-fix PR URL (or "skipped: WIP cap" /
+"none"), issues filed (or skipped-as-duplicate), and the dry-run counts. Point
+at `/tmp/audit.json` for the raw findings.
+
+## Deferred detectors (NOT implemented in v1)
+
+Documented so a later PR can design out the false-positive source before
+enabling. Each floods the reference-dense repo today:
+
+- **file:line citation checks** — docs cite source-root-relative paths
+  (`LLM/Foo.swift` meaning `Pastura/Pastura/LLM/Foo.swift`), GitHub org/repo
+  slugs (`mattt/llama.swift`), external paths (`src/llama-grammar.cpp`), and
+  property accessors (`TurnOutput.primaryText`). A repo-root existence check
+  misreads all of these. Needs source-root resolution + a non-file exclusion.
+- **ADR-missing reference checks** — reserved/not-yet-written ADRs (ADR-006)
+  are referenced from ~20 lines that lack the marker. Needs a canonical
+  reserved-ADR set parsed from the ADR index, not a per-line marker.
+- **broken-anchor / `§"..."` cross-refs** — GitHub-slug anchor matching is
+  fragile on emoji headings and duplicate-heading suffixes; bare `§"..."` prose
+  refs have no unambiguous target. Needs a verified slug normalizer + a target
+  resolution rule.

--- a/.claude/skills/consistency-audit/scripts/audit_docs.py
+++ b/.claude/skills/consistency-audit/scripts/audit_docs.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Mechanically-verifiable documentation / ADR consistency detector.
+
+Read-only by default: prints a JSON report of inconsistencies and exits.
+Nothing is written and no PR/issue is created — that is the consistency-audit
+SKILL's job, which consumes this JSON. This separation keeps detection
+deterministic and testable, and makes "dry-run" the default by construction.
+
+Two finding classes:
+
+  auto_fixable   — the correct value is uniquely determined by an authoritative
+                   source (Package.resolved, project.pbxproj). Safe to rewrite
+                   mechanically; `--fix` applies exactly these edits in place.
+  needs_judgment — detected mechanically, but the fix needs human judgment
+                   (which target did a dead link mean?). Never auto-applied;
+                   the SKILL files an issue with a confidence + counter-evidence
+                   section.
+
+Conservatism is deliberate: false positives poison the queue, so each detector
+prefers a miss over a wrong flag. v1 ships only the three detectors proven to
+fire zero false positives on the current repo (dependency_version, min_ios,
+dead_link). Detectors that flood until their FP sources are designed out are
+intentionally deferred — see the SKILL's "Deferred detectors" note:
+  - file:line citation checks   (docs cite source-root-relative paths, GitHub
+                                 org/repo slugs, and property accessors that a
+                                 naive repo-root existence check misreads)
+  - ADR-missing reference checks (reserved/not-yet-written ADRs like ADR-006
+                                 are referenced from lines without the marker)
+  - broken-anchor / `§"..."`    (fragile GitHub-slug matching; ambiguous target)
+
+usage:
+  audit_docs.py [--repo-root DIR] [--fix]
+                [--package-resolved PATH] [--pbxproj PATH]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Authoritative-source default locations (relative to the repo root). The
+# xcodeproj's resolved file is the one Xcode actually builds against.
+DEFAULT_RESOLVED = (
+    "Pastura/Pastura.xcodeproj/project.xcworkspace/"
+    "xcshareddata/swiftpm/Package.resolved"
+)
+DEFAULT_PBXPROJ = "Pastura/Pastura.xcodeproj/project.pbxproj"
+
+# Dependencies we mirror in docs, keyed by the Package.resolved `identity`.
+# GRDB's identity is `grdb.swift` (not `grdb`); matching by identity — and
+# reading `version`, never `revision` — avoids picking up a transitive pin or
+# substituting a 40-char git SHA into the docs.
+DEP_TOKENS = [("Yams", "yams"), ("GRDB", "grdb.swift")]
+
+SEMVER = re.compile(r"\b\d+\.\d+\.\d+\b")
+IOS_VER = re.compile(r"\b\d+\.\d+\b")
+MINIOS_LABEL = re.compile(r"(?i)min(?:imum)?\s+ios")
+MD_LINK = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+RESERVED = re.compile(r"(?i)reserved|not[\s-]?yet[\s-]?written")
+FENCE = re.compile(r"^\s*(```|~~~)")
+
+EXCLUDE_PARTS = {".git", "DerivedData", "node_modules"}
+
+
+def excluded(relpath: str) -> bool:
+    rp = relpath.replace(os.sep, "/")
+    if any(p in EXCLUDE_PARTS for p in rp.split("/")):
+        return True
+    # Never scan the audit's own fixtures or sibling worktrees.
+    if "tests/fixtures/" in rp + "/" or rp.startswith("tests/fixtures/"):
+        return True
+    if rp.startswith(".claude/worktrees/") or "/.claude/worktrees/" in "/" + rp:
+        return True
+    return False
+
+
+def discover_docs(root: Path) -> list[Path]:
+    docs: list[Path] = []
+    for name in ("CLAUDE.md", "README.md", "CONTRIBUTING.md"):
+        p = root / name
+        if p.is_file():
+            docs.append(p)
+    for base in ("docs", ".claude/rules"):
+        bp = root / base
+        if bp.is_dir():
+            docs.extend(sorted(bp.rglob("*.md")))
+    return [p for p in docs if not excluded(os.path.relpath(p, root))]
+
+
+def load_resolved(path: Path) -> dict[str, str]:
+    """identity -> version, for our mirrored deps only. Reads `version`,
+    never `revision`."""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    out: dict[str, str] = {}
+    wanted = {ident for _, ident in DEP_TOKENS}
+    for pin in data.get("pins", []):
+        ident = pin.get("identity")
+        if ident in wanted:
+            ver = pin.get("state", {}).get("version")
+            if ver:
+                out[ident] = ver
+    return out
+
+
+def load_min_ios(path: Path) -> str | None:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    vals = set(re.findall(r"IPHONEOS_DEPLOYMENT_TARGET\s*=\s*([0-9.]+)", text))
+    return vals.pop() if len(vals) == 1 else None
+
+
+def scan_doc(path: Path, root: Path, resolved: dict[str, str],
+             min_ios: str | None):
+    """Return (auto_fixable, judgment) finding lists for one doc file."""
+    rel = os.path.relpath(path, root).replace(os.sep, "/")
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return [], []
+    auto: list[dict] = []
+    judg: list[dict] = []
+    doc_dir = path.parent
+    in_fence = False
+
+    for lineno, line in enumerate(lines, 1):
+        if FENCE.match(line):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+
+        # --- auto_fixable: dependency version drift ---
+        for display, ident in DEP_TOKENS:
+            if ident not in resolved:
+                continue
+            if not re.search(r"\b" + re.escape(display) + r"\b", line):
+                continue
+            semvers = SEMVER.findall(line)
+            if len(semvers) != 1:  # 0 = no claim, >1 = ambiguous -> skip
+                continue
+            if semvers[0] != resolved[ident]:
+                auto.append({
+                    "type": "dependency_version",
+                    "file": rel, "line": lineno,
+                    "dependency": display,
+                    "current": semvers[0], "expected": resolved[ident],
+                    "authoritative_source": "Package.resolved",
+                })
+
+        # --- auto_fixable: minimum-iOS drift ---
+        if min_ios and MINIOS_LABEL.search(line):
+            vers = IOS_VER.findall(line)
+            if len(vers) == 1 and vers[0] != min_ios:
+                auto.append({
+                    "type": "min_ios",
+                    "file": rel, "line": lineno,
+                    "current": vers[0], "expected": min_ios,
+                    "authoritative_source": "project.pbxproj",
+                })
+
+        # A line carrying a "reserved / not yet written" marker describes an
+        # intentionally-absent target (e.g. the ADR-006 reservation row), so
+        # missing-target detectors must skip it.
+        if RESERVED.search(line):
+            continue
+
+        # --- needs_judgment: dead relative .md links ---
+        for m in MD_LINK.finditer(line):
+            raw = m.group(1).strip()
+            url = raw.split()[0] if raw else ""  # drop optional "title"
+            target = url.split("#", 1)[0]
+            if not target:
+                continue  # pure #anchor -> deferred broken_anchor detector
+            low = target.lower()
+            if low.startswith(("http://", "https://", "mailto:", "tel:",
+                               "//", "/", "#")):
+                continue
+            if not low.endswith(".md"):
+                continue  # v1 scope: doc-to-doc links only
+            tgt = (doc_dir / target).resolve()
+            if not tgt.exists():
+                judg.append({"type": "dead_link", "target": target,
+                             "key": str(tgt), "file": rel, "line": lineno})
+
+    return auto, judg
+
+
+def dedup_judgment(items: list[dict]) -> list[dict]:
+    """Collapse by (type, key) so one broken target is one finding with all
+    its locations — one issue per distinct problem, not per occurrence."""
+    grouped: dict[tuple[str, str], dict] = {}
+    for it in items:
+        gk = (it["type"], it["key"])
+        g = grouped.setdefault(gk, {
+            "type": it["type"], "target": it["target"], "locations": []})
+        g["locations"].append({"file": it["file"], "line": it["line"]})
+    return list(grouped.values())
+
+
+def apply_fixes(root: Path, fixes: list[dict]) -> None:
+    by_file: dict[str, list[dict]] = {}
+    for f in fixes:
+        by_file.setdefault(f["file"], []).append(f)
+    for rel, items in by_file.items():
+        p = root / rel
+        lines = p.read_text(encoding="utf-8").splitlines(keepends=True)
+        for it in items:
+            idx = it["line"] - 1
+            if 0 <= idx < len(lines):
+                lines[idx] = lines[idx].replace(
+                    it["current"], it["expected"], 1)
+        p.write_text("".join(lines), encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--repo-root", default=None)
+    ap.add_argument("--package-resolved", default=None)
+    ap.add_argument("--pbxproj", default=None)
+    ap.add_argument("--fix", action="store_true",
+                    help="apply auto_fixable version-string edits in place")
+    args = ap.parse_args()
+
+    if args.repo_root:
+        root = Path(args.repo_root).resolve()
+    else:
+        try:
+            root = Path(subprocess.check_output(
+                ["git", "rev-parse", "--show-toplevel"],
+                text=True).strip()).resolve()
+        except (subprocess.CalledProcessError, OSError):
+            print("error: not in a git repo; pass --repo-root", file=sys.stderr)
+            return 2
+
+    resolved_path = (Path(args.package_resolved) if args.package_resolved
+                     else root / DEFAULT_RESOLVED)
+    pbxproj_path = (Path(args.pbxproj) if args.pbxproj
+                    else root / DEFAULT_PBXPROJ)
+    resolved = load_resolved(resolved_path)
+    min_ios = load_min_ios(pbxproj_path)
+
+    auto: list[dict] = []
+    judg: list[dict] = []
+    for doc in discover_docs(root):
+        a, j = scan_doc(doc, root, resolved, min_ios)
+        auto.extend(a)
+        judg.extend(j)
+
+    if args.fix and auto:
+        apply_fixes(root, auto)
+
+    report = {
+        "auto_fixable": auto,
+        "needs_judgment": dedup_judgment(judg),
+        "fixed": bool(args.fix and auto),
+    }
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/consistency-audit/scripts/audit_docs.py
+++ b/.claude/skills/consistency-audit/scripts/audit_docs.py
@@ -144,26 +144,34 @@ def scan_doc(path: Path, root: Path, resolved: dict[str, str],
                 continue
             if not re.search(r"\b" + re.escape(display) + r"\b", line):
                 continue
-            semvers = SEMVER.findall(line)
-            if len(semvers) != 1:  # 0 = no claim, >1 = ambiguous -> skip
+            # finditer (not findall) so we keep the matched token's column —
+            # the fixer splices by offset, never by boundary-unaware
+            # str.replace, so a stale value embedded in a non-word-bounded
+            # token elsewhere on the line can never be rewritten by mistake.
+            ms = list(SEMVER.finditer(line))
+            if len(ms) != 1:  # 0 = no claim, >1 = ambiguous -> skip
                 continue
-            if semvers[0] != resolved[ident]:
+            m = ms[0]
+            if m.group(0) != resolved[ident]:
                 auto.append({
                     "type": "dependency_version",
                     "file": rel, "line": lineno,
                     "dependency": display,
-                    "current": semvers[0], "expected": resolved[ident],
+                    "current": m.group(0), "expected": resolved[ident],
+                    "col": m.start(), "end": m.end(),
                     "authoritative_source": "Package.resolved",
                 })
 
         # --- auto_fixable: minimum-iOS drift ---
         if min_ios and MINIOS_LABEL.search(line):
-            vers = IOS_VER.findall(line)
-            if len(vers) == 1 and vers[0] != min_ios:
+            ms = list(IOS_VER.finditer(line))
+            if len(ms) == 1 and ms[0].group(0) != min_ios:
+                m = ms[0]
                 auto.append({
                     "type": "min_ios",
                     "file": rel, "line": lineno,
-                    "current": vers[0], "expected": min_ios,
+                    "current": m.group(0), "expected": min_ios,
+                    "col": m.start(), "end": m.end(),
                     "authoritative_source": "project.pbxproj",
                 })
 
@@ -207,17 +215,28 @@ def dedup_judgment(items: list[dict]) -> list[dict]:
 
 
 def apply_fixes(root: Path, fixes: list[dict]) -> None:
+    """Splice each fix at its recorded [col, end) offset — never str.replace,
+    which is boundary-unaware and could rewrite a stale value embedded in an
+    unrelated token. Apply right-to-left within a file so that an earlier
+    fix's length change cannot shift a later fix's offsets."""
     by_file: dict[str, list[dict]] = {}
     for f in fixes:
         by_file.setdefault(f["file"], []).append(f)
     for rel, items in by_file.items():
         p = root / rel
         lines = p.read_text(encoding="utf-8").splitlines(keepends=True)
-        for it in items:
+        for it in sorted(items, key=lambda x: (x["line"], x.get("col", 0)),
+                         reverse=True):
             idx = it["line"] - 1
-            if 0 <= idx < len(lines):
-                lines[idx] = lines[idx].replace(
-                    it["current"], it["expected"], 1)
+            col, end = it.get("col"), it.get("end")
+            if not (0 <= idx < len(lines)) or col is None or end is None:
+                continue
+            line = lines[idx]
+            # Defensive: only splice if the bytes at the offset still match the
+            # detected value. A mismatch (drifted offsets) is skipped, and the
+            # SKILL's post-fix re-audit will catch the un-applied fix.
+            if line[col:end] == it["current"]:
+                lines[idx] = line[:col] + it["expected"] + line[end:]
         p.write_text("".join(lines), encoding="utf-8")
 
 

--- a/.claude/skills/consistency-audit/tests/fixtures/boundary/CLAUDE.md
+++ b/.claude/skills/consistency-audit/tests/fixtures/boundary/CLAUDE.md
@@ -1,0 +1,10 @@
+# Boundary fixture
+
+Regression for the offset-based fixer. The stale value `7.10.0` appears twice
+on the line below: once embedded in the non-word-bounded token `v7.10.0x`
+(which the detector must NOT count or rewrite) and once as a real, bounded
+version token. `--fix` must rewrite only the bounded token, leaving `v7.10.0x`
+byte-for-byte intact — a boundary-unaware `str.replace` would corrupt the
+first occurrence instead.
+
+Track GRDB v7.10.0x build; pinned GRDB version 7.10.0 here.

--- a/.claude/skills/consistency-audit/tests/fixtures/boundary/Package.resolved
+++ b/.claude/skills/consistency-audit/tests/fixtures/boundary/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "fixtureboundary00000000000000000000000000000000000000000000000",
+  "pins" : [
+    {
+      "identity" : "grdb.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/groue/GRDB.swift.git",
+      "state" : {
+        "revision" : "9ed8c8457e00aaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "version" : "7.11.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/.claude/skills/consistency-audit/tests/fixtures/clean/CLAUDE.md
+++ b/.claude/skills/consistency-audit/tests/fixtures/clean/CLAUDE.md
@@ -1,0 +1,39 @@
+# Clean fixture
+
+Every reference here is consistent — the auditor must report ZERO findings.
+This fixture doubles as the "must-NOT-fire" regression set for the three
+active detectors (dependency_version, min_ios, dead_link). The deferred
+detectors (file:line, ADR-missing, anchors) are not exercised here.
+
+## Tech Stack
+
+| Component   | Choice | Version |
+|-------------|--------|---------|
+| YAML parser | Yams   | 6.2.2   |
+| SQLite      | GRDB   | 7.11.0  |
+| Min iOS     | 17.0   |         |
+| Language    | Swift  | 6.x     |
+
+Swift is intentionally written as `6.x` (a range) while the build pins
+`SWIFT_VERSION = 6.0` — the auditor must NOT treat this as drift (Swift
+version is excluded).
+
+## Prose that must not fire
+
+- iOS 26 Liquid Glass is mentioned here, but this line has no "min", so the
+  min-iOS detector must skip it.
+- The explanatory line "Yams ships 6.2.2 and 6.2.2 again" has two semver
+  tokens, so the dependency detector must skip it as ambiguous.
+- A working doc link: [foo](docs/foo.md).
+- A working nested doc link: [adr](docs/decisions/ADR-001.md).
+- A reserved-line link is skipped: [future](docs/not-written.md) — reserved,
+  not yet written.
+
+## Fenced block (must be skipped)
+
+```
+[broken](docs/does-not-exist.md)
+| stale | Yams | 1.0.0 |
+```
+
+The references inside the fence above must be skipped.

--- a/.claude/skills/consistency-audit/tests/fixtures/clean/Package.resolved
+++ b/.claude/skills/consistency-audit/tests/fixtures/clean/Package.resolved
@@ -1,0 +1,33 @@
+{
+  "originHash" : "fixtureclean000000000000000000000000000000000000000000000000000",
+  "pins" : [
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "a27b21e0c81c0d4c6f99af3d31bcc4b85ea38c8e",
+        "version" : "6.2.2"
+      }
+    },
+    {
+      "identity" : "grdb.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/groue/GRDB.swift.git",
+      "state" : {
+        "revision" : "9ed8c8457e00aaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "version" : "7.11.0"
+      }
+    },
+    {
+      "identity" : "swift-transitive",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/example/swift-transitive.git",
+      "state" : {
+        "revision" : "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        "version" : "2.8694.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/.claude/skills/consistency-audit/tests/fixtures/clean/docs/decisions/ADR-001.md
+++ b/.claude/skills/consistency-audit/tests/fixtures/clean/docs/decisions/ADR-001.md
@@ -1,0 +1,3 @@
+# ADR-001
+
+A real ADR so the `ADR-001` reference in the clean fixture resolves.

--- a/.claude/skills/consistency-audit/tests/fixtures/clean/docs/foo.md
+++ b/.claude/skills/consistency-audit/tests/fixtures/clean/docs/foo.md
@@ -1,0 +1,4 @@
+# Foo
+
+A real doc so the working link and file:line citation in the clean fixture
+resolve.

--- a/.claude/skills/consistency-audit/tests/fixtures/clean/pbxproj.txt
+++ b/.claude/skills/consistency-audit/tests/fixtures/clean/pbxproj.txt
@@ -1,0 +1,5 @@
+/* fixture excerpt — only the keys the auditor reads */
+		IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+		SWIFT_VERSION = 6.0;
+		IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+		SWIFT_VERSION = 6.0;

--- a/.claude/skills/consistency-audit/tests/fixtures/drift/CLAUDE.md
+++ b/.claude/skills/consistency-audit/tests/fixtures/drift/CLAUDE.md
@@ -1,0 +1,19 @@
+# Drift fixture
+
+The version strings below disagree with the authoritative sources, so the
+auditor must report three `auto_fixable` findings, and `--fix` must rewrite
+them to match.
+
+| Component | Choice | Version |
+|-----------|--------|---------|
+| YAML parser | Yams | 6.2.1 |
+| SQLite | GRDB | 7.10.0 |
+| Min iOS | 16.0 | |
+
+The explanatory bullets below mention both the stale and the correct value on
+one line, so the detector must skip them (two versions on a line is
+ambiguous) and fire only on the single-version table rows above:
+
+- Yams resolves to 6.2.2 (doc table says 6.2.1).
+- GRDB resolves to 7.11.0 (doc table says 7.10.0).
+- The build targets iOS 17.0 (doc Min iOS says 16.0).

--- a/.claude/skills/consistency-audit/tests/fixtures/drift/Package.resolved
+++ b/.claude/skills/consistency-audit/tests/fixtures/drift/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "fixturedrift000000000000000000000000000000000000000000000000000",
+  "pins" : [
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "a27b21e0c81c0d4c6f99af3d31bcc4b85ea38c8e",
+        "version" : "6.2.2"
+      }
+    },
+    {
+      "identity" : "grdb.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/groue/GRDB.swift.git",
+      "state" : {
+        "revision" : "9ed8c8457e00aaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "version" : "7.11.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/.claude/skills/consistency-audit/tests/fixtures/drift/pbxproj.txt
+++ b/.claude/skills/consistency-audit/tests/fixtures/drift/pbxproj.txt
@@ -1,0 +1,3 @@
+/* fixture excerpt — only the keys the auditor reads */
+		IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+		SWIFT_VERSION = 6.0;

--- a/.claude/skills/consistency-audit/tests/fixtures/judgment/CLAUDE.md
+++ b/.claude/skills/consistency-audit/tests/fixtures/judgment/CLAUDE.md
@@ -1,0 +1,20 @@
+# Judgment fixture
+
+No authoritative sources accompany this fixture (the auditor must degrade
+gracefully and report zero `auto_fixable` findings). Two distinct dead doc
+links are expected as `needs_judgment` findings; the negatives below must NOT
+fire.
+
+- A dead doc link: [gone](docs/missing-a.md).
+- Another dead doc link to a different target: [also gone](docs/missing-b.md).
+
+Negatives (must not fire):
+
+- A working link resolves: [foo](docs/foo.md).
+- An external link is ignored: [repo](https://github.com/example/repo).
+- A link on a reserved line is skipped: [future](docs/not-written.md) is
+  reserved — not yet written.
+
+```
+[fenced](docs/missing-c.md) lives inside a code fence and must be skipped.
+```

--- a/.claude/skills/consistency-audit/tests/fixtures/judgment/docs/foo.md
+++ b/.claude/skills/consistency-audit/tests/fixtures/judgment/docs/foo.md
@@ -1,0 +1,3 @@
+# Foo
+
+A real doc so the working-link negative in the judgment fixture resolves.

--- a/.claude/skills/consistency-audit/tests/run_tests.sh
+++ b/.claude/skills/consistency-audit/tests/run_tests.sh
@@ -29,12 +29,15 @@ OUT=$(python3 "$AUDIT" --repo-root fixtures/drift \
   --pbxproj fixtures/drift/pbxproj.txt)
 [ "$(af_len "$OUT")" -eq 3 ] || fail "drift: expected 3 auto_fixable, got $(af_len "$OUT")"
 [ "$(nj_len "$OUT")" -eq 0 ] || fail "drift: needs_judgment not empty: $(echo "$OUT" | jq -c .needs_judgment)"
-# the GRDB fix must come from the resolved "version" (7.11.0)...
+# the fixes must come from the resolved "version" (GRDB 7.11.0 / Yams 6.2.2)...
 echo "$OUT" | jq -e '.auto_fixable[] | select(.dependency=="GRDB" and .expected=="7.11.0")' >/dev/null \
   || fail "drift: GRDB expected value is not 7.11.0"
-# ...never from a git "revision" SHA (the version-vs-revision trap).
-if echo "$OUT" | jq -e '.auto_fixable[] | select(.expected|test("^[0-9a-f]{12,}$"))' >/dev/null; then
-  fail "drift: a fix used a git revision SHA instead of the version"
+echo "$OUT" | jq -e '.auto_fixable[] | select(.dependency=="Yams" and .expected=="6.2.2")' >/dev/null \
+  || fail "drift: Yams expected value is not 6.2.2"
+# ...never a git "revision": every dependency expected must be a clean semver
+# (positive allowlist, so a SHA of any length — not just 12+ hex — fails).
+if echo "$OUT" | jq -e '.auto_fixable[] | select(.type=="dependency_version") | select((.expected|test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))|not)' >/dev/null; then
+  fail "drift: a dependency expected value is not a clean semver (revision leak?)"
 fi
 
 # --- --fix applies the version edits in place, leaving zero drift ----------
@@ -49,6 +52,23 @@ OUT=$(python3 "$AUDIT" --repo-root "$TMP/drift" \
   --package-resolved "$TMP/drift/Package.resolved" \
   --pbxproj "$TMP/drift/pbxproj.txt")
 [ "$(af_len "$OUT")" -eq 0 ] || fail "--fix: drift remains after fix: $(echo "$OUT" | jq -c .auto_fixable)"
+
+# --- boundary: --fix splices at the offset, never str.replace -------------
+# The stale value also appears inside the non-bounded token `v7.10.0x`, which
+# a boundary-unaware replace would corrupt while leaving the real drift.
+cp -R fixtures/boundary "$TMP/boundary"
+OUT=$(python3 "$AUDIT" --repo-root "$TMP/boundary" \
+  --package-resolved "$TMP/boundary/Package.resolved")
+[ "$(af_len "$OUT")" -eq 1 ] || fail "boundary: expected 1 auto_fixable, got $(af_len "$OUT")"
+python3 "$AUDIT" --repo-root "$TMP/boundary" \
+  --package-resolved "$TMP/boundary/Package.resolved" --fix >/dev/null
+grep -qF "v7.10.0x" "$TMP/boundary/CLAUDE.md" \
+  || fail "boundary: --fix corrupted the non-bounded token v7.10.0x"
+grep -qF "version 7.11.0" "$TMP/boundary/CLAUDE.md" \
+  || fail "boundary: --fix did not correct the bounded version token"
+OUT=$(python3 "$AUDIT" --repo-root "$TMP/boundary" \
+  --package-resolved "$TMP/boundary/Package.resolved")
+[ "$(af_len "$OUT")" -eq 0 ] || fail "boundary: drift remains after offset fix"
 
 # --- judgment fixture: two dead_link findings, missing sources tolerated ----
 # Also the must-NOT-fire negatives: working link, external link, reserved-line

--- a/.claude/skills/consistency-audit/tests/run_tests.sh
+++ b/.claude/skills/consistency-audit/tests/run_tests.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Self-test for the consistency-audit detector. No Swift toolchain or network
+# needed — exercises the three fixture repos (clean / drift / judgment)
+# against audit_docs.py, including the must-NOT-fire regression set and the
+# Package.resolved version-vs-revision trap.
+#
+# usage: bash .claude/skills/consistency-audit/tests/run_tests.sh
+# requires: python3, jq
+set -eu
+cd "$(dirname "$0")"
+AUDIT=../scripts/audit_docs.py
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+af_len() { echo "$1" | jq '.auto_fixable | length'; }
+nj_len() { echo "$1" | jq '.needs_judgment | length'; }
+
+# --- clean fixture: zero findings (doubles as the must-NOT-fire set) --------
+OUT=$(python3 "$AUDIT" --repo-root fixtures/clean \
+  --package-resolved fixtures/clean/Package.resolved \
+  --pbxproj fixtures/clean/pbxproj.txt)
+[ "$(af_len "$OUT")" -eq 0 ] || fail "clean: auto_fixable not empty: $(echo "$OUT" | jq -c .auto_fixable)"
+[ "$(nj_len "$OUT")" -eq 0 ] || fail "clean: needs_judgment not empty: $(echo "$OUT" | jq -c .needs_judgment)"
+
+# --- drift fixture: three auto_fixable, no judgment -------------------------
+OUT=$(python3 "$AUDIT" --repo-root fixtures/drift \
+  --package-resolved fixtures/drift/Package.resolved \
+  --pbxproj fixtures/drift/pbxproj.txt)
+[ "$(af_len "$OUT")" -eq 3 ] || fail "drift: expected 3 auto_fixable, got $(af_len "$OUT")"
+[ "$(nj_len "$OUT")" -eq 0 ] || fail "drift: needs_judgment not empty: $(echo "$OUT" | jq -c .needs_judgment)"
+# the GRDB fix must come from the resolved "version" (7.11.0)...
+echo "$OUT" | jq -e '.auto_fixable[] | select(.dependency=="GRDB" and .expected=="7.11.0")' >/dev/null \
+  || fail "drift: GRDB expected value is not 7.11.0"
+# ...never from a git "revision" SHA (the version-vs-revision trap).
+if echo "$OUT" | jq -e '.auto_fixable[] | select(.expected|test("^[0-9a-f]{12,}$"))' >/dev/null; then
+  fail "drift: a fix used a git revision SHA instead of the version"
+fi
+
+# --- --fix applies the version edits in place, leaving zero drift ----------
+cp -R fixtures/drift "$TMP/drift"
+python3 "$AUDIT" --repo-root "$TMP/drift" \
+  --package-resolved "$TMP/drift/Package.resolved" \
+  --pbxproj "$TMP/drift/pbxproj.txt" --fix >/dev/null
+grep -qF "| Yams | 6.2.2 |" "$TMP/drift/CLAUDE.md" || fail "--fix: Yams table row not rewritten"
+grep -qF "| GRDB | 7.11.0 |" "$TMP/drift/CLAUDE.md" || fail "--fix: GRDB table row not rewritten"
+grep -qF "| Min iOS | 17.0 |" "$TMP/drift/CLAUDE.md" || fail "--fix: Min iOS table row not rewritten"
+OUT=$(python3 "$AUDIT" --repo-root "$TMP/drift" \
+  --package-resolved "$TMP/drift/Package.resolved" \
+  --pbxproj "$TMP/drift/pbxproj.txt")
+[ "$(af_len "$OUT")" -eq 0 ] || fail "--fix: drift remains after fix: $(echo "$OUT" | jq -c .auto_fixable)"
+
+# --- judgment fixture: two dead_link findings, missing sources tolerated ----
+# Also the must-NOT-fire negatives: working link, external link, reserved-line
+# link, and a fenced link are all present and must stay silent.
+OUT=$(python3 "$AUDIT" --repo-root fixtures/judgment)
+[ "$(af_len "$OUT")" -eq 0 ] || fail "judgment: auto_fixable should be empty when sources are absent"
+[ "$(nj_len "$OUT")" -eq 2 ] || fail "judgment: expected 2 needs_judgment, got $(nj_len "$OUT"): $(echo "$OUT" | jq -c .needs_judgment)"
+[ "$(echo "$OUT" | jq '[.needs_judgment[] | select(.type=="dead_link")] | length')" -eq 2 ] \
+  || fail "judgment: both findings should be dead_link"
+echo "$OUT" | jq -e '.needs_judgment[] | select(.target=="docs/missing-a.md")' >/dev/null \
+  || fail "judgment: missing-a.md dead link not found"
+
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
## Summary

PR #1 of the "nightly brush-up automation" initiative — a `consistency-audit` skill that detects mechanically-verifiable documentation/ADR drift and acts on it, plus the reusable **Output Contract** later generators inherit.

- **Detector** (`scripts/audit_docs.py`) — read-only, dry-run by default; `--fix` applies only `auto_fixable` version-string edits, spliced at the detected token's offset (never a boundary-unaware replace).
- **v1 detectors** (proven zero false positives against current main): `dependency_version` (Yams/GRDB vs Package.resolved, keyed on identity, reads `version` never `revision`), `min_ios` (vs pbxproj IPHONEOS_DEPLOYMENT_TARGET), `dead_link` (relative `.md` targets).
- **Output Contract** (reusable): mechanical fix → one batched Draft PR; judgment → issue with confidence + counter-evidence; auto-fix bounded to authoritative-source values; WIP cap (5 open `audit/*` Draft PRs) as backpressure.
- **Deferred detectors** documented with the FP source each must design out (file:line, ADR-missing, anchors) — they flood the reference-dense repo today.
- **Manual-first**: no self-scheduling; digest + the Draft-PR triage guardian are follow-up PRs.

Conservatism is the prime directive: a wrong auto-fix poisons the queue, so each detector prefers a miss over a wrong flag. `code-reviewer` is deliberately omitted on auto-fix PRs (Draft + human-merge is the gate; bounded to version-string offset edits) — rationale in SKILL.md.

## Test plan

- `bash .claude/skills/consistency-audit/tests/run_tests.sh` → ALL TESTS PASSED (clean / drift / boundary / judgment fixtures; version-vs-revision trap; offset-splice regression; must-NOT-fire set).
- Dry-run against current main: 0 false positives.

## Note — the tool's first real catch (NOT fixed here)

The dry-run flagged a genuine drift: `docs/specs/demo-replay-spec.md:104` says "reuses Yams **6.2.1**" while the project resolves Yams 6.2.2. Left for the skill itself to auto-PR once it runs — kept out of this tooling PR for scope purity.

Closes #544