### PR TITLE
📝 docs: reconcile subagent-usage mirror after claude-kit #3

### DIFF
--- a/.claude/rules/subagent-usage.md
+++ b/.claude/rules/subagent-usage.md
@@ -1,10 +1,13 @@
 # Subagent Usage Rules
 
 > Derived from [claude-kit](https://github.com/tyabu12/claude-kit) `rules/subagent-usage.md` —
-> the generic core is canonical there; reconcile one-way (kit → Pastura). In particular the
-> volatile facts (the cap table, the 800/8/5 and 1500/12/7 split thresholds, the #24055 status)
-> are kit-canonical: when they change upstream, update this copy from the kit, never the reverse.
-> Pastura-specific content lives only in this copy.
+> the generic core is canonical there; reconcile one-way (kit → Pastura). Everything numeric — the
+> cap table, the `#24055` status, the 800/8/5 and 1500/12/7 split thresholds — is kit-canonical.
+> The thresholds are *derived* from the cap table (smallest practical budget, prose-dense report),
+> so they are recomputed upstream, never retuned here. The one genuinely local input is report
+> density per changed line: it licenses bounding a call **tighter at the call site, never looser**
+> — a caller wanting less scope splits smaller instead of editing §2's numbers or the copies in
+> `.claude/agents/code-reviewer.md`. Pastura-specific content lives only in this copy.
 
 Always-loaded — see `CLAUDE.md` `## Context-Specific Rules` for the
 loading-mode rationale. Subagent calls can originate from any layer
@@ -47,16 +50,15 @@ Docs: [sub-agents](https://code.claude.com/docs/en/sub-agents.md),
 ## 2. Caller-side scope discipline
 
 When invoking a subagent, bound the work so the final report fits the
-budget:
+budget (derived — tighten at the call site, don't edit; see the header):
 
 - **Soft budget** (split if over): ~800 changed lines OR ~8 changed
   files OR ~5 review axes per invocation, whichever is tighter.
 - **Hard split** (always split): >1500 changed lines, >12 files, or
   >7 axes — these reliably truncate before the final report.
 
-Actual usage depends on file size and output verbosity — when numbers
-fall between soft and hard, prefer splitting. If splitting is
-impractical, see **§3. Sonnet override**.
+When numbers fall between soft and hard, prefer splitting. If splitting
+is impractical, see **§3. Sonnet override**.
 
 ## 3. Sonnet override (escape valve)
 
@@ -86,7 +88,11 @@ exceeded. The kit-provided `claude-kit:critic` self-defends differently
 (its `Output Discipline & Scope` section triages: highest-risk axes
 first, explicit deferrals instead of a bail-out). Defense in depth: subagent
 budget exhaustion is silent (intermediate text returned, final report
-missing), so the duplication with §2 is intentional.
+missing), so the duplication with §2 is intentional. Concretely, that
+looks like the mandated terminal section (`code-reviewer`'s Verdict
+block, `critic`'s Summary Table / Top Actions) missing *while*
+intermediate tool output is present and no `SCOPE_TOO_LARGE` fired — a
+merely short report is not the signal.
 
 ## 5. Official `/code-review` vs the custom agents
 

--- a/.claude/rules/subagent-usage.md
+++ b/.claude/rules/subagent-usage.md
@@ -2,12 +2,13 @@
 
 > Derived from [claude-kit](https://github.com/tyabu12/claude-kit) `rules/subagent-usage.md` —
 > the generic core is canonical there; reconcile one-way (kit → Pastura). Everything numeric — the
-> cap table, the `#24055` status, the 800/8/5 and 1500/12/7 split thresholds — is kit-canonical.
-> The thresholds are *derived* from the cap table (smallest practical budget, prose-dense report),
-> so they are recomputed upstream, never retuned here. The one genuinely local input is report
-> density per changed line: it licenses bounding a call **tighter at the call site, never looser**
-> — a caller wanting less scope splits smaller instead of editing §2's numbers or the copies in
-> `.claude/agents/code-reviewer.md`. Pastura-specific content lives only in this copy.
+> cap table, the `#24055` status, the 800/8/5 and 1500/12/7 split thresholds — is kit-canonical:
+> the thresholds are *derived* from the cap table (smallest practical budget, prose-dense report),
+> so they are recomputed upstream, never retuned here. The one lever a caller controls is report
+> density per changed line — generated fixtures report far shorter than dense source — and it
+> licenses bounding a call **tighter at the call site, never looser**: split smaller rather than
+> edit §2's numbers or any agent copy of them (today `.claude/agents/code-reviewer.md`).
+> Pastura-specific content lives only in this copy.
 
 Always-loaded — see `CLAUDE.md` `## Context-Specific Rules` for the
 loading-mode rationale. Subagent calls can originate from any layer
@@ -89,8 +90,9 @@ exceeded. The kit-provided `claude-kit:critic` self-defends differently
 first, explicit deferrals instead of a bail-out). Defense in depth: subagent
 budget exhaustion is silent (intermediate text returned, final report
 missing), so the duplication with §2 is intentional. Concretely, that
-looks like the mandated terminal section (`code-reviewer`'s Verdict
-block, `critic`'s Summary Table / Top Actions) missing *while*
+looks like a mandated section missing (`code-reviewer` ends with
+Dependency Check, not the Verdict; `critic` emits its tail first, so
+there it is the per-axis bodies that go) *while*
 intermediate tool output is present and no `SCOPE_TOO_LARGE` fired — a
 merely short report is not the signal.
 


### PR DESCRIPTION
## Summary

Reconciles the `.claude/rules/subagent-usage.md` mirror after claude-kit PR #3 (`b8ed389`).

- The `800/8/5` and `1500/12/7` split thresholds are **derived from the output-cap table** — pinned to the smallest practical budget, assuming prose-dense report output — so they are recomputed upstream, never retuned here. The old "volatile facts" wording left them looking like arbitrary upstream constants a reader might reasonably retune.
- Name the one lever a caller actually controls: report density per changed line, spent by bounding a call **tighter at the call site, never looser** — split smaller rather than edit §2's numbers or any agent copy of them. Upstream's fixtures-vs-dense-source contrast comes along, because that density judgment is the only one this file asks a caller to exercise locally, and a name without a signal is not applicable.
- §2 gains a pointer to that framing, so a reader landing there without the header still learns the numbers are derived. Its now-redundant `Actual usage depends on file size and output verbosity` caveat goes — output verbosity is a property of the invoked agent, not a caller-side lever, so it never belonged in a caller-side section.
- §4 gains the observable definition of cap exhaustion — mandated section missing **while** intermediate tool output is present **and** no `SCOPE_TOO_LARGE` fired. "Silent" alone left the failure indistinguishable from a terse run.

Ownership is unchanged: one-way reconcile (kit → Pastura), nothing becomes project-owned. The cap table, the `#24055` line, and the numbers themselves are untouched — none changed upstream. Pastura's project-owned §3 (Sonnet override tied to `/orchestrate`'s Coupling rule) and §5 (`/code-review` vs the custom agents) are untouched.

**Cost, measured rather than eyeballed:** +112 words / +715 chars (+11%) on an always-loaded file. The line diffstat (+16/-8) understates it — prose-dense additions cost more per line than what they replaced. What it buys is the exhaustion definition and the density signal.

## Test plan

Docs-only; no code surface. Verified by assertion-checking instead:

- `.claude/agents/code-reviewer.md:15-16` inlines the full threshold set and carries **no** edit-inviting language (`grep 'retune\|tunable\|tune'` → no hits), so it is consistent with floor semantics and needs no parallel change.
- Repo-wide sweep for other numeric mirrors: only `code-reviewer.md`, and `.claude/agents/` holds exactly one file. `.claude/skills/orchestrate/SKILL.md` holds pointers, not numbers; `docs/decisions/ADR-021.md`'s `≲800` is historical split rationale, not normative. The prohibition is nonetheless written category-shaped so a future second inliner does not fall outside it.
- Every path and named section the new text asserts was checked against the real file — including the one that turned out wrong (below).
- Diffed against `git show origin/main:rules/subagent-usage.md`; every remaining divergence is deliberate Pastura-specific content.

⚠️ Note for anyone re-checking upstream: the local `claude-kit` checkout was on a side branch **without** #3, so reading its working tree shows the *stale* version and makes it look as though nothing changed upstream. Use `git show origin/main:rules/subagent-usage.md`.

## Review trail

Three gates ran. The second commit exists because the third one found something the first two missed.

- `claude-kit:critic` (Opus, pre-impl) — no Critical; 2 Warnings adopted.
- `code-reviewer` (Opus) — **PASS**, 0 issues. It raised as a low-priority suggestion that `code-reviewer.md`'s Output Format does not literally end with the Verdict block; I judged that inherited upstream shorthand and left it.
- `/risk-review` (3 clusters, 8 axes) — that judgement was **wrong**, and this is the finding worth reviewing: `code-reviewer`'s Verdict opens the *Review Summary*, while the report **terminates** at `## Dependency Check`. A report truncated in the token-hungry middle therefore keeps its Verdict and satisfies the detector's "terminal section present" test — so the rule would have told a reader to accept a review missing the Dependency-Rules gate, on the unattended `/queue-consumer` path where `code-reviewer` is the *sole* gate. Fixed by naming the terminating section. Also noted: `critic` emits its tail first under cap pressure, inverting the signature.

Two other risk-review Warnings are also applied: the density lever had lost its applicable signal, and the header's derivation clause was compacted after measuring the real (word/char) cost rather than trusting the line diffstat.

**Known follow-up, not in this PR:** claude-kit's own copy carries the same imprecise "`code-reviewer`'s verdict" wording. Per the one-way rule it should be corrected upstream and re-mirrored, rather than diverging here permanently — filing separately.

## Device QA

実機QA不要 — always-loaded rules doc only; no app surface, no build inputs.

Closes #1179