### PR TITLE
🐛 fix: remove choose-phase GBNF value enumeration (#599)

### DIFF
--- a/Pastura/Pastura/Engine/LLMCaller.swift
+++ b/Pastura/Pastura/Engine/LLMCaller.swift
@@ -290,11 +290,13 @@ nonisolated struct LLMCaller: Sendable {
     return detected == expected ? nil : detected
   }
 
-  /// Collect natural-language values from `output`, filtering out
-  /// schema fields whose `kind == .enumeration(...)` (author-supplied
-  /// tokens like `cooperate` / `betray` in a `choose` phase — their
-  /// language is fixed by the scenario author, not by the LLM, so they
-  /// would skew the detector's verdict).
+  /// Collect natural-language values from `output`, keeping only fields
+  /// whose `kind == .string`. Author-defined choice tokens
+  /// (`kind == .choice`, e.g. `cooperate` / `betray` in a `choose`
+  /// phase) are excluded — their language is fixed by the scenario
+  /// author, not the LLM, so they would skew the detector's verdict
+  /// (ADR-010 Step E, #405). The `.string`-only whitelist excludes
+  /// `.choice` by construction.
   ///
   /// When `schema` is nil the caller hasn't opted into constrained
   /// decoding; we treat every field as natural language (conservative

--- a/Pastura/Pastura/Engine/Phases/ChooseHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/ChooseHandler.swift
@@ -4,7 +4,14 @@ import Foundation
 ///
 /// Supports two modes: round-robin pairing (adjacent pairs, each agent calls LLM
 /// with opponent context) or individual choice (each agent chooses independently).
-/// Invalid actions fall back to `options[0]`.
+/// Invalid actions fall back to `options[0]` via `validateAction`.
+///
+/// `validateAction` is the **sole** value constraint: the `action` field is a
+/// `.choice` in the grammar (structure-only — no value enumeration; see
+/// ``OutputSchema/Kind/choice`` and ADR-002 §Amendment 2026-06-14, #599), so
+/// the runtime check is what keeps the result within the option set. The model
+/// is steered toward valid options by ``PromptBuilder``, which lists them in
+/// the prompt, so the fallback is rare in practice.
 nonisolated struct ChooseHandler: PhaseHandler {
   private let promptBuilder = PromptBuilder()
   private let llmCaller = LLMCaller()

--- a/Pastura/Pastura/LLM/GBNFGrammarBuilder.swift
+++ b/Pastura/Pastura/LLM/GBNFGrammarBuilder.swift
@@ -9,14 +9,13 @@ import Foundation
 /// byte sequence via `[^"\\]` — Japanese / emoji pass through without a
 /// separate code-point class.
 ///
-/// Enumeration fields (currently only `choose.action` with non-empty
-/// options) get a per-field rule named `<fieldname>-value` (any `_` in
-/// the field name is mapped to `-` because llama.cpp's GBNF
-/// `is_word_char` rejects underscores in rule identifiers — see
-/// `llama-grammar.cpp:98` of b8694, and ADR-002 §12.8). The options
-/// are emitted as alternation literals; this is strictly stronger
-/// than the runtime `validateAction` fallback because the model cannot
-/// produce an out-of-set value in the first place.
+/// Every field's value position uses the shared `string` production —
+/// the grammar constrains JSON **structure** (object shape, keys, commas)
+/// but never enumerates values. Author-defined choice options
+/// (`choose.action`) were once emitted as alternation literals, but that
+/// crashed llama.cpp's sampler on CJK / dynamic values; value constraint
+/// now lives at runtime (``ChooseHandler`` `validateAction`). See
+/// ``OutputSchema/Kind/choice`` and ADR-002 §12.8 for the history.
 ///
 /// Pure transformation — no I/O, no state. Output is stable and testable
 /// byte-for-byte against golden files for each preset (see
@@ -31,30 +30,19 @@ nonisolated public struct GBNFGrammarBuilder: Sendable {
   /// ``LLMError/invalidGrammar`` (Item 4) so the retry budget is
   /// preserved.
   nonisolated public enum BuilderError: Error, Equatable, Sendable {
-    /// `.enumeration([])` — a choose-phase options list was empty or
-    /// missing; grammar would have zero alternatives, which llama.cpp
-    /// rejects.
-    case emptyEnumeration(field: String)
     /// Two ``OutputSchema/Field`` entries share the same name.
     case duplicateFieldName(String)
     /// Field name does not match Pastura's preset-input shape
     /// (Unicode-aware): first char must be a letter
     /// (`Character.isLetter` — accepts ASCII + Japanese + other
     /// scripts), and subsequent chars must be letter / digit / `_`.
-    /// Leading `_` and `-` are intentionally rejected to keep
-    /// sanitized rule identifiers (`<name>-value`) from starting
-    /// with `-` (see Shared Scenarios concern in ADR-002 §12.8). The
-    /// actual GBNF rule-name shape (`[a-zA-Z0-9-]` per
-    /// `llama-grammar.cpp:98`) is enforced separately at emit time
-    /// via `sanitizeRuleName(_:)` — input validation gates Pastura
-    /// hygiene, sanitization handles the GBNF mapping.
+    /// Field names are emitted as JSON-key literals (`"\"name\""`) in
+    /// the grammar; rejecting hostile chars here keeps the literal
+    /// well-formed. Leading `_` / `-` stay rejected as a conservative
+    /// Pastura-hygiene rule — see ADR-002 §12.8 for the original
+    /// rule-identifier rationale (now historical, since per-field
+    /// `<name>-value` rules no longer exist).
     case invalidFieldName(String)
-    /// An enumeration option contains a character that would need
-    /// escaping in the GBNF literal form (`"`, `\`, or a control
-    /// byte). Shared Scenarios entries can inject arbitrary `options`
-    /// strings, so we validate up-front and throw a clear error
-    /// rather than emit malformed grammar the sampler would reject.
-    case invalidEnumerationOption(field: String, option: String)
   }
 
   /// Build the complete grammar for ``OutputSchema``.
@@ -66,11 +54,6 @@ nonisolated public struct GBNFGrammarBuilder: Sendable {
 
     var rules: [String] = []
     rules.append(rootRule(for: schema))
-    for field in schema.fields {
-      if case .enumeration(let options) = field.kind {
-        rules.append(enumerationRule(name: field.name, options: options))
-      }
-    }
     rules.append(Self.sharedStringProduction)
     rules.append(Self.sharedWhitespaceProduction)
     rules.append(Self.sharedTrailingProduction)
@@ -119,40 +102,13 @@ nonisolated public struct GBNFGrammarBuilder: Sendable {
   }
 
   private func valueRuleName(for field: OutputSchema.Field) -> String {
+    // Both kinds use the shared `string` production — the grammar
+    // constrains structure, not values (see type doc and
+    // ``OutputSchema/Kind/choice``).
     switch field.kind {
-    case .string:
+    case .string, .choice:
       return "string"
-    case .enumeration:
-      return "\(sanitizeRuleName(field.name))-value"
     }
-  }
-
-  private func enumerationRule(name: String, options: [String]) -> String {
-    let alternatives =
-      options
-      .map { #""\""# + $0 + #"\"""# }
-      .joined(separator: " | ")
-    return "\(sanitizeRuleName(name))-value ::= \(alternatives)"
-  }
-
-  /// Map a Pastura field name to a llama.cpp-acceptable GBNF rule
-  /// identifier. The parser's `is_word_char` (`llama-grammar.cpp:98`
-  /// of b8694) accepts only `[a-zA-Z0-9-]` — underscores are NOT
-  /// valid in rule names, even though Pastura's preset YAML uses
-  /// snake_case for field names. We translate `_` → `-` here so
-  /// `inner_thought` (input) emits as `inner-thought-value` (rule
-  /// reference).
-  ///
-  /// Other invalid chars (leading non-letter, `.`, spaces, control
-  /// bytes) are caught upstream by `validateFieldName`, which is
-  /// Unicode-aware (`Character.isLetter` accepts Japanese / other
-  /// scripts). A non-ASCII letter that passes Pastura validation
-  /// would still fail llama.cpp's ASCII-only `is_word_char` at emit
-  /// time — the stderr-capture diagnostic in `+Sampler.swift` would
-  /// surface that mismatch within one device run if a future preset
-  /// hits it. See ADR-002 §12.8 for the discovery story.
-  private func sanitizeRuleName(_ name: String) -> String {
-    name.replacingOccurrences(of: "_", with: "-")
   }
 
   // MARK: - Validation
@@ -165,42 +121,17 @@ nonisolated public struct GBNFGrammarBuilder: Sendable {
         throw BuilderError.duplicateFieldName(field.name)
       }
       seen.insert(field.name)
-      if case .enumeration(let options) = field.kind {
-        guard !options.isEmpty else {
-          throw BuilderError.emptyEnumeration(field: field.name)
-        }
-        for option in options {
-          try validateEnumerationOption(option, field: field.name)
-        }
-      }
-    }
-  }
-
-  private func validateEnumerationOption(_ option: String, field: String) throws {
-    // Reject characters that would need GBNF escaping in the `"\"opt\""`
-    // literal form. Pastura's YAML presets contain only identifier-like
-    // options (`cooperate`, `betray`), but Shared Scenarios entries can
-    // inject arbitrary strings — guard at builder time so the failure
-    // mode is a clear `BuilderError`, not a NULL-return from
-    // `llama_sampler_init_grammar` via `LLMError.invalidGrammar`.
-    for char in option {
-      if char == "\"" || char == "\\" || char.isNewline
-        || char.asciiValue.map({ $0 < 0x20 }) == true {
-        throw BuilderError.invalidEnumerationOption(field: field, option: option)
-      }
     }
   }
 
   private func validateFieldName(_ name: String) throws {
-    // First char must be a letter — leading `_` (or `-`) was previously
-    // tolerated for Pastura's snake_case convention but Shared Scenarios
-    // scenarios can ship arbitrary YAML, and a leading-`_` field name
-    // would sanitize to a leading-`-` rule identifier (`-thing-value`).
-    // b8694's parser accepts that, but it is unconventional and a
-    // future llama.cpp tightening could reject it. Reject at the
-    // Pastura boundary so failures surface as a clear `BuilderError`,
-    // not a llama.cpp `failed to parse grammar` from sampler init.
-    // See ADR-002 §12.8.
+    // Field names are emitted as JSON-key literals (`"\"name\""`) in the
+    // grammar. Reject names whose chars would break that literal or that
+    // Shared Scenarios YAML could inject. The leading-letter + body
+    // letter/digit/`_` rule is a conservative Pastura-hygiene boundary
+    // (it originally also guarded the now-removed `<name>-value` rule
+    // identifier — see ADR-002 §12.8, historical). A clear `BuilderError`
+    // here beats a llama.cpp `failed to parse grammar` at sampler init.
     guard let first = name.first, first.isLetter else {
       throw BuilderError.invalidFieldName(name)
     }

--- a/Pastura/Pastura/LLM/LLMError.swift
+++ b/Pastura/Pastura/LLM/LLMError.swift
@@ -32,8 +32,8 @@ nonisolated public enum LLMError: Error, Sendable, Equatable {
 
   /// The ``GBNFGrammarBuilder`` produced a grammar string that the
   /// backend's grammar parser rejected, or the builder itself threw a
-  /// validation error (empty enumeration / duplicate field / invalid
-  /// rule name). This is a caller-side / engineering bug, not a runtime
+  /// validation error (duplicate field / invalid field name). This is a
+  /// caller-side / engineering bug, not a runtime
   /// LLM failure — `LLMCaller` treats it as fail-fast and **does not
   /// consume retry budget**, so a deterministic builder defect surfaces
   /// as a single clear error instead of 3× flaky-inference retries

--- a/Pastura/Pastura/Models/OutputSchema.swift
+++ b/Pastura/Pastura/Models/OutputSchema.swift
@@ -16,7 +16,7 @@ import Foundation
 /// stream. See ADR-002 §12 and the PR #194 plan for the critic-driven
 /// rationale.
 ///
-/// Vocabulary is intentionally minimal (``Kind/string`` + ``Kind/enumeration(_:)``)
+/// Vocabulary is intentionally minimal (``Kind/string`` + ``Kind/choice``)
 /// — matches Pastura's actual scenario shape. Future backends needing
 /// richer JSON Schema features (integers, booleans, regex formats) should
 /// add an adapter, not extend this enum.
@@ -59,17 +59,19 @@ nonisolated public struct OutputSchema: Codable, Sendable, Equatable {
   ///   constrained decoding" and skip grammar injection.
   ///
   /// For `.choose` phases with non-empty `options`, the `action` field
-  /// (if present in the schema) becomes ``Kind/enumeration(_:)``
-  /// carrying those options — stronger than the runtime
-  /// `validateAction` fallback.
+  /// (if present in the schema) becomes ``Kind/choice`` — a marker that
+  /// the field carries an author-defined choice token. The value is NOT
+  /// grammar-constrained (see ``Kind/choice`` for the model-agnostic
+  /// safety rationale, #599); the runtime ``ChooseHandler`` `validateAction`
+  /// fallback constrains it instead.
   public static func from(phase: Phase) -> OutputSchema? {
     guard let raw = phase.outputSchema, !raw.isEmpty else { return nil }
     let orderedNames = orderKeys(Array(raw.keys))
     let isChooseWithOptions =
       phase.type == .choose && !(phase.options ?? []).isEmpty
     let fields = orderedNames.map { name -> Field in
-      if isChooseWithOptions, name == "action", let options = phase.options {
-        return Field(name: name, kind: .enumeration(options))
+      if isChooseWithOptions, name == "action" {
+        return Field(name: name, kind: .choice)
       }
       return Field(name: name, kind: .string)
     }
@@ -108,15 +110,31 @@ nonisolated public struct OutputSchema: Codable, Sendable, Equatable {
 
   /// The kind of value a ``Field`` accepts.
   ///
-  /// Intentionally narrow — Pastura's presets only ever express "a
-  /// string" or "one of these literal string options". Future scenario
-  /// shapes should prefer an adapter to JSON Schema over extending this
-  /// enum.
+  /// Intentionally narrow — Pastura's presets only ever express "a free
+  /// string" or "an author-defined choice token". Future scenario shapes
+  /// should prefer an adapter to JSON Schema over extending this enum.
   nonisolated public enum Kind: Codable, Sendable, Equatable {
     /// Any string value (UTF-8, including CJK / emoji).
     case string
-    /// One of a fixed set of string literals — used for
-    /// ``Phase/options`` on `.choose` phases.
-    case enumeration([String])
+    /// An author-defined choice field (the `action` of a `.choose`
+    /// phase with non-empty ``Phase/options``).
+    ///
+    /// Carries **no** option payload by design. The choice options were
+    /// once enumerated directly into the GBNF grammar as alternation
+    /// literals, but that crashed llama.cpp's sampler on CJK / dynamic
+    /// option values — the crash is token-dependent, so a char-class
+    /// guard cannot make it safe across models (#597 vote precedent,
+    /// #599). The grammar now constrains JSON **structure** only; this
+    /// case is grammar-equivalent to ``string`` (emits the shared
+    /// `string` production). The value is constrained at runtime by
+    /// ``ChooseHandler`` `validateAction` (invalid → `options[0]`), and
+    /// the model still learns the valid options from the prompt
+    /// (``PromptBuilder``).
+    ///
+    /// The marker is retained (rather than collapsing to ``string``) so
+    /// the language-adherence detector can exclude author-fixed tokens
+    /// like `cooperate` / `betray` from its verdict — see
+    /// `LLMCaller.naturalLanguageFieldValues` (ADR-010 Step E, #405).
+    case choice
   }
 }

--- a/Pastura/Pastura/Models/ScenarioConventions.swift
+++ b/Pastura/Pastura/Models/ScenarioConventions.swift
@@ -13,9 +13,11 @@ import Foundation
 ///
 /// Speak phases route the canonical field's value into the conversation log
 /// (read by ``PromptBuilder``) and into the agent's primary display text
-/// (rendered by ``AgentOutputRow``). Choose binds the canonical field to a
-/// GBNF enum constraint (see ``OutputSchema/from(phase:)``) and reads it back
-/// directly in ``ChooseHandler``. Vote is similarly read directly by
+/// (rendered by ``AgentOutputRow``). Choose reads the canonical field back
+/// directly in ``ChooseHandler``, which validates it against the phase
+/// options at runtime (the value is not grammar-constrained — see
+/// ``OutputSchema/from(phase:)`` and ADR-002 §Amendment 2026-06-14). Vote
+/// is similarly read directly by
 /// ``VoteHandler`` and surfaces composite formatting via
 /// ``TurnOutput/primaryText(for:)``.
 ///

--- a/Pastura/Pastura/Models/TurnOutput.swift
+++ b/Pastura/Pastura/Models/TurnOutput.swift
@@ -57,8 +57,10 @@ nonisolated public struct TurnOutput: Codable, Sendable, Equatable {
   public var vote: String? { fields["vote"] }
 
   /// Agent's chosen action (canonical primary field for `.choose` phases —
-  /// e.g., "cooperate" or "betray"). `OutputSchema.from(phase:)` binds this
-  /// field to a GBNF enum constraint when the phase has non-empty `options`.
+  /// e.g., "cooperate" or "betray"). `OutputSchema.from(phase:)` marks this
+  /// field `.choice` when the phase has non-empty `options`; the value is
+  /// validated at runtime by `ChooseHandler` (invalid → `options[0]`), not
+  /// grammar-constrained (#599).
   public var action: String? { fields["action"] }
 
   /// Agent's private inner thought (hidden by default in UI, revealed on tap).

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -4738,18 +4738,18 @@
         }
       }
     },
-    "Use `action` for the chosen value. The options enum constraint binds to this field." : {
+    "Use `action` for the chosen value. It is restricted to the phase options." : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Use `action` for the chosen value. The options enum constraint binds to this field."
+            "value" : "Use `action` for the chosen value. It is restricted to the phase options."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "選択結果は `action` フィールドで追加してください。options の列挙制約はこのフィールドに紐づきます。"
+            "value" : "選択結果は `action` フィールドで追加してください。値はこの phase の options に制限されます。"
           }
         }
       }

--- a/Pastura/Pastura/Views/Editor/PhaseEditorSheet+CanonicalFieldHint.swift
+++ b/Pastura/Pastura/Views/Editor/PhaseEditorSheet+CanonicalFieldHint.swift
@@ -57,7 +57,7 @@ extension PhaseEditorSheet {
     case .choose:
       return String(
         localized:
-          "Use `action` for the chosen value. The options enum constraint binds to this field."
+          "Use `action` for the chosen value. It is restricted to the phase options."
       )
     case .vote:
       return String(localized: "Use `vote` for the target name.")

--- a/Pastura/PasturaTests/Engine/LLMCallerLanguageAdherenceTests.swift
+++ b/Pastura/PasturaTests/Engine/LLMCallerLanguageAdherenceTests.swift
@@ -251,7 +251,7 @@ struct LLMCallerLanguageAdherenceTests {
 
   // MARK: - Schema-aware carve-out (case g)
 
-  @Test func noRetryForChooseSchemaWithEnumOptions() async throws {
+  @Test func noRetryForChooseSchemaWithChoiceField() async throws {
     // choose-phase schema with `action: .choice` on a ja scenario.
     // Output is the author-supplied action token — English text but not
     // LLM-generated language. The schema filter excludes `.choice` from

--- a/Pastura/PasturaTests/Engine/LLMCallerLanguageAdherenceTests.swift
+++ b/Pastura/PasturaTests/Engine/LLMCallerLanguageAdherenceTests.swift
@@ -17,10 +17,10 @@ import os
 /// - Priority pin: when a response has both `empty_field` and
 ///   wrong-language, the parse-empty retry fires first — the adherence
 ///   check is gated on a non-empty output
-/// - Schema-aware carve-out: option-bound enum fields
-///   (`Field.kind == .enumeration(...)`) are excluded from the
-///   detection input, so a `choose` scenario in `ja` with English
-///   option tokens does not spuriously retry
+/// - Schema-aware carve-out: author-defined choice fields
+///   (`Field.kind == .choice`) are excluded from the detection input,
+///   so a `choose` scenario in `ja` with English option tokens does not
+///   spuriously retry
 @Suite(.timeLimit(.minutes(1)))
 struct LLMCallerLanguageAdherenceTests {
   let caller = LLMCaller()
@@ -51,12 +51,12 @@ struct LLMCallerLanguageAdherenceTests {
   }
 
   /// Mimics a `choose` phase schema with author-supplied English options.
-  /// The `action` field is enum-constrained — the adherence check must
-  /// filter it out and base its verdict on remaining natural-language
-  /// fields (none here → check is skipped entirely).
+  /// The `action` field is `.choice` — the adherence check must filter it
+  /// out and base its verdict on remaining natural-language fields (none
+  /// here → check is skipped entirely).
   private func chooseSchemaWithEnOptions() -> OutputSchema {
     OutputSchema(fields: [
-      OutputSchema.Field(name: "action", kind: .enumeration(["cooperate", "betray"]))
+      OutputSchema.Field(name: "action", kind: .choice)
     ])
   }
 
@@ -252,11 +252,11 @@ struct LLMCallerLanguageAdherenceTests {
   // MARK: - Schema-aware carve-out (case g)
 
   @Test func noRetryForChooseSchemaWithEnumOptions() async throws {
-    // choose-phase schema with `action: .enumeration(["cooperate", "betray"])`
-    // on a ja scenario. Output is the enum-constrained action token —
-    // English text but author-supplied, not LLM-generated language. The
-    // schema filter excludes `action` from natural-language fields, so
-    // the joined detection input is empty → check skipped → no retry.
+    // choose-phase schema with `action: .choice` on a ja scenario.
+    // Output is the author-supplied action token — English text but not
+    // LLM-generated language. The schema filter excludes `.choice` from
+    // natural-language fields, so the joined detection input is empty →
+    // check skipped → no retry.
     let mock = MockLLMService(responses: [
       #"{"action": "cooperate"}"#
     ])

--- a/Pastura/PasturaTests/LLM/GBNFGrammarBuilderTests.swift
+++ b/Pastura/PasturaTests/LLM/GBNFGrammarBuilderTests.swift
@@ -117,52 +117,30 @@ struct GBNFGrammarBuilderTests {
     #expect(iIdx < eIdx)
   }
 
-  // MARK: - Enumeration (choose.options)
+  // MARK: - Choice fields use the shared string production
 
-  @Test("enumeration generates a per-field alternation rule")
-  func enumerationAloneProducesPerFieldRule() throws {
+  @Test("choice field is grammar-equivalent to string (no value enumeration)")
+  func choiceFieldUsesStringProduction() throws {
+    // `.choice` carries no option payload — the grammar must NOT enumerate
+    // values (model-agnostic crash safety, #599). The action value position
+    // references the shared `string` production, exactly like a `.string`
+    // field, and no `action-value` alternation rule is emitted.
     let schema = OutputSchema(fields: [
-      .init(name: "action", kind: .enumeration(["cooperate", "betray"]))
-    ])
-    let grammar = try builder.build(from: schema)
-    #expect(
-      grammar.contains(#"root ::= "{" ws "\"action\"" ws ":" ws action-value ws "}" trailing"#))
-    #expect(
-      grammar.contains(#"action-value ::= "\"cooperate\"" | "\"betray\"""#))
-    // Enumeration-only grammars still include `string` + `ws` because
-    // shared productions are emitted unconditionally (cheap; avoids
-    // future regression if an enumeration grammar later references them).
-    #expect(grammar.contains("string ::="))
-    #expect(grammar.contains("ws ::="))
-  }
-
-  @Test("enumeration + string mix: enumeration rule AND string production")
-  func enumerationMixedWithString() throws {
-    // prisoners_dilemma choose-phase shape — covered in golden-file test
-    // below too, but kept here as a focused per-field assertion.
-    let schema = OutputSchema(fields: [
-      .init(name: "action", kind: .enumeration(["cooperate", "betray"])),
+      .init(name: "action", kind: .choice),
       .init(name: "inner_thought", kind: .string)
     ])
     let grammar = try builder.build(from: schema)
-    #expect(grammar.contains(#"action-value ::= "\"cooperate\"" | "\"betray\"""#))
     #expect(
       grammar.contains(
-        #"root ::= "{" ws "\"action\"" ws ":" ws action-value ws "," ws "\"inner_thought\"" ws ":" ws string ws "}" trailing"#
+        #"root ::= "{" ws "\"action\"" ws ":" ws string ws "," ws "\"inner_thought\"" ws ":" ws string ws "}" trailing"#
       ))
+    // No per-field enumeration rule is emitted for the choice field.
+    // (The shared `string` production legitimately contains ` | ` for the
+    // JSON escape alternation, so we assert on the rule name, not ` | `.)
+    #expect(!grammar.contains("action-value"))
   }
 
   // MARK: - Validation errors
-
-  @Test("empty enumeration throws")
-  func emptyEnumerationThrows() {
-    let schema = OutputSchema(fields: [
-      .init(name: "action", kind: .enumeration([]))
-    ])
-    #expect(throws: GBNFGrammarBuilder.BuilderError.self) {
-      try builder.build(from: schema)
-    }
-  }
 
   @Test("duplicate field name throws")
   func duplicateFieldNameThrows() {
@@ -177,17 +155,14 @@ struct GBNFGrammarBuilderTests {
     }
   }
 
-  @Test("invalid rule-name field throws")
+  @Test("invalid field name throws")
   func invalidFieldNameThrows() {
-    // Pastura preset field-name input requires a leading letter
-    // followed by letter / digit / `_`. The actual GBNF rule shape
-    // (no `_`) is enforced separately by `sanitizeRuleName` at emit
-    // time, so `dash-only` is rejected here as Pastura input
-    // convention. Leading `_` is now also rejected — sanitization
-    // would produce a leading-`-` rule identifier (`-thing-value`)
-    // which is unconventional and a future llama.cpp tightening
-    // could reject (ADR-002 §12.8). Leading digit / literal `.` /
-    // spaces fail in any case.
+    // Field names are emitted as JSON-key literals (`"\"name\""`) in the
+    // grammar. Pastura input requires a leading letter followed by
+    // letter / digit / `_`. Leading `_` / `-` stay rejected as a
+    // conservative hygiene rule (originally also guarded the now-removed
+    // `<name>-value` rule identifier — ADR-002 §12.8, historical).
+    // Leading digit / literal `.` / spaces fail in any case.
     let badNames = [
       "1badName", "with space", "dash-only", "dot.name",
       "_leading", "-leading",
@@ -211,12 +186,13 @@ struct GBNFGrammarBuilderTests {
   func validFieldNamesAccepted() throws {
     // `validateFieldName` is Unicode-aware via `Character.isLetter`:
     // ASCII snake_case (`_` only in body, never leading) AND non-ASCII
-    // letters like Japanese both pass. The Unicode case would surface
-    // as an `is_word_char` mismatch at llama.cpp's emit time (deferred
-    // per ADR-002 §12.8); the stderr-capture diagnostic in
-    // `+Sampler.swift` would catch it within one device run. This
-    // test locks in the builder-level Unicode acceptance so a future
-    // contributor tightening to ASCII-only must break it explicitly.
+    // letters like Japanese both pass at the builder level. This test
+    // locks in builder-level Unicode acceptance so a future contributor
+    // tightening to ASCII-only must break it explicitly. (Non-ASCII
+    // field NAMES become JSON-key literals; a CJK-key on-device crash is
+    // the same mechanism as the removed CJK-option crash and is tracked
+    // as a separate follow-up — out of scope for #599, which covers
+    // choose OPTION values.)
     let okNames = [
       "statement", "inner_thought", "action", "a1b2", "内なる思考"
     ]
@@ -224,61 +200,6 @@ struct GBNFGrammarBuilderTests {
       let schema = OutputSchema(fields: [.init(name: name, kind: .string)])
       _ = try builder.build(from: schema)
     }
-  }
-
-  @Test("enum field name with `_` emits sanitized `-` rule reference")
-  func enumFieldNameUnderscoreSanitizedToHyphenInRuleName() throws {
-    // `is_word_char` (llama-grammar.cpp:98 of b8694) rejects `_` in rule
-    // identifiers, so Pastura snake_case input gets mapped to hyphenated
-    // form at emit time. JSON keys (which appear inside string literals)
-    // are unaffected and retain the original `_`.
-    let schema = OutputSchema(fields: [
-      .init(name: "inner_secret", kind: .enumeration(["alpha", "beta"]))
-    ])
-    let grammar = try builder.build(from: schema)
-    // Rule reference and definition both use the sanitized form.
-    #expect(grammar.contains("inner-secret-value"))
-    #expect(!grammar.contains("inner_secret-value"))
-    #expect(!grammar.contains("inner_secret_value"))
-    // JSON key inside the string literal keeps the original `_`.
-    #expect(grammar.contains(#""\"inner_secret\"""#))
-  }
-
-  @Test("enumeration options with GBNF-hostile chars throw")
-  func enumerationOptionWithHostileCharsThrows() {
-    // Shared Scenarios entries can inject arbitrary option strings; the
-    // builder validates upfront so failures surface as a clear
-    // BuilderError rather than a NULL-return from llama.cpp's grammar
-    // parser (which would hit `LLMError.invalidGrammar` at sampler init).
-    let badOptions: [String] = [
-      "has\"quote",  // raw `"` would break the GBNF literal
-      "has\\backslash",  // `\` would need escaping
-      "has\nnewline",  // control byte
-      "has\ttab"  // control byte
-    ]
-    for option in badOptions {
-      let schema = OutputSchema(fields: [
-        .init(name: "action", kind: .enumeration([option]))
-      ])
-      #expect(
-        throws: GBNFGrammarBuilder.BuilderError.self,
-        "option \(option.debugDescription) should be rejected"
-      ) {
-        try builder.build(from: schema)
-      }
-    }
-  }
-
-  @Test("enumeration options with CJK / unicode accepted")
-  func enumerationOptionWithUnicodeAccepted() throws {
-    // Non-ASCII printable characters are fine — GBNF's `[^"\\]` byte
-    // class accepts them transparently and they don't collide with
-    // literal delimiters.
-    let schema = OutputSchema(fields: [
-      .init(name: "action", kind: .enumeration(["協力", "裏切り"]))
-    ])
-    let grammar = try builder.build(from: schema)
-    #expect(grammar.contains(#"action-value ::= "\"協力\"" | "\"裏切り\"""#))
   }
 
   // MARK: - Golden files (each preset LLM phase)
@@ -298,7 +219,7 @@ struct GBNFGrammarBuilderTests {
       options: ["cooperate", "betray"])
     let schema = try #require(OutputSchema.from(phase: phase))
     let grammar = try builder.build(from: schema)
-    #expect(grammar == Self.goldenChooseActionBetray)
+    #expect(grammar == Self.goldenChooseAction)
   }
 
   @Test("golden: word_wolf speak_all phase")
@@ -345,9 +266,11 @@ struct GBNFGrammarBuilderTests {
     trailing ::= ([\\t\\n\\r -~] trailing)?
     """
 
-  private static let goldenChooseActionBetray = """
-    root ::= "{" ws "\\"action\\"" ws ":" ws action-value ws "," ws "\\"inner_thought\\"" ws ":" ws string ws "}" trailing
-    action-value ::= "\\"cooperate\\"" | "\\"betray\\""
+  // Choose phase: `action` is a `.choice` field, grammar-equivalent to
+  // `.string` (no value enumeration — #599). Shape matches a two-string
+  // schema with `action` + `inner_thought` keys.
+  private static let goldenChooseAction = """
+    root ::= "{" ws "\\"action\\"" ws ":" ws string ws "," ws "\\"inner_thought\\"" ws ":" ws string ws "}" trailing
     \(sharedTail)
     """
 

--- a/Pastura/PasturaTests/LLM/GBNFGrammarBuilderTests.swift
+++ b/Pastura/PasturaTests/LLM/GBNFGrammarBuilderTests.swift
@@ -140,6 +140,39 @@ struct GBNFGrammarBuilderTests {
     #expect(!grammar.contains("action-value"))
   }
 
+  @Test("regression #599: CJK / GBNF-hostile choose options never reach the grammar as literals")
+  func chooseOptionsNeverEnumeratedIntoGrammar() throws {
+    // Replaces the former `enumerationOptionWithUnicodeAccepted` test,
+    // which asserted CJK options were "fine" to enumerate. They were NOT:
+    // CJK option literals crashed llama.cpp's sampler on-device
+    // (token-dependent, uncatchable), and GBNF-hostile chars aborted the
+    // run at sampler init. Both are now structurally impossible — choose
+    // options become a payload-free `.choice` marker (no value
+    // enumeration). This exercises the real `OutputSchema.from(phase:)` →
+    // `build` path with dangerous options and asserts none leak into the
+    // grammar and nothing throws. Reverting the `.choice` pivot fails this:
+    // the literals would reappear (CJK) or `build` would throw (hostile).
+    let dangerousOptions = ["協力", "裏切り", #"a"b"#, #"x\y"#, "with\nnewline"]
+    let phase = Phase(
+      type: .choose, prompt: "…",
+      outputSchema: ["action": "string"],
+      options: dangerousOptions)
+    let schema = try #require(OutputSchema.from(phase: phase))
+    #expect(schema.fields.first { $0.name == "action" }?.kind == .choice)
+    // Must not throw — the dangerous options never reach a literal emitter.
+    let grammar = try builder.build(from: schema)
+    // The action value position references the shared `string` production.
+    #expect(
+      grammar.contains(#"root ::= "{" ws "\"action\"" ws ":" ws string ws "}" trailing"#))
+    #expect(!grammar.contains("action-value"))
+    // None of the option strings leaked into the grammar as literals.
+    for option in dangerousOptions {
+      #expect(
+        !grammar.contains(option),
+        "option \(option.debugDescription) must not appear in the grammar")
+    }
+  }
+
   // MARK: - Validation errors
 
   @Test("duplicate field name throws")

--- a/Pastura/PasturaTests/Models/OutputSchemaTests.swift
+++ b/Pastura/PasturaTests/Models/OutputSchemaTests.swift
@@ -72,10 +72,14 @@ struct OutputSchemaTests {
         == ["statement", "inner_thought", "alpha", "zeta"])
   }
 
-  // MARK: - Enumeration for choose.options
+  // MARK: - Choice marker for choose.options
 
-  @Test("choose with options produces enumeration on action field")
-  func chooseOptionsBecomesEnumeration() throws {
+  @Test("choose with options marks the action field as .choice")
+  func chooseOptionsBecomesChoice() throws {
+    // `.choice` is a payload-free marker (no option strings) — the
+    // options are NOT enumerated into the grammar (model-agnostic crash
+    // safety, #599). It signals "author-fixed token, exclude from
+    // language detection" only.
     let schema = try #require(
       OutputSchema.from(
         phase: Phase(
@@ -83,7 +87,7 @@ struct OutputSchemaTests {
           outputSchema: ["action": "string", "inner_thought": "string"],
           options: ["cooperate", "betray"])))
     let actionField = try #require(schema.fields.first { $0.name == "action" })
-    #expect(actionField.kind == .enumeration(["cooperate", "betray"]))
+    #expect(actionField.kind == .choice)
     let thoughtField = try #require(
       schema.fields.first { $0.name == "inner_thought" })
     #expect(thoughtField.kind == .string)
@@ -101,9 +105,9 @@ struct OutputSchemaTests {
     #expect(actionField.kind == .string)
   }
 
-  @Test("non-choose phases never produce enumeration even with options-shaped data")
+  @Test("non-choose phases never produce .choice even with options-shaped data")
   func speakPhaseIgnoresOptions() throws {
-    // Defensive: speak_all should never get enumeration even if options accidentally present
+    // Defensive: speak_all should never get .choice even if options accidentally present
     let schema = try #require(
       OutputSchema.from(
         phase: Phase(

--- a/Pastura/PasturaTests/Models/OutputSchemaTests.swift
+++ b/Pastura/PasturaTests/Models/OutputSchemaTests.swift
@@ -93,6 +93,22 @@ struct OutputSchemaTests {
     #expect(thoughtField.kind == .string)
   }
 
+  @Test("regression #599: choose with CJK / hostile options yields .choice, never enumeration")
+  func chooseDangerousOptionsBecomeChoice() throws {
+    // `from(phase:)` must not carry option strings anywhere. Choose
+    // options with CJK or GBNF-hostile chars (which previously enumerated
+    // into the grammar and crashed/aborted) produce a payload-free
+    // `.choice` marker with no validation/throw at the Models layer.
+    let schema = try #require(
+      OutputSchema.from(
+        phase: Phase(
+          type: .choose, prompt: "…",
+          outputSchema: ["action": "string"],
+          options: ["協力", "裏切り", #"a"b"#])))
+    let actionField = try #require(schema.fields.first { $0.name == "action" })
+    #expect(actionField.kind == .choice)
+  }
+
   @Test("choose without options keeps action as plain string")
   func chooseWithoutOptionsIsString() throws {
     let schema = try #require(

--- a/docs/decisions/ADR-002.md
+++ b/docs/decisions/ADR-002.md
@@ -1571,8 +1571,9 @@ alternation literals crashed llama.cpp's sampler at accept-time on
 CJK / dynamic values — the §12.9 EOG-path abort class. The trigger is
 the model's BPE tokenizer behavior, not a fixed character set, so the
 former `validateEnumerationOption` char-class guard (and the
-`isSafeEnumerationOption` predicate briefly added for the vote phase in
-#597) **cannot** make value-enumeration safe across models: a guard that
+`isSafeEnumerationOption` predicate added then removed within #597 — it
+no longer exists in code) **cannot** make value-enumeration safe across
+models: a guard that
 passes for Gemma 4 E2B is unverified for any other runtime-selectable
 model or the planned LiteRT-LM backend. #597 already dropped grammar
 enumeration for the `vote` field for this reason; #599 mirrors that for

--- a/docs/decisions/ADR-002.md
+++ b/docs/decisions/ADR-002.md
@@ -861,6 +861,11 @@ native constrained-decoding mechanism:
 — matches every Pastura preset shape; richer JSON Schema features for future
 backends should land as an adapter, not as enum extensions.
 
+> **Superseded (2026-06-14, #599):** `.enumeration([String])` was replaced
+> by a payload-free `.choice` marker — `choose` values are no longer
+> enumerated into the grammar. See the §Amendment 2026-06-14 at the end of
+> this ADR.
+
 ### 12.3 Hard JSON design choice
 
 Grammar is enforced from token 0, preventing Gemma from emitting its
@@ -902,6 +907,11 @@ enumeration, duplicate field name, invalid GBNF rule-name) and throws
 `LLMError.invalidGrammar(description:)`. The same error fires when
 `llama_sampler_init_grammar` returns NULL (unparseable GBNF).
 
+> **Superseded (2026-06-14, #599):** the empty-enumeration / option
+> validation is gone with value-enumeration. The builder now validates
+> only duplicate field name + invalid field name. See §Amendment
+> 2026-06-14.
+
 `LLMCaller.call` wraps this as `SimulationError.llmGenerationFailed`
 and exits the retry loop without consuming budget — the generic catch
 is placed BEFORE the retry loop's `continue` branches. A deterministic
@@ -942,6 +952,13 @@ choice.
 - `docs/measurements/grammar-baseline.md` (paired baseline protocol)
 
 ### 12.8 Underscore is not a GBNF identifier char
+
+> **Superseded (2026-06-14, #599):** `sanitizeRuleName` /
+> `enumerationRule` are removed — no per-field `<name>-value` rule
+> identifiers exist anymore, so the `_`→`-` mapping is moot. Field names
+> now appear only as JSON-key literals; `validateFieldName`'s hygiene
+> check is retained. This subsection is historical. See §Amendment
+> 2026-06-14.
 
 **Discovery (2026-04-26).** llama.cpp's GBNF parser at b8694 rejects
 underscore (`_`) in rule-name identifiers. The accepted character set
@@ -1531,3 +1548,61 @@ is fundamentally broken (likely a stuck inference or livelock).
   (wait-and-claim).
 - `Pastura/PasturaTests/LLM/LlamaCppServiceTests+CooperativeWait.swift`
   — timing-based regression tests, including the multi-waiter race.
+
+## Amendment 2026-06-14 — `choose` value-enumeration removed (#599)
+
+**Supersedes** the value-enumeration machinery described in §12.2 (the
+`.enumeration([String])` `Kind` at §860), §12.5 (empty-enumeration /
+option validation), and §12.8 (`sanitizeRuleName` / `enumerationRule`).
+Those sections are retained as historical record of *why* the machinery
+existed; the current behavior is below.
+
+**What changed.** The `choose` phase no longer enumerates its `options`
+into the GBNF grammar. `OutputSchema.Field.Kind.enumeration([String])` is
+replaced by a payload-free `Kind.choice` marker, and the builder's
+enumeration machinery (`enumerationRule`, `validateEnumerationOption`,
+`sanitizeRuleName`, `BuilderError.emptyEnumeration` /
+`.invalidEnumerationOption`) is deleted. Every field's value position now
+uses the shared `string` production — the grammar constrains JSON
+**structure** (object shape, keys, commas) but never enumerates values.
+
+**Why (model-agnostic safety).** Emitting option strings as GBNF
+alternation literals crashed llama.cpp's sampler at accept-time on
+CJK / dynamic values — the §12.9 EOG-path abort class. The trigger is
+the model's BPE tokenizer behavior, not a fixed character set, so the
+former `validateEnumerationOption` char-class guard (and the
+`isSafeEnumerationOption` predicate briefly added for the vote phase in
+#597) **cannot** make value-enumeration safe across models: a guard that
+passes for Gemma 4 E2B is unverified for any other runtime-selectable
+model or the planned LiteRT-LM backend. #597 already dropped grammar
+enumeration for the `vote` field for this reason; #599 mirrors that for
+`choose`. Removing value-enumeration eliminates the crash surface *by
+construction* rather than per-model.
+
+**New constraint contract.** Mechanism, not a pinned per-model gate
+(per `adr-writing.md` §2):
+
+- **Structure** — grammar enforces the JSON object shape + keys + the
+  shared `string` value production (model-agnostic; `[^"\\]` accepts any
+  UTF-8 byte).
+- **Value** — `ChooseHandler.validateAction` maps an out-of-set action to
+  `options[0]` at runtime (the correctness floor, unchanged).
+- **Steering** — `PromptBuilder` injects the valid options into the
+  prompt ("The action field must be one of: …"), so the runtime fallback
+  is rare in practice.
+
+**Field-name validation retained.** `validateFieldName` still rejects
+hostile / leading-`_` field names — field names are emitted as JSON-key
+literals (`"\"name\""`). The §12.8 `_`→`-` rule-identifier mapping is
+gone (no per-field rules exist anymore), but the hygiene check stays.
+
+**Known residual (out of scope, follow-up).** CJK field *names* still
+emit as JSON-key literals and carry the same accept-time crash mechanism
+as the removed CJK options. All bundled presets use ASCII keys; Shared
+Scenarios could inject CJK keys. Tracked separately from #599 (which
+covers `choose` option *values*).
+
+Code: `Models/OutputSchema.swift` (`Kind.choice`),
+`LLM/GBNFGrammarBuilder.swift`, `Engine/LLMCaller.swift`
+(`naturalLanguageFieldValues` keeps excluding `.choice` from the
+language-adherence detector — ADR-010 Step E / #405).

--- a/docs/decisions/ADR-010.md
+++ b/docs/decisions/ADR-010.md
@@ -247,9 +247,10 @@ following contract:
   directories.
 - **Detection input filter.** Adherence is checked against the joined
   values of `OutputSchema.Field.kind == .string` fields only;
-  `.enumeration(...)` fields (e.g., `action` on choose phases) are
-  excluded because their values are author-supplied tokens rather
-  than LLM-emitted language. Joined input below 12 codepoints skips
+  `.choice` fields (e.g., `action` on choose phases) are excluded
+  because their values are author-supplied tokens rather than
+  LLM-emitted language. (`.choice` replaced `.enumeration([String])`
+  in #599 — ADR-002 §Amendment 2026-06-14.) Joined input below 12 codepoints skips
   the check and emits a `StreamingDiag langCheckSkipped agent=…
   reason=too_short` line.
 - **Retry / event semantics.** `LLMCaller.call(detector:expectedLanguage:)`

--- a/docs/measurements/grammar-baseline.md
+++ b/docs/measurements/grammar-baseline.md
@@ -37,12 +37,13 @@ hard-JSON choice.
   physical-device delta is the merge gate, the simulator pair is a
   sanity check.
 - **Two presets: `prisoners_dilemma` AND `word_wolf`** — `prisoners_dilemma`
-  exercises the `choose` enumeration path; `word_wolf` exercises the
-  `vote` phase whose schema shape (`vote, reason`) and round-robin
-  elimination logic neither of the other presets covers. The vote
-  phase is the only place the enumeration-on-`action` pattern does
-  NOT apply — so it catches "grammar works for choose but regresses
-  for plain strings" by construction.
+  exercises the `choose` phase (`action` is a `.choice` field, validated
+  at runtime — value enumeration was removed in #599, see ADR-002
+  §Amendment 2026-06-14); `word_wolf` exercises the `vote` phase whose
+  schema shape (`vote, reason`) and round-robin elimination logic neither
+  of the other presets covers. Both phases now use the shared `string`
+  value production, so this pair simply spans the round-robin (`choose`)
+  and tally/elimination (`vote`) code paths.
 - **Speed: `.normal`** — the project default; `.slow` adds stream-jitter
   noise that obscures the grammar effect, `.instant` bypasses the
   event-layer gate.


### PR DESCRIPTION
## Summary
`choose` injected its `options` into the GBNF grammar as alternation literals
(`OutputSchema.from(phase:)`). Two latent failure modes resulted: GBNF-hostile
option chars (`"` `\` newline/control) aborted the whole run with no retry, and
**CJK options crashed llama.cpp's sampler at accept-time on-device** (uncatchable
SIGABRT). The crash is token-dependent (per-model tokenizer behaviour), so a
char-class guard cannot make value-enumeration safe across models.

This removes value-enumeration entirely (mirroring the #597 vote precedent):
- `OutputSchema.Field.Kind.enumeration([String])` → payload-free `.choice` marker.
- Deletes the builder's enumeration machinery (`enumerationRule`,
  `validateEnumerationOption`, `sanitizeRuleName`, two `BuilderError` cases).
- **Grammar constrains JSON structure only**; choose values are validated at
  runtime by the existing `ChooseHandler.validateAction` (invalid → `options[0]`),
  and the model still learns valid options from the prompt (`PromptBuilder`).
- `.choice` is retained (vs collapsing to `.string`) so the #405 language-adherence
  detector keeps excluding author-fixed tokens — without ever carrying option
  strings into the grammar.

Model-agnostic by construction: no backend sampler ever receives enumeration
literals, so future ModelRegistry models / LiteRT-LM inherit the safety.

ADR-002 gains an §Amendment 2026-06-14; cross-references and the editor's
choose hint (EN + ja) are reconciled.

**Out of scope (follow-up):** CJK field *names* emit as JSON-key literals with the
same crash mechanism; presets use ASCII keys. Tracked separately.

## Test plan
- New regression test `chooseOptionsNeverEnumeratedIntoGrammar`: CJK + GBNF-hostile
  choose options → `.choice` + `string`-production grammar, no literals, no throw
  (revert-sensitive — restoring `.enumeration` re-emits literals / throws).
- Updated `OutputSchemaTests`, `GBNFGrammarBuilderTests`, `LLMCallerLanguageAdherenceTests`.
- Full unit suite (1861 tests) green; swiftlint --strict clean; i18n coverage OK (462 keys).
- Code review: PASS (Opus, 0 Critical/Warning).

Closes #599