### PR TITLE
✨ feat: add English versions of 2 form-swap comedy gallery scenarios

### DIFF
--- a/docs/gallery/chin_jimaku_v1_en.yaml
+++ b/docs/gallery/chin_jimaku_v1_en.yaml
@@ -1,0 +1,86 @@
+id: chin_jimaku_v1_en
+language: en
+name: Terrible Movie Subtitles
+agents: 4
+rounds: 2
+description: >
+  A famous movie scene and its original line are given, and four hopeless subtitle
+  translators each slap on an absurd English subtitle in their own signature
+  style — a comedy game. Everyone votes for the funniest subtitle.
+context: >
+  You are a subtitle translator on the worst subtitling team in the business,
+  captioning famous foreign-film moments for their international release.
+  A famous scene and its original line are announced.
+  Fully in character, write your English subtitle for that line in 1-2 sentences.
+  This is a contest of comedy, not accuracy.
+  Afterward, you vote for the funniest subtitle other than your own.
+
+topics:
+  - >
+    SCENE — the hero sprints from a massive explosion, turns back and shouts to
+    his crew. LINE — "We need to go, NOW!"
+  - >
+    SCENE — in the pouring rain, the heroine fights back tears as she says
+    goodbye to the hero. LINE — "I will never forget you."
+
+personas:
+  - name: Literal Larry
+    description: >
+      [Role] A translator who mechanically swaps word for word.
+      [Goal] NEVER write natural English — always mangle the line into broken,
+      stilted translationese with wrong word order and clunky grammar. If it reads
+      correctly, you failed.
+      e.g. "We are having the need for going, at the now!" / "You, I will be
+      forgetting never."
+  - name: Over-Local Ollie
+    description: >
+      [Role] A localizer who drags everything into hyper-casual modern slang.
+      [Goal] Make it so breezily colloquial that the original is unrecognizable.
+      e.g. "Ugh, let's bounce, fam."
+  - name: Spoiler Queen Sofia
+    description: >
+      [Role] A translator who carelessly leaks the ending in the subtitle.
+      [Goal] Slip an unrelated ending or plot twist into this line's subtitle.
+      e.g. "Let's go! (He's secretly a ghost the whole time, by the way.)"
+  - name: Trivia Todd
+    description: >
+      [Role] A busybody who tacks on trivia that has nothing to do with the line.
+      [Goal] ALWAYS end your subtitle with a "(Note: ...)" footnote containing a
+      pointless, unrelated fact. The footnote is your whole gimmick — never skip it.
+      e.g. "We should go. (Note: this hill has an average grade of 4%.)"
+
+phases:
+  - type: assign
+    source: topics
+    target: all
+
+  - type: speak_all
+    prompt: >
+      {assigned_topic}
+
+      Fully in character, write your English subtitle for this line in 1-2
+      sentences. Keep it short and commit to the bit.
+    output:
+      statement: string
+      inner_thought: string
+
+  - type: vote
+    prompt: >
+      {assigned_topic}
+
+      The subtitles the other translators wrote:
+      {conversation_log}
+
+      Vote for the funniest subtitle other than your own.
+      Write your vote as exactly one of these names: {candidates}
+    output:
+      vote: string
+      reason: string
+    exclude_self: true
+
+  - type: score_calc
+    logic: vote_tally
+
+  - type: summarize
+    template: >
+      Round {current_round} result: {scoreboard}

--- a/docs/gallery/gallery.json
+++ b/docs/gallery/gallery.json
@@ -735,6 +735,28 @@
       "yaml_url": "chin_jimaku_v1_en.yaml",
       "yaml_sha256": "c5b2bb7b2dd0a2c5f380de4216dc6c86f39cd279921f0b3575c7ecaba9783c21",
       "added_at": "2026-07-01"
