### PR TITLE
🐛 fix: demo replay code-phase display parity (narration lines + chapter separators)

### DIFF
--- a/Pastura/Pastura/App/ReplayViewModel.swift
+++ b/Pastura/Pastura/App/ReplayViewModel.swift
@@ -364,6 +364,8 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
     case scenarioIntro(id: UUID, premise: String)
     case simulationResult(id: UUID, model: SimulationResultCard.Model)
     case codePhaseLine(id: UUID, line: CodePhaseLine)
+    case roundSeparator(id: UUID, round: Int, totalRounds: Int)
+    case phaseSeparator(id: UUID, phaseType: PhaseType)
 
     var id: UUID {
       switch self {
@@ -372,6 +374,8 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
       case .scenarioIntro(let id, _): return id
       case .simulationResult(let id, _): return id
       case .codePhaseLine(let id, _): return id
+      case .roundSeparator(let id, _, _): return id
+      case .phaseSeparator(let id, _): return id
       }
     }
   }
@@ -1021,21 +1025,30 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
   /// for the subset of events ``YAMLReplaySource/plannedEvents()``
   /// can emit — see the sync-risk note in this file's header.
   ///
-  /// The `cyclomatic_complexity` waiver matches the live VM's `handleEvent`:
-  /// restoring the per-event code-phase lines (#932) split one combined case
-  /// into individual arms, one over the default bound — a flat dispatch, not
-  /// nested logic.
-  private func apply(_ event: SimulationEvent) {  // swiftlint:disable:this cyclomatic_complexity
+  /// The `cyclomatic_complexity` / `function_body_length` waivers match the
+  /// live VM's `handleEvent`: restoring the per-event code-phase lines and the
+  /// lifecycle chapter separators (#932) split combined cases into individual
+  /// arms — a flat dispatch, not nested logic.
+  private func apply(_ event: SimulationEvent) {  // swiftlint:disable:this cyclomatic_complexity function_body_length
     switch event {
     case .roundStarted(let round, let totalRounds):
       currentRound = round
       currentTotalRounds = totalRounds
+      // Inline round separator so the demo transcript chunks by round like the
+      // live sim (#932 follow-up). The GameHeader also carries round position,
+      // but the separator marks WHERE in the scroll history each round begins.
+      chatItems.append(
+        .roundSeparator(id: UUID(), round: round, totalRounds: totalRounds))
 
     case .phaseStarted(let phaseType, _):
       currentPhase = phaseType
       // Increment pseudo-ROUND counter. Survives pause/resume; reset
       // only on source rotation via ``resetPerDemoState(forSourceIndex:)``.
       phaseProgress += 1
+      // Inline phase separator, mirroring the live sim: LLM phases render a
+      // full-width chapter rule, code phases an inline badge (the host view
+      // dispatches on `phaseType.requiresLLM`).
+      chatItems.append(.phaseSeparator(id: UUID(), phaseType: phaseType))
 
     case .agentOutput(let agent, let output, let phaseType):
       let filtered = contentFilter.filter(output)

--- a/Pastura/Pastura/App/ReplayViewModel.swift
+++ b/Pastura/Pastura/App/ReplayViewModel.swift
@@ -38,15 +38,36 @@ import Foundation
 /// `.agentOutputStream` is not emitted by replay (spec §4.7) so is not
 /// in scope.
 ///
+/// **Intentional divergence from the live VM (#932).** The live
+/// ``SimulationViewModel/handleEvent(_:)`` appends `.assignment` /
+/// `.summary` **raw** — its ContentFilter touches only `.agentOutput`.
+/// The demo replay, an App-Store-review-visible DL-time surface, applies
+/// the render-time filter to `.assignment.value` / `.summary.text` /
+/// `.pairingResult.action1/2` as ADR-005 defense-in-depth, matching how it
+/// already filters `.agentOutput`. Demo content is curated
+/// (`content_filter_applied: true` attestation), so the filter fires on
+/// nothing and there is no visible delta from the live lines — the two are
+/// pixel-identical in practice; the divergence is purely a belt-and-suspenders
+/// re-check on the untrusted-at-runtime path.
+///
 /// **Sync-risk with ``SimulationViewModel``:** The live VM's
 /// `handleEvent` (see `SimulationViewModel.swift`) is the canonical
 /// event→view-state transform. Events that `YAMLReplaySource.plannedEvents()`
 /// can currently emit — `.roundStarted`, `.phaseStarted`, `.agentOutput`,
 /// `.scoreUpdate`, `.elimination`, `.summary`, `.voteResults`,
-/// `.pairingResult`, `.assignment` — should mirror the live VM's
-/// filtering and state-update rules. When the live VM adds filtering
-/// to a new case, check whether ``YAMLReplaySource/plannedEvents()``
+/// `.pairingResult`, `.assignment`, `.eventInjected` — should mirror the
+/// live VM's filtering and state-update rules. When the live VM adds
+/// filtering to a new case, check whether ``YAMLReplaySource/plannedEvents()``
 /// can emit it; if yes, mirror the filter here; if no, leave alone.
+///
+/// **Visible-line mapping (#932).** The code-phase events
+/// (`.assignment`, `.summary`, `.voteResults`, `.scoreUpdate`,
+/// `.elimination`, `.pairingResult`, `.eventInjected`) each append a
+/// ``ChatItem/codePhaseLine`` for inline rendering — the demo mirror of
+/// the live ``SimulationView``'s `secondaryLogEntryView`. The three that
+/// also feed the closing card (`.scoreUpdate` / `.voteResults` /
+/// `.elimination`) STILL update their accumulators (#868/#884) in addition
+/// to appending — the two surfaces are independent.
 @Observable
 @MainActor
 final class ReplayViewModel {  // swiftlint:disable:this type_body_length
@@ -325,6 +346,15 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
   /// closing card. It rides the same timeline; on rotation the order is
   /// result card → boundary → intro card.
   ///
+  /// `.codePhaseLine` carries an inline referee/narrator line (the per-round
+  /// assignment お題, round summary, injected event, vote tally, score
+  /// update, elimination, or pairing result) — the demo mirror of the live
+  /// simulation's inline log entries (`SimulationView`'s
+  /// `secondaryLogEntryView`). Restored in #932: these events were previously
+  /// dropped by ``apply(_:)``, so assign-based demos lost the お題 that grounds
+  /// every agent response. Appended inline during playback in publish order,
+  /// alongside `.agentOutput`.
+  ///
   /// `id` is projected from the inner payload so SwiftUI's
   /// `ForEach`/`scrollTo(_:anchor:)` keep working identically to the
   /// pre-#208 `AgentOutputEntry`-only timeline.
@@ -333,6 +363,7 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
     case demoBoundary(id: UUID, scenarioName: String)
     case scenarioIntro(id: UUID, premise: String)
     case simulationResult(id: UUID, model: SimulationResultCard.Model)
+    case codePhaseLine(id: UUID, line: CodePhaseLine)
 
     var id: UUID {
       switch self {
@@ -340,8 +371,30 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
       case .demoBoundary(let id, _): return id
       case .scenarioIntro(let id, _): return id
       case .simulationResult(let id, _): return id
+      case .codePhaseLine(let id, _): return id
       }
     }
+  }
+
+  /// An inline code-phase narration line rendered in the demo chat stream —
+  /// the demo counterpart of the live simulation's `LogEntry` render kinds
+  /// (`SimulationView+LogEntries.swift`). One variant per code-phase event
+  /// ``apply(_:)`` can surface. The host view (`ModelDownloadHostView`) maps
+  /// each variant to a row using the SAME design tokens and localized keys as
+  /// the live helpers, so the two chat streams stay visually unified (#273).
+  ///
+  /// Structured identifiers (persona names in `voteResults` / `scoreUpdate` /
+  /// `elimination` / `pairingResult`) are carried verbatim — never
+  /// ContentFilter-rewritten (see ``apply(_:)`` and the header §"ContentFilter
+  /// scope"). `assignment.value` / `summary.text` arrive already-filtered.
+  nonisolated enum CodePhaseLine: Sendable, Equatable {
+    case assignment(agent: String, value: String)
+    case summary(text: String)
+    case voteResults(tallies: [String: Int])
+    case scoreUpdate(scores: [String: Int])
+    case elimination(agent: String, voteCount: Int)
+    case pairingResult(agent1: String, action1: String, agent2: String, action2: String)
+    case eventInjected(event: String?)
   }
 
   // MARK: - Dependencies
@@ -712,9 +765,15 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
       await sleepOrYield(milliseconds: delayMs)
       if Task.isCancelled { return }
       apply(paced.event)
-      // The floor for THIS bubble gates the delay before the NEXT event — the
-      // window during which this bubble is typing on screen.
-      pendingFloorMs = typingFloorMs(for: paced.event, script: script)
+      // The floor for THIS event gates the delay before the NEXT event — the
+      // window during which this line stays on screen. Agent bubbles reserve
+      // typing + reading time; text-carrying code-phase lines (#932) reserve a
+      // reading beat so the お題 / summary can be read before the round's turns
+      // arrive (they render instantly, so no typing term). Exactly one term is
+      // non-zero per event, so `max` just selects the applicable floor.
+      pendingFloorMs = max(
+        typingFloorMs(for: paced.event, script: script),
+        codePhaseFloorMs(for: paced.event, script: script))
       cursor += 1
       // Only advance observable cursor if we're still playing (not
       // backgrounded mid-publish). Guards against a stale state
@@ -961,7 +1020,12 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
   /// scope. Mirror of the live ``SimulationViewModel/handleEvent(_:)``
   /// for the subset of events ``YAMLReplaySource/plannedEvents()``
   /// can emit — see the sync-risk note in this file's header.
-  private func apply(_ event: SimulationEvent) {
+  ///
+  /// The `cyclomatic_complexity` waiver matches the live VM's `handleEvent`:
+  /// restoring the per-event code-phase lines (#932) split one combined case
+  /// into individual arms, one over the default bound — a flat dispatch, not
+  /// nested logic.
+  private func apply(_ event: SimulationEvent) {  // swiftlint:disable:this cyclomatic_complexity
     switch event {
     case .roundStarted(let round, let totalRounds):
       currentRound = round
@@ -981,29 +1045,65 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
 
     case .scoreUpdate(let newScores):
       // Full-replace, matching ``SimulationViewModel/handleScoreUpdate``.
-      // Feeds the closing card's ranking (#884). No ContentFilter — the keys
-      // are persona names (structured identifiers); filtering could corrupt a
-      // name that happens to contain a blocklist substring (see header §
-      // "ContentFilter scope").
+      // Feeds the closing card's ranking (#884) AND renders an inline score
+      // summary line (#932). No ContentFilter — the keys are persona names
+      // (structured identifiers); filtering could corrupt a name that happens
+      // to contain a blocklist substring (see header § "ContentFilter scope").
       scores = newScores
+      chatItems.append(
+        .codePhaseLine(id: UUID(), line: .scoreUpdate(scores: newScores)))
 
     case .voteResults(_, let tallies):
-      // Keep the latest tallies for the closing card's vote-only ranking.
-      // Last-wins matches `scores`' full-replace semantics. `votes` (who voted
-      // for whom) has no closing-card surface, so it is dropped here.
+      // Keep the latest tallies for the closing card's vote-only ranking AND
+      // render an inline tally line (#932). Last-wins matches `scores`'
+      // full-replace semantics. `votes` (who voted for whom) has no visible
+      // surface, so it is dropped here.
       voteResults = tallies
+      chatItems.append(
+        .codePhaseLine(id: UUID(), line: .voteResults(tallies: tallies)))
 
     case .elimination(let agent, let voteCount):
       // Capture the count at elimination time so the card's survival framing
-      // shows each eliminated agent's own round tally (#884).
+      // shows each eliminated agent's own round tally (#884) AND render an
+      // inline elimination line (#932). Structured identifiers — unfiltered.
       eliminated[agent] = true
       eliminationVotes[agent] = voteCount
+      chatItems.append(
+        .codePhaseLine(id: UUID(), line: .elimination(agent: agent, voteCount: voteCount)))
 
-    case .summary, .pairingResult, .assignment, .eventInjected:
-      // No closing-card surface: `.pairingResult` / `.assignment` feed scores
-      // via a later `.scoreUpdate`; `.summary` / `.eventInjected` are narrative
-      // only. Nothing visible updates here; rendering them is a no-op.
-      return
+    case .assignment(let agent, let value):
+      // The per-round お題 that grounds every agent response (#932) — the
+      // reported bug was this being a silent no-op. Render-time ContentFilter
+      // on the value per the header § "ContentFilter scope" (defense-in-depth;
+      // the live VM appends raw). The agent name is a structured identifier,
+      // passed through unfiltered.
+      chatItems.append(
+        .codePhaseLine(
+          id: UUID(),
+          line: .assignment(agent: agent, value: contentFilter.filter(value))))
+
+    case .summary(let text):
+      // Round summary / narrator line (#932). Filtered per the header scope.
+      chatItems.append(
+        .codePhaseLine(id: UUID(), line: .summary(text: contentFilter.filter(text))))
+
+    case .pairingResult(let agent1, let act1, let agent2, let act2):
+      // `choose`-phase pairing (#932). Filter the chosen actions (LLM text)
+      // per the header scope; agent names are structured identifiers.
+      chatItems.append(
+        .codePhaseLine(
+          id: UUID(),
+          line: .pairingResult(
+            agent1: agent1, action1: contentFilter.filter(act1),
+            agent2: agent2, action2: contentFilter.filter(act2))))
+
+    case .eventInjected(let event):
+      // Injected-event narration (#932). `nil` = the probabilistic phase's
+      // miss; the render arm shows an explicit "no event" marker (mirrors the
+      // live `eventInjectedEntry`). Filter the hit text per the header scope.
+      chatItems.append(
+        .codePhaseLine(
+          id: UUID(), line: .eventInjected(event: event.map(contentFilter.filter))))
 
     case .roundCompleted, .phaseCompleted, .simulationCompleted,
       .roundCheckpoint, .simulationPaused, .conditionalEvaluated,
@@ -1110,6 +1210,39 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
     let dwellMs = Self.milliseconds(
       playbackSpeed.readingDwell(displayLength: premise.count, script: script))
     return typing + dwellMs
+  }
+
+  /// Reading-dwell floor (raw ms, real wall-clock at the current speed) that
+  /// the inter-event delay after a text-carrying code-phase line
+  /// (``CodePhaseLine/assignment`` / ``CodePhaseLine/summary`` / a non-nil
+  /// ``CodePhaseLine/eventInjected``) must cover so the line can be read before
+  /// the next event lands. These lines render instantly (no typing animation,
+  /// unlike ``AgentOutputRow``), so the floor is a pure reading dwell — no
+  /// typing term. It is the demo's substitute for the seconds-apart pacing the
+  /// live LLM-driven sim gets for free; without it the context-critical お題 can
+  /// flash and be buried by the round's first turn on fast playback (#932).
+  ///
+  /// Returns 0 for non-text code-phase events (votes / scores / eliminations /
+  /// pairings are glanceable and re-surfaced on the closing card) and when
+  /// there is no proportional dwell (opt-out config / `.instant` → nil cps),
+  /// gated on the same ``typingCharsPerSecond`` nil-check as
+  /// ``introFloorMs(forSourceIndex:script:)`` so `.instant` stays instant.
+  /// Uses the raw (pre-filter) event text; curated demo content means the
+  /// ContentFilter is a no-op, and the floor is a lower-bound estimate anyway
+  /// (see ``typingFloorMs(for:script:)``). `internal` (not `private`) so
+  /// `ReplayViewModelTests+Pacing` can exercise it.
+  func codePhaseFloorMs(for event: SimulationEvent, script: ReadingScript) -> Int {
+    guard typingCharsPerSecond != nil else { return 0 }
+    let text: String
+    switch event {
+    case .assignment(_, let value): text = value
+    case .summary(let summaryText): text = summaryText
+    case .eventInjected(let injected): text = injected ?? ""
+    default: return 0
+    }
+    guard !text.isEmpty else { return 0 }
+    return Self.milliseconds(
+      playbackSpeed.readingDwell(displayLength: text.count, script: script))
   }
 
   /// Whole milliseconds of a `Duration` that carries only ms precision

--- a/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+ChatStream.swift
+++ b/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+ChatStream.swift
@@ -37,6 +37,10 @@ extension ModelDownloadHostView {
                 demoResultCard(id: id, model: model)
               case .codePhaseLine(let id, let line):
                 demoCodePhaseRow(id: id, line: line)
+              case .roundSeparator(let id, let round, let total):
+                demoRoundSeparator(id: id, round: round, totalRounds: total)
+              case .phaseSeparator(let id, let phaseType):
+                demoPhaseSeparator(id: id, phaseType: phaseType)
               }
             }
           }

--- a/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+ChatStream.swift
+++ b/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+ChatStream.swift
@@ -35,6 +35,8 @@ extension ModelDownloadHostView {
                 demoIntroCard(id: id, premise: premise, viewModel: viewModel)
               case .simulationResult(let id, let model):
                 demoResultCard(id: id, model: model)
+              case .codePhaseLine(let id, let line):
+                demoCodePhaseRow(id: id, line: line)
               }
             }
           }

--- a/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+CodePhaseRows.swift
+++ b/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+CodePhaseRows.swift
@@ -1,0 +1,121 @@
+import SwiftUI
+
+// Inline code-phase narration rows for the DL-time demo replay chat stream
+// (#932) — the demo counterpart of the live simulation's inline log entries
+// (`SimulationView+LogEntries.swift`). Split out of `+ChatStream` so both stay
+// under swiftlint's 400-line `file_length` cap, mirroring the live split.
+//
+// These deliberately REPLICATE the live helpers rather than share them: the
+// live versions are methods on the `SimulationView` extension and are wired to
+// its per-entry `opacity(forEntryId:)` reveal animation, which the demo does
+// not have. The demo already replicates rather than shares its agent row
+// (`demoAgentRow`), so this follows the same seam. The design tokens
+// (`Typography.*`, `Color.*`) and the `String(localized:)` keys are copied
+// byte-for-byte from the live helpers so the two chat streams stay visually
+// unified (#273) and no new catalog key is spawned — a whitespace drift in a
+// format string (e.g. the two leading spaces in `"  %@: %lld votes"`) would
+// fork a key.
+extension ModelDownloadHostView {
+
+  /// One inline code-phase line, dispatched by ``ReplayViewModel/CodePhaseLine``
+  /// variant. `.transition` + `.id` mirror the demo's other chat rows
+  /// (`demoAgentRow` / `demoIntroCard`) so it animates in and scroll-follows
+  /// identically.
+  @ViewBuilder
+  func demoCodePhaseRow(id: UUID, line: ReplayViewModel.CodePhaseLine) -> some View {
+    codePhaseContent(line)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .id(id)
+      .transition(reduceMotion ? .identity : .opacity)
+  }
+
+  @ViewBuilder
+  private func codePhaseContent(_ line: ReplayViewModel.CodePhaseLine) -> some View {
+    switch line {
+    case .assignment(let agent, let value):
+      // Mirrors `SimulationView.assignmentEntry`.
+      Text(String(format: String(localized: "%@ assigned: %@"), agent, value))
+        .textStyle(Typography.metaValue)
+        .foregroundStyle(Color.muted)
+    case .summary(let text):
+      // Mirrors `SimulationView.summaryEntry`.
+      Text(text)
+        .textStyle(Typography.bodyBubble)
+        .foregroundStyle(Color.inkSecondary)
+    case .voteResults(let tallies):
+      voteResultsContent(tallies)
+    case .scoreUpdate(let scores):
+      scoresContent(scores)
+    case .elimination(let agent, let voteCount):
+      // Mirrors `SimulationView.eliminationEntry`.
+      HStack(spacing: 4) {
+        Image(systemName: "xmark.circle.fill")
+          .foregroundStyle(Color.inkSecondary)
+        Text(String(format: String(localized: "%@ eliminated (%lld votes)"), agent, voteCount))
+          .textStyle(Typography.titlePhase)
+      }
+    case .pairingResult(let agent1, let action1, let agent2, let action2):
+      pairingResultContent(agent1: agent1, action1: action1, agent2: agent2, action2: action2)
+    case .eventInjected(let event):
+      eventInjectedContent(event)
+    }
+  }
+
+  /// Mirrors `SimulationView.voteResultsEntry`.
+  private func voteResultsContent(_ tallies: [String: Int]) -> some View {
+    VStack(alignment: .leading, spacing: 2) {
+      Text(String(localized: "Vote Results"))
+        .textStyle(Typography.metaLabel)
+        .foregroundStyle(Color.inkSecondary)
+      ForEach(tallies.sorted(by: { $0.value > $1.value }), id: \.key) { name, count in
+        Text(String(format: String(localized: "  %@: %lld votes"), name, count))
+          .textStyle(Typography.metaValue)
+      }
+    }
+    .foregroundStyle(Color.muted)
+  }
+
+  /// Mirrors `SimulationView.scoresSummary`.
+  private func scoresContent(_ scores: [String: Int]) -> some View {
+    HStack(spacing: 8) {
+      ForEach(scores.sorted(by: { $0.value > $1.value }).prefix(5), id: \.key) { name, score in
+        Text(verbatim: "\(name):\(score)")
+          .textStyle(Typography.metaValue)
+          .monospacedDigit()
+      }
+    }
+    .foregroundStyle(Color.muted)
+  }
+
+  /// Mirrors `SimulationView.pairingResultEntry`.
+  private func pairingResultContent(
+    agent1: String, action1: String, agent2: String, action2: String
+  ) -> some View {
+    HStack {
+      Text(verbatim: "\(agent1)(\(action1))")
+      Text(String(localized: "vs"))
+        .foregroundStyle(Color.muted)
+      Text(verbatim: "\(agent2)(\(action2))")
+    }
+    .textStyle(Typography.titlePhase)
+  }
+
+  /// Mirrors `SimulationView.eventInjectedEntry`. The miss case (`event == nil`)
+  /// renders an explicit "no event" marker rather than disappearing — users
+  /// observing a probabilistic phase need to see the dice roll, not just hits.
+  @ViewBuilder
+  private func eventInjectedContent(_ event: String?) -> some View {
+    if let event {
+      HStack(spacing: 4) {
+        Image(systemName: "die.face.5").foregroundStyle(Color.inkSecondary)
+        Text(event)
+          .textStyle(Typography.bodyBubble)
+          .foregroundStyle(Color.inkSecondary)
+      }
+    } else {
+      Text(String(localized: "No event this round"))
+        .textStyle(Typography.metaValue)
+        .foregroundStyle(Color.muted)
+    }
+  }
+}

--- a/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+CodePhaseRows.swift
+++ b/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+CodePhaseRows.swift
@@ -118,4 +118,45 @@ extension ModelDownloadHostView {
         .foregroundStyle(Color.muted)
     }
   }
