### PR TITLE
✨ feat: reflect phase (agent private memos) + opt-in log window (#907)

### DIFF
--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -212,6 +212,14 @@ Port directly from Python prototype `parse_json_response()`. Must handle:
    pipeline still fires on a genuinely-unclosed object. (#751 sub-class 1)
 4. All values normalized to String in TurnOutput
 
+**Schema-guarded multi-object salvage (#907).** When the happy-path parse
+fails AND `expectedKeys` is non-empty, `parse(_:expectedKeys:)` re-extracts
+the first balanced object with `allowObjectResidue: true` (overriding the
+#751 refusal) and accepts it only if it carries ALL expected keys with
+content — repairKind `multi_object_salvage`. The schema-less path
+(`parse(_:)`) keeps the #751 refusal verbatim. Single-field grammars made
+the multi-object shape dominant, so retrying that span never converges.
+
 ### Retry Policy
 
 Max 2 retries. Retry on:
@@ -234,6 +242,13 @@ scan recovers it. An incomplete object still fails parse and consumes the
 retry budget as before. `LLMCaller`'s retry routing on this error stays as
 defense in depth for any other surfacer (#885). The `samplerCrashCaught`
 diagnostic still fires once per catch for occurrence-rate telemetry.
+
+`GBNFGrammarBuilder`'s `trailing` production is a BOUNDED chain
+(`trailingByteBudget` = 16 links) rather than an unbounded self-reference:
+the unbounded form accepted unlimited printable ASCII after the close,
+inviting the fabricated follow-on objects behind the salvage above (#907).
+Overflow past the budget lands on this catch-as-EOS path — benign, the
+object is already complete.
 
 ## Content Filter
 

--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -223,6 +223,18 @@ position-0 suspected) exhausts the retry budget. It is inference-side, not
 parser-recoverable — root-cause on-device per the issue before adding any
 retry-budget change. Tracked under #751.
 
+**Grammar-accept crash after object completion → graceful stop (#907).** For
+single-field grammars (e.g. `reflect`'s `{ note }`) Gemma 4 E2B frequently
+completes the JSON object then keeps generating, tripping the caught
+grammar-accept crash (`LLMError.samplerCrashCaught`). The generation loops
+(`LlamaCppService.runGeneration` / `runStreamGeneration`) now catch it as
+end-of-generation (like an EOG break) instead of failing — the completed
+object is already in the accumulated text, so the parser's balanced-brace
+scan recovers it. An incomplete object still fails parse and consumes the
+retry budget as before. `LLMCaller`'s retry routing on this error stays as
+defense in depth for any other surfacer (#885). The `samplerCrashCaught`
+diagnostic still fires once per catch for occurrence-rate telemetry.
+
 ## Content Filter
 
 Applied BETWEEN Engine output and UI display (not inside Engine).

--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -26,6 +26,7 @@ includes them.
 | speak_each   | LLM        | Agents speak in turn (accumulating)  |
 | vote         | LLM        | All agents vote for one agent        |
 | choose       | LLM        | Choose from options                  |
+| reflect      | LLM        | Each agent privately updates a short memo (`note`) |
 | score_calc   | Code       | Calculate scores                     |
 | assign       | Code       | Distribute info to agents            |
 | eliminate    | Code       | Remove most-voted agent              |
@@ -37,6 +38,16 @@ includes them.
 assign / score_calc nesting) — `ConditionalHandler.subHandlers` includes
 it, and `ScenarioValidator.validateBranch` runs the same shape-check it
 applies at the top level.
+
+`reflect` is an LLM phase: each non-eliminated agent makes one call
+producing `{ note }` — a private memo stored under the reserved
+`notes_<name>` key in `state.variables` and surfaced back to only that
+agent (system-prompt section + `{my_notes}` template variable). Notes
+never enter the conversation log or `lastOutputs`; the canonical `note`
+output is itself the private reasoning, so reflect declares no secondary
+thought field. `reflect` is NOT allowed inside `conditional` branches —
+`ScenarioValidator.validateBranch` rejects it at load time and
+`ConditionalHandler.subHandlers` omits it.
 
 ### PhaseHandler Protocol
 
@@ -61,8 +72,8 @@ the only mutable argument. Handlers are registered in PhaseDispatcher as a
 [PhaseType: PhaseHandler] dictionary.
 
 `phasePath` identifies the handler's position in the scenario. Top-level
-handlers get `[K]`; handlers that dispatch sub-phases (conditional today,
-event_inject / reflect later) append the sub-phase index so inner lifecycle
+handlers get `[K]`; handlers that dispatch sub-phases (conditional today)
+append the sub-phase index so inner lifecycle
 events can be attributed to their enclosing branch. `pauseCheck` is a narrow
 bridge onto `SimulationRunner.checkPaused`; handlers running sub-phases
 must call it between each one so the user's pause request is honored at
@@ -89,6 +100,7 @@ Cancellation uses standard Swift `Task` cancellation.
 | agents           | ≥ 2     | Error if below      |
 | agents           | ≤ 10    | Error if exceeded   |
 | rounds           | ≤ 30    | Error if exceeded   |
+| log_window       | ≥ 1     | Error if below (when present) |
 | est. inferences  | > 50    | Warning displayed   |
 | est. inferences  | > 100   | Error, block run    |
 
@@ -115,6 +127,7 @@ See `ScenarioValidator` for the gate; #665 for the boundary rationale.
 speak_all:  agentCount per round
 speak_each: agentCount × subRounds per round
 vote:       agentCount per round
+reflect:    agentCount per round
 choose:     agentCount × 2 for round_robin (N adjacent pairs, 2 calls each)
             agentCount for individual (no pairing)
 score_calc/assign/eliminate/summarize/event_inject: 0 (code phases)
@@ -129,6 +142,17 @@ The same `max` reduction is used for BOTH the >50 warning and the >100
 hard cap (see `ScenarioLoader.estimatePhase`). Using `sum(both)` anywhere
 would over-count by construction — a rarely-taken expensive branch would
 reject scenarios that in practice spend ≤ `max` inferences per round.
+
+### Conversation-Log Window (`log_window`)
+
+Scenario-level opt-in (`log_window: N`, N ≥ 1; absent = full log). Trims
+the conversation log passed to LLM prompts to the last N entries
+(`PromptBuilder.formatConversationLog(window:)`, threaded by all five LLM
+handlers from `scenario.logWindow`). **Prompt-side only** — TurnRecord
+persistence, replay, and export keep the full log. Interaction: the
+window truncates the same log the #911 speak_each address rule reads, so
+keep N ≥ agentCount for accumulating (speak_each) scenarios or same-round
+earlier speakers vanish from the addressee pool.
 
 ### Pairing Data Flow (choose phase)
 
@@ -227,8 +251,8 @@ nonisolated public enum SimulationEvent: Sendable, Equatable {
     case roundCompleted(round: Int, scores: [String: Int])
 
     // Phase lifecycle. `phasePath` is `[K]` for top-level phase K; nested
-    // sub-phases carry `[K, N]` so future phase types with sub-phases
-    // (conditional / event_inject / reflect) share one identifier shape.
+    // sub-phases carry `[K, N]` so future phase types with nested
+    // sub-phases share one identifier shape.
     case phaseStarted(phaseType: PhaseType, phasePath: [Int])
     case phaseCompleted(phaseType: PhaseType, phasePath: [Int])
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ Phase 2 progress:
 - **Launch animation** — cold "Pastoral Drift" + warm "Breath" hybrid; per-scene `LaunchPhaseCoordinator` + Reduce Motion fallback (#412/#415)
 - **Home redesign** — bottom-tab IA (ADR-016, #602) + pause/resume of an interrupted run from the Home card (P3: round-boundary checkpoint producer #662, resume consumer + historical-log replay #667, confirm-on-leave pause for in-flight runs #673)
 - **Viewer prediction** — pre-vote-reveal prediction sheet ("who is the wolf?" / "who is #1?") + hit / consecutive-streak tracking; Engine-untouched App/ViewModel event buffering, ground truth scored at the reveal moment (#906 umbrella / #915)
+- **Reflect phase + log window** — per-agent private memo (`reflect` LLM phase, reserved `notes_<name>` namespace, own-prompt re-injection) + opt-in `log_window` prompt-side log trimming; presets unchanged pending per-scenario tuning (#906 umbrella / #907)
 
 ## Language Rules
 

--- a/Pastura/Pastura/App/ScenarioEditorViewModel.swift
+++ b/Pastura/Pastura/App/ScenarioEditorViewModel.swift
@@ -65,6 +65,11 @@ final class ScenarioEditorViewModel {  // swiftlint:disable:this type_body_lengt
   var editorSimulationLanguage: String?
   var agentCount: Int = 2
   var rounds: Int = 1
+  /// Optional prompt-side conversation-log window (#907). No Visual UI yet —
+  /// carry-through only, so a value set in YAML mode (`log_window:`) survives a
+  /// visual-mode save instead of being silently dropped. Mirrors
+  /// `editorSimulationLanguage`.
+  var editorLogWindow: Int?
   var context: String = ""
   var personas: [EditablePersona] = []
   var phases: [EditablePhase] = []
@@ -453,6 +458,7 @@ final class ScenarioEditorViewModel {  // swiftlint:disable:this type_body_lengt
       context: context,
       personas: personas.map { $0.toPersona() },
       phases: phases.map { $0.toPhase() },
+      logWindow: editorLogWindow,
       extraData: carriedExtraData
     )
   }
@@ -466,6 +472,7 @@ final class ScenarioEditorViewModel {  // swiftlint:disable:this type_body_lengt
     editorSimulationLanguage = scenario.simulationLanguage
     agentCount = scenario.agentCount
     rounds = scenario.rounds
+    editorLogWindow = scenario.logWindow
     context = scenario.context
     personas = scenario.personas.map { EditablePersona(from: $0) }
     phases = scenario.phases.map { EditablePhase(from: $0) }

--- a/Pastura/Pastura/Engine/LLMCaller+StreamFailure.swift
+++ b/Pastura/Pastura/Engine/LLMCaller+StreamFailure.swift
@@ -23,13 +23,15 @@ nonisolated extension LLMCaller {
   /// Whether a failed inference stream should be retried, emitting the
   /// `retryCause` diagnostic as a side effect when it should.
   ///
-  /// A caught sampler crash (``LLMError/samplerCrashCaught``) is sampling
-  /// noise, not a deterministic per-(model, prompt, schema) defect (#885):
-  /// the model continued past the completed JSON object with a token
-  /// (often CJK) outside the grammar's ASCII trailing set, so a fresh
-  /// inference of the same inputs usually succeeds — it is retried while
-  /// budget remains. Every **other** throw returns `false` and keeps the
-  /// immediate abort: `.suspended` is already absorbed upstream in
+  /// A caught sampler crash (``LLMError/samplerCrashCaught``) is retried
+  /// while budget remains. As of #907 the generation loops intercept the
+  /// common case (post-object-completion continuation) as end-of-generation,
+  /// so this rarely fires; it remains defense in depth for any other
+  /// surfacer of the error (#885) — the trigger is sampling noise, not a
+  /// deterministic per-(model, prompt, schema) defect, so a fresh inference
+  /// of the same inputs usually succeeds. Every **other** throw returns
+  /// `false` and keeps the immediate abort: `.suspended` is absorbed
+  /// upstream in
   /// `consumeStreamWithSuspendRetry`, cancellation must propagate, and
   /// `.invalidGrammar` is a fail-fast engineering bug (its doc-comment
   /// rejects the 3× retry charade).

--- a/Pastura/Pastura/Engine/LLMCaller.swift
+++ b/Pastura/Pastura/Engine/LLMCaller.swift
@@ -89,9 +89,9 @@ nonisolated struct LLMCaller: Sendable {
       } catch {
         // Tokens are unknown on failure — the backend didn't complete generation.
         emitInferenceCompleted(agent: agentName, since: startTime, tokens: nil, emitter: emitter)
-        // A caught sampler crash is retryable sampling noise (#885); every
-        // other throw aborts. See `shouldRetryStreamFailure`. On exhaustion
-        // the caught what() still surfaces via `readableDescription`.
+        // The generation loops intercept the common sampler-crash case as
+        // end-of-generation (#907); this retry is defense in depth (#885).
+        // Other throws abort. See `shouldRetryStreamFailure`.
         if shouldRetryStreamFailure(error, agent: agentName, attempt: attempt) {
           continue
         }

--- a/Pastura/Pastura/Engine/PhaseDispatcher.swift
+++ b/Pastura/Pastura/Engine/PhaseDispatcher.swift
@@ -18,7 +18,8 @@ nonisolated struct PhaseDispatcher: Sendable {
       .eliminate: EliminateHandler(),
       .summarize: SummarizeHandler(),
       .conditional: ConditionalHandler(),
-      .eventInject: EventInjectHandler()
+      .eventInject: EventInjectHandler(),
+      .reflect: ReflectHandler()
     ]
   }
 

--- a/Pastura/Pastura/Engine/PhaseHandler.swift
+++ b/Pastura/Pastura/Engine/PhaseHandler.swift
@@ -26,9 +26,9 @@ nonisolated public struct PhaseContext: Sendable {
 
   /// The path identifying this handler's position in the scenario. Top-level
   /// handlers run with `[K]`; sub-phases inside a conditional run with
-  /// `[K, N]`. Handlers that dispatch nested sub-phases (conditional today,
-  /// event_inject / reflect tomorrow) must append the sub-phase index when
-  /// constructing lifecycle events for the inner work.
+  /// `[K, N]`. Handlers that dispatch nested sub-phases (conditional today)
+  /// must append the sub-phase index when constructing lifecycle events for
+  /// the inner work.
   public let phasePath: [Int]
 
   /// Optional language detector used by ``LLMCaller`` for ADR-010 Step E PR2

--- a/Pastura/Pastura/Engine/Phases/ChooseHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/ChooseHandler.swift
@@ -92,6 +92,7 @@ nonisolated struct ChooseHandler: PhaseHandler {
     variables["conversation_log"] = promptBuilder.formatConversationLog(
       state.conversationLog, language: context.scenario.engineLanguage)
     promptBuilder.injectAssigned(into: &variables, personaName: persona.name)
+    promptBuilder.injectNotes(into: &variables, personaName: persona.name)
     let userPrompt = promptBuilder.expandTemplate(promptTemplate, variables: variables)
 
     let output = try await llmCaller.call(
@@ -126,6 +127,7 @@ nonisolated struct ChooseHandler: PhaseHandler {
       variables["conversation_log"] = promptBuilder.formatConversationLog(
         state.conversationLog, language: context.scenario.engineLanguage)
       promptBuilder.injectAssigned(into: &variables, personaName: persona.name)
+      promptBuilder.injectNotes(into: &variables, personaName: persona.name)
       let userPrompt = promptBuilder.expandTemplate(promptTemplate, variables: variables)
 
       let output = try await llmCaller.call(

--- a/Pastura/Pastura/Engine/Phases/ChooseHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/ChooseHandler.swift
@@ -90,7 +90,8 @@ nonisolated struct ChooseHandler: PhaseHandler {
     variables["opponent_name"] = opponent.name
     variables["scoreboard"] = promptBuilder.formatScoreboard(state.scores)
     variables["conversation_log"] = promptBuilder.formatConversationLog(
-      state.conversationLog, language: context.scenario.engineLanguage)
+      state.conversationLog, language: context.scenario.engineLanguage,
+      window: context.scenario.logWindow)
     promptBuilder.injectAssigned(into: &variables, personaName: persona.name)
     promptBuilder.injectNotes(into: &variables, personaName: persona.name)
     let userPrompt = promptBuilder.expandTemplate(promptTemplate, variables: variables)
@@ -125,7 +126,8 @@ nonisolated struct ChooseHandler: PhaseHandler {
       var variables = state.variables
       variables["scoreboard"] = promptBuilder.formatScoreboard(state.scores)
       variables["conversation_log"] = promptBuilder.formatConversationLog(
-        state.conversationLog, language: context.scenario.engineLanguage)
+        state.conversationLog, language: context.scenario.engineLanguage,
+        window: context.scenario.logWindow)
       promptBuilder.injectAssigned(into: &variables, personaName: persona.name)
       promptBuilder.injectNotes(into: &variables, personaName: persona.name)
       let userPrompt = promptBuilder.expandTemplate(promptTemplate, variables: variables)

--- a/Pastura/Pastura/Engine/Phases/ReflectHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/ReflectHandler.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+/// Handles `reflect` phases where each agent privately updates a personal memo.
+///
+/// Each non-eliminated agent makes one LLM call producing `{ note }` — a short
+/// private memo (impressions, suspicions, plans). The note is stored under the
+/// reserved per-persona key `notes_<name>` in ``SimulationState/variables``
+/// (mirroring the `assigned_<name>` namespace, see
+/// ``PromptBuilder/injectNotes(into:personaName:)``) and surfaced back to that
+/// agent — and only that agent — in every subsequent LLM call's system prompt.
+///
+/// Unlike the speak handlers, the note is **private**: it is never appended to
+/// `conversationLog` (so other agents can't see it) and never written to
+/// `lastOutputs` (so it doesn't replace the public last output). Only the
+/// `.agentOutput` event is emitted, keeping the persistence / UI / replay flow
+/// identical to the other LLM phases.
+nonisolated struct ReflectHandler: PhaseHandler {
+  private let promptBuilder = PromptBuilder()
+  private let llmCaller = LLMCaller()
+
+  func execute(
+    context: PhaseContext,
+    state: inout SimulationState
+  ) async throws {
+    let promptTemplate =
+      context.phase.prompt
+      ?? pickLanguage(
+        context.scenario.engineLanguage,
+        ja: "これまでの会話: {conversation_log}\nこれまでの状況を踏まえ、所感・警戒・今後の方針を自分用のメモとして更新してください。",
+        en:
+          "Conversation so far: {conversation_log}\nUpdate your private notes: impressions, suspicions, and your plan going forward."
+      )
+
+    for persona in context.scenario.personas {
+      guard state.eliminated[persona.name] != true else { continue }
+
+      let systemPrompt = promptBuilder.buildSystemPrompt(
+        scenario: context.scenario, persona: persona, phase: context.phase, state: state
+      )
+
+      var variables = state.variables
+      variables["scoreboard"] = promptBuilder.formatScoreboard(state.scores)
+      variables["conversation_log"] = promptBuilder.formatConversationLog(
+        state.conversationLog, language: context.scenario.engineLanguage)
+      promptBuilder.injectAssigned(into: &variables, personaName: persona.name)
+      promptBuilder.injectNotes(into: &variables, personaName: persona.name)
+      let userPrompt = promptBuilder.expandTemplate(promptTemplate, variables: variables)
+
+      let output = try await llmCaller.call(
+        llm: context.llm, system: systemPrompt, user: userPrompt,
+        agentName: persona.name,
+        schema: OutputSchema.from(phase: context.phase),
+        detector: context.detector,
+        expectedLanguage: context.scenario.engineLanguage,
+        suspendController: context.suspendController,
+        emitter: context.emitter
+      )
+
+      context.emitter(
+        .agentOutput(agent: persona.name, output: output, phaseType: context.phase.type))
+
+      // Persist the memo privately under the reserved `notes_<name>` namespace.
+      // Only write a non-empty note: a failed/empty inference (LLMCaller returns
+      // "" after exhausting the empty-field retry budget) must not erase the
+      // agent's memo from a previous round.
+      let note = output.fields["note"] ?? ""
+      if !note.isEmpty {
+        state.variables["notes_\(persona.name)"] = note
+      }
+
+      // Deliberately NOT appended to `conversationLog`: the note is private, so
+      // other agents (whose prompts include the log) must never see it.
+      // Deliberately NOT written to `lastOutputs`: the public last output must
+      // not be replaced by a private memo (it feeds `{last_output}`-style
+      // downstream reads and the public display).
+    }
+  }
+}

--- a/Pastura/Pastura/Engine/Phases/ReflectHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/ReflectHandler.swift
@@ -41,7 +41,8 @@ nonisolated struct ReflectHandler: PhaseHandler {
       var variables = state.variables
       variables["scoreboard"] = promptBuilder.formatScoreboard(state.scores)
       variables["conversation_log"] = promptBuilder.formatConversationLog(
-        state.conversationLog, language: context.scenario.engineLanguage)
+        state.conversationLog, language: context.scenario.engineLanguage,
+        window: context.scenario.logWindow)
       promptBuilder.injectAssigned(into: &variables, personaName: persona.name)
       promptBuilder.injectNotes(into: &variables, personaName: persona.name)
       let userPrompt = promptBuilder.expandTemplate(promptTemplate, variables: variables)

--- a/Pastura/Pastura/Engine/Phases/SpeakAllHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/SpeakAllHandler.swift
@@ -29,7 +29,8 @@ nonisolated struct SpeakAllHandler: PhaseHandler {
       var variables = state.variables
       variables["scoreboard"] = promptBuilder.formatScoreboard(state.scores)
       variables["conversation_log"] = promptBuilder.formatConversationLog(
-        state.conversationLog, language: context.scenario.engineLanguage)
+        state.conversationLog, language: context.scenario.engineLanguage,
+        window: context.scenario.logWindow)
       promptBuilder.injectAssigned(into: &variables, personaName: persona.name)
       promptBuilder.injectNotes(into: &variables, personaName: persona.name)
       let userPrompt = promptBuilder.expandTemplate(promptTemplate, variables: variables)

--- a/Pastura/Pastura/Engine/Phases/SpeakAllHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/SpeakAllHandler.swift
@@ -31,6 +31,7 @@ nonisolated struct SpeakAllHandler: PhaseHandler {
       variables["conversation_log"] = promptBuilder.formatConversationLog(
         state.conversationLog, language: context.scenario.engineLanguage)
       promptBuilder.injectAssigned(into: &variables, personaName: persona.name)
+      promptBuilder.injectNotes(into: &variables, personaName: persona.name)
       let userPrompt = promptBuilder.expandTemplate(promptTemplate, variables: variables)
 
       let output = try await llmCaller.call(

--- a/Pastura/Pastura/Engine/Phases/SpeakEachHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/SpeakEachHandler.swift
@@ -33,6 +33,7 @@ nonisolated struct SpeakEachHandler: PhaseHandler {
         variables["conversation_log"] = promptBuilder.formatConversationLog(
           state.conversationLog, language: context.scenario.engineLanguage)
         promptBuilder.injectAssigned(into: &variables, personaName: persona.name)
+        promptBuilder.injectNotes(into: &variables, personaName: persona.name)
         let userPrompt = promptBuilder.expandTemplate(promptTemplate, variables: variables)
 
         let output = try await llmCaller.call(

--- a/Pastura/Pastura/Engine/Phases/SpeakEachHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/SpeakEachHandler.swift
@@ -31,7 +31,8 @@ nonisolated struct SpeakEachHandler: PhaseHandler {
         var variables = state.variables
         variables["scoreboard"] = promptBuilder.formatScoreboard(state.scores)
         variables["conversation_log"] = promptBuilder.formatConversationLog(
-          state.conversationLog, language: context.scenario.engineLanguage)
+          state.conversationLog, language: context.scenario.engineLanguage,
+          window: context.scenario.logWindow)
         promptBuilder.injectAssigned(into: &variables, personaName: persona.name)
         promptBuilder.injectNotes(into: &variables, personaName: persona.name)
         let userPrompt = promptBuilder.expandTemplate(promptTemplate, variables: variables)

--- a/Pastura/Pastura/Engine/Phases/VoteHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/VoteHandler.swift
@@ -34,18 +34,14 @@ nonisolated struct VoteHandler: PhaseHandler {
         scenario: context.scenario, persona: persona, phase: context.phase, state: state
       )
 
-      let candidates = context.scenario.personas
-        .map(\.name)
-        .filter { name in
-          if excludeSelf && name == persona.name { return false }
-          if state.eliminated[name] == true { return false }
-          return true
-        }
+      let candidates = voteCandidates(
+        scenario: context.scenario, voter: persona, excludeSelf: excludeSelf, state: state)
 
       var variables = state.variables
       variables["scoreboard"] = promptBuilder.formatScoreboard(state.scores)
       variables["conversation_log"] = promptBuilder.formatConversationLog(
-        state.conversationLog, language: context.scenario.engineLanguage)
+        state.conversationLog, language: context.scenario.engineLanguage,
+        window: context.scenario.logWindow)
       variables["candidates"] = candidates.joined(separator: ", ")
       promptBuilder.injectAssigned(into: &variables, personaName: persona.name)
       promptBuilder.injectNotes(into: &variables, personaName: persona.name)
@@ -84,5 +80,20 @@ nonisolated struct VoteHandler: PhaseHandler {
     state.variables["vote_results"] = promptBuilder.formatScoreboard(tallies)
 
     context.emitter(.voteResults(votes: votes, tallies: tallies))
+  }
+
+  /// The valid vote targets for `voter`: all personas minus self (under
+  /// `exclude_self`) and any eliminated agent. Extracted from `execute` to keep
+  /// that method under the `function_body_length` cap.
+  private func voteCandidates(
+    scenario: Scenario, voter: Persona, excludeSelf: Bool, state: SimulationState
+  ) -> [String] {
+    scenario.personas
+      .map(\.name)
+      .filter { name in
+        if excludeSelf && name == voter.name { return false }
+        if state.eliminated[name] == true { return false }
+        return true
+      }
   }
 }

--- a/Pastura/Pastura/Engine/Phases/VoteHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/VoteHandler.swift
@@ -48,6 +48,7 @@ nonisolated struct VoteHandler: PhaseHandler {
         state.conversationLog, language: context.scenario.engineLanguage)
       variables["candidates"] = candidates.joined(separator: ", ")
       promptBuilder.injectAssigned(into: &variables, personaName: persona.name)
+      promptBuilder.injectNotes(into: &variables, personaName: persona.name)
       let userPrompt = promptBuilder.expandTemplate(promptTemplate, variables: variables)
 
       let output = try await llmCaller.call(

--- a/Pastura/Pastura/Engine/PromptBuilder.swift
+++ b/Pastura/Pastura/Engine/PromptBuilder.swift
@@ -42,6 +42,20 @@ nonisolated struct PromptBuilder: Sendable {
     variables["assigned_word"] = mine
   }
 
+  /// Injects the current speaker's `reflect`-phase memo under the `{my_notes}`
+  /// key.
+  ///
+  /// ``ReflectHandler`` stores each agent's private note under a per-persona
+  /// key `notes_<name>` (#907); this reads that back for the speaker so custom
+  /// user-prompt templates can reference `{my_notes}`. The `notes_` prefix is a
+  /// reserved namespace, mirroring `assigned_` (see ``injectAssigned(into:personaName:)``).
+  ///
+  /// Missing note resolves to empty string (not a literal placeholder), matching
+  /// `injectAssigned`'s miss posture.
+  func injectNotes(into variables: inout [String: String], personaName: String) {
+    variables["my_notes"] = variables["notes_\(personaName)"] ?? ""
+  }
+
   // MARK: - Scoreboard
 
   /// Serializes a score dictionary into a compact JSON-like string for template injection.
@@ -127,6 +141,21 @@ nonisolated struct PromptBuilder: Sendable {
       \(persona.description)
       """)
 
+    // Private reflect memo (#907): surface the agent's own prior-round note back
+    // to itself only. Other agents never see it (it is not in the conversation
+    // log), so the header stresses its privacy.
+    if let note = state.variables["notes_\(persona.name)"], !note.isEmpty {
+      let notesHeader = pickLanguage(
+        language,
+        ja: "## あなたの内心メモ（他の参加者には見えません）",
+        en: "## Your Private Notes (invisible to other participants)")
+      sections.append(
+        """
+        \(notesHeader)
+        \(note)
+        """)
+    }
+
     sections.append(
       buildAnswerRules(scenario: scenario, persona: persona, phase: phase, state: state))
 
@@ -185,6 +214,11 @@ nonisolated struct PromptBuilder: Sendable {
       rules += addressRule(language: language)
     }
 
+    // Reflect notes get a tighter 2-sentence cap (see `reflectBrevityRule`).
+    if phase.type == .reflect {
+      rules += reflectBrevityRule(language: language)
+    }
+
     if phase.type == .choose, let options = phase.options {
       let optionsList = options.joined(separator: ", ")
       rules += pickLanguage(
@@ -194,22 +228,42 @@ nonisolated struct PromptBuilder: Sendable {
     }
 
     if phase.type == .vote {
-      let excludeSelf = phase.excludeSelf ?? true
-      let candidates = scenario.personas
-        .map(\.name)
-        .filter { name in
-          if excludeSelf && name == persona.name { return false }
-          if state.eliminated[name] == true { return false }
-          return true
-        }
-      let candidatesList = candidates.joined(separator: ", ")
-      rules += pickLanguage(
-        language,
-        ja: "\n- voteフィールドは必ず次の名前のいずれかを正確に書くこと: \(candidatesList)",
-        en: "\n- The vote field must be exactly one of these names: \(candidatesList)")
+      rules += voteCandidateRule(scenario: scenario, persona: persona, phase: phase, state: state)
     }
 
     return rules
+  }
+
+  /// The `vote` candidate-list constraint appended for vote phases only.
+  /// Lists the valid vote targets (excluding self under `exclude_self` and
+  /// any eliminated agent). Extracted from `buildAnswerRules` to keep that
+  /// function under the `function_body_length` cap.
+  private func voteCandidateRule(
+    scenario: Scenario, persona: Persona, phase: Phase, state: SimulationState
+  ) -> String {
+    let excludeSelf = phase.excludeSelf ?? true
+    let candidates = scenario.personas
+      .map(\.name)
+      .filter { name in
+        if excludeSelf && name == persona.name { return false }
+        if state.eliminated[name] == true { return false }
+        return true
+      }
+    let candidatesList = candidates.joined(separator: ", ")
+    return pickLanguage(
+      scenario.engineLanguage,
+      ja: "\n- voteフィールドは必ず次の名前のいずれかを正確に書くこと: \(candidatesList)",
+      en: "\n- The vote field must be exactly one of these names: \(candidatesList)")
+  }
+
+  /// The #907 brevity rule appended for `reflect` phases only. Caps the private
+  /// note at 2 sentences — same constraint family as the #877 statement brevity
+  /// rule. Keep ja/en scope-parallel when editing.
+  private func reflectBrevityRule(language: String) -> String {
+    pickLanguage(
+      language,
+      ja: "\n- メモ（note）は2文以内で簡潔に書くこと（長文・箇条書きの羅列は禁止）",
+      en: "\n- Keep your note to at most 2 sentences (no long paragraphs or bullet lists).")
   }
 
   /// The #911 address rule appended for turn-based `speak_each` phases only.

--- a/Pastura/Pastura/Engine/PromptBuilder.swift
+++ b/Pastura/Pastura/Engine/PromptBuilder.swift
@@ -52,6 +52,11 @@ nonisolated struct PromptBuilder: Sendable {
   ///
   /// Missing note resolves to empty string (not a literal placeholder), matching
   /// `injectAssigned`'s miss posture.
+  ///
+  /// - Note: the privacy guarantee covers the conversation-log, system-prompt,
+  ///   and `{my_notes}` paths. Raw `notes_<other>` keys remain resolvable by a
+  ///   template that hand-references them (`{notes_Bob}`) — same exposure as
+  ///   the `assigned_` namespace, accepted for pattern consistency.
   func injectNotes(into variables: inout [String: String], personaName: String) {
     variables["my_notes"] = variables["notes_\(personaName)"] ?? ""
   }

--- a/Pastura/Pastura/Engine/PromptBuilder.swift
+++ b/Pastura/Pastura/Engine/PromptBuilder.swift
@@ -75,11 +75,21 @@ nonisolated struct PromptBuilder: Sendable {
   /// chosen via the effective Engine language (callers pass
   /// `scenario.engineLanguage`, ADR-010 D5 / D6 row 1). ADR-010 D7
   /// Translation Table.
-  func formatConversationLog(_ entries: [ConversationEntry], language: String) -> String {
+  ///
+  /// - Parameter window: Optional cap (`scenario.logWindow`, #907). When
+  ///   non-nil, only the last `window` entries are formatted — a prompt-side
+  ///   trim; the full log is untouched in persistence. `nil` keeps every entry.
+  ///   For any `window ≥ 1` (the validator's floor) the trimmed slice is
+  ///   non-empty whenever `entries` is, so the empty-log placeholder still only
+  ///   fires on a genuinely empty log.
+  func formatConversationLog(
+    _ entries: [ConversationEntry], language: String, window: Int? = nil
+  ) -> String {
     if entries.isEmpty {
       return pickLanguage(language, ja: "（まだなし）", en: "(none yet)")
     }
-    return entries.map { "  \($0.agentName): \($0.content)" }.joined(separator: "\n")
+    let windowed = window.map { Array(entries.suffix($0)) } ?? entries
+    return windowed.map { "  \($0.agentName): \($0.content)" }.joined(separator: "\n")
   }
 
   // MARK: - Main Field Detection

--- a/Pastura/Pastura/Engine/ScenarioLoader.swift
+++ b/Pastura/Pastura/Engine/ScenarioLoader.swift
@@ -23,7 +23,7 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
   /// Standard fields that are mapped to `Scenario` properties (not collected as extraData).
   private static let standardKeys: Set<String> = [
     "id", "name", "description", "language", "simulation_language",
-    "agents", "rounds", "context", "personas", "phases"
+    "agents", "rounds", "context", "personas", "phases", "log_window"
   ]
 
   // MARK: - Loading
@@ -211,6 +211,10 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
     let agentCount: Int = try parseRequired(dict, key: "agents", label: "Scenario")
     let rounds: Int = try parseRequired(dict, key: "rounds", label: "Scenario")
     let context: String = try parseRequired(dict, key: "context", label: "Scenario")
+    // Optional prompt-side conversation-log cap (#907). Strict-Int parse
+    // (mirrors `agents`/`rounds`): a quoted number or other type errors rather
+    // than silently coercing. The `≥ 1` bound is enforced by ScenarioValidator.
+    let logWindow: Int? = try parseOptional(dict, key: "log_window", label: "Scenario")
 
     let personasRaw: [[String: Any]] = try parseRequired(
       dict, key: "personas", label: "Scenario")
@@ -235,7 +239,7 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
       language: language,
       simulationLanguage: simulationLanguage,
       agentCount: agentCount, rounds: rounds, context: context,
-      personas: personas, phases: phases, extraData: extraData
+      personas: personas, phases: phases, logWindow: logWindow, extraData: extraData
     )
   }
 

--- a/Pastura/Pastura/Engine/ScenarioLoader.swift
+++ b/Pastura/Pastura/Engine/ScenarioLoader.swift
@@ -72,6 +72,7 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
   /// - `speak_all`: agentCount
   /// - `speak_each`: agentCount × subRounds
   /// - `vote`: agentCount
+  /// - `reflect`: agentCount
   /// - `choose`: agentCount × 2 (round_robin) or agentCount (individual)
   /// - `conditional`: `max(sum(thenPhases), sum(elsePhases))` — only one branch
   ///   runs per invocation, so `max` matches execution semantics. Using `sum`
@@ -91,7 +92,7 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
       return agents
     case .speakEach:
       return agents * (phase.subRounds ?? 1)
-    case .vote:
+    case .vote, .reflect:
       return agents
     case .choose:
       return phase.pairing == .roundRobin ? agents * 2 : agents

--- a/Pastura/Pastura/Engine/ScenarioSerializer.swift
+++ b/Pastura/Pastura/Engine/ScenarioSerializer.swift
@@ -34,6 +34,11 @@ nonisolated struct ScenarioSerializer: Sendable {
     lines.append(yamlReadableBlockScalar("description", scenario.description))
     lines.append("agents: \(scenario.agentCount)")
     lines.append("rounds: \(scenario.rounds)")
+    // Optional prompt-side conversation-log cap (#907); omit the key when nil
+    // so scenarios without a window round-trip unchanged.
+    if let logWindow = scenario.logWindow {
+      lines.append("log_window: \(logWindow)")
+    }
     lines.append(yamlBlockScalar("context", scenario.context))
 
     // Extra data (top-level, before personas/phases)

--- a/Pastura/Pastura/Engine/ScenarioValidator.swift
+++ b/Pastura/Pastura/Engine/ScenarioValidator.swift
@@ -63,6 +63,14 @@ nonisolated struct ScenarioValidator: Sendable {
         String(localized: "Round count (%lld) exceeds maximum of 30"), scenario.rounds)
     }
 
+    // Conversation-log window (#907): a prompt-side cap that must keep at least
+    // one entry when set. `nil` means "no window" (full log); `0` or negative
+    // would silently strip the whole log, so reject it as a misconfiguration.
+    if let logWindow = scenario.logWindow, logWindow < 1 {
+      throw validationError(
+        String(localized: "Log window (%lld) must be at least 1"), logWindow)
+    }
+
     // Inference count estimation
     let estimated = ScenarioLoader.estimateInferenceCount(scenario)
 

--- a/Pastura/Pastura/Engine/ScenarioValidator.swift
+++ b/Pastura/Pastura/Engine/ScenarioValidator.swift
@@ -116,7 +116,7 @@ nonisolated struct ScenarioValidator: Sendable {
           phase, label: "Phase \(index + 1) (assign)", scenario: scenario)
       case .conditional:
         try validateConditionalPhase(phase, index: index, scenario: scenario, depth: 0)
-      case .speakAll, .speakEach, .vote, .choose, .scoreCalc, .eliminate, .summarize:
+      case .speakAll, .speakEach, .vote, .choose, .reflect, .scoreCalc, .eliminate, .summarize:
         break
       case .eventInject:
         try validateEventInjectShape(
@@ -185,12 +185,13 @@ nonisolated struct ScenarioValidator: Sendable {
 
   /// Recursively validates each sub-phase in a conditional branch.
   ///
-  /// Rejects nested `.conditional` (depth-1 rule) and applies the same
-  /// semantic checks we run at the top level — e.g., an `assign` phase
-  /// with mismatched target/source shape still errors when buried inside
-  /// a `then:` or `else:` branch. `event_inject` is allowed inside a
-  /// branch (consistent with assign / score_calc) and gets the same
-  /// shape-check it would receive at the top level.
+  /// Rejects nested `.conditional` (depth-1 rule) and `.reflect` (not
+  /// supported inside a branch in v1), and applies the same semantic checks
+  /// we run at the top level — e.g., an `assign` phase with mismatched
+  /// target/source shape still errors when buried inside a `then:` or
+  /// `else:` branch. `event_inject` is allowed inside a branch (consistent
+  /// with assign / score_calc) and gets the same shape-check it would
+  /// receive at the top level.
   private func validateBranch(
     _ phases: [Phase], parentLabel: String, branchLabel: String, scenario: Scenario
   ) throws {
@@ -200,6 +201,14 @@ nonisolated struct ScenarioValidator: Sendable {
       if subPhase.type == .conditional {
         throw validationError(
           String(localized: "%@ is another conditional, which is not allowed (depth-1 rule)."),
+          subLabel)
+      }
+      // `reflect` is not supported inside a conditional branch in v1. Reject
+      // at load-time validation (mirroring the nested-conditional rule above)
+      // so it fails here rather than at `ConditionalHandler` dispatch.
+      if subPhase.type == .reflect {
+        throw validationError(
+          String(localized: "%@ is a reflect phase, which is not allowed inside a conditional."),
           subLabel)
       }
       if subPhase.type == .assign {

--- a/Pastura/Pastura/Engine/ScenarioValidator.swift
+++ b/Pastura/Pastura/Engine/ScenarioValidator.swift
@@ -124,7 +124,9 @@ nonisolated struct ScenarioValidator: Sendable {
           phase, label: "Phase \(index + 1) (assign)", scenario: scenario)
       case .conditional:
         try validateConditionalPhase(phase, index: index, scenario: scenario, depth: 0)
-      case .speakAll, .speakEach, .vote, .choose, .reflect, .scoreCalc, .eliminate, .summarize:
+      case .reflect:
+        try validateReflectShape(phase, label: "Phase \(index + 1)")
+      case .speakAll, .speakEach, .vote, .choose, .scoreCalc, .eliminate, .summarize:
         break
       case .eventInject:
         try validateEventInjectShape(
@@ -247,6 +249,23 @@ nonisolated struct ScenarioValidator: Sendable {
   ///   (`< 0` never fires, `>= 1.0` always fires), but a curator who
   ///   wrote `probability: 1.5` almost certainly mistyped — surfacing
   ///   it early is friendlier than silent over-fire.
+  /// Requires reflect phases to declare the canonical `note` output at the
+  /// RUN gate (`validate`), not just the commit gate.
+  ///
+  /// Other LLM phases run schema-less in degraded-but-visible form (their
+  /// primary text lands in the conversation log as empty prose), but a
+  /// reflect phase without `note` is a pure no-op inference — it burns one
+  /// call per agent per round and stores nothing, with no user-visible
+  /// symptom to debug from. Failing fast at the run gate is friendlier.
+  /// Reuses the commit-gate message so both gates read identically.
+  private func validateReflectShape(_ phase: Phase, label: String) throws {
+    if (phase.outputSchema ?? [:])["note"] == nil {
+      throw validationError(
+        String(localized: "%@ (%@) requires field '%@' in output."),
+        label, phase.type.rawValue, "note")
+    }
+  }
+
   private func validateEventInjectShape(
     _ phase: Phase, label: String, scenario: Scenario
   ) throws {

--- a/Pastura/Pastura/Engine/ScenarioYAMLPatcher.swift
+++ b/Pastura/Pastura/Engine/ScenarioYAMLPatcher.swift
@@ -117,6 +117,9 @@ nonisolated public struct ScenarioYAMLPatcher: Sendable {
       && tryEdit(
         base.rounds != visual.rounds, root["rounds"]?.scalar, String(visual.rounds), &edits)
       && tryEdit(
+        base.logWindow != visual.logWindow, root["log_window"]?.scalar,
+        visual.logWindow.map(String.init), &edits)
+      && tryEdit(
         base.context != visual.context, root["context"]?.scalar, quote(visual.context), &edits)
   }
 

--- a/Pastura/Pastura/LLM/GBNFGrammarBuilder.swift
+++ b/Pastura/Pastura/LLM/GBNFGrammarBuilder.swift
@@ -93,11 +93,19 @@ nonisolated public struct GBNFGrammarBuilder: Sendable {
     // like `}: ` (token 7493) — `}` closes the object but the
     // trailing bytes in the same token have no grammar home.
     //
-    // The `trailing` rule uses recursive `(byte trailing)?` form
-    // instead of inline `[^"\\]*` because llama.cpp's grammar parser
+    // The `trailing` rule is a BOUNDED chain (depth
+    // `trailingByteBudget`) of `(byte trailingN)?` productions rather
+    // than an unbounded self-reference. Recursive `(byte trailingN)?`
+    // form (not inline `[^"\\]*`) because llama.cpp's grammar parser
     // intermittently rejects Kleene-star on top-level char classes
     // (same symptom that made us switch `ws` to its recursive form
-    // earlier in this PR).
+    // earlier in this PR). The previous UNBOUNDED form absorbed
+    // unlimited printable ASCII after the close — inviting the model to
+    // emit fabricated follow-on objects that then tripped the parser's
+    // multi-object refusal (#907). The bound caps residue at
+    // `trailingByteBudget` bytes; overflow lands on the catch-as-EOS
+    // path (the prior commit) — a benign stop after the object is
+    // already complete, not the old hard failure.
     parts.append("trailing")
     return "root ::= \(parts.joined(separator: " "))"
   }
@@ -156,16 +164,26 @@ nonisolated public struct GBNFGrammarBuilder: Sendable {
   // hedge.
   private static let sharedWhitespaceProduction = #"ws ::= ([ \t\n] ws)?"#
 
+  /// Max bytes the bounded `trailing` chain absorbs after the closing `}`.
+  /// Covers any single BPE-merged close token's residue (`}: `, token 7493)
+  /// with margin; overflow past this budget lands on the catch-as-EOS path
+  /// (#907) — a benign stop once the object is already complete.
+  private static let trailingByteBudget = 16
+
   // Trailing rule used after the closing `}` to tolerate BPE-merged
-  // tokens whose tail continues past the object boundary. Recursive
-  // form + positive char class.
+  // tokens whose tail continues past the object boundary. BOUNDED
+  // recursive chain (`trailingByteBudget` links) + positive char class.
   //
-  // History (all returned NULL from `llama_sampler_init_grammar`):
+  // History (all returned NULL from `llama_sampler_init_grammar` unless
+  // noted):
   //   1. `ws` reuse (`"}" ws` at top level)           — OK parse, crash on `}: ` accept
   //   2. inline `[^\x00]*`                             — parse NULL
   //   3. inline `[^"\\]*`                              — parse NULL
   //   4. recursive `trailing ::= ([^"\\] trailing)?`   — parse NULL
-  //   5. recursive + positive class (this commit)      — trying
+  //   5. recursive + positive class (unbounded)        — parsed OK, but the
+  //      unlimited printable-ASCII acceptance let the model emit fabricated
+  //      follow-on objects that tripped the multi-object refusal (#907)
+  //   6. bounded chain + positive class (this commit)  — caps residue
   //
   // Hypothesis: llama.cpp's grammar parser has an edge case with
   // negated char classes when used in a recursive rule (theory 4),
@@ -179,5 +197,22 @@ nonisolated public struct GBNFGrammarBuilder: Sendable {
   // post-`}` bytes would still cause an accept-time crash, but the
   // model is trained to emit EOS immediately after a closed object
   // so that path is practically unreachable.
-  private static let sharedTrailingProduction = #"trailing ::= ([\t\n\r -~] trailing)?"#
+  //
+  // Emits, e.g. for budget 16:
+  //   trailing   ::= ([\t\n\r -~] trailing1)?
+  //   trailing1  ::= ([\t\n\r -~] trailing2)?
+  //   …
+  //   trailing15 ::= ([\t\n\r -~])?
+  // The terminal link omits the self-reference, capping the chain.
+  private static var sharedTrailingProduction: String {
+    (0..<trailingByteBudget).map { depth in
+      let ruleName = depth == 0 ? "trailing" : "trailing\(depth)"
+      if depth == trailingByteBudget - 1 {
+        // Terminal link — no next-reference, bounds the chain length.
+        return #"\#(ruleName) ::= ([\t\n\r -~])?"#
+      }
+      return #"\#(ruleName) ::= ([\t\n\r -~] trailing\#(depth + 1))?"#
+    }
+    .joined(separator: "\n")
+  }
 }

--- a/Pastura/Pastura/LLM/JSONResponseParser.swift
+++ b/Pastura/Pastura/LLM/JSONResponseParser.swift
@@ -57,9 +57,17 @@ nonisolated public struct JSONResponseParser: Sendable {
   /// 4. Extract the first balanced `{...}` object (string-aware), discarding
   ///    any trailing content after its matching close brace
   /// 5. Try `JSONSerialization` on the cleaned text
-  /// 6. On failure: apply the two-step repair pipeline
-  ///    (`unclosed_string` → `unclosed_brace`), retry parse, and reject
-  ///    the result if `expectedKeys` are not all present and non-empty
+  /// 6. On failure with non-empty `expectedKeys`: attempt schema-guarded
+  ///    multi-object salvage (see below) before the repair pipeline
+  /// 7. On failure: two-step repair (`unclosed_string` → `unclosed_brace`),
+  ///    retry parse, reject if `expectedKeys` not all present + non-empty
+  ///
+  /// Schema-guarded multi-object salvage (#907): on happy-path failure with a
+  /// non-empty schema, the first balanced object is re-extracted ignoring the
+  /// #751 object-like-residue refusal and accepted only with ALL `expectedKeys`
+  /// present and non-empty (see `extractFirstJSONObject`'s `allowObjectResidue`).
+  /// The schema-less path keeps the #751 refusal verbatim; single-field
+  /// grammars made the multi-object shape dominant, so retrying cannot converge.
   ///
   /// Repair order rationale: unclosed-string runs first because closing
   /// the string changes the subsequent brace-balance computation.
@@ -87,6 +95,16 @@ nonisolated public struct JSONResponseParser: Sendable {
     // Try as-is — happy path, no repair needed.
     if let output = tryParse(cleaned, originalText: text) {
       return (output, nil)
+    }
+
+    // Schema-guarded multi-object salvage (#907) — recovers a complete-but-
+    // followed-by-junk first object before the repair pipeline runs.
+    if !expectedKeys.isEmpty {
+      let salvaged = applyCleanupPipeline(text, allowObjectResidue: true)
+      if let output = tryParse(salvaged, originalText: text),
+        hasAllExpectedKeys(output, expectedKeys: expectedKeys) {
+        return (output, "multi_object_salvage")
+      }
     }
 
     // Repair pipeline. Each repair operates on the *current* repaired text
@@ -132,11 +150,7 @@ nonisolated public struct JSONResponseParser: Sendable {
     // Non-empty `expectedKeys` typically comes from `phase.outputSchema?.keys`
     // at the handler call site (passed via `LLMCaller`).
     if !expectedKeys.isEmpty {
-      let allPresent = expectedKeys.allSatisfy { key in
-        guard let value = output.fields[key], !value.isEmpty else { return false }
-        return true
-      }
-      guard allPresent else {
+      guard hasAllExpectedKeys(output, expectedKeys: expectedKeys) else {
         throw LLMError.invalidResponse(raw: text)
       }
     }
@@ -146,7 +160,19 @@ nonisolated public struct JSONResponseParser: Sendable {
 
   // MARK: - Internal helpers
 
-  private func applyCleanupPipeline(_ text: String) -> String {
+  /// True when every `expectedKeys` entry is present with a non-empty value.
+  private func hasAllExpectedKeys(
+    _ output: TurnOutput, expectedKeys: Set<String>
+  ) -> Bool {
+    expectedKeys.allSatisfy { key in
+      guard let value = output.fields[key], !value.isEmpty else { return false }
+      return true
+    }
+  }
+
+  private func applyCleanupPipeline(
+    _ text: String, allowObjectResidue: Bool = false
+  ) -> String {
     var cleaned = text.trimmingCharacters(in: .whitespacesAndNewlines)
     cleaned = stripThinkingTags(cleaned)
     cleaned = truncateAtChatTemplateToken(cleaned)
@@ -159,8 +185,10 @@ nonisolated public struct JSONResponseParser: Sendable {
     // an identity transform for an already-clean object; for trailing garbage
     // it trims back to the first complete object, and for an object-like
     // trailing residue (`{…}{…}`) it returns the input unchanged so the
-    // multi-object span throws (see `extractFirstJSONObject`, #751 hybrid).
-    cleaned = extractFirstJSONObject(cleaned)
+    // multi-object span throws (see `extractFirstJSONObject`, #751 hybrid) —
+    // UNLESS `allowObjectResidue` is set for the schema-guarded salvage path
+    // (#907), which salvages the first object instead.
+    cleaned = extractFirstJSONObject(cleaned, allowObjectResidue: allowObjectResidue)
     return cleaned
   }
 
@@ -296,15 +324,20 @@ nonisolated public struct JSONResponseParser: Sendable {
   ///   it and keep the complete first object.
   /// - A trailing **object-like** residue (`{…}{…}`, the post-close text
   ///   starts with `{`) signals the generation re-rolled a whole second
-  ///   answer — a stronger instability signal. Return the input unchanged so
-  ///   `JSONSerialization` rejects the multi-object span → the inference is
-  ///   re-tried for a cleaner sample, rather than silently salvaging a
-  ///   possibly off-persona first object.
+  ///   answer. By default (schema-less path) return the input unchanged so
+  ///   `JSONSerialization` rejects the multi-object span → re-try for a
+  ///   cleaner sample, rather than salvaging a possibly off-persona first
+  ///   object. `allowObjectResidue` overrides that: the first object is
+  ///   salvaged anyway. Only the schema-guarded salvage path
+  ///   (`parse(_:expectedKeys:)`, #907) passes `true`, and it additionally
+  ///   requires all expected keys with content.
   ///
   /// Also returns the input unchanged when no `{` exists or the braces never
   /// balance (unclosed object) so the downstream repair pipeline
   /// (`closeUnclosedBraces`) can still fire.
-  private func extractFirstJSONObject(_ text: String) -> String {
+  private func extractFirstJSONObject(
+    _ text: String, allowObjectResidue: Bool = false
+  ) -> String {
     let chars = Array(text)
     let machine = StringStateMachine(text)
     guard
@@ -323,9 +356,10 @@ nonisolated public struct JSONResponseParser: Sendable {
       case "}":
         balance -= 1
         if balance == 0 {
-          // Object-like trailing residue → defer to multi-object throw.
+          // Object-like trailing residue → defer to multi-object throw,
+          // unless the schema-guarded salvage path opts in (#907).
           let residue = chars[(i + 1)...].drop(while: { $0.isWhitespace })
-          if residue.first == "{" {
+          if residue.first == "{" && !allowObjectResidue {
             return text
           }
           return String(chars[start...i])

--- a/Pastura/Pastura/LLM/LLMError.swift
+++ b/Pastura/Pastura/LLM/LLMError.swift
@@ -45,14 +45,17 @@ nonisolated public enum LLMError: Error, Sendable, Equatable {
   /// stack …` and was caught instead of aborting the process. The
   /// stored `description` is the caught `what()` detail.
   ///
-  /// **Retryable** — unlike ``generationFailed`` / ``invalidGrammar``,
-  /// this case is routed through ``LLMCaller``'s existing retry budget
-  /// (#885). The trigger is sampling noise, not a deterministic
-  /// per-(model, prompt, schema) defect: the model continues past the
-  /// completed JSON object with a token (often CJK) outside the
-  /// grammar's ASCII trailing production, so a fresh inference of the
-  /// same inputs usually succeeds. On budget exhaustion the `what()`
-  /// detail survives into the user-visible error.
+  /// **Handled as end-of-generation (#907)** — the generation loops
+  /// (`runGeneration` / `runStreamGeneration`) catch this error and end
+  /// generation gracefully rather than failing. The common trigger is the
+  /// model continuing past the completed JSON object with a token (often
+  /// CJK) outside the grammar's ASCII trailing production, so the completed
+  /// object is already in the accumulated text; the completed-object case
+  /// wins and the incomplete case falls through to the parser's
+  /// parse-failure retry. ``LLMCaller`` still routes this case through its
+  /// retry budget (#885) as defense in depth for any other surfacer of the
+  /// error; on budget exhaustion the `what()` detail survives into the
+  /// user-visible error.
   case samplerCrashCaught(description: String)
 }
 

--- a/Pastura/Pastura/LLM/LlamaCppService+Sampler.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService+Sampler.swift
@@ -143,6 +143,10 @@ extension LlamaCppService {
   /// `apply` does not throw `std::exception` (only `GGML_ASSERT` /
   /// `GGML_ABORT` signals), so the Swift-side `apply` here loses no coverage.
   ///
+  /// The generation loops catch the thrown `LLMError.samplerCrashCaught` as
+  /// end-of-generation (`nextContentTokenOrStop`, #907); the diagnostic
+  /// still fires once per catch for occurrence-rate telemetry.
+  ///
   /// - Parameters:
   ///   - vocab: model vocab pointer, for EOG classification.
   ///   - candidates: caller-owned, `n_vocab`-sized scratch buffer reused
@@ -235,14 +239,21 @@ extension LlamaCppService {
   ///   2. Emit a `samplerCrashCaught` structured line on
   ///      `category:StreamingDiag` (always-on; see `samplerCatchDiagLogger`)
   ///      so the analyzer pipeline can aggregate occurrence rates across builds.
-  ///   3. Throw `LLMError.samplerCrashCaught`. `LLMCaller` routes this
-  ///      case through its existing retry budget (#885): the crash is
-  ///      sampling noise (the model continuing past the completed object
-  ///      with a token outside the grammar's ASCII trailing set), not
-  ///      deterministic per (model, prompt, schema), so a fresh
-  ///      inference usually recovers. The diagnostic above fires once
-  ///      per **attempt** so occurrence rates stay accurate across the
-  ///      (bounded) retries.
+  ///      This line MUST keep firing once per catch — it is the
+  ///      occurrence-rate telemetry — regardless of how callers handle the
+  ///      thrown error.
+  ///   3. Throw `LLMError.samplerCrashCaught`. As of #907 the generation
+  ///      loops (`runGeneration` / `runStreamGeneration`) catch this error
+  ///      and end generation gracefully instead of failing: the crash's
+  ///      common trigger is the model continuing past a completed JSON
+  ///      object with a token outside the grammar's ASCII trailing set, so
+  ///      the completed object is already in the accumulated text — the
+  ///      completed-object case wins outright, and the incomplete case
+  ///      falls through to the parser's parse-failure retry (`LLMCaller`).
+  ///      `LLMCaller` still routes the error through its retry budget (#885)
+  ///      as defense in depth for any other surfacer, but the loops now
+  ///      intercept the common case. The diagnostic above fires once per
+  ///      catch so occurrence rates stay accurate.
   private func handleSamplerCatch(_ errorMessage: String?, mode: String) throws {
     guard let errorMessage else { return }
     let truncated = String(errorMessage.prefix(160))
@@ -257,10 +268,12 @@ extension LlamaCppService {
       mode=\(mode, privacy: .public) \
       model=\(self.modelIdentifier, privacy: .public)
       """)
-    // Retryable, not fail-fast: the raw `what()` rides in the associated
-    // value and `LLMCaller` re-runs the inference through its retry
-    // budget (#885). `LLMError.errorDescription` formats it for display
-    // via the same "Sampler crash caught: %@" catalog key.
+    // Graceful stop, not fail-fast: the generation loops catch this and
+    // end generation (the completed-object case wins; #907). The raw
+    // `what()` rides in the associated value so any OTHER surfacer still
+    // gets `LLMCaller`'s retry budget (#885) as defense in depth, and
+    // `LLMError.errorDescription` formats it for display via the same
+    // "Sampler crash caught: %@" catalog key.
     throw LLMError.samplerCrashCaught(description: truncated)
   }
 

--- a/Pastura/Pastura/LLM/LlamaCppService.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService.swift
@@ -532,11 +532,14 @@ extension LlamaCppService {
         throw LLMError.suspended
       }
 
-      let newTokenId = try safeSample(
-        sampler: sampler, context: context, vocab: vocab,
-        candidates: candidateBuffer, mode: "non-stream")
-
-      if llama_vocab_is_eog(vocab, newTokenId) { break }
+      // `nil` ends generation (EOG token OR a caught #907 grammar-accept
+      // crash — a post-object-completion continuation) with no token
+      // appended, exactly as an EOG break did before.
+      guard
+        let newTokenId = try nextContentTokenOrStop(
+          sampler: sampler, context: context, vocab: vocab,
+          candidates: candidateBuffer, mode: "non-stream")
+      else { break }
 
       generatedTokens += 1
       outputText += decodePiece(vocab: vocab, token: newTokenId)
@@ -584,6 +587,38 @@ extension LlamaCppService {
     #endif
 
     return GenerationResult(text: outputText, completionTokens: generatedTokens)
+  }
+
+  /// Sample the next content token, or `nil` when generation should stop.
+  ///
+  /// Two stop conditions both return `nil` and both leave the accumulated
+  /// output untouched (no token appended), so the token loops handle them
+  /// with a single `guard … else { break }`:
+  /// 1. an EOG token (normal end), and
+  /// 2. a caught grammar-accept crash (``LLMError/samplerCrashCaught``) —
+  ///    the #907 post-object-completion continuation. For single-field
+  ///    grammars the model often finishes the JSON object then keeps
+  ///    generating a token outside the grammar's trailing production; the
+  ///    completed object is already accumulated, so ending here (like EOG)
+  ///    lets the parser recover it instead of failing the whole inference
+  ///    and consuming the retry budget. An incomplete object still fails
+  ///    parse and retries as before. All other errors propagate. See
+  ///    ``handleSamplerCatch(_:mode:)``.
+  func nextContentTokenOrStop(
+    sampler: UnsafeMutablePointer<llama_sampler>, context: OpaquePointer,
+    vocab: OpaquePointer?,
+    candidates: UnsafeMutableBufferPointer<llama_token_data>?,
+    mode: String
+  ) throws -> Int32? {
+    let token: Int32
+    do {
+      token = try safeSample(
+        sampler: sampler, context: context, vocab: vocab,
+        candidates: candidates, mode: mode)
+    } catch LLMError.samplerCrashCaught {
+      return nil
+    }
+    return llama_vocab_is_eog(vocab, token) ? nil : token
   }
 }
 
@@ -698,10 +733,14 @@ extension LlamaCppService {
         throw LLMError.suspended
       }
 
-      let newTokenId = try safeSample(
-        sampler: sampler, context: context, vocab: vocab,
-        candidates: candidateBuffer, mode: "stream")
-      if llama_vocab_is_eog(vocab, newTokenId) { break }
+      // `nil` ends generation (EOG token OR a caught #907 grammar-accept
+      // crash) with no token appended. Breaking here — not throwing — still
+      // runs the post-loop held-back flush below, matching the EOG break.
+      guard
+        let newTokenId = try nextContentTokenOrStop(
+          sampler: sampler, context: context, vocab: vocab,
+          candidates: candidateBuffer, mode: "stream")
+      else { break }
 
       generatedTokens += 1
       let pieceBytes = decodePieceRaw(vocab: vocab, token: newTokenId)

--- a/Pastura/Pastura/LLM/LlamaCppService.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService.swift
@@ -604,7 +604,7 @@ extension LlamaCppService {
   ///    and consuming the retry budget. An incomplete object still fails
   ///    parse and retries as before. All other errors propagate. See
   ///    ``handleSamplerCatch(_:mode:)``.
-  func nextContentTokenOrStop(
+  fileprivate func nextContentTokenOrStop(
     sampler: UnsafeMutablePointer<llama_sampler>, context: OpaquePointer,
     vocab: OpaquePointer?,
     candidates: UnsafeMutableBufferPointer<llama_token_data>?,

--- a/Pastura/Pastura/LLM/PartialOutputExtractor.swift
+++ b/Pastura/Pastura/LLM/PartialOutputExtractor.swift
@@ -12,7 +12,7 @@ import Foundation
 nonisolated public struct PartialSnapshot: Sendable, Equatable {
   /// Currently-visible value of the first primary key present in the
   /// buffer (one of `PartialOutputExtractor.primaryKeys` —
-  /// `statement` / `action` / `vote`, matching
+  /// `statement` / `action` / `vote` / `note`, matching
   /// ``ScenarioConventions/primaryField(for:)``). `nil` while the
   /// extractor is waiting for that key's opening quote.
   public let primary: String?
@@ -52,11 +52,12 @@ nonisolated public struct PartialOutputExtractor: Sendable {
   ///
   /// Matches the canonical fields advertised by
   /// ``ScenarioConventions/primaryField(for:)`` (one canonical field per
-  /// LLM phase: speak → `statement`, choose → `action`, vote → `vote`)
-  /// and is kept consistent with ``OutputSchema/knownPrimaryKeys`` —
-  /// verified by `OutputSchemaTests.primaryKeySuperset`.
+  /// LLM phase: speak → `statement`, choose → `action`, vote → `vote`,
+  /// reflect → `note`) and is kept consistent with
+  /// ``OutputSchema/knownPrimaryKeys`` — verified by
+  /// `OutputSchemaTests.primaryKeySuperset`.
   public static let primaryKeys = [
-    "statement", "action", "vote"
+    "statement", "action", "vote", "note"
   ]
   public static let thoughtKey = "inner_thought"
 

--- a/Pastura/Pastura/Models/OutputSchema.swift
+++ b/Pastura/Pastura/Models/OutputSchema.swift
@@ -36,9 +36,10 @@ nonisolated public struct OutputSchema: Codable, Sendable, Equatable {
   ///
   /// Matches the canonical fields advertised by
   /// ``ScenarioConventions/primaryField(for:)`` (one canonical field per
-  /// LLM phase: speak → `statement`, choose → `action`, vote → `vote`).
+  /// LLM phase: speak → `statement`, choose → `action`, vote → `vote`,
+  /// reflect → `note`).
   public static let knownPrimaryKeys: [String] = [
-    "statement", "action", "vote"
+    "statement", "action", "vote", "note"
   ]
 
   /// Known secondary-output field names (reasoning / justification).

--- a/Pastura/Pastura/Models/PhaseType.swift
+++ b/Pastura/Pastura/Models/PhaseType.swift
@@ -2,16 +2,17 @@ import Foundation
 
 /// The type of a simulation phase, determining how it is processed.
 ///
-/// LLM phases (`speakAll`, `speakEach`, `vote`, `choose`) require LLM inference.
-/// Code phases (`scoreCalc`, `assign`, `eliminate`, `summarize`, `eventInject`)
-/// are processed deterministically by the engine. `conditional` is a
-/// control-flow phase: the handler itself does no inference, but its
-/// sub-phases may be of any type.
+/// LLM phases (`speakAll`, `speakEach`, `vote`, `choose`, `reflect`) require
+/// LLM inference. Code phases (`scoreCalc`, `assign`, `eliminate`,
+/// `summarize`, `eventInject`) are processed deterministically by the engine.
+/// `conditional` is a control-flow phase: the handler itself does no
+/// inference, but its sub-phases may be of any type.
 nonisolated public enum PhaseType: String, Codable, Sendable, CaseIterable {
   case speakAll = "speak_all"
   case speakEach = "speak_each"
   case vote
   case choose
+  case reflect
   case scoreCalc = "score_calc"
   case assign
   case eliminate
@@ -32,9 +33,13 @@ nonisolated public enum PhaseType: String, Codable, Sendable, CaseIterable {
   /// scenario `extraData` and writes it into `state.variables` — no LLM
   /// call. Subsequent prompt phases reference the injected value via the
   /// `as:` variable name (default `current_event`).
+  ///
+  /// `reflect` returns `true`: each agent runs an LLM inference to privately
+  /// update a short note about the situation (canonical `note` output field),
+  /// so it costs one inference per agent per round like `speakAll` / `vote`.
   public var requiresLLM: Bool {
     switch self {
-    case .speakAll, .speakEach, .vote, .choose:
+    case .speakAll, .speakEach, .vote, .choose, .reflect:
       return true
     case .scoreCalc, .assign, .eliminate, .summarize, .conditional, .eventInject:
       return false

--- a/Pastura/Pastura/Models/Scenario.swift
+++ b/Pastura/Pastura/Models/Scenario.swift
@@ -77,6 +77,17 @@ nonisolated public struct Scenario: Codable, Sendable, Equatable {
   /// Number of rounds to execute.
   public let rounds: Int
 
+  /// Optional cap on how many recent conversation-log entries reach each LLM
+  /// prompt.
+  ///
+  /// `nil` (the default, and every current scenario) means the full log is
+  /// injected. When set (must be `≥ 1`, enforced by ``ScenarioValidator``),
+  /// only the last N ``ConversationEntry`` values are formatted into a prompt
+  /// via `PromptBuilder.formatConversationLog(_:language:window:)`. This is a
+  /// **prompt-side window only** — `TurnRecord` persistence, replay, and
+  /// export all keep the complete log. YAML key: `log_window` (#907).
+  public let logWindow: Int?
+
   /// Shared context injected into every agent's system prompt.
   public let context: String
 
@@ -105,6 +116,7 @@ nonisolated public struct Scenario: Codable, Sendable, Equatable {
     context: String,
     personas: [Persona],
     phases: [Phase],
+    logWindow: Int? = nil,
     extraData: [String: AnyCodableValue] = [:]
   ) {
     self.id = id
@@ -117,6 +129,7 @@ nonisolated public struct Scenario: Codable, Sendable, Equatable {
     self.context = context
     self.personas = personas
     self.phases = phases
+    self.logWindow = logWindow
     self.extraData = extraData
   }
 }

--- a/Pastura/Pastura/Models/ScenarioConventions.swift
+++ b/Pastura/Pastura/Models/ScenarioConventions.swift
@@ -10,6 +10,7 @@ import Foundation
 /// | `.speakAll`, `.speakEach` | `statement` |
 /// | `.choose` | `action` |
 /// | `.vote` | `vote` |
+/// | `.reflect` | `note` |
 ///
 /// Speak phases route the canonical field's value into the conversation log
 /// (read by ``PromptBuilder``) and into the agent's primary display text
@@ -35,7 +36,8 @@ nonisolated public enum ScenarioConventions {
   /// output.
   ///
   /// Speak phases return `"statement"`, choose returns `"action"`, vote
-  /// returns `"vote"`. All other phase types return `nil`.
+  /// returns `"vote"`, reflect returns `"note"`. All other phase types return
+  /// `nil`.
   public static func primaryField(for phaseType: PhaseType) -> String? {
     switch phaseType {
     case .speakAll, .speakEach:
@@ -44,6 +46,8 @@ nonisolated public enum ScenarioConventions {
       return "action"
     case .vote:
       return "vote"
+    case .reflect:
+      return "note"
     case .scoreCalc, .assign, .eliminate, .summarize, .conditional, .eventInject:
       return nil
     }
@@ -52,7 +56,10 @@ nonisolated public enum ScenarioConventions {
   /// Returns the private-thought (secondary) output field name expected on
   /// `output:` for the given LLM phase, or `nil` for code phases.
   ///
-  /// Vote returns `"reason"`; every other LLM phase returns `"inner_thought"`.
+  /// Vote returns `"reason"`; `reflect` returns `nil` (its canonical `note`
+  /// output *is* the agent's private reasoning, so there is no separate
+  /// secondary thought field — a reflect note is authored as a single-field
+  /// `{ note }` schema); every other LLM phase returns `"inner_thought"`.
   /// Both fields are display-only private reasoning (never routed into the
   /// conversation log, so invisible to other agents) — `reason` is simply the
   /// vote-phase spelling of the same concept (vote schemas author
@@ -79,7 +86,9 @@ nonisolated public enum ScenarioConventions {
       return "reason"
     case .speakAll, .speakEach, .choose:
       return "inner_thought"
-    case .scoreCalc, .assign, .eliminate, .summarize, .conditional, .eventInject:
+    // `.reflect`'s canonical `note` output is itself the private reasoning, so
+    // it declares no secondary thought field (single-field `{ note }` schema).
+    case .reflect, .scoreCalc, .assign, .eliminate, .summarize, .conditional, .eventInject:
       return nil
     }
   }

--- a/Pastura/Pastura/Models/SimulationEvent.swift
+++ b/Pastura/Pastura/Models/SimulationEvent.swift
@@ -21,8 +21,8 @@ nonisolated public enum SimulationEvent: Sendable, Equatable {
   /// `phasePath` uniquely identifies the phase's position in the scenario.
   /// Top-level phase K has path `[K]`; a sub-phase at index N inside a
   /// conditional at top-level K has path `[K, N]`. The array form lets
-  /// future phase types (e.g. `event_inject`, `reflect`) reuse the same
-  /// identifier shape without widening the event signature again.
+  /// future phase types with nested sub-phases reuse the same identifier
+  /// shape without widening the event signature again.
   case phaseStarted(phaseType: PhaseType, phasePath: [Int])
 
   /// A phase has finished execution.

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -3768,6 +3768,22 @@
         }
       }
     },
+    "Log window (%lld) must be at least 1" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Log window (%lld) must be at least 1"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "会話ログの表示件数 (%lld) は1以上にしてください"
+          }
+        }
+      }
+    },
     "Logic" : {
       "localizations" : {
         "ja" : {

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -2678,18 +2678,18 @@
         }
       }
     },
-    "Each agent privately updates a short memo about the situation." : {
+    "Each agent privately updates a short memo about the situation" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Each agent privately updates a short memo about the situation."
+            "value" : "Each agent privately updates a short memo about the situation"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "各エージェントが状況について短い内心メモを更新します。"
+            "value" : "各エージェントが状況について短い内心メモを更新"
           }
         }
       }

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -381,6 +381,22 @@
         }
       }
     },
+    "%@ is a reflect phase, which is not allowed inside a conditional." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ is a reflect phase, which is not allowed inside a conditional."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ は reflect フェーズであり、conditional の中では許可されていません。"
+          }
+        }
+      }
+    },
     "%@ is another conditional, which is not allowed (depth-1 rule)." : {
       "localizations" : {
         "en" : {
@@ -2662,6 +2678,22 @@
         }
       }
     },
+    "Each agent privately updates a short memo about the situation." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Each agent privately updates a short memo about the situation."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "各エージェントが状況について短い内心メモを更新します。"
+          }
+        }
+      }
+    },
     "Edit" : {
       "localizations" : {
         "ja" : {
@@ -4835,6 +4867,22 @@
         }
       }
     },
+    "Reflect" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reflect"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ふりかえり"
+          }
+        }
+      }
+    },
     "Reloading model..." : {
       "localizations" : {
         "ja" : {
@@ -6219,6 +6267,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "選択結果は `action` フィールドで追加してください。値はこの phase の options に制限されます。"
+          }
+        }
+      }
+    },
+    "Use `note` for the agent's private memo. This is the reflect phase's only output field." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use `note` for the agent's private memo. This is the reflect phase's only output field."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エージェントの内心メモには `note` を使います。reflect フェーズの唯一の出力フィールドです。"
           }
         }
       }

--- a/Pastura/Pastura/Views/Components/PhaseDisplayName.swift
+++ b/Pastura/Pastura/Views/Components/PhaseDisplayName.swift
@@ -23,6 +23,9 @@ import Foundation
 /// separators stay snake_case-free and localized (#882).
 public enum PhaseDisplayName {
 
+  // Pure name-mapping switch (one line per phase type). The 11-case count
+  // exceeds SwiftLint's cyclomatic threshold but carries no branching logic.
+  // swiftlint:disable cyclomatic_complexity
   /// Compact display label for `phase`. The English source string is
   /// the xcstrings key (literal-en convention used throughout the
   /// catalog); `ja` translations are authored in
@@ -33,6 +36,7 @@ public enum PhaseDisplayName {
     case .speakEach: return String(localized: "Speak Each")
     case .vote: return String(localized: "Vote")
     case .choose: return String(localized: "Choose")
+    case .reflect: return String(localized: "Reflect")
     case .scoreCalc: return String(localized: "Score Calc")
     case .assign: return String(localized: "Assign")
     case .eliminate: return String(localized: "Eliminate")
@@ -41,4 +45,5 @@ public enum PhaseDisplayName {
     case .eventInject: return String(localized: "Event")
     }
   }
+  // swiftlint:enable cyclomatic_complexity
 }

--- a/Pastura/Pastura/Views/Components/PhaseGlyph.swift
+++ b/Pastura/Pastura/Views/Components/PhaseGlyph.swift
@@ -3,12 +3,12 @@ import Foundation
 /// Single source of truth for the `PhaseType` → SF Symbol mapping used by
 /// the shared-scenario detail screen's "What happens" phase-step surface.
 ///
-/// 6 of the 10 kinds intentionally reuse the Browse art-tile glyphs
+/// 6 of the 11 kinds intentionally reuse the Browse art-tile glyphs
 /// (``ScenarioSignaturePhase/sfSymbolName`` in `GalleryCatalogRow.swift`) to
 /// keep one visual language across the two gallery surfaces — a parity test
 /// (`PhaseGlyphTests`) guards the two mappings against drift. The remaining
-/// 4 kinds (`speak_all`, `speak_each`, `assign`, `summarize`) have no
-/// `ScenarioSignaturePhase` counterpart (that enum only maps the "headline"
+/// 5 kinds (`speak_all`, `speak_each`, `assign`, `summarize`, `reflect`) have
+/// no `ScenarioSignaturePhase` counterpart (that enum only maps the "headline"
 /// mechanic kinds) and get their own symbol here.
 ///
 /// Left MainActor-default (not `nonisolated`) to mirror ``PhaseDisplayName``
@@ -16,6 +16,9 @@ import Foundation
 /// (swift-isolation.md Pattern 5).
 public enum PhaseGlyph {
 
+  // Pure name-mapping switch (one line per phase type). The 11-case count
+  // exceeds SwiftLint's cyclomatic threshold but carries no branching logic.
+  // swiftlint:disable cyclomatic_complexity
   /// SF Symbol name for `phase`'s glyph badge.
   public static func symbolName(for phase: PhaseType) -> String {
     switch phase {
@@ -23,6 +26,7 @@ public enum PhaseGlyph {
     case .speakEach: return "bubble.left"
     case .vote: return "checkmark.square"
     case .choose: return "arrow.triangle.branch"
+    case .reflect: return "square.and.pencil"
     case .scoreCalc: return "chart.bar"
     case .assign: return "tag"
     case .eliminate: return "xmark.circle"
@@ -31,4 +35,5 @@ public enum PhaseGlyph {
     case .eventInject: return "bolt.fill"
     }
   }
+  // swiftlint:enable cyclomatic_complexity
 }

--- a/Pastura/Pastura/Views/Editor/PhaseBlockRow.swift
+++ b/Pastura/Pastura/Views/Editor/PhaseBlockRow.swift
@@ -33,7 +33,7 @@ struct PhaseBlockRow: View {
   /// A brief human-readable summary of the phase content.
   private var summary: String {
     switch phase.type {
-    case .speakAll, .speakEach, .vote, .choose:
+    case .speakAll, .speakEach, .vote, .choose, .reflect:
       return phase.prompt.prefix(50).trimmingCharacters(in: .whitespacesAndNewlines)
     case .scoreCalc:
       return phase.logic?.rawValue ?? "—"

--- a/Pastura/Pastura/Views/Editor/PhaseEditorSheet+CanonicalFieldHint.swift
+++ b/Pastura/Pastura/Views/Editor/PhaseEditorSheet+CanonicalFieldHint.swift
@@ -61,6 +61,11 @@ extension PhaseEditorSheet {
       )
     case .vote:
       return String(localized: "Use `vote` for the target name.")
+    case .reflect:
+      return String(
+        localized:
+          "Use `note` for the agent's private memo. This is the reflect phase's only output field."
+      )
     case .scoreCalc, .assign, .eliminate, .summarize, .conditional, .eventInject:
       return nil
     }

--- a/Pastura/Pastura/Views/Editor/PhaseEditorSheet.swift
+++ b/Pastura/Pastura/Views/Editor/PhaseEditorSheet.swift
@@ -25,10 +25,11 @@ struct PhaseEditorSheet: View {
   let onSave: (EditablePhase) -> Void
 
   /// Phase types selectable in the picker. Call sites pass
-  /// `PhaseType.allCases.filter { $0 != .conditional }` when opening the
-  /// sheet for a nested sub-phase of a conditional — this is how the
-  /// depth-1 rule is enforced at the UI layer. The validator and loader
-  /// have the same check as a safety net.
+  /// `PhaseType.allCases.filter { $0 != .conditional && $0 != .reflect }` when
+  /// opening the sheet for a nested sub-phase of a conditional — this is how
+  /// the depth-1 rule (and the "no reflect inside a conditional" rule) is
+  /// enforced at the UI layer. The validator and loader have the same checks
+  /// as a safety net.
   var availableTypes: [PhaseType] = PhaseType.allCases
 
   /// Content validator for the Save-tap inline check (#261). Default-
@@ -99,17 +100,18 @@ struct PhaseEditorSheet: View {
         }
       }
       .sheet(item: $editingSubPhase) { context in
-        // Nested editor — filter `.conditional` out of the picker so the
-        // depth-1 rule is enforced at the UI layer (the validator + loader
-        // also reject nested conditional as defense in depth). The
-        // validator is forwarded so nested Save runs against the same
-        // blocklist instance the outer sheet uses (#261).
+        // Nested editor — filter `.conditional` (depth-1 rule) and `.reflect`
+        // (not supported inside a conditional in v1) out of the picker so both
+        // rules are enforced at the UI layer (the validator + loader also
+        // reject them as defense in depth). The validator is forwarded so
+        // nested Save runs against the same blocklist instance the outer sheet
+        // uses (#261).
         PhaseEditorSheet(
           phase: context.phase,
           onSave: { edited in
             writeBackSubPhase(edited, context: context)
           },
-          availableTypes: PhaseType.allCases.filter { $0 != .conditional },
+          availableTypes: PhaseType.allCases.filter { $0 != .conditional && $0 != .reflect },
           validator: validator
         )
         .deepLinkGated()
@@ -218,7 +220,9 @@ struct PhaseEditorSheet: View {
       assignSection
     case .summarize:
       summarizeSection
-    case .speakAll, .eliminate:
+    case .speakAll, .reflect, .eliminate:
+      // reflect is a prompt-based LLM phase with no extra config beyond the
+      // shared prompt + output-fields sections (like speak_all).
       EmptyView()
     case .conditional:
       conditionalSection
@@ -373,6 +377,8 @@ struct PhaseEditorSheet: View {
     case .speakEach: return String(localized: "Agents speak in turn (accumulating context)")
     case .vote: return String(localized: "All agents vote for one agent")
     case .choose: return String(localized: "Choose from predefined options")
+    case .reflect:
+      return String(localized: "Each agent privately updates a short memo about the situation.")
     case .scoreCalc: return String(localized: "Calculate scores (code, no LLM)")
     case .assign: return String(localized: "Distribute info to agents (code)")
     case .eliminate: return String(localized: "Remove most-voted agent (code)")

--- a/Pastura/Pastura/Views/Editor/PhaseEditorSheet.swift
+++ b/Pastura/Pastura/Views/Editor/PhaseEditorSheet.swift
@@ -378,7 +378,7 @@ struct PhaseEditorSheet: View {
     case .vote: return String(localized: "All agents vote for one agent")
     case .choose: return String(localized: "Choose from predefined options")
     case .reflect:
-      return String(localized: "Each agent privately updates a short memo about the situation.")
+      return String(localized: "Each agent privately updates a short memo about the situation")
     case .scoreCalc: return String(localized: "Calculate scores (code, no LLM)")
     case .assign: return String(localized: "Distribute info to agents (code)")
     case .eliminate: return String(localized: "Remove most-voted agent (code)")

--- a/Pastura/PasturaTests/App/EditablePhaseTests.swift
+++ b/Pastura/PasturaTests/App/EditablePhaseTests.swift
@@ -37,6 +37,14 @@ struct EditablePhaseTests {
     #expect(sut.outputFields == ["action": "string", "inner_thought": "string"])
   }
 
+  @Test func seedReflectAddsNoteOnly() {
+    // reflect's canonical primary is `note` and it has no secondary thought
+    // field, so seeding adds exactly `{ note }`.
+    var sut = EditablePhase(type: .reflect)
+    sut.reconcileCanonicalOutputFields(from: nil)
+    #expect(sut.outputFields == ["note": "string"])
+  }
+
   @Test func seedCodePhaseAddsNothing() {
     for type in [PhaseType.scoreCalc, .assign, .eliminate, .summarize, .conditional, .eventInject] {
       var sut = EditablePhase(type: type)

--- a/Pastura/PasturaTests/App/ScenarioEditorViewModelTests.swift
+++ b/Pastura/PasturaTests/App/ScenarioEditorViewModelTests.swift
@@ -336,6 +336,44 @@ struct ScenarioEditorViewModelTests {
     #expect(reloaded.extraData["topics"] == .array(["Photo A", "Photo B", "Photo C"]))
   }
 
+  /// A `log_window` set in YAML has no Visual UI, so `editorLogWindow` must be
+  /// carried through `buildScenario()` on a visual-mode save — same pattern as
+  /// `carriedExtraData` / `editorSimulationLanguage` (#907).
+  @Test func visualModeSavePreservesLogWindow() async throws {
+    let (sut, repo) = try makeSUTWithRepo()
+    let yaml = """
+      id: lw_visual_save_test
+      language: ja
+      name: LW Visual Save Test
+      description: Tests log_window survival on visual-mode save
+      agents: 2
+      rounds: 1
+      log_window: 5
+      context: Context
+      personas:
+        - name: Alice
+          description: Agent A
+        - name: Bob
+          description: Agent B
+      phases:
+        - type: speak_all
+          prompt: "Say something"
+          output:
+            statement: string
+      """
+    sut.loadFromTemplate(yaml: yaml)
+    #expect(sut.editorMode == .visual)
+    #expect(sut.editorLogWindow == 5)
+
+    let success = await sut.save()
+
+    #expect(success)
+    let savedId = try #require(sut.savedScenarioId)
+    let record = try repo.fetchById(savedId)
+    let reloaded = try ScenarioLoader().load(yaml: record?.yamlDefinition ?? "")
+    #expect(reloaded.logWindow == 5)
+  }
+
   @Test func saveSurfacesSourceNotFoundValidationMessage() async throws {
     let sut = try makeSUT()
     // YAML with an `assign` phase referencing a non-existent `topics` source.

--- a/Pastura/PasturaTests/Engine/ConditionalValidatorTests+Reflect.swift
+++ b/Pastura/PasturaTests/Engine/ConditionalValidatorTests+Reflect.swift
@@ -1,0 +1,49 @@
+import Testing
+
+@testable import Pastura
+
+/// reflect is NOT allowed inside a conditional branch in v1. The validator
+/// rejects it at load-time (mirroring the nested-conditional rejection) so it
+/// fails here rather than at `ConditionalHandler` dispatch. Split into a
+/// sibling extension (not a new `@Suite`) per `.claude/rules/testing.md` so it
+/// shares `ConditionalValidatorTests`'s serialization and keeps the main file
+/// under the `type_body_length` cap.
+extension ConditionalValidatorTests {
+
+  @Test func rejectsReflectInThenBranch() {
+    let scenario = makeScenario(phases: [
+      Phase(
+        type: .conditional,
+        condition: "current_round == 1",
+        thenPhases: [
+          Phase(type: .reflect, prompt: "Reflect.", outputSchema: ["note": "string"])
+        ]
+      )
+    ])
+    #expect(throws: SimulationError.self) {
+      try validator.validate(scenario)
+    }
+  }
+
+  @Test func rejectsReflectInElseBranch() {
+    let scenario = makeScenario(phases: [
+      Phase(
+        type: .conditional,
+        condition: "current_round == 1",
+        thenPhases: [Phase(type: .summarize, template: "ok")],
+        elsePhases: [
+          Phase(type: .reflect, prompt: "Reflect.", outputSchema: ["note": "string"])
+        ]
+      )
+    ])
+    do {
+      _ = try validator.validate(scenario)
+      Issue.record("Expected validation to throw for reflect inside a conditional branch")
+    } catch let SimulationError.scenarioValidationFailed(message) {
+      #expect(message.contains("else[1]"))
+      #expect(message.contains("reflect"))
+    } catch {
+      Issue.record("Unexpected error: \(error)")
+    }
+  }
+}

--- a/Pastura/PasturaTests/Engine/PhaseDispatcherTests.swift
+++ b/Pastura/PasturaTests/Engine/PhaseDispatcherTests.swift
@@ -31,11 +31,7 @@ struct PhaseDispatcherTests {
       case .eventInject:
         #expect(try dispatcher.handler(for: phaseType) is EventInjectHandler)
       case .reflect:
-        // ReflectHandler is added in a follow-up (issue #907, item 2). Until
-        // then no handler is registered, so dispatch throws.
-        #expect(throws: SimulationError.self) {
-          try dispatcher.handler(for: phaseType)
-        }
+        #expect(try dispatcher.handler(for: phaseType) is ReflectHandler)
       }
     }
   }

--- a/Pastura/PasturaTests/Engine/PhaseDispatcherTests.swift
+++ b/Pastura/PasturaTests/Engine/PhaseDispatcherTests.swift
@@ -30,6 +30,12 @@ struct PhaseDispatcherTests {
         #expect(try dispatcher.handler(for: phaseType) is ConditionalHandler)
       case .eventInject:
         #expect(try dispatcher.handler(for: phaseType) is EventInjectHandler)
+      case .reflect:
+        // ReflectHandler is added in a follow-up (issue #907, item 2). Until
+        // then no handler is registered, so dispatch throws.
+        #expect(throws: SimulationError.self) {
+          try dispatcher.handler(for: phaseType)
+        }
       }
     }
   }

--- a/Pastura/PasturaTests/Engine/Phases/ReflectHandlerTests.swift
+++ b/Pastura/PasturaTests/Engine/Phases/ReflectHandlerTests.swift
@@ -1,0 +1,152 @@
+import Testing
+
+@testable import Pastura
+
+@Suite(.timeLimit(.minutes(1)))
+struct ReflectHandlerTests {
+  let handler = ReflectHandler()
+
+  private func reflectPhase(prompt: String? = "Reflect!") -> Phase {
+    Phase(type: .reflect, prompt: prompt, outputSchema: ["note": "string"])
+  }
+
+  @Test func storesNoteUnderNotesKeyForEachAgent() async throws {
+    let mock = MockLLMService(responses: [
+      #"{"note": "Alice suspects Bob"}"#,
+      #"{"note": "Bob trusts no one"}"#
+    ])
+    try await mock.loadModel()
+
+    let scenario = makeTestScenario(
+      agentNames: ["Alice", "Bob"],
+      phases: [reflectPhase()]
+    )
+    var state = SimulationState.initial(for: scenario)
+    state.currentRound = 1
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    #expect(state.variables["notes_Alice"] == "Alice suspects Bob")
+    #expect(state.variables["notes_Bob"] == "Bob trusts no one")
+  }
+
+  @Test func emitsAgentOutputWithReflectPhaseType() async throws {
+    let mock = MockLLMService(responses: [
+      #"{"note": "a"}"#,
+      #"{"note": "b"}"#
+    ])
+    try await mock.loadModel()
+
+    let scenario = makeTestScenario(
+      agentNames: ["Alice", "Bob"],
+      phases: [reflectPhase()]
+    )
+    var state = SimulationState.initial(for: scenario)
+    state.currentRound = 1
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    let reflectAgents = collector.events.compactMap { event -> String? in
+      if case .agentOutput(let agent, _, let phaseType) = event, phaseType == .reflect {
+        return agent
+      }
+      return nil
+    }
+    #expect(reflectAgents == ["Alice", "Bob"])
+  }
+
+  @Test func doesNotAppendToConversationLog() async throws {
+    let mock = MockLLMService(responses: [
+      #"{"note": "private memo"}"#
+    ])
+    try await mock.loadModel()
+
+    let scenario = makeTestScenario(
+      agentNames: ["Alice"],
+      phases: [reflectPhase()]
+    )
+    var state = SimulationState.initial(for: scenario)
+    state.currentRound = 1
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    #expect(state.conversationLog.isEmpty)
+  }
+
+  @Test func doesNotUpdateLastOutputs() async throws {
+    let mock = MockLLMService(responses: [
+      #"{"note": "private memo"}"#
+    ])
+    try await mock.loadModel()
+
+    let scenario = makeTestScenario(
+      agentNames: ["Alice"],
+      phases: [reflectPhase()]
+    )
+    var state = SimulationState.initial(for: scenario)
+    state.currentRound = 1
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    #expect(state.lastOutputs["Alice"] == nil)
+  }
+
+  @Test func skipsEliminatedAgents() async throws {
+    let mock = MockLLMService(responses: [
+      #"{"note": "Alice note"}"#,
+      #"{"note": "Charlie note"}"#
+    ])
+    try await mock.loadModel()
+
+    let scenario = makeTestScenario(
+      agentNames: ["Alice", "Bob", "Charlie"],
+      phases: [reflectPhase()]
+    )
+    var state = SimulationState.initial(for: scenario)
+    state.currentRound = 1
+    state.eliminated["Bob"] = true
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    #expect(mock.generateCallCount == 2)
+    #expect(state.variables["notes_Bob"] == nil)
+    #expect(state.variables["notes_Alice"] == "Alice note")
+    #expect(state.variables["notes_Charlie"] == "Charlie note")
+  }
+
+  // An empty note (LLM returned "" after exhausting the empty-field retry
+  // budget) must NOT overwrite the previous round's memo. Three identical
+  // empty responses cover maxRetries (2) + the initial attempt.
+  @Test func emptyNoteDoesNotErasePreExistingNote() async throws {
+    let mock = MockLLMService(responses: [
+      #"{"note": ""}"#,
+      #"{"note": ""}"#,
+      #"{"note": ""}"#
+    ])
+    try await mock.loadModel()
+
+    let scenario = makeTestScenario(
+      agentNames: ["Alice"],
+      phases: [reflectPhase()]
+    )
+    var state = SimulationState.initial(for: scenario)
+    state.currentRound = 1
+    state.variables["notes_Alice"] = "prior round memo"
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    #expect(state.variables["notes_Alice"] == "prior round memo")
+  }
+}

--- a/Pastura/PasturaTests/Engine/Phases/SpeakAllHandlerTests.swift
+++ b/Pastura/PasturaTests/Engine/Phases/SpeakAllHandlerTests.swift
@@ -73,6 +73,40 @@ struct SpeakAllHandlerTests {
     #expect(agentOutputs == ["Alice", "Bob"])
   }
 
+  /// The user prompt's `{conversation_log}` expansion honors
+  /// `scenario.logWindow` — only the last N prior entries reach the LLM (#907).
+  @Test func userPromptRespectsLogWindow() async throws {
+    let mock = MockLLMService(responses: [#"{"statement": "reply"}"#])
+    try await mock.loadModel()
+
+    let scenario = Scenario(
+      id: "lw", name: "LW", description: "log window handler test",
+      language: "en", agentCount: 1, rounds: 1, context: "Context",
+      personas: [Persona(name: "Alice", description: "A")],
+      phases: [
+        Phase(
+          type: .speakAll, prompt: "Log: {conversation_log}",
+          outputSchema: ["statement": "string"])
+      ],
+      logWindow: 2)
+    var state = SimulationState.initial(for: scenario)
+    state.currentRound = 2
+    state.conversationLog = [
+      ConversationEntry(agentName: "Alice", content: "oldest", phaseType: .speakAll, round: 1),
+      ConversationEntry(agentName: "Bob", content: "middle", phaseType: .speakAll, round: 1),
+      ConversationEntry(agentName: "Carol", content: "newest", phaseType: .speakAll, round: 1)
+    ]
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    let userPrompt = try #require(mock.capturedPrompts.first).user
+    #expect(!userPrompt.contains("oldest"))
+    #expect(userPrompt.contains("middle"))
+    #expect(userPrompt.contains("newest"))
+  }
+
   @Test func updatesConversationLog() async throws {
     let mock = MockLLMService(responses: [
       #"{"statement": "Alice says hi"}"#,

--- a/Pastura/PasturaTests/Engine/PromptBuilderTests+Hardening.swift
+++ b/Pastura/PasturaTests/Engine/PromptBuilderTests+Hardening.swift
@@ -199,6 +199,95 @@ extension PromptBuilderTests {
   // `inner_thought` — alphabetical would invert this and break
   // PartialOutputExtractor's streaming UX (user sees nothing until
   // inner_thought finishes). Source of truth: OutputSchema.fields.
+  // MARK: - Reflect private-notes injection (#907)
+
+  // The agent's own prior-round memo is surfaced in the system prompt
+  // (invisible to other participants) so subsequent LLM calls are
+  // grounded in what the agent privately concluded.
+  @Test func systemPromptContainsPrivateNotesSectionWhenSet() {
+    let scenario = makeScenario()
+    let phase = Phase(type: .speakAll, prompt: "Speak!", outputSchema: ["statement": "string"])
+    var state = SimulationState.initial(for: scenario)
+    state.variables["notes_Alice"] = "I suspect Bob is the wolf."
+
+    let prompt = builder.buildSystemPrompt(
+      scenario: scenario, persona: scenario.personas[0], phase: phase, state: state
+    )
+    #expect(prompt.contains("あなたの内心メモ"))
+    #expect(prompt.contains("I suspect Bob is the wolf."))
+  }
+
+  @Test func systemPromptOmitsPrivateNotesSectionWhenUnset() {
+    let scenario = makeScenario()
+    let phase = Phase(type: .speakAll, prompt: "Speak!", outputSchema: ["statement": "string"])
+    let state = SimulationState.initial(for: scenario)
+
+    let prompt = builder.buildSystemPrompt(
+      scenario: scenario, persona: scenario.personas[0], phase: phase, state: state
+    )
+    #expect(!prompt.contains("あなたの内心メモ"))
+  }
+
+  @Test func systemPromptPrivateNotesSectionEnHeader() {
+    let scenario = makeScenario(language: "en")
+    let phase = Phase(type: .speakAll, prompt: "Speak!", outputSchema: ["statement": "string"])
+    var state = SimulationState.initial(for: scenario)
+    state.variables["notes_Alice"] = "Bob seems nervous."
+
+    let prompt = builder.buildSystemPrompt(
+      scenario: scenario, persona: scenario.personas[0], phase: phase, state: state
+    )
+    #expect(prompt.contains("Your Private Notes"))
+    #expect(prompt.contains("Bob seems nervous."))
+  }
+
+  @Test func injectNotesSetsMyNotesFromNamespacedKey() {
+    var variables = ["notes_Alice": "remember the clue"]
+    builder.injectNotes(into: &variables, personaName: "Alice")
+    #expect(variables["my_notes"] == "remember the clue")
+  }
+
+  @Test func injectNotesSetsEmptyStringOnMiss() {
+    var variables: [String: String] = [:]
+    builder.injectNotes(into: &variables, personaName: "Alice")
+    #expect(variables["my_notes"] == "")
+  }
+
+  // The reflect-specific brevity rule caps the note at 2 sentences, matching
+  // the #877 constraint family. It must appear ONLY for reflect phases.
+  @Test func reflectAnswerRulesIncludeTwoSentenceBrevityJa() {
+    let scenario = makeScenario()
+    let phase = Phase(type: .reflect, prompt: "Reflect!", outputSchema: ["note": "string"])
+    let state = SimulationState.initial(for: scenario)
+
+    let prompt = builder.buildSystemPrompt(
+      scenario: scenario, persona: scenario.personas[0], phase: phase, state: state
+    )
+    #expect(prompt.contains("2文以内"))
+  }
+
+  @Test func reflectAnswerRulesIncludeTwoSentenceBrevityEn() {
+    let scenario = makeScenario(language: "en")
+    let phase = Phase(type: .reflect, prompt: "Reflect!", outputSchema: ["note": "string"])
+    let state = SimulationState.initial(for: scenario)
+
+    let prompt = builder.buildSystemPrompt(
+      scenario: scenario, persona: scenario.personas[0], phase: phase, state: state
+    )
+    #expect(prompt.contains("at most 2 sentences"))
+  }
+
+  @Test func nonReflectPhaseOmitsTwoSentenceBrevityRule() {
+    let scenario = makeScenario()
+    let phase = Phase(type: .speakAll, prompt: "Speak!", outputSchema: ["statement": "string"])
+    let state = SimulationState.initial(for: scenario)
+
+    let prompt = builder.buildSystemPrompt(
+      scenario: scenario, persona: scenario.personas[0], phase: phase, state: state
+    )
+    #expect(!prompt.contains("2文以内"))
+  }
+
   @Test func systemPromptExampleUsesPrimaryFirstOrder() {
     let scenario = makeScenario()
     let phase = Phase(

--- a/Pastura/PasturaTests/Engine/PromptBuilderTests.swift
+++ b/Pastura/PasturaTests/Engine/PromptBuilderTests.swift
@@ -55,6 +55,41 @@ struct PromptBuilderTests {
     #expect(result.contains("Bob: Hi there!"))
   }
 
+  // MARK: - Conversation Log Window (#907)
+
+  private var threeEntries: [ConversationEntry] {
+    [
+      ConversationEntry(agentName: "Alice", content: "one", phaseType: .speakAll, round: 1),
+      ConversationEntry(agentName: "Bob", content: "two", phaseType: .speakAll, round: 1),
+      ConversationEntry(agentName: "Charlie", content: "three", phaseType: .speakAll, round: 1)
+    ]
+  }
+
+  @Test func windowKeepsOnlyLastNEntries() {
+    let result = builder.formatConversationLog(threeEntries, language: "en", window: 2)
+    #expect(!result.contains("Alice: one"))
+    #expect(result.contains("Bob: two"))
+    #expect(result.contains("Charlie: three"))
+  }
+
+  @Test func windowLargerThanCountKeepsAll() {
+    let result = builder.formatConversationLog(threeEntries, language: "en", window: 10)
+    #expect(result.contains("Alice: one"))
+    #expect(result.contains("Bob: two"))
+    #expect(result.contains("Charlie: three"))
+  }
+
+  @Test func nilWindowKeepsAll() {
+    let result = builder.formatConversationLog(threeEntries, language: "en", window: nil)
+    #expect(result.contains("Alice: one"))
+    #expect(result.contains("Charlie: three"))
+  }
+
+  @Test func windowWithEmptyLogYieldsPlaceholder() {
+    let result = builder.formatConversationLog([], language: "en", window: 2)
+    #expect(result == "(none yet)")
+  }
+
   // MARK: - Get Main Field
 
   /// Speak phases route the canonical `statement` field into the

--- a/Pastura/PasturaTests/Engine/ScenarioLoaderTests.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioLoaderTests.swift
@@ -42,6 +42,64 @@ struct ScenarioLoaderTests {
     #expect(scenario.phases.count == 1)
   }
 
+  // MARK: - log_window (#907)
+
+  @Test func parsesLogWindow() throws {
+    let yaml = """
+      id: lw_test
+      language: ja
+      name: LW
+      description: log window test
+      agents: 2
+      rounds: 1
+      log_window: 5
+      context: Context
+      personas:
+        - name: Alice
+          description: A
+        - name: Bob
+          description: B
+      phases:
+        - type: speak_all
+          prompt: Go
+          output:
+            statement: string
+      """
+    let scenario = try loader.load(yaml: yaml)
+    #expect(scenario.logWindow == 5)
+  }
+
+  @Test func absentLogWindowIsNil() throws {
+    let scenario = try loader.load(yaml: makeMinimalYAML())
+    #expect(scenario.logWindow == nil)
+  }
+
+  @Test func rejectsNonIntLogWindow() {
+    let yaml = """
+      id: lw_bad
+      language: ja
+      name: LW
+      description: log window test
+      agents: 2
+      rounds: 1
+      log_window: "five"
+      context: Context
+      personas:
+        - name: Alice
+          description: A
+        - name: Bob
+          description: B
+      phases:
+        - type: speak_all
+          prompt: Go
+          output:
+            statement: string
+      """
+    #expect(throws: SimulationError.self) {
+      try loader.load(yaml: yaml)
+    }
+  }
+
   @Test func parsesPersonasCorrectly() throws {
     let scenario = try loader.load(yaml: makeMinimalYAML())
     #expect(scenario.personas[0].name == "Alice")

--- a/Pastura/PasturaTests/Engine/ScenarioSerializerTests.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioSerializerTests.swift
@@ -284,6 +284,34 @@ struct ScenarioSerializerTests {
     #expect(reloaded.phases[0].probability == 1.0)
   }
 
+  // MARK: - log_window (#907)
+
+  @Test func serializesLogWindowWhenSet() throws {
+    let scenario = makeLogWindowScenario(logWindow: 5)
+    let yaml = serializer.serialize(scenario)
+    #expect(yaml.contains("log_window: 5"))
+    let reloaded = try loader.load(yaml: yaml)
+    #expect(reloaded.logWindow == 5)
+  }
+
+  @Test func omitsLogWindowWhenNil() throws {
+    let scenario = makeLogWindowScenario(logWindow: nil)
+    let yaml = serializer.serialize(scenario)
+    #expect(!yaml.contains("log_window"))
+    let reloaded = try loader.load(yaml: yaml)
+    #expect(reloaded.logWindow == nil)
+  }
+
+  private func makeLogWindowScenario(logWindow: Int?) -> Scenario {
+    Scenario(
+      id: "lw_test", name: "LW", description: "Log window round-trip",
+      language: "ja", agentCount: 2, rounds: 1, context: "Context",
+      personas: [Persona(name: "Alice", description: "A"), Persona(name: "Bob", description: "B")],
+      phases: [Phase(type: .speakAll, prompt: "Go", outputSchema: ["statement": "string"])],
+      logWindow: logWindow
+    )
+  }
+
   // MARK: - Helpers
 
   private func assertRoundTrip(presetNamed name: String) throws {

--- a/Pastura/PasturaTests/Engine/ScenarioValidatorTests+Commit.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioValidatorTests+Commit.swift
@@ -102,6 +102,34 @@ extension ScenarioValidatorTests {
     }
   }
 
+  // MARK: - Reflect (canonical: note, no secondary field)
+
+  @Test func validateForCommit_acceptsReflectWithNote() throws {
+    let phase = Phase(
+      type: .reflect, prompt: "Reflect.",
+      outputSchema: ["note": "string"])
+    let scenario = makeScenario(agents: 2, rounds: 1, phases: [phase])
+    _ = try validator.validateForCommit(scenario)
+  }
+
+  @Test func validateForCommit_rejectsReflectWithoutNote() {
+    let phase = Phase(
+      type: .reflect, prompt: "Reflect.",
+      outputSchema: ["memo": "string"])
+    let scenario = makeScenario(agents: 2, rounds: 1, phases: [phase])
+    #expect(throws: SimulationError.self) {
+      try validator.validateForCommit(scenario)
+    }
+  }
+
+  @Test func validateForCommit_rejectsReflectWithMissingOutputSchema() {
+    let phase = Phase(type: .reflect, prompt: "Reflect.")
+    let scenario = makeScenario(agents: 2, rounds: 1, phases: [phase])
+    #expect(throws: SimulationError.self) {
+      try validator.validateForCommit(scenario)
+    }
+  }
+
   // MARK: - Code phases (no canonical field — exempt)
 
   @Test func validateForCommit_acceptsCodePhases() throws {

--- a/Pastura/PasturaTests/Engine/ScenarioValidatorTests.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioValidatorTests.swift
@@ -113,10 +113,33 @@ struct ScenarioValidatorTests {
     // 5 agents × (speak_all + reflect) × 2 rounds = 20.
     let scenario = makeScenario(
       agents: 5, rounds: 2,
-      phases: [Phase(type: .speakAll), Phase(type: .reflect)]
+      phases: [Phase(type: .speakAll), Phase(type: .reflect, outputSchema: ["note": "string"])]
     )
     let result = try validator.validate(scenario)
     #expect(result.estimatedInferences == 20)
+  }
+
+  @Test func rejectsReflectWithoutNoteOutputAtRunGate() {
+    // Run-gate strictness beyond sibling LLM phases: a schema-less reflect is
+    // a pure no-op inference (nothing stored, no visible symptom), so
+    // `validate` — not just `validateForCommit` — requires the `note` field.
+    let scenario = makeScenario(
+      agents: 2, rounds: 1,
+      phases: [Phase(type: .reflect)]
+    )
+    #expect(throws: SimulationError.self) {
+      try validator.validate(scenario)
+    }
+  }
+
+  @Test func acceptsReflectWithExtraOutputFieldAlongsideNote() throws {
+    // Only `note` presence is required at the run gate; additional fields
+    // (unusual but legal) do not trip it.
+    let scenario = makeScenario(
+      agents: 2, rounds: 1,
+      phases: [Phase(type: .reflect, outputSchema: ["note": "string", "mood": "string"])]
+    )
+    _ = try validator.validate(scenario)
   }
 
   @Test func rejectsPersonaCountMismatch() {

--- a/Pastura/PasturaTests/Engine/ScenarioValidatorTests.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioValidatorTests.swift
@@ -87,6 +87,17 @@ struct ScenarioValidatorTests {
     #expect(result.estimatedInferences == 20)
   }
 
+  @Test func reflectPhaseAddsAgentCountPerRound() throws {
+    // reflect costs one inference per agent per round (like speak_all / vote).
+    // 5 agents × (speak_all + reflect) × 2 rounds = 20.
+    let scenario = makeScenario(
+      agents: 5, rounds: 2,
+      phases: [Phase(type: .speakAll), Phase(type: .reflect)]
+    )
+    let result = try validator.validate(scenario)
+    #expect(result.estimatedInferences == 20)
+  }
+
   @Test func rejectsPersonaCountMismatch() {
     // Constructed directly because makeScenario auto-generates matching personas
     let scenario = Scenario(

--- a/Pastura/PasturaTests/Engine/ScenarioValidatorTests.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioValidatorTests.swift
@@ -52,6 +52,27 @@ struct ScenarioValidatorTests {
     }
   }
 
+  // MARK: - log_window (#907)
+
+  @Test func rejectsZeroLogWindow() {
+    let scenario = makeLogWindowScenario(logWindow: 0)
+    #expect(throws: SimulationError.self) {
+      try validator.validate(scenario)
+    }
+  }
+
+  @Test func acceptsLogWindowOfOne() throws {
+    let scenario = makeLogWindowScenario(logWindow: 1)
+    let result = try validator.validate(scenario)
+    #expect(result.warnings.isEmpty)
+  }
+
+  @Test func acceptsNilLogWindow() throws {
+    let scenario = makeLogWindowScenario(logWindow: nil)
+    let result = try validator.validate(scenario)
+    #expect(result.warnings.isEmpty)
+  }
+
   @Test func warnsWhenInferencesExceed50() throws {
     // 10 agents × (speak_all + vote) × 3 rounds = 60
     let scenario = makeScenario(
@@ -414,6 +435,17 @@ struct ScenarioValidatorTests {
       agentCount: agents, rounds: rounds, context: "Context",
       personas: (0..<agents).map { Persona(name: "A\($0)", description: "D") },
       phases: phases
+    )
+  }
+
+  private func makeLogWindowScenario(logWindow: Int?) -> Scenario {
+    Scenario(
+      id: "test", name: "Test", description: "Test",
+      language: "ja",
+      agentCount: 2, rounds: 1, context: "Context",
+      personas: [Persona(name: "A", description: "D"), Persona(name: "B", description: "D")],
+      phases: [Phase(type: .speakAll)],
+      logWindow: logWindow
     )
   }
 

--- a/Pastura/PasturaTests/Engine/ScenarioYAMLPatcherTests.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioYAMLPatcherTests.swift
@@ -9,6 +9,7 @@ import Testing
 /// updates, fallback parity for out-of-scope edits, semantic equivalence of the
 /// patched output, and corruption resistance on the documented edge cases.
 @Suite(.timeLimit(.minutes(1)))
+// swiftlint:disable:next type_body_length
 struct ScenarioYAMLPatcherTests {
 
   let patcher = ScenarioYAMLPatcher()
@@ -99,6 +100,43 @@ struct ScenarioYAMLPatcherTests {
     #expect(out.contains("rounds: 7"))
     #expect(out.contains("# A friendly scenario"))
     #expect(try loader.load(yaml: out) == visual)
+  }
+
+  @Test func logWindowScalarUpdateCarriesNewValue() throws {
+    let lwBase = """
+      # scenario with a log window
+      id: lw_demo
+      language: en
+      name: LW Demo
+      description: A test scenario
+      agents: 2
+      rounds: 3
+      log_window: 5  # keep last five
+      context: Shared context.
+      personas:
+        - name: Alice
+          description: An agent
+        - name: Bob
+          description: Another agent
+      phases:
+        - type: speak_all
+          prompt: Speak.
+          output:
+            statement: string
+      """
+    let baseScenario = try loader.load(yaml: lwBase)
+    let visual = Scenario(
+      id: baseScenario.id, name: baseScenario.name, description: baseScenario.description,
+      language: baseScenario.language, simulationLanguage: baseScenario.simulationLanguage,
+      agentCount: baseScenario.agentCount, rounds: baseScenario.rounds,
+      context: baseScenario.context, personas: baseScenario.personas,
+      phases: baseScenario.phases, logWindow: 3, extraData: baseScenario.extraData)
+    let out = patcher.patch(visual: visual, base: lwBase)
+
+    // Semantics: the reparse carries the new value (surgical or fallback).
+    #expect(try loader.load(yaml: out).logWindow == 3)
+    // This is an in-scope inline-scalar edit, so the comment is preserved too.
+    #expect(out.contains("# keep last five"))
   }
 
   // MARK: - Fallback parity

--- a/Pastura/PasturaTests/LLM/GBNFGrammarBuilderTests.swift
+++ b/Pastura/PasturaTests/LLM/GBNFGrammarBuilderTests.swift
@@ -38,9 +38,11 @@ struct GBNFGrammarBuilderTests {
     //      `init_grammar` returned NULL at parse time (top-level
     //      Kleene star on a char class seems to trip llama.cpp's
     //      grammar parser — same symptom as `ws ::= [ \t\n]*`).
-    // Final shape: `"}" trailing` with `trailing ::= ([^"\\] trailing)?`
-    // — recursive form parses cleanly AND accepts arbitrary trailing
-    // bytes. See in-code comments on `rootRule` and
+    // Final shape: `"}" trailing` with a BOUNDED chain
+    // `trailing ::= ([\t\n\r -~] trailing1)?` … `trailing15 ::= ([\t\n\r -~])?`
+    // — recursive positive-class form parses cleanly AND caps trailing
+    // bytes at 16 so the model can't emit unbounded fabricated follow-on
+    // objects (#907). See in-code comments on `rootRule` and
     // `sharedTrailingProduction` for the full rationale.
     let schema = OutputSchema(fields: [
       .init(name: "statement", kind: .string)
@@ -50,12 +52,32 @@ struct GBNFGrammarBuilderTests {
     #expect(
       rootLine.hasSuffix(#""}" trailing"#),
       "root must end with trailing rule reference, got: \(rootLine)")
-    // Trailing rule must itself be defined in the grammar with the
-    // positive-class recursive form (negation + recursion triggered
-    // parse-time NULL — see rationale in `sharedTrailingProduction`).
+    // The head link references `trailing1` (bounded chain), NOT itself —
+    // the unbounded self-reference invited fabricated follow-on objects.
     #expect(
-      grammar.contains(#"trailing ::= ([\t\n\r -~] trailing)?"#),
-      "grammar must define `trailing` in recursive + positive-class form")
+      grammar.contains(#"trailing ::= ([\t\n\r -~] trailing1)?"#),
+      "grammar must define `trailing` as the head of a bounded chain")
+    #expect(
+      !grammar.contains(#"trailing ::= ([\t\n\r -~] trailing)?"#),
+      "grammar must NOT contain the unbounded self-referential trailing rule")
+  }
+
+  @Test("trailing chain is bounded to 16 links, terminal link has no self-ref")
+  func trailingChainIsBounded() throws {
+    let schema = OutputSchema(fields: [
+      .init(name: "statement", kind: .string)
+    ])
+    let grammar = try builder.build(from: schema)
+    let trailingRules = grammar.components(separatedBy: "\n")
+      .filter { $0.hasPrefix("trailing") && $0.contains("::=") }
+    // 16 rules total: `trailing` head + `trailing1` … `trailing15`.
+    #expect(trailingRules.count == 16, "expected 16 trailing rules, got \(trailingRules.count)")
+    // Terminal link caps the recursion — accepts one byte, references nothing.
+    #expect(
+      grammar.contains(#"trailing15 ::= ([\t\n\r -~])?"#),
+      "terminal link `trailing15` must have no self/next reference")
+    // No trailing rule references a `trailing16` (off-by-one guard).
+    #expect(!grammar.contains("trailing16"))
   }
 
   @Test("ws production allows space / tab / newline (recursive form)")
@@ -309,7 +331,22 @@ struct GBNFGrammarBuilderTests {
   private static let sharedTail = """
     string ::= "\\"" ( [^"\\\\] | "\\\\" (["\\\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]) )* "\\""
     ws ::= ([ \\t\\n] ws)?
-    trailing ::= ([\\t\\n\\r -~] trailing)?
+    trailing ::= ([\\t\\n\\r -~] trailing1)?
+    trailing1 ::= ([\\t\\n\\r -~] trailing2)?
+    trailing2 ::= ([\\t\\n\\r -~] trailing3)?
+    trailing3 ::= ([\\t\\n\\r -~] trailing4)?
+    trailing4 ::= ([\\t\\n\\r -~] trailing5)?
+    trailing5 ::= ([\\t\\n\\r -~] trailing6)?
+    trailing6 ::= ([\\t\\n\\r -~] trailing7)?
+    trailing7 ::= ([\\t\\n\\r -~] trailing8)?
+    trailing8 ::= ([\\t\\n\\r -~] trailing9)?
+    trailing9 ::= ([\\t\\n\\r -~] trailing10)?
+    trailing10 ::= ([\\t\\n\\r -~] trailing11)?
+    trailing11 ::= ([\\t\\n\\r -~] trailing12)?
+    trailing12 ::= ([\\t\\n\\r -~] trailing13)?
+    trailing13 ::= ([\\t\\n\\r -~] trailing14)?
+    trailing14 ::= ([\\t\\n\\r -~] trailing15)?
+    trailing15 ::= ([\\t\\n\\r -~])?
     """
 
   // Choose phase: `action` is a `.choice` field, grammar-equivalent to

--- a/Pastura/PasturaTests/LLM/JSONResponseParserTests+Repair.swift
+++ b/Pastura/PasturaTests/LLM/JSONResponseParserTests+Repair.swift
@@ -177,6 +177,52 @@ extension JSONResponseParserTests {
     }
   }
 
+  // MARK: - Schema-guarded multi-object salvage (#907)
+
+  // Reflect's `{ note }` failure shape: the model completes a schema-valid
+  // first object then keeps emitting fabricated ASCII-only objects. With a
+  // non-empty schema the salvage extracts the first object (ignoring the
+  // #751 object-like-residue refusal) and reports `multi_object_salvage`.
+  @Test func salvagesFirstObjectWhenSchemaGuardPasses() throws {
+    let (output, kind) = try parser.parse(
+      #"{"note": "watch Alice"}{"vote_strategy": "fabricated"}"#,
+      expectedKeys: ["note"])
+    #expect(output.fields["note"] == "watch Alice")
+    #expect(kind == "multi_object_salvage")
+  }
+
+  // Posture pin (#751): the SAME multi-object raw with an EMPTY schema keeps
+  // the refusal — no salvage, the concatenated span fails to parse → throw.
+  @Test func multiObjectStillThrowsWithoutSchema() {
+    #expect(throws: LLMError.self) {
+      _ = try parser.parse(
+        #"{"note": "watch Alice"}{"vote_strategy": "fabricated"}"#,
+        expectedKeys: [])
+    }
+  }
+
+  // Salvage only fires when the FIRST object carries all expected keys with
+  // content. First object missing the required key → fall through to the
+  // repair pipeline, which can't salvage the balanced multi-object span →
+  // throw (no off-schema fabrication).
+  @Test func multiObjectThrowsWhenFirstObjectMissingExpectedKey() {
+    #expect(throws: LLMError.self) {
+      _ = try parser.parse(
+        #"{"statement": "hi"}{"note": "too late"}"#,
+        expectedKeys: ["note"])
+    }
+  }
+
+  // First object present-but-empty for the required key → salvage rejects it
+  // (empty value fails the schema guard) → fall through → throw.
+  @Test func multiObjectThrowsWhenFirstObjectHasEmptyExpectedKey() {
+    #expect(throws: LLMError.self) {
+      _ = try parser.parse(
+        #"{"note": ""}{"note": "later"}"#,
+        expectedKeys: ["note"])
+    }
+  }
+
   // Fully empty / unparseable → throw, no fake fabrication.
   @Test func throwsOnFullyMalformedInput() {
     #expect(throws: LLMError.self) {

--- a/Pastura/PasturaTests/LLM/PartialOutputExtractorTests.swift
+++ b/Pastura/PasturaTests/LLM/PartialOutputExtractorTests.swift
@@ -58,6 +58,15 @@ struct PartialOutputExtractorTests {
     }
   }
 
+  @Test func reflectNoteStreamsAsPrimary() {
+    // reflect's canonical primary field is `note`; a partial reflect JSON must
+    // yield a live primary snapshot as it types in.
+    let partial = extractor.extract(from: #"{"note":"I should keep quiet abo"#)
+    #expect(partial.primary == "I should keep quiet abo")
+    let complete = extractor.extract(from: #"{"note":"I should keep quiet."}"#)
+    #expect(complete.primary == "I should keep quiet.")
+  }
+
   // MARK: - Thought
 
   @Test func thoughtResolvesAfterPrimary() {

--- a/Pastura/PasturaTests/Models/OutputSchemaTests.swift
+++ b/Pastura/PasturaTests/Models/OutputSchemaTests.swift
@@ -42,6 +42,18 @@ struct OutputSchemaTests {
     #expect(schema.fields.map(\.name) == ["action", "inner_thought"])
   }
 
+  @Test("reflect note is a plain-string primary field")
+  func reflectNoteIsStringPrimary() throws {
+    let schema = try #require(
+      OutputSchema.from(
+        phase: Phase(
+          type: .reflect, prompt: "…",
+          outputSchema: ["note": "string"])))
+    #expect(schema.fields.map(\.name) == ["note"])
+    let noteField = try #require(schema.fields.first { $0.name == "note" })
+    #expect(noteField.kind == .string)
+  }
+
   @Test("input order swap yields identical field order (stability)")
   func inputOrderSwapIsStable() throws {
     let forward = try #require(

--- a/Pastura/PasturaTests/Models/PhaseTypeTests.swift
+++ b/Pastura/PasturaTests/Models/PhaseTypeTests.swift
@@ -16,10 +16,11 @@ struct PhaseTypeTests {
     #expect(PhaseType.summarize.rawValue == "summarize")
     #expect(PhaseType.conditional.rawValue == "conditional")
     #expect(PhaseType.eventInject.rawValue == "event_inject")
+    #expect(PhaseType.reflect.rawValue == "reflect")
   }
 
   @Test func allCasesCount() {
-    #expect(PhaseType.allCases.count == 10)
+    #expect(PhaseType.allCases.count == 11)
   }
 
   @Test func llmPhasesRequireLLM() {
@@ -27,6 +28,8 @@ struct PhaseTypeTests {
     #expect(PhaseType.speakEach.requiresLLM)
     #expect(PhaseType.vote.requiresLLM)
     #expect(PhaseType.choose.requiresLLM)
+    // reflect is an LLM phase: each agent privately updates a `note`.
+    #expect(PhaseType.reflect.requiresLLM)
   }
 
   @Test func codePhasesDoNotRequireLLM() {

--- a/Pastura/PasturaTests/Models/ScenarioConventionsTests.swift
+++ b/Pastura/PasturaTests/Models/ScenarioConventionsTests.swift
@@ -21,6 +21,10 @@ struct ScenarioConventionsTests {
     #expect(ScenarioConventions.primaryField(for: .vote) == "vote")
   }
 
+  @Test func primaryFieldForReflectReturnsNote() {
+    #expect(ScenarioConventions.primaryField(for: .reflect) == "note")
+  }
+
   /// Code phases emit no LLM output — `nil` is the contract for callers that
   /// need to distinguish "no primary field expected" from "primary field
   /// missing".
@@ -41,7 +45,7 @@ struct ScenarioConventionsTests {
   /// `nil` (code phases). Compiler exhaustiveness already catches a *missing*
   /// case in `primaryField(for:)`; this test catches a *wrong* classification.
   @Test func everyPhaseTypeMapsToCanonicalSetOrNil() {
-    let canonical: Set<String> = ["statement", "action", "vote"]
+    let canonical: Set<String> = ["statement", "action", "vote", "note"]
     for phaseType in PhaseType.allCases {
       let field = ScenarioConventions.primaryField(for: phaseType)
       if let field {
@@ -67,6 +71,12 @@ struct ScenarioConventionsTests {
     #expect(ScenarioConventions.thoughtField(for: .speakAll) == "inner_thought")
     #expect(ScenarioConventions.thoughtField(for: .speakEach) == "inner_thought")
     #expect(ScenarioConventions.thoughtField(for: .choose) == "inner_thought")
+  }
+
+  /// Reflect has no secondary thought field: its canonical `note` output *is*
+  /// the agent's private reasoning (single-field `{ note }` schema).
+  @Test func thoughtFieldForReflectReturnsNil() {
+    #expect(ScenarioConventions.thoughtField(for: .reflect) == nil)
   }
 
   /// Code phases emit no LLM output, so they have no private-thought field.

--- a/Pastura/PasturaTests/Views/PhaseDisplayNameTests.swift
+++ b/Pastura/PasturaTests/Views/PhaseDisplayNameTests.swift
@@ -60,6 +60,6 @@ struct PhaseDisplayNameTests {
     // cheap non-render guard (ADR-009) against a future `requiresLLM`
     // change silently altering the transcript's separator layout.
     let llmPhases = PhaseType.allCases.filter(\.requiresLLM)
-    #expect(Set(llmPhases) == [.speakAll, .speakEach, .vote, .choose])
+    #expect(Set(llmPhases) == [.speakAll, .speakEach, .vote, .choose, .reflect])
   }
 }

--- a/Pastura/PasturaTests/Views/PhaseTypeLabelTests.swift
+++ b/Pastura/PasturaTests/Views/PhaseTypeLabelTests.swift
@@ -22,7 +22,7 @@ struct PhaseTypeLabelTests {
     // this exact predicate, so the invariant is the badge's contract.
     for phase in PhaseType.allCases {
       switch phase {
-      case .speakAll, .speakEach, .vote, .choose:
+      case .speakAll, .speakEach, .vote, .choose, .reflect:
         #expect(phase.requiresLLM, "\(phase) is an LLM-driven phase")
       case .scoreCalc, .assign, .eliminate, .summarize, .conditional, .eventInject:
         #expect(!phase.requiresLLM, "\(phase) is a code-driven phase")


### PR DESCRIPTION
## Summary
- New `reflect` LLM phase: at any point in a round, each non-eliminated agent makes one inference producing `{note}` — a private 2-sentence memo stored under the reserved `notes_<name>` namespace and injected back into only that agent's subsequent system prompts (+ `{my_notes}` template variable). Notes never enter the conversation log and never overwrite `lastOutputs`; they persist via the existing `.agentOutput` flow (no new `SimulationEvent` case) and render as normal Sim rows with the reflect capsule.
- Opt-in conversation-log window: scenario-level `log_window: N` (≥ 1, absent = full log) trims the log passed to LLM prompts to the last N entries. Prompt-side only — TurnRecord persistence / replay / export keep the full log. Threaded through loader / validator / serializer / YAML patcher / all five LLM handlers / editor funnel (carry-through, no visual UI yet).
- Backend fixes surfaced by harness field-testing (the first single-field grammar exposed a latent class): generation loops treat the caught post-completion grammar-accept crash as end-of-generation (`nextContentTokenOrStop`); `JSONResponseParser` gained schema-guarded multi-object salvage (schema-less callers keep the #751 refusal posture); the GBNF `trailing` production is bounded to 16 bytes (was an unbounded printable-ASCII sink inviting fabricated follow-on objects).
- Bundled presets unchanged — adoption is follow-up work under the #906 umbrella, gated on scenario-by-scenario tuning.

## Field test (pastura-harness, Gemma 4 E2B, real inference)
word_wolf reflect-variant ×3 + prisoners_dilemma reflect-variant ×3: **255 inferences, 0 retries, 0 crashes** (pre-fix: 2/2 runs died in the reflect phase). Memory references observed in 6/6 runs — including an explicit 「私の内なるメモに従い、今回は一貫して協調を選択します」 and a cross-round grudge arc (「リュウジが裏切った→次は彼をターゲットに」). All notes ≤ 3 sentences, no bullet-list runaway. Known tuning point for preset adoption: some agents repeat near-identical notes across rounds (E2B repetition class, #877) — a "note what changed" prompt nudge is a candidate lever.

## Test plan
- Full unit suite: 2511 tests / 212 suites green; `swiftlint --strict` clean; i18n coverage 580 keys OK
- Navigating UI test (`BackGestureTests`) green — render-crash canary for the Views switch additions
- `swift build` (ADR-013 harness canary) green — no `SimulationEvent` change, `EventLineMapper` untouched
- Opus code-review ×2 split passes (Engine/Models/App + LLM/Views): PASS, 0 critical / 0 warning; 4 of 5 suggestions adopted (reflect run-gate `note` requirement, namespace-exposure doc, description punctuation, access tightening)

Closes #907

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uq1DVHL5kf7215vgTaPKiB