### PR TITLE
✨ feat: relative timestamps below summary in Past Results rows

### DIFF
--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -826,6 +826,36 @@
         }
       }
     },
+    "%lld days ago" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld日前"
+          }
+        }
+      }
+    },
+    "%lld hours ago" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld時間前"
+          }
+        }
+      }
+    },
+    "%lld minutes ago" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld分前"
+          }
+        }
+      }
+    },
     "%lld pts" : {
       "localizations" : {
         "ja" : {
@@ -1281,6 +1311,36 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "- 🎲 このラウンドはイベントなし"
+          }
+        }
+      }
+    },
+    "1 day ago" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1日前"
+          }
+        }
+      }
+    },
+    "1 hour ago" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1時間前"
+          }
+        }
+      }
+    },
+    "1 minute ago" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1分前"
           }
         }
       }
@@ -3284,6 +3344,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "日本語"
+          }
+        }
+      }
+    },
+    "Just now" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "たった今"
           }
         }
       }

--- a/Pastura/Pastura/Views/Results/ResultsRowFormat.swift
+++ b/Pastura/Pastura/Views/Results/ResultsRowFormat.swift
@@ -205,6 +205,10 @@ nonisolated enum ResultsRowFormat {
     let formatter = DateFormatter()
     formatter.calendar = calendar
     formatter.locale = calendar.locale ?? Locale.current
+    // Pin the zone to the injected calendar's (not DateFormatter's default
+    // `TimeZone.current`) so the rendered day/year agrees with the `sameYear`
+    // extraction above for any injected calendar — full test determinism.
+    formatter.timeZone = calendar.timeZone
     formatter.setLocalizedDateFormatFromTemplate(sameYear ? "MMMd" : "yMMMd")
     return formatter.string(from: date)
   }

--- a/Pastura/Pastura/Views/Results/ResultsRowFormat.swift
+++ b/Pastura/Pastura/Views/Results/ResultsRowFormat.swift
@@ -150,4 +150,62 @@ nonisolated enum ResultsRowFormat {
     guard let agentCount, agentCount > 0 else { return 0 }
     return min(agentCount, maxRowSheep)
   }
+
+  // MARK: - Relative timestamp (#712)
+
+  /// A relative, X / Instagram-style timestamp for a History row: "Just now" /
+  /// "N minutes / hours / days ago" for recent runs, then a locale-formatted
+  /// absolute date ("Jun 11" this year, "Nov 10, 2025" earlier).
+  ///
+  /// The tiers use **elapsed time** (`now − date`), deliberately independent of
+  /// the section header's **calendar-day** bucket (Today / This Week / …) — so a
+  /// run from 22:00 yesterday, read at 09:00, sits under "This Week" yet shows
+  /// "11 hours ago". The two are complementary, not contradictory.
+  ///
+  /// English singular forms are separate keys (n == 1) so "1 hour ago" never
+  /// renders as the ungrammatical "1 hours ago"; Japanese has no plural so both
+  /// map to the same shape (1時間前 / N時間前). A future date (clock skew,
+  /// `delta ≤ 0`) collapses to "Just now".
+  ///
+  /// - Parameters:
+  ///   - now / calendar: injectable so the elapsed-time tiers and the
+  ///     locale-driven absolute date are deterministic in tests (production
+  ///     passes `Date()` / `Calendar.current`).
+  static func relativeTimestamp(for date: Date, now: Date, calendar: Calendar) -> String {
+    let delta = now.timeIntervalSince(date)
+    if delta < 60 { return String(localized: "Just now") }
+    if delta < 3600 {
+      let minutes = Int(delta / 60)
+      return minutes == 1
+        ? String(localized: "1 minute ago")
+        : String(format: String(localized: "%lld minutes ago"), minutes)
+    }
+    if delta < 86_400 {
+      let hours = Int(delta / 3600)
+      return hours == 1
+        ? String(localized: "1 hour ago")
+        : String(format: String(localized: "%lld hours ago"), hours)
+    }
+    if delta < 7 * 86_400 {
+      let days = Int(delta / 86_400)
+      return days == 1
+        ? String(localized: "1 day ago")
+        : String(format: String(localized: "%lld days ago"), days)
+    }
+    return absoluteDate(for: date, now: now, calendar: calendar)
+  }
+
+  /// Locale-formatted absolute date for an older run — month + day this year,
+  /// month + day + year for a prior year. Mirrors ``monthHeading``'s mechanism
+  /// (a `DateFormatter` keyed off the injected calendar's locale) with a day
+  /// component, so the ja "6月11日" / "2025年11月10日" ordering is CLDR-driven.
+  private static func absoluteDate(for date: Date, now: Date, calendar: Calendar) -> String {
+    let sameYear =
+      calendar.component(.year, from: date) == calendar.component(.year, from: now)
+    let formatter = DateFormatter()
+    formatter.calendar = calendar
+    formatter.locale = calendar.locale ?? Locale.current
+    formatter.setLocalizedDateFormatFromTemplate(sameYear ? "MMMd" : "yMMMd")
+    return formatter.string(from: date)
+  }
 }

