### PR TITLE
📝 docs: resolve #496 LiteRT-LM sequencing — conditional iOS-first

### DIFF
--- a/docs/decisions/ADR-002.md
+++ b/docs/decisions/ADR-002.md
@@ -313,15 +313,27 @@ When LiteRT-LM Swift SDK ships with iOS GPU support:
 
 The `LLMService` protocol was specifically designed for this swap (ADR-001 §7).
 
-### 8.1 Cross-platform migration synchronisation — pointer (2026-04-22)
+### 8.1 Cross-platform migration sequencing — resolved (2026-04-22; updated 2026-07-10)
 
-ADR-004 §3.6 (Draft) proposes that Phase 3 starts with unified
-llama.cpp across all platforms, and that migration to LiteRT-LM — when
-the §8 trigger fires — is synchronised across platforms during
-Phase 3.0 rather than iOS-first. This ADR-002 section will be written
-in full (with its own constraints and rationale) only when ADR-004 is
-accepted; until then, ADR-002's Accepted §8 migration plan remains
-iOS-scoped as originally committed.
+ADR-004 (now **Accepted**) §3.6 establishes that Phase 3 starts with
+unified llama.cpp across all platforms. The originally-open question —
+whether the eventual LiteRT-LM migration is **iOS-first** or
+**synchronised across platforms** — was resolved on **#496 Open Question
+#1 (2026-07-10)** as **conditional iOS-first**:
+
+- Readiness gate: `LiteRT #6745 closed AND (constrained decoding reachable
+  from the Swift surface OR prompt-only harness readout acceptable vs the
+  llama.cpp + GBNF baseline)`.
+- If the gate opens before the KMP Engine port (ADR-023) starts, iOS
+  migrates standalone via the §8 drop-in (`LlamaCppService` kept as a
+  feature-flag fallback ≥1 TestFlight cycle); if it opens mid-port, the
+  swap is frozen until the port lands; if still closed at port completion,
+  iOS migrates whenever it opens — **never** gated on Android/KMP
+  readiness.
+
+Full rationale and the branch table live in **ADR-004 §3.6** (the
+*iOS-migration sequencing* note). The §8 drop-in plan below is exactly
+what branches 1 and 3 execute, and remains unchanged.
 
 ### 8.2 Migration trigger fired — evaluation in progress (2026-06-11)
 
@@ -356,10 +368,11 @@ Reframing of the §8 monitoring pointers:
   for cross-platform distribution and hitting ABI mismatches — not the
   official prebuilt SwiftPM package Pastura consumes. It stays relevant
   only to the source-build / KMP cross-platform path (ADR-004 §3.6).
