### PR TITLE
✨ feat: rename inference "THINKING" label to "INNER VOICE"

### DIFF
--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -4432,12 +4432,12 @@
         }
       }
     },
-    "THINKING" : {
+    "INNER VOICE" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "考え中"
+            "value" : "心の声"
           }
         }
       }

--- a/Pastura/Pastura/Views/Components/AgentOutputRow.swift
+++ b/Pastura/Pastura/Views/Components/AgentOutputRow.swift
@@ -394,7 +394,7 @@ struct AgentOutputRow: View {
     // the accent color is preserved by the per-segment foregroundStyle.
     (Text(showInnerThought ? "▾ " : "▸ ")
       .foregroundStyle(Color.moss)
-      + Text(String(localized: "THINKING"))
+      + Text(String(localized: "INNER VOICE"))
       .foregroundStyle(Color.muted))
       .textStyle(Typography.thinkingTag)
       // 44pt tap target via the **negative-padding trick**.

--- a/docs/design/demo-replay-reference.html
+++ b/docs/design/demo-replay-reference.html
@@ -346,8 +346,8 @@ function bubble(x, opts={}){
         <div class="b-name">${x.who}</div>
         <div class="b-text">${x.bubble}</div>
         ${opts.showInner
-          ? `<div class="b-inner"><span class="tag">THINKING</span>${x.inner}</div>`
-          : `<div class="b-inner collapsed">THINKING</div>`}
+          ? `<div class="b-inner"><span class="tag">INNER VOICE</span>${x.inner}</div>`
+          : `<div class="b-inner collapsed">INNER VOICE</div>`}
       </div>
     </div>`;
 }

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -206,7 +206,7 @@ Pastura 唯一のブランド色。用途別に4段階。
 | `body/promo` | 12pt | 400 | 1.65 | 0 | プロモ文 |
 | `caption/name` | 10.5pt | 400 | 1.3 | 0.04em | アバター下の名前 |
 | `thinking/body` | 10.5pt | 400 italic | 1.7 | 0.02em | 内なる思考 |
-| `thinking/tag` | 8.5pt | 400 mono UPPER | 1.2 | 0.22em | REASON/THINKING ラベル |
+| `thinking/tag` | 8.5pt | 400 mono UPPER | 1.2 | 0.22em | REASON/INNER VOICE ラベル |
 | `meta/label` | 9pt | 600 mono | 1.2 | 0.06em | meta labels (DL / Vote Results / Round / sub-phase) |
 | `meta/value` | 9pt | 400 mono | 1.2 | 0 | `35%`, `1.0 GB` |
 | `meta/eta` | 10pt | 500 mono | 1.3 | 0 | 残り約4分 |
@@ -272,7 +272,7 @@ box-shadow:
 ```
 [Avatar 48pt]  Alice
                [バブル: しっぽは上左]
-               ▸ THINKING / ▾ タグ＋本文
+               ▸ INNER VOICE / ▾ タグ＋本文
 ```
 
 - バブル間 spacing: 14pt

--- a/docs/design/ds/chat-bubble.html
+++ b/docs/design/ds/chat-bubble.html
@@ -1,4 +1,4 @@
-<!-- @dsCard group="Components" name="Chat bubble" subtitle="Tailed bubble + THINKING expansion, 48pt avatar (§5.2)" -->
+<!-- @dsCard group="Components" name="Chat bubble" subtitle="Tailed bubble + INNER VOICE expansion, 48pt avatar (§5.2)" -->
 <!doctype html>
 <html lang="ja">
 <head>
@@ -50,7 +50,7 @@
           <div class="who t-caption-name">Alice</div>
           <div class="bubble t-body-bubble">おはよう。今日は北の柵のあたりが、いつもより静かみたいだね。</div>
           <div class="thinking">
-            <span class="tag t-thinking-tag">thinking</span>
+            <span class="tag t-thinking-tag">inner voice</span>
             <span class="body t-thinking-body">みんなの様子を先に聞いてから、自分の見たことを話そう。</span>
           </div>
         </div>
@@ -67,7 +67,7 @@
         </div>
       </div>
     </div>
-    <p class="section-note">フェードイン: 700ms ease-out・180ms ずつディレイ（§5.2 / §6 — 本カードは静的見本）。THINKING は --moss-soft の左線 + thinking/tag + thinking/body のセット。バブル背景は --bubble-bg、シャドウは §4.3 の2レイヤー。</p>
+    <p class="section-note">フェードイン: 700ms ease-out・180ms ずつディレイ（§5.2 / §6 — 本カードは静的見本）。INNER VOICE は --moss-soft の左線 + thinking/tag + thinking/body のセット。バブル背景は --bubble-bg、シャドウは §4.3 の2レイヤー。</p>
   </div>
 </div>
 </body>

--- a/docs/specs/demo-replay-ui.md
+++ b/docs/specs/demo-replay-ui.md
@@ -100,7 +100,7 @@ HTML/CSS/JS をそのまま移植せず、**SwiftUI のイディオム**（`VSta
 - **PromoCard**: 起動時は Slot A 表示（独立タイマー駆動で 〜20 秒後に B へ、DL 進捗とは無関係）
 
 ### Frame 2 — デモ序盤の全員発話
-- **状態**: Alice, Bob, Carol, Dave の 4 発言が順次フェードイン（各 180ms ディレイ）。Dave にのみ "THINKING"（内なる思考）を展開
+- **状態**: Alice, Bob, Carol, Dave の 4 発言が順次フェードイン（各 180ms ディレイ）。Dave にのみ "INNER VOICE"（内なる思考）を展開
 - **PromoCard**: Slot A / B / C のいずれか（経過時間次第、DL 進捗とは無関係）
 
 ### Frame 3 — デモ中盤の投票フェーズ
@@ -172,7 +172,7 @@ ZStack(alignment: .top) {
 - フォント: 13pt / 色 `#2d2e26` / line-height 1.65
 
 #### THINKING（内なる思考）
-- 折りたたみ時: `▸ THINKING` のみ（8.5pt / モノスペース / `#b1ac92` / letterSpacing 0.22em）
+- 折りたたみ時: `▸ INNER VOICE` のみ（8.5pt / モノスペース / `#b1ac92` / letterSpacing 0.22em）
 - 展開時: 左に1.5pt縦線（`#d4cba8`）、本文は 10.5pt / `#8a876f` / italic / line-height 1.7
 - **デフォルトは展開**。タップでトグル（折りたたみ ↔ 展開）。
 

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -98,10 +98,10 @@ const jsonLd = {
                 </blockquote>
               </div>
               <div class="thinking-toggle" aria-hidden="true">
-                <span class="chev">▾</span><span class="tag">THINKING</span>
+                <span class="chev">▾</span><span class="tag">INNER VOICE</span>
               </div>
               <p class="thought-body">
-                <span class="sr-only">Alice (thinking): </span>Park&rsquo;s vague enough — most outdoor words fit.
+                <span class="sr-only">Alice (inner voice): </span>Park&rsquo;s vague enough — most outdoor words fit.
               </p>
             </div>
           </div>
@@ -128,10 +128,10 @@ const jsonLd = {
                 </blockquote>
               </div>
               <div class="thinking-toggle" aria-hidden="true">
-                <span class="chev">▾</span><span class="tag">THINKING</span>
+                <span class="chev">▾</span><span class="tag">INNER VOICE</span>
               </div>
               <p class="thought-body">
-                <span class="sr-only">Bob (thinking): </span>Echo Alice. Stay safe until I read the room.
+                <span class="sr-only">Bob (inner voice): </span>Echo Alice. Stay safe until I read the room.
               </p>
             </div>
           </div>
@@ -158,10 +158,10 @@ const jsonLd = {
                 </blockquote>
               </div>
               <div class="thinking-toggle" aria-hidden="true">
-                <span class="chev">▾</span><span class="tag">THINKING</span>
+                <span class="chev">▾</span><span class="tag">INNER VOICE</span>
               </div>
               <p class="thought-body">
-                <span class="sr-only">Dave (thinking): </span>A walk…? Mine&rsquo;s nothing like that. Stay vague.
+                <span class="sr-only">Dave (inner voice): </span>A walk…? Mine&rsquo;s nothing like that. Stay vague.
               </p>
             </div>
           </div>
@@ -306,10 +306,10 @@ const jsonLd = {
                     </blockquote>
                   </div>
                   <div class="thinking-toggle" aria-hidden="true">
-                    <span class="chev">▾</span><span class="tag">THINKING</span>
+                    <span class="chev">▾</span><span class="tag">INNER VOICE</span>
                   </div>
                   <p class="thought-body">
-                    <span class="sr-only">Alice (thinking): </span>Bench narrows it — but still sounds innocuous.
+                    <span class="sr-only">Alice (inner voice): </span>Bench narrows it — but still sounds innocuous.
                   </p>
                 </div>
               </div>
@@ -335,10 +335,10 @@ const jsonLd = {
                     </blockquote>
                   </div>
                   <div class="thinking-toggle" aria-hidden="true">
-                    <span class="chev">▾</span><span class="tag">THINKING</span>
+                    <span class="chev">▾</span><span class="tag">INNER VOICE</span>
                   </div>
                   <p class="thought-body">
-                    <span class="sr-only">Dave (thinking): </span>…Alice is the only one who mentioned a bench. Curious.
+                    <span class="sr-only">Dave (inner voice): </span>…Alice is the only one who mentioned a bench. Curious.
                   </p>
                 </div>
               </div>

--- a/web/src/pages/ja/index.astro
+++ b/web/src/pages/ja/index.astro
@@ -97,7 +97,7 @@ const jsonLd = {
                 </blockquote>
               </div>
               <div class="thinking-toggle" aria-hidden="true">
-                <span class="chev">▾</span><span class="tag">THINKING</span>
+                <span class="chev">▾</span><span class="tag">INNER VOICE</span>
               </div>
               <p class="thought-body">
                 <span class="sr-only">アリス（内心）：</span>公園って曖昧。たいていの屋外ワードに当てはまる。
@@ -127,7 +127,7 @@ const jsonLd = {
                 </blockquote>
               </div>
               <div class="thinking-toggle" aria-hidden="true">
-                <span class="chev">▾</span><span class="tag">THINKING</span>
+                <span class="chev">▾</span><span class="tag">INNER VOICE</span>
               </div>
               <p class="thought-body">
                 <span class="sr-only">ボブ（内心）：</span>アリスに合わせよう。様子を見るまでは無難に。
@@ -157,7 +157,7 @@ const jsonLd = {
                 </blockquote>
               </div>
               <div class="thinking-toggle" aria-hidden="true">
-                <span class="chev">▾</span><span class="tag">THINKING</span>
+                <span class="chev">▾</span><span class="tag">INNER VOICE</span>
               </div>
               <p class="thought-body">
                 <span class="sr-only">デイブ（内心）：</span>散歩…？自分は全く違う。曖昧にやり過ごそう。
@@ -309,7 +309,7 @@ const jsonLd = {
                     </blockquote>
                   </div>
                   <div class="thinking-toggle" aria-hidden="true">
-                    <span class="chev">▾</span><span class="tag">THINKING</span>
+                    <span class="chev">▾</span><span class="tag">INNER VOICE</span>
                   </div>
                   <p class="thought-body">
                     <span class="sr-only">アリス（内心）：</span>ベンチで少し絞り込めた。でも、まだ怪しまれない範囲。
@@ -338,7 +338,7 @@ const jsonLd = {
                     </blockquote>
                   </div>
                   <div class="thinking-toggle" aria-hidden="true">
-                    <span class="chev">▾</span><span class="tag">THINKING</span>
+                    <span class="chev">▾</span><span class="tag">INNER VOICE</span>
                   </div>
                   <p class="thought-body">
                     <span class="sr-only">デイブ（内心）：</span>…ベンチに触れたのはアリスだけ。気になる。


### PR DESCRIPTION
## Summary
The collapsible inference section shows each agent's private `inner_thought` / vote `reason` — its true voice behind the public statement, not a loading state. The label "THINKING" (ja "考え中") read as a progress indicator, which is semantically wrong. Rename the displayed label to **"INNER VOICE"** (ja **"心の声"**).

Scope (displayed-label string only):
- **App**: catalog key `"THINKING"` → `"INNER VOICE"` (ja "心の声") + `AgentOutputRow` label
- **LP**: chat-bubble tag ×10 (EN + JA) + EN sr-only labels
- **Design refs**: rendered-label depictions in demo-replay prototype, chat-bubble DS card, design-system bubble diagram, demo-replay-ui spec

Intentionally **unchanged**:
- Progress key `"%@ is thinking..."` (ja "%@ は考え中...") — a genuine progress indicator
- Internal token taxonomy (`thinking/tag`, `Typography.thinkingTag`, CSS `.thinking-toggle`), the "THINKING section/toggle" concept in code comments/tests, and historical-spec prose

## Test plan
- `scripts/xcodebuild.sh test -skip-testing:PasturaUITests` → **TEST SUCCEEDED**
- `swiftlint lint --strict` → clean
- `check_localization_coverage.py` → 462 keys, all ja translated
- critic (plan) + code-reviewer (Opus, diff) → both clean

Closes #630

🤖 Generated with [Claude Code](https://claude.com/claude-code)