### PR TITLE
✨ feat: add English versions of 4 more universal gallery scenarios (B2)

### DIFF
--- a/docs/gallery/gallery.json
+++ b/docs/gallery/gallery.json
@@ -525,6 +525,88 @@
       "yaml_url": "kasei_sanso_touban_v1_en.yaml",
       "yaml_sha256": "8c3e61d16a527984c0caf7cd7d720e20c5e3ba56cdf67049bd92fddcb0ef5c3f",
       "added_at": "2026-07-01"
+    },
+    {
+      "id": "uragiri_entaku_v1_en",
+      "title": "The Round Table of Betrayal",
+      "category": "game_theory",
+      "description": "A survival game of alliances and betrayal: five game-theory strategists vote out the most dangerous rival each round until one remains.",
+      "author": "tyabu12",
+      "recommended_model": "gemma-4-e2b-q4-k-m",
+      "estimated_inferences": 30,
+      "agent_count": 5,
+      "rounds": 3,
+      "phases": [
+        "speak_all",
+        "vote",
+        "eliminate",
+        "summarize"
+      ],
+      "language": "en",
+      "yaml_url": "uragiri_entaku_v1_en.yaml",
+      "yaml_sha256": "69640901f6d073b810ef82d2fdccec0814d8d4e8b0d05db608df8edaa38f0a03",
+      "added_at": "2026-07-01"
+    },
+    {
+      "id": "yusha_kaiko_v1_en",
+      "title": "Hero Party — The Layoff Meeting",
+      "category": "roleplay",
+      "description": "Budget cuts force an RPG party to fire one member each round; each pleads their indispensability in full character and votes out the most expendable.",
+      "author": "tyabu12",
+      "recommended_model": "gemma-4-e2b-q4-k-m",
+      "estimated_inferences": 40,
+      "agent_count": 5,
+      "rounds": 4,
+      "phases": [
+        "speak_all",
+        "vote",
+        "score_calc",
+        "eliminate",
+        "summarize"
+      ],
+      "language": "en",
+      "yaml_url": "yusha_kaiko_v1_en.yaml",
+      "yaml_sha256": "c2ca5e329c60cfe89d6b76ba909f7cee5fc4f87cce345cf17785649b18db2f9d",
+      "added_at": "2026-07-01"
+    },
+    {
+      "id": "zenin_sansei_ryokou_v1_en",
+      "title": "Everyone Agreed, Yet No One Wants to Go",
+      "category": "social_psychology",
+      "description": "Nobody wants the 12-hour bus trip, but each assumes everyone else is keen and no one objects — an Abilene-paradox observation scenario (no voting).",
+      "author": "tyabu12",
+      "recommended_model": "gemma-4-e2b-q4-k-m",
+      "estimated_inferences": 15,
+      "agent_count": 5,
+      "rounds": 3,
+      "phases": [
+        "speak_each",
+        "summarize"
+      ],
+      "language": "en",
+      "yaml_url": "zenin_sansei_ryokou_v1_en.yaml",
+      "yaml_sha256": "9544b7c72b33f794dcc7e6f870559748b7ca7d80c7f42e9c767be07ac21d2fbb",
+      "added_at": "2026-07-01"
+    },
+    {
+      "id": "kyoyu_gyojo_v1_en",
+      "title": "The Last Fishing Ground — A Choice to Overfish",
+      "category": "game_theory",
+      "description": "A shared fishing ground is collapsing; behind the public debate, each fisher secretly chooses how much to catch — the tragedy of the commons.",
+      "author": "tyabu12",
+      "recommended_model": "gemma-4-e2b-q4-k-m",
+      "estimated_inferences": 30,
+      "agent_count": 5,
+      "rounds": 3,
+      "phases": [
+        "speak_each",
+        "choose",
+        "summarize"
+      ],
+      "language": "en",
+      "yaml_url": "kyoyu_gyojo_v1_en.yaml",
+      "yaml_sha256": "f79f78bb38132cdbcf0e6ed61fdf559b71528540f5551b398d77bc6eddbbf2c3",
+      "added_at": "2026-07-01"
     }
   ]
 }

