### PR TITLE
✨ feat: show final-ranking card at demo replay segment tails

### DIFF
--- a/Pastura/Pastura/App/ReplayViewModel.swift
+++ b/Pastura/Pastura/App/ReplayViewModel.swift
@@ -141,6 +141,44 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
   /// ``totalPhaseCount``.
   private var cachedTotalPhaseCount: Int = 0
 
+  // MARK: - Closing-card accumulators (#884)
+  //
+  // Mirror of the live ``SimulationViewModel`` result state. These are the
+  // inputs ``concludeSource(sourceIndex:)`` feeds to
+  // ``SimulationResultCard/Model/init(scores:eliminated:voteResults:eliminationVotes:phases:)``
+  // at each segment's tail. Plain `private var` (no `@Observable` bridge): the
+  // demo has no live scoreboard, so nothing renders these directly — they are
+  // snapshotted into a static ``ChatItem/simulationResult`` card. Seeded /
+  // reset per source in ``resetPerDemoState(forSourceIndex:)``.
+
+  /// Agent → cumulative score. Full-replaced on each `.scoreUpdate`, matching
+  /// ``SimulationViewModel/scores`` semantics. Seeded all-`0` from the source's
+  /// personas so "are there scores worth ranking" is decided by *any non-zero*
+  /// value, not `!isEmpty` (see the resolver's doc-comment).
+  private var scores: [String: Int] = [:]
+
+  /// Agent → eliminated flag. Seeded all-`false`; set `true` on `.elimination`.
+  private var eliminated: [String: Bool] = [:]
+
+  /// Latest `.voteResults` tallies (agent → votes received). Ranks a vote-only
+  /// "popularity vote" that eliminates nobody (#868).
+  private var voteResults: [String: Int] = [:]
+
+  /// Per-agent vote count captured at the moment of each agent's elimination.
+  /// Round-correct — an agent eliminated in an earlier round keeps its own
+  /// count, which a last-wins tally would drop.
+  private var eliminationVotes: [String: Int] = [:]
+
+  /// Whether the current source's closing card has already been appended.
+  /// Single Bool (NOT a `Set<Int>` keyed by source index): under the default
+  /// `.loop` config the same index recurs every cycle, so a keyed set that is
+  /// never cleared would append the card in cycle 1 only, then silently skip
+  /// forever. Cleared on every fresh source entry in
+  /// ``resetPerDemoState(forSourceIndex:)`` (which fires from `start()` and both
+  /// rotation arms, but NOT on resume) — so it re-arms each loop cycle while
+  /// still guarding against a resume-driven double append (#884).
+  private var resultCardAppendedForCurrentSource = false
+
   /// User-selectable playback speed. Initialized from
   /// ``ReplayPlaybackConfig/playbackSpeed`` and writable at runtime
   /// (Demo controlBar's Speed Menu assigns to it directly, mirroring
@@ -617,6 +655,12 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
         firstSleepOverrideMs: overrideMs)
       overrideMs = nil
       if Task.isCancelled { return }
+      // Segment tail: append the closing card (if the outcome resolves) and,
+      // on a `.loop` wrap only, hold it briefly BEFORE `advanceAfterSource`
+      // wipes `chatItems` — otherwise the last source's card would be
+      // appended-then-wiped in the same synchronous call and never seen.
+      await concludeSource(sourceIndex: sourceIndex)
+      if Task.isCancelled { return }
       switch advanceAfterSource(currentIndex: sourceIndex) {
       case .continue(let nextIndex):
         sourceIndex = nextIndex
@@ -795,6 +839,17 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
     currentTotalRounds = nil
     phaseProgress = 0
     cachedTotalPhaseCount = Self.countPhases(in: sources[sourceIndex])
+    // Closing-card state (#884). Seed scores/eliminated from the roster (all
+    // `0` / `false`) — mirroring the live VM's run-start seed — so the resolver
+    // sees the full roster and `hasScores` keys off any non-zero value. Reset
+    // the vote maps and re-arm the append latch for this fresh source entry.
+    scores = Dictionary(
+      uniqueKeysWithValues: sources[sourceIndex].scenario.personas.map { ($0.name, 0) })
+    eliminated = Dictionary(
+      uniqueKeysWithValues: sources[sourceIndex].scenario.personas.map { ($0.name, false) })
+    voteResults = [:]
+    eliminationVotes = [:]
+    resultCardAppendedForCurrentSource = false
   }
 
   /// Pre-computes the number of `.phaseStarted` events in a source's
