### PR TITLE
✨ feat: Browse tab scenario search (searchable)

### DIFF
--- a/Pastura/Pastura/App/Community/Gallery/GalleryScenarioSearch.swift
+++ b/Pastura/Pastura/App/Community/Gallery/GalleryScenarioSearch.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// Pure, side-effect-free search/filter projection for the Browse (さがす)
+/// tab's curated gallery. Drives `SharedScenariosViewModel.visibleScenarios`
+/// and `.emptyReason`.
+///
+/// Kept `nonisolated` and dependency-free (plain `[GalleryScenario]` +
+/// category + query inputs, no ViewModel reference) so the filtering and the
+/// empty-state classification are unit-testable without rendering or a
+/// `@MainActor` hop (ADR-009 / `.claude/rules/view-testing.md`). Sibling of
+/// `GalleryCategoryFilter`, which models the chip presentation; this type
+/// models the actual data filtering those chips (plus the search field) feed.
+nonisolated enum GalleryScenarioSearch {
+
+  /// Returns the scenarios matching both the category filter and the search
+  /// query.
+  ///
+  /// - `category == nil` means "all categories" (no category narrowing).
+  /// - A blank or whitespace-only `query` applies no text filter; otherwise
+  ///   a scenario matches when the query is a substring of its `title` or
+  ///   `description`. Matching uses `localizedStandardContains` — the
+  ///   Finder-like case- and diacritic-insensitive comparison appropriate
+  ///   for user-facing search.
+  static func filter(
+    _ scenarios: [GalleryScenario], category: GalleryCategory?, query: String
+  ) -> [GalleryScenario] {
+    let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+    return scenarios.filter { scenario in
+      if let category, scenario.category != category { return false }
+      guard !trimmed.isEmpty else { return true }
+      return scenario.title.localizedStandardContains(trimmed)
+        || scenario.description.localizedStandardContains(trimmed)
+    }
+  }
+
+  /// Why the filtered list came back empty — selects the empty-card copy.
+  ///
+  /// Only meaningful when `filter(...)` actually returned an empty result.
+  /// `galleryEmpty` (the curated gallery loaded successfully but shipped
+  /// zero scenarios) is deliberately distinct from
+  /// `SharedScenariosViewModel.LoadState.empty` (network-down, no cache),
+  /// which is rendered by the top-level state switch — not the card — so a
+  /// reader must not conflate the two.
+  enum EmptyReason: Equatable, Sendable {
+    /// A non-blank search query matched nothing.
+    case noMatchingQuery
+    /// A selected category contains no scenarios (no active query).
+    case emptyCategory
+    /// The gallery itself is empty (no query, no category narrowing).
+    case galleryEmpty
+  }
+
+  /// Classifies why a filtered-empty Browse list is empty.
+  ///
+  /// Precedence: a genuinely empty gallery dominates (the user's
+  /// category/query is moot when there is nothing to filter), then a present
+  /// query, then a selected category.
+  static func emptyReason(
+    allScenariosEmpty: Bool, category: GalleryCategory?, query: String
+  ) -> EmptyReason {
+    if allScenariosEmpty { return .galleryEmpty }
+    let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+    if !trimmed.isEmpty { return .noMatchingQuery }
+    if category != nil { return .emptyCategory }
+    return .galleryEmpty
+  }
+}

--- a/Pastura/Pastura/App/Community/Gallery/GalleryScenarioSearch.swift
+++ b/Pastura/Pastura/App/Community/Gallery/GalleryScenarioSearch.swift
@@ -7,9 +7,10 @@ import Foundation
 /// Kept `nonisolated` and dependency-free (plain `[GalleryScenario]` +
 /// category + query inputs, no ViewModel reference) so the filtering and the
 /// empty-state classification are unit-testable without rendering or a
