### PR TITLE
✨ feat: seed empty/error states into the screenshot tour (ui-refine L5/L6)

### DIFF
--- a/Pastura/Pastura/App/UITestSupport/StubGalleryService.swift
+++ b/Pastura/Pastura/App/UITestSupport/StubGalleryService.swift
@@ -10,17 +10,46 @@
   /// flows deterministic. Hash verification is skipped because UI tests
   /// exercise navigation flow, not integrity checks.
   nonisolated public final class StubGalleryService: GalleryService {
-    private let index: GalleryIndex
-    private let yamlsByURL: [URL: String]
-
-    public init(index: GalleryIndex, yamlsByURL: [URL: String] = [:]) {
-      self.index = index
-      self.yamlsByURL = yamlsByURL
+    /// How the stub answers `loadCachedIndex` / `refreshIndex`, so the
+    /// screenshot tour can reach the gallery sad-paths (#811).
+    public enum Behavior: Sendable {
+      /// Both methods serve `index` — the default, populated path.
+      case serveIndex
+      /// `loadCachedIndex` returns nil AND `refreshIndex` throws, so
+      /// `SharedScenariosViewModel` lands on `.empty` ("Gallery Unavailable").
+      /// Both halves are load-bearing: a nil cache alone leaves `.loading`,
+      /// and a throwing refresh over a served cache yields `.offlineWithCache`
+      /// — only the pair reaches `.empty`.
+      case offline
     }
 
-    public func loadCachedIndex() throws -> GalleryIndex? { index }
+    private let index: GalleryIndex
+    private let yamlsByURL: [URL: String]
+    private let behavior: Behavior
 
-    public func refreshIndex() async throws -> GalleryIndex? { index }
+    public init(
+      index: GalleryIndex,
+      yamlsByURL: [URL: String] = [:],
+      behavior: Behavior = .serveIndex
+    ) {
+      self.index = index
+      self.yamlsByURL = yamlsByURL
+      self.behavior = behavior
+    }
+
+    public func loadCachedIndex() throws -> GalleryIndex? {
+      switch behavior {
+      case .serveIndex: return index
+      case .offline: return nil
+      }
+    }
+
+    public func refreshIndex() async throws -> GalleryIndex? {
+      switch behavior {
+      case .serveIndex: return index
+      case .offline: throw GalleryServiceError.unexpectedStatus(503)
+      }
+    }
 
     public func fetchScenarioYAML(from url: URL, expectedSHA256: String) async throws -> String {
       guard let yaml = yamlsByURL[url] else {
@@ -88,6 +117,26 @@
         version: 1, updatedAt: "2026-04-15", scenarios: [scenario])
       return StubGalleryService(
         index: index, yamlsByURL: [canaryYAMLURL: canaryYAML])
+    }
+
+    /// Gallery that loads successfully but ships **zero** scenarios — drives
+    /// the `.loaded` state's empty `scenariosCard` (`.galleryEmpty` reason,
+    /// "No scenarios available yet"). Used by `--ui-test-seed-empty-gallery`
+    /// for the screenshot tour (#811). Distinct from ``uiTestOfflineGallery()``
+    /// (which renders the `.empty` LoadState's "Gallery Unavailable").
+    public static func uiTestEmptyGallery() -> StubGalleryService {
+      let index = GalleryIndex(version: 1, updatedAt: "2026-04-15", scenarios: [])
+      return StubGalleryService(index: index)
+    }
+
+    /// Gallery that cannot load and has no cache — drives the `.empty`
+    /// LoadState ("Gallery Unavailable" + Retry). Used by
+    /// `--ui-test-seed-gallery-offline` for the screenshot tour (#811). The
+    /// `index` is never served (``Behavior/offline`` returns nil / throws), so
+    /// an empty placeholder is fine.
+    public static func uiTestOfflineGallery() -> StubGalleryService {
+      let index = GalleryIndex(version: 1, updatedAt: "2026-04-15", scenarios: [])
+      return StubGalleryService(index: index, behavior: .offline)
     }
   }
 

--- a/Pastura/Pastura/PasturaApp.swift
+++ b/Pastura/Pastura/PasturaApp.swift
@@ -733,7 +733,18 @@ private struct RootView: View {
         // UI-test runs on the same simulator.
         FeatureFlags.setKeepRunningOnLeave(
           CommandLine.arguments.contains("--ui-test-keep-running"))
-        let gallery = StubGalleryService.uiTestPreset()
+        // Gallery sad-path captures for the ui-refine L5/L6 lenses (#811).
+        // --ui-test-seed-gallery-offline → `.empty` ("Gallery Unavailable");
+        // --ui-test-seed-empty-gallery → `.loaded` with a galleryEmpty card
+        // ("No scenarios available yet"). Plain --ui-test keeps the canary.
+        let gallery: StubGalleryService
+        if CommandLine.arguments.contains("--ui-test-seed-gallery-offline") {
+          gallery = StubGalleryService.uiTestOfflineGallery()
+        } else if CommandLine.arguments.contains("--ui-test-seed-empty-gallery") {
+          gallery = StubGalleryService.uiTestEmptyGallery()
+        } else {
+          gallery = StubGalleryService.uiTestPreset()
+        }
         let editorSeedYAML =
           CommandLine.arguments.contains("--ui-test-editor-seed-yaml")
           ? StubScenarioSeeder.editorSeedYAML : nil
@@ -742,7 +753,14 @@ private struct RootView: View {
           galleryService: gallery,
           uiTestEditorSeedYAML: editorSeedYAML
         )
-        try await StubScenarioSeeder.seed(into: deps.scenarioRepository)
+        // Default-on base seed (1 Home row). --ui-test-seed-empty-inventory
+        // skips it so the Home/Past-Results empty states render for the
+        // screenshot tour (#811). The inversion is load-bearing: plain
+        // --ui-test (no arg) still seeds, so BackGestureTests / EditorReloadTests
+        // keep their deterministic "before" row.
+        if !CommandLine.arguments.contains("--ui-test-seed-empty-inventory") {
+          try await StubScenarioSeeder.seed(into: deps.scenarioRepository)
+        }
         // Rich Home fixture (presets + a gallery-sourced "shared" row) is
         // opt-in for the ui-tour Home captures. Also implied by
         // --ui-test-seed-paused, since the resume card reads its metadata from

--- a/Pastura/Pastura/Views/Community/SharedScenarios/SharedScenariosListView.swift
+++ b/Pastura/Pastura/Views/Community/SharedScenarios/SharedScenariosListView.swift
@@ -85,6 +85,10 @@ struct SharedScenariosListView: View {
       }
       .buttonStyle(PasturaPrimaryButtonStyle())
     }
+    // Anchor for the gallery offline / load-failure screenshot-tour capture
+    // (--ui-test-seed-gallery-offline → `.empty`, #811). Distinct from
+    // `errorState` below (the `.error` LoadState, currently unreachable).
+    .accessibilityIdentifier("sharedScenarios.galleryUnavailable")
   }
 
   private func errorState(message: String, viewModel: SharedScenariosViewModel) -> some View {
@@ -135,6 +139,11 @@ struct SharedScenariosListView: View {
           .padding(.horizontal, 17)
           .padding(.vertical, 14)
       }
+      // Anchor for the no-search-match (--ui-test-seed-empty-inventory + typed
+      // query) and gallery-empty (--ui-test-seed-empty-gallery → .galleryEmpty)
+      // screenshot-tour captures (#811). One anchor, two captures — only the
+      // emptyResultsMessage copy differs by EmptyReason.
+      .accessibilityIdentifier("sharedScenarios.emptyResultsCard")
     } else {
       // Spaced landscape catalog cards (tab-identity PR2, #777) — NOT a divided
       // `.grouped` band — so Browse reads as a card catalog, distinct from the

--- a/Pastura/Pastura/Views/Home/HomeView.swift
+++ b/Pastura/Pastura/Views/Home/HomeView.swift
@@ -126,6 +126,10 @@ struct HomeView: View {
           )
           .frame(maxWidth: .infinity)
           .padding(.top, 60)
+          // Anchor for the empty-inventory screenshot-tour capture
+          // (--ui-test-seed-empty-inventory, #811). The sibling error overlay
+          // below (viewModel.errorMessage) is a distinct surface — keep ids apart.
+          .accessibilityIdentifier("home.emptyState")
         } else {
           scenariosSection(viewModel: viewModel)
         }

