### PR TITLE
📝 docs: a split leaves a seam no shard owns

### DIFF
--- a/.claude/rules/subagent-usage.md
+++ b/.claude/rules/subagent-usage.md
@@ -62,6 +62,11 @@ budget (derived — tighten at the call site, don't edit; see the header):
 When numbers fall between soft and hard, prefer splitting. If splitting
 is impractical, see **§3. Sonnet override**.
 
+**A split leaves a seam no shard owns.** Each invocation sees only its own
+slice, so anything spanning the split — a mirrored count, a cross-reference,
+a claim one shard makes about another's files — is unreviewed by
+construction. Name the seam's owner, or add a final pass over the whole.
+
 **What exhaustion looks like.** *Not* a missing summary: review agents
 are built to emit their verdict/summary **first** under cap pressure, so
 it survives exactly when the run is truncated. Look instead for **detail


### PR DESCRIPTION
Mirrors [tyabu12/claude-kit#14](https://github.com/tyabu12/claude-kit/pull/14) — `subagent-usage.md`'s generic core is kit-canonical, reconciled one-way.

§2 tells the caller to split past the soft budget and says nothing about what splitting costs. Each shard is scoped to its own files, so anything spanning the split — a mirrored count, a cross-reference, a claim one shard makes about another's subject — is unreviewed **by construction**. Not missed: unassigned.

Four lines, in the paragraph that prescribes the split.

## Where it came from

#1336's review: 12 files against a ~8-file soft budget, split into a source half and a docs half. Both returned clean on round 2. A third pass over the whole diff found two things neither half could have:

- `CLAUDE.md`'s Reference Documents row still said "the five risk classes" and enumerated five, while the docs half had just changed `dark-mode-qa.md` to six and added class F. The source half did not read `CLAUDE.md`; the docs half read the table, not its always-loaded mirror.
- `ADR-028`'s own "(six `## Amendment` headings exist)" — the branch added the seventh, in a section neither half was looking at.

Both are the class `knowledge-layering.md` § "Rule-writing self-check" already names. The gap was not knowing to check them; it was that no shard owned them.

## Test plan

Prose-only change to a rule file. No code, no gates touched. `swiftlint` and the build are skipped by `precommit-gate-classify.sh` for a `.claude/`-only changeset, as intended.

## Device QA

実機QA不要 — documentation only, no user-facing surface.