### PR TITLE
🐛 fix: clamp speak_each subRounds to ≥1 (ClosedRange trap)

### DIFF
--- a/Pastura/Pastura/Engine/Phases/SpeakEachHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/SpeakEachHandler.swift
@@ -17,7 +17,11 @@ nonisolated struct SpeakEachHandler: PhaseHandler {
     context: PhaseContext,
     state: inout SimulationState
   ) async throws {
-    let subRounds = context.phase.subRounds ?? 1
+    // `subRounds` is untrusted (any un-vetted YAML ingest can set `rounds: 0`
+    // or a negative); clamp to ≥1 so `1...subRounds` below can't form an
+    // invalid ClosedRange and trap. Mirrors WhisperHandler's guard on the
+    // same "sub-rounds" input.
+    let subRounds = max(1, context.phase.subRounds ?? 1)
     let promptTemplate =
       context.phase.prompt
       ?? pickLanguage(

--- a/Pastura/PasturaTests/Engine/Phases/SpeakEachHandlerTests.swift
+++ b/Pastura/PasturaTests/Engine/Phases/SpeakEachHandlerTests.swift
@@ -108,6 +108,60 @@ struct SpeakEachHandlerTests {
     #expect(mock.generateCallCount == 1)
   }
 
+  // MARK: - subRounds clamp (untrusted YAML guard, #1064)
+
+  // `subRounds: 0` would form the invalid ClosedRange `1...0` and trap the
+  // app pre-fix. The clamp (`max(1, …)`) makes it behave as one sub-round —
+  // exactly one pass over the personas. Reverting the clamp line must crash
+  // this test, not merely change its pass mode.
+  @Test func zeroSubRoundsRunsOncePerPersona() async throws {
+    let mock = MockLLMService(responses: [
+      #"{"statement": "A1"}"#,
+      #"{"statement": "B1"}"#
+    ])
+    try await mock.loadModel()
+
+    let scenario = makeTestScenario(
+      agentNames: ["Alice", "Bob"],
+      phases: [
+        Phase(type: .speakEach, prompt: "Talk", outputSchema: ["statement": "string"], subRounds: 0)
+      ]
+    )
+    var state = SimulationState.initial(for: scenario)
+    state.currentRound = 1
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    // 2 agents × 1 clamped sub-round = 2 calls (no trap).
+    #expect(mock.generateCallCount == 2)
+  }
+
+  @Test func negativeSubRoundsRunsOncePerPersona() async throws {
+    let mock = MockLLMService(responses: [
+      #"{"statement": "A1"}"#,
+      #"{"statement": "B1"}"#
+    ])
+    try await mock.loadModel()
+
+    let scenario = makeTestScenario(
+      agentNames: ["Alice", "Bob"],
+      phases: [
+        Phase(
+          type: .speakEach, prompt: "Talk", outputSchema: ["statement": "string"], subRounds: -1)
+      ]
+    )
+    var state = SimulationState.initial(for: scenario)
+    state.currentRound = 1
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    #expect(mock.generateCallCount == 2)
+  }
+
   // MARK: - simulationLanguage override (ADR-010 Step E)
 
   @Test func speakEachHonorsSimulationLanguageOverride_jaToEn() async throws {


### PR DESCRIPTION
Closes #1064

## Summary

A `speak_each` phase whose `subRounds` (`rounds:` in YAML) is `0` or negative passed both `ScenarioLoader.load` and `ScenarioValidator.validate`, then trapped the app at `for _ in 1...subRounds` (`SpeakEachHandler.execute`) — an uncatchable Swift `ClosedRange` `fatalError`, not a UI-surfaceable `SimulationError`. This clamps `subRounds` to `max(1, …)`, mirroring the already-shipped `WhisperHandler` guard on the same "sub-rounds" input, making the crash structurally impossible regardless of upstream validation.

## Acceptance criteria → diff → test

| Criterion | How the diff satisfies it | Test |
|---|---|---|
| 1. `subRounds: 0` completes as if `1` (one pass over personas), no trap | `let subRounds = max(1, context.phase.subRounds ?? 1)` → `1...1` | `zeroSubRoundsRunsOncePerPersona` (asserts 2 calls for 2 agents × 1 clamped sub-round) |
| 2. Negative (`subRounds: -1`) likewise handled as `1` | same clamp | `negativeSubRoundsRunsOncePerPersona` |
| 3. Targeted suite passes; full unit suite green | — | `PasturaTests/SpeakEachHandlerTests` (10/10) + full unit suite (2961 tests) |
| 4. Validator range-check (conditional — "if added") | **Not added** — see Judgment calls | — |

Revert check (per `.claude/rules/testing.md` "a regression test must drive the exact unguarded-path input"): deleting the clamp line makes `subRounds` stay `0`/`-1`, so `1...subRounds` traps and both new tests crash — a confident "revert ⇒ fail", not coverage theater.

## Judgment calls

- **Validator defense-in-depth check intentionally omitted.** The issue lists the `ScenarioValidator` `speak_each` sub-rounds range-check as *recommended, defense-in-depth* and criterion 4 is conditional ("If the validator range-check is added"). Per the queue's minimum-change rule and the issue's own note that the handler clamp is "the minimal, self-contained fix" that "makes the crash structurally impossible", I kept scope to the handler clamp only. Adding the validator check (so an author gets a clean validation error instead of a silent clamp) remains a valid, independently-mergeable follow-up.
- **Out of scope honored**: no shared "clamp sub-rounds" helper/refactor across `SpeakEachHandler`/`WhisperHandler`, and `WhisperHandler` (already correct) untouched.
- **STOP conditions checked**: `grep` confirmed no existing test or bundled preset relies on `speak_each` with `subRounds <= 0` producing zero passes.

## Test results

- `scripts/xcodebuild.sh test -only-testing PasturaTests/SpeakEachHandlerTests` → **TEST SUCCEEDED** (10 tests, incl. 2 new)
- `scripts/xcodebuild.sh test -skip-testing:PasturaUITests` → **TEST SUCCEEDED** (2961 tests, 239 suites)
- Code-reviewer (Opus): **PASS**, 0 issues.

_Provenance: `code-health-audit` finding CH-003. Generated via `/queue-consumer` overnight run._
