### PR TITLE
✨ feat: シミュレーション画面にオープニングカード（入口演出）

### DIFF
--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -556,14 +556,17 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   /// Arms the intro gate at run start (View-driven, only when an opening card
   /// will be shown — the View owns the single premise-visibility predicate, so
   /// the gate can't wait for a card that never renders). Starts the backstop.
-  func beginIntro() {
+  ///
+  /// `revealBackstop` is a last-resort cap (should never fire): the caller sizes
+  /// it above the real reveal time (premise length ÷ slowest playback speed +
+  /// buffer) so a card that silently never signals can't freeze the run, without
+  /// clipping a long premise typing at the slow speed.
+  func beginIntro(revealBackstop: TimeInterval) {
     introGateArmed = true
     introRevealCompleted = false
     introTimeoutTask?.cancel()
     introTimeoutTask = Task { @MainActor [weak self] in
-      // Generous cap — longer than any plausible premise reveal (short
-      // descriptions, min 6 cps); only fires if the card silently never signals.
-      try? await Task.sleep(for: .seconds(60))
+      try? await Task.sleep(for: .seconds(revealBackstop))
       self?.introRevealDidComplete()
     }
   }
@@ -941,12 +944,16 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
       currentLLM = nil
       suspendController = nil
       // Intro-gate teardown (#853): cancel the reveal backstop so it can't
-      // outlive the run. The gate's own cancellation handler already resumed
-      // any waiting `awaitIntroReveal()` on task-cancel (this defer runs only
-      // once `run()` returns, so it can't rescue a still-suspended gate — the
-      // cancellation handler / latch does that). No-op in resume() (unarmed).
+      // outlive the run, and disarm so `isPlayingIntro` settles to false on
+      // EVERY exit (normal / load-failure early-return / cancel — the last two
+      // never reach the reveal-complete latch, so without this the flag would
+      // linger until dealloc). The gate's own cancellation handler already
+      // resumed any waiting `awaitIntroReveal()` on task-cancel (this defer runs
+      // only once `run()` returns, so it can't rescue a still-suspended gate —
+      // the cancellation handler / latch does that). No-op in resume() (unarmed).
       introTimeoutTask?.cancel()
       introTimeoutTask = nil
+      introGateArmed = false
       simulationActivityRegistry?.leave()
     }
 
@@ -1178,12 +1185,16 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
       currentLLM = nil
       suspendController = nil
       // Intro-gate teardown (#853): cancel the reveal backstop so it can't
-      // outlive the run. The gate's own cancellation handler already resumed
-      // any waiting `awaitIntroReveal()` on task-cancel (this defer runs only
-      // once `run()` returns, so it can't rescue a still-suspended gate — the
-      // cancellation handler / latch does that). No-op in resume() (unarmed).
+      // outlive the run, and disarm so `isPlayingIntro` settles to false on
+      // EVERY exit (normal / load-failure early-return / cancel — the last two
+      // never reach the reveal-complete latch, so without this the flag would
+      // linger until dealloc). The gate's own cancellation handler already
+      // resumed any waiting `awaitIntroReveal()` on task-cancel (this defer runs
+      // only once `run()` returns, so it can't rescue a still-suspended gate —
+      // the cancellation handler / latch does that). No-op in resume() (unarmed).
       introTimeoutTask?.cancel()
       introTimeoutTask = nil
+      introGateArmed = false
       simulationActivityRegistry?.leave()
     }
 

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -521,6 +521,95 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   /// `private(set)`: only mutated here in `run()` / `resume()` (same file).
   private(set) var isLoadingModel = false
 
+  // MARK: Opening-card intro gate (#853)
+  //
+  // Coordinates the opening-card premise reveal with the run lifecycle so the
+  // premise types on a clean background WHILE the model loads, and the
+  // conversation only starts AFTER the reveal finishes. Three collaborators:
+  // the View arms the gate (``beginIntro()``) iff there is a premise card, the
+  // card signals completion (``introRevealDidComplete()``), and `run()` waits
+  // at ``awaitIntroReveal()`` between model load and engine start. All state is
+  // MainActor-isolated (the VM is `@MainActor`), so the latch + continuation
+  // handoff needs no lock and cannot double-resume across actors.
+
+  /// Set by the View at run start when an opening card will be shown, so `run()`
+  /// knows to wait for the reveal. Unarmed runs (no premise, or resume) skip the
+  /// wait entirely.
+  private var introGateArmed = false
+  /// Latch: the reveal has finished (or was released). Read by
+  /// ``awaitIntroReveal()`` so a completion that fires *before* the gate is
+  /// awaited (the common fast-reveal / slow-load case) is not missed.
+  private var introRevealCompleted = false
+  /// The suspended `run()` continuation, when the gate is awaited before the
+  /// reveal completes. Stored-then-nilled on first resume so a second resume
+  /// (timeout backstop / cancellation / late signal) can never trap.
+  private var introContinuation: CheckedContinuation<Void, Never>?
+  /// Last-resort backstop so a card that never signals can't freeze the run
+  /// forever. Cancelled on normal completion; should never fire in practice.
+  private var introTimeoutTask: Task<Void, Never>?
+
+  /// True while the opening-card premise is still revealing — armed but not yet
+  /// complete. Drives ``SimulationDisplayState`` to suppress the model-load
+  /// scrim so the premise types on a clean background (the load runs behind it).
+  var isPlayingIntro: Bool { introGateArmed && !introRevealCompleted }
+
+  /// Arms the intro gate at run start (View-driven, only when an opening card
+  /// will be shown — the View owns the single premise-visibility predicate, so
+  /// the gate can't wait for a card that never renders). Starts the backstop.
+  func beginIntro() {
+    introGateArmed = true
+    introRevealCompleted = false
+    introTimeoutTask?.cancel()
+    introTimeoutTask = Task { @MainActor [weak self] in
+      // Generous cap — longer than any plausible premise reveal (short
+      // descriptions, min 6 cps); only fires if the card silently never signals.
+      try? await Task.sleep(for: .seconds(60))
+      self?.introRevealDidComplete()
+    }
+  }
+
+  /// Signalled by the opening card when its reveal finishes (both the typed and
+  /// static paths). Idempotent: latches, clears ``isPlayingIntro``, cancels the
+  /// backstop, and resumes any waiting `run()`. Safe to call unarmed / twice.
+  func introRevealDidComplete() {
+    guard !introRevealCompleted else { return }
+    introRevealCompleted = true
+    introTimeoutTask?.cancel()
+    introTimeoutTask = nil
+    resumeIntroContinuation()
+  }
+
+  /// Resumes the stored `run()` continuation exactly once (store-then-nil).
+  private func resumeIntroContinuation() {
+    if let continuation = introContinuation {
+      introContinuation = nil
+      continuation.resume()
+    }
+  }
+
+  /// Awaited by `run()` between model load and engine start. Returns immediately
+  /// when the gate is unarmed or the reveal already completed; otherwise suspends
+  /// until ``introRevealDidComplete()`` fires. Cancellation-aware: a run torn
+  /// down mid-reveal (navigate-away) resumes promptly rather than stalling.
+  func awaitIntroReveal() async {
+    guard introGateArmed, !introRevealCompleted else { return }
+    await withTaskCancellationHandler {
+      await withCheckedContinuation { continuation in
+        // Re-check under MainActor: completion may have latched between the
+        // guard above and here (no real suspension in between, but cheap
+        // insurance) — resume at once rather than storing a stale continuation.
+        if introRevealCompleted {
+          continuation.resume()
+        } else {
+          introContinuation = continuation
+        }
+      }
+    } onCancel: {
+      // The cancel handler runs outside actor isolation; hop back to release.
+      Task { @MainActor [weak self] in self?.resumeIntroContinuation() }
+    }
+  }
+
   /// Holds the currently running simulation task for cancellation support.
   /// Set by the caller (SimulationView) after launching `run()` in a Task.
   /// Memory warning or explicit user action can cancel via `cancelSimulation()`.
@@ -810,7 +899,7 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   /// the YAML, so it is threaded in here rather than reached for from the
   /// repository (which would reintroduce the refetch-by-id drift the snapshot
   /// design deliberately avoids). `nil` for local / self-made scenarios.
