### PR TITLE
🐛 fix: proportional turn dwell for demo replay (no turn-snap)

### DIFF
--- a/Pastura/Pastura/App/ReplayPlaybackConfig.swift
+++ b/Pastura/Pastura/App/ReplayPlaybackConfig.swift
@@ -49,6 +49,22 @@ nonisolated public struct ReplayPlaybackConfig: Sendable, Equatable {
   /// What the consumer does once playback has nothing left to play.
   public var onComplete: CompletionAction
 
+  /// Character-reveal rate (chars/second) for the demo replay's typing
+  /// animation, and the rate the pacing floor uses to estimate how long a
+  /// bubble takes to type. **Single source of truth** so the View
+  /// (``AgentOutputRow`` via ``ModelDownloadHostView``, through
+  /// ``ReplayViewModel/typingCharsPerSecond``) and the
+  /// ``ReplayViewModel`` turn-dwell floor read the same value and cannot
+  /// drift.
+  ///
+  /// `nil` means "no proportional dwell" — the turn pacing stays on the
+  /// flat ``turnDelayMs`` / ``codePhaseDelayMs`` schedule and the View
+  /// renders full text immediately (matching ``PlaybackSpeed/charsPerSecond``
+  /// `nil == .instant`). Defaults to `nil` so existing configs and
+  /// timing-sensitive tests keep their legacy behaviour; only ``demoDefault``
+  /// opts in.
+  public var typingCharsPerSecond: Double?
+
   public enum LoopBehaviour: Sendable, Equatable {
     /// Rewind to the first event and keep playing — DL-time demo default.
     case loop
@@ -75,13 +91,15 @@ nonisolated public struct ReplayPlaybackConfig: Sendable, Equatable {
     turnDelayMs: Int = 1200,
     codePhaseDelayMs: Int = 500,
     loopBehaviour: LoopBehaviour,
-    onComplete: CompletionAction
+    onComplete: CompletionAction,
+    typingCharsPerSecond: Double? = nil
   ) {
     self.playbackSpeed = playbackSpeed
     self.turnDelayMs = turnDelayMs
     self.codePhaseDelayMs = codePhaseDelayMs
     self.loopBehaviour = loopBehaviour
     self.onComplete = onComplete
+    self.typingCharsPerSecond = typingCharsPerSecond
   }
 
   /// Preset for the DL-time demo host: nominal speed, loop forever,
@@ -93,5 +111,8 @@ nonisolated public struct ReplayPlaybackConfig: Sendable, Equatable {
   public static let demoDefault = ReplayPlaybackConfig(
     playbackSpeed: .normal,
     loopBehaviour: .loop,
-    onComplete: .awaitTransitionSignal)
+    onComplete: .awaitTransitionSignal,
+    // Opt the demo into proportional turn dwell at the Sim x1 cadence so a
+    // long bubble finishes typing before the next turn appears (no snap).
+    typingCharsPerSecond: PlaybackSpeed.normal.charsPerSecond)
 }

--- a/Pastura/Pastura/App/ReplayViewModel.swift
+++ b/Pastura/Pastura/App/ReplayViewModel.swift
@@ -167,6 +167,15 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
   /// is acceptable for the Demo screen.
   var playbackSpeed: PlaybackSpeed
 
+  /// Whether agent thought lines (`▸ THINKING`) are expanded across the
+  /// demo chat stream. Owned here (not on the host `View`) so the pacing
+  /// floor can read it — the turn-dwell estimate only counts the thought
+  /// segment's typing time when thoughts are shown. Default `true` mirrors
+  /// the Sim / Results state. Aligns the demo with Sim's per-VM toggle
+  /// (``SimulationViewModel``); ``ModelDownloadHostView`` binds the control
+  /// bar's ``ThoughtVisibilityToggle`` to `$viewModel.showAllThoughts`.
+  var showAllThoughts: Bool = true
+
   /// Chat-stream timeline backing the host view's `ScrollView` —
   /// mixed agent outputs and demo-boundary markers in publish order.
   ///

--- a/Pastura/Pastura/App/ReplayViewModel.swift
+++ b/Pastura/Pastura/App/ReplayViewModel.swift
@@ -595,14 +595,25 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
     let plan = sources[sourceIndex].plannedEvents()
     var cursor = startCursor
     var overrideMs = firstSleepOverrideMs
+    // Typing-dwell floor owed by the previously-applied agent bubble (raw,
+    // pre-speed). A LOCAL var — seeded 0 on each `playSource` entry — so it
+    // never leaks across a source rotation (`advanceAfterSource` re-enters
+    // with a fresh call) or a resume-from-background restart (which supplies
+    // `firstSleepOverrideMs`). The resume override bypasses the floor for the
+    // single restarted event, which is correct: its remaining sleep was
+    // already computed with the floor folded in before backgrounding.
+    var pendingFloorMs = 0
     while cursor < plan.count {
       if Task.isCancelled { return }
       let paced = plan[cursor]
-      let delayMs = overrideMs ?? scaledDelay(for: paced.kind)
+      let delayMs = overrideMs ?? scaledDelay(for: paced.kind, floorMs: pendingFloorMs)
       overrideMs = nil
       await sleepOrYield(milliseconds: delayMs)
       if Task.isCancelled { return }
       apply(paced.event)
+      // The floor for THIS bubble gates the delay before the NEXT event — the
+      // window during which this bubble is typing on screen.
+      pendingFloorMs = typingFloorMs(for: paced.event)
       cursor += 1
       // Only advance observable cursor if we're still playing (not
       // backgrounded mid-publish). Guards against a stale state
@@ -643,6 +654,12 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
   }
 
   private func advanceAfterSource(currentIndex: Int) -> AdvanceAction {
+    // Out of scope for proportional turn dwell (#779): the source's LAST
+    // bubble gets no dwell floor here — the floor only widens the delay that
+    // sits *before* the next event, and rotation/wrap has no such next-event
+    // sleep to widen. So a long final bubble of a source may still be mid-type
+    // when the rotation fires. Accepted; covering it would need a post-event
+    // settle hop the playback loop doesn't currently have.
     let isLastSource = currentIndex == sources.count - 1
     switch config.loopBehaviour {
     case .loop:
@@ -779,6 +796,42 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
 
   // MARK: - Pacing helpers
 
+  /// Extra dwell (ms) added on top of a bubble's typing duration so a fully
+  /// typed line lingers a beat before the next turn replaces the latest-row
+  /// animation. Tuned so a short turn's `max(turnDelayMs, typing + readPause)`
+  /// stays near the flat 1200ms rhythm while long bubbles extend past it.
+  private let typingReadPauseMs = 700
+
+  /// Proportional turn-dwell floor (raw ms, pre-speed) the *next* inter-event
+  /// delay must cover so the just-applied agent bubble finishes its
+  /// ``AgentOutputRow`` reveal animation before the next turn appears.
+  ///
+  /// Returns 0 for non-agent events (nothing is typing) and when the config
+  /// opts out of proportional dwell (``ReplayPlaybackConfig/typingCharsPerSecond``
+  /// `== nil`). Otherwise estimates the reveal time via
+  /// ``TurnOutput/revealedSegments(for:includeThought:)`` +
+  /// ``typingDurationMs(primary:thought:charsPerSecond:)`` and adds
+  /// ``typingReadPauseMs``.
+  ///
+  /// The thought segment is gated on the global ``showAllThoughts``. NOTE:
+  /// ``AgentOutputRow`` honours a *per-row* `showInnerThought` seeded from
+  /// this global but then mutable via the row's chevron, so a mid-flight
+  /// chevron tap on the latest row makes this estimate slightly inexact. That
+  /// is an accepted heuristic imprecision — the floor is a lower bound on
+  /// dwell, not a frame-exact contract (animation timing is code-review-gated
+  /// per `.claude/rules/view-testing.md` rule 4, not asserted). `internal`
+  /// (not `private`) so `ReplayViewModelTests+Pacing` can exercise it.
+  func typingFloorMs(for event: SimulationEvent) -> Int {
+    guard case .agentOutput(_, let output, let phaseType) = event else { return 0 }
+    guard let cps = config.typingCharsPerSecond else { return 0 }
+    let segments = output.revealedSegments(
+      for: phaseType, includeThought: showAllThoughts)
+    let typing = typingDurationMs(
+      primary: segments.primary, thought: segments.thought, charsPerSecond: cps)
+    guard typing > 0 else { return 0 }
+    return typing + typingReadPauseMs
+  }
+
   /// Per-event sleep in milliseconds. Reads ``playbackSpeed`` (the
   /// runtime-mutable VM state, not `config.playbackSpeed`) so a Speed
   /// Menu change reflects on the next call.
@@ -788,17 +841,27 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
   /// `.infinity` sentinel on `.instant.multiplier` would arithmetically
   /// produce 0 too, but explicit early-return avoids depending on
   /// IEEE-754 division semantics.
-  private func scaledDelay(for kind: PacedEvent.Kind) -> Int {
+  ///
+  /// `floorMs` is the proportional turn-dwell floor (raw, pre-speed): the
+  /// time the previously-applied agent bubble still needs to finish typing
+  /// (see ``typingFloorMs(for:)``). The base delay is raised to at least the
+  /// floor *before* the speed division, so a long bubble holds the next turn
+  /// until it has typed out, while short turns keep the flat ``turnDelayMs``
+  /// rhythm. `.instant` ignores the floor too (collapses to 0). `internal`
+  /// (not `private`) so `ReplayViewModelTests+Pacing` can pin the arithmetic.
+  func scaledDelay(for kind: PacedEvent.Kind, floorMs: Int = 0) -> Int {
     if playbackSpeed == .instant { return 0 }
     let speed = max(playbackSpeed.multiplier, 0.001)
+    let base: Int
     switch kind {
     case .turn:
-      return Int(Double(config.turnDelayMs) / speed)
+      base = config.turnDelayMs
     case .codePhase:
-      return Int(Double(config.codePhaseDelayMs) / speed)
+      base = config.codePhaseDelayMs
     case .lifecycle:
-      return 0
+      base = 0
     }
+    return Int(Double(max(base, floorMs)) / speed)
   }
 
   /// Computes the outstanding sleep in milliseconds given

--- a/Pastura/Pastura/App/ReplayViewModel.swift
+++ b/Pastura/Pastura/App/ReplayViewModel.swift
@@ -212,6 +212,14 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
     }
   }
 
+  /// Character-reveal rate forwarded from
+  /// ``ReplayPlaybackConfig/typingCharsPerSecond``. ``ModelDownloadHostView``
+  /// reads this when building each ``AgentOutputRow`` so the View's typing
+  /// animation and this VM's turn-dwell floor share one source of truth
+  /// (`nil` ⇒ instant text / no proportional dwell). No `@Observable`
+  /// bridging needed — `config` is immutable.
+  var typingCharsPerSecond: Double? { config.typingCharsPerSecond }
+
   /// One rendered agent output suitable for `AgentOutputRow`.
   nonisolated struct AgentOutputEntry: Sendable, Equatable, Identifiable {
     public let id: UUID

--- a/Pastura/Pastura/Models/TurnOutput.swift
+++ b/Pastura/Pastura/Models/TurnOutput.swift
@@ -118,6 +118,35 @@ nonisolated public struct TurnOutput: Codable, Sendable, Equatable {
     }
     return fields[key]
   }
+
+  /// The exact display segments ``AgentOutputRow`` reveals for this output
+  /// in the committed / replay (non-streaming) path: the decorated primary
+  /// (vote → `→ <name>`) and the private thought, the latter empty unless
+  /// `includeThought`.
+  ///
+  /// Single source of truth shared by the reveal counter
+  /// (``AgentOutputRow`` `targetLength`, which reads the same
+  /// ``primaryText(for:)`` / ``secondaryText(for:)`` accessors) and the
+  /// replay typing-duration estimate (``ReplayViewModel`` turn-dwell floor),
+  /// so the two can never disagree on what — or how much — gets typed. The
+  /// vote arrow is applied exactly once here (via ``primaryText(for:)``),
+  /// never re-decorated.
+  ///
+  /// `nil` primary / thought collapse to `""` so callers can concatenate and
+  /// count without optional handling. Code phases yield `("", "")`.
+  ///
+  /// - Parameters:
+  ///   - phaseType: The phase whose canonical fields to resolve.
+  ///   - includeThought: Whether the THINKING section is currently shown;
+  ///     when `false` the thought segment is empty (the reveal counter omits
+  ///     it too).
+  public func revealedSegments(
+    for phaseType: PhaseType, includeThought: Bool
+  ) -> (primary: String, thought: String) {
+    let primary = primaryText(for: phaseType) ?? ""
+    let thought = includeThought ? (secondaryText(for: phaseType) ?? "") : ""
+    return (primary, thought)
+  }
 }
 
 /// Errors related to accessing ``TurnOutput`` fields.

--- a/Pastura/Pastura/Utilities/TypingPunctuation.swift
+++ b/Pastura/Pastura/Utilities/TypingPunctuation.swift
@@ -38,3 +38,46 @@ nonisolated func punctuationPauseMs(after character: Character) -> Int {
 /// Functions as a rhetorical beat — the reader registers the end of the
 /// spoken line before the private thought starts.
 nonisolated let statementToThoughtPauseMs: Int = 300
+
+/// Estimated wall-clock time (in milliseconds) the ``AgentOutputRow``
+/// reveal animation spends typing `primary` followed by `thought` at
+/// `charsPerSecond`, used by the demo replay's proportional turn-dwell floor
+/// (``ReplayViewModel``) to hold the next turn until the bubble finishes.
+///
+/// Mirrors `AgentOutputRow.startAnimationIfNeeded`'s loop **exactly**, reusing
+/// the same per-character ``punctuationPauseMs(after:)`` walk and the same
+/// ``statementToThoughtPauseMs`` boundary beat (not just the same constants),
+/// so the estimate and the animation cannot drift:
+/// - `ceil(totalChars / cps * 1000)` base reveal time (one tick per grapheme),
+/// - plus `punctuationPauseMs` summed over every revealed character,
+/// - plus one `statementToThoughtPauseMs` beat iff **both** `primary` and
+///   `thought` are non-empty (the reveal loop fires it when the counter
+///   crosses the non-empty primary into a non-empty thought).
+///
+/// Pure and dependency-free (primitive inputs only — never a `TurnOutput`,
+/// keeping the Utilities layer free of a Models dependency). Callers resolve
+/// the segments via ``TurnOutput/revealedSegments(for:includeThought:)`` and
+/// pass the strings down.
+///
+/// Returns `0` when `charsPerSecond <= 0` (mirrors the reveal loop's
+/// `cps > 0` guard → snap to full, no dwell) or when there is nothing to type.
+///
+/// - Parameters:
+///   - primary: The decorated primary text the row types first.
+///   - thought: The private-thought text typed after the primary (empty when
+///     the THINKING section is collapsed).
+///   - charsPerSecond: Reveal rate; `<= 0` disables the estimate.
+/// - Returns: Estimated typing duration in milliseconds.
+nonisolated func typingDurationMs(
+  primary: String, thought: String, charsPerSecond: Double
+) -> Int {
+  guard charsPerSecond > 0 else { return 0 }
+  let full = primary + thought
+  guard !full.isEmpty else { return 0 }
+
+  let base = Int((Double(full.count) / charsPerSecond * 1000).rounded(.up))
+  let punctuation = full.reduce(0) { $0 + punctuationPauseMs(after: $1) }
+  let boundary =
+    (!primary.isEmpty && !thought.isEmpty) ? statementToThoughtPauseMs : 0
+  return base + punctuation + boundary
+}

--- a/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+ControlBar.swift
+++ b/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+ControlBar.swift
@@ -13,9 +13,10 @@ extension ModelDownloadHostView {
   /// - Speed Menu binds directly to ``ReplayViewModel/playbackSpeed``
   ///   over `PlaybackSpeed.allCases`, matching Sim's pattern at
   ///   `SimulationView.swift:434`.
-  /// - Thought toggle remains bound to `showAllThoughts` (Sim and
-  ///   Replay diverge here — Sim's is a per-VM property, Demo's is a
-  ///   View-local `@State`).
+  /// - Thought toggle binds to `$viewModel.showAllThoughts` — a per-VM
+  ///   property, matching Sim (``SimulationViewModel``). The previous
+  ///   View-local `@State` divergence was removed so the demo's pacing
+  ///   floor can read the flag (#779).
   ///
   /// Does **not** apply `.ignoresSafeArea(.container, edges: .bottom)`
   /// (unlike `SimulationView.controlBar`). The host's
@@ -25,13 +26,16 @@ extension ModelDownloadHostView {
   /// PromoCard layer (#273 critic Axis 2).
   @ViewBuilder
   func controlBar(viewModel: ReplayViewModel) -> some View {
+    // Rebind so the thought toggle can project a `Binding` into the VM's
+    // `showAllThoughts` (a plain parameter has no projected value).
+    @Bindable var viewModel = viewModel
     HStack(spacing: 16) {
       pauseButton(viewModel: viewModel)
       speedMenu(viewModel: viewModel)
 
       Spacer()
 
-      ThoughtVisibilityToggle(isOn: $showAllThoughts)
+      ThoughtVisibilityToggle(isOn: $viewModel.showAllThoughts)
         .font(.title3)
     }
     .padding(.horizontal)

--- a/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView.swift
+++ b/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView.swift
@@ -84,13 +84,9 @@ struct ModelDownloadHostView: View {
   @State private var replayHadStarted: Bool = false
   @State private var sources: [any ReplaySource] = []
   @State private var isShowingCancelConfirmation: Bool = false
-  /// Whether agent thought lines (`▸ THINKING`) are expanded across the
-  /// chat stream. Default `true` mirrors the Sim / Results state and the
-  /// `docs/specs/demo-replay-ui.md` §163-165 amendment in this PR
-  /// (project-wide "expanded by default"). Module-internal (drops
-  /// `private`) so the sibling `+ControlBar.swift` extension can bind
-  /// to it via `$showAllThoughts`.
-  @State var showAllThoughts: Bool = true
+  // Thought-visibility (`▸ THINKING` expanded) now lives on `ReplayViewModel`
+  // (`showAllThoughts`) so the pacing floor can read it; the control bar binds
+  // `$viewModel.showAllThoughts`. See the VM property's doc-comment.
   /// Re-entry guard for `handleModelStateChange`: `.onChange(of: currentState)`
   /// only fires on inequality, but a defensive same-value re-emit by
   /// `ModelManager` (or a future refactor) would otherwise dispatch the
@@ -233,7 +229,7 @@ struct ModelDownloadHostView: View {
                   agent: entry.agent,
                   output: entry.output,
                   phaseType: entry.phaseType,
-                  showAllThoughts: showAllThoughts,
+                  showAllThoughts: viewModel.showAllThoughts,
                   isLatest: entry.id == lastAgentId,
                   charsPerSecond: viewModel.typingCharsPerSecond,
                   agentPosition: agentPosition(for: entry.agent, viewModel: viewModel)

--- a/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView.swift
+++ b/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView.swift
@@ -235,7 +235,7 @@ struct ModelDownloadHostView: View {
                   phaseType: entry.phaseType,
                   showAllThoughts: showAllThoughts,
                   isLatest: entry.id == lastAgentId,
-                  charsPerSecond: PlaybackSpeed.normal.charsPerSecond,
+                  charsPerSecond: viewModel.typingCharsPerSecond,
                   agentPosition: agentPosition(for: entry.agent, viewModel: viewModel)
                 )
                 .id(entry.id)

--- a/Pastura/PasturaTests/App/ReplayPlaybackConfigTests.swift
+++ b/Pastura/PasturaTests/App/ReplayPlaybackConfigTests.swift
@@ -1,0 +1,29 @@
+import Testing
+
+@testable import Pastura
+
+/// Contract tests for ``ReplayPlaybackConfig``'s typing-cadence knob.
+///
+/// `typingCharsPerSecond` is the single source of truth for the demo
+/// replay's character-reveal rate, read by both the View (``AgentOutputRow``
+/// via ``ModelDownloadHostView``) and the ``ReplayViewModel`` pacing floor.
+/// It defaults to `nil` (no proportional dwell / instant text) so legacy
+/// configs and timing-sensitive tests are unaffected; only ``demoDefault``
+/// opts in.
+@Suite(.timeLimit(.minutes(1)))
+struct ReplayPlaybackConfigTests {
+  @Test func typingCharsPerSecondDefaultsToNil() {
+    let config = ReplayPlaybackConfig(
+      loopBehaviour: .loop, onComplete: .stopPlayback)
+    #expect(config.typingCharsPerSecond == nil)
+  }
+
+  @Test func demoDefaultOptsIntoNormalTypingSpeed() {
+    #expect(
+      ReplayPlaybackConfig.demoDefault.typingCharsPerSecond
+        == PlaybackSpeed.normal.charsPerSecond)
+    // Pins the concrete value so a future PlaybackSpeed.normal change is a
+    // deliberate, reviewed edit rather than a silent demo-cadence shift.
+    #expect(ReplayPlaybackConfig.demoDefault.typingCharsPerSecond == 30)
+  }
+}

--- a/Pastura/PasturaTests/App/ReplayViewModelTests+Pacing.swift
+++ b/Pastura/PasturaTests/App/ReplayViewModelTests+Pacing.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+/// Pacing-floor (proportional turn dwell) tests for ``ReplayViewModel``.
+///
+/// Sibling extension of `ReplayViewModelTests` (NOT a new `@Suite`) per
+/// `.claude/rules/testing.md` — a separate suite would run in parallel and
+/// race the VM-spawning original on the shared test process.
+extension ReplayViewModelTests {
+
+  // MARK: - typingCharsPerSecond accessor (single source of truth)
+
+  @Test func typingCharsPerSecondForwardsConfigNil() throws {
+    // `fastConfig` leaves `typingCharsPerSecond` at its `nil` default.
+    let viewModel = try Self.makeVM()
+    #expect(viewModel.typingCharsPerSecond == nil)
+  }
+
+  @Test func typingCharsPerSecondForwardsConfigValue() throws {
+    let source = try Self.makeSource()
+    let viewModel = ReplayViewModel(
+      sources: [source], config: .demoDefault, contentFilter: ContentFilter())
+    #expect(viewModel.typingCharsPerSecond == PlaybackSpeed.normal.charsPerSecond)
+  }
+}

--- a/Pastura/PasturaTests/App/ReplayViewModelTests+Pacing.swift
+++ b/Pastura/PasturaTests/App/ReplayViewModelTests+Pacing.swift
@@ -31,4 +31,73 @@ extension ReplayViewModelTests {
     let viewModel = try Self.makeVM()
     #expect(viewModel.showAllThoughts)
   }
+
+  // MARK: - typingFloorMs (per-bubble dwell floor)
+
+  /// VM built with `demoDefault` (opts into `typingCharsPerSecond == 30`).
+  private static func makeDemoPacedVM() throws -> ReplayViewModel {
+    let source = try Self.makeSource()
+    return ReplayViewModel(
+      sources: [source], config: .demoDefault, contentFilter: ContentFilter())
+  }
+
+  @Test func floorIsZeroForNonAgentEvent() throws {
+    let viewModel = try Self.makeDemoPacedVM()
+    #expect(viewModel.typingFloorMs(for: .roundStarted(round: 1, totalRounds: 3)) == 0)
+  }
+
+  @Test func floorIsZeroWhenConfigOptsOut() throws {
+    // `fastConfig` leaves `typingCharsPerSecond` nil → no proportional dwell.
+    let viewModel = try Self.makeVM()
+    let event = SimulationEvent.agentOutput(
+      agent: "Alice", output: TurnOutput(fields: ["statement": "Hi."]),
+      phaseType: .speakAll)
+    #expect(viewModel.typingFloorMs(for: event) == 0)
+  }
+
+  @Test func floorIsTypingDurationPlusReadPause() throws {
+    let viewModel = try Self.makeDemoPacedVM()
+    let event = SimulationEvent.agentOutput(
+      agent: "Alice", output: TurnOutput(fields: ["statement": "Hi."]),
+      phaseType: .speakAll)
+    // typingDurationMs("Hi.", "", 30) == 400; + typingReadPauseMs(700) == 1100.
+    #expect(viewModel.typingFloorMs(for: event) == 1100)
+  }
+
+  @Test func floorOmitsThoughtWhenThoughtsHidden() throws {
+    let viewModel = try Self.makeDemoPacedVM()
+    viewModel.showAllThoughts = false
+    let event = SimulationEvent.agentOutput(
+      agent: "Alice",
+      output: TurnOutput(fields: ["statement": "Hi.", "inner_thought": "secret"]),
+      phaseType: .speakAll)
+    // Thought segment excluded → same as the no-thought case (1100), not larger.
+    #expect(viewModel.typingFloorMs(for: event) == 1100)
+  }
+
+  // MARK: - scaledDelay floor application
+
+  @Test func scaledDelayTakesFloorWhenFloorExceedsBase() throws {
+    let viewModel = try Self.makeDemoPacedVM()  // .normal speed (multiplier 1.0)
+    // floor 5000 > turnDelayMs 1200 → 5000.
+    #expect(viewModel.scaledDelay(for: .turn, floorMs: 5000) == 5000)
+  }
+
+  @Test func scaledDelayTakesBaseWhenFloorBelowBase() throws {
+    let viewModel = try Self.makeDemoPacedVM()
+    // floor 100 < turnDelayMs 1200 → 1200 (short turns keep the ~1.2s rhythm).
+    #expect(viewModel.scaledDelay(for: .turn, floorMs: 100) == 1200)
+  }
+
+  @Test func scaledDelayAppliesFloorToLifecycleKind() throws {
+    let viewModel = try Self.makeDemoPacedVM()
+    // Lifecycle base is 0, so the floor (a preceding bubble still typing) wins.
+    #expect(viewModel.scaledDelay(for: .lifecycle, floorMs: 800) == 800)
+  }
+
+  @Test func instantSpeedCollapsesDelayIncludingFloor() throws {
+    let viewModel = try Self.makeDemoPacedVM()
+    viewModel.playbackSpeed = .instant
+    #expect(viewModel.scaledDelay(for: .turn, floorMs: 5000) == 0)
+  }
 }

--- a/Pastura/PasturaTests/App/ReplayViewModelTests+Pacing.swift
+++ b/Pastura/PasturaTests/App/ReplayViewModelTests+Pacing.swift
@@ -24,4 +24,11 @@ extension ReplayViewModelTests {
       sources: [source], config: .demoDefault, contentFilter: ContentFilter())
     #expect(viewModel.typingCharsPerSecond == PlaybackSpeed.normal.charsPerSecond)
   }
+
+  // MARK: - showAllThoughts ownership (moved from host @State)
+
+  @Test func showAllThoughtsDefaultsToTrue() throws {
+    let viewModel = try Self.makeVM()
+    #expect(viewModel.showAllThoughts)
+  }
 }

--- a/Pastura/PasturaTests/Models/TurnOutputTests.swift
+++ b/Pastura/PasturaTests/Models/TurnOutputTests.swift
@@ -173,4 +173,45 @@ struct TurnOutputTests {
     let output = TurnOutput(fields: ["inner_thought": "x", "reason": "y"])
     #expect(output.secondaryText(for: .scoreCalc) == nil)
   }
+
+  // MARK: - revealedSegments (what AgentOutputRow actually types)
+
+  @Test func revealedSegmentsSpeakWithThought() {
+    let output = TurnOutput(fields: ["statement": "Hello", "inner_thought": "hmm"])
+    let segments = output.revealedSegments(for: .speakAll, includeThought: true)
+    #expect(segments.primary == "Hello")
+    #expect(segments.thought == "hmm")
+  }
+
+  @Test func revealedSegmentsGatesThoughtOnIncludeFlag() {
+    let output = TurnOutput(fields: ["statement": "Hello", "inner_thought": "hmm"])
+    let segments = output.revealedSegments(for: .speakAll, includeThought: false)
+    #expect(segments.primary == "Hello")
+    #expect(segments.thought == "")
+  }
+
+  @Test func revealedSegmentsVoteCarriesArrowAndReason() {
+    let output = TurnOutput(fields: ["vote": "Alice", "reason": "trust"])
+    let segments = output.revealedSegments(for: .vote, includeThought: true)
+    // Vote primary is the decorated `→ <name>` form, NOT double-decorated.
+    #expect(segments.primary == "→ Alice")
+    #expect(segments.thought == "trust")
+  }
+
+  // Pins the no-drift contract: revealedSegments resolves the primary via the
+  // SAME `primaryText(for:)` accessor AgentOutputRow's replay path uses, so the
+  // vote arrow is applied exactly once (never re-decorated into `→ → Alice`).
+  @Test func revealedSegmentsPrimaryMatchesPrimaryTextAccessor() {
+    let output = TurnOutput(fields: ["vote": "Alice", "reason": "trust"])
+    #expect(
+      output.revealedSegments(for: .vote, includeThought: false).primary
+        == output.primaryText(for: .vote))
+  }
+
+  @Test func revealedSegmentsEmptyForCodePhase() {
+    let output = TurnOutput(fields: ["inner_thought": "x"])
+    let segments = output.revealedSegments(for: .scoreCalc, includeThought: true)
+    #expect(segments.primary == "")
+    #expect(segments.thought == "")
+  }
 }

--- a/Pastura/PasturaTests/Utilities/TypingPunctuationTests.swift
+++ b/Pastura/PasturaTests/Utilities/TypingPunctuationTests.swift
@@ -29,4 +29,55 @@ struct TypingPunctuationTests {
     #expect(punctuationPauseMs(after: ":") == 0)
     #expect(punctuationPauseMs(after: ";") == 0)
   }
+
+  // MARK: - typingDurationMs (proportional turn-dwell floor estimate)
+  //
+  // Hand-computed against the exact AgentOutputRow reveal-loop model
+  // (`AgentOutputRow.startAnimationIfNeeded`): N base ticks of 1000/cps ms
+  // (ceil'd over the total), plus `punctuationPauseMs` summed per revealed
+  // character, plus one `statementToThoughtPauseMs` boundary beat iff both
+  // primary and thought are non-empty.
+
+  @Test func durationShortStatementNoThought() {
+    // "Hi." → base ceil(3/30*1000)=100, '.'=300, no boundary.
+    #expect(typingDurationMs(primary: "Hi.", thought: "", charsPerSecond: 30) == 400)
+  }
+
+  @Test func durationVoteArrowPlusReason() {
+    // "→ Bob" (5 chars, no punctuation) + "Risky." (6 chars, '.'=300).
+    // base ceil(11/30*1000)=367, punctuation 300, boundary 300.
+    #expect(
+      typingDurationMs(primary: "→ Bob", thought: "Risky.", charsPerSecond: 30) == 967)
+  }
+
+  @Test func durationCommaHeavyNoThought() {
+    // "A, b, c." (8 chars): base ceil(8/30*1000)=267, ','+','+'.'=120+120+300=540.
+    #expect(
+      typingDurationMs(primary: "A, b, c.", thought: "", charsPerSecond: 30) == 807)
+  }
+
+  @Test func durationStatementThoughtBoundaryBeat() {
+    // "Hello world"(11) + "thinking"(8) = 19 chars, no punctuation.
+    // base ceil(19/30*1000)=634, boundary 300.
+    #expect(
+      typingDurationMs(primary: "Hello world", thought: "thinking", charsPerSecond: 30)
+        == 934)
+  }
+
+  @Test func durationNoBoundaryWhenPrimaryEmpty() {
+    // Empty primary + non-empty thought: the reveal loop never hits the
+    // `newPosition == primaryLen(0)` boundary, so no 300ms beat.
+    // "ok" (2 chars): base ceil(2/30*1000)=67, no punctuation, no boundary.
+    #expect(typingDurationMs(primary: "", thought: "ok", charsPerSecond: 30) == 67)
+  }
+
+  @Test func durationZeroForNonPositiveCharsPerSecond() {
+    // cps <= 0 mirrors AgentOutputRow's `cps > 0` guard → snap to full, no dwell.
+    #expect(typingDurationMs(primary: "Hi.", thought: "x", charsPerSecond: 0) == 0)
+    #expect(typingDurationMs(primary: "Hi.", thought: "x", charsPerSecond: -5) == 0)
+  }
+
+  @Test func durationZeroForEmptyText() {
+    #expect(typingDurationMs(primary: "", thought: "", charsPerSecond: 30) == 0)
+  }
 }


