### PR TITLE
📝 docs: localize ja App Store subtitle + switch ja listing URLs to /ja/

### DIFF
--- a/docs/store/README.md
+++ b/docs/store/README.md
@@ -17,11 +17,14 @@ the copy that a human pastes into App Store Connect.
 ## Fixed values (do not change)
 
 - **Name**: `Pastura - Local LLMs simulator` (globally unique; `release-setup.md` B2)
-- **Subtitle**: `Like stargazing, but for LLMs` (29/30 chars)
+- **Subtitle** (per-locale): en `Like stargazing, but for LLMs` (29/30) · ja `天体観測のように、LLM観測` (14/30)
 - **Primary category**: Developer Tools · **Secondary**: Entertainment (per-version editable, not a one-way door)
 - **Age rating**: 13+ (ADR-005 §3.2; 16+ pre-planned fallback)
 - **Primary locale**: en (Go criterion = English submission Approved)
-- **URLs**: Support `https://pastura.app/support/` · Marketing `https://pastura.app/` · Privacy `https://pastura.app/legal/privacy-policy/`
+- **URLs** (Support/Marketing are per-locale; Privacy Policy is set in App Information):
+  - en — Support `https://pastura.app/support/` · Marketing `https://pastura.app/`
+  - ja — Support `https://pastura.app/ja/support/` · Marketing `https://pastura.app/ja/`
+  - Privacy Policy `https://pastura.app/legal/privacy-policy/` (ja: `https://pastura.app/ja/legal/privacy-policy/`)
 
 ## Pre-submission checklist (operator)
 
@@ -52,8 +55,8 @@ Copy is ready; these are the gates around it. Not all are in this repo's scope.
 
 | Field | Limit | en | ja |
 |---|---|---|---|
-| Subtitle | 30 | 29 | (English, shared) |
-| Description | 4,000 | 1,995 | 1,080 |
+| Subtitle | 30 | 29 | 14 |
+| Description | 4,000 | 1,995 | 1,070 |
 | Keywords | 100 | 97 | 86 |
 | Promotional Text | 170 | 164 | 93 |
 

--- a/docs/store/listing-ja.md
+++ b/docs/store/listing-ja.md
@@ -13,10 +13,21 @@
 
 ## App name / Subtitle
 
-The store Name (`Pastura - Local LLMs simulator`) and Subtitle
-(`Like stargazing, but for LLMs`) are kept in English across both locales
-(confirmed values, `docs/release-setup.md` Part B2). Localizing them to ja is
-possible in ASC but out of scope for 1.0 — the English wordplay is the brand.
+The store **Name** (`Pastura - Local LLMs simulator`) is kept in English across
+both locales (confirmed value, `docs/release-setup.md` Part B2) — the English
+brand identity plus the global-uniqueness constraint (`Pastura` alone is reserved).
+
+The **Subtitle** is localized per locale (the Subtitle field is per-locale and
+search-indexed in App Store Connect):
+
+| Locale | Subtitle | Chars |
+|---|---|---|
+| en | `Like stargazing, but for LLMs` | 29 / 30 |
+| ja | `天体観測のように、LLM観測` | 14 / 30 |
+
+The ja subtitle reads naturally in Japanese, echoes the Description opener
+(`AI観測。天体観測のように…`), and — since the Subtitle field is search-indexed — adds
+ja keyword surface that an English subtitle would not.
 
 ## Promotional Text
 
@@ -60,8 +71,9 @@ LLM モデルは他人のサーバーではなく、あなたの端末の中に�
 
 ## Keywords
 
-> `AI観測` and `ローカルLLM` are ja search terms; the English Name/Subtitle don't
-> compete with them within the ja keyword field.
+> `AI観測` and `ローカルLLM` are ja search terms; the English Name and the ja
+> Subtitle (`天体観測のように、LLM観測`) add complementary surface, not duplicating
+> these exact keyword tokens.
 
 ```
 AIエージェント,オンデバイス,オフライン,マルチエージェント,ロールプレイ,ローカルLLM,人狼,囚人のジレンマ,シナリオ,AI観測,サンドボックス,Gemma,Qwen
@@ -71,15 +83,18 @@ AIエージェント,オンデバイス,オフライン,マルチエージェン
 
 ## URLs
 
-Same as EN — the site serves ja mirrors at the same paths (`/support/` etc.
-resolve per Accept-Language / locale). ASC URL fields are not per-locale on the
-public host, so reuse:
+Support URL and Marketing URL are set **per App Store locale** — each version
+localization has its own URL fields (confirmed in the ASC UI: the en locale
+holds the root paths, the ja locale the `/ja/`-prefixed pages). The Astro site
+serves both as static locale-prefixed routes; there is no Accept-Language
+redirect. Privacy Policy URL is set in App Information (アプリ情報), not on the
+version page. ja-locale values:
 
-| Field | Value |
+| Field | Value (ja locale) |
 |---|---|
-| Support URL | `https://pastura.app/support/` |
-| Marketing URL | `https://pastura.app/` |
-| Privacy Policy URL | `https://pastura.app/legal/privacy-policy/` |
+| Support URL | `https://pastura.app/ja/support/` |
+| Marketing URL | `https://pastura.app/ja/` |
+| Privacy Policy URL | `https://pastura.app/ja/legal/privacy-policy/` |
 
 ## Screenshot captions (JA)
 


### PR DESCRIPTION
## Summary
Syncs `docs/store/` (the source-of-truth copy pasted into App Store Connect) to the values actually submitted for the 1.0 review.

- **ja Subtitle** localized to `天体観測のように、LLM観測` (14/30). The Subtitle field is per-locale and search-indexed in ASC, so a Japanese subtitle adds ja keyword surface an English one would not; it echoes the Description opener (`AI観測。天体観測のように…`). The app **Name** stays English (brand identity + global-uniqueness — `Pastura` alone is reserved).
- **ja Support/Marketing URLs** switched to the `/ja/` localized pages (en stays root). Confirmed in the ASC UI that these URL fields are per-locale (operator screenshots: en=root, ja=/ja/); the three `/ja/` pages return HTTP 200 and exist in `web/src/pages/ja/`. This corrects the old prose that claimed URLs "resolve per Accept-Language" and are "not per-locale".
- **README.md** kept consistent: subtitle fixed-value line, char-limit table ja cell = 14, URL split en/ja. Also fixes a pre-existing stale ja Description count (`1,080` → `1,070`, verified by code-point count).
- Privacy Policy URL noted as set in App Information (single field), not the version page.

See #233 (App Store release prep) — that issue is closed separately.

## Test plan
Docs-only, no code. Verified by count: ja subtitle = 14 code points, ja Description = 1,070; all three `/ja/` URLs return HTTP 200. code-reviewer PASS (cross-doc consistency, factual accuracy, stale-prose removal, markdown well-formedness).

> Supersedes the operator's uncommitted `/ja/` URL edit in the main working tree — after merge, discard it with `git checkout docs/store/listing-ja.md`.