### PR TITLE
📝 docs: memory→rules promotion Round 8 (ci-workflows + i18n)

### DIFF
--- a/.claude/rules/ci-workflows.md
+++ b/.claude/rules/ci-workflows.md
@@ -6,7 +6,11 @@ paths:
 
 # CI Workflows (GHA, macOS runners)
 
-Seven concern families when editing CI workflow YAML or supporting scripts on this repo: shell-language gotchas on the macOS runner, long-lived integration-branch gating shape, required-check-safe path gating, step-level `if:` semantics, the script unit-test suite that runs in CI only, rename/namespace-sweep completion gates, and gate scripts' annotation paths and tracked-only scope.
+Nine concern families when editing CI workflow YAML or supporting scripts on this repo: the CI wall-clock budget per PR, shell-language gotchas on the macOS runner, long-lived integration-branch gating shape, required-check-safe path gating, step-level `if:` semantics, the script unit-test suite that runs in CI only, rename/namespace-sweep completion gates, grep's line-boundedness in call-shape guards, and gate scripts' annotation paths and tracked-only scope.
+
+## CI wall-clock budget per PR
+
+Target **≤10 min**, up to ~12 min acceptable, **20 min is a blocker** — at 20 min the feedback loop on UI-test-affected PRs is unusable. When adding CI steps (new test targets, matrix builds, coverage passes), estimate wall-clock impact **before** proposing; if a change pushes above ~12 min, surface the trade-off explicitly (drop a redundant test, build-sharing, move to a nightly schedule) rather than shipping a slow suite and fixing later. UI tests especially run several times slower on CI simulators than locally — budget them aggressively.
 
 ## Shell scripting gotchas (macOS GHA runners)
 
@@ -186,6 +190,23 @@ git grep -nF 'com\.tyabu12'          # backslash-escaped on-disk literal
 `git grep` is tracked-only (fast, never descends into ignored/huge files) and
 repo-wide by default. Pairs with the "grep ALL instances before scoping"
 discipline.
+
+## `grep` is line-bound — call-shape CI guards miss multi-line calls
+
+A CI guard matching a Swift call *shape* (`grep -E 'foo\([^)]*\bbar\b'`) silently
+passes when SwiftFormatter splits the call across lines — the two tokens land on
+different lines, so the pattern never matches and a regression sails through.
+`rg -U` multiline mode works but ripgrep is **not** pre-installed on
+`ubuntu-latest` (adds an `apt-get install ripgrep` step). Portable fix: match the
+bare token anywhere, then post-filter comment lines (`grep -vE ':[[:space:]]*//'`),
+plus a per-file allow-list (`--exclude=`) for legitimate authoring sites.
+**Self-test before commit**: inject a regression in the *multi-line* shape
+SwiftFormatter would produce and confirm the script exits 1 — a single-line
+self-test passes a guard that misses the real wrapped form. Reference:
+`scripts/check_engine_language_axis.sh`. The same line-bound blindness hits prose
+sweeps (a markdown link wrapped across two lines is invisible to a one-line
+pattern) — grep the shortest stable token (a bare filename), not a phrase. Sibling
+grep-completeness trap: § "Rename / namespace-sweep completion gate".
 
 ## Gate scripts: `::error file=` is repo-relative, and scope must be tracked-only
 

--- a/.claude/rules/i18n.md
+++ b/.claude/rules/i18n.md
@@ -343,3 +343,13 @@ For i18n Tier 2 audit candidates whose target is `.accessibilityLabel(...)`, run
 Apply during initial plan drafting, not at critic time — saves a Critical-verdict re-revision cycle.
 
 Canonical case study: `Pastura/Pastura/Views/Components/SheepAvatar.swift` `Character.accessibilityLabel` returned color-slot canonical names ("Alice"/"Bob"/"Carol"/"Dave"), not agent display names. Wrapping with ja would have committed those as translatable personal names and amplified the VoiceOver dissonance for ja-locale users. Fix: `.accessibilityHidden(true)` (avatar is decorative; adjacent `Text(agent)` carries identity).