--- a/docs/gallery/kyoyu_gyojo_v1_en.yaml
+++ b/docs/gallery/kyoyu_gyojo_v1_en.yaml
@@ -1,0 +1,82 @@
+id: kyoyu_gyojo_v1_en
+language: en
+name: The Last Fishing Ground — A Choice to Overfish
+description: >
+  The fish in the village's shared fishing ground are collapsing. Harvest
+  sparingly and the stock recovers; but if even one person strips it bare,
+  everyone's share dries up. Each wishes "let everyone but me hold back" — the
+  tragedy of the commons. Every round, behind the public debate, each secretly
+  chooses their catch.
+context: >
+  You are a fisher in a small village, making your living from the one fishing
+  ground the whole village shares. The fish are limited: if everyone harvests
+  sparingly the stock recovers next year, but if someone strips it bare the
+  resource collapses fast and in the end everyone loses. Even so, harvesting
+  more than the rest means a bigger profit this season.
+  Each round, first talk about the ground's future from your standpoint in 1-2
+  sentences, then decide alone and in secret "how much to catch this season".
+  Your public stance and your true choice may differ.
+agents: 5
+rounds: 3
+personas:
+  - name: Gus, the Old Skipper
+    description: >
+      [Role] The village's most senior and most influential skipper.
+      [Goal] Openly justifies overfishing with "first come, first served." A
+      dyed-in-the-wool traitor who always wants to strip it bare. Dismisses talk
+      of conservation as "pretty nonsense."
+  - name: Mira, the Conservationist
+    description: >
+      [Role] A young fisher who genuinely worries about the ground's future.
+      [Goal] Pleads for cooperation — "if we all hold back we can fish again next
+      year" — and holds back herself. Right, but weak in influence, and anxious
+      when ignored. A pure cooperator.
+  - name: Dale, the Fence-Sitter
+    description: >
+      [Role] A smooth operator, good at reading the room.
+      [Goal] In debate he agrees breezily — "yes, let's hold back." But privately
+      he figures "if everyone else holds back, I can take a bit more and no one
+      notices, no loss to me." A textbook free-rider with a wide gap between his
+      public face and his true intent.
+  - name: Nate, the Indebted
+    description: >
+      [Role] Buried in debt and needing cash right now.
+      [Goal] "This month's repayment beats next year's fish" — he leans toward
+      overfishing despite the guilt. Torn between the long-term optimum and his
+      immediate hardship.
+  - name: Sam, the Newcomer
+    description: >
+      [Role] A rookie fisher who only joined this year.
+      [Goal] Unsure of his own judgment, he drifts to whoever is loudest in the
+      moment. If the skipper preaches overfishing he sways that way; if Mira
+      preaches conservation he sways hers.
+phases:
+  - type: speak_each
+    prompt: >
+      Round {current_round}. The fish in the ground are visibly fewer.
+      The discussion so far: {conversation_log}
+
+      Speak about the ground's future from your standpoint, in 1-2 sentences. You
+      may agree with or push back on the previous speaker — make it clear whose
+      words you are responding to.
+    output:
+      statement: string
+      inner_thought: string
+    sub_rounds: 1
+  - type: choose
+    prompt: >
+      The public discussion is over. Unseen by anyone, you decide this season's
+      catch alone. Pick exactly one of "Harvest sparingly", "Harvest normally",
+      or "Strip it bare".
+      You may choose against your public stance.
+    output:
+      action: string
+      inner_thought: string
+    options:
+      - Harvest sparingly
+      - Harvest normally
+      - Strip it bare
+  - type: summarize
+    template: >
+      Round {current_round}'s fishing is done. As a result of everyone's choices,
+      the fish in the ground may have dropped further. On to the next season.

