### PR TITLE
✨ feat: event_inject draw-without-replacement (no_repeat)

### DIFF
--- a/Pastura/Pastura/App/EditablePhase.swift
+++ b/Pastura/Pastura/App/EditablePhase.swift
@@ -37,6 +37,11 @@ struct EditablePhase: Identifiable, Sendable {
   // UI in `PhaseEditorSheet`), but modelled here so a visual→YAML round-trip
   // preserves it instead of dropping it on re-serialization.
   var maxSentences: Int?
+  // event_inject draw-without-replacement opt-in (#1006). YAML-only for v1 (no
+  // editing UI), modelled here so the visual→YAML round-trip preserves it.
+  // `Bool` (not `Bool?`) mirrors `excludeSelf`: false and nil are semantically
+  // identical, and `toPhase()` collapses false back to nil.
+  var noRepeat: Bool
 
   // swiftlint:disable:next function_default_parameter_at_end
   init(
@@ -58,7 +63,8 @@ struct EditablePhase: Identifiable, Sendable {
     eventVariable: String = "",
     voteAgainst: Int? = nil,
     actionDeltas: [String: Int] = [:],
-    maxSentences: Int? = nil
+    maxSentences: Int? = nil,
+    noRepeat: Bool = false
   ) {
     self.type = type
     self.prompt = prompt
@@ -79,6 +85,7 @@ struct EditablePhase: Identifiable, Sendable {
     self.voteAgainst = voteAgainst
     self.actionDeltas = actionDeltas
     self.maxSentences = maxSentences
+    self.noRepeat = noRepeat
   }
 
   init(from phase: Phase) {
@@ -101,6 +108,7 @@ struct EditablePhase: Identifiable, Sendable {
     self.voteAgainst = phase.voteAgainst
     self.actionDeltas = phase.actionDeltas ?? [:]
     self.maxSentences = phase.maxSentences
+    self.noRepeat = phase.noRepeat ?? false
   }
 
   /// Identifies which branch of a conditional phase to target.
@@ -214,7 +222,8 @@ struct EditablePhase: Identifiable, Sendable {
       eventVariable: eventVariable.isEmpty ? nil : eventVariable,
       voteAgainst: voteAgainst,
       actionDeltas: actionDeltas.isEmpty ? nil : actionDeltas,
-      maxSentences: maxSentences
+      maxSentences: maxSentences,
+      noRepeat: noRepeat ? true : nil
     )
   }
 }

--- a/Pastura/Pastura/Engine/EngineSchemaVersion.swift
+++ b/Pastura/Pastura/Engine/EngineSchemaVersion.swift
@@ -27,9 +27,14 @@ import Foundation
 /// an old app produces a *different* simulation. **Do not** bump for a truly
 /// inert additive-optional string swept harmlessly into `extraData`.
 nonisolated public enum EngineSchemaVersion {
-  /// The current build's engine capability version. Baseline is `1`
-  /// (set before the first App Store release, ADR-020 §5).
-  public static let current: Int = 1
+  /// The current build's engine capability version. Baseline was `1` (set
+  /// before the first App Store release, ADR-020 §5).
+  ///
+  /// `2` — `event_inject`'s `no_repeat` opt-in (#1006). An old app that ignores
+  /// the key silently runs with-replacement, a *different* simulation than a
+  /// no_repeat-honoring app, so §4's semantic-equivalence proviso is not met and
+  /// the ⚠️ silent-wrong-run rule requires a bump. See ADR-020 §8.
+  public static let current: Int = 2
 
   /// Whether a gallery scenario described by its index metadata can be
   /// executed by this build's engine (ADR-020 D2 + D3).

--- a/Pastura/Pastura/Engine/Phases/EventInjectHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/EventInjectHandler.swift
@@ -23,6 +23,12 @@ import Foundation
 ///   substitution well-defined.
 /// - On hit, picks a random element via `randomElement()` and writes it
 ///   to `state.variables[as]`, emitting `.eventInjected(event)`.
+/// - `no_repeat: true` (#1006) draws **without replacement** across the run:
+///   already-drawn events are tracked per variable in `state.drawnEvents` and
+///   the pick is taken from the remainder, resetting to the full pool once
+///   every entry has been drawn. Default is with-replacement. A miss never
+///   consumes the pool. Identical-text entries collapse in the drawn `Set`, so
+///   a curator relying on strict no-repeat should keep event texts distinct.
 ///
 /// RNG is not injected. The probability boundaries (0.0 / 1.0) make the
 /// fire/miss decision deterministically testable, and a single-element
@@ -111,14 +117,45 @@ nonisolated struct EventInjectHandler: PhaseHandler {
       return
     }
 
-    // randomElement() on a non-empty array always returns Some — the
-    // guard above guarantees `events.isEmpty == false`. The `??` is a
-    // no-op safety net rather than a real fallback path.
-    let chosen = events.randomElement() ?? (text: "", favors: nil)
+    // `no_repeat` (#1006) draws from the not-yet-drawn remainder and records
+    // the pick; the default path keeps plain with-replacement selection.
+    // randomElement() on a non-empty array always returns Some — the guard
+    // above guarantees `events.isEmpty == false` — so the `??` is a no-op
+    // safety net. Both branches funnel the chosen tuple through the SAME
+    // variable / favored-var writes below, so dict-shaped `{text,favors}`
+    // scoring (#931) is preserved regardless of draw mode.
+    let chosen: (text: String, favors: String?) =
+      context.phase.noRepeat == true
+      ? pickWithoutRepeat(events, variableName: variableName, state: &state)
+      : (events.randomElement() ?? (text: "", favors: nil))
+
     state.variables[variableName] = chosen.text
     // Write "" (not absent) for a dict entry with no `favors` tag, so an
     // earlier round's favored action never ghosts into `event_reactive`.
     if carriesFavors { state.variables[favoredName] = chosen.favors ?? "" }
     context.emitter(.eventInjected(event: chosen.text))
+  }
+
+  /// Draws an event not yet chosen this run (`no_repeat`), recording the pick
+  /// in `state.drawnEvents[variableName]`. When every entry has already been
+  /// drawn the pool is reset and a fresh full draw is taken — a late repeat is
+  /// preferable to blanking the variable mid-scenario (#1006). `events` is
+  /// guaranteed non-empty by the caller, so the `??` is an unreachable safety
+  /// net mirroring the default path.
+  private func pickWithoutRepeat(
+    _ events: [(text: String, favors: String?)],
+    variableName: String,
+    state: inout SimulationState
+  ) -> (text: String, favors: String?) {
+    let drawn = state.drawnEvents[variableName] ?? []
+    var remaining = events.filter { !drawn.contains($0.text) }
+    if remaining.isEmpty {
+      // Pool exhausted — reset so the next draw sees the full list again.
+      state.drawnEvents[variableName] = []
+      remaining = events
+    }
+    let chosen = remaining.randomElement() ?? (text: "", favors: nil)
+    state.drawnEvents[variableName, default: []].insert(chosen.text)
+    return chosen
   }
 }

--- a/Pastura/Pastura/Engine/ScenarioLoader.swift
+++ b/Pastura/Pastura/Engine/ScenarioLoader.swift
@@ -339,6 +339,10 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
     // variable name written by the handler.
     let probability = try parseOptionalDoubleAcceptingInt(dict, key: "probability", label: label)
     let eventVariable: String? = try parseOptional(dict, key: "as", label: label)
+    // Draw-without-replacement opt-in (#1006). Generic Bool path like
+    // `exclude_self`; no validation needed — a bool is always well-formed, and
+    // `no_repeat` on a short/1-element source is harmless (resets each round).
+    let noRepeat: Bool? = try parseOptional(dict, key: "no_repeat", label: label)
 
     // relationship_update-specific fields (#910). Both YAML-only — no visual
     // editing UI in v1 — but they round-trip through the editor's dual buffer.
@@ -368,7 +372,8 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
       eventVariable: eventVariable,
       voteAgainst: voteAgainst,
       actionDeltas: actionDeltas,
-      maxSentences: maxSentences
+      maxSentences: maxSentences,
+      noRepeat: noRepeat
     )
   }
 

