### PR TITLE
✨ feat: promote-factory-to-gallery.sh — automate factory→gallery bridge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -510,8 +510,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      # Regression tests for the repo's shell gates (currently the p8
-      # secret-gate test). Pure git + bash, so ubuntu — no Xcode needed.
+      # gallery-scripts-test.sh delegates to add/check-gallery-entry.sh,
+      # which parse YAML via PyYAML. Pin major to match the gallery-drift
+      # job's install. The other shell tests don't need it; the install
+      # is cheap and unconditional keeps the job simple.
+      - name: Install PyYAML
+        run: python3 -m pip install --quiet 'pyyaml>=6,<7'
+
+      # Regression tests for the repo's shell gates (p8 secret-gate,
+      # gallery tooling, …). Pure git + bash, so ubuntu — no Xcode needed.
       # The `*-test.sh` naming convention is the contract: any matching
       # file becomes a CI gate. GHA's default shell runs `set -eo pipefail`,
       # so a non-zero test exit fails the job (no `|| true` wrapper).

--- a/docs/gallery/README.md
+++ b/docs/gallery/README.md
@@ -153,13 +153,31 @@ entry:
    through the blocklist gate (that gate is Presets-only). Apply the
    *Content guidelines* above yourself.
 
-Then continue with step 2 (`add-gallery-entry.sh`) below — step 1's
-drafting is already done.
+Steps 1–3 are automated by `scripts/promote-factory-to-gallery.sh`,
+which copies + rewrites the YAML, extracts `estimated_inferences` from
+the run log, defaults `category` / `recommended_model`, then delegates
+registration to `add-gallery-entry.sh`:
 
-> **Automation trigger:** if you have hand-run this bridge ≥3 times, or
-> the factory becomes a scheduled Routine, graduate steps 1–3 to
-> `scripts/promote-factory-to-gallery.sh` (curation stays manual — the
-> script takes an explicit slug). Tracked in #542.
+```sh
+bash scripts/promote-factory-to-gallery.sh <factory-id> \
+  --description "<short card-friendly summary>"
+```
+
+`<factory-id>` is the YAML's `id:` (e.g. `factory_20260618_uso_kigen`);
+the script derives the scenario / run-log paths and the default
+`<slug>_v1` gallery id from it. Pass `--description` to write a clean
+card summary — without it the factory YAML's description (which carries
+curation meta-notes) is used verbatim and only a warning is printed (it
+becomes a hard error under `--non-interactive`). Preview the derived
+values first with `--dry-run`; `--help` lists every flag — notably
+`--category` (default `creative`), `--recommended-model`, `--id` (for a
+`_v2` re-promotion), and `--scenario` / `--run-log` (to promote a
+non-factory source YAML, e.g. an improved variant). **Step 4 (curation)
+is still yours** — the script promotes the id you name and never picks
+by score.
+
+Then verify the scenario end-to-end (§3 below) and open a PR (§4) — the
+script has already done §1's drafting and §2's registration.
 
 ### 1. Draft the YAML
 

--- a/docs/gallery/README.md
+++ b/docs/gallery/README.md
@@ -170,8 +170,9 @@ card summary — without it the factory YAML's description (which carries
 curation meta-notes) is used verbatim and only a warning is printed (it
 becomes a hard error under `--non-interactive`). Preview the derived
 values first with `--dry-run`; `--help` lists every flag — notably
-`--category` (default `creative`), `--recommended-model`, `--id` (for a
-`_v2` re-promotion), and `--scenario` / `--run-log` (to promote a
+`--category` (default `creative`), `--recommended-model` (default
+`gemma-4-e2b-q4-k-m`), `--id` (for a `_v2` re-promotion), and
+`--scenario` / `--run-log` (to promote a
 non-factory source YAML, e.g. an improved variant). **Step 4 (curation)
 is still yours** — the script promotes the id you name and never picks
 by score.

--- a/scripts/promote-factory-to-gallery.sh
+++ b/scripts/promote-factory-to-gallery.sh
@@ -128,7 +128,7 @@ while [ $# -gt 0 ]; do
     --force) FORCE=1; shift ;;
     --dry-run) DRY_RUN=1; shift ;;
     --non-interactive|-y) NON_INTERACTIVE=1; shift ;;
-    -h|--help) awk '/^# Usage/{p=1} /^set -/{exit} p' "$0" | sed -E 's/^# ?//'; exit 0 ;;
+    -h|--help) awk 'NR==1{next} /^set -/{exit} /^#/' "$0" | sed -E 's/^# ?//'; exit 0 ;;
     -*) echo "Unknown flag: $1" >&2; exit 1 ;;
     *)
       if [ -z "$FACTORY_ID" ]; then
@@ -257,11 +257,12 @@ case "$ESTIMATED_INFERENCES" in
     echo "ERROR: estimated_inferences must be a positive integer (got: '$ESTIMATED_INFERENCES')." >&2
     exit 1 ;;
 esac
-# Advisory only — the gallery README suggests rough parity with a real run;
-# unusually large values are worth a glance but not a hard failure.
+# Advisory only — docs/gallery/README.md § "Content guidelines" sets a
+# soft norm of "under ~50 total estimated inferences"; flag (not fail)
+# anything above it so the curator can eyeball cost before promoting.
 if [ "$ESTIMATED_INFERENCES" -gt 50 ]; then
