### PR TITLE
📝 docs: memory→rules promotion Round 9 (swiftlint + resolver-naming + concept-register)

### DIFF
--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -348,6 +348,21 @@ recurse. Data-layer `SimulationRecord.currentPhaseIndex: Int` remains the
 top-level resume marker for now; distinguishing sub-phase turns in the
 persistence layer is tracked as a follow-up issue.
 
+### Consumer-scoped resolver naming
+
+When a `Scenario` (or shared-state) value is resolved differently by multiple
+consumers — Engine / Editor / Picker / UI shell each apply their own priority —
+name the consumer-bound resolver after **its consumer**: `engineLanguage`, not a
+generic `effectiveLanguage` / `resolved…`. A generic name invites a future
+"consolidation" to route other consumers' reads through it, silently bypassing
+their priority rules; the encoded name signals that other consumers keep their
+own resolvers. Pair the property with a doc-comment listing every consumer row +
+its resolver — a CI grep-guard defends *current* call sites, the name defends
+*future* additions.
+
+Reference: `Scenario.engineLanguage` (`Models/Scenario.swift`, with its consumer
+table); rationale + the four-consumer table in ADR-010 §D5–D6.
+
 ## JSON Response Parser
 
 Port directly from Python prototype `parse_json_response()`. Must handle:

--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -42,7 +42,7 @@ This procedure is for **PROMOTE**; retirement (DELETE / TRIM) is memory-direct a
 
 File a rolling tracking issue collecting candidate sections, then `/orchestrate` a PR that:
 
-1. Lands additions to `.claude/rules/` (or `CLAUDE.md` for project-wide rules).
+1. Lands additions to `.claude/rules/` (or `CLAUDE.md` for project-wide rules), drafted at **concept level** — WHY + the invariant + a durable pointer, not the exhaustive HOW (grep blocks, enumerations, step lists). This holds for **path-scoped** targets too, where `context-budget.md`'s always-loaded discipline stops; expand a section only when a reviewer shows the omitted detail is load-bearing for the rule to fire.
 2. Strips `Source memory: feedback_*` provenance lines from drafts before commit — repo-tracked files referring to per-user memory by name are dead links for other contributors.
 3. If the promoted content is mirrored elsewhere — the code-reviewer trap cheat sheet (`.claude/agents/code-reviewer.md`), a CLAUDE.md summary parenthetical — update every mirror in the same PR. Mirrors drift silently otherwise (e.g., swift-isolation gained Pattern 5 while two "4 traps" enumerations stayed behind).
 4. After PR merges, locally `command rm ~/.claude/projects/.../memory/<source>.md` — the PR can't enforce memory deletion (it's per-user / per-machine); track via the rolling issue checklist.

--- a/.claude/rules/swiftui-traps.md
+++ b/.claude/rules/swiftui-traps.md
@@ -165,6 +165,27 @@ if taken, pick a distinct name (rename the type too if it also clashes). Case
 study: #759 renamed a new `ScenarioSummary.swift` (Views) that collided with the
 Data-layer `ScenarioSummary` → `ScenarioSummaryStrip`.
 
+## SwiftLint directive placement around a `///` doc comment (lint trap, not SwiftUI)
+
+A `swiftlint:disable[:next] X` directive can't cleanly suppress a rule on a
+declaration that also carries a `///` doc comment — **both** placements fail:
+
+- **Between the doc comment and the declaration** (a `// swiftlint:disable:next X`
+  line separating `/// …` from the `func`): detaches the doc comment, firing
+  `orphaned_doc_comment`.
+- **Inside the `///` block** (`/// swiftlint:disable:next X`): a **no-op** under
+  `swiftlint --strict` — the comment-command parser recognizes `//`-form only, so
+  the warning upgrades to an error unsuppressed. It looks load-bearing but is
+  untested until the body later crosses the threshold.
+
+**Apply** — don't relocate the directive; remove the need for it:
+
+- `function_body_length` → **extract a helper** so each body stays under the
+  threshold. Ref: `BundledDemoReplaySource.loadOne` → `buildSourceOrSkip`.
+- `identifier_name` (short domain identifiers like `ja` / `en`) → add a
+  **`.swiftlint.yml` `identifier_name.excluded`** entry (ref: the `ja` / `en`
+  exclusions consumed by `pickLanguage(_:ja:en:)`), or rename to 3+ chars.
+
 ## iOS 26 `.confirmationDialog` renders as a mis-anchored popover
 
 On iOS 26 a SwiftUI `.confirmationDialog` **anchored to a specific control** — a


### PR DESCRIPTION
## Summary

Round 9 of the #780 memory→rules promotion backlog — a docs-only round promoting 4 per-user memories into 3 project rules files, all at concept-level (WHY + invariant + durable pointer).

- **`swiftui-traps.md`** — NEW "SwiftLint directive placement around a `///` doc comment (lint trap, not SwiftUI)" section, merging two same-class traps: (1) a `swiftlint:disable:next` line *between* a `///` doc comment and the declaration fires `orphaned_doc_comment`; (2) the directive *inside* the `///` block is a no-op under `--strict`. Fix = remove the need (helper extraction / `.swiftlint.yml` exclusion), not relocate the directive. Homed here because the trap fires in production Swift across Engine + App, which this glob covers (engine.md/testing.md would each miss half).
- **`engine.md`** — NEW "Consumer-scoped resolver naming" subsection: name a consumer-bound resolver after its consumer (`engineLanguage`, not generic `effectiveLanguage`); the name defends *future* additions, a CI grep-guard defends *current* state. Cites `Scenario.engineLanguage` + ADR-010 §D5–D6.
- **`knowledge-layering.md`** — Procedure step 1 now mandates concept-level drafting, extended to **path-scoped** targets (closes the gap `context-budget.md` leaves open by explicitly loosening the path-scoped budget). Always-loaded, so kept to one clause.

## Review trail

- Plan critic (Opus): all 6 axes OK, 0 Critical/Warning.
- code-reviewer (Opus): PASS, 0 Critical/Warning. Both reviews raised one non-blocking suggestion (a cross-pointer from `models-and-data.md`); deliberately not added — the Models-side risk is already backstopped by the `Scenario.engineLanguage` doc-comment consumer table + `scripts/check_engine_language_axis.sh`, so per the concept-register rule being promoted the detail is not load-bearing.
- All cited symbols / paths / ADR headings verified against current main.

## Test plan

Docs-only (`.claude/rules/**`). Pre-commit correctly skipped SwiftLint + xcodebuild build (build-irrelevant paths). No public-doc mirror affected (none of the three files map to README/CONTRIBUTING per the Reference Documents table).

## Device QA

実機QA不要 — documentation-only change, no simulator-excluded or Metal/llama.cpp surface touched.

Part of #780.