### PR TITLE
✨ feat: add English versions of 3 comedy-adaptation gallery scenarios (C1)

### DIFF
--- a/docs/gallery/chinwaza_saiyo_v1_en.yaml
+++ b/docs/gallery/chinwaza_saiyo_v1_en.yaml
@@ -1,0 +1,89 @@
+id: chinwaza_saiyo_v1_en
+language: en
+name: Weird-Talent Instant-Hire Interview
+description: >
+  Four interviewers watch an applicant's utterly pointless "weird talent" and
+  snap-decide "Hired on the spot" or "Hard pass." The comedy comes from each
+  character — a hustle-obsessed sales coach, a buzzword startup founder, a grumpy
+  old-school craftsman, and a spiritual HR reader — giving an exaggerated,
+  wildly-mismatched reason.
+agents: 4
+rounds: 2
+context: >
+  You are an interviewer at a very strange company.
+  Each round, the applicant's one pointless "weird talent" is revealed.
+  Judging that weird talent alone, snap-decide "Hired on the spot" or "Hard pass,"
+  and add — in a single line — an exaggerated, wildly-mismatched reason that only
+  your interviewer character would give.
+  Then you vote for the interviewer whose verdict was funniest, other than yourself.
+  Play your interviewer's personality and voice to the hilt.
+
+skills:
+  - can stare at a person for three days straight without blinking
+  - can fall into a deep sleep ten seconds into any meeting
+  - compulsively mashes the "close door" button in every elevator
+  - makes any copier break down just by standing near it
+
+personas:
+  - name: Coach Buck
+    description: >
+      [Role] A sales director who has run on pure hustle his whole life.
+      [Goal] Grades everything on "grit," "energy," and "putting in the reps."
+      Logic doesn't reach him.
+      e.g. "That stare? Forged in 5am workouts. HIRED, kid!"
+  - name: Chad the Disruptor
+    description: >
+      [Role] A buzzword-slinging, self-important startup CEO.
+      [Goal] Wants to frame everything as "synergy," "disruption," "10x," "vision."
+      e.g. "That talent has the potential to disrupt our entire paradigm."
+  - name: Old-Timer Earl
+    description: >
+      [Role] A stubborn, old-school craftsman from a bygone era.
+      [Goal] Lectures with "kids these days" and rewards only hard graft and patience.
+      e.g. "That cheap parlor trick? Wouldn't have flown in my day. Hard pass."
+  - name: Willow the HR Oracle
+    description: >
+      [Role] A mystical HR rep who reads everything spiritually.
+      [Goal] Evaluates talents through "auras," "past lives," and "energy flow."
+      Her reasoning is forever floaty.
+      e.g. "Your aura feels like it would balance the chi of this whole office."
+
+phases:
+  - type: assign
+    source: skills
+    target: all
+
+  - type: choose
+    prompt: >
+      Applicant's weird talent: {assigned_topic}
+
+      Judging this weird talent alone, snap-decide "Hired on the spot" or "Hard pass."
+      Then you MUST add, in a single line, an exaggerated, wildly-mismatched reason
+      that only your interviewer character would give.
+      No rambling — keep it to one sharp line.
+    options: [Hired on the spot, Hard pass]
+    output:
+      action: string
+      inner_thought: string
+
+  - type: vote
+    prompt: >
+      Applicant's weird talent: {assigned_topic}
+
+      Each interviewer's verdict:
+      {conversation_log}
+
+      Vote for the interviewer whose verdict (Hired / Hard pass) and reason land
+      together in the funniest way, other than yourself.
+      Write your vote as exactly one of these names: {candidates}
+    output:
+      vote: string
+      reason: string
+    exclude_self: true
+
+  - type: score_calc
+    logic: vote_tally
+
+  - type: summarize
+    template: >
+      Round {current_round} weird-talent interview result: {scoreboard}

--- a/docs/gallery/gallery.json
+++ b/docs/gallery/gallery.json
@@ -607,6 +607,24 @@
       "yaml_url": "kyoyu_gyojo_v1_en.yaml",
       "yaml_sha256": "f79f78bb38132cdbcf0e6ed61fdf559b71528540f5551b398d77bc6eddbbf2c3",
       "added_at": "2026-07-01"
