### PR TITLE
📝 docs: clean up navigation doc drift after Home P1

### DIFF
--- a/.claude/rules/swiftui-traps.md
+++ b/.claude/rules/swiftui-traps.md
@@ -26,6 +26,24 @@ Root cause for the iOS 26 regression on `.navigationBarBackButtonHidden(true)`: 
 
 Architectural rationale: [ADR-008 §Amendment 2026-05-10](../../docs/decisions/ADR-008.md).
 
+## TabView tab-bar SF Symbol auto-fill (iOS 15+)
+
+A native `TabView` tab bar auto-applies the `.fill` SF Symbol variant to
+**every** tab icon (iOS 15+). If you drive the active/inactive
+outline↔fill distinction yourself (e.g. `house` ↔ `house.fill`), the
+auto-fill overrides it — every tab renders filled in both states and the
+distinction is erased.
+
+**Apply**: add `.environment(\.symbolVariants, .none)` to each tab
+`Image` to disable the auto-variant, then let your own `isActive`-driven
+symbol name carry the fill toggle. The modifier is LOAD-BEARING —
+removing it silently re-fills every tab.
+
+Reference impl + full rationale (including why `magnifyingglass`, which
+has no `.fill` variant, was the only tab where the symptom was
+diagnosable): the LOAD-BEARING comment in
+`Pastura/Pastura/App/RootTabView.swift` (`symbolName(for:isActive:)`).
+
 ## Production-side-effecting service: inject at View boundary
 
 When introducing a **production-only side-effecting service** (LLM-output detector, telemetry analyzer, content-rewriting filter, on-the-fly classifier, A/B-flag injector), inject it at the **View boundary**, NOT as a default value on the VM's `init()` signature.

--- a/Pastura/Pastura/App/AppRouter.swift
+++ b/Pastura/Pastura/App/AppRouter.swift
@@ -1,16 +1,16 @@
 import Foundation
 import SwiftUI
 
-/// Owner of the root `NavigationStack`'s path.
+/// Owner of one tab's `NavigationStack` path.
 ///
 /// Inject via `@Environment(AppRouter.self)`. Bind the path with
-/// `NavigationStack(path: $router.path)` at the root view, and call
+/// `NavigationStack(path: $router.path)` inside the tab's stack, and call
 /// `push(_:)` / `pop()` / `popToRoot()` from anywhere in the view tree
 /// for programmatic navigation.
 ///
 /// ## Scope (load-bearing)
 ///
-/// `AppRouter` manages the **root NavigationStack's path only**. It is
+/// `AppRouter` manages **one tab's NavigationStack path only**. It is
 /// deliberately not a place to put selection state, modal presentation
 /// flags, search queries, or any other UI state. See
 /// `.claude/rules/navigation.md` for the full convention.

--- a/docs/decisions/ADR-016.md
+++ b/docs/decisions/ADR-016.md
@@ -93,11 +93,11 @@ Their `Route` cases are deleted so the compiler enforces the new IA
 (the implementation PR for this lives in P1; this ADR only records the
 target shape):
 
-- `case sharedScenarios` (`App/Router.swift:63`) — **deleted**; the
+- `case sharedScenarios` (`App/Router.swift`) — **deleted**; the
   Search (さがす) tab root replaces it.
-- `case settings` (`App/Router.swift:70`) — **deleted**; the Settings
+- `case settings` (`App/Router.swift`) — **deleted**; the Settings
   (設定) tab root replaces it.
-- `case results(scenarioId:)` (`App/Router.swift:57`) — **split**. Its
+- `case results(scenarioId:)` (`App/Router.swift`) — **split**. Its
   Home-entry semantic (empty `scenarioId`, cross-variant aggregation —
   the `sourceId` linkage from [ADR-010](ADR-010.md) D4 plus the
   cross-variant-vs-per-variant UX seam in `App/Router.swift`'s `results`
@@ -107,7 +107,7 @@ target shape):
   **keeps** its `Route` case and continues to push onto whichever tab's
   stack surfaced it.
 
-`case resultDetail(simulationId:)` (`App/Router.swift:60`) is **kept** —
+`case resultDetail(simulationId:)` (`App/Router.swift`) is **kept** —
 it is a genuine push destination, not a promoted root.
 
 Rationale: keeping `.settings` / `.sharedScenarios` as `Route` cases
@@ -123,12 +123,11 @@ full migration surface mechanically rather than by audit.
 This is the decision the prior nav/sequence critic flagged as a
 Must-fix. Today the deep-link machinery assumes a **single** stack:
 
-- `isSimulationOnTop` (`PasturaApp.swift:404`) is
+- `isSimulationOnTop` (`PasturaApp.swift`) is
   `if case .some(.simulation) = router.path.last`.
-- The drain (`handleOpenURL` `PasturaApp.swift:408` →
-  `tryDrain` `:424` → `applyResolution` `:448`) pushes onto the one
-  router; the terminal action is
-  `router.push(.galleryScenarioDetail(scenario:))` (`:452`).
+- The drain (`handleOpenURL` → `tryDrain` → `applyResolution` in
+  `PasturaApp.swift`) pushes onto the one router; the terminal action is
+  `router.push(.galleryScenarioDetail(scenario:))`.
 
 Under four stacks the contract is redefined as follows.
 