+
+  // MARK: - Lifecycle chapter separators (#932 follow-up)
+
+  /// Full-width round separator, mirroring `SimulationView.roundSeparator`.
+  /// Reuses the `"Round %lld / %lld"` key already wired into `GameHeader` so the
+  /// separator label and header label stay translation-aligned.
+  func demoRoundSeparator(id: UUID, round: Int, totalRounds: Int) -> some View {
+    HStack {
+      Rectangle().fill(Color.rule).frame(height: 1)
+      Text(String(format: String(localized: "Round %lld / %lld"), round, totalRounds))
+        .textStyle(Typography.metaLabel)
+        .foregroundStyle(Color.inkSecondary)
+      Rectangle().fill(Color.rule).frame(height: 1)
+    }
+    .padding(.vertical, 4)
+    .id(id)
+    .transition(reduceMotion ? .identity : .opacity)
+  }
+
+  /// Phase separator, mirroring the live sim's `.phaseStarted` dispatch: LLM
+  /// phases (speak / vote / choose) get a full-width chapter rule around a
+  /// `PhaseTypeLabel`; code phases (assign / score_calc / summarize) keep the
+  /// inline badge to avoid over-chunking code-phase-heavy scenarios (#882).
+  @ViewBuilder
+  func demoPhaseSeparator(id: UUID, phaseType: PhaseType) -> some View {
+    Group {
+      if phaseType.requiresLLM {
+        HStack {
+          Rectangle().fill(Color.rule).frame(height: 1)
+          PhaseTypeLabel(phaseType: phaseType)
+          Rectangle().fill(Color.rule).frame(height: 1)
+        }
+        .padding(.vertical, 4)
+      } else {
+        PhaseTypeLabel(phaseType: phaseType)
+          .padding(.top, 4)
+      }
+    }
+    .id(id)
+    .transition(reduceMotion ? .identity : .opacity)
+  }
 }

