### PR TITLE
🧪 test: park-on-hide memory-warning coverage + UI-test rationale

### DIFF
--- a/Pastura/Pastura/PasturaApp.swift
+++ b/Pastura/Pastura/PasturaApp.swift
@@ -704,6 +704,28 @@ private struct RootView: View {
         // real inference). Lets the Phase B park-and-return flow be exercised
         // end-to-end (the run blocks in the first `generate`, so `registry.isActive`
         // stays true throughout — `InFlightIndicatorReconnectUITests`).
+        //
+        // Why `generateDelay` and NOT `MockLLMService.suspendOnControllerAttach()`:
+        // `generateDelay` blocks INSIDE `generate` (a `Task.sleep` before the
+        // suspend check), faithfully modelling a sim that is still *running*.
+        // `suspendOnControllerAttach` instead *parks* the run pre-generate by
+        // requesting controller suspend — but the test returns to the run through
+        // the `.viewHide` resume gate (`requestResume(.viewHide)` resumes the
+        // controller), which would then let the parked generate proceed, exhaust
+        // the empty `responses: []`, and error-terminate the run. The two
+        // mechanisms are deliberately distinct (blocked-in-generate vs parked); do
+        // not swap them here.
+        //
+        // Why 120s and NOT a smaller constant: the delay is a wall-clock
+        // `Task.sleep` unaffected by park, and once the test returns and the gate
+        // resumes the controller, only the still-ongoing sleep keeps the run
+        // in-flight — so the delay must outlast the whole tap→final-assert window.
+        // On CI this test has been observed at ~109s end-to-end (with a flaky
+        // ~286s attempt on the same run), so 120s is near the safe floor, not
+        // over-generous; trimming it reintroduces a mid-test sleep-expiry flake.
+        // The wall-clock approach is itself timing-fragile against CI variance —
+        // the durable fix is a signal-blocked mock (block in `generate` until an
+        // explicit unblock), tracked in #719, not a larger constant.
         let llm =
           CommandLine.arguments.contains("--ui-test-slow-llm")
           ? MockLLMService(responses: [], generateDelay: .seconds(120))

--- a/Pastura/PasturaTests/App/SimulationSessionTests+ParkGate.swift
+++ b/Pastura/PasturaTests/App/SimulationSessionTests+ParkGate.swift
@@ -304,4 +304,84 @@ extension SimulationSessionTests {
     session.end()
     await viewModel.runTask?.value
   }
+
+  /// Starts a real 1-round `speak_all` run and parks it away (`.viewHide`),
+  /// returning once the run is genuinely held in-flight at its first generate
+  /// (parked, not yet completed). Mirrors the inline setup of
+  /// `memoryWarningPausesInFlightRun`; the two memory-warning-while-parked tests
+  /// below share it. Uses `.milliseconds(50)` to settle, matching that test.
+  ///
+  /// The two `responses` are provisioned to mirror that inline setup but are
+  /// never consumed by design: the run parks at its first generate and both
+  /// callers tear it down (pause-compose / background-cancel → `end()`) before
+  /// any generate completes, so `MockLLMService`'s exhaustion throw never fires.
+  private func startParkedAwayRun() async throws -> (
+    session: SimulationSession, viewModel: SimulationViewModel
+  ) {
+    let (viewModel, _) = try makeViewModel()
+    let mock = MockLLMService(responses: [
+      #"{"statement": "first"}"#,
+      #"{"statement": "second"}"#
+    ])
+    let scenario = makeTestScenario(
+      agentNames: ["Alice", "Bob"],
+      rounds: 1,
+      phases: [Phase(type: .speakAll, prompt: "Speak", outputSchema: ["statement": "string"])]
+    )
+    let session = SimulationSession()
+    _ = session.startGuarded(
+      source: .scenario(scenarioId: "test"),
+      scenario: scenario,
+      tab: .home,
+      makeViewModel: { viewModel },
+      body: { model in await model.run(scenario: scenario, llm: mock) })
+
+    while viewModel.suspendController == nil {
+      await Task.yield()
+    }
+    // The user left the screen with "keep running" → view-hide park.
+    session.requestPark(reason: .viewHide)
+    try await Task.sleep(for: .milliseconds(50))
+    return (session, viewModel)
+  }
+
+  @Test func memoryWarningPauseComposesWithViewHidePark() async throws {
+    // Parked-away (`.viewHide` held) + a FOREGROUND memory warning. The throttle
+    // pauses (first warning), and `pauseSimulation` routes its suspend through the
+    // gate as `.userPause` — so the run stays suspended and `parkReasons` composes
+    // both reasons. Distinct from `memoryWarningPausesInFlightRun`, which pins only
+    // the pause-not-cancel policy: this pins the park-gate composition (a
+    // memory-warning pause must not desync the view-hide park).
+    let (session, viewModel) = try await startParkedAwayRun()
+    #expect(viewModel.isRunning == true)
+    #expect(session.parkReasons == [.viewHide])
+
+    session.handleMemoryWarning(isAppActive: true)
+    #expect(viewModel.isPaused == true, "first foreground warning pauses, not cancels")
+    #expect(viewModel.isCancelled == false)
+    #expect(
+      session.parkReasons == [.viewHide, .userPause],
+      "the pause composes through the gate without un-parking the view-hide hold")
+    #expect(viewModel.suspendController?.isSuspendRequested() == true)
+
+    session.end()
+    await viewModel.runTask?.value
+  }
+
+  @Test func memoryWarningCancelsParkedAwayRunInBackground() async throws {
+    // Parked-away (`.viewHide` held) + a BACKGROUND memory warning. The throttle's
+    // `!isActive` branch cancels immediately — a backgrounded run is jetsamed at a
+    // much lower threshold, so preserving the terminal `.cancelled` status beats
+    // losing the run silently. The view-hide park must not suppress that cancel.
+    let (session, viewModel) = try await startParkedAwayRun()
+    #expect(viewModel.isRunning == true)
+
+    session.handleMemoryWarning(isAppActive: false)
+    #expect(
+      viewModel.isCancelled == true,
+      "a background memory warning cancels even a view-hide-parked run")
+
+    session.end()
+    await viewModel.runTask?.value
+  }
 }

