### PR TITLE
🧹 chore: port inject* prompt infra to commonMain + SpeakAll parity

### DIFF
--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/SpeakAllHandler.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/SpeakAllHandler.kt
@@ -17,13 +17,16 @@ import com.pastura.models.SimulationState
  * cleared — while the remaining agents still speak. Systemic errors, cancellation,
  * and the D4 circuit breaker propagate and abort the run (see [TurnFailureGate]).
  *
- * ## Still absent — later Wave-B / Stage-3 freight
+ * ## Prompt-injection parity (Wave B)
  *
- * Per [PromptBuilder]'s absence table the `inject*` family (assigned / notes /
- * whispers / relationships / mood) and `captureMood` are not called here yet. Those
- * land with their consumers in later Wave-B PRs and are orthogonal to the
- * turn-gate behavior restored here. The `detector` / `logger` seams ARE wired now
- * (B0b) — the handler threads them from [PhaseContext] into [LLMCaller].
+ * The reserved-namespace `inject*` family (assigned / notes / whispers /
+ * relationships / mood) and [PromptBuilder.captureMood] ARE now wired here — this
+ * handler is the first consumer of the Wave-B injection infrastructure. It calls
+ * all five injectors on the local prompt map (a miss resolves to `""`, so a scenario
+ * whose producer phases never ran is unaffected) and folds `captureMood` into its
+ * success-path state, a no-op unless the phase declares a `mood` output field. The
+ * `detector` / `logger` seams were wired earlier (B0b) — the handler threads them
+ * from [PhaseContext] into [LLMCaller].
  *
  * Swift original: `Pastura/Pastura/Engine/Phases/SpeakAllHandler.swift`.
  */
@@ -78,6 +81,9 @@ internal class SpeakAllHandler : PhaseHandler {
             state = state,
         )
 
