### PR TITLE
✨ feat: contextual bottom action bar on ScenarioDetail

### DIFF
--- a/.claude/rules/navigation.md
+++ b/.claude/rules/navigation.md
@@ -79,6 +79,21 @@ Key invariants:
   (the sim route was popped on leave), guarded against a duplicate when
   already on top. This re-consumes the `isSimulationOnTop` fold — do not
   delete it.
+- **Contextual bottom action bar on ScenarioDetail (#856, ADR-016 § Amendment
+  2026-07-01).** `ScenarioDetailView` and `ScenarioEditorView` hide the tab bar
+  (`.toolbar(.hidden, for: .tabBar)`) and replace it with a contextual bottom
+  action bar (`ScenarioDetailActionBar` in a `.safeAreaInset`: Run /
+  Edit·Template / Delete, tab-bar-style icon-over-label) — tab-switching to
+  other sections isn't a real use case from a scenario detail / editor. Same
+  **API** as focus mode (#646) for the hide but a **different rationale**
+  (contextual actions, not run-protection): `isSimulationOnTop` and the
+  focus-mode machinery are untouched. Editor hides its own tab bar so its state
+  is consistent regardless of entry (ScenarioDetail vs Home "new scenario").
+  The bar applies `glassEffect` (iOS 26+) so it reads as a continuation of the
+  native tab bar it replaces; the glass rendering + the `InFlightSimulationIndicator`
+  pill's clearance against it are real-device QA gates. Bar items are tap-driven
+  `NavigationLink`s (a custom bar, not a native `.bottomBar` — the latter is
+  icon-only on iOS 26).
 
 ## When to use what
 

--- a/.claude/rules/swiftui-traps.md
+++ b/.claude/rules/swiftui-traps.md
@@ -139,11 +139,12 @@ blanket "id always leaks."
 ```swift
 ScrollView { … }
   .accessibilityIdentifier("scenarioDetail.list")   // BEFORE — scopes scroll content only
-  .safeAreaInset(edge: .bottom) { runCTA }            // inset keeps its own button id
+  .safeAreaInset(edge: .bottom) { actionBar }         // inset keeps its own button id
 ```
 
 Reference + inline rationale: `ScenarioDetailView.swift` (`scenarioDetail.list`
-just above its `.safeAreaInset`).
+just above its `.safeAreaInset` hosting `ScenarioDetailActionBar`, whose Run
+button carries `scenarioDetail.runSimulationButton`).
 
 **Diagnose** which id an element actually carries — instead of guessing —
 by exporting the a11y snapshot from the failing `.xcresult`:

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -5071,6 +5071,16 @@
         }
       }
     },
+    "Run" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "実行"
+          }
+        }
+      }
+    },
     "Run Simulation" : {
       "localizations" : {
         "ja" : {

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -1,9 +1,6 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "" : {
-
-    },
     "\n  - 💭 _%@_" : {
       "localizations" : {
         "en" : {
@@ -49,457 +46,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "  %1$@: %2$lld 票"
-          }
-        }
-      }
-    },
-    "_(empty)_" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "_(empty)_"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "_(なし)_"
-          }
-        }
-      }
-    },
-    "_No roster data._" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "_No roster data._"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "_ロスターデータなし_"
-          }
-        }
-      }
-    },
-    "_No score data._" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "_No score data._"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "_スコアデータなし_"
-          }
-        }
-      }
-    },
-    "_No turns recorded._" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "_No turns recorded._"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "_ターン記録なし_"
-          }
-        }
-      }
-    },
-    "- _(code phase — no agent output)_" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- _(code phase — no agent output)_"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- _(コードフェーズ — エージェント出力なし)_"
-          }
-        }
-      }
-    },
-    "- **%@** (%@) ↔ **%@** (%@)" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **%1$@** (%2$@) ↔ **%3$@** (%4$@)"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **%@** (%@) ↔ **%@** (%@)"
-          }
-        }
-      }
-    },
-    "- **%@** was assigned: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **%1$@** was assigned: %2$@"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **%@** に割り当て: %@"
-          }
-        }
-      }
-    },
-    "- **%@** was eliminated (%lld votes)" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **%1$@** was eliminated (%2$lld votes)"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **%@** が脱落 (%lld 票)"
-          }
-        }
-      }
-    },
-    "- **%@**: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **%1$@**: %2$@"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **%@**: %@"
-          }
-        }
-      }
-    },
-    "- **Backend**: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **Backend**: %@"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **バックエンド**: %@"
-          }
-        }
-      }
-    },
-    "- **Device**: %@ / %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **Device**: %1$@ / %2$@"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **デバイス**: %@ / %@"
-          }
-        }
-      }
-    },
-    "- **Duration**: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **Duration**: %@"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **所要時間**: %@"
-          }
-        }
-      }
-    },
-    "- **Ended**: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **Ended**: %@"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **終了**: %@"
-          }
-        }
-      }
-    },
-    "- **Inference count**: %lld" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **Inference count**: %lld"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **推論回数**: %lld"
-          }
-        }
-      }
-    },
-    "- **Model**: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **Model**: %@"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **モデル**: %@"
-          }
-        }
-      }
-    },
-    "- **Scenario**: %@ (`%@`)" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **Scenario**: %1$@ (`%2$@`)"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **シナリオ**: %@ (`%@`)"
-          }
-        }
-      }
-    },
-    "- **Started**: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **Started**: %@"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **開始**: %@"
-          }
-        }
-      }
-    },
-    "- **Status**: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **Status**: %@"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **ステータス**: %@"
-          }
-        }
-      }
-    },
-    "- 🎲 Event: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- 🎲 Event: %@"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- 🎲 イベント: %@"
-          }
-        }
-      }
-    },
-    "- 🎲 No event this round" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- 🎲 No event this round"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- 🎲 このラウンドはイベントなし"
-          }
-        }
-      }
-    },
-    "- Scores — %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- Scores — %@"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- スコア — %@"
-          }
-        }
-      }
-    },
-    "- Tallies:" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- Tallies:"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- 集計:"
-          }
-        }
-      }
-    },
-    "- Votes:" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- Votes:"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- 投票:"
-          }
-        }
-      }
-    },
-    ", " : {
-      "comment" : "VoiceOver list separator inside GameHeader's combined accessibility label.",
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "、"
-          }
-        }
-      }
-    },
-    "·" : {
-
-    },
-    "“%@” will be deleted. Past simulation results are kept and stay viewable." : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "「%@」を削除します。過去のシミュレーション結果は残り、引き続き閲覧できます。"
-          }
-        }
-      }
-    },
-    "(no condition)" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "（条件なし）"
-          }
-        }
-      }
-    },
-    "(unknown)" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "(unknown)"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "(不明)"
-          }
-        }
-      }
-    },
-    "(unnamed)" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "(unnamed)"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "(無名)"
-          }
-        }
-      }
-    },
-    "(unreadable payload)" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "(unreadable payload)"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "(ペイロード解読不可)"
           }
         }
       }
@@ -664,22 +210,6 @@
         }
       }
     },
-    "%@ (%@) ↔ %@ (%@)" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ (%2$@) ↔ %3$@ (%4$@)"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ (%@) ↔ %@ (%@)"
-          }
-        }
-      }
-    },
     "%@ (%@) requires field '%@' in output." : {
       "localizations" : {
         "en" : {
@@ -712,6 +242,22 @@
         }
       }
     },
+    "%@ (%@) ↔ %@ (%@)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ (%2$@) ↔ %3$@ (%4$@)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ (%@) ↔ %@ (%@)"
+          }
+        }
+      }
+    },
     "%@ (%lld)" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -725,56 +271,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ (%2$lld)"
-          }
-        }
-      }
-    },
-    "%@ → %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ → %2$@"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ → %2$@"
-          }
-        }
-      }
-    },
-    "%@ → then:%lld else:%lld" : {
-      "comment" : "Conditional phase summary in scenario editor; condition expr / then-branch count / else-branch count.",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ → then:%2$lld else:%3$lld"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ → then:%2$lld else:%3$lld"
-          }
-        }
-      }
-    },
-    "%@ × %@" : {
-      "comment" : "Event-inject phase summary in scenario editor; first arg is YAML source key name, second arg is probability (e.g. 0.5).",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ × %2$@"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ × %2$@"
           }
         }
       }
@@ -991,18 +487,68 @@
         }
       }
     },
-    "%@: '%@' must be an array of phase objects" : {
+    "%@ × %@" : {
+      "comment" : "Event-inject phase summary in scenario editor; first arg is YAML source key name, second arg is probability (e.g. 0.5).",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$@: '%2$@' must be an array of phase objects"
+            "value" : "%1$@ × %2$@"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$@: '%2$@' はフェーズオブジェクトの配列である必要があります"
+            "value" : "%1$@ × %2$@"
+          }
+        }
+      }
+    },
+    "%@ → %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ → %2$@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ → %2$@"
+          }
+        }
+      }
+    },
+    "%@ → then:%lld else:%lld" : {
+      "comment" : "Conditional phase summary in scenario editor; condition expr / then-branch count / else-branch count.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ → then:%2$lld else:%3$lld"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ → then:%2$lld else:%3$lld"
+          }
+        }
+      }
+    },
+    "%@(%@)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@(%2$@)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@(%2$@)"
           }
         }
       }
@@ -1019,6 +565,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@: %2$lld"
+          }
+        }
+      }
+    },
+    "%@: '%@' must be an array of phase objects" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: '%2$@' must be an array of phase objects"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: '%2$@' はフェーズオブジェクトの配列である必要があります"
           }
         }
       }
@@ -1279,22 +841,6 @@
         }
       }
     },
-    "%@(%@)" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@(%2$@)"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@(%2$@)"
-          }
-        }
-      }
-    },
     "%lld agents" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1446,23 +992,376 @@
         }
       }
     },
-    "↳ sub-phase" : {
+    "(no condition)" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "↳ サブフェーズ"
+            "value" : "（条件なし）"
           }
         }
       }
     },
-    "~%lld inferences" : {
-      "extractionState" : "stale",
+    "(unknown)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(unknown)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(不明)"
+          }
+        }
+      }
+    },
+    "(unnamed)" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(unnamed)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(無名)"
+          }
+        }
+      }
+    },
+    "(unreadable payload)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(unreadable payload)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(ペイロード解読不可)"
+          }
+        }
+      }
+    },
+    ", " : {
+      "comment" : "VoiceOver list separator inside GameHeader's combined accessibility label.",
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "~%lld 回の推論"
+            "value" : "、"
+          }
+        }
+      }
+    },
+    "- **%@** (%@) ↔ **%@** (%@)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **%1$@** (%2$@) ↔ **%3$@** (%4$@)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **%@** (%@) ↔ **%@** (%@)"
+          }
+        }
+      }
+    },
+    "- **%@** was assigned: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **%1$@** was assigned: %2$@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **%@** に割り当て: %@"
+          }
+        }
+      }
+    },
+    "- **%@** was eliminated (%lld votes)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **%1$@** was eliminated (%2$lld votes)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **%@** が脱落 (%lld 票)"
+          }
+        }
+      }
+    },
+    "- **%@**: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **%1$@**: %2$@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **%@**: %@"
+          }
+        }
+      }
+    },
+    "- **Backend**: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **Backend**: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **バックエンド**: %@"
+          }
+        }
+      }
+    },
+    "- **Device**: %@ / %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **Device**: %1$@ / %2$@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **デバイス**: %@ / %@"
+          }
+        }
+      }
+    },
+    "- **Duration**: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **Duration**: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **所要時間**: %@"
+          }
+        }
+      }
+    },
+    "- **Ended**: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **Ended**: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **終了**: %@"
+          }
+        }
+      }
+    },
+    "- **Inference count**: %lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **Inference count**: %lld"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **推論回数**: %lld"
+          }
+        }
+      }
+    },
+    "- **Model**: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **Model**: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **モデル**: %@"
+          }
+        }
+      }
+    },
+    "- **Scenario**: %@ (`%@`)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **Scenario**: %1$@ (`%2$@`)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **シナリオ**: %@ (`%@`)"
+          }
+        }
+      }
+    },
+    "- **Started**: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **Started**: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **開始**: %@"
+          }
+        }
+      }
+    },
+    "- **Status**: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **Status**: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **ステータス**: %@"
+          }
+        }
+      }
+    },
+    "- Scores — %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- Scores — %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- スコア — %@"
+          }
+        }
+      }
+    },
+    "- Tallies:" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- Tallies:"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- 集計:"
+          }
+        }
+      }
+    },
+    "- Votes:" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- Votes:"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- 投票:"
+          }
+        }
+      }
+    },
+    "- _(code phase — no agent output)_" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- _(code phase — no agent output)_"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- _(コードフェーズ — エージェント出力なし)_"
+          }
+        }
+      }
+    },
+    "- 🎲 Event: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- 🎲 Event: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- 🎲 イベント: %@"
+          }
+        }
+      }
+    },
+    "- 🎲 No event this round" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- 🎲 No event this round"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- 🎲 このラウンドはイベントなし"
           }
         }
       }
@@ -1527,28 +1426,32 @@
         }
       }
     },