-  func run(
+  func run(  // swiftlint:disable:this function_body_length
     scenario: Scenario, llm: any LLMService, scenarioCategorySnapshot: String? = nil
   ) async {
     let controller = await prepareRunInfrastructure(llm: llm)
@@ -851,6 +940,13 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
       isLoadingModel = false
       currentLLM = nil
       suspendController = nil
+      // Intro-gate teardown (#853): cancel the reveal backstop so it can't
+      // outlive the run. The gate's own cancellation handler already resumed
+      // any waiting `awaitIntroReveal()` on task-cancel (this defer runs only
+      // once `run()` returns, so it can't rescue a still-suspended gate — the
+      // cancellation handler / latch does that). No-op in resume() (unarmed).
+      introTimeoutTask?.cancel()
+      introTimeoutTask = nil
       simulationActivityRegistry?.leave()
     }
 
@@ -868,6 +964,15 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
       return
     }
     isLoadingModel = false
+
+    // Opening-card intro gate (#853): the model has loaded (concurrently with
+    // the premise reveal, whose scrim was suppressed via `isPlayingIntro`); now
+    // wait for the reveal to finish before the conversation begins. LOAD-BEARING
+    // ORDERING: this MUST sit after `isLoadingModel = false` and BEFORE
+    // `runner.run(...)` is created below — the runner's producer Task starts at
+    // stream creation, so awaiting here (not after) keeps inference from running
+    // and buffering ahead during the reveal. No-op for unarmed runs.
+    await awaitIntroReveal()
 
     // Consume event stream. Agent outputs are paced by the per-row typing
     // animation in AgentOutputRow; other events (phase/round separators,
@@ -1072,6 +1177,13 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
       isLoadingModel = false
       currentLLM = nil
       suspendController = nil
+      // Intro-gate teardown (#853): cancel the reveal backstop so it can't
+      // outlive the run. The gate's own cancellation handler already resumed
+      // any waiting `awaitIntroReveal()` on task-cancel (this defer runs only
+      // once `run()` returns, so it can't rescue a still-suspended gate — the
+      // cancellation handler / latch does that). No-op in resume() (unarmed).
+      introTimeoutTask?.cancel()
+      introTimeoutTask = nil
       simulationActivityRegistry?.leave()
     }
 

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -5781,6 +5781,16 @@
         }
       }
     },
