### PR TITLE
🌐 feat: i18n-wrap ScenarioValidator error messages

### DIFF
--- a/Pastura/Pastura/Engine/ScenarioValidator.swift
+++ b/Pastura/Pastura/Engine/ScenarioValidator.swift
@@ -27,52 +27,48 @@ nonisolated struct ScenarioValidator: Sendable {
     // gate, mirrors `ScenarioLoader`'s YAML-parse path).
     if !Scenario.acceptedLanguages.contains(scenario.language) {
       let allowed = Scenario.acceptedLanguages.sorted().joined(separator: ", ")
-      throw SimulationError.scenarioValidationFailed(
-        "Scenario: field 'language' must be one of {\(allowed)}, got '\(scenario.language)'"
-      )
+      throw validationError(
+        String(localized: "Scenario: field 'language' must be one of {%@}, got '%@'"),
+        allowed, scenario.language)
     }
     if let simulationLanguage = scenario.simulationLanguage,
       !Scenario.acceptedLanguages.contains(simulationLanguage) {
       let allowed = Scenario.acceptedLanguages.sorted().joined(separator: ", ")
-      throw SimulationError.scenarioValidationFailed(
-        "Scenario: field 'simulationLanguage' must be one of {\(allowed)} or nil, "
-          + "got '\(simulationLanguage)'"
-      )
+      throw validationError(
+        String(
+          localized: "Scenario: field 'simulationLanguage' must be one of {%@} or nil, got '%@'"),
+        allowed, simulationLanguage)
     }
 
     // Agent count limits (checked first for clearer error messages)
     if scenario.agentCount < 2 {
-      throw SimulationError.scenarioValidationFailed(
-        "Agent count (\(scenario.agentCount)) is below minimum of 2"
-      )
+      throw validationError(
+        String(localized: "Agent count (%lld) is below minimum of 2"), scenario.agentCount)
     }
     if scenario.agentCount > 10 {
-      throw SimulationError.scenarioValidationFailed(
-        "Agent count (\(scenario.agentCount)) exceeds maximum of 10"
-      )
+      throw validationError(
+        String(localized: "Agent count (%lld) exceeds maximum of 10"), scenario.agentCount)
     }
 
     // Persona count must match agentCount
     if scenario.personas.count != scenario.agentCount {
-      throw SimulationError.scenarioValidationFailed(
-        "Persona count (\(scenario.personas.count)) does not match agent count (\(scenario.agentCount))"
-      )
+      throw validationError(
+        String(localized: "Persona count (%lld) does not match agent count (%lld)"),
+        scenario.personas.count, scenario.agentCount)
     }
 
     // Round count limit
     if scenario.rounds > 30 {
-      throw SimulationError.scenarioValidationFailed(
-        "Round count (\(scenario.rounds)) exceeds maximum of 30"
-      )
+      throw validationError(
+        String(localized: "Round count (%lld) exceeds maximum of 30"), scenario.rounds)
     }
 
     // Inference count estimation
     let estimated = ScenarioLoader.estimateInferenceCount(scenario)
 
     if estimated > 100 {
-      throw SimulationError.scenarioValidationFailed(
-        "Estimated inferences (\(estimated)) exceeds maximum of 100"
-      )
+      throw validationError(
+        String(localized: "Estimated inferences (%lld) exceeds maximum of 100"), estimated)
     }
 
     try validatePhases(scenario)
@@ -80,8 +76,10 @@ nonisolated struct ScenarioValidator: Sendable {
     var warnings: [String] = []
     if estimated > 50 {
       warnings.append(
-        "High inference count (\(estimated)). Simulation may take several minutes."
-      )
+        String(
+          format: String(
+            localized: "High inference count (%lld). Simulation may take several minutes."),
+          estimated))
     }
 
     return ValidationResult(warnings: warnings, estimatedInferences: estimated)
@@ -133,12 +131,9 @@ nonisolated struct ScenarioValidator: Sendable {
     }
     let schema = phase.outputSchema ?? [:]
     if schema[canonical] == nil {
-      throw SimulationError.scenarioValidationFailed(
-        String(
-          format: String(localized: "%@ (%@) requires field '%@' in output."),
-          label, phase.type.rawValue, canonical
-        )
-      )
+      throw validationError(
+        String(localized: "%@ (%@) requires field '%@' in output."),
+        label, phase.type.rawValue, canonical)
     }
   }
 
