### PR TITLE
📝 docs: promote memory lessons → rules (plan-time verify, register law, EN gen)

### DIFF
--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -74,6 +74,16 @@ When adding a `.claude/rules/` section (or `CLAUDE.md` content) that includes an
 
 Pre-impl critic and code-reviewer reviews have repeatedly missed this class: they evaluate the *content* of the rule but rarely run the *check* the rule itself prescribes. The writer is the only one who reliably can.
 
+The same "verify before you lock it" discipline extends past rule assertions to **any load-bearing claim a plan leans on**, checked **before plan-lock (Step 1b critic)**. `critic`'s axes are codebase-internal (dependency rules, phase scope, integration risk), so a claim that is *externally* false but internally plausible passes critic and surfaces only at code-review or in production — the plan author is the one positioned to check. Verify each against its authoritative source:
+
+| Claim a plan leans on | Verify by |
+|---|---|
+| A header/doc comment asserting cross-file structure ("defined in M", "consumable by Y") | grep the actual symbol/type — comments can be aspirational, not descriptive |
+| A `§"Heading"` cross-doc reference | grep the target for the exact heading **and read under it** to confirm the content matches; add a named heading if absent |
+| "band-aid / hack / dead code" framing of a change | grep ALL producers + consumers across layers (esp. Engine/runtime), not just the layer the issue scopes — the target may be load-bearing |
+| An external standard (SEO, RFC, sitemap/robots, OAuth, HTTP semantics) | WebSearch + WebFetch the authority (Google Search Central, the RFC, MDN); verbatim-cite before critic |
+| Vendor feature availability (free/paid/plan tier) | WebFetch the canonical docs; verbatim-quote the "Who can use this feature" box — never infer from search snippets |
+
 ### Apply
 
 For each load-bearing assertion in the draft:

--- a/.claude/rules/presets.md
+++ b/.claude/rules/presets.md
@@ -76,3 +76,21 @@ bias toward *adding* fields/phases — this section is the brake.)
   the `vote → score_calc → summarize` spine when the payoff is the phenomenon
   itself — `scoring_free` observation and a `narrate` (#909) score-free ending
   are first-class.
+
+## The register-dominance law (#958)
+
+Gemma 4 E2B's behavior follows a persona's **register** — its tone, archetype,
+and the phase structure around it — **not** the persona's stated goal or the
+wording of its instructions. A "scheming" goal reaches `inner_thought` but rarely
+changes what the agent *does* (#958); a per-turn state field like `mood` fixates
+on its seed value and echoes it mechanically rather than tracking events (#913 — a
+seeded mood token was copied verbatim across four turns while the agent was under
+direct attack).
+
+**Apply:** to change agent *behavior*, change **structure** — phase design, forced
+events, hard-binary choices, non-mappable persona values — not goal prose or "be
+dynamic" nudges. Wording-only levers move flavor, not action; confirmed by #911
+(framing > instruction), #957 (whisper pays off only where game structure fits it),
+#958 / #913 (goal/mood wording inert). This is *why* the subtract-by-default and
+scaffold-over-improv defaults above hold: the model rides structure, so give it
+structure, not more words.

--- a/.claude/rules/presets.md
+++ b/.claude/rules/presets.md
@@ -91,6 +91,6 @@ direct attack).
 events, hard-binary choices, non-mappable persona values — not goal prose or "be
 dynamic" nudges. Wording-only levers move flavor, not action; confirmed by #911
 (framing > instruction), #957 (whisper pays off only where game structure fits it),
-#958 / #913 (goal/mood wording inert). This is *why* the subtract-by-default and
-scaffold-over-improv defaults above hold: the model rides structure, so give it
-structure, not more words.
+#958 / #913 (goal/mood wording inert). This is *why* the subtract-by-default
+default above holds: the model rides structure, so give it structure, not more
+words.

--- a/.claude/skills/scenario-factory/PLAYBOOK.md
+++ b/.claude/skills/scenario-factory/PLAYBOOK.md
@@ -38,6 +38,8 @@ rounds; scoring optional) unless the axis needs it — full guidelines in
    keep option strings short and unambiguous (free-text wobble recurs), push
    reasoning into a preceding speak phase — structured choose decode is the
    suspected #253 trigger; fewer rounds shrink exposure. (06-21/22 repro + v2)