-  echo "ADVISORY: estimated_inferences=$ESTIMATED_INFERENCES is high (>50);" >&2
-  echo "          confirm it matches a real run (see docs/gallery/README.md)." >&2
+  echo "ADVISORY: estimated_inferences=$ESTIMATED_INFERENCES exceeds the ~50 soft" >&2
+  echo "          norm (docs/gallery/README.md § Content guidelines); confirm." >&2
 fi
 
 # --- description resolution ------------------------------------------------
@@ -284,8 +285,12 @@ if [ "$DESCRIPTION_SET" != "1" ]; then
 fi
 
 # --- Original id (for messaging) ------------------------------------------
-
-ORIG_ID="$(awk '/^id:[[:space:]]/{sub(/^id:[[:space:]]*/, ""); print; exit}' "$SCENARIO_PATH")"
+#
+# Message-only: the actual id rewrite below writes GALLERY_ID regardless of
+# the source's quoting, so this awk does not need to match add-gallery's
+# PyYAML parse — it just strips surrounding quotes so a quoted source id
+# (`id: "factory_…"`) renders cleanly in the "id: X → Y" line.
+ORIG_ID="$(awk '/^id:[[:space:]]/{sub(/^id:[[:space:]]*/, ""); print; exit}' "$SCENARIO_PATH" | sed -E 's/^["'\'']//; s/["'\'']$//')"
 if [ -z "$ORIG_ID" ]; then
   echo "ERROR: source YAML has no top-level 'id:' line: $SCENARIO_PATH" >&2
   exit 1

