### PR TITLE
🐛 fix: balanced string-aware JSON first-object extraction (#751)

### DIFF
--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -178,7 +178,14 @@ Port directly from Python prototype `parse_json_response()`. Must handle:
 
 1. Gemma 4 thinking tags: `<|channel>thought\n...<channel|>` → strip
 2. Code block wrapping: ```json ... ``` → extract inner content
-3. Leading garbage before `{` → find first `{...}` with regex
+3. Leading garbage / trailing garbage around the object → extract the first
+   **balanced** `{...}` via a string-aware brace scan (`StringStateMachine`),
+   stopping at the `}` that returns brace balance to zero. This runs
+   unconditionally (NOT gated on a `{`/`}` prefix/suffix check) so a stray
+   trailing `}` (`{…}}`) or post-object prose is discarded. A greedy
+   `\{.*\}` regex would keep them by matching to the last `}`. The scan
+   returns the input unchanged when braces never balance, so the repair
+   pipeline still fires on a genuinely-unclosed object. (#751 sub-class 1)
 4. All values normalized to String in TurnOutput
 
 ### Retry Policy
@@ -186,6 +193,11 @@ Port directly from Python prototype `parse_json_response()`. Must handle:
 Max 2 retries. Retry on:
 - JSON parse failure
 - Empty fields ("..." or empty string)
+
+**Deferred (#751 sub-class 2):** completely-empty model output (EOG-at-
+position-0 suspected) exhausts the retry budget. It is inference-side, not
+parser-recoverable — root-cause on-device per the issue before adding any
+retry-budget change. Tracked under #751.
 
 ## Content Filter
 

--- a/Pastura/Pastura/LLM/JSONResponseParser.swift
+++ b/Pastura/Pastura/LLM/JSONResponseParser.swift
@@ -30,10 +30,6 @@ nonisolated public struct JSONResponseParser: Sendable {
     pattern: #"```(?:json)?\s*\n?(.*?)\n?```"#,
     options: .dotMatchesLineSeparators
   )
-  private static let jsonObjectRegex = try? NSRegularExpression(
-    pattern: #"\{.*\}"#,
-    options: .dotMatchesLineSeparators
-  )
 
   public init() {}
 
@@ -58,7 +54,8 @@ nonisolated public struct JSONResponseParser: Sendable {
   /// 1. Strip thinking tags (`<think>...`, `<|channel>thought...`)
   /// 2. Truncate at chat template tokens (`<|im_end|>`)
   /// 3. Extract content from markdown code blocks
-  /// 4. Find first `{...}` JSON object
+  /// 4. Extract the first balanced `{...}` object (string-aware), discarding
+  ///    any trailing content after its matching close brace
   /// 5. Try `JSONSerialization` on the cleaned text
   /// 6. On failure: apply the two-step repair pipeline
   ///    (`unclosed_string` → `unclosed_brace`), retry parse, and reject
@@ -155,9 +152,15 @@ nonisolated public struct JSONResponseParser: Sendable {
     cleaned = truncateAtChatTemplateToken(cleaned)
     cleaned = extractFromCodeBlock(cleaned)
     cleaned = cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
-    if !cleaned.hasPrefix("{") || !cleaned.hasSuffix("}") {
-      cleaned = extractFirstJSONObject(cleaned)
-    }
+    // Always extract: a `{`/`}`-framed string is NOT proof of a clean single
+    // object. Grammar-constrained generation can append a stray `}` (`{…}}`,
+    // #751 sub-class 1) or trailing prose after the real close — both pass a
+    // prefix/suffix check yet break `JSONSerialization`. The balanced scan is
+    // an identity transform for an already-clean object; for trailing garbage
+    // it trims back to the first complete object, and for an object-like
+    // trailing residue (`{…}{…}`) it returns the input unchanged so the
+    // multi-object span throws (see `extractFirstJSONObject`, #751 hybrid).
+    cleaned = extractFirstJSONObject(cleaned)
     return cleaned
   }
 
@@ -277,18 +280,62 @@ nonisolated public struct JSONResponseParser: Sendable {
     return String(text[contentRange])
   }
 
-  /// Find the first `{...}` JSON object in text with leading garbage.
+  /// Extract the first balanced `{...}` JSON object, string-aware.
+  ///
+  /// Walks from the first structural `{` (outside any string literal),
+  /// tracking brace balance over characters outside string context via
+  /// ``StringStateMachine``, and returns the slice ending at the `}` that
+  /// brings balance back to zero. A greedy `#"\{.*\}"#` regex (the prior
+  /// implementation) would instead run to the *last* `}` in the text; the
+  /// balanced scan stops at the *first* matching close.
+  ///
+  /// Trailing content after that close is treated by its severity (#751
+  /// hybrid):
+  /// - A stray `}` (`{…}}`, #751 sub-class 1) or trailing prose is a benign
+  ///   boundary artifact (the object content completed before it) — discard
+  ///   it and keep the complete first object.
+  /// - A trailing **object-like** residue (`{…}{…}`, the post-close text
+  ///   starts with `{`) signals the generation re-rolled a whole second
+  ///   answer — a stronger instability signal. Return the input unchanged so
+  ///   `JSONSerialization` rejects the multi-object span → the inference is
+  ///   re-tried for a cleaner sample, rather than silently salvaging a
+  ///   possibly off-persona first object.
+  ///
+  /// Also returns the input unchanged when no `{` exists or the braces never
+  /// balance (unclosed object) so the downstream repair pipeline
+  /// (`closeUnclosedBraces`) can still fire.
   private func extractFirstJSONObject(_ text: String) -> String {
-    guard let regex = Self.jsonObjectRegex else { return text }
-
-    let range = NSRange(text.startIndex..., in: text)
-    guard let match = regex.firstMatch(in: text, range: range),
-      let matchRange = Range(match.range, in: text)
+    let chars = Array(text)
+    let machine = StringStateMachine(text)
+    guard
+      let start = chars.indices.first(where: {
+        chars[$0] == "{" && !machine.isInsideString(at: $0)
+      })
     else {
       return text
     }
 
-    return String(text[matchRange])
+    var balance = 0
+    for i in start..<chars.count where !machine.isInsideString(at: i) {
+      switch chars[i] {
+      case "{":
+        balance += 1
+      case "}":
+        balance -= 1
+        if balance == 0 {
+          // Object-like trailing residue → defer to multi-object throw.
+          let residue = chars[(i + 1)...].drop(while: { $0.isWhitespace })
+          if residue.first == "{" {
+            return text
+          }
+          return String(chars[start...i])
+        }
+      default:
+        break
+      }
+    }
+    // Unclosed — let the repair pipeline handle it.
+    return text
   }
 
   /// Normalize all JSON values to `String`. Null values are omitted.

--- a/Pastura/PasturaTests/LLM/JSONResponseParserTests+Repair.swift
+++ b/Pastura/PasturaTests/LLM/JSONResponseParserTests+Repair.swift
@@ -153,12 +153,27 @@ extension JSONResponseParserTests {
     }
   }
 
-  // Multi-object input — existing greedy `\{.*\}` regex captures the
-  // whole span; repair pipeline must not "fix" it into a single fake
-  // object.
+  // Multi-object input — the balanced scan finds the first complete object
+  // but sees an object-like trailing residue (`{"b":2}`), so it returns the
+  // input unchanged rather than salvaging the first object. A second whole
+  // object is a strong instability signal: re-roll the inference for a
+  // cleaner sample instead of silently accepting a possibly off-persona
+  // first answer (#751 hybrid). The concatenated span then fails to parse →
+  // throw.
   @Test func throwsOnMultipleObjectsInput() {
     #expect(throws: LLMError.self) {
       _ = try parser.parse(#"{"a":1}{"b":2}"#, expectedKeys: [])
+    }
+  }
+
+  // Hybrid boundary (#751): an object-like trailing residue triggers the
+  // multi-object throw even when that residue is itself incomplete — the
+  // `{`-start is the signal, not its validity. Distinguishes this path from
+  // `discardsTrailingProseAfterObject` (residue NOT starting with `{` →
+  // salvaged).
+  @Test func throwsWhenTrailingResidueIsObjectLike() {
+    #expect(throws: LLMError.self) {
+      _ = try parser.parse(#"{"statement": "hi"} {"oops"#, expectedKeys: [])
     }
   }
 

--- a/Pastura/PasturaTests/LLM/JSONResponseParserTests.swift
+++ b/Pastura/PasturaTests/LLM/JSONResponseParserTests.swift
@@ -278,6 +278,61 @@ struct JSONResponseParserTests {
     #expect(output.rawText == input, "rawText should preserve the original pre-cleanup input")
   }
 
+  // MARK: - 24. Balanced first-object extraction (#751)
+
+  // Sub-class 1 of #751: grammar-constrained generation occasionally emits
+  // an otherwise-valid object plus one stray trailing `}` (`{…}}`). The old
+  // pipeline skipped extraction when the text both started with `{` and ended
+  // with `}`, so `{…}}` reached `JSONSerialization` unmodified and was
+  // rejected. Reverting the balanced-extraction fix makes this test fail.
+  @Test func recoversStrayTrailingBrace() throws {
+    let input = #"{"statement": "hello", "inner_thought": "wary"}}"#
+    let output = try parser.parse(input)
+    #expect(output.fields["statement"] == "hello")
+    #expect(output.fields["inner_thought"] == "wary")
+  }
+
+  // Trailing prose after the closing brace is discarded by the balanced scan.
+  @Test func discardsTrailingProseAfterObject() throws {
+    let input = #"{"action": "betray"} and that is my final answer."#
+    let output = try parser.parse(input)
+    #expect(output.fields["action"] == "betray")
+  }
+
+  // String-aware core: a `}` (and `{`) INSIDE a string value must not be
+  // mistaken for the structural close. Without `StringStateMachine`-driven
+  // string tracking the scan would stop early at the in-string `}`.
+  @Test func ignoresBracesInsideStringValue() throws {
+    let input = #"{"statement": "use {a} or }b{ here"} trailing"#
+    let output = try parser.parse(input)
+    #expect(output.fields["statement"] == "use {a} or }b{ here")
+  }
+
+  // Nested object balances both levels, then discards trailing garbage.
+  @Test func balancesNestedObjectAndDiscardsGarbage() throws {
+    let input = #"{"data": {"key": "value"}, "ok": "yes"}garbage}"#
+    let output = try parser.parse(input)
+    #expect(output.fields["ok"] == "yes")
+    let dataValue = try #require(output.fields["data"])
+    #expect(dataValue.contains("value"))
+  }
+
+  // Empty object `{}` balances immediately and parses to an empty field set.
+  @Test func parsesEmptyObject() throws {
+    let output = try parser.parse("{}")
+    #expect(output.fields.isEmpty)
+  }
+
+  // Identity guard: removing the prefix/suffix extraction skip changes the
+  // pipeline for EVERY input, so confirm a clean single object with NO
+  // trailing content still parses (no over-trimming regression).
+  @Test func cleanObjectUnaffectedByAlwaysOnExtraction() throws {
+    let input = #"{"statement": "hi", "action": "cooperate"}"#
+    let output = try parser.parse(input)
+    #expect(output.fields["statement"] == "hi")
+    #expect(output.fields["action"] == "cooperate")
+  }
+
   // A2 repair-pipeline tests live in `JSONResponseParserTests+Repair.swift`
   // (sibling extension). Split per `.claude/rules/testing.md` to keep this
   // file under the `file_length` lint budget.

--- a/Pastura/PasturaTests/LLM/JSONResponseParserTests.swift
+++ b/Pastura/PasturaTests/LLM/JSONResponseParserTests.swift
@@ -318,6 +318,9 @@ struct JSONResponseParserTests {
   }
 
   // Empty object `{}` balances immediately and parses to an empty field set.
+  // Also exercises the residue boundary the scan's OOB-safety relies on:
+  // balance hits 0 at the last char, so `chars[(i+1)...]` is the empty slice
+  // (`residue.first == nil`) — neither salvage-trim nor the object-like throw.
   @Test func parsesEmptyObject() throws {
     let output = try parser.parse("{}")
     #expect(output.fields.isEmpty)


### PR DESCRIPTION
## Summary

Fixes the recoverable parse-retry flakiness from #751 **sub-class 1**: grammar-constrained generation occasionally appends a stray trailing `}` (`{…}}`) after an otherwise-valid object, which the parser failed to recover — burning a parse-retry (and, if it exhausted the budget, a whole harness-run retry).

**Root cause:** `JSONResponseParser.applyCleanupPipeline` skipped `extractFirstJSONObject` when the text both started with `{` and ended with `}` — which `{…}}` satisfies — so the stray brace reached `JSONSerialization` unmodified and was rejected. The repair pipeline never recovered it (`closeUnclosedBraces` only fires for *too few* closes, not too many), and the greedy `\{.*\}` extraction regex would have kept the brace anyway by matching to the *last* `}`.

**Fix:** Replace the greedy regex with a **balanced, string-aware brace scan** (`StringStateMachine`) that walks from the first structural `{` to the `}` returning brace balance to zero, and run it unconditionally. In-string `{`/`}` are correctly ignored. Trailing content is handled by severity (the **#751 hybrid**, confirmed with the maintainer):

- **stray `}` / trailing prose** → benign boundary artifact (the object content completed before it) → discard, keep the complete first object.
- **object-like trailing residue** (`{…}{…}`, post-close text starts with `{`) → strong instability signal (a whole second answer was re-rolled) → return the input unchanged so the multi-object span throws and the inference re-rolls for a cleaner sample, rather than silently salvaging a possibly off-persona first object. This intentionally **preserves** the existing `throwsOnMultipleObjectsInput` behavior.

The scan returns the input unchanged on unclosed / no-brace input so the existing repair pipeline still fires. The full raw output remains audit-preserved in `TurnRecord.rawOutput`, so real-world multi-object occurrences stay observable post-hoc.

### Scope — `Part of #751`, not `Closes`

This addresses **sub-class 1 only**. **Sub-class 2** (completely-empty model output → retries exhausted) is **inference-side** (EOG-at-position-0 suspected), not parser-recoverable, and deferred per the issue's Solution C ("root-cause on-device before any retry-budget change"). The issue stays open to track it; `.claude/rules/engine.md` records the deferral.

## Test plan

- `scripts/xcodebuild.sh test` — full unit suite **2153 tests passed**.
- `JSONResponseParserTests` (incl. `+Repair`) — **48 tests passed** (41 existing unchanged + 7 new).
  - New regression: `recoversStrayTrailingBrace` (`{…}}`) — verified RED on revert.
  - `ignoresBracesInsideStringValue` — load-bearing string-awareness (`}b{` inside a value).
  - `balancesNestedObjectAndDiscardsGarbage`, `discardsTrailingProseAfterObject`, `parsesEmptyObject`, `cleanObjectUnaffectedByAlwaysOnExtraction`.
  - `throwsWhenTrailingResidueIsObjectLike` — pins the hybrid `{`-start throw boundary.
- `swift build` — ADR-013 SwiftPM harness (a `JSONResponseParser` consumer not built by xcodebuild/pre-commit) builds clean.
- `swiftlint lint --strict` — clean.
- `code-reviewer` (Opus) — **PASS, 0 issues**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
