### PR TITLE
✨ feat: generic pairwise_payoff scoring engine (ADR-027 PR2)

### DIFF
--- a/Pastura/Pastura/App/EditablePhase.swift
+++ b/Pastura/Pastura/App/EditablePhase.swift
@@ -47,6 +47,11 @@ struct EditablePhase: Identifiable, Sendable {
   // it. `String` (not `String?`) mirrors `eventVariable`/`template`: empty and
   // nil are semantically identical, and `toPhase()` collapses empty back to nil.
   var narrator: String
+  // pairwise_payoff table (ADR-027). YAML-only for v1 (no editing UI in
+  // `PhaseEditorSheet`), modelled here so the visual→YAML round-trip preserves
+  // it. `[PayoffRule]` (not optional) mirrors `actionDeltas`: empty and nil are
+  // semantically identical, and `toPhase()` collapses empty back to nil.
+  var payoff: [PayoffRule]
 
   // swiftlint:disable:next function_default_parameter_at_end
   init(
@@ -70,7 +75,8 @@ struct EditablePhase: Identifiable, Sendable {
     actionDeltas: [String: Int] = [:],
     maxSentences: Int? = nil,
     noRepeat: Bool = false,
-    narrator: String = ""
+    narrator: String = "",
+    payoff: [PayoffRule] = []
   ) {
     self.type = type
     self.prompt = prompt
@@ -93,6 +99,7 @@ struct EditablePhase: Identifiable, Sendable {
     self.maxSentences = maxSentences
     self.noRepeat = noRepeat
     self.narrator = narrator
+    self.payoff = payoff
   }
 
   init(from phase: Phase) {
@@ -117,6 +124,7 @@ struct EditablePhase: Identifiable, Sendable {
     self.maxSentences = phase.maxSentences
     self.noRepeat = phase.noRepeat ?? false
     self.narrator = phase.narrator ?? ""
+    self.payoff = phase.payoff ?? []
   }
 
   /// Identifies which branch of a conditional phase to target.
@@ -232,7 +240,8 @@ struct EditablePhase: Identifiable, Sendable {
       actionDeltas: actionDeltas.isEmpty ? nil : actionDeltas,
       maxSentences: maxSentences,
       noRepeat: noRepeat ? true : nil,
-      narrator: narrator.isEmpty ? nil : narrator
+      narrator: narrator.isEmpty ? nil : narrator,
+      payoff: payoff.isEmpty ? nil : payoff
     )
   }
 }

--- a/Pastura/Pastura/App/ScenarioGenerationPrompt.swift
+++ b/Pastura/Pastura/App/ScenarioGenerationPrompt.swift
@@ -144,6 +144,9 @@ nonisolated enum ScenarioGenerationPrompt {
     case .eventReactive:
       return
         "reward agents whose last choose matched the injected event; needs event_inject before it"
+    case .pairwisePayoff:
+      return
+        "generic two-player payoff table in YAML (payoff: when/points); needs a round_robin choose before it"
     }
   }
 }

--- a/Pastura/Pastura/Engine/EngineSchemaVersion.swift
+++ b/Pastura/Pastura/Engine/EngineSchemaVersion.swift
@@ -47,7 +47,13 @@ nonisolated public enum EngineSchemaVersion {
   /// simulation, with no throw and no grey-out. D2's `allCases` phase gate
   /// cannot see it (no new phase), so §4's ⚠️ silent-wrong-run rule requires the
   /// bump and D3 is the only gate that can fire. Same shape as `2` above.
-  public static let current: Int = 4
+  ///
+  /// `5` — `ScoreCalcLogic.pairwise_payoff` (ADR-027), a new by-name-parsed
+  /// `score_calc` logic. §4's second bump trigger fires directly. D2's `allCases`
+  /// phase gate does not fire (no new `PhaseType`), so D3 (`min_engine_version`)
+  /// is the only proactive gate and D5's parse-throw is the backstop when a
+  /// shared scenario omits the declaration. See ADR-027 § "Blast radius".
+  public static let current: Int = 5
 
   /// Whether a gallery scenario described by its index metadata can be
   /// executed by this build's engine (ADR-020 D2 + D3).

--- a/Pastura/Pastura/Engine/Phases/ScoreCalcHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/ScoreCalcHandler.swift
@@ -33,6 +33,11 @@ nonisolated struct ScoreCalcHandler: PhaseHandler {
         favoredVariable: EventInjectHandler.favoredVariableName(
           for: EventInjectHandler.defaultVariableName),
         emitter: context.emitter)
+    case .pairwisePayoff:
+      // An absent `payoff:` is an empty table (all pairings score nothing) —
+      // flagged by the semantic linter (R20a), not a dispatch-time throw.
+      PairwisePayoffLogic().calculate(
+        state: &state, payoff: context.phase.payoff ?? [], emitter: context.emitter)
     }
   }
 }

--- a/Pastura/Pastura/Engine/ScenarioLoader.swift
+++ b/Pastura/Pastura/Engine/ScenarioLoader.swift
@@ -374,6 +374,13 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
     // the editor's dual buffer like `vote_against` / `action_deltas`.
     let narrator: String? = try parseOptional(dict, key: "narrator", label: label)
 
+    // pairwise_payoff table (ADR-027). YAML-only, round-trips through the
+    // editor's dual buffer like `narrator` / `action_deltas`. An absent `payoff:`
+    // is left nil (a guaranteed-no-op phase flagged by the linter, not a load
+    // throw — `load` stays non-validating, #665); only a malformed *present*
+    // table throws here.
+    let payoff = try parsePayoff(dict, label: label)
+
     return Phase(
       type: phaseType,
       prompt: prompt,
@@ -395,8 +402,45 @@ nonisolated public struct ScenarioLoader: Sendable {  // swiftlint:disable:this 
       actionDeltas: actionDeltas,
       maxSentences: maxSentences,
       noRepeat: noRepeat,
-      narrator: narrator
+      narrator: narrator,
+      payoff: payoff
     )
+  }
+
+  /// Parses the `payoff:` table for a `pairwise_payoff` `score_calc` phase — a
+  /// list of `{when: [String], points: [Int]}` rows (ADR-027). Strict on arity:
+  /// each `when` / `points` must hold exactly two elements, and `points` must be
+  /// `Int` (Bool excluded, since `as? Int` launders it — same guard as
+  /// `parseActionDeltas`). A malformed row throws rather than silently scoring a
+  /// wrong verdict at runtime.
+  private func parsePayoff(_ dict: [String: Any], label: String) throws -> [PayoffRule]? {
+    guard let raw = dict["payoff"] else { return nil }
+    guard let list = raw as? [[String: Any]] else {
+      throw validationError(.payoffNotList(label: label, got: String(describing: type(of: raw))))
+    }
+    var result: [PayoffRule] = []
+    for (index, row) in list.enumerated() {
+      guard let when = row["when"] as? [String], when.count == 2 else {
+        throw validationError(
+          .payoffRowInvalid(label: label, detail: "row \(index) 'when' must be 2 strings"))
+      }
+      guard let pointsRaw = row["points"] as? [Any], pointsRaw.count == 2 else {
+        throw validationError(
+          .payoffRowInvalid(label: label, detail: "row \(index) 'points' must be 2 ints"))
+      }
+      var points: [Int] = []
+      for value in pointsRaw {
+        guard let intValue = value as? Int, !(value is Bool) else {
+          throw validationError(
+            .payoffRowInvalid(
+              label: label,
+              detail: "row \(index) 'points' has a non-Int value"))
+        }
+        points.append(intValue)
+      }
+      result.append(PayoffRule(when: when, points: points))
+    }
+    return result
   }
 
   /// Parses the `action_deltas:` map for `relationship_update` phases — a

