### PR TITLE
✨ feat: unify shared-topic assignment as one sharedAssignment event

### DIFF
--- a/.claude/rules/presets.md
+++ b/.claude/rules/presets.md
@@ -45,3 +45,9 @@ Current inventory (each has an `_en` sibling — see i18n below):
   a closed set.
 - **ja/en parity**: keep the `_en` sibling structurally in sync (same phases,
   agent count, topic/word count); wording is localized, mechanics are not.
+- **`assign` with `target: all` — self-framing topic values (#939).** The shared
+  お題 renders as one line with the value **verbatim** and no "Topic:"/"お題:"
+  label (`SimulationEvent.sharedAssignment`), so each `source:`/`topics` entry
+  must read as a complete self-framing statement (e.g. `やらかし「…」`,
+  `Your blunder: …`, `お悩み:「…」`, `Problem: …`) — a bare noun would render
+  contextless.

--- a/Pastura/Pastura/App/ReplayViewModel.swift
+++ b/Pastura/Pastura/App/ReplayViewModel.swift
@@ -393,6 +393,10 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
   /// scope"). `assignment.value` / `summary.text` arrive already-filtered.
   nonisolated enum CodePhaseLine: Sendable, Equatable {
     case assignment(agent: String, value: String)
+    /// The round's shared お題 assigned to every agent (`assign` target: all,
+    /// #939). One line, no agent attribution — the value arrives
+    /// already-filtered like `assignment.value` / `summary.text`.
+    case sharedAssignment(value: String)
     case summary(text: String)
     case voteResults(tallies: [String: Int])
     case scoreUpdate(scores: [String: Int])
@@ -1095,6 +1099,15 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
           id: UUID(),
           line: .assignment(agent: agent, value: contentFilter.filter(value))))
 
