### PR TITLE
🐛 fix: offload model load off MainActor (sim-transition freeze)

### DIFF
--- a/.claude/rules/swift-isolation.md
+++ b/.claude/rules/swift-isolation.md
@@ -1,13 +1,13 @@
 # Swift Isolation Rules
 
-**Scope**: `nonisolated` annotation traps under `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` only. Broader actor isolation topics (`@MainActor` binding, `Sendable` conformance design, actor reentrancy) are out of scope — keep those in CLAUDE.md or a separate rule.
+**Scope**: `nonisolated` annotation traps + the `nonisolated async` executor-inheritance trap under `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` (with `SWIFT_APPROACHABLE_CONCURRENCY = YES`). Patterns 1–5 are **compile-time annotation traps** (a diagnostic fires); Pattern 6 is a **silent runtime trap** (executor inheritance — no diagnostic, surfaces as a UI freeze). Broader actor isolation topics (`@MainActor` binding, `Sendable` conformance design, actor reentrancy) are out of scope — keep those in CLAUDE.md or a separate rule.
 
 Per CLAUDE.md, types in `Models/`, `LLM/`, `Engine/`, `Data/` are marked `nonisolated` at the type level. Conformances declared in `App/` (and any default-MainActor layer) hit MainActor inference traps in five specific patterns. The five share the same root cause (MainActor inference) but surface in two diagnostic forms:
 
 - **Conformance-site** (Pattern 1): `conformance of '<Type>' to protocol '<Protocol>' crosses into main actor-isolated code and can cause data races` — a previously-compiling type suddenly refusing to build.
 - **Use-site** (Patterns 2–5): fires at the test, generic collection, Sendable closure callsite, or conformance-lookup callsite — not the declaration. Patterns 2–4 surface as `Call to main actor-isolated <thing> in a synchronous nonisolated context`; Pattern 5 surfaces as `main actor-isolated conformance of '<Type>' to '<Protocol>' cannot be used in nonisolated context`.
 
-Easy to miss because the diagnostic doesn't point at the type definition.
+Easy to miss because the diagnostic doesn't point at the type definition. **Pattern 6 is the exception to this framing** — it produces *no diagnostic at all* (the code compiles and silently runs blocking work on the caller's MainActor executor). It is grouped here because it shares the root cause: a `nonisolated` member that fails to land off-main under default-MainActor isolation.
 
 ## Pattern 1 — Protocol-extension default impl + escaping closure
 
@@ -95,3 +95,49 @@ Pattern 2 (which says "auto-synth doesn't need the annotation").
 Reference: `Pastura/PasturaTests/Views/ModelRowAccessibilityTests.swift`
 carries `@MainActor` on the suite; `SheepAvatar.Character` keeps its
 default-MainActor isolation.
+
+## Pattern 6 — `nonisolated async` runs on the caller's executor (silent UI freeze)
+
+Under `SWIFT_APPROACHABLE_CONCURRENCY = YES` (which enables the
+`NonisolatedNonsendingByDefault` upcoming feature, SE-0461), a
+`nonisolated async` function does **not** hop to the global executor on
+its own — it runs on the **caller's** executor. So a `nonisolated async`
+method `await`-ed from a MainActor context runs **on the MainActor**, and
+any synchronous blocking work inside (a multi-second C call, heavy CPU)
+**freezes the UI**. The type-level `nonisolated` on the enclosing class
+does NOT save it: that annotation governs the *default isolation* of
+members, not which executor an `async` body runs on.
+
+Unlike Patterns 1–5 there is **no compiler diagnostic** — it builds clean
+and the freeze only shows on a real device. The same method is safe when
+reached from an already-off-main caller (e.g. inside an Engine `Task {}`
+producer), which is why a sibling `nonisolated async` can look fine while
+this one freezes.
+
+### Fix
+
+Mark the blocking `async` method `@concurrent` (the SE-0461 pairing
+attribute) to force its body onto the global concurrent executor
+regardless of caller.
+
+```swift
+nonisolated final class LlamaCppService: ... {
+  // Without @concurrent this runs on the MainActor caller
+  // (SimulationViewModel.run) and the synchronous multi-GB GGUF load
+  // freezes the UI on the scenario→simulation transition.
+  @concurrent private func loadModelInternal(...) async throws {
+    guard let model = llama_model_load_from_file(...) else { ... }  // blocking C call
+    _model = model  // nonisolated(unsafe) — no Sendable crossing
+  }
+}
+```
+
+Prefer `@concurrent` over wrapping the body in `Task.detached` when it
+touches non-`Sendable` state (e.g. C `OpaquePointer`s): `@concurrent` only
+changes the executor, so nothing crosses an isolation boundary, whereas
+returning a non-`Sendable` value out of a detached task is a Swift 6 error.
+`@concurrent` on a protocol witness does not change the protocol
+requirement's signature, so sibling conformances need no annotation.
+
+Reference: `Pastura/Pastura/LLM/LlamaCppService.swift` — `loadModelInternal`
+and `unloadModel` carry `@concurrent` (#822).

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -512,6 +512,15 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   /// on foreground return from a background simulation.
   var isReloadingModel = false
 
+  /// True while the LLM model is being loaded from disk at the start of a
+  /// run / resume (before the first `SimulationEvent`). Surfaced to the UI so
+  /// it can show a "Loading model..." overlay over the still-empty log — the
+  /// load reads a multi-GB GGUF + inits the Metal context and takes a few
+  /// seconds (HIG: show progress for waits of unquantifiable duration). The
+  /// initial-load sibling of ``isReloadingModel`` (GPU↔CPU switch). (#822)
+  /// `private(set)`: only mutated here in `run()` / `resume()` (same file).
+  private(set) var isLoadingModel = false
+
   /// Holds the currently running simulation task for cancellation support.
   /// Set by the caller (SimulationView) after launching `run()` in a Task.
   /// Memory warning or explicit user action can cancel via `cancelSimulation()`.
@@ -836,12 +845,17 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
       codePhasePersistenceContinuation?.finish()
       backgroundManager?.completeTask(success: isCompleted)
       isRunning = false
+      // Safety net for the early-return / cancellation paths; the success path
+      // clears it explicitly below before the event stream so the overlay is
+      // gone while the log fills.
+      isLoadingModel = false
       currentLLM = nil
       suspendController = nil
       simulationActivityRegistry?.leave()
     }
 
     // Load LLM model
