### PR TITLE
♻️ refactor: Home P1 ④ — History tab root, split Route.results chrome

### DIFF
--- a/Pastura/Pastura/App/RootTabView.swift
+++ b/Pastura/Pastura/App/RootTabView.swift
@@ -77,9 +77,11 @@ struct RootTabView: View {
       }
 
       TabNavigationStack(router: coordinator.historyRouter) {
-        // Home-entry semantic (cross-variant aggregation): empty
-        // scenarioId. Becomes the History tab root (ADR-016 D4); its
-        // `Route.results` case split lands in a later sub-PR.
+        // History tab root (ADR-016 D4): empty scenarioId selects the
+        // cross-variant aggregation of all past results. `Route.results`
+        // survives only as the per-scenario detail push (non-empty
+        // scenarioId) from ScenarioDetailView; ``ResultsView`` drops its
+        // back chrome for this empty-id root variant.
         ResultsView(scenarioId: "")
       }
       .tag(AppTab.history)

--- a/Pastura/Pastura/Views/Home/HomeView.swift
+++ b/Pastura/Pastura/Views/Home/HomeView.swift
@@ -95,8 +95,6 @@ struct HomeView: View {
       }
 
       userScenariosSection(viewModel: viewModel)
-
-      browseSection()
     }
     .listStyle(.insetGrouped)
     .scrollContentBackground(.hidden)
@@ -123,22 +121,6 @@ struct HomeView: View {
           description: Text(error)
         )
       }
-    }
-  }
-
-  /// Entry row for past results — a navigation destination that isn't
-  /// tied to a single scenario row. (Shared Scenarios moved to its own
-  /// "Browse" tab in ADR-016 D4, so it is no longer a Home push.)
-  @ViewBuilder
-  private func browseSection() -> some View {
-    Section {
-      NavigationLink(value: Route.results(scenarioId: "")) {
-        navRowLabel(
-          title: String(localized: "Past Results"),
-          systemImage: "clock.arrow.circlepath")
-      }
-      .accessibilityIdentifier("home.pastResultsButton")
-      .pasturaCardRow()
     }
   }
 
@@ -238,18 +220,6 @@ struct HomeView: View {
       }
     }
     .padding(.vertical, 2)
-  }
-
-  /// Navigation-row label that keeps the moss-tinted icon (brand accent)
-  /// while inking the title — `Label`'s single `foregroundStyle` can't
-  /// split the two, so the icon + text are composed by hand.
-  private func navRowLabel(title: String, systemImage: String) -> some View {
-    HStack(spacing: 10) {
-      Image(systemName: systemImage)
-        .foregroundStyle(Color.moss)
-      Text(title)
-        .foregroundStyle(Color.ink)
-    }
   }
 
 }

