### PR TITLE
🔧 chore: settle the en secret-section close on the declarative form

### DIFF
--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -469,9 +469,7 @@ which is where a newly-found one gets added — read it there rather than trusti
 this paragraph to have stayed current. Note also that a wording change is a
 *behaviour* change: pair it with a harness A/B, and give that A/B a **deleted-text
 control arm** — without one, "the two wordings tie" cannot be told from "this text
-does nothing". #1301 ran that control and found a whole guidance sentence inert in
-`en` on its decision metric; what that does and does not license is recorded on
-`appendSecretSection`'s doc comment.
+does nothing" (#1301 found a shipped guidance sentence inert in `en` exactly that way).
 
 ## SimulationEvent & the projection contract
 

--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -469,8 +469,8 @@ which is where a newly-found one gets added — read it there rather than trusti
 this paragraph to have stayed current. Note also that a wording change is a
 *behaviour* change: pair it with a harness A/B, and give that A/B a **deleted-text
 control arm** — without one, "the two wordings tie" cannot be told from "this text
-does nothing". #1301 ran that control and found a whole guidance sentence inert on
-its decision metric, against a positive control that reached 100 %.
+does nothing". #1301 ran that control and found a whole guidance sentence inert in
+`en` on its decision metric, against a positive control that reached 100 %.
 
 ## SimulationEvent & the projection contract
 

--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -470,7 +470,8 @@ this paragraph to have stayed current. Note also that a wording change is a
 *behaviour* change: pair it with a harness A/B, and give that A/B a **deleted-text
 control arm** — without one, "the two wordings tie" cannot be told from "this text
 does nothing". #1301 ran that control and found a whole guidance sentence inert in
-`en` on its decision metric, against a positive control that reached 100 %.
+`en` on its decision metric; what that does and does not license is recorded on
+`appendSecretSection`'s doc comment.
 
 ## SimulationEvent & the projection contract
 

--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -467,7 +467,10 @@ and prompt literals outside `pickLanguage` are invisible to it. The enumerated
 blind spots live in the checker's own `What this cannot see` docstring section,
 which is where a newly-found one gets added — read it there rather than trusting
 this paragraph to have stayed current. Note also that a wording change is a
-*behaviour* change: pair it with a harness A/B, not just with the other side.
+*behaviour* change: pair it with a harness A/B, and give that A/B a **deleted-text
+control arm** — without one, "the two wordings tie" cannot be told from "this text
+does nothing". #1301 ran that control and found a whole guidance sentence inert on
+its decision metric, against a positive control that reached 100 %.
 
 ## SimulationEvent & the projection contract
 

