### PR TITLE
🌐 feat: i18n-wrap ScenarioLoader error messages (#671)

### DIFF
--- a/Pastura/Pastura/Engine/ScenarioLoader.swift
+++ b/Pastura/Pastura/Engine/ScenarioLoader.swift
@@ -58,7 +58,7 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
     guard let raw = try? Yams.load(yaml: stripped),
       let dict = raw as? [String: Any]
     else {
-      throw SimulationError.scenarioValidationFailed("Invalid YAML format")
+      throw validationError(String(localized: "Invalid YAML format"))
     }
 
     return try mapToScenario(dict)
@@ -129,14 +129,13 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
     _ dict: [String: Any], key: String, label: String
   ) throws -> T {
     guard let raw = dict[key] else {
-      throw SimulationError.scenarioValidationFailed(
-        "\(label): missing required field '\(key)'"
-      )
+      throw validationError(
+        String(localized: "%@: missing required field '%@'"), label, key)
     }
     guard let typed = raw as? T else {
-      throw SimulationError.scenarioValidationFailed(
-        "\(label): field '\(key)' must be \(T.self), got \(type(of: raw))"
-      )
+      throw validationError(
+        String(localized: "%@: field '%@' must be %@, got %@"),
+        label, key, String(describing: T.self), String(describing: type(of: raw)))
     }
     return typed
   }
@@ -151,9 +150,9 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
   ) throws -> T? {
     guard let raw = dict[key] else { return nil }
     guard let typed = raw as? T else {
-      throw SimulationError.scenarioValidationFailed(
-        "\(label): field '\(key)' must be \(T.self), got \(type(of: raw))"
-      )
+      throw validationError(
+        String(localized: "%@: field '%@' must be %@, got %@"),
+        label, key, String(describing: T.self), String(describing: type(of: raw)))
     }
     return typed
   }
@@ -181,9 +180,9 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
     if let int = raw as? Int, !(raw is Bool) {
       return Double(int)
     }
-    throw SimulationError.scenarioValidationFailed(
-      "\(label): field '\(key)' must be Double or Int, got \(type(of: raw))"
-    )
+    throw validationError(
+      String(localized: "%@: field '%@' must be Double or Int, got %@"),
+      label, key, String(describing: type(of: raw)))
   }
 
   /// Maps a raw YAML dictionary to a ``Scenario`` model.
@@ -194,18 +193,19 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
     let language: String = try parseRequired(dict, key: "language", label: "Scenario")
     guard Scenario.acceptedLanguages.contains(language) else {
       let allowed = Scenario.acceptedLanguages.sorted().joined(separator: ", ")
-      throw SimulationError.scenarioValidationFailed(
-        "Scenario: field 'language' must be one of {\(allowed)}, got '\(language)'"
-      )
+      throw validationError(
+        String(localized: "Scenario: field 'language' must be one of {%@}, got '%@'"),
+        allowed, language)
     }
     let simulationLanguage: String? = try parseOptional(
       dict, key: "simulation_language", label: "Scenario")
     if let simulationLanguage, !Scenario.acceptedLanguages.contains(simulationLanguage) {
       let allowed = Scenario.acceptedLanguages.sorted().joined(separator: ", ")
-      throw SimulationError.scenarioValidationFailed(
-        "Scenario: field 'simulation_language' must be one of {\(allowed)} or absent, "
-          + "got '\(simulationLanguage)'"
-      )
+      throw validationError(
+        String(
+          localized: "Scenario: field 'simulation_language' must be one of {%@} or absent, got '%@'"
+        ),
+        allowed, simulationLanguage)
     }
     let agentCount: Int = try parseRequired(dict, key: "agents", label: "Scenario")
     let rounds: Int = try parseRequired(dict, key: "rounds", label: "Scenario")
@@ -218,9 +218,9 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
 
     let personas = try personasRaw.map { try mapPersona($0) }
     if personas.count != agentCount {
-      throw SimulationError.scenarioValidationFailed(
-        "agents (\(agentCount)) does not match personas count (\(personas.count))"
-      )
+      throw validationError(
+        String(localized: "agents (%lld) does not match personas count (%lld)"),
+        agentCount, personas.count)
     }
 
     let phases = try phasesRaw.enumerated().map { index, raw in
@@ -267,9 +267,9 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
       return nil
     }
     guard let parsed = AssignTarget(rawValue: str) else {
-      throw SimulationError.scenarioValidationFailed(
-        "\(label) has invalid target: '\(str)'. Use 'all' or 'random_one'."
-      )
+      throw validationError(
+        String(localized: "%@ has invalid target: '%@'. Use 'all' or 'random_one'."),
+        label, str)
     }
     return parsed
   }
