### PR TITLE
✨ feat: detect amendment-dominated ADRs with no navigation section

### DIFF
--- a/.claude/rules/adr-writing.md
+++ b/.claude/rules/adr-writing.md
@@ -80,7 +80,7 @@ what the skill cannot derive belongs here.
   generalises to any ADR past the size where a reader can hold its section
   structure (#1382).
 - **What *is* enforced is findability, not placement.** `consistency-audit`'s
-  `adr_navigation_missing` files an issue when a tracked ADR passes 600 lines,
+  `adr_navigation_missing` files an issue when a tracked ADR reaches 600 lines,
   is at least half amendment by section span, and has no `## How to read this
   ADR` section. It says nothing about whether a given value landed in the body
   or in an amendment — that judgment is still yours. Two ways to discharge it:

--- a/.claude/rules/adr-writing.md
+++ b/.claude/rules/adr-writing.md
@@ -75,9 +75,21 @@ what the skill cannot derive belongs here.
   measurements and retracted drafts stay in the amendment, which is why
   amendments are not trimmed away later; superseding an earlier one marks it in
   place rather than rewriting it. Stated here because nothing enforces it: no
-  lint, no gate, and `consistency-audit` has no amendment-placement detector, so
-  it is reviewer-enforced and only fires if it is loaded. It generalises to any
-  ADR past the size where a reader can hold its section structure (#1382).
+  lint, no gate, and `consistency-audit` has no amendment-**placement**
+  detector, so it is reviewer-enforced and only fires if it is loaded. It
+  generalises to any ADR past the size where a reader can hold its section
+  structure (#1382).
+- **What *is* enforced is findability, not placement.** `consistency-audit`'s
+  `adr_navigation_missing` files an issue when a tracked ADR passes 600 lines,
+  is at least half amendment by section span, and has no `## How to read this
+  ADR` section. It says nothing about whether a given value landed in the body
+  or in an amendment — that judgment is still yours. Two ways to discharge it:
+  add a navigation section whose heading starts `## How to read` (the ADR-028
+  pattern, and the literal shape matched — `## Navigation` will not satisfy
+  it), or, if you judge the ADR navigable as it stands, record
+  `<!-- nav-exempt: <reason> -->` in the file. Closing the issue without one of
+  those re-files it on the next run. The detector never proposes deleting or
+  trimming an amendment, for the reason in the bullet above.
 - **A file listing can also *over*-report.** The skill's reservation check
   covers a listing that under-reports; the inverse also happens here — an ADR
   draft sitting **untracked** in one checkout is visible to `ls` but absent for

--- a/.claude/rules/adr-writing.md
+++ b/.claude/rules/adr-writing.md
@@ -87,9 +87,11 @@ what the skill cannot derive belongs here.
   add a navigation section whose heading starts `## How to read` (the ADR-028
   pattern, and the literal shape matched — `## Navigation` will not satisfy
   it), or, if you judge the ADR navigable as it stands, record
-  `<!-- nav-exempt: <reason> -->` in the file. Closing the issue without one of
-  those re-files it on the next run. The detector never proposes deleting or
-  trimming an amendment, for the reason in the bullet above.
+  `<!-- nav-exempt: <reason> -->` **on a line of its own, unindented** — it is
+  matched at column 0, so a marker inside a list item, a block quote or an
+  indented code block does not count. Closing the issue without one of those
+  re-files it on the next run. The detector never proposes deleting or trimming
+  an amendment, for the reason in the bullet above.
 - **A file listing can also *over*-report.** The skill's reservation check
   covers a listing that under-reports; the inverse also happens here — an ADR
   draft sitting **untracked** in one checkout is visible to `ls` but absent for

--- a/.claude/skills/consistency-audit/SKILL.md
+++ b/.claude/skills/consistency-audit/SKILL.md
@@ -32,9 +32,13 @@ contract in context.
   the commit-time gate moved to the git pre-commit hook (`swiftlint --strict` +
   build), so there is no per-commit prompt. (`gh issue create` was allowlisted
   with the dangling-ADR detector (#876); every needs_judgment detector can
-  file Step 4 issues. It is exercised only when one actually fires; on a clean
-  `main` all of them are designed to report zero, so Step 4 stays quiet by
-  construction, not because it is unreachable.)
+  file Step 4 issues. The *drift* detectors report zero on a clean `main` by
+  construction — they describe states that should not exist. **`adr_navigation_missing`
+  does not**: it reports on a structural property a healthy repo can legitimately
+  have, and it fires on `main` today, so Step 4 now runs on ordinary passes
+  rather than only on a regression. That makes the cap-1 dedup in Step 4 step 1
+  and the `nav-exempt` opt-out load-bearing rather than theoretical — without
+  one of them, every run re-files the same finding.)
 - **No merging, no issue closing.** The human reviews each Draft PR; merging
   closes nothing automatically here.
 - **No parallelism — single writer.** One audit run at a time. Two overlapping
@@ -214,12 +218,12 @@ For each `needs_judgment` finding (already deduped by `target`):
    for `dangling_adr` it is the ADR id (`ADR-099`), for `embedded_source_mirror`
    it is the `<docfile>::<sourcepath>` composite (so the same source mirrored in
    two docs files two distinct issues), for `unparsed_adr_reservation` it is
-   `reservation:ADR-NNN` and for `adr_roster_drift` `roster:ADR-NNN` (or
-   `roster:<file>` for a shape drift) — embed `target` in the issue title
-   verbatim.
+   `reservation:ADR-NNN`, for `adr_roster_drift` `roster:ADR-NNN` (or
+   `roster:<file>` for a shape drift), and for `adr_navigation_missing`
+   `nav:ADR-NNN` — embed `target` in the issue title verbatim.
 
-   **The namespacing on the last two is load-bearing, and it is not
-   sufficient.** The search cannot tell finding types apart, so a bare
+   **The namespacing on the three ADR-keyed types is load-bearing, and it is
+   not sufficient.** The search cannot tell finding types apart, so a bare
    `ADR-NNN` would be permanently suppressed by the open `dangling_adr` issue
    it exists to explain — most likely exactly when both fire. The prefix stops
    that, but GitHub also matches on tokens rather than whole strings, and
@@ -229,10 +233,11 @@ For each `needs_judgment` finding (already deduped by `target`):
    — a match on the bare ADR id when the target is namespaced (or vice versa)
    is a different finding, and skipping on it drops a real one silently.
 
-   Quote the target when it contains a `:` — `--search '"roster:ADR-006" in:title'`.
-   Unquoted, GitHub reads `roster:` as a search qualifier. (This predates the
-   two new types: `embedded_source_mirror`'s `<docfile>::<sourcepath>` composite
-   has the same shape.)
+   Quote the target when it contains a `:` — `--search '"roster:ADR-006" in:title'`,
+   and likewise `'"nav:ADR-002" in:title'`. Unquoted, GitHub reads `roster:` /
+   `nav:` as a search qualifier. (This predates the newer types:
+   `embedded_source_mirror`'s `<docfile>::<sourcepath>` composite has the same
+   shape.)
 2. File an issue (`--label documentation`) whose body has:
    - **Locations**: every `file:line` the target is referenced from.
    - **Confidence**: how sure the detector is this is a real problem.
@@ -242,12 +247,19 @@ For each `needs_judgment` finding (already deduped by `target`):
    - **Suggested action**, explicitly left for a human to decide.
 
    Most detectors pre-author these fields. `dangling_adr`,
-   `embedded_source_mirror`, `unparsed_adr_reservation` and `adr_roster_drift`
-   findings already carry `confidence`, `counter_evidence`, and
-   `suggested_action` on the JSON — use them verbatim rather than re-deriving.
+   `embedded_source_mirror`, `unparsed_adr_reservation`, `adr_roster_drift` and
+   `adr_navigation_missing` findings already carry `confidence`,
+   `counter_evidence`, and `suggested_action` on the JSON — use them verbatim
+   rather than re-deriving.
    Each also carries one field naming what it found: `source` (the real file a
    mirrored block drifted from), `shape` (which reservation shape was seen),
-   and `problems` (the list of roster/INDEX/disk disagreements for one ADR).
+   `problems` (the list of roster/INDEX/disk disagreements for one ADR), and
+   `sections` (the per-amendment heading and span behind a navigation finding).
+   **Reproduce `sections` in the issue body**, not just the share: the share is
+   title-based, so a numbered section belonging to the ADR's own outline counts
+   as an amendment, and the breakdown plus `numbered_section_count` is what
+   makes the finding arguable instead of a bare percentage a maintainer can
+   only accept or reject.
    `dead_link` does not, so author its confidence / counter-evidence at filing
    time as before.
 
@@ -290,3 +302,25 @@ enabling. Each floods the reference-dense repo today:
   fragile on emoji headings and duplicate-heading suffixes; bare `§"..."` prose
   refs have no unambiguous target. Needs a verified slug normalizer + a target
   resolution rule.
+
+Two more were measured and rejected while `adr_navigation_missing` was built
+(#1400). Both are amendment **placement** checks — the thing `adr-writing.md`
+still says nothing enforces — so record why each was declined rather than
+leaving the next author to re-derive it:
+
+- **stranded values** ("a definitive value that lives only in an amendment,
+  never in the body") — ADR-028 § "Where new amendment content goes" *puts*
+  derivation and measurements in amendments deliberately, so a hex value or a
+  threshold inside one is usually correct placement, not drift. Separating a
+  standing value from a derivation record is exactly the judgment the
+  convention leaves to a human, and a mechanical proxy floods on ADR-028 —
+  the one ADR that already follows the convention. Needs a way to tell "this
+  is the current answer" from "this is how we got there".
+- **supersede-convention violations** (`adr-writing.md` requires marking a
+  superseded section in place with a leading block quote plus a `†` in the
+  index row) — measured on 2026-08-08, `supersed*` appears in ADR-023 (×9),
+  ADR-027 (×2), ADR-020 (×2), ADR-021, ADR-022 and INDEX (×3), and the
+  majority are **cross-ADR** supersession, which the intra-file convention
+  does not govern. `†` exists only in ADR-028. A naive "mentions supersede ⇒
+  must carry †" predicate yields 5+ false positives. Needs the claim's scope
+  resolved (does this supersede a section of *this* file?) before it can fire.

--- a/.claude/skills/consistency-audit/SKILL.md
+++ b/.claude/skills/consistency-audit/SKILL.md
@@ -32,13 +32,14 @@ contract in context.
   the commit-time gate moved to the git pre-commit hook (`swiftlint --strict` +
   build), so there is no per-commit prompt. (`gh issue create` was allowlisted
   with the dangling-ADR detector (#876); every needs_judgment detector can
-  file Step 4 issues. The *drift* detectors report zero on a clean `main` by
-  construction — they describe states that should not exist. **`adr_navigation_missing`
-  does not**: it reports on a structural property a healthy repo can legitimately
-  have, and it fires on `main` today, so Step 4 now runs on ordinary passes
-  rather than only on a regression. That makes the cap-1 dedup in Step 4 step 1
-  and the `nav-exempt` opt-out load-bearing rather than theoretical — without
-  one of them, every run re-files the same finding.)
+  file Step 4 issues. **Step 4 runs on ordinary passes — a clean `main` is not
+  a zero-findings state**, and measurement rather than assumption is the rule
+  here: `dead_link ledger.md` has reported since long before this detector
+  existed (a gitignored-by-design target, so it is absent in every fresh clone),
+  and `adr_navigation_missing` reports by design on a property a healthy repo
+  can have. So the per-target open-issue dedup in Step 4 step 1 and the
+  `nav-exempt` opt-out are load-bearing, not theoretical — without them a run
+  re-files what a human already answered.)
 - **No merging, no issue closing.** The human reviews each Draft PR; merging
   closes nothing automatically here.
 - **No parallelism — single writer.** One audit run at a time. Two overlapping
@@ -318,9 +319,21 @@ leaving the next author to re-derive it:
   is the current answer" from "this is how we got there".
 - **supersede-convention violations** (`adr-writing.md` requires marking a
   superseded section in place with a leading block quote plus a `†` in the
-  index row) — measured on 2026-08-08, `supersed*` appears in ADR-023 (×9),
-  ADR-027 (×2), ADR-020 (×2), ADR-021, ADR-022 and INDEX (×3), and the
-  majority are **cross-ADR** supersession, which the intra-file convention
-  does not govern. `†` exists only in ADR-028. A naive "mentions supersede ⇒
-  must carry †" predicate yields 5+ false positives. Needs the claim's scope
-  resolved (does this supersede a section of *this* file?) before it can fire.
+  index row) — measured 2026-08-08 with
+  `grep -ric 'supersed' docs/decisions/*.md` (matching lines, not occurrences)
+  and `grep -lc '†' docs/decisions/*.md`:
+
+  ```
+  ADR-028 21 · ADR-023 11 · ADR-002 9 · ADR-021 6 · ADR-017 4 · INDEX 3
+  ADR-004 2 · ADR-020 2 · ADR-027 2 · ADR-016 1 · ADR-018 1 · ADR-022 1
+  adr-writing-guide 1          †: ADR-028 only
+  ```
+
+  Thirteen files mention supersession, eleven of them `ADR-NNN.md`, and
+  exactly one carries `†` — so a naive "mentions supersede ⇒ must carry †"
+  predicate flags **ten ADRs**, nearly all wrongly. The mentions are mostly
+  about something other than an amendment inside the same file: ADR-027's
+  entry supersedes *ADR-021/-002* text, ADR-018's supersedes an *issue*'s
+  direction, and ADR-004's are about its own draft hold. The intra-file
+  convention governs none of those. Needs the claim's scope resolved — does
+  this supersede a section of *this* file? — before it can fire.

--- a/.claude/skills/consistency-audit/SKILL.md
+++ b/.claude/skills/consistency-audit/SKILL.md
@@ -331,9 +331,14 @@ leaving the next author to re-derive it:
 
   Thirteen files mention supersession, eleven of them `ADR-NNN.md`, and
   exactly one carries `†` — so a naive "mentions supersede ⇒ must carry †"
-  predicate flags **ten ADRs**, nearly all wrongly. The mentions are mostly
-  about something other than an amendment inside the same file: ADR-027's
-  entry supersedes *ADR-021/-002* text, ADR-018's supersedes an *issue*'s
-  direction, and ADR-004's are about its own draft hold. The intra-file
-  convention governs none of those. Needs the claim's scope resolved — does
-  this supersede a section of *this* file? — before it can fire.
+  predicate flags **ten ADRs**. Most mentions are about something the
+  intra-file convention does not govern: `ADR-027.md:352` supersedes
+  *ADR-021/-002* text, `ADR-018.md:184` supersedes an *issue*'s direction.
+  But not all — `ADR-004.md:402` ("This supersedes the 2026-06-11 … pointer
+  and the earlier … default this section leaned toward") supersedes ADR-004's
+  own earlier text and marks it with a bold `**Update**` instead of the block
+  quote + `†` the convention asks for, so it is a **true** positive the naive
+  predicate would catch. The deferral is therefore about precision, not about
+  the check being worthless: it needs the claim's scope resolved — does this
+  supersede a section of *this* file? — before it can fire without burying the
+  real hits under the cross-ADR ones.

--- a/.claude/skills/consistency-audit/scripts/audit_docs.py
+++ b/.claude/skills/consistency-audit/scripts/audit_docs.py
@@ -141,6 +141,38 @@ ROSTER_DECLARED = "ADR roster"
 # finding: see reservation_findings. Three is "a couple of reservations went
 # unparsed"; more is a structural accident.
 RESERVATION_FLOOD_CAP = 3
+# --- adr_navigation_missing ------------------------------------------------
+H2_HEADING = re.compile(r"^## ")
+# `re.I` is load-bearing, not cosmetic: every amendment heading in this repo
+# capitalises "Amendment" except ADR-002's four parenthetical ones, so dropping
+# the flag scores ADR-021 at 0% and silences it outright. fixtures/adr-nav-case
+# is the arm that reddens if it is ever removed.
+AMENDMENT_HEADING = re.compile(r"^## +(?:\d+\.\s*)?.*\bamendments?\b", re.I)
+NUMBERED_HEADING = re.compile(r"^## +\d+\.\s")
+# ADR-028's `## How to read this ADR` is the pattern; matched on the stable
+# prefix so a variant tail ("How to read ADR-028") still discharges.
+NAV_HEADING = re.compile(r"^## +How to read", re.I)
+# The opt-out. This is the first HTML-comment convention in docs/decisions/, so
+# both discharge routes are documented in `.claude/rules/adr-writing.md` — a
+# marker nobody can discover is a nag loop with extra steps.
+NAV_EXEMPT = re.compile(r"<!--\s*nav-exempt:")
+# A **fitted separator, not a derivation** — say so rather than let a reader
+# infer a principle that isn't there. Both boundaries are set by the same ADR
+# (ADR-021 at 653 lines / 52%), so the pair has one degree of freedom. What the
+# two terms mean: 50% is "the majority of the file is derivation log, so the
+# body is a minority of what a reader scrolls past" — a large ADR whose bulk is
+# *body* (ADR-005: 1479 lines, 8%) is not this problem; 600 is the operator's
+# judgment that ADR-021 is past what a reader can hold, set well below the
+# 2355-line/75% case #1382 actually problematised. Conservative per Output
+# Contract rule 6: prefer a miss.
+#
+# Known false-negative class: ADR-010 records amendments as inline bold
+# (`**Amendment 2026-06-20 …:**`), not as a heading, so it can never fire no
+# matter how far its amendments grow. Widening to catch it would have to
+# distinguish an amendment marker from any other bold lead-in, which is the
+# flood this detector is scoped to avoid.
+NAV_MIN_LINES = 600
+NAV_MIN_SHARE = 0.50
 # CommonMark lets an ATX heading sit flush against a paragraph on either side,
 # so a heading line is a paragraph boundary even though it is not blank. The
 # roster's own `### ADR roster` written without a blank line after it would
@@ -630,6 +662,129 @@ def roster_findings(claude_md: Path, index_md: Path,
     return out
 
 
+def navigation_findings(root: Path, tracked_adrs: set[str]) -> list[dict]:
+    """An ADR that is large, amendment-dominated, and carries no navigation
+    section — the reader problem #1382 measured on ADR-028, where the body a
+    reader actually wants sits under ~1750 lines of amendment.
+
+    The remedy this points at is the one ADR-028 demonstrated: add a map and
+    promote standing values into the body. It is NOT deletion — `adr-writing.md`
+    records that amendments are not trimmed away later, because a value with no
+    recorded derivation gets re-litigated. So this detector never proposes
+    removing anything, and it is needs_judgment: whether a given ADR has crossed
+    into unreadable is a human call.
+
+    Scoped to `tracked` ADRs for the same reason the listing detectors are: an
+    untracked draft is being written right now, and flagging its structure is
+    noise aimed at the one person who already knows.
+
+    Section classification is **title-based** — any `## ` heading naming
+    "amendment" counts, including a numbered section belonging to the ADR's own
+    outline (ADR-002 §10–§13 are exactly that shape). Taking the author's own
+    label at face value is deliberate: re-classifying a section the author
+    called an amendment would be the detector claiming to know the document
+    better than its writer. The cost is that the share can overstate how much is
+    really derivation log, so the finding carries the per-section breakdown and
+    the numbered count for the human to weigh."""
+    out: list[dict] = []
+    for nnn in sorted(tracked_adrs):
+        adr = f"ADR-{nnn}"
+        rel = f"{ADR_DIR}/{adr}.md"
+        try:
+            lines = (root / rel).read_text(encoding="utf-8").splitlines()
+        except OSError:
+            continue  # fail open: an unreadable ADR is not a finding
+        total = len(lines)
+        if total < NAV_MIN_LINES:
+            continue
+
+        # Fence-aware, like scan_doc: a `## Amendment`-shaped line inside a
+        # fenced block is illustration, not structure. Same for the opt-out
+        # marker — an ADR documenting the marker in an example must not thereby
+        # exempt itself.
+        headings: list[tuple[int, str]] = []
+        bare: list[str] = []
+        in_fence = False
+        fence_delim = ""
+        for idx, line in enumerate(lines):
+            fm = FENCE_DELIM.match(line)
+            if fm:
+                ticks = fm.group(2)
+                if not in_fence:
+                    in_fence, fence_delim = True, ticks[0]
+                elif ticks[0] == fence_delim:
+                    in_fence, fence_delim = False, ""
+                continue
+            if in_fence:
+                continue
+            bare.append(line)
+            if H2_HEADING.match(line):
+                headings.append((idx, line))
+
+        if any(NAV_HEADING.match(line) for _, line in headings):
+            continue
+        if any(NAV_EXEMPT.search(line) for line in bare):
+            continue
+
+        # Per-section spans, NOT first-amendment-to-EOF: ADR-023/029/027 all
+        # carry body sections *after* an amendment, which the EOF measure would
+        # count as amendment.
+        sections: list[dict] = []
+        for k, (idx, line) in enumerate(headings):
+            if not AMENDMENT_HEADING.match(line):
+                continue
+            end = headings[k + 1][0] if k + 1 < len(headings) else total
+            sections.append({"heading": line.strip(), "line": idx + 1,
+                             "lines": end - idx,
+                             "numbered": bool(NUMBERED_HEADING.match(line))})
+        amendment_lines = sum(s["lines"] for s in sections)
+        if not sections or amendment_lines < total * NAV_MIN_SHARE:
+            continue
+
+        numbered = sum(1 for s in sections if s["numbered"])
+        key = f"nav:{adr}"
+        out.append({
+            "type": "adr_navigation_missing",
+            "adr": adr, "target": key, "key": key,
+            "total_lines": total,
+            "amendment_lines": amendment_lines,
+            "amendment_share": round(amendment_lines / total, 3),
+            "section_count": len(sections),
+            "numbered_section_count": numbered,
+            "sections": sections,
+            "confidence": "medium",
+            "counter_evidence": (
+                f"Section classification is title-based, so a numbered section "
+                f"belonging to the ADR's own outline counts as an amendment — "
+                f"{numbered} of {len(sections)} classified sections here are "
+                f"numbered. Read the per-section breakdown before treating the "
+                f"share as pure derivation log. The thresholds "
+                f"({NAV_MIN_LINES} lines / {int(NAV_MIN_SHARE * 100)}%) are a "
+                f"deliberately conservative fitted separator, not a derived "
+                f"constant: an ADR just under them can have the same problem, "
+                f"and one just over it may still be perfectly readable. A "
+                f"maintainer who knows this document may simply judge it "
+                f"navigable as it stands."),
+            "suggested_action": (
+                f"Add a navigation section to {rel} — the `## How to read this "
+                f"ADR` pattern ADR-028 established — pointing at where the "
+                f"current answer lives, and promote any standing value or "
+                f"invariant that exists only inside an amendment into the body. "
+                f"Do NOT delete or trim amendments: `.claude/rules/"
+                f"adr-writing.md` records that they are not trimmed away later, "
+                f"because a value with no recorded derivation gets "
+                f"re-litigated. If you judge this ADR does not need a map, "
+                f"record `<!-- nav-exempt: <reason> -->` in the file — closing "
+                f"this issue without the marker re-files the finding on the "
+                f"next run."),
+            # The first `## ` heading is where a navigation section goes
+            # (ADR-028's sits at its first one), so it is the actionable anchor
+            # rather than the ADR's title line.
+            "file": rel, "line": (headings[0][0] + 1) if headings else 1,
+        })
+    return out
+
+
 def build_yaml_index(root: Path) -> dict[str, list[str]]:
     """basename -> [repo-relative paths] for every tracked-ish YAML under root.
     Used to resolve which source file an embedded `id:`-keyed block mirrors.
@@ -985,6 +1140,7 @@ def main() -> int:
         claude_md, reserved_adrs, index_adrs, existing_adrs)
     judg.extend(roster_findings(claude_md, index_md, index_adrs,
                                 tracked_adrs, existing_adrs, reserved_adrs))
+    judg.extend(navigation_findings(root, tracked_adrs))
     for doc in discover_docs(root):
         a, j = scan_doc(doc, root, resolved, min_ios, reserved_adrs, yaml_index)
         auto.extend(a)

--- a/.claude/skills/consistency-audit/scripts/audit_docs.py
+++ b/.claude/skills/consistency-audit/scripts/audit_docs.py
@@ -715,6 +715,13 @@ def navigation_findings(root: Path, tracked_adrs: set[str]) -> list[dict]:
     untracked draft is being written right now, and flagging its structure is
     noise aimed at the one person who already knows.
 
+    No flood cap, unlike reservation_findings': the count is bounded by the ADR
+    count and each finding is a distinct, individually-actionable document, so
+    collapsing them would only hide work. Backpressure is Step 4's per-target
+    open-issue dedup plus the `nav-exempt` opt-out — a run files each ADR once
+    and never re-files one a human has answered. Revisit if a repo ever lands
+    enough large ADRs at once for that to be insufficient.
+
     Section classification is **title-based** — any `## ` heading naming
     "amendment" counts, including a numbered section belonging to the ADR's own
     outline (ADR-002 §10–§13 are exactly that shape). Taking the author's own
@@ -790,13 +797,21 @@ def navigation_findings(root: Path, tracked_adrs: set[str]) -> list[dict]:
         residual = amendment_lines - numbered_lines
         residual_share = round(residual / total, 3)
         # Percentage for the prose. NOT `int(share * 100)`, which truncates a
-        # binary float and printed ADR-021's 51.8% as "51%". One decimal, and —
-        # load-bearing — the sentence's "under / still over the gate" clause
-        # branches on this **printed** value rather than on the raw ratio, so
-        # the number a maintainer reads can never contradict the claim beside
-        # it. Rounding alone does not achieve that: 49.96% rounds to a printed
-        # 50.0 while the raw value is genuinely under the 50 gate.
+        # binary float and printed ADR-021's 51.8% as "51%".
+        #
+        # The clause beside it branches on `residual_clears` — the SAME
+        # predicate the detector's own gate uses, so its meaning ("would this
+        # finding survive without the title-based call?") is always right. Two
+        # earlier attempts got this wrong in opposite directions: branching on
+        # the raw ratio while printing a truncated integer made the number
+        # disagree with the clause, and branching on the *printed* value fixed
+        # the display at the cost of inverting the meaning — at 49.96% the
+        # printed 50.0 said "still over" when the finding does not in fact
+        # survive. No rounding removes that: some raw value always rounds
+        # across any gate. So the clause names no percentage at all; the gate
+        # is stated once, in the thresholds sentence below.
         residual_pct = round(residual / total * 100, 1)
+        residual_clears = residual >= total * NAV_MIN_SHARE
         gate_pct = NAV_MIN_SHARE * 100
         key = f"nav:{adr}"
         out.append({
@@ -818,12 +833,12 @@ def navigation_findings(root: Path, tracked_adrs: set[str]) -> list[dict]:
                 f"numbered, supplying {numbered_lines} of {amendment_lines} "
                 f"amendment lines. Excluding them the share is "
                 f"{residual_pct}%"
-                + (f", under the {gate_pct:g}% gate — so this finding rests "
-                   f"entirely on the title-based call"
-                   if residual_pct < gate_pct else
-                   f", still over the {gate_pct:g}% gate")
+                + (" — still clears the share gate without them"
+                   if residual_clears else
+                   " — below the share gate, so this finding rests entirely "
+                   "on the title-based call")
                 + f". The thresholds "
-                f"({NAV_MIN_LINES} lines / {int(NAV_MIN_SHARE * 100)}%) are a "
+                f"({NAV_MIN_LINES} lines / {gate_pct:g}%) are a "
                 f"deliberately conservative fitted separator, not a derived "
                 f"constant: an ADR just under them can have the same problem, "
                 f"and one just over it may still be perfectly readable. A "
@@ -831,8 +846,10 @@ def navigation_findings(root: Path, tracked_adrs: set[str]) -> list[dict]:
                 f"navigable as it stands."),
             "suggested_action": (
                 f"Add a navigation section to {rel} — the `## How to read this "
-                f"ADR` pattern ADR-028 established — pointing at where the "
-                f"current answer lives, and promote any standing value or "
+                f"ADR` pattern ADR-028 established; the heading is matched on "
+                f"the `## How to read` prefix, so `## Navigation` or "
+                f"`## Section map` will not discharge this — pointing at where "
+                f"the current answer lives, and promote any standing value or "
                 f"invariant that exists only inside an amendment into the body. "
                 f"Do NOT delete or trim amendments: `.claude/rules/"
                 f"adr-writing.md` records that they are not trimmed away later, "

--- a/.claude/skills/consistency-audit/scripts/audit_docs.py
+++ b/.claude/skills/consistency-audit/scripts/audit_docs.py
@@ -20,8 +20,17 @@ Conservatism is deliberate: false positives poison the queue, so each detector
 prefers a miss over a wrong flag. Every shipped detector fires zero false
 positives on the current repo: dependency_version, min_ios, dead_link
 (needs_judgment), dangling_adr (needs_judgment), embedded_source_mirror
-(needs_judgment), unparsed_adr_reservation (needs_judgment), and
-adr_roster_drift (needs_judgment).
+(needs_judgment), unparsed_adr_reservation (needs_judgment),
+adr_roster_drift (needs_judgment), and adr_navigation_missing
+(needs_judgment).
+
+adr_navigation_missing is the first detector that reports on a clean `main` —
+two ADRs at the time it landed. That is not a false positive: the others
+describe states that should not exist, whereas this one describes a structural
+property a healthy repo can legitimately have and a maintainer may legitimately
+accept. It is why the `<!-- nav-exempt: … -->` opt-out exists — a finding whose
+correct resolution is sometimes "no" needs a place to record the no, or every
+run re-files it.
 Detectors that flood until their FP sources are designed out
 are intentionally deferred — see the SKILL's "Deferred detectors" note:
   - file:line citation checks   (docs cite source-root-relative paths, GitHub

--- a/.claude/skills/consistency-audit/scripts/audit_docs.py
+++ b/.claude/skills/consistency-audit/scripts/audit_docs.py
@@ -26,7 +26,8 @@ adr_navigation_missing (needs_judgment).
 A clean `main` is NOT a zero-findings state, and was not one before
 adr_navigation_missing landed. Measure before asserting otherwise:
 
-  python3 audit_docs.py --repo-root . | jq '[.needs_judgment[].type]|unique'
+  python3 .claude/skills/consistency-audit/scripts/audit_docs.py --repo-root . \
+    | jq '[.needs_judgment[].type] | unique'          # from the repo root
 
 Two standing reports, for opposite reasons:
 
@@ -182,12 +183,16 @@ NAV_HEADING = re.compile(r"^## +How to read", re.I)
 # both discharge routes are documented in `.claude/rules/adr-writing.md` — a
 # marker nobody can discover is a nag loop with extra steps.
 #
-# Anchored to its own line, which is the guard against *accidental* exemption:
-# the natural way to mention the marker in prose is an inline code span
-# (`` `<!-- nav-exempt: … -->` ``), and a substring search would let an ADR that
-# merely discusses the convention silently exempt itself. Fence-skipping alone
-# does not cover that — inline spans are not fences.
-NAV_EXEMPT = re.compile(r"^\s*<!--\s*nav-exempt:")
+# Anchored at column 0, which is the guard against *accidental* exemption. Two
+# ways to show the marker as an example evade a substring search's opposite:
+# an inline code span (`` `<!-- nav-exempt: … -->` ``), which no fence skip sees
+# because a span is not a fence; and a 4-space indented code block, which
+# FENCE_DELIM also ignores since it only recognises ``` / ~~~. Allowing leading
+# whitespace would re-admit the second. The cost is that a marker inside a list
+# item or block quote does not exempt either — so every instruction that tells a
+# human to write the marker must say "on a line of its own, unindented", and the
+# ADR-112 fixture arm holds the indented case.
+NAV_EXEMPT = re.compile(r"^<!--\s*nav-exempt:")
 # A **fitted separator, not a derivation** — say so rather than let a reader
 # infer a principle that isn't there. Both boundaries are set by the same ADR
 # (ADR-021 at 653 lines / 52%), so the pair has one degree of freedom. What the
@@ -784,6 +789,15 @@ def navigation_findings(root: Path, tracked_adrs: set[str]) -> list[dict]:
         numbered_lines = sum(s["lines"] for s in sections if s["numbered"])
         residual = amendment_lines - numbered_lines
         residual_share = round(residual / total, 3)
+        # Percentage for the prose. NOT `int(share * 100)`, which truncates a
+        # binary float and printed ADR-021's 51.8% as "51%". One decimal, and —
+        # load-bearing — the sentence's "under / still over the gate" clause
+        # branches on this **printed** value rather than on the raw ratio, so
+        # the number a maintainer reads can never contradict the claim beside
+        # it. Rounding alone does not achieve that: 49.96% rounds to a printed
+        # 50.0 while the raw value is genuinely under the 50 gate.
+        residual_pct = round(residual / total * 100, 1)
+        gate_pct = NAV_MIN_SHARE * 100
         key = f"nav:{adr}"
         out.append({
             "type": "adr_navigation_missing",
@@ -803,11 +817,11 @@ def navigation_findings(root: Path, tracked_adrs: set[str]) -> list[dict]:
                 f"{numbered} of {len(sections)} classified sections here are "
                 f"numbered, supplying {numbered_lines} of {amendment_lines} "
                 f"amendment lines. Excluding them the share is "
-                f"{int(residual_share * 100)}%"
-                + (f", under the {int(NAV_MIN_SHARE * 100)}% gate — so this "
-                   f"finding rests entirely on the title-based call"
-                   if residual < total * NAV_MIN_SHARE else
-                   f", still over the {int(NAV_MIN_SHARE * 100)}% gate")
+                f"{residual_pct}%"
+                + (f", under the {gate_pct:g}% gate — so this finding rests "
+                   f"entirely on the title-based call"
+                   if residual_pct < gate_pct else
+                   f", still over the {gate_pct:g}% gate")
                 + f". The thresholds "
                 f"({NAV_MIN_LINES} lines / {int(NAV_MIN_SHARE * 100)}%) are a "
                 f"deliberately conservative fitted separator, not a derived "
@@ -824,9 +838,11 @@ def navigation_findings(root: Path, tracked_adrs: set[str]) -> list[dict]:
                 f"adr-writing.md` records that they are not trimmed away later, "
                 f"because a value with no recorded derivation gets "
                 f"re-litigated. If you judge this ADR does not need a map, "
-                f"record `<!-- nav-exempt: <reason> -->` in the file — closing "
-                f"this issue without the marker re-files the finding on the "
-                f"next run."),
+                f"record `<!-- nav-exempt: <reason> -->` on a line of its own, "
+                f"unindented and not inside a list item or block quote — the "
+                f"marker is matched at column 0, so an indented one does not "
+                f"count. Closing this issue without a marker the detector can "
+                f"see re-files the finding on the next run."),
             # The first `## ` heading is where a navigation section goes
             # (ADR-028's sits at its first one), so it is the actionable anchor
             # rather than the ADR's title line. `headings` is non-empty here by

--- a/.claude/skills/consistency-audit/scripts/audit_docs.py
+++ b/.claude/skills/consistency-audit/scripts/audit_docs.py
@@ -17,19 +17,31 @@ Two finding classes:
                    section.
 
 Conservatism is deliberate: false positives poison the queue, so each detector
-prefers a miss over a wrong flag. Every shipped detector fires zero false
-positives on the current repo: dependency_version, min_ios, dead_link
-(needs_judgment), dangling_adr (needs_judgment), embedded_source_mirror
-(needs_judgment), unparsed_adr_reservation (needs_judgment),
-adr_roster_drift (needs_judgment), and adr_navigation_missing
-(needs_judgment).
+prefers a miss over a wrong flag. The shipped set is dependency_version,
+min_ios, dead_link (needs_judgment), dangling_adr (needs_judgment),
+embedded_source_mirror (needs_judgment), unparsed_adr_reservation
+(needs_judgment), adr_roster_drift (needs_judgment), and
+adr_navigation_missing (needs_judgment).
 
-adr_navigation_missing is the first detector that reports on a clean `main` —
-two ADRs at the time it landed. That is not a false positive: the others
-describe states that should not exist, whereas this one describes a structural
-property a healthy repo can legitimately have and a maintainer may legitimately
-accept. It is why the `<!-- nav-exempt: … -->` opt-out exists — a finding whose
-correct resolution is sometimes "no" needs a place to record the no, or every
+A clean `main` is NOT a zero-findings state, and was not one before
+adr_navigation_missing landed. Measure before asserting otherwise:
+
+  python3 audit_docs.py --repo-root . | jq '[.needs_judgment[].type]|unique'
+
+Two standing reports, for opposite reasons:
+
+  dead_link `ledger.md`             — docs/code-health/README.md links a file
+                                      that is gitignored by design, so it is
+                                      absent in every fresh clone and in CI.
+                                      A genuine false positive, and the
+                                      counterexample to any "zero FPs" claim.
+  adr_navigation_missing            — reports by design on a structural
+                                      property a healthy repo can legitimately
+                                      have and a maintainer may legitimately
+                                      accept. Not a defect in either direction.
+
+The second is why the `<!-- nav-exempt: … -->` opt-out exists: a finding whose
+correct resolution is sometimes "no" needs somewhere to record the no, or every
 run re-files it.
 Detectors that flood until their FP sources are designed out
 are intentionally deferred — see the SKILL's "Deferred detectors" note:
@@ -154,8 +166,13 @@ RESERVATION_FLOOD_CAP = 3
 H2_HEADING = re.compile(r"^## ")
 # `re.I` is load-bearing, not cosmetic: every amendment heading in this repo
 # capitalises "Amendment" except ADR-002's four parenthetical ones, so dropping
-# the flag scores ADR-021 at 0% and silences it outright. fixtures/adr-nav-case
-# is the arm that reddens if it is ever removed.
+# the flag scores ADR-021 at 0% and silences it outright. Arm ADR-101 in
+# tests/make_nav_fixture.py reddens if it is ever removed.
+#
+# `(?:\d+\.\s*)?` matches nothing `.*` would not already absorb — it is kept so
+# the "narrow to headings that START with Amendment" mutation in
+# tests/mutate_nav_guards.py is a one-token diff against this declaration,
+# which is what makes that control readable as the rejected alternative.
 AMENDMENT_HEADING = re.compile(r"^## +(?:\d+\.\s*)?.*\bamendments?\b", re.I)
 NUMBERED_HEADING = re.compile(r"^## +\d+\.\s")
 # ADR-028's `## How to read this ADR` is the pattern; matched on the stable
@@ -164,7 +181,13 @@ NAV_HEADING = re.compile(r"^## +How to read", re.I)
 # The opt-out. This is the first HTML-comment convention in docs/decisions/, so
 # both discharge routes are documented in `.claude/rules/adr-writing.md` — a
 # marker nobody can discover is a nag loop with extra steps.
-NAV_EXEMPT = re.compile(r"<!--\s*nav-exempt:")
+#
+# Anchored to its own line, which is the guard against *accidental* exemption:
+# the natural way to mention the marker in prose is an inline code span
+# (`` `<!-- nav-exempt: … -->` ``), and a substring search would let an ADR that
+# merely discusses the convention silently exempt itself. Fence-skipping alone
+# does not cover that — inline spans are not fences.
+NAV_EXEMPT = re.compile(r"^\s*<!--\s*nav-exempt:")
 # A **fitted separator, not a derivation** — say so rather than let a reader
 # infer a principle that isn't there. Both boundaries are set by the same ADR
 # (ADR-021 at 653 lines / 52%), so the pair has one degree of freedom. What the
@@ -708,9 +731,10 @@ def navigation_findings(root: Path, tracked_adrs: set[str]) -> list[dict]:
             continue
 
         # Fence-aware, like scan_doc: a `## Amendment`-shaped line inside a
-        # fenced block is illustration, not structure. Same for the opt-out
-        # marker — an ADR documenting the marker in an example must not thereby
-        # exempt itself.
+        # fenced block is illustration, not structure. The opt-out marker is
+        # searched over the same fence-stripped lines, but what actually stops a
+        # documenting mention from exempting the file is NAV_EXEMPT's own
+        # line anchor — see its declaration.
         headings: list[tuple[int, str]] = []
         bare: list[str] = []
         in_fence = False
@@ -751,6 +775,15 @@ def navigation_findings(root: Path, tracked_adrs: set[str]) -> list[dict]:
             continue
 
         numbered = sum(1 for s in sections if s["numbered"])
+        # The counter-evidence has to carry the *line* arithmetic, not just the
+        # section count: on ADR-002 four numbered outline sections supply 89% of
+        # the amendment lines, so "4 of 6 sections" reads as a partial caveat
+        # when the honest statement is that the finding evaporates without the
+        # title-based call. Making the reader do that division is the wrong way
+        # round under Output Contract rule 6.
+        numbered_lines = sum(s["lines"] for s in sections if s["numbered"])
+        residual = amendment_lines - numbered_lines
+        residual_share = round(residual / total, 3)
         key = f"nav:{adr}"
         out.append({
             "type": "adr_navigation_missing",
@@ -760,14 +793,22 @@ def navigation_findings(root: Path, tracked_adrs: set[str]) -> list[dict]:
             "amendment_share": round(amendment_lines / total, 3),
             "section_count": len(sections),
             "numbered_section_count": numbered,
+            "numbered_lines": numbered_lines,
+            "residual_share": residual_share,
             "sections": sections,
             "confidence": "medium",
             "counter_evidence": (
                 f"Section classification is title-based, so a numbered section "
                 f"belonging to the ADR's own outline counts as an amendment — "
                 f"{numbered} of {len(sections)} classified sections here are "
-                f"numbered. Read the per-section breakdown before treating the "
-                f"share as pure derivation log. The thresholds "
+                f"numbered, supplying {numbered_lines} of {amendment_lines} "
+                f"amendment lines. Excluding them the share is "
+                f"{int(residual_share * 100)}%"
+                + (f", under the {int(NAV_MIN_SHARE * 100)}% gate — so this "
+                   f"finding rests entirely on the title-based call"
+                   if residual < total * NAV_MIN_SHARE else
+                   f", still over the {int(NAV_MIN_SHARE * 100)}% gate")
+                + f". The thresholds "
                 f"({NAV_MIN_LINES} lines / {int(NAV_MIN_SHARE * 100)}%) are a "
                 f"deliberately conservative fitted separator, not a derived "
                 f"constant: an ADR just under them can have the same problem, "
@@ -788,8 +829,9 @@ def navigation_findings(root: Path, tracked_adrs: set[str]) -> list[dict]:
                 f"next run."),
             # The first `## ` heading is where a navigation section goes
             # (ADR-028's sits at its first one), so it is the actionable anchor
-            # rather than the ADR's title line.
-            "file": rel, "line": (headings[0][0] + 1) if headings else 1,
+            # rather than the ADR's title line. `headings` is non-empty here by
+            # construction — a non-empty `sections` implies it.
+            "file": rel, "line": headings[0][0] + 1,
         })
     return out
 

--- a/.claude/skills/consistency-audit/tests/make_nav_fixture.py
+++ b/.claude/skills/consistency-audit/tests/make_nav_fixture.py
@@ -64,6 +64,15 @@ ARMS: dict[str, tuple[str, list[str]]] = {
     "106": ("body section AFTER an amendment — span-sum vs EOF control",
             section("## Context", 40) + section("## Amendment 2026-01-01 — settled", 180)
             + section("## Consequences", 450)),
+    # FIRES: mentions the opt-out inside an inline code span, the natural way to
+    # write about it in prose. A substring search would let a document that
+    # merely *discusses* the marker exempt itself; fence-skipping does not cover
+    # this, because an inline span is not a fence.
+    "111": ("mentions the nav-exempt marker in prose, without adopting it",
+            ["An ADR opts out by putting `<!-- nav-exempt: reason -->` on its "
+             "own line.", ""]
+            + section("## Context", 250)
+            + section("## Amendment 2026-01-01 — settled", 400)),
     # Silent: `###` is not a top-level heading, so it is not a section boundary.
     "107": ("amendment recorded at ### level only",
             section("## Context", 250) + section("### Amendment 2026-01-01 — settled", 400)),
@@ -111,8 +120,8 @@ def main() -> int:
     # declares one, so omitting it keeps this fixture scoped to one detector.
     (root / "CLAUDE.md").write_text(
         "# adr_navigation_missing fixture\n\n"
-        "Ten arms; two must fire (ADR-101, ADR-110) and eight must stay "
-        "silent, each for its own stated reason.\n",
+        "Eleven arms; three must fire (ADR-101, ADR-110, ADR-111) and eight "
+        "must stay silent, each for its own stated reason.\n",
         encoding="utf-8")
     print(json.dumps(manifest, indent=2))
     return 0

--- a/.claude/skills/consistency-audit/tests/make_nav_fixture.py
+++ b/.claude/skills/consistency-audit/tests/make_nav_fixture.py
@@ -73,6 +73,15 @@ ARMS: dict[str, tuple[str, list[str]]] = {
              "own line.", ""]
             + section("## Context", 250)
             + section("## Amendment 2026-01-01 — settled", 400)),
+    # FIRES: shows the marker as a 4-space indented code block, the other way
+    # to write an example. FENCE_DELIM only recognises ``` / ~~~, so nothing
+    # strips it — the column-0 anchor is the only thing keeping this file from
+    # exempting itself.
+    "112": ("shows the nav-exempt marker as an indented code block",
+            ["An ADR opts out like this:", "",
+             "    <!-- nav-exempt: reason -->", ""]
+            + section("## Context", 250)
+            + section("## Amendment 2026-01-01 — settled", 400)),
     # Silent: `###` is not a top-level heading, so it is not a section boundary.
     "107": ("amendment recorded at ### level only",
             section("## Context", 250) + section("### Amendment 2026-01-01 — settled", 400)),
@@ -120,8 +129,8 @@ def main() -> int:
     # declares one, so omitting it keeps this fixture scoped to one detector.
     (root / "CLAUDE.md").write_text(
         "# adr_navigation_missing fixture\n\n"
-        "Eleven arms; three must fire (ADR-101, ADR-110, ADR-111) and eight "
-        "must stay silent, each for its own stated reason.\n",
+        "Twelve arms; four must fire (ADR-101, ADR-110, ADR-111, ADR-112) and "
+        "eight must stay silent, each for its own stated reason.\n",
         encoding="utf-8")
     print(json.dumps(manifest, indent=2))
     return 0

--- a/.claude/skills/consistency-audit/tests/make_nav_fixture.py
+++ b/.claude/skills/consistency-audit/tests/make_nav_fixture.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Materialize the adr_navigation_missing fixture repo into a target directory.
+
+Generated rather than committed, for a reason that is itself the point of the
+arms: every "must NOT count" arm has to clear NAV_MIN_LINES (600) so that it is
+silent because of the *counting* rule it tests and not because it is short. A
+control that cannot redden is measuring nothing. Ten such ADRs is ~5500 lines of
+filler; the arm table below IS the fixture, and the filler is noise materialized
+on demand.
+
+Emits a JSON manifest on stdout: {"ADR-NNN": {"total_lines": N}, ...}. The
+harness asserts every must-not-fire arm cleared the size gate, which is what
+stops a drifting generator from turning an arm into a false green.
+
+usage: make_nav_fixture.py <dir>
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+FILLER = ("Filler prose that carries no ADR reference and no heading, so it "
+          "contributes only to the line count.")
+
+
+def section(heading: str, n: int) -> list[str]:
+    return [heading, ""] + [FILLER] * n + [""]
+
+
+def fenced_section(heading: str, n: int, buried: str) -> list[str]:
+    """A section whose filler wraps a fenced block containing `buried` — the
+    shape that must not be read as structure."""
+    return ([heading, "", "```markdown", buried, "```", ""]
+            + [FILLER] * n + [""])
+
+
+# (nnn, title, body_lines, extra) — `extra` returns the lines after the intro.
+ARMS: dict[str, tuple[str, list[str]]] = {
+    # FIRES: plain capital `## Amendment <date>`. Doubles as the re.I control —
+    # without the flag `\bamendments?\b` cannot match "Amendment", this arm
+    # stops firing, and the expected-count assertion reddens.
+    "101": ("plain amendment heading, over both thresholds, no map",
+            section("## Context", 250) + section("## Amendment 2026-01-01 — settled", 400)),
+    # Silent: the navigation section discharges it (the ADR-028 shape).
+    "102": ("same bulk, but carries a navigation section",
+            section("## How to read this ADR", 20) + section("## Context", 250)
+            + section("## Amendment 2026-01-01 — settled", 400)),
+    # Silent: under the size gate. Share is 66%, so only size can be silencing it.
+    "103": ("high share but small — under the size gate",
+            section("## Context", 100) + section("## Amendment 2026-01-01 — settled", 200)),
+    # Silent: over the size gate, under the share gate. The second threshold
+    # needs its own arm — arm 103 cannot exercise it.
+    "104": ("large but body-dominated — under the share gate",
+            section("## Context", 600) + section("## Amendment 2026-01-01 — settled", 100)),
+    # Silent: the opt-out marker.
+    "105": ("would fire, but carries the nav-exempt marker",
+            ["<!-- nav-exempt: short enough to hold in one read -->", ""]
+            + section("## Context", 250)
+            + section("## Amendment 2026-01-01 — settled", 400)),
+    # Silent under per-section spans, FIRES under first-amendment-to-EOF. The
+    # two measures land on opposite sides of the gate by construction, so this
+    # arm is what catches an EOF-measuring implementation.
+    "106": ("body section AFTER an amendment — span-sum vs EOF control",
+            section("## Context", 40) + section("## Amendment 2026-01-01 — settled", 180)
+            + section("## Consequences", 450)),
+    # Silent: `###` is not a top-level heading, so it is not a section boundary.
+    "107": ("amendment recorded at ### level only",
+            section("## Context", 250) + section("### Amendment 2026-01-01 — settled", 400)),
+    # Silent: inline bold is not a heading. This is a real ADR's convention in
+    # this repo, and the permanent false-negative class the module docstring
+    # records. The arm title carries no `ADR-NNN` token — a reference to a
+    # fileless ADR would fire dangling_adr and contaminate this fixture.
+    "108": ("amendment recorded as inline bold only",
+            section("## Context", 250)
+            + ["## Notes", "", "**Amendment 2026-01-01:** recorded inline.", ""]
+            + [FILLER] * 400 + [""]),
+    # Silent: a heading-shaped line inside a fence is illustration.
+    "109": ("`## Amendment` appears only inside a fenced block",
+            section("## Context", 250)
+            + fenced_section("## Notes", 400, "## Amendment 2026-01-01 — an example")),
+    # FIRES: the numbered + lowercase-suffix shape (ADR-002 §10–13) and the
+    # `## N. Amendments` shape (ADR-005). Both must count, and both must be
+    # reported as numbered so the finding's counter-evidence is accurate.
+    "110": ("numbered and lowercase-suffix amendment shapes",
+            section("## Context", 120)
+            + section("## 10. Streaming Extension (2026-01-01 amendment)", 300)
+            + section("## 11. Amendments", 200)),
+}
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+    root = Path(sys.argv[1])
+    adr_dir = root / "docs" / "decisions"
+    adr_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest: dict[str, dict] = {}
+    index = ["# Decision records", ""]
+    for nnn, (title, extra) in sorted(ARMS.items()):
+        lines = [f"# ADR-{nnn} — {title}", ""] + extra
+        (adr_dir / f"ADR-{nnn}.md").write_text("\n".join(lines) + "\n",
+                                               encoding="utf-8")
+        manifest[f"ADR-{nnn}"] = {"total_lines": len(lines)}
+        index.append(f"## ADR-{nnn} — {title}")
+        index.append("")
+    (adr_dir / "INDEX.md").write_text("\n".join(index) + "\n", encoding="utf-8")
+    # No "ADR roster" line: roster_findings only probes a CLAUDE.md that
+    # declares one, so omitting it keeps this fixture scoped to one detector.
+    (root / "CLAUDE.md").write_text(
+        "# adr_navigation_missing fixture\n\n"
+        "Ten arms; two must fire (ADR-101, ADR-110) and eight must stay "
+        "silent, each for its own stated reason.\n",
+        encoding="utf-8")
+    print(json.dumps(manifest, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/consistency-audit/tests/make_nav_fixture.py
+++ b/.claude/skills/consistency-audit/tests/make_nav_fixture.py
@@ -2,11 +2,12 @@
 """Materialize the adr_navigation_missing fixture repo into a target directory.
 
 Generated rather than committed, for a reason that is itself the point of the
-arms: every "must NOT count" arm has to clear NAV_MIN_LINES (600) so that it is
-silent because of the *counting* rule it tests and not because it is short. A
-control that cannot redden is measuring nothing. Ten such ADRs is ~5500 lines of
-filler; the arm table below IS the fixture, and the filler is noise materialized
-on demand.
+arms: every arm except ADR-103 has to clear NAV_MIN_LINES (600), so that a
+silent one is silent because of the *counting* rule it tests and not because it
+is short. (ADR-103 is the deliberate exception — it is the arm that tests the
+size gate, so being short is what it exercises.) A control that cannot redden is
+measuring nothing. Those eleven arms are ~7300 lines of filler; the arm table
+below IS the fixture, and the filler is noise materialized on demand.
 
 Emits a JSON manifest on stdout: {"ADR-NNN": {"total_lines": N}, ...}. The
 harness asserts every must-not-fire arm cleared the size gate, which is what

--- a/.claude/skills/consistency-audit/tests/mutate_nav_guards.py
+++ b/.claude/skills/consistency-audit/tests/mutate_nav_guards.py
@@ -22,7 +22,7 @@ defended by *both* heading anchors (widening either alone is a no-op), and the
 first `###` mutation targeted the classifier when the collection filter was
 doing the work.
 
-usage: mutate_nav_guards.py [workdir]   (cwd must be this tests/ directory)
+usage: mutate_nav_guards.py            (cwd must be this tests/ directory)
 """
 from __future__ import annotations
 
@@ -46,8 +46,9 @@ MUTATIONS: list[tuple] = [
      [(AMD_DECL, AMD_DECL.replace(", re.I", ""))],
      "ADR-101", "stops",
      # 110's `## 11. Amendments` needs the flag too; without it 110 keeps only
-     # its lowercase-suffix section and falls to 47.9%, under the share gate.
-     {"ADR-110"}),
+     # its lowercase-suffix section and falls to 48.0%, under the share gate.
+     # 111 carries the same capital-A heading as 101 and drops out with it.
+     {"ADR-110", "ADR-111"}),
     ("measure first-amendment-to-EOF instead of per-section spans",
      [("            end = headings[k + 1][0] if k + 1 < len(headings) else total",
        "            end = total")],
@@ -76,7 +77,17 @@ MUTATIONS: list[tuple] = [
     ("drop the nav-exempt opt-out",
      [("        if any(NAV_EXEMPT.search(line) for line in bare):\n            continue",
        "        if False:\n            continue")],
-     "ADR-105", "starts", set()),
+     "ADR-105", "starts",
+     # 111 mentions the marker in prose and must keep firing either way; it is
+     # unaffected here because the mutation removes the check entirely.
+     set()),
+    # Un-anchor the marker so a mention counts as an adoption. ADR-111 is the
+    # arm: it discusses the marker in an inline code span, which no fence skip
+    # can see.
+    ("un-anchor NAV_EXEMPT so a prose mention exempts the file",
+     [(r'NAV_EXEMPT = re.compile(r"^\s*<!--\s*nav-exempt:")',
+       r'NAV_EXEMPT = re.compile(r"<!--\s*nav-exempt:")')],
+     "ADR-111", "stops", set()),
     ("drop the navigation-section check",
      [("        if any(NAV_HEADING.match(line) for _, line in headings):\n            continue",
        "        if False:\n            continue")],
@@ -89,11 +100,11 @@ MUTATIONS: list[tuple] = [
      [("        if not sections or amendment_lines < total * NAV_MIN_SHARE:",
        "        if not sections or False:")],
      "ADR-104", "starts",
-     # 106 is silent *because of* the share gate (span-sum share 26.7%).
+     # 106 is silent *because of* the share gate (span-sum share 26.9%).
      {"ADR-106"}),
 ]
 
-BASELINE = {"ADR-101", "ADR-110"}
+BASELINE = {"ADR-101", "ADR-110", "ADR-111"}
 
 
 def fired(script: Path, fixdir: Path) -> set[str]:
@@ -119,15 +130,22 @@ def main() -> int:
             return 1
         mutant = work / "mutant.py"
         for name, pairs, arm, expect, collateral in MUTATIONS:
-            if any(old not in orig for old, _ in pairs):
-                print(f"FAIL: anchor miss for {name!r} — the mutation would "
-                      f"no-op and the control would pass vacuously",
-                      file=sys.stderr)
+            # Checked against the progressively-mutated text, not `orig`: in a
+            # multi-pair mutation an earlier replacement can invalidate a later
+            # anchor, and checking the original would miss exactly that.
+            text = orig
+            missed = False
+            for old, new in pairs:
+                if old not in text:
+                    print(f"FAIL: anchor miss for {name!r} — the mutation "
+                          f"would no-op and the control would pass vacuously",
+                          file=sys.stderr)
+                    missed = True
+                    break
+                text = text.replace(old, new, 1)
+            if missed:
                 ok = False
                 continue
-            text = orig
-            for old, new in pairs:
-                text = text.replace(old, new, 1)
             mutant.write_text(text, encoding="utf-8")
             got = fired(mutant, fixdir)
             flipped = (arm in base and arm not in got) if expect == "stops" \

--- a/.claude/skills/consistency-audit/tests/mutate_nav_guards.py
+++ b/.claude/skills/consistency-audit/tests/mutate_nav_guards.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Negative controls for adr_navigation_missing: one mutation per guard.
+
+The fixture arms in make_nav_fixture.py are silent by design, and a silent arm
+proves nothing on its own — a guard's success case never demonstrates the guard
+exists. Each mutation below disables exactly one guard and asserts the arm that
+claims to defend against it flips. An arm with no mutation here is an untested
+arm, so every arm has one.
+
+Two things this checks that a naive mutation harness does not:
+
+  * **The anchor matched.** A `str.replace` that finds nothing leaves the
+    original behaviour and reads as a passing control.
+  * **Collateral is declared, not ignored.** A second arm that also depends on
+    the mutated guard is real coupling and is listed; an *undeclared* flip means
+    the arm is not keyed to this guard alone and would redden for the wrong
+    reason.
+
+Two arms took more than one attempt to key correctly, which is why the harness
+is committed rather than run once by hand: `###` exclusion turned out to be
+defended by *both* heading anchors (widening either alone is a no-op), and the
+first `###` mutation targeted the classifier when the collection filter was
+doing the work.
+
+usage: mutate_nav_guards.py [workdir]   (cwd must be this tests/ directory)
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+SRC = Path("../scripts/audit_docs.py")
+GEN = Path("make_nav_fixture.py")
+
+AMD_DECL = (r'AMENDMENT_HEADING = re.compile('
+            r'r"^## +(?:\d+\.\s*)?.*\bamendments?\b", re.I)')
+H2_DECL = 'H2_HEADING = re.compile(r"^## ")'
+
+# (name, replacements, arm, expectation, declared_collateral)
+MUTATIONS: list[tuple] = [
+    ("drop re.I on AMENDMENT_HEADING",
+     [(AMD_DECL, AMD_DECL.replace(", re.I", ""))],
+     "ADR-101", "stops",
+     # 110's `## 11. Amendments` needs the flag too; without it 110 keeps only
+     # its lowercase-suffix section and falls to 47.9%, under the share gate.
+     {"ADR-110"}),
+    ("measure first-amendment-to-EOF instead of per-section spans",
+     [("            end = headings[k + 1][0] if k + 1 < len(headings) else total",
+       "            end = total")],
+     "ADR-106", "starts", set()),
+    ("widen both heading anchors to ###",
+     [(H2_DECL, 'H2_HEADING = re.compile(r"^#{2,3} ")'),
+      ('AMENDMENT_HEADING = re.compile(r"^## +',
+       'AMENDMENT_HEADING = re.compile(r"^#{2,3} +')],
+     "ADR-107", "starts", set()),
+    ("count inline-bold markers as amendment headings",
+     [(H2_DECL, 'H2_HEADING = re.compile(r"^(?:## |\\*\\*Amendment)")'),
+      (AMD_DECL, r'AMENDMENT_HEADING = re.compile('
+                 r'r"^(?:## +(?:\d+\.\s*)?|\*\*).*\bamendments?\b", re.I)')],
+     "ADR-108", "starts", set()),
+    # The narrowing this detector considered and declined: it silences the
+    # numbered / lowercase-suffix shape, so ADR-110 records the *choice*, not
+    # merely the behaviour.
+    ("narrow to headings that START with Amendment",
+     [(AMD_DECL, r'AMENDMENT_HEADING = re.compile('
+                 r'r"^## +(?:\d+\.\s*)?Amendments?\b", re.I)')],
+     "ADR-110", "stops", set()),
+    ("drop the fence skip",
+     [("            if in_fence:\n                continue\n            bare.append(line)",
+       "            if False:\n                continue\n            bare.append(line)")],
+     "ADR-109", "starts", set()),
+    ("drop the nav-exempt opt-out",
+     [("        if any(NAV_EXEMPT.search(line) for line in bare):\n            continue",
+       "        if False:\n            continue")],
+     "ADR-105", "starts", set()),
+    ("drop the navigation-section check",
+     [("        if any(NAV_HEADING.match(line) for _, line in headings):\n            continue",
+       "        if False:\n            continue")],
+     "ADR-102", "starts", set()),
+    ("drop the size gate",
+     [("        if total < NAV_MIN_LINES:\n            continue",
+       "        if False:\n            continue")],
+     "ADR-103", "starts", set()),
+    ("drop the share gate",
+     [("        if not sections or amendment_lines < total * NAV_MIN_SHARE:",
+       "        if not sections or False:")],
+     "ADR-104", "starts",
+     # 106 is silent *because of* the share gate (span-sum share 26.7%).
+     {"ADR-106"}),
+]
+
+BASELINE = {"ADR-101", "ADR-110"}
+
+
+def fired(script: Path, fixdir: Path) -> set[str]:
+    shutil.rmtree(fixdir, ignore_errors=True)
+    subprocess.run([sys.executable, str(GEN), str(fixdir)], check=True,
+                   stdout=subprocess.DEVNULL)
+    out = subprocess.run([sys.executable, str(script), "--repo-root", str(fixdir)],
+                         capture_output=True, text=True, check=True).stdout
+    return {f["adr"] for f in json.loads(out)["needs_judgment"]
+            if f["type"] == "adr_navigation_missing"}
+
+
+def main() -> int:
+    orig = SRC.read_text(encoding="utf-8")
+    ok = True
+    with tempfile.TemporaryDirectory() as td:
+        work = Path(td)
+        fixdir = work / "fix"
+        base = fired(SRC, fixdir)
+        if base != BASELINE:
+            print(f"FAIL: baseline fires {sorted(base)}, expected "
+                  f"{sorted(BASELINE)}", file=sys.stderr)
+            return 1
+        mutant = work / "mutant.py"
+        for name, pairs, arm, expect, collateral in MUTATIONS:
+            if any(old not in orig for old, _ in pairs):
+                print(f"FAIL: anchor miss for {name!r} — the mutation would "
+                      f"no-op and the control would pass vacuously",
+                      file=sys.stderr)
+                ok = False
+                continue
+            text = orig
+            for old, new in pairs:
+                text = text.replace(old, new, 1)
+            mutant.write_text(text, encoding="utf-8")
+            got = fired(mutant, fixdir)
+            flipped = (arm in base and arm not in got) if expect == "stops" \
+                else (arm not in base and arm in got)
+            undeclared = (got ^ base) - {arm} - collateral
+            if flipped and not undeclared:
+                print(f"  ok   {arm} {expect:<6} <- {name}")
+            else:
+                ok = False
+                print(f"  FAIL {arm} {expect:<6} <- {name}: got {sorted(got)}"
+                      + (f", undeclared collateral {sorted(undeclared)}"
+                         if undeclared else ""), file=sys.stderr)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/consistency-audit/tests/mutate_nav_guards.py
+++ b/.claude/skills/consistency-audit/tests/mutate_nav_guards.py
@@ -47,8 +47,8 @@ MUTATIONS: list[tuple] = [
      "ADR-101", "stops",
      # 110's `## 11. Amendments` needs the flag too; without it 110 keeps only
      # its lowercase-suffix section and falls to 48.0%, under the share gate.
-     # 111 carries the same capital-A heading as 101 and drops out with it.
-     {"ADR-110", "ADR-111"}),
+     # 111 and 112 carry the same capital-A heading as 101 and drop out with it.
+     {"ADR-110", "ADR-111", "ADR-112"}),
     ("measure first-amendment-to-EOF instead of per-section spans",
      [("            end = headings[k + 1][0] if k + 1 < len(headings) else total",
        "            end = total")],
@@ -81,13 +81,20 @@ MUTATIONS: list[tuple] = [
      # 111 mentions the marker in prose and must keep firing either way; it is
      # unaffected here because the mutation removes the check entirely.
      set()),
-    # Un-anchor the marker so a mention counts as an adoption. ADR-111 is the
-    # arm: it discusses the marker in an inline code span, which no fence skip
-    # can see.
+    # Un-anchor the marker entirely so any mention counts as an adoption.
+    # ADR-111 is the arm: it discusses the marker in an inline code span, which
+    # no fence skip can see. ADR-112 flips too — an unanchored pattern matches
+    # its indented example as well.
     ("un-anchor NAV_EXEMPT so a prose mention exempts the file",
-     [(r'NAV_EXEMPT = re.compile(r"^\s*<!--\s*nav-exempt:")',
+     [(r'NAV_EXEMPT = re.compile(r"^<!--\s*nav-exempt:")',
        r'NAV_EXEMPT = re.compile(r"<!--\s*nav-exempt:")')],
-     "ADR-111", "stops", set()),
+     "ADR-111", "stops", {"ADR-112"}),
+    # Allow leading whitespace — the weaker anchor this started with. Only the
+    # indented-code-block arm can tell the two apart, which is why it exists.
+    ("allow leading whitespace before the marker",
+     [(r'NAV_EXEMPT = re.compile(r"^<!--\s*nav-exempt:")',
+       r'NAV_EXEMPT = re.compile(r"^\s*<!--\s*nav-exempt:")')],
+     "ADR-112", "stops", set()),
     ("drop the navigation-section check",
      [("        if any(NAV_HEADING.match(line) for _, line in headings):\n            continue",
        "        if False:\n            continue")],
@@ -104,7 +111,7 @@ MUTATIONS: list[tuple] = [
      {"ADR-106"}),
 ]
 
-BASELINE = {"ADR-101", "ADR-110", "ADR-111"}
+BASELINE = {"ADR-101", "ADR-110", "ADR-111", "ADR-112"}
 
 
 def fired(script: Path, fixdir: Path) -> set[str]:

--- a/.claude/skills/consistency-audit/tests/run_tests.sh
+++ b/.claude/skills/consistency-audit/tests/run_tests.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 # Self-test for the consistency-audit detector. No Swift toolchain or network
-# needed — exercises the fixture repos (clean / drift / judgment / boundary /
-# adr) against audit_docs.py, including the must-NOT-fire regression set, the
-# Package.resolved version-vs-revision trap, and the dangling-ADR reserved-set
-# / first-cell-keying guards.
+# needed — exercises the fixture repos under fixtures/ against audit_docs.py,
+# plus the generated adr_navigation_missing fixture, covering the must-NOT-fire
+# regression sets, the Package.resolved version-vs-revision trap, the
+# dangling-ADR reserved-set / first-cell-keying guards, and one mutation per
+# navigation guard. No fixture roster here: each block below names the fixture
+# it drives, and a summary list at the top only went stale.
+#
+# Assertions are fixture-only, deliberately: this runs in CI on every PR with
+# no path filter, so an assertion about the live repo would redden unrelated
+# work whenever an ADR's line count moved.
 #
 # usage: bash .claude/skills/consistency-audit/tests/run_tests.sh
 # requires: python3, jq

--- a/.claude/skills/consistency-audit/tests/run_tests.sh
+++ b/.claude/skills/consistency-audit/tests/run_tests.sh
@@ -410,11 +410,11 @@ echo "$OUT" | jq -e '[.needs_judgment[]|select(.type=="embedded_source_mirror")|
   || fail "mirror: a mirror finding is missing its pre-authored judgment scalars"
 no_target_collision "$OUT" "mirror"
 
-# --- adr_navigation_missing: ten arms, exactly two must fire ---------------
-# The fixture is generated, not committed: every must-NOT-fire arm has to clear
-# the 600-line gate so it is silent for the rule it tests rather than for its
-# size, and ten such ADRs would be ~5500 lines of filler in the repo. The arm
-# table in make_nav_fixture.py is the fixture; this block asserts the outcome.
+# --- adr_navigation_missing: twelve arms, exactly four must fire -----------
+# The fixture is generated, not committed: every arm but ADR-103 has to clear
+# the 600-line gate so a silent one is silent for the rule it tests rather than
+# for its size, and those eleven are ~7300 lines of filler. The arm table in
+# make_nav_fixture.py is the fixture; this block asserts the outcome.
 NAVFIX="$TMP/navfix"
 MANIFEST=$(python3 make_nav_fixture.py "$NAVFIX")
 # The wrong-reason guard: a silent arm must be silent for the rule it tests,
@@ -456,20 +456,33 @@ NUM=$(echo "$OUT" | jq '[.needs_judgment[]|select(.target=="nav:ADR-110")|.numbe
 # test against "0" fails on a correct value.
 echo "$OUT" | jq -e '[.needs_judgment[]|select(.target=="nav:ADR-110")|.residual_share][0] == 0' >/dev/null \
   || fail "nav: ADR-110's residual share should be 0 (both sections numbered), got $(echo "$OUT" | jq -c '[.needs_judgment[]|select(.target=="nav:ADR-110")|.residual_share][0]')"
-echo "$OUT" | jq -e '.needs_judgment[]|select(.target=="nav:ADR-110")|.counter_evidence|test("rests entirely on the title-based call")' >/dev/null \
+echo "$OUT" | jq -e '.needs_judgment[]|select(.target=="nav:ADR-110")|.counter_evidence|test("below the share gate, so this finding rests entirely on the title-based call")' >/dev/null \
   || fail "nav: ADR-110's counter_evidence must say the finding rests on the title-based call"
+# The clause must name no percentage of its own: it branches on the raw
+# comparison, so a printed figure beside it could disagree at the boundary
+# (49.96% prints as 50.0). The gate appears once, in the thresholds sentence.
+echo "$OUT" | jq -e '[.needs_judgment[]|select(.type=="adr_navigation_missing")|.counter_evidence|test("(under|over|below|clears) the [0-9.]+% gate")|not]|all' >/dev/null \
+  || fail "nav: a counter_evidence clause restates the gate percentage — it can contradict the printed share at the boundary"
 # The interpolated arithmetic, not just the clause around it — a regression that
 # emits the right sentence with wrong numbers is exactly the defect the int()
 # truncation was. ADR-110's two sections are both numbered, so numbered_lines
-# equals amendment_lines and the residual reads 0%.
+# equals amendment_lines and the residual reads 0.0%.
+#
+# Scope, since this reads stronger than it is: the hardcoded `0.0%` catches a
+# truncation regression (an int() prints `0`), and reusing $AL on both sides
+# catches prose/field divergence. It can NOT catch an `amendment_lines` that is
+# wrong but self-consistent — field and sentence move together. The absolute
+# assertion on the next line pins that, from the arm table's own spans
+# (300 + 200 filler lines + 3 structural lines each).
 AL=$(echo "$OUT" | jq -r '[.needs_judgment[]|select(.target=="nav:ADR-110")|.amendment_lines][0]')
+[ "$AL" -eq 506 ] || fail "nav: ADR-110's amendment_lines should be 506 from the arm table, got $AL"
 echo "$OUT" | jq -e --arg s "supplying $AL of $AL amendment lines. Excluding them the share is 0.0%" \
   '.needs_judgment[]|select(.target=="nav:ADR-110")|.counter_evidence|contains($s)' >/dev/null \
   || fail "nav: ADR-110's counter_evidence arithmetic does not match its own fields: $(echo "$OUT" | jq -r '[.needs_judgment[]|select(.target=="nav:ADR-110")|.counter_evidence][0]' | head -c 200)"
 # ADR-101 is the contrast: no numbered sections, so its residual share equals
 # its full share and the counter-evidence must NOT claim the finding evaporates.
-echo "$OUT" | jq -e '.needs_judgment[]|select(.target=="nav:ADR-101")|.counter_evidence|test("still over the")' >/dev/null \
-  || fail "nav: ADR-101's counter_evidence should report the residual share as still over the gate"
+echo "$OUT" | jq -e '.needs_judgment[]|select(.target=="nav:ADR-101")|.counter_evidence|test("still clears the share gate without them")' >/dev/null \
+  || fail "nav: ADR-101's counter_evidence should report the residual share as still clearing the gate"
 # The remedy is a map plus promotion into the body — never deletion.
 # `.claude/rules/adr-writing.md` records that amendments are not trimmed away
 # later (#1382 declined that on principle), so a generator proposing it would

--- a/.claude/skills/consistency-audit/tests/run_tests.sh
+++ b/.claude/skills/consistency-audit/tests/run_tests.sh
@@ -404,4 +404,57 @@ echo "$OUT" | jq -e '[.needs_judgment[]|select(.type=="embedded_source_mirror")|
   || fail "mirror: a mirror finding is missing its pre-authored judgment scalars"
 no_target_collision "$OUT" "mirror"
 
+# --- adr_navigation_missing: ten arms, exactly two must fire ---------------
+# The fixture is generated, not committed: every must-NOT-fire arm has to clear
+# the 600-line gate so it is silent for the rule it tests rather than for its
+# size, and ten such ADRs would be ~5500 lines of filler in the repo. The arm
+# table in make_nav_fixture.py is the fixture; this block asserts the outcome.
+NAVFIX="$TMP/navfix"
+MANIFEST=$(python3 make_nav_fixture.py "$NAVFIX")
+# The wrong-reason guard. ADR-103 is the one arm deliberately under the gate
+# (it tests the gate); every other arm must clear it, or a "must not count"
+# arm is passing because it is short.
+for adr in ADR-101 ADR-102 ADR-104 ADR-105 ADR-106 ADR-107 ADR-108 ADR-109 ADR-110; do
+  n=$(echo "$MANIFEST" | jq --arg a "$adr" '.[$a].total_lines')
+  [ "$n" -ge 600 ] || fail "nav: $adr is only $n lines — under the size gate, so its arm would pass for the wrong reason"
+done
+NL=$(echo "$MANIFEST" | jq '."ADR-103".total_lines')
+[ "$NL" -lt 600 ] || fail "nav: ADR-103 must stay under the size gate to test it, got $NL"
+
+OUT=$(python3 "$AUDIT" --repo-root "$NAVFIX")
+[ "$(af_len "$OUT")" -eq 0 ] || fail "nav: auto_fixable must stay empty — this detector is needs_judgment only: $(echo "$OUT" | jq -c .auto_fixable)"
+# No other detector may fire: a contaminated fixture (e.g. an arm title naming a
+# fileless ADR-NNN, which trips dangling_adr) makes the counts below meaningless.
+[ "$(nj_len "$OUT")" -eq 2 ] || fail "nav: expected exactly 2 findings, got $(nj_len "$OUT"): $(echo "$OUT" | jq -c '[.needs_judgment[]|{type,target}]')"
+[ "$(nj_type_len "$OUT" adr_navigation_missing)" -eq 2 ] || fail "nav: expected 2 adr_navigation_missing, got $(nj_type_len "$OUT" adr_navigation_missing)"
+for want in "nav:ADR-101" "nav:ADR-110"; do
+  echo "$OUT" | jq -e --arg t "$want" '.needs_judgment[]|select(.type=="adr_navigation_missing" and .target==$t)' >/dev/null \
+    || fail "nav: expected a finding targeted $want"
+done
+# `nav:` namespacing, for the same reason `roster:` carries it — Step 4's
+# cross-run dedup matches the target as a title substring and is type-blind.
+echo "$OUT" | jq -e '[.needs_judgment[]|select(.type=="adr_navigation_missing")|.target|startswith("nav:")]|all' >/dev/null \
+  || fail "nav: a finding target is not namespaced with nav:"
+# Pre-authored judgment scalars — SKILL.md Step 4 uses these verbatim.
+echo "$OUT" | jq -e '[.needs_judgment[]|select(.type=="adr_navigation_missing")|(has("confidence") and has("counter_evidence") and has("suggested_action") and has("sections") and (.locations|length>0))]|all' >/dev/null \
+  || fail "nav: a finding is missing its pre-authored judgment scalars or locations"
+# The counter-evidence leans on this count, so it is asserted rather than
+# assumed: ADR-110's two sections are both numbered.
+NUM=$(echo "$OUT" | jq '[.needs_judgment[]|select(.target=="nav:ADR-110")|.numbered_section_count][0]')
+[ "$NUM" -eq 2 ] || fail "nav: ADR-110 should report 2 numbered sections, got $NUM"
+# The remedy is a map plus promotion into the body — never deletion.
+# `.claude/rules/adr-writing.md` records that amendments are not trimmed away
+# later (#1382 declined that on principle), so a generator proposing it would
+# be putting an unattended run at odds with a house rule. Asserted as a plain
+# positive: the disclaimer must be present, which cannot pass vacuously.
+echo "$OUT" | jq -e '[.needs_judgment[]|select(.type=="adr_navigation_missing")|.suggested_action|test("Do NOT delete or trim amendments")]|all' >/dev/null \
+  || fail "nav: suggested_action lost its do-not-delete disclaimer"
+no_target_collision "$OUT" "nav"
+
+# --- negative controls: each guard has a mutation that flips its arm --------
+# Silent arms prove nothing by themselves; this is what demonstrates the guards
+# exist. Also asserts every mutation's anchor matched, so a no-op replace cannot
+# pass as a verified control.
+python3 mutate_nav_guards.py || fail "nav: a guard's negative control did not flip (see above)"
+
 echo "ALL TESTS PASSED"

--- a/.claude/skills/consistency-audit/tests/run_tests.sh
+++ b/.claude/skills/consistency-audit/tests/run_tests.sh
@@ -417,10 +417,11 @@ no_target_collision "$OUT" "mirror"
 # table in make_nav_fixture.py is the fixture; this block asserts the outcome.
 NAVFIX="$TMP/navfix"
 MANIFEST=$(python3 make_nav_fixture.py "$NAVFIX")
-# The wrong-reason guard. ADR-103 is the one arm deliberately under the gate
-# (it tests the gate); every other arm must clear it, or a "must not count"
-# arm is passing because it is short.
-for adr in ADR-101 ADR-102 ADR-104 ADR-105 ADR-106 ADR-107 ADR-108 ADR-109 ADR-110 ADR-111; do
+# The wrong-reason guard: a silent arm must be silent for the rule it tests,
+# not because it fell under the size gate. ADR-103 is the one arm deliberately
+# under the gate (it tests the gate); every other arm — firing or silent —
+# must clear it.
+for adr in ADR-101 ADR-102 ADR-104 ADR-105 ADR-106 ADR-107 ADR-108 ADR-109 ADR-110 ADR-111 ADR-112; do
   n=$(echo "$MANIFEST" | jq --arg a "$adr" '.[$a].total_lines')
   [ "$n" -ge 600 ] || fail "nav: $adr is only $n lines — under the size gate, so its arm would pass for the wrong reason"
 done
@@ -431,9 +432,9 @@ OUT=$(python3 "$AUDIT" --repo-root "$NAVFIX")
 [ "$(af_len "$OUT")" -eq 0 ] || fail "nav: auto_fixable must stay empty — this detector is needs_judgment only: $(echo "$OUT" | jq -c .auto_fixable)"
 # No other detector may fire: a contaminated fixture (e.g. an arm title naming a
 # fileless ADR-NNN, which trips dangling_adr) makes the counts below meaningless.
-[ "$(nj_len "$OUT")" -eq 3 ] || fail "nav: expected exactly 3 findings, got $(nj_len "$OUT"): $(echo "$OUT" | jq -c '[.needs_judgment[]|{type,target}]')"
-[ "$(nj_type_len "$OUT" adr_navigation_missing)" -eq 3 ] || fail "nav: expected 3 adr_navigation_missing, got $(nj_type_len "$OUT" adr_navigation_missing)"
-for want in "nav:ADR-101" "nav:ADR-110" "nav:ADR-111"; do
+[ "$(nj_len "$OUT")" -eq 4 ] || fail "nav: expected exactly 4 findings, got $(nj_len "$OUT"): $(echo "$OUT" | jq -c '[.needs_judgment[]|{type,target}]')"
+[ "$(nj_type_len "$OUT" adr_navigation_missing)" -eq 4 ] || fail "nav: expected 4 adr_navigation_missing, got $(nj_type_len "$OUT" adr_navigation_missing)"
+for want in "nav:ADR-101" "nav:ADR-110" "nav:ADR-111" "nav:ADR-112"; do
   echo "$OUT" | jq -e --arg t "$want" '.needs_judgment[]|select(.type=="adr_navigation_missing" and .target==$t)' >/dev/null \
     || fail "nav: expected a finding targeted $want"
 done
@@ -457,6 +458,14 @@ echo "$OUT" | jq -e '[.needs_judgment[]|select(.target=="nav:ADR-110")|.residual
   || fail "nav: ADR-110's residual share should be 0 (both sections numbered), got $(echo "$OUT" | jq -c '[.needs_judgment[]|select(.target=="nav:ADR-110")|.residual_share][0]')"
 echo "$OUT" | jq -e '.needs_judgment[]|select(.target=="nav:ADR-110")|.counter_evidence|test("rests entirely on the title-based call")' >/dev/null \
   || fail "nav: ADR-110's counter_evidence must say the finding rests on the title-based call"
+# The interpolated arithmetic, not just the clause around it — a regression that
+# emits the right sentence with wrong numbers is exactly the defect the int()
+# truncation was. ADR-110's two sections are both numbered, so numbered_lines
+# equals amendment_lines and the residual reads 0%.
+AL=$(echo "$OUT" | jq -r '[.needs_judgment[]|select(.target=="nav:ADR-110")|.amendment_lines][0]')
+echo "$OUT" | jq -e --arg s "supplying $AL of $AL amendment lines. Excluding them the share is 0.0%" \
+  '.needs_judgment[]|select(.target=="nav:ADR-110")|.counter_evidence|contains($s)' >/dev/null \
+  || fail "nav: ADR-110's counter_evidence arithmetic does not match its own fields: $(echo "$OUT" | jq -r '[.needs_judgment[]|select(.target=="nav:ADR-110")|.counter_evidence][0]' | head -c 200)"
 # ADR-101 is the contrast: no numbered sections, so its residual share equals
 # its full share and the counter-evidence must NOT claim the finding evaporates.
 echo "$OUT" | jq -e '.needs_judgment[]|select(.target=="nav:ADR-101")|.counter_evidence|test("still over the")' >/dev/null \

--- a/.claude/skills/consistency-audit/tests/run_tests.sh
+++ b/.claude/skills/consistency-audit/tests/run_tests.sh
@@ -420,7 +420,7 @@ MANIFEST=$(python3 make_nav_fixture.py "$NAVFIX")
 # The wrong-reason guard. ADR-103 is the one arm deliberately under the gate
 # (it tests the gate); every other arm must clear it, or a "must not count"
 # arm is passing because it is short.
-for adr in ADR-101 ADR-102 ADR-104 ADR-105 ADR-106 ADR-107 ADR-108 ADR-109 ADR-110; do
+for adr in ADR-101 ADR-102 ADR-104 ADR-105 ADR-106 ADR-107 ADR-108 ADR-109 ADR-110 ADR-111; do
   n=$(echo "$MANIFEST" | jq --arg a "$adr" '.[$a].total_lines')
   [ "$n" -ge 600 ] || fail "nav: $adr is only $n lines — under the size gate, so its arm would pass for the wrong reason"
 done
@@ -431,9 +431,9 @@ OUT=$(python3 "$AUDIT" --repo-root "$NAVFIX")
 [ "$(af_len "$OUT")" -eq 0 ] || fail "nav: auto_fixable must stay empty — this detector is needs_judgment only: $(echo "$OUT" | jq -c .auto_fixable)"
 # No other detector may fire: a contaminated fixture (e.g. an arm title naming a
 # fileless ADR-NNN, which trips dangling_adr) makes the counts below meaningless.
-[ "$(nj_len "$OUT")" -eq 2 ] || fail "nav: expected exactly 2 findings, got $(nj_len "$OUT"): $(echo "$OUT" | jq -c '[.needs_judgment[]|{type,target}]')"
-[ "$(nj_type_len "$OUT" adr_navigation_missing)" -eq 2 ] || fail "nav: expected 2 adr_navigation_missing, got $(nj_type_len "$OUT" adr_navigation_missing)"
-for want in "nav:ADR-101" "nav:ADR-110"; do
+[ "$(nj_len "$OUT")" -eq 3 ] || fail "nav: expected exactly 3 findings, got $(nj_len "$OUT"): $(echo "$OUT" | jq -c '[.needs_judgment[]|{type,target}]')"
+[ "$(nj_type_len "$OUT" adr_navigation_missing)" -eq 3 ] || fail "nav: expected 3 adr_navigation_missing, got $(nj_type_len "$OUT" adr_navigation_missing)"
+for want in "nav:ADR-101" "nav:ADR-110" "nav:ADR-111"; do
   echo "$OUT" | jq -e --arg t "$want" '.needs_judgment[]|select(.type=="adr_navigation_missing" and .target==$t)' >/dev/null \
     || fail "nav: expected a finding targeted $want"
 done
@@ -444,10 +444,23 @@ echo "$OUT" | jq -e '[.needs_judgment[]|select(.type=="adr_navigation_missing")|
 # Pre-authored judgment scalars — SKILL.md Step 4 uses these verbatim.
 echo "$OUT" | jq -e '[.needs_judgment[]|select(.type=="adr_navigation_missing")|(has("confidence") and has("counter_evidence") and has("suggested_action") and has("sections") and (.locations|length>0))]|all' >/dev/null \
   || fail "nav: a finding is missing its pre-authored judgment scalars or locations"
-# The counter-evidence leans on this count, so it is asserted rather than
-# assumed: ADR-110's two sections are both numbered.
+# The counter-evidence leans on these, so they are asserted rather than
+# assumed: ADR-110's two sections are both numbered, and its residual share
+# (the share once numbered outline sections are excluded) is 0 — i.e. the
+# finding rests entirely on the title-based call, which is precisely what the
+# counter-evidence must tell a maintainer.
 NUM=$(echo "$OUT" | jq '[.needs_judgment[]|select(.target=="nav:ADR-110")|.numbered_section_count][0]')
 [ "$NUM" -eq 2 ] || fail "nav: ADR-110 should report 2 numbered sections, got $NUM"
+# Compared numerically: jq renders the rounded float as `0.0`, so a string
+# test against "0" fails on a correct value.
+echo "$OUT" | jq -e '[.needs_judgment[]|select(.target=="nav:ADR-110")|.residual_share][0] == 0' >/dev/null \
+  || fail "nav: ADR-110's residual share should be 0 (both sections numbered), got $(echo "$OUT" | jq -c '[.needs_judgment[]|select(.target=="nav:ADR-110")|.residual_share][0]')"
+echo "$OUT" | jq -e '.needs_judgment[]|select(.target=="nav:ADR-110")|.counter_evidence|test("rests entirely on the title-based call")' >/dev/null \
+  || fail "nav: ADR-110's counter_evidence must say the finding rests on the title-based call"
+# ADR-101 is the contrast: no numbered sections, so its residual share equals
+# its full share and the counter-evidence must NOT claim the finding evaporates.
+echo "$OUT" | jq -e '.needs_judgment[]|select(.target=="nav:ADR-101")|.counter_evidence|test("still over the")' >/dev/null \
+  || fail "nav: ADR-101's counter_evidence should report the residual share as still over the gate"
 # The remedy is a map plus promotion into the body — never deletion.
 # `.claude/rules/adr-writing.md` records that amendments are not trimmed away
 # later (#1382 declined that on principle), so a generator proposing it would

--- a/scripts/tests/consistency-audit-test.sh
+++ b/scripts/tests/consistency-audit-test.sh
@@ -6,9 +6,16 @@
 # The skill's own harness lives at
 # `.claude/skills/consistency-audit/tests/run_tests.sh`, which the CI
 # "Shell gate tests" job does NOT pick up — that job globs only
-# `scripts/tests/*-test.sh`. Without this shim the detector's fixtures
-# (clean / drift / judgment / boundary / adr) run nowhere automatically,
-# so the "zero findings on main" guarantee would have no regression guard.
+# `scripts/tests/*-test.sh`. Without this shim the detector's fixtures run
+# nowhere automatically, so every detector's must-NOT-fire set would have no
+# regression guard. (Fixtures are enumerated in the harness itself rather than
+# here, so the list cannot go stale from this end.)
+#
+# The harness asserts fixture behaviour only — never the live repo. `main` is
+# not a zero-findings invariant since adr_navigation_missing landed, and even
+# where a live assertion looks stable it would redden unrelated PRs: this job
+# has no path filter, so an ordinary docs edit that shifts an ADR's line count
+# would fail the consistency-audit gate.
 # This file matches the glob and delegates, giving the harness a CI home.
 #
 # The harness needs python3 + jq (both present on the ubuntu-latest runner);


### PR DESCRIPTION
## Summary

Adds an `adr_navigation_missing` detector to `consistency-audit`. It files a `needs_judgment` issue when a tracked ADR reaches 600 lines, is at least 50% amendment by per-section span, and carries no `## How to read this ADR` navigation section.

It fills a gap the repo names outright at `.claude/rules/adr-writing.md:77-80` — *"nothing enforces it: no lint, no gate, and `consistency-audit` has no amendment-placement detector"*.

**It detects findability, not placement, and never proposes deleting anything.** #1382 measured the "amendments are deletable history" hypothesis on ADR-028 and it did not hold; `adr-writing.md:76` records the house rule that amendments are not trimmed away later. The remedy this points at is the one ADR-028 demonstrated: add a map, promote standing values into the body. `adr-writing.md`'s "no amendment-**placement** detector" clause is deliberately kept — editing it to imply placement is now enforced would replace a true claim with a false one.

Two predicates were measured and **declined**, recorded in "Deferred detectors" with the evidence so the next author does not re-derive them: stranded values (floods on ADR-028, whose convention deliberately puts derivation in amendments) and supersede-convention violations (13 files mention supersession, 11 of them ADRs, `†` in one — 10 would-be flags, mostly cross-ADR cases the intra-file convention does not govern).

## Live findings on `main`

```
nav:ADR-002   1783 lines · 1367 amendment (76.7%) · no map
nav:ADR-021    653 lines ·  338 amendment (51.8%) · no map
```

**ADR-002's finding is the weaker of the two and says so itself.** Section classification is title-based, so its four numbered outline sections (`## 10.`–`## 13.`, titled `(<date> amendment)`) count — 1215 of its 1367 amendment lines. The emitted counter-evidence states that excluding them the share is 8.5%, below the gate, so the finding rests entirely on the title-based call. Taking the author's own label at face value was the deliberate choice; the breakdown is what makes the issue arguable rather than a percentage to accept or reject.

`main` is **not** a zero-findings state and was not one before this: `dead_link ledger.md` has always reported, because `docs/code-health/README.md` links a file `.gitignore` keeps out of every checkout. Four claims that assumed otherwise are corrected here.

## Test plan

```bash
bash .claude/skills/consistency-audit/tests/run_tests.sh   # incl. all prior fixtures
bash scripts/tests/consistency-audit-test.sh               # the CI shim
python3 .claude/skills/consistency-audit/scripts/audit_docs.py --repo-root . \
  | jq '[.needs_judgment[].type] | unique'
```

Twelve fixture arms, four firing. Assertions are fixture-only by design — the `shell-tests` CI job has no path filter, so a live-repo assertion would redden unrelated PRs whenever an ADR's line count moved.

`tests/mutate_nav_guards.py` carries one mutation per guard: each disables exactly one guard and asserts the arm defending against it flips, that the mutation's anchor matched (a silent no-op replace would read as a verified control), and that any collateral flip is declared. Two arms needed re-keying before they measured anything — `###` exclusion turned out to be defended by *both* heading anchors, and the first attempt mutated the classifier when the collection filter was doing the work.

## Review history

Three `code-reviewer` rounds (2 Critical, 13 Warning, 11 Suggestion — all addressed), then a Fable second opinion after the pattern became the concern rather than the findings: **each round found that the previous round's fix commit had authored a new false claim.** Round 1's Critical was in the commit whose purpose was fixing falsified claims; round 3's was introduced by round 2's fix.

The independent pass re-derived every measurable claim on the tip and found the errors concentrated in *narrative* — commit-message and comment prose recounting the history — not in code, fixtures, generated text, or repo-tracked docs, all of which it verified clean. Two residual items came out of it; both are handled:

- `adr-writing.md` said an ADR "passes 600 lines" — the gate is inclusive (`total < NAV_MIN_LINES` skips), so it fires at exactly 600. Fixed in `d18e1980`.
- **Correction to `11f14c19`'s message**: it says restoring the old wording trips the gate-restatement guard on "3 of 4" fixture findings. Restoring *both* branches, which is what "the old wording" means, trips it on **4 of 4** — the probe behind that number only restored one branch. The guard is stronger than claimed, not weaker.

## Device QA

実機QA不要 — no Swift sources touched; changes are confined to `.claude/skills/consistency-audit/**`, `.claude/rules/adr-writing.md`, and `scripts/tests/consistency-audit-test.sh`.

Closes #1400
