### PR TITLE
🧹 chore: port WhisperHandler to shared/engine (ADR-023 Wave B B3)

### DIFF
--- a/docs/kmp-migration-status.md
+++ b/docs/kmp-migration-status.md
@@ -43,7 +43,7 @@ Legend: ✅ done · 🔄 in progress · 🟡 partial · ⬜ not started.
 |---|:--:|---|
 | Models mirror | ✅ done | #1193 #1196 #1202 |
 | Wave A — non-handler run-path (scoring, mechanisms, prompt/LLM glue) | ✅ done | #1207 #1212 #1217 |
-| Wave B — 14 phase handlers | 🔄 9/14 | checklist ↓ |
+| Wave B — 14 phase handlers | 🔄 10/14 | checklist ↓ |
 | code-phase track | ✅ done | CP1 #1226 · CP2 #1230 · CP3 #1232 |
 
 ### Wave B handler checklist
@@ -66,7 +66,7 @@ machine-checked — see the maintenance invariant above.
 - [x] ScoreCalcHandler — #1230
 - [ ] SpeakEachHandler
 - [x] VoteHandler — #1249
-- [ ] WhisperHandler
+- [x] WhisperHandler — #1252
 <!-- kmp-status:wave-b:end -->
 
 ## Stages 4–5 — remaining integration

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/PhaseDispatcher.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/PhaseDispatcher.kt
@@ -10,9 +10,9 @@ import kotlinx.serialization.serializer
  * ## Scope: the ADR-023 Stage-3 port, in progress
  *
  * **`SPEAK_ALL`, `ELIMINATE`, `SUMMARIZE`, `ASSIGN`, `EVENT_INJECT`, `SCORE_CALC`,
