### PR TITLE
✨ feat: viewer prediction — pre-vote guess + streak (#915)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ Phase 2 progress:
 - **Localization (i18n: ja/en)** — *in progress* — see ROADMAP § "Localization Plan" (#276/#277, ADR-010 stub #279, body #367, B-1a public pages #369, responsive-design migration #373, Engine dynamic localization #383, drift script + Past Results compat #386, bundled English presets + EN DL demo replays + locale-driven runtime selection #388, Step E PR1 simulation_language Engine wiring #398, Step E PR2 LLM output-language adherence enforcement #405, Step E follow-up `.languageMismatch` UI toast + completion summary #422, Past Results cross-language aggregation (ADR-010 D4 consumer) #392)
 - **Launch animation** — cold "Pastoral Drift" + warm "Breath" hybrid; per-scene `LaunchPhaseCoordinator` + Reduce Motion fallback (#412/#415)
 - **Home redesign** — bottom-tab IA (ADR-016, #602) + pause/resume of an interrupted run from the Home card (P3: round-boundary checkpoint producer #662, resume consumer + historical-log replay #667, confirm-on-leave pause for in-flight runs #673)
+- **Viewer prediction** — pre-vote-reveal prediction sheet ("who is the wolf?" / "who is #1?") + hit / consecutive-streak tracking; Engine-untouched App/ViewModel event buffering, ground truth scored at the reveal moment (#906 umbrella / #915)
 
 ## Language Rules
 

--- a/Pastura/Pastura/App/AppDependencies.swift
+++ b/Pastura/Pastura/App/AppDependencies.swift
@@ -18,6 +18,7 @@ final class AppDependencies: @unchecked Sendable {
   let simulationRepository: any SimulationRepository
   let turnRepository: any TurnRepository
   let codePhaseEventRepository: any CodePhaseEventRepository
+  let predictionRepository: any PredictionRepository
 
   /// The LLM service used for simulation execution.
   ///
@@ -83,6 +84,7 @@ final class AppDependencies: @unchecked Sendable {
     self.simulationRepository = GRDBSimulationRepository(dbWriter: writer)
     self.turnRepository = GRDBTurnRepository(dbWriter: writer)
     self.codePhaseEventRepository = GRDBCodePhaseEventRepository(dbWriter: writer)
+    self.predictionRepository = GRDBPredictionRepository(dbWriter: writer)
     if let llmService {
       self.llmService = llmService
     } else {

--- a/Pastura/Pastura/App/FeatureFlags.swift
+++ b/Pastura/Pastura/App/FeatureFlags.swift
@@ -26,6 +26,7 @@ nonisolated enum FeatureFlags {
   private static let realtimeStreamingKey = "realtimeStreamingEnabled"
   private static let backgroundContinuationKey = "backgroundContinuationEnabled"
   private static let keepRunningOnLeaveKey = "keepRunningOnLeaveEnabled"
+  private static let viewerPredictionKey = "viewerPredictionEnabled"
 
   // MARK: - Read accessors
 
@@ -127,12 +128,32 @@ nonisolated enum FeatureFlags {
     defaultsReadBool(key: keepRunningOnLeaveKey, default: false)
   }
 
+  /// Whether the viewer-prediction sheet interrupts the first vote reveal to
+  /// ask the viewer to predict the outcome ("who is the wolf?" / "who is #1?";
+  /// #915). Gates the `SimulationViewModel` interception; when `false`, runs
+  /// play straight through with no prediction and no DB writes.
+  ///
+  /// **Opt-out flag — defaults to `true`.** It is the headline
+  /// experience-changer from the #906 interestingness umbrella, so it ships
+  /// enabled for discoverability; the sheet is skippable and time-boxed, so
+  /// "watch only" viewers are not obstructed. User-facing: the Settings toggle
+  /// writes it via ``setViewerPredictionEnabled(_:)``.
+  static var viewerPredictionEnabled: Bool {
+    defaultsReadBool(key: viewerPredictionKey, default: true)
+  }
+
   // MARK: - Write accessors
 
   /// Persists the user's choice for ``keepRunningOnLeaveEnabled`` (Settings
   /// toggle). Read on demand (no caching), so the next leave honours it.
   static func setKeepRunningOnLeave(_ enabled: Bool) {
     UserDefaults.standard.set(enabled, forKey: keepRunningOnLeaveKey)
+  }
+
+  /// Persists the user's choice for ``viewerPredictionEnabled`` (Settings
+  /// toggle). Read on demand (no caching), so the next run honours it.
+  static func setViewerPredictionEnabled(_ enabled: Bool) {
+    UserDefaults.standard.set(enabled, forKey: viewerPredictionKey)
   }
 
   // MARK: - Helpers

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -32,6 +32,14 @@ struct LogEntry: Identifiable {
   }
 }
 
+/// Presentation model for the viewer-prediction sheet (#915), wrapping the
+/// question and choosable roster with a stable identity for `.sheet(item:)`.
+struct ViewerPredictionPrompt: Identifiable {
+  let id = UUID()
+  let question: ViewerPredictionLogic.Question
+  let candidates: [String]
+}
+
 /// ViewModel for the live simulation execution screen.
 ///
 /// Consumes `AsyncStream<SimulationEvent>` from `SimulationRunner`, applies
@@ -460,6 +468,11 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   private let turnRepository: any TurnRepository
   private let codePhaseEventRepository: (any CodePhaseEventRepository)?
   private let scenarioRepository: (any ScenarioRepository)?
+  // Viewer-prediction store (#915). Optional + nil-defaulted so fixture-driven
+  // tests (which construct the VM without it) never write predictions; the gate
+  // in `interceptFirstVoteIfNeeded` also requires a visible view, so tests are
+  // doubly insulated. Production wires it at the `SimulationView` boundary.
+  private let predictionRepository: (any PredictionRepository)?
   // Guards model-switch UI while inference is running. Optional to keep
   // the existing test fixtures (which don't need the guard) unchanged.
   private let simulationActivityRegistry: SimulationActivityRegistry?
@@ -469,6 +482,32 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   // routine state transitions and `error` for unexpected paths so device logs
   // stay readable.
   let lifecycleLogger = Logger(subsystem: "app.pastura.Pastura", category: "SimulationVM")
+
+  // MARK: - Viewer prediction (#915)
+
+  /// Drives `.sheet(item:)` for the prediction prompt; non-nil while the sheet
+  /// is up. Set from the run loop's interception, cleared on resolution.
+  private(set) var predictionPrompt: ViewerPredictionPrompt?
+
+  /// Whether `SimulationView` is currently on screen. Gates the prediction
+  /// sheet so a navigated-away (ADR-017 Phase B park) run never presents a
+  /// modal (scene-background is handled separately by `isAppBackgrounded`).
+  /// Defaults to `true` because the VM is only ever constructed by the
+  /// on-screen `SimulationView`; the view corrects it via
+  /// `setViewVisible(_:)` on appear/disappear.
+  private(set) var isViewVisible = true
+
+  /// Accumulated `.assignment` events (agent → assigned value), used to derive
+  /// the wolf ground-truth at the first vote reveal. Reset per run.
+  private var predictionAssignments: [String: String] = [:]
+
+  /// Latch: set once the prediction has been offered this run (answered OR
+  /// skipped), so it fires at most once with no DB round-trip. Reset per run.
+  private var hasAttemptedPrediction = false
+
+  /// Suspends the run loop while the prediction sheet awaits the viewer's
+  /// answer; resumed exactly once by `resolvePrediction`.
+  private var predictionContinuation: CheckedContinuation<ViewerPredictionSheet.Resolution, Never>?
 
   #if DEBUG
     // Streaming-display diagnostic logger for #133 PR#4 device-run sessions.
@@ -697,6 +736,7 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     turnRepository: any TurnRepository,
     codePhaseEventRepository: (any CodePhaseEventRepository)? = nil,
     scenarioRepository: (any ScenarioRepository)? = nil,
+    predictionRepository: (any PredictionRepository)? = nil,
     backgroundManager: BackgroundSimulationManager? = nil,
     simulationActivityRegistry: SimulationActivityRegistry? = nil
   ) {
@@ -706,6 +746,7 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     self.turnRepository = turnRepository
     self.codePhaseEventRepository = codePhaseEventRepository
     self.scenarioRepository = scenarioRepository
+    self.predictionRepository = predictionRepository
     self.backgroundManager = backgroundManager
     self.simulationActivityRegistry = simulationActivityRegistry
   }
@@ -867,6 +908,11 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     // The resume path re-seeds these below from the checkpoint / replayed log.
     voteResults = [:]
     eliminationVotes = [:]
+    // Viewer-prediction accumulators (#915) — reset so a re-used VM does not
+    // inherit the previous run's assignments or the once-per-run latch.
+    predictionAssignments = [:]
+    hasAttemptedPrediction = false
+    predictionPrompt = nil
     // Latent: a second run on the same VM instance would otherwise inherit
     // these from the previous simulation — `latestAgentOutputId` points at a
     // UUID no longer in `logEntries`, and `streamingSnapshot` could render a
@@ -1010,6 +1056,14 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
       } else if speed.interEventDelayMs > 0 {
         try? await Task.sleep(for: .milliseconds(speed.interEventDelayMs))
       }
+
+      // Viewer prediction (#915): before the FIRST vote reveal is committed,
+      // pause the loop to ask the viewer to predict the outcome — scored + saved
+      // here from the tallies/assignments already in hand, then the normal
+      // `handleEvent` below commits `voteResults`. `run()` only (a resumed run
+      // never asks). The unbounded AsyncStream buffers ahead during the wait
+      // (accepted trade-off), so the producer never deadlocks.
+      await interceptFirstVoteIfNeeded(event: event, scenario: scenario)
 
       handleEvent(event, scenario: scenario)
 
@@ -1416,6 +1470,10 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
         phaseType: currentPhaseType?.rawValue ?? PhaseType.eliminate.rawValue,
         payload: .elimination(agent: agent, voteCount: voteCount))
     case .assignment(let agent, let value):
+      // Accumulate for the wolf ground-truth derivation at the first vote
+      // reveal (#915). Assign phases run before any vote, so this is populated
+      // by the time the prediction is scored.
+      predictionAssignments[agent] = value
       logEntries.append(LogEntry(kind: .assignment(agent: agent, value: value)))
       persistCodePhaseEvent(
         phaseType: currentPhaseType?.rawValue ?? PhaseType.assign.rawValue,
@@ -1921,6 +1979,119 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
       lifecycleLogger.error(
         "Failed to encode code-phase payload: \(String(describing: error), privacy: .public)")
     }
+  }
+
+  // MARK: - Viewer prediction (#915)
+
+  /// If `event` is the first vote reveal of a fresh run and the feature is
+  /// enabled + the view is visible + foregrounded, pauses the loop to present
+  /// the prediction sheet, scores the answer against the reveal-moment ground
+  /// truth, and persists it (answered predictions only). Fires at most once per
+  /// run via the `hasAttemptedPrediction` latch (set even on skip), so no DB
+  /// round-trip is needed and a multi-vote scenario is not re-asked.
+  ///
+  /// Internal (not `private`) so it can be driven directly from a unit test
+  /// (ADR-009 / `.claude/rules/view-testing.md`) without spinning the full
+  /// run loop; the test resolves the sheet by polling `predictionPrompt` and
+  /// calling `resolvePrediction`.
+  func interceptFirstVoteIfNeeded(
+    event: SimulationEvent, scenario: Scenario
+  ) async {
+    guard case .voteResults(_, let tallies) = event else { return }
+    guard
+      !hasAttemptedPrediction,
+      FeatureFlags.viewerPredictionEnabled,
+      isViewVisible, !isAppBackgrounded,
+      let predictionRepository,
+      let simId = simulationId,
+      let question = ViewerPredictionLogic.question(for: scenario.phases)
+    else { return }
+
+    hasAttemptedPrediction = true
+
+    let candidates = activePredictionCandidates(scenario: scenario)
+    // Need at least two agents to make a prediction meaningful.
+    guard candidates.count >= 2 else { return }
+
+    let resolution = await presentPrediction(
+      ViewerPredictionPrompt(question: question, candidates: candidates))
+
+    // Skip / timeout / navigate-away leave no row (see `PredictionRecord`).
+    guard case .predicted(let picked) = resolution else { return }
+
+    let actual: String? = {
+      switch question {
+      case .wolf:
+        return ViewerPredictionLogic.wolf(from: predictionAssignments)
+      case .topVote:
+        return ViewerPredictionLogic.topVote(tallies: tallies, roster: candidates)
+      }
+    }()
+    // Ground truth not uniquely derivable (e.g. an ambiguous minority) → leave
+    // the run unscored rather than record a coin-flip.
+    guard let actual else { return }
+
+    await persistPrediction(
+      repository: predictionRepository, simulationId: simId,
+      question: question, predicted: picked, actual: actual)
+  }
+
+  /// Active (non-eliminated) agent names — the choosable roster. At the first
+  /// vote nobody is eliminated yet, so this is the full cast.
+  private func activePredictionCandidates(scenario: Scenario) -> [String] {
+    scenario.personas.map(\.name).filter { !(eliminated[$0] ?? false) }
+  }
+
+  /// Presents the sheet and suspends until the viewer resolves it.
+  private func presentPrediction(
+    _ prompt: ViewerPredictionPrompt
+  ) async -> ViewerPredictionSheet.Resolution {
+    await withCheckedContinuation { continuation in
+      predictionContinuation = continuation
+      predictionPrompt = prompt
+    }
+  }
+
+  /// Resolves a pending prediction sheet exactly once — called by the sheet's
+  /// `onResolve` and by `setViewVisible(false)` (navigate-away safety net). A
+  /// no-op when nothing is pending.
+  func resolvePrediction(_ resolution: ViewerPredictionSheet.Resolution) {
+    guard let continuation = predictionContinuation else { return }
+    predictionContinuation = nil
+    predictionPrompt = nil
+    continuation.resume(returning: resolution)
+  }
+
+  /// Mirrors `SimulationView`'s on-screen state. Leaving the screen mid-sheet
+  /// resolves it as a skip so no phantom sheet resurfaces on return.
+  func setViewVisible(_ visible: Bool) {
+    isViewVisible = visible
+    if !visible { resolvePrediction(.skipped) }
+  }
+
+  /// Writes an answered prediction off-main and awaits it, so the row exists
+  /// before the run completes and the result card reads it back.
+  private func persistPrediction(
+    repository: any PredictionRepository, simulationId: String,
+    question: ViewerPredictionLogic.Question, predicted: String, actual: String
+  ) async {
+    let record = PredictionRecord(
+      id: UUID().uuidString,
+      simulationId: simulationId,
+      questionKind: question.rawValue,
+      predictedAgent: predicted,
+      actualAgent: actual,
+      isHit: ViewerPredictionLogic.isHit(predicted: predicted, actual: actual),
+      createdAt: Date())
+    let logger = lifecycleLogger
+    await Task.detached {
+      do {
+        try repository.save(record)
+      } catch {
+        logger.error(
+          "Failed to persist prediction: \(String(describing: error), privacy: .public)")
+      }
+    }.value
   }
 
   // MARK: - Test Seams

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -40,6 +40,13 @@ struct ViewerPredictionPrompt: Identifiable {
   let candidates: [String]
 }
 
+/// The scored result of this run's viewer prediction (#915), shown alongside
+/// the final result card. `streak` is the consecutive-hit count as of this run.
+struct PredictionOutcome: Equatable, Sendable {
+  let isHit: Bool
+  let streak: Int
+}
+
 /// ViewModel for the live simulation execution screen.
 ///
 /// Consumes `AsyncStream<SimulationEvent>` from `SimulationRunner`, applies
@@ -489,6 +496,11 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   /// is up. Set from the run loop's interception, cleared on resolution.
   private(set) var predictionPrompt: ViewerPredictionPrompt?
 
+  /// This run's scored prediction result (hit/miss + streak), shown next to the
+  /// final result card. `nil` when the run had no answered prediction. Reset
+  /// per run.
+  private(set) var predictionOutcome: PredictionOutcome?
+
   /// Whether `SimulationView` is currently on screen. Gates the prediction
   /// sheet so a navigated-away (ADR-017 Phase B park) run never presents a
   /// modal (scene-background is handled separately by `isAppBackgrounded`).
@@ -913,6 +925,7 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     predictionAssignments = [:]
     hasAttemptedPrediction = false
     predictionPrompt = nil
+    predictionOutcome = nil
     // Latent: a second run on the same VM instance would otherwise inherit
     // these from the previous simulation — `latestAgentOutputId` points at a
     // UUID no longer in `logEntries`, and `streamingSnapshot` could render a
@@ -2031,9 +2044,12 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     // the run unscored rather than record a coin-flip.
     guard let actual else { return }
 
-    await persistPrediction(
+    let streak = await persistPrediction(
       repository: predictionRepository, simulationId: simId,
       question: question, predicted: picked, actual: actual)
+    predictionOutcome = PredictionOutcome(
+      isHit: ViewerPredictionLogic.isHit(predicted: picked, actual: actual),
+      streak: streak)
   }
 
   /// Active (non-eliminated) agent names — the choosable roster. At the first
@@ -2069,12 +2085,13 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     if !visible { resolvePrediction(.skipped) }
   }
 
-  /// Writes an answered prediction off-main and awaits it, so the row exists
-  /// before the run completes and the result card reads it back.
+  /// Writes an answered prediction off-main and returns the resulting
+  /// consecutive-hit streak (0 on write failure). Awaited so the row exists and
+  /// the streak is known before the run completes and the card renders.
   private func persistPrediction(
     repository: any PredictionRepository, simulationId: String,
     question: ViewerPredictionLogic.Question, predicted: String, actual: String
-  ) async {
+  ) async -> Int {
     let record = PredictionRecord(
       id: UUID().uuidString,
       simulationId: simulationId,
@@ -2084,12 +2101,14 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
       isHit: ViewerPredictionLogic.isHit(predicted: predicted, actual: actual),
       createdAt: Date())
     let logger = lifecycleLogger
-    await Task.detached {
+    return await Task.detached {
       do {
         try repository.save(record)
+        return (try? repository.currentStreak()) ?? 0
       } catch {
         logger.error(
           "Failed to persist prediction: \(String(describing: error), privacy: .public)")
+        return 0
       }
     }.value
   }

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -860,6 +860,11 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
       "cancelSimulation called by \(caller, privacy: .public): isRunning=\(self.isRunning), isOnCPU=\(self.isOnCPU), isReloadingModel=\(self.isReloadingModel)"
     )
     runTask?.cancel()
+    // Defensive: if the run loop is suspended awaiting the prediction sheet
+    // (a `Never` continuation that ignores task cancellation), resolve it so
+    // the loop can unwind rather than leaking the continuation (#915). Normally
+    // unreachable — the modal covers the stop button — but cheap insurance.
+    resolvePrediction(.skipped)
     isCancelled = true
     // User-initiated cancel supersedes a prior pause: clear the survival flag
     // so the terminal ladder writes `.cancelled` (its `isCancelled` branch
@@ -1996,12 +2001,13 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
 
   // MARK: - Viewer prediction (#915)
 
-  /// If `event` is the first vote reveal of a fresh run and the feature is
-  /// enabled + the view is visible + foregrounded, pauses the loop to present
-  /// the prediction sheet, scores the answer against the reveal-moment ground
-  /// truth, and persists it (answered predictions only). Fires at most once per
-  /// run via the `hasAttemptedPrediction` latch (set even on skip), so no DB
-  /// round-trip is needed and a multi-vote scenario is not re-asked.
+  /// On the first vote reveal of a fresh run with the feature enabled, latches
+  /// the run's single prediction opportunity, then — if the sim screen is
+  /// foreground-visible — pauses the loop to present the sheet, scores the answer
+  /// against the reveal-moment ground truth, and persists it (answered
+  /// predictions only). The latch is set BEFORE the visibility check (set even
+  /// on skip / not-presentable), so it fires at most once per run with no DB
+  /// round-trip and a multi-vote scenario is never re-asked on a later vote.
   ///
   /// Internal (not `private`) so it can be driven directly from a unit test
   /// (ADR-009 / `.claude/rules/view-testing.md`) without spinning the full
@@ -2014,13 +2020,20 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     guard
       !hasAttemptedPrediction,
       FeatureFlags.viewerPredictionEnabled,
-      isViewVisible, !isAppBackgrounded,
       let predictionRepository,
       let simId = simulationId,
       let question = ViewerPredictionLogic.question(for: scenario.phases)
     else { return }
 
+    // This first vote consumes the run's single prediction opportunity — latch
+    // BEFORE the visibility check so that if we can't present now (parked /
+    // backgrounded), a later vote in the same run is skipped too rather than
+    // asked, keeping the "first vote" contract strict.
     hasAttemptedPrediction = true
+
+    // Present only when the sim screen is foreground-visible; a parked
+    // (ADR-017 Phase B) or backgrounded run skips this run's prediction.
+    guard isViewVisible, !isAppBackgrounded else { return }
 
     let candidates = activePredictionCandidates(scenario: scenario)
     // Need at least two agents to make a prediction meaningful.

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -501,6 +501,10 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   /// per run.
   private(set) var predictionOutcome: PredictionOutcome?
 
+  /// A pick captured at vote-phase start, awaiting the tally to be scored at
+  /// `.voteResults`. Reset per run.
+  private var pendingPrediction: PendingPrediction?
+
   /// Whether `SimulationView` is currently on screen. Gates the prediction
   /// sheet so a navigated-away (ADR-017 Phase B park) run never presents a
   /// modal (scene-background is handled separately by `isAppBackgrounded`).
@@ -931,6 +935,7 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     hasAttemptedPrediction = false
     predictionPrompt = nil
     predictionOutcome = nil
+    pendingPrediction = nil
     // Latent: a second run on the same VM instance would otherwise inherit
     // these from the previous simulation — `latestAgentOutputId` points at a
     // UUID no longer in `logEntries`, and `streamingSnapshot` could render a
@@ -1075,13 +1080,12 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
         try? await Task.sleep(for: .milliseconds(speed.interEventDelayMs))
       }
 
-      // Viewer prediction (#915): before the FIRST vote reveal is committed,
-      // pause the loop to ask the viewer to predict the outcome — scored + saved
-      // here from the tallies/assignments already in hand, then the normal
-      // `handleEvent` below commits `voteResults`. `run()` only (a resumed run
+      // Viewer prediction (#915): present the sheet at the first vote-phase
+      // START (before any vote is shown, so the outcome isn't spoiled) and score
+      // the captured pick when the tally arrives. `run()` only (a resumed run
       // never asks). The unbounded AsyncStream buffers ahead during the wait
       // (accepted trade-off), so the producer never deadlocks.
-      await interceptFirstVoteIfNeeded(event: event, scenario: scenario)
+      await handleViewerPredictionEvent(event: event, scenario: scenario)
 
       handleEvent(event, scenario: scenario)
 
@@ -2001,34 +2005,59 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
 
   // MARK: - Viewer prediction (#915)
 
-  /// On the first vote reveal of a fresh run with the feature enabled, latches
-  /// the run's single prediction opportunity, then — if the sim screen is
-  /// foreground-visible — pauses the loop to present the sheet, scores the answer
-  /// against the reveal-moment ground truth, and persists it (answered
-  /// predictions only). The latch is set BEFORE the visibility check (set even
-  /// on skip / not-presentable), so it fires at most once per run with no DB
-  /// round-trip and a multi-vote scenario is never re-asked on a later vote.
+  /// A prediction captured at vote-phase start, awaiting the tally to score it.
+  private struct PendingPrediction {
+    let question: ViewerPredictionLogic.Question
+    let picked: String
+    /// Roster captured at prompt time — the `topVote` scoring ranks over this.
+    let candidates: [String]
+  }
+
+  /// Drives the viewer-prediction feature off the run loop (#915). Two events
+  /// matter, and interception happens BEFORE the votes are shown so the outcome
+  /// isn't spoiled:
   ///
-  /// Internal (not `private`) so it can be driven directly from a unit test
-  /// (ADR-009 / `.claude/rules/view-testing.md`) without spinning the full
-  /// run loop; the test resolves the sheet by polling `predictionPrompt` and
-  /// calling `resolvePrediction`.
-  func interceptFirstVoteIfNeeded(
+  /// - **`.phaseStarted(.vote)`** — the first vote phase of a fresh run. Latches
+  ///   the run's single prediction opportunity, then (if foreground-visible)
+  ///   pauses the loop to present the sheet and captures the pick into
+  ///   `pendingPrediction`. This fires *before* any agent casts a vote
+  ///   (`SimulationRunner` emits `phaseStarted` before the handler runs), so the
+  ///   individual votes don't leak the answer.
+  /// - **`.voteResults`** — the tally. Scores the captured pick against the
+  ///   reveal-moment ground truth (wolf from `.assignment` events; `#1` from
+  ///   these tallies) and persists it (answered predictions only).
+  ///
+  /// The latch is set BEFORE the visibility check (even on skip / not-presentable)
+  /// so a parked/backgrounded first vote consumes the opportunity and a later
+  /// vote is never asked. `run()` only — a resumed run never asks.
+  ///
+  /// Internal (not `private`) so a unit test can drive it directly (ADR-009 /
+  /// `.claude/rules/view-testing.md`): feed `.phaseStarted(.vote)` (resolving the
+  /// sheet by polling `predictionPrompt`), then `.voteResults`.
+  func handleViewerPredictionEvent(
     event: SimulationEvent, scenario: Scenario
   ) async {
-    guard case .voteResults(_, let tallies) = event else { return }
+    switch event {
+    case .phaseStarted(let phaseType, _) where phaseType == .vote:
+      await presentPredictionAtVoteStart(scenario: scenario)
+    case .voteResults(_, let tallies):
+      await scorePendingPrediction(tallies: tallies)
+    default:
+      break
+    }
+  }
+
+  private func presentPredictionAtVoteStart(scenario: Scenario) async {
     guard
       !hasAttemptedPrediction,
       FeatureFlags.viewerPredictionEnabled,
-      let predictionRepository,
-      let simId = simulationId,
+      predictionRepository != nil,
+      simulationId != nil,
       let question = ViewerPredictionLogic.question(for: scenario.phases)
     else { return }
 
-    // This first vote consumes the run's single prediction opportunity — latch
-    // BEFORE the visibility check so that if we can't present now (parked /
-    // backgrounded), a later vote in the same run is skipped too rather than
-    // asked, keeping the "first vote" contract strict.
+    // Latch BEFORE the visibility check so a parked/backgrounded first vote
+    // still consumes the run's one opportunity (a later vote is never asked).
     hasAttemptedPrediction = true
 
     // Present only when the sim screen is foreground-visible; a parked
@@ -2042,15 +2071,27 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     let resolution = await presentPrediction(
       ViewerPredictionPrompt(question: question, candidates: candidates))
 
-    // Skip / timeout / navigate-away leave no row (see `PredictionRecord`).
+    // Skip / timeout / navigate-away leave no pending pick and no row.
     guard case .predicted(let picked) = resolution else { return }
+    pendingPrediction = PendingPrediction(
+      question: question, picked: picked, candidates: candidates)
+  }
+
+  private func scorePendingPrediction(tallies: [String: Int]) async {
+    guard
+      let pending = pendingPrediction,
+      let predictionRepository,
+      let simId = simulationId
+    else { return }
+    pendingPrediction = nil
 
     let actual: String? = {
-      switch question {
+      switch pending.question {
       case .wolf:
         return ViewerPredictionLogic.wolf(from: predictionAssignments)
       case .topVote:
-        return ViewerPredictionLogic.topVote(tallies: tallies, roster: candidates)
+        return ViewerPredictionLogic.topVote(
+          tallies: tallies, roster: pending.candidates)
       }
     }()
     // Ground truth not uniquely derivable (e.g. an ambiguous minority) → leave
@@ -2059,9 +2100,9 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
 
     let streak = await persistPrediction(
       repository: predictionRepository, simulationId: simId,
-      question: question, predicted: picked, actual: actual)
+      question: pending.question, predicted: pending.picked, actual: actual)
     predictionOutcome = PredictionOutcome(
-      isHit: ViewerPredictionLogic.isHit(predicted: picked, actual: actual),
+      isHit: ViewerPredictionLogic.isHit(predicted: pending.picked, actual: actual),
       streak: streak)
   }
 

--- a/Pastura/Pastura/App/ViewerPredictionLogic.swift
+++ b/Pastura/Pastura/App/ViewerPredictionLogic.swift
@@ -61,6 +61,7 @@ nonisolated enum ViewerPredictionLogic {
     RankingOrder.leader(values: tallies, among: roster)
   }
 
+  /// Whether the viewer's pick matched the ground-truth agent.
   static func isHit(predicted: String, actual: String) -> Bool {
     predicted == actual
   }

--- a/Pastura/Pastura/App/ViewerPredictionLogic.swift
+++ b/Pastura/Pastura/App/ViewerPredictionLogic.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Pure, off-main decision logic for the viewer-prediction feature (#915).
+///
+/// The ViewModel owns event interception and DB persistence; this enum owns
+/// the *decisions*: which question a scenario invites, and — computed at the
+/// vote-reveal moment from data already in hand, never from the completion-time
+/// result card — the ground-truth answer. Kept `nonisolated` and dependency-free
+/// (Models only) so it unit-tests off the MainActor without rendering a View
+/// (ADR-009 / `.claude/rules/view-testing.md`).
+nonisolated enum ViewerPredictionLogic {
+
+  /// The prediction a scenario invites.
+  enum Question: String, Equatable, Sendable {
+    /// "Who is the wolf?" — scored against the minority-word holder.
+    case wolf
+    /// "Who is #1?" — scored against the top vote-getter.
+    case topVote
+  }
+
+  /// Classifies a scenario into a prediction question, or `nil` when it isn't
+  /// prediction-shaped. Wolf takes priority: a word-wolf scenario has both a
+  /// `random_one` assign and a `vote`, and the wolf-guess is the sharper
+  /// question. Scenarios with neither a `random_one` assign nor a `vote`
+  /// (e.g. prisoner's-dilemma `choose` scenarios) invite no prediction, so the
+  /// sheet never interrupts them.
+  static func question(for phases: [Phase]) -> Question? {
+    let all = flattened(phases)
+    if all.contains(where: { $0.type == .assign && $0.target == .randomOne }) {
+      return .wolf
+    }
+    if all.contains(where: { $0.type == .vote }) {
+      return .topVote
+    }
+    return nil
+  }
+
+  /// Ground truth for `.wolf`: the sole holder of the minority (rarest) value
+  /// among `assignments` (agent → assigned value). Returns `nil` when the
+  /// minority is not uniquely determined — a 2-agent 1-vs-1 split, two values
+  /// tied for rarest, or a rarest value shared by several agents — so the run
+  /// is left unscored rather than mis-scored.
+  static func wolf(from assignments: [String: String]) -> String? {
+    guard !assignments.isEmpty else { return nil }
+    var frequency: [String: Int] = [:]
+    for value in assignments.values { frequency[value, default: 0] += 1 }
+    guard let minCount = frequency.values.min() else { return nil }
+    let rarestValues = frequency.filter { $0.value == minCount }.map(\.key)
+    guard rarestValues.count == 1, let minorityValue = rarestValues.first else {
+      return nil
+    }
+    let holders = assignments.filter { $0.value == minorityValue }.map(\.key)
+    guard holders.count == 1 else { return nil }
+    return holders.first
+  }
+
+  /// Ground truth for `.topVote`: the #1 vote-getter among `roster`, using the
+  /// same tiebreak the result card uses (`RankingOrder`) so the accuracy badge
+  /// and the displayed #1 can never disagree. `nil` when `roster` is empty.
+  static func topVote(tallies: [String: Int], roster: [String]) -> String? {
+    RankingOrder.leader(values: tallies, among: roster)
+  }
+
+  static func isHit(predicted: String, actual: String) -> Bool {
+    predicted == actual
+  }
+
+  /// Flattens depth-1 conditional branches so a `vote` / `assign` nested inside
+  /// a `conditional` still classifies (the engine caps conditional nesting at
+  /// depth 1, so a single non-recursive expansion is exhaustive).
+  private static func flattened(_ phases: [Phase]) -> [Phase] {
+    phases.flatMap { phase in
+      [phase] + (phase.thenPhases ?? []) + (phase.elsePhases ?? [])
+    }
+  }
+}

--- a/Pastura/Pastura/Data/DatabaseManager+Migrations.swift
+++ b/Pastura/Pastura/Data/DatabaseManager+Migrations.swift
@@ -92,10 +92,15 @@ nonisolated extension DatabaseManager {
         t.column("createdAt", .datetime).notNull()
       }
 
+      // Unique: at most one answered prediction per run (the App layer's
+      // once-per-run latch is the primary guard; the unique constraint makes a
+      // stray double-insert throw at the DB boundary rather than silently
+      // corrupt a streak/badge).
       try db.create(
         index: "idx_prediction_records_simulation",
         on: "prediction_records",
-        columns: ["simulationId"])
+        columns: ["simulationId"],
+        options: [.unique])
     }
   }
 

--- a/Pastura/Pastura/Data/DatabaseManager+Migrations.swift
+++ b/Pastura/Pastura/Data/DatabaseManager+Migrations.swift
@@ -71,6 +71,32 @@ nonisolated extension DatabaseManager {
     registerV8(&migrator)
     registerV9(&migrator)
     registerV10(&migrator)
+    registerV11(&migrator)
+  }
+
+  private static func registerV11(_ migrator: inout DatabaseMigrator) {
+    // Viewer-prediction outcomes (#915). One row per *answered* prediction,
+    // keyed to its run; skipped predictions leave no row (see
+    // `PredictionRecord`). Cascade-delete with the parent run so purging a
+    // simulation drops its prediction. The `simulations` row is created at
+    // run-start (before the first vote), so the FK is satisfied at insert.
+    migrator.registerMigration("v11_createPredictionRecordsTable") { db in
+      try db.create(table: "prediction_records") { t in
+        t.primaryKey("id", .text)
+        t.column("simulationId", .text).notNull()
+          .references("simulations", onDelete: .cascade)
+        t.column("questionKind", .text).notNull()
+        t.column("predictedAgent", .text).notNull()
+        t.column("actualAgent", .text).notNull()
+        t.column("isHit", .boolean).notNull()
+        t.column("createdAt", .datetime).notNull()
+      }
+
+      try db.create(
+        index: "idx_prediction_records_simulation",
+        on: "prediction_records",
+        columns: ["simulationId"])
+    }
   }
 
   private static func registerV9(_ migrator: inout DatabaseMigrator) {

--- a/Pastura/Pastura/Data/Models/PredictionRecord.swift
+++ b/Pastura/Pastura/Data/Models/PredictionRecord.swift
@@ -23,7 +23,7 @@ nonisolated public struct PredictionRecord: Codable, Sendable, Equatable,
   public var id: String
   public var simulationId: String
   /// Which question was asked. Stored as a raw string for forward compat;
-  /// the typed vocabulary is `ViewerPredictionQuestion.Kind` ("wolf" /
+  /// the typed vocabulary is `ViewerPredictionLogic.Question` ("wolf" /
   /// "topVote").
   public var questionKind: String
   /// The agent the viewer picked.

--- a/Pastura/Pastura/Data/Models/PredictionRecord.swift
+++ b/Pastura/Pastura/Data/Models/PredictionRecord.swift
@@ -1,0 +1,56 @@
+import Foundation
+import GRDB
+
+/// Database record type for the `prediction_records` table (#915).
+///
+/// Each record captures one *answered* viewer prediction: before a
+/// simulation reveals its first vote tally, the app asks the viewer to
+/// predict an outcome ("who is the wolf?" / "who is #1?"). The answer and
+/// the ground truth — both computed at the reveal moment (see
+/// `ViewerPredictionLogic`) — are frozen into a row here so the result card
+/// and Past Results can show a hit/miss badge and a running streak without
+/// replaying events.
+///
+/// Only answered predictions produce a row. Skipped / timed-out /
+/// backgrounded predictions leave no row (an in-memory latch prevents a
+/// same-run re-ask, and the fresh-`run()`-only interception means a resumed
+/// run never asks), so both `predictedAgent` and `actualAgent` are always
+/// populated — there is no skip sentinel.
+nonisolated public struct PredictionRecord: Codable, Sendable, Equatable,
+  FetchableRecord, PersistableRecord {
+  public static let databaseTableName = "prediction_records"
+
+  public var id: String
+  public var simulationId: String
+  /// Which question was asked. Stored as a raw string for forward compat;
+  /// the typed vocabulary is `ViewerPredictionQuestion.Kind` ("wolf" /
+  /// "topVote").
+  public var questionKind: String
+  /// The agent the viewer picked.
+  public var predictedAgent: String
+  /// The ground-truth agent computed at reveal time (the minority-word
+  /// holder for "wolf", the top-tally agent for "topVote").
+  public var actualAgent: String
+  /// `predictedAgent == actualAgent`, frozen at capture so historical rows
+  /// stay stable even if scoring semantics later change.
+  public var isHit: Bool
+  public var createdAt: Date
+
+  public init(
+    id: String,
+    simulationId: String,
+    questionKind: String,
+    predictedAgent: String,
+    actualAgent: String,
+    isHit: Bool,
+    createdAt: Date
+  ) {
+    self.id = id
+    self.simulationId = simulationId
+    self.questionKind = questionKind
+    self.predictedAgent = predictedAgent
+    self.actualAgent = actualAgent
+    self.isHit = isHit
+    self.createdAt = createdAt
+  }
+}

--- a/Pastura/Pastura/Data/PredictionRepository.swift
+++ b/Pastura/Pastura/Data/PredictionRepository.swift
@@ -1,0 +1,85 @@
+import Foundation
+import GRDB
+
+/// Repository for persisting and retrieving viewer-prediction records (#915).
+///
+/// Predictions are written at most once per run (only when answered), so
+/// per-simulation lookups return a single optional record. The streak query
+/// powers the "連続的中" indicator on the result card.
+nonisolated public protocol PredictionRepository: Sendable {
+  /// Saves a single answered prediction.
+  func save(_ record: PredictionRecord) throws
+
+  /// Fetches the prediction for a simulation, or `nil` when the run had none
+  /// (skipped, disabled, or a non-prediction scenario).
+  func fetchBySimulationId(_ simulationId: String) throws -> PredictionRecord?
+
+  /// Fetches predictions for many simulations at once, keyed by
+  /// `simulationId`. Used by the Past Results list projection to attach a
+  /// hit/miss badge per row without an N+1 query.
+  func fetchBySimulationIds(
+    _ simulationIds: [String]
+  ) throws -> [String: PredictionRecord]
+
+  /// The current consecutive-hit streak: counts hits from the most recent
+  /// prediction backwards, stopping at the first miss. Returns `0` when the
+  /// latest prediction was a miss or none exist.
+  func currentStreak() throws -> Int
+}
+
+/// GRDB-backed implementation of `PredictionRepository`.
+nonisolated public final class GRDBPredictionRepository: PredictionRepository, Sendable {
+  private let dbWriter: any DatabaseWriter
+
+  public init(dbWriter: any DatabaseWriter) {
+    self.dbWriter = dbWriter
+  }
+
+  public func save(_ record: PredictionRecord) throws {
+    try dbWriter.write { db in
+      try record.insert(db)
+    }
+  }
+
+  public func fetchBySimulationId(
+    _ simulationId: String
+  ) throws -> PredictionRecord? {
+    try dbWriter.read { db in
+      try PredictionRecord
+        .filter(Column("simulationId") == simulationId)
+        .fetchOne(db)
+    }
+  }
+
+  public func fetchBySimulationIds(
+    _ simulationIds: [String]
+  ) throws -> [String: PredictionRecord] {
+    guard !simulationIds.isEmpty else { return [:] }
+    return try dbWriter.read { db in
+      let records =
+        try PredictionRecord
+        .filter(simulationIds.contains(Column("simulationId")))
+        .fetchAll(db)
+      // At most one row per simulationId, so keying is unambiguous.
+      return Dictionary(records.map { ($0.simulationId, $0) }) { first, _ in first }
+    }
+  }
+
+  public func currentStreak() throws -> Int {
+    try dbWriter.read { db in
+      // Most-recent-first; `id` breaks any createdAt tie deterministically.
+      let hits =
+        try Bool.fetchAll(
+          db,
+          PredictionRecord
+            .select(Column("isHit"))
+            .order(Column("createdAt").desc, Column("id").desc))
+      var streak = 0
+      for hit in hits {
+        guard hit else { break }
+        streak += 1
+      }
+      return streak
+    }
+  }
+}

--- a/Pastura/Pastura/Models/RankingOrder.swift
+++ b/Pastura/Pastura/Models/RankingOrder.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Deterministic "who is #1" ordering shared by the result card
+/// (`SimulationResultCard.Model`) and viewer-prediction scoring
+/// (`ViewerPredictionLogic`), introduced in #915 so the displayed leader and
+/// the scored leader can never diverge.
+///
+/// Highest value wins; ties break by name ascending, giving a stable
+/// run-to-run winner (a bare `.max` would pick a dictionary-order-dependent
+/// tie-winner that could disagree with the card).
+nonisolated public enum RankingOrder {
+  /// Whether `lhs` outranks `rhs`: higher value first, then name ascending as
+  /// the deterministic tiebreak. Usable directly as a `sorted(by:)` predicate.
+  public static func isOrderedBefore(
+    lhsName: String, lhsValue: Int, rhsName: String, rhsValue: Int
+  ) -> Bool {
+    lhsValue != rhsValue ? lhsValue > rhsValue : lhsName < rhsName
+  }
+
+  /// The single leader among `roster` by `values` (missing keys count as 0),
+  /// or `nil` when `roster` is empty.
+  public static func leader(
+    values: [String: Int], among roster: [String]
+  ) -> String? {
+    guard !roster.isEmpty else { return nil }
+    return roster.sorted {
+      isOrderedBefore(
+        lhsName: $0, lhsValue: values[$0] ?? 0,
+        rhsName: $1, rhsValue: values[$1] ?? 0)
+    }.first
+  }
+}

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -878,6 +878,16 @@
         }
       }
     },