+    "AI Models" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AI モデル"
+          }
+        }
+      }
+    },
+    "AI agents converse right inside your iPhone." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AIエージェントが、あなたのiPhoneの中で対話します"
+          }
+        }
+      }
+    },
     "About %lld min left" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "残り約 %lld 分"
-          }
-        }
-      }
-    },
-    "active" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "active"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アクティブ"
           }
         }
       }
@@ -1693,22 +1596,6 @@
         }
       }
     },
-    "agents (%lld) does not match personas count (%lld)" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "agents (%1$lld) does not match personas count (%2$lld)"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "agents (%1$lld) が personas の数 (%2$lld) と一致しません"
-          }
-        }
-      }
-    },
     "Agents run entirely on your device." : {
       "localizations" : {
         "ja" : {
@@ -1725,26 +1612,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "エージェントが順番に発言（コンテキストを累積）"
-          }
-        }
-      }
-    },
-    "AI agents converse right inside your iPhone." : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "AIエージェントが、あなたのiPhoneの中で対話します"
-          }
-        }
-      }
-    },
-    "AI Models" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "AI モデル"
           }
         }
       }
@@ -2271,22 +2138,22 @@
         }
       }
     },
-    "Could not check local scenarios: %@" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ローカルシナリオの確認に失敗しました: %@"
-          }
-        }
-      }
-    },
     "Could Not Reach Gallery" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "ギャラリーに接続できませんでした"
+          }
+        }
+      }
+    },
+    "Could not check local scenarios: %@" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ローカルシナリオの確認に失敗しました: %@"
           }
         }
       }
@@ -2341,8 +2208,26 @@
         }
       }
     },
-    "current_event" : {
-
+    "DL" : {
+      "comment" : "Status abbreviation in PromoCard meta row. Intentionally identical en/ja — kept short to fit the dot-progress strip.",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DL"
+          }
+        }
+      }
+    },
+    "Database Needs Recovery" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "データベースの復旧が必要です"
+          }
+        }
+      }
     },
     "Database error: %@" : {
       "localizations" : {
@@ -2360,16 +2245,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "データベースのマイグレーションに失敗しました:\n%@"
-          }
-        }
-      }
-    },
-    "Database Needs Recovery" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "データベースの復旧が必要です"
           }
         }
       }
@@ -2430,22 +2305,22 @@
         }
       }
     },
-    "Delete failed" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "削除に失敗しました"
-          }
-        }
-      }
-    },
     "Delete Scenario?" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "シナリオを削除しますか？"
+          }
+        }
+      }
+    },
+    "Delete failed" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "削除に失敗しました"
           }
         }
       }
@@ -2553,33 +2428,12 @@
         }
       }
     },
-    "disabled" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "無効"
-          }
-        }
-      }
-    },
     "Distribute info to agents (code)" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "エージェントへ情報を配布（コード）"
-          }
-        }
-      }
-    },
-    "DL" : {
-      "comment" : "Status abbreviation in PromoCard meta row. Intentionally identical en/ja — kept short to fit the dot-progress strip.",
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DL"
           }
         }
       }
@@ -2627,6 +2481,16 @@
         }
       }
     },
+    "Download Failed" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダウンロードに失敗"
+          }
+        }
+      }
+    },
     "Download anyway" : {
       "localizations" : {
         "ja" : {
@@ -2643,16 +2507,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ダウンロードに失敗しました"
-          }
-        }
-      }
-    },
-    "Download Failed" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ダウンロードに失敗"
           }
         }
       }
@@ -2703,22 +2557,6 @@
         }
       }
     },
-    "Downloaded · %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Downloaded · %@"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ダウンロード済み · %@"
-          }
-        }
-      }
-    },
     "Downloaded file size mismatch (expected %lld, got %lld)" : {
       "localizations" : {
         "en" : {
@@ -2748,6 +2586,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ダウンロード済みモデル · %@"
+          }
+        }
+      }
+    },
+    "Downloaded · %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Downloaded · %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダウンロード済み · %@"
           }
         }
       }
@@ -2794,16 +2648,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ダウンロード中…"
-          }
-        }
-      }
-    },
-    "e.g. max_score >= 10 && active_count > 1" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "例: max_score >= 10 && active_count > 1"
           }
         }
       }
@@ -2858,38 +2702,12 @@
         }
       }
     },
-    "eliminated" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "eliminated"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "脱落"
-          }
-        }
-      }
-    },
     "Else branch (condition false)" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Else ブランチ（条件が false）"
-          }
-        }
-      }
-    },
-    "enabled" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "有効"
           }
         }
       }
@@ -2934,7 +2752,7 @@
         }
       }
     },
-    "Est. inferences" : {
+    "Est. Inferences" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
@@ -2944,7 +2762,7 @@
         }
       }
     },
-    "Est. Inferences" : {
+    "Est. inferences" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
@@ -3347,12 +3165,38 @@
         }
       }
     },
+    "GBNF grammar parse failed: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GBNF grammar parse failed: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GBNF 文法の解析に失敗しました: %@"
+          }
+        }
+      }
+    },
     "Gallery Cache Corrupted" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "ギャラリーキャッシュが破損しています"
+          }
+        }
+      }
+    },
+    "Gallery Unavailable" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ギャラリーが利用できません"
           }
         }
       }
@@ -3433,38 +3277,12 @@
         }
       }
     },
-    "Gallery Unavailable" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ギャラリーが利用できません"
-          }
-        }
-      }
-    },
     "Game Theory" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "ゲーム理論"
-          }
-        }
-      }
-    },
-    "GBNF grammar parse failed: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GBNF grammar parse failed: %@"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GBNF 文法の解析に失敗しました: %@"
           }
         }
       }
@@ -3545,6 +3363,16 @@
         }
       }
     },
+    "INNER VOICE" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "心の声"
+          }
+        }
+      }
+    },
     "Inference was suspended and will retry" : {
       "localizations" : {
         "ja" : {
@@ -3585,16 +3413,6 @@
         }
       }
     },
-    "INNER VOICE" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "心の声"
-          }
-        }
-      }
-    },
     "Installed" : {
       "localizations" : {
         "ja" : {
@@ -3631,16 +3449,6 @@
         }
       }
     },
-    "Invalid grammar for constrained decoding: %@" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "制約付きデコードの文法が不正です: %@"
-          }
-        }
-      }
-    },
     "Invalid LLM response: %@" : {
       "localizations" : {
         "ja" : {
@@ -3667,12 +3475,12 @@
         }
       }
     },
-    "Japanese" : {
+    "Invalid grammar for constrained decoding: %@" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "日本語"
+            "value" : "制約付きデコードの文法が不正です: %@"
           }
         }
       }
@@ -3683,6 +3491,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "JSON 解析に失敗しました: %@"
+          }
+        }
+      }
+    },
+    "Japanese" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日本語"
           }
         }
       }
@@ -3713,6 +3531,26 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "画面を離れても実行を続ける"
+          }
+        }
+      }
+    },
+    "LLM" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LLM"
+          }
+        }
+      }
+    },
+    "LLM returned invalid output after retries. Try again or check model health." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "再試行しても LLM の出力が不正でした。再度実行するか、モデルの状態を確認してください。"
           }
         }
       }
@@ -3804,42 +3642,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ライセンス"
-          }
-        }
-      }
-    },
-    "llama_decode failed (error %lld)" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "llama_decode failed (error %lld)"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "llama_decode に失敗しました（エラー %lld）"
-          }
-        }
-      }
-    },
-    "LLM" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "LLM"
-          }
-        }
-      }
-    },
-    "LLM returned invalid output after retries. Try again or check model health." : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "再試行しても LLM の出力が不正でした。再度実行するか、モデルの状態を確認してください。"
           }
         }
       }
@@ -3962,6 +3764,16 @@
         }
       }
     },
+    "Model Setup" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "モデルセットアップ"
+          }
+        }
+      }
+    },
     "Model generated no output tokens" : {
       "localizations" : {
         "en" : {
@@ -3994,16 +3806,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "モデルが読み込まれていません"
-          }
-        }
-      }
-    },
-    "Model Setup" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "モデルセットアップ"
           }
         }
       }
@@ -4079,16 +3881,6 @@
         }
       }
     },
-    "New option" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "新しい選択肢"
-          }
-        }
-      }
-    },
     "New Persona" : {
       "localizations" : {
         "ja" : {
@@ -4109,12 +3901,52 @@
         }
       }
     },
+    "New option" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新しい選択肢"
+          }
+        }
+      }
+    },
     "Next demo: %@" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "次のデモ: %@"
+          }
+        }
+      }
+    },
+    "No Data" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "データなし"
+          }
+        }
+      }
+    },
+    "No Results" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "結果なし"
+          }
+        }
+      }
+    },
+    "No Scenarios" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シナリオがありません"
           }
         }
       }
@@ -4165,16 +3997,6 @@
         }
       }
     },
-    "No Data" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "データなし"
-          }
-        }
-      }
-    },
     "No event this round" : {
       "localizations" : {
         "ja" : {
@@ -4197,26 +4019,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "モデルなし"
-          }
-        }
-      }
-    },
-    "No Results" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "結果なし"
-          }
-        }
-      }
-    },
-    "No Scenarios" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "シナリオがありません"
           }
         }
       }
@@ -4301,16 +4103,6 @@
         }
       }
     },
-    "Offline — showing cached content" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "オフライン — キャッシュされたコンテンツを表示しています"
-          }
-        }
-      }
-    },
     "OK" : {
       "localizations" : {
         "ja" : {
@@ -4321,22 +4113,12 @@
         }
       }
     },
-    "Open local copy" : {
+    "Offline — showing cached content" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ローカルコピーを開く"
-          }
-        }
-      }
-    },
-    "Open on GitHub" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GitHub で開く"
+            "value" : "オフライン — キャッシュされたコンテンツを表示しています"
           }
         }
       }
@@ -4357,6 +4139,26 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "共有シナリオを開いて更新してから、もう一度リンクを試してください。"
+          }
+        }
+      }
+    },
+    "Open local copy" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ローカルコピーを開く"
+          }
+        }
+      }
+    },
+    "Open on GitHub" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GitHub で開く"
           }
         }
       }
@@ -4401,6 +4203,16 @@
         }
       }
     },
+    "Output Fields" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "出力フィールド"
+          }
+        }
+      }
+    },
     "Output drifted from expected %@ for %@" : {
       "localizations" : {
         "en" : {
@@ -4433,16 +4245,6 @@
         }
       }
     },
-    "Output Fields" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "出力フィールド"
-          }
-        }
-      }
-    },
     "Overview" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -4450,6 +4252,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "概要"
+          }
+        }
+      }
+    },
+    "PASTURA · SETUP" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PASTURA · セットアップ"
           }
         }
       }
@@ -4470,19 +4282,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "過去の結果"
-          }
-        }
-      }
-    },
-    "Pastura" : {
-
-    },
-    "PASTURA · SETUP" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "PASTURA · セットアップ"
           }
         }
       }
@@ -4634,16 +4433,6 @@
         }
       }
     },
-    "Persona '%@' description contains a term that is not allowed" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ペルソナ '%@' の説明に許可されていない用語が含まれています"
-          }
-        }
-      }
-    },
     "Persona %lld description contains a term that is not allowed" : {
       "localizations" : {
         "ja" : {
@@ -4660,6 +4449,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ペルソナ %lld の名前に許可されていない用語が含まれています"
+          }
+        }
+      }
+    },
+    "Persona '%@' description contains a term that is not allowed" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ペルソナ '%@' の説明に許可されていない用語が含まれています"
           }
         }
       }
@@ -4919,16 +4718,6 @@
         }
       }
     },
-    "Recommended model" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "推奨モデル"
-          }
-        }
-      }
-    },
     "Recommended Scenarios" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -4936,6 +4725,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "おすすめのシナリオ"
+          }
+        }
+      }
+    },
+    "Recommended model" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "推奨モデル"
           }
         }
       }
@@ -4967,7 +4766,6 @@
       }
     },
     "Recovery requires an active model" : {
-      "extractionState" : "stale",
       "localizations" : {
         "ja" : {
           "stringUnit" : {
@@ -5230,6 +5028,16 @@
         }
       }
     },
+    "Round Robin" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ラウンドロビン"
+          }
+        }
+      }
+    },
     "Round count (%lld) exceeds maximum of 30" : {
       "localizations" : {
         "en" : {
@@ -5242,16 +5050,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ラウンド数 (%lld) が最大値の30を超えています"
-          }
-        }
-      }
-    },
-    "Round Robin" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ラウンドロビン"
           }
         }
       }
@@ -5293,22 +5091,22 @@
         }
       }
     },
-    "Run a simulation to see results here" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "シミュレーションを実行すると、ここに結果が表示されます"
-          }
-        }
-      }
-    },
     "Run Simulation" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "シミュレーション実行"
+          }
+        }
+      }
+    },
+    "Run a simulation to see results here" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シミュレーションを実行すると、ここに結果が表示されます"
           }
         }
       }
@@ -5335,6 +5133,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "バックグラウンドで実行中"
+          }
+        }
+      }
+    },
+    "STORAGE" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ストレージ"
           }
         }
       }
@@ -5399,16 +5207,6 @@
         }
       }
     },
