### PR TITLE
✨ feat: polish Sim controls — primary play button + leave sheet

### DIFF
--- a/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+ControlBar.swift
+++ b/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+ControlBar.swift
@@ -57,6 +57,11 @@ extension ModelDownloadHostView {
   /// Scene-phase pause does **not** flip the icon — the UI is hidden
   /// during BG anyway, but the boundary is meaningful for the
   /// transient redraw frame on FG return.
+  ///
+  /// Filled `mossDark` circle + white glyph via the shared
+  /// ``SimulationPlayButtonMetrics``, keeping parity with
+  /// `SimulationView.controlBar` (#273). Always interactive (no disabled
+  /// state — PR 1b / #290), so only the `enabledFill` is used.
   @ViewBuilder
   private func pauseButton(viewModel: ReplayViewModel) -> some View {
     Button {
@@ -67,7 +72,13 @@ extension ModelDownloadHostView {
       }
     } label: {
       Image(systemName: viewModel.isUserPaused ? "play.fill" : "pause.fill")
-        .font(.title3)
+        .font(.system(size: SimulationPlayButtonMetrics.glyphPointSize, weight: .semibold))
+        .foregroundStyle(SimulationPlayButtonMetrics.glyphColor)
+        .frame(
+          width: SimulationPlayButtonMetrics.diameter,
+          height: SimulationPlayButtonMetrics.diameter
+        )
+        .background(SimulationPlayButtonMetrics.enabledFill, in: Circle())
     }
     .buttonStyle(.plain)
     .accessibilityLabel(

--- a/Pastura/Pastura/Views/Simulation/SimulationLeaveSheet.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationLeaveSheet.swift
@@ -1,0 +1,148 @@
+import SwiftUI
+
+/// Semantic color tokens for ``SimulationLeaveSheet``, extracted so
+/// `SimulationControlsTokenTests` can pin them as a **change-detector
+/// tripwire** (ADR-009 § "Change-detector tripwire").
+///
+/// The load-bearing decision: the "keep running" action is a *caution*
+/// (design-system §2.6 `warning`, amber), **not** a *destructive* action
+/// (§2.6 `danger`, red). The run keeps executing and is recoverable via the
+/// in-flight indicator, so red would mis-signal data loss — including to
+/// VoiceOver, which announces `.destructive` distinctly. The test guards that
+/// `warning`-not-`danger` distinction against a silent token swap.
+///
+/// The button *layout* stays private to the sheet (`CautionButtonStyle` /
+/// `NeutralButtonStyle`); only these semantic tokens are exposed for the test.
+enum SimulationLeaveSheetTokens {
+  /// Caution-action fill — `warningSoft` (#F2EAD3). Deliberately NOT `dangerSoft`.
+  static let cautionFill: Color = .warningSoft
+
+  /// Caution-action label — `warningInk` (#6F5C2D). Deliberately NOT `dangerInk`.
+  static let cautionText: Color = .warningInk
+
+  /// Caution-action hairline — `warning` (#C7A566).
+  static let cautionBorder: Color = .warning
+
+  /// Neutral cancel label — `inkSecondary`. Cancel stays neutral (§2.6).
+  static let cancelText: Color = .inkSecondary
+
+  /// Neutral cancel hairline — `rule`.
+  static let cancelBorder: Color = .rule
+
+  /// Corner radius, shared with `PasturaPrimaryButtonStyle` (12pt) so the
+  /// three stacked buttons read as one family.
+  static let cornerRadius: CGFloat = PasturaPrimaryButtonStyle.cornerRadius
+}
+
+/// Custom confirm-on-leave sheet for an in-flight simulation (#673 / #682).
+///
+/// Replaces the former system `.alert`, whose three buttons all rendered in
+/// the green accent (no hierarchy). A bottom sheet lets each action carry a
+/// semantic design-system color: a `mossDark` **primary** (the recommended,
+/// fully-safe "pause and save"), a `warning`-amber **caution** ("keep
+/// running" — recoverable, but the OS may terminate it while away), and a
+/// neutral **cancel**. The caution uses §2.6 `warning`, NOT `danger` red,
+/// because nothing is destroyed — see ``SimulationLeaveSheetTokens``.
+///
+/// Pastura's first custom confirm dialog: system `.alert` (the other ~13
+/// sites) exposes no per-button color API (design-system §5.8.3). Presented
+/// via `.sheet`, not `.confirmationDialog` (which mis-anchors as a popover on
+/// iOS 26 — `.claude/rules/swiftui-traps.md`). Buttons wrap (`lineLimit(nil)`)
+/// so long localized labels don't clip at large Dynamic Type sizes.
+struct SimulationLeaveSheet: View {
+  /// Persist a resumable `.paused`, then leave (recommended / safe).
+  let onPauseAndLeave: () -> Void
+  /// Park the run in memory and leave — it keeps executing in the background.
+  let onKeepRunning: () -> Void
+  /// Dismiss without leaving.
+  let onStay: () -> Void
+
+  var body: some View {
+    VStack(spacing: 16) {
+      // Title + message come first so VoiceOver reads the context before the
+      // action buttons.
+      Text(String(localized: "A simulation is in progress"))
+        .font(.headline)
+        .multilineTextAlignment(.center)
+
+      Text(
+        String(
+          localized:
+            "Pause and save it so you can resume later, or keep it running while you step away?"
+        )
+      )
+      .font(.subheadline)
+      .foregroundStyle(Color.inkSecondary)
+      .multilineTextAlignment(.center)
+      .fixedSize(horizontal: false, vertical: true)
+
+      VStack(spacing: 10) {
+        Button(action: onPauseAndLeave) {
+          sheetLabel(String(localized: "Pause and leave"))
+        }
+        .buttonStyle(PasturaPrimaryButtonStyle())
+
+        Button(action: onKeepRunning) {
+          sheetLabel(String(localized: "Leave & keep running"))
+        }
+        .buttonStyle(CautionButtonStyle())
+
+        Button(action: onStay) {
+          sheetLabel(String(localized: "Stay"))
+        }
+        .buttonStyle(NeutralButtonStyle())
+      }
+    }
+    .padding(24)
+    .frame(maxWidth: .infinity)
+  }
+
+  /// Full-width, wrap-not-clip label shared by the three actions.
+  private func sheetLabel(_ text: String) -> some View {
+    Text(text)
+      .frame(maxWidth: .infinity)
+      .multilineTextAlignment(.center)
+      .lineLimit(nil)
+  }
+}
+
+/// Private — caution (amber) action style. Consumes the testable
+/// ``SimulationLeaveSheetTokens`` so the warning-not-danger decision is
+/// change-detector-pinned. Press feedback mirrors `PasturaPrimaryButtonStyle`
+/// (opacity dim, no capsule / scale — §1 "static, observed").
+private struct CautionButtonStyle: ButtonStyle {
+  func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .font(.system(size: 16, weight: .semibold))
+      .foregroundStyle(SimulationLeaveSheetTokens.cautionText)
+      .padding(.vertical, 15)
+      .padding(.horizontal, 20)
+      .background(
+        SimulationLeaveSheetTokens.cautionFill,
+        in: RoundedRectangle(
+          cornerRadius: SimulationLeaveSheetTokens.cornerRadius, style: .continuous)
+      )
+      .overlay(
+        RoundedRectangle(cornerRadius: SimulationLeaveSheetTokens.cornerRadius, style: .continuous)
+          .strokeBorder(SimulationLeaveSheetTokens.cautionBorder, lineWidth: 1)
+      )
+      .opacity(configuration.isPressed ? PasturaPrimaryButtonStyle.pressedOpacity : 1.0)
+  }
+}
+
+/// Private — neutral cancel ("Stay") style: transparent fill, `rule` hairline,
+/// `inkSecondary` label (§2.6 "cancel stays neutral").
+private struct NeutralButtonStyle: ButtonStyle {
+  func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .font(.system(size: 16, weight: .semibold))
+      .foregroundStyle(SimulationLeaveSheetTokens.cancelText)
+      .padding(.vertical, 15)
+      .padding(.horizontal, 20)
+      .overlay(
+        RoundedRectangle(cornerRadius: SimulationLeaveSheetTokens.cornerRadius, style: .continuous)
+          .strokeBorder(SimulationLeaveSheetTokens.cancelBorder, lineWidth: 1)
+      )
+      .opacity(configuration.isPressed ? PasturaPrimaryButtonStyle.pressedOpacity : 1.0)
+  }
+}

--- a/Pastura/Pastura/Views/Simulation/SimulationPlayButtonMetrics.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationPlayButtonMetrics.swift
@@ -1,7 +1,8 @@
 import SwiftUI
 
-/// Layout + color tokens for ``SimulationView``'s control-bar play/pause
-/// button (`controlBar`).
+/// Layout + color tokens for the control-bar play/pause button, shared by
+/// ``SimulationView`` (`controlBar`) and the DL-time demo replay control bar
+/// (`ModelDownloadHostView.controlBar`) so the two stay in parity (#273).
 ///
 /// Extracted from the View so `SimulationControlsTokenTests` can act as a
 /// **change-detector tripwire** (ADR-009 § "Change-detector tripwire";

--- a/Pastura/Pastura/Views/Simulation/SimulationPlayButtonMetrics.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationPlayButtonMetrics.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+/// Layout + color tokens for ``SimulationView``'s control-bar play/pause
+/// button (`controlBar`).
+///
+/// Extracted from the View so `SimulationControlsTokenTests` can act as a
+/// **change-detector tripwire** (ADR-009 § "Change-detector tripwire";
+/// rendered appearance is code-review-gated only). A failure here is NOT a
+/// bug — it means a code-review-gated visual token drifted in a refactor and
+/// the editor must confirm the change was intended before updating the
+/// expected value.
+///
+/// ## Why a filled circle (not the former bare glyph)
+///
+/// The old control used a lone `play.fill` / `pause.fill` glyph in
+/// `Color.ink` — the only filled, near-black element on the frosted control
+/// bar, so it read as a stray "black blob" rather than *the* primary action.
+/// A `mossDark` filled circle with a white glyph reads as a deliberate
+/// primary control and stays in-palette. No drop-shadow on the circle: the
+/// frosted bar already supplies one elevation layer, and design-system §1/§4.3
+/// limit the Sim screen to a single floating element (avoid double-lift).
+enum SimulationPlayButtonMetrics {
+  /// Circle diameter. User-confirmed at 34pt via mockup (a touch smaller than
+  /// the 38pt first draft).
+  static let diameter: CGFloat = 34
+
+  /// White glyph point size inside the circle (~0.41 × diameter).
+  static let glyphPointSize: CGFloat = 14
+
+  /// Enabled fill — `mossDark` (#6B7852); white-on-fill ≈ 4.76:1 (WCAG AA).
+  static let enabledFill: Color = .mossDark
+
+  /// Disabled fill — `disabledText` (#B5B0A2). Disabled controls are exempt
+  /// from the contrast target, so the muted tan + white glyph is intentional.
+  static let disabledFill: Color = .disabledText
+
+  /// Glyph color — white on both fills (text-on-accent; §1's "avoid pure
+  /// white" concerns backgrounds, not glyphs on an accent fill).
+  static let glyphColor: Color = .white
+}

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -244,25 +244,28 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
       Text(exportError ?? "")
     }
     // Back-button confirm-on-leave (#673, extended for Phase B opt-in #682).
