### PR TITLE
✨ feat: in-app review prompt + Settings Feedback section

### DIFF
--- a/.claude/rules/i18n.md
+++ b/.claude/rules/i18n.md
@@ -154,7 +154,7 @@ failure for another:
 |---|---|---|---|
 | `title: String` + `Text(title)` | `String(localized: "Rate Pastura")` | ✅ auto-tracked | a future caller passing a **raw literal** leaks silently — Tier 1 + Tier 2 are both blind (§ "Why Tier 1 / Tier 2 don't catch this") |
 | `title: LocalizedStringKey` | `"Rate Pastura"` | ❌ key flips to `stale` on **every** `scripts/xcodebuild.sh build` | — |
-| `title: LocalizedStringKey` **+ `extractionState: "manual"`** | `"Rate Pastura"` | ✅ survives (opted out of auto-sync) | a later **rename** of the literal leaves the old key orphaned and the new one absent — and coverage cannot fail on a key that isn't there (same blind spot as § "`#if DEBUG` strings are not auto-extracted") |
+| `title: LocalizedStringKey` **+ `extractionState: "manual"`** | `"Rate Pastura"` | ✅ survives (opted out of auto-sync) | a later **rename** of the literal leaves the old key orphaned and the new one absent — and coverage cannot fail on a key that isn't there (same blind spot as § "`#if DEBUG` strings are not auto-extracted to the catalog") |
 
 Why row 2 fails: `scripts/xcodebuild.sh build` runs a **source-based**
 `xcstringstool extract` with no type information, so it cannot tell that a bare
@@ -163,20 +163,18 @@ literals disappear and marks them `stale`. (Distinct from § "SwiftUI
 convenience-init label trap", which is about SwiftUI's *own* `LocalizedStringKey`
 initializers and interpolation — this one has no interpolation and still fails.)
 
-Row 3 is the § "Plurals" rule-3 escape hatch applied here, and it **does** work —
-don't assume otherwise. Both measured 2026-07-27 on
-`SettingsView.externalLinkRow`: switching the parameter flipped `"Privacy Policy"`
-and `"Rate Pastura"` to `"extractionState" : "stale"`; adding `manual` held them
-across two consecutive builds with `check_localization_coverage.py` green.
+Row 3 is the § "Plurals" rule-3 escape hatch applied here, and it works. Both
+rows measured 2026-07-27 on `SettingsView.externalLinkRow`: switching the
+parameter flipped `"Privacy Policy"` and `"Rate Pastura"` to
+`"extractionState" : "stale"`; adding `manual` held them across two consecutive
+builds with `check_localization_coverage.py` green.
 
 **Apply**: prefer row 1 — keep `String`, keep `String(localized:)` at every
-callsite, and put the contract in the helper's doc comment. Rationale for the
-choice, not a claim that row 3 is broken: row 1's failure needs a future
-contributor to add a caller *and* ignore the contract in the doc comment they
-are reading; row 3's fires on an ordinary copy edit, silently, on keys that
-already ship. Reach for row 3 when the helper's callers are numerous enough that
-the doc comment stops being a credible gate. Canonical:
-`SettingsView+Feedback.swift` `externalLinkRow`.
+callsite, and put the contract in the helper's doc comment. Row 1's failure
+needs a future contributor to add a caller *and* ignore that contract; row 3's
+fires on an ordinary copy rename, silently, on keys that already ship. Reach for
+row 3 once a helper has enough callers that a doc comment stops being a credible
+gate. Canonical: `SettingsView+Feedback.swift` `externalLinkRow`.
 
 ## xcstringstool sync output
 

--- a/.claude/rules/i18n.md
+++ b/.claude/rules/i18n.md
@@ -144,6 +144,34 @@ rg '(Stepper|Toggle|Picker|Slider|Section)\("[^"]*\\\(' --type swift
 Run before any i18n slice that touches Editor / Settings / Form-heavy
 surfaces.
 
+## A custom func's `LocalizedStringKey` parameter is not extracted
+
+Factoring a repeated row/label into a helper raises the question of how to type
+its text parameter. Both answers have a failure mode, and the *safe* one is the
+one that looks weaker:
+
+| Helper signature | Caller | Outcome |
+|---|---|---|
+| `title: String` + `Text(title)` | `String(localized: "Rate Pastura")` | ✅ extracted — but a future caller passing a raw literal leaks silently (Tier 1 + Tier 2 both blind, per § "Why Tier 1 / Tier 2 don't catch this") |
+| `title: LocalizedStringKey` | `"Rate Pastura"` | ❌ key goes **`stale`** on the next build |
+
+The `LocalizedStringKey` form is the instinctive fix and it breaks the catalog:
+`scripts/xcodebuild.sh build` runs a **source-based** `xcstringstool extract`
+with no type information, so it cannot tell that a bare literal at a *custom*
+function's callsite is a localizable key. It sees the literals disappear and
+marks them `stale` — a state Apple keeps for translator reference and the prune
+script later removes. Measured 2026-07-27 on `SettingsView.externalLinkRow`:
+switching the parameter flipped both `"Privacy Policy"` and `"Rate Pastura"` to
+`"extractionState" : "stale"`; reverting cleared it. (Distinct from
+§ "SwiftUI convenience-init label trap", which is about SwiftUI's *own*
+`LocalizedStringKey` initializers and interpolation — this one has no
+interpolation and still fails.)
+
+**Apply**: keep `String`, keep `String(localized:)` at every callsite, and put
+the contract in the helper's doc comment — the residual leak risk is a future
+caller, and a doc comment is the only gate that reaches them. Canonical:
+`SettingsView+Feedback.swift` `externalLinkRow`.
+
 ## xcstringstool sync output
 
 `scripts/xcodebuild.sh build` auto-runs `xcrun xcstringstool sync` against `Localizable.xcstrings`. For **multi-arg** keys, sync generates a catalog entry with the source key plus a positional-form `en` block:

--- a/.claude/rules/i18n.md
+++ b/.claude/rules/i18n.md
@@ -147,29 +147,35 @@ surfaces.
 ## A custom func's `LocalizedStringKey` parameter is not extracted
 
 Factoring a repeated row/label into a helper raises the question of how to type
-its text parameter. Both answers have a failure mode, and the *safe* one is the
-one that looks weaker:
+its text parameter. There is no free answer — each shape trades one silent
+failure for another:
 
-| Helper signature | Caller | Outcome |
-|---|---|---|
-| `title: String` + `Text(title)` | `String(localized: "Rate Pastura")` | ✅ extracted — but a future caller passing a raw literal leaks silently (Tier 1 + Tier 2 both blind, per § "Why Tier 1 / Tier 2 don't catch this") |
-| `title: LocalizedStringKey` | `"Rate Pastura"` | ❌ key goes **`stale`** on the next build |
+| Helper signature | Caller | Extraction | Residual risk |
+|---|---|---|---|
+| `title: String` + `Text(title)` | `String(localized: "Rate Pastura")` | ✅ auto-tracked | a future caller passing a **raw literal** leaks silently — Tier 1 + Tier 2 are both blind (§ "Why Tier 1 / Tier 2 don't catch this") |
+| `title: LocalizedStringKey` | `"Rate Pastura"` | ❌ key flips to `stale` on **every** `scripts/xcodebuild.sh build` | — |
+| `title: LocalizedStringKey` **+ `extractionState: "manual"`** | `"Rate Pastura"` | ✅ survives (opted out of auto-sync) | a later **rename** of the literal leaves the old key orphaned and the new one absent — and coverage cannot fail on a key that isn't there (same blind spot as § "`#if DEBUG` strings are not auto-extracted") |
 
-The `LocalizedStringKey` form is the instinctive fix and it breaks the catalog:
-`scripts/xcodebuild.sh build` runs a **source-based** `xcstringstool extract`
-with no type information, so it cannot tell that a bare literal at a *custom*
-function's callsite is a localizable key. It sees the literals disappear and
-marks them `stale` — a state Apple keeps for translator reference and the prune
-script later removes. Measured 2026-07-27 on `SettingsView.externalLinkRow`:
-switching the parameter flipped both `"Privacy Policy"` and `"Rate Pastura"` to
-`"extractionState" : "stale"`; reverting cleared it. (Distinct from
-§ "SwiftUI convenience-init label trap", which is about SwiftUI's *own*
-`LocalizedStringKey` initializers and interpolation — this one has no
-interpolation and still fails.)
+Why row 2 fails: `scripts/xcodebuild.sh build` runs a **source-based**
+`xcstringstool extract` with no type information, so it cannot tell that a bare
+literal at a *custom* function's callsite is a localizable key. It sees the
+literals disappear and marks them `stale`. (Distinct from § "SwiftUI
+convenience-init label trap", which is about SwiftUI's *own* `LocalizedStringKey`
+initializers and interpolation — this one has no interpolation and still fails.)
 
-**Apply**: keep `String`, keep `String(localized:)` at every callsite, and put
-the contract in the helper's doc comment — the residual leak risk is a future
-caller, and a doc comment is the only gate that reaches them. Canonical:
+Row 3 is the § "Plurals" rule-3 escape hatch applied here, and it **does** work —
+don't assume otherwise. Both measured 2026-07-27 on
+`SettingsView.externalLinkRow`: switching the parameter flipped `"Privacy Policy"`
+and `"Rate Pastura"` to `"extractionState" : "stale"`; adding `manual` held them
+across two consecutive builds with `check_localization_coverage.py` green.
+
+**Apply**: prefer row 1 — keep `String`, keep `String(localized:)` at every
+callsite, and put the contract in the helper's doc comment. Rationale for the
+choice, not a claim that row 3 is broken: row 1's failure needs a future
+contributor to add a caller *and* ignore the contract in the doc comment they
+are reading; row 3's fires on an ordinary copy edit, silently, on keys that
+already ship. Reach for row 3 when the helper's callers are numerous enough that
+the doc comment stops being a credible gate. Canonical:
 `SettingsView+Feedback.swift` `externalLinkRow`.
 
 ## xcstringstool sync output

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -143,6 +143,13 @@ resolves zero matching tests and reports success (0 failures = `TEST SUCCEEDED`)
 This does NOT affect XCTest (`func testXxx()` in `XCTestCase`), which individual
 targeting works correctly for.
 
+**Suite-level still means the TYPE name, not a `@Suite("Display Name")`.**
+`@Suite("SimulationViewCompletionChrome") struct SimulationViewCompletionChromeTests`
+matches only the latter; the display name silently resolves to zero tests and
+still prints `TEST SUCCEEDED`. Confirm the `✔ Test` / `Test run with N tests`
+markers, per `xcodebuild-cli.md` § "\"Executed 0 tests\" in the XCTest stanza is
+cosmetic for Swift-Testing suites".
+
 **Verify:** Always check the test count in the output to confirm tests actually ran.
 
 ## Duplicate Suite Names Silently Halve `-only-testing`

--- a/Pastura/Pastura/App/ReviewRequestCoordinator.swift
+++ b/Pastura/Pastura/App/ReviewRequestCoordinator.swift
@@ -1,0 +1,85 @@
+import Foundation
+import os
+
+/// Drives the App Store review prompt at a completed run's "happy moment"
+/// (#1279): reads the engagement count, applies ``ReviewRequestPolicy``, and
+/// fires the caller-supplied StoreKit request exactly once per app version.
+///
+/// Lives in `App/` because it spans Data (the run count) and UI (the SwiftUI
+/// `requestReview` action); `App/` may depend on everything. The StoreKit
+/// action itself is injected as a closure rather than imported here, so this
+/// type stays free of SwiftUI and the decision path is reachable from a plain
+/// caller.
+///
+/// MainActor-isolated by the `App/` layer default — the injected
+/// `requestReview` action must be invoked on the main actor, and the only DB
+/// read hops off via ``offMain(_:)``.
+enum ReviewRequestCoordinator {
+
+  private static let logger = Logger(
+    subsystem: "app.pastura.Pastura", category: "ReviewRequest")
+
+  /// Requests a review if every ``ReviewRequestPolicy`` condition holds.
+  ///
+  /// Silent no-op otherwise — including on a DB read failure, which must never
+  /// escalate: a missed prompt costs one rating, a thrown error at a run's
+  /// closing moment costs the user's session.
+  ///
+  /// - Parameters:
+  ///   - repository: source of the lifetime completed-run count.
+  ///   - currentRunId: the run that just finished, excluded from the count so
+  ///     the threshold does not depend on whether its `status = 'completed'`
+  ///     write has landed yet. See ``ReviewRequestPolicy/minimumPriorCompletedRuns``.
+  ///   - degradedTurnCount: ADR-021 skip count for the run that just finished.
+  ///   - isUITestMode: injectable for tests; production callers take the
+  ///     default. Under `--ui-test` the harness seeds completed runs, so the
+  ///     threshold is already satisfiable — and a StoreKit modal appearing
+  ///     mid-XCUITest surfaces as an element-query flake rather than a clean
+  ///     failure. Same suppression rationale as `DogMark` /
+  ///     `InFlightSimulationIndicator`. This is deliberately an explicit gate
+  ///     rather than relying on the harness's empty mock queue incidentally
+  ///     tripping the `degradedTurnCount` condition.
+  ///   - requestReview: the StoreKit request to fire on success. StoreKit
+  ///     reports neither whether the dialog appeared nor the user's response,
+  ///     so there is nothing to return.
+  static func requestIfEligible(
+    repository: any SimulationRepository,
+    currentRunId: String?,
+    degradedTurnCount: Int,
+    isUITestMode: Bool = UITestMode.isActive,
+    requestReview: () -> Void
+  ) async {
+    guard !isUITestMode else { return }
+    // Structural, not a duplicate of the policy's own version check: without a
+    // readable version there is nothing to stamp on success.
+    guard let currentVersion = ReviewRequestPolicy.currentVersion else { return }
+
+    let priorCompletedRunCount: Int
+    do {
+      priorCompletedRunCount = try await offMain {
+        try repository.completedRunCount(excludingRunId: currentRunId)
+      }
+    } catch {
+      // `OSLogMessage` is not a String — the interpolation must live in a
+      // single literal, not a `+` concatenation.
+      logger.error(
+        "completedRunCount failed; skipping review prompt: \(String(describing: error), privacy: .public)"
+      )
+      return
+    }
+
+    guard
+      ReviewRequestPolicy.isEligible(
+        priorCompletedRunCount: priorCompletedRunCount,
+        degradedTurnCount: degradedTurnCount,
+        lastRequestedVersion: ReviewRequestPolicy.lastRequestedVersion,
+        currentVersion: currentVersion)
+    else { return }
+
+    // Stamp before firing: StoreKit gives no completion signal, so a stamp
+    // afterwards has no better moment to run and a crash in between would
+    // re-arm the prompt for the same version.
+    ReviewRequestPolicy.markRequested(version: currentVersion)
+    requestReview()
+  }
+}

