### PR TITLE
🔧 chore: let the worktree pruner dispose machine-local files

### DIFF
--- a/.claude/rules/ci-workflows.md
+++ b/.claude/rules/ci-workflows.md
@@ -145,23 +145,16 @@ never runs the extraction, so it was green locally, red in CI.
 ### Synthetic git fixtures: anchor every directory an ignored entry sits under
 
 git collapses a wholly-ignored **untracked** directory up to its topmost untracked
-parent, so `status --porcelain --ignored` reports `!! Pastura/` rather than
-`!! Pastura/DerivedData/` unless something under `Pastura/` is tracked. A fixture
-repo built with `git init` + one commit has almost nothing tracked, so it silently
-produces path shapes this repository cannot produce.
+parent — `status --ignored` reports `!! Pastura/`, not `!! Pastura/DerivedData/`,
+unless something under `Pastura/` is tracked. A fixture repo tracks almost nothing,
+so it silently produces path shapes this repo cannot.
 
-Why it matters more than a wrong fixture usually does: the **positive** case fails
-loudly and gets fixed, while every **negative** control passes *for the wrong
-reason* — the parent collapsed, so the predicate under test was never consulted at
-all. That is a false-green guard, the shape `knowledge-layering.md` § "Claims you
-author are assertions too" warns about.
-
-**Apply**: in the fixture's initial commit, put a tracked file under every
-directory an ignored entry will sit in; then assert per case that the **exact**
-entry string reached the code under test, reading the same `-z`/non-`-z` form the
-code consumes (they differ in C-quoting). Worked example:
-`scripts/tests/prune-stale-worktrees-test.sh` (`assert_ignored_entry`). Hit twice —
-`Pastura/` in #1340, `.claude/skills/` in #1352 — each time costing a review round.
+**Apply**: track a file under every directory an ignored entry will sit in, and
+assert per case that the exact entry string reached the code under test. Skip it
+and the positive case still fails loudly while every negative control passes for
+the wrong reason — the same false-green shape § "Gate scripts" flags for
+`mktemp -d` fixtures, from a different cause. Worked example (recurred #1340,
+#1352): `scripts/tests/prune-stale-worktrees-test.sh` § `assert_ignored_entry`.
 
 ### Skill-local harnesses are NOT auto-wired — each needs a `scripts/tests/` shim
 

--- a/.claude/rules/ci-workflows.md
+++ b/.claude/rules/ci-workflows.md
@@ -142,6 +142,27 @@ that extraction required, aborting every `gallery-scripts-test.sh` case whose
 fixture builder (`mk_factory` / `mk_gallery_yaml`) predated it. `check-gallery-entry.sh`
 never runs the extraction, so it was green locally, red in CI.
 
+### Synthetic git fixtures: anchor every directory an ignored entry sits under
+
+git collapses a wholly-ignored **untracked** directory up to its topmost untracked
+parent, so `status --porcelain --ignored` reports `!! Pastura/` rather than
+`!! Pastura/DerivedData/` unless something under `Pastura/` is tracked. A fixture
+repo built with `git init` + one commit has almost nothing tracked, so it silently
+produces path shapes this repository cannot produce.
+
+Why it matters more than a wrong fixture usually does: the **positive** case fails
+loudly and gets fixed, while every **negative** control passes *for the wrong
+reason* — the parent collapsed, so the predicate under test was never consulted at
+all. That is a false-green guard, the shape `knowledge-layering.md` § "Claims you
+author are assertions too" warns about.
+
+**Apply**: in the fixture's initial commit, put a tracked file under every
+directory an ignored entry will sit in; then assert per case that the **exact**
+entry string reached the code under test, reading the same `-z`/non-`-z` form the
+code consumes (they differ in C-quoting). Worked example:
+`scripts/tests/prune-stale-worktrees-test.sh` (`assert_ignored_entry`). Hit twice —
+`Pastura/` in #1340, `.claude/skills/` in #1352 — each time costing a review round.
+
 ### Skill-local harnesses are NOT auto-wired — each needs a `scripts/tests/` shim
 
 The Shell-gate glob is `scripts/tests/*-test.sh` **only**, so a skill's own

--- a/scripts/prune-stale-worktrees.sh
+++ b/scripts/prune-stale-worktrees.sh
@@ -14,7 +14,8 @@
 #   b. basename matches ^[a-z]+-[a-z]+-[0-9a-f]{6}$
 #   c. the worktree is not `locked`
 #   d. `git status --porcelain` is empty
-#   e. ignored content is limited to build output (DISPOSABLE_COMPONENTS below)
+#   e. all of its ignored content is disposable — build output, or a
+#      machine-local file that simply regenerates (three lists below)
 #   f. nothing in the worktree or its git metadata changed in the last 12h
 #   g. HEAD is attached to a branch (a detached HEAD's commits are reachable
 #      from no ref, so removal would orphan them)
@@ -90,17 +91,40 @@
 # TUNING THE DISPOSABLE SET
 # Anything ignored-but-not-disposable blocks removal (safe direction: residue
 # stays, nothing is lost). The dry-run log names the exact blocking entry for
-# each KEEP, which is how this set is meant to be tuned: run dry for a few
-# nights, read the log, then add only what is provably build output.
-# Two entries to expect FIRST in that log, both deliberately not disposable:
-#   - `.claude/settings.local.json` — Claude Code writes permission grants
-#     there, so a session that granted anything leaves one behind.
-#   - `data/` — the repository tracks no file under it at all, so git collapses
-#     the whole directory to a single `!! data/` entry the moment a routine
-#     writes its digest there.
-# If either turns out to dominate the log, that is a finding about what a
-# routine worktree actually accumulates, not a reason to widen the set
-# reflexively: widening it is what makes a removal unrecoverable.
+# each KEEP, which is how these lists are tuned: run dry for a few nights, read
+# the log, then add only what is provably build output OR provably machine-local
+# and regenerable. Widening is what makes a removal unrecoverable, so a blocker
+# that dominates the log is a finding about what routine worktrees accumulate,
+# not licence to widen reflexively.
+#
+# That procedure has now run once. Recording what it produced, because the
+# previous version of this section predicted the wrong things:
+#   - The first blocker was `.claude/probe-instructions-hook.sh`, unanticipated
+#     here. It was dead residue from a one-off probe, ignored only through one
+#     clone's `.git/info/exclude` — cleaned up at the source rather than
+#     allowlisted, because on any other clone it is not ignored at all and
+#     condition (d) stops the worktree instead. Prefer that resolution: residue
+#     is temporary, an allowlist entry is permanent.
+#   - `data/` was predicted and never appeared. `queue-consumer`'s
+#     `append_digest.py` resolves its digest to the MAIN checkout via
+#     `--git-common-dir`, so a worktree's `data/` stays empty. That is specific
+#     to routines resolving that way — `scenario-factory`'s takes `--digest`
+#     from its caller — so a factory worktree blocking on `data/` later is
+#     expected, not a contradiction.
+#
+# WHY `.claude/settings.local.json` IS DISPOSABLE — and what that is NOT saying
+# Claude Code writes permission grants there, which is why an earlier version of
+# this section listed it as deliberately non-disposable. The correction is to
+# the inference, not to that fact. The three observed worktree copies measured
+# byte-identical to the main checkout's — but that is evidence about three
+# instances, while this rule matches on PATH, unconditionally, with no runtime
+# content check. A session that grants a permission inside a worktree diverges
+# its copy, and this deletes it anyway.
+# What licenses the entry is BOUNDED LOSS: worst case, a grant made inside a
+# stale worktree is lost and re-prompts. Contrast `data/queue/digest.md`, which
+# is unrecoverable. Do NOT restate this as "it dies with the worktree anyway" —
+# condition (e) exists precisely to stop a worktree dying while it holds
+# content, so that reasoning is circular.
 #
 # USAGE
 #   scripts/prune-stale-worktrees.sh              # dry run (default)
@@ -140,11 +164,22 @@ VERBOSE=0
 QUIET=0
 LOG_FILE=""
 
-# Exact final-path-component match, mirroring the bare-pattern semantics of
-# .gitignore's own `build/`, `DerivedData/` and `.build/` rules (which match at
-# any depth). Exact rather than glob so a new, unrecognized artifact directory
-# fails toward KEEP.
+# Three exact-match lists, never globs, so anything unrecognized fails toward
+# KEEP. Which list applies is decided by the trailing slash git puts on
+# directories in `--ignored` porcelain output — see is_disposable.
+#
+# Directories, matched on the final path component, mirroring the bare-pattern
+# semantics of .gitignore's own `build/`, `DerivedData/` and `.build/` rules
+# (which match at any depth).
 DISPOSABLE_COMPONENTS="build DerivedData .build .gradle node_modules PasturaShared.xcframework"
+# Files, matched on the full repo-relative path. Deliberately not by basename:
+# a copy of this filename somewhere else in the tree is not the same file and
+# must keep blocking. See § "WHY .claude/settings.local.json IS DISPOSABLE".
+DISPOSABLE_FILES=".claude/settings.local.json"
+# Files matched on basename alone, for names that legitimately appear at any
+# depth. `.DS_Store` is Finder metadata and is unanchored in .gitignore too, so
+# the semantics agree; it cannot hold anything a human would miss.
+DISPOSABLE_BASENAMES=".DS_Store"
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -258,22 +293,35 @@ is_fresh() {
   return 1
 }
 
-# A git-status path such as "Pastura/DerivedData/" is disposable when it is a
-# directory whose final component is in DISPOSABLE_COMPONENTS.
+# Is a git-status path such as "Pastura/DerivedData/" or ".claude/skills/.DS_Store"
+# disposable? The trailing slash is the ONLY arm selector — git's `--ignored`
+# porcelain guarantees it on directories — so a directory that happens to be
+# named `.DS_Store/` takes the directory arm and can never reach the basename
+# rule below.
 is_disposable() {
   local entry="$1" last
   case "$entry" in
-    */) entry="${entry%/}" ;;
-    *) return 1 ;;
+    */)
+      entry="${entry%/}"
+      last="${entry##*/}"
+      case " $DISPOSABLE_COMPONENTS " in
+        *" $last "*) return 0 ;;
+      esac
+      return 1
+      ;;
+  esac
+
+  case " $DISPOSABLE_FILES " in
+    *" $entry "*) return 0 ;;
   esac
   last="${entry##*/}"
