### PR TITLE
📝 docs: scripts/tests CI-only note + gallery.json display-field schema

### DIFF
--- a/.claude/rules/ci-workflows.md
+++ b/.claude/rules/ci-workflows.md
@@ -6,7 +6,7 @@ paths:
 
 # CI Workflows (GHA, macOS runners)
 
-Three concern families when editing CI workflow YAML or supporting scripts on this repo: shell-language gotchas on the macOS runner, long-lived integration-branch gating shape, and required-check-safe path gating.
+Four concern families when editing CI workflow YAML or supporting scripts on this repo: shell-language gotchas on the macOS runner, long-lived integration-branch gating shape, required-check-safe path gating, and the script unit-test suite that runs in CI only.
 
 ## Shell scripting gotchas (macOS GHA runners)
 
@@ -95,6 +95,30 @@ Load-bearing invariants when adding/changing such gating:
 3. **Don't gate the cheap ubuntu drift guards.** They cost little and gating them risks the same required-check trap for no benefit — gate only the macOS jobs.
 4. **`pr-comment` runs even when its deps skip — deliberately.** It carries `if: !cancelled() && …`, a status function, so it does **not** inherit a skipped dependency: on a web/docs-only PR (macOS jobs skipped) it still runs and posts a "did not run / skipped" comment (cosmetically noisy, functionally fine). Don't "fix" it to a plain boolean or the comment vanishes. (Contrast: a *plain-boolean* `if:` WOULD inherit the skip — that's the lever when you want a consumer to skip alongside its dependency.)
 5. **Verify BOTH branches on dummy PRs** (the "Long-lived branch gating — two layers × two directions" § `### Procedure` step 3 applies here too): one docs/web-only PR must skip the macOS jobs *and* still show the required checks green/mergeable; one trivial `.swift` PR must run them. A gating PR that touches only `.github/`/`.claude/` skips the macOS jobs on itself, so its *run* path is never exercised pre-merge — test it separately.
+
+## Script unit tests (`scripts/tests/`) run in CI only — not the pre-commit hook
+
+`scripts/tests/*-test.sh` unit-test the **scripts themselves** (e.g.
+`gallery-scripts-test.sh` exercises `add-gallery-entry.sh` /
+`promote-factory-to-gallery.sh` against fixtures). They run **only** in the CI
+**"Shell gate tests"** job. The git pre-commit hook runs the *gate* scripts
+(`gallery-precommit-gate.sh` → `check-gallery-entry.sh`, blocklist, nav-map,
+scenario-editor-funnel), which validate inputs/outputs (SHA, schema, drift) but
+**never exercise a curation script's own field-extraction logic**. So a
+`scripts/` change can pass the local commit and every pre-commit gate yet still
+fail CI.
+
+**Apply:** when editing any `scripts/*.sh`, run the suite locally before pushing:
+
+```bash
+for t in scripts/tests/*-test.sh; do bash "$t" || echo "FAIL: $t"; done
+```
+
+Watch especially for test fixtures that lag a new required field: #788 (the
+art-tile PR that also added `phases:` extraction to `add-gallery-entry.sh`) made
+that extraction required, aborting every `gallery-scripts-test.sh` case whose
+fixture builder (`mk_factory` / `mk_gallery_yaml`) predated it. `check-gallery-entry.sh`
+never runs the extraction, so it was green locally, red in CI.
 
 ## Related
 

--- a/docs/gallery/README.md
+++ b/docs/gallery/README.md
@@ -38,6 +38,9 @@ app. Fields:
       "author": "<github handle>",
       "recommended_model": "<model id>",     // must match a `ModelRegistry.catalog` id, e.g. "gemma-4-e2b-q4-k-m"
       "estimated_inferences": <int>,         // rough total LLM calls to complete
+      "agent_count": <int>,                  // optional; from YAML `agents:` — Browse row sheep cluster + footer
+      "rounds": <int>,                       // optional; from YAML `rounds:` — Browse footer
+      "phases": ["<phase_type>", ...],       // optional; ordered YAML phase types — Browse art-tile signature glyph
       "yaml_url": "<filename or absolute https URL>",  // resolved relative to gallery.json
       "yaml_sha256": "<lowercase hex>",      // SHA-256 of the YAML body
       "added_at": "YYYY-MM-DD"
@@ -278,6 +281,9 @@ In update mode:
 | (file body)     | `yaml_sha256`   | **Yes**     | Recomputed via `shasum -a 256` on every run — the whole point of `--update`.                                              |
 | `name:`         | `title`         | **Yes**     | `GallerySeedYAMLTests.galleryTitleMatchesYAMLName` enforces byte-equality; can't drift.                                   |
 | `description:`  | `description`   | **No**      | Curators commonly use `--description "shorter card summary"` to give the gallery card a tighter blurb than the YAML body. |
+| `agents:`       | `agent_count`   | **Yes**     | YAML-derived fact; `GallerySeedYAMLTests.galleryAgentCountAndRoundsMatchYAML` enforces equality.                          |
+| `rounds:`       | `rounds`        | **Yes**     | Same YAML-derived enforcement as `agent_count` (same test).                                                               |
+| `phases[].type` | `phases`        | **Yes**     | Ordered phase types; `GallerySeedYAMLTests.galleryPhasesMatchYAML` enforces equality.                                     |
 
 If you actually want the gallery `description` to re-sync from the
 YAML, pass it explicitly. One-liner that pulls the current YAML value:


### PR DESCRIPTION
## Summary
Two doc gaps surfaced during PR #788:

- **`.claude/rules/ci-workflows.md`** — new section documenting that `scripts/tests/*-test.sh` runs **only** in the CI "Shell gate tests" job. The git pre-commit hook runs the *gate* scripts (`check-gallery-entry.sh` etc.), which validate inputs/outputs but never exercise a curation script's own field-extraction logic — so a `scripts/` change can pass locally yet fail CI (the #788 `phases:`-extraction incident). Includes the local-run one-liner. Path-scoped to `scripts/**`, so it surfaces exactly when editing scripts.
- **`docs/gallery/README.md`** — added the optional, YAML-derived display fields `agent_count` / `rounds` / `phases` to the `## Schema` block and the YAML-source field table (with their enforcing `GallerySeedYAMLTests`). These shipped in #781 / #788 without schema docs.

## Test plan
- Docs-only — no Swift / build / test changes (pre-commit correctly skipped the iOS build).
- Claims verified against the worktree: pre-commit hook runs gate scripts only; `ci.yml` "Shell gate tests" job runs `scripts/tests/*-test.sh`; both cited tests exist; `gallery.json` carries all three fields; `GalleryScenario` decodes them as optional. No `memory` references leaked into repo-tracked files (knowledge-layering anti-pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)