@@ -279,9 +279,9 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
       return nil
     }
     guard let parsed = PairingStrategy(rawValue: str) else {
-      throw SimulationError.scenarioValidationFailed(
-        "\(label) has invalid pairing: '\(str)'. Use 'round_robin'."
-      )
+      throw validationError(
+        String(localized: "%@ has invalid pairing: '%@'. Use 'round_robin'."),
+        label, str)
     }
     return parsed
   }
@@ -292,9 +292,9 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
     }
     guard let parsed = ScoreCalcLogic(rawValue: str) else {
       let allowed = ScoreCalcLogic.allCases.map(\.rawValue).joined(separator: ", ")
-      throw SimulationError.scenarioValidationFailed(
-        "\(label) has invalid logic: '\(str)'. Expected one of: \(allowed)."
-      )
+      throw validationError(
+        String(localized: "%@ has invalid logic: '%@'. Expected one of: %@."),
+        label, str, allowed)
     }
     return parsed
   }
@@ -366,18 +366,18 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
     _ dict: [String: Any], label: String, depth: Int
   ) throws -> PhaseType {
     guard let typeString = dict["type"] as? String else {
-      throw SimulationError.scenarioValidationFailed("\(label) missing 'type'")
+      throw validationError(String(localized: "%@ missing 'type'"), label)
     }
     guard let phaseType = PhaseType(rawValue: typeString) else {
-      throw SimulationError.scenarioValidationFailed(
-        "\(label) has invalid type: '\(typeString)'"
-      )
+      throw validationError(
+        String(localized: "%@ has invalid type: '%@'"), label, typeString)
     }
     if phaseType == .conditional && depth > 0 {
-      throw SimulationError.scenarioValidationFailed(
-        "\(label): nested 'conditional' inside another conditional is not "
-          + "allowed (depth-1 rule)."
-      )
+      throw validationError(
+        String(
+          localized:
+            "%@: nested 'conditional' inside another conditional is not allowed (depth-1 rule)."),
+        label)
     }
     return phaseType
   }
@@ -390,16 +390,16 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
   ) throws -> [String: String]? {
     guard let raw = dict["output"] else { return nil }
     guard let output = raw as? [String: Any] else {
-      throw SimulationError.scenarioValidationFailed(
-        "\(label): field 'output' must be a dictionary of String values, got \(type(of: raw))"
-      )
+      throw validationError(
+        String(localized: "%@: field 'output' must be a dictionary of String values, got %@"),
+        label, String(describing: type(of: raw)))
     }
     var result: [String: String] = [:]
     for (key, value) in output {
       guard let str = value as? String else {
-        throw SimulationError.scenarioValidationFailed(
-          "\(label): output schema value for '\(key)' must be String, got \(type(of: value))"
-        )
+        throw validationError(
+          String(localized: "%@: output schema value for '%@' must be String, got %@"),
+          label, key, String(describing: type(of: value)))
       }
       result[key] = str
     }
@@ -411,9 +411,9 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
   ) throws -> [Phase]? {
     guard let phasesRaw = raw else { return nil }
     guard let list = phasesRaw as? [[String: Any]] else {
-      throw SimulationError.scenarioValidationFailed(
-        "\(parentLabel): '\(branchLabel)' must be an array of phase objects"
-      )
+      throw validationError(
+        String(localized: "%@: '%@' must be an array of phase objects"),
+        parentLabel, branchLabel)
     }
     return try list.enumerated().map { subIndex, subRaw in
       try mapPhase(
@@ -445,31 +445,50 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
       // Array of dicts where any value isn't a String — previously stringified
       // silently, which hid typos like `majority: 1`.
       if arr.allSatisfy({ $0 is [String: Any] }) {
-        throw SimulationError.scenarioValidationFailed(
-          "Top-level field '\(key)': array-of-dict values must all be String. "
-            + "Quote non-string values (e.g. `majority: \"1\"`)."
-        )
+        throw validationError(
+          String(
+            localized:
+              "Top-level field '%@': array-of-dict values must all be String. Quote non-string values (e.g. `majority: \"1\"`)."
+          ),
+          key)
       }
       if arr.allSatisfy({ $0 is String }) {
         return .array(arr.compactMap { $0 as? String })
       }
-      throw SimulationError.scenarioValidationFailed(
-        "Top-level field '\(key)': mixed-type arrays are not supported. "
-          + "Use a pure [String] or [[String: String]]."
-      )
+      throw validationError(
+        String(
+          localized:
+            "Top-level field '%@': mixed-type arrays are not supported. Use a pure [String] or [[String: String]]."
+        ),
+        key)
     }
     if let dict = value as? [String: String] {
       return .dictionary(dict)
     }
     if value is [String: Any] {
-      throw SimulationError.scenarioValidationFailed(
-        "Top-level field '\(key)': dictionary values must all be String. "
-          + "Quote non-string values."
-      )
+      throw validationError(
+        String(
+          localized:
+            "Top-level field '%@': dictionary values must all be String. Quote non-string values."),
+        key)
     }
-    throw SimulationError.scenarioValidationFailed(
-      "Top-level field '\(key)' has unsupported type \(type(of: value)). "
-        + "Supported shapes: \(Self.supportedExtraDataShapes)."
-    )
+    throw validationError(
+      String(localized: "Top-level field '%@' has unsupported type %@. Supported shapes: %@."),
+      key, String(describing: type(of: value)), Self.supportedExtraDataShapes)
   }
+}
+
+/// Builds a ``SimulationError/scenarioValidationFailed(_:)`` from a localized
+/// format string and its arguments. Collapses the `String(format:)` wrapper at
+/// every call site so each throw stays a single `String(localized:)` literal —
+/// xcstringstool still extracts it as Form B (see `.claude/rules/i18n.md`).
+///
+/// File-scope (not a method) so it stays out of `ScenarioLoader`'s
+/// `type_body_length` budget; `nonisolated` because top-level functions inherit
+/// `MainActor` under `SWIFT_DEFAULT_ACTOR_ISOLATION` and the `nonisolated`
+/// loader calls it synchronously.
+nonisolated private func validationError(
+  _ format: String, _ arguments: CVarArg...
+) -> SimulationError {
+  .scenarioValidationFailed(String(format: format, arguments: arguments))
 }

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -300,6 +300,70 @@
         }
       }
     },
