### PR TITLE
📝 docs: unify /release version notation on X.Y

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -63,12 +63,13 @@ git log --pretty='- %s' "${LAST_TAG}..HEAD" 2>/dev/null || git log --pretty='- %
 Propose **major / minor** from the change content (breaking → major,
 anything else → minor) and **ask the operator to confirm** the target
 `X.Y`. If `$ARGUMENTS` already carries a version, treat it as the
-proposal and still confirm. Bind the confirmed value — Steps 4 and 6
-pass it as `"$VERSION"`:
-
-```bash
-VERSION=1.2   # ← the version the operator just confirmed
-```
+proposal and still confirm, then **substitute it literally into the
+Steps 4 and 6 commands** — shell state does not persist across tool
+calls, so a variable bound here would expand empty there. The `X.Y` those
+commands carry is a placeholder `release.sh` rejects (it does not start
+with a digit), so an unsubstituted run dies at argument validation
+instead of binding a plausible wrong version and surfacing it only after
+the archive, past the Step 5 gate.
 
 **Two components is the shape** (`ADR-014` § Decision, item 4). Pastura
 ships `1.0`, `1.1`, … so a **fixes-only release is still a minor bump**
@@ -211,7 +212,7 @@ hard error, so the fallback never fires silently mid-release.
 ## Step 4 — Dry-run the preflight
 
 ```bash
-scripts/release.sh --version "$VERSION" --notes-file "$NOTES_FILE" --dry-run
+scripts/release.sh --version X.Y --notes-file "$NOTES_FILE" --dry-run
 ```
 
 This runs the full preflight (HEAD == origin/main, every required check
@@ -243,7 +244,7 @@ upload that follows cannot be undone.
 ## Step 6 — Release
 
 ```bash
-scripts/release.sh --version "$VERSION" --notes-file "$NOTES_FILE"
+scripts/release.sh --version X.Y --notes-file "$NOTES_FILE"
 ```
 
 The script archives, re-checks the ADR-005 §8.5 Ollama-symbol guard on
@@ -336,7 +337,7 @@ so the right move differs by *where* it failed:
 | Failure point | State | Recovery |
 |---|---|---|
 | preflight / archive / export / **upload before ASC ingest** | nothing ingested, no tag (tag is last) | fix the cause and re-run `/release` — the build number is unchanged and that is fine |
-| **upload fails after ASC has ingested the build** | the build number now collides with an ingested build; a naive re-run is **correctly blocked** by release.sh's strict-exceeds guard | land a **new commit on `main`** (a no-op commit or a `MARKETING_VERSION` version bump) via `/orchestrate`, wait for green, then re-`/release`. This is a new green-main cycle, not an in-place retry — the build number must advance |
+| **upload fails after ASC has ingested the build** | the build number now collides with an ingested build; a naive re-run is **correctly blocked** by release.sh's strict-exceeds guard | land a **new commit on `main`** (a no-op commit or a `MARKETING_VERSION` bump) via `/orchestrate`, wait for green, then re-`/release`. This is a new green-main cycle, not an in-place retry — the build number must advance |
 | **tag pushed but the release must be retracted** | tag exists locally + remotely | `git tag -d v<version>+<build>` and `git push origin :refs/tags/v<version>+<build>` |
 | **public GitHub Release (Step 7) published then must be retracted** | Release is public; git tag is fine | `gh release delete v<version>+<build> --yes` (no `--cleanup-tag` — keep the tag). Re-cutting can re-promote it |
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -2,7 +2,7 @@
 name: release
 description: Cut a Pastura release — version bump, TestFlight and App Store release notes, then a gated scripts/release.sh archive/upload/tag. Use when asked to cut or ship a release, upload a build to TestFlight, or run the release pipeline.
 allowed-tools: Read, Grep, Glob, Bash
-argument-hint: "[X.Y.Z]"
+argument-hint: "[X.Y]"
 ---
 
 # /release
@@ -11,7 +11,7 @@ Drive one TestFlight release of Pastura. This skill is the **interactive
 judgment layer** over the deterministic mechanism in
 `scripts/release.sh` (ADR-014). The script owns preflight → archive →
 symbol check → export → upload → tag; this skill owns the human
-decisions around it: the semver bump, the release notes, and the
+decisions around it: the version bump, the release notes, and the
 **mandatory confirmation before the irreversible upload**.
 
 > **Not an `/orchestrate` task.** `/release` drives an *external*
@@ -53,17 +53,28 @@ action needed.
 
 ## Step 1 — Decide the version
 
-Read the commits since the last release tag and propose a semver bump:
+Read the commits since the last release tag and propose a version bump:
 
 ```bash
 LAST_TAG="$(git describe --tags --abbrev=0 2>/dev/null || echo '(none)')"
 git log --pretty='- %s' "${LAST_TAG}..HEAD" 2>/dev/null || git log --pretty='- %s' -n 20
 ```
 
-Propose **major / minor / patch** from the change content (breaking →
-major, new feature → minor, fixes only → patch) and **ask the operator
-to confirm** the target `X.Y.Z`. If `$ARGUMENTS` already carries a
-version, treat it as the proposal and still confirm.
+Propose **major / minor** from the change content (breaking → major,
+anything else → minor) and **ask the operator to confirm** the target
+`X.Y`. If `$ARGUMENTS` already carries a version, treat it as the
+proposal and still confirm. Bind the confirmed value — Steps 4 and 6
+pass it as `"$VERSION"`:
+
+```bash
+VERSION=1.2   # ← the version the operator just confirmed
+```
+
+**Two components is the shape** (`ADR-014` § Decision, item 4). Pastura
+ships `1.0`, `1.1`, … so a **fixes-only release is still a minor bump**
+(`1.1` → `1.2`), not a third component. Reserve `X.Y.Z` for a hotfix on a
+version already published to the App Store: `release.sh` accepts either
+shape, but a normal release never carries a third component.
 
 ## Step 2 — Ensure the version is on a green `main` (sequencing)
 
@@ -200,7 +211,7 @@ hard error, so the fallback never fires silently mid-release.
 ## Step 4 — Dry-run the preflight
 
 ```bash
-scripts/release.sh --version X.Y.Z --notes-file "$NOTES_FILE" --dry-run
+scripts/release.sh --version "$VERSION" --notes-file "$NOTES_FILE" --dry-run
 ```
 
 This runs the full preflight (HEAD == origin/main, every required check
@@ -232,13 +243,13 @@ upload that follows cannot be undone.
 ## Step 6 — Release
 
 ```bash
-scripts/release.sh --version X.Y.Z --notes-file "$NOTES_FILE"
+scripts/release.sh --version "$VERSION" --notes-file "$NOTES_FILE"
 ```
 
 The script archives, re-checks the ADR-005 §8.5 Ollama-symbol guard on
 the signed binary, exports an `app-store` `.ipa`, uploads via fastlane
 (waiting for ASC processing), and — only on a successful upload —
-creates and pushes the annotated tag `vX.Y.Z+<build>`. Report the result
+creates and pushes the annotated tag `v<version>+<build>`. Report the result
 and that the build is processing on TestFlight.
 
 ## Step 7 — Promote to a public GitHub Release (at App Store publish)
@@ -256,9 +267,9 @@ and that the build is processing on TestFlight.
 
 **Trigger:** a build has been **approved and released on the App Store** (an
 App Store Connect–side event this repo does not observe). Each `/release`
-run already tagged its build `vX.Y.Z+<build>`; this step attaches a *public*
+run already tagged its build `v<version>+<build>`; this step attaches a *public*
 GitHub Release to the tag of the build that went live — titled `Pastura
-X.Y.Z` (the public marketing version, no build suffix), marked `--latest`,
+<version>` (the public marketing version, no build suffix), marked `--latest`,
 never a pre-release.
 
 **Changelog source.** The GitHub Release carries the developer-facing
@@ -278,7 +289,7 @@ confirmation-gate discipline (Step 5): never flip `--draft=false` on an
 unreviewed auto-changelog.
 
 ```bash
-TAG="vX.Y.Z+<build>"                       # the approved build's tag
+TAG="v<version>+<build>"                   # the approved build's tag
 PREV=$(gh release list --exclude-drafts --limit 1 --json tagName -q '.[0].tagName')
 
 # 1. Create as a DRAFT with the auto-generated changelog. Build the
@@ -287,7 +298,7 @@ PREV=$(gh release list --exclude-drafts --limit 1 --json tagName -q '.[0].tagNam
 #    collapse into one bad argument that gh rejects.
 notes_args=()
 [ -n "$PREV" ] && notes_args=(--notes-start-tag "$PREV")
-gh release create "$TAG" --title "Pastura X.Y.Z" --latest --draft \
+gh release create "$TAG" --title "Pastura <version>" --latest --draft \
   --generate-notes "${notes_args[@]}"
 
 # 2. Prepend a hand-written 2–3 line intro (the release headline) above
@@ -325,9 +336,9 @@ so the right move differs by *where* it failed:
 | Failure point | State | Recovery |
 |---|---|---|
 | preflight / archive / export / **upload before ASC ingest** | nothing ingested, no tag (tag is last) | fix the cause and re-run `/release` — the build number is unchanged and that is fine |
-| **upload fails after ASC has ingested the build** | the build number now collides with an ingested build; a naive re-run is **correctly blocked** by release.sh's strict-exceeds guard | land a **new commit on `main`** (a no-op commit or a `MARKETING_VERSION` patch bump) via `/orchestrate`, wait for green, then re-`/release`. This is a new green-main cycle, not an in-place retry — the build number must advance |
-| **tag pushed but the release must be retracted** | tag exists locally + remotely | `git tag -d vX.Y.Z+<build>` and `git push origin :refs/tags/vX.Y.Z+<build>` |
-| **public GitHub Release (Step 7) published then must be retracted** | Release is public; git tag is fine | `gh release delete vX.Y.Z+<build> --yes` (no `--cleanup-tag` — keep the tag). Re-cutting can re-promote it |
+| **upload fails after ASC has ingested the build** | the build number now collides with an ingested build; a naive re-run is **correctly blocked** by release.sh's strict-exceeds guard | land a **new commit on `main`** (a no-op commit or a `MARKETING_VERSION` version bump) via `/orchestrate`, wait for green, then re-`/release`. This is a new green-main cycle, not an in-place retry — the build number must advance |
+| **tag pushed but the release must be retracted** | tag exists locally + remotely | `git tag -d v<version>+<build>` and `git push origin :refs/tags/v<version>+<build>` |
+| **public GitHub Release (Step 7) published then must be retracted** | Release is public; git tag is fine | `gh release delete v<version>+<build> --yes` (no `--cleanup-tag` — keep the tag). Re-cutting can re-promote it |
 
 ## ASC API key revocation (leak response)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -292,7 +292,7 @@ Update with `/plugin`. Install steps: CONTRIBUTING.md § "If you use Claude Code
 
 Record architectural decisions in `docs/decisions/` as `ADR-NNN.md`.
 
-**Editability window**: For recently-Accepted ADRs whose decisions have not yet shipped in code, prefer **in-place edits** when implementation planning surfaces a refinement. Use `§N. Amendment YYYY-MM-DD` sections only after the ADR's decisions have been implemented — Amendment text doubles reviewer overhead on every cross-section read.
+**Editability window**: For recently-Accepted ADRs whose decisions have not yet shipped in code, prefer **in-place edits** when implementation planning surfaces a refinement. Use `§N. Amendment YYYY-MM-DD` sections only after the ADR's decisions have been implemented — Amendment text doubles reviewer overhead on every cross-section read. **Factual corrections are exempt** — text that became wrong about shipped behaviour is edited in place at any age.
 
 ## Reference Documents
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -292,7 +292,7 @@ Update with `/plugin`. Install steps: CONTRIBUTING.md § "If you use Claude Code
 
 Record architectural decisions in `docs/decisions/` as `ADR-NNN.md`.
 
-**Editability window**: For recently-Accepted ADRs whose decisions have not yet shipped in code, prefer **in-place edits** when implementation planning surfaces a refinement. Use `§N. Amendment YYYY-MM-DD` sections only after the ADR's decisions have been implemented — Amendment text doubles reviewer overhead on every cross-section read. **Factual corrections are exempt** — text that became wrong about shipped behaviour is edited in place at any age.
+**Editability window**: For recently-Accepted ADRs whose decisions have not yet shipped in code, prefer **in-place edits** when implementation planning surfaces a refinement. Use `§N. Amendment YYYY-MM-DD` sections only after the ADR's decisions have been implemented — Amendment text doubles reviewer overhead on every cross-section read. **Factual corrections are exempt** — text that became wrong about shipped behaviour is edited in place at any age, provided the decision itself is unchanged.
 
 ## Reference Documents
 

--- a/docs/decisions/ADR-014.md
+++ b/docs/decisions/ADR-014.md
@@ -41,8 +41,9 @@
      when absent), pre-flight checklist cross-check, and the
      **mandatory confirmation gate before the irreversible upload**.
 4. **Versioning:** `MARKETING_VERSION` is a manual bump, `X.Y` by convention
-   (`release.sh` also accepts `X.Y.Z`); `CURRENT_PROJECT_VERSION` (build
-   number) is derived (see § "Build number").
+   (`release.sh` also accepts `X.Y.Z` — see `.claude/skills/release/SKILL.md`
+   § Step 1 for when the third component applies);
+   `CURRENT_PROJECT_VERSION` (build number) is derived (see § "Build number").
 
 ## Why this shape
 
@@ -134,7 +135,7 @@ recorded so they fail loudly, not silently:
   build number for the current `MARKETING_VERSION` and asserts the computed
   number strictly exceeds it — turning a mid-upload silent reject into a clean
   preflight failure. The recovery is then an explicit choice: a no-op commit
-  (advances the count) or a `MARKETING_VERSION` version bump.
+  (advances the count) or a `MARKETING_VERSION` bump.
 - **Shallow-clone undercount.** `actions/checkout` defaults to `fetch-depth: 1`,
   under which `rev-list --count HEAD` returns 1, not the full commit count.
   **`fetch-depth: 0` is

--- a/docs/decisions/ADR-014.md
+++ b/docs/decisions/ADR-014.md
@@ -36,12 +36,13 @@
    - `fastlane/Fastfile` + `Appfile` — API Key auth, version/build wiring,
      `upload_to_testflight`.
    - `.claude/skills/release/SKILL.md` — the judgement + interactive layer:
-     semver decision, reviewed tester-facing "What to Test" notes (passed to
+     version decision, reviewed tester-facing "What to Test" notes (passed to
      `release.sh` via `--notes-file`; commit-log subjects are the fallback
      when absent), pre-flight checklist cross-check, and the
      **mandatory confirmation gate before the irreversible upload**.
-4. **Versioning:** `MARKETING_VERSION` is a manual semver bump;
-   `CURRENT_PROJECT_VERSION` (build number) is derived (see § "Build number").
+4. **Versioning:** `MARKETING_VERSION` is a manual bump, `X.Y` by convention
+   (`release.sh` also accepts `X.Y.Z`); `CURRENT_PROJECT_VERSION` (build
+   number) is derived (see § "Build number").
 
 ## Why this shape
 
@@ -86,7 +87,7 @@ created and pushed *after* a successful upload**, not before (see rationale):
    `gh api repos/{owner}/{repo}/commits/<sha>/check-runs`); reject if any
    context is missing, `in_progress`, `queued`, or `pending`, and refuse
    outright if the derived list is empty. (See § "Preflight discipline".)
-2. **Version** — bump `MARKETING_VERSION` (manual semver, if changing);
+2. **Version** — bump `MARKETING_VERSION` (manual, if changing);
    compute the build number (see § "Build number"); assert it strictly
    exceeds the latest build already uploaded to ASC for this version
    (via fastlane `latest_testflight_build_number(version:)`).
@@ -133,7 +134,7 @@ recorded so they fail loudly, not silently:
   build number for the current `MARKETING_VERSION` and asserts the computed
   number strictly exceeds it — turning a mid-upload silent reject into a clean
   preflight failure. The recovery is then an explicit choice: a no-op commit
-  (advances the count) or a `MARKETING_VERSION` patch bump.
+  (advances the count) or a `MARKETING_VERSION` version bump.
 - **Shallow-clone undercount.** `actions/checkout` defaults to `fetch-depth: 1`,
   under which `rev-list --count HEAD` returns 1, not the full commit count.
   **`fetch-depth: 0` is
@@ -237,10 +238,10 @@ A leaked ASC API Key is a high-severity credential exposure, so a single
 
 ## Amendment 2026-07-09 — Public GitHub Release promotion
 
-`scripts/release.sh` pushes an annotated git tag `vX.Y.Z+<build>` per
+`scripts/release.sh` pushes an annotated git tag `v<version>+<build>` per
 TestFlight upload but creates **no** GitHub Release. When a version is
 approved and released on the App Store, a **public GitHub Release** is
-promoted onto that build's existing tag — titled `Pastura X.Y.Z`, marked
+promoted onto that build's existing tag — titled `Pastura <version>`, marked
 `--latest`, carrying the developer-facing changelog (merged PRs, deliberately
 kept out of the tester-facing "What to Test" notes).
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -30,7 +30,7 @@
 #   ASC_KEY_ID, ASC_ISSUER_ID, ASC_KEY_PATH  (see fastlane/Fastfile)
 #
 # Usage:
-#   scripts/release.sh --version X.Y.Z [--notes-file PATH] [--dry-run]
+#   scripts/release.sh --version X.Y[.Z] [--notes-file PATH] [--dry-run]
 #
 #   --notes-file PATH  Use PATH's contents as the TestFlight "What to Test"
 #               changelog — the channel by which the /release skill ships its
@@ -78,10 +78,10 @@ while [ "$#" -gt 0 ]; do
     *) die "unknown argument: $1 (see --help)" ;;
   esac
 done
-[ -n "$VERSION" ] || die "--version X.Y.Z is required (the marketing/semver version)."
+[ -n "$VERSION" ] || die "--version X.Y is required (the marketing version; X.Y.Z only for a hotfix)."
 case "$VERSION" in
   [0-9]*.[0-9]*.[0-9]*|[0-9]*.[0-9]*) : ;;
