### PR TITLE
🐛 fix: stop premise/latest row re-typing on keep-running return

### DIFF
--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -120,6 +120,17 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   /// row animates; earlier rows render full text immediately).
   private(set) var latestAgentOutputId: UUID?
 
+  /// Whether the current ``latestAgentOutputId`` row has already finished its
+  /// typewriter reveal. Load-bearing for the ADR-017 Phase B "keep running"
+  /// adopt path: when a parked run is re-projected into a fresh `SimulationView`
+  /// (`SimulationSession.adoptIfMatching`), the row's per-view `visibleChars`
+  /// `@State` resets to its handoff seed and would re-type — even though the
+  /// user already watched it reveal. This flag lives on the surviving VM so the
+  /// re-projection restores it: ``effectiveCharsPerSecond(forEntryId:)`` returns
+  /// `nil` (static) for a completed latest row. Reset to `false` when a newer
+  /// row commits (it becomes the latest and hasn't revealed yet) and per `run()`.
+  private(set) var latestRowRevealCompleted = false
+
   /// Grapheme length of the most recently committed `.agentOutput` primary
   /// text (inner-thought excluded), captured in
   /// ``handleAgentOutput(agent:output:phaseType:)``. Drives the post-dispatch
@@ -267,8 +278,27 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   ///
   /// Uses ``PlaybackSpeed/charsPerSecond`` — the single typing-rate source of
   /// truth shared with the demo replay (``ReplayViewModel/typingCharsPerSecond``).
+  ///
+  /// Returns `nil` for the **latest** row once its reveal has completed
+  /// (``latestRowRevealCompleted``), so a fresh `AgentOutputRow` mount on the
+  /// ADR-017 Phase B adopt path snaps to full instead of re-typing. NOTE: this
+  /// makes the return value intentionally NON-constant across a row's lifetime
+  /// (it flips real-cps → `nil` at completion). `AgentOutputRow` tolerates that
+  /// because it starts its reveal in `.onAppear` and has no `.onChange(of:
+  /// charsPerSecond)` — do NOT add one, or a completed latest row would restart.
   func effectiveCharsPerSecond(forEntryId entryId: UUID) -> Double? {
-    speed.charsPerSecond
+    if entryId == latestAgentOutputId, latestRowRevealCompleted { return nil }
+    return speed.charsPerSecond
+  }
+
+  /// Records that the latest committed row has finished its typewriter reveal,
+  /// so a later View re-projection (adopt / keep-running return, ADR-017
+  /// Phase B) renders it static instead of re-typing. Guarded to the current
+  /// ``latestAgentOutputId`` — a stale completion from a row that is no longer
+  /// latest is ignored (that row already snaps to full via `isLatest == false`).
+  func markLatestRowRevealCompleted(entryId: UUID) {
+    guard entryId == latestAgentOutputId else { return }
+    latestRowRevealCompleted = true
   }
 
   /// Reveal-handoff seed for the committed row of `entryId`: the
@@ -604,6 +634,15 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   /// ``awaitIntroReveal()`` so a completion that fires *before* the gate is
   /// awaited (the common fast-reveal / slow-load case) is not missed.
   private var introRevealCompleted = false
+
+  /// Latch: the opening-card premise reveal has BEGUN (or already run) for this
+  /// run. Read by `SimulationView`'s premise-card `charsPerSecond` guard so the
+  /// card renders static on the ADR-017 Phase B adopt path: when a parked run is
+  /// re-projected into a fresh `SimulationView`, the view's `introHasTyped`
+  /// `@State` would reset and re-type the premise. Living on the surviving VM,
+  /// this latch survives re-projection. Set on the animated reveal's start
+  /// (`onRevealStarted` → ``markIntroRevealBegan()``); reset per `beginIntro`.
+  private(set) var introRevealHasBegun = false
   /// The suspended `run()` continuation, when the gate is awaited before the
   /// reveal completes. Stored-then-nilled on first resume so a second resume
   /// (timeout backstop / cancellation / late signal) can never trap.
