### PR TITLE
📝 docs: promote 15 memory traps to .claude/rules/ (round 6)

### DIFF
--- a/.claude/rules/swiftui-traps.md
+++ b/.claude/rules/swiftui-traps.md
@@ -136,3 +136,82 @@ cross-layer) collides.
 if taken, pick a distinct name (rename the type too if it also clashes). Case
 study: #759 renamed a new `ScenarioSummary.swift` (Views) that collided with the
 Data-layer `ScenarioSummary` → `ScenarioSummaryStrip`.
+
+## iOS 26 `.confirmationDialog` renders as a mis-anchored popover
+
+On iOS 26 a SwiftUI `.confirmationDialog` (body-attached and/or triggered from a
+`Menu` item) renders on iPhone as a **popover whose arrow anchors to the body
+centre** — pointing at empty space, not the control that opened it.
+`.confirmationDialog` exposes no source-anchor API, so the anchor cannot be fixed.
+
+**Use `.alert` for confirmations** — a centred modal, no arrow, presents correctly
+regardless of trigger. Two caveats:
+- `.alert` does NOT auto-add a Cancel button (confirmationDialog does) — add
+  `Button(role: .cancel) {}` explicitly.
+- `.alert` supports `presenting:` for item-scoped dialogs, same as confirmationDialog.
+
+In-code rationale lives at the delete-confirmation callsites (`ResultDetailView+Delete.swift`,
+`HomeView.swift`, `ScenarioDetailView.swift`, `SettingsView+PastResults.swift`).
+
+## iOS 26 Liquid Glass toolbar capsule — `.buttonStyle(.plain)` does NOT remove it
+
+On iOS 26 every `ToolbarItem` is wrapped in a translucent Liquid Glass capsule by the
+**toolbar itself**, independently of the inner `Button`'s style. `.buttonStyle(.plain)`
+only changes how content renders *inside* the capsule — it does **not** remove the
+capsule. The documented opt-out is `sharedBackgroundVisibility(.hidden)` on
+`ToolbarContent` (iOS 26+).
+
+Pastura wraps it for the iOS 17 deployment target as
+`ToolbarContent.hidingPasturaSharedBackground()` (`PasturaBackButton.swift`) — apply to
+every `ToolbarItem` that wraps a custom Pastura control. Caveats:
+- **Real-device verification required**: the iOS 26 simulator suppresses the capsule even
+  without the opt-out, so the simulator visual is misleading.
+- `UIDesignRequiresCompatibility = YES` (Info.plist) is the global escape hatch; Pastura
+  uses per-item opt-out instead, so that key is NOT set.
+
+Design-system reference: `docs/design/design-system.md` § 5.8.
+
+## Swift 6 makes accessibility env keypaths read-only
+
+Pre-Swift-6, `.environment(\.accessibilityReduceMotion, true)` inside a `#Preview`
+overrode the value for visual testing. Under Swift 6 strict + `InferIsolatedConformances`,
+the keypath is `any KeyPath<EnvironmentValues, Bool> & Sendable`, not `WritableKeyPath`, so
+`.environment(_:_:)` no longer accepts it (compile error: `cannot convert ... to expected
+argument type 'WritableKeyPath<...>'`). Affects `accessibilityReduceMotion`,
+`accessibilityReduceTransparency`, and the other system-set (app-read) accessibility env
+values.
+
+**Pattern**: extract animation timing into a `nonisolated enum` of pure functions taking
+`reduceMotion: Bool` (see `ModelSelectionAnimations`); the View reads
+`@Environment(\.accessibilityReduceMotion)` and forwards per call site; unit-test the pure
+helper across the phase × reduceMotion matrix. Do NOT write the Preview override; cover
+visual parity with manual QA (Settings → Accessibility → Reduce Motion → relaunch).
+
+## Custom `Color` tokens don't work with `.foregroundStyle` dot-syntax
+
+`.foregroundStyle(.muted)` (and any `PasturaPalette`-derived token: `.ink`, `.inkSecondary`,
+`.moss`, `.mossDark`, …) does **not** compile — the leading-dot in `foregroundStyle(_:)`
+resolves against `HierarchicalShapeStyle`/`ShapeStyle`, not `Color`. Our tokens live only on
+`Color` (`DesignTokens+SwiftUI.swift`), so write the type explicitly:
+`.foregroundStyle(Color.muted)`.
+
+System hierarchy styles (`.secondary`, `.tertiary`, `.quaternary`, `.clear`) *do* work with
+dot-syntax because they're `ShapeStyle` conformances — which is why pre-token code compiled.
+When token-izing `.foregroundStyle(.secondary)`, always switch to `Color.tokenName`.
+
+## `.sheet(item:)` — pass `Optional<Model>`, never `Int: Identifiable`
+
+For `.sheet(item: $binding)`, pass the **model itself** as `Optional<Model>`. Never wrap an
+array index in a project-wide `extension Int: Identifiable` — it applies to every `Int` in
+the project, conflicts with future Swift evolution, and silently affects any code passing
+`Int` where `Identifiable` is expected. Capturing an array index in the sheet closure also
+risks out-of-bounds if the array mutates between trigger and body evaluation; do a
+`firstIndex(where: { $0.id == item.id })` lookup inside the closure instead.
+
+## Never instantiate a ViewModel in a factory func / computed property
+
+A ViewModel created inside a View function or computed property (`let vm = MyViewModel()`
+then `return EditorView(viewModel: vm)`) gets a **fresh instance on every `body`
+re-evaluation**, silently wiping user state — because `@Bindable`/`@Observable` references
+observe but do not own. Retain it with `@State` in a host view that creates the VM once
+(`.task { guard viewModel == nil ... }`), rendering a `ProgressView` until it exists.

