### PR TITLE
✨ feat: move Run Simulation CTA to the ScenarioDetail toolbar

### DIFF
--- a/.claude/rules/swiftui-traps.md
+++ b/.claude/rules/swiftui-traps.md
@@ -138,12 +138,17 @@ blanket "id always leaks."
 
 ```swift
 ScrollView { … }
-  .accessibilityIdentifier("scenarioDetail.list")   // BEFORE — scopes scroll content only
-  .safeAreaInset(edge: .bottom) { runCTA }            // inset keeps its own button id
+  .accessibilityIdentifier("myScreen.list")   // BEFORE — scopes scroll content only
+  .safeAreaInset(edge: .bottom) { footerButton }  // inset keeps its own button id
 ```
 
-Reference + inline rationale: `ScenarioDetailView.swift` (`scenarioDetail.list`
-just above its `.safeAreaInset`).
+The motivating instance — `ScenarioDetailView`'s bottom Run CTA under
+`scenarioDetail.list` — was moved into the toolbar (#851), so no live
+in-repo case of this exact bottom-inset-plus-button-id shape remains; the
+trap still applies to any future bottom-`safeAreaInset` that hosts an
+id'd control. The other live bottom-`.safeAreaInset` user
+(`ModelDownloadHostView+ChatStream.swift`, `promoCardInset`) doesn't hit
+it because its inset content carries no competing button id.
 
 **Diagnose** which id an element actually carries — instead of guessing —
 by exporting the a11y snapshot from the failing `.xcresult`:

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -5071,6 +5071,16 @@
         }
       }
     },