@@ -628,6 +667,7 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   func beginIntro(revealBackstop: TimeInterval) {
     introGateArmed = true
     introRevealCompleted = false
+    introRevealHasBegun = false
     introTimeoutTask?.cancel()
     introTimeoutTask = Task { @MainActor [weak self] in
       try? await Task.sleep(for: .seconds(revealBackstop))
@@ -644,6 +684,14 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     introTimeoutTask?.cancel()
     introTimeoutTask = nil
     resumeIntroContinuation()
+  }
+
+  /// Signalled by the opening card when its typewriter reveal *starts* (only the
+  /// animated path fires it, per `ScenarioIntroCard.onRevealStarted`). Latches
+  /// ``introRevealHasBegun`` so a later View re-projection (ADR-017 Phase B
+  /// adopt) renders the premise static instead of re-typing.
+  func markIntroRevealBegan() {
+    introRevealHasBegun = true
   }
 
   /// Resumes the stored `run()` continuation exactly once (store-then-nil).
@@ -941,6 +989,7 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     // UUID no longer in `logEntries`, and `streamingSnapshot` could render a
     // stale in-flight row under a brand-new scenario.
     latestAgentOutputId = nil
+    latestRowRevealCompleted = false
     streamingSnapshot = nil
     streamingHandoffChars = [:]
     streamingRevealedChars = 0
@@ -1626,6 +1675,10 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     // animation to only the latest row — older rows snap to full text when
     // this id flips.
     latestAgentOutputId = entry.id
+    // The new latest row has not revealed yet — clear the completion latch so
+    // an adopt re-projection mid-reveal doesn't wrongly treat it as static
+    // (ADR-017 Phase B; see ``latestRowRevealCompleted``).
+    latestRowRevealCompleted = false
     if wasStreamed { streamingHandoffChars[entry.id] = handoffSeed }
     // Capture the reveal inputs so `holdAfterAgentOutput` can hold the next
     // turn until this row finishes typing from `handoffSeed` (bug 2). Uses

--- a/Pastura/Pastura/Views/Components/AgentOutputRow.swift
+++ b/Pastura/Pastura/Views/Components/AgentOutputRow.swift
@@ -125,6 +125,16 @@ struct AgentOutputRow: View {
   /// complete but the reveal is still catching up.)
   var onRevealProgress: (() -> Void)?
 
+  /// Invoked ONCE when the typewriter reveal reaches the full target length by
+  /// running to completion — NOT when it is cancelled mid-reveal (early unmount)
+  /// or snaps to full without animating. The live Sim latest row wires this so
+  /// ``SimulationViewModel`` can record that the row finished revealing, so a
+  /// later View re-projection (ADR-017 Phase B adopt / keep-running return)
+  /// renders it static instead of re-typing (#934). Fired from the animation
+  /// `Task` after its loop exits un-cancelled — deliberately NOT from the
+  /// `defer` (which also runs on cancellation).
+  var onRevealCompleted: (() -> Void)?
+
   /// Invoked on every reveal-counter tick with the current `visibleChars`.
   /// The **live Sim streaming row** passes this so ``SimulationViewModel``
   /// can record the reveal position and hand it off to the committed row at
@@ -236,6 +246,7 @@ struct AgentOutputRow: View {
     charsPerSecond: Double? = nil,
     onAnimatingChange: ((Bool) -> Void)? = nil,
     onRevealProgress: (() -> Void)? = nil,
+    onRevealCompleted: (() -> Void)? = nil,
     onStreamingRevealProgress: ((Int) -> Void)? = nil,
     streamingPrimary: String? = nil,
     streamingThought: String? = nil,
@@ -253,6 +264,7 @@ struct AgentOutputRow: View {
     self.charsPerSecond = charsPerSecond
     self.onAnimatingChange = onAnimatingChange
     self.onRevealProgress = onRevealProgress
+    self.onRevealCompleted = onRevealCompleted
     self.onStreamingRevealProgress = onStreamingRevealProgress
     self.streamingPrimary = streamingPrimary
     self.streamingThought = streamingThought
@@ -648,12 +660,15 @@ struct AgentOutputRow: View {
           if Task.isCancelled { return }
         }
       }
+      // Natural completion: the loop exited because the reveal reached the
+      // target, NOT via a cancellation `return` above. Record it so a later
+      // View re-projection (ADR-017 Phase B adopt) renders this row static
+      // instead of re-typing (#934). Deliberately here, not in the `defer` —
+      // the `defer` also runs on the cancellation paths.
+      if !Task.isCancelled && visibleChars >= targetLength {
+        onRevealCompleted?()
+      }
     }
-  }
-
-  private func snapToFull() {
-    animationTask?.cancel()
-    visibleChars = targetLength
   }
 
   /// React to a mid-stream primary / thought update.
@@ -845,6 +860,12 @@ extension AgentOutputRow {
   func characterAt(index: Int, in text: String) -> Character? {
     guard index >= 0, index < text.count else { return nil }
     return text[text.index(text.startIndex, offsetBy: index)]
+  }
+
+  /// Cancel any in-flight reveal and jump straight to the full text.
+  func snapToFull() {
+    animationTask?.cancel()
+    visibleChars = targetLength
   }
 
   /// Whether this row should run the character-reveal animation. The

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -55,11 +55,6 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
   // Accessed from SimulationView+Background.swift extension for the toggle subtitle.
   @State var scenario: Scenario?
   @State private var showScoreboard = false
-  /// Latches the opening card's premise reveal to a single run (#853): once the
-  /// typewriter *begins*, the card renders statically on any later re-mount
-  /// (e.g. scrolling back to the top) instead of re-typing — set at reveal
-  /// start so an interrupted reveal still latches.
-  @State private var introHasTyped = false
   /// Drives the final-ranking card's animated insertion at run completion
   /// (#868). Mirrors `viewModel.isCompleted`, but flipped inside `withAnimation`
   /// so the card fades/slides in — `isCompleted` is set on the VM outside any
@@ -171,6 +166,11 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
       if let adopted = session.adoptIfMatching(source: source) {
         viewModel = adopted
         scenario = session.scenario
+        // Deliberately NO reveal-state reset here: the adopted VM carries
+        // `introRevealHasBegun` / `latestRowRevealCompleted` from the original
+        // mount, and that survival is exactly what keeps the premise + latest
+        // row from re-typing on this re-projection (#934). `beginIntro` /
+        // `run()`'s reset run only on a fresh start, which this path bypasses.
         // Returning to the screen clears the view-hide park; if no other reason
         // holds (app-background / user-pause), the parked generate resumes.
         session.requestResume(reason: .viewHide)
@@ -496,20 +496,25 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
             // ForEach below. Title is `nil`: the header already shows the name.
             // Hidden when the scenario has no description (Model init? → nil).
             // The premise types in at the playback speed as the scene-setting
-            // beat; `introHasTyped` latches it to a single reveal so scrolling
-            // back to the top doesn't re-type (the card lives in this
-            // LazyVStack). `.instant` speed (`charsPerSecond == nil`) and
-            // Reduce Motion fall to the static path inside the card. Resume
-            // entries render statically (no typing, no gate) — the reveal beat
-            // is only for a fresh run's start. `onRevealComplete` releases the
-            // VM intro gate so the conversation starts after the reveal (#853).
+            // beat; `viewModel.introRevealHasBegun` latches it to a single
+            // reveal so scrolling back to the top doesn't re-type (the card
+            // lives in this LazyVStack). The latch lives on the VM (not View
+            // `@State`) so it survives an ADR-017 Phase B adopt re-projection —
+            // returning to a parked run must not re-type the premise (#934).
+            // `.instant` speed (`charsPerSecond == nil`) and Reduce Motion fall
+            // to the static path inside the card. Resume entries render
+            // statically (no typing, no gate) — the reveal beat is only for a
+            // fresh run's start. `onRevealComplete` releases the VM intro gate
+            // so the conversation starts after the reveal (#853).
             if let introModel {
               ScenarioIntroCard(
                 model: introModel,
-                charsPerSecond: (isResumeEntry || introHasTyped)
-                  ? nil : viewModel.speed.charsPerSecond,
+                charsPerSecond: Self.premiseCharsPerSecond(
+                  isResumeEntry: isResumeEntry,
+                  introRevealHasBegun: viewModel.introRevealHasBegun,
+                  speedCharsPerSecond: viewModel.speed.charsPerSecond),
                 leadIn: introLeadIn(for: viewModel.speed),
-                onRevealStarted: { introHasTyped = true },
+                onRevealStarted: { viewModel.markIntroRevealBegan() },
                 onRevealComplete: { viewModel.introRevealDidComplete() }
               )
             }
@@ -827,6 +832,20 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
     return false
   }
 
+  /// Typing speed for the opening premise card, or `nil` for the static (no
+  /// typing) path. Pure so the reveal-gate logic is unit-tested (ADR-009):
+  /// - Resume entries (`isResumeEntry`) never re-play the reveal beat.
+  /// - Once the reveal has begun (`introRevealHasBegun`, a VM latch that
+  ///   survives an ADR-017 Phase B adopt re-projection), the card is static so
+  ///   returning to a parked run doesn't re-type the premise (#934).
+  /// - Otherwise it types at the playback speed (`.instant` passes `nil` here,
+  ///   collapsing to the static path).
+  static func premiseCharsPerSecond(
+    isResumeEntry: Bool, introRevealHasBegun: Bool, speedCharsPerSecond: Double?
+  ) -> Double? {
+    (isResumeEntry || introRevealHasBegun) ? nil : speedCharsPerSecond
+  }
+
   /// A short "held breath" before the premise starts typing so the reveal
   /// doesn't begin abruptly on mount (#853). Scaled inversely with playback
   /// speed via `multiplier` (slow ⇒ longer, fast ⇒ shorter); `.instant`'s
@@ -976,6 +995,12 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
         // yanks back to the bottom.
         onRevealProgress: {
           if isLatest { scrollToBottom(proxy) }
+        },
+        // Record the latest row's reveal completion on the VM so an ADR-017
+        // Phase B adopt re-projection renders it static instead of re-typing
+        // (#934). Guarded to the latest row; the VM re-guards on entry id.
+        onRevealCompleted: {
+          if isLatest { viewModel.markLatestRowRevealCompleted(entryId: entry.id) }
         },
         // Grow the bubble with the revealed prefix so the handoff from the
         // streaming row is seamless (self-gates: only the latest animating

--- a/Pastura/PasturaTests/App/SimulationViewModelIntroGateTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelIntroGateTests.swift
@@ -93,4 +93,33 @@ struct SimulationViewModelIntroGateTests {
     #expect(resumed == true)
     #expect(sut.isPlayingIntro == false)
   }
+
+  // MARK: - Premise reveal-begun latch (#934, ADR-017 Phase B adopt path)
+
+  /// The latch starts false so a genuinely fresh run's premise types.
+  @Test func introRevealHasBegunStartsFalse() throws {
+    let sut = try makeSUT()
+    #expect(sut.introRevealHasBegun == false)
+  }
+
+  /// The card's `onRevealStarted` latches it — so a later View re-projection
+  /// (adopt / keep-running return) renders the premise static, not re-typed.
+  @Test func markIntroRevealBeganLatchesAcrossReprojection() throws {
+    let sut = try makeSUT()
+    sut.markIntroRevealBegan()
+    #expect(sut.introRevealHasBegun == true)
+    // Idempotent — a re-mounted card firing again keeps it latched.
+    sut.markIntroRevealBegan()
+    #expect(sut.introRevealHasBegun == true)
+  }
+
+  /// A brand-new run re-arms the gate and clears the begun-latch so its own
+  /// premise types from scratch.
+  @Test func beginIntroResetsRevealBegunLatch() throws {
+    let sut = try makeSUT()
+    sut.markIntroRevealBegan()
+    #expect(sut.introRevealHasBegun == true)
+    sut.beginIntro(revealBackstop: 60)
+    #expect(sut.introRevealHasBegun == false)
+  }
 }

--- a/Pastura/PasturaTests/App/SimulationViewModelStreamingTests+RevealCompletion.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelStreamingTests+RevealCompletion.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+/// Latest-row reveal-completion latch tests (#934) — the ADR-017 Phase B adopt
+/// path must NOT re-type the latest committed row when a parked run is
+/// re-projected into a fresh `SimulationView`. Split from
+/// `SimulationViewModelStreamingTests` to keep that suite under the
+/// `type_body_length` / `file_length` caps. Same suite via `extension` — NOT
+/// a new `@Suite` (Swift Testing runs suites in parallel; see
+/// `.claude/rules/testing.md`).
+///
+/// The reveal-completion FIRING (the natural-vs-cancel distinction inside
+/// `AgentOutputRow`'s animation `Task`) is animation-timing code and stays
+/// device-QA / code-review-gated per view-testing.md rule 4; these tests pin
+/// the pure VM decision logic that the firing drives.
+extension SimulationViewModelStreamingTests {
+
+  // MARK: - Reveal-completion latch (latest row static after it finished)
+
+  @Test func latestRowIsStaticOnceRevealCompleted() throws {
+    let (sut, scenario) = try makeSUT()
+    sut.speed = .normal
+    sut.handleEvent(
+      .phaseStarted(phaseType: .speakAll, phasePath: [0]), scenario: scenario)
+    sut.handleEvent(
+      .agentOutput(
+        agent: "Alice", output: TurnOutput(fields: ["statement": "hello"]),
+        phaseType: .speakAll),
+      scenario: scenario)
+
+    let id = try #require(sut.latestAgentOutputId)
+    // Before completion the latest row still animates at cps.
+    #expect(sut.effectiveCharsPerSecond(forEntryId: id) == PlaybackSpeed.normal.charsPerSecond)
+
+    sut.markLatestRowRevealCompleted(entryId: id)
+    // After completion it must render static so an adopt re-projection does not
+    // re-type it.
+    #expect(sut.effectiveCharsPerSecond(forEntryId: id) == nil)
+  }
+
+  @Test func markLatestRowRevealCompletedIgnoresStaleEntry() throws {
+    let (sut, scenario) = try makeSUT()
+    sut.speed = .normal
+    sut.handleEvent(
+      .phaseStarted(phaseType: .speakAll, phasePath: [0]), scenario: scenario)
+    sut.handleEvent(
+      .agentOutput(
+        agent: "Alice", output: TurnOutput(fields: ["statement": "hi"]),
+        phaseType: .speakAll),
+      scenario: scenario)
+    let aliceId = try #require(sut.latestAgentOutputId)
+    // A newer row commits — Alice is no longer the latest.
+    sut.handleEvent(
+      .agentOutput(
+        agent: "Bob", output: TurnOutput(fields: ["statement": "yo"]),
+        phaseType: .speakAll),
+      scenario: scenario)
+    let bobId = try #require(sut.latestAgentOutputId)
+
+    // A stale completion for the no-longer-latest row is ignored.
+    sut.markLatestRowRevealCompleted(entryId: aliceId)
+    #expect(sut.effectiveCharsPerSecond(forEntryId: bobId) == PlaybackSpeed.normal.charsPerSecond)
+
+    // The current latest row's completion does latch.
+    sut.markLatestRowRevealCompleted(entryId: bobId)
+    #expect(sut.effectiveCharsPerSecond(forEntryId: bobId) == nil)
+  }
+
+  @Test func newCommitResetsCompletionLatch() throws {
+    let (sut, scenario) = try makeSUT()
+    sut.speed = .normal
+    sut.handleEvent(
+      .phaseStarted(phaseType: .speakAll, phasePath: [0]), scenario: scenario)
+    sut.handleEvent(
+      .agentOutput(
+        agent: "Alice", output: TurnOutput(fields: ["statement": "hi"]),
+        phaseType: .speakAll),
+      scenario: scenario)
+    let aliceId = try #require(sut.latestAgentOutputId)
+    sut.markLatestRowRevealCompleted(entryId: aliceId)
+    #expect(sut.effectiveCharsPerSecond(forEntryId: aliceId) == nil)
+
+    // A newer row commits — the latch resets so the fresh latest row animates.
+    sut.handleEvent(
+      .agentOutput(
+        agent: "Bob", output: TurnOutput(fields: ["statement": "yo"]),
+        phaseType: .speakAll),
+      scenario: scenario)
+    let bobId = try #require(sut.latestAgentOutputId)
+    #expect(sut.effectiveCharsPerSecond(forEntryId: bobId) == PlaybackSpeed.normal.charsPerSecond)
+  }
+}

--- a/Pastura/PasturaTests/Views/SimulationViewLeaveGuardTests.swift
+++ b/Pastura/PasturaTests/Views/SimulationViewLeaveGuardTests.swift
@@ -114,4 +114,36 @@ struct SimulationViewLeaveGuardTests {
       SimulationView.disappearAction(
         leaveHandled: false, owns: true, keepRunningEnabled: false, isGuarded: true) == .end)
   }