+   In **en**, use DESCRIPTIVE discrete options — E2B won't echo a numeric-range
+   option (invents `Under $X`). (en #850)
 4. **[validated]** Stray trailing `」}` shapes appear ~1/30 outputs and
    self-recover via parse-retry — judging noise, not a design signal.
 
@@ -53,11 +55,10 @@ rounds; scoring optional) unless the axis needs it — full guidelines in
 7. **[validated]** In `summarize` templates: `{scoreboard}` always resolves
    (safe); `{vote_winner}` / `{vote_results}` inside a conditional branch leak
    unrendered. (06-26 → confirmed fixed 06-28/07-01)
-8. **[validated]** `event_inject` draws via `randomElement()` — WITH
-   replacement, so repeats happen and order/coverage are never guaranteed.
-   Scripted arcs, must-cover stimulus sets, and freshness-only rotation all
-   want round-indexed `assign source:<list>` instead. (06-28/06-30/07-07;
-   assign ordered 07-03/07-05/07-06)
+8. **[validated]** `event_inject` draws via `randomElement()` — WITH replacement,
+   so repeats happen and order/coverage are never guaranteed. Scripted arcs,
+   must-cover stimulus sets, and freshness rotation want round-indexed
+   `assign source:<list>` instead. (06-28/30, 07-03/05/06/07)
 9. **[validated]** `eliminate` uses the per-round vote tally (not cumulative
    `vote_tally`) and breaks ties deterministically — knockouts are safe to pair
    with cumulative scoring. (06-29, reconfirmed nightly)
@@ -70,6 +71,9 @@ rounds; scoring optional) unless the axis needs it — full guidelines in
 12. **[validated]** To hold a genuine multi-round split, force a HARD BINARY
     choice and give personas non-mappable top values — a safe middle absorbs
     the pragmatists into consensus. (06-27 collapse; 06-28/07-01/07-06 held)
+    In **en** a straight-translated binary `choose` collapses to all-one-answer
+    unless ≥2 agents hold hardcoded OPPOSITE verdicts (fixed-verdict personas
+    make it uncollapsible); run the ja baseline first. (en #850)
 
 ## Persona design
 
@@ -79,6 +83,9 @@ rounds; scoring optional) unless the axis needs it — full guidelines in
 14. **[hypothesis]** A gimmick the model can't reliably produce dissolves into
     the shared register (and gets gang-eliminated first) — swap in forms E2B
     demonstrably lands; reinforce signature gags. (07-01/06-30; fix untested)
+    In **en** the drift is stronger (slides to generic epic caps-lock, sheds
+    gimmicks); symbol anchors (arrows, frame counts) resist better than text.
+    (en #850)
 15. **[hypothesis]** Relay "build on the previous turn" instructions pull
     personas toward the prior speaker's register — instruct "re-translate the
     previous content INTO your own style" instead. (06-30; partial fix 07-01)
@@ -92,18 +99,17 @@ rounds; scoring optional) unless the axis needs it — full guidelines in
     `speak_all` yields parallel monologues (cross-ref only in votes). Choose by
     whether interaction is the payoff. (06-25 A/B) [hypothesis] an explicit
     cross-reference instruction MAY upgrade speak_all — test first. (07-07)
