### PR TITLE
✨ feat: Instagram Stories 直接共有（カスタム共有シート）(#1083)

### DIFF
--- a/Pastura/Pastura/Info.plist
+++ b/Pastura/Pastura/Info.plist
@@ -17,6 +17,21 @@
 			</array>
 		</dict>
 	</array>
+	<!-- Facebook App ID for "Share to Instagram Stories" (#1083).
+	     Required by Instagram since Jan 2023: passed as the
+	     `source_application` query param of `instagram-stories://share`.
+	     A free, PUBLIC client identifier (NOT a secret) — obtain one at
+	     developers.facebook.com (register → create app → copy the App ID)
+	     and paste it below. While this stays empty the Instagram Stories
+	     share path stays dark: `InstagramStoriesSharer.isAvailable` gates on
+	     a non-empty value, so the share button falls through to the system
+	     share sheet unchanged. -->
+	<key>FacebookAppID</key>
+	<string></string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>instagram-stories</string>
+	</array>
 	<key>UILaunchScreen</key>
 	<dict>
 		<key>UIColorName</key>

--- a/Pastura/Pastura/Info.plist
+++ b/Pastura/Pastura/Info.plist
@@ -27,7 +27,7 @@
 	     a non-empty value, so the share button falls through to the system
 	     share sheet unchanged. -->
 	<key>FacebookAppID</key>
-	<string></string>
+	<string>4307199252924586</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>instagram-stories</string>

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -3718,6 +3718,16 @@
         }
       }
     },
+    "Instagram Stories" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Instagram ストーリーズ"
+          }
+        }
+      }
+    },
     "Installed" : {
       "localizations" : {
         "ja" : {
@@ -5974,6 +5984,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "カードで共有"
+          }
+        }
+      }
+    },
+    "Share via…" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "その他で共有…"
           }
         }
       }

--- a/Pastura/Pastura/Views/Components/HighlightCardImageRenderer.swift
+++ b/Pastura/Pastura/Views/Components/HighlightCardImageRenderer.swift
@@ -31,6 +31,33 @@ enum HighlightCardImageRenderer {
     return renderer.uiImage
   }
 
+  /// Corner radius in the card's 360 pt space (×3 at export → 120 px on the
+  /// 1080 px sticker) for the Instagram Stories sticker. Rounded like X's
+  /// share-to-Stories card — a visual sign-off knob, tweak freely. (#1083)
+  static let storyStickerCornerRadius: CGFloat = 40
+
+  /// Rounded-corner, transparent-background variant for the Instagram Stories
+  /// sticker (#1083). Clips the square card to a rounded rectangle and renders
+  /// with alpha so the corners fall away to transparency — Instagram then
+  /// composites the *rounded* card onto the moss gradient background (à la X),
+  /// instead of a hard square. Distinct from ``render`` (opaque square), which
+  /// stays the system-share card.
+  static func renderStorySticker(
+    _ model: HighlightShareCard.Model, colorScheme: ColorScheme
+  ) -> UIImage? {
+    let card = HighlightShareCard(model: model, colorScheme: colorScheme)
+      .clipShape(
+        RoundedRectangle(cornerRadius: storyStickerCornerRadius, style: .continuous)
+      )
+      .environment(\.colorScheme, colorScheme)
+    let renderer = ImageRenderer(content: card)
+    renderer.scale = scale
+    // Alpha ON (unlike `render`): the corners outside the rounded rect must be
+    // transparent so Instagram's gradient shows through them.
+    renderer.isOpaque = false
+    return renderer.uiImage
+  }
+
   /// Builds a ready-to-share item, or `nil` when rendering fails — the call
   /// site then simply does not present the share sheet (a silent no-op is the
   /// intended UX for the rare render failure).