--- a/Pastura/Pastura/Engine/ScenarioSemanticLinter+Config.swift
+++ b/Pastura/Pastura/Engine/ScenarioSemanticLinter+Config.swift
@@ -13,13 +13,14 @@ import Foundation
 /// rules.
 nonisolated extension ScenarioSemanticLinter {
 
-  /// Silently-inert-configuration findings (R7/R8/R9/R17/R18).
+  /// Silently-inert-configuration findings (R7/R8/R9/R17/R18/R20a/R20b).
   func configFindings(in scenario: Scenario) -> [LintFinding] {
     chooseOptionsFindings(in: scenario.phases)
       + assignSourceFindings(in: scenario.phases, scenario: scenario)
       + summarizePairingFindings(in: scenario.phases)
       + logWindowFindings(in: scenario)
       + maxSentencesNoOpFindings(in: scenario.phases)
+      + payoffTokenFindings(in: scenario.phases)
   }
 
   // MARK: - R7 choose-should-declare-options (warning)
@@ -151,6 +152,66 @@ nonisolated extension ScenarioSemanticLinter {
       .map { configFinding("max-sentences-no-op", .warning, at: $0.topLevelIndex) }
   }
 
+  // MARK: - R20a pairwise-payoff-no-scorable-row (error) / R20b dead-row (warning)
+
+  /// R20a/R20b (ADR-024 § Amendment 2026-07-17): a `pairwise_payoff` `payoff`
+  /// table whose `when` tokens are checked against the round-robin `choose`
+  /// options that populate its pairings. A `when` token outside the option set
+  /// can never match a real (canonicalized) action, so its row is dead.
+  ///
+  /// - **R20a** (`.error`): *no* row is satisfiable (incl. an absent/empty
+  ///   `payoff:`) → every pairing scores nothing, a guaranteed no-op.
+  /// - **R20b** (`.warning`): some rows fire but at least one is dead → the
+  ///   phase still scores; leaving combinations unlisted is a legitimate choice.
+  ///
+  /// Skipped when no options-bearing round-robin `choose` precedes: R19 owns the
+  /// "no round-robin choose" case and R7 owns "choose with no options", so R20
+  /// has no closed set to check and must not double-report.
+  private func payoffTokenFindings(in phases: [Phase]) -> [LintFinding] {
+    let chooseOptions = roundRobinChooseOptions(in: phases)
+    return phaseRefs(in: phases, where: { $0.type == .scoreCalc && $0.logic == .pairwisePayoff })
+      .compactMap { payoffFinding(for: $0, chooseOptions: chooseOptions) }
+  }
+
+  /// Round-robin `choose` phases carrying a non-empty `options` list, paired with
+  /// the top-level index their pairings anchor to (a branch choose counts at its
+  /// conditional's index — the may-run imprecision shared with the ordering rules).
+  private func roundRobinChooseOptions(in phases: [Phase]) -> [(index: Int, options: Set<String>)] {
+    var result: [(index: Int, options: Set<String>)] = []
+    for (index, phase) in phases.enumerated() {
+      for candidate in [phase] + branchPhases(of: phase)
+      where candidate.type == .choose && candidate.pairing == .roundRobin {
+        let options = candidate.options ?? []
+        if !options.isEmpty { result.append((index, Set(options))) }
+      }
+    }
+    return result
+  }
+
+  /// The R20a/R20b finding for one `pairwise_payoff` `score_calc`, or `nil` when
+  /// it has no options-bearing round-robin `choose` producer (R19/R7 territory)
+  /// or every row is satisfiable.
+  private func payoffFinding(
+    for ref: PhaseRef, chooseOptions: [(index: Int, options: Set<String>)]
+  ) -> LintFinding? {
+    let idx = ref.topLevelIndex
+    guard
+      let options = chooseOptions.filter({ $0.index <= idx })
+        .max(by: { $0.index < $1.index })?.options
+    else { return nil }
+    let rows = ref.phase.payoff ?? []
+    let satisfiable = rows.filter {
+      $0.when.count == 2 && options.contains($0.when[0]) && options.contains($0.when[1])
+    }
+    if satisfiable.isEmpty {
+      return configFinding("pairwise-payoff-no-scorable-row", .error, at: idx)
+    }
+    if satisfiable.count < rows.count {
+      return configFinding("pairwise-payoff-dead-row", .warning, at: idx)
+    }
+    return nil
+  }
+
   // MARK: - Shared
 
   /// Builds the single-element findings array for a config `ruleID`,
@@ -184,6 +245,16 @@ nonisolated extension ScenarioSemanticLinter {
       return String(
         localized:
           "max-sentences-no-op: this phase emits no LLM statement, so its 'max_sentences' cap never reaches a prompt and has no effect — remove it, or move it to a phase that emits a statement (speak_all / speak_each / whisper)."
+      )
+    case "pairwise-payoff-no-scorable-row":
+      return String(
+        localized:
+          "pairwise-payoff-no-scorable-row: no 'payoff' row's 'when' tokens match the round-robin 'choose' options, so no pairing is ever scored — add a 'payoff' table whose 'when' rows use the 'choose' option tokens."
+      )
+    case "pairwise-payoff-dead-row":
+      return String(
+        localized:
+          "pairwise-payoff-dead-row: one or more 'payoff' rows use 'when' tokens that aren't in the round-robin 'choose' options, so those rows never fire — fix the tokens to match the 'choose' options, or remove the unused rows."
       )
     default:
       return String(

--- a/Pastura/Pastura/Engine/ScenarioSemanticLinter+Config.swift
+++ b/Pastura/Pastura/Engine/ScenarioSemanticLinter+Config.swift
@@ -156,8 +156,14 @@ nonisolated extension ScenarioSemanticLinter {
 
   /// R20a/R20b (ADR-024 § Amendment 2026-07-17): a `pairwise_payoff` `payoff`
   /// table whose `when` tokens are checked against the round-robin `choose`
-  /// options that populate its pairings. A `when` token outside the option set
-  /// can never match a real (canonicalized) action, so its row is dead.
+  /// options that populate its pairings. `ChooseHandler.validateAction`
+  /// canonicalizes every action to an **exact** option string (on-menu verbatim,
+  /// else `options[0]`) — no case/whitespace folding — and `PairwisePayoffLogic`
+  /// matches rows by exact `==`, so a `when` token outside the option set can
+  /// never match a real action and its row is dead. The exact `Set.contains`
+  /// below mirrors that runtime exactly; if a future change (ADR-021 § Amendment,
+  /// PR2.5) adds folding to `validateAction`, fold both sides here too, or this
+  /// blocking `.error` rule becomes stricter than the runtime it models.
   ///
   /// - **R20a** (`.error`): *no* row is satisfiable (incl. an absent/empty
   ///   `payoff:`) → every pairing scores nothing, a guaranteed no-op.

--- a/Pastura/Pastura/Engine/ScenarioSemanticLinter+Ordering.swift
+++ b/Pastura/Pastura/Engine/ScenarioSemanticLinter+Ordering.swift
@@ -85,10 +85,10 @@ nonisolated extension ScenarioSemanticLinter {
   ///   interleaves.
   /// - **`actionDeltas`** reads `state.pairings`, populated only by a
   ///   round-robin `choose`. Broken when (a) no round-robin `choose` runs before
-  ///   this phase, or (b) a `prisoners_dilemma` `score_calc` clears
-  ///   `state.pairings` (see `PrisonersDilemmaLogic`) between the LAST preceding
-  ///   round-robin `choose` and this phase — a later choose surviving un-cleared
-  ///   satisfies the rule (no false positive).
+  ///   this phase, or (b) a pairings-clearing `score_calc` (`prisoners_dilemma`
+  ///   or `pairwise_payoff` — both clear `state.pairings`) sits between the LAST
+  ///   preceding round-robin `choose` and this phase — a later choose surviving
+  ///   un-cleared satisfies the rule (no false positive).
   ///
   /// One finding per phase max. Fires when ANY declared rule's signal is lost:
   /// a phase declaring both rules where only one is reachable is still a real
@@ -101,8 +101,12 @@ nonisolated extension ScenarioSemanticLinter {
     let roundRobinChoose = producerIndices(in: phases) {
       $0.type == .choose && $0.pairing == .roundRobin
     }
-    let pdScoreCalc = producerIndices(in: phases) {
-      $0.type == .scoreCalc && $0.logic == .prisonersDilemma
+    // Both `prisoners_dilemma` and `pairwise_payoff` clear `state.pairings`
+    // after scoring (ADR-027), so both break a later `action_deltas` read. This
+    // is an `==` predicate — invisible to ADR-022's compiler gate, so it must be
+    // hand-maintained when a pairings-clearing logic is added.
+    let pairingsClearingScoreCalc = producerIndices(in: phases) {
+      $0.type == .scoreCalc && ($0.logic == .prisonersDilemma || $0.logic == .pairwisePayoff)
     }
     // `lastOutputs`-writers that DROP the vote field. A second `vote` rewrites a
     // fresher vote rather than losing it, so `.vote` is excluded here.
@@ -118,7 +122,8 @@ nonisolated extension ScenarioSemanticLinter {
         && voteSignalUnreachable(before: i, votes: votes, losers: voteSignalLosers)
       let actionBroken =
         !(phase.actionDeltas ?? [:]).isEmpty
-        && actionSignalUnreachable(before: i, choose: roundRobinChoose, clears: pdScoreCalc)
+        && actionSignalUnreachable(
+          before: i, choose: roundRobinChoose, clears: pairingsClearingScoreCalc)
       if voteBroken || actionBroken {
         findings += finding("relationship-update-placement", .warning, at: i)
       }
@@ -136,11 +141,35 @@ nonisolated extension ScenarioSemanticLinter {
 
   /// Whether an `action_deltas` rule at top-level index `i` can't read pairings:
   /// no round-robin `choose` precedes it, or a pairings-clearing
-  /// `prisoners_dilemma` `score_calc` sits between the last preceding
-  /// round-robin `choose` and it (a later un-cleared choose satisfies the rule).
+  /// `prisoners_dilemma` / `pairwise_payoff` `score_calc` sits between the last
+  /// preceding round-robin `choose` and it (a later un-cleared choose satisfies
+  /// the rule).
   private func actionSignalUnreachable(before i: Int, choose: Set<Int>, clears: Set<Int>) -> Bool {
     guard let lastChoose = choose.filter({ $0 < i }).max() else { return true }
     return clears.contains { $0 > lastChoose && $0 < i }
+  }
+
+  /// Shared R2 (`pd-needs-round-robin-choose`) / R19
+  /// (`pairwise-payoff-needs-round-robin-choose`) predicate: a pairing-consuming
+  /// `score_calc` at top-level index `idx` needs a round-robin `choose` at or
+  /// before it to populate `state.pairings`, or scores never change. `true` ⇒
+  /// the finding fires. Extracted so R2 and R19 share one predicate while
+  /// keeping distinct ruleIDs (ADR-024 § Amendment 2026-07-17).
+  private func needsRoundRobinChoose(at idx: Int, roundRobinChoose: Set<Int>) -> Bool {
+    !roundRobinChoose.contains(where: { $0 <= idx })
+  }
+
+  /// R3 `wordwolf-needs-assign-and-vote` (error): `wordwolf_judge` needs both an
+  /// `assign target: random_one` (to pick the odd-one-out) and a `vote` at or
+  /// before it. Extracted from `scoreCalcFindings` to keep its cyclomatic
+  /// complexity within the lint budget after R19's arm was added.
+  private func wordwolfFindings(
+    at idx: Int, votes: Set<Int>, assignRandomOne: Set<Int>
+  ) -> [LintFinding] {
+    let hasAssign = assignRandomOne.contains { $0 <= idx }
+    let hasVote = votes.contains { $0 <= idx }
+    guard !(hasAssign && hasVote) else { return [] }
+    return finding("wordwolf-needs-assign-and-vote", .error, at: idx)
   }
 
   // MARK: - Per-consumer rules
@@ -157,7 +186,7 @@ nonisolated extension ScenarioSemanticLinter {
     return []
   }
 
-  /// R2/R3/R5/R6 — the `score_calc` logic-specific producer dependencies.
+  /// R2/R3/R5/R6/R19 — the `score_calc` logic-specific producer dependencies.
   private func scoreCalcFindings(
     _ consumer: PhaseRef, votes: Set<Int>, roundRobinChoose: Set<Int>,
     assignRandomOne: Set<Int>, eventInject: Set<Int>
@@ -165,13 +194,16 @@ nonisolated extension ScenarioSemanticLinter {
     let idx = consumer.topLevelIndex
     switch consumer.phase.logic {
     case .prisonersDilemma:
-      guard !roundRobinChoose.contains(where: { $0 <= idx }) else { return [] }
+      guard needsRoundRobinChoose(at: idx, roundRobinChoose: roundRobinChoose) else { return [] }
       return finding("pd-needs-round-robin-choose", .error, at: idx)
+    case .pairwisePayoff:
+      // R19 — semantically identical to R2, but a distinct ruleID (ADR-024 D3
+      // "IDs are stable"): a `pd-needs-…` finding on a scenario with no
+      // prisoner's dilemma names the wrong mechanic. Shares R2's predicate.
+      guard needsRoundRobinChoose(at: idx, roundRobinChoose: roundRobinChoose) else { return [] }
+      return finding("pairwise-payoff-needs-round-robin-choose", .error, at: idx)
     case .wordwolfJudge:
-      let hasAssign = assignRandomOne.contains { $0 <= idx }
-      let hasVote = votes.contains { $0 <= idx }
-      guard !(hasAssign && hasVote) else { return [] }
-      return finding("wordwolf-needs-assign-and-vote", .error, at: idx)
+      return wordwolfFindings(at: idx, votes: votes, assignRandomOne: assignRandomOne)
     case .eventReactive:
       guard !eventInject.contains(where: { $0 <= idx }) else { return [] }
       return finding("event-reactive-needs-event-inject", .error, at: idx)
@@ -214,6 +246,11 @@ nonisolated extension ScenarioSemanticLinter {
       return String(
         localized:
           "pd-needs-round-robin-choose: 'prisoners_dilemma' scoring needs a round-robin 'choose' phase earlier in the round to populate pairings, or scores never change — add one before this 'score_calc'."
+      )
+    case "pairwise-payoff-needs-round-robin-choose":
+      return String(
+        localized:
+          "pairwise-payoff-needs-round-robin-choose: 'pairwise_payoff' scoring needs a round-robin 'choose' phase earlier in the round to populate pairings, or scores never change — add one before this 'score_calc'."
       )
     case "wordwolf-needs-assign-and-vote":
       return String(

--- a/Pastura/Pastura/Engine/ScenarioSerializer.swift
+++ b/Pastura/Pastura/Engine/ScenarioSerializer.swift
@@ -193,7 +193,10 @@ nonisolated struct ScenarioSerializer: Sendable {
 
     // pairwise_payoff table (ADR-027). Flow sequences per row; `when` tokens are
     // quoted for round-trip safety (they may be CJK / contain YAML specials).
-    if let payoff = phase.payoff {
+    // Gate on non-empty: an empty table is a behavioural no-op (like nil), and
+    // emitting a childless `payoff:` line would reload as a null scalar that
+    // `parsePayoff` rejects — so collapse empty→omitted to keep the round-trip.
+    if let payoff = phase.payoff, !payoff.isEmpty {
       lines.append("    payoff:")
       for row in payoff {
         let when = row.when.map { yamlScalar($0) }.joined(separator: ", ")

--- a/Pastura/Pastura/Engine/ScenarioSerializer.swift
+++ b/Pastura/Pastura/Engine/ScenarioSerializer.swift
@@ -191,6 +191,18 @@ nonisolated struct ScenarioSerializer: Sendable {
       lines.append("    narrator: \(yamlScalar(narrator))")
     }
 
+    // pairwise_payoff table (ADR-027). Flow sequences per row; `when` tokens are
+    // quoted for round-trip safety (they may be CJK / contain YAML specials).
+    if let payoff = phase.payoff {
+      lines.append("    payoff:")
+      for row in payoff {
+        let when = row.when.map { yamlScalar($0) }.joined(separator: ", ")
+        let points = row.points.map(String.init).joined(separator: ", ")
+        lines.append("      - when: [\(when)]")
+        lines.append("        points: [\(points)]")
+      }
+    }
+
     return lines
   }
 

--- a/Pastura/Pastura/Engine/ScoringLogic/PairwisePayoffLogic.swift
+++ b/Pastura/Pastura/Engine/ScoringLogic/PairwisePayoffLogic.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Generic pairwise payoff scoring logic (ADR-027).
+///
+/// Scores each `Pairing` by matching `(action1, action2)` positionally against
+/// a YAML-authored payoff table (`[PayoffRule]`). The first row whose `when`
+/// equals the pairing's two actions awards `points[0]` to `agent1` and
+/// `points[1]` to `agent2`. A pairing matching no row scores nothing — the
+/// engine never fabricates a verdict (a `nil` action, an off-table action
+/// pair, or an empty table all degrade to zero, per ADR-027 § "Dead code
+/// removed in passing").
+///
+/// Mirrors the YAML-authored-token shape of `EventReactivePayoffLogic` (#931):
+/// no option literal is hardcoded here, so localized tokens (`[協力, 裏切り]`)
+/// and chicken / stag-hunt tables score with no engine change. Clears
+/// `state.pairings` after scoring, exactly as the legacy `PrisonersDilemmaLogic`
+/// shim does.
+nonisolated struct PairwisePayoffLogic: Sendable {
+
+  func calculate(
+    state: inout SimulationState,
+    payoff: [PayoffRule],
+    emitter: @Sendable (SimulationEvent) -> Void
+  ) {
+    for pairing in state.pairings {
+      guard let act1 = pairing.action1, let act2 = pairing.action2 else {
+        // A half-real pairing (either action nil) matches no row and scores
+        // nothing — the correct degradation, not a fabricated verdict.
+        continue
+      }
+      guard let row = payoff.first(where: { $0.when == [act1, act2] }),
+        row.points.count == 2
+      else {
+        // No row for this action pair (or a malformed row that slipped past
+        // the loader's arity guard) → score nothing.
+        continue
+      }
+      state.scores[pairing.agent1, default: 0] += row.points[0]
+      state.scores[pairing.agent2, default: 0] += row.points[1]
+    }
+
+    emitter(.scoreUpdate(scores: state.scores))
+    state.pairings = []
+  }
+}

--- a/Pastura/Pastura/Engine/ScoringLogic/PrisonersDilemmaLogic.swift
+++ b/Pastura/Pastura/Engine/ScoringLogic/PrisonersDilemmaLogic.swift
@@ -1,42 +1,36 @@
 import Foundation
 
-/// Prisoner's dilemma scoring logic.
+/// Prisoner's dilemma scoring logic — a **legacy shim** over
+/// `PairwisePayoffLogic` (ADR-027).
 ///
-/// Payoff matrix:
-/// - cooperate/cooperate = 3, 3
-/// - cooperate/betray = 0, 5
-/// - betray/cooperate = 5, 0
-/// - betray/betray = 1, 1
+/// This case is kept indefinitely, NOT because prisoner's dilemma is special,
+/// but because a user's "Copy & Edit" clone on a shipped device may carry
+/// `logic: prisoners_dilemma` in its saved YAML; deleting the case would make
+/// that record unopenable (ADR-027 § "Why the legacy case cannot be retired").
+/// New scenarios should use `pairwise_payoff` with a YAML `payoff:` table.
 ///
-/// Reads actions from `Pairing.action1/action2` and clears pairings after scoring.
+/// The shim hands `PairwisePayoffLogic` the fixed English payoff table below.
+/// That table is the game's rule set — it must **not** be trimmed: dropping the
+/// `[betray, betray] → [1, 1]` row would score mutual defection as 0 in shipped
+/// TestFlight content (ADR-027 § "What it shrinks to").
 nonisolated struct PrisonersDilemmaLogic: Sendable {
+
+  /// The legacy prisoner's-dilemma payoff matrix. Exhaustive over
+  /// `{cooperate, betray}²`, so for all shipped content every pairing matches a
+  /// row — the shim is behaviourally identical to the pre-ADR-027 hardcoded
+  /// `switch` for every reachable action pair.
+  static let legacyTable: [PayoffRule] = [
+    PayoffRule(when: ["cooperate", "cooperate"], points: [3, 3]),
+    PayoffRule(when: ["cooperate", "betray"], points: [0, 5]),
+    PayoffRule(when: ["betray", "cooperate"], points: [5, 0]),
+    PayoffRule(when: ["betray", "betray"], points: [1, 1])
+  ]
 
   func calculate(
     state: inout SimulationState,
     emitter: @Sendable (SimulationEvent) -> Void
   ) {
-    for pairing in state.pairings {
-      let act1 = pairing.action1 ?? "cooperate"
-      let act2 = pairing.action2 ?? "cooperate"
-
-      switch (act1, act2) {
-      case ("cooperate", "cooperate"):
-        state.scores[pairing.agent1, default: 0] += 3
-        state.scores[pairing.agent2, default: 0] += 3
-      case ("cooperate", "betray"):
-        // agent1 gets 0, agent2 gets 5
-        state.scores[pairing.agent2, default: 0] += 5
-      case ("betray", "cooperate"):
-        state.scores[pairing.agent1, default: 0] += 5
-      // agent2 gets 0
-      default:
-        // betray/betray
-        state.scores[pairing.agent1, default: 0] += 1
-        state.scores[pairing.agent2, default: 0] += 1
-      }
-    }
-
-    emitter(.scoreUpdate(scores: state.scores))
-    state.pairings = []
+    PairwisePayoffLogic().calculate(
+      state: &state, payoff: Self.legacyTable, emitter: emitter)
   }
 }

--- a/Pastura/Pastura/Models/PayoffRule.swift
+++ b/Pastura/Pastura/Models/PayoffRule.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// A single row of a `pairwise_payoff` scoring table (ADR-027).
+///
+/// `when` is matched **positionally** against `Pairing.action1` / `action2`;
+/// `points` awards `[agent1, agent2]`. Both are two-element arrays — the
+/// `ScenarioLoader` rejects any other arity at parse time, and
+/// `PairwisePayoffLogic` additionally guards defensively. A pairing matching
+/// no row scores nothing (the engine never invents a verdict).
+///
+/// The payoff table is authored in scenario YAML rather than compiled into
+/// Swift, so chicken / stag-hunt variants and localized option tokens
+/// (`[協力, 裏切り]`) become writable without an engine change. See ADR-027.
+nonisolated public struct PayoffRule: Codable, Sendable, Equatable {
+  /// The pair of actions this row matches, positional against
+  /// `Pairing.action1` / `action2` (e.g. `["cooperate", "betray"]`).
+  public let when: [String]
+
+  /// The points awarded, positional against `Pairing.agent1` / `agent2`
+  /// (e.g. `[0, 5]` — agent1 gets 0, agent2 gets 5).
+  public let points: [Int]
+
+  public init(when: [String], points: [Int]) {
+    self.when = when
+    self.points = points
+  }
+}

--- a/Pastura/Pastura/Models/Phase.swift
+++ b/Pastura/Pastura/Models/Phase.swift
@@ -140,6 +140,17 @@ nonisolated public struct Phase: Codable, Sendable, Equatable {
   /// See #909.
   public let narrator: String?
 
+  /// Payoff table for a `score_calc` phase whose `logic` is `pairwise_payoff`
+  /// (the YAML `payoff:` key, a list of `{when: [String], points: [Int]}`
+  /// rows). See `PayoffRule` and ADR-027.
+  ///
+  /// `nil` for every other logic. A `pairwise_payoff` phase with no rows (or
+  /// none satisfiable by the `choose` options) is a guaranteed no-op, flagged
+  /// by the semantic linter (R20a). YAML-only (no visual editor field), but
+  /// round-trips through the editor's dual buffer like `narrator` /
+  /// `action_deltas`.
+  public let payoff: [PayoffRule]?
+
   public init(
     type: PhaseType,
     prompt: String? = nil,
@@ -161,7 +172,8 @@ nonisolated public struct Phase: Codable, Sendable, Equatable {
     actionDeltas: [String: Int]? = nil,
     maxSentences: Int? = nil,
     noRepeat: Bool? = nil,
-    narrator: String? = nil
+    narrator: String? = nil,
+    payoff: [PayoffRule]? = nil
   ) {
     self.type = type
     self.prompt = prompt
@@ -184,6 +196,7 @@ nonisolated public struct Phase: Codable, Sendable, Equatable {
     self.maxSentences = maxSentences
     self.noRepeat = noRepeat
     self.narrator = narrator
+    self.payoff = payoff
   }
 
   /// The schema's required keys as a `Set`, or an empty set when the

--- a/Pastura/Pastura/Models/ScenarioValidationMessage.swift
+++ b/Pastura/Pastura/Models/ScenarioValidationMessage.swift
@@ -65,6 +65,8 @@ nonisolated public enum ScenarioValidationMessage: Sendable {
   case invalidLogic(label: String, value: String, allowed: String)
   case actionDeltasNotDict(label: String, got: String)
   case actionDeltasValueNotInt(label: String, key: String, got: String)
+  case payoffNotList(label: String, got: String)
+  case payoffRowInvalid(label: String, detail: String)
   case phaseMissingType(label: String)
   case phaseInvalidType(label: String, value: String)
   case outputNotDict(label: String, got: String)
@@ -253,6 +255,17 @@ nonisolated extension ScenarioValidationMessage {
       return String(
         format: String(localized: "%@: action_deltas value for '%@' must be Int, got %@"),
         label, key, got)
+    case .payoffNotList(let label, let got):
+      return String(
+        format: String(
+          localized: "%@: field 'payoff' must be a list of {when, points} rows, got %@"),
+        label, got)
+    case .payoffRowInvalid(let label, let detail):
+      return String(
+        format: String(
+          localized:
+            "%@: each 'payoff' row needs 'when' (2 strings) and 'points' (2 ints) — %@"),
+        label, detail)
     case .phaseMissingType(let label):
       return String(format: String(localized: "%@ missing 'type'"), label)
     case .phaseInvalidType(let label, let value):

--- a/Pastura/Pastura/Models/ScoreCalcLogic.swift
+++ b/Pastura/Pastura/Models/ScoreCalcLogic.swift
@@ -23,4 +23,11 @@ nonisolated public enum ScoreCalcLogic: String, Codable, Sendable, CaseIterable 
   /// peer vote (the local judge's conservative prior never credits a bold
   /// read). See `EventReactivePayoffLogic` and #931.
   case eventReactive = "event_reactive"
+
+  /// Generic two-player payoff table authored in scenario YAML (`payoff:`),
+  /// matched positionally against a round-robin `choose`'s pairings. Supersedes
+  /// the hardcoded matrix of ``prisonersDilemma`` (kept as a legacy shim) and
+  /// unblocks localized option tokens + chicken / stag-hunt variants with no
+  /// engine change. See `PairwisePayoffLogic`, `PayoffRule`, and ADR-027.
+  case pairwisePayoff = "pairwise_payoff"
 }

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -8206,6 +8206,16 @@
         }
       }
     },
+    "pairwise-payoff-needs-round-robin-choose: 'pairwise_payoff' scoring needs a round-robin 'choose' phase earlier in the round to populate pairings, or scores never change — add one before this 'score_calc'." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "pairwise-payoff-needs-round-robin-choose: 'pairwise_payoff' スコアリングには、ペアリングを埋めるためラウンド内のより前にラウンドロビン形式の 'choose' フェーズが必要です。ないとスコアが変化しません — この 'score_calc' より前に追加してください。"
+          }
+        }
+      }
+    },
     "pd-needs-round-robin-choose: 'prisoners_dilemma' scoring needs a round-robin 'choose' phase earlier in the round to populate pairings, or scores never change — add one before this 'score_calc'." : {
       "localizations" : {
         "ja" : {

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -8238,12 +8238,32 @@
         }
       }
     },
+    "pairwise-payoff-dead-row: one or more 'payoff' rows use 'when' tokens that aren't in the round-robin 'choose' options, so those rows never fire — fix the tokens to match the 'choose' options, or remove the unused rows." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "pairwise-payoff-dead-row: 一部の 'payoff' 行の 'when' トークンがラウンドロビン形式の 'choose' の選択肢に含まれていないため、それらの行は決して発火しません — トークンを 'choose' の選択肢に合わせるか、使われない行を削除してください。"
+          }
+        }
+      }
+    },
     "pairwise-payoff-needs-round-robin-choose: 'pairwise_payoff' scoring needs a round-robin 'choose' phase earlier in the round to populate pairings, or scores never change — add one before this 'score_calc'." : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "pairwise-payoff-needs-round-robin-choose: 'pairwise_payoff' スコアリングには、ペアリングを埋めるためラウンド内のより前にラウンドロビン形式の 'choose' フェーズが必要です。ないとスコアが変化しません — この 'score_calc' より前に追加してください。"
+          }
+        }
+      }
+    },
+    "pairwise-payoff-no-scorable-row: no 'payoff' row's 'when' tokens match the round-robin 'choose' options, so no pairing is ever scored — add a 'payoff' table whose 'when' rows use the 'choose' option tokens." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "pairwise-payoff-no-scorable-row: どの 'payoff' 行の 'when' トークンもラウンドロビン形式の 'choose' の選択肢と一致しないため、どのペアリングも採点されません — 'when' 行が 'choose' の選択肢トークンを使う 'payoff' テーブルを追加してください。"
           }
         }
       }

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -713,6 +713,22 @@
         }
       }
     },