-18. **[validated]** Vote reasons parrot other speakers verbatim. The
-    "write your OWN reason" nudge is shape-dependent — held in an elimination
-    shape (07-06), failed verbatim in speak_all+vote (07-07); prefer structural
-    fixes (elicit the reason before showing the log). (bug 06-24→07-07)
+18. **[validated]** Vote reasons parrot other speakers verbatim; the "write your
+    OWN reason" nudge is shape-dependent (held in elimination 07-06, failed in
+    speak_all+vote 07-07). Prefer a structural fix: elicit the reason before the
+    log. (bug 06-24→07-07)
 19. **[validated]** Acknowledgment ≠ persuasion: personas engage with others'
     arguments but almost never change their choice because of them. Don't
     stake a payoff on mid-run mind-changing. (07-03/07-06)
-20. **[hypothesis]** `whisper` pairs form dyadic mutual-trust bonds — trust
-    votes flow back along the pair, yielding all-tie scoreboards; rotate pairs
-    faster than the vote cadence or add an observer channel. Working half:
-    `{my_whispers}` leakage into later PUBLIC statements drives cross-round
-    development. (07-07 dousoukai)
+20. **[hypothesis]** `whisper` pairs form dyadic mutual-trust bonds — trust votes
+    flow back along the pair (all-tie scoreboards); rotate pairs faster than the
+    vote cadence or add an observer channel. Working half: `{my_whispers}` leaking
+    into later PUBLIC statements drives cross-round development. (07-07 dousoukai)
 
 ## Experiment design
 
@@ -112,7 +118,11 @@ rounds; scoring optional) unless the axis needs it — full guidelines in
     otherwise everyone rationalizes the same action. (07-03; fix untested)
 22. **[validated]** Introspective payoff ≠ behavioral payoff: a bias can be
     textbook in `inner_thought` while choices stay uniform. Measure the channel
