### PR TITLE
✨ feat: ADR-022 PR-C — non-Swift event gates + P11 round-trip

### DIFF
--- a/Pastura/PasturaTests/App/EditablePhaseRoundTripTests.swift
+++ b/Pastura/PasturaTests/App/EditablePhaseRoundTripTests.swift
@@ -1,0 +1,119 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+/// ADR-022 §D4 (P11) — `PhaseType.allCases`-driven visual→YAML round-trip guard.
+///
+/// `EditablePhase` models every `Phase` field, so the visual editor's
+/// `init(from:)` → `toPhase()` bridge and `ScenarioSerializer` must both
+/// preserve every field of every phase kind. Neither is a `switch`, so a field
+/// a new phase type introduces silently drops on the visual→YAML round-trip
+/// (#961) unless caught here. This converts that class into test-caught two ways:
+///
+///  1. `canonicalPhase(for:)` is a **no-default `switch`** over `PhaseType`, so
+///     a new case breaks the TEST-TARGET compile until it gets a fixture (the
+///     D5 no-default-fixture-builder pattern).
+///  2. The tests iterate `PhaseType.allCases`, so the fixture set cannot
+///     silently lag the enum even if the switch were ever loosened.
+@Suite(.timeLimit(.minutes(1)))
+@MainActor
+struct EditablePhaseRoundTripTests {
+  let serializer = ScenarioSerializer()
+  let loader = ScenarioLoader()
+
+  /// The visual-editor bridge (`EditablePhase.init(from:)` → `toPhase()`) is
+  /// lossless for every phase kind — the #961 field-drop class.
+  @Test func everyPhaseTypeRoundTripsThroughEditablePhase() {
+    for type in PhaseType.allCases {
+      let phase = canonicalPhase(for: type)
+      let roundTripped = EditablePhase(from: phase).toPhase()
+      #expect(
+        roundTripped == phase,
+        "EditablePhase visual round-trip dropped a field for \(type.rawValue)")
+    }
+  }
+
+  /// `ScenarioSerializer` → `ScenarioLoader` preserves every phase kind's
+  /// fields — the second, YAML half of the same round-trip.
+  @Test func everyPhaseTypeRoundTripsThroughSerializer() throws {
+    for type in PhaseType.allCases {
+      let scenario = wrap(canonicalPhase(for: type))
+      let reloaded = try loader.load(yaml: serializer.serialize(scenario))
+      #expect(
+        reloaded.phases == scenario.phases,
+        "serializer round-trip dropped a field for \(type.rawValue)")
+    }
+  }
+
+  // One arm per PhaseType, no nested logic. Block disable rather than
+  // `disable:next` (which would orphan the doc comment below it); the disable
+  // command line must hold only the rule name, so this rationale is separate.
+  // swiftlint:disable cyclomatic_complexity
+  /// A canonical `Phase` populating every field the given phase type uses.
+  /// **No `default:`** — a new `PhaseType` fails to compile until it gets a
+  /// fixture here. Booleans use only the non-default value (`excludeSelf: true`)
+  /// because `false` round-trips to `nil` by design (`EditablePhase.toPhase`).
+  private func canonicalPhase(for type: PhaseType) -> Phase {
+    switch type {
+    case .speakAll:
+      return Phase(
+        type: .speakAll, prompt: "Speak.",
+        outputSchema: ["statement": "string", "inner_thought": "string"])
+    case .speakEach:
+      return Phase(
+        type: .speakEach, prompt: "Speak in turn.",
+        outputSchema: ["statement": "string"], subRounds: 2)
+    case .vote:
+      return Phase(
+        type: .vote, prompt: "Vote.",
+        outputSchema: ["vote": "string", "reason": "string"], excludeSelf: true)
+    case .choose:
+      return Phase(
+        type: .choose, prompt: "Choose.", outputSchema: ["action": "string"],
+        options: ["cooperate", "betray"], pairing: .roundRobin)
+    case .reflect:
+      return Phase(type: .reflect, prompt: "Reflect.", outputSchema: ["note": "string"])
+    case .whisper:
+      return Phase(
+        type: .whisper, prompt: "Whisper.",
+        outputSchema: ["statement": "string"], subRounds: 2)
+    case .scoreCalc:
+      return Phase(type: .scoreCalc, logic: .prisonersDilemma)
+    case .assign:
+      return Phase(type: .assign, source: "topics", target: .randomOne)
+    case .eliminate:
+      return Phase(type: .eliminate)
+    case .summarize:
+      return Phase(type: .summarize, template: "Round summary: {scoreboard}")
+    case .conditional:
+      return Phase(
+        type: .conditional, condition: "max_score >= 10",
+        thenPhases: [Phase(type: .summarize, template: "Done.")],
+        elsePhases: [
+          Phase(type: .speakAll, prompt: "Continue.", outputSchema: ["statement": "string"])
+        ])
+    case .eventInject:
+      return Phase(
+        type: .eventInject, source: "trials", probability: 0.5,
+        eventVariable: "current_event")
+    case .relationshipUpdate:
+      return Phase(
+        type: .relationshipUpdate, voteAgainst: -1,
+        actionDeltas: ["cooperate": 1, "betray": -2])
+    }
+  }
+  // swiftlint:enable cyclomatic_complexity
+
+  /// Minimal loadable scenario wrapping a single phase for the serializer half.
+  private func wrap(_ phase: Phase) -> Scenario {
+    Scenario(
+      id: "roundtrip", name: "Round Trip", description: "d", language: "en",
+      agentCount: 2, rounds: 1, context: "c",
+      personas: [
+        Persona(name: "Alice", description: "a"),
+        Persona(name: "Bob", description: "b")
+      ],
+      phases: [phase])
+  }
+}

