### PR TITLE
🧪 test: signal-blocked MockLLMService hold for UI-test (#719)

### DIFF
--- a/Pastura/Pastura/LLM/MockLLMService.swift
+++ b/Pastura/Pastura/LLM/MockLLMService.swift
@@ -37,24 +37,29 @@ nonisolated public final class MockLLMService: LLMService, @unchecked Sendable {
     /// separately from `callIndex` (which counts `generate` calls) so
     /// tests that mix both paths can assert each count independently.
     var streamCallIndex: Int = 0
-    /// Artificial per-call delay applied before each `generate` returns.
-    /// `.zero` (default) keeps existing tests instant. Used by the UI-test
-    /// harness to hold a run in-flight long enough to exercise the Phase B
-    /// park-and-return flow on the simulator (which can't run real inference).
-    var generateDelay: Duration = .zero
+    /// Signal-blocked gate for the UI-test hold — see ``blockGenerateUntilSignal()``.
+    var blockGate: BlockGate = .disabled
+  }
+
+  /// State of the ``blockGenerateUntilSignal()`` gate. Stored continuation is
+  /// non-nil only while a `generate` call is parked. Mirrors
+  /// ``SuspendController``'s `idle`/`suspended`/`resumed` shape (incl. its
+  /// proven cancel-before-store race fix); `.disabled` is the mode-off default
+  /// so the gate is a pure no-op unless explicitly armed.
+  private enum BlockGate: Sendable {
+    case disabled
+    case armed(CheckedContinuation<Void, Never>?)
+    case released
   }
 
   private let state: OSAllocatedUnfairLock<State>
 
   /// Initialize with an ordered sequence of raw JSON responses.
   ///
-  /// - Parameters:
-  ///   - responses: The responses to return in order from ``generate(system:user:)``.
-  ///   - generateDelay: Artificial delay applied before each `generate` returns.
-  ///     Defaults to `.zero` (instant) — set only by the UI-test harness.
-  public init(responses: [String], generateDelay: Duration = .zero) {
-    self.state = OSAllocatedUnfairLock(
-      initialState: State(responses: responses, generateDelay: generateDelay))
+  /// - Parameter responses: The responses to return in order from
+  ///   ``generate(system:user:)``.
+  public init(responses: [String]) {
+    self.state = OSAllocatedUnfairLock(initialState: State(responses: responses))
   }
 
   public func loadModel() async throws {
@@ -75,11 +80,11 @@ nonisolated public final class MockLLMService: LLMService, @unchecked Sendable {
   public func generate(
     system: String, user: String, schema: OutputSchema?
   ) async throws -> String {
-    // Await the configured delay OUTSIDE the lock (can't `await` inside a
-    // synchronous `withLock`). Cooperative cancellation lets a cancelled run
-    // tear down promptly. Default `.zero` is a no-op for existing tests.
-    let delay = state.withLock { $0.generateDelay }
-    if delay > .zero { try await Task.sleep(for: delay) }
+    // Park on the block gate OUTSIDE the lock (can't `await` inside a
+    // synchronous `withLock`). Disabled by default — a pure no-op for existing
+    // tests. When armed, the run is held in-flight until unblock or
+    // cancellation, wall-clock-independent (#719).
+    try await awaitBlockReleaseIfArmed()
     return try state.withLock { mutableState in
       guard mutableState.isModelLoaded else { throw LLMError.notLoaded }
       // Drain a pending suspend slot first — this lets tests deterministically
@@ -128,6 +133,108 @@ nonisolated public final class MockLLMService: LLMService, @unchecked Sendable {
   /// resumed or torn down. Deterministic regardless of `.instant` speed (#707).
   public func suspendOnControllerAttach() {
     state.withLock { $0.suspendOnAttach = true }
+  }
+
+  // MARK: - Signal-blocked generate (UI-test hold)
+
+  /// Arm `generate` to park (before its not-loaded / suspend / response checks)
+  /// until ``unblockGenerate()`` is called or the calling task is cancelled.
+  ///
+  /// Holds a run in-flight **independent of wall-clock** — replaces the former
+  /// `generateDelay` timed sleep so a slow CI runner can never expire the hold
+  /// mid-test (#719). The block lives INSIDE `generate` and is **not** released
+  /// by a ``SuspendController`` resume, which is the whole point: it stays
+  /// distinct from ``suspendOnControllerAttach()`` (a pre-generate *park* that
+  /// the `.viewHide` resume gate would clear, letting the generate run on and
+  /// exhaust an empty `responses` queue).
+  ///
+  /// Scope: gates ``generate(system:user:schema:)`` and therefore wrap-mode
+  /// ``generateStream(system:user:schema:)``, but NOT explicit
+  /// ``setStreamChunks(_:)`` streaming (that path never calls `generate`). The
+  /// armed mode is a *configuration* that survives ``reset()`` (like
+  /// `controller` / `suspendOnAttach`); ``unblockGenerate()`` releases it.
+  public func blockGenerateUntilSignal() {
+    state.withLock { $0.blockGate = .armed(nil) }
+  }
+
+  /// Release a `generate` parked by ``blockGenerateUntilSignal()`` and latch the
+  /// release so a later park returns immediately.
+  ///
+  /// Idempotent and safe to call before any `generate` parks (the latch makes
+  /// the unblock un-loseable). No-op when the gate is `.disabled`.
+  public func unblockGenerate() {
+    // Extract the parked continuation under the lock, resume OUTSIDE it (the
+    // executor enqueue must not run while holding the lock). Mirrors
+    // SuspendController.resume().
+    let continuation: CheckedContinuation<Void, Never>? = state.withLock { mutableState in
+      switch mutableState.blockGate {
+      case .disabled, .released:
+        return nil
+      case .armed(let stored):
+        mutableState.blockGate = .released
+        return stored
+      }
+    }
+    continuation?.resume()
+  }
+
+  /// Park the calling task on an armed block gate until ``unblockGenerate()`` or
+  /// task cancellation; return immediately when the gate is `.disabled` /
+  /// `.released`. Verbatim-mirrors ``SuspendController/awaitResume()``'s proven
+  /// cancel-before-store race fix (#134) — `<Void, Never>` + post-await `checkCancellation()`.
+  private func awaitBlockReleaseIfArmed() async throws {
+    // Fast path: skip the continuation hop when the mode is off, so a default
+    // MockLLMService behaves exactly as before.
+    let isArmed = state.withLock { mutableState -> Bool in
+      if case .disabled = mutableState.blockGate { return false }
+      return true
+    }
+    guard isArmed else { return }
+    await withTaskCancellationHandler {
+      await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+        let resumeNow = state.withLock { mutableState -> Bool in
+          switch mutableState.blockGate {
+          case .disabled, .released:
+            // Already released (latched unblock) — return immediately.
+            return true
+          case .armed(let existing):
+            precondition(
+              existing == nil,
+              "MockLLMService: multi-awaiter block not supported (1 generate = 1 waiter)"
+            )
+            mutableState.blockGate = .armed(continuation)
+            return false
+          }
+        }
+        if resumeNow {
+          continuation.resume()
+          return
+        }
+        // onCancel may have fired BEFORE the continuation was installed — it
+        // then saw `.armed(nil)` and no-op'd, leaving the just-stored
+        // continuation parked forever. Self-resume to close the race.
+        if Task.isCancelled {
+          extractParkedBlockContinuation()?.resume()
+        }
+      }
+    } onCancel: {
+      extractParkedBlockContinuation()?.resume()
+    }
+    // Distinguish cancellation from a normal unblock for the caller.
+    try Task.checkCancellation()
+  }
+
+  /// Atomically extract the parked block continuation (if any), clearing it to
+  /// `.armed(nil)` so cancel / unblock paths never resume it twice. Resume the
+  /// returned value OUTSIDE any lock. Mirrors `extractStoredContinuation()`.
+  private func extractParkedBlockContinuation() -> CheckedContinuation<Void, Never>? {
+    state.withLock { mutableState in
+      guard case .armed(let stored) = mutableState.blockGate, let cont = stored else {
+        return nil
+      }
+      mutableState.blockGate = .armed(nil)
+      return cont
+    }
   }
 
   // MARK: - Streaming

--- a/Pastura/Pastura/PasturaApp.swift
+++ b/Pastura/Pastura/PasturaApp.swift
@@ -699,37 +699,27 @@ private struct RootView: View {
     /// that would make navigation regressions hard to catch reliably.
     private func setupUITestState() async {
       do {
-        // `--ui-test-slow-llm`: hold each inference for longer than a UI test
-        // runs so a started simulation stays in-flight (the simulator can't run
-        // real inference). Lets the Phase B park-and-return flow be exercised
+        // `--ui-test-slow-llm`: hold the run in-flight for the whole UI test so a
+        // started simulation never completes (the simulator can't run real
+        // inference). Lets the Phase B park-and-return flow be exercised
         // end-to-end (the run blocks in the first `generate`, so `registry.isActive`
         // stays true throughout — `InFlightIndicatorReconnectUITests`).
         //
-        // Why `generateDelay` and NOT `MockLLMService.suspendOnControllerAttach()`:
-        // `generateDelay` blocks INSIDE `generate` (a `Task.sleep` before the
-        // suspend check), faithfully modelling a sim that is still *running*.
-        // `suspendOnControllerAttach` instead *parks* the run pre-generate by
-        // requesting controller suspend — but the test returns to the run through
-        // the `.viewHide` resume gate (`requestResume(.viewHide)` resumes the
-        // controller), which would then let the parked generate proceed, exhaust
-        // the empty `responses: []`, and error-terminate the run. The two
-        // mechanisms are deliberately distinct (blocked-in-generate vs parked); do
-        // not swap them here.
+        // `blockGenerateUntilSignal()` blocks INSIDE `generate` on an explicit
+        // signal — wall-clock-INDEPENDENT, so a slow CI runner can never expire
+        // the hold mid-test (#719; the old `generateDelay` wall-clock sleep was
+        // calibrated to a 120s constant against 109–286s CI timing variance).
+        // The test never unblocks; tearDown's `terminate()` ends the run.
         //
-        // Why 120s and NOT a smaller constant: the delay is a wall-clock
-        // `Task.sleep` unaffected by park, and once the test returns and the gate
-        // resumes the controller, only the still-ongoing sleep keeps the run
-        // in-flight — so the delay must outlast the whole tap→final-assert window.
-        // On CI this test has been observed at ~109s end-to-end (with a flaky
-        // ~286s attempt on the same run), so 120s is near the safe floor, not
-        // over-generous; trimming it reintroduces a mid-test sleep-expiry flake.
-        // The wall-clock approach is itself timing-fragile against CI variance —
-        // the durable fix is a signal-blocked mock (block in `generate` until an
-        // explicit unblock), tracked in #719, not a larger constant.
-        let llm =
-          CommandLine.arguments.contains("--ui-test-slow-llm")
-          ? MockLLMService(responses: [], generateDelay: .seconds(120))
-          : MockLLMService(responses: [])
+        // NOT `suspendOnControllerAttach()`: that *parks* the run pre-generate via
+        // the controller, which the test's `.viewHide` resume gate
+        // (`requestResume(.viewHide)`) would clear — letting the generate run on,
+        // exhaust the empty `responses: []`, and error-terminate the run. The two
+        // mechanisms are deliberately distinct (blocked-in-generate vs parked).
+        let llm = MockLLMService(responses: [])
+        if CommandLine.arguments.contains("--ui-test-slow-llm") {
+          llm.blockGenerateUntilSignal()
+        }
         // Normalize keep-running-on-leave every --ui-test launch (a real Bool
         // write; a `-key YES` launch arg lands as a String that `FeatureFlags`'
         // `object(forKey:) as? Bool` reads as nil → default false). Setting it

--- a/Pastura/PasturaTests/LLM/MockLLMServiceTests.swift
+++ b/Pastura/PasturaTests/LLM/MockLLMServiceTests.swift
@@ -163,6 +163,46 @@ struct MockLLMServiceTests {
     #expect(result == "a")
   }
 
+  // MARK: - Signal-blocked generate (UI-test Phase B hold)
+
+  @Test func blockGenerateHoldsThenUnblockReleases() async throws {
+    let service = MockLLMService(responses: ["done"])
+    try await service.loadModel()
+    service.blockGenerateUntilSignal()
+
+    let task = Task { try await service.generate(system: "s", user: "u") }
+    // Race-free: if generate hasn't parked yet, the latched release covers the
+    // next park; if it has parked, the stored continuation resumes.
+    service.unblockGenerate()
+
+    let result = try await task.value
+    #expect(result == "done")
+  }
+
+  @Test func blockedGenerateThrowsOnCancellation() async throws {
+    let service = MockLLMService(responses: ["never"])
+    try await service.loadModel()
+    service.blockGenerateUntilSignal()
+
+    let task = Task { try await service.generate(system: "s", user: "u") }
+    task.cancel()
+
+    await #expect(throws: CancellationError.self) {
+      try await task.value
+    }
+  }
+
+  @Test func unblockBeforeParkIsNotLost() async throws {
+    let service = MockLLMService(responses: ["done"])
+    try await service.loadModel()
+    service.blockGenerateUntilSignal()
+    // Unblock latches before any generate parks — the signal must not be lost.
+    service.unblockGenerate()
+
+    let result = try await service.generate(system: "s", user: "u")
+    #expect(result == "done")
+  }
+
   // MARK: - generateWithMetrics default dispatch
 
   /// Mock doesn't override `generateWithMetrics`, so the protocol-extension

--- a/Pastura/PasturaTests/LLM/MockLLMServiceTests.swift
+++ b/Pastura/PasturaTests/LLM/MockLLMServiceTests.swift
@@ -203,6 +203,19 @@ struct MockLLMServiceTests {
     #expect(result == "done")
   }
 
+  @Test func armedButUnloadedStillThrowsNotLoadedAfterUnblock() async throws {
+    // The block parks BEFORE the isModelLoaded check — releasing it must not
+    // swallow the .notLoaded throw. Locks the ordering the production comment
+    // on blockGenerateUntilSignal() relies on (never loaded here on purpose).
+    let service = MockLLMService(responses: ["done"])
+    service.blockGenerateUntilSignal()
+    service.unblockGenerate()
+
+    await #expect(throws: LLMError.notLoaded) {
+      try await service.generate(system: "s", user: "u")
+    }
+  }
+
   // MARK: - generateWithMetrics default dispatch
 
   /// Mock doesn't override `generateWithMetrics`, so the protocol-extension

--- a/Pastura/PasturaUITests/InFlightIndicatorReconnectUITests.swift
+++ b/Pastura/PasturaUITests/InFlightIndicatorReconnectUITests.swift
@@ -16,12 +16,14 @@ import XCTest
 /// that `FeatureFlags`' `object(forKey:) as? Bool` reads as nil) so leaving
 /// silently parks.
 ///
-/// The slow-LLM hold uses a wall-clock `generateDelay` (blocked *inside*
-/// `generate`), deliberately NOT `suspendOnControllerAttach` (which *parks*
-/// pre-generate): the return path resumes the controller through the
+/// The slow-LLM hold uses `blockGenerateUntilSignal()` — `generate` blocks on
+/// an explicit signal, deliberately NOT `suspendOnControllerAttach` (which
+/// *parks* pre-generate): the return path resumes the controller through the
 /// `.viewHide` gate, which would let a parked generate exhaust its empty
-/// `responses: []` and error. That wall-clock delay is timing-fragile against
-/// CI variance (durable fix tracked in #719). Full rationale lives at
+/// `responses: []` and error. The block is wall-clock-independent, so a slow CI
+/// runner can never expire the hold mid-test (#719 replaced the former
+/// timing-fragile `generateDelay` sleep); the test never unblocks — tearDown's
+/// `terminate()` ends the run. Full rationale lives at
 /// `PasturaApp.setupUITestState`.
 ///
 /// Subject to the UI-test flake classes in `.claude/rules/xcodebuild-cli.md`.


### PR DESCRIPTION
## Summary
- Replace the `--ui-test-slow-llm` wall-clock `Task.sleep` hold (`MockLLMService(generateDelay: .seconds(120))`) with a **signal-blocked gate**. The old delay was calibrated to one CI run's timing (109–286s observed variance); when the test window outlasts the sleep, the resumed generate hits empty-`responses` exhaustion and the run error-terminates — a flake that looks like a product bug.
- `blockGenerateUntilSignal()` parks `generate` (before its checks) on a stored `CheckedContinuation<Void, Never>` until `unblockGenerate()` or task cancellation — wall-clock-independent. Verbatim-mirrors `SuspendController`'s proven cancel-before-store race fix (#134): latched `.released`, store/extract under the lock, resume outside, post-await `Task.checkCancellation()`.
- Stays distinct from `suspendOnControllerAttach()` — the block is **not** released by the `.viewHide` controller resume the test triggers on return.
- `generateDelay` removed entirely (no remaining consumer) — eliminates the calibration.

## Test plan
- New unit tests: unblock-release, cancellation throws `CancellationError`, unblock-before-park not lost, armed-but-unloaded still throws `.notLoaded`.
- Full unit suite: 2114 tests pass.
- `swift build` (SwiftPM harness — `MockLLMService` is in its source set) succeeds.
- `swiftlint --strict` passes.
- code-reviewer (Opus): PASS (0 critical / 0 warning).

Closes #719