### PR TITLE
🧰 feat: motion-capture demo variant for typing-speed verification

### DIFF
--- a/Pastura/Pastura/App/ModelManager.swift
+++ b/Pastura/Pastura/App/ModelManager.swift
@@ -1024,3 +1024,29 @@ extension ModelManager {
     cancelDownload(descriptor: descriptor)
   }
 }
+
+#if DEBUG
+  // MARK: - Capture tooling (DEBUG only)
+
+  extension ModelManager {
+    /// Forces `descriptor` into `.downloading` so the `.needsModelDownload`
+    /// host renders the demo replay screen for `scripts/motion-capture.sh demo`
+    /// — WITHOUT starting a real network download. Motion-capture tooling only;
+    /// never call from product code.
+    ///
+    /// **Why a seam is needed:** `state` is `private(set)`, so the external
+    /// caller (`RootView.setupCaptureDemoState()`) cannot seed it directly.
+    ///
+    /// **Why a static `.downloading(progress:)` value is sufficient:** the demo
+    /// replay (`ReplayViewModel`) plays independently of download progress — it
+    /// owns its own pacing and writes to no repository / DB sink (ADR-007 §4.2),
+    /// and `ModelDownloadHostView.stateView(...)` routes any `.downloading` (with
+    /// ≥ `minPlayableDemoCount` demos loaded) to `.demoHost`. The progress value
+    /// never has to advance for the typing animation to run.
+    func captureSeedDownloadingState(
+      for descriptor: ModelDescriptor, progress: Double = 0.4
+    ) {
+      state[descriptor.id] = .downloading(progress: progress)
+    }
+  }
+#endif

--- a/Pastura/Pastura/PasturaApp.swift
+++ b/Pastura/Pastura/PasturaApp.swift
@@ -153,6 +153,9 @@ private struct RootView: View {
       // these args, control falls through unchanged.
       if CommandLine.arguments.contains("--capture-launch-warm") { return .warm }
       if CommandLine.arguments.contains("--capture-launch") { return .cold }
+      // The `demo` capture variant records the demo replay screen, not the
+      // splash — suppress the splash so it doesn't clip the recording window.
+      if CommandLine.arguments.contains("--capture-demo") { return nil }
       if CommandLine.arguments.contains("--ui-test") { return nil }
     #endif
     return .cold
@@ -505,10 +508,9 @@ private struct RootView: View {
 
   private func initialize() async {
     #if DEBUG
-      if CommandLine.arguments.contains("--ui-test") {
-        await setupUITestState()
-        return
-      }
+      // Capture-tooling / UI-test launch overrides. Extracted to a helper so
+      // initialize() stays under SwiftLint's cyclomatic-complexity cap.
+      if await handleDebugLaunchOverride() { return }
     #endif
     // Fail-fast on catalog collisions at the earliest possible point so
     // duplicate ids / fileNames crash in dev rather than corrupting
@@ -778,6 +780,43 @@ private struct RootView: View {
       } catch {
         appState = .error("UI test setup failed: \(error.localizedDescription)")
       }
+    }
+
+    /// Dispatches DEBUG-only launch overrides. Returns `true` when an override
+    /// fired (caller returns early), `false` to fall through to normal init.
+    /// `--capture-demo` must be handled before `initialize()`'s `#if
+    /// targetEnvironment(simulator)` branch, which otherwise goes straight to
+    /// `.ready` on the simulator and never reaches `.needsModelDownload`.
+    private func handleDebugLaunchOverride() async -> Bool {
+      if CommandLine.arguments.contains("--capture-demo") {
+        setupCaptureDemoState()
+        return true
+      }
+      if CommandLine.arguments.contains("--ui-test") {
+        await setupUITestState()
+        return true
+      }
+      return false
+    }
+
+    /// Capture-tooling-only bootstrap (`scripts/motion-capture.sh demo`): seed
+    /// the active descriptor into `.downloading` and route to
+    /// `.needsModelDownload` so `ModelDownloadHostView` renders the demo replay
+    /// screen for recording. Starts NO real download (no `startDownload`) — the
+    /// demo replay plays independently of download progress (ADR-007 §4.2).
+    private func setupCaptureDemoState() {
+      // `activeDescriptor` is nil only with an empty catalog (never in
+      // production). Guard loudly: without it the seed can't fire, the host
+      // routes to `.plainProgress`, and the capture silently records a
+      // no-typing screen that the script's size check can't flag.
+      guard let descriptor = modelManager.activeDescriptor else {
+        Self.logger.error(
+          "--capture-demo: no active descriptor; demo replay will not render")
+        appState = .needsModelDownload
+        return
+      }
+      modelManager.captureSeedDownloadingState(for: descriptor)
+      appState = .needsModelDownload
     }
   #endif
 }

--- a/Pastura/PasturaTests/App/ModelManagerTests+CaptureSeed.swift
+++ b/Pastura/PasturaTests/App/ModelManagerTests+CaptureSeed.swift
@@ -17,9 +17,12 @@ import Testing
       // Precondition: a fresh manager seeds every descriptor `.checking`.
       #expect(sut.state[descriptor.id] == .checking)
 
-      sut.captureSeedDownloadingState(for: descriptor)
+      // Pass an explicit progress so the assertion exercises the seam's
+      // contract ("force `.downloading` with the given value") rather than
+      // coupling to the production default.
+      sut.captureSeedDownloadingState(for: descriptor, progress: 0.3)
 
-      #expect(sut.state[descriptor.id] == .downloading(progress: 0.4))
+      #expect(sut.state[descriptor.id] == .downloading(progress: 0.3))
     }
   }
 #endif

