### PR TITLE
✨ feat: enrich shared-scenario detail (agents/rounds/phases, title, report)

### DIFF
--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -3545,6 +3545,16 @@
         }
       }
     },
+    "Language" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "言語"
+          }
+        }
+      }
+    },
     "Language mismatch ×%lld" : {
       "localizations" : {
         "ja" : {
@@ -6313,6 +6323,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Wi-Fi を待つ"
+          }
+        }
+      }
+    },
+    "What happens" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "進行の流れ"
           }
         }
       }

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -3810,16 +3810,6 @@
         }
       }
     },
-    "More" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "詳細"
-          }
-        }
-      }
-    },
     "Move to Else Branch" : {
       "localizations" : {
         "ja" : {

--- a/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailFormat.swift
+++ b/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailFormat.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Pure presentation helpers for ``GalleryScenarioDetailView``'s enriched
+/// metadata rows and the "What happens" phase-flow section.
+///
+/// Extracted from the View so the mapping / hide-when-empty logic is
+/// unit-testable without rendering (`.claude/rules/view-testing.md` rule 1).
+///
+/// Left at the default (MainActor) isolation — **not** `nonisolated` — because
+/// ``phaseFlow(phases:)`` composes ``PhaseDisplayName/label(for:)``, a
+/// MainActor View-layer helper; a `nonisolated` enum passing that function
+/// value would drop the `@MainActor` (swift-isolation.md Pattern 5). The test
+/// suite is therefore `@MainActor`; MainActor can still call these directly.
+enum GalleryScenarioDetailFormat {
+
+  /// Separator drawn between consecutive phase labels in the flow.
+  static let phaseSeparator = " → "
+
+  /// Ordered, human-readable phase flow for the "What happens" section,
+  /// derived from a gallery entry's `phases` raw strings (e.g.
+  /// `"Speak Each → Summarize"`).
+  ///
+  /// Each raw value is mapped through ``PhaseType`` → ``PhaseDisplayName``;
+  /// unknown kinds (a feed newer than this build knows) are skipped, mirroring
+  /// the lenient forward-compat posture of ``GalleryScenario/phases``. Returns
+  /// `nil` — so the caller hides the section — when `phases` is absent / empty
+  /// **or** every entry mapped away (all-unknown), so no empty section renders.
+  static func phaseFlow(phases: [String]?) -> String? {
+    guard let phases else { return nil }
+    let labels =
+      phases
+      .compactMap { PhaseType(rawValue: $0) }
+      .map(PhaseDisplayName.label(for:))
+    guard !labels.isEmpty else { return nil }
+    return labels.joined(separator: phaseSeparator)
+  }
+
+  /// Localized language name for a gallery entry's raw ISO 639-1 `language`
+  /// code, or `nil` when absent / unrecognized so the Language row is hidden.
+  ///
+  /// Only the two launch languages are mapped explicitly (a finite localized
+  /// switch mirroring ``GalleryCategory/displayName``) — an unknown code hides
+  /// the row rather than surfacing a raw `"xx"` string. The caller passes the
+  /// **raw** ``GalleryScenario/language`` (not ``GalleryScenario/effectiveLanguage``)
+  /// so the nil default is preserved and hide-on-nil holds.
+  static func languageLabel(code: String?) -> String? {
+    switch code {
+    case "ja": return String(localized: "Japanese")
+    case "en": return String(localized: "English")
+    default: return nil
+    }
+  }
+}

--- a/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailView.swift
+++ b/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailView.swift
@@ -62,20 +62,19 @@ struct GalleryScenarioDetailView: View {
       }
       .hidingPasturaSharedBackground()
       ToolbarItem(placement: .primaryAction) {
-        Menu {
-          Button {
-            isReportSheetPresented = true
-          } label: {
-            Label(
-              String(localized: "Report this scenario"),
-              systemImage: "exclamationmark.bubble")
-          }
-          .accessibilityIdentifier("galleryDetail.reportMenuItem")
+        // Report is the only action, so surface it directly as an icon button
+        // rather than nesting it under an ellipsis menu. `.iconOnly` keeps the
+        // label text as the VoiceOver name.
+        Button {
+          isReportSheetPresented = true
         } label: {
-          Label(String(localized: "More"), systemImage: "ellipsis.circle")
+          Label(
+            String(localized: "Report this scenario"),
+            systemImage: "exclamationmark.bubble")
         }
-        .menuStyle(.button)
+        .labelStyle(.iconOnly)
         .buttonStyle(PasturaToolbarButtonStyle(variant: .secondary))
+        .accessibilityIdentifier("galleryDetail.reportButton")
       }
       .hidingPasturaSharedBackground()
     }
@@ -117,17 +116,14 @@ struct GalleryScenarioDetailView: View {
   }
 
   private var headerCard: some View {
+    // The scenario title is already the `.large` navigation title, so the card
+    // carries only the description — no duplicate heading above it.
     PasturaSection {
-      VStack(alignment: .leading, spacing: 8) {
-        Text(scenario.title)
-          .font(.title2.bold())
-          .foregroundStyle(Color.ink)
-        Text(scenario.description)
-          .font(.body)
-          .foregroundStyle(Color.inkSecondary)
-      }
-      .frame(maxWidth: .infinity, alignment: .leading)
-      .padding(17)
+      Text(scenario.description)
+        .font(.body)
+        .foregroundStyle(Color.inkSecondary)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(17)
     }
   }
 

--- a/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailView.swift
+++ b/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailView.swift
@@ -94,6 +94,7 @@ struct GalleryScenarioDetailView: View {
       VStack(alignment: .leading, spacing: PasturaCardMetrics.interCardSpacing) {
         if wasOpenedFromDeepLink { deepLinkBanner }
         headerCard
+        whatHappensSection
         detailsCard
         recommendedModelSection
         actionFooter(viewModel: viewModel)
@@ -130,23 +131,58 @@ struct GalleryScenarioDetailView: View {
     }
   }
 
+  /// Ordered detail rows. Agents / Rounds / Language are omitted entirely when
+  /// their backing value is absent (older-feed forward-compat), mirroring the
+  /// "never fabricate unknown data" posture of `GalleryCatalogRowFormat`.
+  private var detailRows: [(label: String, value: String)] {
+    var rows: [(label: String, value: String)] = [
+      (String(localized: "Category"), scenario.category.displayName)
+    ]
+    if let agentCount = scenario.agentCount {
+      rows.append((String(localized: "Agents"), "\(agentCount)"))
+    }
+    if let rounds = scenario.rounds {
+      rows.append((String(localized: "Rounds"), "\(rounds)"))
+    }
+    rows.append(
+      (
+        String(localized: "Recommended model"),
+        ModelRegistry.lookup(id: scenario.recommendedModel)?.displayName
+          ?? String(format: String(localized: "Unknown model (%@)"), scenario.recommendedModel)
+      ))
+    rows.append((String(localized: "Est. inferences"), "\(scenario.estimatedInferences)"))
+    if let language = GalleryScenarioDetailFormat.languageLabel(code: scenario.language) {
+      rows.append((String(localized: "Language"), language))
+    }
+    rows.append((String(localized: "Author"), scenario.author))
+    rows.append((String(localized: "Added"), scenario.addedAt))
+    return rows
+  }
+
   private var detailsCard: some View {
     PasturaSection(String(localized: "Details")) {
       VStack(spacing: 0) {
-        detailRow(String(localized: "Category"), value: scenario.category.displayName)
-        PasturaRowDivider()
-        detailRow(String(localized: "Author"), value: scenario.author)
-        PasturaRowDivider()
-        detailRow(
-          String(localized: "Recommended model"),
-          value: ModelRegistry.lookup(id: scenario.recommendedModel)?.displayName
-            ?? String(
-              format: String(localized: "Unknown model (%@)"), scenario.recommendedModel))
-        PasturaRowDivider()
-        detailRow(
-          String(localized: "Est. inferences"), value: "\(scenario.estimatedInferences)")
-        PasturaRowDivider()
-        detailRow(String(localized: "Added"), value: scenario.addedAt)
+        ForEach(Array(detailRows.enumerated()), id: \.offset) { index, row in
+          if index > 0 { PasturaRowDivider() }
+          detailRow(row.label, value: row.value)
+        }
+      }
+    }
+  }
+
+  /// "What happens" — the scenario's phase sequence as an arrow flow. Hidden
+  /// when the mapped flow is empty (no phases, or all unknown kinds).
+  @ViewBuilder
+  private var whatHappensSection: some View {
+    if let flow = GalleryScenarioDetailFormat.phaseFlow(phases: scenario.phases) {
+      PasturaSection(String(localized: "What happens")) {
+        // `verbatim` — `flow` is a runtime-composed string; a plain `Text(flow)`
+        // would reinterpret it as a `LocalizedStringKey` and miss the catalog.
+        Text(verbatim: flow)
+          .font(.body)
+          .foregroundStyle(Color.inkSecondary)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .padding(17)
       }
     }
   }

--- a/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailView.swift
+++ b/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailView.swift
@@ -172,8 +172,10 @@ struct GalleryScenarioDetailView: View {
   private var whatHappensSection: some View {
     if let flow = GalleryScenarioDetailFormat.phaseFlow(phases: scenario.phases) {
       PasturaSection(String(localized: "What happens")) {
-        // `verbatim` — `flow` is a runtime-composed string; a plain `Text(flow)`
-        // would reinterpret it as a `LocalizedStringKey` and miss the catalog.
+        // `verbatim` documents intent: `flow` is a pre-composed string of
+        // already-localized `PhaseDisplayName` fragments, not a catalog key —
+        // and guards against a future string *literal* creeping in here and
+        // silently becoming a `LocalizedStringKey` lookup.
         Text(verbatim: flow)
           .font(.body)
           .foregroundStyle(Color.inkSecondary)

--- a/Pastura/PasturaTests/Views/GalleryScenarioDetailFormatTests.swift
+++ b/Pastura/PasturaTests/Views/GalleryScenarioDetailFormatTests.swift
@@ -1,0 +1,68 @@
+import Testing
+
+@testable import Pastura
+
+/// Unit coverage of the pure ``GalleryScenarioDetailFormat`` helpers backing
+/// the shared-scenario detail screen's enriched metadata rows and the
+/// "What happens" phase flow (view-testing.md rule 1 — logic extracted from
+/// the View so it is testable without rendering).
+///
+/// `@MainActor`: ``GalleryScenarioDetailFormat`` sits at the default (MainActor)
+/// isolation because it composes the MainActor ``PhaseDisplayName`` helper
+/// (swift-isolation.md Pattern 5) — the suite matches so it can call directly.
+/// Phase-label literals are the `en` base strings from ``PhaseDisplayName``
+/// (tests run under the `en` base locale).
+@Suite("GalleryScenarioDetailFormat", .timeLimit(.minutes(1)))
+@MainActor
+struct GalleryScenarioDetailFormatTests {
+
+  // MARK: - phaseFlow
+
+  @Test func phaseFlowJoinsLabelsInOrder() {
+    #expect(
+      GalleryScenarioDetailFormat.phaseFlow(phases: ["speak_each", "summarize"])
+        == "Speak Each → Summarize")
+  }
+
+  @Test func phaseFlowPreservesGivenOrder() {
+    #expect(
+      GalleryScenarioDetailFormat.phaseFlow(phases: ["summarize", "vote", "assign"])
+        == "Summarize → Vote → Assign")
+  }
+
+  @Test func phaseFlowNilWhenAbsent() {
+    #expect(GalleryScenarioDetailFormat.phaseFlow(phases: nil) == nil)
+  }
+
+  @Test func phaseFlowNilWhenEmpty() {
+    #expect(GalleryScenarioDetailFormat.phaseFlow(phases: []) == nil)
+  }
+
+  @Test func phaseFlowSkipsUnknownKinds() {
+    // A feed newer than this build carries a phase kind we don't know — it is
+    // skipped, and the known ones still render.
+    #expect(
+      GalleryScenarioDetailFormat.phaseFlow(phases: ["future_kind", "vote"]) == "Vote")
+  }
+
+  @Test func phaseFlowNilWhenAllUnknown() {
+    // Non-empty but every entry maps away → section hidden, not an empty box.
+    #expect(GalleryScenarioDetailFormat.phaseFlow(phases: ["future_kind", "another"]) == nil)
+  }
+
+  // MARK: - languageLabel
+
+  @Test func languageLabelMapsLaunchLanguages() {
+    #expect(GalleryScenarioDetailFormat.languageLabel(code: "ja") != nil)
+    #expect(GalleryScenarioDetailFormat.languageLabel(code: "en") != nil)
+    // Distinct names — not the same fallback string.
+    #expect(
+      GalleryScenarioDetailFormat.languageLabel(code: "ja")
+        != GalleryScenarioDetailFormat.languageLabel(code: "en"))
+  }
+
+  @Test func languageLabelNilWhenAbsentOrUnknown() {
+    #expect(GalleryScenarioDetailFormat.languageLabel(code: nil) == nil)
+    #expect(GalleryScenarioDetailFormat.languageLabel(code: "fr") == nil)
+  }
+}


### PR DESCRIPTION
## Summary
Improve the shared-scenario detail screen (`GalleryScenarioDetailView`):
- **More info** — the details card now surfaces gallery metadata it was dropping: **Agents / Rounds / Language** rows (each hidden when its value is absent), plus a new **"What happens"** section rendering the scenario's phase sequence as an arrow flow (e.g. `Speak Each → Summarize`).
- **No duplicate title** — the scenario name was shown twice (the `.large` navigation title *and* a heading above the description); the redundant heading is removed so the header card carries only the description.
- **Direct report button** — the top-right `…` menu held only a single Report action, so it collapses into a direct report icon button (`exclamationmark.bubble`, `.iconOnly` so VoiceOver keeps the label; a11y id → `galleryDetail.reportButton`).

Phase labels reuse the existing `PhaseDisplayName` single source of truth (no new mapping). New pure-logic helper `GalleryScenarioDetailFormat` (phase-flow + language-label) is unit-tested; all data shown is already present in `gallery.json` (no extra fetch). The now-orphaned `"More"` catalog key is pruned.

## Test plan
- `GalleryScenarioDetailFormatTests` (8 tests): flow join/order, nil on absent/empty/all-unknown, unknown-kind skip; language ja/en → name, nil otherwise.
- Full unit suite: 2401 tests pass. SwiftLint `--strict` clean. i18n coverage OK (566 keys).
- code-reviewer (Opus): PASS, 0 blocking.

## Manual QA (device)
- ⚠️ iOS 26 toolbar Liquid-Glass capsule + swipe-back are simulator-misleading (swiftui-traps.md) — verify the new report toolbar button on a **real device**.
- Open a scenario detail: rows appear, "What happens" flow reads correctly, no duplicate title, report button opens the report sheet.

Closes #855

🤖 Generated with [Claude Code](https://claude.com/claude-code)