### PR TITLE
✨ feat: 🃏 declaration/action contradiction badge (#916 PR2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ Phase 2 progress:
 - **Home redesign** — bottom-tab IA (ADR-016, #602) + pause/resume of an interrupted run from the Home card (P3: round-boundary checkpoint producer #662, resume consumer + historical-log replay #667, confirm-on-leave pause for in-flight runs #673)
 - **Viewer prediction** — pre-vote-reveal prediction sheet ("who is the wolf?" / "who is #1?") + hit / consecutive-streak tracking; Engine-untouched App/ViewModel event buffering, ground truth scored at the reveal moment (#906 umbrella / #915)
 - **Reflect phase + log window** — per-agent private memo (`reflect` LLM phase, reserved `notes_<name>` namespace, own-prompt re-injection) + opt-in `log_window` prompt-side log trimming; presets unchanged pending per-scenario tuning (#906 umbrella / #907)
+- **Contradiction badge** — 🃏 declaration/action lie detection in prisoners_dilemma: reserved `declared_intent` speak-output field machine-compared against same-round choose actions (full contradiction only, raw-action precision-first); reveal at choose completion in the live transcript + display-time recompute in Past Results, Engine untouched (#906 umbrella / #916)
 
 ## Language Rules
 

--- a/Pastura/Pastura/App/ContradictionDetectionLogic.swift
+++ b/Pastura/Pastura/App/ContradictionDetectionLogic.swift
@@ -22,6 +22,23 @@ import Foundation
 ///   therefore disqualifies the whole round instead.
 nonisolated enum ContradictionDetectionLogic {
 
+  /// The reserved speak-phase output field carrying an agent's public stance
+  /// (#916). Presence of this field is what opts a scenario into detection —
+  /// no scenario-id keying.
+  static let declaredIntentField = "declared_intent"
+
+  /// The option vocabulary declarations are checked against: the first
+  /// choose phase carrying options, searched through depth-1 conditional
+  /// branches (the engine caps conditional nesting at depth 1, mirroring
+  /// `ViewerPredictionLogic.flattened`). Scenarios with several differently
+  /// -optioned choose phases per round are out of scope until one exists.
+  static func chooseOptions(in phases: [Phase]) -> [String] {
+    let all = phases.flatMap { phase in
+      [phase] + (phase.thenPhases ?? []) + (phase.elsePhases ?? [])
+    }
+    return all.first { $0.type == .choose && !($0.options ?? []).isEmpty }?.options ?? []
+  }
+
   /// Whether `declared` (a speak-phase `declared_intent` value) is
   /// contradicted by every entry in `actions` (the same agent's raw parsed
   /// choose actions from the same round), given the choose phase's `options`.

--- a/Pastura/Pastura/App/ContradictionDetectionLogic.swift
+++ b/Pastura/Pastura/App/ContradictionDetectionLogic.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Pure decision logic for the declaration/action contradiction badge (#916).
+///
+/// The ViewModel (live) and `ResultDetailTimelineBuilder` (Past Results) own
+/// data assembly; this enum owns the single decision: did an agent's public
+/// `declared_intent` get contradicted by *all* of its choose actions that
+/// round? Kept `nonisolated` and dependency-free so it unit-tests off the
+/// MainActor without rendering a View (ADR-009 / `.claude/rules/view-testing.md`).
+///
+/// Precision-first rules, fixed by the #916 PR1 harness validation:
+/// - The declaration must be a clean match of one of the choose phase's
+///   `options` — `unclear` (the sanctioned hedge) and free-form values never
+///   badge.
+/// - Every action must be a clean option match, and every one must differ
+///   from the declaration. A partial split (betrayed one neighbour,
+///   cooperated with the other) is opponent-conditioned strategy, not a
+///   provable lie — no badge.
+/// - Raw parsed actions are compared, not `ChooseHandler.validateAction`
+///   output: validation coerces any unparseable action to `options[0]`,
+///   which could manufacture a phantom contradiction. A dirty raw action
+///   therefore disqualifies the whole round instead.
+nonisolated enum ContradictionDetectionLogic {
+
+  /// Whether `declared` (a speak-phase `declared_intent` value) is
+  /// contradicted by every entry in `actions` (the same agent's raw parsed
+  /// choose actions from the same round), given the choose phase's `options`.
+  static func isContradiction(
+    declared: String?, actions: [String], options: [String]
+  ) -> Bool {
+    let normalizedOptions = options.map(normalize)
+    guard let declared,
+      case let declaredOption = normalize(declared),
+      normalizedOptions.contains(declaredOption),
+      !actions.isEmpty
+    else { return false }
+
+    return actions.allSatisfy { action in
+      let actionOption = normalize(action)
+      return normalizedOptions.contains(actionOption) && actionOption != declaredOption
+    }
+  }
+
+  private static func normalize(_ value: String) -> String {
+    value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+  }
+}

--- a/Pastura/Pastura/App/ResultDetailTimelineBuilder.swift
+++ b/Pastura/Pastura/App/ResultDetailTimelineBuilder.swift
@@ -97,4 +97,49 @@ nonisolated enum ResultDetailTimelineBuilder {
     guard let data = record.payloadJSON.data(using: .utf8) else { return nil }
     return try? JSONDecoder().decode(CodePhaseEventPayload.self, from: data)
   }
+
+  /// Ids of declaration `TurnRecord`s whose `declared_intent` was
+  /// contradicted by every one of that agent's choose actions in the same
+  /// round (#916) — the Past Results twin of the live VM's
+  /// `contradictionBadgedEntryIDs`, recomputed at display time from the
+  /// persisted records (no schema change; runs recorded before the field
+  /// existed simply never match). `options` comes from the run's resolved
+  /// scenario snapshot; pass `[]` when the snapshot failed to parse — the
+  /// timeline then renders unbadged, mirroring the avatar-order degrade.
+  ///
+  /// Detection matches the live rule: per (round, agent), the last
+  /// declaration wins, and actions accumulate across the round in
+  /// `sequenceNumber` order (`turns` arrives so ordered from the
+  /// repository).
+  static func contradictionBadgedTurnIDs(
+    turns: [TurnRecord], options: [String]
+  ) -> Set<String> {
+    guard !options.isEmpty else { return [] }
+    struct AgentRound: Hashable {
+      let round: Int
+      let agent: String
+    }
+    var declarations: [AgentRound: (value: String, turnID: String)] = [:]
+    var actions: [AgentRound: [String]] = [:]
+    for turn in turns {
+      guard let agent = turn.agentName,
+        let data = turn.parsedOutputJSON.data(using: .utf8),
+        let output = try? JSONDecoder().decode(TurnOutput.self, from: data)
+      else { continue }
+      let key = AgentRound(round: turn.roundNumber, agent: agent)
+      if let declared = output.fields[ContradictionDetectionLogic.declaredIntentField] {
+        declarations[key] = (value: declared, turnID: turn.id)
+      }
+      if turn.phaseType == PhaseType.choose.rawValue, let action = output.action {
+        actions[key, default: []].append(action)
+      }
+    }
+    var badged: Set<String> = []
+    for (key, declaration) in declarations
+    where ContradictionDetectionLogic.isContradiction(
+      declared: declaration.value, actions: actions[key] ?? [], options: options) {
+      badged.insert(declaration.turnID)
+    }
+    return badged
+  }
 }

--- a/Pastura/Pastura/App/ResultDetailTimelineBuilder.swift
+++ b/Pastura/Pastura/App/ResultDetailTimelineBuilder.swift
@@ -108,9 +108,9 @@ nonisolated enum ResultDetailTimelineBuilder {
   /// timeline then renders unbadged, mirroring the avatar-order degrade.
   ///
   /// Detection matches the live rule: per (round, agent), the last
-  /// declaration wins, and actions accumulate across the round in
-  /// `sequenceNumber` order (`turns` arrives so ordered from the
-  /// repository).
+  /// declaration wins (which is why `turns` must arrive in
+  /// `sequenceNumber` order — the repository guarantees it), and all of
+  /// the round's actions are compared as a set.
   static func contradictionBadgedTurnIDs(
     turns: [TurnRecord], options: [String]
   ) -> Set<String> {

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -1789,7 +1789,11 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     // `filtered`: declared_intent / action are machine tokens the filter
     // could in principle rewrite, and detection must match what the agent
     // actually produced. Neither token is displayed from these buffers.
-    if let declared = output.fields[ContradictionDetectionLogic.declaredIntentField] {
+    // Speak-phase gate: declared_intent is a speak-phase declaration; a
+    // different phase emitting the reserved field must not re-key the
+    // badge onto a non-declaration row.
+    if phaseType == .speakAll || phaseType == .speakEach,
+      let declared = output.fields[ContradictionDetectionLogic.declaredIntentField] {
       declaredIntents[agent] = (value: declared, entryID: entry.id)
     }
     if phaseType == .choose, let action = output.action {

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -31,6 +31,10 @@ struct LogEntry: Identifiable {
     /// probability roll missed; the live log renders this as a muted "no
     /// event this time" line so users can observe the dice did roll.
     case eventInjected(event: String?)
+    /// A declaration/action contradiction detected at choose-phase completion
+    /// (#916): `agent`'s `declared_intent` was contradicted by every one of
+    /// their choose actions this round. Rendered as the 🃏 reveal line.
+    case contradictionRevealed(agent: String)
     case error(String)
   }
 }
@@ -558,6 +562,28 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   /// answer; resumed exactly once by `resolvePrediction`.
   private var predictionContinuation: CheckedContinuation<ViewerPredictionSheet.Resolution, Never>?
 
+  // MARK: Contradiction badge (#916)
+
+  /// Ids of committed declaration rows (`.agentOutput` entries carrying
+  /// `declared_intent`) whose declaration was contradicted by every one of
+  /// that agent's choose actions in the same round. Views decorate those
+  /// rows retroactively by membership lookup. VM-owned (not row `@State`)
+  /// so an ADR-017 Phase B adopt re-projection neither loses nor replays
+  /// the badges (`.claude/rules/swiftui-traps.md` § Re-projection). Grows
+  /// monotonically over the run; reset per run.
+  private(set) var contradictionBadgedEntryIDs: Set<UUID> = []
+
+  /// Current round's `declared_intent` per agent, with the id of the
+  /// committed declaration row for retroactive badging. Raw parsed values
+  /// (pre-`ContentFilter`) — detection compares machine tokens, not
+  /// display text. Reset each round.
+  private var declaredIntents: [String: (value: String, entryID: UUID)] = [:]
+
+  /// Current round's raw parsed choose actions per agent (both round-robin
+  /// appearances). Raw, not `validateAction`-coerced — see
+  /// `ContradictionDetectionLogic`. Reset each round.
+  private var chooseRawActions: [String: [String]] = [:]
+
   #if DEBUG
     // Streaming-display diagnostic logger for #133 PR#4 device-run sessions.
     // Shared across VM + `AgentOutputRow`; filter Console.app with
@@ -1010,6 +1036,11 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     // inherit the previous run's assignments or the once-per-run latch.
     predictionAssignments = [:]
     hasAttemptedPrediction = false
+    // Contradiction-badge accumulators (#916) — reset so a re-used VM does
+    // not badge rows of a previous run (the ids would be stale anyway).
+    contradictionBadgedEntryIDs = []
+    declaredIntents = [:]
+    chooseRawActions = [:]
     predictionPrompt = nil
     predictionOutcome = nil
     pendingPrediction = nil
@@ -1460,7 +1491,7 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
       currentPhaseType = phaseType
       currentPhasePath = phasePath
       logEntries.append(LogEntry(kind: .phaseStarted(phaseType: phaseType)))
-    case .phaseCompleted(_, let phasePath):
+    case .phaseCompleted(let phaseType, let phasePath):
       // Pop `currentPhasePath` back one level when the inner sub-phase's
       // completion arrives (path matches AND count > 1) — so a subsequent
       // event fired before the next `.phaseStarted` isn't mis-attributed to
@@ -1469,6 +1500,15 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
       // read the event's own `phaseType` per `.claude/rules/engine.md`.
       if currentPhasePath == phasePath, phasePath.count > 1 {
         currentPhasePath?.removeLast()
+      }
+      // Contradiction badge (#916): evaluate only once the whole choose
+      // phase has completed — every action of the round is then in the
+      // buffers, so a first-appearance action can never fire a premature
+      // full-contradiction verdict. Event consumption is paced by the
+      // reading-hold loop, so this beat is also the display beat: the last
+      // pairing row is already on screen and the reveal spoils nothing.
+      if phaseType == .choose {
+        revealContradictions(scenario: scenario)
       }
     case .simulationPaused, .conditionalEvaluated:
       // No-op — `.simulationPaused` is a runner-side acknowledgement of the
@@ -1643,12 +1683,37 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   private func handleRoundStarted(round: Int, total: Int) {
     currentRound = round
     totalRounds = total
+    // A declaration only ever contradicts actions of its own round (#916).
+    declaredIntents = [:]
+    chooseRawActions = [:]
     logEntries.append(LogEntry(kind: .roundStarted(round: round, totalRounds: total)))
   }
 
   private func handleRoundCompleted(round: Int, scores newScores: [String: Int]) {
     scores = newScores
     logEntries.append(LogEntry(kind: .roundCompleted(round: round, scores: newScores)))
+  }
+
+  /// Runs the #916 contradiction check for every agent that declared this
+  /// round, badges the declaration row, and appends the 🃏 reveal line.
+  /// Persona-roster iteration keeps multi-agent reveal order deterministic.
+  /// Idempotent per declaration row (badged ids are skipped), so a second
+  /// choose phase in the same round cannot double-reveal.
+  private func revealContradictions(scenario: Scenario) {
+    guard !declaredIntents.isEmpty else { return }
+    let options = ContradictionDetectionLogic.chooseOptions(in: scenario.phases)
+    guard !options.isEmpty else { return }
+    for persona in scenario.personas {
+      guard let declaration = declaredIntents[persona.name],
+        !contradictionBadgedEntryIDs.contains(declaration.entryID),
+        ContradictionDetectionLogic.isContradiction(
+          declared: declaration.value,
+          actions: chooseRawActions[persona.name] ?? [],
+          options: options)
+      else { continue }
+      contradictionBadgedEntryIDs.insert(declaration.entryID)
+      logEntries.append(LogEntry(kind: .contradictionRevealed(agent: persona.name)))
+    }
   }
 
   private func handleAgentOutput(agent: String, output: TurnOutput, phaseType: PhaseType) {
@@ -1720,6 +1785,16 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
     let entry = LogEntry(
       kind: .agentOutput(agent: agent, output: filtered, phaseType: phaseType))
     logEntries.append(entry)
+    // Contradiction detection (#916) records from the RAW output, not
+    // `filtered`: declared_intent / action are machine tokens the filter
+    // could in principle rewrite, and detection must match what the agent
+    // actually produced. Neither token is displayed from these buffers.
+    if let declared = output.fields[ContradictionDetectionLogic.declaredIntentField] {
+      declaredIntents[agent] = (value: declared, entryID: entry.id)
+    }
+    if phaseType == .choose, let action = output.action {
+      chooseRawActions[agent, default: []].append(action)
+    }
     // Track the newest agentOutput so AgentOutputRow can gate the typing
     // animation to only the latest row — older rows snap to full text when
     // this id flips.

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -471,6 +471,22 @@
         }
       }
     },
+    "%@ said one thing, did another" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ said one thing, did another"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@、宣言と行動が矛盾"
+          }
+        }
+      }
+    },
     "%@ was assigned: %@" : {
       "localizations" : {
         "en" : {
@@ -5418,6 +5434,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ストレージ"
+          }
+        }
+      }
+    },
+    "Said one thing, did another" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Said one thing, did another"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "宣言と行動が矛盾"
           }
         }
       }

