### PR TITLE
✨ feat: measure the FM token budget + schema-constrained generation path

### DIFF
--- a/.claude/skills/model-eval/tests/run_tests.sh
+++ b/.claude/skills/model-eval/tests/run_tests.sh
@@ -193,6 +193,35 @@ if grep -q -- "--profile" "$ARGV3"; then
   fail "run_scenario: --profile should NOT be passed when only trailing flags follow timeout"
 fi
 
+# --- run_scenario.sh --max-response-tokens / --guided-generation (#1154) ----
+# The FM token-budget battery drives these. `--guided-generation` is a BOOLEAN
+# flag consuming no value; a parser that treated it as value-taking would
+# silently swallow whatever followed it, so the canary puts another flag after
+# it and asserts that one survives.
+ARGV_FM="$TMP/argv_fm.log"
+STATUS_FM=$(
+  cd "$REPO_ROOT" && \
+  PASTURA_HARNESS_BIN="$FAKE_BIN" FAKE_ARGV_CAPTURE="$ARGV_FM" \
+  bash .claude/skills/scenario-factory/scripts/run_scenario.sh \
+    "$DUMMY_YAML" - "$TMP/out_fm.jsonl" 60 --backend foundation-models \
+    --guided-generation --max-response-tokens 512
+)
+printf '%s' "$STATUS_FM" | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['status']=='ok', d" \
+  || fail "run_scenario: fm token-budget canary expected status ok, got: $STATUS_FM"
+grep -q -- "--guided-generation" "$ARGV_FM" \
+  || fail "run_scenario: --guided-generation not passed through argv"
+grep -q -- "--max-response-tokens 512" "$ARGV_FM" \
+  || fail "run_scenario: --max-response-tokens not passed through argv (swallowed by the boolean flag?)"
+
+# neither flag appears unless asked for — otherwise every prior battery's argv
+# would silently change shape
+if grep -q -- "--guided-generation" "$ARGV3"; then
+  fail "run_scenario: --guided-generation must not appear unless requested"
+fi
+if grep -q -- "--max-response-tokens" "$ARGV3"; then
+  fail "run_scenario: --max-response-tokens must not appear unless requested"
+fi
+
 # trailing flags must not disturb the llama-cpp default path
 ARGV4="$TMP/argv4.log"
 STATUS4=$(

--- a/.claude/skills/scenario-factory/scripts/run_scenario.sh
+++ b/.claude/skills/scenario-factory/scripts/run_scenario.sh
@@ -4,6 +4,7 @@
 # usage:
 #   run_scenario.sh <scenario.yaml> <model.gguf> <out.jsonl> [timeout_sec=600] \
 #                   [profile_id] [--backend <id>] [--guardrails <id>]
+#                   [--max-response-tokens <n>] [--guided-generation]
 #   run_scenario.sh --classify <out.jsonl> <exit_code>
 #
 # [profile_id], when non-empty, is passed through to the harness as
@@ -11,7 +12,8 @@
 # "gemma"). Positional args, so passing a profile requires also passing
 # timeout_sec explicitly.
 #
-# --backend / --guardrails are TRAILING FLAGS, not further positionals: making
+# --backend / --guardrails / --max-response-tokens / --guided-generation are
+# TRAILING FLAGS, not further positionals: making
 # them positional #6/#7 would force every foundation-models caller to also
 # supply a timeout and a meaningless profile_id just to reach them.
 #
@@ -60,6 +62,7 @@ usage() {
   cat >&2 <<'EOF'
 usage: run_scenario.sh <scenario.yaml> <model.gguf> <out.jsonl> [timeout_sec=600] [profile_id]
                        [--backend <id>] [--guardrails <id>]
+                       [--max-response-tokens <n>] [--guided-generation]
        run_scenario.sh --classify <out.jsonl> <exit_code>
 
 <model.gguf> may be `-` for a backend with no GGUF file (e.g. foundation-models).
@@ -148,6 +151,8 @@ if [ $# -gt 0 ] && [ "${1#--}" = "$1" ]; then PROFILE="$1"; shift; fi
 
 BACKEND=""
 GUARDRAILS=""
+MAX_RESPONSE_TOKENS=""
+GUIDED_GENERATION=""
 # An explicitly-empty value is a caller bug, not an intent: `-`/empty carries a
 # deliberate sentinel meaning for <model.gguf> above, so silently dropping an
 # empty flag here would be the one inconsistent reading.
@@ -155,6 +160,10 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --backend) [ $# -ge 2 ] && [ -n "$2" ] || usage; BACKEND=$2; shift 2 ;;
     --guardrails) [ $# -ge 2 ] && [ -n "$2" ] || usage; GUARDRAILS=$2; shift 2 ;;
+    --max-response-tokens)
+      [ $# -ge 2 ] && [ -n "$2" ] || usage; MAX_RESPONSE_TOKENS=$2; shift 2 ;;
+    # Boolean flag — consumes no value, mirroring the harness's own shape.
+    --guided-generation) GUIDED_GENERATION=1; shift ;;
     *) usage ;;
   esac
 done
@@ -195,6 +204,8 @@ esac
 if [ -n "$PROFILE" ]; then ARGS+=(--profile "$PROFILE"); fi
 if [ -n "$BACKEND" ]; then ARGS+=(--backend "$BACKEND"); fi
 if [ -n "$GUARDRAILS" ]; then ARGS+=(--guardrails "$GUARDRAILS"); fi
+if [ -n "$MAX_RESPONSE_TOKENS" ]; then ARGS+=(--max-response-tokens "$MAX_RESPONSE_TOKENS"); fi
+if [ -n "$GUIDED_GENERATION" ]; then ARGS+=(--guided-generation); fi
 "$BIN" "${ARGS[@]}" 2>"$STDERR_LOG" &
 PID=$!
 

--- a/Pastura/Pastura/LLM/FoundationModelsService+GuidedGeneration.swift
+++ b/Pastura/Pastura/LLM/FoundationModelsService+GuidedGeneration.swift
@@ -1,0 +1,110 @@
+// Same `canImport(FoundationModels)` gate as the primary file — the framework
+// ships only in the iOS 26 / macOS 26 SDK. CI compiles this (all Swift jobs pin
+// Xcode 26.4, which ships the SDK), so a break here is caught there.
+#if canImport(FoundationModels)
+
+  import Foundation
+  import FoundationModels
+
+  /// Guided-generation (schema-constrained) support for ``FoundationModelsService``.
+  ///
+  /// ## Why this exists
+  ///
+  /// Spike #1072 closed No-Go with a **reversal condition**: its top remaining
+  /// blocker was that FM runs without a GBNF-equivalent constraint, so free-form
+  /// prompts produce JSON that never closes — and that the obvious remedy,
+  /// guided generation, is documented by Apple to **re-enable the default
+  /// guardrails** ("When you use guided generation, the framework runs the
+  /// default guardrails against model input and output as usual"), which would
+  /// cancel out the permissive-guardrails fix that #1159 landed. Two known
+  /// repairs that undo each other, with the interaction never measured. This
+  /// file makes it measurable.
+  ///
+  /// ## Which question this actually answers
+  ///
+  /// #1072's condition names `@Generable` guided generation. This code uses a
+  /// **runtime-built `GenerationSchema`** instead, because Pastura's output
+  /// shape is per-phase data (``OutputSchema``), not a compile-time Swift type.
+  /// Apple's guardrail sentence is scoped to "guided generation" generally, not
+  /// to the macro specifically, so the two are expected to behave alike — but
+  /// that expectation is an **assumption, not a measurement**. Any digest built
+  /// on this code must say "under runtime-schema guided generation", never
+  /// silently "under `@Generable`".
+  @available(iOS 26, macOS 26, *)
+  nonisolated extension FoundationModelsService {
+
+    /// Whether the schema is restated inside the prompt.
+    ///
+    /// **`false` on purpose**, and load-bearing for the experiment:
+    ///
+    /// 1. `PromptBuilder` already states the field contract in the prompt, so
+    ///    `true` would spend the ~4k context on the same information twice —
+    ///    directly worsening the blocker the sibling instrumentation measures.
+    /// 2. It keeps the guided arm's prompt **byte-identical** to the plain
+    ///    arm's, so an A/B differs in exactly one variable (decode constraint
+    ///    present or absent). With `true`, a guardrail difference and an
+    ///    increase in context pressure would arrive confounded.
+    ///
+    /// The schema still constrains decoding either way; only the prompt text
+    /// differs. `schemaTokens` is logged regardless, so the cost this avoids
+    /// stays visible.
+    static let includeSchemaInPrompt = false
+
+    /// Translates Pastura's ``OutputSchema`` into a Foundation Models
+    /// `GenerationSchema`.
+    ///
+    /// Every field maps to a **String** leaf, including ``OutputSchema/Kind/choice``.
+    ///
+    /// - Note: `DynamicGenerationSchema(name:anyOf:)` would let a `.choice`
+    ///   field enumerate its allowed values, and is deliberately NOT used — but
+    ///   **not for the reason the sibling GBNF code avoids enumeration**. The
+    ///   llama.cpp path avoids it because enumerating CJK / dynamic literals
+    ///   crashes that sampler at accept time (#597 / #599); that rationale is
+    ///   specific to llama.cpp's grammar sampler and does not transfer to FM.
+    ///   The actual reason here is simpler and structural: `.choice` carries no
+    ///   option payload (`OutputSchema.Kind` is a payload-free marker), so the
+    ///   allowed values are not reachable from this type at all. If a future
+    ///   schema carries them, `anyOf:` becomes a legitimate option for FM even
+    ///   though it stays forbidden for GBNF.
+    ///
+    /// - Throws: ``LLMError/generationFailed(description:)`` when the schema
+    ///   cannot be built.
+    static func generationSchema(from schema: OutputSchema) throws -> GenerationSchema {
+      let leaf = DynamicGenerationSchema(type: String.self)
+      let properties = schema.fields.map {
+        DynamicGenerationSchema.Property(name: $0.name, schema: leaf)
+      }
+      let root = DynamicGenerationSchema(name: "TurnOutput", properties: properties)
+      do {
+        // Broad catch, not `catch let e as GenerationSchema.SchemaError`: the
+        // initializer is declared with untyped `throws`, so a narrow catch would
+        // let a non-`SchemaError` failure escape as a raw SDK error and lose the
+        // grep-classifiable prefix below.
+        return try GenerationSchema(root: root, dependencies: [])
+      } catch {
+        throw LLMError.generationFailed(
+          description: "Foundation Models guided schema build failed — \(error)")
+      }
+    }
+
+    /// Runs one schema-constrained turn.
+    ///
+    /// Returns the raw JSON text rather than a decoded value so
+    /// ``JSONResponseParser`` — which owns the field contract for every backend
+    /// — stays the single parse path. `rawContent.jsonString` is already
+    /// schema-shaped, so the parser's repair pipeline simply has nothing to do.
+    ///
+    /// - Returns: The JSON text plus the turn's transcript entries, which the
+    ///   caller feeds to the response-side token instrumentation.
+    func respondGuided(
+      session: LanguageModelSession, user: String, schema: GenerationSchema,
+      options: GenerationOptions
+    ) async throws -> (text: String, entries: ArraySlice<Transcript.Entry>) {
+      let response = try await session.respond(
+        to: user, schema: schema, includeSchemaInPrompt: Self.includeSchemaInPrompt,
+        options: options)
+      return (response.rawContent.jsonString, response.transcriptEntries)
+    }
+  }
+
+#endif

--- a/Pastura/Pastura/LLM/FoundationModelsService+GuidedGeneration.swift
+++ b/Pastura/Pastura/LLM/FoundationModelsService+GuidedGeneration.swift
@@ -103,7 +103,30 @@
       let response = try await session.respond(
         to: user, schema: schema, includeSchemaInPrompt: Self.includeSchemaInPrompt,
         options: options)
-      return (response.rawContent.jsonString, response.transcriptEntries)
+      // `content` rather than `rawContent`: for this overload `Content` IS
+      // `GeneratedContent`, so both compile and the SDK documents no difference
+      // between them. `content` is chosen as the schema-DECODED value, which is
+      // what a guided turn is asking for. This is a semantic preference, not a
+      // measured one — the #1154 smoke runs did not isolate any behavioural
+      // difference between the two accessors.
+      let text = response.content.jsonString
+      guard !text.isEmpty else {
+        // Never hand "" to `JSONResponseParser`: an empty string is
+        // indistinguishable there from a model that generated nothing, so it
+        // burns the retry budget and lands in the run log as an ordinary parse
+        // failure — attributing a defect in THIS path to the model.
+        //
+        // Not known to fire: it did not trigger in any smoke run. Empty-output
+        // turns DO occur (parse failures with an empty `raw=` appear in both the
+        // guided and the unguided arm, 9 of 14 in one unguided run), but their
+        // cause was NOT isolated — and since this guard stayed silent while they
+        // occurred, they are reaching the parser from somewhere other than here.
+        // Treat that as an open question for the deferred battery, not as
+        // something this guard explains.
+        throw LLMError.generationFailed(
+          description: "Foundation Models guided generation returned empty content")
+      }
+      return (text, response.transcriptEntries)
     }
   }
 

