### PR TITLE
✨ feat: 共有シートを横アイコン行に刷新＋X共有 (PR1, #1096)

### DIFF
--- a/Pastura/Pastura/Info.plist
+++ b/Pastura/Pastura/Info.plist
@@ -32,6 +32,13 @@
 	<array>
 		<string>instagram-stories</string>
 	</array>
+	<!-- Add-only Photos access for the highlight-card "Save Image" share action
+	     (#1096). Purpose string is deliberately specific (App Store Guideline
+	     5.1.1) and localized via InfoPlist.xcstrings - Info.plist strings sit
+	     outside the Localizable.xcstrings automated i18n gate, so the ja
+	     translation lives in that catalog, not the coverage gate. -->
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>Pastura saves the highlight card image to your photo library when you tap Save Image.</string>
 	<key>UILaunchScreen</key>
 	<dict>
 		<key>UIColorName</key>

--- a/Pastura/Pastura/Resources/InfoPlist.xcstrings
+++ b/Pastura/Pastura/Resources/InfoPlist.xcstrings
@@ -1,0 +1,24 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "NSPhotoLibraryAddUsageDescription" : {
+      "comment" : "Add-only Photos permission for the highlight-card Save Image share action (#1096). Localized here because Info.plist strings are outside the Localizable.xcstrings automated i18n gate.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pastura saves the highlight card image to your photo library when you tap Save Image."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「画像を保存」をタップすると、ハイライトカードの画像を写真ライブラリに保存します。"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/Pastura/Pastura/Resources/InfoPlist.xcstrings
+++ b/Pastura/Pastura/Resources/InfoPlist.xcstrings
@@ -1,30 +1,6 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "CFBundleDisplayName" : {
-      "comment" : "Bundle display name",
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pastura"
-          }
-        }
-      }
-    },
-    "CFBundleName" : {
-      "comment" : "Bundle name",
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pastura"
-          }
-        }
-      }
-    },
     "NSPhotoLibraryAddUsageDescription" : {
       "comment" : "Add-only Photos permission for the highlight-card Save Image share action (#1096). Localized here because Info.plist strings are outside the Localizable.xcstrings automated i18n gate.",
       "extractionState" : "manual",

--- a/Pastura/Pastura/Resources/InfoPlist.xcstrings
+++ b/Pastura/Pastura/Resources/InfoPlist.xcstrings
@@ -1,6 +1,30 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "CFBundleDisplayName" : {
+      "comment" : "Bundle display name",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pastura"
+          }
+        }
+      }
+    },
+    "CFBundleName" : {
+      "comment" : "Bundle name",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pastura"
+          }
+        }
+      }
+    },
     "NSPhotoLibraryAddUsageDescription" : {
       "comment" : "Add-only Photos permission for the highlight-card Save Image share action (#1096). Localized here because Info.plist strings are outside the Localizable.xcstrings automated i18n gate.",
       "extractionState" : "manual",

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -2387,6 +2387,16 @@
         }
       }
     },
+    "Copy Link" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リンクをコピー"
+          }
+        }
+      }
+    },
     "Correct!" : {
       "localizations" : {
         "ja" : {
@@ -3719,6 +3729,7 @@
       }
     },
     "Instagram Stories" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ja" : {
           "stringUnit" : {
@@ -5024,6 +5035,16 @@
         }
       }
     },
+    "Post to X" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "X にポスト"
+          }
+        }
+      }
+    },
     "Predict the outcome" : {
       "localizations" : {
         "ja" : {
@@ -5694,6 +5715,16 @@
         }
       }
     },
+    "Save Image" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画像を保存"
+          }
+        }
+      }
+    },
     "Save failed: %@" : {
       "localizations" : {
         "ja" : {
@@ -5972,6 +6003,16 @@
         }
       }
     },
+    "Share" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シェア"
+          }
+        }
+      }
+    },
     "Share as Card" : {
       "localizations" : {
         "en" : {
@@ -5989,6 +6030,7 @@
       }
     },
     "Share via…" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ja" : {
           "stringUnit" : {
@@ -6272,6 +6314,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用容量: %@"
+          }
+        }
+      }
+    },
+    "Stories" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ストーリーズ"
           }
         }
       }

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -6013,6 +6013,16 @@
         }
       }
     },
+    "Share Scenario" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シナリオを共有"
+          }
+        }
+      }
+    },
     "Share as Card" : {
       "localizations" : {
         "en" : {
@@ -7108,6 +7118,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pastura で AI たちのシミュレーションを観察中 🐑"
+          }
+        }
+      }
+    },
+    "Watching “%@” play out in Pastura 🐑" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pastura で「%@」を観察中 🐑"
           }
         }
       }