-/// `@MainActor` hop (ADR-009 / `.claude/rules/view-testing.md`). Sibling of
-/// `GalleryCategoryFilter`, which models the chip presentation; this type
-/// models the actual data filtering those chips (plus the search field) feed.
+/// `@MainActor` hop (ADR-009 / `.claude/rules/view-testing.md`). Counterpart
+/// to `GalleryCategoryFilter` (in `Views/`, which models the chip
+/// presentation); this type models the actual data filtering those chips
+/// (plus the search field) feed.
 nonisolated enum GalleryScenarioSearch {
 
   /// Returns the scenarios matching both the category filter and the search

--- a/Pastura/Pastura/App/Community/Gallery/SharedScenariosViewModel.swift
+++ b/Pastura/Pastura/App/Community/Gallery/SharedScenariosViewModel.swift
@@ -48,15 +48,29 @@ final class SharedScenariosViewModel {
   /// `nil` means "all categories".
   var selectedCategory: GalleryCategory?
 
+  /// The Browse-tab search field text. Blank / whitespace-only applies no
+  /// text filter (see ``GalleryScenarioSearch/filter(_:category:query:)``).
+  var searchQuery: String = ""
+
   /// Rows keyed by `sourceId` for the subset of scenarios whose
   /// `sourceType == "gallery"` and whose `sourceId` is non-nil. Rebuilt
   /// after every load and save so UI bindings can read synchronously.
   private(set) var installedBySourceId: [String: ScenarioRecord] = [:]
 
-  /// Filtered view based on `selectedCategory`.
+  /// Filtered view based on `selectedCategory` AND `searchQuery`. The actual
+  /// filtering lives in the pure ``GalleryScenarioSearch`` so it is
+  /// unit-testable without the ViewModel (ADR-009).
   var visibleScenarios: [GalleryScenario] {
-    guard let category = selectedCategory else { return allScenarios }
-    return allScenarios.filter { $0.category == category }
+    GalleryScenarioSearch.filter(
+      allScenarios, category: selectedCategory, query: searchQuery)
+  }
+
+  /// Why ``visibleScenarios`` is empty — drives the empty-card copy. Only
+  /// meaningful when ``visibleScenarios`` is actually empty.
+  var emptyReason: GalleryScenarioSearch.EmptyReason {
+    GalleryScenarioSearch.emptyReason(
+      allScenariosEmpty: allScenarios.isEmpty,
+      category: selectedCategory, query: searchQuery)
   }
 
   private let galleryService: any GalleryService

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -3667,12 +3667,32 @@
         }
       }
     },
+    "No scenarios available yet." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "まだシナリオがありません。"
+          }
+        }
+      }
+    },
     "No scenarios in this category." : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "このカテゴリにシナリオはありません。"
+          }
+        }
+      }
+    },
+    "No scenarios match \"%@\"." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「%@」に一致するシナリオはありません。"
           }
         }
       }
@@ -4854,6 +4874,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "スコアリングロジック"
+          }
+        }
+      }
+    },
+    "Search scenarios" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シナリオを検索"
           }
         }
       }

--- a/Pastura/Pastura/Views/Community/SharedScenarios/SharedScenariosListView.swift
+++ b/Pastura/Pastura/Views/Community/SharedScenarios/SharedScenariosListView.swift
@@ -19,6 +19,12 @@ struct SharedScenariosListView: View {
     .navigationTitle(String(localized: "Browse Shared Scenarios"))
     // Inline title to match the other tab roots (design-system § 5.11).
     .navigationBarTitleDisplayMode(.inline)
+    // Attach `.searchable` at the body boundary (mirroring ResultsView's
+    // `AggregateSearchable`), NOT inside `scenarioList`'s ScrollView — so the
+    // field is owned by the tab root's NavigationStack bar and is stable
+    // across `state` transitions. Gated to the loaded states: searching the
+    // loading / network-unavailable / error screens is meaningless.
+    .modifier(GallerySearchable(enabled: isSearchEnabled, text: searchQueryBinding))
     .task {
       let newViewModel = SharedScenariosViewModel(
         galleryService: dependencies.galleryService,
@@ -26,6 +32,23 @@ struct SharedScenariosListView: View {
       viewModel = newViewModel
       await newViewModel.load()
     }
+  }
+
+  /// True only in the states that render a searchable scenario list.
+  private var isSearchEnabled: Bool {
+    guard let viewModel else { return false }
+    switch viewModel.state {
+    case .loaded, .offlineWithCache: return true
+    case .idle, .loading, .empty, .error: return false
+    }
+  }
+
+  /// Bridges the `.searchable` field to the optional ViewModel's
+  /// `searchQuery` (the VM is created lazily in `.task`).
+  private var searchQueryBinding: Binding<String> {
+    Binding(
+      get: { viewModel?.searchQuery ?? "" },
+      set: { viewModel?.searchQuery = $0 })
   }
 
   @ViewBuilder
@@ -107,7 +130,7 @@ struct SharedScenariosListView: View {
   private func scenariosCard(viewModel: SharedScenariosViewModel) -> some View {
     if viewModel.visibleScenarios.isEmpty {
       PasturaSection {
-        Text(String(localized: "No scenarios in this category."))
+        Text(emptyResultsMessage(viewModel: viewModel))
           .foregroundStyle(Color.inkSecondary)
           .frame(maxWidth: .infinity, alignment: .leading)
           .padding(.horizontal, 17)
@@ -127,6 +150,23 @@ struct SharedScenariosListView: View {
           }
         }
       }
+    }
+  }
+
+  /// Context-accurate copy for the empty scenarios card — distinguishes
+  /// "no search match" (with the query echoed), "category is empty", and
+  /// "gallery shipped nothing". The query echo uses the `String(format:)`
+  /// form (i18n Form B), never `\(query)` interpolation, which would
+  /// silently fall back to English on a ja device (.claude/rules/i18n.md).
+  private func emptyResultsMessage(viewModel: SharedScenariosViewModel) -> String {
+    switch viewModel.emptyReason {
+    case .noMatchingQuery:
+      return String(
+        format: String(localized: "No scenarios match \"%@\"."), viewModel.searchQuery)
+    case .emptyCategory:
+      return String(localized: "No scenarios in this category.")
+    case .galleryEmpty:
+      return String(localized: "No scenarios available yet.")
     }
   }
 
@@ -276,6 +316,27 @@ extension GalleryCategory {
     case .roleplay: return String(localized: "Roleplay")
     case .creative: return String(localized: "Creative")
     case .experimental: return String(localized: "Experimental")
+    }
+  }
+}
+
+/// Attaches the scenario `.searchable` field to the Browse tab, but only when
+/// a list is actually on screen (`enabled`). Mirrors ResultsView's
+/// `AggregateSearchable`: applied at the `body` boundary so the field lives on
+/// the tab root's NavigationStack bar rather than inside a state-specific
+/// subtree, keeping it stable across `LoadState` transitions.
+private struct GallerySearchable: ViewModifier {
+  let enabled: Bool
+  @Binding var text: String
+
+  func body(content: Content) -> some View {
+    if enabled {
+      content.searchable(
+        text: $text,
+        placement: .navigationBarDrawer(displayMode: .always),
+        prompt: Text(String(localized: "Search scenarios")))
+    } else {
+      content
     }
   }
 }

