### PR TITLE
✨ feat: add dangling-ADR-reference detector to consistency-audit

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -48,6 +48,7 @@
       "Bash(gh issue list*)",
       "Bash(gh issue edit*)",
       "Bash(gh issue comment*)",
+      "Bash(gh issue create*)",
       "Bash(gh pr create --draft*)",
       "Bash(gh label list*)",
       "Bash(git cat-file -e origin/main:.github/ISSUE_TEMPLATE/agent-task.yml)",

--- a/.claude/skills/consistency-audit/SKILL.md
+++ b/.claude/skills/consistency-audit/SKILL.md
@@ -24,12 +24,15 @@ safe to run unattended.
   once an operator is confident, a *separate* `/schedule` routine invokes
   `/consistency-audit` (see "Scheduling" below). The unattended command set
   (`git switch -c audit/*`, the skill's `python3` scripts, `git push`,
-  `gh pr create --draft`) is now allowlisted so a routine run does not block on
-  those prompts. `git commit` is allowlisted too — since #411 the commit-time
-  gate moved to the git pre-commit hook (`swiftlint --strict` + build), so
-  there is no per-commit prompt. (`gh issue create` is likewise
-  NOT allowlisted — Step 4 is unreachable while all needs_judgment detectors
-  are deferred; a future detector author re-allowlists it deliberately.)
+  `gh pr create --draft`, `gh issue create`) is allowlisted so a routine run
+  does not block on those prompts. `git commit` is allowlisted too — since #411
+  the commit-time gate moved to the git pre-commit hook (`swiftlint --strict` +
+  build), so there is no per-commit prompt. (`gh issue create` was allowlisted
+  with the dangling-ADR detector (#876), which can file Step 4 issues — as can
+  the always-live `dead_link` detector. It is exercised only when a
+  needs_judgment finding actually fires; on a clean `main` both detectors are
+  designed to report zero, so Step 4 stays quiet by construction, not because
+  it is unreachable.)
 - **No merging, no issue closing.** The human reviews each Draft PR; merging
   closes nothing automatically here.
 - **No parallelism — single writer.** One audit run at a time. Two overlapping
@@ -183,10 +186,13 @@ Only if `auto_fixable` is non-empty AND Step 2 found no open `audit/*` PR:
 
 ## Step 4 — needs_judgment → issues
 
-For each `needs_judgment` finding (already deduped by target):
+For each `needs_judgment` finding (already deduped by `target`):
 
 1. **Dedup across runs:** search open issues for the target; skip if one
-   exists. `gh issue list --state open --search "<target> in:title"`.
+   exists. `gh issue list --state open --search "<target> in:title"`. Every
+   finding carries a `target` for this — for `dead_link` it is the link path,
+   for `dangling_adr` it is the ADR id (`ADR-099`), so embed `target` in the
+   issue title verbatim.
 2. File an issue (`--label documentation`) whose body has:
    - **Locations**: every `file:line` the target is referenced from.
    - **Confidence**: how sure the detector is this is a real problem.
@@ -194,6 +200,11 @@ For each `needs_judgment` finding (already deduped by target):
      intentionally-absent path, a generated artifact, or a moved file whose
      correct new location only a human knows.
    - **Suggested action**, explicitly left for a human to decide.
+
+   Some detectors pre-author these fields. A `dangling_adr` finding already
+   carries `confidence`, `counter_evidence`, and `suggested_action` on the JSON
+   — use them verbatim rather than re-deriving. `dead_link` does not, so author
+   its confidence / counter-evidence at filing time as before.
 
 Never auto-fix these — the whole point is the fix needs judgment.
 
@@ -230,9 +241,6 @@ enabling. Each floods the reference-dense repo today:
   slugs (`mattt/llama.swift`), external paths (`src/llama-grammar.cpp`), and
   property accessors (`TurnOutput.primaryText`). A repo-root existence check
   misreads all of these. Needs source-root resolution + a non-file exclusion.
-- **ADR-missing reference checks** — reserved/not-yet-written ADRs (ADR-006)
-  are referenced from ~20 lines that lack the marker. Needs a canonical
-  reserved-ADR set parsed from the ADR index, not a per-line marker.
 - **broken-anchor / `§"..."` cross-refs** — GitHub-slug anchor matching is
   fragile on emoji headings and duplicate-heading suffixes; bare `§"..."` prose
   refs have no unambiguous target. Needs a verified slug normalizer + a target

--- a/.claude/skills/consistency-audit/scripts/audit_docs.py
+++ b/.claude/skills/consistency-audit/scripts/audit_docs.py
@@ -17,16 +17,23 @@ Two finding classes:
                    section.
 
 Conservatism is deliberate: false positives poison the queue, so each detector
-prefers a miss over a wrong flag. v1 ships only the three detectors proven to
-fire zero false positives on the current repo (dependency_version, min_ios,
-dead_link). Detectors that flood until their FP sources are designed out are
-intentionally deferred — see the SKILL's "Deferred detectors" note:
+prefers a miss over a wrong flag. Every shipped detector fires zero false
+positives on the current repo: dependency_version, min_ios, dead_link
+(needs_judgment), and dangling_adr (needs_judgment). Detectors that flood until
+their FP sources are designed out are intentionally deferred — see the SKILL's
+"Deferred detectors" note:
   - file:line citation checks   (docs cite source-root-relative paths, GitHub
                                  org/repo slugs, and property accessors that a
                                  naive repo-root existence check misreads)
-  - ADR-missing reference checks (reserved/not-yet-written ADRs like ADR-006
-                                 are referenced from lines without the marker)
   - broken-anchor / `§"..."`    (fragile GitHub-slug matching; ambiguous target)
+
+The dangling_adr detector neutralizes intentionally-absent ADRs via a canonical
+reserved set parsed from CLAUDE.md's Reference Documents table (not a per-line
+marker) — see load_reserved_adrs. Its blind spots are conservative by design: a
+reserved row must exist in the table before an absent ADR is referenced, else
+the reference is flagged (an issue, never an auto-fix); an inline "ADR-NNN
+(reserved / not yet written)" reference is skipped by the shared reserved-line
+guard even without a table row.
 
 usage:
   audit_docs.py [--repo-root DIR] [--fix]
