### PR TITLE
📝 docs: broaden report-mechanism doc scope to 3 ReportSheet contexts

### DIFF
--- a/Pastura/Pastura/Utilities/ReportURLBuilder.swift
+++ b/Pastura/Pastura/Utilities/ReportURLBuilder.swift
@@ -1,6 +1,9 @@
 import Foundation
 
-/// Builds pre-filled URLs for Shared Scenario reports.
+/// Builds pre-filled report-channel URLs for ``ReportSheet``'s three
+/// contexts: Shared Scenario reports, the DB migration-failure path, and
+/// general contact. (These stay distinct per ADR-005 §6.7 — the
+/// migration-failure path is §1.5 bug intake, not a §1.2 UGC report.)
 ///
 /// Backs `ReportSheet`'s primary (Google Forms) and secondary
 /// (GitHub issue) surfaces. See `docs/gallery/shared-scenario-reports.md`

--- a/docs/gallery/shared-scenario-reports.md
+++ b/docs/gallery/shared-scenario-reports.md
@@ -1,7 +1,11 @@
 # Shared Scenario Report Handling
 
-Operational procedure for Shared Scenario reports, per
-[ADR-005 §6](../decisions/ADR-005.md).
+Operational procedure for the in-app report mechanism (`ReportSheet`),
+covering all three report contexts it serves: Shared Scenario reports
+(§1.1–§1.2), the general-contact co-tenancy on the same Google Form
+(§1.1), and the DB migration-failure path (§1.3) — per
+[ADR-005 §6](../decisions/ADR-005.md) (see §6.7 for the UGC-vs-general-contact
+framing these contexts deliberately keep distinct).
 
 This document is **maintainer-facing**. User-visible copy in the app
 does not state any specific response-time number — this is intentional


### PR DESCRIPTION
## Summary
Follow-up to PR #595 (code-review Suggestion 2). After the `ReportScenarioSheet` to `ReportSheet` rename, the report-mechanism docs read narrower than reality — `ReportSheet` serves 3 contexts (Shared Scenario / DB migration-failure / general), not just gallery reports. Closes #598.

- `docs/gallery/shared-scenario-reports.md`: broadened the **existing intro sentence** to enumerate all 3 contexts via doc-local section anchors. H1 and filename kept (8 inbound refs, anchor stability).
- `Pastura/Pastura/Utilities/ReportURLBuilder.swift`: broadened the leading doc-comment to name the 3 contexts **mechanism-neutrally** (no "content reports" umbrella).

Wording deliberately preserves the Apple App Review Guideline UGC vs general-contact split that ADR-005 §6.7 protects (migration-failure is general-contact bug intake, not a UGC report).

## Decision: keep filename (no rename)
The doc is still gallery-primary (migration-failure is a §1.3 sub-section); a rename would churn 8 inbound refs for no scope gain. Reviewer Suggestion 2's lighter option (a scope note) was taken — implemented as an intro-sentence broadening rather than a standalone note so it lands where readers hit it.

## Test plan
- Doc / doc-comment only, zero logic change. Build succeeds; swiftlint --strict clean.
- All cited anchors (doc §1.1 to §1.3, ADR-005 §6/§6.7) independently verified to exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