--- a/Pastura/Pastura/Views/Components/HighlightCardImageRenderer.swift
+++ b/Pastura/Pastura/Views/Components/HighlightCardImageRenderer.swift
@@ -89,15 +89,20 @@ struct HighlightShareItem: Identifiable {
   /// caption is unconditional (shared even when `linkURL` is nil) so a
   /// URL-less share still carries the app pointer as context.
   var activityItems: [Any] {
-    var items: [Any] = [image, caption]
+    var items: [Any] = [image, Self.caption]
     if let linkURL { items.append(linkURL) }
     return items
   }
 
   /// Short marketing caption giving share targets minimal context about what
-  /// the image is, plus an app pointer. Static (model-independent) and
-  /// localized; kept URL-free per the ordering note on ``activityItems``.
-  private var caption: String {
+  /// the image is, plus an app pointer. Model-independent and localized; kept
+  /// URL-free per the ordering note on ``activityItems``.
+  ///
+  /// Exposed as a single shared source (not a private instance property) so the
+  /// X web-intent post (``XPostSharer``) reuses the exact same localized string
+  /// — a duplicated literal would drift between the system-sheet caption and
+  /// the X post text across ja/en (#1096).
+  static var caption: String {
     String(localized: "Watching AI agents play out a scenario in Pastura 🐑")
   }
 }

--- a/Pastura/Pastura/Views/Components/ScenarioShareSheet.swift
+++ b/Pastura/Pastura/Views/Components/ScenarioShareSheet.swift
@@ -1,0 +1,165 @@
+import SwiftUI
+import UIKit
+
+/// Identity wrapper for presenting ``ScenarioShareSheet`` via `.sheet(item:)`.
+struct ScenarioShareContext: Identifiable {
+  let id = UUID()
+  let scenarioName: String
+  /// Public scenario link (`LocalizedPublicPages.sharedScenario`). Optional —
+  /// X / copy / system-share all handle a missing link without force-unwrap.
+  let link: URL?
+}
+
+/// Wraps the heterogeneous system-share payload so it can drive `.sheet(item:)`.
+private struct ScenarioSystemShareItems: Identifiable {
+  let id = UUID()
+  let items: [Any]
+}
+
+/// A Pastura-branded sheet for sharing a whole **scenario** (its public link),
+/// as opposed to ``StoryShareSheet`` which shares one utterance card image.
+/// Reached from the Scenario Detail toolbar (#1096). Same Instagram/X-native
+/// icon-row aesthetic, minus the card preview — a scenario has no card, so a
+/// scenario-name header stands in.
+///
+/// Destinations:
+/// - **Post to X** → ``XPostSharer`` web intent, scenario-aware caption + link.
+/// - **Copy Link** → copies the scenario link to the pasteboard.
+/// - **Share** → the system share sheet (caption + link) via `onSystemShare`
+///   (dismiss-then-present — see ``ScenarioShareModifier`` — so a nested
+///   `.sheet` can never stall presentation).
+struct ScenarioShareSheet: View {
+  let context: ScenarioShareContext
+  /// Invoked with the caption + link activity items when the user picks the
+  /// system share sheet. The modifier dismisses this sheet first, then presents
+  /// `ShareSheet`.
+  let onSystemShare: ([Any]) -> Void
+
+  @Environment(\.dismiss) private var dismiss
+
+  var body: some View {
+    VStack(spacing: Spacing.l) {
+      header
+      Divider()
+      destinationRow
+    }
+    .padding(.top, Spacing.xl)
+    .padding(.bottom, Spacing.l)
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    .background(Color.screenBackground)
+    .presentationDetents([.height(260)])
+    .presentationDragIndicator(.visible)
+  }
+
+  private var header: some View {
+    VStack(spacing: Spacing.xs) {
+      Image(systemName: "square.and.arrow.up")
+        .font(.system(size: 26, weight: .semibold))
+        .foregroundStyle(Color.moss)
+      Text(context.scenarioName)
+        .font(.headline)
+        .foregroundStyle(Color.ink)
+        .lineLimit(2)
+        .multilineTextAlignment(.center)
+    }
+    .padding(.horizontal, Spacing.l)
+    .accessibilityElement(children: .combine)
+  }
+
+  private var destinationRow: some View {
+    ScrollView(.horizontal, showsIndicators: false) {
+      HStack(spacing: Spacing.xs) {
+        ShareDestinationTab(
+          label: String(localized: "Post to X"),
+          fill: ShareDestinationFill.xBlack, action: postToX
+        ) {
+          ShareTabXGlyph()
+        }
+        ShareDestinationTab(
+          label: String(localized: "Copy Link"),
+          fill: ShareDestinationFill.neutral, action: copyLink
+        ) {
+          ShareTabSymbol(systemName: "link", tint: Color.ink)
+        }
+        ShareDestinationTab(
+          label: String(localized: "Share"),
+          fill: ShareDestinationFill.moss, action: requestSystemShare
+        ) {
+          ShareTabSymbol(systemName: "ellipsis", tint: .white)
+        }
+      }
+      .padding(.horizontal, Spacing.l)
+    }
+  }
+
+  /// Scenario-aware X post caption (name-bearing, unlike the utterance card's
+  /// model-independent caption). Form B (`String(format: String(localized:))`)
+  /// per the i18n format-string convention.
+  private var caption: String {
+    String(
+      format: String(localized: "Watching “%@” play out in Pastura 🐑"),
+      context.scenarioName)
+  }
+
+  private func postToX() {
+    XPostSharer.share(text: caption, link: context.link)
+    dismiss()
+  }
+
+  private func copyLink() {
+    guard let link = context.link else {
+      dismiss()
+      return
+    }
+    UIPasteboard.general.url = link
+    UINotificationFeedbackGenerator().notificationOccurred(.success)
+    dismiss()
+  }
+
+  /// Hands the caption + link to the host's system-share path. Does not dismiss
+  /// here — the modifier dismisses via `context = nil` and re-presents on
+  /// `onDismiss`.
+  private func requestSystemShare() {
+    var items: [Any] = [caption]
+    if let link = context.link { items.append(link) }
+    onSystemShare(items)
+  }
+}
+
+/// Presents ``ScenarioShareSheet`` and bridges its "Share" action to the system
+/// share sheet using **dismiss-then-present**: the custom sheet is dismissed
+/// first (`context = nil`), then the staged items are presented from the
+/// sheet's `onDismiss`, so only one sheet is ever active (a nested `.sheet`
+/// would risk a presentation stall on iOS — mirrors ``HighlightStoryShareModifier``).
+struct ScenarioShareModifier: ViewModifier {
+  @Binding var context: ScenarioShareContext?
+  @State private var pendingSystemShareItems: ScenarioSystemShareItems?
+  @State private var presentedSystemShareItems: ScenarioSystemShareItems?
+
+  func body(content: Content) -> some View {
+    content
+      .sheet(item: $context, onDismiss: presentPendingSystemShare) { ctx in
+        ScenarioShareSheet(
+          context: ctx,
+          onSystemShare: { items in
+            pendingSystemShareItems = ScenarioSystemShareItems(items: items)
+            context = nil
+          })
+      }
+      .sheet(item: $presentedSystemShareItems) { ShareSheet(activityItems: $0.items) }
+  }
+
+  private func presentPendingSystemShare() {
+    guard let pending = pendingSystemShareItems else { return }
+    pendingSystemShareItems = nil
+    presentedSystemShareItems = pending
+  }
+}
+
+extension View {
+  /// Presents the scenario ``ScenarioShareSheet`` bound to `context`, including
+  /// the system-share fallback. See ``ScenarioShareModifier``.
+  func scenarioShareSheet(context: Binding<ScenarioShareContext?>) -> some View {
+    modifier(ScenarioShareModifier(context: context))
+  }
+}

--- a/Pastura/Pastura/Views/Components/ShareDestinationTab.swift
+++ b/Pastura/Pastura/Views/Components/ShareDestinationTab.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+
+/// Layout constants for the horizontal share-destination row, shared by
+/// ``StoryShareSheet`` (utterance card) and ``ScenarioShareSheet`` (scenario
+/// link). Extracted as a named enum so a change-detector unit test can pin them
+/// (ADR-009 view-testing rule): the row is a visual-only surface with no manual
+/// test trigger, so drift is caught by asserting these values rather than
+/// rendering the View.
+enum ShareDestinationLayout {
+  /// Diameter of each circular destination icon.
+  static let iconDiameter: CGFloat = 56
+  /// SF Symbol / glyph point size inside the icon circle.
+  static let iconGlyphSize: CGFloat = 24
+  /// Fixed width of one icon-plus-label tab (drives the horizontal scroll).
+  static let tabWidth: CGFloat = 76
+  /// On-screen size of the (down-scaled) 360 pt card preview (StoryShareSheet).
+  static let previewSide: CGFloat = 176
+}
+
+/// Circle fills for the share destinations. Centralized so both sheets use the
+/// same brand ramps.
+enum ShareDestinationFill {
+  /// Moss brand gradient — the primary (system share) destination.
+  static var moss: AnyShapeStyle {
+    AnyShapeStyle(
+      LinearGradient(
+        colors: [Color.moss, Color.mossDark], startPoint: .topLeading,
+        endPoint: .bottomTrailing))
+  }
+
+  /// Instagram-recognizable warm→violet gradient. Raw RGB (not palette tokens)
+  /// because it deliberately evokes Instagram's brand ramp, not Pastura's moss.
+  static var instagram: AnyShapeStyle {
+    AnyShapeStyle(
+      LinearGradient(
+        colors: [
+          Color(red: 0.98, green: 0.55, blue: 0.12),
+          Color(red: 0.84, green: 0.16, blue: 0.46),
+          Color(red: 0.35, green: 0.36, blue: 0.84)
+        ], startPoint: .topLeading, endPoint: .bottomTrailing))
+  }
+
+  /// Solid black for the X destination.
+  static var xBlack: AnyShapeStyle { AnyShapeStyle(Color.black) }
+
+  /// Neutral chip fill for the utility (save / copy) destinations.
+  static var neutral: AnyShapeStyle { AnyShapeStyle(Color.ink.opacity(0.08)) }
+}
+
+/// One icon-over-label share destination tab: a circular tinted icon with a
+/// caption beneath, sized to ``ShareDestinationLayout/tabWidth``. Shared by both
+/// share sheets so their rows stay visually identical.
+struct ShareDestinationTab<Icon: View>: View {
+  let label: String
+  let fill: AnyShapeStyle
+  let action: () -> Void
+  @ViewBuilder let icon: () -> Icon
+
+  var body: some View {
+    Button(action: action) {
+      VStack(spacing: Spacing.xs) {
+        ZStack {
+          Circle()
+            .fill(fill)
+            .frame(
+              width: ShareDestinationLayout.iconDiameter,
+              height: ShareDestinationLayout.iconDiameter)
+          icon()
+        }
+        Text(label)
+          .font(.caption2)
+          .foregroundStyle(Color.ink)
+          .lineLimit(1)
+          // Degrade gracefully at large Dynamic Type instead of truncating the
+          // longer labels inside the fixed-width tab.
+          .minimumScaleFactor(0.85)
+      }
+      .frame(width: ShareDestinationLayout.tabWidth)
+    }
+    .buttonStyle(.plain)
+  }
+}
+
+/// A standard SF-symbol glyph sized for a ``ShareDestinationTab`` circle.
+struct ShareTabSymbol: View {
+  let systemName: String
+  let tint: Color
+
+  var body: some View {
+    Image(systemName: systemName)
+      .font(.system(size: ShareDestinationLayout.iconGlyphSize, weight: .semibold))
+      .foregroundStyle(tint)
+  }
+}
+
+/// The double-struck 𝕏 (U+1D54F) standing in for the X wordmark inside a tab
+/// circle. The tab's "Post to X" label carries the meaning, so it's decorative.
+struct ShareTabXGlyph: View {
+  var body: some View {
+    Text(verbatim: "𝕏")
+      .font(.system(size: ShareDestinationLayout.iconGlyphSize, weight: .bold))
+      .foregroundStyle(.white)
+  }
+}

--- a/Pastura/Pastura/Views/Components/StoryShareSheet.swift
+++ b/Pastura/Pastura/Views/Components/StoryShareSheet.swift
@@ -1,3 +1,4 @@
+import Photos
 import SwiftUI
 
 /// Identity wrapper for presenting ``StoryShareSheet`` via `.sheet(item:)` —
@@ -160,6 +161,9 @@ struct StoryShareSheet: View {
           .font(.caption2)
           .foregroundStyle(Color.ink)
           .lineLimit(1)
+          // Degrade gracefully at large Dynamic Type instead of truncating the
+          // longer labels ("Post to X" / "Save Image") inside the fixed tab.
+          .minimumScaleFactor(0.85)
       }
       .frame(width: ShareDestinationLayout.tabWidth)
     }