+    "%@: each 'payoff' row needs 'when' (2 strings) and 'points' (2 ints) — %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: each 'payoff' row needs 'when' (2 strings) and 'points' (2 ints) — %2$@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: 各 'payoff' 行には 'when'（文字列2つ）と 'points'（整数2つ）が必要です — %2$@"
+          }
+        }
+      }
+    },
     "%@: field '%@' must be %@, got %@" : {
       "localizations" : {
         "en" : {
@@ -773,6 +789,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@: フィールド 'output' は String 値の辞書である必要がありますが、%2$@ が指定されました"
+          }
+        }
+      }
+    },
+    "%@: field 'payoff' must be a list of {when, points} rows, got %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: field 'payoff' must be a list of {when, points} rows, got %2$@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@: フィールド 'payoff' は {when, points} 行のリストである必要があります。実際は %2$@"
           }
         }
       }

--- a/Pastura/Pastura/Views/Components/SimulationResultCard+Model.swift
+++ b/Pastura/Pastura/Views/Components/SimulationResultCard+Model.swift
@@ -80,10 +80,14 @@ extension SimulationResultCard {
         )
       }
 
-      // 2. Pairing — round-robin choose or a prisoner's-dilemma scoring.
+      // 2. Pairing — round-robin choose or a pairwise scoring
+      //    (prisoners_dilemma / pairwise_payoff, ADR-027). This is an `==`
+      //    predicate invisible to ADR-022's compiler gate — hand-maintained.
       let isPairing =
         phases.contains { $0.type == .choose && $0.pairing == .roundRobin }