-  *) die "--version must look like X.Y.Z (got '$VERSION')." ;;
+  *) die "--version must look like X.Y or X.Y.Z (got '$VERSION')." ;;
 esac
 
 # ── preflight ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`/release` documented the marketing version as `X.Y.Z` throughout, but Pastura ships two components: `v1.0` was released to the App Store (tag `v1.0+522`) and `main` carries `MARKETING_VERSION = 1.1`. The documented tag shape `vX.Y.Z+<build>` did not match the one tag that exists.

- **`/release` skill** — `argument-hint` is now `[X.Y]`; every placeholder site uses `X.Y` / `<version>` / `v<version>+<build>`. Step 1 proposes major / minor and states the convention: a **fixes-only release is still a minor bump** (`1.1` → `1.2`), and `X.Y.Z` is reserved for a hotfix on a version already published.
- **`scripts/release.sh`** — messages only, validation `case` untouched. Its `case` has accepted `[0-9]*.[0-9]*` since `389163d4`, but `--help` and both `die` messages still said the version "must look like X.Y.Z" — the guard contradicted the code it guards.
- **ADR-014** — the `semver` / `X.Y.Z` / `patch bump` wording is corrected in place (see below).

### Why the runnable fences keep a literal placeholder

The two bash fences in Steps 4 and 6 are *executed*, and the placeholder they carry has to satisfy two constraints at once. `<version>` fails the first: `<` and `>` are shell redirections, so a literal paste dies as a parse error. A `"$VERSION"` variable bound back in Step 1 fails the second: shell state does not persist between Bash tool calls, so it expands empty — and seeding it with a plausible literal (`VERSION=1.2`) is worse still, because that value is syntactically valid *and* currently correct, so it binds silently and the mismatch surfaces only at the archive marketing-version assert (`release.sh:225`), which runs **after** the irreversible upload gate at Step 5.

