### PR TITLE
📝 docs: reflect shipped status of ADR-015 §4 follow-ups

### DIFF
--- a/docs/decisions/ADR-015.md
+++ b/docs/decisions/ADR-015.md
@@ -141,14 +141,21 @@ is told growth is large and offered the existing delete tools, and decides.
 
 ## 4. Follow-up implementation issues (out of scope here)
 
-To be filed as separate issues after this ADR lands:
+These were filed as separate issues after this ADR landed — current status
+(the decision text in §1–§3 is unchanged; this is a status annotation):
 
 1. **Clear-all / bulk purge UI** — a Settings-level "delete all runs"
    affordance (with confirmation), reusing `SimulationRepository.delete`
-   semantics, plus a post-purge `VACUUM`.
+   semantics, plus a post-purge `VACUUM`. ✅ **Shipped** — issue #545 / PR #572.
 2. **Advisory growth cap** — a non-silent prompt when run count / DB size
-   crosses a generous threshold; this issue picks the literal number.
-3. **(Conditional) `DatabasePool` / WAL migration handling** — only if/when
+   crosses a generous threshold. ✅ **Shipped** — issue #565 / PR #589: the
+   implementation chose a **250 MB**, **size-only** advisory (run count is
+   not a trigger) surfaced in Settings → Past Results (an always-on storage
+   caption plus a non-deleting over-cap warning that routes to the clear-all
+   affordance above). The
+   literal threshold remains a tunable per D1, not pinned by this ADR.
+3. **(Conditional) `DatabasePool` / WAL migration handling** — ⏳ pending,
+   conditional (no present-tense action). Only if/when
    the writer migrates from `DatabaseQueue` to `DatabasePool` (which opens
    the DB in WAL mode). Two distinct concerns at that point, only one truly
    migration-gated:
@@ -168,6 +175,9 @@ To be filed as separate issues after this ADR lands:
 
    The seam is the `DatabaseManager` writer factory; that property's
    doc-comment carries this gate for the implementer who makes the swap.
+   The standalone tracking issue was retired (closed via PR #596) once this
+   gate lived here in the ADR plus the `DatabaseManager` doc-comment, rather
+   than as a permanently-blocked open issue.
 
 ## 5. Alternatives considered
 


### PR DESCRIPTION
## Summary
Status-annotation update to ADR-015 §4 (follow-up implementation list).
Two of the three follow-ups have shipped since the ADR landed; the list
still read as if none had.

- **#1 Clear-all / bulk purge UI** → ✅ Shipped (issue #545 / PR #572)
- **#2 Advisory growth cap** → ✅ Shipped (issue #565 / PR #589). Restates
  "this issue picks the literal number" as what landed: a 250 MB, size-only
  advisory in Settings → Past Results — framed as the implementation's
  chosen value, still a D1 tunable (not ADR-pinned)
- **#3 DatabasePool/WAL** → pending/conditional; notes its tracking issue
  retired (#596)

Framed as a status annotation over §4 only — the §1–§3 decision text
(D3 "No code ships in this ADR", D1.2 "threshold not pinned here") is
date-anchored and left untouched.

## Test plan
- docs-only — no behavior change
- All cited issue/PR numbers verified via gh (correct mappings, no transpositions)
- Opus code-review PASS; internal consistency with D1.2 / §3 / D3 confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
