### PR TITLE
✨ feat: auto share-highlight candidates at run end (#1070)

### DIFF
--- a/Pastura/Pastura/App/HighlightCandidate.swift
+++ b/Pastura/Pastura/App/HighlightCandidate.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// A single automatic share-highlight candidate surfaced at simulation end
+/// (#1070 Stage 2): one notable agent utterance the viewer can turn into a
+/// share card with a tap.
+///
+/// Carries the resolved `TurnOutput` (already `ContentFilter`-applied at the
+/// VM boundary) plus its `phaseType` so the end-of-run section can both show
+/// a preview excerpt and hand the same `(agent, output, phaseType)` triple to
+/// the existing Stage-1 `shareHighlight` path — no re-derivation. `id` is the
+/// source `LogEntry` id, so the section's `ForEach` / de-dup stays stable
+/// across re-projection.
+struct HighlightCandidate: Identifiable, Equatable, Sendable {
+  let id: UUID
+  let agent: String
+  let output: TurnOutput
+  let phaseType: PhaseType
+  let reason: HighlightReason
+
+  /// The quotable statement shown as the row's excerpt — the same primary
+  /// text `shareHighlight` puts on the card. Non-optional: the VM only builds
+  /// a candidate when this is non-empty (dead-tap guard), so the row and the
+  /// card can never disagree on shareability.
+  var previewText: String {
+    output.primaryText(for: phaseType) ?? ""
+  }
+}

--- a/Pastura/Pastura/App/HighlightCandidateLogic.swift
+++ b/Pastura/Pastura/App/HighlightCandidateLogic.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+/// The reason a live agent utterance was surfaced as a share-highlight
+/// candidate at simulation end (#1070 Stage 2). Drives the reason chip on
+/// each candidate row.
+///
+/// `nonisolated` so it can be constructed and returned from the nonisolated
+/// selection logic below under default-MainActor isolation (a MainActor
+/// `init` would be unreachable from a nonisolated sync context), which also
+/// releases its `Equatable` conformance for nonisolated / test call sites
+/// (swift-isolation Pattern 5).
+nonisolated enum HighlightReason: Equatable, Sendable {
+  /// The agent's public `declared_intent` was contradicted by all of their
+  /// choose actions that round (🃏, #916).
+  case contradiction
+  /// The agent was the ground-truth answer to the run's viewer-prediction
+  /// question — the wolf or the top vote-getter — revealed at vote time
+  /// (🎯, #915). Surfaced whether or not the viewer guessed correctly: the
+  /// reveal itself is the shareable moment.
+  case revealed
+}
+
+/// Pure selection logic for automatic share-highlight candidates (#1070
+/// Stage 2).
+///
+/// The ViewModel owns transcript assembly and card construction; this enum
+/// owns the single decision: given the run's ordered agent-output entries
+/// plus the two zero-inference signals (contradiction badges, prediction
+/// reveal), which entries — in what order, capped — become share candidates
+/// and why. Kept `nonisolated` and dependency-free (Foundation + the Models
+/// `PhaseType` only, never the App-layer `LogEntry`) so it unit-tests off
+/// the MainActor without rendering a View (ADR-009 /
+/// `.claude/rules/view-testing.md`).
+nonisolated enum HighlightCandidateLogic {
+
+  /// A single agent-output entry in transcript order, projected to just the
+  /// fields the selection needs. The caller maps `LogEntry.agentOutput`
+  /// entries to these (`id` = the `LogEntry` id), preserving run order.
+  nonisolated struct Entry: Equatable, Sendable {
+    let id: UUID
+    let agent: String
+    let phaseType: PhaseType
+    /// Whether this entry carries a 🃏 contradiction badge
+    /// (`SimulationViewModel.contradictionBadgedEntryIDs`).
+    let isContradiction: Bool
+  }
+
+  /// One selected candidate: the source entry id and why it was surfaced.
+  nonisolated struct Selection: Equatable, Sendable {
+    let id: UUID
+    let reason: HighlightReason
+  }
+
+  /// Default cap on surfaced candidates — keeps the end-of-run section from
+  /// becoming a wall of cards.
+  static let defaultLimit = 3
+
+  /// Selects share-highlight candidates from `entries` (agent outputs in
+  /// transcript order).
+  ///
+  /// - Contradiction: every entry with `isContradiction == true` becomes a
+  ///   candidate (reason `.contradiction`).
+  /// - Reveal: when `actualAgent` is non-nil (a prediction was scored this
+  ///   run), that agent's *last* speak-phase entry becomes a candidate
+  ///   (reason `.revealed`). Speak phases are `.speakAll` / `.speakEach` —
+  ///   the phases whose primary output is a public statement worth quoting;
+  ///   an agent that only voted (or never spoke) yields no reveal candidate.
+  ///
+  /// De-dup is by entry id with contradiction winning: if the reveal entry
+  /// is already a contradiction candidate it keeps the `.contradiction`
+  /// reason (the stronger signal) rather than appearing twice. Output stays
+  /// in transcript order and is capped at `limit`; because contradictions
+  /// are emitted in order and the reveal is chronologically the agent's last
+  /// statement, a run with `limit` contradictions can evict the reveal.
+  static func candidates(
+    entries: [Entry],
+    actualAgent: String?,
+    limit: Int = defaultLimit
+  ) -> [Selection] {
+    // The reveal entry: the actual agent's last speak-phase output.
+    let revealID: UUID? = actualAgent.flatMap { agent in
+      entries.last { $0.agent == agent && isSpeakPhase($0.phaseType) }?.id
+    }
+
+    var result: [Selection] = []
+    for entry in entries {
+      let reason: HighlightReason?
+      if entry.isContradiction {
+        reason = .contradiction  // contradiction wins the de-dup
+      } else if entry.id == revealID {
+        reason = .revealed
+      } else {
+        reason = nil
+      }
+      guard let reason else { continue }
+      result.append(Selection(id: entry.id, reason: reason))
+      if result.count >= limit { break }
+    }
+    return result
+  }
+
+  /// The speak phases whose primary output is a public statement worth
+  /// quoting on a card. Inlined here (not a `PhaseType` helper) to keep the
+  /// change App-only — Models must not gain a member for this feature.
+  private static func isSpeakPhase(_ phaseType: PhaseType) -> Bool {
+    phaseType == .speakAll || phaseType == .speakEach
+  }
+}

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -66,6 +66,11 @@ struct ViewerPredictionPrompt: Identifiable {
 struct PredictionOutcome: Equatable, Sendable {
   let isHit: Bool
   let streak: Int
+  /// The ground-truth answer that was revealed — the wolf or the top
+  /// vote-getter. Carried so the share-highlight section (#1070 Stage 2) can
+  /// surface that agent's utterance as the 🎯 reveal candidate, regardless of
+  /// whether the viewer guessed correctly.
+  let actualAgent: String
 }
 
 /// ViewModel for the live simulation execution screen.
@@ -2365,7 +2370,8 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
       question: pending.question, predicted: pending.picked, actual: actual)
     predictionOutcome = PredictionOutcome(
       isHit: ViewerPredictionLogic.isHit(predicted: pending.picked, actual: actual),
-      streak: streak)
+      streak: streak,
+      actualAgent: actual)
   }
 
   /// Active (non-eliminated) agent names — the choosable roster. At the first

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -618,6 +618,43 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   /// `ContradictionDetectionLogic`. Reset each round.
   private var chooseRawActions: [String: [String]] = [:]
 
