### PR TITLE
✨ feat: max_sentences override control in PhaseEditorSheet (#881 PR-B)

### DIFF
--- a/Pastura/Pastura/App/EditablePhase.swift
+++ b/Pastura/Pastura/App/EditablePhase.swift
@@ -166,6 +166,21 @@ struct EditablePhase: Identifiable, Sendable {
     }
   }
 
+  /// Clears a `max_sentences` override when the current `type` no longer emits
+  /// an LLM statement (#881). Called on the same `.onChange(of: type)` event as
+  /// ``reconcileCanonicalOutputFields(from:)`` so that switching an LLM phase
+  /// (with an override set) to a code / control phase does not leave a hidden,
+  /// no-longer-editable value behind — such a value would round-trip into the
+  /// code phase and silently trip the R18 `max-sentences-no-op` linter (a
+  /// warning that never blocks, ADR-024), defeating the editor's LLM-only
+  /// display gate. Idempotent: a no-op when `type` still requires LLM or the
+  /// override is already nil.
+  mutating func reconcileMaxSentences() {
+    if !type.requiresLLM {
+      maxSentences = nil
+    }
+  }
+
   /// The canonical primary + thought output field names for `type`
   /// (empty for code phases that emit no LLM output).
   private func canonicalFieldNames(for type: PhaseType) -> [String] {

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -4079,6 +4079,22 @@
         }
       }
     },
+    "Max sentences: %lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Max sentences: %lld"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最大 %lld 文"
+          }
+        }
+      }
+    },
     "Memory warning — simulation paused. Tap resume to continue." : {
       "localizations" : {
         "en" : {
@@ -4602,6 +4618,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%3$@ の出力が %1$@ になりました(想定: %2$@)"
+          }
+        }
+      }
+    },
+    "Override sentence limit" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Override sentence limit"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文数上限を上書き"
           }
         }
       }
@@ -6106,6 +6138,22 @@
         }
       }
     },
+    "Statement Length" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Statement Length"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "発言の長さ"
+          }
+        }
+      }
+    },
     "Status" : {
       "localizations" : {
         "en" : {
@@ -6972,6 +7020,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "進行の流れ"
+          }
+        }
+      }
+    },
+    "When off, statements use the global default (%lld sentences)." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When off, statements use the global default (%lld sentences)."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフの場合、発言は全体の既定（%lld 文）に従います。"
           }
         }
       }

--- a/Pastura/Pastura/Views/Editor/PhaseEditorSheet+MaxSentencesSection.swift
+++ b/Pastura/Pastura/Views/Editor/PhaseEditorSheet+MaxSentencesSection.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+// Per-phase `max_sentences` brevity-override UI for `PhaseEditorSheet` (#881
+// Stage 2 PR-B). The control is a Toggle ("override the global default") plus a
+// conditional Stepper (1…6), shown only for phases that emit an LLM statement.
+// Split out from `PhaseEditorSheet.swift` to keep that file under SwiftLint's
+// `file_length` limit. Accesses `phase` from the parent struct.
+//
+// The pure decision helpers below carry the testable logic (ADR-009); the View
+// section only wires SwiftUI bindings to them.
+
+extension PhaseEditorSheet {
+
+  // MARK: - Pure decision helpers (unit-tested)
+
+  /// Whether the `max_sentences` control is shown for `type`. Gated to phases
+  /// that emit an LLM statement (`requiresLLM`) — the exact set the semantic
+  /// linter's R18 `max-sentences-no-op` rule treats as effective — so an author
+  /// cannot set a silent no-op override on a code / control phase from the
+  /// visual editor.
+  static func showsMaxSentencesControl(for type: PhaseType) -> Bool {
+    type.requiresLLM
+  }
+
+  /// The accepted `max_sentences` range. MUST match the range enforced by
+  /// `ScenarioValidator.validateMaxSentences` (1…6); a UI value outside it would
+  /// fail commit-time validation.
+  static let maxSentencesRange = 1...6
+
+  /// The global default statement cap surfaced when the override is unset.
+  /// Sourced from the Engine so the editor default never drifts from the
+  /// prompt-builder default (Views may depend on Engine).
+  static var defaultMaxSentences: Int { PromptBuilder.defaultStatementMaxSentences }
+
+  /// Maps the override Toggle to the stored value: on → seed with the global
+  /// default (an explicit value the author can then adjust); off → nil (inherit
+  /// the global default). Deliberately not the `subRounds` `== 1 ? nil` collapse
+  /// trick — the default (3) lies inside the range, so "explicit 3" and "unset"
+  /// must stay distinguishable.
+  static func maxSentencesToggled(enabled: Bool) -> Int? {
+    enabled ? defaultMaxSentences : nil
+  }
+
+  /// Clamps a Stepper value into the accepted range.
+  static func clampedMaxSentences(_ value: Int) -> Int {
+    min(max(value, maxSentencesRange.lowerBound), maxSentencesRange.upperBound)
+  }
+
+  /// The value the Stepper displays: the override if set, else the global
+  /// default.
+  static func maxSentencesDisplayValue(_ value: Int?) -> Int {
+    value ?? defaultMaxSentences
+  }
+}