--- a/scripts/check_demo_replay_event_coverage.py
+++ b/scripts/check_demo_replay_event_coverage.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""ADR-022 §D4 (P8) — demo-replay event-coverage gate (fail-closed).
+
+Cross-checks that every `SimulationEvent` name the harness emits to JSONL
+(the `event: "…"` string literals in `EventLineMapper.swift`, the real JSONL
+emit surface) is classified in `jsonl_to_demo_replay.py`'s `HANDLED_EVENTS`
+or `IGNORED_EVENTS`. An emit literal in neither set means the converter would
+silently drop (or now hard-error on) an event the demo pipeline never decided
+about — exactly the P8 drift this gate closes.
+
+This is the gate LOGIC (analogue of `scripts/p8-precommit-gate.sh`); the
+tripwire structure that exercises it against synthetic fixtures + the real
+files lives in `scripts/tests/demo-replay-event-coverage-test.sh` (the CI
+"Shell gate tests" job). Anchoring on the emit literals — not snake_cased
+`SimulationEvent` case names — avoids a hand-maintained alias map and any
+`SimulationError` contamination (ADR-022 §D4). The two events the mapper maps
+to no line (`agentOutputStream`, `roundCheckpoint`) never reach JSONL and are
+covered by the P3 `swift build` canary, so they need no entry here.
+
+Fail-closed by design (unlike the fail-open `gallery_census.py`): any
+uncovered emit literal, any HANDLED∩IGNORED overlap, or an extracted count
+below `--min-events` exits non-zero. The count-floor pins against a regex that
+silently under-extracts (e.g. after an `EventLine` construction reshape).
+
+usage:
+  check_demo_replay_event_coverage.py [--mapper PATH] [--converter PATH]
+                                      [--min-events N]
+Defaults point at the real files; the shell gate overrides both paths to run
+synthetic drift / floor fixtures.
+"""
+import argparse
+import importlib.util
+import re
+import sys
+
+# The `event: "…"` emit literals in EventLineMapper.swift. `event:` is the
+# EventLine initializer's argument label; the only quoted-string values it
+# takes are the JSONL event names (lowercase snake_case). The `func map(_
+# event: SimulationEvent …)` parameter is `event:` followed by a type, not a
+# quoted string, so it does not match.
+_EMIT_RE = re.compile(r'event:\s*"([a-z0-9_]+)"')
+
+_DEFAULT_MAPPER = "tools/harness/Sources/PasturaHarnessKit/EventLineMapper.swift"
+_DEFAULT_CONVERTER = "scripts/jsonl_to_demo_replay.py"
+
+
+def extract_emit_literals(mapper_path):
+    """The set of `event: "…"` literals declared in the mapper source."""
+    with open(mapper_path, encoding="utf-8") as f:
+        return set(_EMIT_RE.findall(f.read()))
+
+
+def load_classification(converter_path):
+    """Import the converter by file path and return (HANDLED, IGNORED) sets.
+
+    `spec_from_file_location` loads an arbitrary path (the temp fixtures the
+    shell gate writes live outside the module search path, so `import_module`
+    can't reach them). Importing runs the converter's top-level defs but NOT
+    `main()` (guarded by `if __name__ == "__main__"`), so it has no side
+    effect beyond its own imports.
+    """
+    spec = importlib.util.spec_from_file_location("converter_under_test", converter_path)
+    if spec is None or spec.loader is None:
+        raise SystemExit(f"check_demo_replay_event_coverage: cannot load {converter_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    try:
+        return set(module.HANDLED_EVENTS), set(module.IGNORED_EVENTS)
+    except AttributeError as exc:
+        raise SystemExit(
+            f"check_demo_replay_event_coverage: {converter_path} is missing "
+            f"HANDLED_EVENTS/IGNORED_EVENTS ({exc})")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mapper", default=_DEFAULT_MAPPER)
+    parser.add_argument("--converter", default=_DEFAULT_CONVERTER)
+    parser.add_argument(
+        "--min-events", type=int, default=0,
+        help="count-floor: fail if fewer emit literals are extracted (guards "
+             "against regex under-extraction). Real-file floor is set by the "
+             "shell gate; bump it when EventLineMapper gains an emit literal.")
+    args = parser.parse_args()
+
+    emits = extract_emit_literals(args.mapper)
+    handled, ignored = load_classification(args.converter)
+
+    errors = []
+
+    if len(emits) < args.min_events:
+        errors.append(
+            f"extracted {len(emits)} emit literal(s) from {args.mapper}, below "
+            f"the --min-events floor of {args.min_events}. The regex likely "
+            "under-extracted (EventLine construction reshaped?) — or an event "
+            "was removed; update the floor if the removal is intended.")
+
+    overlap = handled & ignored
+    if overlap:
+        errors.append(
+            "these events are in BOTH HANDLED_EVENTS and IGNORED_EVENTS "
+            f"(must be exactly one): {', '.join(sorted(overlap))}")
+
+    uncovered = emits - handled - ignored
+    if uncovered:
+        errors.append(
+            "these emitted event(s) are classified in NEITHER HANDLED_EVENTS "
+            f"nor IGNORED_EVENTS: {', '.join(sorted(uncovered))}. Add each to "
+            "one of the two sets in the converter (ADR-022 §D4).")
+
+    if errors:
+        print(f"check_demo_replay_event_coverage: FAIL ({args.mapper})", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+
+    print(
+        f"check_demo_replay_event_coverage: OK — {len(emits)} emit literal(s), "
+        f"all classified ({len(handled)} handled / {len(ignored)} ignored).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/jsonl_to_demo_replay.py
+++ b/scripts/jsonl_to_demo_replay.py
@@ -63,6 +63,39 @@ CODE_KIND = {
     "pairing_result": "pairingResult",
 }
 
+# ADR-022 §D4 (P8) — the forced-decision contract for this non-Swift consumer.
+# Every event name EventLineMapper.swift emits to JSONL must be classified in
+# exactly one of these two sets:
+#   HANDLED_EVENTS — drives a turn or a code-phase event in the demo output.
+#   IGNORED_EVENTS — reaches JSONL but is deliberately dropped from the demo
+#                    (lifecycle / diagnostic events the replay schema has no
+#                    slot for; moving one here is a reviewed diff).
+# An event in NEITHER set is a HARD ERROR at convert time (see the guard in
+# `main`) — previously a silent drop with no failure mode at all. The
+# `scripts/tests/demo-replay-event-coverage-test.sh` shell gate cross-checks
+# this classification against the Swift emit surface so the two never diverge.
+HANDLED_EVENTS = {
+    "round_started",
+    "phase_started",
+    "agent_output",
+    "shared_assignment",
+    "assignment",
+} | set(CODE_KIND)
+
+IGNORED_EVENTS = {
+    "round_completed",
+    "phase_completed",
+    "relationship_update",  # raw affinity matrix (#910); demo/replay drops it
+    "conditional_evaluated",
+    "simulation_completed",
+    "simulation_paused",
+    "error",
+    "inference_started",
+    "inference_completed",
+    "language_mismatch",
+    "turn_skipped",
+}
+
 # Stable field order for turn `fields` (mirrors existing hand-authored demos:
 # statement before inner_thought, vote before reason). Unknown keys keep
 # their source order after these.
@@ -144,6 +177,15 @@ def main():
         if l.get("type") != "event":
             continue
         e = l.get("event")
+        # ADR-022 §D4 (P8) — force a classification decision. An event name in
+        # neither set is a hard error (was: silent drop). The guard sits after
+        # the `type != event` filter so lifecycle lines (run_start/run_end,
+        # which carry no `event` field) never reach it.
+        if e not in HANDLED_EVENTS and e not in IGNORED_EVENTS:
+            raise SystemExit(
+                f"jsonl_to_demo_replay: unknown event {e!r} in {a.run}. Add it "
+                "to HANDLED_EVENTS or IGNORED_EVENTS (did EventLineMapper's "
+                "emit surface change?) — see ADR-022 §D4.")
         if e == "round_started":
             round_no = l["round"]
         elif e == "phase_started":

--- a/scripts/tests/demo-replay-event-coverage-test.sh
+++ b/scripts/tests/demo-replay-event-coverage-test.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+#
+# scripts/tests/demo-replay-event-coverage-test.sh — tripwire for the
+# ADR-022 §D4 (P8) demo-replay event-coverage gate
+# (scripts/check_demo_replay_event_coverage.py).
+#
+# CI-wired: the `*-test.sh` naming convention makes this a gate under the
+# .github/workflows/ci.yml "Shell gate tests" job ("Run scripts/tests/*-test.sh").
+# Pure python3 + git + bash — no Xcode, no PyYAML (the synthetic converter
+# fixtures define only the two sets, so importing them never runs `import yaml`).
+# Run manually: bash scripts/tests/demo-replay-event-coverage-test.sh
+#
+# Structure mirrors the census tripwire (the gallery_census.py drift chain in
+# .claude/skills/scenario-factory/tests/run_tests.sh (e), and its
+# phase_types_current.swift fixture): a repo-root existence assertion, a
+# synthetic-drift positive fixture, and a count-floor pin on the real file. The
+# shell scaffold (tempdir + `trap rm EXIT` + `fail=0` accumulator + per-case
+# subshell) follows scripts/tests/p8-precommit-gate-test.sh — note its "P8" is
+# ADR-014's App Store `.p8` secret-gate, unrelated to ADR-022's projection
+# site P8; only the scaffold shape is borrowed.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+CHECKER="$REPO_ROOT/scripts/check_demo_replay_event_coverage.py"
+MAPPER="$REPO_ROOT/tools/harness/Sources/PasturaHarnessKit/EventLineMapper.swift"
+CONVERTER="$REPO_ROOT/scripts/jsonl_to_demo_replay.py"
+
+# (a) Repo-root existence assertion — a harness/SPM move or a rename fails
+# loudly HERE rather than silently disabling the coverage cross-check (the
+# checker's defaults would resolve to a missing path and the live check below
+# would error, but an explicit assertion names the cause).
+[ -f "$CHECKER" ] || { echo "FAIL: gate script missing at $CHECKER" >&2; exit 1; }
+[ -f "$MAPPER" ] || {
+  echo "FAIL: real EventLineMapper.swift not found at $MAPPER (harness move? update MAPPER)" >&2
+  exit 1
+}
+[ -f "$CONVERTER" ] || {
+  echo "FAIL: real jsonl_to_demo_replay.py not found at $CONVERTER" >&2
+  exit 1
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+fail=0
+
+# Writes a synthetic mapper source: each argument becomes one `event: "…"`
+# emit literal (plus non-matching noise, to prove the regex is specific).
+mk_mapper() { # <path> <event-name>...
+  local path="$1"
+  shift
+  {
+    echo 'func map(_ event: SimulationEvent) -> EventLine? {'  # must NOT match
+    local ev
+    for ev in "$@"; do
+      echo "    return EventLine(t: t, attempt: attempt, event: \"$ev\")"
+    done
+    echo '}'
+  } >"$path"
+}
+
+# Writes a synthetic converter defining just the two classification sets
+# (no `import yaml`, so importing it is cheap). Sets are passed as
+# space-separated event lists.
+mk_converter() { # <path> <handled> <ignored>
+  local path="$1" handled="$2" ignored="$3"
+  {
+    printf 'HANDLED_EVENTS = {'
+    local ev
+    for ev in $handled; do printf '"%s", ' "$ev"; done
+    printf '}\n'
+    printf 'IGNORED_EVENTS = {'
+    for ev in $ignored; do printf '"%s", ' "$ev"; done
+    printf '}\n'
+  } >"$path"
+}
+
+# (d) Live check — the actual drift guard. The REAL mapper's emit literals must
+# all be classified in the REAL converter, and the count-floor pins against
+# regex under-extraction. Bump --min-events when EventLineMapper gains an emit
+# literal (currently 22).
+if ! python3 "$CHECKER" --mapper "$MAPPER" --converter "$CONVERTER" --min-events 22 >/dev/null; then
+  echo "FAIL: real EventLineMapper emits an event unclassified in HANDLED/IGNORED, or count < 22" >&2
+  fail=1
+fi
+
+# (b) Synthetic-drift POSITIVE fixture — a `ghost_event` classified in neither
+# set must make the gate exit non-zero. Without this the fail-closed claim is
+# untested (the live check only ever exercises the pass path).
+mk_mapper "$TMP/drift_mapper.swift" alpha beta ghost_event
+mk_converter "$TMP/drift_converter.py" "alpha" "beta"
+if python3 "$CHECKER" --mapper "$TMP/drift_mapper.swift" \
+    --converter "$TMP/drift_converter.py" --min-events 1 >/dev/null 2>&1; then
+  echo "FAIL: gate accepted an unclassified 'ghost_event' (drift not detected)" >&2
+  fail=1
+fi
+
+# Negative control — the same three events, all classified, must PASS.
+mk_converter "$TMP/covered_converter.py" "alpha ghost_event" "beta"
+if ! python3 "$CHECKER" --mapper "$TMP/drift_mapper.swift" \
+    --converter "$TMP/covered_converter.py" --min-events 1 >/dev/null 2>&1; then
+  echo "FAIL: gate rejected a fully-classified fixture (false positive)" >&2
+  fail=1
+fi
+
+# (c) Count-floor fixture — a fully-classified mapper with FEWER literals than
+# --min-events must still fail, proving the floor catches regex under-extraction
+# independently of coverage.
+mk_mapper "$TMP/floor_mapper.swift" alpha beta
+mk_converter "$TMP/floor_converter.py" "alpha beta" ""
+if python3 "$CHECKER" --mapper "$TMP/floor_mapper.swift" \
+    --converter "$TMP/floor_converter.py" --min-events 5 >/dev/null 2>&1; then
+  echo "FAIL: count-floor not enforced (2 literals passed --min-events 5)" >&2
+  fail=1
+fi
+
+# Overlap guard — an event in BOTH sets is a classification bug and must fail.
+mk_converter "$TMP/overlap_converter.py" "alpha beta" "beta"
+if python3 "$CHECKER" --mapper "$TMP/floor_mapper.swift" \
+    --converter "$TMP/overlap_converter.py" --min-events 1 >/dev/null 2>&1; then
+  echo "FAIL: gate accepted an event in BOTH HANDLED and IGNORED" >&2
+  fail=1
+fi
+
+if [ "$fail" -eq 0 ]; then
+  echo "demo-replay-event-coverage: all cases passed"
+else
+  echo "demo-replay-event-coverage: FAILURES" >&2
+  exit 1
+fi

--- a/scripts/tests/demo-replay-event-coverage-test.sh
+++ b/scripts/tests/demo-replay-event-coverage-test.sh
@@ -6,16 +6,18 @@
 #
 # CI-wired: the `*-test.sh` naming convention makes this a gate under the
 # .github/workflows/ci.yml "Shell gate tests" job ("Run scripts/tests/*-test.sh").
-# Pure python3 + git + bash — no Xcode, no PyYAML (the synthetic converter
-# fixtures define only the two sets, so importing them never runs `import yaml`).
-# Run manually: bash scripts/tests/demo-replay-event-coverage-test.sh
+# python3 + git + bash, no Xcode. The synthetic fixtures define only the two
+# sets (no `import yaml`), but the live check (case d) imports the REAL
+# converter, whose module-level `import yaml` means PyYAML IS required for that
+# case — the shell-tests job pre-installs it (ci.yml). Run manually with PyYAML
+# present: bash scripts/tests/demo-replay-event-coverage-test.sh
 #
 # Structure mirrors the census tripwire (the gallery_census.py drift chain in
 # .claude/skills/scenario-factory/tests/run_tests.sh (e), and its
 # phase_types_current.swift fixture): a repo-root existence assertion, a
 # synthetic-drift positive fixture, and a count-floor pin on the real file. The
-# shell scaffold (tempdir + `trap rm EXIT` + `fail=0` accumulator + per-case
-# subshell) follows scripts/tests/p8-precommit-gate-test.sh — note its "P8" is
+# shell scaffold (tempdir + `trap rm EXIT` + `fail=0` accumulator) follows
+# scripts/tests/p8-precommit-gate-test.sh — note its "P8" is
 # ADR-014's App Store `.p8` secret-gate, unrelated to ADR-022's projection
 # site P8; only the scaffold shape is borrowed.
 set -euo pipefail


### PR DESCRIPTION
## Summary

ADR-022 PR-C (§6.3): the **non-Swift forced-decision gates** (P8) + the **P11 round-trip test**. Independent slice — no collision with #992; PR-A/B already merged.

- **P8 — `jsonl_to_demo_replay.py`**: module-level `HANDLED_EVENTS` / `IGNORED_EVENTS` sets + a hard-error guard so an event name in neither set aborts the convert (was: silent drop). The two sets partition the 22 `EventLineMapper` emit literals exactly (11 handled / 11 ignored, no overlap, no gap).
- **`check_demo_replay_event_coverage.py`** (new): the fail-closed gate — regex-extracts the `event: "…"` emit literals from `EventLineMapper.swift`, imports the converter's sets via `importlib`, and fails if any literal is unclassified, any overlap exists, or the count drops below `--min-events` (count-floor pin against regex under-extraction).
- **`demo-replay-event-coverage-test.sh`** (new): census-tripwire-structured shell gate (CI "Shell gate tests" auto-glob, no `ci.yml` edit) — repo-root existence assert + synthetic drift/floor/overlap fixtures + a live check on the real files (`--min-events 22`).
- **P11 — `EditablePhaseRoundTripTests.swift`** (new): a `PhaseType.allCases`-driven round-trip test with a **no-default `switch`** fixture builder (a new `PhaseType` breaks the test-target compile), asserting both the `EditablePhase.init(from:)`→`toPhase()` visual round-trip and the `ScenarioSerializer`→`ScenarioLoader` YAML round-trip preserve every field of every phase kind (the #961 silent-field-drop class → test-caught).

Scope: `engine.md` / `CLAUDE.md` doc reflection and #961 re-scoping stay in **PR-D**; ADR-022 stays **Proposed** (Accept is PR-D). #961 remains open.

## Test plan

- `for f in scripts/tests/*-test.sh; do bash "$f"; done` — all 13 pass, incl. the new gate (synthetic drift/floor/overlap fixtures each drive the checker to a non-zero exit; live check green on the real 22-literal surface).
- `scripts/xcodebuild.sh test -only-testing PasturaTests/EditablePhaseRoundTripTests` — 2/2 pass.
- Converter hard-errors on an unknown event; valid runs with IGNORED events (round_completed, inference_completed) still convert cleanly (no regression).
- code-reviewer (Opus): PASS.

## Device QA

実機QA不要 — Python/shell scripts + a Swift unit test only; no `#if !targetEnvironment(simulator)` blocks, Metal/llama.cpp paths, or UI surface.

Part of #993