### PR TITLE
📝 docs: model onboarding two-gate procedure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,5 +316,6 @@ same change:
 | `docs/design/design-system.md`        | Cross-screen design system (tokens, philosophy, components) |
 | `docs/design/demo-replay-reference.html` | DL-time demo visual reference prototype (HTML)             |
 | `docs/security/release-checklist.md`  | Operator security checklist (GitHub settings, iOS pre-submission audit, recurring review) |
+| `docs/models/onboarding.md`           | Model onboarding two-gate procedure (Stage-0 harness profile → `/model-eval` Mac filter → ADR-011 real-device accept → registration; intake #979) |
 | `docs/qa/navigation-qa.md`            | Navigation manual QA walkthroughs (scenarios 1–17; extracted from `.claude/rules/navigation.md`) |
 | `docs/prototype/among_them_prototype.py` | Python prototype (reference implementation) |

--- a/docs/models/onboarding.md
+++ b/docs/models/onboarding.md
@@ -36,8 +36,10 @@ candidate). Gate 2 is the sole gate that can **accept**.
 A candidate from a family not already in `ModelProfile.all` (today: `gemma` /
 `qwen`) needs a prior `tools/harness` PR — landed through `/orchestrate` — adding
 a `ModelProfile` static plus its pin test. The profile mirrors **7** load-bearing
-registry fields (`id`, `name`, `stopSequence`, `systemPromptSuffix`,
-`assistantPrefix`, `expectedFileName`, `expectedSHA256`); `ModelProfileTests`
+registry values under its own field names (`id`, `name`, `stopSequence`,
+`systemPromptSuffix`, `assistantPrefix`, `expectedFileName`, `expectedSHA256`;
+`name` / `expectedFileName` / `expectedSHA256` map to the registry's
+`displayName` / `fileName` / `sha256`); `ModelProfileTests`
 pins them against the future/planned `ModelRegistry` values so the harness and
 app never drift.
 
@@ -111,8 +113,8 @@ Then, in the same `/orchestrate` run:
 - **`LicenseCatalog` entry** — add the model's license block
   (`Pastura/Pastura/Views/Settings/LicenseCatalog.swift`).
 - **README mirror** — update "Supported LLM models" per CLAUDE.md § Reference
