### PR TITLE
📝 docs: re-mirror the exhaustion detector from claude-kit

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -13,7 +13,7 @@ You are a senior code reviewer for the Pastura iOS project (Swift 6 / SwiftUI / 
 You run under a 32K output-token cap that cannot be raised by frontmatter or env var.
 
 - **Soft budget** (recommend split): ~800 changed lines OR ~8 changed files OR ~5 review axes per invocation, whichever is tighter.
-- **Hard split** (always split): >1500 lines, >12 files, or >7 axes — these reliably truncate before the final Verdict block.
+- **Hard split** (always split): >1500 lines, >12 files, or >7 axes — at this size the report reliably loses its substance before the run completes.
 
 **Bail-out check (mandatory, before any other tool_use):** Run `git diff <base>...HEAD --stat` (or equivalent) as the very first tool call. If the diff exceeds the soft budget, respond with a single line and stop:
 
@@ -21,13 +21,13 @@ You run under a 32K output-token cap that cannot be raised by frontmatter or env
 SCOPE_TOO_LARGE: <X lines / Y files> exceeds soft budget. Please split into <suggested partitions>. See .claude/rules/subagent-usage.md for Sonnet-override constraints.
 ```
 
-Do NOT begin the Read / Grep cycle after this point — every subsequent tool_use consumes the budget that the final Verdict block needs.
+Do NOT begin the Read / Grep cycle after this point — every subsequent tool_use consumes the budget the report body needs. Your Verdict is cheap and comes first; what runs out is the room to substantiate it.
 
 ## Output Discipline
 
 - Do NOT emit assistant text between `tool_use` calls. Intermediate observations belong in `tool_use` arguments (e.g., the `command` field of `Bash`, the `pattern` field of `Grep`), never in user-visible text.
 - The final report (see Output Format section below) is the ONLY user-visible output.
-- If you find yourself near 20+ `tool_use` calls without having begun the final report, stop investigating and emit the report now. A short Verdict-with-fewer-citations is far more useful than a truncated mid-Verdict.
+- If you find yourself near 20+ `tool_use` calls without having begun the report, stop investigating and emit it now. A Verdict backed by fewer citations is far more useful than one whose supporting sections run out of budget mid-way.
 
 ## Bash Usage — STRICT READ-ONLY
 

--- a/.claude/rules/subagent-usage.md
+++ b/.claude/rules/subagent-usage.md
@@ -56,10 +56,29 @@ budget (derived — tighten at the call site, don't edit; see the header):
 - **Soft budget** (split if over): ~800 changed lines OR ~8 changed
   files OR ~5 review axes per invocation, whichever is tighter.
 - **Hard split** (always split): >1500 changed lines, >12 files, or
-  >7 axes — these reliably truncate before the final report.
+  >7 axes — at this size the report reliably loses its substance
+  before the run completes.
 
 When numbers fall between soft and hard, prefer splitting. If splitting
 is impractical, see **§3. Sonnet override**.
+
+**What exhaustion looks like.** *Not* a missing summary: review agents
+are built to emit their verdict/summary **first** under cap pressure, so
+it survives exactly when the run is truncated. Look instead for **detail
+missing behind a present summary**, which is mechanically checkable as a
+**count mismatch** — the summary claims more issues, axes, or findings
+than the body actually writes out, or names them with no evidence
+attached. Corroborate with intermediate tool output present and no
+`SCOPE_TOO_LARGE`. That combination is the signal to **split and
+re-run** — a report that is short *and internally consistent* is just
+short, and needs nothing. In Pastura the check is arithmetic rather than
+a prose judgement: `code-reviewer`'s summary emits per-severity counts
+(`- **Critical**: N issues`) to compare the body against.
+
+**Blind spot**: a summary claiming nothing cannot mismatch, so a
+zero-issue report truncated right after it reads as consistent. Closing
+that needs a structural check against a pinned Output Format — see
+`queue-consumer` hard rule 6, which carries one for the unattended path.
 
 ## 3. Sonnet override (escape valve)
 
@@ -87,14 +106,11 @@ default and unlocks the 64K Sonnet budget. Use sparingly:
 with `SCOPE_TOO_LARGE` before any tool_use when the soft budget is
 exceeded. The kit-provided `claude-kit:critic` self-defends differently
 (its `Output Discipline & Scope` section triages: highest-risk axes
-first, explicit deferrals instead of a bail-out). Defense in depth: subagent
-budget exhaustion is silent (intermediate text returned, final report
-missing), so the duplication with §2 is intentional. Concretely, that
-looks like a mandated section missing (`code-reviewer` ends with
-Dependency Check, not the Verdict; `critic` emits its tail first, so
-there it is the per-axis bodies that go) *while*
-intermediate tool output is present and no `SCOPE_TOO_LARGE` fired — a
-merely short report is not the signal.
+first, explicit deferrals instead of a bail-out). Defense in depth:
+budget exhaustion is silent, so duplicating §2's budget in the agents'
+own bail-out is intentional.
+For what exhaustion actually looks like, see §2 — the detector lives
+there, with the caller-side heuristics it corroborates.
 
 ## 5. Official `/code-review` vs the custom agents
 

--- a/.claude/skills/queue-consumer/SKILL.md
+++ b/.claude/skills/queue-consumer/SKILL.md
@@ -60,8 +60,22 @@ Non-goals:
    satisfies them. `### Out of scope` is binding. No "while at it"
    changes, even obvious ones — note them in the PR body instead.
 6. **No unreviewed PR.** If the code-reviewer pass is missing, returns
-   `SCOPE_TOO_LARGE`, or looks truncated (no final verdict), do NOT open
-   the PR — treat the issue as blocked with that reason.
+   `SCOPE_TOO_LARGE`, or is **incomplete**, do NOT open the PR — treat
+   the issue as blocked with that reason. Incomplete means either:
+   - **Count mismatch** — the summary's per-severity counts claim more
+     issues than the body writes out, or name them with no evidence
+     (see `.claude/rules/subagent-usage.md` §2).
+   - **Missing terminal section** — the report contains no
+     `## Dependency Check` section, or that section has no verdict line
+     under it. Test containment, not "ends with": `code-reviewer` may
+     append an unpinned footgun proposal after it, and a bare heading
+     with nothing beneath it is exactly the truncation being caught.
+     Naming a section is safe *here* and nowhere else: this gate binds
+     one agent whose Output Format is pinned in this repo, which
+     mandates "Always include the Review Summary and Dependency Check
+     sections". It is also the only check that catches a `PASS (0
+     issues)` report truncated right after its summary — that shape is
+     count-consistent, so the first bullet cannot see it.
 
 ## Step 0 — Preflight (abort the run on any failure)
 
@@ -192,8 +206,9 @@ Agent(subagent_type: "code-reviewer", model: "opus",
 - **PASS** → Step 5.
 - **FAIL** → fix the confirmed findings, re-run the reviewer once. A
   second FAIL = failed attempt (hard rule 4: retry or block).
-- **SCOPE_TOO_LARGE / truncated** → hard rule 6: block, no PR. Do not
-  shrink the review's scope to force a pass.
+- **SCOPE_TOO_LARGE / incomplete** (count mismatch, or no populated
+  `## Dependency Check`) → hard rule 6: block, no PR. Do not shrink the
+  review's scope to force a pass.
 
 ## Step 5 — Draft PR + label release (completes the issue)
 


