### PR TITLE
📝 docs: three corrections left by #1334

### DIFF
--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -122,7 +122,7 @@ A **why-comment you write** asserts runtime or library behaviour as the reason a
 
 When a check is too expensive to run, say the cause was not isolated. A reader can act on an acknowledged gap; a wrong cause they can only inherit.
 
-Motivating incidents: PR #1152 round-1 review; PR #1299 rounds 1–3; #1312 rounds 1–4; PR #1303 rounds 1–3; PR #1314.
+Motivating incidents: PR #1152 round-1 review; PR #1299 rounds 1–3; #1312 rounds 1–4; PR #1303 rounds 1–3; PR #1314; PR #1334.
 
 ### A rules file created mid-session never injects in that session
 

--- a/.claude/rules/xcodebuild-cli.md
+++ b/.claude/rules/xcodebuild-cli.md
@@ -191,7 +191,10 @@ if all are yours, `pkill -f "xcodebuild test"` then
 `xcrun simctl shutdown "$(echo "$DEST" | sed -n 's/.*id=//p')"`. UI-test
 `FBSOpenApplicationServiceErrorDomain Code=1` → `xcrun simctl erase <UDID>`
 + retry **once** (persistent = real signing / plist / app-state bug).
-Full walkthrough: [`docs/ci/xcodebuild-flakes.md`](../../docs/ci/xcodebuild-flakes.md) § Recovery.
+A local full-suite UI-test failure at `t = 0.00s` with no `Pastura-*.ips` is
+simulator infrastructure, not the app — re-run rather than diagnose.
+Full walkthrough: [`docs/ci/xcodebuild-flakes.md`](../../docs/ci/xcodebuild-flakes.md)
+§ Recovery / § "Local full-suite flake".
 
 ## "Executed 0 tests" in the XCTest stanza is cosmetic for Swift-Testing suites
 

--- a/.claude/rules/xcodebuild-cli.md
+++ b/.claude/rules/xcodebuild-cli.md
@@ -194,7 +194,7 @@ if all are yours, `pkill -f "xcodebuild test"` then
 A local full-suite UI-test failure at `t = 0.00s` with no `Pastura-*.ips` is
 simulator infrastructure, not the app — re-run rather than diagnose.
 Full walkthrough: [`docs/ci/xcodebuild-flakes.md`](../../docs/ci/xcodebuild-flakes.md)