--- a/Pastura/PasturaTests/App/DemoReplayIntegrationTests.swift
+++ b/Pastura/PasturaTests/App/DemoReplayIntegrationTests.swift
@@ -187,17 +187,18 @@ struct DemoReplayIntegrationTests {
     } else {
       Issue.record("Expected held .playing(1, _), got \(viewModel.state)")
     }
-    // Per #208, rotation accumulates instead of wiping. After both
-    // demos play, chatItems = source 0's 3 turns (Alice / Bob / Carol,
-    // with Bob filtered) + boundary marker + source 1's 2 turns
-    // (Alice / Bob) = 6 items. The compat-shim agentOutputs filters
-    // out the boundary and surfaces all 5 agent turns.
-    #expect(viewModel.chatItems.count == 6)
-    if case .demoBoundary(_, let scenarioName) = viewModel.chatItems[3] {
+    // Per #208, rotation accumulates instead of wiping. Each single-phase,
+    // single-round source now also contributes a round + phase separator
+    // (#932 follow-up): source 0 = [roundSep, phaseSep, Alice, Bob, Carol]
+    // (5), a boundary marker, then source 1 = [roundSep, phaseSep, Alice, Bob]
+    // (4) = 10 items. The compat-shim agentOutputs filters out separators +
+    // boundary and surfaces all 5 agent turns.
+    #expect(viewModel.chatItems.count == 10)
+    if case .demoBoundary(_, let scenarioName) = viewModel.chatItems[5] {
       #expect(scenarioName == "Prisoner's Dilemma")
     } else {
       Issue.record(
-        "chatItems[3] expected .demoBoundary, got \(viewModel.chatItems[3])")
+        "chatItems[5] expected .demoBoundary, got \(viewModel.chatItems[5])")
     }
     #expect(viewModel.agentOutputs.count == 5)
     #expect(viewModel.agentOutputs[0].agent == "Alice")  // word_wolf

