### PR TITLE
🧪 test: tripwire-guard .languageMismatch toast + QA posture (#456)

### DIFF
--- a/.claude/rules/view-testing.md
+++ b/.claude/rules/view-testing.md
@@ -37,5 +37,23 @@ rule below.
    tests. Defer to manual QA + code-review gatekeeping. PRs #252, #249,
    #150 are case-study patterns.
 
+## Change-detector tripwire for code-review-gated tokens
+
+When a visual / timing surface is code-review-gated only (rule 4) and has
+no manual trigger to *see* it, extract its load-bearing layout / timing
+constants into a named enum and add a **change-detector** unit test that
+asserts each value. A failure is NOT a bug — it means a code-review-gated
+token drifted (typically in an unrelated refactor) and the editor must
+confirm the change passed review, then update the expected value. This
+narrows the silent-drift regression window without rendering the View, so
+rule 3 (no ViewInspector / snapshot) still holds. Frame the intent in the
+test's doc-comment, or the next contributor will (fairly) delete it as
+tautological.
+
+Only `Equatable` constants qualify: `SwiftUI.Font` / `AnyTransition` are
+not `Equatable`, so leave those inline and code-review-gate them. Canonical
+example: `LanguageDriftToastLayout` + `LanguageDriftToastLayoutTests` (the
+`.languageMismatch` drift toast; #456 / ADR-009 § Amendment 2026-06-23).
+
 Full Why + alternatives + revisit triggers:
 [ADR-009](../../docs/decisions/ADR-009.md).

--- a/Pastura/Pastura/Views/Simulation/LanguageDriftToastLayout.swift
+++ b/Pastura/Pastura/Views/Simulation/LanguageDriftToastLayout.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+/// Layout + timing tokens for the `.languageMismatch` drift toast rendered
+/// by ``SimulationView`` (`languageDriftToast`).
+///
+/// These constants are extracted from the View so
+/// `LanguageDriftToastLayoutTests` can act as a **change-detector
+/// tripwire**. The toast's rendered appearance is code-review-gated only
+/// (ADR-009 decision 3 — frame / animation-timing bugs are out of scope
+/// for automated tests, and the DEBUG-only manual trigger that let a
+/// human *see* the toast was removed in #455). The tripwire does NOT
+/// verify rendered appearance; it fails when a token drifts silently in a
+/// refactor, forcing the editor to consciously confirm a code-review-gated
+/// visual / timing change. See issue #456 / ADR-009 § Amendment 2026-06-23.
+///
+/// `font` is deliberately NOT a token here: `SwiftUI.Font` is not
+/// `Equatable`, so it cannot back a value-mirror assertion. The toast's
+/// `.font(.caption)` stays inline in the View, code-review-gated alongside
+/// the other rendered-appearance concerns.
+enum LanguageDriftToastLayout {
+  /// Overlay anchor — the toast sits over the chat-stream area at the top,
+  /// NOT inside `GameHeader`'s frosted strip.
+  static let overlayAlignment: Alignment = .top
+
+  /// Auto-dismiss delay. Long enough for a glance, short enough that a
+  /// drift burst doesn't keep the toast pinned.
+  static let autoDismissSeconds: Double = 4
+
+  /// Horizontal inset of the capsule's text content.
+  static let contentHorizontalPadding: CGFloat = 12
+
+  /// Vertical inset of the capsule's text content.
+  static let contentVerticalPadding: CGFloat = 8
+
+  /// Gap between the toast capsule and the top safe-area edge.
+  static let topInset: CGFloat = 8
+
+  /// Horizontal margin from the screen edges.
+  static let edgeHorizontalPadding: CGFloat = 16
+}

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -519,7 +519,7 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
         modelReloadingOverlay
       }
     }
