### PR TITLE
♻️ refactor: de-localize the Engine run path (S0.1, #501)

### DIFF
--- a/Pastura/Pastura/Engine/LanguageDispatch.swift
+++ b/Pastura/Pastura/Engine/LanguageDispatch.swift
@@ -15,8 +15,9 @@ import Foundation
 ///
 /// **Layer note (D8 normative):** Engine reads `scenario.engineLanguage`
 /// only, never `Bundle.main.preferredLocalizations`. This helper is
-/// intentionally independent of `String(localized:)`, which would
-/// resolve against device locale and break the cross-language goal.
+/// intentionally independent of any device-locale string lookup, which
+/// would resolve against the device locale and break the cross-language
+/// goal.
 ///
 /// The `ja` / `en` parameter names match the resolved language values
 /// verbatim so callsites read as a Translation Table row

--- a/Pastura/Pastura/Engine/ScenarioLoader.swift
+++ b/Pastura/Pastura/Engine/ScenarioLoader.swift
@@ -58,7 +58,7 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
     guard let raw = try? Yams.load(yaml: stripped),
       let dict = raw as? [String: Any]
     else {
-      throw validationError(String(localized: "Invalid YAML format"))
+      throw validationError(.invalidYAMLFormat)
     }
 
     return try mapToScenario(dict)
@@ -135,13 +135,13 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
     _ dict: [String: Any], key: String, label: String
   ) throws -> T {
     guard let raw = dict[key] else {
-      throw validationError(
-        String(localized: "%@: missing required field '%@'"), label, key)
+      throw validationError(.missingRequiredField(label: label, key: key))
     }
     guard let typed = raw as? T else {
       throw validationError(
-        String(localized: "%@: field '%@' must be %@, got %@"),
-        label, key, String(describing: T.self), String(describing: type(of: raw)))
+        .fieldWrongType(
+          label: label, key: key, expected: String(describing: T.self),
+          got: String(describing: type(of: raw))))
     }
     return typed
   }
@@ -157,8 +157,9 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
     guard let raw = dict[key] else { return nil }
     guard let typed = raw as? T else {
       throw validationError(
-        String(localized: "%@: field '%@' must be %@, got %@"),
-        label, key, String(describing: T.self), String(describing: type(of: raw)))
+        .fieldWrongType(
+          label: label, key: key, expected: String(describing: T.self),
+          got: String(describing: type(of: raw))))
     }
     return typed
   }
@@ -187,8 +188,7 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
       return Double(int)
     }
     throw validationError(
-      String(localized: "%@: field '%@' must be Double or Int, got %@"),
-      label, key, String(describing: type(of: raw)))
+      .fieldNotDoubleOrInt(label: label, key: key, got: String(describing: type(of: raw))))
   }
 
   /// Maps a raw YAML dictionary to a ``Scenario`` model.
@@ -199,19 +199,14 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
     let language: String = try parseRequired(dict, key: "language", label: "Scenario")
     guard Scenario.acceptedLanguages.contains(language) else {
       let allowed = Scenario.acceptedLanguages.sorted().joined(separator: ", ")
-      throw validationError(
-        String(localized: "Scenario: field 'language' must be one of {%@}, got '%@'"),
-        allowed, language)
+      throw validationError(.languageNotAccepted(allowed: allowed, got: language))
     }
     let simulationLanguage: String? = try parseOptional(
       dict, key: "simulation_language", label: "Scenario")
     if let simulationLanguage, !Scenario.acceptedLanguages.contains(simulationLanguage) {
       let allowed = Scenario.acceptedLanguages.sorted().joined(separator: ", ")
       throw validationError(
-        String(
-          localized: "Scenario: field 'simulation_language' must be one of {%@} or absent, got '%@'"
-        ),
-        allowed, simulationLanguage)
+        .simulationLanguageYAMLNotAccepted(allowed: allowed, got: simulationLanguage))
     }
     let agentCount: Int = try parseRequired(dict, key: "agents", label: "Scenario")
     let rounds: Int = try parseRequired(dict, key: "rounds", label: "Scenario")
@@ -229,8 +224,7 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
     let personas = try personasRaw.map { try mapPersona($0) }
     if personas.count != agentCount {
       throw validationError(
-        String(localized: "agents (%lld) does not match personas count (%lld)"),
-        agentCount, personas.count)
+        .agentsPersonasCountMismatch(agentCount: agentCount, personaCount: personas.count))
     }
 
     let phases = try phasesRaw.enumerated().map { index, raw in
@@ -277,9 +271,7 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
       return nil
     }
     guard let parsed = AssignTarget(rawValue: str) else {
-      throw validationError(
-        String(localized: "%@ has invalid target: '%@'. Use 'all' or 'random_one'."),
-        label, str)
+      throw validationError(.invalidTarget(label: label, value: str))
     }
     return parsed
   }
@@ -289,9 +281,7 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
       return nil
     }
     guard let parsed = PairingStrategy(rawValue: str) else {
-      throw validationError(
-        String(localized: "%@ has invalid pairing: '%@'. Use 'round_robin'."),
-        label, str)
+      throw validationError(.invalidPairing(label: label, value: str))
     }
     return parsed
   }
@@ -302,9 +292,7 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
     }
     guard let parsed = ScoreCalcLogic(rawValue: str) else {
       let allowed = ScoreCalcLogic.allCases.map(\.rawValue).joined(separator: ", ")
-      throw validationError(
-        String(localized: "%@ has invalid logic: '%@'. Expected one of: %@."),
-        label, str, allowed)
+      throw validationError(.invalidLogic(label: label, value: str, allowed: allowed))
     }
     return parsed
   }
@@ -389,15 +377,14 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
     guard let raw = dict["action_deltas"] else { return nil }
     guard let map = raw as? [String: Any] else {
       throw validationError(
-        String(localized: "%@: field 'action_deltas' must be a dictionary of Int values, got %@"),
-        label, String(describing: type(of: raw)))
+        .actionDeltasNotDict(label: label, got: String(describing: type(of: raw))))
     }
     var result: [String: Int] = [:]
     for (key, value) in map {
       guard let intValue = value as? Int, !(value is Bool) else {
         throw validationError(
-          String(localized: "%@: action_deltas value for '%@' must be Int, got %@"),
-          label, key, String(describing: type(of: value)))
+          .actionDeltasValueNotInt(
+            label: label, key: key, got: String(describing: type(of: value))))
       }
       result[key] = intValue
     }
@@ -408,18 +395,13 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
     _ dict: [String: Any], label: String, depth: Int
   ) throws -> PhaseType {
     guard let typeString = dict["type"] as? String else {
-      throw validationError(String(localized: "%@ missing 'type'"), label)
+      throw validationError(.phaseMissingType(label: label))
     }
     guard let phaseType = PhaseType(rawValue: typeString) else {
-      throw validationError(
-        String(localized: "%@ has invalid type: '%@'"), label, typeString)
+      throw validationError(.phaseInvalidType(label: label, value: typeString))
     }
     if phaseType == .conditional && depth > 0 {
-      throw validationError(
-        String(
-          localized:
-            "%@: nested 'conditional' inside another conditional is not allowed (depth-1 rule)."),
-        label)
+      throw validationError(.nestedConditionalNotAllowed(label: label))
     }
     return phaseType
   }
