### PR TITLE
📝 docs: #1271 の 2 件をルール昇格（locale pin / structural Tab a11y）

### DIFF
--- a/.claude/rules/i18n.md
+++ b/.claude/rules/i18n.md
@@ -86,8 +86,9 @@ Test it two ways (canonical:
 - **Runtime firing** — the actual regression (n=1 → "1 records"). Resolve the key
   against the COMPILED catalog and assert literals:
   `String(localized: "\(1) records", bundle: Bundle(for: <AppClass>.self), locale: Locale(identifier: "en")) == "1 record"`.
-  The explicit **app** bundle (`Bundle(for:)`, not the test runner's
-  `Bundle.main`) + pinned locale make it deterministic and non-tautological; pure
+  Naming the **app** bundle explicitly (`Bundle(for:)`) keeps it
+  non-tautological — the target is app-hosted, so `Bundle.main` resolves to the
+  same bundle, but relying on that is implicit. Pure
   Foundation resolution is ADR-009-compatible (no ViewInspector). `String(localized:
   "…\(x)…")` is fine in **test** code — the `form_a_localized_interpolation`
   SwiftLint rule scopes to app source only. **The `en` pin works because the

--- a/.claude/rules/i18n.md
+++ b/.claude/rules/i18n.md
@@ -90,7 +90,10 @@ Test it two ways (canonical:
   `Bundle.main`) + pinned locale make it deterministic and non-tautological; pure
   Foundation resolution is ADR-009-compatible (no ViewInspector). `String(localized:
   "…\(x)…")` is fine in **test** code — the `form_a_localized_interpolation`
-  SwiftLint rule scopes to app source only.
+  SwiftLint rule scopes to app source only. **The `en` pin works only because
+  `en` is the source language** — `locale:` picks the plural rule, not the
+  `.lproj` table. Read `view-testing.md` § "Non-base-locale expectations"
+  before asserting a `ja` value at runtime.
 
 Device / ja-locale QA is still worth a glance, but the runtime test — not manual
 QA — is the load-bearing firing signal.

--- a/.claude/rules/i18n.md
+++ b/.claude/rules/i18n.md
@@ -90,9 +90,10 @@ Test it two ways (canonical:
   `Bundle.main`) + pinned locale make it deterministic and non-tautological; pure
   Foundation resolution is ADR-009-compatible (no ViewInspector). `String(localized:
   "…\(x)…")` is fine in **test** code — the `form_a_localized_interpolation`
-  SwiftLint rule scopes to app source only. **The `en` pin works only because
-  `en` is the source language** — `locale:` picks the plural rule, not the
-  `.lproj` table. Read `view-testing.md` § "Non-base-locale expectations"
+  SwiftLint rule scopes to app source only. **The `en` pin works because the
+  runner's process localization resolves to `en`** (`Bundle.preferredLocalizations`),
+  not because `en` is the source language — `locale:` picks the plural rule, not
+  the `.lproj` table. Read `view-testing.md` § "Non-base-locale expectations"
   before asserting a `ja` value at runtime.
 
 Device / ja-locale QA is still worth a glance, but the runtime test — not manual

--- a/.claude/rules/swiftui-traps.md
+++ b/.claude/rules/swiftui-traps.md
@@ -44,6 +44,11 @@ has no `.fill` variant, was the only tab where the symptom was
 diagnosable): the LOAD-BEARING comment in
 `Pastura/Pastura/App/RootTabView.swift` (`symbolName(for:isActive:)`).
 
+The a11y modifiers on that same `tabIcon` `Image` are separately unreliable
+— structural `Tab` drops them from the XCUITest tree on some launches, so
+adding another identifier there fixes nothing. See `uitest-traps.md`
+§ "structural `Tab`'s a11y overlay is a per-launch coin toss".
+
 ## NavigationStack in-place top-route replace (`AppRouter.replaceTop`)
 
 Replacing the **top route in place** in a `NavigationStack` path

