### PR TITLE
✨ feat: tap a chat sheep to view its persona (Sim / Demo / Past Results)

### DIFF
--- a/Pastura/Pastura/Models/Scenario.swift
+++ b/Pastura/Pastura/Models/Scenario.swift
@@ -132,4 +132,16 @@ nonisolated public struct Scenario: Codable, Sendable, Equatable {
     self.logWindow = logWindow
     self.extraData = extraData
   }
+
+  /// Returns the persona whose ``Persona/name`` equals `name`, or `nil` when
+  /// no persona matches.
+  ///
+  /// The chat surfaces (Simulation / Demo / Past Results) call this to
+  /// resolve a tapped agent's display name to its persona for the
+  /// persona-detail sheet (#942). On the (unexpected) duplicate-name case the
+  /// **first** persona in ``personas`` order wins; a blank or unmatched name
+  /// returns `nil`, which the call sites treat as "not tappable".
+  public func persona(named name: String) -> Persona? {
+    personas.first { $0.name == name }
+  }
 }

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -4591,6 +4591,16 @@
         }
       }
     },
+    "Persona" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ペルソナ"
+          }
+        }
+      }
+    },
     "Persona %lld description contains a term that is not allowed" : {
       "localizations" : {
         "ja" : {
@@ -5685,6 +5695,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "スコアボード全体を表示"
+          }
+        }
+      }
+    },
+    "Shows this agent's persona" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このエージェントのペルソナを表示します"
           }
         }
       }

--- a/Pastura/Pastura/Views/Components/AgentOutputRow+AvatarTap.swift
+++ b/Pastura/Pastura/Views/Components/AgentOutputRow+AvatarTap.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+// The tap-to-view-persona avatar / name affordances for `AgentOutputRow`,
+// split into a sibling extension to keep the main file's struct body under
+// swiftlint's `type_body_length` cap. These are pure view helpers — they
+// touch none of the file-private reveal-state machine, only the non-private
+// `agent`, `agentPosition`, and `onAvatarTap` members — so the split needs no
+// visibility widening of the reveal internals. See #942.
+extension AgentOutputRow {
+
+  /// The leading avatar column. When ``onAvatarTap`` is set the sheep becomes
+  /// a **sighted-only** tap target and stays `.accessibilityHidden` (it is
+  /// decorative — VoiceOver reaches the persona sheet through ``nameLabel``,
+  /// avoiding `SheepAvatar`'s color-slot label surfacing as a spurious
+  /// button). The gesture sits on the leaf `AvatarSlot`, so the row's
+  /// `@State` identity is untouched.
+  @ViewBuilder var avatarColumn: some View {
+    let slot = AvatarSlot(agentName: agent, position: agentPosition)
+    if let onAvatarTap {
+      slot
+        .contentShape(Rectangle())
+        .onTapGesture { onAvatarTap(agent) }
+        .accessibilityHidden(true)
+    } else {
+      slot
+    }
+  }
+
+  /// The agent-name caption. When ``onAvatarTap`` is set it becomes the single
+  /// VoiceOver entry point to the persona sheet: the `Text` already announces
+  /// the agent's display name, so adding `.isButton` + a default accessibility
+  /// action (plus a pointer `.onTapGesture`) makes the name a button without
+  /// duplicating the identity onto the hidden avatar. The hint describes the
+  /// action, not the target.
+  @ViewBuilder var nameLabel: some View {
+    let label = Text(agent)
+      .textStyle(Typography.captionName)
+      .foregroundStyle(Color.inkSecondary)
+    if let onAvatarTap {
+      label
+        .contentShape(Rectangle())
+        .onTapGesture { onAvatarTap(agent) }
+        .accessibilityAddTraits(.isButton)
+        .accessibilityHint(Text(String(localized: "Shows this agent's persona")))
+        .accessibilityAction { onAvatarTap(agent) }
+    } else {
+      label
+    }
+  }
+}

