### PR TITLE
🐛 fix: commonMain-safe regex + per-PR metadata gate (#1157)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -749,7 +749,11 @@ jobs:
       # silently-growing compile-only (Gradle pulling in link deps, or native
       # test execution sneaking onto this target) fails loudly. Do NOT loosen it
       # if a one-off cold-cache run trips it — that is a first-run artifact, not
-      # a budget regression (#501 D-B).
+      # a budget regression (#501 D-B). The `compileCommonMainKotlinMetadata`
+      # tasks are now part of the budgeted set; they are Kotlin-frontend-only
+      # (no LLVM), so they add negligible time (~a few seconds) and the 8-min
+      # cap holds — the addition is intentional gate coverage, not the silent
+      # growth this tripwire targets.
       - name: Compile native klib (compile-only — per-PR default)
         if: steps.kmp-changes.outputs.full_native != 'true'
         timeout-minutes: 8
@@ -762,7 +766,17 @@ jobs:
         # task depends on `link<Config>Framework<Target>`, which depends on this
         # very `compileKotlinIosSimulatorArm64`. The full-native step is a
         # strict superset — it cannot skip what this step checks.
-        run: ./gradlew :shared:models:compileKotlinIosSimulatorArm64 :shared:engine:compileKotlinIosSimulatorArm64 --no-daemon --stacktrace
+        #
+        # `compileCommonMainKotlinMetadata` compiles commonMain against the
+        # COMMON stdlib only, catching platform-specific-API leaks (e.g.
+        # `RegexOption.DOT_MATCHES_ALL`, which resolves on JVM+Native but not in
+        # common — #1157) that every per-target compile above silently accepts.
+        # Before #1157 this task ran ONLY in the KMP nightly (via
+        # `:shared:engine:build`), so the class escaped per-PR CI for a full
+        # nightly cycle. It is NOT reachable from the XCFramework assembly, so
+        # the full-native step must list it EXPLICITLY too to keep that step a
+        # strict superset of this one.
+        run: ./gradlew :shared:models:compileKotlinIosSimulatorArm64 :shared:engine:compileKotlinIosSimulatorArm64 :shared:models:compileCommonMainKotlinMetadata :shared:engine:compileCommonMainKotlinMetadata --no-daemon --stacktrace
 
       - name: Full native build + XCFramework (build-config touch)
         if: steps.kmp-changes.outputs.full_native == 'true'
@@ -789,14 +803,27 @@ jobs:
         # `assembleDebugPasturaSharedEngineXCFramework` does NOT exist; Gradle
         # rejects it as an ambiguous abbreviation of the per-platform
         # `assembleDebug<Platform>FatFrameworkFor…` tasks.
-        run: ./gradlew :shared:models:assemblePasturaSharedXCFramework :shared:engine:assemblePasturaSharedEngineDebugXCFramework --no-daemon --stacktrace
+        #
+        # The two `compileCommonMainKotlinMetadata` tasks are listed EXPLICITLY,
+        # mirroring the compile-only step: the XCFramework assembly does NOT
+        # depend on the common-metadata klib (it links per-target native
+        # compiles), so without them a common-stdlib API leak (#1157) would slip
+        # this step too — breaking the strict-superset invariant that the
+        # full-native step covers everything the compile-only step does. Both
+        # task tokens verified present via `:shared:{models,engine}:tasks --all`.
+        run: ./gradlew :shared:models:assemblePasturaSharedXCFramework :shared:engine:assemblePasturaSharedEngineDebugXCFramework :shared:models:compileCommonMainKotlinMetadata :shared:engine:compileCommonMainKotlinMetadata --no-daemon --stacktrace
 
       - name: Upload Gradle reports (on failure)
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: kmp-gradle-reports
-          path: shared/models/build/reports/
+          # Both modules' reports — matches kmp-nightly.yml. `:shared:engine`
+          # now runs its own gate tasks on this path (metadata compile + tests),
+          # so an engine-side failure must be diagnosable from the per-PR run.
+          path: |
+            shared/models/build/reports/
+            shared/engine/build/reports/
           retention-days: 7
 
   # Drift guard for bundled DL-time demo replays (#170, spec §3.3 / §5.2).

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
@@ -41,16 +41,24 @@ import kotlinx.serialization.json.JsonPrimitive
 internal class JSONResponseParser {
 
     private companion object {
+        // These patterns must match across newlines (a model's thinking block or
+        // a fenced JSON body spans many lines). The idiomatic flag for that,
+        // `RegexOption.DOT_MATCHES_ALL`, is NOT in the Kotlin *common* stdlib —
+        // it is a platform-specific entry present only on JVM and Native, so
+        // commonMain fails to resolve it (`compileCommonMainKotlinMetadata`).
+        // We therefore encode "any character including newline" directly in the
+        // pattern as `[\s\S]`, which is pure regex syntax with no flag
+        // dependence and identical semantics on every target.
         /** Gemma 4 channel thinking: `<|channel>thought...<channel|>`. */
-        val CHANNEL_THINKING = Regex("""<\|channel>thought\s*.*?<channel\|>""", RegexOption.DOT_MATCHES_ALL)
+        val CHANNEL_THINKING = Regex("""<\|channel>thought\s*[\s\S]*?<channel\|>""")
 
         /** Common thinking-model format: `<think>...</think>` (DeepSeek, Qwen). */
-        val THINK_TAG = Regex("""<think>.*?</think>""", RegexOption.DOT_MATCHES_ALL)
+        val THINK_TAG = Regex("""<think>[\s\S]*?</think>""")
 
         /** Chat-template token — truncate everything from the first occurrence. */
-        val CHAT_TEMPLATE_TOKEN = Regex("""<\|im_end\|>.*""", RegexOption.DOT_MATCHES_ALL)
+        val CHAT_TEMPLATE_TOKEN = Regex("""<\|im_end\|>[\s\S]*""")
 
-        val CODE_BLOCK = Regex("""```(?:json)?\s*\n?(.*?)\n?```""", RegexOption.DOT_MATCHES_ALL)
+        val CODE_BLOCK = Regex("""```(?:json)?\s*\n?([\s\S]*?)\n?```""")
 
         /**
          * `allowTrailingComma`: Swift's `JSONSerialization.jsonObject` accepts

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/JSONResponseParserTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/JSONResponseParserTests.kt
@@ -41,6 +41,16 @@ class JSONResponseParserTests {
     }
 
     @Test
+    fun stripsGemmaChannelThinkingAcrossLines() {
+        // Guards the dot-matches-newline behaviour of CHANNEL_THINKING: the
+        // thought block spans multiple lines, so a swap that drops newline
+        // matching would fail to strip it and the balanced scan would choke.
+        val out = parser.parse("""<|channel>thought I should
+        cooperate with the others<channel|>{"statement": "hi"}""")
+        assertEquals("hi", out.fields["statement"])
+    }
+
+    @Test
     fun stripsThinkTags() {
         val out = parser.parse("""<think>reasoning
         across lines</think>{"statement": "hi"}""")
@@ -57,6 +67,18 @@ class JSONResponseParserTests {
         assertEquals("real", out.fields["statement"])
     }
 
+    @Test
+    fun truncatesAtChatTemplateTokenAcrossLines() {
+        // Guards the dot-matches-newline behaviour of CHAT_TEMPLATE_TOKEN: the
+        // fabricated turn following the token spills onto later lines, which
+        // must still be truncated. A newline-blind swap would leave the second
+        // object in place and the balanced scan could return it.
+        val out = parser.parse("""{"statement": "real"}<|im_end|>
+        {"statement": "fabricated"}
+        more hallucinated text""")
+        assertEquals("real", out.fields["statement"])
+    }
+
     // MARK: - 4. Code fences
 
     @Test
@@ -69,6 +91,17 @@ class JSONResponseParserTests {
     fun extractsFromBareCodeFence() {
         val out = parser.parse("```\n{\"statement\": \"hi\"}\n```")
         assertEquals("hi", out.fields["statement"])
+    }
+
+    @Test
+    fun extractsMultiLineBodyFromCodeFence() {
+        // Guards the dot-matches-newline behaviour of CODE_BLOCK's `(.*?)`
+        // capture group: a pretty-printed JSON body spans several lines inside
+        // the fence. A newline-blind swap would capture only the first line and
+        // the parse would drop every field after it.
+        val out = parser.parse("```json\n{\n  \"statement\": \"hi\",\n  \"inner_thought\": \"hmm\"\n}\n```")
+        assertEquals("hi", out.fields["statement"])
+        assertEquals("hmm", out.fields["inner_thought"])
     }
 
     // MARK: - 5. Surrounding garbage / balanced scan

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/JSONResponseParserTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/JSONResponseParserTests.kt
@@ -34,6 +34,13 @@ class JSONResponseParserTests {
 
     // MARK: - 2. Thinking tags
 
+    // The `*AcrossLines` / `*MultiLine*` cases below guard a different failure
+    // class than the #1157 fix itself. That fix's compile failure
+    // (`RegexOption.DOT_MATCHES_ALL` absent from the common stdlib) is caught by
+    // `compileCommonMainKotlinMetadata` in CI — these tests would NOT have
+    // caught it, since they run on JVM where the flag resolves. What they guard
+    // is a future newline-blind *semantic* regression: a swap to a flagless `.`
+    // that compiles everywhere but silently stops matching across newlines.
     @Test
     fun stripsGemmaChannelThinking() {
         val out = parser.parse("""<|channel>thought I should cooperate<channel|>{"statement": "hi"}""")


### PR DESCRIPTION
## Summary

Fixes the red **KMP nightly full-native** workflow (#1157). Reproduced deterministically on `main`.

**Root cause:** `shared/engine/.../JSONResponseParser.kt` used `RegexOption.DOT_MATCHES_ALL`, which is **not** in the Kotlin *common* stdlib (common has only `IGNORE_CASE` / `MULTILINE`; `DOT_MATCHES_ALL` is a platform-specific entry present on JVM and Native). Per-target compiles (`compileKotlinIosSimulatorArm64`, `jvmTest`) resolved it and passed, but `compileCommonMainKotlinMetadata` — which compiles commonMain against the common stdlib only — failed with `Unresolved reference 'DOT_MATCHES_ALL'` (+ a cascading `groupValues` error at :117). That task runs **only** in the nightly (via `:shared:engine:build`), so no per-PR path caught it. Introduced by #1152.

### Changes
- **Fix:** drop `DOT_MATCHES_ALL` from all four regexes, encode dot-matches-newline in the pattern via `[\s\S]` — flag-independent, identical semantics on every target. Add a why-comment recording the common-stdlib gap.
- **Test:** add three newline-spanning `commonTest` cases (channel-thinking, chat-token truncation, multi-line fenced body). Previously only `THINK_TAG` exercised newline matching, so a mis-swap could have shipped green. These guard a future newline-blind *semantic* regression — distinct from the compile-failure class, which the metadata gate below catches.
- **CI gate:** add `:shared:{models,engine}:compileCommonMainKotlinMetadata` to **both** the compile-only and full-native per-PR steps in `ci.yml`, preserving the documented strict-superset invariant (the XCFramework assembly does not depend on the metadata klib, so the full-native step must list it explicitly). Metadata compile is Kotlin-frontend-only (~a few seconds, no LLVM), so the 8-min budget tripwire holds. Extend the on-failure report upload to `shared/engine/build/reports/`, matching `kmp-nightly.yml`.

Both task tokens verified present via `:shared:{models,engine}:tasks --all` — not inferred.

## Test plan
- `./gradlew :shared:engine:compileCommonMainKotlinMetadata` — green (was the failing task).
- `./gradlew :shared:engine:build` — green in 4m18s, incl. `iosSimulatorArm64Test` / `macosArm64Test` / `jvmTest` (the nightly's exact failing command).
- Exact per-PR compile-only CI command run locally — green; both modules' metadata tasks execute.
- Pre-code `critic` (Opus) + post-code `code-reviewer` (Opus): PASS.

## Device QA
実機QA不要 — Kotlin Multiplatform (`shared/engine/**`) + CI workflow only; no Swift iOS app surface, no device-only `#if !targetEnvironment(simulator)` block, no Metal / llama.cpp path.

Closes #1157