-    "Scenario description contains a term that is not allowed" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "シナリオの説明に許可されていない用語が含まれています"
-          }
-        }
-      }
-    },
     "Scenario ID" : {
       "localizations" : {
         "ja" : {
@@ -5425,6 +5223,26 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "シナリオ ID は必須です"
+          }
+        }
+      }
+    },
+    "Scenario Not Found" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シナリオが見つかりません"
+          }
+        }
+      }
+    },
+    "Scenario description contains a term that is not allowed" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シナリオの説明に許可されていない用語が含まれています"
           }
         }
       }
@@ -5459,16 +5277,6 @@
         }
       }
     },
-    "Scenario Not Found" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "シナリオが見つかりません"
-          }
-        }
-      }
-    },
     "Scenario: field 'language' must be one of {%@}, got '%@'" : {
       "localizations" : {
         "en" : {
@@ -5485,22 +5293,6 @@
         }
       }
     },
-    "Scenario: field 'simulation_language' must be one of {%@} or absent, got '%@'" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scenario: field 'simulation_language' must be one of {%1$@} or absent, got '%2$@'"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scenario: フィールド 'simulation_language' は {%1$@} のいずれか、または省略可能である必要がありますが、'%2$@' が指定されました"
-          }
-        }
-      }
-    },
     "Scenario: field 'simulationLanguage' must be one of {%@} or nil, got '%@'" : {
       "localizations" : {
         "en" : {
@@ -5513,6 +5305,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scenario: フィールド 'simulationLanguage' は {%1$@} のいずれか、または nil である必要がありますが、'%2$@' が指定されました"
+          }
+        }
+      }
+    },
+    "Scenario: field 'simulation_language' must be one of {%@} or absent, got '%@'" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scenario: field 'simulation_language' must be one of {%1$@} or absent, got '%2$@'"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scenario: フィールド 'simulation_language' は {%1$@} のいずれか、または省略可能である必要がありますが、'%2$@' が指定されました"
           }
         }
       }
@@ -5843,16 +5651,6 @@
         }
       }
     },
-    "STORAGE" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ストレージ"
-          }
-        }
-      }
-    },
     "Storage is getting large. Consider clearing old runs to free space." : {
       "localizations" : {
         "ja" : {
@@ -6023,6 +5821,26 @@
         }
       }
     },
+    "This Month" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今月"
+          }
+        }
+      }
+    },
+    "This Week" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今週"
+          }
+        }
+      }
+    },
     "This can take a few seconds" : {
       "localizations" : {
         "ja" : {
@@ -6073,32 +5891,6 @@
         }
       }
     },
-    "this model" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "this model"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "このモデル"
-          }
-        }
-      }
-    },
-    "This Month" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "今月"
-          }
-        }
-      }
-    },
     "This permanently removes every past run and its conversation log. This can't be undone." : {
       "localizations" : {
         "ja" : {
@@ -6129,22 +5921,22 @@
         }
       }
     },
-    "This Week" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "今週"
-          }
-        }
-      }
-    },
     "Today" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "今日"
+          }
+        }
+      }
+    },
+    "Top-level YAML key" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "トップレベルの YAML キー"
           }
         }
       }
@@ -6209,16 +6001,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "トップレベルフィールド '%@': 混在型の配列はサポートされていません。純粋な [String] または [[String: String]] を使用してください。"
-          }
-        }
-      }
-    },
-    "Top-level YAML key" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "トップレベルの YAML キー"
           }
         }
       }
@@ -6545,16 +6327,6 @@
         }
       }
     },
-    "vs" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "vs"
-          }
-        }
-      }
-    },
     "Wait for Wi-Fi" : {
       "localizations" : {
         "ja" : {
@@ -6699,6 +6471,221 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "このデバイスに複数のモデルを保持できます。メモリに読み込まれるのは使用中のモデルだけです。"
+          }
+        }
+      }
+    },
+    "_(empty)_" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "_(empty)_"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "_(なし)_"
+          }
+        }
+      }
+    },
+    "_No roster data._" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "_No roster data._"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "_ロスターデータなし_"
+          }
+        }
+      }
+    },
+    "_No score data._" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "_No score data._"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "_スコアデータなし_"
+          }
+        }
+      }
+    },
+    "_No turns recorded._" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "_No turns recorded._"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "_ターン記録なし_"
+          }
+        }
+      }
+    },
+    "active" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "active"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アクティブ"
+          }
+        }
+      }
+    },
+    "agents (%lld) does not match personas count (%lld)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "agents (%1$lld) does not match personas count (%2$lld)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "agents (%1$lld) が personas の数 (%2$lld) と一致しません"
+          }
+        }
+      }
+    },
+    "disabled" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無効"
+          }
+        }
+      }
+    },
+    "e.g. max_score >= 10 && active_count > 1" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "例: max_score >= 10 && active_count > 1"
+          }
+        }
+      }
+    },
+    "eliminated" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "eliminated"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "脱落"
+          }
+        }
+      }
+    },
+    "enabled" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有効"
+          }
+        }
+      }
+    },
+    "llama_decode failed (error %lld)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "llama_decode failed (error %lld)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "llama_decode に失敗しました（エラー %lld）"
+          }
+        }
+      }
+    },
+    "this model" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "this model"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このモデル"
+          }
+        }
+      }
+    },
+    "vs" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "vs"
+          }
+        }
+      }
+    },
+    "~%lld inferences" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "~%lld 回の推論"
+          }
+        }
+      }
+    },
+    "“%@” will be deleted. Past simulation results are kept and stay viewable." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「%@」を削除します。過去のシミュレーション結果は残り、引き続き閲覧できます。"
+          }
+        }
+      }
+    },
+    "↳ sub-phase" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "↳ サブフェーズ"
           }
         }
       }

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -2118,6 +2118,16 @@
         }
       }
     },
+    "Copy & Edit" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コピーして編集"
+          }
+        }
+      }
+    },
     "Copy Gen Prompt" : {
       "localizations" : {
         "ja" : {
@@ -6171,16 +6181,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "投票先は `vote` フィールドで追加してください。"
-          }
-        }
-      }
-    },
-    "Use as Template" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "テンプレートとして使用"
           }
         }
       }

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -1,6 +1,9 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "" : {
+
+    },
     "\n  - 💭 _%@_" : {
       "localizations" : {
         "en" : {
@@ -46,6 +49,457 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "  %1$@: %2$lld 票"
+          }
+        }
+      }
+    },
+    "_(empty)_" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "_(empty)_"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "_(なし)_"
+          }
+        }
+      }
+    },
+    "_No roster data._" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "_No roster data._"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "_ロスターデータなし_"
+          }
+        }
+      }
+    },
+    "_No score data._" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "_No score data._"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "_スコアデータなし_"
+          }
+        }
+      }
+    },
+    "_No turns recorded._" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "_No turns recorded._"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "_ターン記録なし_"
+          }
+        }
+      }
+    },
+    "- _(code phase — no agent output)_" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- _(code phase — no agent output)_"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- _(コードフェーズ — エージェント出力なし)_"
+          }
+        }
+      }
+    },
+    "- **%@** (%@) ↔ **%@** (%@)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **%1$@** (%2$@) ↔ **%3$@** (%4$@)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **%@** (%@) ↔ **%@** (%@)"
+          }
+        }
+      }
+    },
+    "- **%@** was assigned: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **%1$@** was assigned: %2$@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **%@** に割り当て: %@"
+          }
+        }
+      }
+    },
+    "- **%@** was eliminated (%lld votes)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **%1$@** was eliminated (%2$lld votes)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **%@** が脱落 (%lld 票)"
+          }
+        }
+      }
+    },
+    "- **%@**: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **%1$@**: %2$@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **%@**: %@"
+          }
+        }
+      }
+    },
+    "- **Backend**: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **Backend**: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **バックエンド**: %@"
+          }
+        }
+      }
+    },
+    "- **Device**: %@ / %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **Device**: %1$@ / %2$@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **デバイス**: %@ / %@"
+          }
+        }
+      }
+    },
+    "- **Duration**: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **Duration**: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **所要時間**: %@"
+          }
+        }
+      }
+    },
+    "- **Ended**: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **Ended**: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **終了**: %@"
+          }
+        }
+      }
+    },
+    "- **Inference count**: %lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **Inference count**: %lld"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **推論回数**: %lld"
+          }
+        }
+      }
+    },
+    "- **Model**: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **Model**: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **モデル**: %@"
+          }
+        }
+      }
+    },
+    "- **Scenario**: %@ (`%@`)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **Scenario**: %1$@ (`%2$@`)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **シナリオ**: %@ (`%@`)"
+          }
+        }
+      }
+    },
+    "- **Started**: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **Started**: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **開始**: %@"
+          }
+        }
+      }
+    },
+    "- **Status**: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **Status**: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- **ステータス**: %@"
+          }
+        }
+      }
+    },
+    "- 🎲 Event: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- 🎲 Event: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- 🎲 イベント: %@"
+          }
+        }
+      }
+    },
+    "- 🎲 No event this round" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- 🎲 No event this round"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- 🎲 このラウンドはイベントなし"
+          }
+        }
+      }
+    },
+    "- Scores — %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- Scores — %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- スコア — %@"
+          }
+        }
+      }
+    },
+    "- Tallies:" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- Tallies:"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- 集計:"
+          }
+        }
+      }
+    },
+    "- Votes:" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- Votes:"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "- 投票:"
+          }
+        }
+      }
+    },
+    ", " : {
+      "comment" : "VoiceOver list separator inside GameHeader's combined accessibility label.",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "、"
+          }
+        }
+      }
+    },
+    "·" : {
+
+    },
+    "“%@” will be deleted. Past simulation results are kept and stay viewable." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「%@」を削除します。過去のシミュレーション結果は残り、引き続き閲覧できます。"
+          }
+        }
+      }
+    },
+    "(no condition)" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "（条件なし）"
+          }
+        }
+      }
+    },
+    "(unknown)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(unknown)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(不明)"
+          }
+        }
+      }
+    },
+    "(unnamed)" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(unnamed)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(無名)"
+          }
+        }
+      }
+    },
+    "(unreadable payload)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(unreadable payload)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(ペイロード解読不可)"
           }
         }
       }
@@ -210,6 +664,22 @@
         }
       }
     },
+    "%@ (%@) ↔ %@ (%@)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ (%2$@) ↔ %3$@ (%4$@)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ (%@) ↔ %@ (%@)"
+          }
+        }
+      }
+    },
     "%@ (%@) requires field '%@' in output." : {
       "localizations" : {
         "en" : {
@@ -242,22 +712,6 @@
         }
       }
     },
-    "%@ (%@) ↔ %@ (%@)" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ (%2$@) ↔ %3$@ (%4$@)"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ (%@) ↔ %@ (%@)"
-          }
-        }
-      }
-    },
     "%@ (%lld)" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -271,6 +725,56 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ (%2$lld)"
+          }
+        }
+      }
+    },
+    "%@ → %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ → %2$@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ → %2$@"
+          }
+        }
+      }
+    },
+    "%@ → then:%lld else:%lld" : {
+      "comment" : "Conditional phase summary in scenario editor; condition expr / then-branch count / else-branch count.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ → then:%2$lld else:%3$lld"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ → then:%2$lld else:%3$lld"
+          }
+        }
+      }
+    },
+    "%@ × %@" : {
+      "comment" : "Event-inject phase summary in scenario editor; first arg is YAML source key name, second arg is probability (e.g. 0.5).",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ × %2$@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ × %2$@"
           }
         }
       }
@@ -487,68 +991,18 @@
         }
       }
     },
-    "%@ × %@" : {
-      "comment" : "Event-inject phase summary in scenario editor; first arg is YAML source key name, second arg is probability (e.g. 0.5).",
+    "%@: '%@' must be an array of phase objects" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$@ × %2$@"
+            "value" : "%1$@: '%2$@' must be an array of phase objects"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$@ × %2$@"
-          }
-        }
-      }
-    },
-    "%@ → %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ → %2$@"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ → %2$@"
-          }
-        }
-      }
-    },
-    "%@ → then:%lld else:%lld" : {
-      "comment" : "Conditional phase summary in scenario editor; condition expr / then-branch count / else-branch count.",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ → then:%2$lld else:%3$lld"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ → then:%2$lld else:%3$lld"
-          }
-        }
-      }
-    },
-    "%@(%@)" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@(%2$@)"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@(%2$@)"
+            "value" : "%1$@: '%2$@' はフェーズオブジェクトの配列である必要があります"
           }
         }
       }
@@ -565,22 +1019,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@: %2$lld"
-          }
-        }
-      }
-    },
-    "%@: '%@' must be an array of phase objects" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@: '%2$@' must be an array of phase objects"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@: '%2$@' はフェーズオブジェクトの配列である必要があります"
           }
         }
       }
@@ -841,6 +1279,22 @@
         }
       }
     },
+    "%@(%@)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@(%2$@)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@(%2$@)"
+          }
+        }
+      }
+    },
     "%lld agents" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -992,376 +1446,23 @@
         }
       }
     },
-    "(no condition)" : {
+    "↳ sub-phase" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "（条件なし）"
+            "value" : "↳ サブフェーズ"
           }
         }
       }
     },
