### PR TITLE
✨ feat: 共有カードにキャプション文(ja/en)を追加 (#1082)

### DIFF
--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -7030,6 +7030,16 @@
         }
       }
     },
+    "Watching AI agents play out a scenario in Pastura 🐑" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pastura で AI たちのシミュレーションを観察中 🐑"
+          }
+        }
+      }
+    },
     "What happens" : {
       "localizations" : {
         "ja" : {

--- a/Pastura/Pastura/Views/Components/HighlightCardImageRenderer.swift
+++ b/Pastura/Pastura/Views/Components/HighlightCardImageRenderer.swift
@@ -44,19 +44,33 @@ enum HighlightCardImageRenderer {
 
 /// A rendered highlight card packaged for `.sheet(item:)` + ``ShareSheet``.
 ///
-/// Centralizes the `activityItems` composition so the image is always shared
-/// and the link is appended only when present — the optional link means a
-/// missing URL can never force-unwrap.
+/// Centralizes the `activityItems` composition so the image and caption are
+/// always shared and the link is appended only when present — the optional
+/// link means a missing URL can never force-unwrap.
 struct HighlightShareItem: Identifiable {
   let id = UUID()
   let image: UIImage
   let linkURL: URL?
 
-  /// Heterogeneous payload for `UIActivityViewController`: the card image plus
-  /// the burned-in link (when set) so messaging targets also get a tappable URL.
+  /// Heterogeneous payload for `UIActivityViewController`: the card image, a
+  /// short caption for context, then the burned-in link (when set) so
+  /// messaging targets also get a tappable URL.
+  ///
+  /// Order is image → caption → URL. The caption is a **separate** activity
+  /// item from the URL and never embeds it — the link is already its own item
+  /// (issue #1082), so folding it into the caption would duplicate it. The
+  /// caption is unconditional (shared even when `linkURL` is nil) so a
+  /// URL-less share still carries the app pointer as context.
   var activityItems: [Any] {
-    var items: [Any] = [image]
+    var items: [Any] = [image, caption]
     if let linkURL { items.append(linkURL) }
     return items
+  }
+
+  /// Short marketing caption giving share targets minimal context about what
+  /// the image is, plus an app pointer. Static (model-independent) and
+  /// localized; kept URL-free per the ordering note on ``activityItems``.
+  private var caption: String {
+    String(localized: "Watching AI agents play out a scenario in Pastura 🐑")
   }
 }

--- a/Pastura/PasturaTests/Views/HighlightShareItemTests.swift
+++ b/Pastura/PasturaTests/Views/HighlightShareItemTests.swift
@@ -3,29 +3,38 @@ import UIKit
 
 @testable import Pastura
 
-/// Pure `activityItems` composition for ``HighlightShareItem`` (issue #1070).
+/// Pure `activityItems` composition for ``HighlightShareItem`` (issues #1070,
+/// #1082).
 ///
 /// The rendered `ImageRenderer` output is not tested (ADR-009 — no view
-/// rendering); only the deterministic share-payload shaping is: the image is
-/// always present, and the optional link is appended only when set (guarding
-/// the no-force-unwrap invariant).
+/// rendering); only the deterministic share-payload shaping is: the image and
+/// caption are always present, the caption never duplicates the link (#1082),
+/// and the optional link is appended only when set (guarding the
+/// no-force-unwrap invariant).
 @MainActor
 @Suite(.timeLimit(.minutes(1)))
 struct HighlightShareItemTests {
 
-  @Test("Link is appended after the image when present")
+  @Test("Order is image → caption → link, and the caption never repeats the URL")
   func includesLinkWhenPresent() {
     let url = URL(string: "https://pastura.app")
     let item = HighlightShareItem(image: UIImage(), linkURL: url)
-    #expect(item.activityItems.count == 2)
+    #expect(item.activityItems.count == 3)
     #expect(item.activityItems.first is UIImage)
     #expect(item.activityItems.last as? URL == url)
+    // The caption sits between the image and the URL. Assert its type/position
+    // (locale-independent) and that it never folds the link in — #1082 requires
+    // the URL to stay a separate activity item, never duplicated in the text.
+    let caption = item.activityItems[1] as? String
+    #expect(caption != nil)
+    #expect(caption?.contains("pastura.app") == false)
   }
 
-  @Test("Only the image is shared when the link is nil")
-  func imageOnlyWhenLinkNil() {
+  @Test("Image and caption are shared when the link is nil")
+  func imageAndCaptionWhenLinkNil() {
     let item = HighlightShareItem(image: UIImage(), linkURL: nil)
-    #expect(item.activityItems.count == 1)
+    #expect(item.activityItems.count == 2)
     #expect(item.activityItems.first is UIImage)
+    #expect(item.activityItems.last is String)
   }
 }


### PR DESCRIPTION
## Summary

- 共有シート（`HighlightShareItem.activityItems`）に短いローカライズ済みキャプションを追加。画像・URL とは**別のアクティビティアイテム**として渡すことで、X / LINE / Instagram / メッセージ 等に共有した際に最低限のコンテキストとアプリ誘導が付く。
- 順序は **画像 → キャプション → URL**。URL は既存の別アイテムのままなので、キャプション本文に URL を重複させない構成（issue #1082 準拠）。
- キャプションは静的（model 非依存）・`String(localized:)`。`linkURL == nil` の場合も画像＋キャプションで共有される（アプリ誘導のコンテキストは常に付く）。

文言:
- en（カタログキー）: `Watching AI agents play out a scenario in Pastura 🐑`
- ja: `Pastura で AI たちのシミュレーションを観察中 🐑`

Growth umbrella #1069 A-1（共有カード #1070 / 調整 #1081）のフォローアップ。軽量 PR。

## Test plan

- `HighlightShareItemTests` を更新: 順序が **画像 → キャプション → URL**（link あり = 3 items / link なし = 2 items）であること、中間アイテムが `String` で URL host を含まない（URL 重複禁止の不変条件を固定）ことを assert。ロケール非依存（型・位置で検証、レンダリング文字列は比較しない — ADR-009）。
- `python3 scripts/check_localization_coverage.py` — 645 keys, all `ja` translated ✅。
- フルユニットスイート（UIテスト除く）green。

## Device QA

共有拡張のテキスト取り込み挙動はシミュレータでは再現できないため実機確認が必要:

- **X**: 画像＋URL＋キャプションの入り方を確認（テキスト無視 / URL との連結など挙動が不安定 — 順序・文言の最終調整判断）。X がキャプションを落とす場合は「そのまま許容」とする（URL 重複は禁止のため、キャプションに URL を折り込む回避策は取らない）。
- **LINE / Instagram（フィード）/ メッセージ**: 3 要素が破綻なく取り込まれるか。
- **`linkURL == nil` バリアント**: URL 無しの共有（画像＋キャプションのみ）が意味の通る内容として読めるか。

Closes #1082