--- a/Pastura/Pastura/Views/Results/ResultsView.swift
+++ b/Pastura/Pastura/Views/Results/ResultsView.swift
@@ -29,6 +29,9 @@ struct ResultsView: View {
             systemImage: "tray",
             description: Text(String(localized: "Run a simulation to see results here"))
           )
+          // Anchor for the empty-results screenshot-tour capture
+          // (plain --ui-test without --ui-test-seed-results, #811).
+          .accessibilityIdentifier("results.emptyState")
         } else if scope.isPushedDetail {
           // Pushed per-scenario detail keeps the grouped list — it is a single
           // section, not a tab root, so the timeline's rail + editorial header

--- a/Pastura/PasturaUITests/ScreenshotTourTests.swift
+++ b/Pastura/PasturaUITests/ScreenshotTourTests.swift
@@ -105,6 +105,62 @@ final class ScreenshotTourTests: XCTestCase {
     app.launchArguments = ["--ui-test", "--ui-test-seed-paused"]
     app.launch()
     capture(app, name: "09-home-resume", anchorId: "home.resumeButton", timeout: 10)
+
+    // Empty / error surfaces (#811) — extracted to keep this body within the
+    // function_body_length budget.
+    captureEmptyAndErrorStates(app)
+  }
+
+  /// End-of-tour relaunches that seed the empty / error surfaces the ui-refine
+  /// L5 (empty/error/edge) and L6 (copy) lenses need (#811). Kept separate from
+  /// the populated linear walk so that walk stays undisturbed. `.error` is
+  /// intentionally absent — it is unreachable dead code in
+  /// `SharedScenariosViewModel`.
+  private func captureEmptyAndErrorStates(_ app: XCUIApplication) {
+    // Launch E — empty inventory: Home + Past Results empty, Browse no-match.
+    // --ui-test-seed-empty-inventory skips only the local-scenario base seed;
+    // the canary gallery and the empty Past Results (no results seed) come for
+    // free.
+    app.terminate()
+    app.launchArguments = ["--ui-test", "--ui-test-seed-empty-inventory"]
+    app.launch()
+    // Home empty ("No Scenarios"). Anchor on the empty-state container; the
+    // timeout covers HomeViewModel resolving to zero rows.
+    capture(app, name: "10-home-empty", anchorId: "home.emptyState", timeout: 10)
+    // Past Results empty ("No Results").
+    app.tabBars.buttons["History"].tap()
+    capture(app, name: "11-results-empty", anchorId: "results.emptyState", timeout: 10)
+    // Browse no-search-match — type a query that filters out the canary, then
+    // wait for the empty card AFTER the query commits (`.noMatchingQuery` copy).
+    app.tabBars.buttons["Browse"].tap()
+    let search = app.searchFields.firstMatch
+    XCTAssertTrue(search.waitForExistence(timeout: 10), "Browse search field missing.")
+    search.tap()
+    search.typeText("zzqqxx")
+    capture(
+      app, name: "12-search-no-match",
+      anchorId: "sharedScenarios.emptyResultsCard", timeout: 10)
+
+    // Launch F — gallery loaded but zero scenarios → "No scenarios available
+    // yet" (`.galleryEmpty` reason). Same card anchor as no-match; only the copy
+    // differs by EmptyReason.
+    app.terminate()
+    app.launchArguments = ["--ui-test", "--ui-test-seed-empty-gallery"]
+    app.launch()
+    app.tabBars.buttons["Browse"].tap()
+    capture(
+      app, name: "13-gallery-empty",
+      anchorId: "sharedScenarios.emptyResultsCard", timeout: 10)
+
+    // Launch G — gallery offline with no cache → `.empty` LoadState
+    // ("Gallery Unavailable" + Retry).
+    app.terminate()
+    app.launchArguments = ["--ui-test", "--ui-test-seed-gallery-offline"]
+    app.launch()
+    app.tabBars.buttons["Browse"].tap()
+    capture(
+      app, name: "14-gallery-offline",
+      anchorId: "sharedScenarios.galleryUnavailable", timeout: 10)
   }
 
   // MARK: - Helpers

--- a/docs/design/navigation-map.md
+++ b/docs/design/navigation-map.md
@@ -57,3 +57,8 @@ tab-stack push.
 | 7 | `07-results.png` | `results.list` | tab |
 | 8 | `08-result-detail.png` | `resultDetail.timeline` | push |
 | 9 | `09-home-resume.png` | `home.resumeButton` | root |
+| 10 | `10-home-empty.png` | `home.emptyState` | root |
+| 11 | `11-results-empty.png` | `results.emptyState` | tab |
+| 12 | `12-search-no-match.png` | `sharedScenarios.emptyResultsCard` | tab |
+| 13 | `13-gallery-empty.png` | `sharedScenarios.emptyResultsCard` | tab |
+| 14 | `14-gallery-offline.png` | `sharedScenarios.galleryUnavailable` | tab |

--- a/docs/design/screenshots/README.md
+++ b/docs/design/screenshots/README.md
@@ -27,6 +27,17 @@ build. Review-only capture — no assertion against stored references
 | `06-settings.png` | Settings |
 | `07-results.png` | Past Results list (seeded fixture) |
 | `08-result-detail.png` | Result detail timeline (seeded fixture) |
+| `09-home-resume.png` | Home with the paused-run resume card |
+| `10-home-empty.png` | Home empty state (no local scenarios) |
+| `11-results-empty.png` | Past Results empty state (no results) |
+| `12-search-no-match.png` | Browse search with no matching query |
+| `13-gallery-empty.png` | Browse gallery loaded but empty ("No scenarios available yet") |
+| `14-gallery-offline.png` | Browse gallery offline / load failure ("Gallery Unavailable") |
+
+Rows 10–14 are the empty / error surfaces (#811) the ui-refine L5 (empty /
+error / edge) and L6 (copy) lenses critique — seeded via
+`--ui-test-seed-empty-inventory` / `--ui-test-seed-empty-gallery` /
+`--ui-test-seed-gallery-offline` (see `ScreenshotTourTests`).
 
 Content is fixture-driven (`StubScenarioSeeder` / `StubResultSeeder` /
 `StubGalleryService`), so layouts are representative but copy is test

--- a/docs/design/ui-refine/README.md
+++ b/docs/design/ui-refine/README.md
@@ -86,24 +86,25 @@ journal. Pin this constraint before any Routine is wired up.
 
 ## Known coverage limitations
 
-The capture step (`scripts/ui-tour.sh`) renders the app under `--ui-test`, which
-seeds **populated** fixtures only — it surfaces no genuinely empty (zero
-scenarios / zero results / no-search-match) or error (gallery offline / load
-failure) state. That caps the **L5** (empty / error / edge) and **L6** (copy —
-the on-screen text *is* the UITest fixture) lenses: they can only critique the
-populated surfaces the tour happens to render. The motion path inherits a
-parallel gap — § 5.5 DL-Progress-Dots (motion timing in § 6) and the
-bubble-entrance animation are unreachable under `--ui-test`
-(`../motion/README.md` § Deferred).
+The empty / error gap is now **closed** (#811). The capture step
+(`scripts/ui-tour.sh`) seeds the genuinely empty (zero scenarios / zero results /
+no-search-match) and the gallery offline / load-failure surfaces via
+`--ui-test-seed-empty-inventory` / `--ui-test-seed-empty-gallery` /
+`--ui-test-seed-gallery-offline`. Screens 10–14 in
+[`../screenshots/README.md`](../screenshots/README.md) render them, so the **L5**
+(empty / error / edge) and **L6** (copy — the on-screen text *is* the UITest
+fixture) lenses now have real empty/error copy to critique. One caveat: the
+gallery `.error` LoadState ("Error" + Retry) is **not** captured — it is
+unreachable dead code in `SharedScenariosViewModel` (never assigned), so the
+reachable `.empty` ("Gallery Unavailable") stands in for the offline /
+load-failure surface.
 
-The real fix is a launch-argument path that seeds empty / error states into the
-tour (and a canned-response queue for the live-simulation surfaces) —
-app + `ScreenshotTourTests` work, **out of scope for the markdown-only skill
-iteration** and tracked as a separate follow-up. Until it lands, treat L5/L6
-(and L4's DL-dot / interactive-state anchors) as coverage-bounded: do not infer
-empty / error findings from fixtures that never show those states. This note is
-the durable home for the signal — the per-run digests that first recorded it are
-gitignored.
+The motion path still inherits a parallel gap — § 5.5 DL-Progress-Dots (motion
+timing in § 6) and the bubble-entrance animation are unreachable under
+`--ui-test` (`../motion/README.md` § Deferred). Those live-simulation surfaces
+need a canned-response queue for `MockLLMService`, a distinct blocker that
+unblocks **L4** (DL-dot / interactive-state anchors), not L5/L6. Until it lands,
+still treat L4's DL-dot / interactive-state anchors as coverage-bounded.
 
 ## Deferred next phases (NOT in this prototype)
 


### PR DESCRIPTION
## Summary
- Seed the empty / error UI surfaces into the screenshot tour so the `ui-refine` L5 (empty/error/edge) and L6 (copy) lenses have real states to critique (previously the tour rendered populated fixtures only).
- New DEBUG launch args (mirroring `--ui-test-seed-*`): `--ui-test-seed-empty-inventory` (default-on base-seed inversion → Home / Past Results empty), `--ui-test-seed-empty-gallery` (zero-scenario catalog → "No scenarios available yet"), `--ui-test-seed-gallery-offline` (`StubGalleryService.Behavior.offline` → "Gallery Unavailable").
- 4 unconditional `.accessibilityIdentifier` anchors on the empty/error containers; 5 new tour captures (10–14).
- The gallery `.error` LoadState is **not** captured — it is unreachable dead code in `SharedScenariosViewModel`; the reachable `.empty` stands in for the offline / load-failure surface.
- All new app/test code is `#if DEBUG`-gated and inert in Release.

## Test plan
- `scripts/ui-tour.sh` → 14 PNGs, all anchors resolve; 10/12/13/14 visually confirmed to show the correct state + copy (`No Scenarios`, `No scenarios match "zzqqxx".`, `No scenarios available yet.`, `Gallery Unavailable`).
- Full `scripts/xcodebuild.sh test` → `** TEST SUCCEEDED **` (BackGesture / EditorReload / SharedScenariosViewModel tests unaffected by the base-seed inversion).
- code-reviewer (Opus): PASS, 0 issues.

Closes #811

🤖 Generated with [Claude Code](https://claude.com/claude-code)