### PR TITLE
♻️ refactor: Home P1 ② — settings tab-only, drop Route.settings

### DIFF
--- a/Pastura/Pastura/App/RouteResolver.swift
+++ b/Pastura/Pastura/App/RouteResolver.swift
@@ -37,8 +37,6 @@ struct RouteResolver: View {
       SharedScenariosListView()
     case .galleryScenarioDetail(let scenario):
       GalleryScenarioDetailView(scenario: scenario)
-    case .settings:
-      SettingsView()
     }
   }
 }

--- a/Pastura/Pastura/App/Router.swift
+++ b/Pastura/Pastura/App/Router.swift
@@ -64,8 +64,4 @@ enum Route: Hashable {
 
   /// Detail view for a single gallery scenario, with Try / Update action.
   case galleryScenarioDetail(scenario: GalleryScenario)
-
-  /// Settings screen — content-reporting disclosure and future
-  /// configuration surfaces.
-  case settings
 }

--- a/Pastura/Pastura/Views/Community/SharedScenarios/SharedScenariosListView.swift
+++ b/Pastura/Pastura/Views/Community/SharedScenarios/SharedScenariosListView.swift
@@ -14,6 +14,10 @@ struct SharedScenariosListView: View {
       }
     }
     .navigationTitle(String(localized: "Shared Scenarios"))
