### PR TITLE
✨ feat: apply narrate live-commentary to word_wolf presets (ja/en) (#909)

### DIFF
--- a/Pastura/Pastura/Resources/Presets/word_wolf.yaml
+++ b/Pastura/Pastura/Resources/Presets/word_wolf.yaml
@@ -113,6 +113,20 @@ phases:
       inner_thought: string
     rounds: 1
 
+  # Live commentary before the vote (#909). The narrator sees the full round
+  # of clues + the final remarks and calls the round's highlight. Factuality
+  # was harness-verified on this exact placement (3 ja + 3 en runs on
+  # gemma-4-E2B-it-Q4_K_M, 0 hallucinated commentary).
+  - type: narrate
+    narrator: 熱のこもった実況アナウンサー
+    prompt: >
+      直近のやり取り:
+      {conversation_log}
+
+      ここまでに出た clue の食い違いを踏まえ、最も怪しい人物と決定的なズレを、
+      番組の実況として短く伝えてください。実際に出た clue だけを根拠にすること。
+    max_sentences: 3
+
   - type: vote
     prompt: >
       あなたのお題: {assigned_word}

--- a/Pastura/Pastura/Resources/Presets/word_wolf_en.yaml
+++ b/Pastura/Pastura/Resources/Presets/word_wolf_en.yaml
@@ -133,6 +133,21 @@ phases:
       inner_thought: string
     rounds: 1
 
+  # Live commentary before the vote (#909). The narrator sees the full round
+  # of clues + the final remarks and calls the round's highlight. Factuality
+  # was harness-verified on this exact placement (3 ja + 3 en runs on
+  # gemma-4-E2B-it-Q4_K_M, 0 hallucinated commentary).
+  - type: narrate
+    narrator: an enthusiastic play-by-play commentator
+    prompt: >
+      Recent exchange:
+      {conversation_log}
+
+      Based on the clashes among the clues raised so far, call out the most
+      suspicious player and the decisive mismatch, as a short piece of show
+      commentary. Ground it only on clues that were actually raised.
+    max_sentences: 3
+
   - type: vote
     prompt: >
       Your topic: {assigned_word}

--- a/tools/harness/scenarios/word_wolf_narrate.yaml
+++ b/tools/harness/scenarios/word_wolf_narrate.yaml
@@ -1,14 +1,20 @@
-# Harness-only Go/No-Go fixture for the `narrate` phase (#909). NOT a shipping
-# preset or gallery seed — it exists to feed `pastura-harness --scenario` so the
-# commentary's factuality can be judged (hallucination ≤ 1 / 3 runs). Based on
-# the bundled word_wolf.yaml with a single `narrate` phase inserted before the
-# vote, so the narrator has a full round of clues to ground its commentary on.
+# Harness-only factuality fixture for the `narrate` phase (#909). NOT a shipping
+# preset or gallery seed — it feeds `pastura-harness --scenario` so the
+# commentary's factuality can be judged (Go criterion: hallucination ≤ 1 / 3 runs).
+#
+# This mirrors the FULL production word_wolf.yaml phase sequence (reflect +
+# event_inject + conditional-summarize + the final pre-vote speak_each round)
+# with a single `narrate` phase inserted immediately before the vote — i.e. the
+# exact flow a real user gets now that narrate is applied to the bundled preset.
+# Keeping the full flow (not a reduced proxy) means the narrator sees the same
+# noisy {conversation_log} production emits, so the Go verdict is reproducible.
+# EN sibling: word_wolf_narrate_en.yaml. Verified 3 ja + 3 en runs on
+# gemma-4-E2B-it-Q4_K_M, 0 hallucinated commentary.
 id: word_wolf_narrate
 language: ja
-name: ワードウルフ（実況つき）
+name: ワードウルフ（実況・本番フロー検証）
 description: >
-  ワードウルフに実況フェーズ（narrate）を追加した検証用シナリオ。
-  投票直前に実況者が「このラウンドの見どころ」を1推論で語る。
+  本番 word_wolf に narrate を vote 直前へ挿入した適用検証用シナリオ。
 agents: 5
 rounds: 1
 context: >
@@ -23,6 +29,11 @@ context: >
 words:
   - majority: りんご
     minority: みかん
+
+mid_game_announcements:
+  - "📺 司会者: ここで途中経過のお時間です — 残り時間あとわずか、的を絞っていきましょう。"
+  - "📺 観客席: 抽象論はもう十分！色や味や食べ方の具体的な話が聞きたい！"
+  - "📺 司会者: 怪しい人物が浮かび上がってきましたね。最後の一言で印象を固めましょう。"
 
 personas:
   - name: ユウキ
@@ -75,9 +86,47 @@ phases:
       inner_thought: string
     rounds: 2
 
-  # The narrate phase under test (#909). Placed before the vote so the narrator
-  # has the full round of clues to reference — the Go/No-Go judges whether the
-  # commentary sticks to what actually appears in {conversation_log}.
+  - type: reflect
+    prompt: >
+      あなたのお題: {assigned_word}
+
+      これまでの会話:
+      {conversation_log}
+
+      これまでに出た clue を踏まえ、誰が怪しいか・自分は多数派と少数派の
+      どちららしいか・投票までにどう動くかを、自分用のメモとして更新してください。
+    output:
+      note: string
+
+  - type: event_inject
+    source: mid_game_announcements
+    probability: 0.5
+
+  - type: conditional
+    if: 'current_event != ""'
+    then:
+      - type: summarize
+        template: "{current_event}"
+
+  - type: speak_each
+    prompt: >
+      あなたのお題: {assigned_word}
+
+      これまでの会話:
+      {conversation_log}
+
+      番組からのアナウンス: {current_event}
+
+      これまでに出た clue を踏まえ、誰の手がかりが他とズレているかに触れつつ、
+      投票前の最後の一言を述べてください。お題の単語そのものは言わないこと。
+    output:
+      statement: string
+      inner_thought: string
+    rounds: 1
+
+  # The narrate phase under application test (#909). Inserted right before the
+  # vote so the narrator has the full production log (2 clue rounds + reflect +
+  # any injected announcement + the final statements) to ground its commentary.
   - type: narrate
     narrator: 熱のこもった実況アナウンサー
     prompt: >

--- a/tools/harness/scenarios/word_wolf_narrate_en.yaml
+++ b/tools/harness/scenarios/word_wolf_narrate_en.yaml
@@ -1,0 +1,173 @@
+# Harness-only factuality fixture for the `narrate` phase (#909) — EN sibling of
+# word_wolf_narrate.yaml. NOT a shipping preset or gallery seed; it feeds
+# `pastura-harness --scenario` so the EN commentary's factuality can be judged
+# (Go criterion: hallucination ≤ 1 / 3 runs). Mirrors the FULL production
+# word_wolf_en.yaml phase sequence with a single `narrate` inserted before the
+# vote — the exact flow a real EN user gets. Committed so the ja→en
+# non-transfer risk is covered by a reproducible EN run, not just the ja fixture.
+# Verified 3 EN runs on gemma-4-E2B-it-Q4_K_M, 0 hallucinated commentary.
+id: word_wolf_narrate_en
+language: en
+name: Word Wolf (narrate, production-flow verification)
+description: >
+  Production word_wolf_en with a narrate phase inserted before the vote,
+  for application-verification of #909 factuality on the EN preset.
+agents: 5
+rounds: 1
+context: >
+  You are a contestant on the game show "Word Wolf".
+  Each of you has been given a topic word, but one player has a
+  different word from the rest. Never say your topic word out loud.
+  But do actively describe concrete features that evoke it — colour,
+  shape, taste, season, how you eat it. Anyone who only speaks in vague
+  terms looks suspicious. Then vote to identify the minority (the wolf).
+  You do not know whether you are the majority or the minority.
+
+words:
+  - majority: apple
+    minority: orange
+
+mid_game_announcements:
+  - "📺 Host: Mid-show check-in — time is running short, let's narrow it down."
+  - "📺 Audience: Enough abstractions! We want concrete talk — colour, taste, how you eat it."
+  - "📺 Host: A suspect is starting to emerge. Lock in your impression with one final remark."
+
+personas:
+  - name: Avery
+    description: >
+      [Role] Goes after appearance and colour.
+      [Goal] Describe one concrete visual feature (colour, shape) of the
+      topic and watch for clashes with others' visual descriptions.
+      Calm, concise tone. Example: "Colour-wise, it's a pretty distinct shade."
+  - name: Riley
+    description: >
+      [Role] Outgoing, talks taste and texture.
+      [Goal] Describe the taste, texture, and mouth-feel of the topic
+      concretely.
+      Bright, friendly tone. Example: "That burst of flavour — I love it!"
+  - name: Morgan
+    description: >
+      [Role] Analytical, goes after how and when it's eaten.
+      [Goal] Describe how or when you eat it, and probe contradictions in
+      others' descriptions.
+      Sharp, intellectual tone. Example: "Hold on — that way of eating it doesn't add up with what you said."
+  - name: Casey
+    description: >
+      [Role] Laid-back natural, talks season and memory.
+      [Goal] Speak plainly about the season or a memory tied to the topic;
+      don't overthink.
+      Easy, unhurried tone. Example: "Mmm, I've got this memory of having it with family when it was cold out."
+  - name: Jordan
+    description: >
+      [Role] Poker-faced, doles out clues sparingly.
+      [Goal] Offer just one concrete feature and watch how others react.
+      Cool, detached tone. Example: "Well, if I say one thing… it's the feel of it in your hand."
+
+phases:
+  - type: assign
+    source: words
+    target: random_one
+
+  - type: speak_each
+    prompt: >
+      Your topic: {assigned_word}
+
+      Conversation so far:
+      {conversation_log}
+
+      Talk about the topic. Never say the topic word itself.
+      In `clue`, you must give exactly one concrete feature that evokes
+      your topic (colour, shape, taste, season, how you eat it, a memory —
+      vague phrases like "nice" or "warm" are not allowed). Watch others'
+      clues closely to find the minority.
+    output:
+      statement: string
+      clue: string
+      inner_thought: string
+    rounds: 2
+
+  - type: reflect
+    prompt: >
+      Your topic: {assigned_word}
+
+      Conversation so far:
+      {conversation_log}
+
+      Based on the clues so far, update your private notes: who seems
+      suspicious, whether you seem to be in the majority or the minority,
+      and how you plan to act before the vote.
+    output:
+      note: string
+
+  - type: event_inject
+    source: mid_game_announcements
+    probability: 0.5
+
+  - type: conditional
+    if: 'current_event != ""'
+    then:
+      - type: summarize
+        template: "{current_event}"
+
+  - type: speak_each
+    prompt: >
+      Your topic: {assigned_word}
+
+      Conversation so far:
+      {conversation_log}
+
+      Announcement from the show: {current_event}
+
+      Comparing the clues raised so far, point to whose clue seems out of
+      step with the others, and make your final pre-vote remark. Never say
+      the topic word itself.
+    output:
+      statement: string
+      inner_thought: string
+    rounds: 1
+
+  # The narrate phase under application test (#909). Inserted right before the
+  # vote so the narrator has the full production log (2 clue rounds + reflect +
+  # any injected announcement + the final statements) to ground its commentary.
+  - type: narrate
+    narrator: an enthusiastic play-by-play commentator
+    prompt: >
+      Recent exchange:
+      {conversation_log}
+
+      Based on the clashes among the clues raised so far, call out the most
+      suspicious player and the decisive mismatch, as a short piece of show
+      commentary. Ground it only on clues that were actually raised.
+    max_sentences: 3
+
+  - type: vote
+    prompt: >
+      Your topic: {assigned_word}
+
+      Conversation log:
+      {conversation_log}
+
+      Compare the clues that were given and vote for the minority (the
+      wolf) whose features are out of step with the rest.
+      Write the vote target exactly as one of these names: {candidates}
+    output:
+      vote: string
+      reason: string
+    exclude_self: true
+
+  - type: eliminate
+  - type: score_calc
+    logic: wordwolf_judge
+
+  - type: conditional
+    if: "vote_winner == wolf_name"
+    then:
+      - type: summarize
+        template: >
+          🎯 Wolf found! {wolf_name} received the most votes and was the minority ({vote_results}).
+          The majority wins.
+    else:
+      - type: summarize
+        template: >
+          😈 Wolf escapes! The actual minority was {wolf_name}, but the votes went elsewhere ({vote_results}).
+          The minority wins.


### PR DESCRIPTION
## Summary
- Apply the harness-verified `narrate` phase (#909, shipped as a capability via #1098) to the two bundled `word_wolf` presets (ja/en), inserted immediately before the `vote`. A commentator persona calls the round's highlight from the actual clues.
  - ja narrator: `熱のこもった実況アナウンサー` / en narrator: `an enthusiastic play-by-play commentator`
- narrate was applied to **zero** shipped scenarios before this — this is the feature's first user-visible use. Bundled presets ship with the app (engine always at `ENGINE_SCHEMA_VERSION=3`), so no `min_engine_version` declaration is needed (that gate is shared/gallery-only).
- Also commits the **full-production-flow** verification fixtures so the Go/No-Go is reproducible from the repo: upgraded `tools/harness/scenarios/word_wolf_narrate.yaml` from a reduced proxy to the full production phase sequence (reflect + event_inject + conditional-summarize + final-remark round), and added the `word_wolf_narrate_en.yaml` sibling.

## Factuality verification (Go/No-Go, #909)
Ran the full production flow (preset + narrate before vote) on `gemma-4-E2B-it-Q4_K_M.gguf` (TestFlight-equivalent backend):

| Lang | Runs | Hallucinated commentary | Verdict |
|------|------|-------------------------|---------|
| ja | 3 | 0 | ✅ Go |
| en | 3 | 0 | ✅ Go |

Go criterion was ≤1 hallucination / 3 runs. Every narration referenced only clues/people actually in `{conversation_log}`; the mid-game `event_inject` announcement (fired in all runs) was never misattributed, and no run fabricated vote results (which occur after the narrate point). en persona wording reads natural as show commentary.

## Test plan
- `pastura-harness lint` on all 4 changed YAMLs → 0 errors, 0 warnings (ADR-024 ScenarioSemanticLinter; confirms narrate-before-vote trips no rule).
- `BundledPresetPlaceholderCoverageTests` passes (narrate prompt introduces only `{conversation_log}`, already engine-supplied).
- Full unit suite: 3007 tests / 248 suites pass.
- SwiftLint `--strict` clean.
- code-reviewer (Opus): PASS, 0 issues.

## Device QA
Real-device smoke check (the simulator build uses `MockLLMService`, so it never exercises real narrate inference/rendering):
1. Run `word_wolf` on device to completion.
2. Confirm a live-commentary line renders **before** the vote, and that it references clues actually spoken that round (no invented events/votes).

Closes #1102