### PR TITLE
📝 docs: scenario-format JA localization + Word Wolf example

### DIFF
--- a/web/src/content/scenario-format.en.md
+++ b/web/src/content/scenario-format.en.md
@@ -174,7 +174,9 @@ comparisons with `&&`, `||`, and parentheses.
 Comparison operators are `==`, `!=`, `<`, `<=`, `>`, `>=`. Variables you can
 reference include `current_round`, `total_rounds`, `max_score`, `min_score`,
 `eliminated_count`, `active_count`, `vote_winner`, and `scores.<Name>` for a
-named agent.
+named agent. Scoring logics can expose extra scenario-specific variables. For
+example, `wordwolf_judge` sets `wolf_name` to the agent holding the minority
+word, which the Word Wolf example below uses in its final `conditional`.
 
 **Quote string values with double quotes.** `name == "Alex"` compares against
 the text `Alex`. A single-quoted `'Alex'` is read as an undefined identifier, so

--- a/web/src/content/scenario-format.en.md
+++ b/web/src/content/scenario-format.en.md
@@ -133,8 +133,10 @@ Fields you can set on a phase, beyond `type`, `prompt`, and `output`:
 - `target` (for `assign`): `all` gives every agent the same value, `random_one`
   gives a single random agent the value (used for the odd-one-out in word-wolf
   style games).
-- `source` (for `assign`): the list of values to distribute. It must be
-  non-empty.
+- `source` (for `assign` and `event_inject`): the name of a top-level list key
+  holding the values to distribute or inject. You add that key yourself (for
+  example `words:` or `topics:`) alongside the required top-level keys, and it
+  must be non-empty.
 - `rounds` (for `speak_each` and `whisper`): how many sub-rounds of speaking
   happen within the phase.
 - `logic` (for `score_calc`): one of the scoring logics above.
@@ -198,42 +200,71 @@ blocking ones, but it is easier to get them right the first time.
 
 ## A complete example
 
-The Prisoner's Dilemma preset, with prompt text trimmed for brevity:
+The Word Wolf preset, with personas and prompt text trimmed for brevity:
 
 ```yaml
-id: prisoners_dilemma_en
+id: word_wolf_en
 language: en
-name: Prisoner's Dilemma
-description: Five contestants weigh cooperation against betrayal.
+name: Word Wolf
+description: Players discuss a topic word, but one holds a different word.
 agents: 5
-rounds: 3
+rounds: 1
 context: |
-  You are a contestant on the game show "Prisoner's Dilemma".
-  Against each opponent you choose to cooperate or betray.
-  Both cooperate scores 3 each. Betraying alone scores 5.
+  You are a contestant on the game show "Word Wolf".
+  Everyone has a topic word, but one player's word differs.
+  Never say the word itself. Describe concrete features that
+  evoke it, then vote to expose the minority.
+words:                          # custom top-level list, referenced by source
+  - majority: apple
+    minority: orange
+mid_game_announcements:
+  - "Host: Time is short. Narrow it down."
 personas:
-  - name: Alex
-    description: A calm strategist who computes the optimal move.
-  - name: Mia
-    description: An optimist who trusts people even after being burned.
+  - name: Avery
+    description: A calm observer who leads with colour and shape.
+  - name: Riley
+    description: An outgoing talker who describes taste and texture.
   # ...three more personas...
 phases:
-  - type: speak_all
-    prompt: Address the group before the round.
+  - type: assign                # give one player the minority word
+    source: words
+    target: random_one
+  - type: speak_each
+    prompt: Describe your topic without ever naming it.
     output:
       statement: string
       inner_thought: string
-  - type: choose
-    prompt: For each opponent, cooperate or betray.
-    options:
-      - cooperate
-      - betray
-    pairing: round_robin
+    rounds: 2
+  - type: reflect
+    prompt: Who seems suspicious? Update your private note.
     output:
-      action: string
-      inner_thought: string
+      note: string
+  - type: event_inject          # maybe interrupt with a show announcement
+    source: mid_game_announcements
+    probability: 0.5
+  - type: conditional
+    if: 'current_event != ""'
+    then:
+      - type: summarize
+        template: "{current_event}"
+  - type: narrate
+    narrator: an enthusiastic play-by-play commentator
+    prompt: Call out the most suspicious player and the decisive mismatch.
+    max_sentences: 3
+  - type: vote
+    prompt: Vote for the minority whose clues are out of step.
+    output:
+      vote: string
+      reason: string
+  - type: eliminate
   - type: score_calc
-    logic: prisoners_dilemma
-  - type: summarize
-    template: "Round {current_round}: {scoreboard}"
+    logic: wordwolf_judge
+  - type: conditional           # branch on whether the group caught the wolf
+    if: "vote_winner == wolf_name"
+    then:
+      - type: summarize
+        template: "Wolf found. {wolf_name} was the minority. The majority wins."
+    else:
+      - type: summarize
+        template: "Wolf escapes. The minority was {wolf_name}. The votes went elsewhere."
 ```

