### PR TITLE
🐛 fix: segment-scope force-push hook to stop false-fires on compound commands (#616)

### DIFF
--- a/scripts/hooks/block-force-push-and-pr-ready.sh
+++ b/scripts/hooks/block-force-push-and-pr-ready.sh
@@ -15,11 +15,28 @@
 # sail through. This hook is the mechanical guard behind the skill's
 # hard rules (never force push, PRs stay Draft).
 #
-# Conservative by design: matching is substring/glob-based, so a
-# compound command like `git push origin x && rm -f y` is also blocked
-# (the " -f" could belong to the push). False positives are cheap —
-# split the compound or run the command manually in a terminal; hooks
-# only gate Claude's tool calls, never the human.
+# Scope of the force-flag scan (#616): the unambiguous `--force*` long
+# form is matched against the WHOLE command. The ambiguous shapes
+# (`-f` short-flag clusters, `+refspec`) are scanned ONLY within a
+# `git push` sub-command segment, so a `+`-leading or `-f`-clustered
+# token in a sibling `gh pr create --body "…"` or a heredoc payload no
+# longer false-fires. A segment counts as a push after a leading run of
+# `VAR=value` assignments and `env`/`sudo`/`command` wrappers is
+# stripped, so `env X=y git push -uf` / `sudo git push +x` (which the
+# old whole-command scan blocked) are still caught. Example now
+# ALLOWED: `git push origin x && rm -f y`.
+#
+# Residual (still conservative): the `--force*` literal anywhere in the
+# command still blocks — so a PR/commit body that must contain the text
+# `--force` trips the guard. Use `--body-file` / `git commit -F file`,
+# or split the compound, or run it manually in a terminal; hooks only
+# gate Claude's tool calls, never the human. Regression coverage:
+# scripts/tests/block-force-push-test.sh.
+#
+# bash 3.2-safe (ships to a macOS bash 3.2 machine): no here-strings,
+# no `${var^^}` / `${var,,}`, no `mapfile`. awk / tr / process
+# substitution are all 3.2-safe. The CI self-test runs on ubuntu bash
+# 5+, so it CANNOT catch a 3.2 regression — keep new constructs 3.2-clean.
 #
 # Mirrors gated-runner.sh's input handling (PR #407): malformed JSON
 # falls through to a silent allow (exit 0), matching its fail-open
@@ -38,28 +55,85 @@ block() {
   exit 2
 }
 
+# Inspect ONE command segment that is a `git push` invocation for the
+# AMBIGUOUS force shapes only — short-flag clusters containing `f`
+# (-f / -uf / -fv) and `+refspec` pushes. The unambiguous `--force*`
+# long form is caught globally by the caller, before segmentation.
+# `set -f` stops the unquoted expansion from globbing against cwd.
+scan_push_segment() {
+  set -f
+  for word in $1; do
+    case "$word" in
+      --*) : ;;  # long options handled by the global --force arm
+      -[A-Za-z]*)
+        case "$word" in
+          *f*) block "force push (-f, possibly bundled as $word) is forbidden for Claude sessions." ;;
+        esac
+        ;;
+      +*) block "force push via +refspec ($word) is forbidden for Claude sessions." ;;
+    esac
+  done
+  set +f
+}
+
 case "$COMMAND" in
   *"git push"*)
+    # Unambiguous long force flag — matched against the WHOLE command so
+    # an `env FOO=bar git push --force` / `sudo git push --force` (first
+    # word not `git`) is still blocked.
     case "$COMMAND" in
       *--force*) block "force push (--force*) is forbidden for Claude sessions." ;;
     esac