--- a/Pastura/Pastura/Views/Components/InstagramStoriesSharer.swift
+++ b/Pastura/Pastura/Views/Components/InstagramStoriesSharer.swift
@@ -1,0 +1,124 @@
+import UIKit
+
+/// Direct share to Instagram Stories via the `instagram-stories://` URL scheme
+/// and the `UIPasteboard` sticker contract (#1083).
+///
+/// Instagram composites a 1:1 `stickerImage` onto a 9:16 gradient background
+/// built from `backgroundTopColor` / `backgroundBottomColor`, so the app hands
+/// over the existing square highlight card verbatim and never renders a 9:16
+/// image itself. A Facebook App ID (a public client identifier —
+/// `Info.plist` `FacebookAppID`, read via ``StoryShareConfig``) has been
+/// required by Instagram since Jan 2023 and is passed as the
+/// `source_application` query parameter. Reference: Meta "Sharing to Stories"
+/// (developers.facebook.com/docs/instagram-platform/sharing-to-stories).
+@MainActor
+enum InstagramStoriesSharer {
+
+  /// URL scheme for the Instagram Stories deep link (also the
+  /// `LSApplicationQueriesSchemes` entry the `canOpenURL` probe relies on).
+  static let scheme = "instagram-stories"
+
+  /// Raw pasteboard keys defined by Instagram's sharing contract. They are read
+  /// by the Instagram app (not a Swift API), so they must be string literals.
+  enum PasteboardKey {
+    static let stickerImage = "com.instagram.sharedSticker.stickerImage"
+    static let backgroundTopColor = "com.instagram.sharedSticker.backgroundTopColor"
+    static let backgroundBottomColor = "com.instagram.sharedSticker.backgroundBottomColor"
+  }
+
+  // MARK: - Pure logic (unit-tested)
+
+  /// `instagram-stories://share?source_application=<appID>`, or `nil` if the
+  /// components can't form a valid URL (guards the no-force-unwrap invariant).
+  static func shareURL(appID: String) -> URL? {
+    var components = URLComponents()
+    components.scheme = scheme
+    components.host = "share"
+    components.queryItems = [URLQueryItem(name: "source_application", value: appID)]
+    return components.url
+  }
+
+  /// The pasteboard item Instagram consumes: the square card PNG as a sticker
+  /// plus the moss gradient hex colors that become the 9:16 background.
+  static func pasteboardItem(
+    stickerImagePNG: Data, topColorHex: String, bottomColorHex: String
+  ) -> [String: Any] {
+    [
+      PasteboardKey.stickerImage: stickerImagePNG,
+      PasteboardKey.backgroundTopColor: topColorHex,
+      PasteboardKey.backgroundBottomColor: bottomColorHex
+    ]
+  }
+
+  /// Availability requires **both** Instagram installed and a configured App
+  /// ID — the deep link no-ops without a `source_application`, so a missing
+  /// App ID must hide the entry point exactly as a missing app does.
+  static func isAvailable(isInstagramInstalled: Bool, appID: String?) -> Bool {
+    StoryShareConfig.normalizedAppID(appID) != nil && isInstagramInstalled
+  }
+
+  // MARK: - UIKit shell (side-effecting; not unit-tested per ADR-009)
+
+  /// Whether Instagram is installed, via a `canOpenURL` probe on the stories
+  /// scheme (requires the `LSApplicationQueriesSchemes` allowlist entry).
+  static var isInstagramInstalled: Bool {
+    guard let url = URL(string: "\(scheme)://share") else { return false }
+    return UIApplication.shared.canOpenURL(url)
+  }
+
+  /// Convenience gate combining the live install probe with the configured App
+  /// ID. The custom share sheet reads this to decide whether to offer the
+  /// Instagram Stories destination.
+  static var isAvailableNow: Bool {
+    isAvailable(
+      isInstagramInstalled: isInstagramInstalled, appID: StoryShareConfig.facebookAppID)
+  }
+
+  /// Writes the sticker payload to the general pasteboard (5-minute expiry, per
+  /// Instagram's contract) and opens Instagram Stories. Returns `false` as a
+  /// silent no-op when the URL can't be built or Instagram can't be opened —
+  /// callers gate on ``isAvailableNow`` first; this re-checks defensively.
+  @discardableResult
+  static func share(
+    stickerImagePNG: Data, topColorHex: String, bottomColorHex: String, appID: String
+  ) -> Bool {
+    guard let url = shareURL(appID: appID) else { return false }
+    let options: [UIPasteboard.OptionsKey: Any] = [
+      // 5-minute window matches Instagram's documented expectation; the
+      // pasteboard payload is transient hand-off state, not a lasting copy.
+      .expirationDate: Date().addingTimeInterval(60 * 5)
+    ]
+    UIPasteboard.general.setItems(
+      [
+        pasteboardItem(
+          stickerImagePNG: stickerImagePNG,
+          topColorHex: topColorHex, bottomColorHex: bottomColorHex)
+      ],
+      options: options)
+    guard UIApplication.shared.canOpenURL(url) else { return false }
+    UIApplication.shared.open(url, options: [:], completionHandler: nil)
+    return true
+  }
+}
+
+/// Reads the operator-configured Facebook App ID (`Info.plist` `FacebookAppID`)
+/// that Instagram Stories sharing requires. Kept separate from
+/// ``InstagramStoriesSharer`` so the emptiness normalization stays
+/// unit-testable without touching `Bundle`.
+@MainActor
+enum StoryShareConfig {
+
+  /// The configured Facebook App ID, or `nil` when the `Info.plist` value is
+  /// absent / empty / whitespace (the dark-until-configured state).
+  static var facebookAppID: String? {
+    normalizedAppID(Bundle.main.object(forInfoDictionaryKey: "FacebookAppID") as? String)
+  }
+
+  /// Trims and collapses empty / whitespace to `nil`; returns a real ID
+  /// verbatim (trimmed). Pure — the unit-tested seam for the `Bundle` read.
+  static func normalizedAppID(_ raw: String?) -> String? {
+    guard let raw else { return nil }
+    let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+  }
+}