--- a/Pastura/PasturaTests/App/ModelManagerTests+CaptureSeed.swift
+++ b/Pastura/PasturaTests/App/ModelManagerTests+CaptureSeed.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+// The capture seam is `#if DEBUG`-only (motion-capture tooling), so its test
+// must be gated the same way — otherwise a Release test compile would fail on
+// the missing symbol. Sibling-file extension on the existing suite (not a new
+// `@Suite`) per .claude/rules/testing.md — a parallel suite would race the
+// original on shared Application Support / Caches paths.
+#if DEBUG
+  extension ModelManagerTests {
+    @Test("captureSeedDownloadingState forces the descriptor into .downloading")
+    func captureSeedForcesDownloadingState() {
+      let descriptor = makeTestDescriptor()
+      let sut = makeSUT(catalog: [descriptor])
+      // Precondition: a fresh manager seeds every descriptor `.checking`.
+      #expect(sut.state[descriptor.id] == .checking)
+
+      sut.captureSeedDownloadingState(for: descriptor)
+
+      #expect(sut.state[descriptor.id] == .downloading(progress: 0.4))
+    }
+  }
+#endif

--- a/scripts/motion-capture.sh
+++ b/scripts/motion-capture.sh
@@ -7,12 +7,18 @@
 # under docs/design/motion/<variant>/. The artifacts give a human or agent
 # a *time axis* on motion that a single screenshot can't convey.
 #
-# First-deliverable variants (the app-launch sequence — see
+# Launch-animation variants (the app-launch sequence — see
 # Pastura/Pastura/Views/Splash/ and LaunchAnimationConfig):
 #   cold          — "Pastoral Drift" full cold-launch splash
 #   warm          — abbreviated "Breath" warm-launch splash
 #   reduce-motion — cold splash with the Reduce Motion fallback
-#   all (default) — all three in sequence
+#   all (default) — the three launch variants in sequence
+#
+# Other variants (explicit-only — NOT part of `all`, different in nature):
+#   demo          — the DL-time demo replay screen, for verifying the
+#                   chat-stream TYPING animation speed frame-by-frame
+#                   (the filmstrip gives a time axis; count the characters
+#                   revealed per frame at MOTION_FPS to read off chars/sec).
 #
 # How the launch animation is forced: under `--ui-test` the splash is
 # normally suppressed (PasturaApp.swift). The DEBUG-only `--capture-launch`
@@ -23,6 +29,12 @@
 # accessibilityReduceMotion)`; that key is read-only in Swift 6, so it can't
 # be injected from code).
 #
+# How the demo replay is forced: the DEBUG-only `--capture-demo` arg
+# (PasturaApp.swift) seeds the active model into `.downloading` and routes to
+# `.needsModelDownload`, so `ModelDownloadHostView` renders the bundled demo
+# replay — WITHOUT a real download. It does NOT use `--ui-test` (that would
+# short-circuit to `.ready` and never reach the demo host).
+#
 # Local-run only by design — generated artifacts are gitignored (only the
 # README is tracked), and this is NOT a CI gate (same posture as
 # scripts/ui-tour.sh). Do NOT run concurrently with scripts/ui-tour.sh or
@@ -30,8 +42,9 @@
 # simulator's Reduce Motion setting and holds a video recorder, and the
 # sim-dest.sh gate only sees `xcodebuild test`, not `simctl io`.
 #
-# Usage: scripts/motion-capture.sh [cold|warm|reduce-motion|all]
-# Env:   MOTION_FPS (default 12)   — frame extraction rate
+# Usage: scripts/motion-capture.sh [cold|warm|reduce-motion|all|demo]
+# Env:   MOTION_FPS (default 12)   — frame extraction rate (bump it, e.g.
+#        MOTION_FPS=24, for finer chars/sec resolution on the `demo` variant)
 #        MOTION_THUMB_W (default 160) — per-frame width (px) in the filmstrip
 # Requires: ffmpeg (brew install ffmpeg)
 
@@ -54,9 +67,9 @@ fi
 
 VARIANT="${1:-all}"
 case "$VARIANT" in
-  cold | warm | reduce-motion | all) ;;
+  cold | warm | reduce-motion | all | demo) ;;
   *)