-§ Recovery / § "Local full-suite flake".
+§ Recovery / § Local full-suite flake.
 
 ## "Executed 0 tests" in the XCTest stanza is cosmetic for Swift-Testing suites
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,7 +334,7 @@ same change:
 | `docs/models/eval-log.md`             | Model-eval 判定台帳 — 候補評価の verdict を committed に記録(judgment-only; 生スコアは gitignore の data/models/eval-digest.md; ADR-011 表が追跡する 6GB/1B級以外の候補が対象; #979 intake) |
 | `docs/qa/navigation-qa.md`            | Navigation manual QA walkthroughs (numbered scenarios; extracted from `.claude/rules/navigation.md`) |
 | `docs/qa/dark-mode-qa.md`             | Dark-appearance manual QA walkthrough (ADR-028 gates 4/5; the five risk classes no test can reach — fixed tokens, materials, fixed-appearance exports, non-SwiftUI surfaces, occlusion layers) |
-| `docs/ci/xcodebuild-flakes.md`        | CI UI-test flake catalog + hang/stall session-recovery walkthrough (extracted from `.claude/rules/xcodebuild-cli.md`) |
+| `docs/ci/xcodebuild-flakes.md`        | CI + local UI-test flake catalog + hang/stall session-recovery walkthrough (extracted from `.claude/rules/xcodebuild-cli.md`) |
 | `docs/prototype/among_them_prototype.py` | Python prototype (reference implementation) |
 
 ### ADR roster

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,7 +333,7 @@ same change:
 | `docs/models/onboarding.md`           | Model onboarding two-gate procedure (Stage-0 harness profile → `/model-eval` Mac filter → ADR-011 real-device accept → registration; intake #979) |
 | `docs/models/eval-log.md`             | Model-eval 判定台帳 — 候補評価の verdict を committed に記録(judgment-only; 生スコアは gitignore の data/models/eval-digest.md; ADR-011 表が追跡する 6GB/1B級以外の候補が対象; #979 intake) |
 | `docs/qa/navigation-qa.md`            | Navigation manual QA walkthroughs (numbered scenarios; extracted from `.claude/rules/navigation.md`) |
-| `docs/qa/dark-mode-qa.md`             | Dark-appearance manual QA walkthrough (ADR-028 gates 4/5; the four risk classes no test can reach — fixed tokens, materials, fixed-appearance exports, non-SwiftUI surfaces) |
+| `docs/qa/dark-mode-qa.md`             | Dark-appearance manual QA walkthrough (ADR-028 gates 4/5; the five risk classes no test can reach — fixed tokens, materials, fixed-appearance exports, non-SwiftUI surfaces, occlusion layers) |
 | `docs/ci/xcodebuild-flakes.md`        | CI UI-test flake catalog + hang/stall session-recovery walkthrough (extracted from `.claude/rules/xcodebuild-cli.md`) |
 | `docs/prototype/among_them_prototype.py` | Python prototype (reference implementation) |
 

--- a/docs/ci/xcodebuild-flakes.md
+++ b/docs/ci/xcodebuild-flakes.md
@@ -26,15 +26,9 @@ extracted — it is the one local-only class in a doc otherwise about CI.
 
 ## Local full-suite flake: simulator infrastructure crash before app launch
 
-**Local only** — this class has nothing to do with `ci-retry.yml` or the GHA
-catalog below. It fires during a local `scripts/xcodebuild.sh test` full run and
-is filed here, next to § Recovery, because that is where a local debugging
-session arrives.
-
-Observed three times during #1334, and re-diagnosed all three — twice while
-suspecting a real regression, because the same test failed at the same point
-across consecutive full-suite runs, which § "When to escalate" gives as the
-signal to *stop* treating something as a flake.
+Fires during a local `scripts/xcodebuild.sh test` full run — nothing to do with
+`ci-retry.yml` or the GHA catalog below. Observed three times during #1334 and
+re-diagnosed all three, twice while suspecting a real regression.
 
 **Signature** (the first three together are the discriminator; 4–5 corroborate
 and are not observable on a first encounter):
@@ -56,15 +50,13 @@ the position in the sequence that is being hit, so editing the test moves the
 failure rather than fixing it.
 
 **Why the recurrence rule does not apply.** § "When to escalate" and
-`.claude/rules/xcodebuild-cli.md` § "CI flake catalog" both say to escalate when
-the same message recurs at the same stage across reruns. Both are written about
-**CI reruns** (`run_attempt`, `gh run rerun --failed`), and every cause they
-enumerate is app-side — signing, `Info.plist`, app-init regressions. Generalizing
-that rule to a local full-suite run misfires when the failure *precedes* app
-launch: nothing app-side is running yet, so recurrence carries no information
-about the app. **Absence of a `Pastura-*.ips` is what settles it** — the mirror of
-the AttributeGraph render-crash class, where `.claude/rules/swiftui-traps.md`
-points at those same frames because the crash *is* in the app.
+`.claude/rules/xcodebuild-cli.md` § "CI flake catalog" both escalate on the same
+message recurring at the same stage — but both are scoped to **CI reruns** and
+every cause they name is app-side (signing, `Info.plist`, app-init). Before app
+launch nothing app-side is running, so recurrence says nothing about the app.
+**Absence of a `Pastura-*.ips` is what settles it** — the mirror of the
+AttributeGraph render-crash class, where `.claude/rules/swiftui-traps.md` points
+at those same frames because the crash *is* in the app.
 
 ## CI flake catalog (auto-retried by `ci-retry.yml`)
 

--- a/docs/ci/xcodebuild-flakes.md
+++ b/docs/ci/xcodebuild-flakes.md
@@ -22,6 +22,47 @@ the lead claims + the key inline commands + a pointer to this file.
   → `xcrun simctl erase <UDID>` + retry **once**. Persistent failures
   are real bugs (signing / plist / app-state regression), not flakes.
 
+## Local full-suite flake: simulator infrastructure crash before app launch
+
+**Local only** — this class has nothing to do with `ci-retry.yml` or the GHA
+catalog below. It fires during a local `scripts/xcodebuild.sh test` full run and
+is filed here, next to § Recovery, because that is where a local debugging
+session arrives.
+
+Observed three times during #1334, and re-diagnosed all three — twice while
+suspecting a real regression, because the same test failed at the same point
+across consecutive full-suite runs, which § "When to escalate" gives as the
+signal to *stop* treating something as a flake.
+
+**Signature** (all five together; any one alone is not enough):
+
+- `EditorReloadTests.testEditorSavePopsAndReloadsHome` fails at **`t = 0.00s`**
+  with `[XPCErrors] [C:N] Error received: Connection interrupted` — *before the
+  app launches*, so no app-side change can reach it
+- followed by `Restarting after unexpected exit, crash, or test timeout`
+- **no `Pastura-*.ips`** in `~/Library/Logs/DiagnosticReports/`; instead
+  `SimRenderServer` (`EXC_BREAKPOINT` / `SIGTRAP`) and `testmanagerd` crash logs
+  at the same timestamp
+- passes in isolation: `scripts/xcodebuild.sh test -only-testing PasturaUITests/EditorReloadTests`
+- observed each time on the test that runs immediately after
+  `DeepLinkTabRoutingUITests` — a position, not a property of the test
+
+**Action**: re-run the full suite. Confirm with the `-only-testing` run above if
+you want a second data point first. Do **not** change `EditorReloadTests` — it is
+the position in the sequence that is being hit, so editing the test moves the
+failure rather than fixing it.
+
+**Why the recurrence rule does not apply.** § "When to escalate" and
+`.claude/rules/xcodebuild-cli.md` § "CI flake catalog" both say to escalate when
+the same message recurs at the same stage across reruns. Both are written about
+**CI reruns** (`run_attempt`, `gh run rerun --failed`), and every cause they
+enumerate is app-side — signing, `Info.plist`, app-init regressions. Generalizing
+that rule to a local full-suite run misfires when the failure *precedes* app
+launch: nothing app-side is running yet, so recurrence carries no information
+about the app. **Absence of a `Pastura-*.ips` is what settles it** — the mirror of
+the AttributeGraph render-crash class, where `.claude/rules/swiftui-traps.md`
+points at those same frames because the crash *is* in the app.
+
 ## CI flake catalog (auto-retried by `ci-retry.yml`)
 
 `.github/workflows/ci-retry.yml` auto-retries failed UI test jobs

--- a/docs/ci/xcodebuild-flakes.md
+++ b/docs/ci/xcodebuild-flakes.md
@@ -5,6 +5,8 @@ On-demand reference extracted from `.claude/rules/xcodebuild-cli.md`
 catalog are human-debugging reference, not next-decision material, so
 they live here rather than in the always-loaded rule). The rule keeps
 the lead claims + the key inline commands + a pointer to this file.
+§ Local full-suite flake was recorded directly here rather than
+extracted — it is the one local-only class in a doc otherwise about CI.
 
 ## Recovery (hang or stalled retry)
 
@@ -34,7 +36,8 @@ suspecting a real regression, because the same test failed at the same point
 across consecutive full-suite runs, which § "When to escalate" gives as the
 signal to *stop* treating something as a flake.
 
-**Signature** (all five together; any one alone is not enough):
+**Signature** (the first three together are the discriminator; 4–5 corroborate
+and are not observable on a first encounter):
 
 - `EditorReloadTests.testEditorSavePopsAndReloadsHome` fails at **`t = 0.00s`**
   with `[XPCErrors] [C:N] Error received: Connection interrupted` — *before the


### PR DESCRIPTION
## Summary

Three documentation corrections left by #1334. Two of them record things that
cost real debugging time and were written down nowhere.

- **`CLAUDE.md` undercounted the dark-mode QA risk classes** — the reference-table
  row said "the four risk classes" while `docs/qa/dark-mode-qa.md` § "What is
  actually at risk" lists five (A–E). Class E (occlusion layers) was added late in
  #1334 after review found the model-load scrim defect, and the index row was not
  updated with it. E is the class with no lint guard reaching the scrim shape.

- **Recorded the `EditorReloadTests` local full-suite flake signature** in
  `docs/ci/xcodebuild-flakes.md`. Re-diagnosed three times during #1334 — twice
  while suspecting a real regression, because the same test failed at the same
  point across consecutive full-suite runs, which § "When to escalate" gives as
  the signal to *stop* treating something as a flake.

  The useful half of the entry is saying why that rule does not reach this case:
  it is written about **CI reruns** (`run_attempt`, `gh run rerun --failed`) and
  every cause it enumerates is app-side (signing / `Info.plist` / app-init).
  When the failure precedes app launch, recurrence carries no information about
  the app. Absence of a `Pastura-*.ips` alongside `SimRenderServer` /
  `testmanagerd` crash logs is what settles it — the mirror of the AttributeGraph
  render-crash class, where `.claude/rules/swiftui-traps.md` points at those same
  frames because the crash *is* in the app.

- **Added #1334 to `knowledge-layering.md`'s motivating incidents** for
  § "Claims you author are assertions too" — see the deviation below.

## Two placement decisions worth flagging

**The flake section is a top-level `##` next to § Recovery, not a `###` under
§ "CI flake catalog (auto-retried by `ci-retry.yml`)".** Every sibling under that
parent is GHA-scoped and the parent names auto-retry in its own title, so a
`###` there inherits a CI reading regardless of its own prose. A local debugging
session enters this doc through `.claude/rules/xcodebuild-cli.md`'s § Recovery
pointer, which now names both sections; `CLAUDE.md`'s index row for the doc was
widened from "CI UI-test flake catalog" to "CI + local" for the same reason —
that row was the same defect as the dark-mode row this PR fixes.

**Nothing was added to the always-loaded rule beyond lead-claim + action +
pointer** (`t = 0.00s` with no `Pastura-*.ips` ⇒ infrastructure, re-run rather
than diagnose). The `SimRenderServer` / `testmanagerd` / XPC-message / ordering
detail stays in the on-demand doc, per `context-budget.md`.

## Deviation from #1339: one of the three asks is not implemented

Issue section 3 asks for two changes. Only the first is here.

- ✅ **Add #1334 to the motivating incidents.**
- ❌ **Add a clause naming "a guard narrower than its own claim", described as
  "one shape the section does not currently name".** The premise is false.
  `.claude/rules/knowledge-layering.md` already reads *"Scope it to the claim it
  defends: a check narrower than that claim (a files-only loop behind a
  files-and-directories completeness claim), or one that silently skips its
  exemptions instead of declaring them, passes by construction."*
  `git log -L 118,118` attributes that sentence to `69f48a62` — #1189,
  "reconcile the guard-scope sentence from claude-kit" — which landed **before**
  #1334.

Three reasons to drop it rather than reword it:

1. **Redundant.** #1334's own commit body describes the incident in the clause's
   existing vocabulary — *"A guard was narrower than its own claim … It now
   enumerates every `*.colorset` and requires a dark entry or a named
   exemption"* — hitting both halves: narrower-than-its-claim, and
   declare-your-exemptions.
2. **One-way mirror.** That sentence is identical (after whitespace
   normalization — the kit copy hard-wraps, this one does not) to
   claude-kit `rules/knowledge-layering.md` on `origin/main`. This file
   reconciles kit → Pastura only, so a Pastura-side addition to that bullet
   forks the mirror at the sentence it most recently synced. If the clause is
   wanted, it lands kit-side first. Complementary check: the "Motivating
   incidents:" line has **no** counterpart in the kit copy, so the change this
   PR *does* make creates no divergence.
3. **Context budget.** The file is always-loaded; a second illustration of one
   shape is what `context-budget.md`'s classifier routes to "Drop".

## Test plan

Documentation-only — no Swift sources, no `import` statements, no layer
boundaries. The pre-commit hook skipped SwiftLint and `xcodebuild build` on every
commit (no build-relevant paths staged), as designed by
`scripts/precommit-gate-classify.sh`.

Every authored claim in the new section was checked against repo state before
commit, and independently re-checked by the review pass:

| Claim | Verified against |
|---|---|
| § "When to escalate" enumerates only app-side causes | `docs/ci/xcodebuild-flakes.md` — "signing / `Info.plist` / app-init regressions" only |
| …and is scoped to CI reruns | same block keys on `run_attempt` / `gh run rerun --failed` |
| `.claude/rules/xcodebuild-cli.md` § "CI flake catalog" carries the same rule | present (whitespace-normalized match — the file hard-wraps, so a single-line grep for the sentence is a false negative) |
| `swiftui-traps.md` points at `Pastura-*.ips` frames for the AttributeGraph class | `.claude/rules/swiftui-traps.md:299` |
| `SimRenderServer` / `testmanagerd` logs present, no `Pastura-*.ips` | `~/Library/Logs/DiagnosticReports/` — entries at the #1334 dates, zero `Pastura-*.ips` |
| The cited test exists | `Pastura/PasturaUITests/EditorReloadTests.swift:35` |
| `§ Local full-suite flake` heading exists in the target | `docs/ci/xcodebuild-flakes.md` |
| CLAUDE.md row matches the QA doc | `docs/qa/dark-mode-qa.md` — "these five classes", A–E, same order |

Two numeric claims were **dropped rather than asserted**, both mine: a
`PR #1334 rounds 1–4` suffix on the incidents line (local `code-reviewer` rounds
leave no GitHub record, so the count is unverifiable) and "four authored claims
were false" in a commit body (#1334's own body reports them across several
sections and says "Two" in one of them, so no single tally is defensible).

## Device QA

実機QA不要 — documentation-only; no code, no UI surface, no `#if !targetEnvironment(simulator)` block touched.

Closes #1339