-        || phases.contains { $0.type == .scoreCalc && $0.logic == .prisonersDilemma }
+        || phases.contains {
+          $0.type == .scoreCalc && ($0.logic == .prisonersDilemma || $0.logic == .pairwisePayoff)
+        }
       if isPairing, hasScores {
         return (.pairing, rankedByScore(roster: roster, scores: scores, eliminated: eliminated))
       }

--- a/Pastura/PasturaTests/App/EditablePhaseRoundTripTests.swift
+++ b/Pastura/PasturaTests/App/EditablePhaseRoundTripTests.swift
@@ -74,6 +74,27 @@ struct EditablePhaseRoundTripTests {
     #expect(reloaded.phases.first?.thenPhases?.first?.maxSentences == 6)
   }
 
+  /// The `pairwise_payoff` `payoff:` table (ADR-027) survives both round-trip
+  /// bridges. `canonicalPhase(.scoreCalc)` uses the legacy `prisoners_dilemma`
+  /// (no `payoff`), so this dedicated fixture is what exercises the new field.
+  @Test func payoffTableRoundTripsBothBridges() throws {
+    let phase = Phase(
+      type: .scoreCalc, logic: .pairwisePayoff,
+      payoff: [
+        PayoffRule(when: ["協力", "協力"], points: [3, 3]),
+        PayoffRule(when: ["裏切り", "裏切り"], points: [1, 1])
+      ])
+
+    // Visual bridge.
+    let viaEditable = EditablePhase(from: phase).toPhase()
+    #expect(viaEditable.payoff == phase.payoff)
+
+    // YAML bridge.
+    let reloaded = try loader.load(yaml: serializer.serialize(wrap(phase)))
+    #expect(reloaded.phases.first?.payoff == phase.payoff)
+    #expect(reloaded.phases.first?.logic == .pairwisePayoff)
+  }
+
   // One arm per PhaseType, no nested logic. Block disable rather than
   // `disable:next` (which would orphan the doc comment below it); the disable
   // command line must hold only the rule name, so this rationale is separate.

