### PR TITLE
🐛 fix: decorate vote snapshot before divergence compare (#615)

### DIFF
--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -921,9 +921,20 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     // fires for all speeds — they do not substitute for one another.
     if let snapshot = streamingSnapshot, snapshot.agent == agent {
       let canonicalPrimary = filtered.primaryText(for: phaseType) ?? ""
-      if !canonicalPrimary.hasPrefix(snapshot.primary) {
+      // Compare against the *decorated* snapshot. `PartialOutputExtractor`
+      // stores the bare primary (e.g. the vote value without the `→ ` arrow),
+      // while `primaryText(for:)` returns the decorated form — so for vote
+      // `"→ X".hasPrefix("X")` was structurally always false and fired a
+      // spurious divergence log every turn (#615). Decorating via the #613
+      // single source of truth restores the prefix invariant. Use the
+      // commit-time `phaseType` parameter (not `snapshot.phaseType`): the
+      // canonical parse is authoritative for the phase this turn committed
+      // as, and a mid-turn snapshot can be stale.
+      let decoratedSnapshot = ScenarioConventions.decoratePrimary(
+        snapshot.primary, for: phaseType)
+      if !canonicalPrimary.hasPrefix(decoratedSnapshot) {
         lifecycleLogger.debug(
-          "stream divergence: agent=\(agent, privacy: .public), snapshot primary \(snapshot.primary.prefix(40), privacy: .public) is not a prefix of canonical \(canonicalPrimary.prefix(40), privacy: .public)"
+          "stream divergence: agent=\(agent, privacy: .public), snapshot primary \(decoratedSnapshot.prefix(40), privacy: .public) is not a prefix of canonical \(canonicalPrimary.prefix(40), privacy: .public)"
         )
       }
     }


### PR DESCRIPTION
## Summary
- The stream-divergence debug telemetry in `SimulationViewModel` compared the
  *decorated* canonical primary (`"→ X"` for vote) against the *bare* snapshot
  primary (`"X"`), so `"→ X".hasPrefix("X")` was structurally always false and
  emitted a spurious `stream divergence` debug log every vote turn.
- Fix: decorate `snapshot.primary` via the #613 single source of truth
  (`ScenarioConventions.decoratePrimary(_:for:)`) before the comparison; the log
  interpolation now shows the decorated form too, keeping it self-consistent with
  the condition that produced it.
- Uses the commit-time `phaseType` parameter (not the potentially-stale
  `snapshot.phaseType`) — the canonical parse is authoritative for the committed phase.
- Debug-only telemetry; no functional or TestFlight/Release impact.

## Test plan
- No new automated tests: the bug lives in a debug-only log branch with no
  observable VM seam; the underlying `decoratePrimary` / `primaryText` helpers are
  already covered (`ScenarioConventionsTests`, `TurnOutputTests`). The predicate
  could be extracted into a pure helper + unit-tested in a future cleanup (noted by
  pre-impl critic, deferred by design).
- `scripts/xcodebuild.sh build` → BUILD SUCCEEDED.
- `swiftlint lint --quiet --strict` → clean.
- Pre-impl critic: no Critical. Code review (Opus): PASS, 0 issues.

Closes #615