### PR TITLE
✨ feat: add English versions of 4 universal gallery scenarios (B1)

### DIFF
--- a/docs/gallery/README.md
+++ b/docs/gallery/README.md
@@ -105,10 +105,12 @@ source of truth). Adding new entries follows the workflow in
 | `kinoko_takenoko_v1` | きのこの山 vs たけのこの里 | `ja` | creative | 2026-04-29 |
 
 Per-language sibling entries (e.g., `asch_conformity_v1_en` with
-`language: en`) ship in ADR-010 Step D alongside the bundled English
-presets; the `language` column will gain `en` rows then. Cross-language
-canonical grouping uses `ScenarioRecord.sourceId` per ADR-010 D4 — out
-of scope for this README.
+`language: en`) ship independently of the bundled English presets — the
+gallery is a separate distribution surface. The first en batch (universal
+scenarios) lands via #850; once `gallery.json` carries ≥2 languages the
+Browse (さがす) language-filter chip row auto-un-dormants (ADR-010 D6 /
+#843). Cross-language canonical grouping uses `ScenarioRecord.sourceId`
+per ADR-010 D4 — out of scope for this README.
 
 ## Curation Rules
 

--- a/docs/gallery/asch_conformity_v1_en.yaml
+++ b/docs/gallery/asch_conformity_v1_en.yaml
@@ -1,0 +1,51 @@
+id: asch_conformity_v1_en
+language: en
+name: Asch Conformity Experiment
+description: >
+  A recreation of the classic conformity experiment with four confederates
+  and one real subject. As the confederates confidently give an obviously
+  wrong answer first, the subject wavers between honesty and conformity.
+agents: 5
+rounds: 2
+
+context: >
+  You are taking part in a visual-perception experiment. Three comparison
+  lines are shown, and you must say — in turn — which one matches the
+  reference line in length. The correct answer is clearly "B", but you
+  answer out loud after hearing the other participants respond.
+
+personas:
+  - name: Confederate A
+    description: >
+      [Role] Secretly instructed as an experiment confederate to answer "C".
+      [Goal] State "C" with unwavering confidence, no hesitation.
+  - name: Confederate B
+    description: >
+      [Role] Secretly instructed as an experiment confederate to answer "C".
+      [Goal] Fall in line with A and also answer "C".
+  - name: Confederate C
+    description: >
+      [Role] Secretly instructed as an experiment confederate to answer "C".
+      [Goal] Match the other confederates and answer "C" without pause.
+  - name: Confederate D
+    description: >
+      [Role] Secretly instructed as an experiment confederate to answer "C".
+      [Goal] Declare "C" flatly and assertively.
+  - name: Subject Sam
+    description: >
+      [Role] The one real subject, unaware that the other four are confederates.
+      [Goal] Wants to trust his own eyes and answer honestly, but is rattled
+      when everyone else says something different. Plain-spoken and candid;
+      the kind of person whose doubt slips into his voice.
+
+phases:
+  - type: speak_each
+    prompt: >
+      Which line matches the reference line in length — A, B, or C?
+      Answer in one sentence with your choice and how you feel about it.
+    output:
+      statement: string
+      inner_thought: string
+
+  - type: summarize
+    template: "Round {current_round} answers: {conversation_log}"

--- a/docs/gallery/detective_scene_v1_en.yaml
+++ b/docs/gallery/detective_scene_v1_en.yaml
@@ -1,0 +1,94 @@
+id: detective_scene_v1_en
+language: en
+name: The Detective's Deduction
+description: >
+  A murder at a country manor. Four suspects and one detective trade alibis
+  and motives, and at the end the detective names the culprit — a short
+  deduction roleplay. If the vote splits, it branches into a rebuttal round.
+agents: 5
+rounds: 1
+
+context: >
+  The setting is a 1920s Western manor. The wealthy Mr. Hamilton has been
+  poisoned in his study. The four suspects who were present and an invited
+  private detective sit around a round table. Each reveals an alibi and a
+  motive, and the detective deduces the culprit at the end.
+
+personas:
+  - name: Butler Wallace
+    description: >
+      [Role] A loyal butler who served the master for thirty years.
+      [Goal] Protests his innocence, but hides that the master had been about
+      to dismiss him.
+      Courteous and careful.
+  - name: Niece Eleanor
+    description: >
+      [Role] The master's sole heir apparent.
+      [Goal] Conceals her interest in the inheritance while professing her
+      innocence. Grows talkative when flustered.
+  - name: Gardener Thomas
+    description: >
+      [Role] Has tended the manor's gardens for a few years. Usually quiet.
+      [Goal] Claims he was in the greenhouse the night of the murder, but no
+      one saw him.
+      Blunt and terse.
+  - name: Doctor Carter
+    description: >
+      [Role] The master's personal physician, with knowledge of poisons.
+      [Goal] Explains the situation with professional insight while hiding
+      that his own prescription could have been the weapon.
+      Cool and logical.
+  - name: Detective Holmes
+    description: >
+      [Role] A renowned private detective.
+      [Goal] Presses on the contradictions in each testimony and identifies
+      the true culprit.
+      Sharp, with an occasional streak of irony.
+
+phases:
+  - type: speak_each
+    prompt: >
+      What the others have said: {conversation_log}
+      From your standpoint, state your alibi for the night of the murder or
+      something you observed, in 1-2 sentences.
+    output:
+      statement: string
+      inner_thought: string
+
+  - type: vote
+    prompt: >
+      Statements so far:
+      {conversation_log}
+
+      Who do you think is the culprit? Choose the most suspicious person.
+      Your vote must be exactly one of these names: {candidates}
+    exclude_self: false
+    output:
+      vote: string
+      reason: string
+
+  - type: score_calc
+    logic: vote_tally
+
+  - type: conditional
+    if: "max_score >= 3"
+    then:
+      - type: summarize
+        template: >
+          🔎 Decisive evidence! At least 3 of the 5 named {vote_winner}
+          ({vote_results}). By majority agreement, {vote_winner} is declared
+          the culprit.
+    else:
+      - type: speak_each
+        prompt: >
+          The vote was split: {vote_results}
+          If you were accused, offer a rebuttal; otherwise add one more
+          observation, in 1-2 sentences.
+        output:
+          statement: string
+          inner_thought: string
+      - type: summarize
+        template: >
+          ⚖️ Not quite conclusive... The first vote split ({vote_results}),
+          and even after rebuttals the leading suspicion still points to
+          {vote_winner}. The truth remains in the dark...

--- a/docs/gallery/gallery.json
+++ b/docs/gallery/gallery.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-06-30T00:00:00Z",
+  "updated_at": "2026-07-01T00:00:00Z",
   "scenarios": [
     {
       "id": "asch_conformity_v1",
@@ -445,6 +445,86 @@
       "yaml_url": "kyoyu_gyojo_v1.yaml",
       "yaml_sha256": "a5793670872fca129637c088cf643ea92cf2dd0ca5b2c19dae1e69e39898da77",
       "added_at": "2026-06-30"
+    },
+    {
+      "id": "asch_conformity_v1_en",
+      "title": "Asch Conformity Experiment",
+      "category": "social_psychology",
+      "description": "A recreation of the classic conformity experiment: four confederates and one real subject.",
+      "author": "tyabu12",
+      "recommended_model": "gemma-4-e2b-q4-k-m",
+      "estimated_inferences": 10,
+      "agent_count": 5,
+      "rounds": 2,
+      "phases": [
+        "speak_each",
+        "summarize"
+      ],
+      "language": "en",
+      "yaml_url": "asch_conformity_v1_en.yaml",
+      "yaml_sha256": "35b3484e0d3b6a9b5c90615f9cb101d70a5bbcac0ccd689bde10ed8eb2f18cfc",
+      "added_at": "2026-07-01"
+    },
+    {
+      "id": "trolley_dilemma_v1_en",
+      "title": "The Trolley Problem",
+      "category": "ethics",
+      "description": "Four bystanders with differing ethical outlooks debate, then choose to act.",
+      "author": "tyabu12",
+      "recommended_model": "gemma-4-e2b-q4-k-m",
+      "estimated_inferences": 12,
+      "agent_count": 4,
+      "rounds": 2,
+      "phases": [
+        "speak_all",
+        "choose"
+      ],
+      "language": "en",
+      "yaml_url": "trolley_dilemma_v1_en.yaml",
+      "yaml_sha256": "57cfe1e023d9a2edcf0b2a1685f00fe6c4f78921d25d15f913086933ad7cba89",
+      "added_at": "2026-07-01"
+    },
+    {
+      "id": "detective_scene_v1_en",
+      "title": "The Detective's Deduction",
+      "category": "roleplay",
+      "description": "A manor-murder deduction roleplay with four suspects and one detective; a split vote branches into a rebuttal round.",
+      "author": "tyabu12",
+      "recommended_model": "gemma-4-e2b-q4-k-m",
+      "estimated_inferences": 15,
+      "agent_count": 5,
+      "rounds": 1,
+      "phases": [
+        "speak_each",
+        "vote",
+        "score_calc",
+        "conditional"
+      ],
+      "language": "en",
+      "yaml_url": "detective_scene_v1_en.yaml",
+      "yaml_sha256": "1862ed39acddb11c0a37cb2dd7ef599b50e4036727d2cceadd8d58964757c187",
+      "added_at": "2026-07-01"
+    },
+    {
+      "id": "kasei_sanso_touban_v1_en",
+      "title": "Mars Colony — Oxygen Duty",
+      "category": "game_theory",
+      "description": "The Mars colony's oxygen unit is failing. Someone must make a deadly spacewalk repair, but everyone hopes it won't be them — a volunteer's-dilemma duty meeting.",
+      "author": "tyabu12",
+      "recommended_model": "gemma-4-e2b-q4-k-m",
+      "estimated_inferences": 30,
+      "agent_count": 5,
+      "rounds": 2,
+      "phases": [
+        "speak_all",
+        "vote",
+        "score_calc",
+        "conditional"
+      ],
+      "language": "en",
+      "yaml_url": "kasei_sanso_touban_v1_en.yaml",
+      "yaml_sha256": "8c3e61d16a527984c0caf7cd7d720e20c5e3ba56cdf67049bd92fddcb0ef5c3f",
+      "added_at": "2026-07-01"
     }
   ]
 }