--- a/Pastura/PasturaTests/Engine/EngineSchemaVersionTests.swift
+++ b/Pastura/PasturaTests/Engine/EngineSchemaVersionTests.swift
@@ -8,13 +8,14 @@ struct EngineSchemaVersionTests {
 
   // MARK: - Current version constant
 
-  @Test func currentVersionIsFour() {
+  @Test func currentVersionIsFive() {
     // Bumped 1→2 for event_inject no_repeat (#1006, ADR-020 §8); 2→3 for the
     // narrate phase (#909, ADR-020 §9); 3→4 for Persona.secret (#914 — an old
     // app silently drops the key and runs every agent without its hidden
-    // agenda). Update in lockstep with any further
-    // EngineSchemaVersion.current bump.
-    #expect(EngineSchemaVersion.current == 4)
+    // agenda); 4→5 for ScoreCalcLogic.pairwise_payoff (ADR-027 — a new
+    // by-name-parsed score_calc logic, an old app throws on it via D5). Update
+    // in lockstep with any further EngineSchemaVersion.current bump.
+    #expect(EngineSchemaVersion.current == 5)
   }
 
   // MARK: - D2 (phase-capability) branch

--- a/Pastura/PasturaTests/Engine/ScenarioLoaderTests+Payoff.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioLoaderTests+Payoff.swift
@@ -78,7 +78,9 @@ extension ScenarioLoaderTests {
       Issue.record("Expected scenarioValidationFailed, got \(error)")
       return
     }
-    #expect(msg.contains("when"))
+    // The message template names both fields, so assert the discriminating
+    // detail suffix, not a bare "when" substring.
+    #expect(msg.contains("'when' must be 2 strings"))
   }
 
   @Test func throwsOnPointsArityNotTwo() throws {
@@ -98,7 +100,7 @@ extension ScenarioLoaderTests {
       Issue.record("Expected scenarioValidationFailed, got \(error)")
       return
     }
-    #expect(msg.contains("points"))
+    #expect(msg.contains("'points' must be 2 ints"))
   }
 
   @Test func throwsOnPayoffNotList() throws {

--- a/Pastura/PasturaTests/Engine/ScenarioLoaderTests+Payoff.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioLoaderTests+Payoff.swift
@@ -1,0 +1,121 @@
+import Testing
+
+@testable import Pastura
+
+/// Parse coverage for the `payoff:` table on a `pairwise_payoff` `score_calc`
+/// phase (ADR-027). Guards the literal YAML key names + strict arity, which a
+/// serializer↔loader round-trip alone cannot (a symmetric mis-key round-trips).
+extension ScenarioLoaderTests {
+
+  private var payoffHeader: String {
+    """
+    id: t
+    language: ja
+    name: T
+    description: d
+    agents: 2
+    rounds: 1
+    context: c
+    personas:
+      - name: Alice
+        description: a
+      - name: Bob
+        description: b
+    phases:
+    """
+  }
+
+  @Test func parsesPayoffTableOnScoreCalc() throws {
+    let yaml =
+      payoffHeader + """
+
+          - type: choose
+            options: [協力, 裏切り]
+            pairing: round_robin
+          - type: score_calc
+            logic: pairwise_payoff
+            payoff:
+              - when: [協力, 協力]
+                points: [3, 3]
+              - when: [裏切り, 裏切り]
+                points: [1, 1]
+        """
+    let scenario = try loader.load(yaml: yaml)
+    let payoff = try #require(scenario.phases[1].payoff)
+    #expect(payoff.count == 2)
+    #expect(payoff[0] == PayoffRule(when: ["協力", "協力"], points: [3, 3]))
+    #expect(payoff[1] == PayoffRule(when: ["裏切り", "裏切り"], points: [1, 1]))
+  }
+
+  @Test func absentPayoffLeavesNilNotThrow() throws {
+    // `load` stays non-validating (#665): a pairwise_payoff phase with no
+    // `payoff:` loads with `payoff == nil` — the guaranteed-no-op is a linter
+    // concern (R20a), not a load throw.
+    let yaml =
+      payoffHeader + """
+
+          - type: score_calc
+            logic: pairwise_payoff
+        """
+    let scenario = try loader.load(yaml: yaml)
+    #expect(scenario.phases[0].payoff == nil)
+  }
+
+  @Test func throwsOnWhenArityNotTwo() throws {
+    let yaml =
+      payoffHeader + """
+
+          - type: score_calc
+            logic: pairwise_payoff
+            payoff:
+              - when: [協力]
+                points: [3, 3]
+        """
+    let error = try #require(throws: SimulationError.self) {
+      try loader.load(yaml: yaml)
+    }
+    guard case .scenarioValidationFailed(let msg) = error else {
+      Issue.record("Expected scenarioValidationFailed, got \(error)")
+      return
+    }
+    #expect(msg.contains("when"))
+  }
+
+  @Test func throwsOnPointsArityNotTwo() throws {
+    let yaml =
+      payoffHeader + """
+
+          - type: score_calc
+            logic: pairwise_payoff
+            payoff:
+              - when: [協力, 協力]
+                points: [3]
+        """
+    let error = try #require(throws: SimulationError.self) {
+      try loader.load(yaml: yaml)
+    }
+    guard case .scenarioValidationFailed(let msg) = error else {
+      Issue.record("Expected scenarioValidationFailed, got \(error)")
+      return
+    }
+    #expect(msg.contains("points"))
+  }
+
+  @Test func throwsOnPayoffNotList() throws {
+    let yaml =
+      payoffHeader + """
+
+          - type: score_calc
+            logic: pairwise_payoff
+            payoff: not_a_list
+        """
+    let error = try #require(throws: SimulationError.self) {
+      try loader.load(yaml: yaml)
+    }
+    guard case .scenarioValidationFailed(let msg) = error else {
+      Issue.record("Expected scenarioValidationFailed, got \(error)")
+      return
+    }
+    #expect(msg.contains("payoff"))
+  }
+}

--- a/Pastura/PasturaTests/Engine/ScenarioSemanticLinterTests+Ordering.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioSemanticLinterTests+Ordering.swift
@@ -103,6 +103,47 @@ extension ScenarioSemanticLinterTests {
     #expect(linter.lint(scenario).isEmpty)
   }
 