@@ -847,6 +902,59 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
     chatItems.append(.scenarioIntro(id: UUID(), premise: premise))
   }
 
+  // MARK: - Closing card (simulation result)
+
+  /// Appends the source's closing ``ChatItem/simulationResult`` card at its
+  /// segment tail (when the outcome resolves to something worth showing), then
+  /// — on a `.loop` wrap only — holds it for a reading beat before the caller's
+  /// ``advanceAfterSource(currentIndex:)`` wipes `chatItems`. The demo mirror
+  /// of the live sim's closing card (#868), carried inline on the `chatItems`
+  /// timeline so it accumulates in scroll history across rotation.
+  ///
+  /// Called from ``runPlayback(sourceIndex:startCursor:firstSleepOverrideMs:)``
+  /// after each source's plan drains, before rotation.
+  ///
+  /// **Idempotent** via ``resultCardAppendedForCurrentSource``: a resume that
+  /// re-enters after `playSource` has already drained (cursor at `plan.count`)
+  /// re-invokes this, but the latch skips the duplicate append. The wrap hold
+  /// intentionally re-runs on such a resume — re-showing the just-missed card
+  /// for a beat reads better than a flash-wipe, and threading the remaining
+  /// delay through here for a beat nobody perceives is not worth the plumbing.
+  ///
+  /// **Visibility guard**: the resolver returns `nil` for a summary-only
+  /// segment (no scores / votes / eliminations), so no empty card enters the
+  /// stream — mirroring ``appendIntroCard(forSourceIndex:)``'s empty-premise
+  /// skip.
+  private func concludeSource(sourceIndex: Int) async {
+    // A `downloadComplete()` landing in the gap between `playSource` returning
+    // and here already set `.transitioning` and cancelled the task; don't
+    // append a card into a torn-down VM. The `Task.isCancelled` check catches
+    // that today (every `.transitioning` transition also cancels); the
+    // `case .playing` guard is belt-and-suspenders against a future refactor
+    // that sets `.transitioning` without cancelling.
+    if Task.isCancelled { return }
+    guard case .playing = state else { return }
+    if !resultCardAppendedForCurrentSource,
+      let model = SimulationResultCard.Model(
+        scores: scores, eliminated: eliminated, voteResults: voteResults,
+        eliminationVotes: eliminationVotes,
+        phases: sources[sourceIndex].scenario.phases) {
+      chatItems.append(.simulationResult(id: UUID(), model: model))
+      resultCardAppendedForCurrentSource = true
+    }
+    // Hold only when the upcoming rotation will WIPE the card (loop wrap).
+    // Mid-cycle cards ride the next segment's intro-floor dwell for free;
+    // terminal cards (`.stopAfterLast`) stay on screen. `scaledDelay(for:
+    // .turn)` gives one speed-scaled turn beat (`.instant` → 0), so no bespoke
+    // pacing constant is introduced. Card look + hold feel are device-QA gated
+    // (ADR-009 / `.claude/rules/view-testing.md` rule 4).
+    let isLoopWrap =
+      config.loopBehaviour == .loop && sourceIndex == sources.count - 1
+    if resultCardAppendedForCurrentSource, isLoopWrap {
+      await sleepOrYield(milliseconds: scaledDelay(for: .turn))
+    }
+  }
+
   // MARK: - Render-time state updates
 
   /// Applies `event` to observable state with narrow ContentFilter
@@ -871,13 +979,30 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
         .agentOutput(
           AgentOutputEntry(agent: agent, output: filtered, phaseType: phaseType)))
 
