### PR TITLE
🐛 fix: choose の reason 消失 — secondary フィールド規約を正規名に統一

### DIFF
--- a/.claude/skills/scenario-factory/SKILL.md
+++ b/.claude/skills/scenario-factory/SKILL.md
@@ -80,6 +80,12 @@ Schema requirements (ScenarioLoader — all required):
   `prompt` + `output` field maps; `vote` needs `exclude_self` thought
   through; scoring usually wants a `score_calc` (logic: `vote_tally`)
   and a `summarize`.
+- **Canonical `output` field names** (enforced by
+  `ScenarioValidator.validateForCommit`): primary = `statement` (speak),
+  `action` (choose), `vote` (vote). The optional private-thought field is
+  `reason` for `vote`, `inner_thought` for `speak_all` / `speak_each` /
+  `choose`. Do NOT author `reason` on a choose/speak phase — it streams live
+  but goes blank on the committed row, and the commit gate rejects it (#760).
 - Plain YAML only — no markdown fences in the file.
 
 Inference budget — compute BEFORE writing each file:

--- a/.claude/skills/scenario-refine/SKILL.md
+++ b/.claude/skills/scenario-refine/SKILL.md
@@ -194,6 +194,10 @@ For each chosen baseline:
    *mechanics* (persona differentiation, output-field constraints, round/topic
    structure — see the factory's generation learnings), not just topic
    strings. Keep the inference estimate ≤ 50 (the wrapper hard-blocks > 100).
+   When varying `output` fields, keep the **canonical** names: primary =
+   `statement`/`action`/`vote`, private-thought = `reason` for `vote` and
+   `inner_thought` for `speak_all`/`speak_each`/`choose`. A choose/speak phase
+   with `reason` streams live but goes blank on the committed row (#760).
    **This is the only YAML the skill writes, and it goes under
    `data/factory/` — never next to the baseline.**
 3. Run it (Step 2 shape, into `audit-runs/<DATE>/<id>__v2.jsonl`) and judge it

--- a/Pastura/Pastura/Engine/ScenarioValidator+CanonicalFields.swift
+++ b/Pastura/Pastura/Engine/ScenarioValidator+CanonicalFields.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+/// Commit-time canonical-output-field enforcement, split out of the main
+/// `ScenarioValidator.swift` so each file stays under the `file_length` /
+/// `type_body_length` caps.
+///
+/// `nonisolated` on the extension is load-bearing: `ScenarioValidator` is a
+/// `nonisolated` Engine type, but a sibling-file `extension` inherits
+/// `MainActor` under `SWIFT_DEFAULT_ACTOR_ISOLATION` unless annotated, which
+/// would break the synchronous calls from `validateForCommit` in the main file
+/// (`.claude/rules/swift-isolation.md` Pattern 3).
+nonisolated extension ScenarioValidator {
+
+  /// Enforces ``ScenarioConventions/primaryField(for:)`` and
+  /// ``ScenarioConventions/thoughtField(for:)`` for LLM phases, recursing
+  /// into `conditional` branches so violations inside `then:` / `else:`
+  /// sub-phases are caught at commit time. Code phases are exempt (the
+  /// conventions tables return `nil` and the per-phase checks return
+  /// early). Termination is trivial: `.conditional` is depth-1 by both
+  /// `validateConditionalPhase` and the YAML parser
+  /// (`ScenarioLoader.mapPhase`), so the recursion bottoms out after one
+  /// descent.
+  ///
+  /// Module-internal (not `private`) so `validateForCommit` in the main file
+  /// can call it.
+  func validateCanonicalFields(_ scenario: Scenario) throws {
+    for (index, phase) in scenario.phases.enumerated() {
+      let label = "Phase \(index + 1)"
+      try validateCanonicalFields(in: phase, label: label)
+      // Mirror `validateBranch`'s label shape so sub-phase errors carry
+      // the parent's "(conditional)" annotation — keeps a single mental
+      // template across all branch-related validator messages.
+      let parentLabel = "\(label) (\(phase.type.rawValue))"
+      try validateBranchCanonicalFields(
+        phase.thenPhases, parentLabel: parentLabel, branchLabel: "then")
+      try validateBranchCanonicalFields(
+        phase.elsePhases, parentLabel: parentLabel, branchLabel: "else")
+    }
+  }
+
+  /// Runs both canonical-field checks (primary + thought) for one phase.
+  private func validateCanonicalFields(in phase: Phase, label: String) throws {
+    try validateCanonicalPrimaryField(in: phase, label: label)
+    try validateCanonicalThoughtField(in: phase, label: label)
+  }
+
+  private func validateCanonicalPrimaryField(in phase: Phase, label: String) throws {
+    guard let canonical = ScenarioConventions.primaryField(for: phase.type) else {
+      return
+    }
+    let schema = phase.outputSchema ?? [:]
+    if schema[canonical] == nil {
+      throw validationError(
+        String(localized: "%@ (%@) requires field '%@' in output."),
+        label, phase.type.rawValue, canonical)
+    }
+  }
+
+  /// Enforces ``ScenarioConventions/thoughtField(for:)``: when a phase
+  /// declares any known secondary key (``OutputSchema/knownSecondaryKeys``
+  /// — `inner_thought` / `reason`), it must be the phase's canonical
+  /// thought field (vote→`reason`, speak*/choose→`inner_thought`). The
+  /// secondary field is optional, so a phase that declares none passes.
+  ///
+  /// Checks *every* declared known-secondary key rather than only
+  /// ``OutputSchema/thoughtFieldName``'s priority pick, so a stray `reason`
+  /// alongside a canonical `inner_thought` is still caught. This is what
+  /// keeps the live-streaming THINKING source
+  /// (``OutputSchema/thoughtFieldName``, schema-driven) and the committed
+  /// source (``TurnOutput/secondaryText(for:)``, phase-hardcoded) reading
+  /// the same key — a choose authored with `reason` streamed live but went
+  /// blank on commit (#760).
+  private func validateCanonicalThoughtField(in phase: Phase, label: String) throws {
+    guard let canonical = ScenarioConventions.thoughtField(for: phase.type) else {
+      return
+    }
+    let schema = phase.outputSchema ?? [:]
+    for key in OutputSchema.knownSecondaryKeys
+    where schema[key] != nil && key != canonical {
+      throw validationError(
+        String(localized: "%@ (%@) secondary field must be '%@', not '%@'."),
+        label, phase.type.rawValue, canonical, key)
+    }
+  }
+
+  private func validateBranchCanonicalFields(
+    _ phases: [Phase]?, parentLabel: String, branchLabel: String
+  ) throws {
+    guard let phases else { return }
+    for (subIndex, subPhase) in phases.enumerated() {
+      try validateCanonicalFields(
+        in: subPhase, label: "\(parentLabel) \(branchLabel)[\(subIndex + 1)]")
+    }
+  }
+}
+
+/// File-scope copy of the main file's `validationError`, kept `private` so it
+/// does not collide with the same-named helpers in `ScenarioValidator.swift`
+/// and `ScenarioLoader.swift` at module scope. Same Form-B i18n contract — the
+/// `String(localized:)` literal stays a single extractable key
+/// (see `.claude/rules/i18n.md`).
+nonisolated private func validationError(
+  _ format: String, _ arguments: CVarArg...
+) -> SimulationError {
+  .scenarioValidationFailed(String(format: format, arguments: arguments))
+}

--- a/Pastura/Pastura/Engine/ScenarioValidator.swift
+++ b/Pastura/Pastura/Engine/ScenarioValidator.swift
@@ -98,53 +98,8 @@ nonisolated struct ScenarioValidator: Sendable {
   /// new ones from entering the database in the broken shape.
   func validateForCommit(_ scenario: Scenario) throws -> ValidationResult {
     let result = try validate(scenario)
-    try validateCanonicalPrimaryFields(scenario)
+    try validateCanonicalFields(scenario)
     return result
-  }
-
-  /// Enforces ``ScenarioConventions/primaryField(for:)`` for LLM phases,
-  /// recursing into `conditional` branches so canonical-field violations
-  /// inside `then:` / `else:` sub-phases are caught at commit time.
-  /// Code phases are exempt (the conventions table returns `nil` and the
-  /// per-phase check returns early). Termination is trivial: `.conditional`
-  /// is depth-1 by both `validateConditionalPhase` and the YAML parser
-  /// (`ScenarioLoader.mapPhase`), so the recursion bottoms out after one
-  /// descent.
-  private func validateCanonicalPrimaryFields(_ scenario: Scenario) throws {
-    for (index, phase) in scenario.phases.enumerated() {
-      let label = "Phase \(index + 1)"
-      try validateCanonicalPrimaryField(in: phase, label: label)
-      // Mirror `validateBranch`'s label shape so sub-phase errors carry
-      // the parent's "(conditional)" annotation — keeps a single mental
-      // template across all branch-related validator messages.
-      let parentLabel = "\(label) (\(phase.type.rawValue))"
-      try validateBranchCanonicalFields(
-        phase.thenPhases, parentLabel: parentLabel, branchLabel: "then")
-      try validateBranchCanonicalFields(
-        phase.elsePhases, parentLabel: parentLabel, branchLabel: "else")
-    }
-  }
-
-  private func validateCanonicalPrimaryField(in phase: Phase, label: String) throws {
-    guard let canonical = ScenarioConventions.primaryField(for: phase.type) else {
-      return
-    }
-    let schema = phase.outputSchema ?? [:]
-    if schema[canonical] == nil {
-      throw validationError(
-        String(localized: "%@ (%@) requires field '%@' in output."),
-        label, phase.type.rawValue, canonical)
-    }
-  }
-
-  private func validateBranchCanonicalFields(
-    _ phases: [Phase]?, parentLabel: String, branchLabel: String
-  ) throws {
-    guard let phases else { return }
-    for (subIndex, subPhase) in phases.enumerated() {
-      try validateCanonicalPrimaryField(
-        in: subPhase, label: "\(parentLabel) \(branchLabel)[\(subIndex + 1)]")
-    }
   }
 
   /// Per-phase semantic checks beyond execution-limit validation.
@@ -385,7 +340,9 @@ nonisolated struct ScenarioValidator: Sendable {
 /// File-scope (not a method) so it stays out of `ScenarioValidator`'s
 /// `type_body_length` budget; `nonisolated` because top-level functions inherit
 /// `MainActor` under `SWIFT_DEFAULT_ACTOR_ISOLATION` and the `nonisolated`
-/// validator calls it synchronously.
+/// validator calls it synchronously. `private` (file-scope) so it does not
+/// collide with `ScenarioLoader`'s same-named helper at module scope — the
+/// sibling `ScenarioValidator+CanonicalFields.swift` carries its own copy.
 nonisolated private func validationError(
   _ format: String, _ arguments: CVarArg...
 ) -> SimulationError {

--- a/Pastura/Pastura/Models/ScenarioConventions.swift
+++ b/Pastura/Pastura/Models/ScenarioConventions.swift
@@ -65,6 +65,14 @@ nonisolated public enum ScenarioConventions {
   /// Phase-aware (not a blind `inner_thought` fallback) so a stray `reason` on
   /// a speak/choose output never leaks into THINKING, and a vote's `reason` is
   /// never dropped in favour of an `inner_thought` vote schemas don't author.
+  ///
+  /// **Do not widen this to a `inner_thought ?? reason` fallback.** That would
+  /// re-leak a stray `reason` into a speak/choose THINKING section and re-open
+  /// the divergence against the schema-driven streaming resolver
+  /// (``OutputSchema/thoughtFieldName``). Consistency between the two resolvers
+  /// is held by **authoring enforcement** — `ScenarioValidator.validateForCommit`
+  /// rejects a non-canonical secondary key at commit time — NOT by runtime
+  /// reconciliation here (#760).
   public static func thoughtField(for phaseType: PhaseType) -> String? {
     switch phaseType {
     case .vote:

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -226,6 +226,22 @@
         }
       }
     },
+    "%@ (%@) secondary field must be '%@', not '%@'." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ (%2$@) secondary field must be '%3$@', not '%4$@'."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@（%2$@）の副次フィールドは '%4$@' ではなく '%3$@' を使ってください。"
+          }
+        }
+      }
+    },
     "%@ (%@) ↔ %@ (%@)" : {
       "localizations" : {
         "en" : {

--- a/Pastura/PasturaTests/Engine/ScenarioValidatorTests+Commit.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioValidatorTests+Commit.swift
@@ -216,4 +216,151 @@ extension ScenarioValidatorTests {
       Issue.record("Unexpected error type: \(error)")
     }
   }
+
+  // MARK: - Canonical thought (secondary) field
+  //
+  // Companion to the primary-field checks above. The secondary field is
+  // OPTIONAL, but when a known secondary key (`inner_thought` / `reason`)
+  // is declared it must be the phase's canonical one
+  // (`ScenarioConventions.thoughtField(for:)`): vote→reason,
+  // speak*/choose→inner_thought. This keeps the streaming THINKING source
+  // (`OutputSchema.thoughtFieldName`, schema-driven) and the committed
+  // source (`TurnOutput.secondaryText`, phase-hardcoded) reading the same
+  // key — a choose authored with `reason` streamed live but went blank on
+  // commit (#760).
+
+  @Test func validateForCommit_acceptsChooseWithInnerThought() throws {
+    let phase = Phase(
+      type: .choose, prompt: "Choose.",
+      outputSchema: ["action": "string", "inner_thought": "string"],
+      options: ["yes", "no"])
+    let scenario = makeScenario(agents: 2, rounds: 1, phases: [phase])
+    _ = try validator.validateForCommit(scenario)
+  }
+
+  @Test func validateForCommit_rejectsChooseWithReason() {
+    // The #760 root case: choose authored `reason` (not canonical
+    // `inner_thought`). Streaming surfaced it but the committed row read
+    // the empty `inner_thought`, so the reasoning vanished on commit.
+    let phase = Phase(
+      type: .choose, prompt: "Choose.",
+      outputSchema: ["action": "string", "reason": "string"],
+      options: ["kinoko", "takenoko"])
+    let scenario = makeScenario(agents: 2, rounds: 1, phases: [phase])
+    #expect(throws: SimulationError.self) {
+      try validator.validateForCommit(scenario)
+    }
+  }
+
+  @Test func validateForCommit_rejectsSpeakAllWithReason() {
+    // Speak phases are canonical-`inner_thought` too, so a stray `reason`
+    // is rejected — symmetric to the choose case.
+    let phase = Phase(
+      type: .speakAll, prompt: "Speak.",
+      outputSchema: ["statement": "string", "reason": "string"])
+    let scenario = makeScenario(agents: 2, rounds: 1, phases: [phase])
+    #expect(throws: SimulationError.self) {
+      try validator.validateForCommit(scenario)
+    }
+  }
+
+  @Test func validateForCommit_rejectsVoteWithInnerThought() {
+    // Vote's canonical secondary is `reason`; `inner_thought` is the wrong
+    // key for vote (the inverse of the choose/speak direction).
+    let phase = Phase(
+      type: .vote, prompt: "Vote.",
+      outputSchema: ["vote": "string", "inner_thought": "string"])
+    let scenario = makeScenario(agents: 2, rounds: 1, phases: [phase])
+    #expect(throws: SimulationError.self) {
+      try validator.validateForCommit(scenario)
+    }
+  }
+
+  @Test func validateForCommit_rejectsChooseWithBothInnerThoughtAndReason() {
+    // The rule must inspect EVERY declared known-secondary key, not just
+    // `OutputSchema.thoughtFieldName`'s priority pick (which returns
+    // `inner_thought` here and would miss the stray `reason`).
+    let phase = Phase(
+      type: .choose, prompt: "Choose.",
+      outputSchema: [
+        "action": "string", "inner_thought": "string", "reason": "string"
+      ],
+      options: ["yes", "no"])
+    let scenario = makeScenario(agents: 2, rounds: 1, phases: [phase])
+    #expect(throws: SimulationError.self) {
+      try validator.validateForCommit(scenario)
+    }
+  }
+
+  @Test func validateForCommit_acceptsChooseWithNoSecondaryField() throws {
+    // Secondary is optional — only the canonical primary (`action`) plus
+    // no thought field still passes.
+    let phase = Phase(
+      type: .choose, prompt: "Choose.",
+      outputSchema: ["action": "string"],
+      options: ["yes", "no"])
+    let scenario = makeScenario(agents: 2, rounds: 1, phases: [phase])
+    _ = try validator.validateForCommit(scenario)
+  }
+
+  @Test func validateForCommit_acceptsUnknownSecondaryKey() throws {
+    // The rule keys only on `OutputSchema.knownSecondaryKeys`
+    // (inner_thought / reason). A non-known extra field (`notes`) is not a
+    // secondary key and must not trip the check.
+    let phase = Phase(
+      type: .choose, prompt: "Choose.",
+      outputSchema: ["action": "string", "notes": "string"],
+      options: ["yes", "no"])
+    let scenario = makeScenario(agents: 2, rounds: 1, phases: [phase])
+    _ = try validator.validateForCommit(scenario)
+  }
+
+  @Test func validate_acceptsChooseWithReason() throws {
+    // Runtime `validate(_:)` stays lenient — only `validateForCommit`
+    // enforces the canonical thought-field rule, so a scenario authored
+    // before this convention still runs.
+    let phase = Phase(
+      type: .choose, prompt: "Choose.",
+      outputSchema: ["action": "string", "reason": "string"],
+      options: ["kinoko", "takenoko"])
+    let scenario = makeScenario(agents: 2, rounds: 1, phases: [phase])
+    _ = try validator.validate(scenario)
+  }
+
+  @Test func validateForCommit_rejectsChooseWithReasonInsideThenBranch() {
+    // Recurses into conditional branches, same as the primary-field check.
+    let nested = Phase(
+      type: .choose, prompt: "Choose.",
+      outputSchema: ["action": "string", "reason": "string"],
+      options: ["yes", "no"])
+    let conditional = Phase(
+      type: .conditional, condition: "max_score >= 1",
+      thenPhases: [nested])
+    let scenario = makeScenario(agents: 2, rounds: 1, phases: [conditional])
+    #expect(throws: SimulationError.self) {
+      try validator.validateForCommit(scenario)
+    }
+  }
+
+  @Test func validateForCommit_thoughtFieldErrorMentionsPhaseAndKeys() {
+    let phase = Phase(
+      type: .choose, prompt: "Choose.",
+      outputSchema: ["action": "string", "reason": "string"],
+      options: ["yes", "no"])
+    let scenario = makeScenario(agents: 2, rounds: 1, phases: [phase])
+    do {
+      _ = try validator.validateForCommit(scenario)
+      Issue.record("Expected validateForCommit to throw")
+    } catch let SimulationError.scenarioValidationFailed(message) {
+      // Partial-match per CLAUDE.md i18n rule — the message names the
+      // canonical field, the offending field, the phase type, and the
+      // 1-based phase index.
+      #expect(message.contains("inner_thought"))
+      #expect(message.contains("reason"))
+      #expect(message.contains("choose"))
+      #expect(message.contains("Phase 1"))
+    } catch {
+      Issue.record("Unexpected error type: \(error)")
+    }
+  }
 }

