### PR TITLE
✅ test: D5 mechanism tests + drain-routing seam (Home P1 ⑤)

### DIFF
--- a/Pastura/Pastura/App/TabCoordinator.swift
+++ b/Pastura/Pastura/App/TabCoordinator.swift
@@ -105,4 +105,24 @@ final class TabCoordinator {
       selectedTab = tab
     }
   }
+
+  /// Presents a resolved deep-linked gallery scenario on the さがす
+  /// (Search) tab (ADR-016 D5.2).
+  ///
+  /// A `.galleryScenarioDetail` is a さがす-tab destination, so the target
+  /// tab is fixed by the resolution kind — **not** the currently-selected
+  /// tab. Select that tab, then push onto its router. So a link arriving
+  /// while the user is on another tab still lands the detail on Search.
+  ///
+  /// Plain `push` (not `pushIfOnTop`): the `await` that `pushIfOnTop`
+  /// guards already completed in `PasturaApp.tryDrain` before the drain
+  /// reaches here, and the freshly-selected tab root is normally an empty
+  /// stack where `pushIfOnTop` would no-op. Matches the prior
+  /// unconditional push. (Extracted from `PasturaApp.applyResolution` so
+  /// the routing kernel is unit-testable — `DeepLinkTabRoutingUITests`
+  /// covers the surrounding async drain glue end-to-end.)
+  func presentDeepLinkedGalleryScenario(_ scenario: GalleryScenario) {
+    selectedTab = .search
+    searchRouter.push(.galleryScenarioDetail(scenario: scenario))
+  }
 }

