### PR TITLE
✨ feat: round-progress + endgame rule in prisoners_dilemma (#964)

### DIFF
--- a/Pastura/Pastura/Resources/DemoReplays/prisoners_dilemma_demo.yaml
+++ b/Pastura/Pastura/Resources/DemoReplays/prisoners_dilemma_demo.yaml
@@ -19,7 +19,7 @@ schema_version: 1
 preset_ref:
   id: prisoners_dilemma
   version: '1.0'
-  yaml_sha256: eb2aa0fac995d9fdec095a81e32276d118e75648c8ba8807074550889a601d6b
+  yaml_sha256: '0287b3d802fd26784fe20acf732382d3c76ac2fff04e83321b214e084188badf'
 metadata:
   title: 囚人のジレンマ
   description: 5人のプレイヤーが「協力」か「裏切り」を選ぶ戦略ゲーム。 隣接ペアで総当たり対戦し、得点を競う。宣言でブラフも、 密談で同盟や裏切りの相談も可能。

--- a/Pastura/Pastura/Resources/DemoReplays/prisoners_dilemma_en_demo.yaml
+++ b/Pastura/Pastura/Resources/DemoReplays/prisoners_dilemma_en_demo.yaml
@@ -19,7 +19,7 @@ schema_version: 1
 preset_ref:
   id: prisoners_dilemma_en
   version: '1.0'
-  yaml_sha256: 9578ccc392ce3315e97d182c37415e950bcfaddddbf023f4287308d936233266
+  yaml_sha256: '2f07437090cce61c1e2ed6a45978f439917785c9321cad65d638e2e7a4ecfddc'
 metadata:
   title: Prisoner's Dilemma
   description: Five players choose "cooperate" or "betray" in a strategic game. Round-robin pairwise matches with score accumulation. Bluff in the open, and scheme alliances or betrayals in private whispers.

--- a/Pastura/Pastura/Resources/Presets/prisoners_dilemma.yaml
+++ b/Pastura/Pastura/Resources/Presets/prisoners_dilemma.yaml
@@ -6,12 +6,17 @@ description: >
   隣接ペアで総当たり対戦し、得点を競う。宣言でブラフも、
   密談で同盟や裏切りの相談も可能。
 agents: 5
+# 総ラウンド数。プロンプト内の「/ 2」「全2ラウンド」直書きと結合している
+# （{total_rounds} はプロンプト用プレースホルダ未登録・条件式専用のため）。
+# ここを変えるときは speak_all / whisper / choose / context の直書きも要更新。
 rounds: 2
 context: >
   あなたはゲーム番組「囚人のジレンマ」の出場者です。
   対戦相手と「協力(cooperate)」か「裏切り(betray)」を選びます。
   両方協力=各3点 / 自分だけ裏切り=5点(相手は0点) / 両方裏切り=各1点。
   対戦前に全員に向けて宣言できます（嘘やハッタリもOK）。
+  ゲームは全2ラウンド。得点は最終ラウンド終了時に確定します。
+  最終ラウンドの選択には、あとに続くラウンドがないため報復の機会がありません。
   あなたの性格に合った判断をしてください。
 
 personas:
@@ -44,6 +49,8 @@ personas:
 phases:
   - type: speak_all
     prompt: >
+      現在のラウンド: {current_round} / 2
+
       現在のスコア: {scoreboard}
 
       これまでの対戦履歴:
@@ -61,6 +68,8 @@ phases:
 
   - type: whisper
     prompt: >
+      現在のラウンド: {current_round} / 2
+
       現在のスコア: {scoreboard}
 
       これまでの宣言:
@@ -78,6 +87,8 @@ phases:
 
   - type: choose
     prompt: >
+      現在のラウンド: {current_round} / 2
+
       現在のスコア: {scoreboard}
       対戦相手: {opponent_name}
 

--- a/Pastura/Pastura/Resources/Presets/prisoners_dilemma_en.yaml
+++ b/Pastura/Pastura/Resources/Presets/prisoners_dilemma_en.yaml
@@ -17,6 +17,10 @@ description: >
   Round-robin pairwise matches with score accumulation. Bluff in the
   open, and scheme alliances or betrayals in private whispers.
 agents: 5
+# Total round count. Coupled to the literal "/ 2" and "all 2 rounds" in the
+# speak_all / whisper / choose / context text ({total_rounds} is not a
+# registered prompt placeholder — it is condition-only). Update those literals
+# whenever this value changes.
 rounds: 2
 context: >
   You are a contestant on the game show "Prisoner's Dilemma".
@@ -24,6 +28,9 @@ context: >
   Both cooperate = each gets 3 points. You alone betray = 5 points,
   opponent 0. Both betray = each gets 1 point.
   Before matches you address everyone (bluffing and feints welcome).
+  The game runs for all 2 rounds. Scores are locked in at the end of the
+  final round, and choices made in the final round cannot be retaliated
+  against — there is no round after it.
   Play in line with your personality.
 
 personas:
@@ -58,6 +65,8 @@ personas:
 phases:
   - type: speak_all
     prompt: >
+      Current round: {current_round} / 2
+
       Current score: {scoreboard}
 
       Match history so far:
@@ -76,6 +85,8 @@ phases:
 
   - type: whisper
     prompt: >
+      Current round: {current_round} / 2
+
       Current score: {scoreboard}
 
       Declarations so far:
@@ -95,6 +106,8 @@ phases:
 
   - type: choose
     prompt: >
+      Current round: {current_round} / 2
+
       Current score: {scoreboard}
       Opponent: {opponent_name}
 


### PR DESCRIPTION
## Summary

Harness-validated round-progress injection for the two Prisoner's Dilemma bundled presets (ja/en). Applies the "v3" design:

- **Uniform `{current_round}` injection** — `現在のラウンド: {current_round} / 2` (EN: `Current round: {current_round} / 2`) prepended to the **speak_all, whisper, AND choose** prompts (not just some phases).
- **Explicit endgame rule in `context:`** — states the game is 2 rounds, scores lock at the final round, and final-round choices cannot be retaliated against.
- **Coupling comment** above `rounds: 2` documenting that the literal `/ 2` / `全2ラウンド` is hand-coupled to the rounds value (`{total_rounds}` is condition-only, not a prompt placeholder).
- `rounds: 2` kept; canonical `id:` kept. No Swift code changed.

**Why:** the shipped prompts carried no round signal at all, so agents reasoned as if perpetually early-game (surfaced in #958) — endgame play was structurally impossible.

## Validation (foreground pastura-harness A/B — not agent-ready; done in-session)

13 real local-LLM runs (Gemma 4 E2B Q4_K_M), all `status=ok`, parse/enum health clean, 38 inferences/run:

- **whisper stale-round artifact eliminated: 0 across all v3 runs.** A speak/choose-only injection variant produced up to 12 stale "round 1…" citations in a single run (agents anchored on a round number in the un-injected whisper); uniform injection fixes this.
- **en:** consistent persona-appropriate final-round defection **3/3** (trickster/aggressive archetypes defect, cooperative ones don't) — vs base's erratic 0–30%.
- **ja:** 2/4 clean persona-divergent endgames; **1/4 collapses to full cooperation** — a Gemma 4 E2B ceiling (it reads "final round" as "wrap up harmoniously" even when told there's no retaliation), not preset-fixable.
- Two independent Fable second opinions returned **Go**.

## Known deferred (non-blocking, v4 follow-up)

Ships **exactly as measured**. The ja endgame sentence occasionally leaks into round-1 reasoning, and the "得点は…確定します" line is an echo source — refining the wording now would invalidate the measured evidence, so it is deferred to a separate v4 wording-refinement A/B cycle. Follow-up issue linked below.

## Test plan

- `PresetLoaderTests`, `BundledPresetPlaceholderCoverageTests`, `BundledPresetSourceIdSchemaTests` — 13 tests green (incl. `presetYAMLsAreParseable`, `presetYAMLsPassValidateForCommit`).
- `code-reviewer` (Opus): PASS, 0 issues (ja/en parity, no new token, coupling literal accuracy, YAML validity, canonical ids all verified).

## Device QA

実機QA不要 — preset data change only, no simulator-excluded surface (`#if !targetEnvironment(simulator)` / Metal / llama.cpp untouched). The behavioral effect was validated on pastura-harness, which reuses the same Engine `SimulationRunner`. Reaches users only on the next TestFlight/App Store build (preset change → also needs a future `/release`).

Closes #964