### PR TITLE
📝 docs: promote two memory lessons (vote-elim ban + ASAA law watch)

### DIFF
--- a/.claude/skills/scenario-factory/PLAYBOOK.md
+++ b/.claude/skills/scenario-factory/PLAYBOOK.md
@@ -136,6 +136,17 @@ rounds; scoring optional) unless the axis needs it — full guidelines in
 29. **[validated]** Keep one comedy scenario per batch so the night retains a
     `(d) humor` datapoint (null categories don't score it). (since 06-27)
 
+## Votes & prohibition-following
+
+30. **[validated]** In vote-ELIMINATION scenarios where some personas WANT to
+    be chosen, self-voting is their rational move and `exclude_self` discards
+    it SILENTLY — one night was decided by a single valid vote. Fix with an
+    **in-world rule** ("本は自薦を認めない / the book accepts no self-nomination")
+    in BOTH context and the vote prompt, not a bare mechanical instruction.
+    ja Gemma follows such prohibitions markedly worse than en (field-measured
+    E2B: en invalid votes 5/12→2/12, ja only 6/12→5/12) — judge ja/en
+    separately. (07-08 last_fable / #1003)
+
 ## Saturated premise families (dedup: do not regenerate as-is)
 
 Id-level history lives in `digest-index.jsonl`; these FAMILIES are already

--- a/docs/security/release-checklist.md
+++ b/docs/security/release-checklist.md
@@ -201,6 +201,31 @@ gh api repos/tyabu12/pastura/secret-scanning/alerts \
 Should return an empty array. Investigate any non-empty result the same
 day.
 
+### 3.4 Minor-safety / age-assurance legislation watch
+
+State App Store Accountability Acts (ASAAs) impose age verification and
+parental-consent duties. These are **marketplace-side** obligations — Apple
+and Google verify age at account creation and expose only an age *bracket* to
+developers via Apple's Declared Age Range API (under 13 / 13–15 / 16–17 /
+18+) — **not** App Review submission gates. No action is required to submit a
+build; track them because a live ASAA can change what a minor may download or
+purchase in that state, and a future Pastura feature may need the Declared Age
+Range API.
+
+Status as of 2026-07 (re-verify the current effective date before any
+public-release decision — every date below has already slipped once):
+
+| State | Law | Status |
+|-------|-----|--------|
+| Texas | SB 2420 | **Live** — effective 2026-06-04; SCOTUS declined to block (2026-07) |
+| Utah | ASAA | Effective 2027-05-07 (delayed from 2026-05-06) |
+| Louisiana | ASAA | Effective 2027-07-01 (delayed from 2026-07-01; HB 977 signed 2026-05-15) |
+| Alabama | ASAA | Effective 2027-01-01; existing-account verification by 2027-10-01 |
+
+At each public release, confirm whether Pastura's distribution footprint
+touches these states and whether any Declared Age Range integration is
+required.
+
 ---
 
 ## 4. Release execution (TestFlight)


### PR DESCRIPTION
## Summary

Memory → rules promotion round (`.claude/rules/knowledge-layering.md`). Two durable, non-derivable lessons from a prior session's triage move from per-user memory into repo-tracked files:

- **`.claude/skills/scenario-factory/PLAYBOOK.md`** — new item #30: in vote-**elimination** scenarios where personas *want* to be chosen, self-voting is rational and `exclude_self` discards it silently (one night decided by a single valid vote). The durable remedy is an **in-world self-nomination ban** in context + vote prompt — not a bare mechanical instruction — plus the field-measured ja/en divergence (en 5/12→2/12 vs ja 6/12→5/12; ja Gemma follows prohibitions worse). Appended as a new subsection (not mid-list) to avoid renumbering the internal `rule 12/21/23/24` cross-references.
- **`docs/security/release-checklist.md`** — new §3.4: a recurring-review watch list for state App Store Accountability Acts (TX SB 2420 live; UT/LA/AL). Framed as marketplace-side age-assurance obligations (Apple Declared Age Range API), **not** App Review submission gates.

**Not promoted:** the third triage candidate (Home/Browse inference-count provenance mismatch) — its premise was resolved by #748/#757 (GalleryCategory now persisted; Home rows show category, not the divergent numbers). Memory was corrected instead of promoted.

## Self-check

- **Legal facts WebSearch-verified 2026-07-16.** The memory snapshot was already stale: Louisiana **2026-07-01 → 2027-07-01** (HB 977, signed 2026-05-15) and Utah **2026-05-06 → 2027-05-07** were corrected. Texas SB 2420 confirmed live (effective 2026-06-04; SCOTUS declined to block 2026-07); Alabama 2027-01-01.
- PLAYBOOK insertion confirmed not to disturb the `rule 12/21/23/24` internal references.
- Neither file is mirrored to README/CONTRIBUTING — no parallel doc updates needed.

## Test plan

Docs-only; no code paths touched. Pre-commit correctly skipped SwiftLint + xcodebuild (build-irrelevant paths). No CI gate matches these files.

## Device QA

実機QA不要 — Markdown-only additions to a skill playbook and a security doc; no runtime surface.