--- a/Pastura/Pastura/Views/Editor/PhaseEditorSheet+MaxSentencesSection.swift
+++ b/Pastura/Pastura/Views/Editor/PhaseEditorSheet+MaxSentencesSection.swift
@@ -51,4 +51,50 @@ extension PhaseEditorSheet {
   static func maxSentencesDisplayValue(_ value: Int?) -> Int {
     value ?? defaultMaxSentences
   }
+
+  // MARK: - Section view
+
+  /// The `max_sentences` override control. Shown only inside the
+  /// `requiresLLM` block of `body` — the same gate ``showsMaxSentencesControl(for:)``
+  /// encodes for the unit test. A Toggle switches between the global default
+  /// (off → nil) and an explicit per-phase cap (on → Stepper, 1…6).
+  var maxSentencesSection: some View {
+    Section {
+      Toggle(String(localized: "Override sentence limit"), isOn: maxSentencesOverrideBinding)
+      if phase.maxSentences != nil {
+        Stepper(value: maxSentencesValueBinding, in: Self.maxSentencesRange) {
+          Text(
+            String(
+              format: String(localized: "Max sentences: %lld"),
+              Self.maxSentencesDisplayValue(phase.maxSentences)))
+        }
+      }
+    } header: {
+      Text(String(localized: "Statement Length"))
+    } footer: {
+      Text(
+        String(
+          format: String(
+            localized: "When off, statements use the global default (%lld sentences)."),
+          Self.defaultMaxSentences)
+      )
+      .font(.caption)
+    }
+  }
+
+  // MARK: - Bindings
+
+  private var maxSentencesOverrideBinding: Binding<Bool> {
+    Binding(
+      get: { phase.maxSentences != nil },
+      set: { phase.maxSentences = Self.maxSentencesToggled(enabled: $0) }
+    )
+  }
+
+  private var maxSentencesValueBinding: Binding<Int> {
+    Binding(
+      get: { Self.maxSentencesDisplayValue(phase.maxSentences) },
+      set: { phase.maxSentences = Self.clampedMaxSentences($0) }
+    )
+  }
 }

