### PR TITLE
✨ feat: resume proposal for failed runs (ADR-021 D8)

### DIFF
--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -5334,6 +5334,16 @@
         }
       }
     },
+    "Resume from round %lld" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ラウンド %lld から再開"
+          }
+        }
+      }
+    },
     "Resume playback" : {
       "localizations" : {
         "ja" : {
@@ -6412,6 +6422,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "この結果と会話ログを完全に削除します。この操作は取り消せません。"
+          }
+        }
+      }
+    },
+    "This run stopped early" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "この実行は途中で停止しました"
           }
         }
       }

--- a/Pastura/Pastura/Views/Components/FailedRunResumeBadge.swift
+++ b/Pastura/Pastura/Views/Components/FailedRunResumeBadge.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Pure gating + routing logic for the failed-run resume banner (ADR-021 D8):
+/// a run that ended `.failed` while holding a valid round checkpoint can be
+/// resumed from the next round. Extracted so the show/hide decision and the
+/// resume destination are unit-testable without rendering the View (ADR-009).
+///
+/// Mirrors ``DegradedRunBadge`` (the D6 completion-quality annotation); the two
+/// banners are mutually exclusive by status (`.failed` here vs `.completed`
+/// there), so both can live in the same timeline without ever double-rendering.
+///
+/// **Not `nonisolated`**: ``resumeRoute(simulationId:name:)`` builds a `Route`
+/// (App-layer, default-MainActor), so the type keeps the default MainActor
+/// isolation of the `Views/` layer — same as ``DegradedRunBadge``.
+enum FailedRunResumeBadge {
+  /// Whether the run should offer a resume affordance.
+  ///
+  /// True only for a `.failed` run whose `currentRound >= 1`: the round-boundary
+  /// checkpoint (`stateJSON` + `currentRound`) is written together by
+  /// `SimulationRepository.updateState`, so `currentRound >= 1` means round 1
+  /// completed and a resumable checkpoint exists. A run that died during round 1
+  /// (before any checkpoint) keeps `currentRound == 0` and is not resumable.
+  /// `.completed` / `.paused` / `.running` / `.cancelled` (and a `nil` status)
+  /// never offer resume here — `.paused` has its own Home resume card
+  /// (``HomePausedCard``).
+  static func isResumable(status: SimulationStatus?, currentRound: Int) -> Bool {
+    status == .failed && currentRound >= 1
+  }
+
+  /// The resume destination for the failed run — the same route the Home
+  /// paused-run card uses (``HomePausedCard/resumeRoute(for:)``). Identity is
+  /// the run's id; `name` rides along as an identity-neutral `RouteHint` for the
+  /// nav title from the first frame (ADR-008), so it never perturbs
+  /// `pushIfOnTop` dedup.
+  static func resumeRoute(simulationId: String, name: String?) -> Route {
+    .resumeSimulation(simulationId: simulationId, initialName: .init(name))
+  }
+
+  /// The 1-based round the resume re-enters. The checkpoint's `currentRound` is
+  /// the just-completed round K (the producer emits `.roundCheckpoint` only
+  /// after `.roundCompleted`), so resume starts at K+1 — matching
+  /// `SimulationViewModel.resume`.
+  static func resumeRoundLabel(currentRound: Int) -> Int {
+    currentRound + 1
+  }
+}

