### PR TITLE
♻️ refactor: Home P1 ③ — drop Route.sharedScenarios for Browse tab

### DIFF
--- a/Pastura/Pastura/App/RouteResolver.swift
+++ b/Pastura/Pastura/App/RouteResolver.swift
@@ -33,8 +33,6 @@ struct RouteResolver: View {
       ResultsView(scenarioId: scenarioId)
     case .resultDetail(let simulationId):
       ResultDetailView(simulationId: simulationId)
-    case .sharedScenarios:
-      SharedScenariosListView()
     case .galleryScenarioDetail(let scenario):
       GalleryScenarioDetailView(scenario: scenario)
     }

--- a/Pastura/Pastura/App/Router.swift
+++ b/Pastura/Pastura/App/Router.swift
@@ -59,9 +59,6 @@ enum Route: Hashable {
   /// Detail view for a specific past simulation run.
   case resultDetail(simulationId: String)
 
-  /// Shared Scenarios — browse a curated gallery of scenarios.
-  case sharedScenarios
-
   /// Detail view for a single gallery scenario, with Try / Update action.
   case galleryScenarioDetail(scenario: GalleryScenario)
 }

--- a/Pastura/Pastura/Views/Community/SharedScenarios/SharedScenariosListView.swift
+++ b/Pastura/Pastura/Views/Community/SharedScenarios/SharedScenariosListView.swift
@@ -1,6 +1,9 @@
 import SwiftUI
 
-/// Browse view for the curated gallery of scenarios (Shared Scenarios).
+/// Root of the "Browse" (さがす) tab — a curated gallery of scenarios
+/// (Shared Scenarios). As a tab root it carries no back chrome; it
+/// pushes ``Route/galleryScenarioDetail(scenario:)`` onto its own tab
+/// stack (ADR-016 D4).
 struct SharedScenariosListView: View {
   @Environment(AppDependencies.self) private var dependencies
   @State private var viewModel: SharedScenariosViewModel?
@@ -14,18 +17,8 @@ struct SharedScenariosListView: View {
       }
     }
     .navigationTitle(String(localized: "Shared Scenarios"))
-    // Inline title to match the other tab roots (design-system § 5.11);
-    // "Shared Scenarios" is a generic label, so inline is consistent for
-    // the push variant too.
+    // Inline title to match the other tab roots (design-system § 5.11).
     .navigationBarTitleDisplayMode(.inline)
