### PR TITLE
✨ feat: デモ再生画面にオープニングカード（ScenarioIntroCard 再利用）

### DIFF
--- a/Pastura/Pastura/App/ReplayViewModel.swift
+++ b/Pastura/Pastura/App/ReplayViewModel.swift
@@ -199,6 +199,11 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
   /// - On `.stopAfterLast` terminal (both `.awaitTransitionSignal` and
   ///   `.stopPlayback`), `chatItems` is left untouched — the last source's
   ///   bubbles remain on screen through the hold/idle state.
+  ///
+  /// At each segment's head (`start()` and every rotation, after any boundary
+  /// marker / wrap wipe), a ``ChatItem/scenarioIntro`` opening card is appended
+  /// when the source's premise is non-empty (#867) — see
+  /// ``appendIntroCard(forSourceIndex:)``.
   private(set) var chatItems: [ChatItem] = []
 
   /// Derived projection over ``chatItems`` exposing only agent outputs.
@@ -263,9 +268,16 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
     }
   }
 
-  /// Heterogeneous chat-stream item — either an agent's rendered output
-  /// or a demo-boundary marker inserted between sources during rotation
-  /// (#208). Used by the host view's `ForEach` to dispatch on case.
+  /// Heterogeneous chat-stream item — an agent's rendered output, a
+  /// demo-boundary marker inserted between sources during rotation (#208),
+  /// or a scenario-intro opening card at each segment's head (#867). Used by
+  /// the host view's `ForEach` to dispatch on case.
+  ///
+  /// `.scenarioIntro` carries the source's premise (`scenario.description`) as
+  /// a plain string — the host feeds it to the presentation-only
+  /// ``ScenarioIntroCard`` (no domain type crosses into the View). It rides
+  /// the same accumulate-across-rotation timeline as `.agentOutput` /
+  /// `.demoBoundary`; on rotation the order is boundary → intro card.
   ///
   /// `id` is projected from the inner payload so SwiftUI's
   /// `ForEach`/`scrollTo(_:anchor:)` keep working identically to the
@@ -273,11 +285,13 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
   nonisolated enum ChatItem: Sendable, Equatable, Identifiable {
     case agentOutput(AgentOutputEntry)
     case demoBoundary(id: UUID, scenarioName: String)
+    case scenarioIntro(id: UUID, premise: String)
 
     var id: UUID {
       switch self {
       case .agentOutput(let entry): return entry.id
       case .demoBoundary(let id, _): return id
+      case .scenarioIntro(let id, _): return id
       }
     }
   }
@@ -440,6 +454,7 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
     guard !sources.isEmpty else { return }
     let startIndex = 0
     chatItems = []
+    appendIntroCard(forSourceIndex: startIndex)
     resetPerDemoState(forSourceIndex: startIndex)
     state = .playing(sourceIndex: startIndex, eventCursor: 0)
     launchPlayback(sourceIndex: startIndex, startCursor: 0, firstSleepOverrideMs: nil)
@@ -618,13 +633,23 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
     var cursor = startCursor
     var overrideMs = firstSleepOverrideMs
     // Typing-dwell floor owed by the previously-applied agent bubble (raw,
-    // pre-speed). A LOCAL var — seeded 0 on each `playSource` entry — so it
+    // pre-speed). A LOCAL var — seeded on each `playSource` entry — so it
     // never leaks across a source rotation (`advanceAfterSource` re-enters
     // with a fresh call) or a resume-from-background restart (which supplies
     // `firstSleepOverrideMs`). The resume override bypasses the floor for the
     // single restarted event, which is correct: its remaining sleep was
     // already computed with the floor folded in before backgrounding.
