### PR TITLE
🧹 chore: port RelationshipUpdateHandler to commonMain (ADR-023 CP3)

### DIFF
--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/PhaseDispatcher.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/PhaseDispatcher.kt
@@ -9,9 +9,9 @@ import kotlinx.serialization.serializer
  *
  * ## Scope: the ADR-023 Stage-3 port, in progress
  *
- * **`SPEAK_ALL`, `ELIMINATE`, `SUMMARIZE` and `ASSIGN` are registered.** Swift
- * registers all 14; the remaining 10 are the mechanical bulk of Stage 3
- * ("mechanical after the Stage-2 slice", §4), ported handler-by-handler.
+ * **`SPEAK_ALL`, `ELIMINATE`, `SUMMARIZE`, `ASSIGN` and `RELATIONSHIP_UPDATE` are
+ * registered.** Swift registers all 14; the remaining 9 are the mechanical bulk of
+ * Stage 3 ("mechanical after the Stage-2 slice", §4), ported handler-by-handler.
  *
  * Unlike Swift's `PhaseDispatcher`, this is **not** exhaustive over [PhaseType] —
  * so an unregistered phase fails at dispatch with a clear error rather than at
@@ -29,6 +29,7 @@ internal class PhaseDispatcher {
         PhaseType.ELIMINATE to EliminateHandler(),
         PhaseType.SUMMARIZE to SummarizeHandler(),
         PhaseType.ASSIGN to AssignHandler(),
+        PhaseType.RELATIONSHIP_UPDATE to RelationshipUpdateHandler(),
     )
 
     /**

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/RelationshipUpdateHandler.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/RelationshipUpdateHandler.kt
@@ -1,0 +1,191 @@
+package com.pastura.engine
+
+import com.pastura.models.Persona
+import com.pastura.models.SimulationEvent
+import com.pastura.models.SimulationState
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+
+/**
+ * Handles `relationship_update` phases — a zero-inference code phase that
+ * deterministically maintains a per-agent affinity matrix and injects a
+ * natural-language summary into each agent's prompt (#910).
+ *
+ * Signals are read from state the surrounding phases already populated:
+ * - **Votes**: `state.lastOutputs[voter].vote` (who voted for whom). Applied
+ *   with the `vote_against` delta on the *target's* view of the voter.
+ * - **Choose actions**: `state.pairings` (`action1` / `action2`). Applied with
+ *   the `action_deltas` map on each partner's view of the other.
+ *
+ * **Ordering constraints** (documented, not enforced — a violation is a silent
+ * no-op, not an error):
+ * - Place this phase *after* the vote / choose phase that produces its signals
+ *   and *before* `score_calc` — `PrisonersDilemmaLogic` clears `state.pairings`
+ *   after scoring, so a relationship_update placed after it sees no actions.
+ * - A `lastOutputs`-writing LLM phase (speak / vote / choose) between a vote and
+ *   this phase overwrites `lastOutputs[voter].vote`, losing the vote signal;
+ *   `reflect` / `whisper` do NOT write `lastOutputs`, so they are safe to
+ *   interleave. When neither a vote nor a pairing signal is present the handler
+ *   emits a `.debug` diagnostic so a misordered scenario is discoverable.
+ *
+ * The raw matrix accumulates across rounds in the reserved `relationships_raw_<name>`
+ * `state.variables` key (JSON); the prose summary lands in `relationships_<name>`
+ * (surfaced to only that agent via `PromptBuilder.injectRelationships`). Eliminated
+ * agents are skipped as perceivers — they neither act nor receive an injected summary.
+ *
+ * **No `state: inout`.** Kotlin [SimulationState] is an immutable `data class`, so
+ * [execute] builds the affinity matrix in a LOCAL `MutableMap` (mutating a local is
+ * fine — it is not `SimulationState`) and RETURNS `state.copy(variables = ...)`. The
+ * two apply-helpers keep Swift's side-effecting design over that local matrix, which
+ * is what makes the "evaluate BOTH before combining" ordering below meaningful — see
+ * [applyVotes] / [applyActions] and the regression it guards.
+ *
+ * Swift original: `Pastura/Pastura/Engine/Phases/RelationshipUpdateHandler.swift`.
+ * Ported for the ADR-023 Stage-3 Engine migration (#501).
+ */
+internal class RelationshipUpdateHandler : PhaseHandler {
+
+    override suspend fun execute(context: PhaseContext, state: SimulationState): SimulationState {
+        val active = context.scenario.personas.filter { state.eliminated[it.name] != true }
+        val activeNames = active.map { it.name }.toSet()
+
+        // Seed from the accumulated matrix so scores persist across rounds. The
+        // matrix is a LOCAL mutable map — NOT `SimulationState` — so the apply
+        // helpers may mutate it in place; only the final `state.copy` below crosses
+        // the immutability boundary.
+        val matrix: MutableMap<String, MutableMap<String, Int>> = mutableMapOf()
+        for (persona in active) {
+            val row = decodeRow(state.variables["relationships_raw_${persona.name}"])
+            if (row.isNotEmpty()) matrix[persona.name] = row.toMutableMap()
+        }
+
+        // Evaluate BOTH before combining — each mutates `matrix`, so a
+        // short-circuiting `||` would drop the action signal whenever a vote signal
+        // is also present (a phase may declare both rules; e.g. choose -> vote ->
+        // relationship_update leaves pairings AND lastOutputs.vote populated).
+        val sawVotes = applyVotes(context, state, activeNames, matrix)
+        val sawActions = applyActions(context, state, activeNames, matrix)
+        val sawSignal = sawVotes || sawActions
+
+        if (!sawSignal) {
+            // Most likely a placement mistake: this phase ran with no fresh vote /
+            // pairing signal in state (e.g. after `score_calc` cleared pairings, or
+            // with no preceding vote/choose this round). Not user content.
+            context.logger.log(
+                level = EngineLogLevel.DEBUG,
+                category = "RelationshipUpdate",
+                message = "relationship_update found no vote/pairing signal — check phase ordering",
+                privacy = EngineLogPrivacy.PUBLIC,
+            )
+        }
+
+        val variables = persist(
+            active = active, activeNames = activeNames, matrix = matrix,
+            language = context.scenario.engineLanguage, variables = state.variables,
+        )
+        context.emitter(SimulationEvent.RelationshipUpdate(relationships = matrix))
+        return state.copy(variables = variables)
+    }
+
+    /**
+     * Applies the `vote_against` delta for every voter->target pair readable from
+     * `lastOutputs`. Returns `true` if any vote input was present.
+     */
+    private fun applyVotes(
+        context: PhaseContext,
+        state: SimulationState,
+        activeNames: Set<String>,
+        matrix: MutableMap<String, MutableMap<String, Int>>,
+    ): Boolean {
+        var sawVote = false
+        for (voter in activeNames) {
+            val target = state.lastOutputs[voter]?.vote
+            if (target.isNullOrEmpty()) continue
+            sawVote = true
+            // Self-votes and hallucinated / eliminated targets carry no affinity.
+            if (target == voter || !activeNames.contains(target)) continue
+            val delta = context.phase.voteAgainst ?: continue
+            // The target grows wary of whoever voted against them.
+            val row = matrix.getOrPut(target) { mutableMapOf() }
+            row[voter] = (row[voter] ?: 0) + delta
+        }
+        return sawVote
+    }
+
+    /**
+     * Applies the `action_deltas` map for every choose pairing. Each partner's
+     * view of the other moves by the delta for the other's action. Returns
+     * `true` if any pairing input was present.
+     */
+    private fun applyActions(
+        context: PhaseContext,
+        state: SimulationState,
+        activeNames: Set<String>,
+        matrix: MutableMap<String, MutableMap<String, Int>>,
+    ): Boolean {
+        if (state.pairings.isEmpty()) return false
+        val deltas = context.phase.actionDeltas ?: return true
+        for (pairing in state.pairings) {
+            if (!activeNames.contains(pairing.agent1) || !activeNames.contains(pairing.agent2)) continue
+            val delta2 = pairing.action2?.let { deltas[it] }
+            if (delta2 != null) {
+                val row = matrix.getOrPut(pairing.agent1) { mutableMapOf() }
+                row[pairing.agent2] = (row[pairing.agent2] ?: 0) + delta2
+            }
+            val delta1 = pairing.action1?.let { deltas[it] }
+            if (delta1 != null) {
+                val row = matrix.getOrPut(pairing.agent2) { mutableMapOf() }
+                row[pairing.agent1] = (row[pairing.agent1] ?: 0) + delta1
+            }
+        }
+        return true
+    }
+
+    /**
+     * Writes each active perceiver's non-empty row back as the accumulated raw
+     * matrix plus its prose summary, returning the updated `variables` map.
+     *
+     * The raw matrix keeps the full history (cross-round accumulation + the event
+     * payload / Phase-3 viz), but the injected prose mentions only agents still in
+     * play — an eliminated agent should not surface in "you are wary of X".
+     */
+    private fun persist(
+        active: List<Persona>,
+        activeNames: Set<String>,
+        matrix: Map<String, Map<String, Int>>,
+        language: String,
+        variables: Map<String, String>,
+    ): Map<String, String> {
+        val out = variables.toMutableMap()
+        for (persona in active) {
+            val row = matrix[persona.name]
+            if (row.isNullOrEmpty()) continue
+            out["relationships_raw_${persona.name}"] = encodeRow(row)
+            val visibleRow = row.filterKeys { activeNames.contains(it) }
+            out["relationships_${persona.name}"] = RelationshipVerbalizer.summarize(visibleRow, language)
+        }
+        return out
+    }
+
+    private fun encodeRow(row: Map<String, Int>): String {
+        // Sorted keys for deterministic output + cross-engine parity with Swift's
+        // `JSONEncoder.outputFormatting = .sortedKeys`. `Map.toSortedMap()` is
+        // JVM-only (absent from commonMain), so sort the entries by hand; `toMap()`
+        // yields a LinkedHashMap preserving that sorted insertion order, which the
+        // default compact `Json` then emits as `{"Alice":-1,"Bob":2}` — byte-for-byte
+        // the same shape Swift's `.sortedKeys` produces.
+        val sorted = row.toList().sortedBy { it.first }.toMap()
+        return runCatching { json.encodeToString(rowSerializer, sorted) }.getOrDefault("{}")
+    }
+
+    private fun decodeRow(raw: String?): Map<String, Int> {
+        if (raw.isNullOrEmpty()) return emptyMap()
+        return runCatching { json.decodeFromString(rowSerializer, raw) }.getOrDefault(emptyMap())
+    }
+
+    private companion object {
+        private val json = Json
+        private val rowSerializer = MapSerializer(String.serializer(), Int.serializer())
+    }
+}

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/RelationshipUpdateHandler.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/RelationshipUpdateHandler.kt
@@ -173,8 +173,11 @@ internal class RelationshipUpdateHandler : PhaseHandler {
         // `JSONEncoder.outputFormatting = .sortedKeys`. `Map.toSortedMap()` is
         // JVM-only (absent from commonMain), so sort the entries by hand; `toMap()`
         // yields a LinkedHashMap preserving that sorted insertion order, which the
-        // default compact `Json` then emits as `{"Alice":-1,"Bob":2}` — byte-for-byte
-        // the same shape Swift's `.sortedKeys` produces.
+        // default compact `Json` then emits as `{"Alice":-1,"Bob":2}`. For the
+        // ASCII/BMP agent names in practice this matches Swift's `.sortedKeys`
+        // byte-for-byte; the orderings can diverge only for non-BMP keys (Kotlin
+        // sorts by UTF-16 code unit, Foundation by Unicode scalar), and cross-engine
+        // byte-parity is not exercised yet (Data stays Swift/GRDB, ADR-023).
         val sorted = row.toList().sortedBy { it.first }.toMap()
         return runCatching { json.encodeToString(rowSerializer, sorted) }.getOrDefault("{}")
     }

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/PhaseDispatcherTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/PhaseDispatcherTests.kt
@@ -40,6 +40,11 @@ class PhaseDispatcherTests {
     }
 
     @Test
