### PR TITLE
✨ feat: Home P1 ① — TabCoordinator + native TabView foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,17 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    # `feature/home-redesign-p1` is the Home-redesign P1 integration branch
+    # (6 sub-PRs land there before it merges to main, #612). Without it in
+    # both branch lists, sub-PRs whose base is the integration branch fire
+    # ZERO jobs — the same long-lived-branch gating gap as #220 (see
+    # .claude/rules/ci-workflows.md "Long-lived branch gating", Layer A).
+    # Only the trigger filter needs widening: the verification jobs carry no
+    # main-only `if:`, and coverage stays main-gated by its own `if:`.
+    # Remove both entries once P1 merges to main.
+    branches: [main, feature/home-redesign-p1]
   pull_request:
-    branches: [main]
+    branches: [main, feature/home-redesign-p1]
 
 permissions:
   contents: read

--- a/Pastura/Pastura/App/RootTabView.swift
+++ b/Pastura/Pastura/App/RootTabView.swift
@@ -47,12 +47,20 @@ struct RootTabView: View {
       // `Label(text:)`. VoiceOver reads the per-icon `.accessibilityLabel`
       // (the JA tab name); its correct surfacing on the tab button is
       // confirmed by the real-device QA this PR already requires.
+      //
+      // `.environment(\.symbolVariants, .none)` on each icon is
+      // LOAD-BEARING: since iOS 15 a `TabView` tab bar auto-applies the
+      // `.fill` variant to EVERY tab symbol, which would fill our outline
+      // (inactive) symbols too and erase the active/inactive distinction.
+      // Disabling the auto-variant lets `symbolName(for:isActive:)` drive
+      // the fill toggle explicitly. Do NOT remove it.
       TabNavigationStack(router: coordinator.homeRouter) {
         HomeView()
       }
       .tag(AppTab.home)
       .tabItem {
         Image(systemName: Self.symbolName(for: .home, isActive: coordinator.selectedTab == .home))
+          .environment(\.symbolVariants, .none)
           .accessibilityLabel(Text(String(localized: "Home")))
       }
 
@@ -64,6 +72,7 @@ struct RootTabView: View {
         Image(
           systemName: Self.symbolName(for: .search, isActive: coordinator.selectedTab == .search)
         )
+        .environment(\.symbolVariants, .none)
         .accessibilityLabel(Text(String(localized: "Browse")))
       }
 
@@ -78,6 +87,7 @@ struct RootTabView: View {
         Image(
           systemName: Self.symbolName(for: .history, isActive: coordinator.selectedTab == .history)
         )
+        .environment(\.symbolVariants, .none)
         .accessibilityLabel(Text(String(localized: "History")))
       }
 
@@ -90,6 +100,7 @@ struct RootTabView: View {
           systemName: Self.symbolName(
             for: .settings, isActive: coordinator.selectedTab == .settings)
         )
+        .environment(\.symbolVariants, .none)
         .accessibilityLabel(Text(String(localized: "Settings")))
       }
     }

--- a/Pastura/Pastura/App/RootTabView.swift
+++ b/Pastura/Pastura/App/RootTabView.swift
@@ -1,0 +1,108 @@
+import SwiftUI
+
+/// The app's root four-tab bottom bar (ADR-016 D1 / D2 / D3).
+///
+/// Native `TabView` — **never** hand-rolled (D2). Each tab owns its own
+/// `NavigationStack` driven by the matching `AppRouter` from
+/// ``TabCoordinator`` (D3), and every stack registers the shared
+/// ``RouteResolver`` so a push resolves identically from any tab.
+///
+/// ## Per-tab router injection (D3, load-bearing)
+///
+/// Each tab's `AppRouter` is injected via `.environment` **inside** that
+/// tab's `NavigationStack` subtree (see ``TabNavigationStack``), never
+/// above the `TabView`. So an ambient `@Environment(AppRouter.self)` read
+/// — HomeView's pop-reload, `PasturaBackButton`, `ResultDetailView`'s
+/// post-delete pop — resolves to the router of the tab the view actually
+/// lives in. Injecting a single router above the `TabView` would collapse
+/// all four tabs' `pop()` onto one stack.
+///
+/// ## Tab-reselect → pop-to-root (§2 corrected)
+///
+/// SwiftUI's native auto-pop-to-root on re-tapping the active tab does
+/// **not** fire for a `NavigationStack(path:)` bound to an explicit
+/// `[Route]` array. The native bar supplies the gesture surface (the
+/// selection `Binding`'s setter runs on re-tap); the path reset is
+/// performed by ``TabCoordinator/handleSelection(_:)``.
+///
+/// ## OS styling
+///
+/// `.tint(Color.moss)` tints the active tab on all supported OS. On
+/// iOS 26 the native floating Liquid Glass tab bar renders automatically
+/// (no opt-in); OS-specific treatments (search-role morphing) are
+/// deferred to P4. Real-device QA on both iOS 17–25 and iOS 26 is
+/// required — the simulator mis-renders the iOS 26 bar.
+struct RootTabView: View {
+  @Bindable var coordinator: TabCoordinator
+
+  var body: some View {
+    TabView(
+      selection: Binding(
+        get: { coordinator.selectedTab },
+        set: { coordinator.handleSelection($0) }
+      )
+    ) {
+      TabNavigationStack(router: coordinator.homeRouter) {
+        HomeView()
+      }
+      .tag(AppTab.home)
+      .tabItem {
+        Image(systemName: "house")
+          .accessibilityLabel(Text(String(localized: "Home")))
+      }
+
+      TabNavigationStack(router: coordinator.searchRouter) {
+        SharedScenariosListView()
+      }
+      .tag(AppTab.search)
+      .tabItem {
+        Image(systemName: "magnifyingglass")
+          .accessibilityLabel(Text(String(localized: "Browse")))
+      }
+
+      TabNavigationStack(router: coordinator.historyRouter) {
+        // Home-entry semantic (cross-variant aggregation): empty
+        // scenarioId. Becomes the History tab root (ADR-016 D4); its
+        // `Route.results` case split lands in a later sub-PR.
+        ResultsView(scenarioId: "")
+      }
+      .tag(AppTab.history)
+      .tabItem {
+        Image(systemName: "clock")
+          .accessibilityLabel(Text(String(localized: "History")))
+      }
+
+      TabNavigationStack(router: coordinator.settingsRouter) {
+        SettingsView()
+      }
+      .tag(AppTab.settings)
+      .tabItem {
+        Image(systemName: "gearshape")
+          .accessibilityLabel(Text(String(localized: "Settings")))
+      }
+    }
+    .tint(Color.moss)
+  }
+}
+
+/// One tab's navigation stack: the tab's `AppRouter`-driven
+/// `NavigationStack` + the shared ``RouteResolver`` + per-tab router
+/// injection. Factored out so the four tabs share identical wiring.
+private struct TabNavigationStack<Root: View>: View {
+  let router: AppRouter
+  @ViewBuilder let root: () -> Root
+
+  var body: some View {
+    // Local `@Bindable` rebinding to derive `$router.path` for the stack
+    // (mirrors the established HomeView pattern). `.environment(router)`
+    // scopes this tab's router to its own subtree (D3).
+    @Bindable var router = router
+    return NavigationStack(path: $router.path) {
+      root()
+        .navigationDestination(for: Route.self) { route in
+          RouteResolver(route: route)
+        }
+    }
+    .environment(router)
+  }
+}