+    "%@ has invalid logic: '%@'. Expected one of: %@." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ has invalid logic: '%2$@'. Expected one of: %3$@."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ の logic '%2$@' は無効です。次のいずれかを指定してください: %3$@。"
+          }
+        }
+      }
+    },
+    "%@ has invalid pairing: '%@'. Use 'round_robin'." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ has invalid pairing: '%2$@'. Use 'round_robin'."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ の pairing '%2$@' は無効です。'round_robin' を使用してください。"
+          }
+        }
+      }
+    },
+    "%@ has invalid target: '%@'. Use 'all' or 'random_one'." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ has invalid target: '%2$@'. Use 'all' or 'random_one'."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ の target '%2$@' は無効です。'all' または 'random_one' を使用してください。"
+          }
+        }
+      }
+    },
+    "%@ has invalid type: '%@'" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ has invalid type: '%2$@'"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ の type '%2$@' は無効です"
+          }
+        }
+      }
+    },
     "%@ is another conditional, which is not allowed (depth-1 rule)." : {
       "localizations" : {
         "en" : {
@@ -322,6 +386,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ は考え中..."
+          }
+        }
+      }
+    },
+    "%@ missing 'type'" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ missing 'type'"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ に 'type' がありません"
           }
         }
       }
@@ -456,6 +536,70 @@
         }
       }
     },
+    "%@: '%@' must be an array of phase objects" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: '%2$@' must be an array of phase objects"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: '%2$@' はフェーズオブジェクトの配列である必要があります"
+          }
+        }
+      }
+    },
+    "%@: field '%@' must be %@, got %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: field '%2$@' must be %3$@, got %4$@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: フィールド '%2$@' は %3$@ である必要がありますが、%4$@ が指定されました"
+          }
+        }
+      }
+    },
+    "%@: field '%@' must be Double or Int, got %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: field '%2$@' must be Double or Int, got %3$@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: フィールド '%2$@' は Double または Int である必要がありますが、%3$@ が指定されました"
+          }
+        }
+      }
+    },
+    "%@: field 'output' must be a dictionary of String values, got %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: field 'output' must be a dictionary of String values, got %2$@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: フィールド 'output' は String 値の辞書である必要がありますが、%2$@ が指定されました"
+          }
+        }
+      }
+    },
     "%@: missing 'source'. event_inject requires a 'source' key naming a top-level YAML field that lists the event strings." : {
       "localizations" : {
         "en" : {
@@ -484,6 +628,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@: 'if' 式がないか空です。"
+          }
+        }
+      }
+    },
+    "%@: missing required field '%@'" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: missing required field '%2$@'"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: 必須フィールド '%2$@' がありません"
           }
         }
       }
@@ -532,6 +692,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@: output フィールド名 '%2$@' は ASCII 識別子（英字・数字・アンダースコアのみ。数字またはアンダースコアで始めることはできません）である必要があります。エージェントのテキスト値は任意の言語で構いません。"
+          }
+        }
+      }
+    },
+    "%@: output schema value for '%@' must be String, got %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: output schema value for '%2$@' must be String, got %3$@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: output スキーマのフィールド '%2$@' の値は String である必要がありますが、%3$@ が指定されました"
           }
         }
       }
