### PR TITLE
♻️ refactor: rename ReportScenarioSheet → ReportSheet + relocate

### DIFF
--- a/Pastura/Pastura/PasturaApp.swift
+++ b/Pastura/Pastura/PasturaApp.swift
@@ -297,7 +297,7 @@ private struct RootView: View {
         }
         .padding()
         .sheet(isPresented: $isRecoveryReportSheetPresented) {
-          ReportScenarioSheet(context: .migrationFailure(error: message))
+          ReportSheet(context: .migrationFailure(error: message))
             .deepLinkGated()
         }
 

--- a/Pastura/Pastura/PasturaApp.swift
+++ b/Pastura/Pastura/PasturaApp.swift
@@ -296,10 +296,9 @@ private struct RootView: View {
           .accessibilityIdentifier("recovery.reportButton")
         }
         .padding()
-        .sheet(isPresented: $isRecoveryReportSheetPresented) {
-          ReportSheet(context: .migrationFailure(error: message))
-            .deepLinkGated()
-        }
+        .reportSheet(
+          isPresented: $isRecoveryReportSheetPresented,
+          context: .migrationFailure(error: message))
 
       case .error(let message):
         VStack(spacing: 16) {

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -4165,7 +4165,7 @@
       }
     },
     "Send a content report" : {
-      "comment" : "Settings → Legal section row that opens ReportScenarioSheet with no specific scenario context.",
+      "comment" : "Settings → Legal section row that opens ReportSheet with no specific scenario context.",
       "localizations" : {
         "ja" : {
           "stringUnit" : {
@@ -4176,7 +4176,7 @@
       }
     },
     "Send report" : {
-      "comment" : "Navigation title for ReportScenarioSheet when invoked from Settings (no specific scenario context).",
+      "comment" : "Navigation title for ReportSheet when invoked from Settings (no specific scenario context).",
       "localizations" : {
         "ja" : {
           "stringUnit" : {

--- a/Pastura/Pastura/Utilities/ReportURLBuilder.swift
+++ b/Pastura/Pastura/Utilities/ReportURLBuilder.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Builds pre-filled URLs for Shared Scenario reports.
 ///
-/// Backs `ReportScenarioSheet`'s primary (Google Forms) and secondary
+/// Backs `ReportSheet`'s primary (Google Forms) and secondary
 /// (GitHub issue) surfaces. See `docs/gallery/shared-scenario-reports.md`
 /// for the form configuration and ADR-005 §6.6 for the record of the
 /// chosen mechanism.

--- a/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailView.swift
+++ b/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailView.swift
@@ -76,7 +76,7 @@ struct GalleryScenarioDetailView: View {
       .hidingPasturaSharedBackground()
     }
     .sheet(isPresented: $isReportSheetPresented) {
-      ReportScenarioSheet(context: .scenario(scenario))
+      ReportSheet(context: .scenario(scenario))
         .deepLinkGated()
     }
   }

--- a/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailView.swift
+++ b/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailView.swift
@@ -75,10 +75,7 @@ struct GalleryScenarioDetailView: View {
       }
       .hidingPasturaSharedBackground()
     }
-    .sheet(isPresented: $isReportSheetPresented) {
-      ReportSheet(context: .scenario(scenario))
-        .deepLinkGated()
-    }
+    .reportSheet(isPresented: $isReportSheetPresented, context: .scenario(scenario))
   }
 
   private var wasOpenedFromDeepLink: Bool {

--- a/Pastura/Pastura/Views/Report/ReportSheet.swift
+++ b/Pastura/Pastura/Views/Report/ReportSheet.swift
@@ -48,12 +48,7 @@ enum ReportContext {
 /// See ADR-005 §6 (and §6.7 for the dual-use precedent) for the
 /// policy rationale, and `docs/gallery/shared-scenario-reports.md`
 /// for operational details.
-///
-/// The type/file name still encodes scenario-specificity. Renaming
-/// to `ReportSheet` is deferred to a follow-up — now reinforced by the
-/// migration-failure consumer (#580), which is not a "shared scenario"
-/// concern — to keep this PR focused on the recovery-screen affordance.
-struct ReportScenarioSheet: View {
+struct ReportSheet: View {
   let context: ReportContext
 
   @Environment(\.openURL) private var openURL

--- a/Pastura/Pastura/Views/Report/ReportSheet.swift
+++ b/Pastura/Pastura/Views/Report/ReportSheet.swift
@@ -222,3 +222,23 @@ struct ReportSheet: View {
     (Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String) ?? ""
   }
 }
+
+extension View {
+  /// Presents a ``ReportSheet`` for the given ``ReportContext``, bound to
+  /// `isPresented`.
+  ///
+  /// Folds the three identical report-sheet call sites
+  /// (`GalleryScenarioDetailView`, `SettingsView`, `PasturaApp`'s DB-recovery
+  /// screen) into one presentation surface.
+  ///
+  /// `.deepLinkGated()` is applied **internally** — callers must NOT wrap
+  /// again. Gating is load-bearing here: a `pastura://` URL arriving while
+  /// the user is mid-report queues until the sheet dismisses, rather than
+  /// pushing a destination under it (see `navigation.md` QA scenario 9).
+  func reportSheet(isPresented: Binding<Bool>, context: ReportContext) -> some View {
+    sheet(isPresented: isPresented) {
+      ReportSheet(context: context)
+        .deepLinkGated()
+    }
+  }
+}

--- a/Pastura/Pastura/Views/Settings/SettingsView.swift
+++ b/Pastura/Pastura/Views/Settings/SettingsView.swift
@@ -28,18 +28,18 @@ import os
 ///
 /// Two rows: an external Privacy Policy link (opens Safari via
 /// `Environment(\.openURL)`) and a "Send a content report" Button
-/// that presents `ReportScenarioSheet(context: .general)` via
-/// `.sheet(isPresented:)`. The sheet carries `.deepLinkGated()` for
-/// symmetry with `GalleryScenarioDetailView`'s callsite — see
-/// navigation.md QA scenario 9. ADR-005 §6.6 substantive commitment
-/// ("Settings surface exposes report-mechanism copy per §6.4") is
-/// preserved by `ReportScenarioSheet`'s introCopy.
+/// that presents `ReportSheet(context: .general)` via the
+/// `.reportSheet(isPresented:context:)` helper (which applies
+/// `.deepLinkGated()` internally — see navigation.md QA scenario 9).
+/// ADR-005 §6.6 substantive commitment ("Settings surface exposes
+/// report-mechanism copy per §6.4") is preserved by `ReportSheet`'s
+/// introCopy.
 struct SettingsView: View {
   @Environment(\.openURL) private var openURL
 
-  /// Bound to `.sheet(isPresented:)` for the "Send a content report"
-  /// row inside the Legal section. The sheet reuses
-  /// `ReportScenarioSheet` with `context: .general` (Settings has no
+  /// Bound to `.reportSheet(isPresented:context:)` for the "Send a
+  /// content report" row inside the Legal section. The sheet reuses
+  /// `ReportSheet` with `context: .general` (Settings has no
   /// specific scenario context) — see ADR-005 §6.7 dual-use precedent.
   @State private var isReportSheetPresented: Bool = false
 

--- a/Pastura/Pastura/Views/Settings/SettingsView.swift
+++ b/Pastura/Pastura/Views/Settings/SettingsView.swift
@@ -166,15 +166,7 @@ struct SettingsView: View {
       }
       .hidingPasturaSharedBackground()
     }
-    // `.deepLinkGated()` mirrors the existing report sheet at
-    // GalleryScenarioDetailView's call site — a `pastura://` URL
-    // arriving while the user is mid-report queues until the sheet
-    // dismisses, rather than pushing a gallery detail under it (see
-    // navigation.md QA scenario 9).
-    .sheet(isPresented: $isReportSheetPresented) {
-      ReportSheet(context: .general)
-        .deepLinkGated()
-    }
+    .reportSheet(isPresented: $isReportSheetPresented, context: .general)
     .sheet(isPresented: $isLicensesSheetPresented) {
       LicensesSheet()
         .deepLinkGated()

--- a/Pastura/Pastura/Views/Settings/SettingsView.swift
+++ b/Pastura/Pastura/Views/Settings/SettingsView.swift
@@ -172,7 +172,7 @@ struct SettingsView: View {
     // dismisses, rather than pushing a gallery detail under it (see
     // navigation.md QA scenario 9).
     .sheet(isPresented: $isReportSheetPresented) {
-      ReportScenarioSheet(context: .general)
+      ReportSheet(context: .general)
         .deepLinkGated()
     }
     .sheet(isPresented: $isLicensesSheetPresented) {

--- a/docs/decisions/ADR-005.md
+++ b/docs/decisions/ADR-005.md
@@ -824,7 +824,7 @@ requirement becomes live and a new ADR revisits the reporting surface.
 
 The chosen concrete mechanism (tracked in issue #178):
 
-- **In-app sheet**: `ReportScenarioSheet` with progressive disclosure
+- **In-app sheet**: `ReportSheet` with progressive disclosure
   — primary **Open Report Form** button opens a pre-filled Google
   Forms URL in Safari; secondary **Open on GitHub** link opens a
   pre-seeded issue URL for users who prefer public discussion.
@@ -882,7 +882,7 @@ other is not automatically implicated.
 
 The in-app DB migration-failure report path (#580) extends this §1.5
 general-contact framing — **not** the §1.2 UGC channel. The recovery
-screen reuses `ReportScenarioSheet` to attach the SQLite migration
+screen reuses `ReportSheet` to attach the SQLite migration
 error to a bug report; it pre-fills the form's existing Reason field
 (no new field) and, on the public path, a **dedicated**
 `db-migration-failure.yml` template labelled `bug` (kept out of the §6

--- a/docs/gallery/shared-scenario-reports.md
+++ b/docs/gallery/shared-scenario-reports.md
@@ -9,7 +9,7 @@ does not state any specific response-time number — this is intentional
 
 ## 1. Reporting channel configuration
 
-Two surfaces are exposed to users from `ReportScenarioSheet`:
+Two surfaces are exposed to users from `ReportSheet`:
 
 1. **Primary — Google Forms.** Private report destination.
 2. **Secondary — GitHub issue.** Public discussion path (opt-in).
@@ -66,7 +66,7 @@ the public tracker free of PII.
 ### 1.3 Database migration-failure report path
 
 The in-app "Database Needs Recovery" screen (`PasturaApp`
-`.databaseRecovery`, #580) reuses `ReportScenarioSheet` in
+`.databaseRecovery`, #580) reuses `ReportSheet` in
 `migrationFailure` mode to capture a bug report **before** the user
 resets and the failing DB is moved aside. The exact SQLite migration
 error is auto-attached to both surfaces.
@@ -224,4 +224,4 @@ bound.
 - [`docs/gallery/README.md`](README.md) — Gallery curation + trust model
 - [`.github/ISSUE_TEMPLATE/shared-scenario-report.yml`](../../.github/ISSUE_TEMPLATE/shared-scenario-report.yml)
 - [`Pastura/Pastura/Utilities/ReportURLBuilder.swift`](../../Pastura/Pastura/Utilities/ReportURLBuilder.swift)
-- [`Pastura/Pastura/Views/Community/SharedScenarios/ReportScenarioSheet.swift`](../../Pastura/Pastura/Views/Community/SharedScenarios/ReportScenarioSheet.swift)
+- [`Pastura/Pastura/Views/Report/ReportSheet.swift`](../../Pastura/Pastura/Views/Report/ReportSheet.swift)


### PR DESCRIPTION
## Summary
Pure internal-quality refactor (zero user-facing change). Closes #594.

- **Rename + relocate**: `ReportScenarioSheet` → `ReportSheet`, moved out of `Views/Community/SharedScenarios/` to `Views/Report/`. The type gained a 3-way `ReportContext` in #585 — one consumer is the App-lifecycle DB-recovery screen — so the old `...Scenario...` name + `SharedScenarios/` location actively misled. `ReportContext` moves with the file (zero external refs). Sync-folder groups → no pbxproj edit.
- **Helper extraction** (PR #585 code-review Suggestion 2): folded the 3 identical call sites into `.reportSheet(isPresented:context:)`, which applies the load-bearing `.deepLinkGated()` gate internally so it can't be forgotten. Gate behavior verified preserved at all 3 sites, incl. the DB-recovery site (gate injected at RootView body root, above this scope).
- **Reference sweep**: ADR-005 §6.6/§6.7, shared-scenario-reports.md (incl. file-path link), ReportURLBuilder header, SettingsView doc-comments, 2 xcstrings translator comments. `git grep ReportScenarioSheet` → 0 hits.

## Out of scope (future follow-up)
- `docs/gallery/shared-scenario-reports.md` is gallery-scoped but now also documents the non-gallery (migration-failure / general) contexts — renaming that doc is a separate concern (code-review Suggestion 2).

## Test plan
- 1857 unit tests pass; swiftlint --strict clean; build succeeds.
- Pure rename + call-site fold, no logic change (ADR-009 → no new tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)