### PR TITLE
✨ feat: semantic-lint R18 max_sentences no-op warning (#881 Stage 2 PR-A)

### DIFF
--- a/Pastura/Pastura/Engine/ScenarioSemanticLinter+Config.swift
+++ b/Pastura/Pastura/Engine/ScenarioSemanticLinter+Config.swift
@@ -1,23 +1,25 @@
 import Foundation
 
-/// Silently-inert configuration rules R7/R8/R9/R17 (ADR-024 D3).
+/// Silently-inert configuration rules R7/R8/R9/R17/R18 (ADR-024 D3).
 ///
 /// Unlike the ordering rules (`ScenarioSemanticLinter+Ordering.swift`), these
 /// rules don't compare producer/consumer phase indices — each phase (or the
 /// scenario as a whole, for R17) is inert on its own terms because of a
-/// missing/empty field, or because a *different* producer relation (a
-/// round-robin `choose` gating pairing-placeholder resolution, for R9) never
-/// ran earlier. R9 reuses the same "producer inside a `conditional` branch
-/// counts as present at the conditional's index" imprecision documented on
-/// the ordering rules.
+/// missing/empty field, an out-of-place field (a `max_sentences` on a code
+/// phase, for R18), or because a *different* producer relation (a round-robin
+/// `choose` gating pairing-placeholder resolution, for R9) never ran earlier.
+/// R9/R18 reuse the same "producer inside a `conditional` branch counts as
+/// present at the conditional's index" imprecision documented on the ordering
+/// rules.
 nonisolated extension ScenarioSemanticLinter {
 
-  /// Silently-inert-configuration findings (R7/R8/R9/R17).
+  /// Silently-inert-configuration findings (R7/R8/R9/R17/R18).
   func configFindings(in scenario: Scenario) -> [LintFinding] {
     chooseOptionsFindings(in: scenario.phases)
       + assignSourceFindings(in: scenario.phases, scenario: scenario)
       + summarizePairingFindings(in: scenario.phases)
       + logWindowFindings(in: scenario)
+      + maxSentencesNoOpFindings(in: scenario.phases)
   }
 
   // MARK: - R7 choose-should-declare-options (warning)
@@ -130,6 +132,25 @@ nonisolated extension ScenarioSemanticLinter {
     !phaseRefs(in: phases, where: { $0.type == .speakEach }).isEmpty
   }
 
+  // MARK: - R18 max-sentences-no-op (warning)
+
+  /// A `max_sentences` set on a phase that emits no LLM statement is a silent
+  /// no-op: it is parsed, round-tripped, and serialized, but never reaches a
+  /// prompt. The brevity bullet it feeds is emitted only by
+  /// `PromptBuilder.buildAnswerRules`, which is called from `buildSystemPrompt`
+  /// — reached solely by the six `requiresLLM` handlers. So `requiresLLM`
+  /// is exactly the "cap reaches the prompt" predicate, and its inverse is the
+  /// provable no-op set. Reusing the existing no-default exhaustive switch
+  /// (`PhaseType.requiresLLM`) keeps a single source of truth: a new phase type
+  /// forces a decision there and R18 follows automatically. `reflect` is
+  /// **excluded** (it is `requiresLLM`) even though its cap semantics are fuzzy
+  /// (it emits a `note`, not a `statement`) — the bullet is still emitted, so
+  /// it is not a *silent* no-op. Uniformly `.warning` — never blocks a run.
+  private func maxSentencesNoOpFindings(in phases: [Phase]) -> [LintFinding] {
+    phaseRefs(in: phases, where: { $0.maxSentences != nil && !$0.type.requiresLLM })
+      .map { configFinding("max-sentences-no-op", .warning, at: $0.topLevelIndex) }
+  }
+
   // MARK: - Shared
 
   /// Builds the single-element findings array for a config `ruleID`,
@@ -158,6 +179,11 @@ nonisolated extension ScenarioSemanticLinter {
       return String(
         localized:
           "summarize-pairing-placeholders: this 'summarize' template references {agent1}-family placeholders, but no round-robin 'choose' phase runs earlier in the round, so the placeholders leak literally into the summary — add a round-robin 'choose' phase before this 'summarize', or remove the pairing placeholders."
+      )
+    case "max-sentences-no-op":
+      return String(
+        localized:
+          "max-sentences-no-op: this phase emits no LLM statement, so its 'max_sentences' cap never reaches a prompt and has no effect — remove it, or move it to a speaking phase (speak_all / speak_each / vote / choose / reflect / whisper)."
       )
     default:
       return String(

--- a/Pastura/Pastura/Engine/ScenarioSemanticLinter+Config.swift
+++ b/Pastura/Pastura/Engine/ScenarioSemanticLinter+Config.swift
@@ -183,7 +183,7 @@ nonisolated extension ScenarioSemanticLinter {
     case "max-sentences-no-op":
       return String(
         localized:
-          "max-sentences-no-op: this phase emits no LLM statement, so its 'max_sentences' cap never reaches a prompt and has no effect — remove it, or move it to a speaking phase (speak_all / speak_each / vote / choose / reflect / whisper)."
+          "max-sentences-no-op: this phase emits no LLM statement, so its 'max_sentences' cap never reaches a prompt and has no effect — remove it, or move it to a phase that emits a statement (speak_all / speak_each / whisper)."
       )
     default:
       return String(

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -7368,6 +7368,16 @@
         }
       }
     },
+    "max-sentences-no-op: this phase emits no LLM statement, so its 'max_sentences' cap never reaches a prompt and has no effect — remove it, or move it to a speaking phase (speak_all / speak_each / vote / choose / reflect / whisper)." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "max-sentences-no-op: このフェーズは LLM の発言を生成しないため、'max_sentences' の上限はプロンプトに届かず効果がありません — 削除するか、発話フェーズ（speak_all / speak_each / vote / choose / reflect / whisper）に移動してください。"
+          }
+        }
+      }
+    },
     "pd-needs-round-robin-choose: 'prisoners_dilemma' scoring needs a round-robin 'choose' phase earlier in the round to populate pairings, or scores never change — add one before this 'score_calc'." : {
       "localizations" : {
         "ja" : {

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -7368,12 +7368,12 @@
         }
       }
     },