-    // The back button raises this dialog via `handleBackTap()` when the
-    // keep-running Setting is off; with it on, leaving silently parks (no
-    // dialog). Three buttons, kept as `.alert` deliberately —
-    // `.confirmationDialog` renders as a mis-anchored popover on iOS 26
-    // (`.claude/rules/...` / ADR-016 § Amendment). Focus mode (ADR-017) hides the
-    // tab bar during a run, so only the back / swipe-back path remains.
-    .alert(
-      String(localized: "A simulation is in progress"),
-      isPresented: leaveAlertBinding
-    ) {
-      Button(String(localized: "Pause and leave")) { confirmLeave() }
-      Button(String(localized: "Leave & keep running")) { confirmLeaveKeepRunning() }
-      Button(String(localized: "Stay"), role: .cancel) { stay() }
-    } message: {
-      Text(
-        String(
-          localized:
-            "Pause and save it so you can resume later, or keep it running while you step away?"
-        ))
+    // Raised by `handleBackTap()` only when the keep-running Setting is off
+    // (with it on, leaving silently parks — no dialog). A custom `.sheet`
+    // (`SimulationLeaveSheet`), not `.alert`/`.confirmationDialog`, so the
+    // three actions can carry semantic design-system colors (moss primary /
+    // amber caution / neutral) — `.alert` exposes no per-button color API and
+    // `.confirmationDialog` mis-anchors as a popover on iOS 26 (swiftui-traps).
+    // Reuses `leaveAlertBinding`: a swipe-to-dismiss (no button) routes to
+    // `stay()` via the binding's setter — the correct "keep running, didn't
+    // pick anything" outcome. Focus mode (ADR-017) hides the tab bar during a
+    // run, so only the back / swipe-back path reaches here.
+    .sheet(isPresented: leaveAlertBinding) {
+      // Wrapped in a ScrollView so the content scrolls (not clips) at the
+      // largest Dynamic Type sizes; bounce is suppressed when it already fits.
+      ScrollView {
+        SimulationLeaveSheet(
+          onPauseAndLeave: confirmLeave,
+          onKeepRunning: confirmLeaveKeepRunning,
+          onStay: stay)
+      }
+      .scrollBounceBehavior(.basedOnSize)
+      .presentationDetents([.height(340)])
+      .presentationDragIndicator(.visible)
     }
   }
 