@@ -62,6 +69,13 @@ MINIOS_LABEL = re.compile(r"(?i)min(?:imum)?\s+ios")
 MD_LINK = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
 RESERVED = re.compile(r"(?i)reserved|not[\s-]?yet[\s-]?written")
 FENCE = re.compile(r"^\s*(```|~~~)")
+# Repo convention: ADRs are always ADR-NNN (three digits). Word-bounded so a
+# longer token can't produce a spurious match.
+ADR_REF = re.compile(r"\bADR-(\d{3})\b")
+# The reserved *subject* is the ADR in a Reference-Documents row's first cell
+# (`docs/decisions/ADR-NNN.md`), never a bare ADR-NNN elsewhere in the row —
+# so "see ADR-005 §7.5" inside the ADR-006 reservation row cannot reserve 005.
+RESERVED_ADR_CELL = re.compile(r"docs/decisions/ADR-(\d{3})\.md")
 
 EXCLUDE_PARTS = {".git", "DerivedData", "node_modules"}
 
@@ -118,8 +132,30 @@ def load_min_ios(path: Path) -> str | None:
     return vals.pop() if len(vals) == 1 else None
 
 
+def load_reserved_adrs(claude_md: Path) -> set[str]:
+    """Canonical set of intentionally-absent ADR numbers, parsed from
+    CLAUDE.md's Reference Documents table. A row reserves its subject ADR when
+    it is a table row (`|`-delimited) carrying a reserved / not-yet-written
+    marker AND a `docs/decisions/ADR-NNN.md` first-cell path — keyed on that
+    cell so a bare ADR reference in the description can't reserve the wrong
+    number. Absent/unreadable CLAUDE.md yields the empty set (fail-open: every
+    referenced-but-missing ADR would then be flagged, never silently absorbed)."""
+    try:
+        lines = claude_md.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return set()
+    reserved: set[str] = set()
+    for line in lines:
+        if "|" not in line or not RESERVED.search(line):
+            continue
+        m = RESERVED_ADR_CELL.search(line)
+        if m:
+            reserved.add(m.group(1))
+    return reserved
+
+
 def scan_doc(path: Path, root: Path, resolved: dict[str, str],
-             min_ios: str | None):
+             min_ios: str | None, reserved_adrs: set[str]):
     """Return (auto_fixable, judgment) finding lists for one doc file."""
     rel = os.path.relpath(path, root).replace(os.sep, "/")
     try:
