### PR TITLE
🧹 chore: Kotlin PhaseContext turn-failure gate (ADR-023 Stage3 B0a)

### DIFF
--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/PhaseHandler.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/PhaseHandler.kt
@@ -31,17 +31,17 @@ import com.pastura.models.SimulationState
  *   so [PhaseHandler.execute] returns the next state rather than mutating in
  *   place (the #1063 Stage-2-pre precedent).
  *
- * ## Knowingly absent from this gate slice
+ * ## Knowingly absent — remaining named deferrals
  *
- * Each is a *named* deferral, tracked on #501 — not a silent field drop:
+ * Each is a *named* deferral, tracked on #501 — not a silent field drop. (The
+ * ADR-021 `turnGate` was one of these on the Stage-2 slice; B0a restored it, so
+ * it is now a field below rather than an absence.)
  *
- * - **`turnGate`** (ADR-021 `TurnFailureGate`) — a turn-degradable LLM failure
- *   aborts the run here instead of skipping the agent's turn. Pulling it in would
- *   also pull `turnSkipped` + `turnFailureLimitReached` onto the slice path.
  * - **`detector`** (`LanguageDetector`) — ADR-010 Step E language-adherence retry
- *   is named Stage-3 freight in ADR-023 §6.
- * - **`logger`** (`EngineLogger`, the #501 S0.2 seam) — nothing in the slice logs;
- *   the Kotlin engine has no OSLog to keep out.
+ *   is named Stage-3 freight in ADR-023 §6; lands in B0b with its `LLMCaller`
+ *   consumer.
+ * - **`logger`** (`EngineLogger`, the #501 S0.2 seam) — nothing consumes it until
+ *   `LLMCaller` logging lands in B0b (the Kotlin engine has no OSLog to keep out).
  *
  * Swift original: `Pastura/Pastura/Engine/PhaseHandler.swift`.
  * Ported for the ADR-023 §6 Stage-2 gate slice (#501).
@@ -89,6 +89,20 @@ internal class PhaseContext(
      */
     val pauseCheck: suspend (phasePath: List<Int>) -> Unit,
     val phasePath: List<Int>,
+    /**
+     * Run-scoped ADR-021 turn-failure containment. LLM phase handlers route each
+     * agent turn's `LLMCaller.call` through [TurnFailureGate.attempt] so a
+     * turn-degradable failure *skips* that agent's turn (degrade by omission, D2)
+     * while systemic errors, cancellation, and the D4 breaker abort the run.
+     *
+     * **No default — mirrors Swift `PhaseContext`'s `turnGate`, for the same
+     * reason.** The gate carries a run-scoped consecutive-skip counter, so exactly
+     * ONE instance is created per run and shared by every phase's context (the
+     * runner's `RunLoop` does this); a per-context default would silently reset the
+     * counter each phase. Code phases never touch it — the same shape as Swift,
+     * where the code phases ignore it too.
+     */
+    val turnGate: TurnFailureGate,
 )
 
 /**

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/SpeakAllHandler.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/SpeakAllHandler.kt
@@ -11,22 +11,19 @@ import com.pastura.models.SimulationState
  * Each non-eliminated agent generates output via the LLM. Outputs are appended to
  * the conversation log and stored in `lastOutputs` for subsequent phases.
  *
- * ## Scope: the ADR-023 §6 Stage-2 gate slice
+ * A turn-degradable LLM failure is routed through [PhaseContext.turnGate]
+ * (ADR-021 D1/D2): the failing agent's turn is *skipped* — no `AgentOutput`, no
+ * conversation-log entry, and any stale `lastOutputs` entry for that agent is
+ * cleared — while the remaining agents still speak. Systemic errors, cancellation,
+ * and the D4 circuit breaker propagate and abort the run (see [TurnFailureGate]).
  *
- * **`TurnFailureGate` (ADR-021) is deliberately absent** — a named deferral, not a
- * silent drop. Swift routes each per-agent call through `context.turnGate.attempt`
- * so a turn-degradable LLM failure *skips* that agent's turn and the remaining
- * agents still speak (D1/D2). Here a failure propagates and aborts the run.
+ * ## Still absent — later Wave-B / Stage-3 freight
  *
- * Why it stays out: the gate measures boundary ergonomics, and pulling ADR-021 in
- * would drag `turnSkipped` + `SimulationError.turnFailureLimitReached` onto the
- * slice path — neither exists in Kotlin `SimulationEvent` yet — for no measurement
- * benefit. Stage 3 restores it against `SpeakAllHandlerTests`, which ADR-023 §6
- * names as the executable spec.
- *
- * Also absent, per [PromptBuilder]'s absence table: the `inject*` family
- * (assigned / notes / whispers / relationships / mood) and `captureMood`, whose
- * producer phases are all Stage-3 freight.
+ * Per [PromptBuilder]'s absence table the `inject*` family (assigned / notes /
+ * whispers / relationships / mood) and `captureMood` are not called here yet, and
+ * [LLMCaller] is still constructed without the `detector` / `logger` seams. Those
+ * land with their consumers in later Wave-B PRs and are orthogonal to the
+ * turn-gate behavior restored here.
  *
  * Swift original: `Pastura/Pastura/Engine/Phases/SpeakAllHandler.swift`.
  */
@@ -55,8 +52,10 @@ internal class SpeakAllHandler : PhaseHandler {
     }
 
     /**
-     * Run one persona's turn: build the prompt, call the LLM, fold the result into
-     * state.
+     * Run one persona's turn: build the prompt, route the LLM call through
+     * [PhaseContext.turnGate] (ADR-021 D1/D2), and fold the result into state on
+     * success. On a skipped turn, write nothing and clear any stale `lastOutputs`
+     * entry for the agent.
      *
      * Returns the next state — Kotlin [SimulationState] is immutable, so unlike
      * Swift's `inout` the caller MUST use the return value (see [PhaseHandler]).
@@ -86,14 +85,26 @@ internal class SpeakAllHandler : PhaseHandler {
         )
         val userPrompt = promptBuilder.expandTemplate(promptTemplate, variables)
 
-        val output = llmCaller.call(
-            backend = context.backend,
-            system = systemPrompt,
-            user = userPrompt,
-            agentName = persona.name,
-            schema = OutputSchema.from(context.phase),
-            relay = context.suspensionRelay,
+        val output = context.turnGate.attempt(
+            agent = persona.name,
+            phaseType = context.phase.type,
             emitter = context.emitter,
+        ) {
+            llmCaller.call(
+                backend = context.backend,
+                system = systemPrompt,
+                user = userPrompt,
+                agentName = persona.name,
+                schema = OutputSchema.from(context.phase),
+                relay = context.suspensionRelay,
+                emitter = context.emitter,
+            )
+        } ?: return state.copy(
+            // Turn skipped (ADR-021 D2): write nothing, and clear any stale
+            // prior-round output so downstream consumers keyed on `lastOutputs`
+            // don't read a decision that never happened this turn. Matches Swift's
+            // `state.lastOutputs[persona.name] = nil` on the skip path.
+            lastOutputs = state.lastOutputs - persona.name,
         )
 
         context.emitter(

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/SimulationEngine.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/SimulationEngine.kt
@@ -205,6 +205,12 @@ private class RunLoop(
 
     private val dispatcher = PhaseDispatcher()
 
+    // One gate per run: this RunLoop is constructed once per `run()`, so a plain
+    // property makes the gate run-scoped and shared by every phase's PhaseContext,
+    // keeping its ADR-021 D4 consecutive-skip counter run-scoped. See
+    // TurnFailureGate's doc — a fresh gate per phase would silently reset it.
+    private val turnGate = TurnFailureGate()
+
     suspend fun execute() {
         var state = SimulationState.initial(scenario)
 
@@ -267,6 +273,7 @@ private class RunLoop(
                         emitter = onEvent,
                         pauseCheck = { nested -> checkPaused(round, nested) },
                         phasePath = phasePath,
+                        turnGate = turnGate,
                     ),
                     state = state,
                 )

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/PhaseHandlerTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/PhaseHandlerTests.kt
@@ -40,6 +40,7 @@ class PhaseHandlerTests {
         emitter = emitter,
         pauseCheck = pauseCheck,
         phasePath = listOf(0),
+        turnGate = TurnFailureGate(),
     )
 
     /**
@@ -141,6 +142,7 @@ class PhaseHandlerTests {
                 emitter = {},
                 pauseCheck = { },
                 phasePath = listOf(0),
+                turnGate = TurnFailureGate(),
             )
             assertTrue(ctx.suspensionRelay === relay)
         }

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/SpeakAllHandlerTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/SpeakAllHandlerTests.kt
@@ -56,6 +56,7 @@ class SpeakAllHandlerTests {
         emitter = { events += it },
         pauseCheck = { },
         phasePath = listOf(0),
+        turnGate = TurnFailureGate(),
     )
 
     private fun says(text: String) =

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/SpeakAllHandlerTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/SpeakAllHandlerTests.kt
@@ -4,8 +4,10 @@ import com.pastura.models.Persona
 import com.pastura.models.Phase
 import com.pastura.models.PhaseType
 import com.pastura.models.Scenario
+import com.pastura.models.SimulationError
 import com.pastura.models.SimulationEvent
 import com.pastura.models.SimulationState
+import com.pastura.models.TurnOutput
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -15,12 +17,15 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
- * Kotlin sibling of Swift's `SpeakAllHandlerTests`, scoped to the ported subset.
+ * Kotlin sibling of Swift's `SpeakAllHandlerTests` (+ its `…+TurnDegradation`
+ * split), scoped to the ported subset.
  *
- * ADR-021 turn-gate cases are absent because the gate itself is a named deferral
- * (see [SpeakAllHandler]'s doc) — not because they were forgotten.
+ * The ADR-021 turn-gate integration is exercised here (transient-skip and the D4
+ * circuit breaker). The D3 systemic-error case stays deferred — see the note
+ * above those tests — pending the Stage-3 `StreamFailure` taxonomy.
  *
- * Ported for the ADR-023 §6 Stage-2 gate slice (#501).
+ * Ported for the ADR-023 KMP Engine migration (#501); the turn gate is restored
+ * in Wave B (B0a).
  */
 class SpeakAllHandlerTests {
 
@@ -243,21 +248,76 @@ class SpeakAllHandlerTests {
         assertEquals("a", outputs[0].output.fields["statement"])
     }
 
-    // MARK: - Failure propagates (ADR-021 turn gate is a named deferral)
+    // MARK: - Turn degradation (ADR-021 D1/D2/D4)
+
+    // Parity with `SpeakAllHandlerTests+TurnDegradation.swift`. Gate internals
+    // (failure classification, consecutive-count bookkeeping, and the D3
+    // non-degradable rethrow) are covered by [TurnFailureGateTests]; these pin the
+    // HANDLER's integration with the gate.
+    //
+    // D3 (`systemicErrorPropagatesTypedWithoutSkip` in the Swift sibling) is
+    // deliberately NOT ported here: the systemic-vs-transient `StreamFailure`
+    // taxonomy is Stage-3 freight (see [LLMCaller]'s absence table), so every
+    // failure a [ScriptedLLMBackend] can produce maps to the degradable
+    // `LlmGenerationFailed` — there is no non-degradable LLM failure to script yet.
+    // The gate-level non-degradable rethrow is already covered by
+    // [TurnFailureGateTests], and this handler adds no catch, so nothing here could
+    // swallow a systemic error into a skip. Restore this case when the taxonomy
+    // lands (#501).
 
     @Test
-    fun anLlmFailureAbortsTheRunRatherThanSkippingTheTurn() = runTest {
-        // Pins the DEFERRAL, so its restoration in Stage 3 is a deliberate,
-        // test-visible change rather than a silent behaviour shift. Swift routes
-        // this through TurnFailureGate and skips only the failing agent's turn.
-        val s = scenario()
+    fun aTransientFailureSkipsTheTurnAndOtherAgentsStillSpeak() = runTest {
+        // Alice's call fails transiently (turn-degradable); Bob and Charlie speak.
+        val s = scenario(agents = listOf("Alice", "Bob", "Charlie"))
         val backend = ScriptedLLMBackend(
-            listOf(ScriptedLLMBackend.Script(terminal = TerminalStatus.Failed(errorCode = "boom"))),
+            listOf(
+                ScriptedLLMBackend.Script(terminal = TerminalStatus.Failed(errorCode = "transient blip")),
+                says("from Bob"),
+                says("from Charlie"),
+            ),
         )
-        assertFailsWith<SimulationException> {
-            handler.execute(context(s, backend), SimulationState.initial(s))
+        val events = mutableListOf<SimulationEvent>()
+        // Stale prior-round output — must be cleared on skip (ADR-021 D2), not left
+        // readable by later phases.
+        val before = SimulationState.initial(s).copy(
+            currentRound = 1,
+            lastOutputs = mapOf("Alice" to TurnOutput(fields = mapOf("statement" to "stale"))),
+        )
+        val next = handler.execute(context(s, backend, events), before)
+
+        val outputs = events.filterIsInstance<SimulationEvent.AgentOutput>().map { it.agent }
+        assertEquals(listOf("Bob", "Charlie"), outputs, "the failing agent emits no AgentOutput")
+        assertEquals(listOf("Bob", "Charlie"), next.conversationLog.map { it.agentName })
+
+        val skipped = events.filterIsInstance<SimulationEvent.TurnSkipped>()
+        assertEquals(1, skipped.size)
+        assertEquals("Alice", skipped.single().agent)
+        assertEquals(PhaseType.SPEAK_ALL, skipped.single().phaseType)
+
+        // The stale entry is cleared, not left readable by later phases.
+        assertNull(next.lastOutputs["Alice"], "a skipped turn clears the agent's stale lastOutputs")
+        assertEquals("from Bob", next.lastOutputs["Bob"]?.fields?.get("statement"))
+        assertEquals("from Charlie", next.lastOutputs["Charlie"]?.fields?.get("statement"))
+    }
+
+    @Test
+    fun theThirdConsecutiveFailureTripsTheBreakerAndAbortsThePhase() = runTest {
+        // ADR-021 D4: all three personas fail transiently on the shared per-run
+        // gate — skips 1 and 2 emit TurnSkipped, the 3rd trips the breaker instead.
+        val s = scenario(agents = listOf("Alice", "Bob", "Charlie"))
+        val backend = ScriptedLLMBackend(
+            List(3) { ScriptedLLMBackend.Script(terminal = TerminalStatus.Failed(errorCode = "dead backend")) },
+        )
+        val events = mutableListOf<SimulationEvent>()
+
+        val error = assertFailsWith<SimulationException> {
+            handler.execute(context(s, backend, events), SimulationState.initial(s).copy(currentRound = 1))
         }
-        assertEquals(1, backend.callCount, "Bob never speaks — Swift would have let him")
+        assertEquals(SimulationError.TurnFailureLimitReached(consecutiveCount = 3), error.error)
+
+        // The tripping (3rd) failure throws instead of emitting — only 2 skips.
+        val skipped = events.filterIsInstance<SimulationEvent.TurnSkipped>()
+        assertEquals(2, skipped.size)
     }
 
     @Test


### PR DESCRIPTION
## Summary

ADR-023 Stage 3 Wave B — **B0a**: introduce the ADR-021 turn-failure gate into the Kotlin `PhaseContext` and faithfully restore `SpeakAllHandler`, so a turn-degradable LLM failure *skips* the agent's turn instead of aborting the run. This is the seam-enabling PR that unblocks the faithful port of the remaining LLM phase handlers (B1–B6).

- **`PhaseContext` gains `turnGate: TurnFailureGate`** (no-default field, mirroring Swift). The production `SimulationEngine.RunLoop` constructs **one** gate per run and shares it across every phase's context, keeping the ADR-021 D4 consecutive-skip counter run-scoped.
- **`SpeakAllHandler` restored to parity**: each persona's LLM call routes through `context.turnGate.attempt(...)`; on a degradable skip it writes nothing and clears any stale `lastOutputs` entry for the agent (Swift D2), while the remaining agents still speak. The D4 circuit breaker (3 consecutive skips) and systemic errors abort the run.
- **Tests** flip the old abort-pin to a transient-skip parity test (asserting the stale-`lastOutputs` clear) and add the D4 circuit-breaker case, sourced from `SpeakAllHandlerTests+TurnDegradation.swift`.

### Deferred (documented inline)

- **`detector` / `logger` `PhaseContext` fields** → **B0b**, landing with their `LLMCaller` consumer (both defaulted → zero construction-site churn either PR).
- **D3 systemic-error parity case** — the systemic-vs-transient `StreamFailure` taxonomy is Stage-3 freight (per `LLMCaller`'s absence table), so no non-degradable LLM failure is scriptable yet. The gate-level non-degradable rethrow is already covered by `TurnFailureGateTests`, and the handler adds no `catch`.

## Test plan

- `./gradlew :shared:engine:compileCommonMainKotlinMetadata :shared:models:jvmTest :shared:engine:jvmTest` — all green.
- `SpeakAllHandlerTests` = 17 (abort-pin replaced by transient-skip + circuit-breaker); full engine + models jvmTest suites pass, 0 failures.

## Device QA

実機QA不要 — Kotlin shared モジュールのみ（`shared/engine/`）、Swift 無変更。iOS アプリはまだ XCFramework を consume しない（Phase 3.0 gated）ため実機挙動に影響なし。

Closes #1221
Part of #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LrabG4w8JCc6CBms1N5aS9
