### PR TITLE
✨ feat: address rule for speak_each prompts (#911)

### DIFF
--- a/Pastura/Pastura/Engine/PromptBuilder.swift
+++ b/Pastura/Pastura/Engine/PromptBuilder.swift
@@ -180,6 +180,11 @@ nonisolated struct PromptBuilder: Sendable {
         - Output exactly one object starting with { and ending with }, with no surrounding text.
         """)
 
+    // Turn-based speak_each gets the #911 address rule (see `addressRule`).
+    if phase.type == .speakEach {
+      rules += addressRule(language: language)
+    }
+
     if phase.type == .choose, let options = phase.options {
       let optionsList = options.joined(separator: ", ")
       rules += pickLanguage(
@@ -205,6 +210,26 @@ nonisolated struct PromptBuilder: Sendable {
     }
 
     return rules
+  }
+
+  /// The #911 address rule appended for turn-based `speak_each` phases only.
+  ///
+  /// speak_each otherwise produces parallel monologues (0 % cross-reference at
+  /// baseline); a harness A/B on Gemma 4 E2B lifted word_wolf address-rate to
+  /// ~0.27 (ja) / ~0.18 (en) with no agreement-formulae collapse. It is NOT
+  /// appended for `speak_all`: the A/B showed it inert there (simultaneous
+  /// broadcast framing dominates, e.g. prisoners' "全員に向けて宣言") and mildly
+  /// harmful (parse failures + bokete boke-copying). The "反論でも疑問でもよい"
+  /// clause blocks the agreement-formulae collapse mode. Keep ja/en
+  /// scope-parallel; wording is harness-A/B-tuned.
+  private func addressRule(language: String) -> String {
+    pickLanguage(
+      language,
+      ja:
+        "\n- これまでの会話に他の誰かの発言があれば、そのうち1人の発言に必ず触れてから自分の意見を述べること（同意でも反論でも疑問でもよい）。まだ誰も発言していなければ自由に話してよい",
+      en:
+        "\n- If anyone has spoken earlier in the conversation, refer to one of their statements before giving your own opinion (agreement, disagreement, or a question all count). If no one has spoken yet, speak freely."
+    )
   }
 
   /// Render the `## 出力フォーマット（JSON）` / `## Output Format (JSON)`

--- a/Pastura/PasturaTests/Engine/PromptBuilderTests+Hardening.swift
+++ b/Pastura/PasturaTests/Engine/PromptBuilderTests+Hardening.swift
@@ -64,6 +64,76 @@ extension PromptBuilderTests {
     #expect(prompt.contains("at most 3 sentences"))
   }
 
+  // Address rule (#911, harness-A/B-tuned): turn-based speak_each otherwise
+  // produces parallel monologues (0 % cross-reference at baseline). The rule
+  // lifted word_wolf address-rate to ~0.2–0.33 in BOTH ja and en with no
+  // agreement-formulae collapse. Scoped to speak_each ONLY.
+  @Test func systemPromptIncludesAddressRuleForSpeakEachJa() {
+    let scenario = makeScenario()
+    let phase = Phase(
+      type: .speakEach,
+      prompt: "Speak!",
+      outputSchema: ["statement": "string"]
+    )
+    let state = SimulationState.initial(for: scenario)
+
+    let prompt = builder.buildSystemPrompt(
+      scenario: scenario, persona: scenario.personas[0], phase: phase, state: state
+    )
+    #expect(prompt.contains("必ず触れてから"))
+  }
+
+  @Test func systemPromptIncludesAddressRuleForSpeakEachEn() {
+    let scenario = makeScenario(language: "en")
+    let phase = Phase(
+      type: .speakEach,
+      prompt: "Speak!",
+      outputSchema: ["statement": "string"]
+    )
+    let state = SimulationState.initial(for: scenario)
+
+    let prompt = builder.buildSystemPrompt(
+      scenario: scenario, persona: scenario.personas[0], phase: phase, state: state
+    )
+    #expect(prompt.contains("refer to one of their statements"))
+  }
+
+  // Load-bearing scope guard: the A/B showed the address rule is inert on
+  // speak_all (simultaneous broadcast framing dominates) and mildly harmful
+  // there (parse-failure + boke-copying), so `buildAnswerRules` must NOT
+  // append it for .speakAll. If this fails, the scope guard regressed (#911).
+  @Test func systemPromptOmitsAddressRuleForSpeakAll() {
+    let scenario = makeScenario()
+    let phase = Phase(
+      type: .speakAll,
+      prompt: "Speak!",
+      outputSchema: ["statement": "string"]
+    )
+    let state = SimulationState.initial(for: scenario)
+
+    let prompt = builder.buildSystemPrompt(
+      scenario: scenario, persona: scenario.personas[0], phase: phase, state: state
+    )
+    #expect(!prompt.contains("必ず触れてから"))
+  }
+
+  // The scope guard is language-independent (a `phase.type` check ahead of
+  // pickLanguage), so speak_all omits the rule in en as well as ja.
+  @Test func systemPromptOmitsAddressRuleForSpeakAllEn() {
+    let scenario = makeScenario(language: "en")
+    let phase = Phase(
+      type: .speakAll,
+      prompt: "Speak!",
+      outputSchema: ["statement": "string"]
+    )
+    let state = SimulationState.initial(for: scenario)
+
+    let prompt = builder.buildSystemPrompt(
+      scenario: scenario, persona: scenario.personas[0], phase: phase, state: state
+    )
+    #expect(!prompt.contains("refer to one of their statements"))
+  }
+
   // Placeholder example must appear when outputSchema is set, AND must
   // use placeholder syntax (`<ここに...>`) — concrete Japanese values
   // would risk Gemma 2B parroting the demonstrated content (round 2


### PR DESCRIPTION
## Summary
Turn-based `speak_each` phases otherwise produce parallel monologues (0% cross-reference at baseline). This adds a prompt rule in `PromptBuilder.buildAnswerRules` (extracted to a `private addressRule(language:)` helper) telling agents to reference a prior speaker before speaking. Scoped to `speak_each` only.

## Harness A/B (gemma-4-E2B Q4_K_M, real inference)
| arm | scenario / phase | address-rate | notes |
|---|---|---|---|
| base | word_wolf / speak_each | 0.00 ×3 | parallel monologue |
| **(a) speak_each only** | word_wolf ja | **0.27** (0.267/0.333/0.20) | genuine conversation incl. critique; no agreement-formulae collapse |
| **(a) speak_each only** | word_wolf **en** | **0.18** (0.20/0.20/0.13) | rule transfers to en |
| (b) both | prisoners / speak_all | 0.00 ×3 | **inert** — broadcast framing ("全員に向けて宣言") dominates |
| (b) both | bokete / speak_all | 0.0 | boke-copying + meta-commentary (mild harm) |

**Why speak_each only:** the rule is inert on `speak_all` (simultaneous broadcast) and (b) additionally showed a parse-failure asymmetry (4 parse failures + 1 forced run-retry vs 0 across base/arm_a) and bokete boke-copying. So it's scoped to `speak_each`, where it delivers the full benefit.

Qualitative: no *agreement*-formulae collapse ("〜の言う通り" spam absent); an acknowledge-pivot template convergence appears by round 3 but still reads as conversation. Parse health unchanged (all speak_each runs 1-attempt).

Second opinion: an independent Fable review reproduced the metrics and confirmed the ship-(a) decision.

## Test plan
- `PromptBuilderTests+Hardening.swift`: address rule present in speak_each prompts (ja/en); **absent** from speak_all (ja/en) — load-bearing scope guard.
- Full unit suite: 2461 tests pass. swiftlint --strict clean. code-reviewer (Opus): PASS.

Out of scope (follow-up if desired): DL demo replay recapture (#899 precedent); speak_all reactivity is a scenario-authoring concern, not a prompt-rule one.

Part of #906. Closes #911.

🤖 Generated with [Claude Code](https://claude.com/claude-code)