### PR TITLE
📝 docs: subtract-direction scenario design guidelines (#919)

### DIFF
--- a/.claude/rules/presets.md
+++ b/.claude/rules/presets.md
@@ -51,3 +51,28 @@ Current inventory (each has an `_en` sibling — see i18n below):
   must read as a complete self-framing statement (e.g. `やらかし「…」`,
   `Your blunder: …`, `お悩み:「…」`, `Problem: …`) — a bare noun would render
   contextless.
+
+## Scenario design defaults — bias toward "subtract" (#919)
+
+Default a new scenario to the SMALLER shape; each addition trades against 2B
+breakdown rate, tokens, and on-device latency, so additions need a stated
+reason. These are **defaults for NEW scenarios** — the shipped presets (4 of 5
+run 5 agents) predate the guideline, not violations of it. Guides with a
+reason-for-deviation, not hard rules. (The interestingness proposals in #906
+bias toward *adding* fields/phases — this section is the brake.)
+
+- **Output fields: 2 (`statement` + `inner_thought`).** Each extra output field
+  is another grammar-constrained value per turn — more JSON-parse-failure
+  exposure, tokens, and wait. Add a third only with a reason (canonical field
+  names in Conventions above / `ScenarioConventions`).
+- **Agents: 3–4.** Five agents × several rounds is a long on-device wait
+  (inference target ≤50 — scenario-factory SKILL Step 2); a triangle also reads
+  clearer than a pentagon (general drama-design rule). An axis that genuinely
+  needs more (elimination bracket) is a reasoned exception.
+- **Log growth: design for 2B long-context decay.** Long transcripts degrade the
+  model — cap rounds, or scope prompt visibility with `log_window: N` (#907);
+  don't assume a clean full log in a long run.
+- **Scoring is optional.** Not every scenario must end as a game-show tally. Drop
+  the `vote → score_calc → summarize` spine when the payoff is the phenomenon
+  itself — `scoring_free` observation and a `narrate` (#909) score-free ending
+  are first-class.

--- a/.claude/skills/scenario-factory/PLAYBOOK.md
+++ b/.claude/skills/scenario-factory/PLAYBOOK.md
@@ -20,6 +20,10 @@ Discipline (this header is the contract):
   `/orchestrate` PR (SKILL.md § Lessons promotion) — the nightly cycle never
   edits this file.
 
+**Subtract by default (#919):** smaller shape wins (fewer fields / agents /
+rounds; scoring optional) unless the axis needs it — full guidelines in
+`.claude/rules/presets.md` § "Scenario design defaults".
+
 ## Language & breakdown (Gemma 4 E2B)
 
 1. **[validated]** Low-content speech (agreeable filler, pressured accusation)
@@ -151,5 +155,4 @@ characterized — new instances need a new mechanic angle, not a topic skin:
   anthropomorphic-grievance venting (kaden_rousai, moto_akuyaku).
 - Rumor distortion (dengon) — parallel panel works; chain decay = rules 23/24.
 
-`whisper` and `log_window` now carry first HYPOTHESES (rules 20 / 24);
-`reflect` still has none. Field results land here via the lessons-inbox.
+New field/mechanic results land here via the lessons-inbox.

--- a/.claude/skills/scenario-factory/SKILL.md
+++ b/.claude/skills/scenario-factory/SKILL.md
@@ -143,6 +143,15 @@ non-comedy scenario is judged on its own terms — see Step 4. Each of the 3
 must differ from the other 2 AND from digest history in premise or
 mechanics, not merely in topic strings.
 
+**Design defaults — subtract by default (#919):** author the SMALLER shape
+unless the assigned axis needs more. Concretely: **2 output fields**
+(`statement` + `inner_thought`), **3–4 agents**, and **no mandatory scoring**
+(a `narrate` score-free ending or `scoring_free` observation is fine — drop
+`vote → score_calc → summarize` when the payoff is the phenomenon). Each
+addition trades against 2B breakdown rate, tokens, and latency — justify it.
+Canonical guidelines (the numbers live here): `.claude/rules/presets.md`
+§ "Scenario design defaults".
+
 Schema requirements (ScenarioLoader — all required):
 
 - `id`, `name`, `description`, `language: ja`, `agents`, `rounds`,


### PR DESCRIPTION
## Summary
Documents the "subtract-direction" scenario-authoring guidelines (#919, part of the #906 interestingness umbrella) — a brake on the add-bias of the interestingness proposals.

- **`.claude/rules/presets.md`** (canonical): new "Scenario design defaults — bias toward subtract" section. Four concept-level guides (guide + reason-for-deviation, not hard rules):
  1. Output fields default to 2 (`statement` + `inner_thought`)
  2. Agents default to 3–4
  3. Design for 2B long-context log decay (`log_window: N`, cap rounds)
  4. Scoring is optional (`narrate` / `scoring_free` are first-class endings)
- **`scenario-factory/SKILL.md`** Step 2: reflects the defaults at the factory generation gate — leads "smaller shape" qualitatively, keeps the brake numbers, points to presets.md as canonical.
- **`scenario-factory/PLAYBOOK.md`**: one-line pointer so the scenario-refine cycle (reads PLAYBOOK, not the factory SKILL) also gets the brake.

## Design notes / disclosed trade-offs
- **Placement rationale**: `presets.md` is path-scoped to `Resources/**`, so it loads on bundled-preset editing/promotion but NOT during the factory/refine cycles (they write outside `Resources/**`). Hence the SKILL Step 2 + PLAYBOOK reflections — those are the paths the generation cycles actually read.
- **Manual-sync pair**: the numbers `2` / `3–4` appear in both `presets.md` (canonical) and `SKILL.md` (inline brake). No CI gate guards the pair; a future defaults change must update both. Framed with `presets.md` as the explicit canonical to minimize drift.
- **PLAYBOOK soft-cap**: the file ticks 155 → 158 against its ~150-line soft cap. Partially offset by trimming a low-signal closing meta clause; the net +3 is a disclosed trade-off to close the refine reach gap (a pointer, not the full guidelines).

## Review
- Pre-impl `critic` (Opus): no Critical; two Warnings (drift / refine-reach) addressed by the design notes above.
- `code-reviewer` (Opus): **PASS**, 0 issues requiring a fix; all factual claims (phase names, `#907`/`#909`, agent counts, cross-refs) verified against code.

## Test plan
Documentation/tooling-only — no Swift touched. Verified via review + factual spot-checks. The factory reflection's effect is verified by the next `/scenario-factory` cycle (generated batch should honor the defaults), per the issue's verification method.

## Device QA
実機QA不要 — documentation/tooling-only change (`.claude/rules/`, `.claude/skills/`); no app surface.

Closes #919