--- a/Pastura/Pastura/Views/Results/ResultsView.swift
+++ b/Pastura/Pastura/Views/Results/ResultsView.swift
@@ -33,16 +33,12 @@ struct ResultsView: View {
     .navigationTitle(String(localized: "Past Results"))
     // Inline title to match the other tab roots (design-system § 5.11);
     // "Past Results" is a generic label, so inline is consistent for the
-    // push variant too.
+    // History-tab-root and the pushed-detail variant alike.
     .navigationBarTitleDisplayMode(.inline)
-    .navigationBarBackButtonHidden(true)
-    .preservesPasturaSwipeBackGesture()
-    .toolbar {
-      ToolbarItem(placement: .topBarLeading) {
-        PasturaBackButton()
-      }
-      .hidingPasturaSharedBackground()
-    }
+    // Back chrome only for the pushed-detail variant (non-empty
+    // scenarioId); as the History tab root (`scenarioId == ""`) there is
+    // no parent to pop to. See ``PushBackChrome``.
+    .modifier(PushBackChrome(isPushed: !scenarioId.isEmpty))
     .task {
       viewModel = ResultsViewModel(
         scenarioRepository: dependencies.scenarioRepository,
@@ -177,6 +173,38 @@ struct ResultsView: View {
     case .none:
       Label(String(localized: "Unknown"), systemImage: "questionmark.circle")
         .textStyle(Typography.metaLabel).foregroundStyle(Color.muted)
+    }
+  }
+}
+
+/// Applies the root-stack push chrome — custom back button, hidden system
+/// back, preserved swipe-back gesture — only when ``ResultsView`` is a
+/// pushed detail (non-empty `scenarioId`, entered from a scenario's detail
+/// screen).
+///
+/// As the History tab root (`scenarioId == ""`) the view sits at the bottom
+/// of its tab's `NavigationStack`, so there is nothing to pop to; a
+/// `PasturaBackButton` there would be a dead chevron whose `router.pop()`
+/// fires on an empty path (ADR-016 D4). The three push modifiers are applied
+/// as one unit per the load-bearing pairing in `.claude/rules/navigation.md`.
+/// `scenarioId` is a `let`, so `isPushed` is constant per instance — the
+/// branch never toggles at runtime, so this adds no view-identity churn.
+private struct PushBackChrome: ViewModifier {
+  let isPushed: Bool
+
+  func body(content: Content) -> some View {
+    if isPushed {
+      content
+        .navigationBarBackButtonHidden(true)
+        .preservesPasturaSwipeBackGesture()
+        .toolbar {
+          ToolbarItem(placement: .topBarLeading) {
+            PasturaBackButton()
+          }
+          .hidingPasturaSharedBackground()
+        }
+    } else {
+      content
     }
   }
 }

--- a/Pastura/PasturaUITests/ScreenshotTourTests.swift
+++ b/Pastura/PasturaUITests/ScreenshotTourTests.swift
@@ -64,27 +64,30 @@ final class ScreenshotTourTests: XCTestCase {
     app.buttons["sharedScenarios.galleryCell.ui_test_canary"].tap()
     capture(app, name: "05-gallery-detail", anchorId: "galleryDetail.tryButton")
     // Single goBack pops the gallery detail back to the Browse tab root,
-    // which has no back chevron. (No second goBack: the Home tab kept an
-    // empty stack throughout, so the Settings → Home tab switch below still
-    // lands on Home's root for the past-results step.)
+    // which has no back chevron.
     goBack(app)
 
-    // Settings — now a dedicated tab (ADR-016 D4), reached via the tab
-    // bar rather than a Home push. Switching tabs doesn't push, so there
-    // is no back chevron here; return to the Home tab afterward so the
-    // subsequent past-results step lands on Home's stack.
+    // Settings — a dedicated tab (ADR-016 D4), reached via the tab bar
+    // rather than a Home push. Switching tabs doesn't push, so there is no
+    // back chevron here.
     app.tabBars.buttons["Settings"].tap()
     capture(app, name: "06-settings", anchorId: "settings.licensesLink")
-    app.tabBars.buttons["Home"].tap()
 
-    // Past Results (seeded fixture — see StubResultSeeder).
-    app.buttons["home.pastResultsButton"].tap()
+    // Past Results — now the History tab root (ADR-016 D4), reached via the
+    // tab bar (seeded fixture — see StubResultSeeder). As a tab root it has
+    // no parent to pop to, so confirm the back chevron is absent before
+    // descending into the detail.
+    app.tabBars.buttons["History"].tap()
     capture(app, name: "07-results", anchorId: "results.list")
+    XCTAssertFalse(
+      app.buttons["pasturaBackButton"].exists,
+      "History tab root must not show a back chevron.")
 
-    // Result detail timeline.
+    // Result detail timeline (a push onto the History tab stack).
     app.buttons["results.row.ui_test_result_seed"].tap()
     capture(app, name: "08-result-detail", anchorId: "resultDetail.timeline")
-    goBack(app)
+    // Single goBack pops the result detail back to the History tab root,
+    // which has no back chevron.
     goBack(app)
   }
 

--- a/docs/design/navigation-map.md
+++ b/docs/design/navigation-map.md
@@ -23,7 +23,6 @@ flowchart TD
   galleryScenarioDetail["Gallery Scenario Detail"]
   galleryScenarioDetail --> scenarioDetail
   home -->|"via newScenarioRoute()"| editor
-  home --> results
   home --> scenarioDetail
   results --> resultDetail
   scenarioDetail --> editor
@@ -47,6 +46,6 @@ the tour's per-screen wait identifiers.
 | `scenarioDetail` | Scenario Detail | `galleryScenarioDetail`, `home`, `scenarioDetail` | `scenarioDetail.list` | `02-scenario-detail.png` |
 | `editor` | Scenario Editor | `home`, `scenarioDetail` | `editor.titleField` | `03-editor.png` |
 | `simulation` | Simulation | `scenarioDetail` | — | deferred — see `screenshots/README.md` |
-| `results` | Past Results | `home`, `scenarioDetail` | `results.list` | `07-results.png` |
+| `results` | Past Results | `scenarioDetail` | `results.list` | `07-results.png` |
 | `resultDetail` | Result Detail | `results` | `resultDetail.timeline` | `08-result-detail.png` |
 | `galleryScenarioDetail` | Gallery Scenario Detail | `scenarioDetail`, `sharedScenarios` | `galleryDetail.tryButton` | `05-gallery-detail.png` |


### PR DESCRIPTION
## Summary
Sub-PR ④ of the Home redesign P1 split (ADR-016 D4). The 観察履歴 (Past
Results) screen becomes the **History tab root** (wired in ①). Unlike ②③,
which **deleted** their `Route` cases for compile-error safety,
`Route.results` is **split, not deleted**: `case results(scenarioId:)`
survives as the per-scenario detail push from `ScenarioDetailView+Sections`
(non-empty `scenarioId`). Only the empty-id Home entry is removed. Because
no `switch`-exhaustiveness error guards this, the empty-id consumer set was
audited manually (`git grep` — `HomeView` was the sole production producer).

- **HomeView**: delete `browseSection()` (the "Past Results" row +
  `home.pastResultsButton`) and its now-orphaned `navRowLabel` helper (③
  removed its only other consumer). Home no longer pushes `Route.results`.
- **ResultsView**: `ResultsView` mounts both as the History tab root
  (`scenarioId == ""`) and as a pushed detail (non-empty). Gate the back
  chrome (`PasturaBackButton` / `navigationBarBackButtonHidden` /
  `preservesPasturaSwipeBackGesture` / toolbar) behind a private
  `PushBackChrome` modifier keyed on `!scenarioId.isEmpty`. The tab root
  drops the dead chevron (it has no parent to pop to — a `router.pop()`
  there fires on an empty path); the detail push keeps full chrome.
  `navigationTitle` + `.inline` stay unconditional (tab-root convention,
  design-system §5.11). `scenarioId` is a `let`, so the branch is static
  per instance — no view-identity churn.
- **RootTabView**: refresh the History-root comment now the split lands.
- **ScreenshotTour**: reach past results via `tabBars["History"]`; assert
  the tab root shows no `pasturaBackButton`; drop the second `goBack`
  (only the result-detail pop remains — a second would hit the absent
  tab-root chevron); scrub stale Home-stack narration.
- **navigation-map**: regenerated. `home --> results` drops out; `results`
  stays a normal Route node (it keeps its case) — **not** added to
  `SYNTHETIC_ROOTS` (that would double-count the surviving case). self-test
  8/8, `--check` up to date.

`Route.galleryScenarioDetail` and the `scenarioDetail --> results` detail
push are unchanged.

> Note: the empty-id History-root contract (`ResultsView(scenarioId: "")`
> = cross-variant aggregation, ADR-010 D4 / #392) is now enforced by
> `RootTabView` construction + the CI-skipped tour, not a gating test
> (per ADR-009 no new UI-test bar). A future refactor could promote
> `scenarioId: String` to an explicit `.aggregate` / `.scenario(id)` enum
> so root-vs-detail is type-checked rather than string-sentinel-checked
> (deferred — out of scope; touches the #392 invariant).

## Test plan
- ✅ Full unit suite: `** TEST SUCCEEDED **`
- ✅ UI: `NavigationRegressionTests` + `BackGestureTests` + `ScreenshotTourTests` all green (validates History-tab routing, swipe-back preserved on the detail push, no-back assertion on the tab root)
- ✅ `swiftlint lint --strict`: clean
- ✅ Residual audit: `pastResultsButton` / `navRowLabel` / `browseSection` zero hits; zero empty-id `.results(scenarioId: "")` production consumers; detail push (`+Sections:171`) + doc comments retained
- ✅ nav-map `--self-test` 8/8, `--check` up to date (`home --> results` the only dropped edge)
- ✅ Opus code review: PASS (0 issues)
- ⏳ Real-device QA (iOS 17–26): pending — verify History tab root has no chevron and the per-scenario detail push keeps its back affordance

Part of #612.

🤖 Generated with [Claude Code](https://claude.com/claude-code)