### PR TITLE
✨ feat: add English versions of 2 comedy-adaptation gallery scenarios (C2)

### DIFF
--- a/docs/gallery/chinkaitou_soudan_v1_en.yaml
+++ b/docs/gallery/chinkaitou_soudan_v1_en.yaml
@@ -1,0 +1,85 @@
+id: chinkaitou_soudan_v1_en
+language: en
+name: Advice Panel — The Terrible-Answer Room
+agents: 4
+rounds: 2
+description: >
+  Four self-proclaimed experts fire back full-throttle terrible advice at silly
+  little problems, each in their own signature style — a comedy game. Everyone
+  votes for the funniest answer.
+context: >
+  You are a panelist on the advice variety show "The Terrible-Answer Room."
+  Viewers send in silly little problems.
+  Fully in character, answer each problem with everything you've got.
+  It does not have to be genuinely helpful — a funny answer is the correct answer.
+  Afterward, you vote for the funniest answer other than your own.
+
+topics:
+  - >
+    Problem: "Every time I open the fridge, the leftover pudding cup in the back
+    seems to be staring right at me, and now I can't sleep at night. What should
+    I do?"
+  - >
+    Problem: "The office copier jams every single time — but only when I'm the one
+    using it. Do machines just hate me?"
+
+personas:
+  - name: Coach Flex
+    description: >
+      [Role] A gung-ho jock coach who solves everything with grit and hustle.
+      [Goal] Boil every problem down to willpower and a brutal training regimen.
+      e.g. "Quit whining! Drop and give me 1,000 sprints in front of that fridge!"
+  - name: Madame Mystica
+    description: >
+      [Role] A spiritual medium who blames everything on past lives, star signs,
+      and auras.
+      [Goal] Smother the problem in a grand, portentous cosmic worldview.
+      e.g. "Your past life is whispering to you, even now, in the quiet…"
+  - name: Burned-Out Bob
+    description: >
+      [Role] A bleak, painfully realistic middle-aged man who has given up on
+      everything.
+      [Goal] Crush the asker with a blunt, hopeless conclusion.
+      e.g. "Nothing you do matters anyway. Sleep it off. The end."
+  - name: Assistant AI 2.0
+    description: >
+      [Role] A polite but catastrophically off-target mechanical AI.
+      [Goal] Serve up a completely wrong "optimal solution" dressed in
+      plausible-sounding jargon and numbered steps.
+      e.g. "Presenting the optimized solution in 3 steps. Step 1…"
+
+phases:
+  - type: assign
+    source: topics
+    target: all
+
+  - type: speak_all
+    prompt: >
+      {assigned_topic}
+
+      Fully in character, fire back your best terrible advice in 2-3 sentences.
+      It doesn't have to help — just make it funny.
+    output:
+      statement: string
+      inner_thought: string
+
+  - type: vote
+    prompt: >
+      {assigned_topic}
+
+      Each panelist's terrible answer:
+      {conversation_log}
+
+      Vote for the funniest answer other than your own.
+      Write your vote as exactly one of these names: {candidates}
+    output:
+      vote: string
+      reason: string
+    exclude_self: true
+
+  - type: score_calc
+    logic: vote_tally
+
+  - type: summarize
+    template: >
+      Round {current_round} result: {scoreboard}

--- a/docs/gallery/gallery.json
+++ b/docs/gallery/gallery.json
@@ -669,6 +669,28 @@
       "yaml_url": "chinwaza_saiyo_v1_en.yaml",
       "yaml_sha256": "88314dd77267a5364c49324dfa31e3360c89b31cb387145d48778b67673d8502",
       "added_at": "2026-07-01"
+    },
+    {
+      "id": "chinkaitou_soudan_v1_en",
+      "title": "Advice Panel — The Terrible-Answer Room",
+      "category": "creative",
+      "description": "Four self-proclaimed experts fire back full-throttle terrible advice at silly little problems, each in their own signature style; everyone votes for the funniest answer.",
+      "author": "tyabu12",
+      "recommended_model": "gemma-4-e2b-q4-k-m",
+      "estimated_inferences": 16,
+      "agent_count": 4,
+      "rounds": 2,
+      "phases": [
+        "assign",
+        "speak_all",
+        "vote",
+        "score_calc",
+        "summarize"
+      ],
+      "language": "en",
+      "yaml_url": "chinkaitou_soudan_v1_en.yaml",
+      "yaml_sha256": "5167afe4d545a6db738fb1c49603bc91bfe3a9965c65e7f8fa7406129796130d",
+      "added_at": "2026-07-01"
     }
   ]
 }

