### PR TITLE
✨ feat: whisper phase — pair-private conversation channel (#908 PR1)

### DIFF
--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -27,6 +27,7 @@ includes them.
 | vote         | LLM        | All agents vote for one agent        |
 | choose       | LLM        | Choose from options                  |
 | reflect      | LLM        | Each agent privately updates a short memo (`note`) |
+| whisper      | LLM        | Pairs privately whisper — viewer-visible, hidden from other agents (#908) |
 | score_calc   | Code       | Calculate scores                     |
 | assign       | Code       | Distribute info to agents            |
 | eliminate    | Code       | Remove most-voted agent              |
@@ -48,6 +49,23 @@ output is itself the private reasoning, so reflect declares no secondary
 thought field. `reflect` is NOT allowed inside `conditional` branches —
 `ScenarioValidator.validateBranch` rejects it at load time and
 `ConditionalHandler.subHandlers` omits it.
+
+`whisper` is an LLM phase: active agents pair off (adjacent disjoint
+pairs in persona order, rotated by round; an odd agent sits out) and each
+pair runs `sub_rounds` back-and-forth exchanges producing `{ statement }`
+(canonical, required at the run gate) with optional `inner_thought`.
+Every utterance is emitted as a normal `.agentOutput` carrying a reserved
+`whisper_to` field naming the partner — viewer-visible, but never written
+to the conversation log or `lastOutputs`, so other agents' prompts can't
+see it. Each participant's view of the exchange is stored under the
+reserved `whispers_<name>` key (overwrite — latest exchange only; a
+sat-out agent's stale key is cleared) and surfaced back to only that
+agent (system-prompt section + `{my_whispers}` template variable).
+`{whisper_partner}` / `{whisper_exchange}` are resolvable inside the
+whisper phase's own prompt template; the handler also always appends a
+partner-naming context block, so placeholder-free templates still work.
+Like `reflect`, `whisper` is NOT allowed inside `conditional` branches
+(same two enforcement points).
 
 ### PhaseHandler Protocol
 
@@ -128,6 +146,8 @@ speak_all:  agentCount per round
 speak_each: agentCount × subRounds per round
 vote:       agentCount per round
 reflect:    agentCount per round
+whisper:    (agentCount / 2) × subRounds × 2 per round
+            (integer division — pair count × exchanges × 2 speakers)
 choose:     agentCount × 2 for round_robin (N adjacent pairs, 2 calls each)
             agentCount for individual (no pairing)
 score_calc/assign/eliminate/summarize/event_inject: 0 (code phases)

--- a/Pastura/Pastura/Engine/PhaseDispatcher.swift
+++ b/Pastura/Pastura/Engine/PhaseDispatcher.swift
@@ -2,8 +2,9 @@ import Foundation
 
 /// Routes ``PhaseType`` values to their corresponding ``PhaseHandler`` implementations.
 ///
-/// All 10 phase types are registered at initialization. Used by ``SimulationRunner``
-/// to dispatch each phase in the simulation loop.
+/// All phase types except `.whisper` (whose handler is wired in a follow-up
+/// change) are registered at initialization — 11 of the 12 ``PhaseType`` cases.
+/// Used by ``SimulationRunner`` to dispatch each phase in the simulation loop.
 nonisolated struct PhaseDispatcher: Sendable {
   private let handlers: [PhaseType: any PhaseHandler]
 

--- a/Pastura/Pastura/Engine/PhaseDispatcher.swift
+++ b/Pastura/Pastura/Engine/PhaseDispatcher.swift
@@ -2,9 +2,8 @@ import Foundation
 
 /// Routes ``PhaseType`` values to their corresponding ``PhaseHandler`` implementations.
 ///
-/// All phase types except `.whisper` (whose handler is wired in a follow-up
-/// change) are registered at initialization — 11 of the 12 ``PhaseType`` cases.
-/// Used by ``SimulationRunner`` to dispatch each phase in the simulation loop.
+/// All 12 ``PhaseType`` cases are registered at initialization. Used by
+/// ``SimulationRunner`` to dispatch each phase in the simulation loop.
 nonisolated struct PhaseDispatcher: Sendable {
   private let handlers: [PhaseType: any PhaseHandler]
 
@@ -20,7 +19,8 @@ nonisolated struct PhaseDispatcher: Sendable {
       .summarize: SummarizeHandler(),
       .conditional: ConditionalHandler(),
       .eventInject: EventInjectHandler(),
-      .reflect: ReflectHandler()
+      .reflect: ReflectHandler(),
+      .whisper: WhisperHandler()
     ]
   }
 

--- a/Pastura/Pastura/Engine/Phases/ChooseHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/ChooseHandler.swift
@@ -94,6 +94,7 @@ nonisolated struct ChooseHandler: PhaseHandler {
       window: context.scenario.logWindow)
     promptBuilder.injectAssigned(into: &variables, personaName: persona.name)
     promptBuilder.injectNotes(into: &variables, personaName: persona.name)
+    promptBuilder.injectWhispers(into: &variables, personaName: persona.name)
     let userPrompt = promptBuilder.expandTemplate(promptTemplate, variables: variables)
 
     let output = try await llmCaller.call(

--- a/Pastura/Pastura/Engine/Phases/ConditionalHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/ConditionalHandler.swift
@@ -30,6 +30,11 @@ nonisolated struct ConditionalHandler: PhaseHandler {
   /// handler, including `ConditionalHandler`, which would build another
   /// `PhaseDispatcher` in turn, forever.
   ///
+  /// Also omits `.reflect` and `.whisper` — both are private-channel LLM
+  /// phases that are not supported inside a conditional branch in v1
+  /// (`ScenarioValidator.validateBranch` rejects them at load time; the
+  /// omission here is the runtime backstop).
+  ///
   /// `event_inject` is included so curators can gate event injection on
   /// scenario state (e.g., "only inject in round 3+"). The validator
   /// applies the same shape-check it does at the top level.

--- a/Pastura/Pastura/Engine/Phases/ReflectHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/ReflectHandler.swift
@@ -45,6 +45,7 @@ nonisolated struct ReflectHandler: PhaseHandler {
         window: context.scenario.logWindow)
       promptBuilder.injectAssigned(into: &variables, personaName: persona.name)
       promptBuilder.injectNotes(into: &variables, personaName: persona.name)
+      promptBuilder.injectWhispers(into: &variables, personaName: persona.name)
       let userPrompt = promptBuilder.expandTemplate(promptTemplate, variables: variables)
 
       let output = try await llmCaller.call(

--- a/Pastura/Pastura/Engine/Phases/SpeakAllHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/SpeakAllHandler.swift
@@ -33,6 +33,7 @@ nonisolated struct SpeakAllHandler: PhaseHandler {
         window: context.scenario.logWindow)
       promptBuilder.injectAssigned(into: &variables, personaName: persona.name)
       promptBuilder.injectNotes(into: &variables, personaName: persona.name)
+      promptBuilder.injectWhispers(into: &variables, personaName: persona.name)
       let userPrompt = promptBuilder.expandTemplate(promptTemplate, variables: variables)
 
       let output = try await llmCaller.call(

--- a/Pastura/Pastura/Engine/Phases/SpeakEachHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/SpeakEachHandler.swift
@@ -35,6 +35,7 @@ nonisolated struct SpeakEachHandler: PhaseHandler {
           window: context.scenario.logWindow)
         promptBuilder.injectAssigned(into: &variables, personaName: persona.name)
         promptBuilder.injectNotes(into: &variables, personaName: persona.name)
+        promptBuilder.injectWhispers(into: &variables, personaName: persona.name)
         let userPrompt = promptBuilder.expandTemplate(promptTemplate, variables: variables)
 
         let output = try await llmCaller.call(

--- a/Pastura/Pastura/Engine/Phases/VoteHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/VoteHandler.swift
@@ -45,6 +45,7 @@ nonisolated struct VoteHandler: PhaseHandler {
       variables["candidates"] = candidates.joined(separator: ", ")
       promptBuilder.injectAssigned(into: &variables, personaName: persona.name)
       promptBuilder.injectNotes(into: &variables, personaName: persona.name)
+      promptBuilder.injectWhispers(into: &variables, personaName: persona.name)
       let userPrompt = promptBuilder.expandTemplate(promptTemplate, variables: variables)
 
       let output = try await llmCaller.call(

--- a/Pastura/Pastura/Engine/Phases/WhisperHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/WhisperHandler.swift
@@ -159,7 +159,7 @@ nonisolated struct WhisperHandler: PhaseHandler {
   // MARK: - Formatting
 
   /// A single whisper line, `name` + spoken `statement`.
-  private struct Utterance {
+  nonisolated private struct Utterance {
     let name: String
     let statement: String
   }

--- a/Pastura/Pastura/Engine/Phases/WhisperHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/WhisperHandler.swift
@@ -1,0 +1,177 @@
+import Foundation
+
+/// Handles `whisper` phases: a secret pairwise exchange between two agents.
+///
+/// Active (non-eliminated) agents are paired off in persona declaration order,
+/// rotated by round so the pairings vary. Each pair runs `subRounds` exchanges;
+/// an exchange is agent1 speaking then agent2 speaking. Every utterance reuses
+/// the `.agentOutput` event with a reserved `whisper_to` field naming the
+/// partner, so the whisper surfaces in the viewer UI / persistence exactly like
+/// any other LLM output.
+///
+/// Whisper content is **pair-private**: it is never appended to
+/// `conversationLog` or `lastOutputs`, so other agents' prompts can't see it
+/// (mirroring ``ReflectHandler``'s private note). At the end of the phase each
+/// participant's formatted view of their pair's exchange is written to the
+/// reserved `whispers_<name>` key (overwrite semantics — latest exchange only,
+/// per the #908 plan). An active agent who sat out an odd-count round has their stale
+/// `whispers_<name>` cleared so a later reader never sees a whisper from a round
+/// they didn't participate in; eliminated agents' keys are left untouched (they
+/// are simply not participants this round).
+nonisolated struct WhisperHandler: PhaseHandler {
+  private let promptBuilder = PromptBuilder()
+  private let llmCaller = LLMCaller()
+
+  /// Per-execution invariants bundled to keep the LLM-call helpers under
+  /// SwiftLint's `function_parameter_count`. `state` is a phase-start snapshot:
+  /// whisper reads it for prompt building but never mutates the public log /
+  /// outputs / scores during the phase, so the copy stays accurate.
+  nonisolated private struct Run {
+    let context: PhaseContext
+    let state: SimulationState
+    let promptTemplate: String
+  }
+
+  func execute(
+    context: PhaseContext,
+    state: inout SimulationState
+  ) async throws {
+    let active = context.scenario.personas.filter { state.eliminated[$0.name] != true }
+    // Fewer than two active agents → nothing to pair. Return without any LLM
+    // call or state write; in particular, do NOT clear anyone's channel here.
+    guard active.count >= 2 else { return }
+
+    let rotated = Self.rotate(active, by: state.currentRound)
+    let promptTemplate =
+      context.phase.prompt
+      ?? pickLanguage(
+        context.scenario.engineLanguage,
+        ja: "相手にこっそり耳打ちしてください。",
+        en: "Whisper privately to your partner.")
+    let run = Run(context: context, state: state, promptTemplate: promptTemplate)
+    let exchanges = max(1, context.phase.subRounds ?? 1)
+    let language = context.scenario.engineLanguage
+
+    var pairIndex = 0
+    while pairIndex + 1 < rotated.count {
+      let (first, second) = (rotated[pairIndex], rotated[pairIndex + 1])
+      let transcript = try await runPair(first, second, exchanges: exchanges, run: run)
+      // Both members see the same exchange body, each headed by their own
+      // partner-identifying line.
+      state.variables["whispers_\(first.name)"] =
+        formatChannel(transcript, partner: second, language: language)
+      state.variables["whispers_\(second.name)"] =
+        formatChannel(transcript, partner: first, language: language)
+      pairIndex += 2
+    }
+
+    // Odd active count: the last rotated element sat this round out. Clear its
+    // stale channel for D4 "latest only" consistency.
+    if rotated.count % 2 == 1, let satOut = rotated.last {
+      state.variables.removeValue(forKey: "whispers_\(satOut.name)")
+    }
+  }
+
+  // MARK: - Pairing
+
+  /// Rotates the active list by `(round - 1)` positions so consecutive rounds
+  /// draw different adjacent pairs. The modulo is normalized non-negative to
+  /// tolerate a `round` of `0`.
+  private static func rotate(_ agents: [Persona], by round: Int) -> [Persona] {
+    let count = agents.count
+    let offset = ((round - 1) % count + count) % count
+    return Array(agents[offset...] + agents[..<offset])
+  }
+
+  /// Runs `exchanges` back-and-forth turns for one pair, accumulating the
+  /// running transcript so each speaker's prompt can reference what was said
+  /// so far via `{whisper_exchange}`.
+  private func runPair(
+    _ first: Persona, _ second: Persona, exchanges: Int, run: Run
+  ) async throws -> [Utterance] {
+    var transcript: [Utterance] = []
+    for _ in 0..<exchanges {
+      let out1 = try await whisperTurn(
+        speaker: first, partner: second, transcript: transcript, run: run)
+      transcript.append(Utterance(name: first.name, statement: out1.statement ?? ""))
+      let out2 = try await whisperTurn(
+        speaker: second, partner: first, transcript: transcript, run: run)
+      transcript.append(Utterance(name: second.name, statement: out2.statement ?? ""))
+    }
+    return transcript
+  }
+
+  // MARK: - Single Turn
+
+  private func whisperTurn(
+    speaker: Persona, partner: Persona, transcript: [Utterance], run: Run
+  ) async throws -> TurnOutput {
+    let context = run.context
+    let state = run.state
+    let language = context.scenario.engineLanguage
+
+    let systemPrompt = promptBuilder.buildSystemPrompt(
+      scenario: context.scenario, persona: speaker, phase: context.phase, state: state)
+
+    var variables = state.variables
+    variables["scoreboard"] = promptBuilder.formatScoreboard(state.scores)
+    // The PUBLIC conversation log — whisper participants still see it.
+    variables["conversation_log"] = promptBuilder.formatConversationLog(
+      state.conversationLog, language: language, window: context.scenario.logWindow)
+    variables["whisper_partner"] = partner.name
+    variables["whisper_exchange"] = formatTranscript(transcript)
+    promptBuilder.injectAssigned(into: &variables, personaName: speaker.name)
+    promptBuilder.injectNotes(into: &variables, personaName: speaker.name)
+    let userPrompt = promptBuilder.expandTemplate(run.promptTemplate, variables: variables)
+
+    let output = try await llmCaller.call(
+      llm: context.llm, system: systemPrompt, user: userPrompt,
+      agentName: speaker.name,
+      schema: OutputSchema.from(phase: context.phase),
+      detector: context.detector,
+      expectedLanguage: context.scenario.engineLanguage,
+      suspendController: context.suspendController,
+      emitter: context.emitter
+    )
+
+    // Attribute the partner via the reserved `whisper_to` field, preserving the
+    // original `rawText` provenance per the design contract.
+    var merged = output.fields
+    merged["whisper_to"] = partner.name
+    let attributed = TurnOutput(fields: merged, rawText: output.rawText)
+    context.emitter(
+      .agentOutput(agent: speaker.name, output: attributed, phaseType: context.phase.type))
+    // NOT appended to `conversationLog` and NOT written to `lastOutputs`: a
+    // whisper is pair-private and must never reach another agent's prompt or
+    // the public last-output display (mirrors ``ReflectHandler``).
+    return attributed
+  }
+
+  // MARK: - Formatting
+
+  /// A single whisper line, `name` + spoken `statement`.
+  private struct Utterance {
+    let name: String
+    let statement: String
+  }
+
+  /// Formats the exchange body one utterance per line, mirroring
+  /// ``PromptBuilder/formatConversationLog(_:language:window:)``'s `  Name:
+  /// content` style.
+  private func formatTranscript(_ transcript: [Utterance]) -> String {
+    transcript.map { "  \($0.name): \($0.statement)" }.joined(separator: "\n")
+  }
+
+  /// A participant's stored channel view: a partner-identifying header line
+  /// followed by the full exchange body.
+  private func formatChannel(
+    _ transcript: [Utterance], partner: Persona, language: String
+  ) -> String {
+    let header = pickLanguage(
+      language,
+      ja: "密談相手: \(partner.name)",
+      en: "Whispering with \(partner.name)")
+    let body = formatTranscript(transcript)
+    return body.isEmpty ? header : "\(header)\n\(body)"
+  }
+}

--- a/Pastura/Pastura/Engine/Phases/WhisperHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/WhisperHandler.swift
@@ -122,7 +122,16 @@ nonisolated struct WhisperHandler: PhaseHandler {
     variables["whisper_exchange"] = formatTranscript(transcript)
     promptBuilder.injectAssigned(into: &variables, personaName: speaker.name)
     promptBuilder.injectNotes(into: &variables, personaName: speaker.name)
-    let userPrompt = promptBuilder.expandTemplate(run.promptTemplate, variables: variables)
+    promptBuilder.injectWhispers(into: &variables, personaName: speaker.name)
+    // ALWAYS append a partner-naming context block after expanding the user
+    // template: the default template never names the partner, and a custom
+    // author prompt may omit `{whisper_partner}` / `{whisper_exchange}`. The
+    // template still keeps those placeholders resolvable for authors who DO
+    // reference them; this block guarantees the partner + running exchange
+    // reach the model regardless of template content.
+    let userPrompt =
+      promptBuilder.expandTemplate(run.promptTemplate, variables: variables)
+      + whisperContextBlock(partner: partner, transcript: transcript, language: language)
 
     let output = try await llmCaller.call(
       llm: context.llm, system: systemPrompt, user: userPrompt,
@@ -160,6 +169,23 @@ nonisolated struct WhisperHandler: PhaseHandler {
   /// content` style.
   private func formatTranscript(_ transcript: [Utterance]) -> String {
     transcript.map { "  \($0.name): \($0.statement)" }.joined(separator: "\n")
+  }
+
+  /// A language-aware block appended to every whisper turn prompt so the model
+  /// always knows who its partner is — and, once the pair has spoken, what was
+  /// said so far — no matter what the (possibly partner-agnostic) user template
+  /// contains. The exchange section is omitted on the opening utterance (empty
+  /// transcript) to avoid an empty header.
+  private func whisperContextBlock(
+    partner: Persona, transcript: [Utterance], language: String
+  ) -> String {
+    let partnerLine = pickLanguage(
+      language,
+      ja: "\n\n密談相手: \(partner.name)（この相手だけにこっそり話しかけてください）",
+      en: "\n\nWhisper partner: \(partner.name) (speak privately to them only).")
+    guard !transcript.isEmpty else { return partnerLine }
+    let exchangeHeader = pickLanguage(language, ja: "これまでの密談:", en: "Whisper so far:")
+    return "\(partnerLine)\n\(exchangeHeader)\n\(formatTranscript(transcript))"
   }
 
   /// A participant's stored channel view: a partner-identifying header line

--- a/Pastura/Pastura/Engine/PromptBuilder.swift
+++ b/Pastura/Pastura/Engine/PromptBuilder.swift
@@ -61,6 +61,27 @@ nonisolated struct PromptBuilder: Sendable {
     variables["my_notes"] = variables["notes_\(personaName)"] ?? ""
   }
 
+  /// Injects the current speaker's `whisper`-phase channel under the
+  /// `{my_whispers}` key.
+  ///
+  /// ``WhisperHandler`` stores each participant's private view of their pair's
+  /// exchange under a per-persona key `whispers_<name>` (#908); this reads that
+  /// back for the speaker so custom user-prompt templates can reference
+  /// `{my_whispers}`. The `whispers_` prefix is a reserved namespace, mirroring
+  /// `notes_` (see ``injectNotes(into:personaName:)``).
+  ///
+  /// Missing channel resolves to empty string (not a literal placeholder),
+  /// matching `injectNotes`'s miss posture.
+  ///
+  /// - Note: the privacy guarantee covers the conversation-log, system-prompt,
+  ///   and `{my_whispers}` paths. Raw `whispers_<other>` keys remain resolvable
+  ///   by a template that hand-references them (`{whispers_Bob}`) — same
+  ///   accepted residual exposure as the `notes_<name>` namespace, kept for
+  ///   pattern consistency.
+  func injectWhispers(into variables: inout [String: String], personaName: String) {
+    variables["my_whispers"] = variables["whispers_\(personaName)"] ?? ""
+  }
+
   // MARK: - Scoreboard
 
   /// Serializes a score dictionary into a compact JSON-like string for template injection.
@@ -171,6 +192,22 @@ nonisolated struct PromptBuilder: Sendable {
         """)
     }
 
+    // Private whisper channel (#908): surface the agent's own pair-private
+    // exchange back to itself only. Everyone except the whisper partner is
+    // blind to it (it never enters the conversation log), so the header
+    // stresses that scope.
+    if let whispers = state.variables["whispers_\(persona.name)"], !whispers.isEmpty {
+      let whispersHeader = pickLanguage(
+        language,
+        ja: "## あなたの密談（密談相手以外には見えません）",
+        en: "## Your Private Whispers (invisible to everyone except your whisper partner)")
+      sections.append(
+        """
+        \(whispersHeader)
+        \(whispers)
+        """)
+    }
+
     sections.append(
       buildAnswerRules(scenario: scenario, persona: persona, phase: phase, state: state))
 
@@ -234,6 +271,11 @@ nonisolated struct PromptBuilder: Sendable {
       rules += reflectBrevityRule(language: language)
     }
 
+    // Whisper turns get partner-directed privacy guidance (see `whisperRule`).
+    if phase.type == .whisper {
+      rules += whisperRule(language: language)
+    }
+
     if phase.type == .choose, let options = phase.options {
       let optionsList = options.joined(separator: ", ")
       rules += pickLanguage(
@@ -279,6 +321,19 @@ nonisolated struct PromptBuilder: Sendable {
       language,
       ja: "\n- メモ（note）は2文以内で簡潔に書くこと（長文・箇条書きの羅列は禁止）",
       en: "\n- Keep your note to at most 2 sentences (no long paragraphs or bullet lists).")
+  }
+
+  /// The #908 privacy guidance appended for `whisper` phases only. A whisper is
+  /// a secret one-to-one exchange: nobody except the partner can hear it, so the
+  /// agent should address the partner directly, stay candid/strategic, and keep
+  /// it conversational. Keep ja/en scope-parallel when editing.
+  private func whisperRule(language: String) -> String {
+    pickLanguage(
+      language,
+      ja: "\n- これは密談相手ひとりだけへの秘密の耳打ちです（他の参加者には聞こえません）。相手に直接呼びかけ、本音で戦略的に、短い会話として話すこと",
+      en:
+        "\n- This is a private whisper to your one partner only (no one else can hear). Address them directly, be candid and strategic, and keep it conversational."
+    )
   }
 
   /// The #911 address rule appended for turn-based `speak_each` phases only.

--- a/Pastura/Pastura/Engine/ScenarioLoader.swift
+++ b/Pastura/Pastura/Engine/ScenarioLoader.swift
@@ -73,6 +73,7 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
   /// - `speak_each`: agentCount × subRounds
   /// - `vote`: agentCount
   /// - `reflect`: agentCount
+  /// - `whisper`: (agentCount / 2) × subRounds × 2 — pair count × exchanges × speakers
   /// - `choose`: agentCount × 2 (round_robin) or agentCount (individual)
   /// - `conditional`: `max(sum(thenPhases), sum(elsePhases))` — only one branch
   ///   runs per invocation, so `max` matches execution semantics. Using `sum`
@@ -94,6 +95,10 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
       return agents * (phase.subRounds ?? 1)
     case .vote, .reflect:
       return agents
+    case .whisper:
+      // Active agents pair off (integer division drops the odd one out) and
+      // each pair runs `subRounds` exchanges of 2 utterances (both speakers).
+      return (agents / 2) * (phase.subRounds ?? 1) * 2
     case .choose:
       return phase.pairing == .roundRobin ? agents * 2 : agents
     case .scoreCalc, .assign, .eliminate, .summarize, .eventInject:

--- a/Pastura/Pastura/Engine/ScenarioValidator.swift
+++ b/Pastura/Pastura/Engine/ScenarioValidator.swift
@@ -126,9 +126,9 @@ nonisolated struct ScenarioValidator: Sendable {
         try validateConditionalPhase(phase, index: index, scenario: scenario, depth: 0)
       case .reflect:
         try validateReflectShape(phase, label: "Phase \(index + 1)")
-      // `whisper`-specific validation (min-2-agents, output shape) lands in a
-      // later change; the minimal compiling arm keeps existing scenarios valid.
-      case .speakAll, .speakEach, .vote, .choose, .scoreCalc, .eliminate, .summarize, .whisper:
+      case .whisper:
+        try validateWhisperShape(phase, label: "Phase \(index + 1)")
+      case .speakAll, .speakEach, .vote, .choose, .scoreCalc, .eliminate, .summarize:
         break
       case .eventInject:
         try validateEventInjectShape(
@@ -197,8 +197,8 @@ nonisolated struct ScenarioValidator: Sendable {
 
   /// Recursively validates each sub-phase in a conditional branch.
   ///
-  /// Rejects nested `.conditional` (depth-1 rule) and `.reflect` (not
-  /// supported inside a branch in v1), and applies the same semantic checks
+  /// Rejects nested `.conditional` (depth-1 rule), `.reflect`, and `.whisper`
+  /// (neither supported inside a branch in v1), and applies the same semantic checks
   /// we run at the top level — e.g., an `assign` phase with mismatched
   /// target/source shape still errors when buried inside a `then:` or
   /// `else:` branch. `event_inject` is allowed inside a branch (consistent
@@ -221,6 +221,14 @@ nonisolated struct ScenarioValidator: Sendable {
       if subPhase.type == .reflect {
         throw validationError(
           String(localized: "%@ is a reflect phase, which is not allowed inside a conditional."),
+          subLabel)
+      }
+      // `whisper` is likewise not supported inside a conditional branch in v1
+      // (mirrors the reflect rejection above) — it fails here at load-time
+      // validation rather than at `ConditionalHandler` dispatch.
+      if subPhase.type == .whisper {
+        throw validationError(
+          String(localized: "%@ is a whisper phase, which is not allowed inside a conditional."),
           subLabel)
       }
       if subPhase.type == .assign {
@@ -246,6 +254,21 @@ nonisolated struct ScenarioValidator: Sendable {
       throw validationError(
         String(localized: "%@ (%@) requires field '%@' in output."),
         label, phase.type.rawValue, "note")
+    }
+  }
+
+  /// Requires whisper phases to declare the canonical `statement` output at the
+  /// RUN gate (`validate`), mirroring `validateReflectShape`'s rationale.
+  ///
+  /// A whisper without `statement` burns one inference per participant per pair
+  /// per round and stores nothing user-visible — the same no-op-inference
+  /// failure mode reflect guards against, so it fails fast here at the run gate
+  /// rather than degrading silently. Reuses the shared missing-field message.
+  private func validateWhisperShape(_ phase: Phase, label: String) throws {
+    if (phase.outputSchema ?? [:])["statement"] == nil {
+      throw validationError(
+        String(localized: "%@ (%@) requires field '%@' in output."),
+        label, phase.type.rawValue, "statement")
     }
   }
 

--- a/Pastura/Pastura/Engine/ScenarioValidator.swift
+++ b/Pastura/Pastura/Engine/ScenarioValidator.swift
@@ -126,7 +126,9 @@ nonisolated struct ScenarioValidator: Sendable {
         try validateConditionalPhase(phase, index: index, scenario: scenario, depth: 0)
       case .reflect:
         try validateReflectShape(phase, label: "Phase \(index + 1)")
-      case .speakAll, .speakEach, .vote, .choose, .scoreCalc, .eliminate, .summarize:
+      // `whisper`-specific validation (min-2-agents, output shape) lands in a
+      // later change; the minimal compiling arm keeps existing scenarios valid.
+      case .speakAll, .speakEach, .vote, .choose, .scoreCalc, .eliminate, .summarize, .whisper:
         break
       case .eventInject:
         try validateEventInjectShape(

--- a/Pastura/Pastura/Models/PhaseType.swift
+++ b/Pastura/Pastura/Models/PhaseType.swift
@@ -2,17 +2,18 @@ import Foundation
 
 /// The type of a simulation phase, determining how it is processed.
 ///
-/// LLM phases (`speakAll`, `speakEach`, `vote`, `choose`, `reflect`) require
-/// LLM inference. Code phases (`scoreCalc`, `assign`, `eliminate`,
-/// `summarize`, `eventInject`) are processed deterministically by the engine.
-/// `conditional` is a control-flow phase: the handler itself does no
-/// inference, but its sub-phases may be of any type.
+/// LLM phases (`speakAll`, `speakEach`, `vote`, `choose`, `reflect`,
+/// `whisper`) require LLM inference. Code phases (`scoreCalc`, `assign`,
+/// `eliminate`, `summarize`, `eventInject`) are processed deterministically
+/// by the engine. `conditional` is a control-flow phase: the handler itself
+/// does no inference, but its sub-phases may be of any type.
 nonisolated public enum PhaseType: String, Codable, Sendable, CaseIterable {
   case speakAll = "speak_all"
   case speakEach = "speak_each"
   case vote
   case choose
   case reflect
+  case whisper
   case scoreCalc = "score_calc"
   case assign
   case eliminate
@@ -37,9 +38,13 @@ nonisolated public enum PhaseType: String, Codable, Sendable, CaseIterable {
   /// `reflect` returns `true`: each agent runs an LLM inference to privately
   /// update a short note about the situation (canonical `note` output field),
   /// so it costs one inference per agent per round like `speakAll` / `vote`.
+  ///
+  /// `whisper` returns `true`: pairs of active agents privately exchange
+  /// statements (hidden from other agents' prompts), each utterance costing
+  /// one LLM inference.
   public var requiresLLM: Bool {
     switch self {
-    case .speakAll, .speakEach, .vote, .choose, .reflect:
+    case .speakAll, .speakEach, .vote, .choose, .reflect, .whisper:
       return true
     case .scoreCalc, .assign, .eliminate, .summarize, .conditional, .eventInject:
       return false

--- a/Pastura/Pastura/Models/ScenarioConventions.swift
+++ b/Pastura/Pastura/Models/ScenarioConventions.swift
@@ -48,6 +48,8 @@ nonisolated public enum ScenarioConventions {
       return "vote"
     case .reflect:
       return "note"
+    case .whisper:
+      return "statement"
     case .scoreCalc, .assign, .eliminate, .summarize, .conditional, .eventInject:
       return nil
     }
@@ -84,7 +86,7 @@ nonisolated public enum ScenarioConventions {
     switch phaseType {
     case .vote:
       return "reason"
-    case .speakAll, .speakEach, .choose:
+    case .speakAll, .speakEach, .choose, .whisper:
       return "inner_thought"
     // `.reflect`'s canonical `note` output is itself the private reasoning, so
     // it declares no secondary thought field (single-field `{ note }` schema).

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -397,6 +397,22 @@
         }
       }
     },
+    "%@ is a whisper phase, which is not allowed inside a conditional." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ is a whisper phase, which is not allowed inside a conditional."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ は whisper フェーズであり、conditional の中では許可されていません。"
+          }
+        }
+      }
+    },
     "%@ is another conditional, which is not allowed (depth-1 rule)." : {
       "localizations" : {
         "en" : {

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -4483,6 +4483,22 @@
         }
       }
     },
+    "Pairs of agents privately whisper to each other (hidden from others)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pairs of agents privately whisper to each other (hidden from others)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エージェント同士がペアで密談します（他の参加者には見えません）"
+          }
+        }
+      }
+    },
     "Past Results" : {
       "localizations" : {
         "ja" : {
@@ -6478,6 +6494,22 @@
         }
       }
     },
+    "Use `statement` for the whispered text. Whispers stay private to the pair and never enter the public conversation log." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use `statement` for the whispered text. Whispers stay private to the pair and never enter the public conversation log."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "密談の内容は `statement` フィールドに書いてください。密談はペア内だけの秘密で、公開の会話ログには残りません。"
+          }
+        }
+      }
+    },
     "Use `vote` for the target name." : {
       "localizations" : {
         "en" : {
@@ -6652,6 +6684,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "進行の流れ"
+          }
+        }
+      }
+    },
+    "Whisper" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Whisper"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "密談"
           }
         }
       }

--- a/Pastura/Pastura/Views/Components/PhaseDisplayName.swift
+++ b/Pastura/Pastura/Views/Components/PhaseDisplayName.swift
@@ -23,7 +23,7 @@ import Foundation
 /// separators stay snake_case-free and localized (#882).
 public enum PhaseDisplayName {
 
-  // Pure name-mapping switch (one line per phase type). The 11-case count
+  // Pure name-mapping switch (one line per phase type). The 12-case count
   // exceeds SwiftLint's cyclomatic threshold but carries no branching logic.
   // swiftlint:disable cyclomatic_complexity
   /// Compact display label for `phase`. The English source string is
@@ -37,6 +37,7 @@ public enum PhaseDisplayName {
     case .vote: return String(localized: "Vote")
     case .choose: return String(localized: "Choose")
     case .reflect: return String(localized: "Reflect")
+    case .whisper: return String(localized: "Whisper")
     case .scoreCalc: return String(localized: "Score Calc")
     case .assign: return String(localized: "Assign")
     case .eliminate: return String(localized: "Eliminate")

--- a/Pastura/Pastura/Views/Components/PhaseGlyph.swift
+++ b/Pastura/Pastura/Views/Components/PhaseGlyph.swift
@@ -3,20 +3,20 @@ import Foundation
 /// Single source of truth for the `PhaseType` → SF Symbol mapping used by
 /// the shared-scenario detail screen's "What happens" phase-step surface.
 ///
-/// 6 of the 11 kinds intentionally reuse the Browse art-tile glyphs
+/// 6 of the 12 kinds intentionally reuse the Browse art-tile glyphs
 /// (``ScenarioSignaturePhase/sfSymbolName`` in `GalleryCatalogRow.swift`) to
 /// keep one visual language across the two gallery surfaces — a parity test
 /// (`PhaseGlyphTests`) guards the two mappings against drift. The remaining
-/// 5 kinds (`speak_all`, `speak_each`, `assign`, `summarize`, `reflect`) have
-/// no `ScenarioSignaturePhase` counterpart (that enum only maps the "headline"
-/// mechanic kinds) and get their own symbol here.
+/// 6 kinds (`speak_all`, `speak_each`, `assign`, `summarize`, `reflect`,
+/// `whisper`) have no `ScenarioSignaturePhase` counterpart (that enum only
+/// maps the "headline" mechanic kinds) and get their own symbol here.
 ///
 /// Left MainActor-default (not `nonisolated`) to mirror ``PhaseDisplayName``
 /// so composing helpers stay uniformly MainActor
 /// (swift-isolation.md Pattern 5).
 public enum PhaseGlyph {
 
-  // Pure name-mapping switch (one line per phase type). The 11-case count
+  // Pure name-mapping switch (one line per phase type). The 12-case count
   // exceeds SwiftLint's cyclomatic threshold but carries no branching logic.
   // swiftlint:disable cyclomatic_complexity
   /// SF Symbol name for `phase`'s glyph badge.
@@ -27,6 +27,7 @@ public enum PhaseGlyph {
     case .vote: return "checkmark.square"
     case .choose: return "arrow.triangle.branch"
     case .reflect: return "square.and.pencil"
+    case .whisper: return "ear"
     case .scoreCalc: return "chart.bar"
     case .assign: return "tag"
     case .eliminate: return "xmark.circle"

--- a/Pastura/Pastura/Views/Editor/PhaseBlockRow.swift
+++ b/Pastura/Pastura/Views/Editor/PhaseBlockRow.swift
@@ -33,7 +33,7 @@ struct PhaseBlockRow: View {
   /// A brief human-readable summary of the phase content.
   private var summary: String {
     switch phase.type {
-    case .speakAll, .speakEach, .vote, .choose, .reflect:
+    case .speakAll, .speakEach, .vote, .choose, .reflect, .whisper:
       return phase.prompt.prefix(50).trimmingCharacters(in: .whitespacesAndNewlines)
     case .scoreCalc:
       return phase.logic?.rawValue ?? "—"

--- a/Pastura/Pastura/Views/Editor/PhaseEditorSheet+CanonicalFieldHint.swift
+++ b/Pastura/Pastura/Views/Editor/PhaseEditorSheet+CanonicalFieldHint.swift
@@ -66,6 +66,11 @@ extension PhaseEditorSheet {
         localized:
           "Use `note` for the agent's private memo. This is the reflect phase's only output field."
       )
+    case .whisper:
+      return String(
+        localized:
+          "Use `statement` for the whispered text. Whispers stay private to the pair and never enter the public conversation log."
+      )
     case .scoreCalc, .assign, .eliminate, .summarize, .conditional, .eventInject:
       return nil
     }

--- a/Pastura/Pastura/Views/Editor/PhaseEditorSheet.swift
+++ b/Pastura/Pastura/Views/Editor/PhaseEditorSheet.swift
@@ -100,18 +100,20 @@ struct PhaseEditorSheet: View {
         }
       }
       .sheet(item: $editingSubPhase) { context in
-        // Nested editor — filter `.conditional` (depth-1 rule) and `.reflect`
-        // (not supported inside a conditional in v1) out of the picker so both
-        // rules are enforced at the UI layer (the validator + loader also
-        // reject them as defense in depth). The validator is forwarded so
-        // nested Save runs against the same blocklist instance the outer sheet
-        // uses (#261).
+        // Nested editor — filter `.conditional` (depth-1 rule), `.reflect`,
+        // and `.whisper` (neither supported inside a conditional in v1) out of
+        // the picker so the rules are enforced at the UI layer (the validator +
+        // loader also reject them as defense in depth). The validator is
+        // forwarded so nested Save runs against the same blocklist instance the
+        // outer sheet uses (#261).
         PhaseEditorSheet(
           phase: context.phase,
           onSave: { edited in
             writeBackSubPhase(edited, context: context)
           },
-          availableTypes: PhaseType.allCases.filter { $0 != .conditional && $0 != .reflect },
+          availableTypes: PhaseType.allCases.filter {
+            $0 != .conditional && $0 != .reflect && $0 != .whisper
+          },
           validator: validator
         )
         .deepLinkGated()
@@ -220,9 +222,9 @@ struct PhaseEditorSheet: View {
       assignSection
     case .summarize:
       summarizeSection
-    case .speakAll, .reflect, .eliminate:
-      // reflect is a prompt-based LLM phase with no extra config beyond the
-      // shared prompt + output-fields sections (like speak_all).
+    case .speakAll, .reflect, .eliminate, .whisper:
+      // reflect / whisper are prompt-based LLM phases with no extra config
+      // beyond the shared prompt + output-fields sections (like speak_all).
       EmptyView()
     case .conditional:
       conditionalSection
@@ -379,6 +381,9 @@ struct PhaseEditorSheet: View {
     case .choose: return String(localized: "Choose from predefined options")
     case .reflect:
       return String(localized: "Each agent privately updates a short memo about the situation")
+    case .whisper:
+      return String(
+        localized: "Pairs of agents privately whisper to each other (hidden from others)")
     case .scoreCalc: return String(localized: "Calculate scores (code, no LLM)")
     case .assign: return String(localized: "Distribute info to agents (code)")
     case .eliminate: return String(localized: "Remove most-voted agent (code)")

--- a/Pastura/PasturaTests/Engine/ConditionalValidatorTests+Whisper.swift
+++ b/Pastura/PasturaTests/Engine/ConditionalValidatorTests+Whisper.swift
@@ -1,0 +1,49 @@
+import Testing
+
+@testable import Pastura
+
+/// whisper is NOT allowed inside a conditional branch in v1. The validator
+/// rejects it at load-time (mirroring the nested-conditional and reflect
+/// rejections) so it fails here rather than at `ConditionalHandler` dispatch.
+/// Split into a sibling extension (not a new `@Suite`) per
+/// `.claude/rules/testing.md` so it shares `ConditionalValidatorTests`'s
+/// serialization and keeps the main file under the `type_body_length` cap.
+extension ConditionalValidatorTests {
+
+  @Test func rejectsWhisperInThenBranch() {
+    let scenario = makeScenario(phases: [
+      Phase(
+        type: .conditional,
+        condition: "current_round == 1",
+        thenPhases: [
+          Phase(type: .whisper, prompt: "Whisper.", outputSchema: ["statement": "string"])
+        ]
+      )
+    ])
+    #expect(throws: SimulationError.self) {
+      try validator.validate(scenario)
+    }
+  }
+
+  @Test func rejectsWhisperInElseBranch() {
+    let scenario = makeScenario(phases: [
+      Phase(
+        type: .conditional,
+        condition: "current_round == 1",
+        thenPhases: [Phase(type: .summarize, template: "ok")],
+        elsePhases: [
+          Phase(type: .whisper, prompt: "Whisper.", outputSchema: ["statement": "string"])
+        ]
+      )
+    ])
+    do {
+      _ = try validator.validate(scenario)
+      Issue.record("Expected validation to throw for whisper inside a conditional branch")
+    } catch let SimulationError.scenarioValidationFailed(message) {
+      #expect(message.contains("else[1]"))
+      #expect(message.contains("whisper"))
+    } catch {
+      Issue.record("Unexpected error: \(error)")
+    }
+  }
+}

--- a/Pastura/PasturaTests/Engine/PhaseDispatcherTests.swift
+++ b/Pastura/PasturaTests/Engine/PhaseDispatcherTests.swift
@@ -32,6 +32,12 @@ struct PhaseDispatcherTests {
         #expect(try dispatcher.handler(for: phaseType) is EventInjectHandler)
       case .reflect:
         #expect(try dispatcher.handler(for: phaseType) is ReflectHandler)
+      case .whisper:
+        // Intentionally not registered yet — the WhisperHandler dispatch entry
+        // is wired in a later change. Dispatch throws until then.
+        #expect(throws: SimulationError.self) {
+          _ = try dispatcher.handler(for: phaseType)
+        }
       }
     }
   }

--- a/Pastura/PasturaTests/Engine/PhaseDispatcherTests.swift
+++ b/Pastura/PasturaTests/Engine/PhaseDispatcherTests.swift
@@ -33,11 +33,7 @@ struct PhaseDispatcherTests {
       case .reflect:
         #expect(try dispatcher.handler(for: phaseType) is ReflectHandler)
       case .whisper:
-        // Intentionally not registered yet — the WhisperHandler dispatch entry
-        // is wired in a later change. Dispatch throws until then.
-        #expect(throws: SimulationError.self) {
-          _ = try dispatcher.handler(for: phaseType)
-        }
+        #expect(try dispatcher.handler(for: phaseType) is WhisperHandler)
       }
     }
   }

--- a/Pastura/PasturaTests/Engine/Phases/WhisperHandlerTests.swift
+++ b/Pastura/PasturaTests/Engine/Phases/WhisperHandlerTests.swift
@@ -221,6 +221,33 @@ struct WhisperHandlerTests {
     #expect(secondSpeakerPrompt.contains("B1"))
   }
 
+  /// Prompt hardening (#908): even with the DEFAULT template (which never names
+  /// the partner or references `{whisper_exchange}`), the handler appends a
+  /// context block so the partner name and the running exchange reach the model.
+  @Test func defaultTemplateAlwaysNamesPartnerAndExchange() async throws {
+    let mock = MockLLMService(responses: [stmt("A to B"), stmt("B to A")])
+    try await mock.loadModel()
+
+    // `prompt: nil` → the handler's built-in default template (no placeholders).
+    let scenario = makeTestScenario(
+      agentNames: ["Alice", "Bob"],
+      phases: [whisperPhase(prompt: nil)])
+    var state = SimulationState.initial(for: scenario)
+    state.currentRound = 1
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    // Alice speaks first — her prompt names Bob even without a template token.
+    let alicePrompt = mock.capturedPrompts[0].user
+    #expect(alicePrompt.contains("Bob"))
+    // Bob speaks second — his prompt names Alice AND carries the exchange so far.
+    let bobPrompt = mock.capturedPrompts[1].user
+    #expect(bobPrompt.contains("Alice"))
+    #expect(bobPrompt.contains("A to B"))
+  }
+
   @Test func eliminatedAgentsNeverPaired() async throws {
     let mock = MockLLMService(responses: [
       stmt("A to C"), stmt("C to A")

--- a/Pastura/PasturaTests/Engine/Phases/WhisperHandlerTests.swift
+++ b/Pastura/PasturaTests/Engine/Phases/WhisperHandlerTests.swift
@@ -1,0 +1,248 @@
+import Testing
+
+@testable import Pastura
+
+/// Coverage for ``WhisperHandler`` — the secret pairwise `whisper` phase.
+///
+/// Whisper pairs off active agents, runs `subRounds` exchanges per pair, emits
+/// each utterance as an `.agentOutput` (never touching the public conversation
+/// log / `lastOutputs`), and writes each participant's view of their pair's
+/// exchange to `whispers_<name>`.
+@Suite(.timeLimit(.minutes(1)))
+struct WhisperHandlerTests {
+  let handler = WhisperHandler()
+
+  private func whisperPhase(prompt: String? = "Whisper!", subRounds: Int? = nil) -> Phase {
+    Phase(
+      type: .whisper, prompt: prompt,
+      outputSchema: ["statement": "string", "inner_thought": "string"],
+      subRounds: subRounds)
+  }
+
+  // Prompt template that surfaces the running exchange transcript, so the test
+  // can assert the handler threads it into each utterance's user prompt.
+  private static let exchangeProbePrompt = "Whisper. So far: {whisper_exchange}"
+
+  private func stmt(_ text: String) -> String {
+    #"{"statement": "\#(text)", "inner_thought": "t"}"#
+  }
+
+  private struct WhisperOut {
+    let agent: String
+    let whisperTo: String?
+    let statement: String?
+  }
+
+  /// Extracts `(agent, whisper_to, statement)` for each whisper `.agentOutput`.
+  private func whisperOutputs(_ collector: EventCollector) -> [WhisperOut] {
+    collector.events.compactMap { event in
+      if case .agentOutput(let agent, let output, let phaseType) = event, phaseType == .whisper {
+        return WhisperOut(
+          agent: agent, whisperTo: output.fields["whisper_to"], statement: output.statement)
+      }
+      return nil
+    }
+  }
+
+  @Test func fourAgentsRoundOnePairsAdjacentWithAttribution() async throws {
+    let mock = MockLLMService(responses: [
+      stmt("A to B"), stmt("B to A"), stmt("C to D"), stmt("D to C")
+    ])
+    try await mock.loadModel()
+
+    let scenario = makeTestScenario(
+      agentNames: ["Alice", "Bob", "Carol", "Dave"],
+      phases: [whisperPhase()])
+    var state = SimulationState.initial(for: scenario)
+    state.currentRound = 1
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    let outputs = whisperOutputs(collector)
+    #expect(outputs.count == 4)
+    #expect(outputs.map(\.agent) == ["Alice", "Bob", "Carol", "Dave"])
+    #expect(outputs.map(\.whisperTo) == ["Bob", "Alice", "Dave", "Carol"])
+    // rawText preserved through the whisper_to merge.
+    for event in collector.events {
+      if case .agentOutput(_, let output, .whisper) = event {
+        #expect(output.rawText != nil)
+        #expect(!(output.rawText ?? "").isEmpty)
+      }
+    }
+  }
+
+  @Test func roundTwoRotationShiftsPairs() async throws {
+    let mock = MockLLMService(responses: [
+      stmt("1"), stmt("2"), stmt("3"), stmt("4")
+    ])
+    try await mock.loadModel()
+
+    let scenario = makeTestScenario(
+      agentNames: ["Alice", "Bob", "Carol", "Dave"],
+      phases: [whisperPhase()])
+    var state = SimulationState.initial(for: scenario)
+    state.currentRound = 2
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    // offset = (2-1) % 4 = 1 → rotated [Bob, Carol, Dave, Alice] → (Bob,Carol),(Dave,Alice)
+    let outputs = whisperOutputs(collector)
+    #expect(outputs.map(\.agent) == ["Bob", "Carol", "Dave", "Alice"])
+    #expect(outputs.map(\.whisperTo) == ["Carol", "Bob", "Alice", "Dave"])
+  }
+
+  @Test func doesNotTouchConversationLogOrLastOutputs() async throws {
+    let mock = MockLLMService(responses: [
+      stmt("A to B"), stmt("B to A")
+    ])
+    try await mock.loadModel()
+
+    let scenario = makeTestScenario(
+      agentNames: ["Alice", "Bob"],
+      phases: [whisperPhase()])
+    var state = SimulationState.initial(for: scenario)
+    state.currentRound = 1
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    #expect(state.conversationLog.isEmpty)
+    #expect(state.lastOutputs.isEmpty)
+  }
+
+  @Test func writesPerParticipantChannelWithoutCrossPairLeak() async throws {
+    let mock = MockLLMService(responses: [
+      stmt("A to B"), stmt("B to A"), stmt("C to D"), stmt("D to C")
+    ])
+    try await mock.loadModel()
+
+    let scenario = makeTestScenario(
+      agentNames: ["Alice", "Bob", "Carol", "Dave"],
+      phases: [whisperPhase()])
+    var state = SimulationState.initial(for: scenario)
+    state.currentRound = 1
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    // All four participants get a channel.
+    for name in ["Alice", "Bob", "Carol", "Dave"] {
+      #expect(state.variables["whispers_\(name)"] != nil)
+    }
+    let aliceChannel = try #require(state.variables["whispers_Alice"])
+    #expect(aliceChannel.contains("A to B"))
+    #expect(aliceChannel.contains("B to A"))
+    // No leak of the other pair's content.
+    #expect(!aliceChannel.contains("C to D"))
+    #expect(!aliceChannel.contains("D to C"))
+    #expect(aliceChannel.contains("Bob"))  // partner-identifying line
+  }
+
+  @Test func oddAgentSitsOutAndStaleChannelCleared() async throws {
+    let mock = MockLLMService(responses: [
+      stmt("A to B"), stmt("B to A"), stmt("C to D"), stmt("D to C")
+    ])
+    try await mock.loadModel()
+
+    let scenario = makeTestScenario(
+      agentNames: ["Alice", "Bob", "Carol", "Dave", "Eve"],
+      phases: [whisperPhase()])
+    var state = SimulationState.initial(for: scenario)
+    state.currentRound = 1
+    state.variables["whispers_Eve"] = "stale from a prior round"
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    // Eve (last of rotated list) sits out; her stale channel is cleared.
+    #expect(mock.generateCallCount == 4)
+    #expect(state.variables["whispers_Eve"] == nil)
+    let whisperers = Set(whisperOutputs(collector).map(\.agent))
+    #expect(whisperers == ["Alice", "Bob", "Carol", "Dave"])
+  }
+
+  @Test func singleActiveAgentIsNoOp() async throws {
+    let mock = MockLLMService(responses: [])
+    try await mock.loadModel()
+
+    let scenario = makeTestScenario(
+      agentNames: ["Alice", "Bob", "Carol", "Dave"],
+      phases: [whisperPhase()])
+    var state = SimulationState.initial(for: scenario)
+    state.currentRound = 1
+    state.eliminated["Bob"] = true
+    state.eliminated["Carol"] = true
+    state.eliminated["Dave"] = true
+    state.variables["whispers_Alice"] = "untouched"
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    #expect(mock.generateCallCount == 0)
+    #expect(whisperOutputs(collector).isEmpty)
+    // No-op path must not clear anyone's channel.
+    #expect(state.variables["whispers_Alice"] == "untouched")
+  }
+
+  @Test func subRoundsAccumulatesExchangeTranscript() async throws {
+    let mock = MockLLMService(responses: [
+      stmt("A1"), stmt("B1"), stmt("A2"), stmt("B2"),  // pair (Alice, Bob), 2 exchanges
+      stmt("C1"), stmt("D1"), stmt("C2"), stmt("D2")  // pair (Carol, Dave), 2 exchanges
+    ])
+    try await mock.loadModel()
+
+    let scenario = makeTestScenario(
+      agentNames: ["Alice", "Bob", "Carol", "Dave"],
+      phases: [whisperPhase(prompt: Self.exchangeProbePrompt, subRounds: 2)])
+    var state = SimulationState.initial(for: scenario)
+    state.currentRound = 1
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    #expect(mock.generateCallCount == 8)
+    // The Alice/Bob channel carries all four utterances of the two exchanges.
+    let aliceChannel = try #require(state.variables["whispers_Alice"])
+    for token in ["A1", "B1", "A2", "B2"] {
+      #expect(aliceChannel.contains(token))
+    }
+    // The second exchange's prompt saw the first exchange's transcript.
+    let secondSpeakerPrompt = mock.capturedPrompts[2].user  // Alice's 2nd utterance
+    #expect(secondSpeakerPrompt.contains("A1"))
+    #expect(secondSpeakerPrompt.contains("B1"))
+  }
+
+  @Test func eliminatedAgentsNeverPaired() async throws {
+    let mock = MockLLMService(responses: [
+      stmt("A to C"), stmt("C to A")
+    ])
+    try await mock.loadModel()
+
+    let scenario = makeTestScenario(
+      agentNames: ["Alice", "Bob", "Carol", "Dave"],
+      phases: [whisperPhase()])
+    var state = SimulationState.initial(for: scenario)
+    state.currentRound = 1
+    state.eliminated["Bob"] = true
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    // active = [Alice, Carol, Dave] → (Alice, Carol); Dave sits out; Bob absent.
+    let outputs = whisperOutputs(collector)
+    #expect(outputs.map(\.agent) == ["Alice", "Carol"])
+    #expect(outputs.map(\.whisperTo) == ["Carol", "Alice"])
+    #expect(state.variables["whispers_Bob"] == nil)
+    #expect(state.variables["whispers_Dave"] == nil)
+  }
+}

--- a/Pastura/PasturaTests/Engine/PromptBuilderTests+Whispers.swift
+++ b/Pastura/PasturaTests/Engine/PromptBuilderTests+Whispers.swift
@@ -1,0 +1,157 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+// MARK: - Whisper private-channel injection (#908)
+//
+// Sibling-file extension per the testing.md split convention — NOT a new
+// @Suite (a second suite would run in parallel against the same shared
+// state class; see PR #157). Helpers (`builder`, `makeScenario`) stay at
+// internal access in PromptBuilderTests.swift so this file can see them.
+extension PromptBuilderTests {
+
+  private func whisperPhase() -> Phase {
+    Phase(type: .whisper, prompt: "Whisper!", outputSchema: ["statement": "string"])
+  }
+
+  // A representative standard user template (references only public template
+  // vars — never a raw `whispers_<name>` key), matching how the speak / vote /
+  // choose handlers build their prompts. Used by the leak tests.
+  private static let standardUserTemplate =
+    "Conversation: {conversation_log}\nScore: {scoreboard}\nYour whispers: {my_whispers}"
+
+  // MARK: - injectWhispers
+
+  @Test func injectWhispersSetsMyWhispersFromNamespacedKey() {
+    var variables = ["whispers_Alice": "Whispering with Bob\n  Alice: secret"]
+    builder.injectWhispers(into: &variables, personaName: "Alice")
+    #expect(variables["my_whispers"] == "Whispering with Bob\n  Alice: secret")
+  }
+
+  @Test func injectWhispersSetsEmptyStringOnMiss() {
+    var variables: [String: String] = [:]
+    builder.injectWhispers(into: &variables, personaName: "Alice")
+    #expect(variables["my_whispers"] == "")
+  }
+
+  // MARK: - System-prompt private-whispers section
+
+  @Test func systemPromptContainsPrivateWhispersSectionWhenSet() {
+    let scenario = makeScenario()
+    var state = SimulationState.initial(for: scenario)
+    state.variables["whispers_Alice"] = "密談相手: Bob\n  Alice: SENTINEL_AB"
+
+    let prompt = builder.buildSystemPrompt(
+      scenario: scenario, persona: scenario.personas[0],
+      phase: whisperPhase(), state: state
+    )
+    #expect(prompt.contains("あなたの密談"))
+    #expect(prompt.contains("SENTINEL_AB"))
+  }
+
+  @Test func systemPromptOmitsPrivateWhispersSectionWhenUnset() {
+    let scenario = makeScenario()
+    let state = SimulationState.initial(for: scenario)
+
+    let prompt = builder.buildSystemPrompt(
+      scenario: scenario, persona: scenario.personas[0],
+      phase: whisperPhase(), state: state
+    )
+    #expect(!prompt.contains("あなたの密談"))
+  }
+
+  @Test func systemPromptPrivateWhispersSectionEnHeader() {
+    let scenario = makeScenario(language: "en")
+    var state = SimulationState.initial(for: scenario)
+    state.variables["whispers_Alice"] = "Whispering with Bob\n  Alice: SENTINEL_AB"
+
+    let prompt = builder.buildSystemPrompt(
+      scenario: scenario, persona: scenario.personas[0],
+      phase: whisperPhase(), state: state
+    )
+    #expect(prompt.contains("Your Private Whispers"))
+    #expect(prompt.contains("SENTINEL_AB"))
+  }
+
+  // MARK: - Whisper answer-rule guidance
+
+  @Test func whisperAnswerRulesIncludeGuidanceJa() {
+    let scenario = makeScenario()
+    let state = SimulationState.initial(for: scenario)
+    let prompt = builder.buildSystemPrompt(
+      scenario: scenario, persona: scenario.personas[0],
+      phase: whisperPhase(), state: state
+    )
+    #expect(prompt.contains("密談相手ひとり"))
+  }
+
+  @Test func whisperAnswerRulesIncludeGuidanceEn() {
+    let scenario = makeScenario(language: "en")
+    let state = SimulationState.initial(for: scenario)
+    let prompt = builder.buildSystemPrompt(
+      scenario: scenario, persona: scenario.personas[0],
+      phase: whisperPhase(), state: state
+    )
+    #expect(prompt.contains("private whisper to your one partner"))
+  }
+
+  @Test func nonWhisperPhaseOmitsWhisperGuidance() {
+    let scenario = makeScenario()
+    let phase = Phase(type: .speakAll, prompt: "Speak!", outputSchema: ["statement": "string"])
+    let state = SimulationState.initial(for: scenario)
+    let prompt = builder.buildSystemPrompt(
+      scenario: scenario, persona: scenario.personas[0], phase: phase, state: state
+    )
+    #expect(!prompt.contains("密談相手ひとり"))
+  }
+
+  // MARK: - Cross-pair leak guard (default path only)
+
+  // A NON-participant (Charlie) must never see another pair's whisper sentinel,
+  // in NEITHER the system prompt NOR an expanded standard user template, for the
+  // speak_all / vote / choose phases. The section is gated on the reader's own
+  // `whispers_<name>` key, and `{my_whispers}` resolves empty for Charlie.
+  @Test func nonParticipantNeverSeesAnotherPairsWhisper() {
+    let scenario = makeScenario()  // Alice, Bob, Charlie
+    var state = SimulationState.initial(for: scenario)
+    state.variables["whispers_Alice"] = "密談相手: Bob\n  Alice: SENTINEL_AB"
+    state.variables["whispers_Bob"] = "密談相手: Alice\n  Bob: SENTINEL_AB"
+    let charlie = scenario.personas[2]
+
+    let phases: [Phase] = [
+      Phase(type: .speakAll, prompt: "Speak!", outputSchema: ["statement": "string"]),
+      Phase(type: .vote, prompt: "Vote!", outputSchema: ["vote": "string"]),
+      Phase(type: .choose, prompt: "Choose!", outputSchema: ["action": "string"])
+    ]
+    for phase in phases {
+      let system = builder.buildSystemPrompt(
+        scenario: scenario, persona: charlie, phase: phase, state: state)
+      #expect(!system.contains("SENTINEL_AB"), "system prompt leaked whisper for \(phase.type)")
+
+      var variables = state.variables
+      builder.injectWhispers(into: &variables, personaName: charlie.name)
+      let user = builder.expandTemplate(Self.standardUserTemplate, variables: variables)
+      #expect(!user.contains("SENTINEL_AB"), "user prompt leaked whisper for \(phase.type)")
+    }
+  }
+
+  // The participant (Alice) DOES see her own whisper — in the system-prompt
+  // section AND via `{my_whispers}` on a standard template.
+  @Test func participantSeesOwnWhisper() {
+    let scenario = makeScenario()
+    var state = SimulationState.initial(for: scenario)
+    state.variables["whispers_Alice"] = "密談相手: Bob\n  Alice: SENTINEL_AB"
+    let alice = scenario.personas[0]
+    let phase = Phase(type: .speakAll, prompt: "Speak!", outputSchema: ["statement": "string"])
+
+    let system = builder.buildSystemPrompt(
+      scenario: scenario, persona: alice, phase: phase, state: state)
+    #expect(system.contains("SENTINEL_AB"))
+
+    var variables = state.variables
+    builder.injectWhispers(into: &variables, personaName: alice.name)
+    let user = builder.expandTemplate(Self.standardUserTemplate, variables: variables)
+    #expect(user.contains("SENTINEL_AB"))
+  }
+}

--- a/Pastura/PasturaTests/Engine/ScenarioValidatorTests.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioValidatorTests.swift
@@ -142,6 +142,29 @@ struct ScenarioValidatorTests {
     _ = try validator.validate(scenario)
   }
 
+  // MARK: - whisper (#908)
+
+  @Test func rejectsWhisperWithoutStatementOutputAtRunGate() {
+    // Like reflect, a whisper without its canonical `statement` output burns
+    // one inference per participant and stores nothing user-visible, so
+    // `validate` (the run gate, not just `validateForCommit`) requires it.
+    let scenario = makeScenario(
+      agents: 2, rounds: 1,
+      phases: [Phase(type: .whisper)]
+    )
+    #expect(throws: SimulationError.self) {
+      try validator.validate(scenario)
+    }
+  }
+
+  @Test func acceptsWhisperWithStatementOutput() throws {
+    let scenario = makeScenario(
+      agents: 2, rounds: 1,
+      phases: [Phase(type: .whisper, outputSchema: ["statement": "string"])]
+    )
+    _ = try validator.validate(scenario)
+  }
+
   @Test func rejectsPersonaCountMismatch() {
     // Constructed directly because makeScenario auto-generates matching personas
     let scenario = Scenario(

--- a/Pastura/PasturaTests/Models/PhaseTypeTests.swift
+++ b/Pastura/PasturaTests/Models/PhaseTypeTests.swift
@@ -17,10 +17,11 @@ struct PhaseTypeTests {
     #expect(PhaseType.conditional.rawValue == "conditional")
     #expect(PhaseType.eventInject.rawValue == "event_inject")
     #expect(PhaseType.reflect.rawValue == "reflect")
+    #expect(PhaseType.whisper.rawValue == "whisper")
   }
 
   @Test func allCasesCount() {
-    #expect(PhaseType.allCases.count == 11)
+    #expect(PhaseType.allCases.count == 12)
   }
 
   @Test func llmPhasesRequireLLM() {
@@ -30,6 +31,8 @@ struct PhaseTypeTests {
     #expect(PhaseType.choose.requiresLLM)
     // reflect is an LLM phase: each agent privately updates a `note`.
     #expect(PhaseType.reflect.requiresLLM)
+    // whisper is an LLM phase: pairs privately exchange statements.
+    #expect(PhaseType.whisper.requiresLLM)
   }
 
   @Test func codePhasesDoNotRequireLLM() {

--- a/Pastura/PasturaTests/Views/PhaseDisplayNameTests.swift
+++ b/Pastura/PasturaTests/Views/PhaseDisplayNameTests.swift
@@ -60,6 +60,6 @@ struct PhaseDisplayNameTests {
     // cheap non-render guard (ADR-009) against a future `requiresLLM`
     // change silently altering the transcript's separator layout.
     let llmPhases = PhaseType.allCases.filter(\.requiresLLM)
-    #expect(Set(llmPhases) == [.speakAll, .speakEach, .vote, .choose, .reflect])
+    #expect(Set(llmPhases) == [.speakAll, .speakEach, .vote, .choose, .reflect, .whisper])
   }
 }

--- a/Pastura/PasturaTests/Views/PhaseTypeLabelTests.swift
+++ b/Pastura/PasturaTests/Views/PhaseTypeLabelTests.swift
@@ -22,7 +22,7 @@ struct PhaseTypeLabelTests {
     // this exact predicate, so the invariant is the badge's contract.
     for phase in PhaseType.allCases {
       switch phase {
-      case .speakAll, .speakEach, .vote, .choose, .reflect:
+      case .speakAll, .speakEach, .vote, .choose, .reflect, .whisper:
         #expect(phase.requiresLLM, "\(phase) is an LLM-driven phase")
       case .scoreCalc, .assign, .eliminate, .summarize, .conditional, .eventInject:
         #expect(!phase.requiresLLM, "\(phase) is a code-driven phase")


### PR DESCRIPTION
## Summary
- New `PhaseType.whisper`: rotating disjoint pairs of active agents exchange `sub_rounds` private turns — **visible to viewers, hidden from other agents' prompts** (the relational counterpart to `inner_thought`'s dramatic irony)
- **No new `SimulationEvent` / no GRDB migration**: each utterance reuses `.agentOutput` with a reserved `whisper_to` field naming the partner (`rawText` provenance preserved). Avoids the ADR-007 §2.4 replay cross-amendment; live UI / Past Results / export / harness follow via existing paths
- Pair-private channel `whispers_<name>` (reflect `notes_<name>` parity): re-injected only into the two participants' prompts via `{my_whispers}` + a "Your Private Whispers" system-prompt section; never enters `conversationLog` / `lastOutputs`. Overwrite semantics (latest exchange only; sat-out agent's stale key cleared)
- Whisper turn prompts always get a partner-naming context block (placeholder-free templates still work); `{whisper_partner}` / `{whisper_exchange}` resolvable for custom templates
- Run-gate validation: canonical `statement` output required (reflect-shape rationale); whisper rejected inside `conditional` branches (validator + `ConditionalHandler.subHandlers`, two sync points); `estimateInferenceCount` = ⌊agents/2⌋ × subRounds × 2
- Harness Go/No-Go: **Go** — 3/3 runs with explicit whisper→choose causality (choose thoughts quoting their 密談), zero cross-pair leakage, whispers clearly distinct from public declarations. Details: https://github.com/tyabu12/pastura/issues/908#issuecomment-4888678595

## Notes
- New `PhaseType` case — revisit `ENGINE_SCHEMA_VERSION` coordination if the ADR-020 baseline lands before this merges (no gallery scenario uses whisper yet)
- `subRounds ≤ 0` edge: handler clamps to 1 while the estimator returns 0 — same un-validated pattern as `speak_each`; left consistent with that precedent (reviewer suggestion, non-blocking)
- PR2+ scope: whisper-specific bubble styling, export pair-attribution format, demo replay support, preset adoption

## Test plan
- Full unit suite: 2626 tests / 218 suites green (UI tests skipped — no UI behavior change beyond editor picker arms)
- New/updated suites: WhisperHandlerTests (pairing rotation, whisper_to attribution + rawText, conversationLog/lastOutputs leak guards, cross-pair isolation, odd sit-out clearing, <2-active no-op, subRounds accumulation), PromptBuilderTests+Whispers (injection, ja/en sections + rules, non-participant sentinel leak tests), ScenarioValidatorTests / ConditionalValidatorTests+Whisper, PhaseDispatcherTests
- Harness: `swift build` green; 3 real-inference validation runs (Gemma 4 E2B, ~180 s each, `ok after 1 attempt`)
- `swiftlint lint --strict` clean; localization coverage 600 keys OK

Part of #908 (PR1 — Engine core + validation; UI polish follows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MmfLzqDRvp6HGMTVANg4pU