--- a/Pastura/PasturaTests/App/ReplayViewModelTests+ChatLogAccumulation.swift
+++ b/Pastura/PasturaTests/App/ReplayViewModelTests+ChatLogAccumulation.swift
@@ -147,8 +147,11 @@ extension ReplayViewModelTests {
     #expect(
       boundaryCount == 0,
       "Loop wrap must wipe boundaries, got \(viewModel.chatItems)")
+    // Source 0's fresh replay contributes at most its two lifecycle separators
+    // + one agent turn (#932 follow-up) — well under the pre-wrap 7-item stream,
+    // proving the wipe happened.
     #expect(
-      viewModel.chatItems.count <= 1,
+      viewModel.chatItems.count <= 3,
       "Loop wrap must wipe accumulator, got count=\(viewModel.chatItems.count)")
   }
 
@@ -168,7 +171,9 @@ extension ReplayViewModelTests {
     }
     let preBackgroundCount = viewModel.chatItems.count
     let preBackgroundIds = viewModel.chatItems.map(\.id)
-    #expect(preBackgroundCount == 3)
+    // 2 sources × [roundSeparator, phaseSeparator, agentOutput] + 1 boundary
+    // = 7 items (#932 follow-up added the lifecycle separators).
+    #expect(preBackgroundCount == 7)
 
     viewModel.onBackground()
     if case .paused(_, _, _, .scenePhase) = viewModel.state {
@@ -197,7 +202,8 @@ extension ReplayViewModelTests {
       state == .idle
     }
     #expect(
-      viewModel.chatItems.count == 3, "Prior run must hold both demos + boundary")
+      viewModel.chatItems.count == 7,
+      "Prior run must hold both demos' separators + turns + boundary")
 
     viewModel.start()
     // Synchronous post-start: `start()` body wipes chatItems before