+
+  // MARK: - Premise reveal gate (#934, ADR-017 Phase B adopt path)
+
+  @Test func premiseTypesOnFreshRunFirstReveal() {
+    // Not a resume, reveal not yet begun → types at the playback speed.
+    #expect(
+      SimulationView.premiseCharsPerSecond(
+        isResumeEntry: false, introRevealHasBegun: false, speedCharsPerSecond: 30) == 30)
+  }
+
+  @Test func premiseStaticOnceRevealHasBegun() {
+    // The VM latch survives an adopt re-projection, so a returning parked run
+    // renders the premise static instead of re-typing (#934).
+    #expect(
+      SimulationView.premiseCharsPerSecond(
+        isResumeEntry: false, introRevealHasBegun: true, speedCharsPerSecond: 30) == nil)
+  }
+
+  @Test func premiseStaticOnResumeEntry() {
+    // The checkpoint `.resume` path never plays the reveal beat, regardless of
+    // the latch.
+    #expect(
+      SimulationView.premiseCharsPerSecond(
+        isResumeEntry: true, introRevealHasBegun: false, speedCharsPerSecond: 30) == nil)
+  }
+
+  @Test func premiseStaticAtInstantSpeed() {
+    // `.instant` passes `nil` cps → static even on a fresh first reveal.
+    #expect(
+      SimulationView.premiseCharsPerSecond(
+        isResumeEntry: false, introRevealHasBegun: false, speedCharsPerSecond: nil) == nil)
+  }
 }


