### PR TITLE
✨ feat: harness ModelProfile for Sarashina 2.2 3B (Stage-0 eval)

### DIFF
--- a/tools/harness/Sources/PasturaHarnessKit/ModelProfile.swift
+++ b/tools/harness/Sources/PasturaHarnessKit/ModelProfile.swift
@@ -76,6 +76,16 @@ package struct ModelProfile: Sendable, Equatable {
   /// `App/ModelRegistry` entry yet: it is a candidate under the `/model-eval`
   /// Mac-filter gate, not a shipped model. Registration (a `ModelDescriptor`)
   /// happens only after the ADR-011 real-device accept gate.
+  ///
+  /// Gate-1 result (2026-07-08): **NO-GO**, blocked (not a clean quality
+  /// reject). 3 of 6 battery cells hard-failed with "Model generated no
+  /// output tokens" — the #366-class trap (the GBNF grammar sampler does not
+  /// mask special tokens, so this 3B intermittently samples `</s>`/EOS as a
+  /// turn's first token → empty generation → run abort). The values below are
+  /// correct (the failure is the harness trap, not a wrong field); the profile
+  /// is retained as the reproduction case + reusable instrument for the #371
+  /// fix (post-sample `llama_vocab_is_special` resample) and a re-eval after it
+  /// lands. See the `data/models/eval-digest.md` scorecard and #979.
   package static let sarashina223B = ModelProfile(
     id: "sarashina-2-2-3b-q4-k-m",
     name: "Sarashina 2.2 3B (Q4_K_M)",

--- a/tools/harness/Sources/PasturaHarnessKit/ModelProfile.swift
+++ b/tools/harness/Sources/PasturaHarnessKit/ModelProfile.swift
@@ -71,9 +71,29 @@ package struct ModelProfile: Sendable, Equatable {
     expectedSHA256: "7485fe6f11af29433bc51cab58009521f205840f5b4ae3a32fa7f92e8534fdf5"
   )
 
+  /// Sarashina 2.2 3B Q4_K_M — Stage-0 evaluation candidate (model-validation
+  /// pipeline, intake #979). Unlike `gemma4E2B` / `qwen34B`, this has **no**
+  /// `App/ModelRegistry` entry yet: it is a candidate under the `/model-eval`
+  /// Mac-filter gate, not a shipped model. Registration (a `ModelDescriptor`)
+  /// happens only after the ADR-011 real-device accept gate.
+  package static let sarashina223B = ModelProfile(
+    id: "sarashina-2-2-3b-q4-k-m",
+    name: "Sarashina 2.2 3B (Q4_K_M)",
+    // Sarashina 2.2 (SB Intuitions, MIT) formats turns as
+    // `<|system|>…</s><|user|>…</s><|assistant|>…</s>` with eos `</s>`, and
+    // has no thinking mode — so, unlike Qwen (#366), it needs neither a
+    // `/no_think` suffix nor a `<think>` assistant prefill. The stop sequence
+    // is the plain eos `</s>`; suffix and prefix are nil.
+    stopSequence: "</s>",
+    systemPromptSuffix: nil,
+    assistantPrefix: nil,
+    expectedFileName: "sarashina2.2-3b-instruct-v0.1-Q4_K_M.gguf",
+    expectedSHA256: "d96f4d98eb528df26e8bc09ab81a1d165be4fce67616739e65980bed9038f0f2"
+  )
+
   /// Known profiles the harness `--profile` flag can select, gemma first
   /// as the default.
-  package static let all: [ModelProfile] = [gemma4E2B, qwen34B]
+  package static let all: [ModelProfile] = [gemma4E2B, qwen34B, sarashina223B]
 
   /// Looks up a known profile by its registry `id`, or `nil` if unknown.
   package static func named(_ id: String) -> ModelProfile? {

--- a/tools/harness/Sources/PasturaHarnessKit/ModelProfile.swift
+++ b/tools/harness/Sources/PasturaHarnessKit/ModelProfile.swift
@@ -79,13 +79,16 @@ package struct ModelProfile: Sendable, Equatable {
   ///
   /// Gate-1 result (2026-07-08): **NO-GO**, blocked (not a clean quality
   /// reject). 3 of 6 battery cells hard-failed with "Model generated no
-  /// output tokens" — the #366-class trap (the GBNF grammar sampler does not
-  /// mask special tokens, so this 3B intermittently samples `</s>`/EOS as a
-  /// turn's first token → empty generation → run abort). The values below are
-  /// correct (the failure is the harness trap, not a wrong field); the profile
-  /// is retained as the reproduction case + reusable instrument for the #371
-  /// fix (post-sample `llama_vocab_is_special` resample) and a re-eval after it
-  /// lands. See the `data/models/eval-digest.md` scorecard and #979.
+  /// output tokens": this 3B intermittently samples EOG/EOS at position 0
+  /// under the GBNF grammar, yielding an empty generation. The shipped
+  /// SafeSampler crash-hardening (#253/#371) holds — it does NOT crash — but
+  /// the empty output exhausts the retry budget and aborts the run. That is
+  /// the deferred, inference-side #751 sub-class 2 (empty-output / EOG-at-0),
+  /// NOT the #366 crash class. Stochastic + cumulative: simple/short scenarios
+  /// (bokete) complete, longer/reflect-heavy ones (word_wolf, PD) fail. The
+  /// values below are correct (the failure is this inference-side interaction,
+  /// not a wrong field); the profile is retained as the reproduction case for
+  /// #751 and a re-eval after it lands. See `data/models/eval-digest.md` + #979.
   package static let sarashina223B = ModelProfile(
     id: "sarashina-2-2-3b-q4-k-m",
     name: "Sarashina 2.2 3B (Q4_K_M)",

--- a/tools/harness/Tests/PasturaHarnessKitTests/ModelProfileTests.swift
+++ b/tools/harness/Tests/PasturaHarnessKitTests/ModelProfileTests.swift
@@ -39,9 +39,30 @@ struct ModelProfileTests {
         == "7485fe6f11af29433bc51cab58009521f205840f5b4ae3a32fa7f92e8534fdf5")
   }
 
+  /// Pins the Sarashina 2.2 3B Stage-0 candidate's investigated fields.
+  /// Unlike the gemma/qwen tests above, there is **no** `App/ModelRegistry`
+  /// entry to guard against yet — Sarashina is a candidate under the
+  /// `/model-eval` Mac-filter gate, not a shipped model. This pins the
+  /// values investigated at Stage 0; reconcile them with the eventual
+  /// `ModelDescriptor` at Gate-2 registration (see #979).
+  @Test func sarashinaProfilePinsFields() {
+    let profile = ModelProfile.sarashina223B
+    #expect(profile.id == "sarashina-2-2-3b-q4-k-m")
+    #expect(profile.name == "Sarashina 2.2 3B (Q4_K_M)")
+    // Plain eos stop; no thinking-mode workaround (contrast Qwen #366).
+    #expect(profile.stopSequence == "</s>")
+    #expect(profile.systemPromptSuffix == nil)
+    #expect(profile.assistantPrefix == nil)
+    #expect(profile.expectedFileName == "sarashina2.2-3b-instruct-v0.1-Q4_K_M.gguf")
+    #expect(
+      profile.expectedSHA256
+        == "d96f4d98eb528df26e8bc09ab81a1d165be4fce67616739e65980bed9038f0f2")
+  }
+
   @Test func namedLooksUpKnownProfilesByID() {
     #expect(ModelProfile.named("gemma-4-e2b-q4-k-m") == .gemma4E2B)
     #expect(ModelProfile.named("qwen-3-4b-q4-k-m") == .qwen34B)
+    #expect(ModelProfile.named("sarashina-2-2-3b-q4-k-m") == .sarashina223B)
     #expect(ModelProfile.named("bogus") == nil)
   }
 


### PR DESCRIPTION
## Summary

Stage 0 of the model-validation & onboarding pipeline for the **Sarashina 2.2 3B** candidate (SB Intuitions, MIT). Registers a `ModelProfile` in the `tools/harness` SwiftPM package so `/model-eval` can drive the candidate through the 6-cell Mac-filter battery.

- Adds `ModelProfile.sarashina223B` + its pin test, mirroring the `gemma4E2B` / `qwen34B` pattern.
- **Prompt-format (Stage-0 findings):** Sarashina 2.2 formats turns as `<|system|>…</s><|user|>…</s><|assistant|>…</s>` with eos `</s>` and **no thinking mode** — so, unlike Qwen (#366), it needs neither a `/no_think` suffix nor a `<think>` assistant prefill. `stopSequence = "</s>"`, `systemPromptSuffix`/`assistantPrefix` = nil.
- `expectedSHA256` is authoritative (HF resolve-URL `X-Linked-Etag` on the non-gated `mmnga/sarashina2.2-3b-instruct-v0.1-gguf` mirror, `gated:false`, `license:mit`).
- Underscore-free static name `sarashina223B` (swiftlint `identifier_name --strict`); the `--profile` key `"sarashina-2-2-3b-q4-k-m"` is unchanged.

### Scope boundary

Stage 0 **only**. No `App/ModelRegistry` catalog change (that is Gate-2 registration, after the ADR-011 real-device accept gate), no GGUF download, no `/model-eval` run — those follow after merge. Does not touch the iOS app target, Engine, Models, or `SimulationEvent` (no `EventLineMapper` canary impact).

Since Sarashina has no `ModelRegistry` entry yet, its pin test cannot be a registry drift-guard (unlike gemma/qwen); it pins the investigated Stage-0 values, to be reconciled with the eventual `ModelDescriptor` at Gate-2 registration.

## Test plan

- `swift build` (harness) — clean.
- `swift test` (harness) — 36 tests pass, including the new `sarashinaProfilePinsFields()` and the extended `namedLooksUpKnownProfilesByID()`.
- `swiftlint lint --strict` on the changed source — clean (confirms the underscore-free name).

Part of #975 · candidate intake #979 · pattern from #970.
Closes #1015.

---

## Gate-1 outcome (2026-07-08) — NO-GO, blocked (profile retained)

Running the Mac filter with this profile was a **NO-GO**: 3/6 cells failed with "Model generated no output tokens" — the model samples EOG/EOS at position 0 under the GBNF grammar → empty generation → retry-budget exhaustion. This is the deferred inference-side **#751 sub-class 2**, NOT the #366/#371 crash class (the SafeSampler crash-hardening held — no SIGABRT).

**This PR is still worth landing.** The profile values are correct (the failure is the inference-side #751 interaction, not a wrong field), and the profile is a ready **reproduction case** for #751 — running `pastura-harness word_wolf.yaml` with `sarashina-2-2-3b-q4-k-m` reliably triggers the empty-output failure. It is retained for a re-eval after #751 lands. Full scorecard + no-go writeup: #979.
