### PR TITLE
📝 docs: memory→rules round 7 — 4 STRONG promotions (#780)

### DIFF
--- a/.claude/rules/adr-writing.md
+++ b/.claude/rules/adr-writing.md
@@ -34,3 +34,46 @@ When drafting a DoD criterion that reads `≥ N% on model X`, default to a **mec
 Pastura's roadmap includes multi-model and LiteRT-LM migration, so default toward mechanism contracts. Pin only when the criterion is **single-model-by-design** (e.g., "this ships for Gemma E2B only").
 
 If a plan surfaces a quantitative gate, surface the trade-off to the user at plan time rather than silently committing one framing. See #405 (ADR-010 D5) for the case that collapsed an `if M ≥ 80% pin else fork to PR3` contingency by pivoting to mechanism contract.
+
+## 3. Inter-citation consistency — dates, SHAs, arithmetic
+
+Distinct from §1 (verify each *individual* citation). This is **cross-citation**:
+when the same fact appears in N places, all N must agree, and any arithmetic
+*derived* from a citation must match the cited dates / SHAs. Critic and
+code-reviewer subagents evaluate framing and rule-compliance, not mechanical
+cross-citation arithmetic — so the writer is the only reliable check.
+
+After drafting an ADR / spec / decision record:
+
+1. **Grep every date** (`YYYY-MM-DD`). Sort mentally; cross-check each span
+   claim ("predates by N months", "over a year", "X older than Y") against the
+   actual gap. (An ADR once shipped "predates by over a year" while its own
+   cited commit dates were ~32 days apart — passed two critic rounds + one
+   code-reviewer; caught by a third-party cross-reference.)
+2. **Grep every short SHA.** Each must resolve in `git log` and its subject
+   match the cited claim.
+3. **Grep every `file:line`.** Read each; confirm the cited content is there.
+4. **Grep period words** (`year` / `month` / `week` / `day`) and recompute the
+   span from the dates you cited.
+
+Two recurring variants beyond plain arithmetic:
+
+- **Projection vs measurement.** When a metric appears across a *series* of
+  checkpoints (weekly spikes, CI readings, perf runs), cite the **latest
+  measured** value — not a superseded earlier **projection**. The rosy early
+  estimate is the trap: an evidence-synthesis ADR written from memory reaches
+  for it. (ADR-004 §9.3 once cited a week-1 CI *projection* with ~14 min
+  headroom as the cold-pipeline evidence; the later week-3 *measurement* was
+  17m40s with ~2m20s headroom and a flagged ceiling breach.)
+- **Status-flip staleness.** When amending an ADR to record that a condition
+  flipped (a migration trigger fired, a dependency became available, something
+  got deprecated), the original present-tense rationale ("X is unavailable",
+  "no SDK", status tables) now contradicts the new section. Grep every
+  present-tense claim about the flipped condition and reframe to **dated
+  past-tense + a forward pointer** — do not delete (it's the original decision
+  rationale). A section's date header doesn't cover present-tense bullets/rows
+  below it (a reader landing mid-section misses it). The **cherry-port variant**
+  is worse: porting docs authored *before* a later decision spreads stale
+  framing far beyond the renamed heading, and one decision can fork a single
+  term into two axes needing separate replacement vocab — full-doc grep the old
+  plan's vocabulary, not just the section you renamed.

--- a/.claude/rules/ci-workflows.md
+++ b/.claude/rules/ci-workflows.md
@@ -120,6 +120,36 @@ that extraction required, aborting every `gallery-scripts-test.sh` case whose
 fixture builder (`mk_factory` / `mk_gallery_yaml`) predated it. `check-gallery-entry.sh`
 never runs the extraction, so it was green locally, red in CI.
 
+## Rename / namespace-sweep completion gate — `git grep`, both forms
+
+For a rename or namespace-sweep "0 remaining" completion gate, use
+`git grep -nF '<literal>'` over tracked files — **not** a plain `rg` over the
+worktree — and run it for **both** the bare and the backslash-escaped form.
+
+Two failure modes a plain `rg '<pattern>'` gate hit on a bundle-id rebrand sweep:
+
+1. **Escaped-form blind spot.** A shell script (`scripts/analyze-streaming-diag.sh`)
+   contained `sed 's/.*\[com\.tyabu12\.Pastura...\]//'` — on disk that's
+   `com\.tyabu12` (backslash + dot = two chars), so the regex `com\.tyabu12`
+   (`com` + dot + `tyabu12`) did **not** match. The gate returned 0 while live
+   occurrences remained; caught only by code review. For regex-y patterns use a
+   backslash-tolerant form (`com[\\]?\.tyabu12`), or `-F` both literals.
+2. **`rg` traverses the worktree and can hang** (~tens of minutes) on a huge
+   `DerivedData/*.xcresult` or a symlink loop even with `--glob '!**/DerivedData/**'`.
+
+**Apply** — at sweep gates, run both forms tracked-only and repo-wide (no
+hand-picking dirs — a hand-picked `docs/ + scripts/` once missed
+`.claude/rules/xcodebuild-cli.md`):
+
+```bash
+git grep -nF 'com.tyabu12.Pastura'   # bare
+git grep -nF 'com\.tyabu12'          # backslash-escaped on-disk literal
+```
+
+`git grep` is tracked-only (fast, never descends into ignored/huge files) and
+repo-wide by default. Pairs with the "grep ALL instances before scoping"
+discipline.
+
 ## Related
 
 `.claude/rules/xcodebuild-cli.md` covers the agent-session analogue (`xcodebuild | tail` exit-code masking when invoked from Claude Code). The CI form here is `|| true` defeating `pipefail`; same root family.

--- a/.claude/rules/navigation.md
+++ b/.claude/rules/navigation.md
@@ -15,6 +15,20 @@ Generated screen-graph overview:
 [`docs/design/navigation-map.md`](../../docs/design/navigation-map.md)
 (CI drift-guarded — regenerate via the script, never edit by hand).
 
+Regenerate in the **same commit** as any `Route` add/remove/rename,
+`NavigationLink(value:)` / `router.push` edge change, or callsite **file move**:
+`python3 scripts/generate-navigation-map.py` then `--self-test` then `--check`,
+staging both the map and the script. Both the pre-commit
+`navigation-map-precommit-gate.sh` and the CI "Navigation map drift guard" run
+`--check`, but the pre-commit gate is **trigger-scoped** — it fires only when the
+staged diff touches a nav-map input (`Views`/`App` `.swift`,
+`ScreenshotTourTests.swift`, the generator, or the map), so drift staged without
+one is caught only by CI. A callsite file move fires the guard even when the
+generated map is **byte-identical**: the script attributes each callsite to a
+screen via `FILE_TO_SCREEN`, so a moved `NavigationLink(value: Route.X)` fails
+with "navigation callsite found but file is not in FILE_TO_SCREEN" — fix by
+adding the new path to `FILE_TO_SCREEN`.
+
 ## Bottom-tab IA — `TabCoordinator` (load-bearing)
 
 The four-tab model (ADR-016) replaced the single root `NavigationStack`.
@@ -220,6 +234,10 @@ When reviewing changes that touch navigation:
       re-introduced on `TabCoordinator` (`hasUnsavedInFlightRun` /
       `pendingTabSwitch` were removed). `isSimulationOnTop` stays an any-tab
       fold (ADR-016 § Amendment 2026-06-18).
+- [ ] `Route` add/remove/rename, `NavigationLink`/`router.push` edge change, or
+      callsite **file move** regenerated `docs/design/navigation-map.md` in the
+      same commit (`generate-navigation-map.py --check`; new callsite file also
+      added to `FILE_TO_SCREEN`).
 
 ## Render-time hints — `RouteHint`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,7 @@ Implementation order: `Models → LLM → Engine → Data → Views → App → 
 - **Commits:** Conventional Commits with emoji prefix, under 72 chars.
   `✨ feat:`, `🐛 fix:`, `♻️ refactor:` — add body when "why" isn't obvious.
 - **Small and focused** — one logical change per commit.
+- **Re-stage after a pre-commit hook rejection.** When the pre-commit hook (`swiftlint --strict`, `xcodebuild build`, …) rejects a commit, do not assume the previously-staged files survived — they can silently drop to "Changes not staged". Run `git status` and re-stage (`git add -u` or explicit paths) **before** retrying, or the retry commits a partial changeset and splits one logical change across two commits.
 - **Closing issues in multi-PR splits:** GitHub auto-closes on any `Closes #N` / `Fixes #N` match in the PR body, ignoring qualifiers like "partially" or "PR1 of 3". In non-final PRs of a split, reference without a close-directive keyword (`See #N`, `Part of #N`, `Relates to #N`). Only the final PR should carry `Closes #N`. If auto-close fires by accident on a non-final PR, recover immediately: `gh issue reopen <N> --comment "still tracking remaining scope: ..."`.
 
 ### Test Execution


### PR DESCRIPTION
## Summary
Round 7 of the memory→rules promotion backlog (See #780 — rolling tracking
issue, stays open). Promotes 4 STRONG high-ROI per-user memory entries into
repo-tracked rules:

- `ci-workflows.md` — git-grep sweep-gate trap (both bare+escaped forms; rg
  worktree-hang + escaped-form blind spot)
- `adr-writing.md` §3 — inter-citation consistency (dates/SHAs/arithmetic +
  projection-vs-measurement + status-flip staleness)
- `navigation.md` — nav-map drift on Route change / callsite file move
  (`FILE_TO_SCREEN` trap; trigger-scoped pre-commit gate)
- `CLAUDE.md` § Git Conventions — re-stage after a pre-commit hook rejection

Deferred this round (kept in memory): `band_aid_framing_verify_loadbearing`.

## Reviews
- Pre-impl critic: caught + fixed 1 Critical (stale "pre-commit does NOT run
  `--check`" claim carried from a pre-#652 memory) + 1 Warning (always-loaded
  duplication).
- Opus code-reviewer: PASS, 0 issues — all load-bearing assertions re-verified
  against current main.

## Test plan
- Docs-only; no code/build impact (pre-commit correctly skipped Swift/build
  gates on all 4 commits).
