### PR TITLE
✨ feat: port SpeakEachHandler to shared/engine commonMain (ADR-023 Wave B)

### DIFF
--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -453,11 +453,13 @@ nothing if they run different prompts. The en secret-section guidance diverged o
 **Apply**: change both sides in the same commit. `scripts/check-prompt-literal-parity.py`
 enforces it (pre-commit sub-gate + the CI "Shell gate tests" job); pairing is by
 basename with any `+Extension` suffix stripped, so `PromptBuilder+PrivateSections.swift`
-pairs with `PromptBuilder.kt`. A deliberate one-sided literal — today only the
-#911 `addressRule`, whose handler is not ported, alongside two whole-file
-`unported` deferrals — needs a row in
-`shared/prompt-literal-parity-allowlist.tsv`; the checker prints the exact row to
-paste, keyed on a digest of the pair so a later reword forces re-approval.
+pairs with `PromptBuilder.kt`. A deliberate one-sided literal — today none; the
+allowlist holds a single whole-file `unported` deferral (`NarrateHandler`) —
+needs a row in `shared/prompt-literal-parity-allowlist.tsv`; the checker prints
+the exact row to paste, keyed on a digest of the pair so a later reword forces
+re-approval. Whole-file `unported` rows are capped (`MAX_UNPORTED_ROWS`, at the
+current count) so the deferral budget ratchets down as the ADR-023 port lands
+rather than staying open.
 
 **What the gate does NOT see** — it measures `pickLanguage` literal-pair parity,
 not prompt parity, so separators (the `\n` vs `\n\n` join in `appendSecretSection`)