+    case .sharedAssignment(let value):
+      // The round's shared お題 that grounds every agent response (#939) — one
+      // line, no agent attribution. Render-time ContentFilter on the value per
+      // the header § "ContentFilter scope" (defense-in-depth; the live VM
+      // appends raw).
+      chatItems.append(
+        .codePhaseLine(
+          id: UUID(), line: .sharedAssignment(value: contentFilter.filter(value))))
+
     case .summary(let text):
       // Round summary / narrator line (#932). Filtered per the header scope.
       chatItems.append(
@@ -1249,6 +1262,7 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
     let text: String
     switch event {
     case .assignment(_, let value): text = value
+    case .sharedAssignment(let value): text = value
     case .summary(let summaryText): text = summaryText
     case .eventInjected(let injected): text = injected ?? ""
     default: return 0

--- a/Pastura/Pastura/App/ResultMarkdownExporter.swift
+++ b/Pastura/Pastura/App/ResultMarkdownExporter.swift
@@ -396,6 +396,11 @@ struct ResultMarkdownExporter {  // swiftlint:disable:this type_body_length
       return String(
         format: String(localized: "- **%@** was assigned: %@"),
         agent, value)
+    case .sharedAssignment(let value):
+      // Shared お題 (#939) — value only, self-framing. No String(localized:)
+      // wrap: the line carries no translatable words, only the 📋 marker and
+      // the verbatim value, so it spawns no catalog key.
+      return "- 📋 \(value)"
     case .eventInjected(let event):
       // Past results need to surface the miss explicitly so a reader
       // can tell whether the phase ran at all.

--- a/Pastura/Pastura/App/ResumeLogReplayMapper.swift
+++ b/Pastura/Pastura/App/ResumeLogReplayMapper.swift
@@ -68,6 +68,8 @@ enum ResumeLogReplayMapper {
         agent1: agent1, action1: action1, agent2: agent2, action2: action2)
     case .assignment(let agent, let value):
       return .assignment(agent: agent, value: value)
+    case .sharedAssignment(let value):
+      return .sharedAssignment(value: value)
     case .eventInjected(let event):
       return .eventInjected(event: event)
     }

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -21,6 +21,9 @@ struct LogEntry: Identifiable {
     case scoreUpdate(scores: [String: Int])
     case elimination(agent: String, voteCount: Int)
     case assignment(agent: String, value: String)
+    /// The round's shared お題 assigned to every agent (`assign` target: all,
+    /// #939). One line, no agent attribution.
+    case sharedAssignment(value: String)
     case summary(text: String)
     case voteResults(votes: [String: String], tallies: [String: Int])
     case pairingResult(agent1: String, action1: String, agent2: String, action2: String)
@@ -1549,6 +1552,8 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
       persistCodePhaseEvent(
         phaseType: currentPhaseType?.rawValue ?? PhaseType.assign.rawValue,
         payload: .assignment(agent: agent, value: value))
+    case .sharedAssignment(let value):
+      handleSharedAssignment(value: value)
     case .summary(let text):
       logEntries.append(LogEntry(kind: .summary(text: text)))
       // `.summary` also fires for validator warnings (before the first round
@@ -1860,6 +1865,17 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   private func handleScoreUpdate(scores newScores: [String: Int]) {
     scores = newScores
     logEntries.append(LogEntry(kind: .scoreUpdate(scores: newScores)))
+  }
+
+  private func handleSharedAssignment(value: String) {
+    // Shared お題 assigned to every agent (`assign` target: all, #939). One
+    // line, no agent attribution. Deliberately NOT written to
+    // `predictionAssignments`: that is word-wolf per-agent ground truth (#915),
+    // and a shared topic has no minority holder to derive a wolf from.
+    logEntries.append(LogEntry(kind: .sharedAssignment(value: value)))
+    persistCodePhaseEvent(
+      phaseType: currentPhaseType?.rawValue ?? PhaseType.assign.rawValue,
+      payload: .sharedAssignment(value: value))
   }
 
   private func handleElimination(agent: String, voteCount: Int) {

--- a/Pastura/Pastura/App/YAMLReplayExporter.swift
+++ b/Pastura/Pastura/App/YAMLReplayExporter.swift
@@ -285,6 +285,10 @@ nonisolated struct YAMLReplayExporter {  // swiftlint:disable:this type_body_len
       lines.append("      kind: assignment")
       lines.append("      agent: \(Self.yamlValue(agent))")
       lines.append("      value: \(Self.yamlValue(filter.filter(value)))")
+    case .sharedAssignment(let value):
+      // Shared お題 for the whole round (#939) — no agent attribution.
+      lines.append("      kind: sharedAssignment")
+      lines.append("      value: \(Self.yamlValue(filter.filter(value)))")
     case .eventInjected(let event):
       lines.append("      kind: eventInjected")
       // Distinguishing miss (nil) from hit-with-empty-string is meaningful
@@ -490,6 +494,9 @@ nonisolated struct YAMLReplayExporter {  // swiftlint:disable:this type_body_len
       return String(
         format: String(localized: "%@ was assigned: %@"),
         agent, filter.filter(value))
+    case .sharedAssignment(let value):
+      // The shared お題 is self-framing; the summary is just the value (#939).
+      return filter.filter(value)
     case .eventInjected(let event):
       // Match Markdown exporter wording so the timeline reads the same
       // way regardless of channel.

--- a/Pastura/Pastura/App/YAMLReplaySource.swift
+++ b/Pastura/Pastura/App/YAMLReplaySource.swift
@@ -411,6 +411,7 @@ extension YAMLReplaySource {
     case "voteResults": return try decodeVoteResults(payload)
     case "pairingResult": return try decodePairingResult(payload)
     case "assignment": return try decodeAssignment(payload)
+    case "sharedAssignment": return decodeSharedAssignment(payload)
     case "eventInjected": return decodeEventInjected(payload)
     default: return nil
     }
@@ -464,6 +465,17 @@ extension YAMLReplaySource {
     }
     let value = payload["value"] as? String ?? ""
     return .assignment(agent: agent, value: value)
+  }
+
+  /// Decodes a shared-assignment payload (#939) — the round's お題 assigned to
+  /// every agent, carrying no agent attribution. A missing `value` (legacy /
+  /// hand-written replays) maps to the empty string, mirroring the lenient
+  /// `value` handling in ``decodeAssignment(_:)``.
+  private static func decodeSharedAssignment(
+    _ payload: [String: Any]
+  ) -> SimulationEvent {
+    let value = payload["value"] as? String ?? ""
+    return .sharedAssignment(value: value)
   }
 
   /// Decodes an `event_inject` payload. The miss case (`event: null`)

--- a/Pastura/Pastura/Engine/Phases/AssignHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/AssignHandler.swift
@@ -89,7 +89,13 @@ nonisolated struct AssignHandler: PhaseHandler {
     state.variables["assigned_topic"] = item
     for persona in active {
       state.variables["assigned_\(persona.name)"] = item
-      emitter(.assignment(agent: persona.name, value: item))
     }
+    // Every agent got the SAME item, so emit one shared-topic event for the
+    // whole round — N per-agent `.assignment` events would misleadingly read
+    // as N different assignments (#939). The per-persona `assigned_<name>`
+    // variables above are still set so prompt expansion has each agent's copy.
+    // `assignRandomOne` keeps per-agent `.assignment` (each gets a different
+    // secret).
+    emitter(.sharedAssignment(value: item))
   }
 }

--- a/Pastura/Pastura/Models/CodePhaseEventPayload.swift
+++ b/Pastura/Pastura/Models/CodePhaseEventPayload.swift
@@ -34,6 +34,14 @@ nonisolated public enum CodePhaseEventPayload: Codable, Sendable, Equatable {
   /// (e.g., wolf/villager role in Word Wolf).
   case assignment(agent: String, value: String)
 
+  /// A shared value assigned to *all* agents by an `assign` phase with
+  /// `target: all` (e.g. the round's お題). Rendered as one topic line with
+  /// no agent attribution, distinct from the per-agent
+  /// ``assignment(agent:value:)`` (word wolf). Additive case — old
+  /// `.assignment` rows keep decoding, so no data migration is required
+  /// (see the type-level wire-format note). See #939.
+  case sharedAssignment(value: String)
+
   /// An `event_inject` phase rolled its probability and either selected
   /// a random event string (`event != nil`) or missed (`event == nil`).
   /// The miss case persists explicitly so past-results timelines can

--- a/Pastura/Pastura/Models/SimulationEvent.swift
+++ b/Pastura/Pastura/Models/SimulationEvent.swift
@@ -69,6 +69,15 @@ nonisolated public enum SimulationEvent: Sendable, Equatable {
   /// Data has been assigned to an agent (from `assign` phase).
   case assignment(agent: String, value: String)
 
+  /// The same shared value was assigned to *every* agent (from an `assign`
+  /// phase with `target: all`, e.g. the round's お題). Emitted once per round,
+  /// carrying no agent attribution, so consumers render a single topic line
+  /// rather than N identical `assignment` lines. Distinct from the per-agent
+  /// ``assignment(agent:value:)`` (word wolf, `target: random_one`), which
+  /// stays one event per agent because each agent gets a different secret.
+  /// See #939.
+  case sharedAssignment(value: String)
+
   /// A summary text was generated (from `summarize` phase).
   case summary(text: String)
 

--- a/Pastura/Pastura/Resources/DemoReplays/chinkaitou_soudan_v1_demo.yaml
+++ b/Pastura/Pastura/Resources/DemoReplays/chinkaitou_soudan_v1_demo.yaml
@@ -144,12 +144,11 @@ code_phase_events:
 - round: 1
   phase_index: 0
   phase_type: assign
-  summary: '熱血コーチ先生 assigned: お悩み:「冷蔵庫を開けるたびに、奥にあるプリンが私のことをじっと見ている 気がして、夜も眠れません。どうすればいいですか？」
+  summary: 'お悩み:「冷蔵庫を開けるたびに、奥にあるプリンが私のことをじっと見ている 気がして、夜も眠れません。どうすればいいですか？」
 
     '
   payload:
-    kind: assignment
-    agent: 熱血コーチ先生
+    kind: sharedAssignment
     value: 'お悩み:「冷蔵庫を開けるたびに、奥にあるプリンが私のことをじっと見ている 気がして、夜も眠れません。どうすればいいですか？」
 
       '
@@ -188,12 +187,11 @@ code_phase_events:
 - round: 2
   phase_index: 0
   phase_type: assign
-  summary: '熱血コーチ先生 assigned: お悩み:「会社のコピー機が、なぜか私が使うときだけ必ず紙詰まりします。 機械に嫌われているのでしょうか？」
+  summary: 'お悩み:「会社のコピー機が、なぜか私が使うときだけ必ず紙詰まりします。 機械に嫌われているのでしょうか？」
 
     '
   payload:
-    kind: assignment
-    agent: 熱血コーチ先生
+    kind: sharedAssignment
     value: 'お悩み:「会社のコピー機が、なぜか私が使うときだけ必ず紙詰まりします。 機械に嫌われているのでしょうか？」
 
       '

--- a/Pastura/Pastura/Resources/DemoReplays/chinkaitou_soudan_v1_en_demo.yaml
+++ b/Pastura/Pastura/Resources/DemoReplays/chinkaitou_soudan_v1_en_demo.yaml
@@ -144,12 +144,11 @@ code_phase_events:
 - round: 1
   phase_index: 0
   phase_type: assign
-  summary: 'Coach Blaze assigned: Problem: "Every time I open the fridge, the pudding at the very back feels like it''s staring right at me, and I can''t sleep at night. What should I do?"
+  summary: 'Problem: "Every time I open the fridge, the pudding at the very back feels like it''s staring right at me, and I can''t sleep at night. What should I do?"
 
     '
   payload:
-    kind: assignment
-    agent: Coach Blaze
+    kind: sharedAssignment
     value: 'Problem: "Every time I open the fridge, the pudding at the very back feels like it''s staring right at me, and I can''t sleep at night. What should I do?"
 
       '
@@ -187,12 +186,11 @@ code_phase_events:
 - round: 2
   phase_index: 0
   phase_type: assign
-  summary: 'Coach Blaze assigned: Problem: "The office copier jams without fail, but only when I''m the one using it. Does the machine hate me?"
+  summary: 'Problem: "The office copier jams without fail, but only when I''m the one using it. Does the machine hate me?"
 
     '
   payload:
-    kind: assignment
-    agent: Coach Blaze
+    kind: sharedAssignment
     value: 'Problem: "The office copier jams without fail, but only when I''m the one using it. Does the machine hate me?"
 
       '

--- a/Pastura/Pastura/Resources/DemoReplays/iiwake_battle_v1_demo.yaml
+++ b/Pastura/Pastura/Resources/DemoReplays/iiwake_battle_v1_demo.yaml
@@ -144,10 +144,9 @@ code_phase_events:
 - round: 1
   phase_index: 0
   phase_type: assign
-  summary: '国際派ジョージ assigned: やらかし「大事な会議に2時間遅刻した」'
+  summary: やらかし「大事な会議に2時間遅刻した」
   payload:
-    kind: assignment
-    agent: 国際派ジョージ
+    kind: sharedAssignment
     value: やらかし「大事な会議に2時間遅刻した」
 - round: 1
   phase_index: 2
@@ -183,10 +182,9 @@ code_phase_events:
 - round: 2
   phase_index: 0
   phase_type: assign
-  summary: '国際派ジョージ assigned: やらかし「同僚の机に置いてあったプリンを食べてしまった」'
+  summary: やらかし「同僚の机に置いてあったプリンを食べてしまった」
   payload:
-    kind: assignment
-    agent: 国際派ジョージ
+    kind: sharedAssignment
     value: やらかし「同僚の机に置いてあったプリンを食べてしまった」
 - round: 2
   phase_index: 2

--- a/Pastura/Pastura/Resources/DemoReplays/iiwake_battle_v1_en_demo.yaml
+++ b/Pastura/Pastura/Resources/DemoReplays/iiwake_battle_v1_en_demo.yaml
@@ -144,10 +144,9 @@ code_phase_events:
 - round: 1
   phase_index: 0
   phase_type: assign
-  summary: 'Globe-Trotter Gary assigned: Your blunder: you showed up two hours late to an important meeting.'
+  summary: 'Your blunder: you showed up two hours late to an important meeting.'
   payload:
-    kind: assignment
-    agent: Globe-Trotter Gary
+    kind: sharedAssignment
     value: 'Your blunder: you showed up two hours late to an important meeting.'
 - round: 1
   phase_index: 2
@@ -184,10 +183,9 @@ code_phase_events:
 - round: 2
   phase_index: 0
   phase_type: assign
-  summary: 'Globe-Trotter Gary assigned: Your blunder: you ate the pudding your coworker left on their desk.'
+  summary: 'Your blunder: you ate the pudding your coworker left on their desk.'
   payload:
-    kind: assignment
-    agent: Globe-Trotter Gary
+    kind: sharedAssignment
     value: 'Your blunder: you ate the pudding your coworker left on their desk.'
 - round: 2
   phase_index: 2

--- a/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+CodePhaseRows.swift
+++ b/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+CodePhaseRows.swift
@@ -37,6 +37,16 @@ extension ModelDownloadHostView {
       Text(String(format: String(localized: "%@ assigned: %@"), agent, value))
         .textStyle(Typography.metaValue)
         .foregroundStyle(Color.muted)
+    case .sharedAssignment(let value):
+      // Mirrors `SimulationView.sharedAssignmentEntry` (#939): clipboard icon +
+      // verbatim value, no label. `Text(verbatim:)` — dynamic content, not a key.
+      HStack(spacing: 4) {
+        Image(systemName: "list.clipboard")
+          .foregroundStyle(Color.inkSecondary)
+        Text(verbatim: value)
+          .textStyle(Typography.metaValue)
+          .foregroundStyle(Color.muted)
+      }
     case .summary(let text):
       // Mirrors `SimulationView.summaryEntry`.
       Text(text)

--- a/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+CodePhaseRows.swift
+++ b/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+CodePhaseRows.swift
@@ -38,14 +38,22 @@ extension ModelDownloadHostView {
         .textStyle(Typography.metaValue)
         .foregroundStyle(Color.muted)
     case .sharedAssignment(let value):
-      // Mirrors `SimulationView.sharedAssignmentEntry` (#939): clipboard icon +
-      // verbatim value, no label. `Text(verbatim:)` — dynamic content, not a key.
-      HStack(spacing: 4) {
+      // Mirrors `SimulationView.sharedAssignmentEntry` (#939): the round's
+      // premise gets a moss accent rule + clipboard icon + body-weight ink text,
+      // no "Topic:" label. `Text(verbatim:)` — dynamic content, not a key.
+      HStack(alignment: .firstTextBaseline, spacing: 9) {
         Image(systemName: "list.clipboard")
-          .foregroundStyle(Color.inkSecondary)
+          .foregroundStyle(Color.mossDark)
         Text(verbatim: value)
-          .textStyle(Typography.metaValue)
-          .foregroundStyle(Color.muted)
+          .textStyle(Typography.bodyBubble)
+          .foregroundStyle(Color.ink)
+          .frame(maxWidth: .infinity, alignment: .leading)
+      }
+      .padding(.leading, 11)
+      .overlay(alignment: .leading) {
+        RoundedRectangle(cornerRadius: 1.5)
+          .fill(Color.moss)
+          .frame(width: 3)
       }
     case .summary(let text):
       // Mirrors `SimulationView.summaryEntry`.

--- a/Pastura/Pastura/Views/Results/ResultDetailView+CodePhaseRows.swift
+++ b/Pastura/Pastura/Views/Results/ResultDetailView+CodePhaseRows.swift
@@ -123,15 +123,24 @@ extension ResultDetailView {
   }
 
   // Shared お題 assigned to every agent (#939). Mirrors
-  // `SimulationView.sharedAssignmentEntry`: clipboard icon + verbatim value, no
-  // "Topic:" label (the value is self-framing). `Text(verbatim:)` — the value
-  // is dynamic content, not a `LocalizedStringKey`.
+  // `SimulationView.sharedAssignmentEntry`: the round's premise gets a moss
+  // accent rule + clipboard icon + body-weight ink text (not the muted 9pt meta
+  // of glanceable result lines), no "Topic:" label (the value is self-framing).
+  // `Text(verbatim:)` — dynamic content, not a `LocalizedStringKey`; the value
+  // is `filtered` here (past-results filter at render time).
   private func sharedAssignmentRow(value: String) -> some View {
-    HStack(spacing: 4) {
-      Image(systemName: "list.clipboard").foregroundStyle(Color.inkSecondary)
+    HStack(alignment: .firstTextBaseline, spacing: 9) {
+      Image(systemName: "list.clipboard").foregroundStyle(Color.mossDark)
       Text(verbatim: filtered(value))
-        .textStyle(Typography.metaValue)
-        .foregroundStyle(Color.muted)
+        .textStyle(Typography.bodyBubble)
+        .foregroundStyle(Color.ink)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    .padding(.leading, 11)
+    .overlay(alignment: .leading) {
+      RoundedRectangle(cornerRadius: 1.5)
+        .fill(Color.moss)
+        .frame(width: 3)
     }
   }
 

--- a/Pastura/Pastura/Views/Results/ResultDetailView+CodePhaseRows.swift
+++ b/Pastura/Pastura/Views/Results/ResultDetailView+CodePhaseRows.swift
@@ -36,6 +36,8 @@ extension ResultDetailView {
       pairingRow(agent1: agent1, action1: action1, agent2: agent2, action2: action2)
     case .assignment(let agent, let value):
       assignmentRow(agent: agent, value: value)
+    case .sharedAssignment(let value):
+      sharedAssignmentRow(value: value)
     case .eventInjected(let event):
       eventInjectedRow(event: event)
     }
@@ -118,6 +120,19 @@ extension ResultDetailView {
     Text(String(format: String(localized: "%@ assigned: %@"), filtered(agent), filtered(value)))
       .textStyle(Typography.metaValue)
       .foregroundStyle(Color.muted)
+  }
+
+  // Shared お題 assigned to every agent (#939). Mirrors
+  // `SimulationView.sharedAssignmentEntry`: clipboard icon + verbatim value, no
+  // "Topic:" label (the value is self-framing). `Text(verbatim:)` — the value
+  // is dynamic content, not a `LocalizedStringKey`.
+  private func sharedAssignmentRow(value: String) -> some View {
+    HStack(spacing: 4) {
+      Image(systemName: "list.clipboard").foregroundStyle(Color.inkSecondary)
+      Text(verbatim: filtered(value))
+        .textStyle(Typography.metaValue)
+        .foregroundStyle(Color.muted)
+    }
   }
 
   // The miss case (`event == nil`) renders an explicit "no event"

--- a/Pastura/Pastura/Views/Simulation/SimulationView+LogEntries.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView+LogEntries.swift
@@ -28,21 +28,31 @@ extension SimulationView {
       .foregroundStyle(Color.muted)
   }
 
-  // Shared お題 assigned to every agent (`assign` target: all, #939). The
-  // clipboard icon disambiguates a topic line from an agent statement, and the
-  // value is self-framing (e.g. `やらかし「…」`, `Your blunder: …`) so no
-  // "Topic:" label is added. `Text(verbatim:)` — the value is dynamic content,
-  // not a `LocalizedStringKey`, and must not be looked up in the catalog.
+  // Shared お題 assigned to every agent (`assign` target: all, #939). Styled as
+  // the round's *premise* — a moss accent rule + clipboard icon + body-weight
+  // ink text — NOT the muted 9pt meta style of glanceable result lines, since
+  // every agent responds to this お題 (it is the round's context, not a
+  // progress readout). The value is self-framing (e.g. `やらかし「…」`,
+  // `Your blunder: …`) so no "Topic:" label is added; the accent rule + icon
+  // carry the framing visually. `Text(verbatim:)` — dynamic content, not a
+  // `LocalizedStringKey`, must not be looked up in the catalog.
   // The live entry renders the value RAW (no ContentFilter) — parity with
   // `assignmentEntry`; past-results / demo-replay filter it at render time
   // instead (see the `ReplayViewModel.apply` "the live VM appends raw" note).
   func sharedAssignmentEntry(value: String) -> some View {
-    HStack(spacing: 4) {
+    HStack(alignment: .firstTextBaseline, spacing: 9) {
       Image(systemName: "list.clipboard")
-        .foregroundStyle(Color.inkSecondary)
+        .foregroundStyle(Color.mossDark)
       Text(verbatim: value)
-        .textStyle(Typography.metaValue)
-        .foregroundStyle(Color.muted)
+        .textStyle(Typography.bodyBubble)
+        .foregroundStyle(Color.ink)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    .padding(.leading, 11)
+    .overlay(alignment: .leading) {
+      RoundedRectangle(cornerRadius: 1.5)
+        .fill(Color.moss)
+        .frame(width: 3)
     }
   }
 

--- a/Pastura/Pastura/Views/Simulation/SimulationView+LogEntries.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView+LogEntries.swift
@@ -28,6 +28,21 @@ extension SimulationView {
       .foregroundStyle(Color.muted)
   }
 
+  // Shared お題 assigned to every agent (`assign` target: all, #939). The
+  // clipboard icon disambiguates a topic line from an agent statement, and the
+  // value is self-framing (e.g. `やらかし「…」`, `Your blunder: …`) so no
+  // "Topic:" label is added. `Text(verbatim:)` — the value is dynamic content,
+  // not a `LocalizedStringKey`, and must not be looked up in the catalog.
+  func sharedAssignmentEntry(value: String) -> some View {
+    HStack(spacing: 4) {
+      Image(systemName: "list.clipboard")
+        .foregroundStyle(Color.inkSecondary)
+      Text(verbatim: value)
+        .textStyle(Typography.metaValue)
+        .foregroundStyle(Color.muted)
+    }
+  }
+
   func summaryEntry(text: String) -> some View {
     Text(text)
       .textStyle(Typography.bodyBubble)

--- a/Pastura/Pastura/Views/Simulation/SimulationView+LogEntries.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView+LogEntries.swift
@@ -33,6 +33,9 @@ extension SimulationView {
   // value is self-framing (e.g. `やらかし「…」`, `Your blunder: …`) so no
   // "Topic:" label is added. `Text(verbatim:)` — the value is dynamic content,
   // not a `LocalizedStringKey`, and must not be looked up in the catalog.
+  // The live entry renders the value RAW (no ContentFilter) — parity with
+  // `assignmentEntry`; past-results / demo-replay filter it at render time
+  // instead (see the `ReplayViewModel.apply` "the live VM appends raw" note).
   func sharedAssignmentEntry(value: String) -> some View {
     HStack(spacing: 4) {
       Image(systemName: "list.clipboard")

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -1045,6 +1045,8 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
       eliminationEntry(agent: agent, voteCount: voteCount)
     case .assignment(let agent, let value):
       assignmentEntry(agent: agent, value: value)
+    case .sharedAssignment(let value):
+      sharedAssignmentEntry(value: value)
     case .summary(let text):
       summaryEntry(text: text)
     case .voteResults(_, let tallies):

--- a/Pastura/PasturaTests/App/ReplayViewModelTests+Pacing.swift
+++ b/Pastura/PasturaTests/App/ReplayViewModelTests+Pacing.swift
@@ -159,6 +159,17 @@ extension ReplayViewModelTests {
         for: .assignment(agent: "Alice", value: "abc"), script: Self.demoScript) == 480)
   }
 
+  /// The shared お題 (`sharedAssignment`, #939) reserves the SAME reading dwell
+  /// as the per-agent assignment — it IS the context-critical topic line #932's
+  /// dwell exists for. Guards the silent `codePhaseFloorMs` `default: return 0`
+  /// gap: a missed `.sharedAssignment` arm would flash the topic too fast.
+  @Test func codePhaseFloorIsReadingDwellForSharedAssignment() throws {
+    let viewModel = try Self.makeDemoPacedVM()  // .normal speed, cps 10
+    #expect(
+      viewModel.codePhaseFloorMs(
+        for: .sharedAssignment(value: "abc"), script: Self.demoScript) == 480)
+  }
+
   /// `.instant` → nil cps → no reading floor (symmetric with `introFloorMs` /
   /// `typingFloorMs` opt-out).
   @Test func codePhaseFloorIsZeroAtInstantSpeed() throws {

--- a/Pastura/PasturaTests/App/ReplayViewModelTests+SharedAssignment.swift
+++ b/Pastura/PasturaTests/App/ReplayViewModelTests+SharedAssignment.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+// Inline shared-assignment line (`ChatItem.codePhaseLine` → `.sharedAssignment`)
+// tests for `ReplayViewModel` (#939) — the demo mirror of the live sim's shared
+// お題 log entry. The round's shared topic (`assign` target: all) renders as one
+// line with no agent attribution, distinct from the per-agent `.assignment`
+// (word wolf) covered in `+CodePhaseLines`.
+//
+// Sibling-file `extension` per `.claude/rules/testing.md` — NOT a new `@Suite`
+// (a parallel suite would race the VM-spawning original; the `.serialized` /
+// `.timeLimit` traits live on the base `@Suite`). Split from `+CodePhaseLines`
+// to keep that file under swiftlint's 400-line `file_length` cap.
+extension ReplayViewModelTests {
+
+  /// A turn preceded (by `phase_index`) by a `sharedAssignment` code-phase
+  /// event (`assign` target: all, #939) — the round's shared お題 with no agent
+  /// attribution, landing before the round's speak turn.
+  static let sharedAssignmentThenTurnYAML = """
+    schema_version: 1
+    turns:
+      - round: 1
+        phase_index: 1
+        phase_type: speak_all
+        agent: Alice
+        fields: { statement: 'hello' }
+    code_phase_events:
+      - round: 1
+        phase_index: 0
+        phase_type: assign
+        summary: 'topic X'
+        payload:
+          kind: sharedAssignment
+          value: 'topic X'
+    """
+
+  /// The shared お題 renders as an inline `.sharedAssignment` line (#939) —
+  /// reverting `apply()`'s `.sharedAssignment` arm makes this fail.
+  @Test func sharedAssignmentEventAppendsInlineLine() async throws {
+    let source = try YAMLReplaySource(
+      yaml: Self.sharedAssignmentThenTurnYAML, scenario: Self.makeScenario(),
+      config: Self.fastConfig)
+    let viewModel = ReplayViewModel(
+      sources: [source], config: Self.fastConfig, contentFilter: ContentFilter())
+    viewModel.start()
+    await Self.waitForState(viewModel, timeout: .seconds(5)) { _ in
+      !Self.codePhaseLines(viewModel).isEmpty
+    }
+    #expect(
+      Self.codePhaseLines(viewModel).contains {
+        if case .sharedAssignment(let value) = $0 { return value == "topic X" }
+        return false
+      })
+  }
+
+  /// The shared お題 `value` is filtered (authored/LLM text), mirroring the
+  /// per-agent assignment filtering.
+  @Test func filtersSharedAssignmentValue() async throws {
+    let yaml = """
+      schema_version: 1
+      turns:
+        - round: 1
+          phase_index: 1
+          phase_type: speak_all
+          agent: Alice
+          fields: { statement: 'hello' }
+      code_phase_events:
+        - round: 1
+          phase_index: 0
+          phase_type: assign
+          summary: 'a secret topic'
+          payload:
+            kind: sharedAssignment
+            value: 'a secret topic'
+      """
+    let source = try YAMLReplaySource(
+      yaml: yaml, scenario: Self.makeScenario(), config: Self.fastConfig)
+    let filter = ContentFilter(blockedPatterns: ["secret"], replacement: "XXX")
+    let viewModel = ReplayViewModel(
+      sources: [source], config: Self.fastConfig, contentFilter: filter)
+    viewModel.start()
+    await Self.waitForState(viewModel, timeout: .seconds(5)) { _ in
+      !Self.codePhaseLines(viewModel).isEmpty
+    }
+    guard
+      case .sharedAssignment(let value)? = Self.codePhaseLines(viewModel).first(where: {
+        if case .sharedAssignment = $0 { return true }
+        return false
+      })
+    else {
+      Issue.record("No shared-assignment line in \(Self.codePhaseLines(viewModel))")
+      return
+    }
+    #expect(!value.contains("secret"))
+    #expect(value.contains("XXX"))
+  }
+}

--- a/Pastura/PasturaTests/App/ResultMarkdownExporterCodePhaseTests.swift
+++ b/Pastura/PasturaTests/App/ResultMarkdownExporterCodePhaseTests.swift
@@ -179,6 +179,21 @@ struct ResultMarkdownExporterCodePhaseTests {  // swiftlint:disable:this type_bo
     #expect(result.text.contains("**Alice** was assigned: wolf"))
   }
 
+  @Test func rendersSharedAssignmentEventAsTopicLineWithoutAgent() throws {
+    // The shared お題 (#939) renders as one topic line, value verbatim, no
+    // agent attribution and no "assigned:" phrasing.
+    let exporter = makeExporter()
+    let event = makeCodePhaseEvent(
+      phaseType: "assign", seq: 1,
+      payload: .sharedAssignment(value: "やらかし「会議に遅刻した」"))
+
+    let result = try exporter.export(input(events: [event]))
+
+    #expect(result.text.contains("#### Phase: assign"))
+    #expect(result.text.contains("- 📋 やらかし「会議に遅刻した」"))
+    #expect(!result.text.contains("assigned:"))
+  }
+
   // MARK: - Merge-sort ordering
 
   @Test func mergesTurnsAndEventsBySequenceNumber() throws {

--- a/Pastura/PasturaTests/App/SimulationViewModelCodePhasePersistenceTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelCodePhasePersistenceTests.swift
@@ -90,6 +90,40 @@ struct SimulationViewModelCodePhasePersistenceTests {
         .pairingResult(agent1: "A", action1: "c", agent2: "B", action2: "d")))
   }
 
+  @Test func sharedAssignmentPersistsOneTopicLineAndOneLogEntry() async throws {
+    // Guards the silent `handleOutputEvent` gap (#939): `.sharedAssignment` has
+    // a `default: break`-adjacent explicit arm that must persist exactly ONE
+    // `.sharedAssignment` payload and append exactly ONE `.sharedAssignment`
+    // LogEntry — and must NOT emit a per-agent `.assignment` (the shape the old
+    // assignAll produced). A missed arm compiles clean and drops the event.
+    let sut = try makeSUT()
+    sut.model.handleEvent(.roundStarted(round: 1, totalRounds: 1), scenario: sut.scenario)
+    sut.model.handleEvent(
+      .sharedAssignment(value: "やらかし「大事な会議に2時間遅刻した」"),
+      scenario: sut.scenario)
+
+    await sut.model.finishPersistenceForTest()
+
+    let records = try sut.codeRepo.fetchBySimulationId(sut.simId)
+    #expect(records.count == 1)
+    let payloads = try records.map { try decodePayload($0.payloadJSON) }
+    #expect(
+      payloads == [.sharedAssignment(value: "やらかし「大事な会議に2時間遅刻した」")])
+    #expect(records.first?.phaseType == "assign")
+
+    // Exactly one shared-assignment LogEntry, and no per-agent assignment line.
+    let sharedEntries = sut.model.logEntries.filter {
+      if case .sharedAssignment = $0.kind { return true }
+      return false
+    }
+    #expect(sharedEntries.count == 1)
+    let perAgentEntries = sut.model.logEntries.filter {
+      if case .assignment = $0.kind { return true }
+      return false
+    }
+    #expect(perAgentEntries.isEmpty)
+  }
+
   // MARK: - Shared sequence number across tables
 
   @Test func interleavedAgentAndCodeEventsHaveStrictlyMonotonicSequence() async throws {

--- a/Pastura/PasturaTests/App/SimulationViewModelPredictionTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelPredictionTests.swift
@@ -118,6 +118,28 @@ struct SimulationViewModelPredictionTests {
     #expect(env.sut.predictionOutcome?.streak == 1)
   }
 
+  @Test func sharedAssignmentDoesNotPolluteWolfGroundTruth() async throws {
+    // #939 / critic axis 5: `.sharedAssignment` must NOT feed
+    // `predictionAssignments` — a shared topic has no minority holder, and if it
+    // leaked into the wolf frequency map it could shift the derived wolf. Here
+    // the shared value equals the wolf's minority ("orange"); if it polluted the
+    // map, "orange" would no longer be unique and the wolf would resolve to nil.
+    // The wolf must still resolve to "Eve".
+    FeatureFlags.setViewerPredictionEnabled(true)
+    defer { UserDefaults.standard.removeObject(forKey: Self.flagKey) }
+    let env = try makeEnv(phases: wolfPhases)
+    // Interleave shared-topic events among the per-agent wolf assignments.
+    env.sut.handleEvent(.sharedAssignment(value: "orange"), scenario: env.scenario)
+    feedWolfAssignments(env.sut, scenario: env.scenario)
+    env.sut.handleEvent(.sharedAssignment(value: "orange"), scenario: env.scenario)
+
+    await runPrediction(env, resolve: .predicted("Eve"), tallies: [:])
+
+    let record = try env.repo.fetchBySimulationId("sim1")
+    #expect(record?.actualAgent == "Eve")
+    #expect(record?.isHit == true)
+  }
+
   @Test func wolfWrongGuessPersistsMiss() async throws {
     FeatureFlags.setViewerPredictionEnabled(true)
     defer { UserDefaults.standard.removeObject(forKey: Self.flagKey) }

--- a/Pastura/PasturaTests/App/YAMLReplayRoundTripTests.swift
+++ b/Pastura/PasturaTests/App/YAMLReplayRoundTripTests.swift
@@ -188,6 +188,34 @@ struct YAMLReplayRoundTripTests {
     #expect(replayed[5] == .summary(text: "Bob wins."))
   }
 
+  @Test func sharedAssignmentPayloadRoundTrips() async throws {
+    // Guards the demo-decode silent gap (#939): `decodePayloadStanza` is a
+    // string-keyed switch with `default: return nil`, so a missing
+    // `case "sharedAssignment"` would silently drop the topic line with no
+    // compiler help. Exercises exporter (`kind: sharedAssignment` / value) →
+    // source decode end-to-end.
+    let events = [
+      makeCodeEvent(
+        seq: 3, phase: "assign",
+        payload: .sharedAssignment(value: "やらかし「大事な会議に2時間遅刻した」"))
+    ]
+    let exported = try exporter().export(
+      .init(
+        simulation: simulation, scenario: scenarioRecord,
+        turns: [], codePhaseEvents: events))
+
+    let scenario = try ScenarioLoader().load(yaml: scenarioRecord.yamlDefinition)
+    let source = try YAMLReplaySource(
+      yaml: exported.text, scenario: scenario, config: fastConfig)
+
+    var replayed: [SimulationEvent] = []
+    for await event in source.events() { replayed.append(event) }
+
+    #expect(replayed.count == 1)
+    #expect(
+      replayed[0] == .sharedAssignment(value: "やらかし「大事な会議に2時間遅刻した」"))
+  }
+
   @Test func eventInjectedPayloadRoundTripsHitAndMiss() async throws {
     // Two event_inject events: one hit (event != nil), one miss (event == nil).
     // The miss case is meaningful — past-results timelines need to

--- a/Pastura/PasturaTests/Engine/Phases/AssignHandlerTests.swift
+++ b/Pastura/PasturaTests/Engine/Phases/AssignHandlerTests.swift
@@ -73,7 +73,11 @@ struct AssignHandlerTests {
     }
   }
 
-  @Test func emitsAssignmentEvents() async throws {
+  @Test func emitsSingleSharedAssignmentForAll() async throws {
+    // assignAll (target: all) gives every agent the SAME お題, so it emits ONE
+    // `.sharedAssignment` for the round — never N per-agent `.assignment` events
+    // (#939). This guards the Engine emit shape against a regression back to
+    // per-agent events.
     let mock = MockLLMService(responses: [])
     let scenario = makeTestScenario(
       agentNames: ["Alice", "Bob"],
@@ -87,12 +91,53 @@ struct AssignHandlerTests {
     let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
     try await handler.execute(context: context, state: &state)
 
-    let assignments = collector.events.compactMap { event -> String? in
+    let sharedValues = collector.events.compactMap { event -> String? in
+      if case .sharedAssignment(let value) = event { return value }
+      return nil
+    }
+    #expect(sharedValues == ["Topic"])
+
+    // No per-agent `.assignment` events for the shared case.
+    let perAgent = collector.events.filter {
+      if case .assignment = $0 { return true }
+      return false
+    }
+    #expect(perAgent.isEmpty)
+  }
+
+  @Test func emitsPerAgentAssignmentsForWordwolf() async throws {
+    // Word wolf (target: random_one) gives each agent a DIFFERENT secret, so it
+    // keeps emitting one `.assignment` per agent — the counterpart to the
+    // single-shared shape above (#939).
+    let mock = MockLLMService(responses: [])
+    let scenario = makeTestScenario(
+      agentNames: ["Alice", "Bob", "Charlie"],
+      phases: [Phase(type: .assign, source: "words", target: .randomOne)],
+      extraData: [
+        "words": .arrayOfDictionaries([
+          ["majority": "りんご", "minority": "みかん"]
+        ])
+      ]
+    )
+    var state = SimulationState.initial(for: scenario)
+    state.currentRound = 1
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    let perAgent = collector.events.compactMap { event -> String? in
       if case .assignment(let agent, _) = event { return agent }
       return nil
     }
-    #expect(assignments.count == 2)
-    #expect(assignments.contains("Alice"))
-    #expect(assignments.contains("Bob"))
+    #expect(perAgent.count == 3)
+    #expect(Set(perAgent) == ["Alice", "Bob", "Charlie"])
+
+    // No shared-assignment event for the per-agent word-wolf case.
+    let shared = collector.events.filter {
+      if case .sharedAssignment = $0 { return true }
+      return false
+    }
+    #expect(shared.isEmpty)
   }
 }

--- a/Pastura/PasturaTests/Models/CodePhaseEventPayloadTests.swift
+++ b/Pastura/PasturaTests/Models/CodePhaseEventPayloadTests.swift
@@ -48,6 +48,30 @@ struct CodePhaseEventPayloadTests {
     #expect(try roundTrip(original) == original)
   }
 
+  @Test func sharedAssignmentRoundTrip() throws {
+    let original = CodePhaseEventPayload.sharedAssignment(
+      value: "やらかし「大事な会議に2時間遅刻した」")
+    #expect(try roundTrip(original) == original)
+  }
+
+  @Test func sharedAssignmentIsDistinctFromAssignment() {
+    // The two assign shapes must not compare equal — they render differently
+    // (one topic line vs per-agent lines) and must persist as distinct kinds.
+    let shared = CodePhaseEventPayload.sharedAssignment(value: "topic")
+    let perAgent = CodePhaseEventPayload.assignment(agent: "topic", value: "topic")
+    #expect(shared != perAgent)
+  }
+
+  @Test func legacyAssignmentJSONStillDecodes() throws {
+    // Backward-compat guard (#939): rows persisted before `.sharedAssignment`
+    // existed carry `{"assignment":{...}}` and must keep decoding as
+    // `.assignment` — the additive case must not shadow or break them.
+    let legacy = #"{"assignment":{"agent":"Alice","value":"wolf"}}"#
+    let data = try #require(legacy.data(using: .utf8))
+    let decoded = try JSONDecoder().decode(CodePhaseEventPayload.self, from: data)
+    #expect(decoded == .assignment(agent: "Alice", value: "wolf"))
+  }
+
   @Test func eventInjectedHitRoundTrip() throws {
     let original = CodePhaseEventPayload.eventInjected(event: "突然停電が起きた")
     #expect(try roundTrip(original) == original)

--- a/scripts/jsonl_to_demo_replay.py
+++ b/scripts/jsonl_to_demo_replay.py
@@ -13,9 +13,10 @@ discriminators match `YAMLReplaySource.decodePayloadStanza`.
 
 Mapping:
   - `agent_output`  -> `turns[]`            (statement/inner_thought or vote/reason)
-  - `assignment`    -> one `assignment` code-phase event per round (scene-setter;
-                       deduped — every agent gets the same topic, so only the
-                       first is emitted to set the scene without N identical rows)
+  - `shared_assignment` -> one `sharedAssignment` code-phase event (assign
+                       target: all — the round's shared お題; value only, no agent)
+  - `assignment`    -> one `assignment` code-phase event per agent (assign
+                       target: random_one — word wolf, each agent's own secret)
   - `vote_results`  -> `voteResults`
   - `score_update`  -> `scoreUpdate`
   - `elimination`   -> `elimination`
@@ -139,7 +140,6 @@ def main():
 
     turns, code = [], []
     round_no, phase_idx, phase_type_cur = 0, 0, ""
-    scene_set_rounds = set()  # rounds whose assignment scene-setter is already emitted
     for l in lines:
         if l.get("type") != "event":
             continue
@@ -163,12 +163,21 @@ def main():
                 "agent": l["agent"],
                 "fields": ordered_fields(l["fields"]),
             })
+        elif e == "shared_assignment":
+            # Shared お題 for the whole round (assign target: all, #939). The
+            # harness emits ONE per round, so no dedup — value only, no agent.
+            value = l.get("value", "")
+            code.append({
+                "round": round_no,
+                "phase_index": phase_idx,
+                "phase_type": phase_type_cur,
+                "summary": value,
+                "payload": {"kind": "sharedAssignment", "value": value},
+            })
         elif e == "assignment":
-            # Scene-setter: every agent gets the same topic, so emit only the
-            # first assignment of each round to set the scene (the topic/お題).
-            if round_no in scene_set_rounds:
-                continue
-            scene_set_rounds.add(round_no)
+            # Per-agent assignment (assign target: random_one — word wolf). Each
+            # agent gets a DIFFERENT secret, so emit one line per agent (#939);
+            # deduping here would collapse the wolf/villager split to one word.
             agent, value = l.get("agent", ""), l.get("value", "")
             code.append({
                 "round": round_no,

--- a/tools/harness/Sources/PasturaHarnessKit/EventLineMapper.swift
+++ b/tools/harness/Sources/PasturaHarnessKit/EventLineMapper.swift
@@ -52,6 +52,12 @@ package enum EventLineMapper {
     case .assignment(let agent, let value):
       return EventLine(
         t: t, attempt: attempt, event: "assignment", agent: agent, value: value)
+    case .sharedAssignment(let value):
+      // Shared お題 for the whole round (#939) — distinct event name so
+      // `jsonl_to_demo_replay.py` can tell it apart from per-agent `assignment`
+      // (word wolf).
+      return EventLine(
+        t: t, attempt: attempt, event: "shared_assignment", value: value)
     case .summary(let text):
       return EventLine(t: t, attempt: attempt, event: "summary", value: text)
     case .voteResults(let votes, let tallies):
@@ -102,7 +108,7 @@ package enum EventLineMapper {
       return nil
     case .roundStarted, .roundCompleted, .phaseStarted, .phaseCompleted,
       .agentOutput, .agentOutputStream, .scoreUpdate, .elimination,
-      .assignment, .summary, .voteResults, .pairingResult,
+      .assignment, .sharedAssignment, .summary, .voteResults, .pairingResult,
       .conditionalEvaluated, .eventInjected:
       // Handled by the earlier tiers; unreachable here. Listed explicitly
       // (no `default:`) so a NEW SimulationEvent case breaks compilation in


### PR DESCRIPTION
## Summary

`assignAll` (assign phase, `target: all` — iiwake_battle / chinkaitou_soudan) gives every agent the **same** お題 but emitted one `.assignment(agent:value:)` per agent, so the live sim showed N identical "X assigned: …" lines and demos showed a single misleading one-agent line.

- New `SimulationEvent.sharedAssignment(value:)` + `CodePhaseEventPayload.sharedAssignment(value:)` (additive Codable — **no DB migration**; old `.assignment` rows keep decoding).
- `AssignHandler.assignAll` emits **one** `.sharedAssignment` per round; word wolf (`assignRandomOne`) keeps per-agent `.assignment` untouched.
- The shared お題 is the round's **premise** (every agent responds to it), so it's rendered as a **moss left-accent rule + clipboard icon + body-weight ink text** across all surfaces (live sim, demo, past-results) — not the muted 9pt meta of glanceable result lines. Markdown export uses `- 📋 <value>`. No "Topic:" label (values are self-framing), no new xcstrings key.
- Shared topics are **not** written to `predictionAssignments` — a shared topic has no minority holder, so it can't pollute word-wolf ground truth (#915).
- Harness `EventLineMapper` emits a distinct `shared_assignment` name; 4 demo replays + `jsonl_to_demo_replay.py` updated for the new kind.

**Note:** OLD `assignAll` past-results persisted before this change still render legacy N-per-agent lines by design (no migration) — not a bug.

## Test plan

- Full unit suite: **2535 tests / 215 suites pass**; harness `swift build` green; swiftlint `--strict` clean.
- New guards for each `default:`-protected silent site: AssignHandler emit-shape (1 shared vs N per-agent), payload round-trip + legacy-decode, VM persistence (1 payload + 1 LogEntry), `predictionAssignments`-isolation, YAML decode round-trip, `codePhaseFloorMs` dwell, Markdown rendering, ReplayViewModel inline line + ContentFilter.
- **Device-QA gate**: on the iiwake_battle / chinkaitou_soudan demos + a live assignAll run, confirm the shared お題 renders as the accent-rule premise line (moss rule + clipboard icon + body text, no agent name), readable before the round's turns; glance-check it doesn't feel noisy across multiple rounds.

Closes #939.

🤖 Generated with [Claude Code](https://claude.com/claude-code)