--- a/Pastura/Pastura/Views/Results/ResultDetailView+ResumeBanner.swift
+++ b/Pastura/Pastura/Views/Results/ResultDetailView+ResumeBanner.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+extension ResultDetailView {
+  /// ADR-021 D8 resume banner — shown at the top of the timeline for a
+  /// `.failed` run that still holds a valid round checkpoint, offering a
+  /// one-tap "resume from the next round". Mutually exclusive with the
+  /// ``DegradedRunBadge`` annotation (that gates on `.completed`), so both can
+  /// coexist in ``timelineLog`` without ever rendering together.
+  ///
+  /// Gated by ``FailedRunResumeBadge/isResumable(status:currentRound:)`` **and**
+  /// a successful ``decodeState(from:)`` — defensive: `currentRound >= 1`
+  /// implies a written checkpoint, but a corrupt `stateJSON` must not offer a
+  /// resume that would immediately fail to seed. The push mirrors
+  /// ``HomePausedCard`` (programmatic `router.push` of a helper-built
+  /// `.resumeSimulation` route); the resume machinery is status-agnostic, so a
+  /// `.failed` run resumes through the same path as a `.paused` one.
+  ///
+  /// Visual (moss-tinted card + primary Resume button) is code-review- and
+  /// device-QA-gated per `.claude/rules/view-testing.md` rule 4; the show/hide
+  /// and routing logic is unit-tested via ``FailedRunResumeBadge``.
+  @ViewBuilder
+  var resumeBanner: some View {
+    if let sim = simulation,
+      FailedRunResumeBadge.isResumable(
+        status: sim.simulationStatus, currentRound: sim.currentRound),
+      decodeState(from: sim) != nil {
+      VStack(alignment: .leading, spacing: 10) {
+        Label(
+          String(localized: "This run stopped early"),
+          systemImage: "exclamationmark.arrow.circlepath"
+        )
+        .font(.subheadline.weight(.semibold))
+        .foregroundStyle(Color.ink)
+        HStack {
+          Spacer()
+          Button {
+            router.push(
+              FailedRunResumeBadge.resumeRoute(
+                simulationId: sim.id, name: sim.scenarioNameSnapshot))
+          } label: {
+            Label(
+              String(
+                format: String(localized: "Resume from round %lld"),
+                FailedRunResumeBadge.resumeRoundLabel(currentRound: sim.currentRound)),
+              systemImage: "play.fill")
+          }
+          .buttonStyle(PasturaPrimaryButtonStyle(size: .compact))
+        }
+      }
+      .padding(14)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      // Moss tint ties the banner to its Resume CTA (moss is the resume/paused
+      // branding, cf. HomePausedCard) — muted opacity keeps it a top-of-timeline
+      // annotation, not a focal hero.
+      .background(
+        Color.moss.opacity(0.08),
+        in: RoundedRectangle(cornerRadius: PasturaCardMetrics.cornerRadius, style: .continuous)
+      )
+      .overlay(
+        RoundedRectangle(cornerRadius: PasturaCardMetrics.cornerRadius, style: .continuous)
+          .strokeBorder(Color.mossSoft, lineWidth: 1)
+      )
+      .accessibilityIdentifier("resultDetail.resumeBanner")
+    }
+  }
+}

