### PR TITLE
📝 docs: promote probe-reading discipline + Kotlin port traps into .claude/rules/

### DIFF
--- a/.claude/rules/kmp-interop.md
+++ b/.claude/rules/kmp-interop.md
@@ -145,8 +145,8 @@ Same class of trap:
 
 ## Pattern 4 — traps inside the Kotlin port (`commonMain`, `commonTest`, the port gates)
 
-Patterns 1–3 are about the K/N *boundary*. These fire while writing the port itself, and each one
-compiles or passes somewhere before failing where it counts.
+Patterns 1–3 are about the K/N *boundary*. These fire while writing the port itself, and most of
+them compile or pass somewhere before failing where it counts.
 
 **`commonMain` is not the platform stdlib.** An API present on JVM *and* Native is not necessarily
 in the *common* stdlib. Every per-target compile (`compileKotlinIosSimulatorArm64`, `jvmTest`)
@@ -155,7 +155,8 @@ resolves it and passes — only `compileCommonMainKotlinMetadata` fails. **Run
 instances found so far carry their own why-comments at the call site (`RegexOption.DOT_MATCHES_ALL`,
 `String.codePointCount`, `Map.toSortedMap`); the rule here is the task, not the list.
 
-**Divergences that compile clean:**
+**Divergences from the Swift original** (the first fails loudly at the port site; the second is the
+compile-clean one):
 
 | Swift | Kotlin | Consequence |
 |---|---|---|