### PR DESCRIPTION
## Summary

Re-mirrors claude-kit's rewritten subagent-exhaustion detector (kit `6a59cd0`) into Pastura,
replacing the local section-naming fix from #1180. Nothing was broken — #1180 was correct *for
Pastura*. The kit then fixed the same defect a different way and rejected the naming approach,
because naming an agent's terminal section copies that agent's Output Format into the rule: the
rule goes stale on any format change and silently mis-describes future review agents. Pastura
reconciles one-way from the kit, so the kit wording replaces the local one. This is the mirror
working, not a regression.

A sweep (mandated — the kit found 4 sites when 1 was reported) turned up **7 sites in 3 files**,
splitting into two distinct defect classes:

**(a) Detector text** — `.claude/rules/subagent-usage.md` §2 + §4, `queue-consumer` hard rule 6 and
its Step-4 shorthand. These take the kit's count-mismatch framing. The passage lands in §2
"Caller-side scope discipline", the kit's own structural slot, and §4 shrinks to a cross-reference,
so the always-loaded budget nets **down**.

**(b) Ordering contradiction** — `.claude/agents/code-reviewer.md` called the Verdict "final" while
its own Output Format puts `## Review Summary` first and `## Dependency Check` last. Two of those
three lines are budget-allocation instructions *to the agent*, not caller-side detection, so they
keep their meaning and only stop contradicting the file. No count-mismatch prose was pasted there.

Two Pastura-local findings the kit passage does not carry:

- `code-reviewer`'s summary emits per-severity counts (`- **Critical**: N issues`), so the
  count-mismatch check is **arithmetic** here, not a prose judgement.
- A `PASS (0 issues)` report truncated right after its summary claims nothing, so no count can
  mismatch — a genuine blind spot. `code-reviewer.md` mandates "Always include the Review Summary
  and Dependency Check sections", so `queue-consumer`'s unattended gate closes it with a
  containment test for a *populated* `## Dependency Check`. Naming a section is safe there and
  nowhere else: that gate binds one agent whose format is pinned in this repo.

Untouched, per the mirror header: the cap table, the 800/8/5 and 1500/12/7 thresholds, the
`#24055` line.

## Test plan

Docs-only; no build or test surface. Verification was by **negative control**, not plausibility —
the kit's own original passed two review gates on plausibility, which is how it shipped false.

The source is a **real** `code-reviewer` report: the Step-4 review of this very branch
(`PASS (3 issues)` — Critical 0, Warning 1, Suggestion 2). Predicates applied mechanically:

| # | Report shape | claimed | written | count mismatch | terminal missing | rule 6 blocks | expected |
|---|---|---|---|---|---|---|---|
| 1 | truncated below the per-severity count lines | 3 | 0 | **yes** | yes | **blocks** | blocks ✅ |
| 2 | untruncated — short but internally consistent | 3 | 3 | no | no | passes | passes ✅ |
| 3 | `PASS (0 issues)`, cut at the same point | 0 | 0 | **no** | yes | **blocks** | blocks ✅ |

Case 1 is the firing control (truncated *below* the count lines, so the counts survive to be
compared against — truncating below the Verdict line instead would leave only the `(N issues)`
parenthetical). Case 2 is the negative direction: the detector must **not** fire on a merely short
report. Case 3 confirms the blind spot empirically — count-mismatch does not see it — and that the
structural check is what catches it.

## Review

The Step-4 `code-reviewer` pass (Opus) returned **PASS**. Its one Warning was applied: the terminal
check was restated from "ends with `## Dependency Check`" to containment plus non-emptiness, since
`code-reviewer` may append an unpinned footgun proposal after that section and a bare heading with
nothing under it is exactly the truncation being caught. Both Suggestions were applied too — the
blind-spot paragraph compacted to one line plus a pointer (always-loaded budget; the walkthrough
lives with the check, and mirrors drift), and a dangling antecedent in §4 named.

## Device QA

実機QA不要 — `.claude/**` のドキュメントのみで、アプリのコード・リソースに変更なし。

Closes #1183