-    "max-sentences-no-op: this phase emits no LLM statement, so its 'max_sentences' cap never reaches a prompt and has no effect — remove it, or move it to a speaking phase (speak_all / speak_each / vote / choose / reflect / whisper)." : {
+    "max-sentences-no-op: this phase emits no LLM statement, so its 'max_sentences' cap never reaches a prompt and has no effect — remove it, or move it to a phase that emits a statement (speak_all / speak_each / whisper)." : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "max-sentences-no-op: このフェーズは LLM の発言を生成しないため、'max_sentences' の上限はプロンプトに届かず効果がありません — 削除するか、発話フェーズ（speak_all / speak_each / vote / choose / reflect / whisper）に移動してください。"
+            "value" : "max-sentences-no-op: このフェーズは LLM の発言を生成しないため、'max_sentences' の上限はプロンプトに届かず効果がありません — 削除するか、発言を生成するフェーズ（speak_all / speak_each / whisper）に移動してください。"
           }
         }
       }

--- a/Pastura/PasturaTests/Engine/ScenarioSemanticLinterTests+Config.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioSemanticLinterTests+Config.swift
@@ -136,6 +136,55 @@ extension ScenarioSemanticLinterTests {
     #expect(linter.lint(scenario).isEmpty)
   }
 
+  // MARK: - R18 max-sentences-no-op (warning)
+
+  @Test func maxSentencesOnCodePhaseFiresWarning() {
+    // `max_sentences` only reaches the prompt for `requiresLLM` phases (via
+    // `PromptBuilder.buildAnswerRules`); on a code phase it is parsed +
+    // serialized but never surfaced — a silent no-op.
+    let scenario = makeScenario(
+      agents: 2, rounds: 1,
+      phases: [Phase(type: .summarize, template: "Round complete.", maxSentences: 3)])
+    let findings = linter.lint(scenario).filter { $0.ruleID == "max-sentences-no-op" }
+    #expect(findings.count == 1)
+    #expect(findings.first?.severity == .warning)
+    #expect(findings.first?.phaseIndex == 0)
+  }
+
+  @Test func maxSentencesOnLLMPhasesDoesNotFire() {
+    // All 6 `requiresLLM` phases surface the brevity cap in-prompt, so R18 must
+    // never fire for them. Guards against a `primaryField == "statement"`
+    // over-narrowing that would false-flag vote/choose/reflect (whose brevity
+    // bullet IS still emitted).
+    for llmType in [PhaseType.speakAll, .speakEach, .vote, .choose, .reflect, .whisper] {
+      let scenario = makeScenario(
+        agents: 2, rounds: 1, phases: [Phase(type: llmType, maxSentences: 2)])
+      #expect(!linter.lint(scenario).contains { $0.ruleID == "max-sentences-no-op" })
+    }
+  }
+
+  @Test func maxSentencesNilOnCodePhaseDoesNotFire() {
+    let scenario = makeScenario(
+      agents: 2, rounds: 1, phases: [Phase(type: .summarize, template: "Round complete.")])
+    #expect(!linter.lint(scenario).contains { $0.ruleID == "max-sentences-no-op" })
+  }
+
+  @Test func maxSentencesOnCodePhaseNestedInConditionalFiresAtConditionalIndex() {
+    // `phaseRefs` anchors a branch sub-phase to its enclosing conditional's
+    // top-level index (matches R7/R9 nesting semantics).
+    let scenario = makeScenario(
+      agents: 2, rounds: 1,
+      phases: [
+        Phase(type: .speakAll, prompt: "Go"),
+        Phase(
+          type: .conditional, condition: "current_round >= 1",
+          thenPhases: [Phase(type: .summarize, template: "Done.", maxSentences: 4)])
+      ])
+    let findings = linter.lint(scenario).filter { $0.ruleID == "max-sentences-no-op" }
+    #expect(findings.count == 1)
+    #expect(findings.first?.phaseIndex == 1)
+  }
+
   // MARK: - Helper
 
   // Internal factory for scenarios needing `logWindow` (R17); the base