--- a/Pastura/Pastura/Resources/Presets/prisoners_dilemma.yaml
+++ b/Pastura/Pastura/Resources/Presets/prisoners_dilemma.yaml
@@ -49,8 +49,13 @@ phases:
       {conversation_log}
 
       全員に向けて宣言してください。協力を呼びかけても、ブラフをかけてもOKです。
+
+      declared_intent には、いま全員に見せた宣言の表向きの立場を
+      cooperate / betray / unclear のいずれか1語で示してください。
+      これは宣言のラベルであり、本心と一致していなくてもかまいません。
     output:
       statement: string
+      declared_intent: string
       inner_thought: string
 
   - type: choose

--- a/Pastura/Pastura/Resources/Presets/prisoners_dilemma_en.yaml
+++ b/Pastura/Pastura/Resources/Presets/prisoners_dilemma_en.yaml
@@ -64,8 +64,14 @@ phases:
       {conversation_log}
 
       Address everyone. Call for cooperation, bluff — either is fine.
+
+      In declared_intent, label the public stance of the statement you
+      just made as exactly one of: cooperate / betray / unclear.
+      This labels your public declaration only — it does not have to
+      match your true intentions.
     output:
       statement: string
+      declared_intent: string
       inner_thought: string
 
   - type: choose

--- a/Pastura/Pastura/Views/Components/ContradictionBadge.swift
+++ b/Pastura/Pastura/Views/Components/ContradictionBadge.swift
@@ -13,6 +13,9 @@ struct ContradictionBadge: View {
     HStack(spacing: 5) {
       Text(verbatim: "🃏")
         .font(.caption)
+        // Decorative — without this the combined element announces
+        // "joker" before the meaningful phrase.
+        .accessibilityHidden(true)
       Text(label)
         .font(.caption.weight(.semibold))
     }

--- a/Pastura/Pastura/Views/Components/ContradictionBadge.swift
+++ b/Pastura/Pastura/Views/Components/ContradictionBadge.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+/// 🃏 declaration/action contradiction badge (#916).
+///
+/// Two renderings share the one localized phrasing: the compact form
+/// (`agent == nil`) decorates the original declaration row retroactively,
+/// and the named form is the reveal line appended to the transcript at
+/// choose-phase completion — the moment the actions have just been shown.
+struct ContradictionBadge: View {
+  var agent: String?
+
+  var body: some View {
+    HStack(spacing: 5) {
+      Text(verbatim: "🃏")
+        .font(.caption)
+      Text(label)
+        .font(.caption.weight(.semibold))
+    }
+    .foregroundStyle(Color.mossDark)
+    .padding(.horizontal, 10)
+    .padding(.vertical, 5)
+    .background(Capsule().fill(Color.mossSoft))
+    .accessibilityElement(children: .combine)
+  }
+
+  private var label: String {
+    if let agent {
+      return String(
+        format: String(localized: "%@ said one thing, did another"), agent)
+    }
+    return String(localized: "Said one thing, did another")
+  }
+}

--- a/Pastura/Pastura/Views/Results/ResultDetailView+TurnRows.swift
+++ b/Pastura/Pastura/Views/Results/ResultDetailView+TurnRows.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+// Turn-row rendering split out of ResultDetailView (file_length ceiling).
+// Members these helpers read are internal on the main struct — `private`
+// is invisible to sibling-file extensions.
+extension ResultDetailView {
+
+  /// Resolves a tapped agent name to its persona for the detail sheet
+  /// (#942). Only reached when ``personas`` is non-empty (``turnRow`` gates
+  /// the tap out otherwise); returns `nil` defensively for an unmatched name.
+  func personaItem(for agentName: String) -> PersonaSheetItem? {
+    guard let persona = personas.first(where: { $0.name == agentName }) else { return nil }
+    return PersonaSheetItem(
+      persona: persona,
+      position: agentOrder.firstIndex(of: agentName))
+  }
+
+  @ViewBuilder
+  func turnRow(_ turn: TurnRecord) -> some View {
+    if let agentName = turn.agentName, let phaseType = PhaseType(rawValue: turn.phaseType) {
+      let output = decodeTurnOutput(turn)
+      // Quiet Past Results treatment for the #916 badge: the declaration
+      // row is decorated, but no reveal line is inserted (mirrors how the
+      // prediction badge drops its streak here — the drama beat belongs to
+      // the live transcript).
+      VStack(alignment: .leading, spacing: 4) {
+        AgentOutputRow(
+          agent: agentName,
+          output: output,
+          phaseType: phaseType,
+          showAllThoughts: showAllThoughts,
+          agentPosition: agentOrder.firstIndex(of: agentName),
+          // Gate at the run level, not per-tap: a run whose scenario couldn't
+          // be decoded (pre-v7 deleted scenario, YAML drift) has no personas,
+          // so the rows stay non-tappable rather than showing a dead affordance.
+          onAvatarTap: personas.isEmpty ? nil : { selectedPersona = personaItem(for: $0) }
+        )
+        if contradictionBadgedTurnIDs.contains(turn.id) {
+          ContradictionBadge()
+            .padding(.leading, ChatBubbleLayout.avatarSize + ChatBubbleLayout.avatarTextGap)
+        }
+      }
+    } else {
+      // Pre-#92 fallback: TurnRecord without agentName. Newer code phases
+      // emit CodePhaseEventRecord rows instead, so this path is only hit
+      // by legacy data.
+      HStack(spacing: 4) {
+        Text(turn.phaseType)
+          .textStyle(Typography.metaValue)
+          .foregroundStyle(Color.inkSecondary)
+        Text(String(format: String(localized: "Round %lld"), turn.roundNumber))
+          .textStyle(Typography.metaValue)
+          .foregroundStyle(Color.inkSecondary)
+      }
+    }
+  }
+
+  func decodeTurnOutput(_ turn: TurnRecord) -> TurnOutput {
+    guard let data = turn.parsedOutputJSON.data(using: .utf8),
+      let output = try? JSONDecoder().decode(TurnOutput.self, from: data)
+    else {
+      return TurnOutput(fields: ["raw": turn.rawOutput])
+    }
+    return output
+  }
+}

--- a/Pastura/Pastura/Views/Results/ResultDetailView.swift
+++ b/Pastura/Pastura/Views/Results/ResultDetailView.swift
@@ -26,17 +26,23 @@ struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
   /// scenario YAML couldn't be decoded (legacy data, YAML drift); in
   /// that case `AgentOutputRow` falls back to name-based avatar
   /// resolution.
-  @State private var agentOrder: [String] = []
+  @State var agentOrder: [String] = []  // not private — see note above
   /// Personas in scenario-declared order, decoded from the run's scenario
   /// snapshot alongside ``agentOrder``. Drives the tap-to-view-persona sheet
   /// (#942). Empty for runs whose scenario YAML couldn't be decoded (pre-v7
   /// deleted scenario, YAML drift) — in that case the turn rows stay
   /// non-tappable (``turnRow`` passes `onAvatarTap: nil`).
-  @State private var personas: [Persona] = []
+  @State var personas: [Persona] = []  // not private — see note above
   /// The persona shown when the user taps an agent's avatar / name (#942).
-  @State private var selectedPersona: PersonaSheetItem?
+  @State var selectedPersona: PersonaSheetItem?  // not private — see note above
+  /// Ids of declaration turns to decorate with the 🃏 contradiction badge
+  /// (#916), recomputed off-main at load from the persisted records. Empty
+  /// for pre-#916 runs (no `declared_intent` fields) and for runs whose
+  /// scenario snapshot couldn't be parsed (no choose options to compare
+  /// against) — both degrade to an unbadged timeline.
+  @State var contradictionBadgedTurnIDs: Set<String> = []  // not private — see note above
   @State private var isLoading = true
-  @State private var showAllThoughts = true
+  @State var showAllThoughts = true  // not private — see note above
   @State private var exportPayload: ResultMarkdownExporter.ExportedResult?
   @State private var isExporting = false
   @State private var exportError: String?
@@ -216,54 +222,9 @@ struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
     .accessibilityIdentifier("resultDetail.timeline")
   }
 