--- a/Pastura/Pastura/Views/Results/ResultDetailView+ResumeBanner.swift
+++ b/Pastura/Pastura/Views/Results/ResultDetailView+ResumeBanner.swift
@@ -1,29 +1,43 @@
 import SwiftUI
 
 extension ResultDetailView {
+  /// ADR-021 D8 resume-gate probe, resolved once in ``loadData()`` and cached
+  /// into ``isResumable``: a `.failed` run
+  /// (``FailedRunResumeBadge/isResumable(status:currentRound:)``) whose
+  /// checkpoint still decodes. The ``decodeState(from:)`` probe is a single
+  /// main-thread decode here, vs. one per banner `body` pass.
+  /// `FailedRunResumeBadge` is MainActor-isolated, so this stays on the main
+  /// actor (called after the off-main fetch hop).
+  func resolveIsResumable(_ record: SimulationRecord?) -> Bool {
+    guard let record,
+      FailedRunResumeBadge.isResumable(
+        status: record.simulationStatus, currentRound: record.currentRound)
+    else { return false }
+    return decodeState(from: record) != nil
+  }
+
   /// ADR-021 D8 resume banner — shown at the top of the timeline for a
   /// `.failed` run that still holds a valid round checkpoint, offering a
   /// one-tap "resume from the next round". Mutually exclusive with the
   /// ``DegradedRunBadge`` annotation (that gates on `.completed`), so both can
   /// coexist in ``timelineLog`` without ever rendering together.
   ///
-  /// Gated by ``FailedRunResumeBadge/isResumable(status:currentRound:)`` **and**
-  /// a successful ``decodeState(from:)`` — defensive: `currentRound >= 1`
-  /// implies a written checkpoint, but a corrupt `stateJSON` must not offer a
-  /// resume that would immediately fail to seed. The push mirrors
-  /// ``HomePausedCard`` (programmatic `router.push` of a helper-built
-  /// `.resumeSimulation` route); the resume machinery is status-agnostic, so a
-  /// `.failed` run resumes through the same path as a `.paused` one.
+  /// Gated by ``isResumable`` — the cached
+  /// ``FailedRunResumeBadge/isResumable(status:currentRound:)`` **and**
+  /// successful-``decodeState(from:)`` probe, resolved once in ``loadData()``
+  /// (defensive: `currentRound >= 1` implies a written checkpoint, but a corrupt
+  /// `stateJSON` must not offer a resume that would immediately fail to seed).
+  /// The push mirrors ``HomePausedCard`` (programmatic `router.push` of a
+  /// helper-built `.resumeSimulation` route); the resume machinery is
+  /// status-agnostic, so a `.failed` run resumes through the same path as a
+  /// `.paused` one.
   ///
   /// Visual (moss-tinted card + primary Resume button) is code-review- and
   /// device-QA-gated per `.claude/rules/view-testing.md` rule 4; the show/hide
   /// and routing logic is unit-tested via ``FailedRunResumeBadge``.
   @ViewBuilder
   var resumeBanner: some View {
-    if let sim = simulation,
-      FailedRunResumeBadge.isResumable(
-        status: sim.simulationStatus, currentRound: sim.currentRound),
-      decodeState(from: sim) != nil {
+    if let sim = simulation, isResumable {
       VStack(alignment: .leading, spacing: 10) {
         Label(
           String(localized: "This run stopped early"),

--- a/Pastura/Pastura/Views/Results/ResultDetailView+ResumeBanner.swift
+++ b/Pastura/Pastura/Views/Results/ResultDetailView+ResumeBanner.swift
@@ -16,6 +16,29 @@ extension ResultDetailView {
     return decodeState(from: record) != nil
   }
 
+  #if DEBUG
+    /// DEBUG-only QA hook (ADR-021 D8): force the viewed run's status to
+    /// `.failed` so the resume banner surfaces, then re-load so the gate
+    /// re-resolves. Reproducing the real path (circuit breaker) on-device is
+    /// timing-dependent — it needs round 1 to complete, *then* 3 consecutive
+    /// turn skips — so this shortcut sets up the `.failed` + valid-checkpoint
+    /// state directly. Pause a multi-round run first so `currentRound` lands in
+    /// `[1, rounds-1]` and the resume genuinely re-runs from the checkpoint;
+    /// a completed run still shows the banner but resumes into an empty range.
+    /// Never ships — TestFlight/Release exclude `#if DEBUG`.
+    func forceFailedForQA() async {
+      guard var record = simulation else { return }
+      let repo = dependencies.simulationRepository
+      let simId = record.id
+      try? await offMain { try repo.updateStatus(simId, status: .failed) }
+      // Reflect the flip locally so the banner gate re-resolves without a full
+      // reload (a natural `.task` / re-navigation re-fetches the `.failed` row).
+      record.status = SimulationStatus.failed.rawValue
+      simulation = record
+      isResumable = resolveIsResumable(record)
+    }
+  #endif
+
   /// ADR-021 D8 resume banner — shown at the top of the timeline for a
   /// `.failed` run that still holds a valid round checkpoint, offering a
   /// one-tap "resume from the next round". Mutually exclusive with the

--- a/Pastura/Pastura/Views/Results/ResultDetailView.swift
+++ b/Pastura/Pastura/Views/Results/ResultDetailView.swift
@@ -199,6 +199,10 @@ struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
   private var timelineLog: some View {
     ScrollView {
       LazyVStack(alignment: .leading, spacing: ChatBubbleLayout.bubbleSpacing) {
+        // Failed-run resume affordance (ADR-021 D8) — a `.failed` run holding a
+        // valid round checkpoint offers "resume from round N+1". Mutually
+        // exclusive with the DegradedRunBadge below (`.failed` vs `.completed`).
+        resumeBanner
         // Degraded-run annotation (ADR-021 D6) — a muted summary banner when
         // this completed run omitted one or more LLM turns. Gated to
         // completed + count > 0 by `DegradedRunBadge`.
@@ -348,7 +352,9 @@ struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
     }
   }
 
-  private func decodeState(from record: SimulationRecord) -> SimulationState? {
+  // Not `private`: read by the `+ResumeBanner.swift` sibling extension (D8
+  // resume gate), which can't see `private` members (same-file only).
+  func decodeState(from record: SimulationRecord) -> SimulationState? {
     guard let data = record.stateJSON.data(using: .utf8) else { return nil }
     return try? JSONDecoder().decode(SimulationState.self, from: data)
   }

--- a/Pastura/Pastura/Views/Results/ResultDetailView.swift
+++ b/Pastura/Pastura/Views/Results/ResultDetailView.swift
@@ -42,6 +42,11 @@ struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
   /// against) — both degrade to an unbadged timeline.
   @State var contradictionBadgedTurnIDs: Set<String> = []  // not private — see note above
   @State private var isLoading = true
+  /// Cached D8 resume-affordance gate, computed once in ``loadData()`` so the
+  /// banner never re-decodes `stateJSON` on every `body` pass (mirrors the
+  /// view's decode-once-then-cache convention). Read by the `+ResumeBanner`
+  /// sibling extension — not `private`.
+  @State var isResumable = false
   @State var showAllThoughts = true  // not private — see note above
   @State private var exportPayload: ResultMarkdownExporter.ExportedResult?
   @State private var isExporting = false
@@ -319,10 +324,13 @@ struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
       self.agentOrder = fetched.agentOrder
       self.personas = fetched.personas
       self.contradictionBadgedTurnIDs = fetched.contradictionBadgedTurnIDs
+      // ADR-021 D8: resolve the resume gate once at load (see resolveIsResumable).
+      self.isResumable = resolveIsResumable(fetched.simulation)
     } catch {
       self.turns = []
       self.events = []
       self.items = []
+      self.isResumable = false
     }
     self.isLoading = false
   }
@@ -353,7 +361,8 @@ struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
   }
 
   // Not `private`: read by the `+ResumeBanner.swift` sibling extension (D8
-  // resume gate), which can't see `private` members (same-file only).
+  // resume gate — `decodeState` + `resolveIsResumable` live there), which
+  // can't see `private` members (same-file only).
   func decodeState(from record: SimulationRecord) -> SimulationState? {
     guard let data = record.stateJSON.data(using: .utf8) else { return nil }
     return try? JSONDecoder().decode(SimulationState.self, from: data)

--- a/Pastura/Pastura/Views/Results/ResultDetailView.swift
+++ b/Pastura/Pastura/Views/Results/ResultDetailView.swift
@@ -42,10 +42,9 @@ struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
   /// against) — both degrade to an unbadged timeline.
   @State var contradictionBadgedTurnIDs: Set<String> = []  // not private — see note above
   @State private var isLoading = true
-  /// Cached D8 resume-affordance gate, computed once in ``loadData()`` so the
-  /// banner never re-decodes `stateJSON` on every `body` pass (mirrors the
-  /// view's decode-once-then-cache convention). Read by the `+ResumeBanner`
-  /// sibling extension — not `private`.
+  /// Cached D8 resume gate (resolved once in `loadData` via resolveIsResumable)
+  /// so the banner never re-decodes `stateJSON` per `body`. Not `private` —
+  /// the `+ResumeBanner` sibling reads it.
   @State var isResumable = false
   @State var showAllThoughts = true  // not private — see note above
   @State private var exportPayload: ResultMarkdownExporter.ExportedResult?
@@ -135,6 +134,15 @@ struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
                 Label(String(localized: "Export for demo replay"), systemImage: "film")
               }
               .disabled(!canExportYAML)
+              // ADR-021 D8 QA hook — see forceFailedForQA in +ResumeBanner.
+              Button {
+                Task { await forceFailedForQA() }
+              } label: {
+                Label(
+                  String(localized: "Force .failed (D8 resume QA)"),
+                  systemImage: "exclamationmark.octagon")
+              }
+              .disabled(simulation == nil)
             }
           #endif
           Divider()

--- a/Pastura/PasturaTests/Views/FailedRunResumeBadgeTests.swift
+++ b/Pastura/PasturaTests/Views/FailedRunResumeBadgeTests.swift
@@ -1,0 +1,90 @@
+import Testing
+
+@testable import Pastura
+
+// `@MainActor` unconditionally: `resumeRoute` returns the MainActor-isolated
+// `Route`, and the identity assertions call `==` on `Route` / the truth-table
+// calls `==` on `SimulationStatus` — both resolve their conformance from the
+// MainActor context here (swift-isolation Pattern 5). Mirrors DegradedRunBadgeTests.
+@MainActor
+@Suite(.timeLimit(.minutes(1)))
+struct FailedRunResumeBadgeTests {
+
+  // MARK: - isResumable truth table
+
+  @Test func failedWithFirstRoundCompletedIsResumable() {
+    #expect(FailedRunResumeBadge.isResumable(status: .failed, currentRound: 1))
+  }
+
+  @Test func failedWithLaterRoundIsResumable() {
+    #expect(FailedRunResumeBadge.isResumable(status: .failed, currentRound: 5))
+  }
+
+  @Test func failedBeforeFirstCheckpointIsNotResumable() {
+    // Died in round 1 before any `.roundCheckpoint` → currentRound stays 0.
+    #expect(!FailedRunResumeBadge.isResumable(status: .failed, currentRound: 0))
+  }
+
+  @Test func completedRunIsNotResumable() {
+    #expect(!FailedRunResumeBadge.isResumable(status: .completed, currentRound: 5))
+  }
+
+  @Test func pausedRunIsNotResumableHere() {
+    // `.paused` resumes via the Home card, not this failed-run banner.
+    #expect(!FailedRunResumeBadge.isResumable(status: .paused, currentRound: 5))
+  }
+
+  @Test func runningRunIsNotResumable() {
+    #expect(!FailedRunResumeBadge.isResumable(status: .running, currentRound: 5))
+  }
+
+  @Test func cancelledRunIsNotResumable() {
+    #expect(!FailedRunResumeBadge.isResumable(status: .cancelled, currentRound: 5))
+  }
+
+  @Test func nilStatusIsNotResumable() {
+    #expect(!FailedRunResumeBadge.isResumable(status: nil, currentRound: 5))
+  }
+
+  // MARK: - resumeRoute
+
+  @Test func resumeRouteTargetsResumeSimulationWithId() {
+    let route = FailedRunResumeBadge.resumeRoute(simulationId: "run-1", name: "Foo")
+    guard case .resumeSimulation(let id, let hint) = route else {
+      Issue.record("expected .resumeSimulation, got \(route)")
+      return
+    }
+    #expect(id == "run-1")
+    #expect(hint.value == "Foo")
+  }
+
+  @Test func resumeRouteAcceptsNilName() {
+    let route = FailedRunResumeBadge.resumeRoute(simulationId: "run-1", name: nil)
+    guard case .resumeSimulation(let id, let hint) = route else {
+      Issue.record("expected .resumeSimulation, got \(route)")
+      return
+    }
+    #expect(id == "run-1")
+    #expect(hint.value == nil)
+  }
+
+  @Test func resumeRouteIdentityIgnoresName() {
+    // RouteHint is identity-neutral (ADR-008): same id + different name ⇒ ==.
+    let routeFoo = FailedRunResumeBadge.resumeRoute(simulationId: "run-1", name: "Foo")
+    let routeBar = FailedRunResumeBadge.resumeRoute(simulationId: "run-1", name: "Bar")
+    #expect(routeFoo == routeBar)
+  }
+
+  @Test func resumeRouteIdentityDistinguishesSimulationId() {
+    let routeRun1 = FailedRunResumeBadge.resumeRoute(simulationId: "run-1", name: "Foo")
+    let routeRun2 = FailedRunResumeBadge.resumeRoute(simulationId: "run-2", name: "Foo")
+    #expect(routeRun1 != routeRun2)
+  }
+
+  // MARK: - resumeRoundLabel
+
+  @Test func resumeRoundLabelIsNextRound() {
+    #expect(FailedRunResumeBadge.resumeRoundLabel(currentRound: 3) == 4)
+    #expect(FailedRunResumeBadge.resumeRoundLabel(currentRound: 1) == 2)
+  }
+}


### PR DESCRIPTION
## Summary

Final PR of the #992 graceful-degradation series (ADR-021). PR1 (#1007) / PR2 (#1014) / PR3 (#1028) shipped the containment core; this adds **D8 — the resume proposal for `.failed` runs holding a valid checkpoint**.

**Re-scope decision (ADR-021 D8 mandates one at PR4 planning):** implement now, not spin-off. The machinery is fully reusable and the circuit breaker deliberately produces the `.failed` + checkpoint state D8 rescues, so it is not "rarely reachable" — and field data can't say otherwise pre-launch.

**Why it's a small, App/UX-only change:**
- A `.failed` run **already persists a valid round checkpoint** — `persistCheckpoint` writes `stateJSON` + `currentRound` at every round boundary, and the `.failed` status write only touches the status column.
- The resume path (`SimulationView(source: .resume(runId:))` → `SimulationViewModel.resume`) is **status-agnostic** — it seeds from `stateJSON`/`currentRound`, not from `.paused`. The fresh VM starts `errorMessage == nil`, loadModel success flips the row `.failed` → `.running`, and the terminal ladder handles the end. The circuit-breaker counter resets on resume (ADR-021 D4).

So D8 is purely a discovery/affordance addition. No Engine, Data-migration, or Models change.

### What changed
- **`FailedRunResumeBadge`** (new) — pure static helpers `isResumable(status:currentRound:)` (`.failed && currentRound >= 1`), `resumeRoute(simulationId:name:)` (mirrors `HomePausedCard`), `resumeRoundLabel`. Default-MainActor (not `nonisolated` — `resumeRoute` builds a `Route`).
- **ResultDetailView** — a "This run stopped early / Resume from round N+1" banner at the top of the timeline for a resumable `.failed` run (mutually exclusive with the D6 degraded badge). Gate resolved once at load (`isResumable` @State, `resolveIsResumable` helper) so the banner never re-decodes `stateJSON` per body pass. Push mirrors `HomePausedCard` (`router.push` of the helper-built `.resumeSimulation` route).
- **DEBUG QA hook** — a `#if DEBUG`-only "Force .failed (D8 resume QA)" action in the Result Detail Developer menu (see Device QA below). Excluded from TestFlight/Release.
- **i18n** — two new keys (`This run stopped early`, `Resume from round %lld`, Form B), ja translated.

### Known behaviour (accepted, not a bug)
- **Stale banner:** ResultDetailView loads once via `.task`; after a successful resume + back-nav the run is `.completed` but the banner may linger until a fresh navigation. Display-only — the DB is correct.
- Resume uses the run's `scenarioYamlSnapshot` (via `ScenarioSnapshotResolver`), so a deleted live scenario still resumes.

## Test plan
- `FailedRunResumeBadgeTests` (13 tests): isResumable truth table across all 5 statuses × round boundaries, resumeRoute identity (RouteHint neutrality), resumeRoundLabel.
- Full unit suite green (2900 tests / 234 suites); SwiftLint `--strict` clean; localization-coverage green; nav-map `--check` clean (the helper-indirected push is unmapped, consistent with `HomePausedCard`'s resume edge).
- Pre-impl critic (Opus): 0 Critical / 3 Warnings — all folded in. code-reviewer (Opus): PASS (0 crit / 0 warn); its 1 suggestion (cache the gate at load) is applied.

## Device QA

Reproducing the circuit-breaker `.failed` path on-device is timing-dependent (round 1 must complete, then 3 consecutive turn skips), so this PR ships a **DEBUG-only QA hook** to set up the state reliably:

1. **Failed-run resume end-to-end (real device):** run a **multi-round** scenario and **pause it mid-run** (so `currentRound` ∈ [1, rounds-1] and a real checkpoint exists). Open Result Detail → **⋯ menu → Developer → "Force .failed (D8 resume QA)"**. Confirm the banner appears, tap **Resume from round N+1**, and confirm the run resumes from the checkpoint and runs to completion (real LLM reload from checkpoint — not exercisable in the simulator). (A *completed* run also shows the banner via the hook, but resumes into an empty round range — use a paused run for the real re-run.)
2. **ja-locale:** verify "この実行は途中で停止しました" and "ラウンド N から再開" render on a ja device.
3. **Banner visual (iOS 26):** confirm the moss-tinted card + `PasturaPrimaryButtonStyle` Resume button render correctly on a real device (view-testing rule 4 / Liquid Glass capsule caveats).

Closes #992