### PR TITLE
🔖 chore: bump app MARKETING_VERSION to 1.1

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release
-description: Cut a Pastura TestFlight release — guide the semver bump, synthesize and review the "What to Test" notes, run the preflight dry-run, then drive scripts/release.sh through a confirmation gate to archive, upload, and tag. Use when the user asks to cut/ship a release, upload a build to TestFlight, or run the release pipeline.
+description: Cut a Pastura release — version bump, TestFlight and App Store release notes, then a gated scripts/release.sh archive/upload/tag. Use when asked to cut or ship a release, upload a build to TestFlight, or run the release pipeline.
 allowed-tools: Read, Grep, Glob, Bash
 argument-hint: "[X.Y.Z]"
 ---

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -102,6 +102,77 @@ Test"** prose. These notes are published to TestFlight testers, so:
   State what changed and what to check, like a short developer note to a
   peer.
 
+### Three cuts before writing
+
+Apply in order. Each carries a mechanical check — **run it**; do not reason
+from the commit log alone. Every cut below exists because a plausible-sounding
+claim failed its check.
+
+**Cut 1 — by what the update delivers, not by where the file lives.** The
+question is "can the user do something now that they could not before?", not
+"is the file in the app bundle". Gallery scenarios (`docs/gallery/`) are
+fetched at runtime by `URLSessionGalleryService`, so any that already ran on
+the previous version reached users *without* this update — leave them out.
+
+The exception is gallery content the previous version **gated** (ADR-020
+`EngineSchemaVersion.isCompatible`: D2 rejects an unknown phase kind, D3
+rejects `min_engine_version > current`). That does arrive with the update, so
+name the scenarios. **Compute the set — never assume it is non-empty:**
+
+```bash
+LAST_TAG="$(git describe --tags --abbrev=0)"; [ -n "$LAST_TAG" ] || exit 1
+OLD="$(git show "$LAST_TAG":Pastura/Pastura/Models/PhaseType.swift)"
+jq -r '[.. |objects|select(has("phases")).phases[]]|unique[]' docs/gallery/gallery.json |
+  while read -r p; do
+    printf '%s' "$OLD" | grep -qE "\"${p}\"|case ${p}$" || echo "D2 gated: $p"
+  done
+jq '[.. |objects|select(has("min_engine_version")).min_engine_version]' docs/gallery/gallery.json
+```
+
+Both details are load-bearing and both fail silently toward "nothing gated":
+re-derive `LAST_TAG` here (Bash calls share no shell state, and an empty one
+makes `git show :path` read the *index* and exit 0), and match **raw values**,
+not case identifiers (`case speakAll = "speak_all"`).
+
+No `D2 gated:` line **and** an empty array ⇒ nothing was gated ⇒ **write no
+unlock line at all**; a raised `ENGINE_SCHEMA_VERSION` alone gates nothing.
+When one *is* earned, name the scenarios, keep mechanism words out, and echo
+what the app showed:
+「このシナリオの実行にはより新しいバージョンの Pastura が必要です。アプリを更新してください。」
+
+**Cut 2 — advertise only capabilities a shipped scenario exercises.** A new
+engine capability no bundled preset uses is an *authoring* feature; a player
+cannot encounter it, so listing it as a headline feature promises nothing.
+Substitute a real key before reading the result — an unsubstituted run returns
+zero hits, i.e. the suppressing answer:
+
+```bash
+CAP='secret:'   # ← replace per capability; a placeholder yields a false "not shipped"
+grep -l "$CAP" Pastura/Pastura/Resources/Presets/*.yaml
+```
+
+No hits ⇒ it belongs on an editor/author line, or nowhere.
+
+**Cut 3 — by likelihood of encounter.** Itemize fixes a tester could plausibly
+hit or should re-check; fold the rest — unusual configuration, malformed input,
+internal-consistency repairs — into a single "other minor fixes" line.
+
+**Use the app's own wording.** Feature and phase names must match the ja values
+in `Localizable.xcstrings`, not internal identifiers: `whisper` is 密談,
+`narrate` is 実況. "ラン" is developer vocabulary — the UI says 実行 /
+シミュレーション.
+
+### Two surfaces, two texts
+
+`--notes-file` reaches **TestFlight only** (see the `--notes-file` paragraph
+below). The App Store "What's New" is a separate App Store Connect field,
+entered by hand **per locale** — Pastura ships **ja + en-US** — at submission
+time (Step 7); `release.sh` never touches it. Write both from one shared body:
+TestFlight adds internal-behaviour detail and a "確認してほしいこと" list covering
+every new feature group; the App Store text drops both, since to a general user
+they read as instructions, or as defect reports. **Both texts go to the Step 5
+gate** — the App Store one is the copy that reaches the public.
+
 The **first** build is the exception: with no prior release to diff, write
 a brief app intro + what to test rather than a changelog.
 
@@ -149,6 +220,9 @@ Before the real run, present to the operator and get explicit approval:
 
 - target **version** and computed **build number** and **tag**
 - the final **"What to Test" notes** (Step 3) for sign-off
+- the final **App Store "What's New" text, per locale** (Step 3), if this
+  version is headed for submission — it is the only public-facing copy the
+  skill produces, and no later step gates it
 - confirmation that the one-time bootstrap holds (env vars set, key in
   place)
 

--- a/Pastura/Pastura.xcodeproj/project.pbxproj
+++ b/Pastura/Pastura.xcodeproj/project.pbxproj
@@ -450,7 +450,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = app.pastura.Pastura;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -491,7 +491,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = app.pastura.Pastura;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;


### PR DESCRIPTION
## Summary

- Bump the app target's `MARKETING_VERSION` from `1.0` to `1.1`, in both the Debug and Release build configurations (the two entries adjacent to `PRODUCT_BUNDLE_IDENTIFIER = app.pastura.Pastura`).
- `PasturaTests` / `PasturaUITests` `MARKETING_VERSION` entries are deliberately left at `1.0` — they are not shipped and `release.sh` does not read them.

## Why

Prerequisite for the App Store 1.1 submission. `scripts/release.sh` (ADR-014) asserts that the **archived** `MARKETING_VERSION` equals the `--version` it was invoked with, and it releases only from a checkout that equals `origin/main` and is CI-green. So the target version has to be on `main` before `/release` can run — a local bump commit would make `HEAD` diverge from `origin/main` and fail preflight.

The build number is `git rev-list --count HEAD`, so it advances automatically with this commit and satisfies release.sh's strict-exceeds guard against the previous release (`v1.0+522`) for free.

Note on the `1.0` vs `1.0.0` scheme: Apple accepts both two- and three-component versions and treats trailing-zero variants as numerically equal, so `1.0.0` could not have been submitted after `1.0` anyway. Staying on the two-component scheme (`1.0` → `1.1`) is consistent and correct.

## Test plan

- `git diff main...HEAD` is 2 changed lines, 1 file — verified both changed entries are the app target's and that the four test-target entries still read `1.0`.
- Pre-commit hook ran `xcodebuild build` green (SwiftLint skipped: no Swift staged).
- CI will re-run the full suite.

## Manual QA

Not needed — no code, resource, or UI surface changes. The version string is verifiable post-merge from the release archive: `/release`'s Step 4 dry-run preflight prints the planned version and fails loudly if the archived `MARKETING_VERSION` does not equal `1.1`.