--- a/docs/decisions/ADR-024.md
+++ b/docs/decisions/ADR-024.md
@@ -142,6 +142,7 @@ enforcement existed.
 | R15 `unknown-condition-identifier` | identifier ∉ known set (below) → resolves absent, warning only mid-run | warning | — |
 | R16 `short-circuit-hidden-typo` | typo in a never-evaluated `&&`/`||` sub-expression never surfaces at runtime | info (documented no-op) | ✓ (evaluator doc) |
 | R17 `log-window-below-agent-count` | `log_window < agentCount` with `speak_each` present → same-round speakers vanish from prompts | warning | — (engine.md documents the trap) |
+| R18 `max-sentences-no-op` | `max_sentences` on a phase with no LLM statement (the non-`requiresLLM` code/control phases) → cap never reaches a prompt, silent no-op | warning | — (added post-v1, § Amendment 2026-07-11) |
 
 Ordering semantics (R1–R6, R11): compare **top-level phase-list indices**;
 producers inside `conditional` branches count at the conditional's index
@@ -303,3 +304,26 @@ before this PR merged.
   zero-FP batch proof + ja catalog entries + this ADR.
 - **Follow-up (PR2)**: CI job for the batch lint; editor non-blocking
   warning/info display (`lintWarnings`); #920/#919 reference updates.
