### PR TITLE
✨ feat: embedded-source-mirror drift detector (consistency-audit)

### DIFF
--- a/.claude/skills/consistency-audit/SKILL.md
+++ b/.claude/skills/consistency-audit/SKILL.md
@@ -191,8 +191,10 @@ For each `needs_judgment` finding (already deduped by `target`):
 1. **Dedup across runs:** search open issues for the target; skip if one
    exists. `gh issue list --state open --search "<target> in:title"`. Every
    finding carries a `target` for this — for `dead_link` it is the link path,
-   for `dangling_adr` it is the ADR id (`ADR-099`), so embed `target` in the
-   issue title verbatim.
+   for `dangling_adr` it is the ADR id (`ADR-099`), for `embedded_source_mirror`
+   it is the `<docfile>::<sourcepath>` composite (so the same source mirrored in
+   two docs files two distinct issues) — embed `target` in the issue title
+   verbatim.
 2. File an issue (`--label documentation`) whose body has:
    - **Locations**: every `file:line` the target is referenced from.
    - **Confidence**: how sure the detector is this is a real problem.
@@ -201,10 +203,12 @@ For each `needs_judgment` finding (already deduped by `target`):
      correct new location only a human knows.
    - **Suggested action**, explicitly left for a human to decide.
 
-   Some detectors pre-author these fields. A `dangling_adr` finding already
-   carries `confidence`, `counter_evidence`, and `suggested_action` on the JSON
-   — use them verbatim rather than re-deriving. `dead_link` does not, so author
-   its confidence / counter-evidence at filing time as before.
+   Some detectors pre-author these fields. `dangling_adr` and
+   `embedded_source_mirror` findings already carry `confidence`,
+   `counter_evidence`, and `suggested_action` on the JSON — use them verbatim
+   rather than re-deriving (`embedded_source_mirror` also carries `source`, the
+   real file the block drifted from). `dead_link` does not, so author its
+   confidence / counter-evidence at filing time as before.
 
 Never auto-fix these — the whole point is the fix needs judgment.
 

--- a/.claude/skills/consistency-audit/scripts/audit_docs.py
+++ b/.claude/skills/consistency-audit/scripts/audit_docs.py
@@ -19,13 +19,24 @@ Two finding classes:
 Conservatism is deliberate: false positives poison the queue, so each detector
 prefers a miss over a wrong flag. Every shipped detector fires zero false
 positives on the current repo: dependency_version, min_ios, dead_link
-(needs_judgment), and dangling_adr (needs_judgment). Detectors that flood until
-their FP sources are designed out are intentionally deferred — see the SKILL's
-"Deferred detectors" note:
+(needs_judgment), dangling_adr (needs_judgment), and embedded_source_mirror
+(needs_judgment). Detectors that flood until their FP sources are designed out
+are intentionally deferred — see the SKILL's "Deferred detectors" note:
   - file:line citation checks   (docs cite source-root-relative paths, GitHub
                                  org/repo slugs, and property accessors that a
                                  naive repo-root existence check misreads)
   - broken-anchor / `§"..."`    (fragile GitHub-slug matching; ambiguous target)
+
+The embedded_source_mirror detector catches the inverse of the fence-skip blind
+spot: a fenced YAML block that verbatim-copied a real source file (a preset /
+gallery scenario) and then drifted from it — the #921 failure mode, invisible to
+every other detector because scan_doc skips fenced content. It fires only when a
+block is *attributable* (first line `id: <slug>`, resolving to a unique
+`<slug>.yaml`), *substantial* (>= MIRROR_MIN_LINES), and a *drifted near-copy*
+(difflib ratio >= MIRROR_MIN_RATIO, but not identical). No author marker is
+needed, so it can flag a marker-less mirror like #921; an in-sync embed stays
+silent (surfaces only once it drifts). needs_judgment — the fix (link vs resync
+vs intentional abridgement) is a human call.
 
 The dangling_adr detector neutralizes intentionally-absent ADRs via a canonical
 reserved set parsed from CLAUDE.md's Reference Documents table (not a per-line
@@ -42,6 +53,7 @@ usage:
 from __future__ import annotations
 
 import argparse
