### PR TITLE
📝 docs: step-level `if:` の暗黙 success() をルール化

### DIFF
--- a/.claude/rules/ci-workflows.md
+++ b/.claude/rules/ci-workflows.md
@@ -100,7 +100,9 @@ Load-bearing invariants when adding/changing such gating:
 
 A **step** `if:` with no status-check function carries an implicit `success()`; adding `always()` / `failure()` / `!cancelled()` **removes** it, letting the step run after an earlier one failed. (Job-level contrast: § "Required-check-safe path gating" invariants 1 and 4 drop the implicit gate *deliberately*. Same mechanism, opposite valence — don't conflate the two scopes.)
 
-**Apply** — before adding a status function to a step `if:`, check what the implicit gate was doing. Live case: `kmp-nightly.yml`'s **"Measure warm-cache assembly (Stage-5 sizing)"** step — its implicit `success()` is the only thing stopping its `clean` from wiping the reports that the `if: failure()` upload below it collects. Full rationale is inline above that step. Related: a `continue-on-error: true` step's failure sets `outcome`=failure but `conclusion`=success, so a later `failure()` stays false — and it does not cover a **job** timeout (hence that step's own `timeout-minutes`).
+**Apply** — before adding a status function to a step `if:`, check what the implicit gate was doing. Live case: `kmp-nightly.yml`'s **"Measure warm-cache assembly (Stage-5 sizing)"** step — its implicit `success()` is the only thing stopping its `clean` from wiping the reports that the `if: failure()` upload below it collects. Full rationale is inline above that step.
+
+Related, on the same step: a `continue-on-error: true` step's failure sets `outcome`=failure but `conclusion`=success, and status functions read `conclusion` — so a later `failure()` stays false. `continue-on-error` does not cover a **job** timeout, which is why that step also carries its own `timeout-minutes`.
 
 ## Script unit tests (`scripts/tests/`) run in CI only — not the pre-commit hook
 

--- a/.claude/rules/ci-workflows.md
+++ b/.claude/rules/ci-workflows.md
@@ -6,7 +6,7 @@ paths:
 
 # CI Workflows (GHA, macOS runners)
 
-Four concern families when editing CI workflow YAML or supporting scripts on this repo: shell-language gotchas on the macOS runner, long-lived integration-branch gating shape, required-check-safe path gating, and the script unit-test suite that runs in CI only.
+Six concern families when editing CI workflow YAML or supporting scripts on this repo: shell-language gotchas on the macOS runner, long-lived integration-branch gating shape, required-check-safe path gating, step-level `if:` semantics, the script unit-test suite that runs in CI only, and rename/namespace-sweep completion gates.
 
 ## Shell scripting gotchas (macOS GHA runners)
 
@@ -95,6 +95,12 @@ Load-bearing invariants when adding/changing such gating:
 3. **Don't gate the cheap ubuntu drift guards.** They cost little and gating them risks the same required-check trap for no benefit — gate only the macOS jobs.
 4. **`pr-comment` runs even when its deps skip — deliberately.** It carries `if: !cancelled() && …`, a status function, so it does **not** inherit a skipped dependency: on a web/docs-only PR (macOS jobs skipped) it still runs and posts a "did not run / skipped" comment (cosmetically noisy, functionally fine). Don't "fix" it to a plain boolean or the comment vanishes. (Contrast: a *plain-boolean* `if:` WOULD inherit the skip — that's the lever when you want a consumer to skip alongside its dependency.)
 5. **Verify BOTH branches on dummy PRs** (the "Long-lived branch gating — two layers × two directions" § `### Procedure` step 3 applies here too): one docs/web-only PR must skip the macOS jobs *and* still show the required checks green/mergeable; one trivial `.swift` PR must run them. A gating PR that touches only `.github/`/`.claude/` skips the macOS jobs on itself, so its *run* path is never exercised pre-merge — test it separately.
+
+## Step-level `if:` — the implicit `success()` can be load-bearing
+
+A **step** `if:` with no status-check function carries an implicit `success()`; adding `always()` / `failure()` / `!cancelled()` **removes** it, letting the step run after an earlier one failed. (Job-level contrast: § "Required-check-safe path gating" invariants 1 and 4 drop the implicit gate *deliberately*. Same mechanism, opposite valence — don't conflate the two scopes.)
+
+**Apply** — before adding a status function to a step `if:`, check what the implicit gate was doing. Live case: `kmp-nightly.yml`'s **"Measure warm-cache assembly (Stage-5 sizing)"** step — its implicit `success()` is the only thing stopping its `clean` from wiping the reports that the `if: failure()` upload below it collects. Full rationale is inline above that step. Related: a `continue-on-error: true` step's failure sets `outcome`=failure but `conclusion`=success, so a later `failure()` stays false — and it does not cover a **job** timeout (hence that step's own `timeout-minutes`).
 
 ## Script unit tests (`scripts/tests/`) run in CI only — not the pre-commit hook
 


### PR DESCRIPTION
## Summary

Records one GitHub Actions **step-level** semantics fact in `.claude/rules/ci-workflows.md` as a latent-regression guard. ~4 lines, one file.

**This fixes nothing, and the text says so.** A read-only Opus audit swept all 7 workflow files (~1906 lines, 13 status-function `if:`s) and found **zero** existing defects: every status-function `if:` is correct, the single pre-existing `continue-on-error` (`ci.yml`'s "Post PR comment", last step of its job, nothing `needs:` it) is correct, and no `steps.*.outcome` / `.conclusion` read exists anywhere in the repo.

**Why write it anyway** — one live site where an implicit `success()` is the only load-bearing guard, failing in the "helpful edit" direction: `kmp-nightly.yml`'s **"Measure warm-cache assembly (Stage-5 sizing)"** step. Its implicit `success()` is the only thing stopping its `clean` from wiping `build/reports/` out from under the `if: failure()` upload below it. Someone adding `always()` to "make it robust" silently breaks the failure-diagnostics path, with no test to catch it.

The cost side is why this clears the bar at 4 lines despite zero historical defects: `ci-workflows.md` is **path-scoped** (`.github/workflows/**`, `scripts/**`), so it loads only when someone edits a workflow — exactly when the hazard fires — and costs nothing otherwise. `context-budget.md` explicitly loosens the budget for path-scoped files.

- **Own top-level section**, not nested under § "Required-check-safe path gating" — that section is about merge-blocking semantics, and the guarded site owns no required check (`kmp-nightly.yml` documents itself as explicitly not one). One cross-ref line keeps the **job-level** contrast visible (invariants 1/4 drop the implicit needs-success gate *deliberately* — same mechanism, opposite valence) without merging the scopes.
- **Cites the step by name, not line number.** Workflow line numbers drift; a rules file outlives them. Step names are stable and greppable.
- **Depth not duplicated.** `kmp-nightly.yml` carries the full inline explanation above the step; the rule keeps lead claim + pointer (`context-budget.md` classifier).
- Also fixes the header's "**Four** concern families" → "Six". It was **already stale before this change**: it enumerated 4 while the file carried 5 (the rename/namespace-sweep gate was missing).

## A claim this PR cut, because it turned out to be wrong

An earlier draft cited a **second** site — `ci-retry.yml`'s "Rerun failed jobs" (`if: steps.check.outputs.ui_test_failed != '0'`) — reasoning that a failed `check` step leaves the output empty, `'' != '0'` is true, and only the implicit `success()` prevents a `gh` API blip from firing an unconditional CI rerun. The `critic` round flagged it as unverified; a throwaway-workflow probe **disproved it**.

Under `bash -e`, errexit aborts the step *before* it writes `$GITHUB_OUTPUT`, so the key is **missing**, not empty-string. GHA coerces a missing property to `null`, and `null != '0'` → `0 != 0` → **false**. Probe output, with the implicit gate deliberately removed via `always() &&`:

```
outcome=failure
conclusion=success
raw=[]
expr (x != '0') = false
→ guarded step: SKIPPED
```

The expression alone skips it — the implicit `success()` there is redundant belt-and-braces, not a guard. So the rule cites **one** site, not two, and the justification is stated accordingly. The same probe confirmed the `outcome`/`conclusion` divergence empirically, so that clause is measured rather than assumed.

## Test plan

Rule-writing self-check (`knowledge-layering.md` § "Rule-writing self-check" — the writer is the only one who reliably runs the check a rule prescribes):

- `git grep -nF 'Measure warm-cache assembly (Stage-5 sizing)'` → live at `kmp-nightly.yml:221`.
- The protected `if: failure()` upload exists (`:325`); that step really carries `continue-on-error: true` + `timeout-minutes: 15` (`:223-224`), so the parenthetical is accurate.
- No line-number citations in the new section.
- Header count vs reality: `grep -c "^## "` = 7, minus `## Related` = **6**. Matches "Six", and the six named families are in document order.
- `.claude/agents/code-reviewer.md` grepped for a CI/GHA trap entry → none, so no mirror to update (`knowledge-layering.md` procedure step 3).

Reviewed by 1 Opus `critic` (1 Critical → the site-2 claim above, settled empirically and cut; 3 Warnings → fact scoped to **job** timeout only, placement moved to its own section, size halved) and 1 Opus `code-reviewer` (PASS, 0 blocking; 2 suggestions applied — named `continue-on-error` as the subject where the pronoun pointed at `failure()`, and split the tail out of the **Apply** paragraph).

## Device QA

実機QA不要 — a rules-file documentation change. No source, no CI behavior, no runtime surface.

## Related

- Depends on the site introduced by #1137 (KMP Stage 2-gate PR-A).
- #1142 — Rule 2's pipefail premise is false (GHA's implicit default shell is `bash -e {0}`, no pipefail; zero `shell:` hits repo-wide). Surfaced by the same critic round, **deliberately kept separate**: orthogonal, and it needs its own verification.

Closes #1143
