### PR TITLE
📝 docs: systematize memory retire/triage (knowledge-layering + skill + hook)

### DIFF
--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -34,6 +34,8 @@ Three triggers for a triage pass (promotion **and** retirement), ordered by fire
 
 ## Procedure
 
+This procedure is for **PROMOTE**; retirement (DELETE / TRIM) is memory-direct and needs no PR.
+
 File a rolling tracking issue collecting candidate sections, then `/orchestrate` a PR that:
 
 1. Lands additions to `.claude/rules/` (or `CLAUDE.md` for project-wide rules).

--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -26,7 +26,7 @@ Memory `feedback_*` / `project_*` / `reference_*` entries belong in `.claude/rul
 
 Three triggers for a triage pass (promotion **and** retirement), ordered by fire-rate reliability:
 
-1. **Periodic triage** (most reliable, user-initiated) — run a full triage when total memory files >80 or total memory content >~250KB (`cat memory/*.md | wc -c`; the built-in >24.4KB *index* warning understates true size, since index lines are one-liners — treat it as a late secondary signal), or every several months. Top-N largest memories → promotion candidates; SHIPPED trackers → retire candidates. A persistent `feedback_*>40` signals a *promotion* backlog specifically (retirement never deletes `feedback_*`).
+1. **Periodic triage** (most reliable, user-initiated) — run a full triage when total memory files >80 or total memory content >~250KB (`cat memory/*.md | wc -c`; the built-in MEMORY.md *index*-size warning fires far too late — index lines are one-liners, so it badly understates true content — don't wait for it), or every several months. Top-N largest memories → promotion candidates; SHIPPED trackers → retire candidates. A persistent `feedback_*>40` signals a *promotion* backlog specifically (retirement never deletes `feedback_*`).
 2. **During `/orchestrate`** (rule-aware bundling) — if the current session created new feedback memories and the active PR is already touching `.claude/rules/`, bundle the rule addition in. Cheaper than a separate cleanup PR.
 3. **At memory-save time** (best-effort nudge, expect drift) — for new `feedback_*` saves, apply the quick test above. If it routes to rules, prefer creating a `.claude/rules/` PR alongside (and optionally instead of) the memory entry. The memory is the rapid-capture form; the rule is the durable form.
 

--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -22,13 +22,15 @@ Memory `feedback_*` / `project_*` / `reference_*` entries belong in `.claude/rul
 
 **User-preference carve-out**: feedback flavored as personal preference (e.g., "this user wants critic limited to 2/PR") stays in memory regardless of Pastura-specificity — it's `user_*`-flavored even when the trigger event was project work.
 
-## Promotion: memory → rules
+## Promotion & retirement
 
-Three triggers for considering promotion, ordered by fire-rate reliability:
+Three triggers for a triage pass (promotion **and** retirement), ordered by fire-rate reliability:
 
-1. **Periodic triage** (most reliable, user-initiated) — when MEMORY.md size warning fires (>24.4KB index) or every several months, run a full memory triage. Top-N largest memories become promotion candidates.
+1. **Periodic triage** (most reliable, user-initiated) — run a full triage when total memory files >80 or total memory content >~250KB (`cat memory/*.md | wc -c`; the built-in >24.4KB *index* warning understates true size, since index lines are one-liners — treat it as a late secondary signal), or every several months. Top-N largest memories → promotion candidates; SHIPPED trackers → retire candidates. A persistent `feedback_*>40` signals a *promotion* backlog specifically (retirement never deletes `feedback_*`).
 2. **During `/orchestrate`** (rule-aware bundling) — if the current session created new feedback memories and the active PR is already touching `.claude/rules/`, bundle the rule addition in. Cheaper than a separate cleanup PR.
 3. **At memory-save time** (best-effort nudge, expect drift) — for new `feedback_*` saves, apply the quick test above. If it routes to rules, prefer creating a `.claude/rules/` PR alongside (and optionally instead of) the memory entry. The memory is the rapid-capture form; the rule is the durable form.
+
+**Retire, don't only promote.** A triage pass also *removes* memory. A `project_*` tracker whose work has fully SHIPPED — no open follow-ups, outcome now derivable from code/git/docs — is **DELETED**; one with a shipped bulk plus a few live items is **TRIMMED** to the open-tracking stub. Promotion and retirement compose: run the quick test **first** to promote any durable lesson, then delete/trim the residue — a memory can be promoted *and* deleted the same round. **Prefer deletion**: when promoting, or when tracked work completes, actively check whether the memory can go rather than keeping it. (Operational classification: `promote-memories` § "Step 1: Triage".)
 
 ## Procedure
 

--- a/.claude/skills/promote-memories/SKILL.md
+++ b/.claude/skills/promote-memories/SKILL.md
@@ -1,21 +1,24 @@
 ---
 name: promote-memories
-description: Triage per-user memory and promote durable entries into .claude/rules/ — select candidates, draft at concept level, self-check, and hand off to /orchestrate for the PR.
+description: Triage per-user memory — promote durable entries into .claude/rules/ AND retire (delete/trim) SHIPPED trackers — select candidates, classify, draft at concept level, self-check, hand off to /orchestrate for the promotion PR.
 allowed-tools: Read, Grep, Glob, Bash, Write, Edit, Agent
 argument-hint: "[focus cluster | (empty for full triage)]"
 ---
 
 # /promote-memories
 
-Run a memory → rules promotion round. The **canonical procedure lives in
-`.claude/rules/knowledge-layering.md`** (§ Where knowledge belongs,
-§ Promotion, § Procedure, § Rule-writing self-check) — read it first and
-follow it as the source of truth. This skill adds only the operational
-steps around that procedure; if the two ever disagree, the rule wins.
+Run a memory triage round — **promote** durable lessons to rules and
+**retire** (delete/trim) SHIPPED trackers. The **canonical procedure lives
+in `.claude/rules/knowledge-layering.md`** (§ Where knowledge belongs,
+§ Promotion & retirement, § Procedure, § Rule-writing self-check) — read it
+first and follow it as the source of truth. This skill adds only the
+operational steps around that procedure; if the two ever disagree, the rule
+wins.
 
-Typical trigger: the MEMORY.md size warning (>24.4KB index), or a
-user-requested periodic triage. `$ARGUMENTS` may name a focus cluster
-(e.g. "xcstrings", "kmp") to skip the full triage.
+Typical trigger: total memory files >80 or total content >~250KB (see
+knowledge-layering § Promotion & retirement), or a user-requested periodic
+triage. `$ARGUMENTS` may name a focus cluster (e.g. "xcstrings", "kmp") to
+skip the full triage.
 
 ## Step 1: Triage
 
@@ -26,14 +29,26 @@ user-requested periodic triage. `$ARGUMENTS` may name a focus cluster
 2. For each candidate, apply knowledge-layering.md's quick test
    ("would a new contributor re-derive this?") and its user-preference
    carve-out (`user_*`-flavored feedback stays in memory).
-3. Cluster candidates by target rules file. Prefer path-scoped targets;
-   additions to always-loaded files route through
-   `.claude/rules/context-budget.md`'s classifier first.
-4. **Grep the target rules file before drafting** — entries may already be
-   partially covered; promote only the delta. Defer clusters whose natural
-   target file does not exist yet (e.g. a layer that hasn't landed on main).
-5. Present the slate to the user: promote now / defer (with the reason and
-   a tracking-issue note) / keep in memory. Wait for approval.
+3. **Classify each into a disposition** — run the promotion quick-test
+   *first*, so one memory can be both promoted and then retired:
+   - **PROMOTE** — durable, non-derivable lesson → extract to rules (Steps 2-4).
+   - **DELETE** — a `project_*` tracker whose work has fully SHIPPED (no open
+     items, outcome now derivable from code/git/docs) → retire the file.
+     Extract any durable lesson via PROMOTE first, then delete the residue.
+   - **TRIM** — shipped bulk plus a few live items → rewrite to the
+     open-tracking stub, keeping only the open work.
+   - **KEEP** — active tracking with open work → leave as-is.
+4. For **PROMOTE** candidates: cluster by target rules file (prefer
+   path-scoped; always-loaded targets route through
+   `.claude/rules/context-budget.md`'s classifier first), and **grep the
+   target before drafting** — entries may already be partially covered;
+   promote only the delta. Defer clusters whose target file does not exist yet.
+5. Present the disposition slate to the user (PROMOTE / DELETE / TRIM / KEEP,
+   with reasons; defer + tracking-issue note where relevant). Wait for
+   approval. Then: **PROMOTE** → Steps 2-4 (rules PR); **DELETE / TRIM** →
+   operate on memory directly in-session (per-user, no PR needed; on DELETE,
+   prune the file's MEMORY.md index line and fix any `[[wikilink]]` that
+   pointed to it).
 
 ## Step 2: Draft
 
@@ -75,7 +90,9 @@ checklist — never execute the deletions yourself:
    `rm -i` and silently no-ops in non-interactive shells). Show the list
    for confirmation before the operator runs it.
 2. Shorten remaining over-long MEMORY.md index lines (one line,
-   <200 chars each) — index-line length, not file count, drives the
-   >24.4KB warning, so this is the primary size-relief action.
-3. Re-check MEMORY.md size. If still over the limit, queue the next round
-   from the deferred clusters recorded in the tracking issue.
+   <200 chars each) — this relieves the built-in >24.4KB *index* warning
+   specifically; the primary triage triggers, though, are file-count +
+   content-size (knowledge-layering § Promotion & retirement), which
+   retirement (DELETE / TRIM) addresses directly.
+3. Re-check the triage triggers (file-count / content-size). If still over,
+   queue the next round from the deferred clusters recorded in the tracking issue.

--- a/.claude/skills/promote-memories/SKILL.md
+++ b/.claude/skills/promote-memories/SKILL.md
@@ -90,8 +90,9 @@ checklist — never execute the deletions yourself:
    `rm -i` and silently no-ops in non-interactive shells). Show the list
    for confirmation before the operator runs it.
 2. Shorten remaining over-long MEMORY.md index lines (one line,
-   <200 chars each) — this relieves the built-in >24.4KB *index* warning
-   specifically; the primary triage triggers, though, are file-count +
+   <200 chars each) — this relieves the built-in MEMORY.md *index*-size
+   warning specifically (which fires far too late to rely on); the primary
+   triage triggers, though, are file-count +
    content-size (knowledge-layering § Promotion & retirement), which
    retirement (DELETE / TRIM) addresses directly.
 3. Re-check the triage triggers (file-count / content-size). If still over,

--- a/.claude/skills/promote-memories/SKILL.md
+++ b/.claude/skills/promote-memories/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: promote-memories
-description: Triage per-user memory — promote durable entries into .claude/rules/ AND retire (delete/trim) SHIPPED trackers — select candidates, classify, draft at concept level, self-check, hand off to /orchestrate for the promotion PR.
+description: Triage per-user memory — promote durable entries into .claude/rules/ AND retire (delete/trim) SHIPPED trackers — select candidates, classify, draft at concept level, self-check, hand off to /orchestrate for any promotion PR (retirement is memory-direct, no PR).
 allowed-tools: Read, Grep, Glob, Bash, Write, Edit, Agent
 argument-hint: "[focus cluster | (empty for full triage)]"
 ---

--- a/scripts/hooks/pr-created-reflection.sh
+++ b/scripts/hooks/pr-created-reflection.sh
@@ -19,7 +19,9 @@
 #      + reason) to match the PR body's `## Device QA` section.
 #   2. Surface any observations / concerns / suggestions noticed during
 #      the session.
-#   3. Note any memory files worth creating or updating.
+#   3. Note any memory to create/update — and whether this change lets you
+#      retire one (trim/delete a SHIPPED project_* tracker, or a lesson now
+#      promoted to rules).
 #
 # Reads no stdin (static reminder). The tool-input data is available via
 # the env vars gated-runner.sh exports ($CLAUDE_HOOK_INPUT,
@@ -35,7 +37,7 @@ set -euo pipefail
 jq -n '{
   hookSpecificOutput: {
     hookEventName: "PostToolUse",
-    additionalContext: "PR created. Before moving on: (1) Device QA — restate the on-device QA steps this change needs (or state 実機QA不要 with the reason), matching the ## Device QA section in the PR body. (2) Observations — share any concerns, surprises, or suggestions you noticed during this session. (3) Memory — note any memory files worth creating or updating from this session."
+    additionalContext: "PR created. Before moving on: (1) Device QA — restate the on-device QA steps this change needs (or state 実機QA不要 with the reason), matching the ## Device QA section in the PR body. (2) Observations — share any concerns, surprises, or suggestions you noticed during this session. (3) Memory — note any memory files worth creating or updating from this session, and whether this change now lets you retire one: trim or delete a SHIPPED project_* tracker, or a memory whose lesson you just promoted to rules (per .claude/rules/knowledge-layering.md § Promotion & retirement)."
   }
 }'
 


### PR DESCRIPTION
## Summary
Closes the memory-lifecycle gap surfaced this session: the promote-memories flow covered **promotion** (memory→rules) but not the **retire/棚卸し** side — deleting/trimming SHIPPED completed `project_*` trackers that aren't promotion candidates, which is why memory accumulates. Docs/tooling-only — no Swift.

Three changes:
1. **`.claude/rules/knowledge-layering.md`** (always-loaded) — retitle § "Promotion: memory → rules" → **"Promotion & retirement"**; add a retire note (fully-SHIPPED `project_*` → DELETE, mixed → TRIM to the open stub; promotion-first ordering, prefer deletion). **Revise the periodic-triage trigger** from the weak `>24.4KB index` proxy to **count (>80 files) + total content-size (>~250KB)** primaries — the index-KB warning understates true size (index lines are one-liners: 99 files = ~15.5KB index but ~303KB content). `feedback_*>40` reframed as a *promotion*-backlog signal.
2. **`.claude/skills/promote-memories/SKILL.md`** — extend Step 1 Triage with a **4-way DELETE/TRIM/PROMOTE/KEEP** classification (promotion quick-test first → retire the residue; DELETE/TRIM are memory-direct, only PROMOTE routes to the rules-PR flow). Reconcile the description, intro, "Typical trigger", and Step 5 with the new trigger framing.
3. **`scripts/hooks/pr-created-reflection.sh`** — add a memory-retirement nudge to the PR-creation reflection prompt (item 3).

## Review / process
- Pre-impl `critic` (Opus): 4 Warnings all applied (add-alongside the real >24.4KB warning rather than replace; reframe feedback trigger; drop the worked-example from the always-loaded file; make promotion→retire ordering explicit).
- `code-reviewer` (Opus): **PASS, 0 issues**; 2 non-blocking suggestions applied (retirement-needs-no-PR clarity in the skill description + § Procedure).
- Cross-references verified: `§ "Rule-writing self-check"` heading unchanged (adr-writing.md + SKILL still resolve); `§ "Promotion & retirement"` matches in all 3 skill refs. No per-user memory FILENAME refs added. Hook emits valid jq JSON.

## Test plan
- Docs/tooling only. `scripts/hooks/pr-created-reflection.sh` validated (`| jq -e` non-empty additionalContext, exit 0). Shell-gate test suite: no FAILs; no test references this hook.
- Note: the `scripts/**` change made the pre-commit hook run a full `xcodebuild build` (build-relevant classification) — passed on the (fresh-worktree) build after SPM resolution.

## Device QA
実機QA不要 — docs/tooling-only, no runtime app surface (the hook is a static reflection string).

## Post-merge checklist (manual — dotfiles/personal, not enforceable by this repo PR)
- [ ] Sync personal mirrors: `~/.claude/CLAUDE.md` # Memory principles — (a) memory is not durable storage (promote durable facts, keep only watch-list/様子見/ephemeral) / (b) prefer deletion on promote-or-complete; personal `knowledge-layering.md`; personal `promote-memories/SKILL.md` (add the 4-way retire classification + trigger revision)

Closes #1131