### PR TITLE
♻️ refactor: remove ScenarioRepository.fetchAll() (zero prod callsites)

### DIFF
--- a/.claude/rules/models-and-data.md
+++ b/.claude/rules/models-and-data.md
@@ -132,7 +132,7 @@ All records use `var` properties (GRDB convention for mutable persistence).
 
 | Protocol | Implementation | Key Operations |
 |----------|---------------|----------------|
-| `ScenarioRepository` | `GRDBScenarioRepository` | save (upsert), fetchById, fetchAll, fetchAllSummaries (yamlDefinition-excluding projection), fetchByIds, fetchPresets, delete |
+| `ScenarioRepository` | `GRDBScenarioRepository` | save (upsert), fetchById, fetchAllSummaries (yamlDefinition-excluding projection), fetchByIds, fetchPresets, delete |
 | `SimulationRepository` | `GRDBSimulationRepository` | save, fetchById, fetchByScenarioId, fetchOrphaned, updateState, updateStatus, delete |
 | `TurnRepository` | `GRDBTurnRepository` | save, saveBatch, fetchBySimulationId, fetchBySimulationAndRound, deleteBySimulationId |
 

--- a/Pastura/Pastura/App/ScenarioDetailViewModel.swift
+++ b/Pastura/Pastura/App/ScenarioDetailViewModel.swift
@@ -138,8 +138,8 @@ final class ScenarioDetailViewModel {
     // lightweight ``ScenarioSummary`` projection (only `id` + `sourceId`
     // are needed to match), then load that single record's full row —
     // avoids pulling every scenario's heavy `yamlDefinition` into memory
-    // for a one-row lookup (#704). `fetchAllSummaries()` shares
-    // `fetchAll()`'s `createdAt DESC` ordering, so `.first` preserves the
+    // for a one-row lookup (#704). `fetchAllSummaries()` returns rows
+    // newest-first (`createdAt DESC`), so `.first` preserves the
     // newest-wins tie-break when multiple records share the canonical
     // `sourceId`.
     let summaries = try? await offMain { [repository] in

--- a/Pastura/Pastura/Data/ScenarioRepository.swift
+++ b/Pastura/Pastura/Data/ScenarioRepository.swift
@@ -32,16 +32,13 @@ nonisolated public protocol ScenarioRepository: Sendable {
   /// update detection.
   func fetchBySourceType(_ type: String) throws -> [ScenarioRecord]
 
-  /// Fetches all scenarios.
-  func fetchAll() throws -> [ScenarioRecord]
-
   /// Fetches lightweight summaries of all scenarios, excluding the heavy
   /// `yamlDefinition` column.
   ///
   /// The grouping/listing surfaces (Home, Past Results) only need
   /// `id` / `name` / `isPreset` / `sourceId` / `language` to collapse
   /// cross-language variants and render row labels — see ``ScenarioSummary``.
-  /// Ordered newest-first (`createdAt DESC`) to match ``fetchAll()``.
+  /// Ordered newest-first (`createdAt DESC`).
   func fetchAllSummaries() throws -> [ScenarioSummary]
 
   /// Fetches full records for the given ids. Order-independent; absent ids are
@@ -109,12 +106,6 @@ nonisolated public final class GRDBScenarioRepository: ScenarioRepository, Senda
       try ScenarioRecord
         .filter(Column("sourceType") == type)
         .fetchAll(db)
-    }
-  }
-
-  public func fetchAll() throws -> [ScenarioRecord] {
-    try dbWriter.read { db in
-      try ScenarioRecord.order(Column("createdAt").desc).fetchAll(db)
     }
   }
 

--- a/Pastura/PasturaTests/App/HomeViewModelTests+Deletion.swift
+++ b/Pastura/PasturaTests/App/HomeViewModelTests+Deletion.swift
@@ -6,10 +6,10 @@ import Testing
 // MARK: - Scenario deletion (#686)
 
 /// In-memory `ScenarioRepository` whose `delete(_:)` always throws, while
-/// `fetchAll()` still returns the seeded rows. Required because a single
-/// repository instance backs both `HomeViewModel.loadScenarios()` (via
-/// `fetchAll`) and `HomeViewModel.deleteScenario(_:)` (via `delete`): to
-/// exercise the failure path we need the list populated *and* the delete
+/// `fetchAllSummaries()` still returns the seeded rows. Required because a
+/// single repository instance backs both `HomeViewModel.loadScenarios()` (via
+/// `fetchAllSummaries`) and `HomeViewModel.deleteScenario(_:)` (via `delete`):
+/// to exercise the failure path we need the list populated *and* the delete
 /// to fail, which a real `GRDBScenarioRepository` cannot do at once.
 ///
 /// `nonisolated` because the suite is `@MainActor`; the type holds only
@@ -24,7 +24,6 @@ nonisolated struct ThrowingDeleteScenarioRepository: ScenarioRepository {
   func fetchBySourceType(_ type: String) throws -> [ScenarioRecord] {
     scenarios.filter { $0.sourceType == type }
   }
-  func fetchAll() throws -> [ScenarioRecord] { scenarios }
   func fetchAllSummaries() throws -> [ScenarioSummary] {
     scenarios.map {
       ScenarioSummary(

--- a/Pastura/PasturaTests/App/PresetLoaderTests.swift
+++ b/Pastura/PasturaTests/App/PresetLoaderTests.swift
@@ -14,7 +14,7 @@ struct PresetLoaderTests {
       bundle: Bundle(for: DatabaseManager.self)
     )
 
-    let all = try repo.fetchAll()
+    let all = try repo.fetchAllSummaries()
     #expect(all.count == 8)
 
     let presets = try repo.fetchPresets()
@@ -53,7 +53,7 @@ struct PresetLoaderTests {
     let second = try repo.fetchById("prisoners_dilemma")
 
     #expect(second?.createdAt == firstDate)
-    #expect(try repo.fetchAll().count == 8)
+    #expect(try repo.fetchAllSummaries().count == 8)
   }
 
   /// ADR-010 D4: per-language sibling presets share a canonical
@@ -100,7 +100,7 @@ struct PresetLoaderTests {
     #expect(try repo.fetchById("word_wolf_en")?.language == "en")
     #expect(try repo.fetchById("prisoners_dilemma_en")?.language == "en")
     // Every bundled preset carries a non-nil language column.
-    #expect(try repo.fetchAll().allSatisfy { $0.language != nil })
+    #expect(try repo.fetchAllSummaries().allSatisfy { $0.language != nil })
   }
 
   /// Cross-language grouping invariant: for each canonical id, both
@@ -124,7 +124,7 @@ struct PresetLoaderTests {
       #expect(en?.sourceId == canonical, "EN \(canonical) sourceId")
       // Cross-language grouping reachable by sourceId — distinct PKs,
       // shared canonical key.
-      let bySourceId = try repo.fetchAll().filter { $0.sourceId == canonical }
+      let bySourceId = try repo.fetchAllSummaries().filter { $0.sourceId == canonical }
       #expect(bySourceId.count == 2)
     }
   }
@@ -138,7 +138,7 @@ struct PresetLoaderTests {
       bundle: Bundle(for: DatabaseManager.self)
     )
 
-    let all = try repo.fetchAll()
+    let all = try repo.fetchAllSummaries()
     for record in all {
       #expect(record.isPreset == true)
     }

--- a/Pastura/PasturaTests/App/ResultsViewModelTestSupport.swift
+++ b/Pastura/PasturaTests/App/ResultsViewModelTestSupport.swift
@@ -29,9 +29,10 @@ func resultsTestDate(_ year: Int, _ month: Int, _ day: Int) -> Date {
   resultsTestCalendar.date(from: DateComponents(year: year, month: month, day: day, hour: 12))!
 }
 
-/// Wraps a real ``ScenarioRepository`` and counts ``ScenarioRepository/fetchAll()``
-/// calls so the #678 regression can assert the scenario index is built once,
-/// not rebuilt per filter keystroke. `nonisolated` + `@unchecked Sendable`
+/// Wraps a real ``ScenarioRepository`` and counts
+/// ``ScenarioRepository/fetchAllSummaries()`` calls so the #678 regression can
+/// assert the scenario index is built once, not rebuilt per filter keystroke.
+/// `nonisolated` + `@unchecked Sendable`
 /// with an `NSLock`-guarded counter because repository methods run off the
 /// main actor (`ResultsViewModel.offMain`) and the protocol is `Sendable`.
 nonisolated final class CountingScenarioRepository: ScenarioRepository, @unchecked Sendable {
@@ -39,16 +40,11 @@ nonisolated final class CountingScenarioRepository: ScenarioRepository, @uncheck
   private let lock = NSLock()
   private var _fetchAllCount = 0
 
-  /// Counts the index-rebuild fetches (`fetchAll` / `fetchAllSummaries`) — the
+  /// Counts the index-rebuild fetches (`fetchAllSummaries`) — the
   /// scenario-index load `ResultsViewModel` issues per window reset.
   var fetchAllCount: Int { lock.withLock { _fetchAllCount } }
 
   init(wrapping: any ScenarioRepository) { self.wrapped = wrapping }
-
-  func fetchAll() throws -> [ScenarioRecord] {
-    lock.withLock { _fetchAllCount += 1 }
-    return try wrapped.fetchAll()
-  }
 
   func fetchAllSummaries() throws -> [ScenarioSummary] {
     lock.withLock { _fetchAllCount += 1 }

--- a/Pastura/PasturaTests/App/ResultsViewModelTests.swift
+++ b/Pastura/PasturaTests/App/ResultsViewModelTests.swift
@@ -295,12 +295,12 @@ struct ResultsViewModelTests {
 
   // MARK: - Filter index reuse (#678)
 
-  /// Regression for #678: the scenario index (`scenarioRepository.fetchAll()`)
-  /// must NOT be rebuilt on every filter keystroke. The scenario set is
-  /// invariant while the user types, so the filter path reuses the already-built
-  /// index.
+  /// Regression for #678: the scenario index
+  /// (`scenarioRepository.fetchAllSummaries()`) must NOT be rebuilt on every
+  /// filter keystroke. The scenario set is invariant while the user types, so
+  /// the filter path reuses the already-built index.
   ///
-  /// `CountingScenarioRepository` pins it via `fetchAll()` count: with the fix
+  /// `CountingScenarioRepository` pins it via `fetchAllSummaries()` count: with the fix
   /// the count stays at 1 (the initial load's build); reverting the fix
   /// (re-fetch per keystroke) would raise it to 5 (1 load + 3 distinct filters
   /// + 1 clear). The distinct, non-empty queries matter — a repeated query

--- a/Pastura/PasturaTests/Data/BundledPresetSourceIdSchemaTests.swift
+++ b/Pastura/PasturaTests/Data/BundledPresetSourceIdSchemaTests.swift
@@ -8,7 +8,7 @@ import Testing
 /// aliasing. Step D's `PresetLoader` writes the canonical `sourceId`
 /// on every bundled preset insert (Step D-3, #388 item 3); this suite
 /// asserts the resulting data shape — both JA and EN siblings share
-/// the canonical sourceId, and `fetchAll().filter` aggregates them
+/// the canonical sourceId, and `fetchAllSummaries().filter` aggregates them
 /// reachable by that single key.
 ///
 /// **Scope is deliberately schema-only.** The Past Results UI
@@ -68,11 +68,11 @@ struct BundledPresetSourceIdSchemaTests {
     #expect(try repo.fetchById("word_wolf_en")?.sourceId == "word_wolf")
 
     // Schema-level cross-language aggregation by canonical sourceId.
-    // `fetchAll().filter` is the lowest-common-denominator query
+    // `fetchAllSummaries().filter` is the lowest-common-denominator query
     // shape — the data layer reaches both rows by sourceId regardless
     // of how a future consumer surfaces the aggregation (sourceId-
     // only fetch method, ScenarioSourceType.preset case, etc.).
-    let aggregated = try repo.fetchAll().filter { $0.sourceId == "word_wolf" }
+    let aggregated = try repo.fetchAllSummaries().filter { $0.sourceId == "word_wolf" }
     #expect(aggregated.count == 2)
     let ids = Set(aggregated.map(\.id))
     #expect(ids == ["word_wolf", "word_wolf_en"])

--- a/Pastura/PasturaTests/Data/ScenarioRepositoryTests.swift
+++ b/Pastura/PasturaTests/Data/ScenarioRepositoryTests.swift
@@ -92,7 +92,7 @@ import Testing
     let fetched = try repo.fetchById("s1")
     #expect(fetched?.name == "Updated")
 
-    let all = try repo.fetchAll()
+    let all = try repo.fetchAllSummaries()
     #expect(all.count == 1)
   }
 

--- a/Pastura/PasturaTests/Data/ScenarioRepositoryTests.swift
+++ b/Pastura/PasturaTests/Data/ScenarioRepositoryTests.swift
@@ -45,16 +45,6 @@ import Testing
     #expect(fetched == nil)
   }
 
-  @Test func fetchAllReturnsAllRecords() throws {
-    let repo = try makeRepo()
-    for i in 1...3 {
-      try repo.save(makeRecord(id: "s\(i)", name: "Scenario \(i)"))
-    }
-
-    let all = try repo.fetchAll()
-    #expect(all.count == 3)
-  }
-
   @Test func fetchPresetsReturnsOnlyPresets() throws {
     let repo = try makeRepo()
     try repo.save(makeRecord(id: "p1", name: "Preset 1", isPreset: true))


### PR DESCRIPTION
## Summary
- `fetchAll()` had zero production callsites after #704 — an attractive nuisance vs the projection (`fetchAllSummaries`) / targeted (`fetchById`/`fetchByIds`) / scoped (`fetchPresets`/`fetchBySource*`) methods. Removing it keeps the repository uniformly projection-based and trims the future SPM-extraction surface.
- **Commit 1**: migrate test callsites off `fetchAll()` to `fetchAllSummaries()` (assertions only touch fields the summary projection carries: id / name / isPreset / sourceId / language).
- **Commit 2**: remove the protocol decl + `GRDBScenarioRepository` impl, drop the override from both test doubles (keeping `CountingScenarioRepository`'s `fetchAllSummaries` override + `fetchAllCount` counter — the #678 regression rides on it), delete the `fetchAllReturnsAllRecords` test, and fix dangling doc cross-refs (`ScenarioRepository`, `ScenarioDetailViewModel`, `ResultsViewModelTests`, `ResultsViewModelTestSupport`, `.claude/rules/models-and-data.md`).
- Restorable from git history if a real all-rows use case appears (a batched/cursor API would fit better than load-everything-into-`[ScenarioRecord]`).

## Test plan
- Full unit suite green (2109 tests / 187 suites)
- SwiftLint `--strict` clean
- `rg 'fetchAll\(\)'` returns no hits outside `fetchAllSummaries`
- #678 index-reuse regression (`ResultsViewModelTests`) still pins build-once via the retained `fetchAllCount` counter

Closes #718

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XecbKhxn4repdFwErhpMXQ