### PR TITLE
🐛 fix: match demo replay typing speed to simulation x1

### DIFF
--- a/Pastura/Pastura/App/PlaybackSpeed.swift
+++ b/Pastura/Pastura/App/PlaybackSpeed.swift
@@ -18,17 +18,24 @@ import Foundation
 /// `SimulationViewModel` is `@MainActor` and consumes this type
 /// freely — no isolation friction for value-type enums.
 ///
-/// **Two consumers, two pacing models — properties are NOT
-/// universally consumed:**
-/// - Sim uses ``charsPerSecond`` (typing animation) and
-///   ``interEventDelayMs`` (non-agent inter-event delay).
-/// - Replay uses ``multiplier`` to scale ``ReplayPlaybackConfig``'s
-///   `turnDelayMs` / `codePhaseDelayMs`. Replay does **not** consume
-///   ``charsPerSecond`` (no typing animation on replay) nor
-///   ``interEventDelayMs`` (its turn vs. codePhase distinction is
-///   richer than Sim's flat 120ms-or-zero gap). Don't extend replay
-///   pacing through the Sim-side properties; add a replay-side
-///   property here if a new pacing dimension is needed.
+/// **Consumers — properties are NOT universally consumed:**
+/// - **Sim** (``SimulationViewModel``) uses ``charsPerSecond`` (typing
+///   animation) and ``interEventDelayMs`` (non-agent inter-event delay).
+/// - **``ReplayViewModel``** (the replay *pacing* model) uses
+///   ``multiplier`` to scale ``ReplayPlaybackConfig``'s `turnDelayMs` /
+///   `codePhaseDelayMs`. It does **not** consume ``charsPerSecond`` (it
+///   advances bubbles on its own sleep clock, not a per-character
+///   timeline) nor ``interEventDelayMs`` (its turn vs. codePhase
+///   distinction is richer than Sim's flat 120ms-or-zero gap). Don't
+///   extend replay pacing through the Sim-side properties; add a
+///   replay-side property here if a new pacing dimension is needed.
+/// - **The DL-time demo replay _screen_** (``ModelDownloadHostView``)
+///   renders ``ReplayViewModel``'s `chatItems` through
+///   ``AgentOutputRow`` and statically references ``normal``'s
+///   ``charsPerSecond`` so its typing matches Sim x1. This is the View
+///   surface, distinct from ``ReplayViewModel``'s pacing above: the
+///   demo's Speed picker scales only ``multiplier`` (turn pacing),
+///   never typing cps.
 /// - ``.instant`` should be handled by an explicit early-return at
 ///   each delay-scaling callsite (see ``ReplayViewModel/scaledDelay(for:)``
 ///   and ``YAMLReplaySource``); the sentinel ``multiplier`` value is
@@ -45,7 +52,10 @@ nonisolated public enum PlaybackSpeed:
 
   /// Characters revealed per second during typing animation.
   /// `nil` means "render full text immediately" (`.instant`).
-  /// Sim-only — replay does not animate typing.
+  /// Consumed by Sim (``SimulationViewModel``) and — statically via
+  /// ``normal`` — by the DL-time demo replay screen
+  /// (``ModelDownloadHostView``). ``ReplayViewModel``'s own turn pacing
+  /// does not read it.
   public var charsPerSecond: Double? {
     switch self {
     case .slow: 15

--- a/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView.swift
+++ b/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView.swift
@@ -235,7 +235,7 @@ struct ModelDownloadHostView: View {
                   phaseType: entry.phaseType,
                   showAllThoughts: showAllThoughts,
                   isLatest: entry.id == lastAgentId,
-                  charsPerSecond: 60,
+                  charsPerSecond: PlaybackSpeed.normal.charsPerSecond,
                   agentPosition: agentPosition(for: entry.agent, viewModel: viewModel)
                 )
                 .id(entry.id)


### PR DESCRIPTION
## Summary
The DL-time demo replay typed at a hardcoded **60 cps** — double the simulation x1 speed (`PlaybackSpeed.normal.charsPerSecond` = 30). Both surfaces render via the same `AgentOutputRow` with shared punctuation pauses, so the cps value was the only difference. This references the enum so demo typing matches Sim x1 (and the existing `PlaybackSpeedTests` already pins `.normal == 30`).

PR2 of 2 — PR1 (#773) shipped the motion-capture `demo` variant used to verify this frame-by-frame.

### Changes
- `ModelDownloadHostView.swift:238` — `charsPerSecond: 60` → `PlaybackSpeed.normal.charsPerSecond`. Net-zero lines (the file is at the 400-line `file_length` cap; rationale lives in the `PlaybackSpeed` doc-comment instead).
- `PlaybackSpeed.swift` — doc-comment reconciliation: records the DL-demo **screen** (`ModelDownloadHostView` → `AgentOutputRow`) as a `charsPerSecond` consumer, explicitly distinct from `ReplayViewModel`'s `multiplier`-based turn pacing (which still does NOT read `charsPerSecond`).

## Verification
- Full unit suite (2200 tests) passes; `swiftlint --strict` clean.
- `MOTION_FPS=24 scripts/motion-capture.sh demo` (PR1's tool) re-captured: demo typing measured **~28–30 cps** between close frames (was ~54–60 before), confirming x1 parity.

## Known follow-up (out of scope, NOT a regression)
The demo advances turns on a fixed `turnDelayMs` (1200ms) that is **independent** of typing duration. At 30 cps, long agent bubbles can be snapped to full when the next turn appears (`AgentOutputRow` only animates the `isLatest` row). This pre-existing behavior is now slightly more visible (less text typed before the snap). A proportional turn-delay refinement was designed and reviewed but **deferred** to keep this PR to the literal speed fix — see the abandoned design discussion for the shared-resolver / parity requirements a future PR would need.

Closes #774

🤖 Generated with [Claude Code](https://claude.com/claude-code)