### PR TITLE
✨ feat: 共有カードに心の声を追加＋発言行に共有ボタン

### DIFF
--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -5978,22 +5978,6 @@
         }
       }
     },
-    "Share options" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Share options"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "共有オプション"
-          }
-        }
-      }
-    },
     "Show all thoughts" : {
       "localizations" : {
         "ja" : {

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -5978,6 +5978,22 @@
         }
       }
     },
+    "Share options" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Share options"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "共有オプション"
+          }
+        }
+      }
+    },
     "Show all thoughts" : {
       "localizations" : {
         "ja" : {

--- a/Pastura/Pastura/Views/Components/AgentOutputRow.swift
+++ b/Pastura/Pastura/Views/Components/AgentOutputRow.swift
@@ -398,7 +398,7 @@ struct AgentOutputRow: View {
       // trailing edge is empty (the `Spacer` above).
       .overlay(alignment: .topTrailing) {
         if let onShareHighlight {
-          shareMenuButton(action: onShareHighlight)
+          shareButton(action: onShareHighlight)
         }
       }
     }
@@ -458,13 +458,15 @@ struct AgentOutputRow: View {
 
   // MARK: - Subviews
 
-  /// Visible per-row share affordance (#1080): a quiet "•••" `Menu` that
-  /// surfaces the same "Share as Card" action as the long-press
+  /// Visible per-row share affordance (#1080): a quiet share glyph that
+  /// triggers the same "Share as Card" action as the long-press
   /// ``HighlightShareContextMenu`` — the long-press alone was undiscoverable.
-  /// Both render ``highlightShareMenuItems`` from one builder so they can't
-  /// drift. Rendered only when `onShareHighlight` is non-nil (same nil-omission
-  /// as the context menu — appears on committed Sim + Results rows, not the
-  /// streaming in-flight row nor the DL-demo replay).
+  /// A **direct button** (not a `•••` menu) because share is the only per-row
+  /// action today: burying a sole action behind a menu costs a needless extra
+  /// tap (HIG). If more per-row actions arrive, switch this to a `Menu`
+  /// rendering ``highlightShareMenuItems``. Rendered only when `onShareHighlight`
+  /// is non-nil (same nil-omission as the context menu — appears on committed
+  /// Sim + Results rows, not the streaming in-flight row nor the DL-demo replay).
   ///
   /// `.buttonStyle(.borderless)` isolates the tap so it doesn't activate the
   /// enclosing row inside a `List`/`LazyVStack`, and the `.contentShape` on a
@@ -472,18 +474,16 @@ struct AgentOutputRow: View {
   /// stays pinned to the corner. The INNER VOICE expand chevron lives far
   /// below-left, so the two hit regions don't collide.
   @ViewBuilder
-  private func shareMenuButton(action: @escaping () -> Void) -> some View {
-    Menu {
-      highlightShareMenuItems(action: action)
-    } label: {
-      Image(systemName: "ellipsis")
+  private func shareButton(action: @escaping () -> Void) -> some View {
+    Button(action: action) {
+      Image(systemName: "square.and.arrow.up")
         .font(.system(size: 13, weight: .semibold))
         .foregroundStyle(Color.muted)
         .frame(width: 44, height: 28, alignment: .trailing)
         .contentShape(Rectangle())
     }
     .buttonStyle(.borderless)
-    .accessibilityLabel(String(localized: "Share options"))
+    .accessibilityLabel(String(localized: "Share as Card"))
   }
 
   /// Renders the primary text. Default: the concat trick so the final

--- a/Pastura/Pastura/Views/Components/AgentOutputRow.swift
+++ b/Pastura/Pastura/Views/Components/AgentOutputRow.swift
@@ -392,6 +392,15 @@ struct AgentOutputRow: View {
           ? dim[.top] - SheepAvatar.visibleTopInset(forSize: ChatBubbleLayout.avatarSize)
           : dim[.top]
       }
+      // Visible share affordance (#1080). Placed as an overlay OUTSIDE the
+      // `.firstTextBaseline` name row so its 44pt hit target never inflates
+      // the name/phase baseline; pinned top-trailing where the name row's
+      // trailing edge is empty (the `Spacer` above).
+      .overlay(alignment: .topTrailing) {
+        if let onShareHighlight {
+          shareMenuButton(action: onShareHighlight)
+        }
+      }
     }
     // Layout-stability trio (applied unconditionally; see type doc-comment
     // §"Reflow-stable rendering"). Streaming growth re-runs the text
@@ -448,6 +457,34 @@ struct AgentOutputRow: View {
   }
 
   // MARK: - Subviews
+
+  /// Visible per-row share affordance (#1080): a quiet "•••" `Menu` that
+  /// surfaces the same "Share as Card" action as the long-press
+  /// ``HighlightShareContextMenu`` — the long-press alone was undiscoverable.
+  /// Both render ``highlightShareMenuItems`` from one builder so they can't
+  /// drift. Rendered only when `onShareHighlight` is non-nil (same nil-omission
+  /// as the context menu — appears on committed Sim + Results rows, not the
+  /// streaming in-flight row nor the DL-demo replay).
+  ///
+  /// `.buttonStyle(.borderless)` isolates the tap so it doesn't activate the
+  /// enclosing row inside a `List`/`LazyVStack`, and the `.contentShape` on a
+  /// 44pt-wide, trailing-aligned label gives a HIG hit target while the glyph
+  /// stays pinned to the corner. The INNER VOICE expand chevron lives far
+  /// below-left, so the two hit regions don't collide.
+  @ViewBuilder
+  private func shareMenuButton(action: @escaping () -> Void) -> some View {
+    Menu {
+      highlightShareMenuItems(action: action)
+    } label: {
+      Image(systemName: "ellipsis")
+        .font(.system(size: 13, weight: .semibold))
+        .foregroundStyle(Color.muted)
+        .frame(width: 44, height: 28, alignment: .trailing)
+        .contentShape(Rectangle())
+    }
+    .buttonStyle(.borderless)
+    .accessibilityLabel(String(localized: "Share options"))
+  }
 
   /// Renders the primary text. Default: the concat trick so the final
   /// layout is established on first frame and the revealed prefix grows in

--- a/Pastura/Pastura/Views/Components/HighlightShareCard.swift
+++ b/Pastura/Pastura/Views/Components/HighlightShareCard.swift
@@ -300,11 +300,11 @@ private struct Palette {
     muted: .nightMuted, rule: .nightRule, moss: .nightMoss)
 }
 
-/// The shared menu content for the highlight share affordance — currently a
-/// single "Share as Card" action. Rendered by BOTH the long-press
-/// ``HighlightShareContextMenu`` and the visible `•••` `Menu` in
-/// ``AgentOutputRow`` (#1080), so the two surfaces present an identical menu
-/// and can never drift as actions are added.
+/// The long-press menu content for the highlight share affordance — currently a
+/// single "Share as Card" action, factored out so that if more per-row actions
+/// arrive, ``AgentOutputRow``'s visible affordance can switch from its direct
+/// share button to a `Menu` rendering this same builder without the two
+/// surfaces drifting.
 @ViewBuilder
 func highlightShareMenuItems(action: @escaping () -> Void) -> some View {
   Button(action: action) {
@@ -315,9 +315,8 @@ func highlightShareMenuItems(action: @escaping () -> Void) -> some View {
 /// Adds a "Share as Card" context menu when `action` is non-nil; a nil action
 /// leaves the view untouched (no empty long-press menu on rows without a share
 /// handler). Shared by both highlight entry points (#1070): the live transcript
-/// row and the past-results row. The visible `•••` menu in ``AgentOutputRow``
-/// (#1080) renders the same ``highlightShareMenuItems`` so long-press and tap
-/// stay in lockstep.
+/// row and the past-results row. ``AgentOutputRow`` (#1080) pairs this
+/// long-press menu with a visible direct share button for discoverability.
 struct HighlightShareContextMenu: ViewModifier {
   let action: (() -> Void)?
 

--- a/Pastura/Pastura/Views/Components/HighlightShareCard.swift
+++ b/Pastura/Pastura/Views/Components/HighlightShareCard.swift
@@ -300,19 +300,31 @@ private struct Palette {
     muted: .nightMuted, rule: .nightRule, moss: .nightMoss)
 }
 
+/// The shared menu content for the highlight share affordance — currently a
+/// single "Share as Card" action. Rendered by BOTH the long-press
+/// ``HighlightShareContextMenu`` and the visible `•••` `Menu` in
+/// ``AgentOutputRow`` (#1080), so the two surfaces present an identical menu
+/// and can never drift as actions are added.
+@ViewBuilder
+func highlightShareMenuItems(action: @escaping () -> Void) -> some View {
+  Button(action: action) {
+    Label(String(localized: "Share as Card"), systemImage: "square.and.arrow.up")
+  }
+}
+
 /// Adds a "Share as Card" context menu when `action` is non-nil; a nil action
 /// leaves the view untouched (no empty long-press menu on rows without a share
 /// handler). Shared by both highlight entry points (#1070): the live transcript
-/// row and the past-results row.
+/// row and the past-results row. The visible `•••` menu in ``AgentOutputRow``
+/// (#1080) renders the same ``highlightShareMenuItems`` so long-press and tap
+/// stay in lockstep.
 struct HighlightShareContextMenu: ViewModifier {
   let action: (() -> Void)?
 
   func body(content: Content) -> some View {
     if let action {
       content.contextMenu {
-        Button(action: action) {
-          Label(String(localized: "Share as Card"), systemImage: "square.and.arrow.up")
-        }
+        highlightShareMenuItems(action: action)
       }
     } else {
       content

--- a/Pastura/Pastura/Views/Components/HighlightShareCard.swift
+++ b/Pastura/Pastura/Views/Components/HighlightShareCard.swift
@@ -41,6 +41,10 @@ struct HighlightShareCard: View {
     let character: SheepAvatar.Character
     /// The quoted line — filtered and edge-trimmed, guaranteed non-empty.
     let utterance: String
+    /// The agent's inner thought (心の声), filtered and edge-trimmed, or `nil`
+    /// when absent / filtered-to-empty so the card drops the INNER VOICE
+    /// section rather than rendering an empty ornament (#1080).
+    let thought: String?
     /// Scenario name, or `nil` to omit the "from …" line.
     let scenarioTitle: String?
     /// Inference model label (e.g. "Gemma 4 E2B"), or `nil` to omit the line.
@@ -54,12 +58,19 @@ struct HighlightShareCard: View {
     /// - Parameters:
     ///   - rawUtterance: the display text as read at the call site; it is
     ///     re-filtered here unconditionally.
+    ///   - rawThought: the inner-thought text as read at the call site
+    ///     (`nil` for phases without a thought). Re-filtered here — like
+    ///     `rawUtterance`, persisted thought text is *unfiltered* (#1075), so
+    ///     it must be re-filtered before it is burned into a public share
+    ///     image (ADR-005). A thought that filters to empty collapses to `nil`
+    ///     (utterance-only card); it never drops the whole model.
     ///   - contentFilter: injected so the applied filtering is testable
     ///     (mirrors the production `ContentFilter()` the call sites hold).
     init?(
       agent: String,
       agentPosition: Int?,
       rawUtterance: String,
+      rawThought: String?,
       scenarioTitle: String?,
       modelName: String?,
       linkURL: URL?,
@@ -71,6 +82,7 @@ struct HighlightShareCard: View {
       self.agent = agent
       self.character = SheepAvatar.Character.forAgent(agent, position: agentPosition)
       self.utterance = filtered
+      self.thought = Self.filteredNonEmpty(rawThought, filter: contentFilter)
       self.scenarioTitle = Self.nonEmpty(scenarioTitle)
       self.modelName = Self.nonEmpty(modelName)
       self.linkURL = linkURL
@@ -84,6 +96,19 @@ struct HighlightShareCard: View {
         !trimmed.isEmpty
       else { return nil }
       return trimmed
+    }
+
+    /// Runs an optional raw thought through the content filter and collapses a
+    /// blocked-to-empty / whitespace-only result to `nil`. Same `ContentFilter`
+    /// pass as the utterance (a redaction to visible content like "***" is
+    /// kept — only whitespace-emptiness drops the thought), so the card takes
+    /// the utterance-only layout rather than rendering an empty INNER VOICE
+    /// section.
+    private static func filteredNonEmpty(_ raw: String?, filter: ContentFilter) -> String? {
+      guard let raw else { return nil }
+      let filtered = filter.filter(raw)
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+      return filtered.isEmpty ? nil : filtered
     }
   }
 
@@ -155,24 +180,61 @@ struct HighlightShareCard: View {
   }
 
   private var quote: some View {
-    VStack(alignment: .leading, spacing: 4) {
-      // Serif open-quote ornament — a deliberate off-note against the sans
-      // body, marking "this is a quotation". Fixed height so it doesn't pad
-      // the utterance below it.
-      Text(verbatim: "\u{201C}")
-        .font(.system(size: 52, design: .serif))
-        .foregroundStyle(palette.moss.opacity(0.45))
-        .frame(height: 26, alignment: .top)
-      Text(model.utterance)
-        .font(.system(size: 20, weight: .medium))
-        .foregroundStyle(palette.ink)
-        .lineSpacing(6)
-        // Long utterances are quoted as a *fragment*: cap at 5 lines and
-        // ellipsize (#1070 truncation rule) rather than burning the whole
-        // speech into the card.
-        .lineLimit(5)
-        .truncationMode(.tail)
-        .fixedSize(horizontal: false, vertical: true)
+    VStack(alignment: .leading, spacing: 14) {
+      VStack(alignment: .leading, spacing: 4) {
+        // Serif open-quote ornament — a deliberate off-note against the sans
+        // body, marking "this is a quotation". Fixed height so it doesn't pad
+        // the utterance below it.
+        Text(verbatim: "\u{201C}")
+          .font(.system(size: 52, design: .serif))
+          .foregroundStyle(palette.moss.opacity(0.45))
+          .frame(height: 26, alignment: .top)
+        Text(model.utterance)
+          .font(.system(size: 20, weight: .medium))
+          .foregroundStyle(palette.ink)
+          .lineSpacing(6)
+          // Long utterances are quoted as a *fragment* and ellipsize (#1070
+          // truncation rule). With a thought below, cap the spoken line
+          // tighter so both blocks fit the 360pt square; utterance-only keeps
+          // the original 5-line budget. Over-budget content clips gracefully
+          // via the card's `.clipped()` — the card is a highlight, not a full
+          // transcript.
+          .lineLimit(model.thought == nil ? 5 : 3)
+          .truncationMode(.tail)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+      if let thought = model.thought {
+        thoughtSection(thought)
+      }
+    }
+  }
+
+  /// The 心の声 (INNER VOICE) block beneath the utterance (#1080). Echoes the
+  /// transcript row's inner-voice visual language (design-system §5.2 — moss
+  /// left rule + mono UPPER tag + muted italic body) so the shared card reads
+  /// in the same idiom as the app. Line-capped for the square; long thoughts
+  /// ellipsize.
+  private func thoughtSection(_ thought: String) -> some View {
+    HStack(alignment: .top, spacing: 10) {
+      RoundedRectangle(cornerRadius: 1.25, style: .continuous)
+        .fill(palette.moss.opacity(0.5))
+        .frame(width: 2.5)
+      VStack(alignment: .leading, spacing: 4) {
+        // Reuses the transcript row's "INNER VOICE" catalog key (see
+        // `AgentOutputRow.thoughtToggleHeader`) — same literal, no new key.
+        Text(String(localized: "INNER VOICE"))
+          .font(.system(size: 9.5, weight: .semibold, design: .monospaced))
+          .tracking(0.6)
+          .foregroundStyle(palette.moss)
+        Text(thought)
+          .font(.system(size: 15, weight: .regular))
+          .italic()
+          .foregroundStyle(palette.inkSecondary)
+          .lineSpacing(4)
+          .lineLimit(3)
+          .truncationMode(.tail)
+          .fixedSize(horizontal: false, vertical: true)
+      }
     }
   }
 
@@ -264,6 +326,7 @@ struct HighlightShareContextMenu: ViewModifier {
     if let model = HighlightShareCard.Model(
       agent: "Bob", agentPosition: 1,
       rawUtterance: "正直に言うと、僕は最初から君を裏切るつもりだったんだ。でも今は…少しだけ後悔しているよ。",
+      rawThought: "本当は協力したかった。でも先に裏切られるのが怖くて、こちらから裏切ってしまった。",
       scenarioTitle: "囚人のジレンマ", modelName: "Gemma 4 E2B",
       linkURL: HighlightShareCard.shareLink, contentFilter: filter) {
       HighlightShareCard(model: model, colorScheme: .light)
@@ -271,6 +334,7 @@ struct HighlightShareContextMenu: ViewModifier {
     if let model = HighlightShareCard.Model(
       agent: "Carol", agentPosition: 2,
       rawUtterance: "Honestly? I planned to betray you from the very first round.",
+      rawThought: "I keep telling myself it was just strategy. It wasn’t.",
       scenarioTitle: "The Prisoner’s Dilemma", modelName: "Gemma 4 E2B",
       linkURL: HighlightShareCard.shareLink, contentFilter: filter) {
       HighlightShareCard(model: model, colorScheme: .dark)

--- a/Pastura/Pastura/Views/Results/ResultDetailView+Share.swift
+++ b/Pastura/Pastura/Views/Results/ResultDetailView+Share.swift
@@ -13,6 +13,7 @@ extension ResultDetailView {
         agent: agent,
         agentPosition: agentOrder.firstIndex(of: agent),
         rawUtterance: text,
+        rawThought: output.secondaryText(for: phaseType),
         scenarioTitle: scenario?.name,
         modelName: ModelRegistry.shortDisplayName(forIdentifier: simulation?.modelIdentifier),
         linkURL: HighlightShareCard.shareLink,

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -1153,6 +1153,7 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
         agent: agent,
         agentPosition: scenario?.personas.firstIndex(where: { $0.name == agent }),
         rawUtterance: text,
+        rawThought: output.secondaryText(for: phaseType),
         scenarioTitle: scenario?.name,
         modelName: activeModelName,
         linkURL: HighlightShareCard.shareLink,

--- a/Pastura/PasturaTests/Views/HighlightShareCardModelTests.swift
+++ b/Pastura/PasturaTests/Views/HighlightShareCardModelTests.swift
@@ -21,13 +21,14 @@ struct HighlightShareCardModelTests {
     agent: String = "Bob",
     agentPosition: Int? = 1,
     rawUtterance: String = "A memorable line.",
+    rawThought: String? = nil,
     scenarioTitle: String? = "Prisoner's Dilemma",
     modelName: String? = "Gemma 4 E2B",
     contentFilter: ContentFilter = ContentFilter(blockedPatterns: [])
   ) -> HighlightShareCard.Model? {
     HighlightShareCard.Model(
       agent: agent, agentPosition: agentPosition, rawUtterance: rawUtterance,
-      scenarioTitle: scenarioTitle, modelName: modelName,
+      rawThought: rawThought, scenarioTitle: scenarioTitle, modelName: modelName,
       linkURL: HighlightShareCard.shareLink, contentFilter: contentFilter)
   }
 
@@ -82,5 +83,47 @@ struct HighlightShareCardModelTests {
   func utteranceEdgeTrimmed() throws {
     let sut = try #require(model(rawUtterance: "  keep  the   gaps  "))
     #expect(sut.utterance == "keep  the   gaps")
+  }
+
+  // MARK: - Inner thought (心の声, #1080)
+
+  @Test("ContentFilter is applied to the inner thought")
+  func filterAppliedToThought() throws {
+    let filter = ContentFilter(blockedPatterns: ["betray"], replacement: "***")
+    let sut = try #require(model(rawThought: "I will betray them.", contentFilter: filter))
+    let thought = try #require(sut.thought)
+    #expect(!thought.contains("betray"))
+    #expect(thought.contains("***"))
+  }
+
+  @Test("Nil raw thought yields a nil thought (utterance-only card)")
+  func nilThoughtYieldsNil() throws {
+    let sut = try #require(model(rawThought: nil))
+    #expect(sut.thought == nil)
+  }
+
+  @Test("A thought that filters/trims to empty collapses to nil; model still builds")
+  func emptyThoughtCollapsesToNil() throws {
+    // Whitespace-only thought → dropped, but the card is still produced.
+    let blank = try #require(model(rawThought: "   \n\t "))
+    #expect(blank.thought == nil)
+    #expect(blank.utterance == "A memorable line.")
+    // Thought fully removed by the filter (empty replacement) → dropped.
+    let filter = ContentFilter(blockedPatterns: ["secret"], replacement: "")
+    let redacted = try #require(model(rawThought: "secret", contentFilter: filter))
+    #expect(redacted.thought == nil)
+  }
+
+  @Test("A thought redacted to visible content is kept (redaction is visible content)")
+  func redactedThoughtKept() throws {
+    let filter = ContentFilter(blockedPatterns: ["x"], replacement: "***")
+    let sut = try #require(model(rawThought: "x", contentFilter: filter))
+    #expect(sut.thought == "***")
+  }
+
+  @Test("Inner thought is edge-trimmed; internal spacing preserved")
+  func thoughtEdgeTrimmed() throws {
+    let sut = try #require(model(rawThought: "  I have   doubts  "))
+    #expect(sut.thought == "I have   doubts")
   }
 }


### PR DESCRIPTION
## Summary

Adjusts the shipped highlight share card (Growth A-1, #1070). Two changes:

- **Render the inner thought (心の声 / INNER VOICE) on the share card.** The card previously showed only the spoken utterance; the 心の声 is often the memorable part, so it's now included whenever present. `HighlightShareCard.Model` gains a required `rawThought` init arg, re-filtered through the **same `ContentFilter` pass** as the utterance (persisted thought is *unfiltered* — #1075 — so re-filtering before it's burned into a public image is required, ADR-005) and collapsed to `nil` when it filters/trims to empty (utterance-only card, never an empty INNER VOICE ornament). The card body renders a moss-ruled INNER VOICE block below the quote, echoing the transcript row's inner-voice idiom; the spoken line's cap tightens 5→3 when a thought is present so both blocks fit the 360pt `.clipped()` square.
- **Surface a visible share button on each utterance row.** The share action was reachable only through an invisible long-press `contextMenu`, so users never discovered it. A quiet share glyph (`square.and.arrow.up`) is now pinned to each row header's top-trailing, firing the same "Share as Card" action on tap. The long-press `contextMenu` is kept as a power-user shortcut. (Started as a "•••" menu; switched to a **direct button** since share is the only per-row action today — a single-action menu costs a needless extra tap per HIG. `highlightShareMenuItems` is kept factored out so it can go back to a `Menu` if more actions arrive.)

### Design notes
- The button is an `.overlay(alignment: .topTrailing)` placed **outside** the `.firstTextBaseline` name row, so its 44pt hit target never inflates the name/phase baseline; `.buttonStyle(.borderless)` + `.contentShape` keep the tap from colliding with the INNER VOICE expand chevron below. Omitted entirely when `onShareHighlight` is nil (committed Sim + Results rows only — not the streaming in-flight row nor DL-demo replay).
- Discoverability approach (visible affordance over long-press-only) grounded in HIG (a context menu must not be the sole path to an action) + an independent design consult.

## Test plan
- `HighlightShareCard.Model` unit tests extended (12 total): thought is re-filtered, nil-in→nil-out, filter/trim-to-empty collapses to nil (model still built), redaction-to-visible kept, edge-trim. All green.
- Full unit suite: 2959 tests pass. SwiftLint `--strict` clean. `check_localization_coverage.py` OK (new `Share options` key: en + ja 共有オプション, both translated).
- Code review (Opus): PASS, 0 blocking.

## Device QA
Requires a **real device** (the card rasterizes via `ImageRenderer` in a fixed appearance; the simulator misleads on dark mode — swiftui-traps §ImageRenderer):
- Share a card from a turn **with** an inner thought and one **without** — verify the INNER VOICE block renders (moss rule + label + italic body) and the utterance-only layout falls back cleanly.
- **Light AND dark mode**, and a **long utterance + long thought** case — confirm the 360pt square clips gracefully (no corruption / no empty INNER VOICE ornament) and the line budget reads acceptably. This line budget (utterance 3 / thought 3) is the visual-judgment knob to eyeball and tune.
- **Share button placement**: tap fires the share sheet; the glyph sits at the row header top-trailing without shifting the name/phase baseline; its hit target does not collide with the INNER VOICE expand chevron. Verify on both live Simulation and past Results rows.

Closes #1080. Relates to #1070 (Growth A-1) / umbrella #1069.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