-    case .summary, .scoreUpdate, .elimination, .voteResults,
-      .pairingResult, .assignment, .eventInjected:
-      // Code-phase events currently have no observable state surface
-      // in PR1 — the host view's scoreboard / results strip is the
-      // PR2 concern. ContentFilter is still applied in a follow-up
-      // commit when those surfaces land. For now these events update
-      // nothing visible; rendering them is a no-op here.
+    case .scoreUpdate(let newScores):
+      // Full-replace, matching ``SimulationViewModel/handleScoreUpdate``.
+      // Feeds the closing card's ranking (#884). No ContentFilter — the keys
+      // are persona names (structured identifiers); filtering could corrupt a
+      // name that happens to contain a blocklist substring (see header §
+      // "ContentFilter scope").
+      scores = newScores
+
+    case .voteResults(_, let tallies):
+      // Keep the latest tallies for the closing card's vote-only ranking.
+      // Last-wins matches `scores`' full-replace semantics. `votes` (who voted
+      // for whom) has no closing-card surface, so it is dropped here.
+      voteResults = tallies
+
+    case .elimination(let agent, let voteCount):
+      // Capture the count at elimination time so the card's survival framing
+      // shows each eliminated agent's own round tally (#884).
+      eliminated[agent] = true
+      eliminationVotes[agent] = voteCount
+
+    case .summary, .pairingResult, .assignment, .eventInjected:
+      // No closing-card surface: `.pairingResult` / `.assignment` feed scores
+      // via a later `.scoreUpdate`; `.summary` / `.eventInjected` are narrative
+      // only. Nothing visible updates here; rendering them is a no-op.
       return
 
     case .roundCompleted, .phaseCompleted, .simulationCompleted,

--- a/Pastura/Pastura/App/ReplayViewModel.swift
+++ b/Pastura/Pastura/App/ReplayViewModel.swift
@@ -270,7 +270,8 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
 
   /// Heterogeneous chat-stream item — an agent's rendered output, a
   /// demo-boundary marker inserted between sources during rotation (#208),
-  /// or a scenario-intro opening card at each segment's head (#867). Used by
+  /// a scenario-intro opening card at each segment's head (#867), or a
+  /// final-ranking closing card at each segment's tail (#868). Used by
   /// the host view's `ForEach` to dispatch on case.
   ///
   /// `.scenarioIntro` carries the source's premise (`scenario.description`) as
@@ -279,6 +280,13 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
   /// the same accumulate-across-rotation timeline as `.agentOutput` /
   /// `.demoBoundary`; on rotation the order is boundary → intro card.
   ///
+  /// `.simulationResult` carries an already-resolved
+  /// ``SimulationResultCard/Model`` (plain value type, no domain type crosses
+  /// into the View), appended at a segment's tail by
+  /// ``concludeSource(sourceIndex:)`` — the demo mirror of the live sim's
+  /// closing card. It rides the same timeline; on rotation the order is
+  /// result card → boundary → intro card.
+  ///
   /// `id` is projected from the inner payload so SwiftUI's
   /// `ForEach`/`scrollTo(_:anchor:)` keep working identically to the
   /// pre-#208 `AgentOutputEntry`-only timeline.
@@ -286,12 +294,14 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
     case agentOutput(AgentOutputEntry)
     case demoBoundary(id: UUID, scenarioName: String)
     case scenarioIntro(id: UUID, premise: String)
+    case simulationResult(id: UUID, model: SimulationResultCard.Model)
 
     var id: UUID {
       switch self {
       case .agentOutput(let entry): return entry.id
       case .demoBoundary(let id, _): return id
       case .scenarioIntro(let id, _): return id
+      case .simulationResult(let id, _): return id
       }
     }
   }

