### PR TITLE
✨ feat: /release skill + ADR-014 Accepted (PR-B)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: release
+description: Cut a Pastura TestFlight release — guide the semver bump, synthesize and review the "What to Test" notes, run the preflight dry-run, then drive scripts/release.sh through a confirmation gate to archive, upload, and tag. Use when the user asks to cut/ship a release, upload a build to TestFlight, or run the release pipeline.
+allowed-tools: Read, Grep, Glob, Bash
+argument-hint: "[X.Y.Z]"
+---
+
+# /release
+
+Drive one TestFlight release of Pastura. This skill is the **interactive
+judgment layer** over the deterministic mechanism in
+`scripts/release.sh` (ADR-014). The script owns preflight → archive →
+symbol check → export → upload → tag; this skill owns the human
+decisions around it: the semver bump, the release notes, and the
+**mandatory confirmation before the irreversible upload**.
+
+> **Not an `/orchestrate` task.** `/release` drives an *external*
+> release (App Store Connect), not repo file edits. It does not create
+> branches or commit tracked files. The one push it triggers — the
+> annotated release tag, inside `scripts/release.sh` — is a deliberate,
+> benign exception to the "`/orchestrate` is the only entry point for
+> pushes" rule (see CLAUDE.md § Development Workflow): a tag ref is not
+> branch-protected, touches no tracked files, and is gated behind the
+> confirmation below. Any *code* change a release needs (a version
+> bump) is a separate `/orchestrate` PR — see Step 2.
+
+Run from the repository root.
+
+## One-time bootstrap (must be done before the first release)
+
+These are human-only, performed once (ADR-014 § bootstrap). If any is
+missing the release cannot proceed — check before starting:
+
+- App Store Connect **app record** exists for `app.pastura.Pastura`.
+- An ASC **API key** (`.p8`) is generated and stored outside the repo
+  (fastlane reads `~/.appstoreconnect/private_keys/`). Its identifiers
+  are exported in the environment:
+  `ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_KEY_PATH`.
+- A **distribution certificate / provisioning** exists (automatic
+  signing, team `52G26234A3`; the first archive needs an Apple ID
+  signed into Xcode).
+- `bundle install` has been run once so `Gemfile.lock` pins fastlane.
+
+Confirm with the operator that these hold before continuing. The
+encryption export-compliance declaration is already in place
+(`INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO`, ADR-005 §8.6) — no
+action needed.
+
+## Step 1 — Decide the version
+
+Read the commits since the last release tag and propose a semver bump:
+
+```bash
+LAST_TAG="$(git describe --tags --abbrev=0 2>/dev/null || echo '(none)')"
+git log --pretty='- %s' "${LAST_TAG}..HEAD" 2>/dev/null || git log --pretty='- %s' -n 20
+```
+
+Propose **major / minor / patch** from the change content (breaking →
+major, new feature → minor, fixes only → patch) and **ask the operator
+to confirm** the target `X.Y.Z`. If `$ARGUMENTS` already carries a
+version, treat it as the proposal and still confirm.
+
+## Step 2 — Ensure the version is on a green `main` (sequencing)
+
+`scripts/release.sh` releases only from a checkout that equals
+`origin/main` and is CI-green, and it asserts the **archived**
+`MARKETING_VERSION` equals `--version`. So the target version must
+already be the `MARKETING_VERSION` on `main`.
+
+- **If the chosen version already matches `main`'s `MARKETING_VERSION`**
+  (a re-release or notes/build-only change): proceed to Step 3.
+- **If the version needs to change**: it is a code edit — bump it in a
+  **separate `/orchestrate` PR**, merge it, and wait for `main` CI to go
+  green, *then* return here. Bump **only the app target's two
+  `MARKETING_VERSION` entries** (Debug + Release, the ones near
+  `PRODUCT_BUNDLE_IDENTIFIER = app.pastura.Pastura`) — not the
+  `PasturaTests` / `PasturaUITests` entries. The build number
+  (`git rev-list --count HEAD`) advances automatically with the bump
+  commit, so the release.sh build-number guard is satisfied for free.
+
+Do **not** try to bump and release in one local step — a local bump
+commit would make `HEAD` diverge from `origin/main` and fail preflight.
+
+## Step 3 — Synthesize and review the release notes
+
+Turn the commit subjects (Step 1) into concise **tester-facing "What to
+Test"** prose — group related changes, drop SHAs / internal issue refs /
+implementation jargon. These notes are published to TestFlight testers.
+
+**The operator must review the final notes at the gate (Step 5)** — they
+go to humans and are not content-safety-screened. Never ship raw commit
+subjects unreviewed (a subject can carry a token, internal URL, or
+unpolished text).
+
+## Step 4 — Dry-run the preflight
+
+```bash
+scripts/release.sh --version X.Y.Z --dry-run
+```
+
+This runs the full preflight (HEAD == origin/main, every required check
+green — the required list is derived from the branch ruleset) and prints
+the planned version / build / tag, then stops before any archive or
+upload. Resolve any preflight failure (usually: `main` not green yet, or
+HEAD not synced) before continuing. `scripts/release.sh` is not in the
+permission allowlist, so the first invocation prompts for approval — that
+prompt is itself a safety gate for an irreversible action.
+
+## Step 5 — Confirmation gate (MANDATORY)
+
+Before the real run, present to the operator and get explicit approval:
+
+- target **version** and computed **build number** and **tag**
+- the final **"What to Test" notes** (Step 3) for sign-off
+- confirmation that the one-time bootstrap holds (env vars set, key in
+  place)
+
+Only on explicit "yes" proceed. This is the last reversible point — the
+upload that follows cannot be undone.
+
+## Step 6 — Release
+
+```bash
+scripts/release.sh --version X.Y.Z
+```
+
+The script archives, re-checks the ADR-005 §8.5 Ollama-symbol guard on
+the signed binary, exports an `app-store` `.ipa`, uploads via fastlane
+(waiting for ASC processing), and — only on a successful upload —
+creates and pushes the annotated tag `vX.Y.Z+<build>`. Report the result
+and that the build is processing on TestFlight.
+
+## Failure → recovery
+
+Map the failure point to the recovery — the build number is commit-derived,
+so the right move differs by *where* it failed:
+
+| Failure point | State | Recovery |
+|---|---|---|
+| preflight / archive / export / **upload before ASC ingest** | nothing ingested, no tag (tag is last) | fix the cause and re-run `/release` — the build number is unchanged and that is fine |
+| **upload fails after ASC has ingested the build** | the build number now collides with an ingested build; a naive re-run is **correctly blocked** by release.sh's strict-exceeds guard | land a **new commit on `main`** (a no-op commit or a `MARKETING_VERSION` patch bump) via `/orchestrate`, wait for green, then re-`/release`. This is a new green-main cycle, not an in-place retry — the build number must advance |
+| **tag pushed but the release must be retracted** | tag exists locally + remotely | `git tag -d vX.Y.Z+<build>` and `git push origin :refs/tags/vX.Y.Z+<build>` |
+
+## ASC API key revocation (leak response)
+
+If the `.p8` API key is ever exposed (committed, shared, lost): revoke it
+immediately in **App Store Connect → Users and Access → Integrations →
+App Store Connect API → (select the key) → Revoke**, then generate a
+fresh key and update `ASC_KEY_ID` / `ASC_ISSUER_ID` / `ASC_KEY_PATH`. The
+`scripts/p8-precommit-gate.sh` gate and the `*.p8` gitignore are the
+preventative layers (ADR-014 § Secrets); revocation is the response.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,11 @@ doubt, default to `/orchestrate`.
 The rule does not re-trigger for actions taken from inside `/orchestrate`
 itself or from any sub-agent it dispatches.
 
