### PR TITLE
🐛 fix: drain Metal completions before llama_free (teardown UAF)

### DIFF
--- a/Pastura/Pastura/LLM/LlamaCppService.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService.swift
@@ -233,7 +233,16 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
   deinit {
     // Safety net: free C resources if still loaded.
     if loadedState.withLock({ $0 }) {
-      if let ctx = _context { llama_free(ctx) }
+      if let ctx = _context {
+        // Same UAF guard as `unloadModel`: drain in-flight Metal
+        // command-buffer completions before freeing the context, else an
+        // async completion can reference already-freed buffers (#928).
+        // `deinit` cannot `await awaitGenerateIdle`, so it has no other
+        // drain — low-probability (unloadModel normally clears
+        // `loadedState` first) but the identical pattern, closed symmetrically.
+        llama_synchronize(ctx)
+        llama_free(ctx)
+      }
       if let mdl = _model { llama_model_free(mdl) }
       llama_backend_free()
     }
@@ -354,7 +363,24 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
     guard wasLoaded else { return }
 
     // Free C resources
-    if let ctx = _context { llama_free(ctx) }
+    if let ctx = _context {
+      // Drain in-flight GPU work + Metal command-buffer completions BEFORE
+      // freeing. `awaitGenerateIdle` above clears the Swift-level
+      // `generatingGuard`, but that does NOT wait for the last decode's
+      // async command-buffer completion notification (dispatched on
+      // `com.Metal.CompletionQueueDispatch`). Without this barrier, that
+      // completion can fire after `llama_free` has released the Metal
+      // buffers / residency sets it references → EXC_BAD_ACCESS
+      // (use-after-free). Most visible when a run is interrupted mid-decode,
+      // where teardown immediately follows the last (unsynchronized) decode.
+      // Trade-off: `llama_synchronize` is a bounded wait once in-flight
+      // buffers drain, but a wedged / GPU-denied context (the #680 failure
+      // family, same trigger path) could block here — accepted, since a
+      // recoverable hang beats a use-after-free crash.
+      // (#928; shares the unload-on-interrupt trigger with #680.)
+      llama_synchronize(ctx)
+      llama_free(ctx)
+    }
     if let mdl = _model { llama_model_free(mdl) }
     _context = nil
     _model = nil


### PR DESCRIPTION
## Summary

Interrupting an actively-generating run tore the llama context down (`unloadModel` → `llama_free`) while the last decode's **async Metal command-buffer completion** was still in flight on `com.Metal.CompletionQueueDispatch`, freeing the buffers / residency sets that the completion then messaged → `EXC_BAD_ACCESS` (use-after-free). Device-reproduced; full `bt all` in #928.

**Root cause:** `unloadModel()` gates on `awaitGenerateIdle`, which drains the Swift-level `generatingGuard` — but **not** the Metal command-buffer completion queue. So `llama_free` could release buffers a still-in-flight completion notification then referenced.

**Fix:** insert `llama_synchronize(ctx)` (llama.h: "Wait until all computations are finished") immediately before `llama_free(ctx)` in both `unloadModel()` and the `deinit` safety net (the second callsite was surfaced by the pre-impl critic — identical UAF pattern, closed symmetrically).

## Test plan

- ✅ `xcodebuild build`, full unit suite (2464 tests / 211 suites), `swiftlint --strict` — all green. `llama_synchronize` compiles like the sibling `llama_free` (no `#if` gating).
- ⚠️ **Device-QA is the acceptance gate before merge.** The guarded branch runs only when `_context != nil`, which never holds on the Simulator (it can't run quantized Metal inference — `.claude/rules/engine.md`), so **no unit test can assert the runtime fix** and CI stays green regardless. On a real device, interrupt an **actively-generating** run ~20× under **both** conditions:
  - (a) in-app interrupt — back / swipe-back mid-generation
  - (b) background-during-generation — scenePhase → `.background` (the `.suspended` path)

  No crash under either = pass. (The two exercise different command-buffer completion states through the new barrier.)
- ⚠️ **Residual risk:** `llama_synchronize` waits on GPU *execution*; it is not proven to fully drain the **async IOGPU completion-notification dispatch**. If the crash persists on device, escalate — report upstream to ggml-org/llama.cpp and/or add a stronger barrier.

## Relationship to #680

Shares the unload-on-interrupt → reload churn trigger with #680 (Metal **load-side** silent hang). Distinct bug (this is the **unload-side** hard crash), same code path — noted so the two efforts don't collide on `LlamaCppService` teardown. **Does not close #680.**

Closes #928

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QFFU2RNBz3u7vtnb3NXZjL