--- a/Pastura/PasturaTests/App/ReplayViewModelTests+CodePhaseLines.swift
+++ b/Pastura/PasturaTests/App/ReplayViewModelTests+CodePhaseLines.swift
@@ -237,6 +237,73 @@ extension ReplayViewModelTests {
     #expect(value.contains("XXX"))
   }
 
+  // MARK: - Lifecycle chapter separators (#932 follow-up)
+
+  /// `.roundStarted` appends an inline round separator carrying the round pair,
+  /// mirroring the live sim's `roundSeparator`.
+  @Test func roundStartedAppendsRoundSeparator() async throws {
+    let viewModel = try Self.makeVM()  // threeTurnYAML: round 1 / total 1
+    viewModel.start()
+    await Self.waitForState(viewModel) { _ in
+      viewModel.chatItems.contains {
+        if case .roundSeparator = $0 { return true }
+        return false
+      }
+    }
+    #expect(
+      viewModel.chatItems.contains {
+        if case .roundSeparator(_, let round, let total) = $0 {
+          return round == 1 && total == 1
+        }
+        return false
+      })
+  }
+
+  /// `.phaseStarted` appends an inline phase separator carrying the phase type,
+  /// mirroring the live sim's `phaseSeparator` / inline badge dispatch.
+  @Test func phaseStartedAppendsPhaseSeparator() async throws {
+    let viewModel = try Self.makeVM()  // threeTurnYAML: speak_all
+    viewModel.start()
+    await Self.waitForState(viewModel) { _ in
+      viewModel.chatItems.contains {
+        if case .phaseSeparator = $0 { return true }
+        return false
+      }
+    }
+    #expect(
+      viewModel.chatItems.contains {
+        if case .phaseSeparator(_, let phaseType) = $0 { return phaseType == .speakAll }
+        return false
+      })
+  }
+
+  /// Chapter order at a source head: round separator → phase separator → the
+  /// round's first agent turn (no intro card here — the default fixture's
+  /// `description` is empty).
+  @Test func separatorsPrecedeFirstTurn() async throws {
+    let viewModel = try Self.makeVM()
+    viewModel.start()
+    await Self.waitForState(viewModel) { _ in !viewModel.agentOutputs.isEmpty }
+    let roundIndex = viewModel.chatItems.firstIndex {
+      if case .roundSeparator = $0 { return true }
+      return false
+    }
+    let phaseIndex = viewModel.chatItems.firstIndex {
+      if case .phaseSeparator = $0 { return true }
+      return false
+    }
+    let turnIndex = viewModel.chatItems.firstIndex {
+      if case .agentOutput = $0 { return true }
+      return false
+    }
+    guard let roundIndex, let phaseIndex, let turnIndex else {
+      Issue.record("Missing a separator or turn in \(viewModel.chatItems)")
+      return
+    }
+    #expect(roundIndex < phaseIndex)
+    #expect(phaseIndex < turnIndex)
+  }
+
   @Test func filtersSummaryText() async throws {
     let yaml = """
       schema_version: 1

--- a/Pastura/PasturaTests/App/ReplayViewModelTests+CodePhaseLines.swift
+++ b/Pastura/PasturaTests/App/ReplayViewModelTests+CodePhaseLines.swift
@@ -1,0 +1,278 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+// Inline code-phase narration line (`ChatItem.codePhaseLine`) tests for
+// `ReplayViewModel` (#932) — the demo mirror of the live sim's inline log
+// entries (`SimulationView`'s `secondaryLogEntryView`). Before #932 these
+// events were a silent no-op in `apply()`, so assign-based demos lost the
+// per-round お題 that grounds every agent response.
+//
+// Sibling-file `extension` per `.claude/rules/testing.md` — NOT a new `@Suite`
+// (a parallel suite would race the VM-spawning original on the shared test
+// process; the `.serialized` / `.timeLimit` traits live on the base `@Suite`).
+extension ReplayViewModelTests {
+
+  // MARK: - Fixtures
+
+  /// A turn preceded (by `phase_index`) by an `assign` code-phase event, so the
+  /// お題 chronologically lands before the round's speak turn — exactly the
+  /// real-data shape (assign is phase_index 0, speak is phase_index 1).
+  static let assignmentThenTurnYAML = """
+    schema_version: 1
+    turns:
+      - round: 1
+        phase_index: 1
+        phase_type: speak_all
+        agent: Alice
+        fields: { statement: 'hello' }
+    code_phase_events:
+      - round: 1
+        phase_index: 0
+        phase_type: assign
+        summary: 'Alice assigned: topic X'
+        payload:
+          kind: assignment
+          agent: Alice
+          value: 'topic X'
+    """
+
+  /// A summarize code-phase event carrying narrator text in the top-level
+  /// `summary` field (that field, NOT `payload`, is the source of `.summary`).
+  static let summaryYAML = """
+    schema_version: 1
+    turns:
+      - round: 1
+        phase_index: 0
+        phase_type: speak_all
+        agent: Alice
+        fields: { statement: 'hello' }
+    code_phase_events:
+      - round: 1
+        phase_index: 1
+        phase_type: summarize
+        summary: 'the round wrapped up'
+        payload:
+          kind: summary
+    """
+
+  /// An `event_inject` code-phase event with a hit (non-nil `event`).
+  static let eventInjectedYAML = """
+    schema_version: 1
+    turns:
+      - round: 1
+        phase_index: 0
+        phase_type: speak_all
+        agent: Alice
+        fields: { statement: 'hello' }
+    code_phase_events:
+      - round: 1
+        phase_index: 1
+        phase_type: event_inject
+        summary: 'a wild event appears'
+        payload:
+          kind: eventInjected
+          event: 'a wild event appears'
+    """
+
+  /// All `CodePhaseLine`s currently in the VM's chat stream, in order.
+  static func codePhaseLines(_ viewModel: ReplayViewModel) -> [ReplayViewModel.CodePhaseLine] {
+    viewModel.chatItems.compactMap {
+      if case .codePhaseLine(_, let line) = $0 { return line }
+      return nil
+    }
+  }
+
+  // MARK: - Inline append (the reported bug)
+
+  /// The assignment お題 now renders as an inline `.codePhaseLine` — previously a
+  /// silent no-op. This is the exact regression: reverting `apply()`'s
+  /// `.assignment` arm to `return` makes this fail.
+  @Test func assignmentEventAppendsInlineLine() async throws {
+    let source = try YAMLReplaySource(
+      yaml: Self.assignmentThenTurnYAML, scenario: Self.makeScenario(),
+      config: Self.fastConfig)
+    let viewModel = ReplayViewModel(
+      sources: [source], config: Self.fastConfig, contentFilter: ContentFilter())
+    viewModel.start()
+    await Self.waitForState(viewModel, timeout: .seconds(5)) { _ in
+      !Self.codePhaseLines(viewModel).isEmpty
+    }
+    #expect(
+      Self.codePhaseLines(viewModel).contains {
+        if case .assignment(let agent, let value) = $0 {
+          return agent == "Alice" && value == "topic X"
+        }
+        return false
+      })
+  }
+
+  /// The お題 line lands BEFORE the round's agent turn — without it the response
+  /// has no context (the whole point of the fix).
+  @Test func assignmentLinePrecedesRoundTurns() async throws {
+    let source = try YAMLReplaySource(
+      yaml: Self.assignmentThenTurnYAML, scenario: Self.makeScenario(),
+      config: Self.fastConfig)
+    let viewModel = ReplayViewModel(
+      sources: [source], config: Self.fastConfig, contentFilter: ContentFilter())
+    viewModel.start()
+    await Self.waitForState(viewModel, timeout: .seconds(5)) { _ in
+      !viewModel.agentOutputs.isEmpty && !Self.codePhaseLines(viewModel).isEmpty
+    }
+    let assignIndex = viewModel.chatItems.firstIndex {
+      if case .codePhaseLine(_, .assignment) = $0 { return true }
+      return false
+    }
+    let turnIndex = viewModel.chatItems.firstIndex {
+      if case .agentOutput = $0 { return true }
+      return false
+    }
+    guard let assignIndex, let turnIndex else {
+      Issue.record("Missing assignment line or agent turn in \(viewModel.chatItems)")
+      return
+    }
+    #expect(assignIndex < turnIndex)
+  }
+
+  @Test func summaryEventAppendsInlineLine() async throws {
+    let source = try YAMLReplaySource(
+      yaml: Self.summaryYAML, scenario: Self.makeScenario(), config: Self.fastConfig)
+    let viewModel = ReplayViewModel(
+      sources: [source], config: Self.fastConfig, contentFilter: ContentFilter())
+    viewModel.start()
+    await Self.waitForState(viewModel, timeout: .seconds(5)) { _ in
+      !Self.codePhaseLines(viewModel).isEmpty
+    }
+    #expect(
+      Self.codePhaseLines(viewModel).contains {
+        if case .summary(let text) = $0 { return text == "the round wrapped up" }
+        return false
+      })
+  }
+
+  @Test func eventInjectedAppendsInlineLine() async throws {
+    let source = try YAMLReplaySource(
+      yaml: Self.eventInjectedYAML, scenario: Self.makeScenario(),
+      config: Self.fastConfig)
+    let viewModel = ReplayViewModel(
+      sources: [source], config: Self.fastConfig, contentFilter: ContentFilter())
+    viewModel.start()
+    await Self.waitForState(viewModel, timeout: .seconds(5)) { _ in
+      !Self.codePhaseLines(viewModel).isEmpty
+    }
+    #expect(
+      Self.codePhaseLines(viewModel).contains {
+        if case .eventInjected(let event) = $0 { return event == "a wild event appears" }
+        return false
+      })
+  }
+
+  // MARK: - Dual surface (inline line AND closing-card accumulator, #868/#884)
+
+  /// `.scoreUpdate` must BOTH append an inline line AND still feed the closing
+  /// card — the two surfaces are independent, so restoring the inline line must
+  /// not regress the ranking card.
+  @Test func scoreUpdateAppendsLineAndStillFeedsClosingCard() async throws {
+    let source = try Self.makeRankingSource(config: Self.holdConfig)
+    let viewModel = ReplayViewModel(
+      sources: [source], config: Self.holdConfig, contentFilter: ContentFilter())
+    viewModel.start()
+    await Self.waitForState(viewModel, timeout: .seconds(5)) { _ in
+      Self.hasResultCard(viewModel)
+    }
+    // Inline line present …
+    #expect(
+      Self.codePhaseLines(viewModel).contains {
+        if case .scoreUpdate(let scores) = $0 { return scores["Alice"] == 5 }
+        return false
+      })
+    // … AND the closing card still resolved from the same accumulator.
+    #expect(Self.hasResultCard(viewModel))
+  }
+
+  // MARK: - ContentFilter scope (defense-in-depth, header § "ContentFilter scope")
+
+  /// The assignment `value` is filtered (LLM/authored text) but the `agent`
+  /// name (structured identifier) passes through unchanged.
+  @Test func filtersAssignmentValueNotAgentName() async throws {
+    let yaml = """
+      schema_version: 1
+      turns:
+        - round: 1
+          phase_index: 1
+          phase_type: speak_all
+          agent: Alice
+          fields: { statement: 'hello' }
+      code_phase_events:
+        - round: 1
+          phase_index: 0
+          phase_type: assign
+          summary: 'Alice assigned: a secret topic'
+          payload:
+            kind: assignment
+            agent: Alice
+            value: 'a secret topic'
+      """
+    let source = try YAMLReplaySource(
+      yaml: yaml, scenario: Self.makeScenario(), config: Self.fastConfig)
+    let filter = ContentFilter(blockedPatterns: ["secret"], replacement: "XXX")
+    let viewModel = ReplayViewModel(
+      sources: [source], config: Self.fastConfig, contentFilter: filter)
+    viewModel.start()
+    await Self.waitForState(viewModel, timeout: .seconds(5)) { _ in
+      !Self.codePhaseLines(viewModel).isEmpty
+    }
+    guard
+      case .assignment(let agent, let value)? = Self.codePhaseLines(viewModel).first(where: {
+        if case .assignment = $0 { return true }
+        return false
+      })
+    else {
+      Issue.record("No assignment line in \(Self.codePhaseLines(viewModel))")
+      return
+    }
+    #expect(agent == "Alice")  // structured identifier — unfiltered
+    #expect(!value.contains("secret"))
+    #expect(value.contains("XXX"))
+  }
+
+  @Test func filtersSummaryText() async throws {
+    let yaml = """
+      schema_version: 1
+      turns:
+        - round: 1
+          phase_index: 0
+          phase_type: speak_all
+          agent: Alice
+          fields: { statement: 'hello' }
+      code_phase_events:
+        - round: 1
+          phase_index: 1
+          phase_type: summarize
+          summary: 'a secret recap'
+          payload:
+            kind: summary
+      """
+    let source = try YAMLReplaySource(
+      yaml: yaml, scenario: Self.makeScenario(), config: Self.fastConfig)
+    let filter = ContentFilter(blockedPatterns: ["secret"], replacement: "XXX")
+    let viewModel = ReplayViewModel(
+      sources: [source], config: Self.fastConfig, contentFilter: filter)
+    viewModel.start()
+    await Self.waitForState(viewModel, timeout: .seconds(5)) { _ in
+      !Self.codePhaseLines(viewModel).isEmpty
+    }
+    guard
+      case .summary(let text)? = Self.codePhaseLines(viewModel).first(where: {
+        if case .summary = $0 { return true }
+        return false
+      })
+    else {
+      Issue.record("No summary line in \(Self.codePhaseLines(viewModel))")
+      return
+    }
+    #expect(!text.contains("secret"))
+    #expect(text.contains("XXX"))
+  }
+}

--- a/Pastura/PasturaTests/App/ReplayViewModelTests+Pacing.swift
+++ b/Pastura/PasturaTests/App/ReplayViewModelTests+Pacing.swift
@@ -138,6 +138,48 @@ extension ReplayViewModelTests {
     #expect(viewModel.introFloorMs(forSourceIndex: 0, script: Self.demoScript) == 0)
   }
 
+  // MARK: - codePhaseFloorMs (reading reservation for narration lines, #932)
+
+  /// Structured/glanceable code-phase events (votes, scores, eliminations,
+  /// pairings) reserve no reading beat — they are covered by the closing card.
+  @Test func codePhaseFloorIsZeroForNonTextEvent() throws {
+    let viewModel = try Self.makeDemoPacedVM()
+    #expect(
+      viewModel.codePhaseFloorMs(
+        for: .voteResults(votes: [:], tallies: ["Alice": 2]), script: Self.demoScript) == 0)
+  }
+
+  /// A text-carrying assignment お題 reserves a pure reading dwell (no typing
+  /// term — code-phase lines render instantly). `readingDwell(len 3, dense,
+  /// normal) == 480` per `floorIsTypingPlusReadingDwell` above.
+  @Test func codePhaseFloorIsReadingDwellForAssignment() throws {
+    let viewModel = try Self.makeDemoPacedVM()  // .normal speed, cps 10
+    #expect(
+      viewModel.codePhaseFloorMs(
+        for: .assignment(agent: "Alice", value: "abc"), script: Self.demoScript) == 480)
+  }
+
+  /// `.instant` → nil cps → no reading floor (symmetric with `introFloorMs` /
+  /// `typingFloorMs` opt-out).
+  @Test func codePhaseFloorIsZeroAtInstantSpeed() throws {
+    let viewModel = try Self.makeDemoPacedVM()
+    viewModel.playbackSpeed = .instant
+    #expect(
+      viewModel.codePhaseFloorMs(
+        for: .assignment(agent: "Alice", value: "abc"), script: Self.demoScript) == 0)
+  }
+
+  /// No text ⇒ no floor: an empty summary and an `eventInjected` miss (`nil`)
+  /// both leave no phantom pre-next-event delay.
+  @Test func codePhaseFloorIsZeroForEmptyText() throws {
+    let viewModel = try Self.makeDemoPacedVM()
+    #expect(
+      viewModel.codePhaseFloorMs(for: .summary(text: ""), script: Self.demoScript) == 0)
+    #expect(
+      viewModel.codePhaseFloorMs(
+        for: .eventInjected(event: nil), script: Self.demoScript) == 0)
+  }
+
   // MARK: - scaledDelay floor application
 
   @Test func scaledDelayTakesFloorWhenFloorExceedsBase() throws {

--- a/Pastura/PasturaTests/App/ReplayViewModelTests+Rotation.swift
+++ b/Pastura/PasturaTests/App/ReplayViewModelTests+Rotation.swift
@@ -94,9 +94,12 @@ extension ReplayViewModelTests {
     // `.playing(1, 3)`.
     //
     // Per #208, mid-cycle rotation no longer wipes the chat stream.
-    // chatItems is now: source 0's 1 agent output, a boundary marker
-    // carrying source 1's scenario name, then source 1's 1 agent
-    // output. The compat-shim `agentOutputs` filters out the boundary.
+    // Each source now also contributes lifecycle chapter separators
+    // (#932 follow-up): per source = [roundSeparator, phaseSeparator,
+    // agentOutput]. So the full stream is 3 + boundary + 3 = 7 items:
+    // source 0's separators + turn, a boundary carrying source 1's name,
+    // then source 1's separators + turn. The compat-shim `agentOutputs`
+    // filters to just the two turns.
     let sources = try Self.makeTwoSources()
     let viewModel = ReplayViewModel(
       sources: sources, config: Self.holdConfig,
@@ -111,29 +114,32 @@ extension ReplayViewModelTests {
       }
       return false
     }
-    #expect(viewModel.chatItems.count == 3)
-    if case .agentOutput(let entry) = viewModel.chatItems[0] {
-      #expect(entry.output.statement == "demo 1 alice")
-    } else {
-      Issue.record(
-        "chatItems[0] expected .agentOutput, got \(viewModel.chatItems[0])")
+    #expect(viewModel.chatItems.count == 7)
+    // Exactly one boundary, carrying source 1's scenario name (both fixture
+    // sources use `makeScenario()` → name "Test").
+    let boundaryIndex = viewModel.chatItems.firstIndex {
+      if case .demoBoundary = $0 { return true }
+      return false
     }
-    if case .demoBoundary(_, let scenarioName) = viewModel.chatItems[1] {
-      // Both fixture sources are built from `makeScenario()` (name
-      // "Test"); the marker reads `sources[nextIndex].scenario.name`,
-      // which here is source 1's scenario.
+    guard let boundaryIndex else {
+      Issue.record("Expected a .demoBoundary, got \(viewModel.chatItems)")
+      return
+    }
+    if case .demoBoundary(_, let scenarioName) = viewModel.chatItems[boundaryIndex] {
       #expect(scenarioName == "Test")
-    } else {
-      Issue.record(
-        "chatItems[1] expected .demoBoundary, got \(viewModel.chatItems[1])")
     }
-    if case .agentOutput(let entry) = viewModel.chatItems[2] {
-      #expect(entry.output.statement == "demo 2 bob")
-    } else {
-      Issue.record(
-        "chatItems[2] expected .agentOutput, got \(viewModel.chatItems[2])")
+    // Alice's turn precedes the boundary; Bob's follows it.
+    let aliceIndex = viewModel.chatItems.firstIndex {
+      if case .agentOutput(let entry) = $0 { return entry.output.statement == "demo 1 alice" }
+      return false
     }
-    // Compat-shim view: boundary filtered out, both turns visible.
+    let bobIndex = viewModel.chatItems.firstIndex {
+      if case .agentOutput(let entry) = $0 { return entry.output.statement == "demo 2 bob" }
+      return false
+    }
+    #expect(aliceIndex.map { $0 < boundaryIndex } == true)
+    #expect(bobIndex.map { $0 > boundaryIndex } == true)
+    // Compat-shim view: separators + boundary filtered out, both turns visible.
     #expect(viewModel.agentOutputs.count == 2)
     #expect(viewModel.agentOutputs[0].output.statement == "demo 1 alice")
     #expect(viewModel.agentOutputs[1].output.statement == "demo 2 bob")


### PR DESCRIPTION
## Summary
Brings the DL-time demo replay's transcript to parity with the live simulation
for code-phase content. Two parts:

### 1. Restore dropped code-phase narration lines (the reported bug)
The demo replay silently dropped every code-phase narration event the live sim
renders inline — assign お題, round summaries, injected events, vote tallies,
score updates. For assign-based demos (chinkaitou_soudan, iiwake_battle) the
per-round お題 that grounds every agent response never showed.

- `ChatItem.codePhaseLine` + a `CodePhaseLine` variant per event; `apply()`
  appends the inline line **while still** updating the closing-card
  accumulators (#868/#884 intact).
- Rendered via `ModelDownloadHostView+CodePhaseRows.swift`, replicating the live
  `SimulationView+LogEntries.swift` helpers verbatim — same tokens + localized
  keys, **no new catalog entries**.
- ContentFilter on `assignment.value` / `summary.text` / `pairingResult.action*`
  (ADR-005 defense-in-depth; documented divergence from the live VM's raw
  append; curated demo content ⇒ no visible delta).
- `codePhaseFloorMs` reading-dwell floor keeps the お題 readable before the
  round's turns on fast playback.

### 2. Round / phase chapter separators
The demo showed no lifecycle markers; the live sim chunks its transcript into
round + phase "chapters" (#882). Added `.roundSeparator` / `.phaseSeparator`
ChatItems (appended on `.roundStarted` / `.phaseStarted`), rendered mirroring
the live dispatch — LLM phases → full-width rule around `PhaseTypeLabel`, code
phases → inline badge. Reuses the "Round %lld / %lld" key.

## Not in this PR (follow-up)
Unifying the **shared お題** (assignAll: every agent gets the same topic) so it
renders as ONE topic line instead of N per-agent lines requires a
`SimulationEvent.sharedAssignment` engine change touching Models/Engine/Data +
past-results + harness. That is a separate `feat` PR to keep this fix cleanly
revertable. Until then, this PR's demo still shows the shared お題 attributed to
the first agent (a strict improvement over showing nothing).

## Test plan
- New `ReplayViewModelTests+CodePhaseLines` (append / ordering お題→turns /
  dual-surface accumulator / ContentFilter scope / separators) + `+Pacing`
  codePhaseFloorMs cases. Existing count-pinning tests updated for separators.
  Full unit suite green (2514 tests); swiftlint --strict clean.
- **Device-QA gate** (pacing surface, view-testing.md rule 4): on
  chinkaitou_soudan / iiwake_battle demos, confirm the お題 is readable before
  the round's turns; check the boundary → intro-card → separator stack reads
  cleanly.

Closes #932

🤖 Generated with [Claude Code](https://claude.com/claude-code)