### PR TITLE
✨ feat: unify demo replay typing speed with the live sim

### DIFF
--- a/Pastura/Pastura/App/PlaybackSpeed.swift
+++ b/Pastura/Pastura/App/PlaybackSpeed.swift
@@ -132,12 +132,15 @@ nonisolated public enum PlaybackSpeed:
   /// comprehension over speed.
   ///
   /// **Shared by Sim and the demo replay.** The Sim sleeps this directly in
-  /// ``SimulationViewModel/holdAfterAgentOutput(script:)``; the demo folds it
-  /// into its per-bubble turn-dwell floor
-  /// (``ReplayViewModel/typingFloorMs(for:script:)``) as the `max(typing, dwell)`
-  /// reading beat, so both surfaces use the one length-scaled pause and cannot
-  /// drift. (``interEventDelayMs`` stays Sim-only; the demo's structural base
-  /// delays are scaled by ``multiplier`` instead.)
+  /// ``SimulationViewModel/holdAfterAgentOutput(script:)`` (as `max(dwell,
+  /// remaining-tail-typing)`, since its line was already revealed during
+  /// streaming); the demo adds it on top of the full typing time in its
+  /// per-bubble turn-dwell floor
+  /// (``ReplayViewModel/typingFloorMs(for:script:)`` `== typing + dwell`, since
+  /// the demo types the whole line inside the floor window). Both surfaces use
+  /// the one length-scaled pause and cannot drift. (``interEventDelayMs`` stays
+  /// Sim-only; the demo's structural base delays are scaled by ``multiplier``
+  /// instead.)
   ///
   /// **`displayLength` is the grapheme count of the committed _primary_ text**
   /// (``TurnOutput/primaryText(for:)`` — see the consumer in

--- a/Pastura/Pastura/App/PlaybackSpeed.swift
+++ b/Pastura/Pastura/App/PlaybackSpeed.swift
@@ -19,8 +19,8 @@ import Foundation
 /// freely — no isolation friction for value-type enums.
 ///
 /// **Consumers — properties are NOT universally consumed:**
-/// - **Sim** (``SimulationViewModel``) uses ``simCharsPerSecond`` (typing
-///   animation — slower than ``charsPerSecond`` for read-along comprehension),
+/// - **Sim** (``SimulationViewModel``) uses ``charsPerSecond`` (typing
+///   animation — shared with the demo),
 ///   ``readingDwell(displayLength:script:)`` (post-utterance reading pause),
 ///   and ``interEventDelayMs`` (non-agent inter-event delay).
 /// - **``ReplayViewModel``** (the demo replay) uses ``charsPerSecond`` (the
@@ -55,43 +55,28 @@ nonisolated public enum PlaybackSpeed:
 
   public var id: String { rawValue }
 
-  /// Characters revealed per second during the **DL-time demo replay**
-  /// typing animation. `nil` means "render full text immediately" (`.instant`).
+  /// Characters revealed per second during the typing animation, for **both**
+  /// the live simulation and the DL-time demo replay. `nil` means "render full
+  /// text immediately" (`.instant`).
   ///
