### PR TITLE
🐛 fix: gallery index missing language + auto-derive in curation scripts

### DIFF
--- a/docs/gallery/README.md
+++ b/docs/gallery/README.md
@@ -80,15 +80,16 @@ Note: `language` is a property of the **YAML body** AND is denormalized
 into the `gallery.json` index entry above. The index copy is required so
 the Browse (さがす) tab can filter by language **before** downloading any
 YAML — the in-app install-time read of the YAML body still happens, but it
-is too late for the pre-download list filter. The two MUST agree;
-`GallerySeedYAMLTests.galleryLanguageMatchesYAML` pins index ==
-YAML for every entry. (This complements — does not duplicate — ADR-010 D6's
+is too late for the pre-download list filter. The two MUST agree, and three
+layers enforce it: `scripts/add-gallery-entry.sh` **auto-derives** the index
+`language` from the YAML `language:` scalar (so entries added through the
+script are always in sync), `scripts/check-gallery-entry.sh --all` (pre-commit
++ CI gallery-drift gate) rejects any index entry whose `language` is missing,
+out of range, or ≠ the YAML — covering hand-edits the script never touches —
+and `GallerySeedYAMLTests.galleryLanguageMatchesYAML` pins index == YAML in
+the iOS suite. (This complements — does not duplicate — ADR-010 D6's
 `ScenarioRecord.language` column, which serves the installed-row Home /
 Past Results consumer, a different surface that reads the local DB.)
-
-> Index `language` is currently backfilled by hand when adding an entry.
-> Teaching `scripts/add-gallery-entry.sh` to derive it from the YAML
-> `language:` is a Step D follow-up (alongside the `_en` sibling entries).
 
 ## Current entries
 
@@ -282,8 +283,9 @@ In update mode:
   *No change needed* — `updated_at` is **not** bumped, so re-running
   is free.
 - The confirmation prompt shows an old → new diff for changed fields
-  only, with `(from YAML)` source labels on `title` / `yaml_sha256` so
-  you can tell YAML-driven changes from flag-driven ones.
+  only, with `(from YAML)` source labels on YAML-derived fields
+  (`title` / `agent_count` / `rounds` / `phases` / `language` /
+  `yaml_sha256`) so you can tell YAML-driven changes from flag-driven ones.
 
 ### What auto-syncs from YAML on `--update`?
 
@@ -295,6 +297,7 @@ In update mode:
 | `agents:`       | `agent_count`   | **Yes**     | YAML-derived fact; `GallerySeedYAMLTests.galleryAgentCountAndRoundsMatchYAML` enforces equality.                          |
 | `rounds:`       | `rounds`        | **Yes**     | Same YAML-derived enforcement as `agent_count` (same test).                                                               |
 | `phases[].type` | `phases`        | **Yes**     | Ordered phase types; `GallerySeedYAMLTests.galleryPhasesMatchYAML` enforces equality.                                     |
+| `language:`     | `language`      | **Yes**     | ISO 639-1 (ja/en); `GallerySeedYAMLTests.galleryLanguageMatchesYAML` + `check-gallery-entry.sh` enforce equality.         |
 
 If you actually want the gallery `description` to re-sync from the
 YAML, pass it explicitly. One-liner that pulls the current YAML value:

--- a/docs/gallery/gallery.json
+++ b/docs/gallery/gallery.json
@@ -441,6 +441,7 @@
         "choose",
         "summarize"
       ],
+      "language": "ja",
       "yaml_url": "kyoyu_gyojo_v1.yaml",
       "yaml_sha256": "a5793670872fca129637c088cf643ea92cf2dd0ca5b2c19dae1e69e39898da77",
       "added_at": "2026-06-30"

--- a/scripts/add-gallery-entry.sh
+++ b/scripts/add-gallery-entry.sh
@@ -212,6 +212,19 @@ case "$YAML_ROUNDS" in ''|*[!0-9]*) echo "ERROR: YAML 'rounds' must be a positiv
 # error matching the agents/rounds style above, not a raw Python traceback.
 YAML_PHASES="$(python3 -c "import sys, yaml, json; print(json.dumps([p['type'] for p in yaml.safe_load(open(sys.argv[1]))['phases']]))" "$YAML_PATH")" \
   || { echo "ERROR: YAML 'phases' must be a list of mappings each carrying a 'type' key" >&2; exit 1; }