--- a/docs/gallery/chinwaza_saiyo_v1.yaml
+++ b/docs/gallery/chinwaza_saiyo_v1.yaml
@@ -58,7 +58,7 @@ phases:
     options: [即採用, お祈り]
     output:
       action: string
-      reason: string
+      inner_thought: string
 
   - type: vote
     prompt: >

--- a/docs/gallery/gallery.json
+++ b/docs/gallery/gallery.json
@@ -27,7 +27,7 @@
       "agent_count": 4,
       "rounds": 2,
       "yaml_url": "trolley_dilemma_v1.yaml",
-      "yaml_sha256": "8e4f2d870c1ada91f42cb269d35d7c3c032940a2f76ba7c417186378fdc63d0b",
+      "yaml_sha256": "4f4068e49cef3fc6d0903cdb1da017b5d2884d00f3ce527c7e08f464f20393ab",
       "added_at": "2026-04-15"
     },
     {
@@ -55,7 +55,7 @@
       "agent_count": 5,
       "rounds": 1,
       "yaml_url": "kinoko_takenoko_v1.yaml",
-      "yaml_sha256": "d382514728e1bb484868c0f5a02fdc9a2ba6b463f208d76a4f691172df096024",
+      "yaml_sha256": "11f4ccaeba2e511fdf21ea2695e2bac024f18a2fc15ba56d6c61a1ba7f09777b",
       "added_at": "2026-04-29"
     },
     {
@@ -181,7 +181,7 @@
       "agent_count": 4,
       "rounds": 2,
       "yaml_url": "tengoku_jigoku_v1.yaml",
-      "yaml_sha256": "bc4d0dd059035ba0d97f16333ab8bbc5a015296b8bfca6495ce90b875db1576d",
+      "yaml_sha256": "321828104b4034f020419b28571657d5194dd6e238fe80fdc28464dc2833b736",
       "added_at": "2026-06-20"
     },
     {
@@ -195,7 +195,7 @@
       "agent_count": 4,
       "rounds": 2,
       "yaml_url": "chinwaza_saiyo_v1.yaml",
-      "yaml_sha256": "7dcc4cfdb6ec6f0ffd37f65e2e1c1521fc01e20161410a947f912710a479d6d9",
+      "yaml_sha256": "f9b817d272b26bb10ff0a28e30df6ec00847f7912de96b96f811e5b7d861d08e",
       "added_at": "2026-06-21"
     }
   ]

