### PR TITLE
✨ feat: reflect App Store launch — live store links + Phase 2 complete

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,12 +6,12 @@
 
 ## Current Phase
 
-**Phase 2: Expansion** — See `docs/ROADMAP.md` for scope.
-Phase 1 MVP shipped via TestFlight (conditional Go, 2026-04-13).
+**Phase 2: Expansion — ✅ Complete (2026-07-23).** Phase 3 (Community) not yet entered — its prerequisite (an active user base) is unmet at launch, so Phase 3 features stay deferred. See `docs/ROADMAP.md` for scope.
+Phase 1 MVP shipped via TestFlight (conditional Go, 2026-04-13); v1.0 released to the App Store 2026-07-23.
 If a requested feature is listed under Phase 3, do not implement it — reference the roadmap and defer.
 
 Phase 2 progress:
-- **Localization (i18n: ja/en)** — *implementation complete* (ADR-010 Steps A–E merged, umbrella #276 closed). English App Store launch is the remaining Phase 2 → Phase 3 gate. Step table + PR history: `docs/ROADMAP.md` § "Localization Plan".
+- **Localization (i18n: ja/en)** — *implementation complete* (ADR-010 Steps A–E merged, umbrella #276 closed). English App Store launch — the Phase 2 → Phase 3 gate — **achieved 2026-07-23** (v1.0 approved & released). Step table + PR history: `docs/ROADMAP.md` § "Localization Plan".
 
 Phase 2 increments: see `docs/ROADMAP.md` § "Phase 2 increments (detail)".
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 *AIgazing. Like stargazing, but for local LLMs.*  
 Running local LLM multi-agent simulations on-device.
 
+[<img src="web/public/img/app-store-badge-en.svg" height="40" alt="Download Pastura on the App Store" />](https://apps.apple.com/app/pastura-local-llms-simulator/id6788409688)
+
 [![CI](https://github.com/tyabu12/pastura/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/tyabu12/pastura/actions/workflows/ci.yml)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/tyabu12/2e86dcd3eddf5d5294d75870c9ad62e7/raw/pastura-coverage.json)](https://github.com/tyabu12/pastura/actions/workflows/ci.yml)
 [![License MIT](https://img.shields.io/badge/License-MIT-006400.svg)](LICENSE)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -71,11 +71,13 @@ creation observed. Decision: ship to App Store to gauge wider public reaction.
 
 ---
 
-## Phase 2: Expansion 🔧 In Progress
+## Phase 2: Expansion ✅ Complete
 
 **Goal:** Lower barriers, expand capabilities, reach broader audience.
 
 **Prerequisite:** Phase 1 Go decision from TestFlight feedback. ✅ Conditional Go (2026-04-13)
+
+**Completed 2026-07-23** — the Phase 2 → Phase 3 Go gate is met: v1.0 was approved and released to the App Store (see § "Phase 2 → Phase 3 Go Criteria"). Phase 3 (Community) is **not yet entered** — its prerequisite (an active user base) is unmet at launch. The `Custom score_calc logic` row below (now `Deferred → P3`) was never a Go-gate item.
 
 ### Planned Features
 
@@ -87,8 +89,8 @@ creation observed. Decision: ship to App Store to gauge wider public reaction.
 | `conditional` phase type                 | Medium   | Done        | Nested-branch phase + Visual Editor support; includes `target_score_race` preset and conditional endings in `word_wolf` / `detective_scene` (#126/#141). |
 | `event_inject` phase type                | Medium   | Done        | Random extraData-string injection into `state.variables` (default key `current_event`); Models→Engine→App→Views→Preset full-stack incl. word_wolf mid-flow showcase + demo replay re-record + bundled-demo phase_index alignment CI test (#256) |
 | `reflect` phase type                     | Medium   | Done        | Agent private memos + opt-in log window (#907/#937); adopted in `word_wolf` presets (#949) |
-| Custom score_calc logic                  | Medium   | Planned     | User-defined scoring expressions         |
-| Localization (i18n: ja / en)             | High     | Done (impl) | ja/en implementation complete — ADR-010 Steps A–E all merged (umbrella #276 closed); `localization-coverage` CI gate live. English App Store launch is the remaining Phase 2 → Phase 3 gate. Promoted from Phase 3 on 2026-04-29. See § Localization Plan below. |
+| Custom score_calc logic                  | Medium   | Deferred → P3 | User-defined scoring expressions. Never a Phase 2 Go-gate item (see § "Phase 2 → Phase 3 Go Criteria"); deferred to Phase 3. |
+| Localization (i18n: ja / en)             | High     | Done (impl) | ja/en implementation complete — ADR-010 Steps A–E all merged (umbrella #276 closed); `localization-coverage` CI gate live. English App Store launch (the Phase 2 → Phase 3 gate) achieved 2026-07-23 — v1.0 approved & released. Promoted from Phase 3 on 2026-04-29. See § Localization Plan below. |
 | Scenario sharing (Shared Scenarios)      | Medium   | Done (read-only) | Read-only curated gallery shipped (#87/#93). User submissions / ratings deferred to Phase 3 marketplace. |
 | Scenario deep link (`pastura://` scheme) | Medium   | Done        | 1-tap install from external contexts (SNS, QR, blog). IDs resolved through the curated gallery index only — no arbitrary URL fetch, no auto-execute. Preview via `GalleryScenarioDetailView` with external-link origin banner (#88). Universal Links / QR code generation deferred. |
 | Simulation result export (Markdown)      | Medium   | Done        | Share Sheet export including code-phase results (#91/#98) |
@@ -205,12 +207,14 @@ The stub PR also renames CLAUDE.md "Completed in Phase 2 so far" → "Phase 2 pr
 
 ### Phase 2 → Phase 3 Go Criteria
 
-Phase 2 is complete when:
+Phase 2 is complete when: **✅ met 2026-07-23 (v1.0 approved & released to the App Store).**
 
-- Localization Plan Steps A / B-1a / B-1b / C-1 / C-2 / D are all merged.
-- The English App Store submission has reached Approve. Quantitative signals (DL count, review count and content) are tracked separately as post-release polish indicators rather than Go gates.
-- Phase 2 features already shipped (Visual Editor, BG execution, Multi-model, Shared Scenarios, DL Demo Replay, ...) have no critical regressions.
+- [x] Localization Plan Steps A / B-1a / B-1b / C-1 / C-2 / D are all merged.
+- [x] The English App Store submission has reached Approve — approved & released 2026-07-23. Quantitative signals (DL count, review count and content) are tracked separately as post-release polish indicators rather than Go gates.
+- [x] Phase 2 features already shipped (Visual Editor, BG execution, Multi-model, Shared Scenarios, DL Demo Replay, ...) have no critical regressions.
 - Step E (Cross-language simulation) may run in parallel within Phase 2 but is **not** a completion gate.
+
+Entering Phase 3 is a separate step, gated on the Phase 3 prerequisite (an active user base) — unmet at launch.
 
 ---
 

--- a/web/public/css/base.css
+++ b/web/public/css/base.css
@@ -460,8 +460,8 @@ body {
   text-decoration: none;
   transition: all 0.25s ease-out;
 }
-/* When .badge is rendered as a <button> (e.g., disabled "Coming soon" CTA),
-   strip browser-default button chrome so it matches the <a> path visually. */
+/* When .badge is rendered as a <button>, strip browser-default button
+   chrome so it matches the <a> path visually. */
 button.badge {
   appearance: none;
   -webkit-appearance: none;
@@ -469,14 +469,10 @@ button.badge {
   cursor: pointer;
   text-align: left;
 }
-button.badge:disabled {
-  cursor: not-allowed;
-}
 
-/* Apple's official "Download on the App Store" badge — used for the
-   pre-launch CTA. The badge itself is unmodified per Apple's brand
-   guidelines; visual disabled state is conveyed via opacity + a
-   "Coming soon" caption below. */
+/* Apple's official "Download on the App Store" badge — the live link to
+   Pastura's App Store listing. The badge itself is unmodified per Apple's
+   brand guidelines. */
 .appstore-cta {
   appearance: none;
   -webkit-appearance: none;
@@ -489,21 +485,17 @@ button.badge:disabled {
   align-items: flex-start;
   gap: 6px;
   text-decoration: none;
-  cursor: not-allowed;
+  cursor: pointer;
 }
 .appstore-cta .appstore-img {
   display: block;
   width: 144px;
   height: auto;
-  opacity: 0.55;
+  opacity: 1;
   transition: opacity 0.2s ease-out;
 }
-.appstore-cta .appstore-status {
-  font-family: "JetBrains Mono", ui-monospace, monospace;
-  font-size: 9.5px;
-  letter-spacing: 0.22em;
-  text-transform: uppercase;
-  color: var(--muted);
+.appstore-cta:hover .appstore-img {
+  opacity: 0.85;
 }
 .badge .b-eyebrow {
   font-family: "JetBrains Mono", ui-monospace, monospace;

--- a/web/src/components/ScenarioLanding.astro
+++ b/web/src/components/ScenarioLanding.astro
@@ -34,8 +34,7 @@ const t = isJa
       titleSuffix: '｜Pastura',
       intro: 'このシナリオは Pastura の「みんなのシナリオ」の一つです。',
       openInApp: 'Pastura で開く',
-      badgeAria: 'Pastura を App Store で、近日公開',
-      badgeStatus: '近日公開',
+      badgeAria: 'Pastura を App Store で',
       badgeImg: '/img/app-store-badge-ja.svg',
       meta: `${scenario.agent_count}エージェント · ${scenario.rounds}ラウンド`,
       skip: '本文へスキップ',
@@ -53,8 +52,7 @@ const t = isJa
       titleSuffix: ' · Pastura',
       intro: 'This scenario is one of Pastura’s Shared Scenarios.',
       openInApp: 'Open in Pastura',
-      badgeAria: 'Pastura on the App Store — coming soon',
-      badgeStatus: 'Coming soon',
+      badgeAria: 'Pastura on the App Store',
       badgeImg: '/img/app-store-badge-en.svg',
       meta: `${scenario.agent_count} agents · ${scenario.rounds} rounds`,
       skip: 'Skip to content',
@@ -106,10 +104,9 @@ const t = isJa
         </p>
 
         <div class="badges">
-          <button type="button" aria-disabled="true" class="appstore-cta" aria-label={t.badgeAria}>
+          <a href="https://apps.apple.com/app/pastura-local-llms-simulator/id6788409688" target="_blank" rel="noopener" class="appstore-cta" aria-label={t.badgeAria}>
             <img class="appstore-img" src={t.badgeImg} alt="" aria-hidden="true" width="120" height="40" />
-            <span class="appstore-status">{t.badgeStatus}</span>
-          </button>
+          </a>
         </div>
       </div>
     </main>

--- a/web/src/pages/404.astro
+++ b/web/src/pages/404.astro
@@ -3,8 +3,8 @@
 // path, so this is the fallback for a shared /s/<id> whose scenario is not in
 // the curated gallery (e.g. a user-authored scenario). It cannot know the
 // visitor's locale (served for arbitrary paths), so it is bilingual with an
-// English shell (#1071, Growth A-2). The App Store badge reuses the site's
-// "coming soon" disabled-button treatment until launch.
+// English shell (#1071, Growth A-2). The App Store badge links to the live
+// App Store listing via the site's shared .appstore-cta styling.
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
@@ -42,10 +42,9 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         </p>
 
         <div class="badges">
-          <button type="button" aria-disabled="true" class="appstore-cta" aria-label="Pastura on the App Store — coming soon">
+          <a href="https://apps.apple.com/app/pastura-local-llms-simulator/id6788409688" target="_blank" rel="noopener" class="appstore-cta" aria-label="Pastura on the App Store / Pastura を App Store で">
             <img class="appstore-img" src="/img/app-store-badge-en.svg" alt="" aria-hidden="true" width="120" height="40" />
-            <span class="appstore-status">Coming soon</span>
-          </button>
+          </a>
         </div>
       </div>
     </main>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -58,13 +58,12 @@ const jsonLd = {
           <h1 id="hero-h" class="display hero-fx" style="--i: 0">AIgazing.<br>Like stargazing,<br>but for local LLMs.</h1>
           <p class="lead hero-fx" style="--i: 1">Pastura is a closed pasture for AI agents on your device. Watch as the agents act out the scenarios you&rsquo;ve written.</p>
           <div class="badges hero-fx" style="--i: 2">
-            <button type="button" aria-disabled="true"
+            <a href="https://apps.apple.com/app/pastura-local-llms-simulator/id6788409688" target="_blank" rel="noopener"
                     class="appstore-cta"
-                    aria-label="Pastura on the App Store — coming soon">
+                    aria-label="Pastura on the App Store">
               <img class="appstore-img" src="img/app-store-badge-en.svg"
                    alt="" aria-hidden="true" width="120" height="40">
-              <span class="appstore-status">Coming soon</span>
-            </button>
+            </a>
           </div>
         </div>
 
@@ -503,13 +502,12 @@ const jsonLd = {
           <span class="brand-name">Pastura</span>
         </a>
         <div class="badges">
-          <button type="button" aria-disabled="true"
+          <a href="https://apps.apple.com/app/pastura-local-llms-simulator/id6788409688" target="_blank" rel="noopener"
                   class="appstore-cta"
-                  aria-label="Pastura on the App Store — coming soon">
+                  aria-label="Pastura on the App Store">
             <img class="appstore-img" src="img/app-store-badge-en.svg"
                  alt="" aria-hidden="true" width="120" height="40">
-            <span class="appstore-status">Coming soon</span>
-          </button>
+          </a>
         </div>
       </div>
       <div>

--- a/web/src/pages/ja/index.astro
+++ b/web/src/pages/ja/index.astro
@@ -57,13 +57,12 @@ const jsonLd = {
           <h1 id="hero-h" class="display hero-fx" style="--i: 0">AI 観測。<br>天体観測のように、<br>ローカル LLM を眺める。</h1>
           <p class="lead hero-fx" style="--i: 1">Pastura は端末の中で動く、AI エージェントたちの閉じた牧場。<br>あなたの書いたシナリオをエージェント達が演じる。</p>
           <div class="badges hero-fx" style="--i: 2">
-            <button type="button" aria-disabled="true"
+            <a href="https://apps.apple.com/app/pastura-local-llms-simulator/id6788409688" target="_blank" rel="noopener"
                     class="appstore-cta"
-                    aria-label="Pastura を App Store で、近日公開">
+                    aria-label="Pastura を App Store で">
               <img class="appstore-img" src="../img/app-store-badge-ja.svg"
                    alt="" aria-hidden="true" height="40">
-              <span class="appstore-status">近日公開</span>
-            </button>
+            </a>
           </div>
         </div>
 
@@ -504,13 +503,12 @@ const jsonLd = {
           <span class="brand-name">Pastura</span>
         </a>
         <div class="badges">
-          <button type="button" aria-disabled="true"
+          <a href="https://apps.apple.com/app/pastura-local-llms-simulator/id6788409688" target="_blank" rel="noopener"
                   class="appstore-cta"
-                  aria-label="Pastura を App Store で、近日公開">
+                  aria-label="Pastura を App Store で">
             <img class="appstore-img" src="../img/app-store-badge-ja.svg"
                  alt="" aria-hidden="true" height="40">
-            <span class="appstore-status">近日公開</span>
-          </button>
+          </a>
         </div>
       </div>
       <div>


### PR DESCRIPTION
## Summary

v1.0 was approved and released to the App Store on 2026-07-23
(https://apps.apple.com/app/pastura-local-llms-simulator/id6788409688).
This reflects the launch on the public surfaces and in the project docs.

- **Live App Store links** — convert every disabled "Coming soon / 近日公開"
  CTA into a real link to the listing. 6 instances across 4 files: `index.astro`
  (hero + footer, EN), `ja/index.astro` (hero + footer, JA), `404.astro`
  (bilingual), and `ScenarioLanding.astro` (i18n-driven, rendered on the
  `/s/[id]` scenario deep-link landing pages for both locales — the primary
  external-share destination). aria-labels are locale-correct; only the
  bilingual 404 page uses a combined label. The shared `base.css` badge styling
  is enabled in the same commit (cursor, opacity + hover), and the orphaned
  `.appstore-status` / `button.badge:disabled` rules are removed.
- **README** — add a "Download on the App Store" badge near the top.
- **Phase status** — the Phase 2 → Phase 3 Go gate ("English App Store
  submission has reached Approve") is now met. CLAUDE.md Current Phase → Phase 2
  ✅ Complete; `docs/ROADMAP.md` heading + Go-criteria updated. Phase 3
  (Community) is **not yet entered** — its prerequisite (an active user base) is
  unmet at launch, so Phase 3 features stay deferred. The lone `Custom
  score_calc logic` Planned row is reconciled as Deferred → Phase 3 (never a
  Go-gate item).

The store URL is locale-agnostic — Apple redirects on the numeric app id, so
both locales use the same link.

## Test plan

- `npm run check` (astro check) — **0 errors / 0 warnings / 0 hints**
- `npm run build` (astro build) — **99 pages built, Complete**
- `rg -F appstore-status web/` and `rg -F aria-disabled web/src/` → **0** (no
  leftover disabled CTA markup)
- Apple badge SVGs byte-unchanged; Hero h1 AIgazing / AI観測 copy untouched
- `claude-kit:critic` (plan, ×2) + `code-reviewer` (diff) → PASS

## Device QA

実機QA不要 — web (`web/**`) + docs (`README.md`, `CLAUDE.md`, `docs/ROADMAP.md`)
のみ。Swift ソース非該当・シミュレータ除外ブロックや Metal 面に触れないため、
実機でしか確認できない挙動はない。web は CI (Web Check + Pages build) が検証する。

Closes #1254
