### PR TITLE
✨ feat: full-bleed grouped style for browse lists

### DIFF
--- a/Pastura/Pastura/App/ModelManager.swift
+++ b/Pastura/Pastura/App/ModelManager.swift
@@ -295,12 +295,12 @@ final class ModelManager {  // swiftlint:disable:this type_body_length
   ///
   /// In-flight partial downloads (in `cachesDirectoryURL`) and `.error`-state
   /// leftovers are intentionally excluded — the figure represents completed,
-  /// on-device models, matching the Settings "Downloaded models" label.
+  /// on-device models, matching the Settings "Downloaded" label.
   ///
   /// A `.ready` catalog descriptor's declared `fileSize` is a valid stand-in
   /// for its on-disk size: `computeState` deletes any file whose actual size
   /// ≠ declared size, so the two always agree once `.ready`. Consumed by
-  /// `SettingsView.storageTotalLine`, which feeds it the ready descriptors'
+  /// `SettingsView.downloadedTotalText`, which feeds it the ready descriptors'
   /// declared sizes plus its reactive orphan snapshot (mirrors how the
   /// picker consumes `isLowStorage` — pure static, no filesystem read in
   /// the view body).

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -2460,6 +2460,7 @@
       }
     },
     "Downloaded models · %@" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -2471,6 +2472,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ダウンロード済みモデル · %@"
+          }
+        }
+      }
+    },
+    "Downloaded · %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Downloaded · %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダウンロード済み · %@"
           }
         }
       }
