### PR TITLE
⚡ perf: cut InFlight UI-test reach to one-tap Home-seed row

### DIFF
--- a/Pastura/PasturaUITests/InFlightIndicatorReconnectUITests.swift
+++ b/Pastura/PasturaUITests/InFlightIndicatorReconnectUITests.swift
@@ -53,19 +53,18 @@ final class InFlightIndicatorReconnectUITests: XCTestCase {
       app.navigationBars["Pastura"].waitForExistence(timeout: 10),
       "Home did not appear within 10s.")
 
-    // Reach SimulationView via the proven gallery-install → Run Simulation flow
-    // (mirrors SimulationFocusModeTests).
+    // Reach SimulationView via the one-tap Home-seed row (mirrors BackGestureTests).
+    // The `ui_test_home_seed` scenario is installed unconditionally by
+    // StubScenarioSeeder on every `--ui-test` launch, so tapping its Home row
+    // lands directly on the run-capable ScenarioDetailView — skipping the
+    // Browse → gallery → Try-install reach (~70s, the dominant ui-test cost).
+    // `browseTab` is declared here only as the "tab bar restored" sentinel used
+    // after the park below; it is never tapped (Home is the default tab).
     let browseTab = app.tabBars.buttons["Browse"]
-    XCTAssertTrue(browseTab.waitForExistence(timeout: 5), "Browse tab missing.")
-    browseTab.tap()
 
-    let galleryCell = app.buttons["sharedScenarios.galleryCell.ui_test_canary"]
-    XCTAssertTrue(galleryCell.waitForExistence(timeout: 5), "Canary gallery cell missing.")
-    galleryCell.tap()
-
-    let tryButton = app.buttons["galleryDetail.tryButton"]
-    XCTAssertTrue(tryButton.waitForExistence(timeout: 5), "Try button missing.")
-    tryButton.tap()
+    let homeRow = app.buttons["home.scenarioListCell.ui_test_home_seed"]
+    XCTAssertTrue(homeRow.waitForExistence(timeout: 5), "Home seed scenario row missing.")
+    homeRow.tap()
 
     let detailList = app.scrollViews["scenarioDetail.list"]
     XCTAssertTrue(detailList.waitForExistence(timeout: 10), "ScenarioDetailView did not appear.")


### PR DESCRIPTION
## Summary
- `InFlightIndicatorReconnectUITests` was the dominant ui-test critical-path cost (CI ~182s passing, +291s on flake-retry). Its reach to a running SimulationView used the full Browse → gallery → Try-install → Run flow (~70s, measured identically in `SimulationFocusModeTests`).
- Replace that reach with the already-seeded one-tap Home row (`home.scenarioListCell.ui_test_home_seed`, the same row `BackGestureTests` taps). It lands directly on the run-capable `ScenarioDetailView`, dropping the Browse tab switch, gallery cell, and the Try-install round-trip (real gallery fetch + YAML install + DB write).
- **No production change, no new launch arg, no new seed fixture** — `ui_test_home_seed` is already seeded unconditionally under `--ui-test` (`StubScenarioSeeder`, `PasturaApp.swift:743`). The seam was deliberately left untouched.

## What is preserved (the test's value)
The run→park→indicator→return-adopt core stays byte-for-byte and real-UI-driven: a genuinely live run blocked in its first `generate` (`--ui-test-slow-llm`), left via the real interactive edge-swipe (silent park), the in-flight indicator appears, tap → live `SimulationView` reappears, and the `"Loading scenario..."` reload is asserted absent. No parked / indicator / ownership-lift / SuspendController runtime state is seeded — only the reach was shortened.

## Test plan
- `scripts/xcodebuild.sh test -only-testing PasturaUITests/InFlightIndicatorReconnectUITests` → **TEST SUCCEEDED** (local 34s).
- Plain `--ui-test` behavior unchanged (no new arg), so the other 5 UI tests are unaffected.
- Authoritative CI before/after: old ~182s passing; new measured on this PR's ui-test run.

Closes #734

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127kj1g3WgPw5YVXKx51bCr
