### PR TITLE
🧪 test: deep-link → Search-tab routing UI test (D5.2)

### DIFF
--- a/Pastura/Pastura/PasturaApp.swift
+++ b/Pastura/Pastura/PasturaApp.swift
@@ -710,6 +710,16 @@ private struct RootView: View {
             simulationRepository: deps.simulationRepository,
             turnRepository: deps.turnRepository)
         }
+        // Deep-link injection for UI tests: queue a `pastura://` URL before
+        // `.ready` so the existing gate drains it via the `appStateKind`
+        // onChange once deps are up — the same queue-then-drain path a real
+        // pre-`.ready` `onOpenURL` would take. Exercises D5 deep-link →
+        // Search-tab routing end-to-end (DeepLinkTabRoutingUITests).
+        if let idx = CommandLine.arguments.firstIndex(of: "--ui-test-open-deeplink"),
+          idx + 1 < CommandLine.arguments.count,
+          let url = URL(string: CommandLine.arguments[idx + 1]) {
+          gate.pendingURL = url
+        }
         appState = .ready(deps)
       } catch {
         appState = .error("UI test setup failed: \(error.localizedDescription)")

--- a/Pastura/PasturaUITests/DeepLinkTabRoutingUITests.swift
+++ b/Pastura/PasturaUITests/DeepLinkTabRoutingUITests.swift
@@ -1,0 +1,57 @@
+import XCTest
+
+/// Verifies ADR-016 **D5.2** end-to-end: a deep link resolving to a gallery
+/// scenario selects the さがす (Search) tab and pushes
+/// `.galleryScenarioDetail` onto **that** tab's router — the target tab is
+/// fixed by the resolution kind, NOT the currently-selected (launch-default
+/// Home) tab.
+///
+/// The coordinator-level mechanism is unit-tested in `TabCoordinatorTests`;
+/// this covers the `tryDrain` / `applyResolution` glue that no unit test can
+/// reach. The deep link is injected via the DEBUG-only
+/// `--ui-test-open-deeplink` launch hook, which queues the URL before
+/// `.ready` so the existing gate drains it once dependencies are up — the
+/// same queue-then-drain path a real pre-`.ready` `onOpenURL` takes.
+@MainActor
+final class DeepLinkTabRoutingUITests: XCTestCase {
+  override func setUpWithError() throws {
+    continueAfterFailure = false
+  }
+
+  override func tearDownWithError() throws {
+    // Explicit terminate so the simulator releases the app process before the
+    // next test class launches a fresh one (mirrors NavigationRegressionTests;
+    // avoids background-assertion infra errors on resource-tight CI sims).
+    XCUIApplication().terminate()
+  }
+
+  func testDeepLinkSelectsSearchTabAndPushesGalleryDetail() throws {
+    let app = XCUIApplication()
+    app.launchArguments = [
+      "--ui-test",
+      "--ui-test-open-deeplink", "pastura://scenario/ui_test_canary"
+    ]
+    app.launch()
+
+    // The drain pushes GalleryScenarioDetailView onto the Search tab's stack.
+    // Because all four tab NavigationStacks are mounted at once, only the
+    // *selected* tab's pushed content renders — so the Try button being
+    // on-screen proves the detail landed on the foreground (Search) stack.
+    let tryButton = app.buttons["galleryDetail.tryButton"]
+    XCTAssertTrue(
+      tryButton.waitForExistence(timeout: 10),
+      "Deep link did not drain to the gallery detail — Search tab + push glue regressed.")
+
+    // D5.2 positive: the さがす tab (accessibilityLabel "Browse") is selected.
+    XCTAssertTrue(
+      app.tabBars.buttons["Browse"].isSelected,
+      "Search tab is not selected after the deep link.")
+
+    // D5.2 negative (load-bearing): the app launched on Home, so a passing
+    // test must prove it switched AWAY from the launch-default tab — the
+    // target tab is fixed by the resolution kind, not the current selection.
+    XCTAssertFalse(
+      app.tabBars.buttons["Home"].isSelected,
+      "Home tab is still selected — deep link did not switch to the Search tab.")
+  }
+}


### PR DESCRIPTION
## Summary
- End-to-end UI test for ADR-016 **D5.2**: a `pastura://scenario/<id>` deep link selects the さがす (Search) tab and pushes `.galleryScenarioDetail` onto THAT tab's router — target tab fixed by the resolution kind, not the launch-default Home tab.
- Closes the UI-level gap from P1 ① (the coordinator mechanism is unit-tested in `TabCoordinatorTests`; the `tryDrain`/`applyResolution` glue was not). Pulled forward from sub-PR ⑤.
- Injection: a DEBUG-only `--ui-test-open-deeplink` launch hook in `setupUITestState()` — mirrors the existing `--ui-test-*` args and queues the URL pre-`.ready` so the existing deep-link gate drains it once deps are up.

## Test plan
- New `DeepLinkTabRoutingUITests` (1 test): `galleryDetail.tryButton` visible (timeout 10) + `tabBars.buttons["Browse"].isSelected` + `XCTAssertFalse(...Home...isSelected)` (the negative pins the switch-away). Passed locally (11.1 s).
- `swiftlint --strict` clean. Opus code-review PASS (0 issues).
- Full suite deferred to this PR's CI (integration-branch trigger added in ①).

Concurrency: no file overlap with the parallel sub-PR ② (#620) — this PR touches only `PasturaApp.swift` (a DEBUG leaf in `setupUITestState`) + the new UITest file.

Closes #619
Part of #612

🤖 Generated with [Claude Code](https://claude.com/claude-code)