### PR TITLE
✨ feat: シミュレーション完了時の最終ランキングカード

### DIFF
--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -43,6 +43,15 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   private(set) var logEntries: [LogEntry] = []
   private(set) var scores: [String: Int] = [:]
   private(set) var eliminated: [String: Bool] = [:]
+  /// Latest vote-phase tallies (target name → votes received), from the most
+  /// recent `.voteResults` event. Feeds the final-ranking card's ranking of a
+  /// vote-only ("popularity vote") scenario that eliminates nobody (#868).
+  private(set) var voteResults: [String: Int] = [:]
+  /// Per-agent vote count captured at the moment of each agent's elimination,
+  /// from `.elimination` events. Round-correct — an agent eliminated in an
+  /// earlier round keeps its own count, which a last-wins tally would drop.
+  /// Feeds the final-ranking card's survival framing (#868).
+  private(set) var eliminationVotes: [String: Int] = [:]
   private(set) var currentRound = 0
   private(set) var totalRounds = 0
   private(set) var thinkingAgents: Set<String> = []
@@ -853,6 +862,11 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     statusWriteTask = nil
     errorMessage = nil
     logEntries = []
+    // Result accumulators for the final-ranking card (#868) — reset per run so
+    // a re-used VM instance does not inherit the previous simulation's tallies.
+    // The resume path re-seeds these below from the checkpoint / replayed log.
+    voteResults = [:]
+    eliminationVotes = [:]
     // Latent: a second run on the same VM instance would otherwise inherit
     // these from the previous simulation — `latestAgentOutputId` points at a
     // UUID no longer in `logEntries`, and `streamingSnapshot` could render a
@@ -1158,11 +1172,24 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     // log entries — those are display-only; see ResumeLogReplayMapper).
     scores = state.scores
     eliminated = state.eliminated
+    // Re-seed the final-ranking card's vote-only tallies from the checkpoint
+    // (#868); `SimulationState` persists `voteResults` but not the per-agent
+    // elimination counts, so those are rebuilt from the replayed log below.
+    voteResults = state.voteResults
     currentRound = completedRound
     turnSequence = reseedValue
     let items = ResultDetailTimelineBuilder.build(turns: history.0, events: history.1)
     logEntries = ResumeLogReplayMapper.map(
       items: items, totalRounds: scenario.rounds, contentFilter: contentFilter)
+    // Rebuild per-agent elimination counts from the replayed log so a run
+    // resumed after an earlier-round elimination still shows that agent's own
+    // vote count in the survival framing (#868). Not persisted in state, and
+    // the replay does not route through `handleElimination`.
+    for entry in logEntries {
+      if case .elimination(let agent, let voteCount) = entry.kind {
+        eliminationVotes[agent] = voteCount
+      }
+    }
 
     lifecycleLogger.info(
       "resume() entered: simId=\(simId, privacy: .public), startRound=\(startRound)")
@@ -1405,6 +1432,9 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
           payload: .summary(text: text))
       }
     case .voteResults(let votes, let tallies):
+      // Keep the latest tallies for the final-ranking card's vote-only
+      // ranking (#868); last-wins matches `scores`' full-replace semantics.
+      voteResults = tallies
       logEntries.append(LogEntry(kind: .voteResults(votes: votes, tallies: tallies)))
       persistCodePhaseEvent(
         phaseType: currentPhaseType?.rawValue ?? PhaseType.vote.rawValue,
@@ -1701,6 +1731,9 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
 
   private func handleElimination(agent: String, voteCount: Int) {
     eliminated[agent] = true
+    // Capture the count at elimination time so the final-ranking card's
+    // survival framing shows each eliminated agent's own round tally (#868).
+    eliminationVotes[agent] = voteCount
     logEntries.append(LogEntry(kind: .elimination(agent: agent, voteCount: voteCount)))
   }
 

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -961,7 +961,14 @@
       }
     },
     "%lld votes" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 票"
+          }
+        }
+      }
     },
     "%lldm %llds" : {
       "localizations" : {
@@ -2696,7 +2703,14 @@
       }
     },
     "Eliminated" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "脱落"
+          }
+        }
+      }
     },
     "Else branch (condition false)" : {
       "localizations" : {
@@ -3096,10 +3110,24 @@
       }
     },
     "Final ranking" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最終ランキング"
+          }
+        }
+      }
     },
     "Final scores" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最終スコア"
+          }
+        }
+      }
     },
     "Finish the current simulation before clearing results." : {
       "localizations" : {
@@ -4206,7 +4234,14 @@
       }
     },
     "Outcome" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "結果"
+          }
+        }
+      }
     },
     "Output Fields" : {
       "localizations" : {
@@ -5491,7 +5526,14 @@
       }
     },
     "Shows the full scoreboard" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スコアボード全体を表示"
+          }
+        }
+      }
     },
     "Simulating" : {
       "localizations" : {
@@ -5710,7 +5752,14 @@
       }
     },
     "Survived" : {
-
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "生存"
+          }
+        }
+      }
     },
     "Switch to recommended model" : {
       "localizations" : {

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -960,6 +960,9 @@
         }
       }
     },
+    "%lld votes" : {
+
+    },
     "%lldm %llds" : {
       "localizations" : {
         "en" : {
@@ -2692,6 +2695,9 @@
         }
       }
     },
+    "Eliminated" : {
+
+    },
     "Else branch (condition false)" : {
       "localizations" : {
         "ja" : {
@@ -3088,6 +3094,12 @@
           }
         }
       }
+    },
+    "Final ranking" : {
+
+    },
+    "Final scores" : {
+
     },
     "Finish the current simulation before clearing results." : {
       "localizations" : {
@@ -4192,6 +4204,9 @@
           }
         }
       }