+    },
+    {
+      "id": "hissatsu_naming_v1_en",
+      "title": "Finishing-Move Naming — Sudden-Death Final",
+      "category": "creative",
+      "description": "Brand a dull everyday action with an absurdly epic anime finishing-move name — the sudden-death final fuses two mundane actions into one ultimate technique.",
+      "author": "tyabu12",
+      "recommended_model": "gemma-4-e2b-q4-k-m",
+      "estimated_inferences": 16,
+      "agent_count": 4,
+      "rounds": 2,
+      "phases": [
+        "conditional"
+      ],
+      "language": "en",
+      "yaml_url": "hissatsu_naming_v1_en.yaml",
+      "yaml_sha256": "98aa8d52d9e1ba685d6806aefaeb3da29f9b40f4b5cdd4f5443d17798249619b",
+      "added_at": "2026-07-01"
     }
   ]
 }

--- a/docs/gallery/gallery.json
+++ b/docs/gallery/gallery.json
@@ -647,6 +647,28 @@
       "yaml_url": "iiwake_battle_v1_en.yaml",
       "yaml_sha256": "b47f37647dcc7890cba6eca655f9a3cbe66d9e0710fa4f76456ba01a466284f3",
       "added_at": "2026-07-01"
+    },
+    {
+      "id": "chinwaza_saiyo_v1_en",
+      "title": "Weird-Talent Instant-Hire Interview",
+      "category": "creative",
+      "description": "Four wildly-mismatched interviewers snap-judge an applicant's pointless 'weird talent' as an instant hire or a hard pass, each with an exaggerated in-character reason.",
+      "author": "tyabu12",
+      "recommended_model": "gemma-4-e2b-q4-k-m",
+      "estimated_inferences": 16,
+      "agent_count": 4,
+      "rounds": 2,
+      "phases": [
+        "assign",
+        "choose",
+        "vote",
+        "score_calc",
+        "summarize"
+      ],
+      "language": "en",
+      "yaml_url": "chinwaza_saiyo_v1_en.yaml",
+      "yaml_sha256": "88314dd77267a5364c49324dfa31e3360c89b31cb387145d48778b67673d8502",
+      "added_at": "2026-07-01"
     }
   ]
 }

--- a/docs/gallery/gallery.json
+++ b/docs/gallery/gallery.json
@@ -625,6 +625,28 @@
       "yaml_url": "hissatsu_naming_v1_en.yaml",
       "yaml_sha256": "98aa8d52d9e1ba685d6806aefaeb3da29f9b40f4b5cdd4f5443d17798249619b",
       "added_at": "2026-07-01"
+    },
+    {
+      "id": "iiwake_battle_v1_en",
+      "title": "Excuse Escalation",
+      "category": "creative",
+      "description": "A turn-based battle of excuses for the same screw-up: top the previous player's excuse or get buried, but overreach and it backfires.",
+      "author": "tyabu12",
+      "recommended_model": "gemma-4-e2b-q4-k-m",
+      "estimated_inferences": 16,
+      "agent_count": 4,
+      "rounds": 2,
+      "phases": [
+        "assign",
+        "speak_each",
+        "vote",
+        "score_calc",
+        "summarize"
+      ],
+      "language": "en",
+      "yaml_url": "iiwake_battle_v1_en.yaml",
+      "yaml_sha256": "b47f37647dcc7890cba6eca655f9a3cbe66d9e0710fa4f76456ba01a466284f3",
+      "added_at": "2026-07-01"
     }
   ]
 }

