### PR TITLE
📝 docs: record tools/ and repair the project-layout mirror

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,8 +205,10 @@ Pastura/
 ├── Utilities/
 └── Resources/
     ├── Presets/              # Bundled YAML scenarios
+    ├── DemoPresets/          # Demo-backing scenarios; the bundle flattens these with Presets/
     ├── DemoReplays/          # DL-time demo playback (ADR-007)
-    └── ContentBlocklist.json # ADR-005 content safety
+    ├── ContentBlocklist.json # ADR-005 content safety
+    └── *.xcstrings           # Localizable / InfoPlist string catalogs
 
 web/                             # The pastura.app site (Astro SSG, deployed via .github/workflows/deploy-pages.yml; #475)
 ├── astro.config.mjs             # i18n (en root / ja prefix), sitemap, trailingSlash
@@ -221,7 +223,14 @@ web/                             # The pastura.app site (Astro SSG, deployed via
 
 ```
 shared/                          # KMP shared modules (#501 / ADR-023). Gradle/Kotlin Multiplatform.
-└── models/                      #   `shared/models` — landed Stage 1 as INFRA (not production-wired; mirrors Swift Models/, depends on nothing). `shared/engine` port + iOS consumption are Phase 3.0.
+├── models/                      #   Mirrors Swift Models/; landed as infra, not production-wired.
+└── engine/                      #   Stage-2 gate slice landed; the bulk port and iOS consumption stay gated — read ADR-023 §6/§12 before editing.
+```
+
+```
+tools/                           # Dev tooling, outside the iOS app build
+├── harness/                     #   pastura-harness — headless macOS simulation runner (ADR-013). Built by `swift build` via the root Package.swift, not by the pre-commit hook.
+└── kmp-gate-spike/              #   ADR-023 Stage-2 gate spike consumer. The package builds on the nightly lane only — no per-PR lane takes an XCFramework dep — but its bash guards under scripts/ do run per-PR in ci.yml.
 ```
 
 ## Agent Tooling Dependency

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,7 +205,7 @@ Pastura/
 ├── Utilities/
 └── Resources/
     ├── Presets/              # Bundled YAML scenarios
-    ├── DemoPresets/          # Demo-backing scenarios; the bundle flattens these with Presets/
+    ├── DemoPresets/          # Demo-backing scenarios; bundle-flattened with Presets/ but excluded from PresetLoader.presetFileNames (never in the user picker)
     ├── DemoReplays/          # DL-time demo playback (ADR-007)
     ├── ContentBlocklist.json # ADR-005 content safety
     └── *.xcstrings           # Localizable / InfoPlist string catalogs
@@ -230,7 +230,7 @@ shared/                          # KMP shared modules (#501 / ADR-023). Gradle/K
 ```
 tools/                           # Dev tooling, outside the iOS app build
 ├── harness/                     #   pastura-harness — headless macOS simulation runner (ADR-013). Built by `swift build` via the root Package.swift, not by the pre-commit hook.
-└── kmp-gate-spike/              #   ADR-023 Stage-2 gate spike consumer. No per-PR lane may take an XCFramework dep (ADR-023 §6, decision B′); nightly builds the package, ci.yml runs its own scripts/ guards.
+└── kmp-gate-spike/              #   ADR-023 Stage-2 gate spike consumer. No per-PR lane may take an XCFramework dep (ADR-023 §6, decision B′); the nightly builds the package.
 ```
 
 ## Agent Tooling Dependency

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,13 +224,13 @@ web/                             # The pastura.app site (Astro SSG, deployed via
 ```
 shared/                          # KMP shared modules (#501 / ADR-023). Gradle/Kotlin Multiplatform.
 ├── models/                      #   Mirrors Swift Models/; landed as infra, not production-wired.
-└── engine/                      #   Stage-2 gate slice landed; the bulk port and iOS consumption stay gated — read ADR-023 §6/§12 before editing.
+└── engine/                      #   Stage-2 gate slice landed; the bulk port and iOS consumption stay gated (Phase 3.0) — read ADR-023 §6/§12 before editing.
 ```
 
 ```
 tools/                           # Dev tooling, outside the iOS app build
 ├── harness/                     #   pastura-harness — headless macOS simulation runner (ADR-013). Built by `swift build` via the root Package.swift, not by the pre-commit hook.
-└── kmp-gate-spike/              #   ADR-023 Stage-2 gate spike consumer. The package builds on the nightly lane only — no per-PR lane takes an XCFramework dep — but its bash guards under scripts/ do run per-PR in ci.yml.
+└── kmp-gate-spike/              #   ADR-023 Stage-2 gate spike consumer. No per-PR lane may take an XCFramework dep (ADR-023 §6, decision B′); nightly builds the package, ci.yml runs its own scripts/ guards.
 ```
 
 ## Agent Tooling Dependency

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ pastura/
 │   └── engine/              # Engine port — Stage-2 gate slice landed, bulk port gated
 ├── docs/
 │   ├── ROADMAP.md           # Phase scope and Go / No-Go criteria