+    fun resolvesTheRelationshipUpdateHandler() {
+        assertIs<RelationshipUpdateHandler>(dispatcher.handler(PhaseType.RELATIONSHIP_UPDATE))
+    }
+
+    @Test
     fun returnsAStableHandlerInstance() {
         // Handlers are stateless values; the dispatcher builds its map once.
         assertTrue(dispatcher.handler(PhaseType.SPEAK_ALL) === dispatcher.handler(PhaseType.SPEAK_ALL))
@@ -67,9 +72,10 @@ class PhaseDispatcherTests {
         // PhaseType added to Models cannot silently reach dispatch unhandled.
         val unported = PhaseType.entries.filter {
             it != PhaseType.SPEAK_ALL && it != PhaseType.ELIMINATE &&
-                it != PhaseType.SUMMARIZE && it != PhaseType.ASSIGN
+                it != PhaseType.SUMMARIZE && it != PhaseType.ASSIGN &&
+                it != PhaseType.RELATIONSHIP_UPDATE
         }
-        assertEquals(10, unported.size, "Kotlin PhaseType has 14 cases today; see the #501 drift ledger")
+        assertEquals(9, unported.size, "Kotlin PhaseType has 14 cases today; see the #501 drift ledger")
         for (type in unported) {
             val error = assertFailsWith<SimulationException>("$type must fail cleanly") {
                 dispatcher.handler(type)

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/RelationshipUpdateHandlerTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/RelationshipUpdateHandlerTests.kt
@@ -1,0 +1,295 @@
+package com.pastura.engine
+
+import com.pastura.models.Pairing
+import com.pastura.models.Persona
+import com.pastura.models.Phase
+import com.pastura.models.PhaseType
+import com.pastura.models.Scenario
+import com.pastura.models.SimulationEvent
+import com.pastura.models.SimulationState
+import com.pastura.models.TurnOutput
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Kotlin port of `Pastura/PasturaTests/Engine/Phases/RelationshipUpdateHandlerTests.swift`
+ * — the zero-inference affinity-matrix code phase (#910). Signals are seeded directly
+ * onto [SimulationState] (`lastOutputs` for votes, `pairings` for choose actions) the
+ * way the surrounding phases would, then the handler's deterministic deltas are asserted
+ * via the emitted [SimulationEvent.RelationshipUpdate] matrix and the persisted
+ * `variables`.
+ *
+ * Because Kotlin [SimulationState] is immutable, the two multi-round cases thread
+ * round-1's **returned** state into round 2 and read every `variables[...]` assertion off
+ * the returned state — a naive port that reused the input `state` would silently drop
+ * cross-round accumulation while still compiling (the AssignHandler silent-drop trap).
+ *
+ * Beyond the 9 Swift cases, [placementDiagnosticFiresWhenNoSignal] /
+ * [placementDiagnosticSilentWhenSignalPresent] are a negative control on the no-signal
+ * `.debug` diagnostic — the Swift suite only asserts the empty matrix, never that the
+ * guard actually fires (see `knowledge-layering.md` § "A detector / guard / gate").
+ *
+ * Ported for the ADR-023 Stage-3 code-phase port (#501).
+ */
+class RelationshipUpdateHandlerTests {
+
+    private val handler = RelationshipUpdateHandler()
+
+    private fun scenario(
+        agentNames: List<String> = listOf("Alice", "Bob"),
+        voteAgainst: Int? = null,
+        actionDeltas: Map<String, Int>? = null,
+    ) = Scenario(
+        id = "t",
+        name = "T",
+        description = "d",
+        language = "en",
+        agentCount = agentNames.size,
+        rounds = 1,
+        context = "A test.",
+        personas = agentNames.map { Persona(name = it, description = "$it's persona.") },
+        phases = listOf(
+            Phase(type = PhaseType.RELATIONSHIP_UPDATE, voteAgainst = voteAgainst, actionDeltas = actionDeltas),
+        ),
+    )
+
+    private fun context(
+        scenario: Scenario,
+        events: MutableList<SimulationEvent> = mutableListOf(),
+        logger: EngineLogger = NoopEngineLogger(),
+    ) = PhaseContext(
+        scenario = scenario,
+        phase = scenario.phases[0],
+        backend = ScriptedLLMBackend(emptyList()),
+        suspensionRelay = SuspensionRelay(),
+        emitter = { events += it },
+        pauseCheck = { },
+        phasePath = listOf(0),
+        turnGate = TurnFailureGate(),
+        logger = logger,
+    )
+
+    private fun emittedMatrix(events: List<SimulationEvent>): Map<String, Map<String, Int>>? =
+        events.filterIsInstance<SimulationEvent.RelationshipUpdate>().firstOrNull()?.relationships
+
+    @Test
+    fun appliesVoteAgainstDelta() = runTest {
+        val s = scenario(voteAgainst = -1)
+        // Alice voted Bob, Bob voted Alice.
+        val state = SimulationState.initial(s).copy(
+            currentRound = 1,
+            lastOutputs = mapOf(
+                "Alice" to TurnOutput(fields = mapOf("vote" to "Bob")),
+                "Bob" to TurnOutput(fields = mapOf("vote" to "Alice")),
+            ),
+        )
+        val events = mutableListOf<SimulationEvent>()
+        handler.execute(context(s, events), state)
+
+        val matrix = assertNotNull(emittedMatrix(events))
+        // Each target grows wary of the agent who voted against them.
+        assertEquals(-1, matrix["Bob"]?.get("Alice"))
+        assertEquals(-1, matrix["Alice"]?.get("Bob"))
+    }
+
+    @Test
+    fun ignoresSelfVoteAndHallucinatedTarget() = runTest {
+        val s = scenario(voteAgainst = -1)
+        val state = SimulationState.initial(s).copy(
+            currentRound = 1,
+            lastOutputs = mapOf(
+                "Alice" to TurnOutput(fields = mapOf("vote" to "Alice")), // self-vote
+                "Bob" to TurnOutput(fields = mapOf("vote" to "Ghost")), // not a persona
+            ),
+        )
+        val events = mutableListOf<SimulationEvent>()
+        handler.execute(context(s, events), state)
+
+        val matrix = assertNotNull(emittedMatrix(events))
+        assertTrue(matrix.isEmpty())
+    }
+
+    @Test
+    fun appliesActionDeltasPerPartner() = runTest {
+        val s = scenario(actionDeltas = mapOf("cooperate" to 1, "betray" to -2))
+        val state = SimulationState.initial(s).copy(
+            currentRound = 1,
+            pairings = listOf(
+                Pairing(agent1 = "Alice", agent2 = "Bob", action1 = "cooperate", action2 = "betray"),
+            ),
+        )
+        val events = mutableListOf<SimulationEvent>()
+        handler.execute(context(s, events), state)
+
+        val matrix = assertNotNull(emittedMatrix(events))
+        // Alice sees Bob's action (betray -> -2); Bob sees Alice's (cooperate -> +1).
+        assertEquals(-2, matrix["Alice"]?.get("Bob"))
+        assertEquals(1, matrix["Bob"]?.get("Alice"))
+    }
+
+    @Test
+    fun accumulatesAcrossRounds() = runTest {
+        val s = scenario(voteAgainst = -1)
+        val round1State = SimulationState.initial(s).copy(
+            currentRound = 1,
+            lastOutputs = mapOf("Alice" to TurnOutput(fields = mapOf("vote" to "Bob"))),
+        )
+        // Thread round-1's RETURNED state into round 2 — the raw matrix persists in
+        // `variables`, so a fresh `initial` state would drop the accumulation.
+        val afterRound1 = handler.execute(context(s), round1State)
+
+        // Second round: same vote again.
+        val round2State = afterRound1.copy(
+            currentRound = 2,
+            lastOutputs = mapOf("Alice" to TurnOutput(fields = mapOf("vote" to "Bob"))),
+        )
+        val events2 = mutableListOf<SimulationEvent>()
+        handler.execute(context(s, events2), round2State)
+
+        val matrix = assertNotNull(emittedMatrix(events2))
+        assertEquals(-2, matrix["Bob"]?.get("Alice"))
+    }
+
+    @Test
+    fun skipsEliminatedPerceiver() = runTest {
+        val s = scenario(agentNames = listOf("Alice", "Bob", "Charlie"), voteAgainst = -1)
+        val initial = SimulationState.initial(s)
+        val state = initial.copy(
+            currentRound = 1,
+            eliminated = initial.eliminated + ("Bob" to true),
+            lastOutputs = mapOf(
+                "Alice" to TurnOutput(fields = mapOf("vote" to "Bob")), // target eliminated -> dropped
+                "Charlie" to TurnOutput(fields = mapOf("vote" to "Alice")),
+            ),
+        )
+        val events = mutableListOf<SimulationEvent>()
+        handler.execute(context(s, events), state)
+
+        val matrix = assertNotNull(emittedMatrix(events))
+        assertNull(matrix["Bob"]) // eliminated — no row
+        assertEquals(-1, matrix["Alice"]?.get("Charlie"))
+    }
+
+    @Test
+    fun writesProseSummaryWhenThresholdCrossed() = runTest {
+        val s = scenario(voteAgainst = -2) // one round reaches |2|
+        val state = SimulationState.initial(s).copy(
+            currentRound = 1,
+            lastOutputs = mapOf("Alice" to TurnOutput(fields = mapOf("vote" to "Bob"))),
+        )
+        val result = handler.execute(context(s), state)
+
+        val summary = assertNotNull(result.variables["relationships_Bob"])
+        assertTrue(summary.contains("Alice"))
+        assertTrue(summary.isNotEmpty())
+        // Raw matrix persisted for cross-round accumulation.
+        assertTrue(result.variables["relationships_raw_Bob"]?.contains("Alice") == true)
+    }
+
+    @Test
+    fun noSignalEmitsEmptyMatrixWithoutCrashing() = runTest {
+        val s = scenario(voteAgainst = -1)
+        // No lastOutputs votes, no pairings — misordered/placeholder phase.
+        val state = SimulationState.initial(s).copy(currentRound = 1)
+        val events = mutableListOf<SimulationEvent>()
+        handler.execute(context(s, events), state)
+
+        val matrix = assertNotNull(emittedMatrix(events))
+        assertTrue(matrix.isEmpty())
+    }
+
+    @Test
+    fun appliesBothVoteAndActionSignalsInSamePhase() = runTest {
+        // Regression: a short-circuiting `||` over the two side-effecting apply
+        // helpers dropped the action signal whenever a vote was also present. A
+        // phase may declare both rules and both signals may be live at once.
+        val s = scenario(voteAgainst = -1, actionDeltas = mapOf("cooperate" to 1, "betray" to -2))
+        val state = SimulationState.initial(s).copy(
+            currentRound = 1,
+            lastOutputs = mapOf(
+                "Alice" to TurnOutput(fields = mapOf("vote" to "Bob")),
+                "Bob" to TurnOutput(fields = mapOf("vote" to "Alice")),
+            ),
+            pairings = listOf(
+                Pairing(agent1 = "Alice", agent2 = "Bob", action1 = "cooperate", action2 = "betray"),
+            ),
+        )
+        val events = mutableListOf<SimulationEvent>()
+        handler.execute(context(s, events), state)
+
+        val matrix = assertNotNull(emittedMatrix(events))
+        // Alice: vote (-1) + Bob's betray action (-2) = -3. A `||` short-circuit
+        // would drop the action term and leave -1.
+        assertEquals(-3, matrix["Alice"]?.get("Bob"))
+        // Bob: vote (-1) + Alice's cooperate action (+1) = 0.
+        assertEquals(0, matrix["Bob"]?.get("Alice"))
+    }
+
+    @Test
+    fun prunesEliminatedAgentFromProseButKeepsRawHistory() = runTest {
+        val s = scenario(voteAgainst = -2)
+        // Round 1: Bob votes Alice, so Alice grows wary of Bob (|2| crosses threshold).
+        val round1State = SimulationState.initial(s).copy(
+            currentRound = 1,
+            lastOutputs = mapOf("Bob" to TurnOutput(fields = mapOf("vote" to "Alice"))),
+        )
+        val afterRound1 = handler.execute(context(s), round1State)
+        assertTrue(afterRound1.variables["relationships_Alice"]?.contains("Bob") == true)
+
+        // Bob is eliminated; re-run with no fresh signal, threading the returned state.
+        val round2State = afterRound1.copy(
+            eliminated = afterRound1.eliminated + ("Bob" to true),
+            lastOutputs = emptyMap(),
+        )
+        val result = handler.execute(context(s), round2State)
+
+        // Prose no longer mentions the eliminated agent, but the raw matrix keeps
+        // the accumulated history (for the event payload / Phase-3 viz).
+        assertEquals("", result.variables["relationships_Alice"])
+        assertTrue(result.variables["relationships_raw_Alice"]?.contains("Bob") == true)
+    }
+
+    // MARK: - Negative control on the no-signal placement diagnostic (beyond Swift's 9)
+
+    /** Records every [EngineLogger.log] call for negative-control assertions. */
+    private class CapturingEngineLogger : EngineLogger {
+        data class Entry(val level: EngineLogLevel, val category: String, val message: String)
+
+        val entries = mutableListOf<Entry>()
+        override fun log(level: EngineLogLevel, category: String, message: String, privacy: EngineLogPrivacy) {
+            entries += Entry(level, category, message)
+        }
+    }
+
+    @Test
+    fun placementDiagnosticFiresWhenNoSignal() = runTest {
+        val s = scenario(voteAgainst = -1)
+        // No lastOutputs, no pairings — the misordered/placeholder case the guard targets.
+        val state = SimulationState.initial(s).copy(currentRound = 1)
+        val logger = CapturingEngineLogger()
+        handler.execute(context(s, logger = logger), state)
+
+        val diagnostics = logger.entries.filter { it.category == "RelationshipUpdate" }
+        assertEquals(1, diagnostics.size)
+        assertEquals(EngineLogLevel.DEBUG, diagnostics.single().level)
+    }
+
+    @Test
+    fun placementDiagnosticSilentWhenSignalPresent() = runTest {
+        val s = scenario(voteAgainst = -1)
+        // A live vote signal — the guard must NOT fire (negative control; without it
+        // the "fires when no signal" assertion above passes even for an always-log bug).
+        val state = SimulationState.initial(s).copy(
+            currentRound = 1,
+            lastOutputs = mapOf("Alice" to TurnOutput(fields = mapOf("vote" to "Bob"))),
+        )
+        val logger = CapturingEngineLogger()
+        handler.execute(context(s, logger = logger), state)
+
+        assertTrue(logger.entries.none { it.category == "RelationshipUpdate" })
+    }
+}


### PR DESCRIPTION
## Summary

Ports the Swift `RelationshipUpdateHandler` (a zero-inference `relationship_update` code phase, #910) to Kotlin `commonMain` and registers it in the KMP `PhaseDispatcher`. Part of the ADR-023 Stage 3 Wave B **code-phase** track (`Part of #501`) — independent of the LLM-handler track (B0/B1–B6).

Load-bearing port diffs from the Swift original:

- **Immutable state** — the affinity matrix is built in a **local** `MutableMap` (mutating a local is fine — it is not `SimulationState`), and `execute` returns `state.copy(variables = …)`. The two apply-helpers keep Swift's side-effecting design over that local matrix.
- **No `||` short-circuit** — `applyVotes` / `applyActions` are evaluated in separate statements, then `sawSignal = sawVotes || sawActions`. A short-circuiting `||` over the two side-effecting helpers would drop the action signal whenever a vote signal is also live (a phase may declare both `vote_against` and `action_deltas`). Guarded by `appliesBothVoteAndActionSignalsInSamePhase`.
- **Sorted-keys JSON** — the reserved `relationships_raw_<name>` matrix is encoded with manual key sorting (`row.toList().sortedBy { it.first }.toMap()` — `Map.toSortedMap()` is JVM-only, absent from `commonMain`) via `kotlinx.serialization`, byte-parity with Swift's `JSONEncoder.outputFormatting = .sortedKeys`. `"{}"` / `emptyMap()` fallback mirrors Swift's `try?`.
- **Eliminated agents** excluded as perceivers; the raw matrix keeps full cross-round history but the injected prose (`relationships_<name>`) mentions only currently-active agents.

Scope is runtime execution only — the load-time shape-check (`validateRelationshipUpdateShape`) + linter R4 placement warning are a separate ScenarioValidator/linter slice (out of scope).

## Test plan

- `RelationshipUpdateHandlerTests.kt` — Kotlin parity port of the 9 Swift cases, **plus** a negative control on the no-signal placement diagnostic (asserts `context.logger` fires a single `RelationshipUpdate` `.debug` entry only when neither a vote nor a pairing signal is present, and is silent when a signal is present — the Swift suite never exercised the guard firing). The two multi-round cases thread round-1's **returned** state into round 2.
- `PhaseDispatcherTests.kt` — updated the unported-phase census (10 → 9) + added the positive-resolution assertion for `RELATIONSHIP_UPDATE`.
- Verified locally: `./gradlew :shared:models:jvmTest :shared:engine:jvmTest` — `RelationshipUpdateHandlerTests` 11/0, `PhaseDispatcherTests` 10/0, full engine suite green. `compileCommonMainKotlinMetadata` green (no commonMain stdlib trap).

⚠️ `PhaseDispatcher.kt` / `PhaseDispatcherTests.kt` are shared with the concurrent CP2 session (EVENT_INJECT/SCORE_CALC) — a trivial adjacent-line merge conflict is expected for whichever merges second.

## Device QA

実機QA不要 — Kotlin `shared/` only (no iOS app target code, no LLM/Metal/device-only surface).

Closes #1229
Part of #501
