### PR TITLE
🐛 fix: JSONResponseParser turns the numbers 0/1 into "false"/"true"

### DIFF
--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -103,3 +103,14 @@ For each load-bearing assertion in the draft:
 This applies to **non-grep claims** too: cited file paths (`find` to confirm existence), `(PR #N)` claims about PR body content (`gh pr view N` to verify), heading anchors in cross-doc refs (`grep` for the exact heading).
 
 A 30-second self-check prevents 1–2 extra critic / code-reviewer rounds. Motivating incident: PR #462 round-3 critic.
+
+### Claims you author are assertions too
+
+The table above covers claims you *lean on*, checked before plan-lock. A **why-comment you write** is the same kind of claim — it asserts runtime or library behaviour as the reason a mechanism exists — but it is authored at implementation time and no reviewer executes it. Reviewers check whether the *code* is correct, not whether the *stated reason* is true, so a false why-comment ships and the next reader inherits it as fact: they keep a useless mechanism forever, or delete a load-bearing one whose recorded reason didn't survive scrutiny.
+
+Two shapes, neither expressible as a `Verify by` lookup:
+
+- **Why-comment on a mechanism** → delete the mechanism and run the tests. Green means the claim is false, or the tests never covered it. Both are worth knowing before you commit the comment.
+- **A detector / guard / gate** → construct the thing it claims to catch and confirm it fires. A guard is the one artifact whose success case proves nothing — only a negative control does.
+
+Motivating incident: PR #1152 shipped five such claims to review; all five were false, each with a mechanical check that was never run.

--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -85,10 +85,11 @@ The same "verify before you lock it" discipline extends past rule assertions to 
 | A header/doc comment asserting cross-file structure ("defined in M", "consumable by Y") | grep the actual symbol/type — comments can be aspirational, not descriptive |
 | A `§"Heading"` cross-doc reference | grep the target for the exact heading **and read under it** to confirm the content matches; add a named heading if absent |
 | "band-aid / hack / dead code" framing of a change | grep ALL producers + consumers across layers (esp. Engine/runtime), not just the layer the issue scopes — the target may be load-bearing |
+| A documented defect framed as **live** ("X `would` flow into Y — i.e. fabrication") | grep every **writer** of the value, not just the reader — an upstream guard may already make it unreachable, in which case the comment is that guard's rationale, not a bug report. Subjunctive mood is the tell (#1151) |
 | An external standard (SEO, RFC, sitemap/robots, OAuth, HTTP semantics) | WebSearch + WebFetch the authority (Google Search Central, the RFC, MDN); verbatim-cite before critic |
 | Vendor feature availability (free/paid/plan tier) | WebFetch the canonical docs; verbatim-quote the "Who can use this feature" box — never infer from search snippets |
 
-### Apply
+### Apply (verification table)
 
 For each load-bearing assertion in the draft:
 

--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -106,11 +106,9 @@ A 30-second self-check prevents 1–2 extra critic / code-reviewer rounds. Motiv
 
 ### Claims you author are assertions too
 
-The table above covers claims you *lean on*, checked before plan-lock. A **why-comment you write** is the same kind of claim — it asserts runtime or library behaviour as the reason a mechanism exists — but it is authored at implementation time and no reviewer executes it. Reviewers check whether the *code* is correct, not whether the *stated reason* is true, so a false why-comment ships and the next reader inherits it as fact: they keep a useless mechanism forever, or delete a load-bearing one whose recorded reason didn't survive scrutiny.
+A **why-comment you write** asserts runtime or library behaviour as the reason a mechanism exists — the same kind of claim as the table's, but authored at implementation time and executed by nobody. Reviewers check whether the *code* is correct, not whether the *stated reason* is true, so a false one ships and the next reader inherits it as fact. Two shapes, neither expressible as a `Verify by` lookup:
 
-Two shapes, neither expressible as a `Verify by` lookup:
+- **Why-comment on a mechanism** → delete the mechanism and run the tests. Green means the claim is false, or the tests never covered it.
+- **A detector / guard / gate** → construct the thing it claims to catch and confirm it fires. A guard's success case proves nothing; only a negative control does.
 
