### PR TITLE
✨ feat: split Legal-row tap language by destination (Theme D)

### DIFF
--- a/Pastura/Pastura/Views/Settings/SettingsView.swift
+++ b/Pastura/Pastura/Views/Settings/SettingsView.swift
@@ -76,10 +76,15 @@ struct SettingsView: View {
         #if !targetEnvironment(simulator)
           modelsSection
         #endif
-        // Theme D (tappable-row green language) is intentionally left as-is:
-        // these stay `Button`s with `.foregroundStyle(.primary)`, which the
-        // Button context resolves to the moss accent. Only the container
-        // (card) and field tone change here.
+        // Theme D — tappable-row language split by destination:
+        // Privacy Policy is the lone external link (opens Safari), so it
+        // keeps the green `Color.link` dialect + the external-link arrow
+        // (no chevron). The report / licenses rows open in-app sheets, so
+        // they adopt the standard in-app row vocabulary (`PasturaRowLabel`:
+        // ink text + trailing chevron) shared with Home / ScenarioDetail /
+        // Results. `Color.link` (design-system §2.8) lands its first real
+        // consumer here; the explicit `Color.link` form (not `.link`)
+        // sidesteps the ShapeStyle-vs-Color token trap.
         PasturaSection(String(localized: "Legal")) {
           VStack(spacing: 0) {
             Button {
@@ -88,10 +93,10 @@ struct SettingsView: View {
             } label: {
               HStack {
                 Text(String(localized: "Privacy Policy"))
-                  .foregroundStyle(.primary)
+                  .foregroundStyle(Color.link)
                 Spacer()
                 Image(systemName: "arrow.up.right.square")
-                  .foregroundStyle(.secondary)
+                  .foregroundStyle(Color.link)
               }
               .padding(.horizontal, 17)
               .padding(.vertical, 15)
@@ -103,30 +108,18 @@ struct SettingsView: View {
             Button {
               isReportSheetPresented = true
             } label: {
-              HStack {
-                Text(String(localized: "Send a content report"))
-                  .foregroundStyle(.primary)
-                Spacer()
-              }
-              .padding(.horizontal, 17)
-              .padding(.vertical, 15)
-              .contentShape(Rectangle())
+              PasturaRowLabel(title: String(localized: "Send a content report"))
             }
+            .buttonStyle(.plain)
             .accessibilityIdentifier("settings.sendContentReportButton")
 
             PasturaRowDivider()
             Button {
               isLicensesSheetPresented = true
             } label: {
-              HStack {
-                Text(String(localized: "Licenses"))
-                  .foregroundStyle(.primary)
-                Spacer()
-              }
-              .padding(.horizontal, 17)
-              .padding(.vertical, 15)
-              .contentShape(Rectangle())
+              PasturaRowLabel(title: String(localized: "Licenses"))
             }
+            .buttonStyle(.plain)
             .accessibilityIdentifier("settings.licensesLink")
           }
         }


### PR DESCRIPTION
## Summary
PR #559 で意図的に繰り越した Theme D。Settings の Legal セクションは外部リンク(Privacy Policy)とアプリ内 sheet(Send a content report / Licenses)が一律に緑文字 Button(`.foregroundStyle(.primary)` が Button 文脈で moss に解決)で、遷移先の性質が見た目で区別できなかった。行を遷移先で2語彙に分離する。

- **Privacy Policy(唯一の外部リンク → Safari)**: `Color.link`(#5D7A4D)緑文字 + 外部リンク矢印、chevron なし。design-system §2.8 の予約トークン `Color.link` の初の実消費。ShapeStyle トラップ回避のため `.foregroundStyle(Color.link)` 明示形を使用。
- **Send a content report / Licenses(アプリ内 sheet)**: `PasturaRowLabel`(ink + trailing chevron)に統一し、Home / ScenarioDetail / Results と同じ語彙に。

「緑＋外部リンク矢印」を真の外部リンク専用に限定し、「タップ→アプリ内コンテンツ」を全画面で ink＋chevron に一本化する。アクション(openURL / sheet 提示)と accessibilityIdentifier 3つは不変、ScreenshotTourTests の `settings.licensesLink` アンカーも維持。

## Test plan
- ✅ `xcodebuild build` 成功
- ✅ 全 1833 ユニットテスト成功
- ✅ `swiftlint --strict` クリーン
- ✅ code-reviewer (Opus) PASS / 0 issues
- ✅ ui-tour スクショで Legal セクション視覚確認(2語彙の分離を目視確認)
- ⚠️ iOS 26 Liquid Glass トーンは実機 QA 推奨(simulator では非保証)

Closes #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)