### PR TITLE
✨ feat: editor auto-injects canonical output fields per phase type

### DIFF
--- a/Pastura/Pastura/App/EditablePhase.swift
+++ b/Pastura/Pastura/App/EditablePhase.swift
@@ -112,6 +112,51 @@ struct EditablePhase: Identifiable, Sendable {
     // If not found in either branch, no-op.
   }
 
+  /// Reconciles `outputFields` to the canonical schema for the current
+  /// `type`, so the visual editor defaults authors onto the
+  /// ``ScenarioConventions`` convention — a phase no longer silently ships
+  /// without its `inner_thought` thought bubble (the #799 authoring gap).
+  ///
+  /// This is an editor **default**, not a validation requirement:
+  /// `inner_thought` stays optional by design (#760), and an author may still
+  /// delete a seeded field afterwards.
+  ///
+  /// Pass `oldType` = the phase type before this change (`nil` when seeding a
+  /// brand-new phase). Behavior:
+  /// - Adds the current type's canonical primary + thought field if absent.
+  /// - Removes a field only when it was `oldType`'s canonical primary/thought
+  ///   **and** is not canonical for the new type — so `speak→vote` drops
+  ///   `statement`/`inner_thought` and adds `vote`/`reason`, while
+  ///   `speak→choose` keeps the shared `inner_thought`.
+  /// - Preserves every non-canonical (author-added) field. Removed canonical
+  ///   keys carry only the `"string"` type-hint value, never author content,
+  ///   so the swap discards nothing meaningful.
+  /// - Idempotent: re-applying the same type is a no-op.
+  /// - Code phases (``ScenarioConventions`` returns `nil`) add nothing and, on
+  ///   switching in, drop the prior LLM type's canonical fields.
+  mutating func reconcileCanonicalOutputFields(from oldType: PhaseType?) {
+    let newCanonical = canonicalFieldNames(for: type)
+    if let oldType {
+      // Drop the previous type's canonical fields that no longer apply.
+      for key in canonicalFieldNames(for: oldType) where !newCanonical.contains(key) {
+        outputFields.removeValue(forKey: key)
+      }
+    }
+    // Seed the current type's canonical fields, leaving custom fields intact.
+    for field in newCanonical where outputFields[field] == nil {
+      outputFields[field] = "string"
+    }
+  }
+
+  /// The canonical primary + thought output field names for `type`
+  /// (empty for code phases that emit no LLM output).
+  private func canonicalFieldNames(for type: PhaseType) -> [String] {
+    [
+      ScenarioConventions.primaryField(for: type),
+      ScenarioConventions.thoughtField(for: type)
+    ].compactMap { $0 }
+  }
+
   func toPhase() -> Phase {
     let trimmedTarget = target.trimmingCharacters(in: .whitespacesAndNewlines)
     let trimmedCondition = condition.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Pastura/Pastura/Views/Editor/PhaseEditorSheet.swift
+++ b/Pastura/Pastura/Views/Editor/PhaseEditorSheet.swift
@@ -66,6 +66,24 @@ struct PhaseEditorSheet: View {
       }
       .navigationTitle(String(localized: "Edit Phase"))
       .navigationBarTitleDisplayMode(.inline)
+      .onAppear {
+        // Seed canonical output fields for a brand-new phase — `.onChange`
+        // below does not fire for the Picker's initial selection. Empty ==
+        // fresh: an existing LLM phase always carries its primary field
+        // (commit-time `ScenarioValidator`), and a code phase stays empty
+        // (canonical fields are nil). So an existing primary-only phase is
+        // NOT auto-backfilled with `inner_thought` on open — it stays
+        // optional (#760); only authoring a new phase or changing type seeds.
+        if phase.outputFields.isEmpty {
+          phase.reconcileCanonicalOutputFields(from: nil)
+        }
+      }
+      .onChange(of: phase.type) { oldType, _ in
+        // Swap the canonical fields to the new type, preserving custom fields
+        // (#802). Drives authors onto the convention so a phase doesn't ship
+        // without its `inner_thought` thought bubble (the #799 gap).
+        phase.reconcileCanonicalOutputFields(from: oldType)
+      }
       .toolbar {
         ToolbarItem(placement: .cancellationAction) {
           Button(String(localized: "Cancel")) { dismiss() }

--- a/Pastura/PasturaTests/App/EditablePhaseTests.swift
+++ b/Pastura/PasturaTests/App/EditablePhaseTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+/// Covers `EditablePhase.reconcileCanonicalOutputFields(from:)` — the editor
+/// authoring default that seeds / swaps canonical output fields per phase
+/// type (#802). `inner_thought` stays OPTIONAL by design (#760); these tests
+/// pin the editor default behavior, not a validation requirement.
+@Suite(.timeLimit(.minutes(1)))
+@MainActor
+struct EditablePhaseTests {
+
+  // MARK: - Seeding a brand-new phase (oldType == nil)
+
+  @Test func seedSpeakAllAddsStatementAndInnerThought() {
+    var sut = EditablePhase(type: .speakAll)
+    sut.reconcileCanonicalOutputFields(from: nil)
+    #expect(sut.outputFields == ["statement": "string", "inner_thought": "string"])
+  }
+
+  @Test func seedSpeakEachAddsStatementAndInnerThought() {
+    var sut = EditablePhase(type: .speakEach)
+    sut.reconcileCanonicalOutputFields(from: nil)
+    #expect(sut.outputFields == ["statement": "string", "inner_thought": "string"])
+  }
+
+  @Test func seedVoteAddsVoteAndReason() {
+    var sut = EditablePhase(type: .vote)
+    sut.reconcileCanonicalOutputFields(from: nil)
+    #expect(sut.outputFields == ["vote": "string", "reason": "string"])
+  }
+
+  @Test func seedChooseAddsActionAndInnerThought() {
+    var sut = EditablePhase(type: .choose)
+    sut.reconcileCanonicalOutputFields(from: nil)
+    #expect(sut.outputFields == ["action": "string", "inner_thought": "string"])
+  }
+
+  @Test func seedCodePhaseAddsNothing() {
+    for type in [PhaseType.scoreCalc, .assign, .eliminate, .summarize, .conditional, .eventInject] {
+      var sut = EditablePhase(type: type)
+      sut.reconcileCanonicalOutputFields(from: nil)
+      #expect(sut.outputFields.isEmpty, "code phase \(type.rawValue) should seed no output fields")
+    }
+  }
+
+  // MARK: - Type swap
+
+  @Test func swapSpeakToVoteSwapsCanonicalFields() {
+    var sut = EditablePhase(
+      type: .vote, outputFields: ["statement": "string", "inner_thought": "string"])
+    sut.reconcileCanonicalOutputFields(from: .speakAll)
+    #expect(sut.outputFields == ["vote": "string", "reason": "string"])
+  }
+
+  @Test func swapSpeakToChooseKeepsSharedInnerThought() {
+    // inner_thought is canonical for both speak and choose, so it survives;
+    // statement (speak primary) is dropped, action (choose primary) added.
+    var sut = EditablePhase(
+      type: .choose, outputFields: ["statement": "string", "inner_thought": "string"])
+    sut.reconcileCanonicalOutputFields(from: .speakAll)
+    #expect(sut.outputFields == ["action": "string", "inner_thought": "string"])
+  }
+
+  @Test func swapIntoCodePhaseRemovesCanonicalFields() {
+    var sut = EditablePhase(
+      type: .scoreCalc, outputFields: ["statement": "string", "inner_thought": "string"])
+    sut.reconcileCanonicalOutputFields(from: .speakAll)
+    #expect(sut.outputFields.isEmpty)
+  }
+
+  // MARK: - Custom-field preservation
+
+  @Test func swapPreservesCustomFields() {
+    var sut = EditablePhase(
+      type: .vote,
+      outputFields: ["statement": "string", "inner_thought": "string", "mood": "string"])
+    sut.reconcileCanonicalOutputFields(from: .speakAll)
+    #expect(sut.outputFields == ["vote": "string", "reason": "string", "mood": "string"])
+  }
+
+  @Test func customValueOnCanonicalKeyIsDiscardedOnSwap() {
+    // outputFields values are type-hints, never author content, so dropping a
+    // stale canonical key on type-swap discards nothing meaningful (documented
+    // intended behavior — Step 1b critic).
+    var sut = EditablePhase(
+      type: .vote, outputFields: ["statement": "customtype", "inner_thought": "string"])
+    sut.reconcileCanonicalOutputFields(from: .speakAll)
+    #expect(sut.outputFields["statement"] == nil)
+    #expect(sut.outputFields == ["vote": "string", "reason": "string"])
+  }
+
+  // MARK: - Idempotency
+
+  @Test func reapplyingSameTypeIsNoOp() {
+    var sut = EditablePhase(
+      type: .speakAll, outputFields: ["statement": "string", "inner_thought": "string"])
+    sut.reconcileCanonicalOutputFields(from: .speakAll)
+    #expect(sut.outputFields == ["statement": "string", "inner_thought": "string"])
+  }
+
+  @Test func seedThenImmediateSwapHasNoOrphanedFields() {
+    // Mirrors the editor flow: onAppear seeds a fresh speak phase, then the
+    // user immediately picks vote — onChange fires with the seeded type as old.
+    var sut = EditablePhase(type: .speakAll)
+    sut.reconcileCanonicalOutputFields(from: nil)
+    sut.type = .vote
+    sut.reconcileCanonicalOutputFields(from: .speakAll)
+    #expect(sut.outputFields == ["vote": "string", "reason": "string"])
+  }
+
+  // MARK: - Nested sub-phase parity (the recursive seed path is per-instance)
+
+  @Test func seedWorksOnPhaseUsedAsSubPhase() {
+    // A nested sub-phase is just another EditablePhase; the editor seeds it via
+    // the same per-instance call, so reconcile must behave identically.
+    var subPhase = EditablePhase(type: .speakAll)
+    subPhase.reconcileCanonicalOutputFields(from: nil)
+    let parent = EditablePhase(type: .conditional, thenPhases: [subPhase])
+    #expect(
+      parent.thenPhases.first?.outputFields == ["statement": "string", "inner_thought": "string"])
+  }
+}


### PR DESCRIPTION
## Summary
- When a phase type is selected or changed in the scenario editor (`PhaseEditorSheet`), canonical output fields are now auto-injected per `ScenarioConventions`: `speak_all`/`speak_each` → `statement` + `inner_thought`; `choose` → `action` + `inner_thought`; `vote` → `vote` + `reason`; code phases → none.
- Prevents authors from accidentally omitting `inner_thought` — the gap behind #799, where the hapning_ranyu demo had no thought bubbles because its preset omitted `inner_thought` from `speak_all` output.
- `inner_thought` stays **OPTIONAL by design** (#760) — this is an editor default, not a hard validation requirement. Existing primary-only phases are NOT backfilled on open; only new authoring / type changes seed.

## Implementation
- `EditablePhase.reconcileCanonicalOutputFields(from:)` — pure mutating method. Swap semantics: adds the new type's canonical primary + thought field, removes only the old type's canonical fields that are no longer canonical, preserves all custom fields, idempotent.
- `PhaseEditorSheet`: `.onAppear` seeds a brand-new phase (when `outputFields` empty), `.onChange(of: phase.type)` swaps on type change.

## Test plan
- 13 unit tests in `EditablePhaseTests` (seed per type / swap / custom-field preservation / idempotency / seed-then-swap / nested sub-phase / code-phase no-op).
- Full unit suite: **2303 tests passed**; `swiftlint --strict` clean.
- Scenario-editor funnel invariant intact (`buildScenario()` count = 3); change is purely in the `@State phase` visual layer.

Closes #802

🤖 Generated with [Claude Code](https://claude.com/claude-code)