--- a/Pastura/Pastura/App/RootTabView.swift
+++ b/Pastura/Pastura/App/RootTabView.swift
@@ -52,7 +52,7 @@ struct RootTabView: View {
       }
       .tag(AppTab.home)
       .tabItem {
-        Image(systemName: "house")
+        Image(systemName: Self.symbolName(for: .home, isActive: coordinator.selectedTab == .home))
           .accessibilityLabel(Text(String(localized: "Home")))
       }
 
@@ -61,8 +61,10 @@ struct RootTabView: View {
       }
       .tag(AppTab.search)
       .tabItem {
-        Image(systemName: "magnifyingglass")
-          .accessibilityLabel(Text(String(localized: "Browse")))
+        Image(
+          systemName: Self.symbolName(for: .search, isActive: coordinator.selectedTab == .search)
+        )
+        .accessibilityLabel(Text(String(localized: "Browse")))
       }
 
       TabNavigationStack(router: coordinator.historyRouter) {
@@ -73,8 +75,10 @@ struct RootTabView: View {
       }
       .tag(AppTab.history)
       .tabItem {
-        Image(systemName: "clock")
-          .accessibilityLabel(Text(String(localized: "History")))
+        Image(
+          systemName: Self.symbolName(for: .history, isActive: coordinator.selectedTab == .history)
+        )
+        .accessibilityLabel(Text(String(localized: "History")))
       }
 
       TabNavigationStack(router: coordinator.settingsRouter) {
@@ -82,11 +86,32 @@ struct RootTabView: View {
       }
       .tag(AppTab.settings)
       .tabItem {
-        Image(systemName: "gearshape")
-          .accessibilityLabel(Text(String(localized: "Settings")))
+        Image(
+          systemName: Self.symbolName(
+            for: .settings, isActive: coordinator.selectedTab == .settings)
+        )
+        .accessibilityLabel(Text(String(localized: "Settings")))
       }
     }
     .tint(Color.moss)
+  }
+}
+
+extension RootTabView {
+  /// SF Symbol for `tab`, swapping to the `.fill` variant when active so
+  /// the selected tab reads as filled and the others as outlined.
+  ///
+  /// `magnifyingglass` has **no** `.fill` variant (`magnifyingglass.fill`
+  /// does not exist and would render blank), so the さがす tab keeps the
+  /// outline in both states and relies on the moss `.tint` alone to mark
+  /// active. Pure + `internal` so the mapping is unit-tested.
+  static func symbolName(for tab: AppTab, isActive: Bool) -> String {
+    switch tab {
+    case .home: return isActive ? "house.fill" : "house"
+    case .search: return "magnifyingglass"
+    case .history: return isActive ? "clock.fill" : "clock"
+    case .settings: return isActive ? "gearshape.fill" : "gearshape"
+    }
   }
 }
 

