### PR TITLE
♻️ refactor: swap Engine locks to Mutex, drop import os (#501)

### DIFF
--- a/Pastura/Pastura/Engine/SimulationRunner+PauseState.swift
+++ b/Pastura/Pastura/Engine/SimulationRunner+PauseState.swift
@@ -1,0 +1,38 @@
+import Synchronization
+
+// `nonisolated` on the extension per swift-isolation.md Pattern 3: a sibling-file
+// extension on the `nonisolated` `SimulationRunner` otherwise inherits MainActor
+// and breaks the main file's nonisolated callers (the pause path is all static /
+// nonisolated). Split out of SimulationRunner.swift to keep that file under the
+// `file_length` limit.
+nonisolated extension SimulationRunner {
+  /// Bundles the pause flag and an optional resume continuation in a single lock,
+  /// so the setter can atomically detect "unpaused while someone is waiting" and
+  /// resume the continuation without a race.
+  ///
+  /// Sendable: all access is serialized through the enclosing `Mutex`.
+  struct PauseState: Sendable {
+    var isPaused = false
+    var resumeContinuation: CheckedContinuation<Void, Never>?
+    /// Set by `resumeOnce()` whenever no continuation is currently stored.
+    /// The next store attempt inside `checkPaused` consumes this flag and
+    /// short-circuits without suspending — mirrors the existing
+    /// `Task.isCancelled` race handling. Covers both the emit-before-store
+    /// window and any pre-arm from outside an active pause cycle.
+    var pendingResume = false
+  }
+
+  /// Reference-typed box so the non-copyable `Mutex` can be shared by
+  /// reference through the value-type `ExecutionContext`. `OSAllocatedUnfairLock`
+  /// was itself a class and gave this sharing for free; `Mutex` is a `~Copyable`
+  /// struct, so the box is now explicit.
+  final class PauseGate: Sendable {
+    private let mutex = Mutex<PauseState>(PauseState())
+    // `sending` on the parameter and result mirror `Mutex.withLock`'s exact
+    // signature — `PauseState` carries a non-`Sendable` `CheckedContinuation`,
+    // so the closure transfers it in/out under the lock rather than sharing it.
+    func withLock<R>(_ body: (inout sending PauseState) -> sending R) -> sending R {
+      mutex.withLock(body)
+    }
+  }
+}

--- a/Pastura/Pastura/Engine/SimulationRunner.swift
+++ b/Pastura/Pastura/Engine/SimulationRunner.swift
@@ -1,5 +1,5 @@
 import Foundation
-import os
+import Synchronization
 
 /// Orchestrates simulation execution, emitting events via `AsyncStream`.
 ///
@@ -7,25 +7,10 @@ import os
 /// dispatching each phase to the appropriate handler. Supports pause/resume via
 /// `isPaused` flag and cancellation via Swift `Task` cancellation.
 nonisolated public final class SimulationRunner: @unchecked Sendable {
-  // @unchecked Sendable: mutable pauseState is protected by OSAllocatedUnfairLock.
+  // @unchecked Sendable: mutable pauseState is protected by the PauseGate's Mutex.
+  // `PauseState` + `PauseGate` (the Mutex box) live in SimulationRunner+PauseState.swift.
 
-  /// Bundles the pause flag and an optional resume continuation in a single lock,
-  /// so the setter can atomically detect "unpaused while someone is waiting" and
-  /// resume the continuation without a race.
-  ///
-  /// Sendable: all access is serialized through the enclosing `OSAllocatedUnfairLock`.
-  private struct PauseState: Sendable {
-    var isPaused = false
-    var resumeContinuation: CheckedContinuation<Void, Never>?
-    /// Set by `resumeOnce()` whenever no continuation is currently stored.
-    /// The next store attempt inside `checkPaused` consumes this flag and
-    /// short-circuits without suspending — mirrors the existing
-    /// `Task.isCancelled` race handling. Covers both the emit-before-store
-    /// window and any pre-arm from outside an active pause cycle.
-    var pendingResume = false
-  }
-
-  private let pauseState = OSAllocatedUnfairLock(initialState: PauseState())
+  private let pauseState = PauseGate()
   private let dispatcher = PhaseDispatcher()
   private let validator = ScenarioValidator()
   private let detector: (any LanguageDetector)?
@@ -165,7 +150,7 @@ nonisolated public final class SimulationRunner: @unchecked Sendable {
     let scenario: Scenario
     let llm: LLMService
     let dispatcher: PhaseDispatcher
-    let pauseState: OSAllocatedUnfairLock<PauseState>
+    let pauseState: PauseGate
     let suspendController: SuspendController
     let detector: (any LanguageDetector)?
     let logger: any EngineLogger
@@ -180,7 +165,7 @@ nonisolated public final class SimulationRunner: @unchecked Sendable {
   private static func executeSimulation(
     scenario: Scenario, llm: LLMService,
     dispatcher: PhaseDispatcher, validator: ScenarioValidator,
-    pauseState: OSAllocatedUnfairLock<PauseState>,
+    pauseState: PauseGate,
     suspendController: SuspendController,
     detector: (any LanguageDetector)?,
     logger: any EngineLogger,
@@ -265,7 +250,7 @@ nonisolated public final class SimulationRunner: @unchecked Sendable {
 
     // Why withTaskCancellationHandler + withCheckedContinuation:
     // We need to resume the continuation on EITHER unpause (via isPaused setter)
-    // or task cancellation (via onCancel). The OSAllocatedUnfairLock serializes
+    // or task cancellation (via onCancel). The Mutex serializes
     // all three resume paths (setter, onCancel, and the in-closure isCancelled
     // check) so the continuation is resumed exactly once.
     //

--- a/Pastura/Pastura/Engine/TurnFailureGate.swift
+++ b/Pastura/Pastura/Engine/TurnFailureGate.swift
@@ -1,5 +1,5 @@
 import Foundation
-import os
+import Synchronization
 
 /// Run-scoped containment gate for LLM turn failures (ADR-021 D1–D4).
 ///
@@ -15,7 +15,7 @@ import os
 /// (`ConditionalHandler`) must thread the parent context's gate into the
 /// sub-phase contexts — a fresh gate inside a branch would silently reset
 /// the consecutive-skip counter. The reference semantics plus the
-/// `OSAllocatedUnfairLock` are what make the counter run-scoped;
+/// `Mutex` are what make the counter run-scoped;
 /// `PhaseContext` itself is a value type rebuilt per phase. The counter is
 /// deliberately NOT part of `SimulationState`: a resumed run starts at 0.
 nonisolated public final class TurnFailureGate: Sendable {
@@ -25,7 +25,7 @@ nonisolated public final class TurnFailureGate: Sendable {
   /// through the rest of the scenario — not a per-model tuning contract.
   public static let consecutiveSkipLimit = 3
 
-  private let consecutiveSkips = OSAllocatedUnfairLock<Int>(initialState: 0)
+  private let consecutiveSkips = Mutex<Int>(0)
 
   public init() {}
 


### PR DESCRIPTION
## Summary

KMP Phase 3.0 **Stage-0 "lock-seam" follow-up** (ADR-023 §6, #501) — remove the last `import os` from the Engine layer so it can port to Kotlin `commonMain` cleanly. Swaps both remaining Engine `OSAllocatedUnfairLock` uses to `Synchronization.Mutex` (min iOS 18 / ADR-013 harness macOS 15 both cover `Mutex`).

- **`TurnFailureGate`**: class-owned lock → direct `Mutex<Int>(0)` swap.
- **`SimulationRunner`**: `pauseState` is shared **by value** into the value-type `ExecutionContext`, and `Mutex` is `~Copyable`, so a reference-type **`PauseGate`** box wraps `Mutex<PauseState>` and forwards `withLock` (with `sending` on the closure param/result to match `Mutex.withLock`'s signature — `PauseState` carries a non-`Sendable` `CheckedContinuation`). The box reproduces the old shared-instance semantics `OSAllocatedUnfairLock` (a class) gave, so **all ~6 pause callsites are unchanged**.
- `PauseState` + `PauseGate` extracted to `SimulationRunner+PauseState.swift` (`nonisolated extension`, swift-isolation Pattern 3) to keep the main file under `file_length` (409 → 377).

**No behavior change** — the three-way resume-race serialization (setter / onCancel / in-closure `isCancelled`) is preserved by the same non-reentrant mutex.

Reviewed: 1 `critic` (pre-impl, caught the missing `nonisolated` on the box + the `sending` signature nit) + 1 `code-reviewer` (PASS, 0 issues).

## Test plan

- Acceptance: `rg -n '^import os$' Pastura/Pastura/Engine` = **0**.
- `swift build` (ADR-013 harness — compiles `SimulationRunner` for macOS 15) — ✅.
- Full unit suite (iOS, default-MainActor isolation): **2931 tests / 236 suites pass** — ✅.
- Regression guard `SimulationRunnerTests` + `TurnFailureGateTests` (pause/resume `pendingResume`/`onCancel` race + consecutive-skip counter): **23 tests pass** — ✅.
- `swiftlint lint --strict` clean — ✅.

## Device QA

実機QA不要 — pure Engine-layer refactor: no UI, no `#if !targetEnvironment(simulator)` block, no Metal / llama.cpp inference path, no isolation Pattern-6 executor surface. Behavior-preserving lock-primitive swap verified by the unit suite + harness build.

Part of #501.