+  // MARK: - R19 pairwise-payoff-needs-round-robin-choose (error)
+
+  /// A four-row payoff table over `{cooperate, betray}²` — satisfiable by the
+  /// `["cooperate", "betray"]` option set, so R20a (item 3) stays silent and
+  /// these fixtures isolate R19.
+  private var pdPayoff: [PayoffRule] {
+    [
+      PayoffRule(when: ["cooperate", "cooperate"], points: [3, 3]),
+      PayoffRule(when: ["cooperate", "betray"], points: [0, 5]),
+      PayoffRule(when: ["betray", "cooperate"], points: [5, 0]),
+      PayoffRule(when: ["betray", "betray"], points: [1, 1])
+    ]
+  }
+
+  @Test func pairwisePayoffWithoutRoundRobinChooseFiresError() {
+    // R19 mirrors R2 but keeps a distinct ruleID: an individual (non-round-robin)
+    // choose does not populate pairings, so a pairwise_payoff score_calc scores
+    // nothing. A `pd-`-named finding here would name the wrong mechanic.
+    let scenario = makeScenario(
+      agents: 2, rounds: 1,
+      phases: [
+        Phase(type: .choose, options: ["cooperate", "betray"]),
+        Phase(type: .scoreCalc, logic: .pairwisePayoff, payoff: pdPayoff)
+      ])
+    let findings = linter.lint(scenario)
+    #expect(findings.count == 1)
+    #expect(findings.first?.ruleID == "pairwise-payoff-needs-round-robin-choose")
+    #expect(findings.first?.severity == .error)
+    #expect(findings.first?.phaseIndex == 1)
+  }
+
+  @Test func pairwisePayoffWithRoundRobinChoosePasses() {
+    let scenario = makeScenario(
+      agents: 2, rounds: 1,
+      phases: [
+        Phase(type: .choose, options: ["cooperate", "betray"], pairing: .roundRobin),
+        Phase(type: .scoreCalc, logic: .pairwisePayoff, payoff: pdPayoff)
+      ])
+    #expect(linter.lint(scenario).isEmpty)
+  }
+
   // MARK: - R3 wordwolf-needs-assign-and-vote (error)
 
   @Test func wordwolfWithoutAssignAndVoteFiresError() {
@@ -227,6 +268,23 @@ extension ScenarioSemanticLinterTests {
       phases: [
         Phase(type: .choose, options: ["cooperate", "betray"], pairing: .roundRobin),
         Phase(type: .scoreCalc, logic: .prisonersDilemma),
+        Phase(type: .relationshipUpdate, actionDeltas: ["cooperate": 1, "betray": -1])
+      ])
+    let findings = linter.lint(scenario)
+    #expect(findings.count == 1)
+    #expect(findings.first?.ruleID == "relationship-update-placement")
+    #expect(findings.first?.phaseIndex == 2)
+  }
+
+  @Test func relationshipUpdateWithPairwisePayoffBetweenChooseAndItFiresWarning() {
+    // R4 regression (ADR-027): pairwise_payoff clears state.pairings exactly like
+    // prisoners_dilemma, so it must join the pairings-clearing producer set. If
+    // the `==` predicate omits it, R4 silently stops firing here (false negative).
+    let scenario = makeScenario(
+      agents: 2, rounds: 1,
+      phases: [
+        Phase(type: .choose, options: ["cooperate", "betray"], pairing: .roundRobin),
+        Phase(type: .scoreCalc, logic: .pairwisePayoff, payoff: pdPayoff),
         Phase(type: .relationshipUpdate, actionDeltas: ["cooperate": 1, "betray": -1])
       ])
     let findings = linter.lint(scenario)

--- a/Pastura/PasturaTests/Engine/ScenarioSemanticLinterTests+Payoff.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioSemanticLinterTests+Payoff.swift
@@ -1,0 +1,121 @@
+// R20a/R20b options ↔ payoff.when token rules (ADR-024 § Amendment 2026-07-17).
+// Extension of the existing suite (not a new @Suite) per .claude/rules/testing.md
+// — reuses `linter` / `makeScenario` from the base file.
+import Testing
+
+@testable import Pastura
+
+extension ScenarioSemanticLinterTests {
+
+  /// A four-row payoff table over `{cooperate, betray}²` — fully satisfiable by
+  /// the `["cooperate", "betray"]` option set.
+  private var satisfiablePayoff: [PayoffRule] {
+    [
+      PayoffRule(when: ["cooperate", "cooperate"], points: [3, 3]),
+      PayoffRule(when: ["cooperate", "betray"], points: [0, 5]),
+      PayoffRule(when: ["betray", "cooperate"], points: [5, 0]),
+      PayoffRule(when: ["betray", "betray"], points: [1, 1])
+    ]
+  }
+
+  private func roundRobinChoose(options: [String] = ["cooperate", "betray"]) -> Phase {
+    Phase(type: .choose, options: options, pairing: .roundRobin)
+  }
+
+  // MARK: - R20a pairwise-payoff-no-scorable-row (error)
+
+  @Test func payoffAllRowsOutsideOptionsFiresError() {
+    // Every `when` token is outside the option set → no pairing ever scores.
+    let scenario = makeScenario(
+      agents: 2, rounds: 1,
+      phases: [
+        roundRobinChoose(),
+        Phase(
+          type: .scoreCalc, logic: .pairwisePayoff,
+          payoff: [PayoffRule(when: ["yes", "no"], points: [1, 1])])
+      ])
+    let findings = linter.lint(scenario)
+    #expect(findings.count == 1)
+    #expect(findings.first?.ruleID == "pairwise-payoff-no-scorable-row")
+    #expect(findings.first?.severity == .error)
+    #expect(findings.first?.phaseIndex == 1)
+  }
+
+  @Test func absentPayoffWithValidChooseFiresError() {
+    // A properly-wired pairwise_payoff with no `payoff:` table → guaranteed no-op.
+    let scenario = makeScenario(
+      agents: 2, rounds: 1,
+      phases: [roundRobinChoose(), Phase(type: .scoreCalc, logic: .pairwisePayoff)])
+    let findings = linter.lint(scenario)
+    #expect(findings.count == 1)
+    #expect(findings.first?.ruleID == "pairwise-payoff-no-scorable-row")
+    #expect(findings.first?.severity == .error)
+  }
+
+  // MARK: - R20b pairwise-payoff-dead-row (warning)
+
+  @Test func payoffSomeRowsDeadFiresWarning() {
+    // One satisfiable row + one dead row (`unclear` isn't an option) → the phase
+    // still scores, so a warning, not an error.
+    let scenario = makeScenario(
+      agents: 2, rounds: 1,
+      phases: [
+        roundRobinChoose(),
+        Phase(
+          type: .scoreCalc, logic: .pairwisePayoff,
+          payoff: [
+            PayoffRule(when: ["cooperate", "cooperate"], points: [3, 3]),
+            PayoffRule(when: ["unclear", "unclear"], points: [0, 0])
+          ])
+      ])
+    let findings = linter.lint(scenario)
+    #expect(findings.count == 1)
+    #expect(findings.first?.ruleID == "pairwise-payoff-dead-row")
+    #expect(findings.first?.severity == .warning)
+    #expect(findings.first?.phaseIndex == 1)
+  }
+
+  // MARK: - Passes
+
+  @Test func payoffAllRowsSatisfiablePasses() {
+    let scenario = makeScenario(
+      agents: 2, rounds: 1,
+      phases: [
+        roundRobinChoose(),
+        Phase(type: .scoreCalc, logic: .pairwisePayoff, payoff: satisfiablePayoff)
+      ])
+    #expect(linter.lint(scenario).isEmpty)
+  }
+
+  // MARK: - R20 defers to R19 / R7 (no double-report)
+
+  @Test func payoffWithoutRoundRobinChooseDefersToR19() {
+    // Individual (non-round-robin) choose → R19 owns the empty-pairings case;
+    // R20 must not also fire (no closed option set for the pairings).
+    let scenario = makeScenario(
+      agents: 2, rounds: 1,
+      phases: [
+        Phase(type: .choose, options: ["cooperate", "betray"]),
+        Phase(type: .scoreCalc, logic: .pairwisePayoff, payoff: satisfiablePayoff)
+      ])
+    let findings = linter.lint(scenario)
+    #expect(findings.contains { $0.ruleID == "pairwise-payoff-needs-round-robin-choose" })
+    #expect(!findings.contains { $0.ruleID == "pairwise-payoff-no-scorable-row" })
+    #expect(!findings.contains { $0.ruleID == "pairwise-payoff-dead-row" })
+  }
+
+  @Test func payoffWithOptionlessRoundRobinChooseDefersToR7() {
+    // A round-robin choose with no options → R7 owns the missing-options case;
+    // R20 has no set to check against and must not fire.
+    let scenario = makeScenario(
+      agents: 2, rounds: 1,
+      phases: [
+        Phase(type: .choose, pairing: .roundRobin),
+        Phase(type: .scoreCalc, logic: .pairwisePayoff, payoff: satisfiablePayoff)
+      ])
+    let findings = linter.lint(scenario)
+    #expect(findings.contains { $0.ruleID == "choose-should-declare-options" })
+    #expect(!findings.contains { $0.ruleID == "pairwise-payoff-no-scorable-row" })
+    #expect(!findings.contains { $0.ruleID == "pairwise-payoff-dead-row" })
+  }
+}

--- a/Pastura/PasturaTests/Engine/ScenarioSerializerTests+Payoff.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioSerializerTests+Payoff.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+// Sibling-file split of `ScenarioSerializerTests` (file_length cap). Per
+// `.claude/rules/testing.md`, extend the suite struct rather than declaring a
+// new `@Suite` (which would run in parallel and race shared state).
+extension ScenarioSerializerTests {
+
+  /// Round-trip guard for the `pairwise_payoff` `payoff:` table (ADR-027),
+  /// including localized (CJK) `when` tokens — the motivating case the pre-ADR
+  /// hardcoded English matrix could not express.
+  @Test func roundTripPairwisePayoffTable() throws {
+    let scenario = Scenario(
+      id: "pairwise_roundtrip",
+      name: "Pairwise",
+      description: "A pairwise payoff scenario.",
+      language: "ja",
+      agentCount: 2,
+      rounds: 1,
+      context: "Context.",
+      personas: [
+        Persona(name: "Alice", description: "A"),
+        Persona(name: "Bob", description: "B")
+      ],
+      phases: [
+        Phase(
+          type: .choose, options: ["協力", "裏切り"], pairing: .roundRobin),
+        Phase(
+          type: .scoreCalc, logic: .pairwisePayoff,
+          payoff: [
+            PayoffRule(when: ["協力", "協力"], points: [3, 3]),
+            PayoffRule(when: ["協力", "裏切り"], points: [0, 5]),
+            PayoffRule(when: ["裏切り", "協力"], points: [5, 0]),
+            PayoffRule(when: ["裏切り", "裏切り"], points: [1, 1])
+          ])
+      ]
+    )
+
+    let yaml = serializer.serialize(scenario)
+    let reloaded = try loader.load(yaml: yaml)
+
+    #expect(reloaded.phases[1].payoff == scenario.phases[1].payoff)
+    #expect(reloaded.phases[1].logic == .pairwisePayoff)
+  }
+}

--- a/Pastura/PasturaTests/Engine/ScenarioSerializerTests+Payoff.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioSerializerTests+Payoff.swift
@@ -44,4 +44,29 @@ extension ScenarioSerializerTests {
     #expect(reloaded.phases[1].payoff == scenario.phases[1].payoff)
     #expect(reloaded.phases[1].logic == .pairwisePayoff)
   }
+
+  /// An empty (non-nil) `payoff` table must not serialize to a childless
+  /// `payoff:` line — that reloads as a null scalar `parsePayoff` rejects,
+  /// breaking the round-trip. Both empty and nil are behavioural no-ops, so the
+  /// serializer collapses empty→omitted (reloads as nil). Revert the
+  /// `!payoff.isEmpty` gate and this test fails with a `.payoffNotList` throw.
+  @Test func emptyPayoffTableOmittedNotEmittedAsNullKey() throws {
+    let scenario = Scenario(
+      id: "empty_payoff",
+      name: "Empty",
+      description: "d",
+      language: "en",
+      agentCount: 2,
+      rounds: 1,
+      context: "c",
+      personas: [Persona(name: "Alice", description: "a"), Persona(name: "Bob", description: "b")],
+      phases: [Phase(type: .scoreCalc, logic: .pairwisePayoff, payoff: [])]
+    )
+
+    let yaml = serializer.serialize(scenario)
+    #expect(!yaml.contains("payoff:"))
+
+    let reloaded = try loader.load(yaml: yaml)
+    #expect(reloaded.phases[0].payoff == nil)
+  }
 }

