### PR TITLE
📝 docs: sweep residual pages/ → web/src/pages source-path refs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
 # contact_links intentionally omitted: users reaching this picker already
 # have GitHub accounts, so redirecting them elsewhere adds a hop. Private
-# feedback and Shared Scenario reports live in-app and on pages/support/.
+# feedback and Shared Scenario reports live in-app and on web/src/pages/support.astro.
 blank_issues_enabled: false

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -67,7 +67,7 @@ least the current minor release.
 
 * Pastura iOS source code (`Pastura/Pastura/**`).
 * CI and build infrastructure (`.github/workflows/**`, `scripts/**`).
-* Public web pages (`pages/**`) served from `pastura.app`.
+* Public web pages (`web/src/pages/**`) served from `pastura.app`.
 * Scenario engine logic and the LLM inference layer's invocation of
   third-party libraries (Yams, GRDB, llama.cpp via mattt/llama.swift).
 
@@ -98,7 +98,7 @@ Knowing how Pastura is built may help you assess impact:
 * Pastura has no user accounts and no authentication. There is no server
   component to compromise.
 * See `docs/decisions/ADR-005.md` for content-safety architecture and
-  `pages/legal/privacy-policy/` for the public privacy policy.
+  `web/src/pages/legal/privacy-policy.astro` for the public privacy policy.
 
 ## Acknowledgments
 

--- a/Pastura/Pastura/Utilities/LocalizedPublicPages.swift
+++ b/Pastura/Pastura/Utilities/LocalizedPublicPages.swift
@@ -8,11 +8,11 @@ import Foundation
 /// multi-variant selection of stored content, not external URL routing for the
 /// shell itself.
 ///