A literal `X.Y` satisfies both: no shell metacharacters, and `release.sh`'s validator rejects it (it does not start with a digit), so an unsubstituted run dies at argument parsing with a self-explaining message. That is exactly the property `X.Y.Z` already had — only its shape was wrong. Backticked and quoted sites keep `<version>`, which is inert there.

One other mechanical constraint: `release.sh`'s usage line stays one line, because `--help` is `sed -n '2,48p' "$0"` — a header slice with zero slack, so an added line would silently drop the last one from the output.

### Why ADR-014 is edited in place rather than amended

`git log -L 83,83:scripts/release.sh` shows the validator's two-component alternative was present in the original PR-A commit `389163d4`, and shipped versions are `1.0` / `1.1` — so `semver` was inaccurate from day one. Nothing *flipped*, so this is a factual correction rather than a superseded decision, and `adr-writing.md` §3's dated-past-tense rule does not apply.

CLAUDE.md § Decision Records previously read as "shipped ⇒ Amendment section", with no allowance for correcting text that was simply wrong. This PR adds that allowance in one sentence:

> **Factual corrections are exempt** — text that became wrong about shipped behaviour is edited in place at any age, provided the decision itself is unchanged.

Both bounds are externally checkable. "Wrong about shipped behaviour" is falsifiable against the shipped artifact, and the trailing clause blocks the reading this would otherwise smuggle in — when code and an ADR disagree, "correct the ADR" and "fix the code" are both available, and without it the rule silently elects the first, retroactively blessing accepted drift as the decision.