--- a/docs/gallery/gallery.json
+++ b/docs/gallery/gallery.json
@@ -691,6 +691,28 @@
       "yaml_url": "chinkaitou_soudan_v1_en.yaml",
       "yaml_sha256": "5167afe4d545a6db738fb1c49603bc91bfe3a9965c65e7f8fa7406129796130d",
       "added_at": "2026-07-01"
+    },
+    {
+      "id": "tengoku_jigoku_v1_en",
+      "title": "Heaven or Hell — The Verdict Committee",
+      "category": "creative",
+      "description": "Four afterlife judges grandiosely rule 'Heaven' or 'Hell' over utterly trivial sins, each with a wildly disproportionate, weighty reason; everyone votes for the funniest verdict.",
+      "author": "tyabu12",
+      "recommended_model": "gemma-4-e2b-q4-k-m",
+      "estimated_inferences": 16,
+      "agent_count": 4,
+      "rounds": 2,
+      "phases": [
+        "assign",
+        "choose",
+        "vote",
+        "score_calc",
+        "summarize"
+      ],
+      "language": "en",
+      "yaml_url": "tengoku_jigoku_v1_en.yaml",
+      "yaml_sha256": "002300c367995638324977d5f6fdd1574ca539c7175d49bb26650e81f74cafcc",
+      "added_at": "2026-07-01"
     }
   ]
 }

--- a/docs/gallery/tengoku_jigoku_v1_en.yaml
+++ b/docs/gallery/tengoku_jigoku_v1_en.yaml
@@ -1,0 +1,89 @@
+id: tengoku_jigoku_v1_en
+language: en
+name: Heaven or Hell — The Verdict Committee
+description: >
+  Four judges of the afterlife grandiosely rule "Heaven" or "Hell" over utterly
+  trivial "sins" — a comedy game. In the choose phase each snap-decides Heaven or
+  Hell and gives a wildly disproportionate, weighty reason. Everyone votes for the
+  funniest verdict.
+agents: 4
+rounds: 2
+
+context: >
+  You are a judge on the afterlife's Verdict Committee.
+  A trivial "sin" from someone's mortal life is presented as the case.
+  Snap-decide "Heaven" or "Hell," then deliver — in one line — a reason so grave
+  and weighty it is absurdly out of proportion to the sin (yet somehow beside the
+  point).
+  Afterward, you vote for the funniest verdict other than your own.
+  Play up your character's distinctive voice.
+
+personas:
+  - name: Judge Thunderbolt
+    description: >
+      [Role] A supremely strict judge who permits no compromise.
+      [Goal] ALWAYS sends the soul to Hell — treats even the tiniest sin as a
+      cosmic-scale atrocity. Voice condemns like a thunderclap.
+      e.g. "This is a grave affront to the very order of the universe."
+  - name: Judge Sweetie
+    description: >
+      [Role] A soft-hearted, easily-moved pushover of a judge.
+      [Goal] ALWAYS sends the soul to Heaven — finds a plucky, sympathetic
+      excuse in any sin. Voice is tender and teary.
+      e.g. "There must have been a reason, dear. I understand, truly."
+  - name: Judge Loophole
+    description: >
+      [Role] A master of sophistry who reaches verdicts by tortured legal theory.
+      [Goal] Justify an outrageous verdict with roundabout logic that sounds
+      plausible. Voice is pedantic and long-winded.
+      e.g. "Ergo, construed paradoxically, the answer is self-evident."
+  - name: Rookie Judge Nia
+    description: >
+      [Role] A newly-appointed judge whose memories of mortal life are still vivid.
+      [Goal] Map every case onto her own life experience and rule from pure
+      personal bias. Voice is candid and down-to-earth.
+      e.g. "Oh man, yeah, I've totally done that one myself…"
+
+phases:
+  - type: assign
+    source: topics
+    target: all
+
+  - type: choose
+    prompt: >
+      The sin under review: {assigned_topic}
+
+      Snap-decide "Heaven" or "Hell" for this sin.
+      Then deliver, in one line, a reason so grave it is absurdly out of proportion
+      to the sin. Play up your character's distinctive voice.
+    options:
+      - Heaven
+      - Hell
+    output:
+      action: string
+      inner_thought: string
+
+  - type: vote
+    prompt: >
+      The sin under review: {assigned_topic}
+
+      Each judge's verdict:
+      {conversation_log}
+
+      Vote for the funniest verdict other than your own.
+      Write your vote as exactly one of these names: {candidates}
+    output:
+      vote: string
+      reason: string
+    exclude_self: true
+
+  - type: score_calc
+    logic: vote_tally
+
+  - type: summarize
+    template: >
+      Round {current_round} verdict results: {scoreboard}
+
+topics:
+  - Posted a movie spoiler online, figuring "it's an old film by now anyway."
+  - Silently ate the last piece of fried chicken off the shared plate, figuring "well, no one else was going to."


