### PR TITLE
📝 docs: promote two #1299 findings into the rules

### DIFF
--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -119,4 +119,4 @@ A **why-comment you write** asserts runtime or library behaviour as the reason a
 
 When a check is too expensive to run, say the cause was not isolated. A reader can act on an acknowledged gap; a wrong cause they can only inherit.
 
-Motivating incidents: PR #1152 round-1 review; PR #1299 (all three shapes).
+Motivating incidents: PR #1152 round-1 review; PR #1299 review rounds 1–3.

--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -111,9 +111,12 @@ A 30-second self-check prevents 1–2 extra critic / code-reviewer rounds. Motiv
 
 ### Claims you author are assertions too
 
-A **why-comment you write** asserts runtime or library behaviour as the reason a mechanism exists — the same kind of claim as the table's, but authored at implementation time and executed by nobody. Reviewers check whether the *code* is correct, not whether the *stated reason* is true, so a false one ships and the next reader inherits it as fact. Two shapes, neither expressible as a `Verify by` lookup:
+A **why-comment you write** asserts runtime or library behaviour as the reason a mechanism exists — the same kind of claim as the table's, but authored at implementation *or review-fix* time and executed by nobody. Reviewers check whether the *code* is correct, not whether the *stated reason* is true, so a false one ships and the next reader inherits it as fact. Three shapes, none expressible as a `Verify by` lookup:
 
 - **Why-comment on a mechanism** → delete the mechanism and run the tests. Green means the claim is false, or the tests never covered it.
 - **A detector / guard / gate** → construct the thing it claims to catch and confirm it fires. A guard's success case proves nothing; only a negative control does. Scope it to the claim it defends: a check narrower than that claim (a files-only loop behind a files-and-directories completeness claim), or one that silently skips its exemptions instead of declaring them, passes by construction.
+- **A classification or count built on an earlier claim** → when you fix that claim, grep what cited it. Fixing one authored claim can *invalidate* another you authored earlier, and nothing points back at it; a concessive clause propping up a category ("it belongs here, just differently") is the tell that it already broke.
 
-Motivating incident: PR #1152 round-1 review.
+When a check is too expensive to run, say the cause was not isolated. A reader can act on an acknowledged gap; a wrong cause they can only inherit.
+
+Motivating incidents: PR #1152 round-1 review; PR #1299 (all three shapes).

--- a/.claude/rules/swiftui-traps.md
+++ b/.claude/rules/swiftui-traps.md
@@ -263,7 +263,7 @@ When token-izing `.foregroundStyle(.secondary)`, always switch to `Color.tokenNa
 
 ## Adding a `Color` design token = 5 files; the 5th fails silently (workflow trap, not SwiftUI)
 
-A new color token needs five edits — miss the **5th** (the CSS mirror) and *only* the standalone
+A new color token needs five edits — miss the **5th** (the CSS mirror) and *at best only* the standalone
 `Design tokens drift guard` CI job reddens; build / unit / lint stay green, so it's invisible
 locally (first hit PR #953):
 
@@ -274,7 +274,10 @@ locally (first hit PR #953):
 5. `docs/design/ds/tokens.css` — CSS mirror; the token's CSS form must appear here
 
 `scripts/check_design_tokens_css.py` is the source of truth for the mirror check (hex vs `rgba`
-form, `EXCEPTIONS` exemptions).
+form, `EXCEPTIONS` exemptions) — but it is a **substring match on the hex** over the raw file, so a
+token whose value already appears under another name (`inkOnAccent` #FFFFFF vs `--bubble-bg`) has
+**no automated detector for its step-5 row**: delete that row and the job still exits 0. Steps 1–3
+still guard the token itself. Verify the row by diff (#1299).
 
 **Adding a dark *counterpart* to an existing token is a different, 6th-file shape** — the five
 steps above assume a brand-new value. A dark pair adds: the `night*` raw token (step 1), its

--- a/.claude/rules/swiftui-traps.md
+++ b/.claude/rules/swiftui-traps.md
@@ -276,8 +276,9 @@ locally (first hit PR #953):
 `scripts/check_design_tokens_css.py` is the source of truth for the mirror check (hex vs `rgba`
 form, `EXCEPTIONS` exemptions) — but it is a **substring match on the hex** over the raw file, so a
 token whose value already appears under another name (`inkOnAccent` #FFFFFF vs `--bubble-bg`) has
-**no automated detector for its step-5 row**: delete that row and the job still exits 0. Steps 1–3
-still guard the token itself. Verify the row by diff (#1299).
+**no automated detector for its step-5 row**: delete that row and the job still exits 0. Steps 1–3,
+*when done*, still assert the token's value — but nothing enforces that they were. Verify by diff
+(#1299).
 
 **Adding a dark *counterpart* to an existing token is a different, 6th-file shape** — the five
 steps above assume a brand-new value. A dark pair adds: the `night*` raw token (step 1), its


### PR DESCRIPTION
> ⛔ **Merge `tyabu12/claude-kit#10` first.** The `knowledge-layering.md` half of this PR is a *mirror* of that PR's text, not an origination — this file's header declares its generic core canonical in claude-kit with one-way reconcile (kit → Pastura). If kit#10 is reworded in review or closed unmerged, this copy would assert kit-canonical content that kit never adopted, and nothing automated would catch it (the reconcile is a manual triage-time diff). If you'd rather not wait, ask and I'll split the Pastura-native half out — it has no upstream dependency.