--- a/Pastura/Pastura/Views/Editor/PhaseEditorSheet.swift
+++ b/Pastura/Pastura/Views/Editor/PhaseEditorSheet.swift
@@ -60,8 +60,10 @@ struct PhaseEditorSheet: View {
       Form {
         typeSection
         if phase.type.requiresLLM {
+          // `requiresLLM` == `showsMaxSentencesControl(for:)` (unit-tested).
           promptSection
           outputFieldsSection
+          maxSentencesSection
         }
         typeSpecificSection
       }
@@ -84,6 +86,7 @@ struct PhaseEditorSheet: View {
         // (#802). Drives authors onto the convention so a phase doesn't ship
         // without its `inner_thought` thought bubble (the #799 gap).
         phase.reconcileCanonicalOutputFields(from: oldType)
+        phase.reconcileMaxSentences()  // clear a stale override on switch to non-LLM (#881)
       }
       .toolbar {
         ToolbarItem(placement: .cancellationAction) {

--- a/Pastura/PasturaTests/App/EditablePhaseTests.swift
+++ b/Pastura/PasturaTests/App/EditablePhaseTests.swift
@@ -156,4 +156,29 @@ struct EditablePhaseTests {
     #expect(restored.voteAgainst == nil)
     #expect(restored.actionDeltas == nil)
   }
+
+  // MARK: - reconcileMaxSentences (#881 Stage 2 PR-B — switch-away no-op guard)
+
+  /// Switching an LLM phase with a `max_sentences` override to a code phase must
+  /// clear the override — otherwise the value stays hidden (the editor gates the
+  /// control to LLM phases) yet round-trips into the code phase and trips R18.
+  @Test func reconcileMaxSentencesClearsOverrideOnSwitchToCodePhase() {
+    var sut = EditablePhase(type: .speakAll, maxSentences: 4)
+    sut.type = .scoreCalc
+    sut.reconcileMaxSentences()
+    #expect(sut.maxSentences == nil)
+  }
+
+  @Test func reconcileMaxSentencesPreservesOverrideOnLLMToLLMSwitch() {
+    var sut = EditablePhase(type: .speakAll, maxSentences: 4)
+    sut.type = .vote
+    sut.reconcileMaxSentences()
+    #expect(sut.maxSentences == 4)
+  }
+
+  @Test func reconcileMaxSentencesIsNoOpWhenAlreadyNil() {
+    var sut = EditablePhase(type: .eliminate)
+    sut.reconcileMaxSentences()
+    #expect(sut.maxSentences == nil)
+  }
 }

--- a/Pastura/PasturaTests/Views/PhaseEditorSheetValidationTests.swift
+++ b/Pastura/PasturaTests/Views/PhaseEditorSheetValidationTests.swift
@@ -167,4 +167,48 @@ struct PhaseEditorSheetValidationTests {
     #expect(roundRobin.contains("{opponent_name}"))
     #expect(!individual.contains("{opponent_name}"))
   }
+
+  // MARK: - max_sentences control logic (#881 Stage 2 PR-B)
+
+  /// The control is shown for exactly the 6 LLM phases — the same set the R18
+  /// `max-sentences-no-op` linter treats as effective — and hidden for the 7
+  /// code / control phases, so an author can't author a silent no-op override.
+  @Test func showsMaxSentencesControlOnlyForLLMPhases() {
+    let shown = PhaseType.allCases.filter { PhaseEditorSheet.showsMaxSentencesControl(for: $0) }
+    #expect(Set(shown) == Set([.speakAll, .speakEach, .vote, .choose, .reflect, .whisper]))
+    #expect(shown.count == 6)
+    #expect(PhaseType.allCases.count - shown.count == 7)
+  }
+
+  @Test func maxSentencesToggledOnSeedsGlobalDefault() {
+    // Toggling the override on seeds the global default so the result is
+    // byte-identical to the unset (nil) prompt until the author adjusts it.
+    #expect(
+      PhaseEditorSheet.maxSentencesToggled(enabled: true) == PromptBuilder.defaultStatementMaxSentences)
+  }
+
+  @Test func maxSentencesToggledOffClearsOverride() {
+    #expect(PhaseEditorSheet.maxSentencesToggled(enabled: false) == nil)
+  }
+
+  @Test func maxSentencesToggleRoundTripsNilToValueToNil() {
+    var value: Int?
+    value = PhaseEditorSheet.maxSentencesToggled(enabled: true)
+    #expect(value == PhaseEditorSheet.defaultMaxSentences)
+    value = PhaseEditorSheet.maxSentencesToggled(enabled: false)
+    #expect(value == nil)
+  }
+
+  @Test func clampedMaxSentencesBoundsToAcceptedRange() {
+    #expect(PhaseEditorSheet.clampedMaxSentences(0) == 1)
+    #expect(PhaseEditorSheet.clampedMaxSentences(7) == 6)
+    #expect(PhaseEditorSheet.clampedMaxSentences(4) == 4)
+    #expect(PhaseEditorSheet.clampedMaxSentences(1) == 1)
+    #expect(PhaseEditorSheet.clampedMaxSentences(6) == 6)
+  }
+
+  @Test func maxSentencesDisplayValueFallsBackToDefault() {
+    #expect(PhaseEditorSheet.maxSentencesDisplayValue(nil) == PhaseEditorSheet.defaultMaxSentences)
+    #expect(PhaseEditorSheet.maxSentencesDisplayValue(5) == 5)
+  }
 }