-  /// Resolves a tapped agent name to its persona for the detail sheet
-  /// (#942). Only reached when ``personas`` is non-empty (``turnRow`` gates
-  /// the tap out otherwise); returns `nil` defensively for an unmatched name.
-  private func personaItem(for agentName: String) -> PersonaSheetItem? {
-    guard let persona = personas.first(where: { $0.name == agentName }) else { return nil }
-    return PersonaSheetItem(
-      persona: persona,
-      position: agentOrder.firstIndex(of: agentName))
-  }
-
-  @ViewBuilder
-  private func turnRow(_ turn: TurnRecord) -> some View {
-    if let agentName = turn.agentName, let phaseType = PhaseType(rawValue: turn.phaseType) {
-      let output = decodeTurnOutput(turn)
-      AgentOutputRow(
-        agent: agentName,
-        output: output,
-        phaseType: phaseType,
-        showAllThoughts: showAllThoughts,
-        agentPosition: agentOrder.firstIndex(of: agentName),
-        // Gate at the run level, not per-tap: a run whose scenario couldn't
-        // be decoded (pre-v7 deleted scenario, YAML drift) has no personas,
-        // so the rows stay non-tappable rather than showing a dead affordance.
-        onAvatarTap: personas.isEmpty ? nil : { selectedPersona = personaItem(for: $0) }
-      )
-    } else {
-      // Pre-#92 fallback: TurnRecord without agentName. Newer code phases
-      // emit CodePhaseEventRecord rows instead, so this path is only hit
-      // by legacy data.
-      HStack(spacing: 4) {
-        Text(turn.phaseType)
-          .textStyle(Typography.metaValue)
-          .foregroundStyle(Color.inkSecondary)
-        Text(String(format: String(localized: "Round %lld"), turn.roundNumber))
-          .textStyle(Typography.metaValue)
-          .foregroundStyle(Color.inkSecondary)
-      }
-    }
-  }
-
-  private func decodeTurnOutput(_ turn: TurnRecord) -> TurnOutput {
-    guard let data = turn.parsedOutputJSON.data(using: .utf8),
-      let output = try? JSONDecoder().decode(TurnOutput.self, from: data)
-    else {
-      return TurnOutput(fields: ["raw": turn.rawOutput])
-    }
-    return output
-  }
+  // turnRow / personaItem / decodeTurnOutput live in
+  // ResultDetailView+TurnRows.swift (file_length split). The @State they
+  // read is internal (not private) for the same reason as `simulation`.
 
   /// Bundle returned from the single `offMain` DB hop — struct avoids an N-tuple.
   /// Pre-builds `items` inside the off-main task so the view never decodes
