### PR TITLE
✨ feat: highlight share card — share utterances as images (#1070)

### DIFF
--- a/.claude/rules/swiftui-traps.md
+++ b/.claude/rules/swiftui-traps.md
@@ -301,3 +301,21 @@ Reference: #934 — the premise card + latest conversation row re-typed from Vie
 `introHasTyped` / row `visibleChars` `@State`; moved to
 `SimulationViewModel.introRevealHasBegun` / `latestRowRevealCompleted` (see the
 adopt early-return comment in `SimulationView`).
+
+## `ImageRenderer` does not inherit the ambient environment
+
+`ImageRenderer` rasterizes its content in a **default** environment — it does
+NOT pick up the caller's ambient `@Environment` (notably `\.colorScheme`). No
+diagnostic; the bug is appearance-only and surfaces just on a dark-mode device.
+Compounds with the fact that `PasturaPalette` tokens are static sRGB (light-only
+— the app does not adapt), so a token-styled view rasterizes in one fixed
+appearance regardless of the device.
+
+**Apply**: pass the appearance in **explicitly** — capture
+`@Environment(\.colorScheme)` at the call site, drive the view's palette from
+that value (an explicit `colorScheme` parameter, since static tokens won't
+switch on the environment alone), and also set `.environment(\.colorScheme, …)`
+on the rendered content for any system-colored subviews (SF Symbols, asset
+images). Real-device dark-mode QA required — the simulator misleads.
+
+Reference: `HighlightCardImageRenderer.render` + `HighlightShareCard` (#1070).

--- a/Pastura/Pastura/App/ModelRegistry.swift
+++ b/Pastura/Pastura/App/ModelRegistry.swift
@@ -156,3 +156,17 @@ enum ModelRegistry {
     )
   }
 }
+
+extension ModelRegistry {
+  /// Resolves a persisted `SimulationRecord.modelIdentifier` (stored as a
+  /// descriptor's `displayName`, e.g. "Gemma 4 E2B (Q4_K_M)") to its short
+  /// label ("Gemma 4 E2B") for the highlight share card (#1070), so the
+  /// past-results card shows the same model name as the live card (which reads
+  /// `shortDisplayName` directly). Falls back to the raw identifier when it
+  /// matches no catalog descriptor (a superseded model), and `nil` when absent.
+  nonisolated static func shortDisplayName(forIdentifier identifier: String?) -> String? {
+    guard let identifier, !identifier.isEmpty else { return nil }
+    let match = catalog.first { $0.displayName == identifier }
+    return match?.shortDisplayName ?? match?.displayName ?? identifier
+  }
+}

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -5962,6 +5962,22 @@
         }
       }
     },
+    "Share as Card" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Share as Card"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カードで共有"
+          }
+        }
+      }
+    },
     "Show all thoughts" : {
       "localizations" : {
         "ja" : {

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -7406,6 +7406,22 @@
         }
       }
     },
+    "from “%@”" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "from “%@”"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シナリオ「%@」より"
+          }
+        }
+      }
+    },
     "llama_decode failed (error %lld)" : {
       "localizations" : {
         "en" : {

--- a/Pastura/Pastura/Views/Components/AgentOutputRow.swift
+++ b/Pastura/Pastura/Views/Components/AgentOutputRow.swift
@@ -211,6 +211,11 @@ struct AgentOutputRow: View {
   /// (that would flush the load-bearing `@State`; see the `body` note).
   var onAvatarTap: ((String) -> Void)?
 
+  /// Invoked when the user picks "Share as Card" from the row's context menu
+  /// (#1070). `nil` (default) omits the menu entirely, so rows without a share
+  /// handler carry no long-press affordance.
+  var onShareHighlight: (() -> Void)?
+
   /// Playback-park probe. `nil` (default) = zero impact; a non-nil closure is
   /// evaluated once per reveal tick and, while it returns `true`, the reveal
   /// loop spins in place without advancing ``visibleChars`` — used to freeze
@@ -284,6 +289,7 @@ struct AgentOutputRow: View {
     agentPosition: Int? = nil,
     debugRowID: String? = nil,
     onAvatarTap: ((String) -> Void)? = nil,
+    onShareHighlight: (() -> Void)? = nil,
     isTypingParked: (() -> Bool)? = nil
   ) {
     self.agent = agent
@@ -304,6 +310,7 @@ struct AgentOutputRow: View {
     self.agentPosition = agentPosition
     self.debugRowID = debugRowID
     self.onAvatarTap = onAvatarTap
+    self.onShareHighlight = onShareHighlight
     self.isTypingParked = isTypingParked
     self._showInnerThought = State(initialValue: showAllThoughts)
     // Seed the reveal counter from the handoff position so the first frame
@@ -394,6 +401,7 @@ struct AgentOutputRow: View {
     .frame(maxWidth: .infinity, alignment: .leading)
     .fixedSize(horizontal: false, vertical: true)
     .padding(.vertical, 4)
+    .modifier(HighlightShareContextMenu(action: onShareHighlight))
     .onAppear {
       #if DEBUG
         logDebugLifecycle(event: "onAppear")

--- a/Pastura/Pastura/Views/Components/HighlightCardImageRenderer.swift
+++ b/Pastura/Pastura/Views/Components/HighlightCardImageRenderer.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+import UIKit
+
+/// Rasterizes a ``HighlightShareCard`` to a `UIImage` for the system share
+/// sheet (issue #1070).
+///
+/// First `ImageRenderer` use in the codebase. Two deliberate settings:
+/// - `scale = 3` exports the 360 pt card at 1080 px regardless of the device's
+///   native scale, so shared cards are a consistent resolution.
+/// - the `colorScheme` is passed **explicitly** into the card *and* the render
+///   environment — `ImageRenderer` renders in a default environment and does
+///   not inherit the ambient appearance, so without this a dark-mode user's
+///   card would rasterize light (see the ``HighlightShareCard`` doc-comment).
+@MainActor
+enum HighlightCardImageRenderer {
+
+  /// The export scale (360 pt → 1080 px).
+  static let scale: CGFloat = 3
+
+  /// Renders the card, or `nil` if `ImageRenderer` produced no image.
+  static func render(
+    _ model: HighlightShareCard.Model, colorScheme: ColorScheme
+  ) -> UIImage? {
+    let card = HighlightShareCard(model: model, colorScheme: colorScheme)
+      .environment(\.colorScheme, colorScheme)
+    let renderer = ImageRenderer(content: card)
+    renderer.scale = scale
+    // The card fills a solid background, so an opaque bitmap is correct and
+    // avoids a needless alpha channel in the shared PNG.
+    renderer.isOpaque = true
+    return renderer.uiImage
+  }
+
+  /// Builds a ready-to-share item, or `nil` when rendering fails — the call
+  /// site then simply does not present the share sheet (a silent no-op is the
+  /// intended UX for the rare render failure).
+  static func makeShareItem(
+    _ model: HighlightShareCard.Model, colorScheme: ColorScheme
+  ) -> HighlightShareItem? {
+    guard let image = render(model, colorScheme: colorScheme) else { return nil }
+    return HighlightShareItem(image: image, linkURL: model.linkURL)
+  }
+}
+
+/// A rendered highlight card packaged for `.sheet(item:)` + ``ShareSheet``.
+///
+/// Centralizes the `activityItems` composition so the image is always shared
+/// and the link is appended only when present — the optional link means a
+/// missing URL can never force-unwrap.
+struct HighlightShareItem: Identifiable {
+  let id = UUID()
+  let image: UIImage
+  let linkURL: URL?
+
+  /// Heterogeneous payload for `UIActivityViewController`: the card image plus
+  /// the burned-in link (when set) so messaging targets also get a tappable URL.
+  var activityItems: [Any] {
+    var items: [Any] = [image]
+    if let linkURL { items.append(linkURL) }
+    return items
+  }
+}

--- a/Pastura/Pastura/Views/Components/HighlightShareCard.swift
+++ b/Pastura/Pastura/Views/Components/HighlightShareCard.swift
@@ -238,6 +238,26 @@ private struct Palette {
     muted: .nightMuted, rule: .nightRule, moss: .nightMoss)
 }
 
+/// Adds a "Share as Card" context menu when `action` is non-nil; a nil action
+/// leaves the view untouched (no empty long-press menu on rows without a share
+/// handler). Shared by both highlight entry points (#1070): the live transcript
+/// row and the past-results row.
+struct HighlightShareContextMenu: ViewModifier {
+  let action: (() -> Void)?
+
+  func body(content: Content) -> some View {
+    if let action {
+      content.contextMenu {
+        Button(action: action) {
+          Label(String(localized: "Share as Card"), systemImage: "square.and.arrow.up")
+        }
+      }
+    } else {
+      content
+    }
+  }
+}
+
 #Preview("Highlight card — light / dark") {
   let filter = ContentFilter()
   return HStack(spacing: 20) {

--- a/Pastura/Pastura/Views/Components/HighlightShareCard.swift
+++ b/Pastura/Pastura/Views/Components/HighlightShareCard.swift
@@ -1,0 +1,260 @@
+import SwiftUI
+
+/// A shareable "highlight" image card built from a single agent utterance
+/// (issue #1070, Growth A-1).
+///
+/// The card is rasterized via `ImageRenderer` (see
+/// ``HighlightCardImageRenderer``) and handed to the system share sheet, so a
+/// memorable line from a simulation can be posted to social media as a
+/// self-contained one-shot image — the app's primary organic-growth path.
+///
+/// Presentation-only by design (ADR-009): it takes already-resolved ``Model``
+/// strings, never Engine/Data domain types. Both entry points (the live
+/// `SimulationView` transcript and the past-results `ResultDetailView`) build a
+/// ``Model`` and render this view off-screen.
+///
+/// ## Appearance
+///
+/// The card carries an **explicit** ``colorScheme`` rather than reading
+/// `@Environment(\.colorScheme)`. Two reasons, both load-bearing:
+/// 1. `ImageRenderer` renders its content in a *default* environment and does
+///    NOT inherit the ambient color scheme — an unset card would always
+///    rasterize light regardless of the device.
+/// 2. Pastura's `PasturaPalette` tokens are fixed sRGB (light-only; the app
+///    itself does not adapt to dark mode), so the card selects between the
+///    light and `night*` token families itself via ``Palette``.
+/// The caller captures the device's `@Environment(\.colorScheme)` at the
+/// share site and passes it in, so the shared image matches what the user sees.
+struct HighlightShareCard: View {
+
+  /// Resolved, display-ready values for the highlight card.
+  ///
+  /// The failable initializer is the content-safety + visibility guard: it
+  /// runs the raw utterance through `ContentFilter` (never trust the caller to
+  /// have filtered — the past-results path reads *unfiltered* persisted text,
+  /// see #1075) and returns `nil` when nothing visible remains, so the caller
+  /// renders nothing rather than an empty card.
+  nonisolated struct Model {
+    /// Agent display name (verbatim, not localized).
+    let agent: String
+    /// Avatar color slot, resolved from the agent name + turn position.
+    let character: SheepAvatar.Character
+    /// The quoted line — filtered and edge-trimmed, guaranteed non-empty.
+    let utterance: String
+    /// Scenario name, or `nil` to omit the "from …" line.
+    let scenarioTitle: String?
+    /// Inference model label (e.g. "Gemma 4 E2B"), or `nil` to omit the line.
+    let modelName: String?
+    /// Burned-in link. Optional so a missing/invalid URL just drops the line.
+    let linkURL: URL?
+
+    /// Builds a model, or returns `nil` when the filtered utterance has no
+    /// visible content.
+    ///
+    /// - Parameters:
+    ///   - rawUtterance: the display text as read at the call site; it is
+    ///     re-filtered here unconditionally.
+    ///   - contentFilter: injected so the applied filtering is testable
+    ///     (mirrors the production `ContentFilter()` the call sites hold).
+    init?(
+      agent: String,
+      agentPosition: Int?,
+      rawUtterance: String,
+      scenarioTitle: String?,
+      modelName: String?,
+      linkURL: URL?,
+      contentFilter: ContentFilter
+    ) {
+      let filtered = contentFilter.filter(rawUtterance)
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !filtered.isEmpty else { return nil }
+      self.agent = agent
+      self.character = SheepAvatar.Character.forAgent(agent, position: agentPosition)
+      self.utterance = filtered
+      self.scenarioTitle = Self.nonEmpty(scenarioTitle)
+      self.modelName = Self.nonEmpty(modelName)
+      self.linkURL = linkURL
+    }
+
+    /// Trims and collapses an optional label to `nil` when it has no visible
+    /// content, so an empty scenario title / model id drops its whole line
+    /// rather than rendering a stray separator.
+    private static func nonEmpty(_ value: String?) -> String? {
+      guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+        !trimmed.isEmpty
+      else { return nil }
+      return trimmed
+    }
+  }
+
+  let model: Model
+  /// Explicit appearance — see the type doc for why this is not read from the
+  /// environment.
+  var colorScheme: ColorScheme = .light
+
+  /// Point size of the square card. `ImageRenderer` scales this up (×3) to the
+  /// exported 1080 px asset. Kept as a constant so the layout math and the
+  /// renderer's `proposedSize` agree.
+  static let side: CGFloat = 360
+
+  /// The provisional burned-in share link. Universal-Links deep linking
+  /// (#1069 A-2) will later swap this for `pastura.app/s/<scenario-id>`; until
+  /// then every card points at the site root. Optional by construction so a
+  /// future malformed string can never force-unwrap.
+  static let shareLink: URL? = URL(string: "https://pastura.app")
+
+  private var palette: Palette { colorScheme == .dark ? .dark : .light }
+
+  var body: some View {
+    ZStack {
+      palette.background
+      // The single "light leak" the design system permits (§1: one glow only).
+      // A soft moss radial in the top-right — quiet, never washing the text.
+      RadialGradient(
+        gradient: Gradient(colors: [
+          palette.moss.opacity(colorScheme == .dark ? 0.10 : 0.14),
+          palette.moss.opacity(0)
+        ]),
+        center: .center, startRadius: 0, endRadius: 120
+      )
+      .frame(width: 240, height: 240)
+      .offset(x: 120, y: -120)
+
+      VStack(alignment: .leading, spacing: 0) {
+        header
+        Spacer().frame(height: 15)
+        quote
+        Spacer(minLength: 22)
+        footer
+      }
+      .padding(28)
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+    .frame(width: Self.side, height: Self.side)
+    .clipped()
+  }
+
+  private var header: some View {
+    HStack(spacing: 12) {
+      SheepAvatar(character: model.character, size: 46)
+      VStack(alignment: .leading, spacing: 2) {
+        Text(model.agent)
+          .font(.system(size: 16, weight: .semibold))
+          .foregroundStyle(palette.ink)
+          .lineLimit(1)
+          .minimumScaleFactor(0.8)
+        if let modelName = model.modelName {
+          Text(modelName)
+            .font(.system(size: 9.5, weight: .regular, design: .monospaced))
+            .foregroundStyle(palette.muted)
+            .lineLimit(1)
+            .minimumScaleFactor(0.8)
+        }
+      }
+    }
+  }
+
+  private var quote: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      // Serif open-quote ornament — a deliberate off-note against the sans
+      // body, marking "this is a quotation". Fixed height so it doesn't pad
+      // the utterance below it.
+      Text(verbatim: "\u{201C}")
+        .font(.system(size: 52, design: .serif))
+        .foregroundStyle(palette.moss.opacity(0.45))
+        .frame(height: 26, alignment: .top)
+      Text(model.utterance)
+        .font(.system(size: 20, weight: .medium))
+        .foregroundStyle(palette.ink)
+        .lineSpacing(6)
+        // Long utterances are quoted as a *fragment*: cap at 5 lines and
+        // ellipsize (#1070 truncation rule) rather than burning the whole
+        // speech into the card.
+        .lineLimit(5)
+        .truncationMode(.tail)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+  }
+
+  private var footer: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      Rectangle()
+        .fill(palette.rule)
+        .frame(height: 1)
+        .padding(.bottom, 14)
+      if let scenarioTitle = model.scenarioTitle {
+        Text(scenarioLine(scenarioTitle))
+          .font(.system(size: 12.5))
+          .foregroundStyle(palette.inkSecondary)
+          .lineLimit(1)
+          .minimumScaleFactor(0.8)
+          .padding(.bottom, 16)
+      }
+      HStack(spacing: 0) {
+        HStack(spacing: 9) {
+          Image("BrandIcon")
+            .resizable()
+            .frame(width: 22, height: 22)
+            .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
+          Text(verbatim: "Pastura")
+            .font(.system(size: 16, weight: .semibold))
+            .foregroundStyle(palette.ink)
+        }
+        Spacer(minLength: 8)
+        if let link = model.linkURL {
+          Text(verbatim: link.host ?? "pastura.app")
+            .font(.system(size: 12, design: .monospaced))
+            .foregroundStyle(palette.moss)
+        }
+      }
+    }
+  }
+
+  /// "from “<scenario>”" — localized; ja renders 「シナリオ「%@」より」.
+  private func scenarioLine(_ title: String) -> String {
+    String(format: String(localized: "from “%@”"), title)
+  }
+}
+
+/// Light / night token pair the card selects between by ``HighlightShareCard/colorScheme``.
+/// Reuses the design-system token families (`DesignTokens+SwiftUI`) so the
+/// palette never drifts from the app's canonical colors — the card simply picks
+/// which family renders, since the tokens themselves are static (see the card
+/// doc-comment).
+private struct Palette {
+  let background: Color
+  let ink: Color
+  let inkSecondary: Color
+  let muted: Color
+  let rule: Color
+  let moss: Color
+
+  static let light = Palette(
+    background: .screenBackground, ink: .ink, inkSecondary: .inkSecondary,
+    muted: .muted, rule: .rule, moss: .moss)
+
+  static let dark = Palette(
+    background: .nightBackground, ink: .nightInk, inkSecondary: .nightInkSecondary,
+    muted: .nightMuted, rule: .nightRule, moss: .nightMoss)
+}
+
+#Preview("Highlight card — light / dark") {
+  let filter = ContentFilter()
+  return HStack(spacing: 20) {
+    if let model = HighlightShareCard.Model(
+      agent: "Bob", agentPosition: 1,
+      rawUtterance: "正直に言うと、僕は最初から君を裏切るつもりだったんだ。でも今は…少しだけ後悔しているよ。",
+      scenarioTitle: "囚人のジレンマ", modelName: "Gemma 4 E2B",
+      linkURL: HighlightShareCard.shareLink, contentFilter: filter) {
+      HighlightShareCard(model: model, colorScheme: .light)
+    }
+    if let model = HighlightShareCard.Model(
+      agent: "Carol", agentPosition: 2,
+      rawUtterance: "Honestly? I planned to betray you from the very first round.",
+      scenarioTitle: "The Prisoner’s Dilemma", modelName: "Gemma 4 E2B",
+      linkURL: HighlightShareCard.shareLink, contentFilter: filter) {
+      HighlightShareCard(model: model, colorScheme: .dark)
+    }
+  }
+  .padding()
+}

--- a/Pastura/Pastura/Views/Results/ResultDetailView+Share.swift
+++ b/Pastura/Pastura/Views/Results/ResultDetailView+Share.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+extension ResultDetailView {
+  /// Composes a highlight share card from a past-results turn row and presents
+  /// the share sheet (#1070). Re-applies ContentFilter to the persisted output
+  /// (past-results stores *unfiltered* text — #1075), maps the run's model
+  /// identifier to its short label so the card matches the live path, and
+  /// no-ops if the utterance is empty or rendering fails.
+  func shareHighlight(agent: String, output: TurnOutput, phaseType: PhaseType) {
+    guard let text = output.primaryText(for: phaseType) else { return }
+    guard
+      let model = HighlightShareCard.Model(
+        agent: agent,
+        agentPosition: agentOrder.firstIndex(of: agent),
+        rawUtterance: text,
+        scenarioTitle: scenario?.name,
+        modelName: ModelRegistry.shortDisplayName(forIdentifier: simulation?.modelIdentifier),
+        linkURL: HighlightShareCard.shareLink,
+        contentFilter: contentFilter)
+    else { return }
+    highlightShareItem = HighlightCardImageRenderer.makeShareItem(model, colorScheme: colorScheme)
+  }
+}

--- a/Pastura/Pastura/Views/Results/ResultDetailView+TurnRows.swift
+++ b/Pastura/Pastura/Views/Results/ResultDetailView+TurnRows.swift
@@ -33,7 +33,10 @@ extension ResultDetailView {
           // Gate at the run level, not per-tap: a run whose scenario couldn't
           // be decoded (pre-v7 deleted scenario, YAML drift) has no personas,
           // so the rows stay non-tappable rather than showing a dead affordance.
-          onAvatarTap: personas.isEmpty ? nil : { selectedPersona = personaItem(for: $0) }
+          onAvatarTap: personas.isEmpty ? nil : { selectedPersona = personaItem(for: $0) },
+          onShareHighlight: {
+            shareHighlight(agent: agentName, output: output, phaseType: phaseType)
+          }
         )
         if contradictionBadgedTurnIDs.contains(turn.id) {
           ContradictionBadge()
@@ -62,5 +65,13 @@ extension ResultDetailView {
       return TurnOutput(fields: ["raw": turn.rawOutput])
     }
     return output
+  }
+
+  // Not `private`: read by the `+ResumeBanner.swift` sibling extension (D8
+  // resume gate) and `triggerYAMLExport` — cross-file callers can't see
+  // `private` members. Co-located with `decodeTurnOutput` as a decode helper.
+  func decodeState(from record: SimulationRecord) -> SimulationState? {
+    guard let data = record.stateJSON.data(using: .utf8) else { return nil }
+    return try? JSONDecoder().decode(SimulationState.self, from: data)
   }
 }

--- a/Pastura/Pastura/Views/Results/ResultDetailView.swift
+++ b/Pastura/Pastura/Views/Results/ResultDetailView.swift
@@ -20,7 +20,7 @@ struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
   @State private var events: [CodePhaseEventRecord] = []
   @State private var items: [ResultDetailTimelineBuilder.Item] = []
   @State var simulation: SimulationRecord?  // not private — see note above
-  @State private var scenario: ScenarioRecord?
+  @State var scenario: ScenarioRecord?  // not private — see note above
   /// Agent names in scenario-declared order, used to drive position-
   /// based avatar color assignment on turn rows. Empty when the
   /// scenario YAML couldn't be decoded (legacy data, YAML drift); in
@@ -62,6 +62,10 @@ struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
   // ContentFilter is `nonisolated Sendable` and effectively immutable, so a
   // per-view instance is cheap.
   let contentFilter = ContentFilter()
+  // Non-private + explicit colorScheme: the `+Share.swift` sibling composes and
+  // presents these (ImageRenderer ignores ambient appearance). (#1070)
+  @State var highlightShareItem: HighlightShareItem?
+  @Environment(\.colorScheme) var colorScheme
 
   private var canExport: Bool {
     !isExporting && simulation?.simulationStatus == .completed
@@ -174,6 +178,9 @@ struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
     }
     .sheet(item: $selectedPersona) { item in
       PersonaDetailSheet(persona: item.persona, position: item.position)
+    }
+    .sheet(item: $highlightShareItem) { item in
+      ShareSheet(activityItems: item.activityItems)
     }
     .alert(
       String(localized: "Export failed"),
@@ -366,14 +373,6 @@ struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
     } catch {
       self.exportError = error.localizedDescription
     }
-  }
-
-  // Not `private`: read by the `+ResumeBanner.swift` sibling extension (D8
-  // resume gate — `decodeState` + `resolveIsResumable` live there), which
-  // can't see `private` members (same-file only).
-  func decodeState(from record: SimulationRecord) -> SimulationState? {
-    guard let data = record.stateJSON.data(using: .utf8) else { return nil }
-    return try? JSONDecoder().decode(SimulationState.self, from: data)
   }
 
   /// Runs the demo-replay YAML exporter and hands the result to a

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -40,6 +40,13 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
   // returning to a parked-away run (ADR-017). Focus mode pins the run to whatever
   // tab is selected at start, so `selectedTab` here *is* the host tab.
   @Environment(TabCoordinator.self) private var tabCoordinator
+  // Read for the highlight share card's model label (#1070). Injected at the
+  // app root (PasturaApp), so this resolves on any tab-stack descendant.
+  @Environment(ModelManager.self) private var modelManager
+  // The share card rasterizes in a default ImageRenderer environment (it does
+  // not inherit ambient appearance), so capture the current scheme here and
+  // pass it in explicitly.
+  @Environment(\.colorScheme) private var colorScheme
   @State private var viewModel: SimulationViewModel?
   /// `true` while the back-button confirm-on-leave dialog is showing (#673).
   @State private var pendingBackLeave = false
@@ -67,6 +74,13 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
   @State private var loadError: String?
   @State private var exportPayload: ResultMarkdownExporter.ExportedResult?
   @State private var exportError: String?
+  /// The rendered highlight card awaiting the share sheet (#1070).
+  @State private var highlightShareItem: HighlightShareItem?
+  /// Re-applies content filtering when composing a share card. A View-local
+  /// instance (mirrors `ResultDetailView`) — the live log text is already
+  /// filtered, but re-filtering is idempotent and keeps the card path
+  /// self-contained.
+  private let contentFilter = ContentFilter()
   @State private var isExporting = false
   /// Whether the latest agent-output row is still typing. Used to suppress
   /// "X is thinking..." indicators so they don't appear above text that's
@@ -283,6 +297,9 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
     }
     .sheet(item: $exportPayload) { payload in
       ShareSheet(activityItems: [payload.text, payload.fileURL])
+    }
+    .sheet(item: $highlightShareItem) { item in
+      ShareSheet(activityItems: item.activityItems)
     }
     .alert(
       String(localized: "Export failed"),
@@ -1110,6 +1127,9 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
           agentPosition: scenario?.personas.firstIndex(where: { $0.name == agent }),
           debugRowID: entry.id.uuidString,
           onAvatarTap: { selectedPersona = personaItem(for: $0) },
+          onShareHighlight: {
+            shareHighlight(agent: agent, output: output, phaseType: phaseType)
+          },
           // Freeze the latest row's typewriter while the persona sheet is up
           // (#942 PR2). Live per-tick read — see AgentOutputRow.isTypingParked.
           isTypingParked: { viewModel.isPlaybackHeldForSheet }
@@ -1120,6 +1140,31 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
         }
       }
     }
+  }
+
+  /// Composes a highlight share card from a committed transcript row and
+  /// presents the share sheet (#1070). Re-filters the display text, resolves
+  /// the avatar slot / scenario / active model, and no-ops if the utterance is
+  /// empty or rendering fails.
+  private func shareHighlight(agent: String, output: TurnOutput, phaseType: PhaseType) {
+    guard let text = output.primaryText(for: phaseType) else { return }
+    guard
+      let model = HighlightShareCard.Model(
+        agent: agent,
+        agentPosition: scenario?.personas.firstIndex(where: { $0.name == agent }),
+        rawUtterance: text,
+        scenarioTitle: scenario?.name,
+        modelName: activeModelName,
+        linkURL: HighlightShareCard.shareLink,
+        contentFilter: contentFilter)
+    else { return }
+    highlightShareItem = HighlightCardImageRenderer.makeShareItem(model, colorScheme: colorScheme)
+  }
+
+  /// The active inference model's short label for the share card, or `nil` when
+  /// no model is resolvable (the card then omits the line).
+  private var activeModelName: String? {
+    modelManager.activeDescriptor?.shortDisplayName ?? modelManager.activeDescriptor?.displayName
   }
 
   @ViewBuilder

--- a/Pastura/PasturaTests/App/ModelRegistryShortNameTests.swift
+++ b/Pastura/PasturaTests/App/ModelRegistryShortNameTests.swift
@@ -1,0 +1,30 @@
+import Testing
+
+@testable import Pastura
+
+/// `ModelRegistry.shortDisplayName(forIdentifier:)` — the past-results share
+/// card's model-name resolution (issue #1070). Maps a persisted
+/// `SimulationRecord.modelIdentifier` (a descriptor `displayName`) to its short
+/// label so the past-results card matches the live card.
+@Suite(.timeLimit(.minutes(1)))
+struct ModelRegistryShortNameTests {
+
+  @Test("A known catalog displayName resolves to its short label")
+  func resolvesCatalogDisplayName() throws {
+    let descriptor = try #require(ModelRegistry.catalog.first)
+    let resolved = ModelRegistry.shortDisplayName(forIdentifier: descriptor.displayName)
+    #expect(resolved == (descriptor.shortDisplayName ?? descriptor.displayName))
+  }
+
+  @Test("nil / empty identifier yields nil (line omitted)")
+  func nilAndEmptyYieldNil() {
+    #expect(ModelRegistry.shortDisplayName(forIdentifier: nil) == nil)
+    #expect(ModelRegistry.shortDisplayName(forIdentifier: "") == nil)
+  }
+
+  @Test("Unknown identifier (superseded model) falls back to the raw string")
+  func unknownFallsBackToRaw() {
+    let raw = "Some Legacy Model 0.9B (Q2_K)"
+    #expect(ModelRegistry.shortDisplayName(forIdentifier: raw) == raw)
+  }
+}

--- a/Pastura/PasturaTests/Views/AgentOutputRowContractTests.swift
+++ b/Pastura/PasturaTests/Views/AgentOutputRowContractTests.swift
@@ -85,6 +85,21 @@ struct AgentOutputRowContractTests {
     )
   }
 
+  @Test func agentOutputRowAcceptsShareHighlightCallSite() {
+    // Matches the SimulationView / ResultDetailView committed-row call sites
+    // that wire the highlight-share context menu (#1070). The closure is
+    // optional (defaults nil); pin it so both entry points keep compiling.
+    _ = AgentOutputRow(
+      agent: "Alice",
+      output: TurnOutput(fields: ["statement": "a line worth sharing"]),
+      phaseType: .speakAll,
+      showAllThoughts: false,
+      agentPosition: 0,
+      onAvatarTap: { _ in },
+      onShareHighlight: {}
+    )
+  }
+
   // MARK: - targetLength — pure computed
 
   @Test func targetLengthCoversPrimaryWhenThoughtHidden() {

--- a/Pastura/PasturaTests/Views/HighlightShareCardModelTests.swift
+++ b/Pastura/PasturaTests/Views/HighlightShareCardModelTests.swift
@@ -1,0 +1,86 @@
+import Testing
+
+@testable import Pastura
+
+/// Data-shaping contract for ``HighlightShareCard/Model`` (issue #1070).
+///
+/// Per ADR-009 / `.claude/rules/view-testing.md`, the rendered card is not
+/// tested — only the pure `Model` failable init is: content filtering,
+/// empty→nil guards, avatar-slot resolution, and verbatim utterance storage.
+/// The 5-line truncation is a render concern (depends on font/width) and is
+/// intentionally out of scope here — it is covered by manual device QA.
+///
+/// `@MainActor` so the nonisolated test can compare `SheepAvatar.Character`
+/// values (auto-synth `Equatable` conformance lookup is MainActor-isolated —
+/// Pattern 5, `.claude/rules/swift-isolation.md`).
+@MainActor
+@Suite(.timeLimit(.minutes(1)))
+struct HighlightShareCardModelTests {
+
+  private func model(
+    agent: String = "Bob",
+    agentPosition: Int? = 1,
+    rawUtterance: String = "A memorable line.",
+    scenarioTitle: String? = "Prisoner's Dilemma",
+    modelName: String? = "Gemma 4 E2B",
+    contentFilter: ContentFilter = ContentFilter(blockedPatterns: [])
+  ) -> HighlightShareCard.Model? {
+    HighlightShareCard.Model(
+      agent: agent, agentPosition: agentPosition, rawUtterance: rawUtterance,
+      scenarioTitle: scenarioTitle, modelName: modelName,
+      linkURL: HighlightShareCard.shareLink, contentFilter: contentFilter)
+  }
+
+  @Test("ContentFilter is applied to the utterance")
+  func filterAppliedToUtterance() throws {
+    let filter = ContentFilter(blockedPatterns: ["betray"], replacement: "***")
+    let sut = try #require(
+      model(rawUtterance: "I planned to betray you.", contentFilter: filter))
+    #expect(!sut.utterance.contains("betray"))
+    #expect(sut.utterance.contains("***"))
+  }
+
+  @Test("Whitespace-only utterance yields nil")
+  func emptyUtteranceYieldsNil() {
+    #expect(model(rawUtterance: "   \n\t ") == nil)
+    #expect(model(rawUtterance: "") == nil)
+  }
+
+  @Test("An utterance fully redacted away still yields a model (redaction is visible content)")
+  func fullyRedactedYieldsModel() throws {
+    // "***" is visible content — only whitespace-emptiness drops the card.
+    let filter = ContentFilter(blockedPatterns: ["hi"], replacement: "***")
+    let sut = try #require(model(rawUtterance: "hi", contentFilter: filter))
+    #expect(sut.utterance == "***")
+  }
+
+  @Test("Avatar character resolves by position, then by canonical name")
+  func characterResolution() throws {
+    // Position wins (allCases[1 % 4] == .bob) regardless of name.
+    let byPosition = try #require(model(agent: "Zoe", agentPosition: 1))
+    #expect(byPosition.character == .bob)
+    // No position → canonical-name match.
+    let byName = try #require(model(agent: "Alice", agentPosition: nil))
+    #expect(byName.character == .alice)
+  }
+
+  @Test("Empty scenario title / model name collapse to nil (line omitted)")
+  func emptyLabelsCollapseToNil() throws {
+    let sut = try #require(model(scenarioTitle: "  ", modelName: ""))
+    #expect(sut.scenarioTitle == nil)
+    #expect(sut.modelName == nil)
+  }
+
+  @Test("Non-empty labels are trimmed but preserved")
+  func labelsTrimmed() throws {
+    let sut = try #require(model(scenarioTitle: "  Water Divination  ", modelName: " Gemma 4 E2B "))
+    #expect(sut.scenarioTitle == "Water Divination")
+    #expect(sut.modelName == "Gemma 4 E2B")
+  }
+
+  @Test("Utterance is edge-trimmed; internal spacing preserved")
+  func utteranceEdgeTrimmed() throws {
+    let sut = try #require(model(rawUtterance: "  keep  the   gaps  "))
+    #expect(sut.utterance == "keep  the   gaps")
+  }
+}

--- a/Pastura/PasturaTests/Views/HighlightShareItemTests.swift
+++ b/Pastura/PasturaTests/Views/HighlightShareItemTests.swift
@@ -1,0 +1,31 @@
+import Testing
+import UIKit
+
+@testable import Pastura
+
+/// Pure `activityItems` composition for ``HighlightShareItem`` (issue #1070).
+///
+/// The rendered `ImageRenderer` output is not tested (ADR-009 — no view
+/// rendering); only the deterministic share-payload shaping is: the image is
+/// always present, and the optional link is appended only when set (guarding
+/// the no-force-unwrap invariant).
+@MainActor
+@Suite(.timeLimit(.minutes(1)))
+struct HighlightShareItemTests {
+
+  @Test("Link is appended after the image when present")
+  func includesLinkWhenPresent() {
+    let url = URL(string: "https://pastura.app")
+    let item = HighlightShareItem(image: UIImage(), linkURL: url)
+    #expect(item.activityItems.count == 2)
+    #expect(item.activityItems.first is UIImage)
+    #expect(item.activityItems.last as? URL == url)
+  }
+
+  @Test("Only the image is shared when the link is nil")
+  func imageOnlyWhenLinkNil() {
+    let item = HighlightShareItem(image: UIImage(), linkURL: nil)
+    #expect(item.activityItems.count == 1)
+    #expect(item.activityItems.first is UIImage)
+  }
+}


### PR DESCRIPTION
## Summary

Stage 1 (manual-selection MVP) of the highlight share card (Growth A-1): pick an agent's utterance from a transcript row and share it as a self-contained image card — a sheep avatar, agent name, inference model, quoted line, scenario title, BrandIcon, and a `pastura.app` link — the app's primary organic-growth path ("weird thing said" screenshots).

- **Card** — `HighlightShareCard` (Views/Components): a pure, unit-tested `Model` failable-init that **re-applies `ContentFilter` unconditionally** (the past-results path reads *unfiltered* persisted text, tracked in #1075), plus a presentation-only SwiftUI view (ADR-009 — the rendered view is not unit-tested). Explicit `colorScheme` drives a light/night design-token pair because `ImageRenderer` does not inherit ambient appearance and Pastura's tokens are static light-only.
- **Rasterize + share** — `HighlightCardImageRenderer` (first `ImageRenderer` use; scale 3 → 1080 px, opaque, explicit colorScheme). `HighlightShareItem` centralizes the `ShareSheet` payload (image + optional link, no force unwrap); nil-render is a silent no-op.
- **Two entry points** via a shared `HighlightShareContextMenu` ("Share as Card", no-op when no handler): the live `SimulationView` committed rows (streaming in-flight rows excluded — text incomplete) and the past-results `ResultDetailView` rows. Model name is consistent across both: live reads `ModelManager.activeDescriptor?.shortDisplayName`; past-results maps the persisted `modelIdentifier` via new `ModelRegistry.shortDisplayName(forIdentifier:)`.
- Link is provisional `https://pastura.app`; #1069 A-2 (Universal Links) will later swap in `/s/<scenario-id>` without blocking this.
- `ResultDetailView` was at the 400-line `file_length` cap, so `shareHighlight` lands in a new `+Share.swift` sibling and `decodeState` moves next to `decodeTurnOutput` in `+TurnRows.swift`.

Visual design was approved by the maintainer via an HTML mock before implementation (square 1:1, quote-as-hero, 5-line truncation, real BrandIcon).

Engine diff is zero — App/Views only.

## Test plan

- `HighlightShareCardModelTests` — ContentFilter applied, empty→nil, fully-redacted still renders, avatar-slot resolution, label trimming, verbatim utterance (data-shaping only; truncation is a render concern, ADR-009).
- `HighlightShareItemTests` — activityItems includes the link only when present.
- `ModelRegistryShortNameTests` — displayName→short resolution, nil/empty→nil, unknown→raw fallback.
- `AgentOutputRowContractTests` — pins the new `onShareHighlight` call site.
- Full unit suite: **2954 tests / 239 suites green**. SwiftLint `--strict` clean (each commit).
- `code-reviewer` (Opus): **PASS**, 0 blocking.

## Device QA

Simulator misleads for appearance-sensitive `ImageRenderer` output and for iOS 26 context-menu/sheet rendering (`.claude/rules/swiftui-traps.md`), so verify on a real device:

- **Both entry points** — long-press a committed row in a live simulation, and a turn row in Past Results → "Share as Card" appears and produces a card.
- **Appearance** — card renders correctly in **light and dark** system appearance (device scheme, not just simulator).
- **Locale** — card copy correct in **ja and en** ("シナリオ「…」より" / "from “…”"), and the utterance/model/agent render without clipping.
- **Truncation** — a long utterance caps at 5 lines + ellipsis; short lines and empty labels omit cleanly.
- **Share sheet** — the sheet receives the image (+ link); saving/AirDrop/messaging targets behave.
- **Stacked sheets** — share-card presentation does not race the existing persona / export sheets on the same view (three `.sheet(item:)` now stack).

Part of #1070 (Stage 2 — auto-highlight heuristics — is a separate follow-up PR in the same issue).
