### PR TITLE
🧹 chore: port ReflectHandler to Kotlin shared/engine (ADR-023 Wave B)

### DIFF
--- a/docs/kmp-migration-status.md
+++ b/docs/kmp-migration-status.md
@@ -43,7 +43,7 @@ Legend: ✅ done · 🔄 in progress · 🟡 partial · ⬜ not started.
 |---|:--:|---|
 | Models mirror | ✅ done | #1193 #1196 #1202 |
 | Wave A — non-handler run-path (scoring, mechanisms, prompt/LLM glue) | ✅ done | #1207 #1212 #1217 |
-| Wave B — 14 phase handlers | 🔄 7/14 | checklist ↓ |
+| Wave B — 14 phase handlers | 🔄 8/14 | checklist ↓ |
 | code-phase track | ✅ done | CP1 #1226 · CP2 #1230 · CP3 #1232 |
 
 ### Wave B handler checklist
@@ -61,7 +61,7 @@ machine-checked — see the maintenance invariant above.
 - [ ] ConditionalHandler
 - [x] EventInjectHandler — #1230
 - [ ] NarrateHandler
-- [ ] ReflectHandler
+- [x] ReflectHandler — #1242
 - [x] RelationshipUpdateHandler — #1232
 - [x] ScoreCalcHandler — #1230
 - [ ] SpeakEachHandler

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/PhaseDispatcher.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/PhaseDispatcher.kt
@@ -9,10 +9,10 @@ import kotlinx.serialization.serializer
  *
  * ## Scope: the ADR-023 Stage-3 port, in progress
  *
