### PR TITLE
✨ feat: Home P3 PR2 — confirm-on-leave pause for in-flight runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Phase 2 progress:
 - **Past results — code-phase events** — score_calc / scenario gen events in past-results viewer (#102/#113)
 - **Localization (i18n: ja/en)** — *in progress* — see ROADMAP § "Localization Plan" (#276/#277, ADR-010 stub #279, body #367, B-1a public pages #369, responsive-design migration #373, Engine dynamic localization #383, drift script + Past Results compat #386, bundled English presets + EN DL demo replays + locale-driven runtime selection #388, Step E PR1 simulation_language Engine wiring #398, Step E PR2 LLM output-language adherence enforcement #405, Step E follow-up `.languageMismatch` UI toast + completion summary #422, Past Results cross-language aggregation (ADR-010 D4 consumer) #392)
 - **Launch animation** — cold "Pastoral Drift" + warm "Breath" hybrid; per-scene `LaunchPhaseCoordinator` + Reduce Motion fallback (#412/#415)
-- **Home redesign** — bottom-tab IA (ADR-016, #602) + pause/resume of an interrupted run from the Home card (P3: round-boundary checkpoint producer #662, resume consumer + historical-log replay #667)
+- **Home redesign** — bottom-tab IA (ADR-016, #602) + pause/resume of an interrupted run from the Home card (P3: round-boundary checkpoint producer #662, resume consumer + historical-log replay #667, confirm-on-leave pause for in-flight runs #673)
 
 ## Language Rules
 

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -762,13 +762,16 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   /// For non-paused exits a real error beats a normal end, and explicit
   /// user-cancel beats a normal end.
   ///
-  /// The `isResumedRun && !isCompleted` branch keeps a **resumed** run that was
-  /// torn down mid-flight (tab-switch / back, with no explicit pause or cancel)
-  /// at `.paused` so it stays resumable from its latest checkpoint. A **fresh**
-  /// run reaching here (`isResumedRun == false`) genuinely exhausted its event
-  /// stream and writes `.completed`. This fresh-vs-resumed asymmetry is
-  /// intentional: making a fresh run survive mid-flight teardown is #646 / PR2
-  /// scope (the tab-move dialog), deliberately not lifted here.
+  /// The `!isCompleted` branch keeps **any** run torn down mid-flight (tab-switch
+  /// / back / swipe-back, with no explicit pause, cancel, or error) at `.paused`
+  /// so it stays resumable from its latest round-boundary checkpoint — fresh and
+  /// resumed runs alike. `isCompleted` is set only by the `.simulationCompleted`
+  /// event, so a run that genuinely exhausted its stream still falls through to
+  /// `.completed`; only a teardown that ends the event loop early lands here with
+  /// `isCompleted == false`. Home P3 PR2 (#673) lifted the prior fresh-vs-resumed
+  /// asymmetry that silently mislabelled a torn-down fresh run as `.completed`
+  /// (data loss) — the in-app confirm-on-leave dialog pauses explicitly, but this
+  /// branch is the lossless safety net for the un-prompted swipe-back path.
   private func finalizeRun(llm: any LLMService) async {
     // finish() is idempotent; defer also calls it for early-return paths.
     persistenceContinuation?.finish()
@@ -782,7 +785,7 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
 
     if let status = Self.terminalStatus(
       didPersistPaused: didPersistPaused, errorMessage: errorMessage,
-      isCancelled: isCancelled, isResumedRun: isResumedRun, isCompleted: isCompleted) {
+      isCancelled: isCancelled, isCompleted: isCompleted) {
       await persistStatus(status)
     } else {
       lifecycleLogger.info("run exited while paused; leaving .paused for resume")
@@ -792,20 +795,22 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   /// Pure terminal-status decision for ``finalizeRun(llm:)``. Returns the status
   /// to persist, or `nil` to leave the existing row untouched (the explicit
   /// `.paused` resume point). Lifted to a `static` so the precedence — including
-  /// the resume-specific branch — is unit-testable without driving a full run
+  /// the mid-flight-teardown branch — is unit-testable without driving a full run
   /// (mirrors ``deriveStatus(isCancelled:errorMessage:isCompleted:isPaused:)``).
   ///
   /// Precedence (load-bearing): see ``finalizeRun(llm:)``'s doc-comment for the
-  /// `didPersistPaused`-first rationale and the fresh-vs-resumed asymmetry of
-  /// the `isResumedRun && !isCompleted` branch.
+  /// `didPersistPaused`-first rationale and the `!isCompleted` mid-flight-teardown
+  /// branch. `isResumedRun` is deliberately NOT a parameter — the teardown branch
+  /// is symmetric across fresh and resumed runs (#673); the field still gates the
+  /// `.error(.cancelled)` suppression in `handleEvent`, which is a separate concern.
   static func terminalStatus(
     didPersistPaused: Bool, errorMessage: String?,
-    isCancelled: Bool, isResumedRun: Bool, isCompleted: Bool
+    isCancelled: Bool, isCompleted: Bool
   ) -> SimulationStatus? {
     if didPersistPaused { return nil }
     if errorMessage != nil { return .failed }
     if isCancelled { return .cancelled }
-    if isResumedRun && !isCompleted { return .paused }
+    if !isCompleted { return .paused }
     return .completed
   }
 

--- a/Pastura/Pastura/App/TabCoordinator.swift
+++ b/Pastura/Pastura/App/TabCoordinator.swift
@@ -47,6 +47,23 @@ final class TabCoordinator {
   /// The currently-selected tab. Drives the `TabView` selection binding.
   var selectedTab: AppTab = .home
 
+  /// `true` while an in-flight, not-yet-paused simulation run is on screen —
+  /// published by the active ``SimulationView`` (#673). Gates the cross-tab
+  /// switch in ``handleSelection(_:)`` so a tab tap defers to a confirm-on-leave
+  /// dialog instead of silently tearing the run down.
+  ///
+  /// Lives here (not on `AppRouter`, per `navigation.md` § "AppRouter scope")
+  /// because it gates **tab selection**, which this coordinator already owns.
+  /// The publishing View clears it unconditionally on disappear, so a torn-down
+  /// run can never leave a stale `true` that would freeze all future switches.
+  var hasUnsavedInFlightRun = false
+
+  /// A cross-tab switch deferred by the leave guard, awaiting the user's
+  /// confirm-on-leave decision (#673). The active ``SimulationView`` observes
+  /// this to present its alert; ``commitPendingTabSwitch()`` /
+  /// ``cancelPendingTabSwitch()`` resolve it. `nil` when no switch is pending.
+  var pendingTabSwitch: AppTab?
+
   /// All four routers, for cross-tab folds (e.g. ``isSimulationOnTop``).
   /// Order matches ``AppTab/allCases``.
   var allRouters: [AppRouter] {
@@ -102,12 +119,37 @@ final class TabCoordinator {
   /// Applies a tab-bar selection event: pop the tab to root on
   /// re-selection, switch to it otherwise. Wire this from the `TabView`
   /// selection `Binding`'s setter.
+  ///
+  /// When ``hasUnsavedInFlightRun`` is set, a genuine cross-tab switch is
+  /// **deferred** — `selectedTab` stays put and the target is parked in
+  /// ``pendingTabSwitch`` for the confirm-on-leave dialog (#673). Re-selection
+  /// short-circuits above the guard, so re-tapping the current tab still
+  /// pops-to-root even mid-run (it does not leave the screen).
   func handleSelection(_ tab: AppTab) {
     if isReselection(of: tab) {
       router(for: tab).popToRoot()
+    } else if hasUnsavedInFlightRun {
+      pendingTabSwitch = tab
     } else {
       selectedTab = tab
     }
+  }
+
+  /// Commits a switch deferred by ``handleSelection(_:)`` once the user chose
+  /// "pause and leave" in the confirm-on-leave dialog (#673). No-op when nothing
+  /// is pending. The target is read from coordinator state — never re-read from
+  /// the SimulationView, which may already be tearing down — so the commit is
+  /// race-free.
+  func commitPendingTabSwitch() {
+    guard let tab = pendingTabSwitch else { return }
+    selectedTab = tab
+    pendingTabSwitch = nil
+  }
+
+  /// Discards a deferred switch — the user chose "stay" (#673). The run keeps
+  /// running on the current tab.
+  func cancelPendingTabSwitch() {
+    pendingTabSwitch = nil
   }
 
   /// Presents a resolved deep-linked gallery scenario on the さがす

--- a/Pastura/Pastura/PasturaApp.swift
+++ b/Pastura/Pastura/PasturaApp.swift
@@ -248,6 +248,12 @@ private struct RootView: View {
           // state and drive switch / download / delete without threading
           // it through every intermediate view.
           .environment(modelManager)
+          // The coordinator is exposed app-wide (in addition to driving
+          // RootTabView) so a pushed `SimulationView` can publish its
+          // leave-guard flag and resolve a deferred tab-switch for the
+          // confirm-on-leave dialog (#673). Injected ABOVE the TabView is
+          // safe — unlike the per-tab `AppRouter`, the coordinator is shared.
+          .environment(tabCoordinator)
           .environment(\.lastDeepLinkedScenarioId, lastDeepLinkedScenarioId)
 
       case .databaseRecovery(let message):

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -1108,6 +1108,16 @@
         }
       }
     },
+    "A simulation is in progress" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "実行中のシミュレーションがあります"
+          }
+        }
+      }
+    },
     "AI Models" : {
       "localizations" : {
         "ja" : {
@@ -3691,6 +3701,26 @@
         }
       }
     },
+    "Pause and leave" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一時停止して移動"
+          }
+        }
+      }
+    },
+    "Pause and save it so you can resume later?" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一時停止して保存しますか？あとで再開できます。"
+          }
+        }
+      }
+    },
     "Pause playback" : {
       "localizations" : {
         "ja" : {
@@ -4768,6 +4798,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "状態"
+          }
+        }
+      }
+    },
+    "Stay" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "留まる"
           }
         }
       }