+    "%lld in a row" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連続 %lld"
+          }
+        }
+      }
+    },
     "%lld minutes ago" : {
       "localizations" : {
         "ja" : {
@@ -2164,6 +2174,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "生成プロンプトをコピー"
+          }
+        }
+      }
+    },
+    "Correct!" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "的中！"
           }
         }
       }
@@ -3830,6 +3850,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "メモリ不足のため一時停止しました。再開して続行できます。"
+          }
+        }
+      }
+    },
+    "Missed" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外れ"
           }
         }
       }

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -1773,6 +1773,16 @@
         }
       }
     },
+    "Before the votes are revealed, guess the outcome and track your streak. You can always skip." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "投票結果が公開される前に結果を予想して、連続的中を記録しよう。いつでもスキップできます。"
+          }
+        }
+      }
+    },
     "Branch on state (code, then/else sub-phases)" : {
       "localizations" : {
         "ja" : {
@@ -4641,6 +4651,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ダウンロード中はアプリを開いたままにしてください。"
+          }
+        }
+      }
+    },
+    "Predict the outcome" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "結果を予想する"
           }
         }
       }

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -943,6 +943,16 @@
         }
       }
     },
+    "%lld s left" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "残り %lld 秒"
+          }
+        }
+      }
+    },
     "%lld steps" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -3766,6 +3776,16 @@
         }
       }
     },
