### PR TITLE
✨ feat: per-phase max_sentences brevity override (#881 Stage 1)

### DIFF
--- a/Pastura/Pastura/App/EditablePhase.swift
+++ b/Pastura/Pastura/App/EditablePhase.swift
@@ -33,6 +33,10 @@ struct EditablePhase: Identifiable, Sendable {
   // preserves them instead of dropping them on re-serialization.
   var voteAgainst: Int?
   var actionDeltas: [String: Int]
+  // Per-phase statement brevity override (#881). YAML-only for v1 (no editing
+  // UI in `PhaseEditorSheet`), but modelled here so a visual→YAML round-trip
+  // preserves it instead of dropping it on re-serialization.
+  var maxSentences: Int?
 
   // swiftlint:disable:next function_default_parameter_at_end
   init(
@@ -53,7 +57,8 @@ struct EditablePhase: Identifiable, Sendable {
     probability: Double? = nil,
     eventVariable: String = "",
     voteAgainst: Int? = nil,
-    actionDeltas: [String: Int] = [:]
+    actionDeltas: [String: Int] = [:],
+    maxSentences: Int? = nil
   ) {
     self.type = type
     self.prompt = prompt
@@ -73,6 +78,7 @@ struct EditablePhase: Identifiable, Sendable {
     self.eventVariable = eventVariable
     self.voteAgainst = voteAgainst
     self.actionDeltas = actionDeltas
+    self.maxSentences = maxSentences
   }
 
   init(from phase: Phase) {
@@ -94,6 +100,7 @@ struct EditablePhase: Identifiable, Sendable {
     self.eventVariable = phase.eventVariable ?? ""
     self.voteAgainst = phase.voteAgainst
     self.actionDeltas = phase.actionDeltas ?? [:]
+    self.maxSentences = phase.maxSentences
   }
 
   /// Identifies which branch of a conditional phase to target.
@@ -191,7 +198,8 @@ struct EditablePhase: Identifiable, Sendable {
       probability: probability,
       eventVariable: eventVariable.isEmpty ? nil : eventVariable,
       voteAgainst: voteAgainst,
-      actionDeltas: actionDeltas.isEmpty ? nil : actionDeltas
+      actionDeltas: actionDeltas.isEmpty ? nil : actionDeltas,
+      maxSentences: maxSentences
     )
   }
 }

--- a/Pastura/Pastura/Engine/PromptBuilder.swift
+++ b/Pastura/Pastura/Engine/PromptBuilder.swift
@@ -207,6 +207,10 @@ nonisolated struct PromptBuilder: Sendable {
     return sections.joined(separator: "\n\n")
   }
 
+  /// The global default statement brevity cap (sentences) applied when a
+  /// phase declares no `max_sentences` override (#881, #877).
+  static let defaultStatementMaxSentences = 3
+
   /// Builds the `## 回答ルール / ## Response Rules` block + phase-specific
   /// constraints (choose options, vote candidate list). Extracted from
   /// `buildSystemPrompt` so the Translation Table per-site dispatch fits
@@ -220,6 +224,13 @@ nonisolated struct PromptBuilder: Sendable {
   /// The brevity rule (#877) is a soft cap on the primary statement field
   /// only — inner_thought is intentionally unconstrained. Wording is
   /// harness-A/B-tuned; keep ja/en scope-parallel when editing.
+  ///
+  /// The sentence count is per-phase overridable via `phase.maxSentences`
+  /// (#881), defaulting to ``defaultStatementMaxSentences``. The override
+  /// **replaces** the number in the single brevity bullet (never appends a
+  /// second, contradictory cap); an absent override renders byte-identical to
+  /// the shipped #877 wording. Empirically a ja lever — see
+  /// ``Phase/maxSentences``.
   private func buildAnswerRules(
     scenario: Scenario,
     persona: Persona,
@@ -227,13 +238,19 @@ nonisolated struct PromptBuilder: Sendable {
     state: SimulationState
   ) -> String {
     let language = scenario.engineLanguage
+    // Per-phase statement brevity cap (#881): phase override, else the global
+    // default. The number is interpolated into the single brevity bullet
+    // (REPLACE) so the default (3) renders byte-identical to the #877 wording
+    // and no second, contradictory cap is ever appended.
+    let maxSentences = phase.maxSentences ?? Self.defaultStatementMaxSentences
+    let sentenceNoun = maxSentences == 1 ? "sentence" : "sentences"
     var rules = pickLanguage(
       language,
       ja: """
         ## 回答ルール（厳守）
         - 必ず日本語で回答すること
         - 全フィールドに必ず文章を書くこと（空欄「...」は禁止）
-        - 発言（statement などの本文フィールド）は3文以内で簡潔に書くこと（長い独白は禁止）
+        - 発言（statement などの本文フィールド）は\(maxSentences)文以内で簡潔に書くこと（長い独白は禁止）
         - JSONは必ず1行で書くこと（改行を入れない）
         - JSON以外のテキストやコードブロック(```)は書かないこと
         - JSONに構文エラーがあると失敗扱いになる（カッコ・引用符・カンマを正しく閉じること）
@@ -243,7 +260,7 @@ nonisolated struct PromptBuilder: Sendable {
         ## Response Rules (strict)
         - Respond in English only.
         - Every field must contain a sentence (no empty "..." values).
-        - Keep your statement (the main text field) concise: at most 3 sentences, no long monologues.
+        - Keep your statement (the main text field) concise: at most \(maxSentences) \(sentenceNoun), no long monologues.
         - The JSON output must be a single line (no newlines).
         - Do not include any text or code fences (```) outside the JSON.
         - JSON syntax errors are treated as failure: close every bracket, quote, and comma correctly.

--- a/Pastura/Pastura/Engine/ScenarioLoader.swift
+++ b/Pastura/Pastura/Engine/ScenarioLoader.swift
@@ -345,6 +345,10 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
     let voteAgainst: Int? = try parseOptional(dict, key: "vote_against", label: label)
     let actionDeltas = try parseActionDeltas(dict, label: label)
 
+    // Per-phase statement brevity override (#881). Range 1…6 enforced by
+    // `ScenarioValidator`, not here — `load` stays non-validating (#665).
+    let maxSentences: Int? = try parseOptional(dict, key: "max_sentences", label: label)
+
     return Phase(
       type: phaseType,
       prompt: prompt,
@@ -363,7 +367,8 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
       probability: probability,
       eventVariable: eventVariable,
       voteAgainst: voteAgainst,
-      actionDeltas: actionDeltas
+      actionDeltas: actionDeltas,
+      maxSentences: maxSentences
     )
   }
 

--- a/Pastura/Pastura/Engine/ScenarioSerializer.swift
+++ b/Pastura/Pastura/Engine/ScenarioSerializer.swift
@@ -71,9 +71,9 @@ nonisolated struct ScenarioSerializer: Sendable {
 
   // MARK: - Phase Serialization
 
-  // Each optional field adds one branch — unavoidable for 13 Phase fields
-  // (added probability + as for event_inject in #256). The body length
-  // grows linearly with field count too.
+  // Each optional field adds one branch — unavoidable as the Phase field set
+  // grows (probability + as #256, vote_against + action_deltas #910,
+  // max_sentences #881). The body length grows linearly with field count too.
   // swiftlint:disable:next cyclomatic_complexity function_body_length
   private func serializePhase(_ phase: Phase) -> [String] {
     var lines: [String] = []

--- a/Pastura/Pastura/Engine/ScenarioSerializer.swift
+++ b/Pastura/Pastura/Engine/ScenarioSerializer.swift
@@ -128,6 +128,11 @@ nonisolated struct ScenarioSerializer: Sendable {
       lines.append("    rounds: \(subRounds)")
     }
 
+    // Per-phase statement brevity override (#881).
+    if let maxSentences = phase.maxSentences {
+      lines.append("    max_sentences: \(maxSentences)")
+    }
+
     // Conditional-specific fields — emitted at the end of the phase block
     // with 4-space indentation for nested sub-phase bodies.
     if let condition = phase.condition {

--- a/Pastura/Pastura/Engine/ScenarioValidator.swift
+++ b/Pastura/Pastura/Engine/ScenarioValidator.swift
@@ -108,6 +108,7 @@ nonisolated public struct ScenarioValidator: Sendable {
   private func validatePhases(_ scenario: Scenario) throws {
     for (index, phase) in scenario.phases.enumerated() {
       try validateOutputFieldNames(in: phase, label: "Phase \(index + 1)")
+      try validateMaxSentences(in: phase, label: "Phase \(index + 1)")
       switch phase.type {
       case .assign:
         try validateAssignPhaseShape(
@@ -126,6 +127,19 @@ nonisolated public struct ScenarioValidator: Sendable {
         try validateEventInjectShape(
           phase, label: "Phase \(index + 1) (event_inject)", scenario: scenario)
       }
+    }
+  }
+
+  /// Enforces the accepted range (1…6) for a phase's `max_sentences` override
+  /// (#881). Called at both traversal sites (`validatePhases` and
+  /// `validateBranch`) so a nested `then:` / `else:` sub-phase is checked too.
+  /// A `nil` override (the common case) is a no-op. The upper bound doubles as
+  /// a latency / JSON-stability guard — the model tops out ~3–4 sentences even
+  /// at cap 6 (#881 Stage-0 spike), so higher values are meaningless.
+  private func validateMaxSentences(in phase: Phase, label: String) throws {
+    guard let value = phase.maxSentences else { return }
+    guard (1...6).contains(value) else {
+      throw validationError(.maxSentencesOutOfRange(label: label, value: value))
     }
   }
 
@@ -196,6 +210,7 @@ nonisolated public struct ScenarioValidator: Sendable {
     for (subIndex, subPhase) in phases.enumerated() {
       let subLabel = "\(parentLabel) \(branchLabel)[\(subIndex + 1)]"
       try validateOutputFieldNames(in: subPhase, label: subLabel)
+      try validateMaxSentences(in: subPhase, label: subLabel)
       if subPhase.type == .conditional {
         throw validationError(.branchNestedConditional(label: subLabel))
       }

--- a/Pastura/Pastura/Models/Phase.swift
+++ b/Pastura/Pastura/Models/Phase.swift
@@ -96,6 +96,24 @@ nonisolated public struct Phase: Codable, Sendable, Equatable {
   /// `Pairing.action1/action2` (#910).
   public let actionDeltas: [String: Int]?
 
+  /// Per-phase soft cap on the number of sentences in an agent's primary
+  /// `statement` output (the YAML `max_sentences:` key), overriding the
+  /// global default of 3 sentences for this phase only.
+  ///
+  /// `nil` means the phase uses the global default. `ScenarioValidator`
+  /// enforces the accepted range 1…6. Applied by `PromptBuilder` as a
+  /// **prompt-side** brevity rule on the statement field only — it does not
+  /// constrain `inner_thought`, and code phases (which emit no statement)
+  /// simply never surface the rule.
+  ///
+  /// Empirically a **ja lever**: a Stage-0 harness A/B (#881) found ja
+  /// statement length responds bidirectionally to the cap (cap 1/3/6 →
+  /// ~1.0/1.4/1.9 sentences) while en is near-inert (the model already
+  /// writes a single sentence). Complements phase-`prompt` content
+  /// scaffolding — the cap lifts the ceiling so a scaffolded finale is not
+  /// clipped by the global 3-sentence rule.
+  public let maxSentences: Int?
+
   public init(
     type: PhaseType,
     prompt: String? = nil,
@@ -114,7 +132,8 @@ nonisolated public struct Phase: Codable, Sendable, Equatable {
     probability: Double? = nil,
     eventVariable: String? = nil,
     voteAgainst: Int? = nil,
-    actionDeltas: [String: Int]? = nil
+    actionDeltas: [String: Int]? = nil,
+    maxSentences: Int? = nil
   ) {
     self.type = type
     self.prompt = prompt
@@ -134,6 +153,7 @@ nonisolated public struct Phase: Codable, Sendable, Equatable {
     self.eventVariable = eventVariable
     self.voteAgainst = voteAgainst
     self.actionDeltas = actionDeltas
+    self.maxSentences = maxSentences
   }
 
   /// The schema's required keys as a `Set`, or an empty set when the

--- a/Pastura/Pastura/Models/ScenarioValidationMessage.swift
+++ b/Pastura/Pastura/Models/ScenarioValidationMessage.swift
@@ -84,6 +84,9 @@ nonisolated public enum ScenarioValidationMessage: Sendable {
 
   // MARK: Output field-name validation (+OutputFieldNames)
   case outputFieldNameInvalid(label: String, name: String)
+
+  // MARK: Per-phase statement brevity override (#881)
+  case maxSentencesOutOfRange(label: String, value: Int)
 }
 
 // `nonisolated` on the extension is load-bearing: the enum is a `nonisolated`
@@ -333,6 +336,10 @@ nonisolated extension ScenarioValidationMessage {
             "%@: output field name '%@' must be an ASCII identifier (letters, digits, and underscore, not starting with a digit or underscore). Agent text values may be any language."
         ),
         label, name)
+    case .maxSentencesOutOfRange(let label, let value):
+      return String(
+        format: String(localized: "%@: max_sentences (%lld) must be between 1 and 6"),
+        label, value)
     }
   }
 }

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -761,6 +761,22 @@
         }
       }
     },
+    "%@: max_sentences (%lld) must be between 1 and 6" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: max_sentences (%2$lld) must be between 1 and 6"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: max_sentences (%2$lld) は 1〜6 の範囲で指定してください"
+          }
+        }
+      }
+    },
     "%@: missing 'source'. event_inject requires a 'source' key naming a top-level YAML field that lists the event strings." : {
       "localizations" : {
         "en" : {

--- a/Pastura/PasturaTests/App/EditablePhaseRoundTripTests.swift
+++ b/Pastura/PasturaTests/App/EditablePhaseRoundTripTests.swift
@@ -46,6 +46,34 @@ struct EditablePhaseRoundTripTests {
     }
   }
 
+  /// `max_sentences` (#881) survives BOTH round-trip bridges at the top level
+  /// AND nested inside a conditional branch — the two silent-drop surfaces the
+  /// field could leak through (`EditablePhase.init(from:)`/`toPhase()` and
+  /// `ScenarioSerializer`/`ScenarioLoader`).
+  @Test func maxSentencesRoundTripsTopLevelAndNested() throws {
+    let phase = Phase(
+      type: .conditional, condition: "max_score >= 10",
+      thenPhases: [
+        Phase(
+          type: .speakEach, prompt: "Final defense.",
+          outputSchema: ["statement": "string"], maxSentences: 6)
+      ],
+      elsePhases: [
+        Phase(type: .speakAll, prompt: "Continue.", outputSchema: ["statement": "string"])
+      ],
+      maxSentences: 1)
+
+    // Visual bridge.
+    let viaEditable = EditablePhase(from: phase).toPhase()
+    #expect(viaEditable.maxSentences == 1)
+    #expect(viaEditable.thenPhases?.first?.maxSentences == 6)
+
+    // YAML bridge.
+    let reloaded = try loader.load(yaml: serializer.serialize(wrap(phase)))
+    #expect(reloaded.phases.first?.maxSentences == 1)
+    #expect(reloaded.phases.first?.thenPhases?.first?.maxSentences == 6)
+  }
+
   // One arm per PhaseType, no nested logic. Block disable rather than
   // `disable:next` (which would orphan the doc comment below it); the disable
   // command line must hold only the rule name, so this rationale is separate.

--- a/Pastura/PasturaTests/Engine/PromptBuilderTests+MaxSentences.swift
+++ b/Pastura/PasturaTests/Engine/PromptBuilderTests+MaxSentences.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+// MARK: - Per-phase max_sentences override (#881)
+//
+// Sibling-file extension per the testing.md split convention — NOT a new
+// @Suite (helpers `builder` / `makeScenario` stay internal in the main file).
+// The default (no override) byte-identity is pinned by the #877 brevity tests
+// in PromptBuilderTests+Hardening.swift; these cover the override paths.
+extension PromptBuilderTests {
+
+  private func promptFor(maxSentences: Int?, language: String = "ja") -> String {
+    let scenario = makeScenario(language: language)
+    let phase = Phase(
+      type: .speakAll, prompt: "Speak!",
+      outputSchema: ["statement": "string"], maxSentences: maxSentences)
+    let state = SimulationState.initial(for: scenario)
+    return builder.buildSystemPrompt(
+      scenario: scenario, persona: scenario.personas[0], phase: phase, state: state)
+  }
+
+  @Test func maxSentencesOverrideReplacesCapJa() {
+    let prompt = promptFor(maxSentences: 6)
+    #expect(prompt.contains("6文以内で簡潔に"))
+    // REPLACE, not append — the default 3-cap must not survive alongside it.
+    #expect(!prompt.contains("3文以内"))
+  }
+
+  @Test func maxSentencesOverrideReplacesCapEn() {
+    let prompt = promptFor(maxSentences: 6, language: "en")
+    #expect(prompt.contains("at most 6 sentences"))
+    #expect(!prompt.contains("at most 3 sentences"))
+  }
+
+  /// N=1 pluralizes correctly in en ("1 sentence", not "1 sentences") and
+  /// reads naturally in ja ("1文以内").
+  @Test func maxSentencesOfOneUsesSingularNounEn() {
+    let prompt = promptFor(maxSentences: 1, language: "en")
+    #expect(prompt.contains("at most 1 sentence,"))
+    #expect(!prompt.contains("1 sentences"))
+  }
+
+  @Test func maxSentencesOfOneRendersJa() {
+    #expect(promptFor(maxSentences: 1).contains("1文以内で簡潔に"))
+  }
+
+  /// Absent override falls back to the global default (byte-identical to the
+  /// #877 wording — the Hardening suite pins the exact literal).
+  @Test func absentMaxSentencesUsesDefaultCap() {
+    #expect(promptFor(maxSentences: nil).contains("3文以内で簡潔に"))
+  }
+}

--- a/Pastura/PasturaTests/Engine/ScenarioLoaderTests+MaxSentences.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioLoaderTests+MaxSentences.swift
@@ -1,0 +1,39 @@
+import Testing
+
+@testable import Pastura
+
+/// Parse coverage for the per-phase `max_sentences:` key (#881) — guards the
+/// literal YAML key name, which a serializer↔loader round-trip alone cannot
+/// (a symmetric mis-key would still round-trip).
+extension ScenarioLoaderTests {
+  @Test func parsesMaxSentencesOnPhase() throws {
+    let yaml = """
+      id: t
+      language: ja
+      name: T
+      description: d
+      agents: 2
+      rounds: 1
+      context: c
+      personas:
+        - name: Alice
+          description: a
+        - name: Bob
+          description: b
+      phases:
+        - type: speak_each
+          prompt: "Speak."
+          max_sentences: 5
+          output:
+            statement: string
+        - type: speak_all
+          prompt: "Speak."
+          output:
+            statement: string
+      """
+    let scenario = try loader.load(yaml: yaml)
+    #expect(scenario.phases[0].maxSentences == 5)
+    // Absent key → nil (no backward-compat fill).
+    #expect(scenario.phases[1].maxSentences == nil)
+  }
+}

--- a/Pastura/PasturaTests/Engine/ScenarioValidatorTests+MaxSentences.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioValidatorTests+MaxSentences.swift
@@ -1,0 +1,60 @@
+import Testing
+
+@testable import Pastura
+
+// MARK: - Per-phase max_sentences range (#881)
+//
+// Sibling-file extension per the testing.md split convention — NOT a new
+// @Suite (helpers `validator` / `makeScenario` stay internal in the main file).
+extension ScenarioValidatorTests {
+
+  @Test func rejectsMaxSentencesBelowRange() {
+    let scenario = makeScenario(
+      agents: 2, rounds: 1, phases: [Phase(type: .speakAll, maxSentences: 0)])
+    #expect(throws: SimulationError.self) {
+      try validator.validate(scenario)
+    }
+  }
+
+  @Test func rejectsMaxSentencesAboveRange() {
+    let scenario = makeScenario(
+      agents: 2, rounds: 1, phases: [Phase(type: .speakAll, maxSentences: 7)])
+    #expect(throws: SimulationError.self) {
+      try validator.validate(scenario)
+    }
+  }
+
+  @Test func acceptsMaxSentencesAtBounds() throws {
+    for value in [1, 6] {
+      let scenario = makeScenario(
+        agents: 2, rounds: 1, phases: [Phase(type: .speakAll, maxSentences: value)])
+      #expect(throws: Never.self) {
+        try validator.validate(scenario)
+      }
+    }
+  }
+
+  @Test func acceptsNilMaxSentences() throws {
+    let scenario = makeScenario(
+      agents: 2, rounds: 1, phases: [Phase(type: .speakAll, maxSentences: nil)])
+    #expect(throws: Never.self) {
+      try validator.validate(scenario)
+    }
+  }
+
+  /// The range check runs at the `validateBranch` traversal site too — an
+  /// out-of-range value on a phase nested inside a conditional `then:` is
+  /// rejected, not silently skipped.
+  @Test func rejectsOutOfRangeInNestedBranch() {
+    let scenario = makeScenario(
+      agents: 2, rounds: 1,
+      phases: [
+        Phase(
+          type: .conditional, condition: "max_score >= 10",
+          thenPhases: [Phase(type: .speakAll, maxSentences: 0)])
+      ])
+    #expect(throws: SimulationError.self) {
+      try validator.validate(scenario)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Stage 1 of #881 — an optional per-phase `max_sentences:` YAML field, a second layer on the shipped #877/#878 global statement-brevity soft-rule. It lets a scenario author override the statement sentence-cap per phase (e.g. a terse discussion phase vs a longer finale).

- `Phase.maxSentences: Int?` (YAML `max_sentences`), plumbed through `ScenarioLoader`, `ScenarioSerializer`, and the `EditablePhase` visual-editor buffer (round-trip preserved on both silent-drop surfaces).
- `PromptBuilder` **REPLACE** composition: the effective cap (`phase.maxSentences ?? 3`) is interpolated into the *single existing* brevity bullet — never a second appended line (a doubled cap would contradict a 2B model). The default renders byte-identical to the shipped #877 wording; en pluralizes the noun (`1 → "sentence"`).
- `ScenarioValidator` enforces range **1…6**, checked at both the top-level and conditional-branch traversal sites. New `ScenarioValidationMessage.maxSentencesOutOfRange` (label-carrying) + ja catalog entry.

### Why 1…6, and why it's effectively a **ja** lever

Backed by a throwaway Stage-0 harness A/B (word_wolf ja+en, global cap patched to 1/3/6, real Gemma 4 E2B, 2 runs each):

| cap | ja sentences (mean) | ja chars (mean) | en sentences (mean) |
|-----|--------------------|-----------------|---------------------|
| 1 | 1.00 | ~40 | 1.00 |
| 3 | 1.40 | 53 | 1.00 |
| 6 | ~1.9 | ~63 | 1.00 |

- **ja responds bidirectionally** and monotonically — raising the cap produces measurably longer *and substantively richer* statements (more cross-agent referencing), not padding.
- **en is near-inert** (sentence count pinned at 1.00) — en agents already write a single sentence, so a sentence cap doesn't bite.
- The model tops out ~3–4 sentences even at cap 6, so **6 is a generous practical ceiling** that also bounds per-turn latency / JSON stability.

Value framing: complements phase-`prompt` content scaffolding — the cap lifts the ceiling so a scaffolded finale isn't clipped by the global 3-sentence rule.

## Scope / staging

- **This PR (Stage 1):** model field + loader/serializer/editor round-trip + prompt application + validator range + tests.
- **Deferred to Stage 2:** a `ScenarioSemanticLinter` warning for `max_sentences` on a non-prose (code) phase (silent no-op), and a visual Editor UI control.
- **Deferred to Stage 3:** applying `max_sentences` in a bundled preset + a production harness A/B.

No existing preset uses the field (optional, backward-compatible; absent = today's behavior). No ADR (mirrors the `log_window` / `probability` field-addition precedent).

## Test plan

- Full unit suite green (2917 tests). New coverage:
  - `PromptBuilderTests+MaxSentences` — override renders in ja/en, REPLACE (no doubled cap), N=1 en singular, default byte-identity.
  - `ScenarioValidatorTests+MaxSentences` — 0/7 reject, 1/6 accept, nil accept, out-of-range in a nested `then:` branch rejected.
  - `ScenarioLoaderTests+MaxSentences` — `max_sentences:` key parses; absent = nil.
  - `EditablePhaseRoundTripTests` — new test: field survives both bridges at top-level AND nested.
- `#877` brevity hardening pins stay green (byte-identity confirmed).
- swiftlint `--strict`, localization coverage, and harness `swift build` all green.

## Device QA

実機QA不要 — no device-only surface (`#if !targetEnvironment(simulator)`, Metal/llama.cpp, or view layout) is touched; the field is inert until a scenario opts in (Stage 3), and the runtime prompt effect was already validated on-device by the Stage-0 harness A/B above.

Part of #881

🤖 Generated with [Claude Code](https://claude.com/claude-code)