### PR TITLE
📝 docs: consolidate DatabasePool-migration gate into ADR-015 + code seam

### DIFF
--- a/Pastura/Pastura/Data/DatabaseManager.swift
+++ b/Pastura/Pastura/Data/DatabaseManager.swift
@@ -13,6 +13,29 @@ nonisolated public final class DatabaseManager: Sendable {
   /// The underlying database writer. Exposed as `any DatabaseWriter`
   /// so switching from `DatabaseQueue` to `DatabasePool` later requires
   /// only changing the factory method.
+  ///
+  /// The *factory swap* is one line, but the *migration* is not — a
+  /// `DatabasePool` opens the database in WAL journal mode (vs. the current
+  /// `DatabaseQueue` rollback-journal default — see `recreateByBackingUp`
+  /// for the no-sidecar consequence of that default). Enabling WAL pulls in
+  /// two distinct concerns, only one of which is migration-gated:
+  ///
+  /// 1. **WAL sidecar backup** *(migration-gated)*: WAL adds persistent
+  ///    `-wal` / `-shm` files. Exclude those from iCloud backup while
+  ///    keeping `pastura.sqlite` itself backed up (ADR-015 D2 / §4). No
+  ///    sidecars exist today, so there is nothing to do until WAL is on.
+  /// 2. **File-protection / suspension** *(not WAL-specific — a baseline
+  ///    posture)*: a DB access that holds a lock while the device is locked
+  ///    in the background can hit `SQLITE_IOERR` / `0xdead10cc`. This is a
+  ///    background-execution (ADR-003) interaction, not a WAL one, so it
+  ///    already applies to today's `DatabaseQueue`. It is currently a
+  ///    **non-issue**: the store lives in app-private Application Support
+  ///    (no shared-container — the usual `0xdead10cc` trigger) under the
+  ///    default `CompleteUntilFirstUserAuthentication` protection (readable
+  ///    after first unlock, even while subsequently locked). A WAL
+  ///    migration would *sharpen* it (locks/`-shm` mmap held longer), so
+  ///    re-validate GRDB's `observesSuspensionNotifications` posture **at**
+  ///    that migration — it is not a reason to act now.
   public let dbWriter: any DatabaseWriter
 
   /// Creates a `DatabaseManager` with the given writer and applies migrations.

--- a/docs/decisions/ADR-015.md
+++ b/docs/decisions/ADR-015.md
@@ -148,9 +148,26 @@ To be filed as separate issues after this ADR lands:
    semantics, plus a post-purge `VACUUM`.
 2. **Advisory growth cap** — a non-silent prompt when run count / DB size
    crosses a generous threshold; this issue picks the literal number.
-3. **(Conditional) WAL-sidecar backup handling** — only if/when the writer
-   migrates from `DatabaseQueue` to `DatabasePool` (WAL mode). Gated on
-   that migration; no action while on `DatabaseQueue`.
+3. **(Conditional) `DatabasePool` / WAL migration handling** — only if/when
+   the writer migrates from `DatabaseQueue` to `DatabasePool` (which opens
+   the DB in WAL mode). Two distinct concerns at that point, only one truly
+   migration-gated:
+   - **WAL-sidecar backup** *(migration-gated)* — WAL adds persistent
+     `-wal` / `-shm` files; exclude them from backup while keeping
+     `pastura.sqlite` backed up (D2). No action while on `DatabaseQueue`
+     (rollback-journal → no sidecars).
+   - **File-protection / suspension** *(baseline, not WAL-specific)* — a DB
+     lock held while the device is locked in the background risks
+     `SQLITE_IOERR` / `0xdead10cc`. This is a background-execution
+     ([ADR-003](ADR-003.md)) interaction that already applies to today's
+     `DatabaseQueue`, currently a **non-issue** (app-private store in
+     Application Support — no shared container; default
+     `CompleteUntilFirstUserAuthentication` protection). A WAL migration
+     *sharpens* it, so re-validate GRDB's `observesSuspensionNotifications`
+     posture at migration time — it is not a present-tense action.
+
+   The seam is the `DatabaseManager` writer factory; that property's
+   doc-comment carries this gate for the implementer who makes the swap.
 
 ## 5. Alternatives considered
 


### PR DESCRIPTION
## Summary
Retires the conditional-no-action issue #566 by relocating + enriching its
knowledge into two durable, repo-tracked homes — the seam where a future
`DatabaseQueue`/`DatabasePool` migration is actually made.

- **`DatabaseManager.dbWriter` doc comment**: spells out that the
  `DatabasePool` swap is one factory line but the *migration* is not
- **ADR-015 §4 follow-up #3**: expanded from "WAL-sidecar backup only"

Correctly splits two concerns #566 conflated:
- **WAL sidecar (`-wal`/`-shm`) backup** — genuinely WAL/migration-gated
- **File-protection / `0xdead10cc` / `SQLITE_IOERR`** — a *baseline*
  background-execution (ADR-003) matter, **currently a non-issue**
  (app-private store in Application Support, no shared container; default
  `CompleteUntilFirstUserAuthentication` protection) that a WAL migration
  only *sharpens* — not a present-tense action

Cross-references the existing rollback-journal note rather than restating it.

## Why
Keeps an open issue from lingering as permanent noise while preserving
(and correcting) the knowledge where the next implementer will see it.

## Test plan
- docs/comment-only — no behavior change
- `swiftlint --strict` clean · `xcodebuild build` SUCCEEDED
- Fact-claims verified (Opus code-review PASS): ADR-003 target, DB path,
  default file protection, rollback-journal cross-ref

Closes #566

🤖 Generated with [Claude Code](https://claude.com/claude-code)
