### PR TITLE
📝 docs: promote grammar-structure-only rule to engine.md (#599 follow-up)

### DIFF
--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -272,7 +272,7 @@ llama.cpp is the active TestFlight backend; the LiteRT-LM migration
 trigger has fired and evaluation is in progress (ADR-002 §8, #496) —
 revisit this section if/when `LlamaCppService` is replaced.
 
-Four trap classes from prior incidents. The first three share a crash
+Five trap classes from prior incidents. The first four share a crash
 signature (`Unexpected empty grammar stack` → SIGABRT) but have
 **different root causes and different fixes** — diagnose before fixing.
 
@@ -328,6 +328,27 @@ and the next `llama_sampler_sample` hits `GGML_ASSERT(!stacks.empty())`
 grammar mode, split the chain into two samplers, or build a
 `common_sampler_accept`-style per-component wrapper that excludes the
 grammar. (PR #480 commit eb26153, reverted in 4ffaf6f; ADR-011.)
+
+### Grammar must not enumerate values — structure only
+
+`GBNFGrammarBuilder` constrains JSON **structure** (object shape, keys,
+the shared `string` value production) but MUST NOT emit value
+enumerations (option / candidate literals) into the grammar. CJK /
+multi-byte / dynamic literal values crash llama.cpp's sampler at
+accept-time (the `Unexpected empty grammar stack` class above; ADR-002
+§12.9), and the trigger is the model's BPE tokenizer — so it is
+**per-model**: a char-class guard that passes for Gemma 4 E2B is
+unverified for any other runtime-selectable model or LiteRT-LM. There is
+no model-agnostic "safe enumeration" predicate (one — `isSafeEnumerationOption`
+— was tried and removed in #597).
+
+Constrain closed-set values at **runtime** instead: `choose` → `options[0]`
+fallback in `ChooseHandler.validateAction`; `vote` → tally drop in
+`VoteHandler`. `OutputSchema.Kind.choice` is a payload-free marker so
+option strings never reach a grammar literal. Vote dropped grammar
+enumeration in #597; choose in #599 (ADR-002 §Amendment 2026-06-14).
+Residual: CJK field **names** still emit as JSON-key literals, same
+mechanism (#607).
 
 ### iOS Simulator cannot run quantized inference
 

--- a/docs/decisions/ADR-002.md
+++ b/docs/decisions/ADR-002.md
@@ -990,12 +990,14 @@ through the `llama_log_set` callback that wires into iOS `os_log`. The
 stderr-capture diagnostic in `LlamaCppService+Sampler.swift`
 (`initGrammarCapturingStderr`) was added to recover this lost detail.
 
-**Resolution.** A `sanitizeRuleName(_:)` helper in
-`GBNFGrammarBuilder` maps `_` → `-` at every rule-name emit point
-(`valueRuleName`, `enumerationRule`). Field names retain their
+**Resolution (historical — `sanitizeRuleName` / `enumerationRule` were
+removed in #599; see the Superseded banner above).** A `sanitizeRuleName(_:)`
+helper in `GBNFGrammarBuilder` mapped `_` → `-` at every rule-name emit
+point (`valueRuleName` — which survives but no longer sanitizes — and the
+now-removed `enumerationRule`). Field names retained their
 snake_case form for **JSON keys** (which appear inside GBNF string
 literals where any UTF-8 byte is valid via `[^"\\]` — see §12.4),
-but **rule references** that derive from a field name pass through
+but **rule references** that derived from a field name passed through
 the sanitizer.
 
 **Validator vs sanitizer roles** (load-bearing distinction):
@@ -1005,11 +1007,11 @@ the sanitizer.
   letter; subsequent chars may be letter / digit / `_`. Leading `_`
   and `-` are rejected as Shared Scenarios defense (see below). This is
   a caller-side convention, not a GBNF rule.
-- `sanitizeRuleName` performs **only** the `_` → `-` mapping at
-  emit time so the resulting GBNF identifier satisfies llama.cpp's
+- `sanitizeRuleName` performed **only** the `_` → `-` mapping at
+  emit time so the resulting GBNF identifier satisfied llama.cpp's
   `is_word_char` (`[a-zA-Z0-9-]` per `llama-grammar.cpp:98`). The
-  leading-letter requirement is enforced by the validator, not by
-  the sanitizer — the sanitizer is purely a translator.
+  leading-letter requirement was enforced by the validator, not by
+  the sanitizer — the sanitizer was purely a translator.
 
 Without this split, tightening the validator to GBNF shape (banning
 `_` everywhere) would reject Pastura's existing `inner_thought` /


### PR DESCRIPTION
## Summary
Knowledge promotion (memory → `.claude/rules/`) of the principle established by
#599 / PR #606, per `knowledge-layering.md`.

- **`.claude/rules/engine.md`** — adds a 5th entry to the llama.cpp grammar-trap
  catalog: **"Grammar must not enumerate values — structure only."** The builder
  constrains JSON structure (shape, keys, shared `string` production) but must not
  emit value literals; CJK/dynamic literals crash the sampler at accept-time
  (empty-grammar-stack class), and the trigger is per-model BPE tokenization so no
  char-class guard is model-agnostically safe → constrain closed-set values at
  runtime (`choose` → `options[0]`, `vote` → tally drop). Placed before the
  simulator entry (shares the empty-grammar-stack signature); intro count
  Four → Five, first three → first four.
- **`docs/decisions/ADR-002.md`** — minimal past-tense flip of §12.8's now-historical
  `sanitizeRuleName` "Resolution" prose under its existing Superseded banner
  (`validateFieldName` left present-tense — still in code).

Path-scoped (engine.md loads on Engine/LLM edits), so the rule fires for exactly the
audience that could re-introduce value-enumeration.

## Test plan
- Docs-only — no code changed. Pre-commit build/lint pass trivially.
- Rule-writing self-check (per `knowledge-layering.md`): `###` heading count = 5
  (new entry is #4, simulator #5); no stale "Four"/"first three" refs; #597 MERGED /
  #599 CLOSED / #607 OPEN all resolve; §Amendment 2026-06-14 exists; no memory
  provenance leaked.
- Pre-impl critic: no Critical (signature-grouping accuracy + mechanism claims
  verified against main). Code review: PASS (Opus, 0 issues).

Closes #610