+import difflib
 import json
 import os
 import re
@@ -68,7 +80,30 @@ IOS_VER = re.compile(r"\b\d+\.\d+\b")
 MINIOS_LABEL = re.compile(r"(?i)min(?:imum)?\s+ios")
 MD_LINK = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
 RESERVED = re.compile(r"(?i)reserved|not[\s-]?yet[\s-]?written")
-FENCE = re.compile(r"^\s*(```|~~~)")
+# Fence with capture groups: (indent, delimiter-run, info-string). The delimiter
+# run length + char lets us close on a *matching* fence only, so a ``` or ~~~
+# line that appears *inside* a mirrored block's content can't close it early.
+FENCE_DELIM = re.compile(r"^(\s*)(`{3,}|~{3,})(.*)$")
+# A mirrored preset/gallery YAML block is identified by its first line being a
+# scalar `id:` key — the exact shape that drifted in #921. Scoping the mirror
+# detector to `id:`-keyed YAML keeps candidate resolution unambiguous (basename
+# = `<id>.yaml`) and excludes illustrative swift/prose snippets by construction.
+YAML_ID = re.compile(r"^id:\s*([A-Za-z0-9_./-]+)\s*$")
+# A block counts as a mirror only when it is a *near-complete* drifted copy of
+# the resolved source. The primary discriminator is completeness (block length /
+# source length): a real mirror is essentially the whole file (#921's presets.md
+# blocks were 55/78 and 64/80 ≈ 0.7–0.8), whereas an intentional illustration is
+# an abridged excerpt (the MVP-spec's `id: prisoners_dilemma` example is 33/78 ≈
+# 0.42, two of five personas). Completeness separates these with a far healthier
+# margin than an ordered-line similarity ratio would (0.44 vs 0.34 is a knife
+# edge). MIN_LINES kills tiny schema snippets (the 4-line gallery-README `id: … /
+# name: ...`); MIN_RATIO is a secondary anti-coincidence floor so a long block
+# that merely shares a real id but no content stays silent. needs_judgment, so a
+# borderline miss is preferred to a false flag (Output Contract: conservative
+# wins).
+MIRROR_MIN_LINES = 8
+MIRROR_MIN_COMPLETENESS = 0.6
+MIRROR_MIN_RATIO = 0.3
 # Repo convention: ADRs are always ADR-NNN (three digits). Word-bounded so a
 # longer token can't produce a spurious match.
 ADR_REF = re.compile(r"\bADR-(\d{3})\b")
@@ -154,8 +189,124 @@ def load_reserved_adrs(claude_md: Path) -> set[str]:
     return reserved
 
 
