### PR TITLE
✨ feat: editor lint warnings + phase-aware hint + gallery lint CI (ADR-024 PR2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,10 @@ jobs:
       pull-requests: read
     outputs:
       ios: ${{ steps.classify.outputs.ios }}
+      # ADR-024 D6: true when a shipped scenario YAML (bundled preset OR
+      # gallery) changed, so the harness `lint` gate runs even on a
+      # gallery-only PR (which classifies ios=false). See the classify step.
+      scenarios: ${{ steps.classify.outputs.scenarios }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -86,6 +90,11 @@ jobs:
           # can never skip tests on main. (Also keeps push off the API path.)
           if [ "${{ github.event_name }}" != "pull_request" ]; then
             echo "ios=true" >> "$GITHUB_OUTPUT"
+            # Conservative-by-inversion (ci-workflows.md invariant 1): emit
+            # scenarios=true on every early-exit too, so the harness lint gate
+            # is never left un-triggered by an unset output if the ios arm is
+            # ever narrowed. On non-PR events ios=true already runs harness-build.
+            echo "scenarios=true" >> "$GITHUB_OUTPUT"
             echo "Non-PR event → always run the full iOS suite (main stability)."
             exit 0
           fi
@@ -105,6 +114,7 @@ jobs:
           # file list ⇒ run the full iOS suite.
           if [ -z "$FILES" ]; then
             echo "ios=true" >> "$GITHUB_OUTPUT"
+            echo "scenarios=true" >> "$GITHUB_OUTPUT"
             echo "No file list resolved → defaulting to the full iOS suite."
             exit 0
           fi
@@ -119,6 +129,7 @@ jobs:
           # real iOS change). Default to the full suite instead.
           if ! TOKENS=$(printf '%s\n' "$FILES" | bash scripts/precommit-gate-classify.sh); then
             echo "ios=true" >> "$GITHUB_OUTPUT"
+            echo "scenarios=true" >> "$GITHUB_OUTPUT"
             echo "Classifier failed → defaulting to the full iOS suite."
             exit 0
           fi
@@ -127,6 +138,20 @@ jobs:
             echo "ios=true" >> "$GITHUB_OUTPUT"
           else
             echo "ios=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # ADR-024 D6: independent of the ios classification, flag whether a
+          # shipped scenario YAML changed so `harness-build` runs its `pastura-
+          # harness lint` gate. This is the ONLY path that re-triggers the gate
+          # on a gallery-only PR (docs/ is build-irrelevant ⇒ ios=false), and it
+          # rides the existing `swift build` rather than the heavy macOS suite.
+          # Presets already force ios=true (Resources/ is non-SAFE); listing them
+          # keeps the output honest about both lint globs. `.ya?ml` matches the
+          # bundled/gallery `.yaml` convention (and any stray `.yml`).
+          if printf '%s\n' "$FILES" | grep -qE '^(Pastura/Pastura/Resources/Presets/|docs/gallery/).+\.ya?ml$'; then
+            echo "scenarios=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "scenarios=false" >> "$GITHUB_OUTPUT"
           fi
 
   lint-and-test:
@@ -474,7 +499,10 @@ jobs:
   harness-build:
     name: Harness package build + tests (ADR-013)
     needs: changes
-    if: ${{ !cancelled() && needs.changes.outputs.ios != 'false' }}
+    # Runs on any iOS-relevant change (ios != false) OR when a shipped scenario
+    # YAML changed (scenarios == true) — the latter re-triggers the ADR-024 D6
+    # `lint` gate on a gallery-only PR that would otherwise classify ios=false.
+    if: ${{ !cancelled() && (needs.changes.outputs.ios != 'false' || needs.changes.outputs.scenarios == 'true') }}
     runs-on: macos-26
     timeout-minutes: 15
     env:
@@ -501,6 +529,15 @@ jobs:
 
       - name: Run harness package tests
         run: swift test
+
+      # ADR-024 D6: inference-free zero-regression gate over every shipped
+      # scenario YAML (bundled presets + gallery). Reuses the executable built
+      # by `swift build` above (no rebuild). Exit non-zero on any parse /
+      # validator failure or error-severity lint finding; warnings are listed
+      # but non-fatal. Rides this cheap job so it never extends the ui-test
+      # critical path.
+      - name: Lint shipped scenarios (ADR-024)
+        run: swift run pastura-harness lint Pastura/Pastura/Resources/Presets docs/gallery
 
   # Drift guard for bundled DL-time demo replays (#170, spec §3.3 / §5.2).
   # Re-hashes shipped preset YAMLs and validates each bundled demo's

--- a/Pastura/Pastura/App/ScenarioEditorViewModel.swift
+++ b/Pastura/Pastura/App/ScenarioEditorViewModel.swift
@@ -82,6 +82,13 @@ final class ScenarioEditorViewModel {  // swiftlint:disable:this type_body_lengt
 
   var editorMode: EditorMode = .visual
   private(set) var validationErrors: [String] = []
+  /// Non-blocking semantic-lint findings (`.warning` / `.info`) from the most
+  /// recent ``validate()``, surfaced in the editor's suggestions banner
+  /// (ADR-024 PR2). `.error`-severity findings live in ``validationErrors``
+  /// (blocking); these never block Save. Empty except immediately after a
+  /// `validate()` that reached the linter — reset alongside `validationErrors`
+  /// on every mode switch / load so a stale suggestion never outlives its scenario.
+  private(set) var lintWarnings: [LintFinding] = []
   private(set) var isValid = false
   private(set) var isSaving = false
   private(set) var savedScenarioId: String?
@@ -108,9 +115,10 @@ final class ScenarioEditorViewModel {  // swiftlint:disable:this type_body_lengt
   private let validator = ScenarioValidator()
   private let contentValidator = ScenarioContentValidator()
   /// Semantic linter (ADR-024). Its `.error` findings join the blocking
-  /// `validationErrors` array; warnings/info are not surfaced (PR2 scope).
-  /// Run on the same `Scenario` the validator sees (the `currentScenario()`
-  /// funnel output) — never a fresh visual-state build, per the funnel invariant.
+  /// `validationErrors` array; `.warning`/`.info` go to the non-blocking
+  /// ``lintWarnings`` suggestions banner. Run on the same `Scenario` the
+  /// validator sees (the `currentScenario()` funnel output) — never a fresh
+  /// visual-state build, per the funnel invariant.
   private let linter = ScenarioSemanticLinter()
 
   /// Top-level YAML keys without a Visual UI, captured by
@@ -133,6 +141,7 @@ final class ScenarioEditorViewModel {  // swiftlint:disable:this type_body_lengt
   ///
   /// Generates a new UUID-based ID to prevent collision with the original.
   func loadFromTemplate(yaml: String) {
+    lintWarnings = []
     do {
       let scenario = try loader.load(yaml: yaml)
       populateFromScenario(scenario)
@@ -149,6 +158,7 @@ final class ScenarioEditorViewModel {  // swiftlint:disable:this type_body_lengt
   /// Loads an existing scenario for editing (preserves original ID).
   /// Gallery-sourced rows are read-only and refuse to load for editing.
   func loadForEditing(scenarioId: String) async {
+    lintWarnings = []
     do {
       if let record = try await offMain({ [repository] in
         try repository.fetchById(scenarioId)
@@ -184,6 +194,7 @@ final class ScenarioEditorViewModel {  // swiftlint:disable:this type_body_lengt
   /// ``validate()`` runs so the user sees parse / structural errors right
   /// away.
   func loadFromFile(url: URL) async {
+    lintWarnings = []
     let scoped = url.startAccessingSecurityScopedResource()
     defer { if scoped { url.stopAccessingSecurityScopedResource() } }
 
@@ -206,6 +217,7 @@ final class ScenarioEditorViewModel {  // swiftlint:disable:this type_body_lengt
   /// validation banner. Routed through the same key as `loadFromFile`
   /// since both are file-I/O failures from the user's perspective.
   func surfaceFileImportError(_ error: any Error) {
+    lintWarnings = []
     validationErrors = [
       String(format: String(localized: "Failed to read file: %@"), error.localizedDescription)
     ]
@@ -221,6 +233,7 @@ final class ScenarioEditorViewModel {  // swiftlint:disable:this type_body_lengt
   /// survive; structural or block-scalar changes (and a blank base) fall back to
   /// canonical serialization.
   func switchToYAMLMode() {
+    lintWarnings = []
     let scenario = buildScenario()
     yamlText = patcher.patch(visual: scenario, base: yamlText)
     editorMode = .yaml
@@ -233,6 +246,7 @@ final class ScenarioEditorViewModel {  // swiftlint:disable:this type_body_lengt
   /// - Returns: `true` if switch succeeded, `false` if YAML is invalid.
   @discardableResult
   func switchToVisualMode() -> Bool {
+    lintWarnings = []
     let trimmed = yamlText.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else {
       validationErrors = [String(localized: "YAML is empty")]
@@ -256,6 +270,10 @@ final class ScenarioEditorViewModel {  // swiftlint:disable:this type_body_lengt
   /// Validates the current editor state (from whichever mode is active).
   func validate() {
     validationErrors = []
+    // Reset here (not only at the success point) so an early return below —
+    // visual field error, empty YAML, parse/validator throw — clears a prior
+    // run's suggestions instead of leaving them under a new blocking error.
+    lintWarnings = []
     isValid = false
 
     // Mode-specific pre-checks (visual: field UX errors, YAML: empty guard).
@@ -299,9 +317,12 @@ final class ScenarioEditorViewModel {  // swiftlint:disable:this type_body_lengt
       validationErrors.append(contentsOf: contentFindings)
       // Semantic-lint errors block commit alongside structural/content errors
       // (ADR-024). Same `scenario` value the validator received, per the
-      // `currentScenario()` funnel. Warnings/info stay unsurfaced (PR2 scope).
-      let lintErrors = linter.lint(scenario).filter { $0.severity == .error }.map(\.message)
-      validationErrors.append(contentsOf: lintErrors)
+      // `currentScenario()` funnel. Warnings/info are non-blocking — routed to
+      // `lintWarnings` for the suggestions banner (ADR-024 PR2).
+      let findings = linter.lint(scenario)
+      validationErrors.append(
+        contentsOf: findings.filter { $0.severity == .error }.map(\.message))
+      lintWarnings = findings.filter { $0.severity != .error }
       if validationErrors.isEmpty {
         isValid = true
       }

--- a/Pastura/Pastura/Engine/PlaceholderAvailability.swift
+++ b/Pastura/Pastura/Engine/PlaceholderAvailability.swift
@@ -165,6 +165,26 @@ nonisolated public enum PlaceholderAvailability {
     "agent1", "action1", "agent2", "action2", "score1", "score2"
   ]
 
+  /// Tokens a producer phase writes into `state.variables` and that ANY later
+  /// LLM phase's prompt can read via generic `{token}` expansion — the
+  /// cross-phase-readable complement of the per-persona `inject*` tokens (whose
+  /// availability is phase-type-specific and already modeled by
+  /// ``supplied(for:chooseRoundRobin:)``). Derived as the producer-gated tokens
+  /// minus the per-persona / whisper injected forms so it stays in lockstep with
+  /// ``producerMap``: `{assigned_topic, wolf_name, vote_results, current_event}`.
+  ///
+  /// The editor's phase-aware prompt hint (#920 B) unions this into every LLM
+  /// phase's supplied set, so an author still discovers `{assigned_topic}` /
+  /// `{current_event}` — usable when an upstream `assign` / `event_inject` ran,
+  /// and permitted by the R10/R11 linter's global known-token set. Whether a
+  /// producer actually runs earlier stays R11's lane, not the hint's. A custom
+  /// `event_inject` `as:` name is scenario-specific and intentionally absent
+  /// (the editor sheet has no scenario context; only the default is listed).
+  static let crossPhaseStateReadable: Set<String> =
+    Set(producerMap.keys)
+    .subtracting(perPersonaInjected)
+    .subtracting(whisperSelfInjected)
+
   /// Producer-gated token → producing phase type(s). Cross-checked against
   /// ``supplied(for:chooseRoundRobin:)`` in tests: every producer's output token
   /// is also in that producer's supplied set.

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -6170,6 +6170,16 @@
         }
       }
     },
+    "Suggestions" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提案"
+          }
+        }
+      }
+    },
     "Summarize" : {
       "localizations" : {
         "ja" : {
@@ -6772,22 +6782,22 @@
         }
       }
     },
+    "Variables: %@" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "変数: %@"
+          }
+        }
+      }
+    },
     "Variables: {current_round}, {scoreboard}, {vote_results}" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "変数: {current_round}, {scoreboard}, {vote_results}"
-          }
-        }
-      }
-    },
-    "Variables: {scoreboard}, {conversation_log}, {opponent_name}, {assigned_topic}, {assigned}, {assigned_word}, {current_event}" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "変数: {scoreboard}, {conversation_log}, {opponent_name}, {assigned_topic}, {assigned}, {assigned_word}, {current_event}"
           }
         }
       }

--- a/Pastura/Pastura/Views/Editor/PhaseEditorSheet+CanonicalFieldHint.swift
+++ b/Pastura/Pastura/Views/Editor/PhaseEditorSheet+CanonicalFieldHint.swift
@@ -76,4 +76,22 @@ extension PhaseEditorSheet {
       return nil
     }
   }
+
+  /// The phase-aware `{token}` hint listed under an LLM phase's prompt editor
+  /// (#920 B, ADR-024 D4). Reads the linter-owned ``PlaceholderAvailability``
+  /// map instead of a static hardcoded list: the tokens this phase's handler
+  /// injects (``PlaceholderAvailability/supplied(for:chooseRoundRobin:)`` — so a
+  /// round-robin `choose` gains `{opponent_name}` and the whisper channel, and
+  /// `vote` gains `{candidates}`) unioned with the cross-phase state tokens any
+  /// prompt may read (``PlaceholderAvailability/crossPhaseStateReadable``),
+  /// sorted and brace-wrapped. `static` so it is unit-testable without rendering
+  /// the sheet.
+  static func promptVariableHint(for phase: EditablePhase) -> String {
+    PlaceholderAvailability
+      .supplied(for: phase.type, chooseRoundRobin: phase.pairing == .roundRobin)
+      .union(PlaceholderAvailability.crossPhaseStateReadable)
+      .sorted()
+      .map { "{\($0)}" }
+      .joined(separator: ", ")
+  }
 }

--- a/Pastura/Pastura/Views/Editor/PhaseEditorSheet.swift
+++ b/Pastura/Pastura/Views/Editor/PhaseEditorSheet.swift
@@ -192,10 +192,7 @@ struct PhaseEditorSheet: View {
     } footer: {
       VStack(alignment: .leading, spacing: 4) {
         Text(
-          String(
-            localized:
-              "Variables: {scoreboard}, {conversation_log}, {opponent_name}, {assigned_topic}, {assigned}, {assigned_word}, {current_event}"
-          )
+          String(format: String(localized: "Variables: %@"), Self.promptVariableHint(for: phase))
         )
         .font(.caption)
         if let promptError {

--- a/Pastura/Pastura/Views/Editor/ScenarioEditorView+Banners.swift
+++ b/Pastura/Pastura/Views/Editor/ScenarioEditorView+Banners.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+// The editor's two stacked status banners. Split out of `ScenarioEditorView.swift`
+// to keep that file under SwiftLint's `file_length` limit. The blocking
+// `validationBanner` (structural / content / lint-error) sits above the
+// non-blocking `suggestionsBanner` (semantic-lint warning/info, ADR-024 PR2);
+// the warm `warningSoft` tone vs `dangerSoft` distinguishes advisory from Save-blocking.
+
+extension ScenarioEditorView {
+  // MARK: - Validation Banner
+
+  var validationBanner: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      ForEach(viewModel.validationErrors, id: \.self) { error in
+        HStack(spacing: 6) {
+          Image(systemName: "exclamationmark.triangle.fill")
+            .foregroundStyle(Color.warning)
+          Text(error)
+            .font(.caption)
+        }
+      }
+    }
+    .padding(.horizontal)
+    .padding(.vertical, 8)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(Color.dangerSoft)
+  }
+
+  // MARK: - Suggestions Banner
+
+  /// Non-blocking semantic-lint findings (`.warning` / `.info`) from the
+  /// linter, surfaced below the blocking validation banner (ADR-024 PR2). The
+  /// warm `warningSoft` tone + "Suggestions" header distinguish it from the
+  /// `dangerSoft` error banner so it reads as advisory, not a Save blocker.
+  /// `enumerated().offset` supplies `ForEach` identity because `LintFinding` is
+  /// `Equatable` but not `Hashable`, and a rule can fire on multiple phases.
+  var suggestionsBanner: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      Text(String(localized: "Suggestions"))
+        .font(.caption.bold())
+        .foregroundStyle(Color.warningInk)
+      ForEach(Array(viewModel.lintWarnings.enumerated()), id: \.offset) { _, finding in
+        HStack(spacing: 6) {
+          Image(
+            systemName: finding.severity == .info
+              ? "info.circle.fill" : "exclamationmark.triangle.fill"
+          )
+          .foregroundStyle(finding.severity == .info ? Color.info : Color.warning)
+          Text(finding.message)
+            .font(.caption)
+        }
+      }
+    }
+    .padding(.horizontal)
+    .padding(.vertical, 8)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(Color.warningSoft)
+  }
+}

--- a/Pastura/Pastura/Views/Editor/ScenarioEditorView.swift
+++ b/Pastura/Pastura/Views/Editor/ScenarioEditorView.swift
@@ -38,6 +38,12 @@ struct ScenarioEditorView: View {  // swiftlint:disable:this type_body_length
         validationBanner
       }
 
+      // Non-blocking semantic-lint suggestions (ADR-024 PR2) — shown below any
+      // blocking errors; never gates Save.
+      if !viewModel.lintWarnings.isEmpty {
+        suggestionsBanner
+      }
+
       // Content
       if viewModel.editorMode == .visual {
         visualEditor
@@ -355,25 +361,6 @@ struct ScenarioEditorView: View {  // swiftlint:disable:this type_body_length
       .autocorrectionDisabled()
       .textInputAutocapitalization(.never)
       .padding(.horizontal)
-  }
-
-  // MARK: - Validation Banner
-
-  private var validationBanner: some View {
-    VStack(alignment: .leading, spacing: 4) {
-      ForEach(viewModel.validationErrors, id: \.self) { error in
-        HStack(spacing: 6) {
-          Image(systemName: "exclamationmark.triangle.fill")
-            .foregroundStyle(Color.warning)
-          Text(error)
-            .font(.caption)
-        }
-      }
-    }
-    .padding(.horizontal)
-    .padding(.vertical, 8)
-    .frame(maxWidth: .infinity, alignment: .leading)
-    .background(Color.dangerSoft)
   }
 
   // MARK: - Mode Binding

--- a/Pastura/PasturaTests/App/ScenarioEditorViewModelTests.swift
+++ b/Pastura/PasturaTests/App/ScenarioEditorViewModelTests.swift
@@ -173,8 +173,8 @@ struct ScenarioEditorViewModelTests {
   }
 
   /// A warning-only lint finding (`choose` without `options`, R7) must NOT
-  /// block: warnings/info are unsurfaced in the editor at this stage (PR2
-  /// scope), so the scenario stays valid.
+  /// block: it surfaces non-blocking in `lintWarnings` (ADR-024 PR2), so the
+  /// scenario stays valid and `validationErrors` stays empty.
   @Test func validateAllowsSemanticLintWarningOnly() throws {
     let sut = try makeSUT()
     sut.yamlText = """
@@ -202,6 +202,49 @@ struct ScenarioEditorViewModelTests {
 
     #expect(sut.isValid)
     #expect(sut.validationErrors.isEmpty)
+    // ADR-024 PR2: the warning is now surfaced non-blocking in lintWarnings.
+    #expect(sut.lintWarnings.contains { $0.ruleID == "choose-should-declare-options" })
+    #expect(sut.lintWarnings.allSatisfy { $0.severity != .error })
+  }
+
+  /// Regression (ADR-024 PR2, plan critic Axis 4): a warning that populated
+  /// `lintWarnings` on one clean validate must not survive into a later
+  /// early-return validate. Here the second validate flips to visual mode with
+  /// empty fields, so it returns at the "name is required" pre-check *before*
+  /// the linter runs — the reset must live at the top of `validate()`, not only
+  /// at its success point. Reverting that top-of-`validate()` reset fails this.
+  @Test func validateClearsStaleWarningsOnEarlyReturn() throws {
+    let sut = try makeSUT()
+    sut.yamlText = """
+      id: lint_warn_editor
+      language: ja
+      name: Lint Warn Editor
+      description: choose without options is a warning
+      agents: 2
+      rounds: 1
+      context: Context
+      personas:
+        - name: Alice
+          description: Agent A
+        - name: Bob
+          description: Agent B
+      phases:
+        - type: choose
+          prompt: "Pick"
+          output:
+            action: string
+      """
+    sut.editorMode = .yaml
+    sut.validate()
+    #expect(!sut.lintWarnings.isEmpty)  // precondition: warning surfaced
+
+    // Flip to visual mode; the visual fields were never populated, so
+    // validate() early-returns at the empty-name pre-check before the linter.
+    sut.editorMode = .visual
+    sut.validate()
+
+    #expect(!sut.validationErrors.isEmpty)  // blocked on the empty-name error
+    #expect(sut.lintWarnings.isEmpty)  // the stale warning was cleared
   }
 
   // MARK: - Save

--- a/Pastura/PasturaTests/Engine/PlaceholderAvailabilityTests.swift
+++ b/Pastura/PasturaTests/Engine/PlaceholderAvailabilityTests.swift
@@ -39,6 +39,18 @@ struct PlaceholderAvailabilityTests {
         .isDisjoint(with: PromptPlaceholders.engineSupplied))
   }
 
+  // MARK: - Cross-phase readable set (#920 B editor-hint source)
+
+  /// `crossPhaseStateReadable` is the producer-gated tokens minus the
+  /// per-persona / whisper injected forms — the state-variable tokens any LLM
+  /// phase's prompt can read. Pins the derived value so a `producerMap` /
+  /// `perPersonaInjected` change that shifts it fails here.
+  @Test func crossPhaseStateReadableIsProducerTokensMinusPerPersona() {
+    #expect(
+      PlaceholderAvailability.crossPhaseStateReadable
+        == ["assigned_topic", "wolf_name", "vote_results", "current_event"])
+  }
+
   // MARK: - Vote (VoteHandler)
 
   @Test func candidatesSuppliedByVoteOnly() {

--- a/Pastura/PasturaTests/Views/PhaseEditorSheetValidationTests.swift
+++ b/Pastura/PasturaTests/Views/PhaseEditorSheetValidationTests.swift
@@ -139,4 +139,32 @@ struct PhaseEditorSheetValidationTests {
     )
     #expect(subPromptFindings.prompt != nil)
   }
+
+  // MARK: - Prompt variable hint (#920 B, ADR-024 D4)
+
+  /// The prompt-footer hint is now phase-aware (reads the linter-owned
+  /// `PlaceholderAvailability` map) rather than a static list. A speak phase
+  /// lists its handler-injected tokens plus the cross-phase state tokens any
+  /// prompt may read (`{assigned_topic}` / `{current_event}` — the critic Axis-5
+  /// discoverability the static list carried), but NOT the round-robin-choose-
+  /// only `{opponent_name}`.
+  @Test func promptHintForSpeakPhaseListsInjectedAndCrossPhaseTokens() {
+    let hint = PhaseEditorSheet.promptVariableHint(for: EditablePhase(type: .speakAll))
+    #expect(hint.contains("{scoreboard}"))
+    #expect(hint.contains("{my_notes}"))
+    #expect(hint.contains("{assigned_topic}"))
+    #expect(hint.contains("{current_event}"))
+    #expect(!hint.contains("{opponent_name}"))
+  }
+
+  /// The `choose` round-robin qualifier flows through the hint: `{opponent_name}`
+  /// appears only for a round-robin `choose`, not the individual variant.
+  @Test func promptHintForChooseReflectsRoundRobinQualifier() {
+    let roundRobin = PhaseEditorSheet.promptVariableHint(
+      for: EditablePhase(type: .choose, pairing: .roundRobin))
+    let individual = PhaseEditorSheet.promptVariableHint(
+      for: EditablePhase(type: .choose))
+    #expect(roundRobin.contains("{opponent_name}"))
+    #expect(!individual.contains("{opponent_name}"))
+  }
 }


### PR DESCRIPTION
## Summary
ADR-024 PR2 (final) — the three remaining §5 items after PR1 (#1007) shipped the linter core.

1. **CI gate** — `pastura-harness lint` now runs in `harness-build` over bundled presets + gallery, pinning zero-regression (48 files, 0 errors, 0 warnings). A new `scenarios` output on the `changes` job re-triggers this cheap job on a **gallery-only PR** (which classifies `ios=false`), closing the gap where `docs/gallery/` YAML changes would otherwise skip semantic lint. Shared `precommit-gate-classify.sh` is untouched (pre-commit local DX preserved); the heavy macOS suite is not pulled in.
2. **Editor non-blocking warnings** — `ScenarioEditorViewModel.lintWarnings` routes `.warning`/`.info` findings to a new "Suggestions" banner in `ScenarioEditorView` (warm `warningSoft` tone, distinct from the blocking `dangerSoft` error banner). `.error` findings still block via `validationErrors`. Reset at the top of `validate()` so a later early-return can't leave stale suggestions.
3. **#920(B)** — `PhaseEditorSheet` prompt-variable hint is now phase-aware, read from the linter-owned `PlaceholderAvailability` map (`supplied(for:chooseRoundRobin:) ∪ crossPhaseStateReadable`) instead of a static list. Round-robin `choose` gains `{opponent_name}`; cross-phase state tokens (`{assigned_topic}`, `{current_event}`, …) stay discoverable, aligned with what the R10/R11 linter permits.

`summarizeSection`'s separate hardcoded hint is intentionally **out of scope**: `supplied(for:.summarize)` omits `{vote_results}`, which is genuinely usable there.

## Test plan
- `scripts/xcodebuild.sh test` — 2864 unit tests pass (new: VM warning routing + stale-clear, `crossPhaseStateReadable` derivation, phase-aware hint round-robin qualifier).
- `swift run pastura-harness lint …` — 48 files, 0 errors, 0 warnings.
- `swiftlint --strict` clean; `check_localization_coverage.py` — 632 keys, all `ja` translated.
- **CI verification note**: this gating PR touches only `.github/` + Swift, so it does not self-exercise the `scenarios=true / ios=false` gallery-only path (per `ci-workflows.md` invariant 5). The path is exercised the first time a gallery-only PR lands; the merge to `main` runs the full suite unconditionally.
- **Device QA** (advisory): the Suggestions banner is code-review/manual-QA gated (no ViewInspector) — visual check on a real device recommended.

Closes #994
Closes #920

🤖 Generated with [Claude Code](https://claude.com/claude-code)