@@ -283,6 +244,9 @@ struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
     /// decoded from the same parse. Empty on decode failure — drives the
     /// tap-to-view-persona degrade (#942).
     let personas: [Persona]
+    /// Declaration-turn ids to decorate with the 🃏 badge (#916), computed
+    /// off-main from the fetched turns + the snapshot's choose options.
+    let contradictionBadgedTurnIDs: Set<String>
   }
 
   private func loadData() async {
@@ -311,18 +275,23 @@ struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
         // render, just with name-based avatars.
         let agentOrder: [String]
         let personas: [Persona]
+        let chooseOptions: [String]
         if let scenarioRecord = scenario,
           let parsed = try? ScenarioLoader().load(yaml: scenarioRecord.yamlDefinition) {
           agentOrder = parsed.personas.map(\.name)
           personas = parsed.personas
+          chooseOptions = ContradictionDetectionLogic.chooseOptions(in: parsed.phases)
         } else {
           agentOrder = []
           personas = []
+          chooseOptions = []
         }
         return LoadedData(
           turns: turns, events: events, items: items,
           simulation: sim, scenario: scenario, agentOrder: agentOrder,
-          personas: personas)
+          personas: personas,
+          contradictionBadgedTurnIDs: ResultDetailTimelineBuilder.contradictionBadgedTurnIDs(
+            turns: turns, options: chooseOptions))
       }
       self.turns = fetched.turns
       self.events = fetched.events
@@ -331,6 +300,7 @@ struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
       self.scenario = fetched.scenario
       self.agentOrder = fetched.agentOrder
       self.personas = fetched.personas
+      self.contradictionBadgedTurnIDs = fetched.contradictionBadgedTurnIDs
     } catch {
       self.turns = []
       self.events = []

--- a/Pastura/Pastura/Views/Simulation/SimulationView+LogEntries.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView+LogEntries.swift
@@ -112,6 +112,13 @@ extension SimulationView {
     }
   }
 
