### PR TITLE
✨ feat: highlight-share reaction signal after event_inject/vote (#1109)

### DIFF
--- a/Pastura/Pastura/App/HighlightCandidateLogic.swift
+++ b/Pastura/Pastura/App/HighlightCandidateLogic.swift
@@ -31,9 +31,10 @@ nonisolated enum HighlightReason: Equatable, Sendable {
 ///
 /// The ViewModel owns transcript assembly and card construction; this enum
 /// owns the single decision: given the run's ordered agent-output entries
-/// plus the two zero-inference signals (contradiction badges, prediction
-/// reveal), which entries — in what order, capped — become share candidates
-/// and why. Kept `nonisolated` and dependency-free (Foundation + the Models
+/// plus the three zero-inference signals (contradiction badges, prediction
+/// reveal, post-event reaction), which entries — in what order, capped —
+/// become share candidates and why. Kept `nonisolated` and dependency-free
+/// (Foundation + the Models
 /// `PhaseType` only, never the App-layer `LogEntry`) so it unit-tests off
 /// the MainActor without rendering a View (ADR-009 /
 /// `.claude/rules/view-testing.md`).
@@ -166,7 +167,11 @@ nonisolated enum HighlightCandidateLogic {
     }
 
     // Restore transcript order across both tiers so the section reads
-    // chronologically regardless of which tier surfaced each pick.
+    // chronologically regardless of which tier surfaced each pick. The
+    // `uniquingKeysWith` and `?? 0` are belt-and-suspenders: every selection
+    // id originates from a distinct `entries` element (entry ids are unique
+    // `LogEntry` ids), so no key collides and no lookup misses — the fallbacks
+    // just keep the sort total rather than trapping on a degenerate input.
     let position = Dictionary(
       entries.enumerated().map { ($1.id, $0) }, uniquingKeysWith: { first, _ in first })
     return result.sorted { (position[$0.id] ?? 0) < (position[$1.id] ?? 0) }

--- a/Pastura/Pastura/App/HighlightCandidateLogic.swift
+++ b/Pastura/Pastura/App/HighlightCandidateLogic.swift
@@ -18,6 +18,12 @@ nonisolated enum HighlightReason: Equatable, Sendable {
   /// (🎯, #915). Surfaced whether or not the viewer guessed correctly: the
   /// reveal itself is the shareable moment.
   case revealed
+  /// The agent's first speak-phase utterance right after the game situation
+  /// shifted — an `event_inject` firing or a `vote` reveal (💥, #1109). A
+  /// positional zero-inference signal: the first to speak once "the room
+  /// moved". Weaker than `.contradiction` / `.revealed` (positional, not a
+  /// verified fact), so it is de-dup-superseded by either (see `candidates`).
+  case reaction
 }
 
 /// Pure selection logic for automatic share-highlight candidates (#1070

--- a/Pastura/Pastura/App/HighlightCandidateLogic.swift
+++ b/Pastura/Pastura/App/HighlightCandidateLogic.swift
@@ -49,12 +49,51 @@ nonisolated enum HighlightCandidateLogic {
     /// Whether this entry carries a 🃏 contradiction badge
     /// (`SimulationViewModel.contradictionBadgedEntryIDs`).
     let isContradiction: Bool
+    /// Whether this entry is the first speak-phase reaction after an event
+    /// boundary (💥, #1109), as pre-computed by `reactionEntryIDs`. Defaulted
+    /// so Stage-2 call sites that predate the signal stay source-compatible.
+    let isReaction: Bool
+
+    init(
+      id: UUID,
+      agent: String,
+      phaseType: PhaseType,
+      isContradiction: Bool,
+      isReaction: Bool = false
+    ) {
+      self.id = id
+      self.agent = agent
+      self.phaseType = phaseType
+      self.isContradiction = isContradiction
+      self.isReaction = isReaction
+    }
   }
 
   /// One selected candidate: the source entry id and why it was surfaced.
   nonisolated struct Selection: Equatable, Sendable {
     let id: UUID
     let reason: HighlightReason
+  }
+
+  /// An ordered projection of the run transcript for reaction correlation
+  /// (💥, #1109): either an agent output (tagged with its phase) or a
+  /// "context reset" boundary. The ViewModel builds this from the same single
+  /// filtered `logEntries` walk that produces the `Entry` descriptors.
+  ///
+  /// `nonisolated` for the same reason as `Entry` / `Selection` (swift-isolation
+  /// Pattern 5): `reactionEntryIDs` runs off the MainActor and needs the
+  /// auto-synthesized `Equatable` conformance lookup released.
+  nonisolated enum ReactionItem: Equatable, Sendable {
+    /// An agent output in transcript order — the same entries projected to
+    /// `Entry` — carrying its phase so a reaction can require a speak phase.
+    case output(id: UUID, phaseType: PhaseType)
+    /// "The room moved": an `event_inject` that actually fired (non-nil event)
+    /// or a `vote` reveal. Arms the next speak output as a reaction.
+    case eventBoundary
+    /// A round start — closes the same-round window so a tail-of-round event
+    /// (typically `vote`) never mis-correlates to the next round's opening
+    /// speak.
+    case roundBoundary
   }
 
   /// Default cap on surfaced candidates — keeps the end-of-run section from
@@ -64,6 +103,9 @@ nonisolated enum HighlightCandidateLogic {
   /// Selects share-highlight candidates from `entries` (agent outputs in
   /// transcript order).
   ///
+  /// Two-tier selection (#1109). Tier 1 is the verified/ground-truth signals,
+  /// tier 2 the weaker positional one:
+  ///
   /// - Contradiction: every entry with `isContradiction == true` becomes a
   ///   candidate (reason `.contradiction`).
   /// - Reveal: when `actualAgent` is non-nil (a prediction was scored this
@@ -71,13 +113,20 @@ nonisolated enum HighlightCandidateLogic {
   ///   (reason `.revealed`). Speak phases are `.speakAll` / `.speakEach` —
   ///   the phases whose primary output is a public statement worth quoting;
   ///   an agent that only voted (or never spoke) yields no reveal candidate.
+  /// - Reaction: every entry with `isReaction == true` (pre-computed by
+  ///   `reactionEntryIDs`) can become a candidate (reason `.reaction`), but
+  ///   **only fills slots the tier-1 signals left free** — it never displaces
+  ///   a contradiction or reveal.
   ///
-  /// De-dup is by entry id with contradiction winning: if the reveal entry
-  /// is already a contradiction candidate it keeps the `.contradiction`
-  /// reason (the stronger signal) rather than appearing twice. Output stays
-  /// in transcript order and is capped at `limit`; because contradictions
-  /// are emitted in order and the reveal is chronologically the agent's last
-  /// statement, a run with `limit` contradictions can evict the reveal.
+  /// De-dup is by entry id with the stronger signal winning: a reveal or
+  /// reaction entry already chosen as a contradiction keeps `.contradiction`;
+  /// a reaction entry already chosen as a reveal keeps `.revealed`. Output is
+  /// capped at `limit` and finally sorted into transcript order.
+  ///
+  /// The tier-1 pass is kept **byte-identical to Stage 2** (transcript order,
+  /// contradiction-wins de-dup, inline cap-break): a run with no reactions
+  /// therefore produces exactly the Stage-2 result. This makes the "identical
+  /// to today" guarantee structural, not test-dependent (#1109 critic).
   static func candidates(
     entries: [Entry],
     actualAgent: String?,
@@ -88,6 +137,7 @@ nonisolated enum HighlightCandidateLogic {
       entries.last { $0.agent == agent && isSpeakPhase($0.phaseType) }?.id
     }
 
+    // Tier 1 — contradiction + reveal, verbatim from Stage 2.
     var result: [Selection] = []
     for entry in entries {
       let reason: HighlightReason?
@@ -102,7 +152,53 @@ nonisolated enum HighlightCandidateLogic {
       result.append(Selection(id: entry.id, reason: reason))
       if result.count >= limit { break }
     }
-    return result
+
+    // Tier 2 — reaction fills only the remaining budget, in transcript order,
+    // skipping entries already chosen by a stronger signal. Capping by the
+    // *leftover* slots is what prevents the weakest positional signal from
+    // evicting a verified contradiction / ground-truth reveal.
+    if result.count < limit {
+      let chosen = Set(result.map(\.id))
+      for entry in entries where entry.isReaction && !chosen.contains(entry.id) {
+        result.append(Selection(id: entry.id, reason: .reaction))
+        if result.count >= limit { break }
+      }
+    }
+
+    // Restore transcript order across both tiers so the section reads
+    // chronologically regardless of which tier surfaced each pick.
+    let position = Dictionary(
+      entries.enumerated().map { ($1.id, $0) }, uniquingKeysWith: { first, _ in first })
+    return result.sorted { (position[$0.id] ?? 0) < (position[$1.id] ?? 0) }
+  }
+
+  /// The ids of the entries that are "reactions" (💥, #1109) — the first
+  /// speak-phase output after each event boundary, bounded to the same round.
+  ///
+  /// Walks `items` in transcript order: an `.eventBoundary` arms a pending
+  /// reaction; the first following speak-phase `.output` consumes it (its id
+  /// joins the set, one reaction per boundary); a `.roundBoundary` disarms
+  /// without consuming (the event's same-round window closed). Non-speak
+  /// outputs are skipped without disarming, so a skipped first speaker
+  /// (ADR-021 — no `.output` emitted) naturally shifts the reaction to the
+  /// next agent who actually speaks. Deterministic: same transcript ⇒ same ids.
+  static func reactionEntryIDs(_ items: [ReactionItem]) -> Set<UUID> {
+    var ids: Set<UUID> = []
+    var armed = false
+    for item in items {
+      switch item {
+      case .eventBoundary:
+        armed = true
+      case .roundBoundary:
+        armed = false
+      case .output(let id, let phaseType):
+        if armed, isSpeakPhase(phaseType) {
+          ids.insert(id)
+          armed = false
+        }
+      }
+    }
+    return ids
   }
 
   /// The speak phases whose primary output is a public statement worth

--- a/Pastura/Pastura/App/SimulationViewModel.swift
+++ b/Pastura/Pastura/App/SimulationViewModel.swift
@@ -658,23 +658,50 @@ final class SimulationViewModel {  // swiftlint:disable:this type_body_length
   /// highlight" section — derived, not stored. Projects the live transcript
   /// to `HighlightCandidateLogic` descriptors (only entries whose primary
   /// text is non-empty, so a shown card can never dead-tap the failable
-  /// `HighlightShareCard.Model` init), applies the two zero-inference signals
-  /// (contradiction badges, prediction reveal), and rehydrates the selected
-  /// ids back into full candidates carrying the filtered `TurnOutput`. Reads
-  /// only `@Observable` state (`logEntries`, `contradictionBadgedEntryIDs`,
-  /// `predictionOutcome`), so the View re-renders when the run completes.
+  /// `HighlightShareCard.Model` init), applies the three zero-inference
+  /// signals (contradiction badges, prediction reveal, post-event reaction),
+  /// and rehydrates the selected ids back into full candidates carrying the
+  /// filtered `TurnOutput`. Reads only `@Observable` state (`logEntries`,
+  /// `contradictionBadgedEntryIDs`, `predictionOutcome`), so the View
+  /// re-renders when the run completes.
+  ///
+  /// The reaction signal (#1109) needs the event/round *boundaries*
+  /// interleaved with the outputs, so the same single walk also builds a
+  /// `[ReactionItem]` stream. Both projections gate an output on the **same**
+  /// non-empty-primary predicate, so a reaction id can never point at an entry
+  /// the descriptor list filtered out.
   var highlightCandidates: [HighlightCandidate] {
-    var descriptors: [HighlightCandidateLogic.Entry] = []
+    var outputEntries: [LogEntry] = []
+    var reactionItems: [HighlightCandidateLogic.ReactionItem] = []
     var entryByID: [UUID: LogEntry] = [:]
     for entry in logEntries {
-      guard case .agentOutput(let agent, let output, let phaseType) = entry.kind,
-        let primary = output.primaryText(for: phaseType), !primary.isEmpty
-      else { continue }
-      descriptors.append(
-        HighlightCandidateLogic.Entry(
-          id: entry.id, agent: agent, phaseType: phaseType,
-          isContradiction: contradictionBadgedEntryIDs.contains(entry.id)))
-      entryByID[entry.id] = entry
+      switch entry.kind {
+      case .agentOutput(_, let output, let phaseType):
+        guard let primary = output.primaryText(for: phaseType), !primary.isEmpty
+        else { continue }
+        outputEntries.append(entry)
+        reactionItems.append(.output(id: entry.id, phaseType: phaseType))
+        entryByID[entry.id] = entry
+      case .eventInjected(let event):
+        // Only a *fired* event moves the room. `.eventInjected(nil)` is the
+        // probability roll missing — still logged (a muted "no event" line),
+        // but nothing turned, so it must not arm a reaction (#1109).
+        if event != nil { reactionItems.append(.eventBoundary) }
+      case .voteResults:
+        reactionItems.append(.eventBoundary)
+      case .roundStarted:
+        reactionItems.append(.roundBoundary)
+      default:
+        break
+      }
+    }
+    let reactionIDs = HighlightCandidateLogic.reactionEntryIDs(reactionItems)
+    let descriptors: [HighlightCandidateLogic.Entry] = outputEntries.compactMap { entry in
+      guard case .agentOutput(let agent, _, let phaseType) = entry.kind else { return nil }
+      return HighlightCandidateLogic.Entry(
+        id: entry.id, agent: agent, phaseType: phaseType,
+        isContradiction: contradictionBadgedEntryIDs.contains(entry.id),
+        isReaction: reactionIDs.contains(entry.id))
     }
     let selections = HighlightCandidateLogic.candidates(
       entries: descriptors, actualAgent: predictionOutcome?.actualAgent)

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -7393,6 +7393,16 @@
         }
       }
     },
+    "Turning point" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "場が動いた"
+          }
+        }
+      }
+    },
     "Turns skipped ×%lld" : {
       "localizations" : {
         "ja" : {

--- a/Pastura/Pastura/Views/Simulation/HighlightCandidatesSection.swift
+++ b/Pastura/Pastura/Views/Simulation/HighlightCandidatesSection.swift
@@ -103,6 +103,11 @@ struct HighlightCandidatesSection: View {
         word = String(localized: "Revealed")
         background = Color.mossSoft
         textColor = Color.mossDark
+      case .reaction:
+        emoji = "💥"
+        word = String(localized: "Turning point")
+        background = Color.infoSoft
+        textColor = Color.infoInk
       }
     }
   }
@@ -126,7 +131,15 @@ struct HighlightCandidatesSection: View {
           "statement": "Everyone calm down. I think Alice is the suspicious one here."
         ]),
         phaseType: .speakAll,