+  // MARK: Share-highlight candidates (#1070 Stage 2)
+
+  /// Automatic share-highlight candidates for the end-of-run "Share a
+  /// highlight" section — derived, not stored. Projects the live transcript
+  /// to `HighlightCandidateLogic` descriptors (only entries whose primary
+  /// text is non-empty, so a shown card can never dead-tap the failable
+  /// `HighlightShareCard.Model` init), applies the two zero-inference signals
+  /// (contradiction badges, prediction reveal), and rehydrates the selected
+  /// ids back into full candidates carrying the filtered `TurnOutput`. Reads
+  /// only `@Observable` state (`logEntries`, `contradictionBadgedEntryIDs`,
+  /// `predictionOutcome`), so the View re-renders when the run completes.
+  var highlightCandidates: [HighlightCandidate] {
+    var descriptors: [HighlightCandidateLogic.Entry] = []
+    var entryByID: [UUID: LogEntry] = [:]
+    for entry in logEntries {
+      guard case .agentOutput(let agent, let output, let phaseType) = entry.kind,
+        let primary = output.primaryText(for: phaseType), !primary.isEmpty
+      else { continue }
+      descriptors.append(
+        HighlightCandidateLogic.Entry(
+          id: entry.id, agent: agent, phaseType: phaseType,
+          isContradiction: contradictionBadgedEntryIDs.contains(entry.id)))
+      entryByID[entry.id] = entry
+    }
+    let selections = HighlightCandidateLogic.candidates(
+      entries: descriptors, actualAgent: predictionOutcome?.actualAgent)
+    return selections.compactMap { selection in
+      guard
+        case .agentOutput(let agent, let output, let phaseType) =
+          entryByID[selection.id]?.kind
+      else { return nil }
+      return HighlightCandidate(
+        id: selection.id, agent: agent, output: output,
+        phaseType: phaseType, reason: selection.reason)
+    }
+  }
+
   #if DEBUG
     // Streaming-display diagnostic logger for #133 PR#4 device-run sessions.
     // Shared across VM + `AgentOutputRow`; filter Console.app with

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -2399,6 +2399,16 @@
         }
       }
     },
