### PR TITLE
🐛 fix: left-align Past Results rows (fill row width)

### DIFF
--- a/Pastura/Pastura/Views/Results/ResultsView.swift
+++ b/Pastura/Pastura/Views/Results/ResultsView.swift
@@ -194,6 +194,11 @@ struct ResultsView: View {
         statusBadge(item.simulationStatus)
       }
     }
+    // Fill the row width so every row's title/meta left-aligns at the same x.
+    // Without this the VStack sizes to its content and the enclosing
+    // `resultRow` HStack (no Spacer) centers the group, so each row's left edge
+    // drifts with its content width. The chevron then rides the trailing edge.
+    .frame(maxWidth: .infinity, alignment: .leading)
   }
 
   /// One sheep avatar per agent (clamped via ``ResultsRowFormat/rowSheepCount``).


### PR DESCRIPTION
## Summary

On the 観察履歴 (Past Results) list, each row's title/meta **left edge drifted horizontally per row** (rows rendered centered instead of left-aligned) — see the reported screenshot.

**Cause**: PR #703 commit 4 moved the row's status badge to a fallback (shown only when there's no summary) and removed the `Spacer()` from the meta-line `HStack`. That `Spacer()` had *incidentally* made the row `VStack(alignment: .leading)` fill the full width. Without it the VStack sizes to its content, and the enclosing `resultRow` `HStack(spacing: 10) { simulationRow; chevron }` (no Spacer) centers the group — so each row's left edge shifted with its content width (sheep count, summary/title length).

**Fix**: add `.frame(maxWidth: .infinity, alignment: .leading)` to the `simulationRow` VStack so it fills the row width and left-aligns; the chevron then rides the trailing edge. Codebase-idiomatic (matches `PasturaCard` / `AgentOutputRow`). A why-comment guards against a future refactor re-removing it (the exact PR #703 regression shape).

## Test plan

- Frame/alignment bug ⇒ **no automated test** (out of scope per ADR-009 / `.claude/rules/view-testing.md` rule 4 — manual QA + code-review gate). Build green; `code-reviewer` (Opus) PASS (0 issues); critic (pre-impl) all-OK.
- **Manual QA (device, ja)**: confirm title/meta left edges align across rows of differing sheep-count and summary length, **including at least one badge-fallback row** (running / failed / cancelled) alongside completed rows, and at Dynamic Type XXL (no clipping).

Closes #709