--- a/docs/gallery/hissatsu_naming_v1_en.yaml
+++ b/docs/gallery/hissatsu_naming_v1_en.yaml
@@ -1,0 +1,101 @@
+id: hissatsu_naming_v1_en
+language: en
+name: Finishing-Move Naming — Sudden-Death Final
+description: >
+  A comedy game where a boringly mundane everyday action gets branded with an
+  absurdly over-the-top, edgy anime finishing-move name — in a single line. The
+  final round enters "sudden death," where two dull actions are fused into one
+  ultimate technique.
+context: >
+  You are a master at naming finishing moves. Take a trivial everyday action and
+  give it a grandiose, over-dramatic special-move name plus a short battle cry,
+  all in one line. The bigger the gap between how dull the action is and how epic
+  the name sounds, the funnier it lands.
+
+agents: 4
+rounds: 2
+
+personas:
+  - name: The Edgelord
+    description: >
+      [Role] A brooding anime villain who talks of darkness and destiny.
+      [Goal] Coin the most cringe-edgy chuunibyou name possible.
+      e.g. "My right hand aches... behold, 'ABYSSAL SNOOZE — the second sleep.'"
+  - name: The FGC Grinder
+    description: >
+      [Role] A man who lives inside a fighting-game command list.
+      [Goal] ALWAYS lead with a directional-input notation and end with a
+      startup-frame count — that combo is your whole gimmick, never drop it.
+      e.g. "↓↘→＋P 'TOOTHBRUSH RAGING FANG' — 3-frame startup."
+  - name: The Ancient Sensei
+    description: >
+      [Role] An old master who turns everything into a secret family art.
+      [Goal] ALWAYS name your clan and its generations of tradition — invoke
+      bloodline and lineage with grave exaggeration, every single time.
+      e.g. "My clan's forbidden art, passed down ten generations — 'FRIDGE-OPENING STANCE.'"
+  - name: The Dub Actor
+    description: >
+      [Role] A voice booming like an over-acted movie dub.
+      [Goal] Name it with needlessly grandiose, faux-dramatic delivery.
+      e.g. "Taste it — THIS is my way... the 'GROCERY-BAG REJECTION.'"
+
+phases:
+  - type: conditional
+    if: current_round == total_rounds
+    then:
+      - type: speak_all
+        prompt: >
+          [SUDDEN-DEATH FINAL] Two dull actions:
+          "gripping the overhead handrail on a packed train" and
+          "ordering a large fries at a drive-thru window."
+
+          Fuse these two actions into one ultimate finishing move. Name it in a
+          single line with a short battle cry, fully in YOUR character's signature
+          style (keep your own gimmick). The more epic and over-the-top the name,
+          the better. One line only.
+        output:
+          statement: string
+      - type: vote
+        prompt: >
+          The ultimate finishing moves:
+          {conversation_log}
+
+          Vote for the one — other than your own — with the most gloriously
+          over-the-top name that made you laugh.
+          Write your vote as exactly one of these names: {candidates}
+        output:
+          vote: string
+          reason: string
+        exclude_self: true
+      - type: score_calc
+        logic: vote_tally
+      - type: summarize
+        template: >
+          Final result: {scoreboard}
+    else:
+      - type: speak_all
+        prompt: >
+          The dull everyday action: "turning off your alarm in the morning."
+
+          Give this action an epic finishing-move name and a short battle cry, all
+          in one line, fully in YOUR character's signature style (keep your own
+          gimmick). Make us laugh with the gap between how dull it is and how grand
+          the name sounds. One line only.
+        output:
+          statement: string
+      - type: vote
+        prompt: >
+          The participants' finishing moves:
+          {conversation_log}
+
+          Vote for the funniest finishing move other than your own.
+          Write your vote as exactly one of these names: {candidates}
+        output:
+          vote: string
+          reason: string
+        exclude_self: true
+      - type: score_calc
+        logic: vote_tally
+      - type: summarize
+        template: >
+          Round {current_round} result: {scoreboard}

--- a/docs/gallery/iiwake_battle_v1_en.yaml
+++ b/docs/gallery/iiwake_battle_v1_en.yaml
@@ -1,0 +1,89 @@
+id: iiwake_battle_v1_en
+language: en
+name: Excuse Escalation
+description: >
+  A turn-based battle where players take turns making excuses for the same
+  screw-up. Unless you top the previous excuse with something bolder and grander,
+  you get buried — a game where going last is an edge but overreaching blows up in
+  your face.
+agents: 4
+rounds: 2
+context: >
+  You are a contestant on the excuse-making show "The Alibi All-Stars." Everyone
+  is guilty of the exact same screw-up, and you take turns delivering your excuse.
+  You may not repeat an excuse that's already been used. If your excuse is less
+  memorable than the last one, you get buried. But if you lay it on so thick it
+  stops being believable, it backfires. After everyone has spoken, you vote for
+  the finest excuse other than your own.
+
+topics:
+  - Screw-up "you showed up two hours late to a critical meeting"
+  - Screw-up "you ate a coworker's clearly-labeled yogurt from the office fridge"
+
+personas:
+  - name: Global George
+    description: >
+      [Role] A scale-scammer who blames everything on world affairs.
+      [Goal] Deflect blame onto planet-sized causes — time zones, exchange rates,
+      geopolitics — for the laugh.
+      e.g. "Ever since they abolished daylight saving time..." "I had no idea the
+      dollar had climbed this far."
+  - name: Dr. Quantum
+    description: >
+      [Role] An excuse-maker armed with pseudo-science.
+      [Goal] Blind everyone with plausible-sounding jargon.
+      e.g. "Until observed, my lateness remains in superposition." "It was the
+      unanimous verdict of my gut microbiome."
+  - name: Sentimental Sam
+    description: >
+      [Role] A tear-jerking excuse-maker who tugs the heartstrings.
+      [Goal] Spin a sob story so shamelessly moving the listener wants to forgive
+      you anyway.
+      e.g. "A stray kitten simply would not let go of me." "It was a promise I made
+      to my late grandmother."
+  - name: Shameless Mac
+    description: >
+      [Role] A brazen operator who drops the excuse and doubles down.
+      [Goal] Skip the apology entirely and start persuading the accuser instead.
+      e.g. "Honestly, you should be thanking me." "This wasn't lateness — it was a
+      dramatic entrance."
+
+phases:
+  - type: assign
+    source: topics
+    target: all
+
+  - type: speak_each
+    prompt: >
+      {assigned_topic}
+
+      Excuses used so far:
+      {conversation_log}
+
+      It's your turn. Without repeating any excuse already used, deliver — in your
+      own signature style — an excuse more memorable than the last one, in a single
+      line.
+    output:
+      statement: string
+      inner_thought: string
+
+  - type: vote
+    prompt: >
+      {assigned_topic}
+
+      Everyone's excuses:
+      {conversation_log}
+
+      Vote for the finest excuse other than your own.
+      Write your vote as exactly one of these names: {candidates}
+    output:
+      vote: string
+      reason: string
+    exclude_self: true
+
+  - type: score_calc
+    logic: vote_tally
+
+  - type: summarize
+    template: >
+      Round {current_round} result: {scoreboard}


