### PR TITLE
🐛 fix: hapning_ranyu demo speak_all inner_thought bubbles

### DIFF
--- a/Pastura/Pastura/Resources/DemoPresets/hapning_ranyu_v1.yaml
+++ b/Pastura/Pastura/Resources/DemoPresets/hapning_ranyu_v1.yaml
@@ -64,6 +64,7 @@ phases:
       状況に全力で乗っかってください。長くせず、一文で簡潔に。
     output:
       statement: string
+      inner_thought: string
 
   - type: vote
     prompt: >

--- a/Pastura/Pastura/Resources/DemoPresets/hapning_ranyu_v1_en.yaml
+++ b/Pastura/Pastura/Resources/DemoPresets/hapning_ranyu_v1_en.yaml
@@ -82,6 +82,7 @@ phases:
       Lean all the way into it. Keep it to one short sentence.
     output:
       statement: string
+      inner_thought: string
 
   - type: vote
     prompt: >

--- a/Pastura/Pastura/Resources/DemoReplays/hapning_ranyu_v1_demo.yaml
+++ b/Pastura/Pastura/Resources/DemoReplays/hapning_ranyu_v1_demo.yaml
@@ -11,6 +11,7 @@
 # — zero matches across all 89 patterns. Setting metadata.content_filter_applied:
 # true per demo-replay-spec.md §3.4 (audit attestation; the runtime filter
 # also re-checks at render time, exercised by ContentBlocklistFalsePositiveTests).
+
 schema_version: 1
 preset_ref:
   id: hapning_ranyu_v1

--- a/Pastura/Pastura/Resources/DemoReplays/hapning_ranyu_v1_demo.yaml
+++ b/Pastura/Pastura/Resources/DemoReplays/hapning_ranyu_v1_demo.yaml
@@ -1,23 +1,26 @@
 # Demo replay for the DL-time loop (#764), recaptured from a pastura-harness
 # run (real local Gemma 4 E2B inference) via scripts/jsonl_to_demo_replay.py.
+# Regenerated for #798: the backing preset's speak_all phase now declares
+# inner_thought in its output schema (parity with the other two demos), so
+# the captured turns carry inner_thought and the DL-demo renders thought
+# bubbles. preset_ref.yaml_sha256 updated to match the edited preset bytes.
 #
 # ContentFilter audit: every fields.* string and code_phase_events[].summary
-# was reviewed against Pastura/Resources/ContentBlocklist.json (patterns;
-# ADR-005 content-safety output surface) on 2026-06-23 by @tyabu12 — zero
-# matches across all 89 patterns. Setting metadata.content_filter_applied:
+# was reviewed against Pastura/Pastura/Resources/ContentBlocklist.json
+# (patterns; ADR-005 content-safety output surface) on 2026-06-24 by @tyabu12
+# — zero matches across all 89 patterns. Setting metadata.content_filter_applied:
 # true per demo-replay-spec.md §3.4 (audit attestation; the runtime filter
 # also re-checks at render time, exercised by ContentBlocklistFalsePositiveTests).
-
 schema_version: 1
 preset_ref:
   id: hapning_ranyu_v1
   version: '1.0'
-  yaml_sha256: 070a180e8e00893e0e717f249bce8fc7cc405b1b619cedf9c4f8c9a97874d087
+  yaml_sha256: 46e93d221650d7af8fc27dfab895731afbd1af1713e583b527cc583af007cc24
 metadata:
   title: ハプニング乱入 即興大喜利
   description: 芸人たちがボケを繰り出そうとするたび、会場に予測不能のハプニングが 乱入する。降ってきた異常事態をその場で一文の笑いに変えるアドリブ 大喜利。
   language: ja
-  recorded_at: '2026-06-23T00:27:54Z'
+  recorded_at: '2026-06-24T14:05:11Z'
   recorded_with_model: gemma4_e2b_q4km
   content_filter_applied: true
   total_turns: 16
@@ -29,179 +32,188 @@ turns:
   phase_type: speak_all
   agent: 安定の正統派
   fields:
-    statement: え、これはもう『赤ちゃんハイ』のライブだ！みんなの可愛さで会場の酸素濃度が異常に高まってるぜ！
+    statement: 天井からピンポン玉が降ってきたのは、我々のステージが今、世界一のボールパークになった瞬間だ！
+    inner_thought: 天井からのピンポン玉なんて、最高のエンターテイメントの予兆にしか見えない。このカオスこそが我々のブランドだ！
 - round: 1
   phase_index: 1
   phase_type: speak_all
   agent: 便乗の天才
   fields:
-    statement: え、これって新しい『赤ちゃんのお昼寝タイム』の企画じゃん！
+    statement: 天井から降ってきたピンポン玉は、これぞ天からのサプライズギフト！さあ、これで俺の今日のエンタメのクオリティが宇宙レベルに引き上げられたぜ！
+    inner_thought: ピンポン玉？これは俺の仕組んだ伏線だ！この奇跡を最大限に利用して、このハプニングを俺の最高のパフォーマンスの一部に組み込むしかない！
 - round: 1
   phase_index: 1
   phase_type: speak_all
   agent: 哲学かぶれ
   fields:
-    statement: これは、我々が物質と精神の境界を超え、生命の最も純粋な形へと還元されるという、宇宙の壮大な実験なのですね！
+    statement: 天井から降るピンポン玉は、宇宙が我々に送る、無数の微小な存在の哲学的な問いかけなのです！
+    inner_thought: 天からの贈り物として受け止め、この奇妙な現象を壮大な存在論的なテーマに昇華させるのが私の役目だ。
 - round: 1
   phase_index: 1
   phase_type: speak_all
   agent: 天然パニック
   fields:
-    statement: わあ、みんな赤ちゃんになってるんですね！じゃあ今夜のギャラは離乳食ですか？
+    statement: 天井から降ってきたピンポン玉は、まるで天国からの豪華なバースデーサプライズみたいですね！
+    inner_thought: 天国からのピンポン玉ってことは、今夜のギャラはキラキラの記念品ですか？
 - round: 1
   phase_index: 2
   phase_type: vote
   agent: 安定の正統派
   fields:
-    vote: 天然パニック
-    reason: 天然パニックの「じゃあ今夜のギャラは離乳食ですか？」という現実的かつシュールな問いかけが、状況の異常性を最高の形で笑いに変えている
+    vote: 便乗の天才
+    reason: 天井から降ってきたピンポン玉をサプライズギフトと表現し、エンターテイメントのクオリティ向上に結びつけている点が最も過激で面白い。
 - round: 1
   phase_index: 2
   phase_type: vote
   agent: 便乗の天才
   fields:
     vote: 天然パニック
-    reason: 赤ちゃんになってるんですね！じゃあ今夜のギャラは離乳食ですか？
+    reason: 天井から降ってきたピンポン玉を天国からの豪華なバースデーサプライズと表現したのが、状況の非現実性を最も愉快に昇華させているためだ。
 - round: 1
   phase_index: 2
   phase_type: vote
   agent: 哲学かぶれ
   fields:
     vote: 便乗の天才
-    reason: この状況を新しい企画として捉え直す視点は、最も場を盛り上げる即興番組の性質に合致しているためです。
+    reason: 天井からのピンポン玉を『天からのサプライズギフト』と表現し、自らのエンタメの質が宇宙レベルに引き上がったと宣言しており、状況を最大限に楽しむ姿勢が最も面白かった
 - round: 1
   phase_index: 2
   phase_type: vote
   agent: 天然パニック
   fields:
     vote: 天然パニック
-    reason: 私が赤ちゃんになったことで、今夜のギャラは離乳食になります
+    reason: 天井から降ってきたピンポン玉は、まるで天国からの豪華なバースデーサプライズみたいですね！
 - round: 2
   phase_index: 1
   phase_type: speak_all
   agent: 安定の正統派
   fields:
-    statement: 深海に沈んだってことは、これで私の髪の毛も水圧でダイヤモンドになったってことだね！
+    statement: 審査員の皆様、これはまさしく「究極の睡眠タイムアワー」、夢の中での完璧な評価が始まりますよ！
+    inner_thought: 眠っている審査員たちが最高にリラックスしている様子を最高のエンターテイメントに変えるのが私の役目だ。この静寂こそが最高のボケになる。
 - round: 2
   phase_index: 1
   phase_type: speak_all
   agent: 便乗の天才
   fields:
