### PR TITLE
✅ test: gallery engine-floor deep-link tripwire (ADR-020 §8, #976)

### DIFF
--- a/Pastura/PasturaTests/App/Community/Gallery/GallerySeedYAMLTests+EngineVersion.swift
+++ b/Pastura/PasturaTests/App/Community/Gallery/GallerySeedYAMLTests+EngineVersion.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+extension GallerySeedYAMLTests {
+
+  /// The highest `min_engine_version` a **gallery** scenario may declare
+  /// while ADR-020 §8 item-4's deep-link sequencing obligation is still
+  /// undischarged.
+  ///
+  /// A gallery entry whose declared floor exceeds `EngineSchemaVersion` on an
+  /// **older installed app** greys out (ADR-020 D4) and, on Try, hits the
+  /// `.updateRequired` alert (D5). Until the App Store deep-link — or an
+  /// explicit forward-guidance path — lands on that badge/alert, such a row
+  /// **dead-ends with no way forward** (the exact failure D5 exists to
+  /// prevent; the App Store ID is not yet minted). The safe floor every
+  /// installed app can still run is therefore the pre-`no_repeat` baseline:
+  /// `1`. This is a **literal, deliberately decoupled from
+  /// `EngineSchemaVersion.current`** (= 2) — tying it to `current` would
+  /// auto-raise it on the next bump and silently defeat this tripwire.
+  static let maxGalleryFloorWithoutDeepLink = 1
+
+  /// Tripwire enforcing ADR-020 §8 item-4: **no gallery scenario may declare
+  /// `min_engine_version` above ``maxGalleryFloorWithoutDeepLink`` until the
+  /// deep-link/forward-guidance obligation is discharged.**
+  ///
+  /// This is the mechanical companion to the ADR's prose obligation
+  /// ("revisit before any gallery scenario declares `min_engine_version: 2`"):
+  /// the first curation PR that raises a floor must touch this test, which
+  /// forces its author to read the obligation and land the deep-link first.
+  /// Green today — every current `gallery.json` entry decodes `nil` (see
+  /// `GalleryScenario.minEngineVersion`).
+  ///
+  /// **Bounded scope (does NOT cover the D2 path).** There are two greying
+  /// paths in ADR-020: D3 (a **declared** `min_engine_version`, checked here)
+  /// and D2 (a phase kind in `phases` unknown to an older app's
+  /// `PhaseType.allCases`, auto-greyed with **no declared floor**). A gallery
+  /// entry that adopts a *new* `PhaseType` greys via D2 on older apps yet
+  /// declares no floor, so this tripwire stays **green** for it. Mechanically
+  /// catching the D2 path needs the deferred D3a versioned-capability manifest
+  /// (ADR-020 §7) — out of scope here. In the interim that path is gated only
+  /// by the v2-maintainer-checklist item-2 curator discipline (a new-phase
+  /// adopter is expected to raise `min_engine_version` manually), which the
+  /// ADR does not mechanically guarantee. Do not read this test's green as
+  /// "the deep-link obligation is fully guarded" — it guards only the declared
+  /// floor.
+  @Test func noGalleryScenarioDeclaresFloorAboveDeepLinkBaseline() throws {
+    let galleryDir = Self.repoRoot().appendingPathComponent("docs/gallery")
+    let indexURL = galleryDir.appendingPathComponent("gallery.json")
+    let indexData = try Data(contentsOf: indexURL)
+    let index = try JSONDecoder().decode(GalleryIndex.self, from: indexData)
+
+    #expect(!index.scenarios.isEmpty, "gallery.json has no scenarios")
+
+    for entry in index.scenarios {
+      guard let floor = entry.minEngineVersion else { continue }
+      #expect(
+        floor <= Self.maxGalleryFloorWithoutDeepLink,
+        """
+        gallery.json entry id=\(entry.id) declares min_engine_version=\(floor), \
+        above the deep-link baseline \(Self.maxGalleryFloorWithoutDeepLink). \
+        An older installed app would grey this row (ADR-020 D4/D5) with no way \
+        forward. Land the App Store deep-link (or explicit forward-guidance) on \
+        the "Update app" badge / "Update required" alert FIRST (ADR-020 §8 \
+        item-4, issue #976), then raise maxGalleryFloorWithoutDeepLink.
+        """)
+    }
+  }
+}

--- a/Pastura/PasturaTests/App/Community/Gallery/GallerySeedYAMLTests.swift
+++ b/Pastura/PasturaTests/App/Community/Gallery/GallerySeedYAMLTests.swift
@@ -352,7 +352,11 @@ import Testing
   /// Resolve the repo root relative to this test file. `#filePath` expands
   /// at compile time to the absolute source path; we walk up until we find
   /// the directory that contains `docs/gallery`.
