### PR TITLE
✨ feat: port ChooseHandler to shared/engine (ADR-023 Wave B, B4)

### DIFF
--- a/docs/kmp-migration-status.md
+++ b/docs/kmp-migration-status.md
@@ -22,7 +22,7 @@ At-a-glance progress for the KMP Engine migration (ADR-023 / [#501](https://gith
 > other section is hand-maintained; refresh it when a KMP PR merges (see
 > [`.claude/rules/kmp-interop.md`](../.claude/rules/kmp-interop.md)).
 
-_Last updated: 2026-07-23._
+_Last updated: 2026-07-24._
 
 ## Stages
 
@@ -43,7 +43,7 @@ Legend: ✅ done · 🔄 in progress · 🟡 partial · ⬜ not started.
 |---|:--:|---|
 | Models mirror | ✅ done | #1193 #1196 #1202 |
 | Wave A — non-handler run-path (scoring, mechanisms, prompt/LLM glue) | ✅ done | #1207 #1212 #1217 |
-| Wave B — 14 phase handlers | 🔄 10/14 | checklist ↓ |
+| Wave B — 14 phase handlers | 🔄 11/14 | checklist ↓ |
 | code-phase track | ✅ done | CP1 #1226 · CP2 #1230 · CP3 #1232 |
 
 ### Wave B handler checklist
@@ -57,7 +57,7 @@ machine-checked — see the maintenance invariant above.
 - [x] EliminateHandler — #1226
 - [x] SpeakAllHandler — #1222
 - [x] SummarizeHandler — #1226
-- [ ] ChooseHandler
+- [x] ChooseHandler — #1262
 - [ ] ConditionalHandler
 - [x] EventInjectHandler — #1230
 - [ ] NarrateHandler

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/PhaseDispatcher.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/PhaseDispatcher.kt
@@ -10,9 +10,9 @@ import kotlinx.serialization.serializer
  * ## Scope: the ADR-023 Stage-3 port, in progress
  *
  * **`SPEAK_ALL`, `ELIMINATE`, `SUMMARIZE`, `ASSIGN`, `EVENT_INJECT`, `SCORE_CALC`,
- * `RELATIONSHIP_UPDATE`, `REFLECT`, `VOTE` and `WHISPER` are registered.** Swift
- * registers all 14; the remaining 4 are the mechanical bulk of Stage 3 ("mechanical
- * after the Stage-2 slice", §4), ported handler-by-handler.
+ * `RELATIONSHIP_UPDATE`, `REFLECT`, `VOTE`, `WHISPER` and `CHOOSE` are
+ * registered.** Swift registers all 14; the remaining 3 are the mechanical bulk of
+ * Stage 3 ("mechanical after the Stage-2 slice", §4), ported handler-by-handler.
  *
  * Unlike Swift's `PhaseDispatcher`, this is **not** exhaustive over [PhaseType] —
  * so an unregistered phase fails at dispatch with a clear error rather than at
@@ -36,6 +36,7 @@ internal class PhaseDispatcher {
         PhaseType.REFLECT to ReflectHandler(),
         PhaseType.VOTE to VoteHandler(),
         PhaseType.WHISPER to WhisperHandler(),
+        PhaseType.CHOOSE to ChooseHandler(),
     )
 
     /**

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/ChooseHandler.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/ChooseHandler.kt
@@ -43,9 +43,11 @@ import com.pastura.models.TurnOutput
  *
  * ## Sole producer of `pairings` and `PairingResult`
  *
- * This handler is the **only** writer of [SimulationState.pairings] in the engine
- * (the run loop's per-round reset aside) and the only emitter of
- * [SimulationEvent.PairingResult]. Three already-ported consumers read the former —
+ * `pairings` has exactly three writers in the engine, and this is the only one that
+ * ever **adds** an entry: `SimulationEngine`'s per-round reset and
+ * `PairwisePayoffLogic`'s post-scoring clear both only empty it. This handler is
+ * likewise the only emitter of [SimulationEvent.PairingResult].
+ * Three already-ported consumers read the former —
  * `PairwisePayoffLogic` (exact `payoff.when` list match), `RelationshipUpdateHandler`
  * (`action_deltas[action]` map lookup), and `SummarizeHandler` (`{agent1}` template
  * expansion) — and all three hand-inject `pairings` in their own tests, so dropping

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/ChooseHandler.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/ChooseHandler.kt
@@ -1,0 +1,427 @@
+package com.pastura.engine
+
+import com.pastura.models.OutputSchema
+import com.pastura.models.Pairing
+import com.pastura.models.PairingStrategy
+import com.pastura.models.Persona
+import com.pastura.models.SimulationEvent
+import com.pastura.models.SimulationState
+import com.pastura.models.TurnOutput
+
+/**
+ * Handles `choose` phases where agents select from options.
+ *
+ * Supports two modes: round-robin pairing (adjacent pairs, each agent calls the
+ * LLM with opponent context) or individual choice (each agent chooses
+ * independently). In round-robin, an action that can't be mapped to the option
+ * set drops the whole pairing via [validateAction] (see below).
+ *
+ * [validateAction] is the **sole** value constraint on round-robin actions: the
+ * `action` field is a `.choice` in the grammar (structure-only — no value
+ * enumeration; see `OutputSchema.Kind.choice` and ADR-002 §Amendment 2026-06-14,
+ * #599), so the runtime check is what keeps the result within the option set. The
+ * model is steered toward valid options by [PromptBuilder]'s `chooseOptionsRule`,
+ * which lists them in the prompt, so a rejection is rare in practice.
+ *
+ * It **normalizes then canonicalizes** (ADR-021 § Amendment 2026-07-17 / #1151):
+ * a case/whitespace variant like `"Betray"` folds onto the canonical `betray` and
+ * scores; a genuinely off-menu action (`裏切る`, `betray!`) maps to `null` and the
+ * caller drops the pairing. This replaces the pre-Amendment `options[0]` fallback,
+ * which silently **fabricated** a cooperate for any off-menu answer. Individual
+ * mode does not canonicalize — it writes the raw action to `lastOutputs` for
+ * consumers that normalize on read (`EventReactivePayoffLogic`), inventing nothing.
+ *
+ * A turn-degradable LLM failure is routed through [PhaseContext.turnGate]
+ * (ADR-021 D1/D2). In **round-robin**, a skipped call drops the *whole pairing* —
+ * a half-real pairing (one action absent) would fabricate the missing action
+ * downstream — while the partner's already-emitted `AgentOutput` and `lastOutputs`
+ * still stand (consumed by `EventReactivePayoffLogic`). A **delivered-but-off-menu**
+ * action drops the pairing the same way but emits
+ * [SimulationEvent.ActionRejected] so the drop is observable, since the call
+ * itself succeeded. In **individual** mode a skipped turn writes nothing and clears
+ * the agent's stale `lastOutputs`.
+ *
+ * ## Sole producer of `pairings` and `PairingResult`
+ *
+ * This handler is the **only** writer of [SimulationState.pairings] in the engine
+ * (the run loop's per-round reset aside) and the only emitter of
+ * [SimulationEvent.PairingResult]. Three already-ported consumers read the former —
+ * `PairwisePayoffLogic` (exact `payoff.when` list match), `RelationshipUpdateHandler`
+ * (`action_deltas[action]` map lookup), and `SummarizeHandler` (`{agent1}` template
+ * expansion) — and all three hand-inject `pairings` in their own tests, so dropping
+ * the write here would compile clean and leave every one of them green while the
+ * real run path scores nothing. That is why the canonical-token return of
+ * [validateAction] and the append below are pinned by `ChooseHandlerTests`.
+ *
+ * ## State threading (Kotlin immutability)
+ *
+ * Swift's `callAgent` mutates an `inout state` **and** an `inout succeeded` set
+ * while returning the output. Kotlin's [SimulationState] is immutable and Kotlin
+ * has no `inout`, so [ChooseTurn] carries all three back and the pair loop threads
+ * them off a single `current`. Each success path folds every write —
+ * `lastOutputs`, `captureMood`, and (at the pair level) `pairings` — into ONE
+ * `copy`; a second copy off the original would drop the first write (the
+ * VoteHandler folding discipline, doubled here because a pair is two calls).
+ *
+ * Swift original: `Pastura/Pastura/Engine/Phases/ChooseHandler.swift`.
+ */
+internal class ChooseHandler : PhaseHandler {
+
+    private val promptBuilder = PromptBuilder()
+
+    /**
+     * One round-robin member's turn outcome.
+     *
+     * @property state     The next state (carries the success-path writes, or the
+     *   stale-`lastOutputs` clear on a skip).
+     * @property output    The turn's output, or `null` when the gate skipped it.
+     * @property succeeded The updated set of agents that have produced a successful
+     *   turn somewhere in this phase. Returned rather than mutated because Kotlin
+     *   has no `inout`; the caller must thread it, exactly like [state].
+     */
+    private data class ChooseTurn(
+        val state: SimulationState,
+        val output: TurnOutput?,
+        val succeeded: Set<String>,
+    )
+
+    override suspend fun execute(context: PhaseContext, state: SimulationState): SimulationState {
+        val promptTemplate = context.phase.prompt
+            ?: pickLanguage(
+                context.scenario.engineLanguage,
+                ja = "選択してください。",
+                en = "Make a choice.",
+            )
+        val options = context.phase.options ?: emptyList()
+
+        return if (context.phase.pairing == PairingStrategy.ROUND_ROBIN) {
+            executeRoundRobin(context, state, promptTemplate, options)
+        } else {
+            executeIndividual(context, state, promptTemplate)
+        }
+    }
+
+    // MARK: - Round Robin
+
+    private suspend fun executeRoundRobin(
+        context: PhaseContext,
+        state: SimulationState,
+        promptTemplate: String,
+        options: List<String>,
+    ): SimulationState {
+        val active = context.scenario.personas.filter { state.eliminated[it.name] != true }
+        // N adjacent pairs, wrapping — each agent appears in exactly two of them.
+        //
+        // Two boundaries look like bugs and are neither; both are Swift-faithful and
+        // load-bearing for scoring, so do NOT "fix" either into a dedupe or a guard.
+        //   - 2 active agents -> (A,B) and (B,A), two MIRRORED pairings, both scored.
+        //   - 1 active agent  -> (A,A), a self-pairing that double-scores through
+        //     PairwisePayoffLogic. Reachable: the run loop's "fewer than 2 active"
+        //     break fires at round START, so an `eliminate` phase earlier in the same
+        //     round can drop the roster to 1 before this phase runs.
+        // (0 active is inert — the `0 until 0` range is empty, so `% 0` never runs.)
+        val pairs = active.indices.map { idx -> active[idx] to active[(idx + 1) % active.size] }
+
+        // Agents that produced a successful turn somewhere in this phase. Each agent
+        // participates in two adjacency pairs, so a skip on one call must not clear
+        // a valid output the agent produced on its other call (ADR-021 D2).
+        var succeeded: Set<String> = emptySet()
+        var current = state
+
+        for ((persona1, persona2) in pairs) {
+            val turn1 = callAgent(persona1, persona2, context, promptTemplate, current, succeeded)
+            // Thread state AND succeeded BEFORE any `continue`: the skip path returns
+            // a state with the member's stale `lastOutputs` cleared, so these
+            // assignments are load-bearing even when there is no output.
+            current = turn1.state
+            succeeded = turn1.succeeded
+
+            val turn2 = callAgent(persona2, persona1, context, promptTemplate, current, succeeded)
+            current = turn2.state
+            succeeded = turn2.succeeded
+
+            // Gate 1 — drop the whole pairing if either member skipped (ADR-021 D2):
+            // a half-real pairing would fabricate the missing action downstream.
+            val out1 = turn1.output ?: continue
+            val out2 = turn2.output ?: continue
+
+            // Gate 2 (ADR-021 § Amendment 2026-07-17) — the call succeeded but the
+            // *action* may be off-menu. `validateAction` returns `null` for a
+            // genuinely unmappable action; dropping the pairing here is honest
+            // omission, where the old `options[0]` fallback fabricated a cooperate.
+            // Gate 1 above runs before these calls, so a skipped turn cannot reach
+            // this gate — it is required, not redundant.
+            val rawAction1 = out1.action ?: ""
+            val rawAction2 = out2.action ?: ""
+            val action1 = validateAction(rawAction1, options)
+            val action2 = validateAction(rawAction2, options)
+            if (action1 == null || action2 == null) {
+                // Emit which agent(s) were off-menu, carrying the raw value so the run
+                // log shows what the model said. `AgentOutput` already rendered for
+                // both, so this is a distinct signal, not a `TurnSkipped`.
+                if (action1 == null) {
+                    context.emitter(
+                        SimulationEvent.ActionRejected(
+                            agent = persona1.name,
+                            phaseType = context.phase.type,
+                            raw = rawAction1,
+                        ),
+                    )
+                }
+                if (action2 == null) {
+                    context.emitter(
+                        SimulationEvent.ActionRejected(
+                            agent = persona2.name,
+                            phaseType = context.phase.type,
+                            raw = rawAction2,
+                        ),
+                    )
+                }
+                continue
+            }
+
+            // APPEND, never replace: the run loop resets `pairings` at the top of each
+            // round and `PairwisePayoffLogic` clears it after scoring, so accumulation
+            // is already scoped to one round's choose phase. The stored actions are the
+            // CANONICAL option strings, not the raw model output — see [validateAction].
+            current = current.copy(
+                pairings = current.pairings + Pairing(
+                    agent1 = persona1.name,
+                    agent2 = persona2.name,
+                    action1 = action1,
+                    action2 = action2,
+                ),
+            )
+            context.emitter(
+                SimulationEvent.PairingResult(
+                    agent1 = persona1.name,
+                    action1 = action1,
+                    agent2 = persona2.name,
+                    action2 = action2,
+                ),
+            )
+        }
+        return current
+    }
+
+    /**
+     * Runs one member's round-robin call through [PhaseContext.turnGate]. On success,
+     * emits `AgentOutput`, records `lastOutputs`, captures mood, and adds the agent to
+     * [ChooseTurn.succeeded]. On a skipped turn, emits nothing and clears the agent's
+     * stale `lastOutputs` **only if it hasn't already succeeded this phase** (its other
+     * pairing may hold a valid output), then returns a `null` output.
+     *
+     * Unlike `WhisperHandler.whisperTurn` (which reads a frozen phase-start snapshot
+     * and writes nothing), this both reads and writes the threaded state: a round-robin
+     * member's `lastOutputs` write is visible to the partner's prompt within the same
+     * phase, matching Swift's sequential `inout` mutation.
+     */
+    private suspend fun callAgent(
+        persona: Persona,
+        opponent: Persona,
+        context: PhaseContext,
+        promptTemplate: String,
+        state: SimulationState,
+        succeeded: Set<String>,
+    ): ChooseTurn {
+        // Constructed per turn, matching Swift — a stateless value, cheap. The logger
+        // seam is threaded from the context (Noop by default in the current run path).
+        val llmCaller = LLMCaller(logger = context.logger)
+
+        val systemPrompt = promptBuilder.buildSystemPrompt(
+            scenario = context.scenario,
+            persona = persona,
+            phase = context.phase,
+            state = state,
+        )
+
+        // Local prompt-variable map (thrown away after the prompt is built). The
+        // `inject*` family mutates it in place to surface each reserved-namespace
+        // `{token}` to only this agent; none of this touches persisted state.
+        val variables = state.variables.toMutableMap()
+        // `opponent_name` is the choose-only variable — it is what makes a round-robin
+        // turn "with opponent context". Dropping it fails SILENTLY: expandTemplate
+        // leaves an unknown placeholder unchanged, so the literal `{opponent_name}`
+        // would reach the model with no exception and no diagnostic.
+        variables["opponent_name"] = opponent.name
+        variables["scoreboard"] = promptBuilder.formatScoreboard(state.scores)
+        variables["conversation_log"] = promptBuilder.formatConversationLog(
+            entries = state.conversationLog,
+            language = context.scenario.engineLanguage,
+            window = context.scenario.logWindow,
+        )
+        promptBuilder.injectAssigned(variables, persona.name)
+        promptBuilder.injectNotes(variables, persona.name)
+        promptBuilder.injectWhispers(variables, persona.name)
+        promptBuilder.injectRelationships(variables, persona.name)
+        promptBuilder.injectMood(variables, persona.name)
+        val userPrompt = promptBuilder.expandTemplate(promptTemplate, variables)
+
+        val output = context.turnGate.attempt(
+            agent = persona.name,
+            phaseType = context.phase.type,
+            emitter = context.emitter,
+        ) {
+            llmCaller.call(
+                backend = context.backend,
+                system = systemPrompt,
+                user = userPrompt,
+                agentName = persona.name,
+                schema = OutputSchema.from(context.phase),
+                detector = context.detector,
+                expectedLanguage = context.scenario.engineLanguage,
+                relay = context.suspensionRelay,
+                emitter = context.emitter,
+            )
+        } ?: return ChooseTurn(
+            // Skipped (ADR-021 D2). Clear the stale prior-round output ONLY if this
+            // agent has not already succeeded in this phase: it sits in two adjacency
+            // pairs, and an unconditional clear would erase the valid output from its
+            // other call, which `EventReactivePayoffLogic` legitimately consumes.
+            state = if (succeeded.contains(persona.name)) {
+                state
+            } else {
+                state.copy(lastOutputs = state.lastOutputs - persona.name)
+            },
+            output = null,
+            succeeded = succeeded,
+        )
+
+        context.emitter(
+            SimulationEvent.AgentOutput(
+                agent = persona.name,
+                output = output,
+                phaseType = context.phase.type,
+            ),
+        )
+
+        // Fold BOTH success-path writes into ONE `state.copy`: the choice into
+        // `lastOutputs`, and captureMood (#913, a no-op unless the phase declares
+        // `mood`) into a fresh `variables` copy. A second copy off the original would
+        // drop the first write.
+        val nextVariables = state.variables.toMutableMap()
+        promptBuilder.captureMood(output, nextVariables, persona.name)
+        return ChooseTurn(
+            state = state.copy(
+                variables = nextVariables,
+                lastOutputs = state.lastOutputs + (persona.name to output),
+            ),
+            output = output,
+            succeeded = succeeded + persona.name,
+        )
+    }
+
+    // MARK: - Individual
+
+    private suspend fun executeIndividual(
+        context: PhaseContext,
+        state: SimulationState,
+        promptTemplate: String,
+    ): SimulationState {
+        var current = state
+
+        for (persona in context.scenario.personas) {
+            if (current.eliminated[persona.name] == true) continue
+
+            // Constructed per run with the injected logger (stateless value — cheap).
+            val llmCaller = LLMCaller(logger = context.logger)
+
+            val systemPrompt = promptBuilder.buildSystemPrompt(
+                scenario = context.scenario,
+                persona = persona,
+                phase = context.phase,
+                state = current,
+            )
+
+            val variables = current.variables.toMutableMap()
+            variables["scoreboard"] = promptBuilder.formatScoreboard(current.scores)
+            variables["conversation_log"] = promptBuilder.formatConversationLog(
+                entries = current.conversationLog,
+                language = context.scenario.engineLanguage,
+                window = context.scenario.logWindow,
+            )
+            promptBuilder.injectAssigned(variables, persona.name)
+            promptBuilder.injectNotes(variables, persona.name)
+            promptBuilder.injectRelationships(variables, persona.name)
+            // executeIndividual omits injectWhispers (a real handler asymmetry), but
+            // mood is symmetric — surfaced in every LLM phase (like injectNotes).
+            promptBuilder.injectMood(variables, persona.name)
+            val userPrompt = promptBuilder.expandTemplate(promptTemplate, variables)
+
+            val output = context.turnGate.attempt(
+                agent = persona.name,
+                phaseType = context.phase.type,
+                emitter = context.emitter,
+            ) {
+                llmCaller.call(
+                    backend = context.backend,
+                    system = systemPrompt,
+                    user = userPrompt,
+                    agentName = persona.name,
+                    schema = OutputSchema.from(context.phase),
+                    detector = context.detector,
+                    expectedLanguage = context.scenario.engineLanguage,
+                    relay = context.suspensionRelay,
+                    emitter = context.emitter,
+                )
+            }
+            if (output == null) {
+                // Skipped (ADR-021 D2): write nothing, clear any stale prior-round
+                // output. Unconditional here, unlike round-robin — an individual agent
+                // gets exactly one call, so there is no sibling success to protect.
+                current = current.copy(lastOutputs = current.lastOutputs - persona.name)
+                continue
+            }
+
+            context.emitter(
+                SimulationEvent.AgentOutput(
+                    agent = persona.name,
+                    output = output,
+                    phaseType = context.phase.type,
+                ),
+            )
+
+            // The RAW action is stored, deliberately un-canonicalized: individual mode
+            // has no pairing to drop, and its consumer (`EventReactivePayoffLogic`)
+            // normalizes on read. Canonicalizing here would diverge from Swift.
+            val nextVariables = current.variables.toMutableMap()
+            promptBuilder.captureMood(output, nextVariables, persona.name)
+            current = current.copy(
+                variables = nextVariables,
+                lastOutputs = current.lastOutputs + (persona.name to output),
+            )
+        }
+        return current
+    }
+
+    // MARK: - Helpers
+
+    /**
+     * Maps a raw model action onto the canonical option set, or `null` when it is
+     * genuinely off-menu (ADR-021 § Amendment 2026-07-17 / #1151).
+     *
+     * Normalize-then-canonicalize:
+     * 1. Fold both sides — trim + lowercase, matching `EventReactivePayoffLogic`'s
+     *    normalization — so `"Betray"` / `" betray"` match `betray` instead of dropping.
+     * 2. On a match return the **canonical option string**, not the raw input: the
+     *    return is load-bearing as a *token*, not just a verdict —
+     *    `RelationshipUpdateHandler` looks up `action_deltas[action]` and
+     *    `PairwisePayoffLogic` matches `payoff.when` rows by exact string.
+     * 3. `null` only on genuine non-membership; the caller drops the pairing.
+     *
+     * `options.isEmpty() -> return action` is preserved: an options-less round-robin
+     * `choose` has nothing to canonicalize against, and returning `null` there would
+     * drop every pairing rather than pass the raw value through unchanged (the
+     * pre-Amendment behaviour for that path). Note the asymmetry with
+     * `PromptBuilder.chooseOptionsRule`, which gates on `options != null` — documented
+     * there, and deliberately Swift-faithful on both sides.
+     *
+     * `lowercase()` is locale-independent in Kotlin (unlike Java's default-locale
+     * `toLowerCase()`), so this does not hit the Turkish dotless-i class of bug.
+     */
+    private fun validateAction(action: String, options: List<String>): String? {
+        if (options.isEmpty()) return action
+        val normalized = action.trim().lowercase()
+        return options.firstOrNull { it.trim().lowercase() == normalized }
+    }
+}

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/PromptBuilder.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/PromptBuilder.kt
@@ -30,8 +30,8 @@ import com.pastura.models.TurnOutput
  * private self-knowledge sections, base answer rules + mood rule + vote-candidate
  * rule, output format); the injection family ([injectAssigned] / [injectNotes] /
  * [injectWhispers] / [injectRelationships] / [injectMood]), [captureMood] +
- * `moodRule` + `reflectBrevityRule` + `voteCandidateRule` + `whisperRule`, and
- * `appendPrivateSections`.
+ * `moodRule` + `reflectBrevityRule` + `voteCandidateRule` + `whisperRule` +
+ * `chooseOptionsRule`, and `appendPrivateSections`.
  *
  * What is **knowingly absent** — each a *named* unit, tracked on #501 for its
  * Wave-B handler PR, never a silent drop:
@@ -39,7 +39,6 @@ import com.pastura.models.TurnOutput
  * | Absent | Why |
  * |---|---|
  * | `addressRule` (#911, speak_each) | speak_each is a later Wave-B handler |
- * | choose-options rule | choose is a later Wave-B handler |
  * | `RelationshipVerbalizer`, `PromptPlaceholders`, `ErrorReadability` | types landed in PR-3 (#501 Stage 3); PromptBuilder still has no slice consumer for them (wiring deferred to their Wave-B handlers) |
  *
  * Each remaining unit lands with its handler against the Swift test files, which
@@ -252,10 +251,11 @@ internal class PromptBuilder {
     /**
      * The `## 回答ルール / ## Response Rules` block: the base rules, plus the
      * mood-writing rule ([moodRule], schema-gated), the reflect-note brevity rule
-     * ([reflectBrevityRule], `REFLECT`-gated), and the vote-candidate rule
-     * ([voteCandidateRule], `VOTE`-gated). The remaining phase-specific appendices
-     * (speak_each address, whisper privacy, choose options) are still Stage-3
-     * units; see the class doc.
+     * ([reflectBrevityRule], `REFLECT`-gated), the whisper privacy rule
+     * ([whisperRule], `WHISPER`-gated), the choose-options rule
+     * ([chooseOptionsRule], `CHOOSE`-gated), and the vote-candidate rule
+     * ([voteCandidateRule], `VOTE`-gated). One phase-specific appendix remains a
+     * Stage-3 unit — the speak_each address rule; see the class doc.
      *
      * Takes the full `(scenario, persona, state)` — not just `language` — because
      * [voteCandidateRule] enumerates candidates from the persona + elimination
@@ -312,6 +312,17 @@ internal class PromptBuilder {
         // (PromptBuilder.swift: whisper precedes the choose/vote slots).
         if (phase.type == PhaseType.WHISPER) {
             rules += whisperRule(language)
+        }
+
+        // Choose phases that declare options get the option-list constraint (see
+        // [chooseOptionsRule]). Placed between whisper and vote to match Swift's
+        // rule order (PromptBuilder.swift:212 sits between :208 and :220).
+        // `options` is bound to a local first — `phase.options` is a public property
+        // of another module (shared/models), which Kotlin refuses to smart-cast to
+        // non-null, so passing `phase.options` inside the guard does not compile.
+        val chooseOptions = phase.options
+        if (phase.type == PhaseType.CHOOSE && chooseOptions != null) {
+            rules += chooseOptionsRule(chooseOptions, language)
         }
 
         // Vote phases get the candidate-list constraint (see [voteCandidateRule]).
@@ -392,6 +403,36 @@ internal class PromptBuilder {
             en = "\n- This is a private whisper to your one partner only (no one else can hear). " +
                 "Address them directly, be candid and strategic, and keep it conversational.",
         )
+
+    /**
+     * The `choose` option-list constraint appended for choose phases that declare
+     * `options` ([buildAnswerRules] gates on `phase.type == CHOOSE && options != null`).
+     *
+     * This rule is the *only* steer toward the option set on the prompt side: the
+     * `action` field is a payload-free `.choice` in the grammar (structure-only, no
+     * value enumeration — the CJK sampler-crash trap, ADR-002 §Amendment 2026-06-14),
+     * so the runtime check in `ChooseHandler.validateAction` is the sole hard
+     * constraint and this list is what keeps rejections rare.
+     *
+     * **`options != null` here vs `options.isEmpty()` in the handler — a deliberate
+     * asymmetry carried over from Swift, not an oversight.** An `options: []` phase
+     * passes this gate and renders a rule with an empty list, while `validateAction`
+     * treats the same phase as *unconstrained* and passes the raw action through.
+     * The shape is reachable: neither `ScenarioLoader` nor `ScenarioValidator`
+     * rejects an empty `options`, and ADR-024's R7 lint rule is warning-only. It is
+     * preserved rather than "fixed" so the two engines stay byte-comparable; a fix
+     * belongs on the Swift side first, in both engines at once.
+     *
+     * Keep ja/en scope-parallel when editing.
+     */
+    private fun chooseOptionsRule(options: List<String>, language: String): String {
+        val optionsList = options.joinToString(separator = ", ")
+        return pickLanguage(
+            language,
+            ja = "\n- actionフィールドは必ず次のいずれかを書くこと: $optionsList",
+            en = "\n- The action field must be one of: $optionsList",
+        )
+    }
 
     /**
      * The #913 mood-writing guidance, appended only for phases that opt into a

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/PromptBuilder.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/PromptBuilder.kt
@@ -315,8 +315,10 @@ internal class PromptBuilder {
         }
 
         // Choose phases that declare options get the option-list constraint (see
-        // [chooseOptionsRule]). Placed between whisper and vote to match Swift's
-        // rule order (PromptBuilder.swift:212 sits between :208 and :220).
+        // [chooseOptionsRule]). Placed between the whisper and vote rules to match
+        // Swift's rule order — anchored on the SYMBOLS (`whisperRule` then the choose
+        // block then `voteCandidateRule` in PromptBuilder.swift, around :208-:220),
+        // because nothing gates a cross-language line reference against drift.
         // `options` is bound to a local first — `phase.options` is a public property
         // of another module (shared/models), which Kotlin refuses to smart-cast to
         // non-null, so passing `phase.options` inside the guard does not compile.

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ChooseHandlerTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ChooseHandlerTests.kt
@@ -140,14 +140,17 @@ class ChooseHandlerTests {
 
     @Test
     fun greenPathWritesCanonicalPairingsAndEmitsOnePairingResultEach() = runTest {
-        // The producer->consumer path. ChooseHandler is the engine's SOLE writer of
-        // `pairings` and sole emitter of PairingResult; all three downstream
-        // consumers hand-inject `pairings` in their own tests, so dropping either
-        // here stays green everywhere else. Feeds a CASE VARIANT ("Betray") on the
-        // green path so this also pins the canonical-token contract (axis 5) —
-        // storing the raw input would break the exact-string match that
-        // PairwisePayoffLogic (`payoff.when`) and RelationshipUpdateHandler
-        // (`action_deltas[action]`) depend on.
+        // The producer->consumer path. ChooseHandler is the engine's only APPENDER to
+        // `pairings` (the run loop's reset and PairwisePayoffLogic's post-scoring
+        // clear are the other two writers, both emptying) and the sole emitter of
+        // PairingResult; all three downstream consumers hand-inject `pairings` in
+        // their own tests, so dropping either here stays green everywhere else.
+        //
+        // Deliberately shares its script with `caseVariantActionScores…` below: the
+        // CASE VARIANT ("Betray") makes this test ALSO fail if canonicalization is
+        // reverted, so the production and canonicalization contracts are wired to one
+        // green path rather than two independently-satisfiable ones. The sibling test
+        // keeps the narrower, single-purpose framing of the Swift original.
         val s = scenario(agents = listOf("Alice", "Bob"))
         val events = mutableListOf<SimulationEvent>()
         val backend = ScriptedLLMBackend(
@@ -305,8 +308,16 @@ class ChooseHandlerTests {
     fun roundRobinSkipDropsWholePairingAndSparesTheOtherPairingsOutput() = runTest {
         // 3 agents -> pairs (Alice,Bob) (Bob,Charlie) (Charlie,Alice); call order
         // Alice,Bob,Bob,Charlie,Charlie,Alice. Failing call #1 (Alice as member 1 of
-        // pair 0) drops that pairing. Alice's LATER call (#6, in pair 2) succeeds, so
-        // she keeps a valid lastOutputs — that is the `succeeded` set at work.
+        // pair 0) drops that pairing, and her LATER call (#6, in pair 2) succeeds, so
+        // she still ends the phase with a valid lastOutputs.
+        //
+        // That last assertion does NOT exercise the `succeeded` guard, despite
+        // looking like it: at call #1 `succeeded` is still empty, so the guard takes
+        // its clearing branch anyway (a no-op on an empty map) and call #6 writes
+        // unconditionally. Deleting the guard leaves this test green. The guard's
+        // protective arm — success THEN skip — is pinned by the next test,
+        // `aSkipAfterASuccessDoesNotEraseTheEarlierValidOutput`; this one covers the
+        // skip-then-success direction and the pairing drop.
         val s = scenario()
         val events = mutableListOf<SimulationEvent>()
         val backend = ScriptedLLMBackend(
@@ -406,10 +417,12 @@ class ChooseHandlerTests {
         )
         handler.execute(context(s, backend), initial(s))
 
-        // Call #1 is Alice facing Bob; #2 is Bob facing Alice.
+        // Exact equality, not `contains`: it pins BOTH halves at once — the opponent's
+        // name is substituted AND no unresolved `{opponent_name}` literal survives.
+        // Call #1 is Alice facing Bob; #2 is Bob facing Alice (so this also catches a
+        // port that sets the variable once instead of per turn).
         assertEquals("You face Bob.", backend.requests[0].user)
         assertEquals("You face Alice.", backend.requests[1].user)
-        assertFalse(backend.requests[0].user.contains("{opponent_name}"))
     }
 
     @Test
@@ -533,7 +546,9 @@ class ChooseHandlerTests {
         val next = handler.execute(context(s, backend), state)
 
         assertEquals(2, backend.callCount)
-        assertNull(next.lastOutputs["Bob"])
+        // Identity, not just the count: a port that skipped the WRONG agent would
+        // still make two calls. Bob is absent; the other two ran.
+        assertEquals(setOf("Alice", "Charlie"), next.lastOutputs.keys)
     }
 
     // MARK: - Empty action is a SKIP, not an off-menu rejection

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ChooseHandlerTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ChooseHandlerTests.kt
@@ -1,0 +1,685 @@
+package com.pastura.engine
+
+import com.pastura.models.Pairing
+import com.pastura.models.PairingStrategy
+import com.pastura.models.Persona
+import com.pastura.models.Phase
+import com.pastura.models.PhaseType
+import com.pastura.models.Scenario
+import com.pastura.models.SimulationEvent
+import com.pastura.models.SimulationState
+import com.pastura.models.TurnOutput
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Kotlin sibling of Swift's `ChooseHandlerTests` (+ its `…+TurnDegradation` split),
+ * collapsed into one class per the commonTest convention.
+ *
+ * `choose` is the most entangled LLM handler of Wave B: two modes, and a
+ * round-robin output (`pairings`) that three already-ported consumers read. The
+ * cases below pin, in ADR-023 §12 terms, the mechanisms a green-but-wrong port
+ * would silently lose — the adjacency arithmetic, both drop gates, the `succeeded`
+ * set, the canonicalization boundary (canonical in round-robin, raw in individual),
+ * the `pairings`/`PairingResult` production, and `opponent_name`'s reach into the
+ * prompt.
+ *
+ * Ported for the ADR-023 KMP Engine migration (#501, #1262).
+ */
+class ChooseHandlerTests {
+
+    private val handler = ChooseHandler()
+
+    private fun scenario(
+        agents: List<String> = listOf("Alice", "Bob", "Charlie"),
+        language: String = "en",
+        simulationLanguage: String? = null,
+        prompt: String? = "Choose!",
+        options: List<String>? = listOf("cooperate", "betray"),
+        pairing: PairingStrategy? = PairingStrategy.ROUND_ROBIN,
+        outputSchema: Map<String, String> = mapOf("action" to "string"),
+    ) = Scenario(
+        id = "t",
+        name = "T",
+        description = "d",
+        language = language,
+        simulationLanguage = simulationLanguage,
+        agentCount = agents.size,
+        rounds = 2,
+        logWindow = null,
+        context = "A test.",
+        personas = agents.map { Persona(name = it, description = "$it's persona.") },
+        phases = listOf(
+            Phase(
+                type = PhaseType.CHOOSE,
+                prompt = prompt,
+                outputSchema = outputSchema,
+                options = options,
+                pairing = pairing,
+            ),
+        ),
+    )
+
+    private fun context(
+        s: Scenario,
+        backend: LLMBackend,
+        events: MutableList<SimulationEvent> = mutableListOf(),
+    ) = PhaseContext(
+        scenario = s,
+        phase = s.phases[0],
+        backend = backend,
+        suspensionRelay = SuspensionRelay(),
+        emitter = { events += it },
+        pauseCheck = { },
+        phasePath = listOf(0),
+        turnGate = TurnFailureGate(),
+    )
+
+    private fun chooses(action: String) =
+        ScriptedLLMBackend.Script.completing("""{"action": "$action"}""")
+
+    private fun failing() =
+        ScriptedLLMBackend.Script(terminal = TerminalStatus.Failed(errorCode = "transient blip"))
+
+    private fun initial(s: Scenario) = SimulationState.initial(s).copy(currentRound = 1)
+
+    private fun pairingResults(events: List<SimulationEvent>) =
+        events.filterIsInstance<SimulationEvent.PairingResult>()
+
+    private fun rejections(events: List<SimulationEvent>) =
+        events.filterIsInstance<SimulationEvent.ActionRejected>()
+
+    private fun skips(events: List<SimulationEvent>) =
+        events.filterIsInstance<SimulationEvent.TurnSkipped>()
+
+    // MARK: - Round-robin adjacency (§12 axis 1)
+
+    @Test
+    fun roundRobinCreatesAdjacentPairsAndCallsTheBackendTwicePerPair() = runTest {
+        // 3 agents -> 3 adjacent pairs (Alice,Bob) (Bob,Charlie) (Charlie,Alice),
+        // 2 calls per pair = 6. The `(i+1) % count` wrap is what makes the pair
+        // COUNT equal the agent count; a non-wrapping `zipWithNext` would yield 2
+        // pairs / 4 calls and turn this red.
+        val s = scenario()
+        val backend = ScriptedLLMBackend(
+            listOf(
+                chooses("cooperate"), chooses("betray"),
+                chooses("cooperate"), chooses("cooperate"),
+                chooses("betray"), chooses("betray"),
+            ),
+        )
+        val next = handler.execute(context(s, backend), initial(s))
+
+        assertEquals(6, backend.callCount)
+        assertEquals(3, next.pairings.size)
+        // The wrap pair (last, first) exists — the specific edge a non-wrapping
+        // implementation drops.
+        assertTrue(next.pairings.any { it.agent1 == "Charlie" && it.agent2 == "Alice" })
+    }
+
+    @Test
+    fun roundRobinPairsAreOrderedByPersonaDeclarationOrder() = runTest {
+        val s = scenario(agents = listOf("Alice", "Bob"))
+        val backend = ScriptedLLMBackend(
+            listOf(chooses("cooperate"), chooses("betray"), chooses("betray"), chooses("cooperate")),
+        )
+        val next = handler.execute(context(s, backend), initial(s))
+
+        val first = next.pairings[0]
+        assertEquals("Alice", first.agent1)
+        assertEquals("cooperate", first.action1)
+        assertEquals("Bob", first.agent2)
+        assertEquals("betray", first.action2)
+    }
+
+    // MARK: - pairings + PairingResult production (§12 axis 7)
+
+    @Test
+    fun greenPathWritesCanonicalPairingsAndEmitsOnePairingResultEach() = runTest {
+        // The producer->consumer path. ChooseHandler is the engine's SOLE writer of
+        // `pairings` and sole emitter of PairingResult; all three downstream
+        // consumers hand-inject `pairings` in their own tests, so dropping either
+        // here stays green everywhere else. Feeds a CASE VARIANT ("Betray") on the
+        // green path so this also pins the canonical-token contract (axis 5) —
+        // storing the raw input would break the exact-string match that
+        // PairwisePayoffLogic (`payoff.when`) and RelationshipUpdateHandler
+        // (`action_deltas[action]`) depend on.
+        val s = scenario(agents = listOf("Alice", "Bob"))
+        val events = mutableListOf<SimulationEvent>()
+        val backend = ScriptedLLMBackend(
+            listOf(chooses("Betray"), chooses("cooperate"), chooses("cooperate"), chooses("betray")),
+        )
+        val next = handler.execute(context(s, backend, events), initial(s))
+
+        assertEquals(2, next.pairings.size)
+        assertEquals(2, pairingResults(events).size)
+
+        // Canonical `betray`, NOT the raw `"Betray"` the model produced.
+        val first = next.pairings[0]
+        assertEquals("Alice", first.agent1)
+        assertEquals("betray", first.action1)
+        assertEquals("betray", pairingResults(events)[0].action1)
+        // Nothing was rejected — a case variant must score, not drop.
+        assertTrue(rejections(events).isEmpty())
+
+        // Every stored action is drawn from the declared option set, so an exact-match
+        // consumer can never miss. (A raw-input port fails this on "Betray".)
+        val declared = setOf("cooperate", "betray")
+        for (pairing in next.pairings) {
+            assertTrue(declared.contains(pairing.action1), "non-canonical action1: ${pairing.action1}")
+            assertTrue(declared.contains(pairing.action2), "non-canonical action2: ${pairing.action2}")
+        }
+    }
+
+    @Test
+    fun pairingsAppendRatherThanReplaceAcrossTwoPhaseRuns() = runTest {
+        // Append, not replace: the run loop resets `pairings` per round and
+        // PairwisePayoffLogic clears after scoring, so accumulation within a round is
+        // the correct scope. A `pairings = listOf(...)` port keeps only the last pair
+        // and turns this red (it would also silently drop pairs WITHIN one phase).
+        val s = scenario(agents = listOf("Alice", "Bob"))
+        val backend = ScriptedLLMBackend(List(8) { chooses("cooperate") })
+        val ctx = context(s, backend)
+
+        val afterFirst = handler.execute(ctx, initial(s))
+        assertEquals(2, afterFirst.pairings.size)
+        val afterSecond = handler.execute(ctx, afterFirst)
+        assertEquals(4, afterSecond.pairings.size)
+    }
+
+    // MARK: - Off-menu drop + ActionRejected (§12 axis 2)
+
+    @Test
+    fun dropsPairingAndEmitsActionRejectedOnGenuineOffMenuAction() = runTest {
+        // ADR-021 § Amendment 2026-07-17 (#1151): an off-menu action no longer falls
+        // back to `options[0]` (fabricating a cooperate) — the whole pairing is
+        // dropped and ActionRejected carries the raw value.
+        // 2 agents -> 2 pairs (Alice,Bob) (Bob,Alice) -> 4 calls.
+        val s = scenario(agents = listOf("Alice", "Bob"))
+        val events = mutableListOf<SimulationEvent>()
+        val backend = ScriptedLLMBackend(
+            listOf(
+                chooses("invalid_action"), // Alice, pair 1 — off-menu
+                chooses("cooperate"), // Bob, pair 1
+                chooses("cooperate"), // Bob, pair 2
+                chooses("betray"), // Alice, pair 2
+            ),
+        )
+        val next = handler.execute(context(s, backend, events), initial(s))
+
+        // Pair 1 dropped; only pair 2 survives — no fabricated cooperate for Alice.
+        assertEquals(1, next.pairings.size)
+        assertEquals("Bob", next.pairings[0].agent1)
+        assertEquals("betray", next.pairings[0].action2)
+
+        // Exactly one rejection, for Alice, carrying the verbatim raw value.
+        assertEquals(1, rejections(events).size)
+        assertEquals("Alice", rejections(events).single().agent)
+        assertEquals("invalid_action", rejections(events).single().raw)
+        assertEquals(PhaseType.CHOOSE, rejections(events).single().phaseType)
+
+        // The dropped pairing emits no PairingResult — only pair 2's.
+        assertEquals(1, pairingResults(events).size)
+        // An off-menu answer is NOT a skip: the call succeeded and AgentOutput fired.
+        assertTrue(skips(events).isEmpty())
+        assertEquals(4, events.filterIsInstance<SimulationEvent.AgentOutput>().size)
+    }
+
+    @Test
+    fun emitsOneActionRejectedPerOffMenuMemberWhenBothAreOffMenu() = runTest {
+        // Both members off-menu -> two rejections from ONE dropped pairing. A port
+        // that `return`s after the first rejection (or emits a single pair-level
+        // event) turns this red.
+        val s = scenario(agents = listOf("Alice", "Bob"))
+        val events = mutableListOf<SimulationEvent>()
+        val backend = ScriptedLLMBackend(
+            listOf(chooses("nope"), chooses("nah"), chooses("cooperate"), chooses("betray")),
+        )
+        val next = handler.execute(context(s, backend, events), initial(s))
+
+        assertEquals(listOf("Alice", "Bob"), rejections(events).map { it.agent })
+        assertEquals(listOf("nope", "nah"), rejections(events).map { it.raw })
+        assertEquals(1, next.pairings.size) // pair 2 still scores
+    }
+
+    // MARK: - Canonicalization (§12 axis 5)
+
+    @Test
+    fun caseVariantActionScoresAsCanonicalOptionRatherThanDropping() = runTest {
+        // Regression for the normalization half of validateAction: `"Betray"` must
+        // fold onto `betray` and SCORE. Removing the trim+lowercase fold drops the
+        // pairing instead and turns this red.
+        val s = scenario(agents = listOf("Alice", "Bob"))
+        val events = mutableListOf<SimulationEvent>()
+        val backend = ScriptedLLMBackend(
+            listOf(chooses("Betray"), chooses("cooperate"), chooses("cooperate"), chooses("betray")),
+        )
+        val next = handler.execute(context(s, backend, events), initial(s))
+
+        assertEquals(2, next.pairings.size)
+        assertEquals("betray", next.pairings[0].action1)
+        assertTrue(rejections(events).isEmpty())
+    }
+
+    @Test
+    fun whitespacePaddedActionAlsoFoldsOntoTheCanonicalOption() = runTest {
+        // The trim half of the fold, disjoint from the case half above.
+        val s = scenario(agents = listOf("Alice", "Bob"))
+        val events = mutableListOf<SimulationEvent>()
+        val backend = ScriptedLLMBackend(
+            listOf(chooses("  betray  "), chooses("cooperate"), chooses("cooperate"), chooses("betray")),
+        )
+        val next = handler.execute(context(s, backend, events), initial(s))
+
+        assertEquals("betray", next.pairings[0].action1)
+        assertTrue(rejections(events).isEmpty())
+    }
+
+    @Test
+    fun anOptionlessRoundRobinPassesTheRawActionThroughInsteadOfDroppingEveryPairing() = runTest {
+        // `options.isEmpty() -> return action` is preserved from Swift: an
+        // options-less round-robin has nothing to canonicalize against, and returning
+        // null there would drop EVERY pairing. Reverting the guard turns this red
+        // (0 pairings, 2 rejections). Note the deliberate asymmetry with
+        // PromptBuilder.chooseOptionsRule, which gates on `options != null`.
+        val s = scenario(agents = listOf("Alice", "Bob"), options = null)
+        val events = mutableListOf<SimulationEvent>()
+        val backend = ScriptedLLMBackend(
+            listOf(chooses("Anything"), chooses("Whatever"), chooses("x"), chooses("y")),
+        )
+        val next = handler.execute(context(s, backend, events), initial(s))
+
+        assertEquals(2, next.pairings.size)
+        // Raw, un-canonicalized (there is no option set to canonicalize against).
+        assertEquals("Anything", next.pairings[0].action1)
+        assertTrue(rejections(events).isEmpty())
+    }
+
+    // MARK: - Turn degradation, round-robin (§12 axes 3 + 4)
+
+    @Test
+    fun roundRobinSkipDropsWholePairingAndSparesTheOtherPairingsOutput() = runTest {
+        // 3 agents -> pairs (Alice,Bob) (Bob,Charlie) (Charlie,Alice); call order
+        // Alice,Bob,Bob,Charlie,Charlie,Alice. Failing call #1 (Alice as member 1 of
+        // pair 0) drops that pairing. Alice's LATER call (#6, in pair 2) succeeds, so
+        // she keeps a valid lastOutputs — that is the `succeeded` set at work.
+        val s = scenario()
+        val events = mutableListOf<SimulationEvent>()
+        val backend = ScriptedLLMBackend(
+            listOf(
+                failing(), // #1 Alice   (pair0 member1)
+                chooses("cooperate"), // #2 Bob     (pair0 member2)
+                chooses("cooperate"), // #3 Bob     (pair1 member1)
+                chooses("betray"), // #4 Charlie (pair1 member2)
+                chooses("cooperate"), // #5 Charlie (pair2 member1)
+                chooses("betray"), // #6 Alice   (pair2 member2)
+            ),
+        )
+        val next = handler.execute(context(s, backend, events), initial(s))
+
+        // Exactly one skipped turn, typed to CHOOSE.
+        assertEquals(1, skips(events).size)
+        assertEquals("Alice", skips(events).single().agent)
+        assertEquals(PhaseType.CHOOSE, skips(events).single().phaseType)
+
+        // The (Alice,Bob) pairing is dropped; the other two survive.
+        assertEquals(2, next.pairings.size)
+        assertFalse(next.pairings.any { it.agent1 == "Alice" && it.agent2 == "Bob" })
+        assertEquals(2, pairingResults(events).size)
+
+        // The successful partner (Bob, #2) kept his output...
+        assertEquals("cooperate", next.lastOutputs["Bob"]?.action)
+        // ...and Alice's later success (#6) is NOT erased by her earlier skip.
+        assertEquals("betray", next.lastOutputs["Alice"]?.action)
+    }
+
+    @Test
+    fun aSkipAfterASuccessDoesNotEraseTheEarlierValidOutput() = runTest {
+        // The `succeeded` guard's OTHER arm — success-THEN-skip — which Swift's own
+        // test file documents as unreachable under its position-based mock. The
+        // scripted backend here can express it directly: 3 agents, call #6 (Alice's
+        // SECOND appearance) fails after her #1 succeeded. An unconditional clear on
+        // the skip path wipes `lastOutputs["Alice"]` and turns this red; the guard
+        // keeps her round-1 choice, which EventReactivePayoffLogic legitimately reads.
+        val s = scenario()
+        val events = mutableListOf<SimulationEvent>()
+        val backend = ScriptedLLMBackend(
+            listOf(
+                chooses("cooperate"), // #1 Alice   (pair0 member1) — succeeds
+                chooses("betray"), // #2 Bob
+                chooses("cooperate"), // #3 Bob
+                chooses("betray"), // #4 Charlie
+                chooses("cooperate"), // #5 Charlie
+                failing(), // #6 Alice   (pair2 member2) — skips
+            ),
+        )
+        val next = handler.execute(context(s, backend, events), initial(s))
+
+        assertEquals(1, skips(events).size)
+        assertEquals("Alice", skips(events).single().agent)
+        // Her earlier successful choice survives the later skip.
+        assertEquals("cooperate", next.lastOutputs["Alice"]?.action)
+        // Pair 2 (Charlie,Alice) is dropped; pairs 0 and 1 stand.
+        assertEquals(2, next.pairings.size)
+        assertFalse(next.pairings.any { it.agent1 == "Charlie" && it.agent2 == "Alice" })
+    }
+
+    @Test
+    fun aSkipOnAnAgentsOnlySuccessfulSlotClearsItsStaleLastOutputs() = runTest {
+        // The negative control for the guard above: when the agent NEVER succeeds in
+        // this phase, the stale prior-round output MUST be cleared (ADR-021 D2), so
+        // a decision that never happened cannot leak downstream. A port that always
+        // preserves `lastOutputs` on skip turns this red.
+        // 2 agents -> pairs (Alice,Bob) (Bob,Alice); Alice is calls #1 and #4.
+        val s = scenario(agents = listOf("Alice", "Bob"))
+        val events = mutableListOf<SimulationEvent>()
+        val backend = ScriptedLLMBackend(
+            listOf(failing(), chooses("cooperate"), chooses("cooperate"), failing()),
+        )
+        val before = initial(s).copy(
+            lastOutputs = mapOf("Alice" to TurnOutput(fields = mapOf("action" to "stale"))),
+        )
+        val next = handler.execute(context(s, backend, events), before)
+
+        assertEquals(2, skips(events).size)
+        assertNull(next.lastOutputs["Alice"])
+        assertEquals("cooperate", next.lastOutputs["Bob"]?.action)
+        assertTrue(next.pairings.isEmpty()) // both pairings dropped
+    }
+
+    // MARK: - opponent_name reaches the prompt (§12 axis 8)
+
+    @Test
+    fun opponentNameIsExpandedIntoEachRoundRobinTurnsPrompt() = runTest {
+        // `opponent_name` is the choose-only prompt variable — what makes a
+        // round-robin turn "with opponent context". Dropping it fails SILENTLY:
+        // expandTemplate leaves an unknown placeholder unchanged, so the literal
+        // would reach the model with no exception and no diagnostic. Both halves are
+        // asserted: the opponent's name is present AND the literal is gone.
+        val s = scenario(agents = listOf("Alice", "Bob"), prompt = "You face {opponent_name}.")
+        val backend = ScriptedLLMBackend(
+            listOf(chooses("cooperate"), chooses("betray"), chooses("betray"), chooses("cooperate")),
+        )
+        handler.execute(context(s, backend), initial(s))
+
+        // Call #1 is Alice facing Bob; #2 is Bob facing Alice.
+        assertEquals("You face Bob.", backend.requests[0].user)
+        assertEquals("You face Alice.", backend.requests[1].user)
+        assertFalse(backend.requests[0].user.contains("{opponent_name}"))
+    }
+
+    @Test
+    fun individualModeDoesNotResolveOpponentName() = runTest {
+        // The disjoint control: individual mode has no opponent, so the variable is
+        // deliberately unset and the placeholder survives verbatim. This pins the
+        // asymmetry rather than letting a "helpful" port set it in both modes.
+        val s = scenario(
+            agents = listOf("Alice", "Bob"),
+            prompt = "You face {opponent_name}.",
+            pairing = null,
+        )
+        val backend = ScriptedLLMBackend(listOf(chooses("cooperate"), chooses("betray")))
+        handler.execute(context(s, backend), initial(s))
+
+        assertEquals("You face {opponent_name}.", backend.requests[0].user)
+    }
+
+    // MARK: - Round-robin agent-count boundaries (§12 axis 9)
+
+    @Test
+    fun twoActiveAgentsProduceTwoMirroredPairings() = runTest {
+        // (i+1)%2 yields (A,B) AND (B,A) — two MIRRORED pairings, both scored by
+        // PairwisePayoffLogic. This is Swift-faithful and load-bearing: a
+        // "deduplicate the mirror" fix would halve every 2-agent prisoner's-dilemma
+        // round's score. Pinned so it cannot be silently "fixed".
+        //
+        // The same arithmetic self-pairs at ONE active agent — (A,A), double-scoring
+        // A — which is likewise Swift-faithful. It is reachable rather than
+        // theoretical: the run loop's "fewer than 2 active" break fires at round
+        // START, so an `eliminate` phase earlier in the same round can drop the
+        // roster to 1 before this phase runs. Not asserted here (constructing it
+        // needs a multi-phase run), but do not "fix" that arm either.
+        val s = scenario(agents = listOf("Alice", "Bob"))
+        val events = mutableListOf<SimulationEvent>()
+        val backend = ScriptedLLMBackend(
+            listOf(chooses("cooperate"), chooses("betray"), chooses("betray"), chooses("cooperate")),
+        )
+        val next = handler.execute(context(s, backend, events), initial(s))
+
+        assertEquals(2, next.pairings.size)
+        assertEquals(listOf("Alice" to "Bob", "Bob" to "Alice"), next.pairings.map { it.agent1 to it.agent2 })
+        assertEquals(4, backend.callCount)
+        assertEquals(2, pairingResults(events).size)
+    }
+
+    @Test
+    fun eliminatedAgentsAreExcludedFromPairing() = runTest {
+        // Charlie eliminated -> the active roster is [Alice, Bob] -> 2 pairs, 4 calls.
+        val s = scenario()
+        val backend = ScriptedLLMBackend(
+            listOf(chooses("cooperate"), chooses("betray"), chooses("betray"), chooses("cooperate")),
+        )
+        val state = initial(s).copy(eliminated = mapOf("Charlie" to true))
+        val next = handler.execute(context(s, backend), state)
+
+        assertEquals(4, backend.callCount)
+        assertFalse(next.pairings.any { it.agent1 == "Charlie" || it.agent2 == "Charlie" })
+    }
+
+    // MARK: - Individual mode (§12 axis 6)
+
+    @Test
+    fun individualChoiceCallsEveryActiveAgentAndCreatesNoPairings() = runTest {
+        val s = scenario(agents = listOf("Alice", "Bob"), pairing = null)
+        val events = mutableListOf<SimulationEvent>()
+        val backend = ScriptedLLMBackend(listOf(chooses("cooperate"), chooses("betray")))
+        val next = handler.execute(context(s, backend, events), initial(s))
+
+        assertEquals(2, backend.callCount)
+        assertTrue(next.pairings.isEmpty())
+        assertTrue(pairingResults(events).isEmpty())
+    }
+
+    @Test
+    fun individualModeWritesTheRawActionWithoutCanonicalizing() = runTest {
+        // Deliberate divergence from round-robin: individual mode has no pairing to
+        // drop, and its consumer (EventReactivePayoffLogic) normalizes on read — so
+        // the RAW value is stored, inventing nothing. A port that canonicalizes here
+        // "for consistency" turns this red, and an off-menu answer must likewise pass
+        // through rather than being rejected.
+        val s = scenario(agents = listOf("Alice", "Bob"), pairing = null)
+        val events = mutableListOf<SimulationEvent>()
+        val backend = ScriptedLLMBackend(listOf(chooses("Betray"), chooses("something_else")))
+        val next = handler.execute(context(s, backend, events), initial(s))
+
+        assertEquals("Betray", next.lastOutputs["Alice"]?.action)
+        assertEquals("something_else", next.lastOutputs["Bob"]?.action)
+        // No canonicalization means no rejection path in this mode.
+        assertTrue(rejections(events).isEmpty())
+    }
+
+    @Test
+    fun individualSkipWritesNothingAndClearsStaleLastOutputs() = runTest {
+        // ADR-021 D2 for individual mode: Alice's call fails -> she writes nothing and
+        // her stale lastOutputs is cleared; Bob and Charlie choose normally. The
+        // mirror of the round-robin `succeeded` discipline — here the clear is
+        // unconditional, because one call per agent means no sibling success exists.
+        val s = scenario(pairing = null)
+        val events = mutableListOf<SimulationEvent>()
+        val backend = ScriptedLLMBackend(listOf(failing(), chooses("cooperate"), chooses("betray")))
+        val before = initial(s).copy(
+            lastOutputs = mapOf("Alice" to TurnOutput(fields = mapOf("action" to "stale"))),
+        )
+        val next = handler.execute(context(s, backend, events), before)
+
+        assertEquals(
+            listOf("Bob", "Charlie"),
+            events.filterIsInstance<SimulationEvent.AgentOutput>().map { it.agent },
+        )
+        assertEquals(listOf("Alice"), skips(events).map { it.agent })
+        assertNull(next.lastOutputs["Alice"])
+        assertEquals("cooperate", next.lastOutputs["Bob"]?.action)
+    }
+
+    @Test
+    fun individualModeSkipsEliminatedAgents() = runTest {
+        val s = scenario(pairing = null)
+        val backend = ScriptedLLMBackend(listOf(chooses("cooperate"), chooses("betray")))
+        val state = initial(s).copy(eliminated = mapOf("Bob" to true))
+        val next = handler.execute(context(s, backend), state)
+
+        assertEquals(2, backend.callCount)
+        assertNull(next.lastOutputs["Bob"])
+    }
+
+    // MARK: - Empty action is a SKIP, not an off-menu rejection
+
+    @Test
+    fun emptyActionIsAbsorbedAsSkipNotAsAnOffMenuRejection() = runTest {
+        // The parser rejects a present-but-empty expected key ({"action":""} —
+        // `hasAllExpectedKeys` requires non-empty content), so three empties exhaust
+        // the retry budget -> RetriesExhausted -> the turn gate absorbs it as a SKIP
+        // (ADR-021 D2). It is therefore gate 1 (pairing dropped, TurnSkipped, no
+        // AgentOutput), NOT gate 2 — the two drop paths must not be conflated, since
+        // only gate 2 emits ActionRejected. Asserted through the skip MECHANISM, not
+        // through validateAction's return.
+        // 2 agents; Alice's first call burns 3 scripts, then the run continues.
+        val s = scenario(agents = listOf("Alice", "Bob"))
+        val events = mutableListOf<SimulationEvent>()
+        val backend = ScriptedLLMBackend(
+            listOf(
+                chooses(""), chooses(""), chooses(""), // #1 Alice — 3 attempts, all rejected
+                chooses("cooperate"), // Bob, pair 0 member 2
+                chooses("betray"), // Bob, pair 1 member 1
+                chooses("cooperate"), // Alice, pair 1 member 2
+            ),
+        )
+        val next = handler.execute(context(s, backend, events), initial(s))
+
+        // Skip mechanism fired, and it is a skip — not a rejection.
+        assertEquals(1, skips(events).size)
+        assertEquals("Alice", skips(events).single().agent)
+        assertTrue(rejections(events).isEmpty())
+        // Downstream drop: pair 0 is gone, pair 1 stands.
+        assertEquals(1, next.pairings.size)
+        assertEquals("Bob", next.pairings[0].agent1)
+        // No AgentOutput for the skipped turn (3 calls produced nothing).
+        assertEquals(3, events.filterIsInstance<SimulationEvent.AgentOutput>().size)
+    }
+
+    // MARK: - captureMood round-trip (single-copy fold, #913)
+
+    @Test
+    fun capturedMoodSurfacesInTheNextRoundsPrompt() = runTest {
+        // Pins the success-path `state.copy` fold: captureMood must land in the
+        // RETURNED state (folded alongside lastOutputs), else round N's mood never
+        // reaches round N+1. A second copy off the original drops one of the two.
+        val moodSchema = mapOf("action" to "string", "mood" to "string")
+        val s = scenario(agents = listOf("Alice", "Bob"), outputSchema = moodSchema)
+        val backend = ScriptedLLMBackend(
+            List(8) { idx ->
+                ScriptedLLMBackend.Script.completing(
+                    """{"action": "cooperate", "mood": "mood$idx"}""",
+                )
+            },
+        )
+        val ctx = context(s, backend)
+
+        val afterFirst = handler.execute(ctx, initial(s))
+        assertEquals("mood3", afterFirst.variables["mood_Alice"]) // last write wins (call #4)
+
+        handler.execute(ctx, afterFirst)
+        assertTrue(backend.requests[4].system.contains("mood3"))
+        assertTrue(backend.requests[4].system.contains("Your Current Mood"))
+    }
+
+    @Test
+    fun individualModeAlsoCapturesMood() = runTest {
+        // Mood is symmetric across both modes (unlike injectWhispers). A port that
+        // wires captureMood only into the round-robin path turns this red.
+        val moodSchema = mapOf("action" to "string", "mood" to "string")
+        val s = scenario(agents = listOf("Alice"), outputSchema = moodSchema, pairing = null)
+        val backend = ScriptedLLMBackend(
+            listOf(ScriptedLLMBackend.Script.completing("""{"action": "cooperate", "mood": "焦り"}""")),
+        )
+        val next = handler.execute(context(s, backend), initial(s))
+
+        assertEquals("焦り", next.variables["mood_Alice"])
+    }
+
+    // MARK: - simulationLanguage override (ADR-010 Step E)
+
+    @Test
+    fun chooseHonorsSimulationLanguageOverrideJaToEn() = runTest {
+        // ja authoring, en simulation override, prompt:null forces the fallback. The
+        // captured prompt must contain the English fallback, not the Japanese one.
+        val s = scenario(
+            agents = listOf("Alice", "Bob"),
+            language = "ja",
+            simulationLanguage = "en",
+            prompt = null,
+            pairing = null,
+        )
+        val backend = ScriptedLLMBackend(listOf(chooses("cooperate"), chooses("betray")))
+        handler.execute(context(s, backend), initial(s))
+
+        val prompt = backend.requests[0].user
+        assertTrue(prompt.contains("Make a choice"))
+        assertFalse(prompt.contains("選択してください"))
+    }
+
+    @Test
+    fun chooseHonorsSimulationLanguageOverrideEnToJa() = runTest {
+        // Reverse: en authoring, ja simulation override.
+        val s = scenario(
+            agents = listOf("Alice", "Bob"),
+            language = "en",
+            simulationLanguage = "ja",
+            prompt = null,
+            pairing = null,
+        )
+        val backend = ScriptedLLMBackend(listOf(chooses("cooperate"), chooses("betray")))
+        handler.execute(context(s, backend), initial(s))
+
+        val prompt = backend.requests[0].user
+        assertTrue(prompt.contains("選択してください"))
+        assertFalse(prompt.contains("Make a choice"))
+    }
+
+    // MARK: - Immutable-state contract
+
+    @Test
+    fun theInputStateIsNeverMutated() = runTest {
+        val s = scenario(agents = listOf("Alice", "Bob"))
+        val backend = ScriptedLLMBackend(
+            listOf(chooses("cooperate"), chooses("betray"), chooses("betray"), chooses("cooperate")),
+        )
+        val before = initial(s)
+        val next = handler.execute(context(s, backend), before)
+
+        assertTrue(before.pairings.isEmpty())
+        assertTrue(before.lastOutputs.isEmpty())
+        assertEquals(2, next.pairings.size)
+    }
+
+    @Test
+    fun aPreexistingPairingFromEarlierInTheRoundIsPreserved() = runTest {
+        // Guards the append against a `pairings = listOf(...)` port from a different
+        // angle than the two-run test: an entry already in state must survive.
+        val s = scenario(agents = listOf("Alice", "Bob"))
+        val backend = ScriptedLLMBackend(
+            listOf(chooses("cooperate"), chooses("betray"), chooses("betray"), chooses("cooperate")),
+        )
+        val seeded = initial(s).copy(
+            pairings = listOf(Pairing(agent1 = "X", agent2 = "Y", action1 = "a", action2 = "b")),
+        )
+        val next = handler.execute(context(s, backend), seeded)
+
+        assertEquals(3, next.pairings.size)
+        assertEquals("X", next.pairings[0].agent1)
+    }
+}

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/PhaseDispatcherTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/PhaseDispatcherTests.kt
@@ -70,6 +70,11 @@ class PhaseDispatcherTests {
     }
 
     @Test
+    fun resolvesTheChooseHandler() {
+        assertIs<ChooseHandler>(dispatcher.handler(PhaseType.CHOOSE))
+    }
+
+    @Test
     fun returnsAStableHandlerInstance() {
         // Handlers are stateless values; the dispatcher builds its map once.
         assertTrue(dispatcher.handler(PhaseType.SPEAK_ALL) === dispatcher.handler(PhaseType.SPEAK_ALL))
@@ -77,20 +82,21 @@ class PhaseDispatcherTests {
 
     @Test
     fun throwsForAPhaseTypeThisSliceHasNotPorted() {
-        val error = assertFailsWith<SimulationException> { dispatcher.handler(PhaseType.CHOOSE) }
+        val error = assertFailsWith<SimulationException> { dispatcher.handler(PhaseType.CONDITIONAL) }
         assertIs<SimulationError.ScenarioValidationFailed>(error.error)
     }
 
     @Test
     fun theErrorNamesThePhaseUsingItsWireNameNotItsKotlinCaseName() {
-        // `choose`, not `CHOOSE` — Swift interpolates `phaseType.rawValue`, and a
-        // reader comparing the two engines' errors should see the same token. Uses
-        // a still-unported type (CHOOSE is a later Wave-B handler) so this still
-        // exercises the throw path now that WHISPER resolves.
-        val error = assertFailsWith<SimulationException> { dispatcher.handler(PhaseType.CHOOSE) }
+        // `conditional`, not `CONDITIONAL` — Swift interpolates `phaseType.rawValue`,
+        // and a reader comparing the two engines' errors should see the same token.
+        // The exemplar is CONDITIONAL rather than the next handler in the port queue:
+        // it is LAST in the remaining Wave-B order (SpeakEach -> Narrate ->
+        // Conditional), so this repoint survives the longest.
+        val error = assertFailsWith<SimulationException> { dispatcher.handler(PhaseType.CONDITIONAL) }
         val message = assertIs<SimulationError.ScenarioValidationFailed>(error.error).message
-        assertTrue(message.contains("choose"), "expected the wire name, got: $message")
-        assertTrue(!message.contains("CHOOSE"), "the Kotlin case name must not leak: $message")
+        assertTrue(message.contains("conditional"), "expected the wire name, got: $message")
+        assertTrue(!message.contains("CONDITIONAL"), "the Kotlin case name must not leak: $message")
     }
 
     @Test
@@ -102,9 +108,10 @@ class PhaseDispatcherTests {
                 it != PhaseType.SUMMARIZE && it != PhaseType.ASSIGN &&
                 it != PhaseType.EVENT_INJECT && it != PhaseType.SCORE_CALC &&
                 it != PhaseType.RELATIONSHIP_UPDATE && it != PhaseType.REFLECT &&
-                it != PhaseType.VOTE && it != PhaseType.WHISPER
+                it != PhaseType.VOTE && it != PhaseType.WHISPER &&
+                it != PhaseType.CHOOSE
         }
-        assertEquals(4, unported.size, "Kotlin PhaseType has 14 cases today; see the #501 drift ledger")
+        assertEquals(3, unported.size, "Kotlin PhaseType has 14 cases today; see the #501 drift ledger")
         for (type in unported) {
             val error = assertFailsWith<SimulationException>("$type must fail cleanly") {
                 dispatcher.handler(type)

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/PromptBuilderInjectionTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/PromptBuilderInjectionTests.kt
@@ -20,12 +20,12 @@ import kotlin.test.assertTrue
  *
  * Unlike [PromptBuilderTests] (which disclaims parity for the still-incomplete
  * base slice), these DO assert parity: their landed units are the full Swift
- * behaviour. Deliberately **out of scope** here — deferred to their own Wave-B
- * handler PRs, so their guidance is not yet ported: `addressRule` and the
- * choose-options rule. The `mood`, `reflect`-brevity, vote-candidate, and
- * `whisper` answer-rules ARE asserted, because `moodRule`, `reflectBrevityRule`,
- * `voteCandidateRule`, and `whisperRule` land with this infrastructure / the
- * ReflectHandler / VoteHandler / WhisperHandler PRs.
+ * behaviour. Deliberately **out of scope** here — deferred to its own Wave-B
+ * handler PR, so its guidance is not yet ported: `addressRule`. The `mood`,
+ * `reflect`-brevity, vote-candidate, `whisper`, and choose-options answer-rules
+ * ARE asserted, because `moodRule`, `reflectBrevityRule`, `voteCandidateRule`,
+ * `whisperRule`, and `chooseOptionsRule` land with this infrastructure / the
+ * ReflectHandler / VoteHandler / WhisperHandler / ChooseHandler PRs.
  *
  * Split into its own file per the commonTest concern-per-file convention
  * (cf. [PromptBuilderParityTests]); these are pure, stateless `PromptBuilder`
@@ -215,6 +215,13 @@ class PromptBuilderInjectionTests {
         outputSchema = mapOf("statement" to "string"),
     )
 
+    private val choosePhaseWithOptions = Phase(
+        type = PhaseType.CHOOSE,
+        prompt = "Choose!",
+        outputSchema = mapOf("action" to "string"),
+        options = listOf("cooperate", "betray"),
+    )
+
     @Test
     fun systemPromptContainsPrivateWhispersSectionWhenSet() {
         val s = scenario()
@@ -264,6 +271,74 @@ class PromptBuilderInjectionTests {
             builder.buildSystemPrompt(s, alice, speakAll, stateOf(s))
                 .contains("これは密談相手ひとりだけへの秘密の耳打ち"),
         )
+    }
+
+    // MARK: - Choose options answer-rule (choose phases declaring options)
+
+    @Test
+    fun chooseOptionsRuleAppendedForChoosePhaseJa() {
+        val s = scenario()
+        val prompt = builder.buildSystemPrompt(s, alice, choosePhaseWithOptions, stateOf(s))
+        assertTrue(prompt.contains("actionフィールドは必ず次のいずれかを書くこと: cooperate, betray"))
+    }
+
+    @Test
+    fun chooseOptionsRuleAppendedForChoosePhaseEn() {
+        val s = scenario(language = "en")
+        val prompt = builder.buildSystemPrompt(s, alice, choosePhaseWithOptions, stateOf(s))
+        assertTrue(prompt.contains("The action field must be one of: cooperate, betray"))
+    }
+
+    @Test
+    fun chooseOptionsRuleOmittedForNonChoosePhase() {
+        // A non-choose phase never gets the option-list rule, even though it shares
+        // the same base answer-rule block.
+        val s = scenario()
+        assertFalse(
+            builder.buildSystemPrompt(s, alice, speakAll, stateOf(s))
+                .contains("actionフィールドは必ず次のいずれかを書くこと"),
+        )
+    }
+
+    @Test
+    fun chooseOptionsRuleOmittedWhenTheChoosePhaseDeclaresNoOptions() {
+        // The gate is `options != null`, not the phase type alone: an options-less
+        // choose has nothing to enumerate, and `ChooseHandler.validateAction` treats
+        // it as unconstrained. Reverting the gate to a type-only check renders a
+        // dangling "must be one of:" with no list — this test goes red then.
+        val s = scenario()
+        val optionless = Phase(
+            type = PhaseType.CHOOSE,
+            prompt = "Choose!",
+            outputSchema = mapOf("action" to "string"),
+        )
+        assertFalse(
+            builder.buildSystemPrompt(s, alice, optionless, stateOf(s))
+                .contains("actionフィールドは必ず次のいずれかを書くこと"),
+        )
+    }
+
+    @Test
+    fun chooseOptionsRulePrecedesTheVoteRuleSlotMatchingSwiftRuleOrder() {
+        // Swift's rule order is speakEach -> reflect -> whisper -> CHOOSE -> vote ->
+        // mood (PromptBuilder.swift:212 sits between :208 and :220). The other
+        // rule-membership tests assert via `contains`, which is order-blind, so a
+        // silent ordering divergence would survive them all. Pin it with a phase
+        // that triggers BOTH the choose rule and the mood rule (schema-gated, and
+        // last in Swift's order) and compare indices.
+        val s = scenario()
+        val choosePlusMood = Phase(
+            type = PhaseType.CHOOSE,
+            prompt = "Choose!",
+            outputSchema = mapOf("action" to "string", "mood" to "string"),
+            options = listOf("cooperate", "betray"),
+        )
+        val prompt = builder.buildSystemPrompt(s, alice, choosePlusMood, stateOf(s))
+        val chooseAt = prompt.indexOf("actionフィールドは必ず次のいずれかを書くこと")
+        val moodAt = prompt.indexOf("moodには今の気分を短い言葉で書くこと")
+        assertTrue(chooseAt >= 0, "choose rule missing")
+        assertTrue(moodAt >= 0, "mood rule missing")
+        assertTrue(chooseAt < moodAt, "choose rule must precede the mood rule")
     }
 
     // MARK: - System-prompt private-relationships section (#910)

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/PromptBuilderInjectionTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/PromptBuilderInjectionTests.kt
@@ -16,7 +16,10 @@ import kotlin.test.assertTrue
  * Parity tests for the Wave-B reserved-namespace injection family
  * (`inject*` / [PromptBuilder.captureMood] / `appendPrivateSections` / `moodRule`),
  * ported from the Swift executable spec (ADR-023 §6): `PromptBuilderTests+Mood`,
- * `+Whispers`, `+Relationships`, and the notes cases in `+Hardening`.
+ * `+Whispers`, `+Relationships`, and the notes cases in `+Hardening`. The
+ * choose-options block has **no** Swift sibling — that rule is an inline block in
+ * `PromptBuilder.swift` with no dedicated test — so those cases are authored here
+ * against the Swift source directly, not ported from a Swift test.
  *
  * Unlike [PromptBuilderTests] (which disclaims parity for the still-incomplete
  * base slice), these DO assert parity: their landed units are the full Swift
@@ -319,13 +322,37 @@ class PromptBuilderInjectionTests {
     }
 
     @Test
-    fun chooseOptionsRulePrecedesTheVoteRuleSlotMatchingSwiftRuleOrder() {
+    fun anEmptyOptionsListStillRendersTheRuleWithNoOptions() {
+        // Pins the documented `options != null` (rule) vs `options.isEmpty()`
+        // (ChooseHandler.validateAction) asymmetry: an `options: []` phase passes the
+        // rule's gate and renders a dangling list, while the handler treats the same
+        // phase as unconstrained. It is Swift-faithful — `PromptBuilder.swift` binds
+        // with `let options = phase.options`, the same null-only check — and reachable
+        // (no loader/validator rejection; ADR-024 R7 is warning-only). Pinned rather
+        // than fixed so the two engines stay byte-comparable; a fix belongs on the
+        // Swift side first, in both engines at once.
+        val s = scenario()
+        val emptyOptions = Phase(
+            type = PhaseType.CHOOSE,
+            prompt = "Choose!",
+            outputSchema = mapOf("action" to "string"),
+            options = emptyList(),
+        )
+        val prompt = builder.buildSystemPrompt(s, alice, emptyOptions, stateOf(s))
+        assertTrue(prompt.contains("actionフィールドは必ず次のいずれかを書くこと: \n"))
+    }
+
+    @Test
+    fun chooseOptionsRulePrecedesTheMoodRuleMatchingSwiftRuleOrder() {
         // Swift's rule order is speakEach -> reflect -> whisper -> CHOOSE -> vote ->
-        // mood (PromptBuilder.swift:212 sits between :208 and :220). The other
-        // rule-membership tests assert via `contains`, which is order-blind, so a
-        // silent ordering divergence would survive them all. Pin it with a phase
-        // that triggers BOTH the choose rule and the mood rule (schema-gated, and
-        // last in Swift's order) and compare indices.
+        // mood. The other rule-membership tests assert via `contains`, which is
+        // order-blind, so a silent ordering divergence would survive them all.
+        //
+        // The choose/VOTE boundary is structurally untestable — a phase cannot be
+        // both CHOOSE and VOTE — so this pins the nearest reachable boundary instead:
+        // the mood rule is schema-gated (any LLM phase can declare `mood`) and sits
+        // LAST in Swift's order, so choose-before-mood transitively pins choose out
+        // of the two trailing slots.
         val s = scenario()
         val choosePlusMood = Phase(
             type = PhaseType.CHOOSE,

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/SimulationEngineTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/SimulationEngineTests.kt
@@ -248,16 +248,17 @@ class SimulationEngineTests {
 
     @Test
     fun anUnportedPhaseTypeSurfacesAsAValidationError() = runBlockingTest {
-        // A Stage-3 gap must read as a gap at runtime, not as a crash. Uses a
-        // still-unported type (CHOOSE is a later Wave-B handler) — WHISPER now resolves.
-        val s = scenario().copy(phases = listOf(Phase(type = PhaseType.CHOOSE, prompt = "Choose.")))
+        // A Stage-3 gap must read as a gap at runtime, not as a crash. Uses
+        // CONDITIONAL — last in the remaining Wave-B port order, so this exemplar
+        // outlives the ones ported next (CHOOSE now resolves).
+        val s = scenario().copy(phases = listOf(Phase(type = PhaseType.CONDITIONAL, condition = "1 == 1")))
         val c = Collector()
         SimulationEngine().run(s, ScriptedLLMBackend(emptyList())) { c.record(it) }
         awaitTerminal(c)
 
         val error = assertIs<SimulationEvent.ErrorEvent>(c.snapshot().last())
         val failed = assertIs<SimulationError.ScenarioValidationFailed>(error.error)
-        assertTrue(failed.message.contains("choose"))
+        assertTrue(failed.message.contains("conditional"))
     }
 
     // MARK: - §5.1 pause / resume


### PR DESCRIPTION
## Summary

Ports `ChooseHandler` to `shared/engine` commonMain — ADR-023 Stage 3 Wave B handler **B4**, after Reflect (#1245), Vote (#1249), Whisper (#1252). Board **10/14 → 11/14**. Remaining: SpeakEach → Narrate → Conditional.

- **Both modes.** `round_robin` (N adjacent pairs `(active[i], active[(i+1)%count])`, 2 LLM calls per pair with opponent context) and `individual` (each agent chooses independently).
- **`PromptBuilder.chooseOptionsRule`**, wired between the whisper and vote rules to match Swift's order. Closes one of the two remaining rows in that class's "knowingly absent" table (only `addressRule` / speak_each remains).
- **`pairings` + `PairingResult` production.** This handler is the engine's only **appender** to `SimulationState.pairings` (the run loop's per-round reset and `PairwisePayoffLogic`'s post-scoring clear are the other two writers, both emptying) and the sole emitter of `SimulationEvent.PairingResult`.
- Dispatcher registration, unported-example repoint, board.

## Why the entangled bits are the way they are

**State threading.** Kotlin's `SimulationState` is immutable and Kotlin has no `inout`, so Swift's `callAgent` — which mutates `state` *and* a `succeeded` set while returning the output — folds into `ChooseTurn(state, output, succeeded)`, threaded off a single `current`. Both are threaded **before** the drop `continue`s, because the skip path's stale-`lastOutputs` clear is load-bearing even when there is no output.

**Canonicalization is asymmetric on purpose.** `validateAction` returns the **canonical** option string in round-robin — load-bearing as a token, since `PairwisePayoffLogic` matches `payoff.when` by exact list equality and `RelationshipUpdateHandler` looks up `action_deltas[action]`. Individual mode deliberately writes the **raw** action (Swift-faithful; `EventReactivePayoffLogic` normalizes on read).

**Two round-robin boundaries look like bugs and are not.** 2 active agents yield mirrored `(A,B)` + `(B,A)` pairings, both scored; 1 active agent yields a self-pairing that double-scores. Both are Swift-faithful and commented as do-not-fix. The second is reachable rather than theoretical: the run loop's "fewer than 2 active" break fires at round **start**, so a same-round `eliminate` can drop the roster first.

**Repoint target.** The unported-example throw sites move CHOOSE → **CONDITIONAL** rather than to the next handler in the queue: Conditional is last in the remaining port order, so the repoint survives longest.

## Test plan

`ChooseHandlerTests.kt` ports **all 10** Swift cases (`ChooseHandlerTests.swift` 8 + `+TurnDegradation.swift` 2), collapsed into one class, and adds the coverage the port boundary needs — 27 cases total.

> **Correction:** the plan comment on #1262 and the commit message on `c79836dc` both say "11 Swift cases". That figure was inferred from file length and never counted; `grep -c '@Test func'` gives **10**. All 10 have Kotlin counterparts, so the port is complete either way — but the number was wrong and is corrected here rather than left standing.

Two cases go **beyond** the Swift spec because `ScriptedLLMBackend`'s per-index script list can express an arm Swift's front-filling `throwErrorOnNextGenerate(count:)` cannot — Swift's own file documents succeed-then-skip as structurally unreachable and leaves it unasserted. `aSkipAfterASuccessDoesNotEraseTheEarlierValidOutput` is the **only** detector for the `succeeded` guard's protective arm; `aSkipOnAnAgentsOnlySuccessfulSlotClearsItsStaleLastOutputs` is its negative control.

### ADR-023 §12 perturbation measurements

Each mechanism was broken one at a time by a harness and the red measured. **Zero coverage holes.**

| Axis | Perturbation | Result |
|---|---|---|
| 1 + 9 | adjacency `(i+1)%count` → non-wrapping | RED (16 tests) |
| 2 | gate 2 → pre-Amendment `options[0]` fallback | RED (2) |
| 3 | gate 1 → fabricate a cooperate on skip | RED (4) |
| 4 | `succeeded` set → unconditional clear | RED (1) |
| 5 | `validateAction` → return the raw input | RED (3) |
| 5b | `options.isEmpty()` passthrough → drop every pairing | RED (1) |
| 6 | individual → canonicalize "for consistency" | RED (1) |
| 7a | `pairings` write removed | RED (15) |
| 7b | `PairingResult` emit removed | RED (4) |
| 7c | `pairings` append → replace | RED (12) |
| 8 | `opponent_name` variable removed | RED (1) |
| — | choose-options rule gate moved after the mood gate | RED (1) — and the four order-blind `contains` tests stayed green, which is the reason that ordering test exists |

Axes 4 and 8 were re-measured after the review-fix commit; both still RED.

`theInputStateIsNeverMutated` is **not** counted above: `SimulationState` is an immutable data class, so no plausible port turns it red. It is kept only because 9 sibling handler suites carry the same case.

### Gates run locally

- `./gradlew :shared:models:jvmTest :shared:engine:jvmTest :shared:engine:compileCommonMainKotlinMetadata` → BUILD SUCCESSFUL
- `./gradlew :shared:models:compileKotlinIosSimulatorArm64 :shared:engine:compileKotlinIosSimulatorArm64` (matches the CI job) → BUILD SUCCESSFUL
- `python3 scripts/check-kmp-status.py --check` → 14 handlers, 11 ported ↔ board reconciled both directions
- ChooseHandlerTests 27 / PromptBuilderInjectionTests 50, read from the JUnit XML rather than trusting a cached-green Gradle exit
- Pre-commit hook (`swiftlint --strict` + `xcodebuild build`) ran on all four commits

**The full iOS unit suite was NOT run.** This PR changes zero Swift files, and the iOS app does not consume the KMP framework yet (Phase 3.0-gated), so nothing in `Pastura/**` can be affected. Flagging the skip rather than implying a green run.

## Review

Two Opus `code-reviewer` calls, split per `subagent-usage.md` §2 (~1270 changed lines / 8 files sits in the "prefer splitting" band, and Opus carries the smaller 32K cap): call A on the implementation, call B on the tests as the ADR-023 §12 condition-4 judgment surface (given `ChooseHandler.kt` + `PairwisePayoffLogic.kt` as read-only context, with negative-control integrity as an explicit axis). Both returned PASS. The follow-up commit fixes what they found — two comments that overclaimed, an incomplete writer census, drift-prone line refs, a count-where-identity-matters assertion, and a missing detector for the `options: []` asymmetry.

## Device QA

実機QA不要 — Kotlin-only change to `shared/engine`, which no shipped iOS code path consumes yet (Phase 3.0-gated).

## Follow-up (out of scope)

Two Swift-side comments still describe `validateAction`'s pre-ADR-021-Amendment `options[0]` fallback, which the new Kotlin why-comment now contradicts: `.claude/rules/engine.md` § "Grammar must not enumerate values" and `ScenarioSemanticLinter+Config.swift:159-161`.

Closes #1262. Part of #501.
