### PR TITLE
📝 docs: nav title large/inline display-mode convention

### DIFF
--- a/.claude/rules/navigation.md
+++ b/.claude/rules/navigation.md
@@ -109,6 +109,12 @@ action buttons to opt out of the Liquid Glass capsule that iOS 26
 auto-applies based on `ToolbarItemPlacement`. See
 `docs/design/design-system.md` § 5.8 for variant → token mapping.
 
+**Title display mode (`.large` / `.inline`)**: which pushed screen uses
+a large vs inline navigation title is a design-system convention, not a
+routing concern — see `docs/design/design-system.md`
+§ "Navigation title display mode". This rule governs only the back
+button / toolbar chrome.
+
 ## Sheets, popovers, fullScreenCover — out of scope
 
 `AppRouter` manages the **root NavigationStack only**. Sheet / popover /

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -417,6 +417,18 @@ ToolbarItem(placement: .primaryAction) {
 
 raw `.borderedProminent`（iOS 26 Liquid Glass capsule に opt-in する）は使わない。§5.8 の toolbar opt-out と同じ方針。fill↔token（`mossDark` / 白）は `PasturaPrimaryButtonStyleTests` で pin。
 
+### 5.11 Navigation title display mode（large / inline）
+
+root `NavigationStack` に push される画面の `.navigationBarTitleDisplayMode` 規約。判断軸は **タイトルが「主題の固有名」か「汎用ラベル」か** — 固有名は見出しとして読ませる価値があるので `.large`、汎用ラベルは画面の chrome なので縦スペースを割かない `.inline`。
+
+| バケット | モード | 画面 |
+|---------|-------|------|
+| ブラウズ / 一覧の根 | `.large` | Home / Shared Scenarios / Results |
+| 主題の固有名がタイトルの詳細 | `.large` | ScenarioDetail / GalleryScenarioDetail（シナリオ名） |
+| エディタ / フォーム / 汎用ラベルの詳細 | `.inline` | ScenarioEditor / Settings / ResultDetail |
+
+`.large` の多くは modifier 未指定（iOS デフォルトが large）に依存し、明示しているのは `ScenarioDetailView` のみ。新規詳細画面はこの「固有名 → large / 汎用ラベル → inline」基準で判断する。SimulationView は GameHeader（§2.12）がタイトル行を所有する例外で、空タイトル + `.inline`。表示モードは toolbar の可視性 / back button / Liquid Glass opt-out（§5.8・navigation.md）とは直交。
+
 ---
 
 ## 6. モーション / アニメーション


### PR DESCRIPTION
## Summary
Document which root-`NavigationStack`-pushed screens use `.large` vs `.inline` navigation title display mode — Theme E, carried over from #559. Decision: **ratify the current state** (Option A), zero code change.

The convention (new design-system §5.11):
- **`.large`** — browse/list roots (Home / Shared Scenarios / Results) and detail screens whose title is the subject's own proper name (ScenarioDetail / GalleryScenarioDetail show the scenario name).
- **`.inline`** — editors, forms, and generic-label-titled detail screens (ScenarioEditor / Settings / ResultDetail).
- **Exempt** — SimulationView (empty title; GameHeader owns the title row).

Rationale axis: a proper-name title reads as a heading (worth `.large`); a generic label reads as chrome (`.inline`). This makes the convention generative for future detail screens, not just descriptive of today's nine.

A named cross-reference from `.claude/rules/navigation.md` points back to §5.11 (by heading, not bare number) so the navigation rule and design system don't drift on nav-bar conventions. Display mode is orthogonal to the existing toolbar visibility / back button / Liquid Glass opt-out guidance.

## Test plan
- Doc-only; no code, no tests affected.
- Verified all nine per-screen `.large` / `.inline` claims against `grep` of `navigationBarTitleDisplayMode` / `navigationTitle` (code-reviewer confirmed: `ScenarioDetailView` is the only explicit `.large`).
- Verified the named cross-reference resolves to the §5.11 heading and the `---` divider integrity around the new section.

Closes #590