--- a/Pastura/Pastura/Engine/PromptBuilder+PrivateSections.swift
+++ b/Pastura/Pastura/Engine/PromptBuilder+PrivateSections.swift
@@ -30,17 +30,29 @@ nonisolated extension PromptBuilder {
   ///
   /// The closing sentence is **declarative**, matching the ja literal's close and
   /// restoring the ja/en scope-parallel expectation the sibling rules in
-  /// `PromptBuilder.swift` document. It was chosen by measurement (#1301), and
-  /// what the measurement licenses is narrow. On **decisions** the sentence is
-  /// inert: an imperative arm, this declarative arm, and a control with the
-  /// sentence deleted all landed at the 50 % chance baseline, while a positive
-  /// control carrying an explicit directive reached 100 % — so the flatness
-  /// belongs to the sentence, not to the instrument. A blinded read of the inner
-  /// monologue ranked the deleted-sentence control lowest, which is why the
-  /// sentence stays at all; that arm separation is under-powered and supports
-  /// only "declarative is not worse", never "declarative is better". Only the
-  /// sentence's **mood** was measured — the clause before it was held constant
-  /// across every arm and remains unmeasured.
+  /// `PromptBuilder.swift` document. That convention — **not** a behavioural gain
+  /// — is what settled it (#1301); the A/B licenses far less than it may appear.
+  ///
+  /// On **decisions**, in **en**, on Gemma 4 E2B (Q4_K_M), on a purpose-built
+  /// probe whose personas carried bare `secret:` text, the sentence is inert: an
+  /// imperative arm, this declarative arm, and a control with the sentence
+  /// deleted all sat on the 50 % chance baseline (13/25 · 12/25 · 6/12 of the
+  /// vote turns that named a person; ~31 % named a proposal instead and were
+  /// dropped, evenly across arms, so the baseline is over that retained subset).
+  /// A positive control reached 100 %, but its directive sat in the scenario's
+  /// `secret:` text — that shows the *metric* is movable, which is not the same
+  /// as text in *this* slot being able to move it. The **ja** close was never an
+  /// arm and is entirely unmeasured.
+  ///
+  /// The sentence is kept as the **status quo**: no arm of the pre-registered
+  /// rule could have deleted it. A blinded inner-monologue read did rank the
+  /// deleted-sentence control lowest (12/12 · 10/12 · 8/12), but at n=12/arm the
+  /// scorer declined to reject a common distribution, so that ordering is not
+  /// evidence and is not the reason the sentence stays.
+  ///
+  /// Only the closing sentence's **formulation** varied — mood, segmentation and
+  /// word choice moved together, so none of the three is separately attributable.
+  /// The clause before it was held constant across every arm.
   func appendSecretSection(to sections: inout [String], persona: Persona, language: String) {
     // Non-nil implies non-empty (every ingest path normalizes empty → nil).
     guard let secret = persona.secret else { return }

--- a/Pastura/Pastura/Engine/PromptBuilder+PrivateSections.swift
+++ b/Pastura/Pastura/Engine/PromptBuilder+PrivateSections.swift
@@ -27,6 +27,20 @@ nonisolated extension PromptBuilder {
   /// `whisperRule` tells the agent to be candid and strategic with its partner,
   /// while this one forbids naming the secret. Field-test a secret × whisper
   /// scenario before any preset ships both (#914 follow-up).
+  ///
+  /// The closing sentence is **declarative**, matching the ja literal's close and
+  /// restoring the ja/en scope-parallel expectation the sibling rules in
+  /// `PromptBuilder.swift` document. It was chosen by measurement (#1301), and
+  /// what the measurement licenses is narrow. On **decisions** the sentence is
+  /// inert: an imperative arm, this declarative arm, and a control with the
+  /// sentence deleted all landed at the 50 % chance baseline, while a positive
+  /// control carrying an explicit directive reached 100 % — so the flatness
+  /// belongs to the sentence, not to the instrument. A blinded read of the inner
+  /// monologue ranked the deleted-sentence control lowest, which is why the
+  /// sentence stays at all; that arm separation is under-powered and supports
+  /// only "declarative is not worse", never "declarative is better". Only the
+  /// sentence's **mood** was measured — the clause before it was held constant
+  /// across every arm and remains unmeasured.
   func appendSecretSection(to sections: inout [String], persona: Persona, language: String) {
     // Non-nil implies non-empty (every ingest path normalizes empty → nil).
     guard let secret = persona.secret else { return }
@@ -39,7 +53,7 @@ nonisolated extension PromptBuilder {
       ja:
         "この秘密は、他の参加者に聞こえる発言（statement）では決して明かしてはいけません。心の声（inner_thought）では率直に触れてかまいません。あなたの判断や態度はこの秘密に左右されます。",
       en:
-        "Never reveal this secret in anything the other participants can hear (your statement). You may reference it freely in your inner_thought, and let it shape your decisions and demeanor."
+        "Never reveal this secret in anything the other participants can hear (your statement). You may reference it freely in your inner_thought. It shapes your judgement and attitude."
     )
     sections.append("\(header)\n\(secret)\n\(guidance)")
   }

--- a/Pastura/Pastura/Engine/PromptBuilder+PrivateSections.swift
+++ b/Pastura/Pastura/Engine/PromptBuilder+PrivateSections.swift
@@ -36,19 +36,20 @@ nonisolated extension PromptBuilder {
   /// On **decisions**, in **en**, on Gemma 4 E2B (Q4_K_M), on a purpose-built
   /// probe whose personas carried bare `secret:` text, the sentence is inert: an
   /// imperative arm, this declarative arm, and a control with the sentence
-  /// deleted all sat on the 50 % chance baseline (13/25 · 12/25 · 6/12 of the
-  /// vote turns that named a person; ~31 % named a proposal instead and were
-  /// dropped, evenly across arms, so the baseline is over that retained subset).
-  /// A positive control reached 100 %, but its directive sat in the scenario's
-  /// `secret:` text — that shows the *metric* is movable, which is not the same
-  /// as text in *this* slot being able to move it. The **ja** close was never an
-  /// arm and is entirely unmeasured.
+  /// deleted all sat on the 50 % chance baseline (imperative 13/25 · declarative
+  /// 12/25 · control 6/12 of the vote turns that named a person; ~31 % named a
+  /// proposal instead and were dropped, evenly across arms, so the baseline is
+  /// over that retained subset). A positive control reached 100 % (6/6, one run),
+  /// but its directive sat in the scenario's `secret:` text — that shows the
+  /// *metric* is movable, which is not the same as text in *this* slot being able
+  /// to move it. The **ja** close was never an arm and is entirely unmeasured.
   ///
   /// The sentence is kept as the **status quo**: no arm of the pre-registered
   /// rule could have deleted it. A blinded inner-monologue read did rank the
-  /// deleted-sentence control lowest (12/12 · 10/12 · 8/12), but at n=12/arm the
-  /// scorer declined to reject a common distribution, so that ordering is not
-  /// evidence and is not the reason the sentence stays.
+  /// deleted-sentence control lowest (declarative 12/12 · imperative 10/12 ·
+  /// control 8/12), but at n=12/arm the scorer declined to reject a common
+  /// distribution, so the pre-registered rule gave that ordering no role in the
+  /// decision; it supports "declarative is not worse", never "better".
   ///
   /// Only the closing sentence's **formulation** varied — mood, segmentation and
   /// word choice moved together, so none of the three is separately attributable.

--- a/Pastura/PasturaTests/Engine/PromptBuilderTests+Secret.swift
+++ b/Pastura/PasturaTests/Engine/PromptBuilderTests+Secret.swift
@@ -62,7 +62,8 @@ extension PromptBuilderTests {
     // The closing sentence, unasserted until #1301 and now pinned in BOTH
     // languages. The ja close was never an A/B arm — it was constant throughout —
     // so this pins it for symmetry with the en assertion, which is the one the
-    // arms actually differed on. Its declarative mood is the ja/en scope-parallel.
+    // arms actually differed on. The en close now matches this one's declarative
+    // mood, per the ja/en scope-parallel convention the sibling rules state.
     #expect(prompt.contains("あなたの判断や態度はこの秘密に左右されます"))
   }
 

--- a/Pastura/PasturaTests/Engine/PromptBuilderTests+Secret.swift
+++ b/Pastura/PasturaTests/Engine/PromptBuilderTests+Secret.swift
@@ -59,9 +59,10 @@ extension PromptBuilderTests {
     // Channel-scoped guidance: statement is off-limits, inner_thought licensed.
     #expect(prompt.contains("発言（statement）では決して明かしてはいけません"))
     #expect(prompt.contains("心の声（inner_thought）では率直に触れてかまいません"))
-    // The closing sentence, pinned in BOTH languages (#1301). Until then neither
-    // was asserted, so the two A/B arms — which differ only here — both passed
-    // this suite unchanged. Its declarative mood is the ja/en scope-parallel.
+    // The closing sentence, unasserted until #1301 and now pinned in BOTH
+    // languages. The ja close was never an A/B arm — it was constant throughout —
+    // so this pins it for symmetry with the en assertion, which is the one the
+    // arms actually differed on. Its declarative mood is the ja/en scope-parallel.
     #expect(prompt.contains("あなたの判断や態度はこの秘密に左右されます"))
   }
 
@@ -71,8 +72,9 @@ extension PromptBuilderTests {
     #expect(prompt.contains(Self.aliceSecret))
     #expect(prompt.contains("Never reveal this secret in anything the other participants can hear"))
     #expect(prompt.contains("You may reference it freely in your inner_thought"))
-    // See the ja counterpart: the closing sentence is the #1301 A/B's variable
-    // and went unasserted until it was settled. Declarative, matching the ja.
+    // This is the #1301 A/B's actual variable, and it went unasserted until the
+    // A/B settled it — so both arms passed this suite unchanged, since the line
+    // above matches either wording. Declarative, matching the ja close.
     #expect(prompt.contains("It shapes your judgement and attitude"))
   }
 

--- a/Pastura/PasturaTests/Engine/PromptBuilderTests+Secret.swift
+++ b/Pastura/PasturaTests/Engine/PromptBuilderTests+Secret.swift
@@ -59,6 +59,10 @@ extension PromptBuilderTests {
     // Channel-scoped guidance: statement is off-limits, inner_thought licensed.
     #expect(prompt.contains("発言（statement）では決して明かしてはいけません"))
     #expect(prompt.contains("心の声（inner_thought）では率直に触れてかまいません"))
+    // The closing sentence, pinned in BOTH languages (#1301). Until then neither
+    // was asserted, so the two A/B arms — which differ only here — both passed
+    // this suite unchanged. Its declarative mood is the ja/en scope-parallel.
+    #expect(prompt.contains("あなたの判断や態度はこの秘密に左右されます"))
   }
 
   @Test func systemPromptContainsSecretSectionWhenSetEN() {
@@ -67,6 +71,9 @@ extension PromptBuilderTests {
     #expect(prompt.contains(Self.aliceSecret))
     #expect(prompt.contains("Never reveal this secret in anything the other participants can hear"))
     #expect(prompt.contains("You may reference it freely in your inner_thought"))
+    // See the ja counterpart: the closing sentence is the #1301 A/B's variable
+    // and went unasserted until it was settled. Declarative, matching the ja.
+    #expect(prompt.contains("It shapes your judgement and attitude"))
   }
 
   /// Charlie has no secret. Checked in both languages — asserting the EN header

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/PromptBuilder.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/PromptBuilder.kt
@@ -241,12 +241,18 @@ internal class PromptBuilder {
      * (`scripts/check-prompt-literal-parity.py`); the separator is *not* — see
      * that script's non-coverage list.
      *
-     * **This pin locks in a known ja/en mismatch, tracked on #1301.** The en text
-     * it replaced ("It shapes your judgement and attitude") rendered the ja's
-     * declarative last sentence more closely than the shipped imperative one
-     * does; Swift won on "a parity PR must not move shipped prompt text", not on
-     * translation quality. Neither form has been A/B'd — do not read this pin as
-     * an endorsement of the wording.
+     * The ja/en mismatch this pin once locked in is **resolved** (#1301): the en
+     * close is now declarative, matching the ja. It was settled by a harness A/B,
+     * and that A/B licenses less than it might appear. On **decisions** the
+     * sentence is inert — an imperative arm, the declarative arm, and a control
+     * with the sentence deleted all sat at the 50 % chance baseline, against a
+     * positive control that reached 100 %. A blinded read of the inner monologue
+     * put the deleted-sentence control lowest, which is why the sentence remains;
+     * that separation is under-powered and supports only "declarative is not
+     * worse". Only the sentence's **mood** was measured — the clause before it
+     * was held constant across arms and is still unmeasured, so the pre-#1295
+     * Kotlin text ("You may reflect on it frankly...") was not the arm that won
+     * and is not vindicated here.
      */
     private fun appendSecretSection(sections: MutableList<String>, persona: Persona, language: String) {
         val secret = persona.secret?.takeIf { it.isNotBlank() } ?: return
@@ -260,7 +266,7 @@ internal class PromptBuilder {
             ja = "この秘密は、他の参加者に聞こえる発言（statement）では決して明かしてはいけません。" +
                 "心の声（inner_thought）では率直に触れてかまいません。あなたの判断や態度はこの秘密に左右されます。",
             en = "Never reveal this secret in anything the other participants can hear (your statement). " +
-                "You may reference it freely in your inner_thought, and let it shape your decisions and demeanor.",
+                "You may reference it freely in your inner_thought. It shapes your judgement and attitude.",
         )
         sections += "$header\n$secret\n$guidance"
     }

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/PromptBuilder.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/PromptBuilder.kt
@@ -242,17 +242,16 @@ internal class PromptBuilder {
      * that script's non-coverage list.
      *
      * The ja/en mismatch this pin once locked in is **resolved** (#1301): the en
-     * close is now declarative, matching the ja. It was settled by a harness A/B,
-     * and that A/B licenses less than it might appear. On **decisions** the
-     * sentence is inert — an imperative arm, the declarative arm, and a control
-     * with the sentence deleted all sat at the 50 % chance baseline, against a
-     * positive control that reached 100 %. A blinded read of the inner monologue
-     * put the deleted-sentence control lowest, which is why the sentence remains;
-     * that separation is under-powered and supports only "declarative is not
-     * worse". Only the sentence's **mood** was measured — the clause before it
-     * was held constant across arms and is still unmeasured, so the pre-#1295
-     * Kotlin text ("You may reflect on it frankly...") was not the arm that won
-     * and is not vindicated here.
+     * close is now declarative, matching the ja. It was settled on the ja/en
+     * scope-parallel convention, not on a measured behavioural gain — the full
+     * record of what the A/B does and does not license lives in ONE place, the
+     * Swift `appendSecretSection` doc comment, deliberately un-mirrored here so
+     * these two prose blocks cannot drift the way the en literal did in #1295.
+     *
+     * Worth stating on this side only: the arm that won is **not** the pre-#1295
+     * Kotlin text ("You may reflect on it frankly..."). That text differed in the
+     * preceding clause too, and that clause was held constant across every arm —
+     * so it was never tested and is not vindicated here.
      */
     private fun appendSecretSection(sections: MutableList<String>, persona: Persona, language: String) {
         val secret = persona.secret?.takeIf { it.isNotBlank() } ?: return


### PR DESCRIPTION
## Summary

- The en `appendSecretSection` closing sentence becomes **declarative** (`It shapes your judgement and attitude.`), matching the ja close and restoring the ja/en scope-parallel expectation the sibling rules in `PromptBuilder.swift` document. Both engines move in one commit — `check-prompt-literal-parity.py` requires it.
- **What settled it was the convention, not a behavioural gain.** The harness A/B found the sentence **inert on decisions**: an imperative arm, the declarative arm, and a control with the sentence deleted entirely all sat on the 50 % chance baseline, while a positive control reached 100 %. Adding that third arm is what made a null result readable — without it, "the two wordings tie" is indistinguishable from "this text does nothing".
- Pins the closing sentence in the test suite in **both** languages. It was unasserted until now, so the two A/B arms — which differ only there — both passed the suite unchanged. Verified by negative control in each direction: reverting the en literal reddens only the EN test; mutating the ja close reddens only the JA test.
- Rewrites (does not append to) the closing sentence of `.claude/rules/engine.md` § "Prompt literals are paired with the Kotlin port" so the next prompt-wording A/B is told to carry a deleted-text control arm.

Full pre-registration, amendment, per-arm results and the probe YAML are on #1301. The Swift doc comment on `appendSecretSection` is the single durable home for what the measurement does and does not license; the Kotlin KDoc points at it rather than duplicating it, so the two prose blocks cannot drift the way the en literal did in #1295.

### Results

| Arm | runs | valid vote turns | secret-consistent | `statement` leaks |
|---|---|---|---|---|
| imperative (was shipped) | 6 | 25 | 52.0 % | 0 |
| **declarative (adopted)** | 6 | 25 | 48.0 % | 0 |
| control — sentence deleted | 3 | 12 | 50.0 % | 0 |
| *positive control* | 1 | 6 | *100.0 %* | 0 |

Pooled `{imperative + declarative}` 50.0 % vs control 50.0 % — a 0.0-point difference, inside the pre-registered 10-point margin, so the pre-registered rule adopts the declarative arm.

**What this does not establish.** Only the closing sentence's *formulation* varied (mood, segmentation and word choice moved together, so none is separately attributable); the clause before it was constant in every arm and is still unmeasured. The ja close was never an arm. A blinded inner-monologue read ordered the deleted-sentence control lowest (declarative 12/12 · imperative 10/12 · control 8/12), but at n=12/arm the scorer declined to reject a common distribution — the pre-registered rule gave that ordering no role, and the sentence is retained as the status quo, not because the ordering favoured it.

## Test plan

- `scripts/xcodebuild.sh test -skip-testing:PasturaUITests` — 3284 tests / 271 suites pass.
- `python3 scripts/check-prompt-literal-parity.py` — clean; the allowlist holds only the `NarrateHandler` `unported` row, so this pair is genuinely compared rather than exempted.
- `./gradlew :shared:engine:compileCommonMainKotlinMetadata :shared:models:jvmTest :shared:engine:jvmTest` — green.
- `swiftlint lint --quiet --strict` — clean.
- Negative controls on the two new assertions, run individually: en revert → only `systemPromptContainsSecretSectionWhenSetEN` reddens; ja mutation → only `...WhenSetJA`. Each mutation asserted its anchor matched first, so neither was a silent no-op.

## Device QA

実機QA不要 — no `#if !targetEnvironment(simulator)` block, no `LlamaCppService` / GGUF / Metal code path, and no UI surface is touched; the change is prompt text, and it was exercised against real Gemma 4 E2B (Q4_K_M) inference across 17 harness runs.

Closes #1301
