### PR TITLE
📝 docs: widen scenario-factory dedup to shipped presets + gallery

### DIFF
--- a/.claude/skills/scenario-factory/SKILL.md
+++ b/.claude/skills/scenario-factory/SKILL.md
@@ -48,13 +48,26 @@ Non-goals:
 3. `swift build` once to warm the harness build (incremental afterwards).
    A build failure aborts the cycle — report it, do not generate.
 
-## Step 1 — Read the digest (dedup)
+## Step 1 — Read prior scenarios (dedup)
 
 Read `data/factory/digest.md`. Collect every past scenario **id, name,
 theme, and comment** from the section tables. The new batch must not
 repeat: same premise, same persona cast, or a theme judged ≤2 on humor
 twice in a row. Low-scoring past entries are signals about what NOT to
 generate again; high scorers indicate directions worth varying further.
+
+Also collect the **`name` + `description`** of every already-shipped
+scenario, so generation can avoid colliding with the inventory it might
+later be promoted into (§ Promotion):
+
+- Bundled presets — `Pastura/Pastura/Resources/Presets/*.yaml`, **excluding
+  the `*_en.yaml` English mirrors** (they duplicate the `ja` originals).
+- Shared-scenario gallery — `docs/gallery/*_v1.yaml` (read only the YAML
+  `name:` / `description:` scalars; skip `README.md` / `gallery.json` /
+  `shared-scenario-reports.md`).
+
+A new scenario that repeats a shipped preset/gallery premise, mechanics, or
+persona cast is a dedup miss even when the digest is clean.
 
 ## Step 2 — Generate 3 scenario YAMLs
 


### PR DESCRIPTION
## Summary
- The `/scenario-factory` skill's **Step 1 dedup** gate read only `data/factory/digest.md` (past factory runs), so generation was blind to the already-shipped scenario inventory.
- A gallery-shipped scenario (`chin_jimaku_v1`, parallel comedic-translation oogiri) was therefore invisible to dedup, and tonight's generated `珍訳選手権` collided with it on premise, mechanics, and persona cast. Since the gallery is one of the two **promotion targets** (§ Promotion), not reading it at generation time is structurally inconsistent.
- This widens the dedup corpus to also read the `name` + `description` of bundled presets (`Pastura/Pastura/Resources/Presets/*.yaml`, ja-only — `_en.yaml` mirrors excluded) and the gallery (`docs/gallery/*_v1.yaml`, YAML scalars only).
- The **Step 4 judge rubric (4 axes) is intentionally unchanged** — novelty stays a generation gate, not a scoring axis, preserving the existing design intent.

## Test plan
- Docs-only change to one skill file — no automated tests.
- Path/glob correctness verified by the Opus `code-reviewer` against the live repo tree: 8 presets (4 `_en.yaml` mirrors), 14 gallery `*_v1.yaml` files all carrying `name:`/`description:` scalars, and the `README.md`/`gallery.json`/`shared-scenario-reports.md` non-scenario files correctly excluded by the `*_v1.yaml` glob.
- Heading rename `Read the digest (dedup)` → `Read prior scenarios (dedup)` confirmed to have no stale cross-references in `.claude/`.

Closes #761