-- §8.1 records that the iOS-first-vs-synchronised-KMP **sequencing
-  remains open** pending ADR-004 acceptance (still Draft); it does not yet
-  settle that question. The #496 evaluation must resolve the sequencing
-  before any migration begins.
+- §8.1 records that the iOS-first-vs-synchronised sequencing is
+  **resolved as conditional iOS-first** (ADR-004 §3.6, now Accepted; #496
+  Open Question #1, 2026-07-10). The remaining #496 work is the PoC spike
+  itself — real-device benchmark, deployment-target check, `.litertlm`
+  model path, streaming / constraint parity — gated on LiteRT #6745.
 
 ### Monitoring
 

--- a/docs/decisions/ADR-004.md
+++ b/docs/decisions/ADR-004.md
@@ -51,8 +51,8 @@
   unified llama.cpp backend (same binding choice as Android).
 
 with a footnote under *Platform Expansion Strategy* that enshrines the
-unified-llama.cpp direction and the synchronized LiteRT-LM migration
-trigger.
+unified-llama.cpp direction and the LiteRT-LM migration trigger
+(sequencing resolved in §3.6).
 
 This ADR formalises the KMP-for-logic + native-per-platform-UI direction
 and rejects the alternative of full-UI unification (Option B). The
@@ -101,9 +101,9 @@ commonMain (Kotlin)     Engine / Models / LLMService interface
   Swift `LlamaCppService`; Android and Desktop use a llama.cpp KMP
   binding (specific binding TBD — Llamatik is one candidate). Migration
   to LiteRT-LM is deferred until Google's LiteRT-LM Swift SDK ships with
-  iOS GPU support — at that point synchronised migration across
-  platforms is the Phase 3.0 default, with per-platform timing
-  reconsiderable once Phase 3.0 stabilises (see §3.6 and §8).
+  iOS GPU support; the eventual migration sequencing is resolved as
+  **conditional iOS-first** (§3.6 *iOS-migration sequencing* note; ADR-002
+  §8 / §8.1), not a synchronised all-platform swap.
 
 ### Option B — KMP + Compose Multiplatform (UI unified across iOS/Android/Desktop)
 
@@ -201,9 +201,11 @@ Option A's `expect`/`actual` structure leaves a sub-decision: what
 backend does each platform's `actual` use? The original 2026-04-17
 draft leaned toward *iOS → llama.cpp* + *Android → LiteRT-LM Kotlin
 SDK* (different backends per platform). This section revises the lean
-to **unified llama.cpp across every platform during Phase 3.0**, with
-synchronised migration to LiteRT-LM once the LiteRT-LM Swift SDK + iOS
-GPU ships (ADR-002 §8 / §8.1).
+to **unified llama.cpp across every platform during Phase 3.0**, with the
+eventual LiteRT-LM migration deferred until the LiteRT-LM Swift SDK + iOS
+GPU ships — its cross-platform sequencing resolved as **conditional
+iOS-first** (see the *iOS-migration sequencing* note below; ADR-002
+§8 / §8.1).
 
 **Scope of the rationale below: Phase 3.0 launch triage, not a
 permanent architecture principle.** After Phase 3.0 stabilises (the
@@ -297,16 +299,61 @@ subsection.
   3.1 implementation start; Llamatik is one candidate among others
   to survey at that time.
 
-**Post-Phase-3.0 (informational):**
+**iOS-migration sequencing — resolved (2026-07-10, #496 OQ#1):**
 
-Once Phase 3.0 stabilises, the "synchronise migrations across
-platforms" rule of thumb becomes reconsiderable per-platform. If, for
-example, Android stabilises on llama.cpp well before the LiteRT-LM
-Swift SDK ships, migrating Android to LiteRT-LM Kotlin SDK ahead of
-iOS may become worth the parallel-backend cost. The trigger is
-intentionally left as "situational re-assessment" rather than a
-defined gate — the launch-phase triage benefit decays with stability,
-and forcing a concrete threshold now would be speculative.
+The Post-Phase-3.0 question this section originally left as "situational
+re-assessment" — iOS-first vs synchronised — is now **resolved to
+conditional iOS-first**, decided on #496 Open Question #1 (Fable
+second-opinion consult). The unified-llama.cpp baseline above still holds
+*during* the Phase 3.0 port in the realistic branches (2 and 3 below);
+what is settled is the sequencing of the *eventual* LiteRT-LM migration
+relative to the KMP Engine port (ADR-023).
+
+Trigger = the #496 / #969 readiness gate (the same gate ADR-023 §8 records
+in short form):
+
+> `Ready = LiteRT #6745 closed AND (constrained decoding reachable from the
+> Swift surface OR prompt-only harness readout acceptable vs the
+> llama.cpp + GBNF baseline)`
+
+Decision rule, by when the gate opens:
+
+1. **Gate opens before the KMP port starts** → migrate iOS immediately as
+   a standalone Swift-side swap behind `LLMService` (ADR-002 §8 drop-in),
+   keeping `LlamaCppService` as a feature-flagged fallback for ≥1
+   TestFlight cycle. This is the one branch that relaxes strict Phase-3.0
+   backend symmetry — accepted below.
+2. **Gate opens during the port window** (port start → Stage-2 GO/NO-GO
+   decided + merge + harness-parity green) → **freeze**: queue the swap
+   until the port lands. This is the only interval where the "moving iOS
+   backend target" cost actually bites.
+3. **Gate still closed when the port completes** → migrate iOS whenever it
+   opens; **never** condition iOS on Android/KMP LiteRT readiness.
+4. **Override** — a LiteRT-only must-have model (e.g. a Gemma Nano tier
+   that unlocks the ADR-011 6 GB RAM tier) collapses the freeze window;
+   operator judgement.
+
+**Why conditional iOS-first, not synchronised:** a synchronised migration
+secretly waits on `max(Ready_iOS, Ready_Android/KMP, port completion)`,
+and `Ready_Android/KMP` is a strictly-*deader* exogenous gate — it needs
+both an as-yet-unselected KMP llama binding *and* Kotlin-side constraint
+exposure (tracked only by upstream LiteRT-LM #1662, no maintainer response
+~4 months). So synchronised is not "one migration event later"; it holds
+the only shipping platform hostage to the deader of two Google-controlled
+gates, with unbounded — possibly never — delay. The platform-symmetry
+rationale (point 1 of "Why the revision" above) is an explicitly
+launch-phase triage heuristic that decays with stability, and the operator
+owns no Android device (Android triage is hardware-bottlenecked, not
+backend-symmetry-bottlenecked) — so honouring it by paying an unbounded
+iOS delay inverts the cost structure it was meant to save. Branch 1 also
+makes the port's Stage-2 GO/NO-GO evidence final-backend-true (no post-port
+re-validation of the K/N boundary after a later swap).
+
+**What would flip this back to synchronised:** evidence the two gates open
+close together — a maintainer response on LiteRT-LM #1662, or a release
+exposing constraints in the Kotlin / C API in the same quarter #6745
+closes, *plus* a committed Android beta date within ~one quarter of the KMP
+port landing. No evidence supports that conjunction today.
 
 §3.4's conclusion is unchanged: Option A still aligns strictly with
 ADR-002's migration plan. The revision is a narrowing of "which
