### PR TITLE
✨ feat: highlight section in GalleryScenarioDetailView (ADR-029)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,12 @@ data/factory/audit-digest.md
 data/queue/digest.md
 data/factory/lessons-inbox.md
 
+# Harness transcripts backing gallery highlights (ADR-029) — local-only by
+# decision: the pre-commit human sign-off is the sole durable record of a
+# highlight's provenance (#1384), so the JSONLs referenced by each
+# highlight's source.run_id stay out of the repo.
+data/highlight-runs/
+
 # /model-eval raw run logs and scorecard journal — local-only, same
 # untracked-output-channel rationale as the scenario-factory/-refine block
 # above (the skill never commits or pushes; a stray write stays a dirty

--- a/Pastura/Pastura/App/Community/Gallery/GalleryHighlightLoader.swift
+++ b/Pastura/Pastura/App/Community/Gallery/GalleryHighlightLoader.swift
@@ -1,0 +1,130 @@
+import Foundation
+import OSLog
+
+/// Loads and verifies a gallery scenario's curated highlight (ADR-029).
+///
+/// Deliberately a **separate, detail-screen-scoped** loader rather than a
+/// method on ``SharedScenariosViewModel``: that view model backs both the
+/// Browse list and the detail screen, and its `load()` gates the whole
+/// detail screen behind a spinner. A highlight is a decorative enrichment —
+/// it must never sit on that critical path, must never delay or fail the
+/// screen, and its lifetime is one detail-screen appearance.
+///
+/// Every verification failure hides the section (``highlight`` stays `nil`)
+/// and logs one `.info` line naming the failed check — ADR-029 Decision 4:
+/// a security warning the user cannot act on is worse than absence, but the
+/// failure must not be silent to developers.
+@Observable
+@MainActor
+final class GalleryHighlightLoader {
+
+  /// The verified highlight to render, or `nil` for "show nothing" — which
+  /// covers not-yet-loaded, no highlight declared, and every verification
+  /// failure alike. The view cannot (and must not) distinguish them.
+  private(set) var highlight: GalleryHighlight?
+
+  /// The only `schema_version` this build knows how to render. A newer file
+  /// is hidden rather than best-effort rendered (ADR-029 Decision 4).
+  static let supportedSchemaVersion = 1
+
+  private let galleryService: any GalleryService
+
+  private static let logger = Logger(
+    subsystem: "app.pastura.Pastura", category: "GalleryHighlight")
+
+  init(galleryService: any GalleryService) {
+    self.galleryService = galleryService
+  }
+
+  /// Fetches, verifies, and publishes the highlight for `scenario`.
+  ///
+  /// Safe to call repeatedly (driven by `.task(id:)` from the detail view):
+  /// state is reset on entry so a second call never leaves a previous
+  /// scenario's highlight on screen.
+  func load(for scenario: GalleryScenario) async {
+    highlight = nil
+
+    guard let url = scenario.highlightURL, let expectedHash = scenario.highlightSHA256 else {
+      // Both absent is the ordinary "no highlight" case — silent, no log.
+      // Exactly one present means the index violated the both-or-neither
+      // pairing the repo-side gate enforces, i.e. a tampered or broken
+      // index: hide and say so.
+      if scenario.highlightURL != nil || scenario.highlightSHA256 != nil {
+        log(check: "half_pair", scenarioID: scenario.id)
+      }
+      return
+    }
+
+    let data: Data
+    do {
+      data = try await galleryService.fetchHighlightData(
+        from: url, expectedSHA256: expectedHash)
+    } catch {
+      // Navigating away cancels the fetch; that is not a verification
+      // failure, so it must not spam the log with `fetch_failed`.
+      guard !isCancellation(error) else { return }
+      log(check: checkName(for: error), scenarioID: scenario.id)
+      return
+    }
+
+    // The fetch above is the only suspension point, so one post-`await`
+    // cancellation check covers the whole remaining (synchronous) funnel.
+    guard !Task.isCancelled else { return }
+
+    let decoded: GalleryHighlight
+    do {
+      decoded = try JSONDecoder().decode(GalleryHighlight.self, from: data)
+    } catch {
+      log(check: "unparseable", scenarioID: scenario.id)
+      return
+    }
+
+    guard decoded.schemaVersion == Self.supportedSchemaVersion else {
+      log(check: "unknown_schema_version", scenarioID: scenario.id)
+      return
+    }
+
+    // An *absent* `content_filter_applied` key already failed the decode
+    // above — the model declares it non-optional precisely so a malformed
+    // file cannot pass as audited. This guard covers an explicit `false`.
+    guard decoded.contentFilterApplied else {
+      log(check: "content_filter_not_attested", scenarioID: scenario.id)
+      return
+    }
+
+    // The schema caps the excerpt at 8 entries but has no floor; an empty
+    // section would render as a titled void.
+    guard !decoded.excerpt.isEmpty else {
+      log(check: "empty_excerpt", scenarioID: scenario.id)
+      return
+    }
+
+    highlight = decoded
+  }
+
+  // MARK: - Private
+
+  private func checkName(for error: Error) -> String {
+    guard let serviceError = error as? GalleryServiceError else { return "fetch_failed" }
+    switch serviceError {
+    case .hashMismatch: return "hash_mismatch"
+    case .responseTooLarge: return "size_limit"
+    case .invalidResponse, .unexpectedStatus, .corruptedCache: return "fetch_failed"
+    }
+  }
+
+  private func isCancellation(_ error: Error) -> Bool {
+    if error is CancellationError { return true }
+    if let urlError = error as? URLError, urlError.code == .cancelled { return true }
+    return false
+  }
+
+  /// Both interpolations are `.public` by design: the check name is a
+  /// compile-time constant from this file, and a gallery scenario id is a
+  /// public catalog identifier — not user content. Highlight *content* is
+  /// never logged.
+  private func log(check: String, scenarioID: String) {
+    Self.logger.info(
+      "highlight hidden: check=\(check, privacy: .public) scenario=\(scenarioID, privacy: .public)")
+  }
+}

--- a/Pastura/Pastura/App/Community/Gallery/GalleryService.swift
+++ b/Pastura/Pastura/App/Community/Gallery/GalleryService.swift
@@ -34,6 +34,13 @@ nonisolated public protocol GalleryService: Sendable {
   /// matches `expectedSHA256` (lowercase hex). Throws
   /// `GalleryServiceError.hashMismatch` on mismatch.
   func fetchScenarioYAML(from url: URL, expectedSHA256: String) async throws -> String
+
+  /// Downloads a highlight excerpt file from `url`, verifying the bytes'
+  /// SHA-256 matches `expectedSHA256` (lowercase hex). Throws
+  /// `GalleryServiceError.hashMismatch` on mismatch. Returns the raw
+  /// verified bytes — decoding into `GalleryHighlight` is the caller's job,
+  /// so a parse failure can be distinguished from a fetch failure.
+  func fetchHighlightData(from url: URL, expectedSHA256: String) async throws -> Data
 }
 
 /// Errors produced by conforming `GalleryService` implementations.

--- a/Pastura/Pastura/App/Community/Gallery/URLSessionGalleryService.swift
+++ b/Pastura/Pastura/App/Community/Gallery/URLSessionGalleryService.swift
@@ -27,6 +27,11 @@ public final class URLSessionGalleryService: NSObject, GalleryService, @unchecke
   /// Maximum accepted size of a single scenario YAML, in bytes.
   public static let yamlSizeLimit = 262_144  // 256 KiB
 
+  /// Maximum accepted size of a single highlight excerpt file, in bytes.
+  /// An excerpt is a few KB; this is a defense bound, not a design target
+  /// (ADR-029 Decision 4).
+  public static let highlightSizeLimit = 65_536  // 64 KiB
+
   /// Default remote URL for the gallery index.
   ///
   /// In Debug builds, the `PASTURA_GALLERY_BASE_URL` environment variable
@@ -179,6 +184,29 @@ public final class URLSessionGalleryService: NSObject, GalleryService, @unchecke
       throw GalleryServiceError.invalidResponse
     }
     return yaml
+  }
+
+  public func fetchHighlightData(from url: URL, expectedSHA256: String) async throws -> Data {
+    // Resolve against `indexURL` so `gallery.json` can reference siblings
+    // with relative paths (e.g. `"highlight_url": "highlights/asch_v1.json"`).
+    // Absolute URLs pass through untouched because URL resolution prefers
+    // the string's own scheme when present.
+    let resolved = URL(string: url.relativeString, relativeTo: indexURL) ?? url
+    var request = URLRequest(url: resolved)
+    request.httpMethod = "GET"
+    let (data, response) = try await performDataRequest(request, limit: Self.highlightSizeLimit)
+    guard let http = response as? HTTPURLResponse else {
+      throw GalleryServiceError.invalidResponse
+    }
+    guard http.statusCode == 200 else {
+      throw GalleryServiceError.unexpectedStatus(http.statusCode)
+    }
+    let actual = Self.sha256Hex(data)
+    let expected = expectedSHA256.lowercased()
+    guard actual == expected else {
+      throw GalleryServiceError.hashMismatch(expected: expected, actual: actual)
+    }
+    return data
   }
 
   // MARK: - Private