-    var pendingFloorMs = 0
+    //
+    // On a FRESH source entry (not a resume — resume passes
+    // `firstSleepOverrideMs` and never re-types the already-revealed card) the
+    // segment opens with a ``ScenarioIntroCard`` appended by `start()` /
+    // `advanceAfterSource`. Seed the floor with the card's reveal time so the
+    // first event's pre-yield delay covers the premise typing out — the demo's
+    // substitute for the live Sim's `introRevealDidComplete()` conversation
+    // gate (the demo is time-driven, with no LLM to gate).
+    var pendingFloorMs =
+      (firstSleepOverrideMs == nil && startCursor == 0)
+      ? introFloorMs(forSourceIndex: sourceIndex, script: script) : 0
     while cursor < plan.count {
       if Task.isCancelled { return }
       let paced = plan[cursor]
@@ -698,6 +723,10 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
             id: UUID(),
             scenarioName: sources[nextIndex].scenario.name))
       }
+      // Intro card at the new segment's head, AFTER the boundary append / wrap
+      // wipe (order is always boundary → intro card) and before
+      // `resetPerDemoState`.
+      appendIntroCard(forSourceIndex: nextIndex)
       resetPerDemoState(forSourceIndex: nextIndex)
       if case .playing = state {
         state = .playing(sourceIndex: nextIndex, eventCursor: 0)
@@ -713,6 +742,7 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
         .demoBoundary(
           id: UUID(),
           scenarioName: sources[nextIndex].scenario.name))
+      appendIntroCard(forSourceIndex: nextIndex)
       resetPerDemoState(forSourceIndex: nextIndex)
       if case .playing = state {
         state = .playing(sourceIndex: nextIndex, eventCursor: 0)
@@ -766,6 +796,45 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
       if case .phaseStarted = paced.event { return true }
       return false
     }.count
+  }
+
+  // MARK: - Opening card (scenario intro)
+
+  /// Verbatim premise for the source's opening ``ScenarioIntroCard``, or `nil`
+  /// when it has no visible content.
+  ///
+  /// The emptiness predicate is byte-identical to
+  /// ``ScenarioIntroCard/Model/init(title:premise:)`` — trim whitespace for
+  /// the *check* but return the description **verbatim** (demo descriptions
+  /// carry stray internal spaces that must not be mutated, and the pacing
+  /// floor counts `premise.count`). Sharing this one predicate between the
+  /// card's visibility (``appendIntroCard(forSourceIndex:)``) and its pacing
+  /// reservation (``introFloorMs(forSourceIndex:script:)``) is what prevents
+  /// the two from drifting — a whitespace-only description yields no card AND
+  /// no phantom pre-first-bubble delay.
+  ///
+  /// premise = the SHA-verified bundled preset's `scenario.description`
+  /// (equivalent to the demo YAML `metadata.description` by the drift guard;
+  /// `scenario.name` is likewise already reused by the demo-boundary marker),
+  /// so there is no YAML-metadata re-parse.
+  private func introPremise(forSourceIndex sourceIndex: Int) -> String? {
+    let description = sources[sourceIndex].scenario.description
+    guard !description.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    else { return nil }
+    return description
+  }
+
+  /// Appends a ``ChatItem/scenarioIntro`` opening card for the source at
+  /// `sourceIndex`, or does nothing when the premise has no visible content
+  /// (see ``introPremise(forSourceIndex:)``) — so no empty card enters the
+  /// stream, mirroring the card's own `Model.init?` guard.
+  ///
+  /// Called at each segment's head: `start()` (source 0) and every
+  /// ``advanceAfterSource(currentIndex:)`` rotation (after the demo-boundary
+  /// append / wrap wipe, so the on-screen order is boundary → intro card).
+  private func appendIntroCard(forSourceIndex sourceIndex: Int) {
+    guard let premise = introPremise(forSourceIndex: sourceIndex) else { return }
+    chatItems.append(.scenarioIntro(id: UUID(), premise: premise))
   }
 
   // MARK: - Render-time state updates
@@ -875,6 +944,36 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
     let dwellMs = Self.milliseconds(
       playbackSpeed.readingDwell(
         displayLength: segments.primary.count, script: script))