ADR-014 § Decision, item 4 is therefore kept **descriptive** (`X.Y` by convention, `release.sh` also accepts `X.Y.Z`) — the forward-looking *hotfix policy* lives in the skill, in the skill's own voice, so the ADR states only what already ships and points at the skill for the rest.

## Test plan

No app code changed and there is no automated coverage for these files, so each check below was run in the direction that could **fail** — a guard's success case proves nothing.

| Check | Result |
|---|---|
| `scripts/release.sh --version X.Y` (unsubstituted placeholder) | dies: `--version must look like X.Y or X.Y.Z (got 'X.Y').` — fail-loud confirmed |
| `scripts/release.sh --version 1.1 --dry-run` | passes validation and reaches preflight — the two-component form is genuinely accepted |
| `scripts/release.sh` (no `--version`) | dies: `--version X.Y is required (the marketing version; X.Y.Z only for a hotfix).` |
| `scripts/release.sh --version abc` | dies: `--version must look like X.Y or X.Y.Z (got 'abc').` |
| `scripts/release.sh --help` last line | still `# script is reusable from a GHA macos-* runner later (ADR-014 Decision 2).` — the `2,48p` boundary is intact |
| `git grep -nF 'X.Y.Z'` | only the 4 intentional sites (both `release.sh` die messages, the skill's hotfix sentence, ADR-014 item 4) |
| `git grep -n 'patch bump'` | 0 |
| `git grep -nw semver -- .claude/skills/release scripts/release.sh docs/decisions/ADR-014.md` | 0 |
| `bash scripts/tests/*-test.sh` (16 gates) | all pass |
| pre-commit (`swiftlint --strict` + `xcodebuild build`) | pass |

The expected survivor set was pinned in the plan **before** implementation, so the greps could fail — an unpinned "only intentional survivors" criterion passes by construction.

## Device QA

実機QA不要 — documentation and shell-script message text only; no app target, Swift source, or UI surface is touched.

Closes #1266