### PR DESCRIPTION
## Summary
On the ADR-017 Phase B "keep running" adopt path — returning to a parked run via the in-flight indicator (`SimulationSession.adoptIfMatching`, source stays `.scenario`) — a fresh `SimulationView` re-projects the surviving VM and **re-typed the premise card and the latest conversation row**. Root cause: the "already fully revealed" state lived only in per-View `@State` (`introHasTyped`) and per-row `@State` (`AgentOutputRow.visibleChars`), so it was lost on the re-mount.

The genuine checkpoint `.resume` path (Home paused-card) was already correctly guarded (`isResumeEntry` + `latestAgentOutputId == nil` after replay) and is unaffected.

## Changes
- **VM (`SimulationViewModel`)** holds the "already revealed" state so it survives re-projection:
  - `introRevealHasBegun` latch (`markIntroRevealBegan()`, reset in `beginIntro`).
  - `latestRowRevealCompleted` + latest-only `markLatestRowRevealCompleted(entryId:)`, reset on each new row commit and per `run()`.
  - `effectiveCharsPerSecond(forEntryId:)` returns `nil` (static) for a completed latest row.
- **View/Row wiring**: premise gate reads `viewModel.introRevealHasBegun` via a pure `SimulationView.premiseCharsPerSecond`; `AgentOutputRow.onRevealCompleted` fires once on **natural** loop completion (not on cancel — outside the `defer`) and the latest-row callsite records it. Dropped the per-view `introHasTyped` `@State`.

## Scope note
A run parked *before* the latest row finishes revealing still re-types its tail from the handoff seed on return — accepted and self-healing (the resumed reveal completes and re-latches). Documented as an intended boundary.

## Test plan
- New unit tests (pure-logic per ADR-009 / view-testing.md rule 4): `effectiveCharsPerSecond` latest×completed→nil / latest×incomplete→cps, `markLatestRowRevealCompleted` latest-only guard + reset-on-commit, `introRevealHasBegun` set/reset, and `premiseCharsPerSecond` truth table (fresh/adopt/resume/instant).
- Full unit suite green (2510 tests), `swiftlint --strict` clean.
- Reveal-completion animation-timing firing is code-review-gated (view-testing.md rule 4); **device QA**: with "keep running" enabled, leave a run mid-conversation, return via the in-flight pill, confirm the premise and prior turns render statically (no re-typing) and only genuinely new turns animate.

Closes #934

🤖 Generated with [Claude Code](https://claude.com/claude-code)