### PR TITLE
🧹 chore: port EventInject/ScoreCalc handlers to commonMain (ADR-023 Stage3 CP2)

### DIFF
--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/PhaseDispatcher.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/PhaseDispatcher.kt
@@ -9,9 +9,9 @@ import kotlinx.serialization.serializer
  *
  * ## Scope: the ADR-023 Stage-3 port, in progress
  *
- * **`SPEAK_ALL`, `ELIMINATE`, `SUMMARIZE`, `ASSIGN` and `EVENT_INJECT` are
- * registered.** Swift registers all 14; the remaining 9 are the mechanical bulk
- * of Stage 3 ("mechanical after the Stage-2 slice", §4), ported
+ * **`SPEAK_ALL`, `ELIMINATE`, `SUMMARIZE`, `ASSIGN`, `EVENT_INJECT` and
+ * `SCORE_CALC` are registered.** Swift registers all 14; the remaining 8 are the
+ * mechanical bulk of Stage 3 ("mechanical after the Stage-2 slice", §4), ported
  * handler-by-handler.
  *
  * Unlike Swift's `PhaseDispatcher`, this is **not** exhaustive over [PhaseType] —
@@ -31,6 +31,7 @@ internal class PhaseDispatcher {
         PhaseType.SUMMARIZE to SummarizeHandler(),
         PhaseType.ASSIGN to AssignHandler(),
         PhaseType.EVENT_INJECT to EventInjectHandler(),
+        PhaseType.SCORE_CALC to ScoreCalcHandler(),
     )
 
     /**

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/PhaseDispatcher.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/PhaseDispatcher.kt
@@ -9,9 +9,10 @@ import kotlinx.serialization.serializer
  *
  * ## Scope: the ADR-023 Stage-3 port, in progress
  *
- * **`SPEAK_ALL`, `ELIMINATE`, `SUMMARIZE` and `ASSIGN` are registered.** Swift
- * registers all 14; the remaining 10 are the mechanical bulk of Stage 3
- * ("mechanical after the Stage-2 slice", §4), ported handler-by-handler.
+ * **`SPEAK_ALL`, `ELIMINATE`, `SUMMARIZE`, `ASSIGN` and `EVENT_INJECT` are
+ * registered.** Swift registers all 14; the remaining 9 are the mechanical bulk
+ * of Stage 3 ("mechanical after the Stage-2 slice", §4), ported
+ * handler-by-handler.
  *
  * Unlike Swift's `PhaseDispatcher`, this is **not** exhaustive over [PhaseType] —
  * so an unregistered phase fails at dispatch with a clear error rather than at
@@ -29,6 +30,7 @@ internal class PhaseDispatcher {
         PhaseType.ELIMINATE to EliminateHandler(),
         PhaseType.SUMMARIZE to SummarizeHandler(),
         PhaseType.ASSIGN to AssignHandler(),
+        PhaseType.EVENT_INJECT to EventInjectHandler(),
     )
 
     /**

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/EventInjectHandler.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/EventInjectHandler.kt
@@ -1,0 +1,209 @@
+package com.pastura.engine
+
+import com.pastura.models.AnyCodableValue
+import com.pastura.models.SimulationEvent
+import com.pastura.models.SimulationState
+import kotlin.random.Random
+
+/**
+ * Handles `event_inject` phases — probabilistically injects a random
+ * string from [com.pastura.models.Scenario.extraData] into
+ * [SimulationState.variables].
+ *
+ * Behavior:
+ * - Resolves `Phase.source` against `Scenario.extraData`. The expected
+ *   shape is [AnyCodableValue.ArrayValue] of `String`, or
+ *   [AnyCodableValue.ArrayOfDictionariesValue] of `{ text, favors }` mappings
+ *   (#931) — dict entries additionally write a companion "favored action"
+ *   variable (`<as>__favors`) read by `EventReactivePayoffLogic`. Other shapes
+ *   are surfaced as a [SimulationEvent.Summary] warning so curators can fix the
+ *   YAML; the variable is still written as the empty string so subsequent prompt
+ *   expansion never hits a missing key.
+ * - Rolls `Random.nextDouble() < probability`. Strict `<` against the half-open
+ *   range gives the boundary semantics curators expect: `probability = 0.0`
+ *   never fires, `probability = 1.0` always fires (since `nextDouble()` can
+ *   return 0.0 but never 1.0).
+ * - On miss (roll failed, source missing, or source empty), writes the empty
+ *   string to `state.variables[as]` and emits [SimulationEvent.EventInjected]
+ *   with `event = null`. The empty-string write — rather than leaving the key
+ *   absent — prevents a previous round's value from "ghosting" into the next
+ *   prompt and keeps `PromptBuilder`'s substitution well-defined.
+ * - On hit, picks a random element and writes it to `state.variables[as]`,
+ *   emitting [SimulationEvent.EventInjected] with the chosen text.
+ * - `no_repeat: true` (#1006) draws **without replacement** across the run:
+ *   already-drawn events are tracked per variable in [SimulationState.drawnEvents]
+ *   and the pick is taken from the remainder, resetting to the full pool once
+ *   every entry has been drawn. Default is with-replacement. A miss never
+ *   consumes the pool. Identical-text entries collapse in the drawn `Set`, so a
+ *   curator relying on strict no-repeat should keep event texts distinct.
+ *
+ * RNG is not injected. The probability boundaries (0.0 / 1.0) make the fire/miss
+ * decision deterministically testable, and a single-element `source` makes the
+ * `random()` pick deterministic too — matching the project's pattern in
+ * `AssignHandler` (which also uses `random()` / `Random.nextInt` directly without
+ * injection).
+ *
+ * A code phase — it never touches [PhaseContext.turnGate] (no LLM turn), matching
+ * Swift, where the code phases ignore it too.
+ *
+ * **No `state: inout`.** Kotlin [SimulationState] is an immutable `data class`, so
+ * this RETURNS the next state via `state.copy(...)` rather than mutating in place.
+ * A handler that builds a `.copy` but returns the original `state` compiles
+ * cleanly and silently drops the change — every path below returns the state it
+ * actually mutated.
+ *
+ * Swift original: `Pastura/Pastura/Engine/Phases/EventInjectHandler.swift`.
+ */
+internal class EventInjectHandler : PhaseHandler {
+
+    companion object {
+        /**
+         * Default variable name written when `Phase.eventVariable` is `null`.
+         *
+         * Referenced by `ScoreCalcHandler`/`EventReactivePayoffLogic` and tests so
+         * producer and consumer share the same canonical name.
+         */
+        const val defaultVariableName: String = "current_event"
+
+        /**
+         * Suffix convention for the companion "favored action" variable written
+         * alongside a dict-shaped event (`{ text, favors }`).
+         * `EventReactivePayoffLogic` reads it back via the same convention so the
+         * producer and consumer never drift. See #931.
+         */
+        fun favoredVariableName(eventVariable: String): String = "${eventVariable}__favors"
+    }
+
+    /** A normalized event entry: display `text` and an optional `favors` tag. */
+    private data class ChosenEntry(val text: String, val favors: String?)
+
+    override suspend fun execute(context: PhaseContext, state: SimulationState): SimulationState {
+        val variableName = context.phase.eventVariable ?: defaultVariableName
+        val favoredName = favoredVariableName(variableName)
+        val probability = context.phase.probability ?: 1.0
+        val sourceKey = context.phase.source ?: ""
+
+        // Normalize the source into (text, favors?) entries. A plain [String]
+        // source yields null favors (unchanged #256 behavior, no companion var);
+        // a [[String: String]] source carries the optional `favors` tag (#931).
+        // `carriesFavors` gates every companion-var write so a plain-string
+        // scenario never grows a new variable — existing scenarios unaffected.
+        val events: List<ChosenEntry>
+        val carriesFavors: Boolean
+        when (val source = context.scenario.extraData[sourceKey]) {
+            is AnyCodableValue.ArrayValue -> {
+                events = source.value.map { ChosenEntry(text = it, favors = null) }
+                carriesFavors = false
+            }
+            is AnyCodableValue.ArrayOfDictionariesValue -> {
+                events = source.value.map { ChosenEntry(text = it["text"] ?: "", favors = it["favors"]) }
+                carriesFavors = true
+            }
+            else -> {
+                // Missing-key / wrong-shape (StringValue / DictionaryValue / null)
+                // is curator-fixable so we surface a Summary warning rather than
+                // throwing — the simulation continues with the variable set to ""
+                // so downstream prompts don't break.
+                if (sourceKey.isNotEmpty()) {
+                    context.emitter(
+                        SimulationEvent.Summary(
+                            text = "⚠️ event_inject: source '$sourceKey' " +
+                                "not found or not a list of events — no event injected this round.",
+                        ),
+                    )
+                }
+                context.emitter(SimulationEvent.EventInjected(event = null))
+                return state.copy(variables = state.variables + (variableName to ""))
+            }
+        }
+
+        // Empty list: same observable shape as a probability miss. Curator may
+        // intend to disable injection by clearing the list mid-development.
+        if (events.isEmpty()) {
+            return miss(context, state, variableName, favoredName, carriesFavors)
+        }
+
+        // Strict `<` with `[0.0, 1.0)` gives the documented boundary semantics:
+        //   probability = 0.0 → roll < 0.0 is always false → never fires
+        //   probability = 1.0 → roll < 1.0 is always true  → always fires
+        // (`<=` would allow `probability = 0.0` to occasionally fire when
+        // RNG returns exactly 0.0.)
+        val roll = Random.nextDouble()
+        if (roll >= probability) {
+            return miss(context, state, variableName, favoredName, carriesFavors)
+        }
+
+        // `no_repeat` (#1006) draws from the not-yet-drawn remainder and records
+        // the pick; the default path keeps plain with-replacement selection.
+        // `List.random()` on a non-empty list always returns an element — the
+        // guard above guarantees `events.isNotEmpty()`. Both branches funnel the
+        // chosen entry through the SAME variable / favored-var writes below, so
+        // dict-shaped `{text,favors}` scoring (#931) is preserved regardless of
+        // draw mode.
+        val (chosen, afterPick) =
+            if (context.phase.noRepeat == true) {
+                pickWithoutRepeat(events, variableName, state)
+            } else {
+                events.random() to state
+            }
+
+        var variables = afterPick.variables + (variableName to chosen.text)
+        // Write "" (not absent) for a dict entry with no `favors` tag, so an
+        // earlier round's favored action never ghosts into `event_reactive`.
+        if (carriesFavors) {
+            variables = variables + (favoredName to (chosen.favors ?: ""))
+        }
+        context.emitter(SimulationEvent.EventInjected(event = chosen.text))
+        return afterPick.copy(variables = variables)
+    }
+
+    /**
+     * A miss writes "" to BOTH the event var and (for dict sources) the favored
+     * var, so neither a prior round's event nor its favored action ghosts into
+     * this round's prompt or `event_reactive` scoring, and emits
+     * [SimulationEvent.EventInjected] with `event = null`.
+     */
+    private fun miss(
+        context: PhaseContext,
+        state: SimulationState,
+        variableName: String,
+        favoredName: String,
+        carriesFavors: Boolean,
+    ): SimulationState {
+        var variables = state.variables + (variableName to "")
+        if (carriesFavors) {
+            variables = variables + (favoredName to "")
+        }
+        context.emitter(SimulationEvent.EventInjected(event = null))
+        return state.copy(variables = variables)
+    }
+
+    /**
+     * Draws an event not yet chosen this run (`no_repeat`), recording the pick in
+     * `state.drawnEvents[variableName]`. When every entry has already been drawn
+     * the pool is reset and a fresh full draw is taken — a late repeat is
+     * preferable to blanking the variable mid-scenario (#1006). `events` is
+     * guaranteed non-empty by the caller.
+     *
+     * Because [SimulationState] is immutable, this returns BOTH the chosen entry
+     * and the state carrying the updated `drawnEvents` — a caller that keeps the
+     * chosen entry but drops the returned state silently fails to record the
+     * pick, so no_repeat would repeat.
+     */
+    private fun pickWithoutRepeat(
+        events: List<ChosenEntry>,
+        variableName: String,
+        state: SimulationState,
+    ): Pair<ChosenEntry, SimulationState> {
+        var drawn = state.drawnEvents[variableName] ?: emptySet()
+        var remaining = events.filter { it.text !in drawn }
+        if (remaining.isEmpty()) {
+            // Pool exhausted — reset so the next draw sees the full list again.
+            drawn = emptySet()
+            remaining = events
+        }
+        val chosen = remaining.random()
+        val updatedDrawn = state.drawnEvents + (variableName to (drawn + chosen.text))
+        return chosen to state.copy(drawnEvents = updatedDrawn)
+    }
+}

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/ScoreCalcHandler.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/ScoreCalcHandler.kt
@@ -1,0 +1,72 @@
+package com.pastura.engine
+
+import com.pastura.models.ScoreCalcLogic
+import com.pastura.models.SimulationError
+import com.pastura.models.SimulationState
+
+/**
+ * Handles `score_calc` phases by dispatching to built-in scoring logics.
+ *
+ * Switches on `phase.logic` to delegate to the appropriate scoring implementation.
+ *
+ * A code phase — it never touches [PhaseContext.turnGate] (no LLM turn), matching
+ * Swift, where the code phases ignore it too.
+ *
+ * **No `state: inout`.** Kotlin [SimulationState] is an immutable `data class`, so
+ * this RETURNS the state produced by the dispatched logic rather than mutating in
+ * place. Every `ScoringLogic.calculate(...)` already returns the next state, so
+ * the `when` expression's value is returned directly — returning the input `state`
+ * instead would compile cleanly and silently drop every score change.
+ *
+ * The `when` is an EXPRESSION with **no `else`** so a future sixth
+ * [ScoreCalcLogic] case compile-breaks here, matching Swift's no-`default` switch.
+ *
+ * Swift original: `Pastura/Pastura/Engine/Phases/ScoreCalcHandler.swift`.
+ */
+internal class ScoreCalcHandler : PhaseHandler {
+
+    override suspend fun execute(context: PhaseContext, state: SimulationState): SimulationState {
+        val logic = context.phase.logic ?: throw SimulationException(
+            SimulationError.ScenarioValidationFailed(
+                message = "score_calc phase missing 'logic' field",
+            ),
+        )
+
+        return when (logic) {
+            ScoreCalcLogic.PRISONERS_DILEMMA ->
+                PrisonersDilemmaLogic().calculate(state, context.emitter)
+
+            ScoreCalcLogic.VOTE_TALLY ->
+                VoteTallyLogic().calculate(state, context.emitter)
+
+            ScoreCalcLogic.WORDWOLF_JUDGE ->
+                WordwolfJudgeLogic().calculate(
+                    state,
+                    language = context.scenario.engineLanguage,
+                    emitter = context.emitter,
+                )
+
+            ScoreCalcLogic.EVENT_REACTIVE ->
+                // v1 uses the companion-variable convention keyed off the default
+                // event variable name (`current_event__favors`). Honoring a custom
+                // `as:` on the event_inject phase (via a phase-level
+                // `favored_variable:` field) is deferred — see #931.
+                EventReactivePayoffLogic().calculate(
+                    state,
+                    favoredVariable = EventInjectHandler.favoredVariableName(
+                        EventInjectHandler.defaultVariableName,
+                    ),
+                    emitter = context.emitter,
+                )
+
+            ScoreCalcLogic.PAIRWISE_PAYOFF ->
+                // An absent `payoff:` is an empty table (all pairings score nothing) —
+                // flagged by the semantic linter (R20a), not a dispatch-time throw.
+                PairwisePayoffLogic().calculate(
+                    state,
+                    payoff = context.phase.payoff ?: emptyList(),
+                    emitter = context.emitter,
+                )
+        }
+    }
+}

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/EventInjectHandlerTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/EventInjectHandlerTests.kt
@@ -1,0 +1,453 @@
+package com.pastura.engine
+
+import com.pastura.models.AnyCodableValue
+import com.pastura.models.Persona
+import com.pastura.models.Phase
+import com.pastura.models.PhaseType
+import com.pastura.models.Scenario
+import com.pastura.models.SimulationEvent
+import com.pastura.models.SimulationState
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Kotlin port of `Pastura/PasturaTests/Engine/Phases/EventInjectHandlerTests.swift`
+ * and its `+NoRepeat` sibling.
+ *
+ * `event_inject` is a deterministic code phase: boundary probabilities (0.0 / 1.0)
+ * and single-element (or pre-seeded 1-element-remainder) sources make every
+ * assertion here deterministic without RNG injection — matching the Swift suite.
+ *
+ * Because Kotlin [SimulationState] is immutable, EVERY assertion reads the
+ * **returned** state's `variables` / `drawnEvents`, never the input — a handler
+ * (or the `pickWithoutRepeat` helper) that builds a `.copy` but returns the
+ * original would silently drop the change.
+ *
+ * Ported for the ADR-023 Stage-3 code-phase port (#501).
+ */
+class EventInjectHandlerTests {
+
+    private val handler = EventInjectHandler()
+
+    private fun scenario(
+        source: String,
+        probability: Double? = null,
+        eventVariable: String? = null,
+        noRepeat: Boolean? = null,
+        extraData: Map<String, AnyCodableValue> = emptyMap(),
+        agents: List<String> = listOf("Alice"),
+    ) = Scenario(
+        id = "t",
+        name = "T",
+        description = "d",
+        language = "en",
+        agentCount = agents.size,
+        rounds = 2,
+        context = "A test.",
+        personas = agents.map { Persona(name = it, description = "$it's persona.") },
+        phases = listOf(
+            Phase(
+                type = PhaseType.EVENT_INJECT,
+                source = source,
+                probability = probability,
+                eventVariable = eventVariable,
+                noRepeat = noRepeat,
+            ),
+        ),
+        extraData = extraData,
+    )
+
+    private fun context(
+        scenario: Scenario,
+        events: MutableList<SimulationEvent> = mutableListOf(),
+    ) = PhaseContext(
+        scenario = scenario,
+        phase = scenario.phases[0],
+        backend = ScriptedLLMBackend(emptyList()),
+        suspensionRelay = SuspensionRelay(),
+        emitter = { events += it },
+        pauseCheck = { },
+        phasePath = listOf(0),
+        turnGate = TurnFailureGate(),
+    )
+
+    /**
+     * Extracts every [SimulationEvent.EventInjected] payload, preserving `null`
+     * payloads (the "miss" cases) — a filter that dropped them would hide misses.
+     */
+    private fun injectedEvents(events: List<SimulationEvent>): List<String?> =
+        events.filterIsInstance<SimulationEvent.EventInjected>().map { it.event }
+
+    private fun favoredKey(variableName: String = "current_event") =
+        EventInjectHandler.favoredVariableName(variableName)
+
+    // MARK: - Probability boundaries
+
+    @Test
+    fun firesWhenProbabilityIsOne() = runTest {
+        val s = scenario(
+            source = "events",
+            probability = 1.0,
+            extraData = mapOf("events" to AnyCodableValue.ArrayValue(listOf("突然停電"))),
+        )
+        val events = mutableListOf<SimulationEvent>()
+        val next = handler.execute(context(s, events), SimulationState.initial(s))
+
+        assertEquals("突然停電", next.variables["current_event"])
+        assertEquals(listOf("突然停電"), injectedEvents(events))
+    }
+
+    @Test
+    fun missesWhenProbabilityIsZero() = runTest {
+        val s = scenario(
+            source = "events",
+            probability = 0.0,
+            extraData = mapOf("events" to AnyCodableValue.ArrayValue(listOf("突然停電"))),
+        )
+        val events = mutableListOf<SimulationEvent>()
+        val next = handler.execute(context(s, events), SimulationState.initial(s))
+
+        // Empty-string write (not absent) so prompts referencing {current_event}
+        // expand cleanly without ghosting last round's value.
+        assertEquals("", next.variables["current_event"])
+        assertEquals(listOf<String?>(null), injectedEvents(events))
+    }
+
+    // MARK: - Default probability
+
+    @Test
+    fun defaultProbabilityFires() = runTest {
+        // probability null → 1.0
+        val s = scenario(
+            source = "events",
+            extraData = mapOf("events" to AnyCodableValue.ArrayValue(listOf("only"))),
+        )
+        val next = handler.execute(context(s), SimulationState.initial(s))
+
+        assertEquals("only", next.variables["current_event"])
+    }
+
+    // MARK: - Custom variable name (`as:`)
+
+    @Test
+    fun customVariableNameOverridesDefault() = runTest {
+        val s = scenario(
+            source = "events",
+            probability = 1.0,
+            eventVariable = "my_event",
+            extraData = mapOf("events" to AnyCodableValue.ArrayValue(listOf("x"))),
+        )
+        val next = handler.execute(context(s), SimulationState.initial(s))
+
+        assertEquals("x", next.variables["my_event"])
+        // Default key untouched.
+        assertNull(next.variables["current_event"])
+    }
+
+    // MARK: - Source-missing / empty
+
+    @Test
+    fun missingSourceEmitsWarningAndMissesCleanly() = runTest {
+        // extraData empty — source key absent.
+        val s = scenario(source = "nonexistent", probability = 1.0)
+        val events = mutableListOf<SimulationEvent>()
+        val next = handler.execute(context(s, events), SimulationState.initial(s))
+
+        assertEquals("", next.variables["current_event"])
+        assertEquals(listOf<String?>(null), injectedEvents(events))
+
+        val warned = events.any {
+            it is SimulationEvent.Summary && it.text.contains("nonexistent")
+        }
+        assertTrue(warned)
+    }
+
+    @Test
+    fun absentSourceDoesNotWarn() = runTest {
+        // An empty `source:` must NOT emit a Summary warning (Swift L81 guard).
+        val s = scenario(source = "", probability = 1.0)
+        val events = mutableListOf<SimulationEvent>()
+        val next = handler.execute(context(s, events), SimulationState.initial(s))
+
+        assertEquals("", next.variables["current_event"])
+        assertEquals(listOf<String?>(null), injectedEvents(events))
+        assertTrue(events.none { it is SimulationEvent.Summary })
+    }
+
+    @Test
+    fun wrongShapeSourceEmitsWarning() = runTest {
+        // A non-empty source pointing at a wrong shape (StringValue) IS warned.
+        val s = scenario(
+            source = "events",
+            probability = 1.0,
+            extraData = mapOf("events" to AnyCodableValue.StringValue("not a list")),
+        )
+        val events = mutableListOf<SimulationEvent>()
+        val next = handler.execute(context(s, events), SimulationState.initial(s))
+
+        assertEquals("", next.variables["current_event"])
+        assertEquals(listOf<String?>(null), injectedEvents(events))
+        assertTrue(events.any { it is SimulationEvent.Summary && it.text.contains("events") })
+    }
+
+    @Test
+    fun emptyArrayBehavesLikeMiss() = runTest {
+        val s = scenario(
+            source = "events",
+            probability = 1.0,
+            extraData = mapOf("events" to AnyCodableValue.ArrayValue(emptyList())),
+        )
+        val events = mutableListOf<SimulationEvent>()
+        val next = handler.execute(context(s, events), SimulationState.initial(s))
+
+        assertEquals("", next.variables["current_event"])
+        assertEquals(listOf<String?>(null), injectedEvents(events))
+    }
+
+    // MARK: - Single-element source determinism
+
+    @Test
+    fun singleElementSourceIsDeterministic() = runTest {
+        val s = scenario(
+            source = "events",
+            probability = 1.0,
+            extraData = mapOf("events" to AnyCodableValue.ArrayValue(listOf("only"))),
+        )
+        repeat(5) {
+            val next = handler.execute(context(s), SimulationState.initial(s))
+            assertEquals("only", next.variables["current_event"])
+        }
+    }
+
+    // MARK: - Default variable name constant
+
+    @Test
+    fun defaultVariableNameMatchesPhaseDocumentation() {
+        assertEquals("current_event", EventInjectHandler.defaultVariableName)
+    }
+
+    // MARK: - Dict-shaped events + companion favored variable (#931)
+
+    @Test
+    fun dictEventWritesTextAndFavoredVariable() = runTest {
+        val s = scenario(
+            source = "events",
+            probability = 1.0,
+            extraData = mapOf(
+                "events" to AnyCodableValue.ArrayOfDictionariesValue(
+                    listOf(mapOf("text" to "抜け駆けが得", "favors" to "betray")),
+                ),
+            ),
+        )
+        val events = mutableListOf<SimulationEvent>()
+        val next = handler.execute(context(s, events), SimulationState.initial(s))
+
+        assertEquals("抜け駆けが得", next.variables["current_event"])
+        assertEquals("betray", next.variables[favoredKey()])
+        assertEquals(listOf("抜け駆けが得"), injectedEvents(events))
+    }
+
+    @Test
+    fun dictEventWithoutFavorsWritesEmptyFavoredVariable() = runTest {
+        val s = scenario(
+            source = "events",
+            probability = 1.0,
+            extraData = mapOf(
+                "events" to AnyCodableValue.ArrayOfDictionariesValue(
+                    listOf(mapOf("text" to "ただの出来事")),
+                ),
+            ),
+        )
+        // Pre-seed a stale favored value to prove it gets cleared, not preserved.
+        val state = SimulationState.initial(s).copy(variables = mapOf(favoredKey() to "betray"))
+        val next = handler.execute(context(s), state)
+
+        assertEquals("ただの出来事", next.variables["current_event"])
+        assertEquals("", next.variables[favoredKey()])
+    }
+
+    @Test
+    fun dictEventMissClearsFavoredVariable() = runTest {
+        val s = scenario(
+            source = "events",
+            probability = 0.0,
+            extraData = mapOf(
+                "events" to AnyCodableValue.ArrayOfDictionariesValue(
+                    listOf(mapOf("text" to "x", "favors" to "betray")),
+                ),
+            ),
+        )
+        val state = SimulationState.initial(s).copy(variables = mapOf(favoredKey() to "betray"))
+        val events = mutableListOf<SimulationEvent>()
+        val next = handler.execute(context(s, events), state)
+
+        assertEquals("", next.variables["current_event"])
+        assertEquals("", next.variables[favoredKey()])
+        assertEquals(listOf<String?>(null), injectedEvents(events))
+    }
+
+    @Test
+    fun stringListNeverWritesFavoredVariable() = runTest {
+        val s = scenario(
+            source = "events",
+            probability = 1.0,
+            extraData = mapOf("events" to AnyCodableValue.ArrayValue(listOf("突然停電"))),
+        )
+        val next = handler.execute(context(s), SimulationState.initial(s))
+
+        assertEquals("突然停電", next.variables["current_event"])
+        assertNull(next.variables[favoredKey()])
+    }
+
+    @Test
+    fun dictEventHonorsCustomVariableNameForFavoredKey() = runTest {
+        val s = scenario(
+            source = "events",
+            probability = 1.0,
+            eventVariable = "biz_event",
+            extraData = mapOf(
+                "events" to AnyCodableValue.ArrayOfDictionariesValue(
+                    listOf(mapOf("text" to "x", "favors" to "cooperate")),
+                ),
+            ),
+        )
+        val next = handler.execute(context(s), SimulationState.initial(s))
+
+        assertEquals("x", next.variables["biz_event"])
+        assertEquals("cooperate", next.variables[favoredKey("biz_event")])
+        assertNull(next.variables[favoredKey()])
+    }
+
+    // MARK: - no_repeat draw without replacement (#1006)
+
+    @Test
+    fun noRepeatDrawsFromRemainder() = runTest {
+        val s = scenario(
+            source = "events",
+            probability = 1.0,
+            noRepeat = true,
+            extraData = mapOf("events" to AnyCodableValue.ArrayValue(listOf("A", "B"))),
+        )
+        // "A" already drawn → only "B" remains, so the pick is deterministic.
+        val state = SimulationState.initial(s).copy(drawnEvents = mapOf("current_event" to setOf("A")))
+        val events = mutableListOf<SimulationEvent>()
+        val next = handler.execute(context(s, events), state)
+
+        assertEquals("B", next.variables["current_event"])
+        assertEquals(setOf("A", "B"), next.drawnEvents["current_event"])
+        assertEquals(listOf("B"), injectedEvents(events))
+    }
+
+    @Test
+    fun noRepeatExhaustedPoolResetsAndDraws() = runTest {
+        val s = scenario(
+            source = "events",
+            probability = 1.0,
+            noRepeat = true,
+            extraData = mapOf("events" to AnyCodableValue.ArrayValue(listOf("A", "B"))),
+        )
+        // Both entries drawn → the remainder is empty, forcing a reset+redraw.
+        val state = SimulationState.initial(s).copy(drawnEvents = mapOf("current_event" to setOf("A", "B")))
+        val next = handler.execute(context(s), state)
+
+        // A miss would blank the variable; instead we reset and redraw a real event.
+        val chosen = next.variables["current_event"]
+        assertTrue(chosen == "A" || chosen == "B")
+        // Reset clears the pool, then adds only the freshly-redrawn entry.
+        assertEquals(setOf(chosen), next.drawnEvents["current_event"])
+    }
+
+    @Test
+    fun noRepeatSingleElementRedrawsAfterReset() = runTest {
+        // One-element pool: every round exhausts and resets, so the same event is
+        // redrawn deterministically and the drawn-set never grows past 1.
+        val s = scenario(
+            source = "events",
+            probability = 1.0,
+            noRepeat = true,
+            extraData = mapOf("events" to AnyCodableValue.ArrayValue(listOf("only"))),
+        )
+        var state = SimulationState.initial(s)
+        repeat(3) {
+            state = handler.execute(context(s), state)
+            assertEquals("only", state.variables["current_event"])
+            assertEquals(setOf("only"), state.drawnEvents["current_event"])
+        }
+    }
+
+    @Test
+    fun defaultKeepsWithReplacementAndNeverTouchesDrawnEvents() = runTest {
+        // no_repeat absent → existing random() path, drawnEvents untouched.
+        val s = scenario(
+            source = "events",
+            probability = 1.0,
+            extraData = mapOf("events" to AnyCodableValue.ArrayValue(listOf("A"))),
+        )
+        val next = handler.execute(context(s), SimulationState.initial(s))
+
+        assertEquals("A", next.variables["current_event"])
+        assertTrue(next.drawnEvents.isEmpty())
+    }
+
+    @Test
+    fun noRepeatHonorsCustomVariableName() = runTest {
+        val s = scenario(
+            source = "events",
+            probability = 1.0,
+            eventVariable = "my_event",
+            noRepeat = true,
+            extraData = mapOf("events" to AnyCodableValue.ArrayValue(listOf("A", "B"))),
+        )
+        val state = SimulationState.initial(s).copy(drawnEvents = mapOf("my_event" to setOf("A")))
+        val next = handler.execute(context(s), state)
+
+        assertEquals("B", next.variables["my_event"])
+        assertEquals(setOf("A", "B"), next.drawnEvents["my_event"])
+        // Default key is never used when `as:` is set.
+        assertNull(next.drawnEvents["current_event"])
+    }
+
+    @Test
+    fun noRepeatDictSourcePreservesFavoredVariable() = runTest {
+        val s = scenario(
+            source = "events",
+            probability = 1.0,
+            noRepeat = true,
+            extraData = mapOf(
+                "events" to AnyCodableValue.ArrayOfDictionariesValue(
+                    listOf(
+                        mapOf("text" to "A", "favors" to "betray"),
+                        mapOf("text" to "B", "favors" to "cooperate"),
+                    ),
+                ),
+            ),
+        )
+        // only "B" remains
+        val state = SimulationState.initial(s).copy(drawnEvents = mapOf("current_event" to setOf("A")))
+        val next = handler.execute(context(s), state)
+
+        assertEquals("B", next.variables["current_event"])
+        assertEquals("cooperate", next.variables[favoredKey()])
+        assertEquals(setOf("A", "B"), next.drawnEvents["current_event"])
+    }
+
+    @Test
+    fun noRepeatMissDoesNotConsumePool() = runTest {
+        val s = scenario(
+            source = "events",
+            probability = 0.0,
+            noRepeat = true,
+            extraData = mapOf("events" to AnyCodableValue.ArrayValue(listOf("A", "B"))),
+        )
+        val events = mutableListOf<SimulationEvent>()
+        val next = handler.execute(context(s, events), SimulationState.initial(s))
+
+        assertEquals("", next.variables["current_event"])
+        // A probability miss injects nothing, so it must not mark anything drawn.
+        assertTrue(next.drawnEvents.isEmpty())
+        assertEquals(listOf<String?>(null), injectedEvents(events))
+    }
+}

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/PhaseDispatcherTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/PhaseDispatcherTests.kt
@@ -45,6 +45,11 @@ class PhaseDispatcherTests {
     }
 
     @Test
+    fun resolvesTheScoreCalcHandler() {
+        assertIs<ScoreCalcHandler>(dispatcher.handler(PhaseType.SCORE_CALC))
+    }
+
+    @Test
     fun returnsAStableHandlerInstance() {
         // Handlers are stateless values; the dispatcher builds its map once.
         assertTrue(dispatcher.handler(PhaseType.SPEAK_ALL) === dispatcher.handler(PhaseType.SPEAK_ALL))
@@ -58,12 +63,14 @@ class PhaseDispatcherTests {
 
     @Test
     fun theErrorNamesThePhaseUsingItsWireNameNotItsKotlinCaseName() {
-        // `speak_all`, not `SPEAK_ALL` — Swift interpolates `phaseType.rawValue`,
-        // and a reader comparing the two engines' errors should see the same token.
-        val error = assertFailsWith<SimulationException> { dispatcher.handler(PhaseType.SCORE_CALC) }
+        // `vote`, not `VOTE` — Swift interpolates `phaseType.rawValue`, and a
+        // reader comparing the two engines' errors should see the same token. Uses
+        // an unported type (VOTE stays a B1–B6 LLM handler through CP2) so this
+        // still exercises the throw path now that SCORE_CALC resolves.
+        val error = assertFailsWith<SimulationException> { dispatcher.handler(PhaseType.VOTE) }
         val message = assertIs<SimulationError.ScenarioValidationFailed>(error.error).message
-        assertTrue(message.contains("score_calc"), "expected the wire name, got: $message")
-        assertTrue(!message.contains("SCORE_CALC"), "the Kotlin case name must not leak: $message")
+        assertTrue(message.contains("vote"), "expected the wire name, got: $message")
+        assertTrue(!message.contains("VOTE"), "the Kotlin case name must not leak: $message")
     }
 
     @Test
@@ -73,9 +80,9 @@ class PhaseDispatcherTests {
         val unported = PhaseType.entries.filter {
             it != PhaseType.SPEAK_ALL && it != PhaseType.ELIMINATE &&
                 it != PhaseType.SUMMARIZE && it != PhaseType.ASSIGN &&
-                it != PhaseType.EVENT_INJECT
+                it != PhaseType.EVENT_INJECT && it != PhaseType.SCORE_CALC
         }
-        assertEquals(9, unported.size, "Kotlin PhaseType has 14 cases today; see the #501 drift ledger")
+        assertEquals(8, unported.size, "Kotlin PhaseType has 14 cases today; see the #501 drift ledger")
         for (type in unported) {
             val error = assertFailsWith<SimulationException>("$type must fail cleanly") {
                 dispatcher.handler(type)

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/PhaseDispatcherTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/PhaseDispatcherTests.kt
@@ -40,6 +40,11 @@ class PhaseDispatcherTests {
     }
 
     @Test
+    fun resolvesTheEventInjectHandler() {
+        assertIs<EventInjectHandler>(dispatcher.handler(PhaseType.EVENT_INJECT))
+    }
+
+    @Test
     fun returnsAStableHandlerInstance() {
         // Handlers are stateless values; the dispatcher builds its map once.
         assertTrue(dispatcher.handler(PhaseType.SPEAK_ALL) === dispatcher.handler(PhaseType.SPEAK_ALL))
@@ -67,9 +72,10 @@ class PhaseDispatcherTests {
         // PhaseType added to Models cannot silently reach dispatch unhandled.
         val unported = PhaseType.entries.filter {
             it != PhaseType.SPEAK_ALL && it != PhaseType.ELIMINATE &&
-                it != PhaseType.SUMMARIZE && it != PhaseType.ASSIGN
+                it != PhaseType.SUMMARIZE && it != PhaseType.ASSIGN &&
+                it != PhaseType.EVENT_INJECT
         }
-        assertEquals(10, unported.size, "Kotlin PhaseType has 14 cases today; see the #501 drift ledger")
+        assertEquals(9, unported.size, "Kotlin PhaseType has 14 cases today; see the #501 drift ledger")
         for (type in unported) {
             val error = assertFailsWith<SimulationException>("$type must fail cleanly") {
                 dispatcher.handler(type)

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScoreCalcHandlerTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ScoreCalcHandlerTests.kt
@@ -1,0 +1,154 @@
+package com.pastura.engine
+
+import com.pastura.models.Pairing
+import com.pastura.models.PayoffRule
+import com.pastura.models.Phase
+import com.pastura.models.PhaseType
+import com.pastura.models.Scenario
+import com.pastura.models.ScoreCalcLogic
+import com.pastura.models.SimulationError
+import com.pastura.models.SimulationEvent
+import com.pastura.models.SimulationState
+import com.pastura.models.TurnOutput
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Dispatch-parity tests for [ScoreCalcHandler].
+ *
+ * There is no dedicated Swift `ScoreCalcHandlerTests` — the handler is a thin
+ * dispatcher and the five scoring logics are covered by their own
+ * `*LogicTests` suites under `ScoringLogic/`. This suite proves only the
+ * **routing contract**:
+ * that each [ScoreCalcLogic] reaches its implementation with the correct
+ * arguments, asserted via one distinguishing observable per logic (not by
+ * re-testing each logic's internals). The `logic == null` case pins the
+ * missing-field throw.
+ *
+ * Because Kotlin [SimulationState] is immutable, every assertion reads the
+ * **returned** state (or an emitted [SimulationEvent]) — a handler that dropped
+ * the dispatched logic's return value would compile cleanly and silently score
+ * nothing.
+ *
+ * Ported for the ADR-023 Stage-3 CP2 score_calc slice (#501).
+ */
+class ScoreCalcHandlerTests {
+
+    private val handler = ScoreCalcHandler()
+
+    private fun scenario(
+        agents: List<String> = listOf("Alice", "Bob"),
+        language: String? = null,
+    ): Scenario {
+        val base = makeTestScenario(agentNames = agents)
+        return if (language == null) base else base.copy(simulationLanguage = language)
+    }
+
+    private fun context(
+        scenario: Scenario,
+        logic: ScoreCalcLogic?,
+        payoff: List<PayoffRule>? = null,
+        events: MutableList<SimulationEvent> = mutableListOf(),
+    ) = PhaseContext(
+        scenario = scenario,
+        phase = Phase(type = PhaseType.SCORE_CALC, logic = logic, payoff = payoff),
+        backend = ScriptedLLMBackend(emptyList()),
+        suspensionRelay = SuspensionRelay(),
+        emitter = { events += it },
+        pauseCheck = { },
+        phasePath = listOf(0),
+        turnGate = TurnFailureGate(),
+    )
+
+    @Test
+    fun missingLogicThrowsScenarioValidationFailed() = runTest {
+        val s = scenario()
+        val error = assertFailsWith<SimulationException> {
+            handler.execute(context(s, logic = null), SimulationState.initial(s))
+        }
+        val message = assertIs<SimulationError.ScenarioValidationFailed>(error.error).message
+        assertTrue(message.contains("logic"), "expected the missing-field message to name 'logic': $message")
+    }
+
+    @Test
+    fun routesVoteTally() = runTest {
+        // Distinguishing observable: vote_tally adds voteResults into scores.
+        val s = scenario()
+        val state = SimulationState.initial(s).copy(voteResults = mapOf("Alice" to 2, "Bob" to 1))
+        val next = handler.execute(context(s, ScoreCalcLogic.VOTE_TALLY), state)
+        assertEquals(2, next.scores["Alice"])
+        assertEquals(1, next.scores["Bob"])
+    }
+
+    @Test
+    fun routesEventReactiveWithTheEventInjectCompanionKey() = runTest {
+        // Distinguishing observable: event_reactive rewards agents whose last
+        // action matched the favored value. The reward proves the handler passed
+        // the `current_event__favors` companion key (EventInjectHandler's default
+        // variable) — a wrong key would leave every score at 0.
+        val s = scenario()
+        val favoredKey = EventInjectHandler.favoredVariableName(EventInjectHandler.defaultVariableName)
+        assertEquals("current_event__favors", favoredKey)
+        val state = SimulationState.initial(s).copy(
+            lastOutputs = mapOf(
+                "Alice" to TurnOutput(fields = mapOf("action" to "betray")),
+                "Bob" to TurnOutput(fields = mapOf("action" to "cooperate")),
+            ),
+            variables = mapOf(favoredKey to "betray"),
+        )
+        val next = handler.execute(context(s, ScoreCalcLogic.EVENT_REACTIVE), state)
+        assertEquals(EventReactivePayoffLogic.matchReward, next.scores["Alice"])
+        assertEquals(0, next.scores["Bob"])
+    }
+
+    @Test
+    fun routesPairwisePayoffWithThePhasePayoffTable() = runTest {
+        // Distinguishing observable: pairwise_payoff applies the phase's payoff
+        // row positionally to a pairing.
+        val s = scenario()
+        val table = listOf(PayoffRule(`when` = listOf("cooperate", "betray"), points = listOf(0, 5)))
+        val state = SimulationState.initial(s).copy(
+            pairings = listOf(Pairing(agent1 = "Alice", agent2 = "Bob", action1 = "cooperate", action2 = "betray")),
+        )
+        val next = handler.execute(context(s, ScoreCalcLogic.PAIRWISE_PAYOFF, payoff = table), state)
+        assertEquals(0, next.scores["Alice"])
+        assertEquals(5, next.scores["Bob"])
+        assertTrue(next.pairings.isEmpty(), "pairwise_payoff clears pairings after scoring")
+    }
+
+    @Test
+    fun routesPrisonersDilemmaLegacyMatrix() = runTest {
+        // Distinguishing observable: prisoners_dilemma applies the fixed 3/0/5/1
+        // legacy matrix with NO phase payoff table supplied.
+        val s = scenario()
+        val state = SimulationState.initial(s).copy(
+            pairings = listOf(Pairing(agent1 = "Alice", agent2 = "Bob", action1 = "betray", action2 = "cooperate")),
+        )
+        val next = handler.execute(context(s, ScoreCalcLogic.PRISONERS_DILEMMA), state)
+        assertEquals(5, next.scores["Alice"])
+        assertEquals(0, next.scores["Bob"])
+    }
+
+    @Test
+    fun routesWordwolfJudgeWithTheScenarioEngineLanguage() = runTest {
+        // Distinguishing observable: wordwolf_judge emits a language-specific
+        // Summary. Using a ja scenario proves the handler passed
+        // `scenario.engineLanguage` (a wrong language would emit the en text).
+        val s = scenario(language = "ja")
+        assertEquals("ja", s.engineLanguage)
+        val events = mutableListOf<SimulationEvent>()
+        val state = SimulationState.initial(s).copy(
+            voteResults = mapOf("Alice" to 2, "Bob" to 1),
+            variables = mapOf("wolf_name" to "Alice"),
+        )
+        handler.execute(context(s, ScoreCalcLogic.WORDWOLF_JUDGE, events = events), state)
+        val summaries = events.filterIsInstance<SimulationEvent.Summary>()
+        assertEquals(1, summaries.size)
+        assertTrue(summaries[0].text.contains("最多得票"), "expected ja wordwolf text, got: ${summaries[0].text}")
+        assertTrue(summaries[0].text.contains("ウルフ"), "expected ja wordwolf verdict, got: ${summaries[0].text}")
+    }
+}


### PR DESCRIPTION
## Summary

ADR-023 Stage 3 Wave B — **code-phase track PR-CP2**. Ports the coupled pair
`EventInjectHandler` → `ScoreCalcHandler` from Swift `Engine/Phases/` to Kotlin
`shared/engine/src/commonMain/`, mirroring the CP1 precedent (#1226:
Eliminate/Summarize/Assign). Both are deterministic **code phases** (no LLM), so
they consume the current `PhaseContext` unchanged — independent of the B0a/B0b
LLM-seam work. Swift originals stay in place (removed only at ADR-023 Stage 5).

`PhaseDispatcher` now registers **6 / 14** handlers (unported 8). The 5
ScoringLogic reused as-is from PR-1.

### `EventInjectHandler` (commit 1)
Probabilistic `event_inject`: strict-`<` fire boundary (`Random.nextDouble()`
shares `[0.0, 1.0)` with Swift, so `probability = 0.0` never / `1.0` always),
`ArrayValue` / `ArrayOfDictionariesValue` shape switch, dict-shaped companion
`__favors` var (#931), `no_repeat` draw-without-replacement (#1006), and the
ghosting-prevention `""` writes on miss / wrong-shape. Kotlin-specific:
- Immutable `SimulationState` → `execute` returns `state.copy(...)`; the
  `pickWithoutRepeat` helper returns `Pair<ChosenEntry, SimulationState>` so a
  dropped `drawnEvents` write cannot silently disable `no_repeat`.
- The wrong-shape `.Summary` warning stays guarded by `sourceKey.isNotEmpty()`.
- `companion object` exposes `defaultVariableName` / `favoredVariableName(_)`
  for the ScoreCalc consumer (the coupling that ordered EventInject first).

### `ScoreCalcHandler` (commit 2)
Thin dispatcher: `phase.logic` routes to one of 5 ScoringLogic via a no-`else`
`when` **expression** (a 6th `ScoreCalcLogic` case compile-breaks, mirroring
Swift's no-`default` switch). `null` logic throws
`SimulationException(ScenarioValidationFailed(...))` (Kotlin `SimulationError`
is not `Throwable`). The `EVENT_REACTIVE` arm reads
`EventInjectHandler.favoredVariableName(defaultVariableName)`.

### Guardrail
`PhaseDispatcherTests` unported-count 10→8, filter-set additions, positive
resolve assertions, and the wire-name test swapped off the now-registered
`SCORE_CALC` to the still-unported `VOTE`.

## Test plan
- 22 `EventInjectHandlerTests` + 6 `ScoreCalcHandlerTests` + `PhaseDispatcherTests`
  (11) parity commonTest, all reading the **returned** state.
- `./gradlew :shared:engine:compileCommonMainKotlinMetadata :shared:models:jvmTest
  :shared:engine:jvmTest` → BUILD SUCCESSFUL, all JUnit XML failures/errors = 0.
- `claude-kit:critic` (pre-impl, Opus) — no Critical. `code-reviewer` (Opus) — PASS, 0 issues.
- **condition-4 mutation (negative control)**: two disjoint mutants (drop
  `drawnEvents` write / bypass `VoteTallyLogic`) reddened exactly their own
  suites (5 / 1 failures) and left the others green; reverted, re-run green.
  Recorded on #501.

## Device QA
実機QA不要 — Kotlin `shared/**` only; no iOS runtime surface, no device-only
(`#if !targetEnvironment(simulator)`) code, no Metal/LLM path. The pre-commit
iOS build compiled clean on both commits.

Closes #1228.
Part of #501.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
