### PR TITLE
✨ feat: P7 signature-phase — exhaustive PhaseType switch (ADR-022 PR-B)

### DIFF
--- a/Pastura/Pastura/Views/Community/SharedScenarios/GalleryCatalogRow.swift
+++ b/Pastura/Pastura/Views/Community/SharedScenarios/GalleryCatalogRow.swift
@@ -255,18 +255,32 @@ nonisolated enum ScenarioSignaturePhase: CaseIterable {
     .eliminate, .choose, .conditional, .eventInject, .vote, .scoreCalc
   ]
 
-  /// Maps a ``PhaseType`` raw value to its signature kind, or `nil` for
-  /// scaffolding phases (`assign` / `speak_all` / `speak_each` / `summarize`)
-  /// and any unknown future kind — neither contributes a headline.
+  /// Maps a ``PhaseType`` to its signature kind, or `nil` for the
+  /// signature-less scaffolding / interaction kinds (`speak_all` /
+  /// `speak_each` / `reflect` / `whisper` / `assign` / `summarize` /
+  /// `relationship_update`) — none of which contribute a headline.
+  ///
+  /// `raw` is parsed through ``PhaseType`` first, so an unknown raw value (a
+  /// gallery feed newer than this build) returns `nil` and the caller's
+  /// `compactMap` drops it — preserving ADR-020's forward-compat grey-out
+  /// posture. The `switch` is then **no-default exhaustive over `PhaseType`**
+  /// (ADR-022 D2): a future phase kind breaks this file's compile until its
+  /// headline decision is made here, instead of silently falling through to
+  /// `nil`.
   init?(phaseRawValue raw: String) {
-    switch raw {
-    case "eliminate": self = .eliminate
-    case "choose": self = .choose
-    case "conditional": self = .conditional
-    case "event_inject": self = .eventInject
-    case "vote": self = .vote
-    case "score_calc": self = .scoreCalc
-    default: return nil
+    guard let phaseType = PhaseType(rawValue: raw) else { return nil }
+    switch phaseType {
+    case .eliminate: self = .eliminate
+    case .choose: self = .choose
+    case .conditional: self = .conditional
+    case .eventInject: self = .eventInject
+    case .vote: self = .vote
+    case .scoreCalc: self = .scoreCalc
+    // Signature-less kinds — no headline glyph; a scenario carrying only these
+    // falls back to `discuss` in `signaturePhase(phases:)`.
+    case .speakAll, .speakEach, .reflect, .whisper, .assign, .summarize,
+      .relationshipUpdate:
+      return nil
     }
   }
 

--- a/Pastura/PasturaTests/Views/GalleryCatalogMetricsTests.swift
+++ b/Pastura/PasturaTests/Views/GalleryCatalogMetricsTests.swift
@@ -189,19 +189,22 @@ struct GalleryCatalogMetricsTests {
   }
 
   @Test func signatureMappingTracksPhaseTypeRawValues() {
-    // The Views-layer enum hardcodes phase raw-value literals (deliberate
-    // decoupling from PhaseType). Pin them against the real PhaseType raw
-    // values so the literals can't silently drift.
-    let mapped: [(PhaseType, ScenarioSignaturePhase)] = [
-      (.eliminate, .eliminate), (.choose, .choose), (.conditional, .conditional),
-      (.eventInject, .eventInject), (.vote, .vote), (.scoreCalc, .scoreCalc)
+    // `ScenarioSignaturePhase.init?(phaseRawValue:)` is now a no-default
+    // exhaustive switch over `PhaseType` (ADR-022 D2), so the compiler is the
+    // primary guard that every phase kind gets a headline decision. This test
+    // is the `allCases`-driven backstop: it partitions the FULL `PhaseType`
+    // set into the six signature kinds and the seven signature-less kinds and
+    // asserts both sides, so it can never silently lag the enum the way a
+    // hand-listed nil-side did (it previously covered only 4 of 7).
+    let expected: [PhaseType: ScenarioSignaturePhase] = [
+      .eliminate: .eliminate, .choose: .choose, .conditional: .conditional,
+      .eventInject: .eventInject, .vote: .vote, .scoreCalc: .scoreCalc
     ]
-    for (phase, signature) in mapped {
-      #expect(ScenarioSignaturePhase(phaseRawValue: phase.rawValue) == signature)
-    }
-    // Scaffolding phases carry no headline → nil.
-    for phase in [PhaseType.assign, .speakAll, .speakEach, .summarize] {
-      #expect(ScenarioSignaturePhase(phaseRawValue: phase.rawValue) == nil)
+    for phase in PhaseType.allCases {
+      // `expected[phase]` is `nil` for the signature-less kinds, which is
+      // exactly the mapping we assert — no headline for scaffolding /
+      // interaction phases.
+      #expect(ScenarioSignaturePhase(phaseRawValue: phase.rawValue) == expected[phase])
     }
   }
 


### PR DESCRIPTION
## Summary
Implements ADR-022 §6.2 **PR-B** (Phase/Event Extension Contract — the
"PhaseType display" slice, independent of PR-A and sanctioned to go first
while PR-A waits for #992's App-layer rework to land).

Converts projection site **P7** — `ScenarioSignaturePhase.init?(phaseRawValue:)` —
from a raw-`String` switch (`default: return nil`) to the ADR-022 **D2
"no-default exhaustive over the enum"** contract:

- Pre-parse `PhaseType(rawValue:)` (unknown raw → nil, preserving ADR-020's
  forward-compat grey-out for gallery feeds newer than this build), then switch
  exhaustively over all 13 `PhaseType` cases — 6 signature kinds → their case,
  the 7 signature-less kinds folded into one explicit arm.
- A future `PhaseType` case now **breaks this file's compile** until its
  headline decision is made, instead of silently falling through to nil (the
  recurring P1/P4/P7/P8 parity-bug class the ADR eliminates).
- Behavior is runtime-invariant.

Also rewrites the `GalleryCatalogMetricsTests` completeness backstop to be
`PhaseType.allCases`-driven, closing its prior **4-of-7 stale nil-side**
(`reflect` / `whisper` / `relationship_update` were unlisted) so it can never
lag the enum again. `PhaseGlyphTests.parityWithArtTileGlyph` is left intact — it
guards SF-symbol-name agreement, a distinct invariant.

## Scope / sequencing
- **`Part of #993`** — non-final PR of the ADR-022 A–D split. PR-A (Models+VMs
  core) waits for #992's App-layer PRs to land (`handleEvent`/`apply` collision);
  PR-C (non-Swift gates) and PR-D (docs) follow.
- ADR-022 stays `Status: Proposed`; the Proposed→Accepted flip is deferred to
  PR-D, when the full contract lands. #961 (interim checklist) stays open.

## Test plan
- `GalleryCatalogMetricsTests` + `PhaseGlyphTests`: green (29 tests).
- Full unit suite: green (2864 tests / 230 suites).
- Compile-forcing verified: the no-default switch builds only because all 13
  cases are covered; a new case would fail the build (ADR-022 D2 property).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012NWgBm5qyg2kCdCrCeF1BN