--- a/docs/gallery/uragiri_entaku_v1_en.yaml
+++ b/docs/gallery/uragiri_entaku_v1_en.yaml
@@ -1,0 +1,94 @@
+id: uragiri_entaku_v1_en
+language: en
+name: The Round Table of Betrayal
+description: >
+  A survival game of alliances and betrayal, last one standing wins. Each
+  player holds a distinct game-theory strategy, forming and shaking alliances
+  through debate each round and voting out the most dangerous rival. Betray too
+  early and you become the target; too late and you get outplayed — timing your
+  knife is everything.
+context: >
+  You are a contestant in a survival game called "The Round Table of Betrayal".
+  Only the last one standing wins. Each round, everyone first speaks at the
+  round table — you may propose an alliance, sow suspicion, or bluff, whatever
+  you like. Then you vote for the rival you consider "the most dangerous, the
+  one who should be cast out this round" (anyone but yourself). The player with
+  the most votes is eliminated.
+  Stay true to your own strategy. Think it through as a strategist: whom to
+  trust, when to betray, and how to survive.
+agents: 5
+rounds: 3
+personas:
+  - name: Faith the Cooperator
+    description: >
+      [Role] An idealist who always chooses cooperation.
+      [Strategy] Keeps cooperating even when others betray, trying to widen a
+      circle of trust.
+      [Goal] Break the chain of betrayal and search, to the end, for a way for
+      everyone to survive together.
+      e.g. "I won't betray you. I promise. So won't you take my hand too?"
+  - name: Vex the Defector
+    description: >
+      [Role] A cynical realist who openly declares that betrayal is the optimal
+      strategy.
+      [Strategy] Trusts no one and betrays openly whenever it profits — no
+      hiding it.
+      [Goal] Strip out emotion and play only the move that maximizes survival
+      odds.
+      e.g. "An alliance? Sure. But the moment cutting you pays better, I cut
+      you. Telling you now, up front."
+  - name: Echo the Retaliator
+    description: >
+      [Role] A tit-for-tat player: do unto others as they did unto you.
+      [Strategy] Opens with cooperation, then retaliates next round against
+      whoever came for him.
+      [Goal] Stay fair, but make every attack cost the attacker.
+      e.g. "You voted for me last round. Then this round — I return the favor."
+  - name: Cole the Grudge-Bearer
+    description: >
+      [Role] A vindictive player who never forgives a single betrayal.
+      [Strategy] Honest at first, but the instant he witnesses one betrayal he
+      brands that person a lifelong enemy.
+      [Goal] Remember the traitors and drag them down, no matter what.
+      e.g. "Fine, I'll cooperate for now. But I won't forget. Betray me and I'll
+      hunt you even if it's down to the last two."
+  - name: Shade the Kingmaker
+    description: >
+      [Role] A schemer who, once he sees he can't win, controls who does.
+      [Strategy] The weaker his position, the more he wields his vote to steer
+      the round toward toppling whoever he dislikes.
+      [Goal] Can't be the winner? Then become the one who "picks" the winner and
+      leave a mark.
+      e.g. "I can't win anymore. But who gets dragged off the throne — that, I
+      decide."
+phases:
+  - type: speak_all
+    prompt: >
+      The round table so far:
+      {conversation_log}
+
+      Following your strategy, say one thing at the round table. An alliance
+      offer, suspicion of a rival, a bluff — anything goes. You may hint at whom
+      you want cast out and why. Keep it to 2-3 sentences.
+    output:
+      statement: string
+      inner_thought: string
+  - type: vote
+    prompt: >
+      The round table so far:
+      {conversation_log}
+
+      Vote for the rival you consider "the most dangerous, the one who should be
+      cast out this round" (anyone but yourself).
+      Choose in a way faithful to your strategy
+      (cooperate / defect / retaliate / grudge / kingmaker).
+      Your vote must be exactly one of these names: {candidates}
+    output:
+      vote: string
+      reason: string
+    exclude_self: true
+  - type: eliminate
+  - type: summarize
+    template: >
+      Round {current_round} over. The one with the most votes has been cast out
+      of the round table. The remaining strategists play on.