+    "The premise" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "あらすじ"
+          }
+        }
+      }
+    },
     "Then branch (condition true)" : {
       "localizations" : {
         "ja" : {

--- a/Pastura/Pastura/Views/Components/ScenarioIntroCard.swift
+++ b/Pastura/Pastura/Views/Components/ScenarioIntroCard.swift
@@ -52,11 +52,15 @@ struct ScenarioIntroCard: View {
   /// `.instant` playback speed. Reduce Motion also forces the static path.
   var charsPerSecond: Double?
 
-  /// Called once when the reveal animation finishes, so the caller can flip a
-  /// type-once latch and pass `charsPerSecond == nil` on any later re-mount
-  /// (the card lives in a `LazyVStack` and would otherwise re-type when the
-  /// user scrolls back to the top). Not called on the static path.
-  var onRevealComplete: (() -> Void)?
+  /// Called once when the reveal animation *begins* (not on completion), so the
+  /// caller can flip a type-once latch and pass `charsPerSecond == nil` on any
+  /// later re-mount (the card lives in a `LazyVStack` and would otherwise
+  /// re-type when the user scrolls back to the top). Fired at the start — not
+  /// the end — so a reveal *interrupted* by an early unmount (the `.task` is
+  /// cancelled mid-loop) still latches; the re-mounted card then renders the
+  /// full premise statically instead of restarting the typewriter. Not called
+  /// on the static path (nothing to latch — that path already shows full text).
+  var onRevealStarted: (() -> Void)?
 
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
   /// Number of leading premise characters currently revealed. Drives the
@@ -131,8 +135,9 @@ struct ScenarioIntroCard: View {
   }
 
   /// Advances ``visibleChars`` from 0 to the full length at
-  /// ``charsPerSecond``, then signals ``onRevealComplete``. Cancelled cleanly
-  /// when the card leaves the hierarchy (the `.task` lifetime).
+  /// ``charsPerSecond``. Signals ``onRevealStarted`` up front (so the latch
+  /// holds even if the loop is cancelled mid-reveal), then advances. Cancelled
+  /// cleanly when the card leaves the hierarchy (the `.task` lifetime).
   private func revealPremise() async {
     let total = model.premise.count
     visibleChars = 0
@@ -140,12 +145,15 @@ struct ScenarioIntroCard: View {
       visibleChars = total
       return
     }
+    // Latch before typing: an early unmount cancels the loop below, but the run
+    // has already had its intro beat — a re-mount should show full text, not
+    // restart the typewriter.
+    onRevealStarted?()
     while visibleChars < total {
       try? await Task.sleep(for: .seconds(1.0 / cps))
       if Task.isCancelled { return }
       visibleChars += 1
     }
-    onRevealComplete?()
   }
 }
 

--- a/Pastura/Pastura/Views/Components/ScenarioIntroCard.swift
+++ b/Pastura/Pastura/Views/Components/ScenarioIntroCard.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+
+/// Opening "curtain" card shown above the live simulation log (issue #853).
+///
+/// The simulation screen otherwise drops straight into the first `ASSIGN` /
+/// agent utterance with no scene-setting, which reads as disorienting on a
+/// first run. This card presents the scenario premise once, at the top of the
+/// chat stream, before the first agent turn — so the viewer knows *what this
+/// place is* before the curtain rises.
+///
+/// Presentation-only by design (ADR-009): it takes already-resolved
+/// ``Model`` strings, never the Engine/Data domain types, so both the live
+/// simulation (fed from `Scenario.description`) and — in a follow-up — the
+/// demo-replay screen (fed from the replay YAML `metadata.description`) can
+/// share it without a Views-layer dependency creeping into either source.
+///
+/// The card is **static and side-effect-free** (no `onAppear` / `task`): it
+/// sits inside the log's `LazyVStack`, so any lifecycle work would fire
+/// unpredictably as it scrolls off. All data is passed in.
+struct ScenarioIntroCard: View {
+  /// Resolved, display-ready values for the opening card.
+  ///
+  /// The failable initializer is the load-bearing visibility guard: an empty
+  /// or whitespace-only premise yields `nil` so the caller renders nothing
+  /// (mirroring `ScenarioSummaryRow`'s `!description.isEmpty` guard), rather
+  /// than an empty card box above the log.
+  nonisolated struct Model {
+    /// Scenario name. Optional because the live simulation already shows the
+    /// name in its header — it passes `nil` to avoid a redundant restatement,
+    /// while the future demo adapter may pass it.
+    let title: String?
+    /// Viewer-facing premise (`Scenario.description` / replay
+    /// `metadata.description`). Guaranteed non-empty once the model exists.
+    let premise: String
+
+    /// Builds a model, or returns `nil` when `premise` has no visible
+    /// content. The emptiness check trims whitespace, but the stored
+    /// ``premise`` is preserved verbatim (demo descriptions carry stray
+    /// internal spaces from line-wrapping that must not be mutated).
+    init?(title: String?, premise: String) {
+      guard !premise.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        return nil
+      }
+      self.title = title
+      self.premise = premise
+    }
+  }
+
+  let model: Model
+
+  var body: some View {
+    PasturaCard {
+      VStack(alignment: .leading, spacing: Spacing.xs) {
+        eyebrow
+        if let title = model.title {
+          Text(title)
+            .textStyle(Typography.titlePhase)
+            .foregroundStyle(Color.ink)
+        }
+        Text(model.premise)
+          .textStyle(Typography.bodyBubble)
+          .foregroundStyle(Color.inkSecondary)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+      .padding(Spacing.m)
+      .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    // Combine into one VoiceOver element so the premise is read as a single
+    // "scene setting" announcement rather than icon + label + body fragments.
+    .accessibilityElement(children: .combine)
+  }
+
+  /// Small "The premise" heading with a leading theatre-masks glyph — orients
+  /// the viewer that this block is the scene setup, not an agent speaking.
+  private var eyebrow: some View {
+    HStack(spacing: Spacing.xxs) {
+      Image(systemName: "theatermasks")
+      Text(String(localized: "The premise"))
+    }
+    .textStyle(Typography.captionName)
+    .foregroundStyle(Color.moss)
+  }
+}
+
+#Preview("Scenario intro card") {
+  ScrollView {
+    VStack(spacing: 12) {
+      if let model = ScenarioIntroCard.Model(
+        title: nil,
+        premise: "5人の参加者に「お題」が配られるが、1人だけ違うお題を持つ少数派（ウルフ）。会話から少数派を見抜き、投票で当てるゲーム。") {
+        ScenarioIntroCard(model: model)
+      }
+      if let model = ScenarioIntroCard.Model(
+        title: "Prisoner's Dilemma",
+        premise: "Five players choose to cooperate or betray in a round-robin of adjacent pairings."
+      ) {
+        ScenarioIntroCard(model: model)
+      }
+    }
+    .padding(.horizontal, 20)
+    .padding(.vertical, 8)
+  }
+  .background(Color.screenBackground)
+}

--- a/Pastura/Pastura/Views/Components/ScenarioIntroCard.swift
+++ b/Pastura/Pastura/Views/Components/ScenarioIntroCard.swift
@@ -6,17 +6,15 @@ import SwiftUI
 /// agent utterance with no scene-setting, which reads as disorienting on a
 /// first run. This card presents the scenario premise once, at the top of the
 /// chat stream, before the first agent turn — so the viewer knows *what this
-/// place is* before the curtain rises.
+/// place is* before the curtain rises. The premise types in at the playback
+/// speed (the reveal *is* the scene-setting beat), matching the log's
+/// typewriter feel.
 ///
 /// Presentation-only by design (ADR-009): it takes already-resolved
 /// ``Model`` strings, never the Engine/Data domain types, so both the live
 /// simulation (fed from `Scenario.description`) and — in a follow-up — the
 /// demo-replay screen (fed from the replay YAML `metadata.description`) can
 /// share it without a Views-layer dependency creeping into either source.
-///
-/// The card is **static and side-effect-free** (no `onAppear` / `task`): it
-/// sits inside the log's `LazyVStack`, so any lifecycle work would fire
-/// unpredictably as it scrolls off. All data is passed in.
 struct ScenarioIntroCard: View {
   /// Resolved, display-ready values for the opening card.
   ///
@@ -48,6 +46,29 @@ struct ScenarioIntroCard: View {
 
   let model: Model
 
+  /// Typewriter speed for the premise reveal, in characters/second. `nil`
+  /// renders the full premise at once (no animation) — the caller passes `nil`
+  /// once the premise has already been revealed (type-once) and at
+  /// `.instant` playback speed. Reduce Motion also forces the static path.
+  var charsPerSecond: Double?
+
+  /// Called once when the reveal animation finishes, so the caller can flip a
+  /// type-once latch and pass `charsPerSecond == nil` on any later re-mount
+  /// (the card lives in a `LazyVStack` and would otherwise re-type when the
+  /// user scrolls back to the top). Not called on the static path.
+  var onRevealComplete: (() -> Void)?
+
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  /// Number of leading premise characters currently revealed. Drives the
+  /// typewriter; the full string is always laid out (hidden tail) so the card
+  /// height never grows mid-reveal.
+  @State private var visibleChars: Int = 0
+
+  private var shouldType: Bool {
+    guard let cps = charsPerSecond, cps > 0, !reduceMotion else { return false }
+    return true
+  }
+
   var body: some View {
     PasturaCard {
       VStack(alignment: .leading, spacing: Spacing.xs) {
@@ -57,28 +78,74 @@ struct ScenarioIntroCard: View {
             .textStyle(Typography.titlePhase)
             .foregroundStyle(Color.ink)
         }
-        Text(model.premise)
-          .textStyle(Typography.bodyBubble)
-          .foregroundStyle(Color.inkSecondary)
-          .fixedSize(horizontal: false, vertical: true)
+        premiseText
       }
       .padding(Spacing.m)
       .frame(maxWidth: .infinity, alignment: .leading)
     }
     // Combine into one VoiceOver element so the premise is read as a single
-    // "scene setting" announcement rather than icon + label + body fragments.
+    // "scene setting" announcement. The concatenated Text below always holds
+    // the full string (the unrevealed tail is only visually `.clear`), so
+    // VoiceOver announces the whole premise regardless of the reveal state.
     .accessibilityElement(children: .combine)
+    .task {
+      guard shouldType else {
+        visibleChars = model.premise.count
+        return
+      }
+      await revealPremise()
+    }
   }
 
-  /// Small "The premise" heading with a leading theatre-masks glyph — orients
-  /// the viewer that this block is the scene setup, not an agent speaking.
+  /// The premise text with a typewriter reveal. Rendered as
+  /// `Text(visible) + Text(hidden).foregroundStyle(.clear)` so the full string
+  /// is laid out from the first frame — line-wrap positions stay put and the
+  /// card height is stable as characters appear (same idiom as
+  /// `AgentOutputRow`'s replay path).
+  private var premiseText: some View {
+    let premise = model.premise
+    let clamped = min(max(visibleChars, 0), premise.count)
+    let splitIdx = premise.index(premise.startIndex, offsetBy: clamped)
+    let visible = premise[..<splitIdx]
+    let hidden = premise[splitIdx...]
+    return (Text(visible) + Text(hidden).foregroundStyle(.clear))
+      .textStyle(Typography.bodyBubble)
+      .foregroundStyle(Color.inkSecondary)
+      .fixedSize(horizontal: false, vertical: true)
+      // Freeze the implicit text-change animation so revealed glyphs don't
+      // cross-fade as the counter advances (matches AgentOutputRow).
+      .animation(nil, value: clamped)
+  }
+
+  /// Small "The premise" heading with a leading scroll glyph — orients the
+  /// viewer that this block is the scene setup / synopsis, not an agent
+  /// speaking.
   private var eyebrow: some View {
     HStack(spacing: Spacing.xxs) {
-      Image(systemName: "theatermasks")
+      Image(systemName: "scroll")
+        .accessibilityHidden(true)
       Text(String(localized: "The premise"))
     }
     .textStyle(Typography.captionName)
     .foregroundStyle(Color.moss)
+  }
+
+  /// Advances ``visibleChars`` from 0 to the full length at
+  /// ``charsPerSecond``, then signals ``onRevealComplete``. Cancelled cleanly
+  /// when the card leaves the hierarchy (the `.task` lifetime).
+  private func revealPremise() async {
+    let total = model.premise.count
+    visibleChars = 0
+    guard let cps = charsPerSecond, cps > 0 else {
+      visibleChars = total
+      return
+    }
+    while visibleChars < total {
+      try? await Task.sleep(for: .seconds(1.0 / cps))
+      if Task.isCancelled { return }
+      visibleChars += 1
+    }
+    onRevealComplete?()
   }
 }
 
@@ -88,13 +155,13 @@ struct ScenarioIntroCard: View {
       if let model = ScenarioIntroCard.Model(
         title: nil,
         premise: "5人の参加者に「お題」が配られるが、1人だけ違うお題を持つ少数派（ウルフ）。会話から少数派を見抜き、投票で当てるゲーム。") {
-        ScenarioIntroCard(model: model)
+        ScenarioIntroCard(model: model, charsPerSecond: 10)
       }
       if let model = ScenarioIntroCard.Model(
         title: "Prisoner's Dilemma",
         premise: "Five players choose to cooperate or betray in a round-robin of adjacent pairings."
       ) {
-        ScenarioIntroCard(model: model)
+        ScenarioIntroCard(model: model, charsPerSecond: nil)
       }
     }
     .padding(.horizontal, 20)

--- a/Pastura/Pastura/Views/Components/ScenarioIntroCard.swift
+++ b/Pastura/Pastura/Views/Components/ScenarioIntroCard.swift
@@ -52,6 +52,12 @@ struct ScenarioIntroCard: View {
   /// `.instant` playback speed. Reduce Motion also forces the static path.
   var charsPerSecond: Double?
 
+  /// A short "held breath" pause before the first character appears, so the
+  /// reveal doesn't start abruptly the instant the card mounts. During it the
+  /// eyebrow + empty (full-height) premise box are already shown. `.zero` skips
+  /// it (also the static path). Only applies to the animated reveal.
+  var leadIn: Duration = .zero
+
   /// Called once when the reveal animation *begins* (not on completion), so the
   /// caller can flip a type-once latch and pass `charsPerSecond == nil` on any
   /// later re-mount (the card lives in a `LazyVStack` and would otherwise
@@ -161,6 +167,12 @@ struct ScenarioIntroCard: View {
     // has already had its intro beat — a re-mount should show full text, not
     // restart the typewriter.
     onRevealStarted?()
+    // Held-breath pause before the first glyph (the eyebrow + empty premise box
+    // are already laid out). Cancellation-checked like the loop.
+    if leadIn > .zero {
+      try? await Task.sleep(for: leadIn)
+      if Task.isCancelled { return }
+    }
     while visibleChars < total {
       try? await Task.sleep(for: .seconds(1.0 / cps))
       // Cancelled mid-reveal (early unmount): do NOT signal completion — the

--- a/Pastura/Pastura/Views/Components/ScenarioIntroCard.swift
+++ b/Pastura/Pastura/Views/Components/ScenarioIntroCard.swift
@@ -62,6 +62,14 @@ struct ScenarioIntroCard: View {
   /// on the static path (nothing to latch — that path already shows full text).
   var onRevealStarted: (() -> Void)?
 
+  /// Called once when the premise is fully shown — the end of the typewriter on
+  /// the animated path, or immediately on the static path (instant speed /
+  /// Reduce Motion / an already-latched re-mount). The live simulation uses
+  /// this to gate the start of the conversation on the reveal finishing (#853).
+  /// NOT called when the reveal is cancelled mid-typing (early unmount) — the
+  /// run's own cancellation path releases its gate in that case.
+  var onRevealComplete: (() -> Void)?
+
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
   /// Number of leading premise characters currently revealed. Drives the
   /// typewriter; the full string is always laid out (hidden tail) so the card
@@ -94,7 +102,10 @@ struct ScenarioIntroCard: View {
     .accessibilityElement(children: .combine)
     .task {
       guard shouldType else {
+        // Static path (instant / Reduce Motion / already-latched re-mount):
+        // full text at once, and the reveal is "complete" immediately.
         visibleChars = model.premise.count
+        onRevealComplete?()
         return
       }
       await revealPremise()
@@ -134,10 +145,11 @@ struct ScenarioIntroCard: View {
     .foregroundStyle(Color.moss)
   }
 
-  /// Advances ``visibleChars`` from 0 to the full length at
-  /// ``charsPerSecond``. Signals ``onRevealStarted`` up front (so the latch
-  /// holds even if the loop is cancelled mid-reveal), then advances. Cancelled
-  /// cleanly when the card leaves the hierarchy (the `.task` lifetime).
+  /// Advances ``visibleChars`` from 0 to the full length at ``charsPerSecond``.
+  /// Signals ``onRevealStarted`` up front (so the latch holds even if the loop
+  /// is cancelled mid-reveal), then ``onRevealComplete`` once the full string is
+  /// shown. Cancelled cleanly when the card leaves the hierarchy (the `.task`
+  /// lifetime) — the cancel path fires neither completion.
   private func revealPremise() async {
     let total = model.premise.count
     visibleChars = 0
@@ -151,9 +163,12 @@ struct ScenarioIntroCard: View {
     onRevealStarted?()
     while visibleChars < total {
       try? await Task.sleep(for: .seconds(1.0 / cps))
+      // Cancelled mid-reveal (early unmount): do NOT signal completion — the
+      // run's own cancellation path releases its intro gate.
       if Task.isCancelled { return }
       visibleChars += 1
     }
+    onRevealComplete?()
   }
 }
 

--- a/Pastura/Pastura/Views/Simulation/SimulationDisplayState.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationDisplayState.swift
@@ -51,8 +51,10 @@ nonisolated enum SimulationDisplayState: Equatable {
 
   /// Derives the display state from ``SimulationView``'s inputs, preserving the
   /// pre-existing body + overlay branch precedence exactly: content wins first
-  /// — within it `loadingModel` > `reloadingModel` > `running` — then
-  /// `alreadyRunning`, then `error`, then the scenario-loading fallback.
+  /// — within it `loadingModel` > `reloadingModel` > `running`, except
+  /// `isPlayingIntro` suppresses `loadingModel` (the opening-card reveal shows
+  /// on a clean background while the model loads, #853) — then `alreadyRunning`,
+  /// then `error`, then the scenario-loading fallback.
   ///
   /// `hasContent` is the View's `viewModel != nil && scenario != nil` gate
   /// collapsed to a single flag (they are only ever used together). Until both
@@ -65,15 +67,26 @@ nonisolated enum SimulationDisplayState: Equatable {
   /// `viewModel == nil` (both are assigned in `SimulationView.task` before
   /// `loadAndRun`), so the content-first ordering never masks them in practice.
   /// Do not "fix" the content-first precedence as if it could shadow those.
-  static func resolve(
+  ///
+  /// The six flat inputs ARE the precedence contract — this pure derivation is
+  /// the single testable place that orders them, so the `function_parameter_count`
+  /// disable is intentional: bundling into a struct would churn 14 call sites
+  /// (11 tests) for no readability gain over named arguments.
+  static func resolve(  // swiftlint:disable:this function_parameter_count
     hasContent: Bool,
     isLoadingModel: Bool,
     isReloadingModel: Bool,
+    isPlayingIntro: Bool,
     alreadyRunning: Bool,
     loadError: String?
   ) -> SimulationDisplayState {
     if hasContent {
-      if isLoadingModel { return .loadingModel }
+      // Opening-card intro (#853): while the premise is revealing, suppress the
+      // model-load scrim so the card types on a clean background — the model
+      // loads behind it. Scoped to `.loadingModel` only; the mid-run GPU↔CPU
+      // `.reloadingModel` scrim (ADR-003) stays independent (intro is a
+      // start-of-run beat that completes before any reload).
+      if isLoadingModel && !isPlayingIntro { return .loadingModel }
       if isReloadingModel { return .reloadingModel }
       return .running
     }

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -465,8 +465,7 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
             // dims under the current-utterance opacity focus applied in the
             // ForEach below. Title is `nil`: the header already shows the name.
             // Hidden when the scenario has no description (Model init? → nil).
-            if let introModel = ScenarioIntroCard.Model(
-              title: nil, premise: scenario?.description ?? "") {
+            if let introModel {
               ScenarioIntroCard(model: introModel)
             }
 
@@ -695,13 +694,15 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
             .foregroundStyle(Color.muted)
         }
         // Case B (#853): turn the initial model-load wait into scene-setting
-        // by previewing the premise, which then stays as the opening card once
-        // the scrim dissolves. Also a trailing conditional child (like the
-        // subtitle) — the spinner stays the first, id-less child so its
-        // structural identity, and the #825 no-restart guarantee, are intact.
-        // `.model` only: `.reload` is a mid-run backend switch where the viewer
-        // already has the context.
-        if label == .model, let premise = scrimPremise() {
+        // by previewing the premise — the same text then appears (in the fuller
+        // card treatment) as the opening card once the scrim dissolves. This is
+        // a compact preview (centered, clamped), not a literal carry-over of the
+        // same element, so the handoff is a cross-fade between two treatments.
+        // Also a trailing conditional child (like the subtitle) — the spinner
+        // stays the first, id-less child so its structural identity, and the
+        // #825 no-restart guarantee, are intact. `.model` only: `.reload` is a
+        // mid-run backend switch where the viewer already has the context.
+        if label == .model, let premise = introModel?.premise {
           Text(premise)
             .textStyle(Typography.bodyBubble)
             .foregroundStyle(Color.inkSecondary)
@@ -716,11 +717,12 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
     }
   }
 
-  /// The premise previewed in the initial model-load scrim (Case B, #853).
-  /// Routes through the same ``ScenarioIntroCard/Model`` empty-guard as the
-  /// opening card so the scrim and card agree on when there is nothing to show.
-  private func scrimPremise() -> String? {
-    ScenarioIntroCard.Model(title: nil, premise: scenario?.description ?? "")?.premise
+  /// Opening-card model for the current scenario, or `nil` when there is no
+  /// premise to show (#853). Single source consumed by both the log-top card
+  /// and the Case-B model-load scrim preview, so the two provably agree on
+  /// visibility. `title` is `nil`: the header already shows the scenario name.
+  private var introModel: ScenarioIntroCard.Model? {
+    ScenarioIntroCard.Model(title: nil, premise: scenario?.description ?? "")
   }
 
   private func scrimTitle(_ label: SimulationDisplayState.ScrimLabel) -> String {

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -55,6 +55,10 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
   // Accessed from SimulationView+Background.swift extension for the toggle subtitle.
   @State var scenario: Scenario?
   @State private var showScoreboard = false
+  /// Latches the opening card's premise reveal to a single run (#853): once the
+  /// typewriter finishes, the card renders statically on any later re-mount
+  /// (e.g. scrolling back to the top) instead of re-typing.
+  @State private var introHasTyped = false
   @State private var loadError: String?
   @State private var exportPayload: ResultMarkdownExporter.ExportedResult?
   @State private var exportError: String?
@@ -465,8 +469,17 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
             // dims under the current-utterance opacity focus applied in the
             // ForEach below. Title is `nil`: the header already shows the name.
             // Hidden when the scenario has no description (Model init? → nil).
+            // The premise types in at the playback speed as the scene-setting
+            // beat; `introHasTyped` latches it to a single reveal so scrolling
+            // back to the top doesn't re-type (the card lives in this
+            // LazyVStack). `.instant` speed (`charsPerSecond == nil`) and
+            // Reduce Motion fall to the static path inside the card.
             if let introModel {
-              ScenarioIntroCard(model: introModel)
+              ScenarioIntroCard(
+                model: introModel,
+                charsPerSecond: introHasTyped ? nil : viewModel.speed.charsPerSecond,
+                onRevealComplete: { introHasTyped = true }
+              )
             }
 
             ForEach(viewModel.logEntries) { entry in
@@ -693,24 +706,6 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
             .textStyle(Typography.metaValue)
             .foregroundStyle(Color.muted)
         }
-        // Case B (#853): turn the initial model-load wait into scene-setting
-        // by previewing the premise — the same text then appears (in the fuller
-        // card treatment) as the opening card once the scrim dissolves. This is
-        // a compact preview (centered, clamped), not a literal carry-over of the
-        // same element, so the handoff is a cross-fade between two treatments.
-        // Also a trailing conditional child (like the subtitle) — the spinner
-        // stays the first, id-less child so its structural identity, and the
-        // #825 no-restart guarantee, are intact. `.model` only: `.reload` is a
-        // mid-run backend switch where the viewer already has the context.
-        if label == .model, let premise = introModel?.premise {
-          Text(premise)
-            .textStyle(Typography.bodyBubble)
-            .foregroundStyle(Color.inkSecondary)
-            .multilineTextAlignment(.center)
-            .lineLimit(4)
-            .frame(maxWidth: 300)
-            .padding(.top, 4)
-        }
       }
       .padding(24)
       .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
@@ -718,9 +713,8 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
   }
 
   /// Opening-card model for the current scenario, or `nil` when there is no
-  /// premise to show (#853). Single source consumed by both the log-top card
-  /// and the Case-B model-load scrim preview, so the two provably agree on
-  /// visibility. `title` is `nil`: the header already shows the scenario name.
+  /// premise to show (#853). `title` is `nil`: the header already shows the
+  /// scenario name, so the card would only restate it.
   private var introModel: ScenarioIntroCard.Model? {
     ScenarioIntroCard.Model(title: nil, premise: scenario?.description ?? "")
   }

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -458,6 +458,18 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
       ScrollViewReader { proxy in
         ScrollView {
           LazyVStack(alignment: .leading, spacing: ChatBubbleLayout.bubbleSpacing) {
+            // Opening card: the scenario premise, shown once above the first
+            // agent turn so a run no longer drops straight into ASSIGN / the
+            // first utterance (issue #853). Rendered as a fixed leading element
+            // — NOT injected into `logEntries` — so it never persists and never
+            // dims under the current-utterance opacity focus applied in the
+            // ForEach below. Title is `nil`: the header already shows the name.
+            // Hidden when the scenario has no description (Model init? → nil).
+            if let introModel = ScenarioIntroCard.Model(
+              title: nil, premise: scenario?.description ?? "") {
+              ScenarioIntroCard(model: introModel)
+            }
+
             ForEach(viewModel.logEntries) { entry in
               logEntryView(entry, viewModel: viewModel, proxy: proxy)
                 // Current-utterance focus: dim past rows during playback so the

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -1089,8 +1089,14 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
       // Arm the intro gate iff an opening card will actually render — using the
       // SAME empty-premise guard the card uses (`ScenarioIntroCard.Model`), so
       // the VM never waits on a reveal that never happens (#853, critic Axis 4).
+      // Size the gate's last-resort backstop above the real reveal time
+      // (premise length ÷ the slowest playback speed + buffer) so it never
+      // clips a long premise typing at slow speed, yet still can't hang forever.
       let hasIntroCard = ScenarioIntroCard.Model(title: nil, premise: parsed.description) != nil
-      startOwnedRun(parsed, armIntro: hasIntroCard) { model in
+      let slowestCps = PlaybackSpeed.slow.charsPerSecond ?? 6
+      let introBackstop: TimeInterval? =
+        hasIntroCard ? Double(parsed.description.count) / slowestCps + 15 : nil
+      startOwnedRun(parsed, armIntroBackstop: introBackstop) { model in
         await model.run(
           scenario: parsed, llm: deps.llmService,
           scenarioCategorySnapshot: categorySnapshot)
@@ -1161,7 +1167,7 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
   /// lifted.
   private func startOwnedRun(
     _ parsed: Scenario,
-    armIntro: Bool = false,
+    armIntroBackstop: TimeInterval? = nil,
     body: @escaping (SimulationViewModel) async -> Void
   ) {
     let session = dependencies.simulationSession
@@ -1185,8 +1191,8 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
       // `awaitIntroReveal()` (it first suspends at model load). Set here — not
       // in `run()` — so the View stays the single owner of the premise-card
       // predicate that both arms the gate and renders the card (#853).
-      if armIntro {
-        session.viewModel?.beginIntro()
+      if let armIntroBackstop {
+        session.viewModel?.beginIntro(revealBackstop: armIntroBackstop)
       }
     case .refusedLiveRunExists:
       // PR1: structurally unreachable — `onDisappear` → `session.end()` frees

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -694,10 +694,33 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
             .textStyle(Typography.metaValue)
             .foregroundStyle(Color.muted)
         }
+        // Case B (#853): turn the initial model-load wait into scene-setting
+        // by previewing the premise, which then stays as the opening card once
+        // the scrim dissolves. Also a trailing conditional child (like the
+        // subtitle) — the spinner stays the first, id-less child so its
+        // structural identity, and the #825 no-restart guarantee, are intact.
+        // `.model` only: `.reload` is a mid-run backend switch where the viewer
+        // already has the context.
+        if label == .model, let premise = scrimPremise() {
+          Text(premise)
+            .textStyle(Typography.bodyBubble)
+            .foregroundStyle(Color.inkSecondary)
+            .multilineTextAlignment(.center)
+            .lineLimit(4)
+            .frame(maxWidth: 300)
+            .padding(.top, 4)
+        }
       }
       .padding(24)
       .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
     }
+  }
+
+  /// The premise previewed in the initial model-load scrim (Case B, #853).
+  /// Routes through the same ``ScenarioIntroCard/Model`` empty-guard as the
+  /// opening card so the scrim and card agree on when there is nothing to show.
+  private func scrimPremise() -> String? {
+    ScenarioIntroCard.Model(title: nil, premise: scenario?.description ?? "")?.premise
   }
 
   private func scrimTitle(_ label: SimulationDisplayState.ScrimLabel) -> String {

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -407,6 +407,7 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
       hasContent: viewModel != nil && scenario != nil,
       isLoadingModel: viewModel?.isLoadingModel ?? false,
       isReloadingModel: viewModel?.isReloadingModel ?? false,
+      isPlayingIntro: viewModel?.isPlayingIntro ?? false,
       alreadyRunning: alreadyRunning,
       loadError: loadError)
   }
@@ -474,12 +475,17 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
             // beat; `introHasTyped` latches it to a single reveal so scrolling
             // back to the top doesn't re-type (the card lives in this
             // LazyVStack). `.instant` speed (`charsPerSecond == nil`) and
-            // Reduce Motion fall to the static path inside the card.
+            // Reduce Motion fall to the static path inside the card. Resume
+            // entries render statically (no typing, no gate) — the reveal beat
+            // is only for a fresh run's start. `onRevealComplete` releases the
+            // VM intro gate so the conversation starts after the reveal (#853).
             if let introModel {
               ScenarioIntroCard(
                 model: introModel,
-                charsPerSecond: introHasTyped ? nil : viewModel.speed.charsPerSecond,
-                onRevealStarted: { introHasTyped = true }
+                charsPerSecond: (isResumeEntry || introHasTyped)
+                  ? nil : viewModel.speed.charsPerSecond,
+                onRevealStarted: { introHasTyped = true },
+                onRevealComplete: { viewModel.introRevealDidComplete() }
               )
             }
 
@@ -718,6 +724,14 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
   /// scenario name, so the card would only restate it.
   private var introModel: ScenarioIntroCard.Model? {
     ScenarioIntroCard.Model(title: nil, premise: scenario?.description ?? "")
+  }
+
+  /// `true` for the resume entry (a paused run being reopened). The opening card
+  /// renders statically on resume — the typed reveal + its conversation gate are
+  /// a fresh-run start beat only (#853).
+  private var isResumeEntry: Bool {
+    if case .resume = source { return true }
+    return false
   }
 
   private func scrimTitle(_ label: SimulationDisplayState.ScrimLabel) -> String {
@@ -1072,7 +1086,11 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
       // the run snapshots it without a refetch-by-id — category is gallery
       // metadata not present in the parsed YAML. nil for local scenarios.
       let categorySnapshot = record.category
-      startOwnedRun(parsed) { model in
+      // Arm the intro gate iff an opening card will actually render — using the
+      // SAME empty-premise guard the card uses (`ScenarioIntroCard.Model`), so
+      // the VM never waits on a reveal that never happens (#853, critic Axis 4).
+      let hasIntroCard = ScenarioIntroCard.Model(title: nil, premise: parsed.description) != nil
+      startOwnedRun(parsed, armIntro: hasIntroCard) { model in
         await model.run(
           scenario: parsed, llm: deps.llmService,
           scenarioCategorySnapshot: categorySnapshot)
@@ -1143,6 +1161,7 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
   /// lifted.
   private func startOwnedRun(
     _ parsed: Scenario,
+    armIntro: Bool = false,
     body: @escaping (SimulationViewModel) async -> Void
   ) {
     let session = dependencies.simulationSession
@@ -1162,6 +1181,13 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
       // half-projected frame.
       scenario = parsed
       viewModel = session.viewModel
+      // Arm the intro gate synchronously, before `run()` reaches
+      // `awaitIntroReveal()` (it first suspends at model load). Set here — not
+      // in `run()` — so the View stays the single owner of the premise-card
+      // predicate that both arms the gate and renders the card (#853).
+      if armIntro {
+        session.viewModel?.beginIntro()
+      }
     case .refusedLiveRunExists:
       // PR1: structurally unreachable — `onDisappear` → `session.end()` frees
       // the slot before any second start. The "already running" + Return-to-run

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -484,6 +484,7 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
                 model: introModel,
                 charsPerSecond: (isResumeEntry || introHasTyped)
                   ? nil : viewModel.speed.charsPerSecond,
+                leadIn: introLeadIn(for: viewModel.speed),
                 onRevealStarted: { introHasTyped = true },
                 onRevealComplete: { viewModel.introRevealDidComplete() }
               )
@@ -732,6 +733,17 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
   private var isResumeEntry: Bool {
     if case .resume = source { return true }
     return false
+  }
+
+  /// A short "held breath" before the premise starts typing so the reveal
+  /// doesn't begin abruptly on mount (#853). Scaled inversely with playback
+  /// speed via `multiplier` (slow ⇒ longer, fast ⇒ shorter); `.instant`'s
+  /// infinite multiplier collapses it to `.zero`, matching its static reveal.
+  private func introLeadIn(for speed: PlaybackSpeed) -> Duration {
+    let baseSeconds = 0.45
+    let multiplier = speed.multiplier
+    guard multiplier.isFinite, multiplier > 0 else { return .zero }
+    return .seconds(baseSeconds / multiplier)
   }
 
   private func scrimTitle(_ label: SimulationDisplayState.ScrimLabel) -> String {

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -56,8 +56,9 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
   @State var scenario: Scenario?
   @State private var showScoreboard = false
   /// Latches the opening card's premise reveal to a single run (#853): once the
-  /// typewriter finishes, the card renders statically on any later re-mount
-  /// (e.g. scrolling back to the top) instead of re-typing.
+  /// typewriter *begins*, the card renders statically on any later re-mount
+  /// (e.g. scrolling back to the top) instead of re-typing — set at reveal
+  /// start so an interrupted reveal still latches.
   @State private var introHasTyped = false
   @State private var loadError: String?
   @State private var exportPayload: ResultMarkdownExporter.ExportedResult?
@@ -478,7 +479,7 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
               ScenarioIntroCard(
                 model: introModel,
                 charsPerSecond: introHasTyped ? nil : viewModel.speed.charsPerSecond,
-                onRevealComplete: { introHasTyped = true }
+                onRevealStarted: { introHasTyped = true }
               )
             }
 

--- a/Pastura/PasturaTests/App/SimulationViewModelIntroGateTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelIntroGateTests.swift
@@ -30,13 +30,13 @@ struct SimulationViewModelIntroGateTests {
 
   @Test func beginIntroMarksPlayingIntro() throws {
     let sut = try makeSUT()
-    sut.beginIntro()
+    sut.beginIntro(revealBackstop: 60)
     #expect(sut.isPlayingIntro == true)
   }
 
   @Test func completeClearsPlayingIntro() throws {
     let sut = try makeSUT()
-    sut.beginIntro()
+    sut.beginIntro(revealBackstop: 60)
     sut.introRevealDidComplete()
     #expect(sut.isPlayingIntro == false)
   }
@@ -45,7 +45,7 @@ struct SimulationViewModelIntroGateTests {
   /// guarantees no `CheckedContinuation` double-resume trap).
   @Test func completeIsIdempotent() throws {
     let sut = try makeSUT()
-    sut.beginIntro()
+    sut.beginIntro(revealBackstop: 60)
     sut.introRevealDidComplete()
     sut.introRevealDidComplete()
     #expect(sut.isPlayingIntro == false)
@@ -65,7 +65,7 @@ struct SimulationViewModelIntroGateTests {
   /// already passed.
   @Test func awaitReturnsImmediatelyWhenCompletedBeforeAwait() async throws {
     let sut = try makeSUT()
-    sut.beginIntro()
+    sut.beginIntro(revealBackstop: 60)
     sut.introRevealDidComplete()
     await sut.awaitIntroReveal()  // must not hang
     #expect(sut.isPlayingIntro == false)
@@ -76,7 +76,7 @@ struct SimulationViewModelIntroGateTests {
   /// spawned waiter reaches its continuation suspension on the first yield.
   @Test func awaitSuspendsUntilCompletion() async throws {
     let sut = try makeSUT()
-    sut.beginIntro()
+    sut.beginIntro(revealBackstop: 60)
 
     var resumed = false
     let waiter = Task { @MainActor in

--- a/Pastura/PasturaTests/App/SimulationViewModelIntroGateTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelIntroGateTests.swift
@@ -1,0 +1,96 @@
+import Testing
+
+@testable import Pastura
+
+/// Deterministic coverage for the opening-card intro gate (#853) — the
+/// `beginIntro` / `introRevealDidComplete` / `awaitIntroReveal` handshake that
+/// makes `run()` wait for the premise reveal before the conversation starts.
+///
+/// The continuation plumbing is MainActor-serialized (the VM is `@MainActor`),
+/// so these tests exercise the pure state machine without any engine / model:
+/// the latch semantics (a completion that fires *before* the await still
+/// releases it — the common fast-reveal / slow-load case), the unarmed no-op,
+/// and idempotent completion. The visual reveal timing itself stays device-QA
+/// (ADR-009 rule 4).
+@Suite(.serialized, .timeLimit(.minutes(1)))
+@MainActor
+struct SimulationViewModelIntroGateTests {
+  private func makeSUT() throws -> SimulationViewModel {
+    let db = try DatabaseManager.inMemory()
+    return SimulationViewModel(
+      simulationRepository: GRDBSimulationRepository(dbWriter: db.dbWriter),
+      turnRepository: GRDBTurnRepository(dbWriter: db.dbWriter)
+    )
+  }
+
+  @Test func notPlayingIntroBeforeArming() throws {
+    let sut = try makeSUT()
+    #expect(sut.isPlayingIntro == false)
+  }
+
+  @Test func beginIntroMarksPlayingIntro() throws {
+    let sut = try makeSUT()
+    sut.beginIntro()
+    #expect(sut.isPlayingIntro == true)
+  }
+
+  @Test func completeClearsPlayingIntro() throws {
+    let sut = try makeSUT()
+    sut.beginIntro()
+    sut.introRevealDidComplete()
+    #expect(sut.isPlayingIntro == false)
+  }
+
+  /// Double completion must be a safe no-op (the stored-then-nilled continuation
+  /// guarantees no `CheckedContinuation` double-resume trap).
+  @Test func completeIsIdempotent() throws {
+    let sut = try makeSUT()
+    sut.beginIntro()
+    sut.introRevealDidComplete()
+    sut.introRevealDidComplete()
+    #expect(sut.isPlayingIntro == false)
+  }
+
+  /// Unarmed gate returns immediately — a run with no opening card never waits.
+  /// (A hang would trip the suite's 1-minute timeout.)
+  @Test func awaitReturnsImmediatelyWhenUnarmed() async throws {
+    let sut = try makeSUT()
+    await sut.awaitIntroReveal()
+    #expect(sut.isPlayingIntro == false)
+  }
+
+  /// The load-bearing latch (critic Axis 7): a completion that fires BEFORE the
+  /// gate is awaited (fast reveal finishes during the slow model load) still
+  /// releases the await — it does not suspend forever waiting for a signal that
+  /// already passed.
+  @Test func awaitReturnsImmediatelyWhenCompletedBeforeAwait() async throws {
+    let sut = try makeSUT()
+    sut.beginIntro()
+    sut.introRevealDidComplete()
+    await sut.awaitIntroReveal()  // must not hang
+    #expect(sut.isPlayingIntro == false)
+  }
+
+  /// The suspend→resume path: the gate blocks until completion fires, then
+  /// resumes. Single-threaded MainActor makes the ordering deterministic — the
+  /// spawned waiter reaches its continuation suspension on the first yield.
+  @Test func awaitSuspendsUntilCompletion() async throws {
+    let sut = try makeSUT()
+    sut.beginIntro()
+
+    var resumed = false
+    let waiter = Task { @MainActor in
+      await sut.awaitIntroReveal()
+      resumed = true
+    }
+    // Let the waiter run up to its continuation suspension.
+    await Task.yield()
+    #expect(resumed == false)
+    #expect(sut.isPlayingIntro == true)
+
+    sut.introRevealDidComplete()
+    await waiter.value
+    #expect(resumed == true)
+    #expect(sut.isPlayingIntro == false)
+  }
+}

--- a/Pastura/PasturaTests/Views/ScenarioIntroCardTests.swift
+++ b/Pastura/PasturaTests/Views/ScenarioIntroCardTests.swift
@@ -1,0 +1,53 @@
+import Testing
+
+@testable import Pastura
+
+/// Pure-logic coverage for ``ScenarioIntroCard/Model`` — the opening-card
+/// presentation model shown above the simulation log (issue #853).
+///
+/// Per ADR-009 / `.claude/rules/view-testing.md` rule 1, only the model's
+/// visibility derivation is unit-tested; the card's layout / animation is
+/// left to code review + manual device QA (rule 4).
+///
+/// The load-bearing behavior under test is the empty-premise guard: an
+/// empty / whitespace-only premise must yield `nil` so the caller renders
+/// nothing (mirrors `ScenarioSummaryRow`'s `!description.isEmpty` guard),
+/// rather than an empty card box above the log.
+@Suite(.timeLimit(.minutes(1)))
+struct ScenarioIntroCardTests {
+  @Test("A non-empty premise yields a model preserving title and premise")
+  func nonEmptyPremise() {
+    let model = ScenarioIntroCard.Model(
+      title: "ワードウルフ", premise: "5人の参加者に「お題」が配られる。")
+    #expect(model != nil)
+    #expect(model?.title == "ワードウルフ")
+    #expect(model?.premise == "5人の参加者に「お題」が配られる。")
+  }
+
+  @Test("An empty premise yields nil so the card is hidden")
+  func emptyPremise() {
+    #expect(ScenarioIntroCard.Model(title: "X", premise: "") == nil)
+  }
+
+  @Test("A whitespace-only premise yields nil")
+  func whitespacePremise() {
+    #expect(ScenarioIntroCard.Model(title: "X", premise: "   \n\t ") == nil)
+  }
+
+  @Test("A nil title is allowed when a premise is present")
+  func nilTitleWithPremise() {
+    let model = ScenarioIntroCard.Model(title: nil, premise: "premise text")
+    #expect(model != nil)
+    #expect(model?.title == nil)
+    #expect(model?.premise == "premise text")
+  }
+
+  @Test("The premise is preserved verbatim, including internal whitespace")
+  func premiseVerbatim() {
+    // Demo replay descriptions carry stray internal spaces from line-wrapping
+    // (e.g. "全力の 珍回答"); the guard trims only for the emptiness check and
+    // must not mutate the stored premise.
+    let model = ScenarioIntroCard.Model(title: nil, premise: "  全力の 珍回答  ")
+    #expect(model?.premise == "  全力の 珍回答  ")
+  }
+}

--- a/Pastura/PasturaTests/Views/SimulationDisplayStateTests.swift
+++ b/Pastura/PasturaTests/Views/SimulationDisplayStateTests.swift
@@ -2,7 +2,8 @@ import Testing
 
 @testable import Pastura
 
-/// Pure-logic coverage for ``SimulationDisplayState/resolve(hasContent:isLoadingModel:isReloadingModel:alreadyRunning:loadError:)``
+/// Pure-logic coverage for
+/// ``SimulationDisplayState/resolve(hasContent:isLoadingModel:isReloadingModel:isPlayingIntro:alreadyRunning:loadError:)``
 /// — the derivation that drives `SimulationView`'s single persistent loading
 /// scrim. View-testing.md rule 1: assert the derived state (locale-independent
 /// enum), never rendered output. The spinner-continuity it enables is device-QA
@@ -10,11 +11,14 @@ import Testing
 ///
 /// Precedence under test mirrors the pre-refactor body + overlay branch order:
 /// content wins first — loadingModel > reloadingModel > running — then
-/// alreadyRunning, then error, then the awaiting-scenario fallback. The
-/// `alreadyRunning` / `error` arms are only reachable while `viewModel == nil`
-/// in production (both set in `SimulationView.task` before `loadAndRun`); the
-/// content-first case below documents — not contradicts — that invariant.
-/// `hasContent` is the View's `viewModel != nil && scenario != nil` gate.
+/// alreadyRunning, then error, then the awaiting-scenario fallback. Exception:
+/// `isPlayingIntro` suppresses `loadingModel` (the opening-card premise reveal
+/// shows on a clean background while the model loads, #853), leaving
+/// `reloadingModel` independent. The `alreadyRunning` / `error` arms are only
+/// reachable while `viewModel == nil` in production (both set in
+/// `SimulationView.task` before `loadAndRun`); the content-first case below
+/// documents — not contradicts — that invariant. `hasContent` is the View's
+/// `viewModel != nil && scenario != nil` gate.
 @Suite(.timeLimit(.minutes(1)))
 struct SimulationDisplayStateTests {
   private typealias State = SimulationDisplayState
@@ -25,21 +29,21 @@ struct SimulationDisplayStateTests {
     #expect(
       State.resolve(
         hasContent: true, isLoadingModel: true, isReloadingModel: false,
-        alreadyRunning: false, loadError: nil) == .loadingModel)
+        isPlayingIntro: false, alreadyRunning: false, loadError: nil) == .loadingModel)
   }
 
   @Test func contentReloadingModelWhenNotLoading() {
     #expect(
       State.resolve(
         hasContent: true, isLoadingModel: false, isReloadingModel: true,
-        alreadyRunning: false, loadError: nil) == .reloadingModel)
+        isPlayingIntro: false, alreadyRunning: false, loadError: nil) == .reloadingModel)
   }
 
   @Test func contentRunningWhenNeitherFlag() {
     #expect(
       State.resolve(
         hasContent: true, isLoadingModel: false, isReloadingModel: false,
-        alreadyRunning: false, loadError: nil) == .running)
+        isPlayingIntro: false, alreadyRunning: false, loadError: nil) == .running)
   }
 
   /// Both flags true: loadingModel wins (mirrors the old `if isLoadingModel
@@ -48,7 +52,7 @@ struct SimulationDisplayStateTests {
     #expect(
       State.resolve(
         hasContent: true, isLoadingModel: true, isReloadingModel: true,
-        alreadyRunning: false, loadError: nil) == .loadingModel)
+        isPlayingIntro: false, alreadyRunning: false, loadError: nil) == .loadingModel)
   }
 
   /// Content-first precedence: even with `alreadyRunning` / `loadError` set,
@@ -59,7 +63,40 @@ struct SimulationDisplayStateTests {
     #expect(
       State.resolve(
         hasContent: true, isLoadingModel: false, isReloadingModel: false,
-        alreadyRunning: true, loadError: "boom") == .running)
+        isPlayingIntro: false, alreadyRunning: true, loadError: "boom") == .running)
+  }
+
+  // MARK: - Intro suppression (isPlayingIntro == true, #853)
+
+  /// While the opening-card premise is revealing, the model-load scrim is
+  /// suppressed so the card types on a clean background — the load runs behind
+  /// it. This is the whole point of the flag.
+  @Test func introSuppressesLoadingModelScrim() {
+    #expect(
+      State.resolve(
+        hasContent: true, isLoadingModel: true, isReloadingModel: false,
+        isPlayingIntro: true, alreadyRunning: false, loadError: nil) == .running)
+  }
+
+  /// The suppression is scoped to `loadingModel` only. The mid-run GPU↔CPU
+  /// `reloadingModel` scrim (ADR-003) stays independent — intro is a
+  /// start-of-run beat and never overlaps a reload in practice, but the
+  /// precedence encodes that rather than relying on timing.
+  @Test func introDoesNotSuppressReloadingModelScrim() {
+    #expect(
+      State.resolve(
+        hasContent: true, isLoadingModel: false, isReloadingModel: true,
+        isPlayingIntro: true, alreadyRunning: false, loadError: nil) == .reloadingModel)
+  }
+
+  /// Intro playing without content is inert — the content gate is false, so the
+  /// non-content fallback still wins (the flag is read as
+  /// `viewModel?.isPlayingIntro ?? false`, only true once content exists).
+  @Test func introWithoutContentFallsBackToAwaitingScenario() {
+    #expect(
+      State.resolve(
+        hasContent: false, isLoadingModel: true, isReloadingModel: false,
+        isPlayingIntro: true, alreadyRunning: false, loadError: nil) == .awaitingScenario)
   }
 
   // MARK: - Non-content branch (hasContent == false)
@@ -68,7 +105,7 @@ struct SimulationDisplayStateTests {
     #expect(
       State.resolve(
         hasContent: false, isLoadingModel: false, isReloadingModel: false,
-        alreadyRunning: false, loadError: nil) == .awaitingScenario)
+        isPlayingIntro: false, alreadyRunning: false, loadError: nil) == .awaitingScenario)
   }
 
   /// Without content, the model-loading flags are ignored — covers the
@@ -79,21 +116,22 @@ struct SimulationDisplayStateTests {
     #expect(
       State.resolve(
         hasContent: false, isLoadingModel: true, isReloadingModel: true,
-        alreadyRunning: false, loadError: nil) == .awaitingScenario)
+        isPlayingIntro: false, alreadyRunning: false, loadError: nil) == .awaitingScenario)
   }
 
   @Test func alreadyRunningWhenNoContent() {
     #expect(
       State.resolve(
         hasContent: false, isLoadingModel: false, isReloadingModel: false,
-        alreadyRunning: true, loadError: nil) == .alreadyRunning)
+        isPlayingIntro: false, alreadyRunning: true, loadError: nil) == .alreadyRunning)
   }
 
   @Test func errorWhenNoContentAndLoadError() {
     #expect(
       State.resolve(
         hasContent: false, isLoadingModel: false, isReloadingModel: false,
-        alreadyRunning: false, loadError: "load failed") == .error("load failed"))
+        isPlayingIntro: false, alreadyRunning: false, loadError: "load failed")
+        == .error("load failed"))
   }
 
   /// alreadyRunning takes precedence over error when both set (no content).