--- a/Pastura/Pastura/LLM/FoundationModelsService+GuidedGeneration.swift
+++ b/Pastura/Pastura/LLM/FoundationModelsService+GuidedGeneration.swift
@@ -89,10 +89,10 @@
 
     /// Runs one schema-constrained turn.
     ///
-    /// Returns the raw JSON text rather than a decoded value so
-    /// ``JSONResponseParser`` — which owns the field contract for every backend
-    /// — stays the single parse path. `rawContent.jsonString` is already
-    /// schema-shaped, so the parser's repair pipeline simply has nothing to do.
+    /// Returns JSON text rather than a decoded value so ``JSONResponseParser`` —
+    /// which owns the field contract for every backend — stays the single parse
+    /// path. The text is already schema-shaped, so the parser's repair pipeline
+    /// simply has nothing to do.
     ///
     /// - Returns: The JSON text plus the turn's transcript entries, which the
     ///   caller feeds to the response-side token instrumentation.
@@ -117,12 +117,14 @@
         // failure — attributing a defect in THIS path to the model.
         //
         // Not known to fire: it did not trigger in any smoke run. Empty-output
-        // turns DO occur (parse failures with an empty `raw=` appear in both the
-        // guided and the unguided arm, 9 of 14 in one unguided run), but their
-        // cause was NOT isolated — and since this guard stayed silent while they
-        // occurred, they are reaching the parser from somewhere other than here.
-        // Treat that as an open question for the deferred battery, not as
-        // something this guard explains.
+        // turns DO occur — parse failures with an empty `raw=` appear in the
+        // guided arm as well as the unguided one — but their cause was NOT
+        // isolated. In the GUIDED arm specifically this guard stayed silent
+        // while they occurred, so those reach the parser from somewhere other
+        // than this return; the unguided observations say nothing either way,
+        // since this code is not in that call chain. Treat the whole population
+        // as an open question for the deferred battery, not as something this
+        // guard explains.
         throw LLMError.generationFailed(
           description: "Foundation Models guided generation returned empty content")
       }