@@ -826,26 +829,41 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
     }
   }
 
+  /// Pause/Resume — a filled `mossDark` circle + white glyph (see
+  /// ``SimulationPlayButtonMetrics``) rather than a bare glyph: the lone
+  /// filled symbol used to read as a stray "black blob" on the frosted bar.
+  /// `disabledText` fill when disabled. No circle shadow — the frosted bar
+  /// already lifts (design-system §1/§4.3 single floating element; avoid
+  /// double-lift).
+  private func playPauseButton(viewModel: SimulationViewModel, isDisabled: Bool) -> some View {
+    Button {
+      if viewModel.isPaused {
+        viewModel.resumeSimulation()
+      } else {
+        viewModel.pauseSimulation()
+      }
+    } label: {
+      Image(systemName: viewModel.isPaused ? "play.fill" : "pause.fill")
+        .font(.system(size: SimulationPlayButtonMetrics.glyphPointSize, weight: .semibold))
+        .foregroundStyle(SimulationPlayButtonMetrics.glyphColor)
+        .frame(
+          width: SimulationPlayButtonMetrics.diameter,
+          height: SimulationPlayButtonMetrics.diameter
+        )
+        .background(
+          isDisabled
+            ? SimulationPlayButtonMetrics.disabledFill
+            : SimulationPlayButtonMetrics.enabledFill,
+          in: Circle())
+    }
+    .buttonStyle(.plain)
+    .disabled(isDisabled)
+  }
+
   private func controlBar(viewModel: SimulationViewModel) -> some View {
     let isPauseDisabled = !viewModel.isRunning || viewModel.isCompleted
     return HStack(spacing: 16) {
-      // Pause/Resume
-      Button {
-        if viewModel.isPaused {
-          viewModel.resumeSimulation()
-        } else {
-          viewModel.pauseSimulation()
-        }
-      } label: {
-        // Explicit `Color.disabledText` (design-system §2.7) when
-        // disabled, matching Demo's controlBar (#273 PR 1a). Enabled
-        // state uses `Color.ink` for the icon color rather than the
-        // system tint so the bar's color story stays in our palette.
-        Image(systemName: viewModel.isPaused ? "play.fill" : "pause.fill")
-          .font(.title3)
-          .foregroundStyle(isPauseDisabled ? Color.disabledText : Color.ink)
-      }
-      .disabled(isPauseDisabled)
+      playPauseButton(viewModel: viewModel, isDisabled: isPauseDisabled)
 
       // Speed picker while running; swapped with an export button once the
       // simulation is completed because playback speed is no longer relevant.

--- a/Pastura/PasturaTests/Views/SimulationControlsTokenTests.swift
+++ b/Pastura/PasturaTests/Views/SimulationControlsTokenTests.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+import Testing
+
+@testable import Pastura
+
+/// Change-detector tripwire for the simulation-controls polish tokens
+/// (``SimulationPlayButtonMetrics`` + ``SimulationLeaveSheetTokens``).
+///
+/// These assertions mirror the source-of-truth constants **by design**
+/// (ADR-009 § "Change-detector tripwire"). The rendered appearance is
+/// code-review-gated only; a failure here does NOT mean a bug — it means a
+/// gated visual token drifted in a refactor, and the editor must confirm the
+/// change was intended before updating the expected value.
+///
+/// `@MainActor` because comparing `Color` tokens hits MainActor-isolated
+/// conformance lookup under default-actor isolation (swift-isolation
+/// Pattern 5); MainActor can still read the nonisolated-free token enums.
+@Suite("SimulationControlsTokens", .timeLimit(.minutes(1)))
+@MainActor
+struct SimulationControlsTokenTests {
+
+  // MARK: - Play/pause button
+
+  @Test func playButtonGeometryUnchanged() {
+    // 34pt circle / 14pt glyph — user-confirmed via mockup.
+    #expect(SimulationPlayButtonMetrics.diameter == 34)
+    #expect(SimulationPlayButtonMetrics.glyphPointSize == 14)
+  }
+
+  @Test func playButtonFillsUnchanged() {
+    #expect(SimulationPlayButtonMetrics.enabledFill == .mossDark)
+    #expect(SimulationPlayButtonMetrics.disabledFill == .disabledText)
+    #expect(SimulationPlayButtonMetrics.glyphColor == .white)
+  }
+
+  // MARK: - Leave sheet
+
+  @Test func leaveSheetCautionUsesWarningFamily() {
+    #expect(SimulationLeaveSheetTokens.cautionFill == .warningSoft)
+    #expect(SimulationLeaveSheetTokens.cautionText == .warningInk)
+    #expect(SimulationLeaveSheetTokens.cautionBorder == .warning)
+  }
+
+  /// The load-bearing semantic decision: "keep running" is a *caution*
+  /// (`warning`), NOT a *destructive* action (`danger`). Guards against a
+  /// silent swap back to the red/danger family (critic round-1 Axis 3).
+  @Test func leaveSheetCautionIsNotDanger() {
+    #expect(SimulationLeaveSheetTokens.cautionFill != .dangerSoft)
+    #expect(SimulationLeaveSheetTokens.cautionText != .dangerInk)
+    #expect(SimulationLeaveSheetTokens.cautionBorder != .danger)
+  }
+
+  @Test func leaveSheetCancelStaysNeutral() {
+    #expect(SimulationLeaveSheetTokens.cancelText == .inkSecondary)
+    #expect(SimulationLeaveSheetTokens.cancelBorder == .rule)
+  }
+}

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -386,7 +386,7 @@ ToolbarItem(placement: .primaryAction) {
 |-----------------|------|------|
 | root NavigationStack に push されたビューの toolbar | **カスタム** (`PasturaBackButton` + `PasturaToolbarButtonStyle`) | iOS 26 の Liquid Glass 衝突を回避 |
 | Sheet / fullScreenCover 内の `NavigationStack` | システム標準 | sheet 内 NavigationStack は別 navigation context、現状 Liquid Glass の影響軽微（要観察） |
-| `.confirmationDialog` / `.alert` のボタン | システム標準 | カスタム化 API なし。中立色のまま |
+| `.confirmationDialog` / `.alert` のボタン | システム標準 | カスタム化 API なし（色は赤=`.destructive` か中立のみ）。**例外**: ボタンに意味的な配色（warning など）が要る確認だけ `.sheet` のカスタム確認ダイアログにする（§5.12） |
 
 > **Note**: sheet 内 NavigationStack toolbar item の Liquid Glass 適用が visual problem になった場合、本サブセクションを更新して例外条件を明記すること。現時点では sheet 経路は scope 外。
 
@@ -434,6 +434,14 @@ raw `.borderedProminent`（iOS 26 Liquid Glass capsule に opt-in する）は�
 | エディタ / フォーム / 汎用ラベルの詳細 | `.inline` | ScenarioEditor / ResultDetail |
 
 タブ root ルールは固有名/汎用ラベル軸を上書きする — Home のタイトル `"Pastura"` は固有名だが、タブ root なので `.inline`。4つのタブ root は各 View で明示的に `.inline` を指定する（`HomeView` / `SharedScenariosListView` / `ResultsView` / `SettingsView`）。`Shared Scenarios` / `Past Results` は push でも到達できる（③④で Home 経路が消えるまで）が、どちらも汎用ラベルなので push 版も `.inline` で一貫する。`.large` を明示しているのは固有名詳細の `ScenarioDetailView` のみ（他の large はデフォルト依存）。SimulationView は GameHeader（§2.12）がタイトル行を所有する例外で、空タイトル + `.inline`。表示モードは toolbar の可視性 / back button / Liquid Glass opt-out（§5.8・navigation.md）とは直交。
+
+### 5.12 Simulation control bar — 円形主操作ボタン & 確認シート
+
+Sim 画面に限った2つの例外的コンポーネント。Source: `SimulationPlayButtonMetrics` / `SimulationLeaveSheet`（+`SimulationLeaveSheetTokens`）。両方の load-bearing token は `SimulationControlsTokenTests` で pin。
+
+**再生/停止ボタン（円形主操作）**: フロストのコントロールバー（§4.3）上の主操作。`mossDark` 塗り 34pt 円＋白グリフ（14pt）。素のグリフ（ink）だとバー上で唯一の塗り要素が「黒い塊」として浮いて読めたため、明示的な主操作コントロールにした。**円自身に影は付けない** — バーが既に単一の浮遊要素（§1「観察＝持ち上げない」/ §4.3「Sim で単一要素のみ」）なので二重持ち上げを避ける。disabled は `disabledText` 塗り（disabled は §8 コントラスト対象外）。
+
+**離脱確認シート（`SimulationLeaveSheet`）**: 実行中に戻る際の確認（keep-running 設定 OFF 時）。Pastura で唯一の独自確認ダイアログ — システム `.alert` の「全ボタン緑＝抑揚なし」を、`.sheet` で意味的な3段配色にする。主操作「一時停止して戻る」＝`PasturaPrimaryButtonStyle`（moss）、警戒「実行したまま戻る」＝§2.6 `warning`（琥珀、`warningSoft` 塗り＋`warningInk` 文字）、cancel「とどまる」＝中立（`inkSecondary`＋`rule`）。**警戒に `danger`（赤）を使わない** — 実行は継続・復帰可能で何も破壊しないため。赤は VoiceOver でも破壊操作として読み上げられ誤解を生む。`.confirmationDialog` は iOS 26 でポップオーバー誤アンカー（swiftui-traps）のため `.sheet`。ボタンは `lineLimit(nil)` で大きい Dynamic Type でも折り返す。
 
 ---
 


### PR DESCRIPTION
## Summary
Two user-confirmed UI-polish changes on the simulation screen (mockup-driven).

- **Control-bar play/pause → circular primary button.** The bare `play.fill`/`pause.fill` glyph in `Color.ink` read as a stray "black blob" on the frosted bar. Restyled as a 34pt `mossDark` circle + white glyph (`SimulationPlayButtonMetrics`), no extra shadow (the frosted bar already lifts — §1/§4.3 single floating element). Extracted to a `playPauseButton(...)` helper to stay under `function_body_length`.
- **Back-during-sim confirm → custom sheet with semantic colors.** The old `.alert` rendered all three buttons in the green accent (no hierarchy). Replaced with `SimulationLeaveSheet` (`.sheet`) so the actions carry design-system semantics: **moss** primary (*Pause and leave* — safe/recommended), **amber `warning`** caution (*Leave & keep running* — recoverable, so §2.6 `warning`, **not** `danger`/red), neutral *Stay*. `warning`-not-`danger` was the explicit fix for a pre-impl critic finding (red mis-signals destruction, incl. to VoiceOver). Reuses the existing localized strings (no new catalog keys) and `leaveAlertBinding` (swipe-dismiss → `stay()`).

Closes #795.

## Design rationale
System `.alert`/`.confirmationDialog` expose no per-button color API (design-system §5.8.3); the only native lever is red-`.destructive`. Since "keep running" is recoverable (not destructive), a custom `.sheet` is used so the semantic `warning` (amber) caution color applies — documented as the §5.8.3 exception + new §5.12. `.sheet` (not `.confirmationDialog`) avoids the iOS 26 popover mis-anchor trap (swiftui-traps).

## Test plan
- ✅ New change-detector suite `SimulationControlsTokenTests` (5 tests) pins play-button metrics + leave-sheet tokens, incl. a guard that caution uses the `warning` family **not** `danger`.
- ✅ Full unit suite: 2290 tests pass. swiftlint --strict clean.
- ✅ `code-reviewer` (Opus): PASS, 0 issues.
- ⚠️ **Device QA required (iOS 26):** simulator suppresses/alters frosted + Liquid Glass rendering, so verify on-device — (a) mossDark circle contrast on the frosted bar; (b) the sheet's 3-tier color hierarchy; (c) VoiceOver reads the message before the buttons + announces the caution action without a destructive cue; (d) Dynamic Type AX5 — buttons wrap, don't clip (`.height(340)` detent + ScrollView is the graceful-degradation path); (e) swipe-to-dismiss while running lands in `stay()` (does NOT pop the view).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- **DL-time demo replay parity.** The demo control bar (`ModelDownloadHostView+ControlBar.swift`) mirrors `SimulationView.controlBar` (#273); its pause button now reuses the same shared `SimulationPlayButtonMetrics` circle, so the two screens stay consistent. (Demo has no leave-confirm dialog — change 2 is Sim-only.)