@@ -101,7 +139,7 @@ struct SimulationDisplayStateTests {
     #expect(
       State.resolve(
         hasContent: false, isLoadingModel: false, isReloadingModel: false,
-        alreadyRunning: true, loadError: "load failed") == .alreadyRunning)
+        isPlayingIntro: false, alreadyRunning: true, loadError: "load failed") == .alreadyRunning)
   }
 
   // MARK: - scrimLabel mapping


### PR DESCRIPTION
## Summary
シミュレーション画面が前提説明なしにいきなり ASSIGN / 最初のエージェント発言から始まり、初見で面食らう問題への対応（PR1）。最初のエージェント発言の前に、シナリオの前提（`Scenario.description`）を「オープニングカード」としてタイプ表示し、幕が上がる前に「これは何の場か」を掴めるようにする。

### オープニングカード
- **共通コンポーネント `ScenarioIntroCard`**（`Views/Components/`）— title/premise 文字列を受け取る dumb な presentational View（ADR-009）。空 premise では非表示。デモ再生画面（`metadata.description`）でも再利用できる設計だが、**デモ採用は後続 PR**。
- **ログ先頭に固定描画**（`logEntries` 非注入・ForEach 上）。永続化を汚さず、current-utterance の opacity dimming にも巻き込まれない。header がタイトルを持つため title は nil。
- **前提のタイプ表示**（📜 scroll アイコン＋「あらすじ / The premise」, i18n ja/en）。再生スピード連動（slow 6 / normal 10 / fast 45 cps）、`introHasTyped` で 1ラン1回（開始時 latch）。`.instant` / Reduce Motion / resume は静的表示。レイアウトは `Text(visible)+Text(hidden).clear` で予約しタイプ中も伸縮しない。

