### PR TITLE
🐛 fix: unbreak KMP nightly — pass Phase's 5 new tail args at gate-spike sites

### DIFF
--- a/shared/models/src/commonMain/kotlin/com/pastura/models/Phase.kt
+++ b/shared/models/src/commonMain/kotlin/com/pastura/models/Phase.kt
@@ -120,9 +120,17 @@ public data class Phase(
     public val elsePhases: List<Phase>? = null,
     public val probability: Double? = null,
     public val eventVariable: String? = null,
-    // The five fields below are appended at the tail so existing positional
-    // constructor calls stay valid; Swift interleaves `maxSentences` among them
-    // but JSON parity is by key name, not position (ADR-023 PR0-a2).
+    // The five fields below are appended at the tail so existing *Kotlin*
+    // positional constructor calls stay valid; the hand-written Swift original
+    // (`Pastura/Pastura/Models/Phase.swift`) interleaves `maxSentences` among
+    // them but JSON parity is by key name, not position (ADR-023 PR0-a2).
+    // ⚠️ Tail-appending does NOT keep Swift consumers valid: the K/N-generated
+    // Swift memberwise init carries no default-arg values (kmp-interop.md
+    // Pattern 3 "Default args don't cross"), so every Swift `Phase(...)` site
+    // — today only the nightly-built gate-spike (`tools/kmp-gate-spike`, the
+    // sole K/N↔Swift consumer, ADR-023 §6) — must pass the new args explicitly.
+    // Adding a field here therefore requires updating those sites in the same
+    // change, or the KMP nightly (not per-PR CI) goes red (#1204).
     public val voteAgainst: Int? = null,
     public val actionDeltas: Map<String, Int>? = null,
     public val noRepeat: Boolean? = null,

--- a/tools/kmp-gate-spike/Sources/KMPGateSpike/RelayBenchmark.swift
+++ b/tools/kmp-gate-spike/Sources/KMPGateSpike/RelayBenchmark.swift
@@ -279,7 +279,8 @@ extension Scenario {
           type: PhaseType.speakAll, prompt: "Speak.", outputSchema: ["statement": "string"],
           options: nil, pairing: nil, logic: nil, template: nil, source: nil, target: nil,
           excludeSelf: nil, subRounds: nil, maxSentences: nil, condition: nil, thenPhases: nil,
-          elsePhases: nil, probability: nil, eventVariable: nil)
+          elsePhases: nil, probability: nil, eventVariable: nil,
+          voteAgainst: nil, actionDeltas: nil, noRepeat: nil, narrator: nil, payoff: nil)
       ],
       extraData: [:]
     )

--- a/tools/kmp-gate-spike/Tests/KMPGateSpikeTests/BoundaryContractTests.swift
+++ b/tools/kmp-gate-spike/Tests/KMPGateSpikeTests/BoundaryContractTests.swift
@@ -572,7 +572,8 @@ extension Scenario {
           type: PhaseType.speakAll, prompt: "Speak.", outputSchema: ["statement": "string"],
           options: nil, pairing: nil, logic: nil, template: nil, source: nil, target: nil,
           excludeSelf: nil, subRounds: nil, maxSentences: nil, condition: nil, thenPhases: nil,
-          elsePhases: nil, probability: nil, eventVariable: nil)
+          elsePhases: nil, probability: nil, eventVariable: nil,
+          voteAgainst: nil, actionDeltas: nil, noRepeat: nil, narrator: nil, payoff: nil)
       ],
       extraData: [:]
     )


### PR DESCRIPTION
## Summary
- The KMP nightly full-native workflow went red (#1204). Root cause: the Kotlin `Phase` data class gained 5 tail fields (`voteAgainst/actionDeltas/noRepeat/narrator/payoff`, all `= null`). Kotlin positional calls stay valid, but the **K/N-generated Swift memberwise init carries no default-arg values** (`kmp-interop.md` Pattern 3 "Default args don't cross"), so both gate-spike `Phase(...)` construction sites failed to compile.
- Pass the 5 new args as `nil` at **both** sites — `RelayBenchmark.swift` (Sources) and `BoundaryContractTests.swift` (Tests), in Kotlin declaration order. grep-confirmed these are the only two `Phase(...)` sites in the gate-spike.
- Correct the now-misleading `Phase.kt` comment ("existing positional constructor calls stay valid" → Kotlin-only) with an inline recurrence guard: appending a `Phase` field requires updating the Swift consumer sites in the same change, or the nightly re-reds.

## Why nightly-only
The gate-spike is the sole K/N↔Swift consumer and builds **nightly / `workflow_dispatch` only** — per-PR CI is compile-only for `shared/engine` and takes no XCFramework dep (ADR-023 §6, decision B′). So this Swift-consumer breakage surfaced only in the nightly backstop, exactly as designed.

## Test plan
- Local nightly-equivalent verification (worktree): `tools/kmp-gate-spike/scripts/stage-framework.sh` → `swift build --package-path tools/kmp-gate-spike` → `swift test --package-path tools/kmp-gate-spike --no-parallel` → **29 tests / 5 suites passed, green**.
- Compile-only change; no behavioral difference beyond restoring compilation.
- The KMP nightly's own `swift build` + `swift test` step is the post-merge confirmation.

## Device QA
Not needed — no iOS-app surface touched (`tools/kmp-gate-spike/**` is out of the app build; `shared/models/**` is not yet app-consumed).

Closes #1204.