### PR TITLE
📝 docs: fix -destination re-pass semantics in xcodebuild-cli rules

### DIFF
--- a/.claude/rules/xcodebuild-cli.md
+++ b/.claude/rules/xcodebuild-cli.md
@@ -53,7 +53,7 @@ The wrapper auto-supplies `-scheme`, `-project`, `-destination`, and
 | `-scheme` | **Rejected** — `error: option '-scheme' may only be provided once` |
 | `-project` | **Rejected** — same |
 | `-derivedDataPath` | **Rejected** — same |
-| `-destination` | **Accepted** — last-wins, intentional override per wrapper §"Caller passthrough / flag override" |
+| `-destination` | **Accepted but ADDITIVE, not last-wins** — see below |
 
 xcodebuild prints the rejection error followed by its full usage page
 (exit 64). The error line lands between the wrapper's xtrace and the
@@ -61,6 +61,23 @@ usage page, so it is easy to miss — the failure looks like a wrapper
 bug. Forward only what the wrapper does not supply: typically just
 `-only-testing` / `-skip-testing` / `--tail N` (the last is wrapper-only,
 consumed before xcodebuild is invoked).
+
+**`-destination` is additive for `test`, NOT last-wins.** xcodebuild runs
+the suite on **every** `-destination` given. The wrapper already supplies its
+own `-destination` (from `sim-dest.sh`, default iPhone 17 Pro), so appending a
+second one runs the tests on **both** devices — and a failure on the extra
+device aborts the whole run (exit 65). Do **not** re-pass `-destination` to
+"override" the wrapper's simulator. To pin a **single** simulator, set the
+`PASTURA_SIM_NAME` env var (added to `sim-dest.sh` in #977), which replaces the
+priority list with that one device so the wrapper emits the right lone
+`-destination`:
+
+```bash
+PASTURA_SIM_NAME="iPhone 17 Pro Max" scripts/xcodebuild.sh test …
+```
+
+(`scripts/store-shots.sh` uses this to force the 6.9″ device for App Store
+screenshots.)
 
 ## When to use what
 

--- a/.claude/rules/xcodebuild-cli.md
+++ b/.claude/rules/xcodebuild-cli.md
@@ -68,16 +68,19 @@ own `-destination` (from `sim-dest.sh`, default iPhone 17 Pro), so appending a
 second one runs the tests on **both** devices — and a failure on the extra
 device aborts the whole run (exit 65). Do **not** re-pass `-destination` to
 "override" the wrapper's simulator. To pin a **single** simulator, set the
-`PASTURA_SIM_NAME` env var (added to `sim-dest.sh` in #977), which replaces the
+`PASTURA_SIM_NAME` env var (honored by `sim-dest.sh`), which replaces the
 priority list with that one device so the wrapper emits the right lone
-`-destination`:
+`-destination`. `export` it on its own line — the leading-assignment form
+(`PASTURA_SIM_NAME=… scripts/xcodebuild.sh …`) trips the allowlist approval
+prompt, per § "Canonical invocation":
 
 ```bash
-PASTURA_SIM_NAME="iPhone 17 Pro Max" scripts/xcodebuild.sh test …
+export PASTURA_SIM_NAME="iPhone 17 Pro Max"
+scripts/xcodebuild.sh test …
 ```
 
-(`scripts/store-shots.sh` uses this to force the 6.9″ device for App Store
-screenshots.)
+(`scripts/store-shots.sh` uses this `export` form to force the 6.9″ device for
+App Store screenshots.)
 
 ## When to use what
 


### PR DESCRIPTION
## Summary

`.claude/rules/xcodebuild-cli.md` § "Re-passing wrapper-supplied flags" claimed
`xcodebuild test`'s `-destination` flag is **"last-wins, intentional override"**.
That is **wrong**: `xcodebuild test` is **additive** — it runs the suite on
**every** `-destination` given. The wrapper (`scripts/xcodebuild.sh`) already
supplies its own `-destination` (from `sim-dest.sh`, default iPhone 17 Pro), so
appending a second one runs the tests on **both** devices, and a failure on the
extra device aborts the whole run (exit 65). Hit for real once.

## Changes

- Correct the `-destination` table row: **Accepted but ADDITIVE, not last-wins**.
- Add a paragraph documenting the additive behavior and the correct workaround —
  the `PASTURA_SIM_NAME` env var (honored by `sim-dest.sh`) pins a single
  simulator so the wrapper emits exactly one `-destination`.
- Use the `export`-on-its-own-line form in the example (matching
  `scripts/store-shots.sh`); the leading-assignment shape trips the allowlist
  approval prompt documented in § "Canonical invocation".

The rule now agrees with `sim-dest.sh`'s and `store-shots.sh`'s own inline
comments, which already documented the additive-not-last-wins behavior.

## Test plan

Docs-only change to one always-loaded rules file. All factual claims verified
against `scripts/sim-dest.sh` (L28–34) and `scripts/store-shots.sh` (L23–28);
cross-referenced heading § "Canonical invocation" confirmed present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013newjtFy1B2g5Me7KFxTj4