### PR TITLE
✨ feat: whisper phase in prisoners_dilemma preset (#957)

### DIFF
--- a/Pastura/Pastura/Engine/PlaceholderAvailability.swift
+++ b/Pastura/Pastura/Engine/PlaceholderAvailability.swift
@@ -160,7 +160,7 @@ nonisolated public enum PlaceholderAvailability {
   /// Named here so the union-equality maintenance test can state the delta
   /// explicitly instead of hiding it.
   static let tokensBeyondEngineSupplied: Set<String> = [
-    "my_notes", "my_whispers",
+    "my_notes",  // reflect's channel — promote to engineSupplied when a bundled preset first references {my_notes}
     "whisper_partner", "whisper_exchange",
     "agent1", "action1", "agent2", "action2", "score1", "score2"
   ]

--- a/Pastura/Pastura/Engine/PromptPlaceholders.swift
+++ b/Pastura/Pastura/Engine/PromptPlaceholders.swift
@@ -36,6 +36,7 @@ nonisolated enum PromptPlaceholders {
     "vote_results",  // VoteHandler → Summarize
     "wolf_name",  // AssignHandler (random_one mode) → Summarize
     "current_event",  // EventInjectHandler (default event variable)
-    "relationships"  // RelationshipUpdateHandler → the 5 per-persona LLM sites (#910)
+    "relationships",  // RelationshipUpdateHandler → the 5 per-persona LLM sites (#910)
+    "my_whispers"  // WhisperHandler → participants' later-phase prompts (#908 / #957 PD adoption)
   ]
 }

--- a/Pastura/Pastura/Resources/Presets/prisoners_dilemma.yaml
+++ b/Pastura/Pastura/Resources/Presets/prisoners_dilemma.yaml
@@ -3,9 +3,10 @@ language: ja
 name: 囚人のジレンマ
 description: >
   5人のプレイヤーが「協力」か「裏切り」を選ぶ戦略ゲーム。
-  隣接ペアで総当たり対戦し、得点を競う。宣言でブラフも可能。
+  隣接ペアで総当たり対戦し、得点を競う。宣言でブラフも、
+  密談で同盟や裏切りの相談も可能。
 agents: 5
-rounds: 3
+rounds: 2
 context: >
   あなたはゲーム番組「囚人のジレンマ」の出場者です。
   対戦相手と「協力(cooperate)」か「裏切り(betray)」を選びます。
@@ -58,6 +59,23 @@ phases:
       declared_intent: string
       inner_thought: string
 
+  - type: whisper
+    prompt: >
+      現在のスコア: {scoreboard}
+
+      これまでの宣言:
+      {conversation_log}
+
+      いまは相手とふたりだけの密談です（他の人には聞こえません）。
+      このあとの対戦で協力するか裏切るか、率直に相手とすり合わせてください。
+      公開の宣言とは違う本音を出して構いません。「一緒に協力しよう」と
+      同盟を持ちかけても、あとで裏切るつもりで調子を合わせてもOKです。
+      具体的に、誰を狙うか・この相手とどうするかを相手に伝えてください。
+    output:
+      statement: string
+      inner_thought: string
+    rounds: 1
+
   - type: choose
     prompt: >
       現在のスコア: {scoreboard}
@@ -65,6 +83,9 @@ phases:
 
       これまでの宣言:
       {conversation_log}
+
+      密談での相手とのやり取り:
+      {my_whispers}
 
       「cooperate（協力）」か「betray（裏切り）」を選んでください。
     output:

--- a/Pastura/Pastura/Resources/Presets/prisoners_dilemma_en.yaml
+++ b/Pastura/Pastura/Resources/Presets/prisoners_dilemma_en.yaml
@@ -14,10 +14,10 @@ language: en
 name: Prisoner's Dilemma
 description: >
   Five players choose "cooperate" or "betray" in a strategic game.
-  Round-robin pairwise matches with score accumulation. Bluffing
-  during the declaration phase is allowed.
+  Round-robin pairwise matches with score accumulation. Bluff in the
+  open, and scheme alliances or betrayals in private whispers.
 agents: 5
-rounds: 3
+rounds: 2
 context: >
   You are a contestant on the game show "Prisoner's Dilemma".
   Against each opponent you choose "cooperate" or "betray".
@@ -74,6 +74,25 @@ phases:
       declared_intent: string
       inner_thought: string
 
+  - type: whisper
+    prompt: >
+      Current score: {scoreboard}
+
+      Declarations so far:
+      {conversation_log}
+
+      This is a private whisper — just you and your partner, no one
+      else can hear. Be candid about whether you will cooperate or
+      betray in the matches ahead, and line up your plan together. You
+      can say things here you would not say in the open. Propose an
+      alliance ("let's both cooperate"), or play along now while
+      planning to betray later — either is fine. Tell your partner
+      specifically who you will target and what you will do with them.
+    output:
+      statement: string
+      inner_thought: string
+    rounds: 1
+
   - type: choose
     prompt: >
       Current score: {scoreboard}
@@ -81,6 +100,9 @@ phases:
 
       Declarations so far:
       {conversation_log}
+
+      Whispered exchange with your partner:
+      {my_whispers}
 
       Choose "cooperate" or "betray".
     output:


### PR DESCRIPTION
## Summary
Adopt the existing `whisper` phase (#908) into the `prisoners_dilemma` bundled preset (ja + en). **Retargeted from word_wolf** — a foreground harness field test found word_wolf No-Go (hidden-role game collapsed whisper `statement`s to public clue-talk). PD's 2-camp / known-side structure fits: the "密談で同盟 → 公開で白々しく裏切る" dramatic irony that is #908's core reproduces.

- Insert a `whisper` phase (`rounds: 1`, output `statement` + `inner_thought`) between the declaration (`speak_all`) and `choose`.
- Inject `{my_whispers}` into the `choose` prompt so each agent's private negotiation drives their action.
- Drop top-level `rounds: 3 → 2` — keeps est. inferences at **38** (< the >50 warning; PD was the joint-max bundled preset at 45). ⚠️ This shortens a shipped flagship preset's arc by one round (the inference-count tradeoff #957 flagged; keeping rounds=3 would make PD the first bundled preset to warn at 57).
- Promote `{my_whispers}` into `PromptPlaceholders.engineSupplied` (and out of `PlaceholderAvailability.tokensBeyondEngineSupplied`) — PD is the first bundled preset to reference it, so the coverage guard must recognize it. The set-move keeps the union-equality and disjointness invariants green.

No engine run-path / UI code change — whisper's engine (PR #951) and UI hushed-bubble variant (PR #953) already shipped under #908.

## Harness field-test evidence (Go)
ja×3 + en×3 runs on Gemma 4 E2B (Q4_K_M), all `ok after 1 attempt` (38 inferences, 0 retries). All four criteria met on both languages: 密談→行動の因果 / 漏洩ゼロ / 演じ分け（clue-talk 非収束）/ 安定性. Full transcript excerpts in [#957 comment](https://github.com/tyabu12/pastura/issues/957#issuecomment-4950976487).

## Test plan
- `BundledPresetPlaceholderCoverageTests` + `PlaceholderAvailabilityTests` + `ScenarioSerializerTests` + `PresetLoaderTests` (targeted) — green.
- Full unit suite: **2941 tests / 236 suites** — green.
- `swiftlint --quiet --strict` — clean.
- Plan critic caught the coverage-guard promotion as a Critical (the "YAML-only" framing was wrong); code-reviewer PASS (0 issues).

## Device QA
Optional visual confirmation (not a code gate — this PR changes no UI code; the whisper render path shipped + device-verified in PR #953): run `prisoners_dilemma`, confirm whisper rows render with the PR2 hushed bubble fill + `A → B` pair-attribution header, in light and dark mode. This is the first bundled preset to exercise the whisper render path in the shipped app.

## Out of scope (separate issues)
- Gallery (shared-scenario) whisper adoption.
- Demo-replay (`DemoReplays/`) whisper adoption — pre-recorded data regeneration required.

Closes #957
Part of #906 / #908
