### PR TITLE
🐛 fix: show phase glyph capsule on ScenarioDetail (#901)

### DIFF
--- a/.claude/rules/swiftui-traps.md
+++ b/.claude/rules/swiftui-traps.md
@@ -251,3 +251,32 @@ then `return EditorView(viewModel: vm)`) gets a **fresh instance on every `body`
 re-evaluation**, silently wiping user state — because `@Bindable`/`@Observable` references
 observe but do not own. Retain it with `@State` in a host view that creates the VM once
 (`.task { guard viewModel == nil ... }`), rendering a `ProgressView` until it exists.
+
+## iOS 26 AttributeGraph crash — ForEach + glyph in a plain-ScrollView card
+
+Adding an **unconditional** subview (an `Image`/glyph, a `.background(_, in: Capsule())`
+badge like `PhaseTypeLabel`) to a `ForEach` that renders inside a plain **`ScrollView` →
+eager `VStack`** (custom card, NOT `List`/`Form`/`LazyVStack`) under a `NavigationStack`
+with a `.large` title + `.safeAreaInset` + a `.background(...ignoresSafeArea())` can crash
+on iOS 26 with `EXC_BAD_ACCESS` the instant the screen appears — a pure-SwiftUI fault stack
+(`ForEachChild.updateValue → PairPreferenceCombiner → ContainerBackgroundKeys.NavigationKey
+→ AttributeGraph`), no app frame. A row with a *conditional* extra subview survives;
+the same badge renders fine in a `LazyVStack` (Sim conversation) or `List`/`Form` (editor).
+
+**Two load-bearing lessons — the crash itself is now secondary:**
+
+1. **Render crashes are invisible to `xcodebuild build` + the full unit suite** (both stay
+   green). Only a UI test that navigates in and renders catches them. For a View-tree change
+   on a screen the UI tests exercise, run at least one navigating UI test (cheapest that
+   lands on ScenarioDetail: `PasturaUITests/BackGestureTests/testBackGestureFromScenarioDetailReturnsToHome`).
+   Diagnose from `~/Library/Logs/DiagnosticReports/Pastura-*.ips` frames, not the XCUITest
+   assertion message.
+2. **These AttributeGraph crashes can be OS-build-specific and self-resolve.** This one
+   (`ScenarioDetailView.phasesSection`, #901) was real on iOS 26.5 on 2026-07-03 but no
+   longer reproduced on iOS 26.5 (23F77) — sim OR real device — on 2026-07-04, so the glyph
+   shipped with **no** code workaround. Before investing in a workaround, confirm the repro
+   on the **exact OS build AND a real device** (the sim misleads both ways). If one does
+   resurface, the candidate workarounds, in order: extract the row into a concrete `View`
+   struct → `.compositingGroup()` on the row → `LazyVStack` → drop the enumerated-`\.offset`
+   `ForEach` shape → bisect the container `.background(...ignoresSafeArea())` half the fault
+   stack names → `.geometryGroup()`. See #901 for the full diagnostic write-up.

--- a/Pastura/Pastura/Views/ScenarioDetail/ScenarioDetailView+Sections.swift
+++ b/Pastura/Pastura/Views/ScenarioDetail/ScenarioDetailView+Sections.swift
@@ -109,16 +109,7 @@ extension ScenarioDetailView {
             Text(verbatim: "\(index + 1).")
               .foregroundStyle(Color.muted)
               .monospacedDigit()
-            Text(phase.type.rawValue)
-              .font(.subheadline.monospaced())
-              .foregroundStyle(Color.ink)
-            if phase.type.requiresLLM {
-              // `info` here is a quiet category badge for LLM-required phases, not a
-              // notification — see design-system §2.6 for the alert-family scope.
-              Image(systemName: "brain")
-                .font(.caption)
-                .foregroundStyle(Color.info)
-            }
+            PhaseTypeLabel(phaseType: phase.type)
             Spacer(minLength: 0)
           }
           .padding(.horizontal, 17)


### PR DESCRIPTION
## Summary
- Completes #893/#904's app-wide phase-glyph rollout: ScenarioDetail's `phasesSection` now renders each phase with the shared `PhaseTypeLabel` capsule (glyph + type name). The capsule fill already encodes `requiresLLM`, so the separate `brain` Image is dropped.
- #901 deferred this one spot because adding any glyph to the `phasesSection` ForEach crashed on iOS 26.5 (EXC_BAD_ACCESS, SwiftUI AttributeGraph — invisible to build + unit suite). Re-verified 2026-07-04 on iOS 26.5 (23F77): the crash no longer reproduces on the reporting simulator NOR on a real iOS 26.5 device. It self-resolved at the OS/toolchain level, so the bare capsule ships with no code workaround.
- Records the crash class + the two durable lessons (render crashes are invisible to build+units; these AttributeGraph crashes can be OS-build-specific) in `.claude/rules/swiftui-traps.md`.

## Test plan
- `BackGestureTests` (cheapest ScenarioDetail-rendering gate) green on iOS 26.5 with both the 1-phase seed and a temporary 5-phase seed — no crash log.
- `NavigationRegressionTests` (gallery-install entry path) green.
- Full unit suite: 2458 tests green. `swiftlint --strict` clean.
- Manual device QA on a real iOS 26.5 device: Word Wolf (12 phases) + other multi-phase presets render the capsule cleanly, no crash.

Closes #901

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zMeUqSNPG8ux81m6p2wan