+The `/release` skill's release **tag** push (via `scripts/release.sh`, ADR-014)
+is also exempt: a tag ref is not branch-protected, edits no tracked files, and
+is gated behind the skill's mandatory confirmation. Any *code* change a release
+needs (a `MARKETING_VERSION` bump) still goes through `/orchestrate`.
+
 ### TDD Approach
 
 Engine and LLM layer: test-first (write failing test → minimal implementation → refactor).

--- a/docs/decisions/ADR-014.md
+++ b/docs/decisions/ADR-014.md
@@ -1,6 +1,6 @@
 # ADR-014: Release Automation Toolchain — fastlane + ASC API Key (local-first, TestFlight scope)
 
-> **Status:** Proposed
+> **Status:** Accepted
 > **Date:** 2026-06-13
 > **Context:** Pastura has never uploaded a build to App Store Connect (ASC).
 > The Apple Developer Program account is registered, but install-base is zero
@@ -13,10 +13,11 @@
 
 > **Scope note.** This ADR covers up to **TestFlight upload** only. App Store
 > *review submission* (deliver / metadata / screenshots / store-page) is
-> deferred to Phase 3. The implementation it describes
-> (`scripts/release.sh`, `fastlane/Fastfile`, the `/release` skill) lands in a
-> follow-up PR after this ADR is Accepted — on `main` today only this record
-> exists.
+> deferred to Phase 3. The implementation shipped in two follow-up PRs:
+> PR-A (#563) added the mechanism (`scripts/release.sh`, `fastlane/`, the
+> `*.p8` secret-handling layers); PR-B (#567) added the `/release` skill and
+> flipped this ADR to Accepted. The first live upload is still gated on the
+> one-time human bootstrap (§ bootstrap).
 
 ---
 
@@ -29,8 +30,7 @@
    maintainer's Mac now. The `Fastfile` is authored so the *same* lanes run
    unchanged from GitHub Actions later — the only CI-specific addition is
    secret injection and `fetch-depth: 0` (see § "Build number").
-3. **Three-layer component split** (implemented in the follow-up PR; recorded
-   here as the chosen architecture):
+3. **Three-layer component split** (PR-A shipped layers 1–2, PR-B layer 3):
    - `scripts/release.sh` — deterministic steps (preflight, archive, export,
      Ollama-symbol re-check, fastlane invocation). Reusable from CI.
    - `fastlane/Fastfile` + `Appfile` — API Key auth, version/build wiring,
@@ -207,7 +207,7 @@ are repeated per release.
 ## Secrets — `.p8` defense-in-depth
 
 A leaked ASC API Key is a high-severity credential exposure, so a single
-`.gitignore` line is insufficient. The follow-up PR adds, in layers:
+`.gitignore` line is insufficient. PR-A (#563) added, in layers:
 
 1. **Out-of-tree storage** — the `.p8` lives in
    `~/.appstoreconnect/private_keys/`, never inside the repo working tree.
@@ -245,5 +245,6 @@ A leaked ASC API Key is a high-severity credential exposure, so a single
   operator security + pre-submission audit checklist.
 - [fastlane — App Store Connect API](https://docs.fastlane.tools/app-store-connect-api/)
   / [`upload_to_testflight`](https://docs.fastlane.tools/actions/upload_to_testflight/).
-- Issue #555 — this ADR; the implementation (scripts/skill/Fastfile) follows
-  in a separate PR.
+- Issue #555 — this ADR. Implementation: PR-A #563 (mechanism:
+  `scripts/release.sh`, `fastlane/`, `.p8` gate) and PR-B #567 (`/release`
+  skill + this Status flip).

--- a/docs/decisions/ADR-014.md
+++ b/docs/decisions/ADR-014.md
@@ -69,7 +69,7 @@ pin the version.
 
 ### Release flow (ordered)
 
-The follow-up implementation executes these steps. **The annotated git tag is
+`scripts/release.sh` executes these steps. **The annotated git tag is
 created and pushed *after* a successful upload**, not before (see rationale):
 
 1. **Preflight** — `git fetch origin`; assert local `HEAD` SHA equals
@@ -229,8 +229,8 @@ A leaked ASC API Key is a high-severity credential exposure, so a single
 - The release path is reproducible and CI-portable; moving to CI later needs
   only secret injection + `fetch-depth: 0`, not a rewrite.
 - `docs/security/release-checklist.md` is the operator pre-submission audit;
-  it will be extended (in the follow-up PR) to cross-reference this ADR's
-  preflight and bootstrap steps.
+  PR-B (#567) extended it with a § 4 cross-referencing this ADR's preflight
+  and bootstrap steps.
 
 ## Related
 

--- a/docs/security/release-checklist.md
+++ b/docs/security/release-checklist.md
@@ -9,6 +9,9 @@ outside the codebase. Three sections:
    Runs on the eve of an App Store submission (Phase 3, requires Apple
    Developer Program registration).
 3. [Recurring review](#3-recurring-review). Periodic operator tasks.
+4. [Release execution](#4-release-execution-testflight). How a build
+   actually reaches TestFlight (the automated pipeline + its one-time
+   prerequisites).
 
 The aim is to leave a paper trail of *what* should be true, *how* to
 verify, and *how* to remediate. Re-run the verifier on each release.
@@ -195,3 +198,42 @@ gh api repos/tyabu12/pastura/secret-scanning/alerts \
 
 Should return an empty array. Investigate any non-empty result the same
 day.
+
+---
+
+## 4. Release execution (TestFlight)
+
+The mechanics of getting a build to TestFlight are owned by
+[ADR-014](../decisions/ADR-014.md) and implemented as
+`scripts/release.sh` (the deterministic pipeline) + the `/release` skill
+(the interactive wrapper). This section is the security-relevant index;
+the procedure itself is not duplicated here.
+
+### 4.1 One-time bootstrap (human, not scriptable)
+
+Before the **first** release these must exist (full detail in ADR-014
+§ bootstrap and the `/release` skill's "One-time bootstrap" section):
+
+- ASC app record for `app.pastura.Pastura`.
+- An ASC **API key** (`.p8`) stored **outside the repo** at
+  `~/.appstoreconnect/private_keys/`, with `ASC_KEY_ID` /
+  `ASC_ISSUER_ID` / `ASC_KEY_PATH` exported. The `.p8` must never be
+  committed — `scripts/p8-precommit-gate.sh` and the `*.p8` gitignore
+  enforce this (ADR-014 § Secrets).
+- A distribution certificate / provisioning (automatic signing, team
+  `52G26234A3`).
+
+### 4.2 Per-release gate
+
+`scripts/release.sh` only releases from a checkout that equals
+`origin/main` **and** is green on every required CI check (the list is
+derived from the branch ruleset, not hardcoded). It re-runs the
+ADR-005 §8.5 Ollama-symbol guard on the signed archive and tags only
+after a successful upload. Cut releases exclusively from a CI-green
+`main` SHA — never from a local-only or unsynced checkout.
+
+### 4.3 Key-leak response
+
+If the `.p8` key is exposed, revoke it immediately (App Store Connect →
+Users and Access → Integrations → revoke) and rotate the identifiers.
+The `/release` skill carries the step-by-step runbook.

--- a/docs/security/release-checklist.md
+++ b/docs/security/release-checklist.md
@@ -1,7 +1,7 @@
 # Security Release Checklist
 
 A consolidated checklist for the security-sensitive work that lives
-outside the codebase. Three sections:
+outside the codebase. Four sections:
 
 1. [GitHub repository settings](#1-github-repository-settings).
    One-time configuration kept current; commands are idempotent.


### PR DESCRIPTION
## Summary
PR-B of ADR-014 — the interactive wrapper over the merged release mechanism (PR-A #563).

- `.claude/skills/release/SKILL.md` — `/release` skill: semver proposal from the commit log; the bump-via-separate-`/orchestrate`-PR-then-green sequencing; tester-facing "What to Test" synthesis with mandatory operator review; bootstrap + checklist cross-check; `release.sh --dry-run` → mandatory confirmation gate → real run; failure-point→recovery map; ASC key-revocation runbook. `allowed-tools: Read, Grep, Glob, Bash` (guides + invokes, never edits files).
- `docs/security/release-checklist.md` — new § 4 indexing the ADR-014 bootstrap / green-main gate / key-leak response (links, no duplication).
- `docs/decisions/ADR-014.md` — Status Proposed → Accepted, and reconciled the now-stale future-tense lines (PR-A #563 shipped the mechanism; PR-B #567 the skill).
- `CLAUDE.md` — one-line carve-out: the `/release` tag push is exempt from the `/orchestrate`-only-push rule (benign: non-branch ref, no tracked-file edits, gated behind the confirmation).

Deferred to a small follow-up (critic Axis 6): wiring `scripts/tests/*.sh` into CI. The p8 gate is already enforced at pre-commit, so CI is defense-in-depth.

## Test plan
- Docs/skill only; no Swift. swiftlint clean; build passes via pre-commit hook on each commit.
- code-reviewer (Opus): PASS — verified SKILL.md fidelity to ADR-014 + release.sh (bump sequencing, recovery map, env vars, team/bundle id), ADR tense reconciliation complete (no stale future-tense survivors), the checklist anchor resolves, cross-file consistency, no dead links.

Closes #567

🤖 Generated with [Claude Code](https://claude.com/claude-code)