### PR TITLE
📝 docs: reconcile the gap-list bullet from claude-kit

### DIFF
--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -112,17 +112,18 @@ A 30-second self-check prevents 1–2 extra critic / code-reviewer rounds. Motiv
 
 ### Claims you author are assertions too
 
-A **why-comment you write** asserts runtime or library behaviour as the reason a mechanism exists — the same kind of claim as the table's, but authored at implementation *or review-fix* time and executed by nobody. Reviewers check whether the *code* is correct, not whether the *stated reason* is true, so a false one ships and the next reader inherits it as fact. Three shapes, none expressible as a `Verify by` lookup:
+A **why-comment you write** asserts runtime or library behaviour as the reason a mechanism exists — the same kind of claim as the table's, but authored at implementation *or review-fix* time and executed by nobody. Reviewers check whether the *code* is correct, not whether the *stated reason* is true, so a false one ships and the next reader inherits it as fact. Four shapes, none expressible as a `Verify by` lookup:
 
 - **Why-comment on a mechanism** → delete the mechanism and run the tests. Green means the claim is false, or the tests never covered it.
 - **A detector / guard / gate** → construct the thing it claims to catch and confirm it fires. A guard's success case proves nothing; only a negative control does. Scope it to the claim it defends: a check narrower than that claim (a files-only loop behind a files-and-directories completeness claim), or one that silently skips its exemptions instead of declaring them, passes by construction. And a control whose fixture a **sibling arm** can also reach reddens for the wrong reason — read *which* message fired, not the exit code, and re-key the fixture until only the guard can reach it.
 - **A classification or count built on an earlier claim** → when you fix that claim, grep what cited it. Fixing one authored claim can *invalidate* another you authored earlier, and nothing points back at it; a concessive clause propping up a category ("it belongs here, just differently") is the tell that it already broke.
+- **A gap list — and the remedy you prescribe for it** → each is an enumeration, inheriting the blind spot of whatever it was drawn from. A residue record drawn from the section naming one *kind* of gap cannot see the other kinds, and "re-run §X" is unpayable when §X never listed half the items. Re-derive from what changed, then check the remedy actually reaches it. Two sets written in sequence also read as a **partition** — state the overlap, or the reader does the arithmetic wrong, in the direction that understates residue.
 
 **A probe's outcome gets misread in both directions.** Assert that the mutation's anchor matched — a `replace` that silently no-ops leaves the original behaviour and reads as verified. And treat a probe that stays **green** as a finding about the *fixtures*, not a redundant guard: a suite only reddens on states its fixtures build, so name the state the guard defends and confirm something constructs it before concluding anything.
 
 When a check is too expensive to run, say the cause was not isolated. A reader can act on an acknowledged gap; a wrong cause they can only inherit.
 
-Motivating incidents: PR #1152 round-1 review; PR #1299 rounds 1–3; #1312 rounds 1–4; PR #1303 rounds 1–3; PR #1314; PR #1334.
+Motivating incidents: PR #1152 round-1 review; PR #1299 rounds 1–3; #1312 rounds 1–4; PR #1303 rounds 1–3; PR #1314; PR #1334; PR #1365 / #1370.
 
 ### A rules file created mid-session never injects in that session
 


### PR DESCRIPTION
## Summary

One-way consumer-mirror reconcile (kit → Pastura). claude-kit [#15](https://github.com/tyabu12/claude-kit/pull/15) added a fourth bullet under `rules/knowledge-layering.md` § "Rule-writing self-check" → "Claims you author are assertions too":

> **A gap list — and the remedy you prescribe for it** → each is an enumeration, inheriting the blind spot of whatever it was drawn from. …

Three edits here:

1. **The bullet**, inserted after "A classification or count built on an earlier claim" and before the `**A probe's outcome…**` paragraph, reflowed to this copy's local style (one unwrapped line per bullet; kit wraps ~100 col). Byte-identical to kit otherwise, so future line-level reconciles stay clean.
2. **`Three shapes` → `Four shapes`.** The insertion falsifies the lead sentence, and this file is **always-loaded** here — a rule that contradicts itself at the point of use is worse than a missing bullet.
3. **`; PR #1365 / #1370`** appended to the existing `Motivating incidents:` line, as bare refs matching that line's own style. Kit deliberately carries no incident refs; this is the consumer copy's precedent.

## The count word is not a divergence to revert

The stale numeral came from upstream — kit #15 left `Three shapes` above four bullets — so **claude-kit [#16](https://github.com/tyabu12/claude-kit/pull/16) fixes it there**. A future reconciler diffing the two copies should not "correct" `Four` back to `Three`.

Worth naming for the record: the bullet directly above the new one is *"a classification or count built on an earlier claim → when you fix that claim, grep what cited it"*. So the miss is the exact failure that list describes, committed while extending the list. Nothing catches it — no gate counts list items against a prose numeral, and a reviewer reads the bullet being *added*, not the sentence introducing it.

## Test plan

Docs-only; no Swift touched, so the suite is zero-signal and was not run. What was checked instead, per this file's own § "Rule-writing self-check":

- **Numeral matches reality** — 4 bullets under `Four shapes`, measured on the final tree. The file's other numerals (`4 places`, `Three triggers`, `three ways`) are untouched and still accurate.
- **Canonical fidelity** — the new bullet is identical to kit `origin/main`'s modulo whitespace, verified by normalising both.
- **No staled citations** — `ADR-028.md:707` / `:1163` and `RelationshipUpdateHandlerTests.kt:34` all cite this subsection (or bullet 2) **by heading name**, never by ordinal or count.
- **`(PR #N)` claims verified** — `#1365` and `#1370` confirmed MERGED via `gh pr view` before citing, which this file's `### Apply` step demands.
- **Density** — bullets measure 25 / 101 / 55 / 94 words (`split()` per line, dash included). The new one sits below its largest sibling, far under `context-budget.md`'s "~3× its neighbours" trigger. Compacting it would have bought ~40 words and cost a permanent semantic divergence from the canonical copy.
- Rebased onto `main`; no file overlap.

## Deliberate non-changes

Everything else differing from kit is licensed local divergence and stays: the file-wide unwrapping (reflowing would be a whole-file diff with zero semantic content and would defeat line-level reconciles), the lead-sentence rephrase (every clause of kit's version is preserved), the `Motivating incidents:` line itself, and the `###` promotion of "A rules file created mid-session…".

**One genuine gap was found and deliberately left out**: kit's canonical *"a repo-tracked rule must stay self-contained"* paragraph has never been carried by this mirror. It is filed as #1372 rather than bundled — this PR's plan was scoped to the new bullet, and the pre-implementation critic endorsed that narrow scope precisely because a wider reconcile risks clobbering Pastura-specific content case by case.

## Device QA

**実機QA不要** — documentation only; no code, asset, or token is touched.

Closes #1371.
