### PR TITLE
✨ feat: harness --profile flag — CLI-selectable ModelProfile

### DIFF
--- a/tools/harness/Sources/PasturaHarnessKit/HarnessConfig.swift
+++ b/tools/harness/Sources/PasturaHarnessKit/HarnessConfig.swift
@@ -33,7 +33,7 @@ package struct HarnessConfig: Sendable, Equatable {
     usage: pastura-harness --scenario <path.yaml> --model <path.gguf> \
     [--out <path.jsonl>] [--timeout <seconds>] [--quiet] [--profile <id>]
     --profile selects prompt-format hints and must match the --model file's \
-    model family (default: gemma-4-e2b-q4-k-m)
+    model family (default: \(ModelProfile.gemma4E2B.id))
     """
 
   /// Parses CLI arguments (excluding argv[0]).

--- a/tools/harness/Sources/PasturaHarnessKit/HarnessConfig.swift
+++ b/tools/harness/Sources/PasturaHarnessKit/HarnessConfig.swift
@@ -24,10 +24,16 @@ package struct HarnessConfig: Sendable, Equatable {
   package var timeoutSeconds: Int = 1800
   /// Suppress per-event progress on stdout.
   package var quiet = false
+  /// Prompt-format profile applied to the `--model` GGUF. Defaults to
+  /// Gemma so existing callers (`run_scenario.sh`, scenario-refine) stay
+  /// unchanged.
+  package var profile: ModelProfile = .gemma4E2B
 
   package static let usage = """
     usage: pastura-harness --scenario <path.yaml> --model <path.gguf> \
-    [--out <path.jsonl>] [--timeout <seconds>] [--quiet]
+    [--out <path.jsonl>] [--timeout <seconds>] [--quiet] [--profile <id>]
+    --profile selects prompt-format hints and must match the --model file's \
+    model family (default: gemma-4-e2b-q4-k-m)
     """
 
   /// Parses CLI arguments (excluding argv[0]).
@@ -37,6 +43,7 @@ package struct HarnessConfig: Sendable, Equatable {
     var out: String?
     var timeout = 1800
     var quiet = false
+    var profile = ModelProfile.gemma4E2B
 
     var iterator = args.makeIterator()
     while let arg = iterator.next() {
@@ -44,13 +51,9 @@ package struct HarnessConfig: Sendable, Equatable {
       case "--scenario": scenario = try value(for: arg, from: &iterator)
       case "--model": model = try value(for: arg, from: &iterator)
       case "--out": out = try value(for: arg, from: &iterator)
-      case "--timeout":
-        let raw = try value(for: arg, from: &iterator)
-        guard let parsed = Int(raw), parsed > 0 else {
-          throw HarnessConfigError("--timeout must be a positive integer, got '\(raw)'")
-        }
-        timeout = parsed
+      case "--timeout": timeout = try parseTimeout(value(for: arg, from: &iterator))
       case "--quiet": quiet = true
+      case "--profile": profile = try parseProfile(value(for: arg, from: &iterator))
       default: throw HarnessConfigError("unknown argument '\(arg)'\n\(usage)")
       }
     }
@@ -59,7 +62,7 @@ package struct HarnessConfig: Sendable, Equatable {
     guard let model else { throw HarnessConfigError("--model is required\n\(usage)") }
     return HarnessConfig(
       scenarioPath: scenario, modelPath: model, outPath: out,
-      timeoutSeconds: timeout, quiet: quiet)
+      timeoutSeconds: timeout, quiet: quiet, profile: profile)
   }
 
   private static func value(
@@ -69,5 +72,21 @@ package struct HarnessConfig: Sendable, Equatable {
       throw HarnessConfigError("missing value for \(flag)\n\(usage)")
     }
     return value
+  }
+
+  private static func parseTimeout(_ raw: String) throws -> Int {
+    guard let parsed = Int(raw), parsed > 0 else {
+      throw HarnessConfigError("--timeout must be a positive integer, got '\(raw)'")
+    }
+    return parsed
+  }
+
+  private static func parseProfile(_ raw: String) throws -> ModelProfile {
+    guard let resolved = ModelProfile.named(raw) else {
+      let knownIDs = ModelProfile.all.map(\.id).joined(separator: ", ")
+      throw HarnessConfigError(
+        "unknown --profile '\(raw)' — known profiles: \(knownIDs)\n\(usage)")
+    }
+    return resolved
   }
 }

--- a/tools/harness/Sources/PasturaHarnessKit/ModelProfile.swift
+++ b/tools/harness/Sources/PasturaHarnessKit/ModelProfile.swift
@@ -7,6 +7,9 @@ import Foundation
 /// registry itself is App-layer, outside this package (ADR-013 §4). The
 /// pin test in `ModelProfileTests` guards drift between the two.
 package struct ModelProfile: Sendable, Equatable {
+  /// Registry id. Mirrors `ModelDescriptor.id` — the key accepted by the
+  /// harness `--profile` flag.
+  package let id: String
   /// Human-readable model label, used as `LlamaCppService.modelIdentifier`.
   package let name: String
   /// Stop sequence terminating each generation.
@@ -17,28 +20,78 @@ package struct ModelProfile: Sendable, Equatable {
   /// `<think>...</think>` prefill in the app registry is Qwen-only
   /// (see `.claude/rules/engine.md` § llama.cpp traps).
   package let assistantPrefix: String?
+  /// Expected GGUF file name, mirroring the registry's `fileName`. Used
+  /// ONLY for a non-fatal mismatch warning (`mismatchWarning(forModelPath:)`)
+  /// — never enforced, since operators may rename GGUF files locally.
+  package let expectedFileName: String
   /// Expected SHA-256 of the GGUF file. NOT hashed by the harness at run
   /// time (re-hashing ~3 GB nightly is wasteful); the operator verifies
   /// once via `shasum -a 256` when installing the model file.
   package let expectedSHA256: String
 
   package init(
-    name: String, stopSequence: String, systemPromptSuffix: String?,
-    assistantPrefix: String?, expectedSHA256: String
+    id: String, name: String, stopSequence: String, systemPromptSuffix: String?,
+    assistantPrefix: String?, expectedFileName: String, expectedSHA256: String
   ) {
+    self.id = id
     self.name = name
     self.stopSequence = stopSequence
     self.systemPromptSuffix = systemPromptSuffix
     self.assistantPrefix = assistantPrefix
+    self.expectedFileName = expectedFileName
     self.expectedSHA256 = expectedSHA256
   }
 
   /// Gemma 4 E2B Q4_K_M — the shipping on-device model (ADR-002).
   package static let gemma4E2B = ModelProfile(
+    id: "gemma-4-e2b-q4-k-m",
     name: "Gemma 4 E2B (Q4_K_M)",
     stopSequence: "<|im_end|>",
     systemPromptSuffix: nil,
     assistantPrefix: nil,
+    expectedFileName: "gemma-4-E2B-it-Q4_K_M.gguf",
     expectedSHA256: "ac0069ebccd39925d836f24a88c0f0c858d20578c29b21ab7cedce66ee576845"
   )
+
+  /// Qwen 3 4B Q4_K_M — second selectable on-device model (ADR-002 update).
+  package static let qwen34B = ModelProfile(
+    id: "qwen-3-4b-q4-k-m",
+    name: "Qwen 3 4B (Q4_K_M)",
+    stopSequence: "<|im_end|>",
+    systemPromptSuffix: "/no_think",
+    // Prefill the assistant turn with the empty-thinking marker so Qwen 3
+    // bypasses thinking mode entirely. Issue #366 — without this, Qwen
+    // emits `<think>` as its first sampled token and the GBNF grammar
+    // sampler crashes on `accept_token` (uncaught C++ exception). The
+    // `/no_think` system suffix above is a soft hint only and does not
+    // prevent the leading `<think>` token; this prefill is the
+    // load-bearing fix.
+    assistantPrefix: "<think>\n\n</think>\n\n",
+    expectedFileName: "Qwen3-4B-Q4_K_M.gguf",
+    expectedSHA256: "7485fe6f11af29433bc51cab58009521f205840f5b4ae3a32fa7f92e8534fdf5"
+  )
+
+  /// Known profiles the harness `--profile` flag can select, gemma first
+  /// as the default.
+  package static let all: [ModelProfile] = [gemma4E2B, qwen34B]
+
+  /// Looks up a known profile by its registry `id`, or `nil` if unknown.
+  package static func named(_ id: String) -> ModelProfile? {
+    all.first { $0.id == id }
+  }
+
+  /// Non-fatal warning when `path`'s file name doesn't match
+  /// `expectedFileName` (case-insensitive) — surfaces model↔profile
+  /// mismatches (the #366 crash class) without blocking renamed files.
+  /// Returns `nil` when the file name matches.
+  package func mismatchWarning(forModelPath path: String) -> String? {
+    let actualFileName = (path as NSString).lastPathComponent
+    guard actualFileName.caseInsensitiveCompare(expectedFileName) != .orderedSame else {
+      return nil
+    }
+    return
+      "Warning: model file \"\(actualFileName)\" does not match profile \"\(id)\"'s "
+      + "expected file name \"\(expectedFileName)\" — prompt-format hints (stop sequence, "
+      + "assistant prefill) may be wrong for this file; pass --profile explicitly to override."
+  }
 }

--- a/tools/harness/Sources/pastura-harness/Main.swift
+++ b/tools/harness/Sources/pastura-harness/Main.swift
@@ -36,6 +36,9 @@ enum Main {
     guard FileManager.default.fileExists(atPath: config.modelPath) else {
       throw HarnessConfigError("model file not found: \(config.modelPath)")
     }
+    if let warning = config.profile.mismatchWarning(forModelPath: config.modelPath) {
+      FileHandle.standardError.write(Data("\(warning)\n".utf8))
+    }
     let yaml = try String(contentsOfFile: config.scenarioPath, encoding: .utf8)
     let scenario = try ScenarioLoader().load(yaml: yaml)
 
@@ -44,7 +47,7 @@ enum Main {
     let outPath = config.outPath ?? defaultOutPath(runID: runID, at: now)
     let writer = try FileRunLogWriter(path: outPath)
 
-    let profile = ModelProfile.gemma4E2B
+    let profile = config.profile
     let llmFactory = makeLLMFactory(profile: profile, modelPath: config.modelPath)
     let quiet = config.quiet
     // if/else instead of `quiet ? nil : { ... }` — the ternary trips a

--- a/tools/harness/Tests/PasturaHarnessKitTests/HarnessConfigTests.swift
+++ b/tools/harness/Tests/PasturaHarnessKitTests/HarnessConfigTests.swift
@@ -52,4 +52,42 @@ struct HarnessConfigTests {
       ])
     }
   }
+
+  @Test func defaultsProfileToGemma() throws {
+    let config = try HarnessConfig.parse([
+      "--scenario", "s.yaml", "--model", "m.gguf"
+    ])
+    #expect(config.profile == .gemma4E2B)
+  }
+
+  @Test func parsesExplicitProfile() throws {
+    let config = try HarnessConfig.parse([
+      "--scenario", "s.yaml", "--model", "m.gguf",
+      "--profile", "qwen-3-4b-q4-k-m"
+    ])
+    #expect(config.profile == .qwen34B)
+  }
+
+  @Test func unknownProfileThrows() {
+    do {
+      _ = try HarnessConfig.parse([
+        "--scenario", "s.yaml", "--model", "m.gguf", "--profile", "bogus"
+      ])
+      Issue.record("expected HarnessConfigError")
+    } catch let error as HarnessConfigError {
+      #expect(error.message.contains("bogus"))
+      #expect(error.message.contains("gemma-4-e2b-q4-k-m"))
+      #expect(error.message.contains("qwen-3-4b-q4-k-m"))
+    } catch {
+      Issue.record("expected HarnessConfigError, got \(error)")
+    }
+  }
+
+  @Test func missingProfileValueThrows() {
+    #expect(throws: HarnessConfigError.self) {
+      try HarnessConfig.parse([
+        "--scenario", "s.yaml", "--model", "m.gguf", "--profile"
+      ])
+    }
+  }
 }

--- a/tools/harness/Tests/PasturaHarnessKitTests/ModelProfileTests.swift
+++ b/tools/harness/Tests/PasturaHarnessKitTests/ModelProfileTests.swift
@@ -10,6 +10,7 @@ struct ModelProfileTests {
   /// `ModelProfile.gemma4E2B` to match, deliberately.
   @Test func gemmaProfilePinsMatchAppRegistry() {
     let profile = ModelProfile.gemma4E2B
+    #expect(profile.id == "gemma-4-e2b-q4-k-m")
     #expect(profile.stopSequence == "<|im_end|>")
     #expect(profile.systemPromptSuffix == nil)
     // Gemma needs no assistant prefill — `<think>...` is Qwen-only.
@@ -18,5 +19,49 @@ struct ModelProfileTests {
       profile.expectedSHA256
         == "ac0069ebccd39925d836f24a88c0f0c858d20578c29b21ab7cedce66ee576845")
     #expect(profile.name == "Gemma 4 E2B (Q4_K_M)")
+    #expect(profile.expectedFileName == "gemma-4-E2B-it-Q4_K_M.gguf")
+  }
+
+  /// Drift guard against `App/ModelRegistry.qwen34B` (the registry is
+  /// App-layer, outside this package — a cross-reference comment alone is
+  /// not drift-proof). If this fails, the app registry changed: update
+  /// `ModelProfile.qwen34B` to match, deliberately.
+  @Test func qwenProfilePinsMatchAppRegistry() {
+    let profile = ModelProfile.qwen34B
+    #expect(profile.id == "qwen-3-4b-q4-k-m")
+    #expect(profile.name == "Qwen 3 4B (Q4_K_M)")
+    #expect(profile.stopSequence == "<|im_end|>")
+    #expect(profile.systemPromptSuffix == "/no_think")
+    #expect(profile.assistantPrefix == "<think>\n\n</think>\n\n")
+    #expect(profile.expectedFileName == "Qwen3-4B-Q4_K_M.gguf")
+    #expect(
+      profile.expectedSHA256
+        == "7485fe6f11af29433bc51cab58009521f205840f5b4ae3a32fa7f92e8534fdf5")
+  }
+
+  @Test func namedLooksUpKnownProfilesByID() {
+    #expect(ModelProfile.named("gemma-4-e2b-q4-k-m") == .gemma4E2B)
+    #expect(ModelProfile.named("qwen-3-4b-q4-k-m") == .qwen34B)
+    #expect(ModelProfile.named("bogus") == nil)
+  }
+
+  @Test func mismatchWarningIsNilOnExactFileNameMatch() {
+    let warning = ModelProfile.qwen34B.mismatchWarning(
+      forModelPath: "/Users/x/Models/Qwen3-4B-Q4_K_M.gguf")
+    #expect(warning == nil)
+  }
+
+  @Test func mismatchWarningIsNilOnCaseVariedFileName() {
+    let warning = ModelProfile.qwen34B.mismatchWarning(
+      forModelPath: "/Users/x/Models/qwen3-4b-q4_k_m.gguf")
+    #expect(warning == nil)
+  }
+
+  @Test func mismatchWarningFiresOnMismatchedFileName() {
+    let warning = ModelProfile.qwen34B.mismatchWarning(
+      forModelPath: "/Users/x/Models/gemma-4-E2B-it-Q4_K_M.gguf")
+    #expect(warning != nil)
+    #expect(warning?.contains("gemma-4-E2B-it-Q4_K_M.gguf") == true)
+    #expect(warning?.contains("qwen-3-4b-q4-k-m") == true)
   }
 }


### PR DESCRIPTION
## Summary
- `pastura-harness` (ADR-013) hardcoded `ModelProfile.gemma4E2B` in `Main.swift`, so any `--model` GGUF got Gemma's prompt-format assumptions. The profile is now CLI-selectable via `--profile <id>`.
- New `qwen34B` profile mirrors `App/ModelRegistry.qwen34B` (incl. the Issue #366 load-bearing `<think>\n\n</think>\n\n` assistant prefill), guarded by a pin test like the existing Gemma one.
- Backwards compatible: no `--profile` → Gemma default, so `run_scenario.sh` / scenario-refine work unchanged. Unknown id fails at parse time listing known ids (exit 2).
- Non-fatal stderr warning when the `--model` filename doesn't match the profile's expected file name — surfaces the model↔profile mismatch footgun (the #366 GBNF crash class) without blocking renamed files.

Stage 1 of the model validation & onboarding pipeline (next: Mac-side eval battery, onboarding doc, candidate intake).

## Test plan
- `swift test` from repo root: 29/29 pass (ModelProfileTests: gemma/qwen pin tests, `named(_:)` lookup incl. nil path, mismatch-warning match/case-insensitive/mismatch; HarnessConfigTests: default profile, explicit qwen, unknown-id error lists known ids, missing value).
- `swift build`: harness executable compiles with the config-driven profile.
- Pre-commit hook (swiftlint --strict + xcodebuild build) green on all commits.

Closes #968

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xrar57hsaQzgguMWxoq1YJ