### PR TITLE
📝 docs: document ScenarioLoader parse-vs-validate boundary (#665)

### DIFF
--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -94,6 +94,21 @@ Cancellation uses standard Swift `Task` cancellation.
 
 Use `ScenarioLoader.estimateInferenceCount()` to calculate before execution.
 
+#### Parse vs validate boundary
+
+`ScenarioLoader.load(yaml:)` does **not** run these limit/semantic checks —
+it only does structural mapping + construct-time invariants (accepted-language,
+persona/agent-count, depth-1 conditional). The `ScenarioValidator` gate runs
+separately, so any **new** YAML-ingest path must call it before use:
+
+- Persist a newly-authored/ingested scenario → `validateForCommit(_:)`
+  (adds the canonical-primary-field check on top of `validate`).
+- Run a scenario → `validate(_:)` (already enforced at the run-gate).
+- Re-parse already-persisted YAML (replay/export/display) → no validation;
+  the gate ran upstream at create-time. This is why `load` stays un-validating.
+
+See `ScenarioValidator` for the gate; #665 for the boundary rationale.
+
 ### Inference Count Estimation
 
 ```

--- a/Pastura/Pastura/Engine/ScenarioLoader.swift
+++ b/Pastura/Pastura/Engine/ScenarioLoader.swift
@@ -30,9 +30,28 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
 
   /// Parse a YAML string into a ``Scenario`` model.
   ///
+  /// Enforces structural mapping plus a narrow band of construct-time
+  /// invariants (accepted-`language` / `simulation_language` membership,
+  /// `personas` count matching `agents`, depth-1 `conditional`). It does
+  /// **not** run ``ScenarioValidator``'s execution-limit / inference-cap /
+  /// phase-semantic gate — so the returned scenario is well-formed but not
+  /// yet known to be runnable.
+  ///
+  /// Boundary contract for callers:
+  /// - **Persisting** a newly-authored / ingested scenario to the database →
+  ///   call ``ScenarioValidator/validateForCommit(_:)`` first (it adds the
+  ///   canonical-primary-field check on top of `validate`).
+  /// - **Running** a scenario → ``ScenarioValidator/validate(_:)`` (already
+  ///   enforced at the run-gate in `SimulationRunner`).
+  /// - **Re-parsing** already-persisted YAML (replay / export / display) →
+  ///   no validation needed; the gate already ran upstream at create-time.
+  ///   This exemption is the reason `load` itself stays un-validating.
+  ///
   /// - Parameter yaml: Raw YAML text, possibly wrapped in code fences.
-  /// - Returns: A validated ``Scenario`` instance.
-  /// - Throws: ``SimulationError/scenarioValidationFailed(_:)`` on parse or validation failure.
+  /// - Returns: A structurally-mapped ``Scenario`` instance (not run-validated).
+  /// - Throws: ``SimulationError/scenarioValidationFailed(_:)`` on a YAML
+  ///   parse error or a construct-time invariant violation (wrong field type,
+  ///   unknown `language`, persona/agent mismatch, malformed phase shape).
   public func load(yaml: String) throws -> Scenario {
     let stripped = stripCodeFences(yaml)
 


### PR DESCRIPTION
## Summary
Issue #665 — `ScenarioLoader.load(yaml:)` parses YAML → `Scenario` but does
not run `ScenarioValidator`; validation only happens at the run-gate / editor
/ run-launch. Resolved as **Option 1 (document the boundary)** — no behavior
change.

Why not Option 2 (validate at parse): `load(yaml:)` is `public` and used by
many production callers that re-parse already-persisted (possibly grandfathered)
YAML for replay / export / display. Forcing `validate()` there would regress
them. A speculative `loadValidated()` is YAGNI.

- Correct the misleading `load(yaml:)` doc comment ("Returns: A validated
  Scenario" → structurally-mapped, not run-validated; fix the Throws line too)
  and state the two-tier boundary contract.
- Add a "Parse vs validate boundary" note to `.claude/rules/engine.md` so the
  next ingest-path author knows which gate to call (`validateForCommit` persist
  / `validate` run / none for re-parse).

## Test plan
Doc-only — no behavior change (code-reviewer confirmed the `.swift` hunk is
`///`-comment-only; signature/body byte-identical). `swiftlint --strict` passes
on the changed file. All doc claims verified against code (run-gate at
`SimulationRunner:176`, persist at `ScenarioEditorViewModel:380`).

Closes #665

🤖 Generated with [Claude Code](https://claude.com/claude-code)