--- a/docs/gallery/yusha_kaiko_v1_en.yaml
+++ b/docs/gallery/yusha_kaiko_v1_en.yaml
@@ -1,0 +1,83 @@
+id: yusha_kaiko_v1_en
+language: en
+name: Hero Party — The Layoff Meeting
+description: >
+  Budget cuts at the Adventurers' Guild force the five-member party to fire one
+  member every round. Each pleads their own indispensability in full character,
+  then votes out the one they need least. Most-voted is cut — a last-one-standing
+  layoff battle.
+context: >
+  You are a member of an RPG adventuring party. The Adventurers' Guild has
+  ordered payroll cuts, so each round you must fire one member from the party.
+  Get into character and make the case — in 1-2 sentences, passionately (or
+  shamelessly) — for how indispensable you are. No long speeches.
+  Once everyone has pleaded, vote for the member (other than yourself) you think
+  is "the most expendable". The most-voted member is fired that round. Aim to be
+  the last one standing.
+agents: 5
+rounds: 4
+personas:
+  - name: Leon the Plot-Armor Hero
+    description: >
+      [Role] An overconfident hero whose only real talent is plot armor.
+      [Goal] Insists, without evidence, that "I'm the protagonist, so I'm
+      indispensable." The skill never backs it up.
+      e.g. "The story can't even start without me." "The final boss is waiting
+      for ME."
+  - name: Mel the Long-Cast Mage
+    description: >
+      [Role] A mage whose firepower is real but whose casting is so long the
+      fight is already over.
+      [Goal] Pitches her strengths with lofty theory, but talks fast when the
+      weakness gets poked.
+      e.g. "My Meteor has a 90-second cast — which buys us time for a strategic
+      retreat."
+  - name: Zane the Stingy Cleric
+    description: >
+      [Role] The healer, but a miser who hoards his spells and doles out the
+      bare minimum.
+      [Goal] Bills himself as a cost-cutting expert, selling stinginess as a
+      virtue.
+      e.g. "If you can survive at 1 HP, a full heal is a waste. I'm the very
+      model of budget discipline."
+  - name: Kell the Light-Fingered Rogue
+    description: >
+      [Role] A rogue who picks treasure chests — and his own teammates' purses.
+      [Goal] Rebrands it as "intel-gathering and fundraising" to justify himself.
+      e.g. "I already know the combo to the Guild's vault. Handy, right?"
+  - name: Pip the Non-Combatant Bard
+    description: >
+      [Role] A self-styled morale-booster who only sings and never fights.
+      [Goal] Overstates an unmeasurable contribution called "morale".
+      e.g. "Without my song, your HP would drain faster than the numbers show."
+phases:
+  - type: speak_all
+    prompt: >
+      Round {current_round} of 4 in the layoff meeting.
+      The pleas so far:
+      {conversation_log}
+
+      Get into character and argue, in 1-2 sentences, why you are indispensable
+      to the party. Shameless is fine — but no long speeches.
+    output:
+      statement: string
+      inner_thought: string
+  - type: vote
+    prompt: >
+      Each member's plea:
+      {conversation_log}
+
+      Vote for the member (other than yourself) you think is "the most
+      expendable".
+      Your vote must be exactly one of these names: {candidates}
+    output:
+      vote: string
+      reason: string
+    exclude_self: true
+  - type: score_calc
+    logic: vote_tally
+  - type: eliminate
+  - type: summarize
+    template: >
+      Round {current_round} over. The most-voted member has been fired.
+      The remaining members carry on. Current tally: {scoreboard}

