### PR TITLE
🧹 chore: mark orphaned ~%lld inferences catalog key stale

### DIFF
--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -6478,6 +6478,7 @@
       }
     },
     "~%lld inferences" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ja" : {
           "stringUnit" : {


### PR DESCRIPTION
## Summary
`~%lld inferences` (ja: `~%lld 回の推論`) in `Localizable.xcstrings` is an orphan — no source reference (dropped in the #783 row-UI redesign; the only live "inferences" keys are `ScenarioValidator`'s "Estimated inferences (%lld) exceeds maximum of 100" and `GalleryScenarioDetailView`'s "Est. inferences"). It was the **only** orphan committed without an `extractionState: "stale"` marker, so every `scripts/xcodebuild.sh build|test` re-added the marker via `xcstringstool sync` — a recurring 1-line diff that had to be reverted before committing unrelated work.

This commits the marker (matching its 14 translated-stale siblings, kept for translator reference per #304) so sync sees it already-stale and the churn stops. The marker is byte-identical to sync's own output, so it is self-stable on future builds.

Keep (not delete) is the convention-correct choice — `xcstrings-prune-stale.py --keep-translated` retains translated orphans by design, preserving the ja translation for a future redesign that may re-introduce the label.

## Test plan
- ✅ A second `scripts/xcodebuild.sh build` produces **no further diff** on the key (churn stopped).
- ✅ `python3 scripts/check_localization_coverage.py` green (validator is locale-scoped — it inspects `localizations.ja.extractionState`, never the entry-level marker; the ja `stringUnit` stays `state: "translated"`).
- ✅ critic (0 Critical/Warning) + code-reviewer Opus (PASS, 0 issues).
- Catalog-only; no source / test impact.

Closes #831

🤖 Generated with [Claude Code](https://claude.com/claude-code)