### PR TITLE
🐛 fix: cover StringStateMachine \uXXXX escape path + fix mislabeled test

### DIFF
--- a/Pastura/PasturaTests/LLM/StringStateMachineTests.swift
+++ b/Pastura/PasturaTests/LLM/StringStateMachineTests.swift
@@ -47,9 +47,48 @@ struct StringStateMachineTests {
     #expect(machine.braceBalance == 0)
   }
 
-  @Test func unicodeEscapeIsConsumedAsSingleToken() {
-    // {"a":"é"} — 4 hex digits after \u must not toggle string state.
+  @Test func multibyteCharacterInsideStringDoesNotToggle() {
+    // {"a":"é"} — a literal multibyte UTF-8 char (one Character, no backslash)
+    // inside a string value must not affect quote counting or balance.
+    // NOTE: this input has NO `\u` escape; it exercises multibyte iteration,
+    // not the unicode-escape countdown. The `\u`-escape path is covered by
+    // unicodeEscapeConsumesStructuralHexPositions and
+    // unicodeEscapeAtObjectBoundaryKeepsBalance below.
     let machine = StringStateMachine(#"{"a":"é"}"#)
+    #expect(machine.unescapedQuoteCount == 4)
+    #expect(!machine.hasUnclosedString)
+  }
+
+  @Test func unicodeEscapeConsumesStructuralHexPositions() {
+    // {"a":"\u0{}"end"} — a (malformed) `\u` escape whose 4 consumed
+    // positions are `0`, `{`, `}`, `"`. The `.afterUnicode(remaining:)`
+    // countdown must swallow all four so the structural-looking chars do
+    // NOT toggle string state or move brace balance: the `{`/`}` are not
+    // counted, and the `"` at the 4th hex position does not close the
+    // string (the real closer is the `"` after `end`).
+    //
+    // Regression guard: a countdown that consumes too FEW positions would
+    // let the 4th-position `"` close the string early, leaving an odd
+    // quote count (hasUnclosedString == true) and braceBalance == 1.
+    let machine = StringStateMachine(#"{"a":"\u0{}"end"}"#)
+    #expect(machine.braceBalance == 0)
+    #expect(machine.unescapedQuoteCount == 4)
+    #expect(!machine.hasUnclosedString)
+  }
+
+  @Test func unicodeEscapeAtObjectBoundaryKeepsBalance() {
+    // {"a":"\u00zz"} — a `\u` escape occupying the last content positions
+    // before the closing `"`. `StringStateMachine` models `\uXXXX` as
+    // "consume 4 positions after `\u` without state change" (it does not
+    // validate the 4 chars are hex), so the countdown must swallow exactly
+    // `0`, `0`, `z`, `z` and stop — then the following `"` closes the string
+    // normally.
+    //
+    // Regression guard: a countdown that consumes too MANY positions would
+    // swallow the closing `"`, leaving the string unclosed (odd quote count)
+    // and braceBalance == 1.
+    let machine = StringStateMachine(#"{"a":"\u00zz"}"#)
+    #expect(machine.braceBalance == 0)
     #expect(machine.unescapedQuoteCount == 4)
     #expect(!machine.hasUnclosedString)
   }


### PR DESCRIPTION
Closes #1286

## Summary

`StringStateMachine` models the JSON `\uXXXX` unicode escape (consume 4 positions after `\u` without toggling string/brace/quote state), but no test exercised that path — and the test named for it was mislabeled, feeding false coverage confidence. This adds real `\u`-escape coverage and corrects the mislabel. **Test-only** — no `StringStateMachine.swift` source change (the `\u` handling was already correct; the STOP condition did not fire).

## Acceptance-criteria correspondence

| # | Criterion | How the diff satisfies it | Covering test |
|---|-----------|---------------------------|---------------|
| 1 | New `@Test` feeds a real `\u` escape whose 4 positions include structural chars; asserts escaped `{`/`}` don't affect `braceBalance` (== 0) and string stays closed | `unicodeEscapeConsumesStructuralHexPositions` feeds `#"{"a":"\u0{}"end"}"#` — the 4 consumed positions are `0`, `{`, `}`, `"`; asserts `braceBalance == 0`, `unescapedQuoteCount == 4`, `!hasUnclosedString` | `unicodeEscapeConsumesStructuralHexPositions` |
| 2 | A second case places a `\u` escape at the object boundary; asserts balance/quote-count correct | `unicodeEscapeAtObjectBoundaryKeepsBalance` feeds `#"{"a":"\u00zz"}"#` — escape occupies the last content positions before the closing `"` | `unicodeEscapeAtObjectBoundaryKeepsBalance` |
| 3 | `unicodeEscapeIsConsumedAsSingleToken` no longer misrepresents its input | Renamed → `multibyteCharacterInsideStringDoesNotToggle` with a corrected comment + a NOTE pointing at the two real `\u` tests. Its input (`#"{"a":"é"}"#`) is a literal multibyte char, so the new name is accurate | `multibyteCharacterInsideStringDoesNotToggle` |
| 4 | Targeted suite passes; full suite green | Both confirmed (below) | — |

## Regression-guard design

The two new tests **bracket the `.afterUnicode(remaining:)` countdown in both directions** (each catches one direction of an off-by-one; together they catch both):

- **Test 1** (structural positions) catches *under*-consumption: a countdown swallowing only 3 positions lets the 4th-position `"` close the string early → odd quote count + `braceBalance == 1`.
- **Test 2** (object boundary) catches *over*-consumption: a countdown swallowing 5 positions eats the real closing `"` → string never closes → odd quote count + `braceBalance == 1`.

Mental revert-check confirmed for both (per `.claude/rules/testing.md` § "A regression test must drive the exact unguarded-path input").

## Judgment calls

- **Issue AC1's literal example (`#"{"a":"{}"}"#`) was mangled by `gh`/jq.** The issue was authored with `\uXXXX` sequences that jq's JSON decoder collapsed into literal `{`/`}` when rendering the body. I implemented the *true intent* — escapes whose consumed positions include structural-looking chars — which is what actually exercises the `.afterUnicode` countdown (the literal `{}` form only re-tests the already-covered "braces inside string" case).
- **Test 2 uses `\u00zz` (non-hex positions), not a valid hex escape.** `StringStateMachine` models `\uXXXX` as "consume 4 positions after `\u`" with **no hex validation** (see its doc-comment), so `zz` exercises the boundary contract identically. This also sidesteps a tooling quirk where a valid `\uXXXX` sequence gets decoded before reaching the file. The test comment states this explicitly.
- **Chose "rename" over "repurpose" for AC3.** Since two dedicated `\u` tests are added, renaming the mislabeled test to describe the literal-`é` case it actually exercises is cleaner than repurposing it (keeps the multibyte-iteration coverage it provides).

## Test results

- `scripts/xcodebuild.sh test -only-testing PasturaTests/StringStateMachineTests` → **12/12 passed** (`** TEST SUCCEEDED **`).
- Full unit suite (`-skip-testing:PasturaUITests`) → **3253 tests / 269 suites passed** (`** TEST SUCCEEDED **`).
- Mandatory `code-reviewer` pass → **PASS (0 issues)**; traced the state machine on both inputs and confirmed the regression guards fire.