### PR DESCRIPTION
## Summary
The DL-time demo replay advanced turns on a flat `ReplayPlaybackConfig.turnDelayMs`
(1200ms) independent of typing time. `AgentOutputRow` animates only the latest row
at 30 cps, so a long bubble got its next turn before finishing typing → the text
"snapped" to full. This makes the inter-turn delay a floor proportional to the
just-typed bubble: `max(turnDelayMs, typingDurationMs + readPauseMs) / speed`.

- **`typingCharsPerSecond: Double?`** on `ReplayPlaybackConfig` (nil default, opt-in
  on `demoDefault`) is the single source of truth — both the View (via a new
  `ReplayViewModel.typingCharsPerSecond` accessor) and the pacing floor read it.
- **Shared pure helpers**: `TurnOutput.revealedSegments(for:includeThought:)` [Models]
  resolves the exact strings the row types (vote `→ ` applied once, via the same
  accessor the row uses); `typingDurationMs(...)` [Utilities, primitive args] mirrors
  the reveal-loop timing (base + punctuation pauses + statement→thought beat).
- **`showAllThoughts` moved host @State → `ReplayViewModel`** so the floor can gate
  the thought segment; aligns the demo with Sim's per-VM toggle and net-shrinks the
  host file (400→396).
- **`playSource`** tracks a local `pendingFloorMs` (won't leak across source rotation
  / resume) and feeds `scaledDelay(for:floorMs:)`; `.instant` still collapses to 0.

Short turns keep the ~1.2s rhythm (floor < base); long bubbles hold the next turn
until typed. Continuation of #773 / #775.

### Out of scope
A source's final bubble before loop/rotation has no following delay to widen, so it
can still be mid-type when the rotation fires (commented at `advanceAfterSource`).

## Test plan
- New contract tests: `typingDurationMs` (hand-computed short/vote/comma-heavy/
  boundary cases, cps<=0->0), `revealedSegments` (vote no-double-decorate, thought
  gate), `typingFloorMs` (non-agent->0, nil-cps->0, value, thoughts-off), `scaledDelay`
  floor application + `.instant`->0, config defaults, VM accessor passthrough.
- Full unit suite: **2232 tests / 194 suites passed**; `swiftlint --strict` clean.
- Visual: `MOTION_FPS=24 scripts/motion-capture.sh demo` before/after (manual, optional).

Closes #779.

🤖 Generated with [Claude Code](https://claude.com/claude-code)