### PR TITLE
✨ feat: refine ui-refine skill — L4 motion input + compliance gaps

### DIFF
--- a/.claude/skills/ui-refine/SKILL.md
+++ b/.claude/skills/ui-refine/SKILL.md
@@ -77,10 +77,22 @@ file to triage-guardian's "keep in sync" set.
    `docs/design/ui-refine/` both exist).
 3. Confirm `docs/design/design-system.md` and `docs/design/ui-refine/ledger.md`
    exist (the anchor source and the dedup memory).
+4. Resolve the lens id early (the `lens:` arg, else `date +%u`) — Step 1's
+   capture path branches on it. If it resolves to **L4**, also require `ffmpeg`
+   (`brew install ffmpeg`): L4 captures motion via `scripts/motion-capture.sh`
+   instead of `ui-tour.sh` (Step 1). Full anchor resolution still happens in
+   Step 2; this is only the id needed to pick the capture path.
 
 If any check fails, **abort the cycle** — do not proceed against a partial setup.
 
-## Step 1 — Capture the current UI
+## Step 1 — Capture the current UI (lens-aware)
+
+The capture path branches on the lens id resolved in Step 0. **On any capture
+failure or timeout, ABORT the cycle** (both paths) — never critique against
+stale or missing artifacts; an empty / stale set produces hallucinated, flood-y
+proposals, defeating the anti-flood goal. Report the failure and stop.
+
+### Default lenses (L1–L3, L5–L7) — static screenshots
 
 Run the tour to refresh the screenshots:
 
@@ -91,15 +103,42 @@ scripts/ui-tour.sh
 This runs `ScreenshotTourTests` on the UDID-pinned simulator and writes the 8
 fixture-driven PNGs to `docs/design/screenshots/` (takes several minutes incl.
 the build; subject to the concurrent-session simulator gate per
-`.claude/rules/xcodebuild-cli.md`).
+`.claude/rules/xcodebuild-cli.md`). After it succeeds, confirm the expected PNGs
+are present and freshly written (`docs/design/screenshots/*.png`). The covered
+screens are listed in `docs/design/screenshots/README.md`.
 
-**On any ui-tour failure or timeout, ABORT the cycle.** Never critique against
-stale or missing screenshots — an empty / stale set produces hallucinated,
-flood-y proposals, defeating the anti-flood goal. Report the failure and stop.
+### L4 (Motion & feedback) — motion filmstrips
 
-After it succeeds, confirm the expected PNGs are present and freshly written
-(`docs/design/screenshots/*.png`). The covered screens are listed in
-`docs/design/screenshots/README.md`.
+Motion is a *time axis* a single screenshot can't show, so L4 captures
+filmstrips **instead of** static PNGs. Run `motion-capture.sh` (never alongside
+`ui-tour.sh` — see the concurrency invariant):
+
+```sh
+scripts/motion-capture.sh all   # launch variants: cold / warm / reduce-motion
+```
+
+This writes per-frame images + a tiled filmstrip under
+`docs/design/motion/<variant>/` (requires `ffmpeg`; takes a few minutes incl.
+the build). `all` covers the launch-animation surfaces (§ 6 transitions). The
+`demo` typing variant (`scripts/motion-capture.sh demo`, DL-time demo replay) is
+available when explicitly reviewing that surface, but is **not** part of the
+default L4 capture. After it succeeds, confirm fresh frames are present under
+`docs/design/motion/<variant>/frames/`.
+
+**Concurrency invariant — never run `motion-capture.sh` and `ui-tour.sh` (or
+`xcodebuild test`) against the same simulator at once.** motion-capture mutates
+the sim's Reduce Motion setting and holds a video recorder, and the
+`sim-dest.sh` gate only sees `xcodebuild test`, not `simctl io`
+(`docs/design/motion/README.md` § "Don't run concurrently"). The L4 branch runs
+motion-capture **exclusively** — it does not also run ui-tour.
+
+**Coverage bound:** L4's § 5.5 DL-Progress-Dots and § 2.7 Interactive-States
+anchors are currently **uncapturable** — `--ui-test` bypasses the download flow
+and there is no interaction driver (`docs/design/motion/README.md` § Deferred).
+Until launch-arg seeding lands (README § "Known coverage limitations"), L4's
+motion critique is bounded to the launch (and explicit `demo`-typing) surfaces;
+do not hallucinate DL-dot / pressed-state findings from frames that don't show
+them.
 
 ## Step 2 — Pick today's lens
 