@@ -164,8 +165,8 @@ instances found so far carry their own why-comments at the call site (`RegexOpti
 
 **The schema guard sits at a different place in each engine — a live behavioural divergence, not a
 porting choice.** The two `hasAllExpectedKeys` helpers are identical (both reject a present-but-empty
-expected key), and so is the `LLMCaller` empty-field branch (`LLMCaller.kt:164` says so in its own
-comment). The divergence is **entirely in the parser**: Swift's happy path returns before any guard
+expected key), and so is the `LLMCaller` empty-field branch (`LLMCaller.kt:160-164` says so in its
+own comment). The divergence is **entirely in the parser**: Swift's happy path returns before any guard
 (`JSONResponseParser.swift:95-97`) and applies it only on the salvage and post-repair paths
 (`:105`, `:153`), whereas Kotlin applies it on every successful parse **when the phase declares an
 `output:` schema** (`expectedKeys.isNotEmpty()`, `JSONResponseParser.kt:105`). So for a well-formed
@@ -182,9 +183,14 @@ assert the **skip mechanism** (`TurnSkipped` emitted, no `AgentOutput`, prior va
 the guard. Asserting the guard is coverage theater: revert it and the test stays green (the same rule
 Swift-side is `testing.md` § "A regression test must drive the exact unguarded-path input"). The
 declaration is validator-enforced for reflect→`note` and whisper→`statement`
-(`ScenarioValidator.swift:264,278`). For an **undeclared** key — an optional `mood`, or any key on a
-schema-less phase — `expectedKeys` is empty, the parser guard never runs, and the handler guard *is*
-reachable: there a direct test is correct, and so is porting the Swift one.
+(`ScenarioValidator.swift:264,278`), and the handler must actually pass the schema through
+(`schema = OutputSchema.from(context.phase)`) — omit that and `expectedKeys` is empty again. For an
+**undeclared** key — an optional `mood`, or any key on a schema-less phase — the parser guard never
+runs and the handler guard *is* reachable: there a direct test is correct, and so is porting the
+Swift one. ⚠️ The `TurnSkipped` assertion holds only **below** `TurnFailureGate.consecutiveSkipLimit`
+— the tripping failure throws `TurnFailureLimitReached` and emits no `TurnSkipped`
+(`TurnFailureGate.kt:77-80`), so a test driving that many consecutive empty turns fails the very
+assertion this rule prescribes.
 
 **Stage a new `.kt` before believing either gate.** `check-kmp-status.py` and the prompt-literal
 parity gate both scope themselves to tracked files (correctly — `ci-workflows.md` § "Gate scripts"),

--- a/.claude/rules/kmp-interop.md
+++ b/.claude/rules/kmp-interop.md
@@ -6,8 +6,8 @@ paths:
 
 # KMP Interop Rules
 
-Traps at the Kotlin/Native (K/N) ↔ Swift boundary of the ADR-023 KMP Engine migration
-(`shared/models`, `shared/engine`). Two shapes:
+Traps of the ADR-023 KMP Engine migration (`shared/models`, `shared/engine`) — at the
+Kotlin/Native (K/N) ↔ Swift boundary, and inside the Kotlin port itself. Three shapes:
 
 - **Compile-time interop traps (Patterns 1–2)** — surface at the *Swift consumption* site when
   Swift code imports the generated `PasturaShared` XCFramework. On main that consumer is
@@ -20,6 +20,8 @@ Traps at the Kotlin/Native (K/N) ↔ Swift boundary of the ADR-023 KMP Engine mi
   they compile-fail today.
 - **Plan-time shape trap (Pattern 3)** — fires whenever a plan exercises a K/N type shape; fully
   in-scope for `shared/**` edits.
+- **Port-time traps (Pattern 4)** — fire while writing the Kotlin port and its tests, with no Swift
+  consumer involved; fully in-scope for `shared/**` edits.
 
 > **Prompt-literal parity with the Swift original** is gate-enforced
 > (`scripts/check-prompt-literal-parity.py`) and documented on the Swift side, in
@@ -140,3 +142,61 @@ Same class of trap:
 - **`val` is read-only in Swift** — a `data class val` property cannot be mutated in place; use
   `.copy(...)` or whole-instance reassignment.
 - **Sealed-class export shape varies** — class vs enum-like surface differs (see Pattern 2).
+
+## Pattern 4 — traps inside the Kotlin port (`commonMain`, `commonTest`, the port gates)
+
+Patterns 1–3 are about the K/N *boundary*. These fire while writing the port itself, and each one
+compiles or passes somewhere before failing where it counts.
+
+**`commonMain` is not the platform stdlib.** An API present on JVM *and* Native is not necessarily
+in the *common* stdlib. Every per-target compile (`compileKotlinIosSimulatorArm64`, `jvmTest`)
+resolves it and passes — only `compileCommonMainKotlinMetadata` fails. **Run
+`./gradlew :shared:engine:compileCommonMainKotlinMetadata` locally before pushing a port.** The
+instances found so far carry their own why-comments at the call site (`RegexOption.DOT_MATCHES_ALL`,
+`String.codePointCount`, `Map.toSortedMap`); the rule here is the task, not the list.
+
+**Divergences that compile clean:**
+
+| Swift | Kotlin | Consequence |
+|---|---|---|
+| `SimulationError` is thrown directly | it is a `@Serializable sealed class`, **not** a `Throwable` — the engine throws it wrapped in `SimulationException` | unwrap before matching; a `catch` on the raw case does not compile |
+| `1...0` traps | `1..0` is an **empty range** | a clamp port's failure mode flips from crash to silent zero-iteration, so a why-comment must say which engine it describes |
+
+**The schema guard sits at a different place in each engine — a live behavioural divergence, not a
+porting choice.** The two `hasAllExpectedKeys` helpers are identical (both reject a present-but-empty
+expected key), and so is the `LLMCaller` empty-field branch (`LLMCaller.kt:164` says so in its own
+comment). The divergence is **entirely in the parser**: Swift's happy path returns before any guard
+(`JSONResponseParser.swift:95-97`) and applies it only on the salvage and post-repair paths
+(`:105`, `:153`), whereas Kotlin applies it on every successful parse **when the phase declares an
+`output:` schema** (`expectedKeys.isNotEmpty()`, `JSONResponseParser.kt:105`). So for a well-formed
+but all-empty response (`{"note":""}`) to a schema-declaring phase:
+
+| | Swift | Kotlin |
+|---|---|---|
+| parser | returns the empty output | throws `JsonParseFailed` |
+| `LLMCaller` | `empty_field` retry; the **last attempt returns** the empty output | `parse_failed` every attempt → `RetriesExhausted` → turn-gate skip |
+
+**Apply.** On the Kotlin side a handler's non-empty guard on a key the phase's `output:` **declares**
+is defensive parity, unreachable via that path — so an "empty output doesn't erase X" test must
+assert the **skip mechanism** (`TurnSkipped` emitted, no `AgentOutput`, prior value survives), never
+the guard. Asserting the guard is coverage theater: revert it and the test stays green (the same rule
+Swift-side is `testing.md` § "A regression test must drive the exact unguarded-path input"). The
+declaration is validator-enforced for reflect→`note` and whisper→`statement`
+(`ScenarioValidator.swift:264,278`). For an **undeclared** key — an optional `mood`, or any key on a
+schema-less phase — `expectedKeys` is empty, the parser guard never runs, and the handler guard *is*
+reachable: there a direct test is correct, and so is porting the Swift one.
+
+**Stage a new `.kt` before believing either gate.** `check-kmp-status.py` and the prompt-literal
+parity gate both scope themselves to tracked files (correctly — `ci-workflows.md` § "Gate scripts"),
+so an **untracked** new handler reads as "marked [x] but no ported .kt exists" / "no Kotlin
+counterpart". The tracked directory is **`Phases/` with a capital P** (`KT_PHASES_DIR` is the
+authority); macOS's case-insensitive filesystem lets a lowercase path work locally and fail the gate.
+
+**A Models change can break `shared/engine`.** Adding a `SimulationError` case broke
+`SimulationException`'s exhaustive `when`, and `:shared:models:jvmTest` alone is blind to it. Run the
+CI pair — `:shared:models:jvmTest :shared:engine:jvmTest` — before pushing.
+
+**Test authoring: `copy()` replaces a seeded map.** `SimulationState.initial` seeds `eliminated`
+all-`false` for every agent, so `copy(eliminated = mapOf("Bob" to true))` leaves the others
+**absent** — the test can no longer tell `== true` from `!= null`, and a wrong-polarity check stays
+green against real state. Write the `false` entries explicitly, plus an absent-key case.

--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -3,10 +3,6 @@
 > Derived from [claude-kit](https://github.com/tyabu12/claude-kit) `rules/knowledge-layering.md` —
 > the generic core is canonical there; reconcile one-way (kit → Pastura). Pastura-specific
 > content lives only in this copy.
->
-> ⚠️ 2026-07-29: the probe-outcome text + subagent-verdict row landed here ahead of claude-kit PR #12
-> (open) — once it merges, reconcile the generic core from the kit, keep this copy's
-> `swift-isolation.md` pointer, and delete this note.
 
 Always-loaded — see `CLAUDE.md` `## Context-Specific Rules`. Pairs with `context-budget.md` (content discipline within always-loaded files); this rule covers location choice across all storage tiers.
 

--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -4,10 +4,9 @@
 > the generic core is canonical there; reconcile one-way (kit → Pastura). Pastura-specific
 > content lives only in this copy.
 >
-> ⚠️ As of 2026-07-29 the probe-outcome material in § "Claims you author are assertions too" and
-> its verification-table row landed **here first**, ahead of claude-kit PR #12. That inverts the
-> one-way direction above, so re-diff this file against the kit once #12 merges and take the kit's
-> wording — then delete this note.
+> ⚠️ 2026-07-29: the probe-outcome text + subagent-verdict row landed here ahead of claude-kit PR #12
+> (open) — once it merges, reconcile the generic core from the kit, keep this copy's
+> `swift-isolation.md` pointer, and delete this note.
 
 Always-loaded — see `CLAUDE.md` `## Context-Specific Rules`. Pairs with `context-budget.md` (content discipline within always-loaded files); this rule covers location choice across all storage tiers.
 
@@ -127,7 +126,7 @@ A **why-comment you write** asserts runtime or library behaviour as the reason a
 
 When a check is too expensive to run, say the cause was not isolated. A reader can act on an acknowledged gap; a wrong cause they can only inherit.
 
-Motivating incidents: PR #1152 round-1 review; PR #1299 rounds 1–3; #1312 rounds 1–4; PR #1303 rounds 1–3; PR #1314; PR #1265.
+Motivating incidents: PR #1152 round-1 review; PR #1299 rounds 1–3; #1312 rounds 1–4; PR #1303 rounds 1–3; PR #1314.
 
 ### A rules file created mid-session never injects in that session
 

--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -3,6 +3,11 @@
 > Derived from [claude-kit](https://github.com/tyabu12/claude-kit) `rules/knowledge-layering.md` —
 > the generic core is canonical there; reconcile one-way (kit → Pastura). Pastura-specific
 > content lives only in this copy.
+>
+> ⚠️ As of 2026-07-29 the probe-outcome material in § "Claims you author are assertions too" and
+> its verification-table row landed **here first**, ahead of claude-kit PR #12. That inverts the
+> one-way direction above, so re-diff this file against the kit once #12 merges and take the kit's
+> wording — then delete this note.
 
 Always-loaded — see `CLAUDE.md` `## Context-Specific Rules`. Pairs with `context-budget.md` (content discipline within always-loaded files); this rule covers location choice across all storage tiers.
 
@@ -93,6 +98,7 @@ The same "verify before you lock it" discipline extends past rule assertions to 
 | Two UI surfaces asserted to show "the same metric" | grep both value sources before claiming equivalence — layout/label similarity ≠ value identity; a static estimate and a measured count can read as "matching" yet diverge silently |
 | An external standard (SEO, RFC, sitemap/robots, OAuth, HTTP semantics) | WebSearch + WebFetch the authority (Google Search Central, the RFC, MDN); verbatim-cite before critic |
 | Vendor feature availability (free/paid/plan tier) | WebFetch the canonical docs; verbatim-quote the "Who can use this feature" box — never infer from search snippets |
+| A subagent's verdict on an external platform fact (SDK annotation, threading contract, API availability) | Re-derive it yourself — a verdict that *dismisses* a risk ends inquiry and is the expensive one to get wrong. Then run the prescribed check against a **known-positive control**; `swift-isolation.md` § Pattern 7 is the worked instance |
 
 ### Apply (verification table)
 
@@ -114,12 +120,14 @@ A 30-second self-check prevents 1–2 extra critic / code-reviewer rounds. Motiv
 A **why-comment you write** asserts runtime or library behaviour as the reason a mechanism exists — the same kind of claim as the table's, but authored at implementation *or review-fix* time and executed by nobody. Reviewers check whether the *code* is correct, not whether the *stated reason* is true, so a false one ships and the next reader inherits it as fact. Three shapes, none expressible as a `Verify by` lookup:
 
 - **Why-comment on a mechanism** → delete the mechanism and run the tests. Green means the claim is false, or the tests never covered it.
-- **A detector / guard / gate** → construct the thing it claims to catch and confirm it fires. A guard's success case proves nothing; only a negative control does. Scope it to the claim it defends: a check narrower than that claim (a files-only loop behind a files-and-directories completeness claim), or one that silently skips its exemptions instead of declaring them, passes by construction.
+- **A detector / guard / gate** → construct the thing it claims to catch and confirm it fires. A guard's success case proves nothing; only a negative control does. Scope it to the claim it defends: a check narrower than that claim (a files-only loop behind a files-and-directories completeness claim), or one that silently skips its exemptions instead of declaring them, passes by construction. And a control whose fixture a **sibling arm** can also reach reddens for the wrong reason — read *which* message fired, not the exit code, and re-key the fixture until only the guard can reach it.
 - **A classification or count built on an earlier claim** → when you fix that claim, grep what cited it. Fixing one authored claim can *invalidate* another you authored earlier, and nothing points back at it; a concessive clause propping up a category ("it belongs here, just differently") is the tell that it already broke.
+
+**A probe's outcome gets misread in both directions.** Assert that the mutation's anchor matched — a `replace` that silently no-ops leaves the original behaviour and reads as verified. And treat a probe that stays **green** as a finding about the *fixtures*, not a redundant guard: a suite only reddens on states its fixtures build, so name the state the guard defends and confirm something constructs it before concluding anything.
 
 When a check is too expensive to run, say the cause was not isolated. A reader can act on an acknowledged gap; a wrong cause they can only inherit.
 
-Motivating incidents: PR #1152 round-1 review; PR #1299 rounds 1–3; #1312 rounds 1–4.
+Motivating incidents: PR #1152 round-1 review; PR #1299 rounds 1–3; #1312 rounds 1–4; PR #1303 rounds 1–3; PR #1314; PR #1265.
 
 ### A rules file created mid-session never injects in that session
 


### PR DESCRIPTION
## Summary

A memory-triage round crossed both thresholds in `knowledge-layering.md` § "Promotion & retirement" (83 files / 263 KB), and two clusters routed to rules rather than staying in per-user memory.

**`kmp-interop.md` — new Pattern 4, traps inside the Kotlin port.** Patterns 1–3 are all boundary-facing, so the port-*time* traps Wave B kept re-hitting had nowhere to live; the KMP memory flagged them as "promote at the next rules-touching session" four separate times. Narrate and Conditional remain and every one of these recurs on both. The intro moves with it — it said "Two shapes" and scoped the file to the boundary, and both would now contradict the section list.

The load-bearing entry is the schema-guard divergence, **and it is not the one the memory recorded**. Both `hasAllExpectedKeys` helpers are identical, and so is the `LLMCaller` empty-field branch; the divergence is entirely in the parser. Swift's happy path returns before any guard, Kotlin applies it on every successful parse when the phase declares an `output:` schema. So an all-empty response is *returned* by Swift on the last attempt but becomes `parse_failed` → `RetriesExhausted` → turn-gate skip in Kotlin. That is what makes a handler's non-empty guard on a declared key unreachable Kotlin-side — and equally why it stays reachable for an undeclared key such as an optional `mood`.

**`knowledge-layering.md` — a negative control has two outcomes, and both get misread.** § "Claims you author are assertions too" already required a negative control for a detector/guard/gate; it said nothing about reading one, which is where the class actually fails. A control whose fixture a sibling arm can also reach reddens for the wrong reason (folded into the existing "passes by construction" sentence rather than restated). A probe that stays green means a missing fixture, not a redundant guard. A scripted mutation whose anchor misses is a no-op that looks like a pass. The verification table also gains a row for a subagent's verdict on an external platform fact — the table assumes a claim is *omitted*, so it did not fire when a critic affirmatively blessed a false one.

+73 / −4 across the two files. `knowledge-layering.md` is always-loaded, so its share is deliberately small (+5/−2 lines, +1,016 B): the "cannot redden" principle is cross-referenced to `swift-isolation.md` § Pattern 7, which already carries it verbatim, rather than written a third time.

## Test plan

No code changed, so the substantive check was executing the rules' own assertions — `knowledge-layering.md` § "Rule-writing self-check" makes that the author's job, and the reviewer re-ran them independently.

- Every `file:line` and `§ "Heading"` citation in the new text resolves and points at what the sentence claims: `JSONResponseParser.{swift:95-97,105,153 | kt:105}`, `LLMCaller.{swift:147 | kt:160-164}`, `ScenarioValidator.swift:264,278`, `TurnFailureGate.kt:77-80`, `SimulationState.kt:73`, `check-kmp-status.py:49,79`, `check-prompt-literal-parity.py:754`, `swift-isolation.md` § Pattern 7, `testing.md` § "A regression test must drive the exact unguarded-path input", `ci-workflows.md` § "Gate scripts".
- Cited PRs #1303 / #1314 confirmed MERGED.
- The capital-`P` `Phases/` claim was probed directly rather than assumed: `git ls-files -- …/engine/phases` returns nothing despite `core.ignorecase=true`, so the lowercase failure mode is real.
- Pre-commit ran on all three commits; both gate scripts correctly classified the changeset as build-irrelevant, so SwiftLint and `xcodebuild build` were skipped. The full iOS suite was deliberately **not** run — zero Swift, Kotlin, or script sources are touched.
- `claude-kit:critic` ×2 (round 1 returned a Critical, confirmed correct and rewritten — see below; round 2 Warnings only, all folded). `code-reviewer` (Opus) PASS, 0 Critical; its 3 Warnings + the substantive Suggestion are folded into `10208fa6`.

⚠️ **Round 1's Critical is the reason this PR is worth reading closely.** The drafted text asserted "Kotlin's `hasAllExpectedKeys` is stricter than Swift's" and "`RetriesExhausted` in both engines". Both were false, both came from a memory entry that had recorded them as fact, and both were confirmed false by reading the two engines. The rule being promoted in the other half of this PR is about exactly that failure mode.

## Device QA

実機QA不要 — documentation-only change under `.claude/rules/`; no app target, no device-only code path, no UI.

## Notes

`.claude/rules/knowledge-layering.md` mirrors claude-kit as canonical. tyabu12/claude-kit#12 landed the same generic core and has now **merged**, so this copy has been reconciled against the kit at `origin/main`: the bullet extension and the probe-outcome paragraph are byte-identical modulo line wrapping, and the verification-table row differs in exactly one deliberate spot — this copy points at `swift-isolation.md` § Pattern 7, which is always-loaded here and already carries the principle verbatim, where the kit restates it. The temporary divergence note is therefore removed in `0978b1a9`.

**Always-loaded budget.** `knowledge-layering.md` has no `paths:`, so its +1,016 B is paid every turn of every session. The memory triage that produced this PR cut `MEMORY.md` by 703 B, and retiring the five promoted memories after merge removes a further 875 B of index lines — so the net effect on always-loaded context is **negative**. `kmp-interop.md`'s +5,048 B is path-scoped to `shared/**` and `tools/kmp-gate-spike/**`, i.e. it loads exactly where its traps recur.

Closes #1317