--- a/Pastura/Pastura/App/RootTabView.swift
+++ b/Pastura/Pastura/App/RootTabView.swift
@@ -42,6 +42,11 @@ struct RootTabView: View {
         set: { coordinator.handleSelection($0) }
       )
     ) {
+      // Icon-only tabs across ALL supported OS (ADR-016 D1 / design "D3"
+      // mock) — intentionally no visible text title, so do NOT "restore"
+      // `Label(text:)`. VoiceOver reads the per-icon `.accessibilityLabel`
+      // (the JA tab name); its correct surfacing on the tab button is
+      // confirmed by the real-device QA this PR already requires.
       TabNavigationStack(router: coordinator.homeRouter) {
         HomeView()
       }
@@ -94,8 +99,9 @@ private struct TabNavigationStack<Root: View>: View {
 
   var body: some View {
     // Local `@Bindable` rebinding to derive `$router.path` for the stack
-    // (mirrors the established HomeView pattern). `.environment(router)`
-    // scopes this tab's router to its own subtree (D3).
+    // (the `@Bindable` shadow pattern documented on ``AppRouter``).
+    // `.environment(router)` scopes this tab's router to its own
+    // subtree (D3).
     @Bindable var router = router
     return NavigationStack(path: $router.path) {
       root()

--- a/Pastura/Pastura/App/RouteResolver.swift
+++ b/Pastura/Pastura/App/RouteResolver.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+/// Resolves a ``Route`` to its destination view — shared across all four
+/// tab navigation stacks (ADR-016 D3).
+///
+/// Hoisted out of `HomeView` so every tab's
+/// `NavigationStack(…).navigationDestination(for: Route.self)` resolves
+/// the **same** Route universe: a `.scenarioDetail` / `.simulation` /
+/// `.results(detail)` push originating inside the Search or History tab
+/// must resolve identically to one from Home. Keeping the resolver inside
+/// `HomeView` would tie the Route universe to a single tab's stack.
+///
+/// `RouteHint` identity-neutrality (ADR-008) is unaffected: the resolver
+/// only reads `.value` for display; identity-bearing matching stays in
+/// each tab's own `AppRouter.pushIfOnTop`.
+struct RouteResolver: View {
+  let route: Route
+  @Environment(AppDependencies.self) private var dependencies
+
+  var body: some View {
+    switch route {
+    case .scenarioDetail(let scenarioId, let initialName):
+      ScenarioDetailView(scenarioId: scenarioId, initialName: initialName.value)
+    case .editor(let editingId, let templateYAML):
+      ScenarioEditorHost(
+        repository: dependencies.scenarioRepository,
+        editingId: editingId,
+        templateYAML: templateYAML
+      )
+    case .simulation(let scenarioId, let initialName):
+      SimulationView(scenarioId: scenarioId, initialName: initialName.value)
+    case .results(let scenarioId):
+      ResultsView(scenarioId: scenarioId)
+    case .resultDetail(let simulationId):
+      ResultDetailView(simulationId: simulationId)
+    case .sharedScenarios:
+      SharedScenariosListView()
+    case .galleryScenarioDetail(let scenario):
+      GalleryScenarioDetailView(scenario: scenario)
+    case .settings:
+      SettingsView()
+    }
+  }
+}
+
+/// Host view that owns a ``ScenarioEditorViewModel`` via `@State`.
+///
+/// Needed so the ViewModel is retained across re-renders — creating it
+/// inside a factory function would produce a fresh instance each time,
+/// losing editor state. Moved here from `HomeView` alongside the resolver
+/// (it is only used to build the `.editor` destination).
+private struct ScenarioEditorHost: View {
+  let repository: any ScenarioRepository
+  let editingId: String?
+  let templateYAML: String?
+
+  @State private var viewModel: ScenarioEditorViewModel?
+
+  var body: some View {
+    Group {
+      if let viewModel {
+        ScenarioEditorView(viewModel: viewModel)
+      } else {
+        ProgressView()
+      }
+    }
+    .task {
+      guard viewModel == nil else { return }
+      let newViewModel = ScenarioEditorViewModel(repository: repository)
+      if let editingId {
+        await newViewModel.loadForEditing(scenarioId: editingId)
+      } else if let templateYAML {
+        newViewModel.loadFromTemplate(yaml: templateYAML)
+      }
+      viewModel = newViewModel
+    }
+  }
+}

--- a/Pastura/Pastura/App/TabCoordinator.swift
+++ b/Pastura/Pastura/App/TabCoordinator.swift
@@ -1,0 +1,108 @@
+import Foundation
+import SwiftUI
+
+/// The four bottom-bar tabs (ADR-016 D1).
+///
+/// Raw IA identity only — labels / SF Symbols / tint live at the
+/// `TabView` construction site (``RootTabView``), not here, so the
+/// coordinator stays a pure navigation-state owner with no view concerns.
+enum AppTab: Hashable, CaseIterable {
+  case home
+  case search
+  case history
+  case settings
+}
+
+/// Owns the four per-tab navigation stacks and the selected-tab state for
+/// the bottom-tab information architecture (ADR-016 D3).
+///
+/// ## Why four routers rather than one widened `AppRouter`
+///
+/// The existing navigation guards (`pushIfOnTop`, `popToRoot`,
+/// `path.last`) are written against a single linear `[Route]` stack. Four
+/// independent ``AppRouter`` instances preserve every guard's correctness
+/// **locally inside each tab**; a single four-segmented path would force
+/// each guard to learn which segment it operates on. So this coordinator
+/// holds four *unmodified* `AppRouter`s — the type each guard already
+/// depends on is never mutated (ADR-016 D3, navigation.md
+/// "AppRouter scope").
+///
+/// ## Why `selectedTab` lives here, not on `AppRouter`
+///
+/// `navigation.md` § "AppRouter scope (load-bearing)" forbids non-path
+/// state on `AppRouter`. Tab selection is selection state, not a
+/// navigation path, so it belongs on the coordinator.
+@Observable
+@MainActor
+final class TabCoordinator {
+  /// 牧場 — brand header + resumable-simulation card + scenario list.
+  let homeRouter = AppRouter()
+  /// さがす — shared-scenario gallery + search.
+  let searchRouter = AppRouter()
+  /// 観察履歴 — past results, date-grouped.
+  let historyRouter = AppRouter()
+  /// 設定 — settings surface.
+  let settingsRouter = AppRouter()
+
+  /// The currently-selected tab. Drives the `TabView` selection binding.
+  var selectedTab: AppTab = .home
+
+  /// All four routers, for cross-tab folds (e.g. ``isSimulationOnTop``).
+  /// Order matches ``AppTab/allCases``.
+  var allRouters: [AppRouter] {
+    [homeRouter, searchRouter, historyRouter, settingsRouter]
+  }
+
+  /// The `AppRouter` owning `tab`'s navigation stack.
+  func router(for tab: AppTab) -> AppRouter {
+    switch tab {
+    case .home: return homeRouter
+    case .search: return searchRouter
+    case .history: return historyRouter
+    case .settings: return settingsRouter
+    }
+  }
+
+  /// Whether a `.simulation` route is on top of **any** tab's stack.
+  ///
+  /// `// D5.4: any-tab — do not narrow`. A simulation the user
+  /// backgrounded by switching tabs is genuinely in-flight (its inference
+  /// + `BGContinuedProcessingTask` re-attach keep running regardless of
+  /// the selected tab — ADR-003), so it must still block the deep-link
+  /// drain and suppress the warm splash. Narrowing this to the selected
+  /// tab would mis-time both (ADR-016 D5.4).
+  var isSimulationOnTop: Bool {
+    allRouters.contains { router in
+      if case .some(.simulation) = router.path.last { return true }
+      return false
+    }
+  }
+
+  /// Pure predicate for the tab-reselect → pop-to-root interceptor:
+  /// `true` when `tab` is already the selected tab.
+  ///
+  /// Extracted so the interceptor decision is unit-testable without a
+  /// live `TabView` (mirrors
+  /// ``LaunchPhaseCoordinator/shouldPlayWarmSplash(launchKind:appIsReady:isSimulationOnTop:isSheetActive:)``).
+  ///
+  /// Why a manual interceptor at all: SwiftUI's native auto-pop-to-root
+  /// on re-tapping the active tab does **not** fire for a
+  /// `NavigationStack(path:)` bound to an explicit `[Route]` array — the
+  /// system only manages its own implicit path. The native bar provides
+  /// the *gesture surface* (the selection binding's setter is invoked on
+  /// re-tap); the path reset is ours to perform (ADR-016 §2, corrected).
+  func isReselection(of tab: AppTab) -> Bool {
+    tab == selectedTab
+  }
+
+  /// Applies a tab-bar selection event: pop the tab to root on
+  /// re-selection, switch to it otherwise. Wire this from the `TabView`
+  /// selection `Binding`'s setter.
+  func handleSelection(_ tab: AppTab) {
+    if isReselection(of: tab) {
+      router(for: tab).popToRoot()
+    } else {
+      selectedTab = tab
+    }
+  }
+}

--- a/Pastura/Pastura/PasturaApp.swift
+++ b/Pastura/Pastura/PasturaApp.swift
@@ -117,7 +117,11 @@ private struct DeepLinkErrorAlert: Identifiable {
 private struct RootView: View {
   @State private var appState: AppState = .initializing
   @State private var modelManager = ModelManager()
-  @State private var router = AppRouter()
+  // Four per-tab AppRouters + selectedTab (ADR-016 D3). Replaces the
+  // single root `AppRouter` — the bottom-tab IA has one stack per tab.
+  // Named `tabCoordinator` to avoid colliding with the splash
+  // `coordinator` (LaunchPhaseCoordinator) below.
+  @State private var tabCoordinator = TabCoordinator()
   @State private var gate = DeepLinkGate()
   @State private var lastDeepLinkedScenarioId: String?
   @State private var deepLinkError: DeepLinkErrorAlert?
@@ -172,14 +176,17 @@ private struct RootView: View {
     // triggers are cheap.
     .onChange(of: appStateKind) { _, _ in tryDrain() }
     .onChange(of: gate.sheetPresentationCount) { _, _ in tryDrain() }
-    .onChange(of: router.path) { _, _ in tryDrain() }
+    // D5.3: the drain must re-fire when ANY tab's path changes (a
+    // simulation popped on a backgrounded tab unblocks the drain), so we
+    // observe all four routers' paths, not just the selected tab's.
+    .onChange(of: tabCoordinator.allRouters.map(\.path)) { _, _ in tryDrain() }
     .onChange(of: gate.pendingURL) { _, new in if new != nil { tryDrain() } }
     .onChange(of: scenePhase) { old, new in handleScenePhase(from: old, to: new) }
-    // Reset source-attribution when the user pops all the way back. Any
-    // subsequent visit to the same gallery scenario detail (via Share
-    // Board, for instance) should not show the "Opened from external
-    // link" banner.
-    .onChange(of: router.path.isEmpty) { _, isEmpty in
+    // Reset source-attribution when the user pops all the way back. The
+    // deep-linked gallery detail lands on the さがす (Search) tab (D5.2),
+    // so the attribution clears when THAT tab's stack empties (D5.3) —
+    // not when an unrelated tab happens to be at root.
+    .onChange(of: tabCoordinator.searchRouter.path.isEmpty) { _, isEmpty in
       if isEmpty { lastDeepLinkedScenarioId = nil }
     }
     .alert(item: $deepLinkError) { alert in
@@ -231,9 +238,11 @@ private struct RootView: View {
         }
 
       case .ready(let dependencies):
-        HomeView()
+        // Per-tab `AppRouter` is injected INSIDE each tab's NavigationStack
+        // by RootTabView (D3) — deliberately not `.environment(router)`
+        // here, which would collapse all tabs onto one stack.
+        RootTabView(coordinator: tabCoordinator)
           .environment(dependencies)
-          .environment(router)
           .environment(gate)
           // `ModelManager` is exposed so Settings → Models can observe
           // state and drive switch / download / delete without threading
@@ -400,9 +409,12 @@ private struct RootView: View {
     }
   }
 
+  // D5.1 / D5.4: a `.simulation` on top of ANY tab's stack — not just the
+  // selected tab's. Single source of truth read by all three consumers
+  // (deep-link block reason, drain guard, warm-splash gate); the fold
+  // lives on TabCoordinator. `// D5.4: any-tab — do not narrow`.
   private var isSimulationOnTop: Bool {
-    if case .some(.simulation) = router.path.last { return true }
-    return false
+    tabCoordinator.isSimulationOnTop
   }
 
   private func handleOpenURL(_ url: URL) {
@@ -449,7 +461,15 @@ private struct RootView: View {
     switch result {
     case .found(let scenario):
       lastDeepLinkedScenarioId = scenario.id
-      router.push(.galleryScenarioDetail(scenario: scenario))
+      // D5.2: a `.galleryScenarioDetail` is a さがす (Search) tab
+      // destination — the target tab is fixed by the resolution kind, not
+      // the currently-selected tab. Select that tab, then push onto its
+      // router. Plain `push` (not `pushIfOnTop`): the await that
+      // pushIfOnTop guards already completed in `tryDrain` before this
+      // runs, and the freshly-selected tab root has an empty stack where
+      // `pushIfOnTop` would no-op. Matches the prior unconditional push.
+      tabCoordinator.selectedTab = .search
+      tabCoordinator.searchRouter.push(.galleryScenarioDetail(scenario: scenario))
     case .notFound:
       deepLinkError = DeepLinkErrorAlert(
         title: String(localized: "Scenario Not Found"),

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -1162,6 +1162,16 @@
         }
       }
     },
+    "Browse" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "さがす"
+          }
+        }
+      }
+    },
     "Calculate scores (code, no LLM)" : {
       "localizations" : {
         "ja" : {
@@ -2593,6 +2603,26 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "思考を隠す"
+          }
+        }
+      }
+    },
+    "History" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "観察履歴"
+          }
+        }
+      }
+    },
+    "Home" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "牧場"
           }
         }
       }