### PR DESCRIPTION
## Summary

Stage 2 PR-B of #881 (per-phase `max_sentences` brevity override). Adds the **visual editor UI** for the override — the model, loader/serializer, validator range (1…6), `PromptBuilder` synthesis, and the R18 `max-sentences-no-op` linter all shipped in Stage 1 (#1044) and Stage 2 PR-A (#1048), so this PR is UI-binding-only plus one edit-time reconcile.

- **`maxSentencesSection`** (`PhaseEditorSheet+MaxSentencesSection.swift`) — a Toggle ("Override sentence limit") that switches between the global default (off → `nil`) and an explicit per-phase cap (on → a 1…6 Stepper). Footer names the global default.
- **Shown only for LLM phases** (`requiresLLM` — the exact set R18 treats as effective), so an author can't set a silent no-op override on a code/control phase.
- **nil vs explicit value stays distinguishable** — deliberately *not* the `subRounds` `== 1 ? nil` collapse trick, since the default (3) lies inside the range.
- **Switch-away guard** — `EditablePhase.reconcileMaxSentences()` clears the override on `.onChange(of: type)` to a non-LLM phase, so a hidden value can't survive into a code phase and trip R18 (a gap the pre-impl critic flagged in the display-gate design).
- **Pure logic extracted + unit-tested** (ADR-009): `showsMaxSentencesControl` / `maxSentencesToggled` / `clampedMaxSentences` / `maxSentencesDisplayValue`; default sourced from `PromptBuilder.defaultStatementMaxSentences`, range mirrors `ScenarioValidator`.
- **i18n**: 4 new catalog keys with ja translations; interpolated Stepper/footer strings use the label-closure + `String(format: String(localized:))` (Form B) pattern to avoid the convenience-init label trap.

Part of #881 (Stage 3 — the last_fable finale + real-harness A/B — is the final PR that closes the umbrella).

## Test plan

- `EditablePhaseTests`: `reconcileMaxSentences` clears on switch-away, preserves on LLM→LLM, no-op when already nil (genuine regression tests — revert the guard and they fail).
- `PhaseEditorSheetValidationTests`: 6/7 `requiresLLM` partition (== R18 effective set), nil↔value↔nil round-trip, clamp bounds (0→1, 7→6), toggle-on == `PromptBuilder.defaultStatementMaxSentences`, display fallback.
- Full unit suite green (2930 tests / 236 suites); `swiftlint --strict` clean; `check_localization_coverage.py` green (642 keys, all ja translated).

## Device QA

New Form Section in the phase editor sheet — low render risk (standard `Form` controls, not a plain-ScrollView card), but the new UI + ja copy warrant one on-device pass:

1. Editor → add/edit an **LLM phase** (e.g. speak_all): confirm the "Statement Length" section appears with the Toggle; flipping it on reveals the 1…6 Stepper (default 3); off hides it and the footer names the global default.
2. Switch that phase's type to a **code phase** (e.g. score_calc) → confirm the section disappears and the override does not resurface on switching back (reconcile clear).
3. **ja locale**: confirm `最大 %lld 文` / `文数上限を上書き` / `発言の長さ` / the footer render (not English fallback) and fit the row width.
4. iOS 26: glance the Toggle/Stepper glass rendering in the sheet (simulator misleads on iOS 26 glass).