### PR TITLE
🐛 fix: declare DiskSpace required-reason API in privacy manifest

### DIFF
--- a/Pastura/Pastura/PrivacyInfo.xcprivacy
+++ b/Pastura/Pastura/PrivacyInfo.xcprivacy
@@ -20,6 +20,14 @@
 				<string>C617.1</string>
 			</array>
 		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>E174.1</string>
+			</array>
+		</dict>
 	</array>
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array/>

--- a/Pastura/PasturaTests/App/PrivacyManifestTests.swift
+++ b/Pastura/PasturaTests/App/PrivacyManifestTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Testing
+
+/// Guards the App Store privacy-manifest contract (#879).
+///
+/// Change-detector: pins the bundled `PrivacyInfo.xcprivacy` to the exact
+/// required-reason API set the app actually uses. A failure is NOT
+/// necessarily a bug — it means either (a) a new required-reason API was
+/// adopted in code without a manifest declaration (which would otherwise
+/// surface only as ITMS-91053 at App Store Connect upload, long after the
+/// PR merged), or (b) the manifest changed — confirm the change passed
+/// review, then update the expected values here.
+///
+/// Reads the **bundled** manifest (`Bundle.main` resolves to the test-host
+/// Pastura.app, same as `DeviceRequirementsTests`) rather than the source
+/// file, so it validates the shipped artifact: a manifest that falls out of
+/// the app bundle is itself the ITMS-91053 condition, and fails loudly here
+/// via the missing-resource path.
+@Suite(.timeLimit(.minutes(1)))
+struct PrivacyManifestTests {
+  /// The bundled manifest as a plist dictionary. Throws (loud failure)
+  /// when the resource is absent from the app bundle or not a plist dict.
+  private static func loadManifest() throws -> [String: Any] {
+    let url = try #require(
+      Bundle.main.url(forResource: "PrivacyInfo", withExtension: "xcprivacy"),
+      "PrivacyInfo.xcprivacy missing from the app bundle — this is the ITMS-91053 condition"
+    )
+    let data = try Data(contentsOf: url)
+    let plist = try PropertyListSerialization.propertyList(from: data, format: nil)
+    return try #require(plist as? [String: Any], "manifest root is not a dictionary")
+  }
+
+  @Test func declaresNoTrackingAndNoCollectedData() throws {
+    let manifest = try Self.loadManifest()
+    // The ASC-side "Data Not Collected" nutrition-label answers (manual
+    // gate, tracked in #233) rest on these two staying empty/false; the
+    // manifest file itself is owned by ADR-005 §9.2 row #2 (#149).
+    #expect(manifest["NSPrivacyTracking"] as? Bool == false)
+    let collected = try #require(manifest["NSPrivacyCollectedDataTypes"] as? [Any])
+    #expect(collected.isEmpty)
+  }
+
+  @Test func accessedAPIDeclarationsMatchUsage() throws {
+    let manifest = try Self.loadManifest()
+    let entries = try #require(
+      manifest["NSPrivacyAccessedAPITypes"] as? [[String: Any]])
+
+    var declared: [String: Set<String>] = [:]
+    for entry in entries {
+      let category = try #require(entry["NSPrivacyAccessedAPIType"] as? String)
+      let reasons = try #require(entry["NSPrivacyAccessedAPITypeReasons"] as? [String])
+      #expect(declared[category] == nil, "duplicate category \(category)")
+      declared[category] = Set(reasons)
+    }
+
+    // Exact set of required-reason APIs the app uses today:
+    // - UserDefaults (CA92.1): app-scoped preferences access.
+    // - FileTimestamp (C617.1): timestamps of app-container files.
+    // - DiskSpace (E174.1): `ModelManager.availableStorageBytes()` probes
+    //   `volumeAvailableCapacityForImportantUsage` to warn before a
+    //   multi-GB model download (85F4.1 deliberately NOT claimed — the
+    //   low-storage sheet shows only the model's file size, never the
+    //   probed capacity).
+    #expect(
+      declared == [
+        "NSPrivacyAccessedAPICategoryUserDefaults": ["CA92.1"],
+        "NSPrivacyAccessedAPICategoryFileTimestamp": ["C617.1"],
+        "NSPrivacyAccessedAPICategoryDiskSpace": ["E174.1"]
+      ])
+  }
+}