@@ -148,11 +147,11 @@ root is normally an empty stack where the guard would no-op; the
 rationale is documented on
 `TabCoordinator.presentDeepLinkedGalleryScenario(_:)`. The target tab is
 fixed by the resolution kind, not by whichever tab is currently selected.
-`lastDeepLinkedScenarioId` (`PasturaApp.swift:122` `@State`, injected as
-an environment value at `:242`, set at `:451`, cleared at `:183`)
-remains **app-global** — it is a cross-cutting display hint read across
-the whole view tree, not per-tab state, so it stays on the app root and
-is not duplicated per coordinator.
+`lastDeepLinkedScenarioId` (a `PasturaApp` `@State`, injected as an
+environment value, set on deep-link resolution and cleared when the
+Search tab's stack empties) remains **app-global** — it is a
+cross-cutting display hint read across the whole view tree, not per-tab
+state, so it stays on the app root and is not duplicated per coordinator.
 
 **D5.3 — Complete single-stack consumer inventory.** Every site coupled
 to the single-stack assumption must be migrated to per-tab routers. The
@@ -165,9 +164,9 @@ did **not** cover path *observation* sites that read the whole path
 
 | Site | Current coupling | Per-tab disposition |
 |------|------------------|---------------------|
-| `PasturaApp.swift:404` `isSimulationOnTop` | `router.path.last == .simulation` | Fold over all four routers (D5.1). |
-| `Views/Home/HomeView.swift:79` `.onChange(of: router.path.count)` | pop-reload on the single stack | Bind to the **Home tab's** router; pop-reload is Home-local. |
-| `Views/Results/ResultDetailView+Delete.swift:41` `router.path.last == .resultDetail(...)` | post-delete pop guard on single stack | Bind to the router of the tab that surfaced the detail (History tab root, or whichever tab pushed it). |
+| `PasturaApp.swift` `isSimulationOnTop` | `router.path.last == .simulation` | Fold over all four routers (D5.1). |
+| `Views/Home/HomeView.swift` `.onChange(of: router.path.count)` | pop-reload on the single stack | Bind to the **Home tab's** router; pop-reload is Home-local. |
+| `Views/Results/ResultDetailView+Delete.swift` `router.path.last == .resultDetail(...)` | post-delete pop guard on single stack | Bind to the router of the tab that surfaced the detail (History tab root, or whichever tab pushed it). |
 | `App/AppRouter.popToRoot()` (`App/AppRouter.swift`) | "unwind to root" of the one stack | Now means "unwind **this tab's** stack"; tab re-selection (tapping the active tab) maps to `popToRoot()` on that tab's router. |
 
 Two additional `PasturaApp` path-observation guards (outside the
@@ -188,10 +187,10 @@ in D5.1 is **not** confined to deep linking. `isSimulationOnTop` also
 feeds two launch/lifecycle consumers, and widening it to "any tab"
 changes their behavior:
 
-- `PasturaApp.swift:398` derives the `.simulationActive` lifecycle state
+- `PasturaApp.swift` derives the `.simulationActive` lifecycle state
   from it.
 - `LaunchPhaseCoordinator.shouldPlayWarmSplash(launchKind:appIsReady:isSimulationOnTop:isSheetActive:)`
-  (`App/LaunchPhaseCoordinator.swift:73`) returns
+  (`App/LaunchPhaseCoordinator.swift`) returns
   `appIsReady && !isSimulationOnTop && !isSheetActive` — so a simulation
   on a **non-selected** tab would now suppress the warm splash (#412 /
   #415 launch animation) and flip the lifecycle classification.

--- a/docs/design/navigation-map.md
+++ b/docs/design/navigation-map.md
@@ -2,14 +2,14 @@
      Regenerate: python3 scripts/generate-navigation-map.py
      Drift guard: python3 scripts/generate-navigation-map.py --check (CI: navigation-map-drift) -->
 
-# Navigation Map — root NavigationStack
+# Navigation Map — per-tab NavigationStacks
 
-Screen graph of the root stack, generated from `Route` enum cases and
-`NavigationLink` / `router.push` / `pushIfOnTop` callsites. Sheets and
-fullScreenCover flows are out of scope (`AppRouter` manages the root
-stack only — see `.claude/rules/navigation.md`). `home` (`HomeView`)
-and `sharedScenarios` (`SharedScenariosListView`, the Browse tab root)
-are tab-stack roots, not `Route` cases.
+Screen graph of the four per-tab stacks, generated from `Route` enum
+cases and `NavigationLink` / `router.push` / `pushIfOnTop` callsites.
+Sheets and fullScreenCover flows are out of scope (each `AppRouter`
+manages its tab's stack only — see `.claude/rules/navigation.md`).
+`home` (`HomeView`) and `sharedScenarios` (`SharedScenariosListView`,
+the Browse tab root) are tab-stack roots, not `Route` cases.
 
 ```mermaid
 flowchart TD
@@ -43,7 +43,7 @@ above. `scripts/ui-tour.sh` runs it and extracts the PNGs into
 `docs/design/screenshots/` (gitignored — regenerate to view;
 `docs/design/screenshots/README.md`). Anchors are the per-screen wait
 identifiers; *Reached via* is the launch root, a tab switch, or a
-root-stack push.
+tab-stack push.
 
 | # | Screenshot | Tour anchor | Reached via |
 |---|------------|-------------|-------------|

--- a/scripts/generate-navigation-map.py
+++ b/scripts/generate-navigation-map.py
@@ -5,7 +5,7 @@ Two artifacts, two sources of truth, so the committed map never drifts:
 
 - **Mermaid screen graph** — derived from the ``Route`` enum +
   ``NavigationLink`` / ``router.push`` / ``pushIfOnTop`` callsites (the
-  root-stack push-edge graph).
+  per-tab-stack push-edge graph).
 - **Screenshot-tour table** — derived from ``ScreenshotTourTests.swift`` by
   parsing its ``capture(app, name:, anchorId:)`` calls in order. The test is
   the single source for what the tour actually captures, including
@@ -48,9 +48,9 @@ Tour table details:
   node (Settings) still appears, and a Route node with no capture
   (``simulation``) correctly does not.
 
-Sheets / fullScreenCover are intentionally absent: ``AppRouter`` manages the
-root NavigationStack only (``.claude/rules/navigation.md``); sheet-owned
-flows are out of scope for this map.
+Sheets / fullScreenCover are intentionally absent: each ``AppRouter``
+manages its tab's NavigationStack only (``.claude/rules/navigation.md``);
+sheet-owned flows are out of scope for this map.
 
 Modes:
   (default)     rewrite docs/design/navigation-map.md
@@ -274,14 +274,14 @@ def emit_markdown(
     nodes = list(SYNTHETIC_ROOTS) + route_cases
 
     lines = [HEADER]
-    lines.append("# Navigation Map — root NavigationStack\n")
+    lines.append("# Navigation Map — per-tab NavigationStacks\n")
     lines.append(
-        "Screen graph of the root stack, generated from `Route` enum cases and\n"
-        "`NavigationLink` / `router.push` / `pushIfOnTop` callsites. Sheets and\n"
-        "fullScreenCover flows are out of scope (`AppRouter` manages the root\n"
-        "stack only — see `.claude/rules/navigation.md`). `home` (`HomeView`)\n"
-        "and `sharedScenarios` (`SharedScenariosListView`, the Browse tab root)\n"
-        "are tab-stack roots, not `Route` cases.\n"
+        "Screen graph of the four per-tab stacks, generated from `Route` enum\n"
+        "cases and `NavigationLink` / `router.push` / `pushIfOnTop` callsites.\n"
+        "Sheets and fullScreenCover flows are out of scope (each `AppRouter`\n"
+        "manages its tab's stack only — see `.claude/rules/navigation.md`).\n"
+        "`home` (`HomeView`) and `sharedScenarios` (`SharedScenariosListView`,\n"
+        "the Browse tab root) are tab-stack roots, not `Route` cases.\n"
     )
     lines.append("```mermaid")
     lines.append("flowchart TD")
@@ -308,7 +308,7 @@ def emit_markdown(
         "`docs/design/screenshots/` (gitignored — regenerate to view;\n"
         "`docs/design/screenshots/README.md`). Anchors are the per-screen wait\n"
         "identifiers; *Reached via* is the launch root, a tab switch, or a\n"
-        "root-stack push.\n"
+        "tab-stack push.\n"
     )
     lines.append("| # | Screenshot | Tour anchor | Reached via |")
     lines.append("|---|------------|-------------|-------------|")


### PR DESCRIPTION
## Summary
Post-merge cleanup of navigation documentation drift left after
Home-redesign P1 (ADR-016 bottom-tab IA, #643). Zero behavior change —
the only production line touched is the `AppRouter` doc-comment.

- **ADR-016 §1 D4/D5** — converted stale `file:line` citations to
  path + symbol/expression references (drift-resistant; line numbers not
  reintroduced). Deleted D4 cases keep their historical "deleted" framing.
- **navigation-map generator** — reworded 5 stale "root NavigationStack /
  root stack" sites to per-tab phrasing; regenerated
  `docs/design/navigation-map.md` so the `navigation-map-drift` guard
  stays green (graph nodes/edges unchanged).
- **AppRouter doc-comment** — "root NavigationStack" → "one tab's
  NavigationStack" (3 sites). Doc-comment only.
- **swiftui-traps.md** — promoted the iOS 15+ TabView SF Symbol auto-fill
  trap at concept level (claim + pointer to RootTabView's LOAD-BEARING
  comment).

## Test plan
- `swiftlint lint --strict` → exit 0 (no violations)
- AppRouter doc-comment change built via pre-commit hook
- `python3 scripts/generate-navigation-map.py --self-test` → 17/17
- `python3 scripts/generate-navigation-map.py --check` → up to date (drift green)
- Opus code-review: PASS (0 issues); all ADR symbol refs verified against live code

Closes #647

🤖 Generated with [Claude Code](https://claude.com/claude-code)