--- a/Pastura/Pastura/Views/Components/PasturaBackButton.swift
+++ b/Pastura/Pastura/Views/Components/PasturaBackButton.swift
@@ -30,6 +30,21 @@ import UIKit
 /// `@Environment(\.dismiss)` directly — `PasturaBackButton` will NOT
 /// dismiss a sheet. See `.claude/rules/navigation.md`.
 ///
+/// ## Tap-action override
+///
+/// Pass `action:` to intercept the tap instead of popping — e.g.
+/// SimulationView routes it to a confirm-on-leave dialog before popping
+/// an in-flight run (#673). The override owns the pop: it must call
+/// `router.pop()` itself once it decides to leave. Default `nil` keeps the
+/// plain `router.pop()` behaviour, so every existing callsite is unchanged.
+///
+/// **Swipe-back bypasses the override.** The edge-pan gesture pops via the
+/// UIKit `interactivePopGestureRecognizer` (see below), never through this
+/// `Button`, so an `action` override does NOT gate swipe-back. That gap is
+/// deliberate for #673 — the terminal-ladder safety net (`SimulationViewModel`
+/// persists a torn-down run as resumable `.paused`) makes an un-prompted
+/// swipe-back lossless, so no alert is needed there.
+///
 /// ## Accessibility
 ///
 /// Announces as `"Back, button"`. The chevron-only design intentionally