+    return typing + dwellMs
+  }
+
+  /// Reveal-time floor (raw ms, real wall-clock at the current speed) that the
+  /// FIRST inter-event delay of a source must cover so its opening
+  /// ``ScenarioIntroCard`` types its premise — and is held for a reading beat —
+  /// before the source's first agent turn appears. Seeded into `pendingFloorMs`
+  /// on fresh source entry in
+  /// ``playSource(sourceIndex:startCursor:firstSleepOverrideMs:)``; this pacing
+  /// floor is the demo's substitute for the live Sim's conversation gate
+  /// (`introRevealDidComplete()`), which has no analogue in a time-driven replay.
+  ///
+  /// Structure mirrors ``typingFloorMs(for:script:)`` — `typing + readingDwell`,
+  /// both at the speed-scaled ``typingCharsPerSecond`` the card actually animates
+  /// at, so the floor is already real time and ``scaledDelay(for:floorMs:)`` must
+  /// NOT divide it again. Returns 0 when there is no card to reveal (trimmed-empty
+  /// premise — same ``introPremise(forSourceIndex:)`` predicate the card's
+  /// visibility uses, so a hidden card never leaves a phantom delay) or no
+  /// proportional typing (opt-out config / `.instant` → nil cps). The intro card
+  /// has no thought segment, so `thought` is empty and `displayLength` is the
+  /// whole premise grapheme count.
+  ///
+  /// `internal` (not `private`) so `ReplayViewModelTests+Pacing` can exercise it.
+  func introFloorMs(forSourceIndex sourceIndex: Int, script: ReadingScript) -> Int {
+    guard let premise = introPremise(forSourceIndex: sourceIndex) else { return 0 }
+    guard let cps = typingCharsPerSecond else { return 0 }
+    let typing = typingDurationMs(primary: premise, thought: "", charsPerSecond: cps)
+    guard typing > 0 else { return 0 }
+    let dwellMs = Self.milliseconds(
+      playbackSpeed.readingDwell(displayLength: premise.count, script: script))
     return typing + dwellMs
   }
 