--- a/web/src/content/scenario-format.ja.md
+++ b/web/src/content/scenario-format.ja.md
@@ -176,7 +176,9 @@ phases:                       # 必須。何が起きるかを順に並べたリ
 比較演算子は `==`、`!=`、`<`、`<=`、`>`、`>=` です。参照できる変数には
 `current_round`、`total_rounds`、`max_score`、`min_score`、
 `eliminated_count`、`active_count`、`vote_winner`、特定のエージェントを
-指す `scores.<Name>` があります。
+指す `scores.<Name>` があります。スコアリングロジックはシナリオ固有の追加変数を
+公開することがあります。例えば `wordwolf_judge` は少数派の単語を持つエージェントを
+`wolf_name` に設定し、下のワードウルフの例は最後の `conditional` でこれを使います。
 
 **文字列値はダブルクォートで囲んでください。** `name == "Alex"` は
 テキスト `Alex` と比較します。シングルクォートの `'Alex'` は未定義の

--- a/web/src/content/scenario-format.ja.md
+++ b/web/src/content/scenario-format.ja.md
@@ -12,22 +12,22 @@
 ## トップレベル構造
 
 ```yaml
-id: unique_snake_case_id      # required. Stable identifier, snake_case
-language: en                  # required. Authoring language: `ja` or `en`
-name: My Scenario             # required. Display title
-description: One-line summary  # required
-agents: 5                     # required. Number of agents, 2 to 10
-rounds: 3                     # required. Number of rounds, 1 to 30
-context: |                    # required. Shared briefing every agent sees
-  You are contestants in a game...
-personas:                     # required. One entry per agent (length == agents)
-  - name: Alex
-    description: A calm strategist who plans several moves ahead.
-  - name: Mia
-    description: An optimist who trusts people by default.
-phases:                       # required. The ordered list of what happens
+id: unique_snake_case_id      # 必須。安定した識別子（snake_case）
+language: ja                  # 必須。記述言語: `ja` または `en`
+name: わたしのシナリオ          # 必須。表示タイトル
+description: 一行の概要          # 必須
+agents: 5                     # 必須。エージェント数（2〜10）
+rounds: 3                     # 必須。ラウンド数（1〜30）
+context: |                    # 必須。全エージェントが見る共有の状況説明
+  あなたたちはあるゲームの参加者です...
+personas:                     # 必須。エージェント1体につき1エントリ（数は agents と一致）
+  - name: ユウキ
+    description: 数手先まで読む冷静な戦略家。
+  - name: ミア
+    description: 基本的に人を信じる楽天家。
+phases:                       # 必須。何が起きるかを順に並べたリスト
   - type: speak_all
-    prompt: What do you say to the group?
+    prompt: グループに向けて何を話しますか？
     output:
       statement: string
       inner_thought: string
@@ -92,10 +92,10 @@ phases:                       # required. The ordered list of what happens
 
 ```yaml
 - type: vote