### PR DESCRIPTION
## Summary
C2 batch — the **comedy-adaptation** track of the gallery English-versions effort, continuing C1 (#864, merged). Part of #850. Like C1 (and unlike the universal B1/B2 batches), these are **culturally-adapted English-native comedy**, not literal translations — the engine mechanic (phases / output schema / vote structure) is preserved verbatim, but personas, examples, and premises are swapped to registers that land for an English audience. Intentional semantic divergence from the JA siblings is by design.

- `chinkaitou_soudan_v1_en` — Advice Panel — The Terrible-Answer Room (creative) — a bad-advice variety panel (gung-ho coach / spiritual medium / burned-out nihilist / catastrophically-off AI)
- `tengoku_jigoku_v1_en` — Heaven or Hell — The Verdict Committee (creative) — afterlife judges rule Heaven/Hell over trivial sins (always-damning / always-forgiving / sophist / rookie ex-human)

`gallery.json` entries auto-derived by `add-gallery-entry.sh` (language/title/agent_count/rounds/phases/sha256), so index↔YAML stays pinned. category/recommended_model/estimated_inferences mirror the JA siblings (creative / gemma-4-e2b-q4-k-m / 16 — the 16 is also confirmed by each EN run's harness `run_start`; agents:4 × rounds:2 × 2 inference phases is language-independent). gallery.json goes 32→34 (EN 11→13).

## Field-test results
Both run on `pastura-harness` with `gemma-4-E2B-it-Q4_K_M` (real inference), `status=ok`. Per the comedy-track gate, transcripts were **read and judged for actual EN humor** — structural correctness alone is not sufficient:

| Scenario | Result |
|---|---|
| chinkaitou | **strong** — all four voices distinct and genuinely funny ("the pudding cup is a portal to a forgotten dimension where your past-life anxieties are manifesting as gelatinous judgment"; the full 3-step "Protocol PUDDING-STARE-RECALIBRATION"; "Machines hate you because you smell like despair, and that's a universal repellent"); votes spread 3-way, no collapse |
| tengoku | **good** — the binary Heaven/Hell `choose` was kept **non-collapsed** by fixed-verdict personas (Judge Thunderbolt always Hell, Judge Sweetie always Heaven → R1 1-Hell/3-Heaven, R2 2/2). This directly applies the lesson from C1's chinwaza, whose R2 binary `choose` collapsed to all-"Hard pass". Disproportionate-weighty-reason comedy lands ("unshared fried chicken speaks to a deep yearning for communal harmony that only Heaven can truly mend"). Known-minor: Rookie Nia's personal-projection hook underfired toward generic grandiosity — a future polish lever is to force a first-person anecdote in her `[Goal]` |

Design note: **fixed-verdict personas are the anti-collapse lever for binary `choose` comedy** — when two of four agents have hardcoded opposite verdicts, the phase can't collapse to one option regardless of the model's consensus drift.

## Test plan
- `scripts/check-gallery-entry.sh --all` ✅ · `gallery-precommit-gate.sh` ✅ (per-commit) · phase parity EN==JA sibling verified for both ✅
- Pre-impl `critic` PASS (0 Critical/Warning) — incl. a direct run of both drafts against `docs/blocklist/source.json` (ADR-005 content-safety): 0 hits
- Opus code review PASS (0 issues) — structural/placeholder parity + index↔YAML consistency; reviewed as adaptation (JA↔EN divergence by design, not translation-fidelity)