--- a/docs/gallery/kasei_sanso_touban_v1_en.yaml
+++ b/docs/gallery/kasei_sanso_touban_v1_en.yaml
@@ -1,0 +1,103 @@
+id: kasei_sanso_touban_v1_en
+language: en
+name: Mars Colony — Oxygen Duty
+description: >
+  The Mars colony's oxygen supply unit is about to fail. Unless one person
+  goes out for a dangerous repair, everyone suffocates — but whoever goes may
+  not survive. Everyone hopes "someone other than me should go" — the classic
+  volunteer's dilemma. If they fail to agree, the oxygen drops further.
+context: >
+  You are a resident of a Mars colony. The oxygen supply unit is on the verge
+  of failure, and unless one person goes out for a dangerous repair, everyone
+  will suffocate. But the spacewalk is life-threatening.
+  Each round, you argue from your standpoint — in 1-2 sentences — for who
+  should go out to make the repair (you may offer to go yourself, or push for
+  someone else).
+  Then you vote for whoever, other than yourself, you think is "most fit for
+  the repair duty".
+  If no agreement is reached, the oxygen drops further and the situation worsens.
+agents: 5
+rounds: 2
+personas:
+  - name: Veteran Engineer Galo
+    description: >
+      [Role] The most senior technician, who knows the unit best. Truly the
+      right person for the job.
+      [Goal] Says "I'm the one who should do it, but..." while using his age
+      and irreplaceable experience as a shield to look for a way out.
+      A classic free-rider who stresses his own indispensability to dodge the duty.
+  - name: Rookie Toto
+    description: >
+      [Role] A newcomer, freshly assigned and low in standing.
+      [Goal] Weighed down by "I haven't been useful yet", he keeps nearly
+      getting the job pushed onto him.
+      Doesn't want to go, but struggles to find a reason to refuse.
+  - name: Doctor Karen
+    description: >
+      [Role] The colony's only physician.
+      [Goal] Firmly refuses the duty with the indispensability argument:
+      "If I go down, no one can treat anyone."
+      Her logic is sound — and it keeps her safer than anyone.
+  - name: Optimist Noah
+    description: >
+      [Role] A bystander type who figures things will work out.
+      [Goal] The embodiment of the bystander effect — "surely someone will
+      do it" — with no sense of personal responsibility.
+      Tends to drag the discussion out.
+  - name: Leader Gen
+    description: >
+      [Role] The colony's person in charge; the coordinator.
+      [Goal] Pushes for consensus, but cleverly avoids the one option where he
+      is the one sacrificed.
+      Talks "the good of the whole" while quietly protecting himself.
+phases:
+  - type: speak_all
+    prompt: >
+      Round {current_round}. The oxygen reserve is dropping.
+      Discussion so far: {conversation_log}
+
+      Argue, from your standpoint in 1-2 sentences, for who should go out to
+      make the repair. You may offer to go yourself, or push for someone else.
+    output:
+      statement: string
+      inner_thought: string
+  - type: vote
+    prompt: >
+      Each person's argument:
+      {conversation_log}
+
+      Vote for whoever, other than yourself, you think is "most fit for the
+      repair duty".
+      Your vote must be exactly one of these names: {candidates}
+    output:
+      vote: string
+      reason: string
+    exclude_self: true
+  - type: score_calc
+    logic: vote_tally
+  - type: conditional
+    if: "max_score >= 3"
+    then:
+      - type: summarize
+        template: >
+          Round {current_round}: a majority named a single person for the duty.
+          The colony has barely reached agreement. Nominations: {scoreboard}
+    else:
+      - type: event_inject
+        source: crisis_events
+        as: current_event
+        probability: 1
+      - type: speak_all
+        prompt: >
+          No agreement was reached, and things took a turn for the worse:
+          {current_event}
+
+          In light of this emergency, state your stance in one line from your
+          standpoint.
+        output:
+          statement: string
+crisis_events:
+  - While the argument dragged on, the oxygen level dropped into the danger
+    zone and the alarm began to sound.
+  - White smoke rose from the unit, and the window for repair shrank to almost
+    nothing.