@@ -432,16 +414,13 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
   ) throws -> [String: String]? {
     guard let raw = dict["output"] else { return nil }
     guard let output = raw as? [String: Any] else {
-      throw validationError(
-        String(localized: "%@: field 'output' must be a dictionary of String values, got %@"),
-        label, String(describing: type(of: raw)))
+      throw validationError(.outputNotDict(label: label, got: String(describing: type(of: raw))))
     }
     var result: [String: String] = [:]
     for (key, value) in output {
       guard let str = value as? String else {
         throw validationError(
-          String(localized: "%@: output schema value for '%@' must be String, got %@"),
-          label, key, String(describing: type(of: value)))
+          .outputValueNotString(label: label, key: key, got: String(describing: type(of: value))))
       }
       result[key] = str
     }
@@ -453,9 +432,7 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
   ) throws -> [Phase]? {
     guard let phasesRaw = raw else { return nil }
     guard let list = phasesRaw as? [[String: Any]] else {
-      throw validationError(
-        String(localized: "%@: '%@' must be an array of phase objects"),
-        parentLabel, branchLabel)
+      throw validationError(.branchNotArray(label: parentLabel, branch: branchLabel))
     }
     return try list.enumerated().map { subIndex, subRaw in
       try mapPhase(
@@ -487,50 +464,34 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
       // Array of dicts where any value isn't a String — previously stringified
       // silently, which hid typos like `majority: 1`.
       if arr.allSatisfy({ $0 is [String: Any] }) {
-        throw validationError(
-          String(
-            localized:
-              "Top-level field '%@': array-of-dict values must all be String. Quote non-string values (e.g. `majority: \"1\"`)."
-          ),
-          key)
+        throw validationError(.extraDataArrayOfDictNotString(key: key))
       }
       if arr.allSatisfy({ $0 is String }) {
         return .array(arr.compactMap { $0 as? String })
       }
-      throw validationError(
-        String(
-          localized:
-            "Top-level field '%@': mixed-type arrays are not supported. Use a pure [String] or [[String: String]]."
-        ),
-        key)
+      throw validationError(.extraDataMixedArray(key: key))
     }
     if let dict = value as? [String: String] {
       return .dictionary(dict)
     }
     if value is [String: Any] {
-      throw validationError(
-        String(
-          localized:
-            "Top-level field '%@': dictionary values must all be String. Quote non-string values."),
-        key)
+      throw validationError(.extraDataDictNotString(key: key))
     }
     throw validationError(
-      String(localized: "Top-level field '%@' has unsupported type %@. Supported shapes: %@."),
-      key, String(describing: type(of: value)), Self.supportedExtraDataShapes)
+      .extraDataUnsupportedType(
+        key: key, got: String(describing: type(of: value)), shapes: Self.supportedExtraDataShapes))
   }
 }
 
-/// Builds a ``SimulationError/scenarioValidationFailed(_:)`` from a localized
-/// format string and its arguments. Collapses the `String(format:)` wrapper at
-/// every call site so each throw stays a single `String(localized:)` literal —
-/// xcstringstool still extracts it as Form B (see `.claude/rules/i18n.md`).
+/// Wraps a ``ScenarioValidationMessage`` in
+/// ``SimulationError/scenarioValidationFailed(_:)``, rendering it at the Models
+/// layer so the loader run path stays free of Foundation string localization
+/// and formatting (KMP Phase 3.0 port prep, #501).
 ///
 /// File-scope (not a method) so it stays out of `ScenarioLoader`'s
 /// `type_body_length` budget; `nonisolated` because top-level functions inherit
 /// `MainActor` under `SWIFT_DEFAULT_ACTOR_ISOLATION` and the `nonisolated`
 /// loader calls it synchronously.
-nonisolated private func validationError(
-  _ format: String, _ arguments: CVarArg...
-) -> SimulationError {
-  .scenarioValidationFailed(String(format: format, arguments: arguments))
+nonisolated private func validationError(_ message: ScenarioValidationMessage) -> SimulationError {
+  .scenarioValidationFailed(message.localized)
 }

--- a/Pastura/Pastura/Engine/ScenarioValidator+CanonicalFields.swift
+++ b/Pastura/Pastura/Engine/ScenarioValidator+CanonicalFields.swift
@@ -51,8 +51,7 @@ nonisolated extension ScenarioValidator {
     let schema = phase.outputSchema ?? [:]
     if schema[canonical] == nil {
       throw validationError(
-        String(localized: "%@ (%@) requires field '%@' in output."),
-        label, phase.type.rawValue, canonical)
+        .requiresOutputField(label: label, type: phase.type.rawValue, field: canonical))
     }
   }
 
@@ -78,8 +77,8 @@ nonisolated extension ScenarioValidator {
     for key in OutputSchema.knownSecondaryKeys
     where schema[key] != nil && key != canonical {
       throw validationError(
-        String(localized: "%@ (%@) secondary field must be '%@', not '%@'."),
-        label, phase.type.rawValue, canonical, key)
+        .secondaryFieldMismatch(
+          label: label, type: phase.type.rawValue, canonical: canonical, key: key))
     }
   }
 