-        reason: .revealed)
+        reason: .revealed),
+      HighlightCandidate(
+        id: UUID(),
+        agent: "Alice",
+        output: TurnOutput(fields: [
+          "statement": "Wait — if the storm just hit, we should regroup now."
+        ]),
+        phaseType: .speakAll,
+        reason: .reaction)
     ],
     onShare: { _ in }
   )

--- a/Pastura/PasturaTests/App/HighlightCandidateLogicTests.swift
+++ b/Pastura/PasturaTests/App/HighlightCandidateLogicTests.swift
@@ -25,10 +25,12 @@ struct HighlightCandidateLogicTests {
     _ agent: String,
     _ phaseType: PhaseType = .speakAll,
     contradiction: Bool = false,
+    reaction: Bool = false,
     id: UUID = UUID()
   ) -> HighlightCandidateLogic.Entry {
     HighlightCandidateLogic.Entry(
-      id: id, agent: agent, phaseType: phaseType, isContradiction: contradiction)
+      id: id, agent: agent, phaseType: phaseType,
+      isContradiction: contradiction, isReaction: reaction)
   }
 
   // MARK: Contradiction signal
@@ -123,5 +125,149 @@ struct HighlightCandidateLogicTests {
       entries: [earlyCon, wolfSpeak, lateCon], actualAgent: "Wolf")
     #expect(result.map(\.id) == [earlyCon.id, wolfSpeak.id, lateCon.id])
     #expect(result.map(\.reason) == [.contradiction, .revealed, .contradiction])