--- a/docs/gallery/kinoko_takenoko_v1.yaml
+++ b/docs/gallery/kinoko_takenoko_v1.yaml
@@ -73,7 +73,7 @@ phases:
       - takenoko
     output:
       action: string
-      reason: string
+      inner_thought: string
 
   - type: speak_each
     prompt: >

--- a/docs/gallery/tengoku_jigoku_v1.yaml
+++ b/docs/gallery/tengoku_jigoku_v1.yaml
@@ -55,7 +55,7 @@ phases:
       - 地獄
     output:
       action: string
-      reason: string
+      inner_thought: string
 
   - type: vote
     prompt: >

--- a/docs/gallery/trolley_dilemma_v1.yaml
+++ b/docs/gallery/trolley_dilemma_v1.yaml
@@ -51,7 +51,7 @@ phases:
       一つ選び、1文で理由を述べてください。
     output:
       action: string
-      reason: string
+      inner_thought: string
     options:
       - pull
       - stand


### PR DESCRIPTION
## Summary
`choose` フェーズの reason が推論中（ストリーミング）は表示されるのに、確定後に消えるバグ（#760）を修正。

**根本原因**: 思考(secondary)フィールド解決の二重基準。
- ストリーミング: `OutputSchema.thoughtFieldName`（スキーマ駆動）→ 宣言済みの `inner_thought`/`reason` を拾う
- 確定表示: `ScenarioConventions.thoughtField(for:)`（フェーズ固定）→ choose は常に `inner_thought`