@@ -326,6 +373,12 @@ rather than hypothetical. The cross-platform binding question
 relevant blocker for the KMP path. The iOS-side evaluation is tracked
 in #496; resolve the sequencing at the Phase 2 → Phase 3 transition
 (Phase 3.0 planning).
+
+**Update (2026-07-10) — sequencing resolved:** #496 Open Question #1 is
+closed as **conditional iOS-first** (the 4-branch rule in the
+*iOS-migration sequencing* note above). This supersedes the 2026-06-11
+"resolve at the Phase 2 → Phase 3 transition" pointer and the earlier
+"synchronised migration" default this section leaned toward.
 
 ---
 
@@ -508,10 +561,10 @@ Phase 2 Go/No-Go review:
 - [ ] LiteRT-LM Swift SDK + iOS GPU status is re-checked (ADR-002 §8
       trigger). Per §3.6, Phase 3 starts with unified llama.cpp across
       all platforms regardless of SDK status at the gate review; the
-      check only determines whether the synchronised migration is a
+      check only determines whether the LiteRT-LM migration is a
       near-term Phase 3.x item (if shipped) or remains indefinitely
-      deferred (if not). Post-Phase-3.0 reconsideration remains
-      allowed per §3.6.
+      deferred (if not); its sequencing is conditional iOS-first
+      per §3.6.
 - [ ] No new iOS-only feature landed in Phase 2 that would break the
       "Engine has no iOS dependencies" invariant.
 

--- a/docs/decisions/ADR-004.md
+++ b/docs/decisions/ADR-004.md
@@ -211,7 +211,7 @@ iOS-first** (see the *iOS-migration sequencing* note below; ADR-002
 permanent architecture principle.** After Phase 3.0 stabilises (the
 first App Store release cycle and the first Play Store closed-track
 cycle both complete), per-platform migration timing may be
-reconsidered — see the *Post-Phase-3.0* note at the end of this
+reconsidered — see the *iOS-migration sequencing* note at the end of this
 subsection.
 
 **Why the revision:**
@@ -414,10 +414,10 @@ completion) clear; the architecture choice itself is no longer tentative.
 - **Unified llama.cpp backend during Phase 3.0 (§3.6)** — cross-
   platform behavioural differences in LLM output, sampling, and
   streaming are reduced at the llama.cpp C API level (subject to
-  wrapper-version pinning discipline, §3.6 point 1 caveat). Migration
-  to LiteRT-LM happens synchronously across platforms when the
-  trigger fires. Post-Phase-3.0, per-platform migration timing may
-  be reconsidered.
+  wrapper-version pinning discipline, §3.6 point 1 caveat). The eventual
+  LiteRT-LM migration is sequenced **conditional iOS-first** (§3.6
+  *iOS-migration sequencing* note; ADR-002 §8 / §8.1) — iOS is never
+  gated on Android/KMP readiness.
 
 ### 5.2 Negative
 