+    "Run" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "実行"
+          }
+        }
+      }
+    },
     "Run Simulation" : {
       "localizations" : {
         "ja" : {

--- a/Pastura/Pastura/Views/ScenarioDetail/ScenarioDetailView.swift
+++ b/Pastura/Pastura/Views/ScenarioDetail/ScenarioDetailView.swift
@@ -64,12 +64,24 @@ struct ScenarioDetailView: View {
         PasturaBackButton()
       }
       .hidingPasturaSharedBackground()
-      // Low-frequency scenario-management actions (edit / clone / delete)
-      // live in a `⋯` overflow menu rather than a pinned top-right slot —
-      // the prime real estate is reserved for the primary Run CTA (now a
-      // bottom-pinned button). Mirrors `ResultDetailView`'s ellipsis idiom.
+      // Trailing actions: the primary Run CTA sits at the trailing edge —
+      // the prime slot for the app's core action — with the low-frequency
+      // `⋯` overflow menu (edit / clone / delete) to its LEFT. This reverses
+      // the earlier layout that pinned Run as a bottom `.safeAreaInset`
+      // button: the InFlightSimulationIndicator "return to run" pill is a
+      // bottom-aligned `RootTabView` overlay shown while a run is
+      // parked-away, so it collided with a bottom-pinned Run CTA here.
+      // Moving Run into the toolbar frees the bottom edge for that pill.
+      //
+      // Two SEPARATE `ToolbarItem`s (not one HStack): a single `ToolbarItem`
+      // renders only one control, so an HStack of {Menu, Button} drops the
+      // Button entirely (verified — the Run button vanished from the a11y
+      // tree). Declaration order `[⋯]` then `[Run]` places Run at the
+      // trailing edge; the system's inter-item spacing separates the two so
+      // a stray tap doesn't land on the ⋯ menu (which holds the destructive
+      // Delete). They gate on independent optionals (`record` vs `scenario`).
       if let record = viewModel?.record {
-        ToolbarItem(placement: .primaryAction) {
+        ToolbarItem(placement: .topBarTrailing) {
           Menu {
             // Read-only sources (preset / installed gallery copy) get a
             // clone-as-template action; user scenarios get direct edit.
@@ -100,6 +112,37 @@ struct ScenarioDetailView: View {
             Image(systemName: "ellipsis.circle")
           }
           .accessibilityIdentifier("scenarioDetail.actionsMenu")
+        }
+        .hidingPasturaSharedBackground()
+      }
+      if let viewModel, let scenario = viewModel.scenario {
+        ToolbarItem(placement: .topBarTrailing) {
+          Button {
+            // Synchronous tap → plain `push` onto the current tab's stack
+            // (navigation.md § "When to use what"). A `NavigationLink` in a
+            // toolbar has no precedent here and the file's `Menu`-push
+            // caveat (see the `router` doc-comment above) argues against it.
+            // `initialName` feeds SimulationView's nav title from the first
+            // frame; identity-neutral via `RouteHint` (ADR-008).
+            router.push(
+              .simulation(
+                scenarioId: scenarioId,
+                initialName: .init(scenario.name)))
+          } label: {
+            Label(String(localized: "Run"), systemImage: "play.fill")
+              // Toolbar `Label`s default to icon-only; force the "実行" text
+              // to render beside the ▶ (the approved [▶ Run] treatment, not
+              // an ambiguous icon-only button).
+              .labelStyle(.titleAndIcon)
+          }
+          .buttonStyle(PasturaToolbarButtonStyle(variant: .primary))
+          .disabled(!viewModel.canRun)
+          // `PasturaToolbarButtonStyle` doesn't dim on `.disabled`, so the
+          // not-runnable state is signalled explicitly (mirrors the old
+          // bottom CTA's `.opacity(0.4)`).
+          .opacity(viewModel.canRun ? 1 : 0.4)
+          .accessibilityLabel(String(localized: "Run Simulation"))
+          .accessibilityIdentifier("scenarioDetail.runSimulationButton")
         }
         .hidingPasturaSharedBackground()
       }
@@ -160,17 +203,10 @@ struct ScenarioDetailView: View {
     .background(Color.screenBackground.ignoresSafeArea())
     // Post-load anchor: this ScrollView only exists once the scenario
     // content has resolved, so ScreenshotTourTests / NavigationRegressionTests
-    // can wait on it instead of sleeping. MUST come before `.safeAreaInset`:
-    // applied after, its identifier scopes the inset's Run button too and
-    // overrides the button's own `scenarioDetail.runSimulationButton` id.
+    // can wait on it instead of sleeping. (The primary Run CTA now lives in
+    // the toolbar, so the earlier "must precede `.safeAreaInset`" id-scoping
+    // constraint no longer applies.)
     .accessibilityIdentifier("scenarioDetail.list")
-    // Primary CTA pinned to the bottom safe-area edge so the app's core
-    // action stays in the thumb zone regardless of scroll position; content
-    // scrolls under the band. The tab bar sits below this (focus mode hides
-    // the tab bar only during a run, ADR-017 — not here).
-    .safeAreaInset(edge: .bottom) {
-      runSimulationCTA(scenario: scenario, viewModel: viewModel)
-    }
     .scrollPosition($scrollPosition)
     // A cross-language toggle reuses this leaf (replaceTop swaps the top
     // route in place), so the ScrollView keeps its prior offset — which
@@ -185,42 +221,4 @@ struct ScenarioDetailView: View {
     }
   }
 
-  /// Bottom-pinned primary call-to-action. Uses `PasturaPrimaryButtonStyle`
-  /// in its `.compact` size — a centred, content-width pill rather than a
-  /// full-width slab, keeping design-system §1's restrained "static, observed"
-  /// voice (the full-width mossDark bar read as too dominant on device). Stays
-  /// a `NavigationLink` pushing onto the current tab's stack (no
-  /// `navigationDestination(item:)` — navigation.md).
-  private func runSimulationCTA(
-    scenario: Scenario, viewModel: ScenarioDetailViewModel
-  ) -> some View {
-    // initialName supplies the scenario name to SimulationView's
-    // navigationTitle from the first frame, before loadAndRun() re-parses
-    // the YAML. Identity-neutral via RouteHint (ADR-008).
-    NavigationLink(
-      value: Route.simulation(
-        scenarioId: scenarioId,
-        initialName: .init(scenario.name)
-      )
-    ) {
-      Label(String(localized: "Run Simulation"), systemImage: "play.fill")
-    }
-    .buttonStyle(PasturaPrimaryButtonStyle(size: .compact))
-    .disabled(!viewModel.canRun)
-    .opacity(viewModel.canRun ? 1 : 0.4)
-    .accessibilityIdentifier("scenarioDetail.runSimulationButton")
-    // Intrinsic-width pill centred in the full-width band (no label
-    // `.frame(maxWidth:)`); the outer frame spans the band so the hairline
-    // background reaches both edges.
-    .frame(maxWidth: .infinity)
-    .padding(.vertical, 12)
-    // Opaque band + top hairline so scroll content reads as passing *under*
-    // a distinct footer, not blending into the last card. If device QA shows
-    // a colour seam against the tab bar, bleed the band background down with
-    // `.ignoresSafeArea(.container, edges: .bottom)` (background only).
-    .background(alignment: .top) {
-      Color.screenBackground
-        .overlay(alignment: .top) { Color.rule.frame(height: 0.5) }
-    }
-  }
 }


### PR DESCRIPTION
## Summary
The `InFlightSimulationIndicator` "return to run" pill is a bottom-aligned `RootTabView` overlay shown while a run is parked-away (`isActive && !isSimulationOnTop`, not screen-scoped). On `ScenarioDetailView` it landed on top of the bottom-pinned "Run Simulation" CTA (`.safeAreaInset(edge: .bottom)`) — a direct collision.

This moves the Run CTA into the top-right toolbar, freeing the bottom edge for the pill.

- **Layout**: two `.topBarTrailing` toolbar items ordered `[⋯] [▶ Run]` — Run at the trailing edge (prime slot for the app's core action), the low-frequency ⋯ overflow menu to its left. Two separate `ToolbarItem`s (a single `ToolbarItem` + `HStack` silently drops the second control — verified via the a11y tree).
- **Style**: flat moss `PasturaToolbarButtonStyle(variant: .primary)` — design-system §5.8 compliant (no fill capsule; a filled capsule was considered and rejected). `.labelStyle(.titleAndIcon)` keeps the "実行"/"Run" text beside the ▶ (toolbar `Label`s default to icon-only).
- **Navigation**: `router.push(.simulation(...))` (not `NavigationLink` — no toolbar precedent, and the file's `Menu`-push caveat argues against it).
- **Disabled state**: explicit `.opacity(canRun ? 1 : 0.4)` since the flat style doesn't dim on `.disabled`.
- i18n: new `"Run"` key (ja「実行」) for the short visible label; a11y label keeps the full "Run Simulation". Identifier `scenarioDetail.runSimulationButton` unchanged (UI-test compat).
- Repointed the now-stale `.safeAreaInset` id-scope reference in `swiftui-traps.md`.

## Test plan
- Full test suite green (unit + UI). The 3 UI tests that reach the Run button (`NavigationRegressionTests`, `SimulationFocusModeTests`, `InFlightIndicatorReconnectUITests`) pass against the toolbar button.
- `ScreenshotTourTests` visually confirmed the `[⋯][▶ Run]` order, flat moss styling, and visible text label.
- ⚠️ **Real-device iOS 26 QA needed**: toolbar item order/spacing + the Liquid Glass capsule opt-out (`.hidingPasturaSharedBackground()`) are simulator-misleading per swiftui-traps §5.8.
- Note: Run leaves the bottom thumb-zone for the top-right corner — a deliberate trade-off to resolve the pill collision.

Closes #851

🤖 Generated with [Claude Code](https://claude.com/claude-code)