-│   ├── release-setup.md     # One-time TestFlight release bootstrap (maintainers)
+│   ├── release-setup.md     # TestFlight bootstrap — per-machine + account setup
 │   ├── decisions/           # Architecture Decision Records
 │   ├── specs/               # Feature specifications
 │   ├── design/              # Design system, reference assets
@@ -167,8 +167,8 @@ pastura/
 ├── scripts/                 # Build, lint, release, content-blocklist helpers
 ├── fastlane/                # TestFlight release lanes (ADR-014); Gemfile / Gemfile.lock pin it
 ├── .github/                 # CI workflows and issue templates
-├── .claude/                 # Agent rules, skills, and hooks (see CLAUDE.md)
-├── Package.swift            # SwiftPM manifest for tools/harness (Package.resolved pins it)
+├── .claude/                 # Agent definitions, rules, skills, hook config
+├── Package.swift            # pastura-harness manifest (+ Package.resolved) — compiles app core for macOS
 └── build.gradle.kts         # Gradle root for shared/ (settings.gradle.kts, gradle/, gradlew*)
 ```
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ pastura/
 │   └── engine/              # Engine port — Stage-2 gate slice landed, bulk port gated
 ├── docs/
 │   ├── ROADMAP.md           # Phase scope and Go / No-Go criteria
+│   ├── release-setup.md     # One-time TestFlight release bootstrap (maintainers)
 │   ├── decisions/           # Architecture Decision Records
 │   ├── specs/               # Feature specifications
 │   ├── design/              # Design system, reference assets
@@ -166,12 +167,14 @@ pastura/
 ├── scripts/                 # Build, lint, release, content-blocklist helpers
 ├── fastlane/                # TestFlight release lanes (ADR-014); Gemfile / Gemfile.lock pin it
 ├── .github/                 # CI workflows and issue templates
+├── .claude/                 # Agent rules, skills, and hooks (see CLAUDE.md)
 ├── Package.swift            # SwiftPM manifest for tools/harness (Package.resolved pins it)
-└── build.gradle.kts         # Gradle root for shared/ (with settings.gradle.kts, gradlew*)
+└── build.gradle.kts         # Gradle root for shared/ (settings.gradle.kts, gradle/, gradlew*)
 ```
 
-Config dotfiles (`.swiftlint.yml`, `.swift-format`, `.gitignore`) are omitted
-above; everything else tracked at the repository root is listed.
+Root-level docs (this file, `CLAUDE.md`, `CONTRIBUTING.md`, `LICENSE`) and
+config dotfiles (`.swiftlint.yml`, `.swift-format`, `.gitignore`) are omitted
+above; every other tracked root entry is listed.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -135,20 +135,43 @@ pastura/
 │   │   ├── Models/          # Domain types, depends on nothing
 │   │   ├── Views/           # SwiftUI screens and components
 │   │   ├── Utilities/
-│   │   └── Resources/       # Bundled presets, demo replays, blocklist
+│   │   └── Resources/       # Presets, demo replays, blocklist, .xcstrings catalogs
 │   ├── PasturaTests/        # Unit and integration tests
 │   └── PasturaUITests/      # UI tests
+├── tools/
+│   ├── harness/             # pastura-harness — headless macOS simulation runner (ADR-013)
+│   └── kmp-gate-spike/      # ADR-023 Stage-2 gate spike consumer (builds nightly only)
+├── shared/                  # KMP shared modules (ADR-023)
+│   ├── models/              # Mirrors Swift Models/; landed as infra, not production-wired
+│   └── engine/              # Engine port — Stage-2 gate slice landed, bulk port gated
 ├── docs/
 │   ├── ROADMAP.md           # Phase scope and Go / No-Go criteria
 │   ├── decisions/           # Architecture Decision Records
 │   ├── specs/               # Feature specifications
 │   ├── design/              # Design system, reference assets
 │   ├── i18n/                # Localization workflow