-    # Substring globs cannot catch -f bundled into a short-flag cluster
-    # (-fu / -uf / -fv) without also matching branch names containing
-    # an "f" — tokenize instead and inspect each dash-cluster word.
-    # `set -f` stops the unquoted expansion from globbing against cwd.
-    set -f
-    for word in $COMMAND; do
-      case "$word" in
-        --*) : ;;  # long options handled by the substring arm above
-        -[A-Za-z]*)
-          case "$word" in
-            *f*) block "force push (-f, possibly bundled as $word) is forbidden for Claude sessions." ;;
+
+    # Ambiguous shapes (-f clusters, +refspec) cannot be matched against
+    # the whole command without false-firing on a sibling subcommand's
+    # body or a heredoc payload (#616). Scope the scan to the `git push`
+    # segment(s) only:
+    #   1. awk joins `\`-continued lines so a push whose force flag is on
+    #      the next physical line stays in one segment.
+    #   2. tr splits the joined text on `; & |` (so `&&` / `||` break too);
+    #      embedded newlines are themselves command separators. The split
+    #      is deliberately quote-blind — a `;`/`&`/`|` inside a quoted
+    #      body splits too, but over-splitting only ever shrinks a
+    #      segment's word set, never lets a push flag escape its segment.
+    #   3. `while read` over PROCESS SUBSTITUTION (not a pipe) keeps the
+    #      loop in the current shell so block()'s `exit 2` propagates.
+    #   4. A segment is scanned only if it contains `git push` AND —
+    #      after stripping leading VAR=value assignments and the
+    #      env/sudo/command wrappers — its first word is `git`, so
+    #      quoted/heredoc prose mentioning "git push" is not scanned.
+    while IFS= read -r seg; do
+      case "$seg" in
+        *"git push"*)
+          # Strip a leading run of `VAR=value` assignments and the
+          # wrappers env/sudo/command so a prefix-wrapped push
+          # (`env X=y git push -uf`, `sudo git push +x`, `FOO=bar git
+          # push -uf`) is still scanned. Wrappers that take their own
+          # args (`timeout 5 …`, `nice -n 10 …`, `env -i …`) stop the
+          # strip early and fall through unscanned — a conservative
+          # residual of the same class as the heredoc-prose case.
+          rest=${seg#"${seg%%[![:space:]]*}"}
+          while :; do
+            w=${rest%%[[:space:]]*}
+            case "$w" in
+              env|sudo|command) : ;;  # command wrapper — drop
+              [A-Za-z_]*=*) : ;;      # VAR=value assignment — drop
+              *) break ;;             # `git` or anything else — stop
+            esac
+            rest=${rest#"$w"}
+            rest=${rest#"${rest%%[![:space:]]*}"}
+          done
+          case "$rest" in
+            # Pass the full $seg, NOT $rest — the strip loop only gates
+            # whether to scan; the scan itself must see every arg so a
+            # force flag after the wrapper run is never hidden.
+            git\ *|git) scan_push_segment "$seg" ;;
           esac
           ;;
-        +*) block "force push via +refspec ($word) is forbidden for Claude sessions." ;;
       esac
-    done
-    set +f
+    done < <(printf '%s' "$COMMAND" \
+      | awk '{ if (sub(/\\$/, "")) printf "%s ", $0; else print }' \
+      | tr ';&|' '\n\n\n')
     ;;
 esac
 

--- a/scripts/tests/block-force-push-test.sh
+++ b/scripts/tests/block-force-push-test.sh
@@ -77,6 +77,14 @@ else
 fi
 
 # --- BLOCK cases ---------------------------------------------------------
+#
+# Note: the `--force*` long form is matched against the WHOLE command, so
+# the `--force` BLOCK cases below pass on BOTH the old and new hook and do
+# NOT exercise the segment-scoping path. The cases that genuinely exercise
+# the new code are the ALLOW sibling-body cases above (BLOCKED by the old
+# hook) and the prefix-wrapped AMBIGUOUS cases below (env/sudo/command +
+# `-uf`/`+refspec` — these would slip through a naive "first word is git"
+# guard, so they lock in the strip-leading-wrappers logic).
 
 assert_block "long force flag" 'git push origin x --force'
 assert_block "force-with-lease" 'git push --force-with-lease origin x'