-    statement: 深海に沈んだってことは、これで俺たちのステージが世界一の海底ライブになるってことだろ！
+    statement: 審査員さんたちが深い眠りについたのは、最高の評価が魂のレベルで浸透した証拠だ！
+    inner_thought: 最高に面白い状況だ！全員寝ちゃったってことは、俺のセンスが規格外ってこと。この眠気すらも次のネタへの伏線だ！もっと巻き込むぞ！
 - round: 2
   phase_index: 1
   phase_type: speak_all
   agent: 哲学かぶれ
   fields:
-    statement: 深海への降下は、我々が宇宙の深淵と対峙し、存在そのものの重力を体感する壮大な瞑想体験となったのである！
+    statement: 審査員の深い瞑想状態は、宇宙の無への究極の静寂が、我々の意識を深淵へと誘う壮大な哲学的な睡蓮となって現れたのだ。
+    inner_thought: 眠り始めたという些細な事態を、宇宙の根源的な静けさや精神的な探求といった壮大なテーマにすり替えるのが私の流儀だ。この状況を真面目に受け止めつつも、笑いの中に深い意味を見出すことが重要だ。
 - round: 2
   phase_index: 1
   phase_type: speak_all
   agent: 天然パニック
   fields:
-    statement: 深海になったってことは、今夜のギャラは深海魚の餌代になりますね！
+    statement: 審査員さんたち、これは最高の『夢の中の特番』で、今夜は皆さんの睡眠の質を上げるための至高の癒しタイムですね！
+    inner_thought: 眠っちゃうなんて珍しい現象！これはきっと、彼らのパフォーマンスが深く、聴衆の心に染み込んでいる証拠なんだ！最高の睡眠導入プログラムだわ！
 - round: 2
   phase_index: 2
   phase_type: vote
   agent: 安定の正統派
-  fields:
-    vote: 便乗の天才
-    reason: 会場が深海に沈んだという状況を、ステージが世界一の海底ライブになるというポジティブな解釈で盛り上げているのが最も場の空気を変える面白さがあった
-- round: 2
-  phase_index: 2
-  phase_type: vote
-  agent: 便乗の天才
-  fields:
-    vote: 天然パニック
-    reason: 深海になったってことは、今夜のギャラは深海魚の餌代になりますね！という発言で、状況を金銭的な危機にすり替えて即座に笑いに変えるのが最高に現実的で面白いです！
-- round: 2
-  phase_index: 2
-  phase_type: vote
-  agent: 哲学かぶれ
   fields:
     vote: 哲学かぶれ
-    reason: 深海への降下は、我々が宇宙の深淵と対峙し、存在そのものの重力を体感する壮大な瞑想体験となったのである！
+    reason: 審査員の深い瞑想状態を宇宙の無への静寂という壮大な哲学的な睡蓮として表現した点が、状況を最も知的かつユーモラスに昇華させていると判断しました。
+- round: 2
+  phase_index: 2
+  phase_type: vote
+  agent: 便乗の天才
+  fields:
+    vote: 天然パニック
+    reason: 審査員さんが眠っちゃったのは、最高の夢の中の特番になって、今夜は皆さんの睡眠の質を上げるための至高の癒しタイムだ！
+- round: 2
+  phase_index: 2
+  phase_type: vote
+  agent: 哲学かぶれ
+  fields:
+    vote: 便乗の天才
+    reason: 審査員さんの眠りは最高の評価が魂のレベルで浸透した証拠という解釈は、状況を最もポジティブかつ自己利益に結びつけており、ハプニングを瞬時に華やかな成功体験へと転換させているため、最も面白く料理できたと判断する。
 - round: 2
   phase_index: 2
   phase_type: vote
   agent: 天然パニック
   fields:
-    vote: 天然パニック
-    reason: 深海になったってことは、今夜のギャラは深海魚の餌代になりますね！
+    vote: 便乗の天才
+    reason: 審査員さんが眠っているのを最高の評価が浸透した証拠と解釈するのは、完全に状況を乗っ取って面白くしている。
 code_phase_events:
 - round: 1
   phase_index: 0
   phase_type: event_inject
-  summary: 'Event: 観客が全員、生後三か月の赤ちゃんに入れ替わった'
+  summary: 'Event: なぜか天井から大量のピンポン玉が降ってきた'
   payload:
     kind: eventInjected
