### PR TITLE
🧹 chore: port VoteHandler to shared/engine (ADR-023 Wave B B2)

### DIFF
--- a/docs/kmp-migration-status.md
+++ b/docs/kmp-migration-status.md
@@ -43,7 +43,7 @@ Legend: ✅ done · 🔄 in progress · 🟡 partial · ⬜ not started.
 |---|:--:|---|
 | Models mirror | ✅ done | #1193 #1196 #1202 |
 | Wave A — non-handler run-path (scoring, mechanisms, prompt/LLM glue) | ✅ done | #1207 #1212 #1217 |
-| Wave B — 14 phase handlers | 🔄 8/14 | checklist ↓ |
+| Wave B — 14 phase handlers | 🔄 9/14 | checklist ↓ |
 | code-phase track | ✅ done | CP1 #1226 · CP2 #1230 · CP3 #1232 |
 
 ### Wave B handler checklist
@@ -65,7 +65,7 @@ machine-checked — see the maintenance invariant above.
 - [x] RelationshipUpdateHandler — #1232
 - [x] ScoreCalcHandler — #1230
 - [ ] SpeakEachHandler
-- [ ] VoteHandler
+- [x] VoteHandler — #1249
 - [ ] WhisperHandler
 <!-- kmp-status:wave-b:end -->
 

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/PhaseDispatcher.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/PhaseDispatcher.kt
@@ -10,9 +10,9 @@ import kotlinx.serialization.serializer
  * ## Scope: the ADR-023 Stage-3 port, in progress
  *
  * **`SPEAK_ALL`, `ELIMINATE`, `SUMMARIZE`, `ASSIGN`, `EVENT_INJECT`, `SCORE_CALC`,