-- **Why-comment on a mechanism** → delete the mechanism and run the tests. Green means the claim is false, or the tests never covered it. Both are worth knowing before you commit the comment.
-- **A detector / guard / gate** → construct the thing it claims to catch and confirm it fires. A guard is the one artifact whose success case proves nothing — only a negative control does.
-
-Motivating incident: PR #1152 shipped five such claims to review; all five were false, each with a mechanical check that was never run.
+Motivating incident: PR #1152 round-1 review.

--- a/Pastura/Pastura/LLM/JSONResponseParser+Normalize.swift
+++ b/Pastura/Pastura/LLM/JSONResponseParser+Normalize.swift
@@ -3,10 +3,15 @@ import Foundation
 /// Value normalization — the final step of ``JSONResponseParser/parse(_:)``.
 ///
 /// Split out of `JSONResponseParser.swift`, which sits at the 400-line
-/// `file_length` cap. `nonisolated` is load-bearing on the extension itself:
-/// methods in a plain `extension` inherit MainActor under the project's
-/// default-actor-isolation setting, which breaks the `nonisolated` callers in
-/// the main file (see `.claude/rules/swift-isolation.md` Pattern 3).
+/// `file_length` cap.
+///
+/// `nonisolated` on the extension is load-bearing — verified, not assumed:
+/// dropping it fails the build with `call to main actor-isolated instance
+/// method 'normalizeValues' in a synchronous nonisolated context` at the
+/// `tryParse` callsite. Methods in a plain `extension` inherit MainActor under
+/// the project's default-actor-isolation setting (`.claude/rules/swift-isolation.md`
+/// Pattern 3). Most `LlamaCppService+*.swift` siblings here need no annotation
+/// because their callers are `async`; this one is reached synchronously.
 nonisolated extension JSONResponseParser {
   /// Normalize all JSON values to `String`. Null values are omitted.
   ///

--- a/Pastura/Pastura/LLM/JSONResponseParser+Normalize.swift
+++ b/Pastura/Pastura/LLM/JSONResponseParser+Normalize.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Value normalization — the final step of ``JSONResponseParser/parse(_:)``.
+///
+/// Split out of `JSONResponseParser.swift`, which sits at the 400-line
+/// `file_length` cap. `nonisolated` is load-bearing on the extension itself:
+/// methods in a plain `extension` inherit MainActor under the project's
+/// default-actor-isolation setting, which breaks the `nonisolated` callers in
+/// the main file (see `.claude/rules/swift-isolation.md` Pattern 3).
+nonisolated extension JSONResponseParser {
+  /// Normalize all JSON values to `String`. Null values are omitted.
+  ///
+  /// Internal rather than `private` only because a sibling-file extension
+  /// cannot expose a `private` member to the declaring file's callers.
+  func normalizeValues(_ dictionary: [String: Any]) -> [String: String] {
+    var result: [String: String] = [:]
+    for (key, value) in dictionary {
+      if value is NSNull {
+        // Null values are omitted
+        continue
+      } else if let stringValue = value as? String {
+        result[key] = stringValue
+      } else if let numberValue = value as? NSNumber {
+        // `as? Bool` cannot discriminate here: NSNumber -> Bool bridging
+        // succeeds for exactly 0 and 1, so checking it first swallowed the
+        // NUMBERS 0/1 into "false"/"true" (#1150). Every value reaching this
+        // method comes from `JSONSerialization` (see `tryParse`), which boxes
+        // JSON booleans as __NSCFBoolean and numbers as __NSCFNumber — so the
+        // CoreFoundation type id is the only reliable discriminator.
+        if CFGetTypeID(numberValue) == CFBooleanGetTypeID() {
+          result[key] = numberValue.boolValue ? "true" : "false"
+        } else {
+          result[key] = numberValue.stringValue
+        }
+      } else if JSONSerialization.isValidJSONObject(value) {
+        // Nested object or array → serialize back to JSON string
+        if let jsonData = try? JSONSerialization.data(
+          withJSONObject: value, options: [.sortedKeys]),
+          let jsonString = String(data: jsonData, encoding: .utf8) {
+          result[key] = jsonString
+        }
+      }
+    }
+    return result
+  }
+}

--- a/Pastura/Pastura/LLM/JSONResponseParser+Normalize.swift
+++ b/Pastura/Pastura/LLM/JSONResponseParser+Normalize.swift
@@ -10,8 +10,15 @@ import Foundation
 /// method 'normalizeValues' in a synchronous nonisolated context` at the
 /// `tryParse` callsite. Methods in a plain `extension` inherit MainActor under
 /// the project's default-actor-isolation setting (`.claude/rules/swift-isolation.md`
-/// Pattern 3). Most `LlamaCppService+*.swift` siblings here need no annotation
-/// because their callers are `async`; this one is reached synchronously.
+/// Pattern 3).
+///
+/// Don't generalize that to "any sibling-file extension needs it": most
+/// `LlamaCppService+*.swift` siblings are plain extensions and build fine, and
+/// `LlamaCppService+Tokenization.swift`'s sync `tokenize` is even reached from a
+/// sync `nonisolated` caller (`buildAndSeedDrySampler`) without one. What makes
+/// this file differ was not isolated — `JSONResponseParser` is a `struct` and
+/// `LlamaCppService` a `final class`, but that was never tested as the cause.
+/// Measure before assuming either way.
 nonisolated extension JSONResponseParser {
   /// Normalize all JSON values to `String`. Null values are omitted.
   ///

--- a/Pastura/Pastura/LLM/JSONResponseParser.swift
+++ b/Pastura/Pastura/LLM/JSONResponseParser.swift
@@ -371,30 +371,4 @@ nonisolated public struct JSONResponseParser: Sendable {
     // Unclosed — let the repair pipeline handle it.
     return text
   }
-
-  /// Normalize all JSON values to `String`. Null values are omitted.
-  private func normalizeValues(_ dictionary: [String: Any]) -> [String: String] {
-    var result: [String: String] = [:]
-    for (key, value) in dictionary {
-      if value is NSNull {
-        // Null values are omitted
-        continue
-      } else if let stringValue = value as? String {
-        result[key] = stringValue
-      } else if let boolValue = value as? Bool {
-        // Check Bool before NSNumber — Bool bridges to NSNumber in ObjC
-        result[key] = boolValue ? "true" : "false"
-      } else if let numberValue = value as? NSNumber {
-        result[key] = numberValue.stringValue
-      } else if JSONSerialization.isValidJSONObject(value) {
-        // Nested object or array → serialize back to JSON string
-        if let jsonData = try? JSONSerialization.data(
-          withJSONObject: value, options: [.sortedKeys]),
-          let jsonString = String(data: jsonData, encoding: .utf8) {
-          result[key] = jsonString
-        }
-      }
-    }
-    return result
-  }
 }

--- a/Pastura/PasturaTests/LLM/JSONResponseParserTests.swift
+++ b/Pastura/PasturaTests/LLM/JSONResponseParserTests.swift
@@ -72,8 +72,25 @@ struct JSONResponseParserTests {
     #expect(output.fields["ratio"] == "3.14")
   }
 
+  /// The 0/1 window: `NSNumber -> Bool` casting succeeds for exactly 0 and 1,
+  /// so ordering `as? Bool` ahead of `as? NSNumber` swallowed these into
+  /// "false"/"true" (#1150). `1.0` / `0.0` render without the `.0` because
+  /// `NSNumber.stringValue` normalizes the literal — that formatting difference
+  /// from the Kotlin port is a separate divergence, deferred to ADR-023 Stage 4.
+  @Test func normalizesNumbersInsideTheBoolBridgeWindow() throws {
+    let input = #"{"zero": 0, "one": 1, "floatZero": 0.0, "floatOne": 1.0}"#
+    let output = try parser.parse(input)
+    #expect(output.fields["zero"] == "0")
+    #expect(output.fields["one"] == "1")
+    #expect(output.fields["floatZero"] == "0")
+    #expect(output.fields["floatOne"] == "1")
+  }
+
   // MARK: - 7. Boolean values normalized to String
 
+  /// Doubles as the negative control for #1150's `CFBooleanGetTypeID`
+  /// discrimination: dropping the `as? Bool` branch must not regress real
+  /// JSON booleans, which is the branch's original — and still valid — intent.
   @Test func normalizesBooleanValues() throws {
     let input = #"{"alive": true, "eliminated": false}"#
     let output = try parser.parse(input)

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
@@ -223,11 +223,12 @@ internal class JSONResponseParser {
      *
      * **Why Kotlin did not replicate it.** Replicating it would have cemented an
      * unintended Foundation quirk as a *cross-language contract*, in a language
-     * that has no `NSNumber`. Surfacing it here is ADR-023 §10 working as intended
-     * ("Engine behavior gets a second, cross-language executable spec, which also
-     * hardens the Swift side against accidental semantic drift"): it was filed as
-     * **#1150** and fixed there — Swift now discriminates on `CFBooleanGetTypeID`
-     * rather than on cast success. **No change was needed here.**
+     * that has no `NSNumber`. Porting the parser is what surfaced it at all —
+     * the hardening ADR-023 §10 anticipates from a cross-language spec, arriving
+     * early from the port itself rather than from the Stage-4 harness that
+     * section scopes it to. It was filed as **#1150** and fixed there: Swift now
+     * discriminates on `CFBooleanGetTypeID` rather than on cast success.
+     * **No change was needed here.**
      *
      * **The integer rows closed; the float rows did not.** #1150 makes Swift return
      * `"1"` / `"0"` for `1` / `0` — agreeing with this side. But for `1.0` / `0.0`

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
@@ -204,15 +204,15 @@ internal class JSONResponseParser {
     /**
      * Normalize every JSON value to `String`. Null values are omitted.
      *
-     * ## Deliberate divergence from Swift — a Swift bug this port does NOT copy
+     * ## The Bool-bridge divergence from Swift — a Swift bug this port never copied
      *
-     * Swift's `normalizeValues` checks `value as? Bool` **before** `as? NSNumber`,
-     * with the comment "Check Bool before NSNumber — Bool bridges to NSNumber in
-     * ObjC". The intent is to catch JSON `true`/`false`. The effect is wider,
-     * because `NSNumber` -> `Bool` bridging succeeds for exactly 0 and 1.
-     * Measured on this branch against the real Swift branch order:
+     * Swift's `normalizeValues` **used to** check `value as? Bool` before
+     * `as? NSNumber`, with the comment "Check Bool before NSNumber — Bool bridges
+     * to NSNumber in ObjC". The intent was to catch JSON `true`/`false`. The
+     * effect was wider, because `NSNumber` -> `Bool` bridging succeeds for exactly
+     * 0 and 1, so the numbers `0` / `1` (and `0.0` / `1.0`) were swallowed:
      *
-     * | JSON | Swift | Kotlin (here) |
+     * | JSON | Swift (pre-#1150) | Kotlin (here) |
      * |---|---|---|
      * | `0` | **`"false"`** | `"0"` |
      * | `1` | **`"true"`** | `"1"` |
@@ -221,26 +221,23 @@ internal class JSONResponseParser {
      * | `2`, `-1`, `0.5` | `"2"`, `"-1"`, `"0.5"` | same |
      * | `true` / `false` | `"true"` / `"false"` | same |
      *
-     * **Why Kotlin does not replicate it.** ADR-023 §6 makes the Swift test files
-     * the executable spec — and that spec does **not** pin this: the only numeric
-     * test uses `{"score": 42, "ratio": 3.14}`, values chosen (by luck) to sidestep
-     * the 0/1 range, and no test anywhere passes a numeric 0 or 1 through the
-     * parser. So the behaviour is untested, incidental, and contradicts its own
-     * test's name ("Numeric values normalized to String" — `1` does not become
-     * `"1"`). Replicating it would cement an unintended Foundation quirk as a
-     * *cross-language contract*, in a language that has no `NSNumber`.
+     * **Why Kotlin did not replicate it.** Replicating it would have cemented an
+     * unintended Foundation quirk as a *cross-language contract*, in a language
+     * that has no `NSNumber`. Surfacing it here is ADR-023 §10 working as intended
+     * ("Engine behavior gets a second, cross-language executable spec, which also
+     * hardens the Swift side against accidental semantic drift"): it was filed as
+     * **#1150** and fixed there — Swift now discriminates on `CFBooleanGetTypeID`
+     * rather than on cast success. **No change was needed here.**
      *
-     * **This is not the only normalization divergence** — exponent/float FORMATTING
-     * also differs (`1e3` -> Swift `"1000"` vs Kotlin `"1e3"`). That one is a
-     * formatting choice with no correct side, so it has no issue; see
+     * **The integer rows closed; the float rows did not.** #1150 makes Swift return
+     * `"1"` / `"0"` for `1` / `0` — agreeing with this side. But for `1.0` / `0.0`
+     * Swift returns `"1"` / `"0"` as well, because `NSNumber.stringValue` drops the
+     * `.0`, so those two only changed divergence class: from the Bool bridge to
+     * exponent/float FORMATTING, which also covers `1e3` -> Swift `"1000"` vs
+     * Kotlin `"1e3"`. That class is a formatting choice with no correct side; see
      * `JSONResponseParserParityTests` § "Known Kotlin-side literal-preservation
-     * differences". The same applies to numbers nested inside [canonicalJson].
-     *
-     * Pinned by `JSONResponseParserParityTests` and filed as **#1150** with a
-     * verified fix, per ADR-023 §10 ("Engine behavior gets a second,
-     * cross-language executable spec, which also hardens the Swift side against
-     * accidental semantic drift"). When #1150 lands the divergence closes with **no
-     * change here** — this side is already correct.
+     * differences", and ADR-023 Stage 4 to decide the rule once for both engines.
+     * The same applies to numbers nested inside [canonicalJson].
      *
      * ## Nested values
      *

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/JSONResponseParserParityTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/JSONResponseParserParityTests.kt
@@ -4,43 +4,33 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 /**
- * Pins the ONE deliberate value-normalization divergence from Swift — a Swift
- * bug this port does not copy.
+ * Pins the value-normalization contract against Swift — where the two engines
+ * agree, and the one place they deliberately still do not.
  *
- * ## What Swift does
+ * ## The Bool-bridge divergence — closed by #1150
  *
- * `JSONResponseParser.normalizeValues` checks `value as? Bool` **before**
- * `as? NSNumber`, commented "Check Bool before NSNumber — Bool bridges to
- * NSNumber in ObjC". The intent is to catch JSON `true`/`false`. The effect is
- * wider: `NSNumber` -> `Bool` bridging succeeds for exactly 0 and 1, so numeric
- * `0` and `1` (and `0.0` / `1.0`) are swallowed by the Bool branch.
+ * Swift's `JSONResponseParser.normalizeValues` used to check `value as? Bool`
+ * **before** `as? NSNumber`, intending to catch JSON `true`/`false`. The guard
+ * was wider than the intent: `NSNumber` -> `Bool` bridging succeeds for exactly
+ * 0 and 1, so the numbers `0` / `1` (and `0.0` / `1.0`) were swallowed and
+ * normalized to `"false"` / `"true"`. This port never replicated it —
+ * replicating an unintended Foundation bridging quirk would have cemented it as
+ * a cross-language contract, in a language with no `NSNumber` to justify it.
  *
- * Measured on this branch, replicating Swift's exact branch order:
+ * #1150 fixed the Swift side (discriminate on `CFBooleanGetTypeID` rather than
+ * on cast success), so the integer cases agree now and are pinned on both
+ * sides — this file is no longer their only coverage.
  *
- * ```
- * 0    -> "false"   (__NSCFNumber)      2    -> "2"
- * 1    -> "true"    (__NSCFNumber)      -1   -> "-1"
- * 0.0  -> "false"   (__NSCFNumber)      0.5  -> "0.5"
- * 1.0  -> "true"    (__NSCFNumber)      true -> "true"   (__NSCFBoolean)
- * ```
+ * ## The residual divergence — float formatting, still open
  *
- * ## Why Kotlin does not replicate it
- *
- * ADR-023 §6 makes the Swift test files the executable spec — and that spec does
- * **not** pin this. The only numeric case is `{"score": 42, "ratio": 3.14}`,
- * values that (by luck) sidestep the 0/1 range, and no test anywhere passes a
- * numeric 0 or 1 through the parser. The behaviour is untested, incidental, and
- * contradicts its own test's name: "Numeric values normalized to String" is
- * exactly what does *not* happen to `1`.
- *
- * Replicating it would cement an unintended Foundation bridging quirk as a
- * **cross-language contract**, in a language with no `NSNumber` to justify it.
- *
- * **Tracked as #1150** (with a verified fix: discriminate on `CFBooleanGetTypeID`
- * rather than on cast success). When that lands, the four divergence tests below
- * become *agreement* tests — Swift will return `"1"` / `"0"` too. Update this
- * doc-comment and their names then; **do not** change the expectations, which are
- * already the correct values.
+ * The fix did NOT make `1.0` / `0.0` agree: Swift yields `"1"` / `"0"` because
+ * `NSNumber.stringValue` normalizes the literal, while kotlinx's
+ * `JsonPrimitive.content` preserves it. Same number, different text — and
+ * `fields` is a `[String: String]`, so the text is what ships. Those two cases
+ * only changed divergence *class*, from the Bool bridge to formatting; they
+ * live under "Known Kotlin-side literal-preservation differences" below,
+ * alongside `1e3`. Out of #1150's scope — ADR-023 Stage 4 should decide the
+ * formatting rule once, for both engines.
  *
  * ## Reachability
  *
@@ -58,32 +48,18 @@ class JSONResponseParserParityTests {
 
     private fun field(raw: String): String? = parser.parse("""{"a":$raw}""").fields["a"]
 
-    // MARK: - The divergent range: numeric 0 and 1
+    // MARK: - The former Bool-bridge window: numeric 0 and 1 (agreeing since #1150)
 
     @Test
-    fun numericOneStaysNumericUnlikeSwift() {
-        // Swift measured: "true".
+    fun numericOneAgreesWithSwift() {
+        // Swift returned "true" before #1150.
         assertEquals("1", field("1"))
     }
 
     @Test
-    fun numericZeroStaysNumericUnlikeSwift() {
-        // Swift measured: "false".
+    fun numericZeroAgreesWithSwift() {
+        // Swift returned "false" before #1150.
         assertEquals("0", field("0"))
-    }
-
-    @Test
-    fun floatOneStaysNumericUnlikeSwift() {
-        // Swift measured: "true". Note Kotlin also preserves the literal `.0`,
-        // where Swift's NSNumber.stringValue would render "1" for 1.0 had the
-        // Bool branch not caught it first.
-        assertEquals("1.0", field("1.0"))
-    }
-
-    @Test
-    fun floatZeroStaysNumericUnlikeSwift() {
-        // Swift measured: "false".
-        assertEquals("0.0", field("0.0"))
     }
 
     // MARK: - The agreeing range — outside the Bool-bridge window
@@ -99,7 +75,8 @@ class JSONResponseParserParityTests {
 
     @Test
     fun realBooleansAgreeWithSwift() {
-        // The branch's actual intent, and the part that is correct on both sides.
+        // The branch's actual intent, and the part that was correct on both sides
+        // all along — #1150 preserved it via the CFBooleanGetTypeID check.
         assertEquals("true", field("true"))
         assertEquals("false", field("false"))
     }
@@ -112,6 +89,21 @@ class JSONResponseParserParityTests {
     }
 
     // MARK: - Known Kotlin-side literal-preservation differences
+
+    @Test
+    fun floatOneDivergesInFormattingNotValue() {
+        // Swift measured post-#1150: "1" — NSNumber.stringValue drops the `.0`.
+        // Before #1150 this case diverged for a different reason (the Bool
+        // branch caught it and returned "true"); the fix moved it into the
+        // formatting class below, it did not close it.
+        assertEquals("1.0", field("1.0"))
+    }
+
+    @Test
+    fun floatZeroDivergesInFormattingNotValue() {
+        // Swift measured post-#1150: "0". Same formatting class as `1.0` above.
+        assertEquals("0.0", field("0.0"))
+    }
 
     @Test
     fun exponentNotationDivergesInFormattingNotValue() {


### PR DESCRIPTION
## Summary

- `normalizeValues` checked `as? Bool` before `as? NSNumber`. The comment was right that Bool bridges to NSNumber in ObjC, but the guard was wider than the intent: `NSNumber -> Bool` casting succeeds for exactly 0 and 1, so the JSON numbers `0`/`1`/`0.0`/`1.0` were normalized to `"false"`/`"true"`. Now discriminates on `CFGetTypeID(n) == CFBooleanGetTypeID()`.
- Reconciles the two Kotlin `#1150` doc-comments with post-fix reality. **No expectation values changed.**
- Adds two lessons to `.claude/rules/knowledge-layering.md` § "Rule-writing self-check" (bundled by request; both are verification lessons that land in that one section).

A detail worth flagging for review: `__NSCFBoolean.stringValue` is `"1"`/`"0"`, **not** `"true"`/`"false"`. So the CF branch is load-bearing rather than redundant, and the pre-existing `normalizesBooleanValues` test is a real negative control for it — deleting the branch reds it.

## The Kotlin rename is narrower than the issue said

The parity file instructed that when #1150 lands, all four divergence tests become agreement tests. That holds for the **integers only**. Post-fix Swift renders `1.0`/`0.0` as `"1"`/`"0"` (`NSNumber.stringValue` drops the `.0`), while this port preserves `"1.0"`/`"0.0"`. Those two did not close — they changed divergence *class*, from the Bool bridge to float **formatting**, which is out of scope here and deferred to ADR-023 Stage 4.

So: only the two integer tests were renamed to agreement; the two float tests moved down to "Known Kotlin-side literal-preservation differences" beside the `1e3` case. Nothing would have gone red had the wrong rename shipped — the expectations are unchanged by design, so the executable spec is blind to a false test *name*.

## The rules additions, and why both are here

| Lesson | Shape | Lands as |
|---|---|---|
| A defect framed as **live** may be a guard's rationale — grep every *writer*, not the reader. Subjunctive mood is the tell (#1151) | Someone else's claim, plan-lock time, verified by grep | a table row, next to its inverse ("framed dead → actually load-bearing") |
| A why-comment **you author** asserts library behaviour and nobody executes it (#1152) | Your own claim, implementation time, verified by deleting the mechanism | a sibling subsection — a construct-and-observe check has no `Verify by` cell |

The first came from a parallel session (#1151 / #1153). `### Apply` is retitled `### Apply (verification table)` so its "paste the command into Bash" procedure doesn't appear to scope the new peer subsection.

**This PR is its own case study.** Review caught three false claims in it, all of the shape the new subsection governs — including the same why-comment twice: an unverified `nonisolated`-is-load-bearing claim, then a *replacement* that invented a mechanism to fit the counter-examples and wore a "verified" badge while doing it. The final text keeps the measured diagnostic and states plainly that the distinguishing variable was not isolated. The rule's own author needed the check twice, which is the strongest argument for the rule.

## Out of scope (deliberate)

- **Float/exponent formatting divergence** — `1.0` → Swift `"1"` vs Kotlin `"1.0"`; `1e3` → `"1000"` vs `"1e3"`. Same number, different text; `fields` is `[String: String]`, so the text is what ships. ADR-023 Stage 4 should decide the rule once for both engines.
- **Not in this PR (different repo)**: the generalized mirror at `~/Work/dotfiles/claude/rules/knowledge-layering.md` needs both lessons — each is a principle change per that file's concept-level pairing header. Landing as a direct commit referencing this PR, before merge.

## Note on the file split

`normalizeValues` moved to `JSONResponseParser+Normalize.swift`: the original sat at the 400-line `file_length` cap **exactly**, leaving zero room for a why-comment. Trimming the comment to fit would have contradicted the rule this same PR adds. Follows the `LlamaCppService+*.swift` precedent in that directory. Access widened `private` → internal because a sibling-file extension cannot expose a `private` member to the declaring file's callers.

## Reviewer proposal, not taken here

Review suggested a cheat-sheet entry for `.claude/agents/code-reviewer.md`: *`NSNumber` → `Bool` casting succeeds for exactly 0 and 1; never order `as? Bool` ahead of `as? NSNumber` on JSONSerialization output; corollary, `__NSCFBoolean.stringValue` is `"1"`/`"0"`.* Left out — different lesson, different file, and this PR already carries two rule additions. Worth a follow-up if you want it.

## Test plan

- [x] New tests pin the full measured matrix: `0`/`1`/`0.0`/`1.0` → `"0"`/`"1"`/`"0"`/`"1"`; existing `normalizesBooleanValues` extended as the documented negative control
- [x] Confirmed red before the fix (4 assertions), green after
- [x] Delete-and-test probe on the CF branch → reds `normalizesBooleanValues`, proving the mechanism is covered not assumed
- [x] Delete-and-build probe on `nonisolated` → fails at the `tryParse` callsite, proving the annotation is load-bearing
- [x] Full unit suite: 3130 tests / 258 suites green
- [x] `swiftlint lint --quiet --strict` clean
- [x] `swift build` (ADR-013 harness — `Package.swift` compiles `LLM/`, which neither `scripts/xcodebuild.sh` nor pre-commit builds)
- [x] `./gradlew :shared:engine:jvmTest` green; `assertEquals` lines byte-identical to main

## Device QA

実機QA不要 — parser pure logic + Kotlin doc-comments + rules files; no `#if !targetEnvironment(simulator)` block, no Metal / llama.cpp inference path, no view tree touched.

Closes #1150