+  /// Reveal line for a #916 declaration/action contradiction, appended at
+  /// choose-phase completion. The matching compact badge sits on the
+  /// declaration row itself (see `logEntryView`'s `.agentOutput` case).
+  func contradictionRevealedEntry(agent: String) -> some View {
+    ContradictionBadge(agent: agent)
+  }
+
   /// Full-width phase-boundary separator for LLM phases (speak / vote /
   /// choose). Mirrors `roundSeparator`'s rule + centered-content + rule
   /// structure so the transcript reads as phase "chapters" (#882), but

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -1034,49 +1034,8 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
     _ entry: LogEntry, viewModel: SimulationViewModel, proxy: ScrollViewProxy
   ) -> some View {
     switch entry.kind {
-    case .agentOutput(let agent, let output, let phaseType):
-      let isLatest = viewModel.latestAgentOutputId == entry.id
-      AgentOutputRow(
-        agent: agent, output: output, phaseType: phaseType,
-        showAllThoughts: viewModel.showAllThoughts,
-        isLatest: isLatest,
-        // Display timing is a VM decision. A streamed row is NOT snapped —
-        // it animates from its handoff seed (see `initialVisibleChars`).
-        charsPerSecond: viewModel.effectiveCharsPerSecond(forEntryId: entry.id),
-        // Only the latest row drives the typing-state gate; older rows
-        // never animate so their callbacks would be no-ops, but we guard
-        // here anyway to keep the signal unambiguous.
-        onAnimatingChange: { animating in
-          guard isLatest else { return }
-          latestRowIsAnimating = animating
-        },
-        // Follow the latest row's growth while it types its tail / thought
-        // from the handoff seed (the bubble grows under `growsWithReveal`).
-        // Gated to the latest row so scrolling up through history never
-        // yanks back to the bottom.
-        onRevealProgress: {
-          if isLatest { scrollToBottom(proxy) }
-        },
-        // Record the latest row's reveal completion on the VM so an ADR-017
-        // Phase B adopt re-projection renders it static instead of re-typing
-        // (#934). Guarded to the latest row; the VM re-guards on entry id.
-        onRevealCompleted: {
-          if isLatest { viewModel.markLatestRowRevealCompleted(entryId: entry.id) }
-        },
-        // Grow the bubble with the revealed prefix so the handoff from the
-        // streaming row is seamless (self-gates: only the latest animating
-        // row grows; older rows reserve full layout via shouldReserveHiddenTail).
-        growsWithReveal: true,
-        // Continue typing from where the stream left off instead of snapping
-        // (reveal-position handoff, bug 2); 0 for a non-streamed row.
-        initialVisibleChars: viewModel.handoffSeed(forEntryId: entry.id),
-        agentPosition: scenario?.personas.firstIndex(where: { $0.name == agent }),
-        debugRowID: entry.id.uuidString,
-        onAvatarTap: { selectedPersona = personaItem(for: $0) },
-        // Freeze the latest row's typewriter while the persona sheet is up
-        // (#942 PR2). Live per-tick read — see AgentOutputRow.isTypingParked.
-        isTypingParked: { viewModel.isPlaybackHeldForSheet }
-      )
+    case .agentOutput:
+      agentOutputEntry(entry, viewModel: viewModel, proxy: proxy)
     case .phaseStarted(let phaseType):
       // LLM phases (speak / vote / choose) become full-width separators
       // so the transcript chunks into phase "chapters" (#882); code
@@ -1104,6 +1063,66 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
   }
 
   @ViewBuilder
+  private func agentOutputEntry(
+    _ entry: LogEntry, viewModel: SimulationViewModel, proxy: ScrollViewProxy
+  ) -> some View {
+    if case .agentOutput(let agent, let output, let phaseType) = entry.kind {
+      let isLatest = viewModel.latestAgentOutputId == entry.id
+      // The row is ALWAYS wrapped in this VStack so the badge flipping in
+      // later (#916, at choose-phase completion) is a conditional sibling,
+      // not a structural identity change — AgentOutputRow keeps its
+      // position-based identity and its typing @State is untouched.
+      VStack(alignment: .leading, spacing: 4) {
+        AgentOutputRow(
+          agent: agent, output: output, phaseType: phaseType,
+          showAllThoughts: viewModel.showAllThoughts,
+          isLatest: isLatest,
+          // Display timing is a VM decision. A streamed row is NOT snapped —
+          // it animates from its handoff seed (see `initialVisibleChars`).
+          charsPerSecond: viewModel.effectiveCharsPerSecond(forEntryId: entry.id),
+          // Only the latest row drives the typing-state gate; older rows
+          // never animate so their callbacks would be no-ops, but we guard
+          // here anyway to keep the signal unambiguous.
+          onAnimatingChange: { animating in
+            guard isLatest else { return }
+            latestRowIsAnimating = animating
+          },
+          // Follow the latest row's growth while it types its tail / thought
+          // from the handoff seed (the bubble grows under `growsWithReveal`).
+          // Gated to the latest row so scrolling up through history never
+          // yanks back to the bottom.
+          onRevealProgress: {
+            if isLatest { scrollToBottom(proxy) }
+          },
+          // Record the latest row's reveal completion on the VM so an ADR-017
+          // Phase B adopt re-projection renders it static instead of re-typing
+          // (#934). Guarded to the latest row; the VM re-guards on entry id.
+          onRevealCompleted: {
+            if isLatest { viewModel.markLatestRowRevealCompleted(entryId: entry.id) }
+          },
+          // Grow the bubble with the revealed prefix so the handoff from the
+          // streaming row is seamless (self-gates: only the latest animating
+          // row grows; older rows reserve full layout via shouldReserveHiddenTail).
+          growsWithReveal: true,
+          // Continue typing from where the stream left off instead of snapping
+          // (reveal-position handoff, bug 2); 0 for a non-streamed row.
+          initialVisibleChars: viewModel.handoffSeed(forEntryId: entry.id),
+          agentPosition: scenario?.personas.firstIndex(where: { $0.name == agent }),
+          debugRowID: entry.id.uuidString,
+          onAvatarTap: { selectedPersona = personaItem(for: $0) },
+          // Freeze the latest row's typewriter while the persona sheet is up
+          // (#942 PR2). Live per-tick read — see AgentOutputRow.isTypingParked.
+          isTypingParked: { viewModel.isPlaybackHeldForSheet }
+        )
+        if viewModel.contradictionBadgedEntryIDs.contains(entry.id) {
+          ContradictionBadge()
+            .padding(.leading, ChatBubbleLayout.avatarSize + ChatBubbleLayout.avatarTextGap)
+        }
+      }
+    }
+  }
+
+  @ViewBuilder
   private func secondaryLogEntryView(_ entry: LogEntry) -> some View {
     switch entry.kind {
     case .elimination(let agent, let voteCount):
@@ -1120,6 +1139,8 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
       pairingResultEntry(agent1: agent1, act1: act1, agent2: agent2, act2: act2)
     case .eventInjected(let event):
       eventInjectedEntry(event: event)
+    case .contradictionRevealed(let agent):
+      contradictionRevealedEntry(agent: agent)
     default:
       EmptyView()
     }

--- a/Pastura/PasturaTests/App/ContradictionDetectionLogicTests.swift
+++ b/Pastura/PasturaTests/App/ContradictionDetectionLogicTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+/// Unit coverage for the pure declaration/action contradiction logic (#916).
+///
+/// The precision-first rules pinned here (full contradiction only, dirty
+/// values disqualify) were fixed by the #916 PR1 harness validation; the
+/// 1-of-2 partial case never occurred in those runs, so this suite is its
+/// only coverage.
+@Suite(.timeLimit(.minutes(1)))
+@MainActor
+struct ContradictionDetectionLogicTests {
+
+  private let options = ["cooperate", "betray"]
+
+  // MARK: Full contradictions (badge fires)
+
+  @Test func cooperateDeclaredAllBetrayIsContradiction() {
+    #expect(
+      ContradictionDetectionLogic.isContradiction(
+        declared: "cooperate", actions: ["betray", "betray"], options: options))
+  }
+
+  @Test func betrayDeclaredAllCooperateIsContradictionReverse() {
+    #expect(
+      ContradictionDetectionLogic.isContradiction(
+        declared: "betray", actions: ["cooperate", "cooperate"], options: options))
+  }
+
+  @Test func singleContradictingActionIsContradiction() {
+    #expect(
+      ContradictionDetectionLogic.isContradiction(
+        declared: "cooperate", actions: ["betray"], options: options))
+  }
+
+  @Test func normalizationToleratesCaseAndWhitespace() {
+    #expect(
+      ContradictionDetectionLogic.isContradiction(
+        declared: " Cooperate ", actions: ["BETRAY", "betray\n"], options: options))
+  }
+
+  // MARK: Partial / consistent (no badge — strategy ambiguity)
+
+  @Test func partialBetrayalIsNotContradiction() {
+    // The 1-of-2 case: betrayed one neighbour, cooperated with the other.
+    // Opponent-conditioned strategy, not a provable lie — precision first.
+    #expect(
+      !ContradictionDetectionLogic.isContradiction(
+        declared: "cooperate", actions: ["betray", "cooperate"], options: options))
+  }
+
+  @Test func consistentActionsAreNotContradiction() {
+    #expect(
+      !ContradictionDetectionLogic.isContradiction(
+        declared: "cooperate", actions: ["cooperate", "cooperate"], options: options))
+  }
+
+  // MARK: Non-option / dirty values (ineligible — no badge)
+
+  @Test func unclearDeclarationIsNotContradiction() {
+    #expect(
+      !ContradictionDetectionLogic.isContradiction(
+        declared: "unclear", actions: ["betray", "betray"], options: options))
+  }
+
+  @Test func nilDeclarationIsNotContradiction() {
+    #expect(
+      !ContradictionDetectionLogic.isContradiction(
+        declared: nil, actions: ["betray", "betray"], options: options))
+  }
+
+  @Test func dirtyDeclarationIsNotContradiction() {
+    #expect(
+      !ContradictionDetectionLogic.isContradiction(
+        declared: "betray.", actions: ["cooperate", "cooperate"], options: options))
+  }
+
+  @Test func dirtyActionDisqualifiesTheRound() {
+    // A raw action that is not a clean option match means the round's
+    // actions are not trustworthy — ChooseHandler.validateAction would have
+    // coerced it to options[0], which could manufacture a phantom lie.
+    #expect(
+      !ContradictionDetectionLogic.isContradiction(
+        declared: "cooperate", actions: ["betray", "betray!"], options: options))
+  }
+
+  @Test func emptyActionsAreNotContradiction() {
+    #expect(
+      !ContradictionDetectionLogic.isContradiction(
+        declared: "cooperate", actions: [], options: options))
+  }
+
+  @Test func emptyOptionsAreNotContradiction() {
+    #expect(
+      !ContradictionDetectionLogic.isContradiction(
+        declared: "cooperate", actions: ["betray"], options: []))
+  }
+}