--- a/Pastura/Pastura/Views/Home/HomeView.swift
+++ b/Pastura/Pastura/Views/Home/HomeView.swift
@@ -58,7 +58,7 @@ struct HomeView: View {
         .hidingPasturaSharedBackground()
       }
       .navigationDestination(for: Route.self) { route in
-        routeDestination(route)
+        RouteResolver(route: route)
       }
     }
     .task {
@@ -266,39 +266,11 @@ struct HomeView: View {
 
 }
 
-// Root-stack route resolution, split into an extension to keep the main
-// `HomeView` body under SwiftLint's `type_body_length`.
+// Toolbar route helper, split into an extension to keep the main
+// `HomeView` body under SwiftLint's `type_body_length`. Root-stack route
+// resolution itself was hoisted to ``RouteResolver`` (ADR-016 D3) so all
+// four tab stacks share one Route universe.
 extension HomeView {
-  @ViewBuilder
-  func routeDestination(_ route: Route) -> some View {
-    switch route {
-    case .scenarioDetail(let scenarioId, let initialName):
-      ScenarioDetailView(scenarioId: scenarioId, initialName: initialName.value)
-    case .editor(let editingId, let templateYAML):
-      editorView(editingId: editingId, templateYAML: templateYAML)
-    case .simulation(let scenarioId, let initialName):
-      SimulationView(scenarioId: scenarioId, initialName: initialName.value)
-    case .results(let scenarioId):
-      ResultsView(scenarioId: scenarioId)
-    case .resultDetail(let simulationId):
-      ResultDetailView(simulationId: simulationId)
-    case .sharedScenarios:
-      SharedScenariosListView()
-    case .galleryScenarioDetail(let scenario):
-      GalleryScenarioDetailView(scenario: scenario)
-    case .settings:
-      SettingsView()
-    }
-  }
-
-  private func editorView(editingId: String?, templateYAML: String?) -> some View {
-    ScenarioEditorHost(
-      repository: dependencies.scenarioRepository,
-      editingId: editingId,
-      templateYAML: templateYAML
-    )
-  }
-
   /// Resolves the destination for the toolbar "New Scenario" menu item.
   ///
   /// Under `--ui-test-editor-seed-yaml`, `AppDependencies.uiTestEditorSeedYAML`
@@ -332,38 +304,5 @@ extension View {
         PasturaCardSurface()
           .padding(.vertical, PasturaCardMetrics.interCardSpacing / 2)
       )
-  }
-}
-
-/// Host view that owns a ``ScenarioEditorViewModel`` via `@State`.
-///
-/// Needed so the ViewModel is retained across HomeView re-renders — creating
-/// it inside a factory function would produce a fresh instance each time,
-/// losing editor state.
-private struct ScenarioEditorHost: View {
-  let repository: any ScenarioRepository
-  let editingId: String?
-  let templateYAML: String?
-
-  @State private var viewModel: ScenarioEditorViewModel?
-
-  var body: some View {
-    Group {
-      if let viewModel {
-        ScenarioEditorView(viewModel: viewModel)
-      } else {
-        ProgressView()
-      }
-    }
-    .task {
-      guard viewModel == nil else { return }
-      let newViewModel = ScenarioEditorViewModel(repository: repository)
-      if let editingId {
-        await newViewModel.loadForEditing(scenarioId: editingId)
-      } else if let templateYAML {
-        newViewModel.loadFromTemplate(yaml: templateYAML)
-      }
-      viewModel = newViewModel
-    }
   }
 }