--- a/docs/decisions/ADR-023.md
+++ b/docs/decisions/ADR-023.md
@@ -50,7 +50,7 @@
 | Decision | What it contributes here |
 |---|---|
 | ADR-002 §8 / §8.2 | LiteRT-LM migration trigger has fired, but evaluation (#496) is separate; the port targets the `LLMService`-shaped backend seam, not a specific backend |
-| ADR-004 §3.6 | Phase 3.0 ships **unified llama.cpp** on all platforms; LiteRT-LM migration is synchronized later. This ADR keeps that sequencing |
+| ADR-004 §3.6 | Phase 3.0 ships **unified llama.cpp** on all platforms; the eventual LiteRT-LM migration is **conditional iOS-first** (#496 OQ#1). This ADR is sequencing-agnostic — LLM stays `expect`/`actual` native either way |
 | ADR-012 | `YamlCodec` (`snakeyaml-engine-kmp` → `JsonElement` tree) is the Kotlin-side scenario-parse foundation `ScenarioLoader` ports onto |
 | ADR-013 | The headless macOS harness is the Swift-side runner the cross-language parity harness (§6 Stage 4) reuses |
 | #969 design note | Constrained decoding in LiteRT-LM is an **exposure gap, not a capability gap** — and the **Kotlin API has the same gap**. The R1–R8 parity contract constrains any future backend behind the §5.2 `LLMBackend` interface (§8) |
@@ -363,8 +363,10 @@ llama.cpp-unified), but two design facts couple their futures:
   re-implementing it in Kotlin — the benefit ADR-004 §5.1 records.
 - Engine behavior gets a second, cross-language executable spec (Stage-4 harness), which
   also hardens the Swift side against accidental semantic drift.
-- The `LLMBackend` seam makes the eventual LiteRT-LM evaluation (#496) a backend-swap
-  exercise on both platforms at once, per ADR-004 §3.6's synchronized-migration intent.
+- The `LLMBackend` seam makes the eventual LiteRT-LM evaluation (#496) a contained
+  backend-swap behind the seam on each platform independently — iOS-first per the resolved
+  sequencing (ADR-004 §3.6; #496 OQ#1), with Android reusing whatever exposure path #496
+  lands at Phase 3.1 (§8).
 
 **Harder / accepted costs:**
 


### PR DESCRIPTION
## Summary

Resolves the **sequencing sub-question** of #496 (Open Question #1: iOS `llama.cpp → LiteRT-LM` migration vs the KMP Phase 3.0 Engine port, ADR-023 / #501). Decided as **conditional iOS-first** via a Fable second-opinion consult, then reconciled across the three Accepted ADRs that carried the prior "synchronised migration" framing.

**Decision — 4-branch rule**, keyed on the #969 readiness gate (`LiteRT #6745 closed AND (constrained decoding reachable from Swift OR prompt-only harness parity vs llama.cpp+GBNF)`):

1. Gate opens **before** the KMP port starts → migrate iOS immediately (standalone Swift swap behind `LLMService`, `LlamaCppService` feature-flag fallback ≥1 TestFlight cycle).
2. Gate opens **during** the port window → **freeze** until the port lands.
3. Gate still closed at port completion → migrate iOS whenever it opens; **never** gated on Android/KMP readiness.
4. Override: a LiteRT-only must-have model collapses the freeze window.

**Decisive rationale:** a synchronised migration secretly waits on `max(Ready_iOS, Ready_Android/KMP, port completion)`, and `Ready_Android/KMP` is a strictly-deader exogenous gate (unselected KMP binding + Kotlin constraint exposure tracked only by dead upstream LiteRT-LM #1662) — it would hold the only shipping platform hostage to the deader of two Google-controlled gates, with unbounded delay.

## Changes

- **ADR-004 §3.6** — replace the open "situational re-assessment" Post-Phase-3.0 note with the resolved 4-branch rule + rationale + flip-condition; add a dated `2026-07-10` Update (preserving the `2026-06-11` trigger block); sweep the now-stale "synchronised migration" present-tense claims in §Decision, the §3.6 lean, §5.1 Positive Consequences, and the gate-review checklist.
- **ADR-002 §8.1 / §8.2** — ADR-004 is now Accepted, so reframe the `(Draft)` / "written in full only when accepted" labels to dated past-tense; record the resolved sequencing. The §8 drop-in migration steps are unchanged (branches 1 & 3 execute them).
- **ADR-023 §1.2 / §10** — retag the ADR-004 §3.6 dependency row and the `LLMBackend` seam note as sequencing-agnostic / iOS-first (aligns with §8's Android-reuse language), removing the "both platforms at once" contradiction.

## Test plan

Docs-only. Reviewed by `critic` (plan, pre-edit) and `code-reviewer` (Opus, post-edit) — the latter caught and confirmed the fix of a residual `synchronously` claim in §5.1; final verdict PASS (cross-refs, dates, gate-phrasing consistency, editability-window convention, 4-branch coherence all verified). Broad-stem `grep` across all `docs/decisions/` confirms no residual live synchronised-default claim.

## Device QA

実機QA不要 — decision-record docs only; no code, no runtime surface.

Part of #496 (the PoC spike + real-device benchmark + parity work remain open, gated on LiteRT #6745).