### PR TITLE
📝 docs: cross-ref %arg table to SwiftUI Text runtime-lookup trap (#583)

### DIFF
--- a/.claude/rules/i18n.md
+++ b/.claude/rules/i18n.md
@@ -96,20 +96,49 @@ Empty-body (`"Key" : { }`, no `localizations` block at all) is in fact the domin
 `%arg` literals in `Localizable.xcstrings` keys (e.g., `"Save failed: %arg"`,
 `""%arg" already uses this id..."`) are **Apple's auto-extracted
 placeholder** for `String(localized: "Foo \(x)")` (Swift 5.7+ interpolation
-in `String(localized:)`). They are functional at runtime, NOT bugs:
+in `String(localized:)`). As **catalog entries** they are legitimate
+auto-generated keys, NOT garbage to delete — this is a catalog-hygiene
+fact, separate from whether Form A is *safe to write at a callsite* (it
+often is not — see § "Form A is a runtime hazard at user-facing callsites"
+below):
 
 | Form | Source | Catalog key | Runtime |
 |---|---|---|---|
 | A (Swift-interp) | `String(localized: "Save failed: \(error)")` | `"Save failed: %arg"` | Apple substitutes `error` into `%arg` |
 | B (Pastura convention) | `String(format: String(localized: "Save failed: %@"), error)` | `"Save failed: %@"` | `String(format:)` substitutes via `%@` |
 
-Both render identical user-visible output. Pastura prefers Form B per
+Both render identical output **when the catalog lookup succeeds** — but
+Form A can silently miss that lookup on non-base locales (see § "Form A is
+a runtime hazard at user-facing callsites"). Pastura prefers Form B per
 § "Format-string pattern" — explicit format-specifier control + type
 safety (`%@` vs `%lld` catches `Int`/`String` mismatch).
 
 For multi-arg keys, sync also emits a positional-form `en` block
 (`"Foo %1$arg %2$arg"`), preserved as translator reference per
 § "xcstringstool sync output".
+
+### Form A is a runtime hazard at user-facing callsites
+
+The catalog-hygiene fact above (a `%arg` key is a legitimate entry) does
+**not** make Form A safe to *write* for user-facing copy. For any
+**interpolated user-facing string**, use Form B
+(`String(format: String(localized: "%@"), arg)`), never Form A — the
+project convention in § "Format-string pattern" exists for exactly this
+reason.
+
+Observed failure: in #578 (fixed in PR #579) the Settings → Models delete
+confirmation — `String(localized: "Delete \(name)?")` (Form A) inside an
+alert — rendered in **English on a ja device** despite ja values in the
+catalog. The interpolated literal (`"Delete Foo?"`) became the runtime
+lookup key, missing the `%arg` template entry → English fallback on the
+non-base locale. Same observable symptom as § "SwiftUI convenience-init label trap"
+(a sibling `LocalizedStringKey` variant): both produce silent English
+fallback from a `\(…)`-interpolated literal.
+
+**No automated gate catches this.** `scripts/check_localization_coverage.py`
+validates ja presence + entry state, never *runtime substitution form*; the
+SwiftLint tripwire and Tier 2 audit see a `String(localized:)` callsite and
+treat it as covered. Only **device / ja-locale QA** surfaces it.
 
 ### The partial-conversion trap
 


### PR DESCRIPTION
## Summary
The `%arg` table in `.claude/rules/i18n.md` claimed Form-A keys are "functional at runtime, NOT bugs" without distinguishing **catalog hygiene** from **callsite write-safety** — appearing to contradict the § "SwiftUI convenience-init label trap" one section up.

- Scope the existing claim to catalog entries (legitimate auto-generated keys, not garbage to delete).
- Add § "Form A is a runtime hazard at user-facing callsites": for interpolated user-facing strings, prefer Form B — Form A risks silent English fallback on ja (observed in #578, fixed by PR #579).
- Cross-reference the sibling convenience-init trap; note no automated gate catches this (device/ja QA only).

Docs-only; no source/import changes.

## Test plan
- Cross-reference self-check: all `§ "..."` headings resolve in-file; `scripts/check_localization_coverage.py` path exists; #578=issue / #579=PR citations verified.
- Opus `code-reviewer`: PASS (0 critical/warning).

Closes #583

🤖 Generated with [Claude Code](https://claude.com/claude-code)