## Summary

Two lessons from #1299 promoted from per-user memory into repo-tracked rules.

### 1. `swiftui-traps.md` — the token workflow's 5th step can have *no* detector

Pastura-native, `paths:`-scoped, no upstream dependency.

The section said missing the CSS-mirror step leaves *only* the `Design tokens drift guard` CI job red. `check_design_tokens_css.py` is a **substring match on the hex over the raw file**, so when a new token's value already appears under another name (`inkOnAccent` #FFFFFF vs the pre-existing `--bubble-bg`), deleting its `tokens.css` row leaves that job green too — the step has no automated detector at all.

Measured by negative control three times: on the #1299 branch, on merged `main`, and again by the reviewer on a scratch copy (who also ran the positive control — stripping *both* `#FFFFFF` rows produces 2 errors, so the check does measure something).

The intro's `*only*` became `*at best only*`, since in this case nothing reddens.

### 2. `knowledge-layering.md` — a third shape of authored claim

**Always-loaded file. Net cost: +3 lines.**

§ "Claims you author are assertions too" covered a why-comment and a detector/guard. It missed the shape where correcting one authored claim silently falsifies a *different* one you authored earlier — a classification, a category, a count — with nothing pointing back at it.

#1299 hit it end to end: a token was bucketed as "fixed in both appearances", which held eight downstream count mirrors at their old value; a later commit fixing an *unrelated* false claim in the same token's doc rewrote it to call the value an open two-option question, which is not "fixed". The bucket lost its premise on the spot and nobody went back. A reviewer found it two rounds later.

The lead also now names **review-fix time**, not only implementation time, as when these claims get authored — the same PR produced a false why-comment while fixing a different review finding.

This half also pulls down the closing paragraph ("When a check is too expensive to run…") that had drifted *out* of this copy — a one-way reconcile from kit, unrelated to the promotion.

## Test plan

Documentation only; no build surface. Verified rather than asserted:

- `check_design_tokens_css.py` comparison read at source (`token.upper() in css_upper` over the whole file), and the negative control re-run on merged `main`.
- `#FFFFFF` confirmed present twice in `tokens.css` (`--bubble-bg` L25, `--ink-on-accent` L35).
- The drift-guard job confirmed the **only** automated consumer of `tokens.css` (`git grep check_design_tokens` → `ci.yml` only; the pre-commit hook does not run it), so "no automated detector" is exact rather than rhetorical.
- `DesignTokensTests.inkOnAccentIsOpaquePureWhite` confirmed to exist, so the claim is scoped to the step-5 row rather than to the token — and further scoped to "when done", since nothing enforces that a token gets a test at all.
- The edited section's lead says "Three shapes, none" and carries exactly three bullets. (An earlier draft of this very change said "Two shapes … neither" while adding a trailer referencing three — i.e. it broke a count inside the paragraph about broken counts. Caught by critic.)
- `knowledge-layering.md`'s new text confirmed byte-faithful to kit#10 modulo line wrapping.

## Known, disclosed divergence

The lead sentence of that section differs from kit's for reasons predating this PR: this copy dropped kit's "The table covers claims you *lean on*." and folded the reference into the following sentence. Left alone rather than normalized — worth converging the next time that line is touched.
