### PR TITLE
♻️ refactor: paginate Past Results aggregate list (#586)

### DIFF
--- a/Pastura/Pastura/App/ResultsViewModel.swift
+++ b/Pastura/Pastura/App/ResultsViewModel.swift
@@ -4,44 +4,70 @@ import Foundation
 ///
 /// Two load modes — selected by the ``ResultsScope`` argument:
 ///
-/// - **Aggregate** (``ResultsScope/aggregate``): aggregates per-language
-///   scenario variants under a single canonical group keyed by
-///   `sourceId ?? id` (ADR-010 D4 cross-language aliasing, #392). Each
-///   canonical group's section header is the device-locale variant's
-///   `name`, falling back to the first available variant when the
-///   device-language sibling isn't shipped (D6 line 217). Rows within
-///   a group are sorted newest-first; row labels show the
-///   simulation-time variant's `name` (un-translated) so the un-
-///   translated conversation content stays internally consistent.
+/// - **Aggregate** (``ResultsScope/aggregate``): a paginated global recency
+///   window over **all** runs (#586). Runs are fetched newest-first one keyset
+///   page at a time and bucketed into canonical groups keyed by `sourceId ?? id`
+///   (ADR-010 D4 cross-language aliasing, #392). Each canonical group's section
+///   header is the device-locale variant's `name`, falling back to the first
+///   available variant when the device-language sibling isn't shipped. Rows
+///   within a group stay newest-first; row labels show the simulation-time
+///   variant's `name` (un-translated). Groups are ordered by their most-recent
+///   run, so loading an older page can move an already-shown group up the list,
+///   and NULL-`scenarioId` orphan runs interleave by recency rather than always
+///   sorting last. An optional free-text scenario-name filter narrows the
+///   window (pushed into SQL so it reaches un-loaded runs).
 /// - **Detail** (``ResultsScope/scenario(_:)``): per-variant only — shows
 ///   the one scenario's simulations under a single group. Cross-variant
 ///   aggregation is intentionally limited to ``ResultsScope/aggregate`` so
 ///   a user reading a JA scenario's detail doesn't see EN sibling runs
-///   commingled. See
-///   ``Route/results(scenarioId:)`` for the entry-point contract.
+///   commingled. See ``Route/results(scenarioId:)`` for the entry-point contract.
 @Observable
 final class ResultsViewModel {
   private(set) var groups: [ScenarioGroup] = []
   private(set) var isLoading = false
+  /// `true` while a ``loadMore()`` page fetch is in flight — drives the
+  /// load-more affordance's spinner and guards against re-entrant fetches.
+  private(set) var isLoadingMore = false
+  /// `true` when more aggregate pages may exist (the last raw page filled the
+  /// limit). Always `false` for the un-paginated Detail scope.
+  private(set) var hasMore = false
   private(set) var errorMessage: String?
 
   private let scenarioRepository: any ScenarioRepository
   private let simulationRepository: any SimulationRepository
   private let turnRepository: any TurnRepository
+  /// Page size for the aggregate keyset window. Injectable so tests can drive
+  /// multi-page behavior without seeding hundreds of runs.
+  private let pageSize: Int
+
+  // Aggregate pagination state.
+  private var nameQuery: String = ""
+  private var deviceLanguage: String = LocaleResolver.deviceDefault()
+  /// Accumulated **visible** light items across loaded pages (dangling-
+  /// scenarioId rows already dropped), global newest-first.
+  private var loadedRuns: [PastRunListItem] = []
+  /// Keyset cursor = the last **raw** row of the last fetched page (regardless
+  /// of visibility), so the next page resumes correctly even past filtered rows.
+  private var cursor: SimulationPageCursor?
+  /// Cumulative count of **raw** rows fetched — the depth a reappear-refresh
+  /// re-reads from the top so the user's scroll position survives.
+  private var loadedRawCount = 0
+  /// Live scenarios by id — bounded (small rows), kept for canonical-key
+  /// bucketing and device-locale header resolution.
+  private var scenarioById: [String: ScenarioRecord] = [:]
+  /// Precomputed device-locale section header per live canonical key.
+  private var headerNameByCanonicalKey: [String: String] = [:]
 
   /// One simulation row within a ``ScenarioGroup``.
   ///
-  /// `variantName` is the simulation-time variant's display name —
-  /// the `ScenarioRecord.name` of the variant whose `id` matches
-  /// `record.scenarioId`. Kept un-translated (per-variant) so the
-  /// label stays consistent with the run's recorded conversation
-  /// content. When the variant is later renamed by the user, the
-  /// label reflects the current name at view time (matching the
-  /// section-name behavior in Phase 1).
+  /// `variantName` is the simulation-time variant's display name — the
+  /// `ScenarioRecord.name` of the variant whose `id` matches the run's
+  /// `scenarioId`. Kept un-translated (per-variant) so the label stays
+  /// consistent with the run's recorded conversation content.
   struct SimulationRow: Identifiable, Sendable {
-    let record: SimulationRecord
+    let item: PastRunListItem
     let variantName: String
-    var id: String { record.id }
+    var id: String { item.id }
   }
 
   /// One section in the results list.
@@ -60,26 +86,25 @@ final class ResultsViewModel {
   init(
     scenarioRepository: any ScenarioRepository,
     simulationRepository: any SimulationRepository,
-    turnRepository: any TurnRepository
+    turnRepository: any TurnRepository,
+    pageSize: Int = 50
   ) {
     self.scenarioRepository = scenarioRepository
     self.simulationRepository = simulationRepository
     self.turnRepository = turnRepository
+    self.pageSize = pageSize
   }
 
-  /// Loads results into ``groups``. ``ResultsScope/aggregate`` triggers
-  /// cross-variant aggregation; ``ResultsScope/scenario(_:)`` triggers
-  /// Detail per-variant.
+  /// Loads results into ``groups``. ``ResultsScope/aggregate`` resets the
+  /// keyset window and loads its first visible page; ``ResultsScope/scenario(_:)``
+  /// loads the one scenario's runs (un-paginated).
   ///
   /// - Parameters:
-  ///   - deviceLanguage: Overridable for tests. Production
-  ///     call-sites use the default (``LocaleResolver/deviceDefault(preferredLocalizations:)``).
-  ///   - showLoading: When `false`, the `isLoading` spinner state is
-  ///     left untouched so the call refreshes ``groups`` in place
-  ///     without flashing the full-screen `ProgressView`. Used for the
-  ///     reappear-refresh after a per-run delete (`ResultsView`), where
-  ///     a spinner flash on every back-navigation would be a regression.
-  ///     The default (`true`) preserves the first-load behavior.
+  ///   - deviceLanguage: Overridable for tests. Production call-sites use the
+  ///     default (``LocaleResolver/deviceDefault(preferredLocalizations:)``).
+  ///   - showLoading: When `false`, the `isLoading` spinner state is left
+  ///     untouched so the call refreshes ``groups`` in place without flashing
+  ///     the full-screen `ProgressView` (the Detail reappear-refresh path).
   func load(
     scope: ResultsScope,
     deviceLanguage: String = LocaleResolver.deviceDefault(),
@@ -91,145 +116,230 @@ final class ResultsViewModel {
     do {
       switch scope {
       case .aggregate:
-        groups = try await loadHomeAggregated(deviceLanguage: deviceLanguage)
+        self.deviceLanguage = deviceLanguage
+        try await reloadAggregate()
       case .scenario(let scenarioId):
-        groups = try await loadDetailPerVariant(scenarioId: scenarioId)
+        hasMore = false
+        try await loadDetailPerVariant(scenarioId: scenarioId)
       }
     } catch {
-      errorMessage = String(
-        format: String(localized: "Failed to load results: %@"), error.localizedDescription)
+      errorMessage = Self.failureMessage(error)
     }
 
     if showLoading { isLoading = false }
   }
 
-  /// Home aggregation. Buckets `fetchAll()` by canonical key
-  /// (`sourceId ?? id`) — mirrors ``HomeViewModel/presetsResolvedForLanguage(_:deviceLanguage:)``'s
-  /// convention so the two consumers can migrate together when
-  /// ADR-010 D6's eventual `ScenarioRepository.variants(of:)`
-  /// primitive lands.
-  ///
-  /// Per-variant section-header selection uses ``ScenarioYAMLLanguage/parse(_:)``
-  /// for the variant's `language`. Row variant names are taken from
-  /// the already-fetched `ScenarioRecord.name` — no extra DB hit
-  /// per row.
-  private func loadHomeAggregated(deviceLanguage: String) async throws -> [ScenarioGroup] {
+  /// Loads the next visible page of the aggregate window. No-op when no more
+  /// pages exist or a fetch is already in flight.
+  func loadMore() async {
+    guard hasMore, !isLoadingMore else { return }
+    isLoadingMore = true
+    do {
+      try await drainUntilVisibleProgress()
+      rebuildGroups()
+    } catch {
+      errorMessage = Self.failureMessage(error)
+    }
+    isLoadingMore = false
+  }
+
+  /// Applies (or clears) the scenario-name filter and reloads the aggregate
+  /// window from the top. No spinner — the prior groups stay visible until the
+  /// new page resolves. No-op when the query is unchanged.
+  func applyFilter(
+    _ query: String,
+    deviceLanguage: String = LocaleResolver.deviceDefault()
+  ) async {
+    let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard trimmed != nameQuery else { return }
+    nameQuery = trimmed
+    self.deviceLanguage = deviceLanguage
+    errorMessage = nil
+    do {
+      try await reloadAggregate()
+    } catch {
+      errorMessage = Self.failureMessage(error)
+    }
+  }
+
+  /// Re-fetches in place when the list reappears (e.g. after a per-run delete
+  /// pops back). For aggregate, the currently-loaded depth is re-read from the
+  /// top so a deleted run drops out without resetting the user's scroll
+  /// position (#586 incremental refresh of the #545 reappear-refresh). For
+  /// detail, a silent full reload.
+  func refreshOnReappear(
+    scope: ResultsScope,
+    deviceLanguage: String = LocaleResolver.deviceDefault()
+  ) async {
+    errorMessage = nil
+    switch scope {
+    case .aggregate:
+      self.deviceLanguage = deviceLanguage
+      do {
+        try await refreshAggregatePreservingDepth()
+      } catch {
+        errorMessage = Self.failureMessage(error)
+      }
+    case .scenario:
+      await load(scope: scope, deviceLanguage: deviceLanguage, showLoading: false)
+    }
+  }
+
+  // MARK: - Aggregate (paginated recency window)
+
+  /// Reserved canonical-key prefix for orphaned-run groups. The leading NUL
+  /// guarantees no collision with a live scenario's `sourceId ?? id`.
+  private static let orphanCanonicalKeyPrefix = "\u{0}orphan:"
+
+  /// Resets the window and loads the first visible page.
+  private func reloadAggregate() async throws {
+    try await refreshScenarioIndex()
+    loadedRuns = []
+    cursor = nil
+    loadedRawCount = 0
+    hasMore = true
+    try await drainUntilVisibleProgress()
+    rebuildGroups()
+  }
+
+  /// Fetches keyset pages until at least one new **visible** row is appended or
+  /// no pages remain. A page made entirely of dangling-scenarioId (invisible)
+  /// rows would otherwise stall the load-more affordance, so such pages are
+  /// drained internally rather than surfaced one-at-a-time (#586 auto-drain).
+  private func drainUntilVisibleProgress() async throws {
+    let startCount = loadedRuns.count
+    while loadedRuns.count == startCount && hasMore {
+      let query = nameQuery.isEmpty ? nil : nameQuery
+      let cursorSnapshot = cursor
+      let limit = pageSize
+      let rawPage = try await offMain { [simulationRepository] in
+        try simulationRepository.fetchRecentRunPage(
+          nameQuery: query, before: cursorSnapshot, limit: limit)
+      }
+      ingest(rawPage)
+    }
+  }
+
+  /// Folds a freshly-fetched raw page into the window: advances `hasMore` and
+  /// the keyset `cursor` off the **raw** row count / last raw row, and appends
+  /// only the visible (non-dangling) rows to ``loadedRuns``.
+  private func ingest(_ rawPage: [PastRunListItem]) {
+    loadedRawCount += rawPage.count
+    hasMore = rawPage.count == pageSize
+    if let last = rawPage.last {
+      cursor = SimulationPageCursor(createdAt: last.createdAt, id: last.id)
+    }
+    loadedRuns += rawPage.filter { bucket(for: $0) != nil }
+  }
+
+  /// Re-reads the loaded depth from the top, recomputing `cursor` + `hasMore`
+  /// from the re-fetched window. Keyset tolerates a cursor that points at a
+  /// since-deleted row (it is still a valid `< ` boundary), so a delete between
+  /// pages cannot corrupt a subsequent ``loadMore()``.
+  private func refreshAggregatePreservingDepth() async throws {
+    try await refreshScenarioIndex()
+    let depth = max(loadedRawCount, pageSize)
+    let query = nameQuery.isEmpty ? nil : nameQuery
+    let rawPage = try await offMain { [simulationRepository] in
+      try simulationRepository.fetchRecentRunPage(nameQuery: query, before: nil, limit: depth)
+    }
+    loadedRawCount = rawPage.count
+    hasMore = rawPage.count == depth
+    cursor = rawPage.last.map { SimulationPageCursor(createdAt: $0.createdAt, id: $0.id) }
+    loadedRuns = rawPage.filter { bucket(for: $0) != nil }
+    rebuildGroups()
+  }
+
+  /// Reloads the bounded scenario index + device-locale header map. Scenario
+  /// rows are small (no `stateJSON`); the heavy run rows page in lazily.
+  private func refreshScenarioIndex() async throws {
     let scenarios = try await offMain { [scenarioRepository] in
       try scenarioRepository.fetchAll()
     }
+    scenarioById = Dictionary(
+      scenarios.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
 
     let grouped = Dictionary(grouping: scenarios) { $0.sourceId ?? $0.id }
-
-    var result: [ScenarioGroup] = []
+    var headers: [String: String] = [:]
     for (canonicalKey, variants) in grouped {
-      // Pick the device-locale variant for the section header.
-      // Falls back to first variant when the device-language sibling
-      // isn't in the group (D6 line 217 "falls back to any available
-      // variant if the device-default's variant is absent").
+      // Pick the device-locale variant for the section header, falling back to
+      // the first available variant when the device-language sibling is absent.
       let variantsWithLang = variants.map {
         (record: $0, lang: ScenarioYAMLLanguage.parse($0.yamlDefinition))
       }
       let headerVariant =
         variantsWithLang.first(where: { $0.lang == deviceLanguage })?.record
         ?? variantsWithLang.first?.record
-      guard let headerVariant else { continue }
+      if let headerVariant { headers[canonicalKey] = headerVariant.name }
+    }
+    headerNameByCanonicalKey = headers
+  }
 
-      // Fan-out: fetch sims per variant. Row's variantName uses the
-      // already-fetched ScenarioRecord.name — no extra DB query per
-      // row (avoids the Dependency-Rule violation of pushing the
-      // lookup into ResultsView). N+1 trips are bounded: ≤ 2-3
-      // variants × ≤ ~8-12 canonical groups in practice — when ADR-010
-      // D6's `variants(of:)` ships, this loop can co-migrate to a
-      // batched `fetchByScenarioIds([String])` if perf becomes a
-      // concern.
-      var rows: [SimulationRow] = []
-      for variant in variants {
-        let sims = try await offMain { [simulationRepository] in
-          try simulationRepository.fetchByScenarioId(variant.id)
-        }
-        for sim in sims {
-          rows.append(SimulationRow(record: sim, variantName: variant.name))
-        }
+  /// Buckets a run to its canonical group + per-variant label. Returns `nil`
+  /// for a **dangling** run (non-null `scenarioId` absent from the live index)
+  /// so it stays invisible — preserving the prior structural contract that
+  /// dangling runs never surface (the new direct-table query would otherwise
+  /// return them).
+  private func bucket(for item: PastRunListItem) -> (key: String, variantName: String)? {
+    if let scenarioId = item.scenarioId {
+      guard let scenario = scenarioById[scenarioId] else { return nil }
+      return (scenario.sourceId ?? scenario.id, scenario.name)
+    }
+    // NULL scenarioId — a deleted-scenario orphan; key off the captured
+    // snapshot under the reserved prefix so it cannot merge with a live group.
+    let snapshot = item.scenarioNameSnapshot
+    let name = snapshot ?? String(localized: "Deleted scenario")
+    let keySuffix = snapshot ?? "\u{0}unnamed"
+    return (Self.orphanCanonicalKeyPrefix + keySuffix, name)
+  }
+
+  /// Re-buckets the full accumulated visible window into canonical groups.
+  /// Groups appear in the recency order their most-recent run was first seen
+  /// (``loadedRuns`` is global newest-first), so older pages extend existing
+  /// groups downward and only introduce new groups below.
+  private func rebuildGroups() {
+    var order: [String] = []
+    var rowsByKey: [String: [SimulationRow]] = [:]
+    for item in loadedRuns {
+      guard let bucket = bucket(for: item) else { continue }
+      if rowsByKey[bucket.key] == nil {
+        order.append(bucket.key)
+        rowsByKey[bucket.key] = []
       }
-
-      guard !rows.isEmpty else { continue }
-      rows.sort { $0.record.createdAt > $1.record.createdAt }
-      result.append(
-        ScenarioGroup(
-          sectionName: headerVariant.name,
-          canonicalKey: canonicalKey,
-          rows: rows
-        ))
+      rowsByKey[bucket.key]?.append(SimulationRow(item: item, variantName: bucket.variantName))
     }
-
-    // Surface orphaned runs (scenarioId == nil) whose source scenario was
-    // deleted. The scenario-driven loop above can't reach them, and they
-    // carry no live `sourceId`/`id`, so they group under a reserved canonical
-    // key (NUL-prefixed) that cannot collide with a live group, and are
-    // appended after the live groups regardless of name ordering.
-    let orphanGroups = try await orphanedGroups()
-
-    // Stable cross-group order keyed by canonical id so reloads
-    // don't flicker. Orphaned (deleted-scenario) groups always sort last.
-    return result.sorted { $0.canonicalKey < $1.canonicalKey }
-      + orphanGroups.sorted { $0.sectionName < $1.sectionName }
-  }
-
-  /// Reserved canonical-key prefix for orphaned-run groups. The leading NUL
-  /// guarantees no collision with a live scenario's `sourceId ?? id`.
-  private static let orphanCanonicalKeyPrefix = "\u{0}orphan:"
-
-  /// Builds groups for orphaned runs (`scenarioId IS NULL`), bucketed by the
-  /// scenario name captured in each run's snapshot.
-  private func orphanedGroups() async throws -> [ScenarioGroup] {
-    let orphans = try await offMain { [simulationRepository] in
-      try simulationRepository.fetchOrphaned()
-    }
-    guard !orphans.isEmpty else { return [] }
-
-    let byName = Dictionary(grouping: orphans) { $0.scenarioNameSnapshot }
-    return byName.map { snapshotName, sims in
-      let sectionName = snapshotName ?? String(localized: "Deleted scenario")
-      // Key on the locale-invariant snapshot name (or a fixed sentinel for
-      // the nameless case) so the group's identity / sort order never depends
-      // on the display locale — only `sectionName` carries localized text.
-      let keySuffix = snapshotName ?? "\u{0}unnamed"
-      let rows =
-        sims
-        .map { SimulationRow(record: $0, variantName: sectionName) }
-        .sorted { $0.record.createdAt > $1.record.createdAt }
-      return ScenarioGroup(
-        sectionName: sectionName,
-        canonicalKey: Self.orphanCanonicalKeyPrefix + keySuffix,
-        rows: rows)
+    groups = order.compactMap { key in
+      guard let rows = rowsByKey[key], !rows.isEmpty else { return nil }
+      let header = headerNameByCanonicalKey[key] ?? rows[0].variantName
+      return ScenarioGroup(sectionName: header, canonicalKey: key, rows: rows)
     }
   }
 
-  /// Detail path: shows only this scenario's simulations. No cross-
-  /// variant aggregation by design — a user on a JA `ScenarioDetailView`
-  /// sees only JA runs even when an EN sibling exists. Cross-variant
-  /// browsing is reserved for the Home entry point.
-  private func loadDetailPerVariant(scenarioId: String) async throws -> [ScenarioGroup] {
+  // MARK: - Detail (per-variant, un-paginated)
+
+  /// Detail path: shows only this scenario's simulations as lightweight rows.
+  /// No cross-variant aggregation by design — a user on a JA `ScenarioDetailView`
+  /// sees only JA runs even when an EN sibling exists.
+  private func loadDetailPerVariant(scenarioId: String) async throws {
     let scenario = try await offMain { [scenarioRepository] in
       try scenarioRepository.fetchById(scenarioId)
     }
-    let sims = try await offMain { [simulationRepository] in
-      try simulationRepository.fetchByScenarioId(scenarioId)
+    let items = try await offMain { [simulationRepository] in
+      try simulationRepository.fetchRunList(scenarioId: scenarioId)
     }
-    guard !sims.isEmpty else { return [] }
+    guard !items.isEmpty else {
+      groups = []
+      return
+    }
 
     let name = scenario?.name ?? String(localized: "Unknown")
     let canonical = scenario?.sourceId ?? scenarioId
-
-    let rows =
-      sims
-      .map { SimulationRow(record: $0, variantName: name) }
-      .sorted { $0.record.createdAt > $1.record.createdAt }
-
-    return [
-      ScenarioGroup(sectionName: name, canonicalKey: canonical, rows: rows)
-    ]
+    // `fetchRunList` already returns newest-first; no re-sort needed.
+    let rows = items.map { SimulationRow(item: $0, variantName: name) }
+    groups = [ScenarioGroup(sectionName: name, canonicalKey: canonical, rows: rows)]
   }
+
+  // MARK: - Turns
 
   /// Loads all turn records for a simulation (for result detail replay).
   func loadTurns(simulationId: String) async -> [TurnRecord] {
@@ -244,9 +354,8 @@ final class ResultsViewModel {
     }
   }
 
-  /// Decodes the SimulationState from a record's stateJSON.
-  func decodeState(from record: SimulationRecord) -> SimulationState? {
-    guard let data = record.stateJSON.data(using: .utf8) else { return nil }
-    return try? JSONDecoder().decode(SimulationState.self, from: data)
+  private static func failureMessage(_ error: Error) -> String {
+    String(
+      format: String(localized: "Failed to load results: %@"), error.localizedDescription)
   }
 }

--- a/Pastura/Pastura/App/ResultsViewModel.swift
+++ b/Pastura/Pastura/App/ResultsViewModel.swift
@@ -52,6 +52,13 @@ final class ResultsViewModel {
   /// Cumulative count of **raw** rows fetched — the depth a reappear-refresh
   /// re-reads from the top so the user's scroll position survives.
   private var loadedRawCount = 0
+  /// Monotonic load-cycle stamp. Bumped whenever the window is reset
+  /// (`reloadAggregate` / `applyFilter` / `refreshAggregatePreservingDepth`).
+  /// An in-flight `loadMore`/drain captures the stamp and discards a page whose
+  /// stamp is stale — so a filter change (or reappear-refresh) that lands while
+  /// the auto-firing load-more sentinel is mid-fetch can't fold an
+  /// old-query/old-cursor page into the freshly-reset window.
+  private var loadGeneration = 0
   /// Live scenarios by id — bounded (small rows), kept for canonical-key
   /// bucketing and device-locale header resolution.
   private var scenarioById: [String: ScenarioRecord] = [:]
@@ -130,15 +137,19 @@ final class ResultsViewModel {
   }
 
   /// Loads the next visible page of the aggregate window. No-op when no more
-  /// pages exist or a fetch is already in flight.
+  /// pages exist or a fetch is already in flight. If a window reset (filter /
+  /// refresh) supersedes this call mid-fetch, the stale page is discarded.
   func loadMore() async {
     guard hasMore, !isLoadingMore else { return }
     isLoadingMore = true
+    let generation = loadGeneration
     do {
-      try await drainUntilVisibleProgress()
-      rebuildGroups()
+      try await drainUntilVisibleProgress(generation: generation)
+      if generation == loadGeneration { rebuildGroups() }
     } catch {
-      errorMessage = Self.failureMessage(error)
+      // Suppress an error from a page that a window reset already superseded —
+      // it no longer corresponds to the live window.
+      if generation == loadGeneration { errorMessage = Self.failureMessage(error) }
     }
     isLoadingMore = false
   }
@@ -193,12 +204,16 @@ final class ResultsViewModel {
 
   /// Resets the window and loads the first visible page.
   private func reloadAggregate() async throws {
+    loadGeneration += 1
+    let generation = loadGeneration
     try await refreshScenarioIndex()
+    guard generation == loadGeneration else { return }
     loadedRuns = []
     cursor = nil
     loadedRawCount = 0
     hasMore = true
-    try await drainUntilVisibleProgress()
+    try await drainUntilVisibleProgress(generation: generation)
+    guard generation == loadGeneration else { return }
     rebuildGroups()
   }
 
@@ -206,7 +221,7 @@ final class ResultsViewModel {
   /// no pages remain. A page made entirely of dangling-scenarioId (invisible)
   /// rows would otherwise stall the load-more affordance, so such pages are
   /// drained internally rather than surfaced one-at-a-time (#586 auto-drain).
-  private func drainUntilVisibleProgress() async throws {
+  private func drainUntilVisibleProgress(generation: Int) async throws {
     let startCount = loadedRuns.count
     while loadedRuns.count == startCount && hasMore {
       let query = nameQuery.isEmpty ? nil : nameQuery
@@ -216,6 +231,10 @@ final class ResultsViewModel {
         try simulationRepository.fetchRecentRunPage(
           nameQuery: query, before: cursorSnapshot, limit: limit)
       }
+      // A window reset (filter / refresh) landed during the fetch — this page
+      // was read against a now-stale query/cursor, so drop it rather than fold
+      // it into the reset window.
+      guard generation == loadGeneration else { return }
       ingest(rawPage)
     }
   }
@@ -235,14 +254,21 @@ final class ResultsViewModel {
   /// Re-reads the loaded depth from the top, recomputing `cursor` + `hasMore`
   /// from the re-fetched window. Keyset tolerates a cursor that points at a
   /// since-deleted row (it is still a valid `< ` boundary), so a delete between
-  /// pages cannot corrupt a subsequent ``loadMore()``.
+  /// pages cannot corrupt a subsequent ``loadMore()``. The re-read depth is
+  /// unbounded by design (it preserves the user's scroll position); memory
+  /// stays light because the repository still projects `stateJSON` away per
+  /// row — only the top-3-score CPU cost scales with depth on this path.
   private func refreshAggregatePreservingDepth() async throws {
+    loadGeneration += 1
+    let generation = loadGeneration
     try await refreshScenarioIndex()
+    guard generation == loadGeneration else { return }
     let depth = max(loadedRawCount, pageSize)
     let query = nameQuery.isEmpty ? nil : nameQuery
     let rawPage = try await offMain { [simulationRepository] in
       try simulationRepository.fetchRecentRunPage(nameQuery: query, before: nil, limit: depth)
     }
+    guard generation == loadGeneration else { return }
     loadedRawCount = rawPage.count
     hasMore = rawPage.count == depth
     cursor = rawPage.last.map { SimulationPageCursor(createdAt: $0.createdAt, id: $0.id) }

--- a/Pastura/Pastura/Data/PastRunListItem.swift
+++ b/Pastura/Pastura/Data/PastRunListItem.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// One agent's score within a ``PastRunListItem`` row preview.
+///
+/// Only the run's top-scoring agents are projected (highest-first, capped
+/// at three) so the Past Results list can render its score chips without
+/// retaining the run's full `stateJSON` in memory — see
+/// ``SimulationRepository/fetchRecentRunPage(nameQuery:before:limit:)``.
+nonisolated public struct PastRunScore: Sendable, Equatable {
+  public let name: String
+  public let value: Int
+
+  public init(name: String, value: Int) {
+    self.name = name
+    self.value = value
+  }
+}
+
+/// A lightweight projection of a `simulations` row for the Past Results list.
+///
+/// Past Results paginates over potentially thousands of runs, each carrying
+/// a heavy `stateJSON` (the full conversation log, ~100-300 KB/run per
+/// ADR-015 §2). Materializing whole `SimulationRecord`s would re-create the
+/// memory pressure issue #586 set out to fix, so the repository projects each
+/// row to this light shape — the columns the list cell renders plus the run's
+/// top-3 scores (extracted from `stateJSON` row-by-row and then discarded, so
+/// the full state never crosses into app memory).
+nonisolated public struct PastRunListItem: Sendable, Equatable, Identifiable {
+  public let id: String
+  /// Foreign key into `scenarios`. Nil for orphaned runs (the v7
+  /// `ON DELETE SET NULL` outcome); such runs label off ``scenarioNameSnapshot``.
+  public let scenarioId: String?
+  public let createdAt: Date
+  /// Raw status string (matches `SimulationStatus.rawValue`); use
+  /// ``simulationStatus`` for type-safe access.
+  public let status: String
+  /// Display name captured at run-creation, surfaced for orphaned runs whose
+  /// source scenario was deleted.
+  public let scenarioNameSnapshot: String?
+  /// The run's highest-scoring agents (highest-first, at most three).
+  public let topScores: [PastRunScore]
+
+  public init(
+    id: String,
+    scenarioId: String?,
+    createdAt: Date,
+    status: String,
+    scenarioNameSnapshot: String?,
+    topScores: [PastRunScore]
+  ) {
+    self.id = id
+    self.scenarioId = scenarioId
+    self.createdAt = createdAt
+    self.status = status
+    self.scenarioNameSnapshot = scenarioNameSnapshot
+    self.topScores = topScores
+  }
+
+  /// Type-safe accessor for the run status.
+  public var simulationStatus: SimulationStatus? {
+    SimulationStatus(rawValue: status)
+  }
+}
+
+/// Keyset (seek) cursor for ``SimulationRepository/fetchRecentRunPage(nameQuery:before:limit:)``.
+///
+/// Pagination is keyset rather than `LIMIT/OFFSET` so a run inserted at the
+/// top of the recency stream (e.g. a background simulation completing
+/// mid-scroll, ADR-003) cannot shift the window and duplicate/skip rows. The
+/// cursor is the previous page's **last raw row**; the next page selects rows
+/// strictly older than it on the composite `(createdAt DESC, id DESC)` order.
+nonisolated public struct SimulationPageCursor: Sendable, Equatable {
+  public let createdAt: Date
+  public let id: String
+
+  public init(createdAt: Date, id: String) {
+    self.createdAt = createdAt
+    self.id = id
+  }
+}

--- a/Pastura/Pastura/Data/SimulationRepository.swift
+++ b/Pastura/Pastura/Data/SimulationRepository.swift
@@ -13,6 +13,32 @@ nonisolated public protocol SimulationRepository: Sendable {
   /// Fetches all simulations for a given scenario.
   func fetchByScenarioId(_ scenarioId: String) throws -> [SimulationRecord]
 
+  /// Fetches a page of past runs across **all** scenarios, newest-first, as
+  /// lightweight ``PastRunListItem`` projections — each run's full `stateJSON`
+  /// is decoded only to extract the top-3 scores and is then discarded, so it
+  /// never accumulates in app memory (the #586 memory fix).
+  ///
+  /// Keyset pagination: pass the previous page's last item as `before` (nil
+  /// for the first page); the next page returns rows strictly older than the
+  /// cursor on the composite `(createdAt DESC, id DESC)` order. This is stable
+  /// under concurrent inserts at the top of the stream, unlike `LIMIT/OFFSET`.
+  ///
+  /// When `nameQuery` is non-nil and non-blank the page is narrowed to runs
+  /// whose scenario name (live runs) or ``SimulationRecord/scenarioNameSnapshot``
+  /// (orphaned runs) contains the query as a case-insensitive substring.
+  ///
+  /// - Returns: up to `limit` items. A returned count equal to `limit`
+  ///   indicates more pages may exist.
+  func fetchRecentRunPage(
+    nameQuery: String?, before: SimulationPageCursor?, limit: Int
+  ) throws -> [PastRunListItem]
+
+  /// Fetches **all** runs for a single scenario, newest-first, as lightweight
+  /// ``PastRunListItem`` projections (the per-scenario Detail entry-point —
+  /// not paginated). Shares the `stateJSON`-projecting path with
+  /// ``fetchRecentRunPage(nameQuery:before:limit:)``.
+  func fetchRunList(scenarioId: String) throws -> [PastRunListItem]
+
   /// Fetches all "orphaned" simulations — runs whose source scenario was
   /// deleted, leaving `scenarioId` NULL (the FK is `ON DELETE SET NULL`
   /// since v7). Their display data lives in the `scenario*Snapshot` columns.
@@ -106,6 +132,125 @@ nonisolated public final class GRDBSimulationRepository: SimulationRepository, S
         .order(Column("createdAt").desc)
         .fetchAll(db)
     }
+  }
+
+  public func fetchRecentRunPage(
+    nameQuery: String?, before: SimulationPageCursor?, limit: Int
+  ) throws -> [PastRunListItem] {
+    try dbWriter.read { db in
+      var conditions: [String] = []
+      var arguments: [DatabaseValueConvertible] = []
+
+      // Name filter — push the substring match into SQL so it can surface
+      // runs that are not yet on a loaded page. Live runs match the joined
+      // scenario name; orphaned runs match their captured snapshot. Relies on
+      // SQLite's default ASCII-only case-folding for `LIKE` (adequate for the
+      // ja/en scope: ja has no case; en folds). `%`/`_` in the user query are
+      // escaped so they are matched literally, not as wildcards.
+      let trimmed = nameQuery?.trimmingCharacters(in: .whitespacesAndNewlines)
+      let hasFilter = !(trimmed ?? "").isEmpty
+      if hasFilter, let trimmed {
+        let pattern = "%" + Self.escapeLikePattern(trimmed) + "%"
+        conditions.append(
+          #"(sc.name LIKE ? ESCAPE '\' OR sim.scenarioNameSnapshot LIKE ? ESCAPE '\')"#)
+        arguments.append(pattern)
+        arguments.append(pattern)
+      }
+
+      // Keyset (seek) predicate — strictly older than the cursor on the
+      // composite `(createdAt DESC, id DESC)` order. `createdAt` is stored as
+      // a fixed-width millisecond TEXT (GRDB default), so the `id` tie-break
+      // is load-bearing whenever two runs collapse to the same millisecond.
+      if let cursor = before {
+        conditions.append(
+          "(sim.createdAt < ? OR (sim.createdAt = ? AND sim.id < ?))")
+        arguments.append(cursor.createdAt)
+        arguments.append(cursor.createdAt)
+        arguments.append(cursor.id)
+      }
+
+      let joinClause = hasFilter ? "LEFT JOIN scenarios sc ON sim.scenarioId = sc.id" : ""
+      let whereClause =
+        conditions.isEmpty ? "" : "WHERE " + conditions.joined(separator: " AND ")
+      arguments.append(limit)
+
+      let sql = """
+        SELECT sim.* FROM simulations sim
+        \(joinClause)
+        \(whereClause)
+        ORDER BY sim.createdAt DESC, sim.id DESC
+        LIMIT ?
+        """
+
+      let cursor = try SimulationRecord.fetchCursor(
+        db, sql: sql, arguments: StatementArguments(arguments))
+      var items: [PastRunListItem] = []
+      // Iterate one record at a time so the heavy `stateJSON` of the current
+      // row is the only one resident — it is projected to top-3 scores and the
+      // record is then released before the next is read.
+      while let record = try cursor.next() {
+        items.append(Self.projectListItem(from: record))
+      }
+      return items
+    }
+  }
+
+  public func fetchRunList(scenarioId: String) throws -> [PastRunListItem] {
+    try dbWriter.read { db in
+      let cursor = try SimulationRecord.fetchCursor(
+        db,
+        sql: """
+          SELECT * FROM simulations
+          WHERE scenarioId = ?
+          ORDER BY createdAt DESC, id DESC
+          """,
+        arguments: [scenarioId])
+      var items: [PastRunListItem] = []
+      while let record = try cursor.next() {
+        items.append(Self.projectListItem(from: record))
+      }
+      return items
+    }
+  }
+
+  /// Projects a full record to its lightweight list shape, decoding only the
+  /// `scores` map out of `stateJSON` (the heavy `conversationLog` etc. are
+  /// never materialized). Top scores are highest-first, capped at three, with
+  /// agent name as a deterministic tie-break so the chip order is stable.
+  private static func projectListItem(from record: SimulationRecord) -> PastRunListItem {
+    PastRunListItem(
+      id: record.id,
+      scenarioId: record.scenarioId,
+      createdAt: record.createdAt,
+      status: record.status,
+      scenarioNameSnapshot: record.scenarioNameSnapshot,
+      topScores: topScores(fromStateJSON: record.stateJSON))
+  }
+
+  /// A minimal decodable view over `stateJSON` — only `scores` is read, so
+  /// decoding stays cheap and never holds the full `SimulationState`.
+  private struct ScoresProjection: Decodable {
+    let scores: [String: Int]
+  }
+
+  private static func topScores(fromStateJSON json: String) -> [PastRunScore] {
+    guard let data = json.data(using: .utf8),
+      let parsed = try? JSONDecoder().decode(ScoresProjection.self, from: data)
+    else { return [] }
+    return
+      parsed.scores
+      .sorted { $0.value != $1.value ? $0.value > $1.value : $0.key < $1.key }
+      .prefix(3)
+      .map { PastRunScore(name: $0.key, value: $0.value) }
+  }
+
+  /// Escapes `LIKE` metacharacters so a user's filter text matches literally.
+  /// Backslash first (it is the `ESCAPE` char), then `%` and `_`.
+  private static func escapeLikePattern(_ raw: String) -> String {
+    raw
+      .replacingOccurrences(of: "\\", with: "\\\\")
+      .replacingOccurrences(of: "%", with: "\\%")
+      .replacingOccurrences(of: "_", with: "\\_")
   }
 
   public func fetchOrphaned() throws -> [SimulationRecord] {

--- a/Pastura/Pastura/Data/SimulationRepository.swift
+++ b/Pastura/Pastura/Data/SimulationRepository.swift
@@ -172,6 +172,9 @@ nonisolated public final class GRDBSimulationRepository: SimulationRepository, S
       let joinClause = hasFilter ? "LEFT JOIN scenarios sc ON sim.scenarioId = sc.id" : ""
       let whereClause =
         conditions.isEmpty ? "" : "WHERE " + conditions.joined(separator: " AND ")
+      // `arguments` is bound positionally, so its append order must mirror the
+      // `?` order in the SQL: filter pattern ×2 → cursor ×3 → LIMIT. Any new
+      // condition added above must keep `LIMIT` appended last.
       arguments.append(limit)
 
       let sql = """

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -2815,6 +2815,22 @@
         }
       }
     },
+    "Filter by scenario name" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filter by scenario name"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シナリオ名で絞り込む"
+          }
+        }
+      }
+    },
     "Finish the current simulation before clearing results." : {
       "localizations" : {
         "ja" : {

--- a/Pastura/Pastura/Views/Results/ResultsView.swift
+++ b/Pastura/Pastura/Views/Results/ResultsView.swift
@@ -104,12 +104,17 @@ struct ResultsView: View {
   /// into view. The `isLoadingMore` guard inside `loadMore()` makes a repeated
   /// `onAppear` (e.g. from a group reorder) a no-op.
   private func loadMoreSentinel(viewModel: ResultsViewModel) -> some View {
+    // Fixed height keeps the sentinel materializable (so `onAppear` fires) and
+    // gives a stable hit area; the spinner shows only while a fetch is actually
+    // in flight rather than spinning idly whenever more pages remain.
     HStack {
       Spacer()
-      ProgressView()
+      if viewModel.isLoadingMore {
+        ProgressView()
+      }
       Spacer()
     }
-    .padding(.vertical, 12)
+    .frame(height: 44)
     .accessibilityIdentifier("results.loadMore")
     .onAppear {
       Task { await viewModel.loadMore() }

--- a/Pastura/Pastura/Views/Results/ResultsView.swift
+++ b/Pastura/Pastura/Views/Results/ResultsView.swift
@@ -11,6 +11,10 @@ struct ResultsView: View {
   /// created the view model and finished the first load this stays
   /// `false` and `onAppear` is a no-op.
   @State private var didInitialLoad = false
+  /// Free-text scenario-name filter (aggregate root only — see
+  /// ``AggregateSearchable``). Pushed into SQL via `applyFilter` so it reaches
+  /// runs not yet on a loaded page.
+  @State private var searchText = ""
 
   var body: some View {
     Group {
@@ -39,6 +43,13 @@ struct ResultsView: View {
     // History tab root (`.aggregate`) there is no parent to pop to. See
     // ``PushBackChrome``.
     .modifier(PushBackChrome(isPushed: scope.isPushedDetail))
+    // Scenario-name filter — aggregate root only (a pushed per-scenario detail
+    // already shows a single scenario, so it has nothing to filter).
+    .modifier(AggregateSearchable(enabled: !scope.isPushedDetail, text: $searchText))
+    .onChange(of: searchText) { _, newValue in
+      guard let viewModel, !scope.isPushedDetail else { return }
+      Task { await viewModel.applyFilter(newValue) }
+    }
     .task {
       viewModel = ResultsViewModel(
         scenarioRepository: dependencies.scenarioRepository,
@@ -49,33 +60,36 @@ struct ResultsView: View {
       didInitialLoad = true
     }
     // Re-fetch when the list reappears (e.g. after a per-run delete in
-    // ResultDetailView pops back) so the deleted run drops out. Silent
-    // (`showLoading: false`) to avoid a spinner flash on every back-nav.
-    // NOTE: the aggregate path (`.aggregate`) re-runs the unpaginated
-    // N+1 aggregation each time — acceptable at current scale; pagination
-    // is deferred (#545 stretch item / ADR-015 §4).
+    // ResultDetailView pops back) so the deleted run drops out. Incremental:
+    // the aggregate path re-reads only the loaded depth from the top (keyset),
+    // preserving scroll position; detail does a silent full reload (#586).
     .onAppear {
       guard didInitialLoad, let viewModel else { return }
-      Task { await viewModel.load(scope: scope, showLoading: false) }
+      Task { await viewModel.refreshOnReappear(scope: scope) }
     }
   }
 
   private func resultsList(viewModel: ResultsViewModel) -> some View {
     ScrollView {
-      VStack(alignment: .leading, spacing: PasturaCardMetrics.interCardSpacing) {
+      // LazyVStack so off-screen rows don't decode/materialize eagerly and the
+      // bottom load-more sentinel only fires once scrolled into view (#586).
+      LazyVStack(alignment: .leading, spacing: PasturaCardMetrics.interCardSpacing) {
         ForEach(viewModel.groups) { group in
           PasturaSection(group.sectionName) {
             VStack(spacing: 0) {
               ForEach(Array(group.rows.enumerated()), id: \.element.id) { index, row in
                 if index > 0 { PasturaRowDivider() }
-                NavigationLink(value: Route.resultDetail(simulationId: row.record.id)) {
-                  resultRow(row, viewModel: viewModel)
+                NavigationLink(value: Route.resultDetail(simulationId: row.item.id)) {
+                  resultRow(row)
                 }
                 .buttonStyle(.plain)
-                .accessibilityIdentifier("results.row.\(row.record.id)")
+                .accessibilityIdentifier("results.row.\(row.item.id)")
               }
             }
           }
+        }
+        if viewModel.hasMore {
+          loadMoreSentinel(viewModel: viewModel)
         }
       }
       .padding(.vertical, PasturaCardMetrics.interCardSpacing)
@@ -86,15 +100,28 @@ struct ResultsView: View {
     .accessibilityIdentifier("results.list")
   }
 
+  /// Bottom-of-list affordance that pages in the next window when scrolled
+  /// into view. The `isLoadingMore` guard inside `loadMore()` makes a repeated
+  /// `onAppear` (e.g. from a group reorder) a no-op.
+  private func loadMoreSentinel(viewModel: ResultsViewModel) -> some View {
+    HStack {
+      Spacer()
+      ProgressView()
+      Spacer()
+    }
+    .padding(.vertical, 12)
+    .accessibilityIdentifier("results.loadMore")
+    .onAppear {
+      Task { await viewModel.loadMore() }
+    }
+  }
+
   /// Wraps ``simulationRow`` with a trailing chevron + full-row hit target,
   /// restoring the disclosure affordance the `List` `NavigationLink` row
   /// supplied before the ScrollView conversion.
-  private func resultRow(
-    _ row: ResultsViewModel.SimulationRow,
-    viewModel: ResultsViewModel
-  ) -> some View {
+  private func resultRow(_ row: ResultsViewModel.SimulationRow) -> some View {
     HStack(spacing: 10) {
-      simulationRow(row, viewModel: viewModel)
+      simulationRow(row)
       Image(systemName: "chevron.forward")
         .font(.footnote.weight(.semibold))
         .foregroundStyle(Color.muted)
@@ -110,28 +137,26 @@ struct ResultsView: View {
   // a sibling-language section header. Detail rows show the same name as
   // their section by design — keeping the row shape identical across
   // entry-points (#392).
-  private func simulationRow(
-    _ row: ResultsViewModel.SimulationRow,
-    viewModel: ResultsViewModel
-  ) -> some View {
+  private func simulationRow(_ row: ResultsViewModel.SimulationRow) -> some View {
     VStack(alignment: .leading, spacing: 4) {
       Text(row.variantName)
         .font(.headline)
         .foregroundStyle(Color.ink)
       HStack {
-        Text(row.record.createdAt, style: .date)
-        Text(row.record.createdAt, style: .time)
+        Text(row.item.createdAt, style: .date)
+        Text(row.item.createdAt, style: .time)
         Spacer()
-        statusBadge(row.record.simulationStatus)
+        statusBadge(row.item.simulationStatus)
       }
       .font(.subheadline)
       .foregroundStyle(Color.inkSecondary)
 
-      if let state = viewModel.decodeState(from: row.record) {
-        let top3 = state.scores.sorted(by: { $0.value > $1.value }).prefix(3)
+      // Top-3 score chips come pre-projected from the repository — the heavy
+      // `stateJSON` is never decoded in the list (#586).
+      if !row.item.topScores.isEmpty {
         HStack(spacing: 8) {
-          ForEach(Array(top3), id: \.key) { name, score in
-            Text(String(format: String(localized: "%@ (%lld)"), name, score))
+          ForEach(row.item.topScores, id: \.name) { score in
+            Text(String(format: String(localized: "%@ (%lld)"), score.name, score.value))
               .textStyle(Typography.metaValue)
               .foregroundStyle(Color.muted)
           }
@@ -173,6 +198,27 @@ struct ResultsView: View {
     case .none:
       Label(String(localized: "Unknown"), systemImage: "questionmark.circle")
         .textStyle(Typography.metaLabel).foregroundStyle(Color.muted)
+    }
+  }
+}
+
+/// Attaches the scenario-name `.searchable` field, but only for the aggregate
+/// History-tab root — a pushed per-scenario detail already scopes to a single
+/// scenario, so filtering there is meaningless. `enabled` is derived from a
+/// `let` scope, so the branch is constant per instance (no view-identity churn,
+/// same rationale as ``PushBackChrome``).
+private struct AggregateSearchable: ViewModifier {
+  let enabled: Bool
+  @Binding var text: String
+
+  func body(content: Content) -> some View {
+    if enabled {
+      content.searchable(
+        text: $text,
+        placement: .navigationBarDrawer(displayMode: .always),
+        prompt: Text(String(localized: "Filter by scenario name")))
+    } else {
+      content
     }
   }
 }

--- a/Pastura/PasturaTests/App/ResultsViewModelTests+CrossLanguageAggregation.swift
+++ b/Pastura/PasturaTests/App/ResultsViewModelTests+CrossLanguageAggregation.swift
@@ -75,7 +75,7 @@ extension ResultsViewModelTests {
     let group = try #require(env.sut.groups.first)
     #expect(group.canonicalKey == "word_wolf")
     #expect(group.rows.count == 3)
-    let simIds = Set(group.rows.map { $0.record.id })
+    let simIds = Set(group.rows.map { $0.item.id })
     #expect(simIds == ["sim_ja_1", "sim_ja_2", "sim_en_1"])
   }
 
@@ -172,7 +172,7 @@ extension ResultsViewModelTests {
     #expect(group.sectionName == "ワードウルフ")
     // Rows only include the EN sim.
     #expect(group.rows.count == 1)
-    #expect(group.rows.first?.record.id == "sim_en_1")
+    #expect(group.rows.first?.item.id == "sim_en_1")
     #expect(group.rows.first?.variantName == "Word Wolf")
   }
 
@@ -194,7 +194,7 @@ extension ResultsViewModelTests {
     await env.sut.load(scope: .aggregate, deviceLanguage: "ja")
 
     let rows = try #require(env.sut.groups.first?.rows)
-    let nameById = Dictionary(uniqueKeysWithValues: rows.map { ($0.record.id, $0.variantName) })
+    let nameById = Dictionary(uniqueKeysWithValues: rows.map { ($0.item.id, $0.variantName) })
     #expect(nameById["sim_ja"] == "ワードウルフ")
     #expect(nameById["sim_en"] == "Word Wolf")
   }
@@ -236,7 +236,7 @@ extension ResultsViewModelTests {
     await env.sut.load(scope: .aggregate, deviceLanguage: "ja")
 
     #expect(env.sut.groups.count == 1)
-    let allRowIds = env.sut.groups.flatMap { $0.rows.map(\.record.id) }
+    let allRowIds = env.sut.groups.flatMap { $0.rows.map(\.item.id) }
     #expect(allRowIds == ["sim_owned"])
     #expect(!allRowIds.contains("sim_orphan"))
   }

--- a/Pastura/PasturaTests/App/ResultsViewModelTests+Pagination.swift
+++ b/Pastura/PasturaTests/App/ResultsViewModelTests+Pagination.swift
@@ -1,0 +1,237 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Pastura
+
+/// Keyset-pagination, name-filter, auto-drain, re-entrancy, and incremental
+/// reappear-refresh tests for ``ResultsViewModel``'s aggregate path (#586).
+/// Sibling extension on the same suite — see `testing.md` § "Splitting a Suite
+/// Across Files". Helpers are file-scope (the suite's `makeResultsSUT` builds
+/// at the default page size; these tests need a small page size to drive
+/// multi-page behavior without seeding hundreds of runs).
+extension ResultsViewModelTests {
+
+  // MARK: - Keyset pagination + load-more
+
+  @Test func aggregatePaginatesAcrossPagesWithLoadMore() async throws {
+    let env = try makePagedSUT(pageSize: 2)
+    // 5 scenarios, one run each, distinct times → 5 single-row groups.
+    for index in 1...5 {
+      try seedPagedScenario(env.scenarioRepo, id: "s\(index)", name: "Scenario \(index)")
+      try seedPagedRun(env.simRepo, id: "r\(index)", scenarioId: "s\(index)", at: Double(index))
+    }
+
+    await env.sut.load(scope: .aggregate, deviceLanguage: "ja")
+    #expect(env.sut.groups.count == 2)
+    #expect(env.sut.hasMore)
+    #expect(env.sut.groups.map(\.canonicalKey) == ["s5", "s4"])
+
+    await env.sut.loadMore()
+    #expect(env.sut.groups.count == 4)
+    #expect(env.sut.hasMore)
+
+    await env.sut.loadMore()
+    #expect(env.sut.groups.map(\.canonicalKey) == ["s5", "s4", "s3", "s2", "s1"])
+    #expect(env.sut.hasMore == false)
+
+    // Exhausted — a further loadMore is a no-op.
+    await env.sut.loadMore()
+    #expect(env.sut.groups.count == 5)
+  }
+
+  /// A canonical group whose runs straddle a page boundary must reassemble
+  /// into a single group as the older page loads (critic Axis 1 — the
+  /// row-paginated / group-displayed seam).
+  @Test func aggregateGroupSplitAcrossPagesReassembles() async throws {
+    let env = try makePagedSUT(pageSize: 2)
+    try seedPagedScenario(env.scenarioRepo, id: "A", name: "Alpha")
+    try seedPagedScenario(env.scenarioRepo, id: "B", name: "Beta")
+    // Global recency: A@5, B@4, A@3 → A's runs straddle the 2-row boundary.
+    try seedPagedRun(env.simRepo, id: "a_new", scenarioId: "A", at: 5)
+    try seedPagedRun(env.simRepo, id: "b_mid", scenarioId: "B", at: 4)
+    try seedPagedRun(env.simRepo, id: "a_old", scenarioId: "A", at: 3)
+
+    await env.sut.load(scope: .aggregate, deviceLanguage: "ja")
+    // Page 1: A has only its newest run so far.
+    #expect(env.sut.groups.first { $0.canonicalKey == "A" }?.rows.count == 1)
+
+    await env.sut.loadMore()
+    // Page 2 brings A's older run — the group reassembles to two rows,
+    // newest-first, still a single group.
+    let groupA = try #require(env.sut.groups.first { $0.canonicalKey == "A" })
+    #expect(groupA.rows.map(\.id) == ["a_new", "a_old"])
+    #expect(env.sut.groups.first { $0.canonicalKey == "B" }?.rows.count == 1)
+    #expect(env.sut.groups.count == 2)
+  }
+
+  // MARK: - Auto-drain invisible (dangling) pages
+
+  /// A full page of dangling-scenarioId (invisible) runs must not stall the
+  /// window — `loadMore`/first-load drain past it to surface the visible runs
+  /// beneath (critic Axis 2).
+  @Test func aggregateDrainsAllDanglingPageToSurfaceVisibleRun() async throws {
+    let env = try makePagedSUT(pageSize: 2)
+    try seedPagedScenario(env.scenarioRepo, id: "owned", name: "Owned")
+    // Visible run is the OLDEST; two newer dangling runs fill the first page.
+    try seedPagedRun(env.simRepo, id: "visible", scenarioId: "owned", at: 1)
+    try plantDanglingRun(env.db, id: "ghost_a", at: 3)
+    try plantDanglingRun(env.db, id: "ghost_b", at: 2)
+
+    await env.sut.load(scope: .aggregate, deviceLanguage: "ja")
+
+    // The all-dangling first page was drained internally; the visible run
+    // surfaced rather than the list stalling empty.
+    #expect(env.sut.groups.count == 1)
+    let allRowIds = env.sut.groups.flatMap { $0.rows.map(\.id) }
+    #expect(allRowIds == ["visible"])
+  }
+
+  // MARK: - Name filter
+
+  @Test func aggregateFilterNarrowsThenClears() async throws {
+    let env = try makePagedSUT(pageSize: 50)
+    try seedPagedScenario(env.scenarioRepo, id: "a", name: "Alpha Game")
+    try seedPagedScenario(env.scenarioRepo, id: "b", name: "Beta Game")
+    try seedPagedRun(env.simRepo, id: "ra", scenarioId: "a", at: 2)
+    try seedPagedRun(env.simRepo, id: "rb", scenarioId: "b", at: 1)
+
+    await env.sut.load(scope: .aggregate, deviceLanguage: "ja")
+    #expect(env.sut.groups.count == 2)
+
+    await env.sut.applyFilter("alpha", deviceLanguage: "ja")
+    #expect(env.sut.groups.map(\.canonicalKey) == ["a"])
+
+    // Clearing the filter restores the full window.
+    await env.sut.applyFilter("", deviceLanguage: "ja")
+    #expect(env.sut.groups.count == 2)
+  }
+
+  // MARK: - Re-entrancy
+
+  /// Two concurrent `loadMore()` calls must load exactly one page — the
+  /// `isLoadingMore` guard prevents a double-append at the same cursor
+  /// (critic Axis 4).
+  @Test func aggregateConcurrentLoadMoreLoadsOnePageOnly() async throws {
+    let env = try makePagedSUT(pageSize: 2)
+    for index in 1...5 {
+      try seedPagedScenario(env.scenarioRepo, id: "s\(index)", name: "Scenario \(index)")
+      try seedPagedRun(env.simRepo, id: "r\(index)", scenarioId: "s\(index)", at: Double(index))
+    }
+
+    await env.sut.load(scope: .aggregate, deviceLanguage: "ja")
+    #expect(env.sut.groups.count == 2)
+
+    async let first: Void = env.sut.loadMore()
+    async let second: Void = env.sut.loadMore()
+    _ = await (first, second)
+
+    // Exactly one extra page (2 rows) — not two pages, no duplicate rows.
+    let ids = env.sut.groups.flatMap { $0.rows.map(\.id) }
+    #expect(ids.count == 4)
+    #expect(Set(ids).count == ids.count)
+  }
+
+  // MARK: - Incremental reappear refresh
+
+  /// After a per-run delete (the #545 reappear trigger), the incremental
+  /// refresh re-reads the loaded depth from the top — dropping the deleted run,
+  /// preserving depth, and recomputing the cursor so a later `loadMore` neither
+  /// duplicates nor skips (critic Axis 6).
+  @Test func aggregateRefreshAfterDeletePreservesDepthAndCursor() async throws {
+    let env = try makePagedSUT(pageSize: 2)
+    for index in 1...5 {
+      try seedPagedScenario(env.scenarioRepo, id: "s\(index)", name: "Scenario \(index)")
+      try seedPagedRun(env.simRepo, id: "r\(index)", scenarioId: "s\(index)", at: Double(index))
+    }
+
+    await env.sut.load(scope: .aggregate, deviceLanguage: "ja")  // r5, r4
+    await env.sut.loadMore()  // + r3, r2 → depth 4 loaded, a 5th remains
+
+    // Delete a loaded run, then reappear-refresh.
+    try env.simRepo.delete("r4")
+    await env.sut.refreshOnReappear(scope: .aggregate, deviceLanguage: "ja")
+
+    var ids = env.sut.groups.flatMap { $0.rows.map(\.id) }
+    #expect(!ids.contains("r4"))
+    #expect(Set(ids) == ["r5", "r3", "r2", "r1"])  // depth refilled to 4 from the top
+    #expect(Set(ids).count == ids.count)
+
+    // Cursor was recomputed from the refreshed window — a further loadMore
+    // finds nothing older and adds no duplicate.
+    await env.sut.loadMore()
+    ids = env.sut.groups.flatMap { $0.rows.map(\.id) }
+    #expect(Set(ids) == ["r5", "r3", "r2", "r1"])
+    #expect(Set(ids).count == ids.count)
+  }
+}
+
+// MARK: - File-scope helpers
+
+private struct PagedResultsSUT {
+  let db: DatabaseManager
+  let sut: ResultsViewModel
+  let scenarioRepo: GRDBScenarioRepository
+  let simRepo: GRDBSimulationRepository
+}
+
+@MainActor
+private func makePagedSUT(pageSize: Int) throws -> PagedResultsSUT {
+  let db = try DatabaseManager.inMemory()
+  let scenarioRepo = GRDBScenarioRepository(dbWriter: db.dbWriter)
+  let simRepo = GRDBSimulationRepository(dbWriter: db.dbWriter)
+  let turnRepo = GRDBTurnRepository(dbWriter: db.dbWriter)
+  let sut = ResultsViewModel(
+    scenarioRepository: scenarioRepo,
+    simulationRepository: simRepo,
+    turnRepository: turnRepo,
+    pageSize: pageSize)
+  return PagedResultsSUT(db: db, sut: sut, scenarioRepo: scenarioRepo, simRepo: simRepo)
+}
+
+private func seedPagedScenario(
+  _ repo: GRDBScenarioRepository, id: String, name: String, language: String = "ja"
+) throws {
+  try repo.save(
+    ScenarioRecord(
+      id: id, name: name,
+      yamlDefinition: "id: \(id)\nlanguage: \(language)\nname: \(name)\n",
+      isPreset: false, createdAt: Date(), updatedAt: Date()))
+}
+
+private func seedPagedRun(
+  _ repo: GRDBSimulationRepository, id: String, scenarioId: String, at offset: Double
+) throws {
+  let when = Date(timeIntervalSince1970: offset)
+  try repo.save(
+    SimulationRecord(
+      id: id, scenarioId: scenarioId,
+      status: SimulationStatus.completed.rawValue,
+      currentRound: 1, currentPhaseIndex: 0,
+      stateJSON: "{}", configJSON: nil,
+      createdAt: when, updatedAt: when))
+}
+
+/// Plants a run whose non-null `scenarioId` references no live scenario — a
+/// dangling row only reachable by bypassing FK enforcement (production schema
+/// makes it impossible). Used to exercise the invisible-dangling contract.
+private func plantDanglingRun(_ db: DatabaseManager, id: String, at offset: Double) throws {
+  let when = Date(timeIntervalSince1970: offset)
+  // SQLite ignores `PRAGMA foreign_keys` inside a transaction, so take the
+  // pragma in autocommit mode via `writeWithoutTransaction`.
+  try db.dbWriter.writeWithoutTransaction { db in
+    try db.execute(sql: "PRAGMA foreign_keys = OFF")
+    try db.execute(
+      sql: """
+        INSERT INTO simulations
+        (id, scenarioId, status, currentRound, currentPhaseIndex,
+         stateJSON, configJSON, createdAt, updatedAt)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+      arguments: [
+        id, "ghost_scenario", SimulationStatus.completed.rawValue,
+        1, 0, "{}", nil, when, when
+      ])
+    try db.execute(sql: "PRAGMA foreign_keys = ON")
+  }
+}

--- a/Pastura/PasturaTests/App/ResultsViewModelTests+Pagination.swift
+++ b/Pastura/PasturaTests/App/ResultsViewModelTests+Pagination.swift
@@ -132,6 +132,34 @@ extension ResultsViewModelTests {
     #expect(Set(ids).count == ids.count)
   }
 
+  /// A filter change that lands while an auto-fired `loadMore` is in flight
+  /// must win — the stale (unfiltered) page is discarded by the generation
+  /// guard rather than folded into the freshly-filtered window (review Warning).
+  @Test func aggregateFilterSupersedesInFlightLoadMore() async throws {
+    let env = try makePagedSUT(pageSize: 2)
+    try seedPagedScenario(env.scenarioRepo, id: "alpha", name: "Alpha")
+    try seedPagedScenario(env.scenarioRepo, id: "beta", name: "Beta")
+    try seedPagedRun(env.simRepo, id: "alpha1", scenarioId: "alpha", at: 4)
+    try seedPagedRun(env.simRepo, id: "beta1", scenarioId: "beta", at: 3)
+    try seedPagedRun(env.simRepo, id: "alpha2", scenarioId: "alpha", at: 2)
+    try seedPagedRun(env.simRepo, id: "beta2", scenarioId: "beta", at: 1)
+
+    await env.sut.load(scope: .aggregate, deviceLanguage: "ja")
+    #expect(env.sut.hasMore)
+
+    // Interleave a load-more with a filter change.
+    async let more: Void = env.sut.loadMore()
+    async let filter: Void = env.sut.applyFilter("alpha", deviceLanguage: "ja")
+    _ = await (more, filter)
+
+    // Whatever the interleaving, the final window reflects the "alpha" filter —
+    // no stale Beta rows leaked in from the discarded loadMore page.
+    let canonicalKeys = Set(env.sut.groups.map(\.canonicalKey))
+    #expect(canonicalKeys == ["alpha"])
+    let ids = env.sut.groups.flatMap { $0.rows.map(\.id) }
+    #expect(Set(ids) == ["alpha1", "alpha2"])
+  }
+
   // MARK: - Incremental reappear refresh
 
   /// After a per-run delete (the #545 reappear trigger), the incremental

--- a/Pastura/PasturaTests/App/ResultsViewModelTests.swift
+++ b/Pastura/PasturaTests/App/ResultsViewModelTests.swift
@@ -213,51 +213,6 @@ struct ResultsViewModelTests {
     #expect(env.sut.errorMessage == nil)
   }
 
-  // MARK: - Decode State
-
-  @Test func decodeStateFromValidJSON() throws {
-    let state = SimulationState(
-      scores: ["Alice": 10, "Bob": 5],
-      eliminated: ["Alice": false, "Bob": false],
-      conversationLog: [],
-      lastOutputs: [:],
-      voteResults: [:],
-      pairings: [],
-      variables: [:],
-      currentRound: 2
-    )
-    let stateJSON = String(data: try JSONEncoder().encode(state), encoding: .utf8)!
-
-    let record = SimulationRecord(
-      id: "sim1", scenarioId: "s1",
-      status: "completed", currentRound: 2, currentPhaseIndex: 0,
-      stateJSON: stateJSON, configJSON: nil,
-      createdAt: Date(), updatedAt: Date()
-    )
-
-    let env = try makeResultsSUT()
-    let decoded = env.sut.decodeState(from: record)
-
-    #expect(decoded != nil)
-    #expect(decoded?.scores["Alice"] == 10)
-    #expect(decoded?.scores["Bob"] == 5)
-    #expect(decoded?.currentRound == 2)
-  }
-
-  @Test func decodeStateReturnsNilForInvalidJSON() throws {
-    let record = SimulationRecord(
-      id: "sim1", scenarioId: "s1",
-      status: "completed", currentRound: 1, currentPhaseIndex: 0,
-      stateJSON: "not valid json", configJSON: nil,
-      createdAt: Date(), updatedAt: Date()
-    )
-
-    let env = try makeResultsSUT()
-    let decoded = env.sut.decodeState(from: record)
-
-    #expect(decoded == nil)
-  }
-
   // MARK: - Orphaned runs (deleted scenario) — v7 history preservation
 
   @Test func homeAggregationSurfacesOrphanedRunWithoutMergingLiveGroups() async throws {
@@ -296,11 +251,16 @@ struct ResultsViewModelTests {
     #expect(names.contains("Prisoner's Dilemma"))
 
     // The orphaned group did not merge into a live group: its canonical key
-    // is reserved (≠ the former scenario id), and it sorts last.
+    // is reserved (≠ the former scenario id) and distinct from the live group's.
+    // Under the recency window orphans interleave by time rather than always
+    // sorting last (#586), so the anti-merge contract is asserted on key
+    // identity, not list position.
     let orphanGroup = try #require(
       env.sut.groups.first { $0.sectionName == "Prisoner's Dilemma" })
     #expect(orphanGroup.rows.map(\.id) == ["sim1"])
     #expect(orphanGroup.canonicalKey != "s1")
-    #expect(env.sut.groups.last?.canonicalKey == orphanGroup.canonicalKey)
+    #expect(orphanGroup.canonicalKey.hasPrefix("\u{0}orphan:"))
+    let liveGroup = try #require(env.sut.groups.first { $0.sectionName == "Word Wolf" })
+    #expect(liveGroup.canonicalKey != orphanGroup.canonicalKey)
   }
 }

--- a/Pastura/PasturaTests/App/StubResultSeederTests.swift
+++ b/Pastura/PasturaTests/App/StubResultSeederTests.swift
@@ -38,8 +38,8 @@
       #expect(viewModel.errorMessage == nil)
       #expect(viewModel.groups.count == 1, "seeded run should form one group")
       let row = try #require(viewModel.groups.first?.rows.first)
-      #expect(row.record.id == StubResultSeeder.simulationId)
-      #expect(row.record.simulationStatus == .completed)
+      #expect(row.item.id == StubResultSeeder.simulationId)
+      #expect(row.item.simulationStatus == .completed)
 
       let turns = await viewModel.loadTurns(
         simulationId: StubResultSeeder.simulationId)

--- a/Pastura/PasturaTests/Data/SimulationRepositoryTests+RunListPaging.swift
+++ b/Pastura/PasturaTests/Data/SimulationRepositoryTests+RunListPaging.swift
@@ -1,0 +1,251 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+/// Keyset-pagination + name-filter + lightweight-projection tests for
+/// ``SimulationRepository/fetchRecentRunPage(nameQuery:before:limit:)`` and
+/// ``SimulationRepository/fetchRunList(scenarioId:)`` (issue #586). Sibling
+/// extension on the same suite — see `testing.md` § "Splitting a Suite Across
+/// Files". Helpers live at file scope (the original suite's `makeRepos` /
+/// `makeSimRecord` are `private`, so a sibling can't reach them).
+extension SimulationRepositoryTests {
+
+  // MARK: - Recency window + ordering
+
+  @Test func fetchRecentRunPageReturnsNewestFirstAcrossScenarios() throws {
+    let env = try makePagingRepos()
+    try env.scenarios.save(scenario(id: "s1", name: "One"))
+    try env.scenarios.save(scenario(id: "s2", name: "Two"))
+    try env.sims.save(run(id: "old", scenarioId: "s1", at: 0))
+    try env.sims.save(run(id: "mid", scenarioId: "s2", at: 100))
+    try env.sims.save(run(id: "new", scenarioId: "s1", at: 200))
+
+    let page = try env.sims.fetchRecentRunPage(nameQuery: nil, before: nil, limit: 10)
+
+    #expect(page.map(\.id) == ["new", "mid", "old"])
+  }
+
+  // MARK: - Keyset pagination
+
+  @Test func fetchRecentRunPagePaginatesWithoutOverlapOrGap() throws {
+    let env = try makePagingRepos()
+    try env.scenarios.save(scenario(id: "s1", name: "One"))
+    for index in 0..<5 {
+      try env.sims.save(run(id: "run\(index)", scenarioId: "s1", at: Double(index)))
+    }
+
+    var collected: [String] = []
+    var cursor: SimulationPageCursor?
+    while true {
+      let page = try env.sims.fetchRecentRunPage(nameQuery: nil, before: cursor, limit: 2)
+      collected += page.map(\.id)
+      guard page.count == 2, let last = page.last else { break }
+      cursor = SimulationPageCursor(createdAt: last.createdAt, id: last.id)
+    }
+
+    // Full coverage, newest-first, no duplicates.
+    #expect(collected == ["run4", "run3", "run2", "run1", "run0"])
+    #expect(Set(collected).count == collected.count)
+  }
+
+  /// The keyset tie-break (`createdAt = ? AND id < ?`) is the only non-trivial
+  /// boundary: `createdAt` is stored at millisecond precision, so two runs can
+  /// collapse to the same stored value. Here `run_m` and `run_n` share an
+  /// instant straddling the page boundary; each must appear exactly once.
+  @Test func fetchRecentRunPageSameMillisecondTieStraddlesPageBoundary() throws {
+    let env = try makePagingRepos()
+    try env.scenarios.save(scenario(id: "s1", name: "One"))
+    let shared = Date(timeIntervalSince1970: 50)
+    try env.sims.save(run(id: "run_old", scenarioId: "s1", at: 0))
+    try env.sims.save(run(id: "run_m", scenarioId: "s1", at: shared))
+    try env.sims.save(run(id: "run_n", scenarioId: "s1", at: shared))
+
+    // Order: same-instant rows by id DESC → run_n, run_m, then run_old.
+    let page1 = try env.sims.fetchRecentRunPage(nameQuery: nil, before: nil, limit: 2)
+    #expect(page1.map(\.id) == ["run_n", "run_m"])
+
+    let last = try #require(page1.last)
+    let page2 = try env.sims.fetchRecentRunPage(
+      nameQuery: nil,
+      before: SimulationPageCursor(createdAt: last.createdAt, id: last.id),
+      limit: 2)
+    // run_m (same instant, id not < "run_m") must NOT reappear; run_old follows.
+    #expect(page2.map(\.id) == ["run_old"])
+  }
+
+  /// A run inserted at the top of the stream between page fetches (e.g. a
+  /// background sim completing, ADR-003) must not shift an in-progress keyset
+  /// walk — the cursor is an absolute boundary, so the second page is
+  /// unaffected and yields no duplicate.
+  @Test func fetchRecentRunPageStableUnderConcurrentInsert() throws {
+    let env = try makePagingRepos()
+    try env.scenarios.save(scenario(id: "s1", name: "One"))
+    try env.sims.save(run(id: "r1", scenarioId: "s1", at: 10))
+    try env.sims.save(run(id: "r2", scenarioId: "s1", at: 20))
+    try env.sims.save(run(id: "r3", scenarioId: "s1", at: 30))
+
+    let page1 = try env.sims.fetchRecentRunPage(nameQuery: nil, before: nil, limit: 2)
+    #expect(page1.map(\.id) == ["r3", "r2"])
+    let last = try #require(page1.last)
+
+    // Concurrent insert at the very top of the recency stream.
+    try env.sims.save(run(id: "r4", scenarioId: "s1", at: 40))
+
+    let page2 = try env.sims.fetchRecentRunPage(
+      nameQuery: nil,
+      before: SimulationPageCursor(createdAt: last.createdAt, id: last.id),
+      limit: 2)
+    // Only the older r1 — r4 belongs to a fresh-from-top fetch, not this walk.
+    #expect(page2.map(\.id) == ["r1"])
+  }
+
+  // MARK: - Name filter
+
+  @Test func fetchRecentRunPageFiltersByLiveScenarioName() throws {
+    let env = try makePagingRepos()
+    try env.scenarios.save(scenario(id: "ja", name: "ワードウルフ"))
+    try env.scenarios.save(scenario(id: "en", name: "Word Wolf"))
+    try env.sims.save(run(id: "sim_ja", scenarioId: "ja", at: 10))
+    try env.sims.save(run(id: "sim_en", scenarioId: "en", at: 20))
+
+    // ASCII case-folding: lowercase "word" matches "Word Wolf".
+    let en = try env.sims.fetchRecentRunPage(nameQuery: "word", before: nil, limit: 10)
+    #expect(en.map(\.id) == ["sim_en"])
+
+    let ja = try env.sims.fetchRecentRunPage(nameQuery: "ウルフ", before: nil, limit: 10)
+    #expect(ja.map(\.id) == ["sim_ja"])
+  }
+
+  @Test func fetchRecentRunPageFiltersOrphanByNameSnapshot() throws {
+    let env = try makePagingRepos()
+    try env.scenarios.save(scenario(id: "live", name: "Live Scenario"))
+    try env.sims.save(run(id: "sim_live", scenarioId: "live", at: 10))
+    // Orphaned run (scenarioId nil) carrying a name snapshot.
+    try env.sims.save(
+      run(id: "sim_orphan", scenarioId: nil, at: 20, nameSnapshot: "Deleted Wolf"))
+
+    let page = try env.sims.fetchRecentRunPage(nameQuery: "wolf", before: nil, limit: 10)
+    #expect(page.map(\.id) == ["sim_orphan"])
+  }
+
+  @Test func fetchRecentRunPageExcludesNullSnapshotOrphanUnderFilter() throws {
+    let env = try makePagingRepos()
+    try env.scenarios.save(scenario(id: "live", name: "Match Me"))
+    try env.sims.save(run(id: "sim_live", scenarioId: "live", at: 10))
+    // Nameless orphan — unreachable by any non-empty name query.
+    try env.sims.save(run(id: "sim_nameless", scenarioId: nil, at: 20, nameSnapshot: nil))
+
+    let page = try env.sims.fetchRecentRunPage(nameQuery: "match", before: nil, limit: 10)
+    #expect(page.map(\.id) == ["sim_live"])
+  }
+
+  @Test func fetchRecentRunPageEscapesLikeWildcards() throws {
+    let env = try makePagingRepos()
+    try env.scenarios.save(scenario(id: "pct", name: "100% Effort"))
+    try env.scenarios.save(scenario(id: "other", name: "Plain"))
+    try env.sims.save(run(id: "sim_pct", scenarioId: "pct", at: 10))
+    try env.sims.save(run(id: "sim_other", scenarioId: "other", at: 20))
+
+    // "%" must match literally — not as a wildcard that would match both.
+    let page = try env.sims.fetchRecentRunPage(nameQuery: "100%", before: nil, limit: 10)
+    #expect(page.map(\.id) == ["sim_pct"])
+  }
+
+  @Test func fetchRecentRunPageBlankQueryReturnsAll() throws {
+    let env = try makePagingRepos()
+    try env.scenarios.save(scenario(id: "s1", name: "One"))
+    try env.sims.save(run(id: "a", scenarioId: "s1", at: 10))
+    try env.sims.save(run(id: "b", scenarioId: "s1", at: 20))
+
+    // Whitespace-only is treated as no filter.
+    let page = try env.sims.fetchRecentRunPage(nameQuery: "   ", before: nil, limit: 10)
+    #expect(Set(page.map(\.id)) == ["a", "b"])
+  }
+
+  // MARK: - Top-3 score projection
+
+  @Test func fetchRecentRunPageProjectsTopThreeScoresHighestFirst() throws {
+    let env = try makePagingRepos()
+    try env.scenarios.save(scenario(id: "s1", name: "One"))
+    let stateJSON = #"{"scores":{"Alice":10,"Bob":8,"Carol":12,"Dave":3}}"#
+    try env.sims.save(run(id: "sim", scenarioId: "s1", at: 10, stateJSON: stateJSON))
+
+    let page = try env.sims.fetchRecentRunPage(nameQuery: nil, before: nil, limit: 10)
+    let scores = try #require(page.first).topScores
+    #expect(scores.map(\.name) == ["Carol", "Alice", "Bob"])
+    #expect(scores.map(\.value) == [12, 10, 8])
+  }
+
+  @Test func fetchRecentRunPageEmptyScoresProjectToNoChips() throws {
+    let env = try makePagingRepos()
+    try env.scenarios.save(scenario(id: "s1", name: "One"))
+    try env.sims.save(run(id: "sim", scenarioId: "s1", at: 10, stateJSON: "{}"))
+
+    let page = try env.sims.fetchRecentRunPage(nameQuery: nil, before: nil, limit: 10)
+    #expect(try #require(page.first).topScores.isEmpty)
+  }
+
+  // MARK: - Detail light fetch
+
+  @Test func fetchRunListReturnsScenarioRunsNewestFirst() throws {
+    let env = try makePagingRepos()
+    try env.scenarios.save(scenario(id: "s1", name: "One"))
+    try env.scenarios.save(scenario(id: "s2", name: "Two"))
+    try env.sims.save(run(id: "a", scenarioId: "s1", at: 10))
+    try env.sims.save(run(id: "b", scenarioId: "s1", at: 30))
+    try env.sims.save(run(id: "other", scenarioId: "s2", at: 20))
+
+    let list = try env.sims.fetchRunList(scenarioId: "s1")
+    #expect(list.map(\.id) == ["b", "a"])
+  }
+}
+
+// MARK: - File-scope helpers
+
+private struct PagingRepos {
+  let scenarios: GRDBScenarioRepository
+  let sims: GRDBSimulationRepository
+}
+
+private func makePagingRepos() throws -> PagingRepos {
+  let manager = try DatabaseManager.inMemory()
+  return PagingRepos(
+    scenarios: GRDBScenarioRepository(dbWriter: manager.dbWriter),
+    sims: GRDBSimulationRepository(dbWriter: manager.dbWriter))
+}
+
+private func scenario(id: String, name: String) -> ScenarioRecord {
+  ScenarioRecord(
+    id: id, name: name,
+    yamlDefinition: "id: \(id)\nname: \(name)\n",
+    isPreset: false, createdAt: Date(), updatedAt: Date())
+}
+
+private func run(
+  id: String,
+  scenarioId: String?,
+  at offset: Double,
+  stateJSON: String = "{}",
+  nameSnapshot: String? = nil
+) -> SimulationRecord {
+  run(
+    id: id, scenarioId: scenarioId, at: Date(timeIntervalSince1970: offset),
+    stateJSON: stateJSON, nameSnapshot: nameSnapshot)
+}
+
+private func run(
+  id: String,
+  scenarioId: String?,
+  at createdAt: Date,
+  stateJSON: String = "{}",
+  nameSnapshot: String? = nil
+) -> SimulationRecord {
+  SimulationRecord(
+    id: id, scenarioId: scenarioId,
+    status: SimulationStatus.completed.rawValue,
+    currentRound: 1, currentPhaseIndex: 0,
+    stateJSON: stateJSON, configJSON: nil,
+    createdAt: createdAt, updatedAt: createdAt,
+    scenarioNameSnapshot: nameSnapshot)
+}

--- a/Pastura/PasturaTests/Data/SimulationRepositoryTests+RunListPaging.swift
+++ b/Pastura/PasturaTests/Data/SimulationRepositoryTests+RunListPaging.swift
@@ -152,6 +152,26 @@ extension SimulationRepositoryTests {
     #expect(page.map(\.id) == ["sim_pct"])
   }
 
+  @Test func fetchRecentRunPageEscapesUnderscoreAndBackslashWildcards() throws {
+    let env = try makePagingRepos()
+    // `_` is a single-char LIKE wildcard; a literal `_` must not match a
+    // different character. `\` exercises the escape-char doubling path.
+    try env.scenarios.save(scenario(id: "u", name: "a_b"))
+    try env.scenarios.save(scenario(id: "x", name: "axb"))
+    try env.scenarios.save(scenario(id: "bs", name: #"path\to"#))
+    try env.sims.save(run(id: "sim_u", scenarioId: "u", at: 30))
+    try env.sims.save(run(id: "sim_x", scenarioId: "x", at: 20))
+    try env.sims.save(run(id: "sim_bs", scenarioId: "bs", at: 10))
+
+    // Literal "a_b" matches only "a_b", not "axb".
+    let underscore = try env.sims.fetchRecentRunPage(nameQuery: "a_b", before: nil, limit: 10)
+    #expect(underscore.map(\.id) == ["sim_u"])
+
+    // Literal backslash survives the ESCAPE doubling and matches.
+    let backslash = try env.sims.fetchRecentRunPage(nameQuery: #"path\to"#, before: nil, limit: 10)
+    #expect(backslash.map(\.id) == ["sim_bs"])
+  }
+
   @Test func fetchRecentRunPageBlankQueryReturnsAll() throws {
     let env = try makePagingRepos()
     try env.scenarios.save(scenario(id: "s1", name: "One"))


### PR DESCRIPTION
## Summary
Replaces the unpaginated N+1 aggregate load of `ResultsViewModel.loadHomeAggregated`
with a **keyset (seek) recency window** plus a free-text scenario-name filter, and
projects the heavy `stateJSON` out of the list path entirely — the root of the
#586 memory concern.

- **Data**: new `fetchRecentRunPage(nameQuery:before:limit:)` (keyset on
  `(createdAt DESC, id DESC)`, stable under concurrent inserts; optional
  scenario-name `LIKE` filter pushed into SQL — live runs by joined name,
  orphans by snapshot) and `fetchRunList(scenarioId:)`. Both return a
  lightweight `PastRunListItem` (top-3 scores only), decoding `stateJSON`
  row-by-row via a cursor and discarding it — the full conversation-log JSON
  never accumulates in app memory.
- **App**: `loadHomeAggregated` pages over the new primitive, full-re-bucketing
  accumulated light items into canonical groups ordered by most-recent run
  (NULL-scenarioId orphans now interleave by recency; dangling-scenarioId runs
  stay invisible). `loadMore()` auto-drains all-invisible pages; `applyFilter`
  and an incremental reappear-refresh preserve scroll depth; a `loadGeneration`
  stamp guards against a filter/loadMore interleaving race.
- **Views**: `.searchable` filter (aggregate root only), `LazyVStack` + guarded
  bottom load-more sentinel, rows render pre-projected `topScores`.

### Memory note
The acute issue — every Home->Results visit loading **all** runs upfront — is
gone (50-row keyset pages, projected). `ScenarioRepository.fetchAll()` still
loads the (small) scenario rows for the cross-language header dict; the heavy
`simulations.stateJSON` is the column that no longer crosses into app memory.

## Test plan
- `SimulationRepositoryTests` (+RunListPaging): keyset across-page continuity,
  **same-millisecond tie** straddling a page boundary, concurrent-insert
  stability, `LIKE` escaping (`%`/`_`/backslash), ja+EN filter, NULL-snapshot
  orphan exclusion, top-3 projection.
- `ResultsViewModelTests` (+Pagination): across-page group reassembly, auto-drain
  of an all-dangling page, filter narrow/clear, concurrent-loadMore re-entrancy,
  **filter-supersedes-in-flight-loadMore** race, refresh-after-delete depth/cursor.
- Updated cross-language aggregation + orphan tests for recency ordering
  (anti-merge asserted on key identity, not list position).
- Full unit suite green; two `code-reviewer` (Opus) passes — Data PASS, App+View
  PASS after a race-guard fix.

Closes #586.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