+    "Contradiction" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "矛盾"
+          }
+        }
+      }
+    },
     "Copy & Edit" : {
       "localizations" : {
         "ja" : {
@@ -5521,6 +5531,16 @@
         }
       }
     },
+    "Revealed" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正体判明"
+          }
+        }
+      }
+    },
     "Roleplay" : {
       "localizations" : {
         "ja" : {
@@ -6061,12 +6081,32 @@
         }
       }
     },
+    "Share %@'s highlight" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ の見どころを共有"
+          }
+        }
+      }
+    },
     "Share Scenario" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "シナリオを共有"
+          }
+        }
+      }
+    },
+    "Share a highlight" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "この瞬間をシェア"
           }
         }
       }
@@ -6766,6 +6806,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "このシナリオを試す"
+          }
+        }
+      }
+    },
+    "Turn a standout moment into a card. Tap to open the share card." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今回の見どころを一枚絵で。タップして共有カードを開きます。"
           }
         }
       }

--- a/Pastura/Pastura/Views/Simulation/HighlightCandidatesSection.swift
+++ b/Pastura/Pastura/Views/Simulation/HighlightCandidatesSection.swift
@@ -1,0 +1,134 @@
+import SwiftUI
+
+/// The end-of-run "Share a highlight" section (#1070 Stage 2): lists
+/// automatic share-highlight candidates surfaced from the run's turns.
+/// Tapping a row invokes the caller-supplied `onShare` closure, which opens
+/// the existing share-card sheet with the same `(agent, output, phaseType)`
+/// triple the row previews — no re-derivation.
+///
+/// Callers should only mount this view when `candidates` is non-empty; the
+/// body still guards internally so an empty array renders nothing.
+struct HighlightCandidatesSection: View {
+  let candidates: [HighlightCandidate]
+  let onShare: (HighlightCandidate) -> Void
+
+  var body: some View {
+    if !candidates.isEmpty {
+      VStack(alignment: .leading, spacing: 4) {
+        Text(String(localized: "Share a highlight"))
+          .font(.system(size: 15, weight: .bold))
+          .foregroundStyle(Color.ink)
+
+        Text(String(localized: "Turn a standout moment into a card. Tap to open the share card."))
+          .font(.system(size: 11.5))
+          .foregroundStyle(Color.muted)
+          .padding(.bottom, 8)
+
+        VStack(spacing: 9) {
+          ForEach(candidates) { candidate in
+            Button {
+              onShare(candidate)
+            } label: {
+              row(for: candidate)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(
+              String(format: String(localized: "Share %@'s highlight"), candidate.agent))
+          }
+        }
+      }
+    }
+  }
+
+  private func row(for candidate: HighlightCandidate) -> some View {
+    HStack(spacing: 11) {
+      SheepAvatar(character: .forAgent(candidate.agent, position: nil), size: 40)
+
+      VStack(alignment: .leading, spacing: 2) {
+        HStack(spacing: 6) {
+          Text(candidate.agent)
+            .font(.system(size: 13, weight: .bold))
+            .foregroundStyle(Color.ink)
+            .lineLimit(1)
+
+          reasonChip(for: candidate.reason)
+        }
+
+        Text(candidate.previewText)
+          .font(.system(size: 12))
+          .foregroundStyle(Color.inkSecondary)
+          .lineLimit(2)
+          .truncationMode(.tail)
+      }
+
+      Spacer(minLength: 8)
+
+      Image(systemName: "square.and.arrow.up")
+        .font(.system(size: 15))
+        .foregroundStyle(Color.muted)
+    }
+    .padding(11)
+    .background(RoundedRectangle(cornerRadius: 14).fill(Color.bubbleBackground))
+  }
+
+  private func reasonChip(for reason: HighlightReason) -> some View {
+    let style = ChipStyle(reason: reason)
+    // `style.word` is already `String(localized:)`-resolved; compose verbatim
+    // so the emoji-prefixed string isn't re-read as a LocalizedStringKey lookup
+    // (`.claude/rules/i18n.md` § convenience-init label trap).
+    return Text(verbatim: "\(style.emoji) \(style.word)")
+      .font(.system(size: 10, weight: .bold))
+      .padding(.horizontal, 7)
+      .padding(.vertical, 2)
+      .background(Capsule().fill(style.background))
+      .foregroundStyle(style.textColor)
+  }
+
+  /// Emoji + localized word + capsule colors for a candidate's reason chip.
+  private struct ChipStyle {
+    let emoji: String
+    let word: String
+    let background: Color
+    let textColor: Color
+
+    init(reason: HighlightReason) {
+      switch reason {
+      case .contradiction:
+        emoji = "🃏"
+        word = String(localized: "Contradiction")
+        background = Color.warningSoft
+        textColor = Color.warningInk
+      case .revealed:
+        emoji = "🎯"
+        word = String(localized: "Revealed")
+        background = Color.mossSoft
+        textColor = Color.mossDark
+      }
+    }
+  }
+}
+
+#Preview {
+  HighlightCandidatesSection(
+    candidates: [
+      HighlightCandidate(
+        id: UUID(),
+        agent: "Bob",
+        output: TurnOutput(fields: [
+          "statement": "I'll cooperate for sure, trust me — then betrayed everyone next turn."
+        ]),
+        phaseType: .speakAll,
+        reason: .contradiction),
+      HighlightCandidate(
+        id: UUID(),
+        agent: "Carol",
+        output: TurnOutput(fields: [
+          "statement": "Everyone calm down. I think Alice is the suspicious one here."
+        ]),
+        phaseType: .speakAll,
+        reason: .revealed)
+    ],
+    onShare: { _ in }
+  )
+  .padding()
+}

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -641,6 +641,11 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
             // result card when the run had an answered prediction.
             predictionOutcomeBadge(viewModel: viewModel)
 