-  private static func repoRoot() -> URL {
+  ///
+  /// Internal (not `private`) so sibling-file extensions of this suite can
+  /// reuse it — `private` members are invisible to extensions declared in
+  /// other files (see `.claude/rules/testing.md` § "Splitting a Suite").
+  static func repoRoot() -> URL {
     var url = URL(fileURLWithPath: #filePath)
     while url.path != "/" {
       url.deleteLastPathComponent()

--- a/Pastura/PasturaTests/App/Community/Gallery/GallerySeedYAMLTests.swift
+++ b/Pastura/PasturaTests/App/Community/Gallery/GallerySeedYAMLTests.swift
@@ -355,7 +355,8 @@ import Testing
   ///
   /// Internal (not `private`) so sibling-file extensions of this suite can
   /// reuse it — `private` members are invisible to extensions declared in
-  /// other files (see `.claude/rules/testing.md` § "Splitting a Suite").
+  /// other files (see `.claude/rules/testing.md`
+  /// § "Splitting a Suite Across Files").
   static func repoRoot() -> URL {
     var url = URL(fileURLWithPath: #filePath)
     while url.path != "/" {

--- a/docs/decisions/ADR-020.md
+++ b/docs/decisions/ADR-020.md
@@ -405,4 +405,12 @@ obligation is **not** triggered.
 - *Item 4 (deep-link sequencing):* not yet triggered (see above). **Revisit this
   obligation before any *gallery* scenario declares `min_engine_version: 2`** —
   at that point a pre-`no_repeat` installed base could hit the first-ever greyed
-  row, and the deep-link (or explicit forward-guidance) must land first.
+  row, and the deep-link (or explicit forward-guidance) must land first. This
+  revisit is now **mechanically guarded** for the *declared*-floor (D3) half by
+  `GallerySeedYAMLTests.noGalleryScenarioDeclaresFloorAboveDeepLinkBaseline`
+  (#976): the CI tripwire fails if any `gallery.json` entry declares
+  `min_engine_version` above the constant `maxGalleryFloorWithoutDeepLink` (`1`),
+  so the first curation PR that raises a floor must land the deep-link and bump
+  the constant together. The D2 automatic-greying half (a new `PhaseType` with no
+  declared floor) is **not** covered — that needs the deferred D3a manifest and
+  stays gated by item-2 curator discipline in the interim.


### PR DESCRIPTION
## Summary

Lands the **minimal, non-premature slice** of the ADR-020 v2 follow-up (#976): a CI guardrail tripwire enforcing ADR-020 §8 item-4.

**Background.** #976's three deferred items were gated on "the next PR that bumps `EngineSchemaVersion.current`". That trigger already fired — #1068 bumped `current` 1→2 for `event_inject`'s `no_repeat` — and ADR-020 §8 (2026-07-12) already dispositioned the v2 checklist: the deep-link stays deferred (App Store ID un-minted) and D3a stays deferred (the ADR warns encoding the versioned-capability manifest against zero real post-baseline cases risks getting it wrong). `no_repeat` is used only by the bundled `last_fable*` presets, which ship in lockstep with the engine and never route through the gallery gate — so no row can grey today.

**What this PR adds.** The one obligation that can silently regress is §8 item-4: "revisit before any *gallery* scenario declares `min_engine_version: 2`". This PR makes that mechanical — a tripwire that fails if any `gallery.json` entry declares `min_engine_version` above the deep-link baseline (`1`). The first curation PR that raises a floor must then land the deep-link and bump the constant together, instead of silently dead-ending a pre-`no_repeat` installed app.

**Bounded scope (documented, not overclaimed).** The tripwire guards only the *declared*-floor (D3) path. A gallery entry adopting a new `PhaseType` greys via the D2 automatic gate with no declared floor and is **not** caught here — that needs the deferred D3a manifest, gated in the interim by v2-checklist item-2 curator discipline. Both the test doc-comment and the ADR §8 note state this explicitly.

**Still deferred (this PR does NOT close #976):** App Store deep-link (item 1), D3a derived-floor tooling, D7 structural check.

## Changes

- `GallerySeedYAMLTests+EngineVersion.swift` (new) — the tripwire + `maxGalleryFloorWithoutDeepLink = 1` constant (a literal, deliberately decoupled from `EngineSchemaVersion.current`).
- `GallerySeedYAMLTests.swift` — widen `repoRoot()` `private static`→`static` so the sibling-file extension can reuse it (`.claude/rules/testing.md` § "Splitting a Suite Across Files"; inlining would exceed the 400-line `file_length` cap).
- `docs/decisions/ADR-020.md` — record the landed guardrail in the §8 item-4 disposition.

## Test plan

- `GallerySeedYAMLTests` suite green (10 tests incl. the new tripwire).
- Full unit suite green (`-skip-testing:PasturaUITests`); `swiftlint --strict` clean.
- **Coverage-theater negative check**: temporarily injected `min_engine_version: 2` into a gallery entry → only `noGalleryScenarioDeclaresFloorAboveDeepLinkBaseline` went red → reverted.

## Device QA

実機QA不要 — test + docs only; no `#if !targetEnvironment(simulator)` surface, no Metal/inference, no UI or navigation change.

Relates to #976 (guardrail slice only; deep-link + D3a + D7 remain deferred per ADR-020 §8).