@@ -114,10 +153,11 @@ those are the principles a proposal under this lens must cite.
 
 ## Step 3 — Generate quota-capped proposals
 
-Read the relevant screenshots with vision (all 8, or the `screen:` arg subset),
-read the lens's anchor sections in `docs/design/design-system.md`, then generate
-candidates **strictly through today's lens** — do not drift into other lenses'
-concerns.
+Read the relevant capture artifacts with vision — the static screenshots (all 8,
+or the `screen:` arg subset) for default lenses, or the motion filmstrip frames
+under `docs/design/motion/<variant>/` for **L4** — read the lens's anchor
+sections in `docs/design/design-system.md`, then generate candidates **strictly
+through today's lens** — do not drift into other lenses' concerns.
 
 - **Quota: at most 1–2 candidates.** Force ranking: "if you could change one
   thing under this lens, what and why." Quality via scarcity.

--- a/.claude/skills/ui-refine/SKILL.md
+++ b/.claude/skills/ui-refine/SKILL.md
@@ -173,8 +173,21 @@ unless it survives every test:
 
 - **Already by-design?** Does design-system.md or a `.claude/rules/` entry
   already prescribe the current behaviour deliberately?
-- **Already covered?** Does the design system already address this (so it's a
-  compliance gap to fix in code, not a *design* proposal)?
+- **Already covered — followed or violated?** Does the design system already
+  address this? Split on what the screen *actually does* — this test has two
+  opposite outcomes, and collapsing them is the bug that suppresses the
+  best findings:
+  - **Correctly follows the convention → drop.** Re-stating that a convention
+    exists, when the UI already obeys it, is noise.
+  - **Violates the convention → keep it as a *compliance gap*.** A verified
+    divergence from a spec-determined value is the highest-value,
+    highest-confidence finding — not a design proposal, but never a drop. (The
+    dogfood's UR-001 § 5.11 violation is exactly this; the literal "already
+    covered → drop" test would have suppressed it.) Route it to the
+    **compliance-gap bucket** (Step 6). It MUST cite the *specific* violated
+    anchor **and** the observed-vs-prescribed delta (the same before → after
+    rigor Step 3 demands) — a compliance gap that can't show the delta is a
+    re-derivation in disguise; drop it.
 - **Subjective preference?** Is this taste rather than a principle-grounded
   improvement?
 - **Out of scope?** Is it a Phase 3 feature? Check `docs/ROADMAP.md`
@@ -185,7 +198,9 @@ unless it survives every test:
   plausibly have already weighed and declined it, drop it (or note the
   counter-evidence honestly).
 
-Only survivors proceed.
+Only survivors proceed — *design proposals* and *compliance gaps* alike. Carry
+each survivor's **kind** (`design-proposal` | `compliance-gap`) forward to
+Steps 5–6.
 
 ## Step 5 — Dedup against the ledger
 
@@ -199,13 +214,25 @@ proposals this run" and append nothing.
 ## Step 6 — Write the digest + append the ledger
 
 1. **Digest** — write `docs/design/ui-refine/digests/YYYY-MM-DD-L<n>-<slug>.md`
-   (date from `date +%F`). Rank the survivors. For each: title, screen(s),
-   design-system anchor, before → after, **confidence**, and a
-   **counter-evidence** line (Output Contract rule 2). If there are no survivors,
-   record that explicitly.
-2. **Ledger** — append one row per surviving proposal to `ledger.md` with the
-   next `UR-NNN` id, today's date, the lens, the screen, a one-line concept
-   summary, status `proposed`, and the rationale in `note`. Keep ids ordered
+   (date from `date +%F`). Rank the survivors, grouped into two labeled sections
+   by kind (Step 4):
+   - **Compliance gaps** (spec violations — fix in code) — each cites the
+     violated anchor + the observed-vs-prescribed delta; its counter-evidence
+     line reframes to "maybe the convention itself is wrong / maybe this is an
+     intentional carve-out" (cf. UR-002, a real § 8 contrast finding that
+     resolved *as* an intentional carve-out — a violation candidate is not
+     automatically a defect).
+   - **Design proposals** (judgment) — each carries the design-system anchor,
+     a concrete before → after, **confidence**, and a **counter-evidence** line
+     (Output Contract rule 2).
+   Omit a section that is empty; if there are no survivors at all, record that
+   explicitly.
+2. **Ledger** — append one row per survivor to `ledger.md` with the next
+   `UR-NNN` id, today's date, the lens, the screen, a one-line concept summary,
+   status `proposed`, and the rationale in `note`. **Pin the kind in the row:** a
+   compliance gap prefixes its `note` with `[compliance-gap]` (a design proposal
+   needs no prefix), so the kind is visible to dedup (Step 5) and human triage —
+   a digest-only kind would bypass the linchpin dedup memory. Keep ids ordered
    (newest last). **Do not commit or push** — leave the change in the working
    tree for the human (Safety boundary).
 3. Report to the user: the digest path, the lens used, how many candidates were