--- a/Pastura/Pastura/Views/Components/InstagramStoriesSharer.swift
+++ b/Pastura/Pastura/Views/Components/InstagramStoriesSharer.swift
@@ -82,7 +82,11 @@ enum InstagramStoriesSharer {
   static func share(
     stickerImagePNG: Data, topColorHex: String, bottomColorHex: String, appID: String
   ) -> Bool {
-    guard let url = shareURL(appID: appID) else { return false }
+    // Check openability BEFORE writing the pasteboard — a failed open must not
+    // leave the sticker image on the user's clipboard for the 5-min expiry.
+    guard let url = shareURL(appID: appID), UIApplication.shared.canOpenURL(url) else {
+      return false
+    }
     let options: [UIPasteboard.OptionsKey: Any] = [
       // 5-minute window matches Instagram's documented expectation; the
       // pasteboard payload is transient hand-off state, not a lasting copy.
@@ -95,7 +99,6 @@ enum InstagramStoriesSharer {
           topColorHex: topColorHex, bottomColorHex: bottomColorHex)
       ],
       options: options)
-    guard UIApplication.shared.canOpenURL(url) else { return false }
     UIApplication.shared.open(url, options: [:], completionHandler: nil)
     return true
   }

--- a/Pastura/Pastura/Views/Components/StoryBackgroundGradient.swift
+++ b/Pastura/Pastura/Views/Components/StoryBackgroundGradient.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Moss gradient colors for the Instagram Stories 9:16 background (#1083).
+/// Instagram composites the 1:1 highlight card sticker onto this gradient, so
+/// only the two solid endpoint colors are needed — the app renders no 9:16
+/// image itself. Derived from the shared moss palette tokens (single source of
+/// truth); the exact endpoints are a visual-sign-off surface (real-device QA).
+enum StoryBackgroundGradient {
+  /// Top gradient color — `PasturaPalette.moss`.
+  static var topHex: String { PasturaPalette.moss.hexString }
+  /// Bottom gradient color — `PasturaPalette.mossDark`.
+  static var bottomHex: String { PasturaPalette.mossDark.hexString }
+}

--- a/Pastura/Pastura/Views/Components/StoryShareSheet.swift
+++ b/Pastura/Pastura/Views/Components/StoryShareSheet.swift
@@ -153,4 +153,17 @@ extension View {
   ) -> some View {
     modifier(HighlightStoryShareModifier(context: context, onSystemShare: onSystemShare))
   }
+
+  /// Mounts both highlight share surfaces: the system-share `ShareSheet`
+  /// (`item`, #1070) and the custom ``StoryShareSheet`` (`context`, #1083),
+  /// wired so the story sheet's "Share via…" dismisses and falls back to the
+  /// system sheet. Applied by ResultDetailView and SimulationView.
+  func highlightShareSurfaces(
+    item: Binding<HighlightShareItem?>,
+    context: Binding<HighlightShareContext?>
+  ) -> some View {
+    self
+      .sheet(item: item) { ShareSheet(activityItems: $0.activityItems) }
+      .highlightStoryShare(context: context, onSystemShare: { item.wrappedValue = $0 })
+  }
 }