+
+## Audit planning — three checks before drafting a Tier 2 wrap PR
+
+Run these against a Tier 2 candidate list (`scripts/check_i18n_potential_keys.py`) **before** planning catalog edits — each is otherwise a late Critical the pre-impl critic catches only at review time.
+
+1. **Existing key ⇒ zero new catalog entries.** The audit groups by `(file, line, key)` and flags every wrap-site; xcstringstool dedupes by the literal string alone. Wrapping a literal that already exists in `Localizable.xcstrings` (from a prior wrap elsewhere) creates **no** new key — grep the catalog for the exact string first and drop it from the plan's "new keys" count. Don't pre-plan a `ja` translation; the existing one is reused.
+
+2. **Does the wrap canonicalize a structural bug?** A `String(format:)` literal may hardcode an assumption that should be data-derived (a model size, a count, a unit suffix, a vendor name). Wrapping verbatim freezes that bug into the catalog as the translator source-of-truth, so the later fix costs a Swift edit **plus** a catalog rename **plus** every `ja` update. Scan the literal; if it hardcodes such a value, either parameterize it in the same PR (preferred) or skip the wrap and file a follow-up bundling the wrap with the structural fix.
+
+3. **Intentional deferral needs a documented home.** The audit is stateless — it re-flags the same candidate every run. When a candidate is deliberately left un-wrapped pending a gating event (design-pending copy, deferred multi-model fix), an inline `// TODO` is invisible to the next audit session. Register the deferral as a row in `docs/i18n/leak-detection.md` § "Explicitly-deferred or permanent carve-outs" (source location, gating event, expected resolution), and point the inline comment at that section.


### PR DESCRIPTION
## Summary

Round 8 of the memory→`.claude/rules/` promotion backlog (#780). Promotes 5 per-user memory entries into two **path-scoped** rules files as concept-register additions (durable file/symbol/ADR anchors only — no bare `(#N)` in new prose).

**`.claude/rules/ci-workflows.md`** (+2 concern families)
- **CI wall-clock budget per PR** — target ≤10 min / ~12 min acceptable / 20 min is a blocker; estimate wall-clock before adding CI steps.
- **`grep` is line-bound** — call-shape CI guards miss SwiftFormatter multi-line splits; portable fix = bare-token match + comment-filter + `--exclude` allow-list, self-tested with a multi-line injection. (`rg -U` works but ripgrep isn't pre-installed on `ubuntu-latest`.)
- Intro updated "Seven → Nine concern families" with both new sections in section order.

**`.claude/rules/i18n.md`** (+1 section)
- **Audit planning — three checks before a Tier 2 wrap PR**: existing-key dedup (zero new catalog entries), wrap-canonicalizes-a-structural-bug guard, and registering an intentional deferral in `leak-detection.md`.

## Review trail
- **Pre-impl critic** (Opus): no Critical; 3 Warnings reconciled — softened the unsourced "5–8×" multiplier to qualitative; moved the grep rule out from under the "(macOS GHA runners)" header into its own top-level section beside the `git grep` completion-gate section; **verified** the "rg not on ubuntu-latest" claim against the `actions/runner-images` Ubuntu software inventory (the critic guessed it false — the authoritative inventory confirms it true).
- **code-reviewer** (Opus): **PASS**, 0 Critical / 0 Warning. All cited paths/headings re-verified against main; intro "Nine" count internally consistent.

## Self-check (assertions verified against main)
- `docs/i18n/leak-detection.md` § "Explicitly-deferred or permanent carve-outs" (L124) ✓
- `scripts/check_i18n_potential_keys.py`, `scripts/check_engine_language_axis.sh` ✓
- ripgrep absent from `actions/runner-images` Ubuntu 24.04 inventory ✓

## Test plan
Docs-only, path-scoped rules files. No code paths touched; pre-commit correctly skipped SwiftLint + xcodebuild build (build-irrelevant changeset).

## Device QA
実機QA不要 — docs-only (`.claude/rules/*.md`), no runtime surface.

Part of #780 (deferred backlog continues: `heredoc_escape_leak` + CLAUDE.md always-loaded cluster, SwiftLint directive traps → swiftui-traps.md, orchestrate-skill cluster).