### PR TITLE
📝 docs: re-anchor LiteRT-LM iOS gate off LiteRT #6745

### DIFF
--- a/docs/decisions/ADR-002.md
+++ b/docs/decisions/ADR-002.md
@@ -321,9 +321,14 @@ whether the eventual LiteRT-LM migration is **iOS-first** or
 **synchronised across platforms** — was resolved on **#496 Open Question
 #1 (2026-07-10)** as **conditional iOS-first**:
 
-- Readiness gate: `LiteRT #6745 closed AND (constrained decoding reachable
+- Readiness gate (re-anchored off LiteRT #6745 on 2026-07-10 — see §8.2):
+  `the adopted official LiteRT-LM release provides working third-party iOS
+  GPU inference via its SwiftPM xcframework (statically-linked Metal; not
+  the #6745 litert_prebuilts channel) AND (constrained decoding reachable
   from the Swift surface OR prompt-only harness readout acceptable vs the
-  llama.cpp + GBNF baseline)`.
+  llama.cpp + GBNF baseline)`. The first conjunct is **presumed-met** on
+  third-party evidence; the live gate is the second conjunct (#969). Full
+  grading in **ADR-004 §3.6**.
 - If the gate opens before the KMP Engine port (ADR-023) starts, iOS
   migrates standalone via the §8 drop-in (`LlamaCppService` kept as a
   feature-flag fallback ≥1 TestFlight cycle); if it opens mid-port, the
@@ -344,12 +349,18 @@ SwiftPM (`github.com/google-ai-edge/LiteRT-LM`, minimum `0.12.0`) with
 **Metal GPU acceleration** on iOS (`EngineConfig(backend: .gpu)`). This
 ADR records the trigger on **2026-06-11**, verified against the
 [Swift API documentation](https://developers.google.com/edge/litert-lm/swift)
-(last updated 2026-06-01) and the v0.12.0 release notes. Two later
-releases already exist — v0.13.0 (2026-06-02) added macOS support to the
-same Swift package, and v0.13.1 (2026-06-03) is the latest — but v0.12.0
-is the first version meeting the trigger, so it is cited as the trigger
-version. The macOS addition is relevant to the ADR-004 cross-platform
-story, not to the iOS trigger.
+(last updated 2026-06-01) and the v0.12.0 release notes. Later releases
+followed — v0.13.0 (2026-06-02) added macOS support to the same Swift
+package, v0.13.1 (2026-06-03), and v0.14.0 (2026-07-08) is the latest —
+but v0.12.0 is the first version meeting the trigger, so it is cited as
+the trigger version. The macOS addition is relevant to the ADR-004
+cross-platform story, not to the iOS trigger. One distinction to keep
+sharp, surfaced by **LiteRT-LM #2689** (closed resolved 2026-07-09):
+v0.12.0 shipped the Swift *API surface* + Metal GPU, but third-party
+*on-device* iOS GPU was only community-verified later (on the v0.13.1
+xcframework, statically-linked Metal) — the interim "iOS GPU blocked"
+reports were mis-attributed (wrong dylib channel / Git LFS), not runtime
+defects. See ADR-004 §3.6 Update 2026-07-10b.
 
 This does **not** by itself change the Accepted decision: llama.cpp
 remains the active production backend until the migration evaluation
@@ -372,12 +383,16 @@ Reframing of the §8 monitoring pointers:
   **resolved as conditional iOS-first** (ADR-004 §3.6, now Accepted; #496
   Open Question #1, 2026-07-10). The remaining #496 work is the PoC spike
   itself — real-device benchmark, deployment-target check, `.litertlm`
-  model path, streaming / constraint parity — gated on LiteRT #6745.
+  model path, streaming / constraint parity — whose live gate is now the
+  second conjunct (constrained-decoding exposure / prompt-only, #969), the
+  first conjunct being presumed-met on third-party evidence. LiteRT #6745
+  no longer gates this (wrong channel — ADR-004 §3.6 Update 2026-07-10b).
 
 ### Monitoring
 
 Track these for migration readiness:
-- [LiteRT-LM releases](https://github.com/google-ai-edge/LiteRT-LM/releases) — ✅ Swift SDK + iOS GPU shipped (v0.12.0, 2026-05-18); evaluation tracked in #496 (see §8.2)
+- [LiteRT-LM releases](https://github.com/google-ai-edge/LiteRT-LM/releases) — Swift API surface + Metal shipped v0.12.0 (2026-05-18); third-party on-device iOS GPU community-verified on v0.13.1 (see #2689 below); latest v0.14.0 (2026-07-08); evaluation tracked in #496 (see §8.2)
+- [LiteRT-LM Issue #2689](https://github.com/google-ai-edge/LiteRT-LM/issues/2689) — iOS GPU for third-party apps; **closed resolved 2026-07-09** (author-self-closed, no maintainer confirmation → graded *presumed-met*). Retires LiteRT #6745 as the iOS gate anchor (wrong channel); #6745/#1050 stay live only for the Android/KMP path
 - [LiteRT-LM Issue #1050](https://github.com/google-ai-edge/LiteRT-LM/issues/1050) — source-build GPU plugins (cross-platform / KMP only; does not block the iOS official SwiftPM path — see §8.2)
 - [Gallery Issue #420](https://github.com/google-ai-edge/gallery/issues/420) — iOS source code
 

--- a/docs/decisions/ADR-004.md
+++ b/docs/decisions/ADR-004.md
@@ -100,10 +100,12 @@ commonMain (Kotlin)     Engine / Models / LLMService interface
   platform during Phase 3.0** (see §3.6 for rationale). iOS keeps the
   Swift `LlamaCppService`; Android and Desktop use a llama.cpp KMP
   binding (specific binding TBD — Llamatik is one candidate). Migration
-  to LiteRT-LM is deferred until Google's LiteRT-LM Swift SDK ships with
-  iOS GPU support; the eventual migration sequencing is resolved as
-  **conditional iOS-first** (§3.6 *iOS-migration sequencing* note; ADR-002
-  §8 / §8.1), not a synchronised all-platform swap.
+  to LiteRT-LM is deferred pending the §3.6 readiness gate — the Swift SDK
+  with iOS GPU shipped (v0.12.0, 2026-05-18) and the on-device-GPU first
+  conjunct is now presumed-met, so the live gate is constrained-decoding
+  exposure (#969); see ADR-002 §8.2. The eventual migration sequencing is
+  resolved as **conditional iOS-first** (§3.6 *iOS-migration sequencing*
+  note; ADR-002 §8 / §8.1), not a synchronised all-platform swap.
 
 ### Option B — KMP + Compose Multiplatform (UI unified across iOS/Android/Desktop)
 
@@ -312,9 +314,28 @@ relative to the KMP Engine port (ADR-023).
 Trigger = the #496 / #969 readiness gate (the same gate ADR-023 §8 records
 in short form):
 
-> `Ready = LiteRT #6745 closed AND (constrained decoding reachable from the
-> Swift surface OR prompt-only harness readout acceptable vs the
-> llama.cpp + GBNF baseline)`
+> `Ready = the adopted official LiteRT-LM release provides working
+> third-party iOS GPU inference via its SwiftPM xcframework (Metal
+> accelerator statically linked; not the #6745 litert_prebuilts channel)
+> AND (constrained decoding reachable from the Swift surface OR
+> prompt-only harness readout acceptable vs the llama.cpp + GBNF baseline)`
+
+**First-conjunct status — presumed-met (2026-07-10; see Update
+2026-07-10b).** The iOS-GPU conjunct is *presumed* satisfied on
+third-party evidence (LiteRT-LM #2689, author-self-closed, no maintainer
+confirmation), not confirmed by a Pastura on-device run — so the live
+gate is now the **second** conjunct: constrained-decoding exposure (#969)
+or prompt-only acceptability. First-party confirmation is owed as **#496
+PoC step 0** (smoke test on a minRAM-floor device with an E2B-class model,
+plus an `otool -L`/`nm` + `Package.swift` link-topology check on the
+adopted xcframework confirming no dynamic dependency on the #6745
+prebuilts channel). Any future "gate open" declaration must cite the dated
+harness readout (which run, which metrics, vs which baseline). **LiteRT
+#6745** (`litert_prebuilts.zip` mispackaged dylib) is **not** the iOS
+anchor and **not** an iOS blocker — Pastura consumes the LiteRT-LM SwiftPM
+xcframework, which statically links Metal and does not use that prebuilts
+channel; #6745/#1050 remain live markers only for the Phase-3.1
+Android/KMP path, where the Kotlin artifact's link topology is unverified.
 
 Decision rule, by when the gate opens:
 
@@ -351,9 +372,11 @@ re-validation of the K/N boundary after a later swap).
 
 **What would flip this back to synchronised:** evidence the two gates open
 close together — a maintainer response on LiteRT-LM #1662, or a release
-exposing constraints in the Kotlin / C API in the same quarter #6745
-closes, *plus* a committed Android beta date within ~one quarter of the KMP
-port landing. No evidence supports that conjunction today.
+exposing constraints in the Kotlin / C API in the same quarter the iOS
+second conjunct resolves (Swift-surface constraint exposure or an accepted
+prompt-only readout, #969), *plus* a committed Android beta date within
+~one quarter of the KMP port landing. No evidence supports that
+conjunction today.
 
 §3.4's conclusion is unchanged: Option A still aligns strictly with
 ADR-002's migration plan. The revision is a narrowing of "which
@@ -379,6 +402,34 @@ closed as **conditional iOS-first** (the 4-branch rule in the
 *iOS-migration sequencing* note above). This supersedes the 2026-06-11
 "resolve at the Phase 2 → Phase 3 transition" pointer and the earlier
 "synchronised migration" default this section leaned toward.
+
+**Update (2026-07-10b) — gate re-anchored off LiteRT #6745:** the
+readiness gate's first conjunct previously read "LiteRT #6745 closed".
+New upstream evidence retired that anchor. **LiteRT-LM #2689** ("iOS GPU
+acceleration fully blocked for third-party apps") was closed **resolved
+2026-07-09**: third-party developers reported on-device iOS GPU working
+via the LiteRT-LM v0.13.1 `CLiteRTLM.xcframework` (Metal accelerator
+statically linked, full graph delegation, ~24 tok/s on iPhone 17 Pro).
+The decisive point in the closing thread: the mispackaged-dylib crash
+belongs to the `litert_prebuilts.zip` channel = LiteRT #6745, which
+LiteRT-LM SwiftPM releases do **not** consume (they statically link
+Metal). Two earlier "blocked" reports were later diagnosed as user-side
+mis-attribution — Git LFS not initialised (a 130-byte pointer loaded
+instead of the binary) and a self-converted model needing
+`experimental_lightweight_conversion` disabled — not runtime defects. So
+#6745 was **neither necessary nor sufficient** for Pastura's path and is
+dropped from the gate (retained above only as an iOS non-blocker note /
+live Android-side marker). **Grading is deliberately "presumed-met", not
+"met"** (`.claude/rules/adr-writing.md` §1): #2689 was author-self-closed
+with no Google-maintainer confirmation, and the on-device report is
+Gemma-4-E4B on iPhone 17 Pro — not Pastura's E2B class on the 6.5 GB
+`ModelRegistry.minRAM` floor. First-party confirmation is the #496 PoC
+step 0 (above). The honest posture: **the live blocker is now
+constrained-decoding exposure (#969 / upstream LiteRT-LM #1662), not iOS
+GPU availability.** The first conjunct is stated as a version-agnostic
+release *property* (adr-writing §2), with v0.13.1/#2689 cited as the
+evidence basis and re-verification owed against the actually-adopted
+release (currently v0.14.0, 2026-07-08).
 
 ---
 

--- a/docs/decisions/ADR-023.md
+++ b/docs/decisions/ADR-023.md
@@ -329,8 +329,12 @@ llama.cpp-unified), but two design facts couple their futures:
   upstream Kotlin FR: LiteRT-LM #1662, watched — not filed by us, per operator decision).
   Whatever exposure path #496 eventually lands (tool-call vehicle / upstream / two-layer
   patch / prompt-only) should be evaluated for Android reuse, since Phase 3.1's Android
-  backend hits the identical gap. Migration readiness stays as reframed on #496:
-  `#6745 AND (constraint-exposed OR prompt-only-acceptable)`.
+  backend hits the identical gap. iOS migration readiness (re-anchored off LiteRT
+  #6745 on 2026-07-10 — ADR-004 §3.6): `official-LiteRT-LM-release iOS GPU works
+  via the SwiftPM xcframework (presumed-met, LiteRT-LM #2689) AND (constraint-exposed
+  OR prompt-only-acceptable)` — the live conjunct is the second one (#969). LiteRT
+  #6745/#1050 stay live markers for *this* Android/KMP path, where the Kotlin
+  artifact's GPU link topology is unverified.
 
 ## 9. Rationale
 


### PR DESCRIPTION
## Summary
Re-anchors the LiteRT-LM iOS-migration readiness gate's first conjunct **off LiteRT #6745** across ADR-002 §8, ADR-004 §3.6, and ADR-023 §8.

**Why:** upstream evidence retired #6745 as the right proxy. **LiteRT-LM #2689** ("iOS GPU fully blocked for third-party apps") was closed **resolved 2026-07-09** — third-party devs verified on-device iOS GPU working via the LiteRT-LM v0.13.1 `CLiteRTLM.xcframework` (Metal statically linked, ~24 tok/s iPhone 17 Pro). The decisive point: the mispackaged-dylib crash belongs to the `litert_prebuilts.zip` channel = **#6745**, which LiteRT-LM SwiftPM releases do **not** consume (they statically link Metal). Two earlier "blocked" reports were mis-attributions (Git LFS pointer / `experimental_lightweight_conversion`), not runtime defects. So #6745 is neither necessary nor sufficient for Pastura's path.

## What changed
- **New first conjunct** (version-agnostic release *property*, not a v0.13.1 sighting): `the adopted official LiteRT-LM release provides working third-party iOS GPU inference via its SwiftPM xcframework (statically-linked Metal; not the #6745 litert_prebuilts channel)`.
- **Graded `presumed-met`, not `met`** (adr-writing §1): #2689 was author-self-closed with no Google-maintainer confirmation; the report is E4B on iPhone 17 Pro, not Pastura's E2B / 6.5 GB `minRAM` floor. First-party confirmation owed as **#496 PoC step 0** (minRAM-floor smoke test + `otool -L`/`nm` + `Package.swift` link-topology check).
- **Posture flip stated plainly** in all three ADRs: the live blocker is now **constrained-decoding exposure (#969)**, not iOS GPU availability.
- **iOS-only scope**: #6745/#1050 stay live markers for the Phase-3.1 Android/KMP path (Kotlin artifact link topology unverified).
- **Staleness reconciliation** (adr-writing §3): "iOS GPU shipped ✅ v0.12.0" split into "API surface v0.12.0 / on-device verified v0.13.1"; "v0.13.1 is the latest" → v0.14.0 (2026-07-08); ADR-004 flip-back condition re-keyed off "#6745 closes" → "the iOS second conjunct resolves (#969)".

## Process
Informed by a plan `critic` pass + a **Fable second-opinion consult** (chose Option C — version-agnostic property + presumed-met grading + iOS-only scope over the two candidate framings). Reviewed by `code-reviewer` (Opus): **PASS, 0 issues**, all upstream facts verified.

## Test plan
Docs-only. `git diff main...HEAD` reviewed; all date/issue/version claims verified via `gh` (#2689 closed 2026-07-09; #6745 open; v0.14.0 latest).

## Follow-up (out of scope here)
- ADR-002 §8.2 evaluation checklist still says "iOS 17.0 floor" — stale per ADR-019 (raised to iOS 18). Flagged by code review; left for a separate sweep.

## Device QA
実機QA不要 — documentation-only change; no runtime surface.

Relates to #496 (closed).