### PR TITLE
🐛 fix: choose off-menu action fabrication → drop + actionRejected (ADR-027 PR2.5)

### DIFF
--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -457,13 +457,10 @@ terminal tier is no-default exhaustive (ADR-022 PR-A) — so a new
 `SimulationEvent` case compile-breaks in `handleOutputEvent`, not silently
 no-ops.
 
-**Not compiler-caught — the demo-replay converter (CI-only).** If the new case
-also gets an `EventLineMapper` line (harness transcript), classify its
-snake-case event name in `scripts/jsonl_to_demo_replay.py`'s `HANDLED_EVENTS`
-or `IGNORED_EVENTS` — a live-only degradation signal (like `turn_skipped` /
-`action_rejected`) goes in `IGNORED_EVENTS`. Miss it and the CI **"Shell gate
-tests"** `demo-replay-event-coverage` gate reddens (ADR-022 §D4); the pre-commit
-hook does **not** run it (#1164).
+**Not compiler-caught (CI-only):** a new case that also gets an `EventLineMapper`
+line must be classified in `scripts/jsonl_to_demo_replay.py` (`HANDLED_EVENTS` /
+`IGNORED_EVENTS`; live-only signals → `IGNORED_EVENTS`), or the
+`demo-replay-event-coverage` Shell-gate job reddens (ADR-022 §D4).
 
 ## llama.cpp Backend Traps
 
@@ -558,11 +555,9 @@ no model-agnostic "safe enumeration" predicate (one — `isSafeEnumerationOption
 — was tried and removed in #597).
 
 Constrain closed-set values at **runtime** instead: `choose` (round-robin) →
-`ChooseHandler.validateAction` normalizes (trim + lowercase) then canonicalizes
-against `options`, returning `nil` for a genuinely off-menu action so the caller
-**drops the whole pairing** and emits `.actionRejected` (ADR-021 § Amendment
-2026-07-17 / #1151 — this replaced the old `options[0]` fallback, which
-fabricated a cooperate for any off-menu answer); `vote` → tally drop in
+`ChooseHandler.validateAction` **drops the pairing** (+ emits `.actionRejected`)
+on a genuinely off-menu action, replacing the old fabricating `options[0]`
+fallback (ADR-021 §Amendment 2026-07-17); `vote` → tally drop in
 `VoteHandler`. `OutputSchema.Kind.choice` is a payload-free marker so
 option strings never reach a grammar literal. Vote dropped grammar
 enumeration in #597; choose in #599 (ADR-002 §Amendment 2026-06-14).

--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -457,6 +457,14 @@ terminal tier is no-default exhaustive (ADR-022 PR-A) — so a new
 `SimulationEvent` case compile-breaks in `handleOutputEvent`, not silently
 no-ops.
 
+**Not compiler-caught — the demo-replay converter (CI-only).** If the new case
+also gets an `EventLineMapper` line (harness transcript), classify its
+snake-case event name in `scripts/jsonl_to_demo_replay.py`'s `HANDLED_EVENTS`
+or `IGNORED_EVENTS` — a live-only degradation signal (like `turn_skipped` /
+`action_rejected`) goes in `IGNORED_EVENTS`. Miss it and the CI **"Shell gate
+tests"** `demo-replay-event-coverage` gate reddens (ADR-022 §D4); the pre-commit
+hook does **not** run it (#1164).
+
 ## llama.cpp Backend Traps
 
 llama.cpp is the active TestFlight backend; the LiteRT-LM migration

--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -549,8 +549,12 @@ unverified for any other runtime-selectable model or LiteRT-LM. There is
 no model-agnostic "safe enumeration" predicate (one — `isSafeEnumerationOption`
 — was tried and removed in #597).
 
-Constrain closed-set values at **runtime** instead: `choose` → `options[0]`
-fallback in `ChooseHandler.validateAction`; `vote` → tally drop in
+Constrain closed-set values at **runtime** instead: `choose` (round-robin) →
+`ChooseHandler.validateAction` normalizes (trim + lowercase) then canonicalizes
+against `options`, returning `nil` for a genuinely off-menu action so the caller
+**drops the whole pairing** and emits `.actionRejected` (ADR-021 § Amendment
+2026-07-17 / #1151 — this replaced the old `options[0]` fallback, which
+fabricated a cooperate for any off-menu answer); `vote` → tally drop in
 `VoteHandler`. `OutputSchema.Kind.choice` is a payload-free marker so
 option strings never reach a grammar literal. Vote dropped grammar
 enumeration in #597; choose in #599 (ADR-002 §Amendment 2026-06-14).

--- a/Pastura/Pastura/App/ReplayViewModel.swift
+++ b/Pastura/Pastura/App/ReplayViewModel.swift
@@ -1162,16 +1162,17 @@ final class ReplayViewModel {  // swiftlint:disable:this type_body_length
     case .roundCompleted, .phaseCompleted, .simulationCompleted,
       .roundCheckpoint, .simulationPaused, .conditionalEvaluated,
       .agentOutputStream, .inferenceStarted, .inferenceCompleted, .error,
-      .languageMismatch, .turnSkipped:
+      .languageMismatch, .turnSkipped, .actionRejected:
       // Never emitted by `YAMLReplaySource.plannedEvents()` (see the
       // sync-risk note in the header). A `.error` in particular would
       // signal primitive-level breakage; replay's own failure surface
       // goes through the state machine, not the event stream.
       // `.languageMismatch` arises only from live LLM inference (ADR-010
       // Step E PR2) — pre-recorded YAML replays cannot regenerate
-      // adherence verdicts after the fact. `.turnSkipped` is the same
-      // shape (ADR-021 D5): skip narration is live-only, a pre-recorded
-      // replay cannot regenerate the failure after the fact.
+      // adherence verdicts after the fact. `.turnSkipped` /
+      // `.actionRejected` are the same shape (ADR-021 D5 / § Amendment
+      // 2026-07-17): live-only degradation signals a pre-recorded replay
+      // cannot regenerate after the fact.
       return
     }
   }

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -49,6 +49,13 @@ struct LogEntry: Identifiable {
     /// NOT carried here — the App renders its own localized narration
     /// from `agent` + `phaseType`.
     case turnSkipped(agent: String, phaseType: PhaseType)
+    /// A `choose` action that could not be mapped to the option set, so its
+    /// pairing was dropped (ADR-021 § Amendment 2026-07-17). One live-log line
+    /// per rejection. Unlike `.turnSkipped`, `raw` **is** carried — it is the
+    /// model's own text and the whole point is to show *what* it said — so it
+    /// is stored **already `ContentFilter`-rewritten** at construction (ADR-005;
+    /// see the `.actionRejected` arm in `handleEvent`), never raw.
+    case actionRejected(agent: String, phaseType: PhaseType, raw: String)
     case error(String)
   }
 }
@@ -1658,6 +1665,24 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
         "turn skipped in \(phaseType.rawValue) — \(cause)")
       logEntries.append(
         LogEntry(kind: .turnSkipped(agent: agent, phaseType: phaseType)))
+    case .actionRejected(let agent, let phaseType, let raw):
+      // ADR-021 § Amendment 2026-07-17 — a `choose` action that could not be
+      // mapped to the option set; the pairing was dropped (honest omission,
+      // not the old fabricated cooperate). Fold into the same `degradedTurnCount`
+      // aggregate/badge as `.turnSkipped` (D6 — "completed with quality loss");
+      // the D4 breaker is intentionally NOT fed (a rejection is model
+      // menu-discipline, not infrastructure failure).
+      //
+      // `raw` is model-emitted content, so it MUST be `ContentFilter`-rewritten
+      // before it reaches the UI (ADR-005) — done here at the VM boundary,
+      // mirroring the `.narration` arm below. It is deliberately NOT
+      // Logger-interpolated (the "don't Logger-interpolate agent outputs" rule);
+      // the harness transcript is the diagnostic surface for the raw value.
+      degradedTurnCount += 1
+      logEntries.append(
+        LogEntry(
+          kind: .actionRejected(
+            agent: agent, phaseType: phaseType, raw: contentFilter.filter(raw))))
     case .agentOutput(let agent, let output, let phaseType):
       handleAgentOutput(agent: agent, output: output, phaseType: phaseType)
     case .agentOutputStream(let agent, let primary, let thought):
@@ -1789,7 +1814,7 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
       .agentOutput, .agentOutputStream, .relationshipUpdate,
       .conditionalEvaluated, .simulationCompleted, .roundCheckpoint,
       .simulationPaused, .error, .inferenceStarted, .inferenceCompleted,
-      .languageMismatch, .turnSkipped:
+      .languageMismatch, .turnSkipped, .actionRejected:
       break
     }
     persistCodePhaseEventIfNeeded(event)

--- a/Pastura/Pastura/Engine/Phases/ChooseHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/ChooseHandler.swift
@@ -4,22 +4,34 @@ import Foundation
 ///
 /// Supports two modes: round-robin pairing (adjacent pairs, each agent calls LLM
 /// with opponent context) or individual choice (each agent chooses independently).
-/// Invalid actions fall back to `options[0]` via `validateAction`.
+/// In round-robin, an action that can't be mapped to the option set drops the
+/// whole pairing via `validateAction` (see below).
 ///
-/// `validateAction` is the **sole** value constraint: the `action` field is a
-/// `.choice` in the grammar (structure-only — no value enumeration; see
-/// ``OutputSchema/Kind/choice`` and ADR-002 §Amendment 2026-06-14, #599), so
-/// the runtime check is what keeps the result within the option set. The model
-/// is steered toward valid options by ``PromptBuilder``, which lists them in
-/// the prompt, so the fallback is rare in practice.
+/// `validateAction` is the **sole** value constraint on round-robin actions: the
+/// `action` field is a `.choice` in the grammar (structure-only — no value
+/// enumeration; see ``OutputSchema/Kind/choice`` and ADR-002 §Amendment
+/// 2026-06-14, #599), so the runtime check is what keeps the result within the
+/// option set. The model is steered toward valid options by ``PromptBuilder``,
+/// which lists them in the prompt, so a rejection is rare in practice.
+///
+/// It **normalizes then canonicalizes** (ADR-021 § Amendment 2026-07-17 /
+/// #1151): a case/whitespace variant like `"Betray"` folds onto the canonical
+/// `betray` and scores; a genuinely off-menu action (`裏切る`, `betray!`) maps
+/// to `nil` and the caller drops the pairing. This replaces the pre-Amendment
+/// `options[0]` fallback, which silently **fabricated** a cooperate for any
+/// off-menu answer. Individual mode does not canonicalize — it writes the raw
+/// action to `lastOutputs` for consumers that normalize on read
+/// (`EventReactivePayoffLogic`), inventing nothing.
 ///
 /// A turn-degradable LLM failure is routed through `context.turnGate`
 /// (ADR-021 D1/D2). In **round-robin**, a skipped call drops the *whole
-/// pairing* — a pairing with one real and one absent action would flow into
-/// `PrisonersDilemmaLogic`'s `?? "cooperate"` default, i.e. fabrication — while
-/// the partner's already-emitted `.agentOutput` and `lastOutputs` still stand
-/// (consumed by `EventReactivePayoffLogic`). In **individual** mode a skipped
-/// turn writes nothing and clears the agent's stale `lastOutputs`.
+/// pairing* — a half-real pairing (one action absent) would fabricate the
+/// missing action downstream — while the partner's already-emitted
+/// `.agentOutput` and `lastOutputs` still stand (consumed by
+/// `EventReactivePayoffLogic`). A **delivered-but-off-menu** action drops the
+/// pairing the same way but emits ``SimulationEvent/actionRejected(agent:phaseType:raw:)``
+/// so the drop is observable, since the call itself succeeded. In **individual**
+/// mode a skipped turn writes nothing and clears the agent's stale `lastOutputs`.
 nonisolated struct ChooseHandler: PhaseHandler {
   private let promptBuilder = PromptBuilder()
 
@@ -85,8 +97,32 @@ nonisolated struct ChooseHandler: PhaseHandler {
       // half-real pairing would fabricate the missing action downstream.
       guard let out1 = output1, let out2 = output2 else { continue }
 
-      let action1 = validateAction(out1.action ?? "", options: options)
-      let action2 = validateAction(out2.action ?? "", options: options)
+      // A second drop gate (ADR-021 § Amendment 2026-07-17): the call
+      // succeeded but the *action* may be off-menu. `validateAction` returns
+      // `nil` for a genuinely unmappable action; dropping the pairing here is
+      // honest omission, where the old `options[0]` fallback fabricated a
+      // cooperate. The `:86` guard above runs before these calls, so a `nil`
+      // action cannot reach it — this gate is required, not redundant.
+      let rawAction1 = out1.action ?? ""
+      let rawAction2 = out2.action ?? ""
+      let canonical1 = validateAction(rawAction1, options: options)
+      let canonical2 = validateAction(rawAction2, options: options)
+      guard let action1 = canonical1, let action2 = canonical2 else {
+        // Emit which agent(s) were off-menu, carrying the raw value so the run
+        // log shows what the model said. `.agentOutput` already rendered for
+        // both, so this is a distinct signal, not a `.turnSkipped`.
+        if canonical1 == nil {
+          context.emitter(
+            .actionRejected(
+              agent: persona1.name, phaseType: context.phase.type, raw: rawAction1))
+        }
+        if canonical2 == nil {
+          context.emitter(
+            .actionRejected(
+              agent: persona2.name, phaseType: context.phase.type, raw: rawAction2))
+        }
+        continue
+      }
       state.pairings.append(
         Pairing(agent1: persona1.name, agent2: persona2.name, action1: action1, action2: action2)
       )
@@ -213,8 +249,27 @@ nonisolated struct ChooseHandler: PhaseHandler {
 
   // MARK: - Helpers
 
-  private func validateAction(_ action: String, options: [String]) -> String {
+  /// Maps a raw model action onto the canonical option set, or `nil` when it is
+  /// genuinely off-menu (ADR-021 § Amendment 2026-07-17 / #1151).
+  ///
+  /// Normalize-then-canonicalize:
+  /// 1. Fold both sides — trim + lowercase, matching `EventReactivePayoffLogic.normalize`
+  ///    — so `"Betray"` / `" betray"` match `betray` instead of dropping.
+  /// 2. On a match return the **canonical option string**, not the raw input:
+  ///    the return is load-bearing as a *token*, not just a verdict —
+  ///    `RelationshipUpdateHandler` looks up `action_deltas[action]` and
+  ///    `PairwisePayoffLogic` matches `payoff.when` rows by exact string.
+  /// 3. `nil` only on genuine non-membership; the caller drops the pairing.
+  ///
+  /// `options.isEmpty → return action` is preserved: an options-less
+  /// round-robin `choose` has nothing to canonicalize against, and returning
+  /// `nil` there would drop every pairing rather than pass the raw value
+  /// through unchanged (the pre-Amendment behavior for that path).
+  private func validateAction(_ action: String, options: [String]) -> String? {
     if options.isEmpty { return action }
-    return options.contains(action) ? action : options[0]
+    let normalizedAction = action.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    return options.first {
+      $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == normalizedAction
+    }
   }
 }

--- a/Pastura/Pastura/Models/CodePhaseEventPayload+Event.swift
+++ b/Pastura/Pastura/Models/CodePhaseEventPayload+Event.swift
@@ -48,7 +48,7 @@ nonisolated extension CodePhaseEventPayload {
       .agentOutput, .agentOutputStream, .relationshipUpdate,
       .conditionalEvaluated, .simulationCompleted, .roundCheckpoint,
       .simulationPaused, .error, .inferenceStarted, .inferenceCompleted,
-      .languageMismatch, .turnSkipped:
+      .languageMismatch, .turnSkipped, .actionRejected:
       return nil
     }
   }
@@ -79,7 +79,7 @@ nonisolated extension SimulationEvent {
       .agentOutput, .agentOutputStream, .relationshipUpdate,
       .conditionalEvaluated, .simulationCompleted, .roundCheckpoint,
       .simulationPaused, .error, .inferenceStarted, .inferenceCompleted,
-      .languageMismatch, .turnSkipped:
+      .languageMismatch, .turnSkipped, .actionRejected:
       return nil
     }
   }

--- a/Pastura/Pastura/Models/SimulationEvent.swift
+++ b/Pastura/Pastura/Models/SimulationEvent.swift
@@ -220,6 +220,35 @@ nonisolated public enum SimulationEvent: Sendable, Equatable {
   ///     register as `llmGenerationFailed`'s payload) — not user-facing
   ///     copy; the App layer renders its own localized narration.
   case turnSkipped(agent: String, phaseType: PhaseType, cause: String)
+
+  /// A `choose` (round-robin) agent's LLM call **succeeded** but delivered an
+  /// action outside the phase's option set that no normalization could map
+  /// back (ADR-021 § Amendment 2026-07-17 / #1151). Rather than fabricate a
+  /// decision the agent did not make — the pre-Amendment `options[0]` fallback
+  /// silently scored `betray!` / `"Betray"` / `裏切る` as cooperating — the
+  /// engine **drops the whole pairing** and emits this event.
+  ///
+  /// Distinct from `.turnSkipped`: the turn did **not** skip. The call
+  /// succeeded, `.agentOutput` already rendered the agent's utterance, and this
+  /// only reports that its *action* was unmappable — so reusing `.turnSkipped`
+  /// would both mis-narrate ("Alice said X" then "Alice's turn was skipped")
+  /// and break `.turnSkipped`'s single-emitter invariant.
+  ///
+  /// App-side it folds into the same `degradedTurnCount` aggregate/badge as
+  /// `.turnSkipped` (D6 — "completed with quality loss") without a new column,
+  /// and is live-only like `.turnSkipped` (`ReplayViewModel` no-ops it). The
+  /// ADR-021 D4 breaker is deliberately **not** fed by it — a rejection is
+  /// model menu-discipline, not infrastructure failure.
+  ///
+  /// - Parameters:
+  ///   - agent: The agent whose action was rejected.
+  ///   - phaseType: The phase the rejected action belonged to (always
+  ///     `.choose`, carried for symmetry with `.turnSkipped`).
+  ///   - raw: The exact off-menu string the model emitted. It is **model
+  ///     content** — any UI consumer MUST route it through `ContentFilter`
+  ///     before display (ADR-005), unlike `.turnSkipped`'s engine-generated
+  ///     `cause`. The offline harness transcript records it verbatim (no UI).
+  case actionRejected(agent: String, phaseType: PhaseType, raw: String)
 }
 
 /// Errors that can occur during simulation execution.

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -633,6 +633,22 @@
         }
       }
     },
+    "%@'s choice \"%@\" wasn't an option" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@'s choice \"%2$@\" wasn't an option"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ の選択「%2$@」は選択肢にありません"
+          }
+        }
+      }
+    },
     "%@'s turn was skipped (%@)" : {
       "localizations" : {
         "en" : {

--- a/Pastura/Pastura/Views/Simulation/SimulationView+LogEntries.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView+LogEntries.swift
@@ -148,6 +148,27 @@ extension SimulationView {
     }
   }
 
+  /// Live narration for a rejected off-menu `choose` action (ADR-021 § Amendment
+  /// 2026-07-17). The model's action could not be mapped to the option set, so
+  /// the pairing was dropped rather than fabricating a cooperate. `raw` is the
+  /// model's own text — **already `ContentFilter`-rewritten** at `LogEntry`
+  /// construction (ADR-005; see `SimulationViewModel.handleEvent`'s
+  /// `.actionRejected` arm) — so it is rendered as-is here. Live-only; folds
+  /// into the same degraded-turn badge as `turnSkippedEntry`.
+  func actionRejectedEntry(agent: String, raw: String) -> some View {
+    HStack(spacing: 4) {
+      Image(systemName: "exclamationmark.triangle")
+        .foregroundStyle(Color.muted)
+      Text(
+        String(
+          format: String(localized: "%@'s choice \"%@\" wasn't an option"),
+          agent, raw)
+      )
+      .textStyle(Typography.metaValue)
+      .foregroundStyle(Color.muted)
+    }
+  }
+
   /// Full-width phase-boundary separator for LLM phases (speak / vote /
   /// choose). Mirrors `roundSeparator`'s rule + centered-content + rule
   /// structure so the transcript reads as phase "chapters" (#882), but

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -1250,6 +1250,9 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
       contradictionRevealedEntry(agent: agent)
     case .turnSkipped(let agent, let phaseType):
       turnSkippedEntry(agent: agent, phaseType: phaseType)
+    case .actionRejected(let agent, _, let raw):
+      // phaseType is always `.choose` (the only emitter), so it is not shown.
+      actionRejectedEntry(agent: agent, raw: raw)
     default:
       EmptyView()
     }

--- a/Pastura/PasturaTests/App/CrossVMEventParityTests.swift
+++ b/Pastura/PasturaTests/App/CrossVMEventParityTests.swift
@@ -30,6 +30,7 @@ struct CrossVMEventParityTests {
     case relationshipUpdate, voteResults, pairingResult, conditionalEvaluated
     case eventInjected, simulationCompleted, roundCheckpoint, simulationPaused
     case error, inferenceStarted, inferenceCompleted, languageMismatch, turnSkipped
+    case actionRejected
   }
 
   /// One canonical `SimulationEvent` instance per fixture case.
@@ -71,6 +72,8 @@ struct CrossVMEventParityTests {
       return .languageMismatch(agent: "Alice", detected: "en", expected: "ja")
     case .turnSkipped:
       return .turnSkipped(agent: "Alice", phaseType: .speakAll, cause: "x")
+    case .actionRejected:
+      return .actionRejected(agent: "Alice", phaseType: .choose, raw: "betray!")
     }
   }
 
@@ -103,6 +106,7 @@ struct CrossVMEventParityTests {
     case .inferenceCompleted: return .inferenceCompleted
     case .languageMismatch: return .languageMismatch
     case .turnSkipped: return .turnSkipped
+    case .actionRejected: return .actionRejected
     }
   }
 

--- a/Pastura/PasturaTests/App/SimulationViewModelActionRejectedTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelActionRejectedTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+/// `.actionRejected` event surfacing (ADR-021 § Amendment 2026-07-17 / #1151).
+/// A `choose` action that no normalization could map to the option set drops
+/// its pairing; the App folds the event into the same `degradedTurnCount`
+/// aggregate/badge as `.turnSkipped` and appends a per-rejection live-log line.
+/// Unlike `.turnSkipped`, the `raw` value **is** carried (the whole point is to
+/// show what the model said) and — being model content — MUST be
+/// `ContentFilter`-rewritten before it reaches the UI (ADR-005). This suite
+/// covers the live counting + narration + the mandatory filtering.
+@Suite("SimulationViewModelActionRejected", .serialized, .timeLimit(.minutes(1)))
+@MainActor
+struct SimulationViewModelActionRejectedTests {
+
+  @Test func actionRejectedIncrementsCountAndAppendsLogLine() throws {
+    let (sut, scenario) = try makeSUT()
+    sut.handleEvent(
+      .actionRejected(agent: "Alice", phaseType: .choose, raw: "裏切る"),
+      scenario: scenario)
+    #expect(sut.degradedTurnCount == 1)
+    guard case .actionRejected(let agent, let phaseType, let raw) = sut.logEntries.last?.kind
+    else {
+      Issue.record(
+        "expected a .actionRejected log entry, got \(String(describing: sut.logEntries.last?.kind))"
+      )
+      return
+    }
+    #expect(agent == "Alice")
+    #expect(phaseType == .choose)
+    // The default SUT filter blocks only "badword", so a clean off-menu action
+    // passes through verbatim.
+    #expect(raw == "裏切る")
+  }
+
+  @Test func multipleActionRejectedAccumulateOneLinePerEvent() throws {
+    let (sut, scenario) = try makeSUT()
+    sut.handleEvent(
+      .actionRejected(agent: "Alice", phaseType: .choose, raw: "betray!"),
+      scenario: scenario)
+    sut.handleEvent(
+      .actionRejected(agent: "Bob", phaseType: .choose, raw: "裏切る"),
+      scenario: scenario)
+    #expect(sut.degradedTurnCount == 2)
+    let rejectedLines = sut.logEntries.filter {
+      if case .actionRejected = $0.kind { return true }
+      return false
+    }
+    #expect(rejectedLines.count == 2)
+  }
+
+  /// ADR-005 headline: `raw` is model-emitted content, so the live log must
+  /// show a `ContentFilter`-rewritten value — never the raw string. Reverting
+  /// the `contentFilter.filter(raw)` call in `handleEvent`'s `.actionRejected`
+  /// arm makes `storedRaw == rawInput` and fails here.
+  @Test func actionRejectedRawIsContentFilteredBeforeLiveLog() throws {
+    let filter = ContentFilter(blockedPatterns: ["betrayx"])
+    let (sut, scenario) = try makeSUT(contentFilter: filter)
+    let rawInput = "betrayx!"
+    sut.handleEvent(
+      .actionRejected(agent: "Alice", phaseType: .choose, raw: rawInput),
+      scenario: scenario)
+    guard case .actionRejected(_, _, let storedRaw) = sut.logEntries.last?.kind else {
+      Issue.record(
+        "expected a .actionRejected log entry, got \(String(describing: sut.logEntries.last?.kind))"
+      )
+      return
+    }
+    let expected = filter.filter(rawInput)
+    // Non-tautological: the filter genuinely rewrites this input.
+    #expect(expected != rawInput)
+    #expect(storedRaw == expected)
+    #expect(!storedRaw.contains("betrayx"))
+  }
+}

--- a/Pastura/PasturaTests/Engine/Phases/ChooseHandlerTests.swift
+++ b/Pastura/PasturaTests/Engine/Phases/ChooseHandlerTests.swift
@@ -75,13 +75,16 @@ struct ChooseHandlerTests {
     #expect(pairingEvents.count == 2)
   }
 
-  @Test func fallsBackToFirstOptionOnInvalidChoice() async throws {
-    // 2 agents → 2 adjacent pairs (Alice-Bob, Bob-Alice) → 4 LLM calls
+  @Test func dropsPairingAndEmitsActionRejectedOnGenuineOffMenuAction() async throws {
+    // ADR-021 § Amendment 2026-07-17 (#1151): an off-menu action no longer
+    // falls back to `options[0]` (fabricating a cooperate) — the whole pairing
+    // is dropped and `.actionRejected` is emitted carrying the raw value.
+    // 2 agents → 2 adjacent pairs (Alice-Bob, Bob-Alice) → 4 LLM calls.
     let mock = MockLLMService(responses: [
-      #"{"action": "invalid_action"}"#,
-      #"{"action": "cooperate"}"#,
-      #"{"action": "cooperate"}"#,
-      #"{"action": "betray"}"#
+      #"{"action": "invalid_action"}"#,  // Alice, pair 1 — off-menu
+      #"{"action": "cooperate"}"#,  // Bob, pair 1
+      #"{"action": "cooperate"}"#,  // Bob, pair 2
+      #"{"action": "betray"}"#  // Alice, pair 2
     ])
     try await mock.loadModel()
 
@@ -103,8 +106,73 @@ struct ChooseHandlerTests {
     let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
     try await handler.execute(context: context, state: &state)
 
-    // First pair: Alice-Bob. Alice chose "invalid_action" → falls back to "cooperate"
-    #expect(state.pairings[0].action1 == "cooperate")
+    // Pair 1 dropped (Alice off-menu); only pair 2 survives — no fabricated
+    // cooperate for Alice.
+    #expect(state.pairings.count == 1)
+    #expect(state.pairings[0].agent1 == "Bob")
+    #expect(state.pairings[0].action2 == "betray")
+
+    // Exactly one `.actionRejected`, for Alice, carrying the verbatim raw value.
+    let rejections = collector.events.compactMap { event -> (String, String)? in
+      if case .actionRejected(let agent, _, let raw) = event { return (agent, raw) }
+      return nil
+    }
+    #expect(rejections.count == 1)
+    #expect(rejections.first?.0 == "Alice")
+    #expect(rejections.first?.1 == "invalid_action")
+    // The dropped pairing emits no `.pairingResult` — only pair 2's.
+    let pairingEvents = collector.events.filter {
+      if case .pairingResult = $0 { return true }
+      return false
+    }
+    #expect(pairingEvents.count == 1)
+  }
+
+  @Test func caseVariantActionScoresAsCanonicalOptionRatherThanDropping() async throws {
+    // ADR-021 § Amendment 2026-07-17 regression: a case/whitespace variant
+    // (`"Betray"`) must normalize onto the canonical `betray` and SCORE, not
+    // drop — the normalization in `validateAction` step 1 is what makes this
+    // pass. Reverting that fold would drop the pairing and fail here.
+    // 2 agents → 2 pairs → 4 LLM calls.
+    let mock = MockLLMService(responses: [
+      #"{"action": "Betray"}"#,  // Alice, pair 1 — case variant
+      #"{"action": "cooperate"}"#,  // Bob, pair 1
+      #"{"action": "cooperate"}"#,  // Bob, pair 2
+      #"{"action": "betray"}"#  // Alice, pair 2
+    ])
+    try await mock.loadModel()
+
+    let scenario = makeTestScenario(
+      agentNames: ["Alice", "Bob"],
+      phases: [
+        Phase(
+          type: .choose, prompt: "Choose!",
+          outputSchema: ["action": "string"],
+          options: ["cooperate", "betray"],
+          pairing: .roundRobin
+        )
+      ]
+    )
+    var state = SimulationState.initial(for: scenario)
+    state.currentRound = 1
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    // Both pairings scored — nothing dropped.
+    #expect(state.pairings.count == 2)
+    // Pair 1: Alice's `"Betray"` canonicalized to the option string `betray`,
+    // NOT stored as the raw `"Betray"` (load-bearing for exact-match consumers
+    // like PairwisePayoffLogic / RelationshipUpdateHandler).
+    #expect(state.pairings[0].agent1 == "Alice")
+    #expect(state.pairings[0].action1 == "betray")
+    // No rejection emitted.
+    let rejected = collector.events.contains {
+      if case .actionRejected = $0 { return true }
+      return false
+    }
+    #expect(!rejected)
   }
 
   @Test func populatesPairingActions() async throws {

--- a/scripts/jsonl_to_demo_replay.py
+++ b/scripts/jsonl_to_demo_replay.py
@@ -96,6 +96,9 @@ IGNORED_EVENTS = {
     "inference_completed",
     "language_mismatch",
     "turn_skipped",
+    "action_rejected",  # off-menu choose action dropped (ADR-021 §Amendment
+    # 2026-07-17); live-only degradation signal, same as turn_skipped — a
+    # curated demo cannot regenerate it, so it never reaches the replay.
 }
 
 # Stable field order for turn `fields` (mirrors existing hand-authored demos:

--- a/tools/harness/Sources/PasturaHarnessKit/EventLineMapper.swift
+++ b/tools/harness/Sources/PasturaHarnessKit/EventLineMapper.swift
@@ -122,6 +122,16 @@ package enum EventLineMapper {
       return EventLine(
         t: t, attempt: attempt, event: "turn_skipped", agent: agent,
         phaseType: phaseType.rawValue, value: cause)
+    case .actionRejected(let agent, let phaseType, let raw):
+      // ADR-021 § Amendment 2026-07-17 — a `choose` action that no
+      // normalization could map to the option set; the pairing was dropped.
+      // `raw` is recorded **verbatim** (no ContentFilter — this is an offline
+      // transcript, not a UI surface) so a harness A/B can measure off-menu
+      // rate against `options:` directly (#1158). It rides the same `value`
+      // field as `.turnSkipped`'s cause.
+      return EventLine(
+        t: t, attempt: attempt, event: "action_rejected", agent: agent,
+        phaseType: phaseType.rawValue, value: raw)
     case .roundCheckpoint:
       // Internal resume-persistence snapshot (full SimulationState) — not part
       // of the transcript surface, so it produces no line.
@@ -130,7 +140,8 @@ package enum EventLineMapper {
       .agentOutput, .agentOutputStream, .scoreUpdate, .elimination,
       .assignment, .sharedAssignment, .summary, .narration, .relationshipUpdate,
       .voteResults, .pairingResult, .conditionalEvaluated, .eventInjected:
-      // Handled by the earlier tiers; unreachable here. Listed explicitly
+      // Handled by the earlier tiers; unreachable here (`.actionRejected` is
+      // handled above in this tier). Listed explicitly
       // (no `default:`) so a NEW SimulationEvent case breaks compilation in
       // this switch — the compile-time canary the upstream tiers' `default:`
       // forwarding would otherwise lose.


### PR DESCRIPTION
Implements the [ADR-021 § Amendment 2026-07-17](../blob/main/docs/decisions/ADR-021.md) (#1151) decision — the PR2.5 line of [ADR-027](../blob/main/docs/decisions/ADR-027.md)'s rollout. Lands **after** PR2 (#1162, merged) and **before** the preset-localization PR3 (#1158): the ordering is a safety constraint — shipping ja options into the old fallback would widen the fabrication surface.

## Problem

`ChooseHandler.validateAction` mapped any off-menu action to `options[0]`, **fabricating** a decision the agent did not make: an agent emitting `betray!`, `"Betray"`, or (post-localization) `裏切る` was silently scored as **cooperating**. This is exactly what ADR-021 D1's "degrade by omission, never fabrication" forbids.

## Change

- **`validateAction` → normalize-then-canonicalize (`String?`)**: folds trim + lowercase (matching `EventReactivePayoffLogic.normalize`) and returns the **canonical option string** on match, `nil` on genuine non-membership. The `options.isEmpty → return action` arm is preserved. A case variant (`"Betray"`) now scores as canonical `betray`; a genuinely off-menu action returns `nil`.
- **Round-robin drop-the-pairing**: a `nil` action drops the whole pairing (no `.pairingResult`, no fabricated cooperate) and emits a new **`SimulationEvent.actionRejected(agent:phaseType:raw:)`** carrying the raw value.
- **Observability**: `.actionRejected` folds into the existing `degradedTurnCount` aggregate/badge (no new column). The live log shows the rejection with `raw` **`ContentFilter`-rewritten** at the VM boundary (ADR-005 — `raw` is model content, unlike `.turnSkipped`'s engine diagnostic; it is not Logger-interpolated). The D4 breaker is deliberately untouched (a rejection is model menu-discipline, not infra failure). The offline harness records `raw` verbatim (transcript, not UI — enables the #1158 measurement).
- **Sweeps**: the 4 compiler-forced `SimulationEvent` switches (`CodePhaseEventPayload+Event`, `SimulationViewModel`, `ReplayViewModel`, harness `EventLineMapper`) + `CrossVMEventParityTests` fixture; `.claude/rules/engine.md` § "Grammar must not enumerate values".

## Conscious decisions

- The `degradedTurnCount` badge string ("N turns skipped") is left as-is — ADR-021 § Amendment consciously accepts the aggregate fold ("completed with quality loss", which is true). Adjusting the localized copy is out of PR2.5's scope.
- Two off-menu agents in one pairing emit two `.actionRejected` (degradedTurnCount +2), consistent with `.turnSkipped`'s per-agent counting.

## Test plan

- `swift build` (harness) ✓, full unit suite **3161 tests / 260 suites passed** ✓, `check_localization_coverage.py` ✓ (715 keys), swiftlint `--strict` ✓, nav-map drift ✓, pre-commit hook ✓
- New/changed tests:
  - `ChooseHandlerTests.caseVariantActionScoresAsCanonicalOptionRatherThanDropping` — the ADR-mandated regression: `"Betray"` scores as canonical `betray`, not dropped
  - `ChooseHandlerTests.dropsPairingAndEmitsActionRejectedOnGenuineOffMenuAction` — off-menu drops the pairing + emits `.actionRejected` with the verbatim raw
  - `SimulationViewModelActionRejectedTests` — counting/narration + `actionRejectedRawIsContentFilteredBeforeLiveLog` (negative control: `raw` is filtered before the live log)
- No device-QA required (no device-only code path; the live-log line is a standard `String(localized:)` surface).

Closes #1164

🤖 Generated with [Claude Code](https://claude.com/claude-code)