+    "Make your prediction" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "予想してみよう"
+          }
+        }
+      }
+    },
     "Manage in Settings" : {
       "localizations" : {
         "en" : {
@@ -5615,6 +5635,16 @@
         }
       }
     },
+    "Skip" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スキップ"
+          }
+        }
+      }
+    },
     "Social Psychology" : {
       "localizations" : {
         "ja" : {
@@ -6433,6 +6463,26 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "進行の流れ"
+          }
+        }
+      }
+    },
+    "Who do you think the wolf is?" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウルフは誰だと思う？"
+          }
+        }
+      }
+    },
+    "Who do you think will get the most votes?" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "誰が一番票を集めると思う？"
           }
         }
       }

--- a/Pastura/Pastura/Views/Components/PredictionOutcomeBadge.swift
+++ b/Pastura/Pastura/Views/Components/PredictionOutcomeBadge.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+/// Compact hit/miss badge for a viewer prediction (#915).
+///
+/// Shows the consecutive-hit streak when `streak >= 2` on a hit — the immediate
+/// end-of-run card passes it (the reward moment); the Past Results list omits it
+/// (`streak == nil`) for a quieter row.
+struct PredictionOutcomeBadge: View {
+  let isHit: Bool
+  var streak: Int?
+
+  var body: some View {
+    HStack(spacing: 5) {
+      Image(systemName: isHit ? "target" : "xmark")
+        .font(.caption2.weight(.bold))
+      Text(isHit ? String(localized: "Correct!") : String(localized: "Missed"))
+        .font(.caption.weight(.semibold))
+      if isHit, let streak, streak >= 2 {
+        Text(String(format: String(localized: "%lld in a row"), streak))
+          .font(.caption.weight(.medium))
+          .foregroundStyle(Color.muted)
+      }
+    }
+    .foregroundStyle(isHit ? Color.mossDark : Color.muted)
+    .padding(.horizontal, 10)
+    .padding(.vertical, 5)
+    .background(
+      Capsule().fill(isHit ? Color.mossSoft : Color.bubbleBackground)
+    )
+    .accessibilityElement(children: .combine)
+  }
+}

