### PR TITLE
🐛 fix: 過去の結果の使用容量を結果のみ計測し0になるよう修正

### DIFF
--- a/Pastura/Pastura/App/RetentionAdvisory.swift
+++ b/Pastura/Pastura/App/RetentionAdvisory.swift
@@ -11,12 +11,18 @@ import Foundation
 /// via the existing "Clear all results" affordance (#545). It never
 /// deletes without explicit consent.
 ///
-/// ## Metric: database size only
+/// ## Metric: past-results content size only
 ///
 /// ADR-015 D1 permits "run count **or** total DB size"; #565 picks **size
 /// only**. Per-run storage is dominated by two heavy columns
 /// (`turns.rawOutput`, `simulations.stateJSON` — ADR-015 §2), so total
 /// byte size tracks growth directly without a separate run-count accessor.
+/// As of #770 the measure is the *past-results* content size
+/// (``SimulationRepository/pastResultsByteCount()``), not the whole-DB file
+/// size — it excludes the `scenarios` table + SQLite schema/index pages.
+/// That number is strictly smaller than the old whole-DB measure, so the
+/// advisory now fires *no earlier* than before for the same data; against a
+/// 250 MB threshold the excluded KB-scale overhead is immaterial.
 ///
 /// ## Threshold: 250 MB, generous by design
 ///
