### PR TITLE
♻️ refactor: remove unreachable .error LoadState from SharedScenarios

### DIFF
--- a/Pastura/Pastura/App/Community/Gallery/SharedScenariosViewModel.swift
+++ b/Pastura/Pastura/App/Community/Gallery/SharedScenariosViewModel.swift
@@ -22,8 +22,6 @@ final class SharedScenariosViewModel {
     case offlineWithCache
     /// First run with no cache and no network.
     case empty
-    /// Unexpected error, details in message.
-    case error(String)
   }
 
   /// The result of a `tryInstall` invocation.

--- a/Pastura/Pastura/Views/Community/SharedScenarios/SharedScenariosListView.swift
+++ b/Pastura/Pastura/Views/Community/SharedScenarios/SharedScenariosListView.swift
@@ -39,7 +39,7 @@ struct SharedScenariosListView: View {
     guard let viewModel else { return false }
     switch viewModel.state {
     case .loaded, .offlineWithCache: return true
-    case .idle, .loading, .empty, .error: return false
+    case .idle, .loading, .empty: return false
     }
   }
 
@@ -58,8 +58,6 @@ struct SharedScenariosListView: View {
       loadingView
     case .empty:
       emptyState(viewModel: viewModel)
-    case .error(let message):
-      errorState(message: message, viewModel: viewModel)
     case .loaded, .offlineWithCache:
       scenarioList(viewModel: viewModel)
     }
@@ -86,20 +84,8 @@ struct SharedScenariosListView: View {
       .buttonStyle(PasturaPrimaryButtonStyle())
     }
     // Anchor for the gallery offline / load-failure screenshot-tour capture
-    // (--ui-test-seed-gallery-offline → `.empty`, #811). Distinct from
-    // `errorState` below (the `.error` LoadState, currently unreachable).
+    // (--ui-test-seed-gallery-offline → `.empty`, #811).
     .accessibilityIdentifier("sharedScenarios.galleryUnavailable")
-  }
-
-  private func errorState(message: String, viewModel: SharedScenariosViewModel) -> some View {
-    ContentUnavailableView {
-      Label(String(localized: "Error"), systemImage: "exclamationmark.triangle")
-    } description: {
-      Text(message)
-    } actions: {
-      Button(String(localized: "Retry")) { Task { await viewModel.refresh() } }
-        .buttonStyle(PasturaPrimaryButtonStyle())
-    }
   }
 
   // MARK: - Scenario list


### PR DESCRIPTION
Closes #816

Pure dead-code deletion: removes the unreachable `LoadState.error` case from
`SharedScenariosViewModel` and its `errorState(...)` rendering branch in
`SharedScenariosListView`. The case was **declared but never assigned** —
`load()` / `refresh()` only ever set `.idle`, `.loading`, `.loaded`,
`.offlineWithCache`, or `.empty` — so the "Error" surface it drove could never
appear.

## Acceptance criteria → diff → coverage

| Criterion | How the diff satisfies it | Coverage |
|---|---|---|
| `LoadState.error` + `errorState(...)` removed; no `.error` ref remains in either file | `case error(String)` dropped from the enum; `.error` removed from `isSearchEnabled`; `.error` arm removed from `content(viewModel:)`; `errorState(message:viewModel:)` deleted | `grep -n '\.error'` on both files → none; `grep -rn 'errorState'` → none |
| `scripts/xcodebuild.sh build` succeeds (exhaustive switches compile) | Both switches stay exhaustive over the remaining 5 cases (no `default:`) | `** BUILD SUCCEEDED **` |
| `SharedScenariosViewModelTests` passes; full suite green | No reachable behavior touched | Targeted: 11/11 ✅; full unit suite: 2322/2322 ✅ (UI tests skipped — no UI-behavior change) |
| `check_localization_coverage.py` passes; `"Error"` key retained | No catalog edit; `"Error"`/`"Retry"` keys left for their other live consumers | `✅ 553 keys, all ja translated` |
| No behavior change to reachable gallery states | Deletion-only; `.idle/.loading/.loaded/.offlineWithCache/.empty` paths byte-identical | — |

## Judgment calls

- **Stale prose comment left untouched (out of scope).** `SharedScenariosListView.swift:26`
  reads "…the loading / network-unavailable / **error** screens is meaningless" —
  the "error screens" reference is now mildly stale, but it is **not** in the
  issue's enumerated scope and does not match the acceptance grep (`\.error`).
  Per the queue-consumer scope rule (no "while at it" changes), I left it.
  A follow-up could drop "/ error" from that sentence.
- **Incidental catalog auto-sync artifact reverted.** The build's `xcstringstool sync`
  marked an *unrelated* pre-existing orphan key (`~%lld inferences`, dropped by #777)
  as `stale`. That has nothing to do with this deletion and the issue says "no
  catalog edit needed," so I restored `Localizable.xcstrings` to `origin/main` —
  the PR is exactly the two-file deletion.

## Review

code-reviewer (Opus): **PASS**, 0 issues — confirmed the deletion is complete,
both switches stay compiler-exhaustive, no reachable path removed, conventions intact.

Relates to #811, #812.
