### PR TITLE
🔧 ci: add daily green-main CI schedule (macos-26 canary)

### DIFF
--- a/.claude/rules/ci-workflows.md
+++ b/.claude/rules/ci-workflows.md
@@ -96,6 +96,23 @@ Load-bearing invariants when adding/changing such gating:
 4. **`pr-comment` runs even when its deps skip — deliberately.** It carries `if: !cancelled() && …`, a status function, so it does **not** inherit a skipped dependency: on a web/docs-only PR (macOS jobs skipped) it still runs and posts a "did not run / skipped" comment (cosmetically noisy, functionally fine). Don't "fix" it to a plain boolean or the comment vanishes. (Contrast: a *plain-boolean* `if:` WOULD inherit the skip — that's the lever when you want a consumer to skip alongside its dependency.)
 5. **Verify BOTH branches on dummy PRs** (the "Long-lived branch gating — two layers × two directions" § `### Procedure` step 3 applies here too): one docs/web-only PR must skip the macOS jobs *and* still show the required checks green/mergeable; one trivial `.swift` PR must run them. A gating PR that touches only `.github/`/`.claude/` skips the macOS jobs on itself, so its *run* path is never exercised pre-merge — test it separately.
 
+## `ci.yml` fires on four event shapes — enumerate all when editing an `if:`
+
+`ci.yml` triggers are `push`(main) / `pull_request`(main) / `schedule`(daily
+`cron: '11 1 * * *'` = 10:11 JST green-main canary) / `workflow_dispatch`. Both
+`schedule` and `workflow_dispatch` are non-`pull_request`, so the `changes`
+classifier short-circuits them to `ios=true` (invariant 2) — the daily is a
+**full** CI run (all macOS jobs + drift guards), not ui-test-only. The
+event-gated tail jobs stay correct because they name their event explicitly:
+`coverage` (`event == 'push'`) and `pr-comment` (`event == 'pull_request'`) both
+skip on schedule/dispatch. When adding a new job or `if:`, enumerate all four
+shapes — a guard written only for push/PR silently mis-handles the daily run.
+
+`ci-retry.yml` auto-retries the `schedule` arm with the **same** attempt budget
+as `main push` (< 3), so a ui-test flake on the daily does not surface as a
+false red; `workflow_dispatch` is intentionally **not** retried (human-initiated
+and watched).
+
 ## Script unit tests (`scripts/tests/`) run in CI only — not the pre-commit hook
 
 `scripts/tests/*-test.sh` unit-test the **scripts themselves** (e.g.

--- a/.claude/rules/ci-workflows.md
+++ b/.claude/rules/ci-workflows.md
@@ -91,27 +91,10 @@ So gate at the **job** level: a cheap detection job classifies the diff and emit
 Load-bearing invariants when adding/changing such gating:
 
 1. **Conservative by inversion.** Default to running the full suite on any ambiguity — empty / unresolvable / API-errored file list ⇒ run. A *false skip* (a broken build merged because the gate wrongly skipped) is the worst case. Reuse `scripts/precommit-gate-classify.sh` so CI and the pre-commit hook classify identically (#625); note it emits `""` (not a token) on empty input, so the fail-safe lives in the job's bash, not the script. Extend the same posture to the *gated* jobs: write the gate as `if: ${{ !cancelled() && needs.<classifier>.outputs.<flag> != 'false' }}` (run UNLESS explicitly classified out), not `== 'true'`. `!cancelled()` drops the implicit needs-success gate, so a *failed* classifier job (empty output) runs the suite instead of failed-dependency-skipping the required check — a `== 'true'` gate would false-skip there.
-2. **Gate PRs only; `main`/push runs unconditionally.** The classifier short-circuits every non-`pull_request` event to `ios=true`, so a merge to `main` always runs the full suite — stability on the integration branch outweighs the marginal saving, and it sidesteps any push-event diffing edge cases. The optimization spares redundant *PR* runs, not `main`.
+2. **Gate PRs only; `main`/push runs unconditionally.** The classifier short-circuits every non-`pull_request` event to `ios=true`, so a merge to `main` always runs the full suite — stability on the integration branch outweighs the marginal saving, and it sidesteps any push-event diffing edge cases. The optimization spares redundant *PR* runs, not `main`. That non-PR set is `push` **plus** the daily `schedule` + `workflow_dispatch` canary, so `ci.yml` fires on four event shapes — enumerate all four when adding a job `if:` (a push/PR-only guard silently mis-handles the daily); the schedule/dispatch/concurrency mechanics live in ci.yml's `on:`/`concurrency` comments.
 3. **Don't gate the cheap ubuntu drift guards.** They cost little and gating them risks the same required-check trap for no benefit — gate only the macOS jobs.
 4. **`pr-comment` runs even when its deps skip — deliberately.** It carries `if: !cancelled() && …`, a status function, so it does **not** inherit a skipped dependency: on a web/docs-only PR (macOS jobs skipped) it still runs and posts a "did not run / skipped" comment (cosmetically noisy, functionally fine). Don't "fix" it to a plain boolean or the comment vanishes. (Contrast: a *plain-boolean* `if:` WOULD inherit the skip — that's the lever when you want a consumer to skip alongside its dependency.)
 5. **Verify BOTH branches on dummy PRs** (the "Long-lived branch gating — two layers × two directions" § `### Procedure` step 3 applies here too): one docs/web-only PR must skip the macOS jobs *and* still show the required checks green/mergeable; one trivial `.swift` PR must run them. A gating PR that touches only `.github/`/`.claude/` skips the macOS jobs on itself, so its *run* path is never exercised pre-merge — test it separately.
-
-## `ci.yml` fires on four event shapes — enumerate all when editing an `if:`
-
-`ci.yml` triggers are `push`(main) / `pull_request`(main) / `schedule`(daily
-`cron: '11 1 * * *'` = 10:11 JST green-main canary) / `workflow_dispatch`. Both
-`schedule` and `workflow_dispatch` are non-`pull_request`, so the `changes`
-classifier short-circuits them to `ios=true` (invariant 2) — the daily is a
-**full** CI run (all macOS jobs + drift guards), not ui-test-only. The
-event-gated tail jobs stay correct because they name their event explicitly:
-`coverage` (`event == 'push'`) and `pr-comment` (`event == 'pull_request'`) both
-skip on schedule/dispatch. When adding a new job or `if:`, enumerate all four
-shapes — a guard written only for push/PR silently mis-handles the daily run.
-
-`ci-retry.yml` auto-retries the `schedule` arm with the **same** attempt budget
-as `main push` (< 3), so a ui-test flake on the daily does not surface as a
-false red; `workflow_dispatch` is intentionally **not** retried (human-initiated
-and watched).
 
 ## Script unit tests (`scripts/tests/`) run in CI only — not the pre-commit hook
 

--- a/.github/workflows/ci-retry.yml
+++ b/.github/workflows/ci-retry.yml
@@ -9,6 +9,10 @@
 # Attempt arithmetic (workflow_run.run_attempt is the attempt that just
 # completed-as-failed):
 #   main push: rerun while attempt < 3 → up to 3 total (initial + 2 retries)
+#   main schedule (daily canary): same budget as main push — rerun while
+#     attempt < 3, so a ui-test flake on the daily run does not surface as a
+#     false red. workflow_dispatch is intentionally excluded (human-initiated,
+#     watched — no arm below).
 #   pull_request: rerun while attempt < 2 → up to 2 total (initial + 1 retry)
 # Off-by-one here either disables the retry entirely or creates an unbounded
 # loop, so guard arithmetic carefully on edits.
@@ -56,6 +60,9 @@ jobs:
       github.event.workflow_run.conclusion == 'failure'
       && (
         (github.event.workflow_run.event == 'push'
+          && github.event.workflow_run.head_branch == 'main'
+          && github.event.workflow_run.run_attempt < 3)
+        || (github.event.workflow_run.event == 'schedule'
           && github.event.workflow_run.head_branch == 'main'
           && github.event.workflow_run.run_attempt < 3)
         || (github.event.workflow_run.event == 'pull_request'

--- a/.github/workflows/ci-retry.yml
+++ b/.github/workflows/ci-retry.yml
@@ -8,11 +8,10 @@
 #
 # Attempt arithmetic (workflow_run.run_attempt is the attempt that just
 # completed-as-failed):
-#   main push: rerun while attempt < 3 → up to 3 total (initial + 2 retries)
-#   main schedule (daily canary): same budget as main push — rerun while
-#     attempt < 3, so a ui-test flake on the daily run does not surface as a
-#     false red. workflow_dispatch is intentionally excluded (human-initiated,
-#     watched — no arm below).
+#   main push OR schedule (daily canary): rerun while attempt < 3 → up to 3
+#     total (initial + 2 retries). Identical branch + budget, so they share one
+#     arm — the daily's ui-test flake thus doesn't surface as a false red.
+#     workflow_dispatch is intentionally excluded (human-initiated, watched).
 #   pull_request: rerun while attempt < 2 → up to 2 total (initial + 1 retry)
 # Off-by-one here either disables the retry entirely or creates an unbounded
 # loop, so guard arithmetic carefully on edits.
@@ -59,10 +58,8 @@ jobs:
     if: >-
       github.event.workflow_run.conclusion == 'failure'
       && (
-        (github.event.workflow_run.event == 'push'
-          && github.event.workflow_run.head_branch == 'main'
-          && github.event.workflow_run.run_attempt < 3)
-        || (github.event.workflow_run.event == 'schedule'
+        ((github.event.workflow_run.event == 'push'
+          || github.event.workflow_run.event == 'schedule')
           && github.event.workflow_run.head_branch == 'main'
           && github.event.workflow_run.run_attempt < 3)
         || (github.event.workflow_run.event == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,36 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Daily green-main canary. main's ui-test runs on macos-26, which is most
+  # reliable in the low-GitHub-load window (peak load ≈ UTC 12:00-20:00 =
+  # JST 21:00-05:00 — the "JST night"). 01:11 UTC = 10:11 JST sits in the
+  # low-load trough, and is off the top of the hour where scheduled runs are
+  # most delayed. Purpose is high-signal, not flake-hunting: a red run in this
+  # low-noise JST-morning window points at a real regression on main, not infra
+  # noise (empirically JST 07:00-09:00 ui-test was 20/20 across push/PR runs;
+  # the morning trough carries into the 10:xx slot).
+  # NOTE: GitHub auto-disables a scheduled workflow after 60 days of *no
+  # repository activity* — harmless for an active repo, but that is the silent
+  # failure mode if the daily ever stops firing.
+  schedule:
+    - cron: '11 1 * * *'
+  # Manual trigger for an on-demand full main run (a human dispatched it and is
+  # watching, so — unlike `schedule` — it is intentionally NOT auto-retried by
+  # ci-retry.yml).
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.ref }}
+  # A scheduled (or workflow_dispatch) run on main shares main's `github.ref`
+  # with a push to main, so a plain `ci-${{ github.ref }}` group would let a
+  # concurrent push cancel the daily run (or vice versa). Suffix the group with
+  # the run id for `schedule` only, giving each daily run its own group so it is
+  # never cancelled. push / pull_request / workflow_dispatch keep the empty
+  # suffix and their per-ref mutual-cancellation (a manual dispatch on main thus
+  # shares push's group — harmless, since a push is itself a full main run).
+  group: ci-${{ github.ref }}-${{ github.event_name == 'schedule' && github.run_id || '' }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

Adds a **daily scheduled CI run on `main`** plus a manual `workflow_dispatch` trigger, so a macos-26 ui-test failure in a known-clean window is a **high-signal** indicator of a real regression on `main` — not JST-night infra flakiness.

- **Slot**: `cron: '11 1 * * *'` = **01:11 UTC = 10:11 JST**. Sits in the low-GitHub-load trough (peak ≈ UTC 12:00-20:00 = JST 21:00-05:00, the "JST night") and is off the top of the hour where scheduled runs are most delayed. Results land mid-morning JST. No runner-time collision with the existing CodeQL daily (UTC 18:05).
- **Purpose is high-signal, not flake-hunting**: scheduling at the empirically-clean window (JST 07:00-09:00 ui-test was 20/20 across push/PR runs in a 298-run sample) means a red daily points at a real main regression, not macos-26 noise.

### Changes
- **`ci.yml`**: add `schedule` + `workflow_dispatch` to `on:`. The `changes` classifier already short-circuits non-`pull_request` events to `ios=true`, so the daily runs the **full** macOS + drift-guard matrix with no gating change. `coverage` (push-only) and `pr-comment` (PR-only) correctly skip. The concurrency `group` gains a `run_id` suffix **for `schedule` only**, so a concurrent push to `main` can't cancel the daily run (both share `main`'s `github.ref` otherwise); push/PR/dispatch keep their per-ref mutual-cancellation.
- **`ci-retry.yml`**: add a `schedule`(main, `attempt < 3`) auto-retry arm — same budget as `main push` — so a ui-test flake on the daily doesn't surface as a false red. `workflow_dispatch` is intentionally **not** retried (human-initiated and watched).
- **`ci-workflows.md`**: document the four-event trigger set so the "enumerate every event shape" guidance stays accurate for the next editor.

## Analysis basis
298 CI runs (2026-06-21..07-02). ui-test outcomes: 91 success / 7 failure / rest cancelled(concurrency)+skipped. Failures are few and scattered across JST active hours; the deep-night window has no push data, so the slot choice leans on GitHub's documented load pattern (UTC-midday peak = JST night) plus the empirically-clean JST-morning window.

## Test plan
- [x] Both workflow files parse (`python3 -c yaml.safe_load`) and `actionlint` reports no errors on the touched expressions (`schedule`/`cron`, `workflow_dispatch`, concurrency ternary, ci-retry `if:`).
- [x] Reviewed by `code-reviewer` (Opus) + pre-impl `critic` — PASS, 0 issues.
- [ ] First real fire at 10:11 JST (verify the run appears, executes the full matrix, and — if ui-test flakes — the `ci-retry` schedule arm reruns it).
- Manual smoke: **Actions → CI → Run workflow** (`workflow_dispatch`) can trigger an on-demand full main run at any time.

Closes #896

🤖 Generated with [Claude Code](https://claude.com/claude-code)