+  }
+
+  /// Characterization guard (#1109 critic): tier-1 stays transcript-ordered,
+  /// NOT priority-first. A reveal positioned before later contradictions must
+  /// survive the cap — a priority-first refactor (all contradictions, then
+  /// reveal) would evict it, and no other test catches that regression.
+  @Test func revealSurvivesMidStreamWhenLaterContradictionsWouldFillCap() {
+    let conEarly = entry("A", contradiction: true)
+    let wolfSpeak = entry("Wolf")  // reveal, positionally before later cons
+    let conMid = entry("B", contradiction: true)
+    let conLate = entry("C", contradiction: true)
+    let result = HighlightCandidateLogic.candidates(
+      entries: [conEarly, wolfSpeak, conMid, conLate], actualAgent: "Wolf", limit: 3)
+    #expect(
+      result == [
+        .init(id: conEarly.id, reason: .contradiction),
+        .init(id: wolfSpeak.id, reason: .revealed),
+        .init(id: conMid.id, reason: .contradiction)
+      ])
+  }
+
+  // MARK: Reaction correlation (reactionEntryIDs)
+
+  @Test func reactionIsFirstSpeakOutputAfterEventBoundary() {
+    let speak = UUID()
+    let ids = HighlightCandidateLogic.reactionEntryIDs([
+      .eventBoundary,
+      .output(id: speak, phaseType: .speakAll)
+    ])
+    #expect(ids == [speak])
+  }
+
+  @Test func onlyTheFirstSpeakAfterABoundaryReacts() {
+    let first = UUID()
+    let second = UUID()
+    let ids = HighlightCandidateLogic.reactionEntryIDs([
+      .eventBoundary,
+      .output(id: first, phaseType: .speakEach),
+      .output(id: second, phaseType: .speakEach)
+    ])
+    #expect(ids == [first])
+  }
+
+  @Test func nonSpeakOutputIsSkippedWithoutDisarming() {
+    let voteOut = UUID()
+    let speak = UUID()
+    let ids = HighlightCandidateLogic.reactionEntryIDs([
+      .eventBoundary,
+      .output(id: voteOut, phaseType: .vote),  // non-speak: skipped, stays armed
+      .output(id: speak, phaseType: .speakAll)
+    ])
+    #expect(ids == [speak])
+  }
+
+  @Test func roundBoundaryClosesWindowSoTailEventDoesNotReachNextRound() {
+    // A vote reveal at a round's tail, followed by the next round's opening
+    // speak: the round boundary must close the window so it does not react.
+    let nextRoundSpeak = UUID()
+    let ids = HighlightCandidateLogic.reactionEntryIDs([
+      .eventBoundary,
+      .roundBoundary,
+      .output(id: nextRoundSpeak, phaseType: .speakAll)
+    ])
+    #expect(ids.isEmpty)
+  }
+
+  @Test func noEventBoundaryYieldsNoReactions() {
+    let ids = HighlightCandidateLogic.reactionEntryIDs([
+      .output(id: UUID(), phaseType: .speakAll),
+      .roundBoundary,
+      .output(id: UUID(), phaseType: .speakEach)
+    ])
+    #expect(ids.isEmpty)
+  }
+
+  @Test func eachEventBoundaryGetsItsOwnFirstReaction() {
+    let firstReact = UUID()
+    let secondReact = UUID()
+    let ids = HighlightCandidateLogic.reactionEntryIDs([
+      .eventBoundary,
+      .output(id: firstReact, phaseType: .speakEach),
+      .roundBoundary,
+      .eventBoundary,
+      .output(id: secondReact, phaseType: .speakAll)
+    ])
+    #expect(ids == [firstReact, secondReact])
+  }
+
+  @Test func skippedFirstSpeakerShiftsReactionToNextActualSpeaker() {
+    // The agent who would speak first after the event was skipped (ADR-021):
+    // a skipped turn emits no `.output`, so the first output present is the
+    // next agent who actually spoke, and that becomes the reaction.
+    let bobSpeak = UUID()
+    let ids = HighlightCandidateLogic.reactionEntryIDs([
+      .eventBoundary,
+      .output(id: bobSpeak, phaseType: .speakEach)  // Alice skipped ⇒ absent
+    ])
+    #expect(ids == [bobSpeak])
+  }
+
+  // MARK: Reaction tier (fills only remaining slots)
+
+  @Test func reactionFillsSlotLeftFreeByStrongerSignals() {
+    let con = entry("Alice", contradiction: true)
+    let react = entry("Bob", reaction: true)
+    let result = HighlightCandidateLogic.candidates(
+      entries: [con, react], actualAgent: nil)
+    #expect(
+      result == [
+        .init(id: con.id, reason: .contradiction),
+        .init(id: react.id, reason: .reaction)
+      ])
+  }
+
+  @Test func reactionEntryThatIsAlsoContradictionKeepsContradiction() {
+    let both = entry("Alice", contradiction: true, reaction: true)
+    let result = HighlightCandidateLogic.candidates(
+      entries: [both], actualAgent: nil)
+    #expect(result == [.init(id: both.id, reason: .contradiction)])
+  }
+
+  @Test func reactionDoesNotEvictStrongerSignalsWhenCapFilledByTier1() {
+    let conA = entry("A", contradiction: true)
+    let conB = entry("B", contradiction: true)
+    let conC = entry("C", contradiction: true)
+    let react = entry("D", reaction: true)  // no free slot left → dropped
+    let result = HighlightCandidateLogic.candidates(
+      entries: [conA, conB, conC, react], actualAgent: nil, limit: 3)
+    #expect(result.map(\.id) == [conA.id, conB.id, conC.id])
+    #expect(result.allSatisfy { $0.reason == .contradiction })
+  }
+
+  @Test func reactionSelectedInTier2IsSortedBackIntoTranscriptOrder() {
+    let react = entry("Alice", reaction: true)  // position 0
+    let con = entry("Bob", contradiction: true)  // position 1
+    let result = HighlightCandidateLogic.candidates(
+      entries: [react, con], actualAgent: nil)
+    // con is chosen first (tier 1), react second (tier 2), but the final
+    // output restores transcript order: react (pos 0) precedes con (pos 1).
+    #expect(
+      result == [
+        .init(id: react.id, reason: .reaction),
+        .init(id: con.id, reason: .contradiction)
+      ])
   }
 }

