### PR TITLE
⚡️ perf: reuse scenario index across Past Results filter keystrokes

### DIFF
--- a/Pastura/Pastura/App/ResultsViewModel.swift
+++ b/Pastura/Pastura/App/ResultsViewModel.swift
@@ -64,6 +64,11 @@ final class ResultsViewModel {
   private var scenarioById: [String: ScenarioRecord] = [:]
   /// Precomputed device-locale section header per live canonical key.
   private var headerNameByCanonicalKey: [String: String] = [:]
+  /// The `deviceLanguage` the scenario index was built for (`nil` before the
+  /// first build). The filter path reuses the index while this matches, so it
+  /// doesn't re-`fetchAll()` + re-parse per keystroke; a language change still
+  /// rebuilds (header map is locale-dependent). See #678.
+  private var indexedLanguage: String?
 
   /// One simulation row within a ``ScenarioGroup``.
   ///
@@ -164,10 +169,14 @@ final class ResultsViewModel {
     let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
     guard trimmed != nameQuery else { return }
     nameQuery = trimmed
+    // Assign `deviceLanguage` BEFORE `reloadAggregate` so its index-reuse gate
+    // (`indexedLanguage != deviceLanguage`) sees the active language. Do not
+    // reorder these two lines.
     self.deviceLanguage = deviceLanguage
     errorMessage = nil
     do {
-      try await reloadAggregate()
+      // Reuse the index — the scenario set is invariant while typing (#678).
+      try await reloadAggregate(rebuildIndex: false)
     } catch {
       errorMessage = Self.failureMessage(error)
     }
@@ -202,12 +211,15 @@ final class ResultsViewModel {
   /// guarantees no collision with a live scenario's `sourceId ?? id`.
   private static let orphanCanonicalKeyPrefix = "\u{0}orphan:"
 
-  /// Resets the window and loads the first visible page.
-  private func reloadAggregate() async throws {
+  /// Resets the window and loads the first visible page. `rebuildIndex: false`
+  /// reuses the scenario index (filter path, #678) — see ``indexedLanguage``.
+  private func reloadAggregate(rebuildIndex: Bool = true) async throws {
     loadGeneration += 1
     let generation = loadGeneration
-    try await refreshScenarioIndex()
-    guard generation == loadGeneration else { return }
+    if rebuildIndex || indexedLanguage != deviceLanguage {
+      try await refreshScenarioIndex()
+      guard generation == loadGeneration else { return }
+    }
     loadedRuns = []
     cursor = nil
     loadedRawCount = 0
@@ -299,6 +311,7 @@ final class ResultsViewModel {
       if let headerVariant { headers[canonicalKey] = headerVariant.name }
     }
     headerNameByCanonicalKey = headers
+    indexedLanguage = deviceLanguage  // stamp for the filter-path reuse gate (#678)
   }
 
   /// Buckets a run to its canonical group + per-variant label. Returns `nil`

--- a/Pastura/PasturaTests/App/ResultsViewModelTests.swift
+++ b/Pastura/PasturaTests/App/ResultsViewModelTests.swift
@@ -263,4 +263,85 @@ struct ResultsViewModelTests {
     let liveGroup = try #require(env.sut.groups.first { $0.sectionName == "Word Wolf" })
     #expect(liveGroup.canonicalKey != orphanGroup.canonicalKey)
   }
+
+  // MARK: - Filter index reuse (#678)
+
+  /// Regression for #678: the scenario index — `scenarioRepository.fetchAll()`
+  /// plus a per-row `ScenarioYAMLLanguage.parse(yamlDefinition)` — must NOT be
+  /// rebuilt on every filter keystroke. The scenario set is invariant while
+  /// the user types, so the filter path reuses the already-built index.
+  ///
+  /// `CountingScenarioRepository` pins it via `fetchAll()` count: with the fix
+  /// the count stays at 1 (the initial load's build); reverting the fix
+  /// (re-fetch + re-parse per keystroke) would raise it to 5
+  /// (1 load + 3 distinct filters + 1 clear). The distinct, non-empty queries
+  /// matter — a repeated query would hit `applyFilter`'s no-op guard and
+  /// short-circuit before `reloadAggregate`, passing for the wrong reason.
+  @Test func filterReusesScenarioIndexAcrossKeystrokes() async throws {
+    let db = try DatabaseManager.inMemory()
+    let realScenarioRepo = GRDBScenarioRepository(dbWriter: db.dbWriter)
+    let countingRepo = CountingScenarioRepository(wrapping: realScenarioRepo)
+    let simRepo = GRDBSimulationRepository(dbWriter: db.dbWriter)
+    let turnRepo = GRDBTurnRepository(dbWriter: db.dbWriter)
+    let sut = ResultsViewModel(
+      scenarioRepository: countingRepo,
+      simulationRepository: simRepo,
+      turnRepository: turnRepo)
+
+    try seedScenarioWithSimulation(
+      scenarioRepo: realScenarioRepo, simRepo: simRepo,
+      scenarioId: "s1", scenarioName: "Prisoner's Dilemma", simulationId: "sim1")
+    try seedScenarioWithSimulation(
+      scenarioRepo: realScenarioRepo, simRepo: simRepo,
+      scenarioId: "s2", scenarioName: "Word Wolf", simulationId: "sim2")
+
+    await sut.load(scope: .aggregate, deviceLanguage: "ja")
+    #expect(sut.groups.count == 2)
+    #expect(countingRepo.fetchAllCount == 1)  // initial index build
+
+    // Three distinct, non-empty keystrokes — each a substring LIKE that
+    // narrows to "Prisoner's Dilemma" only — then a clear.
+    await sut.applyFilter("Pri", deviceLanguage: "ja")
+    #expect(sut.groups.count == 1)
+    #expect(sut.groups.first?.sectionName == "Prisoner's Dilemma")
+    await sut.applyFilter("Pris", deviceLanguage: "ja")
+    #expect(sut.groups.count == 1)
+    await sut.applyFilter("Priso", deviceLanguage: "ja")
+    #expect(sut.groups.count == 1)
+
+    // Clearing restores the full window.
+    await sut.applyFilter("", deviceLanguage: "ja")
+    #expect(sut.groups.count == 2)
+
+    // The index was reused throughout — never rebuilt per keystroke.
+    #expect(countingRepo.fetchAllCount == 1)
+  }
+}
+
+/// Wraps a real ``ScenarioRepository`` and counts ``ScenarioRepository/fetchAll()``
+/// calls so the #678 regression can assert the scenario index is built once,
+/// not rebuilt per filter keystroke. `nonisolated` + `@unchecked Sendable`
+/// with an `NSLock`-guarded counter because repository methods run off the
+/// main actor (`ResultsViewModel.offMain`) and the protocol is `Sendable`.
+nonisolated private final class CountingScenarioRepository: ScenarioRepository, @unchecked Sendable {
+  private let wrapped: any ScenarioRepository
+  private let lock = NSLock()
+  private var _fetchAllCount = 0
+
+  var fetchAllCount: Int { lock.withLock { _fetchAllCount } }
+
+  init(wrapping: any ScenarioRepository) { self.wrapped = wrapping }
+
+  func fetchAll() throws -> [ScenarioRecord] {
+    lock.withLock { _fetchAllCount += 1 }
+    return try wrapped.fetchAll()
+  }
+
+  func save(_ record: ScenarioRecord) throws { try wrapped.save(record) }
+  func fetchById(_ id: String) throws -> ScenarioRecord? { try wrapped.fetchById(id) }
+  func fetchBySource(type: String, id: String) throws -> ScenarioRecord? {
+    try wrapped.fetchBySource(type: type, id: id)
+  }
+  func fetchPresets() throws -> [ScenarioRecord] { try wrapped.fetchPresets() }
+  func delete(_ id: String) throws { try wrapped.delete(id) }
 }


### PR DESCRIPTION
## Summary

`ResultsViewModel.applyFilter` fires per keystroke in the Past Results `.searchable` filter and flowed through `reloadAggregate` → `refreshScenarioIndex`, which ran `scenarioRepository.fetchAll()` plus a per-row `ScenarioYAMLLanguage.parse(yamlDefinition)` on **every** keystroke. The scenario set is invariant while the user types, so this was redundant work that gets noticeable at hundreds of scenarios.

This gates the index build behind `reloadAggregate(rebuildIndex:)`, tracked by a new `indexedLanguage: String?` stamp set at the tail of `refreshScenarioIndex`:

- `applyFilter` passes `rebuildIndex: false` and **reuses** the index while the active `deviceLanguage` still matches the indexed one.
- The initial `load(.aggregate)` and a genuine device-language change still rebuild (the section-header map is device-locale-dependent). `applyFilter` assigns `self.deviceLanguage` **before** the gate check so a real language change is caught (load-bearing ordering, commented).

### Invariant

Index reuse is bounded to a single typing burst. All scenario-set mutations (install / delete) route through `refreshAggregatePreservingDepth` (reappear-refresh), which rebuilds the index **unconditionally** — so nothing is staled outside a typing burst.

## Test plan

- New `filterReusesScenarioIndexAcrossKeystrokes` regression test: a `CountingScenarioRepository` spy counts `fetchAll()` and asserts the index is built **once** across load + 3 distinct filters + 1 clear (reverting the fix yields 5). RED→GREEN validated.
- Full unit suite: **2010 tests / 180 suites passed**.
- `swiftlint --strict` clean.

## Follow-up (non-blocking, from code review)

`ResultsViewModel.swift` is now exactly at the swiftlint `file_length` cap (400). The next edit will trip `--strict`; a pre-emptive sibling-file extract along the existing Aggregate / Detail `// MARK:` boundary (`ResultsViewModel+Aggregate.swift`) would relieve it. Out of scope here.

Closes #678