+
+## 6. Amendment 2026-07-11 — R18 `max-sentences-no-op` (#881 Stage 2)
+
+Added after v1 shipped, following the D3 rule-addition policy (the catalog is
+the contract; new rules are additive and pass the D2 leniency test).
+`max_sentences` — a per-phase statement brevity cap shipped in Stage 1
+(PR #1044) — is a **silent no-op** on any phase that emits no LLM statement:
+it is parsed, round-tripped, and serialized, but never reaches a prompt.
+`PromptBuilder.buildAnswerRules` feeds the brevity bullet only from
+`buildSystemPrompt`, which is called by exactly the six `requiresLLM` handlers,
+so `requiresLLM` **is** the "cap reaches the prompt" predicate. R18 reuses that
+existing no-default exhaustive switch (`PhaseType.requiresLLM`) rather than
+adding a new effective-set helper — a future phase type forces the decision
+there and R18 follows automatically. `reflect` is excluded even though its cap
+semantics are fuzzy (it emits a `note`, not a `statement`): the bullet is still
+emitted, so it is not a *silent* no-op. Warning-level, per D2 (never blocks a
+run).
+
+D6 batch re-run over the current inventory: **51 files, 0 errors, 0 warnings**
+(the §D6 count grew from 48 as the gallery expanded; no shipped YAML sets
+`max_sentences` on a code phase, so the zero-false-positive proof still holds).
+Editor-surface exposure of lint warnings stays out of scope (the unchanged D5
+posture); the #881 Editor UI control for `max_sentences` is Stage 2 PR-B.


### PR DESCRIPTION
## Summary

Adds `ScenarioSemanticLinter` rule **R18 `max-sentences-no-op`** (warning-level, ADR-024): flags a `max_sentences` YAML field set on a phase where it never reaches the prompt — a silent no-op.

- **Predicate**: `phase.maxSentences != nil && !phase.type.requiresLLM`. The brevity bullet `max_sentences` feeds is emitted only by `PromptBuilder.buildAnswerRules` (via `buildSystemPrompt`), called by exactly the six `requiresLLM` handlers — so `requiresLLM` **is** the "cap reaches the prompt" predicate. Fires on the 7 non-LLM code/control phases (`score_calc`/`assign`/`eliminate`/`summarize`/`conditional`/`event_inject`/`relationship_update`).
- **No new helper**: reuses the existing `PhaseType.requiresLLM` no-default exhaustive switch, so a future phase type forces the decision there and R18 follows automatically (single source of truth).
- Mirrors the existing R7/R9 config-rule structure (`phaseRefs` + `configFinding` + `configMessage`); rides the run-start `.summary` channel; **never blocks a run**.
- Engine + tests + ja catalog + ADR-024 docs only. **No App/View changes.** The Editor UI control for `max_sentences` is Stage 2 PR-B; harness A/B on real scenarios is Stage 3.

Part of #881 (this is a non-final PR in the Stage 2 split — does not close the umbrella).

## Design note — effective-set = 6 LLM phases, not 3 statement-producers

`max_sentences`'s brevity bullet is emitted for all six `requiresLLM` phases (verified against `PromptBuilder`), so R18 keys off `requiresLLM`, **not** `primaryField == "statement"` (which would false-flag `vote`/`choose`/`reflect`, where the bullet IS emitted). `reflect` is excluded from firing even though its cap semantics are fuzzy (it emits a `note`) — the bullet is still emitted, so it is not a *silent* no-op. The user-facing relocation hint separately narrows to the statement-emitting phases (`speak_all`/`speak_each`/`whisper`) where the cap actually shortens output.

## Test plan

- New unit tests in `ScenarioSemanticLinterTests+Config.swift` (ruleID-scoped, revert-sensitive):
  - fires exactly once on a code phase (`summarize`) with `max_sentences` (phaseIndex 0)
  - does **not** fire on any of the 6 LLM phases with `max_sentences` (guards the effective-set over-narrowing)
  - does not fire on a code phase without `max_sentences`
  - nested code phase inside a `conditional` fires anchored to the conditional's top-level index
- Full unit suite: **2921 tests, all pass**; `swiftlint --strict` clean.
- ADR-013 harness path (not covered by xcodebuild): `swift build` + `swift run pastura-harness lint Pastura/Pastura/Resources/Presets docs/gallery` → **51 files, 0 errors, 0 warnings** (no shipped YAML sets `max_sentences` on a code phase).
- Localization coverage: `check_localization_coverage.py` OK (ja entry added, single-`ja`-block form matching neighboring linter-message keys).
- Reviewed by the `code-reviewer` gate (Opus): PASS, 0 issues. The reviewer's fix-hint suggestion is folded into commit 3.

## Device QA

実機QA不要 — Engine semantic-lint rule + docs + string-catalog only; no device-only (`#if !targetEnvironment(simulator)`), Metal/inference, or View-layout surface.