@@ -4459,6 +4476,7 @@
       }
     },
     "Recommended Scenarios" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ja" : {
           "stringUnit" : {
@@ -6127,6 +6145,7 @@
       }
     },
     "You can keep multiple models on this device. Only the active one is loaded in memory." : {
+      "extractionState" : "stale",
       "localizations" : {
         "ja" : {
           "stringUnit" : {

--- a/Pastura/Pastura/Views/Community/SharedScenarios/SharedScenariosListView+CategoryChips.swift
+++ b/Pastura/Pastura/Views/Community/SharedScenarios/SharedScenariosListView+CategoryChips.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+// Category-filter chip row, split out of `SharedScenariosListView` to keep the
+// main view under the type_body_length budget (#731). `categoryChips` is the
+// only entry point the main file calls, so it is module-internal; the per-chip
+// helpers stay file-private to this sibling.
+extension SharedScenariosListView {
+
+  /// Horizontal, scrollable category-filter chip row (ADR-016 P4). Replaces
+  /// the menu `Picker`: every category is one tap inline, matching the D3
+  /// Browse mock. Drives the existing `selectedCategory` binding (nil =
+  /// "All"); `visibleScenarios` still owns the actual filtering.
+  func categoryChips(selection: Binding<GalleryCategory?>) -> some View {
+    ScrollView(.horizontal, showsIndicators: false) {
+      HStack(spacing: 8) {
+        ForEach(GalleryCategoryFilter.options, id: \.self) { option in
+          categoryChip(option, selection: selection)
+        }
+      }
+      .padding(.horizontal, PasturaCardMetrics.horizontalMargin)
+    }
+  }
+
+  private func categoryChip(
+    _ option: GalleryCategoryFilter, selection: Binding<GalleryCategory?>
+  ) -> some View {
+    let isSelected = option.selectedCategory == selection.wrappedValue
+    return Button {
+      selection.wrappedValue = option.selectedCategory
+    } label: {
+      Text(chipTitle(option))
+        .font(.subheadline.weight(isSelected ? .semibold : .regular))
+        // Selected uses `mossDark`, not base `moss`: white-on-mossDark clears
+        // WCAG AA (≈4.76:1) whereas white-on-moss is only ≈3.0:1
+        // (PasturaPrimaryButtonStyle §2.3). White-on-accent is the
+        // contrast-passing pair, distinct from §1's avoid-white-surfaces rule.
+        .foregroundStyle(isSelected ? Color.white : Color.ink)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 7)
+        .background(isSelected ? Color.mossDark : Color.bubbleBackground, in: Capsule())
+        .overlay(
+          Capsule().strokeBorder(
+            isSelected ? Color.clear : Color.rule,
+            lineWidth: PasturaCardMetrics.chipBorderWidth))
+    }
+    .buttonStyle(.plain)
+    // The menu Picker announced its selection for free; rebuild that on the
+    // hand-rolled chips so VoiceOver still reads which filter is active.
+    .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+  }
+
+  private func chipTitle(_ option: GalleryCategoryFilter) -> String {
+    switch option {
+    case .all: return String(localized: "All")
+    case .category(let category): return category.displayName
+    }
+  }
+}

--- a/Pastura/Pastura/Views/Community/SharedScenarios/SharedScenariosListView.swift
+++ b/Pastura/Pastura/Views/Community/SharedScenarios/SharedScenariosListView.swift
@@ -109,7 +109,6 @@ struct SharedScenariosListView: View {
           offlineBanner
         }
         categoryChips(selection: $bindable.selectedCategory)
-        recommendedHeader
         scenariosCard(viewModel: viewModel)
         if let updated = viewModel.updatedAt {
           Text(String(format: String(localized: "Last updated: %@"), updated))
@@ -205,17 +204,6 @@ struct SharedScenariosListView: View {
   // `categoryChips` / `categoryChip` / `chipTitle` live in
   // `SharedScenariosListView+CategoryChips.swift` (split out for the
   // type_body_length budget, #731).
-
-  /// "Recommended" section header above the scenarios card (D3 Browse mock),
-  /// styled like a ``PasturaSection`` header (muted subheadline).
-  private var recommendedHeader: some View {
-    Text(String(localized: "Recommended Scenarios"))
-      .font(.subheadline)
-      .foregroundStyle(Color.muted)
-      .frame(maxWidth: .infinity, alignment: .leading)
-      .padding(.horizontal, PasturaCardMetrics.horizontalMargin + 6)
-      .accessibilityAddTraits(.isHeader)
-  }
 
   private func scenarioRow(
     scenario: GalleryScenario, viewModel: SharedScenariosViewModel

--- a/Pastura/Pastura/Views/Community/SharedScenarios/SharedScenariosListView.swift
+++ b/Pastura/Pastura/Views/Community/SharedScenarios/SharedScenariosListView.swift
@@ -129,7 +129,7 @@ struct SharedScenariosListView: View {
   @ViewBuilder
   private func scenariosCard(viewModel: SharedScenariosViewModel) -> some View {
     if viewModel.visibleScenarios.isEmpty {
-      PasturaSection {
+      PasturaSection(style: .grouped) {
         Text(emptyResultsMessage(viewModel: viewModel))
           .foregroundStyle(Color.inkSecondary)
           .frame(maxWidth: .infinity, alignment: .leading)
@@ -138,10 +138,12 @@ struct SharedScenariosListView: View {
       }
     } else {
       let scenarios = viewModel.visibleScenarios
-      PasturaSection {
+      PasturaSection(style: .grouped) {
         VStack(spacing: 0) {
           ForEach(Array(scenarios.enumerated()), id: \.element.id) { index, scenario in
-            if index > 0 { PasturaRowDivider() }
+            if index > 0 {
+              PasturaRowDivider(leadingInset: PasturaCardMetrics.horizontalMargin)
+            }
             NavigationLink(value: Route.galleryScenarioDetail(scenario: scenario)) {
               galleryRow(scenario: scenario, viewModel: viewModel)
             }
@@ -199,56 +201,10 @@ struct SharedScenariosListView: View {
   }
 
   // MARK: - Category filter chips
-
-  /// Horizontal, scrollable category-filter chip row (ADR-016 P4). Replaces
-  /// the menu `Picker`: every category is one tap inline, matching the D3
-  /// Browse mock. Drives the existing `selectedCategory` binding (nil =
-  /// "All"); `visibleScenarios` still owns the actual filtering.
-  private func categoryChips(selection: Binding<GalleryCategory?>) -> some View {
-    ScrollView(.horizontal, showsIndicators: false) {
-      HStack(spacing: 8) {
-        ForEach(GalleryCategoryFilter.options, id: \.self) { option in
-          categoryChip(option, selection: selection)
-        }
-      }
-      .padding(.horizontal, PasturaCardMetrics.horizontalMargin)
-    }
-  }
-
-  private func categoryChip(
-    _ option: GalleryCategoryFilter, selection: Binding<GalleryCategory?>
-  ) -> some View {
-    let isSelected = option.selectedCategory == selection.wrappedValue
-    return Button {
-      selection.wrappedValue = option.selectedCategory
-    } label: {
-      Text(chipTitle(option))
-        .font(.subheadline.weight(isSelected ? .semibold : .regular))
-        // Selected uses `mossDark`, not base `moss`: white-on-mossDark clears
-        // WCAG AA (≈4.76:1) whereas white-on-moss is only ≈3.0:1
-        // (PasturaPrimaryButtonStyle §2.3). White-on-accent is the
-        // contrast-passing pair, distinct from §1's avoid-white-surfaces rule.
-        .foregroundStyle(isSelected ? Color.white : Color.ink)
-        .padding(.horizontal, 14)
-        .padding(.vertical, 7)
-        .background(isSelected ? Color.mossDark : Color.bubbleBackground, in: Capsule())
-        .overlay(
-          Capsule().strokeBorder(
-            isSelected ? Color.clear : Color.rule,
-            lineWidth: PasturaCardMetrics.borderWidth))
-    }
-    .buttonStyle(.plain)
-    // The menu Picker announced its selection for free; rebuild that on the
-    // hand-rolled chips so VoiceOver still reads which filter is active.
-    .accessibilityAddTraits(isSelected ? [.isSelected] : [])
-  }
-
-  private func chipTitle(_ option: GalleryCategoryFilter) -> String {
-    switch option {
-    case .all: return String(localized: "All")
-    case .category(let category): return category.displayName
-    }
-  }
+  //
+  // `categoryChips` / `categoryChip` / `chipTitle` live in
+  // `SharedScenariosListView+CategoryChips.swift` (split out for the
+  // type_body_length budget, #731).
 
   /// "Recommended" section header above the scenarios card (D3 Browse mock),
   /// styled like a ``PasturaSection`` header (muted subheadline).

--- a/Pastura/Pastura/Views/Components/PasturaCard.swift
+++ b/Pastura/Pastura/Views/Components/PasturaCard.swift
@@ -7,59 +7,130 @@ import SwiftUI
 /// and inter-card rhythm. All browse screens — Home / Shared Scenarios /
 /// Past Results / Settings — share this one host (#684).
 enum PasturaCardMetrics {
-  /// Card corner radius — design-system §4.2 "プロモカード 14pt".
+  /// Card corner radius for ``PasturaSectionStyle/insetGrouped`` —
+  /// design-system §4.2 "プロモカード 14pt". `.grouped` squares this off.
   static let cornerRadius: CGFloat = 14
-  /// Hairline border width. design-system §2.2 `rule` token, 1pt.
-  static let borderWidth: CGFloat = 1
-  /// Outer horizontal margin from the screen edge to the card.
+  /// Hairline border / row-divider width. design-system §2.2 `rule` token,
+  /// 0.5pt (thinned from 1pt — the floating-box border read too heavy; #731).
+  static let borderWidth: CGFloat = 0.5
+  /// Border width for non-card surfaces that reuse the `rule` token — the
+  /// SharedScenarios category-filter capsules. Held at 1pt independently of
+  /// ``borderWidth`` so the card-hairline thinning doesn't drag chips down.
+  static let chipBorderWidth: CGFloat = 1
+  /// Outer horizontal margin from the screen edge to the card
+  /// (``PasturaSectionStyle/insetGrouped`` only; `.grouped` reaches the edge).
   static let horizontalMargin: CGFloat = 16
   /// Vertical gap between sibling cards in a `ScrollView` stack.
   static let interCardSpacing: CGFloat = 18
 }
 
+/// Visual style for ``PasturaCard`` / ``PasturaSection``, mirroring Apple's
+/// `UITableView.Style` / SwiftUI `ListStyle` vocabulary so the intent reads at
+/// a glance to any iOS engineer.
+///
+/// - ``insetGrouped``: a rounded white pane inset from the screen edge with an
+///   all-around hairline. The detail-screen / content-grouping form
+///   (ScenarioDetail, GalleryScenarioDetail) — the default.
+/// - ``grouped``: a full-bleed white band reaching both screen edges, no corner
+///   radius, top + bottom hairlines only. The browse-list form (Home / Shared
+///   Scenarios / Past Results / Settings; #731).
+///
+/// The full-bleed zero-overrides live here, NOT on ``PasturaCardMetrics`` — the
+/// shared constants stay positive so a refactor can't silently collapse the
+/// inset rhythm (and `PasturaCardTests.layoutSpacingIsPositive` stays honest).
+enum PasturaSectionStyle {
+  case insetGrouped
+  case grouped
+
+  /// Outer horizontal margin from the screen edge to the card. Zero for
+  /// `.grouped` (the band reaches the edges); the shared positive constant
+  /// for `.insetGrouped`.
+  var horizontalMargin: CGFloat {
+    switch self {
+    case .insetGrouped: PasturaCardMetrics.horizontalMargin
+    case .grouped: 0
+    }
+  }
+
+  /// Card corner radius — the shared 14pt for `.insetGrouped`, squared off
+  /// for the full-bleed `.grouped` band.
+  var cornerRadius: CGFloat {
+    switch self {
+    case .insetGrouped: PasturaCardMetrics.cornerRadius
+    case .grouped: 0
+    }
+  }
+}
+
 /// The browse-side card container: wraps arbitrary content in a white
-/// (`bubbleBackground`) `.continuous` rounded rectangle with a 1pt `rule`
-/// hairline border and **no shadow**, clipping content to the rounded corners.
+/// (`bubbleBackground`) surface with a `rule` hairline and **no shadow**.
 ///
-/// Pastura's browse-side card form (design-system §9 "他画面への展開"),
-/// distinct from the chat/promo bubble (§5.2/§5.4) which carries a left 3pt
-/// moss border + soft moss shadow. Here the card reads as a quiet pane laid on
-/// the warm `screenBackground` field — defined by a hairline, not lifted by
-/// elevation (§1 "observation, not manipulation").
+/// Two forms, selected by ``PasturaSectionStyle``:
+/// - `.insetGrouped` — a `.continuous` rounded rectangle clipped + stroked on
+///   all four sides (the chat/promo bubble of §5.2/§5.4 is a separate form with
+///   a left moss border + shadow; this is the quiet browse pane of §5.9).
+/// - `.grouped` — a full-bleed band: white fill reaching both screen edges with
+///   top + bottom hairlines only, no radius, no side border. Against the warm
+///   `screenBackground` field (only ~2% lighter than white) those two hairlines
+///   are load-bearing — they, not elevation, define the band's edges (§1
+///   "observation, not manipulation").
 ///
-/// The container adds **no internal padding** — callers control it. This
-/// keeps full-bleed internal dividers possible for multi-row grouped cards
-/// (e.g. ScenarioDetail "Overview" with three rows separated by 1pt `rule`
-/// dividers, mirroring the iOS inset-grouped structure it replaces).
+/// The container adds **no internal padding** — callers control it. This keeps
+/// internal dividers possible for multi-row grouped cards (e.g. ScenarioDetail
+/// "Overview" with three rows separated by ``PasturaRowDivider``).
 ///
 /// ```swift
-/// PasturaCard {
+/// PasturaCard(style: .grouped) {
 ///   VStack(spacing: 0) {
 ///     row1
-///     PasturaRowDivider()
+///     PasturaRowDivider(leadingInset: PasturaCardMetrics.horizontalMargin)
 ///     row2
 ///   }
 /// }
 /// ```
 ///
 /// For width: the card fills its host's width; the outer horizontal margin is
-/// the caller's responsibility (apply `PasturaCardMetrics.horizontalMargin` to
-/// the enclosing stack). Every browse screen uses this one `ScrollView` host
-/// (#684), so the margins line up across screens by construction.
+/// applied by ``PasturaSection`` from the style. Every browse screen uses this
+/// one `ScrollView` host (#684), so margins line up across screens.
 struct PasturaCard<Content: View>: View {
+  private let style: PasturaSectionStyle
   private let content: Content
 
-  init(@ViewBuilder content: () -> Content) {
+  init(style: PasturaSectionStyle = .insetGrouped, @ViewBuilder content: () -> Content) {
+    self.style = style
     self.content = content()
   }
 
   var body: some View {
-    let shape = RoundedRectangle(
-      cornerRadius: PasturaCardMetrics.cornerRadius, style: .continuous)
-    content
+    switch style {
+    case .insetGrouped: insetGroupedBody
+    case .grouped: groupedBody
+    }
+  }
+
+  private var insetGroupedBody: some View {
+    let shape = RoundedRectangle(cornerRadius: PasturaCardMetrics.cornerRadius, style: .continuous)
+    return
+      content
       .background(Color.bubbleBackground)
       .clipShape(shape)
       .overlay(shape.strokeBorder(Color.rule, lineWidth: PasturaCardMetrics.borderWidth))
+  }
+
+  private var groupedBody: some View {
+    content
+      .frame(maxWidth: .infinity)
+      .background(Color.bubbleBackground)
+      // Full-bleed band: only the top + bottom hairlines define the edges
+      // against the ~2%-lighter cream field (no side border, no radius).
+      .overlay(alignment: .top) { hairline }
+      .overlay(alignment: .bottom) { hairline }
+  }
+
+  private var hairline: some View {
+    Rectangle()
+      .fill(Color.rule)
+      .frame(height: PasturaCardMetrics.borderWidth)
   }
 }
 
@@ -67,12 +138,14 @@ struct PasturaCard<Content: View>: View {
   ScrollView {
     VStack(spacing: PasturaCardMetrics.interCardSpacing) {
       PasturaCard {
-        Text("Single-line card")
+        Text("Inset-grouped card")
           .foregroundStyle(Color.ink)
           .padding(16)
           .frame(maxWidth: .infinity, alignment: .leading)
       }
-      PasturaCard {
+      .padding(.horizontal, PasturaCardMetrics.horizontalMargin)
+
+      PasturaCard(style: .grouped) {
         VStack(spacing: 0) {
           ForEach(["Agents", "Rounds", "Est. Inferences"], id: \.self) { label in
             HStack {
@@ -80,16 +153,15 @@ struct PasturaCard<Content: View>: View {
               Spacer()
               Text("2").foregroundStyle(Color.muted)
             }
-            .padding(.horizontal, 16)
+            .padding(.horizontal, 17)
             .padding(.vertical, 14)
             if label != "Est. Inferences" {
-              Divider().overlay(Color.rule)
+              PasturaRowDivider(leadingInset: PasturaCardMetrics.horizontalMargin)
             }
           }
         }
       }
     }
-    .padding(.horizontal, PasturaCardMetrics.horizontalMargin)
     .padding(.vertical, PasturaCardMetrics.interCardSpacing)
   }
   .background(Color.screenBackground)

--- a/Pastura/Pastura/Views/Components/PasturaSection.swift
+++ b/Pastura/Pastura/Views/Components/PasturaSection.swift
@@ -8,21 +8,32 @@ import SwiftUI
 /// action groups, single-purpose cards. The header text aligns slightly
 /// inset from the card edge, matching the iOS grouped-header convention.
 ///
+/// The `style` selects the card form (see ``PasturaSectionStyle``):
+/// `.insetGrouped` (default — rounded inset pane, for detail screens) or
+/// `.grouped` (full-bleed band, for the browse lists; #731). The style also
+/// drives the section's outer margin — `.grouped` zeroes it so the band
+/// reaches the screen edges, with the header carrying its own inset.
+///
 /// ```swift
-/// PasturaSection(String(localized: "Overview")) {
+/// PasturaSection(String(localized: "Overview"), style: .grouped) {
 ///   VStack(spacing: 0) {
 ///     row1
-///     PasturaRowDivider()
+///     PasturaRowDivider(leadingInset: PasturaCardMetrics.horizontalMargin)
 ///     row2
 ///   }
 /// }
 /// ```
 struct PasturaSection<Content: View>: View {
   let title: String?
+  private let style: PasturaSectionStyle
   private let content: Content
 
-  init(_ title: String? = nil, @ViewBuilder content: () -> Content) {
+  init(
+    _ title: String? = nil, style: PasturaSectionStyle = .insetGrouped,
+    @ViewBuilder content: () -> Content
+  ) {
     self.title = title
+    self.style = style
     self.content = content()
   }
 
@@ -32,19 +43,39 @@ struct PasturaSection<Content: View>: View {
         Text(title)
           .font(.subheadline)
           .foregroundStyle(Color.muted)
-          .padding(.leading, 6)
+          .padding(.leading, headerLeadingInset)
       }
-      PasturaCard { content }
+      PasturaCard(style: style) { content }
     }
-    .padding(.horizontal, PasturaCardMetrics.horizontalMargin)
+    .padding(.horizontal, style.horizontalMargin)
+  }
+
+  // `.insetGrouped` already insets the whole section by `horizontalMargin`, so
+  // the header nudges a further 6pt (iOS grouped-header convention). `.grouped`
+  // sits edge-to-edge, so the header carries the full inset itself to align
+  // with the row content.
+  private var headerLeadingInset: CGFloat {
+    switch style {
+    case .insetGrouped: 6
+    case .grouped: PasturaCardMetrics.horizontalMargin
+    }
   }
 }
 
 /// A hairline divider between rows inside a ``PasturaCard``, tinted with
 /// the `rule` token so multi-row grouped cards read like the inset-grouped
 /// row separators they replace.
+///
+/// `leadingInset` defaults to 0 (full card width — detail screens). Browse
+/// lists pass a positive inset so the separator starts at the row text, the
+/// iOS inset-separator convention (#731).
 struct PasturaRowDivider: View {
+  var leadingInset: CGFloat = 0
+
   var body: some View {
-    Divider().overlay(Color.rule)
+    Rectangle()
+      .fill(Color.rule)
+      .frame(height: PasturaCardMetrics.borderWidth)
+      .padding(.leading, leadingInset)
   }
 }

--- a/Pastura/Pastura/Views/Home/HomePausedCard.swift
+++ b/Pastura/Pastura/Views/Home/HomePausedCard.swift
@@ -43,7 +43,9 @@ struct HomePausedCard: View {
             )
             .truncationMode(.tail)
         }
-        Divider().overlay(Color.rule)
+        // Shared 0.5pt hairline (not a raw `Divider`, ~1pt) so this intra-card
+        // rule matches the thinned separators in the list stacked beneath it.
+        PasturaRowDivider()
         footer
       }
       .padding(16)

--- a/Pastura/Pastura/Views/Home/HomePausedCard.swift
+++ b/Pastura/Pastura/Views/Home/HomePausedCard.swift
@@ -22,7 +22,9 @@ struct HomePausedCard: View {
   }
 
   var body: some View {
-    PasturaCard {
+    // .grouped so the resume card reads as the same full-bleed band as the
+    // scenario list stacked beneath it on Home (#731).
+    PasturaCard(style: .grouped) {
       VStack(alignment: .leading, spacing: 11) {
         Text(summary.name)
           .font(.headline)

--- a/Pastura/Pastura/Views/Home/HomeView.swift
+++ b/Pastura/Pastura/Views/Home/HomeView.swift
@@ -181,7 +181,9 @@ struct HomeView: View {
       .accessibilityIdentifier("home.newScenarioButton")
       .accessibilityLabel(String(localized: "New Scenario"))
     }
-    .padding(.horizontal, 6)
+    // .grouped sections sit edge-to-edge, so the header carries the screen-edge
+    // inset itself (the section no longer pads horizontally).
+    .padding(.horizontal, PasturaCardMetrics.horizontalMargin)
   }
 
   @ViewBuilder
@@ -212,10 +214,9 @@ struct HomeView: View {
       Text(String(localized: "Interrupted Scenario"))
         .font(.subheadline)
         .foregroundStyle(Color.muted)
-        .padding(.leading, 6)
+        .padding(.leading, PasturaCardMetrics.horizontalMargin)
       HomePausedCard(summary: summary)
     }
-    .padding(.horizontal, PasturaCardMetrics.horizontalMargin)
   }
 
   /// The unified scenario card — user scenarios first (deletable via long-press
@@ -227,16 +228,17 @@ struct HomeView: View {
     let rows = viewModel.userScenarios + viewModel.presets
     VStack(alignment: .leading, spacing: 7) {
       scenariosSectionHeader()
-      PasturaCard {
+      PasturaCard(style: .grouped) {
         VStack(spacing: 0) {
           ForEach(Array(rows.enumerated()), id: \.element.id) { index, scenario in
-            if index > 0 { PasturaRowDivider() }
+            if index > 0 {
+              PasturaRowDivider(leadingInset: PasturaCardMetrics.horizontalMargin)
+            }
             scenarioRow(scenario, viewModel: viewModel)
           }
         }
       }
     }
-    .padding(.horizontal, PasturaCardMetrics.horizontalMargin)
   }
 
   /// One scenario row inside the grouped card. User scenarios (non-preset)

--- a/Pastura/Pastura/Views/Results/ResultsView.swift
+++ b/Pastura/Pastura/Views/Results/ResultsView.swift
@@ -94,10 +94,12 @@ struct ResultsView: View {
           recordCountSubtitle(viewModel.totalRunCount)
         }
         ForEach(viewModel.sections) { section in
-          PasturaSection(section.title) {
+          PasturaSection(section.title, style: .grouped) {
             VStack(spacing: 0) {
               ForEach(Array(section.rows.enumerated()), id: \.element.id) { index, row in
-                if index > 0 { PasturaRowDivider() }
+                if index > 0 {
+                  PasturaRowDivider(leadingInset: PasturaCardMetrics.horizontalMargin)
+                }
                 NavigationLink(value: Route.resultDetail(simulationId: row.item.id)) {
                   resultRow(row)
                 }

--- a/Pastura/Pastura/Views/Settings/SettingsView+Models.swift
+++ b/Pastura/Pastura/Views/Settings/SettingsView+Models.swift
@@ -18,7 +18,8 @@ import SwiftUI
     var modelsSection: some View {
       VStack(alignment: .leading, spacing: 7) {
         let catalog = modelManager.catalog
-        PasturaSection(String(localized: "Models"), style: .grouped) {
+        modelsHeader
+        PasturaSection(style: .grouped) {
           VStack(spacing: 0) {
             ForEach(Array(catalog.enumerated()), id: \.element.id) { index, descriptor in
               if index > 0 {
@@ -46,11 +47,6 @@ import SwiftUI
             orphanedFilesRows
           }
         }
-        storageTotalLine
-        modelsFooter
-          .font(.caption)
-          .foregroundStyle(Color.muted)
-          .padding(.horizontal, PasturaCardMetrics.horizontalMargin + 6)
       }
       // `orphanedModelFiles()` is a filesystem read (not `@Observable`),
       // so seed the local `@State` snapshot on appear; delete refreshes it.
@@ -74,46 +70,53 @@ import SwiftUI
       }
     }
 
-    /// Aggregate footprint line ("Downloaded models · X.X GB"). Hidden when
-    /// nothing is on disk (total 0) so the empty state stays quiet. Reads
-    /// observed `state` (reactive to download/delete) and the `@State`
-    /// orphan snapshot, summing via the pure `totalModelStorageBytes(...)`
-    /// so the figure always matches the rows shown above.
+    /// Section header for the Models card: the "Models" label, a downloaded-
+    /// storage subtitle, and — while a run is active — the switch-blocked note.
+    /// These live above the card (not as a footer) so they stay in first view
+    /// as the catalog grows (#731 follow-up). The idle "keep multiple models"
+    /// reassurance was dropped as redundant.
     @ViewBuilder
-    private var storageTotalLine: some View {
+    private var modelsHeader: some View {
+      VStack(alignment: .leading, spacing: 4) {
+        Text(String(localized: "Models"))
+          .font(.subheadline)
+          .foregroundStyle(Color.muted)
+        if let downloadedTotalText {
+          Text(downloadedTotalText)
+            .font(.caption)
+            .foregroundStyle(Color.metaStrongL3)
+        }
+        // Only while a simulation is running: explains why the active-model
+        // switch is disabled (downloads / deletes stay available).
+        if dependencies.simulationActivityRegistry.isActive {
+          Text(
+            String(
+              localized:
+                "Finish the current simulation before switching models. Downloads and deletes of other models remain available."
+            )
+          )
+          .font(.caption)
+          .foregroundStyle(Color.muted)
+        }
+      }
+      .padding(.leading, PasturaCardMetrics.horizontalMargin)
+    }
+
+    /// Aggregate footprint ("Downloaded · X.X GB"), or nil when nothing is on
+    /// disk so the subtitle stays quiet. Sums ready catalog models + the
+    /// `@State` orphan snapshot via the pure `totalModelStorageBytes(...)`, so
+    /// the figure always matches the rows below.
+    private var downloadedTotalText: String? {
       let readySizes: [Int64] = modelManager.catalog.compactMap { descriptor in
         if case .ready = modelManager.state[descriptor.id] { return descriptor.fileSize }
         return nil
       }
       let total = ModelManager.totalModelStorageBytes(
         readyDescriptorSizes: readySizes, orphanSizes: orphanedFiles.map(\.sizeBytes))
-      if total > 0 {
-        Text(
-          String(
-            format: String(localized: "Downloaded models · %@"),
-            ModelSettingsRow.formattedFileSize(total))
-        )
-        .font(.caption)
-        .foregroundStyle(Color.metaStrongL3)
-        .padding(.horizontal, PasturaCardMetrics.horizontalMargin + 6)
-      }
-    }
-
-    @ViewBuilder
-    private var modelsFooter: some View {
-      if dependencies.simulationActivityRegistry.isActive {
-        Text(
-          String(
-            localized:
-              "Finish the current simulation before switching models. Downloads and deletes of other models remain available."
-          ))
-      } else {
-        Text(
-          String(
-            localized:
-              "You can keep multiple models on this device. Only the active one is loaded in memory."
-          ))
-      }
+      guard total > 0 else { return nil }
+      return String(
+        format: String(localized: "Downloaded · %@"),
+        ModelSettingsRow.formattedFileSize(total))
     }
 
     /// Whether any descriptor other than `id` is mid-download or has a

--- a/Pastura/Pastura/Views/Settings/SettingsView+Models.swift
+++ b/Pastura/Pastura/Views/Settings/SettingsView+Models.swift
@@ -18,10 +18,12 @@ import SwiftUI
     var modelsSection: some View {
       VStack(alignment: .leading, spacing: 7) {
         let catalog = modelManager.catalog
-        PasturaSection(String(localized: "Models")) {
+        PasturaSection(String(localized: "Models"), style: .grouped) {
           VStack(spacing: 0) {
             ForEach(Array(catalog.enumerated()), id: \.element.id) { index, descriptor in
-              if index > 0 { PasturaRowDivider() }
+              if index > 0 {
+                PasturaRowDivider(leadingInset: PasturaCardMetrics.horizontalMargin)
+              }
               ModelSettingsRow(
                 descriptor: descriptor,
                 state: modelManager.state[descriptor.id] ?? .checking,
@@ -62,7 +64,7 @@ import SwiftUI
     @ViewBuilder
     private var orphanedFilesRows: some View {
       ForEach(Array(orphanedFiles.enumerated()), id: \.element.id) { _, file in
-        PasturaRowDivider()
+        PasturaRowDivider(leadingInset: PasturaCardMetrics.horizontalMargin)
         OrphanedModelFileRow(
           file: file,
           onRequestDelete: { pendingOrphanDelete = file }

--- a/Pastura/Pastura/Views/Settings/SettingsView+PastResults.swift
+++ b/Pastura/Pastura/Views/Settings/SettingsView+PastResults.swift
@@ -30,7 +30,7 @@ extension SettingsView {
   @ViewBuilder
   var pastResultsSection: some View {
     VStack(alignment: .leading, spacing: 7) {
-      PasturaSection(String(localized: "Past Results")) {
+      PasturaSection(String(localized: "Past Results"), style: .grouped) {
         Button {
           isShowingClearAllConfirm = true
         } label: {

--- a/Pastura/Pastura/Views/Settings/SettingsView.swift
+++ b/Pastura/Pastura/Views/Settings/SettingsView.swift
@@ -126,7 +126,7 @@ struct SettingsView: View {
         // Results. `Color.link` (design-system §2.8) lands its first real
         // consumer here; the explicit `Color.link` form (not `.link`)
         // sidesteps the ShapeStyle-vs-Color token trap.
-        PasturaSection(String(localized: "Legal")) {
+        PasturaSection(String(localized: "Legal"), style: .grouped) {
           VStack(spacing: 0) {
             Button {
               guard let url = LocalizedPublicPages.privacyPolicy() else { return }
@@ -145,7 +145,7 @@ struct SettingsView: View {
             }
             .accessibilityIdentifier("settings.privacyPolicyLink")
 
-            PasturaRowDivider()
+            PasturaRowDivider(leadingInset: PasturaCardMetrics.horizontalMargin)
             Button {
               isReportSheetPresented = true
             } label: {
@@ -154,7 +154,7 @@ struct SettingsView: View {
             .buttonStyle(.plain)
             .accessibilityIdentifier("settings.sendContentReportButton")
 
-            PasturaRowDivider()
+            PasturaRowDivider(leadingInset: PasturaCardMetrics.horizontalMargin)
             Button {
               isLicensesSheetPresented = true
             } label: {
@@ -301,7 +301,7 @@ struct SettingsView: View {
   /// screen instead of pausing it (ADR-017 Phase B, #682). Label-closure form
   /// per the i18n convenience-init convention (`.claude/rules/i18n.md`).
   private var simulationSection: some View {
-    PasturaSection(String(localized: "Simulation")) {
+    PasturaSection(String(localized: "Simulation"), style: .grouped) {
       Toggle(isOn: $keepRunningOnLeave) {
         VStack(alignment: .leading, spacing: 3) {
           Text(String(localized: "Keep running when I leave"))

--- a/Pastura/PasturaTests/Views/PasturaCardTests.swift
+++ b/Pastura/PasturaTests/Views/PasturaCardTests.swift
@@ -15,14 +15,37 @@ struct PasturaCardTests {
   }
 
   @Test func borderIsHairline() {
-    #expect(PasturaCardMetrics.borderWidth == 1)
+    #expect(PasturaCardMetrics.borderWidth == 0.5)
+  }
+
+  // Category chips (SharedScenarios filter capsules) reuse a 1pt border that is
+  // independent of the card hairline — pin it so the borderWidth 1→0.5 thinning
+  // can't silently drag the chip stroke down with it.
+  @Test func chipBorderStaysOnePoint() {
+    #expect(PasturaCardMetrics.chipBorderWidth == 1)
   }
 
   // Outer margin + inter-card spacing are shared across every browse screen's
   // ScrollView host so they align — pin them positive so a refactor can't
-  // silently zero them and collapse the rhythm.
+  // silently zero them and collapse the rhythm. The full-bleed zero-override
+  // lives on ``PasturaSectionStyle``, NOT on these shared constants.
   @Test func layoutSpacingIsPositive() {
     #expect(PasturaCardMetrics.horizontalMargin > 0)
     #expect(PasturaCardMetrics.interCardSpacing > 0)
+  }
+
+  // The full-bleed (.grouped) style zeroes the outer margin and corner radius
+  // to reach both screen edges as a squared-off band; .insetGrouped keeps the
+  // shared constants. Pinning the mapping protects the detail-screen invariant
+  // (detail screens stay .insetGrouped) from an accidental flip.
+  @Test func groupedStyleIsFullBleed() {
+    #expect(PasturaSectionStyle.grouped.horizontalMargin == 0)
+    #expect(PasturaSectionStyle.grouped.cornerRadius == 0)
+  }
+
+  @Test func insetGroupedStyleMatchesSharedConstants() {
+    #expect(
+      PasturaSectionStyle.insetGrouped.horizontalMargin == PasturaCardMetrics.horizontalMargin)
+    #expect(PasturaSectionStyle.insetGrouped.cornerRadius == PasturaCardMetrics.cornerRadius)
   }
 }

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -238,6 +238,8 @@ Pastura 唯一のブランド色。用途別に4段階。
 | iPhone 本体内側 | 31pt（デバイス追従） |
 | 発言バブル | **上左 4pt, 他 14pt**（しっぽ付き） |
 | プロモカード | 14pt |
+| Browse カード（`.insetGrouped`、詳細画面） | 14pt（continuous、§5.9） |
+| 一覧セクション（`.grouped`、一覧画面） | なし（全幅バンド、§5.9 / #731） |
 | ボタン（投票） | 8pt |
 | ドット | 50%（円） |
 
@@ -395,14 +397,14 @@ ToolbarItem(placement: .primaryAction) {
 | 仕様項目 | 値 |
 |---------|-----|
 | 背景 | `bubbleBackground`（#FFFFFF） |
-| 罫線 | `rule`（#E0DBCE）1px 全周（`strokeBorder`） |
-| 角丸 | 14pt（continuous） |
+| 罫線 | `rule`（#E0DBCE）0.5pt ヘアライン。`.insetGrouped` は全周（`strokeBorder`）、`.grouped` は上下のみ |
+| 角丸 | `.insetGrouped` 14pt（continuous） / `.grouped` なし（全幅バンド） |
 | シャドウ | **なし**（§1「観察＝持ち上げない」。§4.3 の苔シャドウは Sim 画面で単一要素が浮く用途に限定） |
 | 地（field） | `screenBackground`（#FCFAF4） |
 
-`PasturaCardMetrics` がレイアウト定数（角丸 14 / 罫線 1 / 外側水平マージン 16 / カード間 18）を一元管理する。全ブラウズ画面が `ScrollView` + `PasturaCard` の単一ホストを共有し、複数行グループは1枚のカード内を `PasturaRowDivider`（`rule` 罫線）で仕切る（iOS inset-grouped の構造を踏襲）。カードに「タップで push する行」を置く場合は `NavigationLink { 行 + 末尾 chevron } .buttonStyle(.plain)`（汎用行は `PasturaRowLabel` ＝ moss アイコン＋ink タイトル＋chevron＋全幅タップを利用）。
+`PasturaCardMetrics` がレイアウト定数（角丸 14 / ヘアライン 0.5 / チップ罫線 1 / 外側水平マージン 16 / カード間 18）を一元管理する。カード形式は `PasturaSectionStyle` で2種を選ぶ（命名は `UITableView.Style` / `ListStyle` に倣う）— `.insetGrouped`（角丸インセット枠・全周罫線、詳細画面の既定）と `.grouped`（左右マージン・角丸・側面罫線なしの全幅バンド＋上下ヘアライン、一覧画面）。全幅化のゼロ上書き（マージン / 角丸）は style 側に持たせ、`PasturaCardMetrics` の共有定数は正のまま保つ。複数行グループは1枚のカード内を `PasturaRowDivider`（`rule` ヘアライン、`.grouped` ではテキスト位置へ `leadingInset` で字下げ）で仕切る（iOS inset-grouped の構造を踏襲）。カードに「タップで push する行」を置く場合は `NavigationLink { 行 + 末尾 chevron } .buttonStyle(.plain)`（汎用行は `PasturaRowLabel` ＝ moss アイコン＋ink タイトル＋chevron＋全幅タップを利用）。
 
-**ホスト選択**: ブラウズ系（Home / Shared Scenarios / Past Results / Settings）は**すべて** `ScrollView` + `PasturaCard` + `PasturaRowDivider` で統一する（#684）。Home も例外ではなく、シナリオ一覧は他画面と同一の `PasturaCard` グループカードで描く — `List` 上で同じ見た目を再現しようとすると角の描画や行間ヘアラインで破綻するため、機構ごと共通化した。
+**ホスト選択**: ブラウズ系は**すべて** `ScrollView` + `PasturaCard` + `PasturaRowDivider` で統一する（#684）。一覧画面（Home / Shared Scenarios / Past Results / Settings）は `.grouped`（全幅バンド、#731）、詳細画面（ScenarioDetail / GalleryScenarioDetail）は `.insetGrouped`（角丸インセット）を使う — 「行のリスト＝全幅 / 内容のまとまり＝角丸」の線引き。一覧側で `.grouped` を採るのは、地のクリーム（#FCFAF4）と白カードの明度差が約2%しかなく、浮いた角丸枠が「箱が並ぶ」印象を与えていたため（#731）。Home も例外ではなく、シナリオ一覧は他画面と同一の `PasturaCard` グループカードで描く — `List` 上で同じ見た目を再現しようとすると角の描画や行間ヘアラインで破綻するため、機構ごと共通化した。一覧の見出し（セクションタイトル）と SharedScenarios のオフラインバナー / カテゴリチップは `.grouped` でも独立して画面端インセットを保つ（全幅化しない）。
 
 - **Home のシナリオ削除** は `List` の `.onDelete` スワイプではなく**長押しコンテキストメニュー**（`.contextMenu` の destructive「削除」）＋ VoiceOver 用 `.accessibilityAction(named:)` で提供する。`List` を捨てたことでスワイプ削除は使えないが、Apple が List 外削除の代替として案内する方式（`swiftui-traps.md` 参照）。プリセット行は非削除なので contextMenu を付けない。
 - **Editor（`.onMove`）** だけは並べ替えのため `Form` を維持し per-row 挙動を保つ。ドラッグ並べ替えを持つ画面が唯一の `List`/`Form` ホスト例外。
@@ -500,7 +502,7 @@ raw `.borderedProminent`（iOS 26 Liquid Glass capsule に opt-in する）は�
 
 - [ ] 背景は必ず `--screen-bg`（#FCFAF4）から始める。ブラウズ系（一覧・詳細・設定）では `screenBackground` を地（field）として敷き、その上にカードを置く（§5.9）。全面コンテンツ画面（Sim / DL）は `screenBackground` をそのまま本体背景に使う
 - [ ] アクセント色は `--moss` の1色のみ。2色目が欲しくなったら「構成を減らす」方を検討
-- [ ] **カード形式は2種を使い分ける**：チャット/プロモのバブルは**角丸 14pt + 白背景 + 左ボーダー3pt moss + 苔シャドウ**（§5.2 / §5.4）。ブラウズ系のカードは**角丸 14pt + 白背景 + 1px `rule` 全周罫線・影なし**（`PasturaCard`、§5.9）。後者は「観察＝持ち上げない」voice に沿って影でなく罫線で面を定義する
+- [ ] **カード形式は2種を使い分ける**：チャット/プロモのバブルは**角丸 14pt + 白背景 + 左ボーダー3pt moss + 苔シャドウ**（§5.2 / §5.4）。ブラウズ系のカードは**白背景 + `rule` 0.5pt ヘアライン・影なし**（`PasturaCard`、§5.9）で、`PasturaSectionStyle` により一覧は `.grouped`（全幅・角丸なし・上下罫線のみ）、詳細は `.insetGrouped`（角丸14pt・全周罫線）を使い分ける。ブラウズ系は「観察＝持ち上げない」voice に沿って影でなく罫線で面を定義する
 - [ ] モノスペースはメタ情報・ラベル・数値のみ。本文には使わない
 - [ ] アニメーションは 600ms 以上、ease-out を基準に
 - [ ] 犬マーク（コリー）は「アシスタント」の記号、羊はユーザー側エージェントの記号として使い分ける


### PR DESCRIPTION
## Summary

Redesign the browse-list visual style: replace the floating bordered card (white panel + 1pt all-around hairline + 14pt radius + 16pt side margins on the warm cream field) with a **full-bleed white grouped section** — edge-to-edge, no radius, top+bottom hairlines only. The floating box read as "boxes stacked on the field" (the white↔cream lightness delta is only ~2%); the grouped band is quieter and more content-forward, à la Instagram / X / App Store / Reddit. Chosen design = mockup option "2-A".

### What changed
- **`PasturaSectionStyle`** enum on the shared `PasturaCard` / `PasturaSection` (naming mirrors `UITableView.Style` / `ListStyle`):
  - `.insetGrouped` (default) — rounded inset pane, all-around hairline → **detail screens** (ScenarioDetail, GalleryScenarioDetail) keep this.
  - `.grouped` — full-bleed band, no radius, top+bottom hairlines only → **browse lists**.
- **Hairline thinned 1pt → 0.5pt** globally (`PasturaCardMetrics.borderWidth`); added `chipBorderWidth = 1` so the SharedScenarios category capsules keep their 1pt stroke. `PasturaRowDivider` is now a 0.5pt `Rectangle` with an optional `leadingInset` (default 0 = detail screens unchanged).
- **`.grouped` applied to**: Home (scenario list + paused resume card), Shared Scenarios, Past Results, and Settings sections (Models / Simulation / Legal / Past Results). Section headers + SharedScenarios offline banner/category chips keep their own screen-edge insets (not full-bleed).
- The zero-overrides (margin/radius) live on the **style**, not on the shared `PasturaCardMetrics` constants, so `layoutSpacingIsPositive` stays honest.
- Category-chip helpers extracted to `SharedScenariosListView+CategoryChips.swift` (type_body_length budget).
- design-system §5.9 / §4.2 / §1 + the #684 host-selection note updated (list = grouped / detail = insetGrouped).

## Test plan
- ✅ Full unit suite (2118 tests) passes; `swiftlint --strict` clean.
- ✅ `PasturaCardTests` extended to pin the style→metric mapping (`.grouped` → margin 0 / radius 0; `.insetGrouped` → 16 / 14), `borderWidth == 0.5`, `chipBorderWidth == 1`.
- 🔍 **Manual QA** (visual, not automated per ADR-009):
  - Detail screens (ScenarioDetail / GalleryScenarioDetail) divider parity after the `Divider()` → `Rectangle` swap.
  - Grouped section stacking — Home (paused + scenario), Past Results (date sections), Settings (multi-section).
  - **Real-device** color check: white-vs-cream (~2%) edge legibility of the full-bleed band can differ from simulator/browser.

> Note: "no outer border (zero rule)" and any field-color change were deliberately deferred — to be reconsidered after on-device review.

Closes #731

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Follow-up (review feedback)

- **Shared Scenarios**: removed the "Recommended Scenarios" header — it labeled the list without adding meaning.
- **Settings → Models**: moved the downloaded-storage total and the run-active "switch blocked" note **above the card** (under the "Models" header) so both stay in first view as the catalog grows; dropped the idle "keep multiple models" reassurance as redundant. The total now reads `Downloaded · X.X GB` (ja「ダウンロード済み」).