--- a/Pastura/PasturaTests/App/Community/Gallery/GalleryScenarioSearchTests.swift
+++ b/Pastura/PasturaTests/App/Community/Gallery/GalleryScenarioSearchTests.swift
@@ -1,0 +1,130 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+/// Unit tests for the Browse tab's pure search/filter projection
+/// (`GalleryScenarioSearch`). Covers the category-AND-query filtering and
+/// the `EmptyReason` classification that drives the empty-card copy.
+/// Asserts logic properties only, never rendered output
+/// (ADR-009 / `.claude/rules/view-testing.md`).
+///
+/// `@MainActor` on the suite sidesteps swift-isolation Pattern 5: a
+/// nonisolated test calling `==` on the auto-synthesized `Equatable`
+/// `EmptyReason` enum would otherwise fail the MainActor-isolated
+/// conformance-lookup check. Matches `SharedScenariosCategoryFilterTests`.
+@MainActor
+@Suite(.timeLimit(.minutes(1)))
+struct GalleryScenarioSearchTests {
+
+  // MARK: - Fixtures
+
+  private func scenario(
+    id: String, title: String, description: String, category: GalleryCategory
+  ) -> GalleryScenario {
+    GalleryScenario(
+      id: id, title: title, category: category,
+      description: description, author: "Author",
+      recommendedModel: ModelRegistry.gemma4E2B.id, estimatedInferences: 10,
+      // swiftlint:disable:next force_unwrapping
+      yamlURL: URL(string: "https://example.com/\(id).yaml")!,
+      yamlSHA256: "hash", addedAt: "2026-01-01")
+  }
+
+  private var sample: [GalleryScenario] {
+    [
+      scenario(
+        id: "asch", title: "Asch Conformity",
+        description: "Conformity under social pressure", category: .socialPsychology),
+      scenario(
+        id: "pd", title: "Prisoner's Dilemma",
+        description: "Cooperate or defect", category: .gameTheory),
+      scenario(
+        id: "trolley", title: "Trolley Problem",
+        description: "An ethical dilemma about sacrifice", category: .ethics)
+    ]
+  }
+
+  // MARK: - Category filtering
+
+  @Test func nilCategoryReturnsEverythingWhenNoQuery() {
+    let result = GalleryScenarioSearch.filter(sample, category: nil, query: "")
+    #expect(result.count == 3)
+  }
+
+  @Test func categoryNarrowsToThatCategory() {
+    let result = GalleryScenarioSearch.filter(sample, category: .gameTheory, query: "")
+    #expect(result.map(\.id) == ["pd"])
+  }
+
+  // MARK: - Query filtering
+
+  @Test func queryMatchesTitleSubstring() {
+    let result = GalleryScenarioSearch.filter(sample, category: nil, query: "trolley")
+    #expect(result.map(\.id) == ["trolley"])
+  }
+
+  @Test func queryMatchesDescriptionSubstring() {
+    let result = GalleryScenarioSearch.filter(sample, category: nil, query: "defect")
+    #expect(result.map(\.id) == ["pd"])
+  }
+
+  @Test func queryIsCaseInsensitive() {
+    let result = GalleryScenarioSearch.filter(sample, category: nil, query: "ASCH")
+    #expect(result.map(\.id) == ["asch"])
+  }
+
+  @Test func whitespaceOnlyQueryAppliesNoTextFilter() {
+    // A whitespace-only query must not collapse the list to empty — it is
+    // treated as "no query", so the category filter alone decides the result.
+    let result = GalleryScenarioSearch.filter(sample, category: .ethics, query: "   ")
+    #expect(result.map(\.id) == ["trolley"])
+  }
+
+  @Test func categoryAndQueryCombineWithAnd() {
+    // "dilemma" matches Prisoner's Dilemma (title) AND Trolley Problem
+    // (description), but the .ethics category narrows it to just Trolley.
+    let result = GalleryScenarioSearch.filter(sample, category: .ethics, query: "dilemma")
+    #expect(result.map(\.id) == ["trolley"])
+  }
+
+  @Test func nonMatchingQueryReturnsEmpty() {
+    let result = GalleryScenarioSearch.filter(sample, category: nil, query: "zzzznomatch")
+    #expect(result.isEmpty)
+  }
+
+  // MARK: - EmptyReason classification
+
+  @Test func emptyReasonIsNoMatchingQueryWhenQueryPresent() {
+    let reason = GalleryScenarioSearch.emptyReason(
+      allScenariosEmpty: false, category: nil, query: "zzz")
+    #expect(reason == .noMatchingQuery)
+  }
+
+  @Test func emptyReasonIsNoMatchingQueryEvenWithCategory() {
+    // A present query takes precedence over category in the empty-state copy.
+    let reason = GalleryScenarioSearch.emptyReason(
+      allScenariosEmpty: false, category: .ethics, query: "zzz")
+    #expect(reason == .noMatchingQuery)
+  }
+
+  @Test func emptyReasonIsEmptyCategoryWhenCategoryFilteredAll() {
+    let reason = GalleryScenarioSearch.emptyReason(
+      allScenariosEmpty: false, category: .creative, query: "")
+    #expect(reason == .emptyCategory)
+  }
+
+  @Test func emptyReasonIsGalleryEmptyWhenNoQueryNoCategory() {
+    let reason = GalleryScenarioSearch.emptyReason(
+      allScenariosEmpty: true, category: nil, query: "")
+    #expect(reason == .galleryEmpty)
+  }
+
+  @Test func emptyReasonIsGalleryEmptyWhenGalleryEmptyTakesPrecedence() {
+    // When the curated gallery itself shipped zero scenarios, that fact
+    // dominates over any category/query the user happens to have set.
+    let reason = GalleryScenarioSearch.emptyReason(
+      allScenariosEmpty: true, category: .ethics, query: "anything")
+    #expect(reason == .galleryEmpty)
+  }
+}