--- a/Pastura/PasturaTests/App/ContradictionDetectionLogicTests.swift
+++ b/Pastura/PasturaTests/App/ContradictionDetectionLogicTests.swift
@@ -97,4 +97,30 @@ struct ContradictionDetectionLogicTests {
       !ContradictionDetectionLogic.isContradiction(
         declared: "cooperate", actions: ["betray"], options: []))
   }
+
+  // MARK: chooseOptions(in:)
+
+  @Test func chooseOptionsReadsFirstOptionedChoosePhase() {
+    let phases = [
+      Phase(type: .speakAll),
+      Phase(type: .choose, options: ["cooperate", "betray"])
+    ]
+    #expect(
+      ContradictionDetectionLogic.chooseOptions(in: phases) == ["cooperate", "betray"])
+  }
+
+  @Test func chooseOptionsSearchesConditionalBranches() {
+    let phases = [
+      Phase(
+        type: .conditional,
+        thenPhases: [Phase(type: .choose, options: ["cooperate", "betray"])])
+    ]
+    #expect(
+      ContradictionDetectionLogic.chooseOptions(in: phases) == ["cooperate", "betray"])
+  }
+
+  @Test func chooseOptionsIsEmptyWithoutAnOptionedChoose() {
+    let phases = [Phase(type: .speakAll), Phase(type: .choose)]
+    #expect(ContradictionDetectionLogic.chooseOptions(in: phases).isEmpty)
+  }
 }

--- a/Pastura/PasturaTests/App/ContradictionDetectionLogicTests.swift
+++ b/Pastura/PasturaTests/App/ContradictionDetectionLogicTests.swift
@@ -10,7 +10,6 @@ import Testing
 /// 1-of-2 partial case never occurred in those runs, so this suite is its
 /// only coverage.
 @Suite(.timeLimit(.minutes(1)))
-@MainActor
 struct ContradictionDetectionLogicTests {
 
   private let options = ["cooperate", "betray"]

--- a/Pastura/PasturaTests/App/ResultDetailTimelineBuilderTests+Contradiction.swift
+++ b/Pastura/PasturaTests/App/ResultDetailTimelineBuilderTests+Contradiction.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+// #916 contradiction-badge coverage for
+// `ResultDetailTimelineBuilder.contradictionBadgedTurnIDs` — sibling-file
+// extension per testing.md's type_body_length split rule (NOT a new
+// @Suite; suites run in parallel and a twin would race the original).
+extension ResultDetailTimelineBuilderTests {
+
+  private var pdOptions: [String] { ["cooperate", "betray"] }
+
+  private func declarationTurn(
+    id: String, round: Int, seq: Int, agent: String, intent: String
+  ) -> TurnRecord {
+    var turn = makeTurn(id: id, round: round, seq: seq, phase: "speak_all", agent: agent)
+    turn.parsedOutputJSON = """
+      {"fields":{"statement":"s","declared_intent":"\(intent)","inner_thought":"t"}}
+      """
+    return turn
+  }
+
+  private func chooseTurn(
+    round: Int, seq: Int, agent: String, action: String
+  ) -> TurnRecord {
+    var turn = makeTurn(round: round, seq: seq, phase: "choose", agent: agent)
+    turn.parsedOutputJSON = """
+      {"fields":{"action":"\(action)","inner_thought":"t"}}
+      """
+    return turn
+  }
+
+  @Test
+  func badgesFullContradictionOnlyWithinTheSameRound() {
+    let turns = [
+      declarationTurn(id: "lie", round: 1, seq: 1, agent: "Alice", intent: "cooperate"),
+      declarationTurn(id: "ok", round: 1, seq: 2, agent: "Bob", intent: "cooperate"),
+      chooseTurn(round: 1, seq: 3, agent: "Alice", action: "betray"),
+      chooseTurn(round: 1, seq: 4, agent: "Bob", action: "cooperate"),
+      chooseTurn(round: 1, seq: 5, agent: "Alice", action: "betray"),
+      chooseTurn(round: 1, seq: 6, agent: "Bob", action: "betray"),
+      // Round 2: Alice declares cooperate but only round-2 actions count.
+      declarationTurn(id: "r2", round: 2, seq: 7, agent: "Alice", intent: "cooperate"),
+      chooseTurn(round: 2, seq: 8, agent: "Alice", action: "cooperate"),
+      chooseTurn(round: 2, seq: 9, agent: "Alice", action: "cooperate")
+    ]
+
+    let badged = ResultDetailTimelineBuilder.contradictionBadgedTurnIDs(
+      turns: turns, options: pdOptions)
+
+    // Alice r1: 2/2 betray → badge. Bob r1: 1/2 → strategy, no badge.
+    // Alice r2: consistent → no badge.
+    #expect(badged == ["lie"])
+  }
+
+  @Test
+  func emptyOptionsProduceNoBadges() {
+    let turns = [
+      declarationTurn(id: "lie", round: 1, seq: 1, agent: "Alice", intent: "cooperate"),
+      chooseTurn(round: 1, seq: 2, agent: "Alice", action: "betray")
+    ]
+    #expect(
+      ResultDetailTimelineBuilder.contradictionBadgedTurnIDs(turns: turns, options: [])
+        .isEmpty)
+  }
+
+  @Test
+  func legacyTurnsWithoutDeclaredIntentProduceNoBadges() {
+    // Pre-#916 runs: speak turns have no declared_intent key at all.
+    let turns = [
+      makeTurn(round: 1, seq: 1, phase: "speak_all", agent: "Alice"),
+      chooseTurn(round: 1, seq: 2, agent: "Alice", action: "betray"),
+      chooseTurn(round: 1, seq: 3, agent: "Alice", action: "betray")
+    ]
+    #expect(
+      ResultDetailTimelineBuilder.contradictionBadgedTurnIDs(
+        turns: turns, options: pdOptions
+      ).isEmpty)
+  }
+}

