### PR TITLE
✨ feat: DB recovery screen bug-report affordance (auto-attach migration error)

### DIFF
--- a/.github/ISSUE_TEMPLATE/db-migration-failure.yml
+++ b/.github/ISSUE_TEMPLATE/db-migration-failure.yml
@@ -1,0 +1,58 @@
+name: Database migration failure
+description: Report a database upgrade (migration) failure surfaced by the in-app recovery screen.
+title: "[DB migration failure] "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a database recovery problem. Issues here are
+        **public** — anyone on the internet can read what you submit.
+
+        If you reached this from the app's "Database Needs Recovery"
+        screen, the error detail below is filled in for you. Please skim
+        it before submitting (see the note on that field).
+
+  - type: textarea
+    id: db_error
+    attributes:
+      label: Database error detail
+      description: |
+        The exact migration error from the recovery screen. This is a
+        technical SQLite message and may, in rare cases, include
+        fragments of your own scenario data. **Review it before
+        submitting** — this issue is public. Auto-filled when you arrive
+        from the app.
+      placeholder: "e.g. SQLite error 1: no such column: foo"
+    validations:
+      required: true
+
+  - type: input
+    id: ios_version
+    attributes:
+      label: iOS version (optional)
+      description: "Found in Settings → General → About → Software Version. Leave blank if unknown."
+      placeholder: "e.g. 18.2"
+    validations:
+      required: false
+
+  - type: input
+    id: app_version
+    attributes:
+      label: App version (optional)
+      description: "Auto-filled when you arrive from the app. Found in the Pastura Settings screen otherwise."
+      placeholder: "e.g. 1.0.0 (TestFlight build 42)"
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional context (optional)
+      description: |
+        What you were doing when the failure appeared, the device model,
+        or any other detail. Do not include personal information — this
+        issue is public.
+    validations:
+      required: false

--- a/Pastura/Pastura/PasturaApp.swift
+++ b/Pastura/Pastura/PasturaApp.swift
@@ -128,6 +128,10 @@ private struct RootView: View {
   /// `databaseRecovery` AppState (#546).
   @State private var pendingRecoveryModelPath: String?
 
+  /// Drives the `.databaseRecovery` "Report this problem" sheet (#580),
+  /// which pre-fills the migration error into the report surfaces.
+  @State private var isRecoveryReportSheetPresented: Bool = false
+
   private static let logger = Logger(subsystem: "app.pastura.Pastura", category: "AppInit")
 
   // Launch animation state — see `Pastura/Pastura/Views/Splash/`.
@@ -273,8 +277,29 @@ private struct RootView: View {
             appState = .initializing
           }
           .buttonStyle(.bordered)
+          // Tertiary affordance: capture a bug report with the migration
+          // error auto-attached, BEFORE the user resets and the failing DB
+          // is moved aside (#580). Quieter than Reset/Retry so it doesn't
+          // compete with recovery.
+          Button(String(localized: "Report this problem")) {
+            // Gate on splash dismissal: the recovery screen is occluded by
+            // the splash overlay until `splashKind == nil` (see the
+            // `deepLinkToast` render guard), so presenting the sheet mid
+            // cold-splash-exit could race the transition. The button is
+            // already unreachable under the opaque splash; this is the
+            // belt-and-suspenders for the exit-animation frame.
+            guard splashKind == nil else { return }
+            isRecoveryReportSheetPresented = true
+          }
+          .font(.footnote)
+          .padding(.top, 4)
+          .accessibilityIdentifier("recovery.reportButton")
         }
         .padding()
+        .sheet(isPresented: $isRecoveryReportSheetPresented) {
+          ReportScenarioSheet(context: .migrationFailure(error: message))
+            .deepLinkGated()
+        }
 
       case .error(let message):
         VStack(spacing: 16) {

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -3656,6 +3656,16 @@
         }
       }
     },