@@ -2999,6 +3175,22 @@
         }
       }
     },
+    "Invalid YAML format" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invalid YAML format"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無効な YAML 形式です"
+          }
+        }
+      }
+    },
     "Invalid grammar for constrained decoding: %@" : {
       "localizations" : {
         "ja" : {
@@ -4496,6 +4688,22 @@
         }
       }
     },
+    "Scenario: field 'simulation_language' must be one of {%@} or absent, got '%@'" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scenario: field 'simulation_language' must be one of {%1$@} or absent, got '%2$@'"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scenario: フィールド 'simulation_language' は {%1$@} のいずれか、または省略可能である必要がありますが、'%2$@' が指定されました"
+          }
+        }
+      }
+    },
     "Scenarios" : {
       "localizations" : {
         "en" : {
@@ -5032,6 +5240,70 @@
         }
       }
     },
+    "Top-level field '%@' has unsupported type %@. Supported shapes: %@." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Top-level field '%1$@' has unsupported type %2$@. Supported shapes: %3$@."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "トップレベルフィールド '%1$@' はサポートされていない型 %2$@ です。サポートされる形式: %3$@。"
+          }
+        }
+      }
+    },
+    "Top-level field '%@': array-of-dict values must all be String. Quote non-string values (e.g. `majority: \"1\"`)." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Top-level field '%@': array-of-dict values must all be String. Quote non-string values (e.g. `majority: \"1\"`)."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "トップレベルフィールド '%@': 辞書配列の値はすべて String である必要があります。String 以外の値は引用符で囲んでください（例: `majority: \"1\"`）。"
+          }
+        }
+      }
+    },
+    "Top-level field '%@': dictionary values must all be String. Quote non-string values." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Top-level field '%@': dictionary values must all be String. Quote non-string values."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "トップレベルフィールド '%@': 辞書の値はすべて String である必要があります。String 以外の値は引用符で囲んでください。"
+          }
+        }
+      }
+    },
+    "Top-level field '%@': mixed-type arrays are not supported. Use a pure [String] or [[String: String]]." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Top-level field '%@': mixed-type arrays are not supported. Use a pure [String] or [[String: String]]."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "トップレベルフィールド '%@': 混在型の配列はサポートされていません。純粋な [String] または [[String: String]] を使用してください。"
+          }
+        }
+      }
+    },
     "Try Again" : {
       "localizations" : {
         "ja" : {
@@ -5550,6 +5822,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "アクティブ"
+          }
+        }
+      }
+    },
+    "agents (%lld) does not match personas count (%lld)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "agents (%1$lld) does not match personas count (%2$lld)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "agents (%1$lld) が personas の数 (%2$lld) と一致しません"
           }
         }
       }


### PR DESCRIPTION
## Summary
- i18n-wrap all 21 `SimulationError.scenarioValidationFailed(...)` throw-site
  literals in `ScenarioLoader.swift` to the Form-B convention
  (`validationError(String(localized: "…%@/%lld…"), args)`). These YAML-load /
  import-path errors previously leaked English on a `ja` device.
- Add a file-scope `nonisolated private func validationError(_:_:)` helper,
  mirroring the one #670 added to `ScenarioValidator.swift`, so each throw stays
  a single `String(localized:)` literal.
- Locators (field names, type names, counts, the accepted-language list) pass as
  un-localized `%@`/`%lld` args; only the sentence templates are localized.
- Catalog: the `'language'` site reuses #670's existing key; 19 new keys added
  with `ja` translations (en+ja `state: translated`).

The YAML-parse twin of #666 / PR #670 (which wrapped `ScenarioValidator.swift`).
Pure i18n debt — no functional change.

### Note: intentional en/ja divergence
The new `'simulation_language'` key (snake_case, "or absent" / "省略可能") is
deliberately distinct from the validator's `'simulationLanguage'` key (camelCase,
"or nil" / "nil"). The loader rejects on the YAML-author surface where "absent"
is the right user-facing term; the validator is the programmatic-construction
surface. Both keys coexist by design — not drift.

## Test plan
- `ScenarioLoaderTests` (incl. `+Language`, `+StrictTypes`) — 54 tests pass;
  assertions use `.contains(...)` on locator substrings preserved as args.
- `swift build` (pastura-harness SwiftPM package) — compiles.
- `python3 scripts/check_localization_coverage.py` — green (507 keys, all ja translated).
- swiftlint `--strict` + pre-commit hook (swiftlint + build + gates) — pass.

Closes #671