@@ -196,9 +191,8 @@ nonisolated struct ScenarioValidator: Sendable {
     let trimmedCondition = (phase.condition ?? "").trimmingCharacters(
       in: .whitespacesAndNewlines)
     if trimmedCondition.isEmpty {
-      throw SimulationError.scenarioValidationFailed(
-        "\(phaseLabel): missing or empty 'if' expression."
-      )
+      throw validationError(
+        String(localized: "%@: missing or empty 'if' expression."), phaseLabel)
     }
 
     // Parse-only pre-flight: malformed `if:` (mismatched parens, dangling
@@ -209,22 +203,26 @@ nonisolated struct ScenarioValidator: Sendable {
     do {
       try ConditionEvaluator().parse(trimmedCondition)
     } catch let SimulationError.scenarioValidationFailed(message) {
+      // Raw interpolation is deliberate here (not Form-B): this only prefixes
+      // the phase locator onto `message`, which is already a localized string
+      // emitted by `ConditionEvaluator.parse`. There is no new translatable
+      // literal to extract, so a future i18n sweep should skip this site.
       throw SimulationError.scenarioValidationFailed("\(phaseLabel): \(message)")
     }
 
     let thenCount = phase.thenPhases?.count ?? 0
     let elseCount = phase.elsePhases?.count ?? 0
     if thenCount == 0 && elseCount == 0 {
-      throw SimulationError.scenarioValidationFailed(
-        "\(phaseLabel): must have at least one sub-phase in 'then' or 'else'."
-      )
+      throw validationError(
+        String(localized: "%@: must have at least one sub-phase in 'then' or 'else'."), phaseLabel)
     }
 
     if depth > 0 {
-      throw SimulationError.scenarioValidationFailed(
-        "\(phaseLabel): nested 'conditional' inside another conditional is "
-          + "not allowed (depth-1 rule)."
-      )
+      throw validationError(
+        String(
+          localized:
+            "%@: nested 'conditional' inside another conditional is not allowed (depth-1 rule)."),
+        phaseLabel)
     }
 
     try validateBranch(
@@ -249,9 +247,9 @@ nonisolated struct ScenarioValidator: Sendable {
     for (subIndex, subPhase) in phases.enumerated() {
       let subLabel = "\(parentLabel) \(branchLabel)[\(subIndex + 1)]"
       if subPhase.type == .conditional {
-        throw SimulationError.scenarioValidationFailed(
-          "\(subLabel) is another conditional, which is not allowed (depth-1 rule)."
-        )
+        throw validationError(
+          String(localized: "%@ is another conditional, which is not allowed (depth-1 rule)."),
+          subLabel)
       }
       if subPhase.type == .assign {
         try validateAssignPhaseShape(subPhase, label: subLabel, scenario: scenario)
@@ -286,16 +284,20 @@ nonisolated struct ScenarioValidator: Sendable {
   ) throws {
     let sourceKey = (phase.source ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
     guard !sourceKey.isEmpty else {
-      throw SimulationError.scenarioValidationFailed(
-        "\(label): missing 'source'. event_inject requires a 'source' key naming "
-          + "a top-level YAML field that lists the event strings."
-      )
+      throw validationError(
+        String(
+          localized:
+            "%@: missing 'source'. event_inject requires a 'source' key naming a top-level YAML field that lists the event strings."
+        ),
+        label)
     }
     guard let sourceValue = scenario.extraData[sourceKey] else {
-      throw SimulationError.scenarioValidationFailed(
-        "\(label): source '\(sourceKey)' not found in scenario data. "
-          + "Add a top-level '\(sourceKey)' field to the scenario YAML."
-      )
+      throw validationError(
+        String(
+          localized:
+            "%@: source '%@' not found in scenario data. Add a top-level '%@' field to the scenario YAML."
+        ),
+        label, sourceKey, sourceKey)
     }
     switch sourceValue {
     case .array(let entries):
@@ -304,25 +306,27 @@ nonisolated struct ScenarioValidator: Sendable {
       // which a curator cannot distinguish from a string of unlucky rolls.
       // Reject early so the misconfiguration surfaces at scenario load.
       guard !entries.isEmpty else {
-        throw SimulationError.scenarioValidationFailed(
-          "\(label): source '\(sourceKey)' is empty. "
-            + "event_inject requires at least one string in the list; "
-            + "for a single fixed event use ['only_event']."
-        )
+        throw validationError(
+          String(
+            localized:
+              "%@: source '%@' is empty. event_inject requires at least one string in the list; for a single fixed event use ['only_event']."
+          ),
+          label, sourceKey)
       }
     case .string, .dictionary, .arrayOfDictionaries:
-      throw SimulationError.scenarioValidationFailed(
-        "\(label): source '\(sourceKey)' must be a list of strings. "
-          + "v1 of event_inject only supports the [String] shape; "
-          + "for a single fixed event use ['only_event']."
-      )
+      throw validationError(
+        String(
+          localized:
+            "%@: source '%@' must be a list of strings. v1 of event_inject only supports the [String] shape; for a single fixed event use ['only_event']."
+        ),
+        label, sourceKey)
     }
     if let probability = phase.probability {
       guard (0.0...1.0).contains(probability) else {
-        throw SimulationError.scenarioValidationFailed(
-          "\(label): probability \(probability) is out of range. "
-            + "Must be between 0.0 and 1.0 inclusive."
-        )
+        throw validationError(
+          String(
+            localized: "%@: probability %@ is out of range. Must be between 0.0 and 1.0 inclusive."),
+          label, String(probability))
       }
     }
   }
@@ -340,10 +344,12 @@ nonisolated struct ScenarioValidator: Sendable {
     // here means the scenario YAML genuinely lacks the referenced field —
     // the assign would silently no-op at runtime. Surface it early.
     guard let sourceValue = scenario.extraData[sourceKey] else {
-      throw SimulationError.scenarioValidationFailed(
-        "\(label): source '\(sourceKey)' not found in scenario data. "
-          + "Add a top-level '\(sourceKey)' field to the scenario YAML."
-      )
+      throw validationError(
+        String(
+          localized:
+            "%@: source '%@' not found in scenario data. Add a top-level '%@' field to the scenario YAML."
+        ),
+        label, sourceKey, sourceKey)
     }
     let effectiveTarget = phase.target ?? .all
     switch effectiveTarget {
@@ -352,22 +358,40 @@ nonisolated struct ScenarioValidator: Sendable {
       case .array, .string:
         return
       case .arrayOfDictionaries, .dictionary:
-        throw SimulationError.scenarioValidationFailed(
-          "\(label): source '\(sourceKey)' contains grouped values (e.g., majority/minority pairs). "
-            + "Use target: random_one to distribute these. "
-            + "Use target: all only for a flat list of strings or a single string."
-        )
+        throw validationError(
+          String(
+            localized:
+              "%@: source '%@' contains grouped values (e.g., majority/minority pairs). Use target: random_one to distribute these. Use target: all only for a flat list of strings or a single string."
+          ),
+          label, sourceKey)
       }
     case .randomOne:
       switch sourceValue {
       case .arrayOfDictionaries:
         return
       case .array, .string, .dictionary:
-        throw SimulationError.scenarioValidationFailed(
-          "\(label): source '\(sourceKey)' must be a list of grouped values "
-            + "(e.g., majority/minority pairs) when target is random_one."
-        )
+        throw validationError(
+          String(
+            localized:
+              "%@: source '%@' must be a list of grouped values (e.g., majority/minority pairs) when target is random_one."
+          ),
+          label, sourceKey)
       }
     }
   }
+}
+
+/// Builds a ``SimulationError/scenarioValidationFailed(_:)`` from a localized
+/// format string and its arguments. Collapses the `String(format:)` wrapper at
+/// every call site so each throw stays a single `String(localized:)` literal —
+/// xcstringstool still extracts it as Form B (see `.claude/rules/i18n.md`).
+///
+/// File-scope (not a method) so it stays out of `ScenarioValidator`'s
+/// `type_body_length` budget; `nonisolated` because top-level functions inherit
+/// `MainActor` under `SWIFT_DEFAULT_ACTOR_ISOLATION` and the `nonisolated`
+/// validator calls it synchronously.
+nonisolated private func validationError(
+  _ format: String, _ arguments: CVarArg...
+) -> SimulationError {
+  .scenarioValidationFailed(String(format: format, arguments: arguments))
 }

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -300,6 +300,22 @@
         }
       }
     },
+    "%@ is another conditional, which is not allowed (depth-1 rule)." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ is another conditional, which is not allowed (depth-1 rule)."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ は別の conditional であり、許可されていません（depth-1 ルール）。"
+          }
+        }
+      }
+    },
     "%@ is thinking..." : {
       "localizations" : {
         "ja" : {
@@ -436,6 +452,166 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@: %2$lld"
+          }
+        }
+      }
+    },
+    "%@: missing 'source'. event_inject requires a 'source' key naming a top-level YAML field that lists the event strings." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@: missing 'source'. event_inject requires a 'source' key naming a top-level YAML field that lists the event strings."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@: 'source' がありません。event_inject には、イベント文字列の一覧を持つトップレベル YAML フィールドを指す 'source' キーが必要です。"
+          }
+        }
+      }
+    },
+    "%@: missing or empty 'if' expression." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@: missing or empty 'if' expression."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@: 'if' 式がないか空です。"
+          }
+        }
+      }
+    },
+    "%@: must have at least one sub-phase in 'then' or 'else'." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@: must have at least one sub-phase in 'then' or 'else'."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@: 'then' または 'else' に少なくとも1つのサブフェーズが必要です。"
+          }
+        }
+      }
+    },
+    "%@: nested 'conditional' inside another conditional is not allowed (depth-1 rule)." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@: nested 'conditional' inside another conditional is not allowed (depth-1 rule)."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@: conditional の中に conditional をネストすることは許可されていません（depth-1 ルール）。"
+          }
+        }
+      }
+    },
+    "%@: probability %@ is out of range. Must be between 0.0 and 1.0 inclusive." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: probability %2$@ is out of range. Must be between 0.0 and 1.0 inclusive."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: probability %2$@ が範囲外です。0.0 以上 1.0 以下である必要があります。"
+          }
+        }
+      }
+    },
+    "%@: source '%@' contains grouped values (e.g., majority/minority pairs). Use target: random_one to distribute these. Use target: all only for a flat list of strings or a single string." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: source '%2$@' contains grouped values (e.g., majority/minority pairs). Use target: random_one to distribute these. Use target: all only for a flat list of strings or a single string."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: source '%2$@' にはグループ化された値（例: 多数派/少数派のペア）が含まれています。これらを配分するには target: random_one を使用してください。target: all は文字列のフラットなリストまたは単一の文字列にのみ使用してください。"
+          }
+        }
+      }
+    },
+    "%@: source '%@' is empty. event_inject requires at least one string in the list; for a single fixed event use ['only_event']." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: source '%2$@' is empty. event_inject requires at least one string in the list; for a single fixed event use ['only_event']."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: source '%2$@' が空です。event_inject にはリストに少なくとも1つの文字列が必要です。単一の固定イベントには ['only_event'] を使用してください。"
+          }
+        }
+      }
+    },
+    "%@: source '%@' must be a list of grouped values (e.g., majority/minority pairs) when target is random_one." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: source '%2$@' must be a list of grouped values (e.g., majority/minority pairs) when target is random_one."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: target が random_one の場合、source '%2$@' はグループ化された値（例: 多数派/少数派のペア）のリストである必要があります。"
+          }
+        }
+      }
+    },
+    "%@: source '%@' must be a list of strings. v1 of event_inject only supports the [String] shape; for a single fixed event use ['only_event']." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: source '%2$@' must be a list of strings. v1 of event_inject only supports the [String] shape; for a single fixed event use ['only_event']."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: source '%2$@' は文字列のリストである必要があります。event_inject の v1 は [String] 形式のみをサポートします。単一の固定イベントには ['only_event'] を使用してください。"
+          }
+        }
+      }
+    },
+    "%@: source '%@' not found in scenario data. Add a top-level '%@' field to the scenario YAML." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: source '%2$@' not found in scenario data. Add a top-level '%3$@' field to the scenario YAML."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: source '%2$@' がシナリオデータに見つかりません。シナリオ YAML にトップレベルの '%3$@' フィールドを追加してください。"
           }
         }
       }
