### PR TITLE
🧹 chore: port run-path mechanisms to shared/engine commonMain (ADR-023 Stage 3 PR-2)

### DIFF
--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/EngineLogger.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/EngineLogger.kt
@@ -1,0 +1,73 @@
+package com.pastura.engine
+
+/**
+ * Severity level for [EngineLogger] diagnostics.
+ *
+ * Deliberately minimal — only the subset the Engine actually emits
+ * ([DEBUG] / [INFO] / [WARNING]) — so the platform logger maps it without
+ * carrying unused OSLog levels. The Swift OSLog adapter maps these to the
+ * matching `os.Logger` convenience calls (`warning` resolves to the `.error`
+ * OSLog type, unchanged from the pre-seam code).
+ *
+ * Swift original: `Pastura/Pastura/Engine/EngineLogger.swift`.
+ */
+internal enum class EngineLogLevel {
+    DEBUG,
+    INFO,
+    WARNING,
+}
+
+/**
+ * Whether a log message's content is shown or redacted in off-device
+ * (TestFlight / Release) captures.
+ *
+ * Mirrors OSLog's redaction contract at message granularity: [PRIVATE] content
+ * renders as `<private>` off-device, [PUBLIC] renders verbatim. The Engine
+ * classifies each call site; the Swift OSLog adapter applies it.
+ */
+internal enum class EngineLogPrivacy {
+    PUBLIC,
+    PRIVATE,
+}
+
+/**
+ * Minimal logging seam that lets Engine code emit diagnostics without importing
+ * OSLog directly.
+ *
+ * The concrete OSLog implementation (`OSLogEngineLogger`) stays in the Swift App
+ * layer and is deliberately NOT ported, keeping the Engine free of `import os`
+ * for the KMP migration (issue #501, Stage 0 / S0.2) — mirroring how the
+ * `LanguageDetector` protocol keeps `NaturalLanguage` out of the Engine while
+ * `NLLanguageDetector` lives in App/.
+ *
+ * The Engine builds the **fully-rendered message string** (preserving the exact
+ * wire format that `scripts/analyze-streaming-diag.sh` parses) and passes the
+ * OSLog `category` plus a privacy classification; the adapter maps `category` to
+ * an `os.Logger(subsystem:category:)` and applies level + privacy. Callers must
+ * NOT pre-redact — they pass the real content and let `privacy` govern
+ * off-device exposure.
+ */
+internal interface EngineLogger {
+    /**
+     * Emit one diagnostic line.
+     *
+     * @param level Severity (maps to the matching OSLog level).
+     * @param category OSLog category. Load-bearing — `"StreamingDiag"` is the
+     *   channel `scripts/analyze-streaming-diag.sh` captures via
+     *   `log stream --predicate '… AND category == "StreamingDiag"'`.
+     * @param message The fully-rendered message. Not pre-redacted; [privacy]
+     *   governs off-device exposure of the whole line.
+     * @param privacy Whether [message] is shown or redacted in Release captures.
+     */
+    fun log(level: EngineLogLevel, category: String, message: String, privacy: EngineLogPrivacy)
+}
+
+/**
+ * A no-op [EngineLogger] used as the injection default so Engine unit tests and
+ * non-App consumers (e.g. the ADR-013 headless harness, which reuses Engine but
+ * not App) construct handlers without wiring OSLog. Production injects
+ * `OSLogEngineLogger` at the View boundary — see `SimulationView`.
+ */
+internal class NoopEngineLogger : EngineLogger {
+    override fun log(level: EngineLogLevel, category: String, message: String, privacy: EngineLogPrivacy) {}
+}

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/EngineSchemaVersion.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/EngineSchemaVersion.kt
@@ -1,0 +1,121 @@
+package com.pastura.engine
+
+import com.pastura.models.PhaseType
+
+/**
+ * The engine's capability version — the single authoritative declaration of
+ * "what capabilities this build's engine can execute" (ADR-020 D1).
+ *
+ * This is the Kotlin realization of the ADR's `ENGINE_SCHEMA_VERSION`: the
+ * constant is exposed as [current]. It is a plain **monotonic integer**, not
+ * semver — the only comparison anyone performs is
+ * `appVersion >= scenarioRequirement`, so ordinal semantics are all that is
+ * needed.
+ *
+ * Engine is the correct home because bumping it is coupled to engine feature
+ * additions (a new phase handler under `Engine/Phases/`, a new `ScoreCalcLogic`
+ * under `Engine/ScoringLogic/`). The App layer reads the constant via
+ * [isCompatible] to drive the Browse-tab grey-out gate. No dependency-rule
+ * violation: the predicate reads only Models ([PhaseType]).
+ *
+ * ## Bump policy
+ *
+ * See ADR-020 §4 for the full bump policy. In short: **bump** when adding a new
+ * [PhaseType] case, a new value of any by-name-parsed enum (`ScoreCalcLogic` /
+ * `AssignTarget` / `PairingStrategy` / a new `conditional` `if:` token), a new
+ * required property, a new top-level scalar key, or any change to the semantics
+ * of an existing phase/property such that an old app produces a *different*
+ * simulation. **Do not** bump for a truly inert additive-optional string swept
+ * harmlessly into `extraData`.
+ *
+ * Swift original: `Pastura/Pastura/Engine/EngineSchemaVersion.swift`.
+ */
+internal object EngineSchemaVersion {
+    /**
+     * The current build's engine capability version. Baseline was `1` (set
+     * before the first App Store release, ADR-020 §5).
+     *
+     * `2` — `event_inject`'s `no_repeat` opt-in (#1006). An old app that ignores
+     * the key silently runs with-replacement, a *different* simulation than a
+     * no_repeat-honoring app, so §4's semantic-equivalence proviso is not met and
+     * the ⚠️ silent-wrong-run rule requires a bump. See ADR-020 §8.
+     *
+     * `3` — the `narrate` phase (#909), a new [PhaseType] case. §4's first bump
+     * trigger fires directly; the D2 phase gate already greys out a `narrate`
+     * scenario on an old app, and this bump is the belt-and-suspenders D3 side so
+     * a scenario may also declare `min_engine_version: 3`.
+     *
+     * `4` — `Persona.secret` (#914). `mapPersona` reads a fixed key set and
+     * silently drops unknown persona keys (persona-level keys are not swept into
+     * `extraData`, which is top-level-only), so an old app runs a secret-bearing
+     * scenario with every agent missing its hidden agenda — a *different*
+     * simulation, with no throw and no grey-out. D2's phase gate cannot see it
+     * (no new phase), so §4's ⚠️ silent-wrong-run rule requires the bump and D3 is
+     * the only gate that can fire. Same shape as `2` above.
+     *
+     * `5` — `ScoreCalcLogic.pairwise_payoff` (ADR-027), a new by-name-parsed
+     * `score_calc` logic. §4's second bump trigger fires directly. D2's phase gate
+     * does not fire (no new [PhaseType]), so D3 (`min_engine_version`) is the only
+     * proactive gate and D5's parse-throw is the backstop when a shared scenario
+     * omits the declaration. See ADR-027 § "Blast radius".
+     */
+    const val current: Int = 5
+
+    /**
+     * Whether a gallery scenario described by its index metadata can be executed
+     * by this build's engine (ADR-020 D2 + D3).
+     *
+     * Two gates, combined with AND (a scenario is compatible only if it passes
+     * **both**):
+     *
+     * - **D2 — capability-derived (automatic).** Every phase kind in [phases]
+     *   must be known to this build ([PhaseType.entries]). This is drift-proof on
+     *   the client side: the entries are the build's real capability set, not a
+     *   hand-maintained list. [phases] is expected to be the *fully-flattened*
+     *   phase-kind set including `conditional` branch sub-phases (D2a).
+     * - **D3 — declared escape hatch.** The scenario's [minEngineVersion] must not
+     *   exceed [current]. This covers breaking changes invisible to D2's
+     *   phase-name check (a new by-name-parsed enum value, a new required
+     *   property, or a semantics-only change on a byte-identical YAML).
+     *
+     * Both inputs are decoded **leniently** (absent → `null`). A `null` [phases]
+     * means "capability cannot be determined from the index" → D2 defers (treated
+     * as unconstrained), relying on D3 and the parse-throw backstop (D5). A `null`
+     * [minEngineVersion] means "unconstrained" (`0`).
+     *
+     * @param phases The scenario's flattened phase-kind raw values from the
+     *   gallery index (`GalleryScenario.phases`), or `null` when absent.
+     * @param minEngineVersion The scenario's declared minimum engine version
+     *   (`GalleryScenario.min_engine_version`), or `null` when absent.
+     * @return `true` when this build can execute the scenario.
+     */
+    fun isCompatible(phases: List<String>?, minEngineVersion: Int?): Boolean =
+        passesPhaseGate(phases) && passesVersionGate(minEngineVersion)
+
+    /**
+     * D2: every listed phase kind is known to this build. `null`/empty → pass
+     * (unconstrained — see [isCompatible]).
+     */
+    private fun passesPhaseGate(phases: List<String>?): Boolean {
+        phases ?: return true
+        val known = PhaseType.entries.map { it.serialName() }.toSet()
+        return phases.all { it in known }
+    }
+
+    /**
+     * D3: the declared requirement does not exceed the current version.
+     * `null` → `0` → pass.
+     */
+    private fun passesVersionGate(minEngineVersion: Int?): Boolean =
+        (minEngineVersion ?: 0) <= current
+
+    /**
+     * The wire raw value for this phase type.
+     *
+     * Read from the `@SerialName` descriptor, mirroring `PhaseDispatcher.kt`'s
+     * `serialName()` — a `PhaseType.entries[ordinal].name`-based derivation would
+     * silently diverge for any case whose `@SerialName` ≠ its Kotlin name.
+     */
+    private fun PhaseType.serialName(): String =
+        PhaseType.serializer().descriptor.getElementName(ordinal)
+}

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/TurnFailureGate.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/TurnFailureGate.kt
@@ -1,0 +1,105 @@
+package com.pastura.engine
+
+import com.pastura.models.PhaseType
+import com.pastura.models.SimulationError
+import com.pastura.models.SimulationEvent
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.incrementAndFetch
+
+/**
+ * Run-scoped containment gate for LLM turn failures (ADR-021 D1–D4).
+ *
+ * LLM phase handlers route each agent turn's `LLMCaller.call` through [attempt].
+ * A transiently-failed turn is contained as a *skip* — the handler omits that
+ * agent's contribution and continues (degrade by omission, ADR-021 D2) — while
+ * systemic errors, cancellation, and the D4 circuit breaker propagate and abort
+ * the run through the existing catch-all in `SimulationRunner.executePhases`.
+ *
+ * One instance is created per run by the runner and shared by every
+ * `PhaseContext`. Handlers that dispatch nested sub-phases (`ConditionalHandler`)
+ * must thread the parent context's gate into the sub-phase contexts — a fresh
+ * gate inside a branch would silently reset the consecutive-skip counter. The
+ * reference semantics plus the [AtomicInt] are what make the counter run-scoped;
+ * `PhaseContext` itself is a value type rebuilt per phase. The counter is
+ * deliberately NOT part of `SimulationState`: a resumed run starts at 0.
+ *
+ * Swift original: `Pastura/Pastura/Engine/TurnFailureGate.swift`.
+ */
+@OptIn(ExperimentalAtomicApi::class)
+internal class TurnFailureGate {
+
+    companion object {
+        /**
+         * Consecutive skipped turns that trip the D4 circuit breaker. A UX bound
+         * — each skip already costs up to a full retry budget of inference
+         * latency, so a systemically-dead backend must not grind through the rest
+         * of the scenario — not a per-model tuning contract.
+         */
+        const val consecutiveSkipLimit = 3
+    }
+
+    // Atomic mirrors the fidelity argument of `SimulationEngine.kt`'s PauseGate:
+    // Swift guards this counter with a `Mutex`, so the port keeps the mutation
+    // atomic rather than degrading it to a bare `Int`.
+    private val consecutiveSkips = AtomicInt(0)
+
+    /**
+     * Runs one turn's LLM work with ADR-021 failure containment.
+     *
+     * @return The work's value on success (any success resets the
+     *   consecutive-skip counter, D4), or `null` when the turn was skipped — the
+     *   gate has already emitted [SimulationEvent.TurnSkipped] and the handler
+     *   should move on to the next agent/pair, writing nothing for this turn.
+     * @throws SimulationException The original error, wrapped, for systemic
+     *   failures, plus [SimulationError.TurnFailureLimitReached] when this failure
+     *   would be the [consecutiveSkipLimit]-th consecutive skip (no
+     *   [SimulationEvent.TurnSkipped] is emitted for the tripping failure).
+     *   `CancellationException` and any non-degradable throw propagate untouched.
+     */
+    suspend fun <T> attempt(
+        agent: String,
+        phaseType: PhaseType,
+        emitter: (SimulationEvent) -> Unit,
+        work: suspend () -> T,
+    ): T? {
+        return try {
+            val value = work()
+            consecutiveSkips.store(0)
+            value
+        } catch (e: Throwable) {
+            // Deliberately rethrows CancellationException (structured-concurrency-
+            // cooperative) and any non-degradable throw before touching the
+            // counter — faithful to Swift's `default: throw`. An explicit
+            // try/catch (not `runCatching`, which swallows CancellationException).
+            if (!isTurnDegradable(e)) throw e
+            val count = consecutiveSkips.incrementAndFetch()
+            if (count >= consecutiveSkipLimit) {
+                throw SimulationException(SimulationError.TurnFailureLimitReached(count))
+            }
+            emitter(SimulationEvent.TurnSkipped(agent = agent, phaseType = phaseType, cause = cause(e)))
+            null
+        }
+    }
+
+    /**
+     * ADR-021 D3: only the transient class is contained. Systemic errors escape
+     * `LLMCaller` wrapped precisely so they fall through this predicate;
+     * cancellation and unclassified throws likewise propagate untouched. Unwraps
+     * [SimulationException] — Kotlin [SimulationError] is not a [Throwable], so a
+     * type-match on it directly could never fire.
+     */
+    private fun isTurnDegradable(e: Throwable): Boolean =
+        e is SimulationException &&
+            (e.error is SimulationError.RetriesExhausted || e.error is SimulationError.LlmGenerationFailed)
+
+    /**
+     * Diagnostic (non-localized) cause carried on [SimulationEvent.TurnSkipped] —
+     * the same register as `llmGenerationFailed`'s payload. The App layer renders
+     * its own localized narration; this string is for logs/harness transcripts.
+     */
+    private fun cause(e: Throwable): String {
+        val err = (e as? SimulationException)?.error
+        return if (err is SimulationError.LlmGenerationFailed) err.description else "retries exhausted"
+    }
+}

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/EngineLoggerSeamTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/EngineLoggerSeamTests.kt
@@ -1,0 +1,60 @@
+package com.pastura.engine
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Seam-shape parity spec for [EngineLogger] / [NoopEngineLogger].
+ *
+ * Behavioral parity is deferred to Wave B: the Swift behavioral tests drive
+ * `LLMCaller(logger:)` consumption and the unported `OSLogEngineLogger`, but
+ * Kotlin `LLMCaller` does not consume the seam yet (ADR-023 §12 condition-2 seam
+ * carve-out, PR0-b precedent). This spec asserts only the seam's shape: the
+ * interface records what it is handed, the Noop swallows every combination, and
+ * the enum case-sets stay complete.
+ */
+class EngineLoggerSeamTests {
+
+    private data class Entry(
+        val level: EngineLogLevel,
+        val category: String,
+        val message: String,
+        val privacy: EngineLogPrivacy,
+    )
+
+    private class SpyEngineLogger : EngineLogger {
+        val entries = mutableListOf<Entry>()
+        override fun log(level: EngineLogLevel, category: String, message: String, privacy: EngineLogPrivacy) {
+            entries.add(Entry(level, category, message, privacy))
+        }
+    }
+
+    @Test
+    fun loggerRecordsWhatItIsHanded() {
+        val spy = SpyEngineLogger()
+        spy.log(EngineLogLevel.WARNING, "StreamingDiag", "boom", EngineLogPrivacy.PUBLIC)
+        assertEquals(
+            Entry(EngineLogLevel.WARNING, "StreamingDiag", "boom", EngineLogPrivacy.PUBLIC),
+            spy.entries.single(),
+        )
+    }
+
+    @Test
+    fun noopHandlesAllLevelPrivacyCombos() {
+        // Mirrors Swift's osLogAdapterHandlesAllLevelPrivacyCombos smoke, against
+        // NoopEngineLogger: every level×privacy pair is callable without throwing.
+        val noop = NoopEngineLogger()
+        for (level in EngineLogLevel.entries) {
+            for (privacy in EngineLogPrivacy.entries) {
+                noop.log(level, "StreamingDiag", "msg", privacy)
+            }
+        }
+    }
+
+    @Test
+    fun enumCaseSetsAreComplete() {
+        // Perturbation target: an added/removed case flips these counts.
+        assertEquals(3, EngineLogLevel.entries.size)
+        assertEquals(2, EngineLogPrivacy.entries.size)
+    }
+}

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/EngineSchemaVersionTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/EngineSchemaVersionTests.kt
@@ -1,0 +1,127 @@
+package com.pastura.engine
+
+import com.pastura.models.PhaseType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * commonTest parity spec for [EngineSchemaVersion], ported 1:1 from
+ * `Pastura/PasturaTests/Engine/EngineSchemaVersionTests.swift`.
+ */
+class EngineSchemaVersionTests {
+
+    /** The wire raw value for a phase type — mirrors [EngineSchemaVersion]'s idiom. */
+    private fun PhaseType.serialName(): String =
+        PhaseType.serializer().descriptor.getElementName(ordinal)
+
+    // MARK: - Current version constant
+
+    @Test
+    fun currentVersionIsFive() {
+        // Bumped 1→2 for event_inject no_repeat (#1006, ADR-020 §8); 2→3 for the
+        // narrate phase (#909, ADR-020 §9); 3→4 for Persona.secret (#914 — an old
+        // app silently drops the key and runs every agent without its hidden
+        // agenda); 4→5 for ScoreCalcLogic.pairwise_payoff (ADR-027 — a new
+        // by-name-parsed score_calc logic, an old app throws on it via D5). Update
+        // in lockstep with any further EngineSchemaVersion.current bump.
+        assertEquals(5, EngineSchemaVersion.current)
+    }
+
+    // MARK: - D2 (phase-capability) branch
+
+    @Test
+    fun nilPhasesAreUnconstrained() {
+        // A legacy/older feed with no `phases` field must not grey out — the
+        // index gate cannot determine capability, so it defers to D3 + the
+        // parse-throw backstop.
+        assertTrue(EngineSchemaVersion.isCompatible(phases = null, minEngineVersion = null))
+    }
+
+    @Test
+    fun emptyPhasesAreCompatible() {
+        assertTrue(EngineSchemaVersion.isCompatible(phases = emptyList(), minEngineVersion = null))
+    }
+
+    @Test
+    fun allKnownPhasesAreCompatible() {
+        val known = PhaseType.entries.map { it.serialName() }
+        assertTrue(EngineSchemaVersion.isCompatible(phases = known, minEngineVersion = null))
+    }
+
+    @Test
+    fun everyCurrentPhaseKindIsIndividuallyCompatible() {
+        // No shipped phase kind may grey out at baseline.
+        for (phase in PhaseType.entries) {
+            assertTrue(
+                EngineSchemaVersion.isCompatible(
+                    phases = listOf(phase.serialName()),
+                    minEngineVersion = null,
+                ),
+                "${phase.serialName()} should be compatible at baseline",
+            )
+        }
+    }
+
+    @Test
+    fun unknownPhaseIsIncompatible() {
+        assertFalse(
+            EngineSchemaVersion.isCompatible(
+                phases = listOf("vote", "future_phase"),
+                minEngineVersion = null,
+            ),
+        )
+    }
+
+    // MARK: - D3 (declared min_engine_version) branch
+
+    @Test
+    fun minEngineVersionEqualToCurrentIsCompatible() {
+        assertTrue(
+            EngineSchemaVersion.isCompatible(
+                phases = null,
+                minEngineVersion = EngineSchemaVersion.current,
+            ),
+        )
+    }
+
+    @Test
+    fun minEngineVersionZeroIsCompatible() {
+        assertTrue(EngineSchemaVersion.isCompatible(phases = null, minEngineVersion = 0))
+    }
+
+    @Test
+    fun minEngineVersionAboveCurrentIsIncompatible() {
+        assertFalse(
+            EngineSchemaVersion.isCompatible(
+                phases = null,
+                minEngineVersion = EngineSchemaVersion.current + 1,
+            ),
+        )
+    }
+
+    @Test
+    fun knownPhasesButFutureMinEngineVersionIsIncompatible() {
+        // D3 alone gates a scenario whose phases are all known but which
+        // declares a future requirement (a semantics-only or non-phase break).
+        assertFalse(
+            EngineSchemaVersion.isCompatible(
+                phases = listOf("vote", "speak_all"),
+                minEngineVersion = EngineSchemaVersion.current + 1,
+            ),
+        )
+    }
+
+    // MARK: - AND-composition (compatible ⇔ both gates pass)
+
+    @Test
+    fun bothGatesFailingIsIncompatible() {
+        assertFalse(
+            EngineSchemaVersion.isCompatible(
+                phases = listOf("future_phase"),
+                minEngineVersion = EngineSchemaVersion.current + 1,
+            ),
+        )
+    }
+}

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/TurnFailureGateTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/TurnFailureGateTests.kt
@@ -176,5 +176,17 @@ class TurnFailureGateTests {
         }
         assertIs<SimulationError.ModelNotLoaded>(thrown.error)
         assertTrue(events.isEmpty())
