### PR TITLE
✨ feat: refresh Gemma/Qwen model picker taglines

### DIFF
--- a/Pastura/Pastura/App/ModelRegistry.swift
+++ b/Pastura/Pastura/App/ModelRegistry.swift
@@ -52,7 +52,7 @@ enum ModelRegistry {
     minRAM: 6_500_000_000,
     modelInfoURL: unsafeURL("https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF"),
     systemPromptSuffix: nil,
-    tagline: String(localized: "Balanced choice. Rich expression and measured reasoning.")
+    tagline: String(localized: "Balanced choice. Rich, considered responses.")
   )
 
   nonisolated static let qwen34B: ModelDescriptor = ModelDescriptor(
@@ -79,11 +79,11 @@ enum ModelRegistry {
     // not prevent the leading `<think>` token; the prefill is the load-bearing
     // fix. `/no_think` stays as belt-and-suspenders.
     assistantPrefix: "<think>\n\n</think>\n\n",
-    // Reuses an existing translated catalog key (originally the conditional
-    // `ModelPickerView.hint(for:)` for `/no_think` descriptors). Item 6 of
-    // the picker redesign removes that helper and routes the tagline through
-    // this field instead.
-    tagline: String(localized: "Lightweight reasoning mode — faster responses, leaner footprint.")
+    // Tagline avoids any "reasoning"/"thinking" framing on purpose: this model
+    // runs with `/no_think` + the empty-thinking prefill above, so thinking
+    // mode is OFF. Copy that implied a reasoning mode would contradict the
+    // runtime config — it leans on size/footprint instead.
+    tagline: String(localized: "Compact and nimble. A small download you can try freely.")
   )
 
   /// Full production catalog, ordered by display preference (Gemma first, Qwen second).

--- a/Pastura/Pastura/Models/ModelDescriptor.swift
+++ b/Pastura/Pastura/Models/ModelDescriptor.swift
@@ -80,8 +80,8 @@ nonisolated public struct ModelDescriptor: Sendable, Hashable {
   public let assistantPrefix: String?
 
   /// User-facing tagline shown in the model picker — a single short sentence
-  /// describing the model's character ("Balanced choice. Rich expression
-  /// with measured reasoning."). Empty string when the descriptor was
+  /// describing the model's character ("Balanced choice. Rich, considered
+  /// responses."). Empty string when the descriptor was
   /// constructed without picker UI in mind (test fixtures, future
   /// descriptors not yet surfaced in the picker). UI sites must hide the
   /// row when empty rather than render a blank line.

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -1682,12 +1682,12 @@
         }
       }
     },
-    "Balanced choice. Rich expression and measured reasoning." : {
+    "Balanced choice. Rich, considered responses." : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "バランス型。表現が豊かで、推論も落ち着いた応答。"
+            "value" : "バランス型。表現が豊かで、落ち着いた応答。"
           }
         }
       }
@@ -1957,6 +1957,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "シェアされたシナリオを開くには、このシートを閉じてください"
+          }
+        }
+      }
+    },
+    "Compact and nimble. A small download you can try freely." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コンパクトで軽快。容量が小さく、気軽に試せる。"
           }
         }
       }
@@ -3525,16 +3535,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ライセンス"
-          }
-        }
-      }
-    },
-    "Lightweight reasoning mode — faster responses, leaner footprint." : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "軽量モード — 応答が速く、容量も小さめ。"
           }
         }
       }

--- a/Pastura/Pastura/Views/ModelSelection/ModelRow.swift
+++ b/Pastura/Pastura/Views/ModelSelection/ModelRow.swift
@@ -11,7 +11,7 @@ import SwiftUI
 ///  ┌───────────────────────────────────────────────────┐
 ///  │ ┃ [sheep]  Gemma 4 E2B  [推奨]                  ◉ │
 ///  │ ┃          Google · 3.1 GB                        │
-///  │ ┃          Balanced choice. Rich expression…     │
+///  │ ┃          Balanced choice. Rich, considered…    │
 ///  └───────────────────────────────────────────────────┘
 /// ```
 ///


### PR DESCRIPTION
## Summary
- First-launch model picker の各モデル tagline を更新。
- **Qwen**: 旧コピーが "reasoning mode" を名乗っていたが、本アプリは Qwen を `/no_think` + empty-thinking prefill で thinking モードを無効化して走らせている (#366) ため矛盾していた。"reasoning" を排除し、未検証の速度断定も外して size/footprint 軸に変更。
  - `Lightweight reasoning mode — faster responses, leaner footprint.` → `Compact and nimble. A small download you can try freely.`
- **Gemma**: 両 tagline に出ていた "reasoning" の重複を解消（軸がぼやけていた）。
  - `Balanced choice. Rich expression and measured reasoning.` → `Balanced choice. Rich, considered responses.`
- em-dash を廃しピリオド区切りに統一（lp-content voice rule に整合）。
- doc-comment 例（`ModelDescriptor` / `ModelRow`）も追従、`Localizable.xcstrings` に ja 訳追加（旧キーは surgical 除去）。

## Test plan
- `scripts/xcodebuild.sh build` → ** BUILD SUCCEEDED **
- `python3 scripts/check_localization_coverage.py` → ✅ 553 keys, all `ja` translated
- `swiftlint --strict` clean / pre-commit hook green
- code-reviewer (Opus): PASS — 0 critical / 0 warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MCAq4GFcyM5gx6R5bmt4S4