@@ -28,15 +34,15 @@ import Foundation
 /// ADR-015 D1 (the *decision* — an advisory cap exists, never auto-deletes
 /// — is fixed in the ADR; only the literal lives in code).
 enum RetentionAdvisory {
-  /// Database byte size at or above which the advisory surfaces. 250 MB.
+  /// Past-results content size at or above which the advisory surfaces. 250 MB.
   static let advisoryByteThreshold: Int64 = 250 * 1024 * 1024
 
-  /// Whether the advisory should surface for the given database size.
+  /// Whether the advisory should surface for the given past-results size.
   ///
-  /// - Parameter databaseByteCount: Logical DB size in bytes, from
-  ///   ``SimulationRepository/databaseByteCount()``.
+  /// - Parameter pastResultsByteCount: Past-results content size in bytes,
+  ///   from ``SimulationRepository/pastResultsByteCount()``.
   /// - Returns: `true` once the size reaches ``advisoryByteThreshold``.
-  static func isOverAdvisoryCap(databaseByteCount: Int64) -> Bool {
-    databaseByteCount >= advisoryByteThreshold
+  static func isOverAdvisoryCap(pastResultsByteCount: Int64) -> Bool {
+    pastResultsByteCount >= advisoryByteThreshold
   }
 }

--- a/Pastura/Pastura/Data/SimulationRepository+PastResultsSize.swift
+++ b/Pastura/Pastura/Data/SimulationRepository+PastResultsSize.swift
@@ -1,0 +1,44 @@
+import Foundation
+import GRDB
+
+// Split out of `SimulationRepository.swift` to keep it under the
+// file_length cap (#770). `nonisolated` on the extension is load-bearing:
+// `GRDBSimulationRepository` is a `nonisolated` Data-layer type, but a
+// plain sibling-file extension inherits the project's default MainActor
+// isolation and would break `nonisolated` callers (see
+// `.claude/rules/swift-isolation.md` Pattern 3).
+nonisolated extension GRDBSimulationRepository {
+  public func pastResultsByteCount() throws -> Int64 {
+    try dbWriter.read { db in
+      // Sum the UTF-8 byte length of each result table's payload + snapshot
+      // TEXT columns. `CAST(col AS BLOB)` makes `LENGTH` count bytes, not
+      // characters; `COALESCE(col, '')` guards the nullable columns (a NULL
+      // term would poison the row sum); the outer `COALESCE(SUM(...), 0)`
+      // returns 0 for an empty table (SUM over zero rows is NULL). Omitted
+      // columns (id / FK / integer / timestamp / short labels such as
+      // `status`, `modelIdentifier`, `llmBackend`, `agentName`) are
+      // byte-negligible next to the JSON payloads (ADR-015 §2). `?? 0` is a
+      // belt-and-suspenders floor — the COALESCEs already guarantee a row.
+      let sql = """
+        SELECT
+          (SELECT COALESCE(SUM(
+             LENGTH(CAST(stateJSON AS BLOB))
+             + LENGTH(CAST(COALESCE(configJSON, '') AS BLOB))
+             + LENGTH(CAST(COALESCE(scenarioYamlSnapshot, '') AS BLOB))
+             + LENGTH(CAST(COALESCE(scenarioNameSnapshot, '') AS BLOB))
+             + LENGTH(CAST(COALESCE(scenarioCategorySnapshot, '') AS BLOB))
+           ), 0) FROM simulations)
+        + (SELECT COALESCE(SUM(
+             LENGTH(CAST(rawOutput AS BLOB))
+             + LENGTH(CAST(parsedOutputJSON AS BLOB))
+             + LENGTH(CAST(COALESCE(phasePathJSON, '') AS BLOB))
+           ), 0) FROM turns)
+        + (SELECT COALESCE(SUM(
+             LENGTH(CAST(payloadJSON AS BLOB))
+             + LENGTH(CAST(COALESCE(phasePathJSON, '') AS BLOB))
+           ), 0) FROM code_phase_events)
+        """
+      return try Int64.fetchOne(db, sql: sql) ?? 0
+    }
+  }
+}

--- a/Pastura/Pastura/Data/SimulationRepository.swift
+++ b/Pastura/Pastura/Data/SimulationRepository.swift
@@ -104,24 +104,35 @@ nonisolated public protocol SimulationRepository: Sendable {
   /// per-run ``delete(_:)`` deliberately skips `VACUUM`).
   func deleteAll() throws
 
-  /// Returns the logical size of the database in bytes, computed as
-  /// `page_count * page_size` (SQLite `PRAGMA`s).
+  /// Returns the byte size of the **past-results** content only — the
+  /// `simulations`, `turns`, and `code_phase_events` tables — by summing
+  /// the UTF-8 length of their substantial TEXT columns.
   ///
-  /// This is the SQLite-allocated size: it counts every page the file
-  /// still holds (deletes free pages but only `VACUUM` shrinks the file)
-  /// and excludes the transient rollback journal. It reads off a single
-  /// connection, so it works for in-memory databases (tests) as well as
-  /// the on-disk store — no file-path dependency, keeping the measure
-  /// inside the Data layer.
+  /// Deliberately **excludes** the `scenarios` table (bundled presets are
+  /// re-seeded on every launch and survive a clear-all), the SQLite schema
+  /// / index / free pages, and the rollback journal. So this is NOT the
+  /// database file size (`page_count * page_size`): it is what "Clear all
+  /// results" actually reclaims, and it reaches exactly `0` once every run
+  /// is deleted — matching the Settings "Past Results" caption's intent
+  /// (#770). It reads off a single connection, so it works for in-memory
+  /// databases (tests) as well as the on-disk store — no file-path
+  /// dependency, keeping the measure inside the Data layer.
+  ///
+  /// The sum covers the JSON-payload + snapshot columns that dominate
+  /// per-run storage (ADR-015 §2); id / FK / integer / timestamp / short
+  /// label columns are omitted as byte-negligible next to the payloads.
   ///
   /// Powers the App layer's advisory growth cap (ADR-015 D1 / §3) — a
   /// non-deleting safety stop surfaced when the store grows large.
-  func databaseByteCount() throws -> Int64
+  func pastResultsByteCount() throws -> Int64
 }
 
 /// GRDB-backed implementation of `SimulationRepository`.
 nonisolated public final class GRDBSimulationRepository: SimulationRepository, Sendable {
-  private let dbWriter: any DatabaseWriter
+  // `internal` (not `private`): read by the `pastResultsByteCount()` impl
+  // in the sibling `SimulationRepository+PastResultsSize.swift` extension,
+  // which a cross-file extension can only reach at module scope.
+  let dbWriter: any DatabaseWriter
 
   public init(dbWriter: any DatabaseWriter) {
     self.dbWriter = dbWriter
@@ -383,18 +394,6 @@ nonisolated public final class GRDBSimulationRepository: SimulationRepository, S
     try dbWriter.writeWithoutTransaction { db in
       _ = try SimulationRecord.deleteAll(db)
       try db.execute(sql: "VACUUM")
-    }
-  }
-
-  public func databaseByteCount() throws -> Int64 {
-    try dbWriter.read { db in
-      // `PRAGMA` results come back as rows; read each as a scalar. `?? 0`
-      // is a safe floor: these PRAGMAs always return a row, but if one ever
-      // didn't, reporting 0 fails soft (suppresses the advisory) rather than
-      // throwing — matching the informational, never-deleting posture.
-      let pageCount = try Int64.fetchOne(db, sql: "PRAGMA page_count") ?? 0
-      let pageSize = try Int64.fetchOne(db, sql: "PRAGMA page_size") ?? 0
-      return pageCount * pageSize
     }
   }
 }

--- a/Pastura/Pastura/Views/Settings/SettingsView+PastResults.swift
+++ b/Pastura/Pastura/Views/Settings/SettingsView+PastResults.swift
@@ -13,8 +13,8 @@ extension SettingsView {
   /// Whether the execution-log DB has crossed the advisory growth cap
   /// (ADR-015 D1 / #565). `false` while the size is still loading (`nil`).
   var isOverGrowthCap: Bool {
-    guard let bytes = databaseByteCount else { return false }
-    return RetentionAdvisory.isOverAdvisoryCap(databaseByteCount: bytes)
+    guard let bytes = pastResultsByteCount else { return false }
+    return RetentionAdvisory.isOverAdvisoryCap(pastResultsByteCount: bytes)
   }
   /// Whether clear-all is blocked because a simulation is in flight.
   /// Mirrors the Models section's model-switch gate
@@ -50,7 +50,7 @@ extension SettingsView {
       }
       // Always-on storage caption (#565) — surfaces current DB size once
       // loaded. Hidden while loading or after a read failure (`nil`).
-      if let bytes = databaseByteCount {
+      if let bytes = pastResultsByteCount {
         Text(
           String(
             format: String(localized: "Storage used: %@"),
@@ -95,17 +95,17 @@ extension SettingsView {
     return formatter.string(fromByteCount: bytes)
   }
 
-  /// Loads the execution-log DB size off the main actor for the storage
-  /// caption + advisory cap (#565). On failure the caption is informational,
-  /// so hide it (`nil`) and log rather than alerting.
+  /// Loads the past-results content size off the main actor for the storage
+  /// caption + advisory cap (#565/#770). On failure the caption is
+  /// informational, so hide it (`nil`) and log rather than alerting.
   func loadStorageUsage() async {
     let simRepo = dependencies.simulationRepository
     do {
-      databaseByteCount = try await offMain { try simRepo.databaseByteCount() }
+      pastResultsByteCount = try await offMain { try simRepo.pastResultsByteCount() }
     } catch {
-      databaseByteCount = nil
+      pastResultsByteCount = nil
       Self.pastResultsLogger.error(
-        "databaseByteCount read failed: \(error.localizedDescription, privacy: .public)")
+        "pastResultsByteCount read failed: \(error.localizedDescription, privacy: .public)")
     }
   }
 

--- a/Pastura/Pastura/Views/Settings/SettingsView.swift
+++ b/Pastura/Pastura/Views/Settings/SettingsView.swift
@@ -69,11 +69,13 @@ struct SettingsView: View {
   /// Set when `deleteAll()` throws; surfaced via an alert. Not `private`
   /// — written by the `+PastResults.swift` sibling extension.
   @State var clearAllError: String?
-  /// Logical size of the execution-log database in bytes, for the Past
-  /// Results storage caption + advisory growth-cap warning (#565). `nil`
-  /// until loaded (and left `nil` on read failure → caption hidden). Not
-  /// `private` — read / written by the `+PastResults.swift` extension.
-  @State var databaseByteCount: Int64?
+  /// Byte size of the past-results content (runs + turns + code-phase
+  /// events) for the Past Results storage caption + advisory growth-cap
+  /// warning (#565/#770). Excludes scenarios + SQLite overhead so it
+  /// reaches 0 after a clear-all. `nil` until loaded (and left `nil` on
+  /// read failure → caption hidden). Not `private` — read / written by the
+  /// `+PastResults.swift` extension.
+  @State var pastResultsByteCount: Int64?
 
   #if !targetEnvironment(simulator)
     // `internal` (not `private`): the device-only helpers in the sibling

--- a/Pastura/PasturaTests/App/RetentionAdvisoryTests.swift
+++ b/Pastura/PasturaTests/App/RetentionAdvisoryTests.swift
@@ -17,18 +17,18 @@ struct RetentionAdvisoryTests {
   }
 
   @Test func belowThresholdDoesNotSurface() {
-    #expect(!RetentionAdvisory.isOverAdvisoryCap(databaseByteCount: threshold - 1))
+    #expect(!RetentionAdvisory.isOverAdvisoryCap(pastResultsByteCount: threshold - 1))
   }
 
   @Test func exactlyAtThresholdSurfaces() {
-    #expect(RetentionAdvisory.isOverAdvisoryCap(databaseByteCount: threshold))
+    #expect(RetentionAdvisory.isOverAdvisoryCap(pastResultsByteCount: threshold))
   }
 
   @Test func aboveThresholdSurfaces() {
-    #expect(RetentionAdvisory.isOverAdvisoryCap(databaseByteCount: threshold + 1))
+    #expect(RetentionAdvisory.isOverAdvisoryCap(pastResultsByteCount: threshold + 1))
   }
 
   @Test func zeroDoesNotSurface() {
-    #expect(!RetentionAdvisory.isOverAdvisoryCap(databaseByteCount: 0))
+    #expect(!RetentionAdvisory.isOverAdvisoryCap(pastResultsByteCount: 0))
   }
 }

--- a/Pastura/PasturaTests/Data/SimulationRepositoryTests.swift
+++ b/Pastura/PasturaTests/Data/SimulationRepositoryTests.swift
@@ -244,28 +244,27 @@ import Testing
     #expect(try turnRepo.fetchBySimulationId("sim1").isEmpty)
   }
 
-  @Test func databaseByteCountIsPositiveForMigratedDatabase() throws {
+  @Test func pastResultsByteCountIsZeroForEmptyDatabase() throws {
     let (_, simRepo) = try makeRepos()
-    // A migrated SQLite DB always holds at least the schema pages
-    // (sqlite_master + table roots), so the logical size is non-zero
-    // even before any run is inserted.
-    #expect(try simRepo.databaseByteCount() > 0)
+    // The measure sums result-table content only — not the SQLite schema
+    // pages. A migrated-but-empty DB has zero runs, so the size is exactly
+    // 0 (the #770 fix: "Storage used" reaches 0 once results are cleared,
+    // unlike the old whole-DB `page_count * page_size` measure).
+    #expect(try simRepo.pastResultsByteCount() == 0)
   }
 
-  @Test func databaseByteCountGrowsAfterHeavyInserts() throws {
+  @Test func pastResultsByteCountGrowsAfterHeavyInserts() throws {
     let (_, simRepo) = try makeRepos()
-    let before = try simRepo.databaseByteCount()
+    let before = try simRepo.pastResultsByteCount()
 
-    // Insert enough large-`stateJSON` rows to force new page allocation
-    // past any free pages left by migration. `stateJSON` is one of the two
-    // heavy columns the advisory cap exists to bound (ADR-015 §2). ~8 KB ×
-    // 40 ≈ 320 KB comfortably exceeds the default 4 KB page so the count
-    // strictly increases, not merely stays flat on free-page reuse.
+    // Insert large-`stateJSON` rows. `stateJSON` is one of the two heavy
+    // columns the advisory cap exists to bound (ADR-015 §2), and is summed
+    // by the content measure, so the count strictly increases.
     let bulkyState = "{\"pad\":\"\(String(repeating: "x", count: 8_000))\"}"
     for index in 0..<40 {
       try simRepo.save(makeSimRecord(id: "sim\(index)", stateJSON: bulkyState))
     }
 
-    #expect(try simRepo.databaseByteCount() > before)
+    #expect(try simRepo.pastResultsByteCount() > before)
   }
 }

--- a/Pastura/PasturaTests/Data/SimulationRepositoryTests.swift
+++ b/Pastura/PasturaTests/Data/SimulationRepositoryTests.swift
@@ -267,4 +267,47 @@ import Testing
 
     #expect(try simRepo.pastResultsByteCount() > before)
   }
+
+  @Test func pastResultsByteCountExcludesScenarios() throws {
+    let (scenarioRepo, simRepo) = try makeRepos()
+    // Save a scenario with a deliberately large `yamlDefinition` and no
+    // simulation runs. The measure must ignore the `scenarios` table
+    // entirely (the #770 root cause: scenarios — incl. re-seeded presets —
+    // survive clear-all but are not "results"), so the size stays 0.
+    try scenarioRepo.save(
+      ScenarioRecord(
+        id: "big", name: "Big",
+        yamlDefinition: String(repeating: "y", count: 20_000),
+        isPreset: true, createdAt: Date(), updatedAt: Date()))
+
+    #expect(try simRepo.pastResultsByteCount() == 0)
+  }
+
+  @Test func pastResultsByteCountIsZeroAfterDeleteAllWithScenariosPresent() throws {
+    let manager = try DatabaseManager.inMemory()
+    let scenarioRepo = GRDBScenarioRepository(dbWriter: manager.dbWriter)
+    let simRepo = GRDBSimulationRepository(dbWriter: manager.dbWriter)
+    let turnRepo = GRDBTurnRepository(dbWriter: manager.dbWriter)
+
+    try scenarioRepo.save(
+      ScenarioRecord(
+        id: "s1", name: "Test", yamlDefinition: "yaml",
+        isPreset: false, createdAt: Date(), updatedAt: Date()))
+    try simRepo.save(makeSimRecord(id: "sim1", stateJSON: "{\"pad\":\"data\"}"))
+    try turnRepo.save(
+      TurnRecord(
+        id: "t1", simulationId: "sim1",
+        roundNumber: 1, phaseType: "speak_all",
+        agentName: "Alice", rawOutput: "raw",
+        parsedOutputJSON: #"{"statement":"hello"}"#,
+        createdAt: Date()))
+    #expect(try simRepo.pastResultsByteCount() > 0)
+
+    try simRepo.deleteAll()
+
+    // Runs are gone → size is 0, even though the scenario row survives
+    // (clear-all never touches `scenarios`).
+    #expect(try simRepo.pastResultsByteCount() == 0)
+    #expect(try scenarioRepo.fetchById("s1") != nil)
+  }
 }

--- a/docs/decisions/ADR-015.md
+++ b/docs/decisions/ADR-015.md
@@ -139,6 +139,20 @@ is told growth is large and offered the existing delete tools, and decides.
   a large manual clear-all, not on a schedule — it rewrites the whole file
   and would block. Scoped to the clear-all follow-up.
 
+## Amendment 2026-06-23 — advisory metric is past-results content size (#770)
+
+D1 (§1) and §4.2 frame the advisory metric as "total DB size". As shipped
+in #770 the metric is the **past-results content size**
+(`SimulationRepository.pastResultsByteCount()`): the summed UTF-8 byte
+length of the `simulations` / `turns` / `code_phase_events` payload +
+snapshot columns. It deliberately excludes the `scenarios` table (bundled
+presets are re-seeded on every launch and survive a clear-all) and the
+SQLite schema / index / free pages — so the Settings → Past Results storage
+caption reaches **0** once every run is deleted, instead of resting on a
+~96 KB whole-file floor. The number is strictly ≤ the old whole-DB measure,
+so the 250 MB advisory fires *no earlier* than before: a metric-scope
+refinement, not a threshold change.
+
 ## 4. Follow-up implementation issues (out of scope here)
 
 These were filed as separate issues after this ADR landed — current status


### PR DESCRIPTION
## Summary
設定画面「過去の結果」の使用容量キャプションは SQLite DB ファイル全体 (`page_count * page_size`) を計測していたため、全結果削除後も ~96KB 残り 0 にならなかった。原因は (a)「全結果削除」が `scenarios` テーブル（起動毎に再シードされるプリセット等）を消さないこと、(b) SQLite がスキーマ/インデックスページを保持すること。

- `databaseByteCount()` → `pastResultsByteCount()` にリネームし、結果テーブル（`simulations`/`turns`/`code_phase_events`）の payload/snapshot TEXT 列の UTF-8 バイト長合計を計測するよう再実装。`scenarios` とスキーマページを除外し、削除後ちょうど 0 に到達する。
  - nullable 列は `COALESCE(col,'')`、ゼロ行は外側 `COALESCE(SUM(...),0)` でガード。`CAST(... AS BLOB)` で文字数でなくバイト数を計測。
  - file_length 上限維持のため実装を sibling `SimulationRepository+PastResultsSize.swift`（`nonisolated extension`、swift-isolation Pattern 3）へ分割。`dbWriter` は `private`→`internal`（最小限の拡大）。
- `deleteAll()` + VACUUM、アドバイザリ閾値 250MB は不変。新計測値は旧 whole-DB 値より常に小さいため、アドバイザリは従来より早く発火しない（計測スコープの精緻化であって閾値変更ではない）。
- ADR-015 に Amendment セクションを追加（§1 D1 / §4.2 の "total DB size" 記述との整合）。

## Test plan
- `swiftlint --strict` clean、フル単体スイート 2201 tests green。
- 回帰テスト2件追加：
  - `pastResultsByteCountExcludesScenarios` — 大きな `yamlDefinition` の scenario のみ → 0
  - `pastResultsByteCountIsZeroAfterDeleteAllWithScenariosPresent` — run+turn 投入で >0 → `deleteAll()` で 0（scenario 行は残存）
  - 既存の空DBテストを `>0`→`==0` に反転（旧 whole-DB 計測なら失敗する形）

Closes #770

🤖 Generated with [Claude Code](https://claude.com/claude-code)