### PR TITLE
✨ feat: さがす catalog cards (tab identity PR2/3)

### DIFF
--- a/Pastura/Pastura/Views/Community/SharedScenarios/GalleryCatalogMetrics.swift
+++ b/Pastura/Pastura/Views/Community/SharedScenarios/GalleryCatalogMetrics.swift
@@ -1,0 +1,88 @@
+import CoreGraphics
+
+/// Load-bearing layout constants for the さがす (Browse / Shared Scenarios)
+/// **catalog-card** rendering (tab-identity redesign PR2, #777): the leading
+/// art tile, its sheep cluster, the landscape card chrome, the inline category
+/// chip, and the list rhythm. Values are transcribed from the approved lookbook
+/// (`docs/design/tab-identity/lookbook.html`, さがす row, "案C 中庸" column).
+///
+/// Extracted into a named `nonisolated enum` so the values are
+/// **change-detector**-testable without rendering the View
+/// (`.claude/rules/view-testing.md` § "Change-detector tripwire"; ADR-009).
+/// Only `Equatable` constants live here — `CGFloat` / `Int`. SwiftUI `Font`s
+/// are **not** `Equatable`, so they stay inline in ``GalleryCatalogRow`` and are
+/// code-review-gated, not asserted here.
+///
+/// `nonisolated` so the change-detector test reads the constants from a
+/// `nonisolated` context without a `@MainActor` suite workaround
+/// (swift-isolation.md Pattern 5). Values are tuned on-device — a test failure
+/// means a code-review-gated layout token drifted, not a bug (see the test's
+/// doc-comment).
+nonisolated enum GalleryCatalogMetrics {
+  // MARK: Art tile
+
+  /// Side length of the square leading art tile.
+  static let artTileSize: CGFloat = 74
+
+  /// Corner radius of the art tile.
+  static let artTileCornerRadius: CGFloat = 13
+
+  /// Size of each ``SheepAvatar`` rendered in the tile's cluster.
+  static let artSheepSize: CGFloat = 26
+
+  /// Gap between sheep in the 2-column cluster (both axes).
+  static let artClusterSpacing: CGFloat = 1
+
+  /// Hairline border width of the art tile (its own value, independent of the
+  /// thinner card hairline — the tile reads as a distinct framed thumbnail).
+  static let artTileBorderWidth: CGFloat = 1
+
+  /// The most sheep the cluster ever draws, regardless of `agentCount`.
+  static let maxClusterSheep: Int = 4
+
+  // MARK: Card
+
+  /// Horizontal gap between the art tile and the text body.
+  static let cardSpacing: CGFloat = 13
+
+  /// Corner radius of the landscape card.
+  static let cardCornerRadius: CGFloat = 16
+
+  /// Inner padding around the card's content.
+  static let cardPadding: CGFloat = 13
+
+  // MARK: List
+
+  /// Vertical gap between consecutive catalog cards.
+  static let listSpacing: CGFloat = 12
+
+  /// Outer horizontal margin from the screen edge to the cards. The catalog
+  /// list is inset (unlike the full-bleed `.grouped` empty-state band).
+  static let listHorizontalMargin: CGFloat = 16
+
+  // MARK: Body
+
+  /// Description truncation limit (2-line catalog blurb). `Int`, also
+  /// `Equatable` — asserted by the change-detector.
+  static let descriptionLineLimit: Int = 2
+
+  /// Top spacing between the title row and the inline category chip.
+  static let titleChipSpacing: CGFloat = 5
+
+  /// Top spacing between the category chip and the description.
+  static let descriptionTopPadding: CGFloat = 6
+
+  /// Top spacing between the description and the `N agents · N rounds` footer.
+  static let footerTopPadding: CGFloat = 7
+
+  // MARK: Category chip
+
+  /// Horizontal inner padding of the category chip.
+  static let catchipHorizontalPadding: CGFloat = 7
+
+  /// Vertical inner padding of the category chip.
+  static let catchipVerticalPadding: CGFloat = 2
+
+  /// Corner radius of the category chip.
+  static let catchipCornerRadius: CGFloat = 6
+}