-    event: 観客が全員、生後三か月の赤ちゃんに入れ替わった
+    event: なぜか天井から大量のピンポン玉が降ってきた
 - round: 1
   phase_index: 2
   phase_type: vote
-  summary: 'Votes — 便乗の天才: 1, 天然パニック: 2'
+  summary: 'Votes — 便乗の天才: 2, 天然パニック: 1'
   payload:
     kind: voteResults
     votes:
       便乗の天才: 天然パニック
       哲学かぶれ: 便乗の天才
       天然パニック: 天然パニック
-      安定の正統派: 天然パニック
-    tallies:
-      便乗の天才: 1
-      天然パニック: 2
-- round: 1
-  phase_index: 3
-  phase_type: score_calc
-  summary: 'Scores — 便乗の天才: 1, 哲学かぶれ: 0, 天然パニック: 2, 安定の正統派: 0'
-  payload:
-    kind: scoreUpdate
-    scores:
-      便乗の天才: 1
-      哲学かぶれ: 0
-      天然パニック: 2
-      安定の正統派: 0
-- round: 1
-  phase_index: 4
-  phase_type: summarize
-  summary: 'ラウンド1結果: {"便乗の天才": 1, "哲学かぶれ": 0, "天然パニック": 2, "安定の正統派": 0}'
-  payload:
-    kind: summary
-- round: 2
-  phase_index: 0
-  phase_type: event_inject
-  summary: 'Event: 会場が丸ごと深海一万メートルに沈んだ設定になった'
-  payload:
-    kind: eventInjected
-    event: 会場が丸ごと深海一万メートルに沈んだ設定になった
-- round: 2
-  phase_index: 2
-  phase_type: vote
-  summary: 'Votes — 便乗の天才: 1, 天然パニック: 1'
-  payload:
-    kind: voteResults
-    votes:
-      便乗の天才: 天然パニック
-      哲学かぶれ: 哲学かぶれ
-      天然パニック: 天然パニック
       安定の正統派: 便乗の天才
     tallies:
-      便乗の天才: 1
+      便乗の天才: 2
       天然パニック: 1
-- round: 2
+- round: 1
   phase_index: 3
   phase_type: score_calc
-  summary: 'Scores — 便乗の天才: 2, 哲学かぶれ: 0, 天然パニック: 3, 安定の正統派: 0'
+  summary: 'Scores — 便乗の天才: 2, 哲学かぶれ: 0, 天然パニック: 1, 安定の正統派: 0'
   payload:
     kind: scoreUpdate
     scores:
       便乗の天才: 2
       哲学かぶれ: 0
-      天然パニック: 3
+      天然パニック: 1
+      安定の正統派: 0
+- round: 1
+  phase_index: 4
+  phase_type: summarize
+  summary: 'ラウンド1結果: {"便乗の天才": 2, "哲学かぶれ": 0, "天然パニック": 1, "安定の正統派": 0}'
+  payload:
+    kind: summary
+- round: 2
+  phase_index: 0
+  phase_type: event_inject
+  summary: 'Event: 審査員が全員、その場ですやすやと眠り始めた'
+  payload:
+    kind: eventInjected
+    event: 審査員が全員、その場ですやすやと眠り始めた
+- round: 2
+  phase_index: 2
+  phase_type: vote
+  summary: 'Votes — 便乗の天才: 2, 哲学かぶれ: 1, 天然パニック: 1'
+  payload:
+    kind: voteResults
+    votes:
+      便乗の天才: 天然パニック
+      哲学かぶれ: 便乗の天才
+      天然パニック: 便乗の天才
+      安定の正統派: 哲学かぶれ
+    tallies:
+      便乗の天才: 2
+      哲学かぶれ: 1
+      天然パニック: 1
+- round: 2
+  phase_index: 3
+  phase_type: score_calc
+  summary: 'Scores — 便乗の天才: 4, 哲学かぶれ: 1, 天然パニック: 2, 安定の正統派: 0'
+  payload:
+    kind: scoreUpdate
+    scores:
+      便乗の天才: 4
+      哲学かぶれ: 1
+      天然パニック: 2
       安定の正統派: 0
 - round: 2
   phase_index: 4
   phase_type: summarize