@@ -998,6 +1174,38 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "エージェント"
+          }
+        }
+      }
+    },
+    "Agent count (%lld) exceeds maximum of 10" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agent count (%lld) exceeds maximum of 10"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エージェント数 (%lld) が最大値の10を超えています"
+          }
+        }
+      }
+    },
+    "Agent count (%lld) is below minimum of 2" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agent count (%lld) is below minimum of 2"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エージェント数 (%lld) が最小値の2を下回っています"
           }
         }
       }
@@ -2104,6 +2312,22 @@
         }
       }
     },
+    "Estimated inferences (%lld) exceeds maximum of 100" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estimated inferences (%lld) exceeds maximum of 100"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "推定推論回数 (%lld) が最大値の100を超えています"
+          }
+        }
+      }
+    },
     "Ethics" : {
       "localizations" : {
         "ja" : {
@@ -2613,6 +2837,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "思考を隠す"
+          }
+        }
+      }
+    },
+    "High inference count (%lld). Simulation may take several minutes." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "High inference count (%lld). Simulation may take several minutes."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "推論回数が多めです (%lld)。シミュレーションに数分かかる場合があります。"
           }
         }
       }
@@ -3491,6 +3731,22 @@
         }
       }
     },
+    "Persona count (%lld) does not match agent count (%lld)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Persona count (%1$lld) does not match agent count (%2$lld)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ペルソナ数 (%1$lld) がエージェント数 (%2$lld) と一致しません"
+          }
+        }
+      }
+    },
     "Persona name" : {
       "localizations" : {
         "ja" : {
@@ -3993,6 +4249,22 @@
         }
       }
     },