@@ -84,7 +92,11 @@ assert_block "+refspec" 'git push origin +main'
 assert_block "-uf short-flag cluster" 'git push -uf origin x'
 assert_block "line-continuation force" "$(printf 'git push origin x \\\n--force')"
 assert_block "line-continuation +refspec" "$(printf 'git push origin \\\n+main')"
-assert_block "env-prefixed force (first word not git)" 'env FOO=bar git push --force'
+assert_block "env-prefixed long force" 'env FOO=bar git push --force'
+assert_block "env-prefixed -uf cluster" 'env FOO=bar git push -uf origin x'
+assert_block "sudo-prefixed +refspec" 'sudo git push origin +main'
+assert_block "command-prefixed -uf cluster" 'command git push -uf origin x'
+assert_block "bare VAR=value prefix +refspec" 'FOO=bar git push origin +main'
 assert_block "gh pr ready" 'gh pr ready 123'
 
 # --- result --------------------------------------------------------------

--- a/scripts/tests/block-force-push-test.sh
+++ b/scripts/tests/block-force-push-test.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+#
+# scripts/tests/block-force-push-test.sh — regression test for
+# scripts/hooks/block-force-push-and-pr-ready.sh (issue #616).
+#
+# Feeds synthetic PreToolUse(Bash) payloads to the hook and asserts the
+# exit code: 0 = allowed, non-zero (2) = blocked. The headline case is
+# the #616 false-fire — a `git push` compound whose SIBLING subcommand
+# body carries a `+`-leading or `-f`-clustered token must be ALLOWED,
+# while every real force-push shape must stay BLOCKED.
+#
+# CI-wired: the `*-test.sh` naming convention makes this a gate under
+# `.github/workflows/ci.yml` ("Run scripts/tests/*-test.sh"). That job
+# runs on ubuntu (bash 5+), so it CANNOT catch a bash-3.2 regression in
+# the hook itself — the hook ships to a macOS (bash 3.2) machine. Run
+# the hook manually under /bin/bash before merge for 3.2 coverage.
+#
+# Run manually:
+#   bash scripts/tests/block-force-push-test.sh
+
+set -euo pipefail
+
+HOOK="$(git rev-parse --show-toplevel)/scripts/hooks/block-force-push-and-pr-ready.sh"
+fail=0
+
+# Run the hook with `.tool_input.command` set to $1; return its exit code.
+# `jq -Rs` slurps stdin (incl. embedded newlines) into a single JSON
+# string — the same shape the harness sends.
+run_hook() {
+  printf '%s' "$1" | jq -Rs '{tool_input:{command:.}}' | bash "$HOOK"
+}
+
+assert_allow() {
+  if run_hook "$2" >/dev/null 2>&1; then
+    : # exit 0 — allowed, as expected
+  else
+    echo "FAIL [expected ALLOW, got BLOCK]: $1" >&2
+    fail=1
+  fi
+}
+
+assert_block() {
+  if run_hook "$2" >/dev/null 2>&1; then
+    echo "FAIL [expected BLOCK, got ALLOW]: $1" >&2
+    fail=1
+  fi
+}
+
+# --- ALLOW cases ---------------------------------------------------------
+
+# The #616 headline: force-looking tokens (+foo, -fv) live in a SIBLING
+# `gh pr create` body, not in the push. Must be allowed.
+assert_allow "compound: + and -f tokens in sibling --body" \
+  'git push -u origin x && gh pr create --body "fixes +foo and use -fv prose"'
+
+# A quoted `&&` inside the body splits via tr alongside the real `&&`;
+# the resulting body fragments are not `git push` invocations.
+assert_allow "compound: quoted && plus +foo inside --body" \
+  'git push -u origin x && gh pr create --body "fixes +foo and a && b -f"'
+
+# Newline-separated sibling commands (a single Bash call with a literal
+# newline, no &&) — the second line is not a push.
+assert_allow "newline-separated sibling with + and -f in body" \
+  "$(printf 'git push -u origin x\ngh pr create --body "has +foo and -f"')"
+
+assert_allow "plain push, no force" 'git push -u origin main'
+
+assert_allow "empty command" ''
+
+# Malformed JSON falls through to a silent allow (fail-open) — bypass
+# run_hook so we feed raw non-JSON straight to the hook.
+if printf 'this is not json at all' | bash "$HOOK" >/dev/null 2>&1; then
+  : # allowed, as expected
+else
+  echo "FAIL [expected ALLOW, got BLOCK]: malformed JSON input" >&2
+  fail=1
+fi
+
+# --- BLOCK cases ---------------------------------------------------------
+
+assert_block "long force flag" 'git push origin x --force'
+assert_block "force-with-lease" 'git push --force-with-lease origin x'
+assert_block "+refspec" 'git push origin +main'
+assert_block "-uf short-flag cluster" 'git push -uf origin x'
+assert_block "line-continuation force" "$(printf 'git push origin x \\\n--force')"
+assert_block "line-continuation +refspec" "$(printf 'git push origin \\\n+main')"
+assert_block "env-prefixed force (first word not git)" 'env FOO=bar git push --force'
+assert_block "gh pr ready" 'gh pr ready 123'
+
+# --- result --------------------------------------------------------------
+
+if [ "$fail" -eq 0 ]; then
+  echo "block-force-push: all cases passed"
+else
+  echo "block-force-push: FAILURES" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- The `block-force-push-and-pr-ready.sh` PreToolUse guard tokenized the
  **whole** compound command, so a `+`-leading or `-f`-clustered token in a
  **sibling** subcommand body (e.g. `git push x && gh pr create --body "…+…"`)
  false-fired the push guard. This recurred often enough to warrant a fix
  (the issue, this PR's own plan comment, and several commits here were all
  blocked by it — workaround was splitting the compound / `--body-file`).