@@ -199,7 +235,44 @@ def scan_doc(path: Path, root: Path, resolved: dict[str, str],
                 judg.append({"type": "dead_link", "target": target,
                              "key": str(tgt), "file": rel, "line": lineno})
 
+        # --- needs_judgment: dangling ADR references ---
+        # A referenced ADR-NNN with no docs/decisions/ADR-NNN.md and no reserved
+        # row is a dead decision reference (a typo, a renumber, or a forthcoming
+        # ADR whose reservation was never recorded). Never auto-fixed — which of
+        # those it is needs a human.
+        for m in ADR_REF.finditer(line):
+            nnn = m.group(1)
+            if nnn in reserved_adrs:
+                continue
+            if (root / "docs" / "decisions" / f"ADR-{nnn}.md").exists():
+                continue
+            adr = f"ADR-{nnn}"
+            judg.append({
+                "type": "dangling_adr", "adr": adr,
+                # target mirrors the ADR id so this rides the shared
+                # dedup_judgment (type, key) grouping and the SKILL Step 4
+                # `<target> in:title` cross-run dedup unchanged.
+                "target": adr, "key": adr,
+                "confidence": "medium",
+                "counter_evidence": (
+                    f"{adr} may be a forthcoming ADR whose reserved row has not "
+                    "yet been added to CLAUDE.md's Reference Documents table, or "
+                    "a renamed / renumbered ADR — only a human knows the "
+                    "intended target."),
+                "suggested_action": (
+                    f"Resolve one of: write docs/decisions/{adr}.md; fix the "
+                    "reference number if it is a typo; or record a reserved row "
+                    "for it in CLAUDE.md's Reference Documents table."),
+                "file": rel, "line": lineno})
+
     return auto, judg
+
+
+# Per-occurrence keys are collapsed into `locations`; every other scalar on a
+# finding (target, adr, confidence, ...) carries through from the first
+# occurrence. Keeps dead_link's output exactly {type, target, locations} while
+# letting dangling_adr surface its judgment scalars.
+_PER_OCCURRENCE = {"file", "line", "key"}
 
 
 def dedup_judgment(items: list[dict]) -> list[dict]:
@@ -208,8 +281,11 @@ def dedup_judgment(items: list[dict]) -> list[dict]:
     grouped: dict[tuple[str, str], dict] = {}
     for it in items:
         gk = (it["type"], it["key"])
-        g = grouped.setdefault(gk, {
-            "type": it["type"], "target": it["target"], "locations": []})
+        g = grouped.get(gk)
+        if g is None:
+            g = {k: v for k, v in it.items() if k not in _PER_OCCURRENCE}
+            g["locations"] = []
+            grouped[gk] = g
         g["locations"].append({"file": it["file"], "line": it["line"]})
     return list(grouped.values())
 
@@ -266,11 +342,12 @@ def main() -> int:
                     else root / DEFAULT_PBXPROJ)
     resolved = load_resolved(resolved_path)
     min_ios = load_min_ios(pbxproj_path)
+    reserved_adrs = load_reserved_adrs(root / "CLAUDE.md")
 
     auto: list[dict] = []
     judg: list[dict] = []
     for doc in discover_docs(root):
-        a, j = scan_doc(doc, root, resolved, min_ios)
+        a, j = scan_doc(doc, root, resolved, min_ios, reserved_adrs)
         auto.extend(a)
         judg.extend(j)
 

--- a/.claude/skills/consistency-audit/tests/fixtures/adr/CLAUDE.md
+++ b/.claude/skills/consistency-audit/tests/fixtures/adr/CLAUDE.md
@@ -1,0 +1,34 @@
+# ADR-reference fixture
+
+Exercises the dangling_adr detector: two references fire, three stay silent.
+Prose avoids the shared per-line marker words except on the two lines that
+intentionally carry a marker.
+
+## Reference Documents
+
+| Document                     | Content                                                       |
+|------------------------------|---------------------------------------------------------------|
+| `docs/decisions/ADR-001.md`  | Architecture overview                                         |
+| `docs/decisions/ADR-006.md`  | Cloud API (Phase 3; reserved — not yet written; see ADR-005 §7.5) |
+
+## Must fire
+
+- A dangling mention of ADR-099 with no matching file is a finding.
+- A plain-body mention of ADR-005 is a finding — it shows up only inside the
+  ADR-006 row's description cell, and first-cell keying keys on 006, so a bare
+  mention in a description cannot silence a different number.
+
+## Must NOT fire
+
+- A plain-body mention of ADR-006 is absorbed by the canonical set built from
+  the table above; this line carries no inline marker, so the set path (not
+  the per-line guard) is what keeps it quiet.
+- A mention of ADR-001 resolves to its file under docs/decisions.
+- An inline mention of ADR-098 (reserved — not yet written) is dropped by the
+  shared per-line guard even though no table row lists it.
+
+## Fenced block (must be skipped)
+
+```
+A fenced mention of ADR-097 stays silent.
+```

