### PR TITLE
✨ feat: port ConditionalHandler to shared/engine — ADR-023 Wave B 14/14

### DIFF
--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -180,6 +180,10 @@ neither compiler nor CI catches:
   and a branch-nested use passes every load gate then throws mid-run at dispatch
   (deferred failure). reflect / whisper / relationship_update / narrate all
   **reject** (#909); add a `ConditionalValidatorTests+<Phase>` test either way.
+  ⚠️ **Mirror the same verdict into two Kotlin maps** — `PhaseDispatcher`'s
+  `defaultHandlers()` and `ConditionalHandler.subHandlers` (`shared/engine`,
+  ADR-023) — where it is likewise not compiler-caught, and where no validator
+  exists to double-enforce it. Details: `.claude/rules/kmp-interop.md` Pattern 4.
 - **Web format-spec coverage** — the public reference at
   `web/src/content/scenario-format.{en,ja}.md` must list the new phase as a
   backtick token, or `scripts/check-scenario-format-coverage.py` fails the

--- a/.claude/rules/kmp-interop.md
+++ b/.claude/rules/kmp-interop.md
@@ -198,6 +198,17 @@ so an **untracked** new handler reads as "marked [x] but no ported .kt exists" /
 counterpart". The tracked directory is **`Phases/` with a capital P** (`KT_PHASES_DIR` is the
 authority); macOS's case-insensitive filesystem lets a lowercase path work locally and fail the gate.
 
+**A new `PhaseType` must be dispositioned in TWO Kotlin maps, neither compiler-caught.**
+`PhaseDispatcher`'s `defaultHandlers()` decides whether the phase runs at all; `ConditionalHandler`'s
+`subHandlers` decides whether it may run *inside a conditional branch*. Both are `Map` literals, so
+omitting a case compiles — the failure is a mid-run throw, not a build error. Give the branch
+decision the same allow/reject verdict as the Swift pair (`ScenarioValidator.validateBranch` +
+`ConditionalHandler.subHandlers`), and remember that on this side there is **no `ScenarioValidator`**,
+so `subHandlers` is the sole enforcement rather than a runtime backstop. The Swift-side cost axis —
+which is where a phase is usually *introduced* — is `engine.md` § "Adding a new `PhaseType`"; that
+rule's `paths:` never reaches a `shared/**`-only session, which is why the Kotlin half is restated
+here rather than cross-referenced.
+
 **A Models change can break `shared/engine`.** Adding a `SimulationError` case broke
 `SimulationException`'s exhaustive `when`, and `:shared:models:jvmTest` alone is blind to it. Run the
 CI pair — `:shared:models:jvmTest :shared:engine:jvmTest` — before pushing.

--- a/.claude/rules/kmp-interop.md
+++ b/.claude/rules/kmp-interop.md
@@ -199,15 +199,11 @@ counterpart". The tracked directory is **`Phases/` with a capital P** (`KT_PHASE
 authority); macOS's case-insensitive filesystem lets a lowercase path work locally and fail the gate.
 
 **A new `PhaseType` must be dispositioned in TWO Kotlin maps, neither compiler-caught.**
-`PhaseDispatcher`'s `defaultHandlers()` decides whether the phase runs at all; `ConditionalHandler`'s
-`subHandlers` decides whether it may run *inside a conditional branch*. Both are `Map` literals, so
-omitting a case compiles — the failure is a mid-run throw, not a build error. Give the branch
-decision the same allow/reject verdict as the Swift pair (`ScenarioValidator.validateBranch` +
-`ConditionalHandler.subHandlers`), and remember that on this side there is **no `ScenarioValidator`**,
-so `subHandlers` is the sole enforcement rather than a runtime backstop. The Swift-side cost axis —
-which is where a phase is usually *introduced* — is `engine.md` § "Adding a new `PhaseType`"; that
-rule's `paths:` never reaches a `shared/**`-only session, which is why the Kotlin half is restated
-here rather than cross-referenced.
+`PhaseDispatcher.defaultHandlers()` decides whether the phase runs at all; `ConditionalHandler`'s
+`subHandlers` decides whether it may run *inside a conditional branch*. Both are `Map` literals, so an
+omission compiles and fails as a mid-run throw. Match the Swift pair's allow/reject verdict
+(`engine.md` § "Adding a new `PhaseType`" — path-scoped to Swift, so it never loads here), and note
+that with no `ScenarioValidator` on this side `subHandlers` is the sole enforcement, not a backstop.
 
 **A Models change can break `shared/engine`.** Adding a `SimulationError` case broke
 `SimulationException`'s exhaustive `when`, and `:shared:models:jvmTest` alone is blind to it. Run the

--- a/Pastura/Pastura/Engine/Phases/ConditionalHandler.swift
+++ b/Pastura/Pastura/Engine/Phases/ConditionalHandler.swift
@@ -3,11 +3,14 @@ import Foundation
 /// Handles `conditional` phases — evaluates a DSL expression against the
 /// current simulation state and dispatches to `thenPhases` or `elsePhases`.
 ///
-/// Owns a private ``PhaseDispatcher`` so the outer runner's dispatcher is
-/// not threaded through ``PhaseContext``. ``SimulationRunner`` remains the
-/// sole emitter of `.simulationPaused`; this handler invokes
-/// `context.pauseCheck` between each sub-phase so the user's pause request
-/// is honored at sub-phase granularity.
+/// Owns a private sub-handler dictionary (``subHandlers``) rather than a
+/// ``PhaseDispatcher``, so the outer runner's dispatcher is not threaded
+/// through ``PhaseContext``. The distinction matters: a `PhaseDispatcher`
+/// contains every handler including this one, so holding one here would
+/// recurse forever at initialization — see ``subHandlers``.
+/// ``SimulationRunner`` remains the sole emitter of `.simulationPaused`;
+/// this handler invokes `context.pauseCheck` between each sub-phase so the
+/// user's pause request is honored at sub-phase granularity.
 ///
 /// Nested lifecycle events (`phaseStarted` / `phaseCompleted`) are emitted
 /// with paths of the form `[outerK, innerN]` so consumers can tell a nested