--- a/Pastura/Pastura/Views/Components/SimulationResultCard+Model.swift
+++ b/Pastura/Pastura/Views/Components/SimulationResultCard+Model.swift
@@ -111,10 +111,11 @@ extension SimulationResultCard {
       roster: [String], value: (String) -> Int, eliminated: [String: Bool],
       valueKind: ValueKind
     ) -> [Entry] {
+      // Shared with `ViewerPredictionLogic.topVote` via `RankingOrder` so the
+      // card's displayed #1 and the prediction's scored #1 never diverge (#915).
       let sorted = roster.sorted { lhs, rhs in
-        let lhsValue = value(lhs)
-        let rhsValue = value(rhs)
-        return lhsValue != rhsValue ? lhsValue > rhsValue : lhs < rhs
+        RankingOrder.isOrderedBefore(
+          lhsName: lhs, lhsValue: value(lhs), rhsName: rhs, rhsValue: value(rhs))
       }
       return sorted.enumerated().map { index, name in
         Entry(

--- a/Pastura/Pastura/Views/Results/ResultsView.swift
+++ b/Pastura/Pastura/Views/Results/ResultsView.swift
@@ -91,7 +91,10 @@ struct ResultsView: View {
   /// Batch-fetches prediction outcomes for the rendered rows off-main. Absent
   /// rows simply have no badge; a fetch failure leaves the map unchanged.
   private func refreshPredictions(ids: [String]) async {
-    guard !ids.isEmpty else { return }
+    guard !ids.isEmpty else {
+      predictionsByRun = [:]
+      return
+    }
     let repository = dependencies.predictionRepository
     let fetched = try? await Task.detached {
       try repository.fetchBySimulationIds(ids)

--- a/Pastura/Pastura/Views/Results/ResultsView.swift
+++ b/Pastura/Pastura/Views/Results/ResultsView.swift
@@ -17,9 +17,14 @@ struct ResultsView: View {
   /// ``AggregateSearchable``). Pushed into SQL via `applyFilter` so it reaches
   /// runs not yet on a loaded page.
   @State private var searchText = ""
+  /// Viewer-prediction outcomes for the currently-rendered rows, keyed by run
+  /// id (#915). Refetched whenever the visible run-id set changes (new page /
+  /// filter), so it always matches what's on screen.
+  @State private var predictionsByRun: [String: PredictionRecord] = [:]
 
   var body: some View {
-    Group {
+    let runIds = viewModel?.sections.flatMap { $0.rows.map(\.id) } ?? []
+    return Group {
       if let viewModel {
         if viewModel.isLoading {
           ProgressView(String(localized: "Loading..."))
@@ -79,6 +84,19 @@ struct ResultsView: View {
       guard didInitialLoad, let viewModel else { return }
       Task { await viewModel.refreshOnReappear(scope: scope) }
     }
+    // Reload prediction badges whenever the visible run set changes.
+    .task(id: runIds) { await refreshPredictions(ids: runIds) }
+  }
+
+  /// Batch-fetches prediction outcomes for the rendered rows off-main. Absent
+  /// rows simply have no badge; a fetch failure leaves the map unchanged.
+  private func refreshPredictions(ids: [String]) async {
+    guard !ids.isEmpty else { return }
+    let repository = dependencies.predictionRepository
+    let fetched = try? await Task.detached {
+      try repository.fetchBySimulationIds(ids)
+    }.value
+    if let fetched { predictionsByRun = fetched }
   }
 
   private func resultsList(viewModel: ResultsViewModel) -> some View {
@@ -217,14 +235,21 @@ struct ResultsView: View {
           .truncationMode(.tail)
       }
 
-      // Relative timestamp (X / Instagram-style), at the bottom. Computed in the
-      // View off the live clock — formatting stays in the Views layer.
-      Text(
-        ResultsRowFormat.relativeTimestamp(
-          for: item.createdAt, now: Date(), calendar: .current)
-      )
-      .font(.caption)
-      .foregroundStyle(Color.muted)
+      // Relative timestamp (X / Instagram-style) with a trailing viewer-
+      // prediction badge (#915) when this run had an answered prediction.
+      // Computed in the View off the live clock — formatting stays in Views.
+      HStack {
+        Text(
+          ResultsRowFormat.relativeTimestamp(
+            for: item.createdAt, now: Date(), calendar: .current)
+        )
+        .font(.caption)
+        .foregroundStyle(Color.muted)
+        if let prediction = predictionsByRun[item.id] {
+          Spacer()
+          PredictionOutcomeBadge(isHit: prediction.isHit)
+        }
+      }
     }
     // Fill the row width so every row's title/meta left-aligns at the same x.
     // Without this the VStack sizes to its content and the enclosing

--- a/Pastura/Pastura/Views/Settings/SettingsView.swift
+++ b/Pastura/Pastura/Views/Settings/SettingsView.swift
@@ -45,6 +45,11 @@ struct SettingsView: View {
   /// flag stays the single source of truth.
   @State private var keepRunningOnLeave = FeatureFlags.keepRunningOnLeaveEnabled
 
+  /// Opt-out: show the viewer-prediction sheet before the first vote reveal
+  /// (#915). Mirrors the `FeatureFlags` value at init and persists every flip
+  /// via its setter, so the flag stays the single source of truth.
+  @State private var viewerPredictionEnabled = FeatureFlags.viewerPredictionEnabled
+
   /// Bound to `.reportSheet(isPresented:context:)` for the "Send a
   /// content report" row inside the Legal section. The sheet reuses
   /// `ReportSheet` with `context: .general` (Settings has no
@@ -180,6 +185,9 @@ struct SettingsView: View {
     .onChange(of: keepRunningOnLeave) { _, newValue in
       FeatureFlags.setKeepRunningOnLeave(newValue)
     }
+    .onChange(of: viewerPredictionEnabled) { _, newValue in
+      FeatureFlags.setViewerPredictionEnabled(newValue)
+    }
     .navigationTitle(String(localized: "Settings"))
     .navigationBarTitleDisplayMode(.inline)
     .reportSheet(isPresented: $isReportSheetPresented, context: .general)
@@ -299,8 +307,8 @@ struct SettingsView: View {
     #endif
   }
 
-  /// Opt-in toggle to keep a run alive (parked in memory) when leaving its
-  /// screen instead of pausing it (ADR-017 Phase B, #682). Label-closure form
+  /// Simulation-behaviour toggles: keep-running-on-leave (opt-in, ADR-017
+  /// Phase B, #682) and viewer prediction (opt-out, #915). Label-closure form
   /// per the i18n convenience-init convention (`.claude/rules/i18n.md`).
   private var simulationSection: some View {
     PasturaSection(String(localized: "Simulation"), style: .grouped) {
@@ -322,6 +330,25 @@ struct SettingsView: View {
       .padding(.horizontal, 17)
       .padding(.vertical, 13)
       .accessibilityIdentifier("settings.keepRunningOnLeaveToggle")
+
+      Toggle(isOn: $viewerPredictionEnabled) {
+        VStack(alignment: .leading, spacing: 3) {
+          Text(String(localized: "Predict the outcome"))
+            .foregroundStyle(Color.ink)
+          Text(
+            String(
+              localized:
+                "Before the votes are revealed, guess the outcome and track your streak. You can always skip."
+            )
+          )
+          .font(.caption)
+          .foregroundStyle(Color.muted)
+        }
+      }
+      .tint(Color.link)
+      .padding(.horizontal, 17)
+      .padding(.vertical, 13)
+      .accessibilityIdentifier("settings.viewerPredictionToggle")
     }
   }
 }

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -145,6 +145,22 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
     // `.simulation` and `.resumeSimulation` routes (both render SimulationView).
     // See ADR-017; opt-in cross-screen continuation is deferred to Phase B.
     .toolbar(.hidden, for: .tabBar)
+    .onAppear { viewModel?.setViewVisible(true) }
+    // Viewer-prediction sheet (#915). The binding's nil-set path (interactive
+    // dismiss, blocked below) routes to a skip; normal resolution is driven by
+    // the sheet's `onResolve`, which clears `predictionPrompt` in the VM.
+    .sheet(
+      item: Binding(
+        get: { viewModel?.predictionPrompt },
+        set: { if $0 == nil { viewModel?.resolvePrediction(.skipped) } })
+    ) { prompt in
+      ViewerPredictionSheet(
+        question: prompt.question,
+        candidates: prompt.candidates,
+        onResolve: { viewModel?.resolvePrediction($0) }
+      )
+      .presentationDetents([.medium, .large])
+    }
     .task {
       // Phase B (ADR-017): reconnect to a run the app-level session still owns
       // instead of starting a fresh one. Under "keep running" the run survives
@@ -187,6 +203,9 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
     // `.paused`). Ownership-guarded so a view that never owned the live run
     // doesn't tear one down. See `disappearAction(...)`.
     .onDisappear {
+      // Leaving the screen resolves any pending prediction sheet as a skip so
+      // it doesn't resurface stale on return (#915).
+      viewModel?.setViewVisible(false)
       let session = dependencies.simulationSession
       switch Self.disappearAction(
         leaveHandled: leaveHandled,
@@ -1220,6 +1239,7 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
       turnRepository: deps.turnRepository,
       codePhaseEventRepository: deps.codePhaseEventRepository,
       scenarioRepository: deps.scenarioRepository,
+      predictionRepository: deps.predictionRepository,
       backgroundManager: deps.backgroundManager,
       simulationActivityRegistry: deps.simulationActivityRegistry
     )

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -597,6 +597,10 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
               .transition(.opacity.combined(with: .move(edge: .bottom)))
             }
 
+            // Viewer-prediction reward (#915): hit/miss + streak, shown with the
+            // result card when the run had an answered prediction.
+            predictionOutcomeBadge(viewModel: viewModel)
+
             // Bottom sentinel: scrollTo target that stays below every other
             // section (log entries, thinking indicators). Scrolling here
             // reliably reveals whatever just appeared last — anchoring to
@@ -794,6 +798,18 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
       voteResults: viewModel.voteResults,
       eliminationVotes: viewModel.eliminationVotes,
       phases: scenario?.phases ?? [])
+  }
+
+  /// The viewer-prediction reward badge, shown with the result card once the
+  /// run completes and only when the run had an answered prediction (#915).
+  /// Extracted from the timeline body to keep its cyclomatic complexity in
+  /// budget.
+  @ViewBuilder
+  private func predictionOutcomeBadge(viewModel: SimulationViewModel) -> some View {
+    if resultCardVisible, let outcome = viewModel.predictionOutcome {
+      PredictionOutcomeBadge(isHit: outcome.isHit, streak: outcome.streak)
+        .transition(.opacity)
+    }
   }
 
   /// Whether any real score exists — gates the closing card's tap-to-scoreboard

--- a/Pastura/Pastura/Views/Simulation/ViewerPredictionSheet.swift
+++ b/Pastura/Pastura/Views/Simulation/ViewerPredictionSheet.swift
@@ -1,0 +1,131 @@
+import SwiftUI
+
+/// Layout / timing constants for ``ViewerPredictionSheet`` (#915).
+///
+/// Extracted so the code-review-gated countdown length has a change-detector
+/// unit test (`.claude/rules/view-testing.md`) — a failure means the value
+/// drifted, not that anything is broken.
+nonisolated enum ViewerPredictionSheetLayout {
+  /// Seconds before the sheet auto-skips. Kept short so it never stalls the
+  /// viewing rhythm the prediction interrupts.
+  static let countdownSeconds = 15
+}
+
+/// Modal shown before the first vote reveal, asking the viewer to predict the
+/// outcome (#915). Resolves exactly once with the picked agent or `.skipped`
+/// (explicit skip, or the countdown reaching zero). The ViewModel owns
+/// presentation and awaits the resolution to score + persist — see
+/// `SimulationViewModel`.
+///
+/// The countdown decrements a discrete per-second `Int` rather than driving a
+/// continuous `CAAnimation`, so it does not trip the XCUITest idle-stall trap
+/// (`.claude/rules/xcodebuild-cli.md`).
+struct ViewerPredictionSheet: View {
+  /// How the viewer resolved the prompt.
+  enum Resolution: Equatable {
+    case predicted(String)
+    case skipped
+  }
+
+  let question: ViewerPredictionLogic.Question
+  let candidates: [String]
+  let onResolve: (Resolution) -> Void
+
+  @State private var remaining = ViewerPredictionSheetLayout.countdownSeconds
+  @State private var didResolve = false
+
+  var body: some View {
+    VStack(spacing: 24) {
+      header
+      candidateList
+      skipButton
+    }
+    .padding(24)
+    .frame(maxWidth: .infinity)
+    .background(Color.page)
+    .task { await runCountdown() }
+    .interactiveDismissDisabled()
+  }
+
+  private var header: some View {
+    VStack(spacing: 8) {
+      Text(String(localized: "Make your prediction"))
+        .font(.subheadline.weight(.semibold))
+        .foregroundStyle(Color.muted)
+      Text(promptText)
+        .font(.title3.weight(.semibold))
+        .foregroundStyle(Color.ink)
+        .multilineTextAlignment(.center)
+      Text(String(format: String(localized: "%lld s left"), remaining))
+        .font(.caption.monospacedDigit())
+        .foregroundStyle(Color.muted)
+        .accessibilityIdentifier("prediction.countdown")
+    }
+  }
+
+  private var promptText: String {
+    switch question {
+    case .wolf:
+      return String(localized: "Who do you think the wolf is?")
+    case .topVote:
+      return String(localized: "Who do you think will get the most votes?")
+    }
+  }
+
+  private var candidateList: some View {
+    VStack(spacing: 10) {
+      ForEach(Array(candidates.enumerated()), id: \.element) { index, name in
+        Button {
+          resolve(.predicted(name))
+        } label: {
+          HStack(spacing: 12) {
+            SheepAvatar(character: .forAgent(name, position: index), size: 32)
+            Text(name)
+              .font(.body.weight(.medium))
+              .foregroundStyle(Color.ink)
+            Spacer()
+          }
+          .padding(.horizontal, 16)
+          .padding(.vertical, 12)
+          .frame(maxWidth: .infinity)
+          .background(
+            RoundedRectangle(cornerRadius: 14)
+              .fill(Color.bubbleBackground)
+              .overlay(
+                RoundedRectangle(cornerRadius: 14)
+                  .strokeBorder(Color.rule, lineWidth: 1))
+          )
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("prediction.candidate.\(name)")
+      }
+    }
+  }
+
+  private var skipButton: some View {
+    Button(String(localized: "Skip")) {
+      resolve(.skipped)
+    }
+    .font(.body.weight(.medium))
+    .foregroundStyle(Color.link)
+    .accessibilityIdentifier("prediction.skipButton")
+  }
+
+  /// Fires `onResolve` at most once — guards the tap-vs-timeout race.
+  private func resolve(_ resolution: Resolution) {
+    guard !didResolve else { return }
+    didResolve = true
+    onResolve(resolution)
+  }
+
+  /// Ticks the countdown once per second; auto-skips at zero. Cancelled with
+  /// the view (`.task`), so dismissing the sheet stops the timer cleanly.
+  private func runCountdown() async {
+    while remaining > 0 {
+      try? await Task.sleep(for: .seconds(1))
+      if didResolve || Task.isCancelled { return }
+      remaining -= 1
+    }
+    resolve(.skipped)
+  }
+}

--- a/Pastura/PasturaTests/App/FeatureFlagsTests.swift
+++ b/Pastura/PasturaTests/App/FeatureFlagsTests.swift
@@ -33,4 +33,29 @@ struct FeatureFlagsTests {
       FeatureFlags.keepRunningOnLeaveEnabled == false,
       "an explicit off is distinguished from unset and honoured")
   }
+
+  // MARK: - viewerPredictionEnabled (#915) — opt-out flag (default true)
+
+  private static let predictionKey = "viewerPredictionEnabled"
+
+  @Test func viewerPredictionDefaultsToTrueWhenUnset() {
+    UserDefaults.standard.removeObject(forKey: Self.predictionKey)
+    defer { UserDefaults.standard.removeObject(forKey: Self.predictionKey) }
+
+    #expect(
+      FeatureFlags.viewerPredictionEnabled == true,
+      "opt-out flag is on until the user disables it")
+  }
+
+  @Test func viewerPredictionReflectsPersistedValue() {
+    defer { UserDefaults.standard.removeObject(forKey: Self.predictionKey) }
+
+    FeatureFlags.setViewerPredictionEnabled(false)
+    #expect(
+      FeatureFlags.viewerPredictionEnabled == false,
+      "an explicit off is distinguished from the on-by-default and honoured")
+
+    FeatureFlags.setViewerPredictionEnabled(true)
+    #expect(FeatureFlags.viewerPredictionEnabled == true)
+  }
 }

--- a/Pastura/PasturaTests/App/SimulationViewModelPredictionTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelPredictionTests.swift
@@ -89,6 +89,9 @@ struct SimulationViewModelPredictionTests {
     #expect(record?.predictedAgent == "Eve")
     #expect(record?.actualAgent == "Eve")
     #expect(record?.questionKind == "wolf")
+    // The end-of-run reward surface (#915) reflects the same result + streak.
+    #expect(env.sut.predictionOutcome?.isHit == true)
+    #expect(env.sut.predictionOutcome?.streak == 1)
   }
 
   @Test func wolfWrongGuessPersistsMiss() async throws {
@@ -106,6 +109,7 @@ struct SimulationViewModelPredictionTests {
     #expect(record?.isHit == false)
     #expect(record?.predictedAgent == "Alice")
     #expect(record?.actualAgent == "Eve")
+    #expect(env.sut.predictionOutcome?.isHit == false)
   }
 
   @Test func topVoteScoresAgainstTallyLeader() async throws {
@@ -137,6 +141,7 @@ struct SimulationViewModelPredictionTests {
     await resolver
 
     #expect(try env.repo.fetchBySimulationId("sim1") == nil)
+    #expect(env.sut.predictionOutcome == nil)
   }
 
   @Test func latchPreventsSecondAsk() async throws {

--- a/Pastura/PasturaTests/App/SimulationViewModelPredictionTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelPredictionTests.swift
@@ -9,6 +9,10 @@ import Testing
 /// scoring, and persistence. The pure decision logic is covered separately in
 /// `ViewerPredictionLogicTests`; these tests pin the VM wiring around it.
 ///
+/// The prediction is presented at the first `.phaseStarted(.vote)` (before any
+/// vote is shown, so the outcome isn't spoiled) and scored at the subsequent
+/// `.voteResults`, so each test drives those two events in order.
+///
 /// Serialized + `@MainActor`: the tests toggle the process-global
 /// `viewerPredictionEnabled` default and exercise MainActor VM state. Each
 /// test removes the key so the suite leaves no residue.
@@ -60,12 +64,35 @@ struct SimulationViewModelPredictionTests {
   }
 
   /// Resolves the sheet once it appears — run concurrently with the awaited
-  /// interception.
+  /// vote-phase-start interception.
   private func autoResolve(
     _ sut: SimulationViewModel, with resolution: ViewerPredictionSheet.Resolution
   ) async {
     while sut.predictionPrompt == nil { await Task.yield() }
     sut.resolvePrediction(resolution)
+  }
+
+  private let votePhaseStart = SimulationEvent.phaseStarted(
+    phaseType: .vote, phasePath: [])
+
+  /// Drives the vote-phase-start prompt (auto-resolving with `resolution` if the
+  /// sheet is expected to appear), then delivers the tally to score it.
+  private func runPrediction(
+    _ env: Env,
+    resolve resolution: ViewerPredictionSheet.Resolution?,
+    tallies: [String: Int]
+  ) async {
+    if let resolution {
+      async let resolver: Void = autoResolve(env.sut, with: resolution)
+      await env.sut.handleViewerPredictionEvent(
+        event: votePhaseStart, scenario: env.scenario)
+      await resolver
+    } else {
+      await env.sut.handleViewerPredictionEvent(
+        event: votePhaseStart, scenario: env.scenario)
+    }
+    await env.sut.handleViewerPredictionEvent(
+      event: .voteResults(votes: [:], tallies: tallies), scenario: env.scenario)
   }
 
   private var wolfPhases: [Phase] {
@@ -79,10 +106,7 @@ struct SimulationViewModelPredictionTests {
     let env = try makeEnv(phases: wolfPhases)
     feedWolfAssignments(env.sut, scenario: env.scenario)
 
-    async let resolver: Void = autoResolve(env.sut, with: .predicted("Eve"))
-    await env.sut.interceptFirstVoteIfNeeded(
-      event: .voteResults(votes: [:], tallies: [:]), scenario: env.scenario)
-    await resolver
+    await runPrediction(env, resolve: .predicted("Eve"), tallies: [:])
 
     let record = try env.repo.fetchBySimulationId("sim1")
     #expect(record?.isHit == true)
@@ -100,10 +124,7 @@ struct SimulationViewModelPredictionTests {
     let env = try makeEnv(phases: wolfPhases)
     feedWolfAssignments(env.sut, scenario: env.scenario)
 
-    async let resolver: Void = autoResolve(env.sut, with: .predicted("Alice"))
-    await env.sut.interceptFirstVoteIfNeeded(
-      event: .voteResults(votes: [:], tallies: [:]), scenario: env.scenario)
-    await resolver
+    await runPrediction(env, resolve: .predicted("Alice"), tallies: [:])
 
     let record = try env.repo.fetchBySimulationId("sim1")
     #expect(record?.isHit == false)
@@ -117,11 +138,7 @@ struct SimulationViewModelPredictionTests {
     defer { UserDefaults.standard.removeObject(forKey: Self.flagKey) }
     let env = try makeEnv(phases: votePhases)
 
-    async let resolver: Void = autoResolve(env.sut, with: .predicted("Bob"))
-    await env.sut.interceptFirstVoteIfNeeded(
-      event: .voteResults(votes: [:], tallies: ["Bob": 3, "Alice": 1]),
-      scenario: env.scenario)
-    await resolver
+    await runPrediction(env, resolve: .predicted("Bob"), tallies: ["Bob": 3, "Alice": 1])
 
     let record = try env.repo.fetchBySimulationId("sim1")
     #expect(record?.isHit == true)
@@ -135,10 +152,7 @@ struct SimulationViewModelPredictionTests {
     let env = try makeEnv(phases: wolfPhases)
     feedWolfAssignments(env.sut, scenario: env.scenario)
 
-    async let resolver: Void = autoResolve(env.sut, with: .skipped)
-    await env.sut.interceptFirstVoteIfNeeded(
-      event: .voteResults(votes: [:], tallies: [:]), scenario: env.scenario)
-    await resolver
+    await runPrediction(env, resolve: .skipped, tallies: [:])
 
     #expect(try env.repo.fetchBySimulationId("sim1") == nil)
     #expect(env.sut.predictionOutcome == nil)
@@ -150,14 +164,11 @@ struct SimulationViewModelPredictionTests {
     let env = try makeEnv(phases: wolfPhases)
     feedWolfAssignments(env.sut, scenario: env.scenario)
 
-    async let resolver: Void = autoResolve(env.sut, with: .predicted("Eve"))
-    await env.sut.interceptFirstVoteIfNeeded(
-      event: .voteResults(votes: [:], tallies: [:]), scenario: env.scenario)
-    await resolver
+    await runPrediction(env, resolve: .predicted("Eve"), tallies: [:])
 
-    // A second vote in the same run must not re-arm the sheet.
-    await env.sut.interceptFirstVoteIfNeeded(
-      event: .voteResults(votes: [:], tallies: ["Bob": 5]), scenario: env.scenario)
+    // A second vote phase in the same run must not re-arm the sheet.
+    await env.sut.handleViewerPredictionEvent(
+      event: votePhaseStart, scenario: env.scenario)
     #expect(env.sut.predictionPrompt == nil)
     // Still exactly the first (wolf) record — the second vote wrote nothing.
     #expect(try env.repo.fetchBySimulationId("sim1")?.questionKind == "wolf")
@@ -169,8 +180,7 @@ struct SimulationViewModelPredictionTests {
     let env = try makeEnv(phases: wolfPhases)
     feedWolfAssignments(env.sut, scenario: env.scenario)
 
-    await env.sut.interceptFirstVoteIfNeeded(
-      event: .voteResults(votes: [:], tallies: [:]), scenario: env.scenario)
+    await runPrediction(env, resolve: nil, tallies: [:])
 
     #expect(env.sut.predictionPrompt == nil)
     #expect(try env.repo.fetchBySimulationId("sim1") == nil)
@@ -182,8 +192,8 @@ struct SimulationViewModelPredictionTests {
     let env = try makeEnv(predictionRepo: false, phases: wolfPhases)
     feedWolfAssignments(env.sut, scenario: env.scenario)
 
-    await env.sut.interceptFirstVoteIfNeeded(
-      event: .voteResults(votes: [:], tallies: [:]), scenario: env.scenario)
+    await env.sut.handleViewerPredictionEvent(
+      event: votePhaseStart, scenario: env.scenario)
 
     #expect(env.sut.predictionPrompt == nil)
   }
@@ -195,30 +205,29 @@ struct SimulationViewModelPredictionTests {
     feedWolfAssignments(env.sut, scenario: env.scenario)
     env.sut.setViewVisible(false)
 
-    await env.sut.interceptFirstVoteIfNeeded(
-      event: .voteResults(votes: [:], tallies: [:]), scenario: env.scenario)
+    await runPrediction(env, resolve: nil, tallies: [:])
 
     #expect(env.sut.predictionPrompt == nil)
     #expect(try env.repo.fetchBySimulationId("sim1") == nil)
   }
 
   @Test func firstVoteWhileNotVisibleConsumesTheOpportunity() async throws {
-    // The first vote latches even when not presentable (parked), so a later
-    // visible vote in the same run is NOT asked — strict "first vote" contract.
-    // If the latch were set AFTER the visibility check, the second vote below
-    // would present the sheet and this test would fail.
+    // The first vote phase latches even when not presentable (parked), so a
+    // later visible vote in the same run is NOT asked — strict "first vote"
+    // contract. If the latch were set AFTER the visibility check, the second
+    // vote-start below would present the sheet and this test would fail.
     FeatureFlags.setViewerPredictionEnabled(true)
     defer { UserDefaults.standard.removeObject(forKey: Self.flagKey) }
     let env = try makeEnv(phases: wolfPhases)
     feedWolfAssignments(env.sut, scenario: env.scenario)
 
     env.sut.setViewVisible(false)
-    await env.sut.interceptFirstVoteIfNeeded(
-      event: .voteResults(votes: [:], tallies: [:]), scenario: env.scenario)
+    await env.sut.handleViewerPredictionEvent(
+      event: votePhaseStart, scenario: env.scenario)
 
     env.sut.setViewVisible(true)
-    await env.sut.interceptFirstVoteIfNeeded(
-      event: .voteResults(votes: [:], tallies: ["Bob": 3]), scenario: env.scenario)
+    await env.sut.handleViewerPredictionEvent(
+      event: votePhaseStart, scenario: env.scenario)
 
     #expect(env.sut.predictionPrompt == nil)
     #expect(try env.repo.fetchBySimulationId("sim1") == nil)

--- a/Pastura/PasturaTests/App/SimulationViewModelPredictionTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelPredictionTests.swift
@@ -1,0 +1,199 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Pastura
+
+/// Integration coverage for the viewer-prediction interception in
+/// `SimulationViewModel` (#915): gating, once-per-run latch, ground-truth
+/// scoring, and persistence. The pure decision logic is covered separately in
+/// `ViewerPredictionLogicTests`; these tests pin the VM wiring around it.
+///
+/// Serialized + `@MainActor`: the tests toggle the process-global
+/// `viewerPredictionEnabled` default and exercise MainActor VM state. Each
+/// test removes the key so the suite leaves no residue.
+@Suite(.serialized, .timeLimit(.minutes(1))) @MainActor
+struct SimulationViewModelPredictionTests {
+  private static let flagKey = "viewerPredictionEnabled"
+
+  private struct Env {
+    let sut: SimulationViewModel
+    let repo: GRDBPredictionRepository
+    let scenario: Scenario
+  }
+
+  private func makeEnv(
+    predictionRepo: Bool = true,
+    phases: [Phase]
+  ) throws -> Env {
+    let db = try DatabaseManager.inMemory()
+    let writer = db.dbWriter
+    let scenarioRepo = GRDBScenarioRepository(dbWriter: writer)
+    let simRepo = GRDBSimulationRepository(dbWriter: writer)
+    try scenarioRepo.save(
+      ScenarioRecord(
+        id: "s1", name: "WW", yamlDefinition: "y",
+        isPreset: false, createdAt: Date(), updatedAt: Date()))
+    try simRepo.save(
+      SimulationRecord(
+        id: "sim1", scenarioId: "s1", status: "running",
+        currentRound: 1, currentPhaseIndex: 0, stateJSON: "{}", configJSON: nil,
+        createdAt: Date(), updatedAt: Date()))
+    let repo = GRDBPredictionRepository(dbWriter: writer)
+    let sut = SimulationViewModel(
+      simulationRepository: simRepo,
+      turnRepository: GRDBTurnRepository(dbWriter: writer),
+      codePhaseEventRepository: GRDBCodePhaseEventRepository(dbWriter: writer),
+      predictionRepository: predictionRepo ? repo : nil)
+    let scenario = makeTestScenario(
+      agentNames: ["Alice", "Bob", "Carol", "Dave", "Eve"], rounds: 1, phases: phases)
+    sut.beginPersistenceForTest(simulationId: "sim1")
+    return Env(sut: sut, repo: repo, scenario: scenario)
+  }
+
+  /// Feeds word-wolf assignments so the wolf ground-truth resolves to "Eve".
+  private func feedWolfAssignments(_ sut: SimulationViewModel, scenario: Scenario) {
+    for agent in ["Alice", "Bob", "Carol", "Dave"] {
+      sut.handleEvent(.assignment(agent: agent, value: "apple"), scenario: scenario)
+    }
+    sut.handleEvent(.assignment(agent: "Eve", value: "orange"), scenario: scenario)
+  }
+
+  /// Resolves the sheet once it appears — run concurrently with the awaited
+  /// interception.
+  private func autoResolve(
+    _ sut: SimulationViewModel, with resolution: ViewerPredictionSheet.Resolution
+  ) async {
+    while sut.predictionPrompt == nil { await Task.yield() }
+    sut.resolvePrediction(resolution)
+  }
+
+  private var wolfPhases: [Phase] {
+    [Phase(type: .assign, target: .randomOne), Phase(type: .vote)]
+  }
+  private var votePhases: [Phase] { [Phase(type: .vote)] }
+
+  @Test func wolfCorrectGuessPersistsHit() async throws {
+    FeatureFlags.setViewerPredictionEnabled(true)
+    defer { UserDefaults.standard.removeObject(forKey: Self.flagKey) }
+    let env = try makeEnv(phases: wolfPhases)
+    feedWolfAssignments(env.sut, scenario: env.scenario)
+
+    async let resolver: Void = autoResolve(env.sut, with: .predicted("Eve"))
+    await env.sut.interceptFirstVoteIfNeeded(
+      event: .voteResults(votes: [:], tallies: [:]), scenario: env.scenario)
+    await resolver
+
+    let record = try env.repo.fetchBySimulationId("sim1")
+    #expect(record?.isHit == true)
+    #expect(record?.predictedAgent == "Eve")
+    #expect(record?.actualAgent == "Eve")
+    #expect(record?.questionKind == "wolf")
+  }
+
+  @Test func wolfWrongGuessPersistsMiss() async throws {
+    FeatureFlags.setViewerPredictionEnabled(true)
+    defer { UserDefaults.standard.removeObject(forKey: Self.flagKey) }
+    let env = try makeEnv(phases: wolfPhases)
+    feedWolfAssignments(env.sut, scenario: env.scenario)
+
+    async let resolver: Void = autoResolve(env.sut, with: .predicted("Alice"))
+    await env.sut.interceptFirstVoteIfNeeded(
+      event: .voteResults(votes: [:], tallies: [:]), scenario: env.scenario)
+    await resolver
+
+    let record = try env.repo.fetchBySimulationId("sim1")
+    #expect(record?.isHit == false)
+    #expect(record?.predictedAgent == "Alice")
+    #expect(record?.actualAgent == "Eve")
+  }
+
+  @Test func topVoteScoresAgainstTallyLeader() async throws {
+    FeatureFlags.setViewerPredictionEnabled(true)
+    defer { UserDefaults.standard.removeObject(forKey: Self.flagKey) }
+    let env = try makeEnv(phases: votePhases)
+
+    async let resolver: Void = autoResolve(env.sut, with: .predicted("Bob"))
+    await env.sut.interceptFirstVoteIfNeeded(
+      event: .voteResults(votes: [:], tallies: ["Bob": 3, "Alice": 1]),
+      scenario: env.scenario)
+    await resolver
+
+    let record = try env.repo.fetchBySimulationId("sim1")
+    #expect(record?.isHit == true)
+    #expect(record?.questionKind == "topVote")
+    #expect(record?.actualAgent == "Bob")
+  }
+
+  @Test func skipWritesNoRecord() async throws {
+    FeatureFlags.setViewerPredictionEnabled(true)
+    defer { UserDefaults.standard.removeObject(forKey: Self.flagKey) }
+    let env = try makeEnv(phases: wolfPhases)
+    feedWolfAssignments(env.sut, scenario: env.scenario)
+
+    async let resolver: Void = autoResolve(env.sut, with: .skipped)
+    await env.sut.interceptFirstVoteIfNeeded(
+      event: .voteResults(votes: [:], tallies: [:]), scenario: env.scenario)
+    await resolver
+
+    #expect(try env.repo.fetchBySimulationId("sim1") == nil)
+  }
+
+  @Test func latchPreventsSecondAsk() async throws {
+    FeatureFlags.setViewerPredictionEnabled(true)
+    defer { UserDefaults.standard.removeObject(forKey: Self.flagKey) }
+    let env = try makeEnv(phases: wolfPhases)
+    feedWolfAssignments(env.sut, scenario: env.scenario)
+
+    async let resolver: Void = autoResolve(env.sut, with: .predicted("Eve"))
+    await env.sut.interceptFirstVoteIfNeeded(
+      event: .voteResults(votes: [:], tallies: [:]), scenario: env.scenario)
+    await resolver
+
+    // A second vote in the same run must not re-arm the sheet.
+    await env.sut.interceptFirstVoteIfNeeded(
+      event: .voteResults(votes: [:], tallies: ["Bob": 5]), scenario: env.scenario)
+    #expect(env.sut.predictionPrompt == nil)
+    // Still exactly the first (wolf) record — the second vote wrote nothing.
+    #expect(try env.repo.fetchBySimulationId("sim1")?.questionKind == "wolf")
+  }
+
+  @Test func disabledFlagSkipsInterception() async throws {
+    FeatureFlags.setViewerPredictionEnabled(false)
+    defer { UserDefaults.standard.removeObject(forKey: Self.flagKey) }
+    let env = try makeEnv(phases: wolfPhases)
+    feedWolfAssignments(env.sut, scenario: env.scenario)
+
+    await env.sut.interceptFirstVoteIfNeeded(
+      event: .voteResults(votes: [:], tallies: [:]), scenario: env.scenario)
+
+    #expect(env.sut.predictionPrompt == nil)
+    #expect(try env.repo.fetchBySimulationId("sim1") == nil)
+  }
+
+  @Test func nilRepositorySkipsInterception() async throws {
+    FeatureFlags.setViewerPredictionEnabled(true)
+    defer { UserDefaults.standard.removeObject(forKey: Self.flagKey) }
+    let env = try makeEnv(predictionRepo: false, phases: wolfPhases)
+    feedWolfAssignments(env.sut, scenario: env.scenario)
+
+    await env.sut.interceptFirstVoteIfNeeded(
+      event: .voteResults(votes: [:], tallies: [:]), scenario: env.scenario)
+
+    #expect(env.sut.predictionPrompt == nil)
+  }
+
+  @Test func notVisibleSkipsInterception() async throws {
+    FeatureFlags.setViewerPredictionEnabled(true)
+    defer { UserDefaults.standard.removeObject(forKey: Self.flagKey) }
+    let env = try makeEnv(phases: wolfPhases)
+    feedWolfAssignments(env.sut, scenario: env.scenario)
+    env.sut.setViewVisible(false)
+
+    await env.sut.interceptFirstVoteIfNeeded(
+      event: .voteResults(votes: [:], tallies: [:]), scenario: env.scenario)
+
+    #expect(env.sut.predictionPrompt == nil)
+    #expect(try env.repo.fetchBySimulationId("sim1") == nil)
+  }
+}

--- a/Pastura/PasturaTests/App/SimulationViewModelPredictionTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelPredictionTests.swift
@@ -201,4 +201,26 @@ struct SimulationViewModelPredictionTests {
     #expect(env.sut.predictionPrompt == nil)
     #expect(try env.repo.fetchBySimulationId("sim1") == nil)
   }
+
+  @Test func firstVoteWhileNotVisibleConsumesTheOpportunity() async throws {
+    // The first vote latches even when not presentable (parked), so a later
+    // visible vote in the same run is NOT asked — strict "first vote" contract.
+    // If the latch were set AFTER the visibility check, the second vote below
+    // would present the sheet and this test would fail.
+    FeatureFlags.setViewerPredictionEnabled(true)
+    defer { UserDefaults.standard.removeObject(forKey: Self.flagKey) }
+    let env = try makeEnv(phases: wolfPhases)
+    feedWolfAssignments(env.sut, scenario: env.scenario)
+
+    env.sut.setViewVisible(false)
+    await env.sut.interceptFirstVoteIfNeeded(
+      event: .voteResults(votes: [:], tallies: [:]), scenario: env.scenario)
+
+    env.sut.setViewVisible(true)
+    await env.sut.interceptFirstVoteIfNeeded(
+      event: .voteResults(votes: [:], tallies: ["Bob": 3]), scenario: env.scenario)
+
+    #expect(env.sut.predictionPrompt == nil)
+    #expect(try env.repo.fetchBySimulationId("sim1") == nil)
+  }
 }

--- a/Pastura/PasturaTests/App/ViewerPredictionLogicTests.swift
+++ b/Pastura/PasturaTests/App/ViewerPredictionLogicTests.swift
@@ -1,0 +1,143 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+/// Unit coverage for the pure viewer-prediction decision logic (#915).
+///
+/// Marked `@MainActor` per `.claude/rules/swift-isolation.md` Pattern 5: the
+/// `Question` enum's auto-synthesized `Equatable` conformance lookup is
+/// MainActor-isolated even though its witnesses are nonisolated, so a bare
+/// nonisolated `#expect(x == .wolf)` would not compile.
+@Suite(.timeLimit(.minutes(1)))
+@MainActor
+struct ViewerPredictionLogicTests {
+
+  // MARK: question(for:)
+
+  @Test func questionIsWolfWhenRandomOneAssignPresent() {
+    let phases = [
+      Phase(type: .assign, target: .randomOne),
+      Phase(type: .vote)
+    ]
+    #expect(ViewerPredictionLogic.question(for: phases) == .wolf)
+  }
+
+  @Test func questionIsTopVoteWhenVoteButNoRandomOneAssign() {
+    let phases = [
+      Phase(type: .assign, target: .all),
+      Phase(type: .vote)
+    ]
+    #expect(ViewerPredictionLogic.question(for: phases) == .topVote)
+  }
+
+  @Test func questionIsNilWhenNoVoteAndNoRandomOneAssign() {
+    let phases = [
+      Phase(type: .speakAll),
+      Phase(type: .choose),
+      Phase(type: .scoreCalc)
+    ]
+    #expect(ViewerPredictionLogic.question(for: phases) == nil)
+  }
+
+  @Test func questionSeesVoteNestedInConditional() {
+    let phases = [
+      Phase(type: .speakAll),
+      Phase(type: .conditional, thenPhases: [Phase(type: .vote)])
+    ]
+    #expect(ViewerPredictionLogic.question(for: phases) == .topVote)
+  }
+
+  @Test func bundledPresetsClassifyAsExpected() throws {
+    let expected: [String: ViewerPredictionLogic.Question?] = [
+      "word_wolf": .wolf,
+      "bokete": .topVote,
+      "prisoners_dilemma": .none
+    ]
+    let bundle = Bundle(for: ViewerPredictionLogicTestsAnchor.self)
+    let loader = ScenarioLoader()
+
+    for (fileName, want) in expected {
+      let url = try #require(
+        bundle.url(forResource: fileName, withExtension: "yaml")
+          ?? Bundle.main.url(forResource: fileName, withExtension: "yaml"),
+        "preset \(fileName).yaml not found in test or app bundle")
+      let scenario = try loader.load(yaml: try String(contentsOf: url, encoding: .utf8))
+      #expect(
+        ViewerPredictionLogic.question(for: scenario.phases) == want,
+        "\(fileName) classified unexpectedly")
+    }
+  }
+
+  // MARK: wolf(from:)
+
+  @Test func wolfIsTheSoleMinorityHolder() {
+    let assignments = [
+      "Alice": "apple", "Bob": "apple", "Carol": "apple",
+      "Dave": "apple", "Eve": "orange"
+    ]
+    #expect(ViewerPredictionLogic.wolf(from: assignments) == "Eve")
+  }
+
+  @Test func wolfIsNilForTwoAgentEvenSplit() {
+    let assignments = ["Alice": "apple", "Bob": "orange"]
+    #expect(ViewerPredictionLogic.wolf(from: assignments) == nil)
+  }
+
+  @Test func wolfIsNilWhenTwoValuesTieForRarest() {
+    // apple×2, orange×1, banana×1 — two values share the min frequency.
+    let assignments = [
+      "Alice": "apple", "Bob": "apple", "Carol": "orange", "Dave": "banana"
+    ]
+    #expect(ViewerPredictionLogic.wolf(from: assignments) == nil)
+  }
+
+  @Test func wolfIsNilWhenRarestValueSharedByMultipleAgents() {
+    // orange×2 is the minority, but two agents hold it — no single wolf.
+    let assignments = [
+      "Alice": "apple", "Bob": "apple", "Carol": "apple",
+      "Dave": "orange", "Eve": "orange"
+    ]
+    #expect(ViewerPredictionLogic.wolf(from: assignments) == nil)
+  }
+
+  @Test func wolfIsNilForEmptyAssignments() {
+    #expect(ViewerPredictionLogic.wolf(from: [:]) == nil)
+  }
+
+  // MARK: topVote(tallies:roster:)
+
+  @Test func topVoteIsTheHighestTally() {
+    let tallies = ["Alice": 1, "Bob": 3, "Carol": 2]
+    let roster = ["Alice", "Bob", "Carol"]
+    #expect(ViewerPredictionLogic.topVote(tallies: tallies, roster: roster) == "Bob")
+  }
+
+  @Test func topVoteBreaksTiesByNameAscending() {
+    // Bob and Carol tie at 3 → name-ascending picks Bob, matching the card.
+    let tallies = ["Alice": 1, "Bob": 3, "Carol": 3]
+    let roster = ["Alice", "Bob", "Carol"]
+    #expect(ViewerPredictionLogic.topVote(tallies: tallies, roster: roster) == "Bob")
+  }
+
+  @Test func topVoteTreatsMissingTallyAsZero() {
+    let tallies = ["Bob": 2]
+    let roster = ["Alice", "Bob", "Carol"]
+    #expect(ViewerPredictionLogic.topVote(tallies: tallies, roster: roster) == "Bob")
+  }
+
+  @Test func topVoteIsNilForEmptyRoster() {
+    #expect(ViewerPredictionLogic.topVote(tallies: ["Bob": 2], roster: []) == nil)
+  }
+
+  // MARK: isHit
+
+  @Test func isHitComparesPredictedAndActual() {
+    #expect(ViewerPredictionLogic.isHit(predicted: "Eve", actual: "Eve"))
+    #expect(!ViewerPredictionLogic.isHit(predicted: "Eve", actual: "Bob"))
+  }
+}
+
+/// Class anchor for `Bundle(for:)` lookup against the test target — preset
+/// YAMLs live in the app bundle, not the simulator UI runner's `Bundle.main`.
+private final class ViewerPredictionLogicTestsAnchor {}

--- a/Pastura/PasturaTests/Data/PredictionRepositoryTests.swift
+++ b/Pastura/PasturaTests/Data/PredictionRepositoryTests.swift
@@ -1,0 +1,152 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Pastura
+
+@Suite(.timeLimit(.minutes(1))) struct PredictionRepositoryTests {
+
+  /// Builds a repo over an in-memory DB and returns it plus the manager so
+  /// tests can plant additional `simulations` rows for the streak cases
+  /// (predictions FK-reference a run).
+  private func makeEnv() throws -> (repo: GRDBPredictionRepository, manager: DatabaseManager) {
+    let manager = try DatabaseManager.inMemory()
+    let scenarioRepo = GRDBScenarioRepository(dbWriter: manager.dbWriter)
+    try scenarioRepo.save(
+      ScenarioRecord(
+        id: "s1", name: "Test", yamlDefinition: "yaml",
+        isPreset: false, createdAt: Date(), updatedAt: Date()))
+    return (GRDBPredictionRepository(dbWriter: manager.dbWriter), manager)
+  }
+
+  /// Inserts a `simulations` row so a prediction can FK-reference it.
+  private func insertSimulation(_ id: String, in manager: DatabaseManager) throws {
+    let simRepo = GRDBSimulationRepository(dbWriter: manager.dbWriter)
+    try simRepo.save(
+      SimulationRecord(
+        id: id, scenarioId: "s1",
+        status: "completed", currentRound: 1, currentPhaseIndex: 0,
+        stateJSON: "{}", configJSON: nil,
+        createdAt: Date(), updatedAt: Date()))
+  }
+
+  private func makeRecord(
+    id: String,
+    simulationId: String,
+    questionKind: String = "wolf",
+    predictedAgent: String = "Alice",
+    actualAgent: String = "Alice",
+    isHit: Bool = true,
+    createdAt: Date = Date(timeIntervalSince1970: 1000)
+  ) -> PredictionRecord {
+    PredictionRecord(
+      id: id, simulationId: simulationId, questionKind: questionKind,
+      predictedAgent: predictedAgent, actualAgent: actualAgent,
+      isHit: isHit, createdAt: createdAt)
+  }
+
+  @Test func saveAndFetchBySimulationId() throws {
+    let env = try makeEnv()
+    try insertSimulation("sim1", in: env.manager)
+    let record = makeRecord(id: "p1", simulationId: "sim1", isHit: true)
+    try env.repo.save(record)
+
+    let fetched = try env.repo.fetchBySimulationId("sim1")
+    #expect(fetched == record)
+  }
+
+  @Test func fetchBySimulationIdReturnsNilWhenAbsent() throws {
+    let env = try makeEnv()
+    #expect(try env.repo.fetchBySimulationId("nope") == nil)
+  }
+
+  @Test func fetchBySimulationIdsKeysByRun() throws {
+    let env = try makeEnv()
+    try insertSimulation("sim1", in: env.manager)
+    try insertSimulation("sim2", in: env.manager)
+    try env.repo.save(makeRecord(id: "p1", simulationId: "sim1"))
+    try env.repo.save(makeRecord(id: "p2", simulationId: "sim2", isHit: false))
+
+    let map = try env.repo.fetchBySimulationIds(["sim1", "sim2", "sim3"])
+    #expect(map.count == 2)
+    #expect(map["sim1"]?.isHit == true)
+    #expect(map["sim2"]?.isHit == false)
+    #expect(map["sim3"] == nil)
+  }
+
+  @Test func fetchBySimulationIdsEmptyInputReturnsEmpty() throws {
+    let env = try makeEnv()
+    #expect(try env.repo.fetchBySimulationIds([]).isEmpty)
+  }
+
+  @Test func currentStreakIsZeroWhenNoRecords() throws {
+    let env = try makeEnv()
+    #expect(try env.repo.currentStreak() == 0)
+  }
+
+  @Test func currentStreakIsZeroWhenLatestIsMiss() throws {
+    let env = try makeEnv()
+    try insertSimulation("sim1", in: env.manager)
+    try insertSimulation("sim2", in: env.manager)
+    // Older hit, newest miss → the miss breaks the streak immediately.
+    try env.repo.save(
+      makeRecord(
+        id: "p1", simulationId: "sim1", isHit: true,
+        createdAt: Date(timeIntervalSince1970: 1000)))
+    try env.repo.save(
+      makeRecord(
+        id: "p2", simulationId: "sim2", isHit: false,
+        createdAt: Date(timeIntervalSince1970: 2000)))
+
+    #expect(try env.repo.currentStreak() == 0)
+  }
+
+  @Test func currentStreakCountsLeadingHitsBackwards() throws {
+    let env = try makeEnv()
+    // createdAt order (oldest→newest): miss, hit, hit → streak of the two
+    // most-recent hits, stopping at the older miss.
+    struct Row {
+      let id: String
+      let hit: Bool
+      let time: Double
+    }
+    let rows = [
+      Row(id: "p1", hit: false, time: 1000),
+      Row(id: "p2", hit: true, time: 2000),
+      Row(id: "p3", hit: true, time: 3000)
+    ]
+    for (i, row) in rows.enumerated() {
+      try insertSimulation("sim\(i)", in: env.manager)
+      try env.repo.save(
+        makeRecord(
+          id: row.id, simulationId: "sim\(i)", isHit: row.hit,
+          createdAt: Date(timeIntervalSince1970: row.time)))
+    }
+
+    #expect(try env.repo.currentStreak() == 2)
+  }
+
+  @Test func currentStreakCountsAllWhenEveryPredictionHits() throws {
+    let env = try makeEnv()
+    for i in 0..<3 {
+      try insertSimulation("sim\(i)", in: env.manager)
+      try env.repo.save(
+        makeRecord(
+          id: "p\(i)", simulationId: "sim\(i)", isHit: true,
+          createdAt: Date(timeIntervalSince1970: Double(1000 + i * 1000))))
+    }
+
+    #expect(try env.repo.currentStreak() == 3)
+  }
+
+  @Test func deletingSimulationCascadesPrediction() throws {
+    let env = try makeEnv()
+    try insertSimulation("sim1", in: env.manager)
+    try env.repo.save(makeRecord(id: "p1", simulationId: "sim1"))
+
+    let simRepo = GRDBSimulationRepository(dbWriter: env.manager.dbWriter)
+    try simRepo.delete("sim1")
+
+    #expect(try env.repo.fetchBySimulationId("sim1") == nil)
+  }
+}

--- a/Pastura/PasturaTests/Views/ViewerPredictionSheetLayoutTests.swift
+++ b/Pastura/PasturaTests/Views/ViewerPredictionSheetLayoutTests.swift
@@ -1,0 +1,17 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+/// Change-detector for `ViewerPredictionSheet`'s code-review-gated countdown
+/// length (#915). A failure here is not a bug — it means the value drifted
+/// (typically in an unrelated refactor) and the editor must confirm the change
+/// passed review before updating the expected value. This narrows the
+/// silent-drift window without rendering the View (ADR-009 / view-testing.md
+/// § "Change-detector tripwire").
+@Suite(.timeLimit(.minutes(1)))
+struct ViewerPredictionSheetLayoutTests {
+  @Test func countdownSecondsIsFifteen() {
+    #expect(ViewerPredictionSheetLayout.countdownSeconds == 15)
+  }
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -97,6 +97,7 @@ creation observed. Decision: ship to App Store to gauge wider public reaction.
 | DL-time demo replay                      | Medium   | Done        | Bundled YAML replays during model download — end-to-end: spec + ADR-007 (#153), VM + Source (#186), host view + UI components (#197), wire into `.needsModelDownload` (#200), bundled YAMLs + CI drift guard (#205). |
 | Multi-model support (Qwen / E4B / other) | Medium   | Done        | Dual-model catalog shipped (Gemma 4 E2B + Qwen 3 4B Q4_K_M) via the `ModelDescriptor` / `ModelRegistry` abstraction over `LLMService` (ADR-001 §7 / ADR-002): plumbing — descriptor, multi-model storage, sequential download, legacy Gemma file auto-recognition (#206); UI — first-run model picker (`AppState.needsModelSelection`), Settings → Models active-model switch + delete, race-prevention via `SimulationActivityRegistry` (#218). Tracking issue #203. E4B and additional models remain forward-looking; add a new `ModelDescriptor` entry to `ModelRegistry` when a model is approved for shipment. |
 | Inference speed display                  | Low      | Done        | tok/s display + simulation playback UX (#99) |
+| Viewer prediction (視聴者予想)             | Low      | In progress | Pre-vote-reveal prediction sheet ("who is the wolf?" / "who is #1?") + hit / consecutive-streak tracking. Engagement mechanic from the #906 interestingness umbrella; Engine-untouched (App/ViewModel event buffering, ground truth scored at the reveal moment) (#915). |
 
 ### Technical Debt to Address
 - Evaluate SPM module split (if file count > 100)


### PR DESCRIPTION
## Summary
Before the first vote result is revealed, the app asks the viewer to predict the
outcome ("who is the wolf?" / "who gets the most votes?"), then tracks hits and a
consecutive-streak. Turns "watching" into "reading to predict" — the #906
interestingness umbrella's highest-leverage viewing-experience change.

- **Engine untouched.** Interception lives in the App/ViewModel layer: `run()`'s
  `for await` loop pauses at the first **vote-phase start** (`phaseStarted(.vote)`,
  before any vote is shown — so the individual votes don't spoil the answer),
  presents a sheet, captures the pick, and scores it against the tally when
  `voteResults` arrives (once per run).
- **Ground truth at reveal** (not `resolve()` at completion): wolf = minority-word
  holder from `.assignment` events; #1 = top tally via a comparator shared with
  the result card (`RankingOrder`), so the badge and the card can never disagree.
- **Scope self-selects by trigger:** prisoner's-dilemma uses `choose` (no vote) →
  no prediction. word_wolf → wolf; vote_tally / bokete → top-vote.
- **Opt-out setting** (default on, skippable, 15s auto-skip). Parked / backgrounded
  runs skip silently. Demo replay never fires (separate `ReplayViewModel`).
- **Reward surfaces:** end-of-run result card shows hit/miss + streak; Past Results
  rows show a hit/miss badge.

## Test plan
- Unit: `ViewerPredictionLogicTests` (classification over word_wolf/bokete/PD,
  wolf minority edge cases, tie tiebreak), `PredictionRepositoryTests` (streak
  boundaries, FK cascade, unique-index), `SimulationViewModelPredictionTests`
  (gating, once-per-run latch incl. parked-first-vote, scoring, persistence),
  `FeatureFlagsTests`, `ViewerPredictionSheetLayoutTests`.
- Full unit suite green (2493); `SimulationFocusModeTests` UI smoke green (render).
- 2-pass Opus code review: PASS/PASS, all warnings fixed.

## Real-device / visual QA (per ADR-009 — not automatable)
- Prediction sheet render + 15s countdown; result-card badge; Past Results badge.
- Interrupt timing doesn't break viewing tempo (No-Go fallback: passive button).

## Deferred (follow-ups)
- Immediate in-run celebration animation; ResultDetailView timeline line.
- Multi-round scenarios predict "this vote" (documented); interrupted-before-vote
  runs forgo that run's prediction.
- Known minor: inference buffers ahead during the countdown (accepted).

Closes #915

🤖 Generated with [Claude Code](https://claude.com/claude-code)
