### PR TITLE
🐛 fix: grammar-first resample kills empty output (#751 sub-class 2)

### DIFF
--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -277,10 +277,18 @@ Max 2 retries. Retry on:
 - JSON parse failure
 - Empty fields ("..." or empty string)
 
-**Deferred (#751 sub-class 2):** completely-empty model output (EOG-at-
-position-0 suspected) exhausts the retry budget. It is inference-side, not
-parser-recoverable — root-cause on-device per the issue before adding any
-retry-budget change. Tracked under #751.
+**Empty-output → grammar-first resample (#751 sub-class 2, FIXED).**
+Completely-empty model output was NOT a retry-budget problem: b8694's
+`llama_sampler_dist_apply` silently selected a grammar-masked (`-inf`)
+token when the grammar (as a chain member, applied after top_k) masked the
+sorted top candidate — the pick is RNG-independent, so all retries
+reproduced it identically and the budget could never recover. Fixed by
+splitting the grammar out of the sampler chain and resampling grammar-first
+on a miss (`LlamaCppService.grammarConstrainedSample`, mirroring llama.cpp's
+`common_sampler_sample`) — see ADR-002 § "Grammar-all-rejected dist
+fallthrough". The retry budget itself is unchanged; the failure is gone at
+the sampler. Diagnostic `samplerGrammarResample` (position-0) measures the
+residual rescue rate as a model-onboarding fragility signal.
 
 **Grammar-accept crash after object completion → graceful stop (#907).** For
 single-field grammars (e.g. `reflect`'s `{ note }`) Gemma 4 E2B frequently
@@ -459,13 +467,17 @@ grammar mode, split the chain into two samplers, or build a
 grammar. (PR #480 commit eb26153, reverted in 4ffaf6f; ADR-011.)
 
 The **EOG-path** variant of this abort (#253 — EOG sampled mid-generation,
-not prompt-token accept) is now mitigated with exactly that
-"control-the-accept-explicitly" technique: `LlamaCppService.safeSample`
-splits the grammar-active step into `llama_sampler_apply` + a guarded
-`llama_sampler_accept`, skipping the accept for EOG tokens (whose post-EOG
-grammar state is never read). Non-EOG selection is byte-identical to the
-bundled `llama_sampler_sample`, so the distribution is unchanged. SafeSampler
-still cannot *catch* a `SIGABRT`; the EOG abort is *avoided*, not caught.
+not prompt-token accept) is mitigated with exactly that
+"control-the-accept-explicitly" technique. As of #751 the grammar is held
+**outside** the sampler chain (`SamplerHandles`) and driven by
+`LlamaCppService.grammarConstrainedSample`: `llama_sampler_apply` masks,
+the chain selects, and the accept is taken on the grammar handle for
+**non-EOG tokens only** (whose post-EOG grammar state is never read).
+Non-EOG selection matches the bundled `common_sampler_sample`, so the
+distribution is unchanged. SafeSampler still cannot *catch* a `SIGABRT`;
+the EOG abort is *avoided*, not caught. The same split-out grammar also
+fixes #751 sub-class 2 (grammar-first resample) — see ADR-002
+§ "Grammar-all-rejected dist fallthrough" and § "Retry Policy" above.
 (ADR-002 §12.9 Mitigation, #253.)
 
 ### Grammar must not enumerate values — structure only

--- a/Pastura/Pastura/LLM/LlamaCppService+GrammarSample.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService+GrammarSample.swift
@@ -1,0 +1,177 @@
+import Foundation
+import LlamaSwift
+
+// MARK: - Grammar-constrained two-pass sampling (#751)
+
+extension LlamaCppService {
+  /// Grammar-constrained token sampling, mirroring llama.cpp's
+  /// `common_sampler_sample` (upstream `common/sampling.cpp`) two-pass
+  /// strategy — the fix for #751 sub-class 2 (empty output / masked
+  /// selection).
+  ///
+  /// **Why two passes.** The grammar is held OUTSIDE the sampler chain (see
+  /// ``SamplerHandles``). A single-pass "grammar inside the chain" runs the
+  /// grammar mask AFTER top_k's truncation; b8694's `llama_sampler_dist_apply`
+  /// then degenerates when the sorted top candidate is masked (`max_l =
+  /// data[0].logit = -inf` → NaN/`exp(+inf)` softmax) or when every truncated
+  /// candidate is masked (all-NaN scan, `assert(found)` compiled out of the
+  /// release xcframework) — either way it silently selects a grammar-invalid
+  /// token, which at position 0 becomes empty output. Splitting the grammar
+  /// out and applying it grammar-FIRST on the resample lets top_k re-sort on
+  /// the masked logits, so `data[0]` is always grammar-valid.
+  ///
+  /// **The passes:**
+  /// 1. Sample from the grammar-free chain (`penalties → top_k → top_p →
+  ///    temp → dist`). If the pick already satisfies the grammar (the common
+  ///    case — the model's top token is grammar-valid), accept and return it.
+  ///    A single-token grammar `apply` is side-effect-free (apply only reads
+  ///    the grammar stacks; only `accept` mutates them), so this probe never
+  ///    desyncs grammar state.
+  /// 2. On a grammar miss, resample: re-fill full-vocab logits, apply the
+  ///    grammar FIRST (masking invalid tokens), then the chain. `data[0]` is
+  ///    grammar-valid, so the dist degeneracy cannot recur.
+  ///
+  /// **Terminal branch.** If the grammar-first pass ALSO lands on a masked
+  /// token, the grammar admits nothing here (all tokens masked, incl. EOG) —
+  /// a genuinely dead grammar state, distinct from the recoverable #751 case.
+  /// Rather than let the dist fallthrough emit garbage, stop gracefully at
+  /// EOS. Unreachable at position 0 for the shipped profiles (their vocabs
+  /// all contain a bare `{`); defensive only.
+  ///
+  /// **Accept discipline.** On a returned (non-terminal) token, the grammar
+  /// handle is advanced for every non-EOG token (EOG is skipped — the #253
+  /// post-EOG `GGML_ABORT`), and the chain is always advanced so its
+  /// penalties ring buffer tracks the emitted token. The grammar `accept`
+  /// can throw the `Unexpected empty grammar stack` `std::runtime_error`
+  /// (#334) and is routed through ``handleSamplerCatch(_:mode:)``; the chain
+  /// `accept` has no grammar member and cannot abort.
+  func grammarConstrainedSample(
+    handles: SamplerHandles,
+    context: OpaquePointer,
+    vocab: OpaquePointer?,
+    candidates: UnsafeMutableBufferPointer<llama_token_data>,
+    diag: SamplerDiagContext
+  ) throws -> Int32 {
+    let chain = handles.chain
+    guard let grammar = handles.grammar else {
+      // Programming error: a candidate buffer was allocated (schema present)
+      // but no grammar handle came back. `makeCandidateBuffer` and
+      // `createSampler` key off the same `schema != nil`, so this is
+      // unreachable — surface it loudly rather than silently mis-sample.
+      throw LLMError.generationFailed(
+        description: "grammarConstrainedSample: candidate buffer present without a grammar handle")
+    }
+    guard let base = candidates.baseAddress, !candidates.isEmpty else {
+      throw LLMError.generationFailed(
+        description: String(localized: "Sampler candidate buffer is empty"))
+    }
+    let count = candidates.count
+
+    // Pass 1: grammar-free chain sample.
+    let firstPick = try fillApplyAndSelect(
+      chain: chain, grammarFirst: nil, context: context, base: base, count: count)
+    if tokenSatisfiesGrammar(firstPick.id, grammar: grammar) {
+      try acceptSampledToken(
+        firstPick.id, chain: chain, grammar: grammar, vocab: vocab, mode: diag.mode)
+      return firstPick.id
+    }
+
+    // Pass 1 missed the grammar — telemetry for the model-onboarding
+    // pipeline: a nonzero position-0 resample rate is the empty-output
+    // fragility signal (weak JSON prior, e.g. Sarashina). Rescued here, not
+    // failed. Off the hot path (only fires when a resample is actually
+    // needed).
+    emitGrammarResampleDiagnostic(rejectedToken: firstPick.id, vocab: vocab, diag: diag)
+
+    // Pass 2: grammar FIRST, then the chain.
+    let resampled = try fillApplyAndSelect(
+      chain: chain, grammarFirst: grammar, context: context, base: base, count: count)
+
+    // Terminal: even the grammar-first pass selected a masked token → dead
+    // grammar. Stop at EOS (no accept — EOS ends generation).
+    if resampled.logit == -Float.infinity {
+      emitMaskedSelectionDiagnostic(
+        token: resampled.id, curP: resampled.array, vocab: vocab, diag: diag)
+      return llama_vocab_eos(vocab)
+    }
+
+    try acceptSampledToken(
+      resampled.id, chain: chain, grammar: grammar, vocab: vocab, mode: diag.mode)
+    return resampled.id
+  }
+
+  /// The result of one apply-and-select pass: the selected token id, its
+  /// post-apply logit (`-inf` iff grammar-masked), and the `cur_p` array it
+  /// was chosen from (for diagnostics).
+  nonisolated private struct SelectedToken {
+    let id: Int32
+    let logit: Float
+    let array: llama_token_data_array
+  }
+
+  /// Rebuild a full-vocab `cur_p` from the context's latest logits, apply
+  /// the grammar first (when `grammarFirst` is non-nil), then the chain, and
+  /// return the selected token. Fills `base[0..<count]` fresh each call so a
+  /// prior pass's truncation/reordering can't leak across the reused buffer.
+  private func fillApplyAndSelect(
+    chain: UnsafeMutablePointer<llama_sampler>,
+    grammarFirst: UnsafeMutablePointer<llama_sampler>?,
+    context: OpaquePointer,
+    base: UnsafeMutablePointer<llama_token_data>,
+    count: Int
+  ) throws -> SelectedToken {
+    guard let logits = llama_get_logits_ith(context, -1) else {
+      throw LLMError.generationFailed(
+        description: String(localized: "Sampler produced no logits"))
+    }
+    for i in 0..<count {
+      base[i] = llama_token_data(id: Int32(i), logit: logits[i], p: 0)
+    }
+    // `selected = -1` so a stale index can't leak; the chain's terminal dist
+    // sampler sets it. `apply` never mutates grammar state (only `accept`
+    // does), so applying the grammar here is side-effect-free.
+    var curP = llama_token_data_array(data: base, size: count, selected: -1, sorted: false)
+    if let grammarFirst {
+      llama_sampler_apply(grammarFirst, &curP)
+    }
+    llama_sampler_apply(chain, &curP)
+    guard curP.selected >= 0, curP.selected < Int64(curP.size), let data = curP.data else {
+      throw LLMError.generationFailed(
+        description: String(localized: "Sampler produced no selection"))
+    }
+    let picked = data[Int(curP.selected)]
+    return SelectedToken(id: picked.id, logit: picked.logit, array: curP)
+  }
+
+  /// Whether `token` is grammar-valid at the current grammar state. Applies
+  /// the grammar to a single-element `cur_p`; a `-inf` result means masked.
+  /// Side-effect-free on the grammar (apply reads stacks, only accept
+  /// mutates), so this probe never advances or desyncs grammar state.
+  private func tokenSatisfiesGrammar(
+    _ token: Int32, grammar: UnsafeMutablePointer<llama_sampler>
+  ) -> Bool {
+    var single = llama_token_data(id: token, logit: 0, p: 0)
+    return withUnsafeMutablePointer(to: &single) { ptr in
+      var arr = llama_token_data_array(data: ptr, size: 1, selected: -1, sorted: false)
+      llama_sampler_apply(grammar, &arr)
+      return ptr.pointee.logit != -Float.infinity
+    }
+  }
+
+  /// Advance the grammar (non-EOG only — #253) and the chain (always, for
+  /// penalties continuity) on the accepted token. Routes the grammar accept
+  /// through the C++ catch shim (#334); the chain accept cannot throw.
+  private func acceptSampledToken(
+    _ token: Int32,
+    chain: UnsafeMutablePointer<llama_sampler>,
+    grammar: UnsafeMutablePointer<llama_sampler>,
+    vocab: OpaquePointer?,
+    mode: String
+  ) throws {
+    if !llama_vocab_is_eog(vocab, token) {
+      let outcome = SafeSampler.accept(sampler: grammar, token: token)
+      try handleSamplerCatch(outcome.errorMessage, mode: mode)
+    }
+    _ = SafeSampler.accept(sampler: chain, token: token)
+  }
+}

--- a/Pastura/Pastura/LLM/LlamaCppService+GrammarSample.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService+GrammarSample.swift
@@ -88,11 +88,22 @@ extension LlamaCppService {
       chain: chain, grammarFirst: grammar, context: context, base: base, count: count)
 
     // Terminal: even the grammar-first pass selected a masked token → dead
-    // grammar. Stop at EOS (no accept — EOS ends generation).
+    // grammar. Stop generation (no accept). Return EOS so
+    // `nextContentTokenOrStop`'s `is_eog` check maps it to a clean stop.
+    // Guard the vocab-has-no-EOS case: `llama_vocab_eos` returns
+    // `LLAMA_TOKEN_NULL` (< 0) then, and `is_eog(-1)` is false — a raw -1
+    // would leak into the decode path as a "content" token. Route that
+    // (doubly-unreachable: dead grammar AND no EOS) through the graceful
+    // stop channel instead. All shipped profiles define an EOS.
     if resampled.logit == -Float.infinity {
       emitMaskedSelectionDiagnostic(
         token: resampled.id, curP: resampled.array, vocab: vocab, diag: diag)
-      return llama_vocab_eos(vocab)
+      let eos = llama_vocab_eos(vocab)
+      guard eos >= 0 else {
+        throw LLMError.samplerCrashCaught(
+          description: "grammar admits no token and vocab defines no EOS")
+      }
+      return eos
     }
 
     try acceptSampledToken(

--- a/Pastura/Pastura/LLM/LlamaCppService+PrepareGeneration.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService+PrepareGeneration.swift
@@ -5,16 +5,17 @@ import LlamaSwift
 
 /// Outputs of ``LlamaCppService/prepareGeneration(model:context:system:user:schema:)``.
 /// `vocab` is needed in the autoregressive loop (`llama_vocab_is_eog`,
-/// piece decoding); `sampler` is the configured chain (penalties → top_k →
-/// top_p → grammar → temperature → dist). The caller owns the sampler's
-/// lifetime — see the precondition note on the helper itself.
+/// piece decoding); `handles` bundles the configured chain (penalties →
+/// top_k → top_p → temperature → dist) and the optional grammar handle held
+/// separately from it (see ``SamplerHandles``). The caller owns both
+/// handles' lifetimes — see the precondition note on the helper itself.
 nonisolated struct PreparedGeneration {
   /// Optional to match the upstream `llama_model_get_vocab` return type
   /// and the existing `tokenize` / `decodePiece` / `decodePieceRaw`
   /// signatures, which all accept `OpaquePointer?` directly without a
   /// nil check at the use site.
   let vocab: OpaquePointer?
-  let sampler: UnsafeMutablePointer<llama_sampler>
+  let handles: SamplerHandles
 }
 
 extension LlamaCppService {
@@ -35,12 +36,15 @@ extension LlamaCppService {
   ///    helper accepts the captured pointers directly because the
   ///    private storage is not visible to sibling-file extensions.
   ///
-  /// **Sampler ownership** — the returned `sampler` is owned by the
+  /// **Sampler ownership** — the returned `handles` are owned by the
   /// caller. Pair every successful return with
-  /// `defer { llama_sampler_free(prepared.sampler) }` in the caller's
-  /// scope. The helper does NOT install its own defer because Swift's
-  /// `defer` only fires at the helper's scope exit, which would free
-  /// the sampler before the caller's inference loop runs.
+  /// `defer { llama_sampler_free(prepared.handles.chain) }` AND
+  /// `defer { prepared.handles.grammar.map { llama_sampler_free($0) } }`
+  /// in the caller's scope. The helper does NOT install its own defer
+  /// because Swift's `defer` only fires at the helper's scope exit, which
+  /// would free the handles before the caller's inference loop runs.
+  /// The split-out grammar is a separate allocation — freeing the chain
+  /// does not reach it (see ``SamplerHandles``).
   ///
   /// **Grammar wire-up** — both calling paths get grammar through this
   /// single seam when `schema` is non-nil. If a third call path is
@@ -82,13 +86,12 @@ extension LlamaCppService {
     // Build grammar once per call when a schema is requested.
     let grammarString = try schema.map { try GBNFGrammarBuilder().build(from: $0) }
 
-    // Keep `createSampler` as the LAST step in this helper. The sampler
-    // is freed by the caller's `defer { llama_sampler_free(...) }`; any
-    // step added after this and before the return would leak the sampler
-    // if it throws.
-    let sampler = try createSampler(grammarString: grammarString, vocab: vocab)
+    // Keep `createSampler` as the LAST step in this helper. The handles
+    // are freed by the caller's `defer`s; any step added after this and
+    // before the return would leak the chain / grammar if it throws.
+    let handles = try createSampler(grammarString: grammarString, vocab: vocab)
 
-    return PreparedGeneration(vocab: vocab, sampler: sampler)
+    return PreparedGeneration(vocab: vocab, handles: handles)
   }
 
   /// Shared empty-output postcondition for both `runGeneration` paths.

--- a/Pastura/Pastura/LLM/LlamaCppService+Sampler.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService+Sampler.swift
@@ -152,12 +152,13 @@ extension LlamaCppService {
   ///   - candidates: caller-owned, `n_vocab`-sized scratch buffer reused
   ///     across the token loop (avoids a per-token allocation). `nil` selects
   ///     the bundled fast path (no grammar active).
-  ///   - mode: `non-stream` / `stream` tag for the diagnostic line, so the
-  ///     analyzer can attribute catches to the calling loop.
+  ///   - diag: per-token diagnostic context (`mode` loop tag + generation
+  ///     `position`) for the always-on sampler telemetry; see
+  ///     ``SamplerDiagContext``.
   /// Allocate the reused per-generation candidate scratch buffer for the
   /// EOG-guarded sampling path, or `nil` when no grammar is active.
   ///
-  /// When a grammar is active, ``safeSample(sampler:context:vocab:candidates:mode:)``
+  /// When a grammar is active, ``safeSample(sampler:context:vocab:candidates:diag:)``
   /// replicates `llama_sampler_sample` so it can skip the abort-prone EOG
   /// accept, which needs an `n_vocab` candidate buffer. Allocated once per
   /// generation and reused across the token loop. Returns `nil` when
@@ -180,14 +181,14 @@ extension LlamaCppService {
     sampler: UnsafeMutablePointer<llama_sampler>, context: OpaquePointer,
     vocab: OpaquePointer?,
     candidates: UnsafeMutableBufferPointer<llama_token_data>?,
-    mode: String
+    diag: SamplerDiagContext
   ) throws -> Int32 {
     guard let candidates else {
       // No grammar active: the bundled sample+accept cannot hit the #253
       // grammar abort (no grammar to accept into), and reuses llama's
       // internal candidate buffer — keep the simpler, allocation-free path.
       let outcome = SafeSampler.sample(sampler: sampler, context: context, idx: -1)
-      try handleSamplerCatch(outcome.errorMessage, mode: mode)
+      try handleSamplerCatch(outcome.errorMessage, mode: diag.mode)
       return outcome.token
     }
 
@@ -221,60 +222,25 @@ extension LlamaCppService {
     }
     let token = selected[Int(curP.selected)].id
 
+    // #751 sub-class 2: a grammar-masked (-inf) selection means b8694's
+    // dist sampler degenerated (all-rejected NaN fallthrough, or a masked
+    // top candidate poisoning the sorted-flag softmax) — see
+    // `emitMaskedSelectionDiagnostic` for the mechanism. Telemetry only;
+    // behavior is intentionally unchanged here. The 2-pass grammar
+    // resample fix lands separately under #751.
+    if selected[Int(curP.selected)].logit == -Float.infinity {
+      emitMaskedSelectionDiagnostic(token: token, curP: curP, vocab: vocab, diag: diag)
+    }
+
     // #253: skip the accept for EOG. Accepting an EOG token advances the
     // grammar into the never-used post-EOG state whose all-non-empty-stack
     // case fires `GGML_ABORT`. Every non-EOG token accepts as the bundled
     // path would, so the distribution is unchanged.
     if !llama_vocab_is_eog(vocab, token) {
       let outcome = SafeSampler.accept(sampler: sampler, token: token)
-      try handleSamplerCatch(outcome.errorMessage, mode: mode)
+      try handleSamplerCatch(outcome.errorMessage, mode: diag.mode)
     }
     return token
-  }
-
-  /// Shared catch handling for both ``safeSample(sampler:context:vocab:candidates:mode:)``
-  /// branches. On a caught C++ exception from the bridge:
-  ///   1. Truncate the captured `what()` to ~160 chars so the OSLog and
-  ///      `LLMError.description` carriers stay readable.
-  ///   2. Emit a `samplerCrashCaught` structured line on
-  ///      `category:StreamingDiag` (always-on; see `samplerCatchDiagLogger`)
-  ///      so the analyzer pipeline can aggregate occurrence rates across builds.
-  ///      This line MUST keep firing once per catch — it is the
-  ///      occurrence-rate telemetry — regardless of how callers handle the
-  ///      thrown error.
-  ///   3. Throw `LLMError.samplerCrashCaught`. As of #907 the generation
-  ///      loops (`runGeneration` / `runStreamGeneration`) catch this error
-  ///      and end generation gracefully instead of failing: the crash's
-  ///      common trigger is the model continuing past a completed JSON
-  ///      object with a token outside the grammar's ASCII trailing set, so
-  ///      the completed object is already in the accumulated text — the
-  ///      completed-object case wins outright, and the incomplete case
-  ///      falls through to the parser's parse-failure retry (`LLMCaller`).
-  ///      `LLMCaller` still routes the error through its retry budget (#885)
-  ///      as defense in depth for any other surfacer, but the loops now
-  ///      intercept the common case. The diagnostic above fires once per
-  ///      catch so occurrence rates stay accurate.
-  private func handleSamplerCatch(_ errorMessage: String?, mode: String) throws {
-    guard let errorMessage else { return }
-    let truncated = String(errorMessage.prefix(160))
-    // `truncated` is llama.cpp's grammar-accept `what()`; its canonical form
-    // includes the just-sampled piece (`"after accepting piece: <piece> (<id>)"`),
-    // which can be a mid-string fragment of model-generated content — keep it
-    // `<private>` in TestFlight / Release per CLAUDE.md "Logger privacy". The
-    // structured `mode` + `model` fields stay `.public` as postmortem pivot keys.
-    Self.samplerCatchDiagLogger.error(
-      """
-      samplerCrashCaught what="\(truncated)" \
-      mode=\(mode, privacy: .public) \
-      model=\(self.modelIdentifier, privacy: .public)
-      """)
-    // Graceful stop, not fail-fast: the generation loops catch this and
-    // end generation (the completed-object case wins; #907). The raw
-    // `what()` rides in the associated value so any OTHER surfacer still
-    // gets `LLMCaller`'s retry budget (#885) as defense in depth, and
-    // `LLMError.errorDescription` formats it for display via the same
-    // "Sampler crash caught: %@" catalog key.
-    throw LLMError.samplerCrashCaught(description: truncated)
   }
 
   /// Call `llama_sampler_init_grammar` with stderr redirected to a `Pipe`

--- a/Pastura/Pastura/LLM/LlamaCppService+Sampler.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService+Sampler.swift
@@ -164,7 +164,7 @@ extension LlamaCppService {
   ///   grammar there is nothing for an EOG accept to abort, and the bundled
   ///   path reuses llama's internal candidate buffer.
   /// - Grammar active (`candidates != nil`): delegates to the two-pass
-  ///   ``grammarConstrainedSample(chain:grammar:context:vocab:candidates:diag:)``,
+  ///   ``grammarConstrainedSample(handles:context:vocab:candidates:diag:)``,
   ///   which keeps the #253 EOG-accept skip and adds the #751 sub-class 2
   ///   grammar-first resample.
   ///

--- a/Pastura/Pastura/LLM/LlamaCppService+Sampler.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService+Sampler.swift
@@ -4,33 +4,53 @@ import os
 
 // MARK: - Sampler
 
+/// Chain + optional grammar handles produced by
+/// ``LlamaCppService/createSampler(grammarString:vocab:)``.
+///
+/// The grammar is held **separately** from the chain (rather than as a
+/// chain member) so ``LlamaCppService/safeSample(handles:context:vocab:candidates:diag:)``
+/// can run the upstream `common_sampler_sample` two-pass strategy: sample
+/// from the grammar-free chain, and only when the pick violates the
+/// grammar, resample with the grammar applied FIRST. That split is what
+/// avoids the b8694 dist-sampler degeneracy (#751 sub-class 2) — a grammar
+/// mask applied after top_k's truncation can leave the sorted top
+/// candidate at `-inf`, poisoning the softmax so the sampler picks a masked
+/// token (empty output at position 0).
+///
+/// **Ownership**: both handles are caller-owned. Free `chain` **always**
+/// and `grammar` when non-nil. Freeing the chain does NOT free the
+/// split-out grammar — it is no longer a chain member, so llama.cpp's
+/// chain-free does not reach it.
+nonisolated struct SamplerHandles {
+  let chain: UnsafeMutablePointer<llama_sampler>
+  /// `nil` when no schema was supplied (unconstrained generation). Present
+  /// iff the caller's `candidates` scratch buffer is present — the two are
+  /// wired from the same `schema != nil` condition and must not drift.
+  let grammar: UnsafeMutablePointer<llama_sampler>?
+}
+
 extension LlamaCppService {
-  /// Build the llama.cpp sampler chain, optionally constrained by a GBNF
-  /// grammar string.
+  /// Build the llama.cpp sampler chain, plus an optional GBNF grammar
+  /// handle held separately from the chain (see ``SamplerHandles``).
   ///
   /// - Parameters:
   ///   - grammarString: Pre-built GBNF from ``GBNFGrammarBuilder``. When
-  ///     non-nil, a `llama_sampler_init_grammar` stage is inserted into
-  ///     the chain to mask the logits to grammar-valid tokens before
-  ///     temperature smoothing.
+  ///     non-nil, a `llama_sampler_init_grammar` handle is built and
+  ///     returned alongside the chain (NOT inserted into it).
   ///   - vocab: The model's vocabulary pointer. Required iff
   ///     `grammarString` is non-nil — the grammar parser needs it to
   ///     resolve token IDs.
   ///
-  /// **Chain order**: `penalties → top_k → top_p → grammar → temperature → dist`.
-  /// Grammar is placed BEFORE temperature per llama.cpp upstream
-  /// convention (see `common/sampling.cpp`): hard-constraint masking on
-  /// the raw logits first, then temperature smoothing on the narrowed
-  /// distribution, then distribution sampling. Putting grammar after
-  /// temperature would re-weight grammar-invalid tokens the masker
-  /// already zeroed out — correct but wasteful.
+  /// **Chain order**: `penalties → top_k → top_p → temperature → dist`.
+  /// The grammar is applied outside the chain by `safeSample` (grammar-first
+  /// only on a resample), matching llama.cpp's `common_sampler_sample`.
   ///
   /// **Call sites**: both `runGeneration` (non-streaming) and
-  /// `runStreamGeneration` (streaming) call this. If you add a third
-  /// caller, wire the `grammarString` / `vocab` pair or explicitly pass
-  /// `nil` for both — missing one side silently bypasses grammar on the
-  /// path the new caller exercises, the exact regression this plan's
-  /// Critic Axis 3 flagged.
+  /// `runStreamGeneration` (streaming) call this via `prepareGeneration`.
+  /// If you add a third caller, wire the `grammarString` / `vocab` pair or
+  /// explicitly pass `nil` for both — missing one side silently bypasses
+  /// grammar on the path the new caller exercises, the exact regression
+  /// this plan's Critic Axis 3 flagged.
   ///
   /// - Throws: ``LLMError/invalidGrammar(description:)`` if
   ///   `llama_sampler_init_grammar` returns NULL (unparseable GBNF —
@@ -38,16 +58,20 @@ extension LlamaCppService {
   func createSampler(
     grammarString: String? = nil,
     vocab: OpaquePointer? = nil
-  ) throws -> UnsafeMutablePointer<llama_sampler> {
+  ) throws -> SamplerHandles {
     let sparams = llama_sampler_chain_default_params()
     guard let chain = llama_sampler_chain_init(sparams) else {
       throw LLMError.generationFailed(description: "Failed to initialize sampler chain")
     }
 
-    // Order: penalties → top_k → top_p → grammar → temperature → dist
-    // Penalties on full vocab first, then narrow, then grammar mask,
-    // then temperature, then selection. See llama.cpp upstream
-    // `common/sampling.cpp` for reference chains.
+    // Chain order: penalties → top_k → top_p → temperature → dist. The
+    // grammar is deliberately NOT a chain member — it is returned as a
+    // separate handle so `safeSample` can run the upstream
+    // `common_sampler_sample` two-pass strategy (sample from the chain,
+    // grammar-check the pick, resample grammar-first only on a miss). A
+    // grammar stage inside the chain would run AFTER top_k's truncation,
+    // reintroducing the b8694 dist-degeneracy that masks the sorted top
+    // candidate and poisons the softmax (#751 sub-class 2).
     llama_sampler_chain_add(
       chain,
       llama_sampler_init_penalties(
@@ -58,113 +82,69 @@ extension LlamaCppService {
       ))
     llama_sampler_chain_add(chain, llama_sampler_init_top_k(Self.topK))
     llama_sampler_chain_add(chain, llama_sampler_init_top_p(Self.topP, 1))
-
-    if let grammarString {
-      guard let vocab else {
-        // Defensive: if the caller supplies grammar but forgets vocab, we
-        // can't wire the grammar sampler. This is a programming bug,
-        // surface it loudly via the same fail-fast path as a NULL return.
-        llama_sampler_free(chain)
-        throw LLMError.invalidGrammar(
-          description: "createSampler: grammar supplied without vocab")
-      }
-      // `llama_sampler_init_grammar` returns NULL when the grammar
-      // string itself fails to parse. GBNFGrammarBuilder golden tests
-      // should prevent this reaching production, but if it does we
-      // want fail-fast, NOT the 3x-retry charade `.generationFailed`
-      // would trigger via LLMCaller (Critic Axis 11).
-      let (grammarSamplerOpt, capturedStderr) = grammarString.withCString { cStr in
-        initGrammarCapturingStderr(vocab: vocab, grammarCString: cStr)
-      }
-      guard let grammarSampler = grammarSamplerOpt else {
-        llama_sampler_free(chain)
-        // Log the FULL grammar at error level so Console.app captures it
-        // verbatim — the `invalidGrammar` error's description field is
-        // rendered in iOS alerts where backslashes / quotes are mangled.
-        // Append captured stderr (the parser-internal detail from
-        // llama-grammar.cpp:713) wrapped in sentinel markers so unrelated
-        // process-level stderr writes during the capture window are
-        // visually attributable rather than mistaken for grammar errors.
-        // Filter:  subsystem:app.pastura.Pastura category:LlamaCppService
-        //          message contains "GBNF grammar parse failed"
-        logger.error(
-          """
-          GBNF grammar parse failed — llama_sampler_init_grammar returned NULL.
-          <<<BEGIN GBNF>>>
-          \(grammarString, privacy: .public)
-          <<<END GBNF>>>
-          --- BEGIN llama.cpp stderr capture (process-wide window — may include unrelated writers) ---
-          \(capturedStderr, privacy: .public)
-          --- END capture ---
-          """)
-        let snippet = grammarString.prefix(200)
-        throw LLMError.invalidGrammar(
-          description: String(
-            format: String(localized: "GBNF grammar parse failed: %@"), String(snippet)))
-      }
-      llama_sampler_chain_add(chain, grammarSampler)
-    }
-
     llama_sampler_chain_add(chain, llama_sampler_init_temp(Self.temperature))
     llama_sampler_chain_add(
       chain, llama_sampler_init_dist(UInt32.random(in: 0...UInt32.max)))
 
-    return chain
+    guard let grammarString else {
+      return SamplerHandles(chain: chain, grammar: nil)
+    }
+    guard let vocab else {
+      // Defensive: if the caller supplies grammar but forgets vocab, we
+      // can't wire the grammar sampler. This is a programming bug,
+      // surface it loudly via the same fail-fast path as a NULL return.
+      llama_sampler_free(chain)
+      throw LLMError.invalidGrammar(
+        description: "createSampler: grammar supplied without vocab")
+    }
+    // `llama_sampler_init_grammar` returns NULL when the grammar
+    // string itself fails to parse. GBNFGrammarBuilder golden tests
+    // should prevent this reaching production, but if it does we
+    // want fail-fast, NOT the 3x-retry charade `.generationFailed`
+    // would trigger via LLMCaller (Critic Axis 11).
+    let (grammarSamplerOpt, capturedStderr) = grammarString.withCString { cStr in
+      initGrammarCapturingStderr(vocab: vocab, grammarCString: cStr)
+    }
+    guard let grammarSampler = grammarSamplerOpt else {
+      llama_sampler_free(chain)
+      // Log the FULL grammar at error level so Console.app captures it
+      // verbatim — the `invalidGrammar` error's description field is
+      // rendered in iOS alerts where backslashes / quotes are mangled.
+      // Append captured stderr (the parser-internal detail from
+      // llama-grammar.cpp:713) wrapped in sentinel markers so unrelated
+      // process-level stderr writes during the capture window are
+      // visually attributable rather than mistaken for grammar errors.
+      // Filter:  subsystem:app.pastura.Pastura category:LlamaCppService
+      //          message contains "GBNF grammar parse failed"
+      logger.error(
+        """
+        GBNF grammar parse failed — llama_sampler_init_grammar returned NULL.
+        <<<BEGIN GBNF>>>
+        \(grammarString, privacy: .public)
+        <<<END GBNF>>>
+        --- BEGIN llama.cpp stderr capture (process-wide window — may include unrelated writers) ---
+        \(capturedStderr, privacy: .public)
+        --- END capture ---
+        """)
+      let snippet = grammarString.prefix(200)
+      throw LLMError.invalidGrammar(
+        description: String(
+          format: String(localized: "GBNF grammar parse failed: %@"), String(snippet)))
+    }
+    return SamplerHandles(chain: chain, grammar: grammarSampler)
   }
 
-  /// Sample the next token, guarding the grammar accept against the #253
-  /// EOG-path `GGML_ABORT`.
-  ///
-  /// `llama_sampler_sample` does apply (logit mask + selection) then
-  /// `llama_sampler_accept` in one call. The #253 abort
-  /// (`llama-grammar.cpp:1435`) fires inside that accept when the sampled
-  /// token is EOG and no grammar stack is empty. Generation ends at EOG, so
-  /// the grammar's post-EOG state is never read again — accepting EOG is
-  /// pointless. POSIX `SIGABRT` cannot be caught (it bypasses `try/catch`),
-  /// so the only fix is to NOT take that accept.
-  ///
-  /// - When a grammar is active (`candidates != nil`) this replicates the
-  ///   sample path — build `cur_p` from the logits → `llama_sampler_apply`
-  ///   (runs the full chain incl. the dist selection) → read `selected` —
-  ///   and then accepts ONLY non-EOG tokens via
-  ///   ``SafeSampler/accept(sampler:token:)``. Non-EOG tokens accept exactly
-  ///   as the bundled call would, so the sampling distribution is unchanged;
-  ///   only the never-used EOG accept is skipped.
-  /// - When no grammar is active (`candidates == nil`) the bundled
-  ///   ``SafeSampler/sample(sampler:context:idx:)`` runs unchanged: with no
-  ///   grammar there is nothing for an EOG accept to abort, and the bundled
-  ///   path reuses llama's internal candidate buffer.
-  ///
-  /// Catch path (both branches): the grammar `accept_token`
-  /// `std::runtime_error` (#334 / #366 / #371) surfaces as
-  /// ``SafeSampler/Outcome/errorMessage`` and is routed through
-  /// ``handleSamplerCatch(_:mode:)`` (diagnostic + `LLMError.samplerCrashCaught`).
-  /// See `LLM/SafeSampler/SafeSampler.h` for the catch scope. The grammar
-  /// `apply` does not throw `std::exception` (only `GGML_ASSERT` /
-  /// `GGML_ABORT` signals), so the Swift-side `apply` here loses no coverage.
-  ///
-  /// The generation loops catch the thrown `LLMError.samplerCrashCaught` as
-  /// end-of-generation (`nextContentTokenOrStop`, #907); the diagnostic
-  /// still fires once per catch for occurrence-rate telemetry.
-  ///
-  /// - Parameters:
-  ///   - vocab: model vocab pointer, for EOG classification.
-  ///   - candidates: caller-owned, `n_vocab`-sized scratch buffer reused
-  ///     across the token loop (avoids a per-token allocation). `nil` selects
-  ///     the bundled fast path (no grammar active).
-  ///   - diag: per-token diagnostic context (`mode` loop tag + generation
-  ///     `position`) for the always-on sampler telemetry; see
-  ///     ``SamplerDiagContext``.
   /// Allocate the reused per-generation candidate scratch buffer for the
-  /// EOG-guarded sampling path, or `nil` when no grammar is active.
+  /// grammar-constrained sampling path, or `nil` when no grammar is active.
   ///
-  /// When a grammar is active, ``safeSample(sampler:context:vocab:candidates:diag:)``
-  /// replicates `llama_sampler_sample` so it can skip the abort-prone EOG
-  /// accept, which needs an `n_vocab` candidate buffer. Allocated once per
+  /// When a grammar is active,
+  /// ``safeSample(handles:context:vocab:candidates:diag:)`` rebuilds a
+  /// full-vocab `cur_p` from the raw logits each token (twice on a
+  /// resample), which needs an `n_vocab`-sized buffer. Allocated once per
   /// generation and reused across the token loop. Returns `nil` when
   /// `schema == nil` (no grammar built — the bundled path needs no buffer),
-  /// mirroring the `createSampler` grammar-build condition so the two call
-  /// sites (`runGeneration` / `runStreamGeneration`) cannot drift.
+  /// mirroring the `createSampler` grammar-build condition so the buffer and
+  /// the ``SamplerHandles/grammar`` handle cannot drift.
   ///
   /// - Important: ownership stays with the caller — the buffer's lifetime is
   ///   the whole generation, so the caller MUST `deallocate()` it (via
@@ -177,8 +157,34 @@ extension LlamaCppService {
     return .allocate(capacity: Int(llama_vocab_n_tokens(vocab)))
   }
 
+  /// Sample the next token, dispatching on whether a grammar is active.
+  ///
+  /// - No grammar (`candidates == nil`): the bundled
+  ///   ``SafeSampler/sample(sampler:context:idx:)`` runs unchanged — with no
+  ///   grammar there is nothing for an EOG accept to abort, and the bundled
+  ///   path reuses llama's internal candidate buffer.
+  /// - Grammar active (`candidates != nil`): delegates to the two-pass
+  ///   ``grammarConstrainedSample(chain:grammar:context:vocab:candidates:diag:)``,
+  ///   which keeps the #253 EOG-accept skip and adds the #751 sub-class 2
+  ///   grammar-first resample.
+  ///
+  /// Catch path: the grammar `accept_token` `std::runtime_error`
+  /// (#334 / #366 / #371) surfaces as ``SafeSampler/Outcome/errorMessage``
+  /// and is routed through ``handleSamplerCatch(_:mode:)`` (diagnostic +
+  /// `LLMError.samplerCrashCaught`). The generation loops catch that as
+  /// end-of-generation (`nextContentTokenOrStop`, #907).
+  ///
+  /// - Parameters:
+  ///   - handles: chain + optional grammar handle from `createSampler`.
+  ///     `handles.grammar` is non-nil iff `candidates` is non-nil.
+  ///   - vocab: model vocab pointer, for EOG classification.
+  ///   - candidates: caller-owned, `n_vocab`-sized scratch buffer reused
+  ///     across the token loop. `nil` selects the bundled fast path.
+  ///   - diag: per-token diagnostic context (`mode` loop tag + generation
+  ///     `position`) for the always-on sampler telemetry; see
+  ///     ``SamplerDiagContext``.
   func safeSample(
-    sampler: UnsafeMutablePointer<llama_sampler>, context: OpaquePointer,
+    handles: SamplerHandles, context: OpaquePointer,
     vocab: OpaquePointer?,
     candidates: UnsafeMutableBufferPointer<llama_token_data>?,
     diag: SamplerDiagContext
@@ -187,60 +193,13 @@ extension LlamaCppService {
       // No grammar active: the bundled sample+accept cannot hit the #253
       // grammar abort (no grammar to accept into), and reuses llama's
       // internal candidate buffer — keep the simpler, allocation-free path.
-      let outcome = SafeSampler.sample(sampler: sampler, context: context, idx: -1)
+      let outcome = SafeSampler.sample(sampler: handles.chain, context: context, idx: -1)
       try handleSamplerCatch(outcome.errorMessage, mode: diag.mode)
       return outcome.token
     }
-
-    // Grammar active: replicate `llama_sampler_sample` so the EOG accept can
-    // be skipped. Mirrors the upstream CPU path (b8694
-    // `src/llama-sampler.cpp`) — our chain uses no backend sampler, so the
-    // plain logits branch is the one that runs.
-    guard let logits = llama_get_logits_ith(context, -1) else {
-      throw LLMError.generationFailed(
-        description: String(localized: "Sampler produced no logits"))
-    }
-    guard let base = candidates.baseAddress, !candidates.isEmpty else {
-      throw LLMError.generationFailed(
-        description: String(localized: "Sampler candidate buffer is empty"))
-    }
-    let count = candidates.count
-    for i in 0..<count {
-      base[i] = llama_token_data(id: Int32(i), logit: logits[i], p: 0)
-    }
-    // Rebuild `cur_p` each token with `selected = -1` so a stale selection
-    // index cannot leak across the reused buffer; `llama_sampler_apply` sets
-    // it (the chain's terminal dist sampler selects).
-    var curP = llama_token_data_array(
-      data: base, size: count, selected: -1, sorted: false)
-    llama_sampler_apply(sampler, &curP)
-    guard curP.selected >= 0, curP.selected < Int64(curP.size),
-      let selected = curP.data
-    else {
-      throw LLMError.generationFailed(
-        description: String(localized: "Sampler produced no selection"))
-    }
-    let token = selected[Int(curP.selected)].id
-
-    // #751 sub-class 2: a grammar-masked (-inf) selection means b8694's
-    // dist sampler degenerated (all-rejected NaN fallthrough, or a masked
-    // top candidate poisoning the sorted-flag softmax) — see
-    // `emitMaskedSelectionDiagnostic` for the mechanism. Telemetry only;
-    // behavior is intentionally unchanged here. The 2-pass grammar
-    // resample fix lands separately under #751.
-    if selected[Int(curP.selected)].logit == -Float.infinity {
-      emitMaskedSelectionDiagnostic(token: token, curP: curP, vocab: vocab, diag: diag)
-    }
-
-    // #253: skip the accept for EOG. Accepting an EOG token advances the
-    // grammar into the never-used post-EOG state whose all-non-empty-stack
-    // case fires `GGML_ABORT`. Every non-EOG token accepts as the bundled
-    // path would, so the distribution is unchanged.
-    if !llama_vocab_is_eog(vocab, token) {
-      let outcome = SafeSampler.accept(sampler: sampler, token: token)
-      try handleSamplerCatch(outcome.errorMessage, mode: diag.mode)
-    }
-    return token
+    return try grammarConstrainedSample(
+      handles: handles, context: context,
+      vocab: vocab, candidates: candidates, diag: diag)
   }
 
   /// Call `llama_sampler_init_grammar` with stderr redirected to a `Pipe`

--- a/Pastura/Pastura/LLM/LlamaCppService+SamplerDiagnostics.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService+SamplerDiagnostics.swift
@@ -1,0 +1,121 @@
+import Foundation
+import LlamaSwift
+import os
+
+// MARK: - Sampler diagnostics
+
+/// Per-token diagnostic context threaded through the sampling path so the
+/// always-on sampler telemetry (`samplerCrashCaught` /
+/// `samplerMaskedSelection`) can attribute events to the calling loop and
+/// the generation position without widening every signature past the
+/// SwiftLint parameter budget.
+nonisolated struct SamplerDiagContext {
+  /// `non-stream` / `stream` tag identifying the calling generation loop.
+  let mode: String
+  /// 0-based count of content tokens generated before this sampling step.
+  /// `position == 0` masked-selection events surface as empty output
+  /// (#751 sub-class 2).
+  let position: Int
+}
+
+extension LlamaCppService {
+  /// #751 sub-class 2 diagnostic: fires when the sampler chain selected a
+  /// grammar-masked (-inf) token. Two observed sub-modes, both
+  /// deterministic (RNG-independent — retries of the same prompt
+  /// mis-select identically), both from b8694's dist sampler
+  /// (`src/llama-sampler.cpp:1036-1097`) whose `assert(found)` is compiled
+  /// out of the release xcframework:
+  ///
+  /// - (a) grammar rejected EVERY truncated candidate → all-NaN softmax →
+  ///   the `sum_run >= sum_tgt` scan never fires → falls through to the
+  ///   LAST candidate (`finiteCandidates=0`);
+  /// - (b) grammar masked the TOP-ranked candidate while finite candidates
+  ///   remain (`finiteCandidates>0`): top_k left `sorted=true`, so dist
+  ///   takes `max_l = data[0].logit = -inf` without rescanning and the
+  ///   softmax degenerates (exp(+inf)/NaN) → garbage selection despite
+  ///   valid tokens in the set.
+  ///
+  /// Detection is the selected token's -inf logit (O(1), checked by the
+  /// caller). `position=0` events surface as empty output (EOG → 0-token
+  /// break; non-EOG → grammar-accept throw → catch-as-EOS with empty
+  /// text). Logs the token ID only — never the decoded piece (CLAUDE.md
+  /// "Logger privacy"). Occurrence-rate telemetry: fires once per event.
+  func emitMaskedSelectionDiagnostic(
+    token: Int32,
+    curP: llama_token_data_array,
+    vocab: OpaquePointer?,
+    diag: SamplerDiagContext
+  ) {
+    guard let data = curP.data else { return }
+    var finiteCandidates = 0
+    for i in 0..<Int(curP.size) where data[i].logit > -Float.infinity {
+      finiteCandidates += 1
+    }
+    let isEOG = llama_vocab_is_eog(vocab, token)
+    Self.samplerCatchDiagLogger.error(
+      """
+      samplerMaskedSelection tokenId=\(token, privacy: .public) \
+      isEOG=\(isEOG, privacy: .public) \
+      position=\(diag.position, privacy: .public) \
+      finiteCandidates=\(finiteCandidates, privacy: .public) \
+      candidates=\(curP.size, privacy: .public) \
+      mode=\(diag.mode, privacy: .public) \
+      model=\(self.modelIdentifier, privacy: .public)
+      """)
+    // Mirror to stderr for the macOS harness (ADR-013): CLI os.Logger
+    // output is not reliably queryable via `log show`, and the harness
+    // captures stderr to `<out>.stderr.log`. Rare path (once per
+    // masked-selection event); invisible and harmless on iOS. Same
+    // privacy discipline — token ID only, never the decoded piece.
+    fputs(
+      "samplerMaskedSelection tokenId=\(token) isEOG=\(isEOG) "
+        + "position=\(diag.position) finiteCandidates=\(finiteCandidates) "
+        + "candidates=\(curP.size) mode=\(diag.mode) model=\(modelIdentifier)\n",
+      stderr)
+  }
+
+  /// Shared catch handling for both ``safeSample(sampler:context:vocab:candidates:diag:)``
+  /// branches. On a caught C++ exception from the bridge:
+  ///   1. Truncate the captured `what()` to ~160 chars so the OSLog and
+  ///      `LLMError.description` carriers stay readable.
+  ///   2. Emit a `samplerCrashCaught` structured line on
+  ///      `category:StreamingDiag` (always-on; see `samplerCatchDiagLogger`)
+  ///      so the analyzer pipeline can aggregate occurrence rates across builds.
+  ///      This line MUST keep firing once per catch — it is the
+  ///      occurrence-rate telemetry — regardless of how callers handle the
+  ///      thrown error.
+  ///   3. Throw `LLMError.samplerCrashCaught`. As of #907 the generation
+  ///      loops (`runGeneration` / `runStreamGeneration`) catch this error
+  ///      and end generation gracefully instead of failing: the crash's
+  ///      common trigger is the model continuing past a completed JSON
+  ///      object with a token outside the grammar's ASCII trailing set, so
+  ///      the completed object is already in the accumulated text — the
+  ///      completed-object case wins outright, and the incomplete case
+  ///      falls through to the parser's parse-failure retry (`LLMCaller`).
+  ///      `LLMCaller` still routes the error through its retry budget (#885)
+  ///      as defense in depth for any other surfacer, but the loops now
+  ///      intercept the common case. The diagnostic above fires once per
+  ///      catch so occurrence rates stay accurate.
+  func handleSamplerCatch(_ errorMessage: String?, mode: String) throws {
+    guard let errorMessage else { return }
+    let truncated = String(errorMessage.prefix(160))
+    // `truncated` is llama.cpp's grammar-accept `what()`; its canonical form
+    // includes the just-sampled piece (`"after accepting piece: <piece> (<id>)"`),
+    // which can be a mid-string fragment of model-generated content — keep it
+    // `<private>` in TestFlight / Release per CLAUDE.md "Logger privacy". The
+    // structured `mode` + `model` fields stay `.public` as postmortem pivot keys.
+    Self.samplerCatchDiagLogger.error(
+      """
+      samplerCrashCaught what="\(truncated)" \
+      mode=\(mode, privacy: .public) \
+      model=\(self.modelIdentifier, privacy: .public)
+      """)
+    // Graceful stop, not fail-fast: the generation loops catch this and
+    // end generation (the completed-object case wins; #907). The raw
+    // `what()` rides in the associated value so any OTHER surfacer still
+    // gets `LLMCaller`'s retry budget (#885) as defense in depth, and
+    // `LLMError.errorDescription` formats it for display via the same
+    // "Sampler crash caught: %@" catalog key.
+    throw LLMError.samplerCrashCaught(description: truncated)
+  }
+}

--- a/Pastura/Pastura/LLM/LlamaCppService+SamplerDiagnostics.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService+SamplerDiagnostics.swift
@@ -74,7 +74,38 @@ extension LlamaCppService {
       stderr)
   }
 
-  /// Shared catch handling for both ``safeSample(sampler:context:vocab:candidates:diag:)``
+  /// #751: fires when pass 1 (grammar-free chain) picked a token the grammar
+  /// rejects, so ``grammarConstrainedSample`` had to resample grammar-first.
+  ///
+  /// Emitted only at `position == 0` — a nonzero position-0 resample rate is
+  /// the empty-output fragility signal for the model-onboarding pipeline (a
+  /// weak JSON prior that would, pre-fix, have produced "Model generated no
+  /// output tokens"). Post-fix these are *rescued*, not failures, so this is
+  /// a health metric, not an error. Off the hot path (only when a resample
+  /// is actually needed) and position-gated to stay low-volume. Token ID
+  /// only — never the decoded piece (CLAUDE.md "Logger privacy").
+  func emitGrammarResampleDiagnostic(
+    rejectedToken: Int32, vocab: OpaquePointer?, diag: SamplerDiagContext
+  ) {
+    guard diag.position == 0 else { return }
+    let isEOG = llama_vocab_is_eog(vocab, rejectedToken)
+    Self.samplerCatchDiagLogger.error(
+      """
+      samplerGrammarResample rejectedTokenId=\(rejectedToken, privacy: .public) \
+      isEOG=\(isEOG, privacy: .public) \
+      position=\(diag.position, privacy: .public) \
+      mode=\(diag.mode, privacy: .public) \
+      model=\(self.modelIdentifier, privacy: .public)
+      """)
+    // Mirror to stderr for the macOS harness (ADR-013), same rationale as
+    // `emitMaskedSelectionDiagnostic`.
+    fputs(
+      "samplerGrammarResample rejectedTokenId=\(rejectedToken) isEOG=\(isEOG) "
+        + "position=\(diag.position) mode=\(diag.mode) model=\(modelIdentifier)\n",
+      stderr)
+  }
+
+  /// Shared catch handling for both ``safeSample(handles:context:vocab:candidates:diag:)``
   /// branches. On a caught C++ exception from the bridge:
   ///   1. Truncate the captured `what()` to ~160 chars so the OSLog and
   ///      `LLMError.description` carriers stay readable.

--- a/Pastura/Pastura/LLM/LlamaCppService.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService.swift
@@ -521,12 +521,13 @@ extension LlamaCppService {
     let prepared = try prepareGeneration(
       model: model, context: context,
       system: system, user: user, schema: schema)
-    defer { llama_sampler_free(prepared.sampler) }
+    defer { llama_sampler_free(prepared.handles.chain) }
+    defer { prepared.handles.grammar.map { llama_sampler_free($0) } }
     let vocab = prepared.vocab
-    let sampler = prepared.sampler
+    let handles = prepared.handles
 
-    // #253 EOG-guard scratch buffer (nil when no grammar is active — that
-    // path uses the bundled sampler). See `makeCandidateBuffer`.
+    // Grammar-constrained scratch buffer (nil when no grammar is active —
+    // that path uses the bundled sampler). See `makeCandidateBuffer`.
     let candidateBuffer = makeCandidateBuffer(schema: schema, vocab: vocab)
     defer { candidateBuffer?.deallocate() }
 
@@ -563,7 +564,7 @@ extension LlamaCppService {
       // appended, exactly as an EOG break did before.
       guard
         let newTokenId = try nextContentTokenOrStop(
-          sampler: sampler, context: context, vocab: vocab,
+          handles: handles, context: context, vocab: vocab,
           candidates: candidateBuffer,
           diag: SamplerDiagContext(mode: "non-stream", position: generatedTokens))
       else { break }
@@ -632,7 +633,7 @@ extension LlamaCppService {
   ///    parse and retries as before. All other errors propagate. See
   ///    ``handleSamplerCatch(_:mode:)``.
   fileprivate func nextContentTokenOrStop(
-    sampler: UnsafeMutablePointer<llama_sampler>, context: OpaquePointer,
+    handles: SamplerHandles, context: OpaquePointer,
     vocab: OpaquePointer?,
     candidates: UnsafeMutableBufferPointer<llama_token_data>?,
     diag: SamplerDiagContext
@@ -640,7 +641,7 @@ extension LlamaCppService {
     let token: Int32
     do {
       token = try safeSample(
-        sampler: sampler, context: context, vocab: vocab,
+        handles: handles, context: context, vocab: vocab,
         candidates: candidates, diag: diag)
     } catch LLMError.samplerCrashCaught {
       return nil
@@ -730,12 +731,13 @@ extension LlamaCppService {
     let prepared = try prepareGeneration(
       model: model, context: context,
       system: system, user: user, schema: schema)
-    defer { llama_sampler_free(prepared.sampler) }
+    defer { llama_sampler_free(prepared.handles.chain) }
+    defer { prepared.handles.grammar.map { llama_sampler_free($0) } }
     let vocab = prepared.vocab
-    let sampler = prepared.sampler
+    let handles = prepared.handles
 
-    // #253 EOG-guard scratch buffer (nil when no grammar is active — that
-    // path uses the bundled sampler). See `makeCandidateBuffer`.
+    // Grammar-constrained scratch buffer (nil when no grammar is active —
+    // that path uses the bundled sampler). See `makeCandidateBuffer`.
     let candidateBuffer = makeCandidateBuffer(schema: schema, vocab: vocab)
     defer { candidateBuffer?.deallocate() }
 
@@ -765,7 +767,7 @@ extension LlamaCppService {
       // runs the post-loop held-back flush below, matching the EOG break.
       guard
         let newTokenId = try nextContentTokenOrStop(
-          sampler: sampler, context: context, vocab: vocab,
+          handles: handles, context: context, vocab: vocab,
           candidates: candidateBuffer,
           diag: SamplerDiagContext(mode: "stream", position: generatedTokens))
       else { break }

--- a/Pastura/Pastura/LLM/LlamaCppService.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService.swift
@@ -564,7 +564,8 @@ extension LlamaCppService {
       guard
         let newTokenId = try nextContentTokenOrStop(
           sampler: sampler, context: context, vocab: vocab,
-          candidates: candidateBuffer, mode: "non-stream")
+          candidates: candidateBuffer,
+          diag: SamplerDiagContext(mode: "non-stream", position: generatedTokens))
       else { break }
 
       generatedTokens += 1
@@ -634,13 +635,13 @@ extension LlamaCppService {
     sampler: UnsafeMutablePointer<llama_sampler>, context: OpaquePointer,
     vocab: OpaquePointer?,
     candidates: UnsafeMutableBufferPointer<llama_token_data>?,
-    mode: String
+    diag: SamplerDiagContext
   ) throws -> Int32? {
     let token: Int32
     do {
       token = try safeSample(
         sampler: sampler, context: context, vocab: vocab,
-        candidates: candidates, mode: mode)
+        candidates: candidates, diag: diag)
     } catch LLMError.samplerCrashCaught {
       return nil
     }
@@ -765,7 +766,8 @@ extension LlamaCppService {
       guard
         let newTokenId = try nextContentTokenOrStop(
           sampler: sampler, context: context, vocab: vocab,
-          candidates: candidateBuffer, mode: "stream")
+          candidates: candidateBuffer,
+          diag: SamplerDiagContext(mode: "stream", position: generatedTokens))
       else { break }
 
       generatedTokens += 1

--- a/docs/decisions/ADR-002.md
+++ b/docs/decisions/ADR-002.md
@@ -1659,3 +1659,89 @@ Code: `Models/OutputSchema.swift` (`Kind.choice`),
 `LLM/GBNFGrammarBuilder.swift`, `Engine/LLMCaller.swift`
 (`naturalLanguageFieldValues` keeps excluding `.choice` from the
 language-adherence detector — ADR-010 Step E / #405).
+
+## Amendment 2026-07-09 — Grammar-all-rejected dist fallthrough (#751 sub-class 2)
+
+**Distinct mechanism from §12.9.** §12.9 is the EOG-path *accept* abort
+(a `GGML_ABORT` when an EOG token is accepted into a grammar with no empty
+stack). This is a separate defect in the *apply/select* step: the b8694
+distribution sampler silently selecting a grammar-**masked** token, which
+at generation position 0 surfaces as completely-empty model output ("Model
+generated no output tokens"). Do not conflate the two — same file, two
+different failure modes.
+
+**Symptom.** Grammar-constrained runs of Sarashina 2.2 3B (Q4_K_M)
+intermittently produced empty output on single-field phases (`reflect`,
+`vote`); both engine retries reproduced it identically, exhausting the
+retry budget and failing the run. Rare on Gemma 4 E2B, reliable on
+Sarashina.
+
+**Root cause (confirmed empirically, #751 item 1).** The former chain
+order placed the grammar **inside** the chain, after truncation:
+`penalties → top_k → top_p → grammar → temp → dist`. When the model's
+top-ranked token at position 0 is grammar-invalid (e.g. Sarashina opening
+a `reflect` turn with the prose token `メモ`, or a leading-space `▁{`
+rather than a bare `{`), the grammar masks it to `-inf` **after** top_k
+already set `sorted = true`. b8694's `llama_sampler_dist_apply`
+(`src/llama-sampler.cpp:1036-1097`) then reads `max_l = data[0].logit =
+-inf` without rescanning and its softmax degenerates
+(`exp(+inf)` / all-NaN); the `sum_run >= sum_tgt` scan never fires and the
+`assert(found)` is compiled out of the release xcframework, so it silently
+selects the **last** (masked) candidate. RNG-independent — hence identical
+across retries. At position 0 both outcomes yield empty output: a selected
+EOG breaks the loop at zero tokens; a selected non-EOG token trips the
+grammar-accept `runtime_error`, caught as the #907 catch-as-EOS with empty
+accumulated text. (The same defect reaching the EOG accept is the §12.9
+abort — #253's crash and this empty-output are two symptoms of one
+upstream dist degeneracy.)
+
+**Decision — mechanism contract (not a per-model gate).** Split the
+grammar **out** of the chain and drive it with llama.cpp's
+`common_sampler_sample` two-pass strategy
+(`LlamaCppService.grammarConstrainedSample`, ``SamplerHandles``):
+
+1. Sample from the grammar-free chain
+   (`penalties → top_k → top_p → temp → dist`).
+2. Grammar-check the pick via a side-effect-free single-token
+   `llama_sampler_apply` (apply reads the grammar stacks; only `accept`
+   mutates them). If valid, accept and return.
+3. On a miss, rebuild full-vocab logits, apply the grammar **first** (so
+   top_k re-sorts on the masked logits and `data[0]` is grammar-valid),
+   then the chain, and resample. The dist degeneracy cannot recur.
+4. Terminal branch: if even the grammar-first pass lands on a masked token
+   (a genuinely dead grammar — every token incl. EOG masked), stop at EOS
+   rather than let the dist fallthrough emit garbage. The full vocab of all
+   shipped profiles contains a bare `{` (Sarashina id 352, Gemma, Qwen), so
+   this is unreachable at position 0 — defensive only.
+
+The `#253` EOG-accept skip is preserved (the grammar handle is advanced on
+non-EOG tokens only; the chain is always advanced for penalties
+continuity). No new C++ `apply`-safe shim is added: the grammar `apply` is
+signal-only (uncatchable `GGML_ASSERT` / `GGML_ABORT`, never a
+`std::exception`) per `SafeSampler.h`, so a wrapper would add zero
+coverage.
+
+**Why a mechanism contract, not "allow leading whitespace in the
+grammar".** Loosening the `root` rule to admit `▁{` is per-model (BPE
+tokenizer-specific, the same hazard as §12.9's value-enumeration) and would
+not cover the general case of a grammar-invalid top token. The two-pass
+resample guarantees a grammar-valid selection whenever the full vocab
+contains one, model-agnostically.
+
+**Verification (pastura-harness, real inference, 2026-07-09).** The three
+Sarashina cells that previously failed — `word_wolf` ja/en +
+`prisoners_dilemma` ja — now complete on attempt 1 with zero empty output;
+the grammar-first resample rescued 8 / 10 / 16 position-0 turns
+respectively, with zero terminal masked-selection fallthroughs. Gemma 4
+E2B `word_wolf` is unchanged (zero resamples — its JSON prior always makes
+the chain's top token grammar-valid). New `samplerGrammarResample`
+(position-0) diagnostic measures the residual rescue rate as a
+model-onboarding fragility signal. The empty-output path is therefore no
+longer a retry-budget concern (`.claude/rules/engine.md`
+§ "Retry Policy").
+
+Code: `LLM/LlamaCppService+Sampler.swift` (`SamplerHandles`,
+`createSampler`, `safeSample` dispatch),
+`LLM/LlamaCppService+GrammarSample.swift` (two-pass core),
+`LLM/LlamaCppService+SamplerDiagnostics.swift` (diagnostics),
+`LLM/LlamaCppService+PrepareGeneration.swift` (handle ownership).


### PR DESCRIPTION
## Summary

Fixes #751 sub-class 2 — grammar-constrained llama.cpp generation intermittently produced completely-empty output ("Model generated no output tokens"), reliably on Sarashina 2.2 3B, rarely on Gemma 4 E2B. (Sub-class 1, the stray trailing `}`, shipped in #756.)

**Root cause (empirically confirmed).** The GBNF grammar was a chain member applied *after* top_k truncation. When the model's top-ranked token at position 0 is grammar-invalid (e.g. Sarashina opening a `reflect` turn with the prose token `メモ`, or a leading-space `▁{`), the grammar masks it to `-inf` after top_k already set `sorted = true`. b8694's `llama_sampler_dist_apply` then reads `max_l = data[0].logit = -inf`, its softmax degenerates (all-NaN), the `sum_run >= sum_tgt` scan never fires, and the `assert(found)` compiled out of the release xcframework silently selects the last (masked) candidate. RNG-independent → all retries reproduce it identically → the retry budget can never recover → empty output at position 0. (The same dist defect reaching the EOG accept is the #253 crash — one upstream bug, two symptoms.)

**Fix.** Split the grammar out of the sampler chain and adopt llama.cpp's `common_sampler_sample` two-pass strategy (`grammarConstrainedSample`): sample from the grammar-free chain, grammar-check the pick (side-effect-free single-token apply), and only on a miss resample with the grammar applied FIRST — so top_k re-sorts on the masked logits and `data[0]` is always grammar-valid. Keeps the #253 EOG-accept skip and #907 catch-as-EOS. Adds a terminal branch (dead grammar → stop at EOS, guarded against a no-EOS vocab). No grammar-side whitespace loosening (per-model BPE risk) and no retry-budget change — the failure is gone at the sampler.

New `samplerGrammarResample` (position-0) diagnostic measures the residual rescue rate as a model-onboarding fragility signal.

## Test plan

- **Harness acceptance (real inference).** The three previously-failing Sarashina 2.2 3B cells now complete on attempt 1 with **zero** "Model generated no output tokens":
  | cell | before | after |
  |---|---|---|
  | word_wolf ja | both attempts failed | ✅ attempt 1, 8 resamples rescued |
  | word_wolf en | both failed, 775s | ✅ attempt 1, 10 rescued |
  | prisoners_dilemma ja | failed (coin-flip) | ✅ attempt 1, 16 rescued |
  | Gemma word_wolf (regression) | ok | ✅ unchanged, 0 resamples |
  Zero terminal masked-selection fallthroughs in all runs.
- **Unit suite**: 2864 tests / 230 suites pass (`scripts/xcodebuild.sh test -skip-testing:PasturaUITests`).
- **Builds**: iOS app target (`scripts/xcodebuild.sh build`) + ADR-013 harness (`swift build`) green; SwiftLint `--strict` clean.
- **Review**: Opus `code-reviewer` PASS (0 Critical); Warning (terminal-branch no-EOS guard) + Suggestion (stale DocC ref) both applied and re-verified.

**Note**: the sampler path cannot run in the iOS simulator (no quantized inference), so it has no simulator unit tests by design — the multi-token grammar-accept continuity (no desync crash across 25–45 grammar-constrained inferences/cell) is exercised by the harness runs above, and the device integration suite backstops it.

Closes #751

🤖 Generated with [Claude Code](https://claude.com/claude-code)