--- a/.claude/rules/uitest-traps.md
+++ b/.claude/rules/uitest-traps.md
@@ -1,0 +1,32 @@
+---
+paths:
+  - "Pastura/PasturaUITests/**"
+---
+
+# XCUITest Traps
+
+XCUITest-only footguns. App-source SwiftUI traps live in `swiftui-traps.md`;
+the View-test *strategy* (what to unit-test vs. UI-test) is `view-testing.md`.
+
+## structural `Tab`'s a11y overlay is a per-launch coin toss
+
+With the iOS 18+ structural API (`TabView { Tab(...) { } label: { ... } }`),
+**both** the `.accessibilityIdentifier` and the `.accessibilityLabel` applied
+to the `Image` inside the `label:` closure are missing from the XCUITest tree
+**on some launches** — the `Image` exposes its raw SF Symbol name instead. It
+is decided once when the a11y bridge is built, so **waiting cannot outlast
+it**: widening the bound (10s, 20s) does not help, and the session never
+recovers. `scripts/store-shots.sh` failed 2 of 3 runs on this.
+
+**The boundary matters — do not sweep working code.** The tab **button**
+keeps its localized title, so `app.tabBars.buttons["<localized label>"]`
+queries are unaffected (11 such call sites across `NavigationRegressionTests`,
+`DeepLinkTabRoutingUITests`, `ScreenshotTourTests`, `SimulationFocusModeTests`
+are fine as-is). Only queries keyed on the `label:`-closure identifier are
+exposed.
+
+**Apply**: switch tabs through `ScreenshotSupport.tapTab`, which waits on a
+**single** predicate OR-ing identifier and localized label — not sequential
+waits, or a broken launch burns the identifier's whole timeout first. Its doc
+comment carries the AX-tree evidence and the label-fallback contract. Adding
+another identifier in `RootTabView.tabIcon` does not fix it (#1271).

--- a/.claude/rules/view-testing.md
+++ b/.claude/rules/view-testing.md
@@ -57,3 +57,20 @@ example: `LanguageDriftToastLayout` + `LanguageDriftToastLayoutTests` (the
 
 Full Why + alternatives + revisit triggers:
 [ADR-009](../../docs/decisions/ADR-009.md).
+
+## Non-base-locale expectations
+
+`locale:` in `String(localized:bundle:locale:)` selects the plural / format
+**rule** only — the `.lproj` table follows the *process's* localization
+(`Bundle.preferredLocalizations`). So a `ja` pin against the app bundle
+silently returns the `en` value, and a guard built on one asserts nothing
+about ja. Probed 2026-07-27 on the simulator test runner: `locale: ja` on
+`"%lld records"` → `1 records`, i.e. ja's `other`-only rule applied to the
+**en** table (`ja.lproj` ships; it is simply not selected).
+
+Three working shapes: pin the **base** locale at runtime
+(`RecordsCountPluralTests`); assert non-base values against the catalog JSON
+— the change-detector shape above (`StoreCaptureTabLabelTests`); or, for a
+real runtime resolution, scope the bundle to the table —
+`Bundle(path: appBundle.path(forResource: "ja", ofType: "lproj"))`, which
+does return `観察履歴`.

--- a/.claude/rules/view-testing.md
+++ b/.claude/rules/view-testing.md
@@ -68,9 +68,10 @@ about ja. Probed 2026-07-27 on the simulator test runner: `locale: ja` on
 `"%lld records"` → `1 records`, i.e. ja's `other`-only rule applied to the
 **en** table (`ja.lproj` ships; it is simply not selected).
 
-Three working shapes: pin the **base** locale at runtime
-(`RecordsCountPluralTests`); assert non-base values against the catalog JSON
-— the change-detector shape above (`StoreCaptureTabLabelTests`); or, for a
-real runtime resolution, scope the bundle to the table —
-`Bundle(path: appBundle.path(forResource: "ja", ofType: "lproj"))`, which
-does return `観察履歴`.
+Three working shapes: pin the locale the **runner already resolves to**
+(`RecordsCountPluralTests` pins `en` on an en simulator); assert other
+locales against the catalog JSON — the change-detector shape above
+(`StoreCaptureTabLabelTests`); or, for a real runtime resolution, scope the
+bundle to the table itself — `Bundle(path: try #require(appBundle
+.path(forResource: "ja", ofType: "lproj")))` returns `観察履歴` (`#require`,
+not `!` — Hard Rule 1; `path(forResource:)` is `String?`).

--- a/.claude/rules/view-testing.md
+++ b/.claude/rules/view-testing.md
@@ -72,6 +72,13 @@ Three working shapes: pin the locale the **runner already resolves to**
 (`RecordsCountPluralTests` pins `en` on an en simulator); assert other
 locales against the catalog JSON — the change-detector shape above
 (`StoreCaptureTabLabelTests`); or, for a real runtime resolution, scope the
-bundle to the table itself — `Bundle(path: try #require(appBundle
-.path(forResource: "ja", ofType: "lproj")))` returns `観察履歴` (`#require`,
-not `!` — Hard Rule 1; `path(forResource:)` is `String?`).
+bundle to the table itself. **Both** layers of that last one are optional
+(`path(forResource:)` is `String?` *and* `Bundle(path:)` is failable), so
+unwrap twice — `#require` over `!` for a located failure, not because Hard
+Rule 1 applies (test code is exempt from it):
+
+```swift
+let jaPath = try #require(appBundle.path(forResource: "ja", ofType: "lproj"))
+let jaBundle = try #require(Bundle(path: jaPath))
+#expect(String(localized: "History", bundle: jaBundle) == "観察履歴")
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,6 +271,7 @@ Update with `/plugin`. Install steps: CONTRIBUTING.md § "If you use Claude Code
 - `swift-testing-parallelism.md` — `.serialized` is intra-suite only (cross-suite needs `swift test --no-parallel`); timing assertions compare against an in-test control, never an absolute (`Pastura/PasturaTests/**`, `Pastura/PasturaUITests/**`, `tools/**`)
 - `swiftui-traps.md` — SwiftUI / Swift 6 trap catalog: toolbar-hide API matrix (iOS 17→26), footguns surfaced during app development; cross-references `navigation.md` for AppRouter mechanics (`Pastura/Pastura/**/*.swift`)
 - `testing.md` — Test target (`Pastura/PasturaTests/**`)
+- `uitest-traps.md` — XCUITest-only traps: structural `Tab` drops the `label:` `Image`'s a11y identifier/label per-launch (waiting never fixes it; button-label queries stay safe) (`Pastura/PasturaUITests/**`)
 - `view-testing.md` — View test strategy: extract logic to unit-tests, narrow UI integration tests, no ViewInspector / snapshot (`Pastura/PasturaTests/**`, `Pastura/PasturaUITests/**`, `Pastura/Pastura/Views/**`, `Pastura/Pastura/App/**ViewModel.swift`). Decision record: [ADR-009](docs/decisions/ADR-009.md).
 
 **Always-loaded** (no frontmatter `paths:` — relevant from any layer):

--- a/Pastura/Pastura/App/RootTabView.swift
+++ b/Pastura/Pastura/App/RootTabView.swift
@@ -137,9 +137,12 @@ struct RootTabView: View {
     Image(systemName: Self.symbolName(for: tab, isActive: coordinator.selectedTab == tab))
       .environment(\.symbolVariants, .none)
       .accessibilityLabel(Text(label))
-      // Locale-independent handle for UI tests to switch tabs by identifier
-      // instead of the localized VoiceOver label (StoreScreenshotTests runs
-      // under en AND ja, where label-based tab queries would not resolve).
+      // Locale-independent handle for UI tests (StoreScreenshotTests runs under
+      // en AND ja). NOT a sufficient one on its own: structural `Tab` drops
+      // both a11y modifiers from the XCUITest tree on some launches, so
+      // `ScreenshotSupport.tapTab` ORs this identifier with the localized
+      // label. Adding a further identifier here does not help —
+      // `.claude/rules/uitest-traps.md`.
       .accessibilityIdentifier(Self.accessibilityID(for: tab))
   }
 }
@@ -164,9 +167,11 @@ extension RootTabView {
   }
 
   /// Stable, locale-independent accessibility identifier for `tab`'s tab-bar
-  /// button. Used by `StoreScreenshotTests` to switch tabs by identifier
-  /// (`app.tabBars.buttons["rootTab.history"]`) so navigation works under any
-  /// locale. Pure + `internal` so the mapping is unit-tested.
+  /// button, so `StoreScreenshotTests` can navigate under any locale. Query it
+  /// through `ScreenshotSupport.tapTab`, never on its own: the identifier is
+  /// absent from the XCUITest tree on some launches, and `tapTab` ORs it with
+  /// the localized label (`.claude/rules/uitest-traps.md`). Pure + `internal`
+  /// so the mapping is unit-tested.
   static func accessibilityID(for tab: AppTab) -> String {
     switch tab {
     case .home: return "rootTab.home"

--- a/Pastura/Pastura/Views/Simulation/SimulationLeaveSheet.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationLeaveSheet.swift
@@ -2,7 +2,8 @@ import SwiftUI
 
 /// Semantic color tokens for ``SimulationLeaveSheet``, extracted so
 /// `SimulationControlsTokenTests` can pin them as a **change-detector
-/// tripwire** (ADR-009 § "Change-detector tripwire").
+/// tripwire** (ADR-009 / view-testing.md
+/// § "Change-detector tripwire for code-review-gated tokens").
 ///
 /// The load-bearing decision: the "keep running" action is a *caution*
 /// (design-system §2.6 `warning`, amber), **not** a *destructive* action

--- a/Pastura/PasturaTests/Localization/RecordsCountPluralTests.swift
+++ b/Pastura/PasturaTests/Localization/RecordsCountPluralTests.swift
@@ -88,16 +88,18 @@ struct RecordsCountPluralTests {
     #expect(state == "translated")
   }
 
-  @Test func englishPluralFiresAtRuntime() {
+  @Test func englishPluralFiresAtRuntime() throws {
     // Behavioral counterpart to the structure assertions: resolve the key
-    // against the COMPILED catalog (app bundle, not the test runner's) with a
+    // against the COMPILED catalog, naming the app bundle explicitly (the
+    // target is app-hosted, so `Bundle.main` is the same bundle), with a
     // pinned `en` locale. The pin fixes the plural RULE, not the table — the
     // table follows the runner's process localization, which is `en` on every
     // simulator we run, so pinning a non-base locale here would silently keep
     // reading `en` (`.claude/rules/view-testing.md` § "Non-base-locale
-    // expectations"). That precondition is asserted below rather than assumed,
-    // so a ja-configured runner fails as "wrong runner locale" instead of
-    // looking like a catalog regression. This is the actual UR-003 regression
+    // expectations"). That precondition is REQUIRED below rather than assumed:
+    // `#require` halts the test, so a ja-configured runner reports the wrong
+    // runner locale and never emits the value mismatches that would read as a
+    // catalog regression. This is the actual UR-003 regression
     // — n=1 rendering "1 records". Not a tautology (asserts hardcoded literals)
     // and not ViewInspector (pure Foundation resolution, ADR-009-compatible).
     // The Int interpolation here is the same plural mechanism the
@@ -105,7 +107,7 @@ struct RecordsCountPluralTests {
     // in test code (the `form_a_localized_interpolation` SwiftLint rule scopes
     // to app source).
     let bundle = Bundle(for: DatabaseManager.self)
-    #expect(bundle.preferredLocalizations.first == "en")
+    try #require(bundle.preferredLocalizations.first == "en")
     let en = Locale(identifier: "en")
     #expect(String(localized: "\(1) records", bundle: bundle, locale: en) == "1 record")
     #expect(String(localized: "\(2) records", bundle: bundle, locale: en) == "2 records")

--- a/Pastura/PasturaTests/Localization/RecordsCountPluralTests.swift
+++ b/Pastura/PasturaTests/Localization/RecordsCountPluralTests.swift
@@ -94,15 +94,18 @@ struct RecordsCountPluralTests {
     // pinned `en` locale. The pin fixes the plural RULE, not the table — the
     // table follows the runner's process localization, which is `en` on every
     // simulator we run, so pinning a non-base locale here would silently keep
-    // reading `en` (`.claude/rules/view-testing.md`
-    // § "Non-base-locale expectations"). This is the actual UR-003 regression
-    // — n=1 rendering
-    // "1 records". Not a tautology (asserts hardcoded literals) and not
-    // ViewInspector (pure Foundation resolution, ADR-009-compatible). The Int
-    // interpolation here is the same plural mechanism the `Text("\(count)…")`
-    // callsite uses; `String(localized: "…\(x)…")` is fine in test code (the
-    // `form_a_localized_interpolation` SwiftLint rule scopes to app source).
+    // reading `en` (`.claude/rules/view-testing.md` § "Non-base-locale
+    // expectations"). That precondition is asserted below rather than assumed,
+    // so a ja-configured runner fails as "wrong runner locale" instead of
+    // looking like a catalog regression. This is the actual UR-003 regression
+    // — n=1 rendering "1 records". Not a tautology (asserts hardcoded literals)
+    // and not ViewInspector (pure Foundation resolution, ADR-009-compatible).
+    // The Int interpolation here is the same plural mechanism the
+    // `Text("\(count)…")` callsite uses; `String(localized: "…\(x)…")` is fine
+    // in test code (the `form_a_localized_interpolation` SwiftLint rule scopes
+    // to app source).
     let bundle = Bundle(for: DatabaseManager.self)
+    #expect(bundle.preferredLocalizations.first == "en")
     let en = Locale(identifier: "en")
     #expect(String(localized: "\(1) records", bundle: bundle, locale: en) == "1 record")
     #expect(String(localized: "\(2) records", bundle: bundle, locale: en) == "2 records")

--- a/Pastura/PasturaTests/Localization/RecordsCountPluralTests.swift
+++ b/Pastura/PasturaTests/Localization/RecordsCountPluralTests.swift
@@ -6,7 +6,8 @@ import Testing
 /// Catalog-structure assertion for the **first plural** entry in
 /// `Localizable.xcstrings` — the Past Results count line (`"%lld records"`,
 /// UR-003). A change-detector test (`.claude/rules/view-testing.md`
-/// § "Change-detector tripwire"), NOT a runtime `String(localized:)` resolution:
+/// § "Change-detector tripwire for code-review-gated tokens"), NOT a runtime
+/// `String(localized:)` resolution:
 /// the catalog compiles to a `.loctable` (no `.xcstrings` ships in the bundle),
 /// and a runtime resolve against the test-runner bundle is both
 /// bundle-ambiguous and tautological — and the SwiftUI `Text` plural path is
@@ -90,8 +91,12 @@ struct RecordsCountPluralTests {
   @Test func englishPluralFiresAtRuntime() {
     // Behavioral counterpart to the structure assertions: resolve the key
     // against the COMPILED catalog (app bundle, not the test runner's) with a
-    // pinned `en` locale, so the assertion is deterministic regardless of the
-    // CI runner's locale. This is the actual UR-003 regression — n=1 rendering
+    // pinned `en` locale. The pin fixes the plural RULE, not the table — the
+    // table follows the runner's process localization, which is `en` on every
+    // simulator we run, so pinning a non-base locale here would silently keep
+    // reading `en` (`.claude/rules/view-testing.md`
+    // § "Non-base-locale expectations"). This is the actual UR-003 regression
+    // — n=1 rendering
     // "1 records". Not a tautology (asserts hardcoded literals) and not
     // ViewInspector (pure Foundation resolution, ADR-009-compatible). The Int
     // interpolation here is the same plural mechanism the `Text("\(count)…")`

--- a/Pastura/PasturaTests/Localization/StoreCaptureTabLabelTests.swift
+++ b/Pastura/PasturaTests/Localization/StoreCaptureTabLabelTests.swift
@@ -13,10 +13,13 @@ import Testing
 /// moment with no slack for it. This fails in CI instead.
 ///
 /// A change-detector against the catalog JSON (`.claude/rules/view-testing.md`
-/// § "Change-detector tripwire"), **not** a runtime `String(localized:)`
-/// resolution. A pinned-`ja` runtime resolve was tried first and returns the
-/// key `"History"` unchanged — the same reason `RecordsCountPluralTests` pins
-/// only `en` at runtime and asserts its ja expectations against this JSON.
+/// § "Change-detector tripwire for code-review-gated tokens"), **not** a
+/// runtime `String(localized:)` resolution. A pinned-`ja` resolve was tried
+/// first and returned `"History"`: `locale:` selects the plural/format rule,
+/// not the `.lproj` table, so it read the `en` table — where this key has no
+/// entry of its own, hence the key came back. Same reason
+/// `RecordsCountPluralTests` pins only `en`. See view-testing.md
+/// § "Non-base-locale expectations".
 ///
 /// A failure here is not necessarily a bug: it means the ja label moved, and
 /// whoever moved it must also update the `historyTabLabel` literals in

--- a/Pastura/PasturaTests/Views/SimulationControlsTokenTests.swift
+++ b/Pastura/PasturaTests/Views/SimulationControlsTokenTests.swift
@@ -7,7 +7,8 @@ import Testing
 /// (``SimulationPlayButtonMetrics`` + ``SimulationLeaveSheetTokens``).
 ///
 /// These assertions mirror the source-of-truth constants **by design**
-/// (ADR-009 § "Change-detector tripwire"). The rendered appearance is
+/// (ADR-009 / view-testing.md
+/// § "Change-detector tripwire for code-review-gated tokens"). The rendered appearance is
 /// code-review-gated only; a failure here does NOT mean a bug — it means a
 /// gated visual token drifted in a refactor, and the editor must confirm the
 /// change was intended before updating the expected value.

--- a/Pastura/PasturaTests/Views/ViewerPredictionSheetLayoutTests.swift
+++ b/Pastura/PasturaTests/Views/ViewerPredictionSheetLayoutTests.swift
@@ -8,7 +8,7 @@ import Testing
 /// (typically in an unrelated refactor) and the editor must confirm the change
 /// passed review before updating the expected value. This narrows the
 /// silent-drift window without rendering the View (ADR-009 / view-testing.md
-/// § "Change-detector tripwire").
+/// § "Change-detector tripwire for code-review-gated tokens").
 @Suite(.timeLimit(.minutes(1)))
 struct ViewerPredictionSheetLayoutTests {
   @Test func countdownSecondsIsFifteen() {

--- a/Pastura/PasturaUITests/StoreScreenshotTests.swift
+++ b/Pastura/PasturaUITests/StoreScreenshotTests.swift
@@ -71,8 +71,9 @@ final class StoreScreenshotTests: XCTestCase {
 
   /// Two launches per locale: launch A walks the seeded home/editor/results/
   /// transcript screens; launch B opens the fixed-data scoreboard. Tabs are
-  /// switched by `rootTab.*` identifier (not the localized label) so the walk
-  /// works under ja as well as en.
+  /// switched via `tapTab`, which matches the `rootTab.*` identifier OR the
+  /// locale's label, so the walk works under ja as well as en even on a launch
+  /// where the identifier never bridges.
   private func captureStoreShots(for locale: StoreLocale) {
     let localeArgs = ["-AppleLanguages", "(\(locale.language))", "-AppleLocale", locale.locale]
     let prefix = locale.prefix
@@ -92,8 +93,8 @@ final class StoreScreenshotTests: XCTestCase {
     captureScreenshot(app, name: "\(prefix)-03-editor", anchorId: "editor.titleField")
     popBack(app)
 
-    // 05 Past Results list — the History tab root (id-based switch is
-    // locale-independent).
+    // 05 Past Results list — the History tab root (identifier OR localized
+    // label, so the switch survives a launch that drops the identifier).
     tapTab(app, "rootTab.history", labelFallback: locale.historyTabLabel)
     captureScreenshot(app, name: "\(prefix)-05-results", anchorId: "results.list")
 

--- a/scripts/store-shots.sh
+++ b/scripts/store-shots.sh
@@ -12,9 +12,10 @@
 # UI-test flake class). Output PNGs are gitignored (docs/store/screenshots/);
 # this is the single regeneration path. See docs/store/screenshot-plan.md.
 #
-# A tab-switch failure here is usually NOT this script: structural `Tab` drops
-# the tab icon's a11y identifier on some launches, so a re-run is the fix, not
-# a longer wait. See .claude/rules/uitest-traps.md.
+# A tab-switch failure here is NOT the structural-`Tab` identifier drop —
+# `tapTab`'s label fallback already absorbs that (.claude/rules/uitest-traps.md).
+# It means the localized label literal drifted (StoreCaptureTabLabelTests guards
+# it) or the tab bar never appeared. Do not just re-run.
 #
 # Usage: scripts/store-shots.sh
 # Requires: jq (brew install jq); an available "iPhone 17 Pro Max" simulator.

--- a/scripts/store-shots.sh
+++ b/scripts/store-shots.sh
@@ -12,6 +12,10 @@
 # UI-test flake class). Output PNGs are gitignored (docs/store/screenshots/);
 # this is the single regeneration path. See docs/store/screenshot-plan.md.
 #
+# A tab-switch failure here is usually NOT this script: structural `Tab` drops
+# the tab icon's a11y identifier on some launches, so a re-run is the fix, not
+# a longer wait. See .claude/rules/uitest-traps.md.
+#
 # Usage: scripts/store-shots.sh
 # Requires: jq (brew install jq); an available "iPhone 17 Pro Max" simulator.
 


### PR DESCRIPTION
## Summary

#1271 で出た 2 件の知見を `.claude/rules/` に昇格。イシューが「未解決」としていた置き場所も決めた。

- **候補1（非 base ロケールのランタイム固定）** → `view-testing.md` に新設 § "Non-base-locale expectations"。イシュー案の `i18n.md` から変更した: `i18n.md` は 355 行あり、`paths:` に `PasturaTests/Localization/**` を足すとそこでのルール読み込み量が約 2 倍になる。`view-testing.md` は 59 行で既に `PasturaTests/**` をカバーし、しかも `StoreCaptureTabLabelTests` の doc コメントが既にこのファイルを置き場所として名指ししていた。`i18n.md` にはカタログ側からの 1 行ポインタのみ。
- **候補2（structural `Tab` の a11y ブリッジ）** → 新規 `uitest-traps.md`（`paths: Pastura/PasturaUITests/**`）。`swiftui-traps.md`（357 行）へ `paths:` を広げると UI テスト編集のたびに全部載り、`view-testing.md` は `Views/**` にもスコープされる。

**always-loaded の増分は CLAUDE.md の 1 行のみ**（`uitest-traps.md` の索引行）。他はすべて path-scoped 本文かソースのコメント。

### イシュー本文の事実を probe で訂正した

「非 base ロケールはランタイム固定できない／キーが返る」は**不正確**だった。使い捨ての probe テストを実際に走らせて確定:

| probe | 結果 |
|---|---|
| `locale: ja` + `"%lld records"` n=1 | `1 records` — ja の複数形規則（`other` のみ）で **en テーブル**の値 |
| `locale: en` 同上 | `1 record` |
| `locale: ja` + `"History"` | `History`（`History` は `en` エントリを持たないのでキー == en 値） |
| `bundle.preferredLocalizations` | `["en"]` ← テーブル選択はこちらに従う |
| `ja.lproj` | **バンドルに存在する**（「引き当て失敗」説を棄却） |
| `Bundle(path: …/ja.lproj)` 経由 | `観察履歴` / `1 回の記録` |

→ 正しい機構は「`locale:` は**複数形/書式規則**だけを選び、`.lproj` テーブルはプロセスの解決済みロケールに従う」。**ja のランタイム解決自体は可能**（テーブルにスコープしたバンドルを渡す）。イシューの表現のままルール化していたら、`RecordsCountPluralTests` の `en` pin と矛盾するルールを恒久化していた。

### 到達性のフック

`PasturaUITests/**` だけでは、実際に落ちた `scripts/store-shots.sh` と、問題のモディファイアが居る `RootTabView.tabIcon` の編集者に届かない。両方に 1 行ずつポインタを置いた（always-loaded 増分ゼロ）。ルール本文には「タブ **button** の label 起点クエリ 11 箇所は無傷」という境界も明記 — これが無いと動いているコードの一斉修正を誘発する。

### レビューで判明した派生修正

- 反証済みの機構がソース側に残っていた: `RootTabView.tabIcon` / `accessibilityID(for:)` / `StoreScreenshotTests` の 4 箇所が「identifier を label の**代わりに**使う」と教えていた。`tapTab` は実際には両者を OR している。
- `§ "Change-detector tripwire"` という見出し参照が **5 箇所すべて壊れていた**。ADR-009 にその見出しは無く、ADR-009 自身が `view-testing.md` の `## Change-detector tripwire for code-review-gated tokens` を指している。全箇所を実見出しに揃えた。
- `englishPluralFiresAtRuntime` は「ランナーのロケールに関係なく決定的」と書いていたが偽（ja ランナーなら ja テーブルを引く）。前提を `try #require(bundle.preferredLocalizations.first == "en")` として自己申告させた。

## Test plan

- `PasturaTests/{RecordsCountPluralTests,StoreCaptureTabLabelTests,SimulationControlsTokenTests,ViewerPredictionSheetLayoutTests}` — 全 PASS
- pre-commit ゲート一式が全コミットで green（swiftlint / xcodebuild build / navigation-map drift / detector self-test 17/17 / serialization gate）
- **負のコントロールで検証**: 新しい `#require` を `"ja"` に差し替えて実行し、issue がちょうど 1 件（require のみ、下流の 3 つの `#expect` は未発火）であることを確認 → 「短絡する」というコメントの主張を実証。成功ケースは何も証明しないため
- probe テストは 2 本とも実行後に削除済み（コミットに含まれない）

## Device QA

実機QA不要 — 変更は `.claude/rules/**`・`CLAUDE.md`・コメント文言・シェルスクリプトのヘッダのみで、実行コードの変更はゼロ（唯一のアプリ層ファイル `RootTabView.swift` も doc/インラインコメントのみ）。

Closes #1276
