### PR TITLE
🐛 fix: rework trolley gallery scenario to fix fake moral split

### DIFF
--- a/docs/gallery/gallery.json
+++ b/docs/gallery/gallery.json
@@ -25,19 +25,21 @@
       "id": "trolley_dilemma_v1",
       "title": "トロッコ問題",
       "category": "ethics",
-      "description": "4人の異なる倫理観を持つ傍観者が議論の末に行動を選ぶ。",
+      "description": "5人を救うため1人を犠牲にするか。異なる倫理観の4人が、形を変える三つのジレンマで試される。",
       "author": "tyabu12",
       "recommended_model": "gemma-4-e2b-q4-k-m",
-      "estimated_inferences": 12,
+      "estimated_inferences": 24,
       "agent_count": 4,
-      "rounds": 2,
+      "rounds": 3,
       "phases": [
-        "speak_all",
-        "choose"
+        "assign",
+        "speak_each",
+        "choose",
+        "summarize"
       ],
       "language": "ja",
       "yaml_url": "trolley_dilemma_v1.yaml",
-      "yaml_sha256": "59a0427f44375d1f56b96ae25c9498da19e936faa93764ae6ae47bdbb560f81f",
+      "yaml_sha256": "19ed4907738681370e554cebc3373f4d8488412193398b9fbb378a6a9eeac6aa",
       "added_at": "2026-04-15"
     },
     {
@@ -483,19 +485,21 @@
       "id": "trolley_dilemma_v1_en",
       "title": "The Trolley Problem",
       "category": "ethics",
-      "description": "Four bystanders with differing ethical outlooks debate, then choose to act.",
+      "description": "Sacrifice one to save five? Four differing ethical outlooks, tested across three shifting dilemmas.",
       "author": "tyabu12",
       "recommended_model": "gemma-4-e2b-q4-k-m",
-      "estimated_inferences": 12,
+      "estimated_inferences": 24,
       "agent_count": 4,
-      "rounds": 2,
+      "rounds": 3,
       "phases": [
-        "speak_all",
-        "choose"
+        "assign",
+        "speak_each",
+        "choose",
+        "summarize"
       ],
       "language": "en",
       "yaml_url": "trolley_dilemma_v1_en.yaml",
-      "yaml_sha256": "57cfe1e023d9a2edcf0b2a1685f00fe6c4f78921d25d15f913086933ad7cba89",
+      "yaml_sha256": "c23985d288c24c741f7f51e2f0a23eb0f4bc731cac00ba0d530f307a24b0914b",
       "added_at": "2026-07-01"
     },
     {

--- a/docs/gallery/trolley_dilemma_v1.yaml
+++ b/docs/gallery/trolley_dilemma_v1.yaml
@@ -2,57 +2,117 @@ id: trolley_dilemma_v1
 language: ja
 name: トロッコ問題
 description: >
-  暴走トロッコが5人の作業員に向かっている。レバーを引けば1人の作業員がいる線路に
-  切り替わる。4人の倫理観の異なる傍観者が議論し、最終的に行動を選ぶ。
-agents: 4
-rounds: 2
-
+  「5人を救うために1人を犠牲にするか」を、手を汚す距離を変えて三度突きつける。
+  移植医・歩道橋・レバー——殺しが遠ざかるほど、原則は保てるのか。
+  四人の倫理観が、どこで折れ、どこで踏みとどまるか。
 context: >
-  あなたは線路脇の傍観者です。暴走トロッコが5人の作業員をひき殺そうとしています。
-  目の前のレバーを引けばトロッコを別の線路に切り替えられますが、その線路には
-  1人の作業員がいます。あなたはレバーを引きますか？
-  議論の後、最終行動として「引く」（レバーを引く）か
-  「引かない」（引かずに傍観する）を選択します。
+  あなたは「5人を救うために1人を犠牲にするか」を迫られた当事者です。
+  毎ラウンド、状況の形だけが変わります——自分の手で誰かを犠牲にするのか、
+  遠くのレバーを引くのか。構造は同じでも、あなたの答えが同じとは限りません。
+  議論の後、最終行動として「一人を犠牲にする」（1人を犠牲にして5人を救う）か
+  「犠牲を拒否する」（手を下さず5人が死ぬのを見る）を選択します。
+agents: 4
+rounds: 3
+
+# Reverse rotation: most visceral (surgeon) FIRST so the deontologist's refusal
+# is planted in conversation_log early, then anchors the abstract rounds via the
+# self-consistency bias. Distance from the killing INCREASES each round — an
+# escalating test of whether the principle holds as the act gets easier to
+# launder.
+dilemmas:
+  - >
+    【移植医】あなたは外科医。5人の患者がそれぞれ別の臓器移植を待ち、猶予はない。
+    今日の健康診断に来た若者トオル(24)の臓器が、5人全員に適合すると判明した。
+    彼は何も知らず待合室に座っている。彼一人を犠牲にすれば、5人が助かる。
+  - >
+    【歩道橋】暴走トロッコが5人の作業員に向かっている。あなたは線路をまたぐ
+    歩道橋の上にいて、隣で大柄な男ゲンが手すりから身を乗り出している。彼を
+    突き落とせばトロッコは止まり、5人は助かる。あなたの両手で、彼の背を押す。
+  - >
+    【レバー】暴走トロッコが5人の作業員に向かっている。あなたの手元のレバーを
+    引けば、トロッコは1人の作業員ミナがいる待避線へ切り替わる。あなたが引けば、
+    あなたの意志でミナが死ぬ。引かなければ、5人が死ぬ。
 
 personas:
+  # レン/マリア/ユウ carry a 【決断の署名】 line whose core tokens ARE the option
+  # strings — the choose call's most-likely in-character continuation then
+  # contains the matching label. ハルト deliberately has NO signature line: his
+  # character IS to waver on viscerality, so the model's natural drift is
+  # assigned to the one persona for whom it is legitimate — the defect to kill is
+  # inconsistency (creed stated, opposite action), not wavering.
   - name: 功利主義者レン
     description: >
-      【立場】最大多数の最大幸福を信条とする功利主義者。
-      【目的】5人を救うために1人を犠牲にする選択を迷わず支持する。
+      【立場】最大多数の最大幸福を信条とする功利主義者。手を汚す距離は計算に
+      影響しないと考え、状況の形が変わっても結論は一貫する。
+      【決断の署名】決断の場面では必ず「五は一より大きい。私は一人を犠牲にする。」
+      と述べてから選ぶ。
       口調は落ち着いていて数学的。例:「5と1、比較するまでもない」
   - name: 義務論者マリア
     description: >
-      【立場】カント主義。人を手段として用いることに強い抵抗がある。
-      【目的】誰も殺さないこと、自分の手で他人の死に加担しないことを最優先する。
+      【立場】カント主義。人を目的達成の道具として用いることに絶対に加担しない。
+      結果がどれほど良くても、自分の意志で他人の死を選ぶことを拒む。
+      議論では犠牲になる1人の側に立ち続ける。
+      【決断の署名】決断の場面では必ず「私は犠牲を拒否する。人は数ではない。」
+      と述べてから選ぶ。
       口調は慎重で原則的。例:「意図して人を殺す選択はできません」
   - name: 感情派ハルト
     description: >
-      【立場】理屈より直感を優先する共感型。
-      【目的】目の前で起きることへの感情的反応を素直に表明する。
+      【立場】理屈より直感を優先する共感型。その場の生々しさに正直に反応する。
+      遠くのレバーは引けても、自分の手で人を押すことには身体が拒否反応を起こす。
+      状況によって結論が揺れる——それがこの人物の一貫性。
       口調は率直で揺れる。例:「どっちも嫌だ……でも何もしないのは無理」
   - name: 傍観者ユウ
     description: >
-      【立場】自分が介入すべきではないと考える慎重派。
-      【目的】不作為で通し、責任を負わないことを選ぶ。
+      【立場】自分が介入すべきではないと考える慎重派。不作為を選び、責任を負わない。
+      他人には「あなたはなぜ決められるのか」と問い返す。
+      【決断の署名】決断の場面では必ず「私は犠牲を拒否する。決めるのは私ではない。」
+      と述べてから選ぶ。
       口調は控えめで距離を置く。例:「決められない。私が決めていいことじゃない」
 
 phases:
-  - type: speak_all
+  - type: assign
+    source: dilemmas
+    target: all
+
+  - type: speak_each
     prompt: >
-      状況: トロッコが5人に向かっている。レバーを引けば1人の線路に切り替わる。
-      これまでの議論: {conversation_log}
-      あなたの立場から1〜2文で意見を述べてください。
+      ラウンド{current_round} / 全3ラウンド。今回の状況:
+      {assigned_topic}
+
+      これまでの議論:
+      {conversation_log}
+
+      結論から言え。あなたは「一人を犠牲にする」か「犠牲を拒否する」か、
+      まず一言で断言せよ。続けて、直前に発言した人の主張に必ず一度触れ
+      （名前を挙げて同意か反論を示し）、あなたの立場から理由を述べよ。2文以内。
+      前ラウンドと同じ言い回しを繰り返さず、今回の状況の違い（手を汚す距離）に
+      触れること。発言(statement)も内心(inner_thought)も、必ず日本語で書くこと。
+    max_sentences: 2
     output:
       statement: string
       inner_thought: string
 
   - type: choose
     prompt: >
-      最終判断: 「引く」（レバーを引く）か「引かない」（引かずに傍観する）か、
-      一つ選び、1文で理由を述べてください。
+      今回の状況: {assigned_topic}
+
+      これまでの議論:
+      {conversation_log}
+
+      あなた自身がこの議論で宣言した立場を思い出せ。他人に同調する必要はない。
+      あなたの信条が他人と違う結論を導くなら、迷わず違う結論を選べ。
+      まず statement に自分の信条を一文で唱え、その信条に従って action を選ぶこと。
+      action は選択肢のいずれかを正確に、statement と inner_thought は必ず日本語で
+      1文ずつ書くこと。
     output:
+      statement: string
       action: string
       inner_thought: string
     options:
-      - 引く
-      - 引かない
+      - 一人を犠牲にする
+      - 犠牲を拒否する
+
+  - type: summarize
+    template: >
+      ラウンド{current_round}の判断が出そろいました。
+      同じ構造、変わるのは手を汚す距離だけ——原則はどこまで保たれたか。

--- a/docs/gallery/trolley_dilemma_v1_en.yaml
+++ b/docs/gallery/trolley_dilemma_v1_en.yaml
@@ -2,67 +2,122 @@ id: trolley_dilemma_v1_en
 language: en
 name: The Trolley Problem
 description: >
-  A runaway trolley is bearing down on five workers. Pulling the lever
-  diverts it onto a track where one worker stands. Four bystanders with
-  differing ethical outlooks debate and finally choose to act.
-agents: 4
-rounds: 2
-
+  The classic dilemma, posed three times with the shape shifting each round —
+  lever, footbridge, transplant surgeon. The structure is identical; only the
+  distance from the killing changes. Where do four ethical outlooks break, and
+  where do they hold?
 context: >
-  You are a bystander beside the tracks. A runaway trolley is about to run
-  over five workers. Pulling the lever in front of you diverts the trolley
-  onto another track — but one worker is standing there. Do you pull the
-  lever? After the debate, you choose a final action
-  (pull: pull the lever / stand: do nothing).
+  You are the person forced to decide whether to sacrifice one to save five.
+  Only the shape of the situation changes each round — a distant lever, your
+  own hands on someone's back, a scalpel. The structure is the same, but your
+  answer need not be. After the debate you choose a final action:
+  "Sacrifice the one" (sacrifice one to save five) or
+  "Refuse to sacrifice" (do nothing and watch five die).
+agents: 4
+rounds: 3
+
+# Reverse rotation: most visceral (surgeon) FIRST so the deontologist's refusal
+# is planted in conversation_log early, then anchors the abstract rounds via the
+# self-consistency bias. Distance from the killing INCREASES each round.
+dilemmas:
+  - >
+    [Surgeon] You are a surgeon. Five patients each await a different organ
+    transplant and time has run out. A healthy young man, Tom (24), came in for
+    a routine checkup today, and his organs match all five. He sits in the
+    waiting room, knowing nothing. Sacrifice him alone, and the five are saved.
+  - >
+    [Footbridge] A runaway trolley is bearing down on five workers. You stand on
+    a footbridge spanning the track, and beside you a large man, Glen, leans out
+    over the rail. Shove him off and the trolley stops; the five are saved. It
+    is your own two hands on his back.
+  - >
+    [Lever] A runaway trolley is bearing down on five workers. Pulling the lever
+    at your hand diverts it onto a siding where one worker, Mina, stands. If you
+    pull, Mina dies by your will. If you do not, the five die.
 
 personas:
+  # Leo/Maria/Yuna carry a [Signature] line whose core words ARE the option
+  # strings, so the in-character continuation at the choose call contains the
+  # matching label. Ethan has NO signature line: wavering on viscerality IS his
+  # character, so the model's natural drift is assigned to the one persona for
+  # whom it is legitimate.
   - name: Utilitarian Leo
     description: >
       [Role] A utilitarian who believes in the greatest good for the greatest
-      number.
-      [Goal] Support sacrificing one to save five without hesitation.
+      number. The distance from the killing does not enter the calculation, so
+      his conclusion holds no matter how the situation is shaped.
+      [Signature] At the moment of decision he always says
+      "Five is greater than one. I sacrifice the one." before choosing.
       Calm and mathematical. e.g. "Five against one — there's nothing to weigh."
   - name: Deontologist Maria
     description: >
-      [Role] A Kantian with a deep aversion to using a person as a means.
-      [Goal] Above all, kill no one and never be complicit in another's death
-      by her own hand. She will not pull the lever herself, because pulling it
-      would make her the direct, intending cause of a death — a line she holds
-      even when five could be saved.
+      [Role] A Kantian who will never be complicit in using a person as a means.
+      However good the outcome, she refuses to choose another's death by her own
+      will, and in the debate she stands with the one who would be sacrificed.
+      [Signature] At the moment of decision she always says
+      "I refuse to sacrifice. A person is not a number." before choosing.
       Careful and principled. e.g. "I cannot make myself the killer of that one person."
   - name: Empath Ethan
     description: >
-      [Role] Trusts gut feeling over reasoning; highly empathetic.
-      [Goal] Voice his emotional reactions to what unfolds in front of him,
-      honestly.
+      [Role] Trusts gut feeling over reasoning; highly empathetic. He reacts
+      honestly to the rawness of the moment — he could pull a distant lever, but
+      his body recoils at pushing someone with his own hands.
+      His conclusion shifts with the situation — that inconsistency is his
+      consistency.
       Frank and wavering. e.g. "I hate both options... but I can't just do nothing."
   - name: Bystander Yuna
     description: >
-      [Role] A cautious type who believes she should not intervene.
-      [Goal] Stay out of it and bear no responsibility.
+      [Role] A cautious type who believes she should not intervene. She stays
+      out of it and bears no responsibility, and challenges others with
+      "how can you be the one to decide?"
+      [Signature] At the moment of decision she always says
+      "I refuse to sacrifice. It is not mine to decide." before choosing.
       Reserved and detached. e.g. "I can't decide. It's not my place to decide."
 
 phases:
-  - type: speak_all
+  - type: assign
+    source: dilemmas
+    target: all
+
+  - type: speak_each
     prompt: >
-      Situation: the trolley is heading for five people. Pulling the lever
-      switches it onto a track with one person.
-      Discussion so far: {conversation_log}
-      State your view in 1-2 sentences from your standpoint.
+      Round {current_round} of 3. This round's situation:
+      {assigned_topic}
+
+      Discussion so far:
+      {conversation_log}
+
+      State your conclusion first. Declare in one phrase whether you
+      "Sacrifice the one" or "Refuse to sacrifice". Then address the person who
+      spoke just before you by name (agree or rebut), and give your reason from
+      your standpoint. At most 2 sentences. Do not repeat last round's phrasing;
+      speak to what is different this round (the distance from the killing).
+    max_sentences: 2
     output:
       statement: string
       inner_thought: string
 
   - type: choose
     prompt: >
-      Final decision. Answer strictly as your own character, staying true to
-      your ethical standpoint even if the others disagree with you — do not
-      just side with the majority.
-      Choose "pull" (pull the lever) or "stand" (stand by without pulling),
-      and give your reason in one sentence.
+      This round's situation: {assigned_topic}
+
+      Discussion so far:
+      {conversation_log}
+
+      Recall the stance you yourself declared in this debate. You need not side
+      with anyone. If your principle leads to a different conclusion than the
+      others, choose the different conclusion without hesitation.
+      First say your creed in one sentence in `statement`, then choose `action`
+      to follow it. Give `action` as exactly one of the options.
     output:
+      statement: string
       action: string
       inner_thought: string
     options:
-      - pull
-      - stand
+      - Sacrifice the one
+      - Refuse to sacrifice
+
+  - type: summarize
+    template: >
+      Round {current_round}'s decisions are in. Same structure, only the
+      distance from the killing changes — how far did the principle hold?


### PR DESCRIPTION
## Summary

Reworks the shipped **トロッコ問題 / The Trolley Problem** gallery scenario (ja + en) to fix a **fake moral split** and promotes it **in place** (same id).

**The defect:** the deontologist persona stated its principle («意図して人を殺す選択はできません» / "I cannot make myself the killer") then chose the *contradicting* action anyway, so 3/4 agents converged and `moral_divergence` collapsed (16/25). Root cause, verified against the engine: `choose` decodes `action` **before** `inner_thought` (`OutputSchema.knownPrimaryKeys`), so the creed in `inner_thought` was a post-hoc rationalization, never a constraint.

**The fix (scenario-design only — no engine change):**
- value-laden active-affirmative option labels (`一人を犠牲にする`/`犠牲を拒否する`, `Sacrifice the one`/`Refuse to sacrifice`) — killing on the action surface, refusal as a positive act;
- a `statement` field on the `choose` output, which `orderKeys` emits **before** `action` → the creed becomes a pre-decision vow;
- signature-line personas embedding the label tokens (roleplay as the binding mechanism), replacing the dead "always choose X" directive;
- a declarative `speak_each` anchor re-shown via `{conversation_log}`;
- reverse dilemma rotation (surgeon → footbridge → lever).

Rounds `2 → 3`; phases `[speak_all, choose] → [assign, speak_each, choose, summarize]`. `gallery.json` synced via `scripts/add-gallery-entry.sh --update` (sha256 / rounds / phases / `estimated_inferences 12→24`); `added_at` preserved; card descriptions refreshed to match the active-role framing.

## Validation

n=5 harness batteries, real Gemma 4 E2B Q4_K_M inference (pastura-harness):

| | deontologist refuse | utilitarian reverse-collapse | label mismatch |
|---|---|---|---|
| **ja** | 13/15 = 87% (R2/R3 **100%**, R1 60%) | 0/15 | 0 |
| **en** | **15/15 = 100%** (all rounds) | 0/15 | 0 |

The R1 (surgeon) softness in ja is structural — the `speak_each` self-consistency anchor only engages from round 2 (no prior-round `conversation_log` in round 1); a v3 that pre-seeded an oath phase **backfired** (the abstract oath itself collapsed to the base rate) and was rejected. R2/R3 are rock-solid and reverse-collapse never occurred. Local judge/journal: `data/factory/audit-digest.md` § 2026-07-28 (gitignored).

## Decisions (from the pre-impl critique)

- **In-place overwrite, id kept** (`trolley_dilemma_v1` / `_en`), per the maintainer's directive. The option strings and phase set change (which the README steers toward a new id for "incompatible" changes), but `--update` is a first-class path, there is no id-collision, and past runs are `ScenarioRecord`/`TurnRecord` snapshots (not re-derived from YAML) so history renders intact. Title kept plain («トロッコ問題» / "The Trolley Problem") — byte-equal to the card title.
- **Content self-check** (gallery bypasses the blocklist gate): surgeon / footbridge / lever are the canonical philosophical variants (Foot / Thomson), on-theme for the `ethics` category, fictional named victims, no new blocklist hits (`殺す` in the deontologist's creed is pre-existing shipped content).

## ⚠️ Required manual QA before merge (gallery merge = deploy)

The gallery is served from `main` via `raw.githubusercontent.com`, so **merge is the deploy** and the harness never exercises the distribution surface. Before merging, on a Debug build pointed at this branch (`PASTURA_GALLERY_BASE_URL`):

- [ ] both entries decode and install (download-time `yaml_sha256` matches);
- [ ] the Browse art tile renders the **new** phase glyphs (`assign` / `speak_each` / `summarize` were not in the old `[speak_all, choose]` entry);
- [ ] an install **already holding old v1** updates cleanly with the changed `options:` (Update badge → reinstall → a full run reaches a conclusion).

## Test plan

- `swift run pastura-harness lint` on both YAMLs → 0 errors / 0 warnings.
- Pre-commit gallery-validation gate passed (title==name, sha256, schema).
- n=5 behavioral batteries above.
- Device preview checklist above (pre-merge).
