### PR TITLE
🐛 fix: mirror NonisolatedNonsendingByDefault in the harness manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -64,9 +64,20 @@ let package = Package(
       sources: ["Models", "LLM", "Engine"],
       swiftSettings: [
         // Mirrors the app target's SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor
-        // so the nonisolated annotations in core sources keep identical
-        // semantics under both build paths.
+        // so the nonisolated annotations in core sources mean the same thing
+        // under both build paths.
         .defaultIsolation(MainActor.self),
+        // The Pattern-6-relevant member of the app target's
+        // SWIFT_APPROACHABLE_CONCURRENCY = YES bundle (SE-0461): a
+        // `nonisolated async` function runs on its *caller's* executor rather
+        // than hopping to the global one. Without it this lane would compile
+        // Engine/LLM under semantics the app does not use, and the
+        // `swift build` gate that `.claude/rules/xcodebuild-cli.md` mandates
+        // after Engine changes would be structurally blind to Pattern 6
+        // (`.claude/rules/swift-isolation.md`). Only this member is mirrored —
+        // the rest of the SWIFT_APPROACHABLE_CONCURRENCY bundle is a separate
+        // decision, deliberately not folded in here (see #1169).
+        .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
         .swiftLanguageMode(.v6),
         // Consumed by LLM/SafeSampler.swift to drop the bridging-header-era
         // DEBUG test hooks, whose C declarations the SwiftPM build cannot

--- a/tools/kmp-gate-spike/Package.swift
+++ b/tools/kmp-gate-spike/Package.swift
@@ -22,13 +22,14 @@ import PackageDescription
 //
 // The XCFramework is a STAGED artifact — see README.md § "Assemble first".
 
-/// Mirrors the **app target's** concurrency regime, not the root harness
-/// package's. The two differ, and the difference is exactly what this gate has
-/// to reproduce:
+/// Mirrors the **app target's** concurrency regime, which this gate has to
+/// reproduce independently — it compiles the K/N boundary adapters, which the
+/// root harness manifest does not build at all:
 ///
 /// - `Pastura.xcodeproj` sets `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` **and**
 ///   `SWIFT_APPROACHABLE_CONCURRENCY = YES`.
-/// - The root `Package.swift` mirrors only the first for `PasturaCore`.
+/// - The root `Package.swift` mirrors both for `PasturaCore` as of #1169; before
+///   that it carried only the first, and the harness lane was Pattern-6-blind.
 ///
 /// The second is what enables `NonisolatedNonsendingByDefault` (SE-0461), under
 /// which a `nonisolated async` function runs on its *caller's* executor. That is


### PR DESCRIPTION
Closes #1169

Opened unattended by `/queue-consumer`. **Draft — awaiting human review.**

## What changed

`PasturaCore` (the `Package.swift` target compiling `Models`/`LLM`/`Engine` for the ADR-013 harness) mirrored the app target's `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` but not `SWIFT_APPROACHABLE_CONCURRENCY = YES`. The latter is what enables `NonisolatedNonsendingByDefault` (SE-0461) — the entire mechanism behind Pattern 6 in `.claude/rules/swift-isolation.md`. So the `swift build` gate that `.claude/rules/xcodebuild-cli.md` mandates after Engine changes was structurally blind to the one isolation trap with no compiler diagnostic.

Two commits:

1. `Package.swift` — add `.enableUpcomingFeature("NonisolatedNonsendingByDefault")` to `PasturaCore`'s `swiftSettings`; reword the parity comment.
2. `tools/kmp-gate-spike/Package.swift` — comment-only. Its doc comment asserted "the root `Package.swift` mirrors only the first", which commit 1 made false. Reconciled in the same change per `knowledge-layering.md` § Procedure step 3.

## Acceptance criteria

| Criterion | How the diff satisfies it | Coverage |
|---|---|---|
| `swift build` green from the repo root | Setting added to `PasturaCore` only; no source changes needed | **Verified locally** — `Build complete! (23.26s)`. The one warning is pre-existing (`DiagLine.type` Codable, `PasturaHarnessKit`), unrelated to this diff. Also gated per-PR by the CI harness-build job |
| `swift test` green from the repo root | ditto | **Verified locally** — `Test run with 63 tests in 6 suites passed` |
| The `PasturaCore` comment no longer overstates what is mirrored | The `.defaultIsolation` comment drops the "identical semantics" claim; the new comment states explicitly that **only** the Pattern-6-relevant member of the `SWIFT_APPROACHABLE_CONCURRENCY` bundle is mirrored | Not machine-testable — comment prose. Reviewer-verified |
| No source changes to `Models` / `LLM` / `Engine` | Diff is two `Package.swift` files, 18 insertions / 6 deletions | `git diff --stat origin/main...HEAD` |

**Bail-out condition did not fire.** Both build and test went green, which per the issue means the change is a compile-time no-op and safe to land alone. No isolation diagnostics appeared, so no design work was performed — as instructed.

## Judgment calls

- **Mirrored one member, not the bundle.** `SWIFT_APPROACHABLE_CONCURRENCY` is a bundle of upcoming features; the issue explicitly flags deciding on the rest as a separate call. Only `NonisolatedNonsendingByDefault` is enabled, and the comment says so plus points at #1169. Whether to mirror the rest is left open for a human.
- **Commit 2 is arguably out of the issue's scope.** I included it because commit 1 is what falsified that comment — leaving it would reinstate the exact misconception the issue exists to remove. It is comment-only, no build behaviour changes. Revert it if you'd rather it went separately.
- **Comment length.** The code reviewer noted the new 11-line comment runs ~3× its neighbours and could compact to ~5 lines (`xcodebuild-cli.md` already owns the gate-blindness explanation). Left as-is to stay minimal against the acceptance criteria; a trim is a fine follow-up or a review-time squash.
- **`tools/kmp-gate-spike` was not built** to verify commit 2 — `swift build` there fails on the missing staged XCFramework artifact, which is expected on any checkout that hasn't run `scripts/stage-framework.sh` (the manifest's own comment documents this). The edit is comment-only and manifest evaluation passed.

## Review

`code-reviewer` (Opus) — **PASS**, 0 critical / 1 warning / 1 suggestion. The warning was the gate-spike mirror drift, fixed in commit 2. The suggestion was the comment-length trim, declined above with rationale. Dependency check: PASS (no imports changed; `PasturaCore`'s target dependencies and `sources:` untouched).

## Device QA

None needed — no runtime or UI surface. The change affects only how the headless macOS harness lane compiles.