-│   └── blocklist/           # ContentBlocklist source + build script
-├── shared/                  # KMP shared modules (Phase 3.0 / ADR-023); `models` landed as infra, not yet wired
+│   ├── blocklist/           # ContentBlocklist source + build script
+│   ├── gallery/             # Shared-scenario gallery (gallery.json + YAMLs)
+│   ├── examples/            # Reference scenario YAMLs, not bundled as presets
+│   ├── prototype/           # Python reference implementation
+│   ├── models/              # LLM model onboarding procedure
+│   ├── measurements/        # Measurement protocols (grammar-sampling baseline)
+│   ├── ci/                  # CI flake catalog and recovery walkthroughs
+│   ├── qa/                  # Manual QA walkthroughs
+│   ├── code-health/         # code-health-audit ledger and digests
+│   ├── security/            # Operator security checklist
+│   ├── store/               # App Store listing copy, review notes, screenshot plan
+│   └── phase0/              # Phase 0 assessment (historical)
 ├── web/                     # The pastura.app site (Astro SSG, deployed via GitHub Pages)
-└── scripts/                 # Build, lint, content-blocklist helpers
+├── scripts/                 # Build, lint, release, content-blocklist helpers
+├── fastlane/                # TestFlight release lanes (ADR-014); Gemfile / Gemfile.lock pin it
+├── .github/                 # CI workflows and issue templates
+├── Package.swift            # SwiftPM manifest for tools/harness (Package.resolved pins it)
+└── build.gradle.kts         # Gradle root for shared/ (with settings.gradle.kts, gradlew*)
 ```
+
+Config dotfiles (`.swiftlint.yml`, `.swift-format`, `.gitignore`) are omitted
+above; everything else tracked at the repository root is listed.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

`tools/` was absent from both README.md § "Project layout" and CLAUDE.md § "Directory Structure". Auditing the pair surfaced more than that entry:

- **`tools/`** — `harness/` (ADR-013 headless macOS simulation runner) and `kmp-gate-spike/` (ADR-023 Stage-2 gate spike consumer) were unrecorded in both files.
- **README `docs/` subtree** listed 5 of 16 tracked subdirectories. Now enumerates all 16 — a partial list reads as authoritative, which is worse than the terse original.
- **README root level** had no entry for the SwiftPM harness manifest, `fastlane/` (+ its `Gemfile`), the Gradle roots, `.github/`, or `.claude/`.
- **CLAUDE.md `shared/`** claimed the engine port was still Phase 3.0 work. The ADR-023 Stage-2 gate slice has landed (13 files under `commonMain`); what stays gated is the bulk port (Stage 3, on §12's four conditions) and iOS consumption (Stage 5). Trimmed to one line per module plus an `ADR-023 §6/§12` pointer, since the stage-status detail already lives in the Reference Documents row and a second copy in an always-loaded file would drift at the next amendment.
- **`Resources/`** omitted `DemoPresets/` and the string catalogs in both files.

Out of scope, verified: `data/` (`factory/`, `models/`, `queue/`) is entirely untracked local journal output.

### Deliberate mirror asymmetry

The 16-way `docs/` enumeration and `.github/` are in README but **not** CLAUDE.md. Both are pure lookup material — grep-derivable, no bearing on an agent's next decision — so `.claude/rules/context-budget.md` § Classifier routes them to the on-demand tier. Recording it here so the delta does not read as drift to the next reader. Root-level docs files and config dotfiles are likewise omitted from the README tree, stated inline beneath it.

## Test plan

Docs-only: the diff touches `README.md` and `CLAUDE.md` and nothing else, so no build output can change. The pre-commit gate reached the same conclusion via `scripts/precommit-gate-classify.sh` and skipped SwiftLint + `xcodebuild build` on every commit; the full suite was not run.

Completeness is the load-bearing claim here, so it was asserted mechanically rather than eyeballed — both enumerations re-derived from `git ls-files` and diffed against what README lists, over directories *as well as* files:

```
root:  every tracked root entry listed, except the 4 root docs files and
       3 config dotfiles named inline (gradlew.bat covered by the gradlew* glob)
docs/: 16 of 16 subdirectories, no phantoms
```

The first version of that check only iterated root *files* and skipped the docs by name, so it could not fail — `.claude/` and `gradle/` slipped through and were caught at review (`08f17157` fixes both the doc and the check).

Every factual claim added to CLAUDE.md was verified against its source rather than asserted from context: the `DemoPresets/` flattening + `PresetLoader.presetFileNames` exclusion, the harness's root-`Package.swift` build path, ADR-023 §6/§12 stage semantics, and which CI lane builds the gate spike versus runs its bash guards. That last one caught a wrong first draft — `ci.yml` does run `tools/kmp-gate-spike/scripts/` guards per-PR, so "nightly only" was too strong; the line now states the actual invariant (no per-PR lane takes an XCFramework dep).

## Device QA

実機QA不要 — documentation-only change with no runtime surface.

Closes #1186
