### PR TITLE
🧹 chore: port prompt + LLM glue remainder to shared/engine commonMain (ADR-023 Stage 3 PR-3)

### DIFF
--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/ErrorReadability.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/ErrorReadability.kt
@@ -1,0 +1,21 @@
+package com.pastura.engine
+
+/**
+ * Returns the most human-readable description of an arbitrary [Throwable].
+ *
+ * The Swift original prefers `LocalizedError.errorDescription` and falls back
+ * to `String(describing:)`. Kotlin has no `LocalizedError`, so the equivalent
+ * mapping is **prefer [Throwable.message], else [Throwable.toString]** — the
+ * `message` carries the meaningful text (mirroring how
+ * [SimulationException.messageFor] renders readable text into `.message`),
+ * while `toString()` prepends the class name and is only the last resort for a
+ * message-less throwable.
+ *
+ * Landed as infra: there is **no Kotlin consumer yet**. The Engine
+ * error-bridge call sites that wrap foreign errors into [SimulationError]-typed
+ * strings — the analogue of the Swift wrap points — are later-Wave freight.
+ *
+ * Swift original: `Pastura/Pastura/Engine/ErrorReadability.swift`.
+ * Ported for the ADR-023 §6 Stage-3 Engine migration (#501).
+ */
+internal fun readableDescription(error: Throwable): String = error.message ?: error.toString()

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
@@ -30,7 +30,7 @@ import kotlinx.serialization.json.JsonPrimitive
  * |---|---|
  * | The two-step repair pipeline (`unclosed_string` -> `unclosed_brace`, #194) | hardening, not a boundary concern; the gate never scripts a truncated stream |
  * | Schema-guarded multi-object salvage (#907) | same |
- * | `PartialOutputExtractor` | named Stage-3 freight in ADR-023 §6 |
+ * | `PartialOutputExtractor` | landed as a sibling commonMain type in PR-3 (#501 Stage 3); this parser still does not consume it — the two share only the duplicated thinking-tag regexes by parity |
  * | `TurnOutput.rawText` passthrough | Kotlin `TurnOutput` has no `rawText`; its only consumer is Data-layer `TurnRecord.rawOutput` audit, outside the Engine port |
  *
  * `expectedKeys` is therefore accepted and **only** used for the post-parse guard,

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMCaller.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMCaller.kt
@@ -33,8 +33,8 @@ import kotlinx.coroutines.suspendCancellableCoroutine
  *
  * | Absent | Why |
  * |---|---|
- * | `PartialOutputExtractor` | named Stage-3 freight; snapshots carry raw accumulated text instead — see [AgentOutputStream emission][emitSnapshot] |
- * | Language-adherence retry (ADR-010 Step E) | named Stage-3 freight; no `detector` reaches this slice |
+ * | `PartialOutputExtractor` | the type landed in PR-3 (#501 Stage 3), but this slice does not consume it yet — snapshots still carry raw accumulated text; wiring is deferred to Wave B (see [emitSnapshot]) |
+ * | Language-adherence retry (ADR-010 Step E) | the `LanguageDetector` seam landed in PR-3, but its retry consumer is Wave-B freight — no detector reaches this slice yet |
  * | `StreamFailure` taxonomy + ADR-021 D3 classification | named Stage-3 freight; [TerminalStatus.Failed] maps straight to [SimulationError.LlmGenerationFailed] |
  * | The `StreamingDiag` log channel | the `EngineLogger` seam is not in this slice's [PhaseContext] |
  *
@@ -225,8 +225,9 @@ internal class LLMCaller(
      * Emit a live progress snapshot.
      *
      * **Carries RAW accumulated text, not an extracted primary/thought split.**
-     * `PartialOutputExtractor` — which computes that split — is named Stage-3
-     * freight (ADR-023 §6). The event is still emitted per chunk on purpose: it is
+     * `PartialOutputExtractor` — which computes that split — landed in PR-3
+     * (ADR-023 §6 Stage 3) but is not consumed here yet. The event is still
+     * emitted per chunk on purpose: it is
      * the highest-frequency Kotlin->Swift crossing, and §6 measurement (i)/(ii)
      * measure exactly that boundary at realistic token rates. Dropping it would
      * leave the gate measuring the event boundary at ~3 crossings per turn instead

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/LanguageDetector.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/LanguageDetector.kt
@@ -1,0 +1,36 @@
+package com.pastura.engine
+
+/**
+ * Abstraction over language-of-text detection for LLM output adherence checks.
+ *
+ * Implementations classify a raw text snippet (typically the natural-language
+ * fields of a parsed `TurnOutput`) and return an ISO 639-1 lowercase code
+ * (`"ja"`, `"en"`, …) or `null` when the input is too short / too ambiguous to
+ * classify above the implementation's confidence threshold.
+ *
+ * The concrete production implementation lives in the Swift App/ layer
+ * (`NLLanguageDetector`, backed by Apple's `NLLanguageRecognizer`). Per ADR-010
+ * D8, `import NaturalLanguage` is forbidden in Engine / LLM / Models / Data
+ * layers — only this abstraction crosses the boundary. The Swift consumer
+ * threads a nullable `(any LanguageDetector)?` (nil = skip the check), so there
+ * is deliberately **no Noop impl** here; the interface is landed as an unwired
+ * seam, mirroring [EngineLogger].
+ *
+ * Swift original: `Pastura/Pastura/LLM/LanguageDetector.swift`.
+ * Ported for the ADR-023 §6 Stage-3 Engine migration (#501).
+ */
+internal interface LanguageDetector {
+    /**
+     * Detect the dominant natural language of [text].
+     *
+     * @param text The text to classify. Callers should join the
+     *   natural-language fields of a parsed `TurnOutput` (excluding
+     *   enum-constrained / option-bound fields whose values are author-supplied
+     *   tokens) before passing.
+     * @return An ISO 639-1 lowercase code (e.g., `"ja"`, `"en"`), or `null`
+     *   when the classification confidence falls below the implementation's
+     *   threshold. The consumer treats `null` as "skip the adherence check"
+     *   rather than "mismatch".
+     */
+    fun detect(text: String): String?
+}

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/PartialOutputExtractor.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/PartialOutputExtractor.kt
@@ -1,0 +1,266 @@
+package com.pastura.engine
+
+/**
+ * Best-effort snapshot of a single LLM inference's currently-emitted fields,
+ * derived from a buffer of streamed text.
+ *
+ * Produced by [PartialOutputExtractor.extract] during incremental generation
+ * and consumed by the streaming caller path to push UI updates. The final
+ * canonical parse (via [JSONResponseParser]) is still the source of truth on
+ * stream end; the extractor's job is to stay *consistent* with that canonical
+ * result — every partial primary must be a prefix of the final one.
+ *
+ * A `data class` gives the Swift original's `Equatable` for free.
+ *
+ * Swift original: `Pastura/Pastura/LLM/PartialOutputExtractor.swift`.
+ */
+internal data class PartialSnapshot(
+    /**
+     * Currently-visible value of the first primary key present in the buffer
+     * (one of [PartialOutputExtractor.primaryKeys] —
+     * `statement` / `action` / `vote` / `note`). `null` while the extractor is
+     * waiting for that key's opening quote.
+     */
+    val primary: String?,
+    /**
+     * Currently-visible value of `inner_thought`, or `null` until its opening
+     * quote has arrived.
+     */
+    val thought: String?,
+) {
+    companion object {
+        val empty = PartialSnapshot(null, null)
+    }
+}
+
+/**
+ * Extracts best-effort `(primary, thought)` snapshots from partial LLM output
+ * text. Stateless — each [extract] call parses the entire buffer fresh.
+ *
+ * Strategy:
+ * 1. Strip closed Gemma / generic thinking tags.
+ * 2. If an *unclosed* thinking tag is present, yield an empty snapshot (the
+ *    model is still reasoning; nothing is safe to display).
+ * 3. Otherwise locate the first `{` and scan for top-level `"<key>":"..."` pairs
+ *    that correspond to known primary keys or [thoughtKey].
+ * 4. Decode escape sequences inside string values; hold back incomplete escapes
+ *    (`\`, partial `\uXXXX`) so the UI never sees invalid characters mid-type.
+ *
+ * Top-level detection uses a cheap heuristic — a candidate `"<key>"` is treated
+ * as a real key only when it is both followed by `:` and preceded by `{` or `,`
+ * (ignoring whitespace). This rejects key-like substrings that appear inside
+ * string values.
+ *
+ * Swift original: `Pastura/Pastura/LLM/PartialOutputExtractor.swift`.
+ */
+internal class PartialOutputExtractor {
+
+    companion object {
+        /**
+         * Recognised primary-output keys in the order they are checked (one
+         * canonical field per LLM phase: speak → `statement`, choose → `action`,
+         * vote → `vote`, reflect → `note`).
+         */
+        val primaryKeys = listOf("statement", "action", "vote", "note")
+        const val thoughtKey = "inner_thought"
+
+        // Duplicated intentionally from JSONResponseParser.kt's CHANNEL_THINKING /
+        // THINK_TAG — mirrors the Swift original's own two-copy structure; do NOT
+        // DRY-merge. `[\s\S]` encodes "any char incl. newline" without
+        // RegexOption.DOT_MATCHES_ALL, which is JVM/Native-only and absent from
+        // commonMain (see JSONResponseParser.kt L43-52).
+        private val channelThinkingRegex = Regex("""<\|channel>thought\s*[\s\S]*?<channel\|>""")
+        private val thinkTagRegex = Regex("""<think>[\s\S]*?</think>""")
+    }
+
+    /**
+     * Extract a best-effort `(primary, thought)` snapshot from a partial buffer.
+     *
+     * [thoughtKey] is the secondary field to surface as the snapshot's `thought`.
+     * Defaults to [PartialOutputExtractor.thoughtKey] (`inner_thought`). The
+     * caller passes the schema-derived key (e.g. `reason` for vote) so the live
+     * streaming THINKING section sources the phase's actual private-thought field
+     * (#609).
+     */
+    fun extract(
+        text: String,
+        thoughtKey: String = PartialOutputExtractor.thoughtKey,
+    ): PartialSnapshot {
+        val stripped = stripClosedThinkingTags(text)
+        if (hasUnclosedThinkingTag(stripped)) {
+            return PartialSnapshot.empty
+        }
+        val braceIdx = stripped.indexOf('{')
+        if (braceIdx < 0) {
+            return PartialSnapshot.empty
+        }
+        val jsonPart = stripped.substring(braceIdx)
+
+        var primary: String? = null
+        for (key in primaryKeys) {
+            val value = extractTopLevelStringValue(key, jsonPart)
+            if (value != null) {
+                primary = value
+                break
+            }
+        }
+        val thought = extractTopLevelStringValue(thoughtKey, jsonPart)
+
+        return PartialSnapshot(primary = primary, thought = thought)
+    }
+
+    // MARK: - Thinking-tag handling
+
+    private fun stripClosedThinkingTags(text: String): String {
+        var result = channelThinkingRegex.replace(text, "")
+        result = thinkTagRegex.replace(result, "")
+        return result
+    }
+
+    /**
+     * After stripping closed tags, an opener that still appears means the model
+     * is still generating reasoning — emission must wait.
+     */
+    private fun hasUnclosedThinkingTag(text: String): Boolean =
+        text.contains("<|channel>") || text.contains("<think>")
+
+    // MARK: - Top-level key lookup
+
+    /**
+     * Find a top-level `"<key>"` position in the JSON-ish buffer. Returns the
+     * index immediately after the closing quote of the key, or `null` if no
+     * top-level occurrence is found.
+     */
+    private fun findTopLevelKey(key: String, json: String): Int? {
+        val pattern = "\"$key\""
+        var searchStart = 0
+        while (searchStart <= json.length) {
+            val start = json.indexOf(pattern, searchStart)
+            if (start < 0) {
+                return null
+            }
+            val end = start + pattern.length
+
+            val followedByColon = isFollowedByColon(end, json)
+            val precededByOpener = isPrecededByOpener(start, json)
+
+            if (followedByColon && precededByOpener) {
+                return end
+            }
+            searchStart = end
+        }
+        return null
+    }
+
+    private fun isFollowedByColon(idx: Int, json: String): Boolean {
+        var i = idx
+        while (i < json.length && json[i].isWhitespace()) {
+            i++
+        }
+        return i < json.length && json[i] == ':'
+    }
+
+    private fun isPrecededByOpener(idx: Int, json: String): Boolean {
+        var i = idx
+        while (i > 0) {
+            i--
+            val char = json[i]
+            if (!char.isWhitespace()) {
+                return char == '{' || char == ','
+            }
+        }
+        return false
+    }
+
+    // MARK: - String-value extraction
+
+    /**
+     * Scan `"<key>"\s*:\s*"<decoded-value>"` at the top level. Returns:
+     * - `null` if the key has not been observed yet at top level.
+     * - `null` if the key exists but no value colon/opening-quote yet.
+     * - `""` once the opening quote is past but no content has arrived.
+     * - decoded partial content thereafter, holding back any incomplete trailing
+     *   escape.
+     */
+    private fun extractTopLevelStringValue(targetKey: String, json: String): String? {
+        val afterKey = findTopLevelKey(targetKey, json) ?: return null
+
+        var i = afterKey
+        while (i < json.length && json[i].isWhitespace()) {
+            i++
+        }
+        if (i >= json.length || json[i] != ':') return null
+        i++
+        while (i < json.length && json[i].isWhitespace()) {
+            i++
+        }
+        if (i >= json.length || json[i] != '"') return null
+        i++
+
+        return decodeStringContent(i, json)
+    }
+
+    /**
+     * Decode JSON string content up to the first unescaped `"` or the end of
+     * buffer. Holds back incomplete trailing escapes so the UI never renders a
+     * lone backslash or a partial `\uXXXX`.
+     */
+    private fun decodeStringContent(start: Int, json: String): String {
+        val decoded = StringBuilder()
+        var i = start
+        while (i < json.length) {
+            val char = json[i]
+            if (char == '"') {
+                return decoded.toString()
+            }
+            if (char == '\\') {
+                val next = i + 1
+                if (next >= json.length) return decoded.toString()
+                val escChar = json[next]
+                when (escChar) {
+                    '"' -> decoded.append('"')
+                    '\\' -> decoded.append('\\')
+                    '/' -> decoded.append('/')
+                    'n' -> decoded.append('\n')
+                    't' -> decoded.append('\t')
+                    'r' -> decoded.append('\r')
+                    'b' -> decoded.append('\u0008')
+                    'f' -> decoded.append('\u000C')
+                    'u' -> {
+                        val hexStart = next + 1
+                        val hexEnd = hexStart + 4
+                        if (hexEnd > json.length) return decoded.toString()
+                        val hex = json.substring(hexStart, hexEnd)
+                        // GUARD 1 (hex-charset): reject a leading sign / garbage
+                        // that Swift's unsigned UInt32(_:radix:) rejects but
+                        // Kotlin's toIntOrNull(16) would ACCEPT (e.g. `\u-0ff` →
+                        // -255) — a real cross-language parity gap.
+                        if (!hex.all { it.digitToIntOrNull(16) != null }) {
+                            return decoded.toString()
+                        }
+                        val code = hex.toInt(16)
+                        // GUARD 2 (surrogate): mirrors Swift Unicode.Scalar(code)
+                        // returning nil for surrogate code points.
+                        if (code in 0xD800..0xDFFF) {
+                            return decoded.toString()
+                        }
+                        decoded.append(code.toChar())
+                        i = hexEnd
+                        continue
+                    }
+                    else -> {
+                        // Unknown escape — preserve both chars verbatim so the
+                        // final canonical parse remains authoritative on meaning.
+                        decoded.append(char)
+                        decoded.append(escChar)
+                    }
+                }
+                i = next + 1
+                continue
+            }
+            decoded.append(char)
+            i++
+        }
+        return decoded.toString()
+    }
+}

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/PromptBuilder.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/PromptBuilder.kt
@@ -35,7 +35,7 @@ import com.pastura.models.SimulationState
  * | `addressRule` (#911, speak_each) | speak_each is Stage 3 |
  * | `reflectBrevityRule` / `whisperRule` | reflect / whisper are Stage 3 |
  * | choose-options rule / `voteCandidateRule` | choose / vote are Stage 3 |
- * | `RelationshipVerbalizer`, `PromptPlaceholders`, `ErrorReadability` | no slice consumer |
+ * | `RelationshipVerbalizer`, `PromptPlaceholders`, `ErrorReadability` | types landed in PR-3 (#501 Stage 3); PromptBuilder still has no slice consumer for them (wiring deferred to Wave B) |
  *
  * A Stage-3 port completes these against the Swift test files, which ADR-023 §6
  * names as the executable spec.

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/PromptPlaceholders.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/PromptPlaceholders.kt
@@ -1,0 +1,48 @@
+package com.pastura.engine
+
+/**
+ * Single source of truth for the `{token}` placeholders the Engine injects
+ * into LLM prompt / summarize-template strings at run time.
+ *
+ * Consumed by `BundledPresetPlaceholderCoverageTests` to fail CI when a
+ * bundled preset (or the Editor's advertised vocabulary) references a
+ * placeholder that **no** handler ever supplies — the failure mode behind
+ * #890 (`{assigned_word}` used by `word_wolf` but injected by nothing).
+ *
+ * **Important:** membership here only proves a token is *known to some
+ * prompt-build site*, NOT that it is supplied in *this* phase context.
+ * Supply is per-phase-type (`opponent_name` → choose round-robin only;
+ * `candidates` → vote only; `assigned` / `assigned_word` → the 5 per-persona
+ * LLM sites, never summarize/code phases). The guard is deliberately
+ * phase-context-blind — it catches the "supplied by no handler at all" class,
+ * which is the one that produced #890. The narrower "supplied by sibling
+ * handlers but omitted by one" class (#862) needs per-phase-availability
+ * modeling and is out of scope. Do not over-trust a green result as "every
+ * placeholder resolves in every phase it appears in".
+ *
+ * Swift original: `Pastura/Pastura/Engine/PromptPlaceholders.swift`.
+ * Ported for the ADR-023 §6 Stage-3 Engine migration (#501).
+ */
+internal object PromptPlaceholders {
+    /**
+     * Every placeholder name a handler can inject into a prompt at run time.
+     *
+     * When a new handler placeholder is added, extend this set in the same
+     * change so the coverage guard stays authoritative.
+     */
+    val engineSupplied: Set<String> = setOf(
+        "scoreboard", // SpeakAll/SpeakEach/Vote/Choose/Summarize
+        "conversation_log", // SpeakAll/SpeakEach/Vote/Choose/Summarize
+        "current_round", // SimulationRunner (per-round)
+        "candidates", // VoteHandler
+        "opponent_name", // ChooseHandler (round-robin)
+        "assigned", // canonical per-persona assign value (#890)
+        "assigned_word", // backward-compat alias of `assigned` (#890)
+        "assigned_topic", // AssignHandler (all mode — shared value)
+        "vote_results", // VoteHandler → Summarize
+        "wolf_name", // AssignHandler (random_one mode) → Summarize
+        "current_event", // EventInjectHandler (default event variable)
+        "relationships", // RelationshipUpdateHandler → the 5 per-persona LLM sites (#910)
+        "my_whispers", // WhisperHandler → participants' later-phase prompts (#908 / #957 PD adoption)
+    )
+}

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/RelationshipVerbalizer.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/RelationshipVerbalizer.kt
@@ -1,0 +1,54 @@
+package com.pastura.engine
+
+import kotlin.math.abs
+
+/**
+ * Renders a perceiver's raw affinity row (`other name → score`) as a short
+ * natural-language summary for injection into that agent's prompt.
+ *
+ * Gemma 4 E2B cannot read a numeric matrix, so the `relationship_update`
+ * phase surfaces its affinities as prose ("You are wary of Ryuji") rather
+ * than raw numbers. Only relationships whose magnitude reaches
+ * [mentionThreshold] are mentioned, keeping the injected text bounded even
+ * as scores accumulate across rounds. Language is chosen by the scenario's
+ * engine language (ja / en), matching every other prompt-side string (#910).
+ *
+ * Swift original: `Pastura/Pastura/Engine/RelationshipVerbalizer.swift`.
+ * Ported for the ADR-023 §6 Stage-3 Engine migration (#501).
+ */
+internal object RelationshipVerbalizer {
+    /**
+     * Minimum absolute affinity score for a relationship to be verbalized.
+     * Below this the feeling is too weak to mention; the gate also caps the
+     * prompt-length growth a fully-connected matrix would otherwise cause.
+     */
+    const val mentionThreshold = 2
+
+    /**
+     * Summarizes [affinities] (`other name → accumulated score`) as prose in
+     * [language]. Mentions only entries with `abs(score) >= mentionThreshold`,
+     * sorted by name for deterministic output, and returns `""` when nothing
+     * crosses the threshold (the caller then injects an empty section).
+     */
+    fun summarize(affinities: Map<String, Int>, language: String): String {
+        val notable = affinities
+            .filter { abs(it.value) >= mentionThreshold }
+            .toList()
+            .sortedBy { it.first }
+        if (notable.isEmpty()) return ""
+        val clauses = notable.map { clause(other = it.first, score = it.second, language = language) }
+        // ja sentences already carry a terminal 。 so they need no separator;
+        // en sentences are space-separated.
+        return clauses.joinToString(separator = pickLanguage(language, ja = "", en = " "))
+    }
+
+    private fun clause(other: String, score: Int, language: String): String {
+        // `summarize` has already filtered to `abs(score) >= mentionThreshold`; the
+        // warmth/wariness split is a pure sign test, decoupled from the magnitude gate.
+        return if (score > 0) {
+            pickLanguage(language, ja = "$other には好感を持っている。", en = "You feel warmly toward $other.")
+        } else {
+            pickLanguage(language, ja = "$other を警戒している。", en = "You are wary of $other.")
+        }
+    }
+}

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/SimulationEngine.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/SimulationEngine.kt
@@ -44,7 +44,7 @@ import kotlinx.coroutines.launch
  * |---|---|
  * | `ScenarioValidator` preflight + `ScenarioSemanticLinter` (ADR-024) | Stage-3 ports — §4's `Load + validate` row, which the linter joined on 2026-07-19 (before that, §4 did not mention it and this row's `(§4)` citation pointed at nothing). Nothing gates a scenario on this side yet, which is why the ported code must not assume validator floors — see `PromptBuilder`. |
  * | Resume (`resumingFrom` seed / `startRound`) | needs the Data layer's persisted state; D2 keeps Data in Swift |
- * | `LanguageDetector` / `EngineLogger` injection | Stage-3 freight; absent from `PhaseContext`. §4 ports the `EngineLogger` **seam only** — `OSLogEngineLogger` stays at `Pastura/Pastura/App/OSLogEngineLogger.swift` |
+ * | `LanguageDetector` / `EngineLogger` injection | injection is Stage-3 freight — absent from `PhaseContext`. §4 ports both **seams only** (`LanguageDetector` in PR-3, `EngineLogger` in PR-2); the concrete `OSLogEngineLogger` / `NLLanguageDetector` stay in Swift App/ |
  *
  * Swift original: `Pastura/Pastura/Engine/SimulationRunner.swift`.
  */

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ErrorReadabilityTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ErrorReadabilityTests.kt
@@ -1,0 +1,45 @@
+package com.pastura.engine
+
+import com.pastura.models.SimulationError
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Parity spec for [readableDescription] — mirrors the intent of the Swift
+ * `ErrorReadabilityTests` wrap-chain cases against the Kotlin
+ * `message ?: toString()` mapping. The message-present cases go red if the
+ * `?:` fallback collapses to a `toString()`-always impl (which would leak the
+ * class name).
+ */
+class ErrorReadabilityTests {
+
+    @Test
+    fun prefersMessageWhenPresent() {
+        val result = readableDescription(RuntimeException("boom"))
+        assertEquals("boom", result)
+        // Regression guard: a `toString()`-always impl would yield
+        // "...RuntimeException: boom", leaking the class name.
+        assertTrue(!result.contains("Exception"))
+    }
+
+    @Test
+    fun fallsBackToToStringWhenMessageIsNull() {
+        val e = RuntimeException()
+        val result = readableDescription(e)
+        // The exact class-name string is platform-specific; assert only that
+        // the `?: toString()` branch produced non-empty text equal to toString().
+        assertTrue(result.isNotEmpty())
+        assertEquals(e.toString(), result)
+    }
+
+    @Test
+    fun wrapChainCarriesInnerSimulationErrorText() {
+        val wrapped = SimulationException(SimulationError.LlmGenerationFailed("connection timeout"))
+        val result = readableDescription(wrapped)
+        assertTrue(result.contains("connection timeout"))
+        // Regression guard: preferring `.message` strips the sealed-subtype
+        // wrapper; a raw `toString()` would leak it.
+        assertTrue(!result.contains("LlmGenerationFailed("))
+    }
+}

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/LanguageDetectorSeamTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/LanguageDetectorSeamTests.kt
@@ -1,0 +1,37 @@
+package com.pastura.engine
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Seam-shape parity spec for [LanguageDetector].
+ *
+ * Behavioral parity is deferred: the Swift behavioral coverage drives
+ * `NLLanguageDetector` + `LLMCaller` consumption, but no Kotlin consumer
+ * threads the seam yet (unwired-seam precedent, cf. [EngineLogger]). This spec
+ * asserts only the seam's shape via a test-local spy: the interface records the
+ * text it is handed and returns whatever the implementation is told to return.
+ */
+class LanguageDetectorSeamTests {
+
+    private class SpyLanguageDetector(private val canned: String?) : LanguageDetector {
+        val recorded = mutableListOf<String>()
+        override fun detect(text: String): String? {
+            recorded.add(text)
+            return canned
+        }
+    }
+
+    @Test
+    fun detectorRecordsTheTextItIsHanded() {
+        val spy = SpyLanguageDetector(canned = "ja")
+        spy.detect("こんにちは")
+        assertEquals("こんにちは", spy.recorded.single())
+    }
+
+    @Test
+    fun detectorReturnsWhatItIsTold() {
+        assertEquals("en", SpyLanguageDetector(canned = "en").detect("hello"))
+        assertEquals(null, SpyLanguageDetector(canned = null).detect("x"))
+    }
+}

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/PartialOutputExtractorTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/PartialOutputExtractorTests.kt
@@ -1,0 +1,233 @@
+package com.pastura.engine
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Kotlin siblings of the Swift `PartialOutputExtractorTests` deterministic
+ * cases. Feeds progressively-longer buffers through the extractor and asserts
+ * the extracted `(primary, thought)` snapshot at each prefix.
+ *
+ * **Knowingly absent** (parity carve-out, cf. the EngineLogger behavioral
+ * carve-out): the three byte-stream fixture-replay tests
+ * (`cjkBoundaryFixtureReplaysWithoutContradiction`,
+ * `escapedQuoteFixtureReplaysWithoutContradiction`,
+ * `normalFixtureReplaysWithoutContradiction`) and their
+ * `replayAndCheckMonotonicity` / `longestValidUtf8Prefix` helpers. They depend
+ * on Swift `LlamaCppTraceFixtures` + the canonical `JSONResponseParser` replay
+ * path, neither of which is in the Kotlin parity scope.
+ *
+ * ### Kotlin string-literal note
+ *
+ * Buffer literals use triple-quoted raw strings (`"""..."""`) — like the Swift
+ * original's `#"..."#` raw strings, they do NOT process escapes, so a `\n` /
+ * `é` / `\\` in the buffer reaches the extractor as LITERAL backslash-escape
+ * bytes for it to decode. Regular double-quoted strings are used only for
+ * assertion expected-values, where the DECODED characters are wanted (a real
+ * newline, a real backslash, `café`).
+ *
+ * Ported for ADR-023 Stage 3 (#501).
+ */
+class PartialOutputExtractorTests {
+
+    private val extractor = PartialOutputExtractor()
+
+    // MARK: - Empty / pre-JSON
+
+    @Test
+    fun emptyBufferYieldsEmptySnapshot() {
+        assertEquals(PartialSnapshot.empty, extractor.extract(""))
+    }
+
+    @Test
+    fun bufferWithoutOpenBraceYieldsEmpty() {
+        assertEquals(PartialSnapshot.empty, extractor.extract("Sure! Here is the JSON:"))
+    }
+
+    @Test
+    fun bufferStoppedBeforeOpeningQuoteYieldsEmpty() {
+        // Colon not yet arrived — extractor must wait.
+        assertNull(extractor.extract("""{"statement"""").primary)
+        // Colon arrived but no opening quote — still wait.
+        assertNull(extractor.extract("""{"statement":""").primary)
+    }
+
+    // MARK: - Primary key reveals
+
+    @Test
+    fun primaryRevealsAfterOpeningQuote() {
+        // Opening quote present but no content — primary is empty string, not null.
+        val snap = extractor.extract("""{"statement":"""")
+        assertEquals("", snap.primary)
+    }
+
+    @Test
+    fun primaryRevealsIncrementalText() {
+        val snap = extractor.extract("""{"statement":"Let's coope""")
+        assertEquals("Let's coope", snap.primary)
+        assertNull(snap.thought)
+    }
+
+    @Test
+    fun primaryRevealsCompleteValue() {
+        val snap = extractor.extract("""{"statement":"Let's cooperate."}""")
+        assertEquals("Let's cooperate.", snap.primary)
+    }
+
+    @Test
+    fun allKnownPrimaryKeysResolve() {
+        for (key in PartialOutputExtractor.primaryKeys) {
+            val snap = extractor.extract("""{"$key":"val"}""")
+            assertEquals("val", snap.primary, "primary key $key failed to resolve")
+        }
+    }
+
+    @Test
+    fun reflectNoteStreamsAsPrimary() {
+        // reflect's canonical primary field is `note`; a partial reflect JSON must
+        // yield a live primary snapshot as it types in.
+        val partial = extractor.extract("""{"note":"I should keep quiet abo""")
+        assertEquals("I should keep quiet abo", partial.primary)
+        val complete = extractor.extract("""{"note":"I should keep quiet."}""")
+        assertEquals("I should keep quiet.", complete.primary)
+    }
+
+    // MARK: - Thought
+
+    @Test
+    fun thoughtResolvesAfterPrimary() {
+        val snap = extractor.extract("""{"statement":"hi","inner_thought":"secret"}""")
+        assertEquals("hi", snap.primary)
+        assertEquals("secret", snap.thought)
+    }
+
+    @Test
+    fun thoughtIsNilIfNotYetOpened() {
+        val snap = extractor.extract("""{"statement":"hi"""")
+        assertEquals("hi", snap.primary)
+        assertNull(snap.thought)
+    }
+
+    // MARK: - Phase-specific thought key (#609)
+
+    // The vote phase's private-thought field is `reason`, not `inner_thought`.
+    // The caller passes the schema-derived thought key so the live streaming
+    // THINKING section surfaces the vote reason as it types in (parity with
+    // speak's `inner_thought`).
+    @Test
+    fun reasonThoughtKeyExtractsVoteReason() {
+        val snap = extractor.extract(
+            """{"vote":"Dave","reason":"散歩に行きたい"}""",
+            thoughtKey = "reason",
+        )
+        assertEquals("Dave", snap.primary)
+        assertEquals("散歩に行きたい", snap.thought)
+    }
+
+    @Test
+    fun reasonThoughtStreamsIncrementally() {
+        val snap = extractor.extract(
+            """{"vote":"Dave","reason":"散""",
+            thoughtKey = "reason",
+        )
+        assertEquals("Dave", snap.primary)
+        assertEquals("散", snap.thought)
+    }
+
+    // Default thought key stays `inner_thought` (back-compat): a vote buffer read
+    // with the default key surfaces no thought.
+    @Test
+    fun defaultThoughtKeyIgnoresReason() {
+        val snap = extractor.extract("""{"vote":"Dave","reason":"散歩"}""")
+        assertEquals("Dave", snap.primary)
+        assertNull(snap.thought)
+    }
+
+    // MARK: - Escape handling
+
+    @Test
+    fun escapedQuoteInPrimary() {
+        val snap = extractor.extract("""{"statement":"She said \"hi\""}""")
+        assertEquals("She said \"hi\"", snap.primary)
+    }
+
+    @Test
+    fun escapedBackslashInPrimary() {
+        val snap = extractor.extract("""{"statement":"a\\b"}""")
+        assertEquals("a\\b", snap.primary)
+    }
+
+    @Test
+    fun escapedNewlineInPrimary() {
+        val snap = extractor.extract("""{"statement":"line1\nline2"}""")
+        assertEquals("line1\nline2", snap.primary)
+    }
+
+    @Test
+    fun incompleteEscapeAtEndHoldsBack() {
+        // Buffer ends with a lone backslash — the next char might be `"` (end of
+        // string) or `\\` (literal backslash). Must not emit the `\` yet.
+        val snap = extractor.extract("""{"statement":"x\""")
+        assertEquals("x", snap.primary)
+    }
+
+    @Test
+    fun incompleteUnicodeEscapeHoldsBack() {
+        // \uXXXX needs 4 hex digits — fewer is incomplete.
+        val snap = extractor.extract("""{"statement":"a\u00""")
+        assertEquals("a", snap.primary)
+    }
+
+    @Test
+    fun completeUnicodeEscapeDecodes() {
+        // é is é. The raw-string buffer holds the literal `é` escape
+        // sequence (Kotlin raw strings do not process \u escapes) for the extractor
+        // to decode; the expected value is the decoded character.
+        val snap = extractor.extract("""{"statement":"caf\u00e9"}""")
+        assertEquals("café", snap.primary)
+    }
+
+    @Test
+    fun signedUnicodeEscapeHoldsBack() {
+        // Kotlin's toIntOrNull(16) accepts a leading '-'; Swift's UInt32(_:radix:)
+        // rejects it. The hex-charset guard makes both hold back the incomplete
+        // escape.
+        val snap = extractor.extract("""{"statement":"a\u-0ff""")
+        assertEquals("a", snap.primary)
+    }
+
+    // MARK: - Thinking-tag handling
+
+    @Test
+    fun unclosedChannelThinkingTagHidesEverything() {
+        // While we're inside a thinking tag, no extraction should fire even if `{`
+        // appears later in the tag's content.
+        val snap = extractor.extract("""<|channel>thought\nI'll say {"statement":"hi"}""")
+        assertEquals(PartialSnapshot.empty, snap)
+    }
+
+    @Test
+    fun closedChannelThinkingTagIsStripped() {
+        val buffer = """
+            <|channel>thought
+            reasoning here
+            <channel|>{"statement":"visible"}
+        """.trimIndent()
+        assertEquals("visible", extractor.extract(buffer).primary)
+    }
+
+    @Test
+    fun unclosedThinkTagHidesEverything() {
+        val snap = extractor.extract("""<think>reasoning {"statement":"hi""")
+        assertEquals(PartialSnapshot.empty, snap)
+    }
+
+    // MARK: - Leading garbage
+
+    @Test
+    fun leadingGarbageSkippedUntilBrace() {
+        val snap = extractor.extract("Sure! Here's my response:\n\n{\"statement\":\"OK\"}")
+        assertEquals("OK", snap.primary)
+    }
+}

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/PartialOutputExtractorTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/PartialOutputExtractorTests.kt
@@ -197,6 +197,17 @@ class PartialOutputExtractorTests {
         assertEquals("a", snap.primary)
     }
 
+    @Test
+    fun surrogateUnicodeEscapeHoldsBack() {
+        // A lone surrogate code point (0xD800..0xDFFF) has no scalar value: Swift's
+        // Unicode.Scalar(code) returns nil there, so the Swift original holds back.
+        // GUARD 2 reproduces that — without it, code.toChar() would append a lone
+        // surrogate Char and break parity. (Not in the Swift suite; added to pin the
+        // ported guard under ADR-023 §12 condition-4 perturbation.)
+        val snap = extractor.extract("""{"statement":"a\uD800"}""")
+        assertEquals("a", snap.primary)
+    }
+
     // MARK: - Thinking-tag handling
 
     @Test

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/PromptPlaceholdersTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/PromptPlaceholdersTests.kt
@@ -1,0 +1,27 @@
+package com.pastura.engine
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Pins [PromptPlaceholders.engineSupplied] — the coverage-guard set of
+ * every `{token}` the Engine can inject at run time (#890). The count pin plus
+ * the membership spot-checks make adding or removing an entry go red, keeping
+ * the set authoritative against silent drift.
+ */
+class PromptPlaceholdersTests {
+
+    @Test
+    fun engineSuppliedHasExactlyThirteenEntries() {
+        assertEquals(13, PromptPlaceholders.engineSupplied.size)
+    }
+
+    @Test
+    fun engineSuppliedContainsKnownMembers() {
+        assertTrue(PromptPlaceholders.engineSupplied.contains("scoreboard"))
+        assertTrue(PromptPlaceholders.engineSupplied.contains("relationships"))
+        assertTrue(PromptPlaceholders.engineSupplied.contains("my_whispers"))
+        assertTrue(PromptPlaceholders.engineSupplied.contains("assigned_word"))
+    }
+}

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/RelationshipVerbalizerTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/RelationshipVerbalizerTests.kt
@@ -1,0 +1,77 @@
+package com.pastura.engine
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Parity spec for [RelationshipVerbalizer] — the raw-affinity-matrix → prose
+ * renderer injected into `relationship_update` agent prompts (#910). Mirrors
+ * the Swift `RelationshipVerbalizerTests`; assertions use partial `contains`
+ * matching so future phrasing tweaks don't break on exact wording.
+ */
+class RelationshipVerbalizerTests {
+
+    @Test
+    fun emptyMatrixProducesEmptyString() {
+        assertTrue(RelationshipVerbalizer.summarize(emptyMap(), language = "ja").isEmpty())
+        assertTrue(RelationshipVerbalizer.summarize(emptyMap(), language = "en").isEmpty())
+    }
+
+    @Test
+    fun belowThresholdIsOmitted() {
+        // |1| < mentionThreshold (2), so nothing is verbalized.
+        assertTrue(RelationshipVerbalizer.summarize(mapOf("Bob" to 1), language = "en").isEmpty())
+        assertTrue(RelationshipVerbalizer.summarize(mapOf("Bob" to -1), language = "en").isEmpty())
+        assertTrue(RelationshipVerbalizer.summarize(mapOf("Bob" to 0), language = "ja").isEmpty())
+    }
+
+    @Test
+    fun atThresholdIsMentioned() {
+        // |2| == mentionThreshold, so it surfaces (inclusive boundary).
+        assertTrue(RelationshipVerbalizer.summarize(mapOf("Bob" to 2), language = "en").isNotEmpty())
+        assertTrue(RelationshipVerbalizer.summarize(mapOf("Bob" to -2), language = "en").isNotEmpty())
+    }
+
+    @Test
+    fun positiveScoreReadsAsWarmth() {
+        val en = RelationshipVerbalizer.summarize(mapOf("Bob" to 3), language = "en")
+        assertTrue(en.contains("Bob"))
+        assertTrue(en.contains("warmly"))
+        val ja = RelationshipVerbalizer.summarize(mapOf("Bob" to 3), language = "ja")
+        assertTrue(ja.contains("Bob"))
+        assertTrue(ja.contains("好感"))
+    }
+
+    @Test
+    fun negativeScoreReadsAsWariness() {
+        val en = RelationshipVerbalizer.summarize(mapOf("Ryuji" to -3), language = "en")
+        assertTrue(en.contains("Ryuji"))
+        assertTrue(en.contains("wary"))
+        val ja = RelationshipVerbalizer.summarize(mapOf("Ryuji" to -3), language = "ja")
+        assertTrue(ja.contains("Ryuji"))
+        assertTrue(ja.contains("警戒"))
+    }
+
+    @Test
+    fun mentionsAreSortedByNameForDeterminism() {
+        // Zoe warm (+2), Ada wary (-2). Deterministic output orders by name,
+        // so "Ada" must precede "Zoe" regardless of map iteration order.
+        val summary = RelationshipVerbalizer.summarize(mapOf("Zoe" to 2, "Ada" to -2), language = "en")
+        val adaIndex = summary.indexOf("Ada")
+        val zoeIndex = summary.indexOf("Zoe")
+        assertTrue(adaIndex >= 0 && zoeIndex >= 0)
+        assertTrue(adaIndex < zoeIndex)
+    }
+
+    @Test
+    fun mixesThresholdAndBelowThresholdEntries() {
+        // Only the two notable entries appear; the |1| entry is dropped.
+        val summary = RelationshipVerbalizer.summarize(
+            mapOf("Ada" to 2, "Bob" to 1, "Zoe" to -4),
+            language = "en",
+        )
+        assertTrue(summary.contains("Ada"))
+        assertTrue(summary.contains("Zoe"))
+        assertTrue(!summary.contains("Bob"))
+    }
+}


### PR DESCRIPTION
## Summary

ADR-023 Stage 3 Engine bulk port — **PR-3 (prompt + LLM glue remainder)**, the last cold slice of Wave A (follows PR-1 #1207, PR-2 #1212). Ports 5 standalone Swift units to `shared/engine/commonMain` as Kotlin `internal`, **landed as infra — nothing wired**; Swift originals stay parallel until Stage 5.

| Unit | Kotlin | commonTest |
|---|---|---|
| `PromptPlaceholders` | `object` (13-entry set) | 2 |
| `RelationshipVerbalizer` | `object` (reuses `pickLanguage`) | 7 |
| `ErrorReadability` | `readableDescription(Throwable)` | 3 |
| `LanguageDetector` | `interface` (**seam only**; concrete `NLLanguageDetector` stays in Swift App/) | 2 |
| `PartialOutputExtractor` + `PartialSnapshot` | `class` + `data class` | 25 |

Highlights:
- **Regexes duplicated** from `JSONResponseParser.kt` (`[\s\S]`, since `RegexOption.DOT_MATCHES_ALL` is JVM/Native-only) — mirrors the Swift original's own two-copy structure, carries a cross-ref "do NOT DRY-merge" comment.
- **Two cross-language parity gaps closed** in `PartialOutputExtractor` vs a naive port: a hex-charset guard rejecting a signed/garbage `\u` slot that `toIntOrNull(16)` would accept but Swift `UInt32(_:radix:)` rejects; and a surrogate-range holdback mirroring Swift `Unicode.Scalar(code) == nil`.
- **Doc-only reconciliation**: the "Stage-3 freight / no slice consumer" absence-table rows for these 5 units in `JSONResponseParser.kt` / `LLMCaller.kt` / `PromptBuilder.kt` / `SimulationEngine.kt` reworded to "landed PR-3; consumer wiring deferred to Wave B" (SimulationEngine mirrors PR-2's EngineLogger-seam precedent). `LLMCaller` L239 `TODO(#501)` preserved.
- Port-ledger untouched (PORT rows keep blank `kotlin_target` — a target reds `check-adr023-port-coverage.py`).

Pre-impl critic (Opus): no Critical, 2 Warnings folded in. code-reviewer (Opus): PASS.

## Test plan

- `./gradlew :shared:engine:compileCommonMainKotlinMetadata` — green (catches the commonMain-stdlib trap).
- `./gradlew :shared:models:jvmTest :shared:engine:jvmTest` — **519 tests, 0 failures/0 errors**.
- §12 condition-4 perturbation battery recorded on #501 (`issuecomment-5040235721`): each targeted injection reds only its named sibling suite (bystander 0); comment-only negative control stays green.

## Device QA

実機QA不要 — Kotlin `shared/**` only; no iOS runtime surface, no Swift compilation change (the iOS app does not consume the framework yet — Phase 3.0-gated).

Closes #1215
Part of #501