### PR TITLE
🐛 fix: yamlScalar round-trip corruption — line breaks / indicators / whitespace

### DIFF
--- a/Pastura/Pastura/Engine/YAMLScalarFormatter.swift
+++ b/Pastura/Pastura/Engine/YAMLScalarFormatter.swift
@@ -15,8 +15,18 @@ nonisolated enum YAMLScalarFormatter {
   ///
   /// Uses double-quoting when the value might be misinterpreted by a YAML
   /// parser (empty, leading indicators, embedded `: ` / ` #`, number/bool
-  /// look-alikes, line breaks). Otherwise returns the value verbatim.
+  /// look-alikes, line breaks, surrounding whitespace). Otherwise returns the
+  /// value verbatim. Inside the double-quoted form, line breaks and tabs are
+  /// emitted as `\n` / `\r` / `\t` escapes — a *literal* LF/CR in a
+  /// double-quoted scalar is folded/normalized to a space on reparse, so an
+  /// unescaped break silently corrupts the round-trip (#749).
   static func quote(_ value: String) -> String {
+    // `.whitespaces` is space + tab; a value differing from its trimmed form
+    // has leading/trailing/all whitespace, which a *plain* scalar strips on
+    // reparse — so it must be quoted. (Leading/trailing line breaks are caught
+    // separately by the `\n` / `\r` checks below.)
+    let trimmed = value.trimmingCharacters(in: .whitespaces)
+
     // Values that need quoting: empty, contains special chars, looks like number/bool
     let needsQuoting =
       value.isEmpty
@@ -24,18 +34,42 @@ nonisolated enum YAMLScalarFormatter {
       || value.hasPrefix("*") || value.hasPrefix("&")
       || value.hasPrefix("!") || value.hasPrefix("%")
       || value.hasPrefix("'") || value.hasPrefix("\"")
+      // YAML indicator characters that cannot safely begin a plain scalar.
+      // `@`/`` ` `` are spec-reserved (§5.3); `|`/`>` are block-scalar headers
+      // and `,`/`=` are flow/reserved indicators. libyaml's tolerance for
+      // these in block-mapping value position is inconsistent and
+      // version-dependent (e.g. `>x` errors while `|x` parses), so quote them
+      // all defensively rather than rely on a parser quirk.
+      || value.hasPrefix("@") || value.hasPrefix("`")
+      || value.hasPrefix("|") || value.hasPrefix(">")
+      || value.hasPrefix(",") || value.hasPrefix("=")
       || value.contains(": ") || value.contains(" #")
       || value.hasPrefix("- ") || value.hasPrefix("? ")
+      // A bare `:` parses as a mapping indicator ("mapping values are not
+      // allowed in this context") rather than the scalar `:`.
+      || value == ":"
       || value == "true" || value == "false"
       || value == "null" || value == "~"
-      || value.contains("\n") || value.contains("\r")
+      // Scalar-level check: `contains("\n")` is grapheme-aware and misses the
+      // LF inside a CRLF cluster (Swift fuses `\r\n` into one Character), so a
+      // CRLF value would slip through unquoted. Inspect unicode scalars.
+      || value.unicodeScalars.contains("\n") || value.unicodeScalars.contains("\r")
+      || value != trimmed
       || Int(value) != nil || Double(value) != nil
 
     if needsQuoting {
+      // Order matters: backslash first (so escapes we add below are not
+      // re-escaped), then the quote delimiter, then the break/tab escapes.
+      // `.literal` matches by unicode scalar, not grapheme cluster — required
+      // so the LF and CR inside a CRLF cluster are each escaped (default,
+      // grapheme-aware matching would skip them and leak a literal break).
       let escaped =
         value
-        .replacingOccurrences(of: "\\", with: "\\\\")
-        .replacingOccurrences(of: "\"", with: "\\\"")
+        .replacingOccurrences(of: "\\", with: "\\\\", options: .literal)
+        .replacingOccurrences(of: "\"", with: "\\\"", options: .literal)
+        .replacingOccurrences(of: "\n", with: "\\n", options: .literal)
+        .replacingOccurrences(of: "\r", with: "\\r", options: .literal)
+        .replacingOccurrences(of: "\t", with: "\\t", options: .literal)
       return "\"\(escaped)\""
     }
 

--- a/Pastura/PasturaTests/Engine/ScenarioSerializerTests+RoundTripEdgeCases.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioSerializerTests+RoundTripEdgeCases.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+// Sibling-file split of `ScenarioSerializerTests` (file_length cap). Per
+// `.claude/rules/testing.md`, extend the suite struct rather than declaring a
+// new `@Suite` (which would run in parallel and race shared state).
+extension ScenarioSerializerTests {
+
+  // `description` and `extraData` strings render through `yamlScalar` (inline),
+  // NOT the block-scalar path that `context`/`prompt`/`template` use. Before
+  // the #749 quoting fix, an embedded newline in one of these folded to a space
+  // (or corrupted) on reload. `assertScenariosEqual` does not compare
+  // `description`, so assert it explicitly here.
+  @Test func roundTripMultilineDescriptionAndExtraDataNewline() throws {
+    let scenario = Scenario(
+      id: "roundtrip_inline_edge",
+      name: "Edge",
+      description: "First line of the brief.\nSecond line with detail.",
+      language: "en",
+      agentCount: 2,
+      rounds: 1,
+      context: "A single-line context.",
+      personas: [
+        Persona(name: "Alice", description: "A strategist"),
+        Persona(name: "Bob", description: "An optimist")
+      ],
+      phases: [
+        Phase(type: .speakAll, prompt: "Speak.", outputSchema: ["statement": "string"])
+      ],
+      extraData: [
+        "note": .string("line one\nline two"),
+        "topics": .array(["plain", "trailing space "])
+      ]
+    )
+
+    let yaml = serializer.serialize(scenario)
+    let reloaded = try loader.load(yaml: yaml)
+
+    #expect(reloaded.description == scenario.description)
+    #expect(reloaded.extraData["note"] == .string("line one\nline two"))
+    #expect(reloaded.extraData["topics"] == .array(["plain", "trailing space "]))
+  }
+}

--- a/Pastura/PasturaTests/Engine/YAMLScalarFormatterTests.swift
+++ b/Pastura/PasturaTests/Engine/YAMLScalarFormatterTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import Yams
 
 @testable import Pastura
 
@@ -52,14 +53,88 @@ struct YAMLScalarFormatterTests {
     #expect(YAMLScalarFormatter.quote("a: b\\c") == "\"a: b\\\\c\"")
   }
 
-  @Test func newlineForcesQuotingWithLiteralBreak() {
-    // A newline forces quoting; the byte stays a literal LF inside the quotes
-    // (the serializer routes true multi-line strings through block scalars).
-    #expect(YAMLScalarFormatter.quote("line1\nline2") == "\"line1\nline2\"")
+  @Test func newlineEscapesAsBackslashN() {
+    // A newline forces quoting and is emitted as the escaped `\n` sequence,
+    // NOT a literal LF byte: a literal LF inside a double-quoted scalar is
+    // FOLDED to a space by YAML on reparse (round-trip corruption). The
+    // escaped form parses back to a real LF. See `roundTripProperty` for the
+    // behavioral guarantee — this test documents the emitted shape.
+    #expect(YAMLScalarFormatter.quote("line1\nline2") == "\"line1\\nline2\"")
   }
 
   @Test func ordinaryJapaneseTextPassesThrough() {
     // CJK text without special indicators stays unquoted (matches serializer).
     #expect(YAMLScalarFormatter.quote("アリス") == "アリス")
+  }
+
+  // MARK: - Round-trip Property (primary regression guard, #749)
+
+  /// Parses `quote(value)` in the exact `key: <scalar>` context the serializer
+  /// emits (`name:`/`description:`/`if:`/…), then extracts the scalar back.
+  /// Returns `nil` if the document doesn't parse as `[key: String]` — which
+  /// surfaces the pre-fix corruption shapes (unquoted leading-indicator →
+  /// ScannerError → throw; number/null look-alikes → non-String node).
+  private func roundTrip(_ value: String) throws -> String? {
+    let yaml = "k: \(YAMLScalarFormatter.quote(value))"
+    let parsed = try Yams.load(yaml: yaml) as? [String: Any]
+    return parsed?["k"] as? String
+  }
+
+  /// Adversarial corpus: each entry is a value whose naive (unquoted /
+  /// literal-LF) emission corrupts or fails on reparse. Every entry MUST
+  /// satisfy `parse(quote(v)) == v`. If the fix is reverted, the newline,
+  /// leading-reserved-indicator, and trailing/leading-whitespace cases must
+  /// fail — that is the regression these assertions guard.
+  @Test func roundTripProperty() throws {
+    let corpus: [String] = [
+      // finding #1 — line breaks fold/normalize inside double quotes
+      "line1\nline2",
+      "carriage\rreturn",
+      "crlf\r\nline",
+      // finding #2 — leading YAML reserved / indicator characters
+      "@reserved",
+      "`backtick",
+      "|pipe",
+      ">folded",
+      ",comma",
+      "=equals",
+      ":colon",
+      ":",
+      // finding #3 — leading / trailing / all whitespace
+      "trailing space ",
+      " leading space",
+      "   ",
+      "\ttab-leading",
+      "tab-trailing\t",
+      "a\tinterior\tb",
+      // combined shapes
+      "@reserved trailing ",
+      // already-handled shapes — confirm no regression
+      "Alice",
+      "アリス",
+      "42",
+      "3.14",
+      "true",
+      "null",
+      "~",
+      "key: value",
+      "trailing # here",
+      "- dash",
+      "say \"hi\"",
+      "a\\b",
+      ""
+    ]
+
+    for value in corpus {
+      do {
+        let parsed = try roundTrip(value)
+        #expect(
+          parsed == value,
+          "round-trip mismatch for \(value.debugDescription): got \(String(describing: parsed).debugDescription)"
+        )
+      } catch {
+        Issue.record("round-trip threw for \(value.debugDescription): \(error)")
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
Fixes pre-existing round-trip corruption gaps in `YAMLScalarFormatter.quote` (surfaced during #725 / ADR-018 review). The shared inline-scalar quoter is consumed by both `ScenarioSerializer` and `ScenarioYAMLPatcher`, so these shapes corrupted on save → reload:

- **Embedded line breaks** — a literal LF/CR inside a double-quoted scalar is folded/normalized to a space on reparse. Now escaped as `\n`/`\r`/`\t`. CRLF needs scalar-level handling (Swift fuses `\r\n` into one grapheme): detection via `unicodeScalars.contains`, escaping via `.literal` matching.
- **Surrounding whitespace** — leading/trailing/all whitespace (incl. tab) stripped by a plain scalar; now quoted via `value != trimmed`.
- **Leading YAML indicators** — `@`/`` ` `` (reserved) + `|`/`>`/`,`/`=` (block/flow), quoted defensively (libyaml tolerance is version-dependent).
- **Bare `:`** — quoted (else "mapping values are not allowed").

Fixing the shared helper repairs both the serializer and the ADR-018 patcher at once (lockstep invariant). Scope: `Engine/` only, no public API change.

## Test plan
- New round-trip **property test** over an adversarial corpus, parsed in the serializer's `key: <scalar>` context via Yams — genuinely fails on revert.
- New serializer-level round-trip test (multi-line `description` + `extraData` newline) in a sibling-file extension (file_length cap).
- Full unit suite (2145 tests) ✅ · SwiftPM harness `swift build` ✅ · lint ✅

> Note: a code-review suggestion to parameterize the corpus (`@Test(arguments:)`) was deferred — the current loop names the offending value via `.debugDescription`.

Closes #749

🤖 Generated with [Claude Code](https://claude.com/claude-code)