### ラン・ライフサイクル協調（実機レビュー反映）
実機で「前提がモデルロードの暗転スクリム越しにタイプされる」「あらすじ表示中に会話が始まる」問題が判明したため、ラン開始シーケンスを協調させた：
- **スクリム抑止**: `isPlayingIntro` 中は `.loadingModel` スクリムを抑止し、前提を素の背景でタイプ。モデルは裏で並行ロードし、あらすじ完了後もまだロード中なら初めてローディング表示（`SimulationDisplayState`）。
- **会話ゲート**: latch式・キャンセル対応の VM ゲート（`beginIntro` / `awaitIntroReveal` / `introRevealDidComplete`）。`run()` はモデルロード後・エンジン開始前に reveal 完了を待つ。fast-reveal/slow-load（arm 前に完了 signal）を latch で取りこぼさず、`withTaskCancellationHandler`＋backstop で hang を防止。
- **単一 arbiter**: View が `ScenarioIntroCard.Model` の同一ガードでゲート arm とカード描画の両方を判定（VM は Views 非依存, `armIntroBackstop: Bool`/`TimeInterval?` で受け取り）。描画されないカードを待つ事故を排除。

案B（ロード中スクリムでの前提静的表示）は検討のうえ不採用（タイプ演出と重複し reveal が台無しになるため）。PR2（別 Issue）で最終結果/投票結果の視認性向上を扱う予定。

## Test plan
- 新規ユニットテスト：`ScenarioIntroCardTests`（Model 空ガード）、`SimulationViewModelIntroGateTests`（latch-before-await / suspend→resume / idempotent / unarmed no-op — 決定論的）、`SimulationDisplayStateTests`（intro 抑止ケース ＋ 全 call site を新引数へ）。ADR-009 準拠の純ロジック。
- 全 2408 ユニットテスト green / `swiftlint --strict` clean / `localization-coverage` green。
- モックスロー LLM で実機（iPhone 17 Pro シミュレータ）キャプチャ：カード表示・scroll アイコン・タイプ途中/完了、**会話ゲート**（タイプ中はカードのみ／完了後に Round・SPEAK_ALL・thinking 開始）を確認。
- **⚠️ device-QA 必須（ADR-009 rule 4）**：
  - 実機モデルロード中に前提が素の背景でタイプされ、暗転スクリムに覆われないこと（モックは loadModel が一瞬で scrim 窓が出ないため実機必須）。
  - あらすじ完了後にまだロード中なら「Loading model...」が出ること。
  - 長い前提での見え方 / スクロール追従 / Reduce Motion・`.instant` の静的化 / resume の静的カード。

Closes #853