+    isLoadingModel = true
     do {
       try await llm.loadModel()
     } catch {
@@ -853,6 +867,7 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
       await persistStatus(.failed)
       return
     }
+    isLoadingModel = false
 
     // Consume event stream. Agent outputs are paced by the per-row typing
     // animation in AgentOutputRow; other events (phase/round separators,
@@ -1052,6 +1067,9 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
       codePhasePersistenceContinuation?.finish()
       backgroundManager?.completeTask(success: isCompleted)
       isRunning = false
+      // Mirror run()'s defer (matched-pair anchor): clear the load overlay on
+      // the early-return / cancellation paths.
+      isLoadingModel = false
       currentLLM = nil
       suspendController = nil
       simulationActivityRegistry?.leave()
@@ -1062,6 +1080,7 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     // `.paused` (no status write below, since we return before `.running` is
     // enqueued) and present the run as paused in-memory so the user can retry
     // from the Home card.
+    isLoadingModel = true
     do {
       try await llm.loadModel()
     } catch {
@@ -1073,6 +1092,7 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
       }
       return
     }
+    isLoadingModel = false
     // Model is up — flip the DB row `.paused` → `.running`. Gated on loadModel
     // success: writing `.running` before the load would strand the row as
     // `.running` on a load failure with no easy restore to `.paused`.