- **Fix:** keep the unambiguous `--force*` long form as a whole-command check
  (so `env`/`sudo`/`command`/`VAR=`-prefixed pushes stay blocked), and
  segment-scope **only** the ambiguous `-f`-cluster / `+refspec` scans to the
  actual `git push` segment. Segmentation: awk-join `\`-continuations → split
  on `; & |` + newlines → `while read` over **process substitution** (current
  shell, so `exit 2` propagates) → scan a segment only when it contains
  `git push` and its first word is `git` after stripping leading `VAR=value`
  assignments and `env`/`sudo`/`command` wrappers.
- New CI-wired regression fixture `scripts/tests/block-force-push-test.sh`
  (runs via the existing `scripts/tests/*-test.sh` job).

## Notes
- **bash 3.2-safe** — the hook ships to a macOS bash 3.2 machine; the CI
  self-test runs on ubuntu bash 5, so it can't catch a 3.2 regression.
  Verified directly under `/bin/bash` (3.2.57).
- **Documented residuals (conservative under/over-block):** a `--force` literal
  anywhere in the command still blocks (use `--body-file`); wrappers that take
  their own args (`timeout 5 …`, `nice -n 10 …`, `env -i …`) stop the prefix
  strip early and fall through unscanned; a heredoc body line literally
  beginning with `git push …` is still scanned.

## Test plan
- `bash scripts/tests/block-force-push-test.sh` → all cases pass on bash 3.2.
- Empirically diffed new vs old hook on `env`/`sudo`/`command`/`VAR=`-prefixed
  `-uf`/`+refspec` pushes → both BLOCK (no security regression); the
  `&& gh pr create --body "…+…-f…"` sibling-body case → old BLOCK, new ALLOW
  (the #616 fix).
- Two review iterations (Opus code-reviewer): iteration 1 caught a
  prefix-wrapped-push regression, fixed; iteration 2 PASS.

Closes #616.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
