### PR TITLE
✨ feat: scenario PLAYBOOK + digest index — apply lessons, slim reads

### DIFF
--- a/.claude/skills/scenario-factory/PLAYBOOK.md
+++ b/.claude/skills/scenario-factory/PLAYBOOK.md
@@ -1,0 +1,158 @@
+# Scenario-Design Playbook
+
+Distilled, numbered design rules for authoring factory scenarios and refine
+v2 candidates. Read by `/scenario-factory` Step 1 (generation gate) and
+`/scenario-refine` Step 4 (v2 authoring) every cycle.
+
+Discipline (this header is the contract):
+
+- **Soft cap ~150 lines.** This file is read every night — it exists to
+  SHRINK generation context, so entries stay concept-level (invariant + why +
+  evidence pointer, per `.claude/rules/context-budget.md`), never incident
+  prose. If an addition would blow the cap, compress or merge first.
+- **Status per rule**: `[validated]` (reproduced or fix-confirmed on the
+  harness), `[hypothesis]` (proposed / one weak datapoint), `[refuted]`
+  (tried, did not work — prune to a one-line tombstone so it isn't retried).
+- **Evidence dates** refer to the operator-local factory journal
+  (`data/factory/digest.md`, gitignored — not readable from a fresh clone;
+  the dates are provenance, not required reading).
+- **Additions** come from `data/factory/lessons-inbox.md` via a human
+  `/orchestrate` PR (see SKILL.md § Lessons promotion) — the nightly cycle
+  never edits this file.
+
+## Language & breakdown (Gemma 4 E2B)
+
+1. **[validated]** Low-content speech (agreeable filler, pressured accusation)
+   drifts into Korean; content-rich personas stay in Japanese. Give EVERY
+   persona a concrete content hook and add an explicit `必ず日本語で` guard to
+   drift-prone prompts (short relays, conformist casts). (07-03/07-05 failures;
+   07-06 clean with both applied)
+2. **[validated]** Cap statements at ≤2 sentences via the prompt — long
+   grammar-constrained generations raise #253 sampler-crash exposure.
+   (07-01 uncapped failed both attempts; 07-03/07-06 capped ran clean)
+3. **[validated]** `choose` output = `action` + `inner_thought` ONLY (#760);
+   keep option strings short and unambiguous (free-text action wobble recurs),
+   and push reasoning into a preceding speak phase — structured choose decode
+   is the suspected #253 trigger, and fewer rounds shrink exposure.
+   (06-21/22 prisoners_dilemma repro + v2 fix)
+4. **[validated]** Stray trailing `」}` shapes appear ~1/30 outputs and
+   self-recover via parse-retry — judging noise, not a design signal.
+
+## Mechanics
+
+5. **[validated]** Never gate a `conditional` on `vote_winner` with
+   self-advocating personas: everyone self-votes, `exclude_self` empties the
+   tally, the branch takes `else` forever and `{vote_winner}` leaks. Frame
+   votes as endorsing ANOTHER's plan, or gate on something else. (07-04; 06-26)
+6. **[validated]** A per-round branch must not test a CUMULATIVE score —
+   `max_score >= N` goes true early and never flips. Use a `rounds: 1` tally,
+   tie, or `active_count` condition. (06-28 failure → 07-01 confirmed recipe)
+7. **[validated]** In `summarize` templates: `{scoreboard}` always resolves
+   (safe); `{vote_winner}` / `{vote_results}` inside a conditional branch leak
+   unrendered. (06-26 → confirmed fixed 06-28/07-01)
+8. **[validated]** `event_inject` draws RANDOMLY each round — a scripted
+   escalation arc or must-cover stimulus set needs round-indexed
+   `assign source:<list>` instead. (06-28/06-30 failures; assign ordered on
+   07-03/07-05/07-06)
+9. **[validated]** `eliminate` uses the per-round vote tally (not cumulative
+   `vote_tally`) and breaks ties deterministically — knockouts are safe to pair
+   with cumulative scoring. (06-29, reconfirmed nightly)
+10. **[validated]** `choose` does NOT write to the conversation log — sequence
+    a speak deliberation BEFORE choose so reasoning (and any anchor/stimulus an
+    experiment needs) is visible downstream. (06-25 Engine-verified;
+    06-27/06-29 applied)
+11. **[validated]** `scoring_free` has no convergence mechanism: deliberations
+    restate positions, comedy loses differentiating pressure. Use it only when
+    the phenomenon itself is the payoff; do not expect an arc. (06-26/06-27/07-04)
+12. **[validated]** To hold a genuine multi-round split, force a HARD BINARY
+    choice and give personas non-mappable top values — a safe middle option
+    absorbs the pragmatists and collapses to consensus. (06-27 collapse;
+    06-28/07-01/07-06 held splits)
+
+## Persona design
+
+13. **[validated]** Differentiate comedy personas by FORM (deadpan / operatic /
+    groveling / …), not backstory — and prefer domains that are naturally
+    form-diverse (apology styles, defeat speeches). Backstory-only casts
+    converge to one register. (06-28 yusha failure → 06-29/07-01/07-03/07-06)
+14. **[hypothesis]** A gimmick the model can't reliably produce dissolves into
+    the shared register (and gets gang-eliminated first) — swap non-firing
+    forms for ones E2B demonstrably lands; reinforce signature gags in the
+    persona text. (07-01/06-30 failures; fix untested)
+15. **[hypothesis]** Relay "build on the previous turn" instructions pull
+    personas toward the prior speaker's register — protect contrast personas
+    with "re-translate the previous content INTO your own style" phrasing.
+    (06-30 failure; anti-echo variant partially worked 07-01)
+16. **[validated]** Expect minor register breaks — 3rd-person self-reference,
+    value flip-flops under pressure. Mitigate with single-axis, unambiguous
+    value assignments per persona. (recurring, many nights)
+
+## Interaction
+
+17. **[validated]** `speak_each` yields name-referenced cross-talk;
+    `speak_all` yields parallel monologues (cross-reference only in votes).
+    Choose by whether interaction is the payoff. (06-25 A/B; consistent since)
+18. **[validated]** Vote reasons parrot other speakers verbatim unless the
+    prompt says "write your OWN reason, not a copy". (bug 06-24→07-03; nudge
+    confirmed 07-06 — watch durability)
+19. **[validated]** Acknowledgment ≠ persuasion: personas engage with others'
+    arguments but almost never change their choice because of them. Don't
+    stake a payoff on mid-run mind-changing. (07-03/07-06)
+
+## Experiment design
+
+20. **[hypothesis]** For a BEHAVIORAL bias split, the objective facts must make
+    the rational action unambiguous so the immune control DEFECTS while the
+    biased captives persist — otherwise everyone rationalizes the same action.
+    (07-03 sunk-cost: introspection textbook, behavior uniform; fix untested)
+21. **[validated]** Introspective payoff ≠ behavioral payoff: a bias can be
+    textbook in `inner_thought` while choices stay uniform. Measure the channel
+    the claim depends on. (07-03; 06-30)
+22. **[validated]** Cumulative telephone-game decay fails with the full
+    conversation log visible — speakers re-anchor to the base fact. Scope such
+    designs as a PARALLEL bias-panel (works cleanly)… (07-06)
+23. **[hypothesis]** …or retry true transmission decay with `log_window: 1`
+    (#907) + `whisper`/`assign` seeding the fact privately — the Engine lever
+    that did not exist when rule 22 was learned. Untested.
+24. **[validated]** "Individuals show the bias, the deliberating group corrects
+    it" is a legitimate, deeper observable — don't score group-level correction
+    as a failed individual-bias demo. (07-05 bousai)
+25. **[validated]** Force a personal REACTION to injected stimuli — otherwise
+    speak phases verbatim-echo the stimulus text. (06-30)
+
+## Comedy / format
+
+26. **[validated]** Form-differentiated knockouts go one-note by R3–R4 (each
+    persona repeats its gimmick). The main lever: rotate a per-round お題 via
+    `assign source:topics` (the "seriffu recipe"); keep such formats ≤4 rounds.
+    (06-29 recipe; 07-01/07-03/07-06 transfers + staleness)
+27. **[validated]** Avoid constrained-wordplay formats (nazokake, homophone
+    puns) — E2B produces the skeleton without the wordplay payload. (06-25)
+28. **[validated]** Keep one comedy scenario per batch so the night retains a
+    `(d) humor` datapoint (null categories don't score it). (operating
+    convention since 06-27)
+
+## Saturated premise families (dedup: do not regenerate as-is)
+
+The full id-level history lives in `digest-index.jsonl`; these are the
+FAMILIES already characterized — new instances need a genuinely new mechanic
+angle (e.g. whisper/reflect/log_window), not a new topic skin:
+
+- Form-differentiated knockout comedy (seriffu / yusha / yokai / shazai /
+  haiboku) — format + its one-note limit fully mapped.
+- Public-declare-then-secret-choose prisoners_dilemma variants (cartel /
+  warikan / preset) — bluff + "defector dominates" outcome exhausted.
+- Free-rider public/private-gap dilemmas (kyoyu_gyojo, kasei_sanso).
+- Hard-binary ethics splits (saigo / kokuhatsu / manbiki / enjou / ai_teishi)
+  — mechanic settled; only a genuinely fresh dilemma domain adds signal.
+- Cognitive-bias panels with a numerate control (anchoring / framing /
+  kakusho / sunk_cost / bousai) — open problem is rule 20, not new bias topics.
+- Scoring-free social-psych observations (zenin / bystander / risky_shift /
+  sokuho / kuuki) — same "inner_thought reveals mechanism, no arc" shape.
+- Improv sequential_build relays (jidaigeki / uchujin / chinjiken).
+- Anthropomorphic-grievance / reformed-villain venting (kaden_rousai /
+  moto_akuyaku).
+- Rumor distortion (dengon) — parallel panel works; chain decay = rules 22/23.
+
+No validated rules exist yet for `whisper` / `reflect` / `log_window`-based
+designs — first field results should land here via the lessons-inbox.

--- a/.claude/skills/scenario-factory/PLAYBOOK.md
+++ b/.claude/skills/scenario-factory/PLAYBOOK.md
@@ -13,12 +13,11 @@ Discipline (this header is the contract):
 - **Status per rule**: `[validated]` (reproduced or fix-confirmed on the
   harness), `[hypothesis]` (proposed / one weak datapoint), `[refuted]`
   (tried, did not work — prune to a one-line tombstone so it isn't retried).
-- **Evidence dates** refer to the operator-local factory journal
-  (`data/factory/digest.md`, gitignored — not readable from a fresh clone;
-  the dates are provenance, not required reading).
+- **Evidence dates** are provenance pointers into the operator-local factory
+  journal (`data/factory/digest.md`, gitignored) — not required reading.
 - **Additions** come from `data/factory/lessons-inbox.md` via a human
-  `/orchestrate` PR (see SKILL.md § Lessons promotion) — the nightly cycle
-  never edits this file.
+  `/orchestrate` PR (SKILL.md § Lessons promotion) — the nightly cycle never
+  edits this file.
 
 ## Language & breakdown (Gemma 4 E2B)
 
@@ -31,10 +30,9 @@ Discipline (this header is the contract):
    grammar-constrained generations raise #253 sampler-crash exposure.
    (07-01 uncapped failed both attempts; 07-03/07-06 capped ran clean)
 3. **[validated]** `choose` output = `action` + `inner_thought` ONLY (#760);
-   keep option strings short and unambiguous (free-text action wobble recurs),
-   and push reasoning into a preceding speak phase — structured choose decode
-   is the suspected #253 trigger, and fewer rounds shrink exposure.
-   (06-21/22 prisoners_dilemma repro + v2 fix)
+   keep option strings short and unambiguous (free-text wobble recurs), push
+   reasoning into a preceding speak phase — structured choose decode is the
+   suspected #253 trigger; fewer rounds shrink exposure. (06-21/22 repro + v2)
 4. **[validated]** Stray trailing `」}` shapes appear ~1/30 outputs and
    self-recover via parse-retry — judging noise, not a design signal.
 
@@ -122,10 +120,9 @@ Discipline (this header is the contract):
 
 ## Comedy / format
 
-26. **[validated]** Form-differentiated knockouts go one-note by R3–R4 (each
-    persona repeats its gimmick). The main lever: rotate a per-round お題 via
-    `assign source:topics` (the "seriffu recipe"); keep such formats ≤4 rounds.
-    (06-29 recipe; 07-01/07-03/07-06 transfers + staleness)
+26. **[validated]** Form-differentiated knockouts go one-note by R3–R4. Main
+    lever: rotate a per-round お題 via `assign source:topics` (the "seriffu
+    recipe"); keep such formats ≤4 rounds. (06-29 recipe; 3 later transfers)
 27. **[validated]** Avoid constrained-wordplay formats (nazokake, homophone
     puns) — E2B produces the skeleton without the wordplay payload. (06-25)
 28. **[validated]** Keep one comedy scenario per batch so the night retains a
@@ -134,24 +131,22 @@ Discipline (this header is the contract):
 
 ## Saturated premise families (dedup: do not regenerate as-is)
 
-The full id-level history lives in `digest-index.jsonl`; these are the
-FAMILIES already characterized — new instances need a genuinely new mechanic
-angle (e.g. whisper/reflect/log_window), not a new topic skin:
+Id-level history lives in `digest-index.jsonl`; these FAMILIES are already
+characterized — new instances need a new mechanic angle (e.g.
+whisper/reflect/log_window), not a new topic skin:
 
 - Form-differentiated knockout comedy (seriffu / yusha / yokai / shazai /
-  haiboku) — format + its one-note limit fully mapped.
-- Public-declare-then-secret-choose prisoners_dilemma variants (cartel /
-  warikan / preset) — bluff + "defector dominates" outcome exhausted.
-- Free-rider public/private-gap dilemmas (kyoyu_gyojo, kasei_sanso).
+  haiboku) — format and its one-note limit fully mapped.
+- Declare-then-secret-choose prisoners_dilemma variants (cartel / warikan /
+  preset); free-rider public/private-gap dilemmas (kyoyu, kasei).
 - Hard-binary ethics splits (saigo / kokuhatsu / manbiki / enjou / ai_teishi)
   — mechanic settled; only a genuinely fresh dilemma domain adds signal.
 - Cognitive-bias panels with a numerate control (anchoring / framing /
-  kakusho / sunk_cost / bousai) — open problem is rule 20, not new bias topics.
+  kakusho / sunk_cost / bousai) — open problem is rule 20, not new topics.
 - Scoring-free social-psych observations (zenin / bystander / risky_shift /
   sokuho / kuuki) — same "inner_thought reveals mechanism, no arc" shape.
-- Improv sequential_build relays (jidaigeki / uchujin / chinjiken).
-- Anthropomorphic-grievance / reformed-villain venting (kaden_rousai /
-  moto_akuyaku).
+- Improv sequential_build relays (jidaigeki / uchujin / chinjiken);
+  anthropomorphic-grievance venting (kaden_rousai, moto_akuyaku).
 - Rumor distortion (dengon) — parallel panel works; chain decay = rules 22/23.
 
 No validated rules exist yet for `whisper` / `reflect` / `log_window`-based

--- a/.claude/skills/scenario-factory/SKILL.md
+++ b/.claude/skills/scenario-factory/SKILL.md
@@ -51,11 +51,31 @@ Non-goals:
 
 ## Step 1 — Read prior scenarios (dedup)
 
-Read `data/factory/digest.md`. Collect every past scenario **id, name,
-theme, and comment** from the section tables. The new batch must not
-repeat: same premise, same persona cast, or a theme judged ≤2 on humor
-twice in a row. Low-scoring past entries are signals about what NOT to
-generate again; high scorers indicate directions worth varying further.
+Read three sources, in order:
+
+- **(a) The PLAYBOOK first** — `.claude/skills/scenario-factory/PLAYBOOK.md`
+  (repo-tracked), in full. It is the **GENERATION GATE**: every generated
+  scenario must comply with its `[validated]` rules; `[hypothesis]` rules are
+  levers to test deliberately (note in the Step 5 digest comment when one is
+  exercised). Its "Saturated premise families" section is dedup input.
+- **(b) `data/factory/digest-index.jsonl`** for FULL-history dedup — one line
+  per past scenario (id / name / theme / axis / status / scores, no comments;
+  ~19 KB vs the ~97 KB digest). Collect every past **id, name, theme** here.
+- **(c) Only the NEWEST 2 sections of `data/factory/digest.md`** for the
+  freshest nuance — last nights' comments, lessons, and axis-rotation context.
+  **NEVER read the whole digest** (it exceeds the session Read cap, ~39k
+  tokens): read with `offset`/`limit`, or stop at the 2nd `## <date>` heading.
+
+Dedup semantics (sourced from (a)+(b)+(c)): the new batch must not repeat same
+premise, same persona cast, or a theme judged ≤2 on humor twice in a row.
+Low-scoring past entries are signals about what NOT to generate again; high
+scorers indicate directions worth varying further.
+
+**Missing-index fallback**: if `digest-index.jsonl` is absent, do NOT read the
+full digest to compensate. Proceed with newest-2-sections dedup plus a cheap
+`grep`-based id/slug collision check against `digest.md`, and include a notice
+in the Step 6 report: `index missing — full-history dedup degraded; run
+append_digest.py --digest data/factory/digest.md --rebuild-index`.
 
 Also collect the **`name` + `description`** of every already-shipped
 scenario, so generation can avoid colliding with the inventory it might
@@ -263,11 +283,33 @@ the comment). The judge is a quality filter, not a safety screen.
 3. Verify: `grep -c 'factory-digest:' data/factory/digest.md` must print
    `2` (both markers survived), and the new `## <DATE>` section exists.
 
+## Step 5.5 — Propose lessons (inbox)
+
+If the night **VALIDATED** or **REFUTED** a design lesson not already covered
+by a PLAYBOOK rule — or produced strong new evidence that should change a
+rule's status — append a dated, concept-level entry to
+`data/factory/lessons-inbox.md` (gitignored; create it with a one-line header
+if absent). Entry shape:
+
+```
+- <DATE> [candidate-status] <one-two sentence rule> (evidence: <ids>)
+```
+
+**Grep-before-append**: if an entry for the same lesson *concept* already
+exists, append `re-observed: <DATE>` to that entry's line instead of
+duplicating. Plain Read / Grep / Write — no helper script.
+
+The inbox is a **PROPOSAL queue only** — the nightly cycle NEVER edits
+`PLAYBOOK.md`. Promotion is human-driven (§ Lessons promotion).
+
 ## Step 6 — Report
 
 Summarize for the user: per-scenario status + scores + best line of the
 night, failures with one-line causes, and where the artifacts live
-(`scenarios/<DATE>/`, `runs/<DATE>/`, the appended digest section).
+(`scenarios/<DATE>/`, `runs/<DATE>/`, the appended digest section; the
+`lessons-inbox.md` entries if any were proposed in Step 5.5). If the index was
+missing (Step 1 fallback), surface the degraded-dedup notice with the
+`--rebuild-index` command.
 `data/factory/digest.md` is a gitignored local log — the new section is
 appended in place and is NOT committed or pushed. Only *promoting* a
 winning scenario (bundled preset or shared-scenario gallery; see
@@ -292,6 +334,19 @@ via an `/orchestrate` PR either way:
   low-coherence / low-humor runs). Full bridge: `docs/gallery/README.md`
   § "Promoting from the scenario factory".
 
+## Lessons promotion
+
+`data/factory/lessons-inbox.md` (Step 5.5) → `PLAYBOOK.md` happens in a
+human-driven `/orchestrate` PR — same pattern as scenario promotion. The PR:
+
+- **Compresses** each promoted entry to PLAYBOOK's concept-level register
+  (invariant + why + evidence pointer; see the PLAYBOOK header discipline,
+  soft cap ~150 lines) — never paste inbox prose verbatim.
+- After merge, an **operator step** CLEARS promoted / duplicate / stale entries
+  from the local inbox. The PR itself can't do this — the inbox is a gitignored
+  local file, invisible to the merge — mirroring how the gitignored digest is
+  maintained locally rather than by the PR.
+
 ## Scheduling (how the unattended run works)
 
 - **The skill never self-registers** (see Non-goals "No scheduled
@@ -305,9 +360,10 @@ via an `/orchestrate` PR either way:
   A *manual* `/scenario-factory` behaves identically. (Promoting a winning
   scenario is a separate `/orchestrate` PR — see § Promotion.)
 - **Run in the user's main checkout — not a throwaway worktree.** The
-  gitignored digest, `scenarios/<DATE>/`, and `runs/<DATE>/` must persist
-  between nights so Step 1 dedup reads the full history; a fresh per-run
-  worktree would start with an empty bootstrapped digest and lose that
+  gitignored digest, its `digest-index.jsonl` sidecar, `scenarios/<DATE>/`,
+  and `runs/<DATE>/` must persist between nights so the full history stays
+  available — Step 1 dedup reads the index (rebuilt from the digest); a fresh
+  per-run worktree would start with an empty bootstrapped digest and lose that
   history. The digest being gitignored is what keeps the main working tree
   clean despite running there.
 - **Routine recipe** (Desktop → Routines → New routine):

--- a/.claude/skills/scenario-factory/scripts/append_digest.py
+++ b/.claude/skills/scenario-factory/scripts/append_digest.py
@@ -2,6 +2,14 @@
 """Append one factory-cycle section to the local digest, date-idempotently.
 
 usage: append_digest.py --results <results.json> --digest <digest.md>
+       append_digest.py --digest <digest.md> --rebuild-index
+
+Alongside the digest an append also writes a machine-readable sidecar index
+`digest-index.jsonl` (one JSON object per scenario, `comment` excluded — it is
+the bulk of digest size). The index lets the nightly generation step dedup
+against FULL history without reading the ~39k-token digest. It is a REBUILDABLE
+cache; digest.md stays the source of truth — `--rebuild-index` regenerates it
+from the digest's markdown tables.
 
 The digest is a LOCAL log (gitignored — not committed). If the target
 file is absent (clean clone / first run), it is bootstrapped from a
@@ -115,11 +123,208 @@ def render_section(results):
     return "\n".join(lines)
 
 
+# --- Sidecar index (digest-index.jsonl) -------------------------------------
+# Index field set: comment is deliberately EXCLUDED (bulk of digest size). The
+# index is a rebuildable cache; digest.md is the source of truth.
+INDEX_FILENAME = "digest-index.jsonl"
+
+# Rubric header cells render as "(a) coherence" etc. — map the label back to the
+# scores dict key (note the header uses a hyphen: "breakdown-free").
+RUBRIC_HEADER_TO_KEY = {
+    "coherence": "coherence",
+    "interaction": "interaction",
+    "breakdown-free": "breakdown_free",
+    "breakdown_free": "breakdown_free",
+    "humor": "humor",
+    "development": "development",
+}
+RUBRIC_HEADER_RE = re.compile(r"^\([a-z]\)\s+(.+)$")
+
+
+def index_path_for(digest_path):
+    """Sidecar index lives in the same directory as the digest, fixed name — so
+    tests pointing --digest at a tmp file get a tmp index too."""
+    return os.path.join(os.path.dirname(digest_path) or ".", INDEX_FILENAME)
+
+
+def build_index_lines(date, scenarios):
+    """One index object per scenario. `comment` omitted by design; `axis` /
+    `scores` are absent-safe (null when the scenario has none)."""
+    return [
+        {
+            "date": date,
+            "id": s.get("id"),
+            "name": s.get("name"),
+            "theme": s.get("theme"),
+            "axis": s.get("axis"),
+            "status": s.get("status"),
+            "scores": s.get("scores"),
+        }
+        for s in scenarios
+    ]
+
+
+def write_index_incremental(digest_path, results):
+    """Update the sidecar from the IN-MEMORY results (not by re-parsing the
+    digest just written). Date-idempotent: drop existing same-date lines before
+    appending, mirroring the digest's section replace. Bootstraps the file if
+    absent. Fail-open: any write failure is a single non-fatal stderr warning —
+    the append (digest is already persisted) must never fail on the cache."""
+    index_path = index_path_for(digest_path)
+    date = results["date"]
+    new_lines = build_index_lines(date, results.get("scenarios", []))
+    try:
+        kept = []
+        if os.path.exists(index_path):
+            with open(index_path, encoding="utf-8") as f:
+                for raw in f:
+                    raw = raw.strip()
+                    if not raw:
+                        continue
+                    obj = json.loads(raw)
+                    if obj.get("date") == date:
+                        continue  # replaced below
+                    kept.append(obj)
+        with open(index_path, "w", encoding="utf-8") as f:
+            for obj in kept + new_lines:
+                f.write(json.dumps(obj, ensure_ascii=False) + "\n")
+    except (OSError, ValueError) as e:
+        # ValueError covers a corrupt existing line (json.JSONDecodeError).
+        print(f"warning: could not update sidecar index {index_path}: {e}; "
+              f"regenerate it with --rebuild-index", file=sys.stderr)
+
+
+def split_row_cells(line):
+    """Split a markdown table row on UNESCAPED pipes, drop the leading/trailing
+    empties from the outer pipes, then unescape `\\|` → `|` (the appender's
+    cell() escapes pipes)."""
+    parts = re.split(r"(?<!\\)\|", line)
+    if parts and parts[0].strip() == "":
+        parts = parts[1:]
+    if parts and parts[-1].strip() == "":
+        parts = parts[:-1]
+    return [p.strip().replace("\\|", "|") for p in parts]
+
+
+def _rebuild_fail(date, header, msg):
+    """Rebuild is a manual/recovery operation — unlike the nightly append it
+    MUST NOT fail-open into a silently partial index. Hard-fail loudly and
+    write nothing."""
+    print(f"rebuild-index: unrecognized table shape in section {date}: {msg}",
+          file=sys.stderr)
+    print(f"  header: {header}", file=sys.stderr)
+    sys.exit(2)
+
+
+def rebuild_index(digest_path):
+    """Regenerate the ENTIRE sidecar by parsing the digest's markdown tables.
+    Header-name-keyed column mapping (not fixed indices) so all three historical
+    shapes parse — pre-axis-column, 4-axis, 5-axis. Writes nothing on any
+    unrecognized shape."""
+    if not os.path.exists(digest_path):
+        print(f"rebuild-index: digest not found: {digest_path}", file=sys.stderr)
+        return 1
+    with open(digest_path, encoding="utf-8") as f:
+        digest = f.read()
+    for marker in (SECTIONS_MARKER, PROMOTION_MARKER):
+        if digest.count(marker) != 1:
+            print(f"rebuild-index: digest must contain exactly one '{marker}'",
+                  file=sys.stderr)
+            return 1
+    body = digest.partition(SECTIONS_MARKER)[2].partition(PROMOTION_MARKER)[0]
+
+    all_lines = []
+    section_count = 0
+    # Sections are `## YYYY-MM-DD` blocks between the two markers.
+    for chunk in re.split(r"(?m)^## ", body):
+        heading, _, rest = chunk.partition("\n")
+        date = heading.strip()
+        if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", date):
+            continue  # preamble / non-section text
+        section_count += 1
+
+        table_lines = [l for l in rest.split("\n") if l.lstrip().startswith("|")]
+        if not table_lines:
+            continue
+        header_line = table_lines[0]
+        colnames = split_row_cells(header_line)
+        # Map rubric columns for THIS table; a rubric-shaped but unknown column
+        # is an unrecognized shape.
+        rubric_cols = {}
+        for cn in colnames:
+            m = RUBRIC_HEADER_RE.match(cn)
+            if m:
+                key = RUBRIC_HEADER_TO_KEY.get(m.group(1).strip())
+                if key is None:
+                    _rebuild_fail(date, header_line,
+                                  f"unknown rubric column {cn!r}")
+                rubric_cols[cn] = key
+
+        for dl in table_lines[1:]:
+            cells = split_row_cells(dl)
+            if cells and all(re.fullmatch(r":?-+:?", c) for c in cells):
+                continue  # separator row (|---|---|)
+            if len(cells) != len(colnames):
+                _rebuild_fail(date, header_line,
+                              f"row has {len(cells)} cells, header has "
+                              f"{len(colnames)}")
+            row = dict(zip(colnames, cells))
+
+            def field(name):
+                v = row.get(name)
+                return None if v in (None, "", "–") else v
+
+            status = field("status")
+            scores = None
+            if status == "ok":
+                scores = {}
+                for cn, key in rubric_cols.items():
+                    cv = row.get(cn)
+                    if cv in (None, "", "–"):
+                        scores[key] = None
+                    else:
+                        try:
+                            scores[key] = int(cv)
+                        except ValueError:
+                            _rebuild_fail(date, header_line,
+                                          f"non-integer rubric cell {cv!r} "
+                                          f"in column {cn!r}")
+            all_lines.append({
+                "date": date,
+                "id": field("id"),
+                "name": field("name"),
+                "theme": field("theme"),
+                "axis": field("axis"),  # None when the table has no axis column
+                "status": status,
+                "scores": scores,
+            })
+
+    # Full parse succeeded — only now write (so a hard-fail leaves no partial).
+    index_path = index_path_for(digest_path)
+    with open(index_path, "w", encoding="utf-8") as f:
+        for obj in all_lines:
+            f.write(json.dumps(obj, ensure_ascii=False) + "\n")
+    print(f"rebuilt index {index_path}: {section_count} section(s), "
+          f"{len(all_lines)} scenario line(s)")
+    return 0
+
+
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--results", required=True)
+    parser.add_argument("--results")
     parser.add_argument("--digest", required=True)
+    parser.add_argument("--rebuild-index", action="store_true",
+                        help="regenerate digest-index.jsonl from the digest "
+                             "(ignores --results)")
     args = parser.parse_args()
+
+    if args.rebuild_index:
+        return rebuild_index(args.digest)
+
+    if not args.results:
+        print("--results is required unless --rebuild-index is given",
+              file=sys.stderr)
+        return 2
 
     with open(args.results, encoding="utf-8") as f:
         results = json.load(f)
@@ -163,6 +368,10 @@ def main():
 
     with open(args.digest, "w", encoding="utf-8") as f:
         f.write(head + SECTIONS_MARKER + body + PROMOTION_MARKER + footer)
+
+    # Digest (source of truth) is now persisted; update the sidecar cache from
+    # the in-memory results. Never fails the append (see write_index_incremental).
+    write_index_incremental(args.digest, results)
 
     action = "replaced" if replaced else "appended"
     print(f"{action} section {results['date']} "

--- a/.claude/skills/scenario-factory/scripts/append_digest.py
+++ b/.claude/skills/scenario-factory/scripts/append_digest.py
@@ -150,18 +150,25 @@ def index_path_for(digest_path):
 def build_index_lines(date, scenarios):
     """One index object per scenario. `comment` omitted by design; `axis` /
     `scores` are absent-safe (null when the scenario has none)."""
-    return [
-        {
+    lines = []
+    for s in scenarios:
+        scores = s.get("scores")
+        if isinstance(scores, dict):
+            # Fill any RUBRIC_KEYS missing from the results dict with None
+            # (present-but-null keys are left as-is) — keeps this incremental
+            # path provably identical to --rebuild-index, which always
+            # materializes every table column from the header.
+            scores = {**scores, **{k: scores.get(k) for k in RUBRIC_KEYS if k not in scores}}
+        lines.append({
             "date": date,
             "id": s.get("id"),
             "name": s.get("name"),
             "theme": s.get("theme"),
             "axis": s.get("axis"),
             "status": s.get("status"),
-            "scores": s.get("scores"),
-        }
-        for s in scenarios
-    ]
+            "scores": scores,
+        })
+    return lines
 
 
 def write_index_incremental(digest_path, results):

--- a/.claude/skills/scenario-factory/tests/fixtures/digest_shapes.md
+++ b/.claude/skills/scenario-factory/tests/fixtures/digest_shapes.md
@@ -1,0 +1,36 @@
+# Scenario Factory Digest (three historical table shapes)
+
+Hand-written fixture exercising the `--rebuild-index` header-name-keyed
+parser across the journal's three real shapes: 5-axis (current), 4-axis
+(no `(e) development`), and pre-axis-column (no `axis` column at all).
+One `name` cell carries an escaped `\|` to prove pipe round-tripping.
+
+<!-- factory-digest:sections -->
+
+## 2026-06-15
+
+Model: gemma \| test | Scenarios: 1 (ok 1 / failed 0 / config_error 0)
+
+| id | name | theme | axis | status | (a) coherence | (b) interaction | (c) breakdown-free | (d) humor | (e) development | comment |
+|---|---|---|---|---|---|---|---|---|---|---|
+| shape_a_ok | テスト \| 大喜利 | 大喜利 | elimination / creative | ok | 4 | 3 | 5 | 2 | 3 | ぱいぷ \| を含む |
+
+## 2026-06-14
+
+Model: gemma | Scenarios: 2 (ok 1 / failed 1 / config_error 0)
+
+| id | name | theme | axis | status | (a) coherence | (b) interaction | (c) breakdown-free | (d) humor | comment |
+|---|---|---|---|---|---|---|---|---|---|
+| shape_b_ok | 四軸OK | テーマ | branching / roleplay | ok | 3 | 4 | 4 | 5 | good |
+| shape_b_fail | 四軸失敗 | テーマ | – | failed | – | – | – | – | error: boom |
+
+## 2026-06-13
+
+Model: gemma | Scenarios: 1 (ok 1 / failed 0 / config_error 0)
+
+| id | name | theme | status | (a) coherence | (b) interaction | (c) breakdown-free | (d) humor | comment |
+|---|---|---|---|---|---|---|---|---|
+| shape_c_ok | 旧形式 | 昔 | ok | 2 | 2 | 3 | 1 | legacy |
+
+<!-- factory-digest:promotion -->
+Promotion: channels documented in `.claude/skills/scenario-factory/SKILL.md` § Promotion.

--- a/.claude/skills/scenario-factory/tests/run_tests.sh
+++ b/.claude/skills/scenario-factory/tests/run_tests.sh
@@ -106,6 +106,43 @@ python3 "$SCRIPTS/append_digest.py" \
   --results fixtures/results_sample.json --digest "$IDX_DIR/digest.md" >/dev/null 2>&1
 [ "$(grep -c . "$IDX")" -eq 3 ] || fail "index: same-date re-run duplicated lines"
 
+# incremental multi-date accumulation: appending a SECOND date's results must
+# keep the first date's index lines (not just replace-by-date).
+MD="$TMP/multidate"; mkdir -p "$MD"
+cp fixtures/digest_seed.md "$MD/digest.md"
+python3 "$SCRIPTS/append_digest.py" \
+  --results fixtures/results_sample.json --digest "$MD/digest.md" >/dev/null
+jq '.date = "2026-06-14"
+    | .scenarios = [.scenarios[0]]
+    | .scenarios[0].id = "factory_20260614_test_ok"
+    | .scenarios[0].scores = {"coherence": 5, "interaction": 4}' \
+  fixtures/results_sample.json > "$MD/results_day2.json"
+python3 "$SCRIPTS/append_digest.py" \
+  --results "$MD/results_day2.json" --digest "$MD/digest.md" >/dev/null
+MDIDX="$MD/digest-index.jsonl"
+[ "$(jq -es 'map(select(.date=="2026-06-13")) | length' "$MDIDX")" -eq 3 ] \
+  || fail "index: day-1 lines lost after day-2 append"
+[ "$(jq -es 'map(select(.date=="2026-06-14")) | length' "$MDIDX")" -eq 1 ] \
+  || fail "index: day-2 line missing"
+# partial scores dict (missing rubric keys) normalized with null-filled
+# keys — matches what --rebuild-index would materialize for the same row
+jq -es 'map(select(.date=="2026-06-14"))[0].scores
+    == {"coherence":5,"interaction":4,"breakdown_free":null,"humor":null,"development":null}' \
+  "$MDIDX" >/dev/null || fail "index: partial scores dict not normalized with null rubric keys"
+
+# corrupt existing index line (malformed JSON) must fail-open like the
+# unwritable-index case above: append still succeeds, warning names
+# --rebuild-index. Pins the ValueError branch of write_index_incremental's
+# `except (OSError, ValueError)`.
+CI="$TMP/corrupt_idx"; mkdir -p "$CI"
+cp fixtures/digest_seed.md "$CI/digest.md"
+echo '{not json' > "$CI/digest-index.jsonl"
+python3 "$SCRIPTS/append_digest.py" \
+  --results fixtures/results_sample.json --digest "$CI/digest.md" >/dev/null 2>"$CI/warn" \
+  || fail "index: corrupt existing index line must not fail the append"
+grep -q "^## 2026-06-13$" "$CI/digest.md" || fail "index: digest not updated on corrupt index line"
+grep -q -- "--rebuild-index" "$CI/warn" || fail "index: corrupt-line warning must name --rebuild-index"
+
 # round-trip: --rebuild-index off the produced digest == the incremental index
 cp "$IDX" "$IDX_DIR/index-incremental.jsonl"
 python3 "$SCRIPTS/append_digest.py" \
@@ -152,6 +189,16 @@ if python3 "$SCRIPTS/append_digest.py" \
   fail "bogus: unrecognized rubric column should hard-fail"
 fi
 [ ! -f "$BG/digest-index.jsonl" ] || fail "bogus: index written despite hard-fail"
+
+# rebuild-index on a digest with both markers but ZERO `## <date>` sections
+# (e.g. the bootstrap scaffold before any append) must exit 0 and write an
+# EMPTY index file — not error, not skip the write.
+ZS="$TMP/zero_sections"; mkdir -p "$ZS"
+cp fixtures/digest_seed.md "$ZS/digest.md"
+python3 "$SCRIPTS/append_digest.py" \
+  --digest "$ZS/digest.md" --rebuild-index >/dev/null || fail "zero-section rebuild failed"
+[ -f "$ZS/digest-index.jsonl" ] || fail "zero-section rebuild: index file not created"
+[ ! -s "$ZS/digest-index.jsonl" ] || fail "zero-section rebuild: index file not empty"
 
 # non-fatal index failure: a directory at the index path blocks the write;
 # the append still succeeds (digest is the source of truth)

--- a/.claude/skills/scenario-factory/tests/run_tests.sh
+++ b/.claude/skills/scenario-factory/tests/run_tests.sh
@@ -86,6 +86,84 @@ grep -q "factory-digest:promotion" "$TMP/bootstrap.md" || fail "bootstrap: promo
 grep -q "^## 2026-06-13$" "$TMP/bootstrap.md" || fail "bootstrap: section not appended"
 tail -1 "$TMP/bootstrap.md" | grep -q "^Promotion:" || fail "bootstrap: promotion line not last"
 
+# --- append_digest.py: sidecar index ----------------------------------------
+# The index (digest-index.jsonl) is a machine-readable dedup cache written
+# alongside the digest; digest.md stays the source of truth.
+IDX_DIR="$TMP/idx"; mkdir -p "$IDX_DIR"
+cp fixtures/digest_seed.md "$IDX_DIR/digest.md"
+python3 "$SCRIPTS/append_digest.py" \
+  --results fixtures/results_sample.json --digest "$IDX_DIR/digest.md" >/dev/null
+IDX="$IDX_DIR/digest-index.jsonl"
+[ -f "$IDX" ] || fail "index: sidecar not created next to digest"
+# one line per scenario (results_sample has 3)
+[ "$(grep -c . "$IDX")" -eq 3 ] || fail "index: expected 3 lines, got $(grep -c . "$IDX")"
+# comment is deliberately excluded (it is the bulk of digest size)
+if jq -es 'map(has("comment")) | any' "$IDX" >/dev/null; then
+  fail "index: comment key must be excluded"
+fi
+# same-date re-run replaces, never duplicates
+python3 "$SCRIPTS/append_digest.py" \
+  --results fixtures/results_sample.json --digest "$IDX_DIR/digest.md" >/dev/null 2>&1
+[ "$(grep -c . "$IDX")" -eq 3 ] || fail "index: same-date re-run duplicated lines"
+
+# round-trip: --rebuild-index off the produced digest == the incremental index
+cp "$IDX" "$IDX_DIR/index-incremental.jsonl"
+python3 "$SCRIPTS/append_digest.py" \
+  --digest "$IDX_DIR/digest.md" --rebuild-index >/dev/null || fail "index: rebuild failed"
+python3 - "$IDX_DIR/index-incremental.jsonl" "$IDX" <<'PY' || fail "index: round-trip mismatch"
+import json, sys
+def norm(path):
+    with open(path, encoding="utf-8") as f:
+        objs = [json.loads(l) for l in f if l.strip()]
+    return sorted(json.dumps(o, sort_keys=True, ensure_ascii=False) for o in objs)
+sys.exit(0 if norm(sys.argv[1]) == norm(sys.argv[2]) else 1)
+PY
+
+# 3-shape rebuild: pre-axis / 4-axis / 5-axis sections, incl. an escaped pipe
+SH="$TMP/shapes"; mkdir -p "$SH"
+cp fixtures/digest_shapes.md "$SH/digest.md"
+python3 "$SCRIPTS/append_digest.py" \
+  --digest "$SH/digest.md" --rebuild-index >/dev/null || fail "shapes: rebuild failed"
+SHIDX="$SH/digest-index.jsonl"
+[ "$(grep -c . "$SHIDX")" -eq 4 ] || fail "shapes: expected 4 scenario lines, got $(grep -c . "$SHIDX")"
+# escaped \| round-trips into the JSON value unescaped
+grep -q 'テスト | 大喜利' "$SHIDX" || fail "shapes: escaped pipe not unescaped in index"
+# pre-axis-column row carries a null axis
+jq -es 'map(select(.id=="shape_c_ok"))[0].axis == null' "$SHIDX" >/dev/null \
+  || fail "shapes: pre-axis-column row axis not null"
+
+# unrecognized table shape → rebuild hard-fails (non-zero) and writes nothing
+BG="$TMP/bogus"; mkdir -p "$BG"
+cat > "$BG/digest.md" <<'EOF'
+# Digest
+<!-- factory-digest:sections -->
+
+## 2026-06-13
+
+| id | name | theme | axis | status | (a) coherence | (z) bogus | comment |
+|---|---|---|---|---|---|---|---|
+| x | n | t | – | ok | 4 | 9 | c |
+
+<!-- factory-digest:promotion -->
+Promotion: x
+EOF
+if python3 "$SCRIPTS/append_digest.py" \
+  --digest "$BG/digest.md" --rebuild-index 2>/dev/null; then
+  fail "bogus: unrecognized rubric column should hard-fail"
+fi
+[ ! -f "$BG/digest-index.jsonl" ] || fail "bogus: index written despite hard-fail"
+
+# non-fatal index failure: a directory at the index path blocks the write;
+# the append still succeeds (digest is the source of truth)
+UW="$TMP/unwr"; mkdir -p "$UW"
+cp fixtures/digest_seed.md "$UW/digest.md"
+mkdir "$UW/digest-index.jsonl"   # a directory can't be overwritten by a file
+python3 "$SCRIPTS/append_digest.py" \
+  --results fixtures/results_sample.json --digest "$UW/digest.md" >/dev/null 2>"$UW/warn" \
+  || fail "index: unwritable index must not fail the append"
+grep -q "^## 2026-06-13$" "$UW/digest.md" || fail "index: digest not updated when index write fails"
+grep -q -- "--rebuild-index" "$UW/warn" || fail "index: failure warning must name --rebuild-index"
+
 # --- gallery_census.py ------------------------------------------------------
 C=$(python3 "$SCRIPTS/gallery_census.py" fixtures/gallery_census_sample.json)
 echo "$C" | grep -q "Suggested targets" || fail "census: suggested-targets section missing"

--- a/.claude/skills/scenario-refine/SKILL.md
+++ b/.claude/skills/scenario-refine/SKILL.md
@@ -77,7 +77,10 @@ Actually changing a shipped scenario is a SEPARATE, human-driven step (see
 2. `command -v jq` — required by the run wrapper and the helper scripts.
 3. `ls .claude/skills/scenario-factory/scripts/run_scenario.sh .claude/skills/scenario-factory/scripts/format_transcript.py`
    — abort if the borrowed factory scripts are gone (cross-skill dependency).
-4. `swift build` once to warm the harness build (incremental afterwards). A
+4. `ls .claude/skills/scenario-factory/PLAYBOOK.md` — abort if missing
+   (cross-skill dependency, same posture as the borrowed scripts above; Step 4
+   reads it for v2 authoring).
+5. `swift build` once to warm the harness build (incremental afterwards). A
    build failure aborts the cycle — report it, do not run.
 
 ## Step 1 — Select the rotation slice
@@ -200,10 +203,14 @@ For each chosen baseline:
 
 1. Read the baseline YAML (read-only). Diagnose the weakest axis from the
    transcript.
-2. Write a v2 targeting that axis to
+2. Read `.claude/skills/scenario-factory/PLAYBOOK.md` first — the v2 MUST
+   comply with its `[validated]` rules. A `[hypothesis]` rule is a legitimate
+   v2 lever (note in the candidate's comment when one is exercised, so the
+   journal can attribute a win/loss to it).
+3. Write a v2 targeting that axis to
    `data/factory/improvements/<DATE>/<id>__v2.yaml` with `id: <id>__v2`. Vary
    *mechanics* (persona differentiation, output-field constraints, round/topic
-   structure — see the factory's generation learnings), not just topic
+   structure — see the PLAYBOOK), not just topic
    strings. Keep the inference estimate ≤ 50 (the wrapper hard-blocks > 100).
    When varying `output` fields, keep the **canonical** names: primary =
    `statement`/`action`/`vote`, private-thought = `reason` for `vote` and
@@ -215,9 +222,9 @@ For each chosen baseline:
    `conditional` branch. Full authoring detail: the factory SKILL.md Step 2.
    **This is the only YAML the skill writes, and it goes under
    `data/factory/` — never next to the baseline.**
-3. Run it (Step 2 shape, into `audit-runs/<DATE>/<id>__v2.jsonl`) and judge it
+4. Run it (Step 2 shape, into `audit-runs/<DATE>/<id>__v2.jsonl`) and judge it
    (Step 3) with the baseline's `payoff_axis`.
-4. Record the candidate result with `candidate_of: "<baseline id>"` so the
+5. Record the candidate result with `candidate_of: "<baseline id>"` so the
    journal computes the A/B delta vs the same-run baseline (`vs base +N ✅`
    when it wins).
 
@@ -240,14 +247,28 @@ promotion — it stays in `improvements/`. See § Promotion.
 3. Verify: `grep -c 'audit-digest:' data/factory/audit-digest.md` prints `2`
    (both markers survived) and the new `## <DATE>` section exists.
 
+## Step 5.5 — Propose lessons (inbox)
+
+An A/B result is evidence too: it validates or refutes a design lesson, not
+just a scenario. If this cycle's A/B outcome (Step 4) confirms or refutes a
+lesson not already covered by a PLAYBOOK rule — or changes a rule's status
+(e.g. a `[hypothesis]` lever that won becomes `[validated]`) — append a dated,
+concept-level entry to `data/factory/lessons-inbox.md`, using the SAME entry
+shape and grep-before-append rule as `/scenario-factory` Step 5.5 (one-line
+reminder: `- <DATE> [candidate-status] <one-two sentence rule> (evidence:
+<ids>)`; see that section for the full spec). The inbox is a proposal queue
+only — refine never edits `PLAYBOOK.md`; promotion is the factory SKILL's
+§ Lessons promotion.
+
 ## Step 6 — Report
 
 Summarize for the user: per-scenario status + scores, **regressions (`⚠️`)
 called out first**, A/B candidate wins (`vs base +N ✅`) with where the YAML
 lives, failures with one-line causes, and where the artifacts are
-(`audit-runs/<DATE>/`, `improvements/<DATE>/`, the appended journal section).
-The journal is a gitignored local log — not committed or pushed. Only
-*promoting* a winner (§ Promotion) goes through `/orchestrate`.
+(`audit-runs/<DATE>/`, `improvements/<DATE>/`, the appended journal section,
+the `lessons-inbox.md` entries if any were proposed in Step 5.5). The journal
+is a gitignored local log — not committed or pushed. Only *promoting* a
+winner (§ Promotion) goes through `/orchestrate`.
 
 ## Promotion
 

--- a/.gitignore
+++ b/.gitignore
@@ -79,8 +79,10 @@ data/factory/improvements/
 # checkout's working tree stays clean; each skill's append_digest.py
 # bootstraps the file from a scaffold if absent.
 data/factory/digest.md
+data/factory/digest-index.jsonl
 data/factory/audit-digest.md
 data/queue/digest.md
+data/factory/lessons-inbox.md
 
 # Design-review screenshots — generated on demand by scripts/ui-tour.sh
 # (see docs/design/screenshots/README.md). Only the README is tracked.


### PR DESCRIPTION
## Summary

第2弾 of the "more interesting scenarios" mechanism (第1弾: #952/#955). The nightly generator now APPLIES distilled lessons instead of re-mining a 39k-token journal:

- **`PLAYBOOK.md`** (repo-tracked, factory skill dir) — 28 numbered, concept-level design rules distilled from ~6 nights of factory digest + 2 nights of refine journal, each tagged `[validated]` / `[hypothesis]` with digest-date evidence, plus a "saturated premise families" dedup section. Header binds the discipline: soft cap ~150 lines, concept-level register, refuted rules pruned to tombstones. Read every cycle as a generation gate (factory Step 1) and v2-authoring gate (refine Step 4).
- **`digest-index.jsonl` sidecar** (gitignored, rebuildable cache — `digest.md` stays source of truth) — `append_digest.py` derives it from in-memory results after each digest write (date-idempotent, fail-open with a `--rebuild-index` pointer; the nightly append can never fail on the cache). `--rebuild-index` re-parses the digest tables header-name-keyed across all three historical shapes (pre-axis / 4-axis / 5-axis), handles escaped `\|`, and hard-fails loudly on unknown shapes instead of writing a silently partial index. **Validated against the real 13-section digest: 39 rows parsed, 18.7 KB (~6k tokens) vs the 97 KB (~39k tokens) digest.**
- **Factory Step 1 restructure** — three-source read (PLAYBOOK gate → index full-history dedup → newest 2 digest sections only; never the full digest), with an explicit missing-index fallback (degraded dedup + operator notice, no over-cap Read).
- **`lessons-inbox.md`** (gitignored) — new Step 5.5 in both skills: validated/refuted lessons are proposed locally with grep-before-append dedup; promotion inbox→PLAYBOOK is a human `/orchestrate` PR (§ Lessons promotion), so the unattended cycle never edits the tracked playbook.
- `.gitignore` covers both new local files (the nightly Routine runs `acceptEdits` in the main checkout).

Pre-implementation critic warnings (source-of-truth posture, missing-index fallback, 3-shape parser fixtures, gitignore gap, playbook/inbox size discipline) all addressed. Opus code-reviewer PASS; both Warnings (fail-open `ValueError` path untested, multi-date accumulation unpinned) + all 3 Suggestions applied in the final commit.

## Test plan

- `bash .claude/skills/scenario-factory/tests/run_tests.sh` → ALL TESTS PASSED (new: index creation/comment-exclusion/same-date replace, incremental↔rebuild round-trip equivalence, 3-shape + escaped-pipe rebuild fixture, unknown-shape hard-fail writes nothing, unwritable-index and corrupt-index-line fail-open, multi-date accumulation + partial-scores normalization, empty-digest rebuild)
- `bash .claude/skills/scenario-refine/tests/run_tests.sh` → ALL TESTS PASSED (doc-only changes there)
- All 11 `scripts/tests/*-test.sh` shell-gate suites PASS locally; harness stays ubuntu-runnable (python3 + jq + git)
- `--rebuild-index` end-to-end against the operator's real digest: 13 sections / 39 scenario lines, no parse failures (index backfilled — tonight's Routine picks up the new flow on merge)
- No Swift changes — iOS build/tests not applicable

Closes #956

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZVKUxmi9jYkB1pj4vCw46