@@ -50,9 +65,18 @@ import UIKit
 struct PasturaBackButton: View {
   @Environment(AppRouter.self) private var router
 
+  /// Optional tap interceptor. When non-nil, the tap invokes `action` instead
+  /// of `router.pop()` — the override is then responsible for popping once it
+  /// decides to leave (#673). `nil` (default) keeps the plain pop behaviour.
+  var action: (() -> Void)?
+
   var body: some View {
     Button {
-      router.pop()
+      if let action {
+        action()
+      } else {
+        router.pop()
+      }
     } label: {
       Image(systemName: Self.iconName)
         .foregroundStyle(Self.tint)

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -18,6 +18,16 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
     case resume(runId: String)
   }
 
+  /// Which leave gesture triggered the confirm-on-leave dialog (#673): a
+  /// deferred cross-tab switch (the target lives in
+  /// ``TabCoordinator/pendingTabSwitch``) or a back-button tap (pop the
+  /// current tab's stack). Swipe-back is intentionally absent — it bypasses
+  /// the dialog and relies on the terminal-ladder `.paused` safety net.
+  private enum PendingLeave: Equatable {
+    case tab
+    case back
+  }
+
   let source: Source
   /// Render-time hint for the navigation title — supplied by the caller
   /// (`ScenarioDetailView`'s Run Simulation push, or the Home resume card)
@@ -28,7 +38,15 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
 
   @Environment(\.scenePhase) private var scenePhase
   @Environment(AppDependencies.self) private var dependencies
+  // Router (current tab's, via the tab-scoped injection) + coordinator drive
+  // the confirm-on-leave flow (#673): the back button pops through `router`,
+  // and `tabCoordinator` carries the leave-guard flag + deferred tab-switch.
+  @Environment(AppRouter.self) private var router
+  @Environment(TabCoordinator.self) private var tabCoordinator
   @State private var viewModel: SimulationViewModel?
+  /// Non-nil while the confirm-on-leave dialog is showing, recording which
+  /// gesture asked to leave (#673).
+  @State private var pendingLeave: PendingLeave?
   // Accessed from SimulationView+Background.swift extension for the toggle subtitle.
   @State var scenario: Scenario?
   @State private var showScoreboard = false
@@ -164,6 +182,87 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
     } message: {
       Text(exportError ?? "")
     }
+    // Confirm-on-leave (#673). Publish the leave guard so a cross-tab tap is
+    // deferred by TabCoordinator; observe the deferral to raise the dialog;
+    // the back button raises it directly via `handleBackTap()`.
+    .onChange(of: leaveGuardActive) { _, active in
+      tabCoordinator.hasUnsavedInFlightRun = active
+    }
+    .onAppear { tabCoordinator.hasUnsavedInFlightRun = leaveGuardActive }
+    // Unconditional clear (critic Axis 4): a torn-down run must never leave a
+    // stale `true` that would freeze every future tab switch app-wide.
+    .onDisappear { tabCoordinator.hasUnsavedInFlightRun = false }
+    .onChange(of: tabCoordinator.pendingTabSwitch) { _, newValue in
+      if newValue != nil { pendingLeave = .tab }
+    }
+    .alert(
+      String(localized: "A simulation is in progress"),
+      isPresented: leaveAlertBinding,
+      presenting: pendingLeave
+    ) { leave in
+      Button(String(localized: "Pause and leave")) { confirmLeave(leave) }
+      Button(String(localized: "Stay"), role: .cancel) { stay() }
+    } message: { _ in
+      Text(String(localized: "Pause and save it so you can resume later?"))
+    }
+  }
+
+  // MARK: - Confirm-on-leave (#673)
+
+  /// Pure predicate: a leave (tab-switch / back) must be confirmed only when a
+  /// run is genuinely in flight and not already paused or completed. A paused
+  /// run is already saved (`.paused`), and a completed one has nothing to lose.
+  /// Extracted `static` so the three-flag logic is unit-tested (ADR-009).
+  static func shouldGuardLeave(isRunning: Bool, isPaused: Bool, isCompleted: Bool) -> Bool {
+    isRunning && !isPaused && !isCompleted
+  }
+
+  /// Whether the current run should gate a leave gesture behind the dialog.
+  private var leaveGuardActive: Bool {
+    guard let viewModel else { return false }
+    return Self.shouldGuardLeave(
+      isRunning: viewModel.isRunning,
+      isPaused: viewModel.isPaused,
+      isCompleted: viewModel.isCompleted)
+  }
+
+  /// Back-button tap (#673). Confirm first when a run is in flight; otherwise
+  /// pop immediately.
+  private func handleBackTap() {
+    if leaveGuardActive {
+      pendingLeave = .back
+    } else {
+      router.pop()
+    }
+  }
+
+  /// `isPresented` binding for the leave dialog. The setter only fires `stay()`
+  /// on a programmatic dismissal that didn't go through a button (the buttons
+  /// already clear `pendingLeave`, so the guard skips the double-handling).
+  private var leaveAlertBinding: Binding<Bool> {
+    Binding(
+      get: { pendingLeave != nil },
+      set: { presented in
+        if !presented, pendingLeave != nil { stay() }
+      })
+  }
+
+  /// "Pause and leave": persist a resumable `.paused`, then perform the parked
+  /// leave (commit the deferred tab-switch, or pop the back stack).
+  private func confirmLeave(_ leave: PendingLeave) {
+    viewModel?.pauseSimulation()
+    switch leave {
+    case .tab: tabCoordinator.commitPendingTabSwitch()
+    case .back: router.pop()
+    }
+    pendingLeave = nil
+  }
+
+  /// "Stay": discard the pending leave and keep running. A deferred tab-switch
+  /// is also cleared on the coordinator so the parked target doesn't linger.
+  private func stay() {
+    if pendingLeave == .tab { tabCoordinator.cancelPendingTabSwitch() }
+    pendingLeave = nil
   }
 
   private func simulationContent(  // swiftlint:disable:this function_body_length
@@ -296,7 +395,10 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
     // continuity. See ADR-008 §Amendment 2026-05-10.
     .toolbar {
       ToolbarItem(placement: .topBarLeading) {
-        PasturaBackButton()
+        // Route the back tap through the confirm-on-leave guard (#673).
+        // Swipe-back bypasses this (UIKit gesture) and relies on the
+        // terminal-ladder `.paused` safety net — see PasturaBackButton's doc.
+        PasturaBackButton(action: handleBackTap)
       }
       .hidingPasturaSharedBackground()
       ToolbarItem(placement: .principal) {

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -253,6 +253,9 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
     viewModel?.pauseSimulation()
     switch leave {
     case .tab: tabCoordinator.commitPendingTabSwitch()
+    // `.back` was raised by handleBackTap(), not the pendingTabSwitch onChange,
+    // so no tab switch is ever parked here — deliberately don't touch coordinator
+    // state, just pop the current tab's stack.
     case .back: router.pop()
     }
     pendingLeave = nil

--- a/Pastura/PasturaTests/App/SimulationViewModelStatusTests+ResumeContinuation.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelStatusTests+ResumeContinuation.swift
@@ -116,6 +116,41 @@ private func pollResumeStatus(
   return try repo.fetchById(simId)
 }
 
+/// A fresh run parked mid-flight by ``startSuspendedFreshRun(rounds:)``.
+@MainActor
+private struct SuspendedFreshRun {
+  let env: ContinuationSUT
+  let simId: String
+  let runTask: Task<Void, Never>
+}
+
+/// Starts a FRESH `run(...)` whose first generate is parked (so the run is
+/// genuinely mid-flight and its `.running` record persisted), localizing the
+/// park-and-wait choreography. The caller then applies the leave action under
+/// test (raw `Task.cancel()` vs `cancelSimulation`). `nil` if no record formed.
+@MainActor
+private func startSuspendedFreshRun(rounds: Int = 3) async throws -> SuspendedFreshRun? {
+  let env = try makeContinuationSUT(rounds: rounds)
+  let mock = MockLLMService(responses: Array(repeating: #"{"statement":"x"}"#, count: 10))
+  env.sut.speed = .instant
+  mock.simulateSuspendOnNextGenerate()
+
+  let runTask = Task { await env.sut.run(scenario: env.scenario, llm: mock) }
+  env.sut.runTask = runTask
+
+  // Wait until the parked inference has started — by then run() has already
+  // awaited createSimulationRecord, so simulationId is populated.
+  let deadline = ContinuousClock.now.advanced(by: .seconds(2))
+  while env.sut.thinkingAgents.isEmpty, ContinuousClock.now < deadline {
+    await Task.yield()
+  }
+  guard let simId = env.sut.simulationId else {
+    runTask.cancel()
+    return nil
+  }
+  return SuspendedFreshRun(env: env, simId: simId, runTask: runTask)
+}
+
 extension SimulationViewModelStatusTests {
 
   // MARK: - Pure terminal-status ladder (deterministic, no run needed)
@@ -326,67 +361,40 @@ extension SimulationViewModelStatusTests {
 
   @Test func freshRunTornDownMidFlightPersistsPaused() async throws {
     // #673 safety net: a FRESH run cancelled at the Task level (tab-switch /
-    // back / swipe-back) WITHOUT cancelSimulation must leave the row .paused —
-    // not the silent .completed (data loss) the prior fresh-vs-resumed asymmetry
-    // produced. A scheduled suspend parks the first generate so the cancel lands
-    // deterministically mid-flight.
-    let env = try makeContinuationSUT(rounds: 3)
-    let mock = MockLLMService(responses: Array(repeating: #"{"statement":"x"}"#, count: 10))
-    env.sut.speed = .instant
-    mock.simulateSuspendOnNextGenerate()
-
-    let runTask = Task { await env.sut.run(scenario: env.scenario, llm: mock) }
-    env.sut.runTask = runTask
-
-    // Wait until the parked inference has started — by then run() has already
-    // awaited createSimulationRecord, so simulationId is populated.
-    let deadline = ContinuousClock.now.advanced(by: .seconds(2))
-    while env.sut.thinkingAgents.isEmpty, ContinuousClock.now < deadline {
-      await Task.yield()
-    }
-    guard let simId = env.sut.simulationId else {
+    // back / swipe-back) WITHOUT cancelSimulation must leave the row .paused, not
+    // the silent .completed (data loss) of the prior asymmetry. Reverting
+    // `!isCompleted` → `isResumedRun && !isCompleted` would fail this assert.
+    guard let run = try await startSuspendedFreshRun() else {
       Issue.record("fresh run did not create a simulation record")
-      runTask.cancel()
       return
     }
 
     // Tab-switch / back teardown: cancel the Task directly (NOT cancelSimulation).
-    runTask.cancel()
-    await runTask.value
+    run.runTask.cancel()
+    await run.runTask.value
 
-    let rec = try await pollResumeStatus(env.simRepo, simId) { $0.simulationStatus == .paused }
+    let rec = try await pollResumeStatus(run.env.simRepo, run.simId) {
+      $0.simulationStatus == .paused
+    }
     #expect(rec?.simulationStatus == .paused)
   }
 
   @Test func freshRunUserCancelledPersistsCancelled() async throws {
     // Guard the #673 ladder change against demoting a genuine user-cancel into
     // `.paused`: cancelSimulation sets isCancelled, which the ladder checks ABOVE
-    // the `!isCompleted` teardown branch → `.cancelled`. Same mid-flight setup as
-    // the teardown test; only the leave action differs (cancelSimulation vs
-    // raw Task cancel).
-    let env = try makeContinuationSUT(rounds: 3)
-    let mock = MockLLMService(responses: Array(repeating: #"{"statement":"x"}"#, count: 10))
-    env.sut.speed = .instant
-    mock.simulateSuspendOnNextGenerate()
-
-    let runTask = Task { await env.sut.run(scenario: env.scenario, llm: mock) }
-    env.sut.runTask = runTask
-
-    let deadline = ContinuousClock.now.advanced(by: .seconds(2))
-    while env.sut.thinkingAgents.isEmpty, ContinuousClock.now < deadline {
-      await Task.yield()
-    }
-    guard let simId = env.sut.simulationId else {
+    // the `!isCompleted` teardown branch → `.cancelled`.
+    guard let run = try await startSuspendedFreshRun() else {
       Issue.record("fresh run did not create a simulation record")
-      runTask.cancel()
       return
     }
 
     // User-initiated cancel (vs. the silent teardown above).
-    env.sut.cancelSimulation()
-    await runTask.value
+    run.env.sut.cancelSimulation()
+    await run.runTask.value
 
-    let rec = try await pollResumeStatus(env.simRepo, simId) { $0.simulationStatus == .cancelled }
+    let rec = try await pollResumeStatus(run.env.simRepo, run.simId) {
+      $0.simulationStatus == .cancelled
+    }
     #expect(rec?.simulationStatus == .cancelled)
   }
 }

--- a/Pastura/PasturaTests/App/SimulationViewModelStatusTests+ResumeContinuation.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelStatusTests+ResumeContinuation.swift
@@ -125,47 +125,53 @@ extension SimulationViewModelStatusTests {
     #expect(
       SimulationViewModel.terminalStatus(
         didPersistPaused: true, errorMessage: "boom",
-        isCancelled: true, isResumedRun: true, isCompleted: false) == nil)
+        isCancelled: true, isCompleted: false) == nil)
   }
 
   @Test func terminalStatusFailedBeatsCompletion() {
     #expect(
       SimulationViewModel.terminalStatus(
         didPersistPaused: false, errorMessage: "boom",
-        isCancelled: false, isResumedRun: true, isCompleted: true) == .failed)
+        isCancelled: false, isCompleted: true) == .failed)
   }
 
-  @Test func terminalStatusCancelBeatsResumeAndCompletion() {
+  @Test func terminalStatusFailedBeatsTeardown() {
+    // A real error on a not-yet-completed run still wins over the `.paused`
+    // teardown branch — errorMessage is checked above `!isCompleted` (#673).
+    #expect(
+      SimulationViewModel.terminalStatus(
+        didPersistPaused: false, errorMessage: "boom",
+        isCancelled: false, isCompleted: false) == .failed)
+  }
+
+  @Test func terminalStatusCancelBeatsTeardownAndCompletion() {
+    // User-cancel (`isCancelled`) is checked above `!isCompleted`, so a run
+    // cancelled mid-flight records `.cancelled`, never the teardown `.paused`.
     #expect(
       SimulationViewModel.terminalStatus(
         didPersistPaused: false, errorMessage: nil,
-        isCancelled: true, isResumedRun: true, isCompleted: false) == .cancelled)
+        isCancelled: true, isCompleted: false) == .cancelled)
   }
 
-  @Test func terminalStatusResumedTornDownMidFlightStaysPaused() {
-    // The resume-specific branch: a resumed run torn down before completion
-    // (no pause/cancel/error) stays resumable rather than being marked complete.
+  @Test func terminalStatusTornDownMidFlightStaysPaused() {
+    // #673 — a run torn down before completion (no pause/cancel/error) stays
+    // resumable rather than being marked complete. Symmetric across fresh and
+    // resumed runs: `isResumedRun` is no longer a discriminator here. This
+    // replaces the prior fresh-vs-resumed asymmetry pin (the fresh case used
+    // to write `.completed`, silently losing the run).
     #expect(
       SimulationViewModel.terminalStatus(
         didPersistPaused: false, errorMessage: nil,
-        isCancelled: false, isResumedRun: true, isCompleted: false) == .paused)
+        isCancelled: false, isCompleted: false) == .paused)
   }
 
-  @Test func terminalStatusResumedRunThatCompletedWritesCompleted() {
+  @Test func terminalStatusCompletedRunWritesCompleted() {
+    // The only path to `.completed`: `.simulationCompleted` set isCompleted, and
+    // no higher-precedence terminal flag fired.
     #expect(
       SimulationViewModel.terminalStatus(
         didPersistPaused: false, errorMessage: nil,
-        isCancelled: false, isResumedRun: true, isCompleted: true) == .completed)
-  }
-
-  @Test func terminalStatusFreshRunTornDownWritesCompletedNotPaused() {
-    // Asymmetry pin: a FRESH run (isResumedRun == false) that exhausts its
-    // stream writes .completed even with isCompleted false — fresh-run
-    // mid-flight survival is #646 / PR2 scope, deliberately not lifted here.
-    #expect(
-      SimulationViewModel.terminalStatus(
-        didPersistPaused: false, errorMessage: nil,
-        isCancelled: false, isResumedRun: false, isCompleted: false) == .completed)
+        isCancelled: false, isCompleted: true) == .completed)
   }
 
   // MARK: - Resume continuation (seed → resume → assert persisted rows)