### PR DESCRIPTION
## Summary
P4 "共有/Browse (さがす)" tab follow-up after the layout-migration PR (#688).
Adds an in-tab search field and makes the empty-result card context-accurate.

- **Search field** — `.searchable` on the Browse tab root, filtering curated
  gallery scenarios by title/description (case- & diacritic-insensitive
  `localizedStandardContains`), combined AND with the existing category chips.
  Attached via a `GallerySearchable` ViewModifier at the body boundary
  (mirroring ResultsView's `AggregateSearchable`), gated to the loaded states.
- **Context-accurate empty state** — the old single "No scenarios in this
  category." card now picks copy from a 3-way `EmptyReason`: no-match (query
  echoed via i18n Form B), empty category, or empty gallery.
- **Pure logic extraction** — new `nonisolated GalleryScenarioSearch`
  (filter + EmptyReason) unit-tested without the ViewModel (ADR-009).
- i18n: 3 new keys + ja (`check_localization_coverage.py` green).

## Out of scope (follow-up — see #693)
- **iOS 26 search-role tab morphing** (`Tab(role:.search)` /
  `.tabViewBottomAccessory`) — needs `RootTabView` restructure + availability
  branching + iOS 26 device QA; aligns with the deferred comment in
  `RootTabView.swift`.
- **Sheep×N · rounds row in Browse** — blocked on `GalleryScenario` lacking
  `agentCount`/`rounds` (gallery feed schema extension).

## Test plan
- New `GalleryScenarioSearchTests` (13 tests) — filter + EmptyReason.
- Full unit suite: 2033 tests green.
- UI: `NavigationRegressionTests` + `DeepLinkTabRoutingUITests` green
  (Browse navbar unaffected by the search bar).
- swiftlint --strict clean; i18n coverage OK.
- **Pending human gate**: real-device QA (iOS 17–25 & 26) for the search bar
  visual + ja-locale empty-state copy.

Closes #691.

🤖 Generated with [Claude Code](https://claude.com/claude-code)