--- a/.claude/rules/swiftui-traps.md
+++ b/.claude/rules/swiftui-traps.md
@@ -139,13 +139,17 @@ Data-layer `ScenarioSummary` → `ScenarioSummaryStrip`.
 
 ## iOS 26 `.confirmationDialog` renders as a mis-anchored popover
 
-On iOS 26 a SwiftUI `.confirmationDialog` (body-attached and/or triggered from a
-`Menu` item) renders on iPhone as a **popover whose arrow anchors to the body
-centre** — pointing at empty space, not the control that opened it.
-`.confirmationDialog` exposes no source-anchor API, so the anchor cannot be fixed.
+On iOS 26 a SwiftUI `.confirmationDialog` **anchored to a specific control** — a
+`⋯`-`Menu` item or a row button in a list/menu — renders on iPhone as a **popover
+whose arrow anchors to the body centre**, pointing at empty space, not the control
+that opened it. `.confirmationDialog` exposes no source-anchor API, so the anchor
+cannot be fixed. **Carve-out**: scene-level `isPresented`-driven *choice* dialogs
+(cellular-consent `CellularConsentDialogModifier` in `PasturaApp.swift`,
+`ModelDownloadHostView.swift`) are NOT control-anchored and render acceptably —
+keep those as `.confirmationDialog`.
 
-**Use `.alert` for confirmations** — a centred modal, no arrow, presents correctly
-regardless of trigger. Two caveats:
+**Use `.alert` for the control-anchored confirmations** — a centred modal, no arrow,
+presents correctly regardless of trigger. Two caveats:
 - `.alert` does NOT auto-add a Cancel button (confirmationDialog does) — add
   `Button(role: .cancel) {}` explicitly.
 - `.alert` supports `presenting:` for item-scoped dialogs, same as confirmationDialog.
@@ -169,15 +173,19 @@ every `ToolbarItem` that wraps a custom Pastura control. Caveats:
 - `UIDesignRequiresCompatibility = YES` (Info.plist) is the global escape hatch; Pastura
   uses per-item opt-out instead, so that key is NOT set.
 
-Design-system reference: `docs/design/design-system.md` § 5.8.
+Canonical source for this fact: `docs/design/design-system.md` § 5.8.1 (the
+`PasturaBackButton` spec) — `navigation.md` and the `PasturaBackButton.swift`
+doc-comment also reference the capsule opt-out; keep this entry pointing there so the
+loci don't drift.
 
 ## Swift 6 makes accessibility env keypaths read-only
 
 Pre-Swift-6, `.environment(\.accessibilityReduceMotion, true)` inside a `#Preview`
