### PR TITLE
✨ feat: last_fable speak_all max_sentences: 6 (#881 Stage 3)

### DIFF
--- a/Pastura/Pastura/Resources/Presets/last_fable.yaml
+++ b/Pastura/Pastura/Resources/Presets/last_fable.yaml
@@ -70,6 +70,11 @@ phases:
     template: "{current_event}"
 
   - type: speak_all
+    # #881: lift the global ≤3-sentence brevity cap for the nightly plea so a
+    # scaffolded closing argument isn't clipped. Harness A/B (gemma-4-E2B, ja)
+    # showed cap 6 ~doubles cross-agent engagement over the ≤3 default at no
+    # latency cost; en is inert but mirrors for structural parity (presets.md).
+    max_sentences: 6
     prompt: >
       {current_event}
 

--- a/Pastura/Pastura/Resources/Presets/last_fable_en.yaml
+++ b/Pastura/Pastura/Resources/Presets/last_fable_en.yaml
@@ -81,6 +81,11 @@ phases:
     template: "{current_event}"
 
   - type: speak_all
+    # #881: lift the global ≤3-sentence brevity cap for the nightly plea so a
+    # scaffolded closing argument isn't clipped. The lever is empirically
+    # ja-only (en statements stay ~1 sentence regardless); mirrored here for
+    # structural ja/en parity (presets.md), not for an en effect.
+    max_sentences: 6
     prompt: >
       {current_event}
 

--- a/Pastura/PasturaTests/App/PresetLoaderTests.swift
+++ b/Pastura/PasturaTests/App/PresetLoaderTests.swift
@@ -262,4 +262,36 @@ struct PresetLoaderTests {
       }
     }
   }
+
+  /// #881 Stage 3 change-detector: the demonstrated brevity-override gain lives
+  /// entirely in `last_fable`'s `speak_all` `max_sentences: 6`. Value-level
+  /// preset content is otherwise unguarded (`presets.md` — the fixture suites
+  /// key on ids / schema shape / placeholder tokens, not scalar values), so a
+  /// future `git add -A` catalog re-serialization or an editor round-trip could
+  /// silently drop the key with every other gate green. A failure here is NOT a
+  /// bug: it means the override drifted — confirm the change was intended, then
+  /// update the expected value. (`view-testing.md` § change-detector tripwire.)
+  @Test func lastFableSpeakAllPinsMaxSentencesOverride() throws {
+    let loader = ScenarioLoader()
+    let bundle = Bundle(for: DatabaseManager.self)
+
+    // Both ja + en siblings carry the mechanic (presets.md ja/en parity),
+    // though the lever is empirically ja-only.
+    for fileName in ["last_fable", "last_fable_en"] {
+      guard let url = bundle.url(forResource: fileName, withExtension: "yaml") else {
+        Issue.record("Missing preset: \(fileName).yaml")
+        continue
+      }
+      let yaml = try String(contentsOf: url, encoding: .utf8)
+      let scenario = try loader.load(yaml: yaml)
+      guard let speakAll = scenario.phases.first(where: { $0.type == .speakAll }) else {
+        Issue.record("\(fileName).yaml: no speak_all phase")
+        continue
+      }
+      #expect(
+        speakAll.maxSentences == 6,
+        "\(fileName).yaml speak_all max_sentences drifted from 6 (got \(speakAll.maxSentences.map(String.init) ?? "nil")) — see #881 Stage 3"
+      )
+    }
+  }
 }


### PR DESCRIPTION
## Summary
Final PR of the #881 split. Applies the shipped per-phase `max_sentences` YAML brevity override (Stage 1 plumbing / Stage 2 lint + editor UI) in the `last_fable` bundled preset (ja + en) to demonstrate the interestingness gain, plus a change-detector test pinning the value.

The nightly plea (`speak_all` — where each animal argues to be inscribed) lifts the global ≤3-sentence brevity cap to **6**, so a scaffolded closing argument isn't clipped. No production Swift changed — two preset YAMLs (data) + one test.

## A/B validation (production harness)
gemma-4-E2B (= TestFlight backend), 3 runs/arm, base/cap5/cap6 × ja+en, `last_fable` `speak_all`:

| arm (ja) | sent_mean | sent_max | >3 sent | **cross-agent ref %※** | wall | parse |
|---|---|---|---|---|---|---|
| base (≤3) | 1.58 | 2 | 0 | 17% | 263s | all ok, attempt 1 |
| cap5 | 2.17 | 4 | 2 | 22% | 261s | all ok |
| **cap6** | 2.17 | 5 | 3 | **36%** | 251s | all ok |

※ share of statements referencing another agent by name = the debate-engagement / substance indicator (#911 family).

**cap6 won**: same length lift as cap5 but ~1.6× the cross-agent engagement (2× base), a longer substantive tail (sent_max 5), at **no latency cost** (251s ≤ base 263s), parse-retry parity, all runs ok. Sampled transcripts confirmed real two-beat *concede + counter* arguments, not padding. **en is empirically inert** (statements stay ~1 sentence across all arms, no regression) — mirrored for structural ja/en parity per `presets.md`, not for an en effect.

## Test plan
- New change-detector test `lastFableSpeakAllPinsMaxSentencesOverride()` — pins `last_fable`/`last_fable_en` `speak_all` `max_sentences == 6`. Guards the deliverable: value-level preset content is otherwise unguarded (fixture suites key on ids/schema/tokens), so a future `git add -A` catalog re-serialization or editor round-trip could silently drop the key with every gate green (`view-testing.md` § change-detector tripwire).
- `PresetLoaderTests` (11 tests incl. fixture-coupling + `presetYAMLsPassValidateForCommit`) — green.
- Full unit suite: 2931 tests / 236 suites — green. `swiftlint --strict` clean.
- `pastura-harness lint` on both presets — 0 errors, 0 warnings (confirms `max_sentences` parses; `speak_all` is `requiresLLM` so no Stage-2 R18 no-op warning).

## Device QA
実機QA不要 — preset data + test only, no `#if !targetEnvironment(simulator)` / Metal / layout surface. The LLM-behavior gain is validated by the harness A/B on gemma-4-E2B, which *is* the on-device inference path (TestFlight backend). Optional: play `last_fable` on TestFlight to feel the fuller nightly pleas in live sim playback.

Closes #881