### PR TITLE
♻️ refactor: clarify misleading throwSuspended mock helper + document park asymmetry

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -164,6 +164,33 @@ PR #474 (#220 W3 PR-B).
   exhausted — this is intentional to catch over/under-provisioning.
 - Use `mock.capturedPrompts` to verify prompt content in tests.
 
+## Parking a run mid-flight (teardown / cancel tests)
+
+To hold a `SimulationViewModel.run()` / `resume()` genuinely parked mid-flight
+(e.g. to test a raw `Task.cancel()` teardown), arm the controller at attach
+time: call `mock.suspendOnControllerAttach()` **before** starting the run. That
+puts the live `SuspendController` in `.suspended` the instant the run attaches
+it — before the first generate — so the run parks deterministically, with no
+scheduling window.
+
+Do **not**:
+
+- Use `mock.throwSuspendedOnNextGenerate()` as a park. It only schedules a
+  `.suspended` throw; the controller stays `.idle`, `awaitResume()` returns
+  immediately, and the run keeps running (that helper is for unit-testing the
+  suspend-retry loop, not parking).
+- Arm `sut.suspendController?.requestSuspend()` from the test **after** the run
+  starts on the **resume** path. `run()` has an awaited `createSimulationRecord`
+  hop before its first generate that yields a window, but `resume()` does not —
+  its `.instant` Engine burst (unbuffered `AsyncStream`, no backpressure) races
+  the arm and the run completes → `.completed` flake (#707).
+- Route through `pauseSimulation()` when the test pins the `!isCompleted`
+  teardown branch (#673) — it sets `didPersistPaused` and shifts the ladder.
+
+Full mechanism + the wait helper live in `parkRunMidFlight`
+(`SimulationViewModelStatusTests+ResumeContinuation.swift`) and the
+`suspendOnControllerAttach()` doc-comment — point there, don't re-derive.
+
 ## Shared Test Helpers (`EngineTestHelpers.swift`)
 
 - **`EventCollector`**: Thread-safe event collector for `@Sendable` emitter closures.

--- a/Pastura/Pastura/LLM/MockLLMService.swift
+++ b/Pastura/Pastura/LLM/MockLLMService.swift
@@ -107,7 +107,7 @@ nonisolated public final class MockLLMService: LLMService, @unchecked Sendable {
   /// Make ``attachSuspendController(_:)`` arm the controller's suspend on attach,
   /// so a run parks GENUINELY at its first generate with no scheduling race.
   ///
-  /// Unlike ``simulateSuspendOnNextGenerate()`` (which pre-schedules a throw but
+  /// Unlike ``throwSuspendedOnNextGenerate()`` (which pre-schedules a throw but
   /// leaves the controller `.idle`, so `awaitResume()` returns immediately and
   /// the run never blocks), this puts the live controller in `.suspended` before
   /// the first generate — `awaitResume()` then genuinely parks until the run is
@@ -266,10 +266,14 @@ nonisolated public final class MockLLMService: LLMService, @unchecked Sendable {
   /// the configured sequence (the response at the current `callIndex` is not
   /// consumed by the suspend throw).
   ///
-  /// - Note: For tests that want to exercise the live controller path instead
-  ///   of pre-scheduling, attach a ``SuspendController`` via
-  ///   ``attachSuspendController(_:)`` and toggle it directly.
-  public func simulateSuspendOnNextGenerate() {
+  /// - Important: This does **NOT** park a run. The attached ``SuspendController``
+  ///   stays `.idle`, so `LLMCaller.awaitResume()` returns immediately and the
+  ///   generate retries and succeeds — the run keeps running. Use this only to
+  ///   unit-test the suspend-retry loop (how a caller reacts to a `.suspended`
+  ///   throw), NOT to hold a run mid-flight. For a genuine mid-flight park, use
+  ///   ``suspendOnControllerAttach()`` (puts the controller in `.suspended` so
+  ///   `awaitResume()` actually blocks).
+  public func throwSuspendedOnNextGenerate() {
     state.withLock { $0.pendingSuspendCount += 1 }
   }
 }

--- a/Pastura/PasturaTests/App/SimulationViewModelLifecycleTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelLifecycleTests.swift
@@ -454,14 +454,14 @@ struct SimulationViewModelLifecycleTests {
     sut.speed = .instant
 
     // 2 agents × 1 phase × 1 round = 2 generate calls. The first generate will
-    // throw `.suspended` (via simulateSuspendOnNextGenerate); the retry after
+    // throw `.suspended` (via throwSuspendedOnNextGenerate); the retry after
     // resume delivers the first response. The second agent's generate runs
     // normally.
     let mock = MockLLMService(responses: [
       #"{"statement": "first"}"#,
       #"{"statement": "second"}"#
     ])
-    mock.simulateSuspendOnNextGenerate()
+    mock.throwSuspendedOnNextGenerate()
 
     let scenario = makeTestScenario(
       agentNames: ["Alice", "Bob"],

--- a/Pastura/PasturaTests/App/SimulationViewModelStatusTests+ResumeContinuation.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelStatusTests+ResumeContinuation.swift
@@ -175,7 +175,7 @@ private func startSuspendedFreshRun(rounds: Int = 3) async throws -> SuspendedFr
   let env = try makeContinuationSUT(rounds: rounds)
   let mock = MockLLMService(responses: Array(repeating: #"{"statement":"x"}"#, count: 10))
   // Arm the run's controller on attach so the first generate parks genuinely —
-  // no fake `simulateSuspendOnNextGenerate` race, no scheduling window (#707).
+  // no fake `throwSuspendedOnNextGenerate` race, no scheduling window (#707).
   mock.suspendOnControllerAttach()
   env.sut.speed = .instant
 

--- a/Pastura/PasturaTests/Engine/LLMCallerTests.swift
+++ b/Pastura/PasturaTests/Engine/LLMCallerTests.swift
@@ -126,9 +126,9 @@ struct LLMCallerTests {
     // would fail. With it, all suspends are absorbed transparently.
     let mock = MockLLMService(responses: [#"{"statement": "ok"}"#])
     try await mock.loadModel()
-    mock.simulateSuspendOnNextGenerate()
-    mock.simulateSuspendOnNextGenerate()
-    mock.simulateSuspendOnNextGenerate()
+    mock.throwSuspendedOnNextGenerate()
+    mock.throwSuspendedOnNextGenerate()
+    mock.throwSuspendedOnNextGenerate()
 
     let collector = EventCollector()
     let result = try await caller.call(
@@ -180,8 +180,8 @@ struct LLMCallerTests {
     // "thinking" indicator for every BG/FG cycle.
     let mock = MockLLMService(responses: [#"{"statement": "hi"}"#])
     try await mock.loadModel()
-    mock.simulateSuspendOnNextGenerate()
-    mock.simulateSuspendOnNextGenerate()
+    mock.throwSuspendedOnNextGenerate()
+    mock.throwSuspendedOnNextGenerate()
 
     let collector = EventCollector()
     _ = try await caller.call(

--- a/Pastura/PasturaTests/LLM/LLMServiceStreamTests.swift
+++ b/Pastura/PasturaTests/LLM/LLMServiceStreamTests.swift
@@ -134,7 +134,7 @@ struct LLMServiceStreamTests {
     let mock = MockLLMService(responses: [])
     mock.setStreamChunks([["x"]])
     try await mock.loadModel()
-    mock.simulateSuspendOnNextGenerate()
+    mock.throwSuspendedOnNextGenerate()
 
     await #expect(throws: LLMError.suspended) {
       for try await _ in mock.generateStream(system: "s", user: "u") {}

--- a/Pastura/PasturaTests/LLM/MockLLMServiceTests.swift
+++ b/Pastura/PasturaTests/LLM/MockLLMServiceTests.swift
@@ -121,11 +121,11 @@ struct MockLLMServiceTests {
 
   // MARK: - Suspend hook
 
-  @Test func simulateSuspendOnNextGenerateThrowsSuspendedThenSucceeds() async throws {
+  @Test func nextGenerateThrowsSuspendedThenSucceeds() async throws {
     let service = MockLLMService(responses: ["after-suspend"])
     try await service.loadModel()
 
-    service.simulateSuspendOnNextGenerate()
+    service.throwSuspendedOnNextGenerate()
 
     await #expect(throws: LLMError.suspended) {
       try await service.generate(system: "s", user: "u")
@@ -155,8 +155,8 @@ struct MockLLMServiceTests {
   @Test func resetClearsPendingSuspends() async throws {
     let service = MockLLMService(responses: ["a"])
     try await service.loadModel()
-    service.simulateSuspendOnNextGenerate()
-    service.simulateSuspendOnNextGenerate()
+    service.throwSuspendedOnNextGenerate()
+    service.throwSuspendedOnNextGenerate()
     service.reset()
     // After reset no suspend should be pending — the next call returns "a".
     let result = try await service.generate(system: "s", user: "u")


### PR DESCRIPTION
## Summary
Follow-up to #711 (#707). Two clarity fixes so the next person doesn't repeat the #707 footgun:

- **Rename** `MockLLMService.simulateSuspendOnNextGenerate()` → `throwSuspendedOnNextGenerate()`. The old name read like it *parks* a run, but it only schedules a `.suspended` throw — the controller stays `.idle`, so `LLMCaller.awaitResume()` returns immediately and the run keeps running. The strengthened doc-comment now warns it does **not** park and points to the genuine-park primitive `suspendOnControllerAttach()`. Pure identifier change across the 4 legit suspend-retry-loop consumers; no behavior change.
- **Document** the run()/resume() mid-flight-park testability asymmetry in `.claude/rules/testing.md`: arm at attach time via `suspendOnControllerAttach()`; test-side arming races the resume path's `.instant` Engine burst because `resume()` lacks `run()`'s awaited `createSimulationRecord` hop; don't `pauseSimulation()` when pinning the `!isCompleted` branch (#673). Concept-level + pointer to `parkRunMidFlight` / the doc-comments (single source of truth).

## Test plan
- Full unit suite (`-skip-testing:PasturaUITests`) green.
- `rg 'simulateSuspendOnNextGenerate'` → zero hits (rename complete; no broken DocC cross-references).
- Pre-commit hook (swiftlint --strict + build) green.

Closes #713

🤖 Generated with [Claude Code](https://claude.com/claude-code)