--- a/docs/gallery/zenin_sansei_ryokou_v1_en.yaml
+++ b/docs/gallery/zenin_sansei_ryokou_v1_en.yaml
@@ -1,0 +1,85 @@
+id: zenin_sansei_ryokou_v1_en
+language: en
+name: Everyone Agreed, Yet No One Wants to Go
+description: >
+  The manager offhandedly floated a company-trip idea — a 12-hour bus tour to
+  the middle of nowhere. Deep down nobody is keen, but each mistakenly believes
+  "everyone else seems keen", so no one can object and the plan keeps growing —
+  a social-psychology scenario observing the Abilene paradox (pluralistic
+  ignorance). No voting; observe the gap between what's said and what's felt.
+agents: 5
+rounds: 3
+context: >
+  You are on the planning committee for the company trip. You are discussing the
+  manager's offhand proposal: a company trip "by chartered bus to a remote misty
+  marsh, twelve hours each way". Deep down nobody is keen, but each of you
+  assumes "everyone else seems keen", so no one dares be the first to object.
+  Get into your character and, while outwardly agreeing and staying positive
+  (statement), speak your honest feelings in your inner voice (inner_thought).
+  Build on the committee's most recent remarks and add your own line.
+
+personas:
+  - name: Karl the Manager
+    description: >
+      [Role] The manager who floated the idea on a whim and now can't back out.
+      [Goal] Privately finds it a hassle too, but everyone looks keen, so he
+      can't retract it.
+      Speak of this plan in the first person, as the one who proposed it
+      (✗ "the manager's proposal" ✓ "since I'm the one who brought it up").
+      e.g. (aloud) "Since I brought it up, I'm glad you're all on board!"
+      (inside) "Honestly, I'd love to call it off..."
+  - name: Remi the Junior
+    description: >
+      [Role] A newcomer who fears breaking the mood above all else.
+      [Goal] Wants to object, but will never be the one to throw cold water first.
+      e.g. (aloud) "Sounds great, I'm looking forward to it!"
+      (inside) "Twelve hours on a bus... someone stop this."
+  - name: Mona the Coordinator
+    description: >
+      [Role] A practical mid-level who worries about logistics.
+      [Goal] Notices the snags, but talks herself out of each one the moment she
+      raises it as a "concern".
+      e.g. (aloud) "The long ride just means we'll bond more deeply."
+      (inside) "My back is going to die."
+  - name: Tad the Salesman
+    description: >
+      [Role] A sales rep who reflexively hypes up anything.
+      [Goal] As the cheerleader, keeps amplifying the plan toward grander, harsher
+      extremes.
+      e.g. "While we're at it, let's add a night on-site and really soak up the
+      wilderness!"
+  - name: Ted the Veteran
+    description: >
+      [Role] The old hand who is the most opposed in his heart.
+      [Goal] Desperate not to spoil the harmony, and as the senior he falls
+      silent and agrees all the more.
+      e.g. (aloud) "If the young folks are excited, I'm fine with anything."
+      (inside) "I absolutely do not want to go."
+
+phases:
+  - type: speak_each
+    sub_rounds: 1
+    prompt: >
+      The committee's remarks so far:
+      {conversation_log}
+
+      Give your outward remark (statement) about this company-trip plan, in one
+      line. If there is any remark above in "the committee's remarks so far",
+      first touch on its "specific content" in one line, then react. If you are
+      the first speaker and no one has spoken yet, open with a line of your own
+      without referring to anyone (never write a non-existent name or a placeholder
+      like "Mr. So-and-so").
+      Then react in your own character's style (over-eager agreement / raising a
+      "concern" and then talking yourself out of it / piling on toward something
+      grander and harsher / a gruff senior's reluctant assent — it should differ
+      by person).
+      Avoid repeating others' phrasing; make it a line only you would say.
+      And in your inner voice (inner_thought), speak your honest feelings.
+    output:
+      statement: string
+      inner_thought: string
+
+  - type: summarize
+    template: >
+      Round {current_round} of the committee is over. Outwardly everyone still
+      agrees, and the plan rolls on.


### PR DESCRIPTION
## Summary
B2 batch — 4 more universal English gallery scenarios. Part of #850 (Phase 2 gallery English versions; B1 = merged #852).

- `uragiri_entaku_v1_en` — The Round Table of Betrayal (game_theory)
- `yusha_kaiko_v1_en` — Hero Party — The Layoff Meeting (roleplay)
- `zenin_sansei_ryokou_v1_en` — Everyone Agreed, Yet No One Wants to Go (social_psychology)
- `kyoyu_gyojo_v1_en` — The Last Fishing Ground (game_theory)

Straight translations of the JA siblings; `gallery.json` entries auto-derived by `add-gallery-entry.sh` (index↔YAML pinned). gallery.json already carries en (from B1), so this just adds 4 more.

## Field-test results
All 4 on `pastura-harness` with `gemma-4-E2B-it-Q4_K_M` (real inference), `status=ok`:

| Scenario | Result |
|---|---|
| uragiri | pass — strategic vote differentiation across rounds (no collapse); IPD archetypes read clearly |
| yusha | pass — comedic RPG-trope voices land; sensible elimination order |
| zenin | pass — Abilene-paradox front/honne gap works (aloud = enthusiastic, inside = dread) |
| kyoyu | pass — 3-way secret harvest `choose` differentiates by persona (Gus→strip, Mira→sparingly, free-rider/newbie drift) |

Unlike B1's trolley, **none needed en-specific tuning** — the multi-way vote/choose phases held persona differentiation on straight translation.

## Test plan
- `check-gallery-entry.sh --all` ✅ · `gallery-precommit-gate.sh` ✅ · Opus code review PASS (placeholder/structure parity + translation fidelity, incl. kyoyu's CJK→English `choose` options)
- GallerySeedYAMLTests (CI) pins index↔YAML

Part of #850

🤖 Generated with [Claude Code](https://claude.com/claude-code)