--- a/Pastura/Pastura/Engine/ScenarioSerializer.swift
+++ b/Pastura/Pastura/Engine/ScenarioSerializer.swift
@@ -162,6 +162,12 @@ nonisolated struct ScenarioSerializer: Sendable {
     if let eventVariable = phase.eventVariable {
       lines.append("    as: \(yamlScalar(eventVariable))")
     }
+    // Draw-without-replacement opt-in (#1006). Only emit the truthy case — the
+    // default (nil/false) stays absent so existing scenarios round-trip byte
+    // for byte, matching the `exclude_self` "only-when-true" convention.
+    if phase.noRepeat == true {
+      lines.append("    no_repeat: true")
+    }
 
     // relationship_update-specific fields (#910). action_deltas keys are
     // sorted for deterministic output (same convention as `output:`).

--- a/Pastura/Pastura/Models/Phase.swift
+++ b/Pastura/Pastura/Models/Phase.swift
@@ -114,6 +114,20 @@ nonisolated public struct Phase: Codable, Sendable, Equatable {
   /// clipped by the global 3-sentence rule.
   public let maxSentences: Int?
 
+  /// Whether `event_inject` draws **without replacement** across a run (the
+  /// YAML `no_repeat:` key).
+  ///
+  /// `nil` / `false` keeps the default with-replacement behavior
+  /// (`randomElement()` each round, so a multi-round scenario can re-draw the
+  /// same event). `true` tracks already-drawn events per event variable in
+  /// ``SimulationState/drawnEvents`` and draws from the remainder, resetting to
+  /// the full pool once every entry has been drawn — a late repeat after
+  /// exhaustion beats silently blanking `{current_event}` mid-scenario.
+  ///
+  /// Opt-in so existing scenarios (e.g. word_wolf `mid_game_announcements`,
+  /// probability < 1.0) are byte-for-byte unaffected. See #1006.
+  public let noRepeat: Bool?
+
   public init(
     type: PhaseType,
     prompt: String? = nil,
@@ -133,7 +147,8 @@ nonisolated public struct Phase: Codable, Sendable, Equatable {
     eventVariable: String? = nil,
     voteAgainst: Int? = nil,
     actionDeltas: [String: Int]? = nil,
-    maxSentences: Int? = nil
+    maxSentences: Int? = nil,
+    noRepeat: Bool? = nil
   ) {
     self.type = type
     self.prompt = prompt
@@ -154,6 +169,7 @@ nonisolated public struct Phase: Codable, Sendable, Equatable {
     self.voteAgainst = voteAgainst
     self.actionDeltas = actionDeltas
     self.maxSentences = maxSentences
+    self.noRepeat = noRepeat
   }
 
   /// The schema's required keys as a `Set`, or an empty set when the

--- a/Pastura/Pastura/Models/SimulationState.swift
+++ b/Pastura/Pastura/Models/SimulationState.swift
@@ -34,6 +34,14 @@ nonisolated public struct SimulationState: Codable, Sendable, Equatable {
   /// The current round number (1-based). Updated by SimulationRunner.
   public var currentRound: Int
 
+  /// Per-event-variable set of already-drawn event strings, tracked only for
+  /// `event_inject` phases opted into `no_repeat` (draw-without-replacement).
+  /// Keyed by the event variable name (`current_event` or the phase's `as:`);
+  /// the value is the set of chosen `text` values drawn so far this run.
+  /// Persisted so a pause/resume mid-run preserves the no-repeat pool. Empty
+  /// for every other scenario. See #1006 and ``Phase/noRepeat``.
+  public var drawnEvents: [String: Set<String>]
+
   public init(
     scores: [String: Int] = [:],
     eliminated: [String: Bool] = [:],
@@ -42,7 +50,8 @@ nonisolated public struct SimulationState: Codable, Sendable, Equatable {
     voteResults: [String: Int] = [:],
     pairings: [Pairing] = [],
     variables: [String: String] = [:],
-    currentRound: Int = 0
+    currentRound: Int = 0,
+    drawnEvents: [String: Set<String>] = [:]
   ) {
     self.scores = scores
     self.eliminated = eliminated
@@ -52,6 +61,31 @@ nonisolated public struct SimulationState: Codable, Sendable, Equatable {
     self.pairings = pairings
     self.variables = variables
     self.currentRound = currentRound
+    self.drawnEvents = drawnEvents
+  }
+
+  /// Custom decoder so a `drawnEvents`-less `stateJSON` — any run persisted
+  /// before #1006 shipped — still resumes instead of throwing `keyNotFound`.
+  /// Pause/resume across an app update is a real path (ADR-003 background
+  /// execution, ADR-021 D8 resume), so the new field must decode leniently.
+  ///
+  /// Only `drawnEvents` is optional-on-decode; the eight original fields keep
+  /// required `decode` so a genuinely-corrupt blob still fails loudly rather
+  /// than silently resuming with zeroed state. Encoding stays synthesized
+  /// (the synthesized `CodingKeys` covers all nine fields, so the round-trip
+  /// is symmetric).
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    scores = try container.decode([String: Int].self, forKey: .scores)
+    eliminated = try container.decode([String: Bool].self, forKey: .eliminated)
+    conversationLog = try container.decode([ConversationEntry].self, forKey: .conversationLog)
+    lastOutputs = try container.decode([String: TurnOutput].self, forKey: .lastOutputs)
+    voteResults = try container.decode([String: Int].self, forKey: .voteResults)
+    pairings = try container.decode([Pairing].self, forKey: .pairings)
+    variables = try container.decode([String: String].self, forKey: .variables)
+    currentRound = try container.decode(Int.self, forKey: .currentRound)
+    drawnEvents =
+      try container.decodeIfPresent([String: Set<String>].self, forKey: .drawnEvents) ?? [:]
   }
 
   /// Creates an initial state for the given scenario with all agents at score 0.

--- a/Pastura/Pastura/Resources/Presets/last_fable.yaml
+++ b/Pastura/Pastura/Resources/Presets/last_fable.yaml
@@ -65,6 +65,9 @@ phases:
   - type: event_inject
     source: trials
     # probability omitted -> defaults to 1.0: a retrial opens every night.
+    # Draw without replacement so a 3-night run never re-opens the same trial
+    # (with-replacement had a ~44% chance of an in-run repeat; #1006).
+    no_repeat: true
 
   - type: summarize
     template: "{current_event}"

--- a/Pastura/Pastura/Resources/Presets/last_fable_en.yaml
+++ b/Pastura/Pastura/Resources/Presets/last_fable_en.yaml
@@ -76,6 +76,9 @@ phases:
   - type: event_inject
     source: trials
     # probability omitted -> defaults to 1.0: a retrial opens every night.
+    # Draw without replacement so a 3-night run never re-opens the same trial
+    # (with-replacement had a ~44% chance of an in-run repeat; #1006).
+    no_repeat: true
 
   - type: summarize
     template: "{current_event}"

--- a/Pastura/PasturaTests/App/EditablePhaseRoundTripTests.swift
+++ b/Pastura/PasturaTests/App/EditablePhaseRoundTripTests.swift
@@ -124,7 +124,7 @@ struct EditablePhaseRoundTripTests {
     case .eventInject:
       return Phase(
         type: .eventInject, source: "trials", probability: 0.5,
-        eventVariable: "current_event")
+        eventVariable: "current_event", noRepeat: true)
     case .relationshipUpdate:
       return Phase(
         type: .relationshipUpdate, voteAgainst: -1,

--- a/Pastura/PasturaTests/Engine/EngineSchemaVersionTests.swift
+++ b/Pastura/PasturaTests/Engine/EngineSchemaVersionTests.swift
@@ -6,10 +6,12 @@ import Testing
 @Suite(.timeLimit(.minutes(1)))
 struct EngineSchemaVersionTests {
 
-  // MARK: - Baseline constant
+  // MARK: - Current version constant
 
-  @Test func baselineIsOne() {
-    #expect(EngineSchemaVersion.current == 1)
+  @Test func currentVersionIsTwo() {
+    // Bumped 1→2 for event_inject no_repeat (#1006, ADR-020 §8). Update in
+    // lockstep with any further EngineSchemaVersion.current bump.
+    #expect(EngineSchemaVersion.current == 2)
   }
 
   // MARK: - D2 (phase-capability) branch

--- a/Pastura/PasturaTests/Engine/Phases/EventInjectHandlerTests+NoRepeat.swift
+++ b/Pastura/PasturaTests/Engine/Phases/EventInjectHandlerTests+NoRepeat.swift
@@ -1,0 +1,180 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+/// `no_repeat` draw-without-replacement tests for `EventInjectHandler` (#1006).
+///
+/// Sibling extension of `EventInjectHandlerTests` (NOT a new `@Suite`) so the
+/// no_repeat cases share the parent suite's `.serialized`-free parallel run and
+/// its `handler` / `injectedEvents` / `favoredKey` helpers — split out only to
+/// keep the main file under swiftlint's 400-line `file_length` cap (see
+/// `.claude/rules/testing.md` § "Splitting a Suite Across Files").
+///
+/// Determinism follows the parent suite's pattern: a 2-element source with one
+/// entry pre-seeded as drawn leaves a 1-element remainder, so `randomElement()`
+/// is deterministic without RNG injection; the exhausted-pool reset asserts on
+/// set cardinality (deterministic) rather than which element is redrawn.
+extension EventInjectHandlerTests {
+
+  // MARK: - Draw without replacement
+
+  @Test func noRepeatDrawsFromRemainder() async throws {
+    let scenario = makeTestScenario(
+      agentNames: ["Alice"],
+      phases: [Phase(type: .eventInject, source: "events", probability: 1.0, noRepeat: true)],
+      extraData: ["events": .array(["A", "B"])]
+    )
+    var state = SimulationState.initial(for: scenario)
+    // "A" already drawn → only "B" remains, so the pick is deterministic.
+    state.drawnEvents["current_event"] = ["A"]
+    let mock = MockLLMService(responses: [])
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    #expect(state.variables["current_event"] == "B")
+    // The chosen entry joins the drawn-set for the run.
+    #expect(state.drawnEvents["current_event"] == ["A", "B"])
+    #expect(injectedEvents(collector) == ["B"])
+  }
+
+  @Test func noRepeatExhaustedPoolResetsAndDraws() async throws {
+    let scenario = makeTestScenario(
+      agentNames: ["Alice"],
+      phases: [Phase(type: .eventInject, source: "events", probability: 1.0, noRepeat: true)],
+      extraData: ["events": .array(["A", "B"])]
+    )
+    var state = SimulationState.initial(for: scenario)
+    // Both entries drawn → the remainder is empty, forcing a reset+redraw.
+    state.drawnEvents["current_event"] = ["A", "B"]
+    let mock = MockLLMService(responses: [])
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    // A miss would blank the variable; instead we reset and redraw a real event.
+    let chosen = try #require(state.variables["current_event"])
+    #expect(["A", "B"].contains(chosen))
+    // Reset clears the pool, then adds only the freshly-redrawn entry.
+    #expect(state.drawnEvents["current_event"] == [chosen])
+  }
+
+  @Test func noRepeatSingleElementRedrawsAfterReset() async throws {
+    // One-element pool: every round exhausts and resets, so the same event is
+    // redrawn deterministically and the drawn-set never grows past 1.
+    let scenario = makeTestScenario(
+      agentNames: ["Alice"],
+      phases: [Phase(type: .eventInject, source: "events", probability: 1.0, noRepeat: true)],
+      extraData: ["events": .array(["only"])]
+    )
+    var state = SimulationState.initial(for: scenario)
+    let mock = MockLLMService(responses: [])
+
+    for _ in 0..<3 {
+      let collector = EventCollector()
+      let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+      try await handler.execute(context: context, state: &state)
+      #expect(state.variables["current_event"] == "only")
+      #expect(state.drawnEvents["current_event"] == ["only"])
+    }
+  }
+
+  // MARK: - Default path unaffected
+
+  @Test func defaultKeepsWithReplacementAndNeverTouchesDrawnEvents() async throws {
+    // no_repeat absent → existing randomElement() path, drawnEvents untouched.
+    let scenario = makeTestScenario(
+      agentNames: ["Alice"],
+      phases: [Phase(type: .eventInject, source: "events", probability: 1.0)],
+      extraData: ["events": .array(["A"])]
+    )
+    var state = SimulationState.initial(for: scenario)
+    let mock = MockLLMService(responses: [])
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    #expect(state.variables["current_event"] == "A")
+    #expect(state.drawnEvents.isEmpty)
+  }
+
+  // MARK: - Custom variable name keys the drawn-set
+
+  @Test func noRepeatHonorsCustomVariableName() async throws {
+    let scenario = makeTestScenario(
+      agentNames: ["Alice"],
+      phases: [
+        Phase(
+          type: .eventInject, source: "events", probability: 1.0,
+          eventVariable: "my_event", noRepeat: true)
+      ],
+      extraData: ["events": .array(["A", "B"])]
+    )
+    var state = SimulationState.initial(for: scenario)
+    state.drawnEvents["my_event"] = ["A"]
+    let mock = MockLLMService(responses: [])
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    #expect(state.variables["my_event"] == "B")
+    #expect(state.drawnEvents["my_event"] == ["A", "B"])
+    // Default key is never used when `as:` is set.
+    #expect(state.drawnEvents["current_event"] == nil)
+  }
+
+  // MARK: - Dict-shaped source preserves the companion favored variable (#931)
+
+  @Test func noRepeatDictSourcePreservesFavoredVariable() async throws {
+    // The no_repeat branch must funnel the chosen (text, favors) tuple through
+    // the same `__favors` write as the default path — else event_reactive
+    // scoring silently breaks for dict-shaped no_repeat scenarios.
+    let scenario = makeTestScenario(
+      agentNames: ["Alice"],
+      phases: [Phase(type: .eventInject, source: "events", probability: 1.0, noRepeat: true)],
+      extraData: [
+        "events": .arrayOfDictionaries([
+          ["text": "A", "favors": "betray"],
+          ["text": "B", "favors": "cooperate"]
+        ])
+      ]
+    )
+    var state = SimulationState.initial(for: scenario)
+    state.drawnEvents["current_event"] = ["A"]  // only "B" remains
+    let mock = MockLLMService(responses: [])
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    #expect(state.variables["current_event"] == "B")
+    #expect(state.variables[favoredKey()] == "cooperate")
+    #expect(state.drawnEvents["current_event"] == ["A", "B"])
+  }
+
+  // MARK: - A miss does not consume the pool
+
+  @Test func noRepeatMissDoesNotConsumePool() async throws {
+    let scenario = makeTestScenario(
+      agentNames: ["Alice"],
+      phases: [Phase(type: .eventInject, source: "events", probability: 0.0, noRepeat: true)],
+      extraData: ["events": .array(["A", "B"])]
+    )
+    var state = SimulationState.initial(for: scenario)
+    let mock = MockLLMService(responses: [])
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    #expect(state.variables["current_event"] == "")
+    // A probability miss injects nothing, so it must not mark anything drawn.
+    #expect(state.drawnEvents.isEmpty)
+    #expect(injectedEvents(collector) == [nil])
+  }
+}

--- a/Pastura/PasturaTests/Engine/Phases/EventInjectHandlerTests.swift
+++ b/Pastura/PasturaTests/Engine/Phases/EventInjectHandlerTests.swift
@@ -17,7 +17,7 @@ struct EventInjectHandlerTests {
   /// preserving `nil` payloads. Manual loop instead of `compactMap` —
   /// `compactMap { _ -> String? in ... }` would silently drop the
   /// "miss" cases (`.eventInjected(nil)`) that we want to assert on.
-  private func injectedEvents(_ collector: EventCollector) -> [String?] {
+  func injectedEvents(_ collector: EventCollector) -> [String?] {
     var result: [String?] = []
     for event in collector.events {
       if case .eventInjected(let value) = event {
@@ -194,7 +194,7 @@ struct EventInjectHandlerTests {
 
   // MARK: - Dict-shaped events + companion favored variable (#931)
 
-  private func favoredKey(_ variableName: String = "current_event") -> String {
+  func favoredKey(_ variableName: String = "current_event") -> String {
     EventInjectHandler.favoredVariableName(for: variableName)
   }
 

--- a/Pastura/PasturaTests/Models/SimulationStateTests.swift
+++ b/Pastura/PasturaTests/Models/SimulationStateTests.swift
@@ -23,6 +23,7 @@ struct SimulationStateTests {
     original.pairings = [Pairing(agent1: "Alice", agent2: "Bob")]
     original.variables = ["assigned_topic": "Test topic"]
     original.currentRound = 2
+    original.drawnEvents = ["current_event": ["retrial", "power_cut"]]
 
     let encoder = JSONEncoder()
     let data = try encoder.encode(original)
@@ -36,6 +37,35 @@ struct SimulationStateTests {
     #expect(decoded.pairings == original.pairings)
     #expect(decoded.variables == original.variables)
     #expect(decoded.currentRound == original.currentRound)
+    #expect(decoded.drawnEvents == original.drawnEvents)
+  }
+
+  /// Backward-compat: a `stateJSON` persisted before #1006 (no `drawnEvents`
+  /// key) must still decode — a paused run resumed across the update boundary
+  /// (ADR-003 / ADR-021 D8) would otherwise throw `keyNotFound` and break
+  /// resume. Drives the exact unguarded path: this JSON omits `drawnEvents`,
+  /// so reverting the custom `init(from:)`'s `decodeIfPresent ?? [:]` makes
+  /// this test fail. `drawnEvents` decodes to empty.
+  @Test func decodesLegacyStateWithoutDrawnEvents() throws {
+    let legacyJSON = """
+      {
+        "scores": {"Alice": 1},
+        "eliminated": {"Alice": false},
+        "conversationLog": [],
+        "lastOutputs": {},
+        "voteResults": {},
+        "pairings": [],
+        "variables": {"current_event": "retrial"},
+        "currentRound": 3
+      }
+      """
+    let data = try #require(legacyJSON.data(using: .utf8))
+    let decoded = try JSONDecoder().decode(SimulationState.self, from: data)
+
+    #expect(decoded.drawnEvents.isEmpty)
+    #expect(decoded.scores == ["Alice": 1])
+    #expect(decoded.currentRound == 3)
+    #expect(decoded.variables == ["current_event": "retrial"])
   }
 
   @Test func initialStateFromScenario() {
@@ -74,5 +104,6 @@ struct SimulationStateTests {
     #expect(state.pairings.isEmpty)
     #expect(state.variables.isEmpty)
     #expect(state.currentRound == 0)
+    #expect(state.drawnEvents.isEmpty)
   }
 }

--- a/docs/decisions/ADR-020.md
+++ b/docs/decisions/ADR-020.md
@@ -349,8 +349,11 @@ shipped vs what is deferred to the first post-baseline (v2) PR:
   §6.5; not needed until a genuinely-incompatible envelope reshape.
 - **App Store deep-link** on the D4 badge and D5 alert. The baseline ships the
   badge + guidance copy only, because the App Store ID is not yet minted (ASC
-  upload not started; installed base zero — nothing can grey a row at baseline
-  since `EngineSchemaVersion.current == 1` and every phase kind is known).
+  upload not started; installed base zero — nothing could grey a row *at
+  baseline*, since `EngineSchemaVersion.current` was `1` and every phase kind was
+  known). The `current` bump to `2` (§8, #1006) does not change this: no gallery
+  scenario declares `min_engine_version: 2`, so no row greys and the deep-link
+  obligation stays un-triggered — see §8.
 
 ### v2 maintainer checklist (when a change bumps `EngineSchemaVersion.current`)
 
@@ -366,3 +369,40 @@ shipped vs what is deferred to the first post-baseline (v2) PR:
    first curated scenario adopts a post-baseline feature. Otherwise the
    first-ever greyed row (D4) / `.updateRequired` alert (D5) dead-ends with no way
    forward — the exact failure D5 exists to prevent.
+
+## 8. Amendment 2026-07-12 — v2 bump for `event_inject` `no_repeat` (#1006)
+
+The first post-baseline bump: `EngineSchemaVersion.current` **`1` → `2`**.
+
+**Why a bump.** #1006 adds an optional `no_repeat: true` key inside the
+`event_inject` phase (draw-without-replacement across a run). That is an
+additive-optional key *inside an existing phase* — the §4 "DO NOT bump" bucket —
+**but** only under the semantic-equivalence proviso, which it fails: an old app
+that ignores `no_repeat` runs with-replacement, which can re-draw the same event
+(the exact defect #1006 fixes), so the old run is *not* semantically identical to
+a no_repeat-honoring one. That is precisely the §4 ⚠️ silent-wrong-run class
+("when in doubt, bump"). Bumping also gives the D3 escape hatch a real version to
+compare against — with `current == 1` there was no value a future gallery
+scenario could set to gate pre-`no_repeat` apps.
+
+**Why it costs nothing today.** D2 is unaffected (`no_repeat` adds no new
+`PhaseType`; `passesPhaseGate` still passes). D3 greys a row only when a
+scenario's `min_engine_version` exceeds `current` — and **no scenario declares
+`min_engine_version: 2`**. The only consumer of `no_repeat` is the bundled
+`last_fable` preset, which ships in lockstep with the engine binary (an app that
+has the preset always has the engine that honors the key) and never routes
+through the gallery gate. So no row greys and the §7-item-4 deep-link sequencing
+obligation is **not** triggered.
+
+**v2 checklist disposition (§7).**
+- *Item 1 (bump):* done — `current = 2`, pinned by
+  `EngineSchemaVersionTests.currentVersionIsTwo`.
+- *Item 2 (by-name enum / required key → D3a or manual floor):* N/A — `no_repeat`
+  is neither a by-name-parsed enum value nor a required key. **D3a stays
+  deferred**; acceptable because no gallery scenario adopts `no_repeat`.
+- *Item 3 (re-run `add-gallery-entry.sh`):* N/A — no new phase kind, no gallery
+  entry changes.
+- *Item 4 (deep-link sequencing):* not yet triggered (see above). **Revisit this
+  obligation before any *gallery* scenario declares `min_engine_version: 2`** —
+  at that point a pre-`no_repeat` installed base could hit the first-ever greyed
+  row, and the deep-link (or explicit forward-guidance) must land first.


### PR DESCRIPTION
## Summary
Adds an opt-in `no_repeat: true` key on `event_inject` phases (#1006). By
default `EventInjectHandler` draws with replacement, so a multi-round scenario
can re-draw the same event — the `last_fable` preset (6 trials × 3 nights,
probability 1.0) had a ~44% chance of an in-run repeat, observed in a harness
field-test.

- **Draw without replacement** — `no_repeat: true` tracks already-drawn events
  per event variable in `SimulationState.drawnEvents` and draws from the
  remainder; once the pool is exhausted it resets and draws from the full list
  (a late repeat after exhaustion beats blanking `{current_event}` mid-run).
- **Default unchanged** — absent/`false` keeps with-replacement, so existing
  scenarios (e.g. word_wolf `mid_game_announcements`) are byte-for-byte
  unaffected.
- **Pause/resume safe** — `drawnEvents` is persisted in `stateJSON`. A custom
  `SimulationState.init(from:)` decodes it leniently so an **old paused run**
  (stateJSON predating this key) still resumes instead of throwing
  `keyNotFound`; the eight original fields keep required decoding.
- **#931 preserved** — the no_repeat branch funnels the chosen `(text, favors)`
  tuple through the same `__favors` companion-var write as the default path, so
  dict-shaped `event_reactive` scoring is unaffected. A miss never consumes the
  pool.
- **`last_fable` adopts it** (ja + en presets).
- **`EngineSchemaVersion` 1→2** — an old app ignoring `no_repeat` runs a
  *different* simulation, so ADR-020 §4's semantic-equivalence proviso fails and
  the ⚠️ silent-wrong-run rule requires a bump. Costs nothing today (no scenario
  declares `min_engine_version: 2`; `last_fable` is a bundled preset shipping in
  lockstep with the engine). Recorded as ADR-020 §8.

## Test plan
- `EventInjectHandlerTests` (+`+NoRepeat` sibling): draw-from-remainder,
  exhausted-pool reset, single-element redraw, default leaves `drawnEvents`
  empty, custom `as:` keys the drawn-set, dict-shape `{text,favors}` preserves
  `__favors`, miss doesn't consume the pool.
- `SimulationStateTests`: codable round-trip incl. `drawnEvents`, and a
  legacy-decode regression (stateJSON without `drawnEvents` → empty).
- `EditablePhaseRoundTripTests`: `noRepeat: true` on the event_inject fixture
  survives both the EditablePhase bridge and serializer→loader.
- `EngineSchemaVersionTests`: `currentVersionIsTwo` pin updated.
- Full unit suite green (2941 tests); swiftlint --strict clean; harness
  `swift build` clean.
- Pre-code `critic` (Opus) + post-code `code-reviewer` (Opus): both PASS.

## Device QA
実機QA不要 — all changes are code-phase logic + `SimulationState` persistence,
fully covered by unit tests. No `#if !targetEnvironment(simulator)` surface, no
Metal/llama.cpp path, no UI layout or executor-isolation change.

Closes #1006