--- a/docs/kmp-migration-status.md
+++ b/docs/kmp-migration-status.md
@@ -22,7 +22,7 @@ At-a-glance progress for the KMP Engine migration (ADR-023 / [#501](https://gith
 > other section is hand-maintained; refresh it when a KMP PR merges (see
 > [`.claude/rules/kmp-interop.md`](../.claude/rules/kmp-interop.md)).
 
-_Last updated: 2026-07-24._
+_Last updated: 2026-07-29._
 
 ## Stages
 
@@ -43,7 +43,7 @@ Legend: ✅ done · 🔄 in progress · 🟡 partial · ⬜ not started.
 |---|:--:|---|
 | Models mirror | ✅ done | #1193 #1196 #1202 |
 | Wave A — non-handler run-path (scoring, mechanisms, prompt/LLM glue) | ✅ done | #1207 #1212 #1217 |
-| Wave B — 14 phase handlers | 🔄 11/14 | checklist ↓ |
+| Wave B — 14 phase handlers | 🔄 12/14 | checklist ↓ |
 | code-phase track | ✅ done | CP1 #1226 · CP2 #1230 · CP3 #1232 |
 
 ### Wave B handler checklist
@@ -64,7 +64,7 @@ machine-checked — see the maintenance invariant above.
 - [x] ReflectHandler — #1242
 - [x] RelationshipUpdateHandler — #1232
 - [x] ScoreCalcHandler — #1230
-- [ ] SpeakEachHandler
+- [x] SpeakEachHandler — #1307
 - [x] VoteHandler — #1249
 - [x] WhisperHandler — #1252
 <!-- kmp-status:wave-b:end -->

--- a/scripts/check-prompt-literal-parity.py
+++ b/scripts/check-prompt-literal-parity.py
@@ -114,9 +114,11 @@ MIN_SWIFT_CALLSITE_FILES = 12
 
 # Cap on whole-file `unported` exemptions. Unlike the digest-keyed rows, these
 # never expire on their own, so an uncapped list is how "temporarily deferred"
-# becomes permanent. Two today (NarrateHandler, SpeakEachHandler); raising it is
-# a deliberate act with its reason recorded in the allowlist header.
-MAX_UNPORTED_ROWS = 2
+# becomes permanent. Kept AT the current count (one today: NarrateHandler) rather
+# than above it, so the budget ratchets down as the ADR-023 port lands instead of
+# leaving a free slot the next deferral can take unreviewed. Raising it is a
+# deliberate act with its reason recorded in the allowlist header.
+MAX_UNPORTED_ROWS = 1
 
 # Floor on the number of checks `--self-test` runs. The printed tally is derived,
 # so it never goes stale — but nothing stops a suite from silently shrinking, and

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMBackend.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMBackend.kt
@@ -76,10 +76,9 @@ public interface LLMBackend {
 /**
  * One inference request crossing the §5.2 boundary.
  *
- * [antiRepetitionSeeds] arrived with its consumer, as this type's earlier
- * "deliberately omits" note said it should: [SpeakEachHandler] is the Engine's
- * only seeder, so the field would have been dead weight for the Swift adapter to
- * map until that handler was ported.
+ * [antiRepetitionSeeds] landed with its consumer, [SpeakEachHandler] (#1105) —
+ * the Engine's only seeder, so until that handler was ported the field would have
+ * been dead weight for the Swift adapter to map.
  *
  * @property system The system prompt defining the agent's persona and rules.
  * @property user   The user prompt with context and instructions for this turn.
@@ -92,22 +91,17 @@ public interface LLMBackend {
  *   passes.
  *
  *   **Read the scope before reaching for this to fix a repetition complaint.**
- *   The chain's own `penalties` sampler is per-generation, so it cannot see
- *   across a `generate()` at all; this field is the only cross-turn mechanism,
- *   and its one producer covers exactly one case. Three scopes exist, and only
- *   the middle one is this:
- *
- *   1. **Within one generation** — the backend's chain penalties. Not this field.
- *   2. **An agent's own prior turns, `speak_each` only** — [SpeakEachHandler]
- *      seeds each turn with that agent's own most-recent statement. This field.
- *   3. **Everything else** — cross-*agent* template collapse, and every phase
- *      other than `speak_each`. **Unreached.** Covering one needs a new seeder,
- *      not a bigger value here.
+ *   It covers exactly one case — an agent's own prior turns, in `speak_each`.
+ *   Cross-*agent* template collapse and every other phase are **unreached**, and
+ *   covering one needs a new seeder rather than a bigger value here. The full
+ *   three-scope contract (including what the backend's own per-generation chain
+ *   penalties do and do not reach) lives in `.claude/rules/engine.md`
+ *   § "The chain's `penalties` cannot reach across a `generate()`" — read it
+ *   there rather than trusting this paragraph to have stayed current.
  *
  *   A backend that cannot seed (Ollama's HTTP API, Foundation Models) ignores it
  *   rather than failing — mirroring the Swift services, which document the same
- *   no-op. `.claude/rules/engine.md` § "The chain's `penalties` cannot reach
- *   across a `generate()`" carries the full contract.
+ *   no-op.
  */
 public data class GenerationRequest(
     public val system: String,

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMBackend.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMBackend.kt
@@ -76,23 +76,44 @@ public interface LLMBackend {
 /**
  * One inference request crossing the §5.2 boundary.
  *
- * **Deliberately omits `antiRepetitionSeeds`** (#1105). Swift's
- * `LLMService.generateStream` carries it, but `SpeakEachHandler.swift:77` is the
- * Engine's ONLY seeder (every other reference plumbs the parameter through `LLM/`
- * or is the `= []` default), and that handler is Stage-3 freight — so a seeds field on this
- * gate slice would be dead weight the Swift adapter must map for nothing. Add it
- * with its consumer.
+ * [antiRepetitionSeeds] arrived with its consumer, as this type's earlier
+ * "deliberately omits" note said it should: [SpeakEachHandler] is the Engine's
+ * only seeder, so the field would have been dead weight for the Swift adapter to
+ * map until that handler was ported.
  *
  * @property system The system prompt defining the agent's persona and rules.
  * @property user   The user prompt with context and instructions for this turn.
  * @property schema Optional output schema. Backends translate this to their
  *   native constrained-decoding mechanism (llama.cpp: GBNF grammar). `null`
  *   means unconstrained generation.
+ * @property antiRepetitionSeeds Prior text spans seeded into the backend's DRY
+ *   sampler so a token-level repetition penalty spans the turn boundary (#1105).
+ *   Empty means no seeding — the default, and what every non-seeding caller
+ *   passes.
+ *
+ *   **Read the scope before reaching for this to fix a repetition complaint.**
+ *   The chain's own `penalties` sampler is per-generation, so it cannot see
+ *   across a `generate()` at all; this field is the only cross-turn mechanism,
+ *   and its one producer covers exactly one case. Three scopes exist, and only
+ *   the middle one is this:
+ *
+ *   1. **Within one generation** — the backend's chain penalties. Not this field.
+ *   2. **An agent's own prior turns, `speak_each` only** — [SpeakEachHandler]
+ *      seeds each turn with that agent's own most-recent statement. This field.
+ *   3. **Everything else** — cross-*agent* template collapse, and every phase
+ *      other than `speak_each`. **Unreached.** Covering one needs a new seeder,
+ *      not a bigger value here.
+ *
+ *   A backend that cannot seed (Ollama's HTTP API, Foundation Models) ignores it
+ *   rather than failing — mirroring the Swift services, which document the same
+ *   no-op. `.claude/rules/engine.md` § "The chain's `penalties` cannot reach
+ *   across a `generate()`" carries the full contract.
  */
 public data class GenerationRequest(
     public val system: String,
     public val user: String,
     public val schema: OutputSchema? = null,
+    public val antiRepetitionSeeds: List<String> = emptyList(),
 )
 
 /**

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMCaller.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMCaller.kt
@@ -100,6 +100,12 @@ internal class LLMCaller(
      * @param expectedLanguage The scenario's `engineLanguage` (ADR-010 D5/D6).
      *   `null` skips the adherence check entirely (back-compat for callers that
      *   pre-date the seam).
+     * @param antiRepetitionSeeds Prior text spans for the backend's DRY sampler
+     *   (#1105), passed straight through onto every attempt's
+     *   [GenerationRequest] — see that property for the scope this does and does
+     *   not cover. Deliberately **not** recomputed per attempt: a retry re-issues
+     *   the same prompt, so it must re-issue the same seeds, and the caller's
+     *   `lastOutputs` read has not changed under it anyway.
      * @throws SimulationException wrapping [SimulationError.RetriesExhausted] after
      *   [MAX_RETRIES] parse failures, or [SimulationError.LlmGenerationFailed] on a
      *   backend failure.
@@ -112,11 +118,17 @@ internal class LLMCaller(
         schema: OutputSchema? = null,
         detector: LanguageDetector? = null,
         expectedLanguage: String? = null,
+        antiRepetitionSeeds: List<String> = emptyList(),
         relay: SuspensionRelay,
         emitter: (SimulationEvent) -> Unit,
     ): TurnOutput {
         val expectedKeys: Set<String> = schema?.fields?.map { it.name }?.toSet() ?: emptySet()
-        val request = GenerationRequest(system = system, user = user, schema = schema)
+        val request = GenerationRequest(
+            system = system,
+            user = user,
+            schema = schema,
+            antiRepetitionSeeds = antiRepetitionSeeds,
+        )
 
         for (attempt in 0..MAX_RETRIES) {
             emitter(SimulationEvent.InferenceStarted(agent = agentName))

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/PhaseDispatcher.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/PhaseDispatcher.kt
@@ -10,9 +10,9 @@ import kotlinx.serialization.serializer
  * ## Scope: the ADR-023 Stage-3 port, in progress
  *
  * **`SPEAK_ALL`, `ELIMINATE`, `SUMMARIZE`, `ASSIGN`, `EVENT_INJECT`, `SCORE_CALC`,
- * `RELATIONSHIP_UPDATE`, `REFLECT`, `VOTE`, `WHISPER` and `CHOOSE` are
- * registered.** Swift registers all 14; the remaining 3 are the mechanical bulk of
- * Stage 3 ("mechanical after the Stage-2 slice", §4), ported handler-by-handler.
+ * `RELATIONSHIP_UPDATE`, `REFLECT`, `VOTE`, `WHISPER`, `CHOOSE` and `SPEAK_EACH`
+ * are registered.** Swift registers all 14; the remaining 2 are the mechanical bulk
+ * of Stage 3 ("mechanical after the Stage-2 slice", §4), ported handler-by-handler.
  *
  * Unlike Swift's `PhaseDispatcher`, this is **not** exhaustive over [PhaseType] —
  * so an unregistered phase fails at dispatch with a clear error rather than at
@@ -37,6 +37,7 @@ internal class PhaseDispatcher {
         PhaseType.VOTE to VoteHandler(),
         PhaseType.WHISPER to WhisperHandler(),
         PhaseType.CHOOSE to ChooseHandler(),
+        PhaseType.SPEAK_EACH to SpeakEachHandler(),
     )
 
     /**

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/SpeakEachHandler.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/SpeakEachHandler.kt
@@ -126,7 +126,10 @@ internal class SpeakEachHandler : PhaseHandler {
         // succeeds. Seeded into the DRY sampler (content-only, value text) so a
         // token-level penalty spans the turn boundary — the register-dominant
         // cross-round verbatim echo that prompt-side fixes could not suppress
-        // (#912 No-Go). Empty when there is no prior statement (first sub-round).
+        // (#912 No-Go). Empty only when the agent has NO prior statement under
+        // this field at all — its first such turn of the run, or right after a D2
+        // skip cleared the key. `lastOutputs` is not reset per round, so a later
+        // round's first sub-round normally still seeds.
         //
         // `isNotBlank()` mirrors Swift's whitespace-trim filter: an empty or
         // `"..."` statement is already caught upstream by the empty-field retry,

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/SpeakEachHandler.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/SpeakEachHandler.kt
@@ -1,0 +1,194 @@
+package com.pastura.engine
+
+import com.pastura.models.ConversationEntry
+import com.pastura.models.OutputSchema
+import com.pastura.models.Persona
+import com.pastura.models.SimulationEvent
+import com.pastura.models.SimulationState
+
+/**
+ * Handles `speak_each` phases where agents speak sequentially with accumulating
+ * context.
+ *
+ * Unlike `speak_all`, the conversation log accumulates *within* sub-rounds, so
+ * each agent sees what previous agents said in the current sub-round.
+ *
+ * A turn-degradable LLM failure is routed through [PhaseContext.turnGate]
+ * (ADR-021 D1/D2): the failing agent's turn is skipped — no `AgentOutput`, no
+ * `conversationLog` entry, and any stale `lastOutputs` entry for that agent is
+ * cleared — and the sub-round continues with the next persona.
+ *
+ * ## Sole seeder of the DRY anti-repetition sampler (#1105)
+ *
+ * This is the only handler in either engine that populates
+ * [GenerationRequest.antiRepetitionSeeds]. It seeds each turn with **that
+ * agent's own** most-recent statement, which is still in `lastOutputs` because
+ * that key is overwritten only after the turn succeeds. Read
+ * [GenerationRequest.antiRepetitionSeeds] before assuming this covers more than
+ * it does — cross-*agent* template collapse and every other phase are not
+ * reached by it.
+ *
+ * Because it is the sole producer, no consumer test can catch a dropped seed:
+ * the backend takes whatever list it is handed and a `emptyList()` here is
+ * indistinguishable from a phase that legitimately does not seed. That is why
+ * `SpeakEachHandlerTests` asserts against the backend's recorded requests rather
+ * than against [LLMCaller] in isolation.
+ *
+ * ## State threading (Kotlin immutability)
+ *
+ * Swift mutates an `inout state` per turn; Kotlin's [SimulationState] is
+ * immutable, so [speakTurn] returns the next state and the loops thread it
+ * through a single `current`. Threading — not a frozen phase-start snapshot as
+ * in `WhisperHandler` — is what makes the accumulation above work: each turn
+ * formats its `conversation_log` from the state the previous turn returned.
+ *
+ * Swift original: `Pastura/Pastura/Engine/Phases/SpeakEachHandler.swift`.
+ */
+internal class SpeakEachHandler : PhaseHandler {
+
+    private val promptBuilder = PromptBuilder()
+
+    override suspend fun execute(context: PhaseContext, state: SimulationState): SimulationState {
+        // `subRounds` is untrusted (any un-vetted YAML ingest can set `rounds: 0`
+        // or a negative). Swift clamps because `1...subRounds` would form an
+        // invalid ClosedRange and TRAP; Kotlin's `1..0` is merely an EMPTY range,
+        // so here the same missing clamp is a silent zero-inference phase instead
+        // of a crash — quieter, and therefore worth guarding just as much.
+        val subRounds = maxOf(1, context.phase.subRounds ?: 1)
+        val promptTemplate = context.phase.prompt
+            ?: pickLanguage(
+                context.scenario.engineLanguage,
+                ja = "これまでの会話: {conversation_log}\nあなたの番です。",
+                en = "Conversation so far: {conversation_log}\nYour turn.",
+            )
+
+        var current = state
+        repeat(subRounds) {
+            for (persona in context.scenario.personas) {
+                // `== true` to SKIP: an agent absent from the map reads `null`,
+                // which is not `true`, so it speaks — matching Swift's
+                // `guard state.eliminated[persona.name] != true else { continue }`.
+                if (current.eliminated[persona.name] == true) continue
+                current = speakTurn(context, persona, promptTemplate, current)
+            }
+        }
+        return current
+    }
+
+    /**
+     * Runs one persona's turn: builds the prompt, routes the LLM call through
+     * [PhaseContext.turnGate] (ADR-021 D1/D2), and folds the result into state on
+     * success. On a skipped turn, writes nothing and clears any stale
+     * `lastOutputs` entry.
+     *
+     * Returns the next state — [SimulationState] is immutable, so unlike Swift's
+     * `inout` the caller MUST use the return value (see [PhaseHandler]).
+     */
+    private suspend fun speakTurn(
+        context: PhaseContext,
+        persona: Persona,
+        promptTemplate: String,
+        state: SimulationState,
+    ): SimulationState {
+        // Constructed per turn, matching Swift — a stateless value, cheap. The
+        // logger seam is threaded from the context.
+        val llmCaller = LLMCaller(logger = context.logger)
+
+        val systemPrompt = promptBuilder.buildSystemPrompt(
+            scenario = context.scenario,
+            persona = persona,
+            phase = context.phase,
+            state = state,
+        )
+
+        // Local prompt-variable map (thrown away after the prompt is built). The
+        // `inject*` family mutates it in place to surface each reserved-namespace
+        // `{token}` to only this speaker; none of this touches persisted state.
+        val variables = state.variables.toMutableMap()
+        variables["scoreboard"] = promptBuilder.formatScoreboard(state.scores)
+        variables["conversation_log"] = promptBuilder.formatConversationLog(
+            entries = state.conversationLog,
+            language = context.scenario.engineLanguage,
+            window = context.scenario.logWindow,
+        )
+        promptBuilder.injectAssigned(variables, persona.name)
+        promptBuilder.injectNotes(variables, persona.name)
+        promptBuilder.injectWhispers(variables, persona.name)
+        promptBuilder.injectRelationships(variables, persona.name)
+        promptBuilder.injectMood(variables, persona.name)
+        val userPrompt = promptBuilder.expandTemplate(promptTemplate, variables)
+
+        // Hoisted above the call because the seed reads the SAME field the
+        // conversation-log entry below writes.
+        val mainField = promptBuilder.getMainField(context.phase)
+        // Anti-repetition seed (#1105): this agent's own most-recent statement,
+        // still in `lastOutputs` because it is overwritten only after this turn
+        // succeeds. Seeded into the DRY sampler (content-only, value text) so a
+        // token-level penalty spans the turn boundary — the register-dominant
+        // cross-round verbatim echo that prompt-side fixes could not suppress
+        // (#912 No-Go). Empty when there is no prior statement (first sub-round).
+        //
+        // `isNotBlank()` mirrors Swift's whitespace-trim filter: an empty or
+        // `"..."` statement is already caught upstream by the empty-field retry,
+        // but a blank-but-nonempty one (`"   "`) reaches `lastOutputs` and would
+        // otherwise be seeded as a meaningless span.
+        val antiRepetitionSeeds =
+            listOfNotNull(state.lastOutputs[persona.name]?.fields?.get(mainField))
+                .filter { it.isNotBlank() }
+
+        val output = context.turnGate.attempt(
+            agent = persona.name,
+            phaseType = context.phase.type,
+            emitter = context.emitter,
+        ) {
+            llmCaller.call(
+                backend = context.backend,
+                system = systemPrompt,
+                user = userPrompt,
+                agentName = persona.name,
+                schema = OutputSchema.from(context.phase),
+                detector = context.detector,
+                expectedLanguage = context.scenario.engineLanguage,
+                antiRepetitionSeeds = antiRepetitionSeeds,
+                relay = context.suspensionRelay,
+                emitter = context.emitter,
+            )
+        } ?: return state.copy(
+            // Turn skipped (ADR-021 D2): write nothing, and clear any stale
+            // prior-round output so downstream consumers keyed on `lastOutputs`
+            // don't read a decision that never happened this turn. Matches Swift's
+            // `state.lastOutputs[persona.name] = nil` on the skip path.
+            //
+            // Note the interaction with the seed above: clearing here also means
+            // the agent's NEXT sub-round seeds empty rather than re-seeding a
+            // statement from before the failure. Swift behaves identically.
+            lastOutputs = state.lastOutputs - persona.name,
+        )
+
+        context.emitter(
+            SimulationEvent.AgentOutput(
+                agent = persona.name,
+                output = output,
+                phaseType = context.phase.type,
+            ),
+        )
+
+        val content = output.fields[mainField] ?: ""
+        // Fold ALL THREE success-path writes into ONE `state.copy` — the log
+        // entry, `lastOutputs`, and captureMood's `variables` (#913, a no-op
+        // unless the phase declares `mood`). A second copy off the original would
+        // drop the first write; see `ChooseHandler`'s § "State threading".
+        val nextVariables = state.variables.toMutableMap()
+        promptBuilder.captureMood(output, nextVariables, persona.name)
+        return state.copy(
+            variables = nextVariables,
+            conversationLog = state.conversationLog + ConversationEntry(
+                agentName = persona.name,
+                content = content,
+                phaseType = context.phase.type,
+                round = state.currentRound,
+            ),
+            lastOutputs = state.lastOutputs + (persona.name to output),
+        )
+    }
+}

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/PromptBuilder.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/PromptBuilder.kt
@@ -31,14 +31,17 @@ import com.pastura.models.TurnOutput
  * rule, output format); the injection family ([injectAssigned] / [injectNotes] /
  * [injectWhispers] / [injectRelationships] / [injectMood]), [captureMood] +
  * `moodRule` + `reflectBrevityRule` + `voteCandidateRule` + `whisperRule` +
- * `chooseOptionsRule`, and `appendPrivateSections`.
+ * `chooseOptionsRule` + `addressRule`, and `appendPrivateSections`.
+ *
+ * With `addressRule` landed alongside [SpeakEachHandler], every phase-specific
+ * answer rule Swift appends is now ported — the answer-rules block is at full
+ * parity.
  *
  * What is **knowingly absent** — each a *named* unit, tracked on #501 for its
  * Wave-B handler PR, never a silent drop:
  *
  * | Absent | Why |
  * |---|---|
- * | `addressRule` (#911, speak_each) | speak_each is a later Wave-B handler |
  * | `RelationshipVerbalizer`, `PromptPlaceholders`, `ErrorReadability` | types landed in PR-3 (#501 Stage 3); PromptBuilder still has no slice consumer for them (wiring deferred to their Wave-B handlers) |
  *
  * Each remaining unit lands with its handler against the Swift test files, which
@@ -264,12 +267,18 @@ internal class PromptBuilder {
 
     /**
      * The `## 回答ルール / ## Response Rules` block: the base rules, plus the
-     * mood-writing rule ([moodRule], schema-gated), the reflect-note brevity rule
-     * ([reflectBrevityRule], `REFLECT`-gated), the whisper privacy rule
+     * address rule ([addressRule], `SPEAK_EACH`-gated), the reflect-note brevity
+     * rule ([reflectBrevityRule], `REFLECT`-gated), the whisper privacy rule
      * ([whisperRule], `WHISPER`-gated), the choose-options rule
-     * ([chooseOptionsRule], `CHOOSE`-gated), and the vote-candidate rule
-     * ([voteCandidateRule], `VOTE`-gated). One phase-specific appendix remains a
-     * Stage-3 unit — the speak_each address rule; see the class doc.
+     * ([chooseOptionsRule], `CHOOSE`-gated), the vote-candidate rule
+     * ([voteCandidateRule], `VOTE`-gated), and the mood-writing rule
+     * ([moodRule], schema-gated). Every phase-specific appendix Swift appends is
+     * now ported.
+     *
+     * **Append order is the prompt.** The rules concatenate into one string, so
+     * the sequence above must stay identical to Swift's
+     * `PromptBuilder.swift:197-228` — speak_each, reflect, whisper, choose, vote,
+     * mood. Reordering is not a refactor; it changes what the model reads.
      *
      * Takes the full `(scenario, persona, state)` — not just `language` — because
      * [voteCandidateRule] enumerates candidates from the persona + elimination
@@ -314,6 +323,13 @@ internal class PromptBuilder {
                 - Output exactly one object starting with { and ending with }, with no surrounding text.
             """.trimIndent(),
         )
+
+        // Turn-based speak_each gets the #911 address rule (see [addressRule]).
+        // FIRST of the phase-specific appendices, matching Swift — see the
+        // append-order note in this function's KDoc.
+        if (phase.type == PhaseType.SPEAK_EACH) {
+            rules += addressRule(language)
+        }
 
         // Reflect notes get a tighter 2-sentence cap (see [reflectBrevityRule]).
         // Type-gated, unlike the schema-gated mood rule below.
@@ -390,6 +406,35 @@ internal class PromptBuilder {
             en = "\n- The vote field must be exactly one of these names: $candidatesList",
         )
     }
+
+    /**
+     * The #911 address rule appended for turn-based `speak_each` phases only
+     * ([buildAnswerRules] gates on `phase.type == SPEAK_EACH`).
+     *
+     * speak_each otherwise produces parallel monologues (0 % cross-reference at
+     * baseline); a harness A/B on Gemma 4 E2B lifted word_wolf address-rate to
+     * ~0.27 (ja) / ~0.18 (en) with no agreement-formulae collapse. It is **NOT**
+     * appended for `speak_all`: the A/B showed it inert there (simultaneous
+     * broadcast framing dominates, e.g. prisoners' 「全員に向けて宣言」) and mildly
+     * harmful (parse failures + bokete boke-copying). The 「反論でも疑問でもよい」
+     * clause blocks the agreement-formulae collapse mode. Keep ja/en
+     * scope-parallel; wording is harness-A/B-tuned.
+     *
+     * **Interacts with `log_window`.** The rule tells the agent to refer to
+     * someone who spoke earlier, and [formatConversationLog] trims that same log
+     * to the last `window` entries — so an accumulating scenario needs
+     * `log_window >= agentCount` or the same round's earlier speakers vanish from
+     * the addressee pool. Enforced as lint warning R17 (ADR-024), Swift-side.
+     */
+    private fun addressRule(language: String): String =
+        pickLanguage(
+            language,
+            ja = "\n- これまでの会話に他の誰かの発言があれば、そのうち1人の発言に必ず触れてから自分の意見を述べること" +
+                "（同意でも反論でも疑問でもよい）。まだ誰も発言していなければ自由に話してよい",
+            en = "\n- If anyone has spoken earlier in the conversation, refer to one of their statements " +
+                "before giving your own opinion (agreement, disagreement, or a question all count). " +
+                "If no one has spoken yet, speak freely.",
+        )
 
     /**
      * The #907 brevity rule appended for `reflect` phases only ([buildAnswerRules]

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/PromptBuilder.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/PromptBuilder.kt
@@ -276,9 +276,13 @@ internal class PromptBuilder {
      * now ported.
      *
      * **Append order is the prompt.** The rules concatenate into one string, so
-     * the sequence above must stay identical to Swift's
-     * `PromptBuilder.swift:197-228` — speak_each, reflect, whisper, choose, vote,
-     * mood. Reordering is not a refactor; it changes what the model reads.
+     * the sequence must stay identical to Swift's: [addressRule] ->
+     * [reflectBrevityRule] -> [whisperRule] -> the choose block ->
+     * [voteCandidateRule] -> [moodRule] (`PromptBuilder.swift`, around :197).
+     * Anchored on the SYMBOL sequence, not on a line range — nothing gates a
+     * cross-language line reference against drift, and an insertion above the
+     * Swift block would silently invalidate one. Reordering is not a refactor; it
+     * changes what the model reads.
      *
      * Takes the full `(scenario, persona, state)` — not just `language` — because
      * [voteCandidateRule] enumerates candidates from the persona + elimination

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/LLMBackendContractTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/LLMBackendContractTests.kt
@@ -143,6 +143,24 @@ class LLMBackendContractTests {
         assertEquals(schema, backend.requests.single().schema)
     }
 
+    @Test
+    fun antiRepetitionSeedsDefaultToEmptyMeaningNoDrySeeding() {
+        // The default is what every non-`speak_each` caller relies on (#1105):
+        // seeding is opt-in, so a backend must be able to read "no seeds" from an
+        // empty list rather than from a null it would have to special-case.
+        assertTrue(request().antiRepetitionSeeds.isEmpty())
+    }
+
+    @Test
+    fun requestCarriesAntiRepetitionSeedsThrough() {
+        val backend = ScriptedLLMBackend(listOf(ScriptedLLMBackend.Script.completing("{}")))
+        backend.generateStream(
+            GenerationRequest(system = "s", user = "u", antiRepetitionSeeds = listOf("prior")),
+            RecordingStreamCallbacks(),
+        )
+        assertEquals(listOf("prior"), backend.requests.single().antiRepetitionSeeds)
+    }
+
     // MARK: - StreamHandle
 
     @Test

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/LLMBackendContractTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/LLMBackendContractTests.kt
@@ -147,18 +147,15 @@ class LLMBackendContractTests {
     fun antiRepetitionSeedsDefaultToEmptyMeaningNoDrySeeding() {
         // The default is what every non-`speak_each` caller relies on (#1105):
         // seeding is opt-in, so a backend must be able to read "no seeds" from an
-        // empty list rather than from a null it would have to special-case.
+        // empty list rather than from a null it would have to special-case. It is
+        // also the K/N-visible half — a Swift consumer gets no default and must
+        // pass this explicitly (kmp-interop.md Pattern 3).
+        //
+        // No sibling `requestCarriesAntiRepetitionSeedsThrough` on purpose: a data
+        // class returning its own constructor argument is not behaviour, so such a
+        // test cannot redden on any revert. The real control is
+        // `LLMCallerTests.antiRepetitionSeedsReachTheBackendAsTheRequestSeeds`.
         assertTrue(request().antiRepetitionSeeds.isEmpty())
-    }
-
-    @Test
-    fun requestCarriesAntiRepetitionSeedsThrough() {
-        val backend = ScriptedLLMBackend(listOf(ScriptedLLMBackend.Script.completing("{}")))
-        backend.generateStream(
-            GenerationRequest(system = "s", user = "u", antiRepetitionSeeds = listOf("prior")),
-            RecordingStreamCallbacks(),
-        )
-        assertEquals(listOf("prior"), backend.requests.single().antiRepetitionSeeds)
     }
 
     // MARK: - StreamHandle

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/LLMCallerTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/LLMCallerTests.kt
@@ -69,6 +69,59 @@ class LLMCallerTests {
         assertEquals("usr", backend.requests.single().user)
     }
 
+    // MARK: - Anti-repetition seeds (#1105)
+
+    @Test
+    fun antiRepetitionSeedsReachTheBackendAsTheRequestSeeds() = runTest {
+        val backend = ScriptedLLMBackend(listOf(script("""{"statement": "hi"}""")))
+        caller.call(
+            backend = backend,
+            system = "sys",
+            user = "usr",
+            agentName = "Alice",
+            schema = schema,
+            antiRepetitionSeeds = listOf("my prior statement"),
+            relay = SuspensionRelay(),
+            emitter = {},
+        )
+        assertEquals(listOf("my prior statement"), backend.requests.single().antiRepetitionSeeds)
+    }
+
+    @Test
+    fun callersThatDoNotSeedGetAnEmptySeedList() = runTest {
+        // Every LLM handler except `speak_each` omits the argument; the default
+        // must arrive as "no seeding", not as a stale value from another call.
+        val backend = ScriptedLLMBackend(listOf(script("""{"statement": "hi"}""")))
+        call(backend)
+        assertTrue(backend.requests.single().antiRepetitionSeeds.isEmpty())
+    }
+
+    @Test
+    fun everyRetryAttemptReIssuesTheSameSeeds() = runTest {
+        // A retry re-issues the SAME prompt, so it must re-issue the same seeds.
+        // Recomputing them per attempt would be the tempting alternative and is
+        // wrong: `lastOutputs` cannot have changed under an in-flight turn, so a
+        // per-attempt read buys nothing and invites drift.
+        val backend = ScriptedLLMBackend(
+            listOf(script("garbage"), script("still garbage"), script("""{"statement": "ok"}""")),
+        )
+        caller.call(
+            backend = backend,
+            system = "sys",
+            user = "usr",
+            agentName = "Alice",
+            schema = schema,
+            antiRepetitionSeeds = listOf("seed"),
+            relay = SuspensionRelay(),
+            emitter = {},
+        )
+        assertEquals(3, backend.callCount)
+        assertEquals(
+            List(3) { listOf("seed") },
+            backend.requests.map { it.antiRepetitionSeeds },
+        )
+    }
+
     // MARK: - Retry budget (parse / empty)
 
     @Test

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/PhaseDispatcherTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/PhaseDispatcherTests.kt
@@ -108,15 +108,16 @@ class PhaseDispatcherTests {
     fun everyUnportedPhaseTypeFailsCleanlyRatherThanCrashing() {
         // A Stage-3 gap must read as a gap. Iterating allCases also means a NEW
         // PhaseType added to Models cannot silently reach dispatch unhandled.
+        // DERIVED from the dispatcher, not a hand-written exclusion list. A hand
+        // list cannot disagree with itself, so it silently stops guarding
+        // registration: de-registering a ported handler just moves that case into
+        // the excluded set, leaving this test green. Deriving makes the count below
+        // fire on BOTH enum growth and an accidental de-registration.
         val unported = PhaseType.entries.filter {
-            it != PhaseType.SPEAK_ALL && it != PhaseType.ELIMINATE &&
-                it != PhaseType.SUMMARIZE && it != PhaseType.ASSIGN &&
-                it != PhaseType.EVENT_INJECT && it != PhaseType.SCORE_CALC &&
-                it != PhaseType.RELATIONSHIP_UPDATE && it != PhaseType.REFLECT &&
-                it != PhaseType.VOTE && it != PhaseType.WHISPER &&
-                it != PhaseType.CHOOSE && it != PhaseType.SPEAK_EACH
+            runCatching { dispatcher.handler(it) }.isFailure
         }
-        assertEquals(2, unported.size, "Kotlin PhaseType has 14 cases today; see the #501 drift ledger")
+        assertEquals(14, PhaseType.entries.size, "the drift ledger's case count is now executable")
+        assertEquals(2, unported.size, "see the #501 drift ledger")
         for (type in unported) {
             val error = assertFailsWith<SimulationException>("$type must fail cleanly") {
                 dispatcher.handler(type)

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/PhaseDispatcherTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/PhaseDispatcherTests.kt
@@ -75,6 +75,11 @@ class PhaseDispatcherTests {
     }
 
     @Test
+    fun resolvesTheSpeakEachHandler() {
+        assertIs<SpeakEachHandler>(dispatcher.handler(PhaseType.SPEAK_EACH))
+    }
+
+    @Test
     fun returnsAStableHandlerInstance() {
         // Handlers are stateless values; the dispatcher builds its map once.
         assertTrue(dispatcher.handler(PhaseType.SPEAK_ALL) === dispatcher.handler(PhaseType.SPEAK_ALL))
@@ -91,8 +96,8 @@ class PhaseDispatcherTests {
         // `conditional`, not `CONDITIONAL` — Swift interpolates `phaseType.rawValue`,
         // and a reader comparing the two engines' errors should see the same token.
         // The exemplar is CONDITIONAL rather than the next handler in the port queue:
-        // it is LAST in the remaining Wave-B order (SpeakEach -> Narrate ->
-        // Conditional), so this repoint survives the longest.
+        // it is LAST in the remaining Wave-B order (Narrate -> Conditional), so this
+        // repoint survives the longest.
         val error = assertFailsWith<SimulationException> { dispatcher.handler(PhaseType.CONDITIONAL) }
         val message = assertIs<SimulationError.ScenarioValidationFailed>(error.error).message
         assertTrue(message.contains("conditional"), "expected the wire name, got: $message")
@@ -109,9 +114,9 @@ class PhaseDispatcherTests {
                 it != PhaseType.EVENT_INJECT && it != PhaseType.SCORE_CALC &&
                 it != PhaseType.RELATIONSHIP_UPDATE && it != PhaseType.REFLECT &&
                 it != PhaseType.VOTE && it != PhaseType.WHISPER &&
-                it != PhaseType.CHOOSE
+                it != PhaseType.CHOOSE && it != PhaseType.SPEAK_EACH
         }
-        assertEquals(3, unported.size, "Kotlin PhaseType has 14 cases today; see the #501 drift ledger")
+        assertEquals(2, unported.size, "Kotlin PhaseType has 14 cases today; see the #501 drift ledger")
         for (type in unported) {
             val error = assertFailsWith<SimulationException>("$type must fail cleanly") {
                 dispatcher.handler(type)

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/PromptBuilderInjectionTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/PromptBuilderInjectionTests.kt
@@ -289,6 +289,10 @@ class PromptBuilderInjectionTests {
         val s = scenario()
         val prompt = builder.buildSystemPrompt(s, alice, speakEach, stateOf(s))
         assertTrue(prompt.contains("そのうち1人の発言に必ず触れてから自分の意見を述べること"))
+        // The rule's KDoc calls this clause load-bearing — it is what blocks the
+        // agreement-formulae collapse mode. Asserted here so the unit test stands
+        // on its own; the parity gate only proves the two engines AGREE.
+        assertTrue(prompt.contains("（同意でも反論でも疑問でもよい）"))
         assertTrue(prompt.contains("まだ誰も発言していなければ自由に話してよい"))
     }
 
@@ -297,6 +301,7 @@ class PromptBuilderInjectionTests {
         val s = scenario(language = "en")
         val prompt = builder.buildSystemPrompt(s, alice, speakEach, stateOf(s))
         assertTrue(prompt.contains("refer to one of their statements before giving your own opinion"))
+        assertTrue(prompt.contains("(agreement, disagreement, or a question all count)"))
         assertTrue(prompt.contains("If no one has spoken yet, speak freely."))
     }
 
@@ -316,11 +321,12 @@ class PromptBuilderInjectionTests {
     @Test
     fun addressRulePrecedesTheMoodRuleInTheAnswerRulesBlock() {
         // The rules concatenate into one string, so append ORDER is prompt
-        // content. Every other appendix is phase-type-gated and therefore
-        // mutually exclusive with this one; `moodRule` is schema-gated, so a
-        // speak_each phase declaring `mood` is the only shape where two
-        // appendices coexist — i.e. the only place the Swift order
-        // (`PromptBuilder.swift:197-228`) is observable at all.
+        // content. Every other appendix is phase-type-gated and therefore mutually
+        // exclusive with `addressRule`; the schema-gated `moodRule` is the only one
+        // that can coexist with it. So this is the only shape in which
+        // **addressRule's** relative position is observable. (Other type-gated
+        // rules pair with `moodRule` the same way — that is not unique to
+        // speak_each; what is unique is that it is addressRule's only pairing.)
         val s = scenario()
         val moodySpeakEach = Phase(
             type = PhaseType.SPEAK_EACH,

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/PromptBuilderInjectionTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/PromptBuilderInjectionTests.kt
@@ -23,12 +23,12 @@ import kotlin.test.assertTrue
  *
  * Unlike [PromptBuilderTests] (which disclaims parity for the still-incomplete
  * base slice), these DO assert parity: their landed units are the full Swift
- * behaviour. Deliberately **out of scope** here — deferred to its own Wave-B
- * handler PR, so its guidance is not yet ported: `addressRule`. The `mood`,
- * `reflect`-brevity, vote-candidate, `whisper`, and choose-options answer-rules
- * ARE asserted, because `moodRule`, `reflectBrevityRule`, `voteCandidateRule`,
- * `whisperRule`, and `chooseOptionsRule` land with this infrastructure / the
- * ReflectHandler / VoteHandler / WhisperHandler / ChooseHandler PRs.
+ * behaviour. Every phase-specific answer rule is now in scope — `mood`,
+ * `reflect`-brevity, vote-candidate, `whisper`, choose-options, and (with the
+ * SpeakEachHandler PR) the #911 `addressRule`, so `moodRule`,
+ * `reflectBrevityRule`, `voteCandidateRule`, `whisperRule`, `chooseOptionsRule`,
+ * and `addressRule` are all asserted here. Nothing in the answer-rules block is
+ * deferred any more.
  *
  * Split into its own file per the commonTest concern-per-file convention
  * (cf. [PromptBuilderParityTests]); these are pure, stateless `PromptBuilder`
@@ -274,6 +274,65 @@ class PromptBuilderInjectionTests {
             builder.buildSystemPrompt(s, alice, speakAll, stateOf(s))
                 .contains("これは密談相手ひとりだけへの秘密の耳打ち"),
         )
+    }
+
+    // MARK: - Address answer-rule (#911, speak_each phases only)
+
+    private val speakEach = Phase(
+        type = PhaseType.SPEAK_EACH,
+        prompt = "Talk.",
+        outputSchema = mapOf("statement" to "string"),
+    )
+
+    @Test
+    fun addressRuleAppendedForSpeakEachPhaseJa() {
+        val s = scenario()
+        val prompt = builder.buildSystemPrompt(s, alice, speakEach, stateOf(s))
+        assertTrue(prompt.contains("そのうち1人の発言に必ず触れてから自分の意見を述べること"))
+        assertTrue(prompt.contains("まだ誰も発言していなければ自由に話してよい"))
+    }
+
+    @Test
+    fun addressRuleAppendedForSpeakEachPhaseEn() {
+        val s = scenario(language = "en")
+        val prompt = builder.buildSystemPrompt(s, alice, speakEach, stateOf(s))
+        assertTrue(prompt.contains("refer to one of their statements before giving your own opinion"))
+        assertTrue(prompt.contains("If no one has spoken yet, speak freely."))
+    }
+
+    @Test
+    fun addressRuleOmittedForSpeakAllPhase() {
+        // NOT a generic "non-speak_each" check — speak_all specifically. The #911
+        // harness A/B measured the rule as inert-to-harmful under simultaneous
+        // broadcast framing, so this omission is a tuned decision, not an
+        // accident of the gate's shape (`PromptBuilder.swift:197-200`).
+        val s = scenario()
+        assertFalse(
+            builder.buildSystemPrompt(s, alice, speakAll, stateOf(s))
+                .contains("そのうち1人の発言に必ず触れてから"),
+        )
+    }
+
+    @Test
+    fun addressRulePrecedesTheMoodRuleInTheAnswerRulesBlock() {
+        // The rules concatenate into one string, so append ORDER is prompt
+        // content. Every other appendix is phase-type-gated and therefore
+        // mutually exclusive with this one; `moodRule` is schema-gated, so a
+        // speak_each phase declaring `mood` is the only shape where two
+        // appendices coexist — i.e. the only place the Swift order
+        // (`PromptBuilder.swift:197-228`) is observable at all.
+        val s = scenario()
+        val moodySpeakEach = Phase(
+            type = PhaseType.SPEAK_EACH,
+            prompt = "Talk.",
+            outputSchema = mapOf("statement" to "string", "mood" to "string"),
+        )
+        val prompt = builder.buildSystemPrompt(s, alice, moodySpeakEach, stateOf(s))
+        val addressAt = prompt.indexOf("そのうち1人の発言に必ず触れてから")
+        val moodAt = prompt.indexOf("moodには今の気分を短い言葉で書くこと")
+        assertTrue(addressAt >= 0, "address rule missing")
+        assertTrue(moodAt >= 0, "mood rule missing")
+        assertTrue(addressAt < moodAt, "address rule must precede the mood rule")
     }
 
     // MARK: - Choose options answer-rule (choose phases declaring options)

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/SpeakEachHandlerTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/SpeakEachHandlerTests.kt
@@ -124,11 +124,27 @@ class SpeakEachHandlerTests {
 
     @Test
     fun skipsEliminatedAgents() = runTest {
+        // Alice's `false` entry is written explicitly. `SimulationState.initial`
+        // seeds EVERY agent to `false`, so a bare `mapOf("Bob" to true)` would
+        // *replace* that map and leave Alice absent — under which a wrong
+        // `eliminated[name] != null` guard still passes this test while skipping
+        // everyone against real state.
         val s = scenario()
         val backend = ScriptedLLMBackend(listOf(says("only Alice")))
-        val state = initial(s).copy(eliminated = mapOf("Bob" to true))
+        val state = initial(s).copy(eliminated = mapOf("Alice" to false, "Bob" to true))
         handler.execute(context(s, backend), state)
         assertEquals(1, backend.callCount)
+    }
+
+    @Test
+    fun anAgentAbsentFromTheEliminatedMapIsActive() = runTest {
+        // The other polarity the impl comment argues for: a missing key reads
+        // `null`, which is not `true`, so the agent speaks. `!= false` would skip
+        // every agent the map never mentions.
+        val s = scenario()
+        val backend = ScriptedLLMBackend(listOf(says("A"), says("B")))
+        handler.execute(context(s, backend), initial(s).copy(eliminated = emptyMap()))
+        assertEquals(2, backend.callCount)
     }
 
     // MARK: - subRounds clamp (untrusted YAML guard, #1064)
@@ -146,6 +162,9 @@ class SpeakEachHandlerTests {
         assertEquals(2, backend.callCount)
     }
 
+    // Adds no discrimination over the zero case in Kotlin (`1..0` and `1..-1`
+    // are both empty ranges); kept as the Swift-parity pair, where the two inputs
+    // were distinct trap arguments.
     @Test
     fun negativeSubRoundsRunsOncePerPersona() = runTest {
         val s = scenario(subRounds = -1)
@@ -188,6 +207,25 @@ class SpeakEachHandlerTests {
         assertContains(backend.requests[1].user, "alice speaks")
     }
 
+    @Test
+    fun logWindowTrimsTheAccumulatedLogTheNextSpeakerSees() = runTest {
+        // The window trims the SAME log the #911 address rule tells the agent to
+        // refer to (ADR-024 lint R17: keep `log_window >= agentCount` for
+        // accumulating scenarios). speak_each is where that interaction bites, so
+        // the axis belongs here and not only on the speak_all sibling.
+        val s = scenario(
+            agents = listOf("A", "B", "C"),
+            prompt = "Log: {conversation_log}",
+            logWindow = 1,
+        )
+        val backend = ScriptedLLMBackend(listOf(says("1"), says("2"), says("3")))
+        handler.execute(context(s, backend), initial(s))
+
+        val third = backend.requests[2].user
+        assertContains(third, "B: 2")
+        assertFalse(third.contains("A: 1"), "window=1 must trim the older entry")
+    }
+
     // MARK: - Anti-repetition seeding (#1105) — sole producer in the engine
 
     @Test
@@ -212,6 +250,9 @@ class SpeakEachHandlerTests {
         // An empty or "..." statement is already caught upstream by the
         // empty-field retry, but a blank-but-nonempty one reaches `lastOutputs`.
         // Dropping the `isNotBlank()` filter makes the second seed `["   "]`.
+        // Depends on `LLMCaller.hasEmptyFields` treating `"   "` as non-empty (it
+        // tests `== "..."` / `isEmpty()`, no trim). If that is ever hardened this
+        // fails as "ScriptedLLMBackend exhausted" rather than as a seed mismatch.
         val s = scenario(agents = listOf("Alice"), subRounds = 2)
         val backend = ScriptedLLMBackend(listOf(says("   "), says("alice-r2")))
         handler.execute(context(s, backend), initial(s))
@@ -246,6 +287,8 @@ class SpeakEachHandlerTests {
         // suite alone stays green with the call dropped entirely. The write also has
         // to survive the SAME `state.copy` as the log and `lastOutputs` writes; a
         // second copy off the original would silently discard one of the three.
+        // Same shape as `ChooseHandlerTests`' fold assertion — see that suite's
+        // § "State threading" reasoning.
         val s = scenario(
             agents = listOf("Alice"),
             outputSchema = mapOf("statement" to "string", "mood" to "string"),
@@ -259,6 +302,12 @@ class SpeakEachHandlerTests {
         // The other two success-path writes must have survived the same copy.
         assertEquals(1, next.conversationLog.size)
         assertEquals("hi", next.lastOutputs["Alice"]?.fields?.get("statement"))
+        // `nextVariables` is derived from the PERSISTED `state.variables`, never
+        // from the throwaway prompt map. Reusing the latter would persist every
+        // reserved-namespace token — leaking one agent's `assigned` / `my_whispers`
+        // into the next agent's `appendPrivateSections` read — and no other
+        // assertion in this suite would move.
+        assertEquals(setOf("mood_Alice"), next.variables.keys)
     }
 
     // MARK: - simulationLanguage override on the fallback prompt (ADR-010 Step E)
@@ -334,10 +383,20 @@ class SpeakEachHandlerTests {
     }
 
     @Test
-    fun systemicErrorPropagatesTypedWithoutSkip() = runTest {
-        // ADR-021 D3: a deterministic engineering bug aborts the run in one throw
-        // and is never converted into a skipped turn. `SystemicProbeError` stands
-        // in for Swift's `LLMError.invalidGrammar`, which is not ported to Kotlin.
+    fun theHandlerAddsNoCatchOfItsOwnAroundATurn() = runTest {
+        // NOT an ADR-021 D3 classification test, despite the shape. The error is
+        // thrown from the backend, i.e. outside `LLMCaller`'s mapping, so widening
+        // `TurnFailureGate.isTurnDegradable` — the actual D3 regression — leaves
+        // this green. D3 classification is `TurnFailureGateTests.systemicError
+        // RethrowsTypedWithoutSkip`, and `SpeakAllHandlerTests` records why no
+        // handler-level D3 case exists yet (every failure a ScriptedLLMBackend can
+        // produce maps to the degradable `LlmGenerationFailed` until the Stage-3
+        // `StreamFailure` taxonomy lands).
+        //
+        // What it DOES pin is narrower and still worth having: this handler wraps
+        // its turn in no `try`/`catch` of its own, so nothing here can swallow a
+        // non-degradable throw into a skip. Restore the real D3 case with the
+        // taxonomy (#501).
         val s = scenario()
         val events = mutableListOf<SimulationEvent>()
 
@@ -349,7 +408,14 @@ class SpeakEachHandlerTests {
     }
 }
 
-/** Stands in for a systemic (non-turn-degradable) engineering fault. */
+/**
+ * Stands in for a fault the gate must not degrade.
+ *
+ * Extends [Exception] deliberately, mirroring `TurnFailureGateTests`' `ProbeError`:
+ * it must stay disjoint from `CancellationException` (itself an
+ * `IllegalStateException`), or a later "simplify to IllegalStateException" edit
+ * would silently reclassify this as the cancellation path.
+ */
 private class SystemicProbeError : Exception("systemic")
 
 /** A backend whose call is a systemic fault rather than a generation failure. */

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/SpeakEachHandlerTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/SpeakEachHandlerTests.kt
@@ -1,0 +1,359 @@
+package com.pastura.engine
+
+import com.pastura.models.Persona
+import com.pastura.models.Phase
+import com.pastura.models.PhaseType
+import com.pastura.models.Scenario
+import com.pastura.models.SimulationEvent
+import com.pastura.models.SimulationState
+import com.pastura.models.TurnOutput
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Kotlin sibling of Swift's `SpeakEachHandlerTests` (+ its `…+TurnDegradation`
+ * split), collapsed into one class per the commonTest convention.
+ *
+ * `speak_each` is the accumulating speak phase and the engine's **sole** seeder of
+ * the DRY anti-repetition sampler (#1105). The cases below pin, in ADR-023 §12
+ * terms, the mechanisms a green-but-wrong port would silently lose — the sub-round
+ * loop and its untrusted-input clamp, the within-phase accumulation that reaches
+ * the next speaker's *prompt* (not merely the log), the per-agent seed selection
+ * and its blank filter, `captureMood`, and both ADR-021 degradation arms.
+ *
+ * **Why the seed cases assert against `backend.requests`**: this handler is the
+ * only producer of `antiRepetitionSeeds`, so no consumer test can catch a dropped
+ * seed — a backend handed `emptyList()` behaves exactly like one serving a phase
+ * that legitimately does not seed. Asserting at `LLMCaller` level would pin the
+ * plumbing while leaving the decision of *what* to seed untested.
+ *
+ * Ported for the ADR-023 KMP Engine migration (#501, #1307).
+ */
+class SpeakEachHandlerTests {
+
+    private val handler = SpeakEachHandler()
+
+    private fun scenario(
+        agents: List<String> = listOf("Alice", "Bob"),
+        language: String = "en",
+        simulationLanguage: String? = null,
+        prompt: String? = "Talk",
+        subRounds: Int? = null,
+        outputSchema: Map<String, String> = mapOf("statement" to "string"),
+        logWindow: Int? = null,
+    ) = Scenario(
+        id = "t",
+        name = "T",
+        description = "d",
+        language = language,
+        simulationLanguage = simulationLanguage,
+        agentCount = agents.size,
+        rounds = 2,
+        logWindow = logWindow,
+        context = "A test.",
+        personas = agents.map { Persona(name = it, description = "$it's persona.") },
+        phases = listOf(
+            Phase(
+                type = PhaseType.SPEAK_EACH,
+                prompt = prompt,
+                outputSchema = outputSchema,
+                subRounds = subRounds,
+            ),
+        ),
+    )
+
+    private fun context(
+        s: Scenario,
+        backend: LLMBackend,
+        events: MutableList<SimulationEvent> = mutableListOf(),
+    ) = PhaseContext(
+        scenario = s,
+        phase = s.phases[0],
+        backend = backend,
+        suspensionRelay = SuspensionRelay(),
+        emitter = { events += it },
+        pauseCheck = { },
+        phasePath = listOf(0),
+        turnGate = TurnFailureGate(),
+    )
+
+    private fun says(statement: String) =
+        ScriptedLLMBackend.Script.completing("""{"statement": "$statement"}""")
+
+    private fun failing() =
+        ScriptedLLMBackend.Script(terminal = TerminalStatus.Failed(errorCode = "transient blip"))
+
+    private fun initial(s: Scenario) = SimulationState.initial(s).copy(currentRound = 1)
+
+    private fun skips(events: List<SimulationEvent>) =
+        events.filterIsInstance<SimulationEvent.TurnSkipped>()
+
+    private fun outputs(events: List<SimulationEvent>) =
+        events.filterIsInstance<SimulationEvent.AgentOutput>()
+
+    // MARK: - Sub-round loop
+
+    @Test
+    fun executesSubRoundsInOrder() = runTest {
+        // 2 agents x 2 sub-rounds = 4 calls, personas in declaration order within
+        // each sub-round.
+        val s = scenario(subRounds = 2)
+        val backend = ScriptedLLMBackend(listOf(says("A1"), says("B1"), says("A2"), says("B2")))
+        val next = handler.execute(context(s, backend), initial(s))
+
+        assertEquals(4, backend.callCount)
+        assertEquals(
+            listOf("Alice", "Bob", "Alice", "Bob"),
+            next.conversationLog.map { it.agentName },
+        )
+    }
+
+    @Test
+    fun defaultsToOneSubRound() = runTest {
+        val s = scenario()
+        val backend = ScriptedLLMBackend(listOf(says("hi"), says("hey")))
+        handler.execute(context(s, backend), initial(s))
+        assertEquals(2, backend.callCount)
+    }
+
+    @Test
+    fun skipsEliminatedAgents() = runTest {
+        val s = scenario()
+        val backend = ScriptedLLMBackend(listOf(says("only Alice")))
+        val state = initial(s).copy(eliminated = mapOf("Bob" to true))
+        handler.execute(context(s, backend), state)
+        assertEquals(1, backend.callCount)
+    }
+
+    // MARK: - subRounds clamp (untrusted YAML guard, #1064)
+
+    @Test
+    fun zeroSubRoundsRunsOncePerPersona() = runTest {
+        // Swift clamps because `1...0` forms an invalid ClosedRange and TRAPS.
+        // Kotlin's `1..0` is merely EMPTY, so an unclamped port would run zero
+        // inferences and emit an empty phase — no crash, no diagnostic. That
+        // quieter failure is what this pins: reverting `maxOf(1, …)` turns the
+        // expected 2 into 0.
+        val s = scenario(subRounds = 0)
+        val backend = ScriptedLLMBackend(listOf(says("A1"), says("B1")))
+        handler.execute(context(s, backend), initial(s))
+        assertEquals(2, backend.callCount)
+    }
+
+    @Test
+    fun negativeSubRoundsRunsOncePerPersona() = runTest {
+        val s = scenario(subRounds = -1)
+        val backend = ScriptedLLMBackend(listOf(says("A1"), says("B1")))
+        handler.execute(context(s, backend), initial(s))
+        assertEquals(2, backend.callCount)
+    }
+
+    // MARK: - Accumulation within sub-rounds (the speak_all difference)
+
+    @Test
+    fun accumulatesConversationWithinSubRounds() = runTest {
+        val s = scenario(prompt = "{conversation_log}", subRounds = 2)
+        val backend = ScriptedLLMBackend(
+            listOf(says("first"), says("second"), says("third"), says("fourth")),
+        )
+        val next = handler.execute(context(s, backend), initial(s))
+
+        assertEquals(4, next.conversationLog.size)
+        assertEquals("first", next.conversationLog[0].content)
+        assertEquals("fourth", next.conversationLog[3].content)
+    }
+
+    @Test
+    fun eachSpeakerSeesTheEarlierSpeakersOfTheSameSubRoundInItsPrompt() = runTest {
+        // The mechanism the log assertion above does NOT reach. Accumulation is
+        // produced by threading each turn's returned state into the next turn, so
+        // reading `state` (the phase-start value) instead of the threaded `current`
+        // would leave the log correct at the end while every prompt saw an empty
+        // conversation. Asserting the PROMPT is what separates the two.
+        val s = scenario(prompt = "Log: {conversation_log}")
+        val backend = ScriptedLLMBackend(listOf(says("alice speaks"), says("bob speaks")))
+        handler.execute(context(s, backend), initial(s))
+
+        assertEquals(2, backend.requests.size)
+        assertFalse(
+            backend.requests[0].user.contains("alice speaks"),
+            "the first speaker must not see itself",
+        )
+        assertContains(backend.requests[1].user, "alice speaks")
+    }
+
+    // MARK: - Anti-repetition seeding (#1105) — sole producer in the engine
+
+    @Test
+    fun seedsOwnPriorStatementPerAgentAcrossSubRounds() = runTest {
+        // Call order: Alice-r1, Bob-r1, Alice-r2, Bob-r2. Each agent's second turn
+        // seeds ITS OWN first-turn statement — not the globally-last one, which is
+        // the tempting simplification and would seed Alice-r2 with "bob-r1".
+        val s = scenario(subRounds = 2)
+        val backend = ScriptedLLMBackend(
+            listOf(says("alice-r1"), says("bob-r1"), says("alice-r2"), says("bob-r2")),
+        )
+        handler.execute(context(s, backend), initial(s))
+
+        assertEquals(
+            listOf(emptyList(), emptyList(), listOf("alice-r1"), listOf("bob-r1")),
+            backend.requests.map { it.antiRepetitionSeeds },
+        )
+    }
+
+    @Test
+    fun whitespaceOnlyPriorDoesNotSeed() = runTest {
+        // An empty or "..." statement is already caught upstream by the
+        // empty-field retry, but a blank-but-nonempty one reaches `lastOutputs`.
+        // Dropping the `isNotBlank()` filter makes the second seed `["   "]`.
+        val s = scenario(agents = listOf("Alice"), subRounds = 2)
+        val backend = ScriptedLLMBackend(listOf(says("   "), says("alice-r2")))
+        handler.execute(context(s, backend), initial(s))
+
+        assertEquals(
+            listOf(emptyList(), emptyList()),
+            backend.requests.map { it.antiRepetitionSeeds },
+        )
+    }
+
+    @Test
+    fun seedsThePriorStatementCarriedInFromAnEarlierPhase() = runTest {
+        // `lastOutputs` survives across phases, so the FIRST sub-round is not
+        // unconditionally unseeded — it seeds whatever the agent last said. Pins
+        // that the seed reads state rather than a phase-local accumulator.
+        val s = scenario(agents = listOf("Alice"))
+        val backend = ScriptedLLMBackend(listOf(says("fresh")))
+        val state = initial(s).copy(
+            lastOutputs = mapOf("Alice" to TurnOutput(fields = mapOf("statement" to "from an earlier phase"))),
+        )
+        handler.execute(context(s, backend), state)
+
+        assertEquals(listOf("from an earlier phase"), backend.requests.single().antiRepetitionSeeds)
+    }
+
+    // MARK: - captureMood (#913)
+
+    @Test
+    fun capturesMoodIntoTheReservedStateVariable() = runTest {
+        // No Swift sibling — `SpeakEachHandler.swift` calls `captureMood` on its
+        // success path but no Swift test covers it, so a faithful port of the Swift
+        // suite alone stays green with the call dropped entirely. The write also has
+        // to survive the SAME `state.copy` as the log and `lastOutputs` writes; a
+        // second copy off the original would silently discard one of the three.
+        val s = scenario(
+            agents = listOf("Alice"),
+            outputSchema = mapOf("statement" to "string", "mood" to "string"),
+        )
+        val backend = ScriptedLLMBackend(
+            listOf(ScriptedLLMBackend.Script.completing("""{"statement": "hi", "mood": "uneasy"}""")),
+        )
+        val next = handler.execute(context(s, backend), initial(s))
+
+        assertEquals("uneasy", next.variables["mood_Alice"])
+        // The other two success-path writes must have survived the same copy.
+        assertEquals(1, next.conversationLog.size)
+        assertEquals("hi", next.lastOutputs["Alice"]?.fields?.get("statement"))
+    }
+
+    // MARK: - simulationLanguage override on the fallback prompt (ADR-010 Step E)
+
+    @Test
+    fun honorsSimulationLanguageOverrideJaToEn() = runTest {
+        // `prompt = null` forces the pickLanguage fallback, which is the only text
+        // the override can move here.
+        val s = scenario(language = "ja", simulationLanguage = "en", prompt = null)
+        val backend = ScriptedLLMBackend(listOf(says("hello"), says("world")))
+        handler.execute(context(s, backend), initial(s))
+
+        val user = backend.requests[0].user
+        assertContains(user, "Conversation so far")
+        assertFalse(user.contains("これまでの会話"))
+    }
+
+    @Test
+    fun honorsSimulationLanguageOverrideEnToJa() = runTest {
+        val s = scenario(language = "en", simulationLanguage = "ja", prompt = null)
+        val backend = ScriptedLLMBackend(listOf(says("hello"), says("world")))
+        handler.execute(context(s, backend), initial(s))
+
+        val user = backend.requests[0].user
+        assertContains(user, "これまでの会話")
+        assertFalse(user.contains("Conversation so far"))
+    }
+
+    // MARK: - Turn degradation (ADR-021 D1/D2/D3)
+
+    @Test
+    fun transientFailureSkipsTurnAndOthersStillSpeak() = runTest {
+        // Alice's call fails turn-degradably; Bob and Charlie still speak in the
+        // same sub-round. The stale prior-round `lastOutputs` for Alice is cleared
+        // so a downstream consumer cannot read a decision that never happened.
+        val s = scenario(agents = listOf("Alice", "Bob", "Charlie"))
+        val backend = ScriptedLLMBackend(
+            listOf(failing(), says("hello from Bob"), says("hello from Charlie")),
+        )
+        val events = mutableListOf<SimulationEvent>()
+        val state = initial(s).copy(
+            lastOutputs = mapOf("Alice" to TurnOutput(fields = mapOf("statement" to "stale"))),
+        )
+        val next = handler.execute(context(s, backend, events), state)
+
+        assertEquals(listOf("Bob", "Charlie"), outputs(events).map { it.agent })
+        assertEquals(listOf("Bob", "Charlie"), next.conversationLog.map { it.agentName })
+
+        val skipped = skips(events)
+        assertEquals(1, skipped.size)
+        assertEquals("Alice", skipped.single().agent)
+        assertEquals(PhaseType.SPEAK_EACH, skipped.single().phaseType)
+
+        assertNull(next.lastOutputs["Alice"])
+        assertEquals("hello from Bob", next.lastOutputs["Bob"]?.fields?.get("statement"))
+        assertEquals("hello from Charlie", next.lastOutputs["Charlie"]?.fields?.get("statement"))
+    }
+
+    @Test
+    fun aSkippedTurnLeavesTheNextSubRoundUnseeded() = runTest {
+        // The seed reads `lastOutputs`, and the D2 skip clears it — so the agent's
+        // next sub-round seeds empty rather than re-seeding a pre-failure
+        // statement. Both mechanisms are Swift-faithful; this pins their
+        // interaction, which neither one's own test observes.
+        val s = scenario(agents = listOf("Alice"), subRounds = 3)
+        val backend = ScriptedLLMBackend(listOf(says("first"), failing(), says("third")))
+        handler.execute(context(s, backend), initial(s))
+
+        assertEquals(
+            listOf(emptyList(), listOf("first"), emptyList()),
+            backend.requests.map { it.antiRepetitionSeeds },
+        )
+    }
+
+    @Test
+    fun systemicErrorPropagatesTypedWithoutSkip() = runTest {
+        // ADR-021 D3: a deterministic engineering bug aborts the run in one throw
+        // and is never converted into a skipped turn. `SystemicProbeError` stands
+        // in for Swift's `LLMError.invalidGrammar`, which is not ported to Kotlin.
+        val s = scenario()
+        val events = mutableListOf<SimulationEvent>()
+
+        assertFailsWith<SystemicProbeError> {
+            handler.execute(context(s, ThrowingBackend(), events), initial(s))
+        }
+        assertTrue(skips(events).isEmpty())
+        assertTrue(outputs(events).isEmpty())
+    }
+}
+
+/** Stands in for a systemic (non-turn-degradable) engineering fault. */
+private class SystemicProbeError : Exception("systemic")
+
+/** A backend whose call is a systemic fault rather than a generation failure. */
+private class ThrowingBackend : LLMBackend {
+    override fun generateStream(request: GenerationRequest, callbacks: StreamCallbacks): StreamHandle =
+        throw SystemicProbeError()
+}

--- a/shared/prompt-literal-parity-allowlist.tsv
+++ b/shared/prompt-literal-parity-allowlist.tsv
@@ -35,6 +35,5 @@
 # fails on a row that no longer matches anything — a healed divergence must drop
 # its row rather than linger as a standing exemption.
 side	stem	digest	excerpt	reason
-swift-only	PromptBuilder	3754ae85aab4	\\n- これまでの会話に他の誰かの発言があれば、そのうち1人の発言に必ず触れてから自分の意見…	The #911 speak_each address rule. PromptBuilder.kt's class doc names it as the one phase-specific appendix left as a Stage-3 unit; it lands with the speak_each handler port (#501). Drop this row then.
 unported	NarrateHandler	-	-	ADR-023 Stage 3: narrate is not in the Wave B port set yet (#501).
 unported	SpeakEachHandler	-	-	ADR-023 Stage 3: speak_each is not ported yet (#501). Ports together with the swift-only PromptBuilder row above.

--- a/shared/prompt-literal-parity-allowlist.tsv
+++ b/shared/prompt-literal-parity-allowlist.tsv
@@ -24,9 +24,10 @@
 #            exempts every literal in that file, including ones added after it was
 #            approved. It expires only when the Kotlin counterpart appears (which
 #            the checker reports as stale). Because "keep them scarce" is advice
-#            nothing executes, the checker caps them — `MAX_UNPORTED_ROWS = 2`
-#            today, matching the two below. Raising it is a deliberate act, and
-#            the reason belongs here.
+#            nothing executes, the checker caps them — `MAX_UNPORTED_ROWS` is held
+#            AT the current row count (1 today), never above it, so the budget
+#            ratchets down as the port lands instead of leaving a free slot.
+#            Raising it is a deliberate act, and the reason belongs here.
 #   excerpt  a readable, escaped prefix of the ja literal. Cosmetic; the digest is
 #            what matches. `<>` marks an erased interpolation.
 #   reason   why the divergence is intended. Required; a blank fails the gate.
@@ -36,4 +37,3 @@
 # its row rather than linger as a standing exemption.
 side	stem	digest	excerpt	reason
 unported	NarrateHandler	-	-	ADR-023 Stage 3: narrate is not in the Wave B port set yet (#501).
-unported	SpeakEachHandler	-	-	ADR-023 Stage 3: speak_each is not ported yet (#501). Ports together with the swift-only PromptBuilder row above.

--- a/tools/kmp-gate-spike/Tests/KMPGateSpikeTests/BoundaryContractTests.swift
+++ b/tools/kmp-gate-spike/Tests/KMPGateSpikeTests/BoundaryContractTests.swift
@@ -524,8 +524,14 @@ func pollUntil(
 
 extension GenerationRequest {
   /// A request whose content no assertion depends on.
+  ///
+  /// `antiRepetitionSeeds:` is passed explicitly even though Kotlin declares a
+  /// default: K/N exports carry no default-argument values, so the generated
+  /// initializer requires every parameter (`.claude/rules/kmp-interop.md`
+  /// Pattern 3). Adding a Kotlin property with a default is therefore a
+  /// **source-breaking** change on this side.
   static var probe: GenerationRequest {
-    GenerationRequest(system: "system", user: "user", schema: nil)
+    GenerationRequest(system: "system", user: "user", schema: nil, antiRepetitionSeeds: [])
   }
 }
 


### PR DESCRIPTION
## Summary

Ports `SpeakEachHandler` to `shared/engine`'s `commonMain` — ADR-023 Stage 3, Wave B, LLM handler #5. Board **11/14 → 12/14**; remaining order is Narrate → Conditional.

SpeakEach is its own PR because it is the **only Engine consumer that seeds the DRY anti-repetition sampler** (#1105), so it is the one handler that widens the Kotlin `LLMCaller` / `GenerationRequest` boundary. `LLMBackend.kt`'s existing KDoc already anticipated this — *"Deliberately omits `antiRepetitionSeeds` … Add it with its consumer."* — so the widening follows the design note rather than deviating from it. ADR-023 does not enumerate `GenerationRequest`'s fields (only the `generateStream` signature), so no ADR edit was needed.

It also lands the deferred #911 `addressRule`, which was the last `swift-only` row in the prompt-literal parity allowlist.

### Behaviour notes worth a reviewer's attention

- **Threaded state, not a frozen snapshot.** `speakTurn` threads a single `current` (the Choose/Vote shape), not `WhisperHandler`'s phase-start snapshot. That choice *is* the accumulation: each turn formats its `conversation_log` from the state the previous turn returned. The test asserts the **prompt** rather than the log, because a snapshot-reading port leaves the final log correct while every prompt sees an empty conversation.
- **All three success-path writes fold into ONE `state.copy`** — log entry, `lastOutputs`, `captureMood`. A second copy off the original drops one silently.
- **The clamp's failure mode differs from Swift's.** `1...0` traps in Swift; `1..0` is merely an empty range in Kotlin, so an unclamped port runs zero inferences and emits an empty phase with no crash and no diagnostic. The why-comment says so.
- **`MAX_UNPORTED_ROWS` drops 2 → 1**, held at the current row count so the deferral budget ratchets down with the port instead of leaving a free slot the next deferral could take unreviewed.

## §12 perturbation measurement

Each mechanism was broken in isolation and the resulting red set measured. The harness **declares the claimant test per axis and fails when that claimant is not in the red set** — "the axis went RED" alone would accept a misattributed comment.

| Axis | Red | Declared claimant reddened |
|---|--:|---|
| subRounds clamp | 2 | ✅ `zeroSubRounds…`, `negativeSubRounds…` |
| state threading (accumulation) | 7 | ✅ `eachSpeakerSees…InItsPrompt`, `accumulatesConversationWithinSubRounds` |
| seed selection is per-agent | 1 | ✅ `seedsOwnPriorStatementPerAgentAcrossSubRounds` |
| seed blank filter | 1 | ✅ `whitespaceOnlyPriorDoesNotSeed` |
| seeds passed to the backend at all | 3 | ✅ `seedsOwnPrior…`, `seedsThePriorStatementCarriedInFromAnEarlierPhase` |
| `captureMood` on the success path | 1 | ✅ `capturesMoodIntoTheReservedStateVariable` |
| persisted vars are NOT the scratch prompt map | 1 | ✅ `capturesMoodIntoTheReservedStateVariable` |
| D2 clears stale `lastOutputs` on skip | 2 | ✅ `transientFailure…`, `aSkippedTurnLeavesTheNextSubRoundUnseeded` |
| `eliminated` guard polarity (`== true`) | 17 | ✅ `skipsEliminatedAgents` |
| `logWindow` reaches the log formatter | 1 | ✅ `logWindowTrimsTheAccumulatedLog…` |
| dispatcher registration | 2 | ✅ `resolvesTheSpeakEachHandler`, `everyUnportedPhaseTypeFailsCleanly…` |
| addressRule **append** | 3 | ✅ ja / en / precedes-mood |
| addressRule **type gate** | 1 | ✅ `addressRuleOmittedForSpeakAllPhase` |

**Three measurement defects were found and fixed, not written up as successes:**

1. **Misattribution.** `everyUnportedPhaseTypeFailsCleanlyRatherThanCrashing` was declared as a claimant for dispatcher registration and did **not** redden — its unported set was a hand-written exclusion list that already excluded `SPEAK_EACH`, so de-registering the handler just moved that case into the excluded set. Fixed at the cause: the set is now **derived from the dispatcher**, so it can no longer disagree with it. The axis now reddens it.
2. **Mislabeled axis with a missing control.** The original "addressRule gate" axis actually removed the *append*, and credited the three presence tests. Deleting the real *type gate* while keeping the append leaves all three green — only `addressRuleOmittedForSpeakAllPhase` sees it, and that test was in no axis at all. Split into two axes.
3. **Inflated red set.** "state threading → 7 red" overstates the coverage: only `eachSpeakerSees…InItsPrompt` and `accumulatesConversationWithinSubRounds` claim the mechanism. The other five redden incidentally (a frozen phase-start state also empties `lastOutputs`, so the seeds go empty). Read it as one dedicated prompt-level claimant plus one log-level one.

## Test plan

- `./gradlew :shared:models:jvmTest :shared:engine:jvmTest :shared:engine:compileCommonMainKotlinMetadata :shared:models:compileKotlinIosSimulatorArm64 :shared:engine:compileKotlinIosSimulatorArm64` — green. Counts read from the JUnit XML, not from Gradle's cached green: **models 211 / engine 526**, 0 failures (engine +22 on this branch; `SpeakEachHandlerTests` = 18).
- `check-prompt-literal-parity.py --self-test` + `--check` — clean, 43 Swift / 37 Kotlin pairs. Verified by **negative control**: perturbing one character of the new Kotlin `addressRule` ja literal reddens the gate, so it genuinely sees the `+`-concatenated pair.
- `check-kmp-status.py --self-test` + `--check` — 14 handlers, 12 ported ↔ board reconcile both directions.
- `tools/kmp-gate-spike/scripts/stage-framework.sh` + `swift build --package-path tools/kmp-gate-spike --build-tests`. **This is not covered by any per-PR CI job** (the spike builds nightly / `workflow_dispatch` only, ADR-023 §6 decision B′), so it was run locally. `--build-tests` is load-bearing — plain `swift build` does not compile the test target, i.e. does not compile the one file this PR edits there.

## Device QA

実機QA不要 — `shared/**` (KMP Kotlin), gate scripts, and docs only. The iOS app target does not consume the XCFramework yet (Phase 3.0-gated, ADR-023 §6), so nothing in this diff reaches a running app.

Closes #1307.
Part of #501.