- * `RELATIONSHIP_UPDATE` and `REFLECT` are registered.** Swift registers all 14; the
- * remaining 6 are the mechanical bulk of Stage 3 ("mechanical after the Stage-2
- * slice", §4), ported handler-by-handler.
+ * `RELATIONSHIP_UPDATE`, `REFLECT` and `VOTE` are registered.** Swift registers all
+ * 14; the remaining 5 are the mechanical bulk of Stage 3 ("mechanical after the
+ * Stage-2 slice", §4), ported handler-by-handler.
  *
  * Unlike Swift's `PhaseDispatcher`, this is **not** exhaustive over [PhaseType] —
  * so an unregistered phase fails at dispatch with a clear error rather than at
@@ -34,6 +34,7 @@ internal class PhaseDispatcher {
         PhaseType.SCORE_CALC to ScoreCalcHandler(),
         PhaseType.RELATIONSHIP_UPDATE to RelationshipUpdateHandler(),
         PhaseType.REFLECT to ReflectHandler(),
+        PhaseType.VOTE to VoteHandler(),
     )
 
     /**

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/VoteHandler.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/VoteHandler.kt
@@ -1,0 +1,218 @@
+package com.pastura.engine
+
+import com.pastura.models.OutputSchema
+import com.pastura.models.Persona
+import com.pastura.models.Scenario
+import com.pastura.models.SimulationEvent
+import com.pastura.models.SimulationState
+import com.pastura.models.TurnOutput
+
+/**
+ * Handles `vote` phases, where every active agent votes for one agent.
+ *
+ * Each non-eliminated agent generates one `{vote}` via the LLM. Votes are tallied,
+ * the result is stored in [SimulationState.voteResults] (and the `{vote_results}`
+ * template variable), and a [SimulationEvent.VoteResults] event is emitted.
+ *
+ * ## Hybrid write semantics — neither pure speak nor pure reflect
+ *
+ * Like [SpeakAllHandler], a vote WRITES `lastOutputs` (so `relationship_update` can
+ * read `state.lastOutputs[voter].vote`) and CLEARS a stale entry on an abstention.
+ * Unlike the speak handlers, a vote is NOT an utterance, so it is never appended to
+ * `conversationLog`. Unlike [ReflectHandler] (which never touches `lastOutputs`),
+ * the skip path here must actively clear the stale ballot.
+ *
+ * A vote outside the voter's candidate list — self under `exclude_self`, an
+ * eliminated agent, or a hallucinated name — is dropped from the tally so it cannot
+ * distort scoring or elimination; the raw value is still recorded in the per-voter
+ * `votes` map for observability in the event (#524).
+ *
+ * A turn-degradable LLM failure is routed through [PhaseContext.turnGate]
+ * (ADR-021 D1/D2) and treated as an **abstention**: no ballot is recorded (neither
+ * the `votes` map nor the tally), no `AgentOutput` is emitted, and the voter's
+ * stale `lastOutputs` entry is cleared so a decision that never happened this turn
+ * can't leak into consumers keyed on it. The remaining agents still vote.
+ *
+ * Swift original: `Pastura/Pastura/Engine/Phases/VoteHandler.swift`.
+ */
+internal class VoteHandler : PhaseHandler {
+
+    private val promptBuilder = PromptBuilder()
+
+    /** A voter's turn outcome: the next state, plus the ballot (`null` on abstention). */
+    private data class VoteTurn(val state: SimulationState, val output: TurnOutput?)
+
+    override suspend fun execute(context: PhaseContext, state: SimulationState): SimulationState {
+        val promptTemplate = context.phase.prompt
+            ?: pickLanguage(
+                context.scenario.engineLanguage,
+                ja = "最も怪しいと思う人に投票してください。",
+                en = "Vote for the person you find most suspicious.",
+            )
+        val excludeSelf = context.phase.excludeSelf ?: true
+
+        val votes = mutableMapOf<String, String>() // voter -> target (raw value)
+        val tallies = mutableMapOf<String, Int>()
+        var current = state
+
+        for (persona in context.scenario.personas) {
+            // `== true` to SKIP: an agent absent from the map reads `null`, which is
+            // not `true`, so it votes — matching Swift's `!= true` guard.
+            if (current.eliminated[persona.name] == true) continue
+
+            val candidates = voteCandidates(context.scenario, persona, excludeSelf, current)
+            val turn = voteTurn(context, persona, promptTemplate, candidates, current)
+            // Thread `current` BEFORE the abstention `continue`: the skip path returns
+            // a state with the voter's stale `lastOutputs` cleared, so this assignment
+            // is load-bearing even when there is no ballot. Reordering it after the
+            // `?: continue` would silently drop that clear.
+            current = turn.state
+            val output = turn.output ?: continue // abstention — gate already emitted TurnSkipped
+
+            val votedFor = output.fields["vote"] ?: ""
+            votes[persona.name] = votedFor
+            // Tally only votes for a valid candidate. Out-of-candidate votes (self
+            // under exclude_self, eliminated agents, or hallucinated names) are
+            // dropped so they cannot distort scoring or elimination (#524); the raw
+            // value stays in `votes` for observability in the VoteResults event.
+            if (candidates.contains(votedFor)) {
+                tallies[votedFor] = (tallies[votedFor] ?: 0) + 1
+            }
+        }
+
+        // Post-loop fold: ONE copy off the THREADED `current` (which already carries
+        // every per-turn lastOutputs / captureMood write) — NOT off the original
+        // `state`, which would drop them all. Key must be "vote_results" (plural) to
+        // match the {vote_results} placeholder documented in PhaseEditorSheet and
+        // used by the word_wolf preset's summarize template.
+        val nextVariables = current.variables.toMutableMap()
+        nextVariables["vote_results"] = promptBuilder.formatScoreboard(tallies)
+        val next = current.copy(
+            voteResults = tallies,
+            variables = nextVariables,
+        )
+
+        context.emitter(SimulationEvent.VoteResults(votes = votes, tallies = tallies))
+        return next
+    }
+
+    /**
+     * Runs one voter's turn: builds the prompt, routes the LLM call through
+     * [PhaseContext.turnGate] (ADR-021 D1/D2), and on success emits `AgentOutput`,
+     * records the ballot in `lastOutputs`, and captures mood. On a skipped turn,
+     * emits nothing, clears any stale `lastOutputs` entry, and returns a `null`
+     * output (the caller records no ballot — an abstention).
+     *
+     * Returns BOTH the next state and the output — unlike [SpeakAllHandler]'s
+     * `speakTurn` / [ReflectHandler]'s `reflectTurn` (state only), the caller needs
+     * the vote value to tally. Kotlin [SimulationState] is immutable, so the caller
+     * MUST use the returned state (see [PhaseHandler]).
+     */
+    private suspend fun voteTurn(
+        context: PhaseContext,
+        persona: Persona,
+        promptTemplate: String,
+        candidates: List<String>,
+        state: SimulationState,
+    ): VoteTurn {
+        // Constructed per turn, matching Swift — a stateless value, cheap. The logger
+        // seam is threaded from the context (Noop by default in the current run
+        // path — see PhaseContext § "Knowingly absent").
+        val llmCaller = LLMCaller(logger = context.logger)
+
+        val systemPrompt = promptBuilder.buildSystemPrompt(
+            scenario = context.scenario,
+            persona = persona,
+            phase = context.phase,
+            state = state,
+        )
+
+        // Local prompt-variable map (thrown away after the prompt is built). The
+        // `inject*` family mutates it in place to surface each reserved-namespace
+        // `{token}` to only this voter; none of this touches persisted state.
+        val variables = state.variables.toMutableMap()
+        variables["scoreboard"] = promptBuilder.formatScoreboard(state.scores)
+        variables["conversation_log"] = promptBuilder.formatConversationLog(
+            entries = state.conversationLog,
+            language = context.scenario.engineLanguage,
+            window = context.scenario.logWindow,
+        )
+        variables["candidates"] = candidates.joinToString(separator = ", ")
+        promptBuilder.injectAssigned(variables, persona.name)
+        promptBuilder.injectNotes(variables, persona.name)
+        promptBuilder.injectWhispers(variables, persona.name)
+        promptBuilder.injectRelationships(variables, persona.name)
+        promptBuilder.injectMood(variables, persona.name)
+        val userPrompt = promptBuilder.expandTemplate(promptTemplate, variables)
+
+        val output = context.turnGate.attempt(
+            agent = persona.name,
+            phaseType = context.phase.type,
+            emitter = context.emitter,
+        ) {
+            llmCaller.call(
+                backend = context.backend,
+                system = systemPrompt,
+                user = userPrompt,
+                agentName = persona.name,
+                schema = OutputSchema.from(context.phase),
+                detector = context.detector,
+                expectedLanguage = context.scenario.engineLanguage,
+                relay = context.suspensionRelay,
+                emitter = context.emitter,
+            )
+        } ?: return VoteTurn(
+            // Abstention (ADR-021 D2): clear any stale prior-round output so
+            // downstream consumers keyed on `lastOutputs` (e.g. relationship_update)
+            // don't read a decision that never happened this turn. Matches Swift's
+            // `state.lastOutputs[persona.name] = nil` on the skip path — the
+            // deliberate divergence from ReflectHandler, which has nothing to clear.
+            state = state.copy(lastOutputs = state.lastOutputs - persona.name),
+            output = null,
+        )
+
+        context.emitter(
+            SimulationEvent.AgentOutput(
+                agent = persona.name,
+                output = output,
+                phaseType = context.phase.type,
+            ),
+        )
+
+        // Fold BOTH success-path writes into ONE `state.copy`: the ballot into
+        // `lastOutputs`, and captureMood (#913, a no-op unless the phase declares
+        // `mood`) into a fresh `variables` copy. A second copy off the original would
+        // drop the first write (Kotlin's immutable state; Swift threads two
+        // sequential `inout` mutations instead). No conversationLog entry — a vote is
+        // not an utterance.
+        val nextVariables = state.variables.toMutableMap()
+        promptBuilder.captureMood(output, nextVariables, persona.name)
+        return VoteTurn(
+            state = state.copy(
+                variables = nextVariables,
+                lastOutputs = state.lastOutputs + (persona.name to output),
+            ),
+            output = output,
+        )
+    }
+
+    /**
+     * The valid vote targets for [voter]: all personas minus self (under
+     * [excludeSelf]) and any eliminated agent. Kept in lockstep with
+     * `PromptBuilder.voteCandidateRule`, which lists the same set in the prompt, so
+     * the prompt's "valid names" and the accepted-vote tally never diverge.
+     */
+    private fun voteCandidates(
+        scenario: Scenario,
+        voter: Persona,
+        excludeSelf: Boolean,
+        state: SimulationState,
+    ): List<String> =
+        scenario.personas
+            .map { it.name }
+            .filter { name ->
+                if (excludeSelf && name == voter.name) return@filter false
+                if (state.eliminated[name] == true) return@filter false
+                true
+            }
+}

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/PromptBuilder.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/PromptBuilder.kt
@@ -27,10 +27,11 @@ import com.pastura.models.TurnOutput
  *
  * What is ported: [expandTemplate], [formatScoreboard], [formatConversationLog],
  * [getMainField]; [buildSystemPrompt] (header, scenario context, persona, secret,
- * private self-knowledge sections, base answer rules + mood rule, output format);
- * the injection family ([injectAssigned] / [injectNotes] / [injectWhispers] /
- * [injectRelationships] / [injectMood]), [captureMood] + `moodRule` +
- * `reflectBrevityRule`, and `appendPrivateSections`.
+ * private self-knowledge sections, base answer rules + mood rule + vote-candidate
+ * rule, output format); the injection family ([injectAssigned] / [injectNotes] /
+ * [injectWhispers] / [injectRelationships] / [injectMood]), [captureMood] +
+ * `moodRule` + `reflectBrevityRule` + `voteCandidateRule`, and
+ * `appendPrivateSections`.
  *
  * What is **knowingly absent** — each a *named* unit, tracked on #501 for its
  * Wave-B handler PR, never a silent drop:
@@ -39,7 +40,7 @@ import com.pastura.models.TurnOutput
  * |---|---|
  * | `addressRule` (#911, speak_each) | speak_each is a later Wave-B handler |
  * | `whisperRule` | whisper is a later Wave-B handler |
- * | choose-options rule / `voteCandidateRule` | choose / vote are later Wave-B handlers |
+ * | choose-options rule | choose is a later Wave-B handler |
  * | `RelationshipVerbalizer`, `PromptPlaceholders`, `ErrorReadability` | types landed in PR-3 (#501 Stage 3); PromptBuilder still has no slice consumer for them (wiring deferred to their Wave-B handlers) |
  *
  * Each remaining unit lands with its handler against the Swift test files, which
@@ -211,7 +212,7 @@ internal class PromptBuilder {
 
         appendSecretSection(sections, persona, language)
         appendPrivateSections(sections, persona, state, language)
-        sections += buildAnswerRules(language, phase)
+        sections += buildAnswerRules(scenario, persona, phase, state)
         formatOutputSchema(OutputSchema.from(phase), language)?.let { sections += it }
 
         return sections.joinToString(separator = "\n\n")
@@ -251,12 +252,23 @@ internal class PromptBuilder {
 
     /**
      * The `## 回答ルール / ## Response Rules` block: the base rules, plus the
-     * mood-writing rule ([moodRule], schema-gated) and the reflect-note brevity
-     * rule ([reflectBrevityRule], `REFLECT`-gated). The remaining phase-specific
-     * appendices (speak_each address, whisper privacy, choose options, vote
-     * candidates) are still Stage-3 units; see the class doc.
+     * mood-writing rule ([moodRule], schema-gated), the reflect-note brevity rule
+     * ([reflectBrevityRule], `REFLECT`-gated), and the vote-candidate rule
+     * ([voteCandidateRule], `VOTE`-gated). The remaining phase-specific appendices
+     * (speak_each address, whisper privacy, choose options) are still Stage-3
+     * units; see the class doc.
+     *
+     * Takes the full `(scenario, persona, state)` — not just `language` — because
+     * [voteCandidateRule] enumerates candidates from the persona + elimination
+     * state. Matches Swift's already-wide `buildAnswerRules(scenario:persona:phase:state:)`.
      */
-    private fun buildAnswerRules(language: String, phase: Phase): String {
+    private fun buildAnswerRules(
+        scenario: Scenario,
+        persona: Persona,
+        phase: Phase,
+        state: SimulationState,
+    ): String {
+        val language = scenario.engineLanguage
         // coerceIn: the THIRD site inheriting a Swift validator guarantee that does
         // not exist on this side yet. `ScenarioValidator.swift:136-145` enforces
         // `max_sentences` in 1..6; that validator is a Stage-3 port, so nothing
@@ -296,12 +308,54 @@ internal class PromptBuilder {
             rules += reflectBrevityRule(language)
         }
 
+        // Vote phases get the candidate-list constraint (see [voteCandidateRule]).
+        // Placed BEFORE the mood gate to match Swift's rule order
+        // (PromptBuilder.swift:220 precedes :226): the injection tests assert rule
+        // *membership* via `.contains`, not order, so a vote+mood ordering
+        // divergence would be silent — this placement pins it.
+        if (phase.type == PhaseType.VOTE) {
+            rules += voteCandidateRule(scenario, persona, phase, state)
+        }
+
         // Mood-opting phases (#913) get the mood-writing guidance. Gated on the
         // schema, not the phase type — any LLM phase can declare `mood`.
         if (phase.outputSchemaKeys.contains("mood")) {
             rules += moodRule(language)
         }
         return rules
+    }
+
+    /**
+     * The `vote` candidate-list constraint appended for vote phases only
+     * ([buildAnswerRules] gates on `phase.type == VOTE`). Lists the valid vote
+     * targets — all personas minus self (under `exclude_self`, default true) and
+     * any eliminated agent.
+     *
+     * The candidate set is derived the same way `VoteHandler` derives it for the
+     * `{candidates}` template variable and its tally filter, so the prompt's "valid
+     * names" and the handler's accepted votes stay in lockstep. Keep ja/en
+     * scope-parallel when editing.
+     */
+    private fun voteCandidateRule(
+        scenario: Scenario,
+        persona: Persona,
+        phase: Phase,
+        state: SimulationState,
+    ): String {
+        val excludeSelf = phase.excludeSelf ?: true
+        val candidates = scenario.personas
+            .map { it.name }
+            .filter { name ->
+                if (excludeSelf && name == persona.name) return@filter false
+                if (state.eliminated[name] == true) return@filter false
+                true
+            }
+        val candidatesList = candidates.joinToString(separator = ", ")
+        return pickLanguage(
+            scenario.engineLanguage,
+            ja = "\n- voteフィールドは必ず次の名前のいずれかを正確に書くこと: $candidatesList",
+            en = "\n- The vote field must be exactly one of these names: $candidatesList",
+        )
     }
 
     /**

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/PhaseDispatcherTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/PhaseDispatcherTests.kt
@@ -60,6 +60,11 @@ class PhaseDispatcherTests {
     }
 
     @Test
+    fun resolvesTheVoteHandler() {
+        assertIs<VoteHandler>(dispatcher.handler(PhaseType.VOTE))
+    }
+
+    @Test
     fun returnsAStableHandlerInstance() {
         // Handlers are stateless values; the dispatcher builds its map once.
         assertTrue(dispatcher.handler(PhaseType.SPEAK_ALL) === dispatcher.handler(PhaseType.SPEAK_ALL))
@@ -67,20 +72,20 @@ class PhaseDispatcherTests {
 
     @Test
     fun throwsForAPhaseTypeThisSliceHasNotPorted() {
-        val error = assertFailsWith<SimulationException> { dispatcher.handler(PhaseType.VOTE) }
+        val error = assertFailsWith<SimulationException> { dispatcher.handler(PhaseType.WHISPER) }
         assertIs<SimulationError.ScenarioValidationFailed>(error.error)
     }
 
     @Test
     fun theErrorNamesThePhaseUsingItsWireNameNotItsKotlinCaseName() {
-        // `vote`, not `VOTE` — Swift interpolates `phaseType.rawValue`, and a
+        // `whisper`, not `WHISPER` — Swift interpolates `phaseType.rawValue`, and a
         // reader comparing the two engines' errors should see the same token. Uses
-        // an unported type (VOTE stays a B1–B6 LLM handler through CP2) so this
-        // still exercises the throw path now that SCORE_CALC resolves.
-        val error = assertFailsWith<SimulationException> { dispatcher.handler(PhaseType.VOTE) }
+        // a still-unported type (WHISPER is a later Wave-B handler) so this still
+        // exercises the throw path now that VOTE resolves.
+        val error = assertFailsWith<SimulationException> { dispatcher.handler(PhaseType.WHISPER) }
         val message = assertIs<SimulationError.ScenarioValidationFailed>(error.error).message
-        assertTrue(message.contains("vote"), "expected the wire name, got: $message")
-        assertTrue(!message.contains("VOTE"), "the Kotlin case name must not leak: $message")
+        assertTrue(message.contains("whisper"), "expected the wire name, got: $message")
+        assertTrue(!message.contains("WHISPER"), "the Kotlin case name must not leak: $message")
     }
 
     @Test
@@ -91,9 +96,10 @@ class PhaseDispatcherTests {
             it != PhaseType.SPEAK_ALL && it != PhaseType.ELIMINATE &&
                 it != PhaseType.SUMMARIZE && it != PhaseType.ASSIGN &&
                 it != PhaseType.EVENT_INJECT && it != PhaseType.SCORE_CALC &&
-                it != PhaseType.RELATIONSHIP_UPDATE && it != PhaseType.REFLECT
+                it != PhaseType.RELATIONSHIP_UPDATE && it != PhaseType.REFLECT &&
+                it != PhaseType.VOTE
         }
-        assertEquals(6, unported.size, "Kotlin PhaseType has 14 cases today; see the #501 drift ledger")
+        assertEquals(5, unported.size, "Kotlin PhaseType has 14 cases today; see the #501 drift ledger")
         for (type in unported) {
             val error = assertFailsWith<SimulationException>("$type must fail cleanly") {
                 dispatcher.handler(type)

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/PromptBuilderInjectionTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/PromptBuilderInjectionTests.kt
@@ -22,9 +22,10 @@ import kotlin.test.assertTrue
  * base slice), these DO assert parity: their landed units are the full Swift
  * behaviour. Deliberately **out of scope** here — deferred to their own Wave-B
  * handler PRs, so their guidance is not yet ported: `whisperRule`, `addressRule`,
- * `voteCandidateRule`, and the choose-options rule. The `mood` and
- * `reflect`-brevity answer-rules ARE asserted, because `moodRule` and
- * `reflectBrevityRule` land with this infrastructure / the ReflectHandler PR.
+ * and the choose-options rule. The `mood`, `reflect`-brevity, and vote-candidate
+ * answer-rules ARE asserted, because `moodRule`, `reflectBrevityRule`, and
+ * `voteCandidateRule` land with this infrastructure / the ReflectHandler /
+ * VoteHandler PRs.
  *
  * Split into its own file per the commonTest concern-per-file convention
  * (cf. [PromptBuilderParityTests]); these are pure, stateless `PromptBuilder`
@@ -428,5 +429,60 @@ class PromptBuilderInjectionTests {
         // though it shares the same base answer-rule block.
         val s = scenario()
         assertFalse(builder.buildSystemPrompt(s, alice, speakAll, stateOf(s)).contains("メモ（note）は2文以内"))
+    }
+
+    // MARK: - Vote candidate answer-rule (vote phases only)
+
+    private val votePhase = Phase(
+        type = PhaseType.VOTE,
+        prompt = "Vote!",
+        outputSchema = mapOf("vote" to "string"),
+    )
+
+    @Test
+    fun voteCandidateRuleListsOthersExcludingSelfJa() {
+        // exclude_self defaults to true, so Alice's candidate list is the other two
+        // in persona order — never herself.
+        val s = scenario()
+        val prompt = builder.buildSystemPrompt(s, alice, votePhase, stateOf(s))
+        assertTrue(prompt.contains("voteフィールドは必ず次の名前のいずれかを正確に書くこと: Bob, Charlie"))
+    }
+
+    @Test
+    fun voteCandidateRuleListsOthersExcludingSelfEn() {
+        val s = scenario(language = "en")
+        val prompt = builder.buildSystemPrompt(s, alice, votePhase, stateOf(s))
+        assertTrue(prompt.contains("The vote field must be exactly one of these names: Bob, Charlie"))
+    }
+
+    @Test
+    fun voteCandidateRuleExcludesEliminatedAgents() {
+        // Bob eliminated + Alice self-excluded → only Charlie remains a candidate.
+        val s = scenario()
+        val state = SimulationState.initial(s).copy(eliminated = mapOf("Bob" to true))
+        val prompt = builder.buildSystemPrompt(s, alice, votePhase, state)
+        assertTrue(prompt.contains("voteフィールドは必ず次の名前のいずれかを正確に書くこと: Charlie"))
+    }
+
+    @Test
+    fun voteCandidateRuleIncludesSelfWhenExcludeSelfFalse() {
+        // exclude_self = false → the voter may vote for herself, so Alice appears in
+        // her own candidate list.
+        val s = scenario()
+        val includeSelf = Phase(
+            type = PhaseType.VOTE,
+            prompt = "Vote!",
+            outputSchema = mapOf("vote" to "string"),
+            excludeSelf = false,
+        )
+        val prompt = builder.buildSystemPrompt(s, alice, includeSelf, stateOf(s))
+        assertTrue(prompt.contains("voteフィールドは必ず次の名前のいずれかを正確に書くこと: Alice, Bob, Charlie"))
+    }
+
+    @Test
+    fun voteCandidateRuleOmittedForNonVotePhase() {
+        // A non-vote phase (speak_all) never gets the candidate-list rule.
+        val s = scenario()
+        assertFalse(builder.buildSystemPrompt(s, alice, speakAll, stateOf(s)).contains("voteフィールドは必ず"))
     }
 }

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/SimulationEngineTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/SimulationEngineTests.kt
@@ -248,15 +248,16 @@ class SimulationEngineTests {
 
     @Test
     fun anUnportedPhaseTypeSurfacesAsAValidationError() = runBlockingTest {
-        // A Stage-3 gap must read as a gap at runtime, not as a crash.
-        val s = scenario().copy(phases = listOf(Phase(type = PhaseType.VOTE, prompt = "Vote.")))
+        // A Stage-3 gap must read as a gap at runtime, not as a crash. Uses a
+        // still-unported type (WHISPER is a later Wave-B handler) — VOTE now resolves.
+        val s = scenario().copy(phases = listOf(Phase(type = PhaseType.WHISPER, prompt = "Whisper.")))
         val c = Collector()
         SimulationEngine().run(s, ScriptedLLMBackend(emptyList())) { c.record(it) }
         awaitTerminal(c)
 
         val error = assertIs<SimulationEvent.ErrorEvent>(c.snapshot().last())
         val failed = assertIs<SimulationError.ScenarioValidationFailed>(error.error)
-        assertTrue(failed.message.contains("vote"))
+        assertTrue(failed.message.contains("whisper"))
     }
 
     // MARK: - §5.1 pause / resume

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/VoteHandlerTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/VoteHandlerTests.kt
@@ -1,0 +1,336 @@
+package com.pastura.engine
+
+import com.pastura.models.Persona
+import com.pastura.models.Phase
+import com.pastura.models.PhaseType
+import com.pastura.models.Scenario
+import com.pastura.models.SimulationEvent
+import com.pastura.models.SimulationState
+import com.pastura.models.TurnOutput
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Kotlin sibling of Swift's `VoteHandlerTests` (+ its `…+TurnDegradation` split),
+ * collapsed into one class per the commonTest convention.
+ *
+ * Vote is a hybrid: it WRITES `lastOutputs` (and clears a stale entry on skip, like
+ * [SpeakAllHandler]) but never appends to `conversationLog` (a vote is not an
+ * utterance). Off-candidate votes are dropped from the tally yet kept in the raw
+ * `votes` map (#524). The ADR-021 turn-gate transient-skip is exercised here; the
+ * D3 systemic-error and D4 circuit-breaker cases ride the same shared gate already
+ * covered by [SpeakAllHandlerTests] + [TurnFailureGateTests].
+ *
+ * Ported for the ADR-023 KMP Engine migration (#501, #1249).
+ */
+class VoteHandlerTests {
+
+    private val handler = VoteHandler()
+
+    private fun scenario(
+        agents: List<String> = listOf("Alice", "Bob", "Charlie"),
+        language: String = "en",
+        simulationLanguage: String? = null,
+        prompt: String? = "Vote!",
+        excludeSelf: Boolean? = true,
+        outputSchema: Map<String, String> = mapOf("vote" to "string"),
+    ) = Scenario(
+        id = "t",
+        name = "T",
+        description = "d",
+        language = language,
+        simulationLanguage = simulationLanguage,
+        agentCount = agents.size,
+        rounds = 2,
+        logWindow = null,
+        context = "A test.",
+        personas = agents.map { Persona(name = it, description = "$it's persona.") },
+        phases = listOf(
+            Phase(type = PhaseType.VOTE, prompt = prompt, outputSchema = outputSchema, excludeSelf = excludeSelf),
+        ),
+    )
+
+    private fun context(
+        scenario: Scenario,
+        backend: LLMBackend,
+        events: MutableList<SimulationEvent> = mutableListOf(),
+    ) = PhaseContext(
+        scenario = scenario,
+        phase = scenario.phases[0],
+        backend = backend,
+        suspensionRelay = SuspensionRelay(),
+        emitter = { events += it },
+        pauseCheck = { },
+        phasePath = listOf(0),
+        turnGate = TurnFailureGate(),
+    )
+
+    private fun votes(target: String) =
+        ScriptedLLMBackend.Script.completing("""{"vote": "$target"}""")
+
+    private fun voteResultsEvent(events: List<SimulationEvent>) =
+        events.filterIsInstance<SimulationEvent.VoteResults>().single()
+
+    private fun initial(s: Scenario) = SimulationState.initial(s).copy(currentRound = 1)
+
+    // MARK: - Core tally
+
+    @Test
+    fun collectsVotesFromAllAgents() = runTest {
+        val s = scenario()
+        val backend = ScriptedLLMBackend(listOf(votes("Bob"), votes("Alice"), votes("Alice")))
+        val next = handler.execute(context(s, backend), initial(s))
+
+        assertEquals(2, next.voteResults["Alice"])
+        assertEquals(1, next.voteResults["Bob"])
+        assertEquals(3, backend.callCount)
+    }
+
+    @Test
+    fun emitsVoteResultsEvent() = runTest {
+        val s = scenario(agents = listOf("Alice", "Bob"))
+        val events = mutableListOf<SimulationEvent>()
+        val backend = ScriptedLLMBackend(listOf(votes("Bob"), votes("Alice")))
+        handler.execute(context(s, backend, events), initial(s))
+
+        val event = voteResultsEvent(events)
+        assertEquals("Bob", event.votes["Alice"])
+        assertEquals("Alice", event.votes["Bob"])
+    }
+
+    @Test
+    fun skipsEliminatedAgents() = runTest {
+        val s = scenario()
+        // Bob eliminated → Alice and Charlie vote; both target the other active pick.
+        val backend = ScriptedLLMBackend(listOf(votes("Charlie"), votes("Alice")))
+        val state = initial(s).copy(eliminated = mapOf("Bob" to true))
+        handler.execute(context(s, backend), state)
+
+        assertEquals(2, backend.callCount)
+    }
+
+    @Test
+    fun populatesVoteResultsStateVariable() = runTest {
+        // Key must be "vote_results" (plural) to match the {vote_results} placeholder
+        // documented in PhaseEditorSheet and used by the word_wolf preset.
+        val s = scenario()
+        val backend = ScriptedLLMBackend(listOf(votes("Bob"), votes("Alice"), votes("Alice")))
+        val next = handler.execute(context(s, backend), initial(s))
+
+        assertEquals("""{"Alice": 2, "Bob": 1}""", next.variables["vote_results"])
+        assertNull(next.variables["vote_result"])
+    }
+
+    // MARK: - Off-candidate tally drop (#524)
+
+    @Test
+    fun dropsInvalidVotesFromTally() = runTest {
+        // Three voters (exclude_self default true):
+        //   Alice → "Alice"   self-vote, invalid (Alice ∉ her candidates)
+        //   Bob   → "Ghost"   hallucinated name, invalid
+        //   Charlie → "Bob"   valid
+        // Reverting the `candidates.contains(votedFor)` guard would put Alice (self)
+        // and Ghost back into the tally — this test goes red in that case.
+        val s = scenario()
+        val events = mutableListOf<SimulationEvent>()
+        val backend = ScriptedLLMBackend(listOf(votes("Alice"), votes("Ghost"), votes("Bob")))
+        val next = handler.execute(context(s, backend, events), initial(s))
+
+        assertEquals(mapOf("Bob" to 1), next.voteResults)
+        assertNull(next.voteResults["Alice"]) // self-vote dropped
+        assertNull(next.voteResults["Ghost"]) // hallucinated dropped
+
+        // Divergence is intentional: the raw votes stay visible in the VoteResults
+        // event even though they are absent from the tally.
+        val event = voteResultsEvent(events)
+        assertEquals("Alice", event.votes["Alice"]) // self-vote preserved in votes map
+        assertEquals("Ghost", event.votes["Bob"]) // hallucinated preserved in votes map
+        assertEquals("Bob", event.votes["Charlie"])
+    }
+
+    @Test
+    fun dropsVotesForEliminatedAgentsFromTally() = runTest {
+        // Disjoint negative control for the `state.eliminated[name] == true` branch of
+        // voteCandidates (the #524 self-vote test above covers only the exclude_self
+        // branch). Charlie eliminated; Alice votes the eliminated Charlie (invalid —
+        // Charlie ∉ Alice's candidates [Bob]), Bob votes Alice (valid). Reverting the
+        // eliminated filter would make Charlie a candidate → Alice's vote tallied → red.
+        val s = scenario()
+        val events = mutableListOf<SimulationEvent>()
+        val backend = ScriptedLLMBackend(listOf(votes("Charlie"), votes("Alice")))
+        val state = initial(s).copy(eliminated = mapOf("Charlie" to true))
+        val next = handler.execute(context(s, backend, events), state)
+
+        assertEquals(mapOf("Alice" to 1), next.voteResults)
+        assertNull(next.voteResults["Charlie"]) // vote for an eliminated agent dropped
+
+        // Raw value still observable in the votes map.
+        assertEquals("Charlie", voteResultsEvent(events).votes["Alice"])
+    }
+
+    // MARK: - Hybrid write semantics (writes lastOutputs, never conversationLog)
+
+    @Test
+    fun writesBallotToLastOutputsAndLeavesConversationLogUntouched() = runTest {
+        val s = scenario(agents = listOf("Alice", "Bob"))
+        val backend = ScriptedLLMBackend(listOf(votes("Bob"), votes("Alice")))
+        val before = initial(s)
+        val next = handler.execute(context(s, backend), before)
+
+        // lastOutputs written (relationship_update reads lastOutputs[voter].vote).
+        assertEquals("Bob", next.lastOutputs["Alice"]?.fields?.get("vote"))
+        assertEquals("Alice", next.lastOutputs["Bob"]?.fields?.get("vote"))
+        // A vote is not an utterance — never appended to the conversation log.
+        assertTrue(next.conversationLog.isEmpty())
+        // Input untouched (immutable-state contract).
+        assertTrue(before.lastOutputs.isEmpty())
+    }
+
+    // MARK: - simulationLanguage override (ADR-010 Step E)
+
+    @Test
+    fun voteHonorsSimulationLanguageOverrideJaToEn() = runTest {
+        // ja authoring, en simulation override, prompt:null forces the fallback. The
+        // captured prompt must contain the English fallback, not the Japanese one.
+        val s = scenario(agents = listOf("Alice", "Bob"), language = "ja", simulationLanguage = "en", prompt = null)
+        val backend = ScriptedLLMBackend(listOf(votes("Bob"), votes("Alice")))
+        handler.execute(context(s, backend), initial(s))
+
+        val prompt = backend.requests[0].user
+        assertTrue(prompt.contains("Vote for the person"))
+        assertTrue(!prompt.contains("最も怪しい"))
+    }
+
+    @Test
+    fun voteHonorsSimulationLanguageOverrideEnToJa() = runTest {
+        // Reverse: en authoring, ja simulation override.
+        val s = scenario(agents = listOf("Alice", "Bob"), language = "en", simulationLanguage = "ja", prompt = null)
+        val backend = ScriptedLLMBackend(listOf(votes("Bob"), votes("Alice")))
+        handler.execute(context(s, backend), initial(s))
+
+        val prompt = backend.requests[0].user
+        assertTrue(prompt.contains("最も怪しい"))
+        assertTrue(!prompt.contains("Vote for the person"))
+    }
+
+    // MARK: - Prompt wiring (candidates injection)
+
+    @Test
+    fun candidatesVariableIsExpandedForEachVoter() = runTest {
+        // The {candidates} variable is the voter's candidate list (exclude_self
+        // default true), so Alice's prompt lists Bob, Charlie — never herself.
+        val s = scenario(prompt = "Candidates: {candidates}")
+        val backend = ScriptedLLMBackend(listOf(votes("Bob"), votes("Alice"), votes("Alice")))
+        handler.execute(context(s, backend), initial(s))
+
+        assertEquals("Candidates: Bob, Charlie", backend.requests[0].user)
+    }
+
+    // MARK: - captureMood round-trip (single-copy fold, #913)
+
+    @Test
+    fun capturedMoodSurfacesInTheNextRoundsPrompt() = runTest {
+        // Pins the single success-path `state.copy` fold: captureMood must land in
+        // the RETURNED state (folded alongside lastOutputs), else round N's mood never
+        // reaches round N+1. Perturbing the captureMood fold turns this red.
+        val moodPhase = Phase(
+            type = PhaseType.VOTE,
+            prompt = "Vote!",
+            outputSchema = mapOf("vote" to "string", "mood" to "string"),
+        )
+        val s = scenario(agents = listOf("Alice", "Bob")).copy(phases = listOf(moodPhase))
+        val backend = ScriptedLLMBackend(
+            listOf(
+                ScriptedLLMBackend.Script.completing("""{"vote": "Bob", "mood": "わくわく"}"""),
+                ScriptedLLMBackend.Script.completing("""{"vote": "Alice", "mood": "冷静"}"""),
+                ScriptedLLMBackend.Script.completing("""{"vote": "Bob", "mood": "不安"}"""),
+                ScriptedLLMBackend.Script.completing("""{"vote": "Alice", "mood": "焦り"}"""),
+            ),
+        )
+        val ctx = context(s, backend)
+
+        val afterRound1 = handler.execute(ctx, initial(s))
+        assertEquals("わくわく", afterRound1.variables["mood_Alice"])
+
+        handler.execute(ctx, afterRound1)
+        // Alice's round-2 prompt (request index 2) must carry her captured mood.
+        assertTrue(backend.requests[2].system.contains("わくわく"))
+        assertTrue(backend.requests[2].system.contains("Your Current Mood"))
+    }
+
+    // MARK: - Empty vote is a skip, NOT a tally drop (parser-guard distinction)
+
+    @Test
+    fun emptyVoteIsAbsorbedAsSkipNotTallyDrop() = runTest {
+        // The parser rejects a present-but-empty expected key ({"vote":""} —
+        // `hasAllExpectedKeys` requires non-empty content), so three empties exhaust
+        // the retry budget → RetriesExhausted → the turn gate absorbs it as a skip
+        // (ADR-021 D2). It is therefore an ABSTENTION (no ballot, stale lastOutputs
+        // cleared), NOT an off-candidate tally drop — the two paths must not be
+        // conflated. Asserted through the skip mechanism, not a tally value.
+        val s = scenario(agents = listOf("Alice"))
+        val backend = ScriptedLLMBackend(listOf(votes(""), votes(""), votes("")))
+        val events = mutableListOf<SimulationEvent>()
+        val state = initial(s).copy(
+            lastOutputs = mapOf("Alice" to TurnOutput(fields = mapOf("vote" to "stale"))),
+        )
+        val next = handler.execute(context(s, backend, events), state)
+
+        // Abstention: no ballot in the tally or the votes map, stale output cleared.
+        assertTrue(next.voteResults.isEmpty())
+        assertNull(voteResultsEvent(events).votes["Alice"])
+        assertNull(next.lastOutputs["Alice"])
+
+        // Mechanism: absorbed as a turn skip (no AgentOutput), not a guard-dropped tally.
+        assertTrue(events.filterIsInstance<SimulationEvent.AgentOutput>().isEmpty())
+        val skipped = events.filterIsInstance<SimulationEvent.TurnSkipped>()
+        assertEquals(1, skipped.size)
+        assertEquals("Alice", skipped.single().agent)
+        assertEquals(PhaseType.VOTE, skipped.single().phaseType)
+    }
+
+    // MARK: - Turn degradation (ADR-021 D1/D2)
+
+    @Test
+    fun transientFailureAbstainsAndOthersStillVote() = runTest {
+        // Alice's call fails transiently (turn-degradable); Bob and Charlie still
+        // vote. Alice's ballot is absent from both the votes map and the tally
+        // (abstention), and her stale lastOutputs entry is cleared (ADR-021 D2).
+        val s = scenario()
+        val backend = ScriptedLLMBackend(
+            listOf(
+                ScriptedLLMBackend.Script(terminal = TerminalStatus.Failed(errorCode = "transient blip")),
+                votes("Alice"),
+                votes("Alice"),
+            ),
+        )
+        val events = mutableListOf<SimulationEvent>()
+        val before = initial(s).copy(
+            lastOutputs = mapOf("Alice" to TurnOutput(fields = mapOf("vote" to "stale"))),
+        )
+        val next = handler.execute(context(s, backend, events), before)
+
+        // Only Bob and Charlie's ballots land; both voted "Alice".
+        assertEquals(2, next.voteResults["Alice"])
+        assertEquals(1, next.voteResults.size)
+
+        // No AgentOutput for the skipped voter; exactly one TurnSkipped.
+        val outputs = events.filterIsInstance<SimulationEvent.AgentOutput>().map { it.agent }
+        assertEquals(listOf("Bob", "Charlie"), outputs)
+
+        val skipped = events.filterIsInstance<SimulationEvent.TurnSkipped>()
+        assertEquals(1, skipped.size)
+        assertEquals("Alice", skipped.single().agent)
+        assertEquals(PhaseType.VOTE, skipped.single().phaseType)
+
+        // Abstention: no ballot for Alice in the emitted votes map, stale output cleared.
+        val event = voteResultsEvent(events)
+        assertNull(event.votes["Alice"])
+        assertEquals("Alice", event.votes["Bob"])
+        assertNull(next.lastOutputs["Alice"])
+        assertEquals("Alice", next.lastOutputs["Bob"]?.fields?.get("vote"))
+    }
+}


### PR DESCRIPTION
## Summary

Ports the `vote` LLM phase handler to `shared/engine` commonMain (ADR-023 Stage 3 Wave B, B2), mirroring the merged `ReflectHandler` (#1242) and `SpeakAllHandler` (#1222). Board **8/14 → 9/14**.

Vote is a **hybrid** of the speak/reflect shapes:
- **WRITES** `lastOutputs` (so `relationship_update` can read `lastOutputs[voter].vote`) and **clears** the stale entry on an abstention — like `SpeakAll`, unlike `Reflect` (which never touches `lastOutputs`).
- **Does NOT** append to `conversationLog` — a vote is not an utterance.
- Writes `state.voteResults` (tallies) + `state.variables["vote_results"]` (`formatScoreboard`) and emits `SimulationEvent.VoteResults(votes, tallies)` + `AgentOutput`.
- **Off-candidate tally drop (#524):** a vote for self (under `exclude_self`), an eliminated agent, or a hallucinated name stays in the raw `votes` map but is dropped from the tally.

Immutable-state fold discipline (the Kotlin-divergent path): the per-turn success path folds `lastOutputs` + `captureMood` into **one** `state.copy`; the abstention path clears the stale `lastOutputs`; the post-loop `voteResults`/`vote_results` write is taken off the **threaded** `current` state, never the original (which would silently drop every per-turn write).

Also lands `PromptBuilder.voteCandidateRule` (the candidate-list prompt constraint), split out of the class-doc absence-table row it shared with the choose-options rule. The VOTE gate is placed **before** the mood gate to match Swift's rule order (the injection tests assert membership, not order).

`PhaseType.VOTE` is registered in `PhaseDispatcher`; the two unported-example tests (`PhaseDispatcherTests`, `SimulationEngineTests`) are repointed VOTE → WHISPER, and the census filter/count adjusted 6 → 5. The migration-status checkbox flip lands in the same commit as `VoteHandler.kt` (`check-kmp-status.py` gate).

## Test plan

- `./gradlew :shared:models:jvmTest :shared:engine:jvmTest :shared:engine:compileCommonMainKotlinMetadata` — green (450 engine tests).
- `python3 scripts/check-kmp-status.py --check` — `9 ported ↔ board reconcile (both directions)`.
- Pre-commit iOS `xcodebuild build` — green (both commits).
- New `VoteHandlerTests.kt` ports the Swift `VoteHandlerTests` + `+TurnDegradation` spec (core tally, event emit, eliminated skip, `vote_results` variable, off-candidate drop #524, ja/en `simulationLanguage` override, `{candidates}` injection, `captureMood` round-trip, transient-skip abstention) plus new disjoint negative controls.
- New `voteCandidateRule` ja/en parity tests in `PromptBuilderInjectionTests.kt`.

### §12 perturbation confirmation (each guard reverted → the pinning test reddens)

| Perturbation | Reddened test(s) |
|---|---|
| tally-drop guard removed (`candidates.contains` → unconditional) | `dropsInvalidVotesFromTally`, `dropsVotesForEliminatedAgentsFromTally` |
| skip-path stale-`lastOutputs` clear removed | `emptyVoteIsAbsorbedAsSkipNotTallyDrop`, `transientFailureAbstainsAndOthersStillVote` |
| `voteCandidates` eliminated-agent filter removed | `dropsVotesForEliminatedAgentsFromTally` (disjoint — only this one) |

Parser-guard distinction verified: `{"vote":""}` is rejected by the parser → `RetriesExhausted` → turn skip (abstention), **not** a tally-drop — so the tally-drop tests use non-empty off-candidate votes, and the empty-vote test asserts the skip mechanism (`TurnSkipped` + `lastOutputs` clear).

## Device QA

実機QA不要 — pure Kotlin `shared/**` change, not yet consumed by the iOS app (KMP integration is Phase 3.0-gated, ADR-023 §6). No iOS-runtime or device-only surface touched; the K/N ↔ Swift boundary is untouched (pure commonMain, no new Swift-consumed sealed-subtype construction).

Closes #1249. Part of #501.