- * **`SPEAK_ALL`, `ELIMINATE`, `SUMMARIZE`, `ASSIGN`, `EVENT_INJECT`, `SCORE_CALC`
- * and `RELATIONSHIP_UPDATE` are registered.** Swift registers all 14; the remaining
- * 7 are the mechanical bulk of Stage 3 ("mechanical after the Stage-2 slice", §4),
- * ported handler-by-handler.
+ * **`SPEAK_ALL`, `ELIMINATE`, `SUMMARIZE`, `ASSIGN`, `EVENT_INJECT`, `SCORE_CALC`,
+ * `RELATIONSHIP_UPDATE` and `REFLECT` are registered.** Swift registers all 14; the
+ * remaining 6 are the mechanical bulk of Stage 3 ("mechanical after the Stage-2
+ * slice", §4), ported handler-by-handler.
  *
  * Unlike Swift's `PhaseDispatcher`, this is **not** exhaustive over [PhaseType] —
  * so an unregistered phase fails at dispatch with a clear error rather than at
@@ -33,6 +33,7 @@ internal class PhaseDispatcher {
         PhaseType.EVENT_INJECT to EventInjectHandler(),
         PhaseType.SCORE_CALC to ScoreCalcHandler(),
         PhaseType.RELATIONSHIP_UPDATE to RelationshipUpdateHandler(),
+        PhaseType.REFLECT to ReflectHandler(),
     )
 
     /**

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/ReflectHandler.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/ReflectHandler.kt
@@ -1,0 +1,162 @@
+package com.pastura.engine
+
+import com.pastura.models.OutputSchema
+import com.pastura.models.Persona
+import com.pastura.models.SimulationEvent
+import com.pastura.models.SimulationState
+
+/**
+ * Handles `reflect` phases, where each active agent privately updates a personal memo.
+ *
+ * Each non-eliminated agent makes one LLM call producing `{ note }` — a short
+ * private memo (impressions, suspicions, plans). The note is stored under the
+ * reserved per-persona key `notes_<name>` in [SimulationState.variables]
+ * (mirroring the `assigned_<name>` namespace, see [PromptBuilder.injectNotes]) and
+ * surfaced back to that agent — and only that agent — in every subsequent LLM
+ * call's system prompt.
+ *
+ * Unlike the speak handlers, the note is **private**: it is never appended to
+ * `conversationLog` (so other agents can't see it) and never written to
+ * `lastOutputs` (so it doesn't replace the public last output). Only the
+ * `AgentOutput` event is emitted, keeping the persistence / UI / replay flow
+ * identical to the other LLM phases.
+ *
+ * A turn-degradable LLM failure is routed through [PhaseContext.turnGate]
+ * (ADR-021 D1/D2): the failing agent's turn is skipped — no `AgentOutput` and no
+ * `notes_<name>` write, so a prior round's memo survives (the same outcome as the
+ * non-empty guard below; private memory persists). Reflect never touches
+ * `lastOutputs`, so — unlike [SpeakAllHandler]'s skip path — there is nothing to
+ * clear: the skip simply returns the state unchanged.
+ *
+ * Swift original: `Pastura/Pastura/Engine/Phases/ReflectHandler.swift`.
+ */
+internal class ReflectHandler : PhaseHandler {
+
+    private val promptBuilder = PromptBuilder()
+
+    override suspend fun execute(context: PhaseContext, state: SimulationState): SimulationState {
+        val promptTemplate = context.phase.prompt
+            ?: pickLanguage(
+                context.scenario.engineLanguage,
+                ja = "これまでの会話: {conversation_log}\n" +
+                    "これまでの状況を踏まえ、所感・警戒・今後の方針を自分用のメモとして更新してください。",
+                en = "Conversation so far: {conversation_log}\n" +
+                    "Update your private notes: impressions, suspicions, and your plan going forward.",
+            )
+
+        var current = state
+        for (persona in context.scenario.personas) {
+            // `== true` to SKIP: an agent absent from the map reads `null`, which
+            // is not `true`, so it reflects — matching Swift's
+            // `guard state.eliminated[persona.name] != true else { continue }`.
+            if (current.eliminated[persona.name] == true) continue
+            current = reflectTurn(context, persona, promptTemplate, current)
+        }
+        return current
+    }
+
+    /**
+     * Runs one persona's reflect turn: builds the prompt, routes the LLM call
+     * through [PhaseContext.turnGate] (ADR-021 D1/D2), and on success emits
+     * `AgentOutput` and persists a non-empty note. On a skipped turn, writes
+     * nothing — the prior `notes_<name>` memo is left intact.
+     *
+     * Returns the next state — Kotlin [SimulationState] is immutable, so unlike
+     * Swift's `inout` the caller MUST use the return value (see [PhaseHandler]).
+     */
+    private suspend fun reflectTurn(
+        context: PhaseContext,
+        persona: Persona,
+        promptTemplate: String,
+        state: SimulationState,
+    ): SimulationState {
+        // Constructed per turn, matching Swift — a stateless value, cheap. The
+        // logger seam is threaded from the context (Noop by default in the current
+        // run path — see PhaseContext § "Knowingly absent").
+        val llmCaller = LLMCaller(logger = context.logger)
+
+        val systemPrompt = promptBuilder.buildSystemPrompt(
+            scenario = context.scenario,
+            persona = persona,
+            phase = context.phase,
+            state = state,
+        )
+
+        // Local prompt-variable map (thrown away after the prompt is built). The
+        // `inject*` family mutates it in place to surface each reserved-namespace
+        // `{token}` to only this reflector; none of this touches persisted state.
+        val variables = state.variables.toMutableMap()
+        variables["scoreboard"] = promptBuilder.formatScoreboard(state.scores)
+        variables["conversation_log"] = promptBuilder.formatConversationLog(
+            entries = state.conversationLog,
+            language = context.scenario.engineLanguage,
+            window = context.scenario.logWindow,
+        )
+        promptBuilder.injectAssigned(variables, persona.name)
+        promptBuilder.injectNotes(variables, persona.name)
+        promptBuilder.injectWhispers(variables, persona.name)
+        promptBuilder.injectRelationships(variables, persona.name)
+        promptBuilder.injectMood(variables, persona.name)
+        val userPrompt = promptBuilder.expandTemplate(promptTemplate, variables)
+
+        val output = context.turnGate.attempt(
+            agent = persona.name,
+            phaseType = context.phase.type,
+            emitter = context.emitter,
+        ) {
+            llmCaller.call(
+                backend = context.backend,
+                system = systemPrompt,
+                user = userPrompt,
+                agentName = persona.name,
+                schema = OutputSchema.from(context.phase),
+                detector = context.detector,
+                expectedLanguage = context.scenario.engineLanguage,
+                relay = context.suspensionRelay,
+                emitter = context.emitter,
+            )
+        }
+        // Skipped (ADR-021 D2): a null return means the gate absorbed a
+        // turn-degradable failure. No note write — the prior `notes_<name>` memo
+        // persists; and nothing to clear (reflect never writes `lastOutputs`), so
+        // the state is returned unchanged — the deliberate divergence from
+        // SpeakAllHandler's skip path.
+            ?: return state
+
+        context.emitter(
+            SimulationEvent.AgentOutput(
+                agent = persona.name,
+                output = output,
+                phaseType = context.phase.type,
+            ),
+        )
+
+        // Fold BOTH persisted writes into one `state.copy(variables = …)`:
+        //  1. the memo under the reserved `notes_<name>` namespace, and
+        //  2. captureMood (#913), a no-op unless this reflect phase declares a
+        //     `mood` output field.
+        // Both mutate the SAME fresh map before the single copy — Kotlin's
+        // immutable state means a second `state.copy` off the original would drop
+        // the first write (Swift threads two sequential `inout` mutations instead).
+        //
+        // The `note.isNotEmpty()` guard is **defensive parity** with Swift, not a
+        // reachable path here: the parser rejects a present-but-empty expected key
+        // (`hasAllExpectedKeys` requires non-empty content), so an all-empty
+        // inference exhausts the retry budget and is absorbed as a turn skip
+        // upstream (the `?: return state` arm above) rather than arriving here as
+        // `note == ""`. Kept so the write stays correct if that upstream guarantee
+        // ever changes — and to mirror the Swift handler verbatim.
+        val nextVariables = state.variables.toMutableMap()
+        val note = output.fields["note"] ?: ""
+        if (note.isNotEmpty()) {
+            nextVariables["notes_${persona.name}"] = note
+        }
+        promptBuilder.captureMood(output, nextVariables, persona.name)
+
+        // Deliberately NOT appended to `conversationLog` (the note is private, so
+        // other agents whose prompts include the log must never see it) and NOT
+        // written to `lastOutputs` (the public last output must not be replaced by
+        // a private memo).
+        return state.copy(variables = nextVariables)
+    }
+}

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/PromptBuilder.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/PromptBuilder.kt
@@ -4,6 +4,7 @@ import com.pastura.models.ConversationEntry
 import com.pastura.models.OutputSchema
 import com.pastura.models.Persona
 import com.pastura.models.Phase
+import com.pastura.models.PhaseType
 import com.pastura.models.Scenario
 import com.pastura.models.ScenarioConventions
 import com.pastura.models.SimulationState
@@ -28,8 +29,8 @@ import com.pastura.models.TurnOutput
  * [getMainField]; [buildSystemPrompt] (header, scenario context, persona, secret,
  * private self-knowledge sections, base answer rules + mood rule, output format);
  * the injection family ([injectAssigned] / [injectNotes] / [injectWhispers] /
- * [injectRelationships] / [injectMood]), [captureMood] + `moodRule`, and
- * `appendPrivateSections`.
+ * [injectRelationships] / [injectMood]), [captureMood] + `moodRule` +
+ * `reflectBrevityRule`, and `appendPrivateSections`.
  *
  * What is **knowingly absent** — each a *named* unit, tracked on #501 for its
  * Wave-B handler PR, never a silent drop:
@@ -37,7 +38,7 @@ import com.pastura.models.TurnOutput
  * | Absent | Why |
  * |---|---|
  * | `addressRule` (#911, speak_each) | speak_each is a later Wave-B handler |
- * | `reflectBrevityRule` / `whisperRule` | reflect / whisper are later Wave-B handlers |
+ * | `whisperRule` | whisper is a later Wave-B handler |
  * | choose-options rule / `voteCandidateRule` | choose / vote are later Wave-B handlers |
  * | `RelationshipVerbalizer`, `PromptPlaceholders`, `ErrorReadability` | types landed in PR-3 (#501 Stage 3); PromptBuilder still has no slice consumer for them (wiring deferred to their Wave-B handlers) |
  *
@@ -249,11 +250,11 @@ internal class PromptBuilder {
     }
 
     /**
-     * The base `## 回答ルール / ## Response Rules` block.
-     *
-     * Only the base rules — the phase-specific appendices (speak_each address,
-     * reflect brevity, whisper privacy, choose options, vote candidates, mood) are
-     * Stage-3 units; see the class doc.
+     * The `## 回答ルール / ## Response Rules` block: the base rules, plus the
+     * mood-writing rule ([moodRule], schema-gated) and the reflect-note brevity
+     * rule ([reflectBrevityRule], `REFLECT`-gated). The remaining phase-specific
+     * appendices (speak_each address, whisper privacy, choose options, vote
+     * candidates) are still Stage-3 units; see the class doc.
      */
     private fun buildAnswerRules(language: String, phase: Phase): String {
         // coerceIn: the THIRD site inheriting a Swift validator guarantee that does
@@ -289,6 +290,12 @@ internal class PromptBuilder {
             """.trimIndent(),
         )
 
+        // Reflect notes get a tighter 2-sentence cap (see [reflectBrevityRule]).
+        // Type-gated, unlike the schema-gated mood rule below.
+        if (phase.type == PhaseType.REFLECT) {
+            rules += reflectBrevityRule(language)
+        }
+
         // Mood-opting phases (#913) get the mood-writing guidance. Gated on the
         // schema, not the phase type — any LLM phase can declare `mood`.
         if (phase.outputSchemaKeys.contains("mood")) {
@@ -296,6 +303,19 @@ internal class PromptBuilder {
         }
         return rules
     }
+
+    /**
+     * The #907 brevity rule appended for `reflect` phases only ([buildAnswerRules]
+     * gates on `phase.type == REFLECT`). Caps the private note at 2 sentences — the
+     * same constraint family as the #877 statement brevity rule. Keep ja/en
+     * scope-parallel when editing.
+     */
+    private fun reflectBrevityRule(language: String): String =
+        pickLanguage(
+            language,
+            ja = "\n- メモ（note）は2文以内で簡潔に書くこと（長文・箇条書きの羅列は禁止）",
+            en = "\n- Keep your note to at most 2 sentences (no long paragraphs or bullet lists).",
+        )
 
     /**
      * The #913 mood-writing guidance, appended only for phases that opt into a

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/PhaseDispatcherTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/PhaseDispatcherTests.kt
@@ -10,8 +10,8 @@ import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 /**
- * Kotlin sibling of Swift's `PhaseDispatcherTests`, scoped to the one handler this
- * slice registers.
+ * Kotlin sibling of Swift's `PhaseDispatcherTests`, scoped to the handlers this
+ * port has registered so far.
  *
  * Ported for the ADR-023 §6 Stage-2 gate slice (#501).
  */
@@ -55,6 +55,11 @@ class PhaseDispatcherTests {
     }
 
     @Test
+    fun resolvesTheReflectHandler() {
+        assertIs<ReflectHandler>(dispatcher.handler(PhaseType.REFLECT))
+    }
+
+    @Test
     fun returnsAStableHandlerInstance() {
         // Handlers are stateless values; the dispatcher builds its map once.
         assertTrue(dispatcher.handler(PhaseType.SPEAK_ALL) === dispatcher.handler(PhaseType.SPEAK_ALL))
@@ -86,9 +91,9 @@ class PhaseDispatcherTests {
             it != PhaseType.SPEAK_ALL && it != PhaseType.ELIMINATE &&
                 it != PhaseType.SUMMARIZE && it != PhaseType.ASSIGN &&
                 it != PhaseType.EVENT_INJECT && it != PhaseType.SCORE_CALC &&
-                it != PhaseType.RELATIONSHIP_UPDATE
+                it != PhaseType.RELATIONSHIP_UPDATE && it != PhaseType.REFLECT
         }
-        assertEquals(7, unported.size, "Kotlin PhaseType has 14 cases today; see the #501 drift ledger")
+        assertEquals(6, unported.size, "Kotlin PhaseType has 14 cases today; see the #501 drift ledger")
         for (type in unported) {
             val error = assertFailsWith<SimulationException>("$type must fail cleanly") {
                 dispatcher.handler(type)

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/PromptBuilderInjectionTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/PromptBuilderInjectionTests.kt
@@ -21,10 +21,10 @@ import kotlin.test.assertTrue
  * Unlike [PromptBuilderTests] (which disclaims parity for the still-incomplete
  * base slice), these DO assert parity: their landed units are the full Swift
  * behaviour. Deliberately **out of scope** here — deferred to their own Wave-B
- * handler PRs, so their guidance is not yet ported: `whisperRule`,
- * `reflectBrevityRule`, `addressRule`, `voteCandidateRule`, and the choose-options
- * rule. Only the `mood` answer-rule is asserted, because `moodRule` lands with
- * this infrastructure.
+ * handler PRs, so their guidance is not yet ported: `whisperRule`, `addressRule`,
+ * `voteCandidateRule`, and the choose-options rule. The `mood` and
+ * `reflect`-brevity answer-rules ARE asserted, because `moodRule` and
+ * `reflectBrevityRule` land with this infrastructure / the ReflectHandler PR.
  *
  * Split into its own file per the commonTest concern-per-file convention
  * (cf. [PromptBuilderParityTests]); these are pure, stateless `PromptBuilder`
@@ -398,5 +398,35 @@ class PromptBuilderInjectionTests {
         builder.injectWhispers(variables, alice.name)
         val user = builder.expandTemplate(standardUserTemplate, variables)
         assertTrue(user.contains("SENTINEL_AB"))
+    }
+
+    // MARK: - Reflect-note brevity answer-rule (reflect phases only, #907)
+
+    private val reflectPhase = Phase(
+        type = PhaseType.REFLECT,
+        prompt = "Reflect!",
+        outputSchema = mapOf("note" to "string"),
+    )
+
+    @Test
+    fun reflectBrevityRuleAppendedForReflectPhaseJa() {
+        val s = scenario()
+        val prompt = builder.buildSystemPrompt(s, alice, reflectPhase, stateOf(s))
+        assertTrue(prompt.contains("メモ（note）は2文以内"))
+    }
+
+    @Test
+    fun reflectBrevityRuleAppendedForReflectPhaseEn() {
+        val s = scenario(language = "en")
+        val prompt = builder.buildSystemPrompt(s, alice, reflectPhase, stateOf(s))
+        assertTrue(prompt.contains("Keep your note to at most 2 sentences"))
+    }
+
+    @Test
+    fun reflectBrevityRuleOmittedForNonReflectPhase() {
+        // A non-reflect phase (speak_all) never gets the note-brevity rule, even
+        // though it shares the same base answer-rule block.
+        val s = scenario()
+        assertFalse(builder.buildSystemPrompt(s, alice, speakAll, stateOf(s)).contains("メモ（note）は2文以内"))
     }
 }

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ReflectHandlerTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ReflectHandlerTests.kt
@@ -1,0 +1,193 @@
+package com.pastura.engine
+
+import com.pastura.models.Persona
+import com.pastura.models.Phase
+import com.pastura.models.PhaseType
+import com.pastura.models.Scenario
+import com.pastura.models.SimulationEvent
+import com.pastura.models.SimulationState
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Kotlin sibling of Swift's `ReflectHandlerTests` (+ its `…+TurnDegradation`
+ * split), collapsed into one class per the commonTest convention.
+ *
+ * The distinctive reflect contract vs the speak handlers: the note is stored under
+ * `notes_<name>` (non-empty guard) but is NEVER written to `conversationLog` or
+ * `lastOutputs`. The ADR-021 turn-gate transient-skip is exercised here; the D3
+ * systemic-error and D4 circuit-breaker cases ride the same shared gate already
+ * covered by [SpeakAllHandlerTests] + [TurnFailureGateTests] — Swift's
+ * `ReflectHandler` degradation coverage is likewise a single transient case.
+ *
+ * Ported for the ADR-023 KMP Engine migration (#501, #1242).
+ */
+class ReflectHandlerTests {
+
+    private val handler = ReflectHandler()
+
+    private fun scenario(
+        agents: List<String> = listOf("Alice", "Bob"),
+        language: String = "en",
+        prompt: String? = "Reflect.",
+    ) = Scenario(
+        id = "t",
+        name = "T",
+        description = "d",
+        language = language,
+        agentCount = agents.size,
+        rounds = 2,
+        logWindow = null,
+        context = "A test.",
+        personas = agents.map { Persona(name = it, description = "$it's persona.") },
+        phases = listOf(Phase(type = PhaseType.REFLECT, prompt = prompt, outputSchema = mapOf("note" to "string"))),
+    )
+
+    private fun context(
+        scenario: Scenario,
+        backend: LLMBackend,
+        events: MutableList<SimulationEvent> = mutableListOf(),
+    ) = PhaseContext(
+        scenario = scenario,
+        phase = scenario.phases[0],
+        backend = backend,
+        suspensionRelay = SuspensionRelay(),
+        emitter = { events += it },
+        pauseCheck = { },
+        phasePath = listOf(0),
+        turnGate = TurnFailureGate(),
+    )
+
+    private fun note(text: String) =
+        ScriptedLLMBackend.Script.completing("""{"note": "$text"}""")
+
+    // MARK: - Note persistence
+
+    @Test
+    fun storesNoteUnderNotesKeyForEachAgent() = runTest {
+        val s = scenario()
+        val backend = ScriptedLLMBackend(listOf(note("Alice suspects Bob"), note("Bob trusts no one")))
+        val next = handler.execute(context(s, backend), SimulationState.initial(s).copy(currentRound = 1))
+
+        assertEquals("Alice suspects Bob", next.variables["notes_Alice"])
+        assertEquals("Bob trusts no one", next.variables["notes_Bob"])
+    }
+
+    @Test
+    fun emitsAgentOutputWithReflectPhaseType() = runTest {
+        val s = scenario()
+        val events = mutableListOf<SimulationEvent>()
+        val backend = ScriptedLLMBackend(listOf(note("a"), note("b")))
+        handler.execute(context(s, backend, events), SimulationState.initial(s).copy(currentRound = 1))
+
+        val reflectAgents = events.filterIsInstance<SimulationEvent.AgentOutput>()
+            .filter { it.phaseType == PhaseType.REFLECT }
+            .map { it.agent }
+        assertEquals(listOf("Alice", "Bob"), reflectAgents)
+    }
+
+    // MARK: - Privacy: never touches conversationLog / lastOutputs
+
+    @Test
+    fun doesNotAppendToConversationLog() = runTest {
+        val s = scenario(agents = listOf("Alice"))
+        val backend = ScriptedLLMBackend(listOf(note("private memo")))
+        val next = handler.execute(context(s, backend), SimulationState.initial(s).copy(currentRound = 1))
+        assertTrue(next.conversationLog.isEmpty())
+    }
+
+    @Test
+    fun doesNotUpdateLastOutputs() = runTest {
+        val s = scenario(agents = listOf("Alice"))
+        val backend = ScriptedLLMBackend(listOf(note("private memo")))
+        val next = handler.execute(context(s, backend), SimulationState.initial(s).copy(currentRound = 1))
+        assertNull(next.lastOutputs["Alice"])
+    }
+
+    // MARK: - Eliminated agents
+
+    @Test
+    fun skipsEliminatedAgents() = runTest {
+        val s = scenario(agents = listOf("Alice", "Bob", "Charlie"))
+        val backend = ScriptedLLMBackend(listOf(note("Alice note"), note("Charlie note")))
+        val state = SimulationState.initial(s).copy(
+            currentRound = 1,
+            eliminated = mapOf("Bob" to true),
+        )
+        val next = handler.execute(context(s, backend), state)
+
+        assertEquals(2, backend.callCount)
+        assertNull(next.variables["notes_Bob"])
+        assertEquals("Alice note", next.variables["notes_Alice"])
+        assertEquals("Charlie note", next.variables["notes_Charlie"])
+    }
+
+    // MARK: - Empty-inference exhaustion must not erase a prior memo
+
+    @Test
+    fun emptyNoteDoesNotErasePreExistingNote() = runTest {
+        // An all-empty inference never reaches the note write on the success path:
+        // the parser rejects a present-but-empty expected key (`{"note":""}` —
+        // `hasAllExpectedKeys` requires non-empty content), so three empties
+        // exhaust the retry budget → RetriesExhausted → the turn gate absorbs it as
+        // a skip (ADR-021 D2), and the prior memo survives via that skip. (Three
+        // empties = MAX_RETRIES (2) + the initial attempt.) Asserted through the
+        // skip mechanism, not the handler's defensive non-empty guard — which this
+        // path can't reach, so a guard-only assertion would be coverage theater.
+        val s = scenario(agents = listOf("Alice"))
+        val backend = ScriptedLLMBackend(listOf(note(""), note(""), note("")))
+        val events = mutableListOf<SimulationEvent>()
+        val state = SimulationState.initial(s).copy(
+            currentRound = 1,
+            variables = mapOf("notes_Alice" to "prior round memo"),
+        )
+        val next = handler.execute(context(s, backend, events), state)
+
+        assertEquals("prior round memo", next.variables["notes_Alice"])
+        // Mechanism: absorbed as a turn skip (no AgentOutput), not a guard-dropped
+        // write. Perturbing the handler's `?: return state` skip arm turns this red.
+        assertTrue(events.filterIsInstance<SimulationEvent.AgentOutput>().isEmpty())
+        val skipped = events.filterIsInstance<SimulationEvent.TurnSkipped>()
+        assertEquals(1, skipped.size)
+        assertEquals("Alice", skipped.single().agent)
+        assertEquals(PhaseType.REFLECT, skipped.single().phaseType)
+    }
+
+    // MARK: - Turn degradation (ADR-021 D1/D2)
+
+    @Test
+    fun transientFailureSkipsAndPreservesPriorNote() = runTest {
+        // Alice's call fails transiently (turn-degradable); her prior-round memo
+        // must survive (no overwrite, no clear — reflect never writes lastOutputs),
+        // and Bob still updates his note.
+        val s = scenario(agents = listOf("Alice", "Bob"))
+        val backend = ScriptedLLMBackend(
+            listOf(
+                ScriptedLLMBackend.Script(terminal = TerminalStatus.Failed(errorCode = "transient blip")),
+                note("Bob's fresh memo"),
+            ),
+        )
+        val events = mutableListOf<SimulationEvent>()
+        val state = SimulationState.initial(s).copy(
+            currentRound = 2,
+            variables = mapOf("notes_Alice" to "Alice's prior memo"),
+        )
+        val next = handler.execute(context(s, backend, events), state)
+
+        // Prior memo preserved on skip; Bob's fresh note written.
+        assertEquals("Alice's prior memo", next.variables["notes_Alice"])
+        assertEquals("Bob's fresh memo", next.variables["notes_Bob"])
+
+        // No AgentOutput for the skipped agent; exactly one TurnSkipped.
+        val outputs = events.filterIsInstance<SimulationEvent.AgentOutput>().map { it.agent }
+        assertEquals(listOf("Bob"), outputs, "the failing agent emits no AgentOutput")
+
+        val skipped = events.filterIsInstance<SimulationEvent.TurnSkipped>()
+        assertEquals(1, skipped.size)
+        assertEquals("Alice", skipped.single().agent)
+        assertEquals(PhaseType.REFLECT, skipped.single().phaseType)
+    }
+}


### PR DESCRIPTION
## Summary
- Port `ReflectHandler` from Swift to Kotlin `shared/engine` commonMain (ADR-023 Stage-3 Wave B, #501) — the **producer** side of the reflect-note loop whose **consumer** side (`injectNotes` / `{my_notes}` / private-notes system-prompt section) landed in #1240. Reflect is the smallest of the 5 inject-consumer handlers and the first tackled.
- Each active agent writes a private `notes_<name>` memo (non-empty guard), folded with `captureMood` into a **single** `state.copy(variables = …)` — and, unlike the speak handlers, **never** touches `conversationLog` / `lastOutputs`. A turn-degradable failure is absorbed as a skip that returns state unchanged with **no** `lastOutputs` clear (the deliberate divergence from `SpeakAllHandler`).
- Port `reflectBrevityRule` (2-sentence note cap) into `PromptBuilder.kt`, gated on `phase.type == REFLECT`; register `REFLECT` in `PhaseDispatcher` (8/14 Wave-B handlers) and flip the migration-status board.

## Test plan
- `./gradlew :shared:models:jvmTest :shared:engine:jvmTest :shared:engine:compileCommonMainKotlinMetadata` — green.
- New `ReflectHandlerTests` (7 tests) ported from Swift `ReflectHandlerTests` (+`+TurnDegradation`), 3 `reflectBrevityRule` parity tests, and a `PhaseDispatcherTests` reflect-resolve case.
- **ADR-023 §12 perturbation-verified**: erasing the skip arm reddens both skip-preserves-memo tests; dropping the note write reddens the three note-write tests. An all-empty inference is rejected by the parser's non-empty-expected-key guard → `RetriesExhausted` → turn-gate skip, so the handler's non-empty note guard is defensive parity (documented as such) and the empty-note test asserts the **skip** mechanism, not the unreachable guard.
- kmp-status pre-commit gate green (8 ported ↔ board, both directions); iOS `xcodebuild build` green.
- Opus code-review: **PASS** (0 issues).

## Device QA
実機QA不要 — Kotlin-only change to `shared/engine`, not consumed by the iOS app target yet (Phase-3.0-gated). No Swift / Metal / llama.cpp / device-only surface.

Closes #1242
Part of #501
