### PR TITLE
🐛 fix: include .well-known in Pages deploy (Universal Links 404)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -99,6 +99,11 @@ jobs:
           # Action input path is relative to the repo root, not the
           # `defaults.run.working-directory` above (that only affects `run`).
           path: web/dist
+          # Without this, the action's internal tar adds `--exclude=.[^/]*`,
+          # dropping every dot-prefixed entry — which silently excluded
+          # `.well-known/apple-app-site-association` (Universal Links AASA) and
+          # `.nojekyll` from the deploy (origin 404). See actions/upload-pages-artifact#129.
+          include-hidden-files: true
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -116,10 +116,18 @@ jobs:
         # failure. `--retry` covers the short propagation window after
         # `deploy-pages` returns. Covers both sitemap files: the index
         # references the child, so a 404 child is a silent SEO break.
+        #
+        # The AASA (.well-known/apple-app-site-association) is included as a
+        # dedicated regression guard: it is a dot-path that upload-pages-artifact
+        # silently drops without `include-hidden-files` (#1071 / upstream #129),
+        # so a 404 here means Universal Links are broken. We assert 200 only —
+        # Content-Type is informational (GitHub Pages serves it as
+        # application/octet-stream, which Apple's AASA CDN accepts, per #1071).
         run: |
           set -euo pipefail
           for url in \
             "https://pastura.app/" \
+            "https://pastura.app/.well-known/apple-app-site-association" \
             "https://pastura.app/css/base.css" \
             "https://pastura.app/css/lp.css" \
             "https://pastura.app/css/page.css" \


### PR DESCRIPTION
## Summary

The GitHub Pages deploy was silently dropping `.well-known/apple-app-site-association` (the Universal Links AASA from #1071 / PR #1086), so `https://pastura.app/.well-known/apple-app-site-association` returned an **origin 404** and Universal Links could never associate.

## Root cause (confirmed)

`actions/upload-pages-artifact@v5.0.0`'s internal `tar` applies `--exclude=.[^/]*` (drop every dot-prefixed entry) **unless** `include-hidden-files: true` is set — and the step didn't set it. So `.well-known/…` and `.nojekyll` were excluded from the uploaded `github-pages` artifact.

Confirmed two ways:
- Downloaded the deployed `github-pages` artifact via `gh run download` and extracted `artifact.tar`: it contained `./CNAME` but **zero** dot-prefixed files.
- Reproduced locally against the real `web/dist`: the `--exclude=.[^/]*` tar yields `0` `.well-known` entries; omitting it restores `.well-known/apple-app-site-association` + `.nojekyll`.

It is **not** a CDN-cache issue and **not** the octet-stream Content-Type concern from #1071 Step 0 — the file was never in the artifact.

## Fix

Two changes to `.github/workflows/deploy-pages.yml`:

1. **`include-hidden-files: true`** on the existing `actions/upload-pages-artifact@v5.0.0` step. v5 exposes this input, so the one-line change is the official, supported fix — no manual `tar`/`upload-artifact` replacement, no artifact-format or `working-directory` risk. Upstream still force-excludes `.git`/`.github`, and `web/dist` is clean Astro build output, so nothing unwanted is swept in.
2. **AASA regression guard**: added `https://pastura.app/.well-known/apple-app-site-association` to the post-deploy "Smoke-check deployed URLs" `curl -fsS` loop, so a dropped/404 AASA fails the workflow instead of shipping silently. Asserts 200 only; Content-Type stays informational (octet-stream is accepted per #1071).

Simplified from an initial manual-tar approach after reading the pinned upstream `action.yml` revealed the `include-hidden-files` input already exists in v5 (critic + code-review both PASS).

## Test plan

- YAML parses (`yaml.safe_load`).
- Local artifact reproduction against the built `web/dist`:
  - current (`--exclude=.[^/]*`) → `.well-known` count **0** (reproduces the bug)
  - fixed (no dot-exclude) → `./.well-known/apple-app-site-association` + `./.nojekyll` **present**
- Code review (Opus): PASS, 0 blocking.

## Deploy verification (at deploy time)

This workflow has no `pull_request` trigger — it runs on push to `main`. So the fix's first real exercise is the deploy on merge (or a `workflow_dispatch` run from this branch to verify early). The current production site already 404s the AASA, so this is strictly an improvement, and the new smoke-check now gates it.

After merge + deploy:
```
curl -sI https://pastura.app/.well-known/apple-app-site-association   # expect HTTP 200
```
Then the #1071 device QA (Universal Link taps, incl. cold launch) can proceed.

## Device QA

実機QA不要 — CI/deploy workflow only, no iOS simulator-excluded surface. Verification is deploy-time (AASA reachability, above).

Closes #1089
References #1071