--- a/scripts/promote-factory-to-gallery.sh
+++ b/scripts/promote-factory-to-gallery.sh
@@ -1,0 +1,376 @@
+#!/usr/bin/env bash
+# scripts/promote-factory-to-gallery.sh — bridge a scenario-factory (or any
+# field-tested) scenario YAML into the shared-scenario gallery. Automates
+# docs/gallery/README.md § "Promoting from the scenario factory" steps 1–3
+# then delegates the mechanical registration (SHA / updated_at / title-sync
+# / validation) to add-gallery-entry.sh.
+#
+# Usage:
+#   bash scripts/promote-factory-to-gallery.sh <factory-id> [flags]   (factory mode)
+#   bash scripts/promote-factory-to-gallery.sh --scenario <yaml> --id <gallery-id> [flags]
+#                                                                      (path-spec mode)
+#
+# Modes:
+#   factory mode    Positional <factory-id> of the form
+#                    `factory_<YYYYMMDD>_<slug>` (the id stamped by the
+#                    /scenario-factory cycle). The date and slug are
+#                    parsed out and used to locate:
+#                      scenario: data/factory/scenarios/<YYYY-MM-DD>/<factory-id>.yaml
+#                      run log:  data/factory/runs/<YYYY-MM-DD>/<factory-id>.jsonl
+#                    The default gallery id is `<slug>_v1`.
+#
+#   path-spec mode  `--scenario <yaml>` points at any scenario YAML (e.g.
+#                    an improved v2 produced by a future improvement
+#                    routine). `--id <gallery-id>` is REQUIRED — the
+#                    target gallery id / filename stem cannot be derived.
+#                    `--run-log <jsonl>` is optional; when omitted you
+#                    MUST pass `--estimated-inferences <n>` (no log to
+#                    read it from).
+#
+# What it does (per the README bridge):
+#   1. Copies the source YAML → docs/gallery/<gallery-id>.yaml and
+#      rewrites the top-level `id:` to <gallery-id> (anchored ^id: edit,
+#      so the stem==id invariant add-gallery-entry.sh enforces holds).
+#   2. Extracts estimated_inferences from the run log's `run_start` line.
+#   3. Defaults category=creative and recommended_model to the factory's
+#      pinned model (both overridable).
+#   4. Calls add-gallery-entry.sh to register the entry.
+#
+# CURATION STAYS MANUAL: this script promotes the id you name. It never
+# inspects judge scores or auto-picks a gallery-worthy scenario — that
+# judgement is yours (see the README's curation guidance).
+#
+# Optional flags:
+#   --scenario <yaml>           path-spec mode source YAML (see Modes)
+#   --run-log <jsonl>           explicit run log (factory mode: derived;
+#                                path-spec mode: optional)
+#   --id <gallery-id>           target gallery id / filename stem
+#                                (factory mode default: <slug>_v1;
+#                                path-spec mode: REQUIRED)
+#   --category <slug>           gallery category (default: creative)
+#   --recommended-model <id>    default: gemma-4-e2b-q4-k-m
+#   --estimated-inferences <n>  override the run-log value; REQUIRED in
+#                                path-spec mode when --run-log is absent
+#   --description <text>        gallery card description. When omitted the
+#                                copied YAML's description is used — but
+#                                factory descriptions carry curation
+#                                meta-notes, so this prints a WARNING and
+#                                is an ERROR under --non-interactive.
+#   --added-at <YYYY-MM-DD>     passthrough to add-gallery-entry.sh
+#   --author <handle>           passthrough to add-gallery-entry.sh
+#   --force                     allow overwriting an existing
+#                                docs/gallery/<gallery-id>.yaml (default:
+#                                refuse, to protect curator edits)
+#   --dry-run                   print derived values + the would-be
+#                                add-gallery-entry.sh command, then exit
+#                                WITHOUT copying or delegating (the add
+#                                script has no dry-run of its own)
+#   --non-interactive, -y       pass --non-interactive to the add script
+#                                (suppresses its confirm prompt); also
+#                                forces --description (see above)
+#   -h, --help                  print this header
+
+set -euo pipefail
+
+# --- Dependency check ------------------------------------------------------
+
+for dep in jq awk shasum basename date; do
+  if ! command -v "$dep" >/dev/null 2>&1; then
+    echo "ERROR: missing dependency: $dep" >&2
+    exit 1
+  fi
+done
+
+ROOT="$(git rev-parse --show-toplevel)"
+GALLERY_DIR="$ROOT/docs/gallery"
+ADD_SCRIPT="$ROOT/scripts/add-gallery-entry.sh"
+
+# Shell-safe single-quote a value for the dry-run command preview. Unlike
+# printf %q this preserves UTF-8 (Japanese descriptions) readably while
+# staying copy-paste-safe: bare for [A-Za-z0-9_./=-], else single-quoted
+# with embedded quotes escaped as '\''.
+shell_quote() {
+  case "$1" in
+    *[!A-Za-z0-9_./=-]*|'')
+      printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")" ;;
+    *) printf '%s' "$1" ;;
+  esac
+}
+
+# --- Argument parsing ------------------------------------------------------
+
+FACTORY_ID=""
+SCENARIO_PATH=""
+RUN_LOG=""
+GALLERY_ID=""
+CATEGORY="creative"
+RECOMMENDED_MODEL="gemma-4-e2b-q4-k-m"
+ESTIMATED_INFERENCES=""
+DESCRIPTION=""
+DESCRIPTION_SET=0
+ADDED_AT=""
+AUTHOR=""
+FORCE=0
+DRY_RUN=0
+NON_INTERACTIVE=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --scenario) SCENARIO_PATH="$2"; shift 2 ;;
+    --run-log) RUN_LOG="$2"; shift 2 ;;
+    --id) GALLERY_ID="$2"; shift 2 ;;
+    --category) CATEGORY="$2"; shift 2 ;;
+    --recommended-model) RECOMMENDED_MODEL="$2"; shift 2 ;;
+    --estimated-inferences) ESTIMATED_INFERENCES="$2"; shift 2 ;;
+    --description) DESCRIPTION="$2"; DESCRIPTION_SET=1; shift 2 ;;
+    --added-at) ADDED_AT="$2"; shift 2 ;;
+    --author) AUTHOR="$2"; shift 2 ;;
+    --force) FORCE=1; shift ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --non-interactive|-y) NON_INTERACTIVE=1; shift ;;
+    -h|--help) awk '/^# Usage/{p=1} /^set -/{exit} p' "$0" | sed -E 's/^# ?//'; exit 0 ;;
+    -*) echo "Unknown flag: $1" >&2; exit 1 ;;
+    *)
+      if [ -z "$FACTORY_ID" ]; then
+        FACTORY_ID="$1"
+      else
+        echo "ERROR: unexpected positional argument: $1" >&2
+        exit 1
+      fi
+      shift
+      ;;
+  esac
+done
+
+# --- Mode resolution -------------------------------------------------------
+
+if [ -n "$FACTORY_ID" ] && [ -n "$SCENARIO_PATH" ]; then
+  echo "ERROR: pass EITHER a <factory-id> positional OR --scenario, not both." >&2
+  exit 1
+fi
+
+if [ -n "$FACTORY_ID" ]; then
+  MODE="factory"
+elif [ -n "$SCENARIO_PATH" ]; then
+  MODE="path"
+else
+  echo "ERROR: provide a <factory-id> positional or --scenario <yaml>." >&2
+  echo "       See: bash $0 --help" >&2
+  exit 1
+fi
+
+# --- Factory-mode derivation ----------------------------------------------
+
+if [ "$MODE" = "factory" ]; then
+  # Expect factory_<8 digits>_<slug>. Validate up front so a path or a
+  # malformed id produces a clear error rather than a confusing
+  # file-not-found far downstream.
+  case "$FACTORY_ID" in
+    factory_[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]_*) ;;
+    *)
+      echo "ERROR: '$FACTORY_ID' is not a factory id of the form factory_<YYYYMMDD>_<slug>." >&2
+      echo "       For an arbitrary YAML, use: --scenario <yaml> --id <gallery-id>" >&2
+      exit 1 ;;
+  esac
+  # Fixed-offset parse (not a delimiter split — slugs contain underscores).
+  REST="${FACTORY_ID#factory_}"     # 20260618_uso_kigen
+  DATESTAMP="${REST:0:8}"           # 20260618
+  SLUG="${REST:9}"                  # uso_kigen  (skip the underscore at index 8)
+  if [ -z "$SLUG" ]; then
+    echo "ERROR: factory id '$FACTORY_ID' has an empty slug." >&2
+    exit 1
+  fi
+  DATE="${DATESTAMP:0:4}-${DATESTAMP:4:2}-${DATESTAMP:6:2}"   # 2026-06-18
+  SCENARIO_PATH="$ROOT/data/factory/scenarios/$DATE/$FACTORY_ID.yaml"
+  if [ -z "$RUN_LOG" ]; then
+    RUN_LOG="$ROOT/data/factory/runs/$DATE/$FACTORY_ID.jsonl"
+  fi
+  if [ -z "$GALLERY_ID" ]; then
+    GALLERY_ID="${SLUG}_v1"
+  fi
+fi
+
+# --- Path-mode requirements -----------------------------------------------
+
+if [ "$MODE" = "path" ] && [ -z "$GALLERY_ID" ]; then
+  echo "ERROR: --id <gallery-id> is required in path-spec mode (cannot be derived)." >&2
+  exit 1
+fi
+
+# --- Common validation -----------------------------------------------------
+
+# gallery-id must be a safe filename stem AND a valid scenario id. The add
+# script enforces stem==id; we keep the id conservative here so neither the
+# copy destination nor the rewrite produce anything surprising.
+case "$GALLERY_ID" in
+  [a-z0-9]*) ;;
+  *) echo "ERROR: gallery id '$GALLERY_ID' must start with a lowercase letter or digit." >&2; exit 1 ;;
+esac
+case "$GALLERY_ID" in
+  *[!a-z0-9_]*) echo "ERROR: gallery id '$GALLERY_ID' may contain only [a-z0-9_]." >&2; exit 1 ;;
+esac
+
+if [ ! -f "$SCENARIO_PATH" ]; then
+  echo "ERROR: scenario YAML not found: $SCENARIO_PATH" >&2
+  exit 1
+fi
+
+if [ ! -f "$ADD_SCRIPT" ]; then
+  echo "ERROR: add-gallery-entry.sh not found at $ADD_SCRIPT" >&2
+  exit 1
+fi
+
+DEST="$GALLERY_DIR/$GALLERY_ID.yaml"
+if [ -e "$DEST" ] && [ "$FORCE" != "1" ]; then
+  echo "ERROR: $DEST already exists." >&2
+  echo "       Refusing to overwrite a curated gallery YAML. Re-run with --force" >&2
+  echo "       to overwrite, or pass a different --id (e.g. a _v2 promotion)." >&2
+  exit 1
+fi
+
+# --- estimated_inferences resolution --------------------------------------
+#
+# Precedence: explicit --estimated-inferences > run log's run_start line.
+# `jq -s` slurps the whole JSONL into an array so we pick the first
+# run_start without a `head -1` SIGPIPE (which would trip `set -o pipefail`).
+if [ -z "$ESTIMATED_INFERENCES" ]; then
+  if [ -n "$RUN_LOG" ] && [ -f "$RUN_LOG" ]; then
+    ESTIMATED_INFERENCES="$(jq -rs '([.[] | select(.type=="run_start")][0] // {}) | .estimated_inferences // empty' "$RUN_LOG")"
+    if [ -z "$ESTIMATED_INFERENCES" ]; then
+      echo "ERROR: no run_start.estimated_inferences found in $RUN_LOG." >&2
+      echo "       Pass --estimated-inferences <n> explicitly." >&2
+      exit 1
+    fi
+  else
+    if [ "$MODE" = "path" ]; then
+      echo "ERROR: path-spec mode without --run-log requires --estimated-inferences <n>." >&2
+    else
+      echo "ERROR: run log not found: $RUN_LOG" >&2
+      echo "       Pass --run-log <jsonl> or --estimated-inferences <n>." >&2
+    fi
+    exit 1
+  fi
+fi
+
+case "$ESTIMATED_INFERENCES" in
+  ''|*[!0-9]*)
+    echo "ERROR: estimated_inferences must be a positive integer (got: '$ESTIMATED_INFERENCES')." >&2
+    exit 1 ;;
+esac
+# Advisory only — the gallery README suggests rough parity with a real run;
+# unusually large values are worth a glance but not a hard failure.
+if [ "$ESTIMATED_INFERENCES" -gt 50 ]; then
+  echo "ADVISORY: estimated_inferences=$ESTIMATED_INFERENCES is high (>50);" >&2
+  echo "          confirm it matches a real run (see docs/gallery/README.md)." >&2
+fi
+
+# --- description resolution ------------------------------------------------
+#
+# When --description is omitted the add script falls back to the copied
+# YAML's description. Factory descriptions carry curation meta-notes, so
+# under --non-interactive (e.g. a scheduled Routine) that fallback would
+# silently ship meta-notes to users — make it a hard error there; warn
+# otherwise.
+if [ "$DESCRIPTION_SET" != "1" ]; then
+  if [ "$NON_INTERACTIVE" = "1" ]; then
+    echo "ERROR: --non-interactive requires an explicit --description." >&2
+    echo "       The source YAML's description may contain curation meta-notes" >&2
+    echo "       unsuitable for a user-facing gallery card." >&2
+    exit 1
+  fi
+  echo "WARNING: no --description given — the gallery card will use the source" >&2
+  echo "         YAML's description verbatim, which may contain curation" >&2
+  echo "         meta-notes. Review and edit the gallery card if needed." >&2
+fi
+
+# --- Original id (for messaging) ------------------------------------------
+
+ORIG_ID="$(awk '/^id:[[:space:]]/{sub(/^id:[[:space:]]*/, ""); print; exit}' "$SCENARIO_PATH")"
+if [ -z "$ORIG_ID" ]; then
+  echo "ERROR: source YAML has no top-level 'id:' line: $SCENARIO_PATH" >&2
+  exit 1
+fi
+
+# --- Build the add-gallery-entry.sh argument vector -----------------------
+
+ADD_ARGS=("$DEST"
+  --category "$CATEGORY"
+  --recommended-model "$RECOMMENDED_MODEL"
+  --estimated-inferences "$ESTIMATED_INFERENCES")
+[ "$DESCRIPTION_SET" = "1" ] && ADD_ARGS+=(--description "$DESCRIPTION")
+[ -n "$ADDED_AT" ] && ADD_ARGS+=(--added-at "$ADDED_AT")
+[ -n "$AUTHOR" ] && ADD_ARGS+=(--author "$AUTHOR")
+[ "$NON_INTERACTIVE" = "1" ] && ADD_ARGS+=(--non-interactive)
+
+# --- Dry run: report and stop BEFORE any write or delegation --------------
+
+if [ "$DRY_RUN" = "1" ]; then
+  echo "[dry-run] would promote:"
+  echo "  mode:                  $MODE"
+  echo "  source YAML:           $SCENARIO_PATH"
+  echo "  source id:             $ORIG_ID"
+  [ -n "$RUN_LOG" ] && echo "  run log:               $RUN_LOG"
+  echo "  destination:           $DEST"
+  echo "  gallery id (= stem):   $GALLERY_ID"
+  echo "  category:              $CATEGORY"
+  echo "  recommended_model:     $RECOMMENDED_MODEL"
+  echo "  estimated_inferences:  $ESTIMATED_INFERENCES"
+  if [ "$DESCRIPTION_SET" = "1" ]; then
+    echo "  description:           (override) $DESCRIPTION"
+  else
+    echo "  description:           (from source YAML — review!)"
+  fi
+  echo ""
+  echo "[dry-run] would then run:"
+  printf '  bash %s' "$(shell_quote "$ADD_SCRIPT")"
+  for a in "${ADD_ARGS[@]}"; do printf ' %s' "$(shell_quote "$a")"; done
+  printf '\n'
+  echo ""
+  echo "[dry-run] no files written."
+  exit 0
+fi
+
+# --- Copy + anchored id rewrite -------------------------------------------
+#
+# Copy first, then rewrite ONLY the first top-level `^id:` line. An
+# unanchored substitution would corrupt any other `factory_<date>_<slug>`
+# occurrence (persona ids, prose); a PyYAML round-trip would reorder keys
+# and drop comments. The single GALLERY_ID is used for BOTH the filename
+# stem (DEST) and the rewritten id, so add-gallery-entry.sh's stem==id
+# guard cannot fail.
+cp "$SCENARIO_PATH" "$DEST"
+
+awk -v newid="$GALLERY_ID" '
+  !done && /^id:[[:space:]]/ { print "id: " newid; done = 1; next }
+  { print }
+  END { if (!done) exit 3 }
+' "$DEST" > "$DEST.tmp" || {
+  rm -f "$DEST.tmp" "$DEST"
+  echo "ERROR: source YAML has no top-level 'id:' line to rewrite." >&2
+  exit 1
+}
+mv "$DEST.tmp" "$DEST"
+
+echo "Wrote $DEST (id: $ORIG_ID → $GALLERY_ID)"
+
+# --- Delegate registration -------------------------------------------------
+
+if bash "$ADD_SCRIPT" "${ADD_ARGS[@]}"; then
+  echo ""
+  echo "Promoted $GALLERY_ID to the gallery."
+  echo "Next: review the diff, run a Debug build with PASTURA_GALLERY_BASE_URL"
+  echo "      pointing at your branch, and confirm the scenario installs cleanly."
+else
+  STATUS=$?
+  # If we created a fresh file (not a --force overwrite of a pre-existing
+  # one), remove the orphan so a failed add (e.g. duplicate id in
+  # gallery.json) does not leave an untracked stray YAML behind.
+  if [ "$FORCE" != "1" ]; then
+    rm -f "$DEST"
+    echo "Removed $DEST (add-gallery-entry.sh failed; no partial promotion left behind)." >&2
+  else
+    echo "WARNING: add-gallery-entry.sh failed and $DEST was overwritten (--force)." >&2
+    echo "         Restore it from git if needed." >&2
+  fi
+  exit "$STATUS"
+fi