-overrode the value for visual testing. Under Swift 6 strict + `InferIsolatedConformances`,
-the keypath is `any KeyPath<EnvironmentValues, Bool> & Sendable`, not `WritableKeyPath`, so
-`.environment(_:_:)` no longer accepts it (compile error: `cannot convert ... to expected
-argument type 'WritableKeyPath<...>'`). Affects `accessibilityReduceMotion`,
+overrode the value for visual testing. Under the project's Swift 6 mode, the system
+accessibility env keypath resolves as `any KeyPath<EnvironmentValues, Bool> & Sendable`,
+NOT `WritableKeyPath`, so `.environment(_:_:)` no longer accepts it (compile error:
+`cannot convert ... to expected argument type 'WritableKeyPath<...>'`). Affects
+`accessibilityReduceMotion`,
 `accessibilityReduceTransparency`, and the other system-set (app-read) accessibility env
 values.
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -202,3 +202,51 @@ Full mechanism + the wait helper live in `parkRunMidFlight`
 - **`makePhaseContext(scenario:phaseIndex:llm:collector:)`**: Convenience factory
   for `PhaseContext`. Bundles scenario, phase, LLM, and emitter for handler tests.
   Use this instead of constructing `PhaseContext` manually.
+
+## Wall-clock test bounds need CI headroom (20–30×)
+
+Wall-clock assertions (`elapsed >= X && elapsed < Y`) that pass locally can fail on CI
+even with generous bounds: the `lint-and-test` job runs `-enableCodeCoverage YES` on a
+shared runner, and coverage bookkeeping is non-trivial for concurrency-heavy code
+(AsyncStream, `Task.sleep`). A body measured at ~120 ms locally was observed at ~3.3 s on
+CI (20×+).
+
+- **Lower bound** (the load-bearing check): keep tight to local — if it trips, something is
+  genuinely broken (pacing bypassed, sleep not applied).
+- **Upper bound** (runaway guard only): set generously, e.g. `< 30.0 s` for a sub-second
+  test; rely on the suite `.timeLimit(.minutes(1))` as the real backstop.
+- **Avoid** absolute windows like `elapsed < 1.0` for a 100 ms test — coverage + scheduler
+  jitter alone consumes that.
+- **Better**: inject an observable (callback counter, Clock stub) so the test is
+  deterministic regardless of runner load.
+
+## Expanding bundled data breaks count-pinning tests far away
+
+Expanding a bundled data file (e.g. ContentBlocklist 9→90) silently breaks `count == N`
+canaries that live in tests far from the data file (`ContentBlocklistTests`, registry /
+preset suites). Narrow `-only-testing` runs — the delegation default — never execute them,
+so the breakage stays invisible until a full run. Before (or in the same commit as) any
+bundled-data expansion, run `rg 'count == |\.count\b' Pastura/PasturaTests --type swift`
+scoped to the data's consumers and update the canaries; instruct delegated subagents to run
+the data's EXISTING suites, not only their new one.
+
+## Use exactly-representable IEEE-754 inputs in float-formatter tests
+
+When pinning `String(format: "%.Nf", x)` (or any platform float formatter), use
+**exactly-representable** Double inputs — halves (`1.5`, `12.5`, `0.25`, `0.125`). `1.85` is
+NOT exactly representable; the stored value sits just above/below, and `%.1f` rounds
+platform-dependently to `"1.8"` or `"1.9"` — passing on one machine, failing on CI. Avoid
+`1.1`, `1.85`, `2.4`, `0.1`, `0.3`, `0.7` (infinite binary expansions). To test a specific
+rounding boundary, use `Decimal` or assert against the platform's actual output, not a
+literal expected string.
+
+## A regression test must drive the exact unguarded-path input
+
+A regression test for a fix that adds a guard (`if case`, `guard let`, branch check) MUST
+construct the input shape that would hit the **unguarded** path. If it only exercises inputs
+that succeed even without the guard, it's coverage theater — it passes both pre- and
+post-fix, and a future refactor dropping the guard still passes. Shape: (1) plant the input
+that would hit the unguarded mutation, (2) run the method, (3) probe via **behavior** (e.g.
+`registerReattachedIfAbsent(...) == false` as a "slot still occupied" probe), not private
+state. Mental check before writing: *"If I revert the fix line, does this test FAIL?"* If not
+a confident yes, it isn't a regression test for the fix.

--- a/.claude/rules/xcodebuild-cli.md
+++ b/.claude/rules/xcodebuild-cli.md
@@ -189,30 +189,25 @@ Swift-Testing-only files it always prints `Executed 0 tests`, which is **cosmeti
 
 ## Engine/Models/`SimulationEvent` changes need local `swift build` (harness)
 
