### PR TITLE
✨ feat: FM permissive-guardrails re-run + harness diagnostics channel (#1072)

### DIFF
--- a/.claude/skills/model-eval/tests/run_tests.sh
+++ b/.claude/skills/model-eval/tests/run_tests.sh
@@ -169,4 +169,55 @@ if grep -q -- "--profile" "$ARGV2"; then
   fail "run_scenario: --profile should NOT be passed without the 5th arg"
 fi
 
+# --- run_scenario.sh --backend / --guardrails canary (#1072) ----------------
+# The foundation-models re-run drives these; they are trailing FLAGS, so they
+# must be reachable without a profile placeholder, and `-` must suppress
+# --model (FM has no GGUF file).
+ARGV3="$TMP/argv3.log"
+STATUS3=$(
+  cd "$REPO_ROOT" && \
+  PASTURA_HARNESS_BIN="$FAKE_BIN" FAKE_ARGV_CAPTURE="$ARGV3" \
+  bash .claude/skills/scenario-factory/scripts/run_scenario.sh \
+    "$DUMMY_YAML" - "$TMP/out3.jsonl" 60 --backend foundation-models --guardrails permissive
+)
+printf '%s' "$STATUS3" | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['status']=='ok', d" \
+  || fail "run_scenario: fm canary expected status ok, got: $STATUS3"
+grep -q -- "--backend foundation-models" "$ARGV3" \
+  || fail "run_scenario: --backend not passed through argv"
+grep -q -- "--guardrails permissive" "$ARGV3" \
+  || fail "run_scenario: --guardrails not passed through argv"
+if grep -q -- "--model" "$ARGV3"; then
+  fail "run_scenario: --model must be omitted when the model arg is '-'"
+fi
+if grep -q -- "--profile" "$ARGV3"; then
+  fail "run_scenario: --profile should NOT be passed when only trailing flags follow timeout"
+fi
+
+# trailing flags must not disturb the llama-cpp default path
+ARGV4="$TMP/argv4.log"
+STATUS4=$(
+  cd "$REPO_ROOT" && \
+  PASTURA_HARNESS_BIN="$FAKE_BIN" FAKE_ARGV_CAPTURE="$ARGV4" \
+  bash .claude/skills/scenario-factory/scripts/run_scenario.sh \
+    "$DUMMY_YAML" "$DUMMY_GGUF" "$TMP/out4.jsonl" 60 gemma-4-e2b --guardrails permissive
+)
+printf '%s' "$STATUS4" | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['status']=='ok', d" \
+  || fail "run_scenario: profile+flag canary expected status ok, got: $STATUS4"
+grep -q -- "--model $DUMMY_GGUF" "$ARGV4" \
+  || fail "run_scenario: --model must still pass through alongside trailing flags"
+grep -q -- "--profile gemma-4-e2b" "$ARGV4" \
+  || fail "run_scenario: --profile must still pass through alongside trailing flags"
+grep -q -- "--guardrails permissive" "$ARGV4" \
+  || fail "run_scenario: --guardrails not passed through after a profile positional"
+
+# an unknown trailing flag is a usage error (exit 2), not a silent drop
+if (
+  cd "$REPO_ROOT" && \
+  PASTURA_HARNESS_BIN="$FAKE_BIN" FAKE_ARGV_CAPTURE="$TMP/argv5.log" \
+  bash .claude/skills/scenario-factory/scripts/run_scenario.sh \
+    "$DUMMY_YAML" - "$TMP/out5.jsonl" 60 --bogus x >/dev/null 2>&1
+); then
+  fail "run_scenario: unknown trailing flag should exit non-zero"
+fi
+
 echo "ALL TESTS PASSED"

--- a/.claude/skills/scenario-factory/scripts/run_scenario.sh
+++ b/.claude/skills/scenario-factory/scripts/run_scenario.sh
@@ -148,10 +148,13 @@ if [ $# -gt 0 ] && [ "${1#--}" = "$1" ]; then PROFILE="$1"; shift; fi
 
 BACKEND=""
 GUARDRAILS=""
+# An explicitly-empty value is a caller bug, not an intent: `-`/empty carries a
+# deliberate sentinel meaning for <model.gguf> above, so silently dropping an
+# empty flag here would be the one inconsistent reading.
 while [ $# -gt 0 ]; do
   case "$1" in
-    --backend) [ $# -ge 2 ] || usage; BACKEND=$2; shift 2 ;;
-    --guardrails) [ $# -ge 2 ] || usage; GUARDRAILS=$2; shift 2 ;;
+    --backend) [ $# -ge 2 ] && [ -n "$2" ] || usage; BACKEND=$2; shift 2 ;;
+    --guardrails) [ $# -ge 2 ] && [ -n "$2" ] || usage; GUARDRAILS=$2; shift 2 ;;
     *) usage ;;
   esac
 done

--- a/.claude/skills/scenario-factory/scripts/run_scenario.sh
+++ b/.claude/skills/scenario-factory/scripts/run_scenario.sh
@@ -2,13 +2,23 @@
 # Crash-tolerant single-scenario runner for the /scenario-factory skill.
 #
 # usage:
-#   run_scenario.sh <scenario.yaml> <model.gguf> <out.jsonl> [timeout_sec=600] [profile_id]
+#   run_scenario.sh <scenario.yaml> <model.gguf> <out.jsonl> [timeout_sec=600] \
+#                   [profile_id] [--backend <id>] [--guardrails <id>]
 #   run_scenario.sh --classify <out.jsonl> <exit_code>
 #
 # [profile_id], when non-empty, is passed through to the harness as
 # `--profile "$PROFILE"` (selects the harness's prompt-format hints; default
 # "gemma"). Positional args, so passing a profile requires also passing
 # timeout_sec explicitly.
+#
+# --backend / --guardrails are TRAILING FLAGS, not further positionals: making
+# them positional #6/#7 would force every foundation-models caller to also
+# supply a timeout and a meaningless profile_id just to reach them.
+#
+# <model.gguf> accepts `-` (or an empty string) for backends that have no GGUF
+# file — `--model` is then omitted from the harness argv entirely, so the
+# harness's own backend-aware check stays the single authority: required for
+# llama-cpp (exit 2 -> config_error), ignored for foundation-models.
 #
 # Run from the repository root (Package.swift must be in the cwd).
 # Emits exactly one JSON status line on stdout. Harness stderr goes to
@@ -49,7 +59,10 @@ RUN_START_WAIT_SEC=90   # run_start poll budget; build is done beforehand
 usage() {
   cat >&2 <<'EOF'
 usage: run_scenario.sh <scenario.yaml> <model.gguf> <out.jsonl> [timeout_sec=600] [profile_id]
+                       [--backend <id>] [--guardrails <id>]
        run_scenario.sh --classify <out.jsonl> <exit_code>
+
+<model.gguf> may be `-` for a backend with no GGUF file (e.g. foundation-models).
 EOF
   exit 2
 }
@@ -120,12 +133,28 @@ if [ "${1:-}" = "--classify" ]; then
   exit 0
 fi
 
-[ $# -ge 3 ] && [ $# -le 5 ] || usage
+[ $# -ge 3 ] || usage
 SCENARIO=$1
 MODEL=$2
 OUT=$3
-TIMEOUT=${4:-600}
-PROFILE="${5:-}"
+shift 3
+
+# Optional positionals come first and stop at the first `--`-prefixed token,
+# so the trailing flags below stay reachable without dummy placeholders.
+TIMEOUT=600
+PROFILE=""
+if [ $# -gt 0 ] && [ "${1#--}" = "$1" ]; then TIMEOUT="${1:-600}"; shift; fi
+if [ $# -gt 0 ] && [ "${1#--}" = "$1" ]; then PROFILE="$1"; shift; fi
+
+BACKEND=""
+GUARDRAILS=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --backend) [ $# -ge 2 ] || usage; BACKEND=$2; shift 2 ;;
+    --guardrails) [ $# -ge 2 ] || usage; GUARDRAILS=$2; shift 2 ;;
+    *) usage ;;
+  esac
+done
 [ -f Package.swift ] || { echo "run from the repository root (Package.swift not found)" >&2; exit 2; }
 
 mkdir -p "$(dirname "$OUT")"
@@ -152,8 +181,17 @@ if [ ! -x "$BIN" ]; then
   exit 0
 fi
 
-ARGS=(--scenario "$SCENARIO" --model "$MODEL" --out "$OUT" --timeout "$TIMEOUT" --quiet)
+ARGS=(--scenario "$SCENARIO" --out "$OUT" --timeout "$TIMEOUT" --quiet)
+# `-` / empty means "this backend has no GGUF file" — omit the flag rather than
+# passing `--model ""`, so the harness's backend-aware requirement check is the
+# one that speaks (see header).
+case "$MODEL" in
+  ""|-) ;;
+  *) ARGS+=(--model "$MODEL") ;;
+esac
 if [ -n "$PROFILE" ]; then ARGS+=(--profile "$PROFILE"); fi
+if [ -n "$BACKEND" ]; then ARGS+=(--backend "$BACKEND"); fi
+if [ -n "$GUARDRAILS" ]; then ARGS+=(--guardrails "$GUARDRAILS"); fi
 "$BIN" "${ARGS[@]}" 2>"$STDERR_LOG" &
 PID=$!
 

--- a/Pastura/Pastura/Engine/LLMCaller+Logging.swift
+++ b/Pastura/Pastura/Engine/LLMCaller+Logging.swift
@@ -15,7 +15,12 @@ nonisolated extension LLMCaller {
   /// Emit the parse-failure log lines (engineering channel + DEBUG
   /// console fallback). Extracted to keep `call` under the lint
   /// `function_body_length` budget.
-  func logParseFailure(raw: String, attempt: Int) {
+  /// - Note: `agent=` is load-bearing for the harness's stderr diagnostics
+  ///   channel: the terminal failure of a turn does NOT emit a following
+  ///   `retryCause` line (`call` throws instead), so a reader cannot recover
+  ///   the agent by scanning neighbours — the record has to name itself.
+  ///   `raw=` stays the trailing token because it is unbounded and multi-line.
+  func logParseFailure(agent: String, raw: String, attempt: Int) {
     // `raw` may echo user-authored scenario / persona content via malformed
     // LLM output, but the same data is already persisted on-device to
     // `TurnRecord.rawOutput` (ADR-001), so OSLog exposure is consistent with
@@ -23,13 +28,13 @@ nonisolated extension LLMCaller {
     // TestFlight / Release builds.
     logger.log(
       .warning, category: Self.logCategory,
-      "JSON parse failed (attempt \(attempt + 1)/\(Self.maxRetries + 1)): raw=\(raw.prefix(500))",
+      "JSON parse failed agent=\(agent) (attempt \(attempt + 1)/\(Self.maxRetries + 1)): raw=\(raw.prefix(500))",
       privacy: .public
     )
     #if DEBUG
       // print() for reliable Xcode console visibility (os.Logger may be filtered)
       print(
-        "[LLMCaller] JSON parse failed (attempt \(attempt + 1)/\(Self.maxRetries + 1)): raw=\(raw.prefix(500))"
+        "[LLMCaller] JSON parse failed agent=\(agent) (attempt \(attempt + 1)/\(Self.maxRetries + 1)): raw=\(raw.prefix(500))"
       )
     #endif
   }

--- a/Pastura/Pastura/Engine/LLMCaller.swift
+++ b/Pastura/Pastura/Engine/LLMCaller.swift
@@ -131,7 +131,7 @@ nonisolated struct LLMCaller: Sendable {
       // bucket repair effects against pre-PR baselines.
       guard let parseResult = try? parser.parse(raw, expectedKeys: expectedKeys)
       else {
-        logParseFailure(raw: raw, attempt: attempt)
+        logParseFailure(agent: agentName, raw: raw, attempt: attempt)
         if attempt < Self.maxRetries {
           emitRetryCause(agent: agentName, attempt: attempt + 1, cause: "parse_failed")
           continue

--- a/Pastura/Pastura/LLM/FoundationModelsService.swift
+++ b/Pastura/Pastura/LLM/FoundationModelsService.swift
@@ -33,8 +33,22 @@
 
     /// Creates a service over a system language model.
     ///
+    /// Guardrail mode is injected through this parameter rather than being a
+    /// setting of its own — pass `SystemLanguageModel(guardrails:)`:
+    ///
+    /// ```swift
+    /// FoundationModelsService(
+    ///   model: SystemLanguageModel(guardrails: .permissiveContentTransformations))
+    /// ```
+    ///
+    /// The default (`.default` guardrails) is what spike #1072's first battery
+    /// measured, and its "Apple offers no guardrail adjustment API" conclusion
+    /// was wrong precisely because no caller ever passed anything else. The
+    /// harness selects the mode via `--guardrails`.
+    ///
     /// - Parameter model: The system model to drive. Defaults to
-    ///   ``SystemLanguageModel/default`` (the general-purpose base model).
+    ///   ``SystemLanguageModel/default`` (the general-purpose base model with
+    ///   default guardrails).
     public init(model: SystemLanguageModel = .default) {
       self.model = model
       self.loadedState = OSAllocatedUnfairLock(initialState: false)
@@ -83,8 +97,20 @@
     /// already instructs JSON and ``JSONResponseParser`` carries the field
     /// contract. Consequence for the #1072 evaluation phase: FM parse-failure
     /// rates are **not** apples-to-apples with the GBNF-grammar-constrained
-    /// ``LlamaCppService`` — guided generation is a defensible follow-up, not
-    /// spike scope.
+    /// ``LlamaCppService``.
+    ///
+    /// - Warning: **Adopting `@Generable` guided generation would silently
+    ///   re-enable the default guardrails**, undoing the permissive mode this
+    ///   backend is being re-evaluated under. Per Apple, permissive guardrails
+    ///   "only work for generating a string value. When you use guided
+    ///   generation, the framework runs the default guardrails against model
+    ///   input and output as usual." This service returns `response.content`
+    ///   (a plain `String`), which is the only shape permissive mode covers.
+    ///   So guided generation is not the free win #1072's first digest called
+    ///   it — it trades JSON-validity assurance (already measured as a
+    ///   non-problem) for the return of the failure that killed the spike.
+    ///   Re-measure guardrails before adopting it.
+    ///   See: https://developer.apple.com/documentation/foundationmodels/improving-the-safety-of-generative-model-output
     ///
     /// - Throws: ``LLMError/notLoaded`` before ``loadModel()``;
     ///   ``LLMError/generationFailed(description:)`` on inference failure. The

--- a/tools/harness/Sources/PasturaHarnessKit/HarnessConfig.swift
+++ b/tools/harness/Sources/PasturaHarnessKit/HarnessConfig.swift
@@ -42,18 +42,46 @@ package struct HarnessConfig: Sendable, Equatable {
   /// stay unchanged.
   package var backend: Backend = .llamaCpp
 
+  /// Apple Foundation Models guardrail mode (spike #1072 correction: Apple
+  /// exposes an adjustment API — `SystemLanguageModel.Guardrails
+  /// .permissiveContentTransformations` — the original spike wrongly assumed
+  /// there was none). This is a PLAIN enum with no `FoundationModels` import:
+  /// that framework only exists in the macOS 26 SDK, and this file must stay
+  /// buildable on toolchains without it (the CI "Harness package build" job).
+  /// FM type references live only in `Main.swift`'s `#if canImport(FoundationModels)` block.
+  package enum Guardrails: String, Sendable, Equatable, CaseIterable {
+    /// Apple's default content guardrails (unchanged behaviour).
+    case `default`
+    /// `SystemLanguageModel.Guardrails.permissiveContentTransformations`.
+    case permissive
+  }
+
+  /// Foundation Models guardrail mode. Ignored for the
+  /// ``Backend/llamaCpp`` backend, which has no guardrail concept.
+  package var guardrails: Guardrails = .default
+
   package static let usage = """
     usage: pastura-harness --scenario <path.yaml> [--model <path.gguf>] \
-    [--backend <id>] [--out <path.jsonl>] [--timeout <seconds>] [--quiet] [--profile <id>]
+    [--backend <id>] [--out <path.jsonl>] [--timeout <seconds>] [--quiet] [--profile <id>] \
+    [--guardrails <id>]
     --backend selects the inference backend (default: \(Backend.llamaCpp.rawValue); \
     also: \(Backend.foundationModels.rawValue)). --model is required for \
     \(Backend.llamaCpp.rawValue) and ignored for \(Backend.foundationModels.rawValue).
     --profile selects prompt-format hints and must match the --model file's \
     model family (default: \(ModelProfile.gemma4E2B.id))
+    --guardrails selects the Foundation Models guardrail mode (default: \
+    \(Guardrails.default.rawValue); also: \(Guardrails.permissive.rawValue)). \
+    Ignored for the \(Backend.llamaCpp.rawValue) backend.
     """
 
-  /// Parses CLI arguments (excluding argv[0]).
-  package static func parse(_ args: [String]) throws -> HarnessConfig {
+  /// Mutable accumulator for ``parse(_:)``'s argument loop.
+  ///
+  /// The arms are split across two `apply*` methods — paths vs run options —
+  /// rather than living in one switch inside `parse`. A single switch put
+  /// `parse` over the cyclomatic-complexity limit the moment `--guardrails`
+  /// was added, and folding every arm into one helper would sit exactly AT
+  /// the limit, so the next flag would break it again.
+  private struct Accumulator {
     var scenario: String?
     var model: String?
     var out: String?
@@ -61,26 +89,67 @@ package struct HarnessConfig: Sendable, Equatable {
     var quiet = false
     var profile = ModelProfile.gemma4E2B
     var backend = Backend.llamaCpp
+    var guardrails = Guardrails.default
 
-    var iterator = args.makeIterator()
-    while let arg = iterator.next() {
-      switch arg {
-      case "--scenario": scenario = try value(for: arg, from: &iterator)
-      case "--model": model = try value(for: arg, from: &iterator)
-      case "--out": out = try value(for: arg, from: &iterator)
-      case "--timeout": timeout = try parseTimeout(value(for: arg, from: &iterator))
-      case "--quiet": quiet = true
-      case "--profile": profile = try parseProfile(value(for: arg, from: &iterator))
-      case "--backend": backend = try parseBackend(value(for: arg, from: &iterator))
-      default: throw HarnessConfigError("unknown argument '\(arg)'\n\(usage)")
-      }
+    mutating func apply(
+      _ arg: String, from iterator: inout IndexingIterator<[String]>
+    ) throws {
+      if try applyPathFlag(arg, from: &iterator) { return }
+      if try applyOptionFlag(arg, from: &iterator) { return }
+      throw HarnessConfigError("unknown argument '\(arg)'\n\(usage)")
     }
 
-    guard let scenario else { throw HarnessConfigError("--scenario is required\n\(usage)") }
-    let modelPath = try resolveModelPath(model, backend: backend)
+    /// - Returns: `true` when `arg` was a path flag this consumed.
+    private mutating func applyPathFlag(
+      _ arg: String, from iterator: inout IndexingIterator<[String]>
+    ) throws -> Bool {
+      switch arg {
+      case "--scenario": scenario = try HarnessConfig.value(for: arg, from: &iterator)
+      case "--model": model = try HarnessConfig.value(for: arg, from: &iterator)
+      case "--out": out = try HarnessConfig.value(for: arg, from: &iterator)
+      default: return false
+      }
+      return true
+    }
+
+    /// - Returns: `true` when `arg` was a run-option flag this consumed.
+    private mutating func applyOptionFlag(
+      _ arg: String, from iterator: inout IndexingIterator<[String]>
+    ) throws -> Bool {
+      switch arg {
+      case "--timeout":
+        timeout = try HarnessConfig.parseTimeout(HarnessConfig.value(for: arg, from: &iterator))
+      case "--quiet": quiet = true
+      case "--profile":
+        profile = try HarnessConfig.parseProfile(HarnessConfig.value(for: arg, from: &iterator))
+      case "--backend":
+        backend = try HarnessConfig.parseBackend(HarnessConfig.value(for: arg, from: &iterator))
+      case "--guardrails":
+        guardrails = try HarnessConfig.parseGuardrails(
+          HarnessConfig.value(for: arg, from: &iterator))
+      default: return false
+      }
+      return true
+    }
+  }
+
+  /// Parses CLI arguments (excluding argv[0]).
+  package static func parse(_ args: [String]) throws -> HarnessConfig {
+    var accumulator = Accumulator()
+    var iterator = args.makeIterator()
+    while let arg = iterator.next() {
+      try accumulator.apply(arg, from: &iterator)
+    }
+
+    guard let scenario = accumulator.scenario else {
+      throw HarnessConfigError("--scenario is required\n\(usage)")
+    }
+    let modelPath = try resolveModelPath(accumulator.model, backend: accumulator.backend)
     return HarnessConfig(
-      scenarioPath: scenario, modelPath: modelPath, outPath: out,
-      timeoutSeconds: timeout, quiet: quiet, profile: profile, backend: backend)
+      scenarioPath: scenario, modelPath: modelPath, outPath: accumulator.out,
+      timeoutSeconds: accumulator.timeout, quiet: accumulator.quiet,
+      profile: accumulator.profile, backend: accumulator.backend,
+      guardrails: accumulator.guardrails)
   }
 
   /// The effective model path: `--model` is required for the GGUF-backed
@@ -128,6 +197,15 @@ package struct HarnessConfig: Sendable, Equatable {
       let knownIDs = Backend.allCases.map(\.rawValue).joined(separator: ", ")
       throw HarnessConfigError(
         "unknown --backend '\(raw)' — known backends: \(knownIDs)\n\(usage)")
+    }
+    return resolved
+  }
+
+  private static func parseGuardrails(_ raw: String) throws -> Guardrails {
+    guard let resolved = Guardrails(rawValue: raw) else {
+      let knownIDs = Guardrails.allCases.map(\.rawValue).joined(separator: ", ")
+      throw HarnessConfigError(
+        "unknown --guardrails '\(raw)' — known guardrails: \(knownIDs)\n\(usage)")
     }
     return resolved
   }

--- a/tools/harness/Sources/PasturaHarnessKit/HarnessRunner.swift
+++ b/tools/harness/Sources/PasturaHarnessKit/HarnessRunner.swift
@@ -31,15 +31,24 @@ package final class HarnessRunner: Sendable {
   private let timeoutSeconds: Int
   private let streamFactory: StreamFactory
   private let progress: (@Sendable (String) -> Void)?
-  /// `nil` when the caller injected its own `streamFactory` — the attempt
-  /// stamp is only meaningful for the stream this type wired itself.
+  /// The logger `execute` stamps the attempt on. `nil` only when a caller
+  /// injects a `streamFactory` without a logger — i.e. opts out of Engine
+  /// diagnostics.
   private let diagLogger: StderrEngineLogger?
 
+  /// - Parameters:
+  ///   - streamFactory: Overrides the production stream. `nil` builds one over
+  ///     `SimulationRunner` wired to `diagLogger`.
+  ///   - diagLogger: Receives Engine diagnostics. `nil` builds a stderr logger
+  ///     when `streamFactory` is also `nil`. Injectable so a test can hold the
+  ///     same instance `execute` stamps attempts on — otherwise the stamp is
+  ///     unreachable from any test that supplies its own `streamFactory`.
   package init(
     llmFactory: @escaping LLMFactory,
     writer: any RunLogWriting,
     timeoutSeconds: Int,
     streamFactory: StreamFactory? = nil,
+    diagLogger: StderrEngineLogger? = nil,
     progress: (@Sendable (String) -> Void)? = nil
   ) {
     self.llmFactory = llmFactory
@@ -49,13 +58,12 @@ package final class HarnessRunner: Sendable {
 
     // Resolved here rather than as a default argument: the default expression
     // cannot reference instance state, and the production stream must capture
-    // the very logger `execute` stamps attempts on. Callers that inject a
-    // `streamFactory` (tests) opt out of Engine diagnostics entirely.
+    // the very logger `execute` stamps attempts on.
     if let streamFactory {
       self.streamFactory = streamFactory
-      self.diagLogger = nil
+      self.diagLogger = diagLogger
     } else {
-      let logger = StderrEngineLogger()
+      let logger = diagLogger ?? StderrEngineLogger()
       self.diagLogger = logger
       self.streamFactory = { scenario, llm, controller in
         SimulationRunner(logger: logger).run(

--- a/tools/harness/Sources/PasturaHarnessKit/HarnessRunner.swift
+++ b/tools/harness/Sources/PasturaHarnessKit/HarnessRunner.swift
@@ -31,22 +31,37 @@ package final class HarnessRunner: Sendable {
   private let timeoutSeconds: Int
   private let streamFactory: StreamFactory
   private let progress: (@Sendable (String) -> Void)?
+  /// `nil` when the caller injected its own `streamFactory` — the attempt
+  /// stamp is only meaningful for the stream this type wired itself.
+  private let diagLogger: StderrEngineLogger?
 
   package init(
     llmFactory: @escaping LLMFactory,
     writer: any RunLogWriting,
     timeoutSeconds: Int,
-    streamFactory: @escaping StreamFactory = { scenario, llm, controller in
-      SimulationRunner().run(
-        scenario: scenario, llm: llm, suspendController: controller)
-    },
+    streamFactory: StreamFactory? = nil,
     progress: (@Sendable (String) -> Void)? = nil
   ) {
     self.llmFactory = llmFactory
     self.writer = writer
     self.timeoutSeconds = timeoutSeconds
-    self.streamFactory = streamFactory
     self.progress = progress
+
+    // Resolved here rather than as a default argument: the default expression
+    // cannot reference instance state, and the production stream must capture
+    // the very logger `execute` stamps attempts on. Callers that inject a
+    // `streamFactory` (tests) opt out of Engine diagnostics entirely.
+    if let streamFactory {
+      self.streamFactory = streamFactory
+      self.diagLogger = nil
+    } else {
+      let logger = StderrEngineLogger()
+      self.diagLogger = logger
+      self.streamFactory = { scenario, llm, controller in
+        SimulationRunner(logger: logger).run(
+          scenario: scenario, llm: llm, suspendController: controller)
+      }
+    }
   }
 
   /// Runs the scenario, writing `run_start` / `event` / `run_end` lines.
@@ -70,6 +85,9 @@ package final class HarnessRunner: Sendable {
     var attempts = 0
     for attempt in 1...2 {
       attempts = attempt
+      // Stamp before the stream starts: a retried scenario replays every
+      // diagnostic, and only this field separates the two passes.
+      diagLogger?.beginAttempt(attempt)
       switch await runAttempt(scenario: scenario, attempt: attempt) {
       case .completed:
         status = .ok

--- a/tools/harness/Sources/PasturaHarnessKit/StderrEngineLogger.swift
+++ b/tools/harness/Sources/PasturaHarnessKit/StderrEngineLogger.swift
@@ -1,0 +1,155 @@
+import Foundation
+import PasturaCore
+import Synchronization
+
+/// One Engine diagnostic, rendered as a single JSONL record.
+///
+/// Deliberately NOT part of the `RunLog` JSONL schema: `RunLog.swift` is
+/// "execution-faithful and deliberately minimal — it serializes what the
+/// Engine emitted, nothing more". Diagnostics are a *second* channel with a
+/// different lifetime, so they go to stderr and stay out of the run log the
+/// judge/digest tooling reads.
+package struct DiagLine: Codable, Sendable, Equatable {
+  package var type = "diag"
+  /// Monotonic within one process, starting at 1. The join key: the Engine
+  /// runs phases sequentially, so `seq` order IS execution order.
+  package let seq: Int
+  /// The enclosing `HarnessRunner` attempt (1 or 2). Without this, a scenario
+  /// that fails attempt 1 and reruns double-counts every diagnostic with no
+  /// way to split the two passes apart.
+  package let attempt: Int
+  package let level: String
+  package let category: String
+  package let message: String
+
+  package init(seq: Int, attempt: Int, level: String, category: String, message: String) {
+    self.seq = seq
+    self.attempt = attempt
+    self.level = level
+    self.category = category
+    self.message = message
+  }
+}
+
+/// An ``EngineLogger`` that writes one JSON record per line to stderr.
+///
+/// ## Why this exists
+///
+/// The harness previously left `SimulationRunner`'s `logger:` at its
+/// `NoopEngineLogger` default, so every Engine diagnostic was discarded. That
+/// is fine until a failure class needs to be *counted* rather than merely
+/// survived — which is exactly the Foundation Models permissive-guardrails
+/// evaluation (#1072):
+///
+/// - With **default** guardrails a refusal throws `guardrailViolation`, and
+///   `TurnFailureGate.cause(for:)` carries the error's description verbatim
+///   into the run log's `turn_skipped` line. Grep-classifiable.
+/// - With **permissive** guardrails that throw never happens (per Apple: the
+///   session "never throws a guardrailViolation error when generating string
+///   responses" — the model returns a refusal *as content* instead). The
+///   refusal then fails JSON parsing and `cause(for:)` falls through to the
+///   literal `"retries exhausted"` — byte-identical to an ordinary malformed
+///   -JSON failure.
+///
+/// So the run log alone cannot tell a refusal from a parse failure, and an
+/// A/B across guardrail modes would compare a labelled arm against an
+/// unlabelled one. `LLMCaller.logParseFailure` already hands the raw model
+/// output to this seam; capturing it is what makes the refusal countable.
+/// Classification stays *post-hoc* and evidence-bearing (the raw text is in
+/// the record) rather than being asserted by a locale-fragile prefix match
+/// inside a production service.
+///
+/// ## Reading the output
+///
+/// `run_scenario.sh` already redirects stderr to `${OUT%.jsonl}.stderr.log`.
+/// One record per line — `message` is JSON-escaped, so a multi-line model
+/// output cannot smear one diagnostic across many lines and inflate a
+/// `grep -c`.
+///
+/// ## Counting rule (load-bearing)
+///
+/// **Never count these records.** One logical failure appears up to
+/// `LLMCaller.maxRetries + 1` times (the retry loop logs every failed
+/// attempt), and a `HarnessRunner` rerun replays the lot — so a `grep -c` over
+/// this channel over-counts by an unstable factor.
+///
+/// The count already exists in the run log: a failed turn emits exactly one
+/// `turn_skipped` line no matter how many retries it burned. So:
+///
+/// - **How many** turns failed → the run log's `turn_skipped` lines.
+/// - **Why** each failed → these records, read as evidence.
+///
+/// That split is what makes the retry multiplicity harmless: what duplicates
+/// is the evidence, never the tally.
+///
+/// Attribution, for a diagnostic that carries no agent of its own (parse
+/// failures don't): the Engine has **no concurrency** — no `TaskGroup` /
+/// `async let` anywhere under `Pastura/Pastura/Engine/` — so records arrive in
+/// execution order and `seq` orders them against the run log. A turn's
+/// parse-failure records are bracketed by the `retryCause agent=… attempt=…
+/// cause=…` records `LLMCaller` emits around the same retry loop, which is
+/// where the agent name comes from.
+package final class StderrEngineLogger: EngineLogger {
+  private struct State {
+    var seq = 0
+    var attempt = 1
+  }
+
+  private let state = Mutex(State())
+  private let sink: @Sendable (String) -> Void
+
+  /// - Parameter sink: Where a rendered record goes. Defaults to stderr;
+  ///   injectable so tests capture records without touching the process's
+  ///   real file descriptors.
+  package init(sink: (@Sendable (String) -> Void)? = nil) {
+    self.sink =
+      sink
+      ?? { line in
+        FileHandle.standardError.write(Data((line + "\n").utf8))
+      }
+  }
+
+  /// Stamps subsequent records with the enclosing harness attempt.
+  ///
+  /// Called by ``HarnessRunner`` at the top of each attempt. The attempt is
+  /// carried here rather than threaded through `StreamFactory` so the factory
+  /// signature — and every test that injects one — stays unchanged.
+  package func beginAttempt(_ attempt: Int) {
+    state.withLock { $0.attempt = attempt }
+  }
+
+  package func log(
+    _ level: EngineLogLevel,
+    category: String,
+    _ message: String,
+    privacy: EngineLogPrivacy
+  ) {
+    // `privacy` is intentionally ignored: it governs OSLog redaction in
+    // off-device TestFlight / Release captures. This logger only ever runs in
+    // a local developer harness, where capturing the real content verbatim is
+    // the entire point — a redacted `<private>` parse failure would defeat it.
+    _ = privacy
+
+    let (seq, attempt) = state.withLock { state -> (Int, Int) in
+      state.seq += 1
+      return (state.seq, state.attempt)
+    }
+    let line = DiagLine(
+      seq: seq, attempt: attempt, level: Self.name(for: level),
+      category: category, message: message)
+    // A diagnostic that cannot be encoded is dropped rather than crashing the
+    // run — the run log is the primary artifact; this channel is advisory.
+    guard let encoded = try? JSONL.encode(line) else { return }
+    sink(encoded)
+  }
+
+  /// No `default:` — a new ``EngineLogLevel`` must be named here rather than
+  /// silently folding into an existing bucket and skewing a diagnostic count.
+  private static func name(for level: EngineLogLevel) -> String {
+    switch level {
+    case .debug: return "debug"
+    case .info: return "info"
+    case .warning: return "warning"
+    }
+  }
+}

--- a/tools/harness/Sources/PasturaHarnessKit/StderrEngineLogger.swift
+++ b/tools/harness/Sources/PasturaHarnessKit/StderrEngineLogger.swift
@@ -10,7 +10,8 @@ import Synchronization
 /// different lifetime, so they go to stderr and stay out of the run log the
 /// judge/digest tooling reads.
 package struct DiagLine: Codable, Sendable, Equatable {
-  package var type = "diag"
+  /// Schema discriminator — a constant, never set per-record.
+  package let type = "diag"
   /// Monotonic within one process, starting at 1. The join key: the Engine
   /// runs phases sequentially, so `seq` order IS execution order.
   package let seq: Int
@@ -54,10 +55,14 @@ package struct DiagLine: Codable, Sendable, Equatable {
 /// So the run log alone cannot tell a refusal from a parse failure, and an
 /// A/B across guardrail modes would compare a labelled arm against an
 /// unlabelled one. `LLMCaller.logParseFailure` already hands the raw model
-/// output to this seam; capturing it is what makes the refusal countable.
+/// output to this seam; capturing it is what makes the refusal classifiable.
 /// Classification stays *post-hoc* and evidence-bearing (the raw text is in
 /// the record) rather than being asserted by a locale-fragile prefix match
 /// inside a production service.
+///
+/// - Note: `LLMCaller` truncates the captured output at `raw.prefix(500)`, so
+///   a long response arrives clipped — read a mid-token ending as truncation,
+///   not as the model stopping there. A refusal is short enough to survive.
 ///
 /// ## Reading the output
 ///
@@ -71,24 +76,46 @@ package struct DiagLine: Codable, Sendable, Equatable {
 /// **Never count these records.** One logical failure appears up to
 /// `LLMCaller.maxRetries + 1` times (the retry loop logs every failed
 /// attempt), and a `HarnessRunner` rerun replays the lot — so a `grep -c` over
-/// this channel over-counts by an unstable factor.
+/// this channel over-counts by an unstable factor. The tally lives in the run
+/// log; these records only answer **why**. What duplicates is the evidence,
+/// never the tally.
 ///
-/// The count already exists in the run log: a failed turn emits exactly one
-/// `turn_skipped` line no matter how many retries it burned. So:
+/// The tally is NOT simply `count(turn_skipped)`. Two carve-outs, both of
+/// which bite the #1072 battery:
 ///
-/// - **How many** turns failed → the run log's `turn_skipped` lines.
-/// - **Why** each failed → these records, read as evidence.
+/// 1. **The breaker's tripping turn is never logged.** `TurnFailureGate` throws
+///    `turnFailureLimitReached` at the 3rd *consecutive* skip and returns
+///    before `emitter(.turnSkipped(...))`, so that turn produces evidence here
+///    but no tally line. A run whose `run_end` carries that error therefore
+///    has `count(turn_skipped) + 1` failures — and it is **truncated**, so its
+///    refusal *rate* is a lower bound, not a rate. (The counter resets on every
+///    success, so the tally is not capped at 2: #1072's word_wolf-ja logged 9
+///    skips before three landed back-to-back.)
+/// 2. **`narrate` is outside the tally entirely.** `NarrateHandler` degrades by
+///    omission and deliberately bypasses the gate — no `.turnSkipped`, no
+///    breaker increment (#909) — yet it drives its own `LLMCaller`, so a
+///    narrator refusal DOES appear here. `word_wolf.yaml` / `word_wolf_en.yaml`
+///    both carry a `narrate` phase, so 2 of the 6 battery cells will show
+///    narrator evidence with no matching tally line. Count `agent=` narrator
+///    records separately; do not fold them into the agent-turn rate.
 ///
-/// That split is what makes the retry multiplicity harmless: what duplicates
-/// is the evidence, never the tally.
+/// Both guardrail arms ARE gate-degradable, so their tallies are comparable:
+/// `FoundationModelsService.map` turns `guardrailViolation` into
+/// `LLMError.generationFailed`, which `streamFailureError` wraps as
+/// `SimulationError.llmGenerationFailed` — one of the two cases
+/// `TurnFailureGate.isTurnDegradable` accepts.
 ///
-/// Attribution, for a diagnostic that carries no agent of its own (parse
-/// failures don't): the Engine has **no concurrency** — no `TaskGroup` /
-/// `async let` anywhere under `Pastura/Pastura/Engine/` — so records arrive in
-/// execution order and `seq` orders them against the run log. A turn's
-/// parse-failure records are bracketed by the `retryCause agent=… attempt=…
-/// cause=…` records `LLMCaller` emits around the same retry loop, which is
-/// where the agent name comes from.
+/// ## Attribution
+///
+/// Records self-attribute: `LLMCaller`'s parse-failure line carries
+/// `agent=…`. Do NOT try to recover the agent by scanning neighbouring
+/// `retryCause` records — a turn's *terminal* failure emits no trailing
+/// `retryCause` (`call` throws instead), so the next record on the channel
+/// belongs to the next agent.
+///
+/// Ordering: the Engine has **no concurrency** — no `TaskGroup` / `async let`
+/// anywhere under `Pastura/Pastura/Engine/` — so records arrive in execution
+/// order and `seq` orders them against the run log.
 package final class StderrEngineLogger: EngineLogger {
   private struct State {
     var seq = 0

--- a/tools/harness/Sources/PasturaHarnessKit/StderrEngineLogger.swift
+++ b/tools/harness/Sources/PasturaHarnessKit/StderrEngineLogger.swift
@@ -73,24 +73,38 @@ package struct DiagLine: Codable, Sendable, Equatable {
 ///
 /// ## Counting rule (load-bearing)
 ///
-/// **Never count these records.** One logical failure appears up to
-/// `LLMCaller.maxRetries + 1` times (the retry loop logs every failed
-/// attempt), and a `HarnessRunner` rerun replays the lot — so a `grep -c` over
-/// this channel over-counts by an unstable factor. The tally lives in the run
-/// log; these records only answer **why**. What duplicates is the evidence,
-/// never the tally.
+/// **One record is one failed SAMPLE, never one failed turn.** A turn burns up
+/// to `LLMCaller.maxRetries + 1` samples and logs each one, and a
+/// `HarnessRunner` rerun replays the lot — so a `grep -c` here answers "how
+/// many samples failed", and answers "how many turns failed" wrong by an
+/// unstable factor. Pick the unit deliberately; both are useful and they are
+/// not interchangeable:
 ///
-/// The tally is NOT simply `count(turn_skipped)`. Two carve-outs, both of
+/// - **Failed turns** → the run log's `turn_skipped` lines, with the two
+///   carve-outs below.
+/// - **Failed samples** → these records, one apiece. This is the unit the two
+///   guardrail arms can actually be compared in — see below.
+/// - **Why any of them failed** → these records' raw text.
+///
+/// Deduplicate by `attempt` first, or a reran scenario counts everything twice
+/// in either unit.
+///
+/// The turn tally is NOT simply `count(turn_skipped)`. Two carve-outs, both of
 /// which bite the #1072 battery:
 ///
 /// 1. **The breaker's tripping turn is never logged.** `TurnFailureGate` throws
 ///    `turnFailureLimitReached` at the 3rd *consecutive* skip and returns
 ///    before `emitter(.turnSkipped(...))`, so that turn produces evidence here
-///    but no tally line. A run whose `run_end` carries that error therefore
-///    has `count(turn_skipped) + 1` failures — and it is **truncated**, so its
-///    refusal *rate* is a lower bound, not a rate. (The counter resets on every
-///    success, so the tally is not capped at 2: #1072's word_wolf-ja logged 9
-///    skips before three landed back-to-back.)
+///    but no tally line. Key the correction **per attempt, not per run**: the
+///    `attempt` whose `event:"error"` line names `turnFailureLimitReached` has
+///    `count(turn_skipped) + 1` failures and is **truncated**, so its refusal
+///    *rate* is a lower bound. Reading `run_end` instead would miss the case
+///    the `attempt` field exists for — `HarnessRunner` reruns a failed attempt,
+///    so a breaker trip on attempt 1 followed by a clean attempt 2 leaves
+///    `run_end` at `status:"ok", error:null` with attempt 1's truncated pass
+///    still sitting in the log. (The counter resets on every success, so the
+///    tally is not capped at 2: #1072's word_wolf-ja logged 9 skips before
+///    three landed back-to-back.)
 /// 2. **`narrate` is outside the tally entirely.** `NarrateHandler` degrades by
 ///    omission and deliberately bypasses the gate — no `.turnSkipped`, no
 ///    breaker increment (#909) — yet it drives its own `LLMCaller`, so a
@@ -99,11 +113,38 @@ package struct DiagLine: Codable, Sendable, Equatable {
 ///    narrator evidence with no matching tally line. Count `agent=` narrator
 ///    records separately; do not fold them into the agent-turn rate.
 ///
-/// Both guardrail arms ARE gate-degradable, so their tallies are comparable:
-/// `FoundationModelsService.map` turns `guardrailViolation` into
-/// `LLMError.generationFailed`, which `streamFailureError` wraps as
-/// `SimulationError.llmGenerationFailed` — one of the two cases
-/// `TurnFailureGate.isTurnDegradable` accepts.
+/// ## Do not compare the two arms' `turn_skipped` counts
+///
+/// Both arms are gate-degradable — `FoundationModelsService.map` turns
+/// `guardrailViolation` into `LLMError.generationFailed`, which
+/// `streamFailureError` wraps as `SimulationError.llmGenerationFailed`, one of
+/// the two cases `TurnFailureGate.isTurnDegradable` accepts — but that only
+/// means both reach the gate. **Their skipped turns do not mean the same
+/// thing**, because the refusal class gets a different retry budget in each:
+///
+/// - **Default arm**: the refusal *throws*. `shouldRetryStreamFailure` retries
+///   only `samplerCrashCaught`, so the turn is skipped after **1** sample.
+///   `turn_skipped` = "the first sample refused".
+/// - **Permissive arm**: the refusal *returns as content*, fails parse, and
+///   rides `for attempt in 0...maxRetries`, so the turn is skipped only after
+///   **3** independent samples all refuse. `turn_skipped` = "three consecutive
+///   samples refused".
+///
+/// So the permissive arm's tally is systematically lower for the same true
+/// refusal rate — and the bias points **toward** the conclusion the #1072
+/// re-run is hoping for. Comparing the two counts directly is how this
+/// experiment produces a second false verdict, this time a Go.
+///
+/// Compare at **sample** granularity instead — the one unit both arms measure
+/// the same way:
+///
+/// - Default arm refused samples = `turn_skipped` lines whose `value` (the
+///   cause) carries the `Foundation Models guardrail refusal` prefix. Each is
+///   exactly one refused sample.
+/// - Permissive arm refused samples = refusal-shaped records on THIS channel,
+///   one per refused sample. This also recovers the refusals that retried into
+///   a success — turns the default arm would have skipped outright, and which
+///   have no `turn_skipped` line at all in the permissive arm.
 ///
 /// ## Attribution
 ///

--- a/tools/harness/Sources/pastura-harness/Main.swift
+++ b/tools/harness/Sources/pastura-harness/Main.swift
@@ -2,6 +2,10 @@ import Foundation
 import PasturaCore
 import PasturaHarnessKit
 
+#if canImport(FoundationModels)
+  import FoundationModels
+#endif
+
 /// Headless simulation harness CLI (ADR-013). Runs one scenario YAML
 /// through the Engine with real llama.cpp inference and writes a JSONL
 /// run log. Exit codes: 0 = run ok, 1 = run failed (recorded in the log),
@@ -126,8 +130,21 @@ enum Main {
     case .foundationModels:
       #if canImport(FoundationModels)
         if #available(macOS 26, *) {
-          let factory: HarnessRunner.LLMFactory = { FoundationModelsService() }
-          return (factory, "Apple Foundation Model")
+          // `HarnessConfig.Guardrails` is a plain enum with no FoundationModels
+          // import — the `SystemLanguageModel` construction stays confined to
+          // this `#if canImport` block so the config type keeps compiling on
+          // toolchains without the macOS 26 SDK.
+          switch config.guardrails {
+          case .default:
+            let factory: HarnessRunner.LLMFactory = { FoundationModelsService() }
+            return (factory, "Apple Foundation Model")
+          case .permissive:
+            let factory: HarnessRunner.LLMFactory = {
+              FoundationModelsService(
+                model: SystemLanguageModel(guardrails: .permissiveContentTransformations))
+            }
+            return (factory, "Apple Foundation Model (permissive)")
+          }
         } else {
           throw HarnessConfigError(
             "--backend \(HarnessConfig.Backend.foundationModels.rawValue) requires macOS 26 or later"

--- a/tools/harness/Tests/PasturaHarnessKitTests/HarnessConfigTests.swift
+++ b/tools/harness/Tests/PasturaHarnessKitTests/HarnessConfigTests.swift
@@ -140,4 +140,42 @@ struct HarnessConfigTests {
       ])
     }
   }
+
+  @Test func defaultsGuardrailsToDefault() throws {
+    let config = try HarnessConfig.parse([
+      "--scenario", "s.yaml", "--model", "m.gguf"
+    ])
+    #expect(config.guardrails == .default)
+  }
+
+  @Test func parsesPermissiveGuardrails() throws {
+    let config = try HarnessConfig.parse([
+      "--scenario", "s.yaml", "--backend", "foundation-models",
+      "--guardrails", "permissive"
+    ])
+    #expect(config.guardrails == .permissive)
+  }
+
+  @Test func unknownGuardrailsThrows() {
+    do {
+      _ = try HarnessConfig.parse([
+        "--scenario", "s.yaml", "--model", "m.gguf", "--guardrails", "bogus"
+      ])
+      Issue.record("expected HarnessConfigError")
+    } catch let error as HarnessConfigError {
+      #expect(error.message.contains("bogus"))
+      #expect(error.message.contains("default"))
+      #expect(error.message.contains("permissive"))
+    } catch {
+      Issue.record("expected HarnessConfigError, got \(error)")
+    }
+  }
+
+  @Test func missingGuardrailsValueThrows() {
+    #expect(throws: HarnessConfigError.self) {
+      try HarnessConfig.parse([
+        "--scenario", "s.yaml", "--model", "m.gguf", "--guardrails"
+      ])
+    }
+  }
 }

--- a/tools/harness/Tests/PasturaHarnessKitTests/HarnessRunnerTests.swift
+++ b/tools/harness/Tests/PasturaHarnessKitTests/HarnessRunnerTests.swift
@@ -69,7 +69,8 @@ private final class Counter: Sendable {
 
 private func makeRunner(
   scripts: ScriptedStreams, writer: InMemoryWriter,
-  timeoutSeconds: Int = 5, factoryCount: Counter? = nil
+  timeoutSeconds: Int = 5, factoryCount: Counter? = nil,
+  diagLogger: StderrEngineLogger? = nil
 ) -> HarnessRunner {
   HarnessRunner(
     llmFactory: {
@@ -79,6 +80,7 @@ private func makeRunner(
     writer: writer,
     timeoutSeconds: timeoutSeconds,
     streamFactory: { _, _, _ in scripts.next() },
+    diagLogger: diagLogger,
     progress: nil)
 }
 
@@ -167,5 +169,47 @@ struct HarnessRunnerTests {
     #expect(summary.status == .error)
     #expect(summary.attempts == 2)
     #expect(summary.error?.contains("timeout") == true)
+  }
+
+  /// A failed attempt replays the whole scenario, so every Engine diagnostic
+  /// is emitted twice. `attempt` is the only field that separates the passes —
+  /// without this the two runs' evidence silently merges and a refusal looks
+  /// twice as common as it is.
+  ///
+  /// Drives the real wiring (`execute` -> the injected logger instance), not a
+  /// hand-called `beginAttempt`: the stamp advancing is exactly what a future
+  /// refactor could drop silently.
+  @Test func stampsDiagnosticsWithTheHarnessAttempt() async throws {
+    let writer = InMemoryWriter()
+    let captured = Mutex<[String]>([])
+    let logger = StderrEngineLogger(sink: { line in captured.withLock { $0.append(line) } })
+
+    // Attempt 1 ends without `.simulationCompleted` -> failure -> rerun.
+    let scripts = ScriptedStreams([
+      [.roundStarted(round: 1, totalRounds: 1)],
+      [.roundStarted(round: 1, totalRounds: 1), .simulationCompleted]
+    ])
+    let runner = makeRunner(scripts: scripts, writer: writer, diagLogger: logger)
+
+    // The scripted streams bypass the Engine, so emit through the same logger
+    // the runner stamps — standing in for `LLMCaller.logParseFailure`.
+    logger.log(.warning, category: "LLMCaller", "before", privacy: .public)
+    let summary = await runner.execute(
+      scenario: try makeScenario(), runID: "test-run", startDate: "2026-06-13T00:00:00Z",
+      modelName: "mock")
+    #expect(summary.attempts == 2)
+
+    // `execute` stamps attempt 1, then 2 — so a record logged after it must
+    // carry the last attempt the runner reached.
+    logger.log(.warning, category: "LLMCaller", "after", privacy: .public)
+
+    let decoder = JSONDecoder()
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
+    let lines = captured.withLock { $0 }
+    let decoded = try lines.map { try decoder.decode(DiagLine.self, from: Data($0.utf8)) }
+    let before = try #require(decoded.first { $0.message == "before" })
+    let after = try #require(decoded.first { $0.message == "after" })
+    #expect(before.attempt == 1)
+    #expect(after.attempt == 2)
   }
 }

--- a/tools/harness/Tests/PasturaHarnessKitTests/StderrEngineLoggerTests.swift
+++ b/tools/harness/Tests/PasturaHarnessKitTests/StderrEngineLoggerTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+import PasturaCore
+import Synchronization
+import Testing
+
+@testable import PasturaHarnessKit
+
+@Suite(.timeLimit(.minutes(1)))
+struct StderrEngineLoggerTests {
+  /// Collects rendered records in order.
+  private final class Sink: Sendable {
+    private let lines = Mutex<[String]>([])
+    var captured: [String] { lines.withLock { $0 } }
+    var write: @Sendable (String) -> Void {
+      { line in self.lines.withLock { $0.append(line) } }
+    }
+  }
+
+  private func decode(_ line: String) throws -> DiagLine {
+    let decoder = JSONDecoder()
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
+    return try decoder.decode(DiagLine.self, from: Data(line.utf8))
+  }
+
+  /// The defect this whole channel exists to avoid: `raw=` carries model
+  /// output, which is routinely multi-line. If one diagnostic could smear
+  /// across many lines, any line-oriented read of the capture would attribute
+  /// newlines inside a refusal to separate diagnostics.
+  @Test func multiLineMessageStaysOneRecord() throws {
+    let sink = Sink()
+    let logger = StderrEngineLogger(sink: sink.write)
+
+    let raw = "Sorry, I can't help with that.\n\nTry a different prompt.\n{\"a\":"
+    logger.log(.warning, category: "LLMCaller", "JSON parse failed: raw=\(raw)", privacy: .public)
+
+    #expect(sink.captured.count == 1)
+    let line = try #require(sink.captured.first)
+    #expect(!line.contains("\n"))
+
+    // The content survives the escaping round-trip — the record is evidence,
+    // so a lossy render would defeat the purpose.
+    let decoded = try decode(line)
+    #expect(decoded.message.contains(raw))
+  }
+
+  @Test func stampsMonotonicSequence() throws {
+    let sink = Sink()
+    let logger = StderrEngineLogger(sink: sink.write)
+
+    logger.log(.info, category: "c", "first", privacy: .public)
+    logger.log(.info, category: "c", "second", privacy: .public)
+    logger.log(.info, category: "c", "third", privacy: .public)
+
+    let seqs = try sink.captured.map { try decode($0).seq }
+    #expect(seqs == [1, 2, 3])
+  }
+
+  /// `HarnessRunner` reruns a failed scenario, replaying every diagnostic.
+  /// Without this stamp the two passes are indistinguishable.
+  @Test func stampsHarnessAttempt() throws {
+    let sink = Sink()
+    let logger = StderrEngineLogger(sink: sink.write)
+
+    logger.beginAttempt(1)
+    logger.log(.warning, category: "c", "first pass", privacy: .public)
+    logger.beginAttempt(2)
+    logger.log(.warning, category: "c", "second pass", privacy: .public)
+
+    let decoded = try sink.captured.map { try decode($0) }
+    #expect(decoded.map(\.attempt) == [1, 2])
+    // seq keeps running across attempts, so records stay totally ordered.
+    #expect(decoded.map(\.seq) == [1, 2])
+  }
+
+  /// A turn burns `LLMCaller.maxRetries + 1` attempts before it is skipped, so
+  /// the evidence channel necessarily repeats. This pins the *documented*
+  /// consequence: the tally must come from the run log's `turn_skipped`, never
+  /// from counting these records. If this ever collapsed to one record per
+  /// turn, the counting rule in the doc comment would be silently wrong.
+  @Test func oneTurnEmitsOneRecordPerFailedAttempt() throws {
+    let sink = Sink()
+    let logger = StderrEngineLogger(sink: sink.write)
+    logger.beginAttempt(1)
+
+    for attempt in 0...2 {
+      logger.log(
+        .warning, category: "LLMCaller",
+        "JSON parse failed (attempt \(attempt + 1)/3): raw=Sorry, I can't help with that.",
+        privacy: .public)
+    }
+
+    #expect(sink.captured.count == 3)
+    let decoded = try sink.captured.map { try decode($0) }
+    #expect(decoded.allSatisfy { $0.attempt == 1 })
+    #expect(decoded.allSatisfy { $0.message.contains("Sorry, I can't help with that.") })
+  }
+
+  @Test func rendersLevelAndCategory() throws {
+    let sink = Sink()
+    let logger = StderrEngineLogger(sink: sink.write)
+
+    logger.log(.debug, category: "StreamingDiag", "d", privacy: .private)
+    logger.log(.info, category: "LLMCaller", "i", privacy: .public)
+    logger.log(.warning, category: "LLMCaller", "w", privacy: .public)
+
+    let decoded = try sink.captured.map { try decode($0) }
+    #expect(decoded.map(\.level) == ["debug", "info", "warning"])
+    #expect(decoded.map(\.category) == ["StreamingDiag", "LLMCaller", "LLMCaller"])
+    #expect(decoded.allSatisfy { $0.type == "diag" })
+  }
+
+  /// `.private` governs OSLog redaction off-device; this logger is a local
+  /// developer instrument where the raw content IS the artifact. A redacting
+  /// implementation would silently empty the evidence channel.
+  @Test func privateMessagesAreNotRedacted() throws {
+    let sink = Sink()
+    let logger = StderrEngineLogger(sink: sink.write)
+
+    logger.log(.warning, category: "c", "sensitive raw output", privacy: .private)
+
+    let decoded = try decode(try #require(sink.captured.first))
+    #expect(decoded.message == "sensitive raw output")
+  }
+}

--- a/tools/harness/Tests/PasturaHarnessKitTests/StderrEngineLoggerTests.swift
+++ b/tools/harness/Tests/PasturaHarnessKitTests/StderrEngineLoggerTests.swift
@@ -31,7 +31,9 @@ struct StderrEngineLoggerTests {
     let logger = StderrEngineLogger(sink: sink.write)
 
     let raw = "Sorry, I can't help with that.\n\nTry a different prompt.\n{\"a\":"
-    logger.log(.warning, category: "LLMCaller", "JSON parse failed: raw=\(raw)", privacy: .public)
+    logger.log(
+      .warning, category: "LLMCaller",
+      "JSON parse failed agent=Alice (attempt 1/3): raw=\(raw)", privacy: .public)
 
     #expect(sink.captured.count == 1)
     let line = try #require(sink.captured.first)
@@ -72,11 +74,12 @@ struct StderrEngineLoggerTests {
     #expect(decoded.map(\.seq) == [1, 2])
   }
 
-  /// A turn burns `LLMCaller.maxRetries + 1` attempts before it is skipped, so
-  /// the evidence channel necessarily repeats. This pins the *documented*
-  /// consequence: the tally must come from the run log's `turn_skipped`, never
-  /// from counting these records. If this ever collapsed to one record per
-  /// turn, the counting rule in the doc comment would be silently wrong.
+  /// Pins the unit: **one record is one failed sample, not one failed turn.**
+  /// A turn burns `LLMCaller.maxRetries + 1` samples and logs each, so a reader
+  /// counting records gets samples — which is the unit the two guardrail arms
+  /// are comparable in, and NOT the turn tally (that lives in `turn_skipped`).
+  /// If this ever collapsed to one record per turn, the doc's counting rule
+  /// would be silently wrong in both units at once.
   @Test func oneTurnEmitsOneRecordPerFailedAttempt() throws {
     let sink = Sink()
     let logger = StderrEngineLogger(sink: sink.write)
@@ -85,7 +88,7 @@ struct StderrEngineLoggerTests {
     for attempt in 0...2 {
       logger.log(
         .warning, category: "LLMCaller",
-        "JSON parse failed (attempt \(attempt + 1)/3): raw=Sorry, I can't help with that.",
+        "JSON parse failed agent=Alice (attempt \(attempt + 1)/3): raw=Sorry, I can't help with that.",
         privacy: .public)
     }
 
@@ -106,7 +109,10 @@ struct StderrEngineLoggerTests {
     let decoded = try sink.captured.map { try decode($0) }
     #expect(decoded.map(\.level) == ["debug", "info", "warning"])
     #expect(decoded.map(\.category) == ["StreamingDiag", "LLMCaller", "LLMCaller"])
-    #expect(decoded.allSatisfy { $0.type == "diag" })
+    // Assert on the raw line, not the decoded value: `type` has an initial
+    // value, so synthesized Decodable never reads it — a decoded check would
+    // pass even if the encoder dropped the field the JSONL consumer keys on.
+    #expect(sink.captured.allSatisfy { $0.contains("\"type\":\"diag\"") })
   }
 
   /// `.private` governs OSLog redaction off-device; this logger is a local


### PR DESCRIPTION
## Summary

#1072 の No-Go 判定は**前提が事実誤認**だった。「Apple はガードレール調整 API を提供していない」を唯一のハードブロッカーとしていたが、出荷中の macOS 26 SDK に最初から存在する:

```swift
@available(iOS 26.0, macOS 26.0, visionOS 26.0, *)
public struct Guardrails : Swift.Sendable {
  public static let `default`: SystemLanguageModel.Guardrails
  public static let permissiveContentTransformations: SystemLanguageModel.Guardrails
}
convenience public init(useCase: SystemLanguageModel.UseCase = .general,
                        guardrails: SystemLanguageModel.Guardrails = Guardrails.default)
```

`FoundationModelsService.swift` の `init(model: SystemLanguageModel = .default)` は一度も引数を渡されていない — **6セルバッテリーは既定ガードレールでしか回っていなかった**。Apple 開発者フォーラム [thread/787736](https://developer.apple.com/forums/thread/787736) では Apple のエンジニア自身が良性コンテンツの誤検知を認め、`.permissiveContentTransformations` を回避策として案内している。

本 PR は**訂正版の再走を可能にするコード**。バッテリー実行自体は対象外（マージ後にメインセッションで実施）。判定は #1072 で暫定保留中。

## この PR の主役は計測器

素朴に `--guardrails permissive` を足して再走すると、**2度目の誤判定を生む**。緩和モードでは Apple のセッションが `guardrailViolation` を throw しなくなり、拒否が**本文として返る**ためパース失敗に化け、`TurnFailureGate.cause(for:)` が `"retries exhausted"` に潰す — ただの JSON 崩れと区別がつかない。既定モードは説明文が `cause=` に載って分類可能なので、**ラベル付きの腕 vs ラベルなしの腕**を比較することになる。

`StderrEngineLogger` はこれを塞ぐ。harness は `SimulationRunner` の `logger:` を `NoopEngineLogger` のまま放置していた（`grep -rn EngineLogger tools/harness/` → 0件）が、`LLMCaller.logParseFailure` は既に生の出力を `EngineLogger` seam に流している。**計測器は harness 側に置き、production のサービスには触れていない** — ロケール依存の脆い接頭辞判定を production 形状のコードに入れる案は、リトライを剥奪して比較可能性を壊すため採らなかった。

## 検証済み API 事実（reviewer はこのコードをコンパイル不可）

FM コードは `canImport(FoundationModels)` の裏にあり、**SDK 判定なので CI / pre-commit は型チェックしない**。ローカルで確認:

- **Xcode 26.6 (Build 17F113) / Swift 6.3.3** で `canImport(FoundationModels)` = **true** → この環境の `swift build` は FM コードを実際に型チェックしており、通っている
- `SystemLanguageModel(guardrails: .permissiveContentTransformations)` が `@available(macOS 26, *)` 下でコンパイル成功 → **26.4 ゲートではない**ので既存の `#available(macOS 26, *)` で足りる
- 正式な綴りは `permissiveContentTransformations`（`.swiftinterface` が権威）。フォーラムの `permissiveContentTransform` は古い名前

## 計測ルール（レビューで2度直した、この PR の要）

**1レコード = 1失敗サンプル。1失敗ターンではない。** 単位を取り違えると結論が変わる:

- **失敗ターン数** → run log の `turn_skipped`。ただし2つの carve-out:
  1. **ブレーカーの発火ターンは記録されない** — `TurnFailureGate` は3連続スキップ目で `emitter(.turnSkipped(...))` の**前**に throw する。`event:"error"` が `turnFailureLimitReached` を名指しする **attempt** が `count + 1`、かつ truncated（率ではなく下限）。`run_end` で見ると、attempt 1 で発火 → attempt 2 成功のとき `status:"ok"` になり見逃す
  2. **`narrate` は集計外** — `NarrateHandler` は設計上ゲートをバイパスする(#909)が自前の `LLMCaller` を駆動するので、証拠だけ出て集計行が出ない。`word_wolf.yaml` / `word_wolf_en.yaml` の**両方に narrate があり**、6セル中2セル — guard9 で死んだ最重要セルを含む
- **失敗サンプル数** → 本チャネルのレコード（1件1サンプル）

### ⚠️ 両腕の `turn_skipped` を直接比べてはいけない

両腕とも gate-degradable だが（`map` → `llmGenerationFailed` → `isTurnDegradable` が受理）、**拒否クラスに与えられるリトライ予算が違う**:

| | 拒否の扱い | skip までのサンプル数 | `turn_skipped` の意味 |
|---|---|---|---|
| 既定 | throw（`shouldRetryStreamFailure` は `samplerCrashCaught` しか再試行しない） | **1** | 「1回目が拒否した」 |
| 緩和 | 本文 → パース失敗 → `for attempt in 0...maxRetries` | **3** | 「3連続で拒否した」 |

同じ真の拒否率でも**緩和側の集計が系統的に低く出る**。しかもバイアスは**再走が期待している結論の向き**に効く。→ **サンプル粒度で比較する**（既定 = guardrail-refusal 接頭辞を持つ `turn_skipped`、緩和 = 拒否形状の diag レコード）。緩和側でリトライして成功した拒否（既定なら skip されていたターン）もこれで拾える。

## Changes

| | |
|---|---|
| `StderrEngineLogger` (新規) | 1レコード1行の JSON を stderr へ。`seq` + harness `attempt` を刻む。`run_scenario.sh` の既存 `2>"$STDERR_LOG"` 捕捉に乗る |
| `HarnessRunner` | `streamFactory` を Optional 化し `init` 内で解決（デフォルト引数式はインスタンス状態を参照不可）。`diagLogger` 注入可 |
| `HarnessConfig` | `--guardrails <default\|permissive>`。**FM 型を一切参照しない**素の enum。引数ループを `Accumulator` に分離（複雑度） |
| `Main.swift` | 既存 `#if canImport` ブロック内で配線。緩和時 model 名は `Apple Foundation Model (permissive)` → run log で両腕を識別 |
| `run_scenario.sh` | `--backend` / `--guardrails` を**末尾フラグ**で（位置引数6/7番目にすると FM 呼び出しが無意味な profile を要求される）。`-` で `--model` を省略 |
| `LLMCaller+Logging` | `agent` を `logParseFailure` に追加 — 終端失敗には `retryCause` が続かないため、近傍走査では帰属できない。レコードが自分で名乗る |
| `FoundationModelsService` | **ドキュメントのみ** |

### `@Generable` トラップ（doc 化した最重要事項）

#1072 の元ダイジェストは `@Generable` guided generation を「妥当な follow-up」と書いたが、**逆**だった。Apple 曰く緩和モードは "only works for generating a string value. When you use guided generation, the framework runs the default guardrails against model input and output as usual." つまり `@Generable` を入れると**既定ガードレールが黙って復活する** — 既に非問題と測定済みの JSON 妥当性と引き換えに、スパイクを殺した failure が戻ってくる。`.refusal` のマップは追加していない（guided generation 専用で、`schema` を無視する限り到達不能な死んだ分岐）。

## Test plan

- `swift build` — クリーン（**Xcode 26.6 SDK で FM コードを実際に型チェック**）
- `swift test` — 52/52（新規: `StderrEngineLoggerTests` 6件、`HarnessRunnerTests.stampsDiagnosticsWithTheHarnessAttempt` 1件、`HarnessConfigTests` 4件）
  - attempt スタンプのテストは `execute()` を実リラン越しに駆動する。`beginAttempt` を消すと落ちる（`.claude/rules/testing.md` の回帰テスト基準）
- `scripts/xcodebuild.sh test -only-testing PasturaTests/EngineLoggerSeamTests -only-testing PasturaTests/LLMCallerTests` — 19/19
- `swiftlint lint --quiet --strict`（全ツリー）— exit 0
- shell gates: `model-eval` / `scenario-factory` の self-tests + `scripts/tests/*` — 全通過
- `--backend` / `--guardrails` パススルーは既存 `PASTURA_HARNESS_BIN` fake-harness seam で canary
- **CI の "Harness package build"**: `HarnessConfig` の FM 参照は doc コメントのみ（`import Foundation` だけ）、parse テストは `#if canImport` ガード外 → 26 SDK 無しのツールチェーンでも緑

## Device QA

実機QA不要 — harness (macOS CLI) + シェルスクリプト + doc のみ。iOS の実行時挙動を変える差分はない（`logParseFailure` の `agent=` 追加はログ文字列のみで、これを解析するスクリプトは存在せず、`EngineLoggerSeamTests` は接頭辞のみ検査）。

## 次のステップ（本 PR 対象外）

1. `--guardrails permissive` で6セルバッテリー再走 → #1072 に訂正版ダイジェスト
2. #1154（`maximumResponseTokens` / `tokenCount` でブロッカー2を実測化）— `prisoners_dilemma-ja` の guard0 は測定値でなく下限値（ctx 超過スキップが拒否機会に到達しないターンを消費）なので、訂正版判定の ctx 交絡注記の参照先
3. 緩和モードを**製品出荷**してよいかは別途 judgment call — Apple の想定用途は変換系でうちは生成系。ただし同じ文書が要求する deny list に ADR-005 のコンテンツブロックリストが相当する

Part of #1072