-  case " $DISPOSABLE_COMPONENTS " in
+  case " $DISPOSABLE_BASENAMES " in
     *" $last "*) return 0 ;;
   esac
   return 1
 }
 
-# First ignored entry that is not build output, or empty when there is none.
+# First ignored entry that is not disposable, or empty when there is none.
 # Returns 2 when the enumeration itself failed, so the caller cannot read a
 # git error as "nothing irreplaceable here". This one matters more than the
 # others: `git worktree remove` is blind to ignored files, so (e) has no
@@ -407,8 +455,8 @@ evaluate() {
   fi
   if [ -n "$blocker" ]; then
     kept=$((kept + 1))
-    record_actionable "KEEP  $name — ignored content that is not build output: $blocker"
-    [ "$VERBOSE" -eq 1 ] && say "keep  $name — ignored content that is not build output: $blocker"
+    record_actionable "KEEP  $name — ignored content that is not disposable: $blocker"
+    [ "$VERBOSE" -eq 1 ] && say "keep  $name — ignored content that is not disposable: $blocker"
     return 0
   fi
 

--- a/scripts/prune-stale-worktrees.sh
+++ b/scripts/prune-stale-worktrees.sh
@@ -120,9 +120,13 @@
 # instances, while this rule matches on PATH, unconditionally, with no runtime
 # content check. A session that grants a permission inside a worktree diverges
 # its copy, and this deletes it anyway.
-# What licenses the entry is BOUNDED LOSS: worst case, a grant made inside a
-# stale worktree is lost and re-prompts. Contrast `data/queue/digest.md`, which
-# is unrecoverable. Do NOT restate this as "it dies with the worktree anyway" —
+# What licenses the entry is BOUNDED LOSS: worst case, any local settings edit
+# made inside a STALE worktree is lost — a permission grant re-prompts, and
+# hook wiring / env / plugin enablement there governed only that dead worktree's
+# sessions. The main checkout's copy is never a candidate: this script
+# self-gates to the main checkout and only ever removes paths under
+# `.claude/worktrees/`. Contrast `data/queue/digest.md`, which is
+# unrecoverable. Do NOT restate this as "it dies with the worktree anyway" —
 # condition (e) exists precisely to stop a worktree dying while it holds
 # content, so that reasoning is circular.
 #
@@ -167,6 +171,13 @@ LOG_FILE=""
 # Three exact-match lists, never globs, so anything unrecognized fails toward
 # KEEP. Which list applies is decided by the trailing slash git puts on
 # directories in `--ignored` porcelain output — see is_disposable.
+#
+# "Never globs" rests on the QUOTING at those match sites, not on the strings
+# happening to be plain: `case " $LIST " in *" $entry "*)` interpolates
+# untrusted path text into a glob pattern, and only the double quotes keep it
+# literal (verified on bash 3.2 with `entry` set to `*` and to a `?`-bearing
+# path). Unquoting `$entry`, or moving to an unquoted `[[ == ]]`, silently
+# turns an observed filename into a wildcard.
 #
 # Directories, matched on the final path component, mirroring the bare-pattern
 # semantics of .gitignore's own `build/`, `DerivedData/` and `.build/` rules

--- a/scripts/tests/prune-stale-worktrees-test.sh
+++ b/scripts/tests/prune-stale-worktrees-test.sh
@@ -33,7 +33,7 @@ fail=0
 pass_count=0
 # Decremented by any branch that legitimately skips a case; see the check at
 # the end of the file.
-EXPECTED_PASSES=20
+EXPECTED_PASSES=25
 
 ok() {
   pass_count=$((pass_count + 1))
@@ -60,15 +60,32 @@ REPO="$(cd "$TMP" && pwd -P)/repo"
 mkdir -p "$REPO"
 sgit init -q -b main "$REPO"
 printf 'DerivedData/\nbuild/\n.gradle/\nnode_modules/\nkeepme.local\n' > "$REPO/.gitignore"
+# Ignore patterns the FILE arm is tested against. `*.bak` and the nested/`data/`
+# paths are ignored on purpose: an entry that is merely untracked would be
+# stopped by condition (d) and the case would silently be testing (d) instead
+# of the file arm.
+printf '.claude/settings.local.json\n.DS_Store\n*.bak\nsub/.claude/settings.local.json\ndata/queue/digest.md\n' >> "$REPO/.gitignore"
 echo seed > "$REPO/a.txt"
-# `Pastura/` and `shared/models/` must be TRACKED, mirroring the real repo.
-# git collapses a wholly-ignored *untracked* directory up to its topmost
-# untracked parent, so an untracked `Pastura/` would be reported as `!! Pastura/`
-# instead of `!! Pastura/DerivedData/` — and the fixture would then exercise a
-# path shape that cannot occur in this repository.
-mkdir -p "$REPO/Pastura" "$REPO/shared/models"
+# Every directory an ignored entry sits under must be TRACKED, mirroring the
+# real repo. git collapses a wholly-ignored *untracked* directory up to its
+# topmost untracked parent, so an untracked `Pastura/` would be reported as
+# `!! Pastura/` instead of `!! Pastura/DerivedData/` — and the fixture would
+# then exercise a path shape that cannot occur in this repository. The same
+# applies to `.claude/`, `sub/.claude/` and `data/queue/`: without an anchor
+# there, every file-arm case below would pass by construction because
+# is_disposable would never see the path it is supposed to match.
+mkdir -p "$REPO/Pastura" "$REPO/shared/models" "$REPO/.claude/rules" "$REPO/.claude/skills" "$REPO/sub/.claude" "$REPO/data/queue"
 echo anchor > "$REPO/Pastura/tracked.txt"
 echo anchor > "$REPO/shared/models/tracked.txt"
+echo anchor > "$REPO/.claude/rules/anchor.md"
+# `.claude/skills/` needs its own anchor: the real repo tracks skill files
+# there, so a `.DS_Store` inside it is reported at full path. Anchoring only
+# `.claude/` leaves `skills/` untracked and git collapses it to
+# `!! .claude/skills/` — a shape this repository cannot produce. The
+# precondition assertion in the file-arm cases is what caught that.
+echo anchor > "$REPO/.claude/skills/anchor.md"
+echo anchor > "$REPO/sub/.claude/anchor.md"
+echo anchor > "$REPO/data/queue/anchor.md"
 sgit -C "$REPO" add -A
 sgit -C "$REPO" commit -qm "init"
 mkdir -p "$REPO/.claude/worktrees"
@@ -386,6 +403,122 @@ if exists "goofy-hypatia-62c51e"; then
 else
   ok "(e) nested build output alone does not block removal"
 fi
+
+# --- file arm ------------------------------------------------------------------
+# Machine-local files that regenerate are disposable; everything else still
+# blocks. Each case asserts FIRST that the exact entry string reached the
+# pruner: git collapses a wholly-ignored untracked directory up to its topmost
+# untracked parent, and a collapsed entry never reaches is_disposable at all, so
+# without that precondition every case here would pass by construction.
+printf '== file arm ==\n'
+
+assert_ignored_entry() {
+  local wt="$1" want="$2" got
+  got="$(sgit -C "$wt" --no-optional-locks status --porcelain --ignored | sed -n 's/^!! //p' | tr '\n' ' ')"
+  case " $got " in
+    *" $want "*) return 0 ;;
+  esac
+  bad "fixture setup: git reported [$got], not '$want' — this case never reaches is_disposable"
+  return 1
+}
+
+# P — the positive control. Reddens if the file arm is removed.
+make_wt "jovial-allen-fb692b"
+JA="$REPO/.claude/worktrees/jovial-allen-fb692b"
+printf '{}\n' > "$JA/.claude/settings.local.json"
+mkdir -p "$JA/.claude/skills"
+printf 'finder junk\n' > "$JA/.claude/skills/.DS_Store"
+age_wt_path "$JA"
+assert_aged "jovial-allen-fb692b"
+assert_ignored_entry "$JA" ".claude/settings.local.json"
+assert_ignored_entry "$JA" ".claude/skills/.DS_Store"
+out="$(run_prune)"
+if exists "jovial-allen-fb692b"; then
+  bad "(P) a worktree holding only machine-local files was kept — got: $out"
+else
+  ok "(P) machine-local files alone do not block removal"
+fi
+
+# N1 — near-miss name. Reddens if any prefix/suffix globbing creeps in.
+make_wt "laughing-shtern-427042"
+LS="$REPO/.claude/worktrees/laughing-shtern-427042"
+printf 'not the real thing\n' > "$LS/.claude/settings.local.json.bak"
+age_wt_path "$LS"
+assert_ignored_entry "$LS" ".claude/settings.local.json.bak"
+out="$(run_prune)"
+if ! exists "laughing-shtern-427042"; then
+  bad "(N1) a near-miss filename was treated as disposable"
+else
+  case "$out" in
+    *"laughing-shtern-427042 — ignored content that is not disposable: .claude/settings.local.json.bak"*)
+      ok "(N1) a near-miss filename still blocks, and is named" ;;
+    *) bad "(N1) kept for the wrong reason — got: $out" ;;
+  esac
+fi
+sgit -C "$REPO" worktree remove --force "$LS" 2>/dev/null
+
+# N2 — same basename, different directory. Reddens if the full-path entry is
+# matched by basename.
+make_wt "musing-feistel-75f689"
+MF="$REPO/.claude/worktrees/musing-feistel-75f689"
+printf '{}\n' > "$MF/sub/.claude/settings.local.json"
+age_wt_path "$MF"
+assert_ignored_entry "$MF" "sub/.claude/settings.local.json"
+out="$(run_prune)"
+if ! exists "musing-feistel-75f689"; then
+  bad "(N2) a copy at a different path was treated as disposable — the full-path entry is being matched by basename"
+else
+  case "$out" in
+    *"musing-feistel-75f689 — ignored content that is not disposable: sub/.claude/settings.local.json"*)
+      ok "(N2) the same basename elsewhere still blocks" ;;
+    *) bad "(N2) kept for the wrong reason — got: $out" ;;
+  esac
+fi
+sgit -C "$REPO" worktree remove --force "$MF" 2>/dev/null
+
+# N3 — a DIRECTORY named .DS_Store. Reddens if the file arm leaks past the
+# trailing-slash selector and reaches the basename rule.
+make_wt "nice-booth-cc6294"
+NB="$REPO/.claude/worktrees/nice-booth-cc6294"
+mkdir -p "$NB/.DS_Store"
+printf 'payload\n' > "$NB/.DS_Store/inside.txt"
+age_wt_path "$NB"
+assert_ignored_entry "$NB" ".DS_Store/"
+out="$(run_prune)"
+if ! exists "nice-booth-cc6294"; then
+  bad "(N3) a DIRECTORY named .DS_Store was treated as disposable — the basename rule is reachable from the directory arm"
+else
+  case "$out" in
+    *"nice-booth-cc6294 — ignored content that is not disposable: .DS_Store/"*)
+      ok "(N3) a directory named .DS_Store still blocks" ;;
+    *) bad "(N3) kept for the wrong reason — got: $out" ;;
+  esac
+fi
+sgit -C "$REPO" worktree remove --force "$NB" 2>/dev/null
+
+# N4 — the widening must not disable (e) wholesale. Holds every allowed entry
+# PLUS one irreplaceable file, and requires that irreplaceable one to be named:
+# this is the control for the "allowing one entry just promotes the next"
+# ordering the change is built on.
+make_wt "pensive-montalcini-9c660f"
+PM="$REPO/.claude/worktrees/pensive-montalcini-9c660f"
+printf '{}\n' > "$PM/.claude/settings.local.json"
+mkdir -p "$PM/.claude/skills"
+printf 'finder junk\n' > "$PM/.claude/skills/.DS_Store"
+printf 'irreplaceable local journal\n' > "$PM/data/queue/digest.md"
+age_wt_path "$PM"
+assert_ignored_entry "$PM" "data/queue/digest.md"
+out="$(run_prune)"
+if ! exists "pensive-montalcini-9c660f"; then
+  bad "(N4) a worktree holding data/queue/digest.md was removed — widening the set disabled condition (e)"
+else
+  case "$out" in
+    *"pensive-montalcini-9c660f — ignored content that is not disposable: data/queue/digest.md"*)
+      ok "(N4) disposable entries are skipped and the irreplaceable one still blocks, by name" ;;
+    *) bad "(N4) kept for the wrong reason — got: $out" ;;
+  esac
+fi
+sgit -C "$REPO" worktree remove --force "$PM" 2>/dev/null
 
 # (a) a worktree outside .claude/worktrees/
 mkdir -p "$REPO/elsewhere"