--- a/scripts/tests/gallery-scripts-test.sh
+++ b/scripts/tests/gallery-scripts-test.sh
@@ -136,6 +136,7 @@ runc "$R" jq -r '.scenarios[0] | "\(.id) \(.estimated_inferences) \(.agent_count
 expect_out "demo_v1 42 4 2 Test demo" "P2 entry has derived id/ei + YAML-sourced agent_count/rounds/title"
 
 # P9 — re-promote without --force refuses to overwrite the curated YAML.
+# Reuses P2's repo (already has demo_v1.yaml); no new_repo between them.
 runc "$R" bash scripts/promote-factory-to-gallery.sh factory_20260101_demo \
   --non-interactive --description x --author tester
 expect_fail "P9 re-promote without --force fails"

--- a/scripts/tests/gallery-scripts-test.sh
+++ b/scripts/tests/gallery-scripts-test.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+#
+# scripts/tests/gallery-scripts-test.sh — regression tests for the gallery
+# tooling: scripts/add-gallery-entry.sh, scripts/check-gallery-entry.sh,
+# and scripts/promote-factory-to-gallery.sh (#542).
+#
+# Black-box tests. Each case scaffolds an ISOLATED throwaway git repo
+# under a tempdir (copies the three scripts into <tmp>/scripts/, writes a
+# minimal docs/gallery/gallery.json, `git init`), then runs the scripts
+# from inside it. Because every script resolves its root via
+# `git rev-parse --show-toplevel`, the temp repo becomes their root — so
+# the real docs/gallery/ is never touched and cases are parallel-safe.
+# No production code change and no new dependency (jq + python3/PyYAML,
+# already required by the scripts under test).
+#
+# check-gallery-entry.sh's Presets uniqueness scan tolerates a missing
+# Pastura/Pastura/Resources/Presets/ dir (the glob yields no match), so
+# the scaffold omits it — gallery-only id uniqueness is still exercised.
+#
+# CI-wired: the `scripts/tests/*-test.sh` naming convention makes this a
+# gate under .github/workflows/ci.yml ("Run scripts/tests/*-test.sh",
+# the `shell-tests` job). That job runs on ubuntu (bash 5+); the scripts
+# under test ship to macOS (bash 3.2), so run this manually under
+# /bin/bash before merge for 3.2 coverage:
+#
+#   /bin/bash scripts/tests/gallery-scripts-test.sh
+
+set -euo pipefail
+
+for dep in jq python3 git shasum; do
+  command -v "$dep" >/dev/null 2>&1 || { echo "ERROR: missing dependency: $dep" >&2; exit 1; }
+done
+python3 -c "import yaml" 2>/dev/null || { echo "ERROR: PyYAML not available — 'python3 -m pip install pyyaml'" >&2; exit 1; }
+
+SRC_SCRIPTS="$(git rev-parse --show-toplevel)/scripts"
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+PASS=0
+FAIL=0
+OUT=""
+RC=0
+
+# --- Assertion + scaffold helpers -----------------------------------------
+
+bad() { echo "FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+
+# Run "$@" with cwd set to repo $1, capturing combined output + exit code
+# into OUT / RC. Toggles errexit so a non-zero exit is observed, not fatal.
+runc() {
+  local d="$1"; shift
+  set +e
+  OUT="$(cd "$d" && "$@" 2>&1)"
+  RC=$?
+  set -e
+}
+
+expect_ok()   { if [ "$RC" -eq 0 ]; then PASS=$((PASS + 1)); else bad "$1 (rc=$RC): $OUT"; fi; }
+expect_fail() { if [ "$RC" -ne 0 ]; then PASS=$((PASS + 1)); else bad "$1 (expected non-zero rc): $OUT"; fi; }
+expect_out()  { case "$OUT" in *"$1"*) PASS=$((PASS + 1));; *) bad "$2 (missing '$1'): $OUT";; esac; }
+expect_file()   { if [ -f "$1" ]; then PASS=$((PASS + 1)); else bad "$2 (no file: $1)"; fi; }
+expect_nofile() { if [ ! -e "$1" ]; then PASS=$((PASS + 1)); else bad "$2 (unexpected file: $1)"; fi; }
+
+new_repo() {
+  local d
+  d="$(mktemp -d "$TMPROOT/repo.XXXXXX")"
+  mkdir -p "$d/scripts" "$d/docs/gallery"
+  cp "$SRC_SCRIPTS/add-gallery-entry.sh" \
+     "$SRC_SCRIPTS/check-gallery-entry.sh" \
+     "$SRC_SCRIPTS/promote-factory-to-gallery.sh" "$d/scripts/"
+  printf '{\n  "updated_at": "2026-01-01T00:00:00Z",\n  "scenarios": []\n}\n' \
+    > "$d/docs/gallery/gallery.json"
+  git -C "$d" init -q
+  git -C "$d" config user.email "t@example.com"
+  git -C "$d" config user.name "tester"
+  printf '%s' "$d"
+}
+
+mk_factory() {  # repo date datestamp slug estimated_inferences
+  local d="$1" date="$2" ds="$3" slug="$4" ei="$5"
+  mkdir -p "$d/data/factory/scenarios/$date" "$d/data/factory/runs/$date"
+  cat > "$d/data/factory/scenarios/$date/factory_${ds}_${slug}.yaml" <<YAML
+id: factory_${ds}_${slug}
+language: ja
+name: Test ${slug}
+agents: 4
+rounds: 2
+description: factory description with a curation meta-note
+personas:
+  - name: persona1
+    description: body references factory_${ds}_${slug} verbatim
+YAML
+  printf '{"type":"run_start","estimated_inferences":%s}\n{"type":"turn"}\n{"type":"run_end"}\n' \
+    "$ei" > "$d/data/factory/runs/$date/factory_${ds}_${slug}.jsonl"
+}
+
+mk_gallery_yaml() {  # repo id agents rounds [description]
+  local d="$1" id="$2" agents="$3" rounds="$4" desc="${5:-card description}"
+  cat > "$d/docs/gallery/$id.yaml" <<YAML
+id: $id
+language: ja
+name: Name of $id
+agents: $agents
+rounds: $rounds
+description: $desc
+personas:
+  - name: a
+    description: aa
+YAML
+}
+
+# ============================ promote-factory ============================
+
+# P1 — dry-run derives id/estimated_inferences and writes nothing.
+R="$(new_repo)"; mk_factory "$R" 2026-01-01 20260101 demo 42
+runc "$R" bash scripts/promote-factory-to-gallery.sh factory_20260101_demo --dry-run --description card
+expect_ok "P1 dry-run exits 0"
+expect_out "demo_v1" "P1 derives gallery id demo_v1"
+expect_out "estimated_inferences:  42" "P1 extracts estimated_inferences from run log"
+expect_nofile "$R/docs/gallery/demo_v1.yaml" "P1 dry-run writes no YAML"
+runc "$R" jq -r '.scenarios | length' docs/gallery/gallery.json
+expect_out "0" "P1 dry-run added no gallery.json entry"
+
+# P2 — real factory promote: id rewrite (anchored) + gallery.json entry.
+R="$(new_repo)"; mk_factory "$R" 2026-01-01 20260101 demo 42
+runc "$R" bash scripts/promote-factory-to-gallery.sh factory_20260101_demo \
+  --non-interactive --description "clean card copy" --author tester
+expect_ok "P2 promote exits 0"
+expect_file "$R/docs/gallery/demo_v1.yaml" "P2 writes the gallery YAML"
+runc "$R" awk 'NR==1' docs/gallery/demo_v1.yaml
+expect_out "id: demo_v1" "P2 top-level id rewritten to demo_v1"
+runc "$R" grep -c "factory_20260101_demo" docs/gallery/demo_v1.yaml
+expect_out "1" "P2 body factory_<id> substring preserved (not clobbered)"
+runc "$R" jq -r '.scenarios[0] | "\(.id) \(.estimated_inferences) \(.agent_count) \(.rounds) \(.title)"' \
+  docs/gallery/gallery.json
+expect_out "demo_v1 42 4 2 Test demo" "P2 entry has derived id/ei + YAML-sourced agent_count/rounds/title"
+
+# P9 — re-promote without --force refuses to overwrite the curated YAML.
+runc "$R" bash scripts/promote-factory-to-gallery.sh factory_20260101_demo \
+  --non-interactive --description x --author tester
+expect_fail "P9 re-promote without --force fails"
+expect_out "already exists" "P9 overwrite guard message"
+
+# P10 — path-spec mode (arbitrary source + explicit id + estimated).
+R="$(new_repo)"; mk_factory "$R" 2026-02-02 20260202 src 7
+runc "$R" bash scripts/promote-factory-to-gallery.sh \
+  --scenario data/factory/scenarios/2026-02-02/factory_20260202_src.yaml \
+  --id improved_v2 --estimated-inferences 7 --description "v2 card" \
+  --non-interactive --author tester
+expect_ok "P10 path-spec promote exits 0"
+expect_file "$R/docs/gallery/improved_v2.yaml" "P10 writes improved_v2.yaml"
+runc "$R" jq -r '.scenarios[0].id' docs/gallery/gallery.json
+expect_out "improved_v2" "P10 registers improved_v2"
+
+# Error paths (each on a fresh repo; some need only arg parsing).
+R="$(new_repo)"
+runc "$R" bash scripts/promote-factory-to-gallery.sh not_a_factory_id
+expect_fail "P-err bad factory id fails"; expect_out "not a factory id" "P-err bad-id message"
+
+runc "$R" bash scripts/promote-factory-to-gallery.sh factory_20260101_demo --scenario x.yaml
+expect_fail "P-err both modes fails"; expect_out "not both" "P-err both-modes message"
+
+runc "$R" bash scripts/promote-factory-to-gallery.sh --scenario docs/gallery/gallery.json
+expect_fail "P-err path mode without --id fails"; expect_out "required in path-spec" "P-err missing --id message"
+
+mk_factory "$R" 2026-03-03 20260303 noec 5
+runc "$R" bash scripts/promote-factory-to-gallery.sh \
+  --scenario data/factory/scenarios/2026-03-03/factory_20260303_noec.yaml --id noec_v1
+expect_fail "P-err path mode no run-log + no estimated fails"
+expect_out "requires --estimated-inferences" "P-err missing estimated message"
+
+mk_factory "$R" 2026-04-04 20260404 nod 9
+runc "$R" bash scripts/promote-factory-to-gallery.sh factory_20260404_nod -y
+expect_fail "P-err -y without --description fails"
+expect_out "requires an explicit --description" "P-err non-interactive description message"
+
+# ============================ add-gallery-entry ==========================
+
+# A1 — add a new entry; agent_count/rounds derived from the YAML.
+R="$(new_repo)"; mk_gallery_yaml "$R" foo_v1 5 3
+runc "$R" bash scripts/add-gallery-entry.sh docs/gallery/foo_v1.yaml \
+  --category creative --recommended-model gemma-4-e2b-q4-k-m \
+  --estimated-inferences 8 --description card --author tester --non-interactive
+expect_ok "A1 add exits 0"
+runc "$R" jq -r '.scenarios[0] | "\(.id) \(.agent_count) \(.rounds)"' docs/gallery/gallery.json
+expect_out "foo_v1 5 3" "A1 entry agent_count/rounds from YAML scalars"
+
+# A2 — duplicate id rejected in add mode (reuses A1's repo state).
+runc "$R" bash scripts/add-gallery-entry.sh docs/gallery/foo_v1.yaml \
+  --category creative --recommended-model gemma-4-e2b-q4-k-m \
+  --estimated-inferences 8 --description card --author tester --non-interactive
+expect_fail "A2 duplicate id fails"; expect_out "already exists" "A2 dup-id message"
+
+# A4 — update mode refreshes the sha after a YAML body edit.
+SHA_BEFORE="$(jq -r '.scenarios[0].yaml_sha256' "$R/docs/gallery/gallery.json")"
+mk_gallery_yaml "$R" foo_v1 5 3 "edited description body"
+runc "$R" bash scripts/add-gallery-entry.sh --update foo_v1 --non-interactive
+expect_ok "A4 update exits 0"; expect_out "Updated entry" "A4 update message"
+SHA_AFTER="$(jq -r '.scenarios[0].yaml_sha256' "$R/docs/gallery/gallery.json")"
+if [ "$SHA_BEFORE" != "$SHA_AFTER" ]; then PASS=$((PASS + 1)); else bad "A4 sha did not refresh"; fi
+
+# A5 — update with no change short-circuits (no-op).
+runc "$R" bash scripts/add-gallery-entry.sh --update foo_v1 --non-interactive
+expect_ok "A5 no-op update exits 0"; expect_out "No change needed" "A5 no-op message"
+
+# A3 — filename stem != YAML id rejected.
+R="$(new_repo)"; mk_gallery_yaml "$R" wrongstem 4 2
+# Rewrite the internal id so stem (wrongstem) != id (otherid).
+sed 's/^id: wrongstem/id: otherid/' "$R/docs/gallery/wrongstem.yaml" > "$R/docs/gallery/wrongstem.yaml.t"
+mv "$R/docs/gallery/wrongstem.yaml.t" "$R/docs/gallery/wrongstem.yaml"
+runc "$R" bash scripts/add-gallery-entry.sh docs/gallery/wrongstem.yaml \
+  --category creative --recommended-model gemma-4-e2b-q4-k-m \
+  --estimated-inferences 8 --description card --author tester --non-interactive
+expect_fail "A3 stem!=id fails"; expect_out "does not match YAML id" "A3 stem-mismatch message"
+
+# A6 — non-interactive with a missing required field fails fast.
+R="$(new_repo)"; mk_gallery_yaml "$R" bar_v1 4 2
+runc "$R" bash scripts/add-gallery-entry.sh docs/gallery/bar_v1.yaml \
+  --recommended-model gemma-4-e2b-q4-k-m --estimated-inferences 8 \
+  --description card --author tester --non-interactive
+expect_fail "A6 non-interactive missing category fails"
+expect_out "category is missing" "A6 missing-field message"
+
+# ================================ summary ================================
+
+echo ""
+echo "gallery-scripts-test: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1
+echo "OK"


