### PR TITLE
✨ feat: randomize DL demo replay order per session

### DIFF
--- a/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView.swift
+++ b/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView.swift
@@ -242,7 +242,15 @@ struct ModelDownloadHostView: View {
   // loads bundled demos. The `stateView` dispatcher handles routing.
   private func initialLoad() async {
     Self.logger.notice("initialLoad: starting (descriptor=\(descriptor.id, privacy: .public))")
-    let loaded = BundledDemoReplaySource.loadAll()
+    // Randomize the demo order on each load so the looped rotation
+    // isn't a fixed sequence (advanceAfterSource wraps via `% sources.count`,
+    // preserving whatever order this array holds). Shuffle exactly ONCE into
+    // the shared `loaded` binding — `sources` and the VM's copy must agree
+    // on order because `currentPresetName(viewModel:)` resolves the header
+    // name via `sources[viewModel.currentSourceIndex]`; two separate
+    // `.shuffled()` calls would desync them. `loadAll()` itself stays
+    // deterministic so order-sensitive tests keep passing.
+    let loaded = BundledDemoReplaySource.loadAll().shuffled()
     Self.logger.notice(
       "initialLoad: loaded \(loaded.count, privacy: .public) sources")
     sources = loaded


### PR DESCRIPTION
## Summary
The DL-time demo replay (ambient playback on `ModelDownloadHostView` while the model downloads) played its bundled scenarios in a fixed bundle-enumeration order and looped in that same order. Now the order is randomized once when the demo loads, then loops in that shuffled order.

- Shuffle `BundledDemoReplaySource.loadAll()` exactly once into the shared `loaded` binding in `initialLoad()`, so the host's `sources` @State and the `ReplayViewModel`'s copy agree on order (`currentPresetName(viewModel:)` indexes `sources[currentSourceIndex]`).
- `loadAll()` itself is unchanged — kept deterministic so order-sensitive tests keep passing.
- The existing loop (`ReplayPlaybackConfig.demoDefault` `.loop` + `advanceAfterSource`'s `% sources.count`) and boundary/closing-card logic are all positional, so they rotate correctly through any permutation.

## Test plan
- `scripts/xcodebuild.sh build` → `** BUILD SUCCEEDED **` (pre-commit hook).
- No new unit test: `.shuffled()` adds no branch logic and randomness is the feature; order-sensitive tests target `loadAll`/`loadFromYAMLs` directly (unchanged) and stay green (ADR-009 / view-testing.md).
- Manual QA: fresh launch → demo rotation starts on a random scenario and loops.

Closes #894

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6cZxDVe8ZDhmWdTe14ARL