--- a/Pastura/Pastura/LLM/FoundationModelsService+TokenBudget.swift
+++ b/Pastura/Pastura/LLM/FoundationModelsService+TokenBudget.swift
@@ -100,6 +100,9 @@
     func logResponseTokenBudget(
       seq: Int, inputTokens: Int, entries: ArraySlice<Transcript.Entry>
     ) async {
+      // No unavailable-note here, unlike the input side: that pass already
+      // marked this turn, and a second identical line per turn would just
+      // inflate the log.
       guard #available(iOS 26.4, macOS 26.4, *) else { return }
       let contextSize = model.contextSize
       let responseEntries = entries.filter {
@@ -107,7 +110,8 @@
       }
       let responseTokens = (try? await model.tokenCount(for: responseEntries)) ?? -1
       // MEASURED, not assumed: on macOS 26.5 this equals `responseTokens` in
-      // every observed turn (22/22 in the #1154 smoke run), i.e.
+      // every observed turn — 79 of 79 across the #1154 smoke runs, holding in
+      // the plain, guided, and capped arms alike — i.e.
       // `Response.transcriptEntries` carries ONLY the response entry — the
       // `.response` filter above is a no-op and this is NOT a full-conversation
       // occupancy figure. It is kept as a tripwire: if a future SDK starts
@@ -121,7 +125,12 @@
       // occupancy, and `headroom` correspondingly an UPPER bound.
       let occupancy =
         inputTokens >= 0 && responseTokens >= 0 ? inputTokens + responseTokens : -1
-      let headroom = occupancy >= 0 ? contextSize - occupancy : -1
+      // Rendered as text, NOT as a -1 sentinel like its neighbours: headroom is
+      // a derived value that goes legitimately negative once occupancy exceeds
+      // the window, so `occupancy == contextSize + 1` would print `headroom=-1`
+      // and read as "unmeasurable". That collision would land exactly on the
+      // overshoot case this instrumentation exists to catch.
+      let headroom = occupancy >= 0 ? String(contextSize - occupancy) : "unmeasured"
       // ADVISORY, not exact. `responseTokens` counts a `Transcript.Entry`, which
       // carries role/segment framing, while `maximumResponseTokens` bounds the
       // generator's raw output — so near the cap this biases toward FALSE

--- a/Pastura/Pastura/LLM/FoundationModelsService+TokenBudget.swift
+++ b/Pastura/Pastura/LLM/FoundationModelsService+TokenBudget.swift
@@ -1,0 +1,140 @@
+// Sibling-file split of ``FoundationModelsService``'s token-budget
+// instrumentation (#1154), extracted when the primary file crossed swiftlint's
+// 400-line `file_length` limit.
+//
+// Three wrappers are all required and each fails differently if omitted:
+//   - `#if canImport(FoundationModels)` — matches the primary file's SDK gate.
+//   - `@available(iOS 26, macOS 26, *)`  — the extended type carries it.
+//   - `nonisolated` on the EXTENSION    — under SWIFT_DEFAULT_ACTOR_ISOLATION
+//     = MainActor a plain extension inherits MainActor, and the diagnostic
+//     fires at the CALLSITE in `generate`, not here
+//     (.claude/rules/swift-isolation.md Pattern 3).
+#if canImport(FoundationModels)
+
+  import Foundation
+  import FoundationModels
+  import os
+
+  @available(iOS 26, macOS 26, *)
+  nonisolated extension FoundationModelsService {
+
+    static let tokenBudgetLogger = Logger(
+      subsystem: "app.pastura.Pastura", category: "FMTokenBudget")
+
+    /// Emits one diagnostic line to OSLog and mirrors it to stderr.
+    ///
+    /// The stderr mirror is what the macOS harness (ADR-013) actually reads —
+    /// CLI `os.Logger` output is not reliably queryable via `log show`, and
+    /// `run_scenario.sh` captures stderr to `<out>.stderr.log`. That file is
+    /// already mixed-content and every consumer parses it with
+    /// `jq -Rc 'fromjson? | select(...)'`, which silently drops non-JSON lines,
+    /// so a plain-text line here cannot corrupt the `DiagLine` JSONL channel.
+    ///
+    /// Every value on these lines is a token count or a fixed marker — never
+    /// scenario text or model output — so `privacy: .public` is correct here
+    /// (CLAUDE.md "Logger privacy").
+    static func emitTokenBudget(_ line: String) {
+      tokenBudgetLogger.info("\(line, privacy: .public)")
+      fputs("\(line)\n", stderr)
+    }
+
+    /// Measures what the turn's INPUT costs against the context window, before
+    /// generation runs (#1154 blocker 2).
+    ///
+    /// `contextSize` is the denominator and is emitted unconditionally: it is
+    /// available at 26.0, and blocker 2's headline "4k" figure is itself a claim
+    /// worth measuring rather than inheriting. The SDK back-deploys a constant
+    /// below 26.4, so a ≥26.4 runtime may legitimately report a different size.
+    ///
+    /// - Note: `Instructions(system)` is load-bearing. `String` conforms to BOTH
+    ///   `PromptRepresentable` and `InstructionsRepresentable`, so passing the
+    ///   bare `String` silently binds the `some PromptRepresentable` overload
+    ///   and measures the system prompt under *prompt* framing — the emitted
+    ///   `instructions=` value would be quietly mislabelled.
+    /// - Returns: The turn's total input tokens, or `-1` when unmeasurable. The
+    ///   caller threads this into ``logResponseTokenBudget(seq:inputTokens:entries:)``
+    ///   so occupancy can be summed — the response side cannot recover it, see
+    ///   that method's note on `transcriptEntries`.
+    @discardableResult
+    func logInputTokenBudget(
+      seq: Int, system: String, user: String, schema: GenerationSchema?
+    ) async -> Int {
+      let contextSize = model.contextSize
+      guard #available(iOS 26.4, macOS 26.4, *) else {
+        // Explicit rather than a silent skip: for an instrument, "no output" and
+        // "nothing to report" are otherwise indistinguishable.
+        Self.emitTokenBudget(
+          "fmTokenBudget seq=\(seq) phase=input contextSize=\(contextSize) "
+            + "note=instrumentation-unavailable-runtime-below-26.4")
+        return -1
+      }
+      // Every count is `try?` with a -1 sentinel. `tokenCount` is `async throws`,
+      // and a propagating instrumentation error would leave `generate` as a
+      // generation failure, reach `LLMCaller`, and be counted as a turn skip
+      // against ADR-021's 3-consecutive-skip breaker — instrumentation
+      // manufacturing the very failures it exists to measure.
+      let instructions = (try? await model.tokenCount(for: Instructions(system))) ?? -1
+      let prompt = (try? await model.tokenCount(for: user)) ?? -1
+      var schemaTokens = -1
+      if let schema {
+        schemaTokens = (try? await model.tokenCount(for: schema)) ?? -1
+      }
+      // Summed here so the response side can report occupancy. `schemaTokens` is
+      // excluded: `includeSchemaInPrompt` is false, so the schema constrains
+      // decoding without entering the prompt — counting it would inflate input.
+      let inputTokens =
+        instructions >= 0 && prompt >= 0 ? instructions + prompt : -1
+      Self.emitTokenBudget(
+        "fmTokenBudget seq=\(seq) phase=input contextSize=\(contextSize) "
+          + "instructions=\(instructions) prompt=\(prompt) schema=\(schemaTokens) "
+          + "input=\(inputTokens)")
+      return inputTokens
+    }
+
+    /// Measures what the completed turn OCCUPIES in the context window.
+    ///
+    /// Takes the transcript slice rather than the `Response` so both the plain
+    /// and the guided path (whose `Content` differs) can call it unchanged, and
+    /// takes `inputTokens` from the input-side pass because the response cannot
+    /// recover it — see the `transcript` note below.
+    func logResponseTokenBudget(
+      seq: Int, inputTokens: Int, entries: ArraySlice<Transcript.Entry>
+    ) async {
+      guard #available(iOS 26.4, macOS 26.4, *) else { return }
+      let contextSize = model.contextSize
+      let responseEntries = entries.filter {
+        if case .response = $0 { return true } else { return false }
+      }
+      let responseTokens = (try? await model.tokenCount(for: responseEntries)) ?? -1
+      // MEASURED, not assumed: on macOS 26.5 this equals `responseTokens` in
+      // every observed turn (22/22 in the #1154 smoke run), i.e.
+      // `Response.transcriptEntries` carries ONLY the response entry — the
+      // `.response` filter above is a no-op and this is NOT a full-conversation
+      // occupancy figure. It is kept as a tripwire: if a future SDK starts
+      // including the prompt entry, the two terms diverge in the log and the
+      // occupancy arithmetic below has to be revisited rather than silently
+      // double-counting.
+      let transcriptTokens = (try? await model.tokenCount(for: entries)) ?? -1
+      // Occupancy is therefore input + response, NOT the transcript count.
+      // Both terms are tokenized as separate fragments, so neither includes the
+      // session's own role/turn framing: this SUM IS A LOWER BOUND on true
+      // occupancy, and `headroom` correspondingly an UPPER bound.
+      let occupancy =
+        inputTokens >= 0 && responseTokens >= 0 ? inputTokens + responseTokens : -1
+      let headroom = occupancy >= 0 ? contextSize - occupancy : -1
+      // ADVISORY, not exact. `responseTokens` counts a `Transcript.Entry`, which
+      // carries role/segment framing, while `maximumResponseTokens` bounds the
+      // generator's raw output — so near the cap this biases toward FALSE
+      // POSITIVES by the framing delta. Read it as "probably truncated" and
+      // confirm against the raw `responseTokens` / `cap` on the same line.
+      let cap = maximumResponseTokens
+      let hitCap = cap.map { responseTokens >= $0 } ?? false
+      Self.emitTokenBudget(
+        "fmTokenBudget seq=\(seq) phase=response contextSize=\(contextSize) "
+          + "input=\(inputTokens) response=\(responseTokens) transcript=\(transcriptTokens) "
+          + "occupancy=\(occupancy) headroom=\(headroom) "
+          + "cap=\(cap.map(String.init) ?? "none") hitCap=\(hitCap)")
+    }
+  }
+
+#endif

--- a/Pastura/Pastura/LLM/FoundationModelsService.swift
+++ b/Pastura/Pastura/LLM/FoundationModelsService.swift
@@ -30,6 +30,7 @@
 
     private let model: SystemLanguageModel
     private let maximumResponseTokens: Int?
+    private let guidedGeneration: Bool
     private let loadedState: OSAllocatedUnfairLock<Bool>
 
     /// Monotonic turn counter, used solely as a join key across the three
@@ -69,9 +70,18 @@
     ///     *not* a clean win: a cap truncates the JSON object mid-object, which
     ///     converts a context-exceeded failure into a parse failure rather than
     ///     removing it. That conversion is itself the measurement.