-    the claim depends on. (07-03; 06-30)
+    the claim depends on. (07-03; 06-30) Port by PAYLOAD TYPE ja→en: funny-persona
+    payloads port cleanly, subtle-decision-bias payloads don't — the bias survives
+    the en discussion but common-sense overrides it at a discrete `choose`
+    (`anchoring_kantei` HELD, en no-go, 4 attempts). Field-test en separately.
+    (en #850)
 23. **[validated]** Cumulative telephone-game decay fails with the full
     conversation log visible — speakers re-anchor to the base fact. Scope such
     designs as a PARALLEL bias-panel (works cleanly)… (07-06)
@@ -131,39 +141,35 @@ rounds; scoring optional) unless the axis needs it — full guidelines in
 27. **[validated]** Form-differentiated knockouts go one-note by R3–R4. Main
     lever: rotate a per-round お題 via `assign source:topics` (the "seriffu
     recipe"); keep such formats ≤4 rounds. (06-29 recipe; 3 later transfers)
-28. **[validated]** Avoid constrained-wordplay formats (nazokake, homophone
-    puns) — E2B produces the skeleton without the wordplay payload. (06-25)
+28. **[validated]** Avoid constrained-wordplay formats (nazokake, homophone puns)
+    — E2B produces the skeleton without the payload. Conversely a SCAFFOLD (role /
+    setting / form — court, appraisal, even a limerick's verse) does the comedic
+    work: scaffolded comedy lands; pure improv-wit (raw お題→ボケ, e.g. oogiri) is
+    mild in ja too — a parity floor, not an en gap. (06-25; both langs #850)
 29. **[validated]** Keep one comedy scenario per batch so the night retains a
     `(d) humor` datapoint (null categories don't score it). (since 06-27)
 
 ## Votes & prohibition-following
 
-30. **[validated]** In vote-ELIMINATION scenarios where some personas WANT to
-    be chosen, self-voting is their rational move and `exclude_self` discards
-    it SILENTLY — one night was decided by a single valid vote. Fix with an
-    **in-world rule** ("本は自薦を認めない / the book accepts no self-nomination")
-    in BOTH context and the vote prompt, not a bare mechanical instruction.
-    ja Gemma follows such prohibitions markedly worse than en (field-measured
-    E2B: en invalid votes 5/12→2/12, ja only 6/12→5/12) — judge ja/en
+30. **[validated]** In vote-ELIMINATION scenarios where some personas WANT to be
+    chosen, self-voting is rational and `exclude_self` discards it SILENTLY (one
+    night decided by a single valid vote). Fix with an **in-world rule** ("本は自薦
+    を認めない / the book accepts no self-nomination") in BOTH context and the vote
+    prompt, not a bare mechanical instruction. ja Gemma follows such prohibitions
+    worse than en (E2B invalid votes en 5/12→2/12, ja 6/12→5/12) — judge ja/en
     separately. (07-08 last_fable / #1003)
 
 ## Saturated premise families (dedup: do not regenerate as-is)
 
-Id-level history lives in `digest-index.jsonl`; these FAMILIES are already
-characterized — new instances need a new mechanic angle, not a topic skin:
+Id-level history lives in `digest-index.jsonl`; these FAMILIES are mapped — a new
+instance needs a new mechanic angle, not a topic skin:
 
-- Form-differentiated knockout comedy (seriffu / yusha / yokai / shazai /
-  haiboku) — format and its one-note limit fully mapped.
-- Declare-then-secret-choose prisoners_dilemma variants (cartel / warikan /
-  preset); free-rider public/private-gap dilemmas (kyoyu, kasei).
-- Hard-binary ethics splits (saigo / kokuhatsu / manbiki / enjou / ai_teishi)
-  — mechanic settled (rule 12); only a fresh dilemma domain adds signal.
-- Cognitive-bias panels with a numerate control (anchoring / framing /
-  kakusho / sunk_cost / bousai) — open problem is rule 21, not new topics.
-- Scoring-free social-psych observations (zenin / bystander / risky_shift /
-  sokuho / kuuki) — same "inner_thought reveals mechanism, no arc" shape.
-- Improv sequential_build relays (jidaigeki / uchujin / chinjiken);
-  anthropomorphic-grievance venting (kaden_rousai, moto_akuyaku).
+- Form-differentiated knockout comedy (seriffu / yusha / yokai / shazai / haiboku) — one-note limit fully mapped.
+- prisoners_dilemma declare-then-secret-choose (cartel / warikan / preset) + free-rider public/private gap (kyoyu / kasei).
+- Hard-binary ethics splits (saigo / kokuhatsu / manbiki / enjou / ai_teishi) — settled (rule 12); needs a fresh dilemma domain.
+- Cognitive-bias panels w/ numerate control (anchoring / framing / kakusho / sunk_cost / bousai) — open problem is rule 21, not topics.
+- Scoring-free social-psych (zenin / bystander / risky_shift / sokuho / kuuki) — "inner_thought reveals mechanism, no arc".
+- Improv sequential_build relays (jidaigeki / uchujin / chinjiken) + anthropomorphic venting (kaden_rousai / moto_akuyaku).
 - Rumor distortion (dengon) — parallel panel works; chain decay = rules 23/24.
 
 New field/mechanic results land here via the lessons-inbox.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ Utilities/ → depends on nothing
 
 - Confirm with user before adding new SPM dependencies
 - When uncertain about direction or trade-offs, always ask before proceeding
-  - Safety-prerequisite follow-ups are a trade-off, not a scope-hygiene choice: if deferring a follow-up to a separate PR leaves `main` in a less-safe state until it lands (the primary PR enables a capability whose compensating control is the deferred item), **bundle it**. Splitting stays correct for *orthogonal* follow-ups; when unsure, surface the trade-off (extra commits vs. the between-merges risk window) rather than deciding silently.
+  - Safety-prerequisite follow-ups are a trade-off, not a scope-hygiene choice: if deferring a follow-up leaves `main` in a less-safe state until it lands, **bundle it**. Splitting stays correct for *orthogonal* follow-ups; when unsure, surface the trade-off (extra commits vs. the between-merges risk window) rather than deciding silently.
 - Major changes to public protocol signatures require user approval
 - Significant design changes beyond the current scope: stop and report first
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ Utilities/ → depends on nothing
 
 - Confirm with user before adding new SPM dependencies
 - When uncertain about direction or trade-offs, always ask before proceeding
+  - Safety-prerequisite follow-ups are a trade-off, not a scope-hygiene choice: if deferring a follow-up to a separate PR leaves `main` in a less-safe state until it lands (the primary PR enables a capability whose compensating control is the deferred item), **bundle it**. Splitting stays correct for *orthogonal* follow-ups; when unsure, surface the trade-off (extra commits vs. the between-merges risk window) rather than deciding silently.
 - Major changes to public protocol signatures require user approval
 - Significant design changes beyond the current scope: stop and report first
 


### PR DESCRIPTION
## Summary
Promotes durable, non-derivable lessons out of per-user memory into repo-tracked rules/docs so **contributors and CI can see them** (memory is per-user / per-machine — invisible to everyone else), then retires the source memories. Docs/rules-only — no Swift source.

Four promotions:
1. **CLAUDE.md § Confirmation Policy** — safety-prerequisite follow-ups are a trade-off, not a scope-hygiene choice: bundle them rather than leave a between-merges risk window.
2. **`.claude/rules/knowledge-layering.md` § "Rule-writing self-check"** — generalized from "assertions inside a rule" to *any load-bearing claim a plan leans on*, verified before plan-lock (Step 1b critic); added a 5-row claim→verify table. **Consolidates 5 memories into one form** (no new always-loaded file — folded into the existing section per critic's context-budget recommendation).
3. **`.claude/rules/presets.md`** — new "register-dominance law (#958)" subsection: E2B behavior follows a persona's register/structure, not its stated goal or instruction wording. Path-scoped (zero always-loaded cost).
4. **`.claude/skills/scenario-factory/PLAYBOOK.md`** — merged 5 EN-generation findings as riders on existing rules 3/12/14/22/28 (no new section), offset by compressing the saturated-families catalog + rules 8/18/20/30.

## Provenance / process notes
- All `Source memory:` provenance stripped; **no per-user memory refs** (`[[wikilink]]` / `` memory `x.md` ``) in any repo-tracked file (knowledge-layering anti-pattern).
- Pre-impl `critic` (Opus) + `code-reviewer` (Opus) both run; review PASS, 1 Warning + 1 Suggestion applied (cross-doc anchor fix + bullet trim).

## Known scope decision (not a defect)
Item 4 nets PLAYBOOK **+6 lines (169→175)**, still over its own ~150 soft cap. The file was **already 169 (19 over) before this PR**. A dedicated sub-150 compression pass on the validated dated rules is a correctness-sensitive refactor deliberately **deferred** — out of scope for a memory-promotion PR. PLAYBOOK is not always-loaded (read only by the scenario-factory/refine skills at generation time).

## Test plan
- No code — docs/rules only. Pre-commit hook correctly skipped SwiftLint/xcodebuild (no build-relevant paths).
- Verified: all 30 PLAYBOOK rules present (1-30); EN merges strictly additive; saturated-families all 7 retained; heading anchors intact.

## Device QA
実機QA不要 — docs/rules-only change, no runtime surface.

## Post-merge checklist (manual — per knowledge-layering § Procedure step 4; a PR cannot enforce per-machine memory deletion)
- [ ] Delete source memories: `feedback_safety_over_scope_hygiene`, `feedback_verify_architecture_comments`, `feedback_cross_doc_reference_verify`, `feedback_band_aid_framing_verify_loadbearing`, `feedback_verify_github_feature_availability_verbatim`, `feedback_external_standards_research_before_plan`
- [ ] Prune their MEMORY.md index lines
- [ ] (register-dominance law stays in `project_sim_interestingness_proposals.md` — that memory tracks active work; the law is now *also* in presets.md)

Closes #1128