### PR TITLE
🐛 fix: FM permissive guardrails never reached the session (#1072)

### DIFF
--- a/Pastura/Pastura/LLM/FoundationModelsService.swift
+++ b/Pastura/Pastura/LLM/FoundationModelsService.swift
@@ -175,6 +175,13 @@
     /// the harness JSONL run log — without adding an ``LLMError`` case (which
     /// would ripple through its no-default-exhaustive `errorDescription`
     /// switch and add i18n catalog keys).
+    ///
+    /// The prefix is what carries the classification — do NOT rely on the
+    /// SDK's `localizedDescription` to disambiguate. Its text for
+    /// `unsupportedLanguageOrLocale` ("An unsupported language or locale was
+    /// used") reads exactly like a hand-written prefix would, so a
+    /// substring-matching consumer cannot tell the prefixed arm from the
+    /// generic one.
     static func map(_ error: LanguageModelSession.GenerationError) -> LLMError {
       switch error {
       case .exceededContextWindowSize:
@@ -183,8 +190,16 @@
       case .guardrailViolation:
         return .generationFailed(
           description: "Foundation Models guardrail refusal — \(error.localizedDescription)")
+      case .unsupportedLanguageOrLocale:
+        // Observed 4× in `prisoners_dilemma_en` where #1072's earlier run of
+        // the same effective config saw 0 — i.e. this class is the corrected
+        // battery's run-to-run noise floor, so the digest has to count it
+        // apart from everything else in the generic bucket.
+        return .generationFailed(
+          description:
+            "Foundation Models unsupported language or locale — \(error.localizedDescription)")
       // Plain `default:` (not `@unknown default` like `describe`): the spike
-      // only distinguishes the two prefixed classes above; every other
+      // only distinguishes the three prefixed classes above; every other
       // GenerationError case intentionally shares the generic message.
       default:
         return .generationFailed(

--- a/Pastura/Pastura/LLM/FoundationModelsService.swift
+++ b/Pastura/Pastura/LLM/FoundationModelsService.swift
@@ -132,7 +132,18 @@
       // exposes no per-request sampler seeding hook (#1105).
       guard isModelLoaded else { throw LLMError.notLoaded }
 
-      let session = LanguageModelSession(instructions: system)
+      // `model:` is LOAD-BEARING and easy to lose: the SDK initializer is
+      // `init(model: SystemLanguageModel = .default, tools:, instructions:)`,
+      // so omitting it silently builds the session over `.default` and the
+      // injected model reaches only `loadModel()`'s availability check — never
+      // generation. #1156 shipped exactly that: a 6-cell battery ran with
+      // `--guardrails permissive`, logged "(permissive)" for every cell, and
+      // produced guardrail-refusal counts byte-identical to the default-
+      // guardrails run (9 and 4), because every session was a default one.
+      // No test can catch a regression here — `LanguageModelSession` exposes no
+      // `model` accessor — so the control is the battery: a permissive run that
+      // still throws `guardrailViolation` means this argument went missing.
+      let session = LanguageModelSession(model: model, instructions: system)
       do {
         let response = try await session.respond(to: user)
         return response.content

--- a/Pastura/Pastura/LLM/FoundationModelsService.swift
+++ b/Pastura/Pastura/LLM/FoundationModelsService.swift
@@ -80,6 +80,13 @@
       loadedState.withLock { $0 }
     }
 
+    /// - Note: Guardrail-blind by construction — `SystemLanguageModel` exposes
+    ///   no `guardrails` accessor, so this cannot reflect the injected model's
+    ///   mode. The harness threads its own guardrail-bearing label instead
+    ///   (`Main.swift`'s run-log name); prefer that when attributing a run.
+    ///   `SimulationViewModel` persists this into `SimulationRecord`, so wiring
+    ///   this service past spike scope means every record carries a
+    ///   guardrail-blind identifier — solve that then, not now.
     public var modelIdentifier: String { "Apple Foundation Model" }
     public let backendIdentifier = "FoundationModels"
 
@@ -139,11 +146,14 @@
       // generation. #1156 shipped exactly that: a 6-cell battery ran with
       // `--guardrails permissive`, logged "(permissive)" for every cell, and
       // produced guardrail-refusal counts byte-identical to the default-
-      // guardrails run (9 and 4), because every session was a default one.
-      // No test can catch a regression here — `LanguageModelSession` exposes no
-      // `model` accessor — so the control is the battery: a permissive run that
-      // still throws `guardrailViolation` means this argument went missing.
-      let session = LanguageModelSession(model: model, instructions: system)
+      // guardrails run (word_wolf-ja 9, bokete-en 4), because every session was
+      // a default one.
+      // As of the Xcode 26.6 SDK no test can reach this: `LanguageModelSession`
+      // exposes no `model` accessor, so the session's model is unobservable.
+      // Re-check on SDK bumps. Until then the control is the battery — a
+      // permissive run that still throws `guardrailViolation` means this
+      // argument went missing.
+      let session = LanguageModelSession(model: self.model, instructions: system)
       do {
         let response = try await session.respond(to: user)
         return response.content

--- a/Pastura/PasturaTests/LLM/FoundationModelsServiceTests.swift
+++ b/Pastura/PasturaTests/LLM/FoundationModelsServiceTests.swift
@@ -66,6 +66,43 @@
       // Distinct messages so loadModel()'s error surfaces the real cause.
       #expect(Set([device, notEnabled, notReady]).count == 3)
     }
+
+    /// The three prefixed classes must stay mutually distinguishable by grep:
+    /// the harness JSONL carries `map`'s description verbatim as a
+    /// `turn_skipped` cause, and the #1072 digest counts them separately.
+    ///
+    /// `unsupportedLanguageOrLocale` earns a prefix because the corrected
+    /// battery observed 4 of them in `prisoners_dilemma_en` where #1072's run
+    /// observed 0 — it is the digest's run-to-run noise floor, and it cannot
+    /// be counted while it shares the generic bucket with every other error.
+    @available(iOS 26, macOS 26, *)
+    @Test func mapsGenerationErrorsToDistinctPrefixes() {
+      let context = LanguageModelSession.GenerationError.Context(debugDescription: "probe")
+      let ctxExceeded = FoundationModelsService.map(.exceededContextWindowSize(context))
+      let guardrail = FoundationModelsService.map(.guardrailViolation(context))
+      let locale = FoundationModelsService.map(.unsupportedLanguageOrLocale(context))
+      let other = FoundationModelsService.map(.rateLimited(context))
+
+      // Assert the PREFIX, not `.contains` — the SDK's own
+      // `localizedDescription` for `unsupportedLanguageOrLocale` reads "An
+      // unsupported language or locale was used", so a `.contains` check
+      // passes on the generic arm too and pins nothing. (It did: this test was
+      // green before the arm existed.)
+      #expect(
+        description(of: ctxExceeded).hasPrefix("Foundation Models context window exceeded — "))
+      #expect(description(of: guardrail).hasPrefix("Foundation Models guardrail refusal — "))
+      #expect(
+        description(of: locale).hasPrefix("Foundation Models unsupported language or locale — "))
+      // Unprefixed classes still share the generic bucket by design.
+      #expect(description(of: other).hasPrefix("Foundation Models generation failed — "))
+    }
+
+    /// Unwraps the description `map` builds — the whole point is the string,
+    /// since `map` deliberately adds no `LLMError` case.
+    private func description(of error: LLMError) -> String {
+      guard case .generationFailed(let description) = error else { return "" }
+      return description
+    }
   }
 
 #endif

--- a/tools/harness/Sources/pastura-harness/Main.swift
+++ b/tools/harness/Sources/pastura-harness/Main.swift
@@ -135,21 +135,31 @@ enum Main {
           // this `#if canImport` block so the config type keeps compiling on
           // toolchains without the macOS 26 SDK.
           //
-          // Both arms construct through `init(guardrails:)` and both the model
-          // and the run-log label derive from `config.guardrails`. Two reasons,
-          // both learned from #1156's invalid battery:
+          // Both arms construct through `init(guardrails:)`, and the model and
+          // the run-log label derive from the same `config.guardrails` value.
+          // Two reasons, both learned from #1156's invalid battery:
           //
           // 1. The label used to be a hand-written literal in this tuple,
           //    independent of what the factory built — which is exactly how six
           //    cells logged "(permissive)" while every session ran default
-          //    guardrails. A label that cannot disagree with the model is the
-          //    only kind worth logging.
+          //    guardrails. Deriving both from one value means neither can drift
+          //    from the *request* on its own. It is not a guarantee the label
+          //    matches the model: `SystemLanguageModel` exposes no `guardrails`
+          //    accessor, so a model-derived label is unreachable, and the
+          //    `switch` below stays an unverified mapping — miswire it and the
+          //    label lies again, one hop upstream. The battery remains its only
+          //    control.
           // 2. The default arm used to call `FoundationModelsService()`, i.e.
           //    the STATIC `SystemLanguageModel.default`, while the permissive
           //    arm called `init(guardrails:)`. That left the A/B differing in
           //    construction path as well as guardrails. Whether the static and
           //    the initializer are equivalent is not knowable from the SDK
           //    interface, so the arms are made symmetric instead of assumed so.
+          //
+          // The instance is now built once and shared across `llmFactory()`
+          // calls (i.e. across `HarnessRunner`'s retry attempts) rather than
+          // per-call. That matches the old default arm, whose static `.default`
+          // was always process-shared — so this is more symmetric, not less.
           let guardrails: SystemLanguageModel.Guardrails
           switch config.guardrails {
           case .default: guardrails = .default

--- a/tools/harness/Sources/pastura-harness/Main.swift
+++ b/tools/harness/Sources/pastura-harness/Main.swift
@@ -134,17 +134,30 @@ enum Main {
           // import — the `SystemLanguageModel` construction stays confined to
           // this `#if canImport` block so the config type keeps compiling on
           // toolchains without the macOS 26 SDK.
+          //
+          // Both arms construct through `init(guardrails:)` and both the model
+          // and the run-log label derive from `config.guardrails`. Two reasons,
+          // both learned from #1156's invalid battery:
+          //
+          // 1. The label used to be a hand-written literal in this tuple,
+          //    independent of what the factory built — which is exactly how six
+          //    cells logged "(permissive)" while every session ran default
+          //    guardrails. A label that cannot disagree with the model is the
+          //    only kind worth logging.
+          // 2. The default arm used to call `FoundationModelsService()`, i.e.
+          //    the STATIC `SystemLanguageModel.default`, while the permissive
+          //    arm called `init(guardrails:)`. That left the A/B differing in
+          //    construction path as well as guardrails. Whether the static and
+          //    the initializer are equivalent is not knowable from the SDK
+          //    interface, so the arms are made symmetric instead of assumed so.
+          let guardrails: SystemLanguageModel.Guardrails
           switch config.guardrails {
-          case .default:
-            let factory: HarnessRunner.LLMFactory = { FoundationModelsService() }
-            return (factory, "Apple Foundation Model")
-          case .permissive:
-            let factory: HarnessRunner.LLMFactory = {
-              FoundationModelsService(
-                model: SystemLanguageModel(guardrails: .permissiveContentTransformations))
-            }
-            return (factory, "Apple Foundation Model (permissive)")
+          case .default: guardrails = .default
+          case .permissive: guardrails = .permissiveContentTransformations
           }
+          let model = SystemLanguageModel(guardrails: guardrails)
+          let factory: HarnessRunner.LLMFactory = { FoundationModelsService(model: model) }
+          return (factory, "Apple Foundation Model (\(config.guardrails.rawValue))")
         } else {
           throw HarnessConfigError(
             "--backend \(HarnessConfig.Backend.foundationModels.rawValue) requires macOS 26 or later"


### PR DESCRIPTION
## Summary

**#1156 の緩和ガードレール配線は一度も効いていなかった。** 6セルバッテリーの実測が証明した。

`generate` は `LanguageModelSession(instructions: system)` でセッションを作っていた。SDK の初期化子は `init(model: SystemLanguageModel = .default, tools:, instructions:)` — **`model:` が `.default` に既定される**ので、`init(model:)` で注入した緩和モデルは `loadModel()` の可用性判定にしか使われず、生成には届かない。

### 無効の証拠（実測）

`--guardrails permissive` 指定で走らせ、run log は全6セル `Apple Foundation Model (permissive)` と記録:

| セル | guardrail refusal | #1072 の**既定**モード走行 |
|---|---|---|
| word_wolf-ja | **9** | **9** |
| bokete-en | **4** | **4** |

**バイト単位で一致。** しかも拒否は `Detected content likely to be unsafe` の **throw**。Apple は緩和モードについて "never throws a guardrailViolation error when generating string responses" と明記しているので、throw されている時点で緩和は適用されていない。

### ルーティング証明（修正後の実測）

`word_wolf.yaml` (ja) を修正後ビルドで再走:

| | #1072 既定 | #1156 の無効走行 | **本 PR 修正後** |
|---|---|---|---|
| guardrail refusal | 9 | 9 | **0** |
| 総スキップ | 9 | 9 | **1**（ctx のみ） |
| 拒否の本文化（diag レコード） | — | — | **0** |
| 結果 | **ERROR** | ok | **ok** / 153秒 |

拒否は消え、**本文にも化けていない**（diag チャネルに拒否形状の生テキスト0件）。計測器の生存確認済み — 同じチャネルは他セルで15件/8件のレコードを出しているので、0件は「故障」ではなく「失敗が無かった」。

## Changes

| コミット | 内容 |
|---|---|
| `8730d57` 🐛 | `LanguageModelSession(model: self.model, instructions: system)` + why-comment |
| `a0d0421` ✨ | `unsupportedLanguageOrLocale` に識別可能な接頭辞 + テスト |
| `f4c0cf3` ♻️ | harness: 両腕を対称構築 + ラベルを `config.guardrails` から導出 |
| `e2a1057` 📝 | レビュー指摘対応（コメントの主張範囲を機構の実力に合わせる） |

### コミット1 にテストが無い理由

seam + スパイの回帰テストを設計し、**破棄した**。スパイが既定クロージャごと差し替えるので、その中の `model:` を revert してもテストは緑のまま — **seam 自身が発明した行を守り、壊れた行は無防備**になる（`.claude/rules/testing.md` §「回帰テストは未ガード経路の入力そのものを駆動せよ」）。`LanguageModelSession` は `model` アクセサを公開していないため、セッションのモデルは**いかなるテストからも観測不能**（Xcode 26.6 SDK 時点。SDK 更新時は再確認）。1行形式なら未検証の行は1本、seam 形式なら2本で悪い方が未検証。**対照はバッテリー**。

### コミット3 が既定腕の継続性を壊すこと

既定腕は `FoundationModelsService()` → **静的** `SystemLanguageModel.default`、緩和腕は `init(useCase:guardrails:)` だった。修正後もそのままだと **A/B がガードレール以外に構築経路でも違う**ことになる。静的と初期化子が等価かは SDK インターフェースから**知りようがない**ので、仮定せず対称にした。

## ⚠️ 再走時の注意（#1072 のダイジェストに反映すること）

### ルーティング証明 ≠ 判定入力

- **ルーティング証明**: guard 9→0。**構造上そうなる**（緩和は throw を消す）。残留すれば fix が効いていない
- **判定入力**: guard→0 は**判定の証拠にならない**。拒否は消えるのではなく**ラベルを失って本文に化けうる**（→ パース失敗 → `cause="retries exhausted"`）。判定の分子は `StderrEngineLogger` の生テキストから取る

混同するのは、元の No-Go を生んだのと同じ誤りクラス（測定経路を誤解したまま信号から一般化する）。

### 両腕を再走する

コミット3 が既定腕の構築を変えたので、**#1072 の既定腕の数字は比較対象として無効**。両腕を本ビルドで再走すること。`(default)` ラベルは来歴のトリップワイヤ — 素の `Apple Foundation Model` と読める行は修正前の走行。

### ノイズ床（偶発的な反復測定）

#1156 の「緩和」走行は実質 #1072 と同一設定だったため、意図せぬ replicate になった。プロジェクトが持つ唯一の run-to-run 変動推定値:
- ガードレール拒否数: **安定**（9→9, 4→4 バイト一致）
- `unsupportedLanguageOrLocale`: **不安定**（0→4）

訂正版ダイジェストの差分はこの床を超えている必要がある。この不安定さがコミット2（接頭辞）の動機。

## Test plan

- `swift build` — クリーン（**Xcode 26.6 SDK で FM コードを実際に型チェック**。`canImport` は SDK 判定なので CI は型チェックしない）
- `swift test` — 52/52
- `scripts/xcodebuild.sh test -only-testing PasturaTests/FoundationModelsServiceTests` — 7/7
- `swiftlint lint --quiet --strict`（全ツリー）— exit 0
- **実機ルーティング検証**: `word_wolf-ja` 緩和モード、guard 9→0、完走（上表）

### コミット2 のテストは一度トートロジーだった

初稿は `.contains("unsupported language or locale")` で書き、**実装前に緑になった** — SDK の `localizedDescription` 自体が "An unsupported language or locale was used" で generic 分岐にマッチしていたため。TDD の赤ステップで発覚し、`hasPrefix` に変更（revert すると落ちることを確認）。同じ罠に戻らないよう `map` の doc コメントに記録した。

## Device QA

実機QA不要 — harness（macOS CLI）+ FM バックエンド（production 未配線、spike スコープ維持）+ doc のみ。iOS の実行時挙動を変える差分はない。

## 次のステップ（本 PR 対象外）

1. 6セル × 両腕をこのビルドで再走 → #1072 に訂正版ダイジェスト
2. #1154（`maximumResponseTokens` / `tokenCount` でブロッカー2 = 4k ctx 超過を実測化）— ルーティング検証でも ctx スキップが1件出ており、ガードレールが晴れた今こちらが主役になる
3. 緩和モードを**製品出荷**してよいかは別の judgment call（Apple の想定用途は変換系、うちは生成系。ただし ADR-005 のコンテンツブロックリストが Apple の要求する deny list に相当する）

Part of #1072