+            // Automatic share-highlight candidates (#1070 Stage 2): notable
+            // moments (🃏 contradiction / 🎯 reveal) offered as one-tap share
+            // cards, shown with the result card at completion.
+            highlightCandidatesSection(viewModel: viewModel)
+
             // Bottom sentinel: scrollTo target that stays below every other
             // section (log entries, thinking indicators). Scrolling here
             // reliably reveals whatever just appeared last — anchoring to
@@ -871,6 +876,26 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
     if resultCardVisible, let outcome = viewModel.predictionOutcome {
       PredictionOutcomeBadge(isHit: outcome.isHit, streak: outcome.streak)
         .transition(.opacity)
+    }
+  }
+
+  /// The automatic share-highlight candidate list (#1070 Stage 2), shown with
+  /// the result card at completion. `HighlightCandidatesSection` self-guards on
+  /// an empty list; `resultCardVisible` keeps it hidden mid-run even as
+  /// contradiction candidates accumulate. Each tap reuses `shareHighlight` — the
+  /// same path as the per-row context menu — so no new share plumbing.
+  @ViewBuilder
+  private func highlightCandidatesSection(viewModel: SimulationViewModel) -> some View {
+    if resultCardVisible {
+      HighlightCandidatesSection(
+        candidates: viewModel.highlightCandidates,
+        onShare: { candidate in
+          shareHighlight(
+            agent: candidate.agent, output: candidate.output,
+            phaseType: candidate.phaseType)
+        }
+      )
+      .transition(.opacity)
     }
   }
 

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -669,8 +669,18 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
           // The no-drift completion path appends no logEntry (the count-driven
           // scroll above never fires), so drive the closing card's animated
           // reveal + a scroll here (#868).