- * `RELATIONSHIP_UPDATE`, `REFLECT` and `VOTE` are registered.** Swift registers all
- * 14; the remaining 5 are the mechanical bulk of Stage 3 ("mechanical after the
- * Stage-2 slice", §4), ported handler-by-handler.
+ * `RELATIONSHIP_UPDATE`, `REFLECT`, `VOTE` and `WHISPER` are registered.** Swift
+ * registers all 14; the remaining 4 are the mechanical bulk of Stage 3 ("mechanical
+ * after the Stage-2 slice", §4), ported handler-by-handler.
  *
  * Unlike Swift's `PhaseDispatcher`, this is **not** exhaustive over [PhaseType] —
  * so an unregistered phase fails at dispatch with a clear error rather than at
@@ -35,6 +35,7 @@ internal class PhaseDispatcher {
         PhaseType.RELATIONSHIP_UPDATE to RelationshipUpdateHandler(),
         PhaseType.REFLECT to ReflectHandler(),
         PhaseType.VOTE to VoteHandler(),
+        PhaseType.WHISPER to WhisperHandler(),
     )
 
     /**

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/WhisperHandler.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/WhisperHandler.kt
@@ -1,0 +1,326 @@
+package com.pastura.engine
+
+import com.pastura.models.OutputSchema
+import com.pastura.models.Persona
+import com.pastura.models.SimulationEvent
+import com.pastura.models.SimulationState
+import com.pastura.models.TurnOutput
+
+/**
+ * Handles `whisper` phases: a secret pairwise exchange between two agents.
+ *
+ * Active (non-eliminated) agents are paired off in persona declaration order,
+ * rotated by round so the pairings vary. Each pair runs `subRounds` exchanges;
+ * an exchange is agent1 speaking then agent2 speaking. Every utterance reuses
+ * the `AgentOutput` event with a reserved `whisper_to` field naming the partner,
+ * so the whisper surfaces in the viewer UI / persistence exactly like any other
+ * LLM output.
+ *
+ * Whisper content is **pair-private**: it is never appended to `conversationLog`
+ * or `lastOutputs`, so other agents' prompts can't see it (mirroring
+ * [ReflectHandler]'s private note). At the end of the phase each participant's
+ * formatted view of their pair's exchange is written to the reserved
+ * `whispers_<name>` key (overwrite semantics — latest exchange only, per the #908
+ * plan). An active agent who sat out an odd-count round has their stale
+ * `whispers_<name>` cleared so a later reader never sees a whisper from a round
+ * they didn't participate in; eliminated agents' keys are left untouched (they are
+ * simply not participants this round).
+ *
+ * A turn-degradable LLM failure is routed through [PhaseContext.turnGate]
+ * (ADR-021 D1/D2): a skipped utterance **ends that pair's exchange early** — the
+ * remaining sub-rounds are not attempted, since a partner replying to a missing
+ * utterance would desync the exchange. Turns already exchanged stand and overwrite
+ * `whispers_<name>` as usual; but a pair whose *first* turn was skipped produces an
+ * empty transcript, and that case leaves the prior round's channels intact rather
+ * than overwriting them with a header-only body (private memory persists, mirroring
+ * [ReflectHandler]'s non-empty guard).
+ *
+ * ## State threading (Kotlin immutability)
+ *
+ * Swift's handler mutates an `inout` `state` in place while [whisperTurn] reads a
+ * phase-start snapshot ([Run.state]) for prompt building. Kotlin's [SimulationState]
+ * is immutable, so this port splits the two explicitly: `frozen` is the read-only
+ * phase-start snapshot every turn's prompt is built from, and `current` threads the
+ * channel / mood / sat-out writes. Each pair folds BOTH channel writes AND every
+ * `captureMood` into ONE `current.copy` — a second copy off the original would drop
+ * the first write (the VoteHandler folding discipline). [whisperTurn] itself writes
+ * nothing to persisted state.
+ *
+ * Swift original: `Pastura/Pastura/Engine/Phases/WhisperHandler.swift`.
+ */
+internal class WhisperHandler : PhaseHandler {
+
+    private val promptBuilder = PromptBuilder()
+
+    /**
+     * A single whisper line: [name] + spoken [statement]. [mood] is carried so
+     * [execute] can persist `mood_<name>` after the pair's exchange (#913) —
+     * [whisperTurn] reads a frozen snapshot and cannot write it itself. Empty when
+     * the phase doesn't opt into a `mood` output field.
+     */
+    private data class Utterance(
+        val name: String,
+        val statement: String,
+        val mood: String = "",
+    )
+
+    override suspend fun execute(context: PhaseContext, state: SimulationState): SimulationState {
+        val active = context.scenario.personas.filter { state.eliminated[it.name] != true }
+        // Fewer than two active agents → nothing to pair. Return WITHOUT any LLM call
+        // or state write; in particular, do NOT clear anyone's channel here.
+        if (active.size < 2) return state
+
+        val rotated = rotate(active, state.currentRound)
+        val promptTemplate = context.phase.prompt
+            ?: pickLanguage(
+                context.scenario.engineLanguage,
+                ja = "相手にこっそり耳打ちしてください。",
+                en = "Whisper privately to your partner.",
+            )
+        val exchanges = maxOf(1, context.phase.subRounds ?: 1)
+        val language = context.scenario.engineLanguage
+
+        // `frozen` is the phase-start snapshot every per-turn prompt reads (Swift's
+        // `Run.state`): whisper never mutates the public log / outputs / scores
+        // mid-phase, so it stays accurate for every pair. `current` threads the
+        // channel / mood / sat-out writes.
+        val frozen = state
+        var current = state
+
+        var pairIndex = 0
+        while (pairIndex + 1 < rotated.size) {
+            val first = rotated[pairIndex]
+            val second = rotated[pairIndex + 1]
+            val transcript = runPair(first, second, exchanges, context, frozen, promptTemplate)
+            // Only overwrite the pair's channels when at least one utterance was
+            // exchanged (ADR-021 D2): a first-turn skip yields an empty transcript, and
+            // writing a header-only channel would erase the prior round's whisper
+            // memory. A partial transcript (>=1 utterance) still overwrites as usual.
+            // Fold BOTH channel writes AND every captureMood into ONE `current.copy` —
+            // a second copy off `current` (or `state`) would drop the first write
+            // (the VoteHandler folding discipline). An empty transcript writes nothing
+            // (the mood loop is empty too).
+            if (transcript.isNotEmpty()) {
+                val vars = current.variables.toMutableMap()
+                // Both members see the same exchange body, each headed by their own
+                // partner-identifying line.
+                vars["whispers_${first.name}"] = formatChannel(transcript, second, language)
+                vars["whispers_${second.name}"] = formatChannel(transcript, first, language)
+                // Persist each speaker's mood from this pair's exchange (#913).
+                // Transcript order gives last-write-wins per speaker across sub_rounds;
+                // captureMood's non-empty guard skips a mood-less utterance so a prior
+                // round's mood isn't erased.
+                for (utterance in transcript) {
+                    promptBuilder.captureMood(
+                        TurnOutput(fields = mapOf("mood" to utterance.mood)),
+                        vars,
+                        utterance.name,
+                    )
+                }
+                current = current.copy(variables = vars)
+            }
+            pairIndex += 2
+        }
+
+        // Odd active count: the last rotated element sat this round out. Clear its
+        // stale channel for "latest only" consistency. An eliminated agent's key is
+        // left untouched — it is simply not a participant this round.
+        if (rotated.size % 2 == 1) {
+            val satOut = rotated.last()
+            current = current.copy(variables = current.variables - "whispers_${satOut.name}")
+        }
+        return current
+    }
+
+    // MARK: - Pairing
+
+    /**
+     * Rotates the active list by `(round - 1)` positions so consecutive rounds draw
+     * different adjacent pairs. The modulo is normalized non-negative to tolerate a
+     * `round` of 0.
+     */
+    private fun rotate(agents: List<Persona>, round: Int): List<Persona> {
+        val count = agents.size
+        val offset = ((round - 1) % count + count) % count
+        return agents.drop(offset) + agents.take(offset)
+    }
+
+    /**
+     * Runs [exchanges] back-and-forth turns for one pair, accumulating the running
+     * transcript so each speaker's prompt can reference what was said so far via
+     * `{whisper_exchange}`.
+     *
+     * A skipped utterance ends the exchange early (ADR-021 D2): the remaining turns
+     * for this pair are not attempted, so no partner replies to a missing utterance.
+     * Turns already appended stand.
+     */
+    private suspend fun runPair(
+        first: Persona,
+        second: Persona,
+        exchanges: Int,
+        context: PhaseContext,
+        frozen: SimulationState,
+        promptTemplate: String,
+    ): List<Utterance> {
+        val transcript = mutableListOf<Utterance>()
+        for (exchange in 0 until exchanges) {
+            val out1 = whisperTurn(first, second, transcript, context, frozen, promptTemplate)
+                ?: break
+            transcript.add(
+                Utterance(name = first.name, statement = out1.statement ?: "", mood = out1.fields["mood"] ?: ""),
+            )
+            val out2 = whisperTurn(second, first, transcript, context, frozen, promptTemplate)
+                ?: break
+            transcript.add(
+                Utterance(name = second.name, statement = out2.statement ?: "", mood = out2.fields["mood"] ?: ""),
+            )
+        }
+        return transcript
+    }
+
+    // MARK: - Single Turn
+
+    /**
+     * Builds one speaker's whisper prompt (from the phase-start [frozen] snapshot),
+     * routes the LLM call through [PhaseContext.turnGate] (ADR-021 D1/D2), and on
+     * success emits an `AgentOutput` carrying the reserved `whisper_to` field naming
+     * the [partner]. Returns the attributed output, or `null` on a skipped turn (the
+     * caller ends the pair's exchange early).
+     *
+     * Deliberately writes NOTHING to persisted state — not `conversationLog`, not
+     * `lastOutputs` (a whisper is pair-private, mirroring [ReflectHandler]). The
+     * channel / mood writes are folded in [execute], where the threaded `current`
+     * lives; this turn reads the frozen snapshot and so cannot (and must not) write.
+     */
+    private suspend fun whisperTurn(
+        speaker: Persona,
+        partner: Persona,
+        transcript: List<Utterance>,
+        context: PhaseContext,
+        frozen: SimulationState,
+        promptTemplate: String,
+    ): TurnOutput? {
+        val language = context.scenario.engineLanguage
+        // Constructed per turn, matching Swift — a stateless value, cheap. The logger
+        // seam is threaded from the context (Noop by default in the current run path).
+        val llmCaller = LLMCaller(logger = context.logger)
+
+        val systemPrompt = promptBuilder.buildSystemPrompt(
+            scenario = context.scenario,
+            persona = speaker,
+            phase = context.phase,
+            state = frozen,
+        )
+
+        // Local prompt-variable map (thrown away after the prompt is built). The
+        // `inject*` family mutates it in place to surface each reserved-namespace
+        // `{token}` to only this speaker; none of this touches persisted state.
+        val variables = frozen.variables.toMutableMap()
+        variables["scoreboard"] = promptBuilder.formatScoreboard(frozen.scores)
+        // The PUBLIC conversation log — whisper participants still see it.
+        variables["conversation_log"] = promptBuilder.formatConversationLog(
+            entries = frozen.conversationLog,
+            language = language,
+            window = context.scenario.logWindow,
+        )
+        variables["whisper_partner"] = partner.name
+        variables["whisper_exchange"] = formatTranscript(transcript)
+        promptBuilder.injectAssigned(variables, speaker.name)
+        promptBuilder.injectNotes(variables, speaker.name)
+        promptBuilder.injectWhispers(variables, speaker.name)
+        promptBuilder.injectRelationships(variables, speaker.name)
+        promptBuilder.injectMood(variables, speaker.name)
+        // ALWAYS append a partner-naming context block after expanding the user
+        // template: the default template never names the partner, and a custom author
+        // prompt may omit {whisper_partner} / {whisper_exchange}. The template still
+        // keeps those placeholders resolvable for authors who DO reference them; this
+        // block guarantees the partner + running exchange reach the model regardless
+        // of template content.
+        val userPrompt = promptBuilder.expandTemplate(promptTemplate, variables) +
+            whisperContextBlock(partner, transcript, language)
+
+        val output = context.turnGate.attempt(
+            agent = speaker.name,
+            phaseType = context.phase.type,
+            emitter = context.emitter,
+        ) {
+            llmCaller.call(
+                backend = context.backend,
+                system = systemPrompt,
+                user = userPrompt,
+                agentName = speaker.name,
+                schema = OutputSchema.from(context.phase),
+                detector = context.detector,
+                expectedLanguage = context.scenario.engineLanguage,
+                relay = context.suspensionRelay,
+                emitter = context.emitter,
+            )
+        }
+        // Skipped (ADR-021 D2): emit nothing; the caller ends the pair's exchange.
+            ?: return null
+
+        // Attribute the partner via the reserved `whisper_to` field. Kotlin TurnOutput
+        // carries only `fields` (no Swift `rawText`), so the merge is a plain copy.
+        val attributed = output.copy(fields = output.fields + ("whisper_to" to partner.name))
+        context.emitter(
+            SimulationEvent.AgentOutput(
+                agent = speaker.name,
+                output = attributed,
+                phaseType = context.phase.type,
+            ),
+        )
+        // NOT appended to `conversationLog` and NOT written to `lastOutputs`: a whisper
+        // is pair-private and must never reach another agent's prompt or the public
+        // last-output display (mirrors ReflectHandler).
+        return attributed
+    }
+
+    // MARK: - Formatting
+
+    /**
+     * Formats the exchange body one utterance per line, mirroring
+     * [PromptBuilder.formatConversationLog]'s `  Name: content` style.
+     */
+    private fun formatTranscript(transcript: List<Utterance>): String =
+        transcript.joinToString(separator = "\n") { "  ${it.name}: ${it.statement}" }
+
+    /**
+     * A language-aware block appended to every whisper turn prompt so the model always
+     * knows who its partner is — and, once the pair has spoken, what was said so far —
+     * no matter what the (possibly partner-agnostic) user template contains. The
+     * exchange section is omitted on the opening utterance (empty transcript) to avoid
+     * an empty header.
+     */
+    private fun whisperContextBlock(
+        partner: Persona,
+        transcript: List<Utterance>,
+        language: String,
+    ): String {
+        val partnerLine = pickLanguage(
+            language,
+            ja = "\n\n密談相手: ${partner.name}（この相手だけにこっそり話しかけてください）",
+            en = "\n\nWhisper partner: ${partner.name} (speak privately to them only).",
+        )
+        if (transcript.isEmpty()) return partnerLine
+        val exchangeHeader = pickLanguage(language, ja = "これまでの密談:", en = "Whisper so far:")
+        return "$partnerLine\n$exchangeHeader\n${formatTranscript(transcript)}"
+    }
+
+    /**
+     * A participant's stored channel view: a partner-identifying header line followed
+     * by the full exchange body.
+     */
+    private fun formatChannel(
+        transcript: List<Utterance>,
+        partner: Persona,
+        language: String,
+    ): String {
+        val header = pickLanguage(
+            language,
+            ja = "密談相手: ${partner.name}",
+            en = "Whispering with ${partner.name}",
+        )
+        val body = formatTranscript(transcript)
+        return if (body.isEmpty()) header else "$header\n$body"
+    }
+}

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/PromptBuilder.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/PromptBuilder.kt
@@ -30,7 +30,7 @@ import com.pastura.models.TurnOutput
  * private self-knowledge sections, base answer rules + mood rule + vote-candidate
  * rule, output format); the injection family ([injectAssigned] / [injectNotes] /
  * [injectWhispers] / [injectRelationships] / [injectMood]), [captureMood] +
- * `moodRule` + `reflectBrevityRule` + `voteCandidateRule`, and
+ * `moodRule` + `reflectBrevityRule` + `voteCandidateRule` + `whisperRule`, and
  * `appendPrivateSections`.
  *
  * What is **knowingly absent** — each a *named* unit, tracked on #501 for its
@@ -39,7 +39,6 @@ import com.pastura.models.TurnOutput
  * | Absent | Why |
  * |---|---|
  * | `addressRule` (#911, speak_each) | speak_each is a later Wave-B handler |
- * | `whisperRule` | whisper is a later Wave-B handler |
  * | choose-options rule | choose is a later Wave-B handler |
  * | `RelationshipVerbalizer`, `PromptPlaceholders`, `ErrorReadability` | types landed in PR-3 (#501 Stage 3); PromptBuilder still has no slice consumer for them (wiring deferred to their Wave-B handlers) |
  *
@@ -308,6 +307,13 @@ internal class PromptBuilder {
             rules += reflectBrevityRule(language)
         }
 
+        // Whisper turns get partner-directed privacy guidance (see [whisperRule]).
+        // Type-gated like reflect. Placed here to match Swift's rule order
+        // (PromptBuilder.swift: whisper precedes the choose/vote slots).
+        if (phase.type == PhaseType.WHISPER) {
+            rules += whisperRule(language)
+        }
+
         // Vote phases get the candidate-list constraint (see [voteCandidateRule]).
         // Placed BEFORE the mood gate to match Swift's rule order
         // (PromptBuilder.swift:220 precedes :226): the injection tests assert rule
@@ -369,6 +375,22 @@ internal class PromptBuilder {
             language,
             ja = "\n- メモ（note）は2文以内で簡潔に書くこと（長文・箇条書きの羅列は禁止）",
             en = "\n- Keep your note to at most 2 sentences (no long paragraphs or bullet lists).",
+        )
+
+    /**
+     * The #908 privacy guidance appended for `whisper` phases only ([buildAnswerRules]
+     * gates on `phase.type == WHISPER`). A whisper is a secret one-to-one exchange:
+     * nobody except the partner can hear it, so the agent should address the partner
+     * directly, stay candid/strategic, and keep it conversational. Keep ja/en
+     * scope-parallel when editing.
+     */
+    private fun whisperRule(language: String): String =
+        pickLanguage(
+            language,
+            ja = "\n- これは密談相手ひとりだけへの秘密の耳打ちです（他の参加者には聞こえません）。" +
+                "相手に直接呼びかけ、本音で戦略的に、短い会話として話すこと",
+            en = "\n- This is a private whisper to your one partner only (no one else can hear). " +
+                "Address them directly, be candid and strategic, and keep it conversational.",
         )
 
     /**

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/PhaseDispatcherTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/PhaseDispatcherTests.kt
@@ -65,6 +65,11 @@ class PhaseDispatcherTests {
     }
 
     @Test
+    fun resolvesTheWhisperHandler() {
+        assertIs<WhisperHandler>(dispatcher.handler(PhaseType.WHISPER))
+    }
+
+    @Test
     fun returnsAStableHandlerInstance() {
         // Handlers are stateless values; the dispatcher builds its map once.
         assertTrue(dispatcher.handler(PhaseType.SPEAK_ALL) === dispatcher.handler(PhaseType.SPEAK_ALL))
@@ -72,20 +77,20 @@ class PhaseDispatcherTests {
 
     @Test
     fun throwsForAPhaseTypeThisSliceHasNotPorted() {
-        val error = assertFailsWith<SimulationException> { dispatcher.handler(PhaseType.WHISPER) }
+        val error = assertFailsWith<SimulationException> { dispatcher.handler(PhaseType.CHOOSE) }
         assertIs<SimulationError.ScenarioValidationFailed>(error.error)
     }
 
     @Test
     fun theErrorNamesThePhaseUsingItsWireNameNotItsKotlinCaseName() {
-        // `whisper`, not `WHISPER` — Swift interpolates `phaseType.rawValue`, and a
+        // `choose`, not `CHOOSE` — Swift interpolates `phaseType.rawValue`, and a
         // reader comparing the two engines' errors should see the same token. Uses
-        // a still-unported type (WHISPER is a later Wave-B handler) so this still
-        // exercises the throw path now that VOTE resolves.
-        val error = assertFailsWith<SimulationException> { dispatcher.handler(PhaseType.WHISPER) }
+        // a still-unported type (CHOOSE is a later Wave-B handler) so this still
+        // exercises the throw path now that WHISPER resolves.
+        val error = assertFailsWith<SimulationException> { dispatcher.handler(PhaseType.CHOOSE) }
         val message = assertIs<SimulationError.ScenarioValidationFailed>(error.error).message
-        assertTrue(message.contains("whisper"), "expected the wire name, got: $message")
-        assertTrue(!message.contains("WHISPER"), "the Kotlin case name must not leak: $message")
+        assertTrue(message.contains("choose"), "expected the wire name, got: $message")
+        assertTrue(!message.contains("CHOOSE"), "the Kotlin case name must not leak: $message")
     }
 
     @Test
@@ -97,9 +102,9 @@ class PhaseDispatcherTests {
                 it != PhaseType.SUMMARIZE && it != PhaseType.ASSIGN &&
                 it != PhaseType.EVENT_INJECT && it != PhaseType.SCORE_CALC &&
                 it != PhaseType.RELATIONSHIP_UPDATE && it != PhaseType.REFLECT &&
-                it != PhaseType.VOTE
+                it != PhaseType.VOTE && it != PhaseType.WHISPER
         }
-        assertEquals(5, unported.size, "Kotlin PhaseType has 14 cases today; see the #501 drift ledger")
+        assertEquals(4, unported.size, "Kotlin PhaseType has 14 cases today; see the #501 drift ledger")
         for (type in unported) {
             val error = assertFailsWith<SimulationException>("$type must fail cleanly") {
                 dispatcher.handler(type)

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/PromptBuilderInjectionTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/PromptBuilderInjectionTests.kt
@@ -21,11 +21,11 @@ import kotlin.test.assertTrue
  * Unlike [PromptBuilderTests] (which disclaims parity for the still-incomplete
  * base slice), these DO assert parity: their landed units are the full Swift
  * behaviour. Deliberately **out of scope** here — deferred to their own Wave-B
- * handler PRs, so their guidance is not yet ported: `whisperRule`, `addressRule`,
- * and the choose-options rule. The `mood`, `reflect`-brevity, and vote-candidate
- * answer-rules ARE asserted, because `moodRule`, `reflectBrevityRule`, and
- * `voteCandidateRule` land with this infrastructure / the ReflectHandler /
- * VoteHandler PRs.
+ * handler PRs, so their guidance is not yet ported: `addressRule` and the
+ * choose-options rule. The `mood`, `reflect`-brevity, vote-candidate, and
+ * `whisper` answer-rules ARE asserted, because `moodRule`, `reflectBrevityRule`,
+ * `voteCandidateRule`, and `whisperRule` land with this infrastructure / the
+ * ReflectHandler / VoteHandler / WhisperHandler PRs.
  *
  * Split into its own file per the commonTest concern-per-file convention
  * (cf. [PromptBuilderParityTests]); these are pure, stateless `PromptBuilder`
@@ -237,6 +237,33 @@ class PromptBuilderInjectionTests {
         val prompt = builder.buildSystemPrompt(s, alice, whisperPhase, state)
         assertTrue(prompt.contains("Your Private Whispers"))
         assertTrue(prompt.contains("SENTINEL_AB"))
+    }
+
+    // MARK: - Whisper privacy answer-rule (whisper phases only, #908)
+
+    @Test
+    fun whisperRuleAppendedForWhisperPhaseJa() {
+        val s = scenario()
+        val prompt = builder.buildSystemPrompt(s, alice, whisperPhase, stateOf(s))
+        assertTrue(prompt.contains("これは密談相手ひとりだけへの秘密の耳打ち"))
+    }
+
+    @Test
+    fun whisperRuleAppendedForWhisperPhaseEn() {
+        val s = scenario(language = "en")
+        val prompt = builder.buildSystemPrompt(s, alice, whisperPhase, stateOf(s))
+        assertTrue(prompt.contains("This is a private whisper to your one partner only"))
+    }
+
+    @Test
+    fun whisperRuleOmittedForNonWhisperPhase() {
+        // A non-whisper phase (speak_all) never gets the whisper privacy rule, even
+        // though it shares the same base answer-rule block.
+        val s = scenario()
+        assertFalse(
+            builder.buildSystemPrompt(s, alice, speakAll, stateOf(s))
+                .contains("これは密談相手ひとりだけへの秘密の耳打ち"),
+        )
     }
 
     // MARK: - System-prompt private-relationships section (#910)

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/SimulationEngineTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/SimulationEngineTests.kt
@@ -249,15 +249,15 @@ class SimulationEngineTests {
     @Test
     fun anUnportedPhaseTypeSurfacesAsAValidationError() = runBlockingTest {
         // A Stage-3 gap must read as a gap at runtime, not as a crash. Uses a
-        // still-unported type (WHISPER is a later Wave-B handler) — VOTE now resolves.
-        val s = scenario().copy(phases = listOf(Phase(type = PhaseType.WHISPER, prompt = "Whisper.")))
+        // still-unported type (CHOOSE is a later Wave-B handler) — WHISPER now resolves.
+        val s = scenario().copy(phases = listOf(Phase(type = PhaseType.CHOOSE, prompt = "Choose.")))
         val c = Collector()
         SimulationEngine().run(s, ScriptedLLMBackend(emptyList())) { c.record(it) }
         awaitTerminal(c)
 
         val error = assertIs<SimulationEvent.ErrorEvent>(c.snapshot().last())
         val failed = assertIs<SimulationError.ScenarioValidationFailed>(error.error)
-        assertTrue(failed.message.contains("whisper"))
+        assertTrue(failed.message.contains("choose"))
     }
 
     // MARK: - §5.1 pause / resume

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/WhisperHandlerTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/WhisperHandlerTests.kt
@@ -1,0 +1,305 @@
+package com.pastura.engine
+
+import com.pastura.models.Persona
+import com.pastura.models.Phase
+import com.pastura.models.PhaseType
+import com.pastura.models.Scenario
+import com.pastura.models.SimulationEvent
+import com.pastura.models.SimulationState
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Kotlin sibling of Swift's `WhisperHandlerTests` (+ its `…+TurnDegradation` split),
+ * collapsed into one class per the commonTest convention.
+ *
+ * Whisper pairs off active agents (rotated by round; an odd agent sits out), runs
+ * `subRounds` exchanges per pair, emits each utterance as an `AgentOutput` carrying a
+ * reserved `whisper_to` field (never touching `conversationLog` / `lastOutputs`), and
+ * writes each participant's view of the exchange to `whispers_<name>`. The four
+ * hardest invariants are each perturbation-verified: pairing rotation, sat-out clear,
+ * ADR-021 skip early-break, and empty-transcript non-overwrite.
+ *
+ * Ported for the ADR-023 KMP Engine migration (#501, #1252).
+ */
+class WhisperHandlerTests {
+
+    private val handler = WhisperHandler()
+
+    private fun scenario(
+        agents: List<String>,
+        language: String = "en",
+        prompt: String? = "Whisper!",
+        subRounds: Int? = null,
+    ) = Scenario(
+        id = "t",
+        name = "T",
+        description = "d",
+        language = language,
+        simulationLanguage = null,
+        agentCount = agents.size,
+        rounds = 2,
+        logWindow = null,
+        context = "A test.",
+        personas = agents.map { Persona(name = it, description = "$it's persona.") },
+        phases = listOf(
+            Phase(
+                type = PhaseType.WHISPER,
+                prompt = prompt,
+                outputSchema = mapOf("statement" to "string", "inner_thought" to "string"),
+                subRounds = subRounds,
+            ),
+        ),
+    )
+
+    private fun context(
+        scenario: Scenario,
+        backend: LLMBackend,
+        events: MutableList<SimulationEvent> = mutableListOf(),
+    ) = PhaseContext(
+        scenario = scenario,
+        phase = scenario.phases[0],
+        backend = backend,
+        suspensionRelay = SuspensionRelay(),
+        emitter = { events += it },
+        pauseCheck = { },
+        phasePath = listOf(0),
+        turnGate = TurnFailureGate(),
+    )
+
+    private fun stmt(text: String) =
+        ScriptedLLMBackend.Script.completing("""{"statement": "$text", "inner_thought": "t"}""")
+
+    /** An empty-statement response: the parser rejects it (non-empty expected key), so
+     *  three in a row exhaust the retry budget → the turn gate absorbs it as a skip. */
+    private fun emptyStmt() =
+        ScriptedLLMBackend.Script.completing("""{"statement": "", "inner_thought": "t"}""")
+
+    private fun failed() =
+        ScriptedLLMBackend.Script(terminal = TerminalStatus.Failed(errorCode = "transient blip"))
+
+    private fun initial(s: Scenario, round: Int = 1) =
+        SimulationState.initial(s).copy(currentRound = round)
+
+    private data class WhisperOut(val agent: String, val whisperTo: String?, val statement: String?)
+
+    /** Extracts `(agent, whisper_to, statement)` for each whisper `AgentOutput`, in order. */
+    private fun whisperOutputs(events: List<SimulationEvent>): List<WhisperOut> =
+        events.filterIsInstance<SimulationEvent.AgentOutput>()
+            .filter { it.phaseType == PhaseType.WHISPER }
+            .map { WhisperOut(it.agent, it.output.fields["whisper_to"], it.output.statement) }
+
+    // MARK: - Pairing & attribution
+
+    @Test
+    fun fourAgentsRoundOnePairsAdjacentWithAttribution() = runTest {
+        val s = scenario(listOf("Alice", "Bob", "Carol", "Dave"))
+        val backend = ScriptedLLMBackend(listOf(stmt("A to B"), stmt("B to A"), stmt("C to D"), stmt("D to C")))
+        val events = mutableListOf<SimulationEvent>()
+        handler.execute(context(s, backend, events), initial(s))
+
+        val outputs = whisperOutputs(events)
+        assertEquals(listOf("Alice", "Bob", "Carol", "Dave"), outputs.map { it.agent })
+        assertEquals(listOf("Bob", "Alice", "Dave", "Carol"), outputs.map { it.whisperTo })
+    }
+
+    @Test
+    fun roundTwoRotationShiftsPairs() = runTest {
+        // PERTURBATION (pairing rotation): offset = (2-1) % 4 = 1 → rotated
+        // [Bob, Carol, Dave, Alice] → pairs (Bob,Carol),(Dave,Alice). Reverting
+        // `rotate` to `by 0` (declaration order) turns the two lists below red.
+        val s = scenario(listOf("Alice", "Bob", "Carol", "Dave"))
+        val backend = ScriptedLLMBackend(listOf(stmt("1"), stmt("2"), stmt("3"), stmt("4")))
+        val events = mutableListOf<SimulationEvent>()
+        handler.execute(context(s, backend, events), initial(s, round = 2))
+
+        val outputs = whisperOutputs(events)
+        assertEquals(listOf("Bob", "Carol", "Dave", "Alice"), outputs.map { it.agent })
+        assertEquals(listOf("Carol", "Bob", "Alice", "Dave"), outputs.map { it.whisperTo })
+    }
+
+    @Test
+    fun eliminatedAgentsNeverPaired() = runTest {
+        // Bob eliminated → active [Alice, Carol, Dave] → pair (Alice, Carol); Dave sits
+        // out; Bob is not a participant. Neither Bob nor Dave gets a channel.
+        val s = scenario(listOf("Alice", "Bob", "Carol", "Dave"))
+        val backend = ScriptedLLMBackend(listOf(stmt("A to C"), stmt("C to A")))
+        val events = mutableListOf<SimulationEvent>()
+        val state = initial(s).copy(eliminated = mapOf("Bob" to true))
+        val next = handler.execute(context(s, backend, events), state)
+
+        val outputs = whisperOutputs(events)
+        assertEquals(listOf("Alice", "Carol"), outputs.map { it.agent })
+        assertEquals(listOf("Carol", "Alice"), outputs.map { it.whisperTo })
+        assertNull(next.variables["whispers_Bob"])
+        assertNull(next.variables["whispers_Dave"])
+    }
+
+    // MARK: - Privacy (never conversationLog / lastOutputs)
+
+    @Test
+    fun doesNotTouchConversationLogOrLastOutputs() = runTest {
+        val s = scenario(listOf("Alice", "Bob"))
+        val backend = ScriptedLLMBackend(listOf(stmt("A to B"), stmt("B to A")))
+        val next = handler.execute(context(s, backend), initial(s))
+
+        assertTrue(next.conversationLog.isEmpty())
+        assertTrue(next.lastOutputs.isEmpty())
+    }
+
+    // MARK: - Per-participant channels
+
+    @Test
+    fun writesPerParticipantChannelWithoutCrossPairLeak() = runTest {
+        val s = scenario(listOf("Alice", "Bob", "Carol", "Dave"))
+        val backend = ScriptedLLMBackend(listOf(stmt("A to B"), stmt("B to A"), stmt("C to D"), stmt("D to C")))
+        val next = handler.execute(context(s, backend), initial(s))
+
+        for (name in listOf("Alice", "Bob", "Carol", "Dave")) {
+            assertTrue(next.variables["whispers_$name"] != null, "$name has a channel")
+        }
+        val aliceChannel = next.variables["whispers_Alice"]!!
+        assertTrue(aliceChannel.contains("A to B"))
+        assertTrue(aliceChannel.contains("B to A"))
+        // No leak of the other pair's content.
+        assertTrue(!aliceChannel.contains("C to D"))
+        assertTrue(!aliceChannel.contains("D to C"))
+        assertTrue(aliceChannel.contains("Bob")) // partner-identifying line
+    }
+
+    @Test
+    fun oddAgentSitsOutAndStaleChannelCleared() = runTest {
+        // PERTURBATION (sat-out clear): five agents → rotated [Alice..Eve]; Eve (last)
+        // sits out. Her stale channel must be cleared. Removing the sat-out
+        // `removeValue` fold leaves "stale" behind → this assertion goes red.
+        val s = scenario(listOf("Alice", "Bob", "Carol", "Dave", "Eve"))
+        val backend = ScriptedLLMBackend(listOf(stmt("A to B"), stmt("B to A"), stmt("C to D"), stmt("D to C")))
+        val events = mutableListOf<SimulationEvent>()
+        val state = initial(s).copy(variables = mapOf("whispers_Eve" to "stale from a prior round"))
+        val next = handler.execute(context(s, backend, events), state)
+
+        assertEquals(4, backend.callCount)
+        assertNull(next.variables["whispers_Eve"])
+        assertEquals(setOf("Alice", "Bob", "Carol", "Dave"), whisperOutputs(events).map { it.agent }.toSet())
+    }
+
+    @Test
+    fun singleActiveAgentIsNoOp() = runTest {
+        // Only Alice active (Bob/Carol/Dave eliminated) → nothing to pair. No LLM call,
+        // no AgentOutput, and — crucially — NO channel is cleared (Alice keeps hers).
+        val s = scenario(listOf("Alice", "Bob", "Carol", "Dave"))
+        val backend = ScriptedLLMBackend(emptyList())
+        val events = mutableListOf<SimulationEvent>()
+        val state = initial(s).copy(
+            eliminated = mapOf("Bob" to true, "Carol" to true, "Dave" to true),
+            variables = mapOf("whispers_Alice" to "untouched"),
+        )
+        val next = handler.execute(context(s, backend, events), state)
+
+        assertEquals(0, backend.callCount)
+        assertTrue(whisperOutputs(events).isEmpty())
+        assertEquals("untouched", next.variables["whispers_Alice"])
+    }
+
+    // MARK: - sub_rounds exchange accumulation
+
+    @Test
+    fun subRoundsAccumulatesExchangeTranscript() = runTest {
+        // Two exchanges per pair; the second speaker's prompt must carry the first
+        // exchange's running transcript (threaded via {whisper_exchange}).
+        val s = scenario(listOf("Alice", "Bob", "Carol", "Dave"), prompt = "Whisper. So far: {whisper_exchange}", subRounds = 2)
+        val backend = ScriptedLLMBackend(
+            listOf(
+                stmt("A1"), stmt("B1"), stmt("A2"), stmt("B2"), // pair (Alice, Bob)
+                stmt("C1"), stmt("D1"), stmt("C2"), stmt("D2"), // pair (Carol, Dave)
+            ),
+        )
+        val next = handler.execute(context(s, backend), initial(s))
+
+        assertEquals(8, backend.callCount)
+        val aliceChannel = next.variables["whispers_Alice"]!!
+        for (token in listOf("A1", "B1", "A2", "B2")) {
+            assertTrue(aliceChannel.contains(token), "channel carries $token")
+        }
+        // Alice's 2nd utterance (request index 2) saw the first exchange's transcript.
+        val secondSpeakerPrompt = backend.requests[2].user
+        assertTrue(secondSpeakerPrompt.contains("A1"))
+        assertTrue(secondSpeakerPrompt.contains("B1"))
+    }
+
+    // MARK: - Prompt hardening (#908): default template still names partner + exchange
+
+    @Test
+    fun defaultTemplateAlwaysNamesPartnerAndExchange() = runTest {
+        // prompt = null → the handler's built-in default (no placeholders). The
+        // appended context block still delivers the partner and running exchange.
+        val s = scenario(listOf("Alice", "Bob"), prompt = null)
+        val backend = ScriptedLLMBackend(listOf(stmt("A to B"), stmt("B to A")))
+        handler.execute(context(s, backend), initial(s))
+
+        // Alice speaks first — her prompt names Bob even without a template token.
+        assertTrue(backend.requests[0].user.contains("Bob"))
+        // Bob speaks second — his prompt names Alice AND carries the exchange so far.
+        val bobPrompt = backend.requests[1].user
+        assertTrue(bobPrompt.contains("Alice"))
+        assertTrue(bobPrompt.contains("A to B"))
+    }
+
+    // MARK: - ADR-021 skip (early-break + empty-transcript preservation)
+
+    @Test
+    fun firstTurnSkipPreservesPriorChannel() = runTest {
+        // PERTURBATION (empty-transcript non-overwrite): Alice's opening utterance is
+        // empty three times → parser rejects → RetriesExhausted → the gate absorbs it
+        // as a skip → the pair breaks with an EMPTY transcript. The `isNotEmpty()`
+        // guard must then leave the prior round's channel intact. Removing that guard
+        // writes a header-only "Whispering with Bob" over PRIOR_SENTINEL → red.
+        // Asserted through the SKIP mechanism (TurnSkipped, no AgentOutput), not the
+        // handler's guard alone.
+        val s = scenario(listOf("Alice", "Bob"))
+        val backend = ScriptedLLMBackend(listOf(emptyStmt(), emptyStmt(), emptyStmt()))
+        val events = mutableListOf<SimulationEvent>()
+        val state = initial(s).copy(variables = mapOf("whispers_Alice" to "PRIOR_SENTINEL"))
+        val next = handler.execute(context(s, backend, events), state)
+
+        // Prior channel untouched (empty transcript never overwrites).
+        assertEquals("PRIOR_SENTINEL", next.variables["whispers_Alice"])
+        // Mechanism: absorbed as a turn skip (no AgentOutput), not a silent guard drop.
+        assertTrue(events.filterIsInstance<SimulationEvent.AgentOutput>().isEmpty())
+        val skipped = events.filterIsInstance<SimulationEvent.TurnSkipped>()
+        assertEquals(1, skipped.size)
+        assertEquals("Alice", skipped.single().agent)
+        assertEquals(PhaseType.WHISPER, skipped.single().phaseType)
+    }
+
+    @Test
+    fun skipEndsPairExchangeEarly() = runTest {
+        // PERTURBATION (skip early-break): sub_rounds = 3. The first exchange
+        // completes (A1, B1); the second exchange's Alice turn fails transiently →
+        // skip → `break` stops the pair, so the THIRD exchange never starts. Only
+        // three calls run. Replacing the `?: break` with a `continue` would advance to
+        // the third exchange (Alice again), attempt a fourth call, and exhaust the
+        // scripted backend — a different failure. The completed exchange still
+        // overwrites the channel. (sub_rounds must exceed 2 so the skip lands on a
+        // non-final exchange; at 2 the skip is on the last one and break vs continue
+        // are indistinguishable.)
+        val s = scenario(listOf("Alice", "Bob"), subRounds = 3)
+        val backend = ScriptedLLMBackend(listOf(stmt("A1"), stmt("B1"), failed()))
+        val events = mutableListOf<SimulationEvent>()
+        val next = handler.execute(context(s, backend, events), initial(s))
+
+        assertEquals(3, backend.callCount) // Bob's exchange-2 turn was never attempted
+        val outputs = whisperOutputs(events)
+        assertEquals(listOf("Alice", "Bob"), outputs.map { it.agent }) // exchange 1 only
+        val skipped = events.filterIsInstance<SimulationEvent.TurnSkipped>()
+        assertEquals(1, skipped.size)
+        assertEquals("Alice", skipped.single().agent)
+        // The completed exchange still overwrites the channel.
+        val aliceChannel = next.variables["whispers_Alice"]!!
+        assertTrue(aliceChannel.contains("A1"))
+        assertTrue(aliceChannel.contains("B1"))
+    }
+}


### PR DESCRIPTION
## Summary

Ports Swift `WhisperHandler` into Kotlin `shared/engine` commonMain — ADR-023 Stage 3 Wave B (B3, the 3rd LLM handler after Reflect #1245 / Vote #1250). Board **9 → 10/14**.

Whisper is the most semantically complex LLM handler ported so far: active agents are paired off in persona order **rotated per round** (odd count → one sit-out), each pair runs `sub_rounds` back-and-forth exchanges, and every utterance is emitted as a normal `AgentOutput` carrying a reserved `whisper_to` field (viewer-visible, hidden from other agents — Reflect-type privacy: never written to `conversationLog` / `lastOutputs`). Each participant's exchange view is stored under `whispers_<name>` (overwrite, latest only; a sat-out agent's stale key is cleared). ADR-021 skip **ends a pair's exchange early**, and a first-turn skip yields an empty transcript that must **not** overwrite the prior round's channel.

Three commits:
1. `whisperRule` (#908 privacy guidance) into `PromptBuilder` + WHISPER type-gate in `buildAnswerRules` + ja/en parity tests.
2. `WhisperHandler.kt` (the port) + register `PhaseType.WHISPER` in `PhaseDispatcher` + repoint the unported-example throw sites (WHISPER→CHOOSE) + flip the migration-status board.
3. `WhisperHandlerTests.kt` — 11 Swift-parity tests.

### Kotlin-specific notes
- **Immutable-state folding**: Swift's `inout state` is split into a read-only phase-start `frozen` snapshot (every prompt is built from it) + a threaded `current` that folds each pair's two `whispers_` writes AND every `captureMood` into a **single** `copy` — the VoteHandler folding discipline (a second copy off the original would silently drop the first write).
- **`whisper_to` injection**: Kotlin `TurnOutput` carries only `fields` (no Swift `rawText`), so the provenance-merge collapses to `output.copy(fields = output.fields + ("whisper_to" to partner.name))`.
- Re-exercised the **empty→skip / handler-defensive-guard** pattern (a pending `kmp-interop.md` promotion candidate): `{"statement":""}` → parser rejects (non-empty expected key) → RetriesExhausted → turn-gate skip; the handler's `isNotEmpty()` guard then preserves the prior channel.

## Test plan
- `./gradlew :shared:models:jvmTest :shared:engine:jvmTest :shared:engine:compileCommonMainKotlinMetadata` — **BUILD SUCCESSFUL**; `WhisperHandlerTests` 11/11 (skipped=0, failures=0).
- `python3 scripts/check-kmp-status.py --check` — reconciled (14 handlers, 10 ported ↔ board).
- iOS `xcodebuild build` via the pre-commit hook on each commit (a `shared/` change triggers it) — green.

### §12 perturbation verification (negative control — each confirmed to go RED)
| Invariant | Perturbation | Test that reddened |
|---|---|---|
| Pairing rotation | `offset` → `0` | `roundTwoRotationShiftsPairs` |
| Sat-out clear | sat-out guard → `false` | `oddAgentSitsOutAndStaleChannelCleared` |
| Skip early-break | `?: break` → `?: continue` | `skipEndsPairExchangeEarly` |
| Empty-transcript non-overwrite | `isNotEmpty()` guard → `true` | `firstTurnSkipPreservesPriorChannel` |

The skip tests assert the turn-gate SKIP mechanism (`TurnSkipped` emitted, no `AgentOutput`, prior channel preserved), not the handler guard alone — so they can't pass as coverage theater.

## Device QA
実機QA不要 — Kotlin-only `shared/engine` change; the iOS app does not yet consume the shared module (Phase 3.0-gated, ADR-023). No `#if !targetEnvironment(simulator)`, Metal, or UI surface is touched.

Closes #1252
Part of #501
