### PR TITLE
🐛 fix: consistent, deterministic vote-tie winner across the engine

### DIFF
--- a/Pastura/Pastura/Engine/ConditionEvaluator.swift
+++ b/Pastura/Pastura/Engine/ConditionEvaluator.swift
@@ -37,7 +37,7 @@ import Foundation
 /// | `min_score`        | `state.scores.values.min()`                 |
 /// | `eliminated_count` | count of `state.eliminated.values == true`  |
 /// | `active_count`     | count of `state.eliminated.values == false` |
-/// | `vote_winner`      | most-voted name in `state.voteResults` (ties broken like `EliminateHandler`) |
+/// | `vote_winner`      | most-voted name in `state.voteResults` (ties broken by count desc, name desc) |
 /// | `scores.<Name>`    | `state.scores["<Name>"]`                    |
 ///
 /// Any other identifier is resolved from `state.variables`.
@@ -280,8 +280,8 @@ nonisolated public struct ConditionEvaluator: Sendable {
       return resolveScoreExtremum(
         state.scores.values.min(), label: "min_score", warnings: &warnings)
     case "vote_winner":
-      // Deterministic tie-break mirrors EliminateHandler: sort by
-      // (count desc, name desc) and take the first.
+      // Canonical deterministic tie-break: sort by (count desc, name desc)
+      // and take the first. EliminateHandler shares this order (#1056).
       let top =
         state.voteResults
         .sorted(by: { ($0.value, $0.key) > ($1.value, $1.key) })

--- a/Pastura/Pastura/Engine/Phases/EliminateHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/EliminateHandler.swift
@@ -12,10 +12,13 @@ nonisolated struct EliminateHandler: PhaseHandler {
   ) async throws {
     guard !state.voteResults.isEmpty else { return }
 
-    // Find the most-voted agent (deterministic tie-breaking: sorted name)
+    // Find the most-voted agent. Deterministic tie-break: (count desc, name
+    // desc) — the canonical order shared with ConditionEvaluator's
+    // `vote_winner` derivation, so an `eliminate` phase and a `conditional`
+    // reading `vote_winner` in the same round never disagree on a tie (#1056).
     guard
       let mostVoted = state.voteResults
-        .sorted(by: { ($0.value, $1.key) > ($1.value, $0.key) })
+        .sorted(by: { ($0.value, $0.key) > ($1.value, $1.key) })
         .first
     else { return }
 

--- a/Pastura/Pastura/Engine/ScoringLogic/WordwolfJudgeLogic.swift
+++ b/Pastura/Pastura/Engine/ScoringLogic/WordwolfJudgeLogic.swift
@@ -22,7 +22,14 @@ nonisolated struct WordwolfJudgeLogic: Sendable {
       return
     }
 
-    let mostVoted = state.voteResults.max { $0.value < $1.value }?.key ?? ""
+    // Deterministic tie-break: (count desc, name desc) — the canonical order
+    // shared with ConditionEvaluator / EliminateHandler. `max(by:)` alone
+    // left ties resolved by hash-seeded dictionary order, so a tied word-wolf
+    // game reported "wolf found" vs "wolf escaped" differently per launch (#1057).
+    let mostVoted =
+      state.voteResults
+      .sorted(by: { ($0.value, $0.key) > ($1.value, $1.key) })
+      .first?.key ?? ""
     let wolf = state.variables["wolf_name"] ?? "?"
     let voteCount = state.voteResults[mostVoted] ?? 0
 

--- a/Pastura/PasturaTests/Engine/Phases/EliminateHandlerTests.swift
+++ b/Pastura/PasturaTests/Engine/Phases/EliminateHandlerTests.swift
@@ -63,8 +63,35 @@ struct EliminateHandlerTests {
     let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
     try await handler.execute(context: context, state: &state)
 
-    // One agent should be eliminated (deterministic: sorted by name)
-    let eliminatedCount = state.eliminated.values.filter { $0 }.count
-    #expect(eliminatedCount == 1)
+    // Canonical tie-break: (count desc, name desc) — Bob sorts before Alice,
+    // matching ConditionEvaluator's `vote_winner` derivation (#1056).
+    #expect(state.eliminated["Bob"] == true)
+    #expect(state.eliminated["Alice"] != true)
+    #expect(state.eliminated.values.filter { $0 }.count == 1)
+  }
+
+  /// The agent `EliminateHandler` removes on a tie must be the SAME agent
+  /// `ConditionEvaluator` resolves `vote_winner` to — otherwise an
+  /// `eliminate` phase and a `conditional` phase reading `vote_winner` in the
+  /// same round silently disagree about who won (#1056).
+  @Test func tieWinnerMatchesVoteWinner() async throws {
+    let mock = MockLLMService(responses: [])
+    let scenario = makeTestScenario(phases: [Phase(type: .eliminate)])
+    var state = SimulationState.initial(for: scenario)
+    state.voteResults = ["Alice": 2, "Bob": 2]
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    // EliminateHandler eliminates Bob (canonical tie-break).
+    #expect(state.eliminated["Bob"] == true)
+
+    // ConditionEvaluator resolves `vote_winner` to the same agent (Bob).
+    let evaluator = ConditionEvaluator()
+    #expect(
+      try evaluator.evaluate("vote_winner == \"Bob\"", state: state, scenario: scenario).value)
+    #expect(
+      try !evaluator.evaluate("vote_winner == \"Alice\"", state: state, scenario: scenario).value)
   }
 }