--- a/.claude/skills/consistency-audit/tests/fixtures/adr/CLAUDE.md
+++ b/.claude/skills/consistency-audit/tests/fixtures/adr/CLAUDE.md
@@ -1,6 +1,6 @@
 # ADR-reference fixture
 
-Exercises the dangling_adr detector: two references fire, three stay silent.
+Exercises the dangling_adr detector: two references fire, four stay silent.
 Prose avoids the shared per-line marker words except on the two lines that
 intentionally carry a marker.
 
@@ -14,9 +14,9 @@ intentionally carry a marker.
 ## Must fire
 
 - A dangling mention of ADR-099 with no matching file is a finding.
-- A plain-body mention of ADR-005 is a finding — it shows up only inside the
-  ADR-006 row's description cell, and first-cell keying keys on 006, so a bare
-  mention in a description cannot silence a different number.
+- A plain-body mention of ADR-005 is a finding — first-cell keying reserves
+  006 alone, so ADR-005 also appearing in the ADR-006 row's description cell
+  (itself guard-skipped) never neutralizes this plain-body mention.
 
 ## Must NOT fire
 

--- a/.claude/skills/consistency-audit/tests/fixtures/adr/docs/decisions/ADR-001.md
+++ b/.claude/skills/consistency-audit/tests/fixtures/adr/docs/decisions/ADR-001.md
@@ -1,0 +1,4 @@
+# ADR-001
+
+A real ADR file so the `ADR-001` reference in the adr fixture resolves and
+must not be flagged as dangling.

--- a/.claude/skills/consistency-audit/tests/run_tests.sh
+++ b/.claude/skills/consistency-audit/tests/run_tests.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # Self-test for the consistency-audit detector. No Swift toolchain or network
-# needed — exercises the three fixture repos (clean / drift / judgment)
-# against audit_docs.py, including the must-NOT-fire regression set and the
-# Package.resolved version-vs-revision trap.
+# needed — exercises the fixture repos (clean / drift / judgment / boundary /
+# adr) against audit_docs.py, including the must-NOT-fire regression set, the
+# Package.resolved version-vs-revision trap, and the dangling-ADR reserved-set
+# / first-cell-keying guards.
 #
 # usage: bash .claude/skills/consistency-audit/tests/run_tests.sh
 # requires: python3, jq

--- a/.claude/skills/consistency-audit/tests/run_tests.sh
+++ b/.claude/skills/consistency-audit/tests/run_tests.sh
@@ -80,5 +80,35 @@ OUT=$(python3 "$AUDIT" --repo-root fixtures/judgment)
   || fail "judgment: both findings should be dead_link"
 echo "$OUT" | jq -e '.needs_judgment[] | select(.target=="docs/missing-a.md")' >/dev/null \
   || fail "judgment: missing-a.md dead link not found"
