### PR TITLE
🐛 fix: harness injects LanguageDetector so language_mismatch fires (#1234)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -352,6 +352,7 @@ same change:
 | `docs/design/demo-replay-reference.html` | DL-time demo visual reference prototype (HTML)             |
 | `docs/security/release-checklist.md`  | Operator security checklist (GitHub settings, iOS pre-submission audit, recurring review) |
 | `docs/models/onboarding.md`           | Model onboarding two-gate procedure (Stage-0 harness profile → `/model-eval` Mac filter → ADR-011 real-device accept → registration; intake #979) |
+| `docs/models/eval-log.md`             | Model-eval 判定台帳 — 候補評価の verdict を committed に記録(judgment-only; 生スコアは gitignore の data/models/eval-digest.md; ADR-011 表が追跡する 6GB/1B級以外の候補が対象; #979 intake) |
 | `docs/qa/navigation-qa.md`            | Navigation manual QA walkthroughs (numbered scenarios; extracted from `.claude/rules/navigation.md`) |
 | `docs/ci/xcodebuild-flakes.md`        | CI UI-test flake catalog + hang/stall session-recovery walkthrough (extracted from `.claude/rules/xcodebuild-cli.md`) |
 | `docs/prototype/among_them_prototype.py` | Python prototype (reference implementation) |

--- a/Pastura/Pastura/App/NLLanguageDetector.swift
+++ b/Pastura/Pastura/App/NLLanguageDetector.swift
@@ -30,7 +30,10 @@ import NaturalLanguage
 ///   would skew confidence on cross-language drift cases (the very cases
 ///   the adherence check exists to catch).
 nonisolated public final class NLLanguageDetector: LanguageDetector {
-  private static let confidenceThreshold: Double = 0.5
+  // Sourced from the shared LLM/ default so this concrete and the harness
+  // concrete (`HarnessLanguageDetector`) never drift apart — see
+  // ``LanguageDetectionDefaults``.
+  private static let confidenceThreshold = LanguageDetectionDefaults.confidenceThreshold
 
   /// Creates a detector with the default confidence threshold (0.5).
   public init() {}

--- a/Pastura/Pastura/LLM/LanguageDetector.swift
+++ b/Pastura/Pastura/LLM/LanguageDetector.swift
@@ -30,3 +30,26 @@ nonisolated public protocol LanguageDetector: Sendable {
   ///   "skip the adherence check" rather than "mismatch".
   func detect(text: String) -> String?
 }
+
+/// Shared tuning defaults for ``LanguageDetector`` implementations.
+///
+/// This is a cross-implementation **parity** constant: both the production
+/// concrete (``NLLanguageDetector`` in App/) and the headless harness concrete
+/// (`HarnessLanguageDetector` in `tools/harness/`) read the confidence
+/// threshold from here, so the `language_mismatch` metric a harness run reports
+/// stays a faithful proxy for production behaviour when this value is revisited
+/// (rather than drifting between two separate literals).
+///
+/// It carries **no** `NaturalLanguage` dependency — a plain `Double` — so it is
+/// legal in the LLM/ layer under ADR-010 D8 (the guarded layers stay free of
+/// `import NaturalLanguage`; only the abstraction crosses the boundary). It
+/// ports to `commonMain` alongside the protocol per ADR-023 §4.
+nonisolated public enum LanguageDetectionDefaults {
+  /// Minimum top-hypothesis confidence for a detection result to be trusted.
+  ///
+  /// Below this, a detector returns `nil` so ``LLMCaller`` skips the adherence
+  /// check rather than misclassifying a short / ambiguous output as a language
+  /// mismatch. Initial value (Step E PR2); the benchmark harness records
+  /// skip-rate to revisit in a follow-up if needed.
+  public static let confidenceThreshold: Double = 0.5
+}

--- a/tools/harness/Sources/PasturaHarnessKit/HarnessLanguageDetector.swift
+++ b/tools/harness/Sources/PasturaHarnessKit/HarnessLanguageDetector.swift
@@ -1,0 +1,46 @@
+import Foundation
+import NaturalLanguage
+import PasturaCore
+
+/// Headless-harness implementation of ``LanguageDetector``, backed by Apple's
+/// `NLLanguageRecognizer` (available on macOS 15+, this package's platform).
+///
+/// This is the harness-side twin of `NLLanguageDetector` (App/). The harness
+/// SwiftPM package reuses `Models`/`LLM`/`Engine` but **excludes** App/ (see
+/// the root `Package.swift`), so it cannot reach the production concrete — yet
+/// without a real detector injected, `LLMCaller.detectLanguageMismatch`
+/// short-circuits on `guard let detector` and the `language_mismatch` metric is
+/// 0 by construction in every harness run (issue #1234). `HarnessRunner`
+/// injects this into `SimulationRunner`.
+///
+/// Why a separate concrete rather than sharing one: ADR-010 D8 forbids
+/// `import NaturalLanguage` in the guarded LLM/ layer (CI-enforced by
+/// `scripts/check_naturallanguage_axis.sh`), and ADR-023 §4 ports the
+/// `LanguageDetector` protocol to `commonMain` while its `NaturalLanguage`
+/// concrete stays platform-side — so "each consumer owns its concrete" is the
+/// intended shape. The only semantically-tunable value, the confidence
+/// threshold, is shared via ``LanguageDetectionDefaults`` (a pure `Double`,
+/// D8-clean) so this and `NLLanguageDetector` cannot drift apart.
+///
+/// Implementation mirrors `NLLanguageDetector`: a fresh `NLLanguageRecognizer`
+/// per call (avoids `reset()` / cross-call state accumulation), top-hypothesis
+/// confidence gated at ``LanguageDetectionDefaults/confidenceThreshold``, and
+/// default `languageHints` / `languageConstraints` (pinning would skew
+/// confidence on the very cross-language drift cases the check exists to catch).
+package final class HarnessLanguageDetector: LanguageDetector {
+  package init() {}
+
+  package func detect(text: String) -> String? {
+    guard !text.isEmpty else { return nil }
+    let recognizer = NLLanguageRecognizer()
+    recognizer.processString(text)
+    let hypotheses = recognizer.languageHypotheses(withMaximum: 1)
+    guard
+      let (language, confidence) = hypotheses.first,
+      confidence >= LanguageDetectionDefaults.confidenceThreshold
+    else {
+      return nil
+    }
+    return language.rawValue
+  }
+}

--- a/tools/harness/Sources/PasturaHarnessKit/HarnessRunner.swift
+++ b/tools/harness/Sources/PasturaHarnessKit/HarnessRunner.swift
@@ -66,7 +66,12 @@ package final class HarnessRunner: Sendable {
       let logger = diagLogger ?? StderrEngineLogger()
       self.diagLogger = logger
       self.streamFactory = { scenario, llm, controller in
-        SimulationRunner(logger: logger).run(
+        // Inject a real detector so the ADR-010 Step E language-adherence
+        // check is live (production wires `NLLanguageDetector` at the View
+        // boundary; App/ is out of the harness sources, so the harness owns
+        // its own `HarnessLanguageDetector`). Without it `language_mismatch`
+        // is 0 by construction in every harness run (#1234).
+        SimulationRunner(detector: HarnessLanguageDetector(), logger: logger).run(
           scenario: scenario, llm: llm, suspendController: controller)
       }
     }

--- a/tools/harness/Tests/PasturaHarnessKitTests/HarnessLanguageDetectorTests.swift
+++ b/tools/harness/Tests/PasturaHarnessKitTests/HarnessLanguageDetectorTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+import PasturaCore
+import Synchronization
+import Testing
+
+@testable import PasturaHarnessKit
+
+/// Collects appended JSONL lines in memory (mirrors `HarnessRunnerTests`).
+private final class InMemoryWriter: RunLogWriting {
+  private let lines = Mutex<[String]>([])
+
+  func append(_ line: String) throws {
+    lines.withLock { $0.append(line) }
+  }
+
+  var all: [String] { lines.withLock { $0 } }
+}
+
+/// A `language: ja` scenario whose `speak_all` output is a `.string` field —
+/// so the ADR-010 Step E language-adherence check runs on the agents'
+/// (English) statements.
+private func makeJapaneseScenario() throws -> Scenario {
+  let yaml = """
+    id: lang_drift_test
+    name: Lang Drift Test
+    description: minimal ja scenario for the language-adherence negative control
+    language: ja
+    agents: 2
+    rounds: 1
+    context: test
+    personas:
+      - name: A
+        personality: calm
+      - name: B
+        personality: bold
+    phases:
+      - type: speak_all
+        prompt: say something
+        output:
+          statement: string
+    """
+  return try ScenarioLoader().load(yaml: yaml)
+}
+
+/// Negative control for issue #1234: the harness must inject a real
+/// `LanguageDetector`, otherwise `LLMCaller.detectLanguageMismatch` short-
+/// circuits on `guard let detector` and the `language_mismatch` metric is 0 by
+/// construction in every harness run.
+///
+/// `.serialized`: this suite constructs a real `SimulationRunner` (via the
+/// default `streamFactory`), which spawns `Task` + `AsyncStream`; per
+/// `.claude/rules/swift-testing-parallelism.md`, such suites serialize to avoid
+/// concurrent-teardown flakes as tests are added.
+@Suite(.serialized, .timeLimit(.minutes(1)))
+struct HarnessLanguageDetectorTests {
+  /// Drives the DEFAULT `streamFactory` path — passing a test-supplied
+  /// `streamFactory` would bypass the injection site and make this pass by
+  /// construction (the exact defect being fixed). Feeds unambiguous English
+  /// through a `ja` scenario and asserts the mismatch reaches the JSONL, so a
+  /// silent regression to `detector == nil` fails loudly.
+  @Test func englishOutputInJapaneseScenarioEmitsLanguageMismatch() async throws {
+    let writer = InMemoryWriter()
+    let diag = Mutex<[String]>([])
+    let diagLogger = StderrEngineLogger(sink: { line in diag.withLock { $0.append(line) } })
+
+    // ≥12 unicode scalars of unambiguous English inside the `.string`
+    // `statement` field (the < 12-scalar gate skips the check as too_short).
+    // Queue enough for 2 agents × 3 attempts: the mismatch only emits on the
+    // 3rd, retry-exhausting attempt (LLMCaller.maxRetries = 2).
+    let english = #"{"statement": "I strongly believe we should all cooperate together right now"}"#
+    let runner = HarnessRunner(
+      llmFactory: { MockLLMService(responses: Array(repeating: english, count: 8)) },
+      writer: writer,
+      timeoutSeconds: 10,
+      diagLogger: diagLogger)
+
+    let summary = await runner.execute(
+      scenario: try makeJapaneseScenario(), runID: "lang-drift",
+      startDate: "2026-07-23T00:00:00Z", modelName: "mock")
+
+    // The mismatch does not fail the run — ADR-010 Step E: the sim continues
+    // with the parsed output, structurally distinct from parse/empty failures.
+    #expect(summary.status == .ok)
+    // Primary negative control: the mismatch actually reached the run-log JSONL.
+    #expect(writer.all.contains { $0.contains("\"event\":\"language_mismatch\"") })
+    // Co-assertion (diagnostic channel, not the JSONL): the check was NOT
+    // skipped as too_short. A future fixture shrink below the 12-scalar gate
+    // would otherwise silently stop firing while this test still "passed".
+    #expect(!diag.withLock { $0 }.contains { $0.contains("reason=too_short") })
+  }
+}


### PR DESCRIPTION
## Summary

- **Fixes #1234** — the `pastura-harness` built `SimulationRunner(logger:)` with no `detector:`, so `LLMCaller.detectLanguageMismatch` short-circuited on `guard let detector` and the `language_mismatch` metric surfaced by `/model-eval`, `/scenario-factory`, and `/scenario-refine` was **0 by construction in every harness run** — a guard that passed by construction.
- **Design (案C)**, chosen over two alternatives after a Fable second-opinion and an Opus critic pass:
  - The harness owns its own `NaturalLanguage` concrete (`HarnessLanguageDetector`), since App/`NLLanguageDetector` is out of the harness sources and **ADR-010 D8 forbids `import NaturalLanguage` in the guarded LLM/ layer** (CI-enforced by `scripts/check_naturallanguage_axis.sh`).
  - Only the confidence threshold is shared, via a pure-`Double` `LanguageDetectionDefaults` enum in `LLM/` (no NL import → D8 stays green), so the two concretes cannot drift.
  - Aligns with **ADR-023 §4** (the `LanguageDetector` protocol ports to `commonMain`; its NL concrete stays platform-side — "each consumer owns its concrete").
- Rejected alternatives: a raw harness-local wrapper (leaves the `0.5` threshold duplicated → drift); adding `App/NLLanguageDetector.swift` to the harness `Package.swift` `sources` (SwiftPM's documented `exclude`-over-`sources` precedence likely drops it, and it creates an implicit "App file must stay self-contained" invariant that remote-breaks harness CI).

## Negative control (why this is not a guard that passes by construction)

The new test in `PasturaHarnessKitTests` drives the **default** `streamFactory` path — a test-supplied `streamFactory` would bypass the injection site and pass by construction (the exact defect being fixed). It feeds unambiguous English (≥ the 12-scalar `minDetectionLength` gate, inside the `.string` `statement` field) through a `ja` scenario and asserts a `"event":"language_mismatch"` JSONL line fires, plus a co-assertion that no `too_short` skip occurred on the diag channel. Verified RED on the unfixed code, GREEN after the fix.

## Test plan

- `swift test` (full harness suite) — 64 tests pass, incl. the new negative control.
- `swift build` — clean.
- `scripts/check_naturallanguage_axis.sh` — D8 boundary clean (Engine/LLM/Models/Data).
- `scripts/xcodebuild.sh build` — iOS app compiles with `App/NLLanguageDetector` sourcing the shared LLM/ constant.

## Note on the second commit

`📝 docs: add eval-log.md row…` is an **independent** doc-consistency fix (the `docs/models/eval-log.md` ledger from #1236 was missing from the CLAUDE.md Reference Documents table) — unrelated to the harness bug, bundled here at the requester's direction. Not part of the #1234 fix.

## Device QA

実機QA不要 — changes are the macOS-only harness, a pure-`Double` LLM/ constant, a constant-reference refactor in `App/NLLanguageDetector` (no behavior change), and a docs row. No `#if !targetEnvironment(simulator)` / Metal / layout surface.

Closes #1234
