### PR TITLE
🧹 chore: port score_calc scoring to shared/engine commonMain

### DIFF
--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/ScoringLogic/EventReactivePayoffLogic.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/ScoringLogic/EventReactivePayoffLogic.kt
@@ -1,0 +1,66 @@
+package com.pastura.engine
+
+import com.pastura.models.SimulationEvent
+import com.pastura.models.SimulationState
+
+/**
+ * Event-reactive payoff scoring logic (#931).
+ *
+ * Rewards every agent whose most recent `choose` action matched the favored
+ * action for this round's injected event. The favored action is read from
+ * `state.variables[favoredVariable]`, written by `EventInjectHandler` for
+ * dict-shaped events.
+ *
+ * A flat `+3` for a correct read is enough to prove the mechanic; scarcity/curve
+ * bonuses and wrong-read penalties are out of scope for v1.
+ *
+ * Swift original:
+ * `Pastura/Pastura/Engine/ScoringLogic/EventReactivePayoffLogic.swift`.
+ */
+internal class EventReactivePayoffLogic {
+
+    fun calculate(
+        state: SimulationState,
+        favoredVariable: String,
+        emitter: (SimulationEvent) -> Unit,
+    ): SimulationState {
+        // No favored action for this round (plain-string event list, a
+        // probability miss, or an untagged dict entry) → inert no-op. The
+        // empty-string check also covers the ghosting-prevention "" that
+        // EventInjectHandler writes on a miss round.
+        val favored = state.variables[favoredVariable]
+        if (favored.isNullOrEmpty()) {
+            emitter(SimulationEvent.ScoreUpdate(scores = state.scores))
+            return state
+        }
+        val normalizedFavored = normalize(favored)
+
+        // `state.scores[name] != null` gates out non-agent outputs; scores are
+        // seeded for every agent at `SimulationState.initial`, so a live agent
+        // is always present.
+        val scores = state.scores.toMutableMap()
+        for ((name, output) in state.lastOutputs) {
+            if (state.scores[name] == null) continue
+            val action = output.action ?: continue
+            if (normalize(action) == normalizedFavored) {
+                scores[name] = (scores[name] ?: 0) + matchReward
+            }
+        }
+
+        emitter(SimulationEvent.ScoreUpdate(scores = scores))
+        return state.copy(scores = scores)
+    }
+
+    companion object {
+        /** Points awarded to each agent whose action matched the favored action. */
+        const val matchReward: Int = 3
+
+        /**
+         * Trim + case-fold for the action↔favored comparison. The individual
+         * (non-round-robin) `choose` path stores the LLM's raw `action` without
+         * canonicalization, so the model may emit `"Betray"` / `" betray"` for a
+         * `favors: betray` round; symmetric fold-both-sides never over-matches.
+         */
+        private fun normalize(value: String): String = value.trim().lowercase()
+    }
+}

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/ScoringLogic/PairwisePayoffLogic.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/ScoringLogic/PairwisePayoffLogic.kt
@@ -1,0 +1,45 @@
+package com.pastura.engine
+
+import com.pastura.models.PayoffRule
+import com.pastura.models.SimulationEvent
+import com.pastura.models.SimulationState
+
+/**
+ * Generic pairwise payoff scoring logic (ADR-027).
+ *
+ * Scores each `Pairing` by matching `(action1, action2)` positionally against a
+ * YAML-authored payoff table ([PayoffRule] list). The first row whose `when`
+ * equals the pairing's two actions awards `points[0]` to `agent1` and
+ * `points[1]` to `agent2`. A pairing matching no row scores nothing — the engine
+ * never fabricates a verdict (a `null` action, an off-table action pair, or an
+ * empty table all degrade to zero). Clears `state.pairings` after scoring,
+ * exactly as the legacy [PrisonersDilemmaLogic] shim does.
+ *
+ * Swift original:
+ * `Pastura/Pastura/Engine/ScoringLogic/PairwisePayoffLogic.swift`.
+ */
+internal class PairwisePayoffLogic {
+
+    fun calculate(
+        state: SimulationState,
+        payoff: List<PayoffRule>,
+        emitter: (SimulationEvent) -> Unit,
+    ): SimulationState {
+        val scores = state.scores.toMutableMap()
+        for (pairing in state.pairings) {
+            // A half-real pairing (either action null) matches no row and scores
+            // nothing — the correct degradation, not a fabricated verdict.
+            val act1 = pairing.action1 ?: continue
+            val act2 = pairing.action2 ?: continue
+            // No row for this action pair (or a malformed row that slipped past
+            // the loader's arity guard) → score nothing.
+            val row = payoff.firstOrNull { it.`when` == listOf(act1, act2) } ?: continue
+            if (row.points.size != 2) continue
+            scores[pairing.agent1] = (scores[pairing.agent1] ?: 0) + row.points[0]
+            scores[pairing.agent2] = (scores[pairing.agent2] ?: 0) + row.points[1]
+        }
+
+        emitter(SimulationEvent.ScoreUpdate(scores = scores))
+        return state.copy(scores = scores, pairings = emptyList())
+    }
+}

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/ScoringLogic/PrisonersDilemmaLogic.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/ScoringLogic/PrisonersDilemmaLogic.kt
@@ -1,0 +1,46 @@
+package com.pastura.engine
+
+import com.pastura.models.PayoffRule
+import com.pastura.models.SimulationEvent
+import com.pastura.models.SimulationState
+
+/**
+ * Prisoner's dilemma scoring logic — a **legacy shim** over [PairwisePayoffLogic]
+ * (ADR-027).
+ *
+ * Kept indefinitely, NOT because prisoner's dilemma is special, but because a
+ * user's "Copy & Edit" clone on a shipped device may carry
+ * `logic: prisoners_dilemma` in its saved YAML; deleting the case would make
+ * that record unopenable. New scenarios should use `pairwise_payoff` with a YAML
+ * `payoff:` table.
+ *
+ * The shim hands [PairwisePayoffLogic] the fixed English payoff table below.
+ * That table is the game's rule set — it must **not** be trimmed: dropping the
+ * `[betray, betray] → [1, 1]` row would score mutual defection as 0 in shipped
+ * content (ADR-027).
+ *
+ * Swift original:
+ * `Pastura/Pastura/Engine/ScoringLogic/PrisonersDilemmaLogic.swift`.
+ */
+internal class PrisonersDilemmaLogic {
+
+    fun calculate(
+        state: SimulationState,
+        emitter: (SimulationEvent) -> Unit,
+    ): SimulationState = PairwisePayoffLogic().calculate(state, legacyTable, emitter)
+
+    internal companion object {
+        /**
+         * The legacy prisoner's-dilemma payoff matrix. Exhaustive over
+         * `{cooperate, betray}²`, so for all shipped content every pairing
+         * matches a row — the shim is behaviourally identical to the
+         * pre-ADR-027 hardcoded `switch`.
+         */
+        val legacyTable: List<PayoffRule> = listOf(
+            PayoffRule(`when` = listOf("cooperate", "cooperate"), points = listOf(3, 3)),
+            PayoffRule(`when` = listOf("cooperate", "betray"), points = listOf(0, 5)),
+            PayoffRule(`when` = listOf("betray", "cooperate"), points = listOf(5, 0)),
+            PayoffRule(`when` = listOf("betray", "betray"), points = listOf(1, 1)),
+        )
+    }
+}

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/ScoringLogic/VoteTallyLogic.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/ScoringLogic/VoteTallyLogic.kt
@@ -1,0 +1,32 @@
+package com.pastura.engine
+
+import com.pastura.models.SimulationEvent
+import com.pastura.models.SimulationState
+
+/**
+ * Vote tally scoring logic.
+ *
+ * Adds each agent's vote count from `state.voteResults` to their cumulative
+ * score. Votes for names not already present in `state.scores` are ignored.
+ *
+ * Kotlin [SimulationState] is immutable, so unlike Swift's `inout` this returns
+ * the next state (see [SpeakAllHandler]).
+ *
+ * Swift original: `Pastura/Pastura/Engine/ScoringLogic/VoteTallyLogic.swift`.
+ */
+internal class VoteTallyLogic {
+
+    fun calculate(
+        state: SimulationState,
+        emitter: (SimulationEvent) -> Unit,
+    ): SimulationState {
+        val scores = state.scores.toMutableMap()
+        for ((name, count) in state.voteResults) {
+            if (state.scores[name] != null) {
+                scores[name] = (scores[name] ?: 0) + count
+            }
+        }
+        emitter(SimulationEvent.ScoreUpdate(scores = scores))
+        return state.copy(scores = scores)
+    }
+}

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/ScoringLogic/WordwolfJudgeLogic.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/ScoringLogic/WordwolfJudgeLogic.kt
@@ -1,0 +1,63 @@
+package com.pastura.engine
+
+import com.pastura.models.SimulationEvent
+import com.pastura.models.SimulationState
+
+/**
+ * Word wolf judge scoring logic.
+ *
+ * Checks if the most-voted agent matches `state.variables["wolf_name"]`. Emits a
+ * summary describing the result in the caller-supplied effective Engine language
+ * (the caller passes `scenario.engineLanguage`, ADR-010 D5 / D6 row 1). Does NOT
+ * mutate scores → returns `state` unchanged.
+ *
+ * **String formatting divergence from Swift (commonMain stdlib trap):** the
+ * Swift original uses `String(format: "…%@…%lld票…", name, count)`. Java-style
+ * `String.format` is not available in commonMain, so this reproduces the SAME
+ * output via Kotlin string interpolation (`%@`→`$name`, `%lld`→`$count`). The
+ * four templates and the empty-votes messages are byte-for-byte identical to the
+ * Swift literals.
+ *
+ * Swift original:
+ * `Pastura/Pastura/Engine/ScoringLogic/WordwolfJudgeLogic.swift`.
+ */
+internal class WordwolfJudgeLogic {
+
+    fun calculate(
+        state: SimulationState,
+        language: String,
+        emitter: (SimulationEvent) -> Unit,
+    ): SimulationState {
+        if (state.voteResults.isEmpty()) {
+            emitter(
+                SimulationEvent.Summary(
+                    text = pickLanguage(language, ja = "投票結果がありません", en = "No votes recorded"),
+                ),
+            )
+            return state
+        }
+
+        // Most-voted agent via the shared canonical tie-break (count desc, name
+        // desc) — a bare `max` left ties resolved by hash order, so a tied
+        // word-wolf game reported "wolf found" vs "wolf escaped" per launch (#1057).
+        val mostVoted = VoteTally.winner(state.voteResults)?.first ?: ""
+        val wolf = state.variables["wolf_name"] ?: "?"
+        val voteCount = state.voteResults[mostVoted] ?: 0
+
+        val text = if (mostVoted == wolf) {
+            pickLanguage(
+                language,
+                ja = "最多得票: $mostVoted (${voteCount}票) — 多数派の勝ち！ウルフを見破った！",
+                en = "Most votes: $mostVoted ($voteCount) — Majority wins! The wolf was found.",
+            )
+        } else {
+            pickLanguage(
+                language,
+                ja = "最多得票: $mostVoted (${voteCount}票) — ウルフの勝ち！逃げ切った！",
+                en = "Most votes: $mostVoted ($voteCount) — The wolf wins! Escaped detection.",
+            )
+        }
+        emitter(SimulationEvent.Summary(text = text))
+        return state
+    }
+}

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/VoteTally.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/VoteTally.kt
@@ -1,0 +1,31 @@
+package com.pastura.engine
+
+import com.pastura.models.RankingOrder
+
+/**
+ * Vote-tally helpers shared across the engine's most-voted-agent sites.
+ *
+ * Consolidates the canonical tie-break so a future change can't reintroduce the
+ * per-launch divergence #1056/#1057 fixed: `EliminateHandler`,
+ * [WordwolfJudgeLogic], and `ConditionEvaluator`'s `vote_winner` derivation all
+ * resolve a tie to the same agent.
+ *
+ * Swift original: `Pastura/Pastura/Engine/VoteTally.swift`. Ported for the
+ * ADR-023 Stage-3 PR-1 score_calc slice (#501).
+ */
+internal object VoteTally {
+    /**
+     * The winning agent by the canonical deterministic tie-break:
+     * (count desc, name desc). Returns `null` for empty input.
+     *
+     * Delegates to [RankingOrder] (Models) so the comparator has a single
+     * definition shared with the result card and viewer-prediction scoring
+     * (#1087). Returns the full `(key, value)` pair so a call site that needs
+     * the vote count can read `.second` without a second lookup.
+     */
+    fun winner(voteResults: Map<String, Int>): Pair<String, Int>? {
+        val key = RankingOrder.leader(voteResults, voteResults.keys.toList()) ?: return null
+        val value = voteResults[key] ?: return null
+        return key to value
+    }
+}

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScoringLogic/EventReactivePayoffLogicTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScoringLogic/EventReactivePayoffLogicTests.kt
@@ -1,0 +1,140 @@
+package com.pastura.engine
+
+import com.pastura.models.SimulationEvent
+import com.pastura.models.SimulationState
+import com.pastura.models.TurnOutput
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Kotlin sibling of Swift's `EventReactivePayoffLogicTests` (#931).
+ *
+ * The favored action is read from `state.variables[favoredVariable]`; these
+ * tests write it directly rather than routing through `EventInjectHandler`.
+ * (Swift's `customEventVariableScoresNothingUnderV1` case is a ScoreCalcHandler
+ * dispatch test — that handler is not part of this slice — so it is omitted.)
+ *
+ * Ported for the ADR-023 Stage-3 PR-1 score_calc slice (#501).
+ */
+class EventReactivePayoffLogicTests {
+
+    private val logic = EventReactivePayoffLogic()
+    private val favoredKey = "current_event__favors"
+    private val reward = EventReactivePayoffLogic.matchReward
+
+    private fun output(action: String) = TurnOutput(fields = mapOf("action" to action))
+
+    @Test
+    fun rewardsOnlyAgentsWhoMatchedFavoredAction() {
+        val state = SimulationState(
+            scores = mapOf("Alice" to 0, "Bob" to 0),
+            lastOutputs = mapOf("Alice" to output("betray"), "Bob" to output("cooperate")),
+            variables = mapOf(favoredKey to "betray"),
+        )
+        val next = logic.calculate(state, favoredKey) { }
+        assertEquals(reward, next.scores["Alice"])
+        assertEquals(0, next.scores["Bob"])
+    }
+
+    @Test
+    fun symmetricForCooperateFavored() {
+        val state = SimulationState(
+            scores = mapOf("Alice" to 0, "Bob" to 0),
+            lastOutputs = mapOf("Alice" to output("betray"), "Bob" to output("cooperate")),
+            variables = mapOf(favoredKey to "cooperate"),
+        )
+        val next = logic.calculate(state, favoredKey) { }
+        assertEquals(0, next.scores["Alice"])
+        assertEquals(reward, next.scores["Bob"])
+    }
+
+    @Test
+    fun rewardAddsToExistingScore() {
+        val state = SimulationState(
+            scores = mapOf("Alice" to 5),
+            lastOutputs = mapOf("Alice" to output("betray")),
+            variables = mapOf(favoredKey to "betray"),
+        )
+        val next = logic.calculate(state, favoredKey) { }
+        assertEquals(5 + reward, next.scores["Alice"])
+    }
+
+    @Test
+    fun missingFavoredVariableIsNoOp() {
+        // favoredKey absent → simulates a plain-string event list (no companion var).
+        val state = SimulationState(
+            scores = mapOf("Alice" to 0, "Bob" to 0),
+            lastOutputs = mapOf("Alice" to output("betray"), "Bob" to output("cooperate")),
+        )
+        val next = logic.calculate(state, favoredKey) { }
+        assertEquals(0, next.scores["Alice"])
+        assertEquals(0, next.scores["Bob"])
+    }
+
+    @Test
+    fun emptyFavoredVariableIsNoOp() {
+        // "" is what EventInjectHandler writes on a miss round — must not reward.
+        val state = SimulationState(
+            scores = mapOf("Alice" to 0),
+            lastOutputs = mapOf("Alice" to output("betray")),
+            variables = mapOf(favoredKey to ""),
+        )
+        val next = logic.calculate(state, favoredKey) { }
+        assertEquals(0, next.scores["Alice"])
+    }
+
+    @Test
+    fun alwaysEmitsScoreUpdate() {
+        // No favored var → inert, but a scoreUpdate must still be emitted.
+        val state = SimulationState(
+            scores = mapOf("Alice" to 0),
+            lastOutputs = mapOf("Alice" to output("betray")),
+        )
+        val events = mutableListOf<SimulationEvent>()
+        logic.calculate(state, favoredKey) { events += it }
+        assertEquals(1, events.filterIsInstance<SimulationEvent.ScoreUpdate>().size)
+    }
+
+    @Test
+    fun ignoresOutputsWithoutASeededScore() {
+        val state = SimulationState(
+            scores = mapOf("Alice" to 0),
+            // No score seeded for "Ghost" → gated out (not a live agent).
+            lastOutputs = mapOf("Alice" to output("betray"), "Ghost" to output("betray")),
+            variables = mapOf(favoredKey to "betray"),
+        )
+        val next = logic.calculate(state, favoredKey) { }
+        assertEquals(reward, next.scores["Alice"])
+        assertNull(next.scores["Ghost"])
+    }
+
+    @Test
+    fun rewardsCaseAndWhitespaceVariantActions() {
+        // Casing/whitespace variants must still count against a lowercase favors.
+        val state = SimulationState(
+            scores = mapOf("Alice" to 0, "Bob" to 0, "Carol" to 0),
+            lastOutputs = mapOf(
+                "Alice" to output("Betray"),
+                "Bob" to output(" betray "),
+                "Carol" to output("BETRAY"),
+            ),
+            variables = mapOf(favoredKey to "betray"),
+        )
+        val next = logic.calculate(state, favoredKey) { }
+        assertEquals(reward, next.scores["Alice"])
+        assertEquals(reward, next.scores["Bob"])
+        assertEquals(reward, next.scores["Carol"])
+    }
+
+    @Test
+    fun doesNotRewardNonMatchingActionAfterNormalization() {
+        val state = SimulationState(
+            scores = mapOf("Alice" to 0),
+            lastOutputs = mapOf("Alice" to output("Cooperate")),
+            variables = mapOf(favoredKey to "betray"),
+        )
+        val next = logic.calculate(state, favoredKey) { }
+        assertEquals(0, next.scores["Alice"])
+    }
+}

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScoringLogic/PairwisePayoffLogicTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScoringLogic/PairwisePayoffLogicTests.kt
@@ -1,0 +1,100 @@
+package com.pastura.engine
+
+import com.pastura.models.Pairing
+import com.pastura.models.PayoffRule
+import com.pastura.models.SimulationEvent
+import com.pastura.models.SimulationState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Kotlin sibling of Swift's `PairwisePayoffLogicTests`.
+ *
+ * Ported for the ADR-023 Stage-3 PR-1 score_calc slice (#501).
+ */
+class PairwisePayoffLogicTests {
+
+    private val logic = PairwisePayoffLogic()
+
+    /**
+     * A localized (Japanese-token) payoff table — the motivating case for
+     * ADR-027, unscorable by the pre-ADR hardcoded English matrix.
+     */
+    private val jaTable: List<PayoffRule> = listOf(
+        PayoffRule(`when` = listOf("協力", "協力"), points = listOf(3, 3)),
+        PayoffRule(`when` = listOf("協力", "裏切り"), points = listOf(0, 5)),
+        PayoffRule(`when` = listOf("裏切り", "協力"), points = listOf(5, 0)),
+        PayoffRule(`when` = listOf("裏切り", "裏切り"), points = listOf(1, 1)),
+    )
+
+    private fun makeState() = SimulationState(scores = mapOf("A" to 0, "B" to 0))
+
+    private fun stateWith(action1: String?, action2: String?) = makeState().copy(
+        pairings = listOf(Pairing(agent1 = "A", agent2 = "B", action1 = action1, action2 = action2)),
+    )
+
+    @Test
+    fun matchesRowAndAwardsPointsPositionally() {
+        val next = logic.calculate(stateWith("協力", "裏切り"), jaTable) { }
+        assertEquals(0, next.scores["A"])
+        assertEquals(5, next.scores["B"])
+    }
+
+    @Test
+    fun unmatchedActionPairScoresNothing() {
+        // Neither action appears in any row's `when`.
+        val next = logic.calculate(stateWith("abstain", "abstain"), jaTable) { }
+        assertEquals(0, next.scores["A"])
+        assertEquals(0, next.scores["B"])
+    }
+
+    @Test
+    fun nilActionScoresNothing() {
+        // A half-real pairing (action2 null) matches no row — no fabricated verdict.
+        val next = logic.calculate(stateWith("協力", null), jaTable) { }
+        assertEquals(0, next.scores["A"])
+        assertEquals(0, next.scores["B"])
+    }
+
+    @Test
+    fun emptyTableScoresNothing() {
+        val next = logic.calculate(stateWith("協力", "協力"), emptyList()) { }
+        assertEquals(0, next.scores["A"])
+        assertEquals(0, next.scores["B"])
+    }
+
+    @Test
+    fun malformedRowArityIsSkippedDefensively() {
+        // A row whose `points` is not two elements must not crash (index guard) —
+        // it simply scores nothing.
+        val badTable = listOf(PayoffRule(`when` = listOf("x", "y"), points = listOf(7)))
+        val next = logic.calculate(stateWith("x", "y"), badTable) { }
+        assertEquals(0, next.scores["A"])
+        assertEquals(0, next.scores["B"])
+    }
+
+    @Test
+    fun firstMatchingRowWins() {
+        val table = listOf(
+            PayoffRule(`when` = listOf("協力", "協力"), points = listOf(3, 3)),
+            PayoffRule(`when` = listOf("協力", "協力"), points = listOf(9, 9)),
+        )
+        val next = logic.calculate(stateWith("協力", "協力"), table) { }
+        assertEquals(3, next.scores["A"])
+        assertEquals(3, next.scores["B"])
+    }
+
+    @Test
+    fun clearsStatePairingsAfterCalc() {
+        val next = logic.calculate(stateWith("協力", "協力"), jaTable) { }
+        assertTrue(next.pairings.isEmpty())
+    }
+
+    @Test
+    fun emitsScoreUpdateEvent() {
+        val events = mutableListOf<SimulationEvent>()
+        logic.calculate(stateWith("協力", "協力"), jaTable) { events += it }
+        assertEquals(1, events.filterIsInstance<SimulationEvent.ScoreUpdate>().size)
+    }
+}

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScoringLogic/PrisonersDilemmaLogicTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScoringLogic/PrisonersDilemmaLogicTests.kt
@@ -1,0 +1,65 @@
+package com.pastura.engine
+
+import com.pastura.models.Pairing
+import com.pastura.models.SimulationEvent
+import com.pastura.models.SimulationState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Kotlin sibling of Swift's `PrisonersDilemmaLogicTests`.
+ *
+ * Ported for the ADR-023 Stage-3 PR-1 score_calc slice (#501).
+ */
+class PrisonersDilemmaLogicTests {
+
+    private val logic = PrisonersDilemmaLogic()
+
+    private fun makeState() = SimulationState(scores = mapOf("A" to 0, "B" to 0))
+
+    private fun stateWith(action1: String, action2: String) = makeState().copy(
+        pairings = listOf(Pairing(agent1 = "A", agent2 = "B", action1 = action1, action2 = action2)),
+    )
+
+    @Test
+    fun cooperateCooperate() {
+        val next = logic.calculate(stateWith("cooperate", "cooperate")) { }
+        assertEquals(3, next.scores["A"])
+        assertEquals(3, next.scores["B"])
+    }
+
+    @Test
+    fun cooperateBetray() {
+        val next = logic.calculate(stateWith("cooperate", "betray")) { }
+        assertEquals(0, next.scores["A"])
+        assertEquals(5, next.scores["B"])
+    }
+
+    @Test
+    fun betrayCooperate() {
+        val next = logic.calculate(stateWith("betray", "cooperate")) { }
+        assertEquals(5, next.scores["A"])
+        assertEquals(0, next.scores["B"])
+    }
+
+    @Test
+    fun betrayBetray() {
+        val next = logic.calculate(stateWith("betray", "betray")) { }
+        assertEquals(1, next.scores["A"])
+        assertEquals(1, next.scores["B"])
+    }
+
+    @Test
+    fun clearsStatePairingsAfterCalc() {
+        val next = logic.calculate(stateWith("cooperate", "cooperate")) { }
+        assertTrue(next.pairings.isEmpty())
+    }
+
+    @Test
+    fun emitsScoreUpdateEvent() {
+        val events = mutableListOf<SimulationEvent>()
+        logic.calculate(stateWith("cooperate", "cooperate")) { events += it }
+        assertEquals(1, events.filterIsInstance<SimulationEvent.ScoreUpdate>().size)
+    }
+}

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScoringLogic/VoteTallyLogicTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScoringLogic/VoteTallyLogicTests.kt
@@ -1,0 +1,53 @@
+package com.pastura.engine
+
+import com.pastura.models.SimulationEvent
+import com.pastura.models.SimulationState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Kotlin sibling of Swift's `VoteTallyLogicTests`.
+ *
+ * Ported for the ADR-023 Stage-3 PR-1 score_calc slice (#501).
+ */
+class VoteTallyLogicTests {
+
+    private val logic = VoteTallyLogic()
+
+    @Test
+    fun talliesVotesIntoScores() {
+        val state = SimulationState(
+            scores = mapOf("A" to 5, "B" to 3),
+            voteResults = mapOf("A" to 2, "B" to 1),
+        )
+        val events = mutableListOf<SimulationEvent>()
+        val next = logic.calculate(state) { events += it }
+        assertEquals(7, next.scores["A"])
+        assertEquals(4, next.scores["B"])
+        assertEquals(1, events.filterIsInstance<SimulationEvent.ScoreUpdate>().size)
+    }
+
+    @Test
+    fun handlesZeroVotes() {
+        val state = SimulationState(
+            scores = mapOf("A" to 5, "B" to 3),
+            voteResults = mapOf("A" to 0, "B" to 0),
+        )
+        val next = logic.calculate(state) { }
+        assertEquals(5, next.scores["A"])
+        assertEquals(3, next.scores["B"])
+    }
+
+    @Test
+    fun ignoresVotesForUnknownAgents() {
+        val state = SimulationState(
+            scores = mapOf("A" to 5),
+            voteResults = mapOf("Unknown" to 3),
+        )
+        val next = logic.calculate(state) { }
+        assertEquals(5, next.scores["A"])
+        // Unknown must not be added to scores.
+        assertNull(next.scores["Unknown"])
+    }
+}

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScoringLogic/WordwolfJudgeLogicTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScoringLogic/WordwolfJudgeLogicTests.kt
@@ -1,0 +1,103 @@
+package com.pastura.engine
+
+import com.pastura.models.SimulationEvent
+import com.pastura.models.SimulationState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Kotlin sibling of Swift's `WordwolfJudgeLogicTests`.
+ *
+ * Includes rendered-string-equality assertions (ja + en) that pin the Swift
+ * `String(format:)` → Kotlin interpolation parity.
+ *
+ * Ported for the ADR-023 Stage-3 PR-1 score_calc slice (#501).
+ */
+class WordwolfJudgeLogicTests {
+
+    private val logic = WordwolfJudgeLogic()
+
+    private fun summaries(
+        state: SimulationState,
+        language: String,
+    ): List<String> {
+        val events = mutableListOf<SimulationEvent>()
+        logic.calculate(state, language) { events += it }
+        return events.filterIsInstance<SimulationEvent.Summary>().map { it.text }
+    }
+
+    @Test
+    fun majorityWinsWhenWolfMostVoted() {
+        val state = SimulationState(
+            voteResults = mapOf("Wolf" to 3, "Other" to 1),
+            variables = mapOf("wolf_name" to "Wolf"),
+        )
+        val out = summaries(state, "ja")
+        assertEquals(1, out.size)
+        // Rendered-string parity (ja, wolf found).
+        assertEquals("最多得票: Wolf (3票) — 多数派の勝ち！ウルフを見破った！", out[0])
+    }
+
+    @Test
+    fun wolfWinsWhenNotDetected() {
+        val state = SimulationState(
+            voteResults = mapOf("Innocent" to 3, "Wolf" to 1),
+            variables = mapOf("wolf_name" to "Wolf"),
+        )
+        assertTrue(summaries(state, "ja")[0].contains("ウルフの勝ち"))
+    }
+
+    @Test
+    fun tieResolvesToStableWinner() {
+        // Canonical tie-break (count desc, name desc) → Bob wins; Bob != wolf
+        // (Alice) → wolf escapes deterministically on every call.
+        fun run(): String {
+            val state = SimulationState(
+                voteResults = mapOf("Alice" to 2, "Bob" to 2),
+                variables = mapOf("wolf_name" to "Alice"),
+            )
+            return summaries(state, "ja").firstOrNull() ?: ""
+        }
+        val first = run()
+        assertTrue(first.contains("Bob"))
+        assertTrue(first.contains("ウルフの勝ち"))
+        assertFalse(first.contains("Alice"))
+        assertEquals(first, run())
+        assertEquals(first, run())
+    }
+
+    @Test
+    fun handlesEmptyVoteResults() {
+        // Both empty-votes literals pinned (rendered-string parity), symmetric
+        // with the win/lose templates below.
+        assertEquals("投票結果がありません", summaries(SimulationState(), "ja")[0])
+        assertEquals("No votes recorded", summaries(SimulationState(), "en")[0])
+    }
+
+    @Test
+    fun majorityWinsInEnglish() {
+        val state = SimulationState(
+            voteResults = mapOf("Wolf" to 3, "Other" to 1),
+            variables = mapOf("wolf_name" to "Wolf"),
+        )
+        val out = summaries(state, "en")
+        assertEquals(1, out.size)
+        // Rendered-string parity (en, wolf found).
+        assertEquals("Most votes: Wolf (3) — Majority wins! The wolf was found.", out[0])
+        assertFalse(out[0].contains("多数派の勝ち"))
+    }
+
+    @Test
+    fun wolfWinsInEnglish() {
+        val state = SimulationState(
+            voteResults = mapOf("Innocent" to 3, "Wolf" to 1),
+            variables = mapOf("wolf_name" to "Wolf"),
+        )
+        val out = summaries(state, "en")
+        assertEquals(1, out.size)
+        assertEquals("Most votes: Innocent (3) — The wolf wins! Escaped detection.", out[0])
+        assertFalse(out[0].contains("ウルフの勝ち"))
+    }
+}


### PR DESCRIPTION
## Summary

ADR-023 Stage-3 **PR-1** — the first cold slice of the Engine bulk port to KMP `commonMain`. Split plan: #501 ([comment](https://github.com/tyabu12/pastura/issues/501#issuecomment-5034504293)).

Ports the 5 `score_calc` scoring-logic types + their `VoteTally` dependency from Swift to `shared/engine/commonMain`, with commonTest behavioral-parity specs. **Kotlin-only — no Swift touched** (the Swift originals stay in place, parallel until a later stage).

- `VoteTally` + `{VoteTally,PrisonersDilemma,PairwisePayoff,EventReactivePayoff,WordwolfJudge}Logic` → `commonMain` (immutable-state `.copy(...)` return vs Swift `inout`, emitter callback — per the `SpeakAllHandler.kt` precedent).
- **`VoteTally` is pulled into PR-1** (not the run-path-mechanisms slice): `WordwolfJudgeLogic` calls `VoteTally.winner`, so the module can't build in `commonMain` without it (dependency-inversion caught at plan critique). Its dep `RankingOrder.leader` is already in `shared/models`; not inlined (keeps the #1056/#1057 canonical tie-break consolidated).
- **WordwolfJudge string parity**: Swift `String(format: "…%@…%lld票…")` reproduced via Kotlin interpolation (`String.format` is absent from `commonMain`). A rendered-string-equality spec (ja + en, win/lose + empty-votes) pins the parity byte-for-byte.
- The enum→impl **dispatch** (`ScoreCalcHandler`) stays Swift (a Wave-B handler); the impls are exercised directly in commonTest.

## Test plan

- 32 commonTest behavioral specs (constructed state in → asserted `scores`/`pairings` + emitted-event transcript), verified green from the JUnit XML: `EventReactive` 9, `Pairwise` 8, `PrisonersDilemma` 6, `VoteTally` 3, `WordwolfJudge` 6.
- Gates run locally: `./gradlew :shared:engine:compileCommonMainKotlinMetadata` (commonMain stdlib trap), `:shared:engine:jvmTest`, `:shared:models:jvmTest` — all green.
- **Condition 2** (cross-language parity): the behavioral specs above are the executable spec; WordwolfJudge adds exact rendered-string equality.
- **Condition 4** (perturbation-red): 5 targeted perturbations each reddened only their named `commonTest` sibling(s), zero bystander; a comment-only negative control reddened nothing. Full record in #501.

## Device QA

実機QA不要 — pure Kotlin `shared/**` module, no iOS/simulator surface, no device-only code path.

Part of #501
Closes #1206