--- a/docs/gallery/trolley_dilemma_v1_en.yaml
+++ b/docs/gallery/trolley_dilemma_v1_en.yaml
@@ -1,0 +1,68 @@
+id: trolley_dilemma_v1_en
+language: en
+name: The Trolley Problem
+description: >
+  A runaway trolley is bearing down on five workers. Pulling the lever
+  diverts it onto a track where one worker stands. Four bystanders with
+  differing ethical outlooks debate and finally choose to act.
+agents: 4
+rounds: 2
+
+context: >
+  You are a bystander beside the tracks. A runaway trolley is about to run
+  over five workers. Pulling the lever in front of you diverts the trolley
+  onto another track — but one worker is standing there. Do you pull the
+  lever? After the debate, you choose a final action
+  (pull: pull the lever / stand: do nothing).
+
+personas:
+  - name: Utilitarian Leo
+    description: >
+      [Role] A utilitarian who believes in the greatest good for the greatest
+      number.
+      [Goal] Support sacrificing one to save five without hesitation.
+      Calm and mathematical. e.g. "Five against one — there's nothing to weigh."
+  - name: Deontologist Maria
+    description: >
+      [Role] A Kantian with a deep aversion to using a person as a means.
+      [Goal] Above all, kill no one and never be complicit in another's death
+      by her own hand. She will not pull the lever herself, because pulling it
+      would make her the direct, intending cause of a death — a line she holds
+      even when five could be saved.
+      Careful and principled. e.g. "I cannot make myself the killer of that one person."
+  - name: Empath Ethan
+    description: >
+      [Role] Trusts gut feeling over reasoning; highly empathetic.
+      [Goal] Voice his emotional reactions to what unfolds in front of him,
+      honestly.
+      Frank and wavering. e.g. "I hate both options... but I can't just do nothing."
+  - name: Bystander Yuna
+    description: >
+      [Role] A cautious type who believes she should not intervene.
+      [Goal] Stay out of it and bear no responsibility.
+      Reserved and detached. e.g. "I can't decide. It's not my place to decide."
+
+phases:
+  - type: speak_all
+    prompt: >
+      Situation: the trolley is heading for five people. Pulling the lever
+      switches it onto a track with one person.
+      Discussion so far: {conversation_log}
+      State your view in 1-2 sentences from your standpoint.
+    output:
+      statement: string
+      inner_thought: string
+
+  - type: choose
+    prompt: >
+      Final decision. Answer strictly as your own character, staying true to
+      your ethical standpoint even if the others disagree with you — do not
+      just side with the majority.
+      Choose "pull" (pull the lever) or "stand" (stand by without pulling),
+      and give your reason in one sentence.
+    output:
+      action: string
+      inner_thought: string
+    options:
+      - pull
+      - stand