--- a/Pastura/Pastura/App/ReviewRequestCoordinator.swift
+++ b/Pastura/Pastura/App/ReviewRequestCoordinator.swift
@@ -39,6 +39,11 @@ enum ReviewRequestCoordinator {
   ///     `InFlightSimulationIndicator`. This is deliberately an explicit gate
   ///     rather than relying on the harness's empty mock queue incidentally
   ///     tripping the `degradedTurnCount` condition.
+  ///   - currentVersion: the marketing version to stamp on success. Injectable
+  ///     for tests; production callers take the `Bundle.main` default.
+  ///   - defaults: store backing the version stamp. Injectable so tests drive
+  ///     an isolated `UserDefaults(suiteName:)` rather than the process-wide
+  ///     store.
   ///   - requestReview: the StoreKit request to fire on success. StoreKit
   ///     reports neither whether the dialog appeared nor the user's response,
   ///     so there is nothing to return.
@@ -47,12 +52,16 @@ enum ReviewRequestCoordinator {
     currentRunId: String?,
     degradedTurnCount: Int,
     isUITestMode: Bool = UITestMode.isActive,
+    currentVersion: String? = ReviewRequestPolicy.currentVersion,
+    defaults: UserDefaults = .standard,
     requestReview: () -> Void
   ) async {
     guard !isUITestMode else { return }
-    // Structural, not a duplicate of the policy's own version check: without a
-    // readable version there is nothing to stamp on success.
-    guard let currentVersion = ReviewRequestPolicy.currentVersion else { return }
+    // Structural, not a duplicate of the policy's own version check: we need a
+    // non-nil, non-empty value to stamp on success, and unwrapping it here also
+    // avoids a pointless DB read on the path where the verdict is already
+    // determined. The policy re-checks so it stays correct for any caller.
+    guard let currentVersion, !currentVersion.isEmpty else { return }
 
     let priorCompletedRunCount: Int
     do {
@@ -60,8 +69,6 @@ enum ReviewRequestCoordinator {
         try repository.completedRunCount(excludingRunId: currentRunId)
       }
     } catch {
-      // `OSLogMessage` is not a String — the interpolation must live in a
-      // single literal, not a `+` concatenation.
       logger.error(
         "completedRunCount failed; skipping review prompt: \(String(describing: error), privacy: .public)"
       )
@@ -72,14 +79,14 @@ enum ReviewRequestCoordinator {
       ReviewRequestPolicy.isEligible(
         priorCompletedRunCount: priorCompletedRunCount,
         degradedTurnCount: degradedTurnCount,
-        lastRequestedVersion: ReviewRequestPolicy.lastRequestedVersion,
+        lastRequestedVersion: ReviewRequestPolicy.lastRequestedVersion(defaults: defaults),
         currentVersion: currentVersion)
     else { return }
 
     // Stamp before firing: StoreKit gives no completion signal, so a stamp
     // afterwards has no better moment to run and a crash in between would
     // re-arm the prompt for the same version.
-    ReviewRequestPolicy.markRequested(version: currentVersion)
+    ReviewRequestPolicy.markRequested(version: currentVersion, defaults: defaults)
     requestReview()
   }
 }

--- a/Pastura/Pastura/App/ReviewRequestPolicy.swift
+++ b/Pastura/Pastura/App/ReviewRequestPolicy.swift
@@ -8,11 +8,12 @@ import Foundation
 /// rule 1. The side-effecting half mirrors ``FeatureFlags``' accessor shape
 /// (static key + read accessor + setter, read on demand with no caching).
 ///
-/// `nonisolated` because the decision is called from both a MainActor caller
-/// (``ReviewRequestCoordinator``) and nonisolated test contexts; leaving it on
-/// the `App/` layer's default MainActor isolation would make the conformance
-/// lookup MainActor-bound at nonisolated call sites
-/// (`.claude/rules/swift-isolation.md` Pattern 5).
+/// `nonisolated` because these are plain `static func`s with no actor-bound
+/// state, and under the `App/` layer's default MainActor isolation a
+/// synchronous nonisolated caller — including a non-`@MainActor` test suite —
+/// could not reach them. (This is *not* `.claude/rules/swift-isolation.md`
+/// Pattern 5: that one is about auto-synthesized `Equatable`/`Hashable`
+/// conformance lookup, and this enum declares no conformance.)
 ///
 /// Deliberately **not** a sentiment gate. Routing users to the dialog based on
 /// a "do you like the app?" pre-prompt violates App Store Guideline 5.6.3, so
@@ -70,15 +71,22 @@ nonisolated enum ReviewRequestPolicy {
   // MARK: - Version stamp
 
   /// The app version the prompt was last requested for, or `nil` if never.
-  static var lastRequestedVersion: String? {
-    UserDefaults.standard.string(forKey: lastRequestVersionKey)
+  ///
+  /// - Parameter defaults: injectable so ``ReviewRequestCoordinator``'s tests
+  ///   can drive the stamp through an isolated `UserDefaults(suiteName:)`
+  ///   store instead of the process-wide one. Production callers take the
+  ///   default.
+  static func lastRequestedVersion(defaults: UserDefaults = .standard) -> String? {
+    defaults.string(forKey: lastRequestVersionKey)
   }
 
   /// Records that the prompt was requested for `version`. Called on the
   /// request itself, not on any user response — StoreKit reports neither
   /// whether the dialog actually appeared nor what the user did with it.
-  static func markRequested(version: String) {
-    UserDefaults.standard.set(version, forKey: lastRequestVersionKey)
+  ///
+  /// - Parameter defaults: see ``lastRequestedVersion(defaults:)``.
+  static func markRequested(version: String, defaults: UserDefaults = .standard) {
+    defaults.set(version, forKey: lastRequestVersionKey)
   }
 
   /// The app's marketing version (`CFBundleShortVersionString`, i.e. the

--- a/Pastura/Pastura/App/ReviewRequestPolicy.swift
+++ b/Pastura/Pastura/App/ReviewRequestPolicy.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+/// Eligibility rules for the App Store review prompt (#1279).
+///
+/// Split into a pure decision (``isEligible(priorCompletedRunCount:degradedTurnCount:lastRequestedVersion:currentVersion:)``)
+/// and the `UserDefaults`-backed version stamp, so the decision is unit-testable
+/// without touching process-wide defaults — see `.claude/rules/view-testing.md`
+/// rule 1. The side-effecting half mirrors ``FeatureFlags``' accessor shape
+/// (static key + read accessor + setter, read on demand with no caching).
+///
+/// `nonisolated` because the decision is called from both a MainActor caller
+/// (``ReviewRequestCoordinator``) and nonisolated test contexts; leaving it on
+/// the `App/` layer's default MainActor isolation would make the conformance
+/// lookup MainActor-bound at nonisolated call sites
+/// (`.claude/rules/swift-isolation.md` Pattern 5).
+///
+/// Deliberately **not** a sentiment gate. Routing users to the dialog based on
+/// a "do you like the app?" pre-prompt violates App Store Guideline 5.6.3, so
+/// the engagement thresholds below are the only filter.
+nonisolated enum ReviewRequestPolicy {
+
+  // MARK: - Thresholds
+
+  /// Completed runs required **before** the run that just finished.
+  ///
+  /// Two prior runs means the just-finished run is the user's **third** — the
+  /// engagement bar from #1279. The count deliberately excludes the current
+  /// run because it is not reliably persisted yet at the moment the prompt
+  /// fires: `SimulationViewModel.isCompleted` is set inline in the event loop,
+  /// but the `status = 'completed'` row write happens later in `finalizeRun`,
+  /// behind `await llm.unloadModel()` — tearing down a multi-GB GGUF is not
+  /// bounded by the prompt's short delay. Counting only *prior* runs makes the
+  /// threshold independent of that race, so the prompt lands on run 3 on every
+  /// device rather than run 3 or 4 depending on model size.
+  static let minimumPriorCompletedRuns = 2
+
+  // MARK: - Keys
+
+  private static let lastRequestVersionKey = "lastReviewRequestVersion"
+
+  // MARK: - Decision
+
+  /// Whether the review prompt may be shown for a run that just completed.
+  ///
+  /// All conditions must hold:
+  /// - `priorCompletedRunCount >= ` ``minimumPriorCompletedRuns`` — demonstrated
+  ///   engagement, per Apple's "natural and happy moment" guidance.
+  /// - `degradedTurnCount == 0` — a run with skipped LLM turns (ADR-021) is a
+  ///   negative-signal window; asking for a rating right after visible
+  ///   degradation invites the review the prompt is meant to earn.
+  /// - The current app version has not been asked before. StoreKit's own
+  ///   3-per-365-days throttle is unobservable, so we record *our attempt* and
+  ///   self-limit to once per released version.
+  ///
+  /// - Parameter currentVersion: the app's marketing version. `nil` or empty
+  ///   returns `false` — without a readable version there is nothing to stamp,
+  ///   so proceeding would re-ask on every completed run. Fail closed.
+  static func isEligible(
+    priorCompletedRunCount: Int,
+    degradedTurnCount: Int,
+    lastRequestedVersion: String?,
+    currentVersion: String?
+  ) -> Bool {
+    guard let currentVersion, !currentVersion.isEmpty else { return false }
+    guard priorCompletedRunCount >= minimumPriorCompletedRuns else { return false }
+    guard degradedTurnCount == 0 else { return false }
+    return lastRequestedVersion != currentVersion
+  }
+
+  // MARK: - Version stamp
+
+  /// The app version the prompt was last requested for, or `nil` if never.
+  static var lastRequestedVersion: String? {
+    UserDefaults.standard.string(forKey: lastRequestVersionKey)
+  }
+
+  /// Records that the prompt was requested for `version`. Called on the
+  /// request itself, not on any user response — StoreKit reports neither
+  /// whether the dialog actually appeared nor what the user did with it.
+  static func markRequested(version: String) {
+    UserDefaults.standard.set(version, forKey: lastRequestVersionKey)
+  }
+
+  /// The app's marketing version (`CFBundleShortVersionString`, i.e. the
+  /// `MARKETING_VERSION` build setting) — the granularity at which the prompt
+  /// re-arms. Build number is deliberately not included: a TestFlight build
+  /// bump should not re-open the prompt for the same released version.
+  static var currentVersion: String? {
+    Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+  }
+}

--- a/Pastura/Pastura/Data/SimulationRepository+CompletedCount.swift
+++ b/Pastura/Pastura/Data/SimulationRepository+CompletedCount.swift
@@ -1,0 +1,31 @@
+import Foundation
+import GRDB
+
+// Split out of `SimulationRepository.swift` to keep it under the
+// file_length cap. `nonisolated` on the extension is load-bearing:
+// `GRDBSimulationRepository` is a `nonisolated` Data-layer type, but a
+// plain sibling-file extension inherits the project's default MainActor
+// isolation and would break `nonisolated` callers (see
+// `.claude/rules/swift-isolation.md` Pattern 3).
+nonisolated extension GRDBSimulationRepository {
+  public func completedRunCount(excludingRunId: String?) throws -> Int {
+    try dbWriter.read { db in
+      // COUNT(*) aggregate, computed SQL-side. Deliberately no
+      // `scenarioId IS NOT NULL` predicate (unlike
+      // completedRunCountsByScenarioId()'s GROUP BY) — that predicate only
+      // exists there to drop a null GROUP BY key; here it would silently
+      // under-count orphaned runs (scenarioId NULL, the ON DELETE SET NULL
+      // outcome since v7), which must still count toward this total.
+      if let excludingRunId {
+        return try Int.fetchOne(
+          db,
+          sql: "SELECT COUNT(*) FROM simulations WHERE status = ? AND id <> ?",
+          arguments: [SimulationStatus.completed.rawValue, excludingRunId]) ?? 0
+      }
+      return try Int.fetchOne(
+        db,
+        sql: "SELECT COUNT(*) FROM simulations WHERE status = ?",
+        arguments: [SimulationStatus.completed.rawValue]) ?? 0
+    }
+  }
+}

--- a/Pastura/Pastura/Data/SimulationRepository.swift
+++ b/Pastura/Pastura/Data/SimulationRepository.swift
@@ -68,6 +68,11 @@ nonisolated public protocol SimulationRepository: Sendable {
   /// `COUNT(*)` aggregate. Orphaned runs (`scenarioId` NULL) are included —
   /// unlike ``completedRunCountsByScenarioId()``, this is not scoped per
   /// scenario, so there is no null-key row to drop.
+  ///
+  /// - Parameter excludingRunId: omits the row with this id from the count,
+  ///   whatever its status; `nil` counts every completed run. Callers reading
+  ///   the count *during* a run's teardown pass that run's id, so the total
+  ///   does not depend on whether its terminal status write has landed yet.
   func completedRunCount(excludingRunId: String?) throws -> Int
 
   /// Updates state-related fields (stateJSON, currentRound, currentPhaseIndex)

--- a/Pastura/Pastura/Data/SimulationRepository.swift
+++ b/Pastura/Pastura/Data/SimulationRepository.swift
@@ -64,6 +64,12 @@ nonisolated public protocol SimulationRepository: Sendable {
   /// `scenarioId` and leaves the cross-variant rollup to the consumer.
   func completedRunCountsByScenarioId() throws -> [String: Int]
 
+  /// Returns the number of **completed** runs across all scenarios, as a
+  /// `COUNT(*)` aggregate. Orphaned runs (`scenarioId` NULL) are included —
+  /// unlike ``completedRunCountsByScenarioId()``, this is not scoped per
+  /// scenario, so there is no null-key row to drop.
+  func completedRunCount(excludingRunId: String?) throws -> Int
+
   /// Updates state-related fields (stateJSON, currentRound, currentPhaseIndex)
   /// without touching other columns. Used for pause/resume.
   ///

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -3468,6 +3468,16 @@
         }
       }
     },
+    "Feedback" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フィードバック"
+          }
+        }
+      }
+    },
     "Field name" : {
       "localizations" : {
         "ja" : {
@@ -5466,6 +5476,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "プロンプトをコピーしました！"
+          }
+        }
+      }
+    },
+    "Rate Pastura" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pastura を評価"
           }
         }
       }