-          withAnimation(.easeOut(duration: 0.35)) { resultCardVisible = done }
-          if done { scrollToBottom(proxy) }
+          //
+          // Scroll in the animation-completion closure, NOT synchronously: the
+          // result card, prediction badge, and share-highlight section (#1070
+          // Stage 2) all mount the instant `resultCardVisible` flips, so an
+          // immediate `scrollToBottom` runs before they lay out and stops at
+          // the result card — leaving the section below the fold (device-QA
+          // #1108). Scrolling once the reveal settles lands on the true bottom.
+          withAnimation(.easeOut(duration: 0.35)) {
+            resultCardVisible = done
+          } completion: {
+            if done { scrollToBottom(proxy) }
+          }
         }
         .onAppear {
           // Mounting onto an already-completed run (no isCompleted transition

--- a/Pastura/PasturaTests/App/HighlightCandidateLogicTests.swift
+++ b/Pastura/PasturaTests/App/HighlightCandidateLogicTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+/// Unit coverage for the pure share-highlight candidate selection logic
+/// (#1070 Stage 2).
+///
+/// The two zero-inference signals (contradiction badges #916, prediction
+/// reveal #915) and their de-dup / cap / ordering interaction are pinned
+/// here; the ViewModel owns only the transcript→descriptor projection and
+/// card construction, which this suite deliberately does not exercise
+/// (ADR-009 / `.claude/rules/view-testing.md`).
+///
+/// `@MainActor` on the suite is the swift-isolation Pattern-5 fix: the
+/// `Selection`/`Entry` auto-synth `Equatable` *lookup* is released for the
+/// nonisolated logic, and a MainActor suite can still call it.
+@Suite(.timeLimit(.minutes(1)))
+@MainActor
+struct HighlightCandidateLogicTests {
+
+  // MARK: Helpers
+
+  private func entry(
+    _ agent: String,
+    _ phaseType: PhaseType = .speakAll,
+    contradiction: Bool = false,
+    id: UUID = UUID()
+  ) -> HighlightCandidateLogic.Entry {
+    HighlightCandidateLogic.Entry(
+      id: id, agent: agent, phaseType: phaseType, isContradiction: contradiction)
+  }
+
+  // MARK: Contradiction signal
+
+  @Test func contradictionEntriesBecomeCandidatesInOrder() {
+    let aliceCon = entry("Alice", contradiction: true)
+    let bobCon = entry("Bob", .speakEach, contradiction: true)
+    let carolPlain = entry("Carol")
+    let result = HighlightCandidateLogic.candidates(
+      entries: [aliceCon, carolPlain, bobCon], actualAgent: nil)
+    #expect(
+      result == [
+        .init(id: aliceCon.id, reason: .contradiction),
+        .init(id: bobCon.id, reason: .contradiction)
+      ])
+  }
+
+  @Test func noSignalsYieldsEmpty() {
+    let result = HighlightCandidateLogic.candidates(
+      entries: [entry("Alice"), entry("Bob")], actualAgent: nil)
+    #expect(result.isEmpty)
+  }
+
+  // MARK: Reveal signal
+
+  @Test func revealPicksActualAgentLastSpeakEntry() {
+    let first = entry("Wolf")
+    let vote = entry("Wolf", .vote)
+    let last = entry("Wolf")
+    let result = HighlightCandidateLogic.candidates(
+      entries: [first, vote, last], actualAgent: "Wolf")
+    // The reveal is the *last* speak-phase entry, not the vote and not the first.
+    #expect(result == [.init(id: last.id, reason: .revealed)])
+  }
+
+  @Test func revealSkippedWhenActualAgentNeverSpoke() {
+    // The actual agent only ever voted — no speak-phase utterance to quote.
+    let result = HighlightCandidateLogic.candidates(
+      entries: [entry("Wolf", .vote), entry("Alice")], actualAgent: "Wolf")
+    #expect(result.isEmpty)
+  }
+
+  @Test func revealSkippedWhenNoPredictionScored() {
+    let result = HighlightCandidateLogic.candidates(
+      entries: [entry("Alice"), entry("Bob")], actualAgent: nil)
+    #expect(result.isEmpty)
+  }
+
+  // MARK: De-dup (contradiction wins)
+
+  @Test func revealEntryThatIsAlsoContradictionAppearsOnceAsContradiction() {
+    let wolf = entry("Wolf", contradiction: true)
+    let result = HighlightCandidateLogic.candidates(
+      entries: [wolf], actualAgent: "Wolf")
+    #expect(result == [.init(id: wolf.id, reason: .contradiction)])
+  }
+
+  @Test func contradictionAndRevealOnDistinctEntriesBothSurface() {
+    let liar = entry("Bob", contradiction: true)
+    let wolfSpeak = entry("Wolf")
+    let result = HighlightCandidateLogic.candidates(
+      entries: [liar, wolfSpeak], actualAgent: "Wolf")
+    #expect(
+      result == [
+        .init(id: liar.id, reason: .contradiction),
+        .init(id: wolfSpeak.id, reason: .revealed)
+      ])
+  }
+
+  // MARK: Cap + ordering
+
+  @Test func capLimitsCountAndEvictsRevealWhenFull() {
+    let conA = entry("A", contradiction: true)
+    let conB = entry("B", contradiction: true)
+    let conC = entry("C", contradiction: true)
+    let wolfSpeak = entry("Wolf")  // chronologically last → evicted at cap 3
+    let result = HighlightCandidateLogic.candidates(
+      entries: [conA, conB, conC, wolfSpeak], actualAgent: "Wolf", limit: 3)
+    #expect(
+      result == [
+        .init(id: conA.id, reason: .contradiction),
+        .init(id: conB.id, reason: .contradiction),
+        .init(id: conC.id, reason: .contradiction)
+      ])
+  }
+
+  @Test func candidatesStayInTranscriptOrder() {
+    let earlyCon = entry("A", contradiction: true)
+    let wolfSpeak = entry("Wolf")  // appears before the later contradiction
+    let lateCon = entry("B", contradiction: true)
+    let result = HighlightCandidateLogic.candidates(
+      entries: [earlyCon, wolfSpeak, lateCon], actualAgent: "Wolf")
+    #expect(result.map(\.id) == [earlyCon.id, wolfSpeak.id, lateCon.id])
+    #expect(result.map(\.reason) == [.contradiction, .revealed, .contradiction])
+  }
+}

