### PR TITLE
✨ feat: scenario-factory novelty census — steer off gallery monoculture

### DIFF
--- a/.claude/skills/scenario-factory/SKILL.md
+++ b/.claude/skills/scenario-factory/SKILL.md
@@ -38,7 +38,8 @@ Non-goals:
   place, never committed; bootstrapped by `append_digest.py` if absent)
 - Per-run timeout: `600` seconds (not the harness default 1800 — bounds a
   wedged run at 2 attempts × 600 s)
-- Helper scripts: `.claude/skills/scenario-factory/scripts/`
+- Helper scripts: `.claude/skills/scenario-factory/scripts/` (incl.
+  `gallery_census.py` — the Step 1.5 novelty census)
 
 ## Step 0 — Preflight
 
@@ -69,18 +70,48 @@ later be promoted into (§ Promotion):
 A new scenario that repeats a shipped preset/gallery premise, mechanics, or
 persona cast is a dedup miss even when the digest is clean.
 
+## Step 1.5 — Pick under-represented axes (novelty census)
+
+The gallery has skewed toward a `vote → score_calc → summarize` scoring
+spine (most entries share it) and `category: creative` — without a counter-
+force, every batch piles onto the crowded majority. Steer **toward the gaps**:
+
+```bash
+python3 .claude/skills/scenario-factory/scripts/gallery_census.py
+```
+
+The census is **deterministic and gallery-only** — it counts phase-*type*
+presence (does a scenario contain a `vote` phase at all?), not mechanical
+depth, and ranks 8 structural mechanic axes + the 6 categories by rarity.
+Read its `Suggested targets` block and **assign each of the 3 scenarios a
+DISTINCT under-represented axis** (a mechanic axis, a category, or both),
+avoiding the `crowded` ones. Valid categories: `social_psychology`,
+`game_theory`, `ethics`, `roleplay`, `creative`, `experimental` — the
+zero-entry ones (`game_theory` / `experimental`) are the rarest possible.
+
+Cross-night rotation is an **in-session reasoning step**, not the script:
+scan the digest's recent `axis` column (Step 5) and, if a suggested axis was
+already targeted in the last 1–2 nights but is **not yet promoted** to the
+gallery, rotate to the next gap so the same hole isn't refilled before
+promotion catches up.
+
 ## Step 2 — Generate 3 scenario YAMLs
 
 Write 3 files to `data/factory/scenarios/<DATE>/<id>.yaml` with
 `id: factory_<DATESTAMP>_<slug>` (snake_case slug, also the filename).
 
-Theme: the **oogiri / comedy family** (current factory focus). Use the
-bundled preset `Pastura/Pastura/Resources/Presets/bokete.yaml` as the
-schema and tone reference, but vary the *format*, not just the topics —
-e.g. constrained-form bokete (kigo / counting / forbidden-word rules),
-role-mismatch interviews, deadpan product pitches, escalating excuse
-battles. Each of the 3 scenarios should differ from the other 2 AND from
-digest history in premise or mechanics, not merely in topic strings.
+Theme: **driven by the per-scenario axis from Step 1.5**, not a fixed
+focus. The oogiri / comedy family is a strong default *tone* — use
+`Pastura/Pastura/Resources/Presets/bokete.yaml` as the schema/tone
+reference — but the assigned mechanic axis dictates the *format* (e.g.
+`elimination` → knockout bracket, `branching` → `conditional` divergent
+paths, `reactive_event` → `event_inject`, `scoring_free` → observation /
+discussion with no vote), and an assigned **category** axis may rotate the
+premise out of comedy entirely (a `game_theory` cooperation dilemma, an
+`experimental` social-psych setup à la the original asch/trolley seeds). A
+non-comedy scenario is judged on its own terms — see Step 4. Each of the 3
+must differ from the other 2 AND from digest history in premise or
+mechanics, not merely in topic strings.
 
 Schema requirements (ScenarioLoader — all required):
 
@@ -160,6 +191,15 @@ comment per scenario:
 | (c) breakdown_free | No format breaks, language drift, or nonsense loops | Frequent breakdowns |
 | (d) humor | Genuinely funny lines a human would quote | Flat or incoherent |
 