--- a/Pastura/PasturaTests/Engine/ScenarioYAMLPatcherTests+Payoff.swift
+++ b/Pastura/PasturaTests/Engine/ScenarioYAMLPatcherTests+Payoff.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+// Sibling-file split of `ScenarioYAMLPatcherTests` (file_length cap). Per
+// `.claude/rules/testing.md`, extend the suite struct rather than declaring a
+// new `@Suite`.
+extension ScenarioYAMLPatcherTests {
+
+  /// ADR-018 × ADR-027: `payoff` is a nested list with no visual editor field,
+  /// so a scalar visual edit must leave the `payoff:` block byte-intact. Guards
+  /// against the surgical patcher silently dropping the nested table.
+  private var payoffBase: String {
+    """
+    id: pairwise_demo
+    language: ja
+    name: Original Name  # display name
+    description: A pairwise scenario
+    agents: 2
+    rounds: 3
+    context: Shared context.
+    personas:
+      - name: Alice
+        description: An optimistic agent
+      - name: Bob
+        description: A skeptical agent
+    phases:
+      - type: choose
+        options: [協力, 裏切り]
+        pairing: round_robin
+        output:
+          action: string
+      - type: score_calc
+        logic: pairwise_payoff
+        payoff:
+          - when: [協力, 協力]
+            points: [3, 3]
+          - when: [裏切り, 裏切り]
+            points: [1, 1]
+    """
+  }
+
+  @Test func scalarEditPreservesPayoffBlock() throws {
+    let baseScenario = try loader.load(yaml: payoffBase)
+    let visual = mutated(baseScenario, name: "New Name")
+    let out = patcher.patch(visual: visual, base: payoffBase)
+
+    // The edited scalar changed…
+    #expect(out.contains("name: New Name  # display name"))
+    // …while the untouched nested payoff block survives verbatim.
+    #expect(out.contains("logic: pairwise_payoff"))
+    #expect(out.contains("- when: [協力, 協力]"))
+    #expect(out.contains("points: [3, 3]"))
+    #expect(out.contains("- when: [裏切り, 裏切り]"))
+    // And the patched output re-parses to the same scenario.
+    #expect(try loader.load(yaml: out) == visual)
+  }
+}

--- a/Pastura/PasturaTests/Engine/ScoringLogic/PairwisePayoffLogicTests.swift
+++ b/Pastura/PasturaTests/Engine/ScoringLogic/PairwisePayoffLogicTests.swift
@@ -1,0 +1,105 @@
+import Testing
+
+@testable import Pastura
+
+@Suite(.timeLimit(.minutes(1)))
+struct PairwisePayoffLogicTests {
+  let logic = PairwisePayoffLogic()
+
+  /// A localized (Japanese-token) payoff table — the motivating case for
+  /// ADR-027, unscorable by the pre-ADR hardcoded English `switch`.
+  private let jaTable: [PayoffRule] = [
+    PayoffRule(when: ["協力", "協力"], points: [3, 3]),
+    PayoffRule(when: ["協力", "裏切り"], points: [0, 5]),
+    PayoffRule(when: ["裏切り", "協力"], points: [5, 0]),
+    PayoffRule(when: ["裏切り", "裏切り"], points: [1, 1])
+  ]
+
+  @Test func matchesRowAndAwardsPointsPositionally() {
+    var state = makeState()
+    state.pairings = [Pairing(agent1: "A", agent2: "B", action1: "協力", action2: "裏切り")]
+    let collector = EventCollector()
+    logic.calculate(state: &state, payoff: jaTable, emitter: collector.emit)
+    #expect(state.scores["A"] == 0)
+    #expect(state.scores["B"] == 5)
+  }
+
+  @Test func unmatchedActionPairScoresNothing() {
+    var state = makeState()
+    // Neither action appears in any row's `when`.
+    state.pairings = [Pairing(agent1: "A", agent2: "B", action1: "abstain", action2: "abstain")]
+    let collector = EventCollector()
+    logic.calculate(state: &state, payoff: jaTable, emitter: collector.emit)
+    #expect(state.scores["A"] == 0)
+    #expect(state.scores["B"] == 0)
+  }
+
+  @Test func nilActionScoresNothing() {
+    var state = makeState()
+    // A half-real pairing (action2 nil) matches no row — no fabricated verdict.
+    state.pairings = [Pairing(agent1: "A", agent2: "B", action1: "協力", action2: nil)]
+    let collector = EventCollector()
+    logic.calculate(state: &state, payoff: jaTable, emitter: collector.emit)
+    #expect(state.scores["A"] == 0)
+    #expect(state.scores["B"] == 0)
+  }
+
+  @Test func emptyTableScoresNothing() {
+    var state = makeState()
+    state.pairings = [Pairing(agent1: "A", agent2: "B", action1: "協力", action2: "協力")]
+    let collector = EventCollector()
+    logic.calculate(state: &state, payoff: [], emitter: collector.emit)
+    #expect(state.scores["A"] == 0)
+    #expect(state.scores["B"] == 0)
+  }
+
+  @Test func malformedRowArityIsSkippedDefensively() {
+    var state = makeState()
+    state.pairings = [Pairing(agent1: "A", agent2: "B", action1: "x", action2: "y")]
+    // A row whose `points` is not two elements must not crash (index guard) —
+    // it simply scores nothing. The loader rejects this arity, but the logic
+    // guards defensively per ADR-027.
+    let badTable = [PayoffRule(when: ["x", "y"], points: [7])]
+    let collector = EventCollector()
+    logic.calculate(state: &state, payoff: badTable, emitter: collector.emit)
+    #expect(state.scores["A"] == 0)
+    #expect(state.scores["B"] == 0)
+  }
+
+  @Test func firstMatchingRowWins() {
+    var state = makeState()
+    state.pairings = [Pairing(agent1: "A", agent2: "B", action1: "協力", action2: "協力")]
+    let table = [
+      PayoffRule(when: ["協力", "協力"], points: [3, 3]),
+      PayoffRule(when: ["協力", "協力"], points: [9, 9])
+    ]
+    let collector = EventCollector()
+    logic.calculate(state: &state, payoff: table, emitter: collector.emit)
+    #expect(state.scores["A"] == 3)
+    #expect(state.scores["B"] == 3)
+  }
+
+  @Test func clearsStatePairingsAfterCalc() {
+    var state = makeState()
+    state.pairings = [Pairing(agent1: "A", agent2: "B", action1: "協力", action2: "協力")]
+    let collector = EventCollector()
+    logic.calculate(state: &state, payoff: jaTable, emitter: collector.emit)
+    #expect(state.pairings.isEmpty)
+  }
+
+  @Test func emitsScoreUpdateEvent() {
+    var state = makeState()
+    state.pairings = [Pairing(agent1: "A", agent2: "B", action1: "協力", action2: "協力")]
+    let collector = EventCollector()
+    logic.calculate(state: &state, payoff: jaTable, emitter: collector.emit)
+    let scoreEvents = collector.events.filter {
+      if case .scoreUpdate = $0 { return true }
+      return false
+    }
+    #expect(scoreEvents.count == 1)
+  }
+
+  private func makeState() -> SimulationState {
+    SimulationState(scores: ["A": 0, "B": 0])
+  }
+}