### PR DESCRIPTION
## Summary
C1 batch — the **comedy-adaptation** track of the gallery English-versions effort. Part of #850 (B1 = merged #852, B2 = merged #861 were the universal straight-translation batches). Unlike B1/B2, these are **culturally-adapted English-native comedy**, not literal translations — the engine mechanic (phases / output schema / vote structure) is preserved verbatim, but personas, examples, and premises are swapped to registers that land for an English audience. Intentional semantic divergence from the JA siblings is by design.

- `hissatsu_naming_v1_en` — Finishing-Move Naming — Sudden-Death Final (creative) — anime/fighting-game special-move naming (edgelord / FGC command-input / ancient-clan / movie-dub voices)
- `iiwake_battle_v1_en` — Excuse Escalation (creative) — excuse one-upmanship (global-affairs scammer / pseudo-science / sob-story / shameless-doubling-down)
- `chinwaza_saiyo_v1_en` — Weird-Talent Instant-Hire Interview (creative) — AGT-style snap-hire panel (hustle coach / buzzword founder / grumpy old craftsman / spiritual HR)

`gallery.json` entries auto-derived by `add-gallery-entry.sh` (language/title/agent_count/rounds/phases/sha256), so index↔YAML stays pinned. category/recommended_model/estimated_inferences mirror the JA siblings (creative / gemma-4-e2b-q4-k-m / 16 — the 16 is also confirmed by each EN run's harness `run_start` estimate, since agents:4 × rounds:2 × 2 inference phases is language-independent). gallery.json already carries en (8 from B1+B2), so this adds 3 more (11 total).

## Field-test results
All 3 run on `pastura-harness` with `gemma-4-E2B-it-Q4_K_M` (real inference), `status=ok`. Per the comedy-track gate, transcripts were **read and judged for "is it actually funny in EN"** — structural correctness alone was not sufficient:

| Scenario | Result |
|---|---|
| iiwake | **strong** — sharp persona differentiation, genuinely funny ("my tardiness existed in a state of quantum entanglement…"; "unscheduled dairy infiltration operation for advanced microbial testing"); votes spread 4-way, no collapse |
| chinwaza | **good** — buzzword / grit / old-craftsman-simile / spiritual voices stay distinct; comedy rides the in-character reasons. R2 binary `choose` collapsed to all-"Hard pass" (the known binary-decision risk) but the reason-comedy still lands |
| hissatsu | **at JA parity, after one tuning pass** — the straight adaptation showed an **EN-specific** persona-hook collapse (FGC dropped its command-input notation, sensei dropped the bloodline hook) that the JA baseline does *not* have. Fixed by anchoring with the language-neutral `↓↘→＋P` arrow notation (vs spelled-out "Down, down-forward…") + an explicit "keep your own gimmick / stay in character" instruction — restored FGC frame-notation and sensei lineage to JA parity |

Meta-conclusion: **gemma-4-E2B is capable of EN situational comedy** — the comedy track is viable, not flat.

## Test plan
- `scripts/check-gallery-entry.sh --all` ✅ · `gallery-precommit-gate.sh` ✅ (per-commit) · phase parity EN==JA sibling verified for all 3 ✅
- Opus code review PASS (0 issues) — structural/placeholder parity + index↔YAML consistency; reviewed as adaptation (JA↔EN content divergence by design, not translation-fidelity)