--- a/scripts/tests/prune-stale-worktrees-test.sh
+++ b/scripts/tests/prune-stale-worktrees-test.sh
@@ -33,7 +33,7 @@ fail=0
 pass_count=0
 # Decremented by any branch that legitimately skips a case; see the check at
 # the end of the file.
-EXPECTED_PASSES=25
+EXPECTED_PASSES=26
 
 ok() {
   pass_count=$((pass_count + 1))
@@ -412,9 +412,12 @@ fi
 # without that precondition every case here would pass by construction.
 printf '== file arm ==\n'
 
+# Reads the `-z` stream, which is what blocking_ignored_entry consumes. The
+# non-`-z` form C-quotes paths containing spaces or specials, so asserting
+# against it would be checking a different string than the pruner sees.
 assert_ignored_entry() {
   local wt="$1" want="$2" got
-  got="$(sgit -C "$wt" --no-optional-locks status --porcelain --ignored | sed -n 's/^!! //p' | tr '\n' ' ')"
+  got="$(sgit -C "$wt" --no-optional-locks status --porcelain -z --ignored | tr '\0' '\n' | sed -n 's/^!! //p' | tr '\n' ' ')"
   case " $got " in
     *" $want "*) return 0 ;;
   esac
@@ -422,35 +425,48 @@ assert_ignored_entry() {
   return 1
 }
 
-# P — the positive control. Reddens if the file arm is removed.
+# P1 / P2 — positive controls, one per list. Kept separate so a mutation that
+# drops ONE list is reported by a case that names it; a single fixture holding
+# both reddens either way but cannot say which list broke.
 make_wt "jovial-allen-fb692b"
 JA="$REPO/.claude/worktrees/jovial-allen-fb692b"
 printf '{}\n' > "$JA/.claude/settings.local.json"
-mkdir -p "$JA/.claude/skills"
-printf 'finder junk\n' > "$JA/.claude/skills/.DS_Store"
 age_wt_path "$JA"
 assert_aged "jovial-allen-fb692b"
 assert_ignored_entry "$JA" ".claude/settings.local.json"
-assert_ignored_entry "$JA" ".claude/skills/.DS_Store"
 out="$(run_prune)"
 if exists "jovial-allen-fb692b"; then
-  bad "(P) a worktree holding only machine-local files was kept — got: $out"
+  bad "(P1) a worktree holding only DISPOSABLE_FILES content was kept — got: $out"
 else
-  ok "(P) machine-local files alone do not block removal"
+  ok "(P1) an exact-path machine-local file does not block removal"
+fi
+
+make_wt "sleepy-mahavira-e64867"
+SM="$REPO/.claude/worktrees/sleepy-mahavira-e64867"
+mkdir -p "$SM/.claude/skills"
+printf 'finder junk\n' > "$SM/.claude/skills/.DS_Store"
+age_wt_path "$SM"
+assert_aged "sleepy-mahavira-e64867"
+assert_ignored_entry "$SM" ".claude/skills/.DS_Store"
+out="$(run_prune)"
+if exists "sleepy-mahavira-e64867"; then
+  bad "(P2) a worktree holding only DISPOSABLE_BASENAMES content was kept — got: $out"
+else
+  ok "(P2) a basename-matched file does not block removal"
 fi
 
 # N1 — near-miss name. Reddens if any prefix/suffix globbing creeps in.
-make_wt "laughing-shtern-427042"
-LS="$REPO/.claude/worktrees/laughing-shtern-427042"
+make_wt "silly-zhukovsky-d58f0f"
+LS="$REPO/.claude/worktrees/silly-zhukovsky-d58f0f"
 printf 'not the real thing\n' > "$LS/.claude/settings.local.json.bak"
 age_wt_path "$LS"
 assert_ignored_entry "$LS" ".claude/settings.local.json.bak"
 out="$(run_prune)"
-if ! exists "laughing-shtern-427042"; then
+if ! exists "silly-zhukovsky-d58f0f"; then
   bad "(N1) a near-miss filename was treated as disposable"
 else
   case "$out" in
-    *"laughing-shtern-427042 — ignored content that is not disposable: .claude/settings.local.json.bak"*)
+    *"silly-zhukovsky-d58f0f — ignored content that is not disposable: .claude/settings.local.json.bak"*)
       ok "(N1) a near-miss filename still blocks, and is named" ;;
     *) bad "(N1) kept for the wrong reason — got: $out" ;;
   esac