@@ -30,10 +33,16 @@ nonisolated struct ConditionalHandler: PhaseHandler {
   /// handler, including `ConditionalHandler`, which would build another
   /// `PhaseDispatcher` in turn, forever.
   ///
-  /// Also omits `.reflect` and `.whisper` — both are private-channel LLM
-  /// phases that are not supported inside a conditional branch in v1
-  /// (`ScenarioValidator.validateBranch` rejects them at load time; the
-  /// omission here is the runtime backstop).
+  /// Also omits four phase types that are not supported inside a conditional
+  /// branch: `.reflect` and `.whisper` (private-channel LLM phases),
+  /// `.relationshipUpdate`, and `.narrate`. For all four,
+  /// `ScenarioValidator.validateBranch` rejects at load time and the omission
+  /// here is the runtime backstop.
+  ///
+  /// Counting `.conditional` above, this dictionary registers 9 of the 14
+  /// phase types. Neither this dictionary nor `validateBranch` is exhaustive
+  /// over `PhaseType`, so a newly added phase is NOT compiler-caught here —
+  /// see `.claude/rules/engine.md` § "Adding a new `PhaseType`".
   ///
   /// `event_inject` is included so curators can gate event injection on
   /// scenario state (e.g., "only inject in round 3+"). The validator
@@ -89,9 +98,13 @@ nonisolated struct ConditionalHandler: PhaseHandler {
 
       // Resolve the handler BEFORE emitting `phaseStarted` so a
       // missing-handler throw doesn't leave a dangling started-without-
-      // completed event in the stream (the outer `.phaseStarted(.conditional)`
-      // / `.phaseCompleted(.conditional)` pair from the runner still brackets
-      // the whole failure path).
+      // completed event in the stream.
+      //
+      // The outer pair does NOT rescue this: on a throw, `executePhases`
+      // emits `.error` and returns without emitting
+      // `.phaseCompleted(.conditional)`, so the outer `phaseStarted` dangles
+      // too. Ordering here is therefore the only thing keeping the INNER
+      // events paired on the rejection path.
       guard let handler = subHandlers[subPhase.type] else {
         throw SimulationError.scenarioValidationFailed(
           "Phase type '\(subPhase.type.rawValue)' is not allowed inside a "

--- a/docs/kmp-migration-status.md
+++ b/docs/kmp-migration-status.md
@@ -45,7 +45,7 @@ Legend: ✅ done · 🔄 in progress · 🟡 partial · ⬜ not started.
 | Wave A — non-handler run-path (scoring, mechanisms, prompt/LLM glue) | ✅ done | #1207 #1212 #1217 |
 | Wave B — 14 phase handlers | ✅ 14/14 | checklist ↓ |
 | code-phase track | ✅ done | CP1 #1226 · CP2 #1230 · CP3 #1232 |
-| Loader / validator port + `detector`·`logger` wiring | ⬜ not started | why Stage 3 stays 🔄 · [ADR-023](decisions/ADR-023.md) §6 · #501 |
+| Loader / validator port + `detector`·`logger` wiring | ⬜ not started | remaining Stage-3 units, not the full list · [ADR-023](decisions/ADR-023.md) §4 · #501 |
 
 ### Wave B handler checklist
 

--- a/docs/kmp-migration-status.md
+++ b/docs/kmp-migration-status.md
@@ -22,7 +22,7 @@ At-a-glance progress for the KMP Engine migration (ADR-023 / [#501](https://gith
 > other section is hand-maintained; refresh it when a KMP PR merges (see
 > [`.claude/rules/kmp-interop.md`](../.claude/rules/kmp-interop.md)).
 
-_Last updated: 2026-07-30._
+_Last updated: 2026-07-31._
 
 ## Stages
 
@@ -43,8 +43,9 @@ Legend: ✅ done · 🔄 in progress · 🟡 partial · ⬜ not started.
 |---|:--:|---|
 | Models mirror | ✅ done | #1193 #1196 #1202 |
 | Wave A — non-handler run-path (scoring, mechanisms, prompt/LLM glue) | ✅ done | #1207 #1212 #1217 |
-| Wave B — 14 phase handlers | 🔄 13/14 | checklist ↓ |
+| Wave B — 14 phase handlers | ✅ 14/14 | checklist ↓ |
 | code-phase track | ✅ done | CP1 #1226 · CP2 #1230 · CP3 #1232 |
+| Loader / validator port + `detector`·`logger` wiring | ⬜ not started | why Stage 3 stays 🔄 · [ADR-023](decisions/ADR-023.md) §6 · #501 |
 
 ### Wave B handler checklist
 
@@ -58,7 +59,7 @@ machine-checked — see the maintenance invariant above.
 - [x] SpeakAllHandler — #1222
 - [x] SummarizeHandler — #1226
 - [x] ChooseHandler — #1262
-- [ ] ConditionalHandler
+- [x] ConditionalHandler — #1342
 - [x] EventInjectHandler — #1230
 - [x] NarrateHandler — #1330
 - [x] ReflectHandler — #1242

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/PhaseDispatcher.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/PhaseDispatcher.kt
@@ -7,13 +7,10 @@ import kotlinx.serialization.serializer
 /**
  * Routes [PhaseType] values to their [PhaseHandler] implementations.
  *
- * ## Scope: the ADR-023 Stage-3 port, in progress
+ * ## Scope: all 14 phase types are registered
  *
- * **`SPEAK_ALL`, `ELIMINATE`, `SUMMARIZE`, `ASSIGN`, `EVENT_INJECT`, `SCORE_CALC`,
- * `RELATIONSHIP_UPDATE`, `REFLECT`, `VOTE`, `WHISPER`, `CHOOSE`, `SPEAK_EACH` and
- * `NARRATE` are registered.** Swift registers all 14; the remaining 1 is the
- * mechanical bulk of Stage 3 ("mechanical after the Stage-2 slice", §4), ported
- * handler-by-handler.
+ * Wave B completed with `CONDITIONAL` (#1342), so this map now covers every
+ * [PhaseType] case, matching Swift.
  *
  * Unlike Swift's `PhaseDispatcher`, this is **not** exhaustive over [PhaseType] —
  * so an unregistered phase fails at dispatch with a clear error rather than at
@@ -22,33 +19,33 @@ import kotlinx.serialization.serializer
  * projection contract demands lives on the *Swift* enum switches, which are
  * unaffected by this port.
  *
+ * **That throw is not dead code now that the map is complete.** It defends the
+ * recurring state this migration keeps producing: a new case lands in
+ * `shared/models` (needed for wire parity) *before* its handler is ported, and
+ * until it is, dispatch must fail as a legible gap rather than crash. Converting
+ * the lookup to an exhaustive `when` would instead hard-compile-break
+ * `shared/engine` for the whole of every such window.
+ *
  * Swift original: `Pastura/Pastura/Engine/PhaseDispatcher.swift`.
+ *
+ * @param handlers **Test seam.** Production always uses the default — the two
+ *   construction sites are `SimulationEngine`'s `RunLoop` and the tests. Injecting
+ *   a partial map is the only way to reach the throw arm below (and, through it,
+ *   [serialName]) now that every real [PhaseType] resolves; without it the
+ *   negative control for the error contract would be unreachable and its test
+ *   would pass vacuously. Registration itself must still be asserted against a
+ *   default-constructed dispatcher.
  */
-internal class PhaseDispatcher {
-
-    private val handlers: Map<PhaseType, PhaseHandler> = mapOf(
-        PhaseType.SPEAK_ALL to SpeakAllHandler(),
-        PhaseType.ELIMINATE to EliminateHandler(),
-        PhaseType.SUMMARIZE to SummarizeHandler(),
-        PhaseType.ASSIGN to AssignHandler(),
-        PhaseType.EVENT_INJECT to EventInjectHandler(),
-        PhaseType.SCORE_CALC to ScoreCalcHandler(),
-        PhaseType.RELATIONSHIP_UPDATE to RelationshipUpdateHandler(),
-        PhaseType.REFLECT to ReflectHandler(),
-        PhaseType.VOTE to VoteHandler(),
-        PhaseType.WHISPER to WhisperHandler(),
-        PhaseType.CHOOSE to ChooseHandler(),
-        PhaseType.SPEAK_EACH to SpeakEachHandler(),
-        PhaseType.NARRATE to NarrateHandler(),
-    )
+internal class PhaseDispatcher(
+    private val handlers: Map<PhaseType, PhaseHandler> = defaultHandlers(),
+) {
 
     /**
      * The handler for [phaseType].
      *
      * @throws SimulationException wrapping [SimulationError.ScenarioValidationFailed]
-     *   when no handler is registered — including for a phase Swift *does* support
-     *   but this slice has not ported yet. The message names the phase so a
-     *   Stage-3 gap reads as a gap rather than as a mystery.
+     *   when no handler is registered. The message names the phase so a registration
+     *   gap reads as a gap rather than as a mystery.
      */
     fun handler(phaseType: PhaseType): PhaseHandler =
         handlers[phaseType] ?: throw SimulationException(
@@ -59,8 +56,36 @@ internal class PhaseDispatcher {
 }
 
 /**
+ * The full production handler registration — one entry per [PhaseType].
+ *
+ * A function, not a shared constant, so each dispatcher keeps constructing its own
+ * handler instances exactly as it did before the seam was added.
+ */
+private fun defaultHandlers(): Map<PhaseType, PhaseHandler> = mapOf(
+    PhaseType.SPEAK_ALL to SpeakAllHandler(),
+    PhaseType.ELIMINATE to EliminateHandler(),
+    PhaseType.SUMMARIZE to SummarizeHandler(),
+    PhaseType.ASSIGN to AssignHandler(),
+    PhaseType.EVENT_INJECT to EventInjectHandler(),
+    PhaseType.SCORE_CALC to ScoreCalcHandler(),
+    PhaseType.RELATIONSHIP_UPDATE to RelationshipUpdateHandler(),
+    PhaseType.REFLECT to ReflectHandler(),
+    PhaseType.VOTE to VoteHandler(),
+    PhaseType.WHISPER to WhisperHandler(),
+    PhaseType.CHOOSE to ChooseHandler(),
+    PhaseType.SPEAK_EACH to SpeakEachHandler(),
+    PhaseType.NARRATE to NarrateHandler(),
+    PhaseType.CONDITIONAL to ConditionalHandler(),
+)
+
+/**
  * The phase type's YAML/wire name (`speak_all`), not its Kotlin case name
  * (`SPEAK_ALL`).
+ *
+ * `internal` rather than file-private so [ConditionalHandler] can build its own
+ * branch-rejection message from the same source — both messages interpolate what
+ * Swift writes as `phaseType.rawValue`, and deriving them separately is how the two
+ * drift.
  *
  * Swift's message interpolates `phaseType.rawValue`, so this keeps the two
  * engines' error text aligned for a reader comparing them.
@@ -73,5 +98,5 @@ internal class PhaseDispatcher {
  * the port boundary; reading the descriptor keeps that literally true instead of
  * re-deriving it from a naming convention.
  */
-private fun PhaseType.serialName(): String =
+internal fun PhaseType.serialName(): String =
     PhaseType.serializer().descriptor.getElementName(ordinal)

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/PhaseHandler.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/PhaseHandler.kt
@@ -50,8 +50,8 @@ import com.pastura.models.SimulationState
  * @property phase     The phase this handler is executing.
  * @property backend   The platform LLM backend (§5.2).
  * @property phasePath This handler's position in the scenario. Top-level handlers
- *   run with `[K]`; sub-phases inside a conditional would run with `[K, N]`. No
- *   nesting handler is in this slice, so it is always single-element here.
+ *   run with `[K]`; sub-phases inside a conditional run with `[K, N]`, built by
+ *   [ConditionalHandler] — the only nesting handler.
  */
 internal class PhaseContext(
     val scenario: Scenario,
@@ -83,9 +83,10 @@ internal class PhaseContext(
      * structurally impossible.
      *
      * Handlers that dispatch nested sub-phases must call this between each one so
-     * a pause is honoured at sub-phase granularity. No such handler exists in this
-     * slice, so nothing calls it yet — it is part of the contract the runner
-     * provides and Stage 3's `ConditionalHandler` consumes.
+     * a pause is honoured at sub-phase granularity. [ConditionalHandler] is the sole
+     * consumer, and relies on the throw above as its *only* cancellation check —
+     * it deliberately carries no `ensureActive()` of its own, so weakening this
+     * contract would silently make branch loops uncancellable.
      */
     val pauseCheck: suspend (phasePath: List<Int>) -> Unit,
     val phasePath: List<Int>,

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/PhaseHandler.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/PhaseHandler.kt
@@ -84,9 +84,12 @@ internal class PhaseContext(
      *
      * Handlers that dispatch nested sub-phases must call this between each one so
      * a pause is honoured at sub-phase granularity. [ConditionalHandler] is the sole
-     * consumer, and relies on the throw above as its *only* cancellation check —
-     * it deliberately carries no `ensureActive()` of its own, so weakening this
-     * contract would silently make branch loops uncancellable.
+     * consumer, and relies on the throw above as its *only* cancellation check — it
+     * deliberately carries no `ensureActive()` of its own. Weakening this contract
+     * would therefore leave a branch of **code phases** with no cancellation check
+     * at all; a branch containing an LLM sub-phase would still unwind at
+     * [LLMCaller]'s own suspension points, and that asymmetry is exactly what would
+     * make the gap easy to miss.
      */
     val pauseCheck: suspend (phasePath: List<Int>) -> Unit,
     val phasePath: List<Int>,

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/ConditionalHandler.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/ConditionalHandler.kt
@@ -1,0 +1,204 @@
+package com.pastura.engine
+
+import com.pastura.models.Phase
+import com.pastura.models.PhaseType
+import com.pastura.models.SimulationError
+import com.pastura.models.SimulationEvent
+import com.pastura.models.SimulationState
+
+/**
+ * Handles `conditional` phases — evaluates a DSL expression against the current
+ * simulation state and dispatches to `thenPhases` or `elsePhases`.
+ *
+ * The only handler that nests. That makes it the first and only consumer of three
+ * [PhaseContext] mechanisms the runner has provided since the Stage-2 gate slice
+ * with nothing calling them: [PhaseContext.pauseCheck], a `[outerK, innerN]`
+ * [PhaseContext.phasePath], and handler-emitted lifecycle events.
+ *
+ * ## Sub-dispatch
+ *
+ * Owns its own [subHandlers] map rather than a [PhaseDispatcher]. That is load
+ * bearing, not a style choice: [PhaseDispatcher] eagerly constructs every handler,
+ * itself included, so a `ConditionalHandler` holding a `PhaseDispatcher()` would
+ * recurse forever at construction — the map builds a `ConditionalHandler`, which
+ * builds a `PhaseDispatcher`, and so on. The Swift original's class comment claims
+ * it "owns a private `PhaseDispatcher`"; it does not, and this port corrects that
+ * claim on both sides rather than inheriting it.
+ *
+ * The map omits **five** of the 14 phase types, for two different reasons:
+ *
+ * - `conditional` — enforces the depth-1 rule structurally, and avoids the
+ *   construction cycle above.
+ * - `reflect`, `whisper`, `relationship_update`, `narrate` — not supported inside a
+ *   branch (`engine.md` § "Adding a new `PhaseType`" records all four as *reject*).
+ *
+ * `event_inject` **is** included, so curators can gate event injection on scenario
+ * state ("only inject in round 3+").
+ *
+ * ⚠️ **On this side the missing-key throw is the SOLE enforcement, not a backstop.**
+ * Swift's `ScenarioValidator.validateBranch` rejects a disallowed branch phase at
+ * load time and the Swift dictionary is merely the runtime backstop. Kotlin has no
+ * `ScenarioValidator` yet (Stage-3 freight, #501), so nothing upstream rejects
+ * anything: every branch-policy violation reaches dispatch and is caught here or
+ * not at all.
+ *
+ * ## Nested lifecycle events
+ *
+ * `phaseStarted` / `phaseCompleted` for each sub-phase are emitted **by this
+ * handler**, at paths of the form `[outerK, innerN]`, so a consumer can tell a
+ * nested phase from a top-level phase of the same `phaseType`. The conditional's
+ * own outer pair comes from the runner.
+ *
+ * Two orderings inside [runBranch] are load-bearing and easy to lose in a port:
+ *
+ * 1. The sub-handler is **resolved before** `phaseStarted` is emitted, so a
+ *    rejected phase type throws without leaving a started-without-completed event
+ *    in the stream.
+ * 2. The `catch` **emits `phaseCompleted` before rethrowing**, so a throwing
+ *    sub-handler still pairs.
+ *
+ * Note what (2) does *not* extend to: on a throw the runner emits `.error` and
+ * returns **without** the outer `phaseCompleted` (`SimulationEngine.kt`'s `RunLoop`,
+ * and `SimulationRunner.swift` identically). So the outer pair does not bracket the
+ * failure path — the Swift comment asserting it does is wrong, and is corrected in
+ * the same change as this port.
+ *
+ * ## Divergences from the Swift original, all deliberate
+ *
+ * - **No `Task.isCancelled` poll.** Swift checks it at the loop head and returns
+ *   early. Kotlin cancellation *throws*, and [PhaseContext.pauseCheck] — called at
+ *   the same loop position — raises it as part of its documented contract, so a
+ *   redundant `ensureActive()` here would assert that contract cannot be trusted.
+ * - **Cancellation has an observably different event tail.** Swift's two early
+ *   returns exit `execute` *normally*, so the runner goes on to emit
+ *   `phaseCompleted(.conditional)`; Kotlin unwinds the run instead. A Stage-4 parity
+ *   harness comparing transcripts will see this — it is a divergence, not an
+ *   implementation detail.
+ * - **The `catch` is `Throwable`, wider than a typical port.** [NarrateHandler]
+ *   narrowed *its* catch because that catch **absorbs** the error; this one rethrows
+ *   unconditionally, so nothing is swallowed at any breadth. Narrower here would let
+ *   `CancellationException` escape between the `phaseStarted` emit and the pairing,
+ *   producing a dangling `phaseStarted([k, n])` Swift never produces.
+ * - **State threads through the loop.** Kotlin handlers return state rather than
+ *   mutating `inout`, so each sub-phase's result feeds the next and [execute]
+ *   returns the accumulation — see [PhaseHandler].
+ *
+ * Swift original: `Pastura/Pastura/Engine/Phases/ConditionalHandler.swift`.
+ * Ported for the ADR-023 KMP Engine migration (#501, #1342).
+ */
+internal class ConditionalHandler : PhaseHandler {
+
+    private val evaluator = ConditionEvaluator()
+
+    /**
+     * Phase types a conditional branch may contain. See the class doc for why five
+     * are absent and why this is a private map rather than a [PhaseDispatcher].
+     */
+    private val subHandlers: Map<PhaseType, PhaseHandler> = mapOf(
+        PhaseType.SPEAK_ALL to SpeakAllHandler(),
+        PhaseType.SPEAK_EACH to SpeakEachHandler(),
+        PhaseType.VOTE to VoteHandler(),
+        PhaseType.CHOOSE to ChooseHandler(),
+        PhaseType.SCORE_CALC to ScoreCalcHandler(),
+        PhaseType.ASSIGN to AssignHandler(),
+        PhaseType.ELIMINATE to EliminateHandler(),
+        PhaseType.SUMMARIZE to SummarizeHandler(),
+        PhaseType.EVENT_INJECT to EventInjectHandler(),
+    )
+
+    override suspend fun execute(context: PhaseContext, state: SimulationState): SimulationState {
+        val expression = context.phase.condition ?: ""
+        // Throws `ScenarioValidationFailed` on a malformed or empty expression.
+        // Reachable here, unlike Swift, where `ScenarioValidator` shadows it at load.
+        val evaluation = evaluator.evaluate(expression, state, context.scenario)
+
+        // Warnings first, then the verdict: a consumer reading the stream sees why a
+        // runtime-absent operand forced `false` before it sees the `false`.
+        for (warning in evaluation.warnings) {
+            context.emitter(SimulationEvent.Summary(text = "⚠️ $warning"))
+        }
+
+        context.emitter(
+            SimulationEvent.ConditionalEvaluated(condition = expression, result = evaluation.value),
+        )
+
+        val branch =
+            if (evaluation.value) context.phase.thenPhases.orEmpty()
+            else context.phase.elsePhases.orEmpty()
+
+        return runBranch(branch, context, state)
+    }
+
+    /**
+     * Runs the selected branch's sub-phases, threading pause checks, lifecycle
+     * events and state through at `[outerK, innerN]` paths.
+     *
+     * An absent branch is an empty list here, so this is a silent no-op returning
+     * [state] unchanged — the `conditionalEvaluated` event is the only trace.
+     */
+    private suspend fun runBranch(
+        phases: List<Phase>,
+        context: PhaseContext,
+        state: SimulationState,
+    ): SimulationState {
+        var current = state
+
+        for ((innerIndex, subPhase) in phases.withIndex()) {
+            val innerPath = context.phasePath + innerIndex
+
+            // Honours a pause at sub-phase granularity, and raises
+            // CancellationException if the run was cancelled — this call is why no
+            // separate cancellation poll is needed (see the class doc).
+            context.pauseCheck(innerPath)
+
+            // Resolve BEFORE emitting `phaseStarted`, so a rejected phase type leaves
+            // no dangling started-without-completed event.
+            val handler = subHandlers[subPhase.type] ?: throw SimulationException(
+                SimulationError.ScenarioValidationFailed(
+                    message = "Phase type '${subPhase.type.serialName()}' is not allowed inside a " +
+                        "conditional branch (depth-1 rule).",
+                ),
+            )
+
+            context.emitter(
+                SimulationEvent.PhaseStarted(phaseType = subPhase.type, phasePath = innerPath),
+            )
+
+            // Scope each sub-phase's context to itself — the sub-handler sees the
+            // nested path as its own `phasePath`. Everything else is the PARENT's
+            // instance. `turnGate` most of all (ADR-021 D4): a fresh gate here would
+            // reset the run-scoped consecutive-skip counter inside branches. Note
+            // `detector` and `logger` are DEFAULTED on `PhaseContext`, so omitting
+            // either would compile clean and silently unwire them for nested phases.
+            val subContext = PhaseContext(
+                scenario = context.scenario,
+                phase = subPhase,
+                backend = context.backend,
+                suspensionRelay = context.suspensionRelay,
+                emitter = context.emitter,
+                pauseCheck = context.pauseCheck,
+                phasePath = innerPath,
+                turnGate = context.turnGate,
+                detector = context.detector,
+                logger = context.logger,
+            )
+
+            current = try {
+                handler.execute(subContext, current)
+            } catch (t: Throwable) {
+                // Pair the lifecycle even on a throw, then rethrow so the runner
+                // surfaces the error. Deliberately `Throwable` — see the class doc.
+                context.emitter(
+                    SimulationEvent.PhaseCompleted(phaseType = subPhase.type, phasePath = innerPath),
+                )
+                throw t
+            }
+
+            context.emitter(
+                SimulationEvent.PhaseCompleted(phaseType = subPhase.type, phasePath = innerPath),
+            )
+        }
+
+        return current
+    }
+}

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/ConditionalHandler.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/ConditionalHandler.kt
@@ -10,10 +10,11 @@ import com.pastura.models.SimulationState
  * Handles `conditional` phases — evaluates a DSL expression against the current
  * simulation state and dispatches to `thenPhases` or `elsePhases`.
  *
- * The only handler that nests. That makes it the first and only consumer of three
+ * The only handler that nests. That makes it the first and only consumer of two
  * [PhaseContext] mechanisms the runner has provided since the Stage-2 gate slice
- * with nothing calling them: [PhaseContext.pauseCheck], a `[outerK, innerN]`
- * [PhaseContext.phasePath], and handler-emitted lifecycle events.
+ * with nothing calling them — [PhaseContext.pauseCheck] and a `[outerK, innerN]`
+ * [PhaseContext.phasePath] — and the only handler that emits lifecycle events of
+ * its own (a convention over the shared `emitter`, not a third field).
  *
  * ## Sub-dispatch
  *

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ConditionalHandlerTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ConditionalHandlerTests.kt
@@ -1,0 +1,591 @@
+package com.pastura.engine
+
+import com.pastura.models.AnyCodableValue
+import com.pastura.models.Persona
+import com.pastura.models.Phase
+import com.pastura.models.PhaseType
+import com.pastura.models.Scenario
+import com.pastura.models.SimulationError
+import com.pastura.models.SimulationEvent
+import com.pastura.models.SimulationState
+import kotlinx.coroutines.test.runTest
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Kotlin sibling of Swift's `ConditionalIntegrationTests`, collapsed into one class
+ * per the commonTest convention.
+ *
+ * `conditional` is the only handler that nests, so it is the sole consumer of three
+ * [PhaseContext] mechanisms and the sole enforcement point of the branch policy on
+ * this side (Kotlin has no `ScenarioValidator`). The cases below pin, in ADR-023
+ * §12 terms, the mechanisms a green-but-wrong port would silently lose.
+ *
+ * ## §12 condition-4 perturbation record
+ *
+ * Each mechanism was broken in isolation and the named **dedicated claimant**
+ * confirmed to redden. Every mutation's anchor was asserted to match **exactly
+ * once** before applying — a `replace` that silently no-ops leaves the original
+ * behaviour and reads as verified. The unmutated baseline was re-confirmed at 0 red
+ * in the same run, so every count below is signal rather than pre-existing noise.
+ * Counts are measured, not derived — re-measure rather than reason if you change a
+ * fixture. Measured 2026-07-31, #1342.
+ *
+ * | Mechanism broken | Mutation | Dedicated claimant | Incidental |
+ * |---|---|---|---|
+ * | Verdict drives the branch | `if (evaluation.value)` → `if (true)` | [takesTheElseBranchWhenTheConditionFails] | 1 — [anAbsentBranchIsASilentNoOp] then runs a branch |
+ * | …other polarity | same → `if (false)` | [takesTheThenBranchWhenTheConditionHolds] | 12 — nearly every fixture puts its sub-phases in `then` |
+ * | Warning forwarding | warnings loop deleted | [forwardsEvaluatorWarningsAsWarningPrefixedSummaries] | 1 — [emitsWarningsBeforeTheVerdict] finds no warning |
+ * | The `⚠️ ` prefix | `"⚠️ $warning"` → `"$warning"` | [forwardsEvaluatorWarningsAsWarningPrefixedSummaries] | 1 — same |
+ * | Warnings precede the verdict | the two emits swapped | [emitsWarningsBeforeTheVerdict] | none |
+ * | Verdict emit | `ConditionalEvaluated` emit deleted | [emitsConditionalEvaluatedCarryingTheExpressionAndVerdict] | 2 — one counts events, one needs the index |
+ * | Absent branch is a no-op | `else …elsePhases.orEmpty()` falls back to `thenPhases` | [anAbsentBranchIsASilentNoOp] | none |
+ * | `phasePath` nesting | `context.phasePath + innerIndex` → `listOf(innerIndex)` | [nestsSubPhasePathsUnderTheOuterPath] | 5 — every other path assertion |
+ * | State into the next sub-phase | `execute(subContext, current)` → `…, state)` | [threadsStateThroughSuccessiveSubPhasesAndReturnsTheAccumulation] | none |
+ * | State out of `runBranch` | `return current` → `return state` | same | none |
+ * | Pairing on throw | the catch arm's emit deleted | [pairsPhaseCompletedWhenASubHandlerThrows] | 1 — [pairsPhaseCompletedForANonSimulationExceptionThrowToo], same arm |
+ * | Catch **breadth** | `Throwable` → `SimulationException` | [pairsPhaseCompletedForANonSimulationExceptionThrowToo] | none |
+ * | Parent `turnGate` threading | `context.turnGate` → `TurnFailureGate()` | [sharesTheParentTurnGateAcrossSubPhases] | 1 — [pairsPhaseCompletedWhenASubHandlerThrows] needs the breaker to throw |
+ * | Loop-head `pauseCheck` call | call deleted | [callsPauseCheckOncePerSubPhaseWithTheNestedPath], [cancellationFromPauseCheckStopsBeforeTheNextSubPhaseStarts] | none |
+ * | `detector` threading | field dropped from the sub-context | [threadsTheDetectorIntoSubPhaseContexts] | none |
+ * | `logger` threading | field dropped | [threadsTheLoggerIntoSubPhaseContexts] | none |
+ * | Allow-set completeness | `EVENT_INJECT` entry removed | [allowsExactlyTheNineBranchPermittedPhaseTypes] | 1 — [threadsStateThroughSuccessiveSubPhasesAndReturnsTheAccumulation] uses it |
+ * | …other polarity | `NARRATE` entry **added** | [allowsExactlyTheNineBranchPermittedPhaseTypes], [rejectsEveryPhaseTypeDisallowedInsideABranch] | 1 — [aRejectedSubPhaseEmitsNoPhaseStarted] keys on NARRATE |
+ * | Resolve-before-emit ordering | guard block moved after the `phaseStarted` emit | [aRejectedSubPhaseEmitsNoPhaseStarted] | none |
+ * | Malformed condition rejected | `evaluate` wrapped in `runCatching` → false | [aMalformedConditionThrowsRatherThanEvaluatingFalse] | 1 — [anAbsentConditionThrowsJustLikeAnEmptyOne] |
+ * | The `?: ""` null default | → `?: "1 == 1"` | [anAbsentConditionThrowsJustLikeAnEmptyOne] | none |
+ * | Sub-context `pauseCheck` threading | `context.pauseCheck` → `{ }` | *(none — expected green)* | none |
+ *
+ * Six things this table encodes that are easy to get wrong:
+ *
+ * 1. **The last row is the point, not a gap.** No registered sub-handler consumes
+ *    `pauseCheck`, so no mutation of that field can redden anything. It is declared
+ *    expected-green rather than listed as covered — and it was re-measured against
+ *    the final suite, not assumed from the earlier one.
+ * 2. **Both gates are measured in both polarities.** Removing an allow-set entry
+ *    only proves an allowed type can be dropped; **adding** a rejected one is what
+ *    proves the branch policy is still enforced. Same for the branch selector.
+ * 3. **The two pairing rows look redundant and are not.** Deleting the catch's emit
+ *    reddens both pairing tests; *narrowing* the catch reddens only the
+ *    non-`SimulationException` one, because a `SimulationException` still pairs
+ *    under the narrow catch. That single-test red is the entire evidence for the
+ *    catch-breadth decision.
+ * 4. **Resolve-before-emit needs its own row.** Moving the guard after the emit
+ *    leaves [rejectsEveryPhaseTypeDisallowedInsideABranch] green — the throw still
+ *    happens — so the rejection axis cannot stand in for the ordering axis.
+ * 5. **One row exists because a mutation came back green.** The first pass mutated
+ *    the `?: ""` default while the only condition test passed a non-null `""`, so
+ *    the elvis never fired and the mutation never reached a test. Read as a finding
+ *    about the fixtures rather than as a redundant guard, it surfaced that the
+ *    `null` path had no coverage at all; [anAbsentConditionThrowsJustLikeAnEmptyOne]
+ *    was added for it, and only then did the row redden.
+ * 6. **Rows 3 and 4 are not separable.** Both produce the same red set, so
+ *    [forwardsEvaluatorWarningsAsWarningPrefixedSummaries] proves "a ⚠️-prefixed
+ *    summary is emitted" and cannot tell a missing emit from a missing prefix. Both
+ *    are real breakages and both are caught, but that is one claim, not two.
+ *
+ * **Coverage of the table itself**: 22 mutations, 21 reddening; all 20 tests are a
+ * dedicated claimant for at least one row.
+ *
+ * **The counts this record leans on are machine-checked, not maintained in prose** —
+ * the "9 of 14" allow-set and the enum's case count are asserted in
+ * [allowsExactlyTheNineBranchPermittedPhaseTypes], and
+ * `TurnFailureGate.consecutiveSkipLimit`, which the parent-gate row's arithmetic
+ * depends on, is asserted in [sharesTheParentTurnGateAcrossSubPhases]. Change
+ * either and a test fails before this table can go stale.
+ *
+ * Ported for the ADR-023 KMP Engine migration (#501, #1342).
+ */
+class ConditionalHandlerTests {
+
+    private val handler = ConditionalHandler()
+
+    /**
+     * The conditional sits at index 2, so [PhaseContext.phasePath] is `[2]`.
+     *
+     * Non-trivial on purpose. With an outer `[0]` a port that rebuilt the nested
+     * path as `listOf(innerIndex)` instead of `context.phasePath + innerIndex`
+     * would emit exactly the same paths, and every path assertion below would pass
+     * against the broken port.
+     */
+    private val outerPath = listOf(2)
+
+    private fun scenario(
+        condition: String? = "1 == 1",
+        then: List<Phase>? = null,
+        otherwise: List<Phase>? = null,
+        agents: List<String> = listOf("Alice", "Bob"),
+        extraData: Map<String, AnyCodableValue> = emptyMap(),
+    ) = Scenario(
+        id = "t",
+        name = "T",
+        description = "d",
+        language = "en",
+        simulationLanguage = null,
+        agentCount = agents.size,
+        rounds = 2,
+        logWindow = null,
+        context = "A test.",
+        personas = agents.map { Persona(name = it, description = "$it's persona.") },
+        phases = listOf(
+            Phase(type = PhaseType.SUMMARIZE, template = "outer-0"),
+            Phase(type = PhaseType.SUMMARIZE, template = "outer-1"),
+            Phase(
+                type = PhaseType.CONDITIONAL,
+                condition = condition,
+                thenPhases = then,
+                elsePhases = otherwise,
+            ),
+        ),
+        extraData = extraData,
+    )
+
+    private fun context(
+        s: Scenario,
+        backend: LLMBackend = ScriptedLLMBackend(emptyList()),
+        events: MutableList<SimulationEvent> = mutableListOf(),
+        gate: TurnFailureGate = TurnFailureGate(),
+        pauseCheck: suspend (List<Int>) -> Unit = { },
+        detector: LanguageDetector? = null,
+        logger: EngineLogger = NoopEngineLogger(),
+    ) = PhaseContext(
+        scenario = s,
+        phase = s.phases[2],
+        backend = backend,
+        suspensionRelay = SuspensionRelay(),
+        emitter = { events += it },
+        pauseCheck = pauseCheck,
+        phasePath = outerPath,
+        turnGate = gate,
+        detector = detector,
+        logger = logger,
+    )
+
+    private fun summarize(text: String) = Phase(type = PhaseType.SUMMARIZE, template = text)
+
+    private fun speakAll() = Phase(
+        type = PhaseType.SPEAK_ALL,
+        prompt = "Speak.",
+        outputSchema = mapOf("statement" to "string"),
+    )
+
+    private fun eventInject(variable: String, source: String) = Phase(
+        type = PhaseType.EVENT_INJECT,
+        source = source,
+        eventVariable = variable,
+        probability = 1.0,
+    )
+
+    private fun failingCall() =
+        ScriptedLLMBackend.Script(terminal = TerminalStatus.Failed(errorCode = "boom"))
+
+    private fun speaks(statement: String) =
+        ScriptedLLMBackend.Script.completing("""{"statement": "$statement"}""")
+
+    private fun started(events: List<SimulationEvent>) =
+        events.filterIsInstance<SimulationEvent.PhaseStarted>()
+
+    private fun completed(events: List<SimulationEvent>) =
+        events.filterIsInstance<SimulationEvent.PhaseCompleted>()
+
+    private fun summaries(events: List<SimulationEvent>) =
+        events.filterIsInstance<SimulationEvent.Summary>()
+
+    private class SpyLanguageDetector(private val canned: String?) : LanguageDetector {
+        val recorded = mutableListOf<String>()
+        override fun detect(text: String): String? {
+            recorded.add(text)
+            return canned
+        }
+    }
+
+    private class SpyEngineLogger : EngineLogger {
+        val messages = mutableListOf<String>()
+        override fun log(
+            level: EngineLogLevel,
+            category: String,
+            message: String,
+            privacy: EngineLogPrivacy,
+        ) {
+            messages.add(message)
+        }
+    }
+
+    // MARK: - Condition evaluation and branch selection
+
+    @Test
+    fun takesTheThenBranchWhenTheConditionHolds() = runTest {
+        val s = scenario(
+            condition = "1 == 1",
+            then = listOf(summarize("THEN")),
+            otherwise = listOf(summarize("ELSE")),
+        )
+        val events = mutableListOf<SimulationEvent>()
+
+        handler.execute(context(s, events = events), SimulationState.initial(s))
+
+        assertEquals(listOf("THEN"), summaries(events).map { it.text })
+    }
+
+    @Test
+    fun takesTheElseBranchWhenTheConditionFails() = runTest {
+        val s = scenario(
+            condition = "1 == 2",
+            then = listOf(summarize("THEN")),
+            otherwise = listOf(summarize("ELSE")),
+        )
+        val events = mutableListOf<SimulationEvent>()
+
+        handler.execute(context(s, events = events), SimulationState.initial(s))
+
+        assertEquals(listOf("ELSE"), summaries(events).map { it.text })
+    }
+
+    @Test
+    fun emitsConditionalEvaluatedCarryingTheExpressionAndVerdict() = runTest {
+        val s = scenario(condition = "1 == 2", then = listOf(summarize("T")))
+        val events = mutableListOf<SimulationEvent>()
+
+        handler.execute(context(s, events = events), SimulationState.initial(s))
+
+        val evaluated = events.filterIsInstance<SimulationEvent.ConditionalEvaluated>().single()
+        assertEquals("1 == 2", evaluated.condition)
+        assertEquals(false, evaluated.result)
+    }
+
+    @Test
+    fun forwardsEvaluatorWarningsAsWarningPrefixedSummaries() = runTest {
+        // `vote_winner` is runtime-absent before any vote runs, so the evaluator
+        // returns false plus a warning. The ⚠️ prefix is asserted, not just the
+        // presence of a Summary: it is a plain interpolation rather than a
+        // `pickLanguage` literal, so the prompt-literal parity gate cannot see it.
+        val s = scenario(condition = "vote_winner == \"Alice\"", then = listOf(summarize("T")))
+        val events = mutableListOf<SimulationEvent>()
+
+        handler.execute(context(s, events = events), SimulationState.initial(s))
+
+        val texts = summaries(events).map { it.text }
+        assertTrue(texts.any { it.startsWith("⚠️ ") }, "expected a ⚠️-prefixed summary, got $texts")
+    }
+
+    @Test
+    fun emitsWarningsBeforeTheVerdict() = runTest {
+        // Ordering is the contract: a consumer reading the stream must see WHY a
+        // runtime-absent operand forced `false` before it sees the `false`.
+        val s = scenario(condition = "vote_winner == \"Alice\"", then = listOf(summarize("T")))
+        val events = mutableListOf<SimulationEvent>()
+
+        handler.execute(context(s, events = events), SimulationState.initial(s))
+
+        val warningIndex = events.indexOfFirst {
+            it is SimulationEvent.Summary && it.text.startsWith("⚠️ ")
+        }
+        val verdictIndex = events.indexOfFirst { it is SimulationEvent.ConditionalEvaluated }
+        assertTrue(warningIndex >= 0, "no warning emitted at all: $events")
+        assertTrue(warningIndex < verdictIndex, "warning must precede the verdict: $events")
+    }
+
+    @Test
+    fun aMalformedConditionThrowsRatherThanEvaluatingFalse() = runTest {
+        // Reachable on this side, unlike Swift, where `ScenarioValidator` rejects the
+        // expression at load and shadows this path entirely.
+        val s = scenario(condition = "", then = listOf(summarize("T")))
+
+        val error = assertFailsWith<SimulationException> {
+            handler.execute(context(s), SimulationState.initial(s))
+        }
+        assertIs<SimulationError.ScenarioValidationFailed>(error.error)
+    }
+
+    @Test
+    fun anAbsentConditionThrowsJustLikeAnEmptyOne() = runTest {
+        // `Phase.condition` is nullable, and `?: ""` is what routes null into the
+        // evaluator's rejection. The empty-string case above does NOT cover this:
+        // "" is non-null, so the elvis never fires there. Found by perturbation —
+        // mutating the default to a truthy expression left the whole suite green,
+        // which was a finding about the fixtures rather than a redundant guard.
+        val s = scenario(condition = null, then = listOf(summarize("T")))
+
+        val error = assertFailsWith<SimulationException> {
+            handler.execute(context(s), SimulationState.initial(s))
+        }
+        assertIs<SimulationError.ScenarioValidationFailed>(error.error)
+    }
+
+    // MARK: - Sub-phase dispatch, paths, and state
+
+    @Test
+    fun anAbsentBranchIsASilentNoOp() = runTest {
+        val s = scenario(condition = "1 == 2", then = listOf(summarize("T"))) // no else
+        val before = SimulationState.initial(s)
+        val events = mutableListOf<SimulationEvent>()
+
+        val after = handler.execute(context(s, events = events), before)
+
+        assertEquals(before, after, "an absent branch must not touch state")
+        assertTrue(started(events).isEmpty(), "no sub-phase started: $events")
+        assertTrue(completed(events).isEmpty(), "no sub-phase completed: $events")
+        assertEquals(1, events.size, "only the verdict should be emitted, got $events")
+    }
+
+    @Test
+    fun nestsSubPhasePathsUnderTheOuterPath() = runTest {
+        val s = scenario(then = listOf(summarize("a"), summarize("b")))
+        val events = mutableListOf<SimulationEvent>()
+
+        handler.execute(context(s, events = events), SimulationState.initial(s))
+
+        assertEquals(listOf(listOf(2, 0), listOf(2, 1)), started(events).map { it.phasePath })
+        assertEquals(listOf(listOf(2, 0), listOf(2, 1)), completed(events).map { it.phasePath })
+    }
+
+    @Test
+    fun threadsStateThroughSuccessiveSubPhasesAndReturnsTheAccumulation() = runTest {
+        // event_inject writes `variables["ev"]`; the summarize that follows expands
+        // `{ev}` from the SAME map. Unknown placeholders are left literal, so a port
+        // that handed each sub-phase the entry state would emit "saw {ev}".
+        val s = scenario(
+            then = listOf(eventInject("ev", "pool"), summarize("saw {ev}")),
+            extraData = mapOf("pool" to AnyCodableValue.ArrayValue(listOf("STORM"))),
+        )
+        val events = mutableListOf<SimulationEvent>()
+
+        val after = handler.execute(context(s, events = events), SimulationState.initial(s))
+
+        assertEquals("saw STORM", summaries(events).map { it.text }.last())
+        assertEquals("STORM", after.variables["ev"], "execute must return the accumulation")
+    }
+
+    // MARK: - Lifecycle pairing
+
+    @Test
+    fun pairsPhaseCompletedWhenASubHandlerThrows() = runTest {
+        val s = scenario(then = listOf(speakAll(), speakAll()))
+        val backend = ScriptedLLMBackend(List(6) { failingCall() })
+        val events = mutableListOf<SimulationEvent>()
+
+        assertFailsWith<SimulationException> {
+            handler.execute(context(s, backend, events), SimulationState.initial(s))
+        }
+
+        assertEquals(listOf(listOf(2, 0), listOf(2, 1)), started(events).map { it.phasePath })
+        assertEquals(
+            listOf(listOf(2, 0), listOf(2, 1)),
+            completed(events).map { it.phasePath },
+            "the throwing sub-phase must still be paired by the catch arm",
+        )
+    }
+
+    @Test
+    fun pairsPhaseCompletedForANonSimulationExceptionThrowToo() = runTest {
+        // Script exhaustion throws IllegalStateException. Used here NOT as failure
+        // injection — `kmp-interop.md` Pattern 4 rightly bans that — but as the
+        // cheapest arbitrary non-SimulationException Throwable, because the mechanism
+        // under test is the catch's BREADTH. Narrow the catch to SimulationException
+        // and this escapes between the phaseStarted emit and the pairing, leaving a
+        // dangling phaseStarted([2, 0]) that Swift never produces.
+        val s = scenario(then = listOf(speakAll()))
+        val events = mutableListOf<SimulationEvent>()
+
+        assertFailsWith<IllegalStateException> {
+            handler.execute(
+                context(s, ScriptedLLMBackend(emptyList()), events),
+                SimulationState.initial(s),
+            )
+        }
+
+        assertEquals(listOf(listOf(2, 0)), started(events).map { it.phasePath })
+        assertEquals(listOf(listOf(2, 0)), completed(events).map { it.phasePath })
+    }
+
+    @Test
+    fun aRejectedSubPhaseEmitsNoPhaseStarted() = runTest {
+        // The handler is resolved BEFORE phaseStarted is emitted. Move the resolve
+        // after the emit and this reddens with a dangling phaseStarted([2, 1]),
+        // while every rejection test below stays green — the throw still happens.
+        val s = scenario(then = listOf(summarize("ok"), Phase(type = PhaseType.NARRATE)))
+        val events = mutableListOf<SimulationEvent>()
+
+        assertFailsWith<SimulationException> {
+            handler.execute(context(s, events = events), SimulationState.initial(s))
+        }
+
+        assertEquals(listOf(listOf(2, 0)), started(events).map { it.phasePath })
+        assertEquals(listOf(listOf(2, 0)), completed(events).map { it.phasePath })
+    }
+
+    // MARK: - Context threading into sub-phases
+
+    @Test
+    fun sharesTheParentTurnGateAcrossSubPhases() = runTest {
+        // consecutiveSkipLimit is 3. Two skips land in sub-phase 0 (Alice, Bob) and
+        // the third in sub-phase 1, which trips the breaker.
+        //
+        // Split across TWO sub-phases deliberately: all three inside one sub-phase
+        // would trip even with a fresh per-sub-context gate, so the test would pass
+        // by construction against exactly the bug it exists to catch.
+        val s = scenario(then = listOf(speakAll(), speakAll()))
+        val backend = ScriptedLLMBackend(List(6) { failingCall() })
+        val events = mutableListOf<SimulationEvent>()
+
+        val error = assertFailsWith<SimulationException> {
+            handler.execute(context(s, backend, events), SimulationState.initial(s))
+        }
+
+        assertEquals(3, TurnFailureGate.consecutiveSkipLimit, "the arithmetic above assumes 3")
+        assertIs<SimulationError.TurnFailureLimitReached>(error.error)
+        assertEquals(
+            2,
+            events.filterIsInstance<SimulationEvent.TurnSkipped>().size,
+            "the tripping failure emits no TurnSkipped",
+        )
+    }
+
+    @Test
+    fun callsPauseCheckOncePerSubPhaseWithTheNestedPath() = runTest {
+        val seen = mutableListOf<List<Int>>()
+        val s = scenario(then = listOf(summarize("a"), summarize("b")))
+
+        handler.execute(context(s, pauseCheck = { seen += it }), SimulationState.initial(s))
+
+        assertEquals(listOf(listOf(2, 0), listOf(2, 1)), seen)
+    }
+
+    @Test
+    fun cancellationFromPauseCheckStopsBeforeTheNextSubPhaseStarts() = runTest {
+        // This is the whole cancellation story on this side. The handler carries no
+        // ensureActive() of its own: pauseCheck raising CancellationException IS the
+        // documented contract, and this test is what holds the handler to using it.
+        var calls = 0
+        val s = scenario(then = listOf(summarize("a"), summarize("b")))
+        val events = mutableListOf<SimulationEvent>()
+
+        assertFailsWith<CancellationException> {
+            handler.execute(
+                context(
+                    s,
+                    events = events,
+                    pauseCheck = {
+                        calls += 1
+                        if (calls == 2) throw CancellationException("cancelled while paused")
+                    },
+                ),
+                SimulationState.initial(s),
+            )
+        }
+
+        assertEquals(listOf(listOf(2, 0)), started(events).map { it.phasePath })
+        assertEquals(listOf(listOf(2, 0)), completed(events).map { it.phasePath })
+    }
+
+    @Test
+    fun threadsTheDetectorIntoSubPhaseContexts() = runTest {
+        // `detector` is DEFAULTED on PhaseContext, so dropping it from the sub-context
+        // compiles clean and leaves every other test green. The adherence check needs
+        // the joined output to clear LLMCaller.MIN_DETECTION_LENGTH, hence the long
+        // statement.
+        val spy = SpyLanguageDetector(canned = "en")
+        val s = scenario(then = listOf(speakAll()), agents = listOf("Alice"))
+        val backend = ScriptedLLMBackend(
+            List(LLMCaller.MAX_RETRIES + 1) { speaks("A sufficiently long English sentence.") },
+        )
+
+        handler.execute(context(s, backend, detector = spy), SimulationState.initial(s))
+
+        assertTrue(
+            spy.recorded.isNotEmpty(),
+            "the adherence check never ran — detector was not threaded into the sub-context",
+        )
+    }
+
+    @Test
+    fun threadsTheLoggerIntoSubPhaseContexts() = runTest {
+        // Same defaulted-field hazard as the detector. A parse failure on the first
+        // attempt guarantees LLMCaller logs, then the retry succeeds.
+        val spy = SpyEngineLogger()
+        val s = scenario(then = listOf(speakAll()), agents = listOf("Alice"))
+        val backend = ScriptedLLMBackend(
+            listOf(
+                ScriptedLLMBackend.Script.completing("not json at all"),
+                speaks("Recovered on retry."),
+            ),
+        )
+
+        handler.execute(context(s, backend, logger = spy), SimulationState.initial(s))
+
+        assertTrue(
+            spy.messages.any { it.contains("JSON parse failed") },
+            "logger was not threaded into the sub-context; recorded: ${spy.messages}",
+        )
+    }
+
+    // MARK: - Depth-1 and the branch policy
+
+    @Test
+    fun rejectsEveryPhaseTypeDisallowedInsideABranch() = runTest {
+        val disallowed = listOf(
+            PhaseType.CONDITIONAL,
+            PhaseType.REFLECT,
+            PhaseType.WHISPER,
+            PhaseType.RELATIONSHIP_UPDATE,
+            PhaseType.NARRATE,
+        )
+        for (type in disallowed) {
+            val s = scenario(then = listOf(Phase(type = type)))
+            val error = assertFailsWith<SimulationException>("$type must be rejected") {
+                handler.execute(context(s), SimulationState.initial(s))
+            }
+            val message = assertIs<SimulationError.ScenarioValidationFailed>(error.error).message
+            assertTrue(message.contains("depth-1"), "expected the depth-1 message, got: $message")
+        }
+    }
+
+    @Test
+    fun allowsExactlyTheNineBranchPermittedPhaseTypes() = runTest {
+        // Derived by probing every PhaseType, not hand-listed: a hand list cannot
+        // disagree with itself, so dropping an entry from `subHandlers` would just
+        // move that type into the expected-rejected set and stay green.
+        //
+        // Classification is on the depth-1 message alone — an allowed handler may
+        // still throw for its own reasons under this bare fixture, and that is not a
+        // rejection.
+        val allowed = mutableSetOf<PhaseType>()
+        for (type in PhaseType.entries) {
+            val s = scenario(
+                then = listOf(Phase(type = type)),
+                agents = listOf("Alice"),
+                extraData = mapOf("pool" to AnyCodableValue.ArrayValue(listOf("E"))),
+            )
+            val thrown = runCatching {
+                handler.execute(
+                    context(s, ScriptedLLMBackend(List(8) { speaks("Something said here.") })),
+                    SimulationState.initial(s),
+                )
+            }.exceptionOrNull()
+            val rejected = thrown is SimulationException &&
+                (thrown.error as? SimulationError.ScenarioValidationFailed)
+                    ?.message?.contains("depth-1") == true
+            if (!rejected) allowed += type
+        }
+
+        assertEquals(14, PhaseType.entries.size, "the 9-of-14 claim is executable, not prose")
+        assertEquals(
+            setOf(
+                PhaseType.SPEAK_ALL,
+                PhaseType.SPEAK_EACH,
+                PhaseType.VOTE,
+                PhaseType.CHOOSE,
+                PhaseType.SCORE_CALC,
+                PhaseType.ASSIGN,
+                PhaseType.ELIMINATE,
+                PhaseType.SUMMARIZE,
+                PhaseType.EVENT_INJECT,
+            ),
+            allowed,
+        )
+    }
+}

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/ConditionalHandlerTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/ConditionalHandlerTests.kt
@@ -391,13 +391,21 @@ class ConditionalHandlerTests {
         val s = scenario(then = listOf(speakAll()))
         val events = mutableListOf<SimulationEvent>()
 
-        assertFailsWith<IllegalStateException> {
+        val thrown = assertFailsWith<IllegalStateException> {
             handler.execute(
                 context(s, ScriptedLLMBackend(emptyList()), events),
                 SimulationState.initial(s),
             )
         }
 
+        // The type alone is too loose to carry the claim: on JVM
+        // `kotlinx.coroutines.CancellationException` IS an `IllegalStateException`
+        // subclass, so this would also pass on a cancellation that never reached the
+        // catch at all. Read WHICH throwable fired, per kmp-interop.md Pattern 4.
+        assertTrue(
+            thrown.message?.contains("ScriptedLLMBackend exhausted") == true,
+            "expected script exhaustion, got: ${thrown.message}",
+        )
         assertEquals(listOf(listOf(2, 0)), started(events).map { it.phasePath })
         assertEquals(listOf(listOf(2, 0)), completed(events).map { it.phasePath })
     }
@@ -485,9 +493,11 @@ class ConditionalHandlerTests {
     @Test
     fun threadsTheDetectorIntoSubPhaseContexts() = runTest {
         // `detector` is DEFAULTED on PhaseContext, so dropping it from the sub-context
-        // compiles clean and leaves every other test green. The adherence check needs
-        // the joined output to clear LLMCaller.MIN_DETECTION_LENGTH, hence the long
-        // statement.
+        // compiles clean and leaves every other test green. The adherence check runs
+        // only once the joined output clears LLMCaller's minimum detection length —
+        // 12 scalars, quoted here as prose because that constant is `private` and
+        // cannot be referenced (unlike MAX_RETRIES below, which is). Hence the
+        // deliberately long statement.
         val spy = SpyLanguageDetector(canned = "en")
         val s = scenario(then = listOf(speakAll()), agents = listOf("Alice"))
         val backend = ScriptedLLMBackend(
@@ -508,10 +518,15 @@ class ConditionalHandlerTests {
         // attempt guarantees LLMCaller logs, then the retry succeeds.
         val spy = SpyEngineLogger()
         val s = scenario(then = listOf(speakAll()), agents = listOf("Alice"))
+        // Over-scripted by one. The flow consumes exactly two calls today, but an
+        // exactly-fitting script list makes any future extra call redden on the
+        // harness's exhaustion error BEFORE `spy.messages` is asserted, which would
+        // misattribute the failure to the logger seam.
         val backend = ScriptedLLMBackend(
             listOf(
                 ScriptedLLMBackend.Script.completing("not json at all"),
                 speaks("Recovered on retry."),
+                speaks("Spare, so the assertion below stays the detector."),
             ),
         )
 
@@ -560,6 +575,11 @@ class ConditionalHandlerTests {
                 agents = listOf("Alice"),
                 extraData = mapOf("pool" to AnyCodableValue.ArrayValue(listOf("E"))),
             )
+            // Scripts are supplied generously rather than exactly: the allowed
+            // handlers have different call counts and some throw for their own
+            // reasons under this bare fixture. That is fine — an exhaustion
+            // IllegalStateException is not a SimulationException, so it classifies
+            // as "allowed", which is the correct verdict for a registered handler.
             val thrown = runCatching {
                 handler.execute(
                     context(s, ScriptedLLMBackend(List(8) { speaks("Something said here.") })),

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/PhaseDispatcherTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/PhaseDispatcherTests.kt
@@ -10,8 +10,12 @@ import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 /**
- * Kotlin sibling of Swift's `PhaseDispatcherTests`, scoped to the handlers this
- * port has registered so far.
+ * Kotlin sibling of Swift's `PhaseDispatcherTests`.
+ *
+ * All 14 phase types are registered as of Wave B's completion (#1342), so the tests
+ * that used `CONDITIONAL` as the "not ported yet" exemplar are gone. The two that
+ * exercise the *error* contract now drive an empty-map dispatcher through the
+ * production seam instead — see [anUnregisteredPhaseTypeFailsCleanlyRatherThanCrashing].
  *
  * Ported for the ADR-023 §6 Stage-2 gate slice (#501).
  */
@@ -85,51 +89,61 @@ class PhaseDispatcherTests {
     }
 
     @Test
+    fun resolvesTheConditionalHandler() {
+        assertIs<ConditionalHandler>(dispatcher.handler(PhaseType.CONDITIONAL))
+    }
+
+    @Test
     fun returnsAStableHandlerInstance() {
         // Handlers are stateless values; the dispatcher builds its map once.
         assertTrue(dispatcher.handler(PhaseType.SPEAK_ALL) === dispatcher.handler(PhaseType.SPEAK_ALL))
     }
 
     @Test
-    fun throwsForAPhaseTypeThisSliceHasNotPorted() {
-        val error = assertFailsWith<SimulationException> { dispatcher.handler(PhaseType.CONDITIONAL) }
-        assertIs<SimulationError.ScenarioValidationFailed>(error.error)
+    fun everyPhaseTypeResolvesToAHandler() {
+        // Wave B completed at 14/14 (#1342), so this flipped from "exactly 1
+        // unported" to "none". It keeps its value in the new polarity: the set is
+        // still DERIVED from the dispatcher rather than hand-listed, so it fires on
+        // BOTH enum growth (a new PhaseType with no handler) and an accidental
+        // de-registration. A hand list cannot disagree with itself and would silently
+        // stop guarding registration.
+        //
+        // Asserted against a DEFAULT-constructed dispatcher on purpose: the seam
+        // exercised below could otherwise satisfy this with an injected map, which
+        // would measure the fixture instead of the production registration.
+        val unported = PhaseType.entries.filter {
+            runCatching { dispatcher.handler(it) }.isFailure
+        }
+        assertEquals(14, PhaseType.entries.size, "the drift ledger's case count is now executable")
+        assertEquals(0, unported.size, "unregistered after Wave B completed: $unported")
+    }
+
+    @Test
+    fun anUnregisteredPhaseTypeFailsCleanlyRatherThanCrashing() {
+        // The throw survives 14/14 registration because it defends the recurring
+        // window where a PhaseType lands in shared/models before its handler is
+        // ported. No real PhaseType reaches it today, so the seam supplies the
+        // negative control — without one this guard would be asserted only by its
+        // own success case, which proves nothing.
+        val empty = PhaseDispatcher(handlers = emptyMap())
+        for (type in PhaseType.entries) {
+            val error = assertFailsWith<SimulationException>("$type must fail cleanly") {
+                empty.handler(type)
+            }
+            assertIs<SimulationError.ScenarioValidationFailed>(error.error)
+        }
     }
 
     @Test
     fun theErrorNamesThePhaseUsingItsWireNameNotItsKotlinCaseName() {
         // `conditional`, not `CONDITIONAL` — Swift interpolates `phaseType.rawValue`,
         // and a reader comparing the two engines' errors should see the same token.
-        // The exemplar is CONDITIONAL because it is the SOLE remaining unported
-        // handler (Wave B is 13/14), so no further repoint is possible: the next port
-        // to land is Conditional itself, and that PR retires this exemplar rather than
-        // moving it.
-        val error = assertFailsWith<SimulationException> { dispatcher.handler(PhaseType.CONDITIONAL) }
+        val error = assertFailsWith<SimulationException> {
+            PhaseDispatcher(handlers = emptyMap()).handler(PhaseType.CONDITIONAL)
+        }
         val message = assertIs<SimulationError.ScenarioValidationFailed>(error.error).message
         assertTrue(message.contains("conditional"), "expected the wire name, got: $message")
         assertTrue(!message.contains("CONDITIONAL"), "the Kotlin case name must not leak: $message")
-    }
-
-    @Test
-    fun everyUnportedPhaseTypeFailsCleanlyRatherThanCrashing() {
-        // A Stage-3 gap must read as a gap. Iterating allCases also means a NEW
-        // PhaseType added to Models cannot silently reach dispatch unhandled.
-        // DERIVED from the dispatcher, not a hand-written exclusion list. A hand
-        // list cannot disagree with itself, so it silently stops guarding
-        // registration: de-registering a ported handler just moves that case into
-        // the excluded set, leaving this test green. Deriving makes the count below
-        // fire on BOTH enum growth and an accidental de-registration.
-        val unported = PhaseType.entries.filter {
-            runCatching { dispatcher.handler(it) }.isFailure
-        }
-        assertEquals(14, PhaseType.entries.size, "the drift ledger's case count is now executable")
-        assertEquals(1, unported.size, "see the #501 drift ledger")
-        for (type in unported) {
-            val error = assertFailsWith<SimulationException>("$type must fail cleanly") {
-                dispatcher.handler(type)
-            }
-            assertIs<SimulationError.ScenarioValidationFailed>(error.error)
-        }
     }
 
     @Test
@@ -138,9 +152,14 @@ class PhaseDispatcherTests {
         // earlier version asserted the lowercase derivation — i.e. exactly the
         // coincidence the implementation deliberately rejects — so it passed
         // identically against a `name.lowercase()` impl and pinned nothing.
+        //
+        // It also used to `continue` past every registered type, so at 14/14 it would
+        // have checked NOTHING while still reporting green. Driving the empty-map
+        // dispatcher turns that vacuum into full coverage: all 14 cases now throw, so
+        // all 14 wire names are actually asserted.
+        val empty = PhaseDispatcher(handlers = emptyMap())
         for (type in PhaseType.entries) {
-            val error = runCatching { dispatcher.handler(type) }.exceptionOrNull()
-            if (error !is SimulationException) continue // SPEAK_ALL resolves
+            val error = assertFailsWith<SimulationException> { empty.handler(type) }
             val message = assertIs<SimulationError.ScenarioValidationFailed>(error.error).message
             val fromDescriptor = PhaseType.serializer().descriptor.getElementName(type.ordinal)
             assertTrue(

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/SimulationEngineTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/SimulationEngineTests.kt
@@ -246,20 +246,14 @@ class SimulationEngineTests {
         assertFalse(c.snapshot().any { it is SimulationEvent.SimulationCompleted })
     }
 
-    @Test
-    fun anUnportedPhaseTypeSurfacesAsAValidationError() = runBlockingTest {
-        // A Stage-3 gap must read as a gap at runtime, not as a crash. Uses
-        // CONDITIONAL — last in the remaining Wave-B port order, so this exemplar
-        // outlives the ones ported next (CHOOSE now resolves).
-        val s = scenario().copy(phases = listOf(Phase(type = PhaseType.CONDITIONAL, condition = "1 == 1")))
-        val c = Collector()
-        SimulationEngine().run(s, ScriptedLLMBackend(emptyList())) { c.record(it) }
-        awaitTerminal(c)
-
-        val error = assertIs<SimulationEvent.ErrorEvent>(c.snapshot().last())
-        val failed = assertIs<SimulationError.ScenarioValidationFailed>(error.error)
-        assertTrue(failed.message.contains("conditional"))
-    }
+    // `anUnportedPhaseTypeSurfacesAsAValidationError` lived here, using CONDITIONAL
+    // as the last-to-be-ported exemplar. Wave B completed at 14/14 (#1342), so no
+    // PhaseType is unported and the case had no subject left. Not repointed: the
+    // dispatcher's throw is unreachable through the public API, and it is covered at
+    // the unit level via the seam (`PhaseDispatcherTests`). Its engine-level claim —
+    // that a phase error ends the run with an ErrorEvent rather than a crash — is
+    // already carried by `aPhaseErrorEndsTheRunWithAnErrorEvent` above, since the
+    // dispatch call sits inside the same `try` as handler execution.
 
     // MARK: - §5.1 pause / resume
 


### PR DESCRIPTION
## Summary

Ports `ConditionalHandler` to `shared/engine` commonMain — the **14th and final** handler of ADR-023 Stage 3 Wave B. The board goes to 14/14.

It is the only handler that nests, so it is the first consumer of two `PhaseContext` mechanisms the runner has provided since the Stage-2 gate slice with nothing calling them (`pauseCheck`, a `[outerK, innerN]` `phasePath`) and the only handler that emits lifecycle events of its own. That is why it was last in the port order: its nine sub-handlers all had to land first.

### Port decisions that are not mechanical

- **No cancellation poll.** Swift returns early on `Task.isCancelled`; Kotlin cancellation *throws*, and `pauseCheck` raises it at the same loop position as part of its documented contract. An explicit `ensureActive()` could only be given a failing test by a fixture that *violates* that contract — a state production cannot reach.
- **The catch around a sub-handler is `Throwable`.** It rethrows unconditionally, so nothing is swallowed at any breadth. Narrower would let `CancellationException` escape between the `phaseStarted` emit and the pairing, producing a dangling `phaseStarted([k, n])` Swift never produces. (`NarrateHandler` narrowed *its* catch because that catch **absorbs** — the reasoning does not transfer.)
- **Its own `subHandlers` map, never a `PhaseDispatcher`.** The dispatcher eagerly builds every handler including this one, so holding one would recurse forever at construction.
- **On this side the missing-key throw is the *sole* enforcement of the branch policy**, not a runtime backstop — Kotlin has no `ScenarioValidator` yet.

### Dispatcher: the throw survives 14/14

`handlers[phaseType] ?: throw` is unreachable for today's `PhaseType` values but defends the recurring window where a case lands in `shared/models` before its handler is ported. Kept, with a default-valued `internal` `handlers` parameter as a test seam so it retains a real negative control. Without it `wireNamesResolveFromTheSerialDescriptorForEveryCase` would have gone **vacuously green** — it `continue`d past every registered type, so at 14/14 it would have asserted nothing while still reporting green. Driven through the seam it now covers all 14 wire names instead of 1.

Five tests used `CONDITIONAL` as the "not ported yet" exemplar; with no unported type left they are retired or repurposed rather than repointed.

### ADR-023 §12 condition-4 perturbation record

22 mutations, each with its anchor asserted to match **exactly once** before applying (a `replace` that silently no-ops leaves the original behaviour and reads as verified), run against a baseline re-confirmed at 0 red in the same pass. 21 reddened their named dedicated claimant; the 22nd is a declared **expected-green** row — nothing consumes the sub-context's `pauseCheck`, so no mutation of it can redden anything. Full table in the test class KDoc.

Two findings came out of the measurement rather than out of review:

- **`Phase.condition`'s null path had no coverage.** The first mutation of the `?: ""` default came back green — not because the guard was redundant, but because the only condition test passed a non-null `""`, so the elvis never fired and the mutation never reached a test. Read as a finding about the fixtures, it surfaced a genuine gap; a test was added and the row then reddened.
- **Resolve-before-emit needs its own claimant.** Moving the guard after the `phaseStarted` emit leaves the rejection test green — the throw still happens — so the rejection axis cannot stand in for the ordering axis.

Counts the record leans on are machine-checked rather than kept in prose: the 9-of-14 allow-set and the enum case count are asserted in `allowsExactlyTheNineBranchPermittedPhaseTypes`, and `consecutiveSkipLimit`, which the parent-gate row's arithmetic depends on, in `sharesTheParentTurnGateAcrossSubPhases`.

### Also in this PR

- **Three factual corrections to the Swift original's doc comment**, all found while porting and verified against `SimulationRunner.swift`. The load-bearing one: it claimed to own a private `PhaseDispatcher`. Stale prose in Swift, but a landmine for the port — a Kotlin handler holding one recurses at construction once `CONDITIONAL` joins the map.
- **A new `PhaseType` must now be dispositioned in two Kotlin maps**, since this port added the second, and neither is compiler-caught. Recorded in `kmp-interop.md` Pattern 4 — the file a `shared/**`-only session actually loads — with a reciprocal pointer from `engine.md`.
- **The stage table's Stage 3 row deliberately stays 🔄.** Wave B completing is not Stage 3 completing: the loader/validator port and the `detector`/`logger` wiring are unstarted, and `JSONResponseParser` / `LLMCaller` name further Stage-3 freight of their own.

## Test plan

Gate, with counts read from the JUnit XML rather than the `BUILD SUCCESSFUL` line (which can be UP-TO-DATE), `--rerun-tasks` to confirm execution:

```
./gradlew :shared:models:jvmTest :shared:engine:jvmTest \
  :shared:engine:compileCommonMainKotlinMetadata \
  :shared:models:compileKotlinIosSimulatorArm64 :shared:engine:compileKotlinIosSimulatorArm64
```

- `shared:engine` **563 tests, 0 failures** (`ConditionalHandlerTests` 20 of them)
- `shared:models` **211 tests, 0 failures**
- `compileCommonMainKotlinMetadata` + both iosSimulatorArm64 compiles green
- pre-commit: kmp-status gate reconciles 14 handlers ↔ board in both directions; prompt-literal parity clean at 43/43 pairs, no new allowlist row, `MAX_UNPORTED_ROWS` stays 0

Reviewed by two Opus `code-reviewer` passes split production / tests — both PASS, no Critical. Their findings are fixed in `cd37f60`, including two claims **this PR had authored** that were wrong (the `pauseCheck` doc over-claiming uncancellability, and an ADR-023 §6 citation that did not support its content).

The kmp-gate-spike is not built — no K/N boundary type changes.

## Device QA

実機QA不要 — Kotlin `shared/**` と doc/rules のみ。iOS アプリはまだ XCFramework を consume していない（Phase 3.0 ゲート）ので、実行時挙動に到達する変更がない。唯一の `Pastura/` 変更は doc comment の修正で、コードは1行も動いていない。

Closes #1342
Part of #501