+**Category-aware (d):** humor is the right axis for a comedy-family
+scenario, but a scenario whose Step 1.5 axis rotated to a non-`creative`
+category (`game_theory` / `experimental` / `social_psychology` / `ethics`)
+should NOT be penalized for not being funny — that would teach the loop to
+avoid the diversity the census requested. For those, score (d) `null` (the
+digest renders `–`) and judge the scenario on (a)–(c) plus whether it
+delivers its category's intended payoff (a real dilemma, a believable
+experiment). Note this in the comment.
+
 Failed runs get **no scores** — record the status and the wrapper's
 `error` (skim the partial transcript only to classify the failure for
 the comment). The judge is a quality filter, not a safety screen.
@@ -167,9 +207,10 @@ the comment). The judge is a quality filter, not a safety screen.
 ## Step 5 — Append the digest
 
 1. Write the results JSON (schema documented in `append_digest.py`'s
-   docstring: date / model / notes / per-scenario id, name, theme, yaml,
-   run_log, status, attempts, duration_sec, scores, comment, error) to a
-   temp file.
+   docstring: date / model / notes / per-scenario id, name, theme, **axis**,
+   yaml, run_log, status, attempts, duration_sec, scores, comment, error) to
+   a temp file. Set `axis` to the Step 1.5 axis this scenario targeted (e.g.
+   `"elimination / creative"`) so cross-night rotation can read it back.
 2. ```bash
    python3 .claude/skills/scenario-factory/scripts/append_digest.py \
      --results /tmp/factory_results_<DATE>.json \

--- a/.claude/skills/scenario-factory/scripts/append_digest.py
+++ b/.claude/skills/scenario-factory/scripts/append_digest.py
@@ -28,6 +28,9 @@ Results JSON schema (composed by the /scenario-factory session):
     {
       "id": "factory_20260613_example",
       "name": "...", "theme": "...",
+      "axis": "branching / roleplay",   // optional: the under-represented
+                                        // gallery axis this scenario targeted
+                                        // (SKILL.md Step 1.5); omitted → em-dash
       "yaml": "data/factory/scenarios/2026-06-13/....yaml",
       "run_log": "data/factory/runs/2026-06-13/....jsonl",
       "status": "ok|failed|config_error",
@@ -88,9 +91,9 @@ def render_section(results):
         f"(ok {counts['ok']} / failed {counts['failed']} / "
         f"config_error {counts['config_error']})",
         "",
-        "| id | name | theme | status | (a) coherence | (b) interaction "
+        "| id | name | theme | axis | status | (a) coherence | (b) interaction "
         "| (c) breakdown-free | (d) humor | comment |",
-        "|---|---|---|---|---|---|---|---|---|",
+        "|---|---|---|---|---|---|---|---|---|---|",
     ]
     for s in scenarios:
         scores = s.get("scores") or {}
@@ -99,7 +102,7 @@ def render_section(results):
             comment = f"{comment} error: {s['error']}".strip()
         row = [
             cell(s.get("id")), cell(s.get("name")), cell(s.get("theme")),
-            cell(s.get("status")),
+            cell(s.get("axis")), cell(s.get("status")),
         ]
         row += [cell(scores.get(k)) for k in RUBRIC_KEYS]
         row.append(cell(comment))

--- a/.claude/skills/scenario-factory/scripts/gallery_census.py
+++ b/.claude/skills/scenario-factory/scripts/gallery_census.py
@@ -25,6 +25,9 @@ import sys
 # scaffolding phases (assign / summarize / speak_all) are deliberately NOT axes
 # — they don't define a scenario's format. List order is the deterministic
 # tie-break for equally-rare axes (a stable sort on count preserves it).
+# NOTE: `scoring_free` is a NEGATION axis — a scenario counts toward it
+# precisely because it lacks vote AND score_calc, so it is anti-correlated
+# with peer_vote/scored by construction (the 8 axes are not all orthogonal).
 AXES = [
     ("peer_vote", lambda p: "vote" in p),
     ("scored", lambda p: "score_calc" in p),
@@ -103,6 +106,9 @@ def main():
         print(line(label, count, n_ax))
 
     # Categories — seed every valid category at 0 so absent ones still rank.
+    # `category` is a non-optional field in the schema, so n_cat == total in
+    # practice; the axis denominator (n_ax) may be smaller because it excludes
+    # phase-less entries — the two fractions are intentionally not comparable.
     cat_counts = {c: 0 for c in VALID_CATEGORIES}
     for s in scenarios:
         cat = s.get("category")
@@ -110,6 +116,13 @@ def main():
             cat_counts[cat] = cat_counts.get(cat, 0) + 1
     n_cat = sum(1 for s in scenarios if s.get("category"))
     cats_by_presence = sorted(cat_counts.items(), key=lambda x: (x[1], x[0]))
+    # Surface enum drift the hardcoded VALID_CATEGORIES can't anticipate, so a
+    # new/typo'd category lands in the overnight log instead of silently
+    # inflating the denominator.
+    unknown = sorted(c for c in cat_counts if c not in VALID_CATEGORIES)
+    if unknown:
+        print("census: WARNING unrecognized categories (GalleryCategory "
+              f"drift?): {', '.join(unknown)}", file=sys.stderr)
 
     print()
     print(f"Category (count / {n_cat}):")

--- a/.claude/skills/scenario-factory/scripts/gallery_census.py
+++ b/.claude/skills/scenario-factory/scripts/gallery_census.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Gallery novelty census — rank under-represented scenario formats & categories.
+
+usage: gallery_census.py [path/to/gallery.json]   (default: docs/gallery/gallery.json)
+
+Reads the shared-scenario gallery and reports, deterministically, which
+STRUCTURAL MECHANIC AXES and CATEGORIES are under-represented, so a
+/scenario-factory cycle steers generation toward the gaps instead of piling
+onto the crowded vote->score_calc majority.
+
+The census measures phase-TYPE presence (does this scenario contain a `vote`
+phase at all?), NOT mechanical depth (vote_tally vs other score_calc logic,
+conditional branch structure). It is gallery-only and fully deterministic —
+cross-night axis rotation is an in-session reasoning step in SKILL.md Step 1.5,
+not handled here.
+
+Exit 0 always (an empty/unreadable gallery prints a notice, never crashes the
+overnight cycle).
+"""
+
+import json
+import sys
+
+# Structural novelty axes: (label, predicate over the phase-type set). The
+# scaffolding phases (assign / summarize / speak_all) are deliberately NOT axes
+# — they don't define a scenario's format. List order is the deterministic
+# tie-break for equally-rare axes (a stable sort on count preserves it).
+AXES = [
+    ("peer_vote", lambda p: "vote" in p),
+    ("scored", lambda p: "score_calc" in p),
+    ("decision", lambda p: "choose" in p),
+    ("elimination", lambda p: "eliminate" in p),
+    ("branching", lambda p: "conditional" in p),
+    ("reactive_event", lambda p: "event_inject" in p),
+    ("sequential_build", lambda p: "speak_each" in p),
+    ("scoring_free", lambda p: "vote" not in p and "score_calc" not in p),
+]
+
+# Valid gallery categories — mirror of GalleryCategory in
+# Pastura/Pastura/Models/GalleryScenario.swift (snake_case raw values). Kept
+# here so the census surfaces ZERO-entry categories (the rarest possible),
+# which never appear as keys in gallery.json. Eyeball on a category enum change.
+VALID_CATEGORIES = [
+    "social_psychology", "game_theory", "ethics",
+    "roleplay", "creative", "experimental",
+]
+
+RARE_FRAC = 0.25
+CROWDED_FRAC = 0.60
+
+
+def flag(count, n):
+    """rare / crowded / "" for a presence count against denominator n."""
+    if n == 0:
+        return ""
+    frac = count / n
+    if frac <= RARE_FRAC:
+        return "rare"
+    if frac >= CROWDED_FRAC:
+        return "crowded"
+    return ""
+
+
+def line(label, count, n):
+    fl = flag(count, n)
+    tag = f"  [{fl}]" if fl else ""
+    return f"  {label:<18} {count:>2}/{n}{tag}"
+
+
+def main():
+    path = sys.argv[1] if len(sys.argv) > 1 else "docs/gallery/gallery.json"
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"gallery_census: cannot read {path}: {exc}", file=sys.stderr)
+        return 0  # never crash the overnight cycle
+
+    scenarios = data.get("scenarios", [])
+    total = len(scenarios)
+    print(f"=== Gallery novelty census ({total} scenario(s)) ===")
+    if total == 0:
+        print("  empty gallery — no targets to suggest.")
+        return 0
+
+    # Structural axes carry a signal only from scenarios with a non-empty
+    # `phases` list. `phases` is [String]? in the schema (nullable for
+    # forward-compat), so missing/null/empty entries are excluded from the axis
+    # denominator rather than miscounted as scoring_free.
+    with_phases = [s for s in scenarios if s.get("phases")]
+    n_ax = len(with_phases)
+    skipped = total - n_ax
+    axis_counts = [
+        (label, sum(1 for s in with_phases if pred(set(s["phases"]))))
+        for label, pred in AXES
+    ]
+    by_presence = sorted(axis_counts, key=lambda x: x[1])  # stable → AXES order on ties
+
+    print()
+    note = f" — {skipped} skipped: no phases" if skipped else ""
+    print(f"Structural axes (presence / {n_ax}){note}:")
+    for label, count in by_presence:
+        print(line(label, count, n_ax))
+
+    # Categories — seed every valid category at 0 so absent ones still rank.
+    cat_counts = {c: 0 for c in VALID_CATEGORIES}
+    for s in scenarios:
+        cat = s.get("category")
+        if cat:
+            cat_counts[cat] = cat_counts.get(cat, 0) + 1
+    n_cat = sum(1 for s in scenarios if s.get("category"))
+    cats_by_presence = sorted(cat_counts.items(), key=lambda x: (x[1], x[0]))
+
+    print()
+    print(f"Category (count / {n_cat}):")
+    for cat, count in cats_by_presence:
+        print(line(cat, count, n_cat))
+
+    # Suggested targets — the rare end; fall back to the 3 rarest if nothing
+    # trips the threshold so a batch always has gap targets to assign.
+    rare_axes = [lab for lab, c in by_presence if flag(c, n_ax) == "rare"]
+    mech_targets = rare_axes or [lab for lab, _ in by_presence[:3]]
+    crowded_axes = [lab for lab, c in by_presence if flag(c, n_ax) == "crowded"]
+    rare_cats = [cat for cat, c in cats_by_presence if flag(c, n_cat) == "rare"]
+    cat_targets = rare_cats or [cat for cat, _ in cats_by_presence[:3]]
+
+    print()
+    print("=== Suggested targets for this batch (favor the rare end) ===")
+    print(f"  mechanic axes: {', '.join(mech_targets) or '(none)'}")
+    print(f"  categories:    {', '.join(cat_targets) or '(none)'}")
+    if crowded_axes:
+        print(f"  avoid piling onto crowded axes: {', '.join(crowded_axes)}")
+    print()
+    print("Assign each of the 3 generated scenarios a DISTINCT axis from the rare end.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/scenario-factory/tests/fixtures/gallery_census_balanced.json
+++ b/.claude/skills/scenario-factory/tests/fixtures/gallery_census_balanced.json
@@ -1,0 +1,30 @@
+{
+  "version": 1,
+  "updated_at": "2026-06-25T00:00:00Z",
+  "scenarios": [
+    {
+      "id": "bal_one_v1",
+      "title": "Balanced one",
+      "category": "creative",
+      "phases": ["vote", "score_calc", "choose", "eliminate"]
+    },
+    {
+      "id": "bal_two_v1",
+      "title": "Balanced two",
+      "category": "ethics",
+      "phases": ["vote", "score_calc", "conditional", "event_inject", "speak_each"]
+    },
+    {
+      "id": "bal_three_v1",
+      "title": "Balanced three",
+      "category": "roleplay",
+      "phases": ["choose", "eliminate", "conditional", "event_inject", "speak_each"]
+    },
+    {
+      "id": "bal_four_v1",
+      "title": "Balanced four",
+      "category": "game_theory",
+      "phases": ["summarize"]
+    }
+  ]
+}

--- a/.claude/skills/scenario-factory/tests/fixtures/gallery_census_sample.json
+++ b/.claude/skills/scenario-factory/tests/fixtures/gallery_census_sample.json
@@ -1,0 +1,36 @@
+{
+  "version": 1,
+  "updated_at": "2026-06-25T00:00:00Z",
+  "scenarios": [
+    {
+      "id": "vote_one_v1",
+      "title": "Vote one",
+      "category": "creative",
+      "phases": ["assign", "speak_all", "vote", "score_calc", "summarize"]
+    },
+    {
+      "id": "vote_two_v1",
+      "title": "Vote two",
+      "category": "creative",
+      "phases": ["assign", "speak_all", "vote", "score_calc", "summarize"]
+    },
+    {
+      "id": "vote_three_v1",
+      "title": "Vote three",
+      "category": "creative",
+      "phases": ["assign", "choose", "vote", "score_calc", "summarize"]
+    },
+    {
+      "id": "branch_one_v1",
+      "title": "Branch one",
+      "category": "roleplay",
+      "phases": ["speak_each", "conditional", "summarize"]
+    },
+    {
+      "id": "no_phases_v1",
+      "title": "No phases",
+      "category": "ethics",
+      "phases": null
+    }
+  ]
+}

--- a/.claude/skills/scenario-factory/tests/fixtures/results_sample.json
+++ b/.claude/skills/scenario-factory/tests/fixtures/results_sample.json
@@ -7,6 +7,7 @@
       "id": "factory_20260613_test_ok",
       "name": "テスト大喜利",
       "theme": "大喜利",
+      "axis": "elimination / creative",
       "yaml": "data/factory/scenarios/2026-06-13/factory_20260613_test_ok.yaml",
       "run_log": "data/factory/runs/2026-06-13/factory_20260613_test_ok.jsonl",
       "status": "ok",

--- a/.claude/skills/scenario-factory/tests/run_tests.sh
+++ b/.claude/skills/scenario-factory/tests/run_tests.sh
@@ -79,4 +79,20 @@ grep -q "factory-digest:promotion" "$TMP/bootstrap.md" || fail "bootstrap: promo
 grep -q "^## 2026-06-13$" "$TMP/bootstrap.md" || fail "bootstrap: section not appended"
 tail -1 "$TMP/bootstrap.md" | grep -q "^Promotion:" || fail "bootstrap: promotion line not last"
 
+# --- gallery_census.py ------------------------------------------------------
+C=$(python3 "$SCRIPTS/gallery_census.py" fixtures/gallery_census_sample.json)
+echo "$C" | grep -q "Suggested targets" || fail "census: suggested-targets section missing"
+# a known-RARE axis (branching, 1/4) must appear in the suggested mechanic line
+echo "$C" | grep "mechanic axes:" | grep -q "branching" || fail "census: rare axis not suggested"
+# a known-CROWDED axis (peer_vote, 3/4) must be flagged crowded
+echo "$C" | grep "peer_vote" | grep -q "crowded" || fail "census: crowded axis not flagged"
+# nullable/absent phases excluded from the axis denominator, reported
+echo "$C" | grep -q "1 skipped: no phases" || fail "census: null-phases row not skipped"
+# zero-entry valid category surfaced as rare (game_theory has no gallery entry)
+echo "$C" | grep "game_theory" | grep -q "rare" || fail "census: zero-count category not rare"
+# empty gallery must not crash the overnight cycle (exit 0, notice printed)
+echo '{"version":1,"scenarios":[]}' > "$TMP/empty.json"
+python3 "$SCRIPTS/gallery_census.py" "$TMP/empty.json" | grep -q "empty gallery" \
+  || fail "census: empty gallery not handled cleanly"
+
 echo "ALL TESTS PASSED"

--- a/.claude/skills/scenario-factory/tests/run_tests.sh
+++ b/.claude/skills/scenario-factory/tests/run_tests.sh
@@ -97,5 +97,13 @@ echo "$C" | grep "game_theory" | grep -q "rare" || fail "census: zero-count cate
 echo '{"version":1,"scenarios":[]}' > "$TMP/empty.json"
 python3 "$SCRIPTS/gallery_census.py" "$TMP/empty.json" | grep -q "empty gallery" \
   || fail "census: empty gallery not handled cleanly"
+# fallback: when no axis trips rare/crowded (all 2/4), still suggest 3 rarest
+F=$(python3 "$SCRIPTS/gallery_census.py" fixtures/gallery_census_balanced.json)
+echo "$F" | grep -q "avoid piling onto crowded" && fail "census: balanced should have no crowded axis"
+echo "$F" | grep "mechanic axes:" | grep -q "peer_vote" || fail "census: fallback rarest-3 targets missing"
+# unrecognized category drift surfaces on stderr (not silently absorbed)
+echo '{"version":1,"scenarios":[{"id":"x","category":"made_up_cat","phases":["vote"]}]}' > "$TMP/drift.json"
+python3 "$SCRIPTS/gallery_census.py" "$TMP/drift.json" 2>"$TMP/drift.err" >/dev/null
+grep -q "unrecognized categories" "$TMP/drift.err" || fail "census: category drift not warned"
 
 echo "ALL TESTS PASSED"

--- a/.claude/skills/scenario-factory/tests/run_tests.sh
+++ b/.claude/skills/scenario-factory/tests/run_tests.sh
@@ -53,6 +53,9 @@ python3 "$SCRIPTS/append_digest.py" \
 grep -q "^## 2026-06-13$" "$TMP/digest.md" || fail "digest: section heading missing"
 grep -q "factory_20260613_test_ok" "$TMP/digest.md" || fail "digest: ok row missing"
 grep -q '設定は一貫、ボケの幅 \\| は狭め' "$TMP/digest.md" || fail "digest: pipe not escaped in comment"
+grep -q 'elimination / creative' "$TMP/digest.md" || fail "digest: axis column not rendered"
+# scenario without an axis renders the em-dash (backward-compat via cell())
+grep -q 'クラッシュ再現 | 大喜利 | – |' "$TMP/digest.md" || fail "digest: missing axis not em-dashed"
 grep -q "factory-digest:promotion" "$TMP/digest.md" || fail "digest: promotion marker lost"
 tail -1 "$TMP/digest.md" | grep -q "^Promotion:" || fail "digest: promotion line no longer last"
 


### PR DESCRIPTION
## Summary

The shared-scenario gallery had drifted into a `vote → score_calc → summarize` / `category: creative` monoculture (10/14 vote, 9/14 score_calc, 11/14 creative; 8/14 share the scoring spine). The scenario-factory had no counter-force — every batch piled onto the crowded majority. This adds a deterministic **novelty census** that steers generation toward under-represented **formats** AND **categories**.

- **`scripts/gallery_census.py`** (NEW) — deterministic, gallery-only tally of 8 structural mechanic axes (peer_vote / scored / decision / elimination / branching / reactive_event / sequential_build / scoring_free) + the 6 categories, flagging `rare` (≤25%) / `crowded` (≥60%) and emitting `Suggested targets`. Hardened for empty galleries (N==0), schema-nullable `phases`, deterministic tie-breaks, and `GalleryCategory` drift (stderr warning).
- **SKILL.md Step 1.5** (NEW) — run the census, assign each of the 3 scenarios a *distinct* under-represented axis; cross-night rotation off the digest `axis` column is an explicit in-session step (the script stays deterministic + gallery-only).
- **Step 2** — relaxed the comedy-only pin so a census-flagged category axis may rotate the premise out of comedy (toward `game_theory` / `experimental` / the original social-psych seeds).
- **Step 4** — category-aware humor: a non-`creative` axis scores humor `null` and is judged on coherence/interaction/breakdown-free + category payoff, so diversity isn't self-penalized.
- **`append_digest.py`** — optional `axis` column (backward-compat em-dash) to track axis coverage across nights.

## Test plan

- `bash .claude/skills/scenario-factory/tests/run_tests.sh` → `ALL TESTS PASSED` (census rare/crowded flags, null-phases skip, zero-count category, empty-gallery graceful, rarest-3 fallback, drift warning, axis-column render + em-dash backward-compat).
- Ran `gallery_census.py` against the real `docs/gallery/gallery.json`: peer_vote/scored crowded, elimination/reactive_event/branching rare, creative crowded, no drift warning.

Reviewed by `critic` (plan) + `code-reviewer` (diff, Opus) — PASS; both review rounds' findings folded in.

Closes #807

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KyRAp4j5DxfB94DeQN269M