+
+        // Prove the throw happened BEFORE the counter incremented: two subsequent
+        // degradable failures now produce exactly two skips (not a breaker trip).
+        // Had ModelNotLoaded counted as skip 1, the second RetriesExhausted would
+        // reach count 3 and throw turnFailureLimitReached instead of skipping.
+        repeat(2) {
+            val value: String? = gate.attempt(
+                agent = "Alice", phaseType = PhaseType.SPEAK_ALL, emitter = { events.add(it) },
+            ) { throw SimulationException(SimulationError.RetriesExhausted) }
+            assertNull(value)
+        }
+        assertEquals(2, events.skipped().size)
     }
 }

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/TurnFailureGateTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/TurnFailureGateTests.kt
@@ -1,0 +1,180 @@
+package com.pastura.engine
+
+import com.pastura.models.PhaseType
+import com.pastura.models.SimulationError
+import com.pastura.models.SimulationEvent
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.test.assertFailsWith
+
+/**
+ * commonTest parity spec for [TurnFailureGate], ported from
+ * `Pastura/PasturaTests/Engine/TurnFailureGateTests.swift` (7 Swift tests) plus
+ * one new wrapped-wrong-case probe.
+ */
+class TurnFailureGateTests {
+
+    // A type DISJOINT from the cancellation hierarchy: Kotlin
+    // `CancellationException : IllegalStateException`, so a systemic-rethrow probe
+    // must not use IllegalStateException or it would read as cancellation.
+    private class ProbeError : RuntimeException("boom")
+
+    private fun MutableList<SimulationEvent>.skipped(): List<SimulationEvent.TurnSkipped> =
+        filterIsInstance<SimulationEvent.TurnSkipped>()
+
+    @Test
+    fun successReturnsValueAndEmitsNothing() = runTest {
+        val gate = TurnFailureGate()
+        val events = mutableListOf<SimulationEvent>()
+
+        val value = gate.attempt(
+            agent = "Alice", phaseType = PhaseType.SPEAK_ALL, emitter = { events.add(it) },
+        ) { "ok" }
+
+        assertEquals("ok", value)
+        assertTrue(events.isEmpty())
+    }
+
+    @Test
+    fun transientFailureSkipsTurnAndEmitsTurnSkipped() = runTest {
+        val gate = TurnFailureGate()
+        val events = mutableListOf<SimulationEvent>()
+
+        val value: String? = gate.attempt(
+            agent = "Alice", phaseType = PhaseType.SPEAK_ALL, emitter = { events.add(it) },
+        ) { throw SimulationException(SimulationError.RetriesExhausted) }
+
+        assertNull(value)
+        assertEquals(
+            listOf(
+                SimulationEvent.TurnSkipped(
+                    agent = "Alice", phaseType = PhaseType.SPEAK_ALL, cause = "retries exhausted",
+                ),
+            ),
+            events.skipped(),
+        )
+    }
+
+    @Test
+    fun generationFailureCarriesDescriptionAsCause() = runTest {
+        val gate = TurnFailureGate()
+        val events = mutableListOf<SimulationEvent>()
+
+        val value: String? = gate.attempt(
+            agent = "Bob", phaseType = PhaseType.VOTE, emitter = { events.add(it) },
+        ) { throw SimulationException(SimulationError.LlmGenerationFailed("transient blip")) }
+
+        assertNull(value)
+        assertEquals(
+            listOf(
+                SimulationEvent.TurnSkipped(
+                    agent = "Bob", phaseType = PhaseType.VOTE, cause = "transient blip",
+                ),
+            ),
+            events.skipped(),
+        )
+    }
+
+    @Test
+    fun systemicErrorRethrowsTypedWithoutSkip() = runTest {
+        // ADR-021 D3: a deterministic engineering bug must abort in one throw,
+        // not degrade turn-by-turn. ProbeError stands in for Swift's
+        // LLMError.invalidGrammar (not ported to Kotlin).
+        val gate = TurnFailureGate()
+        val events = mutableListOf<SimulationEvent>()
+
+        assertFailsWith<ProbeError> {
+            gate.attempt(
+                agent = "Alice", phaseType = PhaseType.SPEAK_ALL, emitter = { events.add(it) },
+            ) { throw ProbeError() }
+        }
+        assertTrue(events.isEmpty())
+    }
+
+    @Test
+    fun cancellationRethrowsWithoutSkip() = runTest {
+        // ADR-021 D3 control-flow class: user cancellation must never be
+        // converted into a skipped turn.
+        val gate = TurnFailureGate()
+        val events = mutableListOf<SimulationEvent>()
+
+        assertFailsWith<CancellationException> {
+            gate.attempt(
+                agent = "Alice", phaseType = PhaseType.SPEAK_ALL, emitter = { events.add(it) },
+            ) { throw CancellationException("cancel") }
+        }
+        assertTrue(events.isEmpty())
+    }
+
+    @Test
+    fun thirdConsecutiveFailureTripsBreaker() = runTest {
+        // ADR-021 D4: skips 1 and 2 emit TurnSkipped; the 3rd consecutive failure
+        // throws turnFailureLimitReached INSTEAD of a 3rd skip. The counter is
+        // shared across phases — the failures span speak_all → vote.
+        val gate = TurnFailureGate()
+        val events = mutableListOf<SimulationEvent>()
+
+        for (phase in listOf(PhaseType.SPEAK_ALL, PhaseType.SPEAK_ALL)) {
+            val value: String? = gate.attempt(
+                agent = "Alice", phaseType = phase, emitter = { events.add(it) },
+            ) { throw SimulationException(SimulationError.RetriesExhausted) }
+            assertNull(value)
+        }
+
+        val thrown = assertFailsWith<SimulationException> {
+            gate.attempt(
+                agent = "Bob", phaseType = PhaseType.VOTE, emitter = { events.add(it) },
+            ) { throw SimulationException(SimulationError.RetriesExhausted) }
+        }
+        val error = thrown.error
+        assertIs<SimulationError.TurnFailureLimitReached>(error)
+        assertEquals(3, error.consecutiveCount)
+        // Only the first two failures produced skip events.
+        assertEquals(2, events.skipped().size)
+    }
+
+    @Test
+    fun successResetsConsecutiveCounter() = runTest {
+        // ADR-021 D4: F F S F F must NOT trip the 3-consecutive breaker.
+        val gate = TurnFailureGate()
+        val events = mutableListOf<SimulationEvent>()
+
+        suspend fun fail(): String? = gate.attempt(
+            agent = "Alice", phaseType = PhaseType.SPEAK_ALL, emitter = { events.add(it) },
+        ) { throw SimulationException(SimulationError.RetriesExhausted) }
+
+        fail()
+        fail()
+        val ok = gate.attempt(
+            agent = "Alice", phaseType = PhaseType.SPEAK_ALL, emitter = { events.add(it) },
+        ) { "recovered" }
+        assertEquals("recovered", ok)
+        fail()
+        fail()
+
+        assertEquals(4, events.skipped().size)
+    }
+
+    @Test
+    fun wrappedNonDegradableCaseRethrowsBeforeCounterIncrements() = runTest {
+        // NEW (fills a gap the Swift set misses): a WRAPPED but non-degradable
+        // SimulationError (ModelNotLoaded) must rethrow before the counter
+        // increments — proving the branch a too-broad `catch(SimulationException)`
+        // would silently degrade. No skip event may be emitted.
+        val gate = TurnFailureGate()
+        val events = mutableListOf<SimulationEvent>()
+
+        val thrown = assertFailsWith<SimulationException> {
+            gate.attempt(
+                agent = "Alice", phaseType = PhaseType.SPEAK_ALL, emitter = { events.add(it) },
+            ) { throw SimulationException(SimulationError.ModelNotLoaded) }
+        }
+        assertIs<SimulationError.ModelNotLoaded>(thrown.error)
+        assertTrue(events.isEmpty())
+    }
+}