-  prompt: Who do you suspect, and why?
+  prompt: 誰を、なぜ疑いますか？
   output:
-    vote: string      # canonical primary for `vote`
-    reason: string    # canonical private-thought for `vote`
+    vote: string      # `vote` の正式な主フィールド
+    reason: string    # `vote` の正式な内心フィールド
 ```
 
 内心フィールドは表示専用です。他のエージェントには見えないため、モデルが
@@ -135,7 +135,9 @@ phases:                       # required. The ordered list of what happens
 - `target`（`assign` 用）: `all` は全エージェントに同じ値を与え、
   `random_one` はランダムに選んだ 1 人のエージェントだけに値を与えます
   （ワードウルフ形式のゲームで少数派を決めるのに使います）。
-- `source`（`assign` 用）: 配分する値のリスト。空にはできません。
+- `source`（`assign` と `event_inject` 用）: 配分または注入する値を保持する
+  トップレベルのリストキー名。そのキー（例: `words:` や `topics:`）を必須の
+  トップレベルキーと並べて自分で追加します。空にはできません。
 - `rounds`（`speak_each` と `whisper` 用）: フェーズ内で何回の発話サブラウンドを
   行うか。
 - `logic`（`score_calc` 用）: 上記のスコアリングロジックのいずれか。
@@ -162,10 +164,10 @@ phases:                       # required. The ordered list of what happens
   if: current_round == total_rounds && max_score >= 10
   then:
     - type: summarize
-      template: "Final round. {vote_winner} is ahead."
+      template: "最終ラウンド。{vote_winner} がリードしています。"
   else:
     - type: speak_all
-      prompt: The game continues.
+      prompt: ゲームは続きます。
       output:
         statement: string
         inner_thought: string
@@ -203,43 +205,71 @@ phases:                       # required. The ordered list of what happens
 
 ## 完全な例
 
-Prisoner's Dilemma プリセットです。プロンプト文は簡潔さのために省略して
-あります。
+ワードウルフのプリセットです。ペルソナとプロンプト文は簡潔さのために省略しています。
 
 ```yaml
-id: prisoners_dilemma_en
-language: en
-name: Prisoner's Dilemma
-description: Five contestants weigh cooperation against betrayal.
+id: word_wolf
+language: ja
+name: ワードウルフ
+description: 全員にお題の単語が配られるが、1人だけ違う単語を持つ。少数派を会話から見抜く。
 agents: 5
-rounds: 3
+rounds: 1
 context: |
-  You are a contestant on the game show "Prisoner's Dilemma".
-  Against each opponent you choose to cooperate or betray.
-  Both cooperate scores 3 each. Betraying alone scores 5.
+  あなたはゲーム番組「ワードウルフ」の出場者です。
+  全員にお題の単語が配られていますが、1人だけ違う単語を持っています。
+  単語そのものは絶対に言わず、それを連想させる具体的な特徴を語ってください。
+  最後に投票で少数派（ウルフ）を当てます。
+words:                          # source から参照するカスタムなトップレベルリスト
+  - majority: りんご
+    minority: みかん
+mid_game_announcements:
+  - "📺 司会者: 残り時間わずか。的を絞っていきましょう。"
 personas:
-  - name: Alex
-    description: A calm strategist who computes the optimal move.
-  - name: Mia
-    description: An optimist who trusts people even after being burned.
-  # ...three more personas...
+  - name: ユウキ
+    description: 見た目や色から攻める冷静な観察者。
+  - name: サクラ
+    description: 味や食感を具体的に語る明るいおしゃべり。
+  # ...ほか3体のペルソナ...
 phases:
-  - type: speak_all
-    prompt: Address the group before the round.
+  - type: assign                # 1人だけに少数派の単語を配る
+    source: words
+    target: random_one
+  - type: speak_each
+    prompt: 単語そのものは言わずに、お題について話してください。
     output:
       statement: string
       inner_thought: string