+# dead_link's post-dedup shape must stay exactly {type, target, locations} —
+# genericizing dedup_judgment for dangling_adr must not leak the ADR-only
+# scalars (adr / confidence / ...) onto a dead_link finding.
+echo "$OUT" | jq -e '.needs_judgment[] | select(.type=="dead_link") | select(has("adr") or has("confidence") or has("key") or has("file") or has("line"))' >/dev/null \
+  && fail "judgment: dead_link finding leaked a non-dead_link/per-occurrence key" || true
+echo "$OUT" | jq -e '[.needs_judgment[] | select(.type=="dead_link") | (has("target") and has("locations"))] | all' >/dev/null \
+  || fail "judgment: a dead_link finding is missing target/locations"
+
+# --- adr fixture: dangling ADR flagged; reserved / existing / fenced silent --
+# ADR-099 (no file, no reserved row) and ADR-005 (only in the ADR-006 row's
+# description — first-cell keying reserves 006, not 005) fire; ADR-006 (reserved
+# set), ADR-001 (existing file), ADR-098 (inline marker) and ADR-097 (fenced)
+# stay silent.
+OUT=$(python3 "$AUDIT" --repo-root fixtures/adr)
+[ "$(af_len "$OUT")" -eq 0 ] || fail "adr: auto_fixable should be empty: $(echo "$OUT" | jq -c .auto_fixable)"
+DAD_LEN=$(echo "$OUT" | jq '[.needs_judgment[] | select(.type=="dangling_adr")] | length')
+[ "$DAD_LEN" -eq 2 ] || fail "adr: expected 2 dangling_adr, got $DAD_LEN: $(echo "$OUT" | jq -c '[.needs_judgment[]|select(.type=="dangling_adr").adr]')"
+echo "$OUT" | jq -e '.needs_judgment[] | select(.type=="dangling_adr" and .adr=="ADR-099")' >/dev/null \
+  || fail "adr: dangling ADR-099 not flagged"
+echo "$OUT" | jq -e '.needs_judgment[] | select(.type=="dangling_adr" and .adr=="ADR-005")' >/dev/null \
+  || fail "adr: ADR-005 (first-cell-keying regression) not flagged"
+# the must-NOT-fire set: reserved subject, existing file, inline-marked, fenced.
+for silent in ADR-006 ADR-001 ADR-098 ADR-097; do
+  echo "$OUT" | jq -e ".needs_judgment[] | select(.type==\"dangling_adr\" and .adr==\"$silent\")" >/dev/null \
+    && fail "adr: $silent should NOT be flagged" || true
+done
+# every dangling_adr finding carries the detector-authored judgment scalars +
+# a target aliasing the ADR id (Step 4 `<target> in:title` dedup depends on it).
+echo "$OUT" | jq -e '[.needs_judgment[] | select(.type=="dangling_adr") | (has("adr") and has("target") and has("confidence") and has("counter_evidence") and has("suggested_action") and (.target==.adr))] | all' >/dev/null \
+  || fail "adr: a dangling_adr finding is missing its judgment scalars or target!=adr"
 
 echo "ALL TESTS PASSED"

--- a/scripts/tests/consistency-audit-test.sh
+++ b/scripts/tests/consistency-audit-test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# scripts/tests/consistency-audit-test.sh — CI shim that runs the
+# consistency-audit detector's self-test (#876).
+#
+# The skill's own harness lives at
+# `.claude/skills/consistency-audit/tests/run_tests.sh`, which the CI
+# "Shell gate tests" job does NOT pick up — that job globs only
+# `scripts/tests/*-test.sh`. Without this shim the detector's fixtures
+# (clean / drift / judgment / boundary / adr) run nowhere automatically,
+# so the "zero findings on main" guarantee would have no regression guard.
+# This file matches the glob and delegates, giving the harness a CI home.
+#
+# The harness needs python3 + jq (both present on the ubuntu-latest runner);
+# it `cd`s to its own dir, so it is invocation-location independent.
+#
+# Run manually: bash scripts/tests/consistency-audit-test.sh
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+bash "$REPO_ROOT/.claude/skills/consistency-audit/tests/run_tests.sh"


### PR DESCRIPTION
## Summary
Implements the deferred **dangling-ADR-reference detector** (#876) for the `consistency-audit` skill.

- New `dangling_adr` detector in `audit_docs.py`: flags `ADR-NNN` references with no `docs/decisions/ADR-NNN.md` file that are not in a canonical reserved-ADR set parsed at runtime from CLAUDE.md's Reference Documents table (first-cell keying — a "see ADR-005" inside the ADR-006 reservation row does not mis-reserve 005). Routed as `needs_judgment` → issue only, never auto-fixed. `dedup_judgment` genericized to carry detector-authored judgment scalars while preserving `dead_link`'s exact `{type,target,locations}` shape.
- **Zero findings on current main** (ADR-006 is the only missing ADR and is absorbed by the reserved set) — the acceptance criterion, verified.
- Fixtures + `run_tests.sh` cases (dangling → flag; reserved / existing / inline-marked / fenced → silent; first-cell-keying regression via ADR-005; `dead_link` shape regression assert) **+ a CI shim** (`scripts/tests/consistency-audit-test.sh`) so the skill harness finally runs under CI's `scripts/tests/*-test.sh` glob — it had no CI home before.
- SKILL.md: moved out of *Deferred detectors*, rewrote the Non-goals note to the accurate invariant, documented Step 4 detector-authored fields; allowlisted `Bash(gh issue create*)`.

## Test plan
- `bash .claude/skills/consistency-audit/tests/run_tests.sh` → ALL TESTS PASSED
- Full `scripts/tests/*-test.sh` suite green locally (incl. the new shim)
- Detector on real `main`: `auto_fixable: 0, needs_judgment: 0`
- No Swift diff → iOS test suite N/A (item-2 pre-commit `xcodebuild build` passed)

Closes #876

🤖 Generated with [Claude Code](https://claude.com/claude-code)