### PR TITLE
✨ feat: phase glyphs in Sim conversation & editor

### DIFF
--- a/Pastura/Pastura/Views/Components/PhaseTypeLabel.swift
+++ b/Pastura/Pastura/Views/Components/PhaseTypeLabel.swift
@@ -1,12 +1,14 @@
 import SwiftUI
 
-/// Displays a phase type as a moss / ink-secondary capsule badge.
+/// Displays a phase type as a moss / ink-secondary capsule badge: a leading
+/// `PhaseGlyph` SF Symbol + the phase `rawValue`.
 ///
-/// Used inline within an `AgentOutputRow` name row and standalone as a
-/// `phaseStarted` log entry in `SimulationView`. The capsule shape + tag
-/// typography carries the "this is a phase marker" semantic; color
-/// distinguishes LLM-driven phases (moss, the only brand accent) from
-/// code-driven phases (ink-secondary, muted neutral).
+/// Used inline within an `AgentOutputRow` name row, standalone as a
+/// `phaseStarted` log entry in `SimulationView`, and in the visual editor's
+/// `PhaseBlockRow`. The capsule shape + tag typography carries the "this is a
+/// phase marker" semantic; color distinguishes LLM-driven phases (moss, the
+/// only brand accent) from code-driven phases (ink-secondary, muted neutral).
+/// Glyph vocabulary is the shared `PhaseGlyph` SSOT (#860).
 struct PhaseTypeLabel: View {
   let phaseType: PhaseType
 
@@ -14,7 +16,7 @@ struct PhaseTypeLabel: View {
     HStack(spacing: 4) {
       // Phase glyph from the shared `PhaseGlyph` SSOT (#860) — the same
       // symbol vocabulary the gallery "What happens" steps use, so one
-      // visual language reads across Sim / Editor / detail. Decorative:
+      // visual language reads across Sim and the Editor. Decorative:
       // the adjacent rawValue Text carries the phase identity, so hide the
       // glyph from VoiceOver rather than announce the raw symbol name.
       Image(systemName: PhaseGlyph.symbolName(for: phaseType))

--- a/Pastura/Pastura/Views/Components/PhaseTypeLabel.swift
+++ b/Pastura/Pastura/Views/Components/PhaseTypeLabel.swift
@@ -11,16 +11,26 @@ struct PhaseTypeLabel: View {
   let phaseType: PhaseType
 
   var body: some View {
-    Text(phaseType.rawValue)
-      .textStyle(Typography.tagPhase)
-      .padding(.horizontal, 8)
-      .padding(.vertical, 3)
-      // Capsule fill at 15% opacity is load-bearing: without it the
-      // label reads as inline text and loses its "badge" affordance
-      // (critic Axis 5). Keep the capsule even if the tint palette
-      // shifts further.
-      .background(badgeFill.opacity(0.15), in: Capsule())
-      .foregroundStyle(badgeText)
+    HStack(spacing: 4) {
+      // Phase glyph from the shared `PhaseGlyph` SSOT (#860) — the same
+      // symbol vocabulary the gallery "What happens" steps use, so one
+      // visual language reads across Sim / Editor / detail. Decorative:
+      // the adjacent rawValue Text carries the phase identity, so hide the
+      // glyph from VoiceOver rather than announce the raw symbol name.
+      Image(systemName: PhaseGlyph.symbolName(for: phaseType))
+        .imageScale(.small)
+        .accessibilityHidden(true)
+      Text(phaseType.rawValue)
+    }
+    .textStyle(Typography.tagPhase)
+    .padding(.horizontal, 8)
+    .padding(.vertical, 3)
+    // Capsule fill at 15% opacity is load-bearing: without it the
+    // label reads as inline text and loses its "badge" affordance
+    // (critic Axis 5). Keep the capsule even if the tint palette
+    // shifts further.
+    .background(badgeFill.opacity(0.15), in: Capsule())
+    .foregroundStyle(badgeText)
   }
 
   /// Text tint. §2.3 reserves `moss-dark` for accent text (アクセント

--- a/Pastura/Pastura/Views/Editor/PhaseEditorSheet.swift
+++ b/Pastura/Pastura/Views/Editor/PhaseEditorSheet.swift
@@ -160,7 +160,7 @@ struct PhaseEditorSheet: View {
       Picker(String(localized: "Type"), selection: $phase.type) {
         ForEach(availableTypes, id: \.self) { type in
           HStack {
-            Text(type.rawValue)
+            Label(type.rawValue, systemImage: PhaseGlyph.symbolName(for: type))
             if type.requiresLLM {
               // `info` here is a quiet category badge for LLM-required phase types,
               // not a notification — see design-system §2.6 for the alert-family scope.


### PR DESCRIPTION
## Summary
- Add the shared `PhaseGlyph` SF Symbol (#860 SSOT) to the phase-type badge `PhaseTypeLabel` (leading glyph + rawValue in the capsule) — propagating to the **simulation conversation** phase markers (`AgentOutputRow` / `SimulationView`) and the **visual editor** phase list (`PhaseBlockRow`).
- Add the glyph to the `PhaseEditorSheet` **type Picker** via a menu-native `Label(rawValue, systemImage:)`.
- rawValue text ("speak_all") kept everywhere; glyph-only. No hardcoded symbol strings — all via `PhaseGlyph`.

## Deferred — ScenarioDetail (→ #901)
The 3rd planned surface (ScenarioDetail `phasesSection`) is **carved out**: adding any glyph there — capsule or inline — reproducibly crashes on iOS 26.5 (`EXC_BAD_ACCESS` in SwiftUI AttributeGraph / `ForEachChild` / `ContainerBackgroundKeys`). Full bisection + repro in #901. The glyph is safe on every other surface.

## Test plan
- Full unit suite green (2448) on the pre-deferral 3-commit build; unaffected by the ScenarioDetail carve-out (View-only) + doc change.
- `SimulationFocusModeTests` UI test green on the final branch (exercises the Sim-conversation glyph end-to-end; this suite is what caught the #901 crash).
- Build green (pre-commit) on all commits.

## Real-device QA
- Glyph size/alignment in the tiny 9.5pt tag capsule (`.imageScale(.small)`) — Sim markers + editor `PhaseBlockRow`.
- `PhaseEditorSheet` menu-Picker glyph rendering (SF Symbol in a `.menu` row).
- iOS 26 visual pass.

Part of #893 (Sim + Editor shipped here; ScenarioDetail → #901)