+def build_yaml_index(root: Path) -> dict[str, list[str]]:
+    """basename -> [repo-relative paths] for every tracked-ish YAML under root.
+    Used to resolve which source file an embedded `id:`-keyed block mirrors.
+    Prunes the same trees `excluded` skips (`.git`, DerivedData, node_modules,
+    sibling worktrees, the audit's own fixtures) so a fixture YAML can never be
+    resolved as the mirror target of a real doc."""
+    index: dict[str, list[str]] = {}
+    for dirpath, dirnames, filenames in os.walk(root):
+        kept = []
+        for d in dirnames:
+            crel = os.path.relpath(os.path.join(dirpath, d), root).replace(os.sep, "/")
+            if d in EXCLUDE_PARTS or crel.startswith(".claude/worktrees") \
+                    or "/tests/fixtures" in "/" + crel:
+                continue
+            kept.append(d)
+        dirnames[:] = kept
+        for fn in filenames:
+            if fn.endswith((".yaml", ".yml")):
+                rel = os.path.relpath(os.path.join(dirpath, fn), root).replace(os.sep, "/")
+                if not excluded(rel):
+                    index.setdefault(fn, []).append(rel)
+    return index
+
+
+def _normalize_lines(lines: list[str]) -> list[str]:
+    """rstrip each line and drop trailing blank lines. Leading whitespace is
+    preserved (YAML is indentation-sensitive); only trailing/blank drift is
+    collapsed so a cosmetic newline difference is not read as content drift."""
+    out = [ln.rstrip() for ln in lines]
+    while out and not out[-1]:
+        out.pop()
+    return out
+
+
+def _dedent_block(block_lines: list[str], indent: int) -> list[str]:
+    """Strip up to `indent` leading spaces from each collected block line before
+    normalizing. A fenced block nested in a list/blockquote carries the fence's
+    base indentation; without dedent every line would diff against a flush-left
+    source file (Axis d false-drift)."""
+    dedented = []
+    for ln in block_lines:
+        i = 0
+        while i < indent and i < len(ln) and ln[i] == " ":
+            i += 1
+        dedented.append(ln[i:])
+    return _normalize_lines(dedented)
+
+
+def _read_source_lines(path: Path) -> list[str] | None:
+    try:
+        return _normalize_lines(path.read_text(encoding="utf-8").splitlines())
+    except (OSError, ValueError):
+        # ValueError covers UnicodeDecodeError on a non-UTF-8 source — skip it
+        # conservatively rather than crash the whole audit (cf. load_resolved).
+        return None
+
+
+_MIRROR_COUNTER_EVIDENCE = (
+    "The block may be an intentionally abridged illustration the author never "
+    "meant to keep in sync, or it may share an id with a different source file. "
+    "A human confirms whether to resync, replace it with a link, or leave it.")
+_MIRROR_SUGGESTED_ACTION = (
+    "Replace the embedded block with a link/pointer to the source file "
+    "(preferred — embedding full source copies drifts silently, see #921), or "
+    "resync it to match.")
+
+
+def mirror_finding(block_lines: list[str], indent: int, open_line: int,
+                   rel: str, root: Path,
+                   yaml_index: dict[str, list[str]]) -> dict | None:
+    """A fenced YAML block whose first line is `id: <slug>` and which is a
+    substantial near-copy of `<slug>.yaml` — but has *drifted* from it — is an
+    embedded source mirror at risk (#921). Returns a needs_judgment finding, or
+    None when the block is not an attributable, drifted mirror.
+
+    Deliberately silent when the block is identical to the source: an in-sync
+    embed is not a current inconsistency, and flagging it would be style-nagging
+    (a false-positive under 'conservative wins'). It surfaces once it drifts."""
+    block = _dedent_block(block_lines, indent)
+    if len(block) < MIRROR_MIN_LINES:
+        return None
+    m = YAML_ID.match(block[0])
+    if not m:
+        return None
+    slug = m.group(1)
+    cands: list[str] = []
+    for base in (f"{slug}.yaml", f"{slug}.yml"):
+        cands = yaml_index.get(base, [])
+        if cands:
+            break
+    if len(cands) != 1:  # 0 = unattributable, >1 = ambiguous -> conservative skip
+        return None
+    src_rel = cands[0]
+    src = _read_source_lines(root / src_rel)
+    if src is None or block == src:
+        return None
+    if not src or len(block) < MIRROR_MIN_COMPLETENESS * len(src):
+        return None  # abridged excerpt / illustration, not a full mirror
+    if difflib.SequenceMatcher(None, block, src).ratio() < MIRROR_MIN_RATIO:
+        return None  # coincidental id match, not a real mirror
+    # target == key so dedup_judgment (type, key) and the SKILL's Step 4
+    # `<target> in:title` cross-run dedup agree — the same source mirrored in two
+    # docs keeps distinct keys (docfile differs), so neither finding is dropped.
+    key = f"{rel}::{src_rel}"
+    return {
+        "type": "embedded_source_mirror",
+        "target": key, "key": key,
+        "source": src_rel,
+        "confidence": "medium",
+        "counter_evidence": _MIRROR_COUNTER_EVIDENCE,
+        "suggested_action": _MIRROR_SUGGESTED_ACTION,
+        "file": rel, "line": open_line,
+    }
+
+
 def scan_doc(path: Path, root: Path, resolved: dict[str, str],
-             min_ios: str | None, reserved_adrs: set[str]):
+             min_ios: str | None, reserved_adrs: set[str],
+             yaml_index: dict[str, list[str]]):
     """Return (auto_fixable, judgment) finding lists for one doc file."""
     rel = os.path.relpath(path, root).replace(os.sep, "/")
     try:
@@ -166,12 +317,46 @@ def scan_doc(path: Path, root: Path, resolved: dict[str, str],
     judg: list[dict] = []
     doc_dir = path.parent
     in_fence = False
+    fence_delim = ""          # delimiter char ('`'/'~') of the open fence
+    collecting = False        # inside a YAML block we may mirror-check
+    block_lines: list[str] = []
+    block_open = 0
+    block_indent = 0
 
     for lineno, line in enumerate(lines, 1):
-        if FENCE.match(line):
-            in_fence = not in_fence
+        fm = FENCE_DELIM.match(line)
+        if fm:
+            indent, ticks, info = fm.group(1), fm.group(2), fm.group(3).strip()
+            if not in_fence:
+                # Opening fence. Only YAML blocks are collected for mirror
+                # checking; every other fence toggles exactly as before.
+                in_fence = True
+                fence_delim = ticks[0]
+                lang = info.split()[0].lower() if info else ""
+                collecting = lang in ("yaml", "yml")
+                block_lines = []
+                block_open = lineno
+                block_indent = len(indent)
+                continue
+            if ticks[0] == fence_delim:
+                # Matching closing fence: run the mirror check on the block.
+                if collecting:
+                    f = mirror_finding(block_lines, block_indent, block_open,
+                                       rel, root, yaml_index)
+                    if f:
+                        judg.append(f)
+                in_fence = False
+                fence_delim = ""
+                collecting = False
+                block_lines = []
+                continue
+            # A different-delimiter fence line inside the block is content.
+            if collecting:
+                block_lines.append(line)
             continue
         if in_fence:
+            if collecting:
+                block_lines.append(line)
             continue
 
         # --- auto_fixable: dependency version drift ---
@@ -343,11 +528,12 @@ def main() -> int:
     resolved = load_resolved(resolved_path)
     min_ios = load_min_ios(pbxproj_path)
     reserved_adrs = load_reserved_adrs(root / "CLAUDE.md")
+    yaml_index = build_yaml_index(root)
 
     auto: list[dict] = []
     judg: list[dict] = []
     for doc in discover_docs(root):
-        a, j = scan_doc(doc, root, resolved, min_ios, reserved_adrs)
+        a, j = scan_doc(doc, root, resolved, min_ios, reserved_adrs, yaml_index)
         auto.extend(a)
         judg.extend(j)
 

--- a/.claude/skills/consistency-audit/tests/fixtures/mirror/Package.resolved
+++ b/.claude/skills/consistency-audit/tests/fixtures/mirror/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams",
+      "state" : {
+        "revision" : "0000000000000000000000000000000000000000",
+        "version" : "6.2.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/.claude/skills/consistency-audit/tests/fixtures/mirror/data/alpha.yaml
+++ b/.claude/skills/consistency-audit/tests/fixtures/mirror/data/alpha.yaml
@@ -1,0 +1,10 @@
+id: alpha
+name: Alpha scenario
+agents: 3
+rounds: 2
+personas:
+  - name: One
+    role: leader
+  - name: Two
+    role: follower
+phase: speak_all

--- a/.claude/skills/consistency-audit/tests/fixtures/mirror/data/beta.yaml
+++ b/.claude/skills/consistency-audit/tests/fixtures/mirror/data/beta.yaml
@@ -1,0 +1,10 @@
+id: beta
+name: Beta scenario
+agents: 4
+rounds: 1
+personas:
+  - name: Alice
+    role: host
+  - name: Bob
+    role: guest
+phase: vote

--- a/.claude/skills/consistency-audit/tests/fixtures/mirror/data/delta.yaml
+++ b/.claude/skills/consistency-audit/tests/fixtures/mirror/data/delta.yaml
@@ -1,0 +1,10 @@
+id: delta
+name: Delta scenario
+agents: 2
+rounds: 5
+personas:
+  - name: X
+    role: a
+  - name: Y
+    role: b
+phase: choose

--- a/.claude/skills/consistency-audit/tests/fixtures/mirror/data/epsilon.yaml
+++ b/.claude/skills/consistency-audit/tests/fixtures/mirror/data/epsilon.yaml
@@ -1,0 +1,9 @@
+id: epsilon
+name: Epsilon
+note: |
+  ```
+  code sample inside
+  ```
+agents: 1
+rounds: 1
+phase: assign

--- a/.claude/skills/consistency-audit/tests/fixtures/mirror/data/gamma.yaml
+++ b/.claude/skills/consistency-audit/tests/fixtures/mirror/data/gamma.yaml
@@ -1,0 +1,20 @@
+id: gamma
+name: Gamma scenario
+agents: 5
+rounds: 3
+context: a long context line for gamma
+personas:
+  - name: P1
+    role: r1
+  - name: P2
+    role: r2
+  - name: P3
+    role: r3
+  - name: P4
+    role: r4
+  - name: P5
+    role: r5
+phases:
+  - type: speak_all
+  - type: vote
+  - type: score_calc

--- a/.claude/skills/consistency-audit/tests/fixtures/mirror/docs/coexist.md
+++ b/.claude/skills/consistency-audit/tests/fixtures/mirror/docs/coexist.md
@@ -1,0 +1,26 @@
+# Coexistence
+
+The mirror machinery must not disturb the other detectors when they share a
+file with a mirrored block.
+
+We pin Yams 1.0.0 in this table (drifts from the resolved pin).
+
+See [the missing doc](missing.md) for the rationale.
+
+Refer to ADR-099 for the original decision.
+
+A drifted near-complete mirror of data/alpha.yaml, placed below the lines the
+other detectors key on:
+
+```yaml
+id: alpha
+name: Alpha scenario RENAMED
+agents: 3
+rounds: 2
+personas:
+  - name: One
+    role: boss
+  - name: Two
+    role: follower
+phase: speak_all
+```

--- a/.claude/skills/consistency-audit/tests/fixtures/mirror/docs/mirrors.md
+++ b/.claude/skills/consistency-audit/tests/fixtures/mirror/docs/mirrors.md
@@ -1,0 +1,120 @@
+# Mirror detector fixture
+
+## FIRE: near-complete drifted copy of data/alpha.yaml
+
+```yaml
+id: alpha
+name: Alpha scenario CHANGED
+agents: 3
+rounds: 2
+personas:
+  - name: One
+    role: chief
+  - name: Two
+    role: follower
+phase: speak_all
+```
+
+## SILENT: identical copy of data/beta.yaml (in sync, not a current drift)
+
+```yaml
+id: beta
+name: Beta scenario
+agents: 4
+rounds: 1
+personas:
+  - name: Alice
+    role: host
+  - name: Bob
+    role: guest
+phase: vote
+```
+
+## SILENT: abridged excerpt of data/gamma.yaml (below completeness threshold)
+
+```yaml
+id: gamma
+name: Gamma scenario
+agents: 5
+rounds: 3
+personas:
+  - name: P1
+    role: r1
+  - name: P2
+    role: r2
+```
+
+## SILENT: coincidental id match, unrelated content (below ratio floor)
+
+```yaml
+id: alpha
+title: completely unrelated content here
+foo: bar
+baz: qux
+items:
+  - one
+  - two
+  - three
+  - four
+tail: done
+```
+
+## SILENT: no id on the first line (unattributable)
+
+```yaml
+name: block with no id first line
+agents: 3
+rounds: 2
+personas:
+  - name: One
+    role: leader
+  - name: Two
+    role: follower
+phase: speak_all
+```
+
+## SILENT: id resolves to no source file
+
+```yaml
+id: zeta
+name: Zeta scenario
+agents: 3
+rounds: 2
+personas:
+  - name: One
+    role: leader
+  - name: Two
+    role: follower
+phase: speak_all
+```
+
+## FIRE: indented fenced block under a list item (dedent to fence indent)
+
+1. A scenario embedded in a list item:
+
+   ```yaml
+   id: delta
+   name: Delta scenario CHANGED
+   agents: 2
+   rounds: 5
+   personas:
+     - name: X
+       role: a
+     - name: Y
+       role: b
+   phase: choose
+   ```
+
+## FIRE: tilde fence whose content contains a backtick fence (no early close)
+
+~~~yaml
+id: epsilon
+name: Epsilon CHANGED
+note: |
+  ```
+  code sample inside
+  ```
+agents: 1
+rounds: 1
+phase: assign
+~~~

--- a/.claude/skills/consistency-audit/tests/run_tests.sh
+++ b/.claude/skills/consistency-audit/tests/run_tests.sh
@@ -112,4 +112,44 @@ done
 echo "$OUT" | jq -e '[.needs_judgment[] | select(.type=="dangling_adr") | (has("adr") and has("target") and has("confidence") and has("counter_evidence") and has("suggested_action") and (.target==.adr))] | all' >/dev/null \
   || fail "adr: a dangling_adr finding is missing its judgment scalars or target!=adr"
 
+# --- mirror fixture: inverted embedded-source-mirror detector --------------
+# FIRE on near-complete drifted copies (alpha flush / delta indented-in-list /
+# epsilon tilde-fenced-with-backtick-content); SILENT on identical (beta),
+# abridged excerpt (gamma), unattributable (zeta / no-id first line), and
+# coincidental-id-with-unrelated-content (alpha). Coexistence: dependency_version,
+# dead_link, and dangling_adr must still fire around a mirror block in the same
+# file (the fence-loop restructure must not disturb them).
+OUT=$(python3 "$AUDIT" --repo-root fixtures/mirror \
+  --package-resolved fixtures/mirror/Package.resolved)
+[ "$(af_len "$OUT")" -eq 1 ] || fail "mirror: expected 1 auto_fixable (Yams), got $(af_len "$OUT")"
+echo "$OUT" | jq -e '.auto_fixable[] | select(.dependency=="Yams" and .expected=="6.2.2")' >/dev/null \
+  || fail "mirror: dependency_version did not fire beside a mirror block"
+[ "$(echo "$OUT" | jq '[.needs_judgment[]|select(.type=="dead_link")]|length')" -eq 1 ] \
+  || fail "mirror: dead_link did not fire beside a mirror block"
+[ "$(echo "$OUT" | jq '[.needs_judgment[]|select(.type=="dangling_adr")]|length')" -eq 1 ] \
+  || fail "mirror: dangling_adr did not fire beside a mirror block"
+# exactly four mirror findings: mirrors.md's three FIRE blocks + coexist's one
+MIR=$(echo "$OUT" | jq '[.needs_judgment[]|select(.type=="embedded_source_mirror")]|length')
+[ "$MIR" -eq 4 ] || fail "mirror: expected 4 embedded_source_mirror, got $MIR: $(echo "$OUT" | jq -c '[.needs_judgment[]|select(.type=="embedded_source_mirror").target]')"
+for want in "docs/mirrors.md::data/alpha.yaml" "docs/mirrors.md::data/delta.yaml" \
+            "docs/mirrors.md::data/epsilon.yaml" "docs/coexist.md::data/alpha.yaml"; do
+  echo "$OUT" | jq -e --arg t "$want" '.needs_judgment[]|select(.type=="embedded_source_mirror" and .target==$t)' >/dev/null \
+    || fail "mirror: expected mirror finding for $want"
+done
+# the SILENT set must produce no mirror finding
+for bad in "beta.yaml" "gamma.yaml" "zeta.yaml"; do
+  echo "$OUT" | jq -e --arg b "$bad" '.needs_judgment[]|select(.type=="embedded_source_mirror" and (.target|contains($b)))' >/dev/null \
+    && fail "mirror: $bad should be silent (identical / abridged / unattributable)" || true
+done
+# the coincidental-id block must not add a second location to the alpha finding
+ALOC=$(echo "$OUT" | jq '[.needs_judgment[]|select(.type=="embedded_source_mirror" and .target=="docs/mirrors.md::data/alpha.yaml")|.locations|length][0]')
+[ "$ALOC" -eq 1 ] || fail "mirror: mirrors.md alpha should have exactly 1 location (coincidental block leaked in?), got $ALOC"
+# a mirror finding carries only paths + judgment scalars, never block/source text
+# (it becomes a public GitHub issue body) — the allowed key set is closed.
+if echo "$OUT" | jq -e '.needs_judgment[]|select(.type=="embedded_source_mirror")|(keys - ["confidence","counter_evidence","locations","source","suggested_action","target","type"])|length>0' >/dev/null; then
+  fail "mirror: an embedded_source_mirror finding leaked an unexpected key (content leak?)"
+fi
+echo "$OUT" | jq -e '[.needs_judgment[]|select(.type=="embedded_source_mirror")|(has("confidence") and has("counter_evidence") and has("suggested_action") and has("source") and (.target==.source|not))]|all' >/dev/null \
+  || fail "mirror: a mirror finding is missing its pre-authored judgment scalars"
+
 echo "ALL TESTS PASSED"


### PR DESCRIPTION
## Summary
`consistency-audit`'s `scan_doc` skips fenced content by design, so a fenced YAML block that verbatim-copied a real source file and then **drifted** — the #921 `presets.md` failure mode — is invisible to every existing detector. This adds an **inverted, marker-free** `embedded_source_mirror` detector for that class.

A block fires (as `needs_judgment` — "candidate mirror, link instead of embedding") only when it is:
- **attributable** — first line `id: <slug>` resolving to a unique `<slug>.yaml` under the repo;
- **substantial** — `>= 8` lines;
- **near-complete** — block length `>= 0.6 ×` source length (the primary discriminator);
- **drifted** — not identical, difflib ratio `>= 0.3` (anti-coincidence floor).

**Why completeness, not similarity, is primary:** a real mirror is basically the whole file (presets blocks ≈ 0.7–0.8 complete) while an intentional illustration is an abridged excerpt (the MVP-spec's `prisoners_dilemma` example is ≈ 0.42, two of five personas) — a far healthier margin than the 0.44-vs-0.34 similarity knife edge.

**Empirically validated against `main`** (where #921's `presets.md` is not yet de-embedded): the detector fires on exactly the two embedded blocks (`prisoners_dilemma`, `bokete`) and stays silent on the MVP-spec abridged example and the gallery-README schema snippet — the drift the current audit reports 0 findings for.

### Design notes
- The fence loop is restructured to collect + check YAML blocks while keeping the four existing detectors byte-identical. Delimiter-matched close (a `~~~` block's inner backtick fence can't close it early) and dedent-to-fence-indentation (an indented block doesn't false-diff) are both pinned by fixtures.
- Findings carry **only paths + pre-authored** `confidence`/`counter_evidence`/`suggested_action`/`source` — never block/source text, since they become public issue bodies. `target == key == <docfile>::<sourcepath>` so `dedup_judgment` and the SKILL's Step 4 `<target> in:title` cross-run dedup agree (same source mirrored in two docs → two issues, neither dropped).
- `needs_judgment` only, never auto-fix — the fix (link vs resync vs intentional abridgement) is a human call.

### Scope / limitation
Scoped to `id:`-keyed YAML (the preset/gallery mirror shape that bit us); other embed shapes are out of v1 scope. It catches marker-less mirrors like #921 but is not a general content-similarity detector (that floods, per the SKILL's Deferred-detectors rationale).

## Test plan
- `bash .claude/skills/consistency-audit/tests/run_tests.sh` — all pass. New `fixtures/mirror/` exercises FIRE (drifted flush / indented-in-list / tilde-fenced-with-backtick-content), SILENT (identical / abridged / unattributable / coincidental-id), **coexistence** (dependency_version + dead_link + dangling_adr still fire around a mirror block — the restructure regression net), dedup (single-location), and the no-content-leak closed-key-set invariant.
- Live `--repo-root <main>` run confirms 2 findings, no new false positives.
- Reviewed by `code-reviewer` (Opus): PASS, 0 Critical/Warning; 2 hardening suggestions applied (non-UTF-8 read guard, prune-condition simplification).
- Docs-only/skill change: pre-commit correctly skipped Swift build/lint. CI Shell-gate runs the harness via the existing `scripts/tests/consistency-audit-test.sh` shim.

Closes #923

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P36EXtV3QNm2o66eyJTizv