-  /// **Demo-replay only** (since the Sim split — the live Sim uses
-  /// ``simCharsPerSecond``). Consumed via ``ReplayViewModel/typingCharsPerSecond``
-  /// (keyed on the runtime ``ReplayViewModel/playbackSpeed``, #791) and seeded
-  /// into ``ReplayPlaybackConfig`` at `.normal`. ``ReplayViewModel``'s turn-dwell
-  /// floor (``ReplayViewModel/typingFloorMs(for:)``) does NOT read this; it uses
-  /// the fixed `config` reference, then ``ReplayViewModel/scaledDelay(for:floorMs:)``
-  /// divides by ``multiplier`` (and `charsPerSecond == 30 × multiplier`, so the
-  /// dwell stays synced with the speed-scaled typing). **Keep `.normal == 30`** —
-  /// that invariant is load-bearing for the demo floor; change the Sim rate via
-  /// ``simCharsPerSecond`` instead.
+  /// **Single source of truth.** The Sim reads it via
+  /// ``SimulationViewModel/effectiveCharsPerSecond(forEntryId:)`` (committed
+  /// rows) and the in-flight streaming row in `SimulationView`; the demo reads
+  /// the speed-scaled value via ``ReplayViewModel/typingCharsPerSecond`` for
+  /// both the on-screen typing and its reading-dwell floor
+  /// (``ReplayViewModel/typingFloorMs(for:script:)``). Because there is one
+  /// property, the two surfaces cannot drift — tuning the rate here moves the
+  /// sim and the demo in lockstep.
+  ///
+  /// `.normal` is anchored at a comfortable read-along pace and `.slow` slower
+  /// still (device testing found faster rates too fast to follow during a run);
+  /// `.fast` is the "I want speed" escape hatch. `.instant` stays `nil` so the
+  /// instant-snap invariant in
+  /// ``SimulationViewModel/effectiveCharsPerSecond(forEntryId:)`` holds. The
+  /// demo's turn-dwell floor no longer assumes any linear relationship between
+  /// these values and ``multiplier`` (see ``ReplayViewModel/scaledDelay(for:floorMs:)``),
+  /// so the tiers are free to be non-linear.
   public var charsPerSecond: Double? {
-    switch self {
-    case .slow: 15
-    case .normal: 30
-    case .fast: 45
-    case .instant: nil
-    }
-  }
-
-  /// Characters revealed per second during the **live simulation** typing
-  /// animation. `nil` means "render full text immediately" (`.instant`).
-  ///
-  /// Split from ``charsPerSecond`` (which now serves only the demo replay) so
-  /// the live Sim can type slower — device testing found the demo-tier rates
-  /// too fast to read along with during an actual run, while the demo's
-  /// `typingFloorMs` invariant requires `charsPerSecond.normal == 30`.
-  /// `.normal` is anchored at a comfortable read-along pace; `.slow` is slower
-  /// still; **`.fast` deliberately matches ``charsPerSecond`` (45)** — the fast
-  /// tier is the "I want speed" escape hatch and should stay quick (do NOT
-  /// "simplify" this apparent duplication away). `.instant` stays `nil` so the
-  /// instant-snap invariant in ``SimulationViewModel/effectiveCharsPerSecond(forEntryId:)``
-  /// holds. Consumed by ``SimulationViewModel/effectiveCharsPerSecond(forEntryId:)``
-  /// (committed rows) and the in-flight streaming row in `SimulationView`.
-  public var simCharsPerSecond: Double? {
     switch self {
     case .slow: 6
     case .normal: 10

--- a/Pastura/Pastura/App/PlaybackSpeed.swift
+++ b/Pastura/Pastura/App/PlaybackSpeed.swift
@@ -22,24 +22,23 @@ import Foundation
 /// - **Sim** (``SimulationViewModel``) uses ``simCharsPerSecond`` (typing
 ///   animation — slower than ``charsPerSecond`` for read-along comprehension),
 ///   ``readingDwell(displayLength:script:)`` (post-utterance reading pause),
-///   and ``interEventDelayMs`` (non-agent inter-event delay). It does NOT use
-///   ``charsPerSecond`` — that property is the demo-replay typing rate (see
-///   below), kept separate so the demo's `typingFloorMs` invariant
-///   (`== normal cps == 30`) is unaffected when the Sim rate changes.
-/// - **``ReplayViewModel``** (the replay *pacing* model) uses
-///   ``multiplier`` to scale ``ReplayPlaybackConfig``'s `turnDelayMs` /
-///   `codePhaseDelayMs`. It does **not** consume ``charsPerSecond`` (it
-///   advances bubbles on its own sleep clock, not a per-character
-///   timeline) nor ``interEventDelayMs`` (its turn vs. codePhase
-///   distinction is richer than Sim's flat 120ms-or-zero gap). Don't
-///   extend replay pacing through the Sim-side properties; add a
-///   replay-side property here if a new pacing dimension is needed.
+///   and ``interEventDelayMs`` (non-agent inter-event delay).
+/// - **``ReplayViewModel``** (the demo replay) uses ``charsPerSecond`` (the
+///   demo typing rate, via ``ReplayViewModel/typingCharsPerSecond``),
+///   ``readingDwell(displayLength:script:)`` — the **same** length-scaled
+///   reading pause the Sim uses — to build its per-bubble turn-dwell floor
+///   (``ReplayViewModel/typingFloorMs(for:script:)``), and ``multiplier`` to
+///   scale the structural base delays (``ReplayPlaybackConfig``'s `turnDelayMs`
+///   / `codePhaseDelayMs`). It does **not** consume ``interEventDelayMs`` (its
+///   turn vs. codePhase distinction is richer than Sim's flat 120ms-or-zero
+///   gap). The dwell floor is real wall-clock at the live cps, so
+///   ``scaledDelay(for:floorMs:)`` scales only the base, never the floor.
 /// - **The DL-time demo replay _screen_** (``ModelDownloadHostView``)
 ///   renders ``ReplayViewModel``'s `chatItems` through ``AgentOutputRow``.
 ///   Its typing cps comes from ``ReplayViewModel/typingCharsPerSecond``,
 ///   which (since #791) tracks the runtime ``ReplayViewModel/playbackSpeed``
-///   — so the demo's Speed picker scales **both** typing cps (this property)
-///   and turn dwell (``multiplier``), matching Sim at every speed (not just
+///   — so the demo's Speed picker scales typing cps, reading dwell, AND the
+///   structural base delays together, matching Sim at every speed (not just
 ///   x1). ``ReplayPlaybackConfig/typingCharsPerSecond`` remains the opt-in
 ///   gate (demo non-nil vs non-demo nil).
 /// - ``.instant`` should be handled by an explicit early-return at
@@ -147,12 +146,13 @@ nonisolated public enum PlaybackSpeed:
   /// gentler than the raw reading-rate ratio (~0.4×) to bias toward
   /// comprehension over speed.
   ///
-  /// **Sim-only.** Like ``charsPerSecond`` and ``interEventDelayMs`` this is
-  /// a Sim-side pacing property: ``ReplayViewModel`` already paces turns via
-  /// ``multiplier`` × `turnDelayMs`/`codePhaseDelayMs` (with its own
-  /// typing-floor read pause) and must NOT route through this — see the
-  /// type-level "Consumers" note and the `multiplier` doc-comment's
-  /// replay-only contract.
+  /// **Shared by Sim and the demo replay.** The Sim sleeps this directly in
+  /// ``SimulationViewModel/holdAfterAgentOutput(script:)``; the demo folds it
+  /// into its per-bubble turn-dwell floor
+  /// (``ReplayViewModel/typingFloorMs(for:script:)``) as the `max(typing, dwell)`
+  /// reading beat, so both surfaces use the one length-scaled pause and cannot
+  /// drift. (``interEventDelayMs`` stays Sim-only; the demo's structural base
+  /// delays are scaled by ``multiplier`` instead.)
   ///
   /// **`displayLength` is the grapheme count of the committed _primary_ text**
   /// (``TurnOutput/primaryText(for:)`` — see the consumer in

--- a/Pastura/Pastura/App/ReplayPlaybackConfig.swift
+++ b/Pastura/Pastura/App/ReplayPlaybackConfig.swift
@@ -49,20 +49,20 @@ nonisolated public struct ReplayPlaybackConfig: Sendable, Equatable {
   /// What the consumer does once playback has nothing left to play.
   public var onComplete: CompletionAction
 
-  /// Character-reveal rate (chars/second) for the demo replay's typing
-  /// animation, and the rate the pacing floor uses to estimate how long a
-  /// bubble takes to type. **Single source of truth** so the View
-  /// (``AgentOutputRow`` via ``ModelDownloadHostView``, through
-  /// ``ReplayViewModel/typingCharsPerSecond``) and the
-  /// ``ReplayViewModel`` turn-dwell floor read the same value and cannot
-  /// drift.
+  /// **Opt-in gate** for the demo replay's typing animation + proportional turn
+  /// dwell. Only its nil-ness is load-bearing: non-nil opts the source into
+  /// per-character reveal and the reading-dwell floor; `nil` keeps the flat
+  /// ``turnDelayMs`` / ``codePhaseDelayMs`` schedule and renders full text
+  /// immediately (matching ``PlaybackSpeed/charsPerSecond`` `nil == .instant`).
   ///
-  /// `nil` means "no proportional dwell" — the turn pacing stays on the
-  /// flat ``turnDelayMs`` / ``codePhaseDelayMs`` schedule and the View
-  /// renders full text immediately (matching ``PlaybackSpeed/charsPerSecond``
-  /// `nil == .instant`). Defaults to `nil` so existing configs and
-  /// timing-sensitive tests keep their legacy behaviour; only ``demoDefault``
-  /// opts in.
+  /// The stored *value* is no longer the floor's cps reference. Both the View
+  /// (``AgentOutputRow`` via ``ModelDownloadHostView``) and the turn-dwell floor
+  /// read ``ReplayViewModel/typingCharsPerSecond``, which resolves the live
+  /// speed-scaled ``PlaybackSpeed/charsPerSecond`` — the single source of truth
+  /// shared with the live Sim — so the two cannot drift regardless of this seed.
+  ///
+  /// Defaults to `nil` so existing configs and timing-sensitive tests keep their
+  /// legacy behaviour; only ``demoDefault`` opts in.
   public var typingCharsPerSecond: Double?
 
   public enum LoopBehaviour: Sendable, Equatable {
@@ -112,7 +112,9 @@ nonisolated public struct ReplayPlaybackConfig: Sendable, Equatable {
     playbackSpeed: .normal,
     loopBehaviour: .loop,
     onComplete: .awaitTransitionSignal,
-    // Opt the demo into proportional turn dwell at the Sim x1 cadence so a
-    // long bubble finishes typing before the next turn appears (no snap).
+    // Opt the demo into per-character typing + the reading-dwell floor. Any
+    // non-nil value works (only nil-ness gates); the floor reads the live
+    // speed-scaled cps, not this seed. `normal.charsPerSecond` is used as the
+    // self-documenting "x1 typing rate" marker.
     typingCharsPerSecond: PlaybackSpeed.normal.charsPerSecond)
 }

--- a/Pastura/Pastura/App/ReplayViewModel.swift
+++ b/Pastura/Pastura/App/ReplayViewModel.swift
@@ -234,12 +234,12 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
   /// SwiftUI re-renders the host (and rebuilds the row with the new cps) when
   /// the menu mutates it — no manual `@Observable` bridge needed.
   ///
-  /// The turn-dwell floor (``typingFloorMs(for:)``) keeps reading the *fixed*
-  /// `config.typingCharsPerSecond` reference, not this speed-scaled value:
-  /// ``scaledDelay(for:floorMs:)`` already divides that floor by
-  /// ``PlaybackSpeed/multiplier``, and `charsPerSecond == 30 × multiplier`, so
-  /// `floorMs / multiplier` already equals the speed-scaled typing duration —
-  /// the dwell stays synced with typing at every speed.
+  /// The turn-dwell floor (``typingFloorMs(for:script:)``) reads this **same**
+  /// speed-scaled value, so the floor is real wall-clock time at the current cps
+  /// rather than a fixed reference divided later. Typing animation, dwell floor,
+  /// and the live Sim (``SimulationViewModel/effectiveCharsPerSecond(forEntryId:)``)
+  /// all resolve from the one ``PlaybackSpeed/charsPerSecond`` source of truth,
+  /// so they cannot drift.
   var typingCharsPerSecond: Double? {
     // `config.typingCharsPerSecond` gates demo (non-nil) vs non-demo (nil).
     guard config.typingCharsPerSecond != nil else { return nil }
@@ -610,6 +610,11 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
     sourceIndex: Int, startCursor: Int, firstSleepOverrideMs: Int?
   ) async {
     let plan = sources[sourceIndex].plannedEvents()
+    // Reading-density class for this source's dwell floor — constant for the
+    // whole source (language can't change mid-stream), resolved once like the
+    // Sim's per-run `script`.
+    let script = ReadingScript.resolve(
+      engineLanguage: sources[sourceIndex].scenario.engineLanguage)
     var cursor = startCursor
     var overrideMs = firstSleepOverrideMs
     // Typing-dwell floor owed by the previously-applied agent bubble (raw,
@@ -630,7 +635,7 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
       apply(paced.event)
       // The floor for THIS bubble gates the delay before the NEXT event — the
       // window during which this bubble is typing on screen.
-      pendingFloorMs = typingFloorMs(for: paced.event)
+      pendingFloorMs = typingFloorMs(for: paced.event, script: script)
       cursor += 1
       // Only advance observable cursor if we're still playing (not
       // backgrounded mid-publish). Guards against a stale state
@@ -813,22 +818,31 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
 
   // MARK: - Pacing helpers
 
-  /// Extra dwell (ms) added on top of a bubble's typing duration so a fully
-  /// typed line lingers a beat before the next turn replaces the latest-row
-  /// animation. Tuned so a short turn's `max(turnDelayMs, typing + readPause)`
-  /// stays near the flat 1200ms rhythm while long bubbles extend past it.
-  private let typingReadPauseMs = 700
-
-  /// Proportional turn-dwell floor (raw ms, pre-speed) the *next* inter-event
-  /// delay must cover so the just-applied agent bubble finishes its
-  /// ``AgentOutputRow`` reveal animation before the next turn appears.
+  /// Proportional turn-dwell floor (raw ms, **real wall-clock at the current
+  /// speed**) the *next* inter-event delay must cover so the just-applied agent
+  /// bubble finishes its ``AgentOutputRow`` reveal — and is read for a beat —
+  /// before the next turn appears.
   ///
-  /// Returns 0 for non-agent events (nothing is typing) and when the config
-  /// opts out of proportional dwell (``ReplayPlaybackConfig/typingCharsPerSecond``
-  /// `== nil`). Otherwise estimates the reveal time via
-  /// ``TurnOutput/revealedSegments(for:includeThought:)`` +
-  /// ``typingDurationMs(primary:thought:charsPerSecond:)`` and adds
-  /// ``typingReadPauseMs``.
+  /// Mirrors the live Sim's
+  /// ``SimulationViewModel/holdAfterAgentOutput(script:)``: the floor is
+  /// `max(typingMs, readingDwellMs)`, NOT their sum, because the two overlap —
+  /// the reader reads the line as it types. Both terms are computed at the
+  /// *actual* speed-scaled cps / tier (the same ``typingCharsPerSecond`` the
+  /// row animates at), so the floor is already real time and ``scaledDelay(for:floorMs:)``
+  /// must NOT divide it again by the speed multiplier.
+  ///
+  /// Returns 0 for non-agent events (nothing is typing) and when there is no
+  /// proportional dwell — the config opts out
+  /// (``ReplayPlaybackConfig/typingCharsPerSecond`` `== nil`, non-demo) or
+  /// playback is `.instant`; both surface as a nil ``typingCharsPerSecond``.
+  ///
+  /// `script` is the current source's reading-density class (from
+  /// ``Scenario/engineLanguage``), resolved once per ``playSource(sourceIndex:startCursor:firstSleepOverrideMs:)``
+  /// entry and threaded in — constant within a source, exactly as the Sim passes
+  /// it to `holdAfterAgentOutput`. The reading dwell's `displayLength` is the
+  /// **primary** grapheme count only (thought excluded), matching the Sim's
+  /// `lastAgentOutputDisplayLength`; the thought, when shown, still counts toward
+  /// the typing term via ``TurnOutput/revealedSegments(for:includeThought:)``.
   ///
   /// The thought segment is gated on the global ``showAllThoughts``. NOTE:
   /// ``AgentOutputRow`` honours a *per-row* `showInnerThought` seeded from
@@ -838,42 +852,50 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
   /// dwell, not a frame-exact contract (animation timing is code-review-gated
   /// per `.claude/rules/view-testing.md` rule 4, not asserted). `internal`
   /// (not `private`) so `ReplayViewModelTests+Pacing` can exercise it.
-  func typingFloorMs(for event: SimulationEvent) -> Int {
+  func typingFloorMs(for event: SimulationEvent, script: ReadingScript) -> Int {
     guard case .agentOutput(_, let output, let phaseType) = event else { return 0 }
-    // Uses the FIXED `config.typingCharsPerSecond` as the dwell reference
-    // (NOT the speed-scaled ``typingCharsPerSecond`` accessor). The
-    // dwell-vs-typing sync (see that accessor's doc) holds only because
-    // ``scaledDelay(for:floorMs:)`` divides this floor by
-    // ``PlaybackSpeed/multiplier`` AND `.demoDefault` seeds
-    // `config.typingCharsPerSecond` to exactly
-    // ``PlaybackSpeed/normal``'s `charsPerSecond` (30), with the speed
-    // buckets as linear multiples of 30. A future config seeding a
-    // non-30 cps while the buckets stay 15/30/45 would desync the floor
-    // from the actual typing rate — keep this reference == normal cps.
-    guard let cps = config.typingCharsPerSecond else { return 0 }
+    // Use the *actual* speed-scaled cps (the same value `AgentOutputRow`
+    // animates at) so the floor is real wall-clock time at the current speed —
+    // NOT a fixed reference divided later. A nil value covers both the opt-out
+    // config (non-demo) and `.instant` (no typing, no dwell).
+    guard let cps = typingCharsPerSecond else { return 0 }
     let segments = output.revealedSegments(
       for: phaseType, includeThought: showAllThoughts)
     let typing = typingDurationMs(
       primary: segments.primary, thought: segments.thought, charsPerSecond: cps)
-    guard typing > 0 else { return 0 }
-    return typing + typingReadPauseMs
+    let dwellMs = Self.milliseconds(
+      playbackSpeed.readingDwell(
+        displayLength: segments.primary.count, script: script))
+    let floor = max(typing, dwellMs)
+    guard floor > 0 else { return 0 }
+    return floor
+  }
+
+  /// Whole milliseconds of a `Duration` that carries only ms precision
+  /// (``PlaybackSpeed/readingDwell(displayLength:script:)`` builds it via
+  /// `.milliseconds`), so the round-trip back to `Int` ms is lossless.
+  private static func milliseconds(_ duration: Duration) -> Int {
+    let (seconds, attoseconds) = duration.components
+    return Int(seconds) * 1000 + Int(attoseconds / 1_000_000_000_000_000)
   }
 
   /// Per-event sleep in milliseconds. Reads ``playbackSpeed`` (the
   /// runtime-mutable VM state, not `config.playbackSpeed`) so a Speed
   /// Menu change reflects on the next call.
   ///
-  /// `.instant` short-circuits to 0ms before the multiplier division —
-  /// symmetric with the early-return in ``YAMLReplaySource``. The
-  /// `.infinity` sentinel on `.instant.multiplier` would arithmetically
-  /// produce 0 too, but explicit early-return avoids depending on
-  /// IEEE-754 division semantics.
+  /// `.instant` short-circuits to 0ms — symmetric with the early-return in
+  /// ``YAMLReplaySource``. The `.infinity` sentinel on `.instant.multiplier`
+  /// would arithmetically produce 0 too, but explicit early-return avoids
+  /// depending on IEEE-754 division semantics.
   ///
-  /// `floorMs` is the proportional turn-dwell floor (raw, pre-speed): the
-  /// time the previously-applied agent bubble still needs to finish typing
-  /// (see ``typingFloorMs(for:)``). The base delay is raised to at least the
-  /// floor *before* the speed division, so a long bubble holds the next turn
-  /// until it has typed out, while short turns keep the flat ``turnDelayMs``
+  /// The **structural base** (``ReplayPlaybackConfig/turnDelayMs`` /
+  /// `codePhaseDelayMs`) scales with ``PlaybackSpeed/multiplier``. `floorMs` —
+  /// the proportional turn-dwell floor from ``typingFloorMs(for:script:)`` — is
+  /// already real wall-clock time at the current cps, so it is **NOT** divided;
+  /// the result is `max(base / multiplier, floorMs)`. This mirrors the live Sim,
+  /// whose hold (`max(readingDwell, pendingTypingHold)`) scales neither term by
+  /// a multiplier. A long bubble therefore holds the next turn until it has
+  /// typed out + been read, while short turns keep the flat ``turnDelayMs``
   /// rhythm. `.instant` ignores the floor too (collapses to 0). `internal`
   /// (not `private`) so `ReplayViewModelTests+Pacing` can pin the arithmetic.
   func scaledDelay(for kind: PacedEvent.Kind, floorMs: Int = 0) -> Int {
@@ -888,7 +910,7 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
     case .lifecycle:
       base = 0
     }
-    return Int(Double(max(base, floorMs)) / speed)
+    return max(Int(Double(base) / speed), floorMs)
   }
 
   /// Computes the outstanding sleep in milliseconds given

--- a/Pastura/Pastura/App/ReplayViewModel.swift
+++ b/Pastura/Pastura/App/ReplayViewModel.swift
@@ -823,13 +823,20 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
   /// bubble finishes its ``AgentOutputRow`` reveal — and is read for a beat —
   /// before the next turn appears.
   ///
-  /// Mirrors the live Sim's
-  /// ``SimulationViewModel/holdAfterAgentOutput(script:)``: the floor is
-  /// `max(typingMs, readingDwellMs)`, NOT their sum, because the two overlap —
-  /// the reader reads the line as it types. Both terms are computed at the
-  /// *actual* speed-scaled cps / tier (the same ``typingCharsPerSecond`` the
-  /// row animates at), so the floor is already real time and ``scaledDelay(for:floorMs:)``
-  /// must NOT divide it again by the speed multiplier.
+  /// The floor is `typingMs + readingDwellMs` — the bubble types its whole line
+  /// over `typingMs`, then the reading dwell is an absorb beat held AFTER the
+  /// line is fully shown. This differs from the live Sim's
+  /// ``SimulationViewModel/holdAfterAgentOutput(script:)``, which uses
+  /// `max(dwell, remaining-tail-typing)`: there the line was already revealed
+  /// during live streaming *before* the hold begins, so the hold only needs the
+  /// dwell (the tail term is tiny). The demo has no streaming pre-reveal — the
+  /// entire reveal happens inside this floor window — so the dwell must be added
+  /// on top of the typing, not max-ed against it (a max would erase the reading
+  /// pause on any line whose typing already exceeds the dwell). Both terms are
+  /// computed at the *actual* speed-scaled cps / tier (the same
+  /// ``typingCharsPerSecond`` the row animates at), so the floor is already real
+  /// time and ``scaledDelay(for:floorMs:)`` must NOT divide it again by the
+  /// speed multiplier.
   ///
   /// Returns 0 for non-agent events (nothing is typing) and when there is no
   /// proportional dwell — the config opts out
@@ -863,12 +870,12 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
       for: phaseType, includeThought: showAllThoughts)
     let typing = typingDurationMs(
       primary: segments.primary, thought: segments.thought, charsPerSecond: cps)
+    // No text to type ⇒ no hold (an empty bubble shouldn't gate the next turn).
+    guard typing > 0 else { return 0 }
     let dwellMs = Self.milliseconds(
       playbackSpeed.readingDwell(
         displayLength: segments.primary.count, script: script))
-    let floor = max(typing, dwellMs)
-    guard floor > 0 else { return 0 }
-    return floor
+    return typing + dwellMs
   }
 
   /// Whole milliseconds of a `Duration` that carries only ms precision

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -236,15 +236,15 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   /// or `nil` when the row must not animate.
   ///
   /// Returns `nil` only for `.instant` playback
-  /// (`speed.simCharsPerSecond == nil`) — every other speed animates. A row
+  /// (`speed.charsPerSecond == nil`) — every other speed animates. A row
   /// whose primary streamed live is NOT snapped here; it animates from its
   /// handoff seed (``handoffSeed(forEntryId:)``) and continues
   /// typing the unrevealed tail at cps (reveal-position handoff, bug 2).
   ///
-  /// Uses ``PlaybackSpeed/simCharsPerSecond`` (the live-Sim rate), NOT
-  /// ``PlaybackSpeed/charsPerSecond`` (which is the demo-replay rate).
+  /// Uses ``PlaybackSpeed/charsPerSecond`` — the single typing-rate source of
+  /// truth shared with the demo replay (``ReplayViewModel/typingCharsPerSecond``).
   func effectiveCharsPerSecond(forEntryId entryId: UUID) -> Double? {
-    speed.simCharsPerSecond
+    speed.charsPerSecond
   }
 
   /// Reveal-handoff seed for the committed row of `entryId`: the
@@ -1460,7 +1460,7 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   /// (`internal`) so the hold decision is unit-testable without a wall-clock
   /// sleep (view-testing rule 4).
   var pendingTypingHold: Duration {
-    guard let reveal = lastAgentOutputReveal, let cps = speed.simCharsPerSecond
+    guard let reveal = lastAgentOutputReveal, let cps = speed.charsPerSecond
     else { return .zero }
     return .milliseconds(
       remainingTypingDurationMs(

--- a/Pastura/Pastura/Views/Components/AgentOutputRow.swift
+++ b/Pastura/Pastura/Views/Components/AgentOutputRow.swift
@@ -75,7 +75,7 @@ import SwiftUI
 /// **Streaming path:** the live Sim in-flight row opts into
 /// ``growsWithReveal`` so the bubble lays out only the visible prefix and
 /// grows with the reveal counter — NOT the streaming buffer. This matters
-/// because the reveal types at ``PlaybackSpeed/simCharsPerSecond`` (slower
+/// because the reveal types at ``PlaybackSpeed/charsPerSecond`` (slower
 /// than tokens arrive); reserving the hidden tail to the buffer made the
 /// bubble expand ahead of the typed text. Width stability is still carried
 /// by `.frame(maxWidth: .infinity, alignment: .leading)` +
@@ -867,7 +867,7 @@ extension AgentOutputRow {
   /// bubble grows with the visible prefix instead of pre-reserving the full
   /// (or, for a streaming row, the *buffer*) height. Two opt-in callers:
   /// the DL-time demo replay rows (#785) and the **live Sim streaming row**
-  /// (its reveal types at ``PlaybackSpeed/simCharsPerSecond`` — slower than
+  /// (its reveal types at ``PlaybackSpeed/charsPerSecond`` — slower than
   /// tokens arrive — so reserving to the streaming buffer made the bubble
   /// outrun the typed text; the demo-proven grow path keeps box and text in
   /// step). Both grow callers pass ``onRevealProgress`` for per-tick

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -485,11 +485,11 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
                 phaseType: snapshot.phaseType,
                 showAllThoughts: viewModel.showAllThoughts,
                 isLatest: false,
-                charsPerSecond: viewModel.speed.simCharsPerSecond,
+                charsPerSecond: viewModel.speed.charsPerSecond,
                 // Follow the per-tick vertical growth: the snapshot-change
                 // scroll below is per-token (too coarse for per-character
                 // growth, and silent once the buffer is complete but the
-                // reveal is still catching up at simCharsPerSecond).
+                // reveal is still catching up at charsPerSecond).
                 onRevealProgress: { scrollToBottom(proxy) },
                 // Report the reveal position so the committed row can pick up
                 // where the stream left off (reveal-position handoff, bug 2).
@@ -497,7 +497,7 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
                 streamingPrimary: snapshot.primary,
                 streamingThought: snapshot.thought,
                 // Grow the bubble with the typed prefix, not the streaming
-                // buffer: the reveal types at simCharsPerSecond (slower than
+                // buffer: the reveal types at charsPerSecond (slower than
                 // tokens arrive), so reserving the hidden tail to the buffer
                 // made the box expand ahead of the visible text.
                 growsWithReveal: true,

--- a/Pastura/PasturaTests/App/PlaybackSpeedTests.swift
+++ b/Pastura/PasturaTests/App/PlaybackSpeedTests.swift
@@ -11,29 +11,18 @@ struct PlaybackSpeedTests {
   }
 
   @Test func charsPerSecondValues() {
-    // Demo-replay typing rate. `.normal == 30` is load-bearing for the demo's
-    // typingFloorMs invariant — do not retune here; the Sim uses simCharsPerSecond.
-    #expect(PlaybackSpeed.slow.charsPerSecond == 15)
-    #expect(PlaybackSpeed.normal.charsPerSecond == 30)
+    // The SINGLE typing-rate source of truth — shared by the live Sim
+    // (``SimulationViewModel/effectiveCharsPerSecond(forEntryId:)``) and the
+    // demo replay (``ReplayViewModel/typingCharsPerSecond``). Change-detector
+    // pin: a failure means a code-review-gated pacing rate drifted — confirm it
+    // was an intentional, reviewed change, then update the expected value.
+    // `.fast` is the speed escape hatch; `.instant` stays nil for the
+    // instant-snap invariant. cps tiers are intentionally non-linear (the demo
+    // floor no longer assumes linearity vs `multiplier`).
+    #expect(PlaybackSpeed.slow.charsPerSecond == 6)
+    #expect(PlaybackSpeed.normal.charsPerSecond == 10)
     #expect(PlaybackSpeed.fast.charsPerSecond == 45)
     #expect(PlaybackSpeed.instant.charsPerSecond == nil)
-  }
-
-  @Test func simCharsPerSecondValues() {
-    // Live-Sim typing rate — slower than charsPerSecond for read-along
-    // comprehension. `.fast` deliberately matches charsPerSecond (45); `.instant`
-    // stays nil for the instant-snap invariant. Change-detector pin.
-    #expect(PlaybackSpeed.slow.simCharsPerSecond == 6)
-    #expect(PlaybackSpeed.normal.simCharsPerSecond == 10)
-    #expect(PlaybackSpeed.fast.simCharsPerSecond == 45)
-    #expect(PlaybackSpeed.instant.simCharsPerSecond == nil)
-  }
-
-  @Test func simCharsPerSecondIsNotFasterThanDemoExceptFast() {
-    // Sim slow/normal are slower (smaller cps) than the demo tiers; fast parity.
-    #expect(PlaybackSpeed.slow.simCharsPerSecond! < PlaybackSpeed.slow.charsPerSecond!)
-    #expect(PlaybackSpeed.normal.simCharsPerSecond! < PlaybackSpeed.normal.charsPerSecond!)
-    #expect(PlaybackSpeed.fast.simCharsPerSecond == PlaybackSpeed.fast.charsPerSecond)
   }
 
   @Test func interEventDelayMsValues() {

--- a/Pastura/PasturaTests/App/ReplayPlaybackConfigTests.swift
+++ b/Pastura/PasturaTests/App/ReplayPlaybackConfigTests.swift
@@ -24,6 +24,8 @@ struct ReplayPlaybackConfigTests {
         == PlaybackSpeed.normal.charsPerSecond)
     // Pins the concrete value so a future PlaybackSpeed.normal change is a
     // deliberate, reviewed edit rather than a silent demo-cadence shift.
-    #expect(ReplayPlaybackConfig.demoDefault.typingCharsPerSecond == 30)
+    // (Only the gate's nil-ness is load-bearing now; the seed value is the
+    // self-documenting x1 typing rate — unified with the Sim at #835.)
+    #expect(ReplayPlaybackConfig.demoDefault.typingCharsPerSecond == 10)
   }
 }

--- a/Pastura/PasturaTests/App/ReplayViewModelTests+Pacing.swift
+++ b/Pastura/PasturaTests/App/ReplayViewModelTests+Pacing.swift
@@ -62,15 +62,16 @@ extension ReplayViewModelTests {
     #expect(viewModel.typingFloorMs(for: event, script: Self.demoScript) == 0)
   }
 
-  @Test func floorIsMaxOfTypingAndReadingDwell() throws {
+  @Test func floorIsTypingPlusReadingDwell() throws {
     let viewModel = try Self.makeDemoPacedVM()  // .normal speed, cps 10
     let event = SimulationEvent.agentOutput(
       agent: "Alice", output: TurnOutput(fields: ["statement": "abc"]),
       phaseType: .speakAll)
     // typingDurationMs("abc", "", 10) == 300 (no punctuation); readingDwell(len 3,
-    // dense, normal) == 300 + 60*3 == 480; floor == max(300, 480) == 480 (the
-    // reading dwell dominates this short line).
-    #expect(viewModel.typingFloorMs(for: event, script: Self.demoScript) == 480)
+    // dense, normal) == 300 + 60*3 == 480; floor == typing + dwell == 780. The
+    // dwell is an absorb beat held AFTER the line types out (the demo reveals the
+    // whole line inside the floor window), not max-ed against typing.
+    #expect(viewModel.typingFloorMs(for: event, script: Self.demoScript) == 780)
   }
 
   @Test func floorUsesSparseDwellForLatinScript() throws {
@@ -79,8 +80,8 @@ extension ReplayViewModelTests {
       agent: "Alice", output: TurnOutput(fields: ["statement": "abc"]),
       phaseType: .speakAll)
     // Same typing (300) but sparse dwell == 300 + 38*3 == 414;
-    // floor == max(300, 414) == 414. Confirms the dwell tracks the script.
-    #expect(viewModel.typingFloorMs(for: event, script: .sparse) == 414)
+    // floor == 300 + 414 == 714. Confirms the dwell tracks the script.
+    #expect(viewModel.typingFloorMs(for: event, script: .sparse) == 714)
   }
 
   @Test func floorOmitsThoughtWhenThoughtsHidden() throws {
@@ -90,9 +91,9 @@ extension ReplayViewModelTests {
       agent: "Alice",
       output: TurnOutput(fields: ["statement": "abc", "inner_thought": "secret"]),
       phaseType: .speakAll)
-    // Thought excluded → floor stays the no-thought dwell (480); including it
-    // would push typing to 1200 (9 chars + boundary beat) and dominate.
-    #expect(viewModel.typingFloorMs(for: event, script: Self.demoScript) == 480)
+    // Thought excluded → typing stays 300, floor == 300 + dwell(480) == 780;
+    // including it would push typing to 1200 (9 chars + boundary beat) → 1680.
+    #expect(viewModel.typingFloorMs(for: event, script: Self.demoScript) == 780)
   }
 
   // MARK: - scaledDelay floor application

--- a/Pastura/PasturaTests/App/ReplayViewModelTests+Pacing.swift
+++ b/Pastura/PasturaTests/App/ReplayViewModelTests+Pacing.swift
@@ -34,7 +34,7 @@ extension ReplayViewModelTests {
 
   // MARK: - typingFloorMs (per-bubble dwell floor)
 
-  /// VM built with `demoDefault` (opts into `typingCharsPerSecond == 30`).
+  /// VM built with `demoDefault` (opts into proportional typing + dwell).
   private static func makeDemoPacedVM() throws -> ReplayViewModel {
     let source = try Self.makeSource()
     return ReplayViewModel(
@@ -63,22 +63,23 @@ extension ReplayViewModelTests {
   }
 
   @Test func floorIsMaxOfTypingAndReadingDwell() throws {
-    let viewModel = try Self.makeDemoPacedVM()  // .normal speed, cps 30 here
+    let viewModel = try Self.makeDemoPacedVM()  // .normal speed, cps 10
     let event = SimulationEvent.agentOutput(
-      agent: "Alice", output: TurnOutput(fields: ["statement": "Hi."]),
+      agent: "Alice", output: TurnOutput(fields: ["statement": "abc"]),
       phaseType: .speakAll)
-    // typingDurationMs("Hi.", "", 30) == 400; readingDwell(len 3, dense, normal)
-    // == 300 + 60*3 == 480; floor == max(400, 480) == 480.
+    // typingDurationMs("abc", "", 10) == 300 (no punctuation); readingDwell(len 3,
+    // dense, normal) == 300 + 60*3 == 480; floor == max(300, 480) == 480 (the
+    // reading dwell dominates this short line).
     #expect(viewModel.typingFloorMs(for: event, script: Self.demoScript) == 480)
   }
 
   @Test func floorUsesSparseDwellForLatinScript() throws {
-    let viewModel = try Self.makeDemoPacedVM()  // .normal speed, cps 30 here
+    let viewModel = try Self.makeDemoPacedVM()  // .normal speed, cps 10
     let event = SimulationEvent.agentOutput(
-      agent: "Alice", output: TurnOutput(fields: ["statement": "Hi."]),
+      agent: "Alice", output: TurnOutput(fields: ["statement": "abc"]),
       phaseType: .speakAll)
-    // Same cps (typing 400) but sparse dwell == 300 + 38*3 == 414;
-    // floor == max(400, 414) == 414. Confirms the dwell tracks the script.
+    // Same typing (300) but sparse dwell == 300 + 38*3 == 414;
+    // floor == max(300, 414) == 414. Confirms the dwell tracks the script.
     #expect(viewModel.typingFloorMs(for: event, script: .sparse) == 414)
   }
 
@@ -87,9 +88,10 @@ extension ReplayViewModelTests {
     viewModel.showAllThoughts = false
     let event = SimulationEvent.agentOutput(
       agent: "Alice",
-      output: TurnOutput(fields: ["statement": "Hi.", "inner_thought": "secret"]),
+      output: TurnOutput(fields: ["statement": "abc", "inner_thought": "secret"]),
       phaseType: .speakAll)
-    // Thought excluded → same as the no-thought case (480), not larger.
+    // Thought excluded → floor stays the no-thought dwell (480); including it
+    // would push typing to 1200 (9 chars + boundary beat) and dominate.
     #expect(viewModel.typingFloorMs(for: event, script: Self.demoScript) == 480)
   }
 
@@ -126,5 +128,29 @@ extension ReplayViewModelTests {
     let viewModel = try Self.makeDemoPacedVM()
     viewModel.playbackSpeed = .instant
     #expect(viewModel.scaledDelay(for: .turn, floorMs: 5000) == 0)
+  }
+
+  // MARK: - Cross-consumer drift guard (single source of truth, #835)
+
+  /// Non-tautological guard that the live Sim and the demo replay resolve their
+  /// typing cps from the **same** ``PlaybackSpeed/charsPerSecond``. It exercises
+  /// the two real consumer methods (not the property directly) at every speed,
+  /// so a future re-split — e.g. reintroducing a Sim-only typing-rate property —
+  /// diverges one side and trips this. This is the structural protection the cps
+  /// unification buys; the value pin lives in `PlaybackSpeedTests`.
+  @Test func simAndDemoResolveSameTypingCps() throws {
+    let demo = try Self.makeDemoPacedVM()  // .demoDefault opts into typing cps
+    let db = try DatabaseManager.inMemory()
+    let sim = SimulationViewModel(
+      contentFilter: ContentFilter(blockedPatterns: []),
+      simulationRepository: GRDBSimulationRepository(dbWriter: db.dbWriter),
+      turnRepository: GRDBTurnRepository(dbWriter: db.dbWriter))
+    for speed in PlaybackSpeed.allCases {
+      demo.playbackSpeed = speed
+      sim.speed = speed
+      #expect(
+        demo.typingCharsPerSecond == sim.effectiveCharsPerSecond(forEntryId: UUID()),
+        "sim and demo typing cps diverged at \(speed)")
+    }
   }
 }

--- a/Pastura/PasturaTests/App/ReplayViewModelTests+Pacing.swift
+++ b/Pastura/PasturaTests/App/ReplayViewModelTests+Pacing.swift
@@ -41,9 +41,16 @@ extension ReplayViewModelTests {
       sources: [source], config: .demoDefault, contentFilter: ContentFilter())
   }
 
+  // The demo fixture is `language: ja` (`makeSource()`), so the run resolves to
+  // `.dense` reading density — pin it explicitly here so the next reader does
+  // not recompute the expected dwell against `.sparse`.
+  private static let demoScript: ReadingScript = .dense
+
   @Test func floorIsZeroForNonAgentEvent() throws {
     let viewModel = try Self.makeDemoPacedVM()
-    #expect(viewModel.typingFloorMs(for: .roundStarted(round: 1, totalRounds: 3)) == 0)
+    #expect(
+      viewModel.typingFloorMs(
+        for: .roundStarted(round: 1, totalRounds: 3), script: Self.demoScript) == 0)
   }
 
   @Test func floorIsZeroWhenConfigOptsOut() throws {
@@ -52,16 +59,27 @@ extension ReplayViewModelTests {
     let event = SimulationEvent.agentOutput(
       agent: "Alice", output: TurnOutput(fields: ["statement": "Hi."]),
       phaseType: .speakAll)
-    #expect(viewModel.typingFloorMs(for: event) == 0)
+    #expect(viewModel.typingFloorMs(for: event, script: Self.demoScript) == 0)
   }
 
-  @Test func floorIsTypingDurationPlusReadPause() throws {
-    let viewModel = try Self.makeDemoPacedVM()
+  @Test func floorIsMaxOfTypingAndReadingDwell() throws {
+    let viewModel = try Self.makeDemoPacedVM()  // .normal speed, cps 30 here
     let event = SimulationEvent.agentOutput(
       agent: "Alice", output: TurnOutput(fields: ["statement": "Hi."]),
       phaseType: .speakAll)
-    // typingDurationMs("Hi.", "", 30) == 400; + typingReadPauseMs(700) == 1100.
-    #expect(viewModel.typingFloorMs(for: event) == 1100)
+    // typingDurationMs("Hi.", "", 30) == 400; readingDwell(len 3, dense, normal)
+    // == 300 + 60*3 == 480; floor == max(400, 480) == 480.
+    #expect(viewModel.typingFloorMs(for: event, script: Self.demoScript) == 480)
+  }
+
+  @Test func floorUsesSparseDwellForLatinScript() throws {
+    let viewModel = try Self.makeDemoPacedVM()  // .normal speed, cps 30 here
+    let event = SimulationEvent.agentOutput(
+      agent: "Alice", output: TurnOutput(fields: ["statement": "Hi."]),
+      phaseType: .speakAll)
+    // Same cps (typing 400) but sparse dwell == 300 + 38*3 == 414;
+    // floor == max(400, 414) == 414. Confirms the dwell tracks the script.
+    #expect(viewModel.typingFloorMs(for: event, script: .sparse) == 414)
   }
 
   @Test func floorOmitsThoughtWhenThoughtsHidden() throws {
@@ -71,8 +89,8 @@ extension ReplayViewModelTests {
       agent: "Alice",
       output: TurnOutput(fields: ["statement": "Hi.", "inner_thought": "secret"]),
       phaseType: .speakAll)
-    // Thought segment excluded → same as the no-thought case (1100), not larger.
-    #expect(viewModel.typingFloorMs(for: event) == 1100)
+    // Thought excluded → same as the no-thought case (480), not larger.
+    #expect(viewModel.typingFloorMs(for: event, script: Self.demoScript) == 480)
   }
 
   // MARK: - scaledDelay floor application
@@ -80,6 +98,15 @@ extension ReplayViewModelTests {
   @Test func scaledDelayTakesFloorWhenFloorExceedsBase() throws {
     let viewModel = try Self.makeDemoPacedVM()  // .normal speed (multiplier 1.0)
     // floor 5000 > turnDelayMs 1200 → 5000.
+    #expect(viewModel.scaledDelay(for: .turn, floorMs: 5000) == 5000)
+  }
+
+  @Test func scaledDelayHonorsRealTimeFloorAtFastSpeed() throws {
+    let viewModel = try Self.makeDemoPacedVM()
+    viewModel.playbackSpeed = .fast
+    // Structural base compresses (1200 / 1.5 == 800) but the floor is real
+    // wall-clock time at the current cps, so it is NOT divided → max(800, 5000)
+    // == 5000. (The old `max(base, floor)/multiplier` form yielded 3333.)
     #expect(viewModel.scaledDelay(for: .turn, floorMs: 5000) == 5000)
   }
 

--- a/Pastura/PasturaTests/App/ReplayViewModelTests+Speed.swift
+++ b/Pastura/PasturaTests/App/ReplayViewModelTests+Speed.swift
@@ -141,12 +141,14 @@ extension ReplayViewModelTests {
 
   // MARK: - typingCharsPerSecond tracks playbackSpeed (#791)
   //
-  // Before #791 the demo's typing cps was the fixed `config.typingCharsPerSecond`
-  // (30), so the Speed menu changed only turn dwell, not typing. These pin that
-  // the cps now follows the runtime `playbackSpeed` (Sim parity) on a demo
-  // (opt-in) config, and that a non-demo config (typingCharsPerSecond == nil)
-  // still opts out regardless of speed. Reverting the fix (returning
+  // Before #791 the demo's typing cps was the fixed `config.typingCharsPerSecond`,
+  // so the Speed menu changed only turn dwell, not typing. These pin that the cps
+  // now follows the runtime `playbackSpeed` (Sim parity) on a demo (opt-in)
+  // config, and that a non-demo config (typingCharsPerSecond == nil) still opts
+  // out regardless of speed. Reverting the fix (returning
   // `config.typingCharsPerSecond`) makes the .slow/.fast/.instant cases fail.
+  // The cps values are the unified ``PlaybackSpeed/charsPerSecond`` (#835),
+  // shared with the live Sim.
 
   @Test func typingCharsPerSecondTracksPlaybackSpeedOnDemoDefault() throws {
     let source = try YAMLReplaySource(
@@ -156,10 +158,10 @@ extension ReplayViewModelTests {
 
     viewModel.playbackSpeed = .slow
     #expect(viewModel.typingCharsPerSecond == PlaybackSpeed.slow.charsPerSecond)
-    #expect(viewModel.typingCharsPerSecond == 15)
+    #expect(viewModel.typingCharsPerSecond == 6)
 
     viewModel.playbackSpeed = .normal
-    #expect(viewModel.typingCharsPerSecond == 30)
+    #expect(viewModel.typingCharsPerSecond == 10)
 
     viewModel.playbackSpeed = .fast
     #expect(viewModel.typingCharsPerSecond == 45)

--- a/Pastura/PasturaTests/App/SimulationViewModelStreamingTests+Handoff.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelStreamingTests+Handoff.swift
@@ -35,7 +35,7 @@ extension SimulationViewModelStreamingTests {
     #expect(sut.handoffSeed(forEntryId: committedId) == 3)
     #expect(
       sut.effectiveCharsPerSecond(forEntryId: committedId)
-        == PlaybackSpeed.normal.simCharsPerSecond)
+        == PlaybackSpeed.normal.charsPerSecond)
   }
 
   @Test func nonStreamedEntryHasZeroHandoffSeed() throws {
@@ -53,7 +53,7 @@ extension SimulationViewModelStreamingTests {
     #expect(sut.handoffSeed(forEntryId: committedId) == 0)
     #expect(
       sut.effectiveCharsPerSecond(forEntryId: committedId)
-        == PlaybackSpeed.normal.simCharsPerSecond)
+        == PlaybackSpeed.normal.charsPerSecond)
   }
 
   @Test func differentAgentCommitGetsZeroHandoff() throws {
@@ -76,7 +76,7 @@ extension SimulationViewModelStreamingTests {
     #expect(sut.handoffSeed(forEntryId: bobId) == 0)
     #expect(
       sut.effectiveCharsPerSecond(forEntryId: bobId)
-        == PlaybackSpeed.normal.simCharsPerSecond)
+        == PlaybackSpeed.normal.charsPerSecond)
   }
 
   @Test func parseRetryAfterStreamSeedsOnlyRetryEntry() throws {
@@ -175,7 +175,7 @@ extension SimulationViewModelStreamingTests {
     #expect(sut.handoffSeed(forEntryId: committedId) == 0)
     #expect(
       sut.effectiveCharsPerSecond(forEntryId: committedId)
-        == PlaybackSpeed.normal.simCharsPerSecond)
+        == PlaybackSpeed.normal.charsPerSecond)
   }
 
   /// `.instant` speed must bypass the streaming snapshot gate entirely.
@@ -204,7 +204,7 @@ extension SimulationViewModelStreamingTests {
     let committedId = try #require(sut.latestAgentOutputId)
     // No streaming row was ever set, so there is no handoff seed.
     #expect(sut.handoffSeed(forEntryId: committedId) == 0)
-    // `.instant.simCharsPerSecond` is nil by definition; pins the instant-snap
+    // `.instant.charsPerSecond` is nil by definition; pins the instant-snap
     // invariant (the only case where the committed row still snaps to full).
     #expect(sut.effectiveCharsPerSecond(forEntryId: committedId) == nil)
   }
@@ -227,7 +227,7 @@ extension SimulationViewModelStreamingTests {
         phaseType: .speakAll),
       scenario: scenario)
 
-    let cps = try #require(PlaybackSpeed.normal.simCharsPerSecond)
+    let cps = try #require(PlaybackSpeed.normal.charsPerSecond)
     let expected = remainingTypingDurationMs(
       seed: 6, primary: "hello world", thought: "", charsPerSecond: cps)
     #expect(expected > 0)  // sanity: there is unrevealed tail to type

--- a/Pastura/PasturaTests/Views/AgentOutputRowContractTests+ReservedTail.swift
+++ b/Pastura/PasturaTests/Views/AgentOutputRowContractTests+ReservedTail.swift
@@ -81,7 +81,7 @@ extension AgentOutputRowContractTests {
 
   @Test func dropsHiddenTailForStreamingRowWithGrowsWithReveal() {
     // The live Sim streaming row opts into `growsWithReveal` so the bubble
-    // grows with the typed prefix (simCharsPerSecond is slower than tokens
+    // grows with the typed prefix (charsPerSecond is slower than tokens
     // arrive — reserving to the buffer made the box outrun the text). A
     // streaming override animates (`shouldAnimate` true via streamingPrimary),
     // so grows + animating → drop the tail.


### PR DESCRIPTION
## Summary
The DL-time demo replay typed ~2-3× faster than the live simulation at
x0.5 / x1: the two surfaces had separate chars-per-second properties, and
only the sim had been retuned to a slower read-along pace (6/10/45) while
the demo kept the older 15/30/45. This unifies the typing speed into one
source of truth and matches the demo's inter-turn pacing to the sim, so
the two cannot drift again.

- **Floor model (commit 1)** — `ReplayViewModel.typingFloorMs` now
  estimates typing at the *actual* speed-scaled cps and folds in the sim's
  length-scaled, language-aware `PlaybackSpeed.readingDwell` as a
  `max(typing, dwell)` reading beat — mirroring
  `SimulationViewModel.holdAfterAgentOutput`. `scaledDelay` becomes
  `max(base / multiplier, floor)` (the floor is real wall-clock time, so
  it is no longer multiplier-divided). The flat 700 ms read pause and the
  old "fixed 30 cps ÷ multiplier" linearity trick are gone, so the cps
  tiers are free to be non-linear. `script` is resolved once per
  `playSource` from the source's `engineLanguage`.
- **cps unification (commit 2)** — deletes `PlaybackSpeed.simCharsPerSecond`;
  the surviving `charsPerSecond` holds the unified **6 / 10 / 45** and both
  the sim (`effectiveCharsPerSecond` / `pendingTypingHold`) and the demo
  (`typingCharsPerSecond`) read it. With a single property the two cannot
  drift. All sim callsites + doc references repointed.

## Test plan
- `scripts/xcodebuild.sh test -skip-testing:PasturaUITests` — **2355 unit
  tests pass**.
- `swiftlint lint --quiet --strict` — clean.
- Updated the cps change-detector to 6/10/45 and refreshed the demo floor
  expectations for the new rate (cps 10: dense dwell 480 / sparse 414 on a
  short line; thought excluded from the dwell).
- Added a **cross-consumer drift guard** (`simAndDemoResolveSameTypingCps`)
  asserting the sim and demo resolve the same typing cps at every speed —
  trips on any future re-split.
- Opus `code-reviewer` pass: PASS (0 blocking issues).

Closes #835.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
