### PR TITLE
🔧 ci: wire skill test harnesses into CI + completeness gate

### DIFF
--- a/.claude/rules/ci-workflows.md
+++ b/.claude/rules/ci-workflows.md
@@ -120,6 +120,25 @@ that extraction required, aborting every `gallery-scripts-test.sh` case whose
 fixture builder (`mk_factory` / `mk_gallery_yaml`) predated it. `check-gallery-entry.sh`
 never runs the extraction, so it was green locally, red in CI.
 
+### Skill-local harnesses are NOT auto-wired — each needs a `scripts/tests/` shim
+
+The Shell-gate glob is `scripts/tests/*-test.sh` **only**, so a skill's own
+self-test at `.claude/skills/<skill>/tests/run_tests.sh` runs **nowhere** in CI
+by default — silent zero coverage (the #888 / #891 gap). Wire each one with a
+thin shim `scripts/tests/<skill>-test.sh` that delegates:
+
+```bash
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+bash "$REPO_ROOT/.claude/skills/<skill>/tests/run_tests.sh"
+```
+
+`scripts/tests/skill-harness-wiring-test.sh` enforces this — it fails the
+Shell-gate job when any harness lacks a shim, and the shim's delegation must be
+a **live** `bash …/run_tests.sh` line (a path named only in a header comment
+does not count). Keep the harness ubuntu-runnable (python3 + jq + git, no Swift,
+no network) since the Shell-gate runner has no Xcode.
+
 ## Rename / namespace-sweep completion gate — `git grep`, both forms
 
 For a rename or namespace-sweep "0 remaining" completion gate, use

--- a/scripts/tests/queue-consumer-test.sh
+++ b/scripts/tests/queue-consumer-test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# scripts/tests/queue-consumer-test.sh — CI shim that runs the queue-consumer
+# skill's helper self-test (#891).
+#
+# The skill's own harness lives at
+# `.claude/skills/queue-consumer/tests/run_tests.sh`, which the CI "Shell gate
+# tests" job does NOT pick up — that job globs only `scripts/tests/*-test.sh`.
+# Without this shim the harness (append_digest.py fixtures + the main-checkout
+# resolver via a throwaway git repo) runs nowhere automatically. This file
+# matches the glob and delegates, giving the harness a CI home.
+#
+# The harness needs python3 + git (both on the ubuntu-latest runner); it uses
+# inline `git -c user.email=... user.name=...` so no global git identity is
+# required, and it `cd`s to its own dir, so it is invocation-location
+# independent.
+#
+# The skill-harness-wiring completeness gate enforces that this shim exists and
+# delegates — see scripts/tests/skill-harness-wiring-test.sh.
+#
+# Run manually: bash scripts/tests/queue-consumer-test.sh
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+bash "$REPO_ROOT/.claude/skills/queue-consumer/tests/run_tests.sh"

--- a/scripts/tests/scenario-factory-test.sh
+++ b/scripts/tests/scenario-factory-test.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# scripts/tests/scenario-factory-test.sh — CI shim that runs the
+# scenario-factory skill's helper self-test (#891).
+#
+# The skill's own harness lives at
+# `.claude/skills/scenario-factory/tests/run_tests.sh`, which the CI "Shell
+# gate tests" job does NOT pick up — that job globs only `scripts/tests/*-test.sh`.
+# Without this shim the harness (run_scenario.sh --classify, format_transcript.py,
+# append_digest.py, gallery_census.py against fixtures) runs nowhere
+# automatically. This file matches the glob and delegates, giving the harness a
+# CI home.
+#
+# The harness needs python3 + jq (both on the ubuntu-latest runner); it `cd`s to
+# its own dir, so it is invocation-location independent.
+#
+# The skill-harness-wiring completeness gate enforces that this shim exists and
+# delegates — see scripts/tests/skill-harness-wiring-test.sh.
+#
+# Run manually: bash scripts/tests/scenario-factory-test.sh
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+bash "$REPO_ROOT/.claude/skills/scenario-factory/tests/run_tests.sh"

--- a/scripts/tests/scenario-refine-test.sh
+++ b/scripts/tests/scenario-refine-test.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# scripts/tests/scenario-refine-test.sh — CI shim that runs the scenario-refine
+# skill's helper self-test (#891).
+#
+# The skill's own harness lives at
+# `.claude/skills/scenario-refine/tests/run_tests.sh`, which the CI "Shell gate
+# tests" job does NOT pick up — that job globs only `scripts/tests/*-test.sh`.
+# Without this shim the harness (inventory selection: rotation / category
+# resolution / ja-en tiering, and audit-journal appending against fixtures)
+# runs nowhere automatically. This file matches the glob and delegates, giving
+# the harness a CI home.
+#
+# The harness needs python3 (on the ubuntu-latest runner); it `cd`s to its own
+# dir, so it is invocation-location independent.
+#
+# The skill-harness-wiring completeness gate enforces that this shim exists and
+# delegates — see scripts/tests/skill-harness-wiring-test.sh.
+#
+# Run manually: bash scripts/tests/scenario-refine-test.sh
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+bash "$REPO_ROOT/.claude/skills/scenario-refine/tests/run_tests.sh"

--- a/scripts/tests/skill-harness-wiring-test.sh
+++ b/scripts/tests/skill-harness-wiring-test.sh
@@ -25,8 +25,7 @@ set -euo pipefail
 # while silently exiting 0 under CI. `[ -e ] || continue` guards the glob's
 # literal-string fallback when zero harnesses match.
 scan() {
-  root="$1"
-  rc=0
+  local root="$1" rc=0 harness skill shim
   for harness in "$root"/.claude/skills/*/tests/run_tests.sh; do
     [ -e "$harness" ] || continue
     skill=$(basename "$(dirname "$(dirname "$harness")")")
@@ -36,6 +35,10 @@ scan() {
       rc=1
       continue
     fi
+    # The `bash` prefix is deliberate — every shim delegates via a plain
+    # `bash …/run_tests.sh` line. A future author switching to `exec bash …`
+    # or `"$BASH" …` would be flagged as a gap; keep the plain form or widen
+    # this regex intentionally.
     if ! grep -Eq "^[[:space:]]*bash[^#]*${skill}/tests/run_tests\.sh" "$shim"; then
       echo "  gap: scripts/tests/${skill}-test.sh has no live 'bash …/${skill}/tests/run_tests.sh' delegation line" >&2
       rc=1

--- a/scripts/tests/skill-harness-wiring-test.sh
+++ b/scripts/tests/skill-harness-wiring-test.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# scripts/tests/skill-harness-wiring-test.sh — completeness gate (#891).
+#
+# Every skill-local self-test harness at `.claude/skills/<skill>/tests/run_tests.sh`
+# MUST have a CI shim at `scripts/tests/<skill>-test.sh` that actually delegates
+# to it. The CI "Shell gate tests" job runs `scripts/tests/*-test.sh` only, so a
+# harness without a shim runs NOWHERE — silent zero coverage (the #888 / #891
+# gap). This gate fails the Shell-gate job when any harness is un-wired, turning
+# a silent miss into a red build.
+#
+# It checks the harness -> shim direction only, so genuine unit tests
+# (gallery-scripts-test.sh, block-force-push-test.sh, and this gate itself) are
+# never mistaken for shims. bash-3.2-clean (the local pre-push run uses macOS
+# /bin/bash 3.2; CI is ubuntu bash 5).
+#
+# Run manually: bash scripts/tests/skill-harness-wiring-test.sh
+set -euo pipefail
+
+# scan <root>: for each skill harness under <root>, require a delegating shim.
+# Prints one "gap:" line per problem to stderr; returns 1 if any gap, else 0.
+# The delegation check anchors on a LIVE `bash ... run_tests.sh` invocation
+# line, not a bare path mention — a shim that only names the harness in a header
+# comment (with its real delegation commented-out) would otherwise pass here
+# while silently exiting 0 under CI. `[ -e ] || continue` guards the glob's
+# literal-string fallback when zero harnesses match.
+scan() {
+  root="$1"
+  rc=0
+  for harness in "$root"/.claude/skills/*/tests/run_tests.sh; do
+    [ -e "$harness" ] || continue
+    skill=$(basename "$(dirname "$(dirname "$harness")")")
+    shim="$root/scripts/tests/${skill}-test.sh"
+    if [ ! -f "$shim" ]; then
+      echo "  gap: skill '$skill' harness has no CI shim at scripts/tests/${skill}-test.sh" >&2
+      rc=1
+      continue
+    fi
+    if ! grep -Eq "^[[:space:]]*bash[^#]*${skill}/tests/run_tests\.sh" "$shim"; then
+      echo "  gap: scripts/tests/${skill}-test.sh has no live 'bash …/${skill}/tests/run_tests.sh' delegation line" >&2
+      rc=1
+    fi
+  done
+  return "$rc"
+}
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# --- self-test: the gate's own logic is the one thing nothing else covers ----
+# Scaffold a throwaway tree and assert scan() fires exactly when it should.
+SELFTEST=$(mktemp -d)
+trap 'rm -rf "$SELFTEST"' EXIT
+mkdir -p "$SELFTEST/.claude/skills/demo/tests" "$SELFTEST/scripts/tests"
+: > "$SELFTEST/.claude/skills/demo/tests/run_tests.sh"
+
+# (a) a correctly-wired shim with a live delegation line -> scan passes
+printf '#!/usr/bin/env bash\nbash "$REPO/.claude/skills/demo/tests/run_tests.sh"\n' \
+  > "$SELFTEST/scripts/tests/demo-test.sh"
+scan "$SELFTEST" || fail "self-test (a): a live-delegating shim must pass"
+
+# (b) delegation only in a comment -> scan must flag it
+printf '#!/usr/bin/env bash\n# bash .claude/skills/demo/tests/run_tests.sh (documented, not run)\ntrue\n' \
+  > "$SELFTEST/scripts/tests/demo-test.sh"
+if scan "$SELFTEST" 2>/dev/null; then fail "self-test (b): a comment-only shim must be flagged"; fi
+
+# (c) no shim at all -> scan must flag it
+rm -f "$SELFTEST/scripts/tests/demo-test.sh"
+if scan "$SELFTEST" 2>/dev/null; then fail "self-test (c): a missing shim must be flagged"; fi
+
+rm -rf "$SELFTEST"
+trap - EXIT
+
+# --- real check: the live repo tree ------------------------------------------
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+scan "$REPO_ROOT" || fail "one or more skill harnesses are not wired into CI (add the shim(s) above)"
+
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
## Summary
Closes a latent CI gap surfaced while shipping #888: three skill-local test harnesses ran **nowhere** in CI. The "Shell gate tests" job globs only `scripts/tests/*-test.sh`, and #888 shimmed only `consistency-audit`.

- **Three delegating shims** — `scripts/tests/{queue-consumer,scenario-factory,scenario-refine}-test.sh`, mirroring the #888 `consistency-audit` shim. All three harnesses are python3 + jq + git only (Swift/network-free), so they run on the ubuntu Shell-gate runner.
- **Completeness meta-gate** — `scripts/tests/skill-harness-wiring-test.sh` fails the Shell-gate job if any `.claude/skills/*/tests/run_tests.sh` lacks a delegating shim, turning the silent zero-coverage gap into a red build. Delegation must be a **live** `bash …/run_tests.sh` line (a comment-only mention doesn't count); carries an inline `mktemp` self-test (correct→pass / comment-only→fail / missing→fail). bash-3.2-clean.
- **Rule doc** — `.claude/rules/ci-workflows.md` § "Script unit tests" now documents the shim requirement + recipe + the enforcing gate.

## Test plan
- All 11 `scripts/tests/*-test.sh` green locally (incl. the 3 new shims + the meta-gate)
- Meta-gate adversarially verified: removing a shim → `gap:` line + exit 1; restored → green
- code-reviewer (Opus) ran the suite on **bash 3.2.57** + adversarial scan → PASS
- No Swift diff → iOS test suite N/A (pre-commit `xcodebuild build` passed on the scripts/ commits)

Closes #891

🤖 Generated with [Claude Code](https://claude.com/claude-code)