--- a/Pastura/Pastura/Views/Home/HomeView.swift
+++ b/Pastura/Pastura/Views/Home/HomeView.swift
@@ -27,39 +27,35 @@ struct HomeView: View {
   }
 
   var body: some View {
-    // `@Bindable` shadow: an `@Observable` injected via `@Environment` is
-    // immutable on the read side; the local `@Bindable` rebinding lets us
-    // derive `$router.path` for `NavigationStack`'s path binding.
-    @Bindable var router = router
-    return NavigationStack(path: $router.path) {
-      Group {
-        if let viewModel {
-          scenarioList(viewModel: viewModel)
-        } else {
-          ProgressView()
-        }
+    // The Home tab's `NavigationStack` (and its `.navigationDestination`
+    // registration via ``RouteResolver``) is owned by ``RootTabView`` so
+    // every tab shares one Route universe (ADR-016 D3). This view is the
+    // Home tab's root *content*; `router` (read below) is the Home tab's
+    // `AppRouter`, injected per-tab by `RootTabView`.
+    Group {
+      if let viewModel {
+        scenarioList(viewModel: viewModel)
+      } else {
+        ProgressView()
       }
-      .background(Color.screenBackground.ignoresSafeArea())
-      .navigationTitle("Pastura")
-      .toolbar {
-        ToolbarItem(placement: .topBarLeading) {
-          NavigationLink(value: Route.settings) {
-            Label(String(localized: "Settings"), systemImage: "gearshape")
-          }
-          .accessibilityIdentifier("home.settingsButton")
+    }
+    .background(Color.screenBackground.ignoresSafeArea())
+    .navigationTitle("Pastura")
+    .toolbar {
+      ToolbarItem(placement: .topBarLeading) {
+        NavigationLink(value: Route.settings) {
+          Label(String(localized: "Settings"), systemImage: "gearshape")
         }
-        .hidingPasturaSharedBackground()
-        ToolbarItem(placement: .primaryAction) {
-          NavigationLink(value: newScenarioRoute()) {
-            Label(String(localized: "New Scenario"), systemImage: "plus")
-          }
-          .accessibilityIdentifier("home.newScenarioButton")
+        .accessibilityIdentifier("home.settingsButton")
+      }
+      .hidingPasturaSharedBackground()
+      ToolbarItem(placement: .primaryAction) {
+        NavigationLink(value: newScenarioRoute()) {
+          Label(String(localized: "New Scenario"), systemImage: "plus")
         }
-        .hidingPasturaSharedBackground()
+        .accessibilityIdentifier("home.newScenarioButton")
       }
-      .navigationDestination(for: Route.self) { route in
-        RouteResolver(route: route)
-      }
+      .hidingPasturaSharedBackground()
     }
     .task {
       // Defer assignment until both `loadScenarios()` and
@@ -77,7 +73,8 @@ struct HomeView: View {
     }
     // Refresh the list whenever the user navigates back to root.
     // `.task` only runs on initial mount; pushed views like the editor
-    // don't re-trigger it on dismiss.
+    // don't re-trigger it on dismiss. D5.3: `router` is the Home tab's
+    // `AppRouter` (per-tab injected), so this pop-reload stays Home-local.
     .onChange(of: router.path.count) { oldCount, newCount in
       if newCount < oldCount {
         Task {

--- a/Pastura/PasturaTests/App/RootTabViewTests.swift
+++ b/Pastura/PasturaTests/App/RootTabViewTests.swift
@@ -1,0 +1,29 @@
+import Testing
+
+@testable import Pastura
+
+@MainActor
+@Suite(.timeLimit(.minutes(1))) struct RootTabViewTests {
+
+  // MARK: - Tab icon fill toggle
+
+  @Test func activeTabUsesFillVariant() {
+    #expect(RootTabView.symbolName(for: .home, isActive: true) == "house.fill")
+    #expect(RootTabView.symbolName(for: .history, isActive: true) == "clock.fill")
+    #expect(RootTabView.symbolName(for: .settings, isActive: true) == "gearshape.fill")
+  }
+
+  @Test func inactiveTabUsesOutlineVariant() {
+    #expect(RootTabView.symbolName(for: .home, isActive: false) == "house")
+    #expect(RootTabView.symbolName(for: .history, isActive: false) == "clock")
+    #expect(RootTabView.symbolName(for: .settings, isActive: false) == "gearshape")
+  }
+
+  @Test func searchTabHasNoFillVariant() {
+    // `magnifyingglass.fill` does not exist in SF Symbols and would render
+    // blank — pin the outline in BOTH states so a future "consistency fix"
+    // doesn't silently break the さがす tab icon.
+    #expect(RootTabView.symbolName(for: .search, isActive: true) == "magnifyingglass")
+    #expect(RootTabView.symbolName(for: .search, isActive: false) == "magnifyingglass")
+  }
+}

--- a/Pastura/PasturaTests/App/TabCoordinatorTests.swift
+++ b/Pastura/PasturaTests/App/TabCoordinatorTests.swift
@@ -1,0 +1,138 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+@MainActor
+@Suite(.timeLimit(.minutes(1))) struct TabCoordinatorTests {
+
+  // MARK: - Construction (ADR-016 D3)
+
+  @Test func startsOnHomeTab() {
+    let coordinator = TabCoordinator()
+    #expect(coordinator.selectedTab == .home)
+  }
+
+  @Test func eachTabRootStartsEmpty() {
+    let coordinator = TabCoordinator()
+    for tab in AppTab.allCases {
+      #expect(coordinator.router(for: tab).path.isEmpty)
+    }
+  }
+
+  @Test func hasFourDistinctRouters() {
+    let coordinator = TabCoordinator()
+    // D3: four *unmodified* AppRouter instances, one per tab — never a
+    // shared/widened router. Identity-distinctness is the contract that
+    // keeps each tab's pushIfOnTop / popToRoot guards local.
+    let ids = AppTab.allCases.map { ObjectIdentifier(coordinator.router(for: $0)) }
+    #expect(Set(ids).count == AppTab.allCases.count)
+  }
+
+  @Test func routerForTabReturnsTheTabsOwnInstance() {
+    let coordinator = TabCoordinator()
+    #expect(coordinator.router(for: .home) === coordinator.homeRouter)
+    #expect(coordinator.router(for: .search) === coordinator.searchRouter)
+    #expect(coordinator.router(for: .history) === coordinator.historyRouter)
+    #expect(coordinator.router(for: .settings) === coordinator.settingsRouter)
+  }
+
+  @Test func allRoutersEnumeratesEveryTab() {
+    let coordinator = TabCoordinator()
+    let fromAll = Set(coordinator.allRouters.map(ObjectIdentifier.init))
+    let fromTabs = Set(AppTab.allCases.map { ObjectIdentifier(coordinator.router(for: $0)) })
+    #expect(fromAll == fromTabs)
+  }
+
+  // MARK: - Tab-reselect → pop-to-root (pure helper; ADR-016 §2 corrected)
+
+  @Test func isReselectionTrueForSelectedTabFalseForOthers() {
+    let coordinator = TabCoordinator()  // selectedTab == .home
+    #expect(coordinator.isReselection(of: .home))
+    #expect(!coordinator.isReselection(of: .search))
+    #expect(!coordinator.isReselection(of: .history))
+    #expect(!coordinator.isReselection(of: .settings))
+  }
+
+  @Test func handleSelectionSwitchesTabWithoutPopping() {
+    let coordinator = TabCoordinator()
+    coordinator.homeRouter.push(.scenarioDetail(scenarioId: "x"))
+
+    coordinator.handleSelection(.search)
+
+    #expect(coordinator.selectedTab == .search)
+    // Switching tabs must NOT unwind the previously-selected tab's stack.
+    #expect(coordinator.homeRouter.path == [.scenarioDetail(scenarioId: "x")])
+  }
+
+  @Test func handleSelectionReselectPopsThatTabToRoot() {
+    let coordinator = TabCoordinator()
+    coordinator.homeRouter.push(.scenarioDetail(scenarioId: "x"))
+    coordinator.homeRouter.push(.simulation(scenarioId: "x"))
+
+    coordinator.handleSelection(.home)  // re-select the already-selected tab
+
+    #expect(coordinator.selectedTab == .home)
+    #expect(coordinator.homeRouter.path.isEmpty)
+  }
+
+  @Test func handleSelectionReselectUnwindsOnlyThatTabsStack() {
+    let coordinator = TabCoordinator()
+    coordinator.homeRouter.push(.scenarioDetail(scenarioId: "home"))
+    coordinator.searchRouter.push(.galleryScenarioDetail(scenario: makeGalleryScenario(id: "g")))
+
+    coordinator.handleSelection(.search)  // switch to search (was on home)
+    coordinator.handleSelection(.search)  // re-select search → pop search only
+
+    #expect(coordinator.searchRouter.path.isEmpty)
+    // Home's stack is untouched by a pop on the search tab.
+    #expect(coordinator.homeRouter.path == [.scenarioDetail(scenarioId: "home")])
+  }
+
+  // MARK: - isSimulationOnTop fold (ADR-016 D5.1 / D5.4)
+
+  @Test func isSimulationOnTopFalseWhenNoSimulationAnywhere() {
+    let coordinator = TabCoordinator()
+    coordinator.homeRouter.push(.scenarioDetail(scenarioId: "x"))
+    #expect(!coordinator.isSimulationOnTop)
+  }
+
+  @Test func isSimulationOnTopTrueWhenSimulationOnNonSelectedTab() {
+    let coordinator = TabCoordinator()  // selectedTab == .home
+    // A simulation the user backgrounded by switching tabs is still
+    // in-flight (ADR-003) — the fold must see it on a NON-selected tab.
+    coordinator.searchRouter.push(.simulation(scenarioId: "x"))
+    #expect(coordinator.selectedTab == .home)
+    #expect(coordinator.isSimulationOnTop)
+  }
+
+  @Test func isSimulationOnTopFalseWhenSimulationIsMidStackNotTop() {
+    let coordinator = TabCoordinator()
+    coordinator.homeRouter.push(.simulation(scenarioId: "x"))
+    coordinator.homeRouter.push(.resultDetail(simulationId: "r"))  // sim now mid-stack
+    #expect(!coordinator.isSimulationOnTop)
+  }
+
+  // MARK: - Cross-tab isolation (ADR-016 D3)
+
+  @Test func pushOnOneTabLeavesOtherTabsEmpty() {
+    let coordinator = TabCoordinator()
+    coordinator.homeRouter.push(.scenarioDetail(scenarioId: "x"))
+
+    #expect(coordinator.searchRouter.path.isEmpty)
+    #expect(coordinator.historyRouter.path.isEmpty)
+    #expect(coordinator.settingsRouter.path.isEmpty)
+  }
+
+  // MARK: - Helpers
+
+  private func makeGalleryScenario(id: String) -> GalleryScenario {
+    GalleryScenario(
+      id: id, title: id, category: .experimental,
+      description: "", author: "",
+      recommendedModel: ModelRegistry.gemma4E2B.id, estimatedInferences: 0,
+      // swiftlint:disable:next force_unwrapping
+      yamlURL: URL(string: "https://example.com/\(id).yaml")!,
+      yamlSHA256: "h", addedAt: "2026-04-15")
+  }
+}


### PR DESCRIPTION
## Summary
- Replace the single root NavigationStack/AppRouter with a four-tab native TabView (ADR-016 D1–D3). `TabCoordinator` owns four **unmodified** `AppRouter`s + `selectedTab`; each tab has its own NavigationStack + per-tab router `.environment` + shared `RouteResolver`.
- Correct-minimal D5 deep-link migration (compile-forced by removing the single root router): any-tab `isSimulationOnTop` (D5.1/D5.4), drain → さがす-tab push (D5.2), drain trigger over all tabs + attribution-clear bound to the search tab (D5.3 — incl. the two consumers the ADR table missed: `PasturaApp` `.onChange(of: router.path)` / `.path.isEmpty`).
- Tab-reselect → pop-to-root via a manual interceptor — native auto-pop does NOT fire for `[Route]`-bound stacks (ADR-016 §2 overstated this; framing correction deferred to ⑥).

## Restructured per pre-impl critic
①/6 of P1, widened from "additive TabView" to include the D5 migration because removing the single `router` is compile-forced (critic Axis 2). Two D5.3 consumers the ADR inventory missed are handled here (Axis 1).

## Deferred (later sub-PRs)
- Route-case deletion (`.settings`/`.sharedScenarios`, `.results` split) + back-chrome strip → ②③④. Dual reach-paths + a no-op back chevron on tab roots are **accepted transient states** on this integration branch.
- Full D5.5 test matrix + D5.4 verification → ⑤.
- navigation.md full revision + ADR-016 in-place edits (D5.3 `:175`/`:182` rows; §2 pop-to-root framing) → ⑥.

## ⚠️ Real-device QA required before P1 → main
iOS 26 Liquid Glass tab-bar rendering + icon-only VoiceOver labels need real-device QA on BOTH iOS 17–25 and iOS 26. **CI green ≠ merge** for the tab-bar visuals.

## Test plan
- New `TabCoordinatorTests` (13): 4 distinct routers; reselect→pop (only that tab); any-tab `isSimulationOnTop` via a non-selected tab; cross-tab push isolation.
- Full unit suite: **1890 tests pass**; `swiftlint --strict` clean; localization coverage green (Home/Browse/History + ja).
- UI tests (NavigationRegression/BackGesture/Editor) deferred to this PR's CI — they exercise the restructured nav surface and may need follow-up.

Part of #612

🤖 Generated with [Claude Code](https://claude.com/claude-code)