+    },
+    {
+      "id": "shachiku_senryu_v1_en",
+      "title": "Cubicle Limerick Battle",
+      "category": "creative",
+      "description": "A verse-battle where each player answers an office-life prompt with one limerick, judged on both the humor and the craft of landing a real AABBA verse.",
+      "author": "tyabu12",
+      "recommended_model": "gemma-4-e2b-q4-k-m",
+      "estimated_inferences": 16,
+      "agent_count": 4,
+      "rounds": 2,
+      "phases": [
+        "assign",
+        "speak_all",
+        "vote",
+        "score_calc",
+        "summarize"
+      ],
+      "language": "en",
+      "yaml_url": "shachiku_senryu_v1_en.yaml",
+      "yaml_sha256": "72fa4456f8576b1290f819dfb9561f786884ac99c50f1d88237795a7674c06e2",
+      "added_at": "2026-07-01"
     }
   ]
 }

--- a/docs/gallery/gallery.json
+++ b/docs/gallery/gallery.json
@@ -713,6 +713,28 @@
       "yaml_url": "tengoku_jigoku_v1_en.yaml",
       "yaml_sha256": "002300c367995638324977d5f6fdd1574ca539c7175d49bb26650e81f74cafcc",
       "added_at": "2026-07-01"
+    },
+    {
+      "id": "chin_jimaku_v1_en",
+      "title": "Terrible Movie Subtitles",
+      "category": "creative",
+      "description": "Four hopeless subtitle translators slap absurd English subtitles onto a famous movie line, each in their own terrible style; everyone votes for the funniest.",
+      "author": "tyabu12",
+      "recommended_model": "gemma-4-e2b-q4-k-m",
+      "estimated_inferences": 16,
+      "agent_count": 4,
+      "rounds": 2,
+      "phases": [
+        "assign",
+        "speak_all",
+        "vote",
+        "score_calc",
+        "summarize"
+      ],
+      "language": "en",
+      "yaml_url": "chin_jimaku_v1_en.yaml",
+      "yaml_sha256": "c5b2bb7b2dd0a2c5f380de4216dc6c86f39cd279921f0b3575c7ecaba9783c21",
+      "added_at": "2026-07-01"
     }
   ]
 }

--- a/docs/gallery/shachiku_senryu_v1_en.yaml
+++ b/docs/gallery/shachiku_senryu_v1_en.yaml
@@ -1,0 +1,81 @@
+id: shachiku_senryu_v1_en
+language: en
+name: Cubicle Limerick Battle
+description: >
+  A verse-form comedy game where each player answers a prompt with one limerick.
+  It's judged not only on how funny the content is, but on the craft of landing it
+  in a real five-line limerick.
+agents: 4
+rounds: 2
+context: >
+  You are a contestant on the verse-battle show "Nine-to-Five Limericks."
+  A prompt is given, and you must answer with exactly ONE limerick — five lines,
+  rhyme scheme AABBA, with a bouncy sing-song rhythm.
+  No preamble, no explanation — give only the limerick itself.
+  Once everyone's limerick is in, you vote for the funniest, other than your own.
+  Let your character's voice and outlook bleed into the verse.
+
+topics:
+  - Prompt "Working from home"
+  - Prompt "Your annual health-checkup results"
+
+personas:
+  - name: Sir Reginald the Knight
+    description: >
+      [Role] An anachronistic medieval knight lost in a modern office.
+      [Goal] Frame office life as epic battle and chivalry, in lofty olde-worlde
+      diction.
+      e.g. "The approval, my liege must bestow / or to war with the spreadsheet I go."
+  - name: Valley-Girl Bree
+    description: >
+      [Role] A Gen-Z contestant who crams trendy slang into the old verse form.
+      [Goal] Get comedy from the clash between airy modern slang and the stately
+      limerick.
+      e.g. "Like, the meeting was giving, no cap…"
+  - name: Byron the Bard
+    description: >
+      [Role] A pretentious Romantic poet drunk on his own melancholy.
+      [Goal] Inflate the pettiest office trifle into grand tragic poetry.
+      e.g. "O, three hundred unread in my Slack / and my soul, it shall never come back."
+  - name: Old-Timer Walt
+    description: >
+      [Role] A weary veteran on the edge of retirement, still dragging the old days
+      along.
+      [Goal] Deliver a dry, bittersweet verse that makes you laugh and ache at once.
+      e.g. "They rehired me, my title cut thin / just a badge and a chair to clock in."
+
+phases:
+  - type: assign
+    source: topics
+    target: all
+
+  - type: speak_all
+    prompt: >
+      {assigned_topic}
+
+      Answer this prompt with exactly ONE limerick — five lines, rhyme scheme
+      AABBA. Give only the limerick, no explanation.
+    output:
+      statement: string
+      inner_thought: string
+
+  - type: vote
+    prompt: >
+      {assigned_topic}
+
+      Everyone's limericks:
+      {conversation_log}
+
+      Vote for the funniest limerick other than your own.
+      Write your vote as exactly one of these names: {candidates}
+    output:
+      vote: string
+      reason: string
+    exclude_self: true
+
+  - type: score_calc
+    logic: vote_tally
+
+  - type: summarize
+    template: >
+      Round {current_round} result: {scoreboard}


