### PR TITLE
✨ feat: show vote reason in the THINKING section

### DIFF
--- a/Pastura/Pastura/App/ResultMarkdownExporter.swift
+++ b/Pastura/Pastura/App/ResultMarkdownExporter.swift
@@ -327,10 +327,16 @@ struct ResultMarkdownExporter {  // swiftlint:disable:this type_body_length
     let output = decodeOutput(turn)
     let content = formatOutput(output, phaseType: turn.phaseType)
     var line = String(format: String(localized: "- **%@**: %@"), agent, content)
-    // Include inner_thought as a nested bullet — the gap between outward
-    // behavior and inner reasoning is often the most analyzable signal in a
-    // multi-agent run (e.g. Asch-style conformity).
-    if let thought = output.innerThought, !thought.isEmpty {
+    // Include the phase's private-thought field as a nested bullet — the gap
+    // between outward behavior and inner reasoning is often the most analyzable
+    // signal in a multi-agent run (e.g. Asch-style conformity). For vote turns
+    // this is `reason` (resolved via `secondaryText(for:)`), which the primary
+    // line no longer carries inline (#609); for speak/choose it is
+    // `inner_thought`. Unknown future phase types fall back to `inner_thought`.
+    let thought =
+      PhaseType(rawValue: turn.phaseType).map { output.secondaryText(for: $0) }
+      ?? output.innerThought
+    if let thought, !thought.isEmpty {
       line += String(format: String(localized: "\n  - 💭 _%@_"), thought)
     }
     return line

--- a/Pastura/Pastura/Engine/LLMCaller.swift
+++ b/Pastura/Pastura/Engine/LLMCaller.swift
@@ -354,6 +354,11 @@ nonisolated struct LLMCaller: Sendable {
     emitter: @Sendable (SimulationEvent) -> Void
   ) async throws -> StreamResult {
     var suspendCount = 0
+    // Surface the phase's private-thought field in the live snapshot: vote
+    // streams `reason`, speak/choose stream `inner_thought`. Derived from the
+    // schema so the streaming THINKING section matches the committed-display
+    // resolver (`TurnOutput.secondaryText(for:)`) — see #609.
+    let thoughtKey = schema?.thoughtFieldName ?? PartialOutputExtractor.thoughtKey
     while true {
       var rawText = ""
       var completionTokens: Int?
@@ -362,7 +367,7 @@ nonisolated struct LLMCaller: Sendable {
         for try await chunk in stream {
           if !chunk.delta.isEmpty {
             rawText += chunk.delta
-            let snap = extractor.extract(from: rawText)
+            let snap = extractor.extract(from: rawText, thoughtKey: thoughtKey)
             emitter(
               .agentOutputStream(
                 agent: agentName,

--- a/Pastura/Pastura/LLM/PartialOutputExtractor.swift
+++ b/Pastura/Pastura/LLM/PartialOutputExtractor.swift
@@ -70,7 +70,17 @@ nonisolated public struct PartialOutputExtractor: Sendable {
 
   public init() {}
 
-  public func extract(from text: String) -> PartialSnapshot {
+  /// Extract a best-effort `(primary, thought)` snapshot from a partial
+  /// buffer.
+  ///
+  /// - Parameter thoughtKey: the secondary field to surface as the
+  ///   snapshot's `thought`. Defaults to ``thoughtKey`` (`inner_thought`).
+  ///   ``LLMCaller`` passes the schema-derived key (e.g. `reason` for vote)
+  ///   so the live streaming THINKING section sources the phase's actual
+  ///   private-thought field — see ``OutputSchema/thoughtFieldName`` (#609).
+  public func extract(
+    from text: String, thoughtKey: String = PartialOutputExtractor.thoughtKey
+  ) -> PartialSnapshot {
     let stripped = stripClosedThinkingTags(text)
     if hasUnclosedThinkingTag(stripped) {
       return .empty
@@ -88,7 +98,7 @@ nonisolated public struct PartialOutputExtractor: Sendable {
       }
     }
     let thought = extractTopLevelStringValue(
-      forKey: Self.thoughtKey, in: jsonPart)
+      forKey: thoughtKey, in: jsonPart)
 
     return PartialSnapshot(primary: primary, thought: thought)
   }

--- a/Pastura/Pastura/Models/OutputSchema.swift
+++ b/Pastura/Pastura/Models/OutputSchema.swift
@@ -48,6 +48,23 @@ nonisolated public struct OutputSchema: Codable, Sendable, Equatable {
     "inner_thought", "reason"
   ]
 
+  /// The declared private-thought (secondary) field name for this schema,
+  /// or `nil` if it declares none. Picks the schema's secondary field in
+  /// ``knownSecondaryKeys`` priority order (`inner_thought` before `reason`).
+  /// Real scenarios author exactly one secondary key per phase (speak →
+  /// `inner_thought`, vote → `reason`), so the order only disambiguates the
+  /// degenerate both-present case.
+  ///
+  /// Consumed by ``LLMCaller`` to feed ``PartialOutputExtractor`` the phase's
+  /// thought key, so the live streaming THINKING section surfaces the vote
+  /// `reason` (not only `inner_thought`). Mirrors the committed-display
+  /// resolver ``ScenarioConventions/thoughtField(for:)`` /
+  /// ``TurnOutput/secondaryText(for:)`` for all preset shapes (#609).
+  public var thoughtFieldName: String? {
+    let declared = Set(fields.map(\.name))
+    return Self.knownSecondaryKeys.first { declared.contains($0) }
+  }
+
   public init(fields: [Field]) {
     self.fields = fields
   }

--- a/Pastura/Pastura/Models/ScenarioConventions.swift
+++ b/Pastura/Pastura/Models/ScenarioConventions.swift
@@ -75,4 +75,16 @@ nonisolated public enum ScenarioConventions {
       return nil
     }
   }
+
+  /// Decorates a raw primary value for display. Vote prefixes the `→ ` arrow
+  /// affordance (`→ <voted>`); all other phases return the value unchanged.
+  ///
+  /// Single source of truth for the vote arrow so the live-streaming path
+  /// (``AgentOutputRow`` over a bare ``PartialSnapshot/primary``) and the
+  /// committed / export path (``TurnOutput/primaryText(for:)``) render
+  /// identically. Without this, the arrow was only added at commit time and
+  /// "popped in" after the streamed bare value (#609 device QA).
+  public static func decoratePrimary(_ value: String, for phaseType: PhaseType) -> String {
+    phaseType == .vote ? "→ \(value)" : value
+  }
 }

--- a/Pastura/Pastura/Models/ScenarioConventions.swift
+++ b/Pastura/Pastura/Models/ScenarioConventions.swift
@@ -48,4 +48,31 @@ nonisolated public enum ScenarioConventions {
       return nil
     }
   }
+
+  /// Returns the private-thought (secondary) output field name expected on
+  /// `output:` for the given LLM phase, or `nil` for code phases.
+  ///
+  /// Vote returns `"reason"`; every other LLM phase returns `"inner_thought"`.
+  /// Both fields are display-only private reasoning (never routed into the
+  /// conversation log, so invisible to other agents) — `reason` is simply the
+  /// vote-phase spelling of the same concept (vote schemas author
+  /// `{ vote, reason }`, speak schemas `{ statement, inner_thought }`). This is
+  /// the single source of truth that keeps the THINKING section's content
+  /// source consistent across the committed-display path
+  /// (``TurnOutput/secondaryText(for:)``) and the live streaming path
+  /// (``PartialOutputExtractor`` driven by ``LLMCaller``).
+  ///
+  /// Phase-aware (not a blind `inner_thought` fallback) so a stray `reason` on
+  /// a speak/choose output never leaks into THINKING, and a vote's `reason` is
+  /// never dropped in favour of an `inner_thought` vote schemas don't author.
+  public static func thoughtField(for phaseType: PhaseType) -> String? {
+    switch phaseType {
+    case .vote:
+      return "reason"
+    case .speakAll, .speakEach, .choose:
+      return "inner_thought"
+    case .scoreCalc, .assign, .eliminate, .summarize, .conditional, .eventInject:
+      return nil
+    }
+  }
 }

--- a/Pastura/Pastura/Models/TurnOutput.swift
+++ b/Pastura/Pastura/Models/TurnOutput.swift
@@ -90,17 +90,30 @@ nonisolated public struct TurnOutput: Codable, Sendable, Equatable {
   ///
   /// Speak / choose phases return the value at
   /// ``ScenarioConventions/primaryField(for:)`` (canonical-field lookup).
-  /// `.vote` returns a composite `→ <voted> (<reason>)` string so the
-  /// markdown export and live UI surface the reason inline. Code phases
-  /// have no LLM output and return `nil`.
+  /// `.vote` returns the arrow form `→ <voted>`. The vote `reason` is the
+  /// vote-phase private-thought field and is surfaced via
+  /// ``secondaryText(for:)`` / the THINKING section — NOT appended inline
+  /// here (see #609). Code phases have no LLM output and return `nil`.
   public func primaryText(for phaseType: PhaseType) -> String? {
     if phaseType == .vote {
-      return vote.map { voted in
-        let reasonPart = reason.map { " (\($0))" } ?? ""
-        return "→ \(voted)\(reasonPart)"
-      }
+      return vote.map { "→ \($0)" }
     }
     guard let key = ScenarioConventions.primaryField(for: phaseType) else {
+      return nil
+    }
+    return fields[key]
+  }
+
+  /// Phase-aware extraction of the private-thought (secondary) display text —
+  /// the agent's reasoning shown in the collapsible THINKING section.
+  ///
+  /// Resolves the field name via ``ScenarioConventions/thoughtField(for:)``
+  /// (`reason` for `.vote`, `inner_thought` otherwise), so the vote `reason`
+  /// and the speak/choose `inner_thought` share one display treatment. Both
+  /// are display-only private reasoning, never routed into the conversation
+  /// log (invisible to other agents). Code phases return `nil`.
+  public func secondaryText(for phaseType: PhaseType) -> String? {
+    guard let key = ScenarioConventions.thoughtField(for: phaseType) else {
       return nil
     }
     return fields[key]

--- a/Pastura/Pastura/Models/TurnOutput.swift
+++ b/Pastura/Pastura/Models/TurnOutput.swift
@@ -96,7 +96,7 @@ nonisolated public struct TurnOutput: Codable, Sendable, Equatable {
   /// here (see #609). Code phases have no LLM output and return `nil`.
   public func primaryText(for phaseType: PhaseType) -> String? {
     if phaseType == .vote {
-      return vote.map { "→ \($0)" }
+      return vote.map { ScenarioConventions.decoratePrimary($0, for: .vote) }
     }
     guard let key = ScenarioConventions.primaryField(for: phaseType) else {
       return nil

--- a/Pastura/Pastura/Views/Components/AgentOutputRow.swift
+++ b/Pastura/Pastura/Views/Components/AgentOutputRow.swift
@@ -701,8 +701,16 @@ struct AgentOutputRow: View {
     return output.primaryText(for: phaseType)
   }
 
-  /// Inner thought text, honouring the streaming override when present.
+  /// Private-thought text for the THINKING section, honouring the streaming
+  /// override when present.
+  ///
+  /// Falls back to the phase's private-thought field via
+  /// ``TurnOutput/secondaryText(for:)`` — `reason` for `.vote`,
+  /// `inner_thought` otherwise — so a vote's reason is surfaced in THINKING
+  /// rather than inline (#609). The streaming override already carries the
+  /// phase-appropriate field (``LLMCaller`` feeds the schema-derived thought
+  /// key to ``PartialOutputExtractor``), so live + committed stay consistent.
   private var resolvedThought: String? {
-    streamingThought ?? output.innerThought
+    streamingThought ?? output.secondaryText(for: phaseType)
   }
 }

--- a/Pastura/Pastura/Views/Components/AgentOutputRow.swift
+++ b/Pastura/Pastura/Views/Components/AgentOutputRow.swift
@@ -697,7 +697,12 @@ struct AgentOutputRow: View {
   /// to ``TurnOutput/primaryText(for:)`` — the canonical per-phase
   /// extraction, keyed by ``ScenarioConventions``.
   private var primaryText: String? {
-    if let streamingPrimary { return streamingPrimary }
+    // Decorate the streamed value with the same phase affordance the
+    // committed path applies (vote → `→ <voted>`), so the arrow is present
+    // from the first reveal tick instead of popping in at commit (#609).
+    if let streamingPrimary {
+      return ScenarioConventions.decoratePrimary(streamingPrimary, for: phaseType)
+    }
     return output.primaryText(for: phaseType)
   }
 

--- a/Pastura/PasturaTests/App/ResultMarkdownExporterTests+VoteReason.swift
+++ b/Pastura/PasturaTests/App/ResultMarkdownExporterTests+VoteReason.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+// Sibling-file extension of `ResultMarkdownExporterTests` (keeps the main
+// suite under the 400-line file_length cap). NOT a new `@Suite` — Swift
+// Testing runs suites in parallel, and these tests share the suite's
+// `makeExporter` / `makeTurn` helpers (see `.claude/rules/testing.md`).
+extension ResultMarkdownExporterTests {
+  // #609: the vote `reason` is the vote-phase private-thought field. It
+  // renders in the same 💭 nested bullet as speak's inner_thought (resolved
+  // via `TurnOutput.secondaryText(for:)`), NOT inline in the primary line.
+  @Test func rendersVoteReasonAsNestedThought() throws {
+    let exporter = makeExporter()
+    let turn = makeTurn(
+      round: 1, seq: 1, phase: "vote",
+      agent: "Alice", fields: ["vote": "Bob", "reason": "Bob is bluffing"])
+    let input = ResultMarkdownExporter.Input(
+      simulation: makeSimulation(),
+      scenario: makeScenario(),
+      turns: [turn],
+      state: makeState())
+
+    let result = try exporter.export(input)
+
+    // Primary line carries the bare arrow form — reason is NOT inline.
+    #expect(result.text.contains("- **Alice**: → Bob"))
+    #expect(!result.text.contains("→ Bob (Bob is bluffing)"))
+    // Reason appears as the 💭 thought bullet.
+    #expect(result.text.contains("  - 💭 _Bob is bluffing_"))
+  }
+}

--- a/Pastura/PasturaTests/App/ResultMarkdownExporterTests.swift
+++ b/Pastura/PasturaTests/App/ResultMarkdownExporterTests.swift
@@ -188,29 +188,6 @@ import Testing
     #expect(result.text.contains("- **Alice**: → Bob"))
   }
 
-  // #609: the vote `reason` is the vote-phase private-thought field. It
-  // renders in the same 💭 nested bullet as speak's inner_thought (resolved
-  // via TurnOutput.secondaryText(for:)), NOT inline in the primary line.
-  @Test func rendersVoteReasonAsNestedThought() throws {
-    let exporter = makeExporter()
-    let turn = makeTurn(
-      round: 1, seq: 1, phase: "vote",
-      agent: "Alice", fields: ["vote": "Bob", "reason": "Bob is bluffing"])
-    let input = ResultMarkdownExporter.Input(
-      simulation: makeSimulation(),
-      scenario: makeScenario(),
-      turns: [turn],
-      state: makeState())
-
-    let result = try exporter.export(input)
-
-    // Primary line carries the bare arrow form — reason is NOT inline.
-    #expect(result.text.contains("- **Alice**: → Bob"))
-    #expect(!result.text.contains("→ Bob (Bob is bluffing)"))
-    // Reason appears as the 💭 thought bullet.
-    #expect(result.text.contains("  - 💭 _Bob is bluffing_"))
-  }
-
   @Test func appliesContentFilterToRenderedMarkdown() throws {
     // Applies to everything — including persona names in YAML and turn output.
     let filter = ContentFilter(blockedPatterns: ["死ね"], replacement: "***")

--- a/Pastura/PasturaTests/App/ResultMarkdownExporterTests.swift
+++ b/Pastura/PasturaTests/App/ResultMarkdownExporterTests.swift
@@ -188,6 +188,29 @@ import Testing
     #expect(result.text.contains("- **Alice**: → Bob"))
   }
 
+  // #609: the vote `reason` is the vote-phase private-thought field. It
+  // renders in the same 💭 nested bullet as speak's inner_thought (resolved
+  // via TurnOutput.secondaryText(for:)), NOT inline in the primary line.
+  @Test func rendersVoteReasonAsNestedThought() throws {
+    let exporter = makeExporter()
+    let turn = makeTurn(
+      round: 1, seq: 1, phase: "vote",
+      agent: "Alice", fields: ["vote": "Bob", "reason": "Bob is bluffing"])
+    let input = ResultMarkdownExporter.Input(
+      simulation: makeSimulation(),
+      scenario: makeScenario(),
+      turns: [turn],
+      state: makeState())
+
+    let result = try exporter.export(input)
+
+    // Primary line carries the bare arrow form — reason is NOT inline.
+    #expect(result.text.contains("- **Alice**: → Bob"))
+    #expect(!result.text.contains("→ Bob (Bob is bluffing)"))
+    // Reason appears as the 💭 thought bullet.
+    #expect(result.text.contains("  - 💭 _Bob is bluffing_"))
+  }
+
   @Test func appliesContentFilterToRenderedMarkdown() throws {
     // Applies to everything — including persona names in YAML and turn output.
     let filter = ContentFilter(blockedPatterns: ["死ね"], replacement: "***")

--- a/Pastura/PasturaTests/LLM/PartialOutputExtractorTests.swift
+++ b/Pastura/PasturaTests/LLM/PartialOutputExtractorTests.swift
@@ -73,6 +73,34 @@ struct PartialOutputExtractorTests {
     #expect(snap.thought == nil)
   }
 
+  // MARK: - Phase-specific thought key (#609)
+
+  // The vote phase's private-thought field is `reason`, not `inner_thought`.
+  // `LLMCaller` passes the schema-derived thought key so the live streaming
+  // THINKING section surfaces the vote reason as it types in (parity with
+  // speak's `inner_thought`).
+  @Test func reasonThoughtKeyExtractsVoteReason() {
+    let snap = extractor.extract(
+      from: #"{"vote":"Dave","reason":"散歩に行きたい"}"#, thoughtKey: "reason")
+    #expect(snap.primary == "Dave")
+    #expect(snap.thought == "散歩に行きたい")
+  }
+
+  @Test func reasonThoughtStreamsIncrementally() {
+    let snap = extractor.extract(
+      from: #"{"vote":"Dave","reason":"散"#, thoughtKey: "reason")
+    #expect(snap.primary == "Dave")
+    #expect(snap.thought == "散")
+  }
+
+  // Default thought key stays `inner_thought` (back-compat): a vote buffer
+  // read with the default key surfaces no thought.
+  @Test func defaultThoughtKeyIgnoresReason() {
+    let snap = extractor.extract(from: #"{"vote":"Dave","reason":"散歩"}"#)
+    #expect(snap.primary == "Dave")
+    #expect(snap.thought == nil)
+  }
+
   // MARK: - Escape handling
 
   @Test func escapedQuoteInPrimary() {

--- a/Pastura/PasturaTests/Models/OutputSchemaTests.swift
+++ b/Pastura/PasturaTests/Models/OutputSchemaTests.swift
@@ -155,6 +155,52 @@ struct OutputSchemaTests {
     #expect(OutputSchema.from(phase: phase) == nil)
   }
 
+  // MARK: - thoughtFieldName (#609)
+
+  @Test("vote schema's thought field is reason")
+  func thoughtFieldNameForVoteIsReason() throws {
+    let schema = try #require(
+      OutputSchema.from(
+        phase: Phase(
+          type: .vote, prompt: "…",
+          outputSchema: ["vote": "string", "reason": "string"])))
+    #expect(schema.thoughtFieldName == "reason")
+  }
+
+  @Test("speak schema's thought field is inner_thought")
+  func thoughtFieldNameForSpeakIsInnerThought() throws {
+    let schema = try #require(
+      OutputSchema.from(
+        phase: Phase(
+          type: .speakAll, prompt: "…",
+          outputSchema: ["statement": "string", "inner_thought": "string"])))
+    #expect(schema.thoughtFieldName == "inner_thought")
+  }
+
+  @Test("schema with no secondary key has nil thought field")
+  func thoughtFieldNameNilWhenNoSecondaryKey() throws {
+    let schema = try #require(
+      OutputSchema.from(
+        phase: Phase(
+          type: .vote, prompt: "…",
+          outputSchema: ["vote": "string"])))
+    #expect(schema.thoughtFieldName == nil)
+  }
+
+  // Degenerate both-present case (presets author one secondary key per
+  // phase): `inner_thought` wins by knownSecondaryKeys priority order.
+  @Test("both secondary keys present resolves to inner_thought by priority")
+  func thoughtFieldNamePrefersInnerThoughtWhenBoth() throws {
+    let schema = try #require(
+      OutputSchema.from(
+        phase: Phase(
+          type: .speakAll, prompt: "…",
+          outputSchema: [
+            "statement": "string", "inner_thought": "string", "reason": "string"
+          ])))
+    #expect(schema.thoughtFieldName == "inner_thought")
+  }
+
   // MARK: - Codable
 
   @Test("Codable round-trip preserves fields and order")

--- a/Pastura/PasturaTests/Models/ScenarioConventionsTests.swift
+++ b/Pastura/PasturaTests/Models/ScenarioConventionsTests.swift
@@ -80,4 +80,19 @@ struct ScenarioConventionsTests {
         "expected nil for code phase \(phase.rawValue)")
     }
   }
+
+  // MARK: - decoratePrimary (#609)
+
+  /// Vote prefixes the `→ ` arrow; other phases pass the value through. The
+  /// shared decorator keeps the live-streaming path (bare snapshot value) and
+  /// the committed/export path rendering the same string — so the arrow no
+  /// longer pops in only at commit time.
+  @Test func decoratePrimaryPrefixesArrowForVote() {
+    #expect(ScenarioConventions.decoratePrimary("ハルト", for: .vote) == "→ ハルト")
+  }
+
+  @Test func decoratePrimaryPassesThroughForNonVote() {
+    #expect(ScenarioConventions.decoratePrimary("Hello", for: .speakAll) == "Hello")
+    #expect(ScenarioConventions.decoratePrimary("cooperate", for: .choose) == "cooperate")
+  }
 }

--- a/Pastura/PasturaTests/Models/ScenarioConventionsTests.swift
+++ b/Pastura/PasturaTests/Models/ScenarioConventionsTests.swift
@@ -51,4 +51,33 @@ struct ScenarioConventionsTests {
       }
     }
   }
+
+  // MARK: - thoughtField (#609)
+
+  /// Vote's private-thought field is `reason`; every other LLM phase uses
+  /// `inner_thought`. This is the single source of truth consumed by both the
+  /// committed-display path (`TurnOutput.secondaryText(for:)`) and the
+  /// streaming path (`PartialOutputExtractor` via `LLMCaller`), keeping the
+  /// THINKING section's source consistent across live + replay.
+  @Test func thoughtFieldForVoteReturnsReason() {
+    #expect(ScenarioConventions.thoughtField(for: .vote) == "reason")
+  }
+
+  @Test func thoughtFieldForSpeakAndChooseReturnsInnerThought() {
+    #expect(ScenarioConventions.thoughtField(for: .speakAll) == "inner_thought")
+    #expect(ScenarioConventions.thoughtField(for: .speakEach) == "inner_thought")
+    #expect(ScenarioConventions.thoughtField(for: .choose) == "inner_thought")
+  }
+
+  /// Code phases emit no LLM output, so they have no private-thought field.
+  @Test func thoughtFieldForCodePhasesReturnsNil() {
+    let codePhases: [PhaseType] = [
+      .scoreCalc, .assign, .eliminate, .summarize, .conditional, .eventInject
+    ]
+    for phase in codePhases {
+      #expect(
+        ScenarioConventions.thoughtField(for: phase) == nil,
+        "expected nil for code phase \(phase.rawValue)")
+    }
+  }
 }

--- a/Pastura/PasturaTests/Models/ThoughtFieldResolverConsistencyTests.swift
+++ b/Pastura/PasturaTests/Models/ThoughtFieldResolverConsistencyTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+/// Cross-resolver consistency for the per-phase private-thought field (#609).
+///
+/// Two resolvers name the THINKING-section source: the committed-display path
+/// uses `ScenarioConventions.thoughtField(for: phaseType)` (phase-driven) and
+/// the live-streaming path uses `OutputSchema.thoughtFieldName` (schema-driven,
+/// the secondary key the phase's `output:` actually declares). They agree as
+/// long as each phase authors at most one secondary key. This suite pins that
+/// invariant across every bundled preset, so a future preset that authors both
+/// `inner_thought` and `reason` on one phase (the sole divergence case) fails
+/// here at commit time rather than as a silent live-vs-replay UI discrepancy.
+@Suite(.timeLimit(.minutes(1)))
+struct ThoughtFieldResolverConsistencyTests {
+  @Test func bundledPresetsAgreeOnThoughtFieldAcrossResolvers() throws {
+    let bundle = Bundle(for: ThoughtFieldResolverConsistencyAnchor.self)
+    let loader = ScenarioLoader()
+
+    for fileName in PresetLoader.presetFileNames {
+      let url = try #require(
+        bundle.url(forResource: fileName, withExtension: "yaml")
+          ?? Bundle.main.url(forResource: fileName, withExtension: "yaml"),
+        "preset \(fileName).yaml not found in test or app bundle")
+      let scenario = try loader.load(yaml: try String(contentsOf: url, encoding: .utf8))
+
+      for phase in scenario.phases {
+        // Only LLM phases that declare a secondary key are constrained —
+        // when the schema declares none, `thoughtFieldName` is nil and the
+        // streaming path falls back to the default key (no inconsistency).
+        guard let schemaThought = OutputSchema.from(phase: phase)?.thoughtFieldName
+        else { continue }
+        #expect(
+          schemaThought == ScenarioConventions.thoughtField(for: phase.type),
+          """
+          \(fileName): phase \(phase.type.rawValue) — schema-derived thought \
+          field '\(schemaThought)' disagrees with phase-driven \
+          '\(ScenarioConventions.thoughtField(for: phase.type) ?? "nil")'
+          """)
+      }
+    }
+  }
+}
+
+/// Class anchor for `Bundle(for:)` lookup against the test target — preset
+/// YAMLs live in the app bundle, not the simulator UI runner's `Bundle.main`.
+private final class ThoughtFieldResolverConsistencyAnchor {}

--- a/Pastura/PasturaTests/Models/TurnOutputTests.swift
+++ b/Pastura/PasturaTests/Models/TurnOutputTests.swift
@@ -108,4 +108,69 @@ struct TurnOutputTests {
     #expect(withRawA == withRawB)
     #expect(withRawA == withoutRaw)
   }
+
+  // MARK: - primaryText (#609)
+
+  // Vote primary text is the bare arrow form `→ <voted>`. The vote `reason`
+  // is the vote-phase private-thought field (the equivalent of speak's
+  // `inner_thought`) and is surfaced via `secondaryText(for:)` / the THINKING
+  // section — NOT appended inline to the primary text. Regression guard:
+  // if a refactor re-appends `(reason)` here, the vote row would double-show
+  // the reason (inline + THINKING).
+  @Test func votePrimaryTextOmitsReason() {
+    let output = TurnOutput(fields: ["vote": "Alice", "reason": "信頼できる"])
+    #expect(output.primaryText(for: .vote) == "→ Alice")
+  }
+
+  @Test func votePrimaryTextWithoutReason() {
+    let output = TurnOutput(fields: ["vote": "Bob"])
+    #expect(output.primaryText(for: .vote) == "→ Bob")
+  }
+
+  @Test func speakPrimaryTextIsStatement() {
+    let output = TurnOutput(fields: ["statement": "Hello"])
+    #expect(output.primaryText(for: .speakAll) == "Hello")
+  }
+
+  // MARK: - secondaryText (#609)
+
+  // `secondaryText(for:)` resolves the phase's private-thought field via
+  // `ScenarioConventions.thoughtField(for:)`: `reason` for vote, `inner_thought`
+  // otherwise. Phase-aware (not a blind `innerThought ?? reason`) so a stray
+  // `reason` on a speak/choose output never leaks into the THINKING section,
+  // and a vote's `reason` is never silently dropped in favour of an
+  // `inner_thought` that vote schemas don't author.
+  @Test func voteSecondaryTextIsReason() {
+    let output = TurnOutput(fields: ["vote": "Alice", "reason": "信頼できる"])
+    #expect(output.secondaryText(for: .vote) == "信頼できる")
+  }
+
+  @Test func speakSecondaryTextIsInnerThought() {
+    let output = TurnOutput(fields: ["statement": "Hi", "inner_thought": "本音"])
+    #expect(output.secondaryText(for: .speakAll) == "本音")
+  }
+
+  @Test func chooseSecondaryTextIsInnerThought() {
+    let output = TurnOutput(fields: ["action": "cooperate", "inner_thought": "戦略"])
+    #expect(output.secondaryText(for: .choose) == "戦略")
+  }
+
+  // Precedence with BOTH fields present (test-fixture shape; presets author
+  // only one per phase). Vote reads `reason`; speak reads `inner_thought` —
+  // neither cross-leaks.
+  @Test func secondaryTextPrefersPhaseFieldWhenBothPresent() {
+    let output = TurnOutput(fields: [
+      "vote": "Alice",
+      "inner_thought": "private calc",
+      "reason": "stated reason"
+    ])
+    #expect(output.secondaryText(for: .vote) == "stated reason")
+    #expect(output.secondaryText(for: .speakAll) == "private calc")
+  }
+
+  // Code phases have no private-thought field.
+  @Test func secondaryTextNilForCodePhase() {
+    let output = TurnOutput(fields: ["inner_thought": "x", "reason": "y"])
+    #expect(output.secondaryText(for: .scoreCalc) == nil)
+  }
 }

--- a/Pastura/PasturaTests/Views/AgentOutputRowContractTests.swift
+++ b/Pastura/PasturaTests/Views/AgentOutputRowContractTests.swift
@@ -170,18 +170,33 @@ struct AgentOutputRowContractTests {
   }
 
   @Test func targetLengthForVotePhaseFormatsArrowNotation() {
-    // Vote phase primary text = "→ Target (reason)" — counted as chars
-    // for typing reveal. Regression guard against a refactor that
-    // changes the format string and silently shifts the reveal count.
+    // Vote phase primary text = "→ Target" (the `reason` is NOT appended
+    // inline — it is the vote's private-thought field, shown in THINKING;
+    // see #609). With thoughts hidden, only the arrow form counts toward
+    // the typing reveal. Regression guard: re-appending `(reason)` here
+    // would double-show the reason (inline + THINKING) and shift the count.
     let row = AgentOutputRow(
       agent: "Alice",
       output: TurnOutput(fields: ["vote": "Dave", "reason": "散歩"]),
       phaseType: .vote,
       showAllThoughts: false
     )
-    // "→ Dave (散歩)" — 1 arrow + 1 space + 4 "Dave" + 1 space + 1 "(" + 2 散歩 + 1 ")"
-    let expected = "→ Dave (散歩)".count
-    #expect(row.targetLength == expected)
+    // "→ Dave" — 1 arrow + 1 space + 4 "Dave"
+    #expect(row.targetLength == "→ Dave".count)
+  }
+
+  @Test func targetLengthForVotePhaseCountsReasonAsThoughtWhenShown() {
+    // #609: the vote `reason` flows into the THINKING section via
+    // `TurnOutput.secondaryText(for:)`, so when thoughts are shown the
+    // reveal counter covers the arrow primary PLUS the reason — exactly
+    // like speak's statement + inner_thought.
+    let row = AgentOutputRow(
+      agent: "Alice",
+      output: TurnOutput(fields: ["vote": "Dave", "reason": "散歩"]),
+      phaseType: .vote,
+      showAllThoughts: true
+    )
+    #expect(row.targetLength == "→ Dave".count + "散歩".count)
   }
 
   // MARK: - Thought-visibility seed contract

--- a/Pastura/PasturaTests/Views/AgentOutputRowContractTests.swift
+++ b/Pastura/PasturaTests/Views/AgentOutputRowContractTests.swift
@@ -185,6 +185,22 @@ struct AgentOutputRowContractTests {
     #expect(row.targetLength == "→ Dave".count)
   }
 
+  @Test func targetLengthForVotePhaseDecoratesStreamingPrimaryWithArrow() {
+    // #609 device-QA fix: during streaming the row receives the BARE vote
+    // value (no arrow) from the extractor. The arrow must be applied to the
+    // streaming primary too — otherwise it pops in only when the row commits.
+    // targetLength tracking "→ Dave" (not bare "Dave") proves the decoration
+    // is present while streaming.
+    let row = AgentOutputRow(
+      agent: "Alice",
+      output: TurnOutput(fields: [:]),
+      phaseType: .vote,
+      showAllThoughts: false,
+      streamingPrimary: "Dave"  // bare extractor value, no arrow
+    )
+    #expect(row.targetLength == "→ Dave".count)
+  }
+
   @Test func targetLengthForVotePhaseCountsReasonAsThoughtWhenShown() {
     // #609: the vote `reason` flows into the THINKING section via
     // `TurnOutput.secondaryText(for:)`, so when thoughts are shown the


### PR DESCRIPTION
## Summary
Unifies the vote-phase `reason` display with `inner_thought`. Investigation confirmed both are display-only private reasoning never routed into the conversation log (invisible to other agents) — `reason` is simply the vote-phase spelling of `inner_thought`. Previously `reason` showed inline as `→ Alice (理由)`; the "REASON"-flavoured framing also risked implying it was visible to other agents. Now it renders in the same collapsible `▾ THINKING` section, with live-streaming parity.

- **Models**: `ScenarioConventions.thoughtField(for:)` — single source of truth (vote→`reason`, other LLM→`inner_thought`). `TurnOutput.primaryText(.vote)` drops the inline `(reason)` → `→ <voted>`; new phase-aware `secondaryText(for:)`.
- **LLM/Engine**: `PartialOutputExtractor.extract(from:thoughtKey:)` parametrized (default `inner_thought`, back-compat) + `OutputSchema.thoughtFieldName`; `LLMCaller` feeds the schema-derived key so the vote `reason` streams live into the THINKING section, matching speak's `inner_thought`.
- **Views**: `AgentOutputRow.resolvedThought` falls back to `secondaryText(for: phaseType)` (covers live Sim + Past Results, which both route through `AgentOutputRow`).
- **App**: `ResultMarkdownExporter` surfaces the vote `reason` in the nested `💭` thought bullet instead of inline.

## Test plan
- Full unit suite: **1897 tests pass**; `swiftlint --strict` clean.
- New/updated: `TurnOutput.secondaryText` + both-fields precedence, `ScenarioConventions.thoughtField`, `OutputSchema.thoughtFieldName`, `PartialOutputExtractor` phase-key streaming, `AgentOutputRow` reveal-count (reason-as-thought), exporter `💭` bullet, and a preset-wide cross-resolver consistency guard.

## Follow-up (out of scope)
- `SimulationViewModel.swift:923` divergence telemetry logs a spurious entry for every vote turn (`canonicalPrimary` carries the `→ ` prefix that `snapshot.primary` never has) — a **pre-existing**, debug-only log, unchanged by this PR. Cheap future cleanup: compare against the bare `output.vote`.

Closes #609

🤖 Generated with [Claude Code](https://claude.com/claude-code)