--- a/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+ChatStream.swift
+++ b/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+ChatStream.swift
@@ -127,6 +127,9 @@ extension ModelDownloadHostView {
   private func demoIntroCard(
     id: UUID, premise: String, viewModel: ReplayViewModel
   ) -> some View {
+    // Defensive re-guard: `appendIntroCard` already filtered empty premises
+    // with the identical predicate, so `Model.init?` never returns nil for an
+    // appended item — this `if let` is never the empty path in practice.
     if let model = ScenarioIntroCard.Model(title: nil, premise: premise) {
       ScenarioIntroCard(
         model: model,

--- a/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+ChatStream.swift
+++ b/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+ChatStream.swift
@@ -31,6 +31,8 @@ extension ModelDownloadHostView {
                 DemoBoundaryRow(scenarioName: scenarioName)
                   .id(id)
                   .transition(reduceMotion ? .identity : .opacity)
+              case .scenarioIntro(let id, let premise):
+                demoIntroCard(id: id, premise: premise, viewModel: viewModel)
               }
             }
           }
@@ -106,6 +108,35 @@ extension ModelDownloadHostView {
     )
     .id(entry.id)
     .transition(reduceMotion ? .identity : .opacity)
+  }
+
+  /// One opening card (``ScenarioIntroCard``) at a demo segment's head (#867),
+  /// reusing the live Sim's presentation-only component. `title` is `nil` — the
+  /// ``GameHeader`` already names the current demo, matching the Sim's rationale.
+  ///
+  /// The premise types at the playback-scaled ``ReplayViewModel/typingCharsPerSecond``
+  /// (the same source ``demoAgentRow`` uses), unless this card has already typed
+  /// (``typedIntroIds``) — then it renders statically so a scroll-back in the
+  /// `LazyVStack` doesn't re-type. There is deliberately **no** `onRevealComplete`
+  /// gate: the demo is time-driven, so the first turn is held back by
+  /// ``ReplayViewModel/introFloorMs(forSourceIndex:script:)`` rather than a
+  /// reveal-completion callback (the live Sim's conversation-gate has no analogue
+  /// here). `leadIn` is `.zero` — on rotation the `DemoBoundaryRow` already
+  /// supplies the transition beat.
+  @ViewBuilder
+  private func demoIntroCard(
+    id: UUID, premise: String, viewModel: ReplayViewModel
+  ) -> some View {
+    if let model = ScenarioIntroCard.Model(title: nil, premise: premise) {
+      ScenarioIntroCard(
+        model: model,
+        charsPerSecond: typedIntroIds.contains(id) ? nil : viewModel.typingCharsPerSecond,
+        leadIn: .zero,
+        onRevealStarted: { typedIntroIds.insert(id) }
+      )
+      .id(id)
+      .transition(reduceMotion ? .identity : .opacity)
+    }
   }
 
   /// PromoCard lives in the bottom safe area (not a ZStack overlay) so the

--- a/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView.swift
+++ b/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView.swift
@@ -90,6 +90,16 @@ struct ModelDownloadHostView: View {
   // Internal (not `private`) so `+ChatStream.swift`'s `agentPosition`
   // / `promoCardInset` and `currentPresetName` can read it.
   @State var sources: [any ReplaySource] = []
+  // Type-once latch for opening cards (#867), keyed by `ChatItem.scenarioIntro`
+  // id. Generalizes the live Sim's single `introHasTyped` Bool to the demo's
+  // many cards (one per rotated segment): the card lives in a `LazyVStack`, so
+  // scrolling an already-typed card back into view must render it statically
+  // (`charsPerSecond: nil`) instead of re-typing. Internal (not `private`) so
+  // the sibling `+ChatStream.swift` extension can read/insert. Never cleared —
+  // on `.loop` wrap `chatItems` is wiped and each re-shown card gets a fresh
+  // UUID (so it re-reveals, intended), leaving only stale UUIDs here; the
+  // ~16 B/entry growth over a download's lifetime is negligible.
+  @State var typedIntroIds: Set<UUID> = []
   @State private var isShowingCancelConfirmation: Bool = false
   // Thought-visibility (`▸ THINKING` expanded) now lives on `ReplayViewModel`
   // (`showAllThoughts`) so the pacing floor can read it; the control bar binds

--- a/Pastura/PasturaTests/App/ReplayViewModelTests+Intro.swift
+++ b/Pastura/PasturaTests/App/ReplayViewModelTests+Intro.swift
@@ -155,6 +155,13 @@ extension ReplayViewModelTests {
       return
     }
     // The item immediately after the boundary is source 1's opening card.
+    // Bounds-guard the subscript so a regressed invariant records a clear
+    // failure instead of crashing the suite.
+    guard boundaryIndex + 1 < viewModel.chatItems.count else {
+      Issue.record(
+        "No item after the boundary at \(boundaryIndex); chatItems: \(viewModel.chatItems)")
+      return
+    }
     let afterBoundary = viewModel.chatItems[boundaryIndex + 1]
     guard case .scenarioIntro(_, let premise) = afterBoundary else {
       Issue.record("chatItems after boundary expected .scenarioIntro, got \(afterBoundary)")

--- a/Pastura/PasturaTests/App/ReplayViewModelTests+Intro.swift
+++ b/Pastura/PasturaTests/App/ReplayViewModelTests+Intro.swift
@@ -1,0 +1,173 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+// Opening-card (`ChatItem.scenarioIntro`) emission tests for `ReplayViewModel`
+// (#867). Sibling-file extension per `.claude/rules/testing.md` — NOT a new
+// `@Suite` (a parallel suite would race the VM-spawning original on the shared
+// test process).
+//
+// The premised-scenario helpers below are `internal static` (not `private`) so
+// the sibling `ReplayViewModelTests+Pacing.swift` can build a source whose
+// `scenario.description` is non-empty for the `introFloorMs` tests — the default
+// suite fixtures all use `description: ''`.
+extension ReplayViewModelTests {
+
+  // MARK: - Premised-scenario fixtures
+
+  /// Non-empty premise for the source-0 opening card. `ja` text so the source
+  /// resolves to the `.dense` reading-density class (matches `demoScript`).
+  static let introPremiseText = "五人の参加者から少数派を会話で見抜く推理ゲーム。"
+
+  /// Second-source premise, distinct from ``introPremiseText`` so a rotation
+  /// test can assert *which* intro card follows the boundary marker.
+  static let introPremiseTextTwo = "全員が同じお題で言い訳を重ねるターン制コメディ。"
+
+  /// A single-phase `speak_all` scenario (2 personas, `ja`) with a caller-chosen
+  /// `description`. Used to exercise the opening card, which reads
+  /// `scenario.description` as its premise.
+  static func makeScenarioWithPremise(description: String) throws -> Scenario {
+    let yaml = """
+      id: premised
+      language: ja
+      name: Premised Demo
+      description: '\(description)'
+      agents: 2
+      rounds: 1
+      context: ''
+      personas:
+        - name: Alice
+          description: ''
+        - name: Bob
+          description: ''
+      phases:
+        - type: speak_all
+          prompt: say
+          output:
+            statement: string
+      """
+    return try ScenarioLoader().load(yaml: yaml)
+  }
+
+  /// A demo source (the shared `threeTurnYAML` turns) whose backing scenario
+  /// carries `description` — so its opening card is shown.
+  static func makeSourceWithPremise(
+    description: String = introPremiseText, config: ReplayPlaybackConfig
+  ) throws -> YAMLReplaySource {
+    try YAMLReplaySource(
+      yaml: threeTurnYAML,
+      scenario: makeScenarioWithPremise(description: description),
+      config: config)
+  }
+
+  /// Two single-turn demo sources with distinct premises, for rotation-order
+  /// assertions. Mirrors `makeTwoSources()` but with non-empty descriptions.
+  static func makeTwoPremisedSources(config: ReplayPlaybackConfig) throws
+    -> [YAMLReplaySource] {
+    let yaml1 = """
+      schema_version: 1
+      turns:
+        - round: 1
+          phase_index: 0
+          phase_type: speak_all
+          agent: Alice
+          fields: { statement: 'demo 1 alice' }
+      """
+    let yaml2 = """
+      schema_version: 1
+      turns:
+        - round: 1
+          phase_index: 0
+          phase_type: speak_all
+          agent: Bob
+          fields: { statement: 'demo 2 bob' }
+      """
+    return [
+      try YAMLReplaySource(
+        yaml: yaml1,
+        scenario: makeScenarioWithPremise(description: introPremiseText),
+        config: config),
+      try YAMLReplaySource(
+        yaml: yaml2,
+        scenario: makeScenarioWithPremise(description: introPremiseTextTwo),
+        config: config)
+    ]
+  }
+
+  // MARK: - start() emission
+
+  /// A premised source prepends its opening card as the first chat item. The
+  /// append happens synchronously inside `start()` (before the playback `Task`
+  /// runs), so the assertion is race-free without awaiting.
+  @Test func startPrependsScenarioIntroForPremisedSource() throws {
+    let source = try Self.makeSourceWithPremise(config: .demoDefault)
+    let viewModel = ReplayViewModel(
+      sources: [source], config: .demoDefault, contentFilter: ContentFilter())
+    viewModel.start()
+    guard case .scenarioIntro(_, let premise) = viewModel.chatItems.first else {
+      Issue.record(
+        "chatItems.first expected .scenarioIntro, got \(String(describing: viewModel.chatItems.first))"
+      )
+      return
+    }
+    #expect(premise == Self.introPremiseText)
+  }
+
+  /// An empty-description source inserts NO opening card — mirrors the card's
+  /// own `Model.init?` visibility guard. Asserted synchronously after `start()`
+  /// (the empty-desc default fixture; the playback `Task` has not run yet).
+  @Test func startInsertsNoIntroForEmptyDescription() throws {
+    let viewModel = try Self.makeVM()  // default fixture: `description: ''`
+    viewModel.start()
+    let hasIntro = viewModel.chatItems.contains {
+      if case .scenarioIntro = $0 { return true }
+      return false
+    }
+    #expect(!hasIntro)
+  }
+
+  // MARK: - Rotation emission (boundary → intro order)
+
+  /// On rotation the opening card follows the demo-boundary marker (order is
+  /// always boundary → intro card), and carries the *next* source's premise.
+  /// Uses `stopAfterLast + awaitTransitionSignal` so the VM holds after a
+  /// deterministic source-0 → source-1 transition.
+  @Test func rotationInsertsIntroAfterBoundary() async throws {
+    let sources = try Self.makeTwoPremisedSources(config: Self.holdConfig)
+    let viewModel = ReplayViewModel(
+      sources: sources, config: Self.holdConfig, contentFilter: ContentFilter())
+    viewModel.start()
+    // Hold point: source 1 reached its final cursor (2 lifecycle + 1 turn).
+    await Self.waitForState(viewModel, timeout: .seconds(5)) { state in
+      if case .playing(let idx, let cursor) = state, idx == 1, cursor >= 3 {
+        return true
+      }
+      return false
+    }
+    guard
+      let boundaryIndex = viewModel.chatItems.firstIndex(where: {
+        if case .demoBoundary = $0 { return true }
+        return false
+      })
+    else {
+      Issue.record("Expected a .demoBoundary in chatItems, got \(viewModel.chatItems)")
+      return
+    }
+    // The item immediately after the boundary is source 1's opening card.
+    let afterBoundary = viewModel.chatItems[boundaryIndex + 1]
+    guard case .scenarioIntro(_, let premise) = afterBoundary else {
+      Issue.record("chatItems after boundary expected .scenarioIntro, got \(afterBoundary)")
+      return
+    }
+    #expect(premise == Self.introPremiseTextTwo)
+    // Source 0's card is still the very first item (accumulate-across-rotation).
+    if case .scenarioIntro(_, let firstPremise) = viewModel.chatItems.first {
+      #expect(firstPremise == Self.introPremiseText)
+    } else {
+      Issue.record(
+        "chatItems.first expected source-0 .scenarioIntro, got \(String(describing: viewModel.chatItems.first))"
+      )
+    }
+  }
+}

--- a/Pastura/PasturaTests/App/ReplayViewModelTests+Pacing.swift
+++ b/Pastura/PasturaTests/App/ReplayViewModelTests+Pacing.swift
@@ -96,6 +96,48 @@ extension ReplayViewModelTests {
     #expect(viewModel.typingFloorMs(for: event, script: Self.demoScript) == 780)
   }
 
+  // MARK: - introFloorMs (opening-card reveal reservation, #867)
+
+  /// `.demoDefault` opts into typing cps at `.normal`, and the premised source
+  /// has a non-empty `scenario.description`, so the opening card reserves a
+  /// positive reveal window before the first turn. (Exact value is not pinned —
+  /// the `typing + readingDwell` arithmetic is already value-pinned by the
+  /// `typingFloorMs` tests above; here only presence-of-a-floor matters.)
+  @Test func introFloorIsPositiveForPremiseAtNormalSpeed() throws {
+    let source = try Self.makeSourceWithPremise(config: .demoDefault)
+    let viewModel = ReplayViewModel(
+      sources: [source], config: .demoDefault, contentFilter: ContentFilter())
+    #expect(viewModel.introFloorMs(forSourceIndex: 0, script: Self.demoScript) > 0)
+  }
+
+  /// `.instant` → nil cps → no typing → no reveal floor (symmetric with
+  /// `typingFloorMs`'s opt-out path).
+  @Test func introFloorIsZeroAtInstantSpeed() throws {
+    let source = try Self.makeSourceWithPremise(config: .demoDefault)
+    let viewModel = ReplayViewModel(
+      sources: [source], config: .demoDefault, contentFilter: ContentFilter())
+    viewModel.playbackSpeed = .instant
+    #expect(viewModel.introFloorMs(forSourceIndex: 0, script: Self.demoScript) == 0)
+  }
+
+  /// Empty `scenario.description` → no card → no floor (the default fixture
+  /// scenario has `description: ''`).
+  @Test func introFloorIsZeroForEmptyDescription() throws {
+    let viewModel = try Self.makeDemoPacedVM()
+    #expect(viewModel.introFloorMs(forSourceIndex: 0, script: Self.demoScript) == 0)
+  }
+
+  /// Whitespace-only `scenario.description` → no card → no floor. Exercises the
+  /// *trimmed*-empty predicate (byte-identical to `ScenarioIntroCard.Model.init?`
+  /// via the shared `introPremise`), not just the fully-empty branch — so a
+  /// hidden card can never leave a phantom pre-first-bubble delay.
+  @Test func introFloorIsZeroForWhitespaceOnlyDescription() throws {
+    let source = try Self.makeSourceWithPremise(description: "   ", config: .demoDefault)
+    let viewModel = ReplayViewModel(
+      sources: [source], config: .demoDefault, contentFilter: ContentFilter())
+    #expect(viewModel.introFloorMs(forSourceIndex: 0, script: Self.demoScript) == 0)
+  }
+
   // MARK: - scaledDelay floor application
 
   @Test func scaledDelayTakesFloorWhenFloorExceedsBase() throws {


### PR DESCRIPTION
## Summary
DL時デモ再生（`ModelDownloadHostView` / `ReplayViewModel`）に、Sim で導入済みの presentation-only 共通コンポーネント `ScenarioIntroCard` を再利用してオープニングカードを展開（#857 で意図的に後続送りにしたデモ採用）。

- `ChatItem` に `.scenarioIntro(id:premise:)` を追加、各 segment 先頭にインターリーブ（start/rotation とも **boundary → card** の順、`DemoBoundaryRow` と併用）。premise は SHA 検証済みプリセットの `scenario.description`（`metadata.description` と等価）、title は nil（GameHeader が名称表示）。
- `appendIntroCard` / `introFloorMs` の空判定を共有 private ヘルパ `introPremise` で統一（`ScenarioIntroCard.Model.init?` と byte-identical に trim 判定・verbatim 返却）→ 隠れカードが phantom delay を残さない。
- 会話ゲートの代わりに既存 pacing floor を再利用: `introFloorMs` を新規開始時（resume 除外）のみ `pendingFloorMs` に seed し、第一発話をカードのリビール後まで待たせる（デモは時間駆動・LLM ゲート概念なし）。
- host に `typedIntroIds: Set<UUID>` type-once ラッチ（Sim の単一 `introHasTyped` を複数カードに一般化、LazyVStack のスクロールバック再タイプ防止）。

enum case 追加が host の網羅 switch を要求するため実装は build-coupled で 1 コミット。

## Test plan
- ✅ Full unit suite: 2423 tests passed
- ✅ Unit: `introFloorMs`（.normal 正値 / .instant 0 / 空 description 0 / whitespace-only 0）
- ✅ Unit: chatItem 挿入順（start 先頭 scenarioIntro / rotation boundary→intro / 空 description 非挿入）
- ✅ swiftlint --strict / code-reviewer (Opus) PASS

### 実機QA（要確認・ADR-009 rule 4）
- [ ] カードのタイプ表示（premise が playback 速度でタイプされる）
- [ ] 第一発話がカードのリビール後に出る（pacing floor）
- [ ] rotation 時の boundary → card の見た目、`.instant`/Reduce Motion の静的表示
- [ ] スクロール追従・スクロールバックで再タイプしない（type-once ラッチ）

Closes #867

🤖 Generated with [Claude Code](https://claude.com/claude-code)