--- a/Pastura/PasturaTests/App/ResultDetailTimelineBuilderTests+Contradiction.swift
+++ b/Pastura/PasturaTests/App/ResultDetailTimelineBuilderTests+Contradiction.swift
@@ -55,6 +55,23 @@ extension ResultDetailTimelineBuilderTests {
   }
 
   @Test
+  func lastDeclarationInTheRoundWins() {
+    // Two declarations by the same agent in one round: only the later one
+    // is the badge anchor — a first-wins refactor must fail this.
+    let turns = [
+      declarationTurn(id: "early", round: 1, seq: 1, agent: "Alice", intent: "betray"),
+      declarationTurn(id: "late", round: 1, seq: 2, agent: "Alice", intent: "cooperate"),
+      chooseTurn(round: 1, seq: 3, agent: "Alice", action: "betray"),
+      chooseTurn(round: 1, seq: 4, agent: "Alice", action: "betray")
+    ]
+
+    let badged = ResultDetailTimelineBuilder.contradictionBadgedTurnIDs(
+      turns: turns, options: pdOptions)
+
+    #expect(badged == ["late"])
+  }
+
+  @Test
   func emptyOptionsProduceNoBadges() {
     let turns = [
       declarationTurn(id: "lie", round: 1, seq: 1, agent: "Alice", intent: "cooperate"),

--- a/Pastura/PasturaTests/App/ResultDetailTimelineBuilderTests.swift
+++ b/Pastura/PasturaTests/App/ResultDetailTimelineBuilderTests.swift
@@ -8,7 +8,9 @@ struct ResultDetailTimelineBuilderTests {
 
   // MARK: - Fixtures
 
-  private func makeTurn(
+  // internal (not private) — the +Contradiction sibling-file extension
+  // calls it, and `private` is invisible across files (testing.md split rule).
+  func makeTurn(
     id: String = UUID().uuidString,
     round: Int,
     seq: Int,

--- a/Pastura/PasturaTests/App/SimulationViewModelContradictionTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelContradictionTests.swift
@@ -1,0 +1,181 @@
+import Foundation
+import GRDB
+import Testing
+
+@testable import Pastura
+
+/// Integration coverage for the #916 contradiction-badge wiring in
+/// `SimulationViewModel`: buffering, the choose-phase-completion evaluation
+/// beat, per-round resets, and the reveal log line. The pure decision rule is
+/// covered separately in `ContradictionDetectionLogicTests`; these tests pin
+/// the VM plumbing around it.
+@Suite(.timeLimit(.minutes(1))) @MainActor
+struct SimulationViewModelContradictionTests {
+
+  private func makeSut() throws -> SimulationViewModel {
+    let db = try DatabaseManager.inMemory()
+    let writer = db.dbWriter
+    let scenarioRepo = GRDBScenarioRepository(dbWriter: writer)
+    let simRepo = GRDBSimulationRepository(dbWriter: writer)
+    try scenarioRepo.save(
+      ScenarioRecord(
+        id: "s1", name: "PD", yamlDefinition: "y",
+        isPreset: false, createdAt: Date(), updatedAt: Date()))
+    try simRepo.save(
+      SimulationRecord(
+        id: "sim1", scenarioId: "s1", status: "running",
+        currentRound: 1, currentPhaseIndex: 0, stateJSON: "{}", configJSON: nil,
+        createdAt: Date(), updatedAt: Date()))
+    let sut = SimulationViewModel(
+      simulationRepository: simRepo,
+      turnRepository: GRDBTurnRepository(dbWriter: writer),
+      codePhaseEventRepository: GRDBCodePhaseEventRepository(dbWriter: writer))
+    sut.beginPersistenceForTest(simulationId: "sim1")
+    return sut
+  }
+
+  /// prisoners_dilemma-shaped phases: a declaration speak_all + an optioned
+  /// round-robin choose.
+  private let phases = [
+    Phase(type: .speakAll),
+    Phase(type: .choose, options: ["cooperate", "betray"], pairing: .roundRobin)
+  ]
+
+  private func makeScenario() -> Scenario {
+    makeTestScenario(agentNames: ["Alice", "Bob"], rounds: 1, phases: phases)
+  }
+
+  private func declaration(_ agent: String, _ intent: String) -> SimulationEvent {
+    .agentOutput(
+      agent: agent,
+      output: TurnOutput(fields: [
+        "statement": "Let's all be friends.",
+        "declared_intent": intent,
+        "inner_thought": "…"
+      ]),
+      phaseType: .speakAll)
+  }
+
+  private func chooseAction(_ agent: String, _ action: String) -> SimulationEvent {
+    .agentOutput(
+      agent: agent,
+      output: TurnOutput(fields: ["action": action, "inner_thought": "…"]),
+      phaseType: .choose)
+  }
+
+  private let choosePhaseCompleted = SimulationEvent.phaseCompleted(
+    phaseType: .choose, phasePath: [1])
+
+  /// The id of the committed declaration row for `agent` (the retro-badge
+  /// anchor the views look up).
+  private func declarationEntryID(
+    _ sut: SimulationViewModel, agent: String
+  ) -> UUID? {
+    sut.logEntries.first { entry in
+      if case .agentOutput(let name, let output, .speakAll) = entry.kind {
+        return name == agent && output.fields["declared_intent"] != nil
+      }
+      return false
+    }?.id
+  }
+
+  private func revealedAgents(_ sut: SimulationViewModel) -> [String] {
+    sut.logEntries.compactMap { entry in
+      if case .contradictionRevealed(let agent) = entry.kind { return agent }
+      return nil
+    }
+  }
+
+  // MARK: Detection
+
+  @Test func fullContradictionBadgesDeclarationAndAppendsReveal() throws {
+    let sut = try makeSut()
+    let scenario = makeScenario()
+    sut.handleEvent(.roundStarted(round: 1, totalRounds: 1), scenario: scenario)
+    sut.handleEvent(declaration("Alice", "cooperate"), scenario: scenario)
+    sut.handleEvent(declaration("Bob", "cooperate"), scenario: scenario)
+    sut.handleEvent(chooseAction("Alice", "betray"), scenario: scenario)
+    sut.handleEvent(chooseAction("Bob", "cooperate"), scenario: scenario)
+    sut.handleEvent(chooseAction("Alice", "betray"), scenario: scenario)
+    sut.handleEvent(chooseAction("Bob", "cooperate"), scenario: scenario)
+    sut.handleEvent(choosePhaseCompleted, scenario: scenario)
+
+    let aliceRow = try #require(declarationEntryID(sut, agent: "Alice"))
+    #expect(sut.contradictionBadgedEntryIDs == [aliceRow])
+    #expect(revealedAgents(sut) == ["Alice"])
+  }
+
+  @Test func partialSplitDoesNotBadge() throws {
+    let sut = try makeSut()
+    let scenario = makeScenario()
+    sut.handleEvent(.roundStarted(round: 1, totalRounds: 1), scenario: scenario)
+    sut.handleEvent(declaration("Alice", "cooperate"), scenario: scenario)
+    sut.handleEvent(chooseAction("Alice", "betray"), scenario: scenario)
+    sut.handleEvent(chooseAction("Alice", "cooperate"), scenario: scenario)
+    sut.handleEvent(choosePhaseCompleted, scenario: scenario)
+
+    #expect(sut.contradictionBadgedEntryIDs.isEmpty)
+    #expect(revealedAgents(sut).isEmpty)
+  }
+
+  @Test func noEvaluationBeforeChoosePhaseCompletes() throws {
+    // The badge must not exist while actions are still landing — a
+    // first-appearance betray would otherwise fire a premature verdict
+    // (and spoil the reveal beat).
+    let sut = try makeSut()
+    let scenario = makeScenario()
+    sut.handleEvent(.roundStarted(round: 1, totalRounds: 1), scenario: scenario)
+    sut.handleEvent(declaration("Alice", "cooperate"), scenario: scenario)
+    sut.handleEvent(chooseAction("Alice", "betray"), scenario: scenario)
+    sut.handleEvent(chooseAction("Alice", "betray"), scenario: scenario)
+
+    #expect(sut.contradictionBadgedEntryIDs.isEmpty)
+
+    sut.handleEvent(choosePhaseCompleted, scenario: scenario)
+    #expect(sut.contradictionBadgedEntryIDs.count == 1)
+  }
+
+  @Test func roundStartResetsDeclarationAndActionBuffers() throws {
+    // A round-1 declaration must not badge against round-2 actions.
+    let sut = try makeSut()
+    let scenario = makeScenario()
+    sut.handleEvent(.roundStarted(round: 1, totalRounds: 2), scenario: scenario)
+    sut.handleEvent(declaration("Alice", "cooperate"), scenario: scenario)
+    sut.handleEvent(.roundStarted(round: 2, totalRounds: 2), scenario: scenario)
+    sut.handleEvent(chooseAction("Alice", "betray"), scenario: scenario)
+    sut.handleEvent(chooseAction("Alice", "betray"), scenario: scenario)
+    sut.handleEvent(choosePhaseCompleted, scenario: scenario)
+
+    #expect(sut.contradictionBadgedEntryIDs.isEmpty)
+  }
+
+  @Test func scenarioWithoutChooseOptionsNeverBadges() throws {
+    let sut = try makeSut()
+    let scenario = makeTestScenario(
+      agentNames: ["Alice", "Bob"], rounds: 1,
+      phases: [Phase(type: .speakAll), Phase(type: .choose)])
+    sut.handleEvent(.roundStarted(round: 1, totalRounds: 1), scenario: scenario)
+    sut.handleEvent(declaration("Alice", "cooperate"), scenario: scenario)
+    sut.handleEvent(chooseAction("Alice", "betray"), scenario: scenario)
+    sut.handleEvent(choosePhaseCompleted, scenario: scenario)
+
+    #expect(sut.contradictionBadgedEntryIDs.isEmpty)
+  }
+
+  @Test func revealOrderFollowsPersonaRoster() throws {
+    // Two liars in one round: reveal lines follow the scenario's persona
+    // order, not dictionary iteration order.
+    let sut = try makeSut()
+    let scenario = makeScenario()
+    sut.handleEvent(.roundStarted(round: 1, totalRounds: 1), scenario: scenario)
+    sut.handleEvent(declaration("Bob", "cooperate"), scenario: scenario)
+    sut.handleEvent(declaration("Alice", "cooperate"), scenario: scenario)
+    for _ in 0..<2 {
+      sut.handleEvent(chooseAction("Alice", "betray"), scenario: scenario)
+      sut.handleEvent(chooseAction("Bob", "betray"), scenario: scenario)
+    }
+    sut.handleEvent(choosePhaseCompleted, scenario: scenario)
+
+    #expect(revealedAgents(sut) == ["Alice", "Bob"])
+  }
+}

--- a/Pastura/PasturaTests/App/SimulationViewModelContradictionTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelContradictionTests.swift
@@ -9,7 +9,7 @@ import Testing
 /// beat, per-round resets, and the reveal log line. The pure decision rule is
 /// covered separately in `ContradictionDetectionLogicTests`; these tests pin
 /// the VM plumbing around it.
-@Suite(.timeLimit(.minutes(1))) @MainActor
+@Suite(.serialized, .timeLimit(.minutes(1))) @MainActor
 struct SimulationViewModelContradictionTests {
 
   private func makeSut() throws -> SimulationViewModel {


### PR DESCRIPTION
## Summary
- Ship the PR1-held `declared_intent` field into the prisoners_dilemma presets (ja+en) with the harness-validated prompt wording (see the [PR1 Go report](https://github.com/tyabu12/pastura/issues/916#issuecomment-4888693226): bluff rate unchanged vs base, enum adherence 75/75, parse retries 1/225)
- `ContradictionDetectionLogic` (App/, pure, `ViewerPredictionLogic`-shaped): full contradiction only — declared option ∧ ALL of the agent's same-round raw choose actions differ. 1-of-2 partial = strategy, no badge; `unclear` / dirty values disqualify (raw actions, not `validateAction` output, so an `options[0]` coercion can never manufacture a phantom lie)
- Live transcript: `SimulationViewModel` buffers declarations + raw actions (Engine untouched, #915 pattern) and reveals at `.phaseCompleted(.choose)` — the reading-hold-paced display beat, so nothing spoils early. 🃏 `ContradictionBadge` renders as a reveal line + a retroactive decoration on the declaration row (VM-owned ids; adopt re-projection safe)
- Past Results: `ResultDetailTimelineBuilder.contradictionBadgedTurnIDs` recomputes at display time from persisted TurnRecords + the scenario snapshot's choose options — no DB schema change; pre-#916 runs and unparseable snapshots degrade to an unbadged timeline
- Length-ceiling splits: `ResultDetailView+TurnRows.swift`, builder-test sibling extension

## Test plan
- [x] 21 new unit tests (`ContradictionDetectionLogicTests` 12 / `SimulationViewModelContradictionTests` 6 incl. premature-evaluation + per-round-reset pins / builder contradiction tests 4 incl. last-declaration-wins)
- [x] Full unit suite: 2650 tests in 220 suites pass; `swiftlint --strict` clean; localization coverage green (2 new keys, ja translated)
- [x] Preset fixture suites (`PresetLoaderTests` / `BundledPresetSourceIdSchemaTests` / `BundledPresetPlaceholderCoverageTests`) pass
- [x] 3-slice Opus code review: PASS ×3, all findings applied (`.serialized`, speak-phase gate, VoiceOver emoji hide, last-wins test)

## Device-QA gates (before merge)
- [ ] Live run (prisoners_dilemma): retro badge appearing on the declaration row does NOT replay that row's typing/reveal animation (timing-class, unit-untestable)
- [ ] iOS 26 real device: Results detail with a contradiction row renders without AttributeGraph issues (LazyVStack = documented-safe class, but render crashes are invisible to build+units)
- [ ] en run sanity: badge fires on an actual bluff (PR1 observed Ryan r2 as the reliable case); ja rarely fires by design (baseline bluff rate ~0 — precision over recall, noted in the PR1 report)

## Deferred (documented, out of scope)
- Resumed-run historical replay does not rebuild live badges (Past Results recomputes independently)
- Markdown / YAML exporters skip the reveal line; demo replays unaffected (no PD demo bundled)
- Badge fire-rate tuning in ja (persona-side work, separate issue if wanted)

Closes #916

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vK5Vzn26EdEct8Hd4ogEV