--- a/Pastura/Pastura/Views/Components/SimulationResultCard+Model.swift
+++ b/Pastura/Pastura/Views/Components/SimulationResultCard+Model.swift
@@ -11,7 +11,12 @@ extension SimulationResultCard {
   /// keep `SimulationResultCard`'s type body under swiftlint's limit; declared
   /// `nonisolated` so the pure derivation runs off the MainActor and is
   /// unit-testable from a nonisolated test.
-  nonisolated struct Model: Equatable {
+  ///
+  /// `Sendable` is explicit (not left to implicit synthesis) because this Model
+  /// is carried as a payload on ``ReplayViewModel/ChatItem``, whose own
+  /// `Sendable` conformance requires every associated value to be `Sendable`
+  /// (#884). `Framing` / `Entry` are `Sendable` value types.
+  nonisolated struct Model: Equatable, Sendable {
     let framing: Framing
     let entries: [Entry]
 

--- a/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+ChatStream.swift
+++ b/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+ChatStream.swift
@@ -33,6 +33,8 @@ extension ModelDownloadHostView {
                   .transition(reduceMotion ? .identity : .opacity)
               case .scenarioIntro(let id, let premise):
                 demoIntroCard(id: id, premise: premise, viewModel: viewModel)
+              case .simulationResult(let id, let model):
+                demoResultCard(id: id, model: model)
               }
             }
           }
@@ -140,6 +142,25 @@ extension ModelDownloadHostView {
       .id(id)
       .transition(reduceMotion ? .identity : .opacity)
     }
+  }
+
+  /// One closing card (``SimulationResultCard``) at a demo segment's tail
+  /// (#868), reusing the live sim's presentation-only component. The demo
+  /// mirror of the live sim's closing card — but carried inline in the
+  /// `chatItems` timeline (so it accumulates in scroll history across demo
+  /// rotation) rather than as a fixed trailing View element the way
+  /// ``SimulationView`` renders it.
+  ///
+  /// `onTap` is `nil`: the demo host has no `ScoreboardSheet`, so the card is
+  /// display-only here (an intentional asymmetry with the live sim's
+  /// tap-to-scoreboard affordance — the demo is a passive preview). The card
+  /// is static (no typewriter reveal), so — unlike ``demoIntroCard`` — it
+  /// needs no `typedIntroIds`-style latch.
+  @ViewBuilder
+  private func demoResultCard(id: UUID, model: SimulationResultCard.Model) -> some View {
+    SimulationResultCard(model: model, onTap: nil)
+      .id(id)
+      .transition(reduceMotion ? .identity : .opacity)
   }
 
   /// PromoCard lives in the bottom safe area (not a ZStack overlay) so the