### PR DESCRIPTION
## Summary
- New `scripts/promote-factory-to-gallery.sh` automates the scenario-factory → shared-scenario-gallery bridge (README § "Promoting from the scenario factory" steps 1–3), then delegates registration to `add-gallery-entry.sh`.
- **Factory mode**: `promote-factory-to-gallery.sh <factory-id>` derives date/slug/scenario-path/run-log from the id; default gallery id `<slug>_v1`; extracts `estimated_inferences` from the run log's `run_start` line.
- **Path-spec mode**: `--scenario <yaml> [--run-log <jsonl>] --id <id>` promotes any source YAML — the hook for a future scenario-improvement routine (e.g. an improved `_v2` variant).
- Anchored `^id:` rewrite (single gallery-id var = filename stem + internal id) so add-gallery's stem==id guard holds and body `factory_<date>_<slug>` substrings are never clobbered.
- `--description` override (YAML fallback warns; hard error under `--non-interactive` so a Routine can't ship curation meta-notes), `--force`-guarded overwrite, `--dry-run` (stops before copy + delegation), `--help`. bash 3.2-safe. **Curation stays manual** — the script promotes the id you name, never auto-picks by score.
- README updated to document the script (replaces the #542 deferral note).
- **Tests**: new `scripts/tests/gallery-scripts-test.sh` — black-box regression coverage for `add-gallery-entry.sh`, `check-gallery-entry.sh`, and the new script (38 assertions). Each case scaffolds an isolated throwaway git repo (copies the scripts in + minimal `gallery.json` + `git init`), so the real `docs/gallery/` is never touched and cases are parallel-safe. Auto-wired as a CI gate via the `scripts/tests/*-test.sh` convention (`shell-tests` job, + a PyYAML install step).

## Test plan
- `scripts/tests/gallery-scripts-test.sh`: 38 assertions green under macOS bash 3.2. Covers promote dry-run derivation, anchored id-rewrite (+ body substring preservation), gallery.json entry shape, every error path, path-spec mode; add new/duplicate-id/stem!=id/update-refresh/update-noop/non-interactive-missing-field.
- Manual: `--help` / `--dry-run` (factory + path-spec); end-to-end promote into a synthetic fixture verified id rewrite (top-level only; persona `factory_…` substring preserved), correct `gallery.json` entry (title/agent_count/rounds/sha auto), re-promotion overwrite guard. `shellcheck` clean.

Closes #542

🤖 Generated with [Claude Code](https://claude.com/claude-code)