### PR TITLE
📝 docs: engine.md projection contract + PhaseType checklist

### DIFF
--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -93,6 +93,57 @@ while `reflect`/`whisper` are safe to interleave. The handler logs a
 `reflect`/`whisper`, it is NOT allowed inside `conditional` branches
 (validator rejection + `ConditionalHandler.subHandlers` omission).
 
+### Adding a new `PhaseType`
+
+A new `PhaseType` case ripples to many sites in two classes: the Swift
+compiler force-catches one (ADR-022's no-default-exhaustive contract — see
+§ "SimulationEvent & the projection contract"), while the other only fails a
+specific CI job or ships a silent gap. Touch **both** classes.
+
+**Compiler-caught** — no-default exhaustive `switch` over `PhaseType`; omit one
+and the build fails:
+
+- `Models/PhaseType.swift` — the case + `requiresLLM`.
+- `Models/ScenarioConventions.swift` — `primaryField` + `thoughtField`.
+- `Engine/ScenarioLoader.swift` — `estimatePhase` (inference count).
+- `Engine/ScenarioValidator.swift` — `validatePhases` arm (+ a
+  `validateRelationshipUpdateShape`-style shape check if the phase needs one).
+- `Views/Components/PhaseGlyph.swift`, `PhaseDisplayName.swift`;
+  `Views/Editor/PhaseBlockRow.swift`, `PhaseEditorSheet.swift` (×2 switches) +
+  `PhaseEditorSheet+CanonicalFieldHint.swift`.
+- `Views/Community/SharedScenarios/GalleryCatalogRow.swift` —
+  `ScenarioSignaturePhase.init?(phaseRawValue:)` (signature-glyph decision;
+  parse-then-exhaustive since ADR-022 PR-B).
+- Test switches: `PasturaTests/Engine/PhaseDispatcherTests.swift`,
+  `PasturaTests/Views/PhaseTypeLabelTests.swift`, and the
+  `PhaseType.allCases.count` pin in `PasturaTests/Models/PhaseTypeTests.swift`.
+
+**NOT compiler-caught** — green iOS build (+ unit suite + pre-commit), red
+elsewhere or a silent gap:
+
+- **`.claude/skills/scenario-factory/scripts/gallery_census.py`** — add the
+  phase to `AXES` + `AXIS_PHASES` (a distinctive mechanic) OR
+  `SCAFFOLDING_PHASES` (structural), else the Ubuntu **"Shell gate tests"** CI
+  job fails (`census: unexpected drift`). Also update both connected fixtures
+  under `.claude/skills/scenario-factory/tests/fixtures/`:
+  `gallery_census_balanced.json` (keep the new axis at 2/4 so the
+  fallback-rarest-3 test still fires) and `phase_types_current.swift` (mirror
+  the new case count).
+- YAML config fields → `App/EditablePhase.swift` (`init(from:)` + `toPhase()`)
+  and `Engine/ScenarioSerializer.swift` — neither is a `switch`, so a miss
+  silently drops the field on the visual→YAML round-trip.
+- A new `SimulationEvent` (if the phase emits one) has two *silent* sinks:
+  `tools/harness/Sources/PasturaHarnessKit/EventLineMapper.swift` — a no-default
+  canary, but caught by `swift build` only, **not** the iOS build / pre-commit
+  (see `xcodebuild-cli.md`); and `SimulationViewModel.handleEvent` /
+  `handleOutputEvent`, which still use `default:` (pending ADR-022 PR-A) so a
+  new case is silently dropped. No-default `SimulationEvent` switches like
+  `App/ReplayViewModel.apply` *do* break the iOS build — those are
+  compiler-caught, not silent.
+
+Motivating incident: PR #959 (`relationship_update`, #910) — every iOS build /
+unit / lint gate green, "Shell gate tests" red on the missing census axis.
+
 ### PhaseHandler Protocol
 
 ```swift
@@ -325,83 +376,33 @@ MVP includes exactly 3 scoring logics:
 
 Custom logic is Phase 2 scope.
 
-## SimulationEvent Definition
+## SimulationEvent & the projection contract
 
-This enum is the contract between Engine, App, and Views. Define it early —
-all three layers depend on it.
+`SimulationEvent` (and its `.error` payload `SimulationError`) is the contract
+between Engine, App, and Views — all three layers depend on it. **Single source
+of truth: `Pastura/Pastura/Models/SimulationEvent.swift`.** Do not re-enumerate
+the cases here — per `context-budget.md`, grep-findable enumerations don't
+belong in rules files, and this listing drifted twice before deletion.
 
-```swift
-nonisolated public enum SimulationEvent: Sendable, Equatable {
-    // Round lifecycle
-    case roundStarted(round: Int, totalRounds: Int)
-    case roundCompleted(round: Int, scores: [String: Int])
+**Projection contract (ADR-022) — new code.** Every production `switch` over
+`SimulationEvent`, `PhaseType`, or `CodePhaseEventPayload` must be **no-default
+exhaustive over the enum type**:
 
-    // Phase lifecycle. `phasePath` is `[K]` for top-level phase K; nested
-    // sub-phases carry `[K, N]` so future phase types with nested
-    // sub-phases share one identifier shape.
-    case phaseStarted(phaseType: PhaseType, phasePath: [Int])
-    case phaseCompleted(phaseType: PhaseType, phasePath: [Int])
+- **No `default:`.** A case a surface intentionally ignores goes in an
+  explicitly-listed arm with a why-comment, so a new case lands in *no* arm and
+  the compiler rejects the file (the `ReplayViewModel.apply` pattern).
+- **Tiered switches are allowed iff the terminal tier is no-default
+  exhaustive** (the `EventLineMapper` pattern: earlier tiers may `default:`-
+  forward, the last one lists every remaining case).
+- **No raw-string switching over phase/event kinds.** Parse
+  `PhaseType(rawValue:)` first, then switch exhaustively over the enum (the
+  `ScenarioSignaturePhase.init?(phaseRawValue:)` pattern).
 
-    // Agent outputs (LLM phases)
-    case agentOutput(agent: String, output: TurnOutput, phaseType: PhaseType)
+Full contract + rationale: `docs/decisions/ADR-022.md` § D2.
 
-    // Code phase results
-    case scoreUpdate(scores: [String: Int])
-    case elimination(agent: String, voteCount: Int)
-    case assignment(agent: String, value: String)
-    case summary(text: String)
-
-    // Vote results (after vote phase completes)
-    case voteResults(votes: [String: String], tallies: [String: Int])
-
-    // Pairing results (choose phase with round_robin)
-    case pairingResult(agent1: String, action1: String, agent2: String, action2: String)
-
-    // Simulation lifecycle
-    case simulationCompleted
-    // Emitted only by `SimulationRunner.checkPaused`; handlers must not
-    // emit this case directly. Nested handlers invoke pause through
-    // `PhaseContext.pauseCheck`, which routes back to the single runner-
-    // owned emit point.
-    case simulationPaused(round: Int, phasePath: [Int])
-    case error(SimulationError)
-
-    // Progress (for UI feedback during long inferences)
-    case inferenceStarted(agent: String)
-    case inferenceCompleted(agent: String, durationSeconds: Double)
-}
-
-nonisolated public enum SimulationError: Error, Sendable, Equatable {
-    case scenarioValidationFailed(String)
-    /// Stores description as String (not Error) for Sendable + Equatable conformance.
-    case llmGenerationFailed(description: String)
-    case jsonParseFailed(raw: String)
-    case retriesExhausted
-    case modelNotLoaded
-    case cancelled
-}
-```
-
-### Usage Pattern in Views
-
-```swift
-// In SimulationView
-.task {
-    for await event in runner.run(scenario: scenario, config: config) {
-        switch event {
-        case .agentOutput(let agent, let output, _):
-            viewModel.appendOutput(agent: agent, output: output)
-        case .roundCompleted(_, let scores):
-            viewModel.updateScores(scores)
-        case .inferenceStarted(let agent):
-            viewModel.showThinking(agent: agent)
-        case .error(let error):
-            viewModel.showError(error)
-        // ...
-        }
-    }
-}
-```
+**Known pre-conversion carve-out (pending ADR-022 PR-A):**
+`SimulationViewModel.handleEvent` / `handleOutputEvent` still use `default:`.
+New switches follow the contract regardless.
 
 ## llama.cpp Backend Traps
 


### PR DESCRIPTION
## Summary

Lands ADR-022's **PR-D docs slice** — the one slice that does not depend on #992. Docs-only, single file `.claude/rules/engine.md`.

- **Deletes** the drifted `SimulationEvent` case listing (+ the `SimulationError` block and a generic "Usage Pattern in Views" switch example that contradicts the new no-default contract). Replaces it with a pointer to `Pastura/Pastura/Models/SimulationEvent.swift` as the single source of truth (the listing had drifted twice — it was missing 8 of 24 cases and a stale `inferenceCompleted` signature).
- **Adds** the ADR-022 § D2 **projection contract** (no-default exhaustive over `SimulationEvent` / `PhaseType` / `CodePhaseEventPayload`; explicit ignored-arm; tiered switches iff the terminal tier is exhaustive; no raw-string switching), scoped to new code, with the one live carve-out named.
- **Adds** the "Adding a new `PhaseType`" checklist, grouped **compiler-caught** vs **NOT-compiler-caught** (census axis + fixtures + Ubuntu "Shell gate tests" job, `swift build`-only `EventLineMapper` canary, silent visual→YAML round-trip drops).

## Reconciliation vs the issue text (knowledge-layering self-check)

Both #961 and #1002 were written before two changes landed; the doc encodes **current main**, not the issue snapshots:

- `SimulationEvent` is now **24** cases (issue said 23) — `turnSkipped` landed via #1007. Moot: the listing is deleted, not re-enumerated.
- `ScenarioSignaturePhase.init?(phaseRawValue:)` was **already converted** to parse-then-exhaustive by ADR-022 PR-B (#1025). So the issue's "raw-string switch carve-out" is stale — dropped here, and it becomes the positive `PhaseType(rawValue:)`-then-exhaustive example. The **only** remaining carve-out is `SimulationViewModel.handleEvent` / `handleOutputEvent` (`default:`, pending ADR-022 PR-A).

Pre-impl `critic` (Opus) caught + fixed a classification inversion (`ReplayViewModel.apply` is no-default exhaustive → compiler-caught, not a silent sink); `code-reviewer` (Opus) verified all 22 cited paths and both classifications against main → PASS.

## Follow-up (not in this PR)

`engine.md` is path-scoped to `Engine/**` + `LLM/**`, so the checklist does **not** auto-load when editing `Models/PhaseType.swift` — the true first-edit point. A one-line breadcrumb (a `models-and-data.md` pointer or an enum-adjacent comment) would fire it there; deferred to keep this diff docs-only per #1002's AC. Will file a tracking issue.

## Test plan

Docs-only; no code/behavior change. Verified: single-file diff (`.claude/rules/engine.md`), no stray `Closes #993`, every cited path/switch-site/census-set/fixture/CI-job re-verified against current main.

## Device QA

実機QA不要 — documentation-only change to a `.claude/rules/` file; no app surface touched.

Closes #961
Closes #1002
Part of #993