+    // Inline title to match the other tab roots (design-system § 5.11);
+    // "Shared Scenarios" is a generic label, so inline is consistent for
+    // the push variant too.
+    .navigationBarTitleDisplayMode(.inline)
     .navigationBarBackButtonHidden(true)
     .preservesPasturaSwipeBackGesture()
     .toolbar {

--- a/Pastura/Pastura/Views/Home/HomeView.swift
+++ b/Pastura/Pastura/Views/Home/HomeView.swift
@@ -42,13 +42,6 @@ struct HomeView: View {
     .background(Color.screenBackground.ignoresSafeArea())
     .navigationTitle("Pastura")
     .toolbar {
-      ToolbarItem(placement: .topBarLeading) {
-        NavigationLink(value: Route.settings) {
-          Label(String(localized: "Settings"), systemImage: "gearshape")
-        }
-        .accessibilityIdentifier("home.settingsButton")
-      }
-      .hidingPasturaSharedBackground()
       ToolbarItem(placement: .primaryAction) {
         NavigationLink(value: newScenarioRoute()) {
           Label(String(localized: "New Scenario"), systemImage: "plus")

--- a/Pastura/Pastura/Views/Home/HomeView.swift
+++ b/Pastura/Pastura/Views/Home/HomeView.swift
@@ -41,6 +41,10 @@ struct HomeView: View {
     }
     .background(Color.screenBackground.ignoresSafeArea())
     .navigationTitle("Pastura")
+    // Tab roots use an inline title for quiet chrome (design-system § 5.11);
+    // the tab-root rule overrides the 固有名→large axis even though
+    // "Pastura" is a brand name.
+    .navigationBarTitleDisplayMode(.inline)
     .toolbar {
       ToolbarItem(placement: .primaryAction) {
         NavigationLink(value: newScenarioRoute()) {

--- a/Pastura/Pastura/Views/Results/ResultsView.swift
+++ b/Pastura/Pastura/Views/Results/ResultsView.swift
@@ -31,6 +31,10 @@ struct ResultsView: View {
       }
     }
     .navigationTitle(String(localized: "Past Results"))
+    // Inline title to match the other tab roots (design-system § 5.11);
+    // "Past Results" is a generic label, so inline is consistent for the
+    // push variant too.
+    .navigationBarTitleDisplayMode(.inline)
     .navigationBarBackButtonHidden(true)
     .preservesPasturaSwipeBackGesture()
     .toolbar {

--- a/Pastura/Pastura/Views/Settings/SettingsView.swift
+++ b/Pastura/Pastura/Views/Settings/SettingsView.swift
@@ -4,12 +4,14 @@ import os
 /// Settings screen hosting the Models section (device only) and a
 /// Legal section with Privacy Policy + content-report sheet.
 ///
-/// Pushed onto the root `NavigationStack` via `Route.settings`. Per
+/// The Settings tab's root content, mounted in the tab's
+/// `NavigationStack` by `RootTabView` (ADR-016 D4). Per
 /// `.claude/rules/navigation.md`, this view must NOT add
-/// `navigationDestination(item:|isPresented:)` modifiers — sheets
-/// (`.sheet(isPresented:)`) and `.fullScreenCover(item:)` are exempt
-/// from that rule and are used here for the report sheet and download
-/// cover respectively.
+/// `navigationDestination(item:|isPresented:)` modifiers — the tab's
+/// stack runs the same `Route` destination registry, so mixing scopes
+/// would fight it; sheets (`.sheet(isPresented:)`) and
+/// `.fullScreenCover(item:)` are exempt from that rule and are used
+/// here for the report sheet and download cover respectively.
 ///
 /// ## Models section (device only)
 ///
@@ -168,14 +170,6 @@ struct SettingsView: View {
     .task { await loadStorageUsage() }
     .navigationTitle(String(localized: "Settings"))
     .navigationBarTitleDisplayMode(.inline)
-    .navigationBarBackButtonHidden(true)
-    .preservesPasturaSwipeBackGesture()
-    .toolbar {
-      ToolbarItem(placement: .topBarLeading) {
-        PasturaBackButton()
-      }
-      .hidingPasturaSharedBackground()
-    }
     .reportSheet(isPresented: $isReportSheetPresented, context: .general)
     .sheet(isPresented: $isLicensesSheetPresented) {
       LicensesSheet()

--- a/Pastura/PasturaUITests/ScreenshotTourTests.swift
+++ b/Pastura/PasturaUITests/ScreenshotTourTests.swift
@@ -65,10 +65,13 @@ final class ScreenshotTourTests: XCTestCase {
     goBack(app)
     goBack(app)
 
-    // Settings.
-    app.buttons["home.settingsButton"].tap()
+    // Settings — now a dedicated tab (ADR-016 D4), reached via the tab
+    // bar rather than a Home push. Switching tabs doesn't push, so there
+    // is no back chevron here; return to the Home tab afterward so the
+    // subsequent past-results step lands on Home's stack.
+    app.tabBars.buttons["Settings"].tap()
     capture(app, name: "06-settings", anchorId: "settings.licensesLink")
-    goBack(app)
+    app.tabBars.buttons["Home"].tap()
 
     // Past Results (seeded fixture — see StubResultSeeder).
     app.buttons["home.pastResultsButton"].tap()

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -419,15 +419,15 @@ raw `.borderedProminent`（iOS 26 Liquid Glass capsule に opt-in する）は�
 
 ### 5.11 Navigation title display mode（large / inline）
 
-root `NavigationStack` に push される画面の `.navigationBarTitleDisplayMode` 規約。判断軸は **タイトルが「主題の固有名」か「汎用ラベル」か** — 固有名は見出しとして読ませる価値があるので `.large`、汎用ラベルは画面の chrome なので縦スペースを割かない `.inline`。
+各画面の `.navigationBarTitleDisplayMode` 規約。**タブ root（ボトムタブ4本の根）は常に `.inline`** — タブのタイトルは chrome なので静かに、縦スペースを割かない。タブ root 以外の push 画面は **タイトルが「主題の固有名」か「汎用ラベル」か** で判断 — 固有名は見出しとして読ませる価値があるので `.large`、汎用ラベルは chrome なので `.inline`。
 
 | バケット | モード | 画面 |
 |---------|-------|------|
-| ブラウズ / 一覧の根 | `.large` | Home / Shared Scenarios / Results |
+| タブ root（4タブの根） | `.inline` | Home / Shared Scenarios / Past Results / Settings |
 | 主題の固有名がタイトルの詳細 | `.large` | ScenarioDetail / GalleryScenarioDetail（シナリオ名） |
-| エディタ / フォーム / 汎用ラベルの詳細 | `.inline` | ScenarioEditor / Settings / ResultDetail |
+| エディタ / フォーム / 汎用ラベルの詳細 | `.inline` | ScenarioEditor / ResultDetail |
 
-`.large` の多くは modifier 未指定（iOS デフォルトが large）に依存し、明示しているのは `ScenarioDetailView` のみ。新規詳細画面はこの「固有名 → large / 汎用ラベル → inline」基準で判断する。SimulationView は GameHeader（§2.12）がタイトル行を所有する例外で、空タイトル + `.inline`。表示モードは toolbar の可視性 / back button / Liquid Glass opt-out（§5.8・navigation.md）とは直交。
+タブ root ルールは固有名/汎用ラベル軸を上書きする — Home のタイトル `"Pastura"` は固有名だが、タブ root なので `.inline`。4つのタブ root は各 View で明示的に `.inline` を指定する（`HomeView` / `SharedScenariosListView` / `ResultsView` / `SettingsView`）。`Shared Scenarios` / `Past Results` は push でも到達できる（③④で Home 経路が消えるまで）が、どちらも汎用ラベルなので push 版も `.inline` で一貫する。`.large` を明示しているのは固有名詳細の `ScenarioDetailView` のみ（他の large はデフォルト依存）。SimulationView は GameHeader（§2.12）がタイトル行を所有する例外で、空タイトル + `.inline`。表示モードは toolbar の可視性 / back button / Liquid Glass opt-out（§5.8・navigation.md）とは直交。
 
 ---
 

--- a/docs/design/navigation-map.md
+++ b/docs/design/navigation-map.md
@@ -20,12 +20,10 @@ flowchart TD
   resultDetail["Result Detail"]
   sharedScenarios["Shared Scenarios"]
   galleryScenarioDetail["Gallery Scenario Detail"]
-  settings["Settings"]
   galleryScenarioDetail --> scenarioDetail
   home -->|"via newScenarioRoute()"| editor
   home --> results
   home --> scenarioDetail
-  home --> settings
   home --> sharedScenarios
   results --> resultDetail
   scenarioDetail --> editor
@@ -52,4 +50,3 @@ the tour's per-screen wait identifiers.
 | `resultDetail` | Result Detail | `results` | `resultDetail.timeline` | `08-result-detail.png` |
 | `sharedScenarios` | Shared Scenarios | `home` | `sharedScenarios.galleryCell.*` | `04-shared-scenarios.png` |
 | `galleryScenarioDetail` | Gallery Scenario Detail | `scenarioDetail`, `sharedScenarios` | `galleryDetail.tryButton` | `05-gallery-detail.png` |
-| `settings` | Settings | `home` | `settings.licensesLink` | `06-settings.png` |


### PR DESCRIPTION
## Summary
Sub-PR ② of Home redesign P1 (ADR-016 D4). Settings is now reached only via
its dedicated bottom tab (wired in ①), so this removes the push route entirely.

- Delete `Route.settings` + its `RouteResolver` arm + the Home toolbar settings
  button. Compile-error-driven: the now-exhaustive `switch` in `RouteResolver`
  surfaces any stray consumer at build time.
- Strip `SettingsView`'s back-nav chrome (`PasturaBackButton` /
  `.navigationBarBackButtonHidden(true)` / `.preservesPasturaSwipeBackGesture()`
  / now-empty toolbar) now that it's a tab root, not a pushed view. The
  `navigationDestination(item:|isPresented:)` prohibition in the doc comment is
  kept — the tab's `NavigationStack` runs the same `Route` registry.
- Update `ScreenshotTourTests` to reach Settings via the tab bar.
- Regenerate `docs/design/navigation-map.md` (CI drift guard) after the
  `Route.settings` removal.

### Follow-on: inline title across all tab roots
Settings already used an inline navigation title; Home / Shared Scenarios /
Past Results were large, leaving the four tab roots inconsistent. Add
`.navigationBarTitleDisplayMode(.inline)` to the three and revise
design-system § 5.11 from "browse/list root → large" to "tab root → inline".
Shared/Results stay push-reachable until ③/④; their titles are generic labels,
so inline is convention-correct for the push variant too.

`AppTab.settings` (the tab enum) is untouched.

## Test plan
- Full unit suite: **1917 tests / 174 suites pass** (re-run after the title-mode change)
- `swiftlint --strict`: clean
- Build green at each commit (compile-error-driven removal verified)
- navigation-map `--self-test` 7/7 + `--check` up to date
- Pre-impl critic + **two** Opus code-reviews (settings-tab removal, then the
  title-mode delta): **PASS / 0 issues**
- Real-device QA (settings-tab behavior): **all pass**. Title-mode visual
  (Home/Shared/Results now inline) is a small added delta — worth a quick
  glance on device.

Part of #612

Follow-up tooling issue (tour table single-source): #622

🤖 Generated with [Claude Code](https://claude.com/claude-code)