--- a/Pastura/PasturaTests/App/SimulationViewModelHighlightsTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelHighlightsTests.swift
@@ -1,0 +1,131 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+/// Integration coverage for `SimulationViewModel.highlightCandidates` (#1070
+/// Stage 2) — the transcript→candidate projection that feeds the end-of-run
+/// "Share a highlight" section. The pure selection rule is covered by
+/// `HighlightCandidateLogicTests`; these pin the VM wiring: a 🃏 badge
+/// becomes a candidate carrying the filtered output, and the non-empty
+/// primary pre-filter (dead-tap guard) excludes an empty declaration.
+///
+/// The `.revealed` path (prediction ground truth) is not driven here: it
+/// requires toggling the shared `FeatureFlags` UserDefaults key, which would
+/// race a parallel suite (`.claude/rules/testing.md`). It is covered by
+/// `HighlightCandidateLogicTests` (selection) + `SimulationViewModelPrediction
+/// Tests` (`actualAgent` is carried on `PredictionOutcome`); the VM property
+/// only forwards `predictionOutcome?.actualAgent` to the logic.
+@Suite(.serialized, .timeLimit(.minutes(1))) @MainActor
+struct SimulationViewModelHighlightsTests {
+
+  private func makeSut() throws -> SimulationViewModel {
+    let db = try DatabaseManager.inMemory()
+    let writer = db.dbWriter
+    let scenarioRepo = GRDBScenarioRepository(dbWriter: writer)
+    let simRepo = GRDBSimulationRepository(dbWriter: writer)
+    try scenarioRepo.save(
+      ScenarioRecord(
+        id: "s1", name: "PD", yamlDefinition: "y",
+        isPreset: false, createdAt: Date(), updatedAt: Date()))
+    try simRepo.save(
+      SimulationRecord(
+        id: "sim1", scenarioId: "s1", status: "running",
+        currentRound: 1, currentPhaseIndex: 0, stateJSON: "{}", configJSON: nil,
+        createdAt: Date(), updatedAt: Date()))
+    let sut = SimulationViewModel(
+      simulationRepository: simRepo,
+      turnRepository: GRDBTurnRepository(dbWriter: writer),
+      codePhaseEventRepository: GRDBCodePhaseEventRepository(dbWriter: writer))
+    sut.beginPersistenceForTest(simulationId: "sim1")
+    return sut
+  }
+
+  private let phases = [
+    Phase(type: .speakAll),
+    Phase(type: .choose, options: ["cooperate", "betray"], pairing: .roundRobin)
+  ]
+
+  private func makeScenario() -> Scenario {
+    makeTestScenario(agentNames: ["Alice", "Bob"], rounds: 1, phases: phases)
+  }
+
+  private func declaration(
+    _ agent: String, _ intent: String, statement: String = "Let's all be friends."
+  ) -> SimulationEvent {
+    .agentOutput(
+      agent: agent,
+      output: TurnOutput(fields: [
+        "statement": statement,
+        "declared_intent": intent,
+        "inner_thought": "…"
+      ]),
+      phaseType: .speakAll)
+  }
+
+  private func chooseAction(_ agent: String, _ action: String) -> SimulationEvent {
+    .agentOutput(
+      agent: agent,
+      output: TurnOutput(fields: ["action": action, "inner_thought": "…"]),
+      phaseType: .choose)
+  }
+
+  private let choosePhaseCompleted = SimulationEvent.phaseCompleted(
+    phaseType: .choose, phasePath: [1])
+
+  /// Drives Alice into a full declaration/action contradiction; Bob stays
+  /// consistent. `statement` lets a caller blank Alice's public statement.
+  private func runAliceContradiction(
+    _ sut: SimulationViewModel, scenario: Scenario, aliceStatement: String
+  ) {
+    sut.handleEvent(.roundStarted(round: 1, totalRounds: 1), scenario: scenario)
+    sut.handleEvent(
+      declaration("Alice", "cooperate", statement: aliceStatement), scenario: scenario)
+    sut.handleEvent(declaration("Bob", "cooperate"), scenario: scenario)
+    sut.handleEvent(chooseAction("Alice", "betray"), scenario: scenario)
+    sut.handleEvent(chooseAction("Bob", "cooperate"), scenario: scenario)
+    sut.handleEvent(chooseAction("Alice", "betray"), scenario: scenario)
+    sut.handleEvent(chooseAction("Bob", "cooperate"), scenario: scenario)
+    sut.handleEvent(choosePhaseCompleted, scenario: scenario)
+  }
+
+  @Test func contradictionBadgeBecomesCandidateCarryingOutput() throws {
+    let sut = try makeSut()
+    let scenario = makeScenario()
+    runAliceContradiction(sut, scenario: scenario, aliceStatement: "Trust me, I'm loyal.")
+
+    let candidates = sut.highlightCandidates
+    #expect(candidates.count == 1)
+    let candidate = try #require(candidates.first)
+    #expect(candidate.agent == "Alice")
+    #expect(candidate.reason == .contradiction)
+    #expect(candidate.previewText == "Trust me, I'm loyal.")
+    // The candidate id is the badged declaration row's id.
+    #expect(sut.contradictionBadgedEntryIDs.contains(candidate.id))
+  }
+
+  @Test func emptyPrimaryDeclarationIsFilteredEvenWhenBadged() throws {
+    // Dead-tap guard: a badged row with no public statement must not surface —
+    // `HighlightShareCard.Model`'s failable init would reject it on tap.
+    let sut = try makeSut()
+    let scenario = makeScenario()
+    runAliceContradiction(sut, scenario: scenario, aliceStatement: "")
+
+    #expect(sut.contradictionBadgedEntryIDs.count == 1)  // still badged…
+    #expect(sut.highlightCandidates.isEmpty)  // …but not a candidate
+  }
+
+  @Test func noSignalsYieldsNoCandidates() throws {
+    let sut = try makeSut()
+    let scenario = makeScenario()
+    sut.handleEvent(.roundStarted(round: 1, totalRounds: 1), scenario: scenario)
+    sut.handleEvent(declaration("Alice", "cooperate"), scenario: scenario)
+    sut.handleEvent(declaration("Bob", "cooperate"), scenario: scenario)
+    // Consistent actions — no contradiction, no prediction scored.
+    sut.handleEvent(chooseAction("Alice", "cooperate"), scenario: scenario)
+    sut.handleEvent(chooseAction("Bob", "cooperate"), scenario: scenario)
+    sut.handleEvent(choosePhaseCompleted, scenario: scenario)
+
+    #expect(sut.highlightCandidates.isEmpty)
+  }
+}

