### PR TITLE
✨ feat(kmp): empty shared/engine scaffold (#501 Stage 1 PR-2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -715,12 +715,19 @@ jobs:
       - name: Compile native klib (compile-only — per-PR default)
         if: steps.kmp-changes.outputs.full_native != 'true'
         timeout-minutes: 8
-        run: ./gradlew :shared:models:compileKotlinIosSimulatorArm64 --no-daemon --stacktrace
+        # `:shared:engine` (empty scaffold, #501 PR-2) compiles here too so
+        # future engine-source-only PRs (Stage 2-pre onward) are covered on the
+        # per-PR default path. The `:shared:engine` task token is identical to
+        # the full-native step below, so the two stay divergence-safe.
+        run: ./gradlew :shared:models:compileKotlinIosSimulatorArm64 :shared:engine:compileKotlinIosSimulatorArm64 --no-daemon --stacktrace
 
       - name: Full native build + XCFramework (build-config touch)
         if: steps.kmp-changes.outputs.full_native == 'true'
         timeout-minutes: 18
-        run: ./gradlew :shared:models:assemblePasturaSharedXCFramework --no-daemon --stacktrace
+        # `:shared:engine` has no XCFramework task yet (export deferred to
+        # Stage 5), so it is compiled alongside the models XCFramework assembly
+        # in the same Gradle invocation — one process, no second cold start.
+        run: ./gradlew :shared:models:assemblePasturaSharedXCFramework :shared:engine:compileKotlinIosSimulatorArm64 --no-daemon --stacktrace
 
       - name: Upload Gradle reports (on failure)
         if: failure()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,9 @@
 // Pastura KMP integration (Issue #220 — KMP Models Layer Validation Spike).
 // Per ADR-004 §6 (Draft) and #220 D1, Gradle modules mirror Swift layers:
-// `shared/{models,llm,engine,data,utilities}`. W1 covers only `shared/models`.
+// `shared/{models,llm,engine,data,utilities}`. `shared/models` landed as
+// infrastructure in #501 Stage 1 PR-1; `shared/engine` is added here (PR-2) as
+// an empty scaffold — the landing pad for the Stage 2-pre ConditionEvaluator
+// port (ADR-023 §6). The remaining layer modules follow with their ports.
 
 rootProject.name = "Pastura"
 
@@ -20,3 +23,4 @@ dependencyResolutionManagement {
 }
 
 include(":shared:models")
+include(":shared:engine")

--- a/shared/engine/build.gradle.kts
+++ b/shared/engine/build.gradle.kts
@@ -1,0 +1,61 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+// `shared/engine` — Kotlin Multiplatform port target for Pastura's `Engine/`
+// Swift layer (Issue #501 / ADR-023). Landed here (Stage 1 PR-2) as an EMPTY
+// scaffold: it registers the module and its target set so the Stage 2-pre
+// `ConditionEvaluator` port has a compiling landing pad to drop into. No engine
+// logic ports in this PR (Stage 1 = infrastructure only).
+//
+// Deliberately minimal vs `shared/models`:
+//   - No `kotlin-serialization` plugin and no `snakeyaml-engine-kmp` — the
+//     engine run-path does not declare its own `@Serializable` types or parse
+//     YAML (that is Models' `YamlCodec`). Added in a later stage only if a
+//     ported handler actually needs them.
+//   - No framework/XCFramework export block — Swift consumption of the engine
+//     module is Stage 5 (iOS consumption switch, ADR-023 §6). Stage 1 only
+//     needs the module to compile (jvm + native klib).
+//
+// The `shared/models` dependency (Engine→Models, a CLAUDE.md hard rule) is
+// pulled forward from Stage 2-pre so this PR validates the Gradle module graph
+// + the models klib building as an upstream dependency. It is `implementation`
+// (matching the models module's own dep-scope convention) — promote to `api`
+// in Stage 2-pre only if `ConditionEvaluator`'s public API re-exports Models
+// types to a consumer.
+
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+}
+
+kotlin {
+    jvm {
+        // Pin bytecode target to JVM 17, matching `shared/models` (T2 in #220):
+        // JVM parity tests + the Stage 4 cross-language harness run on jvmTest.
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+        }
+    }
+
+    // iOS target triple mirrors `shared/models` so the eventual XCFramework
+    // (Stage 5) covers the same device + simulator + x64 set. No framework
+    // binary is declared here yet — Stage 1 only compiles the native klib.
+    iosArm64()
+    iosSimulatorArm64()
+    iosX64()
+
+    sourceSets {
+        commonMain.dependencies {
+            // Engine→Models layer edge. Inert at Stage 1 (no engine sources
+            // reference Models yet); present so the module graph is validated
+            // now rather than at the first ported symbol in Stage 2-pre.
+            implementation(project(":shared:models"))
+        }
+        commonTest.dependencies {
+            implementation(kotlin("test"))
+            // `commonMain` uses `implementation` for the models edge, so it is
+            // not transitively on the test compile classpath — add it explicitly
+            // so Stage 2-pre's `ConditionEvaluator` tests can reference Models
+            // types the moment they land (mirrors `shared/models`'s pattern).
+            implementation(project(":shared:models"))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

KMP Engine migration **Stage 1, PR-2** (ADR-023 §6). Adds an **empty** `shared/engine` Kotlin Multiplatform module beside `shared/models` (landed in PR-1 #1052) — the compiling **landing pad** for the Stage 2-pre `ConditionEvaluator` port. Infrastructure only; **no engine logic ports here**.

- `settings.gradle.kts` — `include(":shared:engine")` + comment update.
- `shared/engine/build.gradle.kts` — kotlin-multiplatform only; `jvm` (JVM 17) + `iosArm64`/`iosSimulatorArm64`/`iosX64`; empty `commonMain`/`commonTest`. Carries the **Engine→Models** edge as `implementation(project(":shared:models"))` — deliberately **pulled forward from Stage 2-pre** so this PR validates the Gradle module graph + the models klib building as an upstream dependency. Deliberately **omits** the serialization plugin, `snakeyaml-engine-kmp`, and the framework/XCFramework export block (added only in the stages that need them; Swift consumption is Stage 5). `implementation` (not `api`) matches the `shared/models` dep-scope convention — promote to `api` in 2-pre only if `ConditionEvaluator`'s public API re-exports Models types.
- `.github/workflows/ci.yml` — adds `:shared:engine:compileKotlinIosSimulatorArm64` to **both** the `kmp-build-test` compile-only step (per-PR default) and the full-native step (appended to the existing XCFramework invocation, one Gradle process). Identical `:shared:engine` task token across both steps keeps them divergence-safe.

**CI path note:** this PR touches build-config (`settings.gradle.kts` + `build.gradle.kts`), so the classifier promotes it to **full-native** — the full-native engine line runs on this PR's CI; the **compile-only** engine line first runs in CI at Stage 2-pre (an engine-source-only PR). Both paths were verified locally (below).

Empty-module compile emits `:shared:engine:compileKotlinIosSimulatorArm64 NO-SOURCE` — the expected "commonMain compiles empty" DoD signal, with the models klib built as its upstream dependency.

## Test plan

Local Gradle verification of the exact commands this PR's CI runs:

- compile-only path (future Stage 2-pre): `./gradlew :shared:models:compileKotlinIosSimulatorArm64 :shared:engine:compileKotlinIosSimulatorArm64` → **BUILD SUCCESSFUL (6s)**
- full-native path (this PR): `./gradlew :shared:models:assemblePasturaSharedXCFramework :shared:engine:compileKotlinIosSimulatorArm64` → **BUILD SUCCESSFUL (2m21s)**, `PasturaShared.xcframework` written, engine `NO-SOURCE`
- `ci.yml` YAML validated; `code-reviewer` (Opus) PASS, 0 blocking.

Satisfies the Stage 1 DoD items: `shared/engine` green-builds, commonMain compiles empty, `assemblePasturaSharedXCFramework` green.

## Device QA

実機QA不要 — Gradle/CI 設定のみ。Swift 変更ゼロ、シミュレータ除外ブロック・Metal/推論経路への影響なし。

Part of #501