--- a/Pastura/Pastura/App/Community/Gallery/URLSessionGalleryService.swift
+++ b/Pastura/Pastura/App/Community/Gallery/URLSessionGalleryService.swift
@@ -161,25 +161,8 @@ public final class URLSessionGalleryService: NSObject, GalleryService, @unchecke
   }
 
   public func fetchScenarioYAML(from url: URL, expectedSHA256: String) async throws -> String {
-    // Resolve against `indexURL` so `gallery.json` can reference siblings
-    // with relative paths (e.g. `"yaml_url": "asch_v1.yaml"`). Absolute
-    // URLs pass through untouched because URL resolution prefers the
-    // string's own scheme when present.
-    let resolved = URL(string: url.relativeString, relativeTo: indexURL) ?? url
-    var request = URLRequest(url: resolved)
-    request.httpMethod = "GET"
-    let (data, response) = try await performDataRequest(request, limit: Self.yamlSizeLimit)
-    guard let http = response as? HTTPURLResponse else {
-      throw GalleryServiceError.invalidResponse
-    }
-    guard http.statusCode == 200 else {
-      throw GalleryServiceError.unexpectedStatus(http.statusCode)
-    }
-    let actual = Self.sha256Hex(data)
-    let expected = expectedSHA256.lowercased()
-    guard actual == expected else {
-      throw GalleryServiceError.hashMismatch(expected: expected, actual: actual)
-    }
+    let data = try await fetchVerifiedBytes(
+      from: url, expectedSHA256: expectedSHA256, limit: Self.yamlSizeLimit)
     guard let yaml = String(data: data, encoding: .utf8) else {
       throw GalleryServiceError.invalidResponse
     }
@@ -187,14 +170,25 @@ public final class URLSessionGalleryService: NSObject, GalleryService, @unchecke
   }
 
   public func fetchHighlightData(from url: URL, expectedSHA256: String) async throws -> Data {
-    // Resolve against `indexURL` so `gallery.json` can reference siblings
-    // with relative paths (e.g. `"highlight_url": "highlights/asch_v1.json"`).
-    // Absolute URLs pass through untouched because URL resolution prefers
-    // the string's own scheme when present.
+    try await fetchVerifiedBytes(
+      from: url, expectedSHA256: expectedSHA256, limit: Self.highlightSizeLimit)
+  }
+
+  /// Shared body of the two per-entry artifact fetches: size-limited GET +
+  /// SHA-256 verification against the index-declared hash.
+  ///
+  /// Resolves `url` against `indexURL` so `gallery.json` can reference
+  /// siblings with relative paths (e.g. `"yaml_url": "asch_v1.yaml"`,
+  /// `"highlight_url": "highlights/asch_v1.json"`). Absolute URLs pass
+  /// through untouched because URL resolution prefers the string's own
+  /// scheme when present.
+  private func fetchVerifiedBytes(
+    from url: URL, expectedSHA256: String, limit: Int
+  ) async throws -> Data {
     let resolved = URL(string: url.relativeString, relativeTo: indexURL) ?? url
     var request = URLRequest(url: resolved)
     request.httpMethod = "GET"
-    let (data, response) = try await performDataRequest(request, limit: Self.highlightSizeLimit)
+    let (data, response) = try await performDataRequest(request, limit: limit)
     guard let http = response as? HTTPURLResponse else {
       throw GalleryServiceError.invalidResponse
     }

--- a/Pastura/Pastura/App/UITestSupport/StubGalleryService.swift
+++ b/Pastura/Pastura/App/UITestSupport/StubGalleryService.swift
@@ -57,6 +57,12 @@
       }
       return yaml
     }
+
+    public func fetchHighlightData(from url: URL, expectedSHA256: String) async throws -> Data {
+      // No UI test flow exercises highlights yet — no network access, so
+      // this always fails like an unfetchable URL.
+      throw GalleryServiceError.unexpectedStatus(404)
+    }
   }
 
   // MARK: - UI test fixture

--- a/Pastura/Pastura/Models/GalleryHighlight.swift
+++ b/Pastura/Pastura/Models/GalleryHighlight.swift
@@ -1,0 +1,197 @@
+import Foundation
+
+/// A curated, spoiler-safe excerpt of a gallery scenario's run (ADR-029).
+///
+/// Decodes one `docs/gallery/highlights/<id>.json` file, fetched by the app
+/// only when the detail screen shows (no cache, unconditional hash-verified
+/// fetch — ADR-029 Decision 4). All fields are **required**: `schema_version`
+/// 1 pins the exact shape, and the feature's fail-closed posture means a
+/// malformed or partial file must throw at decode time so the caller hides
+/// the section, rather than silently rendering a degraded one.
+nonisolated public struct GalleryHighlight: Codable, Equatable, Sendable {
+  /// Schema version of this highlight file (currently `1`). Not validated
+  /// against a known set here — an unrecognised version is still decodable
+  /// structurally; the repo-side gate is what pins the shape per version.
+  public let schemaVersion: Int
+
+  /// Identifies which gallery scenario (and which pinned YAML content) this
+  /// highlight was generated from.
+  public let scenarioRef: GalleryHighlightScenarioRef
+
+  /// Provenance of the harness run this highlight was extracted from.
+  public let source: GalleryHighlightSource
+
+  /// Ordered, spoiler-filtered excerpt of persona utterances (ADR-029
+  /// Decision 3). Schema-capped at 8 entries by the generation pipeline —
+  /// not re-enforced at decode time.
+  public let excerpt: [GalleryHighlightExcerptEntry]
+
+  /// A snippet of the scenario's backing YAML, shown alongside the excerpt
+  /// to invite editing.
+  public let yamlHook: GalleryHighlightYAMLHook
+
+  /// A single spoiler-free line teasing the scenario's outcome.
+  public let teaser: String
+
+  /// `true` if the excerpt draws from later than the default round window
+  /// (rounds 1 through ⌈N/2⌉) — an explicit, auditable override recorded by
+  /// the curator (ADR-029 Decision 3, "Position rule").
+  public let windowOverride: Bool
+
+  /// Attests the published strings (`excerpt[].text`, `yamlHook`, `teaser`)
+  /// passed the `ContentBlocklist` audit at generation time (ADR-029
+  /// Decision 2). Required (not optional-defaulting-to-false) and the
+  /// caller must additionally check it is `true` before rendering: a
+  /// missing key must fail the *decode*, not silently attest a pass, per
+  /// the ADR-029 Decision 4 fail-closed policy — a lenient default here
+  /// would let a malformed file through as if it had been audited.
+  public let contentFilterApplied: Bool
+
+  public init(
+    schemaVersion: Int,
+    scenarioRef: GalleryHighlightScenarioRef,
+    source: GalleryHighlightSource,
+    excerpt: [GalleryHighlightExcerptEntry],
+    yamlHook: GalleryHighlightYAMLHook,
+    teaser: String,
+    windowOverride: Bool,
+    contentFilterApplied: Bool
+  ) {
+    self.schemaVersion = schemaVersion
+    self.scenarioRef = scenarioRef
+    self.source = source
+    self.excerpt = excerpt
+    self.yamlHook = yamlHook
+    self.teaser = teaser
+    self.windowOverride = windowOverride
+    self.contentFilterApplied = contentFilterApplied
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case schemaVersion = "schema_version"
+    case scenarioRef = "scenario_ref"
+    case source
+    case excerpt
+    case yamlHook = "yaml_hook"
+    case teaser
+    case windowOverride = "window_override"
+    case contentFilterApplied = "content_filter_applied"
+  }
+}
+
+/// Pins this highlight to the exact gallery scenario + YAML content it was
+/// extracted from.
+nonisolated public struct GalleryHighlightScenarioRef: Codable, Equatable, Sendable {
+  /// The gallery scenario's canonical identifier (matches
+  /// ``GalleryScenario/id``).
+  public let id: String
+
+  /// SHA-256 of the backing YAML this highlight was generated from.
+  /// Editing the YAML obligates regenerating (or deleting) the highlight
+  /// — enforced by the repo-side gate, not re-checked by the app.
+  public let yamlSHA256: String
+
+  public init(id: String, yamlSHA256: String) {
+    self.id = id
+    self.yamlSHA256 = yamlSHA256
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case id
+    case yamlSHA256 = "yaml_sha256"
+  }
+}
+
+/// Provenance of the pastura-harness run a highlight was extracted from.
+nonisolated public struct GalleryHighlightSource: Codable, Equatable, Sendable {
+  /// Identifier of the LLM model used for the run.
+  public let model: String
+
+  /// The harness run's identifier.
+  public let runID: String
+
+  /// ISO 8601 date-only string (e.g. `"2026-08-06"`) the run was
+  /// generated on. Kept as `String` for the same reason as
+  /// ``GalleryScenario/addedAt``.
+  public let generatedAt: String
+
+  public init(model: String, runID: String, generatedAt: String) {
+    self.model = model
+    self.runID = runID
+    self.generatedAt = generatedAt
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case model
+    case runID = "run_id"
+    case generatedAt = "generated_at"
+  }
+}
+
+/// One spoiler-eligible persona utterance in the excerpt (ADR-029
+/// Decision 3 — `speak_all` / `speak_each` output, `statement` field
+/// only).
+nonisolated public struct GalleryHighlightExcerptEntry: Codable, Equatable, Sendable {
+  /// Display name of the persona who spoke this line.
+  public let agent: String
+
+  /// 1-based round number the utterance occurred in.
+  public let round: Int
+
+  /// Raw phase-type value the utterance came from (e.g. `"speak_each"`).
+  /// Kept as `String` rather than `PhaseType` for the same forward-compat
+  /// reason as ``GalleryScenario/phases``.
+  public let phase: String
+
+  /// Index of this phase within its round's phase list — the value the
+  /// repo-side gate checks against the entry's `phases` list to enforce
+  /// the within-round spoiler bound.
+  public let phaseIndex: Int
+
+  /// Which field of the phase's output this excerpt was drawn from
+  /// (currently always `"statement"` — the Decision 1 allowlist).
+  public let sourceField: String
+
+  /// The excerpted line itself.
+  public let text: String
+
+  public init(
+    agent: String,
+    round: Int,
+    phase: String,
+    phaseIndex: Int,
+    sourceField: String,
+    text: String
+  ) {
+    self.agent = agent
+    self.round = round
+    self.phase = phase
+    self.phaseIndex = phaseIndex
+    self.sourceField = sourceField
+    self.text = text
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case agent
+    case round
+    case phase
+    case phaseIndex = "phase_index"
+    case sourceField = "source_field"
+    case text
+  }
+}
+
+/// A snippet of the scenario's backing YAML shown alongside the excerpt,
+/// inviting the reader to open and edit it in-app.
+nonisolated public struct GalleryHighlightYAMLHook: Codable, Equatable, Sendable {
+  /// The YAML fragment itself (e.g. one persona's `description:` block).
+  public let fragment: String
+
+  /// Human-readable caption explaining what to try editing.
+  public let caption: String
+
+  public init(fragment: String, caption: String) {
+    self.fragment = fragment
+    self.caption = caption
+  }
+}