@@ -314,5 +320,73 @@ extension SimulationViewModelStatusTests {
 
     let rec = try await pollResumeStatus(env.simRepo, simId) { $0.simulationStatus == .paused }
     #expect(rec?.simulationStatus == .paused)
+  }
+
+  // MARK: - Fresh-run mid-flight teardown (#673 terminal-ladder symmetry)
+
+  @Test func freshRunTornDownMidFlightPersistsPaused() async throws {
+    // #673 safety net: a FRESH run cancelled at the Task level (tab-switch /
+    // back / swipe-back) WITHOUT cancelSimulation must leave the row .paused —
+    // not the silent .completed (data loss) the prior fresh-vs-resumed asymmetry
+    // produced. A scheduled suspend parks the first generate so the cancel lands
+    // deterministically mid-flight.
+    let env = try makeContinuationSUT(rounds: 3)
+    let mock = MockLLMService(responses: Array(repeating: #"{"statement":"x"}"#, count: 10))
+    env.sut.speed = .instant
+    mock.simulateSuspendOnNextGenerate()
+
+    let runTask = Task { await env.sut.run(scenario: env.scenario, llm: mock) }
+    env.sut.runTask = runTask
+
+    // Wait until the parked inference has started — by then run() has already
+    // awaited createSimulationRecord, so simulationId is populated.
+    let deadline = ContinuousClock.now.advanced(by: .seconds(2))
+    while env.sut.thinkingAgents.isEmpty, ContinuousClock.now < deadline {
+      await Task.yield()
+    }
+    guard let simId = env.sut.simulationId else {
+      Issue.record("fresh run did not create a simulation record")
+      runTask.cancel()
+      return
+    }
+
+    // Tab-switch / back teardown: cancel the Task directly (NOT cancelSimulation).
+    runTask.cancel()
+    await runTask.value
+
+    let rec = try await pollResumeStatus(env.simRepo, simId) { $0.simulationStatus == .paused }
+    #expect(rec?.simulationStatus == .paused)
+  }
+
+  @Test func freshRunUserCancelledPersistsCancelled() async throws {
+    // Guard the #673 ladder change against demoting a genuine user-cancel into
+    // `.paused`: cancelSimulation sets isCancelled, which the ladder checks ABOVE
+    // the `!isCompleted` teardown branch → `.cancelled`. Same mid-flight setup as
+    // the teardown test; only the leave action differs (cancelSimulation vs
+    // raw Task cancel).
+    let env = try makeContinuationSUT(rounds: 3)
+    let mock = MockLLMService(responses: Array(repeating: #"{"statement":"x"}"#, count: 10))
+    env.sut.speed = .instant
+    mock.simulateSuspendOnNextGenerate()
+
+    let runTask = Task { await env.sut.run(scenario: env.scenario, llm: mock) }
+    env.sut.runTask = runTask
+
+    let deadline = ContinuousClock.now.advanced(by: .seconds(2))
+    while env.sut.thinkingAgents.isEmpty, ContinuousClock.now < deadline {
+      await Task.yield()
+    }
+    guard let simId = env.sut.simulationId else {
+      Issue.record("fresh run did not create a simulation record")
+      runTask.cancel()
+      return
+    }
+
+    // User-initiated cancel (vs. the silent teardown above).
+    env.sut.cancelSimulation()
+    await runTask.value
+
+    let rec = try await pollResumeStatus(env.simRepo, simId) { $0.simulationStatus == .cancelled }
+    #expect(rec?.simulationStatus == .cancelled)
   }
 }

--- a/Pastura/PasturaTests/App/TabCoordinatorTests.swift
+++ b/Pastura/PasturaTests/App/TabCoordinatorTests.swift
@@ -204,6 +204,77 @@ import Testing
     #expect(coordinator.settingsRouter.path.isEmpty)
   }
 
+  // MARK: - Leave guard / deferred tab-switch (#673)
+
+  @Test func guardDefersCrossTabSwitch() {
+    let coordinator = TabCoordinator()
+    coordinator.homeRouter.push(.simulation(scenarioId: "x"))
+    coordinator.hasUnsavedInFlightRun = true
+
+    coordinator.handleSelection(.history)
+
+    // The switch is deferred: selectedTab stays put, target is parked.
+    #expect(coordinator.selectedTab == .home)
+    #expect(coordinator.pendingTabSwitch == .history)
+  }
+
+  @Test func guardDoesNotBlockReselectionPopToRoot() {
+    // Re-selection short-circuits above the guard — re-tapping the current tab
+    // pops-to-root even mid-run (it does not leave the screen, so no confirm).
+    let coordinator = TabCoordinator()
+    coordinator.homeRouter.push(.simulation(scenarioId: "x"))
+    coordinator.hasUnsavedInFlightRun = true
+
+    coordinator.handleSelection(.home)
+
+    #expect(coordinator.homeRouter.path.isEmpty)
+    #expect(coordinator.pendingTabSwitch == nil)
+    #expect(coordinator.selectedTab == .home)
+  }
+
+  @Test func clearedGuardDoesNotDeferSelection() {
+    // Race guard (critic Axis 4): a SimulationView that set the flag true and
+    // then cleared it on disappear must not leave a stale `true` that freezes
+    // every subsequent tab switch.
+    let coordinator = TabCoordinator()
+    coordinator.hasUnsavedInFlightRun = true
+    coordinator.hasUnsavedInFlightRun = false  // onDisappear unconditional clear
+
+    coordinator.handleSelection(.search)
+
+    #expect(coordinator.selectedTab == .search)
+    #expect(coordinator.pendingTabSwitch == nil)
+  }
+
+  @Test func commitPendingTabSwitchPerformsDeferredSwitch() {
+    let coordinator = TabCoordinator()
+    coordinator.hasUnsavedInFlightRun = true
+    coordinator.handleSelection(.settings)
+
+    coordinator.commitPendingTabSwitch()
+
+    #expect(coordinator.selectedTab == .settings)
+    #expect(coordinator.pendingTabSwitch == nil)
+  }
+
+  @Test func commitPendingTabSwitchIsNoopWhenNothingPending() {
+    let coordinator = TabCoordinator()
+    coordinator.commitPendingTabSwitch()
+    #expect(coordinator.selectedTab == .home)
+    #expect(coordinator.pendingTabSwitch == nil)
+  }
+
+  @Test func cancelPendingTabSwitchStaysOnCurrentTab() {
+    let coordinator = TabCoordinator()
+    coordinator.hasUnsavedInFlightRun = true
+    coordinator.handleSelection(.settings)
+
+    coordinator.cancelPendingTabSwitch()
+
+    #expect(coordinator.selectedTab == .home)
+    #expect(coordinator.pendingTabSwitch == nil)
+  }
+
   // MARK: - Helpers
 
   private func makeGalleryScenario(id: String) -> GalleryScenario {

--- a/Pastura/PasturaTests/Views/SimulationViewLeaveGuardTests.swift
+++ b/Pastura/PasturaTests/Views/SimulationViewLeaveGuardTests.swift
@@ -1,0 +1,31 @@
+import Testing
+
+@testable import Pastura
+
+// `@MainActor` because `shouldGuardLeave` is a static on the default-MainActor
+// `SimulationView`; the suite isolation lets a nonisolated caller reach it
+// (`.claude/rules/swift-isolation.md` Pattern 5).
+@MainActor
+@Suite(.timeLimit(.minutes(1)))
+struct SimulationViewLeaveGuardTests {
+
+  @Test func guardsWhenRunningNotPausedNotCompleted() {
+    // The only state that risks a silent loss: an in-flight run the user hasn't
+    // explicitly paused. Leaving it must be confirmed (#673).
+    #expect(SimulationView.shouldGuardLeave(isRunning: true, isPaused: false, isCompleted: false))
+  }
+
+  @Test func noGuardWhenNotRunning() {
+    #expect(!SimulationView.shouldGuardLeave(isRunning: false, isPaused: false, isCompleted: false))
+  }
+
+  @Test func noGuardWhenPaused() {
+    // A paused run is already persisted as `.paused` — leaving loses nothing.
+    #expect(!SimulationView.shouldGuardLeave(isRunning: true, isPaused: true, isCompleted: false))
+  }
+
+  @Test func noGuardWhenCompleted() {
+    // A completed run has its terminal `.completed` row — nothing to confirm.
+    #expect(!SimulationView.shouldGuardLeave(isRunning: true, isPaused: false, isCompleted: true))
+  }
+}


### PR DESCRIPTION
## Summary
Home redesign P3 PR2 (ADR-016, follows #667). When a simulation run is
in-flight and the user leaves the screen, confirm before tearing it down so
the run is explicitly paused (→ resumable `.paused`) rather than lost.

- **Terminal-ladder safety net** — `SimulationViewModel.terminalStatus` now
  persists ANY mid-flight torn-down run (fresh *or* resumed) as resumable
  `.paused`, dropping the prior `isResumedRun` gate that silently mislabelled a
  torn-down **fresh** run as `.completed` (data loss). `.failed`/`.cancelled`
  still win above the teardown branch.
- **Confirm-on-leave dialog** — a 2-button `.alert` ("Pause and leave" / "Stay")
  on **tab-switch** (deferred via `TabCoordinator`) and **back-button** (via a
  `PasturaBackButton` action override). Pausing persists `.paused`, then performs
  the parked leave; "Stay" keeps running.
- **Swipe-back** deliberately bypasses the dialog (un-interceptable UIKit
  gesture) and relies on the terminal-ladder safety net — lossless, resumable
  from the Home card.

**Out of scope**: #646 本丸 (lifting run ownership to run across tabs) — deferred
to the ADR-003 BG mechanism.

## Design notes
- `hasUnsavedInFlightRun` + `pendingTabSwitch` live on `TabCoordinator` (gate tab
  selection), never `AppRouter` (navigation.md scope). Unconditional
  `onDisappear` clear prevents a stale guard freezing future switches.
- `.alert` (not `confirmationDialog` — iOS 26 mis-anchors it). Pure
  `shouldGuardLeave` helper unit-tested (ADR-009).

## Test plan
- Full unit suite (1997 tests / 180 suites) green; `swiftlint --strict` clean;
  localization coverage OK.
- New pure terminalStatus ladder tests + end-to-end `freshRunTornDownMidFlight…`
  (→ `.paused`) / `freshRunUserCancelled…` (→ `.cancelled`); TabCoordinator
  deferral + race-guard tests; `SimulationViewLeaveGuardTests`.
- **Pre-merge manual QA gate (real device, iOS 17–26)**: pause → leave-confirm
  → save → Home paused card → resume; **iOS 26 tab-bar snap-back** when the
  deferral holds `selectedTab` at the old tab (fallback if it desyncs: visual
  switch + pause/commit, "Stay" switches back).

Closes #673

🤖 Generated with [Claude Code](https://claude.com/claude-code)