-/// Japanese (`"ja"`) routes to the `/ja/` mirror (`pages/ja/**`); every other
-/// locale falls through to the English pages.
+/// Japanese (`"ja"`) routes to the `/ja/` mirror (`web/src/pages/ja/**`);
+/// every other locale falls through to the English pages.
 nonisolated enum LocalizedPublicPages {
 
-  /// Privacy Policy page (`pages/legal/privacy-policy/`). Linked from
+  /// Privacy Policy page (`web/src/pages/legal/privacy-policy.astro`). Linked from
   /// Settings → Legal per App Store Guideline 5.1.1.
   ///
   /// - Parameter preferredLocalizations: Injectable for unit tests.
@@ -24,7 +24,7 @@ nonisolated enum LocalizedPublicPages {
     url(path: "legal/privacy-policy/", preferredLocalizations: preferredLocalizations)
   }
 
-  /// Support landing page (`pages/support/`) — the App Store Connect
+  /// Support landing page (`web/src/pages/support.astro`) — the App Store Connect
   /// Support URL and ADR-005 §6 report-channel host. Also documents
   /// supported devices, which is why the unsupported-device fallback
   /// links here instead of hardcoding model names that drift (#499).
@@ -40,8 +40,9 @@ nonisolated enum LocalizedPublicPages {
 
   /// Deep link to the "Supported devices" section of the support page.
   /// The fragment matches the `id="supported-devices"` anchor in
-  /// `pages/support/index.html` and its `ja` mirror — update both if
-  /// the anchor is ever renamed.
+  /// `web/src/pages/support.astro` and its `ja` mirror
+  /// (`web/src/pages/ja/support.astro`) — update both if the anchor is
+  /// ever renamed.
   static func supportedDevices(
     preferredLocalizations: [String] = Bundle.main.preferredLocalizations
   ) -> URL? {
@@ -50,7 +51,7 @@ nonisolated enum LocalizedPublicPages {
       preferredLocalizations: preferredLocalizations)
   }
 
-  /// Scenario guide page (`pages/docs/scenario/`) — the public
+  /// Scenario guide page (`web/src/pages/docs/scenario.astro`) — the public
   /// walkthrough of how Pastura scenarios work. Linked from the
   /// in-app scenario editor's help affordance (#638), completing the
   /// Swift-side half of the guide shipped on pastura.app in #628.

--- a/Pastura/Pastura/Utilities/ReportURLBuilder.swift
+++ b/Pastura/Pastura/Utilities/ReportURLBuilder.swift
@@ -54,7 +54,7 @@ nonisolated enum ReportURLBuilder {
   ///
   /// The same underlying form co-tenants as the §1.5 general-contact
   /// surface reached from the App Store Connect Support URL landing
-  /// page (`pages/support/index.html`, #182). That path links the bare
+  /// page (`web/src/pages/support.astro`, #182). That path links the bare
   /// form URL with no pre-fill, and the Scenario ID field is
   /// configured as optional so general-feedback submissions can leave
   /// it blank. This builder always pre-fills both fields — the

--- a/Pastura/PasturaTests/Utilities/LocalizedPublicPagesTests.swift
+++ b/Pastura/PasturaTests/Utilities/LocalizedPublicPagesTests.swift
@@ -8,7 +8,7 @@ import Testing
 /// (UI shell consumer), routing reads `Bundle.main.preferredLocalizations`
 /// directly — `LocaleResolver` is deliberately not used (its D2 scope is
 /// new-data creation + multi-variant selection, not external URL
-/// routing). The `ja` pages mirror at `pages/ja/**`; every other locale
+/// routing). The `ja` pages mirror at `web/src/pages/ja/**`; every other locale
 /// falls through to the English pages.
 @MainActor
 @Suite(.timeLimit(.minutes(1)))

--- a/docs/gallery/shared-scenario-reports.md
+++ b/docs/gallery/shared-scenario-reports.md
@@ -27,7 +27,7 @@ time. Misconfiguring any of the below breaks that compliance claim.
 
 This form also co-tenants as the §1.5 general-contact surface reached
 from the App Store Connect Support URL landing page
-(`pages/support/index.html`, #182). General feedback — no scenario
+(`web/src/pages/support.astro`, #182). General feedback — no scenario
 context — is a legitimate second use. The form's title, description,
 and Scenario ID helper copy all signal this; keep them in sync when
 editing.

--- a/docs/security/release-checklist.md
+++ b/docs/security/release-checklist.md
@@ -148,7 +148,7 @@ Pastura's only outbound network is the model download. Cross-check:
 * `App/ModelRegistry.swift` URLs are HTTPS and point to known publishers
   (Hugging Face, Kaggle).
 * `Info.plist` does not declare any `NSAppTransportSecurity` overrides.
-* The privacy policy at `pages/legal/privacy-policy/` accurately reflects
+* The privacy policy at `web/src/pages/legal/privacy-policy.astro` accurately reflects
   the model-download host list.
 
 ### 2.5 Account deletion


### PR DESCRIPTION
## Summary
- PR #624 (#475) migrated the public site to an Astro project under `web/`; this sweeps the residual `pages/…` source-path references it deliberately left behind to keep that diff reviewable.
- Updated to the single-`.astro`-file form (`web/src/pages/*.astro`):
  - `LocalizedPublicPages.swift` / `ReportURLBuilder.swift` / `LocalizedPublicPagesTests.swift` doc comments
  - `docs/security/release-checklist.md`, `docs/gallery/shared-scenario-reports.md`
  - `.github/SECURITY.md` (in-scope glob + privacy-policy pointer), `.github/ISSUE_TEMPLATE/config.yml`
- Deployed URLs (`https://pastura.app/support/` etc.) are unchanged — only in-repo source-path mentions changed.
- Left as-written (point-in-time records): `ADR-005.md`, `ROADMAP.md` completed checklist, `deploy-pages.yml` "hand-written pages/ tree" comment.

## Test plan
- `git grep -n 'pages/' -- ':!web'` returns only the intended historical/structural hits.
- `Localizable.xcstrings` unchanged (doc comments aren't extractable literals).
- Pre-commit build passed on the Swift-touching commit; Opus code-review PASS (0 issues).

Closes #623

🤖 Generated with [Claude Code](https://claude.com/claude-code)