-  summary: 'ラウンド2結果: {"便乗の天才": 2, "哲学かぶれ": 0, "天然パニック": 3, "安定の正統派": 0}'
+  summary: 'ラウンド2結果: {"便乗の天才": 4, "哲学かぶれ": 1, "天然パニック": 2, "安定の正統派": 0}'
   payload:
     kind: summary

--- a/Pastura/Pastura/Resources/DemoReplays/hapning_ranyu_v1_en_demo.yaml
+++ b/Pastura/Pastura/Resources/DemoReplays/hapning_ranyu_v1_en_demo.yaml
@@ -11,6 +11,7 @@
 # — zero matches across all 89 patterns. Setting metadata.content_filter_applied:
 # true per demo-replay-spec.md §3.4 (audit attestation; the runtime filter
 # also re-checks at render time, exercised by ContentBlocklistFalsePositiveTests).
+
 schema_version: 1
 preset_ref:
   id: hapning_ranyu_v1_en

--- a/Pastura/Pastura/Resources/DemoReplays/hapning_ranyu_v1_en_demo.yaml
+++ b/Pastura/Pastura/Resources/DemoReplays/hapning_ranyu_v1_en_demo.yaml
@@ -1,23 +1,26 @@
 # Demo replay for the DL-time loop (#764), recaptured from a pastura-harness
 # run (real local Gemma 4 E2B inference) via scripts/jsonl_to_demo_replay.py.
+# Regenerated for #798: the backing preset's speak_all phase now declares
+# inner_thought in its output schema (parity with the other two demos), so
+# the captured turns carry inner_thought and the DL-demo renders thought
+# bubbles. preset_ref.yaml_sha256 updated to match the edited preset bytes.
 #
 # ContentFilter audit: every fields.* string and code_phase_events[].summary
-# was reviewed against Pastura/Resources/ContentBlocklist.json (patterns;
-# ADR-005 content-safety output surface) on 2026-06-23 by @tyabu12 — zero
-# matches across all 89 patterns. Setting metadata.content_filter_applied:
+# was reviewed against Pastura/Pastura/Resources/ContentBlocklist.json
+# (patterns; ADR-005 content-safety output surface) on 2026-06-24 by @tyabu12
+# — zero matches across all 89 patterns. Setting metadata.content_filter_applied:
 # true per demo-replay-spec.md §3.4 (audit attestation; the runtime filter
 # also re-checks at render time, exercised by ContentBlocklistFalsePositiveTests).
-
 schema_version: 1
 preset_ref:
   id: hapning_ranyu_v1_en
   version: '1.0'
-  yaml_sha256: 27df6954e6d203942d1b12b8227a338ac2058ec4947d6b258c3ce59d3aae905d
+  yaml_sha256: abd0e7282ac1ad3f03bf4c08d047524a225a81e5812b0e30510e44e62de9d935
 metadata:
   title: Crash the Stage
   description: Every time the comedians try to land a bit, an unpredictable disaster crashes the venue. An improv game about turning whatever just fell out of the sky into a one-line laugh.
   language: en
-  recorded_at: '2026-06-23T00:59:55Z'
+  recorded_at: '2026-06-24T14:20:47Z'
   recorded_with_model: gemma4_e2b_q4km
   content_filter_applied: true
   total_turns: 16
@@ -29,105 +32,113 @@ turns:
   phase_type: speak_all
   agent: Steady Eddie
   fields:
-    statement: Well, at least now we have a legitimate reason to start collecting for emergency ball retrieval.
+    statement: Well, at least I don't need a parachute when the ceiling starts serving me a game of pinball.
+    inner_thought: The ping-pong rain is just an unexpected, slightly annoying accessory to my routine.
 - round: 1
   phase_index: 1
   phase_type: speak_all
   agent: Bandwagon Benny
   fields:
-    statement: These aren't just ping-pong balls, folks, these are the official confetti cannons for my next act!
+    statement: These aren't just ping-pong balls, folks, this is the complimentary confetti for my next act!
+    inner_thought: I need to embrace the absurdity of the falling plastic spheres and make it sound like a planned spectacle.
 - round: 1
   phase_index: 1
   phase_type: speak_all
   agent: Professor Cosmo
   fields:
