### PR TITLE
🐛 fix: guard AssignHandler.assignRandomOne against empty active set

### DIFF
--- a/Pastura/Pastura/Engine/Phases/AssignHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/AssignHandler.swift
@@ -35,6 +35,10 @@ nonisolated struct AssignHandler: PhaseHandler {
   /// rejects mismatched shapes upstream — the `guard` fall-through is a no-op
   /// safety net for scenarios constructed in tests or future code paths that
   /// bypass validation.
+  ///
+  /// Empty `active` (every persona eliminated before this phase) is handled
+  /// as a clean no-op — the `!active.isEmpty` guard prevents an uncatchable
+  /// `Int.random(in: 0..<0)` trap (#1287).
   private func assignRandomOne(
     active: [Persona],
     sourceData: AnyCodableValue?,
@@ -46,6 +50,11 @@ nonisolated struct AssignHandler: PhaseHandler {
     }
 
     guard let topic = topics.randomElement() else { return }
+    // An empty active set means there is no agent to receive the minority
+    // value — return a clean no-op rather than trapping on the uncatchable
+    // `Int.random(in: 0..<0)` precondition failure (#1287). Mirrors the
+    // active-count guards in sibling per-active-agent handlers (WhisperHandler).
+    guard !active.isEmpty else { return }
     let wolfIdx = Int.random(in: 0..<active.count)
 
     for (index, persona) in active.enumerated() {

--- a/Pastura/PasturaTests/Engine/Phases/AssignHandlerTests.swift
+++ b/Pastura/PasturaTests/Engine/Phases/AssignHandlerTests.swift
@@ -140,4 +140,44 @@ struct AssignHandlerTests {
     }
     #expect(shared.isEmpty)
   }
+
+  @Test func assignRandomOneWithEmptyActiveSetIsNoOp() async throws {
+    // Every persona eliminated → `active` is empty. `assignRandomOne` must NOT
+    // trap on `Int.random(in: 0..<0)` (the missing `!active.isEmpty` guard,
+    // #1287) — it returns cleanly, setting no `wolf_name` and emitting no
+    // `.assignment`.
+    //
+    // Regression guard (unguarded-path input): reverting the `guard
+    // !active.isEmpty` makes `Int.random(in: 0..<active.count)` hit an
+    // uncatchable "Range is empty" precondition failure and crash this test
+    // process. The empty active set is the exact input that reaches that line.
+    let mock = MockLLMService(responses: [])
+    let scenario = makeTestScenario(
+      agentNames: ["Alice", "Bob", "Charlie"],
+      phases: [Phase(type: .assign, source: "words", target: .randomOne)],
+      extraData: [
+        "words": .arrayOfDictionaries([
+          ["majority": "りんご", "minority": "みかん"]
+        ])
+      ]
+    )
+    var state = SimulationState.initial(for: scenario)
+    state.currentRound = 1
+    // Drive the active set to empty by eliminating every persona.
+    for name in ["Alice", "Bob", "Charlie"] {
+      state.eliminated[name] = true
+    }
+    let collector = EventCollector()
+
+    let context = makePhaseContext(scenario: scenario, llm: mock, collector: collector)
+    try await handler.execute(context: context, state: &state)
+
+    // Clean no-op: no wolf chosen, no assignment events.
+    #expect(state.variables["wolf_name"] == nil)
+    let assignments = collector.events.filter {
+      if case .assignment = $0 { return true }
+      return false
+    }
+    #expect(assignments.isEmpty)
+  }
 }


### PR DESCRIPTION
Closes #1287

## Summary

`AssignHandler.assignRandomOne` called `Int.random(in: 0..<active.count)` with no empty-active guard. On an empty active set that is `Int.random(in: 0..<0)` — an uncatchable precondition failure (SIGABRT) at the Swift boundary. Sibling per-active-agent handlers guard exactly this; this one did not.

The fix adds a single defensive guard mirroring `WhisperHandler`. Reachability is constructible-but-contrived (no bundled preset chains eliminations to `active → 0` before an `assign(random_one)`), but the crash is certain once reached.

## Acceptance-criteria correspondence

| # | Criterion | How the diff satisfies it | Covering test |
|---|-----------|---------------------------|---------------|
| 1 | A test drives an empty active set (all personas eliminated) through `assign(target: random_one)` with a valid `.arrayOfDictionaries` source; asserts no crash + zero `.assignment` events | `assignRandomOneWithEmptyActiveSetIsNoOp` sets `state.eliminated[name] = true` for all 3 personas → `active` is empty; asserts `wolf_name == nil` and no `.assignment` events | `assignRandomOneWithEmptyActiveSetIsNoOp` |
| 2 | Reverting the new guard makes the test crash (regression-test-drives-the-unguarded-path) | The empty active set reaches line 58 (both `topics` guards pass on the non-empty source); reverting `guard !active.isEmpty` lands on `Int.random(in: 0..<0)` → uncatchable trap → test process crashes | (same) |
| 3 | Targeted suite passes; full suite green | Both confirmed (below) | — |

## The fix

```swift
guard let topic = topics.randomElement() else { return }
// An empty active set means there is no agent to receive the minority
// value — return a clean no-op rather than trapping on the uncatchable
// `Int.random(in: 0..<0)` precondition failure (#1287). Mirrors the
// active-count guards in sibling per-active-agent handlers (WhisperHandler).
guard !active.isEmpty else { return }
let wolfIdx = Int.random(in: 0..<active.count)
```

Plus a doc-comment note on the empty-active no-op (the issue flagged that the doc-comment addressed only the `sourceData`-shape precondition).

## Scope honored

- `assignAll` untouched (its `default` branch already no-ops).
- **No** validator/lint rule added to cap `eliminate` count or prevent `active → 0` — that broader scenario-authoring concern is explicitly out of scope; this is the cheap handler-level defense only.

## Judgment calls

- **STOP condition (structural reachability):** The issue's STOP condition asked to note if `active → 0` before an `assign(random_one)` is structurally impossible. I did not exhaustively prove reachability either way — the fix is a cheap defensive guard regardless, and the issue directs to add guard + test even if the runtime risk is only theoretical. Left as documented in the issue's own Impact analysis (constructible via two `eliminate` phases in one round, or an `exclude_self: false` last-agent self-elimination; no bundled preset does this).
- **Applied one cosmetic doc-comment reword** flagged by the code-review pass: dropped the word "Precondition" from the empty-active doc line (a defensively-handled case is not a caller precondition). Comment-only.

## Test results

- `scripts/xcodebuild.sh test -only-testing PasturaTests/AssignHandlerTests` → **6/6 passed** (`** TEST SUCCEEDED **`).
- Full unit suite (`-skip-testing:PasturaUITests`) → **3252 tests / 269 suites passed** (`** TEST SUCCEEDED **`).
- Mandatory `code-reviewer` pass → **PASS**; traced the handler + test and confirmed the guard placement and the regression-test unguarded-path drive.
