### PR TITLE
📝 docs: Gemma 4 QAT の Gate 1 結果記録 + ADR-011/engine.md の事実修正

### DIFF
--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -553,7 +553,7 @@ yes, it needs a closed-form `assistantPrefix` or no grammar.
 Defense-in-depth (post-sample `llama_vocab_is_special` check) is tracked
 in #371 — consult it before adding any thinking-mode model.
 
-### GGUF source matters — control-token type flags
+### GGUF source *and variant* matter — control-token flags, shared-KV layout
 
 unsloth's Gemma 3 GGUF exports flag `<start_of_turn>` / `<end_of_turn>`
 as NORMAL instead of CONTROL (unslothai/unsloth#5070), so llama.cpp
@@ -562,9 +562,21 @@ emits a garbage first token, which then trips the grammar. **Same crash
 signature as the special-token trap above, different root cause,
 different fix**: switch GGUF source — `assistantPrefix` does not help.
 Prefer `ggml-org/*-GGUF` (or bartowski) for the Gemma 3 family; Gemma 4
-unsloth exports are unaffected and the existing Gemma 4 E2B descriptor
-stays on unsloth. (PR #480, closed — Gemma 3 1B no-go; durable record in
-ADR-011.)
+unsloth exports are unaffected **by #5070** and the existing Gemma 4 E2B
+descriptor stays on unsloth. (PR #480, closed — Gemma 3 1B no-go;
+durable record in ADR-011.)
+
+**Variant matters too, not just publisher.** Gemma 4 **QAT** exports —
+Google's official and unsloth's re-export alike — use a shared-KV
+tail-layer layout: 541 tensors, dropping `attn_k` / `attn_v` /
+`attn_k_norm` for layers 15–34 (20 × 3 = 60), where the shipped non-QAT
+Q4_K_M materialises all 601. The pinned llama.cpp rejects them outright
+with `missing tensor 'blk.15.attn_k.weight'`. So "unsloth is fine for
+Gemma 4" holds for the **non-QAT** export only — a `-qat-` repo is not a
+drop-in swap. Note the descriptor you would edit (`ModelRegistry.swift`)
+is in `App/`, which this rule's `paths:` do **not** cover — the
+descriptor-side procedure is `docs/models/onboarding.md`. (Measured
+2026-08-08; verdict + retry gating in `docs/models/eval-log.md`, #1415.)
 
 When pinning a new descriptor, the HF resolve-URL headers
 `X-Linked-Size` / `X-Linked-ETag` give authoritative `fileSize` /

--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -553,7 +553,7 @@ yes, it needs a closed-form `assistantPrefix` or no grammar.
 Defense-in-depth (post-sample `llama_vocab_is_special` check) is tracked
 in #371 — consult it before adding any thinking-mode model.
 
-### GGUF source *and variant* matter — control-token flags, shared-KV layout
+### GGUF source *and variant* matter
 
 unsloth's Gemma 3 GGUF exports flag `<start_of_turn>` / `<end_of_turn>`
 as NORMAL instead of CONTROL (unslothai/unsloth#5070), so llama.cpp
@@ -566,17 +566,12 @@ unsloth exports are unaffected **by #5070** and the existing Gemma 4 E2B
 descriptor stays on unsloth. (PR #480, closed — Gemma 3 1B no-go;
 durable record in ADR-011.)
 
-**Variant matters too, not just publisher.** Gemma 4 **QAT** exports —
-Google's official and unsloth's re-export alike — use a shared-KV
-tail-layer layout: 541 tensors, dropping `attn_k` / `attn_v` /
-`attn_k_norm` for layers 15–34 (20 × 3 = 60), where the shipped non-QAT
-Q4_K_M materialises all 601. The pinned llama.cpp rejects them outright
-with `missing tensor 'blk.15.attn_k.weight'`. So "unsloth is fine for
-Gemma 4" holds for the **non-QAT** export only — a `-qat-` repo is not a
-drop-in swap. Note the descriptor you would edit (`ModelRegistry.swift`)
-is in `App/`, which this rule's `paths:` do **not** cover — the
-descriptor-side procedure is `docs/models/onboarding.md`. (Measured
-2026-08-08; verdict + retry gating in `docs/models/eval-log.md`, #1415.)
+**Variant, not just publisher.** Gemma 4 **QAT** exports — Google's and
+unsloth's alike — ship a shared-KV tail layer the pinned llama.cpp cannot
+load (`missing tensor 'blk.15.attn_k.weight'`), so a `-qat-` repo is never
+a drop-in swap for its non-QAT sibling. Descriptor-side procedure:
+`docs/models/onboarding.md`; measurement + retry gating:
+`docs/models/eval-log.md` §2026-08-08 (#1415).
 
 When pinning a new descriptor, the HF resolve-URL headers
 `X-Linked-Size` / `X-Linked-ETag` give authoritative `fileSize` /

--- a/docs/decisions/ADR-011.md
+++ b/docs/decisions/ADR-011.md
@@ -35,16 +35,15 @@
       `URLSession` fetch without auth-token negotiation. Gating
       is a **per-repo measurement, never inferred from the
       publisher**: Google's Gemma *3* QAT repos are gated behind
-      a license click-through — the observation this ADR was
-      written against, and `google/gemma-3-1b-it-qat-q4_0-gguf`
-      was still `gated: manual` when re-checked 2026-08-08 —
-      whereas the Gemma *4* QAT repos are **not**
-      (`gated: false`, Apache-2.0, anonymous resolve succeeds;
-      same date). Note also that clearing P1 does not imply the
-      GGUF loads: the Gemma 4 QAT exports clear it and still
-      fail, for an unrelated reason recorded in
+      a license click-through (the observation this ADR was
+      written against; `google/gemma-3-1b-it-qat-q4_0-gguf` was
+      still `gated: manual` when re-checked 2026-08-08), whereas
+      the Gemma *4* QAT repos are **not** (`gated: false`,
+      Apache-2.0, anonymous resolve succeeds; same date) —
+      though clearing P1 does not imply the GGUF loads: those
+      exports clear it and still fail, see
       [`docs/models/eval-log.md`](../models/eval-log.md)
-      §2026-08-08 (#1415 / #1416).
+      §2026-08-08.
    2. **Tokenizer + chat template metadata correct in the GGUF** —
       `tokenizer.ggml.token_type` flags `<start_of_turn>` /
       `<im_start>` / equivalent control markers as `CONTROL (3)`
@@ -344,8 +343,9 @@ sequel decision, not a 6 GB tier catalog addition. Out of scope.
 
 - Issue #477 — 6 GB RAM tier device support (original tracking)
 - Issue #1415 — llama.cpp pin bump spike (shared-KV tail-layer
-  support); a merged bump must sweep P1's "the Gemma 4 QAT exports
-  clear it and still fail" claim
+  support); a merged bump must sweep the pin-relative wording in
+  `.claude/rules/engine.md` § "GGUF source *and variant* matter"
+  and `docs/models/eval-log.md` §2026-08-08, plus P1 above
 - Issue #1416 — Gemma 4 E2B QAT Gate 1 retry, blocked on #1415
 - PR #480 — implementation + PoC; to be closed unmerged when this
   ADR lands, with the investigation chain captured in commit

--- a/docs/decisions/ADR-011.md
+++ b/docs/decisions/ADR-011.md
@@ -343,6 +343,10 @@ sequel decision, not a 6 GB tier catalog addition. Out of scope.
 ## Related
 
 - Issue #477 — 6 GB RAM tier device support (original tracking)
+- Issue #1415 — llama.cpp pin bump spike (shared-KV tail-layer
+  support); a merged bump must sweep P1's "the Gemma 4 QAT exports
+  clear it and still fail" claim
+- Issue #1416 — Gemma 4 E2B QAT Gate 1 retry, blocked on #1415
 - PR #480 — implementation + PoC; to be closed unmerged when this
   ADR lands, with the investigation chain captured in commit
   messages and this ADR. Key commits: `3237e7a` (descriptor add),

--- a/docs/decisions/ADR-011.md
+++ b/docs/decisions/ADR-011.md
@@ -32,9 +32,19 @@
 2. **Hard prerequisites for any future 6 GB tier candidate** (all
    must clear before merging to `catalog`):
    1. **Non-gated GGUF source on HuggingFace** — direct
-      `URLSession` fetch without auth-token negotiation. Gates
-      Google's own QAT GGUF (license-click-through) out for the
-      foreseeable Pastura download path.
+      `URLSession` fetch without auth-token negotiation. Gating
+      is a **per-repo measurement, never inferred from the
+      publisher**: Google's Gemma *3* QAT repos are gated behind
+      a license click-through — the observation this ADR was
+      written against, and `google/gemma-3-1b-it-qat-q4_0-gguf`
+      was still `gated: manual` when re-checked 2026-08-08 —
+      whereas the Gemma *4* QAT repos are **not**
+      (`gated: false`, Apache-2.0, anonymous resolve succeeds;
+      same date). Note also that clearing P1 does not imply the
+      GGUF loads: the Gemma 4 QAT exports clear it and still
+      fail, for an unrelated reason recorded in
+      [`docs/models/eval-log.md`](../models/eval-log.md)
+      §2026-08-08 (#1415 / #1416).
    2. **Tokenizer + chat template metadata correct in the GGUF** —
       `tokenizer.ggml.token_type` flags `<start_of_turn>` /
       `<im_start>` / equivalent control markers as `CONTROL (3)`

--- a/docs/models/eval-log.md
+++ b/docs/models/eval-log.md
@@ -35,30 +35,24 @@ everything else here.
 
 ## Gemma 4 E2B QAT Q4_0 (`google/gemma-4-E2B-it-qat-q4_0-gguf`) — 2026-08-08 — **FAIL (BLOCKED — runtime compatibility, not a quality rejection)**
 
-> **Not the shipped model.** This is a *different build* of a catalog model: the
-> QAT Q4_0 export. The shipped descriptor
-> (`unsloth/gemma-4-E2B-it-GGUF` Q4_K_M, non-QAT) is **unaffected and remains in
-> the catalog** — nothing here indicates a regression in a released build.
-
 - **Gate**: 1 (Mac filter, `/model-eval`) — **blocked at model load, never
-  reached inference.** All 6 battery cells failed in ~0.9 s each with the
-  identical error and 2 attempts apiece:
+  reached inference.** All 6 battery cells failed in ~0.9 s each, 2 attempts
+  apiece, with the identical scenario-independent error
   `llama_model_load: error loading model: missing tensor 'blk.15.attn_k.weight'`.
-  Scenario-independent (all 3 families × ja/en fail the same way).
 - **Model**: `google/gemma-4-E2B-it-qat-q4_0-gguf` @ `675cff4` ·
   `gemma-4-E2B_q4_0-it.gguf` · QAT `Q4_0` · Apache-2.0, non-gated · 3,349,516,256 B
   · sha256 `fa401b55…6634` (both matching the HF resolve `X-Linked-Size` /
-  `X-Linked-ETag`). **No Stage-0 profile of its own** — the run deliberately
-  reused the incumbent's `gemma-4-e2b-q4-k-m` profile, legitimate per
-  [`onboarding.md`](onboarding.md) (Stage 0 is per *family*, and `gemma` is
-  registered) after verifying the three prompt-format fields are equivalent.
-  Consequence: the raw logs are stamped with the incumbent's `modelIdentifier`,
-  and a future retry still has no validated profile of its own.
-- **Differentiation**: **UNASSESSABLE.** Zero inferences were produced, so this
-  run yields no evidence whatsoever about output character. The QAT question is
-  *untested*, not answered — nothing here supports or refutes a slot claim.
-- **Snapshot**: `runs_ok 0 / 6`, `language_mismatch_total 0`, `attempts_mean 2.0`,
-  `tok_per_sec` n/a, inferences **0**. No rubric scores exist for any cell.
+  `X-Linked-ETag`). A *different build* of a catalog model — the shipped
+  descriptor (`unsloth/gemma-4-E2B-it-GGUF` Q4_K_M, non-QAT) is unaffected and
+  remains in the catalog. **No Stage-0 profile of its own** — the run reused the
+  incumbent's `gemma-4-e2b-q4-k-m` profile, legitimate per
+  [`onboarding.md`](onboarding.md) (Stage 0 is per *family*) after verifying the
+  three prompt-format fields are equivalent; so the raw logs carry the
+  incumbent's `modelIdentifier` and a retry still has no validated profile.
+- **Differentiation**: **UNASSESSABLE** — zero inferences, so the QAT question is
+  *untested*, not answered.
+- **Snapshot**: `runs_ok 0 / 6`, `attempts_mean 2.0`, inferences **0** — no rubric
+  scores exist for any cell.
 - **Rationale**: Gemma 4 E2B **QAT** GGUFs ship a **shared-KV tail-layer** layout —
   541 tensors, omitting `attn_k` / `attn_v` / `attn_k_norm` for layers 15–34 (60
   tensors) — where the shipped non-QAT Q4_K_M materialises all 601. Zero tensors
@@ -67,7 +61,8 @@ everything else here.
   `exact: "2.8694.0"`) has no shared-KV tail-layer loader. **Not vendor-specific**:
   unsloth's own QAT re-export (`unsloth/gemma-4-E2B-it-qat-GGUF` →
   `gemma-4-E2B-it-qat-UD-Q4_K_XL.gguf`, 2,620,370,976 B, sha256 `e5310072…6889`)
-  carries the byte-identical 541-tensor layout, so the split is **QAT-vs-non-QAT,
+  carries the same 541-tensor layout (identical tensor-name set, different
+  quantisation and byte length), so the split is **QAT-vs-non-QAT,
   not Google-vs-unsloth**. Confirmed by direct measurement in a throwaway
   standalone SwiftPM package with the repository's own pin untouched: llama.swift
   **2.10327.0** (llama.cpp b10327) loads the QAT file *and* the incumbent, while

--- a/docs/models/eval-log.md
+++ b/docs/models/eval-log.md
@@ -33,6 +33,64 @@ everything else here.
 
 ---
 
+## Gemma 4 E2B QAT Q4_0 (`google/gemma-4-E2B-it-qat-q4_0-gguf`) — 2026-08-08 — **FAIL (BLOCKED — runtime compatibility, not a quality rejection)**
+
+> **Not the shipped model.** This is a *different build* of a catalog model: the
+> QAT Q4_0 export. The shipped descriptor
+> (`unsloth/gemma-4-E2B-it-GGUF` Q4_K_M, non-QAT) is **unaffected and remains in
+> the catalog** — nothing here indicates a regression in a released build.
+
+- **Gate**: 1 (Mac filter, `/model-eval`) — **blocked at model load, never
+  reached inference.** All 6 battery cells failed in ~0.9 s each with the
+  identical error and 2 attempts apiece:
+  `llama_model_load: error loading model: missing tensor 'blk.15.attn_k.weight'`.
+  Scenario-independent (all 3 families × ja/en fail the same way).
+- **Model**: `google/gemma-4-E2B-it-qat-q4_0-gguf` @ `675cff4` ·
+  `gemma-4-E2B_q4_0-it.gguf` · QAT `Q4_0` · Apache-2.0, non-gated · 3,349,516,256 B
+  · sha256 `fa401b55…6634` (both matching the HF resolve `X-Linked-Size` /
+  `X-Linked-ETag`). **No Stage-0 profile of its own** — the run deliberately
+  reused the incumbent's `gemma-4-e2b-q4-k-m` profile, legitimate per
+  [`onboarding.md`](onboarding.md) (Stage 0 is per *family*, and `gemma` is
+  registered) after verifying the three prompt-format fields are equivalent.
+  Consequence: the raw logs are stamped with the incumbent's `modelIdentifier`,
+  and a future retry still has no validated profile of its own.
+- **Differentiation**: **UNASSESSABLE.** Zero inferences were produced, so this
+  run yields no evidence whatsoever about output character. The QAT question is
+  *untested*, not answered — nothing here supports or refutes a slot claim.
+- **Snapshot**: `runs_ok 0 / 6`, `language_mismatch_total 0`, `attempts_mean 2.0`,
+  `tok_per_sec` n/a, inferences **0**. No rubric scores exist for any cell.
+- **Rationale**: Gemma 4 E2B **QAT** GGUFs ship a **shared-KV tail-layer** layout —
+  541 tensors, omitting `attn_k` / `attn_v` / `attn_k_norm` for layers 15–34 (60
+  tensors) — where the shipped non-QAT Q4_K_M materialises all 601. Zero tensors
+  exist in the QAT file that are absent from the incumbent, so it is a structural
+  difference, not corruption. The pinned llama.cpp b8694 (`mattt/llama.swift`
+  `exact: "2.8694.0"`) has no shared-KV tail-layer loader. **Not vendor-specific**:
+  unsloth's own QAT re-export (`unsloth/gemma-4-E2B-it-qat-GGUF` →
+  `gemma-4-E2B-it-qat-UD-Q4_K_XL.gguf`, 2,620,370,976 B, sha256 `e5310072…6889`)
+  carries the byte-identical 541-tensor layout, so the split is **QAT-vs-non-QAT,
+  not Google-vs-unsloth**. Confirmed by direct measurement in a throwaway
+  standalone SwiftPM package with the repository's own pin untouched: llama.swift
+  **2.10327.0** (llama.cpp b10327) loads the QAT file *and* the incumbent, while
+  b8694 loads only the incumbent — a bump is therefore sufficient *and* the
+  wrapper release exists.
+- **Disposition**: **not rejected.** Retry is gated on a llama.cpp pin carrying
+  shared-KV tail-layer support → #1415 (spike) then #1416 (Gate 1 retry).
+  Pre-cleared for that retry, so it need not be re-derived: ADR-011 **P1**
+  non-gated (HF `gated: false`; anonymous resolve 302 → CDN 200) and **P2**
+  CONTROL flags (`<|turn>` id 105, `<turn|>` id 106, both `token_type=3`); EOG set
+  `{1, 50, 106, 212}` is a **superset** of the incumbent's `{50, 106, 212}`, so
+  `<turn|>` terminates generation on both builds and there is no runaway-generation
+  risk. Worth evaluating alongside the unsloth QAT file above, which is ~0.49 GB
+  *smaller* than the shipped Q4_K_M (2.62 vs 3.11 GB). **P3–P5 remain untouched**
+  (Gate 2).
+- **Pointers**: raw scorecard → `data/models/eval-digest.md` §2026-08-08 ·
+  gemma-4-e2b-q4-k-m (gitignored, and replaced by key `(date, profile_id)` — which
+  here is the *incumbent's* id, so treat it as volatile) · intake → #979 · pin
+  spike → #1415 · retry → #1416 · dead `stopSequence` + false rationale comment
+  surfaced during this eval → #1417.
+
+---
+
 ## Sarashina 2.2 3B Instruct v0.1 (Q4_K_M) — 2026-07-23 — **FAIL (NO-GO)**
 
 - **Gate**: 1 (Mac filter, `/model-eval`) — re-eval after the #751 empty-output

--- a/docs/models/onboarding.md
+++ b/docs/models/onboarding.md
@@ -95,7 +95,7 @@ init in `Pastura/Pastura/App/ModelRegistry.swift`:
 | `id` | Stable catalog id; also the `--profile` / `ModelProfile.id`. |
 | `displayName` / `shortDisplayName` | Full + compact labels. |
 | `vendor` / `vendorURL` | Publisher name + site. |
-| `downloadURL` | **Pins a specific HF commit SHA** (`resolve/<commit>/...`), not `main`. |
+| `downloadURL` | **Pins a specific HF commit SHA** (`resolve/<commit>/...`), not `main`. A `-qat-` repo is **not** a drop-in swap for its non-QAT sibling — see `.claude/rules/engine.md` § "GGUF source *and variant* matter". |
 | `fileName` | GGUF filename; unique across the catalog. |
 | `fileSize` / `sha256` | From `curl -sIL` `X-Linked-Size` / `X-Linked-ETag` (Gate 1 note). |
 | `stopSequence` | Prompt-format field — must match the Stage-0 profile. |


### PR DESCRIPTION
## Summary

Records the 2026-08-08 `/model-eval` Gate 1 outcome for the Gemma 4 E2B **QAT**
candidate, and fixes three documentation sites that today's evidence made wrong,
incomplete, or unreachable.

**The candidate never produced a token.** All 6 battery cells failed at model load in
~0.9 s with `missing tensor 'blk.15.attn_k.weight'`. So this PR records a **blocked**
outcome, not a quality rejection — nothing here says anything about whether QAT would
improve output, because that stayed unmeasured.

### What was actually established

Gemma 4 E2B **QAT** GGUFs ship a **shared-KV tail-layer** layout — 541 tensors,
dropping `attn_k` / `attn_v` / `attn_k_norm` for layers 15–34 (20 × 3 = 60) — where the
shipped non-QAT unsloth Q4_K_M materialises all 601. Zero tensors exist in the QAT file
that are absent from the incumbent, so it is structural, not corruption. The pinned
llama.cpp b8694 has no shared-KV loader.

**Not a Google-vs-unsloth issue.** unsloth's own QAT re-export
(`gemma-4-E2B-it-qat-UD-Q4_K_XL.gguf`) has the byte-identical 541-tensor layout. The
split is **QAT vs non-QAT**.

Verified in a throwaway standalone SwiftPM package **with the repository's own pin
untouched**: llama.swift 2.10327.0 (llama.cpp b10327) loads the QAT file *and* the
incumbent; b8694 loads only the incumbent. So a pin bump is sufficient, and the wrapper
release exists — recorded as first-hand measurement rather than the third-party report
it would otherwise have rested on.

### Changes

| File | Change |
|---|---|
| `docs/models/eval-log.md` | New verdict entry. Verdict token stays `FAIL` to match the taxonomy `/model-eval` emits (`pass\|borderline\|fail`) and the digest's own gate value, with `BLOCKED` as the qualifier. Leads with a callout that this is a *different build* of an already-shipping catalog model. |
| `docs/decisions/ADR-011.md` | P1 claimed a non-gated requirement "gates Google's own QAT GGUF out". True for Gemma 3, **false for Gemma 4**. Corrected in place; #1415/#1416 added to § Related. |
| `.claude/rules/engine.md` | § "GGUF source matters" implied unsloth is safe for Gemma 4 as a property of the publisher, which would have licensed exactly the wrong swap. Adds the variant axis; retitled to cover both mechanisms. |
| `docs/models/onboarding.md` | One-line pointer on the `downloadURL` row, because engine.md is path-scoped to `Engine/**` + `LLM/**` and does **not** load where descriptors are actually edited (`App/ModelRegistry.swift`). |

### Notes on judgment calls

- **In-place edit, not a `§N. Amendment`.** The P1 *requirement* is unchanged; only an
  illustrative factual claim was wrong, which CLAUDE.md § Decision Records exempts.
  Per `adr-writing-guide.md` § "Status-flip staleness" the original observation is
  preserved as dated past-tense with a forward pointer, not deleted — it is still the
  rationale the decision was made on.
- **ADR-011 deliberately does not name the pin or the shared-KV mechanism.** Per
  `adr-writing.md` §2 that prerequisite list is a mechanism contract, and a
  pin-relative fact there is precisely what #1415 is chartered to invalidate. It points
  at the ledger instead.
- **First standalone entry for a blocked run.** The 2026-07-08 Sarashina block was only
  ever recorded retroactively, as a clause inside its later verdict entry — so this
  establishes the shape rather than following a precedent.

### Follow-ups filed

- #1415 — llama.cpp pin bump, scoped as a **discardable spike**: the QAT upside is
  unmeasured, so it measures the delta before committing to a bump
- #1416 — Gate 1 retry, blocked on #1415, with P1/P2/EOG pre-cleared so they need not
  be re-derived
- #1417 — `stopSequence "<|im_end|>"` is absent from Gemma 4's vocab; no runtime
  impact, but the why-comment at `LlamaCppService.swift:97-101` states a false reason
- #1419 — the pipeline has no `blocked` (retry-gated) disposition, surfaced by this
  PR's review

## Test plan

- [x] Documentation-only — no Swift, no tests, no build inputs. Pre-commit correctly
      skipped SwiftLint and `xcodebuild` on all four commits.
- [x] Every number, SHA fragment, size, token id, and issue reference verified against
      its authoritative source (HF `X-Linked-Size`/`X-Linked-ETag`, `Package.resolved`,
      `ModelRegistry.swift`, `gh issue view`).
- [x] Arithmetic self-check caught two real errors during authoring: a size delta
      computed against the wrong baseline (0.73 → **0.49 GB**, also corrected in #1416
      and the #979 comment), and a tensor enumeration missing `attn_k_norm` that made
      20 × 2 ≠ 60.
- [x] Cited heading `§ "GGUF source *and variant* matter"` confirmed byte-exact;
      verified nothing cited the *old* heading (all file types, not just markdown).
- [x] Relative link `../models/eval-log.md` from `docs/decisions/` resolves.
- [x] Mirror sweep for the falsified claim: only `ADR-011.md` stated it. Every file
      citing ADR-011 glosses P1 as "non-gated GGUF source", which stays correct.

## Device QA

実機QA不要 — documentation only; no code, no device-only (`#if !targetEnvironment(simulator)`)
surface, no Metal or model-load path touched.

Closes #1418
