### PR TITLE
✨ feat(kmp): port ConditionEvaluator to shared/engine (#501 Stage 2-pre)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -705,7 +705,11 @@ jobs:
 
       - name: Run JVM tests
         timeout-minutes: 8
-        run: ./gradlew :shared:models:jvmTest --no-daemon --stacktrace
+        # `:shared:engine:jvmTest` runs here too since Stage 2-pre (#501) — the
+        # ported ConditionEvaluator commonTest is the cross-language executable
+        # spec and must run per-PR on JVM, not only nightly-native. Before it,
+        # `:shared:engine` had no commonTest (jvmTest was NO-SOURCE).
+        run: ./gradlew :shared:models:jvmTest :shared:engine:jvmTest --no-daemon --stacktrace
 
       # The per-PR budget tripwire lives HERE, on the compile-only step, so a
       # silently-growing compile-only (Gradle pulling in link deps, or native

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/ConditionEvaluator.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/ConditionEvaluator.kt
@@ -1,0 +1,609 @@
+package com.pastura.engine
+
+import com.pastura.models.Scenario
+import com.pastura.models.SimulationError
+import com.pastura.models.SimulationState
+
+/**
+ * Evaluates a boolean condition expression used by the `conditional` phase
+ * type. Supports `&&` / `||` combinators and parenthesized grouping on top of a
+ * single-comparison primitive.
+ *
+ * Kotlin port of `Pastura/Pastura/Engine/ConditionEvaluator.swift` +
+ * `ConditionEvaluator+Parser.swift` (#501 Stage 2-pre / ADR-023 §6). The Swift
+ * original splits tokenizer/parser into a sibling `nonisolated extension` to
+ * dodge a default-MainActor isolation trap; Kotlin has no such trap, so the
+ * whole grammar (public API, walker, resolver, tokenizer, recursive-descent
+ * parser) lives in this one file. The Swift `ConditionEvaluator` is NOT deleted —
+ * iOS keeps using it; this port runs in parallel until the Stage-5 consumption
+ * switch. `ConditionEvaluatorTests` (commonTest) is the cross-language executable
+ * spec.
+ *
+ * Grammar:
+ * ```
+ * expression ::= or
+ * or         ::= and ('||' and)*
+ * and        ::= factor ('&&' factor)*
+ * factor     ::= '(' or ')'  |  comparison
+ * comparison ::= operand OP operand
+ * OP         ::= "==" | "!=" | "<=" | ">=" | "<" | ">"
+ * operand    ::= Identifier ("." Identifier)? | NumberLiteral | StringLiteral
+ * StringLiteral ::= '"' .* '"'
+ * ```
+ *
+ * Precedence (loosest to tightest): `||` < `&&` < comparison. Both are
+ * left-associative. Parens group any boolean sub-expression; an operand itself
+ * cannot be parenthesized (`(current_round) == 1` is rejected).
+ *
+ * Tokenization is quote-aware: operator-like characters inside a quoted string
+ * literal (`"a && b"`, `"x>y"`, `"(foo)"`) are literal content, not tokens.
+ *
+ * Derived read-only variables (either side of a comparison): `current_round`,
+ * `total_rounds`, `max_score`, `min_score`, `eliminated_count`, `active_count`,
+ * `vote_winner` (most-voted name, ties broken like `EliminateHandler`),
+ * `scores.<Name>`. Any other identifier resolves from `state.variables`.
+ *
+ * **Parse-time errors** (missing operator, empty operand, mismatched/empty
+ * parens, dangling `&&`/`||`, unterminated string) throw a [SimulationException]
+ * carrying [SimulationError.ScenarioValidationFailed]. (Swift throws the sealed
+ * `SimulationError` directly; Kotlin's is not a `Throwable`, so the Engine wraps
+ * it — see [SimulationException].) Use [parse] to fail fast at scenario-load time.
+ *
+ * **Runtime-absent values** (e.g. `vote_winner` pre-vote, `scores.Nobody`) do NOT
+ * throw; the comparison returns `value = false` and appends a warning to
+ * [EvaluationResult.warnings].
+ *
+ * **Short-circuit policy** (Swift-style): the dropped side of `false && X` /
+ * `true || X` is NOT resolved, so absent-variable warnings on the skipped branch
+ * never appear.
+ *
+ * **Cross-language numeric parity.** Numeric detection uses a fixed decimal-literal
+ * regex ([numericLiteralRegex]) rather than raw `String.toDoubleOrNull()`, which
+ * would accept `"Infinity"` / `"NaN"` / type-suffixed literals Swift's
+ * `Double(String)` does not, and reject the hex-floats Swift accepts. A token is
+ * numeric iff it is a plain optionally-signed decimal with optional fraction /
+ * exponent — identical in Swift and Kotlin on that grammar. Accepted, documented
+ * divergences (out-of-domain — real operands are integers or names): `Infinity` /
+ * `NaN` / hex (`0x10`) / suffix (`1f`) take the string path here; Swift's
+ * `Double()` would treat some as numbers. Pinned by `ConditionEvaluatorParityTests`.
+ */
+public class ConditionEvaluator {
+
+    /** Result of evaluating a condition expression. */
+    public data class EvaluationResult(
+        /**
+         * The evaluated boolean. `false` when a comparison's operand is
+         * runtime-absent, or when the sub-expression's truth value (and
+         * short-circuit policy) drives it false.
+         */
+        public val value: Boolean,
+        /**
+         * Non-fatal diagnostics (e.g. runtime-absent variables). Warnings from
+         * short-circuited sub-expressions are suppressed by design.
+         */
+        public val warnings: List<String>,
+    )
+
+    /** Lexical token classes recognized by the DSL. */
+    internal sealed interface Token {
+        data object OpenParen : Token
+        data object CloseParen : Token
+        data object LogicalAnd : Token
+        data object LogicalOr : Token
+        data class ComparisonOp(val symbol: String) : Token
+
+        /**
+         * String preserving its source form: numbers as their digits, bare
+         * identifiers as-is (including dotted access like `scores.Alice`), and
+         * quoted strings WITH surrounding `"` so the resolver can distinguish
+         * `Alice` (identifier) from `"Alice"` (string literal).
+         */
+        data class Operand(val text: String) : Token
+    }
+
+    /** AST node for the parsed expression (Swift's `indirect enum`). */
+    internal sealed interface Node {
+        data class LogicalOr(val lhs: Node, val rhs: Node) : Node
+        data class LogicalAnd(val lhs: Node, val rhs: Node) : Node
+        data class Comparison(val lhs: String, val symbol: String, val rhs: String) : Node
+    }
+
+    /**
+     * Evaluates [expression] against [state] and [scenario].
+     *
+     * @throws SimulationException carrying [SimulationError.ScenarioValidationFailed]
+     *   for parse-time errors.
+     */
+    public fun evaluate(
+        expression: String,
+        state: SimulationState,
+        scenario: Scenario,
+    ): EvaluationResult {
+        val ast = parseToAST(expression)
+        return walk(ast, state, scenario)
+    }
+
+    /**
+     * Parses [expression] and discards the AST. Used to surface malformed `if:`
+     * strings at scenario-load time, before any `state` exists.
+     *
+     * @throws SimulationException on syntactic errors. Runtime-absent identifiers
+     *   do NOT throw — those only surface during [evaluate] as warnings.
+     */
+    public fun parse(expression: String) {
+        parseToAST(expression)
+    }
+
+    // MARK: - AST walker (with short-circuit)
+
+    private fun walk(node: Node, state: SimulationState, scenario: Scenario): EvaluationResult =
+        when (node) {
+            is Node.Comparison ->
+                walkComparison(node.lhs, node.symbol, node.rhs, state, scenario)
+
+            is Node.LogicalAnd -> {
+                val lhsResult = walk(node.lhs, state, scenario)
+                // Short-circuit: dropped side is NOT resolved, so its warnings
+                // never enter the result. Documented Swift-style policy.
+                if (!lhsResult.value) {
+                    lhsResult
+                } else {
+                    val rhsResult = walk(node.rhs, state, scenario)
+                    EvaluationResult(rhsResult.value, lhsResult.warnings + rhsResult.warnings)
+                }
+            }
+
+            is Node.LogicalOr -> {
+                val lhsResult = walk(node.lhs, state, scenario)
+                if (lhsResult.value) {
+                    lhsResult
+                } else {
+                    val rhsResult = walk(node.rhs, state, scenario)
+                    EvaluationResult(rhsResult.value, lhsResult.warnings + rhsResult.warnings)
+                }
+            }
+        }
+
+    private fun walkComparison(
+        lhs: String,
+        symbol: String,
+        rhs: String,
+        state: SimulationState,
+        scenario: Scenario,
+    ): EvaluationResult {
+        val warnings = mutableListOf<String>()
+        val lhsValue = resolve(lhs, state, scenario, warnings)
+        val rhsValue = resolve(rhs, state, scenario, warnings)
+        if (lhsValue == null || rhsValue == null) {
+            return EvaluationResult(false, warnings)
+        }
+        return EvaluationResult(compare(lhsValue, symbol, rhsValue), warnings)
+    }
+
+    // MARK: - Operand resolution
+
+    /**
+     * Resolves a token to a string value, or `null` if the identifier refers to
+     * data not present at runtime (with a warning appended to [warnings]).
+     */
+    private fun resolve(
+        token: String,
+        state: SimulationState,
+        scenario: Scenario,
+        warnings: MutableList<String>,
+    ): String? {
+        if (token.length >= 2 && token.startsWith("\"") && token.endsWith("\"")) {
+            return token.substring(1, token.length - 1)
+        }
+        if (isNumericLiteral(token)) {
+            return token
+        }
+        val dotIndex = token.indexOf('.')
+        if (dotIndex >= 0) {
+            return resolveDotted(token, dotIndex, state, warnings)
+        }
+
+        when (val derived = resolveDerived(token, state, scenario, warnings)) {
+            is DerivedResolution.Value -> return derived.value
+            DerivedResolution.Absent -> return null
+            DerivedResolution.NotDerived -> Unit
+        }
+
+        state.variables[token]?.let { return it }
+        warnings.add("Unknown identifier '$token'")
+        return null
+    }
+
+    private fun resolveDotted(
+        token: String,
+        dotIndex: Int,
+        state: SimulationState,
+        warnings: MutableList<String>,
+    ): String? {
+        val head = token.substring(0, dotIndex)
+        val tail = token.substring(dotIndex + 1)
+        if (head == "scores") {
+            state.scores[tail]?.let { return it.toString() }
+            warnings.add("scores.$tail is not set (agent absent from scores)")
+            return null
+        }
+        warnings.add("Unknown dotted identifier '$token'")
+        return null
+    }
+
+    /** Tri-state result for derived-variable resolution. */
+    private sealed interface DerivedResolution {
+        data class Value(val value: String) : DerivedResolution
+
+        /** Recognized as derived but has no runtime value (warning already appended). */
+        data object Absent : DerivedResolution
+
+        /** Not a derived variable at all; caller falls through to `state.variables`. */
+        data object NotDerived : DerivedResolution
+    }
+
+    private fun resolveDerived(
+        identifier: String,
+        state: SimulationState,
+        scenario: Scenario,
+        warnings: MutableList<String>,
+    ): DerivedResolution {
+        resolveAlwaysPresentDerived(identifier, state, scenario)?.let {
+            return DerivedResolution.Value(it)
+        }
+        return resolveMayBeAbsentDerived(identifier, state, warnings)
+    }
+
+    private fun resolveAlwaysPresentDerived(
+        identifier: String,
+        state: SimulationState,
+        scenario: Scenario,
+    ): String? = when (identifier) {
+        "current_round" -> state.currentRound.toString()
+        "total_rounds" -> scenario.rounds.toString()
+        "eliminated_count" -> state.eliminated.values.count { it }.toString()
+        "active_count" -> state.eliminated.values.count { !it }.toString()
+        else -> null
+    }
+
+    private fun resolveMayBeAbsentDerived(
+        identifier: String,
+        state: SimulationState,
+        warnings: MutableList<String>,
+    ): DerivedResolution = when (identifier) {
+        "max_score" ->
+            resolveScoreExtremum(state.scores.values.maxOrNull(), "max_score", warnings)
+
+        "min_score" ->
+            resolveScoreExtremum(state.scores.values.minOrNull(), "min_score", warnings)
+
+        "vote_winner" -> {
+            // Deterministic tie-break mirrors EliminateHandler: sort by
+            // (count desc, name desc) and take the first. Kotlin string order
+            // (UTF-16) matches Swift scalar order across the BMP (agent names);
+            // see the port's numeric/ordering-parity doc note and
+            // ConditionEvaluatorParityTests. Future parity with a ported
+            // EliminateHandler is a Stage-3 concern.
+            val top = state.voteResults.entries
+                .sortedWith(
+                    compareByDescending<Map.Entry<String, Int>> { it.value }
+                        .thenByDescending { it.key },
+                )
+                .firstOrNull()
+            if (top != null) {
+                DerivedResolution.Value(top.key)
+            } else {
+                warnings.add("vote_winner has no value (no vote phase has run this round)")
+                DerivedResolution.Absent
+            }
+        }
+
+        else -> DerivedResolution.NotDerived
+    }
+
+    private fun resolveScoreExtremum(
+        value: Int?,
+        label: String,
+        warnings: MutableList<String>,
+    ): DerivedResolution {
+        if (value != null) {
+            return DerivedResolution.Value(value.toString())
+        }
+        warnings.add("$label has no value (scores is empty)")
+        return DerivedResolution.Absent
+    }
+
+    // MARK: - Comparison
+
+    private fun compare(lhs: String, symbol: String, rhs: String): Boolean {
+        val lhsNum = numericValue(lhs)
+        val rhsNum = numericValue(rhs)
+        if (lhsNum != null && rhsNum != null) {
+            return applyOperator(symbol, lhsNum, rhsNum)
+        }
+        return applyOperator(symbol, lhs, rhs)
+    }
+
+    private fun applyOperator(symbol: String, lhs: Double, rhs: Double): Boolean = when (symbol) {
+        "==" -> lhs == rhs
+        "!=" -> lhs != rhs
+        "<" -> lhs < rhs
+        "<=" -> lhs <= rhs
+        ">" -> lhs > rhs
+        ">=" -> lhs >= rhs
+        else -> false
+    }
+
+    private fun applyOperator(symbol: String, lhs: String, rhs: String): Boolean = when (symbol) {
+        "==" -> lhs == rhs
+        "!=" -> lhs != rhs
+        "<" -> lhs < rhs
+        "<=" -> lhs <= rhs
+        ">" -> lhs > rhs
+        ">=" -> lhs >= rhs
+        else -> false
+    }
+
+    // MARK: - Tokenizer
+
+    private fun tokenize(expression: String): List<Token> {
+        val chars = expression
+        val tokens = mutableListOf<Token>()
+        var index = 0
+
+        while (index < chars.length) {
+            val char = chars[index]
+            if (char.isWhitespace()) {
+                index += 1
+                continue
+            }
+            // Two-char operators scanned before single-char prefixes so `<=` is
+            // not split into `<` + `=`, and `&&` / `||` are not read as bare chars.
+            val multi = readMultiCharToken(chars, index)
+            if (multi != null) {
+                tokens.add(multi.first)
+                index += multi.second
+                continue
+            }
+            val single = readSingleCharToken(chars, index)
+            if (single != null) {
+                tokens.add(single.first)
+                index += single.second
+                continue
+            }
+            if (char == '"') {
+                val quoted = readQuotedOperand(chars, index, expression)
+                tokens.add(quoted.first)
+                index = quoted.second
+                continue
+            }
+            val bare = readBareOperand(chars, index, expression)
+            tokens.add(bare.first)
+            index = bare.second
+        }
+
+        return tokens
+    }
+
+    /** Two-character operators (`&&`, `||`, `==`, `!=`, `<=`, `>=`); `null` otherwise. */
+    private fun readMultiCharToken(chars: String, index: Int): Pair<Token, Int>? {
+        if (index + 1 >= chars.length) return null
+        val pair = chars.substring(index, index + 2)
+        return when (pair) {
+            "&&" -> Token.LogicalAnd to 2
+            "||" -> Token.LogicalOr to 2
+            "==", "!=", "<=", ">=" -> Token.ComparisonOp(pair) to 2
+            else -> null
+        }
+    }
+
+    /** Single-character tokens (`(`, `)`, `<`, `>`); `null` otherwise. */
+    private fun readSingleCharToken(chars: String, index: Int): Pair<Token, Int>? =
+        when (chars[index]) {
+            '(' -> Token.OpenParen to 1
+            ')' -> Token.CloseParen to 1
+            '<', '>' -> Token.ComparisonOp(chars[index].toString()) to 1
+            else -> null
+        }
+
+    /** Quoted string operand. Keeps the surrounding `"` so the resolver can tell literals apart. */
+    private fun readQuotedOperand(chars: String, index: Int, source: String): Pair<Token, Int> {
+        var end = index + 1
+        while (end < chars.length && chars[end] != '"') {
+            end += 1
+        }
+        if (end >= chars.length) {
+            throw SimulationException(
+                SimulationError.ScenarioValidationFailed(
+                    "Condition expression '$source' has unterminated string literal",
+                ),
+            )
+        }
+        return Token.Operand(chars.substring(index, end + 1)) to (end + 1)
+    }
+
+    /**
+     * Bare operand: identifier, number, or dotted access. Accumulates until a
+     * delimiter (whitespace, paren, quote, operator-prefix) is hit.
+     */
+    private fun readBareOperand(chars: String, index: Int, source: String): Pair<Token, Int> {
+        var end = index
+        while (end < chars.length && !isOperandDelimiter(chars, end)) {
+            end += 1
+        }
+        if (end == index) {
+            throw SimulationException(
+                SimulationError.ScenarioValidationFailed(
+                    "Condition expression '$source' contains unexpected character '${chars[index]}'",
+                ),
+            )
+        }
+        return Token.Operand(chars.substring(index, end)) to end
+    }
+
+    /** True when `chars[end]` starts a delimiter that terminates a bare operand. */
+    private fun isOperandDelimiter(chars: String, end: Int): Boolean {
+        val next = chars[end]
+        if (next.isWhitespace()) return true
+        if (next == '(' || next == ')' || next == '"') return true
+        if (next == '<' || next == '>') return true
+        if (end + 1 < chars.length) {
+            val pair = chars.substring(end, end + 2)
+            if (pair == "&&" || pair == "||" ||
+                pair == "==" || pair == "!=" ||
+                pair == "<=" || pair == ">="
+            ) {
+                return true
+            }
+        }
+        return false
+    }
+
+    // MARK: - Parser entry point
+
+    private fun parseToAST(expression: String): Node {
+        val tokens = tokenize(expression)
+        if (tokens.isEmpty()) {
+            throw SimulationException(
+                SimulationError.ScenarioValidationFailed(
+                    "Condition expression '$expression' is empty",
+                ),
+            )
+        }
+        val parser = Parser(tokens, expression)
+        val node = parser.parseOr()
+        if (parser.position < tokens.size) {
+            throw SimulationException(
+                SimulationError.ScenarioValidationFailed(
+                    "Condition expression '$expression' has unexpected trailing token " +
+                        "near position ${parser.position} (likely an unmatched ')' or extra operator)",
+                ),
+            )
+        }
+        return node
+    }
+
+    /**
+     * Recursive-descent parser. [position] is the cursor into [tokens]; each
+     * `parseX` advances it past the tokens it consumed.
+     */
+    private class Parser(
+        private val tokens: List<Token>,
+        private val source: String,
+    ) {
+        var position: Int = 0
+
+        private fun peek(): Token? = if (position < tokens.size) tokens[position] else null
+
+        private fun advance() {
+            position += 1
+        }
+
+        fun parseOr(): Node {
+            var lhs = parseAnd()
+            while (peek() == Token.LogicalOr) {
+                advance()
+                val rhs = parseAnd()
+                lhs = Node.LogicalOr(lhs, rhs)
+            }
+            return lhs
+        }
+
+        private fun parseAnd(): Node {
+            var lhs = parseFactor()
+            while (peek() == Token.LogicalAnd) {
+                advance()
+                val rhs = parseFactor()
+                lhs = Node.LogicalAnd(lhs, rhs)
+            }
+            return lhs
+        }
+
+        private fun parseFactor(): Node {
+            if (peek() == Token.OpenParen) {
+                advance()
+                // Empty parens `()` — guard so the message is specific rather than
+                // the generic "expected operand (got ')')" from parseComparison.
+                if (peek() == Token.CloseParen) {
+                    throw SimulationException(
+                        SimulationError.ScenarioValidationFailed(
+                            "Condition expression '$source' has empty parentheses '()'",
+                        ),
+                    )
+                }
+                val inner = parseOr()
+                if (peek() != Token.CloseParen) {
+                    throw SimulationException(
+                        SimulationError.ScenarioValidationFailed(
+                            "Condition expression '$source' is missing ')' to close a " +
+                                "parenthesized sub-expression",
+                        ),
+                    )
+                }
+                advance()
+                return inner
+            }
+            return parseComparison()
+        }
+
+        private fun parseComparison(): Node {
+            val lhsToken = peek()
+            if (lhsToken !is Token.Operand) {
+                throw SimulationException(
+                    SimulationError.ScenarioValidationFailed(
+                        "Condition expression '$source' expected an operand ${describeUnexpected()}",
+                    ),
+                )
+            }
+            advance()
+            val opToken = peek()
+            if (opToken !is Token.ComparisonOp) {
+                throw SimulationException(
+                    SimulationError.ScenarioValidationFailed(
+                        "Condition expression '$source' expected a comparison operator " +
+                            "(==, !=, <, <=, >, >=) after '${lhsToken.text}' ${describeUnexpected()}",
+                    ),
+                )
+            }
+            advance()
+            val rhsToken = peek()
+            if (rhsToken !is Token.Operand) {
+                throw SimulationException(
+                    SimulationError.ScenarioValidationFailed(
+                        "Condition expression '$source' expected an operand after " +
+                            "'${lhsToken.text} ${opToken.symbol}' ${describeUnexpected()}",
+                    ),
+                )
+            }
+            advance()
+            return Node.Comparison(lhsToken.text, opToken.symbol, rhsToken.text)
+        }
+
+        /** Short " (got 'X')" hint for the current token, or end-of-expression. */
+        private fun describeUnexpected(): String =
+            when (val token = peek()) {
+                null -> "(reached end of expression)"
+                Token.OpenParen -> "(got '(')"
+                Token.CloseParen -> "(got ')')"
+                Token.LogicalAnd -> "(got '&&')"
+                Token.LogicalOr -> "(got '||')"
+                is Token.ComparisonOp -> "(got '${token.symbol}')"
+                is Token.Operand -> "(got '${token.text}')"
+            }
+    }
+
+    private companion object {
+        /**
+         * A plain optionally-signed decimal with optional fraction / exponent.
+         * Used for numeric detection in both [resolve] and [compare] so the
+         * numeric-vs-string branch is identical across Swift and Kotlin — see the
+         * class doc note on cross-language numeric parity.
+         */
+        private val numericLiteralRegex = Regex("^[+-]?[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?$")
+
+        private fun isNumericLiteral(token: String): Boolean = numericLiteralRegex.matches(token)
+
+        private fun numericValue(token: String): Double? =
+            if (isNumericLiteral(token)) token.toDouble() else null
+    }
+}

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/ConditionEvaluator.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/ConditionEvaluator.kt
@@ -58,14 +58,16 @@ import com.pastura.models.SimulationState
  * never appear.
  *
  * **Cross-language numeric parity.** Numeric detection uses a fixed decimal-literal
- * regex ([numericLiteralRegex]) rather than raw `String.toDoubleOrNull()`, which
- * would accept `"Infinity"` / `"NaN"` / type-suffixed literals Swift's
- * `Double(String)` does not, and reject the hex-floats Swift accepts. A token is
- * numeric iff it is a plain optionally-signed decimal with optional fraction /
- * exponent — identical in Swift and Kotlin on that grammar. Accepted, documented
- * divergences (out-of-domain — real operands are integers or names): `Infinity` /
- * `NaN` / hex (`0x10`) / suffix (`1f`) take the string path here; Swift's
- * `Double()` would treat some as numbers. Pinned by `ConditionEvaluatorParityTests`.
+ * regex ([numericLiteralRegex]) rather than raw `String.toDoubleOrNull()`. Neither
+ * raw parser is a stable cross-language predicate: Kotlin `toDoubleOrNull` accepts
+ * `"Infinity"` / `"NaN"` / type-suffixed literals (`"1f"`) that are not plain
+ * decimals, while Swift `Double(String)` accepts hex-floats (`"0x1p4"`) Kotlin
+ * rejects. The regex accepts a token iff it is a plain optionally-signed decimal
+ * with optional fraction / exponent — identical in Swift and Kotlin on that
+ * grammar. Everything else (`Infinity` / `NaN` / suffixed `1f` — normalizing
+ * Kotlin's laxer acceptance; hex-floats — the one Swift accepts) takes the string
+ * path. All out-of-domain: real operands are integers or names. Pinned by
+ * `ConditionEvaluatorParityTests`.
  */
 public class ConditionEvaluator {
 

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/SimulationException.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/SimulationException.kt
@@ -1,0 +1,46 @@
+package com.pastura.engine
+
+import com.pastura.models.SimulationError
+
+/**
+ * A [Throwable] carrier for a [SimulationError] so the KMP Engine port can
+ * `throw` a structured error value across its pure-logic call stack.
+ *
+ * **Why this exists:** Kotlin's [SimulationError] (in `shared/models`) is a
+ * `@Serializable sealed class`, deliberately NOT a `Throwable` — it is the wire
+ * shape shared with Swift, where `SimulationError` gains `Error` conformance
+ * only via a `LocalizedError` extension the Models layer omits. That type's
+ * doc-comment sanctions wrapping it "in a Kotlin `Throwable` subclass at [the
+ * Engine] layer" when the Engine needs to throw; this is that wrapper.
+ *
+ * **Provisional scope (#501 Stage 2-pre).** Introduced by the
+ * `ConditionEvaluator` port — the first engine logic to throw a
+ * [SimulationError]. ADR-023 §6 scopes this PR as a "tooling shakedown", NOT the
+ * Stage-2 GO/NO-GO gate, so the shape of this wrapper is **interim**: the durable
+ * throw-convention (which cases wrap, whether the 1:1 error→exception mapping
+ * holds) is ratified at the Stage-2 gate / Stage 3 once the full engine
+ * throw-surface is known. Today only [SimulationError.ScenarioValidationFailed]
+ * is thrown through it.
+ *
+ * The message mapping is a no-`else` exhaustive `when` over the sealed
+ * hierarchy on purpose: a new [SimulationError] case compile-breaks here,
+ * forcing a deliberate decision rather than silently defaulting.
+ *
+ * @property error the structured error carried across the throw boundary.
+ */
+public class SimulationException(
+    public val error: SimulationError,
+) : RuntimeException(messageFor(error)) {
+
+    private companion object {
+        private fun messageFor(error: SimulationError): String =
+            when (error) {
+                is SimulationError.ScenarioValidationFailed -> error.message
+                is SimulationError.LlmGenerationFailed -> error.description
+                is SimulationError.JsonParseFailed -> "JSON parse failed: ${error.raw}"
+                SimulationError.RetriesExhausted -> "LLM retries exhausted"
+                SimulationError.ModelNotLoaded -> "LLM model not loaded"
+                SimulationError.Cancelled -> "Simulation cancelled"
+            }
+    }
+}

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ConditionEvaluatorCombinatorTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ConditionEvaluatorCombinatorTests.kt
@@ -1,0 +1,265 @@
+package com.pastura.engine
+
+import com.pastura.models.SimulationState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Kotlin port of
+ * `Pastura/PasturaTests/Engine/ConditionEvaluatorTests+Combinators.swift` —
+ * `&&` / `||` / parens, precedence, left-associativity, short-circuit warning
+ * policy, and the parse-only entry point. Separate top-level class (not a Swift
+ * "extension") since Kotlin has no cross-file member extension; the two classes
+ * share [makeTestScenario].
+ */
+class ConditionEvaluatorCombinatorTests {
+    private val evaluator = ConditionEvaluator()
+
+    // MARK: - Combinators (&& / ||)
+
+    @Test
+    fun logicalAndBothTrue() {
+        val scenario = makeTestScenario(agentNames = listOf("A", "B", "C"), rounds = 5)
+        val state = SimulationState.initial(scenario)
+            .copy(currentRound = 3, eliminated = mapOf("A" to false, "B" to false, "C" to false))
+        val result = evaluator.evaluate("current_round > 0 && active_count > 1", state, scenario)
+        assertTrue(result.value)
+    }
+
+    @Test
+    fun logicalAndOneFalse() {
+        val scenario = makeTestScenario(agentNames = listOf("A", "B"), rounds = 5)
+        val state = SimulationState.initial(scenario)
+            .copy(currentRound = 3, scores = mapOf("A" to 1, "B" to 0))
+        // current_round > 0 (true) && max_score > 5 (false) → false
+        assertFalse(evaluator.evaluate("current_round > 0 && max_score > 5", state, scenario).value)
+    }
+
+    @Test
+    fun logicalOrFirstTrueShortCircuits() {
+        val scenario = makeTestScenario(agentNames = listOf("Alice", "Bob"))
+        val state = SimulationState.initial(scenario)
+            .copy(scores = mapOf("Alice" to 12, "Bob" to 0), voteResults = mapOf("Bob" to 1))
+        val result = evaluator.evaluate("max_score >= 10 || vote_winner == \"Alice\"", state, scenario)
+        assertTrue(result.value)
+    }
+
+    @Test
+    fun logicalOrSecondTrue() {
+        val scenario = makeTestScenario(agentNames = listOf("Alice", "Bob"))
+        val state = SimulationState.initial(scenario)
+            .copy(scores = mapOf("Alice" to 5, "Bob" to 0), voteResults = mapOf("Alice" to 2, "Bob" to 1))
+        val result = evaluator.evaluate("max_score >= 10 || vote_winner == \"Alice\"", state, scenario)
+        assertTrue(result.value)
+    }
+
+    // MARK: - Precedence: && binds tighter than ||
+
+    @Test
+    fun precedenceAndOverOrTrueViaAnd() {
+        // (a > 0 && b > 0) || c > 0  with a=1, b=1, c=0 → true
+        val scenario = makeTestScenario(agentNames = listOf("A", "B"), rounds = 5)
+        val state = SimulationState.initial(scenario).copy(variables = mapOf("a" to "1", "b" to "1", "c" to "0"))
+        assertTrue(evaluator.evaluate("a > 0 && b > 0 || c > 0", state, scenario).value)
+    }
+
+    @Test
+    fun precedenceAndOverOrTrueViaOr() {
+        // (a > 0 && b > 0) || c > 0  with a=0, b=1, c=1 → true (RHS of ||)
+        val scenario = makeTestScenario(agentNames = listOf("A", "B"), rounds = 5)
+        val state = SimulationState.initial(scenario).copy(variables = mapOf("a" to "0", "b" to "1", "c" to "1"))
+        assertTrue(evaluator.evaluate("a > 0 && b > 0 || c > 0", state, scenario).value)
+    }
+
+    @Test
+    fun precedenceOrAndAndPinsAndTighter() {
+        // a > 0 || b > 0 && c > 0  with a=1, b=1, c=0
+        // && tighter → a || (b && c) → 1 || (1 && 0) → true
+        // Equal-prec left-assoc would parse as (a || b) && c → (1 || 1) && 0 → false.
+        val scenario = makeTestScenario(agentNames = listOf("A", "B"), rounds = 5)
+        val state = SimulationState.initial(scenario).copy(variables = mapOf("a" to "1", "b" to "1", "c" to "0"))
+        assertTrue(evaluator.evaluate("a > 0 || b > 0 && c > 0", state, scenario).value)
+    }
+
+    // MARK: - Parentheses
+
+    @Test
+    fun parensOverridePrecedence() {
+        // (a > 0 || b > 0) && c > 0  with a=1, b=0, c=0 → false
+        // Without parens (&& tighter): a || (b && c) → 1 || 0 → true.
+        val scenario = makeTestScenario(agentNames = listOf("A", "B"), rounds = 5)
+        val state = SimulationState.initial(scenario).copy(variables = mapOf("a" to "1", "b" to "0", "c" to "0"))
+        assertFalse(evaluator.evaluate("(a > 0 || b > 0) && c > 0", state, scenario).value)
+    }
+
+    @Test
+    fun parensWithCombinatorMixingComparisonAndString() {
+        val scenario = makeTestScenario(agentNames = listOf("Alice", "Bob"), rounds = 5)
+        val state = SimulationState.initial(scenario).copy(
+            scores = mapOf("Alice" to 3, "Bob" to 1),
+            voteResults = mapOf("Alice" to 2, "Bob" to 0),
+            currentRound = 4,
+        )
+        val result = evaluator.evaluate(
+            "(max_score < 5 || vote_winner == \"Alice\") && current_round >= 3",
+            state,
+            scenario,
+        )
+        assertTrue(result.value)
+    }
+
+    @Test
+    fun deeplyNestedParensReduceCorrectly() {
+        val scenario = makeTestScenario(agentNames = listOf("A", "B"), rounds = 5)
+        val state = SimulationState.initial(scenario).copy(currentRound = 1)
+        assertTrue(evaluator.evaluate("(((current_round == 1)))", state, scenario).value)
+    }
+
+    // MARK: - Left-associativity
+
+    @Test
+    fun leftAssociativeOrChain() {
+        val scenario = makeTestScenario(agentNames = listOf("A", "B"), rounds = 5)
+        val trueState = SimulationState.initial(scenario).copy(variables = mapOf("a" to "0", "b" to "0", "c" to "1"))
+        assertTrue(evaluator.evaluate("a > 0 || b > 0 || c > 0", trueState, scenario).value)
+        val falseState = SimulationState.initial(scenario).copy(variables = mapOf("a" to "0", "b" to "0", "c" to "0"))
+        assertFalse(evaluator.evaluate("a > 0 || b > 0 || c > 0", falseState, scenario).value)
+    }
+
+    @Test
+    fun leftAssociativeAndChain() {
+        val scenario = makeTestScenario(agentNames = listOf("A", "B"), rounds = 5)
+        val trueState = SimulationState.initial(scenario).copy(variables = mapOf("a" to "1", "b" to "1", "c" to "1"))
+        assertTrue(evaluator.evaluate("a > 0 && b > 0 && c > 0", trueState, scenario).value)
+        val falseState = SimulationState.initial(scenario).copy(variables = mapOf("a" to "1", "b" to "0", "c" to "1"))
+        assertFalse(evaluator.evaluate("a > 0 && b > 0 && c > 0", falseState, scenario).value)
+    }
+
+    // MARK: - Short-circuit evaluation policy
+
+    @Test
+    fun shortCircuitFalseAndAbsentSuppressesWarning() {
+        // LHS false; RHS uses runtime-absent vote_winner. Per Swift-style
+        // short-circuit policy, RHS is NOT resolved, so its warning never appears.
+        val scenario = makeTestScenario(agentNames = listOf("Alice", "Bob"))
+        val state = SimulationState.initial(scenario).copy(currentRound = 1)
+        val result = evaluator.evaluate(
+            "current_round > 999 && vote_winner == \"Alice\"",
+            state,
+            scenario,
+        )
+        assertFalse(result.value)
+        assertTrue(result.warnings.isEmpty())
+    }
+
+    @Test
+    fun shortCircuitTrueOrAbsentSuppressesWarning() {
+        val scenario = makeTestScenario(agentNames = listOf("Alice", "Bob"))
+        val state = SimulationState.initial(scenario).copy(currentRound = 1)
+        val result = evaluator.evaluate(
+            "current_round == 1 || vote_winner == \"Alice\"",
+            state,
+            scenario,
+        )
+        assertTrue(result.value)
+        assertTrue(result.warnings.isEmpty())
+    }
+
+    @Test
+    fun dualAbsentVariablesNoShortCircuitBothWarnings() {
+        // LHS false-with-warning (scores.Nobody absent), RHS not short-circuited
+        // (|| looks at the right side when LHS is false), RHS also false-with-warning.
+        val scenario = makeTestScenario(agentNames = listOf("Alice", "Bob"))
+        val state = SimulationState.initial(scenario)
+        val result = evaluator.evaluate(
+            "scores.Nobody > 0 || vote_winner == \"X\"",
+            state,
+            scenario,
+        )
+        assertFalse(result.value)
+        assertEquals(2, result.warnings.size)
+    }
+
+    // MARK: - Quote awareness across new tokens
+
+    @Test
+    fun combinatorInsideQuotedRHSIsNotSplit() {
+        val scenario = makeTestScenario(agentNames = listOf("A", "B"))
+        val state = SimulationState.initial(scenario).copy(variables = mapOf("topic" to "tea && coffee"))
+        val result = evaluator.evaluate("topic == \"tea && coffee\"", state, scenario)
+        assertTrue(result.value)
+    }
+
+    @Test
+    fun parensInsideQuotedRHSIsNotSplit() {
+        val scenario = makeTestScenario(agentNames = listOf("A", "B"))
+        val state = SimulationState.initial(scenario).copy(variables = mapOf("tag" to "(foo)"))
+        val result = evaluator.evaluate("tag == \"(foo)\"", state, scenario)
+        assertTrue(result.value)
+    }
+
+    // MARK: - Parse errors
+
+    @Test
+    fun emptyParensThrows() {
+        val scenario = makeTestScenario(agentNames = listOf("A", "B"))
+        val state = SimulationState.initial(scenario)
+        assertFailsWith<SimulationException> {
+            evaluator.evaluate("()", state, scenario)
+        }
+    }
+
+    @Test
+    fun mismatchedOpenParenThrows() {
+        val scenario = makeTestScenario(agentNames = listOf("A", "B"))
+        val state = SimulationState.initial(scenario)
+        assertFailsWith<SimulationException> {
+            evaluator.evaluate("(current_round == 1 && max_score > 0", state, scenario)
+        }
+    }
+
+    @Test
+    fun mismatchedCloseParenThrows() {
+        val scenario = makeTestScenario(agentNames = listOf("A", "B"))
+        val state = SimulationState.initial(scenario)
+        assertFailsWith<SimulationException> {
+            evaluator.evaluate("current_round == 1) && max_score > 0", state, scenario)
+        }
+    }
+
+    @Test
+    fun danglingAndOperatorThrows() {
+        val scenario = makeTestScenario(agentNames = listOf("A", "B"))
+        val state = SimulationState.initial(scenario)
+        assertFailsWith<SimulationException> {
+            evaluator.evaluate("current_round == 1 &&", state, scenario)
+        }
+    }
+
+    @Test
+    fun leadingOrOperatorThrows() {
+        val scenario = makeTestScenario(agentNames = listOf("A", "B"))
+        val state = SimulationState.initial(scenario)
+        assertFailsWith<SimulationException> {
+            evaluator.evaluate("|| current_round == 1", state, scenario)
+        }
+    }
+
+    // MARK: - Parse-only entry point (used by ScenarioValidator)
+
+    @Test
+    fun parseAcceptsValidExpression() {
+        // No throw = pass.
+        evaluator.parse("current_round == 1 && (max_score > 0 || vote_winner == \"X\")")
+    }
+
+    @Test
+    fun parseRejectsMalformedExpression() {
+        assertFailsWith<SimulationException> {
+            evaluator.parse("(current_round == 1")
+        }
+    }
+}

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ConditionEvaluatorParityTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ConditionEvaluatorParityTests.kt
@@ -1,0 +1,109 @@
+package com.pastura.engine
+
+import com.pastura.models.SimulationState
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Cross-language numeric-detection and string-ordering parity for the
+ * `ConditionEvaluator` port (#501 Stage 2-pre, critic Axis 3).
+ *
+ * These have no Swift counterpart — they lock behaviours the ported Swift test
+ * set (CJK *equality* + ASCII tie-break) does not exercise, precisely because
+ * those cases pass identically in both languages and mask the two primitives
+ * that genuinely diverge:
+ *
+ * 1. **Numeric detection.** Swift `Double(String)` and Kotlin
+ *    `String.toDoubleOrNull()` disagree on `"Infinity"`, `"NaN"`, hex-float
+ *    (`"0x10"`), and type-suffixed (`"1f"`) literals. The port sidesteps both by
+ *    matching a fixed decimal-literal regex (`ConditionEvaluator.numericLiteralRegex`),
+ *    so a token is numeric iff it is a plain optionally-signed decimal with
+ *    optional fraction / exponent — identical in both languages. The tests below
+ *    pin: clean decimals / exponents / negatives ARE numeric; `Infinity` / hex /
+ *    suffix are NOT (treated as strings — the accepted, documented divergence
+ *    from Swift, which is out-of-domain since real scenario operands are
+ *    integers or names).
+ * 2. **String ordering.** Kotlin `String.compareTo` is UTF-16 code-unit order;
+ *    Swift `String <` is Unicode-scalar order. They agree across the entire BMP
+ *    (all CJK/kana), diverging only on supplementary-plane code points and
+ *    canonical-equivalence forms — out-of-domain for agent names. The CJK
+ *    ordering tests below lock the in-domain BMP parity.
+ */
+class ConditionEvaluatorParityTests {
+    private val evaluator = ConditionEvaluator()
+
+    // MARK: - Numeric detection — in-domain literals ARE numeric
+
+    @Test
+    fun cleanDecimalLiteralComparesNumerically() {
+        val scenario = makeTestScenario(agentNames = listOf("A", "B"))
+        val state = SimulationState.initial(scenario).copy(variables = mapOf("x" to "3.5"))
+        // 3.5 < 4 numerically (string compare would give "3.5" < "4" → also true,
+        // so pair it with a case string-compare would get WRONG):
+        assertTrue(evaluator.evaluate("x < 4", state, scenario).value)
+        // "3.5" > "10" lexicographically ('3' > '1') but 3.5 < 10 numerically.
+        val state2 = SimulationState.initial(scenario).copy(variables = mapOf("x" to "3.5"))
+        assertTrue(evaluator.evaluate("x < 10", state2, scenario).value)
+    }
+
+    @Test
+    fun exponentLiteralComparesNumerically() {
+        val scenario = makeTestScenario(agentNames = listOf("A", "B"))
+        val state = SimulationState.initial(scenario).copy(variables = mapOf("y" to "1e2"))
+        // 1e2 == 100 numerically. String compare "1e2" == "100" would be false.
+        assertTrue(evaluator.evaluate("y == 100", state, scenario).value)
+    }
+
+    @Test
+    fun negativeLiteralComparesNumerically() {
+        val scenario = makeTestScenario(agentNames = listOf("A", "B"), rounds = 5)
+        val state = SimulationState.initial(scenario).copy(currentRound = 0)
+        // The literal `-1` on the RHS must tokenize as one operand and compare numerically.
+        assertTrue(evaluator.evaluate("current_round > -1", state, scenario).value)
+    }
+
+    // MARK: - Numeric detection — accepted divergence: non-decimal → string path
+
+    @Test
+    fun infinityLiteralTreatedAsStringNotNumber() {
+        val scenario = makeTestScenario(agentNames = listOf("A", "B"))
+        val state = SimulationState.initial(scenario).copy(variables = mapOf("v" to "Infinity"))
+        // Kotlin's toDoubleOrNull("Infinity") == ∞, but the port's decimal regex
+        // rejects it → string path. Equality against the quoted string holds.
+        assertTrue(evaluator.evaluate("v == \"Infinity\"", state, scenario).value)
+    }
+
+    @Test
+    fun hexLiteralTreatedAsStringNotNumber_acceptedDivergenceFromSwift() {
+        val scenario = makeTestScenario(agentNames = listOf("A", "B"))
+        val state = SimulationState.initial(scenario).copy(variables = mapOf("hex" to "0x10"))
+        // ACCEPTED DIVERGENCE: Swift `Double("0x10") == 16` → `hex == 16` would be
+        // TRUE in Swift. The Kotlin port treats "0x10" as a string (decimal regex
+        // rejects hex), so `hex == 16` is FALSE. Out-of-domain (no real scenario
+        // uses hex operands); pinned here so the divergence is deliberate, not silent.
+        assertFalse(evaluator.evaluate("hex == 16", state, scenario).value)
+        // It IS equal to itself as a string:
+        assertTrue(evaluator.evaluate("hex == \"0x10\"", state, scenario).value)
+    }
+
+    // MARK: - String ordering — in-domain BMP parity (UTF-16 == scalar order)
+
+    @Test
+    fun cjkTieBreakMatchesScalarOrder() {
+        // Tie 1-1: (count desc, name desc) → higher code unit wins.
+        // ア U+30A2 < ミ U+30DF, so "ミサキ" is the deterministic winner. UTF-16
+        // and Unicode-scalar order agree across the BMP.
+        val scenario = makeTestScenario(agentNames = listOf("アキラ", "ミサキ"))
+        val state = SimulationState.initial(scenario).copy(voteResults = mapOf("アキラ" to 1, "ミサキ" to 1))
+        assertTrue(evaluator.evaluate("vote_winner == \"ミサキ\"", state, scenario).value)
+    }
+
+    @Test
+    fun cjkStringLessThanMatchesScalarOrder() {
+        val scenario = makeTestScenario(agentNames = listOf("A", "B"))
+        val state = SimulationState.initial(scenario).copy(variables = mapOf("a" to "アキラ"))
+        // "アキラ" < "ミサキ" (ア < ミ). BMP — both orderings agree.
+        assertTrue(evaluator.evaluate("a < \"ミサキ\"", state, scenario).value)
+    }
+}

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ConditionEvaluatorParityTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ConditionEvaluatorParityTests.kt
@@ -14,16 +14,17 @@ import kotlin.test.assertTrue
  * those cases pass identically in both languages and mask the two primitives
  * that genuinely diverge:
  *
- * 1. **Numeric detection.** Swift `Double(String)` and Kotlin
- *    `String.toDoubleOrNull()` disagree on `"Infinity"`, `"NaN"`, hex-float
- *    (`"0x10"`), and type-suffixed (`"1f"`) literals. The port sidesteps both by
- *    matching a fixed decimal-literal regex (`ConditionEvaluator.numericLiteralRegex`),
- *    so a token is numeric iff it is a plain optionally-signed decimal with
- *    optional fraction / exponent — identical in both languages. The tests below
- *    pin: clean decimals / exponents / negatives ARE numeric; `Infinity` / hex /
- *    suffix are NOT (treated as strings — the accepted, documented divergence
- *    from Swift, which is out-of-domain since real scenario operands are
- *    integers or names).
+ * 1. **Numeric detection.** Neither raw parser is a stable cross-language
+ *    predicate: Kotlin `String.toDoubleOrNull()` accepts `"Infinity"` / `"NaN"` /
+ *    type-suffixed literals (`"1f"`) that are not plain decimals, while Swift
+ *    `Double(String)` in turn accepts hex-floats (`"0x1p4"`) Kotlin rejects. The
+ *    port sidesteps both by matching a fixed decimal-literal regex
+ *    (`ConditionEvaluator.numericLiteralRegex`), so a token is numeric iff it is a
+ *    plain optionally-signed decimal with optional fraction / exponent — identical
+ *    in both languages. The tests below pin: clean decimals / exponents / negatives
+ *    ARE numeric; `Infinity` / suffixed literals are NOT (treated as strings —
+ *    normalizing Kotlin's laxer acceptance to the strict grammar). Out-of-domain
+ *    for real scenario operands, which are integers or names.
  * 2. **String ordering.** Kotlin `String.compareTo` is UTF-16 code-unit order;
  *    Swift `String <` is Unicode-scalar order. They agree across the entire BMP
  *    (all CJK/kana), diverging only on supplementary-plane code points and
@@ -75,16 +76,18 @@ class ConditionEvaluatorParityTests {
     }
 
     @Test
-    fun hexLiteralTreatedAsStringNotNumber_acceptedDivergenceFromSwift() {
+    fun typeSuffixedLiteralTreatedAsStringNotNumber() {
         val scenario = makeTestScenario(agentNames = listOf("A", "B"))
-        val state = SimulationState.initial(scenario).copy(variables = mapOf("hex" to "0x10"))
-        // ACCEPTED DIVERGENCE: Swift `Double("0x10") == 16` → `hex == 16` would be
-        // TRUE in Swift. The Kotlin port treats "0x10" as a string (decimal regex
-        // rejects hex), so `hex == 16` is FALSE. Out-of-domain (no real scenario
-        // uses hex operands); pinned here so the divergence is deliberate, not silent.
-        assertFalse(evaluator.evaluate("hex == 16", state, scenario).value)
+        val state = SimulationState.initial(scenario).copy(variables = mapOf("v" to "1f"))
+        // Kotlin's `"1f".toDoubleOrNull()` == 1.0 (Java accepts the trailing
+        // `f`/`d` suffix), so RAW numeric detection would make `v == 1` TRUE. The
+        // port's decimal regex rejects "1f" → string path → `v == 1` is FALSE.
+        // This is the regex's core job: normalize Kotlin's laxer `toDoubleOrNull`
+        // to a strict decimal grammar. Out-of-domain (real operands are integers
+        // or names); pinned so the behaviour is deliberate, not silent.
+        assertFalse(evaluator.evaluate("v == 1", state, scenario).value)
         // It IS equal to itself as a string:
-        assertTrue(evaluator.evaluate("hex == \"0x10\"", state, scenario).value)
+        assertTrue(evaluator.evaluate("v == \"1f\"", state, scenario).value)
     }
 
     // MARK: - String ordering — in-domain BMP parity (UTF-16 == scalar order)

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ConditionEvaluatorTestSupport.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ConditionEvaluatorTestSupport.kt
@@ -1,0 +1,29 @@
+package com.pastura.engine
+
+import com.pastura.models.Persona
+import com.pastura.models.Scenario
+
+/**
+ * Kotlin counterpart of the Swift `makeTestScenario(agentNames:rounds:)` helper
+ * (`EngineTestHelpers.swift`). Builds a minimal [Scenario] for `ConditionEvaluator`
+ * tests — only the fields the derived-variable resolver reads (`rounds`,
+ * `personas`) carry meaning; the rest are placeholders.
+ *
+ * Note: unlike Swift (mutable `var` state), Kotlin [com.pastura.models.SimulationState]
+ * is an immutable `data class` — tests set state via `SimulationState.initial(scenario).copy(...)`,
+ * not field mutation.
+ */
+internal fun makeTestScenario(
+    agentNames: List<String>,
+    rounds: Int = 1,
+): Scenario = Scenario(
+    id = "test-condition",
+    name = "Condition Test",
+    description = "A scenario for ConditionEvaluator tests.",
+    language = "en",
+    agentCount = agentNames.size,
+    rounds = rounds,
+    context = "You are participating in a test.",
+    personas = agentNames.map { Persona(name = it, description = "Test persona.") },
+    phases = emptyList(),
+)

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ConditionEvaluatorTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ConditionEvaluatorTests.kt
@@ -1,0 +1,231 @@
+package com.pastura.engine
+
+import com.pastura.models.SimulationState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Kotlin port of `Pastura/PasturaTests/Engine/ConditionEvaluatorTests.swift`.
+ *
+ * This is the cross-language executable spec for the `conditional`-phase `if:`
+ * DSL evaluator (#501 Stage 2-pre / ADR-023 §6): the same behaviours the Swift
+ * `ConditionEvaluator` guarantees must hold in the Kotlin port. Combinator (`&&`
+ * / `||` / parens) coverage lives in [ConditionEvaluatorCombinatorTests]; the
+ * cross-language numeric / ordering parity cases live in
+ * [ConditionEvaluatorParityTests].
+ *
+ * Parse-time errors throw [SimulationException] (the Kotlin Engine's `Throwable`
+ * carrier for the sealed `SimulationError`), NOT `SimulationError` directly —
+ * that type is a non-`Throwable` sealed class in `shared/models`.
+ */
+class ConditionEvaluatorTests {
+    private val evaluator = ConditionEvaluator()
+
+    // MARK: - Numeric comparison — derived variables
+
+    @Test
+    fun maxScoreGTE() {
+        val scenario = makeTestScenario(agentNames = listOf("Alice", "Bob"))
+        val state = SimulationState.initial(scenario).copy(scores = mapOf("Alice" to 10, "Bob" to 3))
+        assertTrue(evaluator.evaluate("max_score >= 10", state, scenario).value)
+        assertFalse(evaluator.evaluate("max_score >= 11", state, scenario).value)
+    }
+
+    @Test
+    fun minScoreLT() {
+        val scenario = makeTestScenario(agentNames = listOf("Alice", "Bob"))
+        val state = SimulationState.initial(scenario).copy(scores = mapOf("Alice" to 10, "Bob" to 3))
+        assertTrue(evaluator.evaluate("min_score < 5", state, scenario).value)
+    }
+
+    @Test
+    fun eliminatedCountEQ() {
+        val scenario = makeTestScenario(agentNames = listOf("Alice", "Bob", "Charlie"))
+        val state = SimulationState.initial(scenario)
+            .copy(eliminated = mapOf("Alice" to false, "Bob" to true, "Charlie" to false))
+        assertTrue(evaluator.evaluate("eliminated_count == 1", state, scenario).value)
+    }
+
+    @Test
+    fun activeCountGT() {
+        val scenario = makeTestScenario(agentNames = listOf("Alice", "Bob", "Charlie"))
+        val state = SimulationState.initial(scenario)
+            .copy(eliminated = mapOf("Alice" to false, "Bob" to true, "Charlie" to false))
+        assertTrue(evaluator.evaluate("active_count > 1", state, scenario).value)
+    }
+
+    @Test
+    fun currentRoundLE() {
+        val scenario = makeTestScenario(agentNames = listOf("A", "B"), rounds = 5)
+        val state = SimulationState.initial(scenario).copy(currentRound = 3)
+        assertTrue(evaluator.evaluate("current_round <= 3", state, scenario).value)
+        assertFalse(evaluator.evaluate("current_round <= 2", state, scenario).value)
+    }
+
+    @Test
+    fun totalRoundsComparison() {
+        val scenario = makeTestScenario(agentNames = listOf("A", "B"), rounds = 5)
+        val state = SimulationState.initial(scenario)
+        assertTrue(evaluator.evaluate("total_rounds == 5", state, scenario).value)
+    }
+
+    // MARK: - Dotted access: scores.<Name>
+
+    @Test
+    fun scoresDotAccess() {
+        val scenario = makeTestScenario(agentNames = listOf("Alice", "Bob"))
+        val state = SimulationState.initial(scenario).copy(scores = mapOf("Alice" to 7, "Bob" to 2))
+        assertTrue(evaluator.evaluate("scores.Alice >= 5", state, scenario).value)
+        assertFalse(evaluator.evaluate("scores.Bob >= 5", state, scenario).value)
+    }
+
+    @Test
+    fun scoresDotAccessCJK() {
+        val scenario = makeTestScenario(agentNames = listOf("アキラ", "ミサキ"))
+        val state = SimulationState.initial(scenario).copy(scores = mapOf("アキラ" to 8, "ミサキ" to 1))
+        assertTrue(evaluator.evaluate("scores.アキラ > 5", state, scenario).value)
+    }
+
+    // MARK: - String comparison (requires double quotes)
+
+    @Test
+    fun voteWinnerEQString() {
+        val scenario = makeTestScenario(agentNames = listOf("Alice", "Bob"))
+        val state = SimulationState.initial(scenario).copy(voteResults = mapOf("Alice" to 2, "Bob" to 1))
+        val result = evaluator.evaluate("vote_winner == \"Alice\"", state, scenario)
+        assertTrue(result.value)
+    }
+
+    @Test
+    fun voteWinnerCJK() {
+        val scenario = makeTestScenario(agentNames = listOf("アキラ", "ミサキ"))
+        val state = SimulationState.initial(scenario).copy(voteResults = mapOf("アキラ" to 2, "ミサキ" to 0))
+        val result = evaluator.evaluate("vote_winner == \"アキラ\"", state, scenario)
+        assertTrue(result.value)
+    }
+
+    @Test
+    fun voteWinnerTieBreaksDeterministically() {
+        // Two-way tie: deterministic per spec — same (count desc, name desc)
+        // sort as EliminateHandler; higher name wins. Alice vs Bob 2-2 → Bob.
+        val scenario = makeTestScenario(agentNames = listOf("Alice", "Bob"))
+        val state = SimulationState.initial(scenario).copy(voteResults = mapOf("Alice" to 2, "Bob" to 2))
+        val result = evaluator.evaluate("vote_winner == \"Bob\"", state, scenario)
+        assertTrue(result.value)
+    }
+
+    // MARK: - Template-variable side (state.variables)
+
+    @Test
+    fun stateVariableAccess() {
+        val scenario = makeTestScenario(agentNames = listOf("Alice", "Bob"))
+        val state = SimulationState.initial(scenario).copy(variables = mapOf("assigned_topic" to "cats"))
+        val result = evaluator.evaluate("assigned_topic == \"cats\"", state, scenario)
+        assertTrue(result.value)
+    }
+
+    // MARK: - Runtime-absent: returns false + warning, no throw
+
+    @Test
+    fun voteWinnerPreVoteReturnsFalseWithWarning() {
+        val scenario = makeTestScenario(agentNames = listOf("Alice", "Bob"))
+        val state = SimulationState.initial(scenario) // empty voteResults
+        val result = evaluator.evaluate("vote_winner == \"Alice\"", state, scenario)
+        assertFalse(result.value)
+        assertTrue(result.warnings.isNotEmpty())
+    }
+
+    @Test
+    fun unknownScoresNameReturnsFalseWithWarning() {
+        val scenario = makeTestScenario(agentNames = listOf("Alice", "Bob"))
+        val state = SimulationState.initial(scenario)
+        // scores.Nobody is not an agent; value is absent at runtime.
+        val result = evaluator.evaluate("scores.Nobody > 0", state, scenario)
+        assertFalse(result.value)
+        assertTrue(result.warnings.isNotEmpty())
+    }
+
+    // MARK: - Parse-time errors: throw
+
+    @Test
+    fun missingOperatorThrows() {
+        val scenario = makeTestScenario(agentNames = listOf("A", "B"))
+        val state = SimulationState.initial(scenario)
+        assertFailsWith<SimulationException> {
+            evaluator.evaluate("max_score", state, scenario)
+        }
+    }
+
+    @Test
+    fun emptyLHSThrows() {
+        val scenario = makeTestScenario(agentNames = listOf("A", "B"))
+        val state = SimulationState.initial(scenario)
+        assertFailsWith<SimulationException> {
+            evaluator.evaluate(" == 5", state, scenario)
+        }
+    }
+
+    @Test
+    fun emptyRHSThrows() {
+        val scenario = makeTestScenario(agentNames = listOf("A", "B"))
+        val state = SimulationState.initial(scenario)
+        assertFailsWith<SimulationException> {
+            evaluator.evaluate("max_score ==", state, scenario)
+        }
+    }
+
+    @Test
+    fun emptyExpressionThrows() {
+        val scenario = makeTestScenario(agentNames = listOf("A", "B"))
+        val state = SimulationState.initial(scenario)
+        assertFailsWith<SimulationException> {
+            evaluator.evaluate("", state, scenario)
+        }
+    }
+
+    // MARK: - Tokenize-before-expand: operator inside quoted RHS is preserved
+
+    @Test
+    fun operatorInsideQuotedRHSIsNotAmbiguous() {
+        val scenario = makeTestScenario(agentNames = listOf("Alice", "Bob"))
+        val state = SimulationState.initial(scenario).copy(variables = mapOf("tag" to "A>B"))
+        // The '>' inside "A>B" must not split the expression.
+        val result = evaluator.evaluate("tag == \"A>B\"", state, scenario)
+        assertTrue(result.value)
+    }
+
+    // MARK: - Operator priority: <= / >= before < / >
+
+    @Test
+    fun lessThanOrEqualScannedBeforeLessThan() {
+        val scenario = makeTestScenario(agentNames = listOf("A", "B"))
+        val state = SimulationState.initial(scenario).copy(currentRound = 5)
+        // Must tokenize as `current_round <= 5`, not `current_round < = 5`.
+        assertTrue(evaluator.evaluate("current_round <= 5", state, scenario).value)
+    }
+
+    @Test
+    fun notEqualOperator() {
+        val scenario = makeTestScenario(agentNames = listOf("A", "B"))
+        val state = SimulationState.initial(scenario).copy(scores = mapOf("A" to 3, "B" to 0))
+        assertTrue(evaluator.evaluate("max_score != 0", state, scenario).value)
+    }
+
+    // MARK: - Error carries the wrapped SimulationError
+
+    @Test
+    fun parseErrorCarriesScenarioValidationFailed() {
+        val scenario = makeTestScenario(agentNames = listOf("A", "B"))
+        val state = SimulationState.initial(scenario)
+        val caught = assertFailsWith<SimulationException> {
+            evaluator.evaluate("max_score", state, scenario)
+        }
+        assertEquals(
+            true,
+            caught.error is com.pastura.models.SimulationError.ScenarioValidationFailed,
+        )
+    }
+}

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/SimulationExceptionTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/SimulationExceptionTests.kt
@@ -1,0 +1,36 @@
+package com.pastura.engine
+
+import com.pastura.models.SimulationError
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Contract for [SimulationException], the KMP Engine's `Throwable` carrier for
+ * the (non-`Throwable`) sealed [SimulationError]. See the type doc-comment for
+ * why the wrapper exists (#501 Stage 2-pre).
+ */
+class SimulationExceptionTests {
+
+    @Test
+    fun carriesTheWrappedError() {
+        val error = SimulationError.ScenarioValidationFailed("bad expr")
+        val exception = SimulationException(error)
+        assertEquals(error, exception.error)
+    }
+
+    @Test
+    fun exposesScenarioValidationTextAsThrowableMessage() {
+        val exception = SimulationException(SimulationError.ScenarioValidationFailed("bad expr"))
+        assertEquals("bad expr", exception.message)
+    }
+
+    @Test
+    fun isThrowableAndCatchableByType() {
+        val caught = assertFailsWith<SimulationException> {
+            throw SimulationException(SimulationError.ScenarioValidationFailed("x"))
+        }
+        assertTrue(caught.error is SimulationError.ScenarioValidationFailed)
+    }
+}


### PR DESCRIPTION
## Summary

KMP Stage 2-pre (#501 / ADR-023 §6): port the Swift `ConditionEvaluator` + `ConditionEvaluator+Parser` — the pure `conditional`-phase `if:` DSL evaluator (quote-aware tokenizer + recursive-descent parser for `&&`/`||`/parens + single comparison, derived-variable resolver) — from `Pastura/Pastura/Engine/` to Kotlin `shared/engine/src/commonMain/kotlin/com/pastura/engine/`. **First real logic in the `shared/engine` module** (Stage 1 landed an empty scaffold).

Per ADR-023 §6 this is a **tooling shakedown, not the Stage-2 GO/NO-GO gate** (that is a separate two-boundary vertical slice). It touches **neither** K/N boundary — engine is not exported to Swift (XCFramework stays models-only; Swift consumption is Stage 5). The Swift `ConditionEvaluator.swift` is **not** deleted: iOS keeps using it, and the Kotlin port runs in parallel until the Stage-5 consumption switch.

### What landed (3 commits + 1 review follow-up)

1. **`SimulationException`** — a Kotlin `Throwable` wrapping the sealed (non-`Throwable`) `SimulationError` so the Engine port can throw parse errors. Kotlin `SimulationError`'s own doc-comment sanctions this wrapper "at the Engine layer". Doc-comment framed **provisional** — the durable throw-convention is ratified at the Stage-2 gate / Stage 3, not here.
2. **`ConditionEvaluator`** port — `indirect enum` → `sealed interface`; strict preservation of short-circuit warning suppression, runtime-absent-returns-false-with-warning (no throw), the full parse-error throw set, and the `(count desc, name desc)` `vote_winner` tie-break. The two Swift test files are ported to `commonTest` as the **cross-language executable spec**, plus additive parity tests.
3. **CI** — `:shared:engine:jvmTest` added to the per-PR "Run JVM tests" step (previously `:shared:models:jvmTest` only; engine's `jvmTest` was `NO-SOURCE`) so the ported spec runs per-PR on JVM, not only nightly-native. Token addition to an existing step — no `on:`-level path filter, so no required-check-gating change.
4. **Review follow-up** — corrected the numeric-parity rationale (a prior comment wrongly claimed `0x10` diverges in Swift) and sharpened the regex parity test.

### Cross-language numeric parity (design note)

Numeric detection uses a fixed decimal-literal regex (`^[+-]?[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?$`) rather than raw `toDoubleOrNull()`, because neither raw parser is a stable cross-language predicate: Kotlin's `toDoubleOrNull` accepts `1f`/`Infinity`/`NaN`, while Swift's `Double()` accepts hex-floats (`0x1p4`) Kotlin rejects. The regex makes the numeric-vs-string branch identical across both languages; the accepted out-of-domain divergences (real operands are integers or names) are documented and pinned by `ConditionEvaluatorParityTests`.

## Test plan

- `./gradlew :shared:engine:jvmTest` — **56 tests, 0 failures** (JVM).
- `./gradlew :shared:engine:iosSimulatorArm64Test` — **56 tests, 0 failures** (Kotlin/Native). Cross-language runtime parity confirmed on both.
- `./gradlew :shared:models:jvmTest :shared:engine:jvmTest` (the exact new CI line) — green.
- Ported tests: `ConditionEvaluatorTests` (22) + `ConditionEvaluatorCombinatorTests` (24) + `ConditionEvaluatorParityTests` (7, additive) + `SimulationExceptionTests` (3).

## Device QA

実機QA不要 — KMP-only change (`shared/engine` Kotlin + `.github/workflows/ci.yml`); no iOS Simulator-unbuildable surface, no Metal/llama.cpp, no `#if !targetEnvironment(simulator)` block, no UI.

Part of #501
Closes #1062

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EzRvnrD51MTpha2w33Wfu