### PR TITLE
✨ feat: glyph phase steps for the gallery "What happens" section

### DIFF
--- a/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailFormat.swift
+++ b/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailFormat.swift
@@ -1,39 +1,18 @@
 import Foundation
 
 /// Pure presentation helpers for ``GalleryScenarioDetailView``'s enriched
-/// metadata rows and the "What happens" phase-flow section.
+/// metadata rows and the "What happens" phase-step section.
 ///
 /// Extracted from the View so the mapping / hide-when-empty logic is
 /// unit-testable without rendering (`.claude/rules/view-testing.md` rule 1).
 ///
 /// Left at the default (MainActor) isolation — **not** `nonisolated` — because
-/// ``phaseFlow(phases:)`` composes ``PhaseDisplayName/label(for:)``, a
-/// MainActor View-layer helper; a `nonisolated` enum passing that function
-/// value would drop the `@MainActor` (swift-isolation.md Pattern 5). The test
-/// suite is therefore `@MainActor`; MainActor can still call these directly.
+/// ``phaseSteps(phases:)`` composes ``PhaseDisplayName/label(for:)`` and
+/// ``PhaseGlyph/symbolName(for:)``, MainActor View-layer helpers; a
+/// `nonisolated` enum passing those function values would drop the
+/// `@MainActor` (swift-isolation.md Pattern 5). The test suite is therefore
+/// `@MainActor`; MainActor can still call these directly.
 enum GalleryScenarioDetailFormat {
-
-  /// Separator drawn between consecutive phase labels in the flow.
-  static let phaseSeparator = " → "
-
-  /// Ordered, human-readable phase flow for the "What happens" section,
-  /// derived from a gallery entry's `phases` raw strings (e.g.
-  /// `"Speak Each → Summarize"`).
-  ///
-  /// Each raw value is mapped through ``PhaseType`` → ``PhaseDisplayName``;
-  /// unknown kinds (a feed newer than this build knows) are skipped, mirroring
-  /// the lenient forward-compat posture of ``GalleryScenario/phases``. Returns
-  /// `nil` — so the caller hides the section — when `phases` is absent / empty
-  /// **or** every entry mapped away (all-unknown), so no empty section renders.
-  static func phaseFlow(phases: [String]?) -> String? {
-    guard let phases else { return nil }
-    let labels =
-      phases
-      .compactMap { PhaseType(rawValue: $0) }
-      .map(PhaseDisplayName.label(for:))
-    guard !labels.isEmpty else { return nil }
-    return labels.joined(separator: phaseSeparator)
-  }
 
   /// Ordered glyph + label steps for the "What happens" section, one per
   /// phase, derived from a gallery entry's `phases` raw strings.
@@ -41,7 +20,7 @@ enum GalleryScenarioDetailFormat {
   /// Each raw value is mapped through ``PhaseType`` → (``PhaseGlyph``,
   /// ``PhaseDisplayName``); unknown kinds (a feed newer than this build knows)
   /// are skipped, mirroring the lenient forward-compat posture of
-  /// ``phaseFlow(phases:)``. Returns `[]` — never `nil` — when `phases` is
+  /// ``GalleryScenario/phases``. Returns `[]` — never `nil` — when `phases` is
   /// absent / empty **or** every entry mapped away (all-unknown), so the
   /// caller can hide the section on `.isEmpty` without an extra optional.
   static func phaseSteps(phases: [String]?) -> [(symbol: String, label: String)] {

--- a/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailFormat.swift
+++ b/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailFormat.swift
@@ -35,6 +35,23 @@ enum GalleryScenarioDetailFormat {
     return labels.joined(separator: phaseSeparator)
   }
 
+  /// Ordered glyph + label steps for the "What happens" section, one per
+  /// phase, derived from a gallery entry's `phases` raw strings.
+  ///
+  /// Each raw value is mapped through ``PhaseType`` → (``PhaseGlyph``,
+  /// ``PhaseDisplayName``); unknown kinds (a feed newer than this build knows)
+  /// are skipped, mirroring the lenient forward-compat posture of
+  /// ``phaseFlow(phases:)``. Returns `[]` — never `nil` — when `phases` is
+  /// absent / empty **or** every entry mapped away (all-unknown), so the
+  /// caller can hide the section on `.isEmpty` without an extra optional.
+  static func phaseSteps(phases: [String]?) -> [(symbol: String, label: String)] {
+    guard let phases else { return [] }
+    return
+      phases
+      .compactMap { PhaseType(rawValue: $0) }
+      .map { (symbol: PhaseGlyph.symbolName(for: $0), label: PhaseDisplayName.label(for: $0)) }
+  }
+
   /// Localized language name for a gallery entry's raw ISO 639-1 `language`
   /// code, or `nil` when absent / unrecognized so the Language row is hidden.
   ///

--- a/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailView.swift
+++ b/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailView.swift
@@ -199,7 +199,7 @@ struct GalleryScenarioDetailView: View {
         .foregroundStyle(Color.mossDark)
         .frame(width: 22, alignment: .center)
         .accessibilityHidden(true)
-      Text(label)
+      Text(verbatim: label)
         .foregroundStyle(Color.ink)
       Spacer(minLength: 0)
     }

--- a/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailView.swift
+++ b/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailView.swift
@@ -166,23 +166,45 @@ struct GalleryScenarioDetailView: View {
     }
   }
 
-  /// "What happens" — the scenario's phase sequence as an arrow flow. Hidden
-  /// when the mapped flow is empty (no phases, or all unknown kinds).
+  /// "What happens" — the scenario's phase sequence as a numbered vertical
+  /// step list (number + glyph + label per row). Hidden when no phases map
+  /// (absent, empty, or all-unknown kinds).
   @ViewBuilder
   private var whatHappensSection: some View {
-    if let flow = GalleryScenarioDetailFormat.phaseFlow(phases: scenario.phases) {
+    let steps = GalleryScenarioDetailFormat.phaseSteps(phases: scenario.phases)
+    if !steps.isEmpty {
       PasturaSection(String(localized: "What happens")) {
-        // `verbatim` documents intent: `flow` is a pre-composed string of
-        // already-localized `PhaseDisplayName` fragments, not a catalog key —
-        // and guards against a future string *literal* creeping in here and
-        // silently becoming a `LocalizedStringKey` lookup.
-        Text(verbatim: flow)
-          .font(.body)
-          .foregroundStyle(Color.inkSecondary)
-          .frame(maxWidth: .infinity, alignment: .leading)
-          .padding(17)
+        VStack(spacing: 0) {
+          // `enumerated().offset` id (mirroring `detailsCard`) keeps rows
+          // stable when a scenario repeats a phase kind (e.g. two speak_each).
+          ForEach(Array(steps.enumerated()), id: \.offset) { index, step in
+            if index > 0 { PasturaRowDivider() }
+            phaseStepRow(number: index + 1, symbol: step.symbol, label: step.label)
+          }
+        }
       }
     }
+  }
+
+  /// One "What happens" step: 1-based number + phase glyph + localized label.
+  private func phaseStepRow(number: Int, symbol: String, label: String) -> some View {
+    HStack(spacing: 12) {
+      Text(number, format: .number)
+        .foregroundStyle(Color.muted)
+        .monospacedDigit()
+        .frame(minWidth: 16, alignment: .trailing)
+      // Decorative: the adjacent label carries the phase identity, so the
+      // glyph is hidden from VoiceOver to avoid announcing the raw symbol name.
+      Image(systemName: symbol)
+        .foregroundStyle(Color.mossDark)
+        .frame(width: 22, alignment: .center)
+        .accessibilityHidden(true)
+      Text(label)
+        .foregroundStyle(Color.ink)
+      Spacer(minLength: 0)
+    }
+    .padding(.horizontal, 17)
+    .padding(.vertical, 14)
   }
 
   private func actionFooter(viewModel: SharedScenariosViewModel) -> some View {

--- a/Pastura/Pastura/Views/Components/PhaseGlyph.swift
+++ b/Pastura/Pastura/Views/Components/PhaseGlyph.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Single source of truth for the `PhaseType` → SF Symbol mapping used by
+/// the shared-scenario detail screen's "What happens" phase-flow surface.
+///
+/// 6 of the 10 kinds intentionally reuse the Browse art-tile glyphs
+/// (``ScenarioSignaturePhase/sfSymbolName`` in `GalleryCatalogRow.swift`) to
+/// keep one visual language across the two gallery surfaces — a parity test
+/// (`PhaseGlyphTests`) guards the two mappings against drift. The remaining
+/// 4 kinds (`speak_all`, `speak_each`, `assign`, `summarize`) have no
+/// `ScenarioSignaturePhase` counterpart (that enum only maps the "headline"
+/// mechanic kinds) and get their own symbol here.
+///
+/// Left MainActor-default (not `nonisolated`) to mirror ``PhaseDisplayName``
+/// so composing helpers stay uniformly MainActor
+/// (swift-isolation.md Pattern 5).
+public enum PhaseGlyph {
+
+  /// SF Symbol name for `phase`'s glyph badge.
+  public static func symbolName(for phase: PhaseType) -> String {
+    switch phase {
+    case .speakAll: return "bubble.left.and.bubble.right"
+    case .speakEach: return "bubble.left"
+    case .vote: return "checkmark.square"
+    case .choose: return "arrow.triangle.branch"
+    case .scoreCalc: return "chart.bar"
+    case .assign: return "tag"
+    case .eliminate: return "xmark.circle"
+    case .summarize: return "list.bullet.rectangle"
+    case .conditional: return "diamond"
+    case .eventInject: return "bolt.fill"
+    }
+  }
+}

--- a/Pastura/Pastura/Views/Components/PhaseGlyph.swift
+++ b/Pastura/Pastura/Views/Components/PhaseGlyph.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Single source of truth for the `PhaseType` → SF Symbol mapping used by
-/// the shared-scenario detail screen's "What happens" phase-flow surface.
+/// the shared-scenario detail screen's "What happens" phase-step surface.
 ///
 /// 6 of the 10 kinds intentionally reuse the Browse art-tile glyphs
 /// (``ScenarioSignaturePhase/sfSymbolName`` in `GalleryCatalogRow.swift`) to

--- a/Pastura/PasturaTests/Views/GalleryScenarioDetailFormatTests.swift
+++ b/Pastura/PasturaTests/Views/GalleryScenarioDetailFormatTests.swift
@@ -16,40 +16,6 @@ import Testing
 @MainActor
 struct GalleryScenarioDetailFormatTests {
 
-  // MARK: - phaseFlow
-
-  @Test func phaseFlowJoinsLabelsInOrder() {
-    #expect(
-      GalleryScenarioDetailFormat.phaseFlow(phases: ["speak_each", "summarize"])
-        == "Speak Each → Summarize")
-  }
-
-  @Test func phaseFlowPreservesGivenOrder() {
-    #expect(
-      GalleryScenarioDetailFormat.phaseFlow(phases: ["summarize", "vote", "assign"])
-        == "Summarize → Vote → Assign")
-  }
-
-  @Test func phaseFlowNilWhenAbsent() {
-    #expect(GalleryScenarioDetailFormat.phaseFlow(phases: nil) == nil)
-  }
-
-  @Test func phaseFlowNilWhenEmpty() {
-    #expect(GalleryScenarioDetailFormat.phaseFlow(phases: []) == nil)
-  }
-
-  @Test func phaseFlowSkipsUnknownKinds() {
-    // A feed newer than this build carries a phase kind we don't know — it is
-    // skipped, and the known ones still render.
-    #expect(
-      GalleryScenarioDetailFormat.phaseFlow(phases: ["future_kind", "vote"]) == "Vote")
-  }
-
-  @Test func phaseFlowNilWhenAllUnknown() {
-    // Non-empty but every entry maps away → section hidden, not an empty box.
-    #expect(GalleryScenarioDetailFormat.phaseFlow(phases: ["future_kind", "another"]) == nil)
-  }
-
   // MARK: - phaseSteps
 
   @Test func phaseStepsProducesGlyphAndLabelInOrder() {

--- a/Pastura/PasturaTests/Views/GalleryScenarioDetailFormatTests.swift
+++ b/Pastura/PasturaTests/Views/GalleryScenarioDetailFormatTests.swift
@@ -50,6 +50,32 @@ struct GalleryScenarioDetailFormatTests {
     #expect(GalleryScenarioDetailFormat.phaseFlow(phases: ["future_kind", "another"]) == nil)
   }
 
+  // MARK: - phaseSteps
+
+  @Test func phaseStepsProducesGlyphAndLabelInOrder() {
+    let steps = GalleryScenarioDetailFormat.phaseSteps(phases: ["speak_each", "summarize"])
+    #expect(steps.map(\.symbol) == ["bubble.left", "list.bullet.rectangle"])
+    #expect(steps.map(\.label) == ["Speak Each", "Summarize"])
+  }
+
+  @Test func phaseStepsSkipsUnknownKinds() {
+    let steps = GalleryScenarioDetailFormat.phaseSteps(phases: ["vote", "bogus_kind", "assign"])
+    #expect(steps.map(\.symbol) == ["checkmark.square", "tag"])
+    #expect(steps.map(\.label) == ["Vote", "Assign"])
+  }
+
+  @Test func phaseStepsEmptyWhenAbsent() {
+    #expect(GalleryScenarioDetailFormat.phaseSteps(phases: nil).isEmpty)
+  }
+
+  @Test func phaseStepsEmptyWhenEmpty() {
+    #expect(GalleryScenarioDetailFormat.phaseSteps(phases: []).isEmpty)
+  }
+
+  @Test func phaseStepsEmptyWhenAllUnknown() {
+    #expect(GalleryScenarioDetailFormat.phaseSteps(phases: ["nope", "nada"]).isEmpty)
+  }
+
   // MARK: - languageLabel
 
   @Test func languageLabelMapsLaunchLanguages() {

--- a/Pastura/PasturaTests/Views/GalleryScenarioDetailFormatTests.swift
+++ b/Pastura/PasturaTests/Views/GalleryScenarioDetailFormatTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 /// Unit coverage of the pure ``GalleryScenarioDetailFormat`` helpers backing
 /// the shared-scenario detail screen's enriched metadata rows and the
-/// "What happens" phase flow (view-testing.md rule 1 — logic extracted from
+/// "What happens" phase step (view-testing.md rule 1 — logic extracted from
 /// the View so it is testable without rendering).
 ///
 /// `@MainActor`: ``GalleryScenarioDetailFormat`` sits at the default (MainActor)

--- a/Pastura/PasturaTests/Views/PhaseGlyphTests.swift
+++ b/Pastura/PasturaTests/Views/PhaseGlyphTests.swift
@@ -5,7 +5,7 @@ import UIKit
 
 /// Unit coverage of ``PhaseGlyph``, the single source of truth for the
 /// `PhaseType` → SF Symbol mapping used by the shared-scenario "What
-/// happens" phase-flow surface.
+/// happens" phase-step surface.
 ///
 /// `@MainActor`: ``PhaseGlyph`` sits at the default (MainActor) isolation
 /// (mirroring ``PhaseDisplayName``, swift-isolation.md Pattern 5), and

--- a/Pastura/PasturaTests/Views/PhaseGlyphTests.swift
+++ b/Pastura/PasturaTests/Views/PhaseGlyphTests.swift
@@ -1,0 +1,37 @@
+import Testing
+import UIKit
+
+@testable import Pastura
+
+/// Unit coverage of ``PhaseGlyph``, the single source of truth for the
+/// `PhaseType` → SF Symbol mapping used by the shared-scenario "What
+/// happens" phase-flow surface.
+///
+/// `@MainActor`: ``PhaseGlyph`` sits at the default (MainActor) isolation
+/// (mirroring ``PhaseDisplayName``, swift-isolation.md Pattern 5), and
+/// ``ScenarioSignaturePhase`` is `nonisolated` so it is callable from either
+/// context — the suite matches ``PhaseGlyph`` so it can call directly.
+@Suite("PhaseGlyph", .timeLimit(.minutes(1)))
+@MainActor
+struct PhaseGlyphTests {
+
+  @Test func everyPhaseMapsToAValidSymbol() {
+    for phase in PhaseType.allCases {
+      let name = PhaseGlyph.symbolName(for: phase)
+      #expect(
+        UIImage(systemName: name) != nil,
+        "PhaseGlyph.symbolName(for: \(phase)) = \"\(name)\" is not a valid SF Symbol")
+    }
+  }
+
+  @Test func parityWithArtTileGlyph() {
+    for phase in PhaseType.allCases {
+      guard let signature = ScenarioSignaturePhase(phaseRawValue: phase.rawValue) else {
+        continue
+      }
+      #expect(
+        PhaseGlyph.symbolName(for: phase) == signature.sfSymbolName,
+        "PhaseGlyph and ScenarioSignaturePhase diverge for \(phase)")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Upgrade the shared-scenario detail screen's "What happens" section from a text-only arrow flow (`Speak Each → Summarize`) to a **numbered vertical step list** — number + SF Symbol glyph + label per row, `PasturaRowDivider` between rows.
- Add `PhaseGlyph` (`Views/Components/`) as the single source of truth for `PhaseType` → SF Symbol; 6 kinds reuse the Browse art-tile glyphs (`ScenarioSignaturePhase`), guarded by a parity test; 4 scaffolding kinds are new.
- Add `GalleryScenarioDetailFormat.phaseSteps(phases:)` producing `(symbol, label)` row models; remove the now-superseded `phaseFlow` / `phaseSeparator`.
- Tokens: number `Color.muted`, glyph `Color.mossDark`, label `Color.ink` (no new color token). Glyph is a11y-hidden (adjacent label carries identity).

## Test plan
- Unit: `PhaseGlyphTests` — completeness (`UIImage(systemName:)` resolves all 10 kinds) + parity with `ScenarioSignaturePhase`; `phaseSteps` order / skip-unknown / empty cases.
- Full unit + UI suite green (`** TEST SUCCEEDED **`, 7 UI tests).
- Visual (SF Symbol alignment + iOS 26 rendering) is real-device QA-gated per view-testing.md rule 4.

Closes #860

🤖 Generated with [Claude Code](https://claude.com/claude-code)