### PR DESCRIPTION
## Summary
The △ **form-swap** batch of the gallery English-versions effort, continuing the merged C1 (#864) and C2 (#865) comedy batches. Part of #850. Both are **culturally-adapted English-native comedy**, not literal translations — the engine mechanic (phases / output schema / vote structure) is preserved verbatim, but the *referent* or *form* is swapped so the joke works for an English audience.

- `chin_jimaku_v1_en` — Terrible Movie Subtitles (creative) — **referent-swap**: JA subtitles-of-English-films → EN subtitles-of-foreign-films. Four hopeless translators (literal-machine / over-localizer / spoiler-leaker / trivia-footnoter) botch a famous line.
- `shachiku_senryu_v1_en` — Cubicle Limerick Battle (creative) — **form-swap**: 5-7-5 senryu → limerick (AABBA). Office-life prompts answered in verse (anachronistic knight / Gen-Z slang / melancholy Romantic / weary veteran).

`gallery.json` entries auto-derived by `add-gallery-entry.sh` (language/title/agent_count/rounds/phases/sha256), so index↔YAML stays pinned. category/recommended_model/estimated_inferences mirror the JA siblings (creative / gemma-4-e2b-q4-k-m / 16 — confirmed by each EN run's harness `run_start`). gallery.json goes 34→36 (EN 13→15).

## Field-test results
Both run on `pastura-harness` with `gemma-4-E2B-it-Q4_K_M` (real inference), `status=ok`. Per the comedy-track gate, transcripts were **read and judged for actual EN humor**:

| Scenario | Result |
|---|---|
| chin_jimaku | **funny** — the bad-translator role scaffold works ("the hero is actually a talking squirrel", "gotta bounce, fam", "run like you just remembered you left the stove on!"). Needed 1 tune to force Literal Larry's translationese ("Need we go, at the now!") and Trivia Todd's footnote gimmick |
| shachiku_senryu | **the limerick form transferred cleanly** — the model produced valid AABBA limericks in all runs, with distinct persona voices (knight frames office life as battle, Byron as melancholy, Walt as wistful). Minor: one round had 3 personas open with a near-identical template line |

Design note: **a structured verse form (limerick) acts as a helpful *scaffold*, not a barrier** — the constraint gives the model something to build on, producing competent, differentiated output. This mirrors the broader finding across C1/C2/△: *scaffolded* comedy (role, setting, or form) ports to EN well, whereas pure improv-wit (raw oogiri, piloted separately) stays mild.

## Test plan
- `scripts/check-gallery-entry.sh --all` ✅ · `gallery-precommit-gate.sh` ✅ (per-commit) · phase parity EN==JA sibling verified for both ✅
- Pre-impl `critic` PASS (0 Critical/Warning) — incl. programmatic checks: topics parse as pure string arrays, and both drafts vs `docs/blocklist/source.json` (ADR-005) = 0/92 hits
- Opus code review PASS (0 issues) — structural/placeholder parity + index↔YAML consistency (`git diff --numstat` gallery.json = purely additive); reviewed as adaptation (referent-swap + form-swap by design, not translation-fidelity)