### PR DESCRIPTION
## Summary
B1 batch (universal 4) of the gallery English-versions effort — the **first** en content in the shared-scenario gallery. Part of #850 (Phase 2 translation; #843 shipped the app-side language-filter plumbing, #849 the tooling).

- `asch_conformity_v1_en` — Asch Conformity Experiment (social_psychology)
- `trolley_dilemma_v1_en` — The Trolley Problem (ethics)
- `detective_scene_v1_en` — The Detective's Deduction (roleplay)
- `kasei_sanso_touban_v1_en` — Mars Colony — Oxygen Duty (game_theory)

Each is a translation of its JA sibling; `gallery.json` entries mirror the siblings' category/model/est_inferences and were auto-derived by `add-gallery-entry.sh` (language/title/agent_count/rounds/phases/sha256), so index↔YAML stays pinned.

**Activation:** this merge lands ≥2 languages in `gallery.json`, so the Browse (さがす) language-filter chip row auto-un-dormants (ADR-010 D6 / #843). A leading "All" chip keeps every language reachable.

## Field-test results
All 4 run on `pastura-harness` with `gemma-4-E2B-it-Q4_K_M` (real inference), `status=ok`:

| Scenario | Result |
|---|---|
| asch | pass **at JA parity** — the confederate-answer-flip is a pre-existing weakness present in the JA original too (verified by running the JA baseline); the subject behaves correctly |
| trolley | pass — required en-specific `choose`-phase tuning (persona-fidelity anchor + Maria decision-explicit goal) A/B-tested 3/3 to recover JA choice-differentiation (JA: Maria→stand, Yu→stand, Ren/Haruto→pull; straight-translated en collapsed all to pull) |
| detective | pass — persona voices strong; split-vote rebuttal else-branch fires |
| kasei | pass (strong) — free-rider / volunteer's-dilemma dynamic lands |

## Test plan
- `scripts/check-gallery-entry.sh --all` ✅ · `gallery-precommit-gate.sh` ✅ · Opus code review PASS (placeholder/structure parity + translation fidelity)
- GallerySeedYAMLTests (CI) pins index↔YAML — green expected
- Device QA: confirm the language-filter chip row appears and the "All" chip reaches the 21 JA scenarios (filter flips live on merge)

Part of #850

🤖 Generated with [Claude Code](https://claude.com/claude-code)