--- a/Pastura/Pastura/Views/Community/SharedScenarios/GalleryCatalogRow.swift
+++ b/Pastura/Pastura/Views/Community/SharedScenarios/GalleryCatalogRow.swift
@@ -1,0 +1,184 @@
+import SwiftUI
+
+/// A landscape "catalog card" row for the さがす (Browse / Shared Scenarios)
+/// tab — a leading ``ScenarioArtTile`` plus a body of title (+ optional badge),
+/// an inline category chip, a 2-line description, and a `N agents · N rounds`
+/// footer. Introduced for the tab-identity redesign (PR2, #777) so Browse reads
+/// as a spaced card catalog, visually distinct from the Home compact rows and
+/// the Past Results timeline.
+///
+/// Presentation-only: it takes already-resolved values (``Model``), never the
+/// `GalleryScenario` domain type, so it stays unit-testable (ADR-009) and
+/// SPM-extraction-safe — the caller maps its record into the model. Mirrors
+/// ``ScenarioSummaryRow`` (which Home still uses; Browse moves to this card,
+/// and the shared row's retirement is deferred to PR3).
+struct GalleryCatalogRow: View {
+  /// Resolved, display-ready values for one catalog card.
+  ///
+  /// Intentionally **not** `Equatable` — auto-synthesized `Equatable` on a
+  /// default-MainActor value type makes its conformance lookup MainActor-bound,
+  /// which would force any future `nonisolated` comparator to a `@MainActor`
+  /// test suite (swift-isolation.md Pattern 5). The change-detector test asserts
+  /// ``GalleryCatalogMetrics`` / ``GalleryCatalogRowFormat`` instead.
+  struct Model {
+    let title: String
+    let badge: ScenarioBadge?
+    /// Already-localized category name shown in the inline chip (e.g. "Ethics").
+    let category: String
+    let description: String?
+    let agentCount: Int?
+    let rounds: Int?
+
+    init(
+      title: String,
+      badge: ScenarioBadge? = nil,
+      category: String,
+      description: String? = nil,
+      agentCount: Int? = nil,
+      rounds: Int? = nil
+    ) {
+      self.title = title
+      self.badge = badge
+      self.category = category
+      self.description = description
+      self.agentCount = agentCount
+      self.rounds = rounds
+    }
+  }
+
+  let model: Model
+
+  var body: some View {
+    let shape = RoundedRectangle(
+      cornerRadius: GalleryCatalogMetrics.cardCornerRadius, style: .continuous)
+    return HStack(alignment: .top, spacing: GalleryCatalogMetrics.cardSpacing) {
+      ScenarioArtTile(agentCount: model.agentCount)
+      bodyColumn
+    }
+    .padding(GalleryCatalogMetrics.cardPadding)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(Color.bubbleBackground, in: shape)
+    .overlay(shape.stroke(Color.rule, lineWidth: PasturaCardMetrics.borderWidth))
+    .shadow(
+      color: PasturaShadows.tight.color.color, radius: PasturaShadows.tight.radius,
+      x: PasturaShadows.tight.x, y: PasturaShadows.tight.y
+    )
+    // Full-card hit target (the prior `galleryRow` carried this via
+    // `.contentShape`; the catalog card drops the chevron, so re-assert it).
+    .contentShape(Rectangle())
+    // Announce the card as one actionable cell (title + badge + category +
+    // meta), matching the prior row's single-tap-target VoiceOver semantics.
+    .accessibilityElement(children: .combine)
+  }
+
+  private var bodyColumn: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      HStack(alignment: .firstTextBaseline) {
+        Text(model.title)
+          .font(.headline)
+          .foregroundStyle(Color.ink)
+          .lineLimit(1)
+        Spacer(minLength: 8)
+        if let badge = model.badge {
+          badgeView(badge)
+        }
+      }
+      categoryChip
+      if let description = model.description, !description.isEmpty {
+        Text(description)
+          .font(.subheadline)
+          .foregroundStyle(Color.inkSecondary)
+          .lineLimit(GalleryCatalogMetrics.descriptionLineLimit)
+          .truncationMode(.tail)
+          .padding(.top, GalleryCatalogMetrics.descriptionTopPadding)
+      }
+      // Push the footer to the card's bottom edge so cards of differing
+      // description length keep a consistent footer baseline (lookbook
+      // `margin-top:auto`).
+      Spacer(minLength: 0)
+      footer
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+
+  /// Inline category chip — mossDark text on the moss `selected` wash, mirroring
+  /// the filter-chip accent without the capsule (a quieter inline tag).
+  private var categoryChip: some View {
+    Text(model.category)
+      .font(.caption2.weight(.semibold))
+      .foregroundStyle(Color.mossDark)
+      .padding(.horizontal, GalleryCatalogMetrics.catchipHorizontalPadding)
+      .padding(.vertical, GalleryCatalogMetrics.catchipVerticalPadding)
+      .background(
+        Color.selected,
+        in: RoundedRectangle(
+          cornerRadius: GalleryCatalogMetrics.catchipCornerRadius, style: .continuous)
+      )
+      .padding(.top, GalleryCatalogMetrics.titleChipSpacing)
+  }
+
+  @ViewBuilder private var footer: some View {
+    let segments = GalleryCatalogRowFormat.footerSegments(
+      agentCount: model.agentCount, rounds: model.rounds)
+    if !segments.isEmpty {
+      HStack(spacing: 6) {
+        // Already-localized strings (+ the verbatim dot) — verbatim init so
+        // they are not re-interpreted as LocalizedStringKey lookups.
+        ForEach(Array(segments.enumerated()), id: \.offset) { _, segment in
+          Text(verbatim: segment)
+        }
+      }
+      .font(.caption)
+      .foregroundStyle(Color.muted)
+      .padding(.top, GalleryCatalogMetrics.footerTopPadding)
+    }
+  }
+
+  /// Title-trailing provenance / update badge. Replicates
+  /// ``ScenarioSummaryRow``'s badge styling minimally (rather than sharing a
+  /// component) to keep this PR scoped to Browse — PR3's shared-row retirement
+  /// is the right place to consolidate the two badge renderers.
+  private func badgeView(_ badge: ScenarioBadge) -> some View {
+    let isTint = badge.style == .tint
+    return Text(badge.label)
+      .font(.caption2.bold())
+      .padding(.horizontal, 6)
+      .padding(.vertical, 2)
+      .background(
+        isTint ? Color.accentColor.opacity(0.2) : Color.secondary.opacity(0.15),
+        in: Capsule()
+      )
+      .foregroundStyle(isTint ? AnyShapeStyle(Color.accentColor) : AnyShapeStyle(.secondary))
+  }
+}
+
+/// Pure display-formatting helpers for ``GalleryCatalogRow`` / ``ScenarioArtTile``.
+/// Side-effect-free and `nonisolated` so the non-trivial footer-assembly and
+/// cluster-count logic are unit-testable without rendering (ADR-009 /
+/// `.claude/rules/view-testing.md`).
+nonisolated enum GalleryCatalogRowFormat {
+  /// The ordered footer segments — `N agents` and `N rounds`, joined with a `·`
+  /// **only when both are present**. Returns `[]` when neither exists so the
+  /// caller renders no footer, and never emits a dangling separator (mirrors
+  /// ``ScenarioSummaryRowFormat/captionSegments``). Reuses the existing
+  /// `"%lld agents"` / `"%lld rounds"` catalog keys (Form B per i18n.md).
+  static func footerSegments(agentCount: Int?, rounds: Int?) -> [String] {
+    let agents = agentCount.map { String(format: String(localized: "%lld agents"), $0) }
+    let roundsText = rounds.map { String(format: String(localized: "%lld rounds"), $0) }
+    switch (agents, roundsText) {
+    case (let agents?, let roundsText?): return [agents, "·", roundsText]
+    case (let agents?, nil): return [agents]
+    case (nil, let roundsText?): return [roundsText]
+    case (nil, nil): return []
+    }
+  }
+
+  /// Number of sheep the ``ScenarioArtTile`` cluster should draw: clamped to
+  /// `[0, maxClusterSheep]`. Unknown (`nil`) or non-positive counts return `0`
+  /// — the catalog never fabricates agent data the rest of the app hides
+  /// (mirrors `HomeScenarioRowFormat`'s unknown-count handling).
+  static func clusterSheepCount(agentCount: Int?) -> Int {
+    guard let agentCount, agentCount > 0 else { return 0 }
+    return min(agentCount, GalleryCatalogMetrics.maxClusterSheep)
+  }
+}