+    "Report this problem" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "この問題を報告"
+          }
+        }
+      }
+    },
     "Report this scenario" : {
       "localizations" : {
         "ja" : {

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -3636,6 +3636,16 @@
         }
       }
     },
+    "Report a problem" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "問題を報告"
+          }
+        }
+      }
+    },
     "Report scenario" : {
       "localizations" : {
         "ja" : {
@@ -4406,6 +4416,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "このダウンロードは Wi-Fi 接続のみに設定されています。再試行ボタンで変更してください。"
+          }
+        }
+      }
+    },
+    "This error detail is attached to your report:" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このエラー詳細が報告に添付されます:"
           }
         }
       }

--- a/Pastura/Pastura/Utilities/ReportURLBuilder.swift
+++ b/Pastura/Pastura/Utilities/ReportURLBuilder.swift
@@ -34,6 +34,9 @@ nonisolated enum ReportURLBuilder {
   // is load-bearing (a hyphen would silently no-op the auto-attach).
   private static let dbMigrationTemplateSlug = "db-migration-failure.yml"
   private static let dbMigrationErrorFieldID = "db_error"
+  // Must exist in the repo's label set — GitHub silently drops an
+  // unknown `labels` value from the pre-seeded issue (same silent-skip
+  // failure mode as a mismatched field id above).
   private static let dbMigrationLabel = "bug"
 
   /// Build the pre-filled Google Forms URL for a Shared Scenario report.
@@ -117,7 +120,9 @@ nonisolated enum ReportURLBuilder {
   ///   - appVersion: Running app version (e.g. "1.0.0"). Empty strings
   ///     are permitted and leave the App Version field blank.
   ///   - dbError: The migration error detail (e.g.
-  ///     `SQLite error 1: no such column …`).
+  ///     `SQLite error 1: no such column …`). Expected non-empty in
+  ///     practice (the sole caller passes `localizedDescription`); an
+  ///     empty value leaves the form's required Reason field blank.
   /// - Returns: The pre-filled form URL, or `nil` if URL construction
   ///   fails.
   static func buildGoogleFormURL(appVersion: String, dbError: String) -> URL? {

--- a/Pastura/Pastura/Utilities/ReportURLBuilder.swift
+++ b/Pastura/Pastura/Utilities/ReportURLBuilder.swift
@@ -17,11 +17,24 @@ nonisolated enum ReportURLBuilder {
     "1FAIpQLSfsZkY9-R3QxqVfdXSzsUnx3SXR-g9O7DxjdN-1-VtMjMXSAw"
   private static let scenarioIdFieldID = "entry.149667905"
   private static let appVersionFieldID = "entry.1904779030"
+  // The existing "Reason" paragraph field (form field #3, docs/gallery/
+  // shared-scenario-reports.md §1.1). The DB-migration report path
+  // pre-fills it with the SQLite error so no new form field is needed.
+  private static let reasonFieldID = "entry.532267701"
 
   // GitHub issue identifiers.
   private static let githubRepoPath = "tyabu12/pastura"
   private static let githubTemplateSlug = "shared-scenario-report.yml"
   private static let githubLabel = "shared-scenario-report"
+
+  // GitHub issue identifiers for the DB-migration-failure report path.
+  // `dbMigrationErrorFieldID` MUST equal the `id:` of the `db_error`
+  // field in `.github/ISSUE_TEMPLATE/db-migration-failure.yml` — GitHub
+  // prefills issue-form fields by exact id match, so the underscore form
+  // is load-bearing (a hyphen would silently no-op the auto-attach).
+  private static let dbMigrationTemplateSlug = "db-migration-failure.yml"
+  private static let dbMigrationErrorFieldID = "db_error"
+  private static let dbMigrationLabel = "bug"
 
   /// Build the pre-filled Google Forms URL for a Shared Scenario report.
   ///
@@ -89,6 +102,39 @@ nonisolated enum ReportURLBuilder {
     return components.url
   }
 
+  /// Build the pre-filled Google Forms URL for a database
+  /// migration-failure report (private path of the recovery screen).
+  ///
+  /// Pre-fills the existing **Reason** paragraph field with the exact
+  /// migration error so the reporter doesn't have to hand-type a SQLite
+  /// string; App Version is pre-filled as usual. No new form field is
+  /// added — the migration error rides the same Reason field general
+  /// feedback uses, framed as an extension of the §1.5 general-contact
+  /// co-tenancy (ADR-005 §6.7), not a §1.2 UGC report. The Scenario ID
+  /// field is omitted (there is no scenario context on a boot failure).
+  ///
+  /// - Parameters:
+  ///   - appVersion: Running app version (e.g. "1.0.0"). Empty strings
+  ///     are permitted and leave the App Version field blank.
+  ///   - dbError: The migration error detail (e.g.
+  ///     `SQLite error 1: no such column …`).
+  /// - Returns: The pre-filled form URL, or `nil` if URL construction
+  ///   fails.
+  static func buildGoogleFormURL(appVersion: String, dbError: String) -> URL? {
+    guard
+      var components = URLComponents(
+        string: "https://docs.google.com/forms/d/e/\(googleFormID)/viewform")
+    else {
+      return nil
+    }
+    components.queryItems = [
+      URLQueryItem(name: "usp", value: "pp_url"),
+      URLQueryItem(name: appVersionFieldID, value: appVersion),
+      URLQueryItem(name: reasonFieldID, value: dbError)
+    ]
+    return components.url
+  }
+
   /// Build the pre-seeded GitHub issue URL for a Shared Scenario report.
   ///
   /// Opens github.com's new-issue page with the Shared Scenario template
@@ -138,6 +184,40 @@ nonisolated enum ReportURLBuilder {
       URLQueryItem(name: "template", value: githubTemplateSlug),
       URLQueryItem(name: "title", value: "[Shared Scenario Report]"),
       URLQueryItem(name: "labels", value: githubLabel)
+    ]
+    return components.url
+  }
+
+  /// Build the pre-seeded GitHub issue URL for a database
+  /// migration-failure report (public path of the recovery screen).
+  ///
+  /// Selects the dedicated `db-migration-failure.yml` issue-form
+  /// template and pre-fills its `db_error` field with the migration
+  /// error. The query-parameter name MUST match the template field's
+  /// `id` exactly (`db_error`, underscore) — GitHub prefills issue-form
+  /// fields by exact id match, so a hyphen would silently no-op. This
+  /// is the public-tracker (account-required) path; the SQLite error
+  /// may, in rare data-migrating failures, embed scenario fragments, so
+  /// the template carries a review-before-submit caveat (ADR-005 §6 PII
+  /// hygiene). Framed as technical bug intake (`bug` label), outside the
+  /// §6 Shared Scenario UGC report tracker.
+  ///
+  /// - Parameter migrationError: The migration error detail rendered
+  ///   into the pre-filled `db_error` field.
+  /// - Returns: The pre-seeded issue-creation URL, or `nil` if URL
+  ///   construction fails.
+  static func buildGitHubIssueURL(migrationError: String) -> URL? {
+    guard
+      var components = URLComponents(
+        string: "https://github.com/\(githubRepoPath)/issues/new")
+    else {
+      return nil
+    }
+    components.queryItems = [
+      URLQueryItem(name: "template", value: dbMigrationTemplateSlug),
+      URLQueryItem(name: "title", value: "[DB migration failure]"),
+      URLQueryItem(name: "labels", value: dbMigrationLabel),
+      URLQueryItem(name: dbMigrationErrorFieldID, value: migrationError)
     ]
     return components.url
   }

--- a/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailView.swift
+++ b/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailView.swift
@@ -76,7 +76,7 @@ struct GalleryScenarioDetailView: View {
       .hidingPasturaSharedBackground()
     }
     .sheet(isPresented: $isReportSheetPresented) {
-      ReportScenarioSheet(scenario: scenario)
+      ReportScenarioSheet(context: .scenario(scenario))
         .deepLinkGated()
     }
   }

--- a/Pastura/Pastura/Views/Community/SharedScenarios/ReportScenarioSheet.swift
+++ b/Pastura/Pastura/Views/Community/SharedScenarios/ReportScenarioSheet.swift
@@ -1,18 +1,39 @@
 import SwiftUI
 
-/// Dual-use presentation surface for content reports.
+/// The reporting context the sheet was opened with.
 ///
-/// - **Scenario-scoped** (`scenario != nil`): pushed from a Shared
-///   Scenarios detail's More menu. Shows scenario metadata, pre-fills
-///   the form / GitHub URLs with scenarioId.
-/// - **General** (`scenario == nil`): pushed from Settings → Legal →
-///   "Send a content report". Hides scenarioMetadata; routes the
-///   form and GitHub URLs to the no-scenarioId variants in
-///   `ReportURLBuilder`. The Google Forms scenario id field and the
-///   GitHub issue template's `scenario_id` are both configured as
-///   optional with "leave blank for general feedback" hints — same
-///   shape as the App Store Connect §1.5 Support URL co-tenancy
-///   precedent in ADR-005 §6.7.
+/// An explicit three-way replacing the prior `scenario: GalleryScenario?`
+/// two-state, so the illegal "scenario AND migration error" combination
+/// is unrepresentable by construction.
+///
+/// - ``scenario(_:)``: pushed from a Shared Scenarios detail's More menu.
+/// - ``migrationFailure(error:)``: presented from the DB recovery screen
+///   (`PasturaApp` `.databaseRecovery`, #580) with the SQLite migration
+///   error auto-attached.
+/// - ``general``: pushed from Settings → Legal → "Send a content report".
+enum ReportContext {
+  case scenario(GalleryScenario)
+  case migrationFailure(error: String)
+  case general
+}
+
+/// Multi-use presentation surface for reports.
+///
+/// Routes each ``ReportContext`` to the matching `ReportURLBuilder`
+/// variant:
+///
+/// - **Scenario-scoped**: shows scenario metadata, pre-fills the
+///   form / GitHub URLs with scenarioId.
+/// - **Migration failure**: shows the attached error, pre-fills the
+///   Google Form Reason field and a dedicated GitHub issue template
+///   (`db-migration-failure.yml`) with the SQLite error. Framed as a
+///   technical bug report (GitHub `bug` label / §1.5 general-contact
+///   co-tenancy on the form), NOT a §1.2 UGC content report.
+/// - **General**: hides scenario metadata; routes to the no-scenarioId
+///   variants. The Google Forms scenario id field and the GitHub issue
+///   template's `scenario_id` are both configured as optional with
+///   "leave blank for general feedback" hints — same shape as the App
+///   Store Connect §1.5 Support URL co-tenancy precedent in ADR-005 §6.7.
 ///
 /// Progressive disclosure: the primary action opens a Google Forms
 /// report in Safari (no account required); the secondary opens a
@@ -29,10 +50,11 @@ import SwiftUI
 /// for operational details.
 ///
 /// The type/file name still encodes scenario-specificity. Renaming
-/// to `ReportSheet` is deferred to a follow-up to keep this PR
-/// focused on the UX additions.
+/// to `ReportSheet` is deferred to a follow-up — now reinforced by the
+/// migration-failure consumer (#580), which is not a "shared scenario"
+/// concern — to keep this PR focused on the recovery-screen affordance.
 struct ReportScenarioSheet: View {
-  let scenario: GalleryScenario?
+  let context: ReportContext
 
   @Environment(\.openURL) private var openURL
   @Environment(\.dismiss) private var dismiss
@@ -41,8 +63,13 @@ struct ReportScenarioSheet: View {
     NavigationStack {
       ScrollView {
         VStack(alignment: .leading, spacing: 20) {
-          if let scenario {
+          switch context {
+          case .scenario(let scenario):
             scenarioMetadata(for: scenario)
+          case .migrationFailure(let error):
+            migrationErrorDetail(error)
+          case .general:
+            EmptyView()
           }
           introCopy
           primarySection
@@ -58,9 +85,14 @@ struct ReportScenarioSheet: View {
   }
 
   private var navigationTitleText: String {
-    scenario == nil
-      ? String(localized: "Send report")
-      : String(localized: "Report scenario")
+    switch context {
+    case .scenario:
+      return String(localized: "Report scenario")
+    case .migrationFailure:
+      return String(localized: "Report a problem")
+    case .general:
+      return String(localized: "Send report")
+    }
   }
 
   // MARK: - Sections
@@ -72,6 +104,20 @@ struct ReportScenarioSheet: View {
       Text(String(format: String(localized: "ID: %@"), scenario.id))
         .font(.caption)
         .foregroundStyle(.secondary)
+        .textSelection(.enabled)
+    }
+    .padding(12)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(Color.secondary.opacity(0.1), in: RoundedRectangle(cornerRadius: 8))
+  }
+
+  private func migrationErrorDetail(_ error: String) -> some View {
+    VStack(alignment: .leading, spacing: 4) {
+      Text(String(localized: "This error detail is attached to your report:"))
+        .font(.caption)
+        .foregroundStyle(.secondary)
+      Text(error)
+        .font(.caption.monospaced())
         .textSelection(.enabled)
     }
     .padding(12)
@@ -141,28 +187,36 @@ struct ReportScenarioSheet: View {
 
   private func openReportForm() {
     let urlOrNil: URL? = {
-      if let scenario {
+      switch context {
+      case .scenario(let scenario):
         return ReportURLBuilder.buildGoogleFormURL(
           scenarioId: scenario.id, appVersion: appVersion)
+      case .migrationFailure(let error):
+        return ReportURLBuilder.buildGoogleFormURL(appVersion: appVersion, dbError: error)
+      case .general:
+        return ReportURLBuilder.buildGoogleFormURL(appVersion: appVersion)
       }
-      return ReportURLBuilder.buildGoogleFormURL(appVersion: appVersion)
     }()
     guard let url = urlOrNil else { return }
     openURL(url)
     dismiss()
   }
 
-  /// Dispatches by nil-ness, mirroring `openReportForm`. The general
-  /// path (`scenario == nil`) produces a bare `[Shared Scenario
-  /// Report]` title; the reporter fills in details on GitHub. The
-  /// issue template's `scenario_id` field is optional, so general
-  /// reports can submit without a value.
+  /// Mirrors `openReportForm`'s dispatch. The general path produces a
+  /// bare `[Shared Scenario Report]` title (the template's `scenario_id`
+  /// is optional, so general reports submit without a value); the
+  /// migration path selects the dedicated `db-migration-failure.yml`
+  /// template with the SQLite error pre-filled.
   private func openGitHubIssue() {
     let urlOrNil: URL? = {
-      if let scenario {
+      switch context {
+      case .scenario(let scenario):
         return ReportURLBuilder.buildGitHubIssueURL(scenarioId: scenario.id)
+      case .migrationFailure(let error):
+        return ReportURLBuilder.buildGitHubIssueURL(migrationError: error)
+      case .general:
+        return ReportURLBuilder.buildGitHubIssueURL()
       }
-      return ReportURLBuilder.buildGitHubIssueURL()
     }()
     guard let url = urlOrNil else { return }
     openURL(url)

--- a/Pastura/Pastura/Views/Settings/SettingsView.swift
+++ b/Pastura/Pastura/Views/Settings/SettingsView.swift
@@ -28,7 +28,7 @@ import os
 ///
 /// Two rows: an external Privacy Policy link (opens Safari via
 /// `Environment(\.openURL)`) and a "Send a content report" Button
-/// that presents `ReportScenarioSheet(scenario: nil)` via
+/// that presents `ReportScenarioSheet(context: .general)` via
 /// `.sheet(isPresented:)`. The sheet carries `.deepLinkGated()` for
 /// symmetry with `GalleryScenarioDetailView`'s callsite — see
 /// navigation.md QA scenario 9. ADR-005 §6.6 substantive commitment
@@ -39,7 +39,7 @@ struct SettingsView: View {
 
   /// Bound to `.sheet(isPresented:)` for the "Send a content report"
   /// row inside the Legal section. The sheet reuses
-  /// `ReportScenarioSheet` with `scenario: nil` (Settings has no
+  /// `ReportScenarioSheet` with `context: .general` (Settings has no
   /// specific scenario context) — see ADR-005 §6.7 dual-use precedent.
   @State private var isReportSheetPresented: Bool = false
 
@@ -155,7 +155,7 @@ struct SettingsView: View {
     // dismisses, rather than pushing a gallery detail under it (see
     // navigation.md QA scenario 9).
     .sheet(isPresented: $isReportSheetPresented) {
-      ReportScenarioSheet(scenario: nil)
+      ReportScenarioSheet(context: .general)
         .deepLinkGated()
     }
     .sheet(isPresented: $isLicensesSheetPresented) {

--- a/Pastura/PasturaTests/ReportURLBuilderTests.swift
+++ b/Pastura/PasturaTests/ReportURLBuilderTests.swift
@@ -170,4 +170,83 @@ struct ReportURLBuilderTests {
     // Title is exactly the bare prefix — no trailing space, no scenario id.
     #expect(items.contains { $0.name == "title" && $0.value == "[Shared Scenario Report]" })
   }
+
+  // MARK: - GitHub issue URL (DB migration failure)
+
+  @Test
+  func gitHubIssueURLMigrationBuildsWithExpectedHostAndPath() throws {
+    let url = try #require(ReportURLBuilder.buildGitHubIssueURL(migrationError: "boom"))
+    #expect(url.scheme == "https")
+    #expect(url.host == "github.com")
+    #expect(url.path == "/tyabu12/pastura/issues/new")
+  }
+
+  @Test
+  func gitHubIssueURLMigrationCarriesTemplateLabelTitleAndDbError() throws {
+    let error = "SQLite error 1: no such column: foo"
+    let url = try #require(ReportURLBuilder.buildGitHubIssueURL(migrationError: error))
+    let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+    let items = components.queryItems ?? []
+    #expect(items.contains { $0.name == "template" && $0.value == "db-migration-failure.yml" })
+    #expect(items.contains { $0.name == "labels" && $0.value == "bug" })
+    #expect(items.contains { $0.name == "title" && $0.value == "[DB migration failure]" })
+    // C1 regression guard: the prefill query param key MUST be the underscore
+    // form `db_error` (matching the yml field id), not the hyphen form
+    // `db-error` — GitHub prefills issue-form fields by exact id match, so a
+    // hyphen would silently no-op the auto-attach.
+    #expect(items.contains { $0.name == "db_error" && $0.value == error })
+    #expect(!items.contains { $0.name == "db-error" })
+  }
+
+  @Test
+  func gitHubIssueURLMigrationRoundTripsErrorDetail() throws {
+    // Real SQLite errors carry colons, spaces, and (rarely) multi-byte
+    // scenario fragments. Confirm the value survives percent-encoding intact.
+    let error = "table シナリオ has 3 columns but 4 values supplied: a/b&c"
+    let url = try #require(ReportURLBuilder.buildGitHubIssueURL(migrationError: error))
+    let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+    let match = components.queryItems?.first { $0.name == "db_error" && $0.value == error }
+    #expect(match != nil)
+  }
+
+  // MARK: - Google Forms URL (DB migration failure)
+
+  @Test
+  func googleFormURLMigrationBuildsWithExpectedHostAndPath() throws {
+    let url = try #require(
+      ReportURLBuilder.buildGoogleFormURL(appVersion: "1.0.0", dbError: "boom"))
+    #expect(url.scheme == "https")
+    #expect(url.host == "docs.google.com")
+    #expect(url.path.hasPrefix("/forms/d/e/"))
+    #expect(url.path.hasSuffix("/viewform"))
+  }
+
+  @Test
+  func googleFormURLMigrationEmbedsAppVersionAndReasonError() throws {
+    let error = "SQLite error 1: no such column: foo"
+    let url = try #require(
+      ReportURLBuilder.buildGoogleFormURL(appVersion: "1.2.3", dbError: error))
+    let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+    let items = components.queryItems ?? []
+    #expect(items.contains { $0.name == "usp" && $0.value == "pp_url" })
+    // The migration error pre-fills the existing Reason paragraph field
+    // (entry.532267701) — no new form field was added.
+    #expect(items.contains { $0.name == "entry.532267701" && $0.value == error })
+    let values = items.compactMap { $0.value }
+    #expect(values.contains("1.2.3"))
+    // No scenario-id field on this path (matches the no-scenario variant).
+    #expect(!items.contains { $0.name == "entry.149667905" })
+  }
+
+  @Test
+  func googleFormURLMigrationRoundTripsErrorDetail() throws {
+    let error = "table シナリオ has 3 columns but 4 values supplied: a/b&c"
+    let url = try #require(
+      ReportURLBuilder.buildGoogleFormURL(appVersion: "", dbError: error))
+    let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+    let match = components.queryItems?.first {
+      $0.name == "entry.532267701" && $0.value == error
+    }
+    #expect(match != nil)
+  }
 }

--- a/docs/decisions/ADR-005.md
+++ b/docs/decisions/ADR-005.md
@@ -880,6 +880,19 @@ surface (one form) but not the framing. The separation matters for
 compliance-claim bookkeeping: if Apple ever challenges one, the
 other is not automatically implicated.
 
+The in-app DB migration-failure report path (#580) extends this §1.5
+general-contact framing — **not** the §1.2 UGC channel. The recovery
+screen reuses `ReportScenarioSheet` to attach the SQLite migration
+error to a bug report; it pre-fills the form's existing Reason field
+(no new field) and, on the public path, a **dedicated**
+`db-migration-failure.yml` template labelled `bug` (kept out of the §6
+`shared-scenario-report` tracker). Because it is technical-crash intake,
+the §6.3 content-moderation commitments (7-day triage, 72-hour content
+hide-out) do not apply — there is no gallery entry to hide. The §6 UGC
+report machinery in §6.6 is therefore unchanged; only the §1.5
+general-contact surface gains a consumer. Operational detail:
+`docs/gallery/shared-scenario-reports.md` §1.3.
+
 Tracked in §9.2 row #9 (#182).
 
 ---

--- a/docs/gallery/shared-scenario-reports.md
+++ b/docs/gallery/shared-scenario-reports.md
@@ -44,7 +44,7 @@ editing.
 | auto | Email | Email | yes (enforced) | Auto-added by Responder input. Not pre-fillable by URL parameter (Google design). |
 | 1 | Short answer | Scenario ID | **no** | Pre-filled by the app via URL parameter when reporting from Shared Scenarios. Left blank on the §1.5 general-contact path. Helper text: "Auto-filled when reporting from the app. Leave blank for general feedback." |
 | 2 | Short answer | App Version | no | Pre-filled by the app. Blank on the §1.5 path. |
-| 3 | Paragraph | Reason | yes | User writes the report body or feedback text. |
+| 3 | Paragraph | Reason | yes | User writes the report body or feedback text. The DB migration-failure path (§1.3) pre-fills this field with the SQLite error (`entry.532267701`). |
 
 **Settings → Presentation → Confirmation message:** see §2.1.
 
@@ -62,6 +62,43 @@ filed via this template carry the `shared-scenario-report` label.
 Reporter contact is **not collected** — reply via @-mention on the
 issue (the GitHub author is visible in the issue header). This keeps
 the public tracker free of PII.
+
+### 1.3 Database migration-failure report path
+
+The in-app "Database Needs Recovery" screen (`PasturaApp`
+`.databaseRecovery`, #580) reuses `ReportScenarioSheet` in
+`migrationFailure` mode to capture a bug report **before** the user
+resets and the failing DB is moved aside. The exact SQLite migration
+error is auto-attached to both surfaces.
+
+This is **technical bug intake, not a §1.2 UGC content report** — there
+is no gallery entry to hide and no abusive user to block, so the §6.3
+content-moderation SLAs (7-day triage, 72-hour content hide-out) do not
+apply. It is framed instead as an extension of the §1.5 general-contact
+co-tenancy (ADR-005 §6.7):
+
+- **Google Form (private).** Pre-fills the existing **Reason** field
+  (`entry.532267701`) with the error — no new form field was added, so
+  no live-form edit is required. App Version is pre-filled as usual;
+  Scenario ID is omitted (a boot failure has no scenario context). The
+  neutral §2.1 confirmation copy ("Thanks for your message…") already
+  fits this case.
+- **GitHub issue (public).** Uses a **dedicated** template,
+  `.github/ISSUE_TEMPLATE/db-migration-failure.yml`, labelled `bug`
+  (kept out of the §6 `shared-scenario-report` tracker). The migration
+  error pre-fills the template's `db_error` field via
+  `?template=db-migration-failure.yml&db_error=<error>` — the query-param
+  key **must** equal the field `id` exactly (`db_error`, underscore), or
+  GitHub silently skips the prefill.
+
+**PII note.** The prefilled value is the SQLite `localizedDescription`,
+which can in rare data-migrating failures embed scenario-data fragments.
+The Google Form path is private; the GitHub path is public, so the
+`db_error` field description carries a review-before-submit caveat and
+the in-app sheet shows the attached error so the user sees exactly what
+is sent. The `entry.532267701` (Reason), `db_error` field id, and
+template slug are mirrored as constants in `ReportURLBuilder.swift` —
+keep them in sync with this doc and the form/template.
 
 ## 2. Response templates
 


### PR DESCRIPTION
## Summary
- Adds a tertiary "Report this problem" button to the `.databaseRecovery` screen that captures a bug report with the exact SQLite migration error auto-attached — before the user resets and the failing DB is moved aside.
- Both report surfaces (progressive disclosure): Google Form (private, prefills the existing Reason field) + a dedicated public GitHub template (`db-migration-failure.yml`, prefills `db_error`).
- Refactors `ReportScenarioSheet` to a `ReportContext` enum (scenario / migrationFailure / general) so the illegal both-set state is unrepresentable.

## Design notes (critic-incorporated)
- **Framing**: technical bug intake, NOT a §1.2 UGC content report. GitHub path is `bug`-labelled and outside the §6 report tracker; Google Form path extends the §1.5 general-contact co-tenancy (ADR-005 §6.7). §6.3 content SLAs do not apply.
- **`db_error` field id**: query-param key pinned to the underscore form to match the yml field id (GitHub prefills by exact id; a hyphen silently no-ops). Regression-guarded in tests.
- **Splash race**: sheet presentation gated on `splashKind == nil`.
- **PII**: SQLite error may embed scenario fragments → public `db_error` field carries a review-before-submit caveat; the sheet shows the attached error before send.

## Test plan
- 6 new `ReportURLBuilderTests` (db_error= underscore guard, Reason prefill, round-trips). Full unit suite (1855) green; swiftlint --strict clean; localization coverage OK (3 new ja keys).
- Manual QA: trigger `.databaseRecovery` on cold launch, tap Report before/after splash settle; verify both surfaces open with the error prefilled.

Closes #580

🤖 Generated with [Claude Code](https://claude.com/claude-code)