-  - type: choose
-    prompt: For each opponent, cooperate or betray.
-    options:
-      - cooperate
-      - betray
-    pairing: round_robin
+    rounds: 2
+  - type: reflect
+    prompt: 誰が怪しいか、自分用のメモを更新してください。
     output:
-      action: string
-      inner_thought: string
+      note: string
+  - type: event_inject          # 番組アナウンスで途中に割り込むことがある
+    source: mid_game_announcements
+    probability: 0.5
+  - type: conditional
+    if: 'current_event != ""'
+    then:
+      - type: summarize
+        template: "{current_event}"
+  - type: narrate
+    narrator: 熱のこもった実況アナウンサー
+    prompt: 最も怪しい人物と決定的なズレを短く伝えてください。
+    max_sentences: 3
+  - type: vote
+    prompt: 特徴が他とズレている少数派（ウルフ）に投票してください。
+    output:
+      vote: string
+      reason: string
+  - type: eliminate
   - type: score_calc
-    logic: prisoners_dilemma
-  - type: summarize
-    template: "Round {current_round}: {scoreboard}"
+    logic: wordwolf_judge
+  - type: conditional           # 少数派を当てられたかで分岐する
+    if: "vote_winner == wolf_name"
+    then:
+      - type: summarize
+        template: "ウルフ発見。{wolf_name} が少数派でした。多数派の勝ちです。"
+    else:
+      - type: summarize
+        template: "ウルフ逃げ切り。少数派は {wolf_name} でしたが票は割れました。"
 ```


### PR DESCRIPTION
## Summary
- Localize every YAML snippet on the JA scenario-format reference (`web/src/content/scenario-format.ja.md`) to Japanese: comments, `context`, `prompt`, persona names/descriptions, `language: ja`. Keys, enum/type values, and canonical `output` field names (`statement`, `inner_thought`, `vote`, `reason`, `note`) stay ASCII per the page's own "field names must be ASCII" rule.
- Swap the "complete example" on **both** locales from Prisoner's Dilemma to a trimmed Word Wolf scenario (2 personas + `# ...three more...`, prompt bodies shortened). Word Wolf exercises a much richer phase set (`assign` target:random_one → `speak_each` → `reflect` → `event_inject` → `conditional` → `narrate` → `vote` → `eliminate` → `score_calc` wordwolf_judge → final `conditional`).
- Document the constructs the richer example needs so the "complete reference" stays honest: the `source:` top-level list-key pattern (for `assign` + `event_inject`), and the `wolf_name` scenario-specific condition variable.

## Why
The JA page was showing English scenario YAML (English comments, `Alex`/`Mia` personas, `language: en`) on a Japanese-language page. Prisoner's Dilemma was also the sole complete example; Word Wolf is the flagship scenario and shows far more of the DSL.

A pre-impl `critic` flagged that Word Wolf intrinsically needs `words:`/`source:`/`wolf_name` — constructs the page did not document — so rather than gut the example, the three small doc additions above land alongside. The trimmed example only uses documented constructs (canonical `statement`/`inner_thought` output; the dropped `clue`/`exclude_self` fields are omitted), and includes the `words:` + `mid_game_announcements:` top-level blocks so `assign`/`event_inject` `source:` resolve (else it would violate the page's own "assign needs non-empty source" pitfall).

## Test plan
- `python3 scripts/check-scenario-format-coverage.py --self-test` and `--check` — green (18 DSL tokens present in both locale specs; the swap removed no last-occurrence backtick token).
- `npm run check` (astro check: 0 errors) and `npm run build` (99 pages built) in `web/`.
- Verified no leftover English in the JA YAML snippets; ja/en complete examples structurally in sync (`agents: 5`, `rounds: 1`, identical phase list).
- Reviewed by `code-reviewer` (PASS, 0 critical / 0 warning); the `wolf_name` doc note is the applied suggestion.

## Device QA
実機QA不要 — docs/web-only markdown content change, no iOS surface touched.

Closes #1127