--- a/Pastura/PasturaTests/App/SimulationViewModelHighlightsTests.swift
+++ b/Pastura/PasturaTests/App/SimulationViewModelHighlightsTests.swift
@@ -73,6 +73,13 @@ struct SimulationViewModelHighlightsTests {
   private let choosePhaseCompleted = SimulationEvent.phaseCompleted(
     phaseType: .choose, phasePath: [1])
 
+  private func speak(_ agent: String, _ text: String) -> SimulationEvent {
+    .agentOutput(
+      agent: agent,
+      output: TurnOutput(fields: ["statement": text]),
+      phaseType: .speakAll)
+  }
+
   /// Drives Alice into a full declaration/action contradiction; Bob stays
   /// consistent. `statement` lets a caller blank Alice's public statement.
   private func runAliceContradiction(
@@ -127,5 +134,73 @@ struct SimulationViewModelHighlightsTests {
     sut.handleEvent(choosePhaseCompleted, scenario: scenario)
 
     #expect(sut.highlightCandidates.isEmpty)
+  }
+
+  // MARK: Reaction signal (#1109)
+
+  @Test func eventInjectReactionSurfacesFirstSpeakerAfter() throws {
+    let sut = try makeSut()
+    let scenario = makeScenario()
+    sut.handleEvent(.roundStarted(round: 1, totalRounds: 1), scenario: scenario)
+    sut.handleEvent(.eventInjected(event: "A storm hits the camp."), scenario: scenario)
+    sut.handleEvent(speak("Alice", "We must regroup now!"), scenario: scenario)
+    sut.handleEvent(speak("Bob", "Everyone stay calm."), scenario: scenario)
+
+    let candidates = sut.highlightCandidates
+    #expect(candidates.count == 1)
+    let candidate = try #require(candidates.first)
+    #expect(candidate.agent == "Alice")  // only the FIRST post-event speaker
+    #expect(candidate.reason == .reaction)
+    #expect(candidate.previewText == "We must regroup now!")
+  }
+
+  @Test func eventInjectMissDoesNotSurfaceReaction() throws {
+    // `.eventInjected(nil)` = probability roll missed: logged but not a turning
+    // point, so the following speak is an ordinary utterance, not a reaction.
+    let sut = try makeSut()
+    let scenario = makeScenario()
+    sut.handleEvent(.roundStarted(round: 1, totalRounds: 1), scenario: scenario)
+    sut.handleEvent(.eventInjected(event: nil), scenario: scenario)
+    sut.handleEvent(speak("Alice", "Just another quiet turn."), scenario: scenario)
+
+    #expect(sut.highlightCandidates.isEmpty)
+  }
+
+  @Test func voteResultsReactionSurfacesSameRoundSpeaker() throws {
+    // A same-round speak after a vote reveal (a defense / parting line) reacts.
+    let sut = try makeSut()
+    let scenario = makeScenario()
+    sut.handleEvent(.roundStarted(round: 1, totalRounds: 1), scenario: scenario)
+    sut.handleEvent(
+      .voteResults(votes: ["Alice": "Bob"], tallies: ["Bob": 1]), scenario: scenario)
+    sut.handleEvent(speak("Bob", "You'll regret voting me out."), scenario: scenario)
+
+    let candidates = sut.highlightCandidates
+    #expect(candidates.count == 1)
+    #expect(candidates.first?.agent == "Bob")
+    #expect(candidates.first?.reason == .reaction)
+  }
+
+  @Test func contradictionOutranksReactionOnTheSameEntry() throws {
+    // Alice's declaration is BOTH the first post-event speaker (reaction) and a
+    // contradiction; the stronger signal wins and the entry surfaces once.
+    let sut = try makeSut()
+    let scenario = makeScenario()
+    sut.handleEvent(.roundStarted(round: 1, totalRounds: 1), scenario: scenario)
+    sut.handleEvent(.eventInjected(event: "A storm hits the camp."), scenario: scenario)
+    sut.handleEvent(
+      declaration("Alice", "cooperate", statement: "Trust me, I'm loyal."),
+      scenario: scenario)
+    sut.handleEvent(declaration("Bob", "cooperate"), scenario: scenario)
+    sut.handleEvent(chooseAction("Alice", "betray"), scenario: scenario)
+    sut.handleEvent(chooseAction("Bob", "cooperate"), scenario: scenario)
+    sut.handleEvent(chooseAction("Alice", "betray"), scenario: scenario)
+    sut.handleEvent(chooseAction("Bob", "cooperate"), scenario: scenario)
+    sut.handleEvent(choosePhaseCompleted, scenario: scenario)
+
+    let candidates = sut.highlightCandidates
+    #expect(candidates.count == 1)
+    #expect(candidates.first?.agent == "Alice")
+    #expect(candidates.first?.reason == .contradiction)
   }
 }


### PR DESCRIPTION
## Summary

Adds the **third** zero-inference share-highlight signal (Stage 3 of #1070) — 💥 **reaction**: the first speak-phase agent utterance right after the game situation shifts (`event_inject` firing or a `vote` reveal). Follows 🃏 contradiction (#916) and 🎯 revealed (#915). Engine diff is zero; App/Views-only; deterministic (same transcript ⇒ same candidates).

Part of #1069 (Growth track A-1). Closes #1109.

### Design (settled with a Fable second-opinion + `claude-kit:critic`)

- **Correlation** (`HighlightCandidateLogic.reactionEntryIDs`): the first speak-phase output after an event boundary, bounded to the **same round** — the search closes at the next event boundary *or* `roundStarted`, so a tail-of-round `vote` never mis-correlates to the next round's opening speak. One reaction per boundary; non-speak outputs are skipped without disarming (a skipped first speaker, ADR-021, shifts the reaction to the next real speaker).
- **`.eventInjected(nil)` excluded** — a probability-roll *miss* is still logged (a muted "no event" line) but nothing turned, so it must not arm a reaction. Guarded in the VM projection with a why-comment + a dedicated non-firing test (the pure-logic tests can't reach this branch).
- **Priority** 🃏 > 🎯 > 💥: `candidates()` is restructured into two tiers — tier-1 (contradiction+reveal) is kept **byte-identical to Stage 2** (transcript order, contradiction-wins de-dup, inline cap-break), then reaction fills only the leftover cap budget, then the merged picks are sorted back into transcript order. So the weakest positional signal can never evict a verified contradiction / ground-truth reveal, and a no-reaction run reproduces the Stage-2 result *structurally* (a characterization test pins tier-1 stays transcript-ordered, not priority-first).
- **Trigger scope**: `event_inject` **and** `vote` are both wired. `vote`-triggered reactions are **dormant** on every shipped preset today (no preset has a same-round speak after `vote` — word_wolf: vote→eliminate; last_fable: vote→relationship_update→eliminate), but the behavior is deterministic + test-covered, so a future gallery scenario with a post-vote speech fires it correctly with no further code.
- **Chip**: 💥 「場が動いた」/ "Turning point", `infoSoft`/`infoInk` (blue-grey), alongside 🃏/🎯.

## Test plan

- `HighlightCandidateLogicTests` (+12): reaction correlation (same-round bound, per-boundary reset, non-speak skip, skipped-first-speaker), tier-2 fill, priority overlap, cap-eviction-cannot-drop-a-stronger-signal, and a characterization test that tier-1 stays transcript-ordered.
- `SimulationViewModelHighlightsTests` (+4): event_inject reaction fires on the first speaker; `.eventInjected(nil)` does **not** fire; a vote same-round speak reacts; contradiction outranks reaction on a shared entry.
- Full unit suite green (3187 tests / 261 suites); `swiftlint --strict` clean; `check_localization_coverage.py` passing.

## Device QA

軽微。終了画面の "Share a highlight" セクションに 💥「場が動いた」チップが 🃏🎯 と並んで表示されること — シミュレータで確認可。`event_inject` を含むシナリオ（word_wolf / last_fable）完走で、イベント直後の最初の発言に 💥 が付く。カラートークンは静的 sRGB のため dark mode は実機で一瞥推奨（レイアウトはシミュレータで十分）。