--- a/Pastura/Pastura/Views/Community/SharedScenarios/SharedScenariosListView.swift
+++ b/Pastura/Pastura/Views/Community/SharedScenarios/SharedScenariosListView.swift
@@ -136,21 +136,19 @@ struct SharedScenariosListView: View {
           .padding(.vertical, 14)
       }
     } else {
-      let scenarios = viewModel.visibleScenarios
-      PasturaSection(style: .grouped) {
-        VStack(spacing: 0) {
-          ForEach(Array(scenarios.enumerated()), id: \.element.id) { index, scenario in
-            if index > 0 {
-              PasturaRowDivider(leadingInset: PasturaCardMetrics.horizontalMargin)
-            }
-            NavigationLink(value: Route.galleryScenarioDetail(scenario: scenario)) {
-              galleryRow(scenario: scenario, viewModel: viewModel)
-            }
-            .buttonStyle(.plain)
-            .accessibilityIdentifier("sharedScenarios.galleryCell.\(scenario.id)")
+      // Spaced landscape catalog cards (tab-identity PR2, #777) — NOT a divided
+      // `.grouped` band — so Browse reads as a card catalog, distinct from the
+      // Home compact rows and the Past Results timeline.
+      VStack(alignment: .leading, spacing: GalleryCatalogMetrics.listSpacing) {
+        ForEach(viewModel.visibleScenarios, id: \.id) { scenario in
+          NavigationLink(value: Route.galleryScenarioDetail(scenario: scenario)) {
+            GalleryCatalogRow(model: catalogModel(scenario: scenario, viewModel: viewModel))
           }
+          .buttonStyle(.plain)
+          .accessibilityIdentifier("sharedScenarios.galleryCell.\(scenario.id)")
         }
       }
+      .padding(.horizontal, GalleryCatalogMetrics.listHorizontalMargin)
     }
   }
 
@@ -183,50 +181,33 @@ struct SharedScenariosListView: View {
     .padding(.horizontal, PasturaCardMetrics.horizontalMargin + 6)
   }
 
-  /// Wraps ``scenarioRow`` with a trailing chevron + full-row hit target,
-  /// restoring the List disclosure affordance after the ScrollView move.
-  private func galleryRow(
-    scenario: GalleryScenario, viewModel: SharedScenariosViewModel
-  ) -> some View {
-    HStack(spacing: 10) {
-      scenarioRow(scenario: scenario, viewModel: viewModel)
-      Image(systemName: "chevron.forward")
-        .font(.footnote.weight(.semibold))
-        .foregroundStyle(Color.muted)
-    }
-    .padding(.horizontal, 17)
-    .padding(.vertical, 12)
-    .contentShape(Rectangle())
-  }
-
   // MARK: - Category filter chips
   //
   // `categoryChips` / `categoryChip` / `chipTitle` live in
   // `SharedScenariosListView+CategoryChips.swift` (split out for the
   // type_body_length budget, #731).
 
-  private func scenarioRow(
+  /// Maps a ``GalleryScenario`` into the presentation-only
+  /// ``GalleryCatalogRow/Model`` (tab-identity PR2, #777). The category moves
+  /// to the card's inline chip and `agent_count · rounds` to its footer; the
+  /// `~N inferences` caption from the old shared row is dropped under the
+  /// catalog layout (matches the approved lookbook).
+  private func catalogModel(
     scenario: GalleryScenario, viewModel: SharedScenariosViewModel
-  ) -> some View {
+  ) -> GalleryCatalogRow.Model {
     // hasUpdate wins over isInstalled — an updatable scenario is installed too,
     // but the "changed" signal is the more useful one to surface.
     let badge: ScenarioBadge? =
       viewModel.hasUpdate(for: scenario)
       ? .update
       : (viewModel.isInstalled(scenario) ? .installed : nil)
-    return ScenarioSummaryRow(
-      model: ScenarioSummaryRow.Model(
-        title: scenario.title,
-        badge: badge,
-        agentCount: scenario.agentCount,
-        rounds: scenario.rounds,
-        description: scenario.description,
-        descriptionLineLimit: 2,
-        captionLeading: scenario.category.displayName,
-        captionTrailing: String(
-          format: String(localized: "~%lld inferences"), scenario.estimatedInferences)
-      )
-    )
+    return GalleryCatalogRow.Model(
+      title: scenario.title,
+      badge: badge,
+      category: scenario.category.displayName,
+      description: scenario.description,
+      agentCount: scenario.agentCount,
+      rounds: scenario.rounds)
   }
 }
 

--- a/Pastura/Pastura/Views/Components/ScenarioArtTile.swift
+++ b/Pastura/Pastura/Views/Components/ScenarioArtTile.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+/// Leading art tile for a ``GalleryCatalogRow`` — a moss-tinted rounded square
+/// holding a small cluster of ``SheepAvatar`` heads that hints at the
+/// scenario's agent count. Decorative chrome for the さがす (Browse) catalog-card
+/// layout (tab-identity redesign PR2, #777); the row's title and description
+/// carry the actual identity, so the tile is hidden from VoiceOver.
+///
+/// When `agentCount` is `nil` or non-positive (older gallery feed / parse
+/// failure), the tile renders **empty** rather than fabricating a cluster —
+/// mirroring `HomeScenarioRowFormat`'s "hide the sheep when the count is
+/// unknown" convention, so the catalog never invents agent data the rest of
+/// the app treats as absent. The clamp/empty logic lives in
+/// ``GalleryCatalogRowFormat/clusterSheepCount(agentCount:)`` so it is
+/// unit-testable without rendering.
+struct ScenarioArtTile: View {
+  /// Number of agents the scenario runs, or `nil` / non-positive when unknown.
+  let agentCount: Int?
+
+  var body: some View {
+    let shape = RoundedRectangle(
+      cornerRadius: GalleryCatalogMetrics.artTileCornerRadius, style: .continuous)
+    return
+      shape
+      // Inline moss wash (lookbook --moss-wash, rgba(138,154,108,.10)) — no
+      // dedicated token per the PR2 "no new design token" constraint.
+      .fill(Color.moss.opacity(0.10))
+      .overlay(
+        shape.strokeBorder(Color.mossSoft, lineWidth: GalleryCatalogMetrics.artTileBorderWidth)
+      )
+      .frame(width: GalleryCatalogMetrics.artTileSize, height: GalleryCatalogMetrics.artTileSize)
+      .overlay(cluster)
+      // Decorative: SheepAvatar is already a11y-hidden, and the row's
+      // title / description announce identity.
+      .accessibilityHidden(true)
+  }
+
+  /// A 2-column grid of up to ``GalleryCatalogMetrics/maxClusterSheep`` sheep,
+  /// sized by `agentCount`. Empty when the count is unknown / non-positive.
+  @ViewBuilder private var cluster: some View {
+    let count = GalleryCatalogRowFormat.clusterSheepCount(agentCount: agentCount)
+    if count > 0 {
+      VStack(spacing: GalleryCatalogMetrics.artClusterSpacing) {
+        ForEach(Array(clusterRows(count: count).enumerated()), id: \.offset) { _, row in
+          HStack(spacing: GalleryCatalogMetrics.artClusterSpacing) {
+            ForEach(row, id: \.self) { index in
+              SheepAvatar(
+                character: .forAgent("", position: index),
+                size: GalleryCatalogMetrics.artSheepSize)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /// Chunk `0..<count` into rows of 2 (matches the lookbook 2-column grid:
+  /// 3 sheep → `[0, 1]`, `[2]`).
+  private func clusterRows(count: Int) -> [[Int]] {
+    stride(from: 0, to: count, by: 2).map { start in
+      Array(start..<min(start + 2, count))
+    }
+  }
+}

--- a/Pastura/PasturaTests/Views/GalleryCatalogMetricsTests.swift
+++ b/Pastura/PasturaTests/Views/GalleryCatalogMetricsTests.swift
@@ -1,0 +1,98 @@
+import CoreGraphics
+import Testing
+
+@testable import Pastura
+
+/// Change-detector tripwire for the さがす (Browse) catalog-card layout tokens
+/// (``GalleryCatalogMetrics``; tab-identity redesign PR2, #777) plus unit
+/// coverage of the pure ``GalleryCatalogRowFormat`` helpers.
+///
+/// The metric assertions mirror the source-of-truth constants **by design**.
+/// The card's rendered appearance (art tile, cluster, chip, spacing) is
+/// code-review-gated only (ADR-009 decision 3 — frame / layout tuning is out of
+/// scope for automated tests; the final values are tuned on-device). A failure
+/// here does NOT mean a bug was found: it means a code-review-gated layout token
+/// drifted (typically in an unrelated refactor), and the editor must confirm the
+/// change passed code review before updating the expected value. See
+/// `.claude/rules/view-testing.md` § "Change-detector tripwire".
+///
+/// The suite is intentionally **not** `@MainActor`: ``GalleryCatalogMetrics``
+/// and ``GalleryCatalogRowFormat`` are `nonisolated`, so a nonisolated test
+/// reads them directly — this suite also documents that isolation contract.
+@Suite("GalleryCatalogMetrics", .timeLimit(.minutes(1)))
+struct GalleryCatalogMetricsTests {
+
+  @Test func artTileGeometryUnchanged() {
+    #expect(GalleryCatalogMetrics.artTileSize == 74)
+    #expect(GalleryCatalogMetrics.artTileCornerRadius == 13)
+    #expect(GalleryCatalogMetrics.artSheepSize == 26)
+    #expect(GalleryCatalogMetrics.artClusterSpacing == 1)
+    #expect(GalleryCatalogMetrics.artTileBorderWidth == 1)
+    #expect(GalleryCatalogMetrics.maxClusterSheep == 4)
+  }
+
+  @Test func cardChromeUnchanged() {
+    #expect(GalleryCatalogMetrics.cardSpacing == 13)
+    #expect(GalleryCatalogMetrics.cardCornerRadius == 16)
+    #expect(GalleryCatalogMetrics.cardPadding == 13)
+  }
+
+  @Test func listRhythmUnchanged() {
+    #expect(GalleryCatalogMetrics.listSpacing == 12)
+    #expect(GalleryCatalogMetrics.listHorizontalMargin == 16)
+  }
+
+  @Test func bodySpacingUnchanged() {
+    #expect(GalleryCatalogMetrics.descriptionLineLimit == 2)
+    #expect(GalleryCatalogMetrics.titleChipSpacing == 5)
+    #expect(GalleryCatalogMetrics.descriptionTopPadding == 6)
+    #expect(GalleryCatalogMetrics.footerTopPadding == 7)
+  }
+
+  @Test func categoryChipMetricsUnchanged() {
+    #expect(GalleryCatalogMetrics.catchipHorizontalPadding == 7)
+    #expect(GalleryCatalogMetrics.catchipVerticalPadding == 2)
+    #expect(GalleryCatalogMetrics.catchipCornerRadius == 6)
+  }
+
+  // MARK: - footerSegments
+
+  @Test func footerSegmentsJoinsBothHalvesWithDot() {
+    let segments = GalleryCatalogRowFormat.footerSegments(agentCount: 4, rounds: 6)
+    #expect(segments.count == 3)
+    #expect(segments[1] == "·")
+    // The numeric halves render through the existing %lld keys; assert the
+    // count digit appears so a swapped placeholder is caught.
+    #expect(segments[0].contains("4"))
+    #expect(segments[2].contains("6"))
+  }
+
+  @Test func footerSegmentsOmitsMissingHalves() {
+    #expect(GalleryCatalogRowFormat.footerSegments(agentCount: 3, rounds: nil).count == 1)
+    #expect(GalleryCatalogRowFormat.footerSegments(agentCount: nil, rounds: 5).count == 1)
+    // No dangling separator when only one half is present.
+    #expect(!GalleryCatalogRowFormat.footerSegments(agentCount: 3, rounds: nil).contains("·"))
+  }
+
+  @Test func footerSegmentsEmptyWhenNeitherPresent() {
+    #expect(GalleryCatalogRowFormat.footerSegments(agentCount: nil, rounds: nil).isEmpty)
+  }
+
+  // MARK: - clusterSheepCount
+
+  @Test func clusterSheepCountClampsToRange() {
+    #expect(GalleryCatalogRowFormat.clusterSheepCount(agentCount: 1) == 1)
+    #expect(GalleryCatalogRowFormat.clusterSheepCount(agentCount: 3) == 3)
+    #expect(GalleryCatalogRowFormat.clusterSheepCount(agentCount: 4) == 4)
+    // Clamped to maxClusterSheep.
+    #expect(GalleryCatalogRowFormat.clusterSheepCount(agentCount: 9) == 4)
+  }
+
+  @Test func clusterSheepCountEmptyWhenUnknownOrNonPositive() {
+    // Unknown (nil) and non-positive counts draw no sheep — the catalog never
+    // fabricates agent data the rest of the app hides.
+    #expect(GalleryCatalogRowFormat.clusterSheepCount(agentCount: nil) == 0)
+    #expect(GalleryCatalogRowFormat.clusterSheepCount(agentCount: 0) == 0)
+    #expect(GalleryCatalogRowFormat.clusterSheepCount(agentCount: -2) == 0)
+  }
+}


### PR DESCRIPTION
## Summary
PR2 of the 3-PR tab-identity redesign (PR1 = Past Results timeline, #768).
Differentiates the さがす (Browse / Shared Scenarios) tab from Home and the
Past Results timeline by replacing its shared divided `PasturaCard(.grouped)`
list with spaced **landscape catalog cards** — a leading moss-tinted art tile
(sheep cluster) + title, inline category chip, 2-line description, and a
`N agents · N rounds` footer.

Visual target: `docs/design/tab-identity/lookbook.html` (さがす, 案C 中庸).

- New: `GalleryCatalogMetrics` (nonisolated layout tokens), `ScenarioArtTile`
  (art tile; empty when agent count unknown), `GalleryCatalogRow`
  (presentation-only card + `GalleryCatalogRowFormat` helpers).
- `SharedScenariosListView` non-empty branch → catalog cards; `galleryRow` /
  `scenarioRow` removed, replaced by a `catalogModel` mapper.
- Kept (PR1 lesson): inline nav title "Browse Shared Scenarios" + category
  chips + always-on `.searchable` — **no** in-scroll big header (would invert
  title→search order under the search drawer). Offline banner, empty / loading
  / error states, "Last updated" footer, and all
  `sharedScenarios.galleryCell.<id>` identifiers preserved.
- No new design token (art-tile wash = `Color.moss.opacity(0.10)` inline) and
  no new i18n key (footer reuses `%lld agents` / `%lld rounds`).
- Out of scope: Home and Past Results untouched; `ScenarioSummaryRow` retained
  (Home still uses it — retirement deferred to PR3).

## Test plan
- `GalleryCatalogMetricsTests` — change-detector for every layout token +
  `footerSegments` / `clusterSheepCount` edge cases (10 tests, green).
- Full unit suite: **TEST SUCCEEDED**.
- `NavigationRegressionTests` (gallery-cell push boundary): passed.
- swiftlint --strict, `check_localization_coverage.py` (552 keys, all ja),
  navigation-map `--check`: all green.

## Follow-up (PR3)
- Consolidate `GalleryCatalogRow.badgeView` with `ScenarioSummaryRow`'s badge
  renderer when the shared row is retired.

Closes #777