--- a/Pastura/PasturaUITests/InFlightIndicatorReconnectUITests.swift
+++ b/Pastura/PasturaUITests/InFlightIndicatorReconnectUITests.swift
@@ -16,6 +16,14 @@ import XCTest
 /// that `FeatureFlags`' `object(forKey:) as? Bool` reads as nil) so leaving
 /// silently parks.
 ///
+/// The slow-LLM hold uses a wall-clock `generateDelay` (blocked *inside*
+/// `generate`), deliberately NOT `suspendOnControllerAttach` (which *parks*
+/// pre-generate): the return path resumes the controller through the
+/// `.viewHide` gate, which would let a parked generate exhaust its empty
+/// `responses: []` and error. That wall-clock delay is timing-fragile against
+/// CI variance (durable fix tracked in #719). Full rationale lives at
+/// `PasturaApp.setupUITestState`.
+///
 /// Subject to the UI-test flake classes in `.claude/rules/xcodebuild-cli.md`.
 @MainActor
 final class InFlightIndicatorReconnectUITests: XCTestCase {


### PR DESCRIPTION
## Summary

A #717 follow-up (ADR-017 Phase B opt-in park-on-hide) addressing two
code-reviewer notes. No product behavior change — comments + tests only.

**1. Document the `--ui-test-slow-llm` harness mechanism** (`PasturaApp.setupUITestState` + `InFlightIndicatorReconnectUITests` header). Two non-obvious points were undocumented and easy to "fix" wrongly:
- **Don't swap `generateDelay` → `suspendOnControllerAttach`.** `generateDelay` blocks *inside* `generate`, faithfully modelling a still-running sim. `suspendOnControllerAttach` *parks* pre-generate — but the test returns through the `.viewHide` resume gate, which would resume the generate into empty-`responses` exhaustion and error-terminate the run.
- **Don't trim the `.seconds(120)` delay.** The sleep is wall-clock, unaffected by park; once the test returns and the gate resumes the controller, only the ongoing sleep keeps the run in-flight, so it must outlast the whole tap→final-assert window. CI measured this test at ~109s end-to-end (a flaky ~286s attempt on the same run), so 120s is near the safe floor, not over-generous. The wall-clock approach is itself timing-fragile — the durable fix (a signal-blocked mock) is tracked in #719.

**2. Cover the one un-asserted combination from #717** — a memory warning arriving while a run is parked-away (`.viewHide` held). Two real-run integration tests added to the existing `SimulationSessionTests+ParkGate` sibling extension (not a new `@Suite`, per `testing.md`):
- `memoryWarningPauseComposesWithViewHidePark` — a foreground warning pauses (first-warning policy) **and** `pauseSimulation` routes through the gate as `.userPause`, so `parkReasons` composes `[.viewHide, .userPause]` and the controller stays suspended. Distinct from `memoryWarningPausesInFlightRun`, which pins only the pause-not-cancel policy.
- `memoryWarningCancelsParkedAwayRunInBackground` — a background warning takes the throttle's `!isActive` branch and cancels, even while view-hide-parked.

A shared `private startParkedAwayRun()` helper removes the duplicated in-flight-run setup.

## Test plan
- `scripts/xcodebuild.sh test -only-testing PasturaTests/SimulationSessionTests` — all 18 green (incl. the 2 new)
- `scripts/xcodebuild.sh test -only-testing PasturaUITests/InFlightIndicatorReconnectUITests` — green (26.4s local)
- `swiftlint lint --strict` — clean
- Reviewed by the `code-reviewer` subagent (Opus): PASS, 0 issues

## Notes
Follow-up to #717. Spawned #719 (durable fix for the timing-fragile UI-test hold) — left open.

Closes #721