-    "(unknown)" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "(unknown)"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "(不明)"
-          }
-        }
-      }
-    },
-    "(unnamed)" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "(unnamed)"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "(無名)"
-          }
-        }
-      }
-    },
-    "(unreadable payload)" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "(unreadable payload)"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "(ペイロード解読不可)"
-          }
-        }
-      }
-    },
-    ", " : {
-      "comment" : "VoiceOver list separator inside GameHeader's combined accessibility label.",
+    "~%lld inferences" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "、"
-          }
-        }
-      }
-    },
-    "- **%@** (%@) ↔ **%@** (%@)" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **%1$@** (%2$@) ↔ **%3$@** (%4$@)"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **%@** (%@) ↔ **%@** (%@)"
-          }
-        }
-      }
-    },
-    "- **%@** was assigned: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **%1$@** was assigned: %2$@"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **%@** に割り当て: %@"
-          }
-        }
-      }
-    },
-    "- **%@** was eliminated (%lld votes)" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **%1$@** was eliminated (%2$lld votes)"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **%@** が脱落 (%lld 票)"
-          }
-        }
-      }
-    },
-    "- **%@**: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **%1$@**: %2$@"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **%@**: %@"
-          }
-        }
-      }
-    },
-    "- **Backend**: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **Backend**: %@"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **バックエンド**: %@"
-          }
-        }
-      }
-    },
-    "- **Device**: %@ / %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **Device**: %1$@ / %2$@"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **デバイス**: %@ / %@"
-          }
-        }
-      }
-    },
-    "- **Duration**: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **Duration**: %@"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **所要時間**: %@"
-          }
-        }
-      }
-    },
-    "- **Ended**: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **Ended**: %@"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **終了**: %@"
-          }
-        }
-      }
-    },
-    "- **Inference count**: %lld" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **Inference count**: %lld"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **推論回数**: %lld"
-          }
-        }
-      }
-    },
-    "- **Model**: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **Model**: %@"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **モデル**: %@"
-          }
-        }
-      }
-    },
-    "- **Scenario**: %@ (`%@`)" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **Scenario**: %1$@ (`%2$@`)"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **シナリオ**: %@ (`%@`)"
-          }
-        }
-      }
-    },
-    "- **Started**: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **Started**: %@"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **開始**: %@"
-          }
-        }
-      }
-    },
-    "- **Status**: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **Status**: %@"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- **ステータス**: %@"
-          }
-        }
-      }
-    },
-    "- Scores — %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- Scores — %@"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- スコア — %@"
-          }
-        }
-      }
-    },
-    "- Tallies:" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- Tallies:"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- 集計:"
-          }
-        }
-      }
-    },
-    "- Votes:" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- Votes:"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- 投票:"
-          }
-        }
-      }
-    },
-    "- _(code phase — no agent output)_" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- _(code phase — no agent output)_"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- _(コードフェーズ — エージェント出力なし)_"
-          }
-        }
-      }
-    },
-    "- 🎲 Event: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- 🎲 Event: %@"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- 🎲 イベント: %@"
-          }
-        }
-      }
-    },
-    "- 🎲 No event this round" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- 🎲 No event this round"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "- 🎲 このラウンドはイベントなし"
+            "value" : "~%lld 回の推論"
           }
         }
       }
@@ -1426,32 +1527,28 @@
         }
       }
     },
-    "AI Models" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "AI モデル"
-          }
-        }
-      }
-    },
-    "AI agents converse right inside your iPhone." : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "AIエージェントが、あなたのiPhoneの中で対話します"
-          }
-        }
-      }
-    },
     "About %lld min left" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "残り約 %lld 分"
+          }
+        }
+      }
+    },
+    "active" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "active"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アクティブ"
           }
         }
       }
@@ -1596,6 +1693,22 @@
         }
       }
     },
+    "agents (%lld) does not match personas count (%lld)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "agents (%1$lld) does not match personas count (%2$lld)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "agents (%1$lld) が personas の数 (%2$lld) と一致しません"
+          }
+        }
+      }
+    },
     "Agents run entirely on your device." : {
       "localizations" : {
         "ja" : {
@@ -1612,6 +1725,26 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "エージェントが順番に発言（コンテキストを累積）"
+          }
+        }
+      }
+    },
+    "AI agents converse right inside your iPhone." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AIエージェントが、あなたのiPhoneの中で対話します"
+          }
+        }
+      }
+    },
+    "AI Models" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AI モデル"
           }
         }
       }
@@ -2138,22 +2271,22 @@
         }
       }
     },
-    "Could Not Reach Gallery" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ギャラリーに接続できませんでした"
-          }
-        }
-      }
-    },
     "Could not check local scenarios: %@" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "ローカルシナリオの確認に失敗しました: %@"
+          }
+        }
+      }
+    },
+    "Could Not Reach Gallery" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ギャラリーに接続できませんでした"
           }
         }
       }
@@ -2208,26 +2341,8 @@
         }
       }
     },
-    "DL" : {
-      "comment" : "Status abbreviation in PromoCard meta row. Intentionally identical en/ja — kept short to fit the dot-progress strip.",
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DL"
-          }
-        }
-      }
-    },
-    "Database Needs Recovery" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "データベースの復旧が必要です"
-          }
-        }
-      }
+    "current_event" : {
+
     },
     "Database error: %@" : {
       "localizations" : {
@@ -2245,6 +2360,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "データベースのマイグレーションに失敗しました:\n%@"
+          }
+        }
+      }
+    },
+    "Database Needs Recovery" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "データベースの復旧が必要です"
           }
         }
       }
@@ -2305,22 +2430,22 @@
         }
       }
     },
-    "Delete Scenario?" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "シナリオを削除しますか？"
-          }
-        }
-      }
-    },
     "Delete failed" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "削除に失敗しました"
+          }
+        }
+      }
+    },
+    "Delete Scenario?" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シナリオを削除しますか？"
           }
         }
       }
@@ -2428,12 +2553,33 @@
         }
       }
     },
+    "disabled" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無効"
+          }
+        }
+      }
+    },
     "Distribute info to agents (code)" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "エージェントへ情報を配布（コード）"
+          }
+        }
+      }
+    },
+    "DL" : {
+      "comment" : "Status abbreviation in PromoCard meta row. Intentionally identical en/ja — kept short to fit the dot-progress strip.",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DL"
           }
         }
       }
@@ -2481,16 +2627,6 @@
         }
       }
     },
-    "Download Failed" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ダウンロードに失敗"
-          }
-        }
-      }
-    },
     "Download anyway" : {
       "localizations" : {
         "ja" : {
@@ -2507,6 +2643,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ダウンロードに失敗しました"
+          }
+        }
+      }
+    },
+    "Download Failed" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダウンロードに失敗"
           }
         }
       }
@@ -2557,6 +2703,22 @@
         }
       }
     },
+    "Downloaded · %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Downloaded · %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダウンロード済み · %@"
+          }
+        }
+      }
+    },
     "Downloaded file size mismatch (expected %lld, got %lld)" : {
       "localizations" : {
         "en" : {
@@ -2586,22 +2748,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ダウンロード済みモデル · %@"
-          }
-        }
-      }
-    },
-    "Downloaded · %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Downloaded · %@"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ダウンロード済み · %@"
           }
         }
       }
@@ -2648,6 +2794,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ダウンロード中…"
+          }
+        }
+      }
+    },
+    "e.g. max_score >= 10 && active_count > 1" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "例: max_score >= 10 && active_count > 1"
           }
         }
       }
@@ -2702,12 +2858,38 @@
         }
       }
     },
+    "eliminated" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "eliminated"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "脱落"
+          }
+        }
+      }
+    },
     "Else branch (condition false)" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Else ブランチ（条件が false）"
+          }
+        }
+      }
+    },
+    "enabled" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有効"
           }
         }
       }
@@ -2752,7 +2934,7 @@
         }
       }
     },
-    "Est. Inferences" : {
+    "Est. inferences" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
@@ -2762,7 +2944,7 @@
         }
       }
     },
-    "Est. inferences" : {
+    "Est. Inferences" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
@@ -3165,38 +3347,12 @@
         }
       }
     },
-    "GBNF grammar parse failed: %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GBNF grammar parse failed: %@"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "GBNF 文法の解析に失敗しました: %@"
-          }
-        }
-      }
-    },
     "Gallery Cache Corrupted" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "ギャラリーキャッシュが破損しています"
-          }
-        }
-      }
-    },
-    "Gallery Unavailable" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ギャラリーが利用できません"
           }
         }
       }
@@ -3277,12 +3433,38 @@
         }
       }
     },
+    "Gallery Unavailable" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ギャラリーが利用できません"
+          }
+        }
+      }
+    },
     "Game Theory" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "ゲーム理論"
+          }
+        }
+      }
+    },
+    "GBNF grammar parse failed: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GBNF grammar parse failed: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GBNF 文法の解析に失敗しました: %@"
           }
         }
       }
@@ -3363,16 +3545,6 @@
         }
       }
     },
-    "INNER VOICE" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "心の声"
-          }
-        }
-      }
-    },
     "Inference was suspended and will retry" : {
       "localizations" : {
         "ja" : {
@@ -3413,6 +3585,16 @@
         }
       }
     },
+    "INNER VOICE" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "心の声"
+          }
+        }
+      }
+    },
     "Installed" : {
       "localizations" : {
         "ja" : {
@@ -3449,6 +3631,16 @@
         }
       }
     },
+    "Invalid grammar for constrained decoding: %@" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "制約付きデコードの文法が不正です: %@"
+          }
+        }
+      }
+    },
     "Invalid LLM response: %@" : {
       "localizations" : {
         "ja" : {
@@ -3475,12 +3667,12 @@
         }
       }
     },
-    "Invalid grammar for constrained decoding: %@" : {
+    "Japanese" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "制約付きデコードの文法が不正です: %@"
+            "value" : "日本語"
           }
         }
       }
@@ -3491,16 +3683,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "JSON 解析に失敗しました: %@"
-          }
-        }
-      }
-    },
-    "Japanese" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "日本語"
           }
         }
       }
@@ -3531,26 +3713,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "画面を離れても実行を続ける"
-          }
-        }
-      }
-    },
-    "LLM" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "LLM"
-          }
-        }
-      }
-    },
-    "LLM returned invalid output after retries. Try again or check model health." : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "再試行しても LLM の出力が不正でした。再度実行するか、モデルの状態を確認してください。"
           }
         }
       }
@@ -3642,6 +3804,42 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ライセンス"
+          }
+        }
+      }
+    },
+    "llama_decode failed (error %lld)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "llama_decode failed (error %lld)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "llama_decode に失敗しました（エラー %lld）"
+          }
+        }
+      }
+    },
+    "LLM" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LLM"
+          }
+        }
+      }
+    },
+    "LLM returned invalid output after retries. Try again or check model health." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "再試行しても LLM の出力が不正でした。再度実行するか、モデルの状態を確認してください。"
           }
         }
       }
@@ -3764,16 +3962,6 @@
         }
       }
     },
-    "Model Setup" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "モデルセットアップ"
-          }
-        }
-      }
-    },
     "Model generated no output tokens" : {
       "localizations" : {
         "en" : {
@@ -3806,6 +3994,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "モデルが読み込まれていません"
+          }
+        }
+      }
+    },
+    "Model Setup" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "モデルセットアップ"
           }
         }
       }
@@ -3881,6 +4079,16 @@
         }
       }
     },
+    "New option" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新しい選択肢"
+          }
+        }
+      }
+    },
     "New Persona" : {
       "localizations" : {
         "ja" : {
@@ -3901,52 +4109,12 @@
         }
       }
     },
-    "New option" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "新しい選択肢"
-          }
-        }
-      }
-    },
     "Next demo: %@" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "次のデモ: %@"
-          }
-        }
-      }
-    },
-    "No Data" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "データなし"
-          }
-        }
-      }
-    },
-    "No Results" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "結果なし"
-          }
-        }
-      }
-    },
-    "No Scenarios" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "シナリオがありません"
           }
         }
       }
@@ -3997,6 +4165,16 @@
         }
       }
     },
+    "No Data" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "データなし"
+          }
+        }
+      }
+    },
     "No event this round" : {
       "localizations" : {
         "ja" : {
@@ -4019,6 +4197,26 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "モデルなし"
+          }
+        }
+      }
+    },
+    "No Results" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "結果なし"
+          }
+        }
+      }
+    },
+    "No Scenarios" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シナリオがありません"
           }
         }
       }
@@ -4103,16 +4301,6 @@
         }
       }
     },
-    "OK" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
-          }
-        }
-      }
-    },
     "Offline — showing cached content" : {
       "localizations" : {
         "ja" : {
@@ -4123,22 +4311,12 @@
         }
       }
     },
-    "Open Report Form" : {
+    "OK" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "報告フォームを開く"
-          }
-        }
-      }
-    },
-    "Open Shared Scenarios to refresh, then try the link again." : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "共有シナリオを開いて更新してから、もう一度リンクを試してください。"
+            "value" : "OK"
           }
         }
       }
@@ -4159,6 +4337,26 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "GitHub で開く"
+          }
+        }
+      }
+    },
+    "Open Report Form" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "報告フォームを開く"
+          }
+        }
+      }
+    },
+    "Open Shared Scenarios to refresh, then try the link again." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "共有シナリオを開いて更新してから、もう一度リンクを試してください。"
           }
         }
       }
