### PR TITLE
🔧 chore: move unused_import to analyzer_rules in .swiftlint.yml

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -36,6 +36,13 @@ opt_in_rules:
   - private_action
   - private_outlet
   - redundant_nil_coalescing
+
+# Analyzer-only rules (require `swiftlint analyze`, not `swiftlint lint`).
+# NOTE: no pipeline runs `analyze` today — CI, the git pre-commit hook, and
+# the Claude Code edit hook all run `swiftlint lint` only — so these are
+# armed-but-dormant, not enforced. Listed here for correct placement (the
+# lint warning that asked for this section) + intent if `analyze` is ever wired up.
+analyzer_rules:
   - unused_import
 
 custom_rules:


### PR DESCRIPTION
## Summary
`swiftlint lint` emitted an informational warning on every run:
`'unused_import' should be listed in the 'analyzer_rules' configuration
section for more clarity as it is only run by 'swiftlint analyze'`.

Relocate `unused_import` from `opt_in_rules:` to a new `analyzer_rules:`
section to silence it, with a comment noting that no pipeline runs
`swiftlint analyze` today (CI / pre-commit hook / Claude edit hook all
run `swiftlint lint` only) — so the rule is armed-but-dormant.

**Behavior-invariant**: analyzer-only rules never run during `swiftlint
lint` regardless of which section they live in, so lint enforcement is
unchanged — only the informational warning disappears.

## Test plan
- `swiftlint lint --quiet --strict` (full project) → exit 0, 0 warnings/errors
- Confirmed the `should be listed in the 'analyzer_rules'` warning no longer appears
- Diff is a move (not a copy): `unused_import` removed from `opt_in_rules:`, appears only under `analyzer_rules:`
- Opus code-review: PASS (0 issues)

Closes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)