@@ -96,11 +95,8 @@ nonisolated extension ScenarioValidator {
 
 /// File-scope copy of the main file's `validationError`, kept `private` so it
 /// does not collide with the same-named helpers in `ScenarioValidator.swift`
-/// and `ScenarioLoader.swift` at module scope. Same Form-B i18n contract — the
-/// `String(localized:)` literal stays a single extractable key
-/// (see `.claude/rules/i18n.md`).
-nonisolated private func validationError(
-  _ format: String, _ arguments: CVarArg...
-) -> SimulationError {
-  .scenarioValidationFailed(String(format: format, arguments: arguments))
+/// and `ScenarioLoader.swift` at module scope. Renders the
+/// ``ScenarioValidationMessage`` at the Models layer (#501).
+nonisolated private func validationError(_ message: ScenarioValidationMessage) -> SimulationError {
+  .scenarioValidationFailed(message.localized)
 }

--- a/Pastura/Pastura/Engine/ScenarioValidator+EventInject.swift
+++ b/Pastura/Pastura/Engine/ScenarioValidator+EventInject.swift
@@ -32,20 +32,10 @@ nonisolated extension ScenarioValidator {
   ) throws {
     let sourceKey = (phase.source ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
     guard !sourceKey.isEmpty else {
-      throw validationError(
-        String(
-          localized:
-            "%@: missing 'source'. event_inject requires a 'source' key naming a top-level YAML field that lists the event strings."
-        ),
-        label)
+      throw validationError(.eventInjectMissingSource(label: label))
     }
     guard let sourceValue = scenario.extraData[sourceKey] else {
-      throw validationError(
-        String(
-          localized:
-            "%@: source '%@' not found in scenario data. Add a top-level '%@' field to the scenario YAML."
-        ),
-        label, sourceKey, sourceKey)
+      throw validationError(.sourceNotFound(label: label, source: sourceKey))
     }
     switch sourceValue {
     case .array(let entries):
@@ -54,22 +44,12 @@ nonisolated extension ScenarioValidator {
       // a curator cannot distinguish from a string of unlucky rolls. Reject
       // early so the misconfiguration surfaces at scenario load.
       guard !entries.isEmpty else {
-        throw validationError(
-          String(
-            localized:
-              "%@: source '%@' is empty. event_inject requires at least one string in the list; for a single fixed event use ['only_event']."
-          ),
-          label, sourceKey)
+        throw validationError(.eventInjectSourceEmptyStrings(label: label, source: sourceKey))
       }
     case .arrayOfDictionaries(let entries):
       try validateDictEventEntries(entries, sourceKey: sourceKey, label: label)
     case .string, .dictionary:
-      throw validationError(
-        String(
-          localized:
-            "%@: source '%@' must be a list of event strings or {text, favors} mappings; for a single fixed event use ['only_event']."
-        ),
-        label, sourceKey)
+      throw validationError(.eventInjectSourceWrongShape(label: label, source: sourceKey))
     }
     try validateEventProbability(phase.probability, label: label)
   }
@@ -82,21 +62,11 @@ nonisolated extension ScenarioValidator {
     _ entries: [[String: String]], sourceKey: String, label: String
   ) throws {
     guard !entries.isEmpty else {
-      throw validationError(
-        String(
-          localized:
-            "%@: source '%@' is empty. event_inject requires at least one event in the list; for a single fixed event use ['only_event']."
-        ),
-        label, sourceKey)
+      throw validationError(.eventInjectSourceEmptyEvents(label: label, source: sourceKey))
     }
     for entry in entries
     where (entry["text"] ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-      throw validationError(
-        String(
-          localized:
-            "%@: source '%@' has an event entry missing a non-empty 'text'. Dict-shaped events require 'text' (and may add 'favors')."
-        ),
-        label, sourceKey)
+      throw validationError(.eventInjectEntryMissingText(label: label, source: sourceKey))
     }
   }
 
@@ -106,9 +76,7 @@ nonisolated extension ScenarioValidator {
     guard let probability else { return }
     guard (0.0...1.0).contains(probability) else {
       throw validationError(
-        String(
-          localized: "%@: probability %@ is out of range. Must be between 0.0 and 1.0 inclusive."),
-        label, String(probability))
+        .eventInjectProbabilityOutOfRange(label: label, probability: String(probability)))
     }
   }
 }
@@ -117,8 +85,6 @@ nonisolated extension ScenarioValidator {
 // file's same-named helper, mirroring `ScenarioValidator+CanonicalFields.swift`.
 // A module-scope `internal` version would collide with `ScenarioLoader`'s
 // same-named helper.
-nonisolated private func validationError(
-  _ format: String, _ arguments: CVarArg...
-) -> SimulationError {
-  .scenarioValidationFailed(String(format: format, arguments: arguments))
+nonisolated private func validationError(_ message: ScenarioValidationMessage) -> SimulationError {
+  .scenarioValidationFailed(message.localized)
 }

--- a/Pastura/Pastura/Engine/ScenarioValidator+OutputFieldNames.swift
+++ b/Pastura/Pastura/Engine/ScenarioValidator+OutputFieldNames.swift
@@ -26,13 +26,7 @@ nonisolated extension ScenarioValidator {
     guard let schema = phase.outputSchema else { return }
     for name in schema.keys.sorted() where !ScenarioConventions.isValidFieldName(name) {
       throw SimulationError.scenarioValidationFailed(
-        String(
-          format: String(
-            localized:
-              "%@: output field name '%@' must be an ASCII identifier (letters, digits, and underscore, not starting with a digit or underscore). Agent text values may be any language."
-          ),
-          label, name)
-      )
+        ScenarioValidationMessage.outputFieldNameInvalid(label: label, name: name).localized)
     }
   }
 }

--- a/Pastura/Pastura/Engine/ScenarioValidator.swift
+++ b/Pastura/Pastura/Engine/ScenarioValidator.swift
@@ -27,67 +27,54 @@ nonisolated struct ScenarioValidator: Sendable {
     // gate, mirrors `ScenarioLoader`'s YAML-parse path).
     if !Scenario.acceptedLanguages.contains(scenario.language) {
       let allowed = Scenario.acceptedLanguages.sorted().joined(separator: ", ")
-      throw validationError(
-        String(localized: "Scenario: field 'language' must be one of {%@}, got '%@'"),
-        allowed, scenario.language)
+      throw validationError(.languageNotAccepted(allowed: allowed, got: scenario.language))
     }
     if let simulationLanguage = scenario.simulationLanguage,
       !Scenario.acceptedLanguages.contains(simulationLanguage) {
       let allowed = Scenario.acceptedLanguages.sorted().joined(separator: ", ")
       throw validationError(
-        String(
-          localized: "Scenario: field 'simulationLanguage' must be one of {%@} or nil, got '%@'"),
-        allowed, simulationLanguage)
+        .simulationLanguageNotAccepted(allowed: allowed, got: simulationLanguage))
     }
 
     // Agent count limits (checked first for clearer error messages)
     if scenario.agentCount < 2 {
-      throw validationError(
-        String(localized: "Agent count (%lld) is below minimum of 2"), scenario.agentCount)
+      throw validationError(.agentCountBelowMinimum(scenario.agentCount))
     }
     if scenario.agentCount > 10 {
-      throw validationError(
-        String(localized: "Agent count (%lld) exceeds maximum of 10"), scenario.agentCount)
+      throw validationError(.agentCountExceedsMaximum(scenario.agentCount))
     }
 
     // Persona count must match agentCount
     if scenario.personas.count != scenario.agentCount {
       throw validationError(
-        String(localized: "Persona count (%lld) does not match agent count (%lld)"),
-        scenario.personas.count, scenario.agentCount)
+        .personaCountMismatch(
+          personaCount: scenario.personas.count, agentCount: scenario.agentCount))
     }
 
     // Round count limit
     if scenario.rounds > 30 {
-      throw validationError(
-        String(localized: "Round count (%lld) exceeds maximum of 30"), scenario.rounds)
+      throw validationError(.roundCountExceedsMaximum(scenario.rounds))
     }
 
     // Conversation-log window (#907): a prompt-side cap that must keep at least
     // one entry when set. `nil` means "no window" (full log); `0` or negative
     // would silently strip the whole log, so reject it as a misconfiguration.
     if let logWindow = scenario.logWindow, logWindow < 1 {
-      throw validationError(
-        String(localized: "Log window (%lld) must be at least 1"), logWindow)
+      throw validationError(.logWindowBelowMinimum(logWindow))
     }
 
     // Inference count estimation
     let estimated = ScenarioLoader.estimateInferenceCount(scenario)
 
     if estimated > 100 {
-      throw validationError(
-        String(localized: "Estimated inferences (%lld) exceeds maximum of 100"), estimated)
+      throw validationError(.estimatedInferencesExceedsMaximum(estimated))
     }
 
     try validatePhases(scenario)
 
     var warnings: [String] = []
     if estimated > 50 {
-      warnings.append(
-        String(
-          format: String(
-            localized: "High inference count (%lld). Simulation may take several minutes."),
-          estimated))
+      warnings.append(ScenarioValidationMessage.highInferenceCount(estimated).localized)
     }
 
     return ValidationResult(warnings: warnings, estimatedInferences: estimated)
@@ -155,8 +142,7 @@ nonisolated struct ScenarioValidator: Sendable {
     let trimmedCondition = (phase.condition ?? "").trimmingCharacters(
       in: .whitespacesAndNewlines)
     if trimmedCondition.isEmpty {
-      throw validationError(
-        String(localized: "%@: missing or empty 'if' expression."), phaseLabel)
+      throw validationError(.conditionalMissingIf(label: phaseLabel))
     }
 
     // Parse-only pre-flight: malformed `if:` (mismatched parens, dangling
@@ -167,26 +153,21 @@ nonisolated struct ScenarioValidator: Sendable {
     do {
       try ConditionEvaluator().parse(trimmedCondition)
     } catch let SimulationError.scenarioValidationFailed(message) {
-      // Raw interpolation is deliberate here (not Form-B): this only prefixes
-      // the phase locator onto `message`, which is already a localized string
-      // emitted by `ConditionEvaluator.parse`. There is no new translatable
-      // literal to extract, so a future i18n sweep should skip this site.
+      // Raw interpolation is deliberate here (not a `ScenarioValidationMessage`
+      // case): this only prefixes the phase locator onto `message`, an
+      // already-rendered string emitted by `ConditionEvaluator.parse`. There is
+      // no new translatable literal to extract, so a future i18n sweep skips it.
       throw SimulationError.scenarioValidationFailed("\(phaseLabel): \(message)")
     }
 
     let thenCount = phase.thenPhases?.count ?? 0
     let elseCount = phase.elsePhases?.count ?? 0
     if thenCount == 0 && elseCount == 0 {
-      throw validationError(
-        String(localized: "%@: must have at least one sub-phase in 'then' or 'else'."), phaseLabel)
+      throw validationError(.conditionalEmptyBranches(label: phaseLabel))
     }
 
     if depth > 0 {
-      throw validationError(
-        String(
-          localized:
-            "%@: nested 'conditional' inside another conditional is not allowed (depth-1 rule)."),
-        phaseLabel)
+      throw validationError(.nestedConditionalNotAllowed(label: phaseLabel))
     }
 
     try validateBranch(
@@ -213,35 +194,25 @@ nonisolated struct ScenarioValidator: Sendable {
       let subLabel = "\(parentLabel) \(branchLabel)[\(subIndex + 1)]"
       try validateOutputFieldNames(in: subPhase, label: subLabel)
       if subPhase.type == .conditional {
-        throw validationError(
-          String(localized: "%@ is another conditional, which is not allowed (depth-1 rule)."),
-          subLabel)
+        throw validationError(.branchNestedConditional(label: subLabel))
       }
       // `reflect` is not supported inside a conditional branch in v1. Reject
       // at load-time validation (mirroring the nested-conditional rule above)
       // so it fails here rather than at `ConditionalHandler` dispatch.
       if subPhase.type == .reflect {
-        throw validationError(
-          String(localized: "%@ is a reflect phase, which is not allowed inside a conditional."),
-          subLabel)
+        throw validationError(.branchReflectNotAllowed(label: subLabel))
       }
       // `whisper` is likewise not supported inside a conditional branch in v1
       // (mirrors the reflect rejection above) — it fails here at load-time
       // validation rather than at `ConditionalHandler` dispatch.
       if subPhase.type == .whisper {
-        throw validationError(
-          String(localized: "%@ is a whisper phase, which is not allowed inside a conditional."),
-          subLabel)
+        throw validationError(.branchWhisperNotAllowed(label: subLabel))
       }
       // `relationship_update` is likewise not supported inside a conditional
       // branch in v1 (mirrors the reflect/whisper rejections above); it is also
       // omitted from `ConditionalHandler.subHandlers` as a structural backstop.
       if subPhase.type == .relationshipUpdate {
-        throw validationError(
-          String(
-            localized:
-              "%@ is a relationship_update phase, which is not allowed inside a conditional."),
-          subLabel)
+        throw validationError(.branchRelationshipUpdateNotAllowed(label: subLabel))
       }
       if subPhase.type == .assign {
         try validateAssignPhaseShape(subPhase, label: subLabel, scenario: scenario)
@@ -264,8 +235,7 @@ nonisolated struct ScenarioValidator: Sendable {
   private func validateReflectShape(_ phase: Phase, label: String) throws {
     if (phase.outputSchema ?? [:])["note"] == nil {
       throw validationError(
-        String(localized: "%@ (%@) requires field '%@' in output."),
-        label, phase.type.rawValue, "note")
+        .requiresOutputField(label: label, type: phase.type.rawValue, field: "note"))
     }
   }
 
@@ -279,8 +249,7 @@ nonisolated struct ScenarioValidator: Sendable {
   private func validateWhisperShape(_ phase: Phase, label: String) throws {
     if (phase.outputSchema ?? [:])["statement"] == nil {
       throw validationError(
-        String(localized: "%@ (%@) requires field '%@' in output."),
-        label, phase.type.rawValue, "statement")
+        .requiresOutputField(label: label, type: phase.type.rawValue, field: "statement"))
     }
   }
 
@@ -297,10 +266,7 @@ nonisolated struct ScenarioValidator: Sendable {
     let hasActionRule = !(phase.actionDeltas ?? [:]).isEmpty
     if !hasVoteRule && !hasActionRule {
       throw validationError(
-        String(
-          localized:
-            "%@ (%@) requires at least one affinity rule: 'vote_against' and/or 'action_deltas'."),
-        label, phase.type.rawValue)
+        .relationshipUpdateMissingRule(label: label, type: phase.type.rawValue))
     }
   }
 
@@ -317,12 +283,7 @@ nonisolated struct ScenarioValidator: Sendable {
     // here means the scenario YAML genuinely lacks the referenced field —
     // the assign would silently no-op at runtime. Surface it early.
     guard let sourceValue = scenario.extraData[sourceKey] else {
-      throw validationError(
-        String(
-          localized:
-            "%@: source '%@' not found in scenario data. Add a top-level '%@' field to the scenario YAML."
-        ),
-        label, sourceKey, sourceKey)
+      throw validationError(.sourceNotFound(label: label, source: sourceKey))
     }
     let effectiveTarget = phase.target ?? .all
     switch effectiveTarget {
@@ -331,42 +292,30 @@ nonisolated struct ScenarioValidator: Sendable {
       case .array, .string:
         return
       case .arrayOfDictionaries, .dictionary:
-        throw validationError(
-          String(
-            localized:
-              "%@: source '%@' contains grouped values (e.g., majority/minority pairs). Use target: random_one to distribute these. Use target: all only for a flat list of strings or a single string."
-          ),
-          label, sourceKey)
+        throw validationError(.assignSourceGroupedForAll(label: label, source: sourceKey))
       }
     case .randomOne:
       switch sourceValue {
       case .arrayOfDictionaries:
         return
       case .array, .string, .dictionary:
-        throw validationError(
-          String(
-            localized:
-              "%@: source '%@' must be a list of grouped values (e.g., majority/minority pairs) when target is random_one."
-          ),
-          label, sourceKey)
+        throw validationError(.assignSourceNotGroupedForRandomOne(label: label, source: sourceKey))
       }
     }
   }
 }
 
-/// Builds a ``SimulationError/scenarioValidationFailed(_:)`` from a localized
-/// format string and its arguments. Collapses the `String(format:)` wrapper at
-/// every call site so each throw stays a single `String(localized:)` literal —
-/// xcstringstool still extracts it as Form B (see `.claude/rules/i18n.md`).
+/// Wraps a ``ScenarioValidationMessage`` in
+/// ``SimulationError/scenarioValidationFailed(_:)``, rendering it at the Models
+/// layer so the Engine run path stays free of Foundation string localization
+/// and formatting (KMP Phase 3.0 port prep, #501).
 ///
 /// File-scope (not a method) so it stays out of `ScenarioValidator`'s
 /// `type_body_length` budget; `nonisolated` because top-level functions inherit
 /// `MainActor` under `SWIFT_DEFAULT_ACTOR_ISOLATION` and the `nonisolated`
 /// validator calls it synchronously. `private` (file-scope) so it does not
 /// collide with `ScenarioLoader`'s same-named helper at module scope — the
-/// sibling `ScenarioValidator+CanonicalFields.swift` carries its own copy.
-nonisolated private func validationError(
-  _ format: String, _ arguments: CVarArg...
-) -> SimulationError {
-  .scenarioValidationFailed(String(format: format, arguments: arguments))
+/// sibling `ScenarioValidator+*.swift` extensions carry their own copies.
+nonisolated private func validationError(_ message: ScenarioValidationMessage) -> SimulationError {
+  .scenarioValidationFailed(message.localized)
 }

--- a/Pastura/Pastura/Engine/ScoringLogic/WordwolfJudgeLogic.swift
+++ b/Pastura/Pastura/Engine/ScoringLogic/WordwolfJudgeLogic.swift
@@ -7,7 +7,7 @@ import Foundation
 /// Engine language (the caller — `ScoreCalcHandler` — passes
 /// `scenario.engineLanguage`, ADR-010 D5 / D6 row 1). ADR-010 D7 / D8 —
 /// scenario-language-bound, so `String(format:)` is used with literal
-/// English / Japanese rather than `String(localized:)`.
+/// English / Japanese rather than a device-locale string lookup.
 nonisolated struct WordwolfJudgeLogic: Sendable {
 
   func calculate(

--- a/Pastura/Pastura/Models/ScenarioValidationMessage.swift
+++ b/Pastura/Pastura/Models/ScenarioValidationMessage.swift
@@ -1,0 +1,338 @@
+import Foundation
+
+/// A parameter-carrying description of a scenario load / validation failure.
+///
+/// The Engine run path (``ScenarioValidator`` + extensions, ``ScenarioLoader``)
+/// throws these instead of building user-facing strings inline: each case is a
+/// **portable structured payload** (enum case + typed args, no Foundation), and
+/// ``localized`` is the single **platform-specific rendering leaf** that turns a
+/// case into the display string.
+///
+/// This is the message-model split for the KMP Phase 3.0 Engine port (issue
+/// #501, Stage 0 / S0.1): the cases move to Kotlin `commonMain` 1:1 as a sealed
+/// class, while `localized` becomes an `expect`/`actual` leaf. Concretely it
+/// removes `CVarArg` **and** `String(format:)` **and** `String(localized:)` —
+/// all Foundation/ObjC-isms — from the Engine files, which is the real
+/// portability delta, not merely relocating the `String(localized:)` token.
+///
+/// The rendered text is byte-identical to the pre-refactor Engine literals so
+/// `Localizable.xcstrings` keys are unchanged. Callers wrap the rendered string
+/// in ``SimulationError/scenarioValidationFailed(_:)`` (unchanged payload type —
+/// it is shared by many out-of-scope plain-literal throwers).
+nonisolated public enum ScenarioValidationMessage: Sendable {
+  // MARK: Language membership (shared: ScenarioValidator + ScenarioLoader)
+  case languageNotAccepted(allowed: String, got: String)
+  case simulationLanguageNotAccepted(allowed: String, got: String)
+  case simulationLanguageYAMLNotAccepted(allowed: String, got: String)
+
+  // MARK: Execution limits (ScenarioValidator)
+  case agentCountBelowMinimum(Int)
+  case agentCountExceedsMaximum(Int)
+  case personaCountMismatch(personaCount: Int, agentCount: Int)
+  case roundCountExceedsMaximum(Int)
+  case logWindowBelowMinimum(Int)
+  case estimatedInferencesExceedsMaximum(Int)
+  case highInferenceCount(Int)
+
+  // MARK: Conditional-phase shape (ScenarioValidator; nestedConditional shared with ScenarioLoader)
+  case conditionalMissingIf(label: String)
+  case conditionalEmptyBranches(label: String)
+  case nestedConditionalNotAllowed(label: String)
+  case branchNestedConditional(label: String)
+  case branchReflectNotAllowed(label: String)
+  case branchWhisperNotAllowed(label: String)
+  case branchRelationshipUpdateNotAllowed(label: String)
+
+  // MARK: Canonical / required output fields (shared: ScenarioValidator + +CanonicalFields)
+  case requiresOutputField(label: String, type: String, field: String)
+  case secondaryFieldMismatch(label: String, type: String, canonical: String, key: String)
+  case relationshipUpdateMissingRule(label: String, type: String)
+
+  // MARK: Assign-phase source shape (ScenarioValidator; sourceNotFound shared with +EventInject)
+  case sourceNotFound(label: String, source: String)
+  case assignSourceGroupedForAll(label: String, source: String)
+  case assignSourceNotGroupedForRandomOne(label: String, source: String)
+
+  // MARK: Structural mapping (ScenarioLoader)
+  case invalidYAMLFormat
+  case missingRequiredField(label: String, key: String)
+  case fieldWrongType(label: String, key: String, expected: String, got: String)
+  case fieldNotDoubleOrInt(label: String, key: String, got: String)
+  case agentsPersonasCountMismatch(agentCount: Int, personaCount: Int)
+  case invalidTarget(label: String, value: String)
+  case invalidPairing(label: String, value: String)
+  case invalidLogic(label: String, value: String, allowed: String)
+  case actionDeltasNotDict(label: String, got: String)
+  case actionDeltasValueNotInt(label: String, key: String, got: String)
+  case phaseMissingType(label: String)
+  case phaseInvalidType(label: String, value: String)
+  case outputNotDict(label: String, got: String)
+  case outputValueNotString(label: String, key: String, got: String)
+  case branchNotArray(label: String, branch: String)
+  case extraDataArrayOfDictNotString(key: String)
+  case extraDataMixedArray(key: String)
+  case extraDataDictNotString(key: String)
+  case extraDataUnsupportedType(key: String, got: String, shapes: String)
+
+  // MARK: event_inject shape (+EventInject)
+  case eventInjectMissingSource(label: String)
+  case eventInjectSourceEmptyStrings(label: String, source: String)
+  case eventInjectSourceWrongShape(label: String, source: String)
+  case eventInjectSourceEmptyEvents(label: String, source: String)
+  case eventInjectEntryMissingText(label: String, source: String)
+  case eventInjectProbabilityOutOfRange(label: String, probability: String)
+
+  // MARK: Output field-name validation (+OutputFieldNames)
+  case outputFieldNameInvalid(label: String, name: String)
+}
+
+// `nonisolated` on the extension is load-bearing: the enum is a `nonisolated`
+// Models type, but a sibling `extension` inherits the project's default
+// MainActor isolation unless annotated (`.claude/rules/swift-isolation.md`
+// Pattern 3), which would break the synchronous `nonisolated` Engine callers.
+nonisolated extension ScenarioValidationMessage {
+
+  /// Renders the case to its user-facing string.
+  ///
+  /// The **only** Foundation-touching member — the KMP `expect`/`actual` leaf
+  /// (see the type doc). Literals are byte-identical to the pre-refactor Engine
+  /// callsites so `Localizable.xcstrings` keys stay stable. No-arg cases use
+  /// `String(localized:)` directly (never `String(format:)`, which would
+  /// misread a stray `%` in a future literal). `%lld` args stay `Int` — passing
+  /// `Int` to `%lld` on 64-bit iOS matches the pre-refactor `CVarArg` behavior.
+  public var localized: String {
+    switch self {
+    case .languageNotAccepted(let allowed, let got):
+      return String(
+        format: String(localized: "Scenario: field 'language' must be one of {%@}, got '%@'"),
+        allowed, got)
+    case .simulationLanguageNotAccepted(let allowed, let got):
+      return String(
+        format: String(
+          localized: "Scenario: field 'simulationLanguage' must be one of {%@} or nil, got '%@'"),
+        allowed, got)
+    case .simulationLanguageYAMLNotAccepted(let allowed, let got):
+      return String(
+        format: String(
+          localized: "Scenario: field 'simulation_language' must be one of {%@} or absent, got '%@'"
+        ),
+        allowed, got)
+    case .agentCountBelowMinimum(let count):
+      return String(
+        format: String(localized: "Agent count (%lld) is below minimum of 2"), count)
+    case .agentCountExceedsMaximum(let count):
+      return String(
+        format: String(localized: "Agent count (%lld) exceeds maximum of 10"), count)
+    case .personaCountMismatch(let personaCount, let agentCount):
+      return String(
+        format: String(localized: "Persona count (%lld) does not match agent count (%lld)"),
+        personaCount, agentCount)
+    case .roundCountExceedsMaximum(let rounds):
+      return String(
+        format: String(localized: "Round count (%lld) exceeds maximum of 30"), rounds)
+    case .logWindowBelowMinimum(let window):
+      return String(
+        format: String(localized: "Log window (%lld) must be at least 1"), window)
+    case .estimatedInferencesExceedsMaximum(let estimated):
+      return String(
+        format: String(localized: "Estimated inferences (%lld) exceeds maximum of 100"), estimated)
+    case .highInferenceCount(let estimated):
+      return String(
+        format: String(
+          localized: "High inference count (%lld). Simulation may take several minutes."),
+        estimated)
+    case .conditionalMissingIf(let label):
+      return String(
+        format: String(localized: "%@: missing or empty 'if' expression."), label)
+    case .conditionalEmptyBranches(let label):
+      return String(
+        format: String(localized: "%@: must have at least one sub-phase in 'then' or 'else'."),
+        label)
+    case .nestedConditionalNotAllowed(let label):
+      return String(
+        format: String(
+          localized:
+            "%@: nested 'conditional' inside another conditional is not allowed (depth-1 rule)."),
+        label)
+    case .branchNestedConditional(let label):
+      return String(
+        format: String(
+          localized: "%@ is another conditional, which is not allowed (depth-1 rule)."),
+        label)
+    case .branchReflectNotAllowed(let label):
+      return String(
+        format: String(
+          localized: "%@ is a reflect phase, which is not allowed inside a conditional."),
+        label)
+    case .branchWhisperNotAllowed(let label):
+      return String(
+        format: String(
+          localized: "%@ is a whisper phase, which is not allowed inside a conditional."),
+        label)
+    case .branchRelationshipUpdateNotAllowed(let label):
+      return String(
+        format: String(
+          localized:
+            "%@ is a relationship_update phase, which is not allowed inside a conditional."),
+        label)
+    case .requiresOutputField(let label, let type, let field):
+      return String(
+        format: String(localized: "%@ (%@) requires field '%@' in output."), label, type, field)
+    case .secondaryFieldMismatch(let label, let type, let canonical, let key):
+      return String(
+        format: String(localized: "%@ (%@) secondary field must be '%@', not '%@'."),
+        label, type, canonical, key)
+    case .relationshipUpdateMissingRule(let label, let type):
+      return String(
+        format: String(
+          localized:
+            "%@ (%@) requires at least one affinity rule: 'vote_against' and/or 'action_deltas'."),
+        label, type)
+    case .sourceNotFound(let label, let source):
+      return String(
+        format: String(
+          localized:
+            "%@: source '%@' not found in scenario data. Add a top-level '%@' field to the scenario YAML."
+        ),
+        label, source, source)
+    case .assignSourceGroupedForAll(let label, let source):
+      return String(
+        format: String(
+          localized:
+            "%@: source '%@' contains grouped values (e.g., majority/minority pairs). Use target: random_one to distribute these. Use target: all only for a flat list of strings or a single string."
+        ),
+        label, source)
+    case .assignSourceNotGroupedForRandomOne(let label, let source):
+      return String(
+        format: String(
+          localized:
+            "%@: source '%@' must be a list of grouped values (e.g., majority/minority pairs) when target is random_one."
+        ),
+        label, source)
+    case .invalidYAMLFormat:
+      return String(localized: "Invalid YAML format")
+    case .missingRequiredField(let label, let key):
+      return String(
+        format: String(localized: "%@: missing required field '%@'"), label, key)
+    case .fieldWrongType(let label, let key, let expected, let got):
+      return String(
+        format: String(localized: "%@: field '%@' must be %@, got %@"), label, key, expected, got)
+    case .fieldNotDoubleOrInt(let label, let key, let got):
+      return String(
+        format: String(localized: "%@: field '%@' must be Double or Int, got %@"), label, key, got)
+    case .agentsPersonasCountMismatch(let agentCount, let personaCount):
+      return String(
+        format: String(localized: "agents (%lld) does not match personas count (%lld)"),
+        agentCount, personaCount)
+    case .invalidTarget(let label, let value):
+      return String(
+        format: String(localized: "%@ has invalid target: '%@'. Use 'all' or 'random_one'."),
+        label, value)
+    case .invalidPairing(let label, let value):
+      return String(
+        format: String(localized: "%@ has invalid pairing: '%@'. Use 'round_robin'."), label, value)
+    case .invalidLogic(let label, let value, let allowed):
+      return String(
+        format: String(localized: "%@ has invalid logic: '%@'. Expected one of: %@."),
+        label, value, allowed)
+    case .actionDeltasNotDict(let label, let got):
+      return String(
+        format: String(
+          localized: "%@: field 'action_deltas' must be a dictionary of Int values, got %@"),
+        label, got)
+    case .actionDeltasValueNotInt(let label, let key, let got):
+      return String(
+        format: String(localized: "%@: action_deltas value for '%@' must be Int, got %@"),
+        label, key, got)
+    case .phaseMissingType(let label):
+      return String(format: String(localized: "%@ missing 'type'"), label)
+    case .phaseInvalidType(let label, let value):
+      return String(
+        format: String(localized: "%@ has invalid type: '%@'"), label, value)
+    case .outputNotDict(let label, let got):
+      return String(
+        format: String(
+          localized: "%@: field 'output' must be a dictionary of String values, got %@"),
+        label, got)
+    case .outputValueNotString(let label, let key, let got):
+      return String(
+        format: String(localized: "%@: output schema value for '%@' must be String, got %@"),
+        label, key, got)
+    case .branchNotArray(let label, let branch):
+      return String(
+        format: String(localized: "%@: '%@' must be an array of phase objects"), label, branch)
+    case .extraDataArrayOfDictNotString(let key):
+      return String(
+        format: String(
+          localized:
+            "Top-level field '%@': array-of-dict values must all be String. Quote non-string values (e.g. `majority: \"1\"`)."
+        ),
+        key)
+    case .extraDataMixedArray(let key):
+      return String(
+        format: String(
+          localized:
+            "Top-level field '%@': mixed-type arrays are not supported. Use a pure [String] or [[String: String]]."
+        ),
+        key)
+    case .extraDataDictNotString(let key):
+      return String(
+        format: String(
+          localized:
+            "Top-level field '%@': dictionary values must all be String. Quote non-string values."),
+        key)
+    case .extraDataUnsupportedType(let key, let got, let shapes):
+      return String(
+        format: String(
+          localized: "Top-level field '%@' has unsupported type %@. Supported shapes: %@."),
+        key, got, shapes)
+    case .eventInjectMissingSource(let label):
+      return String(
+        format: String(
+          localized:
+            "%@: missing 'source'. event_inject requires a 'source' key naming a top-level YAML field that lists the event strings."
+        ),
+        label)
+    case .eventInjectSourceEmptyStrings(let label, let source):
+      return String(
+        format: String(
+          localized:
+            "%@: source '%@' is empty. event_inject requires at least one string in the list; for a single fixed event use ['only_event']."
+        ),
+        label, source)
+    case .eventInjectSourceWrongShape(let label, let source):
+      return String(
+        format: String(
+          localized:
+            "%@: source '%@' must be a list of event strings or {text, favors} mappings; for a single fixed event use ['only_event']."
+        ),
+        label, source)
+    case .eventInjectSourceEmptyEvents(let label, let source):
+      return String(
+        format: String(
+          localized:
+            "%@: source '%@' is empty. event_inject requires at least one event in the list; for a single fixed event use ['only_event']."
+        ),
+        label, source)
+    case .eventInjectEntryMissingText(let label, let source):
+      return String(
+        format: String(
+          localized:
+            "%@: source '%@' has an event entry missing a non-empty 'text'. Dict-shaped events require 'text' (and may add 'favors')."
+        ),
+        label, source)
+    case .eventInjectProbabilityOutOfRange(let label, let probability):
+      return String(
+        format: String(
+          localized: "%@: probability %@ is out of range. Must be between 0.0 and 1.0 inclusive."),
+        label, probability)
+    case .outputFieldNameInvalid(let label, let name):
+      return String(
+        format: String(
+          localized:
+            "%@: output field name '%@' must be an ASCII identifier (letters, digits, and underscore, not starting with a digit or underscore). Agent text values may be any language."
+        ),
+        label, name)
+    }
+  }
+}

--- a/Pastura/PasturaTests/Models/ScenarioValidationMessageTests.swift
+++ b/Pastura/PasturaTests/Models/ScenarioValidationMessageTests.swift
@@ -1,0 +1,118 @@
+import Testing
+
+@testable import Pastura
+
+/// Locks ``ScenarioValidationMessage/localized`` rendering to the byte-identical
+/// strings the Engine emitted before the S0.1 de-localization refactor (#501).
+/// Focus: argument order + multi-arg / shared / no-arg / multi-line-wrapped
+/// literals — a `.contains` substring test cannot catch an arg-order swap, so
+/// these assert the full rendered string. English base locale (CI default).
+@Suite(.timeLimit(.minutes(1)))
+struct ScenarioValidationMessageTests {
+
+  // MARK: %lld formatting (Int arg → %lld, matching pre-refactor CVarArg behavior)
+
+  @Test func agentCountBelowMinimumRendersInt() {
+    #expect(
+      ScenarioValidationMessage.agentCountBelowMinimum(1).localized
+        == "Agent count (1) is below minimum of 2")
+  }
+
+  @Test func personaCountMismatchOrdersBothInts() {
+    // Two %lld — arg order is personaCount then agentCount.
+    #expect(
+      ScenarioValidationMessage.personaCountMismatch(personaCount: 3, agentCount: 5).localized
+        == "Persona count (3) does not match agent count (5)")
+  }
+
+  @Test func agentsPersonasCountMismatchOrdersBothInts() {
+    #expect(
+      ScenarioValidationMessage.agentsPersonasCountMismatch(agentCount: 5, personaCount: 3)
+        .localized
+        == "agents (5) does not match personas count (3)")
+  }
+
+  @Test func highInferenceWarningRendersMultiLineLiteral() {
+    // The `rg 'String(localized:'` blind spot — literal was multi-line-wrapped.
+    #expect(
+      ScenarioValidationMessage.highInferenceCount(72).localized
+        == "High inference count (72). Simulation may take several minutes.")
+  }
+
+  // MARK: Shared / multi-arg literals (arg order is load-bearing)
+
+  @Test func languageNotAcceptedOrdersAllowedThenGot() {
+    #expect(
+      ScenarioValidationMessage.languageNotAccepted(allowed: "en, ja", got: "fr").localized
+        == "Scenario: field 'language' must be one of {en, ja}, got 'fr'")
+  }
+
+  @Test func requiresOutputFieldOrdersThreeArgs() {
+    #expect(
+      ScenarioValidationMessage.requiresOutputField(
+        label: "Phase 1", type: "reflect", field: "note"
+      ).localized == "Phase 1 (reflect) requires field 'note' in output.")
+  }
+
+  @Test func secondaryFieldMismatchOrdersFourArgs() {
+    #expect(
+      ScenarioValidationMessage.secondaryFieldMismatch(
+        label: "Phase 2", type: "vote", canonical: "reason", key: "inner_thought"
+      ).localized == "Phase 2 (vote) secondary field must be 'reason', not 'inner_thought'.")
+  }
+
+  @Test func fieldWrongTypeOrdersFourArgs() {
+    #expect(
+      ScenarioValidationMessage.fieldWrongType(
+        label: "Scenario", key: "agents", expected: "Int", got: "String"
+      ).localized == "Scenario: field 'agents' must be Int, got String")
+  }
+
+  @Test func sourceNotFoundRepeatsSourceArgTwice() {
+    // Literal has three %@; `source` is substituted into positions 2 and 3.
+    #expect(
+      ScenarioValidationMessage.sourceNotFound(label: "Phase 3", source: "roles").localized
+        == "Phase 3: source 'roles' not found in scenario data. "
+        + "Add a top-level 'roles' field to the scenario YAML.")
+  }
+
+  @Test func nestedConditionalRendersSharedLiteral() {
+    #expect(
+      ScenarioValidationMessage.nestedConditionalNotAllowed(label: "Phase 4").localized
+        == "Phase 4: nested 'conditional' inside another conditional is not allowed (depth-1 rule)."
+    )
+  }
+
+  // MARK: No-arg case renders via String(localized:) directly
+
+  @Test func invalidYAMLFormatRendersNoArgLiteral() {
+    #expect(ScenarioValidationMessage.invalidYAMLFormat.localized == "Invalid YAML format")
+  }
+
+  // MARK: Literals with embedded backticks / escaped quotes stay byte-identical
+
+  @Test func extraDataArrayOfDictPreservesBacktickAndQuotes() {
+    #expect(
+      ScenarioValidationMessage.extraDataArrayOfDictNotString(key: "teams").localized
+        == "Top-level field 'teams': array-of-dict values must all be String. "
+        + "Quote non-string values (e.g. `majority: \"1\"`).")
+  }
+
+  // MARK: Extension-file (out-of-original-5-scope) cases
+
+  @Test func eventInjectProbabilityOutOfRangeOrdersArgs() {
+    #expect(
+      ScenarioValidationMessage.eventInjectProbabilityOutOfRange(
+        label: "Phase 5", probability: "1.5"
+      ).localized
+        == "Phase 5: probability 1.5 is out of range. Must be between 0.0 and 1.0 inclusive.")
+  }
+
+  @Test func outputFieldNameInvalidOrdersArgs() {
+    #expect(
+      ScenarioValidationMessage.outputFieldNameInvalid(label: "Phase 6", name: "感想").localized
+        == "Phase 6: output field name '感想' must be an ASCII identifier "
+        + "(letters, digits, and underscore, not starting with a digit or underscore). "
+        + "Agent text values may be any language.")
+  }
+}

