### PR TITLE
✨ feat: port NarrateHandler to shared/engine commonMain (ADR-023 Wave B)

### DIFF
--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -453,13 +453,15 @@ nothing if they run different prompts. The en secret-section guidance diverged o
 **Apply**: change both sides in the same commit. `scripts/check-prompt-literal-parity.py`
 enforces it (pre-commit sub-gate + the CI "Shell gate tests" job); pairing is by
 basename with any `+Extension` suffix stripped, so `PromptBuilder+PrivateSections.swift`
-pairs with `PromptBuilder.kt`. A deliberate one-sided literal — today none; the
-allowlist holds a single whole-file `unported` deferral (`NarrateHandler`) —
-needs a row in `shared/prompt-literal-parity-allowlist.tsv`; the checker prints
-the exact row to paste, keyed on a digest of the pair so a later reword forces
-re-approval. Whole-file `unported` rows are capped (`MAX_UNPORTED_ROWS`, at the
-current count) so the deferral budget ratchets down as the ADR-023 port lands
-rather than staying open.
+pairs with `PromptBuilder.kt`. A deliberate one-sided literal — today none, and
+the allowlist now holds **no** rows at all — needs a row in
+`shared/prompt-literal-parity-allowlist.tsv`; the checker prints the exact row to
+paste, keyed on a digest of the pair so a later reword forces re-approval.
+Whole-file `unported` rows are capped (`MAX_UNPORTED_ROWS`) at the current count,
+which reached its terminus of **0** when `NarrateHandler` ported (#1330) — the
+last remaining Wave-B handler, `ConditionalHandler`, has no `pickLanguage`
+literals. So adding an `unported` row now requires raising the cap in the same
+change, with the reason recorded in the allowlist header.
 
 **What the gate does NOT see** — it measures `pickLanguage` literal-pair parity,
 not prompt parity, so separators (the `\n` vs `\n\n` join in `appendSecretSection`)

--- a/.claude/rules/kmp-interop.md
+++ b/.claude/rules/kmp-interop.md
@@ -206,3 +206,13 @@ CI pair — `:shared:models:jvmTest :shared:engine:jvmTest` — before pushing.
 all-`false` for every agent, so `copy(eliminated = mapOf("Bob" to true))` leaves the others
 **absent** — the test can no longer tell `== true` from `!= null`, and a wrong-polarity check stays
 green against real state. Write the `false` entries explicitly, plus an absent-key case.
+
+**Test authoring: `ScriptedLLMBackend` exhaustion is a harness fault, not a backend failure.** Running
+out of scripts throws `IllegalStateException` by design, to flag an unintended extra call — so it is
+**not** failure injection (a 1:1 port of Swift's `MockLLMService(responses: [])` fails unless the
+handler's `catch` is widened, and a wide catch here swallows `CancellationException`, a JVM subclass of
+`IllegalStateException`; script `TerminalStatus.Failed` instead), and it **pre-empts assertions** — a
+`callCount` / `requests` assertion with no spare script is unreachable, so the test reddens without its
+own assertion ever running. Over-script (`MAX_RETRIES + 1`) so the written assertion is the detector.
+Decisive in §12 perturbation work, where "it reddened" IS the evidence: read *which* message fired.
+Worked example: `NarrateHandlerTests` (#1331).

--- a/docs/kmp-migration-status.md
+++ b/docs/kmp-migration-status.md
@@ -22,7 +22,7 @@ At-a-glance progress for the KMP Engine migration (ADR-023 / [#501](https://gith
 > other section is hand-maintained; refresh it when a KMP PR merges (see
 > [`.claude/rules/kmp-interop.md`](../.claude/rules/kmp-interop.md)).
 
-_Last updated: 2026-07-29._
+_Last updated: 2026-07-30._
 
 ## Stages
 
@@ -43,7 +43,7 @@ Legend: ✅ done · 🔄 in progress · 🟡 partial · ⬜ not started.
 |---|:--:|---|
 | Models mirror | ✅ done | #1193 #1196 #1202 |
 | Wave A — non-handler run-path (scoring, mechanisms, prompt/LLM glue) | ✅ done | #1207 #1212 #1217 |
-| Wave B — 14 phase handlers | 🔄 12/14 | checklist ↓ |
+| Wave B — 14 phase handlers | 🔄 13/14 | checklist ↓ |
 | code-phase track | ✅ done | CP1 #1226 · CP2 #1230 · CP3 #1232 |
 
 ### Wave B handler checklist
@@ -60,7 +60,7 @@ machine-checked — see the maintenance invariant above.
 - [x] ChooseHandler — #1262
 - [ ] ConditionalHandler
 - [x] EventInjectHandler — #1230
-- [ ] NarrateHandler
+- [x] NarrateHandler — #1330
 - [x] ReflectHandler — #1242
 - [x] RelationshipUpdateHandler — #1232
 - [x] ScoreCalcHandler — #1230

--- a/scripts/check-prompt-literal-parity.py
+++ b/scripts/check-prompt-literal-parity.py
@@ -134,6 +134,8 @@ MAX_UNPORTED_ROWS = 0
 # structural rather than an omission: a control that proved it would have to
 # delete checks, including itself. Verified out of band instead — raise the floor
 # above the real count and confirm it fires. Do that when changing it.
+# Re-verified 2026-07-30 on the 56 -> 57 bump: at 58 it fires ("only 57 checks ran
+# (floor 58)"), at 57 the suite passes.
 MIN_SELF_TEST_CHECKS = 57
 
 # The helper's own declaration in LanguageDispatch.{swift,kt}, whose `ja: String`
@@ -1091,8 +1093,7 @@ def self_test() -> int:
     )
     # 11. The dangling-`unported` arm — previously reachable but unexercised.
     #     `cap=1` so the dangling check is what fails, not the cap (see case 6).
-    #     Case 10 above needs no such override: an empty-reason row is rejected
-    #     before `unported.add`, so it never counts toward the cap at all.
+    #     Case 10 needs the override too, for a different reason — see its own comment.
     expect(
         "dangling unported row is caught",
         evaluate({}, {}, _HEADER + "unported\tGhost\t-\t-\twhy\n", cap=1),

--- a/scripts/check-prompt-literal-parity.py
+++ b/scripts/check-prompt-literal-parity.py
@@ -114,11 +114,17 @@ MIN_SWIFT_CALLSITE_FILES = 12
 
 # Cap on whole-file `unported` exemptions. Unlike the digest-keyed rows, these
 # never expire on their own, so an uncapped list is how "temporarily deferred"
-# becomes permanent. Kept AT the current count (one today: NarrateHandler) rather
-# than above it, so the budget ratchets down as the ADR-023 port lands instead of
-# leaving a free slot the next deferral can take unreviewed. Raising it is a
-# deliberate act with its reason recorded in the allowlist header.
-MAX_UNPORTED_ROWS = 1
+# becomes permanent. Kept AT the current count — which is now **zero**: the last
+# deferral (NarrateHandler) landed its Kotlin port in #1330, and the sole remaining
+# Wave-B handler, ConditionalHandler, has no `pickLanguage` literals at all, so no
+# planned port needs a row. This is the ratchet's terminus, not a temporary low:
+# closed by default, and a genuinely new deferral raises it deliberately with its
+# reason recorded in the allowlist header.
+#
+# The `unported` machinery below is deliberately kept (and still tested, via
+# `evaluate`'s `cap` parameter) rather than deleted — a future raise must find it
+# already verified.
+MAX_UNPORTED_ROWS = 0
 
 # Floor on the number of checks `--self-test` runs. The printed tally is derived,
 # so it never goes stale — but nothing stops a suite from silently shrinking, and
@@ -128,7 +134,7 @@ MAX_UNPORTED_ROWS = 1
 # structural rather than an omission: a control that proved it would have to
 # delete checks, including itself. Verified out of band instead — raise the floor
 # above the real count and confirm it fires. Do that when changing it.
-MIN_SELF_TEST_CHECKS = 56
+MIN_SELF_TEST_CHECKS = 57
 
 # The helper's own declaration in LanguageDispatch.{swift,kt}, whose `ja: String`
 # args are types, not literals. Excluding it is load-bearing: the literal parser
@@ -592,8 +598,20 @@ def evaluate(
     swift_sources: dict[str, str],
     kotlin_sources: dict[str, str],
     allowlist_text: str,
+    cap: int = MAX_UNPORTED_ROWS,
 ) -> list[str]:
-    """Return the list of problems; empty means the invariant holds."""
+    """Return the list of problems; empty means the invariant holds.
+
+    `cap` overrides `MAX_UNPORTED_ROWS` for one call. Production never passes it —
+    the default IS the production constant, and one `--self-test` arm asserts that
+    by relying on it. It exists because the cap and the `unported` *mechanism* are
+    orthogonal properties that a single global cannot exercise at once: with the cap
+    at its terminal 0, every one-row fixture would fail on the cap before reaching
+    the stale / dangling / dead-row / escape-hatch guard under test, so those cases
+    would pass for the wrong reason and go mutation-blind. Preferred over rebinding
+    the global in a context manager: no global mutation, no try/finally, and each
+    call site says which property it is measuring.
+    """
     divergences, unported, problems = parse_allowlist(allowlist_text)
     problems = list(problems)
 
@@ -649,9 +667,9 @@ def evaluate(
     # `unported` rows carry no digest, so each one exempts a whole file forever —
     # including literals added after it was approved. A prose "keep them scarce"
     # is advice nothing executes; this is the assertion.
-    if len(unported) > MAX_UNPORTED_ROWS:
+    if len(unported) > cap:
         problems.append(
-            f"{len(unported)} `unported` allowlist rows exceeds the cap of {MAX_UNPORTED_ROWS}. "
+            f"{len(unported)} `unported` allowlist rows exceeds the cap of {cap}. "
             "Each exempts an entire file with no digest to expire it — port one, or raise the "
             "cap deliberately with the reason in this file's header."
         )
@@ -1007,14 +1025,18 @@ def self_test() -> int:
 
     # 6. Swift file with no Kotlin counterpart at all — needs an `unported` row.
     expect("unported Swift file without a row fails", evaluate(sw, {}, _HEADER), False)
+    # `cap=1` on both: these measure the `unported` MECHANISM (escape hatch, then
+    # staleness), not the cap. MAX_UNPORTED_ROWS is 0 in production, so without the
+    # override the single fixture row would fail on the cap — turning the first arm
+    # red and making the second pass for the wrong reason. See `evaluate`'s docstring.
     expect(
         "unported Swift file with a row passes",
-        evaluate(sw, {}, _HEADER + "unported\tPromptBuilder\t-\t-\tStage-3 deferral\n"),
+        evaluate(sw, {}, _HEADER + "unported\tPromptBuilder\t-\t-\tStage-3 deferral\n", cap=1),
         True,
     )
     expect(
         "stale unported row is caught once the port lands",
-        evaluate(sw, kt, _HEADER + "unported\tPromptBuilder\t-\t-\tStage-3 deferral\n"),
+        evaluate(sw, kt, _HEADER + "unported\tPromptBuilder\t-\t-\tStage-3 deferral\n", cap=1),
         False,
     )
 
@@ -1059,9 +1081,12 @@ def self_test() -> int:
         False,
     )
     # 11. The dangling-`unported` arm — previously reachable but unexercised.
+    #     `cap=1` so the dangling check is what fails, not the cap (see case 6).
+    #     Case 10 above needs no such override: an empty-reason row is rejected
+    #     before `unported.add`, so it never counts toward the cap at all.
     expect(
         "dangling unported row is caught",
-        evaluate({}, {}, _HEADER + "unported\tGhost\t-\t-\twhy\n"),
+        evaluate({}, {}, _HEADER + "unported\tGhost\t-\t-\twhy\n", cap=1),
         False,
     )
     # 12. A `swift-only` row on an `unported` stem is dead — `_compare` never runs
@@ -1082,6 +1107,7 @@ def self_test() -> int:
             _HEADER
             + "unported\tPromptBuilder\t-\t-\tdeferral\n"
             + f"swift-only\tPromptBuilder\t{digest(real_pair)}\t{excerpt(real_pair)}\tdead\n",
+            cap=1,  # the dead-row check must be what fails, not the cap (case 6)
         ),
         False,
     )
@@ -1168,21 +1194,39 @@ def self_test() -> int:
         False,
     )
 
-    # 18b. The `unported` cap is an assertion, not advice.
+    # 18b. The `unported` cap is an assertion, not advice. TWO arms, because the
+    # production setting and the boundary behaviour are separate claims and the
+    # constant is now at its terminal 0.
+    #
     # Stems must be REAL and genuinely unported, or each row is also *dangling*
     # and that check satisfies the expectation with the cap removed.
-    capped_swift = {
-        f"Pastura/Pastura/Engine/Capped{n}.swift":
-        f'func f() {{ _ = pickLanguage(l, ja: "j{n}", en: "e{n}") }}\n'
-        for n in range(MAX_UNPORTED_ROWS + 1)
-    }
-    capped_rows = "".join(
-        f"unported\tCapped{n}\t-\t-\twhy\n" for n in range(MAX_UNPORTED_ROWS + 1)
+    def capped_swift(n: int) -> dict[str, str]:
+        return {
+            f"Pastura/Pastura/Engine/Capped{i}.swift":
+            f'func f() {{ _ = pickLanguage(l, ja: "j{i}", en: "e{i}") }}\n'
+            for i in range(n)
+        }
+
+    def capped_rows(n: int) -> str:
+        return _HEADER + "".join(f"unported\tCapped{i}\t-\t-\twhy\n" for i in range(n))
+
+    # (i) The PRODUCTION setting. Deliberately no `cap=` — this is the only arm that
+    #     exercises `evaluate`'s default argument, so it is what notices if
+    #     MAX_UNPORTED_ROWS is raised without a deliberate edit here. At the terminal
+    #     0 that means even one row is refused; raising the cap is supposed to break
+    #     this line and force the raiser to look at it.
+    expect(
+        "the production cap refuses one more row than MAX_UNPORTED_ROWS allows",
+        evaluate(capped_swift(MAX_UNPORTED_ROWS + 1), {}, capped_rows(MAX_UNPORTED_ROWS + 1)),
+        False,
     )
-    expect("rows at the cap are accepted", evaluate(
-        {k: v for k, v in list(capped_swift.items())[:MAX_UNPORTED_ROWS]}, {},
-        _HEADER + "".join(f"unported\tCapped{n}\t-\t-\twhy\n" for n in range(MAX_UNPORTED_ROWS))), True)
-    expect("the unported-row cap is not enforced", evaluate(capped_swift, {}, _HEADER + capped_rows), False)
+    # (ii) The boundary itself, measured independently of the production constant:
+    #      N rows accepted at cap N, refused at cap N-1. `range(MAX_UNPORTED_ROWS…)`
+    #      arithmetic cannot express this at 0 — the accept arm degenerated to
+    #      `evaluate({}, {}, header)`, i.e. "an empty repo has no problems", which
+    #      cannot redden on any cap regression. That vacuity is why `cap` exists.
+    expect("rows at the cap are accepted", evaluate(capped_swift(2), {}, capped_rows(2), cap=2), True)
+    expect("one row past the cap is refused", evaluate(capped_swift(2), {}, capped_rows(2), cap=1), False)
 
     # 18c. `collect`'s extraction-error report. The dangerous case is BOTH sides
     #      hitting the same unmodelled shape (likely — the literals are ported

--- a/scripts/check-prompt-literal-parity.py
+++ b/scripts/check-prompt-literal-parity.py
@@ -603,8 +603,9 @@ def evaluate(
     """Return the list of problems; empty means the invariant holds.
 
     `cap` overrides `MAX_UNPORTED_ROWS` for one call. Production never passes it —
-    the default IS the production constant, and one `--self-test` arm asserts that
-    by relying on it. It exists because the cap and the `unported` *mechanism* are
+    the default IS the production constant, and one `--self-test` arm (18b arm (i))
+    pins that value by hardcoding a fixture the default must refuse, rather than by
+    merely relying on the default. It exists because the cap and the `unported` *mechanism* are
     orthogonal properties that a single global cannot exercise at once: with the cap
     at its terminal 0, every one-row fixture would fail on the cap before reaching
     the stale / dangling / dead-row / escape-hatch guard under test, so those cases
@@ -1075,9 +1076,17 @@ def self_test() -> int:
     # file, and the case goes green. Keyed on a ghost stem instead (as it was
     # first written) the dangling-row check fires either way and the control
     # passes by construction, measuring nothing.
+    # `cap=1` for the same reason as case 6, and this case needed it MOST. The
+    # criterion is not what the row does on an unmutated run (there it is rejected
+    # before `unported.add`, so it never reaches the cap) but what it does under the
+    # mutation this control exists to catch: with the guard deleted the row parses as
+    # a valid `unported PromptBuilder` and IS counted, so at the production cap of 0
+    # the cap check appends a problem, `expect(..., False)` still passes, and the
+    # deleted guard goes undetected. Measured. At `cap=1` the mutated run returns no
+    # problems and reddens, which is the whole point of the case.
     expect(
         "empty reason is reported",
-        evaluate(sw, {}, _HEADER + "unported\tPromptBuilder\t-\t-\t\n"),
+        evaluate(sw, {}, _HEADER + "unported\tPromptBuilder\t-\t-\t\n", cap=1),
         False,
     )
     # 11. The dangling-`unported` arm — previously reachable but unexercised.
@@ -1210,14 +1219,17 @@ def self_test() -> int:
     def capped_rows(n: int) -> str:
         return _HEADER + "".join(f"unported\tCapped{i}\t-\t-\twhy\n" for i in range(n))
 
-    # (i) The PRODUCTION setting. Deliberately no `cap=` — this is the only arm that
-    #     exercises `evaluate`'s default argument, so it is what notices if
-    #     MAX_UNPORTED_ROWS is raised without a deliberate edit here. At the terminal
-    #     0 that means even one row is refused; raising the cap is supposed to break
-    #     this line and force the raiser to look at it.
+    # (i) The PRODUCTION setting, pinned to the literal 0. Deliberately no `cap=`, so
+    #     the default is load-bearing here — this is the only arm whose VERDICT
+    #     depends on the default's value (every other arm that omits `cap=` merely
+    #     uses it). The row count is hardcoded to 1 rather than derived from
+    #     MAX_UNPORTED_ROWS: a `MAX_UNPORTED_ROWS + 1` fixture always presents one row
+    #     past whatever the cap happens to be, so it passes at EVERY cap and pins
+    #     nothing but "the comparison exists". Hardcoded, raising the constant to 1
+    #     makes this line redden and forces the raiser to look at it.
     expect(
-        "the production cap refuses one more row than MAX_UNPORTED_ROWS allows",
-        evaluate(capped_swift(MAX_UNPORTED_ROWS + 1), {}, capped_rows(MAX_UNPORTED_ROWS + 1)),
+        "the production cap of 0 refuses a single unported row",
+        evaluate(capped_swift(1), {}, capped_rows(1)),
         False,
     )
     # (ii) The boundary itself, measured independently of the production constant:

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/PhaseDispatcher.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/PhaseDispatcher.kt
@@ -10,9 +10,10 @@ import kotlinx.serialization.serializer
  * ## Scope: the ADR-023 Stage-3 port, in progress
  *
  * **`SPEAK_ALL`, `ELIMINATE`, `SUMMARIZE`, `ASSIGN`, `EVENT_INJECT`, `SCORE_CALC`,
- * `RELATIONSHIP_UPDATE`, `REFLECT`, `VOTE`, `WHISPER`, `CHOOSE` and `SPEAK_EACH`
- * are registered.** Swift registers all 14; the remaining 2 are the mechanical bulk
- * of Stage 3 ("mechanical after the Stage-2 slice", §4), ported handler-by-handler.
+ * `RELATIONSHIP_UPDATE`, `REFLECT`, `VOTE`, `WHISPER`, `CHOOSE`, `SPEAK_EACH` and
+ * `NARRATE` are registered.** Swift registers all 14; the remaining 1 is the
+ * mechanical bulk of Stage 3 ("mechanical after the Stage-2 slice", §4), ported
+ * handler-by-handler.
  *
  * Unlike Swift's `PhaseDispatcher`, this is **not** exhaustive over [PhaseType] —
  * so an unregistered phase fails at dispatch with a clear error rather than at
@@ -38,6 +39,7 @@ internal class PhaseDispatcher {
         PhaseType.WHISPER to WhisperHandler(),
         PhaseType.CHOOSE to ChooseHandler(),
         PhaseType.SPEAK_EACH to SpeakEachHandler(),
+        PhaseType.NARRATE to NarrateHandler(),
     )
 
     /**

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/NarrateHandler.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/NarrateHandler.kt
@@ -46,8 +46,12 @@ import com.pastura.models.SimulationState
  * - **No [PhaseContext.turnGate].** The `try/catch` below replaces it (see § Grounding).
  * - **The catch is narrower than Swift's bare `catch` — see [execute].**
  * - **`emitter = {}` into [LLMCaller]**, suppressing the agent-attributed events.
- * - **Never copies state.** `execute` returns its input `state` on all four exits;
- *   narrate is the only handler in either engine that persists nothing at all.
+ * - **Never copies state.** `execute` returns its input `state` on all four exits.
+ *   Unique among the *LLM* handlers; [SummarizeHandler] is the code-phase precedent
+ *   for an emit-only handler, and documents the same posture.
+ * - **`max_sentences` is clamped, unlike Swift** — see [execute].
+ * - **Its own system prompt**, not [PromptBuilder.buildSystemPrompt] — see
+ *   [buildNarratorSystemPrompt].
  *
  * Swift original: `Pastura/Pastura/Engine/Phases/NarrateHandler.swift`.
  * Ported for the ADR-023 KMP Engine migration (#501, #1330).
@@ -143,7 +147,7 @@ internal class NarrateHandler : PhaseHandler {
                 emitter = {},
             )
             commentary = output.fields["commentary"] ?: ""
-        } catch (e: SimulationException) {
+        } catch (_: SimulationException) {
             // Degrade by omission (see type doc): no `Narration`, no `TurnSkipped`, no
             // breaker increment. `.debug`-level so no user content is logged.
             //
@@ -156,8 +160,17 @@ internal class NarrateHandler : PhaseHandler {
             // `Throwable` but re-throws anything non-degradable — see
             // `TurnFailureGate.kt` § `isTurnDegradable`. narrate has no gate, so it owes
             // the discipline itself. `SimulationException` is precisely the class
-            // `LLMCaller` throws for every failure mode it models, so this catches
-            // everything Swift's bare `catch` does except cancellation.
+            // `LLMCaller` throws for every failure mode it MODELS, so this catches
+            // everything Swift's bare `catch` does for those.
+            //
+            // It does not catch an *unmodelled* one: `LLMCaller` calls
+            // `backend.generateStream` un-guarded, so an adapter that violates the
+            // `LLMBackend` contract by throwing instead of reporting
+            // `TerminalStatus.Failed` propagates past here and aborts the run, where
+            // Swift's bare `catch` would absorb it as "no commentary". That is
+            // deliberate, not an oversight — it is the same posture
+            // `TurnFailureGate.attempt` takes for every other handler, catching
+            // `Throwable` and then re-throwing anything `isTurnDegradable` rejects.
             context.logger.log(
                 level = EngineLogLevel.DEBUG,
                 category = LOG_CATEGORY,

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/NarrateHandler.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/NarrateHandler.kt
@@ -1,0 +1,283 @@
+package com.pastura.engine
+
+import com.pastura.models.OutputSchema
+import com.pastura.models.Scenario
+import com.pastura.models.SimulationEvent
+import com.pastura.models.SimulationState
+
+/**
+ * Handles `narrate` phases (#909): a single commentator inference per round.
+ *
+ * Unlike the per-agent LLM handlers, `narrate` makes **one** LLM call per round —
+ * a commentator persona narrates the round's highlight. The narrator is **not** a
+ * participant: it is not in `scenario.personas`, so it never votes, scores, or
+ * appears on the scoreboard, and its output is never written to `conversationLog`
+ * or `lastOutputs` (so other agents never see it).
+ *
+ * ## Grounding & degradation
+ *
+ * - **Empty-log skip.** If nothing has happened this round (`state.conversationLog`
+ *   empty — e.g. `narrate` placed first, or round 1 before any speak phase), the
+ *   handler emits nothing rather than inviting the model to invent commentary about
+ *   an empty round (the hallucination edge; #909 critic Axis 11).
+ * - **Degrade by omission, no circuit breaker.** A failed / empty inference simply
+ *   emits no `Narration`; the round proceeds without commentary. The narrator is not
+ *   an agent, so it deliberately bypasses the agent-attributed [TurnFailureGate] — a
+ *   narrator failure must not emit `TurnSkipped` nor feed the ADR-021
+ *   consecutive-skip circuit breaker (#909 critic Axis 4).
+ *
+ * ## Output & display
+ *
+ * The commentary is emitted RAW via [SimulationEvent.Narration]; `ContentFilter` is
+ * applied at the App/UI boundary (ADR-005 — the filter runs between Engine output
+ * and display, never inside the Engine). The output schema is Engine-fixed
+ * (`{ commentary }`), not author-declared, so a `narrate` phase needs no `output:`
+ * block — authors tune only the optional `narrator:` voice, `prompt:`, and
+ * `max_sentences:`.
+ *
+ * ## Divergences from every other ported LLM handler — all deliberate
+ *
+ * A port that mirrors [ReflectHandler] (the nearest structural sibling: single-field
+ * engine schema, private output, no log write) would be **green and wrong**. This
+ * handler must NOT call `buildSystemPrompt`, any `inject*` helper, `captureMood`, or
+ * `state.copy(...)`; `ReflectHandler` calls all four and none of them would fail the
+ * build here.
+ *
+ * - **No [PhaseContext.turnGate].** The `try/catch` below replaces it (see § Grounding).
+ * - **The catch is narrower than Swift's bare `catch` — see [execute].**
+ * - **`emitter = {}` into [LLMCaller]**, suppressing the agent-attributed events.
+ * - **Never copies state.** `execute` returns its input `state` on all four exits;
+ *   narrate is the only handler in either engine that persists nothing at all.
+ *
+ * Swift original: `Pastura/Pastura/Engine/Phases/NarrateHandler.swift`.
+ * Ported for the ADR-023 KMP Engine migration (#501, #1330).
+ */
+internal class NarrateHandler : PhaseHandler {
+
+    private val promptBuilder = PromptBuilder()
+
+    private companion object {
+        /** OSLog category for narrate diagnostics. */
+        const val LOG_CATEGORY = "NarrateHandler"
+
+        /**
+         * Reserved event-attribution name for the narrator's inference. Used only
+         * for the suppressed [LLMCaller] progress events (see [execute]); it never
+         * reaches the UI because those events are dropped.
+         */
+        const val NARRATOR_AGENT_NAME = "narrator"
+
+        /**
+         * Default brevity cap when a phase does not set `max_sentences:` (#909 —
+         * the narrator's runaway is the second-largest risk after hallucination).
+         *
+         * Deliberately narrate's OWN constant rather than
+         * `PromptBuilder.DEFAULT_STATEMENT_MAX_SENTENCES`: the two defaults are
+         * independent knobs, and sharing one would make the narrator's brevity
+         * silently track the statement default.
+         */
+        const val DEFAULT_MAX_SENTENCES = 3
+    }
+
+    override suspend fun execute(context: PhaseContext, state: SimulationState): SimulationState {
+        // Empty-log guard: no grounded facts to narrate → skip rather than invent.
+        if (state.conversationLog.isEmpty()) {
+            context.logger.log(
+                level = EngineLogLevel.DEBUG,
+                category = LOG_CATEGORY,
+                message = "narrate: empty conversation log — skipping commentary",
+                privacy = EngineLogPrivacy.PUBLIC,
+            )
+            return state
+        }
+
+        val language = context.scenario.engineLanguage
+        // coerceIn: another site inheriting a Swift validator guarantee that does not
+        // exist on this side yet. `ScenarioValidator.validateMaxSentences` enforces
+        // `max_sentences` in 1..6 and is called UNCONDITIONALLY from the
+        // `validatePhases` traversal (`ScenarioValidator.swift:111`, and `:216` for
+        // conditional-branch sub-phases), so it covers narrate and Swift's accepted
+        // domain is `{null} ∪ [1,6]` — which is why the Swift original needs no clamp.
+        // That validator is a Stage-3 port, so nothing rejects `max_sentences: 0` here,
+        // and un-clamped it renders "0文以内" / "at most 0 sentence(s)" — an
+        // unsatisfiable instruction handed to the model. Same class as the clamp in
+        // `PromptBuilder.buildAnswerRules` and the `log_window: 0` guard in
+        // `formatConversationLog`.
+        val maxSentences = (context.phase.maxSentences ?: DEFAULT_MAX_SENTENCES).coerceIn(1, 6)
+
+        val systemPrompt = buildNarratorSystemPrompt(
+            scenario = context.scenario,
+            narrator = context.phase.narrator,
+            maxSentences = maxSentences,
+            language = language,
+        )
+        val userPrompt = buildNarratorUserPrompt(context = context, state = state, language = language)
+
+        // Engine-fixed single-field schema (mirrors reflect's `{ note }`); a free
+        // string, so the grammar constrains structure only — no value enumeration
+        // (the llama.cpp accept-time crash class, see .claude/rules/engine.md).
+        val schema = OutputSchema(
+            fields = listOf(
+                OutputSchema.Field(name = "commentary", kind = OutputSchema.Kind.StringKind),
+            ),
+        )
+
+        val llmCaller = LLMCaller(logger = context.logger)
+        val commentary: String
+        try {
+            val output = llmCaller.call(
+                backend = context.backend,
+                system = systemPrompt,
+                user = userPrompt,
+                agentName = NARRATOR_AGENT_NAME,
+                schema = schema,
+                detector = context.detector,
+                expectedLanguage = language,
+                relay = context.suspensionRelay,
+                // Suppress the narrator's per-token streaming + inference-progress
+                // events so the commentator never renders as a participant agent row;
+                // only the final `Narration` (below) surfaces. `LLMCaller` routes every
+                // agent-attributed event through this parameter, so a no-op sink drops
+                // them completely. EVENTS only — the `StreamingDiag` diagnostics still
+                // reach `context.logger`, exactly as in Swift.
+                emitter = {},
+            )
+            commentary = output.fields["commentary"] ?: ""
+        } catch (e: SimulationException) {
+            // Degrade by omission (see type doc): no `Narration`, no `TurnSkipped`, no
+            // breaker increment. `.debug`-level so no user content is logged.
+            //
+            // Deliberately NARROWER than Swift's bare `catch`, and the difference is
+            // load-bearing rather than cosmetic. Kotlin cancellation is a *throw*, so a
+            // broad `catch (e: Throwable)` here would swallow the user's cancel and let
+            // the run continue to the next suspension point; Swift's bare `catch` is safe
+            // only because its runner polls `Task.isCancelled`. Every other LLM handler
+            // gets this rethrow for free from `TurnFailureGate.attempt`, which catches
+            // `Throwable` but re-throws anything non-degradable — see
+            // `TurnFailureGate.kt` § `isTurnDegradable`. narrate has no gate, so it owes
+            // the discipline itself. `SimulationException` is precisely the class
+            // `LLMCaller` throws for every failure mode it models, so this catches
+            // everything Swift's bare `catch` does except cancellation.
+            context.logger.log(
+                level = EngineLogLevel.DEBUG,
+                category = LOG_CATEGORY,
+                message = "narrate: inference failed — skipping commentary",
+                privacy = EngineLogPrivacy.PUBLIC,
+            )
+            return state
+        }
+
+        // **Defensive parity, not a reachable path here.** Kotlin's
+        // `JSONResponseParser` applies `hasAllExpectedKeys` on every successful parse
+        // when the schema declares keys, and narrate always declares `{ commentary }`,
+        // so `{"commentary": ""}` throws `JsonParseFailed` on each attempt and arrives
+        // as `RetriesExhausted` at the catch above — never here as `commentary == ""`.
+        // Swift's parser returns the empty output instead, so there the guard IS the
+        // live path. Kept to mirror the Swift handler verbatim and to stay correct if
+        // that upstream divergence is ever reconciled (same posture as
+        // `ReflectHandler`'s `note.isNotEmpty()` guard).
+        if (commentary.isEmpty()) {
+            context.logger.log(
+                level = EngineLogLevel.DEBUG,
+                category = LOG_CATEGORY,
+                message = "narrate: empty commentary — skipping emission",
+                privacy = EngineLogPrivacy.PUBLIC,
+            )
+            return state
+        }
+
+        // Emit RAW — ContentFilter runs at the App/UI boundary (ADR-005). NOT written
+        // to conversationLog / lastOutputs: the narrator is not a participant, so
+        // agents' prompts must never include the commentary. Nothing is persisted at
+        // all, hence the bare `state` rather than a `state.copy(...)`.
+        context.emitter(SimulationEvent.Narration(text = commentary))
+        return state
+    }
+
+    /**
+     * Builds the Engine-owned commentator system prompt. The factuality and brevity
+     * guardrails are fixed here (not author-overridable); the optional `narrator:`
+     * descriptor is injected to shape the commentator's *voice* only.
+     *
+     * Deliberately NOT [PromptBuilder.buildSystemPrompt]: the narrator has no
+     * [com.pastura.models.Persona], no private reserved-namespace sections, and no
+     * answer rules — so all five literal pairs below are narrate's own and exist
+     * nowhere in `PromptBuilder`.
+     */
+    private fun buildNarratorSystemPrompt(
+        scenario: Scenario,
+        narrator: String?,
+        maxSentences: Int,
+        language: String,
+    ): String {
+        val sections = mutableListOf<String>()
+
+        val context = scenario.context.trim()
+        if (context.isNotEmpty()) {
+            sections += pickLanguage(language, ja = "設定: $context", en = "Setting: $context")
+        }
+
+        // Role + factuality guardrail (Engine-owned).
+        sections += pickLanguage(
+            language,
+            ja = "あなたはこのシミュレーションの実況者です。会話ログに実際に書かれた出来事だけを根拠に、このラウンドの見どころを実況してください。ログに無い発言・出来事・結果を創作してはいけません。",
+            en = "You are the live commentator for this simulation. Narrate the highlight of this round, grounded ONLY in what actually appears in the conversation log. Never invent lines, events, or outcomes that are not in the log.",
+        )
+
+        // Optional author-supplied voice descriptor (shapes voice, not the rules).
+        val trimmedNarrator = (narrator ?: "").trim()
+        if (trimmedNarrator.isNotEmpty()) {
+            sections += pickLanguage(
+                language,
+                ja = "実況者のキャラクター: $trimmedNarrator",
+                en = "Commentator persona: $trimmedNarrator",
+            )
+        }
+
+        // Brevity guardrail (Engine-owned).
+        sections += pickLanguage(
+            language,
+            ja = "${maxSentences}文以内で、簡潔に述べてください。",
+            en = "Keep it concise — at most $maxSentences sentence(s).",
+        )
+
+        // Output format.
+        sections += pickLanguage(
+            language,
+            ja = "出力は次の形の1行 JSON のみ: {\"commentary\": \"...\"}",
+            en = "Output only single-line JSON of the form: {\"commentary\": \"...\"}",
+        )
+
+        return sections.joinToString("\n\n")
+    }
+
+    /**
+     * Builds the user prompt from the phase's `prompt:` (or a default) with the recent
+     * conversation log injected — the narrator's factual grounding.
+     *
+     * The variable map is local and thrown away after expansion. No `inject*` helper
+     * runs: those surface per-persona reserved namespaces to a speaker, and the
+     * narrator is not one.
+     */
+    private fun buildNarratorUserPrompt(
+        context: PhaseContext,
+        state: SimulationState,
+        language: String,
+    ): String {
+        val promptTemplate = context.phase.prompt
+            ?: pickLanguage(
+                language,
+                ja = "直近のやり取り:\n{conversation_log}\n\nこのラウンドの見どころを実況してください。",
+                en = "Recent exchanges:\n{conversation_log}\n\nNarrate the highlight of this round.",
+            )
+
+        val variables = state.variables.toMutableMap()
+        variables["conversation_log"] = promptBuilder.formatConversationLog(
+            entries = state.conversationLog,
+            language = language,
+            window = context.scenario.logWindow,
+        )
+        variables["scoreboard"] = promptBuilder.formatScoreboard(state.scores)
+        return promptBuilder.expandTemplate(promptTemplate, variables)
+    }
+}

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/PromptBuilder.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/PromptBuilder.kt
@@ -300,8 +300,8 @@ internal class PromptBuilder {
         state: SimulationState,
     ): String {
         val language = scenario.engineLanguage
-        // coerceIn: the THIRD site inheriting a Swift validator guarantee that does
-        // not exist on this side yet. `ScenarioValidator.swift:136-145` enforces
+        // coerceIn: one of several sites inheriting a Swift validator guarantee that
+        // does not exist on this side yet. `ScenarioValidator.swift:136-145` enforces
         // `max_sentences` in 1..6; that validator is a Stage-3 port, so nothing
         // rejects `max_sentences: 0` here — and un-clamped it renders "at most 0
         // sentences" / "0文以内", an unsatisfiable instruction handed to the model.

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/NarrateHandlerTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/NarrateHandlerTests.kt
@@ -1,0 +1,410 @@
+package com.pastura.engine
+
+import com.pastura.models.ConversationEntry
+import com.pastura.models.Persona
+import com.pastura.models.Phase
+import com.pastura.models.PhaseType
+import com.pastura.models.Scenario
+import com.pastura.models.SimulationEvent
+import com.pastura.models.SimulationState
+import com.pastura.models.TurnOutput
+import kotlinx.coroutines.test.runTest
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Kotlin sibling of Swift's `NarrateHandlerTests`, collapsed into one class per the
+ * commonTest convention.
+ *
+ * `narrate` is the one LLM phase that is **not** an agent turn: one inference per
+ * round, no participation, and degradation by omission instead of through
+ * [TurnFailureGate]. The cases below pin, in ADR-023 §12 terms, the mechanisms a
+ * green-but-wrong port would silently lose.
+ *
+ * ## §12 condition-4 perturbation record
+ *
+ * Each mechanism was broken in isolation and the named **dedicated claimant**
+ * confirmed to redden (a claimant that stayed green would be a measurement defect,
+ * not a redundant test). Three mutations also break the happy path and so redden
+ * most of the suite; that **incidental** breakage is listed separately, because a
+ * wide red set is not evidence about the axis. Measured 2026-07-30, #1330.
+ *
+ * | Mechanism broken | Dedicated claimant | Incidental |
+ * |---|---|---|
+ * | Empty-log guard → `isNotEmpty()` | [skipsEmissionOnEmptyLog] | 12 others (inverting also skips the happy path) |
+ * | Catch arm `return state` → `throw e` | [degradesByOmissionOnFailure] | 1 ([emptyCommentaryIsAbsorbedByTheCatchArmNotTheGuard], which routes through the same arm) |
+ * | Catch breadth → `catch (e: Throwable)` | [aSystemicThrowEscapesRatherThanDegrading], [cancellationEscapesRatherThanBeingSwallowed] | none |
+ * | `emitter = {}` → `context.emitter` | [suppressesTheNarratorsAgentAttributedEvents] | none |
+ * | Final `return state` → a persisting `copy` | [narratorIsNotAParticipant] | none |
+ * | Descriptor section dropped | [injectsNarratorDescriptorIntoSystemPrompt] | none |
+ * | Schema field renamed | [requestsCommentarySchema] | 8 others (the parse then fails) |
+ * | A second inference added | [singleInferenceRegardlessOfAgentCount] | 10 others (the script list runs out) |
+ * | Empty-commentary guard **deleted** | *(none — expected green)* | none |
+ *
+ * The last row is the point of the exercise, not a gap: the guard is unreachable on
+ * this side, so nothing can redden. Confirmed by measurement rather than asserted —
+ * see [emptyCommentaryIsAbsorbedByTheCatchArmNotTheGuard].
+ *
+ * Note what the "one inference" row does **not** establish. Its assertion is
+ * `callCount == 1`, so it catches any multiplication of the call but does not by
+ * itself prove agent-count *independence*; that claim rests on `callCount == 1`
+ * **together with** the 3-agent pin in [scenario], which is why the pin is asserted
+ * in the test body rather than left implicit.
+ *
+ * Ported for the ADR-023 KMP Engine migration (#501, #1330).
+ */
+class NarrateHandlerTests {
+
+    private val handler = NarrateHandler()
+
+    /**
+     * Three agents pinned explicitly: [singleInferenceRegardlessOfAgentCount] relies
+     * on `agentCount > 1` to prove per-round rather than per-agent inference, so it
+     * must not silently weaken to `1 == 1`.
+     */
+    private fun scenario(
+        narrator: String? = null,
+        prompt: String? = null,
+        language: String = "en",
+        maxSentences: Int? = null,
+        agents: List<String> = listOf("Alice", "Bob", "Charlie"),
+        context: String = "A test.",
+    ) = Scenario(
+        id = "t",
+        name = "T",
+        description = "d",
+        language = language,
+        simulationLanguage = null,
+        agentCount = agents.size,
+        rounds = 2,
+        logWindow = null,
+        context = context,
+        personas = agents.map { Persona(name = it, description = "$it's persona.") },
+        phases = listOf(
+            Phase(
+                type = PhaseType.NARRATE,
+                prompt = prompt,
+                narrator = narrator,
+                maxSentences = maxSentences,
+            ),
+        ),
+    )
+
+    private fun context(
+        s: Scenario,
+        backend: LLMBackend,
+        events: MutableList<SimulationEvent> = mutableListOf(),
+    ) = PhaseContext(
+        scenario = s,
+        phase = s.phases[0],
+        backend = backend,
+        suspensionRelay = SuspensionRelay(),
+        emitter = { events += it },
+        pauseCheck = { },
+        phasePath = listOf(0),
+        turnGate = TurnFailureGate(),
+    )
+
+    /**
+     * A state whose conversation log is non-empty, so narrate has facts to ground on
+     * and does not hit the empty-log skip.
+     *
+     * `conversationLog` defaults to `emptyList()` on [SimulationState.initial] — only
+     * `eliminated` is seeded — so replacing it wholesale here cannot hide an
+     * absent-key hole (`.claude/rules/kmp-interop.md` Pattern 4). narrate never reads
+     * `eliminated` regardless.
+     */
+    private fun stateWithLog(s: Scenario) = SimulationState.initial(s).copy(
+        currentRound = 1,
+        conversationLog = listOf(
+            ConversationEntry(
+                agentName = "Alice",
+                content = "I accuse Bob.",
+                phaseType = PhaseType.SPEAK_ALL,
+                round = 1,
+            ),
+            ConversationEntry(
+                agentName = "Bob",
+                content = "That is absurd.",
+                phaseType = PhaseType.SPEAK_ALL,
+                round = 1,
+            ),
+        ),
+    )
+
+    private fun narrates(commentary: String) =
+        ScriptedLLMBackend.Script.completing("""{"commentary": "$commentary"}""")
+
+    private fun narrations(events: List<SimulationEvent>) =
+        events.filterIsInstance<SimulationEvent.Narration>()
+
+    private fun skips(events: List<SimulationEvent>) =
+        events.filterIsInstance<SimulationEvent.TurnSkipped>()
+
+    // MARK: - Happy path
+
+    @Test
+    fun emitsNarrationOnSuccess() = runTest {
+        val s = scenario()
+        val backend = ScriptedLLMBackend(listOf(narrates("Alice went on the attack!")))
+        val events = mutableListOf<SimulationEvent>()
+
+        handler.execute(context(s, backend, events), stateWithLog(s))
+
+        assertEquals(listOf("Alice went on the attack!"), narrations(events).map { it.text })
+    }
+
+    @Test
+    fun singleInferenceRegardlessOfAgentCount() = runTest {
+        // 3 agents, but narrate must call the backend exactly ONCE: the narrator is
+        // not a participant, so cost is agent-count-independent. A per-persona loop
+        // would issue 3 calls and exhaust the single script.
+        val s = scenario()
+        val backend = ScriptedLLMBackend(listOf(narrates("A tense round.")))
+
+        handler.execute(context(s, backend), stateWithLog(s))
+
+        assertEquals(3, s.personas.size, "the per-round claim needs agentCount > 1 to mean anything")
+        assertEquals(1, backend.callCount)
+    }
+
+    @Test
+    fun narratorIsNotAParticipant() = runTest {
+        // Whole-state equality, deliberately: it is trivially true today (execute
+        // returns its input `state`), and that is the point — it becomes a real
+        // change-detector the moment someone adds a `state.copy(...)` that persists
+        // something, which is the failure mode a ReflectHandler-shaped port invites.
+        // Do NOT delete this as tautological; see the class KDoc's perturbation record.
+        val s = scenario()
+        val backend = ScriptedLLMBackend(listOf(narrates("What a move.")))
+        val events = mutableListOf<SimulationEvent>()
+        val before = stateWithLog(s).copy(
+            lastOutputs = mapOf("Alice" to TurnOutput(fields = mapOf("statement" to "I accuse Bob."))),
+        )
+
+        val after = handler.execute(context(s, backend, events), before)
+
+        assertEquals(before, after, "narrate must persist nothing at all")
+        // Spelled out too, so a failure names the field rather than dumping two states.
+        assertEquals(before.conversationLog, after.conversationLog)
+        assertEquals(before.lastOutputs, after.lastOutputs)
+        assertEquals(before.variables, after.variables)
+        // Never an AgentOutput — that is what would put the narrator in votes,
+        // scores, and the scoreboard.
+        assertTrue(events.filterIsInstance<SimulationEvent.AgentOutput>().isEmpty())
+        assertEquals(1, narrations(events).size)
+    }
+
+    @Test
+    fun suppressesTheNarratorsAgentAttributedEvents() = runTest {
+        // `emitter = {}` into LLMCaller: the ONLY event reaching the real emitter is
+        // the final Narration. Handing LLMCaller `context.emitter` instead would leak
+        // InferenceStarted / InferenceCompleted / AgentOutputStream under the reserved
+        // "narrator" name and render it as a participant row.
+        val s = scenario()
+        val backend = ScriptedLLMBackend(listOf(narrates("Quiet round.")))
+        val events = mutableListOf<SimulationEvent>()
+
+        handler.execute(context(s, backend, events), stateWithLog(s))
+
+        assertEquals(1, events.size, "expected only the Narration, got: $events")
+        assertTrue(events.single() is SimulationEvent.Narration)
+    }
+
+    // MARK: - The three skip paths
+
+    @Test
+    fun skipsEmissionOnEmptyLog() = runTest {
+        // Round 1 before any speak phase: nothing to narrate, so no inference and no
+        // event — the hallucination edge is answered by skipping, not inventing.
+        // An empty script list is correct HERE precisely because zero calls are
+        // expected: any call at all trips the harness's exhaustion signal.
+        val s = scenario()
+        val backend = ScriptedLLMBackend(emptyList())
+        val events = mutableListOf<SimulationEvent>()
+
+        handler.execute(context(s, backend, events), SimulationState.initial(s).copy(currentRound = 1))
+
+        assertEquals(0, backend.callCount)
+        assertTrue(narrations(events).isEmpty())
+    }
+
+    @Test
+    fun degradesByOmissionOnFailure() = runTest {
+        // A generation failure emits no Narration, no TurnSkipped, and execute does
+        // NOT throw: narrate degrades by omission and bypasses the agent-attributed
+        // TurnFailureGate, so an ADR-021 breaker increment must not happen either
+        // (#909 critic Axis 4).
+        //
+        // A `Failed` terminal, NOT `ScriptedLLMBackend(emptyList())`. Exhaustion
+        // throws IllegalStateException as a deliberate *test-harness bug* signal
+        // (LLMBackendTestSupport), so porting Swift's `MockLLMService(responses: [])`
+        // 1:1 would either fail this test or pressure the handler's catch wide open —
+        // manufacturing the very defect `cancellationEscapesRatherThanBeingSwallowed`
+        // guards. `Failed` is not retried by LLMCaller, so one script suffices.
+        val s = scenario()
+        val backend = ScriptedLLMBackend(
+            listOf(ScriptedLLMBackend.Script(terminal = TerminalStatus.Failed(errorCode = "transient blip"))),
+        )
+        val events = mutableListOf<SimulationEvent>()
+
+        val after = handler.execute(context(s, backend, events), stateWithLog(s))
+
+        assertTrue(narrations(events).isEmpty())
+        assertTrue(skips(events).isEmpty(), "narrate must never emit TurnSkipped: $events")
+        assertEquals(stateWithLog(s), after)
+    }
+
+    @Test
+    fun emptyCommentaryIsAbsorbedByTheCatchArmNotTheGuard() = runTest {
+        // Swift's sibling case is named `skipsEmissionOnEmptyCommentary` and drives
+        // the handler's `commentary.isEmpty()` guard. **In Kotlin it cannot.** The
+        // parser applies `hasAllExpectedKeys` on every successful parse when the
+        // schema declares keys, and narrate always declares `{ commentary }`, so
+        // `{"commentary": ""}` throws JsonParseFailed on each of the 3 attempts and
+        // arrives as RetriesExhausted at the catch arm instead.
+        //
+        // So this asserts the observable (no Narration emitted), never the guard.
+        // Deleting the guard leaves this test green — that is a fact about the
+        // divergence, not a coverage gap, and the guard stays as defensive parity per
+        // the ReflectHandler precedent. Do not "strengthen" this into guard coverage;
+        // no input reaches it from here.
+        val s = scenario()
+        val backend = ScriptedLLMBackend(List(LLMCaller.MAX_RETRIES + 1) { narrates("") })
+        val events = mutableListOf<SimulationEvent>()
+
+        handler.execute(context(s, backend, events), stateWithLog(s))
+
+        assertEquals(LLMCaller.MAX_RETRIES + 1, backend.callCount, "expected the full retry budget")
+        assertTrue(narrations(events).isEmpty())
+        assertTrue(skips(events).isEmpty())
+    }
+
+    // MARK: - Catch breadth (negative controls for the narrowed catch)
+
+    @Test
+    fun aSystemicThrowEscapesRatherThanDegrading() = runTest {
+        // The catch is `SimulationException`, so a fault outside that class must
+        // propagate rather than be silently absorbed as "no commentary this round".
+        val s = scenario()
+        val events = mutableListOf<SimulationEvent>()
+
+        assertFailsWith<NarrateProbeError> {
+            handler.execute(context(s, NarrateThrowingBackend(), events), stateWithLog(s))
+        }
+        assertTrue(narrations(events).isEmpty())
+    }
+
+    @Test
+    fun cancellationEscapesRatherThanBeingSwallowed() = runTest {
+        // The motivating case for narrowing the catch. Kotlin cancellation is a
+        // *throw*, and narrate has no TurnFailureGate to rethrow it (the gate catches
+        // Throwable but re-throws anything non-degradable). A broad catch here would
+        // absorb a user's cancel and let the run continue to the next suspension
+        // point — silently, with no diagnostic. Swift's bare `catch` is safe only
+        // because its runner polls `Task.isCancelled`.
+        val s = scenario()
+        val events = mutableListOf<SimulationEvent>()
+
+        assertFailsWith<CancellationException> {
+            handler.execute(context(s, NarrateCancellingBackend(), events), stateWithLog(s))
+        }
+        assertTrue(narrations(events).isEmpty())
+    }
+
+    // MARK: - Prompt construction
+
+    @Test
+    fun injectsNarratorDescriptorIntoSystemPrompt() = runTest {
+        // The optional `narrator:` descriptor shapes the commentator's voice and is
+        // injected into the Engine-owned system prompt.
+        val s = scenario(narrator = "熱血なスポーツ実況")
+        val backend = ScriptedLLMBackend(listOf(narrates("ok")))
+
+        handler.execute(context(s, backend), stateWithLog(s))
+
+        assertContains(backend.requests.single().system, "熱血なスポーツ実況")
+    }
+
+    @Test
+    fun omitsTheDescriptorSectionWhenNarratorIsAbsent() = runTest {
+        // Guards the `isNotEmpty()` branch: a blank descriptor must not emit an empty
+        // "Commentator persona:" heading with nothing after it.
+        val s = scenario(narrator = "   ")
+        val backend = ScriptedLLMBackend(listOf(narrates("ok")))
+
+        handler.execute(context(s, backend), stateWithLog(s))
+
+        assertTrue("Commentator persona" !in backend.requests.single().system)
+    }
+
+    @Test
+    fun groundsTheUserPromptInTheConversationLog() = runTest {
+        // The log IS the factuality grounding — the default template expands
+        // {conversation_log}, so a dropped expansion would leave the model narrating
+        // an unseen round.
+        val s = scenario()
+        val backend = ScriptedLLMBackend(listOf(narrates("ok")))
+
+        handler.execute(context(s, backend), stateWithLog(s))
+
+        val user = backend.requests.single().user
+        assertContains(user, "I accuse Bob.")
+        assertContains(user, "That is absurd.")
+        assertTrue("{conversation_log}" !in user, "the placeholder must be expanded, not passed through")
+    }
+
+    @Test
+    fun clampsMaxSentencesIntoTheSwiftValidatorRange() = runTest {
+        // `max_sentences: 0` is rejected Swift-side by ScenarioValidator, which is not
+        // ported — so un-clamped this renders "at most 0 sentence(s)", an
+        // unsatisfiable instruction. Asserts the clamped floor of 1.
+        val s = scenario(maxSentences = 0)
+        val backend = ScriptedLLMBackend(listOf(narrates("ok")))
+
+        handler.execute(context(s, backend), stateWithLog(s))
+
+        val system = backend.requests.single().system
+        assertContains(system, "at most 1 sentence(s)")
+        assertTrue("at most 0" !in system)
+    }
+
+    @Test
+    fun requestsCommentarySchema() = runTest {
+        // Engine-fixed single-field `{ commentary }` schema — not author-declared, so
+        // the backend receives exactly that constraint regardless of the phase YAML.
+        val s = scenario()
+        val backend = ScriptedLLMBackend(listOf(narrates("ok")))
+
+        handler.execute(context(s, backend), stateWithLog(s))
+
+        val schema = backend.requests.single().schema
+        assertEquals(listOf("commentary"), schema?.fields?.map { it.name })
+    }
+}
+
+/**
+ * Stands in for a fault narrate must not absorb.
+ *
+ * Extends [Exception] deliberately, mirroring `SpeakEachHandlerTests`'
+ * `SystemicProbeError`: it must stay disjoint from `CancellationException` (itself
+ * an `IllegalStateException`), or a later "simplify to IllegalStateException" edit
+ * would silently reclassify this as the cancellation path.
+ */
+private class NarrateProbeError : Exception("systemic")
+
+/** A backend whose call is a systemic fault rather than a generation failure. */
+private class NarrateThrowingBackend : LLMBackend {
+    override fun generateStream(request: GenerationRequest, callbacks: StreamCallbacks): StreamHandle =
+        throw NarrateProbeError()
+}
+
+/** A backend that cancels, so the handler's catch breadth is measurable. */
+private class NarrateCancellingBackend : LLMBackend {
+    override fun generateStream(request: GenerationRequest, callbacks: StreamCallbacks): StreamHandle =
+        throw CancellationException("cancelled mid-narration")
+}

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/NarrateHandlerTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/NarrateHandlerTests.kt
@@ -43,7 +43,7 @@ import kotlin.test.assertTrue
  * | Persists nothing | final `return state` → a `copy` writing a probe var | [narratorIsNotAParticipant] | none |
  * | Descriptor gate — **closed** | `if (trimmed.isNotEmpty())` → `if (false)` | [injectsNarratorDescriptorIntoSystemPrompt] | none |
  * | Descriptor gate — **open** | same → `if (true)` | [omitsTheDescriptorSectionWhenNarratorIsBlank] | none |
- * | `max_sentences` clamp (divergence 6) | `.coerceIn(1, 6)` deleted | [clampsMaxSentencesIntoTheSwiftValidatorRange], [clampsMaxSentencesToTheUpperBoundToo] | none |
+ * | `max_sentences` clamp (divergence 6) | `NarrateHandler.execute`'s `.coerceIn(1, 6)` deleted — the expression is NOT unique, `PromptBuilder` has its own and deleting that reddens neither | [clampsMaxSentencesIntoTheSwiftValidatorRange], [clampsMaxSentencesToTheUpperBoundToo] | none |
  * | Log grounding | `variables["conversation_log"] = …` dropped | [groundsTheUserPromptInTheConversationLog] | none |
  * | Engine-fixed schema | field `"commentary"` → `"comment"` | [requestsCommentarySchema] | 10 (every response then fails to parse) |
  * | One inference per round | a 2nd `call` immediately **before the `try`** | [singleInferenceRegardlessOfAgentCount] | 11 (it consumes script #1) |
@@ -70,9 +70,19 @@ import kotlin.test.assertTrue
  *    `assertEquals`, not via the harness's script-exhaustion error — which would be
  *    the same failure mode as all 10 incidentals and therefore no evidence at all.
  *
- * **Coverage of the table itself**: 12 axes, 13 of the 16 tests are a dedicated
- * claimant, and every mechanism named in the handler's "Divergences" list has a row —
- * including the clamp, which was only ever *incidental* until this was checked. The
+ * **Coverage of the table itself**: 12 axes and 13 of the 16 tests as a dedicated
+ * claimant — including the clamp, which was only ever *incidental* until this was
+ * checked. Five of the handler's six "Divergences" bullets have their own row; two
+ * items are covered only **transitively**, and saying so is the point:
+ *
+ * - **"Its own system prompt"** — switching to `PromptBuilder.buildSystemPrompt` would
+ *   drop the narrator descriptor and redden [injectsNarratorDescriptorIntoSystemPrompt],
+ *   so it is detected, but by a claimant belonging to another axis.
+ * - **An added `inject*` call** — the "must NOT call" list names these, and **nothing
+ *   here would catch one today.** No test asserts the absence of a reserved-namespace
+ *   token in the prompt. An acknowledged gap, not a covered mechanism.
+ *
+ * The
  * three non-claimants are deliberate: [emitsNarrationOnSuccess] pins the happy path
  * (it is the baseline the other rows perturb), [usesTheHandlersOwnDefaultWhenMaxSentencesIsAbsent]
  * pins a value no mutation can isolate while both defaults are 3 (see its comment),
@@ -143,10 +153,11 @@ class NarrateHandlerTests {
      * A state whose conversation log is non-empty, so narrate has facts to ground on
      * and does not hit the empty-log skip.
      *
-     * `conversationLog` defaults to `emptyList()` on [SimulationState.initial] — only
-     * `eliminated` is seeded — so replacing it wholesale here cannot hide an
-     * absent-key hole (`.claude/rules/kmp-interop.md` Pattern 4). narrate never reads
-     * `eliminated` regardless.
+     * `conversationLog` defaults to `emptyList()` on [SimulationState.initial] — the
+     * only seeded maps are `scores` and `eliminated` — so replacing it wholesale here
+     * cannot hide an absent-key hole (`.claude/rules/kmp-interop.md` Pattern 4).
+     * narrate never reads `eliminated`, and it reads `scores` only through
+     * `formatScoreboard`, which this fixture leaves fully seeded.
      */
     private fun stateWithLog(s: Scenario) = SimulationState.initial(s).copy(
         currentRound = 1,

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/NarrateHandlerTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/NarrateHandlerTests.kt
@@ -42,9 +42,11 @@ import kotlin.test.assertTrue
  * | Emitter swallowing | `emitter = {}` → `context.emitter` | [suppressesTheNarratorsAgentAttributedEvents] | none |
  * | Persists nothing | final `return state` → a `copy` writing a probe var | [narratorIsNotAParticipant] | none |
  * | Descriptor gate — **closed** | `if (trimmed.isNotEmpty())` → `if (false)` | [injectsNarratorDescriptorIntoSystemPrompt] | none |
- * | Descriptor gate — **open** | same → `if (true)` | [omitsTheDescriptorSectionWhenNarratorIsAbsent] | none |
+ * | Descriptor gate — **open** | same → `if (true)` | [omitsTheDescriptorSectionWhenNarratorIsBlank] | none |
+ * | `max_sentences` clamp (divergence 6) | `.coerceIn(1, 6)` deleted | [clampsMaxSentencesIntoTheSwiftValidatorRange], [clampsMaxSentencesToTheUpperBoundToo] | none |
+ * | Log grounding | `variables["conversation_log"] = …` dropped | [groundsTheUserPromptInTheConversationLog] | none |
  * | Engine-fixed schema | field `"commentary"` → `"comment"` | [requestsCommentarySchema] | 10 (every response then fails to parse) |
- * | One inference per round | a 2nd `call` **before** the real one | [singleInferenceRegardlessOfAgentCount] | 11 (it consumes script #1) |
+ * | One inference per round | a 2nd `call` immediately **before the `try`** | [singleInferenceRegardlessOfAgentCount] | 11 (it consumes script #1) |
  * | Empty-commentary guard | block **deleted** | *(none — expected green)* | none |
  *
  * Four things this table encodes that a first draft of it got wrong:
@@ -54,16 +56,28 @@ import kotlin.test.assertTrue
  *    [emptyCommentaryIsAbsorbedByTheCatchArmNotTheGuard].
  * 2. **Both gate polarities are measured.** `if (false)` removes the descriptor
  *    *append*; only `if (true)` breaks the *gate*, and that is what
- *    [omitsTheDescriptorSectionWhenNarratorIsAbsent] guards. Testing one polarity
+ *    [omitsTheDescriptorSectionWhenNarratorIsBlank] guards. Testing one polarity
  *    leaves the other test green by construction.
- * 3. **The mutation column is load-bearing.** The "one inference" row reddens 11
- *    others only because the extra call is inserted *before* the real one and eats
- *    script #1; inserted *after*, the two catch-arm tests would stay green. Without
- *    the site named, the row is not reproducible.
+ * 3. **The mutation column is load-bearing, down to the exact site.** The "one
+ *    inference" row's incidental count holds only for an extra call placed
+ *    *outside* the `try`, where its own `SimulationException` is unguarded and so
+ *    reddens the two catch-arm tests as well. Placed *inside* the `try` — which is
+ *    what the realistic regression, a per-persona loop, would look like — those two
+ *    stay green and the count is lower. "Before the real call" alone does not
+ *    identify the mutation.
  * 4. **A claimant must fail on its own assertion.** [requestsCommentarySchema] is
  *    scripted with the full retry budget precisely so a renamed field reddens it at
  *    `assertEquals`, not via the harness's script-exhaustion error — which would be
  *    the same failure mode as all 10 incidentals and therefore no evidence at all.
+ *
+ * **Coverage of the table itself**: 12 axes, 13 of the 16 tests are a dedicated
+ * claimant, and every mechanism named in the handler's "Divergences" list has a row —
+ * including the clamp, which was only ever *incidental* until this was checked. The
+ * three non-claimants are deliberate: [emitsNarrationOnSuccess] pins the happy path
+ * (it is the baseline the other rows perturb), [usesTheHandlersOwnDefaultWhenMaxSentencesIsAbsent]
+ * pins a value no mutation can isolate while both defaults are 3 (see its comment),
+ * and [emptyCommentaryIsAbsorbedByTheCatchArmNotTheGuard] is the *subject* of the
+ * expected-green row rather than a claimant for it — by construction it has none.
  *
  * What the "one inference" row does **not** establish: its assertion is
  * `callCount == 1`, which catches any multiplication of the call but does not by
@@ -177,10 +191,15 @@ class NarrateHandlerTests {
     @Test
     fun singleInferenceRegardlessOfAgentCount() = runTest {
         // 3 agents, but narrate must call the backend exactly ONCE: the narrator is
-        // not a participant, so cost is agent-count-independent. A per-persona loop
-        // would issue 3 calls and exhaust the single script.
+        // not a participant, so cost is agent-count-independent.
+        //
+        // Over-scripted on purpose (same reasoning as requestsCommentarySchema): with
+        // a single script an extra call throws the harness's exhaustion
+        // `IllegalStateException` before `assertEquals` runs, so the assertion below
+        // could never be the detector and the red would carry no count. Serving the
+        // extra call makes the failure message name the real one (`expected 1, got 2`).
         val s = scenario()
-        val backend = ScriptedLLMBackend(listOf(narrates("A tense round.")))
+        val backend = ScriptedLLMBackend(List(LLMCaller.MAX_RETRIES + 1) { narrates("A tense round.") })
 
         handler.execute(context(s, backend), stateWithLog(s))
 
@@ -237,10 +256,13 @@ class NarrateHandlerTests {
     fun skipsEmissionOnEmptyLog() = runTest {
         // Round 1 before any speak phase: nothing to narrate, so no inference and no
         // event — the hallucination edge is answered by skipping, not inventing.
-        // An empty script list is correct HERE precisely because zero calls are
-        // expected: any call at all trips the harness's exhaustion signal.
+        //
+        // Scripted with ONE response even though zero calls are expected, so that
+        // `assertEquals(0, …)` below is what detects a disabled guard rather than the
+        // harness's exhaustion throw. `emptyList()` would be the tighter expression of
+        // "no call" but would make the written assertion structurally unreachable.
         val s = scenario()
-        val backend = ScriptedLLMBackend(emptyList())
+        val backend = ScriptedLLMBackend(listOf(narrates("should not fire")))
         val events = mutableListOf<SimulationEvent>()
 
         handler.execute(context(s, backend, events), SimulationState.initial(s).copy(currentRound = 1))
@@ -351,7 +373,7 @@ class NarrateHandlerTests {
     }
 
     @Test
-    fun omitsTheDescriptorSectionWhenNarratorIsAbsent() = runTest {
+    fun omitsTheDescriptorSectionWhenNarratorIsBlank() = runTest {
         // Pins the GATE on the descriptor section, not merely its rendering: a blank
         // descriptor must not emit an empty "Commentator persona:" heading with
         // nothing after it. Claimant for the `if (true)` perturbation — forcing the
@@ -413,10 +435,11 @@ class NarrateHandlerTests {
 
     @Test
     fun usesTheHandlersOwnDefaultWhenMaxSentencesIsAbsent() = runTest {
-        // Pins DEFAULT_MAX_SENTENCES = 3. Without this, the handler's explicit "this
-        // is narrate's OWN constant, not PromptBuilder.DEFAULT_STATEMENT_MAX_SENTENCES"
-        // rationale is unobservable — the two values are both 3 today, so nothing
-        // would notice narrate silently starting to track the statement default.
+        // Pins the value 3. It CANNOT discriminate WHICH constant that 3 came from
+        // while PromptBuilder.DEFAULT_STATEMENT_MAX_SENTENCES is also 3 — refactoring
+        // narrate to read the statement constant leaves this green. It becomes a
+        // coupling detector for the handler's "narrate's OWN constant" rationale only
+        // once the two values diverge.
         val s = scenario(maxSentences = null)
         val backend = ScriptedLLMBackend(listOf(narrates("ok")))
 

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/NarrateHandlerTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/NarrateHandlerTests.kt
@@ -29,31 +29,47 @@ import kotlin.test.assertTrue
  *
  * Each mechanism was broken in isolation and the named **dedicated claimant**
  * confirmed to redden (a claimant that stayed green would be a measurement defect,
- * not a redundant test). Three mutations also break the happy path and so redden
- * most of the suite; that **incidental** breakage is listed separately, because a
- * wide red set is not evidence about the axis. Measured 2026-07-30, #1330.
+ * not a redundant test). Two mutations also break the happy path and so redden most
+ * of the suite; that **incidental** breakage is listed separately, because a wide red
+ * set is not evidence about the axis. Counts are measured, not derived —
+ * re-measure rather than reason if you change a fixture. Measured 2026-07-30, #1330.
  *
- * | Mechanism broken | Dedicated claimant | Incidental |
- * |---|---|---|
- * | Empty-log guard → `isNotEmpty()` | [skipsEmissionOnEmptyLog] | 12 others (inverting also skips the happy path) |
- * | Catch arm `return state` → `throw e` | [degradesByOmissionOnFailure] | 1 ([emptyCommentaryIsAbsorbedByTheCatchArmNotTheGuard], which routes through the same arm) |
- * | Catch breadth → `catch (e: Throwable)` | [aSystemicThrowEscapesRatherThanDegrading], [cancellationEscapesRatherThanBeingSwallowed] | none |
- * | `emitter = {}` → `context.emitter` | [suppressesTheNarratorsAgentAttributedEvents] | none |
- * | Final `return state` → a persisting `copy` | [narratorIsNotAParticipant] | none |
- * | Descriptor section dropped | [injectsNarratorDescriptorIntoSystemPrompt] | none |
- * | Schema field renamed | [requestsCommentarySchema] | 8 others (the parse then fails) |
- * | A second inference added | [singleInferenceRegardlessOfAgentCount] | 10 others (the script list runs out) |
- * | Empty-commentary guard **deleted** | *(none — expected green)* | none |
+ * | Mechanism broken | Mutation | Dedicated claimant | Incidental |
+ * |---|---|---|---|
+ * | Empty-log guard | `if (…isEmpty())` → `if (false)` | [skipsEmissionOnEmptyLog] | none |
+ * | Catch arm degrades | `return state` → `error(…)` | [degradesByOmissionOnFailure] | 1 — [emptyCommentaryIsAbsorbedByTheCatchArmNotTheGuard] routes through the same arm |
+ * | Catch breadth | `SimulationException` → `Throwable` | [aSystemicThrowEscapesRatherThanDegrading], [cancellationEscapesRatherThanBeingSwallowed] | none |
+ * | Emitter swallowing | `emitter = {}` → `context.emitter` | [suppressesTheNarratorsAgentAttributedEvents] | none |
+ * | Persists nothing | final `return state` → a `copy` writing a probe var | [narratorIsNotAParticipant] | none |
+ * | Descriptor gate — **closed** | `if (trimmed.isNotEmpty())` → `if (false)` | [injectsNarratorDescriptorIntoSystemPrompt] | none |
+ * | Descriptor gate — **open** | same → `if (true)` | [omitsTheDescriptorSectionWhenNarratorIsAbsent] | none |
+ * | Engine-fixed schema | field `"commentary"` → `"comment"` | [requestsCommentarySchema] | 10 (every response then fails to parse) |
+ * | One inference per round | a 2nd `call` **before** the real one | [singleInferenceRegardlessOfAgentCount] | 11 (it consumes script #1) |
+ * | Empty-commentary guard | block **deleted** | *(none — expected green)* | none |
  *
- * The last row is the point of the exercise, not a gap: the guard is unreachable on
- * this side, so nothing can redden. Confirmed by measurement rather than asserted —
- * see [emptyCommentaryIsAbsorbedByTheCatchArmNotTheGuard].
+ * Four things this table encodes that a first draft of it got wrong:
  *
- * Note what the "one inference" row does **not** establish. Its assertion is
- * `callCount == 1`, so it catches any multiplication of the call but does not by
- * itself prove agent-count *independence*; that claim rests on `callCount == 1`
- * **together with** the 3-agent pin in [scenario], which is why the pin is asserted
- * in the test body rather than left implicit.
+ * 1. **The last row is the point, not a gap.** The guard is unreachable on this side,
+ *    so nothing can redden. Measured, not assumed — see
+ *    [emptyCommentaryIsAbsorbedByTheCatchArmNotTheGuard].
+ * 2. **Both gate polarities are measured.** `if (false)` removes the descriptor
+ *    *append*; only `if (true)` breaks the *gate*, and that is what
+ *    [omitsTheDescriptorSectionWhenNarratorIsAbsent] guards. Testing one polarity
+ *    leaves the other test green by construction.
+ * 3. **The mutation column is load-bearing.** The "one inference" row reddens 11
+ *    others only because the extra call is inserted *before* the real one and eats
+ *    script #1; inserted *after*, the two catch-arm tests would stay green. Without
+ *    the site named, the row is not reproducible.
+ * 4. **A claimant must fail on its own assertion.** [requestsCommentarySchema] is
+ *    scripted with the full retry budget precisely so a renamed field reddens it at
+ *    `assertEquals`, not via the harness's script-exhaustion error — which would be
+ *    the same failure mode as all 10 incidentals and therefore no evidence at all.
+ *
+ * What the "one inference" row does **not** establish: its assertion is
+ * `callCount == 1`, which catches any multiplication of the call but does not by
+ * itself prove agent-count *independence*. That claim rests on `callCount == 1`
+ * **together with** the 3-agent pin, which is why the pin is asserted in the test
+ * body rather than left implicit.
  *
  * Ported for the ADR-023 KMP Engine migration (#501, #1330).
  */
@@ -310,9 +326,13 @@ class NarrateHandlerTests {
         val s = scenario()
         val events = mutableListOf<SimulationEvent>()
 
-        assertFailsWith<CancellationException> {
+        // Asserting the message, not just the type: `CancellationException` is an
+        // `IllegalStateException` on JVM and so is `ScriptedLLMBackend`'s exhaustion
+        // signal, so pinning the text keeps this from ever passing on a harness fault.
+        val e = assertFailsWith<CancellationException> {
             handler.execute(context(s, NarrateCancellingBackend(), events), stateWithLog(s))
         }
+        assertEquals("cancelled mid-narration", e.message)
         assertTrue(narrations(events).isEmpty())
     }
 
@@ -332,8 +352,12 @@ class NarrateHandlerTests {
 
     @Test
     fun omitsTheDescriptorSectionWhenNarratorIsAbsent() = runTest {
-        // Guards the `isNotEmpty()` branch: a blank descriptor must not emit an empty
-        // "Commentator persona:" heading with nothing after it.
+        // Pins the GATE on the descriptor section, not merely its rendering: a blank
+        // descriptor must not emit an empty "Commentator persona:" heading with
+        // nothing after it. Claimant for the `if (true)` perturbation — forcing the
+        // gate open is what this catches, where forcing it CLOSED (`if (false)`) is
+        // caught by injectsNarratorDescriptorIntoSystemPrompt. Both polarities are
+        // measured; see the class KDoc.
         val s = scenario(narrator = "   ")
         val backend = ScriptedLLMBackend(listOf(narrates("ok")))
 
@@ -374,15 +398,51 @@ class NarrateHandlerTests {
     }
 
     @Test
-    fun requestsCommentarySchema() = runTest {
-        // Engine-fixed single-field `{ commentary }` schema — not author-declared, so
-        // the backend receives exactly that constraint regardless of the phase YAML.
-        val s = scenario()
+    fun clampsMaxSentencesToTheUpperBoundToo() = runTest {
+        // The floor alone would leave `coerceIn(1, 100)` green while the clamp's name
+        // promises the validator's 1..6 range. Pins the ceiling.
+        val s = scenario(maxSentences = 99)
         val backend = ScriptedLLMBackend(listOf(narrates("ok")))
 
         handler.execute(context(s, backend), stateWithLog(s))
 
-        val schema = backend.requests.single().schema
+        val system = backend.requests.single().system
+        assertContains(system, "at most 6 sentence(s)")
+        assertTrue("at most 99" !in system)
+    }
+
+    @Test
+    fun usesTheHandlersOwnDefaultWhenMaxSentencesIsAbsent() = runTest {
+        // Pins DEFAULT_MAX_SENTENCES = 3. Without this, the handler's explicit "this
+        // is narrate's OWN constant, not PromptBuilder.DEFAULT_STATEMENT_MAX_SENTENCES"
+        // rationale is unobservable — the two values are both 3 today, so nothing
+        // would notice narrate silently starting to track the statement default.
+        val s = scenario(maxSentences = null)
+        val backend = ScriptedLLMBackend(listOf(narrates("ok")))
+
+        handler.execute(context(s, backend), stateWithLog(s))
+
+        assertContains(backend.requests.single().system, "at most 3 sentence(s)")
+    }
+
+    @Test
+    fun requestsCommentarySchema() = runTest {
+        // Engine-fixed single-field `{ commentary }` schema — not author-declared, so
+        // the backend receives exactly that constraint regardless of the phase YAML.
+        //
+        // Scripted with the FULL retry budget, and reading `requests.first()` rather
+        // than `.single()`, so that a renamed schema field is caught by the assertion
+        // below rather than by the harness. With one script, renaming the field makes
+        // the parser reject every response, the retry loop asks for a second script,
+        // and `ScriptedLLMBackend` throws its exhaustion `IllegalStateException`
+        // *before* this test ever reads the request — reddening for the same reason
+        // as every unrelated test, which is not evidence about the schema.
+        val s = scenario()
+        val backend = ScriptedLLMBackend(List(LLMCaller.MAX_RETRIES + 1) { narrates("ok") })
+
+        handler.execute(context(s, backend), stateWithLog(s))
+
+        val schema = backend.requests.first().schema
         assertEquals(listOf("commentary"), schema?.fields?.map { it.name })
     }
 }

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/PhaseDispatcherTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/PhaseDispatcherTests.kt
@@ -80,6 +80,11 @@ class PhaseDispatcherTests {
     }
 
     @Test
+    fun resolvesTheNarrateHandler() {
+        assertIs<NarrateHandler>(dispatcher.handler(PhaseType.NARRATE))
+    }
+
+    @Test
     fun returnsAStableHandlerInstance() {
         // Handlers are stateless values; the dispatcher builds its map once.
         assertTrue(dispatcher.handler(PhaseType.SPEAK_ALL) === dispatcher.handler(PhaseType.SPEAK_ALL))
@@ -95,9 +100,10 @@ class PhaseDispatcherTests {
     fun theErrorNamesThePhaseUsingItsWireNameNotItsKotlinCaseName() {
         // `conditional`, not `CONDITIONAL` — Swift interpolates `phaseType.rawValue`,
         // and a reader comparing the two engines' errors should see the same token.
-        // The exemplar is CONDITIONAL rather than the next handler in the port queue:
-        // it is LAST in the remaining Wave-B order (Narrate -> Conditional), so this
-        // repoint survives the longest.
+        // The exemplar is CONDITIONAL because it is the SOLE remaining unported
+        // handler (Wave B is 13/14), so no further repoint is possible: the next port
+        // to land is Conditional itself, and that PR retires this exemplar rather than
+        // moving it.
         val error = assertFailsWith<SimulationException> { dispatcher.handler(PhaseType.CONDITIONAL) }
         val message = assertIs<SimulationError.ScenarioValidationFailed>(error.error).message
         assertTrue(message.contains("conditional"), "expected the wire name, got: $message")
@@ -117,7 +123,7 @@ class PhaseDispatcherTests {
             runCatching { dispatcher.handler(it) }.isFailure
         }
         assertEquals(14, PhaseType.entries.size, "the drift ledger's case count is now executable")
-        assertEquals(2, unported.size, "see the #501 drift ledger")
+        assertEquals(1, unported.size, "see the #501 drift ledger")
         for (type in unported) {
             val error = assertFailsWith<SimulationException>("$type must fail cleanly") {
                 dispatcher.handler(type)

--- a/shared/prompt-literal-parity-allowlist.tsv
+++ b/shared/prompt-literal-parity-allowlist.tsv
@@ -36,4 +36,3 @@
 # fails on a row that no longer matches anything — a healed divergence must drop
 # its row rather than linger as a standing exemption.
 side	stem	digest	excerpt	reason
-unported	NarrateHandler	-	-	ADR-023 Stage 3: narrate is not in the Wave B port set yet (#501).

--- a/shared/prompt-literal-parity-allowlist.tsv
+++ b/shared/prompt-literal-parity-allowlist.tsv
@@ -25,9 +25,13 @@
 #            approved. It expires only when the Kotlin counterpart appears (which
 #            the checker reports as stale). Because "keep them scarce" is advice
 #            nothing executes, the checker caps them — `MAX_UNPORTED_ROWS` is held
-#            AT the current row count (1 today), never above it, so the budget
-#            ratchets down as the port lands instead of leaving a free slot.
-#            Raising it is a deliberate act, and the reason belongs here.
+#            AT the current row count, never above it, so the budget ratchets down
+#            as the port lands instead of leaving a free slot. That count is now
+#            **0**: the last deferral (NarrateHandler) landed in #1330, and the sole
+#            remaining Wave-B handler (ConditionalHandler) has no `pickLanguage`
+#            literals, so no planned port needs a row. The cap is therefore closed
+#            by default — adding ANY `unported` row now means raising the cap in the
+#            same change, deliberately, with the reason recorded right here.
 #   excerpt  a readable, escaped prefix of the ja literal. Cosmetic; the digest is
 #            what matches. `<>` marks an erased interpolation.
 #   reason   why the divergence is intended. Required; a blank fails the gate.


### PR DESCRIPTION
## Summary

Ports `NarrateHandler` to the KMP `shared/engine` `commonMain` module — ADR-023 Stage 3 Wave B,
handler 6 of the LLM set. Board **12/14 → 13/14**; only `ConditionalHandler` remains, and it stays
last by design because it nests LLM sub-handlers.

`narrate` is structurally unlike the five LLM handlers already ported, so the port deliberately
diverges from `ReflectHandler` — its nearest structural sibling, which calls
`buildSystemPrompt`, five `inject*` helpers, `captureMood`, and `state.copy(...)`. **All four are
wrong for narrate, and none would fail the build**, so the handler KDoc carries an explicit
"must NOT call" list.

| Mechanism | Why it differs |
|---|---|
| No `TurnFailureGate` | The narrator is not a participant, so a `TurnSkipped` must not feed the ADR-021 consecutive-skip breaker (#909 critic Axis 4). Its own `try/catch` degrades by omission. |
| `catch (e: SimulationException)` — **narrower than Swift's bare `catch`** | Kotlin cancellation is a *throw*. Every other handler gets the rethrow free from the gate; narrate has no gate, so a broad catch would swallow a user's cancel and let the run continue. Swift's bare `catch` is safe only because its runner polls `Task.isCancelled`. |
| `emitter = {}` into `LLMCaller` | Drops the agent-attributed events so the commentator never renders as a participant row. **Events only** — `StreamingDiag` still reaches `context.logger`, as in Swift. |
| Never copies state | narrate persists nothing, so `execute` returns its input `state` on all four exits — the only handler in either engine that does. |
| Engine-fixed `{ commentary }` schema | Not author-declared; a `narrate` phase needs no `output:` block. |

**`maxSentences` gains `coerceIn(1, 6)`.** This looked like a fidelity-vs-precedent conflict and
is not one: `ScenarioValidator.validateMaxSentences` is called *unconditionally* from the
`validatePhases` traversal (`ScenarioValidator.swift:111`, and `:216` for branch sub-phases), so it
covers narrate and Swift's accepted domain is `{nil} ∪ [1,6]` — which is why the Swift original
needs no clamp. That validator is a Stage-3 deferral, so un-clamped this side renders `0文以内` /
"at most 0 sentence(s)", an unsatisfiable instruction. `PromptBuilder`'s sibling clamp called itself
"the THIRD site"; this makes a fourth, so the ordinal is dropped in the same commit.

All **6** `pickLanguage` pairs port byte-identically (the sixth is the user-prompt default template,
easy to miss behind the five system-prompt sections). Gate: 43/43 across 12 Swift files.

### The `unported` ratchet reaches 0

`NarrateHandler` was the allowlist's last whole-file deferral, and `ConditionalHandler` has **zero**
`pickLanguage` literals, so `MAX_UNPORTED_ROWS` hits its terminus rather than a temporary low.

It could not be done by editing the constant. Measured: at 0, `--self-test` **fails** on case 6's
positive arm, which is unconditional and hardcodes a one-row allowlist asserting that an `unported`
row *is* a working escape hatch. Four more cases kept passing but would have gone mutation-blind,
the cap firing before the property each targets. Fixed with an `evaluate(..., cap=)` parameter — the
cap has a single production consumer, so one keyword argument separates "the cap is enforced" from
"the mechanism works". 18b splits into a production-default arm and a boundary arm, because its old
accept arm degenerates at 0 to `evaluate({}, {}, header)` — "an empty repo has no problems", which
cannot redden on a cap regression.

## Test plan

Run with `--rerun-tasks` (31/31 tasks executed — not a cached green), counts read from the **JUnit XML** rather than Gradle's summary:

- `./gradlew :shared:models:jvmTest :shared:engine:jvmTest :shared:engine:compileCommonMainKotlinMetadata :shared:models:compileKotlinIosSimulatorArm64 :shared:engine:compileKotlinIosSimulatorArm64` → **754 tests / 0 failures**; `NarrateHandlerTests` 16.
- `python3 scripts/check-prompt-literal-parity.py` → clean, 43/43 across 12 files.
- `python3 scripts/check-prompt-literal-parity.py --self-test` → 57 checks (floor 56 → 57, verified out of band per its own comment: fires at 58, passes at 57).
- `python3 scripts/check-kmp-status.py` → 14 handlers, 13 ported ↔ board reconciled both directions.
- All 16 `scripts/tests/*-test.sh` pass (a `scripts/` change is otherwise CI-only tested).

Three mutation-sensitivity properties verified rather than argued:

- **Cap enforcement at 0** — appending an `unported` row makes the checker print the cap message verbatim. The first control attempt was **mis-keyed** on a stem with no literals and measured the *dangling* arm instead; re-keyed, and the verdict read from *which message fired*, not the exit code.
- **Case 10's control** — deleting the empty-reason guard leaves the suite green at cap 0 without `cap=1`, and reddens with it.
- **18b arm (i)** — raising `MAX_UNPORTED_ROWS` to 1 reddens it. The previous `MAX+1` form passed at every cap.

### ADR-023 §12 condition-4 perturbation record

12 axes broken in isolation via a harness that fails *itself* if a declared claimant stays green,
and that asserts each mutation's anchor matched exactly once (a silent no-op would otherwise read as
verified). Every declared claimant reddened; the expected-green axis stayed green. 13 of the 16 tests
are a dedicated claimant, and that count is machine-checked rather than hand-maintained.

The harness earned its self-failing property twice: once when a test rename left a declared claimant
stale (it exited 1 with the claimant green while an unnamed test reddened), and once when a mutation
anchor stopped matching after `catch (e:)` became `catch (_:)`. A plain "did anything redden?" check
passes in both cases and reports success.

| Mechanism broken | Mutation | Dedicated claimant | Incidental |
|---|---|---|---|
| Empty-log guard | `if (…isEmpty())` → `if (false)` | `skipsEmissionOnEmptyLog` | none |
| Catch arm degrades | `return state` → `error(…)` | `degradesByOmissionOnFailure` | 1 |
| Catch breadth | `SimulationException` → `Throwable` | `aSystemicThrowEscapes…`, `cancellationEscapes…` | none |
| Emitter swallowing | `emitter = {}` → `context.emitter` | `suppressesTheNarratorsAgentAttributedEvents` | none |
| Persists nothing | final `return state` → a probe-writing `copy` | `narratorIsNotAParticipant` | none |
| Descriptor gate — **closed** | `if (trimmed.isNotEmpty())` → `if (false)` | `injectsNarratorDescriptorIntoSystemPrompt` | none |
| Descriptor gate — **open** | same → `if (true)` | `omitsTheDescriptorSectionWhenNarratorIsAbsent` | none |
| **`max_sentences` clamp** (divergence 6) | `.coerceIn(1, 6)` deleted | `clampsMaxSentencesIntoTheSwiftValidatorRange`, `clampsMaxSentencesToTheUpperBoundToo` | none |
| Log grounding | `variables["conversation_log"]` dropped | `groundsTheUserPromptInTheConversationLog` | none |
| Engine-fixed schema | field `"commentary"` → `"comment"` | `requestsCommentarySchema` | 10 |
| One inference per round | a 2nd `call` immediately **before the `try`** | `singleInferenceRegardlessOfAgentCount` | 11 |
| Empty-commentary guard | block **deleted** | *(none — expected green)* | none |

**The last row is the point of the exercise, not a gap.** Kotlin's parser rejects a
present-but-empty expected key, so `{"commentary": ""}` exhausts the retry budget and lands on the
*catch* arm — the handler's empty-commentary guard is unreachable here, where in Swift it is the
live path. The guard is kept as defensive parity (`ReflectHandler` precedent) and the test asserts
the observable, never the guard, and says so. Deleting the guard leaves it green: **measured**, and
independently re-derived end-to-end by the reviewer.

Four defects in earlier drafts of this record, all caught by measurement or review rather than by
reasoning — which is the case for keeping the mutation column and the dedicated/incidental split:

1. An "alone" claim on the empty-log row that actually reddened 13 tests.
2. The **schema claimant reddening for the wrong reason** — script exhaustion, before its own
   assertion ran, i.e. the same failure mode as all 10 incidentals and therefore no evidence about
   the schema. Now scripted with the full retry budget so it fails at `assertEquals`.
3. **The descriptor gate perturbed in one polarity only.** `if (false)` removes the *append*; only
   `if (true)` breaks the *gate*, which is what the omission test guards — so that test had been
   green by construction while claiming coverage.
4. An unreproducible "one inference" row: the count depends on the extra call being inserted
   *before* the real one (consuming script #1), which is now stated.

Failure injection uses `Script(terminal = Failed(...))`, **not** an empty script list: exhaustion
throws `IllegalStateException` as a deliberate test-harness bug signal, so a 1:1 port of Swift's
`MockLLMService(responses: [])` would have pressured the catch wide open — manufacturing the very
defect the two cancellation/systemic controls guard.

### Acknowledged coverage gap

Five of the handler's six documented divergences have a dedicated axis. Two are covered only
**transitively**, and the KDoc says so rather than implying otherwise:

- Switching to `PromptBuilder.buildSystemPrompt` would drop the narrator descriptor and redden
  `injectsNarratorDescriptorIntoSystemPrompt` — detected, but by another axis's claimant.
- **An added `inject*` call is caught by nothing.** The handler's "must NOT call" list warns against
  it, but no test asserts the absence of a reserved-namespace token in the prompt.

Left as a stated gap rather than closed with an axis invented to make a completeness sentence true.

### Rule promotion (rule-aware bundling)

One paragraph added to `.claude/rules/kmp-interop.md` Pattern 4, folded into its existing
"Test authoring:" cluster: **`ScriptedLLMBackend` exhaustion is a harness fault, not a backend
failure.** Both findings this PR hit share that root cause — the 1:1 port of Swift's
`MockLLMService(responses: [])` is the natural thing to write and pressures the handler's `catch`
wide open (swallowing cancellation on this side), and an assertion behind a script list with no
spare is structurally unreachable, so a perturbation can report "claimant reddened" with the
claimant's own assertion never having run. Directly relevant to the remaining `ConditionalHandler`
port.

Every assertion in it was executed before commit per `knowledge-layering.md` §
"Rule-writing self-check" — including `javap java.util.concurrent.CancellationException`, which
prints `extends java.lang.IllegalStateException`. +10 lines on a path-scoped file, so no
always-loaded budget cost.

### Deferred follow-up (not in this PR)

`ScriptedLLMBackend`'s exhaustion signal is a bare `IllegalStateException`, which on JVM is a
**supertype** of `kotlin.coroutines.cancellation.CancellationException`. Nothing misfires today —
`cancellationEscapesRatherThanBeingSwallowed` asserts the subtype *and* the message, and no test
asserts `IllegalStateException` — but a future `assertFailsWith<IllegalStateException>` anywhere in
`commonTest` would accept a swallowed-cancel bug as harness exhaustion. A bespoke
`ScriptExhaustedException` would make that disjointness structural. Deliberately **not** bundled:
`LLMBackendTestSupport.kt` is shared by every handler suite, so the change belongs on its own rather
than widening a port PR.

## Device QA

実機QA不要 — `shared/**` Kotlin (not consumed by the iOS app until Stage 5), a dev-only gate script,
and docs. No iOS surface changes.

Closes #1330
Part of #501