+    "Round count (%lld) exceeds maximum of 30" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Round count (%lld) exceeds maximum of 30"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ラウンド数 (%lld) が最大値の30を超えています"
+          }
+        }
+      }
+    },
     "Rounds" : {
       "localizations" : {
         "ja" : {
@@ -4172,6 +4444,38 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "シナリオが見つかりません"
+          }
+        }
+      }
+    },
+    "Scenario: field 'language' must be one of {%@}, got '%@'" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scenario: field 'language' must be one of {%1$@}, got '%2$@'"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scenario: フィールド 'language' は {%1$@} のいずれかである必要がありますが、'%2$@' が指定されました"
+          }
+        }
+      }
+    },
+    "Scenario: field 'simulationLanguage' must be one of {%@} or nil, got '%@'" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scenario: field 'simulationLanguage' must be one of {%1$@} or nil, got '%2$@'"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scenario: フィールド 'simulationLanguage' は {%1$@} のいずれか、または nil である必要がありますが、'%2$@' が指定されました"
           }
         }
       }


### PR DESCRIPTION
## Summary
- Converts 19 raw interpolated `scenarioValidationFailed` literals + the
  high-inference-count warning in `ScenarioValidator.swift` to the Form-B
  i18n convention `String(format: String(localized: "...%@/%lld..."), args)`,
  and adds `ja` catalog translations. These messages reach the run-gate /
  editor validation UI and previously leaked English on a `ja` device.
- Locators (`Phase N (type)`, `then`/`else`, rawValues, source keys, counts)
  are passed as un-localized args per the #664 precedent; only sentence
  templates are localized. `probability` (Double) → `String(probability)` → `%@`.
- A file-scope `private nonisolated func validationError(_:_:)` collapses the
  `String(format:)` wrapper, keeping the file within swiftlint length budgets.
- The conditional re-throw glue `"\(phaseLabel): \(message)"` is left raw
  (pure punctuation; `message` already localized) with a `// why` comment.

## Test plan
- `swiftlint lint --strict` clean
- Full unit suite: 1957 tests / 177 suites pass (`.contains()` assertions
  unaffected — rendered output is byte-identical)
- `check_localization_coverage.py` green (488 keys, all `ja` translated)

## Follow-up
- `ScenarioLoader.swift` mirrors several of these literals (22 raw,
  0 `String(localized:)`) — a separate twin i18n slice for a future issue.
  No `%arg` orphan is resurrected (those sites are raw, not Form-A).

Closes #666

🤖 Generated with [Claude Code](https://claude.com/claude-code)