--- a/Pastura/PasturaTests/Models/ScenarioValidationMessageTests.swift
+++ b/Pastura/PasturaTests/Models/ScenarioValidationMessageTests.swift
@@ -83,6 +83,26 @@ struct ScenarioValidationMessageTests {
     )
   }
 
+  // MARK: Long assign-path literals (most truncation-prone in a future edit)
+
+  @Test func assignSourceGroupedForAllRendersLongLiteral() {
+    #expect(
+      ScenarioValidationMessage.assignSourceGroupedForAll(label: "Phase 7", source: "teams")
+        .localized
+        == "Phase 7: source 'teams' contains grouped values (e.g., majority/minority pairs). "
+        + "Use target: random_one to distribute these. Use target: all only for a flat list "
+        + "of strings or a single string.")
+  }
+
+  @Test func assignSourceNotGroupedForRandomOneRendersLongLiteral() {
+    #expect(
+      ScenarioValidationMessage.assignSourceNotGroupedForRandomOne(
+        label: "Phase 8", source: "roles"
+      ).localized
+        == "Phase 8: source 'roles' must be a list of grouped values "
+        + "(e.g., majority/minority pairs) when target is random_one.")
+  }
+
   // MARK: No-arg case renders via String(localized:) directly
 
   @Test func invalidYAMLFormatRendersNoArgLiteral() {


### PR DESCRIPTION
## Summary
S0.1 of the KMP Phase 3.0 Engine port. Removes `String(localized:)` from the
Engine run path so `ScenarioValidator` / `ScenarioLoader` can port to Kotlin
`commonMain` (Foundation is unavailable there).

- New Models type `ScenarioValidationMessage` — parameter-carrying enum (49
  cases) whose `localized` property is the single Foundation-touching rendering
  leaf. Removes `CVarArg`, `String(format:)`, and `String(localized:)` from Engine.
- `SimulationError.scenarioValidationFailed(String)` payload type **unchanged**
  (shared by ~15 out-of-scope plain-literal throwers) — the message renders to a
  String at the Engine helper boundary.
- Scope is **7 files, not the 5 originally listed**: `+EventInject` and
  `+OutputFieldNames` also call `String(localized:)` via multi-line-wrapped
  `String(\n localized:` (a line-based-grep blind spot); leaving them would keep
  the run path Foundation-bound. Caught by the Fable plan critic.
- `LanguageDispatch` / `WordwolfJudge` were comment-only references (code already
  ADR-010 scenario-language-bound) — reworded.

Literals relocated **byte-identical** so there is no `Localizable.xcstrings` key delta.

## Test plan
- Full unit suite: **2734 tests green**
- `rg 'String(localized:'` across the 7 files = **0** (line-based and multi-line-aware)
- Post-build `xcstringstool sync` produced an **empty catalog diff**; `check_localization_coverage.py` green (613 keys)
- `swiftlint --strict` clean; harness `swift build` clean
- New `ScenarioValidationMessageTests` (16 cases) lock byte-identity and arg-order on drift-prone literals
- code-reviewer (Opus): **PASS**, 0 Critical / 0 Warning

Part of #501
