### PR TITLE
📝 docs: breadcrumb from PhaseType enum to engine.md checklist

### DIFF
--- a/Pastura/Pastura/Models/PhaseType.swift
+++ b/Pastura/Pastura/Models/PhaseType.swift
@@ -9,6 +9,10 @@ import Foundation
 /// control-flow phase: the handler itself does no inference, but its
 /// sub-phases may be of any type.
 nonisolated public enum PhaseType: String, Codable, Sendable, CaseIterable {
+  // Adding a new phase type? Follow the full checklist in
+  // .claude/rules/engine.md § "Adding a new `PhaseType`" — this enum is the
+  // first edit (new case + `requiresLLM`), but that rule is path-scoped to
+  // Engine/**·LLM/** and won't auto-load here.
   case speakAll = "speak_all"
   case speakEach = "speak_each"
   case vote


### PR DESCRIPTION
Closes #1030

## Summary

`.claude/rules/engine.md` gained an "Adding a new `PhaseType`" checklist in #1029, but that rule is **path-scoped to `Engine/**`·`LLM/**`**, so it does not auto-load when editing `Models/PhaseType.swift` — the *canonical first edit* when adding a phase (new `case` + `requiresLLM`). This adds a one-line breadcrumb at that first-edit point so the checklist surfaces where it's needed.

Implemented via **option 2** from the issue (enum-adjacent comment in `Models/PhaseType.swift`), rather than option 1 (a pointer in `.claude/rules/models-and-data.md`). Rationale below.

## Acceptance criteria correspondence

| Criterion | How the diff satisfies it | Verification |
|---|---|---|
| Editing `Models/PhaseType.swift` (or its path-scoped rule) surfaces a pointer to the engine.md checklist | 4-line breadcrumb placed as the first line inside `enum PhaseType`, directly above `case speakAll` — the exact locus where a new `case` is added | Visible in the diff; code-reviewer confirmed placement at the first-edit point |
| No duplication of the checklist content — pointer only | Comment names the checklist location + the two touch-points (`new case`, `requiresLLM`) as motivation; reproduces **no** checklist steps | code-reviewer confirmed pointer-only |

## Judgment calls

- **Chose option 2 (source comment) over option 1 (`models-and-data.md` edit).** The issue delegates the choice to author judgment. Option 2 keeps the edit off the `.claude/**` tooling surface — a plain Models-layer comment — which is the more conservative, unattended-safe choice. It also co-locates the breadcrumb with the literal first line an author edits, so the pointer fires without depending on which rule files happen to be loaded.
- **Cross-reference integrity checked:** the referenced heading `### Adding a new \`PhaseType\`` exists at `.claude/rules/engine.md:96` (not a dead link) — grep-confirmed by the code-reviewer.
- The comment follows the "Why comments" convention (explains *why* the pointer lives here — the path-scoping gap — not just what).

## Tests

- `scripts/xcodebuild.sh build` — **BUILD SUCCEEDED** (comment-only change; no test-behavior surface, so no new tests. The pre-commit hook re-ran swiftlint --strict + build on commit, both green.)
- Mandatory code-reviewer pass: **PASS** (0 issues — both ACs met, cross-reference live, no convention violations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
