### PR TITLE
✨ feat: localize prisoners_dilemma ja options (ADR-027 PR3)

### DIFF
--- a/Pastura/Pastura/App/ContradictionDetectionLogic.swift
+++ b/Pastura/Pastura/App/ContradictionDetectionLogic.swift
@@ -17,9 +17,11 @@ import Foundation
 ///   cooperated with the other) is opponent-conditioned strategy, not a
 ///   provable lie — no badge.
 /// - Raw parsed actions are compared, not `ChooseHandler.validateAction`
-///   output: validation coerces any unparseable action to `options[0]`,
-///   which could manufacture a phantom contradiction. A dirty raw action
-///   therefore disqualifies the whole round instead.
+///   output: validation now drops any off-menu action (returns `nil`;
+///   ADR-021 § Amendment 2026-07-17, formerly coerced to `options[0]`), so a
+///   validated set would silently omit a dirty action instead of letting it
+///   disqualify the round. A dirty raw action therefore disqualifies the
+///   whole round instead.
 nonisolated enum ContradictionDetectionLogic {
 
   /// The reserved speak-phase output field carrying an agent's public stance

--- a/Pastura/Pastura/Resources/DemoReplays/prisoners_dilemma_demo.yaml
+++ b/Pastura/Pastura/Resources/DemoReplays/prisoners_dilemma_demo.yaml
@@ -15,11 +15,16 @@
 # runtime filter also re-checks at render time, exercised by
 # ContentBlocklistFalsePositiveTests). Final content/visual sign-off rides the
 # device-QA gate on this PR.
+# ADR-027 PR3 (2026-07-18): the machine-value tokens (turns action /
+# declared_intent, code_phase_events summary + pairingResult action1/2) were
+# localized cooperate/betray/unclear → 協力/裏切り/不明 to match the ja
+# preset's now-Japanese options. All three are benign common words — no new
+# blocklist exposure; content_filter_applied stays true.
 schema_version: 1
 preset_ref:
   id: prisoners_dilemma
   version: '1.0'
-  yaml_sha256: '0287b3d802fd26784fe20acf732382d3c76ac2fff04e83321b214e084188badf'
+  yaml_sha256: '8819aa87b925e0f1c5cc94534c1e7c5a21361af03dd75925178eff18887c5db2'
 metadata:
   title: 囚人のジレンマ
   description: 5人のプレイヤーが「協力」か「裏切り」を選ぶ戦略ゲーム。 隣接ペアで総当たり対戦し、得点を競う。宣言でブラフも、 密談で同盟や裏切りの相談も可能。
@@ -38,7 +43,7 @@ turns:
   fields:
     statement: データ分析に基づき、全員が互いに協力することが最も期待値の高い戦略です。
     inner_thought: 相手の行動パターンを予測し、高得点を狙うためには協調性を装うのが合理的です。
-    declared_intent: cooperate
+    declared_intent: 協力
 - round: 1
   phase_index: 0
   phase_type: speak_all
@@ -46,7 +51,7 @@ turns:
   fields:
     statement: みんな、今日は最高のチームワークを見せてくれると信じてるよ！
     inner_thought: 協力すれば全員で良い結果が出せるはず！少しだけハッタリを効かせて、皆の気持ちを良くしたいな。
-    declared_intent: cooperate
+    declared_intent: 協力
 - round: 1
   phase_index: 0
   phase_type: speak_all
@@ -54,7 +59,7 @@ turns:
   fields:
     statement: おい、みんな、手加減はねえぜ。協力だ、って言う奴は引っ込んでろ。
     inner_thought: 協力を呼びかけるのは面倒だが、いつ誰が裏切るか見極めるのが俺のやり方だ。
-    declared_intent: betray
+    declared_intent: 裏切り
 - round: 1
   phase_index: 0
   phase_type: speak_all
@@ -62,7 +67,7 @@ turns:
   fields:
     statement: 皆様、私たちはこのゲームを個々の能力で勝負するのではなく、一つのチームとして勝利を目指すべきだと考えます。
     inner_thought: 私はすぐにでも誰かと手を組んで、安全なポジションを取りたいです。宣言で皆を協力的な雰囲気に誘導するのが私の得意分野です。
-    declared_intent: cooperate
+    declared_intent: 協力
 - round: 1
   phase_index: 0
   phase_type: speak_all
@@ -70,7 +75,7 @@ turns:
   fields:
     statement: さーて、今回はどうしよっかなー？俺はどっちでもいいけどさ。
     inner_thought: 退屈しのぎに予測不能な行動をしたい気分だ。みんなが真面目すぎるのが面白いね。
-    declared_intent: unclear
+    declared_intent: 不明
 - round: 1
   phase_index: 1
   phase_type: whisper
@@ -109,70 +114,70 @@ turns:
   agent: アキラ
   fields:
     inner_thought: ミサキさんは私と協力したい意向を示しており、データ上、協力の期待値が最も高いため、この選択が最適です。
-    action: cooperate
+    action: 協力
 - round: 1
   phase_index: 2
   phase_type: choose
   agent: ミサキ
   fields:
     inner_thought: アキラは協力してくれると言ってくれたから、私は彼と協力して3点をゲットしたいな！みんなで協力すればきっとうまくいく！
-    action: cooperate
+    action: 協力
 - round: 1
   phase_index: 2
   phase_type: choose
   agent: ミサキ
   fields:
     inner_thought: 私は人を信じているから、リュウジの挑発に負けずに協力するべきだ。みんなで力を合わせればきっと良い結果になるよ！
-    action: cooperate
+    action: 協力
 - round: 1
   phase_index: 2
   phase_type: choose
   agent: リュウジ
   fields:
     inner_thought: 協力なんて馬鹿げてる。俺が裏切ってでも点数を稼ぐ方がマシだ。ミサキの甘い期待を打ち砕いてやるぜ。
-    action: betray
+    action: 裏切り
 - round: 1
   phase_index: 2
   phase_type: choose
   agent: リュウジ
   fields:
     inner_thought: ハルカが協力的だと主張するなら、そこを逆手に取るのが一番だ。俺の利益だけ見てるってことを証明してやる必要がある。
-    action: betray
+    action: 裏切り
 - round: 1
   phase_index: 2
   phase_type: choose
   agent: ハルカ
   fields:
     inner_thought: リュウジさんは自分の利益を優先しているようですが、私は同盟を組むことで全体の得点を最大化したいと考えます。協力すれば全員が3点を得られるのが一番良いでしょう。
-    action: cooperate
+    action: 協力
 - round: 1
   phase_index: 2
   phase_type: choose
   agent: ハルカ
   fields:
     inner_thought: ケンタは協力的だから、同盟を組むことで全員の得点を最大化できると考えます。社交的な性格として、まずは穏やかなアプローチで協力体制を提案したいです。
-    action: cooperate
+    action: 協力
 - round: 1
   phase_index: 2
   phase_type: choose
   agent: ケンタ
   fields:
     inner_thought: ハルカが真面目そうだから、今回は皆で協力して綺麗な3点をゲットするのが一番退屈しない方法だね。
-    action: cooperate
+    action: 協力
 - round: 1
   phase_index: 2
   phase_type: choose
   agent: ケンタ
   fields:
     inner_thought: アキラの堅すぎる戦略は退屈だ。俺が勝って、場をめちゃくちゃにしてやるのが一番楽しいぜ！
-    action: betray
+    action: 裏切り
 - round: 1
   phase_index: 2
   phase_type: choose
   agent: アキラ
   fields:
     inner_thought: ケンタの行動パターンは予測が難しいため、まずは期待値の高い協力を選択します。データ上、協力による平均スコアが最も高くなります。
-    action: cooperate
+    action: 協力
 - round: 2
   phase_index: 0
   phase_type: speak_all
@@ -180,7 +185,7 @@ turns:
   fields:
     statement: 皆様、今回のゲームはデータに基づいて最適な戦略を選択します。
     inner_thought: 過去の履歴がないため、期待値計算に基づき協力が最も合理的であると判断します。
-    declared_intent: cooperate
+    declared_intent: 協力
 - round: 2
   phase_index: 0
   phase_type: speak_all
@@ -188,7 +193,7 @@ turns:
   fields:
     statement: みんな、今回は思いっきり協力して3点をゲットしようよ！
     inner_thought: よし、みんなで力を合わせればきっとうまくいくはず！たとえ裏切られたとしても、次こそはきっとチャンスがあるよ！
-    declared_intent: cooperate
+    declared_intent: 協力
 - round: 2
   phase_index: 0
   phase_type: speak_all
@@ -196,7 +201,7 @@ turns:
   fields:
     statement: おい、見てろよ。俺は自分の利益だけ見てるから、協力なんてクソ食らわねえ。
     inner_thought: 協力を呼びかけても相手が甘いことを言うのがオチだ。このゲームは力で決めるべきだ。
-    declared_intent: betray
+    declared_intent: 裏切り
 - round: 2
   phase_index: 0
   phase_type: speak_all
@@ -204,7 +209,7 @@ turns:
   fields:
     statement: 皆様、今回はお互いに信頼し合うことが大切だと私は思います。どうか協力して良い結果を目指しませんか？
     inner_thought: リュウジさんのような利己的な人たちを説得できれば、皆で協力して高いスコアを達成したいです。
-    declared_intent: cooperate
+    declared_intent: 協力
 - round: 2
   phase_index: 0
   phase_type: speak_all
@@ -212,7 +217,7 @@ turns:
   fields:
     statement: さーて、今回は誰が一番面白いことをするかな？俺は適当に選ぶぜ！
     inner_thought: 退屈しのぎに予測不能な動きを見せてやろう。
-    declared_intent: unclear
+    declared_intent: 不明
 - round: 2
   phase_index: 1
   phase_type: whisper
@@ -251,121 +256,121 @@ turns:
   agent: アキラ
   fields:
     inner_thought: ミサキの宣言は協調性を促しており、データ上、協力が最も安定した期待値をもたらします。感情的な判断を排除し、この戦略を採用します。
-    action: cooperate
+    action: 協力
 - round: 2
   phase_index: 2
   phase_type: choose
   agent: ミサキ
   fields:
     inner_thought: ミサキは人を信じる性格なので、今回はみんなで協力して3点を狙うのが一番楽しいと思う！アキラに対しても協力することで、良い雰囲気を作りたいな！
-    action: cooperate
+    action: 協力
 - round: 2
   phase_index: 2
   phase_type: choose
   agent: ミサキ
   fields:
     inner_thought: リュウジは冷たいけど、私は人を信じるタイプだから、やはり協力で3点を狙いたいな！みんなでうまくいくと信じてみよう！
-    action: cooperate
+    action: 協力
 - round: 2
   phase_index: 2
   phase_type: choose
   agent: リュウジ
   fields:
     inner_thought: ミサキが協力なんて言うから、俺が裏切って5点を取るのが一番だ。甘いこと言ってると痛い目見るぜ。
-    action: betray
+    action: 裏切り
 - round: 2
   phase_index: 2
   phase_type: choose
   agent: リュウジ
   fields:
     inner_thought: ハルカは協力的な態度を取っているが、俺は自分の利益しか見ない。裏切って相手をゼロにすれば5点取れるから、報復の心配なんてクソ食らわねえ。
-    action: betray
+    action: 裏切り
 - round: 2
   phase_index: 2
   phase_type: choose
   agent: ハルカ
   fields:
     inner_thought: リュウジはスコアが一番高いので、協力して3点を取るのが最も安全で、同盟を組む絶好の機会だと考えます。
-    action: cooperate
+    action: 協力
 - round: 2
   phase_index: 2
   phase_type: choose
   agent: ハルカ
   fields:
     inner_thought: ケンタさんは楽な道を選んでいて、私自身も同盟を組むことで全員の満足度を高められると考えます。
-    action: cooperate
+    action: 協力
 - round: 2
   phase_index: 2
   phase_type: choose
   agent: ケンタ
   fields:
     inner_thought: ハルカは協力したいと言っているし、二人で3点を狙うのが一番手っ取り早いだろう。退屈しのぎには、誰とでも仲良くするのが一番だね！
-    action: cooperate
+    action: 協力
 - round: 2
   phase_index: 2
   phase_type: choose
   agent: ケンタ
   fields:
     inner_thought: ハルカが協力したいと言っているから、今回は二人で安全に3点を取るのが一番手っ取り早いだろう。予測不能な行動は後回しにして、まずは安定した得点を稼ごうぜ！
-    action: cooperate
+    action: 協力
 - round: 2
   phase_index: 2
   phase_type: choose
   agent: アキラ
   fields:
     inner_thought: ケンタのスコアが8点と高いが、協力による期待値の計算に基づくと、全体的な安定性が高まるため協力を選択する。データ上、ケンタとの協調はリスクを最小化すると判断する。
-    action: cooperate
+    action: 協力
 code_phase_events:
 - round: 1
   phase_index: 2
   phase_type: choose
-  summary: アキラ(cooperate) vs ミサキ(cooperate)
+  summary: アキラ(協力) vs ミサキ(協力)
   payload:
     kind: pairingResult
     agent1: アキラ
-    action1: cooperate
+    action1: 協力
     agent2: ミサキ
-    action2: cooperate
+    action2: 協力
 - round: 1
   phase_index: 2
   phase_type: choose
-  summary: ミサキ(cooperate) vs リュウジ(betray)
+  summary: ミサキ(協力) vs リュウジ(裏切り)
   payload:
     kind: pairingResult
     agent1: ミサキ
-    action1: cooperate
+    action1: 協力
     agent2: リュウジ
-    action2: betray
+    action2: 裏切り
 - round: 1
   phase_index: 2
   phase_type: choose
-  summary: リュウジ(betray) vs ハルカ(cooperate)
+  summary: リュウジ(裏切り) vs ハルカ(協力)
   payload:
     kind: pairingResult
     agent1: リュウジ
-    action1: betray
+    action1: 裏切り
     agent2: ハルカ
-    action2: cooperate
+    action2: 協力
 - round: 1
   phase_index: 2
   phase_type: choose
-  summary: ハルカ(cooperate) vs ケンタ(cooperate)
+  summary: ハルカ(協力) vs ケンタ(協力)
   payload:
     kind: pairingResult
     agent1: ハルカ
-    action1: cooperate
+    action1: 協力
     agent2: ケンタ
-    action2: cooperate
+    action2: 協力
 - round: 1
   phase_index: 2
   phase_type: choose
-  summary: ケンタ(betray) vs アキラ(cooperate)
+  summary: ケンタ(裏切り) vs アキラ(協力)
   payload:
     kind: pairingResult
     agent1: ケンタ
-    action1: betray
+    action1: 裏切り
     agent2: アキラ
-    action2: cooperate
+    action2: 協力
 - round: 1
   phase_index: 3
   phase_type: score_calc
@@ -387,53 +392,53 @@ code_phase_events:
 - round: 2
   phase_index: 2
   phase_type: choose
-  summary: アキラ(cooperate) vs ミサキ(cooperate)
+  summary: アキラ(協力) vs ミサキ(協力)
   payload:
     kind: pairingResult
     agent1: アキラ
-    action1: cooperate
+    action1: 協力
     agent2: ミサキ
-    action2: cooperate
+    action2: 協力
 - round: 2
   phase_index: 2
   phase_type: choose
-  summary: ミサキ(cooperate) vs リュウジ(betray)
+  summary: ミサキ(協力) vs リュウジ(裏切り)
   payload:
     kind: pairingResult
     agent1: ミサキ
-    action1: cooperate
+    action1: 協力
     agent2: リュウジ
-    action2: betray
+    action2: 裏切り
 - round: 2
   phase_index: 2
   phase_type: choose
-  summary: リュウジ(betray) vs ハルカ(cooperate)
+  summary: リュウジ(裏切り) vs ハルカ(協力)
   payload:
     kind: pairingResult
     agent1: リュウジ
-    action1: betray
+    action1: 裏切り
     agent2: ハルカ
-    action2: cooperate
+    action2: 協力
 - round: 2
   phase_index: 2
   phase_type: choose
-  summary: ハルカ(cooperate) vs ケンタ(cooperate)
+  summary: ハルカ(協力) vs ケンタ(協力)
   payload:
     kind: pairingResult
     agent1: ハルカ
-    action1: cooperate
+    action1: 協力
     agent2: ケンタ
-    action2: cooperate
+    action2: 協力
 - round: 2
   phase_index: 2
   phase_type: choose
-  summary: ケンタ(cooperate) vs アキラ(cooperate)
+  summary: ケンタ(協力) vs アキラ(協力)
   payload:
     kind: pairingResult
     agent1: ケンタ
-    action1: cooperate
+    action1: 協力
     agent2: アキラ
-    action2: cooperate
+    action2: 協力
 - round: 2
   phase_index: 3
   phase_type: score_calc

--- a/Pastura/Pastura/Resources/DemoReplays/prisoners_dilemma_en_demo.yaml
+++ b/Pastura/Pastura/Resources/DemoReplays/prisoners_dilemma_en_demo.yaml
@@ -19,7 +19,7 @@ schema_version: 1
 preset_ref:
   id: prisoners_dilemma_en
   version: '1.0'
-  yaml_sha256: '2f07437090cce61c1e2ed6a45978f439917785c9321cad65d638e2e7a4ecfddc'
+  yaml_sha256: '6f5332e7f4dc52845b50219dc1b94e52caee84648b72b46a4412d699bfb58a1e'
 metadata:
   title: Prisoner's Dilemma
   description: Five players choose "cooperate" or "betray" in a strategic game. Round-robin pairwise matches with score accumulation. Bluff in the open, and scheme alliances or betrayals in private whispers.

--- a/Pastura/Pastura/Resources/Presets/prisoners_dilemma.yaml
+++ b/Pastura/Pastura/Resources/Presets/prisoners_dilemma.yaml
@@ -12,7 +12,7 @@ agents: 5
 rounds: 2
 context: >
   あなたはゲーム番組「囚人のジレンマ」の出場者です。
-  対戦相手と「協力(cooperate)」か「裏切り(betray)」を選びます。
+  対戦相手と「協力」か「裏切り」を選びます。
   両方協力=各3点 / 自分だけ裏切り=5点(相手は0点) / 両方裏切り=各1点。
   対戦前に全員に向けて宣言できます（嘘やハッタリもOK）。
   ゲームは全2ラウンド。得点は最終ラウンド終了時に確定します。
@@ -59,7 +59,7 @@ phases:
       全員に向けて宣言してください。協力を呼びかけても、ブラフをかけてもOKです。
 
       declared_intent には、いま全員に見せた宣言の表向きの立場を
-      cooperate / betray / unclear のいずれか1語で示してください。
+      協力 / 裏切り / 不明 のいずれか1語で示してください。
       これは宣言のラベルであり、本心と一致していなくてもかまいません。
     output:
       statement: string
@@ -98,17 +98,26 @@ phases:
       密談での相手とのやり取り:
       {my_whispers}
 
-      「cooperate（協力）」か「betray（裏切り）」を選んでください。
+      「協力」か「裏切り」を選んでください。
     output:
       action: string
       inner_thought: string
     options:
-      - cooperate
-      - betray
+      - 協力
+      - 裏切り
     pairing: round_robin
 
   - type: score_calc
-    logic: prisoners_dilemma
+    logic: pairwise_payoff
+    payoff:
+      - when: [協力, 協力]
+        points: [3, 3]
+      - when: [協力, 裏切り]
+        points: [0, 5]
+      - when: [裏切り, 協力]
+        points: [5, 0]
+      - when: [裏切り, 裏切り]
+        points: [1, 1]
 
   - type: summarize
     template: >

--- a/Pastura/Pastura/Resources/Presets/prisoners_dilemma_en.yaml
+++ b/Pastura/Pastura/Resources/Presets/prisoners_dilemma_en.yaml
@@ -5,9 +5,12 @@
 # - Example utterances rewritten as natural EN equivalents in each
 #   archetype's register (logical / optimistic / aggressive /
 #   persuasive / playful), NOT literal translations.
-# - "cooperate" / "betray" action labels stay English-as-source (same
-#   as the ja preset's parenthetical English in 「協力(cooperate)」)
-#   — the JSON action vocabulary is locale-independent.
+# - "cooperate" / "betray" are this en variant's own option tokens,
+#   matched positionally by its `payoff:` table (ADR-027 pairwise_payoff —
+#   the payoff matrix is authored per-locale in YAML, not a shared Swift
+#   matrix). Option vocabulary is now locale-specific: the ja sibling uses
+#   「協力」/「裏切り」 with its own table (ADR-027 reverses the earlier
+#   English-as-source decision for ja).
 
 id: prisoners_dilemma_en
 language: en
@@ -127,7 +130,16 @@ phases:
     pairing: round_robin
 
   - type: score_calc
-    logic: prisoners_dilemma
+    logic: pairwise_payoff
+    payoff:
+      - when: [cooperate, cooperate]
+        points: [3, 3]
+      - when: [cooperate, betray]
+        points: [0, 5]
+      - when: [betray, cooperate]
+        points: [5, 0]
+      - when: [betray, betray]
+        points: [1, 1]
 
   - type: summarize
     template: >

--- a/docs/decisions/ADR-027.md
+++ b/docs/decisions/ADR-027.md
@@ -353,6 +353,39 @@ with no error. Both move together.
   and belongs where a reader would look (§ "Why the option-token fallback is not in
   this ADR").
 
+## Amendment 2026-07-18 — PR3: ja tokens frozen after harness validation
+
+PR3 lands the ja localization — `options: [協力, 裏切り]`, both siblings on
+`pairwise_payoff`. Two things this ADR did not record at design time, added per
+the PR3 precondition tracked in #1158.
+
+### The freeze was gated on a raw-action fidelity measurement
+
+§ Consequences lists Japanese options as a delivered benefit, but committing to
+`協力` / `裏切り` was conditional on the local model actually emitting them
+verbatim. The measurement must read the **raw** `agent_output.fields.action`, not
+the pairing-result action: `ChooseHandler.validateAction` canonicalizes before the
+`Pairing` is appended and `.pairingResult` emitted, so the pairing field carries
+post-canonicalization values and would report a false 100 % pass for every
+candidate. Measured on pastura-harness (3 runs, real Gemma 4 E2B): **60/60 raw
+choose actions verbatim in {協力, 裏切り}, zero `.actionRejected`,
+`declared_intent` 30/30 in {協力, 裏切り, 不明}**. The residual inflectional-drift
+risk — a model handed the noun 「裏切り」 writing the verb 「裏切る」 into the
+free-form string — did not appear. Freeze confirmed. Post-PR2.5 a miss would be
+visible, not silent (the pairing drops and `.actionRejected` fires, per
+[ADR-021](ADR-021.md) § Amendment 2026-07-17).
+
+### A presentation-layer fallback was available (unused)
+
+§ Options weighed A/B/C/D, all engine-side. A fifth was never listed: keep
+`options: [cooperate, betray]` as the canonical value and localize only the display
+label the player sees. That keeps `payoff.when` keys, both demo replays'
+`preset_ref.yaml_sha256`, and the ja demo's hand-localized values stable — the
+honest landing spot had no Japanese candidate cleared the bar. The measurement
+cleared it decisively, so this was not taken; it is recorded so a future variant,
+or a model swap that regresses token fidelity, has an escape hatch that does not
+contradict the header's "last un-localized surface" framing.
+
 ## Related
 
 - [ADR-002](ADR-002.md) `Amendment 2026-06-14` — `choose` value-enumeration removed;


### PR DESCRIPTION
## Summary

Final PR of ADR-027. Moves both `prisoners_dilemma` siblings onto the generic `pairwise_payoff` scoring logic (shipped in PR2 #1162) and localizes the ja variant's option tokens to `協力 / 裏切り` — the last un-localized surface after #1139.

- **ja preset** — `options: [cooperate, betray]` → `[協力, 裏切り]`; `logic: prisoners_dilemma` → `pairwise_payoff` + `payoff:` table; drop parenthetical English in `context` and the `choose` prompt; `speak_all` `declared_intent` instruction `cooperate/betray/unclear` → `協力/裏切り/不明`.
- **en preset** — `logic` → `pairwise_payoff` + English `payoff:` table (options unchanged); rewrite the now-stale header note that claimed the action vocabulary is locale-independent.
- **ja demo replay** — machine-value tokens localized in all three rendered positions (turns `action`/`declared_intent`, `code_phase_events.summary`, and `pairingResult.action1/2` — `ReplayViewModel` renders the payload verbatim); `preset_ref.yaml_sha256` regenerated.
- **en demo replay** — `yaml_sha256` regenerated only (content stays English; the preset byte change shifts the hash).
- **ADR-027** — `§ Amendment 2026-07-18` (Amendment form: core decisions shipped in PR2/PR2.5).

## Measurement precondition (#1158)

Per #1158, the ja tokens were **not** frozen without a raw-action fidelity measurement. 3 pastura-harness runs (real Gemma 4 E2B) of the ja candidate:

- **60/60** raw `agent_output.fields.action` verbatim in `{協力, 裏切り}` (read raw, not the post-canonicalization `pairing_result`, which false-passes every candidate)
- **0** `.actionRejected`
- `declared_intent` **30/30** in `{協力, 裏切り, 不明}` (不明 fired once — the localized hedge works)

The residual inflectional-drift risk (裏切り → 裏切る) did not materialize. `Closes #1158`.

## Test plan

- `swift run pastura-harness lint Pastura/Pastura/Resources/Presets` — 0 errors (ADR-024 `pairwise_payoff` lint gate, ci.yml:598; not covered by xcodebuild/pre-commit)
- `python3 scripts/check_demo_replay_drift.py` — OK (both demo sha256 parity)
- `scripts/xcodebuild.sh test -skip-testing:PasturaUITests` — 3161 tests / 260 suites pass (real-preset round-trip + demo loaders included)
- `swiftlint lint --strict` — clean

## Bundled cleanup (code-review follow-up)

Code review surfaced a stale doc comment at `App/ContradictionDetectionLogic.swift` (validation "coerces any unparseable action to `options[0]`") — outdated since PR2.5 (#1165) changed `validateAction` to drop off-menu actions (return `nil`). It sits on the exact contradiction-badge coupling this PR touches, so the one-line refresh is bundled here (comment-only, no behavior change).

## Device QA

Real-device on-device inference is **not** the load-bearing gate here — the harness already validated ja-token fidelity + scoring on real Gemma 4 E2B (60/60). Worth a visual pass:

- **Live ja preset** (real device, Gemma 4 E2B): run `囚人のジレンマ` → confirm the choose screen shows 「協力」「裏切り」, pairing result cards read 協力/裏切り, scores match the payoff table (両方協力=各3 / 自分だけ裏切り=5,0 / 両方裏切り=各1), and the contradiction badge fires on 協力/裏切り but never on 不明.
- **DL-time demo replay** (simulator ok): the prisoners_dilemma ja demo on the model-download screen renders Japanese action tokens + pairing summaries and whisper bubbles — the demo header defers final content/visual sign-off to this gate.