gallery の4本が choose に `reason` を書いていたため、ストリーミングは reason を表示するが確定行は空の `inner_thought` を読み、reason が消えていた。

**方針**（未リリースのため表示側の後方互換は不要）: 表示コードは触らず、「secondary フィールドはフェーズごとに正規名1つ（vote→`reason` / speak系・choose→`inner_thought`）」を作者側で強制し、両表示経路が同じ正規キーしか見ないようにする。

## Changes
- **gallery データ修正**: 4本（kinoko_takenoko / chinwaza_saiyo / tengoku_jigoku / trolley_dilemma）の choose output を `reason`→`inner_thought`、`gallery.json` の `yaml_sha256` を再生成。フィールド名は機械内部キー（ユーザー不可視）でプロンプトは無変更。vote の `reason`（正規）は無修正
- **ScenarioValidator**: `validateForCommit` に `validateCanonicalThoughtField` を追加（既存の primary 検証の対）。宣言された既知 secondary キーが正規名と違えば throw。secondary 無しはOK。`thoughtFieldName` の優先1つ判定ではなく**全**既知キーを照合（混在 stray `reason` も検出）。commit時のみ強制。`file_length`/`type_body_length` 維持のため sibling `ScenarioValidator+CanonicalFields.swift`（`nonisolated extension`）に分離
- **ScenarioConventions.thoughtField doc**: 「一貫性は作者側バリデーションで担保、runtime fallback 化禁止」を明記
- **i18n**: 新 throw メッセージの `ja` 追加（Form-B `%@`、state=translated）
- **スキル**: scenario-factory / scenario-refine に正規 secondary フィールド規約を明記（生成・改善時の再発防止）

## Test plan
- 新規10ケースを `ScenarioValidatorTests+Commit.swift` に追加（choose+reason→throw / speak+reason→throw / vote+inner_thought→throw / both-keys→throw / no-secondary→OK / unknown-key→OK / runtime `validate` lenient / conditional 再帰 / エラーメッセージ部分一致）。reject 系は fix を revert すると fail する（バグ形状を踏む）
- `GallerySeedYAMLTests.allSeedYAMLsPassValidateForCommit`（全gallery×validateForCommit）+ `galleryYAMLHashMatchesIndex` が green
- 全ユニットスイート green（2191 tests / 191 suites）
- `swiftlint --strict` / `check-gallery-entry.sh --all` / `check_localization_coverage.py` すべて pass

Closes #760

🤖 Generated with [Claude Code](https://claude.com/claude-code)