### PR TITLE
📝 docs: pay § 2's Browse/Gallery debt, mirror kit's rule invariant, widen the shadow lint

### DIFF
--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -55,6 +55,12 @@ repo-tracked file (CLAUDE.md, CONTRIBUTING.md, ADRs, source comments,
 script header docs) is a **dead link** for everyone except the
 maintainer who wrote the memory.
 
+**This is also why a repo-tracked rule must stay self-contained** — do not
+slim a project's `.claude/rules/` down to "see the maintainer's global
+rule": that global file does not exist for other contributors or in CI.
+Global rules *add* a personal baseline; they never *replace* what a shared
+repo needs to carry itself.
+
 **Apply** — for rationale in any repo-tracked file, prefer inline summary
 + PR / issue / ADR pointer (`#410`, `ADR-007`, etc.). Memory refs are
 acceptable **only** in never-committed places (`~/.claude/CLAUDE.md`,

--- a/.claude/rules/swiftui-traps.md
+++ b/.claude/rules/swiftui-traps.md
@@ -387,7 +387,7 @@ token" but "does one read a **view** that reads it".
 
 Reference: `HighlightCardImageRenderer.render` + `HighlightShareCard` (#1070).
 
-## An occlusion layer — shadow or scrim — must not read a paired `Color.*` alias
+## An occlusion layer — shadow or scrim — must be darker than every ground it covers
 
 A shadow is an occlusion cue, not a surface, so it wants a colour that stays
 dark in **both** appearances. A paired alias inverts instead: `Color.ink`
@@ -400,11 +400,15 @@ design-system §4.3 already takes this position — `PasturaShadows.tight` /
 `.soft` carry a fixed moss-tinted `rgba(90,100,60,…)` and do not pair. The three
 ad-hoc `shadow(color:)` sites were simply written before the aliases paired.
 
-**Apply**: read `PasturaPalette.<token>.color` inside `shadow(color:)`, never
-`Color.<token>`. Same raw-palette convention as the `ImageRenderer` trap above,
-for the opposite reason — there an export needs a *chosen* appearance, here the
-cue needs *none*. A `.stroke` / `.overlay` hairline is the mirror case: it reads
-*against* the surface, so it follows the appearance and keeps the alias.
+**Apply**: read `PasturaOccluderShadows` (design-system §4.3.1) inside
+`shadow(color:)`. Never `Color.<token>` — and since #1377, **a raw
+`PasturaPalette.<token>.color` is not sufficient either** and is flagged at
+`severity: error`: dropping the alias fixes the inversion but not the direction,
+which is the #1373 defect and the whole subject of the paragraphs below. Reach
+for the raw palette only where an export needs a *chosen* appearance (the
+`ImageRenderer` trap above) — the opposite reason, since an occlusion cue needs
+*none*. A `.stroke` / `.overlay` hairline is the mirror case: it reads *against*
+the surface, so it follows the appearance and keeps the alias.
 
 **A full-bleed dimming scrim is the same trap wearing different clothes**, and
 it is louder — but it also corrects the rule above. `Color.ink.opacity(0.4)`
@@ -453,18 +457,19 @@ and `SimulationView`'s `screenBackground.opacity(0.78)`, `ResultsView`'s status
 tints — is the surface case and correctly stays paired. Do not sweep those.
 
 Enforced by the `shadow_color_occluder_family` custom SwiftLint rule — **for the
-shadow half only**. It was a denylist keyed on a leading-dot `Color.*` and so
-never saw the shape that actually shipped three times: a raw
+shadow half only**. As first written (then named `shadow_color_paired_alias`) it
+was a denylist keyed on a leading-dot `Color.*` and so never saw the shape that
+actually shipped three times: a raw
 `PasturaPalette.<lightToken>.color.opacity(…)`, fixed but above the ground.
 #1377 inverted it to an **allowlist** — a shadow tint must name
 `PasturaOccluderShadows` or `PasturaShadows`, and anything else is flagged — so
 the syntactic gap is closed.
 
 **A green run still does not mean "this shadow is dark enough."** `PasturaShadows`
-is on that allowlist while measured *above* the night ground (#1378, below), so
-the rule certifies family membership and nothing more. The scrim shape has no
-lint guard at all: one instance, no stable syntax to key on, so a rule would be
-over-fitted.
+is on that allowlist while measured *above* the night ground (#1378, in the
+consequences above), so the rule certifies family membership and nothing more.
+The scrim shape has no lint guard at all: one instance, no stable syntax to key
+on, so a rule would be over-fitted.
 
 Tests carry what lint cannot — `SimulationScrimStyleTests` and
 `PasturaOccluderShadowsTests` each assert the darker-than-every-ground

--- a/.claude/rules/swiftui-traps.md
+++ b/.claude/rules/swiftui-traps.md
@@ -452,14 +452,19 @@ occlude, or is it a surface?
 and `SimulationView`'s `screenBackground.opacity(0.78)`, `ResultsView`'s status
 tints — is the surface case and correctly stays paired. Do not sweep those.
 
-Enforced by the `shadow_color_paired_alias` custom SwiftLint rule — **for the
-paired-alias half of the shadow half only**. Its regex keys on a leading-dot
-`Color.*`, so it never saw the shape that actually shipped three times: a raw
-`PasturaPalette.<lightToken>.color.opacity(…)`, fixed but above the ground. That
-gap is open and tracked in **#1377**; until it closes, the lint passing means
-only "no paired alias", never "this shadow is dark enough". The scrim shape has
-no lint guard at all: one instance, no stable syntax to key on, so a rule would
-be over-fitted.
+Enforced by the `shadow_color_occluder_family` custom SwiftLint rule — **for the
+shadow half only**. It was a denylist keyed on a leading-dot `Color.*` and so
+never saw the shape that actually shipped three times: a raw
+`PasturaPalette.<lightToken>.color.opacity(…)`, fixed but above the ground.
+#1377 inverted it to an **allowlist** — a shadow tint must name
+`PasturaOccluderShadows` or `PasturaShadows`, and anything else is flagged — so
+the syntactic gap is closed.
+
+**A green run still does not mean "this shadow is dark enough."** `PasturaShadows`
+is on that allowlist while measured *above* the night ground (#1378, below), so
+the rule certifies family membership and nothing more. The scrim shape has no
+lint guard at all: one instance, no stable syntax to key on, so a rule would be
+over-fitted.
 
 Tests carry what lint cannot — `SimulationScrimStyleTests` and
 `PasturaOccluderShadowsTests` each assert the darker-than-every-ground

--- a/.claude/rules/swiftui-traps.md
+++ b/.claude/rules/swiftui-traps.md
@@ -266,9 +266,11 @@ file's own header says so). See ADR-028.
 sheet / overlay fill, the comparand is the **composited** backdrop — the presentation dims what is
 behind and not the surface itself, which can flip the sign. `nightPage` sits 1.099 *below*
 `nightBackground` by design and renders 1.031 *above* its own backdrop. Judge such a value against a
-device screenshot, not the pair. ADR-028 § Amendment 2026-08-05 (#1336). Sibling of § "An occlusion layer"
-below — same "what does it actually composite over" question, asked of a surface rather than an
-occluder; keep the two pointing at each other.
+device screenshot, not the pair. ADR-028 § Amendment 2026-08-05 (#1336). Sibling of
+§ "An occlusion layer ... must be darker than every ground it covers" below — same "what does it
+actually composite over" question, asked of a surface rather than an occluder; keep the two
+pointing at each other. (Quoted with an ellipsis, not truncated, so a grep for the heading finds
+this pointer too.)
 
 ## `.sheet(item:)` — pass `Optional<Model>`, never `Int: Identifiable`
 
@@ -404,7 +406,9 @@ ad-hoc `shadow(color:)` sites were simply written before the aliases paired.
 `shadow(color:)`. Never `Color.<token>` — and since #1377, **a raw
 `PasturaPalette.<token>.color` is not sufficient either** and is flagged at
 `severity: error`: dropping the alias fixes the inversion but not the direction,
-which is the #1373 defect and the whole subject of the paragraphs below. Reach
+which is the #1373 defect and the whole subject of the paragraphs below.
+(`PasturaShadows` also passes lint — that is the #1378 debt, not an
+endorsement; do not reach for it on a new ground-floating element.) Reach
 for the raw palette only where an export needs a *chosen* appearance (the
 `ImageRenderer` trap above) — the opposite reason, since an occlusion cue needs
 *none*. A `.stroke` / `.overlay` hairline is the mirror case: it reads *against*

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -132,8 +132,9 @@ custom_rules:
   # retries the negative lookahead at a position still inside the whitespace,
   # where "not PasturaShadows" is trivially true and the match succeeds.
   # Requiring one non-space character after the lookahead kills every such
-  # position — measured, not reasoned: before adding it the silence arm below
-  # was 8/8 red.
+  # position — measured, not reasoned: before adding it, linting the eight
+  # sanctioned sites was 8/8 red. The control pair is recorded in #1377's PR
+  # and ADR-028 § "What the guard does and does not certify".
   #
   # `excluded_match_kinds` rather than `match_kinds`, deliberately: the match
   # is short (`.shadow(` + `color:` + one value character), so an allowlist of
@@ -149,6 +150,14 @@ custom_rules:
   # The scrim shape has no lint guard at all — one instance, no stable syntax
   # to key on. `SimulationScrimStyleTests` / `PasturaOccluderShadowsTests`
   # carry what lint cannot.
+  #
+  # An allowlist also flags legitimate INDIRECTION, which a denylist did not: a
+  # reusable modifier taking `shadow(color: someLocal, …)` cannot name a family
+  # at the callsite. No such site exists today. When one arrives, hoist the
+  # value into `PasturaOccluderShadows` and pass the member (preferred — it also
+  # brings the tint under `PasturaOccluderShadowsTests`); only if the indirection
+  # is genuinely dynamic, `// swiftlint:disable:next shadow_color_occluder_family`
+  # with the ground it covers named in the rationale.
   shadow_color_occluder_family:
     name: "Shadow colour outside the occluder families"
     regex: '\.shadow\(\s*color:\s*(?!PasturaOccluderShadows\b|PasturaShadows\b)\S'
@@ -160,7 +169,7 @@ custom_rules:
     included:
       - 'Pastura/Pastura/.*\.swift'
     severity: error
-    message: "A shadow tint must come from a sanctioned occluder family — PasturaOccluderShadows (design-system §4.3.1), or PasturaShadows pending #1378. Anything else, including a raw PasturaPalette.<token>.color, is unchecked against the grounds it covers. See .claude/rules/swiftui-traps.md § 'An occlusion layer — shadow or scrim — must not read a paired Color.* alias'."
+    message: "A shadow tint must come from a sanctioned occluder family — PasturaOccluderShadows (design-system §4.3.1), or PasturaShadows pending #1378. Anything else, including a raw PasturaPalette.<token>.color, is unchecked against the grounds it covers. See .claude/rules/swiftui-traps.md § 'An occlusion layer — shadow or scrim — must be darker than every ground it covers'."
 
   # ADR-028 dark-mode pairing (#1284) — `.borderedProminent` fills from the
   # ambient `\.tint` with the system's own white prominent label. `RootTabView`

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -133,8 +133,9 @@ custom_rules:
   # where "not PasturaShadows" is trivially true and the match succeeds.
   # Requiring one non-space character after the lookahead kills every such
   # position — measured, not reasoned: before adding it, linting the eight
-  # sanctioned sites was 8/8 red. The control pair is recorded in #1377's PR
-  # and ADR-028 § "What the guard does and does not certify".
+  # sanctioned sites was 8/8 red. The control pair — both arms, and the two
+  # syntactic shapes this regex still does NOT reach — is recorded in ADR-028
+  # § "What the guard does and does not certify".
   #
   # `excluded_match_kinds` rather than `match_kinds`, deliberately: the match
   # is short (`.shadow(` + `color:` + one value character), so an allowlist of

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -107,35 +107,60 @@ custom_rules:
     severity: error
     message: "tryClaim/forceClaimGeneratingGuard are the private contract for acquireGenerateGuard (LlamaCppService+Lifecycle.swift). Use acquireGenerateGuard(caller:) instead — see ADR-002 §12."
 
-  # ADR-028 dark-mode pairing (#1284) — a shadow is an occlusion cue, not a
-  # surface, so its colour must be fixed in BOTH appearances. A paired
-  # `Color.*` alias inverts: `Color.mossInk` is #3D4030 in light (a correct
-  # shadow) but resolves `nightMossInk` #C6CBB1 in dark, turning the shadow
-  # into a pale halo. Silent — no diagnostic, and the light build looks right.
-  # Read `PasturaPalette.<token>.color` instead; design-system §4.3's
-  # `PasturaShadows` already fix their tint for the same reason. A `.stroke` /
-  # `.overlay` hairline is the opposite case (it reads AGAINST the surface, so
-  # it follows the appearance) and is deliberately not matched.
+  # ADR-028 dark-mode pairing (#1284, widened #1377) — a shadow is an occlusion
+  # cue, not a surface, so it must be DARKER THAN EVERY GROUND IT COVERS. The
+  # predecessor rule keyed on a leading-dot `Color.*` alias, which catches only
+  # the inverting half of that requirement: `Color.mossInk` is #3D4030 in light
+  # and resolves `nightMossInk` #C6CBB1 in dark, a pale halo. It was blind to
+  # the shape that actually shipped three times — a raw
+  # `PasturaPalette.moss.color.opacity(0.22)`, fixed in both appearances and
+  # still lighter than the #1B1D17 night ground it floated on (#1373).
   #
-  # The regex stops at the alias name, before `radius:` / `.opacity(0.22)`:
-  # `match_kinds` drops a match that spans a kind not listed, so reaching a
-  # numeric literal would make the rule fail OPEN.
+  # So this is an ALLOWLIST, not a denylist: a shadow tint must name one of the
+  # two sanctioned families, and anything else is flagged. A denylist can only
+  # ever enumerate the wrong shapes already seen.
   #
-  # `Color` is optional because the implicit-member form
-  # `.shadow(color: .mossInk.opacity(0.45))` is valid Swift and the natural
-  # thing to write; requiring the explicit type left it passing silently. The
-  # lowercase class after the dot is what keeps `PasturaPalette.` /
-  # `PasturaShadows.` — uppercase, and with no leading dot — unmatched.
-  shadow_color_paired_alias:
-    name: "Shadow colour reads a paired alias"
-    regex: '\.shadow\(\s*color:\s*(Color)?\.[a-z]'
-    match_kinds:
-      - identifier
-      - typeidentifier
+  # `PasturaShadows` is allowlisted despite NOT meeting the requirement —
+  # measured above the night ground, deferred on blast radius across its four
+  # consumers and tracked as #1378. So a green run here means "the tint comes
+  # from a sanctioned family", never "this shadow is dark enough"; the
+  # `message` is worded to claim only the former. Remove `PasturaShadows` from
+  # the lookahead when #1378 lands.
+  #
+  # The trailing `\S` is LOAD-BEARING and is not cosmetic. Without it the rule
+  # flags all eight sanctioned call sites: `\s*` backtracks, so the engine
+  # retries the negative lookahead at a position still inside the whitespace,
+  # where "not PasturaShadows" is trivially true and the match succeeds.
+  # Requiring one non-space character after the lookahead kills every such
+  # position — measured, not reasoned: before adding it the silence arm below
+  # was 8/8 red.
+  #
+  # `excluded_match_kinds` rather than `match_kinds`, deliberately: the match
+  # is short (`.shadow(` + `color:` + one value character), so an allowlist of
+  # kinds would have to anticipate exactly which kinds that span carries — and
+  # `match_kinds` drops a match spanning an unlisted kind SILENTLY, i.e. it
+  # fails OPEN. Excluding comments and strings expresses the only thing that
+  # was ever wanted (`DesignTokens.swift`'s doc comment writes
+  # `.shadow(color:radius:x:y:)`, which this regex matches) and cannot fail
+  # open on a kind nobody anticipated.
+  #
+  # A `.stroke` / `.overlay` hairline is the opposite case (it reads AGAINST
+  # the surface, so it follows the appearance) and is deliberately not matched.
+  # The scrim shape has no lint guard at all — one instance, no stable syntax
+  # to key on. `SimulationScrimStyleTests` / `PasturaOccluderShadowsTests`
+  # carry what lint cannot.
+  shadow_color_occluder_family:
+    name: "Shadow colour outside the occluder families"
+    regex: '\.shadow\(\s*color:\s*(?!PasturaOccluderShadows\b|PasturaShadows\b)\S'
+    excluded_match_kinds:
+      - comment
+      - doccomment
+      - doccomment.field
+      - string
     included:
       - 'Pastura/Pastura/.*\.swift'
     severity: error
-    message: "A shadow must be fixed in both appearances — the Color.* aliases pair, so in dark this inverts into a pale halo. Use PasturaPalette.<token>.color. See .claude/rules/swiftui-traps.md § 'An occlusion layer — shadow or scrim — must not read a paired Color.* alias'."
+    message: "A shadow tint must come from a sanctioned occluder family — PasturaOccluderShadows (design-system §4.3.1), or PasturaShadows pending #1378. Anything else, including a raw PasturaPalette.<token>.color, is unchecked against the grounds it covers. See .claude/rules/swiftui-traps.md § 'An occlusion layer — shadow or scrim — must not read a paired Color.* alias'."
 
   # ADR-028 dark-mode pairing (#1284) — `.borderedProminent` fills from the
   # ambient `\.tint` with the system's own white prominent label. `RootTabView`

--- a/Pastura/Pastura/Views/DesignTokens+OccluderShadows.swift
+++ b/Pastura/Pastura/Views/DesignTokens+OccluderShadows.swift
@@ -54,13 +54,17 @@ import SwiftUI
 ///
 /// ## Why the values are hoisted out of the view bodies
 ///
-/// They are code-review-gated only. The `shadow_color_paired_alias` SwiftLint
-/// rule fires on a leading-dot `Color.*` alias, so it never saw the shape that
-/// actually shipped here — a raw `PasturaPalette` token that is fixed but too
-/// light — and ADR-009 rules out the snapshot test that would.
-/// `PasturaOccluderShadowsTests` asserts the direction requirement and pins the
-/// geometry as a change-detector. It iterates ``all`` — keep new members in that
-/// list, or the suite silently stops covering them.
+/// Because the requirement they carry is not one lint can state. The
+/// `shadow_color_occluder_family` SwiftLint rule reaches every `shadow(color:)`
+/// tint since #1377, but it is an **allowlist over family names** — it
+/// certifies that a tint names this family, never that the value is dark enough
+/// for the ground it covers. (Its predecessor keyed on a leading-dot `Color.*`
+/// alias and never saw the shape that actually shipped here: a raw
+/// `PasturaPalette` token, fixed but too light.) ADR-009 rules out the snapshot
+/// test that would close the difference, so `PasturaOccluderShadowsTests`
+/// asserts the direction requirement and pins the geometry as a
+/// change-detector. It iterates ``all`` — keep new members in that list, or the
+/// suite silently stops covering them.
 ///
 /// The tints are written as `PasturaColorValue(hex:opacity:)` rather than
 /// built from a bare token, because that is the shape

--- a/Pastura/Pastura/Views/Simulation/SimulationScrimStyle.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationScrimStyle.swift
@@ -3,8 +3,10 @@ import SwiftUI
 /// The fill of `SimulationView`'s full-bleed loading scrim.
 ///
 /// Hoisted out of the View body for one reason: the value is code-review-gated
-/// only. The `shadow_color_paired_alias` SwiftLint rule does not reach a bare
-/// `ZStack` fill, and no test can render the overlay (ADR-009 rules out
+/// only. The `shadow_color_occluder_family` SwiftLint rule keys on
+/// `shadow(color:)` and so does not reach a bare `ZStack` fill — widening it in
+/// #1377 did not change that, and a scrim rule was refused as over-fitted at
+/// one instance. No test can render the overlay either (ADR-009 rules out
 /// snapshots), so an edit back to a paired `Color.*` alias would silently
 /// re-land the regression device QA caught in #1284 — the scrim brightening the
 /// screen in dark instead of dimming it. `SimulationScrimStyleTests` pins which

--- a/Pastura/PasturaTests/Views/PasturaOccluderShadowsTests.swift
+++ b/Pastura/PasturaTests/Views/PasturaOccluderShadowsTests.swift
@@ -23,8 +23,8 @@ import Testing
 ///
 /// Arm 2 (`geometryMatchesCodeReviewGatedValues`) is a change-detector, not a
 /// correctness check: these values are code-review-gated only (no test
-/// renders them — see `swiftui-traps.md` § "An occlusion layer ... must not
-/// read a paired `Color.*` alias"), so a failure here is not a bug. It means
+/// renders them — see `swiftui-traps.md` § "An occlusion layer ... must be
+/// darker than every ground it covers"), so a failure here is not a bug. It means
 /// the token drifted, typically in an unrelated refactor — confirm the
 /// change passed review, then update the expected value.
 @MainActor

--- a/docs/decisions/ADR-028.md
+++ b/docs/decisions/ADR-028.md
@@ -1881,9 +1881,26 @@ requires of a new rule. `match_kinds` was replaced by `excluded_match_kinds`
 rather than tuned, because the allowlist form cannot enumerate in advance which
 kinds its short match spans, and `match_kinds` fails open on an unlisted one.
 
-**The remaining gap is no longer syntactic.** `PasturaShadows` sits on the
-allowlist while measured *above* the night ground (#1378), so a green run
-certifies family membership, never darkness. `PasturaOccluderShadowsTests`
-carries the actual requirement, against a **hand-maintained** ground list: a
-future night ground darker than #0B0C0A would not be covered automatically. The
-scrim shape still has no lint guard — one instance, no stable syntax to key on.
+Its control pair, recorded here because § "The three defects, and what each says
+about the gates" above predates the widening and its violation arm is the *old*
+paired-alias shape: the rule
+fires on a raw `PasturaPalette.moss.color.opacity(0.22)` (the #1373 shape), on
+both paired-alias forms, and on an unknown local binding; it stays silent on
+`PasturaOccluderShadows`, on `PasturaShadows`, and across all 8 sanctioned call
+sites in 6 files. Two deliberate negative controls back the mechanism: stripping
+the regex's trailing `\S` turns the silence arm 8/8 **red** (`\s*` backtracks and
+the lookahead then succeeds inside the whitespace), and dropping
+`excluded_match_kinds` makes `DesignTokens.swift:156`'s
+`.shadow(color:radius:x:y:)` doc comment fire.
+
+**The remaining gap is mostly not syntactic — but "mostly" is the word.** Two
+shapes stay unreached, both measured at 0 violations against a control that
+fires on the same defect without them: an intervening comment between
+`.shadow(` and `color:`, and the `ShapeStyle` form `.shadow(.drop(color:))`.
+Neither exists in the tree today. Past those, the gap is a semantic one:
+`PasturaShadows` sits on the allowlist while measured *above* the night ground
+(#1378), so a green run certifies family membership, never darkness.
+`PasturaOccluderShadowsTests` carries the actual requirement, against a
+**hand-maintained** ground list: a future night ground darker than #0B0C0A would
+not be covered automatically. The scrim shape still has no lint guard — one
+instance, no stable syntax to key on.

--- a/docs/decisions/ADR-028.md
+++ b/docs/decisions/ADR-028.md
@@ -1650,10 +1650,14 @@ arm-dependent argument — each is a greedy `ScrollView`, so container and sub-v
 cover the same rect — which is the "fact about today's arms" #1354's own last
 commit declined to rest on when it pinned `ScenarioEditorView` regardless. § 2's
 loaded-state walk was **not** re-run on 2026-08-05, so this is owed too — and a
-re-run alone will not pay it: § 2 carries **no Browse and no GalleryScenarioDetail
-item**, so two of these four need a new entry rather than a repeat, and its
-`Results` item routes to the aggregate timeline and `ResultDetailView`, not to
-the `scope.isPushedDetail` list that also lost its inner ground.
+re-run alone would not have paid it: § 2 carried **no Browse and no
+GalleryScenarioDetail item**, so two of these four needed a new entry rather than
+a repeat, and its `Results` item routed to the aggregate timeline and
+`ResultDetailView`, not to the `scope.isPushedDetail` list that also lost its
+inner ground. #1376 wrote all three — the two entries and the missing route — so
+the checklist is now complete. **The walk itself is still owed**: writing an
+entry is not walking it, and none of these four loaded states has had a device
+pass since the relocation.
 
 **Instrument.** The reading was a **walk, not a pixel sample**: § Amendment
 2026-08-05 below records this class falling to a screenshot measurement —

--- a/docs/decisions/ADR-028.md
+++ b/docs/decisions/ADR-028.md
@@ -1480,9 +1480,17 @@ pairing.
 Defects 2 and 3 are now **mechanically** prevented by two custom SwiftLint rules,
 each verified with a control pair — a real-shaped violation it must catch, and a
 legitimate site it must stay silent on (`PasturaShadows.*.color.color`; a
-`.bordered` callsite). Both regexes stop before any numeric argument, because
-`match_kinds` drops a match spanning an unlisted kind and a regex reaching
+`.bordered` callsite). Both regexes stop short of any numeric argument:
+`match_kinds` drops a match spanning an unlisted kind, so a regex reaching
 `radius:` would fail **open**.
+
+**#1377 took the shadow rule off `match_kinds` entirely.** Once inverted to an
+allowlist, its match is too short to enumerate the kinds it spans in advance —
+and guessing wrong is the silent failure above. It uses `excluded_match_kinds`
+(comments and strings) instead, which expresses the only exclusion ever wanted
+and cannot fail open on an unanticipated kind. The `.borderedProminent` rule is
+unchanged and still keys on `match_kinds`, so "both regexes" above describes
+their shared shape at #1284, not their present ones.
 
 ### Gate 3's predicate was under-scoped, and gate 3 was recorded met against it
 
@@ -1861,12 +1869,21 @@ magnitude lower alpha" and that was wrong twice over (0.2 is 2× the card's new
 **#1378**, with the measurement, so its survival is not read as endorsement —
 the next element that floats on the ground must reach for §4.3.1, not `.tight`.
 
-### The guard that is still missing
+### What the guard does and does not certify
 
-`shadow_color_paired_alias` keys on a leading-dot `Color.*`, so it was blind to
-the shape that shipped three times and remains blind after this fix. Widening it
-to an allowlist needs the control pair this ADR requires of a new rule, plus a
-check that `match_kinds` does not fail open — tracked as **#1377**, not bundled
-here. `PasturaOccluderShadowsTests` carries the requirement in the meantime,
-against a **hand-maintained** ground list: a future night ground darker than
-#0B0C0A would not be covered automatically.
+The rule as first written — then named `shadow_color_paired_alias` — keyed on a
+leading-dot `Color.*`, so it was blind to the shape that shipped three times and
+stayed blind after this fix. **#1377 widened it** and renamed it
+`shadow_color_occluder_family`: it is now an
+allowlist — a shadow tint must name `PasturaOccluderShadows` or
+`PasturaShadows`, anything else is flagged — carrying the control pair this ADR
+requires of a new rule. `match_kinds` was replaced by `excluded_match_kinds`
+rather than tuned, because the allowlist form cannot enumerate in advance which
+kinds its short match spans, and `match_kinds` fails open on an unlisted one.
+
+**The remaining gap is no longer syntactic.** `PasturaShadows` sits on the
+allowlist while measured *above* the night ground (#1378), so a green run
+certifies family membership, never darkness. `PasturaOccluderShadowsTests`
+carries the actual requirement, against a **hand-maintained** ground list: a
+future night ground darker than #0B0C0A would not be covered automatically. The
+scrim shape still has no lint guard — one instance, no stable syntax to key on.

--- a/docs/qa/dark-mode-qa.md
+++ b/docs/qa/dark-mode-qa.md
@@ -223,10 +223,14 @@ record that it was not exercised rather than marking it passed.
 The class with the weakest automated cover, and it has now produced two defects
 rather than one. `shadow_color_occluder_family` — named `shadow_color_paired_alias`
 until #1377 — used to catch a *paired alias* and nothing else, blind to the three
-shadows that were fixed-but-lighter (#1373). #1377 inverted it to an allowlist, so
-it now reaches **every** shadow tint that does not name a sanctioned family. The scrim and the occluder family
-are guarded by `SimulationScrimStyleTests` and `PasturaOccluderShadowsTests`,
-both against hand-maintained ground lists.
+shadows that were fixed-but-lighter (#1373). #1377 inverted it to an allowlist,
+closing that gap: it reaches every `.shadow(color:` tint whose value follows the
+label directly. **Two syntactic shapes stay out of reach** — an intervening
+comment between `.shadow(` and `color:`, and the `ShapeStyle` form
+`.shadow(.drop(color:))` — both measured at 0 violations, neither present in the
+tree today. The scrim and the occluder family are guarded by
+`SimulationScrimStyleTests` and `PasturaOccluderShadowsTests`, both against
+hand-maintained ground lists.
 
 **A green lint run still says little about this class, and nothing about the
 scrim.** It certifies that a shadow tint comes from a sanctioned family — and
@@ -328,9 +332,11 @@ also *moved* the ground off the loaded sub-view onto the container, so their
 loaded states changed too: Results, Browse, ScenarioDetail and — again —
 GalleryScenarioDetail, which is in both groups. § 2 was not re-walked, and it
 carried **no Browse and no GalleryScenarioDetail item** — the two that needed a
-new entry rather than a repeat. Those entries now exist (#1376), but **writing
-them is not walking them**: all four of those relocated loaded grounds, and the
-three transient arms above, are still owed a device pass. And the pass that is
+new entry rather than a repeat — and its `Results` item routed only to the
+aggregate timeline and `ResultDetailView`, not to the `scope.isPushedDetail` list
+that also lost its inner ground. #1376 wrote all three, but **writing them is not
+walking them**: all four of those relocated loaded grounds, and the three
+transient arms above, are still owed a device pass. And the pass that is
 recorded was a walk, not a pixel sample — which is what missed the fifth defect
 twice.
 

--- a/docs/qa/dark-mode-qa.md
+++ b/docs/qa/dark-mode-qa.md
@@ -61,10 +61,12 @@ the transition flashes. `launchScreenBackground` and
 - [ ] The sky / pasture layers (`LaunchIconSky`, `LaunchIconPasture`) are
       light-grounded tiles by design — confirm they still read as one mark.
 
-## 2. Six-screen walk (gate 4)
+## 2. The loaded-state walk (gate 4)
 
 For each: does anything read as *broken* — invisible text, a light-mode slab, a
-washed-out control — as opposed to merely *different*?
+washed-out control — as opposed to merely *different*? The heading carried a
+count until 2026-08-05 and was wrong by two before anyone added anything — the
+list grows whenever a screen gains exposure, so it no longer states one.
 
 - [ ] **Home** — cards, `ActiveModelChip` (including its warning / danger states
       if reachable), scenario rows. Avatars invert through
@@ -87,7 +89,41 @@ washed-out control — as opposed to merely *different*?
       chat stream — measured ≈#2C2E2A over #1B1D17, ≈1.39 → ≈1.25. Delineation
       now rests on the material and the 1pt hairline; confirm the bars still
       read as bars.
-- [ ] **Results** — list and detail, plus the delete flow's `danger` family. The
+- [ ] **Browse** — the Search tab root. #1354 moved its ground onto the
+      container (`SharedScenariosListView`'s `.background(Color.screenBackground)`
+      wraps the `Group`, not `scenarioList`), so the **loaded** state changed
+      here too, not only the branches § 2b reaches. Then the catalog cards
+      (**class E**): each `GalleryCatalogRow` carries a `PasturaShadows.tight`
+      drop shadow and the `ScenarioArtTile` inside it carries a second — the
+      family ADR-028 measured as *lighter* than the night ground and deferred on
+      blast radius (#1378), so this is the screen where that deferral is most
+      visible. Lint is green on both by design; judge whether the cards read as
+      lifted or as haloed. Also the filter chips
+      (`+CategoryChips` / `+LanguageChips`): selected is `inkOnAccent` on
+      `mossDark`, unselected `Color.ink` on `bubbleBackground` behind a
+      `Color.rule` hairline — and each card's inline `categoryChip` is a
+      *different* pair (`mossDark` on `Color.selected`) wearing the same accent,
+      so compare the two. An engine-incompatible card is the same surfaces at
+      `incompatibleCardOpacity`; confirm it still reads as dimmed rather than as
+      absent.
+- [ ] **GalleryScenarioDetail** — reached by tapping a Browse card. Its ground
+      moved onto the container too (`GalleryScenarioDetailView`), and it is the
+      one screen in **both** of #1354's groups: a relocated loaded ground *and* a
+      newly-exposed transient arm (the `ProgressView()` covering the network
+      load). The action button — "Try this scenario" / "Update" / "Open local
+      copy" — is `PasturaPrimaryButtonStyle`, one of the five restyled in the
+      gate pass. The recommended-model section
+      (`+RecommendedModel.swift`) is the densest surface: a `Color.warning`
+      mismatch glyph over `inkSecondary` copy, and a `.bordered` switch button
+      that takes the system tint rather than a Pastura token. Toolbar carries
+      `PasturaToolbarButtonStyle(variant: .secondary)` beside `PasturaBackButton`.
+- [ ] **Results** — list and detail, plus the delete flow's `danger` family.
+      "List and detail" means the aggregate timeline and `ResultDetailView`;
+      **there is a third arm** — the pushed per-scenario list (`ResultsView`'s
+      `resultsList` under `scope.isPushedDetail`, a grouped list rather than the
+      tab root's timeline), reached from a scenario's own results entry. It is
+      the other loaded arm whose inner ground #1354 relocated, so walk it as
+      well as the timeline. The
       **detail** screen is the second class-F site: its ground must be #1B1D17
       too, same comparison against Home. Its **resume banner** is the surface
       that ground change touched — `moss.opacity(0.08)` over it, so its step
@@ -287,9 +323,12 @@ transient spinner a fast device does not hold open. At four screens the sweep
 also *moved* the ground off the loaded sub-view onto the container, so their
 loaded states changed too: Results, Browse, ScenarioDetail and — again —
 GalleryScenarioDetail, which is in both groups. § 2 was not re-walked, and it
-carries **no Browse and no GalleryScenarioDetail item**, so two of those four
-need a new § 2 entry rather than a repeat. And it was a walk, not a pixel
-sample — which is what missed the fifth defect twice.
+carried **no Browse and no GalleryScenarioDetail item** — the two that needed a
+new entry rather than a repeat. Those entries now exist (#1376), but **writing
+them is not walking them**: all four of those relocated loaded grounds, and the
+three transient arms above, are still owed a device pass. And the pass that is
+recorded was a walk, not a pixel sample — which is what missed the fifth defect
+twice.
 
 ## While you are here: skim the dark review set
 

--- a/docs/qa/dark-mode-qa.md
+++ b/docs/qa/dark-mode-qa.md
@@ -27,7 +27,7 @@ classes are:
 | B. Materials | `.ultraThinMaterial` / `.regularMaterial` / `glassEffect` re-render themselves, independently of every token underneath | 11 surfaces (12 call lines — the action bar has two OS branches), §3 |
 | C. Fixed-appearance exports | The share card and avatar palettes bypass the alias system and take `colorScheme` explicitly | `HighlightShareCard`, `SheepAvatarPalette`, `StoryShareSheet` (§4) |
 | D. Non-SwiftUI surfaces | Launch screen, splash and the UIKit nav-bar appearance proxy sit outside the token mechanism | §1 and §5 |
-| E. Occlusion layers | A shadow or scrim must be **darker than what it covers** — a paired alias inverts, and a *fixed* tint that is merely lighter than the ground brightens too. The lint rule catches only the first, and reaches the scrim shape not at all | §6 — the class that produced the fourth defect, and the seventh (#1373) |
+| E. Occlusion layers | A shadow or scrim must be **darker than what it covers** — a paired alias inverts, and a *fixed* tint that is merely lighter than the ground brightens too. Since #1377 the lint rule reaches both shadow shapes, but it certifies only that the tint names a sanctioned family — one of which is itself too light (#1378) — and it reaches the scrim shape not at all | §6 — the class that produced the fourth defect, and the seventh (#1373) |
 | F. A **rendered state** with no ground behind it | An **absent** background falls through to the system colour. Light hides it (#FFFFFF vs #FCFAF4); dark does not (#000000 vs #1B1D17). Nothing greps for a missing modifier — and the question is a layout one ("does every branch have a ground behind it"), not a syntactic one, so no gate is available either | §2 — the whole class is swept as of #1354; **walk the loading / empty / error branch of a screen, not just its loaded state**. Presented sheets are out of class — see the note under the table |
 
 Everything else is a paired token doing what it was designed to do. Look at it,
@@ -221,13 +221,17 @@ record that it was not exercised rather than marking it passed.
 ## 6. Occlusion layers (class E)
 
 The class with the weakest automated cover, and it has now produced two defects
-rather than one. `shadow_color_paired_alias` catches a *paired alias* and
-nothing else — it was blind to the three shadows that were fixed-but-lighter
-(#1373), and remains blind after that fix; widening it is tracked in **#1377**.
-The scrim and the occluder family are guarded by `SimulationScrimStyleTests` and
-`PasturaOccluderShadowsTests`, both against hand-maintained ground lists.
+rather than one. `shadow_color_occluder_family` used to catch a *paired alias*
+and nothing else — blind to the three shadows that were fixed-but-lighter
+(#1373). #1377 inverted it to an allowlist, so it now reaches **every** shadow
+tint that does not name a sanctioned family. The scrim and the occluder family
+are guarded by `SimulationScrimStyleTests` and `PasturaOccluderShadowsTests`,
+both against hand-maintained ground lists.
 
-**A green lint run says nothing about this class.** Walk it.
+**A green lint run still says little about this class, and nothing about the
+scrim.** It certifies that a shadow tint comes from a sanctioned family — and
+`PasturaShadows`, one of the two, is itself measured above the night ground
+(#1378). The scrim has no lint guard at all. Walk it.
 
 - [ ] **Model-load scrim** — start a simulation and watch the wait overlay. The
       background behind the card must be **darker** than the surrounding UI, not

--- a/docs/qa/dark-mode-qa.md
+++ b/docs/qa/dark-mode-qa.md
@@ -221,10 +221,10 @@ record that it was not exercised rather than marking it passed.
 ## 6. Occlusion layers (class E)
 
 The class with the weakest automated cover, and it has now produced two defects
-rather than one. `shadow_color_occluder_family` used to catch a *paired alias*
-and nothing else — blind to the three shadows that were fixed-but-lighter
-(#1373). #1377 inverted it to an allowlist, so it now reaches **every** shadow
-tint that does not name a sanctioned family. The scrim and the occluder family
+rather than one. `shadow_color_occluder_family` — named `shadow_color_paired_alias`
+until #1377 — used to catch a *paired alias* and nothing else, blind to the three
+shadows that were fixed-but-lighter (#1373). #1377 inverted it to an allowlist, so
+it now reaches **every** shadow tint that does not name a sanctioned family. The scrim and the occluder family
 are guarded by `SimulationScrimStyleTests` and `PasturaOccluderShadowsTests`,
 both against hand-maintained ground lists.
 


### PR DESCRIPTION
## Summary

Three ADR-028 follow-ups, bundled because they overlap in `docs/qa/dark-mode-qa.md` and `docs/decisions/ADR-028.md` — split across PRs, one side would read stale between merges.

- **#1372** — `.claude/rules/knowledge-layering.md` never carried claude-kit's "a repo-tracked rule must stay self-contained" paragraph. It is the invariant that explains this file's own shape: why Pastura keeps a full copy rather than a stub pointing at the maintainer's global `~/.claude/rules/`. Word-identical to kit `origin/main`, reflowed to the section's width.
- **#1376** — § 2 of the dark-mode QA walk had no Browse and no GalleryScenarioDetail entry, so a reader paying the § 2 debt would have believed it discharged while two of #1354's four relocated grounds were never enumerated. Both entries added, derived from each screen's actual composition. The heading's numeral was wrong by two before this change and now carries no count. The `Results` item names the third loaded arm it was missing.
- **#1377** — the shadow lint rule was a denylist keyed on a leading-dot `Color.*`, blind to the fixed-but-too-light shape #1373 found at three sites. Inverted to an occluder-family allowlist, renamed `shadow_color_paired_alias` → `shadow_color_occluder_family`.

## Control pair (#1377)

ADR-028 requires a new lint rule to ship with a verified control pair. Mutations are applied to an **existing** call site in place, not a new fixture file — a file added under `Pastura/Pastura/` auto-joins the Xcode synchronized group and would be compiled. Each probe asserts its anchor matched before linting, and asserts the emitted line **names the rule identifier** rather than reading the exit code.

```
--- positive controls (rule must fire, by identifier)
PASS  fires   #1373 shape: raw fixed-but-light palette token
PASS  fires   predecessor shape: implicit-member paired alias
PASS  fires   predecessor shape: explicit paired alias
PASS  fires   unknown local binding
--- negative controls (rule must stay silent)
PASS  silent  sanctioned: PasturaShadows
PASS  silent  sanctioned: PasturaOccluderShadows
--- silence arm: all 8 sanctioned call sites, 6 files
PASS  all 8 silent
--- comment exclusion: DesignTokens.swift's '.shadow(color:radius:x:y:)' doc comment
PASS  doc comment silent

ALL CONTROLS PASS
```

The silence arm covers **8 call sites across 6 files**. #1377's acceptance wording ("four `PasturaShadows` consumers … three `PasturaOccluderShadows` consumers") mixes files with call sites — `PasturaShadows` has 4 consumer *files* but 5 call sites, so the checkbox is satisfied by 8, not 7.

### Two things the controls found that reasoning did not

**The trailing `\S` is load-bearing.** The proposed regex in the issue was `\.shadow\(\s*color:\s*(?!PasturaOccluderShadows|PasturaShadows)`. That flags **all eight sanctioned sites**: `\s*` backtracks, so the engine retries the negative lookahead at a position still inside the whitespace, where "not `PasturaShadows`" is trivially true. Requiring one non-space character after the lookahead kills every such position. The silence arm caught this at 8/8 red.

**`match_kinds` is replaced, not tuned.** The issue asked for `match_kinds` to be verified not to fail open. Once inverted, the match is too short to enumerate its kinds in advance — and guessing wrong is exactly the silent failure. It now uses `excluded_match_kinds` (comments, strings), which expresses the only exclusion ever wanted and cannot fail open on an unanticipated kind. Verified load-bearing by removing it: `DesignTokens.swift:156`'s `.shadow(color:radius:x:y:)` doc comment then fires.

### What the rule does *not* certify

Two things, and the docs now say both.

**Semantically** — `PasturaShadows` is on the allowlist while ADR-028 measures it *above* the night ground (deferred on blast radius as **#1378**), covering 5 of the 8 sanctioned sites. So a green run means "the tint names a sanctioned family", never "this shadow is dark enough". The `message:` and every reconciled passage claim only the former, and the config carries a note to drop `PasturaShadows` from the lookahead when #1378 lands.

**Syntactically** — two shapes stay unreached, both measured at 0 violations against a control that fires on the same defect without them, and neither present in the tree today:

```swift
.shadow(
  // an intervening comment
  color: Color.mossInk, radius: 6                                  // unreached
)
.fill(Color.red.shadow(.drop(color: Color.mossInk, radius: 2)))    // ShapeStyle form, unreached
```

The first draft of this PR claimed the rule reaches "**every** shadow tint that does not name a sanctioned family" and that "the remaining gap is no longer syntactic". Code review falsified both by negative control; the sentences whose job is to calibrate a green run now name the residuals instead.

## Reconcile completeness (#1377)

Swept two ways, because a grep on the old key is blind by construction to prose that describes the rule's reach without naming it:

- **Old-key grep** — `shadow_color_paired_alias` now appears once, in ADR-028, explicitly introduced as the predecessor name in the same sentence that records the rename.
- **Semantic sweep** (`leading-dot`, `catches only`, `blind to`, `green lint`, `no lint guard`, …) — this is what found `ADR-028.md:1483`, which asserted that **both** custom regexes stop short of a numeric argument *because of* `match_kinds`. That goes false for one of the two. The key-shaped grep could not have reached it.

Seven sites reconciled: `.claude/rules/swiftui-traps.md`, `docs/qa/dark-mode-qa.md` (class-E table row + § 6), `docs/decisions/ADR-028.md` (the `### The guard that is still missing` heading — renamed, and confirmed uncited elsewhere — plus its body and the `match_kinds` paragraph), `DesignTokens+OccluderShadows.swift`, `SimulationScrimStyle.swift`.

**Neither sweep was sufficient, and code review found the gap.** `swiftui-traps.md`'s `**Apply**` directive still read *"read `PasturaPalette.<token>.color` inside `shadow(color:)`"* — the exact shape the widened rule flags at `severity: error`, on the imperative line of the very section the lint `message:` points a flagged contributor at. The old-key grep could not see it (no key named) and neither could the semantic sweep, which searched for prose describing the **rule**; this passage states the **convention** and never mentions lint. Fixed, and the corrected directive was verified against the rule rather than only read.

The same drift had reached the section heading, which named only the predecessor's predicate. Renamed to the requirement the section's own conclusion already states — `An occlusion layer — shadow or scrim — must be darker than every ground it covers` — with all **three** citations updated: the lint `message:`, the short-form sibling pointer at `swiftui-traps.md:269`, and `PasturaOccluderShadowsTests.swift:26`. (A grep on the full heading text finds only the first; the other two quote it elided or partially.)

## Claims this PR falsifies, corrected in the same commits

Adding the two § 2 entries makes two repo-tracked sentences false. Both are rewritten to preserve the debt rather than discharge it — **the entries are written, not walked**:

- `docs/qa/dark-mode-qa.md`'s "Record of the gate-4 / gate-5 pass"
- `docs/decisions/ADR-028.md` gap 2 (in-place factual correction; the decision is unchanged, so CLAUDE.md's editability window applies rather than an Amendment)

Neither Browse nor GalleryScenarioDetail appears in § 3's material table, so the issue's "point at § 3 rather than restate" cross-check resolves to no pointer — recorded here so the omission does not read as a miss.

Citations in the new prose use **#1354**, not #1365: the PR number appears zero times in `dark-mode-qa.md`, `ADR-028.md` and `swiftui-traps.md`, while #1354 appears 5 and 6 times for the same sweep. New prose citing #1365 beside § 2b's #1354 would read as two different changes.

## Test plan

- `swiftlint lint --quiet --strict --config .swiftlint.yml --no-cache` over the whole tree — green.
- Control pair above — all arms pass, including two deliberate negative controls (regex without `\S`; config without `excluded_match_kinds`).
- `scripts/xcodebuild.sh test -only-testing PasturaTests/PasturaOccluderShadowsTests -only-testing PasturaTests/SimulationScrimStyleTests` — `TEST SUCCEEDED`, 5 tests in 2 suites. These are the suites that guard the tokens whose doc comments changed.
- `xcodebuild build` via the pre-commit hook — green.
- **The full suite was not run.** The only Swift changes are doc comments; no behaviour changed, the build passes, and the two directly-related suites pass, so a full local run is zero-signal here. CI runs it as usual.
- Two Opus `code-reviewer` passes. **Round 1: FAIL** — one Critical (the `**Apply**` directive above), a Warning and four Suggestions; all six accepted and fixed. **Round 2: PASS** — 0 Critical, with a Warning (the over-broad reach claim above) and four Suggestions, all also fixed. Both rounds independently reproduced the control pair and the two negative controls rather than reading the prose.
- One self-caught error worth recording: a fix in round 1 introduced a cross-reference to `§ "Mechanical prevention"`, a heading that does not exist (the real one is `§ "The three defects, and what each says about the gates"`). Caught by the pre-commit grep that `knowledge-layering.md` § "Rule-writing self-check" prescribes for `§"Heading"` references — a reminder that a cross-reference you *author* is an assertion too.

Every symbol named in the new § 2 prose was grep-verified against source before commit, and § 2's item count (10) matches the heading, which no longer states one. § 2b's four entries are untouched.

## Device QA

**実機QA不要** for this PR — it is documentation, a lint config, and two doc comments; no rendered surface changes.

But note what it *writes*: § 2 now carries two entries that have never been walked, and the docs say so explicitly. The device pass for all four relocated loaded grounds (Results, Browse, ScenarioDetail, GalleryScenarioDetail) remains owed and is not discharged here.

## Context-economy

**Context-economy: kept 3 paragraphs (+6 always-loaded, +31 path-scoped), relocated the mechanism detail to `.swiftlint.yml`, dropped 0 — the always-loaded addition is the invariant governing how every `.claude/rules/` file may be compacted, and the path-scoped additions are what a reader acts on when deciding whether lint covers a new occluder.**

Per-paragraph, through `context-budget.md`'s classifier:

- **Keep** — `.claude/rules/knowledge-layering.md` **+6 always-loaded**: kit-canonical, and the one paragraph that answers "can we slim this file to a pointer at the maintainer's global rule?" — the next decision it fires on. Lead claim + the reason, no enumeration.
- **Keep** — `.claude/rules/swiftui-traps.md` **+31 path-scoped** (loads only on a `Views/` / `App/` read): the `**Apply**` rewrite is the imperative line the lint `message:` routes a flagged contributor to — this PR exists partly because it had gone false — and the reach/certification paragraph is what stops the next reader treating a green run as "dark enough". Both are lead-claim-plus-pointer.
- **Relocate, not add** — the regex backtracking, the `match_kinds` fail-open reasoning, and the indirection escape hatch went into `.swiftlint.yml`'s block comment, which loads only when that file is read. None of it entered an always-loaded rule.
- **Drop** — none. The control-pair arms and the measured residual shapes are recorded in ADR-028 and this PR body (on-demand), not in a rule.

Closes #1376
Closes #1372
Closes #1377