@@ -4203,16 +4401,6 @@
         }
       }
     },
-    "Output Fields" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "出力フィールド"
-          }
-        }
-      }
-    },
     "Output drifted from expected %@ for %@" : {
       "localizations" : {
         "en" : {
@@ -4245,6 +4433,16 @@
         }
       }
     },
+    "Output Fields" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "出力フィールド"
+          }
+        }
+      }
+    },
     "Overview" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -4252,16 +4450,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "概要"
-          }
-        }
-      }
-    },
-    "PASTURA · SETUP" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "PASTURA · セットアップ"
           }
         }
       }
@@ -4282,6 +4470,19 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "過去の結果"
+          }
+        }
+      }
+    },
+    "Pastura" : {
+
+    },
+    "PASTURA · SETUP" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PASTURA · セットアップ"
           }
         }
       }
@@ -4433,6 +4634,16 @@
         }
       }
     },
+    "Persona '%@' description contains a term that is not allowed" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ペルソナ '%@' の説明に許可されていない用語が含まれています"
+          }
+        }
+      }
+    },
     "Persona %lld description contains a term that is not allowed" : {
       "localizations" : {
         "ja" : {
@@ -4449,16 +4660,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ペルソナ %lld の名前に許可されていない用語が含まれています"
-          }
-        }
-      }
-    },
-    "Persona '%@' description contains a term that is not allowed" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ペルソナ '%@' の説明に許可されていない用語が含まれています"
           }
         }
       }
@@ -4718,6 +4919,16 @@
         }
       }
     },
+    "Recommended model" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "推奨モデル"
+          }
+        }
+      }
+    },
     "Recommended Scenarios" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -4725,16 +4936,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "おすすめのシナリオ"
-          }
-        }
-      }
-    },
-    "Recommended model" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "推奨モデル"
           }
         }
       }
@@ -4766,6 +4967,7 @@
       }
     },
     "Recovery requires an active model" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ja" : {
           "stringUnit" : {
@@ -5028,16 +5230,6 @@
         }
       }
     },
-    "Round Robin" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ラウンドロビン"
-          }
-        }
-      }
-    },
     "Round count (%lld) exceeds maximum of 30" : {
       "localizations" : {
         "en" : {
@@ -5050,6 +5242,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ラウンド数 (%lld) が最大値の30を超えています"
+          }
+        }
+      }
+    },
+    "Round Robin" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ラウンドロビン"
           }
         }
       }
@@ -5091,22 +5293,22 @@
         }
       }
     },
-    "Run Simulation" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "シミュレーション実行"
-          }
-        }
-      }
-    },
     "Run a simulation to see results here" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "シミュレーションを実行すると、ここに結果が表示されます"
+          }
+        }
+      }
+    },
+    "Run Simulation" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シミュレーション実行"
           }
         }
       }
@@ -5133,16 +5335,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "バックグラウンドで実行中"
-          }
-        }
-      }
-    },
-    "STORAGE" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ストレージ"
           }
         }
       }
@@ -5207,6 +5399,16 @@
         }
       }
     },
+    "Scenario description contains a term that is not allowed" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シナリオの説明に許可されていない用語が含まれています"
+          }
+        }
+      }
+    },
     "Scenario ID" : {
       "localizations" : {
         "ja" : {
@@ -5223,26 +5425,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "シナリオ ID は必須です"
-          }
-        }
-      }
-    },
-    "Scenario Not Found" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "シナリオが見つかりません"
-          }
-        }
-      }
-    },
-    "Scenario description contains a term that is not allowed" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "シナリオの説明に許可されていない用語が含まれています"
           }
         }
       }
@@ -5277,6 +5459,16 @@
         }
       }
     },
+    "Scenario Not Found" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シナリオが見つかりません"
+          }
+        }
+      }
+    },
     "Scenario: field 'language' must be one of {%@}, got '%@'" : {
       "localizations" : {
         "en" : {
@@ -5293,22 +5485,6 @@
         }
       }
     },
-    "Scenario: field 'simulationLanguage' must be one of {%@} or nil, got '%@'" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scenario: field 'simulationLanguage' must be one of {%1$@} or nil, got '%2$@'"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scenario: フィールド 'simulationLanguage' は {%1$@} のいずれか、または nil である必要がありますが、'%2$@' が指定されました"
-          }
-        }
-      }
-    },
     "Scenario: field 'simulation_language' must be one of {%@} or absent, got '%@'" : {
       "localizations" : {
         "en" : {
@@ -5321,6 +5497,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scenario: フィールド 'simulation_language' は {%1$@} のいずれか、または省略可能である必要がありますが、'%2$@' が指定されました"
+          }
+        }
+      }
+    },
+    "Scenario: field 'simulationLanguage' must be one of {%@} or nil, got '%@'" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scenario: field 'simulationLanguage' must be one of {%1$@} or nil, got '%2$@'"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scenario: フィールド 'simulationLanguage' は {%1$@} のいずれか、または nil である必要がありますが、'%2$@' が指定されました"
           }
         }
       }
@@ -5651,6 +5843,16 @@
         }
       }
     },
+    "STORAGE" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ストレージ"
+          }
+        }
+      }
+    },
     "Storage is getting large. Consider clearing old runs to free space." : {
       "localizations" : {
         "ja" : {
@@ -5821,26 +6023,6 @@
         }
       }
     },
-    "This Month" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "今月"
-          }
-        }
-      }
-    },
-    "This Week" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "今週"
-          }
-        }
-      }
-    },
     "This can take a few seconds" : {
       "localizations" : {
         "ja" : {
@@ -5891,6 +6073,32 @@
         }
       }
     },
+    "this model" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "this model"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このモデル"
+          }
+        }
+      }
+    },
+    "This Month" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今月"
+          }
+        }
+      }
+    },
     "This permanently removes every past run and its conversation log. This can't be undone." : {
       "localizations" : {
         "ja" : {
@@ -5921,22 +6129,22 @@
         }
       }
     },
+    "This Week" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今週"
+          }
+        }
+      }
+    },
     "Today" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "今日"
-          }
-        }
-      }
-    },
-    "Top-level YAML key" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "トップレベルの YAML キー"
           }
         }
       }
@@ -6001,6 +6209,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "トップレベルフィールド '%@': 混在型の配列はサポートされていません。純粋な [String] または [[String: String]] を使用してください。"
+          }
+        }
+      }
+    },
+    "Top-level YAML key" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "トップレベルの YAML キー"
           }
         }
       }
@@ -6327,6 +6545,16 @@
         }
       }
     },
+    "vs" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "vs"
+          }
+        }
+      }
+    },
     "Wait for Wi-Fi" : {
       "localizations" : {
         "ja" : {
@@ -6471,221 +6699,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "このデバイスに複数のモデルを保持できます。メモリに読み込まれるのは使用中のモデルだけです。"
-          }
-        }
-      }
-    },
-    "_(empty)_" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "_(empty)_"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "_(なし)_"
-          }
-        }
-      }
-    },
-    "_No roster data._" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "_No roster data._"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "_ロスターデータなし_"
-          }
-        }
-      }
-    },
-    "_No score data._" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "_No score data._"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "_スコアデータなし_"
-          }
-        }
-      }
-    },
-    "_No turns recorded._" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "_No turns recorded._"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "_ターン記録なし_"
-          }
-        }
-      }
-    },
-    "active" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "active"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アクティブ"
-          }
-        }
-      }
-    },
-    "agents (%lld) does not match personas count (%lld)" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "agents (%1$lld) does not match personas count (%2$lld)"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "agents (%1$lld) が personas の数 (%2$lld) と一致しません"
-          }
-        }
-      }
-    },
-    "disabled" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "無効"
-          }
-        }
-      }
-    },
-    "e.g. max_score >= 10 && active_count > 1" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "例: max_score >= 10 && active_count > 1"
-          }
-        }
-      }
-    },
-    "eliminated" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "eliminated"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "脱落"
-          }
-        }
-      }
-    },
-    "enabled" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "有効"
-          }
-        }
-      }
-    },
-    "llama_decode failed (error %lld)" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "llama_decode failed (error %lld)"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "llama_decode に失敗しました（エラー %lld）"
-          }
-        }
-      }
-    },
-    "this model" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "this model"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "このモデル"
-          }
-        }
-      }
-    },
-    "vs" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "vs"
-          }
-        }
-      }
-    },
-    "~%lld inferences" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "~%lld 回の推論"
-          }
-        }
-      }
-    },
-    "“%@” will be deleted. Past simulation results are kept and stay viewable." : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "「%@」を削除します。過去のシミュレーション結果は残り、引き続き閲覧できます。"
-          }
-        }
-      }
-    },
-    "↳ sub-phase" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "↳ サブフェーズ"
           }
         }
       }

--- a/Pastura/Pastura/Views/Editor/ScenarioEditorView.swift
+++ b/Pastura/Pastura/Views/Editor/ScenarioEditorView.swift
@@ -52,6 +52,11 @@ struct ScenarioEditorView: View {  // swiftlint:disable:this type_body_length
     .navigationBarTitleDisplayMode(.inline)
     .navigationBarBackButtonHidden(true)
     .preservesPasturaSwipeBackGesture()
+    // Hide the tab bar so the editor's tab-bar state is consistent regardless
+    // of entry path (reached from ScenarioDetail — which already hides it —
+    // and from Home's "new scenario"). Editing is a focused task; tab-switching
+    // mid-edit isn't a real use case. See ADR-016 § contextual action bar.
+    .toolbar(.hidden, for: .tabBar)
     .toolbar { toolbarContent }
     .sheet(isPresented: $showNewPersonaSheet) {
       PersonaEditorSheet(name: "", description: "") { name, description in

--- a/Pastura/Pastura/Views/ScenarioDetail/ScenarioDetailActionBar.swift
+++ b/Pastura/Pastura/Views/ScenarioDetail/ScenarioDetailActionBar.swift
@@ -39,9 +39,14 @@ struct ScenarioDetailActionBar: View {
         }
       }
     }
-    .padding(.top, Spacing.xxs)
     .frame(maxWidth: .infinity)
+    .padding(.vertical, Spacing.xs)
     .pasturaBottomActionBarSurface()
+    // Inset from the screen edges + float above the bottom so the bar reads as
+    // the same detached rounded capsule the native iOS 26 tab bar uses on Home
+    // (not a full-width edge-to-edge band).
+    .padding(.horizontal, Spacing.l)
+    .padding(.bottom, Spacing.xs)
   }
 
   /// Primary. Tap-driven push → `NavigationLink(value:)` (navigation.md);
@@ -116,15 +121,15 @@ struct ScenarioDetailActionBar: View {
 }
 
 extension View {
-  /// Bottom-bar surface: iOS 26 Liquid Glass (continuity with the native tab
-  /// bar this replaces), `.regularMaterial` + top hairline on iOS 18–25.
+  /// Bottom-bar surface: a rounded **capsule** matching the native iOS 26
+  /// floating tab bar on Home — Liquid Glass on iOS 26, `.regularMaterial` in a
+  /// Capsule on iOS 18–25.
   @ViewBuilder
   fileprivate func pasturaBottomActionBarSurface() -> some View {
     if #available(iOS 26.0, *) {
-      glassEffect(.regular, in: .rect)
+      glassEffect(.regular, in: .capsule)
     } else {
-      background(.regularMaterial)
-        .overlay(alignment: .top) { Color.rule.frame(height: 0.5) }
+      background(.regularMaterial, in: Capsule())
     }
   }
 }

--- a/Pastura/Pastura/Views/ScenarioDetail/ScenarioDetailActionBar.swift
+++ b/Pastura/Pastura/Views/ScenarioDetail/ScenarioDetailActionBar.swift
@@ -3,9 +3,10 @@ import SwiftUI
 /// Bottom contextual action bar for ``ScenarioDetailView`` — replaces the tab
 /// bar on the scenario-detail screen (ADR-016 § Amendment / contextual bottom
 /// action bar). Two **detached** rounded-capsule elements (icon over label):
-/// a moss **Run** capsule (the emphasized primary, echoing the tab bar's
-/// selected-pill treatment) and a separate neutral capsule grouping the
-/// secondary **Copy & Edit** / **Delete** actions.
+/// a **Run** capsule (the emphasized primary — emphasis comes from its
+/// detachment + moss-coloured content, on a plain Liquid Glass background) and
+/// a separate capsule grouping the secondary **Copy & Edit** / **Delete**
+/// actions.
 ///
 /// Why custom (not a native `.bottomBar`): iOS 26's `.bottomBar` renders
 /// **icon-only** (the design language moved from text to symbols) and offers no
@@ -44,10 +45,12 @@ struct ScenarioDetailActionBar: View {
     .padding(.bottom, Spacing.xs)
   }
 
