### PR TITLE
📝 docs: rule for adopt re-projection @State-loss trap

### DIFF
--- a/.claude/rules/swiftui-traps.md
+++ b/.claude/rules/swiftui-traps.md
@@ -280,3 +280,24 @@ the same badge renders fine in a `LazyVStack` (Sim conversation) or `List`/`Form
    struct → `.compositingGroup()` on the row → `LazyVStack` → drop the enumerated-`\.offset`
    `ForEach` shape → bisect the container `.background(...ignoresSafeArea())` half the fault
    stack names → `.geometryGroup()`. See #901 for the full diagnostic write-up.
+
+## Re-projection resets `@State` — put run-scoped display state on the VM
+
+Re-projecting an **already-running** `@Observable` VM into a **fresh** `View`
+instance (ADR-017 Phase B "keep running": `SimulationSession.adoptIfMatching`
+re-mounts `SimulationView` onto the parked run, source unchanged) resets
+**every** `@State` in that view and its rows. Adopt rescues the *VM*; the fresh
+view instance is what clears the `@State`. Any "already shown / revealed /
+animated" latch that lives only in per-View or per-row `@State` therefore
+**replays** on return — the user re-watches content they already saw.
+
+**Apply**: run-scoped display state that must survive a return-to-run belongs on
+the **surviving VM**, not View/row `@State`; read it back through a VM property /
+method so re-projection restores it. Distinct from the fresh-VM `.resume` path
+(guarded separately via `isResumeEntry` / `effectiveCharsPerSecond`) — the trap
+is specific to re-projecting an already-running VM.
+
+Reference: #934 — the premise card + latest conversation row re-typed from View
+`introHasTyped` / row `visibleChars` `@State`; moved to
+`SimulationViewModel.introRevealHasBegun` / `latestRowRevealCompleted` (see the
+adopt early-return comment in `SimulationView`).

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -638,8 +638,8 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   /// Latch: the opening-card premise reveal has BEGUN (or already run) for this
   /// run. Read by `SimulationView`'s premise-card `charsPerSecond` guard so the
   /// card renders static on the ADR-017 Phase B adopt path: when a parked run is
-  /// re-projected into a fresh `SimulationView`, the view's `introHasTyped`
-  /// `@State` would reset and re-type the premise. Living on the surviving VM,
+  /// re-projected into a fresh `SimulationView`, that view's per-`@State` reveal
+  /// latch would reset and re-type the premise. Living on the surviving VM,
   /// this latch survives re-projection. Set on the animated reveal's start
   /// (`onRevealStarted` → ``markIntroRevealBegan()``); reset per `beginIntro`.
   private(set) var introRevealHasBegun = false

--- a/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView.swift
+++ b/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView.swift
@@ -91,7 +91,8 @@ struct ModelDownloadHostView: View {
   // / `promoCardInset` and `currentPresetName` can read it.
   @State var sources: [any ReplaySource] = []
   // Type-once latch for opening cards (#867), keyed by `ChatItem.scenarioIntro`
-  // id. Generalizes the live Sim's single `introHasTyped` Bool to the demo's
+  // id. Generalizes the live Sim's single reveal latch
+  // (`SimulationViewModel.introRevealHasBegun`) to the demo's
   // many cards (one per rotated segment): the card lives in a `LazyVStack`, so
   // scrolling an already-typed card back into view must render it statically
   // (`charsPerSecond: nil`) instead of re-typing. Internal (not `private`) so


### PR DESCRIPTION
## Summary
Promotes the #934 / PR #935 lesson into `.claude/rules/swiftui-traps.md` so the trap fires for future contributors: re-projecting an **already-running** `@Observable` VM into a **fresh** `SimulationView` (ADR-017 Phase B "keep running" adopt) resets **every** `@State`, so run-scoped "already revealed / animated" latches must live on the surviving VM, not per-View/row `@State`.

Also sweeps two now-stale `introHasTyped` comment references orphaned by PR #935 (the live-Sim `@State` was replaced by the `SimulationViewModel.introRevealHasBegun` VM latch): `SimulationViewModel`'s own doc-comment and `ModelDownloadHostView`'s demo type-once-latch note.

## Changes
- `.claude/rules/swiftui-traps.md`: new "Re-projection resets `@State`" section (mechanism + **Apply** + `#934` pointer; compressed per context-budget discipline).
- `SimulationViewModel.swift` / `ModelDownloadHostView.swift`: comment-only edits removing the dead `introHasTyped` symbol reference.

## Test plan
- Docs + comment-only; no functional change. Pre-commit build + `swiftlint --strict` green.
- Symbol accuracy verified: `adoptIfMatching`, `introRevealHasBegun`, `latestRowRevealCompleted`, `isResumeEntry`, `premiseCharsPerSecond` / `effectiveCharsPerSecond` all exist on main; no dead `introHasTyped` reference remains in Swift source (the one in the rule is an intentional before/after narrative).
- critic (Warning-only, actions folded in) + code-reviewer Opus (PASS, 0 issues).

Closes #936

🤖 Generated with [Claude Code](https://claude.com/claude-code)