--- a/.claude/skills/ui-refine/SKILL.md
+++ b/.claude/skills/ui-refine/SKILL.md
@@ -122,7 +122,10 @@ This writes per-frame images + a tiled filmstrip under
 the build). `all` covers the launch-animation surfaces (§ 6 transitions). The
 `demo` typing variant (`scripts/motion-capture.sh demo`, DL-time demo replay) is
 available when explicitly reviewing that surface, but is **not** part of the
-default L4 capture. After it succeeds, confirm fresh frames are present under
+default L4 capture. The `screen:` arg has **no effect under L4** — motion
+artifacts are variant-indexed (`cold` / `warm` / `reduce-motion` / `demo`), not
+tour-screen-indexed; variant selection beyond the `all` default is out of scope.
+After it succeeds, confirm fresh frames are present under
 `docs/design/motion/<variant>/frames/`.
 
 **Concurrency invariant — never run `motion-capture.sh` and `ui-tour.sh` (or
@@ -159,8 +162,11 @@ under `docs/design/motion/<variant>/` for **L4** — read the lens's anchor
 sections in `docs/design/design-system.md`, then generate candidates **strictly
 through today's lens** — do not drift into other lenses' concerns.
 
-- **Quota: at most 1–2 candidates.** Force ranking: "if you could change one
-  thing under this lens, what and why." Quality via scarcity.
+- **Quota: at most 1–2 candidates — per run, total across both kinds**
+  (design proposals + compliance gaps), **not per bucket.** The two-section
+  digest (Step 6) groups survivors by kind; it does not raise the ceiling. Force
+  ranking: "if you could change one thing under this lens, what and why." Quality
+  via scarcity.
 - **Every candidate must carry:** the design-system anchor (or named HIG / WCAG
   guideline) it advances, the screen(s) it concerns, and a concrete
   **before → after** — not a vague "make it nicer." A candidate that can't name

--- a/docs/design/ui-refine/README.md
+++ b/docs/design/ui-refine/README.md
@@ -41,9 +41,13 @@ resource the whole brush-up family is built to protect:
    guideline) it advances, plus a concrete before → after. Vague "make it nicer"
    is rejected before it reaches the digest.
 5. **Adversarial self-filter** — a second pass tries to *reject* each candidate
-   (already by-design? design-system already covers it? subjective preference?
-   out of scope per the ROADMAP? would a maintainer say "considered, no"?). Only
-   survivors reach the digest.
+   (already by-design? subjective preference? out of scope per the ROADMAP?
+   would a maintainer say "considered, no"?). The "already covered" test splits
+   on what the UI *actually does*: a screen that **correctly follows** the
+   convention is noise → drop; a screen that **violates** a spec-determined value
+   is the highest-value finding → keep it as a **compliance gap** (a code-fix,
+   surfaced separately from judgment-based *design proposals*). Only survivors
+   reach the digest.
 
 This inherits the brush-up family's shared **Output Contract** (canonical text:
 [`.claude/skills/consistency-audit/SKILL.md`](../../../.claude/skills/consistency-audit/SKILL.md)

