### PR TITLE
✨ feat: link editor toolbar to the public scenario guide

### DIFF
--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -2777,6 +2777,16 @@
         }
       }
     },
+    "Learn more" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "詳細はこちら"
+          }
+        }
+      }
+    },
     "Legal" : {
       "comment" : "Settings section header grouping Privacy Policy and content report link.",
       "localizations" : {

--- a/Pastura/Pastura/Utilities/LocalizedPublicPages.swift
+++ b/Pastura/Pastura/Utilities/LocalizedPublicPages.swift
@@ -50,6 +50,20 @@ nonisolated enum LocalizedPublicPages {
       preferredLocalizations: preferredLocalizations)
   }
 
+  /// Scenario guide page (`pages/docs/scenario/`) — the public
+  /// walkthrough of how Pastura scenarios work. Linked from the
+  /// in-app scenario editor's help affordance (#638), completing the
+  /// Swift-side half of the guide shipped on pastura.app in #628.
+  ///
+  /// - Parameter preferredLocalizations: Injectable for unit tests.
+  ///   Production callers pass `Bundle.main.preferredLocalizations`
+  ///   (the default).
+  static func scenarioGuide(
+    preferredLocalizations: [String] = Bundle.main.preferredLocalizations
+  ) -> URL? {
+    url(path: "docs/scenario/", preferredLocalizations: preferredLocalizations)
+  }
+
   private static func url(
     path: String, preferredLocalizations: [String]
   ) -> URL? {

--- a/Pastura/Pastura/Views/Editor/ScenarioEditorView.swift
+++ b/Pastura/Pastura/Views/Editor/ScenarioEditorView.swift
@@ -14,6 +14,7 @@ import UniformTypeIdentifiers
 struct ScenarioEditorView: View {  // swiftlint:disable:this type_body_length
   @Bindable var viewModel: ScenarioEditorViewModel
   @Environment(\.dismiss) private var dismiss
+  @Environment(\.openURL) private var openURL
 
   @State private var editingPersona: EditablePersona?
   @State private var editingPhase: EditablePhase?
@@ -106,6 +107,22 @@ struct ScenarioEditorView: View {  // swiftlint:disable:this type_body_length
   private var toolbarContent: some ToolbarContent {
     ToolbarItem(placement: .topBarLeading) { PasturaBackButton() }
       .hidingPasturaSharedBackground()
+    // Help link is mode-independent (visual + YAML) and declared before the
+    // conditional import affordances so it keeps a stable leftmost position
+    // in the trailing cluster as those appear/disappear with mode.
+    ToolbarItem(placement: .topBarTrailing) {
+      Button {
+        // LocalizedPublicPages routes ja → /ja/docs/scenario/ (ADR-010 D6);
+        // openURL hands off to the system browser — no in-app web view (#638).
+        guard let url = LocalizedPublicPages.scenarioGuide() else { return }
+        openURL(url)
+      } label: {
+        Image(systemName: "questionmark.circle")
+      }
+      .accessibilityLabel(String(localized: "Learn more"))
+      .accessibilityIdentifier("editor.scenarioGuideButton")
+    }
+    .hidingPasturaSharedBackground()
     if showsYAMLImportAffordances {
       ToolbarItem(placement: .topBarTrailing) {
         Button {

--- a/Pastura/PasturaTests/Utilities/LocalizedPublicPagesTests.swift
+++ b/Pastura/PasturaTests/Utilities/LocalizedPublicPagesTests.swift
@@ -53,6 +53,28 @@ struct LocalizedPublicPagesTests {
     #expect(url?.absoluteString == "https://pastura.app/support/")
   }
 
+  // MARK: - Scenario guide
+
+  @Test func jaLocaleResolvesToJapaneseScenarioGuide() {
+    let url = LocalizedPublicPages.scenarioGuide(preferredLocalizations: ["ja"])
+    #expect(url?.absoluteString == "https://pastura.app/ja/docs/scenario/")
+  }
+
+  @Test func enLocaleResolvesToEnglishScenarioGuide() {
+    let url = LocalizedPublicPages.scenarioGuide(preferredLocalizations: ["en"])
+    #expect(url?.absoluteString == "https://pastura.app/docs/scenario/")
+  }
+
+  @Test func unsupportedLocaleFallsBackToEnglishScenarioGuide() {
+    let url = LocalizedPublicPages.scenarioGuide(preferredLocalizations: ["es"])
+    #expect(url?.absoluteString == "https://pastura.app/docs/scenario/")
+  }
+
+  @Test func emptyPreferredLocalizationsFallsBackToEnglishScenarioGuide() {
+    let url = LocalizedPublicPages.scenarioGuide(preferredLocalizations: [])
+    #expect(url?.absoluteString == "https://pastura.app/docs/scenario/")
+  }
+
   // MARK: - Supported devices anchor
 
   @Test func jaLocaleResolvesToJapaneseSupportedDevicesAnchor() {


### PR DESCRIPTION
## Summary
- Add a locale-aware "Learn more" help button (`questionmark.circle`) to the scenario editor toolbar, opening the public scenario guide in the system browser (no in-app web view). Completes the Swift-side half of #628.
- New `LocalizedPublicPages.scenarioGuide()` routes ja → `/ja/docs/scenario/`, every other locale → `/docs/scenario/` (ADR-010 D6: reads `preferredLocalizations`).
- Button is mode-independent and declared before the conditional import affordances for stable toolbar positioning; carries `.hidingPasturaSharedBackground()` for the iOS 26 capsule opt-out.
- Catalog: `"Learn more"` key + ja translation (詳細はこちら).

## Test plan
- 4 new unit tests for `scenarioGuide()` (ja / en / unsupported-locale / empty-localizations fallback).
- Full unit suite: 1925 tests pass.
- `swiftlint --strict` clean; `check_localization_coverage.py` OK (466 keys, all ja translated).
- Manual QA pending: ja-device verify of the label + system-browser handoff.

Closes #638

🤖 Generated with [Claude Code](https://claude.com/claude-code)