### PR TITLE
✨ feat: Browse tab layout — category chips + Recommended header

### DIFF
--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -1598,6 +1598,16 @@
         }
       }
     },
+    "Browse Shared Scenarios" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "共有シナリオを探す"
+          }
+        }
+      }
+    },
     "Calculate scores (code, no LLM)" : {
       "localizations" : {
         "ja" : {
@@ -4250,6 +4260,16 @@
         }
       }
     },
+    "Recommended Scenarios" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "おすすめのシナリオ"
+          }
+        }
+      }
+    },
     "Recommended model" : {
       "localizations" : {
         "ja" : {
@@ -4886,16 +4906,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "準備ができました"
-          }
-        }
-      }
-    },
-    "Shared Scenarios" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "共有シナリオ"
           }
         }
       }

--- a/Pastura/Pastura/Views/Community/SharedScenarios/GalleryCategoryFilter.swift
+++ b/Pastura/Pastura/Views/Community/SharedScenarios/GalleryCategoryFilter.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// One selectable option in the Browse tab's horizontal category-filter
+/// chip row (ADR-016 P4): either the leading "All" chip (no filter) or a
+/// single ``GalleryCategory``.
+///
+/// Kept `nonisolated` and side-effect-free so the chip-options projection
+/// — the "All"-first ordering and the option → `selectedCategory` mapping
+/// — is unit-testable without rendering (ADR-009 /
+/// `.claude/rules/view-testing.md`). The category *filtering* itself stays
+/// in `SharedScenariosViewModel.visibleScenarios`; this type only models
+/// the chip presentation and how a tapped chip maps onto the existing
+/// `selectedCategory` binding.
+nonisolated enum GalleryCategoryFilter: Hashable {
+  /// The leading chip: clears the filter (shows every scenario).
+  case all
+  /// A chip scoped to a single gallery category.
+  case category(GalleryCategory)
+
+  /// The chip options in row order: the "All" chip first, then one chip per
+  /// ``GalleryCategory`` in `allCases` order. "All" leads so the default
+  /// unfiltered state is the first chip the user lands on.
+  static let options: [GalleryCategoryFilter] =
+    [.all] + GalleryCategory.allCases.map(GalleryCategoryFilter.category)
+
+  /// The `selectedCategory` binding value this option represents — `nil`
+  /// for ``all`` (which `visibleScenarios` already treats as "show
+  /// everything"), or the wrapped category otherwise.
+  var selectedCategory: GalleryCategory? {
+    switch self {
+    case .all: return nil
+    case .category(let category): return category
+    }
+  }
+}

--- a/Pastura/Pastura/Views/Community/SharedScenarios/SharedScenariosListView.swift
+++ b/Pastura/Pastura/Views/Community/SharedScenarios/SharedScenariosListView.swift
@@ -16,7 +16,7 @@ struct SharedScenariosListView: View {
         ProgressView()
       }
     }