--- a/Pastura/PasturaTests/App/ReplayViewModelTests+Closing.swift
+++ b/Pastura/PasturaTests/App/ReplayViewModelTests+Closing.swift
@@ -1,0 +1,191 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+// Closing-card (`ChatItem.simulationResult`) emission tests for
+// `ReplayViewModel` (#884) — the demo mirror of the live sim's final-ranking
+// card (#868). Sibling-file `extension` per `.claude/rules/testing.md` — NOT a
+// new `@Suite` (a parallel suite would race the VM-spawning original on the
+// shared test process; the `.serialized` / `.timeLimit` traits live on the base
+// `@Suite`).
+extension ReplayViewModelTests {
+
+  // MARK: - Ranking-outcome fixtures
+
+  /// A demo YAML that pairs one turn with a `scoreUpdate` code-phase event so
+  /// the source resolves to a `.ranking` closing card. The score event shares
+  /// the turn's `(round, phase_index)` so it synthesises no extra
+  /// `.phaseStarted` marker — keeping this fixture off any phase-count canary.
+  static let rankingResultYAML = """
+    schema_version: 1
+    turns:
+      - round: 1
+        phase_index: 0
+        phase_type: speak_all
+        agent: Alice
+        fields: { statement: 'hello' }
+    code_phase_events:
+      - round: 1
+        phase_index: 0
+        phase_type: score_calc
+        summary: 'Scores — Alice: 5, Bob: 2'
+        payload:
+          kind: scoreUpdate
+          scores:
+            Alice: 5
+            Bob: 2
+    """
+
+  /// A source (Alice/Bob `speak_all` scenario) whose recorded events include a
+  /// non-zero `scoreUpdate` — so `concludeSource` resolves a `.ranking` card.
+  static func makeRankingSource(config: ReplayPlaybackConfig) throws -> YAMLReplaySource {
+    try YAMLReplaySource(
+      yaml: rankingResultYAML, scenario: makeScenario(), config: config)
+  }
+
+  /// True when `chatItems` holds at least one closing card.
+  static func hasResultCard(_ viewModel: ReplayViewModel) -> Bool {
+    viewModel.chatItems.contains {
+      if case .simulationResult = $0 { return true }
+      return false
+    }
+  }
+
+  // MARK: - Segment-tail emission
+
+  /// A source with a resolvable outcome appends a `.simulationResult` closing
+  /// card as the tail chat item, carrying the resolved ranking Model. Uses
+  /// `holdConfig` (stopAfterLast + awaitTransitionSignal) so the VM holds after
+  /// the single source's plan, and `.loop`-only wrap-hold never fires.
+  @Test func concludeAppendsRankingResultCardAtTail() async throws {
+    let source = try Self.makeRankingSource(config: Self.holdConfig)
+    let viewModel = ReplayViewModel(
+      sources: [source], config: Self.holdConfig, contentFilter: ContentFilter())
+    viewModel.start()
+    // The card is appended by `concludeSource` AFTER the plan drains, so poll on
+    // `chatItems` (reading state cursor would race the append).
+    await Self.waitForState(viewModel, timeout: .seconds(5)) { _ in
+      Self.hasResultCard(viewModel)
+    }
+    guard case .simulationResult(_, let model) = viewModel.chatItems.last else {
+      Issue.record(
+        "chatItems.last expected .simulationResult, got \(String(describing: viewModel.chatItems.last))"
+      )
+      return
+    }
+    #expect(model.framing == .ranking)
+    #expect(model.entries.count == 2)
+    #expect(model.entries.first?.name == "Alice")
+    #expect(model.entries.first?.rank == 1)
+    #expect(model.entries.first?.primaryValue == 5)
+    #expect(model.entries.last?.name == "Bob")
+    #expect(model.entries.last?.rank == 2)
+  }
+
+  /// A summary-only source (no scores / votes / eliminations) resolves to `nil`
+  /// and appends NO closing card — mirroring the resolver's visibility guard
+  /// and the intro card's empty-premise skip. Uses the default `speak_all`
+  /// fixture, which carries no `code_phase_events`.
+  @Test func summaryOnlySourceAppendsNoResultCard() async throws {
+    let viewModel = try Self.makeVM()  // default: speak_all only, no code events
+    viewModel.start()
+    // Wait for the plan to drain (3 turns + 2 lifecycle = 5), then give
+    // `concludeSource` a beat to run before asserting absence.
+    await Self.waitForState(viewModel, timeout: .seconds(5)) { state in
+      if case .playing(_, let cursor) = state { return cursor >= 5 }
+      return false
+    }
+    try await Task.sleep(for: .milliseconds(50))
+    #expect(!Self.hasResultCard(viewModel))
+  }
+
+  // MARK: - Rotation ordering (result card → boundary)
+
+  /// On mid-cycle rotation the closing card is the tail of the FINISHING
+  /// segment — it lands before the `.demoBoundary` that opens the next segment
+  /// (on-screen order: … turns, result card, boundary, next intro …).
+  @Test func resultCardPrecedesBoundaryOnRotation() async throws {
+    let sources = [
+      try Self.makeRankingSource(config: Self.holdConfig),
+      try Self.makeRankingSource(config: Self.holdConfig)
+    ]
+    let viewModel = ReplayViewModel(
+      sources: sources, config: Self.holdConfig, contentFilter: ContentFilter())
+    viewModel.start()
+    // Wait until BOTH sources have concluded (2 closing cards present). Polling
+    // the card count — not the state cursor — avoids racing the append, which
+    // lands just after `playSource` sets the final `.playing(1, 4)` cursor.
+    await Self.waitForState(viewModel, timeout: .seconds(6)) { _ in
+      viewModel.chatItems.filter {
+        if case .simulationResult = $0 { return true }
+        return false
+      }.count >= 2
+    }
+    guard
+      let boundaryIndex = viewModel.chatItems.firstIndex(where: {
+        if case .demoBoundary = $0 { return true }
+        return false
+      })
+    else {
+      Issue.record("Expected a .demoBoundary in chatItems, got \(viewModel.chatItems)")
+      return
+    }
+    // The item immediately before the boundary is source 0's closing card.
+    guard boundaryIndex >= 1 else {
+      Issue.record("No item before the boundary at \(boundaryIndex): \(viewModel.chatItems)")
+      return
+    }
+    if case .simulationResult = viewModel.chatItems[boundaryIndex - 1] {
+      // expected
+    } else {
+      Issue.record(
+        "Item before boundary expected .simulationResult, got \(viewModel.chatItems[boundaryIndex - 1])"
+      )
+    }
+    // Source 1's own closing card is the very last item.
+    if case .simulationResult = viewModel.chatItems.last {
+      // expected
+    } else {
+      Issue.record(
+        "chatItems.last expected source-1 .simulationResult, got \(String(describing: viewModel.chatItems.last))"
+      )
+    }
+  }
+
+  // MARK: - Loop re-arm (Critical guard, #884)
+
+  /// The append latch must clear on every fresh source entry, so a source
+  /// re-appends its closing card on each `.loop` cycle. Guards the
+  /// keyed-`Set<Int>`-never-cleared bug (cards would render for cycle 1 only,
+  /// then silently vanish under the default loop-forever demo config).
+  @Test func loopReArmsResultCardEachCycle() async throws {
+    let sources = [
+      try Self.makeRankingSource(config: Self.loopConfig),
+      try Self.makeRankingSource(config: Self.loopConfig)
+    ]
+    let viewModel = ReplayViewModel(
+      sources: sources, config: Self.loopConfig, contentFilter: ContentFilter())
+    viewModel.start()
+    // Step 1: wait for wrap-around — the VM must reach source 1, then return to
+    // source 0. The wrap wipes `chatItems`, so any card seen after this point
+    // belongs to cycle 2.
+    var sawSource1 = false
+    await Self.waitForState(viewModel, timeout: .seconds(8)) { state in
+      guard case .playing(let idx, _) = state else { return false }
+      if idx == 1 { sawSource1 = true }
+      return sawSource1 && idx == 0
+    }
+    guard sawSource1 else {
+      Issue.record("Never observed source 1 before timeout; state=\(viewModel.state)")
+      return
+    }
+    // Step 2: source 0 replays in cycle 2 and must append its card AGAIN. If the
+    // latch were keyed and never cleared, no card would appear this cycle.
+    await Self.waitForState(viewModel, timeout: .seconds(8)) { _ in
+      Self.hasResultCard(viewModel)
+    }
+    #expect(Self.hasResultCard(viewModel), "closing card must re-arm on the second loop cycle")
+    viewModel.downloadComplete()  // stop the infinite loop deterministically
+  }
+}