-    public init(model: SystemLanguageModel = .default, maximumResponseTokens: Int? = nil) {
+    ///   - guidedGeneration: When `true`, a turn that carries an
+    ///     ``OutputSchema`` runs schema-constrained via
+    ///     ``respondGuided(session:user:schema:options:)`` instead of free-form.
+    ///     Defaults to `false` — see `FoundationModelsService+GuidedGeneration`
+    ///     for what this measures and why it is off by default.
+    public init(
+      model: SystemLanguageModel = .default, maximumResponseTokens: Int? = nil,
+      guidedGeneration: Bool = false
+    ) {
       self.model = model
       self.maximumResponseTokens = maximumResponseTokens
+      self.guidedGeneration = guidedGeneration
       self.loadedState = OSAllocatedUnfairLock(initialState: false)
       self.turnSeq = OSAllocatedUnfairLock(initialState: 0)
     }
@@ -121,21 +131,26 @@
     /// output) — structurally avoiding the cumulative-transcript overflow a
     /// long-lived session would hit.
     ///
-    /// `schema` is intentionally **ignored** in this spike: the model runs
-    /// schema-unconstrained (no `@Generable` guided generation). The prompt
-    /// already instructs JSON and ``JSONResponseParser`` carries the field
-    /// contract. Consequence for the #1072 evaluation phase: FM parse-failure
-    /// rates are **not** apples-to-apples with the GBNF-grammar-constrained
-    /// ``LlamaCppService``.
+    /// `schema` is honoured only when the service was built with
+    /// `guidedGeneration: true` (default `false`). Unconstrained, the model runs
+    /// free-form: the prompt instructs JSON and ``JSONResponseParser`` carries
+    /// the field contract, so FM parse-failure rates are **not** apples-to-apples
+    /// with the GBNF-grammar-constrained ``LlamaCppService``. Constrained, the
+    /// turn decodes against a runtime `GenerationSchema` — see
+    /// `FoundationModelsService+GuidedGeneration`.
     ///
-    /// - Warning: **Adopting `@Generable` guided generation would silently
-    ///   re-enable the default guardrails**, undoing the permissive mode this
-    ///   backend is being re-evaluated under. Per Apple, permissive guardrails
-    ///   "only work for generating a string value. When you use guided
-    ///   generation, the framework runs the default guardrails against model
-    ///   input and output as usual." This service returns `response.content`
-    ///   (a plain `String`), which is the only shape permissive mode covers.
-    ///   So guided generation is not the free win #1072's first digest called
+    /// - Warning: **Guided generation is documented to re-enable the default
+    ///   guardrails**, which would undo the permissive mode this backend was
+    ///   re-evaluated under. Per Apple, permissive guardrails "only work for
+    ///   generating a string value. When you use guided generation, the
+    ///   framework runs the default guardrails against model input and output
+    ///   as usual." The unconstrained path returns `response.content` (a plain
+    ///   `String`), the only shape permissive mode covers; the guided path
+    ///   returns schema-decoded content and so is expected to lose that cover.
+    ///   That expectation is precisely what `guidedGeneration` exists to
+    ///   **measure** (#1072 reversal condition 1) — it is not yet an observed
+    ///   fact, which is why the flag defaults off. Guided generation is
+    ///   therefore not the free win #1072's first digest called
     ///   it — it trades JSON-validity assurance (already measured as a
     ///   non-problem) for the return of the failure that killed the spike.
     ///   Re-measure guardrails before adopting it.
@@ -191,11 +206,26 @@
       // window throws out of `respond`, and the input-side numbers are exactly
       // what blocker 2 needs on that turn. Measuring after the call would
       // condition the whole sample on success and drop the failing population.
-      await logInputTokenBudget(seq: seq, system: system, user: user, schema: nil)
+      // Built here — ahead of the input-budget emission and OUTSIDE the `do` —
+      // for two reasons: `schemaTokens` needs a schema to report, and a
+      // schema-build failure is not a `GenerationError`, so it must not land in
+      // the catch arm below that maps generation errors.
+      var generationSchema: GenerationSchema?
+      if guidedGeneration, let schema, !schema.fields.isEmpty {
+        generationSchema = try Self.generationSchema(from: schema)
+      }
+      await logInputTokenBudget(seq: seq, system: system, user: user, schema: generationSchema)
       do {
-        let response = try await session.respond(to: user, options: options)
-        await logResponseTokenBudget(seq: seq, entries: response.transcriptEntries)
-        return response.content
+        let result: (text: String, entries: ArraySlice<Transcript.Entry>)
+        if let generationSchema {
+          result = try await respondGuided(
+            session: session, user: user, schema: generationSchema, options: options)
+        } else {
+          let response = try await session.respond(to: user, options: options)
+          result = (response.content, response.transcriptEntries)
+        }
+        await logResponseTokenBudget(seq: seq, entries: result.entries)
+        return result.text
       } catch let error as LanguageModelSession.GenerationError {
         if case .exceededContextWindowSize = error {
           // No response exists, so no response-side line is emitted. Without

--- a/Pastura/Pastura/LLM/FoundationModelsService.swift
+++ b/Pastura/Pastura/LLM/FoundationModelsService.swift
@@ -1,10 +1,16 @@
 // The whole file is gated on `canImport(FoundationModels)` — the framework
-// ships only in the iOS 26 / macOS 26 SDK. On an older toolchain (a CI runner
-// on Xcode < 26) this compiles out entirely, keeping the app + harness builds
-// green without an FM SDK, exactly as llama.cpp real inference is absent from
-// CI. NOTE (#1072 spike): because `canImport` is an SDK check, standard CI /
-// pre-commit that lack the FM SDK never type-check this code — verify a real
-// build on the Xcode-26 SDK (`canImport` true) before trusting the API shape.
+// ships only in the iOS 26 / macOS 26 SDK, so on an older toolchain this
+// compiles out entirely and the app + harness builds stay green without an FM
+// SDK, exactly as llama.cpp real inference is absent from CI.
+//
+// CI DOES type-check this file: every Swift job in `.github/workflows/ci.yml`
+// pins `DEVELOPER_DIR` to Xcode 26.4, which ships the FM SDK, so `canImport` is
+// true there and a break here reddens CI like any other code. (An earlier
+// version of this comment claimed the opposite; the #1072 spike predated the
+// toolchain pin.) What CI still cannot do is RUN any of it — Apple Intelligence
+// needs an eligible device — so inference-dependent behaviour remains
+// device-verified, and only the pure-logic parts (error mapping, the guided
+// schema builder) are machine-gated.
 #if canImport(FoundationModels)
 
   import Foundation

--- a/Pastura/Pastura/LLM/FoundationModelsService.swift
+++ b/Pastura/Pastura/LLM/FoundationModelsService.swift
@@ -32,6 +32,16 @@
     private let maximumResponseTokens: Int?
     private let loadedState: OSAllocatedUnfairLock<Bool>
 
+    /// Monotonic turn counter, used solely as a join key across the three
+    /// diagnostic lines one ``generate(system:user:schema:antiRepetitionSeeds:)``
+    /// call can emit (input / response / overflow). An overflowing turn emits no
+    /// response line, so without a key an analyst cannot pair the overflow with
+    /// the input measurements that produced it.
+    private let turnSeq: OSAllocatedUnfairLock<Int>
+
+    static let tokenBudgetLogger = Logger(
+      subsystem: "app.pastura.Pastura", category: "FMTokenBudget")
+
     /// Creates a service over a system language model.
     ///
     /// Guardrail mode is injected through this parameter rather than being a
@@ -63,6 +73,7 @@
       self.model = model
       self.maximumResponseTokens = maximumResponseTokens
       self.loadedState = OSAllocatedUnfairLock(initialState: false)
+      self.turnSeq = OSAllocatedUnfairLock(initialState: 0)
     }
 
     /// Marks the service ready after confirming the system model is available.
@@ -172,14 +183,122 @@
       // above, whose omission invalidated an entire 6-cell battery (#1156).
       // One value, one construction site, so no two paths can disagree.
       let options = GenerationOptions(maximumResponseTokens: maximumResponseTokens)
+      let seq = turnSeq.withLock { seq in
+        seq += 1
+        return seq
+      }
+      // Emitted BEFORE the `do` on purpose: a turn that overflows the context
+      // window throws out of `respond`, and the input-side numbers are exactly
+      // what blocker 2 needs on that turn. Measuring after the call would
+      // condition the whole sample on success and drop the failing population.
+      await logInputTokenBudget(seq: seq, system: system, user: user, schema: nil)
       do {
         let response = try await session.respond(to: user, options: options)
+        await logResponseTokenBudget(seq: seq, entries: response.transcriptEntries)
         return response.content
       } catch let error as LanguageModelSession.GenerationError {
+        if case .exceededContextWindowSize = error {
+          // No response exists, so no response-side line is emitted. Without
+          // this marker the event blocker 2 is ABOUT would be the one event
+          // absent from the data. `seq` joins it back to the input line.
+          Self.emitTokenBudget("fmTokenBudget seq=\(seq) phase=overflow")
+        }
         throw Self.map(error)
       } catch {
         throw LLMError.generationFailed(description: String(describing: error))
       }
+    }
+
+    /// Emits one diagnostic line to OSLog and mirrors it to stderr.
+    ///
+    /// The stderr mirror is what the macOS harness (ADR-013) actually reads —
+    /// CLI `os.Logger` output is not reliably queryable via `log show`, and
+    /// `run_scenario.sh` captures stderr to `<out>.stderr.log`. That file is
+    /// already mixed-content and every consumer parses it with
+    /// `jq -Rc 'fromjson? | select(...)'`, which silently drops non-JSON lines,
+    /// so a plain-text line here cannot corrupt the `DiagLine` JSONL channel.
+    ///
+    /// Every value on these lines is a token count or a fixed marker — never
+    /// scenario text or model output — so `privacy: .public` is correct here
+    /// (CLAUDE.md "Logger privacy").
+    private static func emitTokenBudget(_ line: String) {
+      tokenBudgetLogger.info("\(line, privacy: .public)")
+      fputs("\(line)\n", stderr)
+    }
+
+    /// Measures what the turn's INPUT costs against the context window, before
+    /// generation runs (#1154 blocker 2).
+    ///
+    /// `contextSize` is the denominator and is emitted unconditionally: it is
+    /// available at 26.0, and blocker 2's headline "4k" figure is itself a claim
+    /// worth measuring rather than inheriting. The SDK back-deploys a constant
+    /// below 26.4, so a ≥26.4 runtime may legitimately report a different size.
+    ///
+    /// - Note: `Instructions(system)` is load-bearing. `String` conforms to BOTH
+    ///   `PromptRepresentable` and `InstructionsRepresentable`, so passing the
+    ///   bare `String` silently binds the `some PromptRepresentable` overload
+    ///   and measures the system prompt under *prompt* framing — the emitted
+    ///   `instructions=` value would be quietly mislabelled.
+    private func logInputTokenBudget(
+      seq: Int, system: String, user: String, schema: GenerationSchema?
+    ) async {
+      let contextSize = model.contextSize
+      guard #available(iOS 26.4, macOS 26.4, *) else {
+        // Explicit rather than a silent skip: for an instrument, "no output" and
+        // "nothing to report" are otherwise indistinguishable.
+        Self.emitTokenBudget(
+          "fmTokenBudget seq=\(seq) phase=input contextSize=\(contextSize) "
+            + "note=instrumentation-unavailable-runtime-below-26.4")
+        return
+      }
+      // Every count is `try?` with a -1 sentinel. `tokenCount` is `async throws`,
+      // and a propagating instrumentation error would leave `generate` as a
+      // generation failure, reach `LLMCaller`, and be counted as a turn skip
+      // against ADR-021's 3-consecutive-skip breaker — instrumentation
+      // manufacturing the very failures it exists to measure.
+      let instructions = (try? await model.tokenCount(for: Instructions(system))) ?? -1
+      let prompt = (try? await model.tokenCount(for: user)) ?? -1
+      var schemaTokens = -1
+      if let schema {
+        schemaTokens = (try? await model.tokenCount(for: schema)) ?? -1
+      }
+      Self.emitTokenBudget(
+        "fmTokenBudget seq=\(seq) phase=input contextSize=\(contextSize) "
+          + "instructions=\(instructions) prompt=\(prompt) schema=\(schemaTokens)")
+    }
+
+    /// Measures what the completed turn OCCUPIES in the context window.
+    ///
+    /// Takes the transcript slice rather than the `Response` so both the plain
+    /// and the guided path (whose `Content` differs) can call it unchanged.
+    private func logResponseTokenBudget(seq: Int, entries: ArraySlice<Transcript.Entry>) async {
+      guard #available(iOS 26.4, macOS 26.4, *) else { return }
+      let contextSize = model.contextSize
+      // Filtered to `.response`: the full slice also carries the prompt entry,
+      // so counting it as "output" would double-count the prompt against the 4k
+      // budget and make the input terms look artificially cheap.
+      let responseEntries = entries.filter {
+        if case .response = $0 { return true } else { return false }
+      }
+      let responseTokens = (try? await model.tokenCount(for: responseEntries)) ?? -1
+      // UNFILTERED, and the authoritative occupancy figure. The three separately
+      // tokenized fragments (instructions / prompt / response) each exclude the
+      // session's own role and turn framing, so their sum is a LOWER BOUND; this
+      // term is the only one directly comparable to `contextSize`. Their
+      // difference is therefore the framing overhead — measurable, not assumed.
+      let transcriptTokens = (try? await model.tokenCount(for: entries)) ?? -1
+      let headroom = transcriptTokens >= 0 ? contextSize - transcriptTokens : -1
+      // ADVISORY, not exact. `responseTokens` counts a `Transcript.Entry`, which
+      // carries role/segment framing, while `maximumResponseTokens` bounds the
+      // generator's raw output — so near the cap this biases toward FALSE
+      // POSITIVES by the framing delta. Read it as "probably truncated" and
+      // confirm against the raw `responseTokens` / `cap` on the same line.
+      let cap = maximumResponseTokens
+      let hitCap = cap.map { responseTokens >= $0 } ?? false
+      Self.emitTokenBudget(
+        "fmTokenBudget seq=\(seq) phase=response contextSize=\(contextSize) "
+          + "response=\(responseTokens) transcript=\(transcriptTokens) "
+          + "headroom=\(headroom) cap=\(cap.map(String.init) ?? "none") hitCap=\(hitCap)")
     }
 
     /// Maps a model-unavailable reason to a human-readable, distinct message so

