### PR TITLE
📝 docs: LLMCaller — empty_field exhaustion returns, not throws

### DIFF
--- a/Pastura/Pastura/Engine/LLMCaller.swift
+++ b/Pastura/Pastura/Engine/LLMCaller.swift
@@ -62,8 +62,10 @@ nonisolated struct LLMCaller: Sendable {
   ///     cause=language_mismatch`), and on exhaustion a
   ///     ``SimulationEvent/languageMismatch(agent:detected:expected:)``
   ///     is emitted and the parsed output is still returned (sim
-  ///     continues — structurally distinct from `parse_failed` /
-  ///     `empty_field` exhaustion which throws).
+  ///     continues — like `empty_field` exhaustion, which also
+  ///     returns the parsed output; structurally distinct from
+  ///     `parse_failed` exhaustion, which throws
+  ///     ``SimulationError/retriesExhausted`` (ADR-021 D7)).
   ///   - expectedLanguage: The scenario's `engineLanguage` per ADR-010
   ///     D5/D6. `nil` skips the adherence check entirely (back-compat
   ///     for callers that pre-date Step E PR2).


### PR DESCRIPTION
## Summary

- Corrects a stale doc-comment on `LLMCaller.call` (the `detector:` parameter note) that wrongly grouped `empty_field` exhaustion with the throwing `parse_failed` path ("structurally distinct from `parse_failed` / `empty_field` exhaustion which throws").
- Per **ADR-021 D7** and the ADR-021 Context table, `empty_field` retry-exhaustion **returns** the parsed output (like `language_mismatch`); only `parse_failed` throws `SimulationError.retriesExhausted`. The **code already matches D7** — this is a comment-only correction, **no behavior change**.
- Surfaced by code-health-audit CH-026. The audit's initial "the code is buggy" framing was corrected on verification against ADR-021 D7 (the plan critic caught it); the doc-comment, not the code, was the stale artifact.

## Test plan

- Comment-only change; the pre-commit hook (`swiftlint --strict` + `xcodebuild build` + sub-gates) passed. No behavior/API change, so no test added.
- Opus `code-reviewer`: **PASS** — verified the new comment against the actual `LLMCaller.call` branches (empty_field returns on exhaustion; parse_failed throws), against ADR-021 D7 + Context table, and that the `` ``SimulationError/retriesExhausted`` `` DocC link resolves. Diff confirmed comment-only.

## Device QA

実機QA不要 — doc-comment only; no runtime, layout, or device-only surface.

Closes #1291. Design residue (whether ADR-021 D7 should be revisited so `empty_field` exhaustion degrades by omission rather than emitting a blank turn) tracked separately in #1290.