-  Documents ("Bundled models (`ModelRegistry.swift`) → README 'Supported LLM
-  models'").
+  Documents (Bundled models (`ModelRegistry.swift`) → README "Supported LLM
+  models").
 - **Real-device QA** — confirm inference on a real device (Metal and
   memory-pressure behavior is not reproduced by the Mac harness or the
   simulator — the reason Gate 2 exists at all, per ADR-011).

--- a/docs/models/onboarding.md
+++ b/docs/models/onboarding.md
@@ -1,0 +1,136 @@
+# Model Onboarding
+
+The committed procedure for onboarding a new GGUF model candidate into the
+Pastura catalog (`ModelRegistry`). It is **pointer-heavy by design**: each stage
+names its canonical source and defers the mechanism to it. On any conflict, the
+pointed-to source wins over this page — treat the citations, not this summary,
+as authoritative.
+
+`docs/models/` (this file) is the committed process. It is distinct from
+`data/models/` — the `/model-eval` skill's **gitignored** eval artifacts
+(`eval-runs/` raw logs, `eval-digest.md` scorecard journal), which are local,
+never committed, and never reach users.
+
+## End-to-end flow
+
+```
+Stage 0  harness ModelProfile PR (new family only)
+   │
+Gate 1   /model-eval  — cheap Mac filter (足切り)
+   │        ├─ reject ──▶ record candidate + failure mode (stop)
+   │        └─ borderline ──▶ re-sample weak cell(s), re-judge (never reject on one sample)
+   │        (pass = ADVANCE only; it cannot accept)
+   ▼
+Gate 2   ADR-011 real-device PoC — the ONLY accept path
+   │        └─ no-go ──▶ record candidate + failure mode (stop)
+   ▼
+Registration  (/orchestrate: descriptor + mirrors + device QA)
+```
+
+Gate 1 can **reject** cheaply or return **borderline** (→ re-sample per the
+skill's asymmetric verdict — one unlucky single-run sample must never discard a
+candidate). Gate 2 is the sole gate that can **accept**.
+
+## Stage 0 — Harness profile (new model family only)
+
+A candidate from a family not already in `ModelProfile.all` (today: `gemma` /
+`qwen`) needs a prior `tools/harness` PR — landed through `/orchestrate` — adding
+a `ModelProfile` static plus its pin test. The profile mirrors **7** load-bearing
+registry fields (`id`, `name`, `stopSequence`, `systemPromptSuffix`,
+`assistantPrefix`, `expectedFileName`, `expectedSHA256`); `ModelProfileTests`
+pins them against the future/planned `ModelRegistry` values so the harness and
+app never drift.
+
+Budget **one** investigation round per new family for prompt-template traps.
+llama.cpp's `llama_chat_apply_template` reads the GGUF-embedded chat template, so
+no per-model Swift formatting code is ever needed — only the hook values
+(`systemPromptSuffix` / `assistantPrefix`). Case study: Qwen (#366) needed the
+`<think>\n\n</think>\n\n` assistant prefill because a thinking-mode model emits a
+leading `<think>` that crashes the GBNF grammar sampler; the `/no_think` suffix
+alone is only a soft hint. The mechanism's source of truth is
+`.claude/rules/engine.md` § "Grammar sampler does not mask special tokens" — do
+not re-derive it here.
+
+## Gate 1 — Mac filter (`/model-eval`)
+
+Run `/model-eval <gguf-path> <profile-id>`. The skill's SKILL.md § "Positioning"
+is canonical; it defines the gate. Key properties only:
+
+- It can **REJECT** an unfit candidate cheaply, but **cannot accept** — a pass
+  only *advances* to Gate 2. A Mac pass must never be reported as "adopted".
+- **Borderline** (one weak/failed cell) → re-sample the weak cell(s), never
+  reject on a single unlucky run (asymmetric, variance-aware verdict).
+- There is **no** tok/s or rubric-total pass number by design (mechanism
+  contract, not a pinned threshold).
+
+Metadata note: the two integrity fields you will later pin (`sha256`,
+`fileSize`) come authoritatively from `curl -sIL` on the HF resolve URL — the
+`X-Linked-Size` / `X-Linked-ETag` headers — with no on-device PoC needed for
+those two values.
+
+## Gate 2 — Real-device accept (ADR-011)
+
+Clear **all five** prerequisites in
+`docs/decisions/ADR-011.md` § Decision, item 2 ("Hard prerequisites for any
+future 6 GB tier candidate"). That list is the source of truth and is
+**deliberately not restated here** — it is a mechanism contract that will be
+edited when the backend changes (e.g. LiteRT-LM). One-line gloss of what the five
+cover: non-gated GGUF source; correct CONTROL token-type flags; on-device GBNF
+PoC on ≥ 2 presets; no regression on the existing catalog; no raw prompt-token
+sampler-accept on a grammar chain.
+
+This is the **only** accept path. Echoing the skill: a Mac-filter pass must never
+be reported as adopted — adoption happens here, on real-device PoC, or not at
+all.
+
+## Registration checklist (after Gate 2 — via `/orchestrate`)
+
+Add a `ModelDescriptor` to `ModelRegistry.catalog`. Field map, read from the
+init in `Pastura/Pastura/App/ModelRegistry.swift`:
+
+| Field | Notes |
+|---|---|
+| `id` | Stable catalog id; also the `--profile` / `ModelProfile.id`. |
+| `displayName` / `shortDisplayName` | Full + compact labels. |
+| `vendor` / `vendorURL` | Publisher name + site. |
+| `downloadURL` | **Pins a specific HF commit SHA** (`resolve/<commit>/...`), not `main`. |
+| `fileName` | GGUF filename; unique across the catalog. |
+| `fileSize` / `sha256` | From `curl -sIL` `X-Linked-Size` / `X-Linked-ETag` (Gate 1 note). |
+| `stopSequence` | Prompt-format field — must match the Stage-0 profile. |
+| `minRAM` | Device RAM floor. |
+| `modelInfoURL` | HF model card. |
+| `systemPromptSuffix` | Prompt-format field — must match the profile (`nil` for none). |
+| `assistantPrefix` | Prompt-format field — Qwen-only today (thinking-mode prefill); omit if unused. |
+| `tagline` | **One** `String(localized:)` literal (not two source strings); its `ja` translation lands in `Localizable.xcstrings`. |
+
+Then, in the same `/orchestrate` run:
+
+- **Prompt-format handoff.** The three format fields (`stopSequence`,
+  `systemPromptSuffix`, `assistantPrefix`) must agree with the Stage-0
+  `ModelProfile`; the pin test enforces the harness side.
+- **`LicenseCatalog` entry** — add the model's license block
+  (`Pastura/Pastura/Views/Settings/LicenseCatalog.swift`).
+- **README mirror** — update "Supported LLM models" per CLAUDE.md § Reference
+  Documents ("Bundled models (`ModelRegistry.swift`) → README 'Supported LLM
+  models'").
+- **Real-device QA** — confirm inference on a real device (Metal and
+  memory-pressure behavior is not reproduced by the Mac harness or the
+  simulator — the reason Gate 2 exists at all, per ADR-011).
+
+## Curation policy
+
+The catalog stays curated at **3–5 models**. A slot is earned by **distinct
+character** (input: the `/model-eval` scorecard's `differentiation` field), not
+by a marginally higher score — a model that merely duplicates an incumbent's
+character earns no slot even with decent numbers. Each model also costs
+~2.5–3.1 GB on device, so the ceiling is a real cost, not a style preference.
+
+## Recording outcomes
+
+- **Pass (through Gate 2)** → the registration PR above.
+- **No-go / reject (either gate)** → record the candidate and its failure mode
+  following ADR-011 § "Alternatives considered" (the Candidate A–F table
+  pattern). Comment on the intake queue, **issue #979**
+  ("model candidates — rolling intake for the validation pipeline"), and — if the
+  candidate is a 6 GB-tier one ADR-011 already tracks — amend its candidate
+  table in the same `/orchestrate` PR.


### PR DESCRIPTION
## Summary
- New `docs/models/onboarding.md`: the committed procedure for onboarding a new GGUF model candidate — Stage 0 harness `ModelProfile` registration (PR #970 pattern, one investigation round budgeted per family for prompt-template traps like Qwen #366) → Gate 1 Mac filter (`/model-eval`, reject-only) → Gate 2 real-device accept (ADR-011 prerequisites) → registration checklist (full 15-field `ModelDescriptor` map incl. commit-pinned `downloadURL`, prompt-format handoff, single-`tagline` i18n shape, `LicenseCatalog`, README mirror, device QA) → curation policy (3–5 slots by distinct character) → no-go recording path (#979 + ADR-011 candidates-table pattern).
- **Pointer-heavy by design** (plan-critic direction): gate semantics stay canonical at `/model-eval` SKILL.md § Positioning and ADR-011's prerequisites — the doc names its sources and states that they win on conflict, so it survives the LiteRT-LM mechanism swap without drifting.
- CLAUDE.md Reference Documents table gains the corresponding row.

Stage 3 (final tooling stage) of the model validation & onboarding pipeline (#968→#970, #975→#978, intake #979).

## Test plan
- Docs-only diff (no runtime surface). All cited headings grep-verified verbatim against current sources (ADR-011 prerequisites + "Alternatives considered", engine.md "Grammar sampler does not mask special tokens", SKILL.md "Positioning", CLAUDE.md mapping); `ModelDescriptor` 15-field table and `ModelProfile` 7-field list transcribed from source; issue refs #366/#979 verified via `gh issue view`.
- Plan critic (Opus) + code-reviewer (Opus): PASS, 2 cosmetic suggestions applied.

Closes #980

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xrar57hsaQzgguMWxoq1YJ