--- a/Pastura/Pastura/LLM/FoundationModelsService.swift
+++ b/Pastura/Pastura/LLM/FoundationModelsService.swift
@@ -29,6 +29,7 @@
     // OSAllocatedUnfairLock. `model` is an immutable Sendable value.
 
     private let model: SystemLanguageModel
+    private let maximumResponseTokens: Int?
     private let loadedState: OSAllocatedUnfairLock<Bool>
 
     /// Creates a service over a system language model.
@@ -46,11 +47,21 @@
     /// was wrong precisely because no caller ever passed anything else. The
     /// harness selects the mode via `--guardrails`.
     ///
-    /// - Parameter model: The system model to drive. Defaults to
-    ///   ``SystemLanguageModel/default`` (the general-purpose base model with
-    ///   default guardrails).
-    public init(model: SystemLanguageModel = .default) {
+    /// - Parameters:
+    ///   - model: The system model to drive. Defaults to
+    ///     ``SystemLanguageModel/default`` (the general-purpose base model with
+    ///     default guardrails).
+    ///   - maximumResponseTokens: Upper bound on generated tokens, forwarded as
+    ///     `GenerationOptions.maximumResponseTokens`. `nil` (the default) leaves
+    ///     generation unconstrained, i.e. the behaviour every prior #1072
+    ///     battery measured. Spike #1154 wires this to test whether capping
+    ///     output relieves the 4k-context blocker — the expected outcome is
+    ///     *not* a clean win: a cap truncates the JSON object mid-object, which
+    ///     converts a context-exceeded failure into a parse failure rather than
+    ///     removing it. That conversion is itself the measurement.
+    public init(model: SystemLanguageModel = .default, maximumResponseTokens: Int? = nil) {
       self.model = model
+      self.maximumResponseTokens = maximumResponseTokens
       self.loadedState = OSAllocatedUnfairLock(initialState: false)
     }
 
@@ -154,8 +165,15 @@
       // permissive run that still throws `guardrailViolation` means this
       // argument went missing.
       let session = LanguageModelSession(model: self.model, instructions: system)
+      // Built ONCE here, ahead of any branch on generation path, and threaded to
+      // every `respond` overload. `respond`'s `options:` carries a compiler
+      // default, so a callsite that omits it silently generates unconstrained —
+      // structurally the same silent-default trap as the `model:` argument
+      // above, whose omission invalidated an entire 6-cell battery (#1156).
+      // One value, one construction site, so no two paths can disagree.
+      let options = GenerationOptions(maximumResponseTokens: maximumResponseTokens)
       do {
-        let response = try await session.respond(to: user)
+        let response = try await session.respond(to: user, options: options)
         return response.content
       } catch let error as LanguageModelSession.GenerationError {
         throw Self.map(error)

--- a/Pastura/Pastura/LLM/FoundationModelsService.swift
+++ b/Pastura/Pastura/LLM/FoundationModelsService.swift
@@ -34,8 +34,11 @@
     // @unchecked Sendable: the only mutable state is `loadedState`, protected by
     // OSAllocatedUnfairLock. `model` is an immutable Sendable value.
 
-    private let model: SystemLanguageModel
-    private let maximumResponseTokens: Int?
+    // `model` / `maximumResponseTokens` are internal rather than private so the
+    // sibling-file extensions can read them — `private` is file-scoped, and the
+    // token-budget instrumentation lives in `+TokenBudget.swift`.
+    let model: SystemLanguageModel
+    let maximumResponseTokens: Int?
     private let guidedGeneration: Bool
     private let loadedState: OSAllocatedUnfairLock<Bool>
 
@@ -45,9 +48,6 @@
     /// response line, so without a key an analyst cannot pair the overflow with
     /// the input measurements that produced it.
     private let turnSeq: OSAllocatedUnfairLock<Int>
-
-    static let tokenBudgetLogger = Logger(
-      subsystem: "app.pastura.Pastura", category: "FMTokenBudget")
 
     /// Creates a service over a system language model.
     ///
@@ -220,7 +220,8 @@
       if guidedGeneration, let schema, !schema.fields.isEmpty {
         generationSchema = try Self.generationSchema(from: schema)
       }
-      await logInputTokenBudget(seq: seq, system: system, user: user, schema: generationSchema)
+      let inputTokens = await logInputTokenBudget(
+        seq: seq, system: system, user: user, schema: generationSchema)
       do {
         let result: (text: String, entries: ArraySlice<Transcript.Entry>)
         if let generationSchema {
@@ -230,111 +231,26 @@
           let response = try await session.respond(to: user, options: options)
           result = (response.content, response.transcriptEntries)
         }
-        await logResponseTokenBudget(seq: seq, entries: result.entries)
+        await logResponseTokenBudget(
+          seq: seq, inputTokens: inputTokens, entries: result.entries)
         return result.text
       } catch let error as LanguageModelSession.GenerationError {
         if case .exceededContextWindowSize = error {
           // No response exists, so no response-side line is emitted. Without
           // this marker the event blocker 2 is ABOUT would be the one event
-          // absent from the data. `seq` joins it back to the input line.
-          Self.emitTokenBudget("fmTokenBudget seq=\(seq) phase=overflow")
+          // absent from the data. Carries `input` directly (not only the `seq`
+          // join) because this line is the primary evidence: the #1154 smoke run
+          // saw overflow at input=403 against contextSize=4096 — under 10% of
+          // the window — while a turn with input=575 succeeded. Whatever
+          // exhausts the window, it is not the size of the input.
+          Self.emitTokenBudget(
+            "fmTokenBudget seq=\(seq) phase=overflow contextSize=\(model.contextSize) "
+              + "input=\(inputTokens)")
         }
         throw Self.map(error)
       } catch {
         throw LLMError.generationFailed(description: String(describing: error))
       }
-    }
-
-    /// Emits one diagnostic line to OSLog and mirrors it to stderr.
-    ///
-    /// The stderr mirror is what the macOS harness (ADR-013) actually reads —
-    /// CLI `os.Logger` output is not reliably queryable via `log show`, and
-    /// `run_scenario.sh` captures stderr to `<out>.stderr.log`. That file is
-    /// already mixed-content and every consumer parses it with
-    /// `jq -Rc 'fromjson? | select(...)'`, which silently drops non-JSON lines,
-    /// so a plain-text line here cannot corrupt the `DiagLine` JSONL channel.
-    ///
-    /// Every value on these lines is a token count or a fixed marker — never
-    /// scenario text or model output — so `privacy: .public` is correct here
-    /// (CLAUDE.md "Logger privacy").
-    private static func emitTokenBudget(_ line: String) {
-      tokenBudgetLogger.info("\(line, privacy: .public)")
-      fputs("\(line)\n", stderr)
-    }
-
-    /// Measures what the turn's INPUT costs against the context window, before
-    /// generation runs (#1154 blocker 2).
-    ///
-    /// `contextSize` is the denominator and is emitted unconditionally: it is
-    /// available at 26.0, and blocker 2's headline "4k" figure is itself a claim
-    /// worth measuring rather than inheriting. The SDK back-deploys a constant
-    /// below 26.4, so a ≥26.4 runtime may legitimately report a different size.
-    ///
-    /// - Note: `Instructions(system)` is load-bearing. `String` conforms to BOTH
-    ///   `PromptRepresentable` and `InstructionsRepresentable`, so passing the
-    ///   bare `String` silently binds the `some PromptRepresentable` overload
-    ///   and measures the system prompt under *prompt* framing — the emitted
-    ///   `instructions=` value would be quietly mislabelled.
-    private func logInputTokenBudget(
-      seq: Int, system: String, user: String, schema: GenerationSchema?
-    ) async {
-      let contextSize = model.contextSize
-      guard #available(iOS 26.4, macOS 26.4, *) else {
-        // Explicit rather than a silent skip: for an instrument, "no output" and
-        // "nothing to report" are otherwise indistinguishable.
-        Self.emitTokenBudget(
-          "fmTokenBudget seq=\(seq) phase=input contextSize=\(contextSize) "
-            + "note=instrumentation-unavailable-runtime-below-26.4")
-        return
-      }
-      // Every count is `try?` with a -1 sentinel. `tokenCount` is `async throws`,
-      // and a propagating instrumentation error would leave `generate` as a
-      // generation failure, reach `LLMCaller`, and be counted as a turn skip
-      // against ADR-021's 3-consecutive-skip breaker — instrumentation
-      // manufacturing the very failures it exists to measure.
-      let instructions = (try? await model.tokenCount(for: Instructions(system))) ?? -1
-      let prompt = (try? await model.tokenCount(for: user)) ?? -1
-      var schemaTokens = -1
-      if let schema {
-        schemaTokens = (try? await model.tokenCount(for: schema)) ?? -1
-      }
-      Self.emitTokenBudget(
-        "fmTokenBudget seq=\(seq) phase=input contextSize=\(contextSize) "
-          + "instructions=\(instructions) prompt=\(prompt) schema=\(schemaTokens)")
-    }
-
-    /// Measures what the completed turn OCCUPIES in the context window.
-    ///
-    /// Takes the transcript slice rather than the `Response` so both the plain
-    /// and the guided path (whose `Content` differs) can call it unchanged.
-    private func logResponseTokenBudget(seq: Int, entries: ArraySlice<Transcript.Entry>) async {
-      guard #available(iOS 26.4, macOS 26.4, *) else { return }
-      let contextSize = model.contextSize
-      // Filtered to `.response`: the full slice also carries the prompt entry,
-      // so counting it as "output" would double-count the prompt against the 4k
-      // budget and make the input terms look artificially cheap.
-      let responseEntries = entries.filter {
-        if case .response = $0 { return true } else { return false }
-      }
-      let responseTokens = (try? await model.tokenCount(for: responseEntries)) ?? -1
-      // UNFILTERED, and the authoritative occupancy figure. The three separately
-      // tokenized fragments (instructions / prompt / response) each exclude the
-      // session's own role and turn framing, so their sum is a LOWER BOUND; this
-      // term is the only one directly comparable to `contextSize`. Their
-      // difference is therefore the framing overhead — measurable, not assumed.
-      let transcriptTokens = (try? await model.tokenCount(for: entries)) ?? -1
-      let headroom = transcriptTokens >= 0 ? contextSize - transcriptTokens : -1
-      // ADVISORY, not exact. `responseTokens` counts a `Transcript.Entry`, which
-      // carries role/segment framing, while `maximumResponseTokens` bounds the
-      // generator's raw output — so near the cap this biases toward FALSE
-      // POSITIVES by the framing delta. Read it as "probably truncated" and
-      // confirm against the raw `responseTokens` / `cap` on the same line.
-      let cap = maximumResponseTokens
-      let hitCap = cap.map { responseTokens >= $0 } ?? false
-      Self.emitTokenBudget(
-        "fmTokenBudget seq=\(seq) phase=response contextSize=\(contextSize) "
-          + "response=\(responseTokens) transcript=\(transcriptTokens) "
-          + "headroom=\(headroom) cap=\(cap.map(String.init) ?? "none") hitCap=\(hitCap)")
     }
 
     /// Maps a model-unavailable reason to a human-readable, distinct message so