-    echo "ERROR: unknown variant '$VARIANT' (expected: cold | warm | reduce-motion | all)" >&2
+    echo "ERROR: unknown variant '$VARIANT' (expected: cold | warm | reduce-motion | all | demo)" >&2
     exit 1
     ;;
 esac
@@ -145,6 +158,18 @@ xcrun simctl launch "$UDID" "$BUNDLE_ID" --ui-test > /dev/null 2>&1 || true
 sleep 4
 xcrun simctl terminate "$UDID" "$BUNDLE_ID" > /dev/null 2>&1 || true
 
+# The `--ui-test` warm-up above boots into the in-memory MockLLM path, which
+# does NOT warm the `--capture-demo` init (AppDependencies.production() + demo
+# resource load). Pay that distinct cold cost once so the demo capture_window
+# below isn't spent waiting on first-launch init instead of the typing it
+# means to record.
+if [ "$VARIANT" = "demo" ]; then
+  echo "Warming up demo-replay init path..."
+  xcrun simctl launch "$UDID" "$BUNDLE_ID" --capture-demo > /dev/null 2>&1 || true
+  sleep 4
+  xcrun simctl terminate "$UDID" "$BUNDLE_ID" > /dev/null 2>&1 || true
+fi
+
 # capture_one <variant>: record a single launch animation and expand it.
 capture_one() {
   local variant="$1"
@@ -169,6 +194,17 @@ capture_one() {
       reduce_motion=0
       # warmDuration 0.7s (~0.5s hold + ~0.2s exit); extra to show Home.
       capture_window=2.0
+      ;;
+    demo)
+      launch_args="--capture-demo"
+      reduce_motion=0
+      # Sized for a COLD demo-host boot (the --ui-test cache warm-up does not
+      # warm the --capture-demo production-init path) PLUS a generous stretch
+      # of the chat-stream typing animation — the actual thing being measured.
+      # The replay loops through several demos, so over-shooting just captures
+      # more typing; under-shooting clips it. Re-run with a larger value (or
+      # a higher MOTION_FPS) if the first agent bubble doesn't finish on screen.
+      capture_window=18.0
       ;;
   esac
 


### PR DESCRIPTION
## Summary
Adds an explicit-only `demo` variant to `scripts/motion-capture.sh` that records the DL-time demo replay screen into a filmstrip, so the chat-stream **typing animation speed** can be measured frame-by-frame. This is verification tooling — PR1 of 2.

The actual speed bug (demo replay types at 60 cps vs simulation x1's 30 cps, hardcoded at `ModelDownloadHostView.swift:238`) is **deferred to PR2**. This PR does NOT change `charsPerSecond: 60`.

### How it works (all DEBUG-only, mirrors the existing `--capture-launch` machinery)
- `ModelManager`: new `#if DEBUG` `captureSeedDownloadingState(for:)` seam — `state` is `private(set)`, so an external seam is required to force `.downloading`.
- `PasturaApp`: new `--capture-demo` launch arg — suppresses the splash, short-circuits `initialize()` **before** the simulator-direct-`.ready` branch (which otherwise never reaches `.needsModelDownload`), seeds `.downloading` and routes to `.needsModelDownload` so `ModelDownloadHostView` renders the bundled demo replay. Starts **no real download**; loud-guards a nil active descriptor. DEBUG launch overrides extracted to `handleDebugLaunchOverride()` to keep `initialize()` under the cyclomatic-complexity cap.
- `scripts/motion-capture.sh`: new `demo` variant (kept out of `all` — different in nature), a `--capture-demo` warm-up (the shared `--ui-test` warm-up doesn't warm the production init path), and a cold-boot-sized capture window. Artifacts land under `docs/design/motion/demo/` (gitignored).

### Why this matters
Typing/animation-timing behavior can't be verified from static screenshots or unit tests (ADR-009 rule 4 — frame/animation-timing bugs are manual-QA + code-review gated). This gives a time axis: count characters revealed per frame at `MOTION_FPS` to read off chars/sec.

Verified end-to-end locally: `MOTION_FPS=24 scripts/motion-capture.sh demo` produced 448 frames + filmstrip showing the demo replay typing. Instantaneous rate measured ~54–60 cps between close frames (consistent with the current 60 hardcode); PR2 will re-capture to confirm the drop to 30.

## Test plan
- [x] New `#if DEBUG`-gated unit test for the seam (`ModelManagerTests+CaptureSeed.swift`)
- [x] Full unit suite (2200 tests) passes
- [x] `swiftlint --strict` clean
- [x] `scripts/motion-capture.sh demo` runs end-to-end and renders the demo replay typing (manual)
- [x] Capture-tooling code is entirely `#if DEBUG`-gated (no production leak)
- [x] `charsPerSecond: 60` unchanged (PR2 scope)

Closes #771

🤖 Generated with [Claude Code](https://claude.com/claude-code)