-    .navigationTitle(String(localized: "Shared Scenarios"))
+    .navigationTitle(String(localized: "Browse Shared Scenarios"))
     // Inline title to match the other tab roots (design-system § 5.11).
     .navigationBarTitleDisplayMode(.inline)
     .task {
@@ -85,15 +85,8 @@ struct SharedScenariosListView: View {
         if case .offlineWithCache = viewModel.state {
           offlineBanner
         }
-        PasturaSection {
-          HStack {
-            Text(String(localized: "Category")).foregroundStyle(Color.ink)
-            Spacer(minLength: 8)
-            categoryPicker(selection: $bindable.selectedCategory)
-          }
-          .padding(.horizontal, 17)
-          .padding(.vertical, 8)
-        }
+        categoryChips(selection: $bindable.selectedCategory)
+        recommendedHeader
         scenariosCard(viewModel: viewModel)
         if let updated = viewModel.updatedAt {
           Text(String(format: String(localized: "Last updated: %@"), updated))
@@ -165,14 +158,67 @@ struct SharedScenariosListView: View {
     .contentShape(Rectangle())
   }
 
-  private func categoryPicker(selection: Binding<GalleryCategory?>) -> some View {
-    Picker(String(localized: "Category"), selection: selection) {
-      Text(String(localized: "All")).tag(GalleryCategory?.none)
-      ForEach(GalleryCategory.allCases, id: \.self) { category in
-        Text(category.displayName).tag(GalleryCategory?.some(category))
+  // MARK: - Category filter chips
+
+  /// Horizontal, scrollable category-filter chip row (ADR-016 P4). Replaces
+  /// the menu `Picker`: every category is one tap inline, matching the D3
+  /// Browse mock. Drives the existing `selectedCategory` binding (nil =
+  /// "All"); `visibleScenarios` still owns the actual filtering.
+  private func categoryChips(selection: Binding<GalleryCategory?>) -> some View {
+    ScrollView(.horizontal, showsIndicators: false) {
+      HStack(spacing: 8) {
+        ForEach(GalleryCategoryFilter.options, id: \.self) { option in
+          categoryChip(option, selection: selection)
+        }
       }
+      .padding(.horizontal, PasturaCardMetrics.horizontalMargin)
     }
-    .pickerStyle(.menu)
+  }
+
+  private func categoryChip(
+    _ option: GalleryCategoryFilter, selection: Binding<GalleryCategory?>
+  ) -> some View {
+    let isSelected = option.selectedCategory == selection.wrappedValue
+    return Button {
+      selection.wrappedValue = option.selectedCategory
+    } label: {
+      Text(chipTitle(option))
+        .font(.subheadline.weight(isSelected ? .semibold : .regular))
+        // Selected uses `mossDark`, not base `moss`: white-on-mossDark clears
+        // WCAG AA (≈4.76:1) whereas white-on-moss is only ≈3.0:1
+        // (PasturaPrimaryButtonStyle §2.3). White-on-accent is the
+        // contrast-passing pair, distinct from §1's avoid-white-surfaces rule.
+        .foregroundStyle(isSelected ? Color.white : Color.ink)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 7)
+        .background(isSelected ? Color.mossDark : Color.bubbleBackground, in: Capsule())
+        .overlay(
+          Capsule().strokeBorder(
+            isSelected ? Color.clear : Color.rule,
+            lineWidth: PasturaCardMetrics.borderWidth))
+    }
+    .buttonStyle(.plain)
+    // The menu Picker announced its selection for free; rebuild that on the
+    // hand-rolled chips so VoiceOver still reads which filter is active.
+    .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+  }
+
+  private func chipTitle(_ option: GalleryCategoryFilter) -> String {
+    switch option {
+    case .all: return String(localized: "All")
+    case .category(let category): return category.displayName
+    }
+  }
+
+  /// "Recommended" section header above the scenarios card (D3 Browse mock),
+  /// styled like a ``PasturaSection`` header (muted subheadline).
+  private var recommendedHeader: some View {
+    Text(String(localized: "Recommended Scenarios"))
+      .font(.subheadline)
+      .foregroundStyle(Color.muted)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .padding(.horizontal, PasturaCardMetrics.horizontalMargin + 6)
+      .accessibilityAddTraits(.isHeader)
   }
 
   private func scenarioRow(

--- a/Pastura/PasturaTests/Views/SharedScenariosCategoryFilterTests.swift
+++ b/Pastura/PasturaTests/Views/SharedScenariosCategoryFilterTests.swift
@@ -1,0 +1,54 @@
+import Testing
+
+@testable import Pastura
+
+/// Unit tests for the Browse tab's category-chip filter projection
+/// (ADR-016 P4 layout migration). Covers the genuinely-new chip-options
+/// logic — the "All" chip ordering and the option → `selectedCategory`
+/// mapping — NOT the category filtering itself, which is already owned by
+/// `SharedScenariosViewModelTests.visibleScenariosFilterByCategory`.
+/// Asserts logic properties only, never rendered output
+/// (ADR-009 / `.claude/rules/view-testing.md`).
+@MainActor
+@Suite(.timeLimit(.minutes(1)))
+struct SharedScenariosCategoryFilterTests {
+
+  // MARK: - Chip ordering / completeness
+
+  @Test func allChipIsFirst() {
+    // The "All" (no-filter) chip must lead the row so the default,
+    // unfiltered state is the first thing the user lands on. A revert that
+    // drops it or moves it after the categories fails here.
+    #expect(GalleryCategoryFilter.options.first == .all)
+  }
+
+  @Test func optionsCoverEveryCategoryExactlyOnce() {
+    let categories = GalleryCategoryFilter.options.compactMap { option -> GalleryCategory? in
+      if case .category(let category) = option { return category }
+      return nil
+    }
+    #expect(categories == GalleryCategory.allCases)
+    // All chip + one chip per category, no duplicates or omissions.
+    #expect(GalleryCategoryFilter.options.count == GalleryCategory.allCases.count + 1)
+  }
+
+  // MARK: - Option → selectedCategory mapping
+
+  @Test func allChipMapsToNilSelection() {
+    // The "All" chip drives the existing `selectedCategory` binding to nil,
+    // which `visibleScenarios` already treats as "show everything".
+    #expect(GalleryCategoryFilter.all.selectedCategory == nil)
+  }
+
+  @Test func categoryChipMapsToItsCategory() {
+    #expect(GalleryCategoryFilter.category(.ethics).selectedCategory == .ethics)
+    #expect(GalleryCategoryFilter.category(.gameTheory).selectedCategory == .gameTheory)
+  }
+
+  @Test func chipMappingPreservesCategoryOrder() {
+    // The category chips, in row order, map back to `allCases` order — a
+    // reordering regression (e.g. building options from a Set) fails here.
+    let mapped = GalleryCategoryFilter.options.dropFirst().map(\.selectedCategory)
+    #expect(mapped == GalleryCategory.allCases.map(Optional.some))
+  }
+}

--- a/Pastura/PasturaUITests/NavigationRegressionTests.swift
+++ b/Pastura/PasturaUITests/NavigationRegressionTests.swift
@@ -40,8 +40,8 @@ final class NavigationRegressionTests: XCTestCase {
     browseTab.tap()
 
     XCTAssertTrue(
-      app.navigationBars["Shared Scenarios"].waitForExistence(timeout: 5),
-      "Shared Scenarios did not appear.")
+      app.navigationBars["Browse Shared Scenarios"].waitForExistence(timeout: 5),
+      "Browse Shared Scenarios did not appear.")
 
     // Shared Scenarios → Gallery scenario detail (push within the Browse tab).
     let galleryCell = app.buttons["sharedScenarios.galleryCell.ui_test_canary"]


### PR DESCRIPTION
## Summary
Migrate the さがす (Browse) tab layout toward the D3 mock — the first of two PRs for ADR-016 P4. **UI-only**; no data-model changes. Search logic is a separate later PR.

- **Category filter**: menu `Picker` → horizontal scrollable chip row. The chip-options projection (All-first ordering, option → `selectedCategory` mapping) is extracted to a pure `GalleryCategoryFilter` enum with unit tests; `visibleScenarios` still owns the actual filtering.
- **Section header**: added "Recommended Scenarios" above the scenarios card.
- **Title**: `navigationTitle` → "Browse Shared Scenarios" (ja: 共有シナリオを探す), matching the "さがす" tab name.
- **i18n**: 2 new keys + ja translations; removed the now-orphaned "Shared Scenarios" key (its sole consumer was the renamed title).
- **Chip styling**: selected chip uses `mossDark` (white-on-fill ≈4.76:1, WCAG AA) per `PasturaPrimaryButtonStyle`; hand-rolled chips rebuild the menu Picker's lost VoiceOver selection announcement via `.accessibilityAddTraits(.isSelected)`.

### Out of scope (deferred to the search PR)
Search field / `.searchable` / search-role tab / empty-result state. Row metadata unchanged (category · ~N inferences); sheep×N · rounds deferred (no `GalleryScenario` schema field) — needs a gallery-feed schema follow-up.

## Test plan
- Full suite (unit + UI incl. `NavigationRegressionTests`, navbar assertion updated in lockstep): **TEST SUCCEEDED**
- `swiftlint lint --strict`: exit 0
- `check_localization_coverage.py`: OK (514 keys, all `ja` translated)
- code-reviewer (Opus): PASS, 0 issues
- **Pending: iOS 26 on-device visual QA** for chip colors / layout (simulator rendering is representative for custom Capsule pills, but device QA recommended).

Closes #687
