### PR TITLE
✨ feat: add brevity soft-rule to system prompt base rules

### DIFF
--- a/Pastura/Pastura/Engine/PromptBuilder.swift
+++ b/Pastura/Pastura/Engine/PromptBuilder.swift
@@ -123,6 +123,10 @@ nonisolated struct PromptBuilder: Sendable {
   /// base block were added in #194 PR#a Item 3 (A3 prompt hardening) to
   /// reduce Hyp A (JSON parse retry) frequency by reinforcing structural
   /// validity at the source on Gemma 4 E2B Q4_K_M.
+  ///
+  /// The brevity rule (#877) is a soft cap on the primary statement field
+  /// only — inner_thought is intentionally unconstrained. Wording is
+  /// harness-A/B-tuned; keep ja/en scope-parallel when editing.
   private func buildAnswerRules(
     scenario: Scenario,
     persona: Persona,
@@ -136,6 +140,7 @@ nonisolated struct PromptBuilder: Sendable {
         ## 回答ルール（厳守）
         - 必ず日本語で回答すること
         - 全フィールドに必ず文章を書くこと（空欄「...」は禁止）
+        - 発言（statement などの本文フィールド）は3文以内で簡潔に書くこと（長い独白は禁止）
         - JSONは必ず1行で書くこと（改行を入れない）
         - JSON以外のテキストやコードブロック(```)は書かないこと
         - JSONに構文エラーがあると失敗扱いになる（カッコ・引用符・カンマを正しく閉じること）
@@ -145,6 +150,7 @@ nonisolated struct PromptBuilder: Sendable {
         ## Response Rules (strict)
         - Respond in English only.
         - Every field must contain a sentence (no empty "..." values).
+        - Keep your statement (the main text field) concise: at most 3 sentences, no long monologues.
         - The JSON output must be a single line (no newlines).
         - Do not include any text or code fences (```) outside the JSON.
         - JSON syntax errors are treated as failure: close every bracket, quote, and comma correctly.

--- a/Pastura/PasturaTests/Engine/PromptBuilderTests+Hardening.swift
+++ b/Pastura/PasturaTests/Engine/PromptBuilderTests+Hardening.swift
@@ -1,0 +1,165 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+// MARK: - Prompt Hardening (#194 PR#a Item 3) + Brevity Rule (#877)
+//
+// Sibling-file extension per the testing.md split convention — NOT a new
+// @Suite (a second suite would run in parallel against the same shared
+// state class; see PR #157). Helpers (`builder`, `makeScenario`) stay at
+// internal access in PromptBuilderTests.swift so this file can see them.
+extension PromptBuilderTests {
+
+  // Two new rule lines added in PR#a Item 3 — assert both are present
+  // so a future refactor doesn't silently drop the structural-validity
+  // emphasis that reduces Hyp A frequency.
+  @Test func systemPromptIncludesAugmentedSyntaxRules() {
+    let scenario = makeScenario()
+    let phase = Phase(
+      type: .speakAll,
+      prompt: "Speak!",
+      outputSchema: ["statement": "string"]
+    )
+    let state = SimulationState.initial(for: scenario)
+
+    let prompt = builder.buildSystemPrompt(
+      scenario: scenario, persona: scenario.personas[0], phase: phase, state: state
+    )
+    #expect(prompt.contains("JSONに構文エラーがあると失敗扱いになる"))
+    #expect(prompt.contains("単一オブジェクトのみ出力"))
+  }
+
+  // Brevity soft-rule (#877): the base rules must cap the primary
+  // statement field at 3 sentences in BOTH languages, so phase-rich
+  // scenarios stay readable in playback. Scope is the main text field
+  // only — inner_thought is intentionally unconstrained (critic Axis 6).
+  @Test func systemPromptIncludesBrevityRuleJa() {
+    let scenario = makeScenario()
+    let phase = Phase(
+      type: .speakAll,
+      prompt: "Speak!",
+      outputSchema: ["statement": "string"]
+    )
+    let state = SimulationState.initial(for: scenario)
+
+    let prompt = builder.buildSystemPrompt(
+      scenario: scenario, persona: scenario.personas[0], phase: phase, state: state
+    )
+    #expect(prompt.contains("3文以内で簡潔に"))
+  }
+
+  @Test func systemPromptIncludesBrevityRuleEn() {
+    let scenario = makeScenario(language: "en")
+    let phase = Phase(
+      type: .speakAll,
+      prompt: "Speak!",
+      outputSchema: ["statement": "string"]
+    )
+    let state = SimulationState.initial(for: scenario)
+
+    let prompt = builder.buildSystemPrompt(
+      scenario: scenario, persona: scenario.personas[0], phase: phase, state: state
+    )
+    #expect(prompt.contains("at most 3 sentences"))
+  }
+
+  // Placeholder example must appear when outputSchema is set, AND must
+  // use placeholder syntax (`<ここに...>`) — concrete Japanese values
+  // would risk Gemma 2B parroting the demonstrated content (round 2
+  // Axis 5 finding).
+  @Test func systemPromptIncludesPlaceholderExampleWhenSchemaSet() {
+    let scenario = makeScenario()
+    let phase = Phase(
+      type: .speakAll,
+      prompt: "Speak!",
+      outputSchema: ["statement": "string", "inner_thought": "string"]
+    )
+    let state = SimulationState.initial(for: scenario)
+
+    let prompt = builder.buildSystemPrompt(
+      scenario: scenario, persona: scenario.personas[0], phase: phase, state: state
+    )
+    let exampleLine =
+      prompt.components(separatedBy: "\n")
+      .first { $0.hasPrefix("例:") } ?? ""
+    #expect(!exampleLine.isEmpty, "expected an `例:` line in the output format section")
+    #expect(exampleLine.contains("<ここに"), "placeholder convention must be `<ここに{key}>`")
+    #expect(exampleLine.contains(">"))
+    #expect(exampleLine.contains("statement"))
+    #expect(exampleLine.contains("inner_thought"))
+  }
+
+  @Test func systemPromptOmitsExampleWhenNoOutputSchema() {
+    let scenario = makeScenario()
+    let phase = Phase(type: .speakAll, prompt: "Speak!")  // no outputSchema
+    let state = SimulationState.initial(for: scenario)
+
+    let prompt = builder.buildSystemPrompt(
+      scenario: scenario, persona: scenario.personas[0], phase: phase, state: state
+    )
+    #expect(!prompt.contains("例:"))
+  }
+
+  // Char-count regression guard — total prompt growth from PR#a Item 3
+  // must stay within +300 chars of the equivalent pre-PR prompt for the
+  // largest preset schema (2 keys per phase across current presets).
+  // Loose upper bound: well under 7K chars for an 8K context model.
+  @Test func systemPromptCharCountStaysWithinBudget() {
+    let scenario = makeScenario()
+    let phase = Phase(
+      type: .speakAll,
+      prompt: "Speak!",
+      outputSchema: ["statement": "string", "inner_thought": "string"]
+    )
+    let state = SimulationState.initial(for: scenario)
+
+    let prompt = builder.buildSystemPrompt(
+      scenario: scenario, persona: scenario.personas[0], phase: phase, state: state
+    )
+    // Budget reasoning: scenario + persona + 7 rule lines + format spec
+    // (~2 short lines) for a 2-key schema fits comfortably under 1500
+    // chars on the test scenario; CI bound at 2000 leaves room for
+    // future minor additions without rebaselining the test.
+    #expect(prompt.count < 2000, "prompt grew larger than expected: \(prompt.count) chars")
+  }
+
+  // Primary-first ordering (#194 PR#b): the placeholder example and the
+  // output-format spec line must both list `statement` before
+  // `inner_thought` — alphabetical would invert this and break
+  // PartialOutputExtractor's streaming UX (user sees nothing until
+  // inner_thought finishes). Source of truth: OutputSchema.fields.
+  @Test func systemPromptExampleUsesPrimaryFirstOrder() {
+    let scenario = makeScenario()
+    let phase = Phase(
+      type: .speakAll,
+      prompt: "Speak!",
+      outputSchema: ["inner_thought": "string", "statement": "string"]
+    )
+    let state = SimulationState.initial(for: scenario)
+
+    let prompt = builder.buildSystemPrompt(
+      scenario: scenario, persona: scenario.personas[0], phase: phase, state: state
+    )
+    // Both the spec line (`{"statement": ...}`) and the `例:` line must
+    // have statement appear before inner_thought.
+    let specLine =
+      prompt.components(separatedBy: "\n")
+      .first { $0.hasPrefix("{\"") } ?? ""
+    let exampleLine =
+      prompt.components(separatedBy: "\n")
+      .first { $0.hasPrefix("例:") } ?? ""
+    for line in [specLine, exampleLine] {
+      guard
+        let sIdx = line.range(of: "statement")?.lowerBound,
+        let tIdx = line.range(of: "inner_thought")?.lowerBound
+      else {
+        Issue.record("expected both keys in line: \(line)")
+        continue
+      }
+      #expect(
+        sIdx < tIdx,
+        "statement must precede inner_thought in primary-first order: \(line)")
+    }
+  }
+}

--- a/Pastura/PasturaTests/Engine/PromptBuilderTests.swift
+++ b/Pastura/PasturaTests/Engine/PromptBuilderTests.swift
@@ -188,134 +188,17 @@ struct PromptBuilderTests {
     #expect(voteLine.contains("Charlie"))
   }
 
-  // MARK: - Prompt Hardening (#194 PR#a Item 3)
-
-  // Two new rule lines added in PR#a Item 3 — assert both are present
-  // so a future refactor doesn't silently drop the structural-validity
-  // emphasis that reduces Hyp A frequency.
-  @Test func systemPromptIncludesAugmentedSyntaxRules() {
-    let scenario = makeScenario()
-    let phase = Phase(
-      type: .speakAll,
-      prompt: "Speak!",
-      outputSchema: ["statement": "string"]
-    )
-    let state = SimulationState.initial(for: scenario)
-
-    let prompt = builder.buildSystemPrompt(
-      scenario: scenario, persona: scenario.personas[0], phase: phase, state: state
-    )
-    #expect(prompt.contains("JSONに構文エラーがあると失敗扱いになる"))
-    #expect(prompt.contains("単一オブジェクトのみ出力"))
-  }
-
-  // Placeholder example must appear when outputSchema is set, AND must
-  // use placeholder syntax (`<ここに...>`) — concrete Japanese values
-  // would risk Gemma 2B parroting the demonstrated content (round 2
-  // Axis 5 finding).
-  @Test func systemPromptIncludesPlaceholderExampleWhenSchemaSet() {
-    let scenario = makeScenario()
-    let phase = Phase(
-      type: .speakAll,
-      prompt: "Speak!",
-      outputSchema: ["statement": "string", "inner_thought": "string"]
-    )
-    let state = SimulationState.initial(for: scenario)
-
-    let prompt = builder.buildSystemPrompt(
-      scenario: scenario, persona: scenario.personas[0], phase: phase, state: state
-    )
-    let exampleLine =
-      prompt.components(separatedBy: "\n")
-      .first { $0.hasPrefix("例:") } ?? ""
-    #expect(!exampleLine.isEmpty, "expected an `例:` line in the output format section")
-    #expect(exampleLine.contains("<ここに"), "placeholder convention must be `<ここに{key}>`")
-    #expect(exampleLine.contains(">"))
-    #expect(exampleLine.contains("statement"))
-    #expect(exampleLine.contains("inner_thought"))
-  }
-
-  @Test func systemPromptOmitsExampleWhenNoOutputSchema() {
-    let scenario = makeScenario()
-    let phase = Phase(type: .speakAll, prompt: "Speak!")  // no outputSchema
-    let state = SimulationState.initial(for: scenario)
-
-    let prompt = builder.buildSystemPrompt(
-      scenario: scenario, persona: scenario.personas[0], phase: phase, state: state
-    )
-    #expect(!prompt.contains("例:"))
-  }
-
-  // Char-count regression guard — total prompt growth from PR#a Item 3
-  // must stay within +300 chars of the equivalent pre-PR prompt for the
-  // largest preset schema (2 keys per phase across current presets).
-  // Loose upper bound: well under 7K chars for an 8K context model.
-  @Test func systemPromptCharCountStaysWithinBudget() {
-    let scenario = makeScenario()
-    let phase = Phase(
-      type: .speakAll,
-      prompt: "Speak!",
-      outputSchema: ["statement": "string", "inner_thought": "string"]
-    )
-    let state = SimulationState.initial(for: scenario)
-
-    let prompt = builder.buildSystemPrompt(
-      scenario: scenario, persona: scenario.personas[0], phase: phase, state: state
-    )
-    // Budget reasoning: scenario + persona + 6 rule lines + format spec
-    // (~2 short lines) for a 2-key schema fits comfortably under 1500
-    // chars on the test scenario; CI bound at 2000 leaves room for
-    // future minor additions without rebaselining the test.
-    #expect(prompt.count < 2000, "prompt grew larger than expected: \(prompt.count) chars")
-  }
-
-  // Primary-first ordering (#194 PR#b): the placeholder example and the
-  // output-format spec line must both list `statement` before
-  // `inner_thought` — alphabetical would invert this and break
-  // PartialOutputExtractor's streaming UX (user sees nothing until
-  // inner_thought finishes). Source of truth: OutputSchema.fields.
-  @Test func systemPromptExampleUsesPrimaryFirstOrder() {
-    let scenario = makeScenario()
-    let phase = Phase(
-      type: .speakAll,
-      prompt: "Speak!",
-      outputSchema: ["inner_thought": "string", "statement": "string"]
-    )
-    let state = SimulationState.initial(for: scenario)
-
-    let prompt = builder.buildSystemPrompt(
-      scenario: scenario, persona: scenario.personas[0], phase: phase, state: state
-    )
-    // Both the spec line (`{"statement": ...}`) and the `例:` line must
-    // have statement appear before inner_thought.
-    let specLine =
-      prompt.components(separatedBy: "\n")
-      .first { $0.hasPrefix("{\"") } ?? ""
-    let exampleLine =
-      prompt.components(separatedBy: "\n")
-      .first { $0.hasPrefix("例:") } ?? ""
-    for line in [specLine, exampleLine] {
-      guard
-        let sIdx = line.range(of: "statement")?.lowerBound,
-        let tIdx = line.range(of: "inner_thought")?.lowerBound
-      else {
-        Issue.record("expected both keys in line: \(line)")
-        continue
-      }
-      #expect(
-        sIdx < tIdx,
-        "statement must precede inner_thought in primary-first order: \(line)")
-    }
-  }
-
   // MARK: - Test Helpers
 
-  private func makeScenario() -> Scenario {
+  // Internal (not private) — the sibling-file extension
+  // PromptBuilderTests+Hardening.swift calls this helper (testing.md split
+  // convention: private members are invisible to sibling-file extensions).
+  func makeScenario(language: String = "ja") -> Scenario {
     Scenario(
       id: "test",
       name: "Test Scenario",
       description: "A test scenario",
-      language: "ja",
+      language: language,
       agentCount: 3,
       rounds: 3,
       context: "You are in a game show.",


### PR DESCRIPTION
## Summary
- Add a brevity soft-rule to `PromptBuilder.buildAnswerRules` (ja/en, scope-parallel): the primary statement field must stay within 3 sentences; `inner_thought` is intentionally unconstrained
- First step of the simulation-readability effort — phase-rich scenarios produced long monologues that made playback hard to read
- `PromptBuilderTests` split into a sibling-file extension (`PromptBuilderTests+Hardening.swift`) per the testing.md convention to stay under `type_body_length`; `makeScenario` widened to internal and given a `language:` parameter

## Harness A/B validation (gemma-4-E2B Q4_K_M, word_wolf ja/en ×3 per arm)

| run | stmt chars (mean) | sentences (mean/max) | >3-sentence stmts | run attempts |
|---|---|---|---|---|
| base ja_1 | 102.9 | 2.67 / 5 | 3/15 | 1 |
| base ja_2 | 75.7 | 2.33 / 4 | 2/15 | 2 |
| base ja_3 | 87.7 | 2.47 / 5 | 4/15 | 1 |
| **rule ja_1** | **45.3** | **1.47 / 2** | **0/15** | 1 |
| **rule ja_2** | **47.8** | **1.53 / 2** | **0/15** | 2 |
| **rule ja_3** | **46.3** | **1.67 / 3** | **0/15** | 1 |

- ja: mean statement length roughly **halved** (76–103 → 45–48 chars); over-3-sentence statements eliminated in all runs; run durations dropped ~30–40 % as a side effect
- en: already 1 sentence/statement at baseline; max chars tightened 178 → 152, no regression (base means 97.7–105.0 → rule 94.1–95.1)
- Parse health: internal run-retry rate identical across arms (1/3 in both ja arms); zero turn-level parse retries anywhere
- Qualitative: persona voice and cross-agent reasoning retained; round-to-round repetition exists **equally in both arms** (pre-existing E2B trait, not caused by the rule)

Baseline arm captured on `main` before the edit; rule arm on this branch. Raw JSONLs under `data/factory/runs/2026-07-02-brevity-ab/` (gitignored).

## Test plan
- `PromptBuilderTests` (22 tests): new ja/en brevity-rule assertions, TDD red→green; char-budget guard comment refreshed (6→7 rule lines)
- Full unit suite: 2439 tests / 207 suites passed; `swiftlint --strict` clean; harness `swift build` passes (PromptBuilder compiles into PasturaCore)

## Follow-up (out of scope)
- Per-scenario/per-phase utterance-style override in YAML — to be filed as a separate issue now that the A/B validates the approach

Closes #877

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5ViCbpCAUb4sRLeRDRyVY