--- a/docs/security/release-checklist.md
+++ b/docs/security/release-checklist.md
@@ -6,8 +6,8 @@ outside the codebase. Four sections:
 1. [GitHub repository settings](#1-github-repository-settings).
    One-time configuration kept current; commands are idempotent.
 2. [iOS pre-submission audit](#2-ios-pre-submission-audit).
-   Runs on the eve of an App Store submission (Phase 3, requires Apple
-   Developer Program registration).
+   Runs on the eve of an App Store submission (the Phase 2 exit gate —
+   see `docs/ROADMAP.md`).
 3. [Recurring review](#3-recurring-review). Periodic operator tasks.
 4. [Release execution](#4-release-execution-testflight). How a build
    actually reaches TestFlight (the automated pipeline + its one-time
@@ -74,8 +74,7 @@ the field stays `disabled` on subsequent GET.
 
 All of the above will stay `disabled` on Pastura's current free plan;
 that is expected, not a regression. Track Secret Protection adoption
-as a paid-plan consideration alongside Apple Developer Program
-registration (see § 2 below).
+as a paid-plan consideration.
 
 ### Branch protection
 
@@ -101,10 +100,10 @@ external-tester submission. Many items are confirmed continuously by
 CI (SwiftLint, the i18n leak audit, the no-force-unwrap rule), but the
 release pass cross-checks them.
 
-> Phase note: Pastura's Apple Developer Program registration is not yet
-> in place at the time of writing. This section is dormant until that
-> registration unlocks Phase 3 release work. See
-> `project_pastura_distribution_status.md` for context.
+> Phase note: Apple Developer Program registration completed 2026-06-07.
+> This section is live for the first App Store submission — the Phase 2
+> exit gate (`docs/ROADMAP.md` § "Phase 2 → Phase 3 Go Criteria").
+> ASC-side manual gates are tracked in #233.
 
 ### 2.1 Privacy Manifest
 
@@ -143,13 +142,16 @@ Confirm no API keys, credentials, or auth tokens are embedded in
 
 ### 2.4 Network destinations
 
-Pastura's only outbound network is the model download. Cross-check:
+Pastura's outbound network is limited to the model download
+(`huggingface.co`) and the Shared Scenarios gallery fetch
+(`raw.githubusercontent.com`; see
+`App/Community/Gallery/URLSessionGalleryService.swift`). Cross-check:
 
 * `App/ModelRegistry.swift` URLs are HTTPS and point to known publishers
-  (Hugging Face, Kaggle).
+  (Hugging Face).
 * `Info.plist` does not declare any `NSAppTransportSecurity` overrides.
 * The privacy policy at `web/src/pages/legal/privacy-policy.astro` accurately reflects
-  the model-download host list.
+  both hosts (model download + gallery fetch).
 
 ### 2.5 Account deletion
 


### PR DESCRIPTION
## Summary
- Declare `NSPrivacyAccessedAPICategoryDiskSpace` (reason `E174.1`) in `PrivacyInfo.xcprivacy`: `ModelManager.availableStorageBytes()` probes `volumeAvailableCapacityForImportantUsage` (a required-reason API) for the pre-download low-storage check, but the manifest declared only UserDefaults + FileTimestamp — the gap would surface as **ITMS-91053** at the first App Store Connect upload. `85F4.1` is deliberately not claimed: `StorageWarningSheet` displays only the model's file size, never the probed capacity.
- Add `PrivacyManifestTests`, a change-detector (pattern: `DeviceRequirementsTests`) that reads the **bundled** manifest via `Bundle.main` and pins `NSPrivacyTracking == false`, empty collected-data types, and the exact accessed-API declaration set — future required-reason drift fails CI instead of the upload.
- Fix four stale claims in `docs/security/release-checklist.md`: header + §2 phase note framed ADP registration as pending / submission as Phase 3 (ADP registered 2026-06-07; submission is the Phase 2 exit gate), a dead per-user memory reference (knowledge-layering.md anti-pattern), and §2.4's outbound-network claim (model download was called the only outbound traffic and "Kaggle" named as a host; actual: `huggingface.co` download + `raw.githubusercontent.com` gallery fetch).

Found by the 2026-07-02 pre-submission App Review red-team audit. ASC-side manual gates from the same audit are tracked in #233.

Closes #879

## Test plan
- [x] TDD red→green: `PrivacyManifestTests` failed on the missing DiskSpace declaration, passes after the manifest fix
- [x] Full unit suite (UI tests skipped — no UI change): 2439 tests / 208 suites passed
- [x] `swiftlint lint --strict` clean
- [x] `grep -n "Phase 3\|Kaggle\|not yet\|project_pastura" docs/security/release-checklist.md` → only the legitimate ROADMAP heading reference remains
- [x] code-reviewer (Opus): PASS (0 Critical / 0 Warning; 1 citation-clarity suggestion applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwZCmHBE7WXhLsKDZwVPxG