--- a/Pastura/PasturaTests/LLM/FoundationModelsServiceTests.swift
+++ b/Pastura/PasturaTests/LLM/FoundationModelsServiceTests.swift
@@ -172,6 +172,37 @@
       #expect(try canonical(schemaJSON(from: oneField)) != canonical(schemaJSON(from: twoFields)))
     }
 
+    /// The guided path deliberately has NO fallback: a schema-build failure
+    /// throws instead of quietly running the turn unguided. That choice is what
+    /// prevents #1156's failure shape — a build failure is deterministic per
+    /// `OutputSchema` shape, so a silent fallback would run an ENTIRE battery
+    /// unguided while the run log still claimed guided. This pins both the throw
+    /// and the grep-classifiable prefix the harness digest keys on.
+    ///
+    /// Duplicate field names are the reachable failing shape: the SDK rejects
+    /// them with `duplicateProperty`. An EMPTY field list and an empty field
+    /// name were both probed and build fine — which is why the callsite guards
+    /// `!schema.fields.isEmpty` itself rather than relying on a throw.
+    @available(iOS 26, macOS 26, *)
+    @Test func guidedSchemaBuildFailureThrowsWithClassifiablePrefix() {
+      let duplicated = OutputSchema(fields: [
+        .init(name: "statement", kind: .string),
+        .init(name: "statement", kind: .string)
+      ])
+
+      #expect(throws: LLMError.self) {
+        try FoundationModelsService.generationSchema(from: duplicated)
+      }
+      do {
+        _ = try FoundationModelsService.generationSchema(from: duplicated)
+        Issue.record("expected a schema-build failure")
+      } catch {
+        #expect(
+          description(of: error as? LLMError ?? .notLoaded)
+            .hasPrefix("Foundation Models guided schema build failed — "))
+      }
+    }
+
     /// Builds the schema and decodes its `Codable` form into inspectable JSON.
     ///
     /// `GenerationSchema` exposes no property accessors, so its encoded form is

--- a/Pastura/PasturaTests/LLM/FoundationModelsServiceTests.swift
+++ b/Pastura/PasturaTests/LLM/FoundationModelsServiceTests.swift
@@ -1,5 +1,6 @@
 #if canImport(FoundationModels)
 
+  import Foundation
   import FoundationModels
   import Testing
 
@@ -95,6 +96,99 @@
         description(of: locale).hasPrefix("Foundation Models unsupported language or locale — "))
       // Unprefixed classes still share the generic bucket by design.
       #expect(description(of: other).hasPrefix("Foundation Models generation failed — "))