--- a/Pastura/Pastura/Models/GalleryHighlight.swift
+++ b/Pastura/Pastura/Models/GalleryHighlight.swift
@@ -194,4 +194,11 @@ nonisolated public struct GalleryHighlightYAMLHook: Codable, Equatable, Sendable
     self.fragment = fragment
     self.caption = caption
   }
+
+  // No snake_case mapping needed today; explicit per the file-family
+  // convention so a future mapped field cannot be added without noticing.
+  private enum CodingKeys: String, CodingKey {
+    case fragment
+    case caption
+  }
 }

--- a/Pastura/Pastura/Models/GalleryScenario.swift
+++ b/Pastura/Pastura/Models/GalleryScenario.swift
@@ -166,6 +166,24 @@ nonisolated public struct GalleryScenario: Codable, Sendable, Equatable, Hashabl
   /// required at the call site; the View layer can parse it as needed.
   public let addedAt: String
 
+  /// Remote URL of this entry's curated highlight excerpt (ADR-029), if one
+  /// has been generated. `nil` for the ~5/45 entries the spoiler policy
+  /// excludes and for any entry predating the feature.
+  ///
+  /// Optional + lenient decode (absent → `nil`) for the same forward-compat
+  /// reason as ``agentCount`` / ``rounds`` / ``phases`` / ``language`` /
+  /// ``minEngineVersion`` / ``featured``: an old cached `gallery.json` — or
+  /// an older app reading a newer feed — predates this key and must still
+  /// decode. Declared index-side (like ``yamlURL``) rather than derived by
+  /// convention, per ADR-029 Decision 4.
+  public let highlightURL: URL?
+
+  /// Lowercase hex SHA-256 of the highlight file at ``highlightURL``, for
+  /// integrity verification (ADR-029 Decision 4). Present iff
+  /// ``highlightURL`` is — both-or-neither is gate-validated on the repo
+  /// side, not re-checked here.
+  public let highlightSHA256: String?
+
   public init(
     id: String,
     title: String,
@@ -182,7 +200,9 @@ nonisolated public struct GalleryScenario: Codable, Sendable, Equatable, Hashabl
     phases: [String]? = nil,
     language: String? = nil,
     minEngineVersion: Int? = nil,
-    featured: Int? = nil
+    featured: Int? = nil,
+    highlightURL: URL? = nil,
+    highlightSHA256: String? = nil
   ) {
     self.id = id
     self.title = title
@@ -200,6 +220,8 @@ nonisolated public struct GalleryScenario: Codable, Sendable, Equatable, Hashabl
     self.language = language
     self.minEngineVersion = minEngineVersion
     self.featured = featured
+    self.highlightURL = highlightURL
+    self.highlightSHA256 = highlightSHA256
   }
 
   // Explicit CodingKeys so the JSON snake_case ↔ Swift camelCase mapping is
@@ -222,6 +244,8 @@ nonisolated public struct GalleryScenario: Codable, Sendable, Equatable, Hashabl
     case yamlURL = "yaml_url"
     case yamlSHA256 = "yaml_sha256"
     case addedAt = "added_at"
+    case highlightURL = "highlight_url"
+    case highlightSHA256 = "highlight_sha256"
   }
 }
 

--- a/Pastura/Pastura/Resources/Localizable.xcstrings
+++ b/Pastura/Pastura/Resources/Localizable.xcstrings
@@ -1715,6 +1715,22 @@
         }
       }
     },
+    "A glimpse of a real run" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A glimpse of a real run"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "実際に動かしたときのようす"
+          }
+        }
+      }
+    },
     "A scenario named “%@” already uses this id. Delete or rename it first, then try again." : {
       "localizations" : {
         "ja" : {
@@ -4759,6 +4775,22 @@
         }
       }
     },
+    "Once it is on your device you can rewrite this YAML freely. Change the setup and see where your own run goes." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Once it is on your device you can rewrite this YAML freely. Change the setup and see where your own run goes."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "端末に取り込めば、この YAML はそのまま書き換えられます。設定を変えて、自分だけの展開を確かめてみてください。"
+          }
+        }
+      }
+    },
     "Open Report Form" : {
       "localizations" : {
         "ja" : {
@@ -6904,6 +6936,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "テンプレートの読み込みに失敗しました: %@"
+          }
+        }
+      }
+    },
+    "The YAML behind these lines" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The YAML behind these lines"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "この会話を生んだ YAML"
           }
         }
       }

