### PR TITLE
✨ feat: ui-tour --dark, and all three capture scripts restore appearance (#1338)

### DIFF
--- a/.claude/skills/ui-refine/SKILL.md
+++ b/.claude/skills/ui-refine/SKILL.md
@@ -106,12 +106,18 @@ Run the tour to refresh the screenshots:
 scripts/ui-tour.sh
 ```
 
-This runs `ScreenshotTourTests` on the UDID-pinned simulator and writes the 8
+This runs `ScreenshotTourTests` on the UDID-pinned simulator and writes the 14
 fixture-driven PNGs to `docs/design/screenshots/` (takes several minutes incl.
 the build; subject to the concurrent-session simulator gate per
 `.claude/rules/xcodebuild-cli.md`). After it succeeds, confirm the expected PNGs
 are present and freshly written (`docs/design/screenshots/*.png`). The covered
 screens are listed in `docs/design/screenshots/README.md`.
+
+**Light appearance only, deliberately.** `scripts/ui-tour.sh --dark` also
+produces a dark set under `docs/design/screenshots/dark/`, which this glob is
+single-level and so does not reach. Reviewing it needs decisions about the lens
+rotation and the proposal ledger — see #1345. Until that lands, a cycle
+critiques the light appearance and should not claim otherwise in its digest.
 
 ### L4 (Motion & feedback) — motion filmstrips
 
@@ -162,7 +168,7 @@ those are the principles a proposal under this lens must cite.
 
 ## Step 3 — Generate quota-capped proposals
 
-Read the relevant capture artifacts with vision — the static screenshots (all 8,
+Read the relevant capture artifacts with vision — the static screenshots (all 14,
 or the `screen:` arg subset) for default lenses, or the motion filmstrip frames
 under `docs/design/motion/<variant>/` for **L4** — read the lens's anchor
 sections in `docs/design/design-system.md`, then generate candidates **strictly

--- a/.gitignore
+++ b/.gitignore
@@ -108,7 +108,10 @@ data/worktree-prune.log
 
 # Design-review screenshots — generated on demand by scripts/ui-tour.sh
 # (see docs/design/screenshots/README.md). Only the README is tracked.
+# The first pattern is single-level, so the `--dark` set needs its own line —
+# without it those PNGs surface as untracked and can be committed by accident.
 docs/design/screenshots/*.png
+docs/design/screenshots/dark/
 
 # App Store submission screenshots — captured locally per docs/store/screenshot-plan.md.
 # Never committed (large binaries; regenerated per submission).

--- a/docs/design/screenshots/README.md
+++ b/docs/design/screenshots/README.md
@@ -58,6 +58,51 @@ Add a tour stop in
 `capture(app, name: "NN-name", anchorId: ...)` on an element that only
 exists once the screen has loaded), then add a row to the table above.
 
+## Dark set
+
+```bash
+scripts/ui-tour.sh --dark     # → docs/design/screenshots/dark/
+```
+
+Same tour, same filenames, second directory — the light set's names are
+referenced by name from this README, `../navigation-map.md` and the
+`ui-refine` skill, so they stay put. Opt-in rather than automatic: each
+appearance is a full `xcodebuild test` pass. The simulator's prior
+appearance is restored on exit, so a `--dark` run does not leave the
+device dark for `scripts/motion-capture.sh`, which is deliberately
+device-following.
+
+**What the dark set is for, and what it is not.** It is for reviewing
+typography, spacing and overall mood in the dark palette. It is **not**
+dark-mode QA coverage. Against the five classes in
+`../../qa/dark-mode-qa.md` § "What is actually at risk":
+
+| Class | On this tour? |
+|---|---|
+| A. Fixed tokens (`GameHeader` meta row) | No — Simulation and Demo replay are both off-tour |
+| B. Materials | **2 of §3's 11 sites**: the ScenarioDetail action bar (stop `02`) and the Editor capsule (stop `03`). A material re-rendering wrong in dark is a static property, so these two captures do show it |
+| C. Fixed-appearance exports (share card) | No — never rendered by the tour |
+| D. Non-SwiftUI | No. §1's launch/splash precede the tour; §5's `UINavigationBar` proxy *is* on screen at stops `02`/`03`/`05`/`08`, but it bakes at launch under the pinned appearance, and its failure mode needs background → switch → return, which no fresh-launch capture reaches |
+| E. Occlusion layers (scrim) | No — the model-load scrim is Simulation-only |
+
+So class B is partially covered and the other four are not. Everything
+else the dark set shows is the ordinary paired-token surfaces, which gate 1
+closed by measurement and `DesignTokensTests` asserts for all 67 pairs.
+Treat a finding here as a design observation, not as a defect the device
+walkthrough would have caught.
+
+**The two sets drift independently.** Each is refreshed only by its own
+invocation, both are gitignored so no diff reveals staleness, and they
+share filenames — `01-home.png` exists in both. Re-run both before any
+side-by-side comparison, or you may be attributing a months-old delta to
+the appearance.
+
+**`ui-refine` does not read the dark set** — the skill runs the bare
+(light) tour and reviews `docs/design/screenshots/*.png`, a single-level
+glob. Making that cycle dark-aware needs decisions about the lens
+rotation and the proposal ledger, so it is tracked separately in
+[#1345](https://github.com/tyabu12/pastura/issues/1345).
+
 ## Deferred (not yet captured)
 
 - **ModelSelection / ModelDownload** — `--ui-test` mode bypasses the
@@ -67,11 +112,6 @@ exists once the screen has loaded), then add a row to the table above.
   response queue under `--ui-test`, so a running simulation errors on
   first inference; capturing a live turn needs canned-response seeding
   via a launch argument.
-- **Dark mode variant** — `scripts/ui-tour.sh` (this tour) deliberately
-  pins the simulator to light appearance so captures stay deterministic,
-  as do the store and marketing shot scripts; a dark set is deferred by
-  choice, not blocked (dark itself renders now — the ADR-028 lock is
-  gone).
 - **Dynamic Type / ja locale variants** — single configuration only
   for now; variants multiply runtime and can be added per-screen when
   a review needs them.

--- a/scripts/marketing-shots.sh
+++ b/scripts/marketing-shots.sh
@@ -62,6 +62,31 @@ set -euo pipefail
 SIM_UDID="${DEST##*,id=}"
 SIM_UDID="${SIM_UDID%%,*}"
 xcrun simctl bootstatus "$SIM_UDID" -b > /dev/null 2>&1 || true
+
+# Restore the operator's appearance on exit. Without this the light pin below
+# persists — appearance is device-global — and scripts/motion-capture.sh, which
+# is deliberately device-following, would then record light filmstrips for an
+# operator who had deliberately set dark. `simctl ui <dev> appearance` with no
+# value prints the current style but can also print `unsupported` / `unknown`;
+# anything else is left empty and the restore skipped, because defaulting to a
+# value would flip a device rather than leave it as found. Same shape and same
+# single-trap constraint as scripts/ui-tour.sh — see its cleanup() for why the
+# two handlers must be one (bash replaces a trap, it does not chain).
+PRIOR_APPEARANCE="$(xcrun simctl ui "$SIM_UDID" appearance 2> /dev/null || true)"
+case "$PRIOR_APPEARANCE" in
+  light | dark) ;;
+  *) PRIOR_APPEARANCE="" ;;
+esac
+
+cleanup() {
+  if [ -n "$PRIOR_APPEARANCE" ]; then
+    xcrun simctl ui "$SIM_UDID" appearance "$PRIOR_APPEARANCE" > /dev/null 2>&1 || true
+  fi
+  [ -n "${EXPORT_DIR:-}" ] && rm -rf "$EXPORT_DIR"
+  return 0
+}
+trap cleanup EXIT INT TERM
+
 xcrun simctl ui "$SIM_UDID" appearance light > /dev/null
 
 # xcodebuild refuses to write into a pre-existing result bundle.
@@ -72,7 +97,6 @@ rm -rf "$RESULT_BUNDLE"
   -resultBundlePath "$RESULT_BUNDLE"
 
 EXPORT_DIR="$(mktemp -d)"
-trap 'rm -rf "$EXPORT_DIR"' EXIT
 
 xcrun xcresulttool export attachments \
   --path "$RESULT_BUNDLE" --output-path "$EXPORT_DIR"

--- a/scripts/motion-capture.sh
+++ b/scripts/motion-capture.sh
@@ -139,10 +139,15 @@ BUNDLE_ID="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$APP_PATH/I
 
 # Deliberately NOT appearance-pinned, unlike ui-tour.sh / store-shots.sh /
 # marketing-shots.sh (#1284): those capture colour for review, this records
-# motion, and an operator recording a dark-mode animation should get one. If a
-# recording's appearance ever needs to be deterministic, add the same
-# `xcrun simctl ui "$UDID" appearance …` line and restore it in the trap below,
-# next to the Reduce Motion save/restore.
+# motion, and an operator recording a dark-mode animation should get one.
+# ui-tour.sh alone honours that: its `--dark` mode (#1338) saves and restores
+# the prior appearance in its own trap, so it cannot hand this script an
+# appearance the operator did not choose. store-shots.sh / marketing-shots.sh
+# still pin light and never restore, so running either one first silently
+# leaves the device light — check the appearance before recording if you set it
+# deliberately. If a recording's appearance ever needs
+# to be deterministic, add the same `xcrun simctl ui "$UDID" appearance …` line
+# and restore it in the trap below, next to the Reduce Motion save/restore.
 echo "Booting simulator $UDID..."
 xcrun simctl boot "$UDID" > /dev/null 2>&1 || true
 xcrun simctl bootstatus "$UDID" > /dev/null 2>&1 || true

--- a/scripts/motion-capture.sh
+++ b/scripts/motion-capture.sh
@@ -140,12 +140,9 @@ BUNDLE_ID="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$APP_PATH/I
 # Deliberately NOT appearance-pinned, unlike ui-tour.sh / store-shots.sh /
 # marketing-shots.sh (#1284): those capture colour for review, this records
 # motion, and an operator recording a dark-mode animation should get one.
-# ui-tour.sh alone honours that: its `--dark` mode (#1338) saves and restores
-# the prior appearance in its own trap, so it cannot hand this script an
-# appearance the operator did not choose. store-shots.sh / marketing-shots.sh
-# still pin light and never restore, so running either one first silently
-# leaves the device light — check the appearance before recording if you set it
-# deliberately. If a recording's appearance ever needs
+# All three now honour that (#1338): each saves the prior appearance and
+# restores it in its own trap, so none of them can hand this script an
+# appearance the operator did not choose. If a recording's appearance ever needs
 # to be deterministic, add the same `xcrun simctl ui "$UDID" appearance …` line
 # and restore it in the trap below, next to the Reduce Motion save/restore.
 echo "Booting simulator $UDID..."

--- a/scripts/store-shots.sh
+++ b/scripts/store-shots.sh
@@ -66,6 +66,31 @@ set -euo pipefail
 SIM_UDID="${DEST##*,id=}"
 SIM_UDID="${SIM_UDID%%,*}"
 xcrun simctl bootstatus "$SIM_UDID" -b > /dev/null 2>&1 || true
+
+# Restore the operator's appearance on exit. Without this the light pin below
+# persists — appearance is device-global — and scripts/motion-capture.sh, which
+# is deliberately device-following, would then record light filmstrips for an
+# operator who had deliberately set dark. `simctl ui <dev> appearance` with no
+# value prints the current style but can also print `unsupported` / `unknown`;
+# anything else is left empty and the restore skipped, because defaulting to a
+# value would flip a device rather than leave it as found. Same shape and same
+# single-trap constraint as scripts/ui-tour.sh — see its cleanup() for why the
+# two handlers must be one (bash replaces a trap, it does not chain).
+PRIOR_APPEARANCE="$(xcrun simctl ui "$SIM_UDID" appearance 2> /dev/null || true)"
+case "$PRIOR_APPEARANCE" in
+  light | dark) ;;
+  *) PRIOR_APPEARANCE="" ;;
+esac
+
+cleanup() {
+  if [ -n "$PRIOR_APPEARANCE" ]; then
+    xcrun simctl ui "$SIM_UDID" appearance "$PRIOR_APPEARANCE" > /dev/null 2>&1 || true
+  fi
+  [ -n "${EXPORT_DIR:-}" ] && rm -rf "$EXPORT_DIR"
+  return 0
+}
+trap cleanup EXIT INT TERM
+
 xcrun simctl ui "$SIM_UDID" appearance light > /dev/null
 
 # xcodebuild refuses to write into a pre-existing result bundle.
@@ -76,7 +101,6 @@ rm -rf "$RESULT_BUNDLE"
   -resultBundlePath "$RESULT_BUNDLE"
 
 EXPORT_DIR="$(mktemp -d)"
-trap 'rm -rf "$EXPORT_DIR"' EXIT
 
 xcrun xcresulttool export attachments \
   --path "$RESULT_BUNDLE" --output-path "$EXPORT_DIR"

--- a/scripts/tests/ui-tour-test.sh
+++ b/scripts/tests/ui-tour-test.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# ui-tour-test.sh — Unit-tests scripts/ui-tour.sh's argument parsing and
+# output-directory selection.
+#
+# Scope is deliberately the pre-simulator prefix only: everything after the
+# `sim-dest.sh` source needs a booted simulator and an Xcode build, which the
+# Shell-gate CI runner (ubuntu, no Xcode) does not have. The flag parser and
+# the OUT_DIR branch are pure shell and are the only part of this script a
+# test can reach — before #1338 added `--dark` there was no branch at all.
+#
+# Runs under bash 3.2 (macOS system bash), per .claude/rules/ci-workflows.md.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/ui-tour.sh"
+FAILURES=0
+
+fail() {
+  echo "FAIL: $1" >&2
+  FAILURES=$((FAILURES + 1))
+}
+
+# The parseable prefix ends at the `fi` closing the OUT_DIR branch. Located by
+# pattern rather than a pinned line number so an edit above it does not
+# silently shift what gets sourced.
+PREFIX_END="$(grep -n '^fi$' "$SCRIPT" | head -1 | cut -d: -f1)"
+if [ -z "$PREFIX_END" ]; then
+  fail "could not locate the OUT_DIR branch terminator in ui-tour.sh"
+  exit 1
+fi
+
+PREFIX="$(mktemp)"
+trap 'rm -f "$PREFIX"' EXIT
+head -"$PREFIX_END" "$SCRIPT" > "$PREFIX"
+
+# Guard the harness itself: if the prefix ever stops containing the parser,
+# every assertion below would pass vacuously.
+if ! grep -q 'APPEARANCE=' "$PREFIX" || ! grep -q 'OUT_DIR=' "$PREFIX"; then
+  fail "sourced prefix contains neither APPEARANCE nor OUT_DIR — harness is measuring nothing"
+  exit 1
+fi
+
+# --- appearance + OUT_DIR selection -----------------------------------------
+
+check_selection() {
+  local args="$1" want_appearance="$2" want_suffix="$3" got
+  got="$(/bin/bash -c "set -- $args; source '$PREFIX'; echo \"\$APPEARANCE|\$OUT_DIR\"")"
+  case "$got" in
+    "$want_appearance|"*"$want_suffix")
+      echo "  ok: '$args' -> $got"
+      ;;
+    *)
+      fail "'$args' selected '$got' (wanted appearance=$want_appearance, dir ending '$want_suffix')"
+      ;;
+  esac
+}
+
+check_selection ""        light docs/design/screenshots
+check_selection "--light" light docs/design/screenshots
+check_selection "--dark"  dark  docs/design/screenshots/dark
+
+# Last flag wins, so a wrapper appending a default cannot silently override an
+# explicit one earlier on the line.
+check_selection "--dark --light" light docs/design/screenshots
+check_selection "--light --dark" dark  docs/design/screenshots/dark
+
+# --- unknown argument rejection ---------------------------------------------
+#
+# Negative control: the real script must exit non-zero on an unknown flag
+# BEFORE it touches the simulator, so this runs the actual script, not the
+# prefix. A regression that dropped the `*)` arm would reach `sim-dest.sh` and
+# either block on the concurrent-session gate or start a build.
+
+if out="$("$SCRIPT" --bogus 2>&1)"; then
+  fail "an unknown argument was accepted (expected a non-zero exit)"
+else
+  case "$out" in
+    *"unknown argument"*)
+      echo "  ok: unknown argument rejected before any simulator work"
+      ;;
+    *)
+      fail "rejected an unknown argument, but with the wrong message: $out"
+      ;;
+  esac
+fi
+
+if [ "$FAILURES" -eq 0 ]; then
+  echo "ui-tour-test.sh: all checks passed"
+else
+  echo "ui-tour-test.sh: $FAILURES check(s) failed" >&2
+  exit 1
+fi

--- a/scripts/ui-tour.sh
+++ b/scripts/ui-tour.sh
@@ -12,14 +12,40 @@
 # (-skip-testing in ci.yml) because it gates nothing and UI-test jobs
 # on GHA runners carry known infrastructure flakes.
 #
-# Usage: scripts/ui-tour.sh
+# Usage: scripts/ui-tour.sh [--light | --dark]
+#   --light (default) → docs/design/screenshots/
+#   --dark            → docs/design/screenshots/dark/
+# The simulator's prior appearance is restored on exit either way.
 # Requires: jq (brew install jq)
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-OUT_DIR="$REPO_ROOT/docs/design/screenshots"
 RESULT_BUNDLE="$REPO_ROOT/Pastura/DerivedData/ui-tour.xcresult"
+
+# Appearance to capture. Opt-in rather than a both-appearances default: each
+# pass is a full xcodebuild test run, so making dark automatic would double
+# every routine regeneration for a set that reaches none of the dark risk
+# classes (see docs/design/screenshots/README.md § Dark set).
+APPEARANCE="light"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dark) APPEARANCE="dark" ;;
+    --light) APPEARANCE="light" ;;
+    *) echo "ERROR: unknown argument '$1' (expected --dark or --light)" >&2; exit 1 ;;
+  esac
+  shift
+done
+
+# The dark set lives in its own directory rather than carrying a filename
+# suffix: the light set's NN-name.png filenames are referenced by name from
+# this repo's docs and from .claude/skills/ui-refine, so they stay put. The
+# per-run wipe and the duplicate-basename guard below are both non-recursive,
+# so each set refreshes independently without touching the other.
+OUT_DIR="$REPO_ROOT/docs/design/screenshots"
+if [ "$APPEARANCE" = "dark" ]; then
+  OUT_DIR="$OUT_DIR/dark"
+fi
 
 if ! command -v jq > /dev/null 2>&1; then
   echo "ERROR: jq is required (brew install jq)" >&2
@@ -35,7 +61,11 @@ export PASTURA_SKIP_XCSTRINGS_SYNC=1
 # Appearance pin. #1284 removed Info.plist's UIUserInterfaceStyle, so the tour
 # renders in whatever appearance the SIMULATOR is set to — and that setting
 # persists across runs, so one session that flipped a device to dark would keep
-# producing dark review screenshots. `simctl ui` needs a booted device
+# producing dark review screenshots. That persistence is also why this script
+# RESTORES the prior appearance on exit (see cleanup below): `--dark` would
+# otherwise leave the device dark for the next unrelated run, and
+# scripts/motion-capture.sh is deliberately device-following — it would silently
+# start recording dark filmstrips nobody asked for. `simctl ui` needs a booted device
 # (CoreSimulator error 405 on Shutdown); xcodebuild boots the same one moments
 # later anyway. Sourced WITH the concurrent-session gate: appearance is
 # device-global, so writing it while another session holds the simulator would
@@ -48,7 +78,36 @@ set -euo pipefail
 SIM_UDID="${DEST##*,id=}"
 SIM_UDID="${SIM_UDID%%,*}"
 xcrun simctl bootstatus "$SIM_UDID" -b > /dev/null 2>&1 || true
-xcrun simctl ui "$SIM_UDID" appearance light > /dev/null
+
+# Save the prior appearance so the trap can put it back. `simctl ui <dev>
+# appearance` with no value prints the current style, but it can also print
+# `unsupported` / `unknown`. Anything that is not light/dark is left EMPTY and
+# the restore is skipped: defaulting to `light` would make a failed read on a
+# genuinely-dark device *flip* it, which is the one outcome this trap exists to
+# prevent. Not restoring leaves the tour's own pin in place, which is no worse
+# than the sibling capture scripts already are.
+PRIOR_APPEARANCE="$(xcrun simctl ui "$SIM_UDID" appearance 2> /dev/null || true)"
+case "$PRIOR_APPEARANCE" in
+  light | dark) ;;
+  *) PRIOR_APPEARANCE="" ;;
+esac
+
+# ONE cleanup handler: bash replaces a trap rather than chaining, so a second
+# `trap … EXIT` further down would silently drop this restore (or leak the
+# mktemp dir, depending on order). Same save/restore shape as
+# scripts/motion-capture.sh's Reduce Motion handling. EXPORT_DIR does not exist
+# yet — the guard is what lets the trap be armed here, immediately after the
+# pin, so an early failure still restores the appearance.
+cleanup() {
+  if [ -n "$PRIOR_APPEARANCE" ]; then
+    xcrun simctl ui "$SIM_UDID" appearance "$PRIOR_APPEARANCE" > /dev/null 2>&1 || true
+  fi
+  [ -n "${EXPORT_DIR:-}" ] && rm -rf "$EXPORT_DIR"
+  return 0
+}
+trap cleanup EXIT INT TERM
+
+xcrun simctl ui "$SIM_UDID" appearance "$APPEARANCE" > /dev/null
 
 # xcodebuild refuses to write into a pre-existing result bundle; pre-clean
 # so re-runs are idempotent.
@@ -59,7 +118,6 @@ rm -rf "$RESULT_BUNDLE"
   -resultBundlePath "$RESULT_BUNDLE"
 
 EXPORT_DIR="$(mktemp -d)"
-trap 'rm -rf "$EXPORT_DIR"' EXIT
 
 xcrun xcresulttool export attachments \
   --path "$RESULT_BUNDLE" --output-path "$EXPORT_DIR"
@@ -72,8 +130,8 @@ fi
 
 mkdir -p "$OUT_DIR"
 # Full refresh: drop stale PNGs from screens that no longer exist in the
-# tour. Only generated files live here (the directory is gitignored except
-# for README.md).
+# tour. Only generated files live here (both directories are gitignored; the
+# light one also tracks its README.md).
 rm -f "$OUT_DIR"/*.png
 
 # The exporter assigns opaque on-disk filenames; the XCTAttachment name we


### PR DESCRIPTION
## Summary

Issue #1338 asked whether the three capture sets want a dark variant. Answer
taken here: **`ui-tour.sh` only.** `store-shots.sh` and `marketing-shots.sh`
stay light-pinned (a marketing call, not a mechanical one) and
`motion-capture.sh` stays device-following.

```bash
scripts/ui-tour.sh --dark     # → docs/design/screenshots/dark/
```

## The evidence, and the decision taken against part of it

The issue argued `ui-tour.sh` has "the strongest case — this is the
design-review surface, and dark is now half the design system". Measured
against `docs/qa/dark-mode-qa.md` § "What is actually at risk", that case is
weaker than it reads: the tour's 14 stops are Home / ScenarioDetail / Editor /
Gallery / GalleryDetail / Settings / Results / ResultDetail plus five
empty-state screens. There is no mid-run Simulation and no share card, so
classes A, C and E are entirely off-tour, and class D's launch surfaces precede
the tour.

The operator's call was to build it anyway, for typography, spacing and mood
review. That is recorded plainly in the README rather than framed as coverage
it does not provide — with the per-class detail, because the first draft of
that claim was **wrong**: it said "none of the five" and hedged materials as
"incidental". Class B is genuinely reached at 2 of §3's 11 sites (the
ScenarioDetail action bar at stop `02`, the Editor capsule at stop `03`), and a
material re-rendering wrong in dark is a static property those captures show.
The hedge was the concessive clause propping up a category that had already
broken.

## Implementation

**A second directory, not a filename suffix.** The light set's `NN-name.png`
names are referenced by name from the README, `docs/design/navigation-map.md`
and the `ui-refine` skill, so they stay put. The script's per-run
`rm -f "$OUT_DIR"/*.png` wipe and its duplicate-basename guard are both
non-recursive, so the two sets refresh independently.

**Opt-in.** Each appearance is a full `xcodebuild test` pass; a
both-appearances default would double every routine regeneration.

**The prior appearance is restored on exit** — the part that matters outside
this script. Appearance is device-global and persists, which is why the tour
pinned light to begin with. `motion-capture.sh` is deliberately
device-following, so without a restore one `--dark` run would hand an operator
dark filmstrips they never asked for. That script's own comment already
prescribed this save/restore-in-the-trap pattern for whoever added an
appearance line.

Three traps handled:

- **`trap` replaces, it does not chain.** The script already had
  `trap 'rm -rf "$EXPORT_DIR"' EXIT`. A second bare `trap … EXIT` would have
  silently dropped one of the two, so both fold into one `cleanup()`, armed
  immediately after the pin — before `EXPORT_DIR` exists, hence the guard.
- **A failed appearance read must not flip the device.** `simctl ui <dev>
  appearance` can print `unsupported` / `unknown`; anything not light/dark
  leaves the saved value empty and skips the restore. Defaulting to `light`
  would flip a genuinely-dark device, the one outcome the trap exists to
  prevent.
- **`.gitignore` is single-level.** `docs/design/screenshots/*.png` does not
  reach `dark/`, so those PNGs would have surfaced as untracked. A second rule
  was added and verified with `git check-ignore -v` on probe files in both
  directories, plus a check that `README.md` stays trackable.

`scripts/motion-capture.sh`'s comment is corrected in the same change. It now
attributes the restore to `ui-tour.sh` alone and records that `store-shots.sh`
/ `marketing-shots.sh` pin light **without** restoring — a pre-existing mirror
of the same hazard, and something an operator recording a deliberately-dark
animation needs to know.

## Test plan

`scripts/tests/*-test.sh` — **18/18 pass**, including a new
`scripts/tests/ui-tour-test.sh`. It covers the flag parser and the `OUT_DIR`
branch, which is the only part of this script reachable without a simulator and
the first branch it has ever had.

**Verified by mutation, not by a green run.** Dropping the `/dark` suffix from
the `OUT_DIR` branch reddens exactly the two `--dark` assertions and leaves the
three light ones green — so the harness discriminates rather than merely
passing. It also guards itself: if the sourced prefix ever stops containing the
parser, it fails instead of passing vacuously.

Shell checks on the system bash 3.2.57 that `.claude/rules/ci-workflows.md`
Rule 1 targets: `bash -n` clean on both edited scripts, shellcheck clean, and
the parser is safe under `set -u`. Negative control on the real script: an
unknown argument exits 1 before any `simctl` call.

Not run: the tour itself (`scripts/ui-tour.sh --dark`) needs a booted simulator
and several minutes, and its output is gitignored, so a reviewer wanting to see
the dark set should run it locally.

## Follow-up filed

`ui-refine` is the only automated consumer of this directory and does not read
the dark set — its freshness glob is single-level and Step 1 runs the bare
tour. Wiring it up needs decisions about the lens rotation, the proposal quota
and the ledger's dedup key, so it is **#1345** rather than a silent omission. A
note in `SKILL.md` says so, to stop a cycle implying dark coverage in its
digest.

Also swept while adjacent: `SKILL.md` said the tour writes "8" PNGs in two
places; it is 14, matching the README and `navigation-map.md` tables.

## Added after review: the sibling scripts had the same hazard mirrored

`store-shots.sh` and `marketing-shots.sh` pinned light and never restored —
their only trap was the `EXPORT_DIR` cleanup. So an operator who set dark
deliberately and ran either one got a light device afterwards, and
`motion-capture.sh` recorded light filmstrips. Pre-existing, found while
writing this PR's restore; folded in here rather than deferred, since it is
the same three-line pattern and leaving it would have made
`motion-capture.sh`'s comment carry an outstanding-hazard note indefinitely.

Verified: shellcheck finding counts unchanged against `main` (2 and 2 — the
`SC2153` on `DEST` comes from `sim-dest.sh` and predates this branch), and the
cleanup shape probed on bash 3.2.57 preserves the script's exit code
(`exit 7` → 7) without tripping errexit.

## Device QA

実機QA不要 — shell scripts, `.gitignore` and documentation only. No app code,
no UI surface. The capture output is gitignored and produced on demand.

Closes #1338

