### PR TITLE
♻️ refactor: drop residual fetchAll() in ScenarioDetail/SharedScenarios lookups

### DIFF
--- a/Pastura/Pastura/App/Community/Gallery/SharedScenariosViewModel.swift
+++ b/Pastura/Pastura/App/Community/Gallery/SharedScenariosViewModel.swift
@@ -249,7 +249,7 @@ final class SharedScenariosViewModel {
     let rows: [ScenarioRecord]
     do {
       rows = try await offMain { [repository] in
-        try repository.fetchAll().filter { $0.sourceType == ScenarioSourceType.gallery }
+        try repository.fetchBySourceType(ScenarioSourceType.gallery)
       }
     } catch {
       // Soft-fail: keep stale snapshot rather than clearing UI state on a

--- a/Pastura/Pastura/App/ScenarioDetailViewModel.swift
+++ b/Pastura/Pastura/App/ScenarioDetailViewModel.swift
@@ -134,14 +134,27 @@ final class ScenarioDetailViewModel {
       return
     }
 
-    // Repository fetch off MainActor — same idiom as the gallery
-    // refresh path above. Cheap for the bundled-preset table (~ 8 rows
-    // today).
-    let all = try? await offMain { [repository] in
-      try repository.fetchAll()
+    // Repository fetch off MainActor. Resolve the sibling via the
+    // lightweight ``ScenarioSummary`` projection (only `id` + `sourceId`
+    // are needed to match), then load that single record's full row —
+    // avoids pulling every scenario's heavy `yamlDefinition` into memory
+    // for a one-row lookup (#704). `fetchAllSummaries()` shares
+    // `fetchAll()`'s `createdAt DESC` ordering, so `.first` preserves the
+    // newest-wins tie-break when multiple records share the canonical
+    // `sourceId`.
+    let summaries = try? await offMain { [repository] in
+      try repository.fetchAllSummaries()
     }
-    siblingVariant = all?.first { other in
-      other.id != record.id && other.sourceId == sourceId
+    guard
+      let siblingId = summaries?.first(where: { summary in
+        summary.id != record.id && summary.sourceId == sourceId
+      })?.id
+    else {
+      siblingVariant = nil
+      return
+    }
+    siblingVariant = try? await offMain { [repository] in
+      try repository.fetchById(siblingId)
     }
   }
 

--- a/Pastura/Pastura/Data/ScenarioRepository.swift
+++ b/Pastura/Pastura/Data/ScenarioRepository.swift
@@ -22,6 +22,16 @@ nonisolated public protocol ScenarioRepository: Sendable {
   /// independently of the primary key. Returns `nil` if no matching row.
   func fetchBySource(type: String, id: String) throws -> ScenarioRecord?
 
+  /// Fetches all scenarios with the given `sourceType` (e.g. gallery
+  /// installs).
+  ///
+  /// DB-side filter so callers needing every row of one source type (e.g.
+  /// the gallery-installed snapshot) avoid loading the full table just to
+  /// filter it in memory. Returns the full records — unlike
+  /// ``fetchAllSummaries()`` — because consumers read `sourceHash` for
+  /// update detection.
+  func fetchBySourceType(_ type: String) throws -> [ScenarioRecord]
+
   /// Fetches all scenarios.
   func fetchAll() throws -> [ScenarioRecord]
 
@@ -91,6 +101,14 @@ nonisolated public final class GRDBScenarioRepository: ScenarioRepository, Senda
         .filter(Column("sourceType") == type)
         .filter(Column("sourceId") == id)
         .fetchOne(db)
+    }
+  }
+
+  public func fetchBySourceType(_ type: String) throws -> [ScenarioRecord] {
+    try dbWriter.read { db in
+      try ScenarioRecord
+        .filter(Column("sourceType") == type)
+        .fetchAll(db)
     }
   }
 

--- a/Pastura/PasturaTests/App/HomeViewModelTests+Deletion.swift
+++ b/Pastura/PasturaTests/App/HomeViewModelTests+Deletion.swift
@@ -21,6 +21,9 @@ nonisolated struct ThrowingDeleteScenarioRepository: ScenarioRepository {
   func save(_ record: ScenarioRecord) throws {}
   func fetchById(_ id: String) throws -> ScenarioRecord? { scenarios.first { $0.id == id } }
   func fetchBySource(type: String, id: String) throws -> ScenarioRecord? { nil }
+  func fetchBySourceType(_ type: String) throws -> [ScenarioRecord] {
+    scenarios.filter { $0.sourceType == type }
+  }
   func fetchAll() throws -> [ScenarioRecord] { scenarios }
   func fetchAllSummaries() throws -> [ScenarioSummary] {
     scenarios.map {

--- a/Pastura/PasturaTests/App/ResultsViewModelTestSupport.swift
+++ b/Pastura/PasturaTests/App/ResultsViewModelTestSupport.swift
@@ -60,6 +60,9 @@ nonisolated final class CountingScenarioRepository: ScenarioRepository, @uncheck
   func fetchBySource(type: String, id: String) throws -> ScenarioRecord? {
     try wrapped.fetchBySource(type: type, id: id)
   }
+  func fetchBySourceType(_ type: String) throws -> [ScenarioRecord] {
+    try wrapped.fetchBySourceType(type)
+  }
   func fetchByIds(_ ids: [String]) throws -> [ScenarioRecord] { try wrapped.fetchByIds(ids) }
   func fetchPresets() throws -> [ScenarioRecord] { try wrapped.fetchPresets() }
   func delete(_ id: String) throws { try wrapped.delete(id) }

--- a/Pastura/PasturaTests/App/ScenarioDetailViewModelTests.swift
+++ b/Pastura/PasturaTests/App/ScenarioDetailViewModelTests.swift
@@ -255,4 +255,41 @@ struct ScenarioDetailViewModelTests {
 
     #expect(viewModel.siblingVariant == nil)
   }
+
+  /// Two siblings share the canonical `sourceId` — the resolver returns
+  /// the **newest** (`createdAt DESC`). Pins the newest-wins tie-break
+  /// preserved by the `fetchAllSummaries()` + `fetchById()` lookup
+  /// (#704), so a future refactor that drops the ordering or resolves
+  /// the wrong sibling fails here.
+  @Test func loadSiblingResolvesNewestAmongMultipleSiblings() async throws {
+    let db = try DatabaseManager.inMemory()
+    let repo = GRDBScenarioRepository(dbWriter: db.dbWriter)
+
+    try repo.save(
+      ScenarioRecord(
+        id: "test_scenario", name: "Test", yamlDefinition: Self.validYAML,
+        isPreset: true, createdAt: Date(timeIntervalSince1970: 2000),
+        updatedAt: Date(timeIntervalSince1970: 2000),
+        sourceType: nil, sourceId: "test_scenario", sourceHash: nil))
+    // Older sibling — must lose to the newer one below.
+    try repo.save(
+      ScenarioRecord(
+        id: "test_scenario_old", name: "Test", yamlDefinition: Self.validYAMLEn,
+        isPreset: true, createdAt: Date(timeIntervalSince1970: 1000),
+        updatedAt: Date(timeIntervalSince1970: 1000),
+        sourceType: nil, sourceId: "test_scenario", sourceHash: nil))
+    // Newest sibling — the resolver should pick this one.
+    try repo.save(
+      ScenarioRecord(
+        id: "test_scenario_new", name: "Test", yamlDefinition: Self.validYAMLEn,
+        isPreset: true, createdAt: Date(timeIntervalSince1970: 3000),
+        updatedAt: Date(timeIntervalSince1970: 3000),
+        sourceType: nil, sourceId: "test_scenario", sourceHash: nil))
+
+    let viewModel = ScenarioDetailViewModel(repository: repo)
+    await viewModel.load(scenarioId: "test_scenario")
+    await viewModel.loadSibling()
+
+    #expect(viewModel.siblingVariant?.id == "test_scenario_new")
+  }
 }

--- a/Pastura/PasturaTests/Data/ScenarioRepositoryTests.swift
+++ b/Pastura/PasturaTests/Data/ScenarioRepositoryTests.swift
@@ -112,6 +112,23 @@ import Testing
     #expect(miss == nil)
   }
 
+  @Test func fetchBySourceTypeReturnsOnlyMatchingRows() throws {
+    let repo = try makeRepo()
+    try repo.save(
+      makeRecord(
+        id: "g1", sourceType: ScenarioSourceType.gallery, sourceId: "asch_v1", sourceHash: "h1"))
+    try repo.save(
+      makeRecord(
+        id: "g2", sourceType: ScenarioSourceType.gallery, sourceId: "milgram_v1", sourceHash: "h2"))
+    try repo.save(makeRecord(id: "local"))  // sourceType = nil
+
+    let gallery = try repo.fetchBySourceType(ScenarioSourceType.gallery)
+    #expect(Set(gallery.map(\.id)) == ["g1", "g2"])
+
+    let none = try repo.fetchBySourceType("nonexistent")
+    #expect(none.isEmpty)
+  }
+
   @Test func fetchBySourceIgnoresLocalRows() throws {
     let repo = try makeRepo()
     try repo.save(makeRecord(id: "local"))  // sourceType = nil


### PR DESCRIPTION
## Summary
Follow-up to #679 — drops the two residual `ScenarioRepository.fetchAll()` callsites that loaded every scenario row (incl. the heavy `yamlDefinition`) for a narrow purpose. Engineering hygiene + SPM-extraction prep.

- **Sibling lookup** (`ScenarioDetailViewModel.loadSibling`): resolve the cross-language sibling's id via the lightweight `ScenarioSummary` projection, then load only that one record's full row via `fetchById`. Newest-wins ordering (`createdAt DESC`) preserved.
- **Gallery snapshot** (`SharedScenariosViewModel.refreshInstalledSnapshot`): add a DB-side `fetchBySourceType(_:)` query (mirrors `fetchBySource(type:id:)`, returns full records since consumers read `sourceHash`) and replace the load-all-then-filter callsite.

No production `fetchAll()` callsite remains after this.

## Test plan
- New regression test `loadSiblingResolvesNewestAmongMultipleSiblings` pins the newest-wins tie-break for the projection-based resolver.
- New repo test `fetchBySourceTypeReturnsOnlyMatchingRows`.
- Full unit suite green (2076 tests); SwiftLint `--strict` clean.

Closes #704

🤖 Generated with [Claude Code](https://claude.com/claude-code)