--- a/Pastura/Pastura/Utilities/AppStoreLinks.swift
+++ b/Pastura/Pastura/Utilities/AppStoreLinks.swift
@@ -16,7 +16,9 @@ nonisolated enum AppStoreLinks {
 
   /// Opens the product page with the write-a-review sheet pre-presented — the
   /// passive, always-available counterpart to the rate-limited system prompt
-  /// (``ReviewRequestPolicy``). User-initiated, so StoreKit's 3-per-365-days
+  /// in `App/`. (Named in prose, not DocC-linked: `Utilities/` depends on
+  /// nothing, and a symbol link is the shape that invites a real import.)
+  /// User-initiated, so StoreKit's 3-per-365-days
   /// cap does not apply, and it stays the path for users who disabled
   /// in-app rating requests entirely.
   ///

--- a/Pastura/Pastura/Utilities/AppStoreLinks.swift
+++ b/Pastura/Pastura/Utilities/AppStoreLinks.swift
@@ -24,7 +24,6 @@ nonisolated enum AppStoreLinks {
   /// `apps.apple.com` universal link to the App Store app either way, whereas
   /// an unregistered custom scheme makes `openURL` fail **silently** — which
   /// device QA cannot distinguish from a tester simply not noticing.
-  static var writeReview: URL? {
-    URL(string: "https://apps.apple.com/app/id\(appStoreItemID)?action=write-review")
-  }
+  static let writeReview = URL(
+    string: "https://apps.apple.com/app/id\(appStoreItemID)?action=write-review")
 }

--- a/Pastura/Pastura/Utilities/AppStoreLinks.swift
+++ b/Pastura/Pastura/Utilities/AppStoreLinks.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// App Store deep links for Pastura's own product page.
+///
+/// Sibling of ``LocalizedPublicPages`` (which routes pastura.app pages); kept
+/// separate because the App Store product page has no per-locale variant — the
+/// store localizes it from the requesting device.
+nonisolated enum AppStoreLinks {
+
+  /// Pastura's App Store item id, as published on pastura.app.
+  ///
+  /// Mirrored in `web/src/pages/index.astro` (and its `ja` mirror),
+  /// `web/src/pages/404.astro`, and `web/src/components/ScenarioLanding.astro`.
+  /// Those are the store-badge links; this is the in-app one.
+  static let appStoreItemID = "6788409688"
+
+  /// Opens the product page with the write-a-review sheet pre-presented — the
+  /// passive, always-available counterpart to the rate-limited system prompt
+  /// (``ReviewRequestPolicy``). User-initiated, so StoreKit's 3-per-365-days
+  /// cap does not apply, and it stays the path for users who disabled
+  /// in-app rating requests entirely.
+  ///
+  /// `https` rather than the `itms-apps://` variant: iOS routes the
+  /// `apps.apple.com` universal link to the App Store app either way, whereas
+  /// an unregistered custom scheme makes `openURL` fail **silently** — which
+  /// device QA cannot distinguish from a tester simply not noticing.
+  static var writeReview: URL? {
+    URL(string: "https://apps.apple.com/app/id\(appStoreItemID)?action=write-review")
+  }
+}

--- a/Pastura/Pastura/Views/Report/ReportSheet.swift
+++ b/Pastura/Pastura/Views/Report/ReportSheet.swift
@@ -10,7 +10,7 @@ import SwiftUI
 /// - ``migrationFailure(error:)``: presented from the DB recovery screen
 ///   (`PasturaApp` `.databaseRecovery`, #580) with the SQLite migration
 ///   error auto-attached.
-/// - ``general``: pushed from Settings → Legal → "Send a content report".
+/// - ``general``: pushed from Settings → Feedback → "Send a content report".
 enum ReportContext {
   case scenario(GalleryScenario)
   case migrationFailure(error: String)

--- a/Pastura/Pastura/Views/Settings/SettingsView+Feedback.swift
+++ b/Pastura/Pastura/Views/Settings/SettingsView+Feedback.swift
@@ -1,0 +1,83 @@
+import OSLog
+import SwiftUI
+
+// Feedback section (rate the app + content report) and the shared
+// external-link row for `SettingsView` (#1279). Split into this sibling to
+// keep `SettingsView` under the file_length cap. `SettingsView` is a
+// default-MainActor View, so this extension needs no `nonisolated`
+// annotation.
+
+extension SettingsView {
+  /// The two ways a user can tell us something (#1279): rate the app on the
+  /// App Store, or report content.
+  ///
+  /// "Rate Pastura" is the passive, always-available counterpart to the
+  /// rate-limited system prompt fired from `SimulationView` — user-initiated,
+  /// so StoreKit's 3-per-365-days cap does not apply, and it remains reachable
+  /// for users who turned in-app rating requests off.
+  ///
+  /// The content-report row lives here rather than under Legal: reporting is
+  /// feedback, and a discoverability-driven rate row buried in a legal section
+  /// would defeat its own purpose. ADR-005 §6.6's substantive commitment is
+  /// about the Settings *surface* exposing report-mechanism copy (carried by
+  /// `ReportSheet`'s introCopy), not about which section header sits above it.
+  ///
+  /// Not `private`: `private` is file-scoped, and `SettingsView.body` lives in
+  /// the sibling file.
+  var feedbackSection: some View {
+    PasturaSection(String(localized: "Feedback"), style: .grouped) {
+      VStack(spacing: 0) {
+        externalLinkRow(
+          title: String(localized: "Rate Pastura"),
+          url: AppStoreLinks.writeReview,
+          accessibilityIdentifier: "settings.rateAppLink")
+
+        PasturaRowDivider(leadingInset: PasturaCardMetrics.horizontalMargin)
+        Button {
+          isReportSheetPresented = true
+        } label: {
+          PasturaRowLabel(title: String(localized: "Send a content report"))
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("settings.sendContentReportButton")
+      }
+    }
+  }
+
+  /// A row that leaves the app: green `Color.link` text plus the external-link
+  /// glyph, no chevron (Theme D — see the `body` comment).
+  ///
+  /// Uses the `openURL(_:completion:)` overload rather than the fire-and-forget
+  /// form: `openURL` reports nothing on a URL the system cannot route, so a
+  /// broken link would be indistinguishable from a tester not noticing. The
+  /// log line is the only signal such a regression would leave.
+  func externalLinkRow(
+    title: String,
+    url: URL?,
+    accessibilityIdentifier: String
+  ) -> some View {
+    Button {
+      guard let url else { return }
+      openURL(url) { accepted in
+        guard !accepted else { return }
+        Self.linkLogger.error(
+          "openURL declined for \(url.absoluteString, privacy: .public)")
+      }
+    } label: {
+      HStack {
+        Text(title)
+          .foregroundStyle(Color.link)
+        Spacer()
+        Image(systemName: "arrow.up.right.square")
+          .foregroundStyle(Color.link)
+      }
+      .padding(.horizontal, 17)
+      .padding(.vertical, 15)
+      .contentShape(Rectangle())
+    }
+    .accessibilityIdentifier(accessibilityIdentifier)
+  }
+
+  private static let linkLogger = Logger(
+    subsystem: "app.pastura.Pastura", category: "SettingsLinks")
+}

--- a/Pastura/Pastura/Views/Settings/SettingsView+Feedback.swift
+++ b/Pastura/Pastura/Views/Settings/SettingsView+Feedback.swift
@@ -56,10 +56,11 @@ extension SettingsView {
   /// `Text(_:)` as a plain `String`, invisible to both the SwiftLint tripwire
   /// and `check_i18n_potential_keys.py` — a future caller passing a raw literal
   /// leaks untranslated copy with no gate firing. Typing the parameter
-  /// `LocalizedStringKey` looks like the fix and is not: it makes the wrapper's
-  /// source-based `xcstringstool extract` stop seeing the literals and mark the
-  /// keys `stale`. Measured, not assumed — see `.claude/rules/i18n.md`
-  /// § "A custom func's `LocalizedStringKey` parameter is not extracted".
+  /// `LocalizedStringKey` is a real alternative — but it needs
+  /// `extractionState: "manual"` on every key, which trades this leak for a
+  /// silent orphan on the next copy rename. Both measured; the trade-off table
+  /// is `.claude/rules/i18n.md` § "A custom func's `LocalizedStringKey`
+  /// parameter is not extracted". Revisit if this helper gains more callers.
   func externalLinkRow(
     title: String,
     url: URL?,

--- a/Pastura/Pastura/Views/Settings/SettingsView+Feedback.swift
+++ b/Pastura/Pastura/Views/Settings/SettingsView+Feedback.swift
@@ -51,6 +51,15 @@ extension SettingsView {
   /// form: `openURL` reports nothing on a URL the system cannot route, so a
   /// broken link would be indistinguishable from a tester not noticing. The
   /// log line is the only signal such a regression would leave.
+  ///
+  /// ⚠️ **`title` MUST be a `String(localized:)` value.** It renders through
+  /// `Text(_:)` as a plain `String`, invisible to both the SwiftLint tripwire
+  /// and `check_i18n_potential_keys.py` — a future caller passing a raw literal
+  /// leaks untranslated copy with no gate firing. Typing the parameter
+  /// `LocalizedStringKey` looks like the fix and is not: it makes the wrapper's
+  /// source-based `xcstringstool extract` stop seeing the literals and mark the
+  /// keys `stale`. Measured, not assumed — see `.claude/rules/i18n.md`
+  /// § "A custom func's `LocalizedStringKey` parameter is not extracted".
   func externalLinkRow(
     title: String,
     url: URL?,

--- a/Pastura/Pastura/Views/Settings/SettingsView.swift
+++ b/Pastura/Pastura/Views/Settings/SettingsView.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 import os
 
-/// Settings screen hosting the Models section (device only) and a
-/// Legal section with Privacy Policy + content-report sheet.
+/// Settings screen hosting the Models section (device only), a Feedback
+/// section (rate the app + content-report sheet), and a Legal section.
 ///
 /// The Settings tab's root content, mounted in the tab's
 /// `NavigationStack` by `RootTabView` (ADR-016 D4). Per
@@ -26,18 +26,25 @@ import os
 /// `simulationActivityRegistry.isActive == false` at the UI layer so
 /// the service is never torn down mid-inference.
 ///
-/// ## Legal section
+/// ## Feedback section
 ///
-/// Two rows: an external Privacy Policy link (opens Safari via
-/// `Environment(\.openURL)`) and a "Send a content report" Button
-/// that presents `ReportSheet(context: .general)` via the
+/// Two rows: "Rate Pastura" (external App Store write-review link, #1279)
+/// and a "Send a content report" Button that presents
+/// `ReportSheet(context: .general)` via the
 /// `.reportSheet(isPresented:context:)` helper (which applies
 /// `.deepLinkGated()` internally — see navigation.md QA scenario 9).
 /// ADR-005 §6.6 substantive commitment ("Settings surface exposes
 /// report-mechanism copy per §6.4") is preserved by `ReportSheet`'s
-/// introCopy.
+/// introCopy — it binds the surface, not the section header.
+///
+/// ## Legal section
+///
+/// Two rows: an external Privacy Policy link (opens Safari via
+/// `Environment(\.openURL)`) and an in-app "Licenses" sheet.
 struct SettingsView: View {
-  @Environment(\.openURL) private var openURL
+  // Not `private` — read by the `+Feedback.swift` sibling extension's
+  // `externalLinkRow`, and `private` is file-scoped.
+  @Environment(\.openURL) var openURL
 
   /// Opt-in: keep a simulation running (parked in memory) when leaving its
   /// screen, skipping the leave dialog (ADR-017 Phase B, #682). Mirrors the
@@ -51,10 +58,11 @@ struct SettingsView: View {
   @State private var viewerPredictionEnabled = FeatureFlags.viewerPredictionEnabled
 
   /// Bound to `.reportSheet(isPresented:context:)` for the "Send a
-  /// content report" row inside the Legal section. The sheet reuses
+  /// content report" row inside the Feedback section. The sheet reuses
   /// `ReportSheet` with `context: .general` (Settings has no
   /// specific scenario context) — see ADR-005 §6.7 dual-use precedent.
-  @State private var isReportSheetPresented: Bool = false
+  /// Not `private` — written by the `+Feedback.swift` sibling extension.
+  @State var isReportSheetPresented: Bool = false
 
   /// Bound to `.sheet(isPresented:)` for the "Licenses"
   /// row inside the Legal section.
@@ -124,42 +132,22 @@ struct SettingsView: View {
           modelsSection
         #endif
         simulationSection
-        // Theme D — tappable-row language split by destination:
-        // Privacy Policy is the lone external link (opens Safari), so it
-        // keeps the green `Color.link` dialect + the external-link arrow
-        // (no chevron). The report / licenses rows open in-app sheets, so
-        // they adopt the standard in-app row vocabulary (`PasturaRowLabel`:
-        // ink text + trailing chevron) shared with Home / ScenarioDetail /
-        // Results. `Color.link` (design-system §2.8) lands its first real
-        // consumer here; the explicit `Color.link` form (not `.link`)
-        // sidesteps the ShapeStyle-vs-Color token trap.
+        // Theme D — tappable-row language split by destination: rows that
+        // leave the app (Rate Pastura, Privacy Policy) take the green
+        // `Color.link` dialect + external-link arrow and no chevron; rows
+        // opening an in-app sheet (report, licenses) take the standard in-app
+        // vocabulary (`PasturaRowLabel`: ink text + trailing chevron) shared
+        // with Home / ScenarioDetail / Results. The explicit `Color.link` form
+        // (not `.link`) sidesteps the ShapeStyle-vs-Color token trap; the
+        // shared `externalLinkRow` helper keeps the two external rows from
+        // drifting apart.
+        feedbackSection
         PasturaSection(String(localized: "Legal"), style: .grouped) {
           VStack(spacing: 0) {
-            Button {
-              guard let url = LocalizedPublicPages.privacyPolicy() else { return }
-              openURL(url)
-            } label: {
-              HStack {
-                Text(String(localized: "Privacy Policy"))
-                  .foregroundStyle(Color.link)
-                Spacer()
-                Image(systemName: "arrow.up.right.square")
-                  .foregroundStyle(Color.link)
-              }
-              .padding(.horizontal, 17)
-              .padding(.vertical, 15)
-              .contentShape(Rectangle())
-            }
-            .accessibilityIdentifier("settings.privacyPolicyLink")
-
-            PasturaRowDivider(leadingInset: PasturaCardMetrics.horizontalMargin)
-            Button {
-              isReportSheetPresented = true
-            } label: {
-              PasturaRowLabel(title: String(localized: "Send a content report"))
-            }
-            .buttonStyle(.plain)
-            .accessibilityIdentifier("settings.sendContentReportButton")
+            externalLinkRow(
+              title: String(localized: "Privacy Policy"),
+              url: LocalizedPublicPages.privacyPolicy(),
+              accessibilityIdentifier: "settings.privacyPolicyLink")
 
             PasturaRowDivider(leadingInset: PasturaCardMetrics.horizontalMargin)
             Button {

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -4,6 +4,7 @@
 // control bar, scoreboard sheet, export flow, and lifecycle hooks. Log-
 // entry rendering is already split into SimulationView+LogEntries.swift;
 // further extraction would scatter state bindings across files.
+import StoreKit
 import SwiftUI
 import UIKit
 import os
@@ -47,6 +48,10 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
   // not inherit ambient appearance), so capture the current scheme here and
   // pass it in explicitly.
   @Environment(\.colorScheme) private var colorScheme
+  // StoreKit review request, fired at the completed run's happy moment (#1279).
+  // Read here rather than inside `ReviewRequestCoordinator` so the coordinator
+  // stays SwiftUI-free; eligibility lives there, presentation lives here.
+  @Environment(\.requestReview) private var requestReview
   @State private var viewModel: SimulationViewModel?
   /// `true` while the back-button confirm-on-leave dialog is showing (#673).
   @State private var pendingBackLeave = false
@@ -806,6 +811,35 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
     .safeAreaInset(edge: .top, spacing: 0) {
       headerMetaInset(viewModel: viewModel)
     }
+    // App Store review prompt at the run's happy moment (#1279). Body
+    // extracted to keep `simulationContent` under `cyclomatic_complexity`.
+    .task(id: viewModel.isCompletionChromeReady) {
+      await requestReviewAtHappyMoment(viewModel: viewModel)
+    }
+  }
+
+  /// Offers the App Store review prompt once a run's closing chrome has
+  /// settled (#1279). Eligibility itself lives in ``ReviewRequestCoordinator``.
+  ///
+  /// Driven by `.task(id:)` rather than `.onChange` + a free `Task`: SwiftUI
+  /// cancels a `.task` on disappear and on every id change, which covers the
+  /// back / swipe-back pop and the ADR-017 Phase B park-on-hide in one
+  /// construct. A detached task would outlive the view and present a StoreKit
+  /// modal over whatever screen the user moved to.
+  ///
+  /// The delay keeps the dialog off the score reveal itself. The post-sleep
+  /// re-check is not redundant: ``SimulationViewModel/isCompletionChromeReady``
+  /// derives from `latestRowRevealCompleted`, which clears on every commit, so
+  /// a true→false→true sequence is representable within the wait.
+  private func requestReviewAtHappyMoment(viewModel: SimulationViewModel) async {
+    guard viewModel.isCompletionChromeReady else { return }
+    try? await Task.sleep(for: Self.reviewPromptDelay)
+    guard !Task.isCancelled, viewModel.isCompletionChromeReady else { return }
+    await ReviewRequestCoordinator.requestIfEligible(
+      repository: dependencies.simulationRepository,
+      currentRunId: viewModel.simulationId,
+      degradedTurnCount: viewModel.degradedTurnCount,
+      requestReview: { requestReview() })
   }
 
   /// One-shot toast for the first `.languageMismatch` event of the
@@ -1273,6 +1307,12 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
   /// reads as one settle. Code-review-gated timing token (no automated firing
   /// signal); pinned by `SimulationViewCompletionChromeTests`.
   static let sharedFadeDuration: Double = 0.35
+
+  /// Wait between the result card settling and the App Store review prompt
+  /// (#1279), so the system dialog never covers the score reveal it is
+  /// rewarding. Code-review-gated timing token; pinned by
+  /// `SimulationViewCompletionChromeTests`.
+  static let reviewPromptDelay: Duration = .seconds(2)
 
   private func scrollToBottom(_ proxy: ScrollViewProxy) {
     withAnimation {

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -822,24 +822,58 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
   /// settled (#1279). Eligibility itself lives in ``ReviewRequestCoordinator``.
   ///
   /// Driven by `.task(id:)` rather than `.onChange` + a free `Task`: SwiftUI
-  /// cancels a `.task` on disappear and on every id change, which covers the
-  /// back / swipe-back pop and the ADR-017 Phase B park-on-hide in one
-  /// construct. A detached task would outlive the view and present a StoreKit
-  /// modal over whatever screen the user moved to.
+  /// cancels a `.task` on disappear, which covers the back / swipe-back pop,
+  /// the tab switch, and the ADR-017 Phase B park-on-hide. A detached task
+  /// would outlive the view and present a StoreKit modal over whatever screen
+  /// the user moved to.
   ///
-  /// The delay keeps the dialog off the score reveal itself. The post-sleep
-  /// re-check is not redundant: ``SimulationViewModel/isCompletionChromeReady``
-  /// derives from `latestRowRevealCompleted`, which clears on every commit, so
-  /// a true→false→true sequence is representable within the wait.
+  /// **Disappear is not the whole story**, which is why the guards below exist:
+  /// presenting a sheet does NOT disappear the host view, and neither does
+  /// `scenePhase` going to `.background`. Firing into either case is worse than
+  /// not firing at all — the coordinator stamps the version *before* it fires
+  /// (it gets no completion signal from StoreKit), so a presentation the system
+  /// silently drops burns this version's single attempt with nothing shown.
+  /// Hence the explicit `scenePhase` + no-modal-open checks, re-read after the
+  /// sleep rather than before it.
+  ///
+  /// The delay keeps the dialog off the score reveal itself.
+  ///
+  /// ⚠️ ``isAnyModalPresented`` is a hand-maintained enumeration — extend it
+  /// when adding a `.sheet` / `.alert` / `.fullScreenCover` to this view.
   private func requestReviewAtHappyMoment(viewModel: SimulationViewModel) async {
     guard viewModel.isCompletionChromeReady else { return }
     try? await Task.sleep(for: Self.reviewPromptDelay)
-    guard !Task.isCancelled, viewModel.isCompletionChromeReady else { return }
+    guard
+      !Task.isCancelled,
+      viewModel.isCompletionChromeReady,
+      scenePhase == .active,
+      !isAnyModalPresented(viewModel: viewModel)
+    else { return }
     await ReviewRequestCoordinator.requestIfEligible(
       repository: dependencies.simulationRepository,
       currentRunId: viewModel.simulationId,
       degradedTurnCount: viewModel.degradedTurnCount,
       requestReview: { requestReview() })
+  }
+
+  /// Whether anything is currently presented over this view. Enumerated by
+  /// hand — SwiftUI exposes no "is a sheet up?" query — so it must be kept in
+  /// step with the `.sheet` / `.alert` bindings in `body` and
+  /// `simulationContent`. Grep this file for `.sheet(` / `.alert(` /
+  /// `.fullScreenCover(` when auditing it.
+  ///
+  /// Consumed only by ``requestReviewAtHappyMoment(viewModel:)``: an
+  /// obstructed screen is not a moment to ask for a rating, and a dropped
+  /// StoreKit presentation is unrecoverable (see that method's doc).
+  private func isAnyModalPresented(viewModel: SimulationViewModel) -> Bool {
+    exportPayload != nil
+      || exportError != nil
+      || highlightShareItem != nil
+      || highlightShareContext != nil
+      || selectedPersona != nil
+      || showScoreboard
+      || pendingBackLeave
+      || viewModel.predictionPrompt != nil
   }
 
   /// One-shot toast for the first `.languageMismatch` event of the

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -838,8 +838,14 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
   ///
   /// The delay keeps the dialog off the score reveal itself.
   ///
-  /// ⚠️ ``isAnyModalPresented`` is a hand-maintained enumeration — extend it
-  /// when adding a `.sheet` / `.alert` / `.fullScreenCover` to this view.
+  /// A skip here is **terminal for this run**: the `.task` id keys on
+  /// `isCompletionChromeReady`, which does not change again, so there is no
+  /// re-attempt once the guards decline. That is the intended trade — nothing
+  /// was stamped, so a later completed run still gets its chance.
+  ///
+  /// ⚠️ ``isAnyModalPresented(viewModel:)`` is a hand-maintained enumeration.
+  /// Extend it when adding a `.sheet` / `.alert` / `.fullScreenCover` to this
+  /// view; `SimulationViewModalInventoryTests` fails if you forget.
   private func requestReviewAtHappyMoment(viewModel: SimulationViewModel) async {
     guard viewModel.isCompletionChromeReady else { return }
     try? await Task.sleep(for: Self.reviewPromptDelay)
@@ -856,11 +862,18 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
       requestReview: { requestReview() })
   }
 
-  /// Whether anything is currently presented over this view. Enumerated by
-  /// hand — SwiftUI exposes no "is a sheet up?" query — so it must be kept in
-  /// step with the `.sheet` / `.alert` bindings in `body` and
-  /// `simulationContent`. Grep this file for `.sheet(` / `.alert(` /
-  /// `.fullScreenCover(` when auditing it.
+  /// Whether a modal **this view owns** is currently up. Enumerated by hand —
+  /// SwiftUI exposes no "is a sheet up?" query — so it must stay in step with
+  /// the `.sheet` / `.alert` bindings in `body` and `simulationContent`.
+  /// `SimulationViewModalInventoryTests` fails when that drifts.
+  ///
+  /// **Scope, stated honestly**: it does NOT see a modal presented by an
+  /// *ancestor* (the scene-level cellular-consent dialog, DB-recovery, …).
+  /// Those cover the same window and would still be obstructed. Accepted:
+  /// they are scene-lifecycle surfaces that do not plausibly appear during a
+  /// run's closing seconds, and the cheap alternative (a UIKit
+  /// `presentedViewController` probe) asserts a presentation-chain shape this
+  /// change has no way to verify.
   ///
   /// Consumed only by ``requestReviewAtHappyMoment(viewModel:)``: an
   /// obstructed screen is not a moment to ask for a rating, and a dropped

--- a/Pastura/Pastura/Views/Simulation/SimulationView.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView.swift
@@ -838,14 +838,16 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
   ///
   /// The delay keeps the dialog off the score reveal itself.
   ///
-  /// A skip here is **terminal for this run**: the `.task` id keys on
-  /// `isCompletionChromeReady`, which does not change again, so there is no
-  /// re-attempt once the guards decline. That is the intended trade — nothing
-  /// was stamped, so a later completed run still gets its chance.
+  /// A skip here is **terminal for this view instance**: the `.task` id keys on
+  /// `isCompletionChromeReady`, which does not change again for the finished
+  /// run, so there is no re-attempt once the guards decline. That is the
+  /// intended trade — nothing was stamped, so a later completed run still gets
+  /// its chance.
   ///
   /// ⚠️ ``isAnyModalPresented(viewModel:)`` is a hand-maintained enumeration.
   /// Extend it when adding a `.sheet` / `.alert` / `.fullScreenCover` to this
-  /// view; `SimulationViewModalInventoryTests` fails if you forget.
+  /// view; `SimulationViewModalInventoryTests` fails when the modal inventory
+  /// changes.
   private func requestReviewAtHappyMoment(viewModel: SimulationViewModel) async {
     guard viewModel.isCompletionChromeReady else { return }
     try? await Task.sleep(for: Self.reviewPromptDelay)
@@ -865,7 +867,9 @@ struct SimulationView: View {  // swiftlint:disable:this type_body_length
   /// Whether a modal **this view owns** is currently up. Enumerated by hand —
   /// SwiftUI exposes no "is a sheet up?" query — so it must stay in step with
   /// the `.sheet` / `.alert` bindings in `body` and `simulationContent`.
-  /// `SimulationViewModalInventoryTests` fails when that drifts.
+  /// `SimulationViewModalInventoryTests` fails when the inventory's size
+  /// changes — it detects arrival, it cannot check that a new binding was
+  /// actually folded into the predicate below.
   ///
   /// **Scope, stated honestly**: it does NOT see a modal presented by an
   /// *ancestor* (the scene-level cellular-consent dialog, DB-recovery, …).

--- a/Pastura/PasturaTests/App/ResultsViewModelTests+Pagination.swift
+++ b/Pastura/PasturaTests/App/ResultsViewModelTests+Pagination.swift
@@ -368,6 +368,9 @@ private final class GatedSimulationRepository: SimulationRepository, @unchecked 
   func completedRunCountsByScenarioId() throws -> [String: Int] {
     try base.completedRunCountsByScenarioId()
   }
+  func completedRunCount(excludingRunId: String?) throws -> Int {
+    try base.completedRunCount(excludingRunId: excludingRunId)
+  }
   func updateState(
     _ id: String, stateJSON: String, currentRound: Int, currentPhaseIndex: Int
   ) throws {

--- a/Pastura/PasturaTests/App/ReviewRequestCoordinatorTests.swift
+++ b/Pastura/PasturaTests/App/ReviewRequestCoordinatorTests.swift
@@ -1,0 +1,246 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+/// Behaviour tests for the review-prompt coordinator (#1279).
+///
+/// The pure threshold arithmetic is covered by `ReviewRequestPolicyTests`; what
+/// lives *only* here is the risky part — the UI-test suppression gate, the
+/// fail-closed unreadable-version guard, the swallow-on-DB-failure path, and
+/// the stamp-before-fire ordering.
+///
+/// Every test drives an isolated `UserDefaults(suiteName:)` store rather than
+/// `.standard`, so the version stamp never leaks across tests or into the
+/// simulator's app defaults.
+@Suite(.timeLimit(.minutes(1)))
+@MainActor
+struct ReviewRequestCoordinatorTests {
+
+  // MARK: - Suppression gates
+
+  @Test func doesNotFireOrEvenReadTheDatabaseUnderUITestMode() async throws {
+    let env = try makeEnv(priorCompletedRuns: 10)
+
+    let fired = await runCoordinator(env, isUITestMode: true)
+
+    #expect(fired == false)
+    // The gate is meant to short-circuit before any work, not merely to
+    // suppress the dialog.
+    #expect(env.repository.completedRunCountCallCount == 0)
+    #expect(env.stampedVersion == nil)
+  }
+
+  @Test func doesNotFireWhenTheAppVersionIsUnreadable() async throws {
+    for unreadable in [nil, ""] {
+      let env = try makeEnv(priorCompletedRuns: 10)
+
+      let fired = await runCoordinator(env, currentVersion: unreadable)
+
+      #expect(fired == false)
+      #expect(env.repository.completedRunCountCallCount == 0)
+      #expect(env.stampedVersion == nil)
+    }
+  }
+
+  // MARK: - Database failure is swallowed, and must not stamp
+
+  @Test func databaseFailureNeitherFiresNorStamps() async throws {
+    let env = try makeEnv(priorCompletedRuns: 10)
+    env.repository.shouldThrow = true
+
+    let fired = await runCoordinator(env)
+
+    #expect(fired == false)
+    // Stamping on a failed read would silently burn the version's one chance
+    // without ever having shown anything.
+    #expect(env.stampedVersion == nil)
+  }
+
+  // MARK: - The happy path, and its ordering
+
+  @Test func firesAndStampsWhenEligible() async throws {
+    let env = try makeEnv(priorCompletedRuns: 2)
+
+    let fired = await runCoordinator(env, currentVersion: "1.1")
+
+    #expect(fired)
+    #expect(env.stampedVersion == "1.1")
+    #expect(env.repository.completedRunCountCallCount == 1)
+  }
+
+  /// The stamp must be observable *before* `requestReview()` runs — the
+  /// coordinator's stated invariant, so a crash between the two re-arms
+  /// nothing. Probed from inside the request closure rather than after the
+  /// call, which would pass either way.
+  @Test func stampLandsBeforeTheRequestFires() async throws {
+    let env = try makeEnv(priorCompletedRuns: 2)
+    var stampVisibleFromInsideRequest: String?
+
+    await ReviewRequestCoordinator.requestIfEligible(
+      repository: env.repository,
+      currentRunId: "current",
+      degradedTurnCount: 0,
+      isUITestMode: false,
+      currentVersion: "1.1",
+      defaults: env.defaults,
+      requestReview: {
+        stampVisibleFromInsideRequest =
+          ReviewRequestPolicy.lastRequestedVersion(defaults: env.defaults)
+      })
+
+    #expect(stampVisibleFromInsideRequest == "1.1")
+  }
+
+  @Test func doesNotFireASecondTimeForTheSameVersion() async throws {
+    let env = try makeEnv(priorCompletedRuns: 10)
+
+    let first = await runCoordinator(env, currentVersion: "1.1")
+    let second = await runCoordinator(env, currentVersion: "1.1")
+
+    #expect(first)
+    #expect(second == false)
+  }
+
+  @Test func firesAgainAfterAVersionBump() async throws {
+    let env = try makeEnv(priorCompletedRuns: 10)
+
+    _ = await runCoordinator(env, currentVersion: "1.1")
+    let afterBump = await runCoordinator(env, currentVersion: "1.2")
+
+    #expect(afterBump)
+    #expect(env.stampedVersion == "1.2")
+  }
+
+  // MARK: - Threshold + degradation reach the policy
+
+  @Test func doesNotFireBelowTheRunThreshold() async throws {
+    let env = try makeEnv(priorCompletedRuns: 1)
+
+    #expect(await runCoordinator(env) == false)
+    #expect(env.stampedVersion == nil)
+  }
+
+  @Test func doesNotFireAfterADegradedRun() async throws {
+    let env = try makeEnv(priorCompletedRuns: 10)
+
+    #expect(await runCoordinator(env, degradedTurnCount: 1) == false)
+    #expect(env.stampedVersion == nil)
+  }
+
+  /// The run that just finished must not count toward its own threshold — the
+  /// whole reason `excludingRunId:` exists. Asserted as a pass-through so a
+  /// future refactor cannot quietly start counting it.
+  @Test func excludesTheCurrentRunFromTheCount() async throws {
+    let env = try makeEnv(priorCompletedRuns: 2)
+
+    _ = await runCoordinator(env, currentRunId: "the-run-that-just-ended")
+
+    #expect(env.repository.lastExcludedRunId == "the-run-that-just-ended")
+  }
+}
+
+// MARK: - Harness
+
+private struct CoordinatorEnv {
+  let repository: CountingSimulationRepository
+  let defaults: UserDefaults
+  let suiteName: String
+
+  var stampedVersion: String? {
+    ReviewRequestPolicy.lastRequestedVersion(defaults: defaults)
+  }
+}
+
+/// Fresh isolated defaults per call, so no test observes another's stamp.
+/// `removePersistentDomain` clears anything a prior run of the same suite left
+/// behind — `UserDefaults(suiteName:)` persists to disk like any other domain.
+private func makeEnv(priorCompletedRuns: Int) throws -> CoordinatorEnv {
+  let suiteName = "app.pastura.tests.review.\(UUID().uuidString)"
+  let defaults = try #require(UserDefaults(suiteName: suiteName))
+  defaults.removePersistentDomain(forName: suiteName)
+  return CoordinatorEnv(
+    repository: CountingSimulationRepository(completedCount: priorCompletedRuns),
+    defaults: defaults,
+    suiteName: suiteName)
+}
+
+/// Returns whether the review request fired.
+@MainActor
+private func runCoordinator(
+  _ env: CoordinatorEnv,
+  currentRunId: String? = "current",
+  degradedTurnCount: Int = 0,
+  isUITestMode: Bool = false,
+  currentVersion: String? = "1.1"
+) async -> Bool {
+  var fired = false
+  await ReviewRequestCoordinator.requestIfEligible(
+    repository: env.repository,
+    currentRunId: currentRunId,
+    degradedTurnCount: degradedTurnCount,
+    isUITestMode: isUITestMode,
+    currentVersion: currentVersion,
+    defaults: env.defaults,
+    requestReview: { fired = true })
+  return fired
+}
+
+/// Records how the coordinator queried the count, and can fail on demand.
+/// Only `completedRunCount(excludingRunId:)` is exercised; every other
+/// requirement traps, so a future coordinator change that reaches for more
+/// surfaces loudly instead of silently passing.
+private final class CountingSimulationRepository: SimulationRepository, @unchecked Sendable {
+  private let completedCount: Int
+  private let lock = NSLock()
+  private var _callCount = 0
+  // Plain optional, not `String??` — "never called" is already distinguishable
+  // via `completedRunCountCallCount`.
+  private var _lastExcludedRunId: String?
+  var shouldThrow = false
+
+  init(completedCount: Int) {
+    self.completedCount = completedCount
+  }
+
+  var completedRunCountCallCount: Int {
+    lock.withLock { _callCount }
+  }
+
+  var lastExcludedRunId: String? {
+    lock.withLock { _lastExcludedRunId }
+  }
+
+  func completedRunCount(excludingRunId: String?) throws -> Int {
+    lock.withLock {
+      _callCount += 1
+      _lastExcludedRunId = excludingRunId
+    }
+    if shouldThrow { throw DataError.recordNotFound(type: "SimulationRecord", id: "boom") }
+    return completedCount
+  }
+
+  func save(_ record: SimulationRecord) throws { unreachable() }
+  func fetchById(_ id: String) throws -> SimulationRecord? { unreachable() }
+  func fetchByScenarioId(_ scenarioId: String) throws -> [SimulationRecord] { unreachable() }
+  func fetchRecentRunPage(
+    nameQuery: String?, before: SimulationPageCursor?, limit: Int
+  ) throws -> [PastRunListItem] { unreachable() }
+  func fetchRunList(scenarioId: String) throws -> [PastRunListItem] { unreachable() }
+  func fetchOrphaned() throws -> [SimulationRecord] { unreachable() }
+  func fetchByStatus(_ status: SimulationStatus) throws -> [SimulationRecord] { unreachable() }
+  func completedRunCountsByScenarioId() throws -> [String: Int] { unreachable() }
+  func updateState(
+    _ id: String, stateJSON: String, currentRound: Int, currentPhaseIndex: Int
+  ) throws { unreachable() }
+  func updateStatus(_ id: String, status: SimulationStatus) throws { unreachable() }
+  func updateDegradedTurnCount(_ id: String, count: Int) throws { unreachable() }
+  func totalRunCount(nameQuery: String?) throws -> Int { unreachable() }
+  func delete(_ id: String) throws { unreachable() }
+  func deleteAll() throws { unreachable() }
+  func pastResultsByteCount() throws -> Int64 { unreachable() }
+
+  private func unreachable() -> Never {
+    fatalError("ReviewRequestCoordinator must not reach this repository method")
+  }
+}

--- a/Pastura/PasturaTests/App/ReviewRequestCoordinatorTests.swift
+++ b/Pastura/PasturaTests/App/ReviewRequestCoordinatorTests.swift
@@ -208,7 +208,13 @@ private func runCoordinator(
 /// other requirement records an `Issue` and returns something benign rather
 /// than trapping: `fatalError` in a test fake aborts the whole test *process*,
 /// killing unrelated suites and truncating the `.xcresult`. `Issue.record`
-/// fails the offending test, names the method, and lets the run finish.
+/// names the method and lets the run finish.
+///
+/// Deliberately no claim about *which* test the issue attaches to: the
+/// coordinator reaches this fake through `offMain`, i.e. `Task.detached`, which
+/// does not inherit task-locals — and that is how swift-testing resolves the
+/// current test. Unverified either way; the surfacing, not the attribution, is
+/// what this buys.
 private final class CountingSimulationRepository: SimulationRepository, @unchecked Sendable {
   private let completedCount: Int
   // Every mutable field sits behind this lock: `completedRunCount` runs
@@ -250,7 +256,10 @@ private final class CountingSimulationRepository: SimulationRepository, @uncheck
   }
 
   func save(_ record: SimulationRecord) throws { unexpected() }
-  func fetchById(_ id: String) throws -> SimulationRecord? { unexpected(); return nil }
+  func fetchById(_ id: String) throws -> SimulationRecord? {
+    unexpected()
+    return nil
+  }
   func fetchByScenarioId(_ scenarioId: String) throws -> [SimulationRecord] {
     unexpected()
     return []

--- a/Pastura/PasturaTests/App/ReviewRequestCoordinatorTests.swift
+++ b/Pastura/PasturaTests/App/ReviewRequestCoordinatorTests.swift
@@ -52,6 +52,9 @@ struct ReviewRequestCoordinatorTests {
     let fired = await runCoordinator(env)
 
     #expect(fired == false)
+    // Pins that the outcome came from the FAILURE path, not from an earlier
+    // bail-out that never reached the repository at all.
+    #expect(env.repository.completedRunCountCallCount == 1)
     // Stamping on a failed read would silently burn the version's one chance
     // without ever having shown anything.
     #expect(env.stampedVersion == nil)
@@ -142,23 +145,36 @@ struct ReviewRequestCoordinatorTests {
 
 // MARK: - Harness
 
-private struct CoordinatorEnv {
+/// A class, not a struct, so `deinit` removes the persisted preference domain.
+/// `UserDefaults(suiteName:)` is disk-backed like any other domain, so without
+/// teardown every full test run would leave one leaked domain per test in the
+/// host container.
+private final class CoordinatorEnv {
   let repository: CountingSimulationRepository
   let defaults: UserDefaults
-  let suiteName: String
+  private let suiteName: String
+
+  init(repository: CountingSimulationRepository, defaults: UserDefaults, suiteName: String) {
+    self.repository = repository
+    self.defaults = defaults
+    self.suiteName = suiteName
+  }
+
+  deinit {
+    defaults.removePersistentDomain(forName: suiteName)
+  }
 
   var stampedVersion: String? {
     ReviewRequestPolicy.lastRequestedVersion(defaults: defaults)
   }
 }
 
-/// Fresh isolated defaults per call, so no test observes another's stamp.
-/// `removePersistentDomain` clears anything a prior run of the same suite left
-/// behind — `UserDefaults(suiteName:)` persists to disk like any other domain.
+/// Fresh isolated defaults per call, so no test observes another's stamp. The
+/// name embeds a UUID, so the domain starts empty by construction — there is
+/// nothing to clear on the way in, only on the way out (see `deinit`).
 private func makeEnv(priorCompletedRuns: Int) throws -> CoordinatorEnv {
   let suiteName = "app.pastura.tests.review.\(UUID().uuidString)"
   let defaults = try #require(UserDefaults(suiteName: suiteName))
-  defaults.removePersistentDomain(forName: suiteName)
   return CoordinatorEnv(
     repository: CountingSimulationRepository(completedCount: priorCompletedRuns),
     defaults: defaults,
@@ -187,17 +203,24 @@ private func runCoordinator(
 }
 
 /// Records how the coordinator queried the count, and can fail on demand.
-/// Only `completedRunCount(excludingRunId:)` is exercised; every other
-/// requirement traps, so a future coordinator change that reaches for more
-/// surfaces loudly instead of silently passing.
+///
+/// Only `completedRunCount(excludingRunId:)` is expected to be reached. Every
+/// other requirement records an `Issue` and returns something benign rather
+/// than trapping: `fatalError` in a test fake aborts the whole test *process*,
+/// killing unrelated suites and truncating the `.xcresult`. `Issue.record`
+/// fails the offending test, names the method, and lets the run finish.
 private final class CountingSimulationRepository: SimulationRepository, @unchecked Sendable {
   private let completedCount: Int
+  // Every mutable field sits behind this lock: `completedRunCount` runs
+  // off-main (`offMain` is `Task.detached`) while the test drives the fake from
+  // the MainActor, and `@unchecked Sendable` suppresses the diagnostic that
+  // would otherwise catch an unguarded one.
   private let lock = NSLock()
   private var _callCount = 0
   // Plain optional, not `String??` — "never called" is already distinguishable
   // via `completedRunCountCallCount`.
   private var _lastExcludedRunId: String?
-  var shouldThrow = false
+  private var _shouldThrow = false
 
   init(completedCount: Int) {
     self.completedCount = completedCount
@@ -211,36 +234,66 @@ private final class CountingSimulationRepository: SimulationRepository, @uncheck
     lock.withLock { _lastExcludedRunId }
   }
 
+  var shouldThrow: Bool {
+    get { lock.withLock { _shouldThrow } }
+    set { lock.withLock { _shouldThrow = newValue } }
+  }
+
   func completedRunCount(excludingRunId: String?) throws -> Int {
-    lock.withLock {
+    let mustThrow = lock.withLock {
       _callCount += 1
       _lastExcludedRunId = excludingRunId
+      return _shouldThrow
     }
-    if shouldThrow { throw DataError.recordNotFound(type: "SimulationRecord", id: "boom") }
+    if mustThrow { throw DataError.recordNotFound(type: "SimulationRecord", id: "boom") }
     return completedCount
   }
 
-  func save(_ record: SimulationRecord) throws { unreachable() }
-  func fetchById(_ id: String) throws -> SimulationRecord? { unreachable() }
-  func fetchByScenarioId(_ scenarioId: String) throws -> [SimulationRecord] { unreachable() }
+  func save(_ record: SimulationRecord) throws { unexpected() }
+  func fetchById(_ id: String) throws -> SimulationRecord? { unexpected(); return nil }
+  func fetchByScenarioId(_ scenarioId: String) throws -> [SimulationRecord] {
+    unexpected()
+    return []
+  }
   func fetchRecentRunPage(
     nameQuery: String?, before: SimulationPageCursor?, limit: Int
-  ) throws -> [PastRunListItem] { unreachable() }
-  func fetchRunList(scenarioId: String) throws -> [PastRunListItem] { unreachable() }
-  func fetchOrphaned() throws -> [SimulationRecord] { unreachable() }
-  func fetchByStatus(_ status: SimulationStatus) throws -> [SimulationRecord] { unreachable() }
-  func completedRunCountsByScenarioId() throws -> [String: Int] { unreachable() }
+  ) throws -> [PastRunListItem] {
+    unexpected()
+    return []
+  }
+  func fetchRunList(scenarioId: String) throws -> [PastRunListItem] {
+    unexpected()
+    return []
+  }
+  func fetchOrphaned() throws -> [SimulationRecord] {
+    unexpected()
+    return []
+  }
+  func fetchByStatus(_ status: SimulationStatus) throws -> [SimulationRecord] {
+    unexpected()
+    return []
+  }
+  func completedRunCountsByScenarioId() throws -> [String: Int] {
+    unexpected()
+    return [:]
+  }
   func updateState(
     _ id: String, stateJSON: String, currentRound: Int, currentPhaseIndex: Int
-  ) throws { unreachable() }
-  func updateStatus(_ id: String, status: SimulationStatus) throws { unreachable() }
-  func updateDegradedTurnCount(_ id: String, count: Int) throws { unreachable() }
-  func totalRunCount(nameQuery: String?) throws -> Int { unreachable() }
-  func delete(_ id: String) throws { unreachable() }
-  func deleteAll() throws { unreachable() }
-  func pastResultsByteCount() throws -> Int64 { unreachable() }
+  ) throws { unexpected() }
+  func updateStatus(_ id: String, status: SimulationStatus) throws { unexpected() }
+  func updateDegradedTurnCount(_ id: String, count: Int) throws { unexpected() }
+  func totalRunCount(nameQuery: String?) throws -> Int {
+    unexpected()
+    return 0
+  }
+  func delete(_ id: String) throws { unexpected() }
+  func deleteAll() throws { unexpected() }
+  func pastResultsByteCount() throws -> Int64 {
+    unexpected()
+    return 0
+  }
 
-  private func unreachable() -> Never {
-    fatalError("ReviewRequestCoordinator must not reach this repository method")
+  private func unexpected(_ method: String = #function) {
+    Issue.record("ReviewRequestCoordinator must not reach \(method)")
   }
 }

--- a/Pastura/PasturaTests/App/ReviewRequestPolicyTests.swift
+++ b/Pastura/PasturaTests/App/ReviewRequestPolicyTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+/// Eligibility tests for the App Store review prompt (#1279).
+///
+/// Scoped to the pure decision function only — the `UserDefaults`-backed
+/// version stamp is process-wide state that would race sibling suites
+/// (`testing.md` § "Splitting a Suite Across Files"), and it is a two-line
+/// accessor pair mirroring ``FeatureFlags``.
+@Suite(.timeLimit(.minutes(1)))
+struct ReviewRequestPolicyTests {
+
+  // MARK: - Threshold semantics
+
+  /// Change-detector for the "prompt on the user's 3rd run" product decision.
+  /// The constant counts runs *before* the one that just finished, so 2 here
+  /// means 3 total. A failure is not a bug — it means the engagement bar moved
+  /// and this expectation (plus the PR/issue rationale) needs updating.
+  @Test func minimumPriorCompletedRunsMeansThirdRun() {
+    #expect(ReviewRequestPolicy.minimumPriorCompletedRuns == 2)
+  }
+
+  @Test func eligibleOnTheThirdRun() {
+    #expect(
+      ReviewRequestPolicy.isEligible(
+        priorCompletedRunCount: 2, degradedTurnCount: 0,
+        lastRequestedVersion: nil, currentVersion: "1.1"))
+  }
+
+  @Test func notEligibleOnTheFirstTwoRuns() {
+    for prior in 0...1 {
+      #expect(
+        !ReviewRequestPolicy.isEligible(
+          priorCompletedRunCount: prior, degradedTurnCount: 0,
+          lastRequestedVersion: nil, currentVersion: "1.1"))
+    }
+  }
+
+  @Test func stillEligibleWellPastTheThreshold() {
+    #expect(
+      ReviewRequestPolicy.isEligible(
+        priorCompletedRunCount: 42, degradedTurnCount: 0,
+        lastRequestedVersion: nil, currentVersion: "1.1"))
+  }
+
+  // MARK: - Degradation gate (ADR-021)
+
+  @Test func notEligibleAfterADegradedRun() {
+    #expect(
+      !ReviewRequestPolicy.isEligible(
+        priorCompletedRunCount: 10, degradedTurnCount: 1,
+        lastRequestedVersion: nil, currentVersion: "1.1"))
+  }
+
+  // MARK: - Once-per-version stamp
+
+  @Test func notEligibleWhenAlreadyRequestedForThisVersion() {
+    #expect(
+      !ReviewRequestPolicy.isEligible(
+        priorCompletedRunCount: 10, degradedTurnCount: 0,
+        lastRequestedVersion: "1.1", currentVersion: "1.1"))
+  }
+
+  @Test func eligibleAgainAfterAVersionBump() {
+    #expect(
+      ReviewRequestPolicy.isEligible(
+        priorCompletedRunCount: 10, degradedTurnCount: 0,
+        lastRequestedVersion: "1.1", currentVersion: "1.2"))
+  }
+
+  // MARK: - Unreadable version fails closed
+
+  /// Without a readable version there is nothing to stamp, so an "eligible"
+  /// verdict would re-ask on every single completed run. Both the `nil` and
+  /// the empty-string shapes must fail closed.
+  @Test func notEligibleWhenCurrentVersionIsUnreadable() {
+    #expect(
+      !ReviewRequestPolicy.isEligible(
+        priorCompletedRunCount: 10, degradedTurnCount: 0,
+        lastRequestedVersion: nil, currentVersion: nil))
+    #expect(
+      !ReviewRequestPolicy.isEligible(
+        priorCompletedRunCount: 10, degradedTurnCount: 0,
+        lastRequestedVersion: nil, currentVersion: ""))
+  }
+}

--- a/Pastura/PasturaTests/App/ReviewRequestPolicyTests.swift
+++ b/Pastura/PasturaTests/App/ReviewRequestPolicyTests.swift
@@ -70,6 +70,26 @@ struct ReviewRequestPolicyTests {
         lastRequestedVersion: "1.1", currentVersion: "1.2"))
   }
 
+  // MARK: - Persisted key
+
+  /// The `UserDefaults` key is a **migration contract**, not an
+  /// implementation detail: renaming it resets the stamp for every existing
+  /// user, so they get asked again on a version they were already asked on.
+  /// Nothing else in the codebase pins the literal — the coordinator's tests
+  /// read back through the same accessor and are agnostic to it.
+  ///
+  /// Uses an isolated store so the assertion never touches `.standard`.
+  @Test func versionStampPersistsUnderItsDocumentedKey() throws {
+    let suiteName = "app.pastura.tests.policy.\(UUID().uuidString)"
+    let defaults = try #require(UserDefaults(suiteName: suiteName))
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+
+    ReviewRequestPolicy.markRequested(version: "1.1", defaults: defaults)
+
+    #expect(defaults.string(forKey: "lastReviewRequestVersion") == "1.1")
+    #expect(ReviewRequestPolicy.lastRequestedVersion(defaults: defaults) == "1.1")
+  }
+
   // MARK: - Unreadable version fails closed
 
   /// Without a readable version there is nothing to stamp, so an "eligible"

--- a/Pastura/PasturaTests/Data/SimulationRepositoryTests+CompletedCount.swift
+++ b/Pastura/PasturaTests/Data/SimulationRepositoryTests+CompletedCount.swift
@@ -1,0 +1,108 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+/// Completed-count tests for
+/// ``SimulationRepository/completedRunCount(excludingRunId:)`` (the in-app
+/// review prompt's engagement threshold). Sibling extension on the same
+/// suite — see `testing.md` § "Splitting a Suite Across Files". Helpers are
+/// file-scope and local (`makeCompletedCountRepos` / `completedCountScenario`
+/// / `completedCountRun`).
+///
+/// Runs are seeded against a **live** scenario except where a test explicitly
+/// exercises the orphan shape, so
+/// ``completedRunCountIncludesOrphanedCompletedRuns`` is a real negative
+/// control: it mixes both populations, and only the orphan half moves if a
+/// `scenarioId IS NOT NULL` predicate is ever copied over from
+/// ``completedRunCountsByScenarioId()``.
+extension SimulationRepositoryTests {
+
+  @Test func completedRunCountReturnsZeroWhenEmpty() throws {
+    let env = try makeCompletedCountRepos()
+    #expect(try env.sims.completedRunCount(excludingRunId: nil) == 0)
+  }
+
+  @Test func completedRunCountCountsOnlyCompletedRuns() throws {
+    let env = try makeCompletedCountRepos()
+    try env.scenarios.save(completedCountScenario(id: "s1"))
+    try env.sims.save(completedCountRun(id: "r1", scenarioId: "s1", status: .completed))
+    try env.sims.save(completedCountRun(id: "r2", scenarioId: "s1", status: .completed))
+    try env.sims.save(completedCountRun(id: "r3", scenarioId: "s1", status: .completed))
+    try env.sims.save(completedCountRun(id: "r4", scenarioId: "s1", status: .paused))
+
+    #expect(try env.sims.completedRunCount(excludingRunId: nil) == 3)
+  }
+
+  @Test func completedRunCountExcludesTheGivenRunId() throws {
+    let env = try makeCompletedCountRepos()
+    try env.scenarios.save(completedCountScenario(id: "s1"))
+    try env.sims.save(completedCountRun(id: "r1", scenarioId: "s1", status: .completed))
+    try env.sims.save(completedCountRun(id: "r2", scenarioId: "s1", status: .completed))
+    try env.sims.save(completedCountRun(id: "r3", scenarioId: "s1", status: .completed))
+
+    #expect(try env.sims.completedRunCount(excludingRunId: "r1") == 2)
+  }
+
+  @Test func completedRunCountExcludingUnmatchedIdLeavesTotalUnchanged() throws {
+    let env = try makeCompletedCountRepos()
+    try env.scenarios.save(completedCountScenario(id: "s1"))
+    try env.sims.save(completedCountRun(id: "r1", scenarioId: "s1", status: .completed))
+    try env.sims.save(completedCountRun(id: "r2", scenarioId: "s1", status: .completed))
+    try env.sims.save(completedCountRun(id: "r3", scenarioId: "s1", status: .completed))
+
+    #expect(try env.sims.completedRunCount(excludingRunId: "no-such-id") == 3)
+  }
+
+  // MARK: - Orphaned-run regression guard
+
+  @Test func completedRunCountIncludesOrphanedCompletedRuns() throws {
+    let env = try makeCompletedCountRepos()
+    try env.scenarios.save(completedCountScenario(id: "s1"))
+    // One live-scenario run + one orphan (scenarioId NULL, the ON DELETE SET
+    // NULL shape since v7). Both must count: `completedRunCount` is a lifetime
+    // total, not a per-scenario aggregate. A `scenarioId IS NOT NULL` predicate
+    // would return 1 here — which is exactly what this mixed population
+    // detects, and what an all-orphan fixture could not distinguish from the
+    // neighbouring tests.
+    try env.sims.save(completedCountRun(id: "r_live", scenarioId: "s1", status: .completed))
+    try env.sims.save(completedCountRun(id: "r_orphan", scenarioId: nil, status: .completed))
+
+    #expect(try env.sims.completedRunCount(excludingRunId: nil) == 2)
+  }
+}
+
+// MARK: - File-scope helpers
+
+private struct CompletedCountRepos {
+  let scenarios: GRDBScenarioRepository
+  let sims: GRDBSimulationRepository
+}
+
+private func makeCompletedCountRepos() throws -> CompletedCountRepos {
+  let manager = try DatabaseManager.inMemory()
+  return CompletedCountRepos(
+    scenarios: GRDBScenarioRepository(dbWriter: manager.dbWriter),
+    sims: GRDBSimulationRepository(dbWriter: manager.dbWriter))
+}
+
+private func completedCountScenario(id: String) -> ScenarioRecord {
+  ScenarioRecord(
+    id: id, name: "Scenario \(id)",
+    yamlDefinition: "id: \(id)\nname: Scenario \(id)\n",
+    isPreset: false, createdAt: Date(), updatedAt: Date())
+}
+
+private func completedCountRun(
+  id: String,
+  scenarioId: String?,
+  status: SimulationStatus
+) -> SimulationRecord {
+  SimulationRecord(
+    id: id, scenarioId: scenarioId,
+    status: status.rawValue,
+    currentRound: 1, currentPhaseIndex: 0,
+    stateJSON: "{}", configJSON: nil,
+    createdAt: Date(), updatedAt: Date(),
+    scenarioNameSnapshot: nil)
+}

--- a/Pastura/PasturaTests/Data/SimulationRepositoryTests+CompletedCount.swift
+++ b/Pastura/PasturaTests/Data/SimulationRepositoryTests+CompletedCount.swift
@@ -18,6 +18,9 @@ import Testing
 /// ``completedRunCountsByScenarioId()``.
 extension SimulationRepositoryTests {
 
+  /// Pins the empty-DB contract (0, not a throw) for the very first launch —
+  /// the state every new user is in. Weak by construction: it also passes
+  /// against a `return 0` stub, so it is a contract pin, not a guard.
   @Test func completedRunCountReturnsZeroWhenEmpty() throws {
     let env = try makeCompletedCountRepos()
     #expect(try env.sims.completedRunCount(excludingRunId: nil) == 0)

--- a/Pastura/PasturaTests/Utilities/AppStoreLinksTests.swift
+++ b/Pastura/PasturaTests/Utilities/AppStoreLinksTests.swift
@@ -51,8 +51,14 @@ struct AppStoreLinksTests {
     let pattern = try Regex(#"apps\.apple\.com/[^"'\s]*?id(\d+)"#)
     var badgeCount = 0
 
-    for case let url as URL in enumerator where url.pathExtension == "astro" {
-      let source = try String(contentsOf: url, encoding: .utf8)
+    // No extension filter: `web/src` also holds `.md` content and `.ts` route
+    // files, and a badge could land in any of them. The regex is the real
+    // predicate, so widening the sweep costs nothing — but the enumerator
+    // yields directories and any binary asset too, and neither reads as UTF-8.
+    // Skipping unreadable entries is safe here precisely because `badgeCount`
+    // below fails the test if the sweep ever stops finding the known badges.
+    for case let url as URL in enumerator where !url.hasDirectoryPath {
+      guard let source = try? String(contentsOf: url, encoding: .utf8) else { continue }
       for match in source.matches(of: pattern) {
         let found = String(source[try #require(match[1].range)])
         #expect(
@@ -63,8 +69,10 @@ struct AppStoreLinksTests {
     }
 
     // Guards the scan itself — a broken path or a changed link shape would
-    // otherwise leave this test vacuously green. Four badges ship today.
-    #expect(badgeCount >= 4, "found only \(badgeCount) store badges — did the scan break?")
+    // otherwise leave this test vacuously green. Counts *occurrences*, not
+    // files: six ship today (index.astro and its ja mirror carry two each,
+    // 404.astro and ScenarioLanding.astro one each).
+    #expect(badgeCount >= 6, "found only \(badgeCount) store badges — did the scan break?")
   }
 
   /// `…/Pastura/PasturaTests/Utilities/<this file>` → four levels up.

--- a/Pastura/PasturaTests/Utilities/AppStoreLinksTests.swift
+++ b/Pastura/PasturaTests/Utilities/AppStoreLinksTests.swift
@@ -37,21 +37,34 @@ struct AppStoreLinksTests {
   /// Repo-relative paths are resolved from `#filePath` (same technique as
   /// `RecordsCountPluralTests` reading the string catalog), since the test
   /// bundle does not carry `web/`.
-  @Test func appStoreItemIDMatchesEveryWebStoreBadge() throws {
-    let mirrors = [
-      "web/src/pages/index.astro",
-      "web/src/pages/ja/index.astro",
-      "web/src/pages/404.astro",
-      "web/src/components/ScenarioLanding.astro"
-    ]
+  ///
+  /// The mirrors are **discovered**, not listed: a hand-list can only catch
+  /// divergence in files it already knows about, and the likelier drift is a
+  /// *new* LP page shipping a badge with a stale id.
+  @Test func everyWebStoreBadgeUsesTheSameAppStoreItemID() throws {
+    let webSource = Self.repoRoot.appending(path: "web/src")
+    let enumerator = try #require(
+      FileManager.default.enumerator(at: webSource, includingPropertiesForKeys: nil))
+    // The LP badges carry a slug (`/app/pastura-local-llms-simulator/id…`)
+    // while the in-app link does not (`/app/id…`), so the path segment between
+    // host and id is optional.
+    let pattern = try Regex(#"apps\.apple\.com/[^"'\s]*?id(\d+)"#)
+    var badgeCount = 0
 
-    for relativePath in mirrors {
-      let url = Self.repoRoot.appending(path: relativePath)
+    for case let url as URL in enumerator where url.pathExtension == "astro" {
       let source = try String(contentsOf: url, encoding: .utf8)
-      #expect(
-        source.contains("id\(AppStoreLinks.appStoreItemID)"),
-        "\(relativePath) does not link id\(AppStoreLinks.appStoreItemID)")
+      for match in source.matches(of: pattern) {
+        let found = String(source[try #require(match[1].range)])
+        #expect(
+          found == AppStoreLinks.appStoreItemID,
+          "\(url.lastPathComponent) links id\(found), expected id\(AppStoreLinks.appStoreItemID)")
+        badgeCount += 1
+      }
     }
+
+    // Guards the scan itself — a broken path or a changed link shape would
+    // otherwise leave this test vacuously green. Four badges ship today.
+    #expect(badgeCount >= 4, "found only \(badgeCount) store badges — did the scan break?")
   }
 
   /// `…/Pastura/PasturaTests/Utilities/<this file>` → four levels up.

--- a/Pastura/PasturaTests/Utilities/AppStoreLinksTests.swift
+++ b/Pastura/PasturaTests/Utilities/AppStoreLinksTests.swift
@@ -28,9 +28,36 @@ struct AppStoreLinksTests {
     #expect(components.queryItems?.first(where: { $0.name == "action" })?.value == "write-review")
   }
 
-  /// Change-detector on the store item id. It is duplicated in the web LP's
-  /// store badges, so a bad edit here would be invisible to those.
-  @Test func appStoreItemIDPinned() {
-    #expect(AppStoreLinks.appStoreItemID == "6788409688")
+  /// The store item id is duplicated across the web LP's App Store badges, and
+  /// a Swift-side edit is invisible to those. This reads the actual `.astro`
+  /// sources and asserts each still carries the Swift constant — an assertion
+  /// against a literal in this file would only re-state the constant and could
+  /// never detect the divergence it claims to guard.
+  ///
+  /// Repo-relative paths are resolved from `#filePath` (same technique as
+  /// `RecordsCountPluralTests` reading the string catalog), since the test
+  /// bundle does not carry `web/`.
+  @Test func appStoreItemIDMatchesEveryWebStoreBadge() throws {
+    let mirrors = [
+      "web/src/pages/index.astro",
+      "web/src/pages/ja/index.astro",
+      "web/src/pages/404.astro",
+      "web/src/components/ScenarioLanding.astro"
+    ]
+
+    for relativePath in mirrors {
+      let url = Self.repoRoot.appending(path: relativePath)
+      let source = try String(contentsOf: url, encoding: .utf8)
+      #expect(
+        source.contains("id\(AppStoreLinks.appStoreItemID)"),
+        "\(relativePath) does not link id\(AppStoreLinks.appStoreItemID)")
+    }
   }
+
+  /// `…/Pastura/PasturaTests/Utilities/<this file>` → four levels up.
+  private static let repoRoot = URL(fileURLWithPath: #filePath)
+    .deletingLastPathComponent()  // Utilities
+    .deletingLastPathComponent()  // PasturaTests
+    .deletingLastPathComponent()  // Pastura
+    .deletingLastPathComponent()  // repo root
 }

--- a/Pastura/PasturaTests/Utilities/AppStoreLinksTests.swift
+++ b/Pastura/PasturaTests/Utilities/AppStoreLinksTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+/// Guards the Settings → Feedback "Rate Pastura" deep link (#1279).
+///
+/// The Settings row calls `openURL`, which **fails silently** on an
+/// unconstructible or unroutable URL — no error, no visible effect. So a
+/// malformed constant would ship undetected; these assertions are the only
+/// automated signal.
+@Suite(.timeLimit(.minutes(1)))
+struct AppStoreLinksTests {
+
+  @Test func writeReviewURLIsConstructible() throws {
+    let url = try #require(AppStoreLinks.writeReview)
+    #expect(url.scheme == "https")
+    #expect(url.host() == "apps.apple.com")
+  }
+
+  @Test func writeReviewURLCarriesTheItemIDAndWriteReviewAction() throws {
+    let url = try #require(AppStoreLinks.writeReview)
+    let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+
+    #expect(components.path == "/app/id\(AppStoreLinks.appStoreItemID)")
+    // The action parameter is what pre-presents the review sheet; without it
+    // the link merely opens the product page.
+    #expect(components.queryItems?.first(where: { $0.name == "action" })?.value == "write-review")
+  }
+
+  /// Change-detector on the store item id. It is duplicated in the web LP's
+  /// store badges, so a bad edit here would be invisible to those.
+  @Test func appStoreItemIDPinned() {
+    #expect(AppStoreLinks.appStoreItemID == "6788409688")
+  }
+}

--- a/Pastura/PasturaTests/Views/SimulationViewCompletionChromeTests.swift
+++ b/Pastura/PasturaTests/Views/SimulationViewCompletionChromeTests.swift
@@ -39,4 +39,12 @@ struct SimulationViewCompletionChromeTests {
     // refactor). Confirm the change passed review, then update the expectation.
     #expect(SimulationView.sharedFadeDuration == 0.35)
   }
+
+  @Test func reviewPromptDelayPinned() {
+    // Same change-detector rationale as above, for the gap between the result
+    // card settling and the App Store review prompt (#1279). The value is
+    // load-bearing product behaviour, not decoration: shrink it toward zero and
+    // the system dialog covers the score reveal it is meant to reward.
+    #expect(SimulationView.reviewPromptDelay == .seconds(2))
+  }
 }

--- a/Pastura/PasturaTests/Views/SimulationViewCompletionChromeTests.swift
+++ b/Pastura/PasturaTests/Views/SimulationViewCompletionChromeTests.swift
@@ -45,6 +45,11 @@ struct SimulationViewCompletionChromeTests {
     // card settling and the App Store review prompt (#1279). The value is
     // load-bearing product behaviour, not decoration: shrink it toward zero and
     // the system dialog covers the score reveal it is meant to reward.
+    //
+    // Limit of the pattern: this pins the VALUE, not the WIRING. Deleting the
+    // `try? await Task.sleep(for: Self.reviewPromptDelay)` in
+    // `requestReviewAtHappyMoment` leaves this green while the behaviour is
+    // gone — that half stays code-review-gated (view-testing.md rule 4).
     #expect(SimulationView.reviewPromptDelay == .seconds(2))
   }
 }

--- a/Pastura/PasturaTests/Views/SimulationViewModalInventoryTests.swift
+++ b/Pastura/PasturaTests/Views/SimulationViewModalInventoryTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+/// Drift gate for `SimulationView.isAnyModalPresented` (#1279).
+///
+/// That predicate is a hand-maintained enumeration of the view's modal
+/// bindings, consumed to suppress the App Store review prompt while the screen
+/// is obstructed. Adding a `.sheet` / `.alert` / `.fullScreenCover` without
+/// extending it silently re-opens the failure it guards — the prompt fires
+/// under a modal, and because the version stamp is written *before* the
+/// request, that build's single attempt is burned with nothing shown.
+///
+/// A doc comment reaches readers; this reaches editors. Source-reading via
+/// `#filePath` follows the same technique as `AppStoreLinksTests` and
+/// `RecordsCountPluralTests`.
+///
+/// **A failure is not a bug.** It means the modal inventory changed: add the
+/// new binding's state to `isAnyModalPresented` (or convince yourself it
+/// cannot obstruct the result card), then update the expected count here.
+@Suite(.timeLimit(.minutes(1)))
+struct SimulationViewModalInventoryTests {
+
+  /// Every modal-presenting modifier across `SimulationView`'s own files.
+  /// Counted, not parsed: the point is to notice the *arrival* of a new one.
+  ///
+  /// Current inventory — 7 presenters mapping to 8 terms in
+  /// `isAnyModalPresented` (`highlightShareSurfaces` mounts two bindings, so
+  /// the two counts legitimately differ): prediction sheet, export share
+  /// sheet, export-failure alert, `highlightShareSurfaces`, leave sheet,
+  /// scoreboard sheet, persona sheet.
+  private static let expectedPresenterCount = 7
+
+  @Test func modalPresenterCountMatchesTheGuardedInventory() throws {
+    let sources = try Self.simulationViewSources()
+
+    let presenters = sources.reduce(into: 0) { total, source in
+      for marker in [".sheet(", ".alert(", ".fullScreenCover(", ".highlightShareSurfaces("] {
+        total += source.components(separatedBy: marker).count - 1
+      }
+    }
+
+    #expect(
+      presenters == Self.expectedPresenterCount,
+      """
+      SimulationView's modal-presenter count changed (\(presenters) vs \
+      \(Self.expectedPresenterCount)). Extend `isAnyModalPresented` to cover the \
+      new binding, then update `expectedPresenterCount`.
+      """)
+  }
+
+  // MARK: - Sources
+
+  /// `SimulationView` is split across siblings; a new presenter could land in
+  /// any of them, so the gate reads all three rather than the main file alone.
+  private static func simulationViewSources() throws -> [String] {
+    let viewsDir = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()  // Views
+      .deletingLastPathComponent()  // PasturaTests
+      .deletingLastPathComponent()  // Pastura
+      .appending(path: "Pastura/Views/Simulation")
+
+    return try [
+      "SimulationView.swift",
+      "SimulationView+LogEntries.swift",
+      "SimulationView+Background.swift"
+    ].map { try String(contentsOf: viewsDir.appending(path: $0), encoding: .utf8) }
+  }
+}

--- a/Pastura/PasturaTests/Views/SimulationViewModalInventoryTests.swift
+++ b/Pastura/PasturaTests/Views/SimulationViewModalInventoryTests.swift
@@ -1,8 +1,6 @@
 import Foundation
 import Testing
 
-@testable import Pastura
-
 /// Drift gate for `SimulationView.isAnyModalPresented` (#1279).
 ///
 /// That predicate is a hand-maintained enumeration of the view's modal


### PR DESCRIPTION
## Summary

Adds the in-app App Store review prompt from #1279, in both halves the issue specifies:

- **Active** — `@Environment(\.requestReview)` fires ~2 s after the simulation result card settles, gated on demonstrated engagement. No sentiment pre-prompt (Guideline 5.6.3).
- **Passive** — a "Rate Pastura" row that deep-links to the write-review sheet. User-initiated, so StoreKit's 3-per-365-days cap does not apply, and it stays reachable for users who turned rating requests off.

Eligibility (all required): ≥ 2 **prior** completed runs (so the run that just finished is the user's 3rd) · `degradedTurnCount == 0` (ADR-021 — don't ask right after visible LLM degradation) · not already asked for this marketing version · not under `--ui-test` · app foregrounded with no modal covering the screen.

### Deviations from the issue, with reasons

| Issue said | Shipped | Why |
|---|---|---|
| Count via `fetchByStatus(.completed)` | New `completedRunCount(excludingRunId:)` `COUNT(*)` aggregate | ADR-015 keeps logs indefinitely, so materializing every record (each with a `stateJSON` blob) to count them grows unbounded. Precedent: `completedRunCountsByScenarioId()`. |
| Lifetime count ≥ 3 | ≥ 2 runs **excluding the current one** | `isCompleted` is set inline in the event loop, but the `status = 'completed'` write lands in `finalizeRun` behind `await llm.unloadModel()`. A plain lifetime count returns N or N+1 depending on device and model size — the prompt would appear on run 3 or run 4. Excluding the current run by id makes it deterministic. |
| Guard against demo replay | No code | Demo replay renders through `ModelDownloadHostView` + `ReplayViewModel`; `SimulationView` has zero references to either. Structurally satisfied. |
| `itms-apps://itunes.apple.com/...` | `https://apps.apple.com/app/id6788409688?action=write-review` | `openURL` fails **silently** on an unregistered scheme, so device QA could not distinguish "wrong scheme" from "tester missed it". The `https` universal link routes to the App Store app either way. |
| "Rate Pastura" under Legal | New **Feedback** section, with the content-report row moved there | A discoverability-driven row buried in a legal section defeats its own purpose. ADR-005 §6.6 binds the Settings *surface*, not the section header; no test or deep link referenced the old placement. |

Two rules-file additions, both measured in this session: `.claude/rules/i18n.md` § "A custom func's `LocalizedStringKey` parameter is not extracted" (a trade-off table produced while resolving a review finding), and a four-line note in `.claude/rules/testing.md` that `-only-testing` needs a suite's **type** name — its `@Suite("Display Name")` silently matches zero tests and still prints `TEST SUCCEEDED`.

## Test plan

- Full unit suite green (3226 → 3255 tests). New: `ReviewRequestPolicyTests` (9), `ReviewRequestCoordinatorTests` (10), `SimulationRepositoryTests+CompletedCount` (5), `AppStoreLinksTests` (3), `SimulationViewModalInventoryTests` (1).
- `PasturaUITests/SimulationFocusModeTests` + `NavigationRegressionTests` green — the former drives a run to completion, so it exercises the new `.task` render path.
- `swiftlint --strict`, `check_localization_coverage.py`, navigation-map drift gate all clean.

**Guards were verified by negative control, not just by passing:**

| Guard | Perturbation | Result |
|---|---|---|
| Orphan-run inclusion in `completedRunCount` | added `scenarioId IS NOT NULL` | only `completedRunCountIncludesOrphanedCompletedRuns` reddened (1 of 51) |
| Web-badge mirror check | diverged the Swift constant | all four mirrors reddened |
| Web-badge non-vacuity floor | deleted one badge | fired at 5 < 6 |
| Modal-inventory drift gate | inserted a probe `.alert` | fired at 8 ≠ 7 |

Three review rounds (2 reviewers × 2, then 1). The last round found the badge floor was `>= 4` when six badges ship — inside the very assertion added to prevent vacuous passes — plus three comments that asserted more than was verified; all fixed in `e7add9e`.

## Device QA

Simulator cannot exercise either surface: there is no App Store app for the deep link, and StoreKit's dialog behaviour differs by build type.

**Read this before starting.** The count is **lifetime** (`SELECT COUNT(*) … WHERE status = 'completed'`, no date or version filter) and `pastura.sqlite` survives app updates — so an **existing user with ≥ 2 completed runs is eligible on their very first completed run after updating**, not their third. That is the intended behaviour (#1279 specifies a lifetime count), and it is also the real launch population. A dev device with run history will therefore prompt on run 1; that is not a bug.

Steps 1–3 need a genuine cold state. **Delete and reinstall the app** — "Clear all results" resets the run count but NOT `lastReviewRequestVersion` (UserDefaults), so it cannot re-arm a prompt that already fired for this version.

0. **Existing-user path (do this first, on a device that already has ≥ 2 completed runs).** Finish one simulation → prompt appears. This is the path most users will take.
1. **Run 1 and 2 complete → no prompt.** After delete + reinstall, finish two simulations; confirm nothing appears after the result card.
2. **Run 3 completes → prompt appears** ~2 s after the result card settles, and does **not** cover the score reveal.
3. **No re-prompt** on run 4 within the same app version.
4. **Degraded run → no prompt.** Force a run with skipped turns (airplane-mode mid-run or a deliberately tiny context) and confirm silence.
5. **Obstructed screen → no prompt.** Right as the result card appears, open the scoreboard or a share sheet; confirm no dialog fires under it, and that a later run still can.
6. **Settings → Feedback → "Rate Pastura"** opens the App Store product page with the review sheet presented. Confirm "Send a content report" still works from its new section.
7. **ja locale**: section header reads 「フィードバック」, row reads 「Pastura を評価」.

Note: the dialog always appears in **debug** builds regardless of throttle, and does **not** reliably appear in TestFlight — absence there is not a bug.

Closes #1279