+    }
+
+    // MARK: - Guided-generation schema builder
+
+    /// The ONLY machine gate on the guided-generation path (#1154 / #1072
+    /// reversal condition 1). Real inference needs an Apple Intelligence device,
+    /// but the `OutputSchema` → `GenerationSchema` translation is pure logic, so
+    /// it runs in CI (every Swift job pins Xcode 26.4, which ships the FM SDK).
+    @available(iOS 26, macOS 26, *)
+    @Test func guidedSchemaCarriesEveryDeclaredFieldAndNothingElse() throws {
+      let json = try schemaJSON(
+        from: OutputSchema(fields: [
+          .init(name: "statement", kind: .string),
+          .init(name: "inner_thought", kind: .string)
+        ]))
+
+      let properties = json["properties"] as? [String: Any] ?? [:]
+      #expect(Set(properties.keys) == ["statement", "inner_thought"])
+      // Every declared field is mandatory — an optional field would let the
+      // model omit one and still satisfy the schema, which is precisely the
+      // missing-key failure `JSONResponseParser` exists to catch.
+      let required = json["required"] as? [String] ?? []
+      #expect(Set(required) == ["statement", "inner_thought"])
+    }
+
+    /// Field ORDER is load-bearing and is carried explicitly by the schema's
+    /// `x-order` key. ``OutputSchema/fields`` documents its order as the single
+    /// source of truth for the primary-first policy — the same ordering
+    /// `GBNFGrammarBuilder` and `PromptBuilder` consume so grammar and prompt
+    /// cannot drift — and `PartialOutputExtractor` relies on the primary field
+    /// arriving first for progressive streaming display. The guided path must
+    /// not silently reorder it.
+    @available(iOS 26, macOS 26, *)
+    @Test func guidedSchemaPreservesDeclaredFieldOrder() throws {
+      let json = try schemaJSON(
+        from: OutputSchema(fields: [
+          .init(name: "statement", kind: .string),
+          .init(name: "inner_thought", kind: .string)
+        ]))
+
+      #expect(json["x-order"] as? [String] == ["statement", "inner_thought"])
+    }
+
+    /// Pins the claim the guided path's why-comment makes: `.choice` maps to a
+    /// plain String leaf, exactly like `.string`. `OutputSchema.Kind.choice`
+    /// carries no option payload, so there is nothing to enumerate — if a future
+    /// change starts emitting `anyOf:` for `.choice`, this fails and forces the
+    /// decision to be explicit rather than incidental.
+    @available(iOS 26, macOS 26, *)
+    @Test func guidedSchemaTreatsChoiceAsAPlainString() throws {
+      let asChoice = OutputSchema(fields: [.init(name: "action", kind: .choice)])
+      let asString = OutputSchema(fields: [.init(name: "action", kind: .string)])
+
+      #expect(try canonical(schemaJSON(from: asChoice)) == canonical(schemaJSON(from: asString)))
+    }
+
+    /// Negative control — a guard's success case proves nothing on its own.
+    /// Adding a field MUST change the schema, or the assertions above would also
+    /// pass against a builder that silently dropped every field.
+    ///
+    /// This control only works on the CANONICALIZED form. `JSONEncoder` output
+    /// for `GenerationSchema` is dictionary-backed and its top-level key order
+    /// varies between two encodes of the *same* schema — so comparing raw
+    /// encoded strings makes any two schemas "differ" and the control passes
+    /// vacuously. It did, until `canonical(_:)` was introduced.
+    @available(iOS 26, macOS 26, *)
+    @Test func guidedSchemaChangesWhenAFieldIsAdded() throws {
+      let oneField = OutputSchema(fields: [.init(name: "statement", kind: .string)])
+      let twoFields = OutputSchema(fields: [
+        .init(name: "statement", kind: .string),
+        .init(name: "inner_thought", kind: .string)
+      ])
+
+      #expect(try canonical(schemaJSON(from: oneField)) != canonical(schemaJSON(from: twoFields)))
+    }
+
+    /// Builds the schema and decodes its `Codable` form into inspectable JSON.
+    ///
+    /// `GenerationSchema` exposes no property accessors, so its encoded form is
+    /// the only reachable surface to assert against — `debugDescription` is an
+    /// undocumented, unstable format and would make a far weaker gate.
+    @available(iOS 26, macOS 26, *)
+    private func schemaJSON(from schema: OutputSchema) throws -> [String: Any] {
+      let generationSchema = try FoundationModelsService.generationSchema(from: schema)
+      let data = try JSONEncoder().encode(generationSchema)
+      return try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
+    }
+
+    /// Key-sorted rendering, so two schemas compare on CONTENT rather than on
+    /// dictionary iteration order (see `guidedSchemaChangesWhenAFieldIsAdded`).
+    private func canonical(_ object: [String: Any]) throws -> String {
+      let data = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+      return String(bytes: data, encoding: .utf8) ?? ""
     }
 
     /// Unwraps the description `map` builds — the whole point is the string,

--- a/tools/harness/Sources/PasturaHarnessKit/HarnessConfig.swift
+++ b/tools/harness/Sources/PasturaHarnessKit/HarnessConfig.swift
@@ -60,10 +60,17 @@ package struct HarnessConfig: Sendable, Equatable {
   /// ``Backend/llamaCpp`` backend, which has no guardrail concept.
   package var guardrails: Guardrails = .default
 
+  /// Foundation Models `maximumResponseTokens` cap. `nil` keeps the SDK
+  /// default. Ignored for the ``Backend/llamaCpp`` backend.
+  package var maxResponseTokens: Int?
+  /// Foundation Models guided-generation mode. Ignored for the
+  /// ``Backend/llamaCpp`` backend.
+  package var guidedGeneration = false
+
   package static let usage = """
     usage: pastura-harness --scenario <path.yaml> [--model <path.gguf>] \
     [--backend <id>] [--out <path.jsonl>] [--timeout <seconds>] [--quiet] [--profile <id>] \
-    [--guardrails <id>]
+    [--guardrails <id>] [--max-response-tokens <n>] [--guided-generation]
     --backend selects the inference backend (default: \(Backend.llamaCpp.rawValue); \
     also: \(Backend.foundationModels.rawValue)). --model is required for \
     \(Backend.llamaCpp.rawValue) and ignored for \(Backend.foundationModels.rawValue).
@@ -72,6 +79,10 @@ package struct HarnessConfig: Sendable, Equatable {
     --guardrails selects the Foundation Models guardrail mode (default: \
     \(Guardrails.default.rawValue); also: \(Guardrails.permissive.rawValue)). \
     Ignored for the \(Backend.llamaCpp.rawValue) backend.
+    --max-response-tokens caps the Foundation Models response length \
+    (default: unset, uses the SDK default). Ignored for the \(Backend.llamaCpp.rawValue) backend.
+    --guided-generation enables Foundation Models guided generation. Ignored for the \
+    \(Backend.llamaCpp.rawValue) backend.
     """
 
   /// Mutable accumulator for ``parse(_:)``'s argument loop.
@@ -90,12 +101,15 @@ package struct HarnessConfig: Sendable, Equatable {
     var profile = ModelProfile.gemma4E2B
     var backend = Backend.llamaCpp
     var guardrails = Guardrails.default
+    var maxResponseTokens: Int?
+    var guidedGeneration = false
 
     mutating func apply(
       _ arg: String, from iterator: inout IndexingIterator<[String]>
     ) throws {
       if try applyPathFlag(arg, from: &iterator) { return }
       if try applyOptionFlag(arg, from: &iterator) { return }
+      if try applyFoundationModelsFlag(arg, from: &iterator) { return }
       throw HarnessConfigError("unknown argument '\(arg)'\n\(usage)")
     }
 
@@ -131,6 +145,22 @@ package struct HarnessConfig: Sendable, Equatable {
       }
       return true
     }
+
+    /// - Returns: `true` when `arg` was a Foundation Models tuning flag this
+    ///   consumed. Split out from `applyOptionFlag` to stay under the
+    ///   cyclomatic-complexity limit (see the note above `apply`).
+    private mutating func applyFoundationModelsFlag(
+      _ arg: String, from iterator: inout IndexingIterator<[String]>
+    ) throws -> Bool {
+      switch arg {
+      case "--max-response-tokens":
+        maxResponseTokens = try HarnessConfig.parseMaxResponseTokens(
+          HarnessConfig.value(for: arg, from: &iterator))
+      case "--guided-generation": guidedGeneration = true
+      default: return false
+      }
+      return true
+    }
   }
 
   /// Parses CLI arguments (excluding argv[0]).
@@ -149,7 +179,25 @@ package struct HarnessConfig: Sendable, Equatable {
       scenarioPath: scenario, modelPath: modelPath, outPath: accumulator.out,
       timeoutSeconds: accumulator.timeout, quiet: accumulator.quiet,
       profile: accumulator.profile, backend: accumulator.backend,
-      guardrails: accumulator.guardrails)
+      guardrails: accumulator.guardrails, maxResponseTokens: accumulator.maxResponseTokens,
+      guidedGeneration: accumulator.guidedGeneration)
+  }
+
+  /// Run-log label for the Foundation Models backend, derived from the same
+  /// guardrails/guided-generation/max-tokens values used to construct the
+  /// `FoundationModelsService` — so a run's log line and its actual request
+  /// shape cannot independently drift (#1156 taught that a hand-written label
+  /// can silently stop matching the request it describes).
+  package var foundationModelsRunLabel: String {
+    var label = "Apple Foundation Model (\(guardrails.rawValue)"
+    if guidedGeneration {
+      label += ", guided"
+    }
+    if let maxResponseTokens {
+      label += ", maxtok=\(maxResponseTokens)"
+    }
+    label += ")"
+    return label
   }
 
   /// The effective model path: `--model` is required for the GGUF-backed
@@ -208,5 +256,13 @@ package struct HarnessConfig: Sendable, Equatable {
         "unknown --guardrails '\(raw)' — known guardrails: \(knownIDs)\n\(usage)")
     }
     return resolved
+  }
+
+  private static func parseMaxResponseTokens(_ raw: String) throws -> Int {
+    guard let parsed = Int(raw), parsed > 0 else {
+      throw HarnessConfigError(
+        "--max-response-tokens must be a positive integer, got '\(raw)'\n\(usage)")
+    }
+    return parsed
   }
 }

--- a/tools/harness/Sources/pastura-harness/Main.swift
+++ b/tools/harness/Sources/pastura-harness/Main.swift
@@ -166,8 +166,18 @@ enum Main {
           case .permissive: guardrails = .permissiveContentTransformations
           }
           let model = SystemLanguageModel(guardrails: guardrails)