--- a/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailFormat.swift
+++ b/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailFormat.swift
@@ -55,9 +55,12 @@ enum GalleryScenarioDetailFormat {
   /// trimmed — leading indentation is load-bearing in YAML, so the first line's
   /// offset is preserved exactly as published.
   static func yamlFragmentForDisplay(_ fragment: String) -> String {
-    // `whitespacesAndNewlines` covers "\n", "\r\n", and trailing spaces alike.
+    // `Character.isWhitespace` is true for "\n", "\r\n", and spaces alike,
+    // so one predicate covers every trailing form. A hand-rolled loop rather
+    // than `trimmingCharacters(in:)`, which trims BOTH ends and would break
+    // the leading-indentation guarantee above.
     var trimmed = Substring(fragment)
-    while let last = trimmed.last, last.isWhitespace || last.isNewline {
+    while let last = trimmed.last, last.isWhitespace {
       trimmed = trimmed.dropLast()
     }
     return String(trimmed)

--- a/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailFormat.swift
+++ b/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailFormat.swift
@@ -47,6 +47,22 @@ enum GalleryScenarioDetailFormat {
     }
   }
 
+  /// Display-ready form of a curated highlight's YAML fragment (ADR-029).
+  ///
+  /// The published fragments are multi-line YAML blocks that commonly end with
+  /// a trailing newline; rendered as-is inside a code-style block that trailing
+  /// blank line reads as a stray empty row. Only **trailing** whitespace is
+  /// trimmed — leading indentation is load-bearing in YAML, so the first line's
+  /// offset is preserved exactly as published.
+  static func yamlFragmentForDisplay(_ fragment: String) -> String {
+    // `whitespacesAndNewlines` covers "\n", "\r\n", and trailing spaces alike.
+    var trimmed = Substring(fragment)
+    while let last = trimmed.last, last.isWhitespace || last.isNewline {
+      trimmed = trimmed.dropLast()
+    }
+    return String(trimmed)
+  }
+
   /// Alert content for a **non-navigating** install outcome, or `nil` for the
   /// navigating ones (`.installed` / `.updated`, which push to the local copy
   /// instead of alerting). Extracted from the View so the copy — including the

--- a/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailView+Highlight.swift
+++ b/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailView+Highlight.swift
@@ -1,0 +1,107 @@
+import SwiftUI
+
+/// The curated-highlight section of `GalleryScenarioDetailView` (ADR-029),
+/// split into a sibling extension to keep the host file inside SwiftLint's
+/// length caps.
+///
+/// **Static text only.** ADR-029 Decision 6 keeps highlights outside the
+/// Phase-3 "Replay gallery" deferral only while this section renders a fixed,
+/// authored excerpt with no run / replay / seek affordance of any kind. The
+/// edit invitation is copy, not a button — the screen's existing install CTA
+/// is the only action.
+///
+/// Every string sourced from the highlight file is remote content (currently
+/// Japanese, on both `en` and `ja` chrome) and is rendered with
+/// `Text(verbatim:)` so it never resolves as a `LocalizedStringKey`.
+extension GalleryScenarioDetailView {
+
+  /// Renders only once the loader has fetched **and** verified a highlight.
+  /// Absent, in-flight, and every verification failure alike collapse to
+  /// `EmptyView()` — no spinner, no placeholder, no error UI (ADR-029
+  /// Decision 4: a failure the user cannot act on is worse than absence).
+  @ViewBuilder
+  var highlightSection: some View {
+    if let highlight = highlightLoader?.highlight {
+      PasturaSection(String(localized: "A glimpse of a real run")) {
+        VStack(alignment: .leading, spacing: 16) {
+          excerptList(highlight.excerpt)
+          teaserLine(highlight.teaser)
+          yamlHook(highlight.yamlHook)
+          editInvitation
+        }
+        .padding(17)
+        .frame(maxWidth: .infinity, alignment: .leading)
+      }
+    }
+  }
+
+  /// Chat-log-style transcript: speaker name above the line it said.
+  /// `enumerated().offset` ids mirror `detailsCard` / `whatHappensSection` —
+  /// one persona can speak more than once, so the entries are not unique.
+  @ViewBuilder
+  fileprivate func excerptList(_ excerpt: [GalleryHighlightExcerptEntry]) -> some View {
+    VStack(alignment: .leading, spacing: 12) {
+      ForEach(Array(excerpt.enumerated()), id: \.offset) { _, entry in
+        VStack(alignment: .leading, spacing: 3) {
+          Text(verbatim: entry.agent)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(Color.mossDark)
+          Text(verbatim: entry.text)
+            .font(.callout)
+            .foregroundStyle(Color.ink)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+      }
+    }
+  }
+
+  /// One spoiler-free line teasing the outcome — italic + secondary ink so it
+  /// reads as a caption on the excerpt rather than another spoken line.
+  fileprivate func teaserLine(_ teaser: String) -> some View {
+    Text(verbatim: teaser)
+      .font(.callout.italic())
+      .foregroundStyle(Color.inkSecondary)
+      .fixedSize(horizontal: false, vertical: true)
+      .frame(maxWidth: .infinity, alignment: .leading)
+  }
+
+  /// The YAML that produced the excerpt, in a code-style block, plus its
+  /// caption. Both strings are remote content.
+  fileprivate func yamlHook(_ hook: GalleryHighlightYAMLHook) -> some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text(String(localized: "The YAML behind these lines"))
+        .font(.subheadline.weight(.semibold))
+        .foregroundStyle(Color.ink)
+      Text(verbatim: GalleryScenarioDetailFormat.yamlFragmentForDisplay(hook.fragment))
+        .font(.system(size: 12, design: .monospaced))
+        .foregroundStyle(Color.inkSecondary)
+        .fixedSize(horizontal: false, vertical: true)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(
+          Color.bubbleBackground,
+          in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+      Text(verbatim: hook.caption)
+        .font(.footnote)
+        .foregroundStyle(Color.muted)
+        .fixedSize(horizontal: false, vertical: true)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+  }
+
+  /// Open-in-app-and-edit invitation (ADR-029 Decision 5). Deliberately says
+  /// nothing about submitting a scenario back to the gallery — user
+  /// submissions are the Phase 3 marketplace — and adds no run affordance.
+  fileprivate var editInvitation: some View {
+    Text(
+      String(
+        localized:
+          "Once it is on your device you can rewrite this YAML freely. Change the setup and see where your own run goes."
+      )
+    )
+    .font(.caption)
+    .foregroundStyle(Color.muted)
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+}

--- a/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailView+Highlight.swift
+++ b/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailView+Highlight.swift
@@ -52,6 +52,9 @@ extension GalleryScenarioDetailView {
             .fixedSize(horizontal: false, vertical: true)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+        // One VoiceOver element per utterance ("<agent>, <line>") — split
+        // elements would read the name, stop, then the line.
+        .accessibilityElement(children: .combine)
       }
     }
   }
@@ -74,7 +77,9 @@ extension GalleryScenarioDetailView {
         .font(.subheadline.weight(.semibold))
         .foregroundStyle(Color.ink)
       Text(verbatim: GalleryScenarioDetailFormat.yamlFragmentForDisplay(hook.fragment))
-        .font(.system(size: 12, design: .monospaced))
+        // Text-style-relative so the code block scales with Dynamic Type
+        // alongside the section's prose (a fixed point size would not).
+        .font(.system(.caption2, design: .monospaced))
         .foregroundStyle(Color.inkSecondary)
         .fixedSize(horizontal: false, vertical: true)
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailView.swift
+++ b/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailView.swift
@@ -20,6 +20,9 @@ struct GalleryScenarioDetailView: View {
   @Environment(ModelManager.self) var modelManager
   @Environment(\.lastDeepLinkedScenarioId) private var lastDeepLinkedScenarioId
   @State private var viewModel: SharedScenariosViewModel?
+  // Read by the sibling extension in `GalleryScenarioDetailView+Highlight.swift`
+  // — `private` would block cross-file extension access.
+  @State var highlightLoader: GalleryHighlightLoader?
   @State var isWorking = false
   @State private var outcomeAlert: OutcomeAlert?
   @State private var isReportSheetPresented = false
@@ -59,6 +62,17 @@ struct GalleryScenarioDetailView: View {
         repository: dependencies.scenarioRepository)
       await newViewModel.load()
       viewModel = newViewModel
+    }
+    // Keyed on `scenario.id` ONLY: `load(for:)` clears its state at entry, so a
+    // re-fire for the same scenario would blank an already-rendered highlight
+    // and flash the section back in. The fetch runs alongside the view-model
+    // load rather than after it — a highlight is decorative enrichment and must
+    // never sit on the screen's critical path (ADR-029 Decision 4).
+    .task(id: scenario.id) {
+      let loader =
+        highlightLoader ?? GalleryHighlightLoader(galleryService: dependencies.galleryService)
+      highlightLoader = loader
+      await loader.load(for: scenario)
     }
     .alert(item: $outcomeAlert) { alert in
       Alert(title: Text(alert.title), message: Text(alert.message))
@@ -101,6 +115,10 @@ struct GalleryScenarioDetailView: View {
         if wasOpenedFromDeepLink { deepLinkBanner }
         headerCard
         whatHappensSection
+        // "What it feels like" reads best right after "what happens", and
+        // before the metadata table — the excerpt is the reason to install,
+        // `detailsCard` is reference material.
+        highlightSection
         detailsCard
         recommendedModelSection
         actionFooter(viewModel: viewModel)

--- a/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailView.swift
+++ b/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailView.swift
@@ -69,10 +69,10 @@ struct GalleryScenarioDetailView: View {
     // load rather than after it — a highlight is decorative enrichment and must
     // never sit on the screen's critical path (ADR-029 Decision 4).
     .task(id: scenario.id) {
-      let loader =
-        highlightLoader ?? GalleryHighlightLoader(galleryService: dependencies.galleryService)
-      highlightLoader = loader
-      await loader.load(for: scenario)
+      if highlightLoader == nil {
+        highlightLoader = GalleryHighlightLoader(galleryService: dependencies.galleryService)
+      }
+      await highlightLoader?.load(for: scenario)
     }
     .alert(item: $outcomeAlert) { alert in
       Alert(title: Text(alert.title), message: Text(alert.message))

--- a/Pastura/PasturaTests/App/Community/Gallery/GalleryHighlightLoaderTests.swift
+++ b/Pastura/PasturaTests/App/Community/Gallery/GalleryHighlightLoaderTests.swift
@@ -1,0 +1,249 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+@MainActor
+@Suite(.timeLimit(.minutes(1))) struct GalleryHighlightLoaderTests {
+
+  // MARK: - Fixtures
+
+  // swiftlint:disable:next force_unwrapping
+  private static let highlightURL = URL(string: "https://example.com/h/asch_v1.json")!
+  private static let highlightHash = String(repeating: "a", count: 64)
+
+  /// Mirrors the shape of `docs/gallery/highlights/asch_conformity_v1.json`.
+  private static func highlightJSON(
+    schemaVersion: Int = 1,
+    contentFilterApplied: Bool = true,
+    excerptCount: Int = 2
+  ) -> Data {
+    let entries = (0..<max(excerptCount, 0)).map { index in
+      """
+      {
+        "agent": "サクラ\(index)",
+        "round": 1,
+        "phase": "speak_each",
+        "phase_index": 0,
+        "source_field": "statement",
+        "text": "答えはCです。"
+      }
+      """
+    }
+    let json = """
+      {
+        "schema_version": \(schemaVersion),
+        "scenario_ref": {
+          "id": "asch_v1",
+          "yaml_sha256": "\(String(repeating: "b", count: 64))"
+        },
+        "source": {
+          "model": "gemma-4-e2b-q4-k-m",
+          "run_id": "20260806-000253-bd2a",
+          "generated_at": "2026-08-06"
+        },
+        "excerpt": [\(entries.joined(separator: ","))],
+        "yaml_hook": {
+          "fragment": "description: 自信家",
+          "caption": "性格を書き換えてみよう"
+        },
+        "teaser": "多数派の答えに引きずられるか。",
+        "window_override": false,
+        "content_filter_applied": \(contentFilterApplied)
+      }
+      """
+    return Data(json.utf8)
+  }
+
+  private func makeScenario(
+    highlightURL: URL? = GalleryHighlightLoaderTests.highlightURL,
+    highlightSHA256: String? = GalleryHighlightLoaderTests.highlightHash
+  ) -> GalleryScenario {
+    GalleryScenario(
+      id: "asch_v1",
+      title: "Asch",
+      category: .socialPsychology,
+      description: "desc",
+      author: "t",
+      recommendedModel: ModelRegistry.gemma4E2B.id,
+      estimatedInferences: 10,
+      // swiftlint:disable:next force_unwrapping
+      yamlURL: URL(string: "https://example.com/asch_v1.yaml")!,
+      yamlSHA256: String(repeating: "c", count: 64),
+      addedAt: "2026-08-06",
+      highlightURL: highlightURL,
+      highlightSHA256: highlightSHA256)
+  }
+
+  // MARK: - Pairing
+
+  @Test func bothFieldsAbsentSkipsFetch() async {
+    let service = HighlightStubGalleryService()
+    let loader = GalleryHighlightLoader(galleryService: service)
+
+    await loader.load(for: makeScenario(highlightURL: nil, highlightSHA256: nil))
+
+    #expect(loader.highlight == nil)
+    #expect(service.highlightFetchCount == 0)
+  }
+
+  @Test func urlWithoutHashSkipsFetch() async {
+    let service = HighlightStubGalleryService()
+    let loader = GalleryHighlightLoader(galleryService: service)
+
+    await loader.load(for: makeScenario(highlightSHA256: nil))
+
+    #expect(loader.highlight == nil)
+    #expect(service.highlightFetchCount == 0)
+  }
+
+  @Test func hashWithoutURLSkipsFetch() async {
+    let service = HighlightStubGalleryService()
+    let loader = GalleryHighlightLoader(galleryService: service)
+
+    await loader.load(for: makeScenario(highlightURL: nil))
+
+    #expect(loader.highlight == nil)
+    #expect(service.highlightFetchCount == 0)
+  }
+
+  // MARK: - Fetch failures
+
+  @Test func hashMismatchHidesSection() async {
+    let service = HighlightStubGalleryService()
+    service.result = .failure(
+      GalleryServiceError.hashMismatch(expected: "a", actual: "b"))
+    let loader = GalleryHighlightLoader(galleryService: service)
+
+    await loader.load(for: makeScenario())
+
+    #expect(loader.highlight == nil)
+    #expect(service.highlightFetchCount == 1)
+  }
+
+  @Test func responseTooLargeHidesSection() async {
+    let service = HighlightStubGalleryService()
+    service.result = .failure(GalleryServiceError.responseTooLarge(limit: 65_536))
+    let loader = GalleryHighlightLoader(galleryService: service)
+
+    await loader.load(for: makeScenario())
+
+    #expect(loader.highlight == nil)
+  }
+
+  @Test func genericFetchErrorHidesSection() async {
+    let service = HighlightStubGalleryService()
+    service.result = .failure(GalleryServiceError.unexpectedStatus(503))
+    let loader = GalleryHighlightLoader(galleryService: service)
+
+    await loader.load(for: makeScenario())
+
+    #expect(loader.highlight == nil)
+  }
+
+  // MARK: - Verification funnel
+
+  @Test func undecodableBytesHideSection() async {
+    let service = HighlightStubGalleryService()
+    service.result = .success(Data("not json at all".utf8))
+    let loader = GalleryHighlightLoader(galleryService: service)
+
+    await loader.load(for: makeScenario())
+
+    #expect(loader.highlight == nil)
+  }
+
+  @Test func unknownSchemaVersionHidesSection() async {
+    let service = HighlightStubGalleryService()
+    service.result = .success(Self.highlightJSON(schemaVersion: 2))
+    let loader = GalleryHighlightLoader(galleryService: service)
+
+    await loader.load(for: makeScenario())
+
+    #expect(loader.highlight == nil)
+  }
+
+  @Test func unattestedContentFilterHidesSection() async {
+    let service = HighlightStubGalleryService()
+    service.result = .success(Self.highlightJSON(contentFilterApplied: false))
+    let loader = GalleryHighlightLoader(galleryService: service)
+
+    await loader.load(for: makeScenario())
+
+    #expect(loader.highlight == nil)
+  }
+
+  @Test func emptyExcerptHidesSection() async {
+    let service = HighlightStubGalleryService()
+    service.result = .success(Self.highlightJSON(excerptCount: 0))
+    let loader = GalleryHighlightLoader(galleryService: service)
+
+    await loader.load(for: makeScenario())
+
+    #expect(loader.highlight == nil)
+  }
+
+  // MARK: - Success
+
+  @Test func validHighlightIsPublished() async {
+    let service = HighlightStubGalleryService()
+    service.result = .success(Self.highlightJSON())
+    let loader = GalleryHighlightLoader(galleryService: service)
+
+    await loader.load(for: makeScenario())
+
+    #expect(loader.highlight?.schemaVersion == 1)
+    #expect(loader.highlight?.excerpt.count == 2)
+    #expect(loader.highlight?.scenarioRef.id == "asch_v1")
+    #expect(loader.highlight?.teaser == "多数派の答えに引きずられるか。")
+  }
+
+  @Test func secondLoadAfterFailureCanSucceed() async {
+    let service = HighlightStubGalleryService()
+    service.result = .failure(GalleryServiceError.unexpectedStatus(500))
+    let loader = GalleryHighlightLoader(galleryService: service)
+
+    await loader.load(for: makeScenario())
+    #expect(loader.highlight == nil)
+
+    service.result = .success(Self.highlightJSON())
+    await loader.load(for: makeScenario())
+    #expect(loader.highlight != nil)
+  }
+
+  @Test func failedLoadClearsAPreviousHighlight() async {
+    let service = HighlightStubGalleryService()
+    service.result = .success(Self.highlightJSON())
+    let loader = GalleryHighlightLoader(galleryService: service)
+
+    await loader.load(for: makeScenario())
+    #expect(loader.highlight != nil)
+
+    service.result = .failure(GalleryServiceError.unexpectedStatus(500))
+    await loader.load(for: makeScenario())
+    #expect(loader.highlight == nil)
+  }
+}
+
+// MARK: - HighlightStubGalleryService
+
+/// Deterministic `GalleryService` stub for ``GalleryHighlightLoader`` tests.
+/// Only `fetchHighlightData` is exercised; the rest are unreachable stubs.
+/// Named distinctly from `StubVMGalleryService` — both are module-scope.
+private final class HighlightStubGalleryService: GalleryService, @unchecked Sendable {
+  var result: Result<Data, Error> = .failure(GalleryServiceError.unexpectedStatus(404))
+  private(set) var highlightFetchCount = 0
+
+  func loadCachedIndex() throws -> GalleryIndex? { nil }
+
+  func refreshIndex() async throws -> GalleryIndex? { nil }
+
+  func fetchScenarioYAML(from url: URL, expectedSHA256: String) async throws -> String {
+    throw GalleryServiceError.unexpectedStatus(404)
+  }
+
+  func fetchHighlightData(from url: URL, expectedSHA256: String) async throws -> Data {
+    highlightFetchCount += 1
+    return try result.get()
+  }
+}

--- a/Pastura/PasturaTests/App/Community/Gallery/GalleryServiceTests+Highlight.swift
+++ b/Pastura/PasturaTests/App/Community/Gallery/GalleryServiceTests+Highlight.swift
@@ -1,0 +1,92 @@
+import CryptoKit
+import Foundation
+import Testing
+
+@testable import Pastura
+
+// Split out of `GalleryServiceTests` to keep that file under swiftlint's
+// 400-line `file_length` cap (testing.md § "Splitting a Suite Across
+// Files"). Sibling-file `extension` of the same suite — NOT a new `@Suite`,
+// which would run in parallel and race the shared GalleryMockURLProtocol handler.
+extension GalleryServiceTests {
+
+  // MARK: - fetchHighlightData
+
+  @Test func fetchHighlightDataReturnsBytesOnHashMatch() async throws {
+    let tmp = try makeTempDir()
+    defer { cleanup(tmp) }
+    let service = makeService(cacheDirectory: tmp)
+
+    let json = "{\"excerpt\":[]}"
+    let data = Data(json.utf8)
+    let hash = URLSessionGalleryService.sha256Hex(data)
+
+    GalleryMockURLProtocol.setHandler { _ in (self.response(status: 200, for: Self.yamlURL), data) }
+
+    let result = try await service.fetchHighlightData(from: Self.yamlURL, expectedSHA256: hash)
+    #expect(result == data)
+  }
+
+  @Test func fetchHighlightDataThrowsOnHashMismatch() async throws {
+    let tmp = try makeTempDir()
+    defer { cleanup(tmp) }
+    let service = makeService(cacheDirectory: tmp)
+
+    let data = Data("{\"excerpt\":[]}".utf8)
+    let wrongHash = String(repeating: "0", count: 64)
+
+    GalleryMockURLProtocol.setHandler { _ in (self.response(status: 200, for: Self.yamlURL), data) }
+
+    await #expect(
+      throws: GalleryServiceError.hashMismatch(
+        expected: wrongHash,
+        actual: URLSessionGalleryService.sha256Hex(data))
+    ) {
+      _ = try await service.fetchHighlightData(from: Self.yamlURL, expectedSHA256: wrongHash)
+    }
+  }
+
+  @Test func fetchHighlightDataRejectsOversizeResponse() async throws {
+    let tmp = try makeTempDir()
+    defer { cleanup(tmp) }
+    let service = makeService(cacheDirectory: tmp)
+
+    // 128 KiB exceeds the 64 KiB highlightSizeLimit.
+    let oversize = Data(repeating: 0x20, count: 128 * 1024)
+    let hash = URLSessionGalleryService.sha256Hex(oversize)
+    GalleryMockURLProtocol.setHandler { _ in (self.response(status: 200, for: Self.yamlURL), oversize) }
+
+    await #expect(
+      throws: GalleryServiceError.responseTooLarge(
+        limit: URLSessionGalleryService.highlightSizeLimit)
+    ) {
+      _ = try await service.fetchHighlightData(from: Self.yamlURL, expectedSHA256: hash)
+    }
+  }
+
+  @Test func fetchHighlightDataResolvesRelativeURLAgainstIndex() async throws {
+    let tmp = try makeTempDir()
+    defer { cleanup(tmp) }
+    let service = makeService(cacheDirectory: tmp)
+
+    // Relative input — should be resolved against indexURL's directory.
+    // swiftlint:disable:next force_unwrapping
+    let relative = URL(string: "highlights/asch.json")!
+    let expectedAbsolute = URL(
+      // swiftlint:disable:next force_unwrapping
+      string: "https://example.com/highlights/asch.json")!
+
+    let data = Data("{\"excerpt\":[]}".utf8)
+    let hash = URLSessionGalleryService.sha256Hex(data)
+
+    let capturedURL = CapturedHeader()  // reuse as a string holder
+    GalleryMockURLProtocol.setHandler { request in
+      capturedURL.set(request.url?.absoluteString)
+      return (self.response(status: 200, for: expectedAbsolute), data)
+    }
+
+    let result = try await service.fetchHighlightData(from: relative, expectedSHA256: hash)
+    #expect(result == data)
+    #expect(capturedURL.get() == expectedAbsolute.absoluteString)
+  }
+}

--- a/Pastura/PasturaTests/App/Community/Gallery/GalleryServiceTests.swift
+++ b/Pastura/PasturaTests/App/Community/Gallery/GalleryServiceTests.swift
@@ -6,7 +6,7 @@ import Testing
 
 /// Tests for `URLSessionGalleryService`.
 ///
-/// `.serialized` because MockURLProtocol shares static handler state across
+/// `.serialized` because GalleryMockURLProtocol shares static handler state across
 /// tests. Each test sets its own handler before exercising the service.
 @Suite(.serialized, .timeLimit(.minutes(1))) struct GalleryServiceTests {
 
@@ -15,7 +15,7 @@ import Testing
   private static let indexURL = URL(
     // swiftlint:disable:next force_unwrapping
     string: "https://example.com/gallery.json")!
-  private static let yamlURL = URL(
+  static let yamlURL = URL(
     // swiftlint:disable:next force_unwrapping
     string: "https://example.com/scenarios/asch.yaml")!
 
@@ -27,27 +27,27 @@ import Testing
     }
     """
 
-  private func makeService(cacheDirectory: URL) -> URLSessionGalleryService {
+  func makeService(cacheDirectory: URL) -> URLSessionGalleryService {
     let config = URLSessionConfiguration.ephemeral
-    config.protocolClasses = [MockURLProtocol.self]
+    config.protocolClasses = [GalleryMockURLProtocol.self]
     return URLSessionGalleryService(
       indexURL: Self.indexURL,
       cacheDirectory: cacheDirectory,
       sessionConfiguration: config)
   }
 
-  private func makeTempDir() throws -> URL {
+  func makeTempDir() throws -> URL {
     let url = FileManager.default.temporaryDirectory
       .appendingPathComponent("pastura-gallery-test-\(UUID().uuidString)")
     try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
     return url
   }
 
-  private func cleanup(_ url: URL) {
+  func cleanup(_ url: URL) {
     try? FileManager.default.removeItem(at: url)
   }
 
-  private func response(
+  func response(
     status: Int, headers: [String: String] = [:], for url: URL = indexURL
   ) -> HTTPURLResponse {
     // swiftlint:disable:next force_unwrapping
@@ -62,7 +62,7 @@ import Testing
     let service = makeService(cacheDirectory: tmp)
 
     let jsonData = Data(Self.sampleJSON.utf8)
-    MockURLProtocol.setHandler { _ in
+    GalleryMockURLProtocol.setHandler { _ in
       (self.response(status: 200, headers: ["ETag": "\"v1\""]), jsonData)
     }
 
@@ -86,14 +86,14 @@ import Testing
 
     // Prime cache with an ETag.
     let jsonData = Data(Self.sampleJSON.utf8)
-    MockURLProtocol.setHandler { _ in
+    GalleryMockURLProtocol.setHandler { _ in
       (self.response(status: 200, headers: ["ETag": "\"v1\""]), jsonData)
     }
     _ = try await service.refreshIndex()
 
     // Next call should include the stored ETag.
     let capturedHeader = CapturedHeader()
-    MockURLProtocol.setHandler { request in
+    GalleryMockURLProtocol.setHandler { request in
       capturedHeader.set(request.value(forHTTPHeaderField: "If-None-Match"))
       return (self.response(status: 304), Data())
     }
@@ -110,7 +110,7 @@ import Testing
 
     // 2 MiB payload exceeds the 1 MiB indexSizeLimit.
     let oversize = Data(repeating: 0x7B, count: 2 * 1024 * 1024)
-    MockURLProtocol.setHandler { _ in (self.response(status: 200), oversize) }
+    GalleryMockURLProtocol.setHandler { _ in (self.response(status: 200), oversize) }
 
     await #expect(
       throws: GalleryServiceError.responseTooLarge(
@@ -125,7 +125,7 @@ import Testing
     defer { cleanup(tmp) }
     let service = makeService(cacheDirectory: tmp)
 
-    MockURLProtocol.setHandler { _ in
+    GalleryMockURLProtocol.setHandler { _ in
       (self.response(status: 200), Data("not json".utf8))
     }
 
@@ -139,7 +139,7 @@ import Testing
     defer { cleanup(tmp) }
     let service = makeService(cacheDirectory: tmp)
 
-    MockURLProtocol.setHandler { _ in (self.response(status: 500), Data()) }
+    GalleryMockURLProtocol.setHandler { _ in (self.response(status: 500), Data()) }
 
     await #expect(throws: GalleryServiceError.unexpectedStatus(500)) {
       _ = try await service.refreshIndex()
@@ -163,7 +163,7 @@ import Testing
     let service = makeService(cacheDirectory: tmp)
 
     let jsonData = Data(Self.sampleJSON.utf8)
-    MockURLProtocol.setHandler { _ in (self.response(status: 200), jsonData) }
+    GalleryMockURLProtocol.setHandler { _ in (self.response(status: 200), jsonData) }
     _ = try await service.refreshIndex()
 
     let cached = try service.loadCachedIndex()
@@ -194,7 +194,7 @@ import Testing
     let data = Data(yaml.utf8)
     let hash = URLSessionGalleryService.sha256Hex(data)
 
-    MockURLProtocol.setHandler { _ in (self.response(status: 200, for: Self.yamlURL), data) }
+    GalleryMockURLProtocol.setHandler { _ in (self.response(status: 200, for: Self.yamlURL), data) }
 
     let result = try await service.fetchScenarioYAML(from: Self.yamlURL, expectedSHA256: hash)
     #expect(result == yaml)
@@ -209,7 +209,7 @@ import Testing
     let data = Data(yaml.utf8)
     let wrongHash = String(repeating: "0", count: 64)
 
-    MockURLProtocol.setHandler { _ in (self.response(status: 200, for: Self.yamlURL), data) }
+    GalleryMockURLProtocol.setHandler { _ in (self.response(status: 200, for: Self.yamlURL), data) }
 
     await #expect(
       throws: GalleryServiceError.hashMismatch(
@@ -237,7 +237,7 @@ import Testing
     let hash = URLSessionGalleryService.sha256Hex(data)
 
     let capturedURL = CapturedHeader()  // reuse as a string holder
-    MockURLProtocol.setHandler { request in
+    GalleryMockURLProtocol.setHandler { request in
       capturedURL.set(request.url?.absoluteString)
       return (self.response(status: 200, for: expectedAbsolute), data)
     }
@@ -255,7 +255,7 @@ import Testing
     // 512 KiB exceeds the 256 KiB yamlSizeLimit.
     let oversize = Data(repeating: 0x20, count: 512 * 1024)
     let hash = URLSessionGalleryService.sha256Hex(oversize)
-    MockURLProtocol.setHandler { _ in (self.response(status: 200, for: Self.yamlURL), oversize) }
+    GalleryMockURLProtocol.setHandler { _ in (self.response(status: 200, for: Self.yamlURL), oversize) }
 
     await #expect(
       throws: GalleryServiceError.responseTooLarge(
@@ -281,7 +281,7 @@ import Testing
 ///
 /// The static handler is shared across all requests in the suite, which is
 /// why the surrounding `@Suite` uses `.serialized`.
-private final class MockURLProtocol: URLProtocol {
+final class GalleryMockURLProtocol: URLProtocol {
   typealias Handler = @Sendable (URLRequest) -> (HTTPURLResponse, Data)
 
   private static let lock = NSLock()
@@ -317,7 +317,7 @@ private final class MockURLProtocol: URLProtocol {
 
 /// Thread-safe holder for a single captured value used across the async
 /// URLSession delegate queue and the test thread.
-private final class CapturedHeader: @unchecked Sendable {
+final class CapturedHeader: @unchecked Sendable {
   private let lock = NSLock()
   private var value: String?
 

--- a/Pastura/PasturaTests/App/Community/Gallery/SharedScenariosViewModelTests.swift
+++ b/Pastura/PasturaTests/App/Community/Gallery/SharedScenariosViewModelTests.swift
@@ -302,4 +302,9 @@ final class StubVMGalleryService: GalleryService, @unchecked Sendable {
     }
     return yaml
   }
+
+  func fetchHighlightData(from url: URL, expectedSHA256: String) async throws -> Data {
+    // No highlight-fetch flow exercised by this view model's tests yet.
+    throw GalleryServiceError.unexpectedStatus(404)
+  }
 }

--- a/Pastura/PasturaTests/App/DeepLink/DeepLinkResolverTests.swift
+++ b/Pastura/PasturaTests/App/DeepLink/DeepLinkResolverTests.swift
@@ -143,4 +143,9 @@ private final class MockGalleryService: GalleryService, @unchecked Sendable {
     // Resolver does not fetch YAML; placeholder for protocol conformance.
     throw GalleryServiceError.unexpectedStatus(404)
   }
+
+  func fetchHighlightData(from url: URL, expectedSHA256: String) async throws -> Data {
+    // Resolver does not fetch highlights; placeholder for protocol conformance.
+    throw GalleryServiceError.unexpectedStatus(404)
+  }
 }

--- a/Pastura/PasturaTests/App/HomeViewModelGalleryBadgeTests.swift
+++ b/Pastura/PasturaTests/App/HomeViewModelGalleryBadgeTests.swift
@@ -95,4 +95,7 @@ private final class StubGalleryService: GalleryService, @unchecked Sendable {
   func fetchScenarioYAML(from url: URL, expectedSHA256: String) async throws -> String {
     throw GalleryServiceError.unexpectedStatus(404)
   }
+  func fetchHighlightData(from url: URL, expectedSHA256: String) async throws -> Data {
+    throw GalleryServiceError.unexpectedStatus(404)
+  }
 }

--- a/Pastura/PasturaTests/Models/GalleryHighlightTests.swift
+++ b/Pastura/PasturaTests/Models/GalleryHighlightTests.swift
@@ -1,0 +1,113 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+@Suite(.timeLimit(.minutes(1))) struct GalleryHighlightTests {
+
+  // MARK: - Fixtures
+
+  private static let validJSON = """
+    {
+      "schema_version": 1,
+      "scenario_ref": {
+        "id": "asch_conformity_v1",
+        "yaml_sha256": "090ef06d9d49ea3a538d33c05299a2b7a45100f6aafa3dfa71da28bd81d13960"
+      },
+      "source": {
+        "model": "gemma-4-e2b-q4-k-m",
+        "run_id": "20260806-000253-bd2a",
+        "generated_at": "2026-08-06"
+      },
+      "excerpt": [
+        {
+          "agent": "サクラA",
+          "round": 1,
+          "phase": "speak_each",
+          "phase_index": 0,
+          "source_field": "statement",
+          "text": "答えはCです。"
+        },
+        {
+          "agent": "被験者ナオキ",
+          "round": 1,
+          "phase": "speak_each",
+          "phase_index": 0,
+          "source_field": "statement",
+          "text": "私は基準線と同じ長さの線はBだと思います。"
+        }
+      ],
+      "yaml_hook": {
+        "fragment": "  - name: 被験者ナオキ\\n    description: >\\n      素朴な性格。",
+        "caption": "サクラの人数を書き換えると、同調圧力の強さが変わる。"
+      },
+      "teaser": "最終ラウンド、ナオキはBを貫けるのか——結末はアプリで。",
+      "window_override": false,
+      "content_filter_applied": true
+    }
+    """
+
+  @Test func decodesFullyValidFixture() throws {
+    let highlight = try JSONDecoder().decode(
+      GalleryHighlight.self, from: Data(Self.validJSON.utf8))
+
+    #expect(highlight.schemaVersion == 1)
+    #expect(highlight.scenarioRef.id == "asch_conformity_v1")
+    #expect(
+      highlight.scenarioRef.yamlSHA256
+        == "090ef06d9d49ea3a538d33c05299a2b7a45100f6aafa3dfa71da28bd81d13960")
+    #expect(highlight.source.model == "gemma-4-e2b-q4-k-m")
+    #expect(highlight.source.runID == "20260806-000253-bd2a")
+    #expect(highlight.source.generatedAt == "2026-08-06")
+    #expect(highlight.excerpt.count == 2)
+    #expect(highlight.excerpt[0].agent == "サクラA")
+    #expect(highlight.excerpt[0].round == 1)
+    #expect(highlight.excerpt[0].phase == "speak_each")
+    #expect(highlight.excerpt[0].phaseIndex == 0)
+    #expect(highlight.excerpt[0].sourceField == "statement")
+    #expect(highlight.excerpt[0].text == "答えはCです。")
+    #expect(highlight.yamlHook.caption == "サクラの人数を書き換えると、同調圧力の強さが変わる。")
+    #expect(highlight.teaser == "最終ラウンド、ナオキはBを貫けるのか——結末はアプリで。")
+    #expect(highlight.windowOverride == false)
+    #expect(highlight.contentFilterApplied == true)
+  }
+
+  /// Fail-closed per ADR-029 Decision 4: an absent `content_filter_applied`
+  /// must throw at decode time rather than default to `false` (or `true`).
+  @Test func missingContentFilterAppliedThrows() throws {
+    var json = try #require(
+      JSONSerialization.jsonObject(with: Data(Self.validJSON.utf8)) as? [String: Any])
+    json.removeValue(forKey: "content_filter_applied")
+    let data = try JSONSerialization.data(withJSONObject: json)
+
+    #expect(throws: (any Error).self) {
+      try JSONDecoder().decode(GalleryHighlight.self, from: data)
+    }
+  }
+
+  /// Any other required top-level field missing must also throw — the
+  /// schema has no optional fields.
+  @Test func missingTeaserThrows() throws {
+    var json = try #require(
+      JSONSerialization.jsonObject(with: Data(Self.validJSON.utf8)) as? [String: Any])
+    json.removeValue(forKey: "teaser")
+    let data = try JSONSerialization.data(withJSONObject: json)
+
+    #expect(throws: (any Error).self) {
+      try JSONDecoder().decode(GalleryHighlight.self, from: data)
+    }
+  }
+
+  /// `content_filter_applied: false` must decode successfully as `false` —
+  /// whether to hide the section on that basis is the caller's decision
+  /// (ADR-029 Decision 4), not the decoder's.
+  @Test func contentFilterAppliedFalseDecodes() throws {
+    var json = try #require(
+      JSONSerialization.jsonObject(with: Data(Self.validJSON.utf8)) as? [String: Any])
+    json["content_filter_applied"] = false
+    let data = try JSONSerialization.data(withJSONObject: json)
+
+    let highlight = try JSONDecoder().decode(GalleryHighlight.self, from: data)
+    #expect(highlight.contentFilterApplied == false)
+  }
+}

--- a/Pastura/PasturaTests/Models/GalleryScenarioTests+Highlight.swift
+++ b/Pastura/PasturaTests/Models/GalleryScenarioTests+Highlight.swift
@@ -4,9 +4,8 @@ import Testing
 @testable import Pastura
 
 // Split out of `GalleryScenarioTests` to keep the parent suite under
-// swiftlint's `type_body_length` cap (testing.md § "Splitting a Suite Across
-// Files"). Sibling-file `extension` of the same suite — NOT a new `@Suite`,
-// which would run in parallel and defeat the shared-suite ordering.
+// swiftlint's `type_body_length` cap — sibling-file `extension` of the same
+// suite, per testing.md § "Splitting a Suite Across Files".
 extension GalleryScenarioTests {
 
   // MARK: - highlightURL / highlightSHA256 (optional, ADR-029)

--- a/Pastura/PasturaTests/Models/GalleryScenarioTests+Highlight.swift
+++ b/Pastura/PasturaTests/Models/GalleryScenarioTests+Highlight.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+// Split out of `GalleryScenarioTests` to keep the parent suite under
+// swiftlint's `type_body_length` cap (testing.md § "Splitting a Suite Across
+// Files"). Sibling-file `extension` of the same suite — NOT a new `@Suite`,
+// which would run in parallel and defeat the shared-suite ordering.
+extension GalleryScenarioTests {
+
+  // MARK: - highlightURL / highlightSHA256 (optional, ADR-029)
+
+  @Test func decodeWithHighlight() throws {
+    let json = """
+      {
+        "id": "asch_conformity_v1",
+        "title": "アッシュの同調実験",
+        "category": "social_psychology",
+        "description": "desc",
+        "author": "tyabu12",
+        "recommended_model": "gemma-4-e2b-q4-k-m",
+        "estimated_inferences": 5,
+        "yaml_url": "https://example.com/asch.yaml",
+        "yaml_sha256": "deadbeef",
+        "added_at": "2026-08-06",
+        "highlight_url": "https://example.com/highlights/asch_conformity_v1.json",
+        "highlight_sha256": "cafef00d"
+      }
+      """
+    let scenario = try JSONDecoder().decode(GalleryScenario.self, from: Data(json.utf8))
+    #expect(
+      scenario.highlightURL?.absoluteString
+        == "https://example.com/highlights/asch_conformity_v1.json")
+    #expect(scenario.highlightSHA256 == "cafef00d")
+  }
+
+  /// Backward compat: an entry without highlight fields (older feed, or a
+  /// scenario the ADR-029 spoiler policy excludes) must decode with both
+  /// `nil` — same posture as `featured` / `minEngineVersion` / etc.
+  @Test func decodeWithoutHighlightYieldsNil() throws {
+    let json = """
+      {
+        "id": "legacy_v1",
+        "title": "Legacy",
+        "category": "experimental",
+        "description": "desc",
+        "author": "tyabu12",
+        "recommended_model": "gemma-4-e2b-q4-k-m",
+        "estimated_inferences": 8,
+        "yaml_url": "https://example.com/legacy.yaml",
+        "yaml_sha256": "deadbeef",
+        "added_at": "2026-04-15"
+      }
+      """
+    let scenario = try JSONDecoder().decode(GalleryScenario.self, from: Data(json.utf8))
+    #expect(scenario.highlightURL == nil)
+    #expect(scenario.highlightSHA256 == nil)
+  }
+}

--- a/Pastura/PasturaTests/Views/GalleryScenarioDetailFormatTests.swift
+++ b/Pastura/PasturaTests/Views/GalleryScenarioDetailFormatTests.swift
@@ -58,6 +58,35 @@ struct GalleryScenarioDetailFormatTests {
     #expect(GalleryScenarioDetailFormat.languageLabel(code: "fr") == nil)
   }
 
+  // MARK: - yamlFragmentForDisplay (ADR-029)
+
+  @Test func yamlFragmentTrimsTrailingNewline() {
+    #expect(
+      GalleryScenarioDetailFormat.yamlFragmentForDisplay("personas:\n  - name: A\n")
+        == "personas:\n  - name: A")
+  }
+
+  @Test func yamlFragmentTrimsRepeatedTrailingWhitespace() {
+    #expect(
+      GalleryScenarioDetailFormat.yamlFragmentForDisplay("a: 1\nb: 2\n\n  \n")
+        == "a: 1\nb: 2")
+  }
+
+  @Test func yamlFragmentPreservesLeadingIndentation() {
+    // Leading offset is load-bearing YAML structure — only the tail is trimmed.
+    #expect(
+      GalleryScenarioDetailFormat.yamlFragmentForDisplay("  description: |\n    hi\n")
+        == "  description: |\n    hi")
+  }
+
+  @Test func yamlFragmentLeavesAlreadyTrimmedFragmentUnchanged() {
+    #expect(GalleryScenarioDetailFormat.yamlFragmentForDisplay("a: 1") == "a: 1")
+  }
+
+  @Test func yamlFragmentHandlesAllWhitespaceInput() {
+    #expect(GalleryScenarioDetailFormat.yamlFragmentForDisplay("\n \n").isEmpty)
+  }
+
   // MARK: - installAlert (ADR-020 D5)
 
   @Test func installAlertNilForNavigatingOutcomes() {


### PR DESCRIPTION
## Summary
- ADR-029 の app 側実装: `GalleryScenarioDetailView` にハイライトセクション（実走行の対話抜粋・teaser・YAML hook + caption・編集への誘い文）を追加
- `GalleryScenario` に optional `highlightURL` / `highlightSHA256`（index が信頼のルート、Decision 4）、新規 `GalleryHighlight` モデル（全フィールド必須の厳格デコード = fail-closed）
- `GalleryService.fetchHighlightData(from:expectedSHA256:)` — `fetchScenarioYAML` と共通の `fetchVerifiedBytes`（相対 URL の `indexURL` 解決・64 KiB 上限・SHA-256 検証、ETag/キャッシュ無し）
- `GalleryHighlightLoader`（詳細画面スコープの @Observable）が検証ファネルを実装: half_pair / hash_mismatch / size_limit / fetch_failed / unparseable / unknown_schema_version / content_filter_not_attested / empty_excerpt — すべて非表示 + `.info` ログ（`privacy: .public`、チェック名のみ）。fetch は `.task(id: scenario.id)` で VM の `load()` と並走し、画面表示を一切ゲートしない
- chrome 文言 3 キーを `String(localized:)` + ja 訳（both translated）、ハイライト内容は `Text(verbatim:)`（Decision 5）。静的テキストのみ、run/replay 導線なし（Decision 6 境界）
- `data/highlight-runs/` を gitignore 化 — ハイライトの元 harness JSONL はローカル限り。**#1384 の未決事項（トランスクリプト保存）はコミット前サインオフを唯一の記録とする方針で解決**（運用者判断 2026-08-06）

## Review
- code-reviewer（Opus）2 分割で両 PASS（Critical 0）。Warning 5 件 + Suggestion 3 件は cfd4113 で修正済み
- 見送った Suggestion: excerpt ≤8 の app 側ガード（ADR-029 が定めた検査リスト外で、web 側と表示可否が割れるため repo ゲートを正とする）/ `checkName` 写像テスト + cancellation 分岐テスト / テストフィクスチャ URL の命名分離・`CapturedHeader` 改名 / UITest スタブが 404 固定のため screenshot ツアーにセクションが写らない点（必要になったら follow-up）

## Test plan
- フルユニットスイート green（3343 tests / 276 suites、UI テストはスキップ — 対象画面の新パスは UITest スタブでは到達不能）
- 新規/変更テスト: `GalleryHighlightTests`(4) / `GalleryScenarioTests+Highlight`(2) / `GalleryServiceTests+Highlight`(4, 相対 URL 回帰含む) / `GalleryHighlightLoaderTests`(13, 全ファネル分岐) / `GalleryScenarioDetailFormatTests`(+5)
- 実データ陽性確認: 公開中 2 件（asch_conformity_v1 / chin_jimaku_v1）の index ⟺ ファイルの hash/schema/attestation/サイズ/YAML 参照を機械検証 — ファネルは両方公開する状態
- `check_localization_coverage.py` ✅（721 keys all ja translated）

## Device QA
シミュレータで可（simulator 除外面・Metal 非接触）。視覚サインオフのみ推奨:
1. さがす → ギャラリー → 「アッシュの同調実験」詳細 → 「What happens」の下にハイライトセクションが出ること（本番 index は #1385 で配信済み）
2. ダークモードで YAML ブロック（bubbleBackground 面 + monospaced 文字）の可読性を一瞥
3. ハイライト無しエントリ（例: tengoku_jigoku_v1）が従来どおり表示されること

Closes #1384

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCPpPJCPDHN6aceXNR9hUa
