### PR TITLE
🐛 fix: ui-refine round-1 — gallery .large title + §8 caption posture

### DIFF
--- a/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailView.swift
+++ b/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailView.swift
@@ -33,6 +33,10 @@ struct GalleryScenarioDetailView: View {
       }
     }
     .navigationTitle(scenario.title)
+    // The scenario name is a proper-noun title, so it reads as a large
+    // heading like ScenarioDetail — not the `.inline` it would otherwise
+    // inherit from the `.inline` Search tab root (design-system § 5.11).
+    .navigationBarTitleDisplayMode(.large)
     .navigationBarBackButtonHidden(true)
     .preservesPasturaSwipeBackGesture()
     .task {

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -433,7 +433,7 @@ raw `.borderedProminent`（iOS 26 Liquid Glass capsule に opt-in する）は�
 | 主題の固有名がタイトルの詳細 | `.large` | ScenarioDetail / GalleryScenarioDetail（シナリオ名） |
 | エディタ / フォーム / 汎用ラベルの詳細 | `.inline` | ScenarioEditor / ResultDetail |
 
-タブ root ルールは固有名/汎用ラベル軸を上書きする — Home のタイトル `"Pastura"` は固有名だが、タブ root なので `.inline`。4つのタブ root は各 View で明示的に `.inline` を指定する（`HomeView` / `SharedScenariosListView` / `ResultsView` / `SettingsView`）。`Shared Scenarios` / `Past Results` は push でも到達できる（③④で Home 経路が消えるまで）が、どちらも汎用ラベルなので push 版も `.inline` で一貫する。`.large` を明示しているのは固有名詳細の `ScenarioDetailView` のみ（他の large はデフォルト依存）。SimulationView は GameHeader（§2.12）がタイトル行を所有する例外で、空タイトル + `.inline`。表示モードは toolbar の可視性 / back button / Liquid Glass opt-out（§5.8・navigation.md）とは直交。
+タブ root ルールは固有名/汎用ラベル軸を上書きする — Home のタイトル `"Pastura"` は固有名だが、タブ root なので `.inline`。4つのタブ root は各 View で明示的に `.inline` を指定する（`HomeView` / `SharedScenariosListView` / `ResultsView` / `SettingsView`）。`Shared Scenarios` / `Past Results` は push でも到達できる（③④で Home 経路が消えるまで）が、どちらも汎用ラベルなので push 版も `.inline` で一貫する。`.large` を明示指定しているのは固有名詳細の `ScenarioDetailView` と `GalleryScenarioDetailView`（どちらもシナリオ名が主題の固有名で、上の表どおり `.large`）。後者は明示しないと `.inline` の Search タブ root から `.inline` を継承してしまうため、明示が必須。SimulationView は GameHeader（§2.12）がタイトル行を所有する例外で、空タイトル + `.inline`。表示モードは toolbar の可視性 / back button / Liquid Glass opt-out（§5.8・navigation.md）とは直交。
 
 ### 5.12 Simulation control bar — 円形主操作ボタン & 確認シート
 

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -495,7 +495,7 @@ Sim 画面に限った2つの例外的コンポーネント。Source: `Simulatio
 ## 8. アクセシビリティ
 
 - 本文の最小コントラスト比: 7:1（AAA）を目標に `--ink` と `--screen-bg` の組み合わせで達成
-- **判読が要るメタ情報**（DL 進捗・ステータス等、確実に読ませる必要があるもの）は § 2.4 の L3 コントラストプリセット（`--meta-base` #4A4E3D ≈ 7:1）で 4.5:1 以上を確保する
+- **判読が要るメタ情報**（DL 進捗・ステータス等、確実に読ませる必要があるもの）は § 2.4 の L3 コントラストプリセット（`--meta-base` #4A4E3D ≈ 8:1）で 4.5:1 以上を確保する
 - **`--muted`（#8A8A83）quietude 階層は意図的に sub-AA**（#FCFAF4 上で ≈ 3.3:1）。一覧キャプション（`provenance · N agents · N rounds`）・脚注・アンビエントなラベル（`DEMO中` など）に使う、§1 の「静謐・観察」を体現する控えめなティアで、上の 4.5:1 要件の対象外とする意図的な判断。これにより § 2.2（`--muted` をメタ情報・脚注に割り当て）と本節の整合を取る。判読が要る情報をこのティアに置かないこと（その場合は上の L3 プリセットへ）
 - DL 進捗は `role="status" aria-live="polite"` / SwiftUI は `.accessibilityAddTraits(.updatesFrequently)`
 - アバター・犬マークは `aria-hidden="true"` / `.accessibilityHidden(true)`（飾りだから）

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -495,7 +495,8 @@ Sim 画面に限った2つの例外的コンポーネント。Source: `Simulatio
 ## 8. アクセシビリティ
 
 - 本文の最小コントラスト比: 7:1（AAA）を目標に `--ink` と `--screen-bg` の組み合わせで達成
-- メタ情報は L3 コントラストで 4.5:1 以上
+- **判読が要るメタ情報**（DL 進捗・ステータス等、確実に読ませる必要があるもの）は § 2.4 の L3 コントラストプリセット（`--meta-base` #4A4E3D ≈ 7:1）で 4.5:1 以上を確保する
+- **`--muted`（#8A8A83）quietude 階層は意図的に sub-AA**（#FCFAF4 上で ≈ 3.3:1）。一覧キャプション（`provenance · N agents · N rounds`）・脚注・アンビエントなラベル（`DEMO中` など）に使う、§1 の「静謐・観察」を体現する控えめなティアで、上の 4.5:1 要件の対象外とする意図的な判断。これにより § 2.2（`--muted` をメタ情報・脚注に割り当て）と本節の整合を取る。判読が要る情報をこのティアに置かないこと（その場合は上の L3 プリセットへ）
 - DL 進捗は `role="status" aria-live="polite"` / SwiftUI は `.accessibilityAddTraits(.updatesFrequently)`
 - アバター・犬マークは `aria-hidden="true"` / `.accessibilityHidden(true)`（飾りだから）
 - タップ領域は 44pt 未満の要素（THINKING トグル等）でも 44pt 確保。SwiftUI では `.padding(.vertical, N).contentShape(Rectangle()).onTapGesture{...}.padding(.vertical, -N)` の **negative-padding トリック**で、視覚上のサイズを変えずヒット判定だけ拡張する（`.contentShape(Rectangle())` 単独では view 自身の bounds までしか広がらない）

--- a/docs/design/ui-refine/ledger.md
+++ b/docs/design/ui-refine/ledger.md
@@ -35,4 +35,6 @@ row's idea (any status), it is a duplicate and must be dropped.
 
 | id | date | lens | screen | proposal | status | note |
 |----|------|------|--------|----------|--------|------|
-| _(empty — first run starts at UR-001)_ | | | | | | |
+| UR-001 | 2026-06-24 | L3 | 05-gallery-detail | GalleryScenarioDetail nav title `.inline`→`.large` per § 5.11 | done | Fixed: added `.navigationBarTitleDisplayMode(.large)`; § 5.11 prose reconciled (table already correct). |
+| UR-002 | 2026-06-24 | L1 | 01-home | List caption `--muted` ≈3.3:1 below § 8 4.5:1 | done | Resolved via § 8 carve-out: `--muted` quietude tier intentionally sub-AA for §1 voice; no code change (user kept muted over darkening). |
+| UR-003 | 2026-06-24 | L5 | 07-results | `"%lld records"` not plural-aware (renders "1 records") | proposed | Split to a follow-up PR: catalog's first plural entry — needs count-aware callsite + xcstringstool-sync verification + a new i18n.md plural rule. n=0 falls to `other` (en CLDR). |


### PR DESCRIPTION
## Summary
Fixes from the `ui-refine` generator's first lens rotation (2026-06-24):

- **UR-001 (L3)** — `GalleryScenarioDetailView` set no title display mode, so it inherited `.inline` from the `.inline` Search tab root; design-system § 5.11 specifies `.large` (scenario name is a proper-noun title, parity with `ScenarioDetailView`). Added `.navigationBarTitleDisplayMode(.large)` and reconciled § 5.11's prose (the table already listed it correctly — the code was the outlier).
- **UR-002 (L1)** — `--muted` (#8A8A83 ≈3.3:1) is below § 8's flat "meta ≥4.5:1", contradicting § 2.2 (muted = meta/footnotes). Resolved doc-only: § 8 now documents the `--muted` quietude tier as intentionally sub-AA for the §1 voice (legibility-critical meta uses the §2.4 L3 presets ≈8:1). No code/token change — kept the muted caption rather than darken it (darkening read as too heavy).
- **ledger** — authored UR-001/002/003 rows in `docs/design/ui-refine/ledger.md` so future runs dedup against them.

**UR-003** ("%lld records" plural) is split to a follow-up PR — it's the catalog's first plural entry, needing a count-aware callsite + `xcstringstool sync` verification + a new i18n.md rule (out of scope for this quick PR).

## Test plan
- UR-001: pre-commit build passed (nav-map self-test 17/17, map unchanged). The modifier is orthogonal to back-button/toolbar (navigation.md); per ADR-009 a view-display-mode modifier isn't unit-tested (consistent with ScenarioDetailView).
- **Visual QA (device)**: confirm a long curated gallery scenario title wraps acceptably at `.large` (critic flagged large-mode wrapping).
- UR-002 / ledger: doc-only.
- Plan reviewed by `critic` (no Critical; 4 Warnings addressed, UR-003 split out); diff reviewed by Opus `code-reviewer` (PASS, 1 suggestion applied).

Closes #800

🤖 Generated with [Claude Code](https://claude.com/claude-code)