### PR TITLE
🐛 fix: expand {conversation_log} in summarize phase

### DIFF
--- a/Pastura/Pastura/Engine/Phases/SummarizeHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/SummarizeHandler.swift
@@ -18,6 +18,10 @@ nonisolated struct SummarizeHandler: PhaseHandler {
         ja: "ラウンド {current_round} 完了",
         en: "Round {current_round} complete")
 
+    // Invariant across pairings — formatted once, injected per-iteration below.
+    let conversationLog = promptBuilder.formatConversationLog(
+      state.conversationLog, language: context.scenario.engineLanguage)
+
     if !state.pairings.isEmpty && template.contains("{agent1}") {
       // Expand template per pairing
       var lines: [String] = []
@@ -36,6 +40,7 @@ nonisolated struct SummarizeHandler: PhaseHandler {
         variables["score2"] = "\(state.scores[pairing.agent2] ?? 0)"
         variables["scoreboard"] = promptBuilder.formatScoreboard(state.scores)
         variables["current_round"] = "\(state.currentRound)"
+        variables["conversation_log"] = conversationLog
         lines.append(promptBuilder.expandTemplate(template, variables: variables))
       }
       context.emitter(.summary(text: lines.joined(separator: "\n")))
@@ -44,6 +49,7 @@ nonisolated struct SummarizeHandler: PhaseHandler {
       var variables = state.variables
       variables["scoreboard"] = promptBuilder.formatScoreboard(state.scores)
       variables["current_round"] = "\(state.currentRound)"
+      variables["conversation_log"] = conversationLog
       let text = promptBuilder.expandTemplate(template, variables: variables)
       context.emitter(.summary(text: text))
     }

--- a/Pastura/PasturaTests/Engine/Phases/SummarizeHandlerTests.swift
+++ b/Pastura/PasturaTests/Engine/Phases/SummarizeHandlerTests.swift
@@ -136,6 +136,31 @@ struct SummarizeHandlerTests {
     #expect(summaries[0] == "Votes: {vote_results}")
   }
 
+  @Test func expandsConversationLogInSimplePath() async throws {
+    let mock = MockLLMService(responses: [])
+    let scenario = makeTestScenario(
+      phases: [Phase(type: .summarize, template: "Log:\n{conversation_log}")]
+    )
+    var state = SimulationState.initial(for: scenario)
+    state.currentRound = 1
+    state.conversationLog = [
+      ConversationEntry(agentName: "Alice", content: "hello", phaseType: .speakEach, round: 1)
+    ]
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    let summaries = collector.events.compactMap { event -> String? in
+      if case .summary(let text) = event { return text }
+      return nil
+    }
+    #expect(summaries.count == 1)
+    // formatConversationLog renders "  agentName: content"; the placeholder must
+    // not survive literally (regression for #862).
+    #expect(summaries[0] == "Log:\n  Alice: hello")
+  }
+
   // MARK: - Pair path: derived variables
 
   @Test func expandsScoreboardInPairPath() async throws {
@@ -189,6 +214,34 @@ struct SummarizeHandlerTests {
     }
     #expect(summaries.count == 1)
     #expect(summaries[0] == "Alice(cooperate)")
+  }
+
+  @Test func expandsConversationLogInPairPath() async throws {
+    // Template carries both {agent1} and {conversation_log} with non-empty
+    // pairings so the L21 gate routes into the per-pairing loop path (#862).
+    let mock = MockLLMService(responses: [])
+    let scenario = makeTestScenario(
+      phases: [Phase(type: .summarize, template: "{agent1} log:\n{conversation_log}")]
+    )
+    var state = SimulationState.initial(for: scenario)
+    state.currentRound = 1
+    state.pairings = [
+      Pairing(agent1: "Alice", agent2: "Bob", action1: "cooperate", action2: "betray")
+    ]
+    state.conversationLog = [
+      ConversationEntry(agentName: "Bob", content: "hi", phaseType: .speakEach, round: 1)
+    ]
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    let summaries = collector.events.compactMap { event -> String? in
+      if case .summary(let text) = event { return text }
+      return nil
+    }
+    #expect(summaries.count == 1)
+    #expect(summaries[0] == "Alice log:\n  Bob: hi")
   }
 
   // MARK: - simulationLanguage override (ADR-010 Step E)


### PR DESCRIPTION
## Summary
- `SummarizeHandler` was the only LLM phase handler that omitted injecting `conversation_log` into its template variables, so `{conversation_log}` rendered literally in summarize templates (`{current_round}` / `{scoreboard}` worked). Inject it into both the per-pairing and simple expansion branches, mirroring `SpeakAllHandler` / `VoteHandler`.
- The formatted log is invariant across pairings, so it is computed once above the loop and assigned per-iteration.
- No bundled preset summarize template references `{conversation_log}` (verified across Presets/DemoPresets), so this changes **no shipped output** — it corrects behavior only for user-authored Editor templates.

## Test plan
- New `expandsConversationLogInSimplePath` / `expandsConversationLogInPairPath` in `SummarizeHandlerTests` — populate `state.conversationLog`, assert `{conversation_log}` expands to `  agentName: content` (not the literal placeholder). Both fail on revert.
- Full unit suite: 2443 tests pass; `swiftlint --strict` clean.

Closes #862

🤖 Generated with [Claude Code](https://claude.com/claude-code)