### PR DESCRIPTION
## Summary

ADR-023 Stage 3 Engine bulk-port, **PR-2 (run-path mechanisms)** — the second Wave-A cold slice after PR-1 (score_calc, #1207). Ports three standalone Swift `Engine/` mechanisms to Kotlin `shared/engine/commonMain`, each with a commonTest parity spec. Landed as infra (**not** wired into `PhaseContext`/handlers — that is Wave B); Swift stays parallel (no deletion before Stage 5).

- **`EngineSchemaVersion`** (ADR-020 D1 capability version) → `object`. D2 phase gate reads `PhaseType.entries` serialName via the `@SerialName` descriptor (`PhaseDispatcher.kt` idiom); D3 version gate.
- **`TurnFailureGate`** (ADR-021 per-turn degradation gate) → `class`, counter as `AtomicInt` under `@OptIn(ExperimentalAtomicApi)` (same fidelity argument as `SimulationEngine.kt`'s PauseGate for Swift's `Mutex<Int>`).
- **`EngineLogger`** seam (2 enums + interface + `NoopEngineLogger`). The concrete `OSLogEngineLogger` stays in the Swift App layer (not ported), per ADR-023 §4's run-path-mechanisms disposition — it lands as infra like its row-siblings, keeping the Engine free of `import os`.

### Faithful-port decisions (pre-impl `critic` + `code-reviewer`-verified)

- **`TurnFailureGate` unwraps `SimulationException`.** Kotlin `SimulationError` is a `@Serializable sealed class`, NOT a `Throwable`; the engine throws it wrapped (`LLMCaller.kt:99,113,163`). So `isTurnDegradable`/`cause` unwrap `SimulationException` rather than type-matching the raw error (which could never be caught). Explicit `try/catch` (not `runCatching`, which swallows `CancellationException`) rethrows cancellation + any non-degradable throw before touching the counter.
- **New wrapped-wrong-case probe** (`SimulationException(ModelNotLoaded)` → rethrow before increment) exceeds the Swift test set, pinning the branch a too-broad `catch(SimulationException)` would silently degrade.
- **`EngineLogger` condition-2 parity is seam-shape only** (enum case-sets + Noop no-throw across level×privacy + spy tuple capture). The Swift behavioral tests drive `LLMCaller(logger:)` consumption + the unported `OSLogEngineLogger`; Kotlin `LLMCaller` does not reference the seam yet, so behavioral parity is Wave-B freight. This is the §12 condition-2 seam carve-out (PR0-b #1202 precedent), not a coverage gap.

## Test plan

- `./gradlew :shared:engine:compileCommonMainKotlinMetadata` → BUILD SUCCESSFUL (commonMain-stdlib check).
- `./gradlew :shared:models:jvmTest :shared:engine:jvmTest` → BUILD SUCCESSFUL; 22 new tests (11 EngineSchemaVersion + 8 TurnFailureGate + 3 EngineLogger), XML `failures="0"`.
- **Condition 4 perturbation** (per-file disjoint batches + comment-only negative control): every perturbation reddened exactly its named sibling(s), 0 spurious bystander, negative control 0 red. Full matrix recorded in #501 (issuecomment).
- Swift untouched — dual-landing preserved.

## Device QA

実機QA不要 — Kotlin `commonMain` infra only, not wired into the iOS app; no `#if !targetEnvironment(simulator)`, Metal, or UI surface touched.

Closes #1209
Part of #501
