### PR TITLE
📝 docs: correct Round 10 orchestrate traps after risk-review

### DIFF
--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -215,9 +215,9 @@ Handle the critic's output:
    git branch -m "$(git branch --show-current)" "{TASK_TYPE}/{SLUG}"
    ```
 5. Verify: `git branch --show-current`.
-6. **Worktree path hygiene** (holds for the rest of the session): the main checkout at `/Users/tyabu12/Work/pastura` stays on another branch, so any tool that silently resolves to it instead of this worktree acts on the wrong tree with no diff warning.
-   - Every absolute Edit/Write path must contain `/worktrees/<name>/` — invalidate any path carried over from a *pre-worktree* tool result before reusing it.
-   - In subagent prompts (Step 3 `implementer`, Step 4 reviewer), embed the **resolved literal** worktree path — `git -C "$WORKTREE" …`, Read at `$WORKTREE/…` — never a `$(git rev-parse …)` the subagent re-runs against its own cwd. A reviewer whose `git diff` resolves to the main checkout instead sees an **empty phantom diff** — a "no changes" review quieter than a wrong-file read.
+6. **Worktree path hygiene** (holds for the rest of the session): the main checkout at `/Users/tyabu12/Work/pastura` stays on another branch, so a tool that resolves to it instead of this worktree acts on the wrong tree silently.
+   - Every absolute Edit/Write path must contain `/worktrees/<name>/` — invalidate any carried over from a *pre-worktree* tool result before reusing it.
+   - Non-isolation subagents (Step 3 `implementer`, Step 4 reviewer) inherit this worktree's cwd, so their git normally resolves here — but embed **already-resolved** absolute paths in their prompts (capture the root once with `git rev-parse --show-toplevel`), never a `$(…)` the subagent re-runs against its own cwd, and never a reused pre-worktree path. A subagent whose git resolved to the main checkout instead would see an **empty phantom diff**.
 
 ## Step 3: Implementation (TDD)
 
@@ -315,7 +315,7 @@ After all implementation, run full verification directly from the main session:
 
 ## Step 4: Review — Gate G3
 
-**Before launching the reviewer,** `git fetch origin {DEFAULT_BRANCH}` and check `git rev-list --count HEAD..origin/{DEFAULT_BRANCH}` — a long session (research → critic → multi-commit implementation) can span hours during which `{DEFAULT_BRANCH}` advances. If the count is non-zero, offer a rebase before review; **mandatory** when the diff touches large generated / data files (xcstrings, lockfiles) where a naive 3-way merge silently reverts upstream work.
+**Before launching the reviewer,** `git fetch origin {DEFAULT_BRANCH}` and check `git rev-list --count HEAD..origin/{DEFAULT_BRANCH}` — a long session (research → critic → multi-commit implementation) can span hours during which `{DEFAULT_BRANCH}` advances. If the count is non-zero, offer a rebase before review; **mandatory** when the diff touches large generated / data files (xcstrings, lockfiles), where a rebase or non-conflicting auto-merge can drop upstream entries without surfacing a conflict.
 
 Launch a `code-reviewer` subagent via the Agent tool to review all changes on the feature branch. Pass `model: $REVIEWER_MODEL` (resolved from the plan's `## Metadata` — via Step 0 on resumption, or via Step 1 on a fresh run; defaults to Opus if absent). The Agent tool's `model` parameter takes precedence over the agent frontmatter's `model: opus`. The agent's checklist carries a Pastura-specific trap cheat sheet to keep the Sonnet-reviewer path safe.
 
@@ -408,4 +408,4 @@ After creation:
 1. `ExitWorktree` with action `"remove"`
 2. `git switch <default-branch> && git pull`
 
-> **Squash / rebase merge caveat:** those merge styles give the merged commit a **new SHA**, so `ExitWorktree(action: "remove")` refuses — it counts the local commits as unmerged by ancestry — even though the work landed. Once the user confirms the merge, re-invoke with `discard_changes: true`, briefly noting why. Merge-commit style keeps the local SHAs reachable and needs no discard — verify the style first if the user used a non-default flow. (Pastura defaults to squash, so this fires by default.)
+> **Post-merge `remove` may refuse:** squash / rebase merge gives the merged commit a **new SHA**, so the worktree's local commits read as unmerged by ancestry and `ExitWorktree(action: "remove")` refuses — as it also can *before* the post-merge `pull`, when local `main` doesn't yet contain the merge. Once the user confirms the merge landed, re-invoke with `discard_changes: true`. (Pastura defaults to squash, so a post-merge `remove` refuses by default.)


### PR DESCRIPTION
## Summary

Follow-up to PR #1211 (**Part of #780**). A `/risk-review` of that diff found 3 fixable inaccuracies in the notes promoted into the `orchestrate` skill doc — all confirmed valid and corrected here. Docs-only, net-neutral (5 insertions / 5 deletions).

| Step | Was | Now |
|------|-----|-----|
| 2b | Example used `$WORKTREE` — an **undefined** shell var (neither a `{curly}` the orchestrator substitutes nor an assigned var). Pasting it into a subagent prompt empty-expands to `git -C ""` → the exact phantom diff the note warns of. | Reframed to match the real mechanism (non-isolation subagents inherit the worktree cwd) + capture the root via `git rev-parse --show-toplevel`; phantom-diff kept as a subjunctive belt-and-suspenders rationale. |
| 4 | "naive 3-way merge **silently reverts** upstream work" — overstated (default `ort` surfaces overlapping edits as conflicts). | "a rebase or **non-conflicting auto-merge** can drop upstream entries without surfacing a conflict." |
| 6 | "merge-commit style keeps local SHAs reachable and **needs no discard**" — false given Step 6 removes **before** pulling, so local `main` lacks the merge. | `remove` can refuse for **any** merge style before the post-merge `pull`; re-invoke with `discard_changes: true`. |

## Why this needed a separate PR

#1211 was already merged when the risk-review ran, so the buggy wording is live on `main` and the fix can't be folded back.

## Review

- Source: a 2-critic `/risk-review` on the kit diff (same additions); all 4 Warnings confirmed valid, `$WORKTREE`-undefined being the sharpest (the example armed its own warning).
- Load-bearing facts verified empirically: `git rev-parse --show-toplevel` returns the *worktree* root (not main); Step 6 is remove-then-pull.
- **code-reviewer** (Opus, worktree-pinned): **PASS**, 0 issues — independently re-confirmed all three corrections + internal consistency with Step 3 line 251.
- The same 3 fixes are applied to the upstream kit skeleton (claude-kit PR #8, follow-up commit).

## Test plan

Docs-only change to `.claude/skills/orchestrate/SKILL.md`. Pre-commit correctly skipped SwiftLint + build (`.claude/`-only). No code surface.

## Device QA

実機QA不要 — documentation-only change to a skill doc.