-          let factory: HarnessRunner.LLMFactory = { FoundationModelsService(model: model) }
-          return (factory, "Apple Foundation Model (\(config.guardrails.rawValue))")
+          let maxResponseTokens = config.maxResponseTokens
+          let guidedGeneration = config.guidedGeneration
+          let factory: HarnessRunner.LLMFactory = {
+            FoundationModelsService(
+              model: model, maximumResponseTokens: maxResponseTokens,
+              guidedGeneration: guidedGeneration)
+          }
+          // Label derives from the same `config` values passed into the
+          // factory above (`foundationModelsRunLabel`) — see the #1156 note
+          // just above for why hand-writing a parallel literal here would
+          // reopen the drift it describes, now across two more dimensions.
+          return (factory, config.foundationModelsRunLabel)
         } else {
           throw HarnessConfigError(
             "--backend \(HarnessConfig.Backend.foundationModels.rawValue) requires macOS 26 or later"

--- a/tools/harness/Tests/PasturaHarnessKitTests/HarnessConfigTests.swift
+++ b/tools/harness/Tests/PasturaHarnessKitTests/HarnessConfigTests.swift
@@ -178,4 +178,100 @@ struct HarnessConfigTests {
       ])
     }
   }
+
+  @Test func defaultsMaxResponseTokensAndGuidedGenerationToUnset() throws {
+    let config = try HarnessConfig.parse([
+      "--scenario", "s.yaml", "--model", "m.gguf"
+    ])
+    #expect(config.maxResponseTokens == nil)
+    #expect(config.guidedGeneration == false)
+  }
+
+  @Test func parsesMaxResponseTokens() throws {
+    let config = try HarnessConfig.parse([
+      "--scenario", "s.yaml", "--backend", "foundation-models",
+      "--max-response-tokens", "512"
+    ])
+    #expect(config.maxResponseTokens == 512)
+  }
+
+  @Test func parsesGuidedGeneration() throws {
+    let config = try HarnessConfig.parse([
+      "--scenario", "s.yaml", "--backend", "foundation-models",
+      "--guided-generation"
+    ])
+    #expect(config.guidedGeneration == true)
+  }
+
+  @Test func nonNumericMaxResponseTokensThrows() {
+    #expect(throws: HarnessConfigError.self) {
+      try HarnessConfig.parse([
+        "--scenario", "s.yaml", "--model", "m.gguf",
+        "--max-response-tokens", "soon"
+      ])
+    }
+  }
+
+  @Test func zeroMaxResponseTokensThrows() {
+    #expect(throws: HarnessConfigError.self) {
+      try HarnessConfig.parse([
+        "--scenario", "s.yaml", "--model", "m.gguf",
+        "--max-response-tokens", "0"
+      ])
+    }
+  }
+
+  @Test func negativeMaxResponseTokensThrows() {
+    #expect(throws: HarnessConfigError.self) {
+      try HarnessConfig.parse([
+        "--scenario", "s.yaml", "--model", "m.gguf",
+        "--max-response-tokens", "-1"
+      ])
+    }
+  }
+
+  @Test func missingMaxResponseTokensValueThrows() {
+    #expect(throws: HarnessConfigError.self) {
+      try HarnessConfig.parse([
+        "--scenario", "s.yaml", "--model", "m.gguf", "--max-response-tokens"
+      ])
+    }
+  }
+
+  @Test func foundationModelsRunLabelDefaultGuardrailsOnly() throws {
+    var config = try HarnessConfig.parse([
+      "--scenario", "s.yaml", "--backend", "foundation-models"
+    ])
+    config.guardrails = .default
+    #expect(config.foundationModelsRunLabel == "Apple Foundation Model (default)")
+  }
+
+  @Test func foundationModelsRunLabelPermissiveOnly() throws {
+    var config = try HarnessConfig.parse([
+      "--scenario", "s.yaml", "--backend", "foundation-models"
+    ])
+    config.guardrails = .permissive
+    #expect(config.foundationModelsRunLabel == "Apple Foundation Model (permissive)")
+  }
+
+  @Test func foundationModelsRunLabelPermissiveGuided() throws {
+    var config = try HarnessConfig.parse([
+      "--scenario", "s.yaml", "--backend", "foundation-models"
+    ])
+    config.guardrails = .permissive
+    config.guidedGeneration = true
+    #expect(config.foundationModelsRunLabel == "Apple Foundation Model (permissive, guided)")
+  }
+
+  @Test func foundationModelsRunLabelPermissiveGuidedMaxTok() throws {
+    var config = try HarnessConfig.parse([
+      "--scenario", "s.yaml", "--backend", "foundation-models"
+    ])
+    config.guardrails = .permissive
+    config.guidedGeneration = true
+    config.maxResponseTokens = 512
+    #expect(
+      config.foundationModelsRunLabel
+        == "Apple Foundation Model (permissive, guided, maxtok=512)")
+  }
 }


### PR DESCRIPTION
## Summary

#1072's blocker 2 — "the ~4k context window is too small" — was never measured, only inferred. This wires the two APIs that make it measurable and adds the schema-constrained path that makes #1072's reversal condition 1 testable. **Both new knobs default OFF; production behaviour is unchanged.**

- `GenerationOptions.maximumResponseTokens`, injectable via `FoundationModelsService.init`. The value is built once ahead of any generation-path branch and threaded to both `respond` callsites — `options:` carries a compiler default, so a missed pass-through compiles clean and silently generates unconstrained (the `model:` omission that invalidated a whole 6-cell battery in #1156 is the same shape).
- Token-budget instrumentation: `contextSize` as the denominator, `instructions` / `prompt` / `schema` / `response` as numerators, plus derived occupancy, headroom and `hitCap`. Emitted to OSLog + an stderr mirror the harness captures.
- A guided-generation path built on a runtime `GenerationSchema` translated from `OutputSchema`.
- Harness CLI flags `--max-response-tokens` / `--guided-generation`, threaded through `run_scenario.sh`, with the run-log label derived from the same config values that construct the service.

The full 6-cell battery for #1154 and the 2-cell guided×permissive re-run for #1072's condition 1 are **deliberately out of scope** — ja cells cost 130–805 s each, which would stall the PR for hours. They run post-merge in the main session and their digests go to #1154 / #1072.

## What the smoke runs already measured

Five real-inference runs on `bokete.yaml` (macOS 26.5, permissive guardrails). This is instrumentation validation, **not a verdict** — one scenario, mostly one arm.

| | plain | guided | cap=32 |
|---|---|---|---|
| turns | 22 | 31 | 18 |
| overflows | 3 (14%) | 11 (35%) | **0** |
| parse failures | 2 | 15 | 18 (100%) |

- **`contextSize` = 4096**, measured rather than assumed.
- **Blocker 2's stated mechanism does not match the data.** Overflow fired at inputs of 403 / 409 / 631 tokens against a 4096 window, while a turn with input=575 succeeded. Peak occupancy on a *successful* turn was 823 (20.1%). "Single-turn input+output exceeds 4k" does not produce these numbers.
- **Capping output removed overflow entirely (3 → 0) and converted every turn into a parse failure** — raw output truncates mid-string (`{"statement": "この猫、会議室で serious してるけど…`). This is exactly what #1154's Scope §1 predicted, now measured, and it is direct evidence that overflow is **generation-length**-driven rather than input-size-driven. `maximumResponseTokens` is therefore a measurement instrument here, not a fix.
- `hitCap`'s documented advisory bias is observable: response=37 against cap=32, a +5 framing delta.

## Two corrections worth flagging to a reviewer

Both are cases where a comment I wrote asserted behaviour the measurement then contradicted.

1. **`transcriptEntries` is not an occupancy figure.** An earlier revision claimed the unfiltered count was framing-inclusive occupancy and derived `headroom` from it. Measured: unfiltered equals `.response`-filtered in **79 of 79** turns across all five runs — the slice carries only the response entry. `headroom` was over-reporting by the entire ~400-token input. Occupancy is now `input + response`, and the term is retained only as a tripwire against a future SDK including the prompt entry.
2. **A near-miss misattribution.** Guided turns showed 15/15 empty model output, and I was about to report "guided generation degrades output" — a claim about the model. Recounting showed an unguided run at 9/14 empty, so the phenomenon is not guided-specific and the comparison I had drawn cited only the run that fit. The cause of empty-output turns is **not isolated**; it is recorded as an open question rather than given a plausible-sounding cause.

## Test plan

- `scripts/xcodebuild.sh test -skip-testing:PasturaUITests` — 3165 tests / 260 suites pass.
- `swift test` (harness package) — 63 tests / 6 suites pass.
- `swiftlint lint --strict` clean across `Pastura/` and `tools/harness`.
- Schema-builder gate verified by **sabotage**: dropping a field fails the membership and order tests. The add-a-field negative control initially passed *vacuously* — `GenerationSchema`'s `Codable` key order is nondeterministic, so any two encodes differ — and now compares canonicalized JSON.
- `run_scenario.sh` flag passthrough verified by an argv canary, also sabotage-checked (making the boolean flag value-taking fails the run).
- Five real-inference smoke runs as above.

## Device QA

実機QA不要 — no UI surface. The FM backend is spike-scope and unwired from `ModelRegistry` / model-selection, both new knobs default off, and the code path is exercised only by the macOS harness. Note CI type-checks this code (all five macOS jobs pin Xcode 26.4, which ships the FM SDK) but cannot run it, since Apple Intelligence needs an eligible device — hence the harness smoke runs above.

## Note for the deferred battery

Under guided generation the refusal numerator must be taken by **reading `agent_output` bodies**, not by counting parse-failure diagnostics: guided output parses, so a refusal arriving as on-schema field text is invisible to both channels #1072's digest used (the `guardrailViolation` throw and the parse-failure record). Comparing a guided cell's refusal count against #1072's table without this would put two different measurements under one column heading.

Closes #1154