--- a/Pastura/Pastura/Views/Results/ResultsView.swift
+++ b/Pastura/Pastura/Views/Results/ResultsView.swift
@@ -155,12 +155,11 @@ struct ResultsView: View {
     .contentShape(Rectangle())
   }
 
-  // Each row shows the simulation-time `variantName` (`.headline` font,
-  // matching HomeView preset list role-weight) — the variant's un-translated
-  // name (or the captured snapshot for a deleted scenario), kept consistent
-  // with the run's recorded conversation content. The meta line carries one
-  // sheep avatar per agent (clamped) plus the timestamp; the result summary
-  // (P5 PR2) replaces the raw score chips with the archetype-safe ladder.
+  // Each row stacks: the simulation-time `variantName` (`.headline`, the
+  // variant's un-translated name or the deleted-scenario snapshot); a sheep
+  // avatar per agent (clamped); the archetype-safe result summary (P5 PR2,
+  // replacing the raw score chips); and a relative timestamp (#712) at the
+  // bottom, left-aligned.
   private func simulationRow(_ row: ResultsViewModel.SimulationRow) -> some View {
     let item = row.item
     let sheepCount = ResultsRowFormat.rowSheepCount(agentCount: row.agentCount)
@@ -173,15 +172,11 @@ struct ResultsView: View {
       Text(row.variantName)
         .font(.headline)
         .foregroundStyle(Color.ink)
-      HStack(spacing: 7) {
-        if sheepCount > 0 {
-          sheepCluster(count: sheepCount, agentCount: row.agentCount)
-        }
-        Text(item.createdAt, style: .date)
-        Text(item.createdAt, style: .time)
+      // Sheep avatars only — the timestamp moved to the bottom line. Guard the
+      // whole row so an unknown agent count (sheepCount 0) leaves no empty gap.
+      if sheepCount > 0 {
+        sheepCluster(count: sheepCount, agentCount: row.agentCount)
       }
-      .font(.subheadline)
-      .foregroundStyle(Color.inkSecondary)
 
       // The archetype-safe result summary — or, when no summary applies
       // (running / failed / cancelled), the status badge as a fallback so the
@@ -193,6 +188,16 @@ struct ResultsView: View {
       } else {
         statusBadge(item.simulationStatus)
       }
+
+      // Relative timestamp (X / Instagram-style), below the summary/status.
+      // Computed in the View off the live clock — formatting stays in the Views
+      // layer, like the summary above.
+      Text(
+        ResultsRowFormat.relativeTimestamp(
+          for: item.createdAt, now: Date(), calendar: .current)
+      )
+      .font(.caption)
+      .foregroundStyle(Color.muted)
     }
     // Fill the row width so every row's title/meta left-aligns at the same x.
     // Without this the VStack sizes to its content and the enclosing

--- a/Pastura/PasturaTests/Views/ResultsRowFormatTests.swift
+++ b/Pastura/PasturaTests/Views/ResultsRowFormatTests.swift
@@ -234,4 +234,108 @@ struct ResultsRowFormatTests {
     #expect(ResultsRowFormat.rowSheepCount(agentCount: nil) == 0)
     #expect(ResultsRowFormat.rowSheepCount(agentCount: 0) == 0)
   }
+
+  // MARK: - Relative timestamp (#712)
+
+  /// `relativeTimestamp` for a run `secondsAgo` before `now`.
+  private func rel(_ now: Date, _ secondsAgo: Double, _ cal: Calendar) -> String {
+    ResultsRowFormat.relativeTimestamp(
+      for: now.addingTimeInterval(-secondsAgo), now: now, calendar: cal)
+  }
+
+  // The relative-tier *copy* comes from `String(localized:)` (device locale), so
+  // the exact words aren't asserted; the locale-independent numeral IS. The
+  // absolute-date tier is driven by the injected en_US_POSIX calendar, so its
+  // month/year ARE asserted exactly (mirrors the date-bucket tests above).
+
+  @Test func relativeJustNowCarriesNoNumber() {
+    let cal = fixedCalendar()
+    let now = date(cal, 2026, 6, 17, 12)
+    // < 60s (and the 59s edge) → "Just now" / "たった今" — no numeral.
+    for secondsAgo in [0.0, 30.0, 59.0] {
+      let result = rel(now, secondsAgo, cal)
+      #expect(result.rangeOfCharacter(from: .decimalDigits) == nil)
+    }
+  }
+
+  @Test func relativeFutureDateCollapsesToJustNow() {
+    let cal = fixedCalendar()
+    let now = date(cal, 2026, 6, 17, 12)
+    // Clock skew (date after now) → "Just now", never a negative number.
+    let result = ResultsRowFormat.relativeTimestamp(
+      for: now.addingTimeInterval(3600), now: now, calendar: cal)
+    #expect(result.rangeOfCharacter(from: .decimalDigits) == nil)
+  }
+
+  @Test func relativeMinutesTier() {
+    let cal = fixedCalendar()
+    let now = date(cal, 2026, 6, 17, 12)
+    #expect(rel(now, 60, cal).contains("1"))  // 60s → singular
+    #expect(rel(now, 330, cal).contains("5"))  // 5m30s → 5
+    #expect(rel(now, 3599, cal).contains("59"))  // 59m59s → still minutes
+  }
+
+  @Test func relativeHoursTierStartsAtExactly3600s() {
+    let cal = fixedCalendar()
+    let now = date(cal, 2026, 6, 17, 12)
+    let oneHour = rel(now, 3600, cal)  // exactly 1h → hours tier, not "59 min"
+    #expect(oneHour.contains("1"))
+    #expect(!oneHour.contains("59"))
+    #expect(rel(now, 23 * 3600, cal).contains("23"))
+  }
+
+  @Test func relativeDaysTierStartsAtExactly24h() {
+    let cal = fixedCalendar()
+    let now = date(cal, 2026, 6, 17, 12)
+    let oneDay = rel(now, 86_400, cal)  // exactly 24h → days tier, not "24 hours"
+    #expect(oneDay.contains("1"))
+    #expect(!oneDay.contains("24"))
+    #expect(rel(now, 6 * 86_400, cal).contains("6"))
+  }
+
+  @Test func relativeTierBoundariesSelectDistinctCopy() {
+    // The numeral "1" is shared by the minute/hour/day singular forms, so assert
+    // the tiers pick *different* copy (locale-robust: ja 1分前/1時間前/1日前 differ).
+    let cal = fixedCalendar()
+    let now = date(cal, 2026, 6, 17, 12)
+    #expect(rel(now, 60, cal) != rel(now, 3600, cal))
+    #expect(rel(now, 3600, cal) != rel(now, 86_400, cal))
+  }
+
+  @Test func relativeSevenDaysSwitchesToAbsoluteDate() {
+    let cal = fixedCalendar()
+    let now = date(cal, 2026, 6, 17, 12)
+    // Exactly 7 days → absolute date tier (en_US_POSIX MMMd → "Jun 10").
+    #expect(rel(now, 7 * 86_400, cal).contains("Jun"))
+  }
+
+  @Test func relativeSameYearDateOmitsYear() {
+    let cal = fixedCalendar()
+    let now = date(cal, 2026, 6, 17, 12)
+    // 14 days ago, same year → "Jun 3" (month + day, no year).
+    let result = ResultsRowFormat.relativeTimestamp(
+      for: date(cal, 2026, 6, 3, 12), now: now, calendar: cal)
+    #expect(result.contains("Jun"))
+    #expect(!result.contains("2026"))
+  }
+
+  @Test func relativePriorYearDateCarriesYear() {
+    let cal = fixedCalendar()
+    let now = date(cal, 2026, 6, 17, 12)
+    let result = ResultsRowFormat.relativeTimestamp(
+      for: date(cal, 2025, 11, 10, 12), now: now, calendar: cal)
+    #expect(result.contains("Nov"))
+    #expect(result.contains("2025"))
+  }
+
+  @Test func relativeCrossYearNearSevenDaysUsesPriorYearDate() {
+    // 8 days ago across the year boundary → absolute date tier, prior-year form
+    // (the one case where a reader might fear a 7-day/date-tier gap).
+    let cal = fixedCalendar()
+    let now = date(cal, 2026, 1, 3, 12)
+    let result = ResultsRowFormat.relativeTimestamp(
+      for: date(cal, 2025, 12, 26, 12), now: now, calendar: cal)
+    #expect(result.contains("Dec"))
+    #expect(result.contains("2025"))
+  }
 }


### PR DESCRIPTION
## Summary

Polishes the 観察履歴 (Past Results) row per QA feedback on #703/#710:

- **Timestamp moved below the summary**, left-aligned. Previously it sat on the meta line right after the variable-width sheep cluster, so its x-position drifted per row. The meta line is now **sheep-avatars-only**.
- **Relative, X/Instagram-style format** (`ResultsRowFormat.relativeTimestamp`, pure + unit-tested): `Just now` / `N minutes·hours·days ago` (elapsed time, `floor`) for recent runs, then a locale-formatted absolute date — `Jun 11` this year, `Nov 10, 2025` earlier (ja: `たった今` / `N分前` / `N時間前` / `N日前` / `6月11日` / `2025年11月10日`). Future dates (clock skew) collapse to `Just now`.

New row layout: name → sheep×N → summary/status → relative timestamp.

Notes:
- English singular forms are **separate keys** (`1 hour ago`, not `1 hours ago`); ja has no plural so both map to one form. 7 new i18n keys + ja.
- The relative tiers use elapsed time, **deliberately independent** of the section header's calendar-day buckets (Today / This Week / …) — complementary, not contradictory.
- The absolute-date tier reuses the shipped `monthHeading` DateFormatter mechanism (locale + timeZone pinned to the injected calendar).
- The sheep row is guarded on `sheepCount > 0` so an unknown agent count leaves no empty gap.

critic (pre-impl, no Critical) + code-reviewer (Opus) **PASS** (0C/0W; one timeZone-determinism suggestion applied).

## Test plan

- New unit tests (10) in `ResultsRowFormatTests`: every tier, exact ceilings (3600s→hours, 86400s→days, 7d→date), tier-selection (distinct copy at boundaries), same/prior-year date forms, the cross-year-near-7-day case, and future dates — asserting the locale-independent numeral + the en_US_POSIX-pinned absolute date.
- Full unit suite green; `swiftlint --strict` clean; `check_localization_coverage.py` OK (533 keys).
- **Manual QA (device, ja & en)**: timestamp reads correctly across tiers (minutes / hours / days / dates); ja `6月11日` / `2025年11月10日`; left edges align across rows incl. a **badge-fallback row** (running/failed) and a **sheepCount-0 row** (no phantom gap); VoiceOver reading order title → … → timestamp is sensible.

Closes #712