@@ -578,7 +594,12 @@ fi
 # sits under .claude/worktrees/ too, so it would otherwise be a live candidate
 # and contaminate the idle-run assertion below.
 sgit -C "$REPO" worktree remove --force "$VICTIM" 2>/dev/null
-rm -rf "$OUTER/.claude"
+# Only the directory this case created. `.claude/` also holds the fixture's
+# TRACKED anchors, so removing it wholesale leaves this worktree permanently
+# dirty — after which the idle-log assertion below survives only because
+# condition (f) short-circuits before (d), an ordering dependency the comment
+# there does not describe and which would invert if evaluate() were reordered.
+rm -rf "$OUTER/.claude/worktrees"
 
 # --- dry-run default ----------------------------------------------------------
 # Its own fixture: hungry-goldberg is reserved for the idle case below, and the

--- a/scripts/tests/prune-stale-worktrees-test.sh
+++ b/scripts/tests/prune-stale-worktrees-test.sh
@@ -362,7 +362,7 @@ fi
 out="$(run_prune)"
 if exists "fervent-kepler-6c3aa2"; then
   case "$out" in
-    *"fervent-kepler-6c3aa2 — ignored content that is not build output: keepme.local"*)
+    *"fervent-kepler-6c3aa2 — ignored content that is not disposable: keepme.local"*)
       ok "(e) irreplaceable ignored file is kept, and the blocking entry is named" ;;
     *) bad "(e) kept for the wrong reason — got: $out" ;;
   esac


