### PR TITLE
📝 docs: sync drifted version references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ Utilities/ → depends on nothing
 | UI                 | SwiftUI                       |           |
 | Min iOS            | 18.0                          |           |
 | YAML parser        | Yams                          | 6.2.2     |
-| SQLite             | GRDB                          | 7.11.0    |
+| SQLite             | GRDB                          | 7.11.1    |
 | LLM (TestFlight)   | llama.cpp via mattt/llama.swift | pinned   |
 | LLM (target)       | LiteRT-LM iOS SDK (planned)  |           |
 | LLM (dev)          | Ollama via OpenAI-compat API  |           |

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ dependency direction is preparation for a future SPM module split.
 ### Libraries
 
 - [Yams](https://github.com/jpsim/Yams) 6.2.2 for YAML parsing
-- [GRDB](https://github.com/groue/GRDB.swift) 7.11.0 for SQLite
+- [GRDB](https://github.com/groue/GRDB.swift) 7.11.1 for SQLite
 
 ### LLM backends
 


### PR DESCRIPTION
## Consistency-audit auto-fix

Mechanically-detected documentation drift, synced against an authoritative source.

| file:line | change | authoritative source |
|---|---|---|
| `CLAUDE.md:115` | GRDB `7.11.0` → `7.11.1` | `Package.resolved` |
| `README.md:61` | GRDB `7.11.0` → `7.11.1` | `Package.resolved` |

Triggered by the GRDB bump in #873 (`63da4d0`); the Tech Stack table and README libraries list still cited the old version.

---

This diff is machine-generated by `/consistency-audit` (auto-fix path: authoritative-source-computed version tokens only, spliced at the detected offset). It is opened as **Draft** and awaits **human merge** — the merge is the review gate (see the skill's Output Contract).
