### PR TITLE
✨ feat: Home redesign P0 — data-layer prep (#604)

### DIFF
--- a/Pastura/Pastura/App/HomeViewModel.swift
+++ b/Pastura/Pastura/App/HomeViewModel.swift
@@ -29,6 +29,14 @@ final class HomeViewModel {
   /// The consuming View (row secondary line, ADR-016 D3) lands in P2.
   private(set) var rowMetadata: [String: ScenarioRowMetadata] = [:]
 
+  /// Completed-run count per displayed row, keyed by ``ScenarioRecord/id``.
+  /// Aggregated across ADR-010 D6 language variants by `sourceId`, so a row
+  /// shows the total "観察回数" across every variant of its canonical
+  /// scenario (a run of the EN variant still counts on the displayed JA row).
+  /// Empty when no ``SimulationRepository`` is injected (fixture tests that
+  /// don't exercise counts). Recomputed on every ``loadScenarios()``.
+  private(set) var observationCounts: [String: Int] = [:]
+
   /// `ScenarioRecord.id`s for rows whose `sourceHash` differs from the
   /// cached gallery's `yaml_sha256`. Empty when no cache exists. The view
   /// reads this as an inline badge on each row.
@@ -36,12 +44,23 @@ final class HomeViewModel {
 
   private let repository: any ScenarioRepository
 
+  /// Optional — supplies completed-run counts for ``observationCounts``.
+  /// Defaults to `nil` so existing fixture tests keep their two-arg-free
+  /// construction; a pure-data repository has no test-isolation hazard
+  /// (cf. `.claude/rules/swiftui-traps.md` § "inject at View boundary",
+  /// which targets *side-effecting* services, not immutable repositories).
+  private let simulationRepository: (any SimulationRepository)?
+
   /// In-process parse memo keyed by `id` + `updatedAt`. See
   /// ``ScenarioRowMetadataCache`` for the keying / invalidation contract.
   private var metadataCache = ScenarioRowMetadataCache()
 
-  init(repository: any ScenarioRepository) {
+  init(
+    repository: any ScenarioRepository,
+    simulationRepository: (any SimulationRepository)? = nil
+  ) {
     self.repository = repository
+    self.simulationRepository = simulationRepository
   }
 
   func loadScenarios() async {
@@ -63,6 +82,18 @@ final class HomeViewModel {
       let loader = ScenarioLoader()
       rowMetadata = metadataCache.resolve(presets + userScenarios) { record in
         Self.parseRowMetadata(record, loader: loader)
+      }
+      // Observation counts are display garnish — a failed count read must not
+      // blank the list (try?), so it's kept out of the batch error path.
+      if let simulationRepository {
+        let completed =
+          (try? await offMain { [simulationRepository] in
+            try simulationRepository.completedRunCountsByScenarioId()
+          }) ?? [:]
+        observationCounts = Self.aggregateObservationCounts(
+          completedByScenarioId: completed,
+          scenarios: all,
+          displayedRows: presets + userScenarios)
       }
     } catch {
       errorMessage = String(localized: "Failed to load scenarios: \(error.localizedDescription)")
@@ -125,6 +156,37 @@ final class HomeViewModel {
       rounds: scenario.rounds,
       description: scenario.description
     )
+  }
+
+  /// Projects per-variant completed-run counts onto the displayed (collapsed)
+  /// rows, summing across ADR-010 D6 language variants by canonical key
+  /// (`sourceId ?? id`). A run recorded against the EN variant therefore
+  /// counts on the displayed JA row, matching ADR-010 D4's cross-variant
+  /// aggregation intent. Every displayed row gets an entry (0 when it has no
+  /// completed runs).
+  internal static func aggregateObservationCounts(
+    completedByScenarioId: [String: Int],
+    scenarios: [ScenarioRecord],
+    displayedRows: [ScenarioRecord]
+  ) -> [String: Int] {
+    // Each concrete scenario id → its canonical D6 key.
+    let canonicalKey = Dictionary(
+      scenarios.map { ($0.id, $0.sourceId ?? $0.id) },
+      uniquingKeysWith: { first, _ in first })
+
+    // Roll per-variant counts up to the canonical key.
+    var byCanonical: [String: Int] = [:]
+    for (scenarioId, count) in completedByScenarioId {
+      guard let key = canonicalKey[scenarioId] else { continue }
+      byCanonical[key, default: 0] += count
+    }
+
+    // Project onto the displayed rows by their own canonical key.
+    var result: [String: Int] = [:]
+    for row in displayedRows {
+      result[row.id] = byCanonical[row.sourceId ?? row.id] ?? 0
+    }
+    return result
   }
 
   func deleteScenario(_ id: String) async {

--- a/Pastura/Pastura/App/HomeViewModel.swift
+++ b/Pastura/Pastura/App/HomeViewModel.swift
@@ -66,6 +66,9 @@ final class HomeViewModel {
   func loadScenarios() async {
     isLoading = true
     errorMessage = nil
+    // Reset so the "recomputed on every load" contract holds even when no
+    // SimulationRepository is injected (the recompute below is gated on it).
+    observationCounts = [:]
 
     do {
       let all = try await offMain { [repository] in

--- a/Pastura/Pastura/App/HomeViewModel.swift
+++ b/Pastura/Pastura/App/HomeViewModel.swift
@@ -21,12 +21,24 @@ final class HomeViewModel {
   private(set) var isLoading = false
   private(set) var errorMessage: String?
 
+  /// Resolved per-row display metadata, keyed by ``ScenarioRecord/id``.
+  /// Rebuilt on every ``loadScenarios()`` from the collapsed (ADR-010 D6)
+  /// preset set plus the user scenarios. A row whose YAML fails to parse
+  /// gets a name-only ``ScenarioRowMetadata`` and **never** sets
+  /// ``errorMessage`` — one broken preset must not blank the whole list.
+  /// The consuming View (row secondary line, ADR-016 D3) lands in P2.
+  private(set) var rowMetadata: [String: ScenarioRowMetadata] = [:]
+
   /// `ScenarioRecord.id`s for rows whose `sourceHash` differs from the
   /// cached gallery's `yaml_sha256`. Empty when no cache exists. The view
   /// reads this as an inline badge on each row.
   private(set) var galleryUpdateBadges: Set<String> = []
 
   private let repository: any ScenarioRepository
+
+  /// In-process parse memo keyed by `id` + `updatedAt`. See
+  /// ``ScenarioRowMetadataCache`` for the keying / invalidation contract.
+  private var metadataCache = ScenarioRowMetadataCache()
 
   init(repository: any ScenarioRepository) {
     self.repository = repository
@@ -44,6 +56,14 @@ final class HomeViewModel {
       presets = Self.presetsResolvedForLanguage(
         allPresets, deviceLanguage: LocaleResolver.deviceDefault())
       userScenarios = all.filter { !$0.isPreset }
+      // Resolve metadata on the *collapsed* (D6) preset rows + user rows —
+      // never the pre-collapse variant set — so the metadata keys stay a
+      // subset of the displayed row ids and language/variant selection is
+      // never re-derived from the heavy parse (ADR-010 D6 non-interference).
+      let loader = ScenarioLoader()
+      rowMetadata = metadataCache.resolve(presets + userScenarios) { record in
+        Self.parseRowMetadata(record, loader: loader)
+      }
     } catch {
       errorMessage = String(localized: "Failed to load scenarios: \(error.localizedDescription)")
     }
@@ -84,6 +104,27 @@ final class HomeViewModel {
 
     // Stable order — sort by canonical key so reloads don't flicker.
     return resolved.sorted { ($0.sourceId ?? $0.id) < ($1.sourceId ?? $1.id) }
+  }
+
+  /// Parses a record's stored YAML into ``ScenarioRowMetadata`` via the full
+  /// ``ScenarioLoader`` schema gate. On any parse / validation failure the row
+  /// **degrades to name-only** — the `try?` keeps the failure local so it can
+  /// never reach the batch ``errorMessage`` path in ``loadScenarios()`` (one
+  /// broken preset must not blank the whole list). This is the heavy parse the
+  /// ``ScenarioRowMetadataCache`` memoizes; the light ``ScenarioYAMLLanguage``
+  /// parse used for D6 variant selection is unaffected.
+  internal static func parseRowMetadata(
+    _ record: ScenarioRecord, loader: ScenarioLoader
+  ) -> ScenarioRowMetadata {
+    guard let scenario = try? loader.load(yaml: record.yamlDefinition) else {
+      return ScenarioRowMetadata(name: record.name)
+    }
+    return ScenarioRowMetadata(
+      name: record.name,
+      agentCount: scenario.agentCount,
+      rounds: scenario.rounds,
+      description: scenario.description
+    )
   }
 
   func deleteScenario(_ id: String) async {

--- a/Pastura/Pastura/App/ScenarioRowMetadata.swift
+++ b/Pastura/Pastura/App/ScenarioRowMetadata.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+/// Display-prep metadata for a Home scenario row, resolved from a
+/// ``ScenarioRecord``'s stored YAML via ``ScenarioLoader``.
+///
+/// On a successful parse, `agentCount` / `rounds` / `description` carry the
+/// scenario meta for the row's secondary line (ADR-016 D3 layout — the
+/// consuming View lands in P2). On a parse failure the row **degrades to
+/// name-only**: `name` always reflects ``ScenarioRecord/name`` (authoritative
+/// for the row title) and the optional fields are `nil`. A parse failure for
+/// one row must never propagate to ``HomeViewModel/errorMessage`` — a single
+/// broken preset cannot be allowed to blank the whole list.
+///
+/// `nonisolated` (App layer defaults to MainActor) because it is pure display
+/// data resolved off the `ScenarioLoader` parse and compared/constructed from
+/// `nonisolated` contexts (the cache below); see
+/// `.claude/rules/swift-isolation.md` Pattern 2/5.
+nonisolated struct ScenarioRowMetadata: Equatable, Sendable {
+  /// Row title — always the record's `name`, even on parse failure.
+  let name: String
+  /// Agent count from the parsed scenario; `nil` when the YAML failed to parse.
+  let agentCount: Int?
+  /// Round count from the parsed scenario; `nil` on parse failure.
+  let rounds: Int?
+  /// One-line description from the parsed scenario; `nil` on parse failure.
+  let description: String?
+
+  init(
+    name: String,
+    agentCount: Int? = nil,
+    rounds: Int? = nil,
+    description: String? = nil
+  ) {
+    self.name = name
+    self.agentCount = agentCount
+    self.rounds = rounds
+    self.description = description
+  }
+}
+
+/// In-process parse memo for Home scenario-row metadata.
+///
+/// Keyed by ``ScenarioRecord/id`` + ``ScenarioRecord/updatedAt`` so an
+/// unchanged row is not re-parsed across reloads (pull-to-refresh). The memo
+/// is **not** persisted and **not** keyed by `sourceId`: keying by `sourceId`
+/// would collapse variants and desync from ADR-010 D6, which collapses
+/// variants for *display* but must parse each concrete variant independently.
+/// A bumped `updatedAt` (e.g. a gallery update) changes the key, so the stale
+/// entry is no longer found and the row is re-parsed.
+///
+/// ``resolve(_:parse:)`` rebuilds the memo to exactly the current key set on
+/// every call, so entries for deleted or superseded rows are dropped — the
+/// memo cannot grow unbounded across the app's lifetime.
+nonisolated struct ScenarioRowMetadataCache {
+  private var memo: [Key: ScenarioRowMetadata] = [:]
+
+  private struct Key: Hashable {
+    let id: String
+    let updatedAt: Date
+  }
+
+  init() {}
+
+  /// Resolves metadata for `records`, reusing memoized parses for unchanged
+  /// `(id, updatedAt)` keys and rebuilding the memo to exactly the current key
+  /// set (stale entries dropped).
+  ///
+  /// - Parameters:
+  ///   - records: the rows to resolve, **after** ADR-010 D6 variant collapsing
+  ///     — never the pre-collapse variant set, so the returned keys stay a
+  ///     subset of the displayed row ids.
+  ///   - parse: invoked only on a cache miss. Injected so the heavy
+  ///     ``ScenarioLoader`` call (and, in tests, a miss counter) stays under
+  ///     the caller's control.
+  /// - Returns: row metadata keyed by ``ScenarioRecord/id``.
+  mutating func resolve(
+    _ records: [ScenarioRecord],
+    parse: (ScenarioRecord) -> ScenarioRowMetadata
+  ) -> [String: ScenarioRowMetadata] {
+    var rebuilt: [Key: ScenarioRowMetadata] = [:]
+    var result: [String: ScenarioRowMetadata] = [:]
+    for record in records {
+      let key = Key(id: record.id, updatedAt: record.updatedAt)
+      let meta = memo[key] ?? parse(record)
+      rebuilt[key] = meta
+      result[record.id] = meta
+    }
+    memo = rebuilt
+    return result
+  }
+}

--- a/Pastura/Pastura/Data/SimulationRepository.swift
+++ b/Pastura/Pastura/Data/SimulationRepository.swift
@@ -19,6 +19,13 @@ nonisolated public protocol SimulationRepository: Sendable {
   /// Ordered newest-first.
   func fetchOrphaned() throws -> [SimulationRecord]
 
+  /// Fetches all simulations with the given status, ordered newest-first.
+  ///
+  /// Used by the Home redesign's resume-from-paused surface (ADR-016 P3),
+  /// which queries `.paused` runs; the P3 resume logic itself is not wired
+  /// here.
+  func fetchByStatus(_ status: SimulationStatus) throws -> [SimulationRecord]
+
   /// Updates state-related fields (stateJSON, currentRound, currentPhaseIndex)
   /// without touching other columns. Used for pause/resume.
   ///
@@ -94,6 +101,15 @@ nonisolated public final class GRDBSimulationRepository: SimulationRepository, S
       // `== nil` compiles to `IS NULL` in GRDB.
       try SimulationRecord
         .filter(Column("scenarioId") == nil)
+        .order(Column("createdAt").desc)
+        .fetchAll(db)
+    }
+  }
+
+  public func fetchByStatus(_ status: SimulationStatus) throws -> [SimulationRecord] {
+    try dbWriter.read { db in
+      try SimulationRecord
+        .filter(Column("status") == status.rawValue)
         .order(Column("createdAt").desc)
         .fetchAll(db)
     }

--- a/Pastura/Pastura/Data/SimulationRepository.swift
+++ b/Pastura/Pastura/Data/SimulationRepository.swift
@@ -26,6 +26,18 @@ nonisolated public protocol SimulationRepository: Sendable {
   /// here.
   func fetchByStatus(_ status: SimulationStatus) throws -> [SimulationRecord]
 
+  /// Returns the number of **completed** runs per scenario, keyed by the
+  /// run's `scenarioId`, computed as a `GROUP BY` aggregate (not a
+  /// fetch-all-then-count). Orphaned runs (`scenarioId IS NULL`, the
+  /// `ON DELETE SET NULL` outcome since v7) are excluded — a null key is
+  /// meaningless for a per-scenario count.
+  ///
+  /// Powers the Home row "観察回数" (ADR-016). The App layer aggregates the
+  /// returned per-variant counts across ADR-010 D6 language variants by
+  /// `sourceId`, so this method intentionally keys by the concrete variant's
+  /// `scenarioId` and leaves the cross-variant rollup to the consumer.
+  func completedRunCountsByScenarioId() throws -> [String: Int]
+
   /// Updates state-related fields (stateJSON, currentRound, currentPhaseIndex)
   /// without touching other columns. Used for pause/resume.
   ///
@@ -112,6 +124,29 @@ nonisolated public final class GRDBSimulationRepository: SimulationRepository, S
         .filter(Column("status") == status.rawValue)
         .order(Column("createdAt").desc)
         .fetchAll(db)
+    }
+  }
+
+  public func completedRunCountsByScenarioId() throws -> [String: Int] {
+    try dbWriter.read { db in
+      // GROUP BY aggregate so the count is computed SQL-side. `scenarioId IS
+      // NOT NULL` drops orphaned runs; a null group key can't map onto a row.
+      let rows = try Row.fetchAll(
+        db,
+        sql: """
+          SELECT scenarioId, COUNT(*) AS cnt
+          FROM simulations
+          WHERE status = ? AND scenarioId IS NOT NULL
+          GROUP BY scenarioId
+          """,
+        arguments: [SimulationStatus.completed.rawValue])
+      var result: [String: Int] = [:]
+      for row in rows {
+        // scenarioId is non-null by the WHERE clause; skip defensively if not.
+        guard let scenarioId: String = row["scenarioId"] else { continue }
+        result[scenarioId] = row["cnt"]
+      }
+      return result
     }
   }
 

--- a/Pastura/Pastura/Views/Components/SheepAvatar.swift
+++ b/Pastura/Pastura/Views/Components/SheepAvatar.swift
@@ -26,6 +26,14 @@ public struct SheepAvatar: View {
   public let character: Character
   public var size: CGFloat = 48
 
+  /// Compact avatar size for dense list rows — the Home scenario list
+  /// renders `agentCount` avatars at this size next to the round count
+  /// (ADR-016 D3 row layout; the consuming View lands in P2). Named so the
+  /// row-density intent is explicit at the call site rather than a bare
+  /// `size: 18` magic number. `Canvas` geometry scales by `size / 28`, so no
+  /// dedicated small-size drawing path is needed at this size.
+  public static let rowSize: CGFloat = 18
+
   /// Top of the visible sheep silhouette expressed as a fraction of
   /// `size`. The outer wool-body circle has center `y = 15` and
   /// radius `8` in the 28-unit viewBox (see ``body``), so the topmost
@@ -269,6 +277,10 @@ extension SheepAvatar.Character {
 
 #Preview("Multiple sizes") {
   HStack(spacing: 20) {
+    VStack(spacing: 4) {
+      SheepAvatar(character: .alice, size: SheepAvatar.rowSize)
+      Text("row (18)").textStyle(Typography.captionName).foregroundStyle(Color.muted)
+    }
     VStack(spacing: 4) {
       SheepAvatar(character: .alice, size: 32)
       Text("32").textStyle(Typography.captionName).foregroundStyle(Color.muted)

--- a/Pastura/Pastura/Views/Home/HomeView.swift
+++ b/Pastura/Pastura/Views/Home/HomeView.swift
@@ -68,7 +68,9 @@ struct HomeView: View {
       // shows first and badges pop in a frame later. Guard prevents
       // re-creation under `.task` re-fire.
       guard viewModel == nil else { return }
-      let newViewModel = HomeViewModel(repository: dependencies.scenarioRepository)
+      let newViewModel = HomeViewModel(
+        repository: dependencies.scenarioRepository,
+        simulationRepository: dependencies.simulationRepository)
       await newViewModel.loadScenarios()
       await newViewModel.refreshGalleryUpdateBadges(using: dependencies.galleryService)
       viewModel = newViewModel

--- a/Pastura/PasturaTests/App/HomeViewModelTests.swift
+++ b/Pastura/PasturaTests/App/HomeViewModelTests.swift
@@ -255,4 +255,101 @@ struct HomeViewModelTests {
     #expect(Set(viewModel.rowMetadata.keys).isSubset(of: displayedIds))
     #expect(viewModel.presets.count == 1)
   }
+
+  // MARK: - Observation count (completed runs, cross-variant aggregated)
+
+  private func completedRun(id: String, scenarioId: String) -> SimulationRecord {
+    SimulationRecord(
+      id: id, scenarioId: scenarioId,
+      status: SimulationStatus.completed.rawValue,
+      currentRound: 0, currentPhaseIndex: 0,
+      stateJSON: "{}", configJSON: nil,
+      createdAt: Date(), updatedAt: Date())
+  }
+
+  /// Completed runs against *different* language variants of one canonical
+  /// scenario aggregate onto the single displayed row (ADR-010 D4 intent):
+  /// 2 runs on the JA variant + 1 on the EN variant → 3 on the displayed row.
+  /// A `.paused` run does not count.
+  @Test func observationCountsAggregateCompletedRunsAcrossVariants() async throws {
+    let db = try DatabaseManager.inMemory()
+    let scenarioRepo = GRDBScenarioRepository(dbWriter: db.dbWriter)
+    let simRepo = GRDBSimulationRepository(dbWriter: db.dbWriter)
+    try scenarioRepo.save(makePreset(id: "word_wolf", language: "ja", sourceId: "word_wolf"))
+    try scenarioRepo.save(makePreset(id: "word_wolf_en", language: "en", sourceId: "word_wolf"))
+
+    try simRepo.save(completedRun(id: "r1", scenarioId: "word_wolf"))
+    try simRepo.save(completedRun(id: "r2", scenarioId: "word_wolf"))
+    try simRepo.save(completedRun(id: "r3", scenarioId: "word_wolf_en"))
+    // A paused run on the same scenario must be excluded.
+    try simRepo.save(
+      SimulationRecord(
+        id: "p1", scenarioId: "word_wolf",
+        status: SimulationStatus.paused.rawValue,
+        currentRound: 0, currentPhaseIndex: 0,
+        stateJSON: "{}", configJSON: nil,
+        createdAt: Date(), updatedAt: Date()))
+
+    let viewModel = HomeViewModel(repository: scenarioRepo, simulationRepository: simRepo)
+    await viewModel.loadScenarios()
+
+    let displayed = try #require(viewModel.presets.first)
+    #expect(viewModel.presets.count == 1)
+    #expect(viewModel.observationCounts[displayed.id] == 3)
+  }
+
+  /// A displayed row with no completed runs reports an explicit 0 (so the
+  /// View can read the dictionary uniformly).
+  @Test func observationCountsReportZeroForRowWithNoRuns() async throws {
+    let db = try DatabaseManager.inMemory()
+    let scenarioRepo = GRDBScenarioRepository(dbWriter: db.dbWriter)
+    let simRepo = GRDBSimulationRepository(dbWriter: db.dbWriter)
+    try scenarioRepo.save(
+      ScenarioRecord(
+        id: "lonely", name: "Lonely", yamlDefinition: "",
+        isPreset: false, createdAt: Date(), updatedAt: Date()))
+
+    let viewModel = HomeViewModel(repository: scenarioRepo, simulationRepository: simRepo)
+    await viewModel.loadScenarios()
+
+    #expect(viewModel.observationCounts["lonely"] == 0)
+  }
+
+  /// Without an injected `SimulationRepository`, observation counts stay empty
+  /// rather than failing the load (back-compat for fixture tests).
+  @Test func observationCountsEmptyWithoutSimulationRepository() async throws {
+    let db = try DatabaseManager.inMemory()
+    let repo = GRDBScenarioRepository(dbWriter: db.dbWriter)
+    try repo.save(
+      ScenarioRecord(
+        id: "u1", name: "U1", yamlDefinition: "",
+        isPreset: false, createdAt: Date(), updatedAt: Date()))
+
+    let viewModel = HomeViewModel(repository: repo)
+    await viewModel.loadScenarios()
+
+    #expect(viewModel.observationCounts.isEmpty)
+    #expect(viewModel.errorMessage == nil)
+  }
+
+  /// Pure-function check of the aggregation: per-variant counts roll up to the
+  /// canonical key and project onto the displayed row.
+  @Test func aggregateObservationCountsSumsByCanonicalKey() {
+    let ja = makePreset(id: "ww_ja", language: "ja", sourceId: "ww")
+    let en = makePreset(id: "ww_en", language: "en", sourceId: "ww")
+    let solo = ScenarioRecord(
+      id: "solo", name: "Solo", yamlDefinition: "",
+      isPreset: false, createdAt: Date(), updatedAt: Date())
+
+    let result = HomeViewModel.aggregateObservationCounts(
+      completedByScenarioId: ["ww_ja": 2, "ww_en": 1, "solo": 4, "ghost": 9],
+      scenarios: [ja, en, solo],
+      displayedRows: [ja, solo])
+
+    // `ja` is the displayed variant; its count includes the EN sibling's run.
+    #expect(result["ww_ja"] == 3)
+    #expect(result["solo"] == 4)
+    // `ghost` has no scenario record → contributes to nothing.
+    #expect(result.count == 2)
+  }
 }

--- a/Pastura/PasturaTests/App/HomeViewModelTests.swift
+++ b/Pastura/PasturaTests/App/HomeViewModelTests.swift
@@ -159,4 +159,100 @@ struct HomeViewModelTests {
     #expect(resolved.count == 1)
     #expect(resolved.first?.id == "broken")
   }
+
+  // MARK: - Row metadata (parse cache + name-only degradation)
+
+  /// A complete, schema-valid scenario YAML. Used so the heavy
+  /// `ScenarioLoader.load` path resolves agentCount / rounds / description.
+  private static func validYAML(
+    id: String, name: String, agents: Int = 2, rounds: Int = 3
+  ) -> String {
+    """
+    id: \(id)
+    language: ja
+    name: \(name)
+    description: A test scenario
+    agents: \(agents)
+    rounds: \(rounds)
+    context: You are in a game.
+    personas:
+      - name: Alice
+        description: A strategist
+      - name: Bob
+        description: An optimist
+    phases:
+      - type: speak_all
+        prompt: "Speak your mind."
+        output:
+          statement: string
+    """
+  }
+
+  @Test func rowMetadataExposesParsedMetaForValidYaml() async throws {
+    let db = try DatabaseManager.inMemory()
+    let repo = GRDBScenarioRepository(dbWriter: db.dbWriter)
+    try repo.save(
+      ScenarioRecord(
+        id: "valid", name: "Valid",
+        yamlDefinition: Self.validYAML(id: "valid", name: "Valid", agents: 2, rounds: 5),
+        isPreset: false, createdAt: Date(), updatedAt: Date()))
+
+    let viewModel = HomeViewModel(repository: repo)
+    await viewModel.loadScenarios()
+
+    let meta = viewModel.rowMetadata["valid"]
+    #expect(meta?.name == "Valid")
+    #expect(meta?.agentCount == 2)
+    #expect(meta?.rounds == 5)
+    #expect(meta?.description == "A test scenario")
+    #expect(viewModel.errorMessage == nil)
+  }
+
+  /// Name-only degradation contract. The YAML parses for the light
+  /// `language` key (so the row survives D6 selection) but throws in the
+  /// heavy `ScenarioLoader.load` (missing required `personas`). The row must
+  /// stay visible with name-only metadata, and `errorMessage` must stay nil —
+  /// the second assertion is the load-bearing regression guard.
+  @Test func rowMetadataDegradesToNameOnlyForBrokenYamlWithoutSettingError() async throws {
+    let db = try DatabaseManager.inMemory()
+    let repo = GRDBScenarioRepository(dbWriter: db.dbWriter)
+    // Valid top-level `language`, but no `personas`/`agents` → load() throws.
+    let brokenYAML = "id: broken\nlanguage: ja\nname: Broken\n"
+    try repo.save(
+      ScenarioRecord(
+        id: "broken", name: "Broken", yamlDefinition: brokenYAML,
+        isPreset: false, createdAt: Date(), updatedAt: Date()))
+
+    let viewModel = HomeViewModel(repository: repo)
+    await viewModel.loadScenarios()
+
+    // Row stays visible.
+    #expect(viewModel.userScenarios.contains { $0.id == "broken" })
+    // Metadata degrades to name-only.
+    let meta = viewModel.rowMetadata["broken"]
+    #expect(meta?.name == "Broken")
+    #expect(meta?.agentCount == nil)
+    #expect(meta?.rounds == nil)
+    #expect(meta?.description == nil)
+    // One broken row never blanks the whole list.
+    #expect(viewModel.errorMessage == nil)
+  }
+
+  /// D6 non-interference: metadata is resolved on the collapsed row set, so
+  /// its keys are a subset of the displayed (preset + user) row ids — never
+  /// the pre-collapse variant ids.
+  @Test func rowMetadataKeysAreSubsetOfDisplayedRows() async throws {
+    let db = try DatabaseManager.inMemory()
+    let repo = GRDBScenarioRepository(dbWriter: db.dbWriter)
+    // Two variants of one canonical scenario — D6 collapses to one row.
+    try repo.save(makePreset(id: "word_wolf", language: "ja", sourceId: "word_wolf"))
+    try repo.save(makePreset(id: "word_wolf_en", language: "en", sourceId: "word_wolf"))
+
+    let viewModel = HomeViewModel(repository: repo)
+    await viewModel.loadScenarios()
+
+    let displayedIds = Set(viewModel.presets.map(\.id) + viewModel.userScenarios.map(\.id))
+    #expect(Set(viewModel.rowMetadata.keys).isSubset(of: displayedIds))
+    #expect(viewModel.presets.count == 1)
+  }
 }

--- a/Pastura/PasturaTests/App/ScenarioRowMetadataCacheTests.swift
+++ b/Pastura/PasturaTests/App/ScenarioRowMetadataCacheTests.swift
@@ -43,8 +43,8 @@ struct ScenarioRowMetadataCacheTests {
 
   @Test func bumpedUpdatedAtForcesReparse() {
     var cache = ScenarioRowMetadataCache()
-    let t1 = Date(timeIntervalSince1970: 1000)
-    let t2 = Date(timeIntervalSince1970: 2000)
+    let earlier = Date(timeIntervalSince1970: 1000)
+    let later = Date(timeIntervalSince1970: 2000)
     var parseCount = 0
     let parse: (ScenarioRecord) -> ScenarioRowMetadata = {
       parseCount += 1
@@ -53,13 +53,13 @@ struct ScenarioRowMetadataCacheTests {
       return ScenarioRowMetadata(name: $0.name, rounds: Int($0.updatedAt.timeIntervalSince1970))
     }
 
-    let first = cache.resolve([record(id: "a", name: "A", updatedAt: t1)], parse: parse)
+    let first = cache.resolve([record(id: "a", name: "A", updatedAt: earlier)], parse: parse)
     #expect(first["a"]?.rounds == 1000)
     #expect(parseCount == 1)
 
     // updatedAt bump (e.g. a gallery update) invalidates the entry → re-parse,
     // and the result reflects the NEW value rather than the stale one.
-    let second = cache.resolve([record(id: "a", name: "A", updatedAt: t2)], parse: parse)
+    let second = cache.resolve([record(id: "a", name: "A", updatedAt: later)], parse: parse)
     #expect(second["a"]?.rounds == 2000)
     #expect(parseCount == 2)
   }

--- a/Pastura/PasturaTests/App/ScenarioRowMetadataCacheTests.swift
+++ b/Pastura/PasturaTests/App/ScenarioRowMetadataCacheTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+@Suite(.timeLimit(.minutes(1)))
+struct ScenarioRowMetadataCacheTests {
+  private func record(id: String, name: String, updatedAt: Date) -> ScenarioRecord {
+    ScenarioRecord(
+      id: id, name: name, yamlDefinition: "",
+      isPreset: true, createdAt: Date(), updatedAt: updatedAt)
+  }
+
+  @Test func resolvesEveryRecordKeyedById() {
+    var cache = ScenarioRowMetadataCache()
+    let now = Date()
+    let records = [
+      record(id: "a", name: "A", updatedAt: now),
+      record(id: "b", name: "B", updatedAt: now)
+    ]
+    let result = cache.resolve(records) { ScenarioRowMetadata(name: $0.name, agentCount: 2) }
+    #expect(Set(result.keys) == ["a", "b"])
+    #expect(result["a"]?.agentCount == 2)
+  }
+
+  @Test func reusesParseForUnchangedUpdatedAt() {
+    var cache = ScenarioRowMetadataCache()
+    let now = Date()
+    let records = [record(id: "a", name: "A", updatedAt: now)]
+    var parseCount = 0
+    let parse: (ScenarioRecord) -> ScenarioRowMetadata = {
+      parseCount += 1
+      return ScenarioRowMetadata(name: $0.name)
+    }
+
+    _ = cache.resolve(records, parse: parse)
+    #expect(parseCount == 1)
+
+    // Same (id, updatedAt) on a second load reuses the memoized parse.
+    _ = cache.resolve(records, parse: parse)
+    #expect(parseCount == 1)
+  }
+
+  @Test func bumpedUpdatedAtForcesReparse() {
+    var cache = ScenarioRowMetadataCache()
+    let t1 = Date(timeIntervalSince1970: 1000)
+    let t2 = Date(timeIntervalSince1970: 2000)
+    var parseCount = 0
+    let parse: (ScenarioRecord) -> ScenarioRowMetadata = {
+      parseCount += 1
+      // Echo the round count off updatedAt so a stale (id-only) cache would
+      // surface the wrong value, not just the wrong count.
+      return ScenarioRowMetadata(name: $0.name, rounds: Int($0.updatedAt.timeIntervalSince1970))
+    }
+
+    let first = cache.resolve([record(id: "a", name: "A", updatedAt: t1)], parse: parse)
+    #expect(first["a"]?.rounds == 1000)
+    #expect(parseCount == 1)
+
+    // updatedAt bump (e.g. a gallery update) invalidates the entry → re-parse,
+    // and the result reflects the NEW value rather than the stale one.
+    let second = cache.resolve([record(id: "a", name: "A", updatedAt: t2)], parse: parse)
+    #expect(second["a"]?.rounds == 2000)
+    #expect(parseCount == 2)
+  }
+
+  @Test func rebuildsToCurrentKeySetDroppingStaleEntries() {
+    var cache = ScenarioRowMetadataCache()
+    let now = Date()
+    var parseCount = 0
+    let parse: (ScenarioRecord) -> ScenarioRowMetadata = {
+      parseCount += 1
+      return ScenarioRowMetadata(name: $0.name)
+    }
+
+    _ = cache.resolve([record(id: "a", name: "A", updatedAt: now)], parse: parse)
+    #expect(parseCount == 1)
+
+    // "a" disappears (deleted) and "b" appears. The memo is rebuilt to the
+    // current key set, so a later reload of "a" must re-parse (its stale
+    // entry was dropped) — proving the memo doesn't grow unbounded.
+    _ = cache.resolve([record(id: "b", name: "B", updatedAt: now)], parse: parse)
+    #expect(parseCount == 2)
+
+    _ = cache.resolve([record(id: "a", name: "A", updatedAt: now)], parse: parse)
+    #expect(parseCount == 3)
+  }
+}

--- a/Pastura/PasturaTests/Data/SimulationRepositoryTests.swift
+++ b/Pastura/PasturaTests/Data/SimulationRepositoryTests.swift
@@ -71,6 +71,34 @@ import Testing
     #expect(results.isEmpty)
   }
 
+  @Test func fetchByStatusReturnsOnlyMatchingStatus() throws {
+    let (_, simRepo) = try makeRepos()
+    try simRepo.save(makeSimRecord(id: "run1", status: .running))
+    try simRepo.save(makeSimRecord(id: "paused1", status: .paused))
+    try simRepo.save(makeSimRecord(id: "done1", status: .completed))
+
+    let paused = try simRepo.fetchByStatus(.paused)
+    #expect(paused.map(\.id) == ["paused1"])
+    #expect(paused.first?.simulationStatus == .paused)
+  }
+
+  @Test func fetchByStatusReturnsEmptyWhenNoneMatch() throws {
+    let (_, simRepo) = try makeRepos()
+    try simRepo.save(makeSimRecord(id: "run1", status: .running))
+    #expect(try simRepo.fetchByStatus(.paused).isEmpty)
+  }
+
+  @Test func fetchByStatusOrdersNewestFirst() throws {
+    let (_, simRepo) = try makeRepos()
+    // Distinct createdAt so the desc ordering is observable.
+    for (id, offset) in [("old", 0.0), ("mid", 100.0), ("new", 200.0)] {
+      var record = makeSimRecord(id: id, status: .paused)
+      record.createdAt = Date(timeIntervalSince1970: offset)
+      try simRepo.save(record)
+    }
+    #expect(try simRepo.fetchByStatus(.paused).map(\.id) == ["new", "mid", "old"])
+  }
+
   @Test func fetchOrphanedReturnsOnlyRunsWhoseScenarioWasDeleted() throws {
     let (scenarioRepo, simRepo) = try makeRepos()
     try scenarioRepo.save(

--- a/Pastura/PasturaTests/Data/SimulationRepositoryTests.swift
+++ b/Pastura/PasturaTests/Data/SimulationRepositoryTests.swift
@@ -99,6 +99,43 @@ import Testing
     #expect(try simRepo.fetchByStatus(.paused).map(\.id) == ["new", "mid", "old"])
   }
 
+  @Test func completedRunCountsGroupByScenarioExcludingPausedAndOrphaned() throws {
+    let (scenarioRepo, simRepo) = try makeRepos()  // seeds s1
+    try scenarioRepo.save(
+      ScenarioRecord(
+        id: "s2", name: "Two", yamlDefinition: "yaml",
+        isPreset: false, createdAt: Date(), updatedAt: Date()))
+    try scenarioRepo.save(
+      ScenarioRecord(
+        id: "s3", name: "Three", yamlDefinition: "yaml",
+        isPreset: false, createdAt: Date(), updatedAt: Date()))
+
+    // s1: 2 completed + 1 paused (paused must be excluded).
+    try simRepo.save(makeSimRecord(id: "c1", status: .completed))
+    try simRepo.save(makeSimRecord(id: "c2", status: .completed))
+    try simRepo.save(makeSimRecord(id: "p1", status: .paused))
+    // s2: 1 completed.
+    var s2Run = makeSimRecord(id: "c3", status: .completed)
+    s2Run.scenarioId = "s2"
+    try simRepo.save(s2Run)
+    // s3: 1 completed, then s3 deleted → run orphaned (scenarioId NULL),
+    // which must be excluded from the per-scenario count.
+    var orphan = makeSimRecord(id: "orph", status: .completed)
+    orphan.scenarioId = "s3"
+    try simRepo.save(orphan)
+    try scenarioRepo.delete("s3")
+
+    let counts = try simRepo.completedRunCountsByScenarioId()
+    #expect(counts == ["s1": 2, "s2": 1])
+  }
+
+  @Test func completedRunCountsEmptyWhenNoCompletedRuns() throws {
+    let (_, simRepo) = try makeRepos()
+    try simRepo.save(makeSimRecord(id: "run1", status: .running))
+    try simRepo.save(makeSimRecord(id: "paused1", status: .paused))
+    #expect(try simRepo.completedRunCountsByScenarioId().isEmpty)
+  }
+
   @Test func fetchOrphanedReturnsOnlyRunsWhoseScenarioWasDeleted() throws {
     let (scenarioRepo, simRepo) = try makeRepos()
     try scenarioRepo.save(


### PR DESCRIPTION
## Summary
Home redesign **P0** (ADR-016 §4) — the only phase independently mergeable to
`main`. Data-layer prep only; **no navigation changes** (Route enum /
TabCoordinator / deep-link routing are P1).

- **Row metadata parse cache + name-only degradation** — resolve per-row
  `agentCount`/`rounds`/`description` via `ScenarioLoader`, memoized by
  `id`+`updatedAt` (rebuilt every load, no persistence, not keyed by
  `sourceId` → no ADR-010 D6 desync). A broken-YAML row degrades to
  name-only and never sets `errorMessage`.
- **`SimulationRepository.fetchByStatus(_:)`** — newest-first status fetch
  (P3 resume dependency; add-only, not wired).
- **Observation count** — `completedRunCountsByScenarioId()` GROUP BY SQL
  aggregate (excludes orphaned / non-completed runs); `HomeViewModel` rolls
  per-variant counts up to the canonical `sourceId` (ADR-010 D4 cross-variant).
- **`SheepAvatar.rowSize` (18 pt)** — named constant for dense Home rows.

## Test plan
- New: `ScenarioRowMetadataCacheTests` (reuse / eviction / updatedAt-bump),
  `HomeViewModelTests` (valid meta, name-only + `errorMessage == nil`, D6
  key-subset, cross-variant counts), `SimulationRepositoryTests`
  (`fetchByStatus`, GROUP BY count with paused / orphan exclusion).
- Full unit suite green (1878 tests); `swiftlint --strict` clean.
- code-reviewer (Opus): PASS.

Closes #604.

🤖 Generated with [Claude Code](https://claude.com/claude-code)