-The ADR-013 harness is a SwiftPM package (root `Package.swift`, `PasturaCore` target reusing
-`Models`/`LLM`/`Engine`). It is built by `swift build` / `swift test`, NOT by
-`scripts/xcodebuild.sh` or the pre-commit hook (iOS app target only). So a change to a
-`SimulationEvent` case — or any Engine/Models source the harness reuses — can pass the full
-xcodebuild suite + pre-commit locally and still break the CI "Harness package build" job.
-`tools/harness/Sources/PasturaHarnessKit/EventLineMapper.swift` has an intentional
-no-`default:` exhaustive switch (compile-time canary) plus a `RunLogTests` curated-list
-canary, so a new event case breaks the harness build by design. **Apply**: when a PR
-adds/changes a `SimulationEvent` case (or harness-reused Engine/Models source), run
-`swift build` (and `swift test`) from the repo root before push, and map the new event in
-`EventLineMapper` (return `nil` for internal/persistence events).
+The ADR-013 harness is a SwiftPM package reusing `Models`/`LLM`/`Engine`, built by
+`swift build` / `swift test` — NOT by `scripts/xcodebuild.sh` or the pre-commit hook (iOS
+app target only). So a change to a `SimulationEvent` case (or any harness-reused Engine/
+Models source) can pass the full xcodebuild suite + pre-commit locally and still break the
+CI "Harness package build" job — `EventLineMapper.swift` has an intentional no-`default:`
+exhaustive switch (compile-time canary). **Apply**: on any such change, run `swift build`
+from the repo root before push and map the new event in `EventLineMapper` (`nil` for
+internal/persistence events). See ADR-013.
 
 ## Compile-checking device-only (`#if !targetEnvironment(simulator)`) code
 
 `#if !targetEnvironment(simulator)` blocks (e.g. `SettingsView` model-management UI,
 `ModelSettingsRow`) are excluded from the simulator build — which is what
-`scripts/xcodebuild.sh build`, `scripts/ui-tour.sh`, and CI all use. A compile error OR
+`scripts/xcodebuild.sh build`, `scripts/ui-tour.sh`, and CI all use, so a compile error OR
 layout regression there ships unseen. Compile-check without provisioning:
 `scripts/xcodebuild.sh build -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO`
-(the wrapper forwards trailing args — `-destination` last-wins, and the
-`CODE_SIGNING_ALLOWED=NO` build-setting reaches xcodebuild — so signing is skipped; Swift
-compilation runs before signing, so `** BUILD SUCCEEDED **` confirms the block compiles).
-**Layout/visual** still needs a real device — flag device-QA explicitly in PRs touching
-these blocks.
+(wrapper forwards both trailing args; signing is skipped, and Swift compiles before signing
+so `** BUILD SUCCEEDED **` confirms the block compiles). **Layout/visual** still needs a
+real device — flag device-QA explicitly in PRs touching these blocks.
 
 ## Fresh worktree's first build can fail SPM resolution (misleading message)
 
@@ -249,17 +244,15 @@ load + within-process clone pressure under constrained VM).
 
 ### XCUITest idle-stall on continuous animations (slowness, not a retry-flake)
 
-When the `ui-test` job is slow (heavy tests 300–400 s on the GPU-less macos-26 sim) but the
-same tests run ~25 s locally, suspect **idle-stall**: XCUITest waits for the app to reach
-"idle" (no continuous `CAAnimation`) before each element query; indeterminate
-`ProgressView()`, `.symbolEffect(…, options: .repeating)`, `.repeatForever` never settle and
-stall every query. Manifests on the GPU-less CI sim, NOT locally (Mac GPU masks it) —
-**local before/after can't validate; use a draft-PR CI run**. Suppress under `--ui-test`
-(`UITestMode.isActive` → `\.isUITestMode` env → `IdleFriendlyProgressView`,
-`symbolEffect(isActive: !isUITestMode)`, DogMark pulse guard). **Cap-tuning gotcha**: legit
-CI durations overlap the stall range, so a single tight
-`-default-test-execution-time-allowance` false-kills slow-by-design tests
-(`InFlightIndicatorReconnectUITests` opts out via `executionTimeAllowance = 600`).
+When the `ui-test` job is slow (heavy tests 300–400 s) but the same tests run ~25 s
+locally, suspect **idle-stall**: XCUITest waits for the app to reach "idle" (no continuous
+`CAAnimation`) before each query, so indeterminate `ProgressView()`,
+`.symbolEffect(…, options: .repeating)`, `.repeatForever` stall every query. Manifests on
+the GPU-less CI sim only (Mac GPU masks it locally) — **local before/after can't validate;
+use a draft-PR CI run**. Suppress under `--ui-test` (`UITestMode.isActive` →
+`IdleFriendlyProgressView` + `symbolEffect(isActive:)` guards). **Cap-tuning gotcha**: legit
+durations overlap the stall range, so a single tight `-default-test-execution-time-allowance`
+false-kills slow-by-design tests (opt out via per-test `executionTimeAllowance`).
 
 ### When to escalate
 