--- a/Pastura/PasturaTests/Models/ScoreCalcLogicTests.swift
+++ b/Pastura/PasturaTests/Models/ScoreCalcLogicTests.swift
@@ -10,10 +10,11 @@ struct ScoreCalcLogicTests {
     #expect(ScoreCalcLogic.voteTally.rawValue == "vote_tally")
     #expect(ScoreCalcLogic.wordwolfJudge.rawValue == "wordwolf_judge")
     #expect(ScoreCalcLogic.eventReactive.rawValue == "event_reactive")
+    #expect(ScoreCalcLogic.pairwisePayoff.rawValue == "pairwise_payoff")
   }
 
   @Test func allCasesCount() {
-    #expect(ScoreCalcLogic.allCases.count == 4)
+    #expect(ScoreCalcLogic.allCases.count == 5)
   }
 
   @Test func roundTripCodable() throws {

--- a/web/src/content/scenario-format.en.md
+++ b/web/src/content/scenario-format.en.md
@@ -127,6 +127,7 @@ A `score_calc` phase names one built-in `logic`:
 | `vote_tally` | One point per vote received |
 | `wordwolf_judge` | Whether the group voted out the odd-one-out |
 | `event_reactive` | Agents whose last `choose` matched the injected event |
+| `pairwise_payoff` | A payoff table you author in YAML, scored per pairing |
 
 Each logic expects specific phases earlier in the round. See the pitfalls
 section below.
@@ -149,6 +150,10 @@ Fields you can set on a phase, beyond `type`, `prompt`, and `output`:
 - `rounds` (for `speak_each` and `whisper`): how many sub-rounds of speaking
   happen within the phase.
 - `logic` (for `score_calc`): one of the scoring logics above.
+- `payoff` (for `score_calc` with `pairwise_payoff`): a list of rows, each
+  `{ when: [action1, action2], points: [p1, p2] }`. A pairing is matched against
+  `when` positionally and awards `points` to the two agents. A pairing matching
+  no row scores nothing.
 - `template` (for `summarize`): the recap string, which may contain `{...}`
   placeholders such as `{scoreboard}` or `{current_round}`.
 - `if`, `then`, `else` (for `conditional`): a condition expression and the
@@ -201,6 +206,8 @@ blocking ones, but it is easier to get them right the first time.
   tally to eliminate from.
 - `prisoners_dilemma` needs a `round_robin` `choose` phase before it, which is
   what creates the pairings it scores.
+- `pairwise_payoff` needs the same `round_robin` `choose` before it, plus a
+  `payoff` table whose `when` rows cover the `choose` options.
 - `wordwolf_judge` needs both an `assign` with `target: random_one` (to pick the
   odd-one-out) and a `vote` before it.
 - `event_reactive` needs an `event_inject` before it, storing the event under a

--- a/web/src/content/scenario-format.ja.md
+++ b/web/src/content/scenario-format.ja.md
@@ -129,6 +129,7 @@ phases:                       # 必須。何が起きるかを順に並べたリ
 | `vote_tally` | 得票 1 票につき 1 ポイント |
 | `wordwolf_judge` | グループが少数派（正解）を追放できたかどうか |
 | `event_reactive` | 直前の `choose` が注入されたイベントと一致したエージェント |
+| `pairwise_payoff` | YAML で記述した報酬テーブルをペアリングごとに評価する |
 
 各ロジックは同じラウンドの前段に特定のフェーズがあることを前提としています。
 詳しくは下記の落とし穴セクションを参照してください。
@@ -151,6 +152,10 @@ phases:                       # 必須。何が起きるかを順に並べたリ
 - `rounds`（`speak_each` と `whisper` 用）: フェーズ内で何回の発話サブラウンドを
   行うか。
 - `logic`（`score_calc` 用）: 上記のスコアリングロジックのいずれか。
+- `payoff`（`pairwise_payoff` の `score_calc` 用）: 各行が
+  `{ when: [action1, action2], points: [p1, p2] }` のリスト。ペアリングを
+  `when` と位置対応で照合し、`points` を 2 人のエージェントに与えます。
+  どの行にも一致しないペアリングは加点されません。
 - `template`（`summarize` 用）: 要約文字列。`{scoreboard}` や
   `{current_round}` のような `{...}` プレースホルダーを含められます。
 - `if`、`then`、`else`（`conditional` 用）: 条件式と、各分岐のサブフェーズ
@@ -206,6 +211,8 @@ phases:                       # 必須。何が起きるかを順に並べたリ
   除外の対象を集計する票数がありません。
 - `prisoners_dilemma` はその前に `round_robin` の `choose` フェーズが必要です。
   これがスコアリング対象のペアリングを作ります。
+- `pairwise_payoff` も同じく前段に `round_robin` の `choose` が必要で、加えて
+  `choose` の選択肢を網羅する `when` 行を持つ `payoff` テーブルが必要です。
 - `wordwolf_judge` は `target: random_one` を指定した `assign`（少数派を
   選ぶため）と、その前の `vote` の両方が必要です。
 - `event_reactive` はその前に `event_inject` が必要で、スコアリングが読む


### PR DESCRIPTION
## Summary

Implements ADR-027 PR2: a generic `pairwise_payoff` `score_calc` logic whose payoff table is authored in scenario YAML instead of hardcoded in Swift. This is the engine layer — PR2.5 (ADR-021 § Amendment, the `validateAction` off-menu fix) and PR3 (preset migration) are out of scope.

- **New `ScoreCalcLogic.pairwisePayoff`** + `PairwisePayoffLogic` (positional `when` match against a round-robin `choose`'s pairings; unmatched/nil-action pairings score nothing — no fabricated verdict).
- **`PrisonersDilemmaLogic` → thin shim** over `PairwisePayoffLogic`, handing it a fixed legacy 4-row table (kept forever because Copy & Edit clones on shipped devices may carry `logic: prisoners_dilemma`; the `[betray,betray]→[1,1]` row is the game rule, not trimmable).
- **`PayoffRule` model** (`{when: [String], points: [Int]}`) + `Phase.payoff`, `ScenarioLoader.parsePayoff` (throws on malformed present rows, leaves absent nil), `ScenarioSerializer` emit, `EditablePhase` YAML-only round-trip.
- **`EngineSchemaVersion` 4→5** (ADR-020 by-name-parse trigger; D3/D5 gate a shared scenario on an old engine).
- **ADR-022 contract**: the 3 compiler-forced switches + the 2 compiler-silent `==` predicates (R4 pairings-clearing set, result-card pairing layout) all updated.
- **Lint rules**: R19 `pairwise-payoff-needs-round-robin-choose` (`.error`, shares R2's extracted predicate, distinct ruleID per ADR-024 D3); R20a `pairwise-payoff-no-scorable-row` (`.error`) / R20b `pairwise-payoff-dead-row` (`.warning`) — options ↔ `payoff.when` token mismatch, day-one severity per ADR-024 § Amendment.
- Both `web/src/content/scenario-format.{en,ja}.md` list the token (coverage gate).

Closes #1160.

## Test plan

- New `PairwisePayoffLogicTests` (match / nil-action / unmatched / empty / malformed-arity / first-match-wins / clears pairings).
- `PrisonersDilemmaLogicTests` now regression-cover the shim's 4-row table (incl. `[betray,betray]→[1,1]`).
- Loader parse (valid / absent-nil / arity + non-list throws), serializer round-trip (localized table + empty-table-omitted regression), ADR-018 patcher round-trip (scalar edit preserves the `payoff:` block), EditablePhase round-trip.
- Linter R19 + R4-regression (proves `pairwise_payoff` joining the pairings-clearing set is load-bearing) + R20a/R20b + R19/R7 deferral.
- Count-pin updates: `ScoreCalcLogic.allCases.count == 5`, `EngineSchemaVersion.current == 5`.
- Full unit suite green (3155 tests); harness `swift build` + D6 batch `pastura-harness lint` over presets + gallery (54 files, 0 errors/0 warnings); swiftlint `--strict` clean.
- Reviewed by 3 parallel code-reviewer passes (all PASS); one real finding fixed (empty-payoff round-trip) + a doc/test-rigor pass.

## Device QA

実機QA不要 — Engine/Models/App logic only; no `#if !targetEnvironment(simulator)` block, no Metal/llama.cpp inference path, no navigation/UI-tree change. `SimulationResultCard+Model` is a pure computed-layout change covered by unit tests, and no `pairwise_payoff` scenario ships until PR3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFoAgjF83qCUdCA3LAxEA9