--- a/Pastura/Pastura/PasturaApp.swift
+++ b/Pastura/Pastura/PasturaApp.swift
@@ -461,15 +461,10 @@ private struct RootView: View {
     switch result {
     case .found(let scenario):
       lastDeepLinkedScenarioId = scenario.id
-      // D5.2: a `.galleryScenarioDetail` is a さがす (Search) tab
-      // destination — the target tab is fixed by the resolution kind, not
-      // the currently-selected tab. Select that tab, then push onto its
-      // router. Plain `push` (not `pushIfOnTop`): the await that
-      // pushIfOnTop guards already completed in `tryDrain` before this
-      // runs, and the freshly-selected tab root has an empty stack where
-      // `pushIfOnTop` would no-op. Matches the prior unconditional push.
-      tabCoordinator.selectedTab = .search
-      tabCoordinator.searchRouter.push(.galleryScenarioDetail(scenario: scenario))
+      // D5.2 fixed-tab routing lives on the coordinator so the kernel is
+      // unit-testable (`TabCoordinatorTests`); the rationale for selecting
+      // さがす + plain-push is documented there.
+      tabCoordinator.presentDeepLinkedGalleryScenario(scenario)
     case .notFound:
       deepLinkError = DeepLinkErrorAlert(
         title: String(localized: "Scenario Not Found"),

--- a/Pastura/PasturaTests/App/TabCoordinatorTests.swift
+++ b/Pastura/PasturaTests/App/TabCoordinatorTests.swift
@@ -113,6 +113,46 @@ import Testing
     #expect(!coordinator.isSimulationOnTop)
   }
 
+  // MARK: - isSimulationOnTop → warm-splash consumer (ADR-016 D5.4)
+
+  // The fold is correct in isolation (above), and `shouldPlayWarmSplash`
+  // is correct given a literal `isSimulationOnTop` (LaunchPhaseCoordinator
+  // tests). These wire the REAL any-tab fold into the warm-splash gate —
+  // the only coverage that catches a narrowing applied between the fold
+  // and its consumer (e.g. the gate reading the selected tab's top route
+  // instead of `isSimulationOnTop`). `// D5.4: any-tab — do not narrow`.
+
+  @Test func anyTabSimulationSuppressesWarmSplash() {
+    let coordinator = TabCoordinator()  // selectedTab == .home
+    // Sim backgrounded on a NON-selected tab: a fold narrowed to the
+    // selected tab would return false here and the splash would wrongly
+    // play over the in-flight run — this is the regression catch.
+    coordinator.searchRouter.push(.simulation(scenarioId: "x"))
+
+    let shouldPlay = LaunchPhaseCoordinator.shouldPlayWarmSplash(
+      launchKind: .warm,
+      appIsReady: true,
+      isSimulationOnTop: coordinator.isSimulationOnTop,
+      isSheetActive: false)
+
+    #expect(shouldPlay == false)
+  }
+
+  @Test func warmSplashPlaysWhenNoTabHasSimulation() {
+    // Positive control so the suppression test isn't vacuously false:
+    // with no sim on any tab the fold is false and the warm splash plays.
+    let coordinator = TabCoordinator()
+    coordinator.homeRouter.push(.scenarioDetail(scenarioId: "x"))
+
+    let shouldPlay = LaunchPhaseCoordinator.shouldPlayWarmSplash(
+      launchKind: .warm,
+      appIsReady: true,
+      isSimulationOnTop: coordinator.isSimulationOnTop,
+      isSheetActive: false)
+
+    #expect(shouldPlay == true)
+  }
+
   // MARK: - Deep-link drain routing (ADR-016 D5.2)
 
   @Test func presentDeepLinkedGalleryScenarioSelectsSearchTabAndPushesOntoIt() {

--- a/Pastura/PasturaTests/App/TabCoordinatorTests.swift
+++ b/Pastura/PasturaTests/App/TabCoordinatorTests.swift
@@ -113,6 +113,46 @@ import Testing
     #expect(!coordinator.isSimulationOnTop)
   }
 
+  // MARK: - Deep-link drain routing (ADR-016 D5.2)
+
+  @Test func presentDeepLinkedGalleryScenarioSelectsSearchTabAndPushesOntoIt() {
+    let coordinator = TabCoordinator()  // selectedTab == .home
+    // User is mid-navigation on a NON-search tab when the link arrives.
+    coordinator.homeRouter.push(.scenarioDetail(scenarioId: "home"))
+    let scenario = makeGalleryScenario(id: "linked")
+
+    coordinator.presentDeepLinkedGalleryScenario(scenario)
+
+    // Primary, each independently revert-sensitive: the target tab is the
+    // resolution-fixed さがす tab (not the currently-selected one), and the
+    // detail lands on THAT tab's router.
+    #expect(coordinator.selectedTab == .search)
+    #expect(coordinator.searchRouter.path.last == .galleryScenarioDetail(scenario: scenario))
+    // Secondary defense-in-depth: the routing touches only さがす.
+    #expect(coordinator.homeRouter.path == [.scenarioDetail(scenarioId: "home")])
+    #expect(coordinator.historyRouter.path.isEmpty)
+    #expect(coordinator.settingsRouter.path.isEmpty)
+  }
+
+  @Test func presentDeepLinkedGalleryScenarioAppendsOntoNonEmptySearchStack() {
+    let coordinator = TabCoordinator()
+    // さがす already shows a gallery detail (user browsed there) when a new
+    // link drains. Plain `push` appends unconditionally — pinning the
+    // D5.2 plain-`push` choice so a future ⑥ switch to a guarded push
+    // surfaces here rather than passing silently.
+    let existing = makeGalleryScenario(id: "existing")
+    coordinator.searchRouter.push(.galleryScenarioDetail(scenario: existing))
+    let linked = makeGalleryScenario(id: "linked")
+
+    coordinator.presentDeepLinkedGalleryScenario(linked)
+
+    #expect(
+      coordinator.searchRouter.path == [
+        .galleryScenarioDetail(scenario: existing),
+        .galleryScenarioDetail(scenario: linked)
+      ])
+  }
+
   // MARK: - Cross-tab isolation (ADR-016 D3)
 
   @Test func pushOnOneTabLeavesOtherTabsEmpty() {


### PR DESCRIPTION
## Summary
D5.5 mechanism test net + D5.4 non-drain-consumer verification for the
bottom-tab IA (ADR-016 D5). Adds **no new behavior** — D5.1–D5.3 shipped
in ① — and tests the **actual ① implementation**, not the ADR prescription.

- **Extracts** the D5.2 deep-link drain routing from the file-private
  `PasturaApp.applyResolution` into `TabCoordinator.presentDeepLinkedGalleryScenario(_:)`
  — a behavior-neutral relocation (`lastDeepLinkedScenarioId` stays on the
  app struct). The routing kernel was unreachable by unit tests (gated
  behind the async drain). This makes `DeepLinkTabRoutingUITests`'s
  "coordinator-level mechanism is unit-tested in TabCoordinatorTests"
  header claim true.
- **Tests added** (all unit, `TabCoordinatorTests`):
  - drain routing: selects さがす + pushes onto **that** tab's router from a
    non-search tab; append-on-top pins the plain-`push` choice
  - D5.4: wires the real any-tab `isSimulationOnTop` fold into
    `LaunchPhaseCoordinator.shouldPlayWarmSplash` — the only test catching
    a narrowing applied **between** the fold and its consumer (+ no-sim
    positive control)

## Out of scope (with reasons)
- **Any-tab fold cardinality (D5.5)** — already covered by existing
  `isSimulationOnTopTrueWhenSimulationOnNonSelectedTab`; the fold has no
  per-tab branching, so all-4-tabs expansion adds no new regression catch.
- **Drain-deferral E2E / HomeView-reload / delete-pop "own-tab router"** —
  structural per-tab `.environment` injection; per-tab isolation is unit-
  covered, E2E covered by `DeepLinkTabRoutingUITests` /
  `NavigationRegressionTests`. No new UI tests (CI budget).

## ADR drift for ⑥
ADR-016 D5.2 prescribes `pushIfOnTop`; ① ships plain `push` (rationale in
the new method's doc-comment). Tests assert the shipped `push`. ADR body
fix deferred to ⑥.

## Test plan
- `scripts/xcodebuild.sh test -skip-testing:PasturaUITests` → **1921 tests / 174 suites pass** (incl. 4 new)
- `DeepLinkTabRoutingUITests` → pass (extraction behavior-neutral E2E)
- `swiftlint lint --strict` → clean

Part of #612.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