--- a/.claude/rules/xcodebuild-cli.md
+++ b/.claude/rules/xcodebuild-cli.md
@@ -208,9 +208,11 @@ adds/changes a `SimulationEvent` case (or harness-reused Engine/Models source), 
 `scripts/xcodebuild.sh build`, `scripts/ui-tour.sh`, and CI all use. A compile error OR
 layout regression there ships unseen. Compile-check without provisioning:
 `scripts/xcodebuild.sh build -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO`
-(`-destination` override accepted last-wins; signing skipped; Swift compilation runs before
-signing so `** BUILD SUCCEEDED **` confirms the block compiles). **Layout/visual** still
-needs a real device — flag device-QA explicitly in PRs touching these blocks.
+(the wrapper forwards trailing args — `-destination` last-wins, and the
+`CODE_SIGNING_ALLOWED=NO` build-setting reaches xcodebuild — so signing is skipped; Swift
+compilation runs before signing, so `** BUILD SUCCEEDED **` confirms the block compiles).
+**Layout/visual** still needs a real device — flag device-QA explicitly in PRs touching
+these blocks.
 
 ## Fresh worktree's first build can fail SPM resolution (misleading message)
 

--- a/.claude/rules/xcodebuild-cli.md
+++ b/.claude/rules/xcodebuild-cli.md
@@ -176,6 +176,52 @@ directly are at risk — child-process invokers (`ui-tour.sh` →
   → `xcrun simctl erase <UDID>` + retry **once**. Persistent failures
   are real bugs (signing / plist / app-state regression), not flakes.
 
+## "Executed 0 tests" in the XCTest stanza is cosmetic for Swift-Testing suites
+
+The XCTest output stanza (`Executed N tests`) counts only `XCTestCase` subclasses — for
+Swift-Testing-only files it always prints `Executed 0 tests`, which is **cosmetic, not a
+"file not in target" signal**. The real count is in the Swift Testing stanza below
+(`✔ Test … passed`, `Test run with N tests …`). Most Pastura tests are Swift Testing.
+**Disambiguate a true zero**: `✔` markers / `Test run with N tests` present → normal; absent
+→ real bug (file at wrong path / not compiled — cf. the `-only-testing` zero-match trap in
+`testing.md`). When filtering output keep the markers:
+`grep -E "(error:|Test Suite|Executed|passed|failed|✔ Test|Test run)"`.
+
+## Engine/Models/`SimulationEvent` changes need local `swift build` (harness)
+
+The ADR-013 harness is a SwiftPM package (root `Package.swift`, `PasturaCore` target reusing
+`Models`/`LLM`/`Engine`). It is built by `swift build` / `swift test`, NOT by
+`scripts/xcodebuild.sh` or the pre-commit hook (iOS app target only). So a change to a
+`SimulationEvent` case — or any Engine/Models source the harness reuses — can pass the full
+xcodebuild suite + pre-commit locally and still break the CI "Harness package build" job.
+`tools/harness/Sources/PasturaHarnessKit/EventLineMapper.swift` has an intentional
+no-`default:` exhaustive switch (compile-time canary) plus a `RunLogTests` curated-list
+canary, so a new event case breaks the harness build by design. **Apply**: when a PR
+adds/changes a `SimulationEvent` case (or harness-reused Engine/Models source), run
+`swift build` (and `swift test`) from the repo root before push, and map the new event in
+`EventLineMapper` (return `nil` for internal/persistence events).
+
+## Compile-checking device-only (`#if !targetEnvironment(simulator)`) code
+
+`#if !targetEnvironment(simulator)` blocks (e.g. `SettingsView` model-management UI,
+`ModelSettingsRow`) are excluded from the simulator build — which is what
+`scripts/xcodebuild.sh build`, `scripts/ui-tour.sh`, and CI all use. A compile error OR
+layout regression there ships unseen. Compile-check without provisioning:
+`scripts/xcodebuild.sh build -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO`
+(`-destination` override accepted last-wins; signing skipped; Swift compilation runs before
+signing so `** BUILD SUCCEEDED **` confirms the block compiles). **Layout/visual** still
+needs a real device — flag device-QA explicitly in PRs touching these blocks.
+
+## Fresh worktree's first build can fail SPM resolution (misleading message)
+
+A fresh `/orchestrate` worktree has its own empty `Pastura/DerivedData/`. The first build the
+pre-commit hook triggers (any build-relevant path — `scripts/**` counts per
+`precommit-gate-classify.sh`) can fail at SPM resolution with a trailing
+`Build failed. Fix compile errors before committing.` — **misleading**: the real cause is
+unresolved SPM working copies, not a compile error. Fix once, then re-commit:
+`xcodebuild -resolvePackageDependencies -project Pastura/Pastura.xcodeproj -scheme Pastura -derivedDataPath Pastura/DerivedData`.
+Distinct from the harness `swift build` entry above (that's the SwiftPM *harness*).
+
 ## CI flake catalog (auto-retried by `ci-retry.yml`)
 
 `.github/workflows/ci-retry.yml` auto-retries failed UI test jobs
@@ -198,6 +244,20 @@ is the runner already booted + app explicitly rejected, recoverable by
 erasing the simulator. The three flakes above are infra-pressure failures
 on the GHA macos-26 runner (suspected root cause: Accessibility framework
 load + within-process clone pressure under constrained VM).
+
+### XCUITest idle-stall on continuous animations (slowness, not a retry-flake)
+
+When the `ui-test` job is slow (heavy tests 300–400 s on the GPU-less macos-26 sim) but the
+same tests run ~25 s locally, suspect **idle-stall**: XCUITest waits for the app to reach
+"idle" (no continuous `CAAnimation`) before each element query; indeterminate
+`ProgressView()`, `.symbolEffect(…, options: .repeating)`, `.repeatForever` never settle and
+stall every query. Manifests on the GPU-less CI sim, NOT locally (Mac GPU masks it) —
+**local before/after can't validate; use a draft-PR CI run**. Suppress under `--ui-test`
+(`UITestMode.isActive` → `\.isUITestMode` env → `IdleFriendlyProgressView`,
+`symbolEffect(isActive: !isUITestMode)`, DogMark pulse guard). **Cap-tuning gotcha**: legit
+CI durations overlap the stall range, so a single tight
+`-default-test-execution-time-allowance` false-kills slow-by-design tests
+(`InFlightIndicatorReconnectUITests` opts out via `executionTimeAllowance = 600`).
 
 ### When to escalate
 

--- a/Pastura/Pastura/Views/Components/PasturaBackButton.swift
+++ b/Pastura/Pastura/Views/Components/PasturaBackButton.swift
@@ -11,7 +11,10 @@ import UIKit
 /// renders inside a translucent "Liquid Glass" capsule. The capsule
 /// styling clashes with Pastura's flat / moss / frosted aesthetic
 /// (see `docs/design/design-system.md` §1). This component renders a
-/// plain chevron with no capsule, opting out via `.buttonStyle(.plain)`.
+/// plain chevron; the capsule is opted out at the `ToolbarItem` via
+/// `hidingPasturaSharedBackground()`. `.buttonStyle(.plain)` only styles
+/// the inner chevron content — it does NOT remove the capsule (see the
+/// `hidingPasturaSharedBackground()` doc-comment below for why).
 ///
 /// ## Usage
 ///
@@ -81,10 +84,10 @@ struct PasturaBackButton: View {
       Image(systemName: Self.iconName)
         .foregroundStyle(Self.tint)
     }
-    // `.plain` opts out of iOS 26's automatic Liquid Glass treatment
-    // for ToolbarItem buttons. Without this, iOS 26 wraps custom
-    // toolbar buttons in a glass capsule that defeats the purpose
-    // of the custom styling.
+    // `.plain` styles the inner chevron content (no button-level chrome).
+    // It does NOT remove the iOS 26 Liquid Glass capsule — that wraps at
+    // the ToolbarItem level and is opted out via
+    // `hidingPasturaSharedBackground()` (see its doc-comment below).
     .buttonStyle(.plain)
     .accessibilityLabel(Self.accessibilityLabel)
     .accessibilityIdentifier("pasturaBackButton")

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -335,7 +335,7 @@ root `NavigationStack` に push された全ビューで、システム back che
 |---------|----------|
 | アイコン | SF Symbol `chevron.backward`（RTL 対応版を選択） |
 | 前景色 | `Color.ink` (#2D2E26、§2.2) |
-| ボタンスタイル | `.buttonStyle(.plain)` で iOS 26 の Liquid Glass を抑制 |
+| ボタンスタイル | `.buttonStyle(.plain)`（内側 chevron の content 用）。iOS 26 Liquid Glass capsule の抑制は ToolbarItem 側の `hidingPasturaSharedBackground()`（`.plain` 単体では capsule は消えない） |
 | タップ動作 | `router.pop()`（`.claude/rules/navigation.md` 準拠） |
 | アクセシビリティラベル | `String(localized: "Back")` → ja "戻る" |
 | swipe-back gesture | `.preservesPasturaSwipeBackGesture()` View modifier 必須 |


### PR DESCRIPTION
## Summary

2026-06-24 のメモリ棚卸し（107 ファイル）で抽出した path-scoped 高 ROI な team-knowledge トラップ 15 件を `.claude/rules/` に昇格し、self-check で発見したドキュメントドリフト 1 件を修正。docs/tooling のみ（Swift 変更は `PasturaBackButton` のコメントのみ・挙動変更ゼロ）。

- **`swiftui-traps.md` (+6)**: iOS 26 confirmationDialog mis-anchored popover→`.alert` / Liquid Glass capsule opt-out / Swift 6 read-only a11y env keypath / ShapeStyle vs `Color` token dot-syntax / `.sheet(item:)` `Optional<Model>` / ViewModel ownership via `@State` host
- **`testing.md` (+4)**: CI wall-clock headroom (20–30×) / bundled-data count canary / exactly-representable IEEE-754 float inputs / regression test drives the unguarded-path input
- **`xcodebuild-cli.md` (+5, always-loaded — tight)**: "Executed 0 tests" output-reading (cross-ref `testing.md`) / harness `swift build` (ADR-013) / device-only `#if` compile-check / fresh-worktree SPM resolution / XCUITest idle-stall (CI flake catalog)
- **Liquid Glass drift fix**: `PasturaBackButton.swift` (L14 + L84-88 comments) と `design-system.md` §5.8.1 が「`.buttonStyle(.plain)` で iOS 26 capsule を抑制」と誤記していた → 権威 doc-comment（`hidingPasturaSharedBackground()` = `sharedBackgroundVisibility(.hidden)`）に三箇所すべて統一

制約（ユーザー指示）: 新規 rule 本文に issue/PR 番号ゼロ — durable file/symbol/ADR アンカーのみ。既存の `#189`/`#31373` pointer リンクは温存。

## Review

- **critic (Opus, plan)**: Critical 1 + Warning 3 → 全て反映（"Executed 0 tests" の重複回避 framing + cross-ref / 3 つ目 stale site `L84-88` 追加 / `design-system.md` L405 ガード / "18 callsites" 数値削除）
- **code-reviewer (Opus, diff)**: PASS（Critical/Warning 0）。`hidingPasturaSharedBackground()` / `ModelSelectionAnimations` / `EventLineMapper.swift` / `IdleFriendlyProgressView` 等の symbol 実在と claim を検証、L405 未変更を確認、新規 `#NNN` ゼロを確認。Suggestion 1（wrapper passthrough 明記）も反映。

## Test plan

ドキュメント / `.claude/rules/` 変更が中心。`PasturaBackButton.swift` はコメントのみの変更で、commit 時の pre-commit hook（`swiftlint --strict` + `xcodebuild build` + navigation-map self-test）が通過済み。新規テストは無し（挙動変更ゼロ）。

Part of #780
