### PR TITLE
✨ feat: snapshot scenario into runs + safe scenario delete (v7)

### DIFF
--- a/.claude/rules/models-and-data.md
+++ b/.claude/rules/models-and-data.md
@@ -132,7 +132,7 @@ All records use `var` properties (GRDB convention for mutable persistence).
 | Protocol | Implementation | Key Operations |
 |----------|---------------|----------------|
 | `ScenarioRepository` | `GRDBScenarioRepository` | save (upsert), fetchById, fetchAll, fetchPresets, delete |
-| `SimulationRepository` | `GRDBSimulationRepository` | save, fetchById, fetchByScenarioId, updateState, updateStatus, delete |
+| `SimulationRepository` | `GRDBSimulationRepository` | save, fetchById, fetchByScenarioId, fetchOrphaned, updateState, updateStatus, delete |
 | `TurnRepository` | `GRDBTurnRepository` | save, saveBatch, fetchBySimulationId, fetchBySimulationAndRound, deleteBySimulationId |
 
 Repositories take `any DatabaseWriter` in their initializer. All methods are synchronous (`throws`).

--- a/.claude/rules/models-and-data.md
+++ b/.claude/rules/models-and-data.md
@@ -77,14 +77,18 @@ scenarios (
 
 simulations (
     id TEXT PRIMARY KEY,
-    scenarioId TEXT NOT NULL REFERENCES scenarios ON DELETE CASCADE,
+    scenarioId TEXT REFERENCES scenarios ON DELETE SET NULL,  -- nullable since v7: orphan (not cascade-delete) runs on scenario delete
     status TEXT NOT NULL DEFAULT 'running',  -- running | paused | completed
     currentRound INTEGER NOT NULL DEFAULT 0,
     currentPhaseIndex INTEGER NOT NULL DEFAULT 0,
     stateJSON TEXT NOT NULL,  -- Codable SimulationState
     configJSON TEXT,
     createdAt DATETIME NOT NULL,
-    updatedAt DATETIME NOT NULL
+    updatedAt DATETIME NOT NULL,
+    modelIdentifier TEXT,         -- LLM model label (v3); NULL for pre-v3 rows
+    llmBackend TEXT,              -- LLM backend label (v3); NULL for pre-v3 rows
+    scenarioYamlSnapshot TEXT,    -- v7: source scenario YAML captured at run-creation; NULL pre-v7
+    scenarioNameSnapshot TEXT     -- v7: source scenario name captured at run-creation; NULL pre-v7
 )
 
 turns (

--- a/Pastura/Pastura/App/ModelRegistry.swift
+++ b/Pastura/Pastura/App/ModelRegistry.swift
@@ -130,7 +130,9 @@ enum ModelRegistry {
   }
 
   /// Precondition-checks the production catalog for duplicate `id` / `fileName` values.
-  /// Call once at app launch (future Item — this PR only provides the API).
+  /// Called once at app launch from `PasturaApp.initialize()` to fail fast on
+  /// catalog collisions before they can corrupt `ModelManager.state` lookups
+  /// or filesystem paths.
   nonisolated static func validateNoCollisions() {
     let reasons = findCollisions(in: catalog)
     precondition(

--- a/Pastura/Pastura/App/ResultsViewModel.swift
+++ b/Pastura/Pastura/App/ResultsViewModel.swift
@@ -150,9 +150,44 @@ final class ResultsViewModel {
         ))
     }
 
+    // Surface orphaned runs (scenarioId == nil) whose source scenario was
+    // deleted. The scenario-driven loop above can't reach them, and they
+    // carry no live `sourceId`/`id`, so they group under a reserved canonical
+    // key (NUL-prefixed) that cannot collide with a live group, and are
+    // appended after the live groups regardless of name ordering.
+    let orphanGroups = try await orphanedGroups()
+
     // Stable cross-group order keyed by canonical id so reloads
-    // don't flicker.
+    // don't flicker. Orphaned (deleted-scenario) groups always sort last.
     return result.sorted { $0.canonicalKey < $1.canonicalKey }
+      + orphanGroups.sorted { $0.sectionName < $1.sectionName }
+  }
+
+  /// Reserved canonical-key prefix for orphaned-run groups. The leading NUL
+  /// guarantees no collision with a live scenario's `sourceId ?? id`.
+  private static let orphanCanonicalKeyPrefix = "\u{0}orphan:"
+
+  /// Builds groups for orphaned runs (`scenarioId IS NULL`), bucketed by the
+  /// scenario name captured in each run's snapshot.
+  private func orphanedGroups() async throws -> [ScenarioGroup] {
+    let orphans = try await offMain { [simulationRepository] in
+      try simulationRepository.fetchOrphaned()
+    }
+    guard !orphans.isEmpty else { return [] }
+
+    let byName = Dictionary(grouping: orphans) {
+      $0.scenarioNameSnapshot ?? String(localized: "Deleted scenario")
+    }
+    return byName.map { name, sims in
+      let rows =
+        sims
+        .map { SimulationRow(record: $0, variantName: name) }
+        .sorted { $0.record.createdAt > $1.record.createdAt }
+      return ScenarioGroup(
+        sectionName: name,
+        canonicalKey: Self.orphanCanonicalKeyPrefix + name,
+        rows: rows)
+    }
   }
 
   /// Detail path: shows only this scenario's simulations. No cross-

--- a/Pastura/Pastura/App/ResultsViewModel.swift
+++ b/Pastura/Pastura/App/ResultsViewModel.swift
@@ -175,17 +175,20 @@ final class ResultsViewModel {
     }
     guard !orphans.isEmpty else { return [] }
 
-    let byName = Dictionary(grouping: orphans) {
-      $0.scenarioNameSnapshot ?? String(localized: "Deleted scenario")
-    }
-    return byName.map { name, sims in
+    let byName = Dictionary(grouping: orphans) { $0.scenarioNameSnapshot }
+    return byName.map { snapshotName, sims in
+      let sectionName = snapshotName ?? String(localized: "Deleted scenario")
+      // Key on the locale-invariant snapshot name (or a fixed sentinel for
+      // the nameless case) so the group's identity / sort order never depends
+      // on the display locale — only `sectionName` carries localized text.
+      let keySuffix = snapshotName ?? "\u{0}unnamed"
       let rows =
         sims
-        .map { SimulationRow(record: $0, variantName: name) }
+        .map { SimulationRow(record: $0, variantName: sectionName) }
         .sorted { $0.record.createdAt > $1.record.createdAt }
       return ScenarioGroup(
-        sectionName: name,
-        canonicalKey: Self.orphanCanonicalKeyPrefix + name,
+        sectionName: sectionName,
+        canonicalKey: Self.orphanCanonicalKeyPrefix + keySuffix,
         rows: rows)
     }
   }

--- a/Pastura/Pastura/App/ScenarioSnapshotResolver.swift
+++ b/Pastura/Pastura/App/ScenarioSnapshotResolver.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Resolves the `ScenarioRecord` to use when displaying or exporting a past
+/// simulation run.
+///
+/// Past results must be faithful to the scenario that *actually ran*, not to
+/// the live scenario row — which the user may have since edited or deleted.
+/// Since the v7 migration, each run carries a `scenarioYamlSnapshot` +
+/// `scenarioNameSnapshot` captured at creation time. This resolver:
+///
+/// 1. **Prefers the snapshot** when present — fixing edit-drift (a later edit
+///    to the live scenario no longer changes historical runs) and surviving
+///    deletion (orphaned runs whose `scenarioId` is `nil` still resolve).
+/// 2. **Falls back to the live scenario** for pre-v7 runs that predate the
+///    snapshot columns; those still carry a valid `scenarioId`.
+/// 3. Returns `nil` only when neither source is available.
+///
+/// The synthesized record is a transient value (never persisted), so read
+/// paths that consume a non-optional `ScenarioRecord`
+/// (`ResultDetailExportAssembler`, `ResultMarkdownExporter.Input`) keep their
+/// signatures unchanged.
+nonisolated enum ScenarioSnapshotResolver {
+  /// - Parameters:
+  ///   - simulation: The run whose scenario should be resolved.
+  ///   - liveLookup: Fetches the live `ScenarioRecord` by id (typically
+  ///     `ScenarioRepository.fetchById`). Only invoked for pre-v7 runs with
+  ///     no snapshot.
+  static func resolve(
+    for simulation: SimulationRecord,
+    liveLookup: (String) throws -> ScenarioRecord?
+  ) rethrows -> ScenarioRecord? {
+    if let snapshotYaml = simulation.scenarioYamlSnapshot {
+      return ScenarioRecord(
+        id: simulation.scenarioId ?? simulation.id,
+        name: simulation.scenarioNameSnapshot ?? "",
+        yamlDefinition: snapshotYaml,
+        isPreset: false,
+        createdAt: simulation.createdAt,
+        updatedAt: simulation.updatedAt)
+    }
+    guard let scenarioId = simulation.scenarioId else { return nil }
+    return try liveLookup(scenarioId)
+  }
+}

--- a/Pastura/Pastura/App/ScenarioSnapshotResolver.swift
+++ b/Pastura/Pastura/App/ScenarioSnapshotResolver.swift
@@ -30,6 +30,9 @@ nonisolated enum ScenarioSnapshotResolver {
     liveLookup: (String) throws -> ScenarioRecord?
   ) rethrows -> ScenarioRecord? {
     if let snapshotYaml = simulation.scenarioYamlSnapshot {
+      // For an orphaned run (`scenarioId` nil) the synthesized record's `id`
+      // is the simulation id — a placeholder so callers have a stable id, NOT
+      // a live scenario id. Never feed it back into `ScenarioRepository`.
       return ScenarioRecord(
         id: simulation.scenarioId ?? simulation.id,
         name: simulation.scenarioNameSnapshot ?? "",

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -1080,6 +1080,13 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   ) async {
     do {
       let stateJSON = try JSONEncoder().encode(state)
+      // Snapshot the scenario that actually ran by re-serializing the live
+      // domain object — NOT by re-fetching the persisted record by id. The
+      // domain object is always in hand here, so the snapshot is faithful to
+      // this run and independent of whether/when the scenario row is later
+      // edited or deleted. Read paths reconstruct from this when `scenarioId`
+      // is nil (scenario deleted) or to avoid edit-drift while it still exists.
+      let scenarioYamlSnapshot = ScenarioSerializer().serialize(scenario)
       let record = SimulationRecord(
         id: simId,
         scenarioId: scenario.id,
@@ -1091,7 +1098,9 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
         createdAt: Date(),
         updatedAt: Date(),
         modelIdentifier: llm.modelIdentifier,
-        llmBackend: llm.backendIdentifier
+        llmBackend: llm.backendIdentifier,
+        scenarioYamlSnapshot: scenarioYamlSnapshot,
+        scenarioNameSnapshot: scenario.name
       )
       try await offMain { [simulationRepository] in
         try simulationRepository.save(record)

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -1288,14 +1288,13 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     let codePhaseEventRepository = self.codePhaseEventRepository
 
     let records: ExportRecords? = try await offMain {
-      // `scenarioId` is optional since v7 (SET NULL on scenario delete).
-      // This live-scenario lookup is replaced by the snapshot resolver in a
-      // later step; for now it preserves the pre-v7 behavior for runs whose
-      // scenario still exists.
+      // Resolve via the run's own snapshot (faithful to what ran, and works
+      // for orphaned runs whose scenario was deleted); falls back to the live
+      // scenario only for pre-v7 runs without a snapshot.
       guard
         let sim = try simulationRepository.fetchById(simId),
-        let scenarioId = sim.scenarioId,
-        let scenario = try scenarioRepository.fetchById(scenarioId)
+        let scenario = try ScenarioSnapshotResolver.resolve(
+          for: sim, liveLookup: scenarioRepository.fetchById)
       else {
         return nil
       }

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -1279,9 +1279,14 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     let codePhaseEventRepository = self.codePhaseEventRepository
 
     let records: ExportRecords? = try await offMain {
+      // `scenarioId` is optional since v7 (SET NULL on scenario delete).
+      // This live-scenario lookup is replaced by the snapshot resolver in a
+      // later step; for now it preserves the pre-v7 behavior for runs whose
+      // scenario still exists.
       guard
         let sim = try simulationRepository.fetchById(simId),
-        let scenario = try scenarioRepository.fetchById(sim.scenarioId)
+        let scenarioId = sim.scenarioId,
+        let scenario = try scenarioRepository.fetchById(scenarioId)
       else {
         return nil
       }

--- a/Pastura/Pastura/Data/DatabaseManager.swift
+++ b/Pastura/Pastura/Data/DatabaseManager.swift
@@ -113,6 +113,56 @@ nonisolated public final class DatabaseManager: Sendable {
         t.add(column: "phasePathJSON", .text)
       }
     }
+
+    registerV7(&migrator)
+  }
+
+  private static func registerV7(_ migrator: inout DatabaseMigrator) {
+    // Snapshot the source scenario into each run + relax the scenario FK so
+    // deleting/editing a scenario no longer destroys or drifts past results.
+    //
+    // SQLite cannot ALTER a column's FK action or nullability in place, so
+    // the `simulations` table is rebuilt. The default `.deferred` foreign-key
+    // policy runs this body with `PRAGMA foreign_keys = OFF` (GRDB follows the
+    // SQLite "other kinds of table schema changes" recipe), so dropping the
+    // old table does NOT cascade-delete the child `turns` /
+    // `code_phase_events` rows; integrity is re-verified at commit.
+    migrator.registerMigration("v7_snapshotScenarioAndRelaxScenarioFK") { db in
+      try db.create(table: "new_simulations") { t in
+        t.primaryKey("id", .text)
+        // Nullable + SET NULL (was NOT NULL + CASCADE): orphan runs on
+        // scenario deletion instead of cascade-deleting their history.
+        t.column("scenarioId", .text)
+          .references("scenarios", onDelete: .setNull)
+        t.column("status", .text).notNull().defaults(to: "running")
+        t.column("currentRound", .integer).notNull().defaults(to: 0)
+        t.column("currentPhaseIndex", .integer).notNull().defaults(to: 0)
+        t.column("stateJSON", .text).notNull()
+        t.column("configJSON", .text)
+        t.column("createdAt", .datetime).notNull()
+        t.column("updatedAt", .datetime).notNull()
+        t.column("modelIdentifier", .text)
+        t.column("llmBackend", .text)
+        t.column("scenarioYamlSnapshot", .text)
+        t.column("scenarioNameSnapshot", .text)
+      }
+
+      // Copy existing rows. Snapshot columns stay NULL for migrated runs —
+      // they fall back to the live scenario via `scenarioId` while it exists.
+      try db.execute(
+        sql: """
+          INSERT INTO new_simulations
+            (id, scenarioId, status, currentRound, currentPhaseIndex,
+             stateJSON, configJSON, createdAt, updatedAt, modelIdentifier, llmBackend)
+          SELECT
+            id, scenarioId, status, currentRound, currentPhaseIndex,
+            stateJSON, configJSON, createdAt, updatedAt, modelIdentifier, llmBackend
+          FROM simulations
+          """)
+
+      try db.drop(table: "simulations")
+      try db.rename(table: "new_simulations", to: "simulations")
+    }
   }
 
   private static func registerV1(_ migrator: inout DatabaseMigrator) {

--- a/Pastura/Pastura/Data/Models/SimulationRecord.swift
+++ b/Pastura/Pastura/Data/Models/SimulationRecord.swift
@@ -12,7 +12,12 @@ nonisolated public struct SimulationRecord: Codable, Sendable, Equatable,
   public static let databaseTableName = "simulations"
 
   public var id: String
-  public var scenarioId: String
+  /// Foreign key into `scenarios`. Nullable since v7: the FK is
+  /// `ON DELETE SET NULL`, so removing a scenario orphans its runs (sets
+  /// this to nil) rather than cascade-deleting them — past results survive
+  /// scenario deletion. Read paths fall back to the `scenario*Snapshot`
+  /// fields below when this is nil.
+  public var scenarioId: String?
   public var status: String
   public var currentRound: Int
   public var currentPhaseIndex: Int
@@ -28,10 +33,20 @@ nonisolated public struct SimulationRecord: Codable, Sendable, Equatable,
   /// Human-readable label for the LLM backend runtime (e.g. `"llama.cpp"`,
   /// `"Ollama"`). Nil for rows created before the v3 migration.
   public var llmBackend: String?
+  /// Snapshot of the source scenario's raw YAML, captured at run-creation
+  /// time. Keeps past-results / export self-contained so editing or deleting
+  /// the source scenario does not drift or destroy historical runs. Nil for
+  /// rows created before the v7 migration (those fall back to the live
+  /// scenario via `scenarioId` while it still exists).
+  public var scenarioYamlSnapshot: String?
+  /// Snapshot of the source scenario's display name, captured at
+  /// run-creation time. Used as the section/label for orphaned runs whose
+  /// `scenarioId` is nil. Nil for rows created before the v7 migration.
+  public var scenarioNameSnapshot: String?
 
   public init(
     id: String,
-    scenarioId: String,
+    scenarioId: String?,
     status: String,
     currentRound: Int,
     currentPhaseIndex: Int,
@@ -40,7 +55,9 @@ nonisolated public struct SimulationRecord: Codable, Sendable, Equatable,
     createdAt: Date,
     updatedAt: Date,
     modelIdentifier: String? = nil,
-    llmBackend: String? = nil
+    llmBackend: String? = nil,
+    scenarioYamlSnapshot: String? = nil,
+    scenarioNameSnapshot: String? = nil
   ) {
     self.id = id
     self.scenarioId = scenarioId
@@ -53,6 +70,8 @@ nonisolated public struct SimulationRecord: Codable, Sendable, Equatable,
     self.updatedAt = updatedAt
     self.modelIdentifier = modelIdentifier
     self.llmBackend = llmBackend
+    self.scenarioYamlSnapshot = scenarioYamlSnapshot
+    self.scenarioNameSnapshot = scenarioNameSnapshot
   }
 
   /// Type-safe accessor for the simulation status.

--- a/Pastura/Pastura/Data/SimulationRepository.swift
+++ b/Pastura/Pastura/Data/SimulationRepository.swift
@@ -13,6 +13,12 @@ nonisolated public protocol SimulationRepository: Sendable {
   /// Fetches all simulations for a given scenario.
   func fetchByScenarioId(_ scenarioId: String) throws -> [SimulationRecord]
 
+  /// Fetches all "orphaned" simulations — runs whose source scenario was
+  /// deleted, leaving `scenarioId` NULL (the FK is `ON DELETE SET NULL`
+  /// since v7). Their display data lives in the `scenario*Snapshot` columns.
+  /// Ordered newest-first.
+  func fetchOrphaned() throws -> [SimulationRecord]
+
   /// Updates state-related fields (stateJSON, currentRound, currentPhaseIndex)
   /// without touching other columns. Used for pause/resume.
   ///
@@ -56,6 +62,16 @@ nonisolated public final class GRDBSimulationRepository: SimulationRepository, S
     try dbWriter.read { db in
       try SimulationRecord
         .filter(Column("scenarioId") == scenarioId)
+        .order(Column("createdAt").desc)
+        .fetchAll(db)
+    }
+  }
+
+  public func fetchOrphaned() throws -> [SimulationRecord] {
+    try dbWriter.read { db in
+      // `== nil` compiles to `IS NULL` in GRDB.
+      try SimulationRecord
+        .filter(Column("scenarioId") == nil)
         .order(Column("createdAt").desc)
         .fetchAll(db)
     }

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -4892,6 +4892,16 @@
         }
       }
     },
+    "“%@” will be deleted. Past simulation results are kept and stay viewable." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「%@」を削除します。過去のシミュレーション結果は残り、引き続き閲覧できます。"
+          }
+        }
+      }
+    },
     "↳ sub-phase" : {
       "localizations" : {
         "ja" : {

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -1578,6 +1578,16 @@
         }
       }
     },
+    "Deleted scenario" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "削除されたシナリオ"
+          }
+        }
+      }
+    },
     "Demoing" : {
       "localizations" : {
         "ja" : {

--- a/Pastura/Pastura/Views/Home/HomeView.swift
+++ b/Pastura/Pastura/Views/Home/HomeView.swift
@@ -5,6 +5,26 @@ struct HomeView: View {
   @Environment(AppDependencies.self) private var dependencies
   @Environment(AppRouter.self) private var router
   @State private var viewModel: HomeViewModel?
+  @State private var pendingDeletion: PendingScenarioDeletion?
+
+  /// A user-scenario deletion awaiting confirmation. Carries the target ids
+  /// (an `.onDelete` swipe is normally one, but multi-select can batch) and
+  /// the first scenario's name for the confirmation copy.
+  private struct PendingScenarioDeletion: Identifiable {
+    let ids: [String]
+    let name: String
+    var id: String { ids.joined(separator: ",") }
+  }
+
+  /// Confirmation copy for deleting a user scenario. Since v7 the scenario
+  /// FK is `ON DELETE SET NULL`, so past runs are orphaned (kept), not
+  /// cascade-deleted — the copy reassures the user their history survives.
+  nonisolated static func scenarioDeletionMessage(name: String) -> String {
+    String(
+      format: String(
+        localized: "“%@” will be deleted. Past simulation results are kept and stay viewable."),
+      name)
+  }
 
   var body: some View {
     // `@Bindable` shadow: an `@Observable` injected via `@Environment` is
@@ -89,6 +109,17 @@ struct HomeView: View {
         .accessibilityIdentifier("home.pastResultsButton")
       }
     }
+    .confirmationDialog(
+      String(localized: "Delete Scenario?"),
+      isPresented: Binding(
+        get: { pendingDeletion != nil },
+        set: { presented in if !presented { pendingDeletion = nil } }),
+      presenting: pendingDeletion
+    ) { pending in
+      deleteConfirmationActions(pending, viewModel: viewModel)
+    } message: { pending in
+      Text(Self.scenarioDeletionMessage(name: pending.name))
+    }
     .refreshable {
       await viewModel.loadScenarios()
       await viewModel.refreshGalleryUpdateBadges(using: dependencies.galleryService)
@@ -119,14 +150,36 @@ struct HomeView: View {
             scenario, hasGalleryUpdate: viewModel.galleryUpdateBadges.contains(scenario.id))
         }
         .onDelete { offsets in
-          let ids = offsets.map { viewModel.userScenarios[$0].id }
-          Task {
-            for id in ids {
-              await viewModel.deleteScenario(id)
-            }
-          }
+          // Confirm before deleting — destructive and not obviously
+          // recoverable from the user's point of view. Past results survive
+          // (orphaned), but the scenario itself is gone.
+          let scenarios = offsets.map { viewModel.userScenarios[$0] }
+          pendingDeletion = PendingScenarioDeletion(
+            ids: scenarios.map(\.id),
+            name: scenarios.first?.name ?? "")
         }
       }
+    }
+  }
+
+  @ViewBuilder
+  private func deleteConfirmationActions(
+    _ pending: PendingScenarioDeletion, viewModel: HomeViewModel
+  ) -> some View {
+    Button(role: .destructive) {
+      Task {
+        for id in pending.ids {
+          await viewModel.deleteScenario(id)
+        }
+        pendingDeletion = nil
+      }
+    } label: {
+      Text(String(localized: "Delete"))
+    }
+    Button(role: .cancel) {
+      pendingDeletion = nil
+    } label: {
+      Text(String(localized: "Cancel"))
     }
   }
 

--- a/Pastura/Pastura/Views/Home/HomeView.swift
+++ b/Pastura/Pastura/Views/Home/HomeView.swift
@@ -153,6 +153,8 @@ struct HomeView: View {
           // Confirm before deleting — destructive and not obviously
           // recoverable from the user's point of view. Past results survive
           // (orphaned), but the scenario itself is gone.
+          // My Scenarios has no EditButton/multi-select, so a swipe deletes a
+          // single row — naming the first scenario in the copy is accurate.
           let scenarios = offsets.map { viewModel.userScenarios[$0] }
           pendingDeletion = PendingScenarioDeletion(
             ids: scenarios.map(\.id),

--- a/Pastura/Pastura/Views/Results/ResultDetailView.swift
+++ b/Pastura/Pastura/Views/Results/ResultDetailView.swift
@@ -280,10 +280,13 @@ struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
     do {
       let fetched: LoadedData = try await offMain {
         let sim = try simRepo.fetchById(simId)
-        // `scenarioId` is optional since v7 (SET NULL on scenario delete).
-        // Replaced by the snapshot resolver in a later step; for now this
-        // preserves pre-v7 behavior for runs whose scenario still exists.
-        let scenario = try sim?.scenarioId.flatMap { try scenarioRepo.fetchById($0) }
+        // Resolve via the run's snapshot (faithful to what ran; survives
+        // scenario edit/delete), falling back to the live scenario only for
+        // pre-v7 runs. Feeds both this detail view's agent ordering and the
+        // export path (which reads `self.scenario`).
+        let scenario = try sim.flatMap {
+          try ScenarioSnapshotResolver.resolve(for: $0, liveLookup: scenarioRepo.fetchById)
+        }
         let turns = try turnRepo.fetchBySimulationId(simId)
         let events = try eventRepo.fetchBySimulationId(simId)
         let items = ResultDetailTimelineBuilder.build(turns: turns, events: events)

--- a/Pastura/Pastura/Views/Results/ResultDetailView.swift
+++ b/Pastura/Pastura/Views/Results/ResultDetailView.swift
@@ -280,7 +280,10 @@ struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
     do {
       let fetched: LoadedData = try await offMain {
         let sim = try simRepo.fetchById(simId)
-        let scenario = try sim.flatMap { try scenarioRepo.fetchById($0.scenarioId) }
+        // `scenarioId` is optional since v7 (SET NULL on scenario delete).
+        // Replaced by the snapshot resolver in a later step; for now this
+        // preserves pre-v7 behavior for runs whose scenario still exists.
+        let scenario = try sim?.scenarioId.flatMap { try scenarioRepo.fetchById($0) }
         let turns = try turnRepo.fetchBySimulationId(simId)
         let events = try eventRepo.fetchBySimulationId(simId)
         let items = ResultDetailTimelineBuilder.build(turns: turns, events: events)

--- a/Pastura/PasturaTests/App/ResultsViewModelTests.swift
+++ b/Pastura/PasturaTests/App/ResultsViewModelTests.swift
@@ -224,4 +224,50 @@ struct ResultsViewModelTests {
 
     #expect(decoded == nil)
   }
+
+  // MARK: - Orphaned runs (deleted scenario) — v7 history preservation
+
+  @Test func homeAggregationSurfacesOrphanedRunWithoutMergingLiveGroups() async throws {
+    let env = try makeResultsSUT()
+
+    // A live scenario + run that stays.
+    try seedScenarioWithSimulation(
+      scenarioRepo: env.scenarioRepo, simRepo: env.simRepo,
+      scenarioId: "s2", scenarioName: "Word Wolf", simulationId: "sim2")
+
+    // A scenario + run carrying a snapshot, which we then delete to orphan
+    // the run (regression: deleting a scenario must NOT erase its history).
+    try env.scenarioRepo.save(
+      ScenarioRecord(
+        id: "s1", name: "Prisoner's Dilemma",
+        yamlDefinition: "id: s1\nlanguage: ja\nname: Prisoner's Dilemma\n",
+        isPreset: false, createdAt: Date(), updatedAt: Date()))
+    try env.simRepo.save(
+      SimulationRecord(
+        id: "sim1", scenarioId: "s1",
+        status: SimulationStatus.completed.rawValue,
+        currentRound: 1, currentPhaseIndex: 0, stateJSON: "{}", configJSON: nil,
+        createdAt: Date(), updatedAt: Date(),
+        scenarioYamlSnapshot: "id: s1\nlanguage: ja\nname: Prisoner's Dilemma\n",
+        scenarioNameSnapshot: "Prisoner's Dilemma"))
+
+    try env.scenarioRepo.delete("s1")  // orphan sim1 (SET NULL)
+
+    await env.sut.load(scenarioId: "", deviceLanguage: "ja")
+
+    // Both the live group and the orphaned group are present — the deleted
+    // scenario's run survives and remains browsable.
+    let names = env.sut.groups.map(\.sectionName)
+    #expect(env.sut.groups.count == 2)
+    #expect(names.contains("Word Wolf"))
+    #expect(names.contains("Prisoner's Dilemma"))
+
+    // The orphaned group did not merge into a live group: its canonical key
+    // is reserved (≠ the former scenario id), and it sorts last.
+    let orphanGroup = try #require(
+      env.sut.groups.first { $0.sectionName == "Prisoner's Dilemma" })
+    #expect(orphanGroup.rows.map(\.id) == ["sim1"])
+    #expect(orphanGroup.canonicalKey != "s1")
+    #expect(env.sut.groups.last?.canonicalKey == orphanGroup.canonicalKey)
+  }
 }

--- a/Pastura/PasturaTests/App/ScenarioSnapshotResolverTests.swift
+++ b/Pastura/PasturaTests/App/ScenarioSnapshotResolverTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+@Suite(.timeLimit(.minutes(1)))
+struct ScenarioSnapshotResolverTests {
+
+  private func makeSim(scenarioId: String?, yaml: String?, name: String?) -> SimulationRecord {
+    SimulationRecord(
+      id: "sim1", scenarioId: scenarioId, status: "completed",
+      currentRound: 1, currentPhaseIndex: 0, stateJSON: "{}", configJSON: nil,
+      createdAt: Date(), updatedAt: Date(),
+      scenarioYamlSnapshot: yaml, scenarioNameSnapshot: name)
+  }
+
+  private func liveRecord(_ id: String, name: String, yaml: String) -> ScenarioRecord {
+    ScenarioRecord(
+      id: id, name: name, yamlDefinition: yaml,
+      isPreset: false, createdAt: Date(), updatedAt: Date())
+  }
+
+  @Test func prefersSnapshotOverLiveScenario() throws {
+    let sim = makeSim(scenarioId: "sc1", yaml: "name: Snapshot\n", name: "Snapshot Name")
+    var liveLookupCalled = false
+    let resolved = try ScenarioSnapshotResolver.resolve(for: sim) { _ in
+      liveLookupCalled = true
+      return self.liveRecord("sc1", name: "Edited Live", yaml: "name: Edited Live\n")
+    }
+    #expect(resolved?.name == "Snapshot Name")
+    #expect(resolved?.yamlDefinition == "name: Snapshot\n")
+    // The live lookup must NOT fire when a snapshot exists — this is what
+    // immunizes past results from later edits to the live scenario.
+    #expect(liveLookupCalled == false)
+  }
+
+  @Test func synthesizesRecordForOrphanedRunUsingSimId() throws {
+    let sim = makeSim(scenarioId: nil, yaml: "name: Orphan\n", name: "Orphan")
+    let resolved = try ScenarioSnapshotResolver.resolve(for: sim) { _ in nil }
+    #expect(resolved?.id == "sim1")
+    #expect(resolved?.name == "Orphan")
+    #expect(resolved?.yamlDefinition == "name: Orphan\n")
+  }
+
+  @Test func fallsBackToLiveScenarioWhenNoSnapshot() throws {
+    let sim = makeSim(scenarioId: "sc1", yaml: nil, name: nil)
+    let resolved = try ScenarioSnapshotResolver.resolve(for: sim) { id in
+      self.liveRecord(id, name: "Live", yaml: "name: Live\n")
+    }
+    #expect(resolved?.name == "Live")
+  }
+
+  @Test func returnsNilWhenNeitherSnapshotNorScenarioId() throws {
+    let sim = makeSim(scenarioId: nil, yaml: nil, name: nil)
+    let resolved = try ScenarioSnapshotResolver.resolve(for: sim) { _ in
+      self.liveRecord("x", name: "Live", yaml: "")
+    }
+    #expect(resolved == nil)
+  }
+}

--- a/Pastura/PasturaTests/App/SimulationViewModelExportTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelExportTests.swift
@@ -156,4 +156,67 @@ struct SimulationViewModelExportTests {
     #expect(afterDelete.scenarioNameSnapshot == "Test Scenario")
     #expect(afterDelete.scenarioYamlSnapshot == snapshotYAML)
   }
+
+  @Test func fetchExportPayloadSucceedsForOrphanedRunAfterScenarioDelete() async throws {
+    let db = try DatabaseManager.inMemory()
+    let simRepo = GRDBSimulationRepository(dbWriter: db.dbWriter)
+    let turnRepo = GRDBTurnRepository(dbWriter: db.dbWriter)
+    let scenarioRepo = GRDBScenarioRepository(dbWriter: db.dbWriter)
+    try scenarioRepo.save(
+      ScenarioRecord(
+        id: "test", name: "Test Scenario", yamlDefinition: "name: Test Scenario\n",
+        isPreset: false, createdAt: Date(), updatedAt: Date()))
+
+    let sut = SimulationViewModel(
+      simulationRepository: simRepo, turnRepository: turnRepo,
+      scenarioRepository: scenarioRepo)
+    sut.speed = .instant
+    let mock = MockLLMService(responses: [#"{"statement": "hi"}"#, #"{"statement": "yo"}"#])
+    let scenario = makeTestScenario(
+      agentNames: ["Alice", "Bob"], rounds: 1,
+      phases: [Phase(type: .speakAll, prompt: "Speak", outputSchema: ["statement": "string"])])
+    await sut.run(scenario: scenario, llm: mock)
+
+    // Delete the source scenario — the run is now orphaned (scenarioId nil).
+    try scenarioRepo.delete("test")
+
+    // Export still succeeds, reconstructing the scenario from the snapshot.
+    let payload = try await sut.fetchExportPayload(exportEnvironment: env)
+    let unwrapped = try #require(payload)
+    #expect(unwrapped.text.contains("# Simulation Export: Test Scenario"))
+    #expect(unwrapped.text.contains("hi"))
+  }
+
+  @Test func fetchExportPayloadUsesSnapshotNotEditedLiveScenario() async throws {
+    let db = try DatabaseManager.inMemory()
+    let simRepo = GRDBSimulationRepository(dbWriter: db.dbWriter)
+    let turnRepo = GRDBTurnRepository(dbWriter: db.dbWriter)
+    let scenarioRepo = GRDBScenarioRepository(dbWriter: db.dbWriter)
+    try scenarioRepo.save(
+      ScenarioRecord(
+        id: "test", name: "Test Scenario", yamlDefinition: "name: Test Scenario\n",
+        isPreset: false, createdAt: Date(), updatedAt: Date()))
+
+    let sut = SimulationViewModel(
+      simulationRepository: simRepo, turnRepository: turnRepo,
+      scenarioRepository: scenarioRepo)
+    sut.speed = .instant
+    let mock = MockLLMService(responses: [#"{"statement": "hi"}"#, #"{"statement": "yo"}"#])
+    let scenario = makeTestScenario(
+      agentNames: ["Alice", "Bob"], rounds: 1,
+      phases: [Phase(type: .speakAll, prompt: "Speak", outputSchema: ["statement": "string"])])
+    await sut.run(scenario: scenario, llm: mock)
+
+    // Edit the live scenario after the run completes (upsert same id, new name).
+    try scenarioRepo.save(
+      ScenarioRecord(
+        id: "test", name: "EDITED NAME", yamlDefinition: "name: EDITED NAME\n",
+        isPreset: false, createdAt: Date(), updatedAt: Date()))
+
+    // Export reflects the snapshot (what ran), not the edited live scenario.
+    let payload = try await sut.fetchExportPayload(exportEnvironment: env)
+    let unwrapped = try #require(payload)
+    #expect(unwrapped.text.contains("# Simulation Export: Test Scenario"))
+    #expect(!unwrapped.text.contains("EDITED NAME"))
+  }
 }

--- a/Pastura/PasturaTests/App/SimulationViewModelExportTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelExportTests.swift
@@ -111,4 +111,49 @@ struct SimulationViewModelExportTests {
     let payload = try await sut.fetchExportPayload(exportEnvironment: env)
     #expect(payload == nil)
   }
+
+  @Test func runPopulatesScenarioSnapshotThatSurvivesScenarioDelete() async throws {
+    let db = try DatabaseManager.inMemory()
+    let simRepo = GRDBSimulationRepository(dbWriter: db.dbWriter)
+    let turnRepo = GRDBTurnRepository(dbWriter: db.dbWriter)
+    let scenarioRepo = GRDBScenarioRepository(dbWriter: db.dbWriter)
+    // The scenario must exist at run time (FK enforced); it is deleted after.
+    try scenarioRepo.save(
+      ScenarioRecord(
+        id: "test", name: "Test Scenario",
+        yamlDefinition: "name: Test Scenario\n",
+        isPreset: false, createdAt: Date(), updatedAt: Date()))
+
+    let sut = SimulationViewModel(
+      simulationRepository: simRepo,
+      turnRepository: turnRepo,
+      scenarioRepository: scenarioRepo)
+    sut.speed = .instant
+
+    let mock = MockLLMService(responses: [
+      #"{"statement": "hi"}"#, #"{"statement": "yo"}"#
+    ])
+    let scenario = makeTestScenario(
+      agentNames: ["Alice", "Bob"], rounds: 1,
+      phases: [Phase(type: .speakAll, prompt: "Speak", outputSchema: ["statement": "string"])])
+
+    await sut.run(scenario: scenario, llm: mock)
+
+    let simId = try #require(sut.simulationId)
+    let afterRun = try #require(try simRepo.fetchById(simId))
+    let snapshotYAML = try #require(afterRun.scenarioYamlSnapshot)
+    #expect(afterRun.scenarioNameSnapshot == "Test Scenario")
+    // The snapshot is re-serialized from the live domain object, so it
+    // round-trips through ScenarioLoader to the same roster — independent of
+    // whether the scenario row was ever persisted.
+    let reparsed = try ScenarioLoader().load(yaml: snapshotYAML)
+    #expect(reparsed.personas.map(\.name) == ["Alice", "Bob"])
+
+    // Deleting the scenario orphans the run (SET NULL) but keeps the snapshot.
+    try scenarioRepo.delete("test")
+    let afterDelete = try #require(try simRepo.fetchById(simId))
+    #expect(afterDelete.scenarioId == nil)
+    #expect(afterDelete.scenarioNameSnapshot == "Test Scenario")
+    #expect(afterDelete.scenarioYamlSnapshot == snapshotYAML)
+  }
 }

--- a/Pastura/PasturaTests/Data/DataIntegrationTests.swift
+++ b/Pastura/PasturaTests/Data/DataIntegrationTests.swift
@@ -105,12 +105,18 @@ import Testing
     let round1Turns = try repos.turn.fetchBySimulationAndRound("sim1", round: 1)
     #expect(round1Turns.count == 2)
 
-    // 8. Delete scenario — cascade removes simulation and turns
+    // 8. Deleting the scenario orphans the run (v7 FK is ON DELETE SET NULL)
+    //    — the simulation and its turns are preserved, not cascade-deleted.
     try repos.scenario.delete("s1")
-    let deletedSim = try repos.simulation.fetchById("sim1")
-    #expect(deletedSim == nil)
-    let remainingTurns = try repos.turn.fetchBySimulationId("sim1")
-    #expect(remainingTurns.isEmpty)
+    let orphanedSim = try repos.simulation.fetchById("sim1")
+    #expect(orphanedSim != nil)
+    #expect(orphanedSim?.scenarioId == nil)
+    #expect(!(try repos.turn.fetchBySimulationId("sim1").isEmpty))
+
+    // 9. Deleting the simulation itself still cascade-removes its turns
+    //    (the turns→simulations cascade is unchanged).
+    try repos.simulation.delete("sim1")
+    #expect(try repos.turn.fetchBySimulationId("sim1").isEmpty)
   }
 
   @Test func simulationStateJsonRoundTrip() throws {

--- a/Pastura/PasturaTests/Data/DatabaseManagerTests.swift
+++ b/Pastura/PasturaTests/Data/DatabaseManagerTests.swift
@@ -63,7 +63,7 @@ import Testing
     }
   }
 
-  @Test func cascadeDeleteScenarioRemovesSimulations() throws {
+  @Test func deletingScenarioOrphansSimulationsViaSetNull() throws {
     let manager = try DatabaseManager.inMemory()
     try manager.dbWriter.write { db in
       try db.execute(
@@ -80,12 +80,17 @@ import Testing
           """,
         arguments: ["sim1", "s1", "running", 0, 0, "{}", Date(), Date()])
 
-      // Delete scenario
+      // Delete the scenario.
       try db.execute(sql: "DELETE FROM scenarios WHERE id = ?", arguments: ["s1"])
 
-      // Simulation should be gone
+      // Since v7 the FK is ON DELETE SET NULL: the simulation survives
+      // (history preserved) with its scenarioId cleared — it is NOT
+      // cascade-deleted.
       let count = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM simulations")
-      #expect(count == 0)
+      #expect(count == 1)
+      let scenarioId = try String.fetchOne(
+        db, sql: "SELECT scenarioId FROM simulations WHERE id = 'sim1'")
+      #expect(scenarioId == nil)
     }
   }
 }

--- a/Pastura/PasturaTests/Data/DatabaseMigrationTests.swift
+++ b/Pastura/PasturaTests/Data/DatabaseMigrationTests.swift
@@ -73,6 +73,118 @@ import Testing
     #expect(gallery?.sourceType == ScenarioSourceType.gallery)
   }
 
+  @Test func v7PreservesChildRowsAndAddsNullableSnapshotColumns() throws {
+    let queue = try makeQueue()
+    let migrator = DatabaseManager.makeMigrator()
+
+    // Migrate only up to v6 — mimics an on-device DB before the
+    // scenario-snapshot rebuild (v7) shipped.
+    try migrator.migrate(queue, upTo: "v6_addPhasePathToTurnsAndCodePhaseEvents")
+
+    // Seed a scenario, a completed run referencing it, and child rows in
+    // both `turns` and `code_phase_events`. Raw SQL: the struct now knows
+    // about v7 columns the v6 schema lacks.
+    let now = Date()
+    try queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO scenarios (id, name, yamlDefinition, isPreset, createdAt, updatedAt)
+          VALUES (?, ?, ?, ?, ?, ?)
+          """,
+        arguments: ["sc1", "Scenario One", "yaml: one", false, now, now])
+      try db.execute(
+        sql: """
+          INSERT INTO simulations
+            (id, scenarioId, status, currentRound, currentPhaseIndex,
+             stateJSON, configJSON, createdAt, updatedAt, modelIdentifier, llmBackend)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          """,
+        arguments: ["sim1", "sc1", "completed", 2, 0, "{}", nil, now, now, "Gemma", "llama.cpp"])
+      try db.execute(
+        sql: """
+          INSERT INTO turns
+            (id, simulationId, roundNumber, phaseType, agentName,
+             rawOutput, parsedOutputJSON, sequenceNumber, createdAt)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+          """,
+        arguments: ["t1", "sim1", 1, "speak", "Alice", "raw", "{}", 0, now])
+      try db.execute(
+        sql: """
+          INSERT INTO code_phase_events
+            (id, simulationId, roundNumber, phaseType, sequenceNumber, payloadJSON, createdAt)
+          VALUES (?, ?, ?, ?, ?, ?, ?)
+          """,
+        arguments: ["e1", "sim1", 1, "score_calc", 0, "{}", now])
+    }
+
+    // Apply v7 — rebuilds the `simulations` table. The deferred-FK
+    // migration must NOT cascade-delete the child rows during the rebuild.
+    try migrator.migrate(queue)
+
+    let counts = try queue.read { db in
+      (
+        turns: try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM turns") ?? -1,
+        events: try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM code_phase_events") ?? -1
+      )
+    }
+    #expect(counts.turns == 1)
+    #expect(counts.events == 1)
+
+    // The simulation row survives with its existing data intact and the
+    // new snapshot columns defaulting to nil for migrated rows.
+    let sim = try queue.read { db in try SimulationRecord.fetchOne(db, key: "sim1") }
+    #expect(sim?.scenarioId == "sc1")
+    #expect(sim?.modelIdentifier == "Gemma")
+    #expect(sim?.llmBackend == "llama.cpp")
+    #expect(sim?.scenarioYamlSnapshot == nil)
+    #expect(sim?.scenarioNameSnapshot == nil)
+  }
+
+  @Test func v7ChangesScenarioFKToSetNullSoScenarioDeletePreservesHistory() throws {
+    let queue = try makeQueue()
+    try DatabaseManager.makeMigrator().migrate(queue)  // full schema incl. v7
+
+    let now = Date()
+    try queue.write { db in
+      try db.execute(
+        sql: """
+          INSERT INTO scenarios (id, name, yamlDefinition, isPreset, createdAt, updatedAt)
+          VALUES (?, ?, ?, ?, ?, ?)
+          """,
+        arguments: ["sc1", "Scenario One", "yaml: one", false, now, now])
+      var sim = SimulationRecord(
+        id: "sim1", scenarioId: "sc1", status: "completed",
+        currentRound: 1, currentPhaseIndex: 0, stateJSON: "{}", configJSON: nil,
+        createdAt: now, updatedAt: now,
+        scenarioYamlSnapshot: "yaml: one", scenarioNameSnapshot: "Scenario One")
+      try sim.insert(db)
+      try db.execute(
+        sql: """
+          INSERT INTO turns
+            (id, simulationId, roundNumber, phaseType, agentName,
+             rawOutput, parsedOutputJSON, sequenceNumber, createdAt)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+          """,
+        arguments: ["t1", "sim1", 1, "speak", "Alice", "raw", "{}", 0, now])
+    }
+
+    // Deleting the scenario must NOT cascade-delete the run; the FK is now
+    // ON DELETE SET NULL, so the run is orphaned but history is preserved.
+    try queue.write { db in
+      _ = try ScenarioRecord.deleteOne(db, key: "sc1")
+    }
+
+    let sim = try queue.read { db in try SimulationRecord.fetchOne(db, key: "sim1") }
+    #expect(sim != nil)
+    #expect(sim?.scenarioId == nil)
+    #expect(sim?.scenarioNameSnapshot == "Scenario One")
+    #expect(sim?.scenarioYamlSnapshot == "yaml: one")
+    let turnCount = try queue.read { db in
+      try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM turns WHERE simulationId = 'sim1'") ?? -1
+    }
+    #expect(turnCount == 1)
+  }
+
   @Test func allMigrationsApplyIdempotently() throws {
     // Applying the full migrator twice must not fail and must not duplicate work.
     let queue = try makeQueue()

--- a/Pastura/PasturaTests/Data/SimulationRecordTests.swift
+++ b/Pastura/PasturaTests/Data/SimulationRecordTests.swift
@@ -118,7 +118,7 @@ import Testing
     #expect(fetched?.llmBackend == nil)
   }
 
-  @Test func cascadeDeleteFromScenario() throws {
+  @Test func deletingScenarioSetsSimulationScenarioIdNull() throws {
     let manager = try makeManagerWithScenario()
     let now = Date()
 
@@ -132,8 +132,11 @@ import Testing
 
       try db.execute(sql: "DELETE FROM scenarios WHERE id = ?", arguments: ["s1"])
 
-      let count = try SimulationRecord.fetchCount(db)
-      #expect(count == 0)
+      // v7 FK is ON DELETE SET NULL: the run survives (history preserved)
+      // with a nil scenarioId instead of being cascade-deleted.
+      let fetched = try SimulationRecord.fetchOne(db, key: "sim1")
+      #expect(fetched != nil)
+      #expect(fetched?.scenarioId == nil)
     }
   }
 

--- a/Pastura/PasturaTests/Data/SimulationRepositoryTests.swift
+++ b/Pastura/PasturaTests/Data/SimulationRepositoryTests.swift
@@ -71,6 +71,28 @@ import Testing
     #expect(results.isEmpty)
   }
 
+  @Test func fetchOrphanedReturnsOnlyRunsWhoseScenarioWasDeleted() throws {
+    let (scenarioRepo, simRepo) = try makeRepos()
+    try scenarioRepo.save(
+      ScenarioRecord(
+        id: "s2", name: "Other", yamlDefinition: "yaml",
+        isPreset: false, createdAt: Date(), updatedAt: Date()))
+    try simRepo.save(makeSimRecord(id: "sim1"))  // references s1
+    var sim2 = makeSimRecord(id: "sim2")
+    sim2.scenarioId = "s2"
+    try simRepo.save(sim2)
+
+    // No orphans while both scenarios exist.
+    #expect(try simRepo.fetchOrphaned().isEmpty)
+
+    // Deleting s1 orphans sim1 (SET NULL); sim2 keeps its FK.
+    try scenarioRepo.delete("s1")
+    let orphans = try simRepo.fetchOrphaned()
+    #expect(orphans.map(\.id) == ["sim1"])
+    #expect(orphans.first?.scenarioId == nil)
+    #expect(try simRepo.fetchById("sim2")?.scenarioId == "s2")
+  }
+
   @Test func updateStateModifiesTargetFields() throws {
     let (_, simRepo) = try makeRepos()
     try simRepo.save(makeSimRecord())

--- a/Pastura/PasturaTests/Views/HomeViewDeletionMessageTests.swift
+++ b/Pastura/PasturaTests/Views/HomeViewDeletionMessageTests.swift
@@ -1,0 +1,21 @@
+import Testing
+
+@testable import Pastura
+
+/// Unit-tests the pure copy-building helper behind HomeView's scenario-delete
+/// confirmation (View-logic extraction per ADR-009 / view-testing rule).
+@Suite(.timeLimit(.minutes(1)))
+struct HomeViewDeletionMessageTests {
+
+  @Test func interpolatesScenarioName() {
+    let message = HomeView.scenarioDeletionMessage(name: "Word Wolf")
+    #expect(message.contains("Word Wolf"))
+  }
+
+  @Test func reassuresThatPastResultsAreKept() {
+    // The post-v7 behavior change: deletion no longer wipes history, so the
+    // copy must say results are kept.
+    let message = HomeView.scenarioDeletionMessage(name: "Any")
+    #expect(message.contains("kept"))
+  }
+}


### PR DESCRIPTION
## Summary
- **v7 migration**: rebuild `simulations` — scenario FK `CASCADE`→`SET NULL`, nullable `scenarioId`, + `scenarioYamlSnapshot`/`scenarioNameSnapshot`. Deleting a scenario now **orphans** its runs instead of wiping all past results/turns/events. The deferred-FK table rebuild preserves the `turns`/`code_phase_events` child rows.
- Runs **snapshot the scenario at creation** (`ScenarioSerializer`); past-results & export resolve via `ScenarioSnapshotResolver` (prefer snapshot, fall back to live for pre-v7 rows) — also fixes display drift when a scenario is later edited.
- Home results **surface orphaned runs** via `SimulationRepository.fetchOrphaned()` under a reserved, locale-invariant canonical key (cannot merge into live groups).
- **Confirmation dialog** on scenario swipe-delete; copy reflects that past results are preserved.
- Fix stale `ModelRegistry.validateNoCollisions()` doc-comment (the launch call already exists in `PasturaApp.initialize()`).

## Test plan
- Full unit suite green (1826 tests). New coverage: v7 migration child-survival + FK-SET-NULL; snapshot population & survives-delete; resolver prefer/fallback/orphan/nil; orphaned-run export e2e + snapshot-over-edited-live; `fetchOrphaned` isolation; Home orphan aggregation no-merge; delete-confirmation copy helper.
- Updated 3 existing tests from the old `ON DELETE CASCADE` contract to `SET NULL`.
- `swiftlint --strict` clean; localization coverage OK (`ja` filled).

## Out of scope (filed separately)
- #545 manual purge UI · #546 migration-failure fallback · #547 retention + iCloud-backup decision · #548 model-update + storage-management UX.

Closes #550.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