### PR DESCRIPTION
## Summary

`scripts/prune-stale-worktrees.sh` (#1340) ran against three nights of real residue and removed nothing — condition (e) blocked every candidate on gitignored content that is not build output. `is_disposable` could not even express the blockers: it rejected any non-directory outright, so they were unreachable from `DISPOSABLE_COMPONENTS`.

Adds a file arm with two exact-match lists, and sweeps the header text the widening makes stale.

| Kind | Match | Entries |
|---|---|---|
| directory | final path component (unchanged) | `build` `DerivedData` `.build` `.gradle` `node_modules` `PasturaShared.xcframework` |
| file | full repo-relative path | `.claude/settings.local.json` |
| file | basename | `.DS_Store` |

The trailing slash git puts on directories in `--ignored` porcelain stays the **only** arm selector, so a directory named `.DS_Store/` takes the directory arm and can never reach the basename rule. Unknown files still fall toward KEEP.

## The justification is bounded loss, not the measurement

The three worktree copies of `.claude/settings.local.json` did measure byte-identical to the main checkout's. That is evidence about **three observed instances**, while the rule matches on **path, unconditionally**, with no runtime content check — a session that grants a permission inside a worktree diverges its copy and this deletes it anyway. So the header justifies the entry by **bounded loss**: worst case, a local settings edit made inside a *stale* worktree is lost. The main checkout's copy is never a candidate — the script self-gates to the main checkout and only removes paths under `.claude/worktrees/`. Contrast `data/queue/digest.md`, which is unrecoverable.

The header also forecloses the circular version explicitly: "it dies with the worktree anyway" is precisely what condition (e) exists to prevent, so it cannot justify letting the worktree die.

## A third blocker was fixed upstream instead

The first blocker observed was `.claude/probe-instructions-hook.sh` — but it was ignored only through one clone's `.git/info/exclude`, under a block headed `# --- /code-review probe round 2 (temporary) ---`, alongside a fixture `docs/decisions/ADR-9999.md`. Dead residue from a 2026-07-18 probe: the hook appended to a scratchpad belonging to a **different project's** long-finished session and failed on every invocation since. Cleaned up at the source rather than allowlisted.

That distinction matters beyond tidiness: on any other clone the file is not ignored at all, so condition (d) stops the worktree and a repo-tracked allowlist entry would have been **inert everywhere but here**. Removing the exclude line demonstrated it — the blocker immediately moved from (e) to (d), because `.git/info/exclude` is shared across worktrees.

## Test controls, each keyed to the regression it detects

| # | Control | Reddens if |
|---|---|---|
| P1 | only `.claude/settings.local.json` → REMOVED | the exact-path list is dropped |
| P2 | only `.claude/skills/.DS_Store` → REMOVED | the basename list is dropped |
| N1 | `.claude/settings.local.json.bak` → KEEP, named | prefix/suffix globbing creeps in |
| N2 | `sub/.claude/settings.local.json` → KEEP, named | a listed path is matched as a suffix |
| N3 | a **directory** `.DS_Store/` → KEEP, named | the file arm leaks past the trailing-slash selector |
| N4 | every allowed entry **plus** `data/queue/digest.md` → KEEP, that one named | widening switched condition (e) off |

N4 is the one proving the widening did not disable (e), and it pins the "allowing one entry just promotes the next" ordering the change rests on.

**The fixture needed anchors before any of this could work.** git collapses a wholly-ignored untracked directory up to its topmost untracked parent, so without tracked files under `.claude/`, `.claude/skills/`, `sub/.claude/` and `data/queue/`, the ignored entries never arrive at `is_disposable` in the shape the file arm matches — every control would have passed while testing nothing. Each case therefore asserts the exact entry string reached the pruner first, reading the same `-z` stream the pruner consumes.

That assertion earned its place on the first run: it reported `!! .claude/skills/` instead of `!! .claude/skills/.DS_Store`, because only `.claude/rules/` had been anchored. The real repository tracks skill files, so the collapsed shape cannot occur there — the fixture was silently testing a state this repo cannot produce.

## Judgment calls

- **Two entries, not three** — see above; the third was residue, and residue gets deleted rather than permanently allowlisted.
- **`.DS_Store` is the only basename-matched entry.** It is unanchored in `.gitignore` too, so the semantics agree, and it cannot hold anything a human would miss. Everything else is full-path.
- **The allowlist will never be complete, and that is the design.** Any future `.git/info/exclude` entry re-blocks the pruner. Occasional blocking is the conservative behaviour working, not a defect — the log names the blocker so it can be judged case by case.

## Test plan

- `scripts/tests/prune-stale-worktrees-test.sh` — **26 assertions**, auto-discovered by the CI "Shell gate tests" job. `EXPECTED_PASSES` re-measured from an actual run, so a case that silently stops running fails rather than counting lower.
- Full local suite: **17/17** `scripts/tests/*-test.sh` pass. `shellcheck -S style` clean on both files.
- An **18-arm mutation harness** (not committed) confirms every guard — including all five new arms — reddens on its own case. One arm had to be re-keyed: mutating the file match to compare basenames breaks the positive control first, so it cannot discriminate N2; the regression N2 actually defends against is a listed path matched as a **suffix**, which a nested copy then satisfies.

Portability unchanged: the script targets macOS while the test runs on `ubuntu-latest`; no `stat`, no `date -d`/`-v`, no bash-4 builtins.

## Scope note — one addition beyond the plan

`.claude/rules/ci-workflows.md` gains a short subsection on the fixture-collapse trap. It is not scope creep for its own sake: this branch hit it for the **second** time (`Pastura/` in #1340, `.claude/skills/` here), it produces false-green negative controls rather than loud failures, and it cost a review round on both occasions. It is path-scoped to `scripts/**`, so it fires when someone edits a script test rather than on every session.

## Device QA

実機QA不要 — shell tooling only; no Swift, no `#if !targetEnvironment(simulator)` block, no Metal/llama.cpp path, no UI surface.

Closes #1352