+        // Local prompt-variable map (thrown away after the prompt is built). The
+        // `inject*` family mutates it in place to surface each reserved-namespace
+        // `{token}` to only this speaker; none of this touches persisted state.
         val variables = state.variables.toMutableMap()
         variables["scoreboard"] = promptBuilder.formatScoreboard(state.scores)
         variables["conversation_log"] = promptBuilder.formatConversationLog(
@@ -85,6 +91,11 @@ internal class SpeakAllHandler : PhaseHandler {
             language = context.scenario.engineLanguage,
             window = context.scenario.logWindow,
         )
+        promptBuilder.injectAssigned(variables, persona.name)
+        promptBuilder.injectNotes(variables, persona.name)
+        promptBuilder.injectWhispers(variables, persona.name)
+        promptBuilder.injectRelationships(variables, persona.name)
+        promptBuilder.injectMood(variables, persona.name)
         val userPrompt = promptBuilder.expandTemplate(promptTemplate, variables)
 
         val output = context.turnGate.attempt(
@@ -121,7 +132,15 @@ internal class SpeakAllHandler : PhaseHandler {
 
         val mainField = promptBuilder.getMainField(context.phase)
         val content = output.fields[mainField] ?: ""
+        // captureMood (#913) folds into the PERSISTED `state.variables` (a fresh
+        // copy), NOT the local prompt map above — and only here on the success
+        // path, never on the skip-path copy. Mirrors Swift's
+        // `captureMood(from: output, into: &state.variables, ...)` after the
+        // conversation-log / lastOutputs writes.
+        val nextVariables = state.variables.toMutableMap()
+        promptBuilder.captureMood(output, nextVariables, persona.name)
         return state.copy(
+            variables = nextVariables,
             conversationLog = state.conversationLog + ConversationEntry(
                 agentName = persona.name,
                 content = content,

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/PromptBuilder.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/PromptBuilder.kt
@@ -7,6 +7,7 @@ import com.pastura.models.Phase
 import com.pastura.models.Scenario
 import com.pastura.models.ScenarioConventions
 import com.pastura.models.SimulationState
+import com.pastura.models.TurnOutput
 
 /**
  * Builds LLM prompts for simulation phases.
@@ -14,31 +15,34 @@ import com.pastura.models.SimulationState
  * Handles template variable expansion, system-prompt construction with persona
  * and scenario context, and conversation-log formatting for prompt injection.
  *
- * ## Scope: the ADR-023 §6 Stage-2 gate slice's *minimal* subset
+ * ## Scope: Stage-3 Wave B — injection family landed, handler rules pending
  *
- * ADR-023 §6 lists `PromptBuilder` as a "hard build-dep — in the slice, or
- * stubbed", i.e. prompt-content fidelity is explicitly **not** what the gate
- * measures; the boundary crossings are. This port is therefore deliberately
- * behaviour-incomplete against Swift, and **must not be read as parity**.
+ * ADR-023 §6 originally listed `PromptBuilder` as a Stage-2 "hard build-dep — in
+ * the slice, or stubbed"; the gate measured boundary crossings, not prompt-content
+ * fidelity. Wave B now closes that gap consumer-by-consumer, so this is **partial
+ * parity**, not full: the reserved-namespace injection family is landed (its first
+ * consumer, `SpeakAllHandler`, calls all of it), but the handler-specific answer
+ * rules and the unwired helper types below are not.
  *
  * What is ported: [expandTemplate], [formatScoreboard], [formatConversationLog],
- * [getMainField], and a [buildSystemPrompt] covering the speak_all path (header,
- * scenario context, persona, secret, base answer rules, output format).
+ * [getMainField]; [buildSystemPrompt] (header, scenario context, persona, secret,
+ * private self-knowledge sections, base answer rules + mood rule, output format);
+ * the injection family ([injectAssigned] / [injectNotes] / [injectWhispers] /
+ * [injectRelationships] / [injectMood]), [captureMood] + `moodRule`, and
+ * `appendPrivateSections`.
  *
- * What is **knowingly absent** — each a *named* unit, tracked on #501 for Stage
- * 3, never a silent drop:
+ * What is **knowingly absent** — each a *named* unit, tracked on #501 for its
+ * Wave-B handler PR, never a silent drop:
  *
  * | Absent | Why |
  * |---|---|
- * | `injectAssigned` / `injectNotes` / `injectWhispers` / `injectRelationships` / `injectMood` | their producer phases (assign / reflect / whisper / relationship_update) are Stage-3 freight |
- * | `captureMood` (#913) + `moodRule` | ditto — no slice phase declares `mood` |
- * | `addressRule` (#911, speak_each) | speak_each is Stage 3 |
- * | `reflectBrevityRule` / `whisperRule` | reflect / whisper are Stage 3 |
- * | choose-options rule / `voteCandidateRule` | choose / vote are Stage 3 |
- * | `RelationshipVerbalizer`, `PromptPlaceholders`, `ErrorReadability` | types landed in PR-3 (#501 Stage 3); PromptBuilder still has no slice consumer for them (wiring deferred to Wave B) |
+ * | `addressRule` (#911, speak_each) | speak_each is a later Wave-B handler |
+ * | `reflectBrevityRule` / `whisperRule` | reflect / whisper are later Wave-B handlers |
+ * | choose-options rule / `voteCandidateRule` | choose / vote are later Wave-B handlers |
+ * | `RelationshipVerbalizer`, `PromptPlaceholders`, `ErrorReadability` | types landed in PR-3 (#501 Stage 3); PromptBuilder still has no slice consumer for them (wiring deferred to their Wave-B handlers) |
  *
- * A Stage-3 port completes these against the Swift test files, which ADR-023 §6
- * names as the executable spec.
+ * Each remaining unit lands with its handler against the Swift test files, which
+ * ADR-023 §6 names as the executable spec.
  *
  * Swift original: `Pastura/Pastura/Engine/PromptBuilder.swift` (+`Injection`,
  * +`PrivateSections`).
@@ -186,11 +190,8 @@ internal class PromptBuilder {
         scenario: Scenario,
         persona: Persona,
         phase: Phase,
-        @Suppress("UNUSED_PARAMETER") state: SimulationState,
+        state: SimulationState,
     ): String {
-        // `state` is unused HERE but kept for signature parity: Swift threads it
-        // into appendPrivateSections and voteCandidateRule, both Stage-3 units in
-        // the absence table. Do not delete — Stage 3 needs it back.
         val language = scenario.engineLanguage
         val sections = mutableListOf<String>()
 
@@ -208,6 +209,7 @@ internal class PromptBuilder {
         sections += "$personaHeader\n$nameLabel: ${persona.name}\n${persona.description}"
 
         appendSecretSection(sections, persona, language)
+        appendPrivateSections(sections, persona, state, language)
         sections += buildAnswerRules(language, phase)
         formatOutputSchema(OutputSchema.from(phase), language)?.let { sections += it }
 
@@ -263,7 +265,7 @@ internal class PromptBuilder {
         val maxSentences =
             (phase.maxSentences ?: DEFAULT_STATEMENT_MAX_SENTENCES).coerceIn(1, 6)
         val sentenceNoun = if (maxSentences == 1) "sentence" else "sentences"
-        return pickLanguage(
+        var rules = pickLanguage(
             language,
             ja = """
                 ## 回答ルール（厳守）
@@ -286,7 +288,33 @@ internal class PromptBuilder {
                 - Output exactly one object starting with { and ending with }, with no surrounding text.
             """.trimIndent(),
         )
+
+        // Mood-opting phases (#913) get the mood-writing guidance. Gated on the
+        // schema, not the phase type — any LLM phase can declare `mood`.
+        if (phase.outputSchemaKeys.contains("mood")) {
+            rules += moodRule(language)
+        }
+        return rules
     }
+
+    /**
+     * The #913 mood-writing guidance, appended only for phases that opt into a
+     * `mood` output field ([buildAnswerRules] gates on the schema). A short-word
+     * cap plus an explicit "change naturally, don't force-maintain or abruptly
+     * reset" instruction is the primary lever against echo-fixation (the same
+     * mood every turn) and unmotivated slashing (flips unrelated to events). Keep
+     * ja/en scope-parallel; wording is harness-A/B-tunable. The reserved-namespace
+     * inject/capture side lives in [captureMood] / [injectMood].
+     */
+    private fun moodRule(language: String): String =
+        pickLanguage(
+            language,
+            ja = "\n- moodには今の気分を短い言葉で書くこと（例: わくわく、苛立ち、不安）。" +
+                "気分は出来事に応じて自然に変化してよく、無理に維持も急変もしないこと",
+            en = "\n- Write your current mood in the mood field as a short phrase " +
+                "(e.g. excited, irritated, uneasy). Let it shift naturally with what happens — " +
+                "neither forced to stay the same nor snapped to something unrelated.",
+        )
 
     /**
      * The `## 出力フォーマット（JSON）/ ## Output Format (JSON)` block, or `null` for a
@@ -316,5 +344,154 @@ internal class PromptBuilder {
         )
         val examplePrefix = pickLanguage(language, ja = "例", en = "Example")
         return "$header\n{$spec}\n$examplePrefix: {$example}"
+    }
+
+    // MARK: - Reserved-namespace injection (#890 / #907 / #908 / #910 / #913)
+
+    // Each `inject*` reads a per-persona `<prefix>_<name>` key from the caller's
+    // local prompt-variable map and surfaces it to only the current speaker under
+    // a public `{token}`. They mutate [variables] IN PLACE (the local prompt map,
+    // seeded from `state.variables` and discarded after the prompt is built) — NOT
+    // persisted state; this mirrors Swift's `inout [String: String]`. The matching
+    // system-prompt *sections* live in [appendPrivateSections]; the mood answer-rule
+    // in [moodRule]. A missing key resolves to empty string, never a literal
+    // placeholder — the shared miss posture.
+
+    /**
+     * Injects the current speaker's `assign`-phase value under the canonical
+     * `{assigned}` key and its backward-compat alias `{assigned_word}`.
+     *
+     * `AssignHandler` stores each agent's value under `assigned_<name>`; this reads
+     * it back for the speaker so per-persona prompt templates resolve (#890 —
+     * before this `{assigned_word}` leaked literally and Word Wolf's secret-word
+     * mechanic never worked).
+     *
+     * Note: a persona literally named `word` would produce key `assigned_word`,
+     * colliding with this alias — the alias then reflects the current speaker's
+     * value, not that persona's assignment. Contrived and absent from all bundled
+     * presets; the `assigned_` prefix is effectively a reserved namespace.
+     */
+    fun injectAssigned(variables: MutableMap<String, String>, personaName: String) {
+        val mine = variables["assigned_$personaName"] ?: ""
+        variables["assigned"] = mine
+        variables["assigned_word"] = mine
+    }
+
+    /**
+     * Injects the current speaker's `reflect`-phase memo under `{my_notes}`.
+     * `ReflectHandler` stores each agent's private note under `notes_<name>` (#907).
+     */
+    fun injectNotes(variables: MutableMap<String, String>, personaName: String) {
+        variables["my_notes"] = variables["notes_$personaName"] ?: ""
+    }
+
+    /**
+     * Injects the current speaker's `whisper` channel under `{my_whispers}`.
+     * `WhisperHandler` stores each participant's private view of their pair's
+     * exchange under `whispers_<name>` (#908).
+     */
+    fun injectWhispers(variables: MutableMap<String, String>, personaName: String) {
+        variables["my_whispers"] = variables["whispers_$personaName"] ?: ""
+    }
+
+    /**
+     * Injects the current speaker's `relationship_update` affinity summary under
+     * `{relationships}`. `RelationshipUpdateHandler` stores each agent's prose read
+     * on the others under `relationships_<name>` (#910).
+     */
+    fun injectRelationships(variables: MutableMap<String, String>, personaName: String) {
+        variables["relationships"] = variables["relationships_$personaName"] ?: ""
+    }
+
+    /**
+     * Injects the current speaker's carried-over `mood` under `{my_mood}`.
+     *
+     * [captureMood] persists the value under `mood_<name>` (#913); a miss (scenario
+     * never opts in, or round 1 before any mood is set) renders no mood text.
+     * Unlike notes/whispers, an agent never sees another's mood — it is
+     * self-referential emotional inertia, so there is no cross-agent leak surface.
+     */
+    fun injectMood(variables: MutableMap<String, String>, personaName: String) {
+        variables["my_mood"] = variables["mood_$personaName"] ?: ""
+    }
+
+    /**
+     * Persists a turn's `mood` output field under the reserved per-persona key
+     * `mood_<name>` so it carries into the same agent's next prompt (#913).
+     *
+     * Writes only a **non-empty** mood: a failed/empty inference must not erase the
+     * prior turn's mood (the same non-empty guard `ReflectHandler` applies to its
+     * note); last-write-wins. A phase whose schema does not declare `mood` never
+     * produces the key, so this is a no-op there — called from every LLM handler
+     * for symmetry.
+     *
+     * Mutates [variables] IN PLACE. The handler threads the **persisted**
+     * `state.variables` here (via a copy folded into its success-path
+     * `state.copy`), NOT the local prompt map used by the `inject*` family — that
+     * map is discarded after the prompt is built, so a capture into it would be
+     * lost. Mirrors Swift's `inout &state.variables`.
+     */
+    fun captureMood(output: TurnOutput, variables: MutableMap<String, String>, personaName: String) {
+        val mood = output.fields["mood"] ?: ""
+        if (mood.isNotEmpty()) {
+            variables["mood_$personaName"] = mood
+        }
+    }
+
+    /**
+     * Appends each agent's private self-knowledge sections to [sections]: the
+     * reflect note (`notes_<name>`, #907), the whisper channel (`whispers_<name>`,
+     * #908), the relationship read (`relationships_<name>`, #910), and — placed
+     * LAST for recency and surfaced in EVERY phase so the inertia survives an
+     * intervening vote/choose — the carried-over mood (`mood_<name>`, #913).
+     *
+     * Each is derived only for that agent and never enters the conversation log,
+     * so every header stresses its privacy. An absent or empty value renders no
+     * section (no empty header). Reads the **persisted** `state.variables`
+     * directly — independent of the `inject*` local prompt map.
+     */
+    private fun appendPrivateSections(
+        sections: MutableList<String>,
+        persona: Persona,
+        state: SimulationState,
+        language: String,
+    ) {
+        state.variables["notes_${persona.name}"]?.takeIf { it.isNotEmpty() }?.let { note ->
+            val header = pickLanguage(
+                language,
+                ja = "## あなたの内心メモ（他の参加者には見えません）",
+                en = "## Your Private Notes (invisible to other participants)",
+            )
+            sections += "$header\n$note"
+        }
+
+        state.variables["whispers_${persona.name}"]?.takeIf { it.isNotEmpty() }?.let { whispers ->
+            val header = pickLanguage(
+                language,
+                ja = "## あなたの密談（密談相手以外には見えません）",
+                en = "## Your Private Whispers (invisible to everyone except your whisper partner)",
+            )
+            sections += "$header\n$whispers"
+        }
+
+        state.variables["relationships_${persona.name}"]?.takeIf { it.isNotEmpty() }?.let { relationships ->
+            val header = pickLanguage(
+                language,
+                ja = "## あなたの人間関係（他の参加者には見えません）",
+                en = "## Your Read on the Others (invisible to other participants)",
+            )
+            sections += "$header\n$relationships"
+        }
+
+        // Mood placed LAST (#913): nearest the answer rules for recency, and shown
+        // in EVERY phase (not just declaring ones) so the inertia survives.
+        state.variables["mood_${persona.name}"]?.takeIf { it.isNotEmpty() }?.let { mood ->
+            val header = pickLanguage(
+                language,
+                ja = "## あなたの今の気分",
+                en = "## Your Current Mood",
+            )
+            sections += "$header\n$mood"
+        }
     }
 }

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/PromptBuilderInjectionTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/PromptBuilderInjectionTests.kt
@@ -1,0 +1,402 @@
+package com.pastura.engine
+
+import com.pastura.models.Persona
+import com.pastura.models.Phase
+import com.pastura.models.PhaseType
+import com.pastura.models.Scenario
+import com.pastura.models.SimulationState
+import com.pastura.models.TurnOutput
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Parity tests for the Wave-B reserved-namespace injection family
+ * (`inject*` / [PromptBuilder.captureMood] / `appendPrivateSections` / `moodRule`),
+ * ported from the Swift executable spec (ADR-023 §6): `PromptBuilderTests+Mood`,
+ * `+Whispers`, `+Relationships`, and the notes cases in `+Hardening`.
+ *
+ * Unlike [PromptBuilderTests] (which disclaims parity for the still-incomplete
+ * base slice), these DO assert parity: their landed units are the full Swift
+ * behaviour. Deliberately **out of scope** here — deferred to their own Wave-B
+ * handler PRs, so their guidance is not yet ported: `whisperRule`,
+ * `reflectBrevityRule`, `addressRule`, `voteCandidateRule`, and the choose-options
+ * rule. Only the `mood` answer-rule is asserted, because `moodRule` lands with
+ * this infrastructure.
+ *
+ * Split into its own file per the commonTest concern-per-file convention
+ * (cf. [PromptBuilderParityTests]); these are pure, stateless `PromptBuilder`
+ * calls, so no cross-class shared state applies.
+ */
+class PromptBuilderInjectionTests {
+
+    private val builder = PromptBuilder()
+
+    private val alice = Persona(name = "Alice", description = "A.")
+    private val bob = Persona(name = "Bob", description = "B.")
+    private val charlie = Persona(name = "Charlie", description = "C.")
+
+    private val speakAll = Phase(
+        type = PhaseType.SPEAK_ALL,
+        prompt = "Speak.",
+        outputSchema = mapOf("statement" to "string"),
+    )
+
+    // The Swift `makeScenario()` these specs use defaults to `ja`; mirror that so
+    // the section-header assertions line up.
+    private fun scenario(language: String = "ja") = Scenario(
+        id = "t",
+        name = "T",
+        description = "d",
+        language = language,
+        simulationLanguage = null,
+        agentCount = 3,
+        rounds = 1,
+        logWindow = null,
+        context = "A test.",
+        personas = listOf(alice, bob, charlie),
+        phases = listOf(speakAll),
+    )
+
+    private fun stateOf(s: Scenario, variables: Map<String, String> = emptyMap()) =
+        SimulationState.initial(s).copy(variables = variables)
+
+    // A representative standard user template (references only public template
+    // vars — never a raw `whispers_<name>` key), matching how the speak / vote /
+    // choose handlers build their prompts. Used by the leak tests.
+    private val standardUserTemplate =
+        "Conversation: {conversation_log}\nScore: {scoreboard}\nYour whispers: {my_whispers}"
+
+    // MARK: - injectAssigned (#890)
+
+    @Test
+    fun injectAssignedSetsAssignedAndAliasFromNamespacedKey() {
+        val variables = mutableMapOf("assigned_Alice" to "wolf")
+        builder.injectAssigned(variables, "Alice")
+        assertEquals("wolf", variables["assigned"])
+        assertEquals("wolf", variables["assigned_word"])
+    }
+
+    @Test
+    fun injectAssignedSetsEmptyStringOnMiss() {
+        val variables = mutableMapOf<String, String>()
+        builder.injectAssigned(variables, "Alice")
+        assertEquals("", variables["assigned"])
+        assertEquals("", variables["assigned_word"])
+    }
+
+    // MARK: - injectNotes (#907)
+
+    @Test
+    fun injectNotesSetsMyNotesFromNamespacedKey() {
+        val variables = mutableMapOf("notes_Alice" to "remember the clue")
+        builder.injectNotes(variables, "Alice")
+        assertEquals("remember the clue", variables["my_notes"])
+    }
+
+    @Test
+    fun injectNotesSetsEmptyStringOnMiss() {
+        val variables = mutableMapOf<String, String>()
+        builder.injectNotes(variables, "Alice")
+        assertEquals("", variables["my_notes"])
+    }
+
+    // MARK: - injectWhispers (#908)
+
+    @Test
+    fun injectWhispersSetsMyWhispersFromNamespacedKey() {
+        val variables = mutableMapOf("whispers_Alice" to "Whispering with Bob\n  Alice: secret")
+        builder.injectWhispers(variables, "Alice")
+        assertEquals("Whispering with Bob\n  Alice: secret", variables["my_whispers"])
+    }
+
+    @Test
+    fun injectWhispersSetsEmptyStringOnMiss() {
+        val variables = mutableMapOf<String, String>()
+        builder.injectWhispers(variables, "Alice")
+        assertEquals("", variables["my_whispers"])
+    }
+
+    // MARK: - injectRelationships (#910)
+
+    @Test
+    fun injectRelationshipsSetsRelationshipsFromNamespacedKey() {
+        val variables = mutableMapOf("relationships_Alice" to "You are wary of Bob.")
+        builder.injectRelationships(variables, "Alice")
+        assertEquals("You are wary of Bob.", variables["relationships"])
+    }
+
+    @Test
+    fun injectRelationshipsSetsEmptyStringOnMiss() {
+        val variables = mutableMapOf<String, String>()
+        builder.injectRelationships(variables, "Alice")
+        assertEquals("", variables["relationships"])
+    }
+
+    // MARK: - injectMood (#913)
+
+    @Test
+    fun injectMoodSetsMyMoodFromNamespacedKey() {
+        val variables = mutableMapOf("mood_Alice" to "苛立ち")
+        builder.injectMood(variables, "Alice")
+        assertEquals("苛立ち", variables["my_mood"])
+    }
+
+    @Test
+    fun injectMoodSetsEmptyStringOnMiss() {
+        val variables = mutableMapOf<String, String>()
+        builder.injectMood(variables, "Alice")
+        assertEquals("", variables["my_mood"])
+    }
+
+    // MARK: - captureMood (#913)
+
+    @Test
+    fun captureMoodPersistsNonEmptyMood() {
+        val variables = mutableMapOf<String, String>()
+        val output = TurnOutput(fields = mapOf("statement" to "hi", "mood" to "わくわく"))
+        builder.captureMood(output, variables, "Alice")
+        assertEquals("わくわく", variables["mood_Alice"])
+    }
+
+    @Test
+    fun captureMoodEmptyDoesNotErasePrior() {
+        // A failed/empty inference must NOT erase the prior mood — the non-empty
+        // guard mirrors ReflectHandler's note save.
+        val variables = mutableMapOf("mood_Alice" to "不安")
+        val emptyOutput = TurnOutput(fields = mapOf("statement" to "hi", "mood" to ""))
+        builder.captureMood(emptyOutput, variables, "Alice")
+        assertEquals("不安", variables["mood_Alice"])
+    }
+
+    @Test
+    fun captureMoodNoOpWhenAbsent() {
+        // A phase that never declares mood produces no key → no-op capture.
+        val variables = mutableMapOf<String, String>()
+        val output = TurnOutput(fields = mapOf("statement" to "hi"))
+        builder.captureMood(output, variables, "Alice")
+        assertNull(variables["mood_Alice"])
+    }
+
+    // MARK: - System-prompt private-notes section (#907)
+
+    @Test
+    fun systemPromptContainsNotesSectionWhenSet() {
+        val s = scenario()
+        val state = stateOf(s, mapOf("notes_Alice" to "NOTE_SENTINEL"))
+        val prompt = builder.buildSystemPrompt(s, alice, speakAll, state)
+        assertTrue(prompt.contains("あなたの内心メモ"))
+        assertTrue(prompt.contains("NOTE_SENTINEL"))
+    }
+
+    @Test
+    fun systemPromptOmitsNotesSectionWhenUnset() {
+        val s = scenario()
+        assertFalse(builder.buildSystemPrompt(s, alice, speakAll, stateOf(s)).contains("あなたの内心メモ"))
+    }
+
+    @Test
+    fun systemPromptNotesSectionEnHeader() {
+        val s = scenario(language = "en")
+        val state = stateOf(s, mapOf("notes_Alice" to "NOTE_SENTINEL"))
+        val prompt = builder.buildSystemPrompt(s, alice, speakAll, state)
+        assertTrue(prompt.contains("Your Private Notes"))
+        assertTrue(prompt.contains("NOTE_SENTINEL"))
+    }
+
+    // MARK: - System-prompt private-whispers section (#908)
+
+    private val whisperPhase = Phase(
+        type = PhaseType.WHISPER,
+        prompt = "Whisper!",
+        outputSchema = mapOf("statement" to "string"),
+    )
+
+    @Test
+    fun systemPromptContainsPrivateWhispersSectionWhenSet() {
+        val s = scenario()
+        val state = stateOf(s, mapOf("whispers_Alice" to "密談相手: Bob\n  Alice: SENTINEL_AB"))
+        val prompt = builder.buildSystemPrompt(s, alice, whisperPhase, state)
+        assertTrue(prompt.contains("あなたの密談"))
+        assertTrue(prompt.contains("SENTINEL_AB"))
+    }
+
+    @Test
+    fun systemPromptOmitsPrivateWhispersSectionWhenUnset() {
+        val s = scenario()
+        assertFalse(builder.buildSystemPrompt(s, alice, whisperPhase, stateOf(s)).contains("あなたの密談"))
+    }
+
+    @Test
+    fun systemPromptPrivateWhispersSectionEnHeader() {
+        val s = scenario(language = "en")
+        val state = stateOf(s, mapOf("whispers_Alice" to "Whispering with Bob\n  Alice: SENTINEL_AB"))
+        val prompt = builder.buildSystemPrompt(s, alice, whisperPhase, state)
+        assertTrue(prompt.contains("Your Private Whispers"))
+        assertTrue(prompt.contains("SENTINEL_AB"))
+    }
+
+    // MARK: - System-prompt private-relationships section (#910)
+
+    @Test
+    fun systemPromptContainsRelationshipsSectionWhenSet() {
+        val s = scenario()
+        val state = stateOf(s, mapOf("relationships_Alice" to "SENTINEL_REL_WARY"))
+        val prompt = builder.buildSystemPrompt(s, alice, speakAll, state)
+        assertTrue(prompt.contains("あなたの人間関係"))
+        assertTrue(prompt.contains("SENTINEL_REL_WARY"))
+    }
+
+    @Test
+    fun systemPromptOmitsRelationshipsSectionWhenUnset() {
+        val s = scenario()
+        assertFalse(builder.buildSystemPrompt(s, alice, speakAll, stateOf(s)).contains("あなたの人間関係"))
+    }
+
+    @Test
+    fun systemPromptOmitsRelationshipsSectionWhenEmpty() {
+        // An empty summary (no relationship crossed the verbalizer threshold) must
+        // not render an empty header, mirroring the reflect / whisper guards.
+        val s = scenario()
+        val state = stateOf(s, mapOf("relationships_Alice" to ""))
+        assertFalse(builder.buildSystemPrompt(s, alice, speakAll, state).contains("あなたの人間関係"))
+    }
+
+    @Test
+    fun systemPromptRelationshipsSectionEnHeader() {
+        val s = scenario(language = "en")
+        val state = stateOf(s, mapOf("relationships_Alice" to "SENTINEL_REL_WARY"))
+        val prompt = builder.buildSystemPrompt(s, alice, speakAll, state)
+        assertTrue(prompt.contains("Your Read on the Others"))
+        assertTrue(prompt.contains("SENTINEL_REL_WARY"))
+    }
+
+    // MARK: - System-prompt mood section (#913)
+
+    private val moodSpeakPhase = Phase(
+        type = PhaseType.SPEAK_ALL,
+        prompt = "Speak!",
+        outputSchema = mapOf("statement" to "string", "mood" to "string"),
+    )
+
+    @Test
+    fun systemPromptContainsMoodSectionWhenSet() {
+        val s = scenario()
+        val state = stateOf(s, mapOf("mood_Alice" to "MOOD_SENTINEL"))
+        val prompt = builder.buildSystemPrompt(s, alice, moodSpeakPhase, state)
+        assertTrue(prompt.contains("あなたの今の気分"))
+        assertTrue(prompt.contains("MOOD_SENTINEL"))
+    }
+
+    @Test
+    fun systemPromptOmitsMoodSectionWhenUnset() {
+        val s = scenario()
+        assertFalse(builder.buildSystemPrompt(s, alice, moodSpeakPhase, stateOf(s)).contains("あなたの今の気分"))
+    }
+
+    @Test
+    fun systemPromptMoodSectionEnHeader() {
+        val s = scenario(language = "en")
+        val state = stateOf(s, mapOf("mood_Alice" to "MOOD_SENTINEL"))
+        val prompt = builder.buildSystemPrompt(s, alice, moodSpeakPhase, state)
+        assertTrue(prompt.contains("Your Current Mood"))
+        assertTrue(prompt.contains("MOOD_SENTINEL"))
+    }
+
+    @Test
+    fun systemPromptMoodSurfacesInNonDeclaringPhase() {
+        // Mood inertia must survive an intervening non-declaring phase: the mood
+        // section surfaces even when the current phase does not declare `mood`.
+        val s = scenario()
+        val votePhase = Phase(type = PhaseType.VOTE, prompt = "Vote!", outputSchema = mapOf("vote" to "string"))
+        val state = stateOf(s, mapOf("mood_Alice" to "MOOD_SENTINEL"))
+        assertTrue(builder.buildSystemPrompt(s, alice, votePhase, state).contains("MOOD_SENTINEL"))
+    }
+
+    @Test
+    fun systemPromptMoodCoexistsWithNotes() {
+        // Mood coexists with the reflect-note section (both surface together).
+        val s = scenario()
+        val state = stateOf(s, mapOf("mood_Alice" to "MOOD_SENTINEL", "notes_Alice" to "NOTE_SENTINEL"))
+        val prompt = builder.buildSystemPrompt(s, alice, moodSpeakPhase, state)
+        assertTrue(prompt.contains("MOOD_SENTINEL"))
+        assertTrue(prompt.contains("NOTE_SENTINEL"))
+    }
+
+    // MARK: - Mood answer-rule guidance (declaring phases only)
+
+    @Test
+    fun moodAnswerRuleAppendedForDeclaringPhaseJa() {
+        val s = scenario()
+        val prompt = builder.buildSystemPrompt(s, alice, moodSpeakPhase, stateOf(s))
+        assertTrue(prompt.contains("moodには今の気分を短い言葉"))
+    }
+
+    @Test
+    fun moodAnswerRuleAppendedForDeclaringPhaseEn() {
+        val s = scenario(language = "en")
+        val prompt = builder.buildSystemPrompt(s, alice, moodSpeakPhase, stateOf(s))
+        assertTrue(prompt.contains("Write your current mood in the mood field"))
+    }
+
+    @Test
+    fun moodAnswerRuleOmittedForNonDeclaringPhase() {
+        // A phase that does not declare `mood` never gets the mood-writing rule,
+        // even if a carried-over mood is being surfaced in the section above.
+        val s = scenario()
+        val votePhase = Phase(type = PhaseType.VOTE, prompt = "Vote!", outputSchema = mapOf("vote" to "string"))
+        val state = stateOf(s, mapOf("mood_Alice" to "MOOD_SENTINEL"))
+        assertFalse(builder.buildSystemPrompt(s, alice, votePhase, state).contains("moodには今の気分を短い言葉"))
+    }
+
+    // MARK: - Cross-pair whisper leak guard (default path only, #908)
+
+    @Test
+    fun nonParticipantNeverSeesAnotherPairsWhisper() {
+        // A NON-participant (Charlie) must never see another pair's whisper sentinel,
+        // in NEITHER the system prompt NOR an expanded standard user template, for
+        // the speak_all / vote / choose phases. The section is gated on the reader's
+        // own `whispers_<name>` key, and `{my_whispers}` resolves empty for Charlie.
+        val s = scenario()
+        val state = stateOf(
+            s,
+            mapOf(
+                "whispers_Alice" to "密談相手: Bob\n  Alice: SENTINEL_AB",
+                "whispers_Bob" to "密談相手: Alice\n  Bob: SENTINEL_AB",
+            ),
+        )
+        val phases = listOf(
+            Phase(type = PhaseType.SPEAK_ALL, prompt = "Speak!", outputSchema = mapOf("statement" to "string")),
+            Phase(type = PhaseType.VOTE, prompt = "Vote!", outputSchema = mapOf("vote" to "string")),
+            Phase(type = PhaseType.CHOOSE, prompt = "Choose!", outputSchema = mapOf("action" to "string")),
+        )
+        for (phase in phases) {
+            val system = builder.buildSystemPrompt(s, charlie, phase, state)
+            assertFalse(system.contains("SENTINEL_AB"), "system prompt leaked whisper for ${phase.type}")
+
+            val variables = state.variables.toMutableMap()
+            builder.injectWhispers(variables, charlie.name)
+            val user = builder.expandTemplate(standardUserTemplate, variables)
+            assertFalse(user.contains("SENTINEL_AB"), "user prompt leaked whisper for ${phase.type}")
+        }
+    }
+
+    @Test
+    fun participantSeesOwnWhisper() {
+        // The participant (Alice) DOES see her own whisper — in the system-prompt
+        // section AND via `{my_whispers}` on a standard template.
+        val s = scenario()
+        val state = stateOf(s, mapOf("whispers_Alice" to "密談相手: Bob\n  Alice: SENTINEL_AB"))
+        val phase = Phase(type = PhaseType.SPEAK_ALL, prompt = "Speak!", outputSchema = mapOf("statement" to "string"))
+
+        val system = builder.buildSystemPrompt(s, alice, phase, state)
+        assertTrue(system.contains("SENTINEL_AB"))
+
+        val variables = state.variables.toMutableMap()
+        builder.injectWhispers(variables, alice.name)
+        val user = builder.expandTemplate(standardUserTemplate, variables)
+        assertTrue(user.contains("SENTINEL_AB"))
+    }
+}

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/SpeakAllHandlerTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/SpeakAllHandlerTests.kt
@@ -169,6 +169,45 @@ class SpeakAllHandlerTests {
         }
     }
 
+    // MARK: - Prompt injection parity (Wave B — captureMood round-trip)
+
+    @Test
+    fun capturedMoodSurfacesInTheNextTurnsPrompt() = runTest {
+        // THE Kotlin-divergent path. Swift threads mood forward via
+        // `inout &state.variables`; Kotlin must fold captureMood into the
+        // success-path `state.copy`, else turn N's mood never reaches turn N+1.
+        // Neither Swift's nor the base Kotlin handler suite asserted this
+        // round-trip, so it is pinned here (critic action, #501). Revert the
+        // `captureMood` fold in SpeakAllHandler and this goes red.
+        val moodPhase = Phase(
+            type = PhaseType.SPEAK_ALL,
+            prompt = "Speak.",
+            outputSchema = mapOf("statement" to "string", "mood" to "string"),
+        )
+        val s = scenario(agents = listOf("Alice")).copy(phases = listOf(moodPhase))
+        val backend = ScriptedLLMBackend(
+            listOf(
+                ScriptedLLMBackend.Script.completing("""{"statement": "hi", "mood": "わくわく"}"""),
+                ScriptedLLMBackend.Script.completing("""{"statement": "again", "mood": "落ち着き"}"""),
+            ),
+        )
+        val ctx = context(s, backend)
+
+        val afterTurn1 = handler.execute(ctx, SimulationState.initial(s))
+        assertEquals(
+            "わくわく",
+            afterTurn1.variables["mood_Alice"],
+            "captureMood must fold the non-empty mood into the returned state",
+        )
+
+        handler.execute(ctx, afterTurn1)
+        assertTrue(
+            backend.requests[1].system.contains("わくわく"),
+            "turn N's captured mood must surface in turn N+1's system prompt",
+        )
+        assertTrue(backend.requests[1].system.contains("Your Current Mood"))
+    }
+
     // MARK: - Prompt wiring
 
     @Test


### PR DESCRIPTION
## Summary

Ports the reserved-namespace **prompt-injection family** to Kotlin `commonMain` and completes the already-ported `SpeakAllHandler.kt` — a *deliberate partial port* (its doc said the injection family "lands with its consumer in a later Wave-B PR") — to **full Swift parity** as the first consumer. Part of the ADR-023 Stage 3 Wave B port (`Part of #501`).

This is the **shared prerequisite** for the 5 remaining inject-consuming LLM handlers (Reflect / Vote / Whisper / Choose / SpeakEach), landed before the first of them rather than duplicated into each. `AssignHandler.kt` (#1226) and `RelationshipUpdateHandler.kt` (#1232) already write the producer keys, so the Kotlin engine was in a half-wired "assign writes but speak_all doesn't read back" state that this closes.

Load-bearing port details:

- **inject\* 5** (`injectAssigned` / `injectNotes` / `injectWhispers` / `injectRelationships` / `injectMood`) + **`captureMood`** + **`appendPrivateSections`** + **`moodRule`**, all threading through immutable Kotlin state. The one line that structurally diverges from Swift's `inout`: `inject*` mutate the **local prompt `MutableMap`** in place (discarded after the prompt is built), while `captureMood` folds into the **success-path `state.copy(variables=…)` only** (never the skip path), using a fresh copy of the **persisted** `state.variables` — the two maps are never conflated. Cross-persona mood carry-forward is preserved by the loop's `current = speakTurn(...)` accumulation.
- Wired `appendPrivateSections` into `buildSystemPrompt` (the previously-`@Suppress`-ed `state` param) and the schema-gated `moodRule` (`phase.outputSchemaKeys.contains("mood")`, not phase-type) into `buildAnswerRules`; refreshed the `PromptBuilder` "knowingly absent" table + removed the stale "state unused / do not delete" comment.

**Scope discipline:** `whisperRule` / `reflectBrevityRule` / `addressRule` / `voteCandidateRule` / choose-options rule stay deferred to their own Wave-B handler PRs (they remain in the updated absence table). Only `moodRule` is ported here, because it lands with this infrastructure.

**Wave-B checklist unchanged** — `SpeakAllHandler` is already `[x]` (#1222) and the gate-enforced checklist tracks handler files, not this infra unit; this PR completes #1222's partial port to full parity under the same box.

## Test plan

- New `PromptBuilderInjectionTests.kt` (30 parity tests) ported from the Swift executable spec (`PromptBuilderTests+Mood` / `+Whispers` / `+Relationships` + the notes cases in `+Hardening`): every injector (hit + miss), `captureMood` (persist / non-erase-on-empty / no-op-when-absent), all four private sections (set / unset / en-header, + relationships empty-guard), mood answer-rule gating (ja/en/omitted), and the **cross-pair whisper leak guard** (a non-participant sees nothing in the system prompt AND the expanded user template across speak_all/vote/choose).
- `SpeakAllHandlerTests.capturedMoodSurfacesInTheNextTurnsPrompt` — a handler-level **captureMood round-trip** (turn N's mood → turn N+1's system prompt). This is the Kotlin-divergent `state.copy` fold, untested on both sides before this PR.
- **Shown red under perturbation** per ADR-023 §12: reverting the `captureMood` fold reddens both the unit and the round-trip test; breaking the whisper persona-scoping reddens the leak guard.
- Verified: `./gradlew :shared:models:jvmTest :shared:engine:jvmTest :shared:engine:compileCommonMainKotlinMetadata` — **420 tests green**.

## Device QA

実機QA不要 — Kotlin `shared/engine` only (commonMain + commonTest). No iOS app-target code, no LLM/Metal/device-only surface; the iOS app does not consume the KMP framework yet (Phase 3.0-gated, ADR-023 §6).

Closes #1238
Part of #501