--- a/Pastura/PasturaTests/Engine/ScoringLogic/WordwolfJudgeLogicTests.swift
+++ b/Pastura/PasturaTests/Engine/ScoringLogic/WordwolfJudgeLogicTests.swift
@@ -33,6 +33,39 @@ struct WordwolfJudgeLogicTests {
     #expect(summaries[0].contains("ウルフの勝ち"))
   }
 
+  /// A vote tie must resolve to a **stable** winner. Before #1057 the winner
+  /// came from `Dictionary.max(by:)` with no secondary key, so it flipped with
+  /// hash-seed randomization across launches. Canonical tie-break is
+  /// (count desc, name desc) → Bob wins the tie; with the wolf being Alice,
+  /// the wolf escapes deterministically on every call.
+  @Test func tieResolvesToStableWinner() {
+    func run() -> String {
+      var state = SimulationState()
+      state.voteResults = ["Alice": 2, "Bob": 2]
+      state.variables["wolf_name"] = "Alice"
+      let collector = EventCollector()
+      logic.calculate(state: &state, language: "ja", emitter: collector.emit)
+      let summaries = collector.events.compactMap { event -> String? in
+        if case .summary(let text) = event { return text }
+        return nil
+      }
+      return summaries.first ?? ""
+    }
+
+    let first = run()
+    // Load-bearing: the deterministic winner is Bob (name desc); Bob != wolf
+    // (Alice) → wolf wins. The old `max(by:)` could not pin this — it returned
+    // whichever tied key dictionary order surfaced first.
+    #expect(first.contains("Bob"))
+    #expect(first.contains("ウルフの勝ち"))
+    #expect(!first.contains("Alice"))
+    // Independently-constructed states yield the identical outcome. Pre-fix
+    // these could diverge within a single run (observed Alice, then Bob);
+    // the sort makes the winner a pure function of the vote counts + names.
+    #expect(run() == first)
+    #expect(run() == first)
+  }
+
   @Test func handlesEmptyVoteResults() {
     var state = SimulationState()
     let collector = EventCollector()


### PR DESCRIPTION
## Summary

Two related vote-tie-break bugs, fixed together so the three engine sites that pick a "most-voted" agent share one canonical order — **`(count desc, name desc)`**, already used by `ConditionEvaluator.vote_winner`.

- **#1056 — `EliminateHandler` diverged from `vote_winner`.** Its comparator cross-mixed the keys (`($0.value, $1.key) > ($1.value, $0.key)`), resolving ties name-**ascending** — the opposite winner from `vote_winner` (name-descending). An `eliminate` phase and a `conditional` reading `vote_winner` in the same round could silently name opposite agents on a tie. Fixed the comparator to match `ConditionEvaluator`, and reworded `ConditionEvaluator`'s now-backwards "mirrors EliminateHandler" comments (`:40` / `:283`) to state the canonical order literally (comment-only, no logic change).
- **#1057 — `WordwolfJudgeLogic` was non-deterministic.** It picked the winner with `max(by:)` and no secondary key, so a tied word-wolf game reported "wolf found" vs "wolf escaped" differently across launches (and even across calls within one process — the new test demonstrated this pre-fix). Replaced with the canonical `sorted(...).first`, preserving the `?? ""` empty-guard.

DRY note: the three sites now share an identical, commented comparator. A shared tie-break helper is intentionally **out of scope** here (kept independently mergeable) — a reasonable follow-up.

## Test plan

- `EliminateHandlerTests`: strengthened `handlesTiedVotes` to assert the **specific** eliminated agent (Bob, name-desc), and added `tieWinnerMatchesVoteWinner` — runs the same tied `voteResults` through `EliminateHandler` **and** `ConditionEvaluator.evaluate("vote_winner == \"Bob\"")` and asserts they name the same agent. Confirmed red against the old name-asc behavior first.
- `WordwolfJudgeLogicTests`: added `tieResolvesToStableWinner` — asserts a specific stable winner and identical repeated outcomes. Pre-fix red output showed the winner flipping (Alice, then Bob) within one process.
- Full unit suite green (2933 tests). ADR-013 harness `swift build` green. `swiftlint --strict` clean.

## Device QA

実機QA不要 — Engine-layer scoring/comparator logic + unit tests only; no `#if !targetEnvironment(simulator)` block, Metal/llama.cpp path, or UI surface touched.

Closes #1056
Closes #1057