### PR DESCRIPTION
## Summary
- Adopt `SimulationResultCard` (the final-ranking closing card) into the DL-time demo replay screen (`ModelDownloadHostView` ChatStream). Demo replay previously showed agent turns but no outcome (votes / eliminations / scores).
- Mirror of the live-sim closing card (#868) and the demo intro-card adoption (#867). The card rides the `chatItems` timeline as a new `ChatItem.simulationResult` case, so it accumulates inline in scroll history across demo rotation — unlike the live `SimulationView`, which renders it as a fixed trailing element.
- `ReplayViewModel` now accumulates `scores` / `eliminated` / `voteResults` / `eliminationVotes` from the interleaved code-phase events (`apply()` no longer drops them; persona-name keys pass through ContentFilter-free as structured identifiers), seeds/resets them per source, and a new `concludeSource` step resolves + appends the card between `playSource` and rotation.
- A single-Bool append latch (cleared on fresh source entry in `resetPerDemoState`, not on resume) re-arms the card each `.loop` cycle while guarding resume double-append. A speed-scaled hold (`scaledDelay(for: .turn)`) runs **only** on a `.loop` wrap — where `advanceAfterSource` would otherwise wipe the just-appended card before it is seen; mid-cycle and terminal (`.stopAfterLast`) cards need no hold.
- No new SPM deps. No new user-facing strings (card text is already in the catalog).

## Test plan
- New `ReplayViewModelTests+Closing.swift` (extension of the existing `.serialized` suite, not a new `@Suite`): ranking card at tail, summary-only source → no card, result-card-before-boundary ordering, and a loop re-arm regression guard (fails if the latch is keyed / never cleared).
- Full unit suite: **2445 tests / 208 suites pass**; `swiftlint --strict` clean.
- code-reviewer (Opus): PASS (0 critical / 0 warning).

## Device QA
- Card look + hold feel are code-review + device-QA gated (ADR-009 / `.claude/rules/view-testing.md` rule 4). Confirm the `.loop`-wrap hold reads well on device.
- At **Max (`.instant`)** playback speed the wrap hold collapses to `0`, so the last-of-cycle card is appended then wiped in the same tick — consistent with the "everything is instant at Max" contract; verify it matches the intended demo feel.

Closes #884.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