--- a/Pastura/PasturaTests/App/SimulationViewModelPredictionTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelPredictionTests.swift
@@ -116,6 +116,8 @@ struct SimulationViewModelPredictionTests {
     // The end-of-run reward surface (#915) reflects the same result + streak.
     #expect(env.sut.predictionOutcome?.isHit == true)
     #expect(env.sut.predictionOutcome?.streak == 1)
+    // The revealed ground truth is carried for the #1070 Stage 2 reveal candidate.
+    #expect(env.sut.predictionOutcome?.actualAgent == "Eve")
   }
 
   @Test func sharedAssignmentDoesNotPolluteWolfGroundTruth() async throws {
@@ -153,6 +155,8 @@ struct SimulationViewModelPredictionTests {
     #expect(record?.predictedAgent == "Alice")
     #expect(record?.actualAgent == "Eve")
     #expect(env.sut.predictionOutcome?.isHit == false)
+    // Reveal ground truth is carried even on a miss (#1070 Stage 2).
+    #expect(env.sut.predictionOutcome?.actualAgent == "Eve")
   }
 
   @Test func topVoteScoresAgainstTallyLeader() async throws {


### PR DESCRIPTION
## Summary

Stage 2 of #1070 — the **automatic** side of the highlight-share feature (Stage 1 manual selection shipped in #1078).

At simulation end, a **"Share a highlight"** section appears below the result card + prediction badge, offering the run's notable moments as one-tap share cards. Candidates come from two zero-inference, in-memory signals:

- 🃏 **Contradiction** (#916): each `declared_intent`-vs-action contradiction badge.
- 🎯 **Revealed** (#915): the viewer-prediction ground-truth agent (wolf / top vote-getter) — surfaced on hit *or* miss, since the reveal itself is the shareable moment.

De-dup by entry id (contradiction wins), transcript order, cap 3. Tapping a candidate reuses the existing `shareHighlight` path → the #1096 custom share sheet — **no new share plumbing**. Engine diff is zero; all work is in `App/` + `Views/`.

Heuristic #3 (vote / `event_inject` reactions) from the issue body is **out of scope** here — deferred to a separate issue (no clean reaction-grouping signal exists yet).

## Changes

- `App/HighlightCandidateLogic.swift` — nonisolated pure selection logic + `HighlightReason`; unit-tested off-main.
- `App/HighlightCandidate.swift` — candidate model carrying the filtered `TurnOutput` for the card tap.
- `App/SimulationViewModel.swift` — `highlightCandidates` derived property (pre-filters to non-empty `primaryText` → dead-tap guard) + `actualAgent` added to `PredictionOutcome`.
- `Views/Simulation/HighlightCandidatesSection.swift` — the section view (avatar + name + reason chip + excerpt + share glyph), per the visually-approved mockup.
- `Views/Simulation/SimulationView.swift` — wire the section into the post-completion stack (`resultCardVisible`-gated).
- `Localizable.xcstrings` — 5 new keys with ja fills.

## Test plan

- `HighlightCandidateLogicTests` (9) — selection: contradiction ordering, reveal picks last speak, never-spoke nil path, de-dup, cap/eviction, transcript order.
- `SimulationViewModelHighlightsTests` (3) — VM projection: badge→candidate, empty-primary filter (dead-tap guard), no-signal empty.
- `SimulationViewModelPredictionTests` — `actualAgent` asserted on hit + miss.
- Full unit suite: **3019 tests / 250 suites green**; `swiftlint --strict` clean; localization coverage OK (662 keys).

## Device QA

Real-device required (the section renders only at completion and the iOS-26 render surface / share sheet aren't exercised by the simulator-only build or unit tests):

1. Run a **word_wolf** scenario to completion with a viewer prediction answered → confirm the 🎯 reveal candidate appears and its card shares.
2. Run **prisoners_dilemma** to a contradiction → confirm the 🃏 candidate appears; tap → the share sheet opens with the right utterance.
3. Verify section layout in **light + dark** and **ja + en** (no clipping; chip colors legible).
4. Confirm no AttributeGraph crash on the completion screen (iOS 26 — per `.claude/rules/swiftui-traps.md`), and that the section stays hidden mid-run.

Closes #1070

🤖 Generated with [Claude Code](https://claude.com/claude-code)