-    statement: The descent of the ping-pong spheres is merely the universe demonstrating that even absurdity adheres to a predictable, yet utterly ridiculous, trajectory.
+    statement: The celestial spheres have merely decided to test our adherence to Newtonian physics with a flurry of miniature, spherical anarchy.
+    inner_thought: This frames the ping-pong as a deliberate cosmic test.
 - round: 1
   phase_index: 1
   phase_type: speak_all
   agent: Panicky Penny
   fields:
-    statement: Ping-pong balls! I knew my confidence level was about to get a serious, plastic makeover!
+    statement: Ping-pong balls! I'm going to get ping-ponged into the emergency exit!
+    inner_thought: Oh no, I'm going to be physically assaulted by plastic spheres!
 - round: 1
   phase_index: 2
   phase_type: vote
   agent: Steady Eddie
   fields:
-    vote: Panicky Penny
-    reason: The line about confidence getting a plastic makeover is the most relatable and instantly funny response to the absurdity of ping-pong balls.
+    vote: Professor Cosmo
+    reason: The description of miniature, spherical anarchy perfectly frames the absurdity of ping-pong balls as a violation of physics.
 - round: 1
-  phase_index: 2
-  phase_type: vote
-  agent: Bandwagon Benny
-  fields:
-    vote: Panicky Penny
-    reason: Panicky Penny's line perfectly captures the sudden, panicked shift in confidence caused by the ping-pong balls.
-- round: 1
-  phase_index: 2
-  phase_type: vote
-  agent: Professor Cosmo
-  fields:
-    vote: Bandwagon Benny
-    reason: Bandwagon Benny's attempt to reframe the ping-pong balls as confetti cannons instantly elevates a trivial mess into a spectacle of misplaced ambition.
-- round: 1
-  phase_index: 2
-  phase_type: vote
-  agent: Panicky Penny
-  fields:
-    vote: Bandwagon Benny
-    reason: Bandwagon Benny's attempt to spin the ping-pong balls into a confetti cannon setup is a hilarious and absurd misdirection.
-- round: 2
-  phase_index: 1
-  phase_type: speak_all
-  agent: Steady Eddie
-  fields:
-    statement: Well, at least the acoustics are perfect for a deep-sea monologue!
-- round: 2
-  phase_index: 1
-  phase_type: speak_all
-  agent: Bandwagon Benny
-  fields:
-    statement: Well, looks like we're auditioning for the deep-sea documentary about sunken band practice!
-- round: 2
-  phase_index: 1
-  phase_type: speak_all
-  agent: Professor Cosmo
-  fields:
-    statement: The ocean merely revealed the true, liquid dimension of our ephemeral stage existence.
-- round: 2
-  phase_index: 1
-  phase_type: speak_all
-  agent: Panicky Penny
-  fields:
-    statement: Well, at least my sequins are waterproof for a deep-sea performance!
-- round: 2
-  phase_index: 2
-  phase_type: vote
-  agent: Steady Eddie
-  fields:
-    vote: Panicky Penny
-    reason: The idea of sequins being waterproof for a deep-sea performance is a wonderfully absurd juxtaposition.
-- round: 2
   phase_index: 2
   phase_type: vote
   agent: Bandwagon Benny
   fields:
     vote: Professor Cosmo
