### PR TITLE
📝 docs: sync drifted Yams version reference

### DIFF
--- a/docs/specs/demo-replay-spec.md
+++ b/docs/specs/demo-replay-spec.md
@@ -101,7 +101,7 @@ Each references where in the spec the detailed treatment lives.
 
 | # | Decision | Detailed in |
 |---|----------|-------------|
-| 1 | Recording format: **YAML** (reuses Yams 6.2.1; curator-editable; JSON export deferred) | §3 |
+| 1 | Recording format: **YAML** (reuses Yams 6.2.2; curator-editable; JSON export deferred) | §3 |
 | 2 | Recording content model: `preset_ref` (id + version + `yaml_sha256`) + recorded turns + metadata; scenario definition is **referenced**, not inlined | §3 |
 | 3 | Filter timing: **filter-at-record** (curator-side) **AND filter-at-render** (ADR-005 §5.1 compliance, defense-in-depth) | §3, §4 |
 | 4 | Bundle location: `Pastura/Pastura/Resources/DemoReplays/*.yaml`, total ≤ 3 MB | §5 |


### PR DESCRIPTION
Machine-generated by the `consistency-audit` skill (first auto-fix run). The diff is **Draft** and awaits human merge — the human merge is the review gate (see the skill's Output Contract).

## Auto-fixable findings (1)

| file:line | change | authoritative source |
|---|---|---|
| `docs/specs/demo-replay-spec.md:104` | Yams `6.2.1` → `6.2.2` | `Package.resolved` |

Each fix is a single version token whose correct value is uniquely determined by the authoritative source, spliced at the detected offset (never a free-text replace). No prose was edited.

🤖 auto-generated by `/consistency-audit`