+    },
+    "Outcome" : {
+
     },
     "Output Fields" : {
       "localizations" : {
@@ -5475,6 +5490,9 @@
         }
       }
     },
+    "Shows the full scoreboard" : {
+
+    },
     "Simulating" : {
       "localizations" : {
         "ja" : {
@@ -5690,6 +5708,9 @@
           }
         }
       }
+    },
+    "Survived" : {
+
     },
     "Switch to recommended model" : {
       "localizations" : {

--- a/Pastura/Pastura/Views/Components/SimulationResultCard+Model.swift
+++ b/Pastura/Pastura/Views/Components/SimulationResultCard+Model.swift
@@ -1,0 +1,171 @@
+import Foundation
+
+extension SimulationResultCard {
+  /// Display-ready outcome for the card. The failable initializer is the
+  /// visibility guard: a run with nothing worth showing (a pure discussion /
+  /// summary, no scores / votes / eliminations) yields `nil` so the caller
+  /// renders no card — mirroring ``ScenarioIntroCard/Model``'s empty-premise
+  /// guard.
+  ///
+  /// Split into this sibling file (Apple's `Type+Feature.swift` convention) to
+  /// keep `SimulationResultCard`'s type body under swiftlint's limit; declared
+  /// `nonisolated` so the pure derivation runs off the MainActor and is
+  /// unit-testable from a nonisolated test.
+  nonisolated struct Model: Equatable {
+    let framing: Framing
+    let entries: [Entry]
+
+    /// Resolves the outcome from the ViewModel's accumulated result state.
+    ///
+    /// Classification is **survival-primary**: an `.eliminate` phase makes
+    /// survival the framing even when scores are also present (Werewolf), per
+    /// the #868 product decision. `scores` is seeded with every persona at `0`
+    /// at run start, so "are there scores worth ranking" is decided by *any
+    /// non-zero* value (`hasScores`) — never `!scores.isEmpty`.
+    ///
+    /// - Parameters:
+    ///   - scores: agent → cumulative score (all-zero until a scoring phase).
+    ///   - eliminated: agent → eliminated flag.
+    ///   - voteResults: latest vote-phase tallies (agent → votes received),
+    ///     used only to rank a vote-only scenario that eliminates nobody.
+    ///   - eliminationVotes: agent → vote count captured at its elimination.
+    ///   - phases: the scenario's phases, inspected for `.eliminate` /
+    ///     round-robin `.choose` / prisoner's-dilemma `.scoreCalc`.
+    init?(
+      scores: [String: Int],
+      eliminated: [String: Bool],
+      voteResults: [String: Int],
+      eliminationVotes: [String: Int],
+      phases: [Phase]
+    ) {
+      guard
+        let resolved = Self.resolve(
+          scores: scores, eliminated: eliminated, voteResults: voteResults,
+          eliminationVotes: eliminationVotes, phases: phases)
+      else { return nil }
+      self.framing = resolved.framing
+      self.entries = resolved.entries
+    }
+
+    private static func resolve(
+      scores: [String: Int],
+      eliminated: [String: Bool],
+      voteResults: [String: Int],
+      eliminationVotes: [String: Int],
+      phases: [Phase]
+    ) -> (framing: Framing, entries: [Entry])? {
+      let phaseTypes = Set(phases.map(\.type))
+      let hasScores = scores.values.contains { $0 != 0 }
+      // scores/eliminated are seeded with every persona at run start, so either
+      // key set is the full roster; prefer scores, fall back to eliminated.
+      let roster = scores.isEmpty ? Array(eliminated.keys) : Array(scores.keys)
+
+      // 1. Survival — an elimination phase makes "who's left" the outcome, even
+      //    when scores are also present.
+      if phaseTypes.contains(.eliminate) {
+        guard !roster.isEmpty else { return nil }
+        return (
+          .survival,
+          survivalEntries(
+            roster: roster, eliminated: eliminated, scores: scores,
+            hasScores: hasScores, eliminationVotes: eliminationVotes)
+        )
+      }
+
+      // 2. Pairing — round-robin choose or a prisoner's-dilemma scoring.
+      let isPairing =
+        phases.contains { $0.type == .choose && $0.pairing == .roundRobin }
+        || phases.contains { $0.type == .scoreCalc && $0.logic == .prisonersDilemma }
+      if isPairing, hasScores {
+        return (.pairing, rankedByScore(roster: roster, scores: scores, eliminated: eliminated))
+      }
+
+      // 3. Ranking — any real scoring.
+      if hasScores {
+        return (.ranking, rankedByScore(roster: roster, scores: scores, eliminated: eliminated))
+      }
+
+      // 4. Vote-only "popularity vote" — a vote happened but nobody was
+      //    eliminated and nothing scored. Rank by votes received.
+      if !voteResults.isEmpty, !roster.isEmpty {
+        return (
+          .ranking, rankedByVotes(roster: roster, votes: voteResults, eliminated: eliminated)
+        )
+      }
+
+      // 5. Nothing worth showing (discussion / summary only).
+      return nil
+    }
+
+    /// Sorts by `value` descending, then by name ascending as a deterministic
+    /// tiebreak so a top tie never picks a run-to-run-unstable "winner".
+    private static func ranked(
+      roster: [String], value: (String) -> Int, eliminated: [String: Bool],
+      valueKind: ValueKind
+    ) -> [Entry] {
+      let sorted = roster.sorted { lhs, rhs in
+        let lhsValue = value(lhs)
+        let rhsValue = value(rhs)
+        return lhsValue != rhsValue ? lhsValue > rhsValue : lhs < rhs
+      }
+      return sorted.enumerated().map { index, name in
+        Entry(
+          id: name, name: name, rank: index + 1,
+          isEliminated: eliminated[name] ?? false,
+          primaryValue: value(name), valueKind: valueKind)
+      }
+    }
+
+    private static func rankedByScore(
+      roster: [String], scores: [String: Int], eliminated: [String: Bool]
+    ) -> [Entry] {
+      ranked(roster: roster, value: { scores[$0] ?? 0 }, eliminated: eliminated, valueKind: .points)
+    }
+
+    private static func rankedByVotes(
+      roster: [String], votes: [String: Int], eliminated: [String: Bool]
+    ) -> [Entry] {
+      ranked(roster: roster, value: { votes[$0] ?? 0 }, eliminated: eliminated, valueKind: .votes)
+    }
+
+    /// Survivors first, then eliminated — each group deterministically ordered.
+    /// With scores present (Werewolf / score-driven elimination) every row
+    /// shows its score; otherwise eliminated rows show their own elimination
+    /// vote count and survivors show no number.
+    private static func survivalEntries(
+      roster: [String], eliminated: [String: Bool], scores: [String: Int],
+      hasScores: Bool, eliminationVotes: [String: Int]
+    ) -> [Entry] {
+      func isEliminated(_ name: String) -> Bool { eliminated[name] ?? false }
+
+      func order(_ names: [String]) -> [String] {
+        names.sorted { lhs, rhs in
+          let lhsValue = hasScores ? (scores[lhs] ?? 0) : (eliminationVotes[lhs] ?? 0)
+          let rhsValue = hasScores ? (scores[rhs] ?? 0) : (eliminationVotes[rhs] ?? 0)
+          return lhsValue != rhsValue ? lhsValue > rhsValue : lhs < rhs
+        }
+      }
+
+      func makeEntry(_ name: String) -> Entry {
+        if hasScores {
+          return Entry(
+            id: name, name: name, rank: nil, isEliminated: isEliminated(name),
+            primaryValue: scores[name] ?? 0, valueKind: .points)
+        }
+        if isEliminated(name) {
+          let votes = eliminationVotes[name]
+          return Entry(
+            id: name, name: name, rank: nil, isEliminated: true,
+            primaryValue: votes, valueKind: votes != nil ? .votes : .none)
+        }
+        return Entry(
+          id: name, name: name, rank: nil, isEliminated: false,
+          primaryValue: nil, valueKind: .none)
+      }
+
+      let survivors = order(roster.filter { !isEliminated($0) })
+      let eliminatedAgents = order(roster.filter { isEliminated($0) })
+      return (survivors + eliminatedAgents).map(makeEntry)
+    }
+  }
+}

--- a/Pastura/Pastura/Views/Components/SimulationResultCard+Model.swift
+++ b/Pastura/Pastura/Views/Components/SimulationResultCard+Model.swift
@@ -60,9 +60,12 @@ extension SimulationResultCard {
       // key set is the full roster; prefer scores, fall back to eliminated.
       let roster = scores.isEmpty ? Array(eliminated.keys) : Array(scores.keys)
 
-      // 1. Survival — an elimination phase makes "who's left" the outcome, even
-      //    when scores are also present.
-      if phaseTypes.contains(.eliminate) {
+      // 1. Survival — an elimination makes "who's left" the outcome, even when
+      //    scores are also present. OR the ground-truth `eliminated` signal so
+      //    a scenario that nests its eliminate phase inside a `.conditional`
+      //    (the depth-1 rule permits it; `phaseTypes` scans only top-level
+      //    phases) still classifies as survival rather than falling through.
+      if phaseTypes.contains(.eliminate) || eliminated.values.contains(true) {
         guard !roster.isEmpty else { return nil }
         return (
           .survival,

--- a/Pastura/Pastura/Views/Components/SimulationResultCard.swift
+++ b/Pastura/Pastura/Views/Components/SimulationResultCard.swift
@@ -1,0 +1,233 @@
+import SwiftUI
+
+/// Final-ranking "curtain" card shown once at the tail of a completed
+/// simulation log (issue #868).
+///
+/// The mirror image of ``ScenarioIntroCard`` (#853): where the intro card sets
+/// the scene above the first turn, this card resolves the *outcome* below the
+/// last one. Before it, a run's terminal result (scores / vote tallies /
+/// eliminations) rendered as ordinary 9pt-mono log rows — visually
+/// indistinguishable from mid-run chatter. This card gives the outcome its own
+/// elevated container and heavier type so "the result is in" reads at a glance.
+///
+/// Presentation-only by design (ADR-009): it takes an already-resolved
+/// ``Model`` derived from plain value dictionaries, never the Engine/Data
+/// domain types, so the derivation is unit-tested (`SimulationResultCardTests`)
+/// while layout / motion / the tap affordance are code-review + device-QA gated.
+/// The ``Model`` resolver lives in `SimulationResultCard+Model.swift`.
+struct SimulationResultCard: View {
+  /// How the outcome is framed. The resolver classifies every completed run
+  /// into one of these; the seam lets future work diverge the layouts further
+  /// (today `.ranking` and `.pairing` render identically — the eyebrow differs).
+  nonisolated enum Framing: Equatable {
+    /// Score-based leaderboard, or a vote-only "popularity vote".
+    case ranking
+    /// Per-agent scores from a round-robin / prisoner's-dilemma pairing.
+    case pairing
+    /// Vote/elimination outcome — who is left standing is the headline.
+    case survival
+  }
+
+  /// Which number (if any) a row shows next to an agent, so the View renders
+  /// the right unit without re-deriving semantics.
+  nonisolated enum ValueKind: Equatable {
+    case points
+    case votes
+    /// No meaningful number for this row (e.g. a survivor whose last-round
+    /// received-vote count is not comparable across rounds).
+    case none
+  }
+
+  /// One agent's row in the resolved outcome.
+  nonisolated struct Entry: Identifiable, Equatable {
+    /// Agent name — also the identity (agents are unique within a run).
+    let id: String
+    let name: String
+    /// 1-based rank for `.ranking` / `.pairing`; `nil` under `.survival`,
+    /// which groups by survived/eliminated rather than assigning a rank.
+    let rank: Int?
+    let isEliminated: Bool
+    /// The number to show, or `nil` to show none. Paired with ``valueKind``.
+    let primaryValue: Int?
+    let valueKind: ValueKind
+  }
+
+  let model: Model
+
+  /// Whether this run has scores worth a full scoreboard. Drives the
+  /// tap-to-scoreboard affordance (wired by the host in a follow-up): a
+  /// vote-only survival card has all its data on-screen already, so it should
+  /// not offer a "0 pts" scoreboard.
+  var onTap: (() -> Void)?
+
+  var body: some View {
+    let surface = cardSurface
+    if let onTap {
+      Button(action: onTap) { surface }
+        .buttonStyle(.plain)
+        .accessibilityHint(String(localized: "Shows the full scoreboard"))
+    } else {
+      surface
+    }
+  }
+
+  private var cardSurface: some View {
+    PasturaCard {
+      VStack(alignment: .leading, spacing: Spacing.xs) {
+        eyebrow
+        content
+      }
+      .padding(Spacing.m)
+      .frame(maxWidth: .infinity, alignment: .leading)
+    }
+  }
+
+  /// Small framing heading with a leading glyph — orients the viewer that this
+  /// block is the settled outcome, not another agent turn.
+  private var eyebrow: some View {
+    HStack(spacing: Spacing.xxs) {
+      Image(systemName: eyebrowSymbol)
+        .accessibilityHidden(true)
+      Text(eyebrowLabel)
+      if onTap != nil {
+        Spacer(minLength: Spacing.xxs)
+        Image(systemName: "chevron.right")
+          .accessibilityHidden(true)
+      }
+    }
+    .textStyle(Typography.captionName)
+    .foregroundStyle(Color.mossDark)
+  }
+
+  @ViewBuilder private var content: some View {
+    switch model.framing {
+    case .ranking, .pairing:
+      ForEach(model.entries) { rankedRow($0) }
+    case .survival:
+      survivalGroups
+    }
+  }
+
+  private func rankedRow(_ entry: Entry) -> some View {
+    let isWinner = entry.rank == 1
+    return HStack(spacing: Spacing.xs) {
+      if let rank = entry.rank {
+        Text(verbatim: "\(rank)")
+          .textStyle(Typography.bodyBubble)
+          .monospacedDigit()
+          .foregroundStyle(isWinner ? Color.mossInk : Color.muted)
+          .frame(width: 28, alignment: .trailing)
+      }
+      Text(entry.name)
+        // The leader gets the (otherwise unused) heavier completion style so
+        // the eye lands on the winner first.
+        .textStyle(isWinner ? Typography.statusComplete : Typography.bodyBubble)
+        .strikethrough(entry.isEliminated)
+        .foregroundStyle(nameColor(entry, isWinner: isWinner))
+      Spacer(minLength: Spacing.xs)
+      valueText(entry)
+      statusDot(entry)
+    }
+    .accessibilityElement(children: .combine)
+  }
+
+  @ViewBuilder private var survivalGroups: some View {
+    let survivors = model.entries.filter { !$0.isEliminated }
+    let eliminated = model.entries.filter(\.isEliminated)
+    if !survivors.isEmpty {
+      groupHeader(String(localized: "Survived"))
+      ForEach(survivors) { survivalRow($0) }
+    }
+    if !eliminated.isEmpty {
+      groupHeader(String(localized: "Eliminated"))
+      ForEach(eliminated) { survivalRow($0) }
+    }
+  }
+
+  private func survivalRow(_ entry: Entry) -> some View {
+    HStack(spacing: Spacing.xs) {
+      Text(entry.name)
+        .textStyle(Typography.bodyBubble)
+        .strikethrough(entry.isEliminated)
+        .foregroundStyle(entry.isEliminated ? Color.muted : Color.ink)
+      Spacer(minLength: Spacing.xs)
+      valueText(entry)
+      statusDot(entry)
+    }
+    .accessibilityElement(children: .combine)
+  }
+
+  private func groupHeader(_ text: String) -> some View {
+    Text(text)
+      .textStyle(Typography.captionName)
+      .foregroundStyle(Color.muted)
+      .padding(.top, Spacing.xxs)
+  }
+
+  @ViewBuilder private func valueText(_ entry: Entry) -> some View {
+    if let value = entry.primaryValue, entry.valueKind != .none {
+      Text(formattedValue(value, kind: entry.valueKind))
+        .textStyle(Typography.bodyBubble)
+        .monospacedDigit()
+        .foregroundStyle(entry.isEliminated ? Color.muted : Color.inkSecondary)
+    }
+  }
+
+  private func statusDot(_ entry: Entry) -> some View {
+    Image(systemName: entry.isEliminated ? "xmark.circle.fill" : "circle.fill")
+      .font(.caption)
+      .foregroundStyle(entry.isEliminated ? Color.inkSecondary : Color.moss)
+      .accessibilityHidden(true)
+  }
+
+  private func nameColor(_ entry: Entry, isWinner: Bool) -> Color {
+    if entry.isEliminated { return Color.muted }
+    return isWinner ? Color.mossInk : Color.ink
+  }
+
+  private func formattedValue(_ value: Int, kind: ValueKind) -> String {
+    switch kind {
+    case .points: String(format: String(localized: "%lld pts"), value)
+    case .votes: String(format: String(localized: "%lld votes"), value)
+    case .none: ""
+    }
+  }
+
+  private var eyebrowSymbol: String {
+    switch model.framing {
+    case .ranking, .pairing: "trophy"
+    case .survival: "flag.checkered"
+    }
+  }
+
+  private var eyebrowLabel: String {
+    switch model.framing {
+    case .ranking: String(localized: "Final ranking")
+    case .pairing: String(localized: "Final scores")
+    case .survival: String(localized: "Outcome")
+    }
+  }
+}
+
+#Preview("Result card — ranking / survival") {
+  ScrollView {
+    VStack(spacing: 12) {
+      if let model = SimulationResultCard.Model(
+        scores: ["Alice": 12, "Bob": 8, "Carol": 5],
+        eliminated: ["Carol": true], voteResults: [:], eliminationVotes: [:],
+        phases: [Phase(type: .scoreCalc, logic: .voteTally)]) {
+        SimulationResultCard(model: model, onTap: {})
+      }
+      if let model = SimulationResultCard.Model(
+        scores: ["Alice": 0, "Bob": 0, "Carol": 0],
+        eliminated: ["Carol": true], voteResults: ["Carol": 4],
+        eliminationVotes: ["Carol": 4],
+        phases: [Phase(type: .vote), Phase(type: .eliminate)]) {
+        SimulationResultCard(model: model)
+      }
+    }
+    .padding(.horizontal, 20)
+    .padding(.vertical, 8)
+  }
+  .background(Color.screenBackground)
+}

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -764,10 +764,10 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
   }
 
   /// The resolved closing-card outcome, or `nil` when the run has nothing worth
-  /// showing (summary-only). Derived fresh from the VM's result state each
-  /// evaluation — the derivation is pure and cheap; the `resultCardVisible`
-  /// gate (not this) controls *when* it renders (#868). Takes the unwrapped
-  /// `viewModel` (the struct-level `@State` is optional).
+  /// showing (summary-only). The insertion condition short-circuits on
+  /// `resultCardVisible` first, so this runs only post-completion (not on every
+  /// streaming re-eval); the derivation is pure and O(roster) besides. Takes
+  /// the unwrapped `viewModel` (the struct-level `@State` is optional). (#868)
   private func resultModel(viewModel: SimulationViewModel) -> SimulationResultCard.Model? {
     SimulationResultCard.Model(
       scores: viewModel.scores,

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -60,6 +60,11 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
   /// (e.g. scrolling back to the top) instead of re-typing — set at reveal
   /// start so an interrupted reveal still latches.
   @State private var introHasTyped = false
+  /// Drives the final-ranking card's animated insertion at run completion
+  /// (#868). Mirrors `viewModel.isCompleted`, but flipped inside `withAnimation`
+  /// so the card fades/slides in — `isCompleted` is set on the VM outside any
+  /// animation transaction, so gating the card on it directly would pop it in.
+  @State private var resultCardVisible = false
   @State private var loadError: String?
   @State private var exportPayload: ResultMarkdownExporter.ExportedResult?
   @State private var exportError: String?
@@ -554,6 +559,25 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
               }
             }
 
+            // Closing card: the settled outcome (final ranking / survival /
+            // scores), shown once at completion so the result reads as the
+            // terminal payoff instead of another 9pt-mono log row (#868).
+            // Mirror of the opening card — a fixed trailing element, NOT a
+            // logEntry, so it never dims under the current-utterance focus.
+            // `resultCardVisible` is the timing gate (animated at completion);
+            // `resultModel != nil` is the content gate (nil = summary-only run,
+            // no card). Tap opens the full scoreboard only when real scores
+            // exist — a vote-only outcome shows everything inline and a
+            // scoreboard would render misleading "0 pts" rows.
+            if resultCardVisible, let resultModel = resultModel(viewModel: viewModel) {
+              SimulationResultCard(
+                model: resultModel,
+                onTap: hasRankableScores(viewModel: viewModel)
+                  ? { showScoreboard = true } : nil
+              )
+              .transition(.opacity.combined(with: .move(edge: .bottom)))
+            }
+
             // Bottom sentinel: scrollTo target that stays below every other
             // section (log entries, thinking indicators). Scrolling here
             // reliably reveals whatever just appeared last — anchoring to
@@ -572,6 +596,18 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
         }
         .onChange(of: viewModel.logEntries.count) { _, _ in
           scrollToBottom(proxy)
+        }
+        .onChange(of: viewModel.isCompleted) { _, done in
+          // The no-drift completion path appends no logEntry (the count-driven
+          // scroll above never fires), so drive the closing card's animated
+          // reveal + a scroll here (#868).
+          withAnimation(.easeOut(duration: 0.35)) { resultCardVisible = done }
+          if done { scrollToBottom(proxy) }
+        }
+        .onAppear {
+          // Mounting onto an already-completed run (no isCompleted transition
+          // to observe) — show the card without the entrance animation.
+          if viewModel.isCompleted { resultCardVisible = true }
         }
         .onChange(of: viewModel.thinkingAgents) { _, _ in
           // New or cleared thinking agent — when the sentinel is currently
@@ -725,6 +761,27 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
   /// scenario name, so the card would only restate it.
   private var introModel: ScenarioIntroCard.Model? {
     ScenarioIntroCard.Model(title: nil, premise: scenario?.description ?? "")
+  }
+
+  /// The resolved closing-card outcome, or `nil` when the run has nothing worth
+  /// showing (summary-only). Derived fresh from the VM's result state each
+  /// evaluation — the derivation is pure and cheap; the `resultCardVisible`
+  /// gate (not this) controls *when* it renders (#868). Takes the unwrapped
+  /// `viewModel` (the struct-level `@State` is optional).
+  private func resultModel(viewModel: SimulationViewModel) -> SimulationResultCard.Model? {
+    SimulationResultCard.Model(
+      scores: viewModel.scores,
+      eliminated: viewModel.eliminated,
+      voteResults: viewModel.voteResults,
+      eliminationVotes: viewModel.eliminationVotes,
+      phases: scenario?.phases ?? [])
+  }
+
+  /// Whether any real score exists — gates the closing card's tap-to-scoreboard
+  /// affordance (the `ScoreboardSheet` is score-centric; a vote-only outcome
+  /// would render misleading all-zero rows).
+  private func hasRankableScores(viewModel: SimulationViewModel) -> Bool {
+    viewModel.scores.values.contains { $0 != 0 }
   }
 
   /// `true` for the resume entry (a paused run being reopened). The opening card

--- a/Pastura/PasturaTests/App/SimulationViewModelResultStateTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelResultStateTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+/// Unit coverage for the result-state accumulators consumed by the
+/// final-ranking card (issue #868):
+///
+/// - ``SimulationViewModel/eliminationVotes`` — per-agent vote count captured
+///   at the moment each agent was eliminated (round-correct, unlike a
+///   last-wins tally which drops earlier-round participants).
+/// - ``SimulationViewModel/voteResults`` — the latest vote-phase tallies,
+///   used to rank a vote-only ("popularity vote") scenario that eliminates
+///   nobody.
+///
+/// The card's own display derivation is tested separately in
+/// `SimulationResultCardTests`; these tests only pin that the VM feeds it the
+/// right raw data.
+@Suite(.serialized, .timeLimit(.minutes(1))) @MainActor
+struct SimulationViewModelResultStateTests {
+  private func makeModel() throws -> (SimulationViewModel, Scenario) {
+    let db = try DatabaseManager.inMemory()
+    let simRepo = GRDBSimulationRepository(dbWriter: db.dbWriter)
+    let turnRepo = GRDBTurnRepository(dbWriter: db.dbWriter)
+    let codeRepo = GRDBCodePhaseEventRepository(dbWriter: db.dbWriter)
+    let model = SimulationViewModel(
+      simulationRepository: simRepo,
+      turnRepository: turnRepo,
+      codePhaseEventRepository: codeRepo)
+    let scenario = makeTestScenario(agentNames: ["Alice", "Bob", "Carol"], rounds: 1)
+    return (model, scenario)
+  }
+
+  @Test("Elimination events capture each agent's own vote count")
+  func eliminationVotesCaptured() throws {
+    let (model, scenario) = try makeModel()
+    model.handleEvent(.elimination(agent: "Bob", voteCount: 3), scenario: scenario)
+    model.handleEvent(.elimination(agent: "Carol", voteCount: 2), scenario: scenario)
+    #expect(model.eliminationVotes["Bob"] == 3)
+    #expect(model.eliminationVotes["Carol"] == 2)
+    #expect(model.eliminationVotes["Alice"] == nil)
+  }
+
+  @Test("A multi-round elimination retains each agent's own round count")
+  func multiRoundEliminationVotesRetained() throws {
+    // Bob eliminated first (2 votes), Carol later (4 votes). Bob's count must
+    // survive the later elimination — a last-wins vote tally would drop the
+    // earlier-round participant, leaving Bob's survival row without a number.
+    let (model, scenario) = try makeModel()
+    model.handleEvent(.elimination(agent: "Bob", voteCount: 2), scenario: scenario)
+    model.handleEvent(.elimination(agent: "Carol", voteCount: 4), scenario: scenario)
+    #expect(model.eliminationVotes["Bob"] == 2)
+    #expect(model.eliminationVotes["Carol"] == 4)
+  }
+
+  @Test("voteResults reflects the latest vote-phase tallies (last-wins)")
+  func voteResultsLastWins() throws {
+    let (model, scenario) = try makeModel()
+    model.handleEvent(
+      .voteResults(votes: ["Alice": "Bob"], tallies: ["Bob": 1]), scenario: scenario)
+    model.handleEvent(
+      .voteResults(votes: ["Alice": "Carol", "Bob": "Carol"], tallies: ["Carol": 2]),
+      scenario: scenario)
+    #expect(model.voteResults == ["Carol": 2])
+  }
+}

--- a/Pastura/PasturaTests/Views/SimulationResultCardTests.swift
+++ b/Pastura/PasturaTests/Views/SimulationResultCardTests.swift
@@ -131,6 +131,23 @@ struct SimulationResultCardTests {
     #expect(survivors == ["Alice", "Carol"])
   }
 
+  @Test("An elimination not surfaced by a top-level phase still classifies as survival")
+  func eliminationNestedUnderConditional() {
+    // The eliminate phase can be nested inside a `.conditional` (depth-1 rule),
+    // so `phaseTypes` — which scans only top-level phases — would miss it. The
+    // ground-truth `eliminated` dict must still drive survival framing.
+    let model = SimulationResultCard.Model(
+      scores: ["Alice": 0, "Bob": 0, "Carol": 0],
+      eliminated: ["Carol": true],
+      voteResults: [:],
+      eliminationVotes: ["Carol": 3],
+      phases: [Phase(type: .conditional)])
+    #expect(model?.framing == .survival)
+    let carol = model?.entries.first { $0.name == "Carol" }
+    #expect(carol?.isEliminated == true)
+    #expect(carol?.primaryValue == 3)
+  }
+
   // MARK: - Vote-only ranking (popularity vote, eliminates nobody)
 
   @Test("Vote-only scenario ranks by votes and is NOT mislabeled as survival")

--- a/Pastura/PasturaTests/Views/SimulationResultCardTests.swift
+++ b/Pastura/PasturaTests/Views/SimulationResultCardTests.swift
@@ -1,0 +1,187 @@
+import Testing
+
+@testable import Pastura
+
+/// Pure-logic coverage for ``SimulationResultCard/Model`` — the final-ranking
+/// card's display resolver shown at the tail of a completed simulation log
+/// (issue #868).
+///
+/// Per ADR-009 / `.claude/rules/view-testing.md` rule 1, only the model's
+/// derivation (framing classification, ordering, per-row value selection) is
+/// unit-tested; the card's layout / motion / tap affordance is left to code
+/// review + manual device QA (rule 4).
+///
+/// The classification is **survival-primary**: an `.eliminate` phase makes
+/// "who is left standing" the headline even when scores are also present
+/// (Werewolf), per the product decision on #868. `scores` is seeded with every
+/// persona at `0` at run start, so "are there scores worth ranking" is decided
+/// by *any non-zero* value (`hasScores`), never `!scores.isEmpty`.
+@Suite(.timeLimit(.minutes(1)))
+struct SimulationResultCardTests {
+  // MARK: - Ranking (score-based)
+
+  @Test("Score-based scenario ranks by score descending with 1-based ranks")
+  func scoreRankingByScoreDesc() {
+    let model = SimulationResultCard.Model(
+      scores: ["Alice": 5, "Bob": 12, "Carol": 8],
+      eliminated: [:],
+      voteResults: [:],
+      eliminationVotes: [:],
+      phases: [Phase(type: .scoreCalc, logic: .voteTally)])
+    #expect(model?.framing == .ranking)
+    #expect(model?.entries.map(\.name) == ["Bob", "Carol", "Alice"])
+    #expect(model?.entries.map(\.rank) == [1, 2, 3])
+    #expect(model?.entries.first?.primaryValue == 12)
+    #expect(model?.entries.allSatisfy { $0.valueKind == .points } == true)
+  }
+
+  @Test("A top-score tie orders deterministically by name so the winner is stable")
+  func topScoreTieDeterministic() {
+    let model = SimulationResultCard.Model(
+      scores: ["Bob": 10, "Alice": 10, "Carol": 3],
+      eliminated: [:],
+      voteResults: [:],
+      eliminationVotes: [:],
+      phases: [Phase(type: .scoreCalc, logic: .voteTally)])
+    // Alice < Bob lexically → Alice takes rank 1 regardless of dictionary order.
+    #expect(model?.entries.map(\.name) == ["Alice", "Bob", "Carol"])
+    #expect(model?.entries.map(\.rank) == [1, 2, 3])
+  }
+
+  // MARK: - Survival (vote + eliminate)
+
+  @Test("Vote+eliminate lists survivors first, then eliminated with their votes")
+  func survivalSingleRound() {
+    let model = SimulationResultCard.Model(
+      scores: ["Alice": 0, "Bob": 0, "Carol": 0],
+      eliminated: ["Carol": true],
+      voteResults: ["Carol": 4],
+      eliminationVotes: ["Carol": 4],
+      phases: [Phase(type: .vote), Phase(type: .eliminate)])
+    #expect(model?.framing == .survival)
+    // Survivors (not eliminated) come first, eliminated last.
+    #expect(model?.entries.map(\.isEliminated) == [false, false, true])
+    #expect(model?.entries.allSatisfy { $0.rank == nil } == true)
+    let carol = model?.entries.first { $0.name == "Carol" }
+    #expect(carol?.primaryValue == 4)
+    #expect(carol?.valueKind == .votes)
+    // Survivors carry no vote number (last-round received votes are not
+    // meaningful across rounds).
+    let alice = model?.entries.first { $0.name == "Alice" }
+    #expect(alice?.primaryValue == nil)
+    // Qualify the enum case: a bare `.none` against an Optional binds to
+    // `Optional.none` (nil), not `ValueKind.none`.
+    #expect(alice?.valueKind == SimulationResultCard.ValueKind.none)
+  }
+
+  @Test("Multi-round survival shows each eliminated agent's own round count")
+  func survivalMultiRound() {
+    // Bob eliminated round 1 (2 votes), Dave round 2 (5 votes). Both counts
+    // come from eliminationVotes, not a last-wins tally.
+    let model = SimulationResultCard.Model(
+      scores: ["Alice": 0, "Bob": 0, "Carol": 0, "Dave": 0],
+      eliminated: ["Bob": true, "Dave": true],
+      voteResults: ["Dave": 5],
+      eliminationVotes: ["Bob": 2, "Dave": 5],
+      phases: [Phase(type: .vote), Phase(type: .eliminate)])
+    #expect(model?.framing == .survival)
+    let bob = model?.entries.first { $0.name == "Bob" }
+    let dave = model?.entries.first { $0.name == "Dave" }
+    #expect(bob?.primaryValue == 2)
+    #expect(dave?.primaryValue == 5)
+    // Eliminated group ordered by votes desc: Dave (5) before Bob (2).
+    let eliminatedNames = model?.entries.filter(\.isEliminated).map(\.name)
+    #expect(eliminatedNames == ["Dave", "Bob"])
+  }
+
+  @Test("Werewolf (eliminate + scores) uses survival framing but shows scores")
+  func werewolfSurvivalShowsScores() {
+    let model = SimulationResultCard.Model(
+      scores: ["Alice": 3, "Bob": 3, "Carol": 0],
+      eliminated: ["Carol": true],
+      voteResults: ["Carol": 3],
+      eliminationVotes: ["Carol": 3],
+      phases: [
+        Phase(type: .vote), Phase(type: .eliminate),
+        Phase(type: .scoreCalc, logic: .wordwolfJudge)
+      ])
+    #expect(model?.framing == .survival)
+    // Scores are present → every row shows points, not votes (Werewolf keeps
+    // the score visible even under survival framing).
+    #expect(model?.entries.allSatisfy { $0.valueKind == .points } == true)
+    let carol = model?.entries.first { $0.name == "Carol" }
+    #expect(carol?.primaryValue == 0)
+    #expect(carol?.isEliminated == true)
+  }
+
+  @Test("Score-driven elimination (no vote phase) still classifies as survival")
+  func scoreDrivenElimination() {
+    let model = SimulationResultCard.Model(
+      scores: ["Alice": 8, "Bob": 2, "Carol": 5],
+      eliminated: ["Bob": true],
+      voteResults: [:],
+      eliminationVotes: [:],
+      phases: [Phase(type: .scoreCalc, logic: .voteTally), Phase(type: .eliminate)])
+    #expect(model?.framing == .survival)
+    // Scores present → points shown; deterministic order within groups.
+    #expect(model?.entries.allSatisfy { $0.valueKind == .points } == true)
+    #expect(model?.entries.map(\.isEliminated) == [false, false, true])
+    // Survivors ordered by score desc: Alice (8) before Carol (5).
+    let survivors = model?.entries.filter { !$0.isEliminated }.map(\.name)
+    #expect(survivors == ["Alice", "Carol"])
+  }
+
+  // MARK: - Vote-only ranking (popularity vote, eliminates nobody)
+
+  @Test("Vote-only scenario ranks by votes and is NOT mislabeled as survival")
+  func voteOnlyRanking() {
+    let model = SimulationResultCard.Model(
+      scores: ["Alice": 0, "Bob": 0, "Carol": 0],
+      eliminated: [:],
+      voteResults: ["Alice": 3, "Bob": 1, "Carol": 2],
+      eliminationVotes: [:],
+      phases: [Phase(type: .vote)])
+    #expect(model?.framing == .ranking)
+    #expect(model?.entries.map(\.name) == ["Alice", "Carol", "Bob"])
+    #expect(model?.entries.map(\.rank) == [1, 2, 3])
+    #expect(model?.entries.allSatisfy { $0.valueKind == .votes } == true)
+  }
+
+  // MARK: - Pairing
+
+  @Test("Round-robin choose classifies as pairing framing with points")
+  func pairingRoundRobin() {
+    let model = SimulationResultCard.Model(
+      scores: ["Alice": 6, "Bob": 5],
+      eliminated: [:],
+      voteResults: [:],
+      eliminationVotes: [:],
+      phases: [
+        Phase(type: .choose, pairing: .roundRobin),
+        Phase(type: .scoreCalc, logic: .prisonersDilemma)
+      ])
+    #expect(model?.framing == .pairing)
+    #expect(model?.entries.map(\.name) == ["Alice", "Bob"])
+    #expect(model?.entries.allSatisfy { $0.valueKind == .points } == true)
+  }
+
+  // MARK: - Nil (no card)
+
+  @Test("A summary-only run with no scores/votes/eliminations yields nil")
+  func summaryOnlyYieldsNil() {
+    let model = SimulationResultCard.Model(
+      scores: ["Alice": 0, "Bob": 0],
+      eliminated: [:],
+      voteResults: [:],
+      eliminationVotes: [:],
+      phases: [Phase(type: .speakAll), Phase(type: .summarize)])
+    #expect(model == nil)
+  }
+
+  @Test("A fully empty state yields nil")
+  func emptyStateYieldsNil() {
+    let model = SimulationResultCard.Model(
+      scores: [:], eliminated: [:], voteResults: [:], eliminationVotes: [:], phases: [])
+    #expect(model == nil)
+  }
+}


### PR DESCRIPTION
## Summary
シミュレーション完了時、ログ末尾に「最終ランキングカード」を1種追加。結果（投票/票数/脱落/スコア）が 9pt mono の低視覚重量で途中経過と区別できない課題を解消する（入口カード #853 のミラーとなる PR2）。

- **純ロジック resolver**（`SimulationResultCard.Model`, nonisolated sibling, ユニットテスト）が種別を ranking / pairing / survival に分類。survival-primary（eliminate があれば「誰が残ったか」が主、Werewolf はスコアも表示）。
- `scores` は run 開始時に全0で seed されるため、判定は「非0が存在するか」で行う（`!scores.isEmpty` ではない）。
- 脱落なし人気投票は票でランキング（survival と誤ラベルしない）。同点は name 二次キーで決定的（勝者見出しが起動毎に安定）。
- ground-truth の `eliminated` も OR し、`.conditional` にネストした eliminate でも survival 分類。
- VM に `voteResults` / `eliminationVotes`（脱落時票数=ラウンド正しい）を追加。resume 時は checkpoint + 再生ログから再構築。
- カードは PasturaCard + moss eyebrow + 未使用の `statusComplete` で勝者強調、脱落は打ち消し線、出現 transition。`scores` がある時のみタップで既存 ScoreboardSheet。

## Test plan
- `SimulationResultCardTests`（resolver 11 ケース: 各 framing / Werewolf / スコア駆動脱落 / 多ラウンド票数保持 / 脱落 conditional ネスト / vote-only / トップタイ / nil）
- `SimulationViewModelResultStateTests`（VM アキュムレータ populate / last-wins / 多ラウンド保持）
- 全ユニットスイート 2429 passed / swiftlint --strict clean
- **要 device-QA**（ADR-009）: カードの見た目・出現アニメ・survival グループ表示・タップ→スコアボード

Closes #868

🤖 Generated with [Claude Code](https://claude.com/claude-code)