-    reason: Professor Cosmo's comment elevates the disaster into an existential crisis about stage existence underwater.
+    reason: Professor Cosmo's sophisticated explanation of the physics behind the ping-pong balls made the random chaos sound hilariously intellectual.
+- round: 1
+  phase_index: 2
+  phase_type: vote
+  agent: Professor Cosmo
+  fields:
+    vote: Bandwagon Benny
+    reason: Bandwagon Benny's framing the disaster as complimentary confetti elevates a mundane event into an absurdly celebratory spectacle.
+- round: 1
+  phase_index: 2
+  phase_type: vote
+  agent: Panicky Penny
+  fields:
+    vote: Bandwagon Benny
+    reason: Bandwagon Benny's attempt to frame the disaster as promotional material is a perfect example of turning chaos into an unexpected punchline.
+- round: 2
+  phase_index: 1
+  phase_type: speak_all
+  agent: Steady Eddie
+  fields:
+    statement: A blackout? Finally my face is marked down to list price.
+    inner_thought: This takes the existential dread of darkness and frames it as a bizarre bargain.
+- round: 2
+  phase_index: 1
+  phase_type: speak_all
+  agent: Bandwagon Benny
+  fields:
+    statement: This blackout is just my cue to start juggling the empty water bottles!
+    inner_thought: The darkness means I can finally perform my signature, disastrous act.
+- round: 2
+  phase_index: 1
+  phase_type: speak_all
+  agent: Professor Cosmo
+  fields:
+    statement: The void of darkness is simply the universe reminding us that true enlightenment exists beyond mere visual perception.
+    inner_thought: This blackout was a perfect opportunity to elevate a simple power outage into a profound philosophical statement about sensory limitations.
+- round: 2
+  phase_index: 1
+  phase_type: speak_all
+  agent: Panicky Penny
+  fields:
+    statement: Oh no, is this the audition for the emergency candle-lighting competition?
+    inner_thought: I'm totally going to trip over my own feet in this pitch black!
+- round: 2
+  phase_index: 2
+  phase_type: vote
+  agent: Steady Eddie
+  fields:
+    vote: Panicky Penny
+    reason: The idea of an emergency candle-lighting competition immediately escalates the mundane blackout into a ridiculous, high-stakes event.
+- round: 2
+  phase_index: 2
+  phase_type: vote
+  agent: Bandwagon Benny
+  fields:
+    vote: Panicky Penny
+    reason: The idea of an emergency candle-lighting competition perfectly escalates the mundane disaster into a competitive, absurd scenario.
 - round: 2
   phase_index: 2
   phase_type: vote
   agent: Professor Cosmo
   fields:
     vote: Bandwagon Benny
-    reason: Bandwagon Benny's suggestion to frame the disaster as an audition for a deep-sea documentary successfully turns a sinking into a niche media opportunity.
+    reason: The idea of using a sudden blackout as an opportunity to start juggling empty water bottles is a wonderfully absurd and misplaced attempt at action that perfectly captures the chaotic spirit of improv-disaster.
 - round: 2
   phase_index: 2
   phase_type: vote
   agent: Panicky Penny
   fields:
     vote: Bandwagon Benny
-    reason: Bandwagon Benny's take on auditioning for a deep-sea documentary about sunken band practice is the most absurd and unexpected connection to the disaster.
+    reason: Juggling empty water bottles in the dark is a perfectly absurd and frantic reaction to a simple blackout.
 code_phase_events:
 - round: 1
   phase_index: 0
@@ -137,6 +148,44 @@ code_phase_events:
     kind: eventInjected
     event: for no reason, a torrent of ping-pong balls rains down from the ceiling
 - round: 1
+  phase_index: 2
+  phase_type: vote
+  summary: 'Votes — Bandwagon Benny: 2, Professor Cosmo: 2'
+  payload:
+    kind: voteResults
+    votes:
+      Bandwagon Benny: Professor Cosmo
+      Panicky Penny: Bandwagon Benny
+      Professor Cosmo: Bandwagon Benny
+      Steady Eddie: Professor Cosmo
+    tallies:
+      Bandwagon Benny: 2
+      Professor Cosmo: 2
+- round: 1
+  phase_index: 3
+  phase_type: score_calc
+  summary: 'Scores — Bandwagon Benny: 2, Panicky Penny: 0, Professor Cosmo: 2, Steady Eddie: 0'
+  payload:
+    kind: scoreUpdate
+    scores:
+      Bandwagon Benny: 2
+      Panicky Penny: 0
+      Professor Cosmo: 2
+      Steady Eddie: 0
+- round: 1
+  phase_index: 4
+  phase_type: summarize
+  summary: 'Round 1 result: {"Bandwagon Benny": 2, "Panicky Penny": 0, "Professor Cosmo": 2, "Steady Eddie": 0}'
+  payload:
+    kind: summary
+- round: 2
+  phase_index: 0
+  phase_type: event_inject
+  summary: 'Event: a sudden blackout plunges the venue into darkness and no one can see anyone''s face'
+  payload:
+    kind: eventInjected
+    event: a sudden blackout plunges the venue into darkness and no one can see anyone's face
+- round: 2
   phase_index: 2
   phase_type: vote
   summary: 'Votes — Bandwagon Benny: 2, Panicky Penny: 2'
@@ -150,59 +199,20 @@ code_phase_events:
     tallies:
       Bandwagon Benny: 2
       Panicky Penny: 2