--- a/Pastura/Pastura/Views/Components/StoryShareSheet.swift
+++ b/Pastura/Pastura/Views/Components/StoryShareSheet.swift
@@ -56,9 +56,15 @@ struct StoryShareSheet: View {
     // layout size, so the outer `.frame` reserves the scaled footprint.
     HighlightShareCard(model: context.model, colorScheme: context.colorScheme)
       .frame(width: HighlightShareCard.side, height: HighlightShareCard.side)
+      // Clip in card space (before scaling) at the same radius as the exported
+      // sticker, so the preview shows the rounded corners the user will get.
+      .clipShape(
+        RoundedRectangle(
+          cornerRadius: HighlightCardImageRenderer.storyStickerCornerRadius,
+          style: .continuous)
+      )
       .scaleEffect(previewSide / HighlightShareCard.side)
       .frame(width: previewSide, height: previewSide)
-      .clipShape(RoundedRectangle(cornerRadius: Radius.bubbleBody, style: .continuous))
       // Decorative preview — the destination buttons carry the actions.
       .accessibilityHidden(true)
   }
@@ -88,7 +94,7 @@ struct StoryShareSheet: View {
   private func shareToInstagram() {
     guard
       let appID = StoryShareConfig.facebookAppID,
-      let image = HighlightCardImageRenderer.render(
+      let image = HighlightCardImageRenderer.renderStorySticker(
         context.model, colorScheme: context.colorScheme),
       let png = image.pngData()
     else { return }

--- a/Pastura/Pastura/Views/Components/StoryShareSheet.swift
+++ b/Pastura/Pastura/Views/Components/StoryShareSheet.swift
@@ -1,0 +1,156 @@
+import SwiftUI
+
+/// Identity wrapper for presenting ``StoryShareSheet`` via `.sheet(item:)` —
+/// carries the composed card model plus the explicit appearance
+/// (``HighlightCardImageRenderer`` / ``HighlightShareCard`` do not read
+/// `colorScheme` from the environment). (#1083)
+struct HighlightShareContext: Identifiable {
+  let id = UUID()
+  let model: HighlightShareCard.Model
+  let colorScheme: ColorScheme
+}
+
+/// A Pastura-branded share sheet (#1083) offering a card preview and explicit
+/// share destinations — the "Spotify pattern" for story-share discoverability,
+/// preferred over burying the story path in the system sheet's action row.
+///
+/// - **Instagram Stories** (shown only when ``InstagramStoriesSharer/isAvailableNow``)
+///   rasterizes the square card and hands it to Instagram as a sticker on the
+///   moss gradient 9:16 background — Instagram composites the two, so the app
+///   never renders a 9:16 image.
+/// - **Share via…** routes to the system share sheet through the host's
+///   `onSystemShare` closure. The host dismisses this sheet first, then presents
+///   `ShareSheet` (dismiss-then-present — see ``HighlightStoryShareModifier`` —
+///   so a nested `.sheet` can never stall presentation).
+///
+/// The preview is a **live** ``HighlightShareCard`` (not the rasterized image),
+/// so a rasterization failure on the Instagram path can never blank it.
+struct StoryShareSheet: View {
+  let context: HighlightShareContext
+  /// Invoked with the ready-to-share item when the user picks the system share
+  /// sheet. The bridging modifier dismisses this sheet, then the host presents
+  /// its existing `ShareSheet`.
+  let onSystemShare: (HighlightShareItem) -> Void
+
+  @Environment(\.dismiss) private var dismiss
+
+  /// On-screen size of the (down-scaled) 360 pt card preview.
+  private let previewSide: CGFloat = 200
+
+  var body: some View {
+    VStack(spacing: Spacing.xl) {
+      preview
+      destinations
+    }
+    .padding(.horizontal, Spacing.l)
+    .padding(.top, Spacing.xl)
+    .padding(.bottom, Spacing.l)
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    .background(Color.screenBackground)
+    .presentationDetents([.medium])
+    .presentationDragIndicator(.visible)
+  }
+
+  private var preview: some View {
+    // Fixed-size card scaled to the preview box; `.scaleEffect` doesn't change
+    // layout size, so the outer `.frame` reserves the scaled footprint.
+    HighlightShareCard(model: context.model, colorScheme: context.colorScheme)
+      .frame(width: HighlightShareCard.side, height: HighlightShareCard.side)
+      .scaleEffect(previewSide / HighlightShareCard.side)
+      .frame(width: previewSide, height: previewSide)
+      .clipShape(RoundedRectangle(cornerRadius: Radius.bubbleBody, style: .continuous))
+      // Decorative preview — the destination buttons carry the actions.
+      .accessibilityHidden(true)
+  }
+
+  private var destinations: some View {
+    VStack(spacing: Spacing.s) {
+      if InstagramStoriesSharer.isAvailableNow {
+        Button(action: shareToInstagram) {
+          Label(String(localized: "Instagram Stories"), systemImage: "camera.circle.fill")
+        }
+        .buttonStyle(PasturaPrimaryButtonStyle())
+        .frame(maxWidth: .infinity)
+      }
+      Button(action: requestSystemShare) {
+        Label(String(localized: "Share via…"), systemImage: "square.and.arrow.up")
+          .font(.system(size: 16, weight: .semibold))
+          .foregroundStyle(Color.ink)
+          .frame(maxWidth: .infinity)
+          .padding(.vertical, 15)
+      }
+    }
+  }
+
+  /// Rasterizes the card and hands it to Instagram Stories. Guards the two
+  /// nil-producing steps (`render` → `UIImage?`, `pngData()` → `Data?`) with a
+  /// silent no-op, matching ``HighlightCardImageRenderer``'s render-fail UX.
+  private func shareToInstagram() {
+    guard
+      let appID = StoryShareConfig.facebookAppID,
+      let image = HighlightCardImageRenderer.render(
+        context.model, colorScheme: context.colorScheme),
+      let png = image.pngData()
+    else { return }
+    InstagramStoriesSharer.share(
+      stickerImagePNG: png,
+      topColorHex: StoryBackgroundGradient.topHex,
+      bottomColorHex: StoryBackgroundGradient.bottomHex,
+      appID: appID)
+    dismiss()
+  }
+
+  /// Hands the composed share item to the host's system-share path. Does not
+  /// dismiss here — the modifier dismisses via `context = nil` and re-presents
+  /// on `onDismiss`. Falls back to a plain dismiss if rendering fails.
+  private func requestSystemShare() {
+    guard
+      let item = HighlightCardImageRenderer.makeShareItem(
+        context.model, colorScheme: context.colorScheme)
+    else {
+      dismiss()
+      return
+    }
+    onSystemShare(item)
+  }
+}
+
+/// Presents ``StoryShareSheet`` for a highlight and bridges its "Share via…"
+/// action to the host's system share sheet using **dismiss-then-present**: the
+/// custom sheet is dismissed first (`context = nil`), then `onSystemShare`
+/// fires from the sheet's `onDismiss` so only one sheet is ever active — a
+/// nested `.sheet` would risk a presentation stall on iOS (#1083).
+struct HighlightStoryShareModifier: ViewModifier {
+  @Binding var context: HighlightShareContext?
+  let onSystemShare: (HighlightShareItem) -> Void
+  @State private var pendingSystemShareItem: HighlightShareItem?
+
+  func body(content: Content) -> some View {
+    content.sheet(item: $context, onDismiss: presentPendingSystemShare) { ctx in
+      StoryShareSheet(
+        context: ctx,
+        onSystemShare: { item in
+          pendingSystemShareItem = item
+          context = nil
+        })
+    }
+  }
+
+  private func presentPendingSystemShare() {
+    guard let item = pendingSystemShareItem else { return }
+    pendingSystemShareItem = nil
+    onSystemShare(item)
+  }
+}
+
+extension View {
+  /// Presents the highlight ``StoryShareSheet`` bound to `context`, forwarding
+  /// the system-share fallback to `onSystemShare` (the host then presents its
+  /// existing `.sheet(item:)` `ShareSheet`). See ``HighlightStoryShareModifier``.
+  func highlightStoryShare(
+    context: Binding<HighlightShareContext?>,
+    onSystemShare: @escaping (HighlightShareItem) -> Void
+  ) -> some View {
+    modifier(HighlightStoryShareModifier(context: context, onSystemShare: onSystemShare))
+  }
+}

--- a/Pastura/Pastura/Views/DesignTokens.swift
+++ b/Pastura/Pastura/Views/DesignTokens.swift
@@ -57,6 +57,16 @@ struct PasturaColorValue: Sendable, Equatable {
   var color: Color {
     Color(.sRGB, red: red, green: green, blue: blue, opacity: opacity)
   }
+
+  /// The `#RRGGBB` sRGB hex string (opacity dropped). Rounds each 0...1
+  /// component to the nearest 8-bit value. Used to hand solid gradient
+  /// colors to Instagram Stories' background contract (#1083).
+  var hexString: String {
+    let r = Int((red * 255).rounded())
+    let g = Int((green * 255).rounded())
+    let b = Int((blue * 255).rounded())
+    return String(format: "#%02X%02X%02X", r, g, b)
+  }
 }
 
 /// Canonical Pastura color palette. See `design-system.md` §2.

--- a/Pastura/Pastura/Views/Results/ResultDetailView+Share.swift
+++ b/Pastura/Pastura/Views/Results/ResultDetailView+Share.swift
@@ -19,6 +19,15 @@ extension ResultDetailView {
         linkURL: LocalizedPublicPages.sharedScenario(id: scenario?.id),
         contentFilter: contentFilter)
     else { return }
-    highlightShareItem = HighlightCardImageRenderer.makeShareItem(model, colorScheme: colorScheme)
+    // Offer the custom story-share sheet only when Instagram Stories is
+    // actually available (installed + App ID configured); otherwise fall
+    // straight through to the system share sheet — no UX change until the
+    // feature is live (#1083).
+    if InstagramStoriesSharer.isAvailableNow {
+      highlightShareContext = HighlightShareContext(model: model, colorScheme: colorScheme)
+    } else {
+      highlightShareItem = HighlightCardImageRenderer.makeShareItem(
+        model, colorScheme: colorScheme)
+    }
   }
 }

--- a/Pastura/Pastura/Views/Results/ResultDetailView.swift
+++ b/Pastura/Pastura/Views/Results/ResultDetailView.swift
@@ -65,6 +65,8 @@ struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
   // Non-private + explicit colorScheme: the `+Share.swift` sibling composes and
   // presents these (ImageRenderer ignores ambient appearance). (#1070)
   @State var highlightShareItem: HighlightShareItem?
+  // Custom story-share sheet context (#1083); +Share.swift composes it.
+  @State var highlightShareContext: HighlightShareContext?
   @Environment(\.colorScheme) var colorScheme
 
   private var canExport: Bool {
@@ -179,9 +181,7 @@ struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
     .sheet(item: $selectedPersona) { item in
       PersonaDetailSheet(persona: item.persona, position: item.position)
     }
-    .sheet(item: $highlightShareItem) { item in
-      ShareSheet(activityItems: item.activityItems)
-    }
+    .highlightShareSurfaces(item: $highlightShareItem, context: $highlightShareContext)
     .alert(
       String(localized: "Export failed"),
       isPresented: Binding(

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -76,6 +76,9 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
   @State private var exportError: String?
   /// The rendered highlight card awaiting the share sheet (#1070).
   @State private var highlightShareItem: HighlightShareItem?
+  /// Custom story-share sheet context (#1083). Set instead of
+  /// highlightShareItem when Instagram Stories is available.
+  @State private var highlightShareContext: HighlightShareContext?
   /// Re-applies content filtering when composing a share card. A View-local
   /// instance (mirrors `ResultDetailView`) — the live log text is already
   /// filtered, but re-filtering is idempotent and keeps the card path
@@ -298,9 +301,7 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
     .sheet(item: $exportPayload) { payload in
       ShareSheet(activityItems: [payload.text, payload.fileURL])
     }
-    .sheet(item: $highlightShareItem) { item in
-      ShareSheet(activityItems: item.activityItems)
-    }
+    .highlightShareSurfaces(item: $highlightShareItem, context: $highlightShareContext)
     .alert(
       String(localized: "Export failed"),
       isPresented: Binding(
@@ -1159,7 +1160,16 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
         linkURL: LocalizedPublicPages.sharedScenario(id: scenario?.id),
         contentFilter: contentFilter)
     else { return }
-    highlightShareItem = HighlightCardImageRenderer.makeShareItem(model, colorScheme: colorScheme)
+    // Offer the custom story-share sheet only when Instagram Stories is
+    // actually available (installed + App ID configured); otherwise fall
+    // straight through to the system share sheet — no UX change until the
+    // feature is live (#1083).
+    if InstagramStoriesSharer.isAvailableNow {
+      highlightShareContext = HighlightShareContext(model: model, colorScheme: colorScheme)
+    } else {
+      highlightShareItem = HighlightCardImageRenderer.makeShareItem(
+        model, colorScheme: colorScheme)
+    }
   }
 
   /// The active inference model's short label for the share card, or `nil` when

--- a/Pastura/PasturaTests/Views/InstagramStoriesSharerTests.swift
+++ b/Pastura/PasturaTests/Views/InstagramStoriesSharerTests.swift
@@ -1,0 +1,51 @@
+import Testing
+import UIKit
+
+@testable import Pastura
+
+/// Pure logic for direct Instagram Stories sharing (#1083): deep-link URL
+/// shape, pasteboard sticker payload, App-ID normalization, and availability
+/// gating. The UIKit side effects (`UIPasteboard.setItems`,
+/// `UIApplication.open` / `canOpenURL`) are not tested (ADR-009 — no UIKit
+/// integration); only the deterministic payload/gating shaping is.
+@MainActor
+@Suite(.timeLimit(.minutes(1)))
+struct InstagramStoriesSharerTests {
+
+  @Test("shareURL carries the App ID as source_application on the stories scheme")
+  func shareURLShape() {
+    let url = InstagramStoriesSharer.shareURL(appID: "1234567890")
+    #expect(url?.scheme == "instagram-stories")
+    #expect(
+      url?.absoluteString == "instagram-stories://share?source_application=1234567890")
+  }
+
+  @Test("pasteboardItem carries the sticker PNG + both gradient colors under Instagram's keys")
+  func pasteboardItemKeys() {
+    let png = Data([0x01, 0x02, 0x03])
+    let item = InstagramStoriesSharer.pasteboardItem(
+      stickerImagePNG: png, topColorHex: "#8A9A6C", bottomColorHex: "#6B7852")
+    #expect(item["com.instagram.sharedSticker.stickerImage"] as? Data == png)
+    #expect(item["com.instagram.sharedSticker.backgroundTopColor"] as? String == "#8A9A6C")
+    #expect(item["com.instagram.sharedSticker.backgroundBottomColor"] as? String == "#6B7852")
+    #expect(item.count == 3)
+  }
+
+  @Test("isAvailable requires both Instagram installed and a non-empty App ID")
+  func availabilityGate() {
+    #expect(InstagramStoriesSharer.isAvailable(isInstagramInstalled: true, appID: "123"))
+    #expect(!InstagramStoriesSharer.isAvailable(isInstagramInstalled: false, appID: "123"))
+    #expect(!InstagramStoriesSharer.isAvailable(isInstagramInstalled: true, appID: nil))
+    #expect(!InstagramStoriesSharer.isAvailable(isInstagramInstalled: true, appID: ""))
+    #expect(!InstagramStoriesSharer.isAvailable(isInstagramInstalled: true, appID: "   "))
+  }
+
+  @Test("normalizedAppID collapses nil / empty / whitespace to nil, trims real IDs")
+  func normalizeAppID() {
+    #expect(StoryShareConfig.normalizedAppID(nil) == nil)
+    #expect(StoryShareConfig.normalizedAppID("") == nil)
+    #expect(StoryShareConfig.normalizedAppID("   ") == nil)
+    #expect(StoryShareConfig.normalizedAppID("1234567890") == "1234567890")
+    #expect(StoryShareConfig.normalizedAppID("  123  ") == "123")
+  }
+}

--- a/Pastura/PasturaTests/Views/StoryBackgroundGradientTests.swift
+++ b/Pastura/PasturaTests/Views/StoryBackgroundGradientTests.swift
@@ -1,0 +1,24 @@
+import Testing
+
+@testable import Pastura
+
+/// Change-detector tripwire for the Instagram Stories background gradient
+/// endpoints (``StoryBackgroundGradient``). These mirror the source-of-truth
+/// moss palette tokens **by design**. A failure here does NOT mean a bug was
+/// found: it means a code-review-gated visual constant drifted (the moss
+/// palette or its hex derivation changed), and the editor must confirm the
+/// change passed code review before updating the expected value. See #1083.
+@Suite("StoryBackgroundGradient", .timeLimit(.minutes(1)))
+@MainActor
+struct StoryBackgroundGradientTests {
+
+  @Test func hexStringRoundTripsKnownPaletteTokens() {
+    #expect(PasturaPalette.moss.hexString == "#8A9A6C")
+    #expect(PasturaPalette.mossDark.hexString == "#6B7852")
+  }
+
+  @Test func gradientEndpointsMatchMossPalette() {
+    #expect(StoryBackgroundGradient.topHex == "#8A9A6C")
+    #expect(StoryBackgroundGradient.bottomHex == "#6B7852")
+  }
+}


### PR DESCRIPTION
## Summary

Adds a **direct share to Instagram Stories** path to the highlight share-card feature (Growth umbrella #1069, A-1 follow-up). Instagram-first; **TikTok is a deferred follow-up** (separate scheme + SDK, per the issue's staging recommendation).

Tapping a highlight's share button now opens a **custom Pastura share sheet** (the "Spotify pattern" — chosen over a menu or the system sheet's action row for story-share discoverability, backed by how Spotify/Threads implement it):

- **Card preview** — the live `HighlightShareCard` so the user sees exactly what they're sharing.
- **Instagram Stories** — rasterizes the existing 1:1 card and hands it to Instagram as a `stickerImage` on a moss gradient background. Instagram composites the sticker onto the 9:16 story, so the app renders **no** 9:16 image itself (`instagram-stories://share` + `UIPasteboard` sticker contract, 5-min expiry).
- **Share via…** — falls back to the existing system share sheet.

### Feature is dark until a Facebook App ID is configured

Instagram has required a **Facebook App ID** for Stories sharing since Jan 2023 (passed as `source_application`). It's a **free, public client identifier** (not a secret), shipped here as an empty `Info.plist` `FacebookAppID` placeholder. The Instagram Stories destination only appears when Instagram is installed **AND** the App ID is set — until then the share button falls straight through to today's system share sheet, so there is **zero UX change** until the feature is switched on.

## Changes

| Area | What |
|---|---|
| `Info.plist` | `LSApplicationQueriesSchemes: instagram-stories` + empty `FacebookAppID` placeholder (operator comment) |
| `InstagramStoriesSharer` + `StoryShareConfig` | Deep-link URL / pasteboard payload / availability gating (pure, unit-tested) + UIKit shell (untested per ADR-009) |
| `StoryBackgroundGradient` + `PasturaColorValue.hexString` | moss gradient hex source (single-source-of-truth from palette tokens) + change-detector test |
| `StoryShareSheet` + `HighlightShareContext` + `.highlightShareSurfaces` | Custom sheet, dismiss-then-present bridge to the system sheet (avoids a nested-`.sheet` stall) |
| `ResultDetailView` / `SimulationView` | `shareHighlight` routes to the custom sheet when available, else the system sheet |

Plan, critic review, and design notes: issue #1083 plan comment.

## Test plan

- `InstagramStoriesSharerTests` (4) — URL shape, pasteboard keys/values, availability gating, App-ID normalization.
- `StoryBackgroundGradientTests` (2) — hex round-trip + change-detector for the gradient endpoints.
- Full unit suite: **2982 tests / 243 suites passed**. `swiftlint --strict` clean.
- Pasteboard keys / URL shape / 5-min expiry verified against Meta's "Sharing to Stories" spec.

## Device QA

Simulator can't exercise Instagram; **real-device QA + visual sign-off required** (operator):

1. **Register a free Facebook App ID** (developers.facebook.com → register → create app → copy App ID) and paste it into `Info.plist` `FacebookAppID`. No business verification needed.
2. On a device with Instagram installed: share a highlight → **Instagram Stories** → confirm the card lands as a sticker on the moss gradient 9:16 background.
3. Confirm the destination is **hidden** when Instagram is not installed / App ID empty (falls through to the system sheet).
4. **Visual sign-off**: moss gradient colors (`#8A9A6C` → `#6B7852`), card colorScheme (light/dark), 9:16 framing, and the preview sizing on small (SE-class) devices.
5. **Sheet presentation** on iOS 18 + 26: custom sheet → "Share via…" → system sheet (dismiss-then-present, single active sheet).

Closes #1083