-  /// Primary — a **separate** moss capsule so Run reads as the emphasized
-  /// action, distinct from the secondary group. Tap-driven `NavigationLink`
-  /// (navigation.md); `initialName` feeds SimulationView's title from the first
-  /// frame (identity-neutral via `RouteHint`, ADR-008).
+  /// Primary — a **separate** capsule (plain Liquid Glass; moss-coloured
+  /// content) so Run reads as the emphasized action, distinct from the
+  /// secondary group, without a tinted background that could read as a pressed
+  /// state. Tap-driven `NavigationLink` (navigation.md); `initialName` feeds
+  /// SimulationView's title from the first frame (identity-neutral via
+  /// `RouteHint`, ADR-008).
   private var runCapsule: some View {
     NavigationLink(
       value: Route.simulation(
@@ -63,7 +66,7 @@ struct ScenarioDetailActionBar: View {
     .accessibilityLabel(String(localized: "Run Simulation"))
     .accessibilityIdentifier("scenarioDetail.runSimulationButton")
     .frame(maxWidth: .infinity)
-    .pasturaActionCapsule(tint: Color.mossDark)
+    .pasturaActionCapsule()
   }
 
   /// Secondary actions in their own neutral glass capsule.
@@ -75,7 +78,7 @@ struct ScenarioDetailActionBar: View {
       }
     }
     .frame(maxWidth: .infinity)
-    .pasturaActionCapsule(tint: nil)
+    .pasturaActionCapsule()
   }
 
   /// Read-only sources (preset / installed gallery copy) get **Copy & Edit**
@@ -132,18 +135,12 @@ struct ScenarioDetailActionBar: View {
 
 extension View {
   /// Rounded **capsule** surface matching the native iOS 26 floating tab bar:
-  /// Liquid Glass on iOS 26 (optionally `tint`-ed for the primary Run capsule),
-  /// a soft-tint / `.regularMaterial` Capsule on iOS 18–25.
+  /// plain Liquid Glass on iOS 26, `.regularMaterial` Capsule on iOS 18–25.
+  /// (No tint — a coloured background read as a pressed state on device.)
   @ViewBuilder
-  fileprivate func pasturaActionCapsule(tint: Color?) -> some View {
+  fileprivate func pasturaActionCapsule() -> some View {
     if #available(iOS 26.0, *) {
-      if let tint {
-        glassEffect(.regular.tint(tint.opacity(0.18)), in: .capsule)
-      } else {
-        glassEffect(.regular, in: .capsule)
-      }
-    } else if let tint {
-      background(tint.opacity(0.14), in: Capsule())
+      glassEffect(.regular, in: .capsule)
     } else {
       background(.regularMaterial, in: Capsule())
     }

--- a/Pastura/Pastura/Views/ScenarioDetail/ScenarioDetailActionBar.swift
+++ b/Pastura/Pastura/Views/ScenarioDetail/ScenarioDetailActionBar.swift
@@ -2,18 +2,20 @@ import SwiftUI
 
 /// Bottom contextual action bar for ``ScenarioDetailView`` — replaces the tab
 /// bar on the scenario-detail screen (ADR-016 § Amendment / contextual bottom
-/// action bar). Tab-bar-style: equal-width columns, **icon over label**, so it
-/// reads as the tab bar "changing" into Run / Edit·Template / Delete.
+/// action bar). Two **detached** rounded-capsule elements (icon over label):
+/// a moss **Run** capsule (the emphasized primary, echoing the tab bar's
+/// selected-pill treatment) and a separate neutral capsule grouping the
+/// secondary **Copy & Edit** / **Delete** actions.
 ///
 /// Why custom (not a native `.bottomBar`): iOS 26's `.bottomBar` renders
 /// **icon-only** (the design language moved from text to symbols) and offers no
 /// icon-over-label form — that vertical layout is a `TabView` construct. To
 /// keep visible text labels *and* the Liquid Glass continuity with the native
-/// tab bar it replaces, this applies `glassEffect` (iOS 26+) to a custom bar,
-/// with a `.regularMaterial` fallback on iOS 18–25.
+/// tab bar it replaces, this applies `glassEffect` (iOS 26+) to custom
+/// capsules, with a `.regularMaterial` (or soft-tint) fallback on iOS 18–25.
 ///
 /// Colours carry the design-system §5.8 intent: Run = `mossDark` (primary),
-/// Edit·Template = `ink` (secondary), Delete = `dangerInk` (destructive).
+/// Edit / Copy & Edit = `ink` (secondary), Delete = `dangerInk` (destructive).
 ///
 /// The glass rendering is **real-device QA** — the simulator mis-renders iOS 26
 /// bottom chrome (swiftui-traps.md § 5.8) — as is the `InFlightSimulationIndicator`
@@ -22,7 +24,7 @@ struct ScenarioDetailActionBar: View {
   let scenarioId: String
   let scenarioName: String
   let canRun: Bool
-  /// Backs Edit / Use-as-Template / Delete. `nil` during the brief load window
+  /// Backs Copy & Edit / Edit / Delete. `nil` during the brief load window
   /// renders Run only.
   let record: ScenarioRecord?
   let isGallerySourced: Bool
@@ -30,29 +32,23 @@ struct ScenarioDetailActionBar: View {
   let onDelete: () -> Void
 
   var body: some View {
-    HStack(spacing: 0) {
-      runItem
+    HStack(spacing: Spacing.s) {
+      runCapsule
       if let record {
-        editOrTemplateItem(record: record)
-        if !record.isPreset {
-          deleteItem
-        }
+        secondaryGroup(record: record)
       }
     }
-    .frame(maxWidth: .infinity)
-    .padding(.vertical, Spacing.xs)
-    .pasturaBottomActionBarSurface()
-    // Inset from the screen edges + float above the bottom so the bar reads as
-    // the same detached rounded capsule the native iOS 26 tab bar uses on Home
-    // (not a full-width edge-to-edge band).
+    // Inset from the screen edges + float above the bottom so the capsules read
+    // as the same detached rounded shape the native iOS 26 tab bar uses on Home.
     .padding(.horizontal, Spacing.l)
     .padding(.bottom, Spacing.xs)
   }
 
-  /// Primary. Tap-driven push → `NavigationLink(value:)` (navigation.md);
-  /// `initialName` feeds SimulationView's title from the first frame
-  /// (identity-neutral via `RouteHint`, ADR-008).
-  private var runItem: some View {
+  /// Primary — a **separate** moss capsule so Run reads as the emphasized
+  /// action, distinct from the secondary group. Tap-driven `NavigationLink`
+  /// (navigation.md); `initialName` feeds SimulationView's title from the first
+  /// frame (identity-neutral via `RouteHint`, ADR-008).
+  private var runCapsule: some View {
     NavigationLink(
       value: Route.simulation(
         scenarioId: scenarioId, initialName: .init(scenarioName))
@@ -66,16 +62,30 @@ struct ScenarioDetailActionBar: View {
     .opacity(canRun ? 1 : 0.4)
     .accessibilityLabel(String(localized: "Run Simulation"))
     .accessibilityIdentifier("scenarioDetail.runSimulationButton")
+    .frame(maxWidth: .infinity)
+    .pasturaActionCapsule(tint: Color.mossDark)
   }
 
-  /// Read-only sources (preset / installed gallery copy) clone as a template;
-  /// user scenarios edit directly.
+  /// Secondary actions in their own neutral glass capsule.
+  private func secondaryGroup(record: ScenarioRecord) -> some View {
+    HStack(spacing: 0) {
+      editOrCopyItem(record: record)
+      if !record.isPreset {
+        deleteItem
+      }
+    }
+    .frame(maxWidth: .infinity)
+    .pasturaActionCapsule(tint: nil)
+  }
+
+  /// Read-only sources (preset / installed gallery copy) get **Copy & Edit**
+  /// (clone as an editable copy); user scenarios edit directly.
   @ViewBuilder
-  private func editOrTemplateItem(record: ScenarioRecord) -> some View {
+  private func editOrCopyItem(record: ScenarioRecord) -> some View {
     if record.isPreset || isGallerySourced {
       NavigationLink(value: Route.editor(templateYAML: record.yamlDefinition)) {
         actionColumn(
-          title: String(localized: "Use as Template"), systemImage: "doc.on.doc",
+          title: String(localized: "Copy & Edit"), systemImage: "doc.on.doc",
           tint: Color.ink)
       }
       .buttonStyle(.plain)
@@ -101,7 +111,7 @@ struct ScenarioDetailActionBar: View {
     .accessibilityIdentifier("scenarioDetail.deleteButton")
   }
 
-  /// Tab-bar-style equal-width column: icon over label.
+  /// Tab-bar-style column: icon over label, filling its capsule's width.
   private func actionColumn(
     title: String, systemImage: String, tint: Color
   ) -> some View {
@@ -114,20 +124,26 @@ struct ScenarioDetailActionBar: View {
     }
     .foregroundStyle(tint)
     .frame(maxWidth: .infinity)
-    .padding(.vertical, Spacing.xxs)
+    .padding(.vertical, Spacing.s)
     // Full-column hit target (the VStack alone leaves gaps between icon/label).
     .contentShape(Rectangle())
   }
 }
 
 extension View {
-  /// Bottom-bar surface: a rounded **capsule** matching the native iOS 26
-  /// floating tab bar on Home — Liquid Glass on iOS 26, `.regularMaterial` in a
-  /// Capsule on iOS 18–25.
+  /// Rounded **capsule** surface matching the native iOS 26 floating tab bar:
+  /// Liquid Glass on iOS 26 (optionally `tint`-ed for the primary Run capsule),
+  /// a soft-tint / `.regularMaterial` Capsule on iOS 18–25.
   @ViewBuilder
-  fileprivate func pasturaBottomActionBarSurface() -> some View {
+  fileprivate func pasturaActionCapsule(tint: Color?) -> some View {
     if #available(iOS 26.0, *) {
-      glassEffect(.regular, in: .capsule)
+      if let tint {
+        glassEffect(.regular.tint(tint.opacity(0.18)), in: .capsule)
+      } else {
+        glassEffect(.regular, in: .capsule)
+      }
+    } else if let tint {
+      background(tint.opacity(0.14), in: Capsule())
     } else {
       background(.regularMaterial, in: Capsule())
     }

--- a/Pastura/Pastura/Views/ScenarioDetail/ScenarioDetailActionBar.swift
+++ b/Pastura/Pastura/Views/ScenarioDetail/ScenarioDetailActionBar.swift
@@ -1,0 +1,130 @@
+import SwiftUI
+
+/// Bottom contextual action bar for ``ScenarioDetailView`` — replaces the tab
+/// bar on the scenario-detail screen (ADR-016 § Amendment / contextual bottom
+/// action bar). Tab-bar-style: equal-width columns, **icon over label**, so it
+/// reads as the tab bar "changing" into Run / Edit·Template / Delete.
+///
+/// Why custom (not a native `.bottomBar`): iOS 26's `.bottomBar` renders
+/// **icon-only** (the design language moved from text to symbols) and offers no
+/// icon-over-label form — that vertical layout is a `TabView` construct. To
+/// keep visible text labels *and* the Liquid Glass continuity with the native
+/// tab bar it replaces, this applies `glassEffect` (iOS 26+) to a custom bar,
+/// with a `.regularMaterial` fallback on iOS 18–25.
+///
+/// Colours carry the design-system §5.8 intent: Run = `mossDark` (primary),
+/// Edit·Template = `ink` (secondary), Delete = `dangerInk` (destructive).
+///
+/// The glass rendering is **real-device QA** — the simulator mis-renders iOS 26
+/// bottom chrome (swiftui-traps.md § 5.8) — as is the `InFlightSimulationIndicator`
+/// pill's clearance above this bar.
+struct ScenarioDetailActionBar: View {
+  let scenarioId: String
+  let scenarioName: String
+  let canRun: Bool
+  /// Backs Edit / Use-as-Template / Delete. `nil` during the brief load window
+  /// renders Run only.
+  let record: ScenarioRecord?
+  let isGallerySourced: Bool
+  /// Triggers the host's delete-confirmation `.alert`.
+  let onDelete: () -> Void
+
+  var body: some View {
+    HStack(spacing: 0) {
+      runItem
+      if let record {
+        editOrTemplateItem(record: record)
+        if !record.isPreset {
+          deleteItem
+        }
+      }
+    }
+    .padding(.top, Spacing.xxs)
+    .frame(maxWidth: .infinity)
+    .pasturaBottomActionBarSurface()
+  }
+
+  /// Primary. Tap-driven push → `NavigationLink(value:)` (navigation.md);
+  /// `initialName` feeds SimulationView's title from the first frame
+  /// (identity-neutral via `RouteHint`, ADR-008).
+  private var runItem: some View {
+    NavigationLink(
+      value: Route.simulation(
+        scenarioId: scenarioId, initialName: .init(scenarioName))
+    ) {
+      actionColumn(
+        title: String(localized: "Run"), systemImage: "play.fill",
+        tint: Color.mossDark)
+    }
+    .buttonStyle(.plain)
+    .disabled(!canRun)
+    .opacity(canRun ? 1 : 0.4)
+    .accessibilityLabel(String(localized: "Run Simulation"))
+    .accessibilityIdentifier("scenarioDetail.runSimulationButton")
+  }
+
+  /// Read-only sources (preset / installed gallery copy) clone as a template;
+  /// user scenarios edit directly.
+  @ViewBuilder
+  private func editOrTemplateItem(record: ScenarioRecord) -> some View {
+    if record.isPreset || isGallerySourced {
+      NavigationLink(value: Route.editor(templateYAML: record.yamlDefinition)) {
+        actionColumn(
+          title: String(localized: "Use as Template"), systemImage: "doc.on.doc",
+          tint: Color.ink)
+      }
+      .buttonStyle(.plain)
+    } else {
+      NavigationLink(value: Route.editor(editingId: scenarioId)) {
+        actionColumn(
+          title: String(localized: "Edit"), systemImage: "pencil", tint: Color.ink)
+      }
+      .buttonStyle(.plain)
+    }
+  }
+
+  /// Destructive, `dangerInk`. The host owns the confirmation `.alert`
+  /// (`!isPreset` gate mirrors the prior overflow menu — an installed gallery
+  /// copy stays deletable).
+  private var deleteItem: some View {
+    Button(role: .destructive, action: onDelete) {
+      actionColumn(
+        title: String(localized: "Delete"), systemImage: "trash",
+        tint: Color.dangerInk)
+    }
+    .buttonStyle(.plain)
+    .accessibilityIdentifier("scenarioDetail.deleteButton")
+  }
+
+  /// Tab-bar-style equal-width column: icon over label.
+  private func actionColumn(
+    title: String, systemImage: String, tint: Color
+  ) -> some View {
+    VStack(spacing: 4) {
+      Image(systemName: systemImage)
+        .font(.system(size: 20))
+      Text(title)
+        .font(.caption2)
+        .lineLimit(1)
+    }
+    .foregroundStyle(tint)
+    .frame(maxWidth: .infinity)
+    .padding(.vertical, Spacing.xxs)
+    // Full-column hit target (the VStack alone leaves gaps between icon/label).
+    .contentShape(Rectangle())
+  }
+}
+
+extension View {
+  /// Bottom-bar surface: iOS 26 Liquid Glass (continuity with the native tab
+  /// bar this replaces), `.regularMaterial` + top hairline on iOS 18–25.
+  @ViewBuilder
+  fileprivate func pasturaBottomActionBarSurface() -> some View {
+    if #available(iOS 26.0, *) {
+      glassEffect(.regular, in: .rect)
+    } else {
+      background(.regularMaterial)
+        .overlay(alignment: .top) { Color.rule.frame(height: 0.5) }
+    }
+  }
+}

--- a/Pastura/Pastura/Views/ScenarioDetail/ScenarioDetailView+Sections.swift
+++ b/Pastura/Pastura/Views/ScenarioDetail/ScenarioDetailView+Sections.swift
@@ -149,10 +149,10 @@ extension ScenarioDetailView {
   ) -> some View {
     PasturaSection {
       VStack(spacing: 0) {
-        // Run Simulation is the bottom-pinned primary CTA (see
-        // ScenarioDetailView.runSimulationCTA); this section holds the
-        // secondary affordances. Past Results is the first row, so no
-        // leading divider.
+        // Run Simulation is the primary action in the contextual bottom action
+        // bar (see ScenarioDetailActionBar, hosted via ScenarioDetailView's
+        // .safeAreaInset); this section holds the secondary affordances. Past
+        // Results is the first row, so no leading divider.
         NavigationLink(value: Route.results(scenarioId: scenarioId)) {
           PasturaRowLabel(
             title: String(localized: "Past Results"),

--- a/Pastura/Pastura/Views/ScenarioDetail/ScenarioDetailView.swift
+++ b/Pastura/Pastura/Views/ScenarioDetail/ScenarioDetailView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
-/// Displays scenario metadata, personas, phases, and a launch button.
+/// Displays scenario metadata, personas, phases, and a contextual bottom
+/// action bar (Run / Edit·Template / Delete) that replaces the tab bar.
 struct ScenarioDetailView: View {
   let scenarioId: String
   /// Render-time hint for the navigation title — supplied by callers
@@ -13,11 +14,10 @@ struct ScenarioDetailView: View {
 
   @Environment(AppDependencies.self) private var dependencies
   @Environment(\.dismiss) private var dismiss
-  // Programmatic push for the overflow-menu Edit / Use-as-Template actions:
-  // a `NavigationLink` inside a `Menu` does not reliably push, so these go
-  // through the current tab's router (navigation.md § "When to use what").
-  // Not `private`: the sibling-file `+Sections.swift` extension reads it
-  // for the language-toggle `replaceTop` (private is file-scoped).
+  // Not `private`: the sibling-file `+Sections.swift` extension reads it for
+  // the language-toggle `replaceTop` (private is file-scoped). The bottom
+  // action bar navigates via its own `NavigationLink`s, so it doesn't need
+  // this router.
   @Environment(AppRouter.self) var router
   @State private var viewModel: ScenarioDetailViewModel?
   @State private var showDeleteConfirm = false
@@ -59,50 +59,20 @@ struct ScenarioDetailView: View {
     // which mounts an invisible probe to reinstall the gesture.
     .navigationBarBackButtonHidden(true)
     .preservesPasturaSwipeBackGesture()
+    // Replace the tab bar with a contextual bottom action bar
+    // (`scenarioContent`'s `.safeAreaInset` → `ScenarioDetailActionBar`):
+    // tab-bar-style Run / Edit·Template / Delete with iOS 26 Liquid Glass, so
+    // the tab bar reads as "changing" into these actions. Tab-switching to
+    // other sections isn't a real use case from a scenario detail. Precedent
+    // for the hide: SimulationView focus mode (ADR-017), different rationale
+    // (ADR-016 § contextual action bar). (A native `.bottomBar` renders
+    // icon-only on iOS 26 with no icon-over-label form — hence the custom bar.)
+    .toolbar(.hidden, for: .tabBar)
     .toolbar {
       ToolbarItem(placement: .topBarLeading) {
         PasturaBackButton()
       }
       .hidingPasturaSharedBackground()
-      // Low-frequency scenario-management actions (edit / clone / delete)
-      // live in a `⋯` overflow menu rather than a pinned top-right slot —
-      // the prime real estate is reserved for the primary Run CTA (now a
-      // bottom-pinned button). Mirrors `ResultDetailView`'s ellipsis idiom.
-      if let record = viewModel?.record {
-        ToolbarItem(placement: .primaryAction) {
-          Menu {
-            // Read-only sources (preset / installed gallery copy) get a
-            // clone-as-template action; user scenarios get direct edit.
-            if record.isPreset || (viewModel?.isGallerySourced ?? false) {
-              Button {
-                router.push(.editor(templateYAML: record.yamlDefinition))
-              } label: {
-                Label(String(localized: "Use as Template"), systemImage: "doc.on.doc")
-              }
-            } else {
-              Button {
-                router.push(.editor(editingId: scenarioId))
-              } label: {
-                Label(String(localized: "Edit"), systemImage: "pencil")
-              }
-            }
-            // Delete is gated EXACTLY as the prior toolbar button (`!isPreset`),
-            // so an installed gallery copy (`isPreset == false`) stays deletable
-            // — gallery read-only blocks edit/overwrite, not deleting the copy.
-            if !record.isPreset {
-              Button(role: .destructive) {
-                showDeleteConfirm = true
-              } label: {
-                Label(String(localized: "Delete"), systemImage: "trash")
-              }
-            }
-          } label: {
-            Image(systemName: "ellipsis.circle")
-          }
-          .accessibilityIdentifier("scenarioDetail.actionsMenu")
-        }
-        .hidingPasturaSharedBackground()
-      }
     }
     // `.alert` (not `.confirmationDialog`): iOS 26 renders a body-attached
     // confirmationDialog as a popover whose arrow anchors to the body
@@ -162,14 +132,18 @@ struct ScenarioDetailView: View {
     // content has resolved, so ScreenshotTourTests / NavigationRegressionTests
     // can wait on it instead of sleeping. MUST come before `.safeAreaInset`:
     // applied after, its identifier scopes the inset's Run button too and
-    // overrides the button's own `scenarioDetail.runSimulationButton` id.
+    // overrides the button's own `scenarioDetail.runSimulationButton` id
+    // (id-scope trap, swiftui-traps.md).
     .accessibilityIdentifier("scenarioDetail.list")
-    // Primary CTA pinned to the bottom safe-area edge so the app's core
-    // action stays in the thumb zone regardless of scroll position; content
-    // scrolls under the band. The tab bar sits below this (focus mode hides
-    // the tab bar only during a run, ADR-017 — not here).
+    // Contextual bottom action bar (replaces the tab bar — see `body`).
     .safeAreaInset(edge: .bottom) {
-      runSimulationCTA(scenario: scenario, viewModel: viewModel)
+      ScenarioDetailActionBar(
+        scenarioId: scenarioId,
+        scenarioName: scenario.name,
+        canRun: viewModel.canRun,
+        record: viewModel.record,
+        isGallerySourced: viewModel.isGallerySourced,
+        onDelete: { showDeleteConfirm = true })
     }
     .scrollPosition($scrollPosition)
     // A cross-language toggle reuses this leaf (replaceTop swaps the top
@@ -185,42 +159,4 @@ struct ScenarioDetailView: View {
     }
   }
 
-  /// Bottom-pinned primary call-to-action. Uses `PasturaPrimaryButtonStyle`
-  /// in its `.compact` size — a centred, content-width pill rather than a
-  /// full-width slab, keeping design-system §1's restrained "static, observed"
-  /// voice (the full-width mossDark bar read as too dominant on device). Stays
-  /// a `NavigationLink` pushing onto the current tab's stack (no
-  /// `navigationDestination(item:)` — navigation.md).
-  private func runSimulationCTA(
-    scenario: Scenario, viewModel: ScenarioDetailViewModel
-  ) -> some View {
-    // initialName supplies the scenario name to SimulationView's
-    // navigationTitle from the first frame, before loadAndRun() re-parses
-    // the YAML. Identity-neutral via RouteHint (ADR-008).
-    NavigationLink(
-      value: Route.simulation(
-        scenarioId: scenarioId,
-        initialName: .init(scenario.name)
-      )
-    ) {
-      Label(String(localized: "Run Simulation"), systemImage: "play.fill")
-    }
-    .buttonStyle(PasturaPrimaryButtonStyle(size: .compact))
-    .disabled(!viewModel.canRun)
-    .opacity(viewModel.canRun ? 1 : 0.4)
-    .accessibilityIdentifier("scenarioDetail.runSimulationButton")
-    // Intrinsic-width pill centred in the full-width band (no label
-    // `.frame(maxWidth:)`); the outer frame spans the band so the hairline
-    // background reaches both edges.
-    .frame(maxWidth: .infinity)
-    .padding(.vertical, 12)
-    // Opaque band + top hairline so scroll content reads as passing *under*
-    // a distinct footer, not blending into the last card. If device QA shows
-    // a colour seam against the tab bar, bleed the band background down with
-    // `.ignoresSafeArea(.container, edges: .bottom)` (background only).
-    .background(alignment: .top) {
-      Color.screenBackground
-        .overlay(alignment: .top) { Color.rule.frame(height: 0.5) }
-    }
-  }
 }

--- a/Pastura/PasturaUITests/InFlightIndicatorReconnectUITests.swift
+++ b/Pastura/PasturaUITests/InFlightIndicatorReconnectUITests.swift
@@ -58,10 +58,6 @@ final class InFlightIndicatorReconnectUITests: XCTestCase {
     // StubScenarioSeeder on every `--ui-test` launch, so tapping its Home row
     // lands directly on the run-capable ScenarioDetailView — skipping the
     // Browse → gallery → Try-install reach (~70s, the dominant ui-test cost).
-    // `browseTab` is declared here only as the "tab bar restored" sentinel used
-    // after the park below; it is never tapped (Home is the default tab).
-    let browseTab = app.tabBars.buttons["Browse"]
-
     let homeRow = app.buttons["home.scenarioListCell.ui_test_home_seed"]
     XCTAssertTrue(homeRow.waitForExistence(timeout: 5), "Home seed scenario row missing.")
     homeRow.tap()
@@ -99,8 +95,17 @@ final class InFlightIndicatorReconnectUITests: XCTestCase {
     let end = app.coordinate(withNormalizedOffset: CGVector(dx: 0.8, dy: 0.5))
     start.press(forDuration: 0.15, thenDragTo: end)
 
-    // The tab bar restores (left the sim) and the in-flight indicator appears.
-    XCTAssertTrue(browseTab.waitForExistence(timeout: 5), "Tab bar did not restore after leaving.")
+    // Confirm the swipe-back actually popped to ScenarioDetail (its ScrollView
+    // is the sentinel), so a failure to pop can't silently pass on a lingering
+    // indicator.
+    XCTAssertTrue(
+      app.scrollViews["scenarioDetail.list"].waitForExistence(timeout: 5),
+      "Leaving the sim did not return to ScenarioDetail.")
+
+    // ScenarioDetail hides the tab bar (contextual action bar, ADR-016
+    // § Amendment 2026-07-01), so the tab bar stays hidden here — but the
+    // in-flight indicator (a RootTabView overlay, independent of the tab bar)
+    // surfaces once the sim is no longer on top.
     let indicator = app.buttons["inFlightSimulationIndicator"]
     XCTAssertTrue(
       indicator.waitForExistence(timeout: 5),

--- a/Pastura/PasturaUITests/SimulationFocusModeTests.swift
+++ b/Pastura/PasturaUITests/SimulationFocusModeTests.swift
@@ -5,6 +5,13 @@ import XCTest
 /// tab-switching mid-run is structurally impossible — the bug #646 set out to
 /// fix (tab switch → view teardown → reset) can no longer be triggered.
 ///
+/// Note (ADR-016 § Amendment 2026-07-01): `ScenarioDetailView` — the screen
+/// the run is launched from — now ALSO hides the tab bar (contextual bottom
+/// action bar). So popping the sim lands back on a still-hidden screen; the
+/// bar only restores after popping *past* ScenarioDetail to a tab-bar-showing
+/// screen (here GalleryScenarioDetail). This test therefore pops twice to
+/// prove the hide is not sticky.
+///
 /// This UI test guards the **simulator-observable** mechanism only: the bar
 /// disappears on push and restores on pop. The iOS-26 restore-on-pop *visual*
 /// (Liquid Glass flicker / half-render / stuck-hidden) is NOT validated here —
@@ -35,9 +42,52 @@ final class SimulationFocusModeTests: XCTestCase {
       app.navigationBars["Pastura"].waitForExistence(timeout: 10),
       "Home did not appear within 10s.")
 
-    // Reach SimulationView via the proven gallery-install → Run Simulation flow
-    // (mirrors NavigationRegressionTests — the path known to start a sim under
-    // the `--ui-test` harness).
+    // Reach a running SimulationView (Home → Browse → gallery → install →
+    // ScenarioDetail → Run). Returns the Browse tab-bar button as the
+    // tab-bar-visible sentinel.
+    let browseTab = reachRunningSimulation(app)
+
+    // Focus mode: the tab bar must disappear while the sim is on top. The hide
+    // is unconditional on SimulationView, so it holds regardless of whether the
+    // (mock) run has already completed.
+    let tabBarGone = XCTNSPredicateExpectation(
+      predicate: NSPredicate(format: "exists == false"),
+      object: browseTab)
+    wait(for: [tabBarGone], timeout: 5)
+
+    // Pop via the interactive edge-swipe — it bypasses the back-button
+    // confirm-on-leave dialog by design, so this is robust to the mock run's
+    // completion timing. Coordinate-based drag is required;
+    // swipeRight() does not trigger interactivePopGestureRecognizer on iOS 17+
+    // (mirrors BackGestureTests).
+    let start = app.coordinate(withNormalizedOffset: CGVector(dx: 0.0, dy: 0.5))
+    let end = app.coordinate(withNormalizedOffset: CGVector(dx: 0.8, dy: 0.5))
+    start.press(forDuration: 0.15, thenDragTo: end)
+
+    // Popping the sim lands on ScenarioDetail, which ALSO hides the tab bar
+    // (contextual action bar, ADR-016 § Amendment 2026-07-01) — so the bar is
+    // still gone here. Pop once more to leave the run-focused screens and reach
+    // GalleryScenarioDetail, where the tab bar restores.
+    let backOnDetail = app.scrollViews["scenarioDetail.list"]
+    XCTAssertTrue(
+      backOnDetail.waitForExistence(timeout: 5),
+      "Popping the simulation did not return to ScenarioDetail.")
+    start.press(forDuration: 0.15, thenDragTo: end)
+
+    // The tab bar must restore once past the run-focused screens.
+    XCTAssertTrue(
+      browseTab.waitForExistence(timeout: 5),
+      "Tab bar did not restore after leaving the run-focused screens — the"
+        + " focus-mode / ScenarioDetail tab-bar hide did not reverse.")
+  }
+
+  /// Navigates the `--ui-test` harness Home → Browse → gallery → install →
+  /// ScenarioDetail → Run and waits for SimulationView. Mirrors the path in
+  /// `NavigationRegressionTests` (the flow known to start a sim under the
+  /// harness). Returns the Browse tab-bar button — the tab-bar-visible sentinel
+  /// the caller uses for its focus-mode assertions.
+  @discardableResult
+  private func reachRunningSimulation(_ app: XCUIApplication) -> XCUIElement {
     let browseTab = app.tabBars.buttons["Browse"]
     XCTAssertTrue(browseTab.waitForExistence(timeout: 5), "Browse tab missing.")
     browseTab.tap()
@@ -73,33 +123,10 @@ final class SimulationFocusModeTests: XCTestCase {
     runSimulation.tap()
 
     // SimulationView is now on top. Anchor on the always-rendered meta-row inset
-    // (present from first frame, before any inference) — same anchor as
-    // NavigationRegressionTests.
+    // (present from first frame, before any inference).
     XCTAssertTrue(
       app.descendants(matching: .any)["simulation.header.meta"].waitForExistence(timeout: 10),
       "SimulationView did not appear.")
-
-    // Focus mode: the tab bar must disappear while the sim is on top. The hide
-    // is unconditional on SimulationView, so it holds regardless of whether the
-    // (mock) run has already completed.
-    let tabBarGone = XCTNSPredicateExpectation(
-      predicate: NSPredicate(format: "exists == false"),
-      object: browseTab)
-    wait(for: [tabBarGone], timeout: 5)
-
-    // Pop via the interactive edge-swipe — it bypasses the back-button
-    // confirm-on-leave dialog by design, so this is robust to the mock run's
-    // completion timing. Coordinate-based drag is required;
-    // swipeRight() does not trigger interactivePopGestureRecognizer on iOS 17+
-    // (mirrors BackGestureTests).
-    let start = app.coordinate(withNormalizedOffset: CGVector(dx: 0.0, dy: 0.5))
-    let end = app.coordinate(withNormalizedOffset: CGVector(dx: 0.8, dy: 0.5))
-    start.press(forDuration: 0.15, thenDragTo: end)
-
-    // The tab bar must restore once the simulation is popped.
-    XCTAssertTrue(
-      browseTab.waitForExistence(timeout: 5),
-      "Tab bar did not restore after popping the simulation — focus-mode tab-bar"
-        + " hide did not reverse on pop.")
+    return browseTab
   }
 }

--- a/docs/decisions/ADR-016.md
+++ b/docs/decisions/ADR-016.md
@@ -415,3 +415,51 @@ cleanly, the fallback is to accept the native **titled** labels on the
 iOS 18+ branch — which would amend D1's all-OS icon-only mandate to
 "icon-only on iOS 17; native labels on iOS 18+". That amendment is
 deferred until device QA decides; D1 stands as written unless/until then.
+
+## 8. Amendment 2026-07-01 — contextual bottom action bar on ScenarioDetail (#856)
+
+D1 established the four-tab bottom bar as the app's root navigation. This
+amendment records a **screen-level exception**: `ScenarioDetailView` (and the
+`ScenarioEditorView` it pushes) suppress the tab bar and replace it with a
+contextual bottom action bar (`ScenarioDetailActionBar`: Run / Edit·Template /
+Delete) — tab-bar-style equal-width columns, icon over label.
+
+**Why.** Tab-switching to Settings / History from a scenario detail isn't a
+real use case — the actions a user wants there are Run, Edit/Template, and
+Delete. Those previously lived split across a bottom `.safeAreaInset` Run CTA
+plus a `⋯` toolbar overflow menu; consolidating them into one bottom bar that
+takes the tab bar's place reads as a purpose-built screen.
+
+**Collision fix (supersedes the #854 approach).** The old bottom Run CTA (a
+`.safeAreaInset` band *above* the tab bar) collided with the
+`InFlightSimulationIndicator` pill — a bottom-aligned `RootTabView` overlay
+(`padding(.bottom, 56)`) shown while a run is parked-away (§6 / ADR-017
+§ Amendment Phase B). PR #854 moved the CTA into the top toolbar; real-device
+QA found that off. This amendment instead keeps the actions at the very bottom
+edge but **replaces** the tab bar (which is hidden) with the action bar, so the
+pill's existing clearance — tuned to float above the bottom chrome — is
+preserved rather than fought. That clearance is a **real-device QA acceptance
+gate**: the pill's offset behaviour when the tab bar is hidden is not verifiable
+from code (the simulator mis-renders iOS 26 bottom chrome). Fallback if it
+regresses: make the pill's bottom offset tab-bar-visibility-aware.
+
+**Mechanism.** `.toolbar(.hidden, for: .tabBar)` on both views (the same API as
+ADR-017's focus mode, **different rationale** — no run to protect here) plus a
+`.safeAreaInset(edge: .bottom)` hosting `ScenarioDetailActionBar` — a **custom**
+bar, not a native `.bottomBar`: iOS 26's `.bottomBar` renders icon-only (the
+design language moved from text to symbols) with no icon-over-label form, so a
+custom bar is required to keep visible text labels. It applies `glassEffect`
+(iOS 26+, `.regularMaterial` fallback below) so it reads as a continuation of
+the native `TabView` tab bar it replaces (D2 — the tab bar is already native
+glass; §5.8's opt-out is scoped to the *top* navigation bar). Editor sets its
+own `.toolbar(.hidden, for: .tabBar)` so its tab-bar state is consistent whether
+entered from ScenarioDetail (hidden) or Home's "new scenario" (which would
+otherwise leave it visible). Items are tap-driven `NavigationLink`s
+(navigation.md); colours carry §5.8 intent — Run = `mossDark`, Edit·Template =
+`ink`, Delete = `dangerInk` (with `role: .destructive` + confirmation `.alert`).
+
+**Relation to ADR-017.** ADR-017's focus mode is "hide the tab bar to *protect
+a live run*"; this is "hide the tab bar because *contextual actions replace
+tab-switching*." They share only the API. `isSimulationOnTop` and the
+focus-mode machinery are untouched — ScenarioDetail is not a simulation, so
+none of D5 / ADR-017's fold logic applies.

--- a/scripts/generate-navigation-map.py
+++ b/scripts/generate-navigation-map.py
@@ -92,6 +92,7 @@ FILE_TO_SCREEN = {
     "Pastura/Pastura/Views/Home/HomeCompactScenarioRow.swift": "home",
     "Pastura/Pastura/Views/ScenarioDetail/ScenarioDetailView.swift": "scenarioDetail",
     "Pastura/Pastura/Views/ScenarioDetail/ScenarioDetailView+Sections.swift": "scenarioDetail",
+    "Pastura/Pastura/Views/ScenarioDetail/ScenarioDetailActionBar.swift": "scenarioDetail",
     "Pastura/Pastura/Views/Results/ResultsView.swift": "results",
     "Pastura/Pastura/Views/Results/ResultsView+Timeline.swift": "results",
     "Pastura/Pastura/Views/Community/SharedScenarios/SharedScenariosListView.swift": "sharedScenarios",


### PR DESCRIPTION
## Summary
On `ScenarioDetailView` (and the `ScenarioEditorView` it pushes), hide the bottom tab bar and replace it with a contextual bottom action bar (`ScenarioDetailActionBar`) — tab-bar-style equal-width columns, **icon over label**: **Run** / **Edit·Template** / **Delete**. Tab-switching to Settings/History from a scenario detail isn't a real use case; the tab bar "changes" into the actions relevant here (the iOS Photos-detail idiom).

This also resolves the original problem — the bottom Run CTA collided with the `InFlightSimulationIndicator` "return to run" pill (a bottom-aligned `RootTabView` overlay). Superseding approach: the closed **PR #854** moved the CTA to the top toolbar, but real-device QA found that off.

## Design notes
- **Custom bar, not native `.bottomBar`**: iOS 26's `.bottomBar` renders icon-only (design language moved from text to symbols) with no icon-over-label form. To keep visible text labels *and* the Liquid Glass continuity with the tab bar it replaces, the bar applies `glassEffect` (iOS 26+; `.regularMaterial` fallback on iOS 18–25).
- **Colours carry design-system §5.8 intent**: Run = `mossDark` (primary), Edit·Template = `ink` (secondary), Delete = `dangerInk` (destructive), with `role: .destructive` + the existing confirmation `.alert`.
- **Mechanism**: `.toolbar(.hidden, for: .tabBar)` (same API as ADR-017 focus mode, different rationale) + `.safeAreaInset(edge: .bottom)` hosting the bar. Items are tap-driven `NavigationLink`s (navigation.md). Editor hides its own tab bar so its state is consistent regardless of entry path.
- i18n: new `"Run"` key (ja「実行」); a11y label keeps the full "Run Simulation". Run button id `scenarioDetail.runSimulationButton` preserved.
- Docs: ADR-016 § Amendment 2026-07-01, `navigation.md` rule, `swiftui-traps.md` reference, nav-map `FILE_TO_SCREEN` (map byte-identical).

## Test plan
- Full test suite green (unit + UI). `SimulationFocusModeTests` + `InFlightIndicatorReconnectUITests` updated for the new "ScenarioDetail hides the tab bar" behavior (tab bar restores only after popping past ScenarioDetail; the in-flight indicator surfaces independent of the tab bar).
- `ScreenshotTourTests` visually confirmed icon-over-label + text labels + colours.
- ⚠️ **Real-device iOS 26 QA needed**: the `glassEffect` rendering and the `InFlightSimulationIndicator` pill's clearance above the bar are simulator-unreliable (swiftui-traps §5.8). Fallback if the pill collides: make its bottom offset tab-bar-visibility-aware.

Closes #856

🤖 Generated with [Claude Code](https://claude.com/claude-code)