+# language: ISO 639-1 body language (ja/en per ADR-010 D1), a YAML-derived
+# fact like agents/rounds/phases — denormalized into the index so the Browse
+# tab can filter by language before download; the Swift
+# GallerySeedYAMLTests.galleryLanguageMatchesYAML pins it against this value.
+# `.get('language')` (not `['language']`) + the ja/en case-guard emit the same
+# curated error style as the agents/rounds/phases checks on a missing/null or
+# out-of-range value, rather than a raw Python KeyError. The guard is
+# exact-lowercase to match ScenarioLoader's case-sensitive rule.
+YAML_LANGUAGE="$(python3 -c "import sys, yaml; print(yaml.safe_load(open(sys.argv[1])).get('language') or '')" "$YAML_PATH")"
+case "$YAML_LANGUAGE" in
+  ja|en) ;;
+  *) echo "ERROR: YAML 'language' must be present and one of ja/en (got: '$YAML_LANGUAGE')" >&2; exit 1 ;;
+esac
 YAML_SHA="$(shasum -a 256 "$YAML_PATH" | awk '{print $1}')"
 YAML_SIZE="$(wc -c < "$YAML_PATH" | awk '{print $1}')"
 
@@ -383,6 +396,7 @@ NEW_ENTRY=$(jq -n \
   --argjson agent_count "$YAML_AGENTS" \
   --argjson rounds "$YAML_ROUNDS" \
   --argjson phases "$YAML_PHASES" \
+  --arg language "$YAML_LANGUAGE" \
   --arg yaml_url "$YAML_BASENAME" \
   --arg yaml_sha256 "$YAML_SHA" \
   --arg added_at "$ADDED_AT" \
@@ -397,6 +411,7 @@ NEW_ENTRY=$(jq -n \
     agent_count: $agent_count,
     rounds: $rounds,
     phases: $phases,
+    language: $language,
     yaml_url: $yaml_url,
     yaml_sha256: $yaml_sha256,
     added_at: $added_at
@@ -442,7 +457,7 @@ print_entry_diff() {
   local old="$1"
   local new="$2"
   local field old_val new_val source_label
-  for field in title category description author recommended_model estimated_inferences agent_count rounds phases added_at yaml_sha256; do
+  for field in title category description author recommended_model estimated_inferences agent_count rounds phases language added_at yaml_sha256; do
     old_val="$(echo "$old" | jq -r --arg f "$field" '.[$f] | tostring')"
     new_val="$(echo "$new" | jq -r --arg f "$field" '.[$f] | tostring')"
     if [ "$old_val" = "$new_val" ]; then
@@ -450,7 +465,7 @@ print_entry_diff() {
     fi
     source_label=""
     case "$field" in
-      title|yaml_sha256|agent_count|rounds|phases) source_label=" (from YAML)" ;;
+      title|yaml_sha256|agent_count|rounds|phases|language) source_label=" (from YAML)" ;;
     esac
     if [ "$field" = "description" ] && { [[ "$old_val" == *$'\n'* ]] || [[ "$new_val" == *$'\n'* ]]; }; then
       printf "  %s%s (old):\n" "$field" "$source_label"

--- a/scripts/check-gallery-entry.sh
+++ b/scripts/check-gallery-entry.sh
@@ -73,6 +73,13 @@ yaml_id() {
   python3 -c "import sys, yaml; print(yaml.safe_load(open(sys.argv[1]))['id'])" "$1"
 }
 
+# Parse YAML top-level language via PyYAML (same robustness as yaml_id).
+# Prints the empty string when the key is absent/null so the caller can
+# distinguish "missing" from "present but out of range".
+yaml_language() {
+  python3 -c "import sys, yaml; print(yaml.safe_load(open(sys.argv[1])).get('language') or '')" "$1"
+}
+
 # Lowercase hex SHA-256 — matches URLSessionGalleryService's runtime
 # format and gallery.json.yaml_sha256. shasum is BSD perl on macOS and
 # perl-based on ubuntu — output format is identical (`<hex>  <file>`).
@@ -100,6 +107,7 @@ check_entry() {
   local yaml_path="$1"
   local expected_id="$2"
   local expected_sha="$3"
+  local expected_lang="$4"
 
   local actual_id
   actual_id="$(yaml_id "$yaml_path")"
@@ -121,6 +129,21 @@ check_entry() {
   size="$(file_size "$yaml_path")"
   if [ "$size" -gt "$MAX_BYTES" ]; then
     fail "size ${size} bytes exceeds 256 KiB cap (id=$expected_id, $yaml_path)"
+  fi
+  # Language: the index copy must be present, one of ja/en (ADR-010 D1), and
+  # equal to the YAML body's language. This is a data-level gate — it fires at
+  # pre-commit / the gallery-drift CI job, outside the iOS test suite, and so
+  # also covers the README "Manual fallback" hand-edit path that
+  # add-gallery-entry.sh's auto-derivation never touches. Mirrors the Swift
+  # GallerySeedYAMLTests.galleryLanguageMatchesYAML pin (#848).
+  local actual_lang
+  actual_lang="$(yaml_language "$yaml_path")"
+  case "$actual_lang" in
+    ja|en) ;;
+    *) fail "YAML 'language' must be present and one of ja/en — got '$actual_lang' (id=$expected_id, $yaml_path)" ;;
+  esac
+  if [ "$expected_lang" != "$actual_lang" ]; then
+    fail "language mismatch for id=$expected_id — gallery.json='${expected_lang:-<missing>}' but YAML='$actual_lang' ($yaml_path)"
   fi
 }
 
@@ -145,14 +168,14 @@ fi
 
 if [ "$MODE" = "--all" ]; then
   check_id_uniqueness
-  while IFS=$'\t' read -r entry_id entry_url entry_sha; do
+  while IFS=$'\t' read -r entry_id entry_url entry_sha entry_lang; do
     yaml_path="$GALLERY_DIR/$(basename "$entry_url")"
     if [ ! -f "$yaml_path" ]; then
       fail "yaml file missing for id=$entry_id — expected $yaml_path"
       continue
     fi
-    check_entry "$yaml_path" "$entry_id" "$entry_sha"
-  done < <(jq -r '.scenarios[] | [.id, .yaml_url, .yaml_sha256] | @tsv' "$GALLERY_JSON")
+    check_entry "$yaml_path" "$entry_id" "$entry_sha" "$entry_lang"
+  done < <(jq -r '.scenarios[] | [.id, .yaml_url, .yaml_sha256, (.language // "")] | @tsv' "$GALLERY_JSON")
 else
   yaml_path="$MODE"
   if [ ! -f "$yaml_path" ]; then
@@ -168,7 +191,8 @@ else
   else
     expected_id="$(echo "$entry_json" | jq -r '.id')"
     expected_sha="$(echo "$entry_json" | jq -r '.yaml_sha256')"
-    check_entry "$yaml_path" "$expected_id" "$expected_sha"
+    expected_lang="$(echo "$entry_json" | jq -r '.language // ""')"
+    check_entry "$yaml_path" "$expected_id" "$expected_sha" "$expected_lang"
   fi
   check_id_uniqueness
 fi

--- a/scripts/tests/gallery-scripts-test.sh
+++ b/scripts/tests/gallery-scripts-test.sh
@@ -241,6 +241,39 @@ runc "$R" bash scripts/add-gallery-entry.sh docs/gallery/nolang_v1.yaml \
 expect_fail "A7 missing language fails"
 expect_out "must be present and one of ja/en" "A7 missing-language message"
 
+# ============================ check-gallery-entry ========================
+
+# C1 — check --all passes on a well-formed entry (index language present and
+# matching the YAML body). Built via add-gallery-entry (now auto-derives it).
+R="$(new_repo)"; mk_gallery_yaml "$R" cg_v1 4 2
+runc "$R" bash scripts/add-gallery-entry.sh docs/gallery/cg_v1.yaml \
+  --category creative --recommended-model gemma-4-e2b-q4-k-m \
+  --estimated-inferences 8 --description card --author tester --non-interactive
+expect_ok "C1 add exits 0"
+runc "$R" bash scripts/check-gallery-entry.sh --all
+expect_ok "C1 check passes with valid language"
+
+# C2 — index language hand-stripped from gallery.json → check fails. This is
+# the README "Manual fallback" hand-edit path that add-gallery-entry never
+# touches; only this data-level gate (and the Swift test) catches it.
+jq '.scenarios[0] |= del(.language)' "$R/docs/gallery/gallery.json" > "$R/docs/gallery/gallery.json.t"
+mv "$R/docs/gallery/gallery.json.t" "$R/docs/gallery/gallery.json"
+runc "$R" bash scripts/check-gallery-entry.sh --all
+expect_fail "C2 missing index language fails"
+expect_out "language mismatch" "C2 missing-language gate message"
+
+# C3 — index language contradicts the YAML body (en vs ja) → check fails.
+R="$(new_repo)"; mk_gallery_yaml "$R" cg2_v1 4 2
+runc "$R" bash scripts/add-gallery-entry.sh docs/gallery/cg2_v1.yaml \
+  --category creative --recommended-model gemma-4-e2b-q4-k-m \
+  --estimated-inferences 8 --description card --author tester --non-interactive
+expect_ok "C3 add exits 0"
+jq '.scenarios[0].language = "en"' "$R/docs/gallery/gallery.json" > "$R/docs/gallery/gallery.json.t"
+mv "$R/docs/gallery/gallery.json.t" "$R/docs/gallery/gallery.json"
+runc "$R" bash scripts/check-gallery-entry.sh --all
+expect_fail "C3 index != YAML language fails"
+expect_out "language mismatch" "C3 language-mismatch gate message"
+
 # ================================ summary ================================
 
 echo ""

--- a/scripts/tests/gallery-scripts-test.sh
+++ b/scripts/tests/gallery-scripts-test.sh
@@ -191,6 +191,8 @@ runc "$R" bash scripts/add-gallery-entry.sh docs/gallery/foo_v1.yaml \
 expect_ok "A1 add exits 0"
 runc "$R" jq -r '.scenarios[0] | "\(.id) \(.agent_count) \(.rounds)"' docs/gallery/gallery.json
 expect_out "foo_v1 5 3" "A1 entry agent_count/rounds from YAML scalars"
+runc "$R" jq -r '.scenarios[0].language' docs/gallery/gallery.json
+expect_out "ja" "A1 entry language derived from YAML language: scalar"
 
 # A2 — duplicate id rejected in add mode (reuses A1's repo state).
 runc "$R" bash scripts/add-gallery-entry.sh docs/gallery/foo_v1.yaml \
@@ -227,6 +229,17 @@ runc "$R" bash scripts/add-gallery-entry.sh docs/gallery/bar_v1.yaml \
   --description card --author tester --non-interactive
 expect_fail "A6 non-interactive missing category fails"
 expect_out "category is missing" "A6 missing-field message"
+
+# A7 — YAML missing `language:` rejected with a curated error (not a raw
+# Python KeyError). Strip the line portably (mirrors A3's sed-then-mv idiom).
+R="$(new_repo)"; mk_gallery_yaml "$R" nolang_v1 4 2
+grep -v '^language:' "$R/docs/gallery/nolang_v1.yaml" > "$R/docs/gallery/nolang_v1.yaml.t"
+mv "$R/docs/gallery/nolang_v1.yaml.t" "$R/docs/gallery/nolang_v1.yaml"
+runc "$R" bash scripts/add-gallery-entry.sh docs/gallery/nolang_v1.yaml \
+  --category creative --recommended-model gemma-4-e2b-q4-k-m \
+  --estimated-inferences 8 --description card --author tester --non-interactive
+expect_fail "A7 missing language fails"
+expect_out "must be present and one of ja/en" "A7 missing-language message"
 
 # ================================ summary ================================
 


### PR DESCRIPTION
## Summary
Follow-up to #843. A scenario promoted by a PR that branched **before** #843 merged (#847 `kyoyu_gyojo_v1`) landed its `gallery.json` entry without the `language` index field, reddening `main` (`GallerySeedYAMLTests.galleryLanguageMatchesYAML`). Fix it, and prevent recurrence with three enforcement layers.

- **Fix red main**: backfill `"language": "ja"` on `kyoyu_gyojo_v1` (its YAML already declares `language: ja`; index unchanged otherwise → `yaml_sha256` stays valid).
- **`add-gallery-entry.sh` auto-derives** the index `language` from the YAML `language:` scalar — a YAML-derived fact like `agents`/`rounds`/`phases` (always re-derived, never carried from `EXISTING_ENTRY` on `--update`). Validated `ja`/`en` with a curated error (`.get()`, not a raw KeyError); wired into the `jq` entry (before `yaml_url`) and `print_entry_diff` (`(from YAML)` label). Closes the recurrence path for entries added **through the script**.
- **`check-gallery-entry.sh` gates it** (pre-commit + CI, outside the iOS suite): each index `language` must be present, `ja`/`en`, and equal to the YAML — covering the README **hand-edit fallback** path the script can't reach.
- **Docs**: README reworded (three-layer enforcement) + `language` row in the auto-sync table.

### Residual root cause (not fully closed here)
The deeper cause is that #847's branch **merged stale** — its CI passed on a ref that predated #843's test, and it was merged without being brought up to date. Script-derivation + the data gate are necessary but not sufficient for that class; the durable fix is branch-protection "require branches to be up to date before merging" (out of scope for this PR).

## Test plan
- `scripts/tests/gallery-scripts-test.sh`: **48 pass** — A1 (derived `ja`), A7 (missing-`language:` rejected), C1–C3 (check gate: pass / hand-stripped index / index≠YAML).
- `scripts/check-gallery-entry.sh --all`: green on all 21 live entries.
- `GallerySeedYAMLTests` (9, incl. `galleryLanguageMatchesYAML`): **pass** — red main resolved.
- `code-reviewer` (Opus): PASS, 0 issues.

Closes #848

🤖 Generated with [Claude Code](https://claude.com/claude-code)