### PR TITLE
📝 docs: sync setup.sh pre-commit gate list

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -29,5 +29,5 @@ cd "$(git rev-parse --show-toplevel)"
 
 git config core.hooksPath scripts/git-hooks
 echo "✓ git hooks activated (core.hooksPath = scripts/git-hooks)"
-echo "  Pre-commit gates: swiftlint, xcodebuild build, blocklist, gallery"
+echo "  Pre-commit gates: swiftlint, xcodebuild build, blocklist, gallery, p8, navigation-map"
 echo "  Bypass (discouraged): \`git commit --no-verify\` — CLAUDE.md prohibits."


### PR DESCRIPTION
## Summary
`scripts/setup.sh`'s completion message listed only `swiftlint, xcodebuild build, blocklist, gallery`, but the actual `scripts/git-hooks/pre-commit` also runs the **p8** secret gate (ADR-014) and the **navigation-map** drift gate (#655). This syncs the echoed list to the real gate set.

Message-only change — no behavior impact (the hooks themselves are unchanged).

## Test plan
- `bash -n scripts/setup.sh` — syntax OK
- `./scripts/setup.sh` re-run prints the corrected gate list