--- a/Pastura/Pastura/Views/Components/AgentOutputRow.swift
+++ b/Pastura/Pastura/Views/Components/AgentOutputRow.swift
@@ -196,6 +196,21 @@ struct AgentOutputRow: View {
   /// `AgentOutputRow+Diagnostic.swift` for the consumers.
   var debugRowID: String?
 
+  /// Invoked with the agent's display name when the user taps this row's
+  /// avatar or name to inspect the agent's persona. `nil` (default) keeps
+  /// the avatar + name **decorative and non-interactive** — the pre-existing
+  /// behavior for every call site that does not opt in. The three chat
+  /// surfaces pass it only when a persona is actually resolvable (Past
+  /// Results degrades to `nil` for pre-snapshot / unparseable runs). When
+  /// non-nil: the avatar becomes a **sighted-only** tap target (it stays
+  /// `.accessibilityHidden` — identity is carried by the name, and
+  /// `SheepAvatar`'s color-slot label must not surface as a button), and the
+  /// name `Text` gains a VoiceOver `.isButton` action, so both pointer and
+  /// assistive users reach the persona sheet. Tap handling is attached to the
+  /// leaf avatar / name views only — never by wrapping the row in a container
+  /// (that would flush the load-bearing `@State`; see the `body` note).
+  var onAvatarTap: ((String) -> Void)?
+
   /// Per-row thought visibility. Default `false` only when no init value
   /// is provided; the custom init below seeds this from `showAllThoughts`
   /// so a row constructed in "auto-expand" mode starts expanded, and a
@@ -254,7 +269,8 @@ struct AgentOutputRow: View {
     initialVisibleChars: Int = 0,
     showAvatar: Bool = true,
     agentPosition: Int? = nil,
-    debugRowID: String? = nil
+    debugRowID: String? = nil,
+    onAvatarTap: ((String) -> Void)? = nil
   ) {
     self.agent = agent
     self.output = output
@@ -273,6 +289,7 @@ struct AgentOutputRow: View {
     self.showAvatar = showAvatar
     self.agentPosition = agentPosition
     self.debugRowID = debugRowID
+    self.onAvatarTap = onAvatarTap
     self._showInnerThought = State(initialValue: showAllThoughts)
     // Seed the reveal counter from the handoff position so the first frame
     // already shows the streamed prefix (no 0→seed flicker). `showInnerThought`
@@ -302,16 +319,14 @@ struct AgentOutputRow: View {
     // avatar column would have been.
     HStack(alignment: .top, spacing: showAvatar ? ChatBubbleLayout.avatarTextGap : 0) {
       if showAvatar {
-        AvatarSlot(agentName: agent, position: agentPosition)
+        avatarColumn
       }
       VStack(alignment: .leading, spacing: 6) {
         // Agent name + phase. Caption size + ink-secondary matches
         // `design-system.md` §3.2 `caption/name` and reference HTML
         // `.b-name { font-size: 10.5px; color: #7a7e68 }`.
         HStack(alignment: .firstTextBaseline) {
-          Text(agent)
-            .textStyle(Typography.captionName)
-            .foregroundStyle(Color.inkSecondary)
+          nameLabel
           PhaseTypeLabel(phaseType: phaseType)
           Spacer()
         }

--- a/Pastura/Pastura/Views/Components/PersonaDetailSheet.swift
+++ b/Pastura/Pastura/Views/Components/PersonaDetailSheet.swift
@@ -1,0 +1,88 @@
+import SwiftUI
+
+/// A tapped ``Persona`` wrapped for presentation via `.sheet(item:)`.
+///
+/// `Persona` is a `Models`-layer value type without `Identifiable` — its
+/// `name` is not guaranteed unique across the app, so the chat surfaces wrap
+/// the persona here rather than conforming the model (which would leak a
+/// presentation concern into `Models/` and risk `ForEach`/sheet id
+/// collisions elsewhere). Follows the `.sheet(item:)` rule in
+/// `swiftui-traps.md` — pass `Optional<Model>`, never `Int: Identifiable`.
+///
+/// ``position`` mirrors the agent's index in the scenario's persona list so
+/// the sheet's avatar color matches the chat row it was opened from
+/// (``SheepAvatar/Character/forAgent(_:position:)`` is position-priority).
+struct PersonaSheetItem: Identifiable {
+  let persona: Persona
+  let position: Int?
+
+  var id: String { persona.name }
+
+  init(persona: Persona, position: Int? = nil) {
+    self.persona = persona
+    self.position = position
+  }
+}
+
+/// Read-only sheet showing a single agent's persona, surfaced by tapping the
+/// agent's avatar / name in the Simulation, Demo, or Past Results chat log
+/// (#942).
+///
+/// Presentation-only — editing lives in `PersonaEditorSheet`. The chrome
+/// mirrors ``ScoreboardSheet`` (NavigationStack + inline title + Close), and
+/// the avatar + name header reuses the ``ViewerPredictionSheet`` row style.
+/// The body renders ``Persona/description`` **verbatim**: scenarios author it
+/// in the 【立場】【目的】 style, but the sheet imposes no structure so it stays
+/// robust to any description format. Presented at `.medium` detent so the
+/// conversation the user tapped from stays partly visible behind it.
+struct PersonaDetailSheet: View {
+  let persona: Persona
+  var position: Int?
+
+  @Environment(\.dismiss) private var dismiss
+
+  var body: some View {
+    NavigationStack {
+      ScrollView {
+        VStack(alignment: .leading, spacing: 20) {
+          header
+          Text(persona.description)
+            .textStyle(Typography.bodyBubble)
+            .foregroundStyle(Color.ink)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .textSelection(.enabled)
+        }
+        .padding(20)
+      }
+      .navigationTitle(String(localized: "Persona"))
+      .navigationBarTitleDisplayMode(.inline)
+      .toolbar {
+        ToolbarItem(placement: .confirmationAction) {
+          Button(String(localized: "Close")) { dismiss() }
+        }
+      }
+    }
+    .presentationDetents([.medium])
+  }
+
+  private var header: some View {
+    HStack(spacing: 14) {
+      // Decorative — identity is carried by the adjacent name `Text`;
+      // `SheepAvatar`'s accessibility label is a color-slot name
+      // ("Alice"/"Bob"…), not the agent's display name (see i18n rule
+      // §"Audit triage").
+      SheepAvatar(
+        character: .forAgent(persona.name, position: position),
+        size: 56
+      )
+      .accessibilityHidden(true)
+      // Reuses `titleScenario` (the "primary entity name" anchor) — the
+      // persona name is this sheet's primary heading, a semantic match, not
+      // a coincidental size reuse.
+      Text(persona.name)
+        .textStyle(Typography.titleScenario)
+        .foregroundStyle(Color.ink)
+      Spacer(minLength: 0)
+    }
+  }
+}

--- a/Pastura/Pastura/Views/Components/PersonaDetailSheet.swift
+++ b/Pastura/Pastura/Views/Components/PersonaDetailSheet.swift
@@ -37,7 +37,7 @@ struct PersonaSheetItem: Identifiable {
 /// conversation the user tapped from stays partly visible behind it.
 struct PersonaDetailSheet: View {
   let persona: Persona
-  var position: Int?
+  let position: Int?
 
   @Environment(\.dismiss) private var dismiss
 

--- a/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+ChatStream.swift
+++ b/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+ChatStream.swift
@@ -112,7 +112,8 @@ extension ModelDownloadHostView {
         proxy.scrollTo(entry.id, anchor: .bottom)
       },
       growsWithReveal: true,
-      agentPosition: agentPosition(for: entry.agent, viewModel: viewModel)
+      agentPosition: agentPosition(for: entry.agent, viewModel: viewModel),
+      onAvatarTap: { selectedPersona = personaItem(for: $0, viewModel: viewModel) }
     )
     .id(entry.id)
     .transition(reduceMotion ? .identity : .opacity)
@@ -195,5 +196,23 @@ extension ModelDownloadHostView {
       sourceIndex < sources.count
     else { return nil }
     return sources[sourceIndex].scenario.personas.firstIndex(where: { $0.name == agentName })
+  }
+
+  /// Resolves a tapped agent name to its persona for the detail sheet
+  /// (#942), reading the active source's scenario directly (the same
+  /// `sources` the host already holds — no `ReplayViewModel` accessor
+  /// needed). Returns `nil` — so the sheet does not present — when no source
+  /// is active or no persona matches the name.
+  private func personaItem(
+    for agentName: String, viewModel: ReplayViewModel
+  ) -> PersonaSheetItem? {
+    guard let sourceIndex = viewModel.currentSourceIndex,
+      sourceIndex < sources.count
+    else { return nil }
+    let scenario = sources[sourceIndex].scenario
+    guard let persona = scenario.persona(named: agentName) else { return nil }
+    return PersonaSheetItem(
+      persona: persona,
+      position: scenario.personas.firstIndex { $0.name == agentName })
   }
 }

--- a/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView.swift
+++ b/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView.swift
@@ -90,6 +90,11 @@ struct ModelDownloadHostView: View {
   // Internal (not `private`) so `+ChatStream.swift`'s `agentPosition`
   // / `promoCardInset` and `currentPresetName` can read it.
   @State var sources: [any ReplaySource] = []
+  /// The persona shown when the viewer taps an agent's avatar / name in the
+  /// demo stream (#942). Resolved from the active source's scenario via
+  /// ``personaItem(for:viewModel:)`` — `nil` (no active source, or an
+  /// unmatched name) simply doesn't present.
+  @State var selectedPersona: PersonaSheetItem?
   // Type-once latch for opening cards (#867), keyed by `ChatItem.scenarioIntro`
   // id. Generalizes the live Sim's single reveal latch
   // (`SimulationViewModel.introRevealHasBegun`) to the demo's
@@ -150,6 +155,9 @@ struct ModelDownloadHostView: View {
             localized:
               "The partial download will be deleted. Resuming later means starting over from the beginning."
           ))
+      }
+      .sheet(item: $selectedPersona) { item in
+        PersonaDetailSheet(persona: item.persona, position: item.position)
       }
   }
 

--- a/Pastura/Pastura/Views/Results/ResultDetailView+RowLayout.swift
+++ b/Pastura/Pastura/Views/Results/ResultDetailView+RowLayout.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+// Pure, state-independent row-layout helpers for `ResultDetailView`, split
+// into a sibling extension to keep the main file under swiftlint's 400-line
+// `file_length` cap. These read no `@State` — only design tokens — so, unlike
+// the export / load helpers, the split needs no `private`-visibility widening
+// on the host.
+extension ResultDetailView {
+
+  /// Wraps a row with a leading indent and "↳ sub-phase" caption when the
+  /// item's `phasePath` depth is greater than 1 (i.e. it lives inside a
+  /// conditional branch). Top-level items (depth ≤ 1) pass through unchanged.
+  @ViewBuilder
+  func subPhaseWrapper<Content: View>(
+    item: ResultDetailTimelineBuilder.Item,
+    @ViewBuilder content: () -> Content
+  ) -> some View {
+    if (item.phasePath?.count ?? 0) > 1 {
+      VStack(alignment: .leading, spacing: 2) {
+        // `metaLabel` (9pt semibold mono, mixed case) — `tagPhase`
+        // would force "↳ SUB-PHASE" UPPER which reads shouty for a
+        // prose-like marker. tagPhase stays for one-word phase tags
+        // (WORD WOLF). See design-system §3.2.
+        Text(String(localized: "↳ sub-phase"))
+          .textStyle(Typography.metaLabel)
+          .foregroundStyle(Color.muted)
+          .padding(.leading, 32)
+        content()
+          .padding(.leading, 16)
+      }
+    } else {
+      content()
+    }
+  }
+
+  func roundSeparator(_ round: Int) -> some View {
+    HStack {
+      Rectangle().fill(Color.rule).frame(height: 1)
+      // `metaLabel` keeps "Round N" mixed case — tagPhase would
+      // upper-case to "ROUND N" which reads shouty for a prose
+      // marker. tagPhase stays reserved for one-word phase tags
+      // (WORD WOLF). See design-system §3.2.
+      Text(String(format: String(localized: "Round %lld"), round))
+        .textStyle(Typography.metaLabel)
+        .foregroundStyle(Color.inkSecondary)
+      Rectangle().fill(Color.rule).frame(height: 1)
+    }
+    .padding(.vertical, 4)
+  }
+}

--- a/Pastura/Pastura/Views/Results/ResultDetailView.swift
+++ b/Pastura/Pastura/Views/Results/ResultDetailView.swift
@@ -27,6 +27,14 @@ struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
   /// that case `AgentOutputRow` falls back to name-based avatar
   /// resolution.
   @State private var agentOrder: [String] = []
+  /// Personas in scenario-declared order, decoded from the run's scenario
+  /// snapshot alongside ``agentOrder``. Drives the tap-to-view-persona sheet
+  /// (#942). Empty for runs whose scenario YAML couldn't be decoded (pre-v7
+  /// deleted scenario, YAML drift) — in that case the turn rows stay
+  /// non-tappable (``turnRow`` passes `onAvatarTap: nil`).
+  @State private var personas: [Persona] = []
+  /// The persona shown when the user taps an agent's avatar / name (#942).
+  @State private var selectedPersona: PersonaSheetItem?
   @State private var isLoading = true
   @State private var showAllThoughts = true
   @State private var exportPayload: ResultMarkdownExporter.ExportedResult?
@@ -145,6 +153,9 @@ struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
     .sheet(item: $yamlExportPayload) { payload in
       ShareSheet(activityItems: [payload.text, payload.fileURL])
     }
+    .sheet(item: $selectedPersona) { item in
+      PersonaDetailSheet(persona: item.persona, position: item.position)
+    }
     .alert(
       String(localized: "Export failed"),
       isPresented: Binding(
@@ -205,45 +216,14 @@ struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
     .accessibilityIdentifier("resultDetail.timeline")
   }
 
-  /// Wraps a row with a leading indent and "↳ sub-phase" caption when the
-  /// item's `phasePath` depth is greater than 1 (i.e. it lives inside a
-  /// conditional branch). Top-level items (depth ≤ 1) pass through unchanged.
-  @ViewBuilder
-  private func subPhaseWrapper<Content: View>(
-    item: ResultDetailTimelineBuilder.Item,
-    @ViewBuilder content: () -> Content
-  ) -> some View {
-    if (item.phasePath?.count ?? 0) > 1 {
-      VStack(alignment: .leading, spacing: 2) {
-        // `metaLabel` (9pt semibold mono, mixed case) — `tagPhase`
-        // would force "↳ SUB-PHASE" UPPER which reads shouty for a
-        // prose-like marker. tagPhase stays for one-word phase tags
-        // (WORD WOLF). See design-system §3.2.
-        Text(String(localized: "↳ sub-phase"))
-          .textStyle(Typography.metaLabel)
-          .foregroundStyle(Color.muted)
-          .padding(.leading, 32)
-        content()
-          .padding(.leading, 16)
-      }
-    } else {
-      content()
-    }
-  }
-
-  private func roundSeparator(_ round: Int) -> some View {
-    HStack {
-      Rectangle().fill(Color.rule).frame(height: 1)
-      // `metaLabel` keeps "Round N" mixed case — tagPhase would
-      // upper-case to "ROUND N" which reads shouty for a prose
-      // marker. tagPhase stays reserved for one-word phase tags
-      // (WORD WOLF). See design-system §3.2.
-      Text(String(format: String(localized: "Round %lld"), round))
-        .textStyle(Typography.metaLabel)
-        .foregroundStyle(Color.inkSecondary)
-      Rectangle().fill(Color.rule).frame(height: 1)
-    }
-    .padding(.vertical, 4)
+  /// Resolves a tapped agent name to its persona for the detail sheet
+  /// (#942). Only reached when ``personas`` is non-empty (``turnRow`` gates
+  /// the tap out otherwise); returns `nil` defensively for an unmatched name.
+  private func personaItem(for agentName: String) -> PersonaSheetItem? {
+    guard let persona = personas.first(where: { $0.name == agentName }) else { return nil }
+    return PersonaSheetItem(
+      persona: persona,
+      position: agentOrder.firstIndex(of: agentName))
   }
 
   @ViewBuilder
@@ -255,7 +235,11 @@ struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
         output: output,
         phaseType: phaseType,
         showAllThoughts: showAllThoughts,
-        agentPosition: agentOrder.firstIndex(of: agentName)
+        agentPosition: agentOrder.firstIndex(of: agentName),
+        // Gate at the run level, not per-tap: a run whose scenario couldn't
+        // be decoded (pre-v7 deleted scenario, YAML drift) has no personas,
+        // so the rows stay non-tappable rather than showing a dead affordance.
+        onAvatarTap: personas.isEmpty ? nil : { selectedPersona = personaItem(for: $0) }
       )
     } else {
       // Pre-#92 fallback: TurnRecord without agentName. Newer code phases
@@ -295,6 +279,10 @@ struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
     /// on every turn row is an O(1) cache hit. Empty when YAML decode
     /// fails — turnRow falls back to name-based avatar resolution.
     let agentOrder: [String]
+    /// Personas in scenario-declared order (parallel to ``agentOrder``),
+    /// decoded from the same parse. Empty on decode failure — drives the
+    /// tap-to-view-persona degrade (#942).
+    let personas: [Persona]
   }
 
   private func loadData() async {
@@ -322,15 +310,19 @@ struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
         // degradation: past results with unparseable scenarios still
         // render, just with name-based avatars.
         let agentOrder: [String]
+        let personas: [Persona]
         if let scenarioRecord = scenario,
           let parsed = try? ScenarioLoader().load(yaml: scenarioRecord.yamlDefinition) {
           agentOrder = parsed.personas.map(\.name)
+          personas = parsed.personas
         } else {
           agentOrder = []
+          personas = []
         }
         return LoadedData(
           turns: turns, events: events, items: items,
-          simulation: sim, scenario: scenario, agentOrder: agentOrder)
+          simulation: sim, scenario: scenario, agentOrder: agentOrder,
+          personas: personas)
       }
       self.turns = fetched.turns
       self.events = fetched.events
@@ -338,6 +330,7 @@ struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
       self.simulation = fetched.simulation
       self.scenario = fetched.scenario
       self.agentOrder = fetched.agentOrder
+      self.personas = fetched.personas
     } catch {
       self.turns = []
       self.events = []

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -55,6 +55,10 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
   // Accessed from SimulationView+Background.swift extension for the toggle subtitle.
   @State var scenario: Scenario?
   @State private var showScoreboard = false
+  /// The persona shown when the user taps an agent's avatar / name in the
+  /// log (#942). Resolved from ``scenario`` via ``personaItem(for:)`` — `nil`
+  /// (no scenario yet, or an unmatched name) simply doesn't present.
+  @State private var selectedPersona: PersonaSheetItem?
   /// Drives the final-ranking card's animated insertion at run completion
   /// (#868). Mirrors `viewModel.isCompleted`, but flipped inside `withAnimation`
   /// so the card fades/slides in — `isCompleted` is set on the VM outside any
@@ -563,7 +567,8 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
                 // made the box expand ahead of the visible text.
                 growsWithReveal: true,
                 agentPosition: scenario?.personas.firstIndex(where: { $0.name == snapshot.agent }),
-                debugRowID: "stream-\(snapshot.agent)"
+                debugRowID: "stream-\(snapshot.agent)",
+                onAvatarTap: { selectedPersona = personaItem(for: $0) }
               )
               .id("streaming-\(snapshot.agent)")
             }
@@ -680,6 +685,10 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
     .sheet(isPresented: $showScoreboard) {
       ScoreboardSheet(scores: viewModel.scores, eliminated: viewModel.eliminated)
         .presentationDetents([.medium])
+        .deepLinkGated()
+    }
+    .sheet(item: $selectedPersona) { item in
+      PersonaDetailSheet(persona: item.persona, position: item.position)
         .deepLinkGated()
     }
     // The model-busy scrim (initial load + BG reload) now lives at `body`
@@ -968,6 +977,16 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
 
   // MARK: - Log Entries
 
+  /// Resolves a tapped agent name to its persona for the detail sheet
+  /// (#942). Returns `nil` — so the sheet does not present — when the
+  /// scenario hasn't loaded yet or no persona matches the name.
+  private func personaItem(for agent: String) -> PersonaSheetItem? {
+    guard let scenario, let persona = scenario.persona(named: agent) else { return nil }
+    return PersonaSheetItem(
+      persona: persona,
+      position: scenario.personas.firstIndex { $0.name == agent })
+  }
+
   @ViewBuilder
   private func logEntryView(
     _ entry: LogEntry, viewModel: SimulationViewModel, proxy: ScrollViewProxy
@@ -1010,7 +1029,8 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
         // (reveal-position handoff, bug 2); 0 for a non-streamed row.
         initialVisibleChars: viewModel.handoffSeed(forEntryId: entry.id),
         agentPosition: scenario?.personas.firstIndex(where: { $0.name == agent }),
-        debugRowID: entry.id.uuidString
+        debugRowID: entry.id.uuidString,
+        onAvatarTap: { selectedPersona = personaItem(for: $0) }
       )
     case .phaseStarted(let phaseType):
       // LLM phases (speak / vote / choose) become full-width separators

--- a/Pastura/PasturaTests/Models/ScenarioTests.swift
+++ b/Pastura/PasturaTests/Models/ScenarioTests.swift
@@ -42,4 +42,36 @@ struct ScenarioTests {
   @Test func acceptedLanguagesPinsJaAndEn() {
     #expect(Scenario.acceptedLanguages == ["ja", "en"])
   }
+
+  // MARK: - persona(named:) resolution (persona-detail sheet, #942)
+
+  @Test func personaNamedReturnsMatchingPersona() {
+    let scenario = ScenarioFixture.make(personas: [
+      Persona(name: "Alice", description: "Curious café clerk"),
+      Persona(name: "Bob", description: "Level-headed mediator")
+    ])
+    #expect(scenario.persona(named: "Bob")?.description == "Level-headed mediator")
+  }
+
+  @Test func personaNamedReturnsNilForUnknownName() {
+    let scenario = ScenarioFixture.make()
+    #expect(scenario.persona(named: "Nobody") == nil)
+  }
+
+  @Test func personaNamedReturnsNilForBlankName() {
+    // The tapped agent name is always non-blank in practice, but a defensive
+    // empty lookup must not match a real persona.
+    let scenario = ScenarioFixture.make()
+    #expect(scenario.persona(named: "") == nil)
+  }
+
+  @Test func personaNamedFirstMatchWinsOnDuplicateNames() {
+    // Scenarios shouldn't ship duplicate names, but resolution must be
+    // deterministic (first in declared order) if one slips through.
+    let scenario = ScenarioFixture.make(personas: [
+      Persona(name: "Alice", description: "first"),
+      Persona(name: "Alice", description: "second")
+    ])
+    #expect(scenario.persona(named: "Alice")?.description == "first")
+  }
 }


### PR DESCRIPTION
## Summary
Tapping an agent's sheep **avatar or name** in the chat log opens a read-only **persona-detail sheet** (medium detent) showing that agent's persona description. Works on all three chat surfaces — live **Simulation**, DL-time **Demo** replay, and **Past Results**. Answers "who is this person again?" mid-run, and gives the Demo its first persona-viewing path at all.

PR1 of 2 for #942 (split on critic recommendation to isolate the risky part):
- **This PR (PR1)**: the sheet + tap + 3-screen wiring. Typing keeps running behind the sheet.
- **PR2 (follow-up)**: pause the typing animation while the sheet is up (keeps the engine running / buffering). Touches the `AgentOutputRow` reveal Task + playback loops, so it lands separately with device QA.

## How it works
- Shared `AgentOutputRow` gains an opt-in `onAvatarTap: ((String) -> Void)? = nil`. When set, the **avatar** is a sighted-only tap target (stays `.accessibilityHidden` — identity is on the name) and the **name** `Text` becomes the single VoiceOver `.isButton`. Default `nil` keeps every existing call site decorative and unchanged. Gestures sit on leaf views only — the reveal-state `@State`/Task is untouched (#133 race surface).
- `PersonaDetailSheet` renders `Persona.description` verbatim (no format assumptions); `PersonaSheetItem` wraps the persona for `.sheet(item:)`.
- Persona resolved via the new pure `Scenario.persona(named:)`. Sim reads its `@State scenario`; Demo reads the active source's scenario; Past Results retains the parsed personas from the run's YAML snapshot.
- **Graceful degrade**: Past Results runs whose scenario can't be decoded (pre-v7 deleted scenario / YAML drift) pass `onAvatarTap: nil` → rows stay non-tappable, no dead affordance.

## Test plan
- ✅ Full unit suite green (2575 tests); new `ScenarioTests` cases for `persona(named:)` (match / unknown / blank / duplicate-first-wins).
- ✅ `swiftlint --strict` + build green; localization coverage OK (`Persona`, `Shows this agent's persona` with ja).
- ✅ Opus code review: PASS (0 critical / 0 warnings).
- 📱 **Device QA (please verify on device):** tap avatar & name on Sim / Demo / Past Results opens the sheet; VoiceOver announces the name as a button with the "ペルソナを表示" hint and the avatar is skipped; medium-detent sheet leaves the conversation partly visible.

Part of #942

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1JS6ENi2uPq5LMP7Ujxxf