-    .overlay(alignment: .top) {
+    .overlay(alignment: LanguageDriftToastLayout.overlayAlignment) {
       languageDriftToast(viewModel: viewModel)
     }
     .animation(.default, value: viewModel.pendingLanguageMismatchToast)
@@ -568,18 +568,21 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
   ) -> some View {
     if let text = viewModel.languageMismatchToastText {
       Label(text, systemImage: "globe")
+        // `.font(.caption)` stays inline: `SwiftUI.Font` is not `Equatable`,
+        // so it can't back the `LanguageDriftToastLayout` value-mirror
+        // tripwire — it's code-review-gated alongside the rendered surface.
         .font(.caption)
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
+        .padding(.horizontal, LanguageDriftToastLayout.contentHorizontalPadding)
+        .padding(.vertical, LanguageDriftToastLayout.contentVerticalPadding)
         .background(.ultraThinMaterial, in: Capsule())
-        .padding(.top, 8)
-        .padding(.horizontal, 16)
+        .padding(.top, LanguageDriftToastLayout.topInset)
+        .padding(.horizontal, LanguageDriftToastLayout.edgeHorizontalPadding)
         .transition(.move(edge: .top).combined(with: .opacity))
         // Decorative SF Symbol — `text` already carries the semantic.
         // Matches `GameHeader.metaRow`'s globe badge accessibility.
         .accessibilityLabel(text)
         .task(id: viewModel.pendingLanguageMismatchToast) {
-          try? await Task.sleep(for: .seconds(4))
+          try? await Task.sleep(for: .seconds(LanguageDriftToastLayout.autoDismissSeconds))
           viewModel.dismissLanguageMismatchToast()
         }
         .accessibilityIdentifier("simulation.languageDriftToast")

--- a/Pastura/PasturaTests/Views/LanguageDriftToastLayoutTests.swift
+++ b/Pastura/PasturaTests/Views/LanguageDriftToastLayoutTests.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+import Testing
+
+@testable import Pastura
+
+/// Change-detector tripwire for the `.languageMismatch` drift toast's
+/// layout + timing tokens (``LanguageDriftToastLayout``).
+///
+/// These assertions mirror the source-of-truth constants **by design**.
+/// The toast's rendered appearance is code-review-gated only (ADR-009
+/// decision 3 — frame / animation-timing bugs are out of scope for
+/// automated tests; the DEBUG-only manual trigger was removed in #455).
+/// A failure here does NOT mean a bug was found: it means a
+/// code-review-gated visual / timing token drifted, and the editor must
+/// confirm the change passed code review before updating the expected
+/// value. See issue #456 / ADR-009 § Amendment 2026-06-23.
+@Suite("LanguageDriftToastLayout", .timeLimit(.minutes(1)))
+@MainActor
+struct LanguageDriftToastLayoutTests {
+
+  @Test func anchorsToTopOverChatStream() {
+    // The toast sits over the chat-stream area, NOT inside GameHeader's
+    // frosted strip — `.top` is the load-bearing anchor.
+    #expect(LanguageDriftToastLayout.overlayAlignment == .top)
+  }
+
+  @Test func autoDismissesAfterFourSeconds() {
+    #expect(LanguageDriftToastLayout.autoDismissSeconds == 4)
+  }
+
+  @Test func capsuleContentPaddingUnchanged() {
+    #expect(LanguageDriftToastLayout.contentHorizontalPadding == 12)
+    #expect(LanguageDriftToastLayout.contentVerticalPadding == 8)
+  }
+
+  @Test func outerInsetsUnchanged() {
+    #expect(LanguageDriftToastLayout.topInset == 8)
+    #expect(LanguageDriftToastLayout.edgeHorizontalPadding == 16)
+  }
+}

--- a/docs/decisions/ADR-009.md
+++ b/docs/decisions/ADR-009.md
@@ -142,6 +142,45 @@ analysis suggests they may be active.*
    maintenance posture has changed and the (α) rejection — based on the
    recurring lag against Xcode majors — should be re-evaluated.
 
+## Amendment 2026-06-23 — `.languageMismatch` UI surface QA posture (#456)
+
+The `.languageMismatch` adherence-drift feature (#422) renders **two**
+surfaces; this amendment records the QA posture for each, closing #456.
+
+1. **The drift toast** (one-shot per run, `SimulationView`
+   `languageDriftToast`). Its rendered appearance and ~4s auto-dismiss
+   timing fall squarely in decision 3's bucket (b) — frame /
+   animation-timing, not reachable from pure logic. PR #401 had added a
+   DEBUG-only toolbar injector so a human could *see* the toast during
+   QA; #455 removed it as permanent UI clutter for a one-shot aid. With
+   no synthetic trigger, rendered-appearance verification now requires a
+   real model-drift event (rare on bundled Gemma) or a temporary local
+   trigger. **This is the accepted cost of formalizing the toast as a
+   decision-3 (manual-QA + code-review-gated) surface** — not a
+   regression to fix by re-adding the injector (that would re-open the
+   #401 → #455 cycle).
+
+   The narrow automated safety net is a **change-detector tripwire**:
+   `LanguageDriftToastLayout` extracts the toast's `Equatable` layout /
+   timing tokens (anchor, paddings, auto-dismiss seconds), and
+   `LanguageDriftToastLayoutTests` asserts each value. It does NOT verify
+   appearance (decision 3 still forbids ViewInspector / snapshot per
+   decision 4); it fails when a token drifts silently in a refactor,
+   forcing a conscious code-review acknowledgement. `font` is excluded —
+   `SwiftUI.Font` is not `Equatable`, so `.font(.caption)` stays inline,
+   code-review-gated. See `.claude/rules/view-testing.md`
+   § "Change-detector tripwire for code-review-gated tokens".
+
+2. **The run-end completion-summary line** (`Language mismatch ×N`,
+   appended in `SimulationViewModel`'s `.simulationCompleted` handler,
+   `SimulationViewModel.swift:1063-1067`). This reuses the **generic
+   `LogEntry.summary` rendering path** — it has no bespoke layout tokens,
+   so it needs no tripwire. Its only surface-specific concern is the
+   `String(localized:)` count copy, already covered by the i18n gates.
+
+No `revisit trigger` above is altered; this is a posture record for a
+surface that decision 3 already governs.
+
 ## References
 
 - `.claude/rules/view-testing.md` — operational rule that codifies the


### PR DESCRIPTION
## Summary
Implements #456 (option 3 — accept code-review gating + add a token-drift
tripwire) for the `.languageMismatch` adherence-drift UI surface.

- Extract the drift toast's `Equatable` layout/timing values (anchor,
  paddings, 4s auto-dismiss) from `SimulationView` into a
  `LanguageDriftToastLayout` enum (no behavior change) and add a
  change-detector tripwire suite `LanguageDriftToastLayoutTests`.
  `font` stays inline (`SwiftUI.Font` is not `Equatable`).
- Record the QA posture in `ADR-009 § Amendment 2026-06-23` (toast =
  decision-3 manual-QA + code-review-gated, tripwire guards token drift;
  completion-summary = generic `LogEntry.summary` path, no tripwire) +
  a `.claude/rules/view-testing.md` section on the change-detector
  tripwire pattern.

Context: the DEBUG-only manual trigger was removed in #455, leaving the
toast's rendered surface verifiable only at code-review time. The
tripwire narrows the silent-drift window without rendering the View
(ADR-009 still forbids ViewInspector / snapshot).

## Test plan
- `LanguageDriftToastLayoutTests` — 4 tests pass (change-detector on the
  extracted tokens).
- Full unit suite: 2150 tests / 190 suites pass (UI tests skipped — no
  behavior change, no navigation surface touched).
- `swiftlint --strict` clean on changed files; pre-commit gate
  (CI-mirrored) passed.
- Reviewer (Opus code-reviewer): PASS, 0 Critical / 0 Warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #456