### PR TITLE
♻️ refactor: extract shared VoteTally.winner tie-break helper

### DIFF
--- a/Pastura/Pastura/Engine/ConditionEvaluator.swift
+++ b/Pastura/Pastura/Engine/ConditionEvaluator.swift
@@ -280,13 +280,9 @@ nonisolated public struct ConditionEvaluator: Sendable {
       return resolveScoreExtremum(
         state.scores.values.min(), label: "min_score", warnings: &warnings)
     case "vote_winner":
-      // Canonical deterministic tie-break: sort by (count desc, name desc)
-      // and take the first. EliminateHandler shares this order (#1056).
-      let top =
-        state.voteResults
-        .sorted(by: { ($0.value, $0.key) > ($1.value, $1.key) })
-        .first
-      if let winner = top {
+      // Shared canonical tie-break (count desc, name desc). EliminateHandler
+      // and WordwolfJudgeLogic resolve the same winner (#1056).
+      if let winner = VoteTally.winner(state.voteResults) {
         return .value(winner.key)
       }
       warnings.append("vote_winner has no value (no vote phase has run this round)")

--- a/Pastura/Pastura/Engine/Phases/EliminateHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/EliminateHandler.swift
@@ -12,15 +12,10 @@ nonisolated struct EliminateHandler: PhaseHandler {
   ) async throws {
     guard !state.voteResults.isEmpty else { return }
 
-    // Find the most-voted agent. Deterministic tie-break: (count desc, name
-    // desc) — the canonical order shared with ConditionEvaluator's
-    // `vote_winner` derivation, so an `eliminate` phase and a `conditional`
-    // reading `vote_winner` in the same round never disagree on a tie (#1056).
-    guard
-      let mostVoted = state.voteResults
-        .sorted(by: { ($0.value, $0.key) > ($1.value, $1.key) })
-        .first
-    else { return }
+    // Find the most-voted agent via the shared canonical tie-break (count
+    // desc, name desc), so an `eliminate` phase and a `conditional` reading
+    // `vote_winner` in the same round never disagree on a tie (#1056).
+    guard let mostVoted = VoteTally.winner(state.voteResults) else { return }
 
     state.eliminated[mostVoted.key] = true
     context.emitter(.elimination(agent: mostVoted.key, voteCount: mostVoted.value))

--- a/Pastura/Pastura/Engine/ScoringLogic/WordwolfJudgeLogic.swift
+++ b/Pastura/Pastura/Engine/ScoringLogic/WordwolfJudgeLogic.swift
@@ -22,14 +22,11 @@ nonisolated struct WordwolfJudgeLogic: Sendable {
       return
     }
 
-    // Deterministic tie-break: (count desc, name desc) — the canonical order
-    // shared with ConditionEvaluator / EliminateHandler. `max(by:)` alone
-    // left ties resolved by hash-seeded dictionary order, so a tied word-wolf
-    // game reported "wolf found" vs "wolf escaped" differently per launch (#1057).
-    let mostVoted =
-      state.voteResults
-      .sorted(by: { ($0.value, $0.key) > ($1.value, $1.key) })
-      .first?.key ?? ""
+    // Most-voted agent via the shared canonical tie-break (count desc, name
+    // desc) — `max(by:)` alone left ties resolved by hash-seeded dictionary
+    // order, so a tied word-wolf game reported "wolf found" vs "wolf escaped"
+    // differently per launch (#1057).
+    let mostVoted = VoteTally.winner(state.voteResults)?.key ?? ""
     let wolf = state.variables["wolf_name"] ?? "?"
     let voteCount = state.voteResults[mostVoted] ?? 0
 

--- a/Pastura/Pastura/Engine/VoteTally.swift
+++ b/Pastura/Pastura/Engine/VoteTally.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Vote-tally helpers shared across the engine's most-voted-agent sites.
+///
+/// Consolidates the canonical tie-break so a future change can't reintroduce
+/// the per-launch divergence #1056/#1057 fixed: `EliminateHandler`,
+/// `WordwolfJudgeLogic`, and `ConditionEvaluator`'s `vote_winner` derivation
+/// all resolve a tie to the same agent.
+nonisolated enum VoteTally {
+  /// The winning agent by the canonical deterministic tie-break:
+  /// (count desc, name desc). Returns `nil` for empty input.
+  ///
+  /// Returns the full `(key, value)` element so a call site that needs the
+  /// vote count (e.g. `EliminateHandler`'s `.elimination` event) can read
+  /// `.value` without a second lookup.
+  static func winner(_ voteResults: [String: Int]) -> (key: String, value: Int)? {
+    voteResults.sorted(by: { ($0.value, $0.key) > ($1.value, $1.key) }).first
+  }
+}

--- a/Pastura/PasturaTests/Engine/VoteTallyTests.swift
+++ b/Pastura/PasturaTests/Engine/VoteTallyTests.swift
@@ -1,0 +1,23 @@
+import Testing
+
+@testable import Pastura
+
+@Suite(.timeLimit(.minutes(1)))
+struct VoteTallyTests {
+  @Test func clearWinnerByCount() {
+    let winner = VoteTally.winner(["Alice": 3, "Bob": 1, "Carol": 2])
+    #expect(winner?.key == "Alice")
+    #expect(winner?.value == 3)
+  }
+
+  @Test func tieResolvesToNameDescending() {
+    // Alice and Bob both have 2; canonical tie-break is name desc, so "Bob".
+    let winner = VoteTally.winner(["Alice": 2, "Bob": 2])
+    #expect(winner?.key == "Bob")
+    #expect(winner?.value == 2)
+  }
+
+  @Test func emptyReturnsNil() {
+    #expect(VoteTally.winner([:]) == nil)
+  }
+}


### PR DESCRIPTION
Closes #1067

## Summary

Follow-up to #1056 / #1057 (PR #1066). Three Engine sites picked the "most-voted" agent with an identical, hand-copied comparator `sorted(by: { ($0.value, $0.key) > ($1.value, $1.key) })` (canonical tie-break: count desc, name desc). This consolidates them behind a new `nonisolated enum VoteTally.winner(_:)` returning the winning `(key, value)` element, so a future tie-break change can't reintroduce the per-launch divergence #1056/#1057 fixed. **Behavior-preserving.**

## Acceptance criteria → diff → test

| Criterion | How the diff satisfies it | Verification |
|---|---|---|
| 1. Three inlined sorts gone; each site calls the helper | `EliminateHandler`, `WordwolfJudgeLogic`, `ConditionEvaluator` all delegate to `VoteTally.winner` | `rg 'sorted\(by:.*\$0\.value, \$0\.key' Pastura/Pastura/Engine` → only `VoteTally.swift` |
| 2. Helper has a doc comment + unit test (tie / clear / empty) | `VoteTally.swift` (type + method doc comments) | `VoteTallyTests` — `clearWinnerByCount`, `tieResolvesToNameDescending`, `emptyReturnsNil` |
| 3. Tie suites + new helper test pass; full suite green; harness `swift build` green | — | see Test results |

The comparator inside `VoteTally.winner` is byte-identical to the three replaced closures (confirmed by the code-reviewer), so tie-break order and empty-input semantics are unchanged. Each call site keeps its exact prior handling: EliminateHandler's `guard let` + `.elimination` event `voteCount` (from `.value`), WordwolfJudgeLogic's `?? ""` empty-guard, ConditionEvaluator's `.absent` warning path when empty.

## Judgment calls

- **Kept `import Foundation` in `VoteTally.swift`** despite the reviewer flagging it as unused. The three sibling pure-stdlib Engine helper enums (`YAMLScalarFormatter`, `PromptPlaceholders`, `RelationshipVerbalizer`) all `import Foundation`; matching that convention over the micro-optimization. (Optional to drop.)
- **Out of scope honored**: no tie-break-order change, no empty-input-semantics change, no behavior change. `EliminateHandlerTests` and `WordwolfJudgeLogicTests` are **not modified** (`git diff --stat` empty for both) and stay green — STOP condition satisfied.
- New file placed at `Pastura/Pastura/Engine/VoteTally.swift`; auto-included in the ADR-013 harness via its `sources: ["Engine"]` glob (no Package.swift edit needed).

## Test results

- `scripts/xcodebuild.sh test -only-testing PasturaTests/EliminateHandlerTests -only-testing PasturaTests/WordwolfJudgeLogicTests -only-testing PasturaTests/VoteTallyTests -only-testing PasturaTests/ConditionEvaluatorTests` → **TEST SUCCEEDED** (59 tests, incl. 3 new; existing tie tests green unchanged)
- `scripts/xcodebuild.sh test -skip-testing:PasturaUITests` → **TEST SUCCEEDED** (full unit suite)
- `swift build` (ADR-013 harness) → **Build complete!**
- Code-reviewer (Opus): **PASS**, 0 issues (1 optional suggestion, addressed above).

_Generated via `/queue-consumer` overnight run._
