### PR TITLE
📝 docs: reconcile the guard-scope sentence from claude-kit

### DIFF
--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -113,6 +113,6 @@ A 30-second self-check prevents 1–2 extra critic / code-reviewer rounds. Motiv
 A **why-comment you write** asserts runtime or library behaviour as the reason a mechanism exists — the same kind of claim as the table's, but authored at implementation time and executed by nobody. Reviewers check whether the *code* is correct, not whether the *stated reason* is true, so a false one ships and the next reader inherits it as fact. Two shapes, neither expressible as a `Verify by` lookup:
 
 - **Why-comment on a mechanism** → delete the mechanism and run the tests. Green means the claim is false, or the tests never covered it.
-- **A detector / guard / gate** → construct the thing it claims to catch and confirm it fires. A guard's success case proves nothing; only a negative control does.
+- **A detector / guard / gate** → construct the thing it claims to catch and confirm it fires. A guard's success case proves nothing; only a negative control does. Scope it to the claim it defends: a check narrower than that claim (a files-only loop behind a files-and-directories completeness claim), or one that silently skips its exemptions instead of declaring them, passes by construction.
 
 Motivating incident: PR #1152 round-1 review.


### PR DESCRIPTION
## Summary

One-way mirror reconcile (kit → Pastura). Appends one sentence to the detector/guard bullet in `.claude/rules/knowledge-layering.md` § "Claims you author are assertions too":

> Scope it to the claim it defends: a check narrower than that claim (a files-only loop behind a files-and-directories completeness claim), or one that silently skips its exemptions instead of declaring them, passes by construction.

The bullet already said a guard's success case proves nothing and to build a negative control. What it did not say is that the control has to cover the same ground as the claim it defends.

### Motivating incident

In #1187, README asserted it listed every tracked root entry except three named config dotfiles. The verification script written to defend that claim iterated root *files* only — never directories — and skipped the awkward entries (`README.md`, `LICENSE`, …) by name instead of declaring them as carve-outs. It printed PASS. Two tracked directories (`.claude/`, `gradle/`) were genuinely missing from the README; a `code-reviewer` subagent caught it by re-deriving the set independently. Two failure shapes, neither previously covered: the check's domain was narrower than the claim's, and its exemptions were silently skipped rather than declared.

### ⚠️ Merge ordering — read before merging

**This PR must not merge before [claude-kit#7](https://github.com/tyabu12/claude-kit/pull/7).** That PR is the canonical source; this file's header declares kit canonical and reconcile one-way. The sentence here was verified byte-identical against kit branch `rules/guard-scope-matches-claim` @ `6bcb4e9`, which is *not* yet an ancestor of kit `main`. If kit#7 is reworded in review and this lands first, Pastura becomes the source of text that never became canonical — inverting the one-way invariant.

Before merging: land kit#7, then re-diff against `git show origin/main:rules/knowledge-layering.md` in the kit repo.

### Declared scope boundary

Only the guard-scope sentence is reconciled. The section carries two further kit/Pastura deltas, both pre-existing and both out of scope here:

- **Pastura has, kit lacks** — the trailing `Motivating incident: PR #1152 round-1 review.` pointer. Principled: § Procedure step 2 requires stripping consumer-specific provenance from kit-bound content.
- **Kit has, Pastura lacks** — kit's closing "when a check is too expensive to run" paragraph. Deliberately left *unlabelled*: kit's history is a single squashed initial commit, so it cannot be shown to be an intentional omission rather than an unreconciled gap. Calling it intentional would make the periodic-triage pass (§ Promotion & retirement, trigger 1 — which diffs kit rules against consumer copies as a missed-mirror backstop) skip it permanently.

Declaring this rather than silently skipping it, since the PR would otherwise reproduce the exact failure the new sentence warns about.

## Test plan

Docs-only, one line in an always-loaded rules file; no build output can change, and the pre-commit gate skipped SwiftLint + `xcodebuild build` accordingly.

The load-bearing claim is byte-identity with upstream, so it was asserted mechanically — whitespace-normalized `cmp` against `6bcb4e9`, **plus a negative control** confirming the comparison actually fails when the text is perturbed (`narrower` → `wider`). A check that cannot fail is precisely what this PR's sentence is about; running it without the control would have been self-refuting.

Wrap style was checked against the local section (one line per bullet, unwrapped) rather than kit's ~95-column form.

## Device QA

実機QA不要 — documentation-only change with no runtime surface.

Closes #1188