--- a/Pastura/Pastura/LLM/LlamaCppService.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService.swift
@@ -255,6 +255,11 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
   /// - Note: Any attached ``SuspendController`` is preserved across the
   ///   unload/load cycle via `defer`, matching ``reloadModel(gpuAcceleration:)``.
   public func loadModel() async throws {
+    // This wrapper is NOT `@concurrent`, so it runs on the MainActor caller
+    // (`SimulationViewModel.run()`). That is safe only because it delegates all
+    // blocking work to the `@concurrent` `unloadModel` / `loadModelInternal`.
+    // Do NOT add synchronous blocking work directly here — it would re-freeze the
+    // UI with no diagnostic (swift-isolation.md Pattern 6). (#822)
     let preservedController = suspendController
     defer { suspendController = preservedController }
     try await unloadModel()
@@ -283,6 +288,8 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
   ///
   /// - Parameter gpuAcceleration: Desired GPU acceleration mode for the new load.
   public func reloadModel(gpuAcceleration: GPUAcceleration) async throws {
+    // See `loadModel()`: this wrapper runs on its caller's executor; keep all
+    // blocking work in the `@concurrent` internals it delegates to. (#822)
     let preservedController = suspendController
     defer { suspendController = preservedController }
     try await unloadModel()

--- a/Pastura/Pastura/LLM/LlamaCppService.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService.swift
@@ -289,7 +289,15 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
     try await loadModelInternal(gpuAcceleration: gpuAcceleration)
   }
 
-  private func loadModelInternal(gpuAcceleration: GPUAcceleration) async throws {
+  // `@concurrent`: the synchronous `llama_model_load_from_file` /
+  // `llama_init_from_model` calls below read a multi-GB GGUF and create the
+  // Metal context, blocking for seconds. This is a `nonisolated async` method,
+  // but under `SWIFT_APPROACHABLE_CONCURRENCY` (NonisolatedNonsendingByDefault)
+  // it would otherwise run on the *caller's* executor — and `loadModel()` is
+  // awaited from the MainActor `SimulationViewModel.run()`, so the load froze the
+  // UI on the scenario→simulation transition. `@concurrent` forces the body onto
+  // the global concurrent executor regardless of caller. (#822)
+  @concurrent private func loadModelInternal(gpuAcceleration: GPUAcceleration) async throws {
     await awaitGenerateIdle(caller: "loadModel")
 
     // llama_backend_init is internally ref-counted — safe to call multiple times
@@ -323,7 +331,11 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
     loadedState.withLock { $0 = true }
   }
 
-  public func unloadModel() async throws {
+  // `@concurrent` for the same reason as `loadModelInternal`: `llama_free` /
+  // `llama_model_free` below release multi-GB buffers and would block the
+  // MainActor caller (`finalizeRun`, the memory-warning unload) under
+  // NonisolatedNonsendingByDefault. (#822)
+  @concurrent public func unloadModel() async throws {
     await awaitGenerateIdle(caller: "unloadModel")
 
     let wasLoaded = loadedState.withLock { loaded -> Bool in

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -3568,6 +3568,16 @@
         }
       }
     },
+    "Loading model..." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "モデルを読み込み中..."
+          }
+        }
+      }
+    },
     "Loading scenario..." : {
       "localizations" : {
         "ja" : {

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -540,8 +540,12 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
         .deepLinkGated()
     }
     .overlay {
-      if viewModel.isReloadingModel {
-        modelReloadingOverlay
+      // Initial load (run/resume) and BG GPU↔CPU reload are mutually
+      // exclusive in time; both surface the same "model busy" affordance.
+      if viewModel.isLoadingModel {
+        modelStatusOverlay(String(localized: "Loading model..."))
+      } else if viewModel.isReloadingModel {
+        modelStatusOverlay(String(localized: "Reloading model..."))
       }
     }
     .overlay(alignment: LanguageDriftToastLayout.overlayAlignment) {
@@ -614,13 +618,16 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
     }
   }
 
-  private var modelReloadingOverlay: some View {
+  /// Dimmed centered overlay for a "model busy" wait — shared by the initial
+  /// load (`isLoadingModel`) and the BG GPU↔CPU reload (`isReloadingModel`),
+  /// parametrized only by the title. The subtitle is shared verbatim.
+  private func modelStatusOverlay(_ title: String) -> some View {
     ZStack {
       Color.ink.opacity(0.4).ignoresSafeArea()
       VStack(spacing: 12) {
         IdleFriendlyProgressView()
           .scaleEffect(1.2)
-        Text(String(localized: "Reloading model..."))
+        Text(title)
           .textStyle(Typography.titlePhase)
           .foregroundStyle(Color.ink)
         Text(String(localized: "This can take a few seconds"))


### PR DESCRIPTION
## Summary
Fixes an intermittent multi-second UI freeze when navigating scenario detail → simulation (playback), and adds a loading affordance during model load.

**Root cause**: `LlamaCppService.loadModelInternal()` / `unloadModel()` contain synchronous llama.cpp C calls (multi-GB GGUF read + Metal context init; buffer frees). They are `nonisolated async`, but under `SWIFT_APPROACHABLE_CONCURRENCY = YES` (`NonisolatedNonsendingByDefault`) a `nonisolated async` function runs on the **caller's** executor — and `loadModel()` is awaited from the MainActor `SimulationViewModel.run()`, so the blocking C work froze the UI. The type-level `nonisolated` on the class does not move it off-main. (`generate()` never froze because it runs inside the Engine's off-main `AsyncStream` producer.) Intermittent because `SimulationSession.adoptIfMatching` reuses an already-loaded run on re-navigation.

**Fix**: mark `loadModelInternal` / `unloadModel` `@concurrent` (SE-0461) so the blocking bodies run on the global concurrent executor regardless of caller. The `awaitGenerateIdle` sequential-access contract (ADR-002 §6) is ordering, not thread-affinity, so it is preserved. Guard comments on the `loadModel` / `reloadModel` wrappers prevent a future re-freeze; a new swift-isolation.md **Pattern 6** documents the trap.

**Loading affordance**: now that the load is async, the sim screen is live but the log is empty for the few seconds the model loads. Add a `"Loading model..."` overlay during that wait ([HIG: show progress for waits of unquantifiable duration](https://developer.apple.com/design/human-interface-guidelines/progress-indicators)), via an `isLoadingModel` flag (toggled around `loadModel()` in `run()` + `resume()`) reusing the existing BG-reload overlay (refactored to `modelStatusOverlay(_:)`). This only animates because of the off-main fix above — hence bundled here.

## Test plan
- ✅ Full unit suite (2340 tests) + `swiftlint --strict` + localization-coverage green.
- ✅ Build verifies `@concurrent` compiles under this toolchain.
- ⚠️ **Device QA required** (executor identity / the freeze are not unit-observable; the simulator can't run quantized inference):
  - Scenario → simulation **entry** (first run / after cleanup): no freeze; the **"Loading model..." overlay shows and its spinner animates** during the load.
  - **Teardown / back-nav** path (existential `unloadModel` via `any LLMService` in `finalizeRun`) runs off-main.
  - **Resume** path (Home card → resume a paused run): overlay shows during its model load too.
  - load → unload → reload cycle + a **BG CPU↔GPU switch** cycle: no GGML/Metal abort; the BG switch still shows "Reloading model...".

Closes #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)