-    .navigationBarBackButtonHidden(true)
-    .preservesPasturaSwipeBackGesture()
-    .toolbar {
-      ToolbarItem(placement: .topBarLeading) {
-        PasturaBackButton()
-      }
-      .hidingPasturaSharedBackground()
-    }
     .task {
       let newViewModel = SharedScenariosViewModel(
         galleryService: dependencies.galleryService,

--- a/Pastura/Pastura/Views/Home/HomeView.swift
+++ b/Pastura/Pastura/Views/Home/HomeView.swift
@@ -126,18 +126,12 @@ struct HomeView: View {
     }
   }
 
-  /// Entry rows for the curated gallery and past results — navigation
-  /// destinations that aren't tied to a single scenario row.
+  /// Entry row for past results — a navigation destination that isn't
+  /// tied to a single scenario row. (Shared Scenarios moved to its own
+  /// "Browse" tab in ADR-016 D4, so it is no longer a Home push.)
   @ViewBuilder
   private func browseSection() -> some View {
     Section {
-      NavigationLink(value: Route.sharedScenarios) {
-        navRowLabel(
-          title: String(localized: "Shared Scenarios"),
-          systemImage: "square.grid.2x2.fill")
-      }
-      .accessibilityIdentifier("home.sharedScenariosButton")
-      .pasturaCardRow()
       NavigationLink(value: Route.results(scenarioId: "")) {
         navRowLabel(
           title: String(localized: "Past Results"),

--- a/Pastura/PasturaTests/App/AppRouterTests.swift
+++ b/Pastura/PasturaTests/App/AppRouterTests.swift
@@ -13,18 +13,18 @@ import Testing
 
   @Test func pushAppendsRoute() {
     let router = AppRouter()
-    router.push(.sharedScenarios)
-    #expect(router.path == [.sharedScenarios])
+    router.push(.resultDetail(simulationId: ""))
+    #expect(router.path == [.resultDetail(simulationId: "")])
     router.push(.scenarioDetail(scenarioId: "x"))
-    #expect(router.path == [.sharedScenarios, .scenarioDetail(scenarioId: "x")])
+    #expect(router.path == [.resultDetail(simulationId: ""), .scenarioDetail(scenarioId: "x")])
   }
 
   @Test func popRemovesLast() {
     let router = AppRouter()
-    router.push(.sharedScenarios)
+    router.push(.resultDetail(simulationId: ""))
     router.push(.scenarioDetail(scenarioId: "x"))
     router.pop()
-    #expect(router.path == [.sharedScenarios])
+    #expect(router.path == [.resultDetail(simulationId: "")])
   }
 
   @Test func popOnEmptyIsNoOp() {
@@ -35,7 +35,7 @@ import Testing
 
   @Test func popToRootClearsPath() {
     let router = AppRouter()
-    router.push(.sharedScenarios)
+    router.push(.resultDetail(simulationId: ""))
     router.push(.scenarioDetail(scenarioId: "x"))
     router.push(.simulation(scenarioId: "x"))
     router.popToRoot()
@@ -44,14 +44,14 @@ import Testing
 
   @Test func replacePathOverwrites() {
     let router = AppRouter()
-    router.push(.sharedScenarios)
+    router.push(.resultDetail(simulationId: ""))
     router.replacePath([.results(scenarioId: "y"), .resultDetail(simulationId: "z")])
     #expect(router.path == [.results(scenarioId: "y"), .resultDetail(simulationId: "z")])
   }
 
   @Test func replacePathWithEmptyClearsPath() {
     let router = AppRouter()
-    router.push(.sharedScenarios)
+    router.push(.resultDetail(simulationId: ""))
     router.push(.scenarioDetail(scenarioId: "x"))
     router.replacePath([])
     #expect(router.path.isEmpty)
@@ -59,8 +59,8 @@ import Testing
 
   @Test func replacePathFromEmptySeedsPath() {
     let router = AppRouter()
-    router.replacePath([.sharedScenarios, .scenarioDetail(scenarioId: "x")])
-    #expect(router.path == [.sharedScenarios, .scenarioDetail(scenarioId: "x")])
+    router.replacePath([.resultDetail(simulationId: ""), .scenarioDetail(scenarioId: "x")])
+    #expect(router.path == [.resultDetail(simulationId: ""), .scenarioDetail(scenarioId: "x")])
   }
 
   // MARK: - pushIfOnTop guard
@@ -81,8 +81,8 @@ import Testing
 
   @Test func pushIfOnTopSkipsWhenExpectedDoesNotMatch() {
     let router = AppRouter()
-    // User has already navigated away (e.g. popped back to Shared Scenarios).
-    router.push(.sharedScenarios)
+    // User has already navigated away (e.g. popped back to an earlier screen).
+    router.push(.resultDetail(simulationId: ""))
 
     let scenario = makeGalleryScenario(id: "asch_v1")
     let pushed = router.pushIfOnTop(
@@ -90,13 +90,13 @@ import Testing
       next: .scenarioDetail(scenarioId: "asch_v1"))
 
     #expect(!pushed)
-    #expect(router.path == [.sharedScenarios])
+    #expect(router.path == [.resultDetail(simulationId: "")])
   }
 
   @Test func pushIfOnTopSkipsWhenPathIsEmpty() {
     let router = AppRouter()
     let pushed = router.pushIfOnTop(
-      expected: .sharedScenarios,
+      expected: .resultDetail(simulationId: ""),
       next: .scenarioDetail(scenarioId: "x"))
     #expect(!pushed)
     #expect(router.path.isEmpty)
@@ -107,14 +107,14 @@ import Testing
     // not enough — it must be the current top. Guards against a future
     // well-meaning refactor that loosens the check to `path.contains`.
     let router = AppRouter()
-    router.push(.sharedScenarios)
-    router.push(.scenarioDetail(scenarioId: "x"))  // sharedScenarios is now mid-stack
+    router.push(.resultDetail(simulationId: ""))
+    router.push(.scenarioDetail(scenarioId: "x"))  // resultDetail is now mid-stack
 
     let pushed = router.pushIfOnTop(
-      expected: .sharedScenarios,
+      expected: .resultDetail(simulationId: ""),
       next: .results(scenarioId: "y"))
     #expect(!pushed)
-    #expect(router.path == [.sharedScenarios, .scenarioDetail(scenarioId: "x")])
+    #expect(router.path == [.resultDetail(simulationId: ""), .scenarioDetail(scenarioId: "x")])
   }
 
   // MARK: - RouteHint identity-neutrality (ADR-008)

--- a/Pastura/PasturaUITests/NavigationRegressionTests.swift
+++ b/Pastura/PasturaUITests/NavigationRegressionTests.swift
@@ -32,17 +32,18 @@ final class NavigationRegressionTests: XCTestCase {
       app.navigationBars["Pastura"].waitForExistence(timeout: 10),
       "Home did not appear within 10s.")
 
-    // Home → Shared Scenarios.
-    let sharedScenariosCell = app.buttons["home.sharedScenariosButton"]
+    // Switch to the Browse tab (Shared Scenarios is its root since
+    // ADR-016 D4 — no longer a Home push).
+    let browseTab = app.tabBars.buttons["Browse"]
     XCTAssertTrue(
-      sharedScenariosCell.waitForExistence(timeout: 5), "Shared Scenarios entry missing.")
-    sharedScenariosCell.tap()
+      browseTab.waitForExistence(timeout: 5), "Browse tab missing.")
+    browseTab.tap()
 
     XCTAssertTrue(
       app.navigationBars["Shared Scenarios"].waitForExistence(timeout: 5),
       "Shared Scenarios did not appear.")
 
-    // Shared Scenarios → Gallery scenario detail.
+    // Shared Scenarios → Gallery scenario detail (push within the Browse tab).
     let galleryCell = app.buttons["sharedScenarios.galleryCell.ui_test_canary"]
     XCTAssertTrue(
       galleryCell.waitForExistence(timeout: 5),

--- a/Pastura/PasturaUITests/ScreenshotTourTests.swift
+++ b/Pastura/PasturaUITests/ScreenshotTourTests.swift
@@ -53,16 +53,20 @@ final class ScreenshotTourTests: XCTestCase {
     capture(app, name: "03-editor", anchorId: "editor.titleField")
     goBack(app)
 
-    // Shared Scenarios gallery (StubGalleryService fixture content).
-    app.buttons["home.sharedScenariosButton"].tap()
+    // Shared Scenarios gallery — now the "Browse" tab root (ADR-016 D4),
+    // reached via the tab bar rather than a Home push.
+    app.tabBars.buttons["Browse"].tap()
     capture(
       app, name: "04-shared-scenarios",
       anchorId: "sharedScenarios.galleryCell.ui_test_canary")
 
-    // Gallery scenario detail.
+    // Gallery scenario detail (push within the Browse tab stack).
     app.buttons["sharedScenarios.galleryCell.ui_test_canary"].tap()
     capture(app, name: "05-gallery-detail", anchorId: "galleryDetail.tryButton")
-    goBack(app)
+    // Single goBack pops the gallery detail back to the Browse tab root,
+    // which has no back chevron. (No second goBack: the Home tab kept an
+    // empty stack throughout, so the Settings → Home tab switch below still
+    // lands on Home's root for the past-results step.)
     goBack(app)
 
     // Settings — now a dedicated tab (ADR-016 D4), reached via the tab

--- a/docs/design/navigation-map.md
+++ b/docs/design/navigation-map.md
@@ -7,24 +7,24 @@
 Screen graph of the root stack, generated from `Route` enum cases and
 `NavigationLink` / `router.push` / `pushIfOnTop` callsites. Sheets and
 fullScreenCover flows are out of scope (`AppRouter` manages the root
-stack only — see `.claude/rules/navigation.md`). `home` is the stack
-root (`HomeView`), not a `Route` case.
+stack only — see `.claude/rules/navigation.md`). `home` (`HomeView`)
+and `sharedScenarios` (`SharedScenariosListView`, the Browse tab root)
+are tab-stack roots, not `Route` cases.
 
 ```mermaid
 flowchart TD
   home([Home])
+  sharedScenarios([Shared Scenarios])
   scenarioDetail["Scenario Detail"]
   editor["Scenario Editor"]
   simulation["Simulation"]
   results["Past Results"]
   resultDetail["Result Detail"]
-  sharedScenarios["Shared Scenarios"]
   galleryScenarioDetail["Gallery Scenario Detail"]
   galleryScenarioDetail --> scenarioDetail
   home -->|"via newScenarioRoute()"| editor
   home --> results
   home --> scenarioDetail
-  home --> sharedScenarios
   results --> resultDetail
   scenarioDetail --> editor
   scenarioDetail --> galleryScenarioDetail
@@ -43,10 +43,10 @@ the tour's per-screen wait identifiers.
 | Node | Screen | Pushed from | Tour anchor | Screenshot |
 |------|--------|-------------|-------------|------------|
 | `home` | Home | — (stack root) | `home.scenarioListCell.*` | `01-home.png` |
+| `sharedScenarios` | Shared Scenarios | — (stack root) | `sharedScenarios.galleryCell.*` | `04-shared-scenarios.png` |
 | `scenarioDetail` | Scenario Detail | `galleryScenarioDetail`, `home`, `scenarioDetail` | `scenarioDetail.list` | `02-scenario-detail.png` |
 | `editor` | Scenario Editor | `home`, `scenarioDetail` | `editor.titleField` | `03-editor.png` |
 | `simulation` | Simulation | `scenarioDetail` | — | deferred — see `screenshots/README.md` |
 | `results` | Past Results | `home`, `scenarioDetail` | `results.list` | `07-results.png` |
 | `resultDetail` | Result Detail | `results` | `resultDetail.timeline` | `08-result-detail.png` |
-| `sharedScenarios` | Shared Scenarios | `home` | `sharedScenarios.galleryCell.*` | `04-shared-scenarios.png` |
 | `galleryScenarioDetail` | Gallery Scenario Detail | `scenarioDetail`, `sharedScenarios` | `galleryDetail.tryButton` | `05-gallery-detail.png` |

--- a/scripts/generate-navigation-map.py
+++ b/scripts/generate-navigation-map.py
@@ -97,7 +97,6 @@ NODE_INFO = {
     "resultDetail": ("Result Detail", "resultDetail.timeline", "08-result-detail"),
     "sharedScenarios": ("Shared Scenarios", "sharedScenarios.galleryCell.*", "04-shared-scenarios"),
     "galleryScenarioDetail": ("Gallery Scenario Detail", "galleryDetail.tryButton", "05-gallery-detail"),
-    "settings": ("Settings", "settings.licensesLink", "06-settings"),
 }
 
 HEADER = """\

--- a/scripts/generate-navigation-map.py
+++ b/scripts/generate-navigation-map.py
@@ -4,8 +4,10 @@
 Derives the screen graph from code so the committed map never drifts:
 
 - **Nodes**: ``Route`` enum cases parsed from ``Pastura/Pastura/App/Router.swift``
-  plus a synthetic ``home`` root (HomeView owns the stack root; it is not a
-  Route case).
+  plus the synthetic tab-stack roots in ``SYNTHETIC_ROOTS`` — ``home``
+  (HomeView) and ``sharedScenarios`` (SharedScenariosListView, the Browse
+  tab root since ADR-016 D4). These own a tab's NavigationStack but are not
+  Route cases.
 - **Edges**: callsites of ``NavigationLink(value: Route.X ...)``,
   ``router.push(.X)`` (forward-looking — zero callsites today), and
   ``router.pushIfOnTop(... next: .X ...)`` scanned across ``Views/`` and
@@ -73,6 +75,15 @@ MANUAL_EDGES = [
 # Helper identifiers covered by MANUAL_EDGES. NavigationLink(value: <id>())
 # with an identifier outside this set is an error.
 KNOWN_HELPERS = {"newScenarioRoute"}
+
+# Synthetic stack-root nodes — own a tab's NavigationStack root but are not
+# Route cases. `home` = Home tab (HomeView). `sharedScenarios` = Browse tab
+# (SharedScenariosListView): ADR-016 D4 deleted its Route case, but it still
+# pushes Route.galleryScenarioDetail onto its own tab stack, so it remains an
+# edge SOURCE and must be a known node. (Settings is also a tab root but
+# pushes no Route, so it needs no node here.) Rendered with the rounded
+# stadium shape to mark them as roots.
+SYNTHETIC_ROOTS = ("home", "sharedScenarios")
 
 # Display label, screenshot-tour anchor identifier, and ui-tour.sh
 # screenshot name per node. Screenshot "None" renders as deferred (see
@@ -173,7 +184,7 @@ def collect_edges() -> tuple[list[tuple[str, str, str]], list[str]]:
 
 
 def emit_markdown(route_cases: list[str], edges: list[tuple[str, str, str]]) -> str:
-    nodes = ["home"] + route_cases
+    nodes = list(SYNTHETIC_ROOTS) + route_cases
     incoming_sources: dict[str, set[str]] = {n: set() for n in nodes}
     for source, target, _ in edges:
         if target in incoming_sources:
@@ -185,14 +196,15 @@ def emit_markdown(route_cases: list[str], edges: list[tuple[str, str, str]]) -> 
         "Screen graph of the root stack, generated from `Route` enum cases and\n"
         "`NavigationLink` / `router.push` / `pushIfOnTop` callsites. Sheets and\n"
         "fullScreenCover flows are out of scope (`AppRouter` manages the root\n"
-        "stack only — see `.claude/rules/navigation.md`). `home` is the stack\n"
-        "root (`HomeView`), not a `Route` case.\n"
+        "stack only — see `.claude/rules/navigation.md`). `home` (`HomeView`)\n"
+        "and `sharedScenarios` (`SharedScenariosListView`, the Browse tab root)\n"
+        "are tab-stack roots, not `Route` cases.\n"
     )
     lines.append("```mermaid")
     lines.append("flowchart TD")
     for node in nodes:
         label = NODE_INFO.get(node, (node, None, None))[0]
-        shape = f"([{label}])" if node == "home" else f'["{label}"]'
+        shape = f"([{label}])" if node in SYNTHETIC_ROOTS else f'["{label}"]'
         lines.append(f"  {node}{shape}")
     seen = set()
     for source, target, label in sorted(edges):
@@ -224,7 +236,7 @@ def emit_markdown(route_cases: list[str], edges: list[tuple[str, str, str]]) -> 
 def generate() -> tuple[str, list[str]]:
     route_cases = parse_route_cases(ROUTER_FILE.read_text(encoding="utf-8"))
     edges, errors = collect_edges()
-    known = set(["home"] + route_cases)
+    known = set(SYNTHETIC_ROOTS) | set(route_cases)
     for source, target, _ in edges:
         if target not in known:
             errors.append(f"edge target '.{target}' is not a Route case — scanner or Route drift")
@@ -295,9 +307,21 @@ def self_test() -> int:
     edges, errs = scan_file_edges("Pastura/Pastura/Views/Settings/SettingsView.swift", "NavigationLink(value: Route.editor()) {}\n")
     check("unknown file: attribution error", edges == [] and len(errs) == 1 and "FILE_TO_SCREEN" in errs[0])
 
+    # SYNTHETIC_ROOTS regression (ADR-016 D4): a tab root whose Route case was
+    # deleted but which still owns an outgoing edge (sharedScenarios →
+    # galleryScenarioDetail) must render as a rounded, sourceless root — not
+    # trip the "unknown node" guard. Exercises emit_markdown, which the seven
+    # fixtures above never touch.
+    md = emit_markdown(["galleryScenarioDetail"], [("sharedScenarios", "galleryScenarioDetail", "")])
+    check(
+        "synthetic root: sourceless rounded tab root",
+        "sharedScenarios([Shared Scenarios])" in md
+        and "| `sharedScenarios` | Shared Scenarios | — (stack root) |" in md,
+    )
+
     for name in failures:
         print(f"SELF-TEST FAIL: {name}", file=sys.stderr)
-    print(f"self-test: {7 - len(failures)}/7 passed")
+    print(f"self-test: {8 - len(failures)}/8 passed")
     return 1 if failures else 0
 
 


### PR DESCRIPTION
## Summary
Sub-PR ③ of the Home redesign P1 split (ADR-016 D4). `SharedScenariosListView`
has been the "Browse" (さがす) tab root since ①, so its `Route` case is no
longer a push destination. Deleting `Route.sharedScenarios` turns every stray
push into a compile error, surfacing the full migration surface mechanically.

- **Router / RouteResolver**: remove `case sharedScenarios` + its resolver arm.
- **HomeView**: remove the "Shared Scenarios" browse row + `home.sharedScenariosButton`.
- **SharedScenariosListView**: strip push-era back chrome (`PasturaBackButton`,
  `navigationBarBackButtonHidden`, `preservesPasturaSwipeBackGesture`, empty
  `.toolbar`); keep `.navigationBarTitleDisplayMode(.inline)` per the tab-root
  convention (design-system §5.11).
- **AppRouterTests**: the case was the only parameterless generic fixture —
  swap to `.resultDetail(simulationId: "")` (collision-free).
- **NavigationRegression / ScreenshotTour**: enter via the Browse tab; drop
  ScreenshotTour's second `goBack` (tab roots have no back chevron).
- **navigation-map generator**: `SYNTHETIC_ROOTS = (home, sharedScenarios)` so
  the Browse tab root stays a sourceless node owning the
  `sharedScenarios -> galleryScenarioDetail` edge; +1 self-test fixture; map regenerated.

`Route.galleryScenarioDetail` stays a push within the Browse tab — unchanged.

## Test plan
- ✅ Unit suite: 1917 tests / 174 suites pass
- ✅ `NavigationRegressionTests` UI test (Browse-tab entry): 1 test, 0 failures
- ✅ `swiftlint --strict` clean
- ✅ nav-map `--self-test` 8/8, `--check` up to date
- ✅ `git grep .sharedScenarios` / `sharedScenariosButton`: zero residual
- ✅ Opus code review: PASS (0 issues)

Part of #612.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