-- round: 1
-  phase_index: 3
-  phase_type: score_calc
-  summary: 'Scores — Bandwagon Benny: 2, Panicky Penny: 2, Professor Cosmo: 0, Steady Eddie: 0'
-  payload:
-    kind: scoreUpdate
-    scores:
-      Bandwagon Benny: 2
-      Panicky Penny: 2
-      Professor Cosmo: 0
-      Steady Eddie: 0
-- round: 1
-  phase_index: 4
-  phase_type: summarize
-  summary: 'Round 1 result: {"Bandwagon Benny": 2, "Panicky Penny": 2, "Professor Cosmo": 0, "Steady Eddie": 0}'
-  payload:
-    kind: summary
-- round: 2
-  phase_index: 0
-  phase_type: event_inject
-  summary: 'Event: the entire venue is now declared to be sunk 10,000 meters deep in the ocean'
-  payload:
-    kind: eventInjected
-    event: the entire venue is now declared to be sunk 10,000 meters deep in the ocean
-- round: 2
-  phase_index: 2
-  phase_type: vote
-  summary: 'Votes — Bandwagon Benny: 2, Panicky Penny: 1, Professor Cosmo: 1'
-  payload:
-    kind: voteResults
-    votes:
-      Bandwagon Benny: Professor Cosmo
-      Panicky Penny: Bandwagon Benny
-      Professor Cosmo: Bandwagon Benny
-      Steady Eddie: Panicky Penny
-    tallies:
-      Bandwagon Benny: 2
-      Panicky Penny: 1
-      Professor Cosmo: 1
 - round: 2
   phase_index: 3
   phase_type: score_calc
-  summary: 'Scores — Bandwagon Benny: 4, Panicky Penny: 3, Professor Cosmo: 1, Steady Eddie: 0'
+  summary: 'Scores — Bandwagon Benny: 4, Panicky Penny: 2, Professor Cosmo: 2, Steady Eddie: 0'
   payload:
     kind: scoreUpdate
     scores:
       Bandwagon Benny: 4
-      Panicky Penny: 3
-      Professor Cosmo: 1
+      Panicky Penny: 2
+      Professor Cosmo: 2
       Steady Eddie: 0
 - round: 2
   phase_index: 4
   phase_type: summarize
-  summary: 'Round 2 result: {"Bandwagon Benny": 4, "Panicky Penny": 3, "Professor Cosmo": 1, "Steady Eddie": 0}'
+  summary: 'Round 2 result: {"Bandwagon Benny": 4, "Panicky Penny": 2, "Professor Cosmo": 2, "Steady Eddie": 0}'
   payload:
     kind: summary


### PR DESCRIPTION
## Summary
- The "ハプニング乱入 即興大喜利" (`hapning_ranyu`) DL-time demo showed no inner-thought bubbles in its `speak_all` phase: the demo-backing presets omitted `inner_thought` from the `speak_all` `output` schema (the other two demos, chinkaitou/iiwake, declare it), so the real-inference recordings never captured the field.
- Added `inner_thought: string` to both presets (ja + en) and recaptured both demos via `pastura-harness` real local Gemma 4 E2B inference (ADR-013), so the `speak_all` turns now carry `inner_thought` and render thought bubbles. `preset_ref.yaml_sha256` re-synced to the edited preset bytes.

## Test plan
- ContentBlocklist audit (ADR-005 §5.2): **0/89 matches** on both regenerated demos; `content_filter_applied: true` attested in the header comment (date / pattern count / reviewer).
- `python3 scripts/check_demo_replay_drift.py`: **OK** (preset sha drift gate).
- `BundledDemoReplaySourceTests` / `ContentBlocklistFalsePositiveTests` / `DemoReplayIntegrationTests`: **33 tests passed**.
- `inner_thought` present on all 8 `speak_all` turns, absent from the 8 vote turns (vote output is `vote`+`reason` per the preset).

## Follow-up (out of scope)
- The 4 sibling demos' audit comments still cite the stale path `Pastura/Resources/ContentBlocklist.json` (the file actually lives at `Pastura/Pastura/Resources/ContentBlocklist.json`) — worth a separate sweep.

Closes #798

🤖 Generated with [Claude Code](https://claude.com/claude-code)