--- a/docs/design/ui-refine/README.md
+++ b/docs/design/ui-refine/README.md
@@ -84,6 +84,27 @@ journal. Pin this constraint before any Routine is wired up.
 4. Commit the `ledger.md` change (and only that) alongside whatever issue/PR work
    the promotion triggered.
 
+## Known coverage limitations
+
+The capture step (`scripts/ui-tour.sh`) renders the app under `--ui-test`, which
+seeds **populated** fixtures only — it surfaces no genuinely empty (zero
+scenarios / zero results / no-search-match) or error (gallery offline / load
+failure) state. That caps the **L5** (empty / error / edge) and **L6** (copy —
+the on-screen text *is* the UITest fixture) lenses: they can only critique the
+populated surfaces the tour happens to render. The motion path inherits a
+parallel gap — § 5.5 DL-Progress-Dots (motion timing in § 6) and the
+bubble-entrance animation are unreachable under `--ui-test`
+(`../motion/README.md` § Deferred).
+
+The real fix is a launch-argument path that seeds empty / error states into the
+tour (and a canned-response queue for the live-simulation surfaces) —
+app + `ScreenshotTourTests` work, **out of scope for the markdown-only skill
+iteration** and tracked as a separate follow-up. Until it lands, treat L5/L6
+(and L4's DL-dot / interactive-state anchors) as coverage-bounded: do not infer
+empty / error findings from fixtures that never show those states. This note is
+the durable home for the signal — the per-run digests that first recorded it are
+gitignored.
+
 ## Deferred next phases (NOT in this prototype)
 
 This prototype stops at "run by hand → produce a digest → human triages." Later,

--- a/docs/design/ui-refine/ledger.md
+++ b/docs/design/ui-refine/ledger.md
@@ -29,12 +29,21 @@ A new run appends rows with status `proposed`. The human later edits the
 *concept*, not the exact string** — if a new candidate restates an existing
 row's idea (any status), it is a duplicate and must be dropped.
 
+**Finding kind (orthogonal to `status`).** A survivor is either a *design
+proposal* (judgment) or a *compliance gap* — a verified divergence from a
+spec-determined value (SKILL § Step 4). Kind is **not** a `status` value:
+`status` is the lifecycle (`proposed`→`filed`→`done`), and a compliance gap
+moves through it like any other finding. Record the kind in the row by prefixing
+its `note` with `[compliance-gap]` (a design proposal needs no prefix), so the
+kind stays visible to dedup and human triage instead of living only in the
+gitignored digest.
+
 ## Ledger
 
 <!-- Append below. Keep newest-last so ids stay ordered. -->
 
 | id | date | lens | screen | proposal | status | note |
 |----|------|------|--------|----------|--------|------|
-| UR-001 | 2026-06-24 | L3 | 05-gallery-detail | GalleryScenarioDetail nav title `.inline`→`.large` per § 5.11 | done | Fixed: added `.navigationBarTitleDisplayMode(.large)`; § 5.11 prose reconciled (table already correct). |
+| UR-001 | 2026-06-24 | L3 | 05-gallery-detail | GalleryScenarioDetail nav title `.inline`→`.large` per § 5.11 | done | [compliance-gap] Fixed: added `.navigationBarTitleDisplayMode(.large)`; § 5.11 prose reconciled (table already correct). |
 | UR-002 | 2026-06-24 | L1 | 01-home | List caption `--muted` ≈3.3:1 below § 8 4.5:1 | done | Resolved via § 8 carve-out: `--muted` quietude tier intentionally sub-AA for §1 voice; no code change (user kept muted over darkening). |
-| UR-003 | 2026-06-24 | L5 | 07-results | `"%lld records"` not plural-aware (renders "1 records") | proposed | Split to a follow-up PR: catalog's first plural entry — needs count-aware callsite + xcstringstool-sync verification + a new i18n.md plural rule. n=0 falls to `other` (en CLDR). |
+| UR-003 | 2026-06-24 | L5 | 07-results | `"%lld records"` not plural-aware (renders "1 records") | proposed | [compliance-gap] Split to a follow-up PR: catalog's first plural entry — needs count-aware callsite + xcstringstool-sync verification + a new i18n.md plural rule. n=0 falls to `other` (en CLDR). |

--- a/docs/design/ui-refine/lenses.md
+++ b/docs/design/ui-refine/lenses.md
@@ -60,6 +60,11 @@ Transitions, loading/progress affordances, state-change feedback, perceived
 latency. Ask: does the UI acknowledge every user action and every wait?
 - Anchors: § 6 モーション / アニメーション; § 2.7 Interactive States;
   § 5.5 DL Progress Dots.
+- **Input:** unlike the other lenses, an L4 run critiques motion *filmstrips*
+  from `scripts/motion-capture.sh` (launch variants), not the static
+  `ui-tour.sh` PNGs — motion needs a time axis (SKILL § Step 1). § 5.5
+  DL-Progress-Dots and § 2.7 Interactive-States are currently uncapturable under
+  `--ui-test` (`docs/design/motion/README.md` § Deferred).
 
 ### L5 — Empty / error / edge states
 First-run/empty inventory, error and failure surfaces, long-content overflow,

--- a/docs/design/ui-refine/lenses.md
+++ b/docs/design/ui-refine/lenses.md
@@ -91,3 +91,7 @@ If the catalog ever changes count, the weekday mapping breaks its 1:1 property �
 re-derive the selection rule (and update the table above) so it stays total and
 in-range for all of `date +%u` 1…7. Keeping it exactly seven is the simplest
 invariant.
+
+If **Motion** ever moves off **L4**, also update the capture-branch literals in
+`SKILL.md` Step 0/1/3 — the L4-only `motion-capture.sh` path keys off that
+number (the rest of the lenses share the static `ui-tour.sh` path).


### PR DESCRIPTION
## Summary

Refines the `ui-refine` skill itself, fixing 3 self-improvement signals from the
first full-rotation dogfood (2026-06-24). Markdown-only — skill body + its docs;
no `Pastura/` source touched.

- **S1 — L4 lens critiques motion, not static frames.** The L4 "Motion &
  feedback" lens was wired to `ui-tour.sh` static PNGs, which can't show a time
  axis, so it structurally surfaced nothing. On an L4 run the skill now resolves
  the lens id early (Step 0) and drives `scripts/motion-capture.sh` filmstrips
  **exclusively instead of** `ui-tour.sh` — with the motion-capture/ui-tour
  concurrency invariant stated inline, the `all` launch variant as the default
  (with `demo` available on request), and a coverage bound noting § 5.5 DL-dots /
  § 2.7 interactive-states stay uncapturable under `--ui-test`.
- **S2 — spec violations route to a compliance-gap bucket.** Step 4's "already
  covered → drop" test, read literally, suppressed genuine spec *violations* —
  the highest-value, highest-confidence findings (UR-001 was exactly a § 5.11
  violation it would have dropped). Split it: a *correctly-followed* convention
  is noise (drop); a *violation* routes to a distinct compliance-gap bucket that
  must cite the violated anchor + observed-vs-prescribed delta. The kind is
  pinned to the ledger row via a `[compliance-gap]` `note` prefix (orthogonal to
  the lifecycle `status`) so it stays visible to the dedup linchpin.
- **S3 — fixture-coverage limitation tracked (note only).** Tour fixtures seed
  populated states only, capping L5/L6. The real fix (launch-arg +
  `ScreenshotTourTests` seeding) is app + UITest work, deferred to a separate
  PR; this PR adds a tracked README note so the signal — first logged in the
  gitignored per-run digests — has a durable home.

## Test plan

- Markdown-only; no automated tests apply.
- Verified: `critic` pre-impl review (no Critical; 2 S1 warnings + 2 S2 tighten
  points all addressed in the diff) and an Opus `code-reviewer` pass (**PASS**,
  0 critical / 0 warning).
- Cross-doc references checked to resolve (`motion/README.md` §§ "Don't run
  concurrently" / "Deferred"; new README § "Known coverage limitations";
  design-system §§ 2.7 / 5.5 / 5.11 / 6).
- The live L4 motion-capture path (needs `ffmpeg` + simulator) is not exercised
  here — it is validated on the next real L4 run, consistent with the skill's
  manual-first precision checkpoint.

Closes #806.
