### PR TITLE
📝 docs: de-drift presets.md — pointer over embedded YAML

### DIFF
--- a/.claude/rules/presets.md
+++ b/.claude/rules/presets.md
@@ -5,135 +5,43 @@ paths:
 
 # Preset YAML Scenarios
 
-These are converted from the Python prototype's hardcoded scenarios.
-Place in `Resources/Presets/`. They serve as both user-facing presets and
-Engine test fixtures.
+Bundled scenarios live in `Resources/Presets/` (originally converted from the
+Python prototype's hardcoded scenarios). **Do NOT embed preset YAML in full
+here** — the source files are the single source of truth, and an inline copy
+drifts silently. It did: this file's snapshots had diverged from the shipped
+files in `description`, `context`, persona wording, the `rounds`/`topics`
+counts, the `summarize` phase, and the `language:` field. Read the actual file
+instead.
 
-## prisoners_dilemma.yaml
+Current inventory (each has an `_en` sibling — see i18n below):
+`prisoners_dilemma`, `bokete`, `target_score_race`, `word_wolf`.
 
-```yaml
-id: prisoners_dilemma
-name: 囚人のジレンマ
-description: 協力か裏切りか。宣言と行動の裏表を楽しむ戦略ゲーム
-agents: 5
-rounds: 3
+## Conventions
 
-context: |
-  あなたはゲーム番組「囚人のジレンマ」の出場者です。
-  対戦相手と「cooperate（協力）」か「betray（裏切り）」を選びます。
-  得点: 両方協力=各3点 / 自分だけ裏切り=5点（相手0点） / 両方裏切り=各1点
-  宣言で嘘やハッタリもOKです。
-
-personas:
-  - name: アキラ
-    description: |
-      【立場】冷静な戦略家。
-      【目的】データと過去の行動パターンから最適解を計算して最高得点を狙う。
-      口調は丁寧で論理的。例:「データ上、協力の期待値が高い」
-  - name: ミサキ
-    description: |
-      【立場】お人好しの楽観主義者。
-      【目的】みんなと協力して全員が得をする結果を目指す。
-      口調は明るく前向き。例:「みんなで協力すればきっとうまくいく！」
-  - name: リュウジ
-    description: |
-      【立場】攻撃的な現実主義者。
-      【目的】出し抜けるなら出し抜いて最高得点を狙う。ただし報復は避けたい。
-      口調は粗くて挑発的。例:「甘いこと言ってると痛い目見るぜ」
-  - name: ハルカ
-    description: |
-      【立場】社交的な外交官タイプ。
-      【目的】同盟を組んで協力者を増やし、安定した得点を積む。
-      口調は柔らかく説得力がある。例:「ここは手を組みませんか？」
-  - name: ケンタ
-    description: |
-      【立場】気まぐれなトリックスター。
-      【目的】予測不能な行動で場を引っかき回す。退屈が嫌い。
-      口調は軽くてふざけている。例:「さーて、今回はどうしよっかなー？」
-
-phases:
-  - type: speak_all
-    prompt: "現在のスコア: {scoreboard}\n全員に向けて1〜2文で宣言してください。ブラフも可。"
-    output: { statement: string, inner_thought: string }
-
-  - type: choose
-    pairing: round_robin
-    prompt: "対戦相手: {opponent_name}\n過去の対戦: {history}\n「cooperate」か「betray」を選べ。1文で理由も。"
-    options: [cooperate, betray]
-    output: { action: string, inner_thought: string }
-
-  - type: score_calc
-    logic: prisoners_dilemma
-
-  - type: summarize
-    template: "{agent1}({action1}) vs {agent2}({action2}) → {score1},{score2}"
-```
-
-## bokete.yaml
-
-```yaml
-id: bokete
-name: ボケて
-description: AIお笑い大喜利バトル。お題に一言ボケをつけて投票で競う
-agents: 5
-rounds: 3
-
-context: |
-  あなたはお笑い大喜利バトル番組の出場者です。
-  写真の説明文が与えられるので、その写真に一言ボケをつけてください。
-  その後、他の参加者のボケを見て一番面白いものに投票します。
-
-topics:
-  - スーツを着た猫が真剣な顔で会議室のホワイトボードの前に立っている写真
-  - おばあちゃんがスケボーで坂道を爆走している写真
-  - コンビニの店員が棚の上で寝ている写真
-
-personas:
-  - name: ツッコミ太郎
-    description: |
-      【立場】ストレートな一言ツッコミ系。
-      【目的】短くて鋭い一言で笑いを取る。
-      例:「お前が言うな」「それ逆だろ」
-  - name: シュール子
-    description: |
-      【立場】シュールで意味不明な方向に飛躍する芸風。
-      【目的】脈絡がないほど良い。予想外の角度で笑いを取る。
-      例:「3年後にこれの意味がわかる」
-  - name: あるある先生
-    description: |
-      【立場】日常の「あるある」に落とし込む芸風。
-      【目的】共感で笑いを取る。
-      例:「月曜の朝、みんなこうなってる」
-  - name: ブラック山田
-    description: |
-      【立場】少し毒のあるブラックユーモア。
-      【目的】皮肉が効いたボケで笑いを取る。
-      例:「給料日前日の財布の中身」
-  - name: 天然ボケ美
-    description: |
-      【立場】本気で的外れなことを言う天然ボケ。
-      【目的】計算ではなく素のずれた発言で笑いを取る。
-      例:「え、これ火曜日ですか？」
-
-phases:
-  - type: assign
-    source: topics
-    target: all
-
-  - type: speak_all
-    prompt: "お題: {assigned_topic}\n1文だけボケてください。説明ではなくボケ。簡潔に。"
-    output: { statement: string, inner_thought: string }
-
-  - type: vote
-    prompt: |
-      お題: {assigned_topic}
-      他の参加者のボケ:
-      {conversation_log}
-      自分以外で一番面白いと思うものに投票してください。
-      投票先は必ず以下の名前のいずれかを正確に書いてください: {candidates}
-    exclude_self: true
-    output: { vote: string, reason: string }
-
-  - type: score_calc
-    logic: vote_tally
-```
+- **File naming**: snake_case matching `id:` (e.g. `prisoners_dilemma.yaml`).
+  The English variant is `<id>_en.yaml` with `language: en`.
+- **`language:` is required** (`ja` / `en`) — it drives runtime preset
+  selection (#388), and `ScenarioLoader` rejects a preset that omits it (no
+  backward-compat fill). A preset without it is a bug.
+- **Dual-purpose = fixture coupling (load-bearing).** These files are BOTH
+  user-facing presets AND test fixtures — but the coupling is **structural, not
+  textual**. Renaming/removing a preset, dropping an `_en` sibling, or changing
+  the preset count / `language` / `sourceId` breaks `PresetLoaderTests` and
+  `BundledPresetSourceIdSchemaTests`; introducing an unknown `{placeholder}`
+  token in a prompt/template breaks `BundledPresetPlaceholderCoverageTests`.
+  Editing persona *wording* or *topic text* alone is safe (those suites key on
+  ids, schema shape, and placeholder tokens — not literal content). Still, grep
+  the `id` across `PasturaTests/` and run the affected suite
+  (`scripts/xcodebuild.sh test -only-testing PasturaTests/<Suite>`) before
+  committing a preset change.
+- **Schema is owned by code, not duplicated here.** The field shape
+  (`id`/`name`/`description`/`agents`/`rounds`/`context`/`personas`/`phases`)
+  is defined by the `Scenario` model + `ScenarioLoader`; the canonical
+  per-phase LLM output field names (`statement` / `inner_thought` for speak,
+  `action` for choose, `vote` / `reason` for vote) live in
+  `ScenarioConventions.swift`. Scenario-specific extra fields (e.g. bokete's
+  `topics`, word wolf's `words`) are modelled as `Scenario.extraData` and
+  referenced by the `assign` phase's `source:` — the field list above is not
+  a closed set.
+- **ja/en parity**: keep the `_en` sibling structurally in sync (same phases,
+  agent count, topic/word count); wording is localized, mechanics are not.


### PR DESCRIPTION
## Summary
- `.claude/rules/presets.md` embedded full copies of `prisoners_dilemma` / `bokete` YAML that had **drifted** from the shipped files (`Pastura/Pastura/Resources/Presets/*.yaml`): `description`, `context`, persona wording, `rounds`/`topics` counts, the `summarize` phase, and the `language:` field all diverged.
- Per `context-budget.md`, the full YAML is grep-findable enumerated content, so replace it with **conventions + a pointer** to the source-of-truth files (140 → 47 lines).
- Retained the load-bearing conventions: snake_case / `_en` naming, required `language:` (#388), preset↔test fixture coupling, code-owned schema (`Scenario` / `ScenarioConventions` / `extraData`), ja/en structural parity.
- Fixture-coupling note corrected during review to reflect that coupling is **structural, not textual** — verified against `PresetLoaderTests` / `BundledPresetSourceIdSchemaTests` (structure) and `BundledPresetPlaceholderCoverageTests` (placeholder tokens).

## Test plan
- Docs-only change to a path-scoped `.claude/rules/` file; no Swift code touched (pre-commit build/lint gates correctly skipped).
- All retained factual claims verified against current `main`: inventory + `_en` siblings, `ScenarioLoader` rejecting a missing `language:`, the named test suites, `ScenarioConventions` output-field names, and `Scenario.extraData` topics/words referenced by the `assign` `source:`.

Closes #921

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P36EXtV3QNm2o66eyJTizv