@@ -222,8 +226,10 @@ struct StoryShareSheet: View {
 
   /// Writes the opaque card image to the photo library (add-only —
   /// `NSPhotoLibraryAddUsageDescription`). Guards the render-nil step with a
-  /// silent no-op; a success haptic confirms the write, matching the
-  /// fire-and-forget UX (no completion selector on a value type).
+  /// silent no-op. Uses `PHPhotoLibrary.performChanges` rather than
+  /// `UIImageWriteToSavedPhotosAlbum(_:nil,nil,nil)` so the haptic reflects the
+  /// **real** outcome — the nil-completion form fires no callback, so a
+  /// "success" haptic would also sound when the user denies add-only access.
   private func saveImage() {
     guard
       let image = HighlightCardImageRenderer.render(
@@ -232,8 +238,13 @@ struct StoryShareSheet: View {
       dismiss()
       return
     }
-    UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil)
-    UINotificationFeedbackGenerator().notificationOccurred(.success)
+    PHPhotoLibrary.shared().performChanges {
+      PHAssetChangeRequest.creationRequestForAsset(from: image)
+    } completionHandler: { success, _ in
+      Task { @MainActor in
+        UINotificationFeedbackGenerator().notificationOccurred(success ? .success : .error)
+      }
+    }
     dismiss()
   }
 

--- a/Pastura/Pastura/Views/Components/StoryShareSheet.swift
+++ b/Pastura/Pastura/Views/Components/StoryShareSheet.swift
@@ -11,27 +11,15 @@ struct HighlightShareContext: Identifiable {
   let colorScheme: ColorScheme
 }
 
-/// Layout constants for the horizontal destination row. Extracted as a named
-/// enum so a change-detector unit test can pin them (ADR-009 view-testing
-/// rule): the row is a visual-only surface with no manual test trigger, so
-/// drift is caught by asserting these values rather than rendering the View.
-enum ShareDestinationLayout {
-  /// Diameter of each circular destination icon.
-  static let iconDiameter: CGFloat = 56
-  /// SF Symbol / glyph point size inside the icon circle.
-  static let iconGlyphSize: CGFloat = 24
-  /// Fixed width of one icon-plus-label tab (drives the horizontal scroll).
-  static let tabWidth: CGFloat = 76
-  /// On-screen size of the (down-scaled) 360 pt card preview.
-  static let previewSide: CGFloat = 176
-}
-
 /// A Pastura-branded share sheet (#1083, #1096) offering a card preview and a
 /// horizontal row of circular destination icons — the Instagram/X native
 /// share-sheet pattern, preferred over burying share paths in the system
 /// sheet's action row.
 ///
-/// Destinations, each routed to its medium-native form:
+/// This sheet shares the specific **utterance card** (an agent's line). Scenario
+/// -level sharing (X post / copy link) lives on ``ScenarioShareSheet`` instead,
+/// reached from the Scenario Detail screen — a scenario link is not about one
+/// utterance. Destinations here, each routed to its medium-native form:
 /// - **Share** → the system share sheet (card **image** + caption + link) via
 ///   the host's `onSystemShare` closure. The host dismisses this sheet first,
 ///   then presents `ShareSheet` (dismiss-then-present — see
@@ -40,9 +28,7 @@ enum ShareDestinationLayout {
 /// - **Stories** (shown only when ``InstagramStoriesSharer/isAvailableNow``)
 ///   hands the square card to Instagram as a sticker on the moss gradient 9:16
 ///   background — Instagram composites the two, so the app never renders 9:16.
-/// - **Post to X** → the ``XPostSharer`` web intent (caption + link, no image).
 /// - **Save Image** → writes the rasterized card to the photo library.
-/// - **Copy Link** → copies the scenario link (shown only when a link exists).
 ///
 /// The preview is a **live** ``HighlightShareCard`` (not the rasterized image),
 /// so a rasterization failure on any destination can never blank it.
@@ -96,107 +82,30 @@ struct StoryShareSheet: View {
   private var destinationRow: some View {
     ScrollView(.horizontal, showsIndicators: false) {
       HStack(spacing: Spacing.xs) {
-        destinationTab(
+        ShareDestinationTab(
           label: String(localized: "Share"),
-          fill: AnyShapeStyle(mossGradient), action: requestSystemShare
+          fill: ShareDestinationFill.moss, action: requestSystemShare
         ) {
-          icon("square.and.arrow.up", tint: .white)
+          ShareTabSymbol(systemName: "square.and.arrow.up", tint: .white)
         }
         if InstagramStoriesSharer.isAvailableNow {
-          destinationTab(
+          ShareDestinationTab(
             label: String(localized: "Stories"),
-            fill: AnyShapeStyle(instagramGradient), action: shareToInstagram
+            fill: ShareDestinationFill.instagram, action: shareToInstagram
           ) {
-            icon("camera.fill", tint: .white)
+            ShareTabSymbol(systemName: "camera.fill", tint: .white)
           }
         }
-        destinationTab(
-          label: String(localized: "Post to X"),
-          fill: AnyShapeStyle(Color.black), action: postToX
-        ) {
-          // The double-struck 𝕏 (U+1D54F) stands in for the X wordmark; the
-          // "Post to X" label carries the meaning, so the glyph is decorative.
-          Text(verbatim: "𝕏")
-            .font(.system(size: ShareDestinationLayout.iconGlyphSize, weight: .bold))
-            .foregroundStyle(.white)
-        }
-        destinationTab(
+        ShareDestinationTab(
           label: String(localized: "Save Image"),
-          fill: AnyShapeStyle(neutralFill), action: saveImage
+          fill: ShareDestinationFill.neutral, action: saveImage
         ) {
-          icon("square.and.arrow.down", tint: Color.ink)
-        }
-        if context.model.linkURL != nil {
-          destinationTab(
-            label: String(localized: "Copy Link"),
-            fill: AnyShapeStyle(neutralFill), action: copyLink
-          ) {
-            icon("link", tint: Color.ink)
-          }
+          ShareTabSymbol(systemName: "square.and.arrow.down", tint: Color.ink)
         }
       }
       .padding(.horizontal, Spacing.l)
     }
   }
-
-  /// One icon-over-label destination tab: a circular tinted icon with a caption
-  /// beneath, sized to ``ShareDestinationLayout/tabWidth``.
-  private func destinationTab(
-    label: String,
-    fill: AnyShapeStyle,
-    action: @escaping () -> Void,
-    @ViewBuilder icon: () -> some View
-  ) -> some View {
-    Button(action: action) {
-      VStack(spacing: Spacing.xs) {
-        ZStack {
-          Circle()
-            .fill(fill)
-            .frame(
-              width: ShareDestinationLayout.iconDiameter,
-              height: ShareDestinationLayout.iconDiameter)
-          icon()
-        }
-        Text(label)
-          .font(.caption2)
-          .foregroundStyle(Color.ink)
-          .lineLimit(1)
-          // Degrade gracefully at large Dynamic Type instead of truncating the
-          // longer labels ("Post to X" / "Save Image") inside the fixed tab.
-          .minimumScaleFactor(0.85)
-      }
-      .frame(width: ShareDestinationLayout.tabWidth)
-    }
-    .buttonStyle(.plain)
-  }
-
-  /// An SF Symbol sized for the icon circle.
-  private func icon(_ systemName: String, tint: Color) -> some View {
-    Image(systemName: systemName)
-      .font(.system(size: ShareDestinationLayout.iconGlyphSize, weight: .semibold))
-      .foregroundStyle(tint)
-  }
-
-  /// Moss brand gradient for the primary (system share) destination.
-  private var mossGradient: LinearGradient {
-    LinearGradient(
-      colors: [Color.moss, Color.mossDark], startPoint: .topLeading,
-      endPoint: .bottomTrailing)
-  }
-
-  /// Instagram-recognizable warm→violet gradient. Raw RGB (not palette tokens)
-  /// because it deliberately evokes Instagram's brand ramp, not Pastura's moss.
-  private var instagramGradient: LinearGradient {
-    LinearGradient(
-      colors: [
-        Color(red: 0.98, green: 0.55, blue: 0.12),
-        Color(red: 0.84, green: 0.16, blue: 0.46),
-        Color(red: 0.35, green: 0.36, blue: 0.84)
-      ], startPoint: .topLeading, endPoint: .bottomTrailing)
-  }
-
-  /// Neutral chip fill for the utility (save / copy) destinations.
-  private var neutralFill: Color { Color.ink.opacity(0.08) }
 
   /// Rasterizes the card and hands it to Instagram Stories. Guards the two
   /// nil-producing steps (`render` → `UIImage?`, `pngData()` → `Data?`) with a
@@ -213,14 +122,6 @@ struct StoryShareSheet: View {
       topColorHex: StoryBackgroundGradient.topHex,
       bottomColorHex: StoryBackgroundGradient.bottomHex,
       appID: appID)
-    dismiss()
-  }
-
-  /// Opens the X composer pre-filled with the shared caption + scenario link
-  /// (no image — X has no image deep link; ``XPostSharer``). Reuses the same
-  /// caption as the system-sheet path so the two can't drift across ja/en.
-  private func postToX() {
-    XPostSharer.share(text: HighlightShareItem.caption, link: context.model.linkURL)
     dismiss()
   }
 
@@ -255,19 +156,6 @@ struct StoryShareSheet: View {
         }
       }
     }
-    dismiss()
-  }
-
-  /// Copies the scenario link to the pasteboard. Guarded on a non-nil link (the
-  /// tab is hidden when nil), so the guard is defensive; a success haptic
-  /// confirms the copy.
-  private func copyLink() {
-    guard let link = context.model.linkURL else {
-      dismiss()
-      return
-    }
-    UIPasteboard.general.url = link
-    UINotificationFeedbackGenerator().notificationOccurred(.success)
     dismiss()
   }
 

--- a/Pastura/Pastura/Views/Components/StoryShareSheet.swift
+++ b/Pastura/Pastura/Views/Components/StoryShareSheet.swift
@@ -238,11 +238,21 @@ struct StoryShareSheet: View {
       dismiss()
       return
     }
-    PHPhotoLibrary.shared().performChanges {
-      PHAssetChangeRequest.creationRequestForAsset(from: image)
-    } completionHandler: { success, _ in
-      Task { @MainActor in
-        UINotificationFeedbackGenerator().notificationOccurred(success ? .success : .error)
+    // Request **add-only** access explicitly. Reaching `performChanges` with an
+    // undetermined status makes Photos prompt for full read-write access, which
+    // requires `NSPhotoLibraryUsageDescription` — absent here (we ship only the
+    // add-only key), so that path crashes. `.addOnly` uses the key we declare.
+    PHPhotoLibrary.requestAuthorization(for: .addOnly) { status in
+      guard status == .authorized || status == .limited else {
+        Task { @MainActor in UINotificationFeedbackGenerator().notificationOccurred(.error) }
+        return
+      }
+      PHPhotoLibrary.shared().performChanges {
+        PHAssetChangeRequest.creationRequestForAsset(from: image)
+      } completionHandler: { success, _ in
+        Task { @MainActor in
+          UINotificationFeedbackGenerator().notificationOccurred(success ? .success : .error)
+        }
       }
     }
     dismiss()

--- a/Pastura/Pastura/Views/Components/StoryShareSheet.swift
+++ b/Pastura/Pastura/Views/Components/StoryShareSheet.swift
@@ -10,21 +10,41 @@ struct HighlightShareContext: Identifiable {
   let colorScheme: ColorScheme
 }
 
-/// A Pastura-branded share sheet (#1083) offering a card preview and explicit
-/// share destinations — the "Spotify pattern" for story-share discoverability,
-/// preferred over burying the story path in the system sheet's action row.
+/// Layout constants for the horizontal destination row. Extracted as a named
+/// enum so a change-detector unit test can pin them (ADR-009 view-testing
+/// rule): the row is a visual-only surface with no manual test trigger, so
+/// drift is caught by asserting these values rather than rendering the View.
+enum ShareDestinationLayout {
+  /// Diameter of each circular destination icon.
+  static let iconDiameter: CGFloat = 56
+  /// SF Symbol / glyph point size inside the icon circle.
+  static let iconGlyphSize: CGFloat = 24
+  /// Fixed width of one icon-plus-label tab (drives the horizontal scroll).
+  static let tabWidth: CGFloat = 76
+  /// On-screen size of the (down-scaled) 360 pt card preview.
+  static let previewSide: CGFloat = 176
+}
+
+/// A Pastura-branded share sheet (#1083, #1096) offering a card preview and a
+/// horizontal row of circular destination icons — the Instagram/X native
+/// share-sheet pattern, preferred over burying share paths in the system
+/// sheet's action row.
 ///
-/// - **Instagram Stories** (shown only when ``InstagramStoriesSharer/isAvailableNow``)
-///   rasterizes the square card and hands it to Instagram as a sticker on the
-///   moss gradient 9:16 background — Instagram composites the two, so the app
-///   never renders a 9:16 image.
-/// - **Share via…** routes to the system share sheet through the host's
-///   `onSystemShare` closure. The host dismisses this sheet first, then presents
-///   `ShareSheet` (dismiss-then-present — see ``HighlightStoryShareModifier`` —
-///   so a nested `.sheet` can never stall presentation).
+/// Destinations, each routed to its medium-native form:
+/// - **Share** → the system share sheet (card **image** + caption + link) via
+///   the host's `onSystemShare` closure. The host dismisses this sheet first,
+///   then presents `ShareSheet` (dismiss-then-present — see
+///   ``HighlightStoryShareModifier`` — so a nested `.sheet` can never stall
+///   presentation). X-with-image lives here (X has no image deep link).
+/// - **Stories** (shown only when ``InstagramStoriesSharer/isAvailableNow``)
+///   hands the square card to Instagram as a sticker on the moss gradient 9:16
+///   background — Instagram composites the two, so the app never renders 9:16.
+/// - **Post to X** → the ``XPostSharer`` web intent (caption + link, no image).
+/// - **Save Image** → writes the rasterized card to the photo library.
+/// - **Copy Link** → copies the scenario link (shown only when a link exists).
 ///
 /// The preview is a **live** ``HighlightShareCard`` (not the rasterized image),
-/// so a rasterization failure on the Instagram path can never blank it.
+/// so a rasterization failure on any destination can never blank it.
 struct StoryShareSheet: View {
   let context: HighlightShareContext
   /// Invoked with the ready-to-share item when the user picks the system share
@@ -34,15 +54,12 @@ struct StoryShareSheet: View {
 
   @Environment(\.dismiss) private var dismiss
 
-  /// On-screen size of the (down-scaled) 360 pt card preview.
-  private let previewSide: CGFloat = 200
-
   var body: some View {
-    VStack(spacing: Spacing.xl) {
+    VStack(spacing: Spacing.l) {
       preview
-      destinations
+      Divider()
+      destinationRow
     }
-    .padding(.horizontal, Spacing.l)
     .padding(.top, Spacing.xl)
     .padding(.bottom, Spacing.l)
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
@@ -63,30 +80,119 @@ struct StoryShareSheet: View {
           cornerRadius: HighlightCardImageRenderer.storyStickerCornerRadius,
           style: .continuous)
       )
-      .scaleEffect(previewSide / HighlightShareCard.side)
-      .frame(width: previewSide, height: previewSide)
-      // Decorative preview — the destination buttons carry the actions.
+      .scaleEffect(ShareDestinationLayout.previewSide / HighlightShareCard.side)
+      .frame(
+        width: ShareDestinationLayout.previewSide,
+        height: ShareDestinationLayout.previewSide
+      )
+      // Decorative preview — the destination icons carry the actions.
       .accessibilityHidden(true)
   }
 
-  private var destinations: some View {
-    VStack(spacing: Spacing.s) {
-      if InstagramStoriesSharer.isAvailableNow {
-        Button(action: shareToInstagram) {
-          Label(String(localized: "Instagram Stories"), systemImage: "camera.circle.fill")
+  /// Horizontal, scrollable row of destination icons. Scrolls on the narrowest
+  /// devices (5 tabs at 76 pt exceed the SE width) — matching how Instagram/X
+  /// present their own app rows.
+  private var destinationRow: some View {
+    ScrollView(.horizontal, showsIndicators: false) {
+      HStack(spacing: Spacing.xs) {
+        destinationTab(
+          label: String(localized: "Share"),
+          fill: AnyShapeStyle(mossGradient), action: requestSystemShare
+        ) {
+          icon("square.and.arrow.up", tint: .white)
         }
-        .buttonStyle(PasturaPrimaryButtonStyle())
-        .frame(maxWidth: .infinity)
+        if InstagramStoriesSharer.isAvailableNow {
+          destinationTab(
+            label: String(localized: "Stories"),
+            fill: AnyShapeStyle(instagramGradient), action: shareToInstagram
+          ) {
+            icon("camera.fill", tint: .white)
+          }
+        }
+        destinationTab(
+          label: String(localized: "Post to X"),
+          fill: AnyShapeStyle(Color.black), action: postToX
+        ) {
+          // The double-struck 𝕏 (U+1D54F) stands in for the X wordmark; the
+          // "Post to X" label carries the meaning, so the glyph is decorative.
+          Text(verbatim: "𝕏")
+            .font(.system(size: ShareDestinationLayout.iconGlyphSize, weight: .bold))
+            .foregroundStyle(.white)
+        }
+        destinationTab(
+          label: String(localized: "Save Image"),
+          fill: AnyShapeStyle(neutralFill), action: saveImage
+        ) {
+          icon("square.and.arrow.down", tint: Color.ink)
+        }
+        if context.model.linkURL != nil {
+          destinationTab(
+            label: String(localized: "Copy Link"),
+            fill: AnyShapeStyle(neutralFill), action: copyLink
+          ) {
+            icon("link", tint: Color.ink)
+          }
+        }
       }
-      Button(action: requestSystemShare) {
-        Label(String(localized: "Share via…"), systemImage: "square.and.arrow.up")
-          .font(.system(size: 16, weight: .semibold))
-          .foregroundStyle(Color.ink)
-          .frame(maxWidth: .infinity)
-          .padding(.vertical, 15)
-      }
+      .padding(.horizontal, Spacing.l)
     }
   }
+
+  /// One icon-over-label destination tab: a circular tinted icon with a caption
+  /// beneath, sized to ``ShareDestinationLayout/tabWidth``.
+  private func destinationTab(
+    label: String,
+    fill: AnyShapeStyle,
+    action: @escaping () -> Void,
+    @ViewBuilder icon: () -> some View
+  ) -> some View {
+    Button(action: action) {
+      VStack(spacing: Spacing.xs) {
+        ZStack {
+          Circle()
+            .fill(fill)
+            .frame(
+              width: ShareDestinationLayout.iconDiameter,
+              height: ShareDestinationLayout.iconDiameter)
+          icon()
+        }
+        Text(label)
+          .font(.caption2)
+          .foregroundStyle(Color.ink)
+          .lineLimit(1)
+      }
+      .frame(width: ShareDestinationLayout.tabWidth)
+    }
+    .buttonStyle(.plain)
+  }
+
+  /// An SF Symbol sized for the icon circle.
+  private func icon(_ systemName: String, tint: Color) -> some View {
+    Image(systemName: systemName)
+      .font(.system(size: ShareDestinationLayout.iconGlyphSize, weight: .semibold))
+      .foregroundStyle(tint)
+  }
+
+  /// Moss brand gradient for the primary (system share) destination.
+  private var mossGradient: LinearGradient {
+    LinearGradient(
+      colors: [Color.moss, Color.mossDark], startPoint: .topLeading,
+      endPoint: .bottomTrailing)
+  }
+
+  /// Instagram-recognizable warm→violet gradient. Raw RGB (not palette tokens)
+  /// because it deliberately evokes Instagram's brand ramp, not Pastura's moss.
+  private var instagramGradient: LinearGradient {
+    LinearGradient(
+      colors: [
+        Color(red: 0.98, green: 0.55, blue: 0.12),
+        Color(red: 0.84, green: 0.16, blue: 0.46),
+        Color(red: 0.35, green: 0.36, blue: 0.84)
+      ], startPoint: .topLeading, endPoint: .bottomTrailing)
+  }
+
+  /// Neutral chip fill for the utility (save / copy) destinations.
+  private var neutralFill: Color { Color.ink.opacity(0.08) }
 
   /// Rasterizes the card and hands it to Instagram Stories. Guards the two
   /// nil-producing steps (`render` → `UIImage?`, `pngData()` → `Data?`) with a
@@ -103,6 +209,44 @@ struct StoryShareSheet: View {
       topColorHex: StoryBackgroundGradient.topHex,
       bottomColorHex: StoryBackgroundGradient.bottomHex,
       appID: appID)
+    dismiss()
+  }
+
+  /// Opens the X composer pre-filled with the shared caption + scenario link
+  /// (no image — X has no image deep link; ``XPostSharer``). Reuses the same
+  /// caption as the system-sheet path so the two can't drift across ja/en.
+  private func postToX() {
+    XPostSharer.share(text: HighlightShareItem.caption, link: context.model.linkURL)
+    dismiss()
+  }
+
+  /// Writes the opaque card image to the photo library (add-only —
+  /// `NSPhotoLibraryAddUsageDescription`). Guards the render-nil step with a
+  /// silent no-op; a success haptic confirms the write, matching the
+  /// fire-and-forget UX (no completion selector on a value type).
+  private func saveImage() {
+    guard
+      let image = HighlightCardImageRenderer.render(
+        context.model, colorScheme: context.colorScheme)
+    else {
+      dismiss()
+      return
+    }
+    UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil)
+    UINotificationFeedbackGenerator().notificationOccurred(.success)
+    dismiss()
+  }
+
+  /// Copies the scenario link to the pasteboard. Guarded on a non-nil link (the
+  /// tab is hidden when nil), so the guard is defensive; a success haptic
+  /// confirms the copy.
+  private func copyLink() {
+    guard let link = context.model.linkURL else {
+      dismiss()
+      return
+    }
+    UIPasteboard.general.url = link
+    UINotificationFeedbackGenerator().notificationOccurred(.success)
     dismiss()
   }
 

--- a/Pastura/Pastura/Views/Components/XPostSharer.swift
+++ b/Pastura/Pastura/Views/Components/XPostSharer.swift
@@ -1,0 +1,62 @@
+import UIKit
+
+/// Share to X (Twitter) via the `x.com/intent/tweet` web intent (#1096).
+///
+/// X exposes no image-attach deep link — the intent URL accepts only
+/// `text` / `url` — so the highlight card *image* is shared through the
+/// system share sheet, and this sharer covers the lightweight
+/// caption-plus-link post. The `/intent/tweet` endpoint is used deliberately
+/// over `/intent/post`: on iOS the latter bounces through an in-app browser
+/// into an X-app ↔ Safari redirect loop, while `/intent/tweet` opens the
+/// native composer directly. Reference: X Web Intents
+/// (docs.x.com/x-for-websites/web-intents/overview).
+@MainActor
+enum XPostSharer {
+
+  /// The X web-intent composer endpoint. `x.com` (post-rebrand) avoids the
+  /// extra `twitter.com` → `x.com` redirect hop.
+  static let intentBase = "https://x.com/intent/tweet"
+
+  /// RFC 3986 *unreserved* set — every other character in a query **value** is
+  /// percent-encoded, so spaces, `&`, `:`, `/`, `+`, and emoji can never be
+  /// misread as URL syntax. `URLComponents` leaves several of those raw inside
+  /// a value (the known ampersand-passthrough), which would let a caption `&`
+  /// split the query, so the values are encoded by hand instead.
+  private static let valueAllowed: CharacterSet = {
+    var set = CharacterSet.alphanumerics
+    set.insert(charactersIn: "-._~")
+    return set
+  }()
+
+  // MARK: - Pure logic (unit-tested)
+
+  /// Builds `https://x.com/intent/tweet?text=<text>&url=<link>`, percent-
+  /// encoding both params against ``valueAllowed``. `url=` is omitted when
+  /// `link` is nil (a URL-less share still pre-fills the caption). Returns
+  /// `nil` only if encoding or the final `URL` parse fails — guarding the
+  /// no-force-unwrap invariant.
+  static func intentURL(text: String, link: URL?) -> URL? {
+    guard let encodedText = text.addingPercentEncoding(withAllowedCharacters: valueAllowed)
+    else { return nil }
+    var query = "text=\(encodedText)"
+    if let link,
+      let encodedLink = link.absoluteString.addingPercentEncoding(
+        withAllowedCharacters: valueAllowed) {
+      query += "&url=\(encodedLink)"
+    }
+    return URL(string: "\(intentBase)?\(query)")
+  }
+
+  // MARK: - UIKit shell (side-effecting; not unit-tested per ADR-009)
+
+  /// Opens the X composer pre-filled with `text` (plus `link` when set).
+  /// Returns `false` as a silent no-op if the URL can't be built or opened —
+  /// the https intent falls through to Safari when the X app is absent, so a
+  /// `false` here is genuinely rare.
+  @discardableResult
+  static func share(text: String, link: URL?) -> Bool {
+    guard let url = intentURL(text: text, link: link) else { return false }
+    UIApplication.shared.open(url, options: [:], completionHandler: nil)
+    return true
+  }
+}

--- a/Pastura/Pastura/Views/Results/ResultDetailView+Share.swift
+++ b/Pastura/Pastura/Views/Results/ResultDetailView+Share.swift
@@ -19,15 +19,10 @@ extension ResultDetailView {
         linkURL: LocalizedPublicPages.sharedScenario(id: scenario?.id),
         contentFilter: contentFilter)
     else { return }
-    // Offer the custom story-share sheet only when Instagram Stories is
-    // actually available (installed + App ID configured); otherwise fall
-    // straight through to the system share sheet — no UX change until the
-    // feature is live (#1083).
-    if InstagramStoriesSharer.isAvailableNow {
-      highlightShareContext = HighlightShareContext(model: model, colorScheme: colorScheme)
-    } else {
-      highlightShareItem = HighlightCardImageRenderer.makeShareItem(
-        model, colorScheme: colorScheme)
-    }
+    // Always present the custom share sheet as the default surface (#1096); it
+    // gates the Instagram destination internally on `isAvailableNow`. Its live
+    // card preview means a rasterization failure can't blank the sheet — unlike
+    // the old direct-to-system-sheet fallback, which presented nothing on nil.
+    highlightShareContext = HighlightShareContext(model: model, colorScheme: colorScheme)
   }
 }

--- a/Pastura/Pastura/Views/ScenarioDetail/ScenarioDetailView.swift
+++ b/Pastura/Pastura/Views/ScenarioDetail/ScenarioDetailView.swift
@@ -21,6 +21,9 @@ struct ScenarioDetailView: View {
   @Environment(AppRouter.self) var router
   @State private var viewModel: ScenarioDetailViewModel?
   @State private var showDeleteConfirm = false
+  /// Drives the scenario-level share sheet (link + X post + copy) from the
+  /// toolbar. Distinct from the per-utterance card share on Results/Simulation.
+  @State private var scenarioShareContext: ScenarioShareContext?
 
   /// Drives the content scroll position so a cross-language swap can reset
   /// to the top edge (see `scenarioContent`'s `.onChange`).
@@ -73,7 +76,25 @@ struct ScenarioDetailView: View {
         PasturaBackButton()
       }
       .hidingPasturaSharedBackground()
+      // Scenario-level share (link) — only once the scenario has loaded, so the
+      // link/name are available. The per-utterance card share lives elsewhere.
+      if let scenario = viewModel?.scenario {
+        ToolbarItem(placement: .primaryAction) {
+          Button {
+            scenarioShareContext = ScenarioShareContext(
+              scenarioName: scenario.name,
+              link: LocalizedPublicPages.sharedScenario(id: scenario.id))
+          } label: {
+            Label(String(localized: "Share Scenario"), systemImage: "square.and.arrow.up")
+          }
+          .labelStyle(.iconOnly)
+          .buttonStyle(PasturaToolbarButtonStyle(variant: .secondary))
+          .accessibilityIdentifier("scenarioDetail.shareButton")
+        }
+        .hidingPasturaSharedBackground()
+      }
     }
+    .scenarioShareSheet(context: $scenarioShareContext)
     // `.alert` (not `.confirmationDialog`): iOS 26 renders a body-attached
     // confirmationDialog as a popover whose arrow anchors to the body
     // centre, not the triggering control. A centred alert avoids that.

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -1160,16 +1160,11 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
         linkURL: LocalizedPublicPages.sharedScenario(id: scenario?.id),
         contentFilter: contentFilter)
     else { return }
-    // Offer the custom story-share sheet only when Instagram Stories is
-    // actually available (installed + App ID configured); otherwise fall
-    // straight through to the system share sheet — no UX change until the
-    // feature is live (#1083).
-    if InstagramStoriesSharer.isAvailableNow {
-      highlightShareContext = HighlightShareContext(model: model, colorScheme: colorScheme)
-    } else {
-      highlightShareItem = HighlightCardImageRenderer.makeShareItem(
-        model, colorScheme: colorScheme)
-    }
+    // Always present the custom share sheet as the default surface (#1096); it
+    // gates the Instagram destination internally on `isAvailableNow`. Its live
+    // card preview means a rasterization failure can't blank the sheet — unlike
+    // the old direct-to-system-sheet fallback, which presented nothing on nil.
+    highlightShareContext = HighlightShareContext(model: model, colorScheme: colorScheme)
   }
 
   /// The active inference model's short label for the share card, or `nil` when

--- a/Pastura/PasturaTests/Views/ShareDestinationLayoutTests.swift
+++ b/Pastura/PasturaTests/Views/ShareDestinationLayoutTests.swift
@@ -12,7 +12,7 @@ import Testing
 /// value below.
 @MainActor
 @Suite(.timeLimit(.minutes(1)))
-struct StoryShareSheetLayoutTests {
+struct ShareDestinationLayoutTests {
 
   @Test("Destination-row layout tokens hold their reviewed values")
   func layoutTokens() {

--- a/Pastura/PasturaTests/Views/StoryShareSheetLayoutTests.swift
+++ b/Pastura/PasturaTests/Views/StoryShareSheetLayoutTests.swift
@@ -1,0 +1,24 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+/// Change-detector for ``ShareDestinationLayout`` (#1096). The horizontal
+/// destination row is a visual-only surface with no manual test trigger
+/// (ADR-009 view-testing rule 4), so its load-bearing layout constants are
+/// pinned here rather than rendered. A failure is NOT a bug — it means a
+/// code-review-gated layout token drifted (typically in an unrelated
+/// refactor); confirm the change passed review, then update the expected
+/// value below.
+@MainActor
+@Suite(.timeLimit(.minutes(1)))
+struct StoryShareSheetLayoutTests {
+
+  @Test("Destination-row layout tokens hold their reviewed values")
+  func layoutTokens() {
+    #expect(ShareDestinationLayout.iconDiameter == 56)
+    #expect(ShareDestinationLayout.iconGlyphSize == 24)
+    #expect(ShareDestinationLayout.tabWidth == 76)
+    #expect(ShareDestinationLayout.previewSide == 176)
+  }
+}

--- a/Pastura/PasturaTests/Views/XPostSharerTests.swift
+++ b/Pastura/PasturaTests/Views/XPostSharerTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+/// Pure logic for the X (Twitter) web-intent share (#1096): the
+/// `x.com/intent/tweet` URL shape and percent-encoding of the `text` / `url`
+/// params. The UIKit side effect (`UIApplication.open`) is not tested
+/// (ADR-009 — no UIKit integration); only the deterministic URL shaping is.
+@MainActor
+@Suite(.timeLimit(.minutes(1)))
+struct XPostSharerTests {
+
+  @Test("intentURL targets x.com/intent/tweet and percent-encodes the text param")
+  func intentURLBasicShape() {
+    let url = XPostSharer.intentURL(text: "hello world", link: nil)
+    #expect(url?.scheme == "https")
+    #expect(url?.host == "x.com")
+    #expect(url?.path == "/intent/tweet")
+    // Spaces must be percent-encoded, never a raw space or `+`.
+    #expect(url?.absoluteString == "https://x.com/intent/tweet?text=hello%20world")
+  }
+
+  @Test("intentURL appends url= when a link is present")
+  func intentURLWithLink() throws {
+    let link = URL(string: "https://pastura.app/s/werewolf/")
+    let url = XPostSharer.intentURL(text: "caption", link: link)
+    let string = try #require(url?.absoluteString)
+    #expect(string.hasPrefix("https://x.com/intent/tweet?text=caption&url="))
+    // The link itself is percent-encoded (its `:` / `/` become %3A / %2F).
+    #expect(string.contains("https%3A%2F%2Fpastura.app%2Fs%2Fwerewolf%2F"))
+  }
+
+  @Test("intentURL omits url= entirely when the link is nil")
+  func intentURLNilLink() {
+    let url = XPostSharer.intentURL(text: "caption", link: nil)
+    #expect(url?.absoluteString.contains("url=") == false)
+  }
+
+  @Test("intentURL encodes an ampersand in the text so it can't corrupt the query")
+  func intentURLAmpersandEncoding() throws {
+    // A raw `&` in the value would be read by X as a param separator; it must
+    // land as %26 (guards against URLComponents' known ampersand-passthrough).
+    let url = XPostSharer.intentURL(text: "cats & dogs", link: nil)
+    let string = try #require(url?.absoluteString)
+    #expect(string.contains("%26"))
+    #expect(!string.contains("cats & dogs"))
+  }
+
+  @Test("intentURL percent-encodes emoji in the text")
+  func intentURLEmojiEncoding() throws {
+    let url = XPostSharer.intentURL(text: "Pastura 🐑", link: nil)
+    let string = try #require(url?.absoluteString)
+    // 🐑 (U+1F411) as UTF-8 percent-encoding.
+    #expect(string.contains("%F0%9F%90%91"))
+  }
+}


### PR DESCRIPTION
## Summary
共有 UI を **Instagram/X ネイティブ準拠の横アイコン行**に刷新。共有対象の粒度で **2つの面**に分離する（レビュー中のフィードバック反映）:

- **発言カード共有**（`StoryShareSheet` / Results・Simulation の各発言行から）＝ "その発言カード画像" の共有 → **シェア / ストーリーズ / 画像を保存**
- **シナリオ共有**（`ScenarioShareSheet` / シナリオ詳細のツールバー共有ボタンから）＝ "シナリオ（リンク）" の共有 → **X にポスト / リンクをコピー / 共有(その他)**

**#1083 の残タスクだった TikTok は見送り**（別スキーム・動画媒体不適合）。X を手軽に共有できる導線を追加。Growth umbrella #1069 / #1070 の後続 **PR1（iOS）**。X リンクカードをリッチにする web の OG 画像整備は **PR2（別 run）**。

### 主な設計判断
- **X は `x.com/intent/tweet`**（`/intent/post` は iOS で X↔Safari 無限リダイレクト不具合）。X は画像 deep link 非対応なので、画像で X 共有したい場合は発言カードの「シェア」→ system シートから。
- クエリ値は **RFC 3986 unreserved のみ許可の手動エンコード**で `&`/絵文字/`:` を確実にエスケープ。
- **シナリオ共有の X 文面はシナリオ名入り**（`Watching “<name>” play out in Pastura 🐑`）。発言カードのキャプションは単一共有ソース化して ja/en drift を防止。
- 発言カードのカスタムシートを常時デフォルト化（ライブプレビューでラスタライズ失敗でも空白にならない）。
- **横アイコン行タブを共有コンポーネント（`ShareDestinationTab`）に抽出**し両シートで共用。
- `NSPhotoLibraryAddUsageDescription`（アプリ初の権限文言）を具体的目的文言で追加＋新規 `InfoPlist.xcstrings` で ja（自動 i18n ゲート外）。

### ⚠️ レビュー中に見つかった不具合の修正
- **画像を保存でクラッシュ**していたのを修正: `PHPhotoLibrary.performChanges` を未確定状態で叩くと read-write 権限（`NSPhotoLibraryUsageDescription`、非同梱）を要求してクラッシュ → **add-only 権限を明示要求**してから保存。拒否/失敗は error ハプティクス。

## Test plan
- `XPostSharerTests`(5): intent URL の shape／`&`・絵文字・空白エンコード／nil link で `url=` 省略。
- `ShareDestinationLayoutTests`(1): レイアウト定数 change-detector（ADR-009）。
- フル単体スイート **2997 tests green** / `swiftlint --strict` clean / `check_localization_coverage.py` OK（654 keys）。
- code-reviewer（Opus）2 回とも **PASS / Critical 0**。指摘（save haptic・crash・phantom key・test rename 等）は反映済み。

## Device QA
シミュレータ検証不可の面が多く実機必須:
1. **発言カード共有** — 発言行の共有ボタン → シート（シェア/ストーリーズ/画像を保存）。
   - **画像を保存**: 初回タップで Photos **add-only** 権限プロンプト（**ja 端末で `InfoPlist.xcstrings` の日本語文言**）→ 許可でカメラロール保存＋success ハプティクス／**拒否で error ハプティクス（クラッシュしないこと）**。
   - **シェア**: system シートに画像＋キャプション＋リンク。X を選べば画像添付投稿。
   - **ストーリーズ**: Instagram 直接共有（既存 #1094 と同等か）。
2. **シナリオ共有** — シナリオ詳細の**右上ツールバー共有ボタン** → シート（X にポスト/リンクをコピー/共有）。
   - **X にポスト**: X アプリでシナリオ名入りキャプション＋リンクが pre-fill されるか（未導入で Safari フォールバック）。
   - **リンクをコピー / 共有**: 貼り付け・system シート確認。
3. **レイアウト** — 最小端末（iPhone SE）で横スクロール・`.height(260)`/`.medium` detent。ダークモードで Save/Copy neutral tab（`Color.ink` 固定色）の contrast。
4. ImageRenderer のダークモードカード（既存ゲート）。

Closes #1096