### PR TITLE
🐛 fix: Gemma stopSequence の偽の根拠コメント修正 + model-eval に blocked disposition

### DIFF
--- a/.claude/skills/model-eval/SKILL.md
+++ b/.claude/skills/model-eval/SKILL.md
@@ -186,8 +186,8 @@ character earns no slot even with decent scores.
 
 ## Step 4 — Verdict (asymmetric, variance-aware)
 
-Gate ∈ `pass` | `borderline` | `fail`. **Mechanical prerequisites for
-`pass`** (all required): all 6 cells `ok` AND `language_mismatch_total == 0`
+Gate ∈ `pass` | `borderline` | `fail` | `blocked`. **Mechanical prerequisites
+for `pass`** (all required): all 6 cells `ok` AND `language_mismatch_total == 0`
 AND no `crashed` cell. Beyond the mechanical floor, weigh the rubric totals and
 `differentiation` against the eval-digest history / incumbent baseline — do NOT
 pin numeric tok/s or rubric-total thresholds (mechanism-contract style; the
@@ -200,6 +200,38 @@ comparison).
   Single-run-per-cell means one unlucky sample must not discard a candidate;
   the reject bar is asymmetric — cheap to re-sample, expensive to wrongly
   discard. Re-run into the same `<family>_<lang>.jsonl` path and re-judge.
+- **BLOCKED** — the candidate could not be *evaluated*, so there is nothing to
+  reject. Non-terminal by definition: it is retry-gated, not an endpoint.
+
+### `blocked` — admissibility and its two enforcement layers
+
+`fail` says "measured, and it isn't good enough"; `blocked` says "not measured".
+Choosing between them is an **attribution** judgment — did the non-`ok` cells
+fail because of the candidate, or because of the environment? — and that is NOT
+derivable from cell statuses, so most of it cannot be mechanised.
+
+**Admissibility (prose — nothing executes this; it is your call):** `blocked` is
+admissible only when **every non-`ok` cell shares one scenario-independent
+failure cause** — a model-load error, a runtime/toolchain incompatibility, a
+known infra path — rather than a per-scenario quality breakdown. If cells fail
+for scenario-shaped reasons, that is `fail` or `borderline`. Do not reach for
+`blocked` to soften a genuine quality reject; the whole value of the token is
+that a future reader can trust it means "unmeasured".
+
+**Structure (enforced by `append_eval.py`; it exits 1 otherwise):**
+
+| Rule | Why |
+|---|---|
+| `verdict.unblocked_by` required, non-empty | A blocked entry without a named unblock condition is a `fail` with softer wording |
+| `verdict.retry` required, non-empty | The retry pointer is what makes it non-terminal. The blocker's own issue number is acceptable — a dedicated retry issue need not exist yet |
+| at least one non-`ok` cell | A run where every cell completed was not blocked |
+| **no** `differentiation` when zero cells are `ok` | Zero inferences means zero evidence; a value here would be fabricated |
+| `differentiation` **required** when ≥1 cell is `ok` | A partial block still measured something — record what the completed cells showed, scoped to them |
+
+Note the last two: a blocked run is **not** necessarily a total block.
+Sarashina 2.2 3B on 2026-07-08 had 3 of 6 cells complete and is recorded as
+blocked; a "zero `ok` cells" precondition would have made that shape
+unrecordable. See `docs/models/eval-log.md`.
 
 ## Step 5 — Append the scorecard
 
@@ -208,8 +240,10 @@ comparison).
    `battery[]` per cell with `scenario_id`, `language`, `status`, `attempts`,
    `language_mismatches`, `tok_per_sec`, `rubric` (the 5 axes + `payoff_axis`,
    or `null` for failed/config_error cells), `comment`; `differentiation`;
-   `verdict` `{gate, notes}`). Write it to a temp file (`mktemp` or the
-   session scratchpad — not inside the repo).
+   `verdict` `{gate, notes}` — plus `{unblocked_by, retry}` when the gate is
+   `blocked`, and see Step 4 for when `differentiation` must be omitted).
+   Write it to a temp file (`mktemp` or the session scratchpad — not inside
+   the repo).
 2. ```bash
    python3 .claude/skills/model-eval/scripts/append_eval.py \
      --results <tmp>/results.json \
@@ -229,10 +263,13 @@ Compact final report to the user:
   5 axis scores + total (failed cells show `–`).
 - **Aggregate metrics** (Step 2): `runs_ok` / `runs_failed`,
   `language_mismatch_total`, `attempts_mean`, `tok_per_sec_overall`.
-- **Differentiation**: the one-paragraph slot-earning judgment.
-- **Gate** (`pass` / `borderline` / `fail`) with the explicit line that a
-  **pass only advances the candidate to the ADR-011 real-device GBNF PoC** — it
-  is not an adoption.
+- **Differentiation**: the one-paragraph slot-earning judgment. For a `blocked`
+  run with zero `ok` cells, report it as **UNASSESSABLE** and say why — do not
+  improvise a judgment from zero inferences.
+- **Gate** (`pass` / `borderline` / `fail` / `blocked`) with the explicit line
+  that a **pass only advances the candidate to the ADR-011 real-device GBNF
+  PoC** — it is not an adoption. For `blocked`, state the unblock condition and
+  the retry pointer, and say plainly that the candidate was **not rejected**.
 - Artifact locations (`data/models/eval-runs/<DATE>/`, the appended
   `eval-digest.md` section) — a gitignored local log, not committed or pushed.
 

--- a/.claude/skills/model-eval/SKILL.md
+++ b/.claude/skills/model-eval/SKILL.md
@@ -210,13 +210,35 @@ Choosing between them is an **attribution** judgment — did the non-`ok` cells
 fail because of the candidate, or because of the environment? — and that is NOT
 derivable from cell statuses, so most of it cannot be mechanised.
 
-**Admissibility (prose — nothing executes this; it is your call):** `blocked` is
-admissible only when **every non-`ok` cell shares one scenario-independent
-failure cause** — a model-load error, a runtime/toolchain incompatibility, a
-known infra path — rather than a per-scenario quality breakdown. If cells fail
-for scenario-shaped reasons, that is `fail` or `borderline`. Do not reach for
-`blocked` to soften a genuine quality reject; the whole value of the token is
-that a future reader can trust it means "unmeasured".
+**Admissibility (prose — no code executes this; it is your call):** `blocked` is
+admissible only when **every non-`ok` cell shares one failure CAUSE that is
+independent of scenario content** — a model-load error, a runtime/toolchain
+incompatibility, a known infra path — rather than a per-scenario quality
+breakdown.
+
+**Cause, not incidence.** A scenario-independent cause can still have
+scenario-*correlated* incidence, and mistaking the two would exclude the very
+run this disposition was built for. Sarashina 2.2 3B on 2026-07-08 failed only
+the longer, reflect-heavy cells while short ones completed — which looks
+scenario-shaped — but the cause was the #751 empty-output retry-budget path,
+and fixing that one upstream defect cleared every cell (PR #1024, re-evaluated
+2026-07-23). **The tell is exactly that**: if one upstream fix would clear all
+of them, the cause is independent of scenario content no matter how its
+incidence distributed. If instead each cell fails for its own scenario-shaped
+reason, that is `fail` or `borderline`.
+
+Do not reach for `blocked` to soften a genuine quality reject; the whole value
+of the token is that a future reader can trust it means "unmeasured". Nothing
+downstream re-checks that — the required `retry` pointer is the only backstop,
+and it works only when someone actually runs the retry.
+
+**Why this is not mechanised.** Attribution is not derivable from the fields the
+results schema carries (`battery[].status` is the only failure signal in it).
+The run artifacts *do* carry per-cell error text, so a "all non-`ok` cells share
+one error signature" proxy is constructible — it was considered and not adopted,
+because that text is session-authored, so identity across cells is self-attested
+and carries no attribution power against the case worth catching. It would catch
+sloppiness, not misuse.
 
 **Structure (enforced by `append_eval.py`; it exits 1 otherwise):**
 
@@ -224,11 +246,21 @@ that a future reader can trust it means "unmeasured".
 |---|---|
 | `verdict.unblocked_by` required, non-empty | A blocked entry without a named unblock condition is a `fail` with softer wording |
 | `verdict.retry` required, non-empty | The retry pointer is what makes it non-terminal. The blocker's own issue number is acceptable — a dedicated retry issue need not exist yet |
-| at least one non-`ok` cell | A run where every cell completed was not blocked |
 | **no** `differentiation` when zero cells are `ok` | Zero inferences means zero evidence; a value here would be fabricated |
-| `differentiation` **required** when ≥1 cell is `ok` | A partial block still measured something — record what the completed cells showed, scoped to them |
+| `differentiation` **required** when ≥1 cell is `ok` | A partial block still measured something — record what the completed cells showed, scoped to them. Declining is legitimate; see below |
+| at least one non-`ok` cell | *Coherence assert only* — it rejects a battery whose every row is `ok`, i.e. a self-contradictory composition. It does **not** distinguish `blocked` from `fail` (a `fail` has non-`ok` cells too), and it is satisfiable by recording only the failing rows, since nothing checks the battery for completeness. Do not read it as a substantive guard |
 
-Note the last two: a blocked run is **not** necessarily a total block.
+**Declining a partial differentiation is legitimate.** The validator checks only
+that the field is non-empty, so `PARTIAL (n/6 cells) — insufficient to
+differentiate` satisfies it. Use that form rather than stretching one or two
+completed cells into a slot-earning judgment: `differentiation` means "does this
+model's *character* earn a catalog slot", and a couple of cells rarely answers
+it. The required-when-partial rule exists so real evidence is not silently
+discarded, not to manufacture a verdict — the same fabrication pressure the
+zero-`ok` rule guards against, arriving from the other side.
+
+Note the two `differentiation` rows: a blocked run is **not** necessarily a
+total block.
 Sarashina 2.2 3B on 2026-07-08 had 3 of 6 cells complete (recorded in
 `tools/harness/Sources/PasturaHarnessKit/ModelProfile.swift`, the
 `sarashina223B` doc comment), so a "zero `ok` cells" precondition would have

--- a/.claude/skills/model-eval/SKILL.md
+++ b/.claude/skills/model-eval/SKILL.md
@@ -229,9 +229,13 @@ that a future reader can trust it means "unmeasured".
 | `differentiation` **required** when ≥1 cell is `ok` | A partial block still measured something — record what the completed cells showed, scoped to them |
 
 Note the last two: a blocked run is **not** necessarily a total block.
-Sarashina 2.2 3B on 2026-07-08 had 3 of 6 cells complete and is recorded as
-blocked; a "zero `ok` cells" precondition would have made that shape
-unrecordable. See `docs/models/eval-log.md`.
+Sarashina 2.2 3B on 2026-07-08 had 3 of 6 cells complete (recorded in
+`tools/harness/Sources/PasturaHarnessKit/ModelProfile.swift`, the
+`sarashina223B` doc comment), so a "zero `ok` cells" precondition would have
+made that shape unrecordable. That run predates this disposition and has no
+ledger heading of its own — it is grandfathered inside the later entry,
+`docs/models/eval-log.md` § "Sarashina 2.2 3B Instruct v0.1 (Q4_K_M) —
+2026-07-23", under its *Grandfathered (#1419)* sub-bullet.
 
 ## Step 5 — Append the scorecard
 

--- a/.claude/skills/model-eval/SKILL.md
+++ b/.claude/skills/model-eval/SKILL.md
@@ -217,28 +217,23 @@ incompatibility, a known infra path — rather than a per-scenario quality
 breakdown.
 
 **Cause, not incidence.** A scenario-independent cause can still have
-scenario-*correlated* incidence, and mistaking the two would exclude the very
-run this disposition was built for. Sarashina 2.2 3B on 2026-07-08 failed only
-the longer, reflect-heavy cells while short ones completed — which looks
-scenario-shaped — but the cause was the #751 empty-output retry-budget path,
-and fixing that one upstream defect cleared every cell (PR #1024, re-evaluated
-2026-07-23). **The tell is exactly that**: if one upstream fix would clear all
-of them, the cause is independent of scenario content no matter how its
-incidence distributed. If instead each cell fails for its own scenario-shaped
-reason, that is `fail` or `borderline`.
+scenario-*correlated* incidence. Sarashina 2.2 3B on 2026-07-08 failed only the
+longer, reflect-heavy cells while short ones completed — which looks
+scenario-shaped — but the cause was the #751 empty-output retry-budget path, and
+fixing that one upstream defect cleared every cell (PR #1024). **The tell is
+exactly that**: if one upstream fix would clear all of them, the cause is
+independent of scenario content however its incidence distributed. If instead
+each cell fails for its own scenario-shaped reason, that is `fail` or
+`borderline`.
 
 Do not reach for `blocked` to soften a genuine quality reject; the whole value
 of the token is that a future reader can trust it means "unmeasured". Nothing
 downstream re-checks that — the required `retry` pointer is the only backstop,
-and it works only when someone actually runs the retry.
-
-**Why this is not mechanised.** Attribution is not derivable from the fields the
-results schema carries (`battery[].status` is the only failure signal in it).
-The run artifacts *do* carry per-cell error text, so a "all non-`ok` cells share
-one error signature" proxy is constructible — it was considered and not adopted,
-because that text is session-authored, so identity across cells is self-attested
-and carries no attribution power against the case worth catching. It would catch
-sloppiness, not misuse.
+and it works only when someone actually runs the retry. A mechanical proxy
+("all non-`ok` cells share one error signature") was considered and rejected:
+the run artifacts *do* carry per-cell error text, so the proxy is constructible
+— but that text is session-authored, so identity across cells is self-attested,
+and it would catch sloppiness rather than misuse.
 
 **Structure (enforced by `append_eval.py`; it exits 1 otherwise):**
 
@@ -253,21 +248,15 @@ sloppiness, not misuse.
 **Declining a partial differentiation is legitimate.** The validator checks only
 that the field is non-empty, so `PARTIAL (n/6 cells) — insufficient to
 differentiate` satisfies it. Use that form rather than stretching one or two
-completed cells into a slot-earning judgment: `differentiation` means "does this
-model's *character* earn a catalog slot", and a couple of cells rarely answers
-it. The required-when-partial rule exists so real evidence is not silently
-discarded, not to manufacture a verdict — the same fabrication pressure the
-zero-`ok` rule guards against, arriving from the other side.
+completed cells into a slot-earning judgment. The required-when-partial rule
+exists so real evidence is not silently discarded, not to manufacture a verdict
+— the same fabrication pressure the zero-`ok` rule guards against, arriving from
+the other side.
 
 Note the two `differentiation` rows: a blocked run is **not** necessarily a
-total block.
-Sarashina 2.2 3B on 2026-07-08 had 3 of 6 cells complete (recorded in
-`tools/harness/Sources/PasturaHarnessKit/ModelProfile.swift`, the
-`sarashina223B` doc comment), so a "zero `ok` cells" precondition would have
-made that shape unrecordable. That run predates this disposition and has no
-ledger heading of its own — it is grandfathered inside the later entry,
-`docs/models/eval-log.md` § "Sarashina 2.2 3B Instruct v0.1 (Q4_K_M) —
-2026-07-23", under its *Grandfathered (#1419)* sub-bullet.
+total block. The worked precedent (Sarashina 2.2 3B, 2026-07-08 — 3 of 6 cells
+hard-failed, so some completed) is in `docs/models/eval-log.md` under the
+2026-07-23 entry's *Grandfathered (#1419)* sub-bullet.
 
 ## Step 5 — Append the scorecard
 

--- a/.claude/skills/model-eval/scripts/append_eval.py
+++ b/.claude/skills/model-eval/scripts/append_eval.py
@@ -41,8 +41,18 @@ Results JSON schema (composed by the /model-eval session):
     }
   ],
   "differentiation": "free text: how this model's outputs differ from others",
-  "verdict": {"gate": "pass|borderline|fail", "notes": "..."}
+                     // REQUIRED when gate is "blocked" and >=1 cell is ok;
+                     // FORBIDDEN when gate is "blocked" and no cell is ok
+                     // (zero inferences = zero evidence)
+  "verdict": {"gate": "pass|borderline|fail|blocked", "notes": "...",
+              // the two below are REQUIRED when gate is "blocked":
+              "unblocked_by": "the condition that would allow a retry",
+              "retry": "issue pointer, e.g. #1416 (the blocker's own issue is ok)"}
 }
+
+`blocked` = "could not be evaluated, retry when the blocker clears" — non-
+terminal, and distinct from a quality `fail`. See `validate_blocked` for which
+of its rules are enforced here and which stay in SKILL.md prose (#1419).
 """
 
 import argparse
@@ -117,9 +127,66 @@ def validate_results(results):
 
     verdict = results.get("verdict")
     if not isinstance(verdict, dict) or verdict.get("gate") not in (
-        "pass", "borderline", "fail",
+        "pass", "borderline", "fail", "blocked",
     ):
-        return "results.verdict.gate must be one of pass|borderline|fail"
+        return "results.verdict.gate must be one of pass|borderline|fail|blocked"
+
+    if verdict.get("gate") == "blocked":
+        err = validate_blocked(results, verdict, battery)
+        if err:
+            return err
+
+    return None
+
+
+def validate_blocked(results, verdict, battery):
+    """Structural rules for the `blocked` disposition (#1419).
+
+    `blocked` means "could not be evaluated, retry when the blocker clears" —
+    a non-terminal state, distinct from a quality `fail`. What separates the
+    two is ATTRIBUTION (an environmental blocker vs. the candidate's own
+    quality), which is a judgment and is NOT derivable from `battery[].status`.
+    The admissibility criterion therefore lives in SKILL.md prose; only its
+    structural consequences are enforced here.
+
+    Deliberately NOT a rule: "zero ok cells". Sarashina 2.2 3B on 2026-07-08 —
+    one of the two runs that motivated this disposition — had 3 of 6 cells
+    complete, and is recorded as blocked rather than cleanly rejected. A
+    zero-ok precondition would make that shape unrecordable and re-create the
+    defect this disposition exists to fix.
+    """
+    if not str(verdict.get("unblocked_by") or "").strip():
+        return (
+            "results.verdict.unblocked_by is required when gate is 'blocked' "
+            "— name the condition that would allow a retry"
+        )
+    if not str(verdict.get("retry") or "").strip():
+        return (
+            "results.verdict.retry is required when gate is 'blocked' "
+            "— an issue pointer; the blocker's own issue number is acceptable"
+        )
+
+    ok_cells = [e for e in battery if e.get("status") == "ok"]
+    if len(ok_cells) == len(battery):
+        return (
+            "gate 'blocked' requires at least one non-ok battery cell "
+            "— a run where every cell completed was not blocked"
+        )
+
+    # Zero inferences means zero evidence, so a differentiation judgment there
+    # would be fabricated. A partial block DID measure something, so discarding
+    # that judgment would lose real evidence — hence required, not forbidden.
+    has_differentiation = bool(str(results.get("differentiation") or "").strip())
+    if not ok_cells and has_differentiation:
+        return (
+            "results.differentiation must be absent when gate is 'blocked' and "
+            "no cell is ok — zero inferences means the judgment is unassessable"
+        )
+    if ok_cells and not has_differentiation:
+        return (
+            "results.differentiation is required when gate is 'blocked' and at "
+            "least one cell is ok — record what the completed cells did show"
+        )
 
     return None
 
@@ -204,10 +271,20 @@ def render_section(results):
         lines.append("| " + " | ".join(row) + " |")
 
     lines.append("")
+    verdict = results.get("verdict") or {}
     if results.get("differentiation"):
         lines += [f"Differentiation: {results['differentiation']}", ""]
-    verdict = results.get("verdict") or {}
+    elif verdict.get("gate") == "blocked":
+        # The ledger's anti-drift rule requires a one-line differentiation in
+        # EVERY entry, and this section is what an operator transcribes into it.
+        # Emit the sanctioned placeholder rather than nothing, so the required
+        # line is carried by construction rather than by operator memory.
+        lines += ["Differentiation: UNASSESSABLE (blocked — no cell completed)", ""]
     lines.append(f"**Gate**: {verdict.get('gate', '?')}")
+    if verdict.get("unblocked_by"):
+        lines.append(f"Unblocked by: {verdict['unblocked_by']}")
+    if verdict.get("retry"):
+        lines.append(f"Retry: {verdict['retry']}")
     if verdict.get("notes"):
         lines.append(f"Notes: {verdict['notes']}")
     lines.append("")

--- a/.claude/skills/model-eval/scripts/append_eval.py
+++ b/.claude/skills/model-eval/scripts/append_eval.py
@@ -272,8 +272,14 @@ def render_section(results):
 
     lines.append("")
     verdict = results.get("verdict") or {}
-    if results.get("differentiation"):
-        lines += [f"Differentiation: {results['differentiation']}", ""]
+    # Normalize exactly as `validate_blocked` does, and branch on that same
+    # value. Testing raw truthiness here instead would let the two sites
+    # disagree: a whitespace-only value passes the validator's forbidden-guard
+    # (it strips to "") yet renders as `Differentiation:   `, silently losing
+    # the placeholder line the ledger's anti-drift rule needs.
+    differentiation = str(results.get("differentiation") or "").strip()
+    if differentiation:
+        lines += [f"Differentiation: {differentiation}", ""]
     elif verdict.get("gate") == "blocked":
         # The ledger's anti-drift rule requires a one-line differentiation in
         # EVERY entry, and this section is what an operator transcribes into it.

--- a/.claude/skills/model-eval/scripts/append_eval.py
+++ b/.claude/skills/model-eval/scripts/append_eval.py
@@ -149,11 +149,10 @@ def validate_blocked(results, verdict, battery):
     The admissibility criterion therefore lives in SKILL.md prose; only its
     structural consequences are enforced here.
 
-    Deliberately NOT a rule: "zero ok cells". Sarashina 2.2 3B on 2026-07-08 —
-    one of the two runs that motivated this disposition — had 3 of 6 cells
-    complete, and is recorded as blocked rather than cleanly rejected. A
-    zero-ok precondition would make that shape unrecordable and re-create the
-    defect this disposition exists to fix.
+    Deliberately NOT a rule: "zero ok cells". A block can be partial, and that
+    precondition would make the shape unrecordable — worked precedent in
+    docs/models/eval-log.md, the 2026-07-23 Sarashina entry's
+    *Grandfathered (#1419)* sub-bullet.
     """
     if not str(verdict.get("unblocked_by") or "").strip():
         return (
@@ -272,19 +271,17 @@ def render_section(results):
 
     lines.append("")
     verdict = results.get("verdict") or {}
-    # Normalize exactly as `validate_blocked` does, and branch on that same
-    # value. Testing raw truthiness here instead would let the two sites
-    # disagree: a whitespace-only value passes the validator's forbidden-guard
-    # (it strips to "") yet renders as `Differentiation:   `, silently losing
-    # the placeholder line the ledger's anti-drift rule needs.
+    # Normalize exactly as `validate_blocked` does. On raw truthiness the two
+    # sites would disagree: a whitespace-only value passes the validator's
+    # forbidden-guard yet renders as `Differentiation:   `, losing the
+    # placeholder below.
     differentiation = str(results.get("differentiation") or "").strip()
     if differentiation:
         lines += [f"Differentiation: {differentiation}", ""]
     elif verdict.get("gate") == "blocked":
-        # The ledger's anti-drift rule requires a one-line differentiation in
-        # EVERY entry, and this section is what an operator transcribes into it.
-        # Emit the sanctioned placeholder rather than nothing, so the required
-        # line is carried by construction rather than by operator memory.
+        # The ledger's anti-drift rule wants a one-line differentiation in EVERY
+        # entry, and this section is what an operator transcribes into it — so
+        # carry the sanctioned placeholder by construction, not by memory.
         lines += ["Differentiation: UNASSESSABLE (blocked — no cell completed)", ""]
     lines.append(f"**Gate**: {verdict.get('gate', '?')}")
     if verdict.get("unblocked_by"):

--- a/.claude/skills/model-eval/tests/fixtures/results_blocked_all_ok.json
+++ b/.claude/skills/model-eval/tests/fixtures/results_blocked_all_ok.json
@@ -1,0 +1,20 @@
+{
+  "date": "2026-08-08",
+  "model": {"profile_id": "gemma-4-e2b-q4-k-m", "gguf": "gemma-4-E2B_q4_0-it"},
+  "battery": [
+    {
+      "scenario_id": "bokete", "language": "ja", "status": "ok",
+      "attempts": 1, "language_mismatches": 0, "tok_per_sec": 12.0,
+      "rubric": {"coherence": 4, "interaction": 3, "breakdown_free": 5,
+                 "development": 3, "payoff": 4, "payoff_axis": "humor"},
+      "comment": "keyed so ONLY the non-ok-cell guard can fire"
+    }
+  ],
+  "differentiation": "present, so the differentiation guards cannot fire here",
+  "verdict": {
+    "gate": "blocked",
+    "unblocked_by": "nothing — this run was not actually blocked",
+    "retry": "#1416",
+    "notes": "every cell completed, so blocked is not admissible"
+  }
+}

--- a/.claude/skills/model-eval/tests/fixtures/results_blocked_no_retry.json
+++ b/.claude/skills/model-eval/tests/fixtures/results_blocked_no_retry.json
@@ -1,0 +1,17 @@
+{
+  "date": "2026-08-08",
+  "model": {"profile_id": "gemma-4-e2b-q4-k-m", "gguf": "gemma-4-E2B_q4_0-it"},
+  "battery": [
+    {
+      "scenario_id": "bokete", "language": "ja", "status": "failed",
+      "attempts": 2, "language_mismatches": 0, "tok_per_sec": null,
+      "rubric": null,
+      "comment": "keyed so ONLY the retry guard can fire"
+    }
+  ],
+  "verdict": {
+    "gate": "blocked",
+    "unblocked_by": "pinned llama.cpp gains shared-KV tail-layer support",
+    "notes": "retry pointer deliberately omitted"
+  }
+}

--- a/.claude/skills/model-eval/tests/fixtures/results_blocked_no_unblocked_by.json
+++ b/.claude/skills/model-eval/tests/fixtures/results_blocked_no_unblocked_by.json
@@ -1,0 +1,17 @@
+{
+  "date": "2026-08-08",
+  "model": {"profile_id": "gemma-4-e2b-q4-k-m", "gguf": "gemma-4-E2B_q4_0-it"},
+  "battery": [
+    {
+      "scenario_id": "bokete", "language": "ja", "status": "failed",
+      "attempts": 2, "language_mismatches": 0, "tok_per_sec": null,
+      "rubric": null,
+      "comment": "keyed so ONLY the unblocked_by guard can fire"
+    }
+  ],
+  "verdict": {
+    "gate": "blocked",
+    "retry": "#1416",
+    "notes": "unblock condition deliberately omitted"
+  }
+}

--- a/.claude/skills/model-eval/tests/fixtures/results_blocked_partial_no_differentiation.json
+++ b/.claude/skills/model-eval/tests/fixtures/results_blocked_partial_no_differentiation.json
@@ -1,0 +1,25 @@
+{
+  "date": "2026-07-08",
+  "model": {"profile_id": "sarashina-2-2-3b-q4-k-m", "gguf": "sarashina2.2-3b-instruct-v0.1-Q4_K_M"},
+  "battery": [
+    {
+      "scenario_id": "bokete", "language": "ja", "status": "ok",
+      "attempts": 1, "language_mismatches": 0, "tok_per_sec": 4.9,
+      "rubric": {"coherence": 4, "interaction": 3, "breakdown_free": 4,
+                 "development": 3, "payoff": 5, "payoff_axis": "humor"},
+      "comment": "completed — so real evidence exists"
+    },
+    {
+      "scenario_id": "word_wolf", "language": "ja", "status": "failed",
+      "attempts": 2, "language_mismatches": 0, "tok_per_sec": null,
+      "rubric": null,
+      "comment": "empty-output path (#751)"
+    }
+  ],
+  "verdict": {
+    "gate": "blocked",
+    "unblocked_by": "the #751 empty-output path is fixed",
+    "retry": "#751",
+    "notes": "keyed so ONLY the differentiation-required guard can fire"
+  }
+}

--- a/.claude/skills/model-eval/tests/fixtures/results_blocked_partial_valid.json
+++ b/.claude/skills/model-eval/tests/fixtures/results_blocked_partial_valid.json
@@ -1,0 +1,26 @@
+{
+  "date": "2026-07-08",
+  "model": {"profile_id": "sarashina-2-2-3b-q4-k-m", "gguf": "sarashina2.2-3b-instruct-v0.1-Q4_K_M"},
+  "battery": [
+    {
+      "scenario_id": "bokete", "language": "ja", "status": "ok",
+      "attempts": 1, "language_mismatches": 0, "tok_per_sec": 4.9,
+      "rubric": {"coherence": 4, "interaction": 3, "breakdown_free": 4,
+                 "development": 3, "payoff": 5, "payoff_axis": "humor"},
+      "comment": "completed"
+    },
+    {
+      "scenario_id": "word_wolf", "language": "ja", "status": "failed",
+      "attempts": 2, "language_mismatches": 0, "tok_per_sec": null,
+      "rubric": null,
+      "comment": "empty-output path (#751)"
+    }
+  ],
+  "differentiation": "ja-native humor on the cells that completed; the rest is unmeasured",
+  "verdict": {
+    "gate": "blocked",
+    "unblocked_by": "the #751 empty-output path is fixed",
+    "retry": "#751",
+    "notes": "partial block — the shape a zero-ok precondition would have made unrecordable"
+  }
+}

--- a/.claude/skills/model-eval/tests/fixtures/results_blocked_total_with_differentiation.json
+++ b/.claude/skills/model-eval/tests/fixtures/results_blocked_total_with_differentiation.json
@@ -1,0 +1,19 @@
+{
+  "date": "2026-08-08",
+  "model": {"profile_id": "gemma-4-e2b-q4-k-m", "gguf": "gemma-4-E2B_q4_0-it"},
+  "battery": [
+    {
+      "scenario_id": "bokete", "language": "ja", "status": "failed",
+      "attempts": 2, "language_mismatches": 0, "tok_per_sec": null,
+      "rubric": null,
+      "comment": "zero ok cells, so differentiation is unassessable"
+    }
+  ],
+  "differentiation": "fabricated — there were zero inferences to judge",
+  "verdict": {
+    "gate": "blocked",
+    "unblocked_by": "pinned llama.cpp gains shared-KV tail-layer support",
+    "retry": "#1416",
+    "notes": "keyed so ONLY the differentiation-forbidden guard can fire"
+  }
+}

--- a/.claude/skills/model-eval/tests/fixtures/results_blocked_valid.json
+++ b/.claude/skills/model-eval/tests/fixtures/results_blocked_valid.json
@@ -1,0 +1,24 @@
+{
+  "date": "2026-08-08",
+  "model": {"profile_id": "gemma-4-e2b-q4-k-m", "gguf": "gemma-4-E2B_q4_0-it"},
+  "battery": [
+    {
+      "scenario_id": "bokete", "language": "ja", "status": "failed",
+      "attempts": 2, "language_mismatches": 0, "tok_per_sec": null,
+      "rubric": null,
+      "comment": "model load failed — missing tensor"
+    },
+    {
+      "scenario_id": "word_wolf", "language": "en", "status": "failed",
+      "attempts": 2, "language_mismatches": 0, "tok_per_sec": null,
+      "rubric": null,
+      "comment": "model load failed — missing tensor"
+    }
+  ],
+  "verdict": {
+    "gate": "blocked",
+    "unblocked_by": "pinned llama.cpp gains shared-KV tail-layer support",
+    "retry": "#1416",
+    "notes": "total block — zero inferences reached"
+  }
+}

--- a/.claude/skills/model-eval/tests/run_tests.sh
+++ b/.claude/skills/model-eval/tests/run_tests.sh
@@ -163,10 +163,9 @@ grep -qF "Retry: #1416" "$JOURNAL" || fail "append: blocked section missing the 
 grep -qF "Differentiation: UNASSESSABLE" "$JOURNAL" \
   || fail "append: blocked section must state differentiation is unassessable"
 
-# Positive control #2 — a PARTIAL block (>=1 ok cell). This is the shape the
-# rejected "zero ok cells" precondition would have made unrecordable, so it
-# needs a green arm of its own: without one, re-adding that precondition (or
-# mislabelling a partial block as UNASSESSABLE) would leave the suite green.
+# Positive control #2 — a PARTIAL block (>=1 ok cell). Without a green arm of
+# its own, re-adding the rejected "zero ok cells" precondition (or mislabelling
+# a partial block as UNASSESSABLE) would leave the suite green.
 python3 "$SCRIPTS/append_eval.py" \
   --results fixtures/results_blocked_partial_valid.json --journal "$JOURNAL" >/dev/null \
   || fail "append: valid PARTIAL blocked fixture should succeed"

--- a/.claude/skills/model-eval/tests/run_tests.sh
+++ b/.claude/skills/model-eval/tests/run_tests.sh
@@ -110,7 +110,52 @@ python3 "$SCRIPTS/append_eval.py" \
 RC=$?
 set -e
 [ "$RC" -eq 1 ] || fail "append: invalid verdict.gate fixture should exit 1, got $RC"
-grep -q "gate" "$TMP/invalid_err" || fail "append: invalid-gate error message missing"
+# Message-keyed, not a bare `grep -q gate`: since `blocked` landed there are
+# several distinct errors whose text contains "gate", so a substring match
+# would let this arm pass on another guard's failure (#1419).
+grep -qF "must be one of pass|borderline|fail|blocked" "$TMP/invalid_err" \
+  || fail "append: invalid-gate arm reddened for the wrong reason: $(cat "$TMP/invalid_err")"
+
+# --- `blocked` disposition guards (#1419) ---------------------------------
+# One arm per guard. Each fixture is keyed so ONLY its target guard can redden
+# it, and each arm asserts WHICH message fired — the guards share an exit code,
+# so an exit-status-only arm would pass on a sibling guard's failure.
+assert_blocked_reject() {
+  fixture="$1"
+  expected="$2"
+  errfile="$TMP/err_$fixture"
+  set +e
+  python3 "$SCRIPTS/append_eval.py" \
+    --results "fixtures/$fixture" --journal "$JOURNAL" >/dev/null 2>"$errfile"
+  rc=$?
+  set -e
+  [ "$rc" -eq 1 ] || fail "append: $fixture should exit 1, got $rc"
+  grep -qF "$expected" "$errfile" \
+    || fail "append: $fixture reddened for the wrong reason — expected '$expected', got: $(cat "$errfile")"
+}
+
+assert_blocked_reject results_blocked_no_unblocked_by.json \
+  "verdict.unblocked_by is required when gate is 'blocked'"
+assert_blocked_reject results_blocked_no_retry.json \
+  "verdict.retry is required when gate is 'blocked'"
+assert_blocked_reject results_blocked_all_ok.json \
+  "gate 'blocked' requires at least one non-ok battery cell"
+assert_blocked_reject results_blocked_total_with_differentiation.json \
+  "differentiation must be absent when gate is 'blocked' and no cell is ok"
+assert_blocked_reject results_blocked_partial_no_differentiation.json \
+  "differentiation is required when gate is 'blocked' and at least one cell is ok"
+
+# Positive control: a well-formed total block appends, and the rendered section
+# carries the fields a human transcribes into docs/models/eval-log.md.
+python3 "$SCRIPTS/append_eval.py" \
+  --results fixtures/results_blocked_valid.json --journal "$JOURNAL" >/dev/null \
+  || fail "append: valid blocked fixture should succeed"
+grep -qF "**Gate**: blocked" "$JOURNAL" || fail "append: blocked gate not rendered"
+grep -qF "Unblocked by: pinned llama.cpp" "$JOURNAL" \
+  || fail "append: blocked section missing the Unblocked by line"
+grep -qF "Retry: #1416" "$JOURNAL" || fail "append: blocked section missing the Retry line"
+grep -qF "Differentiation: UNASSESSABLE" "$JOURNAL" \
+  || fail "append: blocked section must state differentiation is unassessable"
 
 # --- run_scenario.sh --profile canary (PASTURA_HARNESS_BIN test seam) ------
 FAKE_BIN="$TMP/fake_harness.sh"

--- a/.claude/skills/model-eval/tests/run_tests.sh
+++ b/.claude/skills/model-eval/tests/run_tests.sh
@@ -121,17 +121,23 @@ grep -qF "must be one of pass|borderline|fail|blocked" "$TMP/invalid_err" \
 # it, and each arm asserts WHICH message fired — the guards share an exit code,
 # so an exit-status-only arm would pass on a sibling guard's failure.
 assert_blocked_reject() {
-  fixture="$1"
-  expected="$2"
-  errfile="$TMP/err_$fixture"
+  local fixture="$1"
+  local expected="$2"
+  local errfile="$TMP/err_$fixture"
+  # A rejected fixture must also leave the journal byte-identical — validation
+  # runs before any write, and this is what pins that.
+  local before
+  before=$(cksum < "$JOURNAL")
   set +e
   python3 "$SCRIPTS/append_eval.py" \
     --results "fixtures/$fixture" --journal "$JOURNAL" >/dev/null 2>"$errfile"
-  rc=$?
+  local rc=$?
   set -e
   [ "$rc" -eq 1 ] || fail "append: $fixture should exit 1, got $rc"
   grep -qF "$expected" "$errfile" \
     || fail "append: $fixture reddened for the wrong reason — expected '$expected', got: $(cat "$errfile")"
+  [ "$(cksum < "$JOURNAL")" = "$before" ] \
+    || fail "append: $fixture was rejected but still mutated the journal"
 }
 
 assert_blocked_reject results_blocked_no_unblocked_by.json \
@@ -156,6 +162,24 @@ grep -qF "Unblocked by: pinned llama.cpp" "$JOURNAL" \
 grep -qF "Retry: #1416" "$JOURNAL" || fail "append: blocked section missing the Retry line"
 grep -qF "Differentiation: UNASSESSABLE" "$JOURNAL" \
   || fail "append: blocked section must state differentiation is unassessable"
+
+# Positive control #2 — a PARTIAL block (>=1 ok cell). This is the shape the
+# rejected "zero ok cells" precondition would have made unrecordable, so it
+# needs a green arm of its own: without one, re-adding that precondition (or
+# mislabelling a partial block as UNASSESSABLE) would leave the suite green.
+python3 "$SCRIPTS/append_eval.py" \
+  --results fixtures/results_blocked_partial_valid.json --journal "$JOURNAL" >/dev/null \
+  || fail "append: valid PARTIAL blocked fixture should succeed"
+grep -qF "Differentiation: ja-native humor on the cells that completed" "$JOURNAL" \
+  || fail "append: partial block must render its real differentiation"
+PARTIAL_SECTION="$TMP/partial_section.md"
+sed -n '/^## 2026-07-08 — sarashina-2-2-3b-q4-k-m/,/^## /p' "$JOURNAL" > "$PARTIAL_SECTION"
+[ -s "$PARTIAL_SECTION" ] || fail "append: partial blocked section not found in the journal"
+if grep -qF "UNASSESSABLE" "$PARTIAL_SECTION"; then
+  fail "append: partial block must NOT be labelled UNASSESSABLE — a cell did complete"
+fi
+grep -qF "Retry: #751" "$PARTIAL_SECTION" \
+  || fail "append: partial blocked section missing the Retry line"
 
 # --- run_scenario.sh --profile canary (PASTURA_HARNESS_BIN test seam) ------
 FAKE_BIN="$TMP/fake_harness.sh"

--- a/Pastura/Pastura/App/ModelRegistry.swift
+++ b/Pastura/Pastura/App/ModelRegistry.swift
@@ -55,12 +55,12 @@ enum ModelRegistry {
     fileName: "gemma-4-E2B-it-Q4_K_M.gguf",
     fileSize: 3_106_735_776,
     sha256: "ac0069ebccd39925d836f24a88c0f0c858d20578c29b21ab7cedce66ee576845",
-    // Inert for Gemma 4, deliberately: `<|im_end|>` is a ChatML sentinel absent
-    // from this model's 262k vocabulary (its markers are `<|turn>` / `<turn|>`,
-    // ids 105/106), and the turn terminates on EOG. `stopSequence` only ever
-    // matches a sentinel the model spells out as text, and no Gemma plaintext
-    // marker has been demonstrated in decoded output — so it is left as-is
-    // rather than guessed at (#1417; the behaviour half is #1422).
+    // Carries no Gemma marker, deliberately: `<|im_end|>` is a ChatML sentinel
+    // absent from this model's 262k vocabulary, and Gemma's own markers are
+    // `<|turn>` / `<turn|>` (ids 105/106, CONTROL). `stopSequence` only ever
+    // matches a sentinel the model spells out as text, and which text a Gemma
+    // hallucination would spell is **not established** — so this is left as-is
+    // rather than replaced by a guess (#1417; the behaviour half is #1422).
     stopSequence: "<|im_end|>",
     minRAM: 6_500_000_000,
     modelInfoURL: unsafeURL("https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF"),

--- a/Pastura/Pastura/App/ModelRegistry.swift
+++ b/Pastura/Pastura/App/ModelRegistry.swift
@@ -55,6 +55,12 @@ enum ModelRegistry {
     fileName: "gemma-4-E2B-it-Q4_K_M.gguf",
     fileSize: 3_106_735_776,
     sha256: "ac0069ebccd39925d836f24a88c0f0c858d20578c29b21ab7cedce66ee576845",
+    // Inert for Gemma 4, deliberately: `<|im_end|>` is a ChatML sentinel absent
+    // from this model's 262k vocabulary (its markers are `<|turn>` / `<turn|>`,
+    // ids 105/106), and the turn terminates on EOG. `stopSequence` only ever
+    // matches a sentinel the model spells out as text, and no Gemma plaintext
+    // marker has been demonstrated in decoded output — so it is left as-is
+    // rather than guessed at (#1417; the behaviour half is #1422).
     stopSequence: "<|im_end|>",
     minRAM: 6_500_000_000,
     modelInfoURL: unsafeURL("https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF"),

--- a/Pastura/Pastura/App/ModelRegistry.swift
+++ b/Pastura/Pastura/App/ModelRegistry.swift
@@ -56,11 +56,9 @@ enum ModelRegistry {
     fileSize: 3_106_735_776,
     sha256: "ac0069ebccd39925d836f24a88c0f0c858d20578c29b21ab7cedce66ee576845",
     // Carries no Gemma marker, deliberately: `<|im_end|>` is a ChatML sentinel
-    // absent from this model's 262k vocabulary, and Gemma's own markers are
-    // `<|turn>` / `<turn|>` (ids 105/106, CONTROL). `stopSequence` only ever
-    // matches a sentinel the model spells out as text, and which text a Gemma
-    // hallucination would spell is **not established** — so this is left as-is
-    // rather than replaced by a guess (#1417; the behaviour half is #1422).
+    // absent from this model's vocabulary, and replacing it would mean guessing
+    // what text a Gemma hallucination spells out. See the canonical note on
+    // `LlamaCppService.stopSequence` (#1417; behaviour half #1422).
     stopSequence: "<|im_end|>",
     minRAM: 6_500_000_000,
     modelInfoURL: unsafeURL("https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF"),

--- a/Pastura/Pastura/Engine/LLMCaller+Logging.swift
+++ b/Pastura/Pastura/Engine/LLMCaller+Logging.swift
@@ -71,11 +71,12 @@ nonisolated extension LLMCaller {
   /// wrap path, Ollama) where the raw string may still contain template
   /// tokens.
   ///
-  /// - Important: ChatML-only. Gemma 4's markers are `<|turn>` / `<turn|>`, so
-  ///   this diagnostic never matches for the default shipped model. Backends
-  ///   that decode server-side — Ollama and Foundation Models, neither of
-  ///   which defines `generateStream` — lack llama.cpp's decode-side
-  ///   guarantee, and are the residual surface here. Making it model-aware is
+  /// - Important: ChatML-only, so for Gemma 4 (markers `<|turn>` / `<turn|>`)
+  ///   it can match only a spelled-out ChatML token. Note the `<|im_start|>`
+  ///   branch stays reachable even under llama.cpp: the streaming path strips
+  ///   `stopSequence`, which is `<|im_end|>` alone, so a spelled-out
+  ///   `<|im_start|>` survives — that is what the #65 TODO on
+  ///   `LlamaCppService.stopSequence` is about. Making this model-aware is
   ///   tracked in #1422.
   func logChatTemplateLeakage(in raw: String) {
     if raw.contains("<|im_start|>") {

--- a/Pastura/Pastura/Engine/LLMCaller+Logging.swift
+++ b/Pastura/Pastura/Engine/LLMCaller+Logging.swift
@@ -71,9 +71,11 @@ nonisolated extension LLMCaller {
   /// wrap path, Ollama) where the raw string may still contain template
   /// tokens.
   ///
-  /// - Important: ChatML-only. Gemma 4's markers are `<|turn>` / `<turn|>`,
-  ///   so this diagnostic is silently blind for the default shipped model.
-  ///   Making it model-aware is tracked in #1422.
+  /// - Important: ChatML-only. Gemma 4's markers are `<|turn>` / `<turn|>`, so
+  ///   this diagnostic sees nothing for the default shipped model. Note the
+  ///   backends named above are exactly the ones without llama.cpp's
+  ///   decode-side guarantee, which is what makes them the residual surface
+  ///   here. Making it model-aware is tracked in #1422.
   func logChatTemplateLeakage(in raw: String) {
     if raw.contains("<|im_start|>") {
       logger.log(

--- a/Pastura/Pastura/Engine/LLMCaller+Logging.swift
+++ b/Pastura/Pastura/Engine/LLMCaller+Logging.swift
@@ -72,10 +72,11 @@ nonisolated extension LLMCaller {
   /// tokens.
   ///
   /// - Important: ChatML-only. Gemma 4's markers are `<|turn>` / `<turn|>`, so
-  ///   this diagnostic sees nothing for the default shipped model. Note the
-  ///   backends named above are exactly the ones without llama.cpp's
-  ///   decode-side guarantee, which is what makes them the residual surface
-  ///   here. Making it model-aware is tracked in #1422.
+  ///   this diagnostic never matches for the default shipped model. Backends
+  ///   that decode server-side — Ollama and Foundation Models, neither of
+  ///   which defines `generateStream` — lack llama.cpp's decode-side
+  ///   guarantee, and are the residual surface here. Making it model-aware is
+  ///   tracked in #1422.
   func logChatTemplateLeakage(in raw: String) {
     if raw.contains("<|im_start|>") {
       logger.log(

--- a/Pastura/Pastura/Engine/LLMCaller+Logging.swift
+++ b/Pastura/Pastura/Engine/LLMCaller+Logging.swift
@@ -71,13 +71,11 @@ nonisolated extension LLMCaller {
   /// wrap path, Ollama) where the raw string may still contain template
   /// tokens.
   ///
-  /// - Important: ChatML-only, so for Gemma 4 (markers `<|turn>` / `<turn|>`)
-  ///   it can match only a spelled-out ChatML token. Note the `<|im_start|>`
-  ///   branch stays reachable even under llama.cpp: the streaming path strips
-  ///   `stopSequence`, which is `<|im_end|>` alone, so a spelled-out
-  ///   `<|im_start|>` survives — that is what the #65 TODO on
-  ///   `LlamaCppService.stopSequence` is about. Making this model-aware is
-  ///   tracked in #1422.
+  /// - Important: ChatML-only, so a non-ChatML model (Gemma 4) is not covered
+  ///   — #1422. A spelled-out `<|im_start|>` stays reachable even under
+  ///   llama.cpp, whose streaming path strips `stopSequence` (`<|im_end|>`)
+  ///   alone; that is what the #65 TODO on `LlamaCppService.stopSequence` is
+  ///   about.
   func logChatTemplateLeakage(in raw: String) {
     if raw.contains("<|im_start|>") {
       logger.log(

--- a/Pastura/Pastura/Engine/LLMCaller+Logging.swift
+++ b/Pastura/Pastura/Engine/LLMCaller+Logging.swift
@@ -66,10 +66,14 @@ nonisolated extension LLMCaller {
   }
 
   /// Detect chat template token leakage and hallucinated continuations.
-  /// `LlamaCppService`'s streaming path strips `<|im_end|>` before
-  /// emission, so this primarily catches non-streaming backends (Mock
+  /// `LlamaCppService`'s streaming path strips a spelled-out `<|im_end|>`
+  /// before emission, so this primarily catches non-streaming backends (Mock
   /// wrap path, Ollama) where the raw string may still contain template
   /// tokens.
+  ///
+  /// - Important: ChatML-only. Gemma 4's markers are `<|turn>` / `<turn|>`,
+  ///   so this diagnostic is silently blind for the default shipped model.
+  ///   Making it model-aware is tracked in #1422.
   func logChatTemplateLeakage(in raw: String) {
     if raw.contains("<|im_start|>") {
       logger.log(

--- a/Pastura/Pastura/LLM/GBNFGrammarBuilder.swift
+++ b/Pastura/Pastura/LLM/GBNFGrammarBuilder.swift
@@ -193,7 +193,9 @@ nonisolated public struct GBNFGrammarBuilder: Sendable {
   // Coverage: tab, CR, LF, space through tilde (0x20-0x7e) —
   // all printable ASCII plus whitespace. Post-`}` tokens from Gemma
   // are almost always whitespace, chat-template fragments
-  // (`<|im_end|>` etc.) or EOS; all fit in this range. Non-ASCII
+  // (`<|turn>` / `<turn|>` — Gemma 4's markers; `<|im_end|>` is a Qwen
+  // ChatML one, absent from Gemma's vocabulary) or EOS; all fit in this
+  // range. Non-ASCII
   // post-`}` bytes would still cause an accept-time crash, but the
   // model is trained to emit EOS immediately after a closed object
   // so that path is practically unreachable.

--- a/Pastura/Pastura/LLM/GBNFGrammarBuilder.swift
+++ b/Pastura/Pastura/LLM/GBNFGrammarBuilder.swift
@@ -192,13 +192,12 @@ nonisolated public struct GBNFGrammarBuilder: Sendable {
   //
   // Coverage: tab, CR, LF, space through tilde (0x20-0x7e) —
   // all printable ASCII plus whitespace. Post-`}` tokens from Gemma
-  // are almost always whitespace, chat-template fragments
-  // (`<|turn>` / `<turn|>` — Gemma 4's markers; `<|im_end|>` is a Qwen
-  // ChatML one, absent from Gemma's vocabulary) or EOS; all fit in this
-  // range. Non-ASCII
-  // post-`}` bytes would still cause an accept-time crash, but the
-  // model is trained to emit EOS immediately after a closed object
-  // so that path is practically unreachable.
+  // are almost always whitespace, chat-template fragments (`<|turn>` /
+  // `<turn|>` — Gemma 4's markers; `<|im_end|>` is a Qwen ChatML one,
+  // absent from Gemma's vocabulary) or EOS; all fit in this range.
+  // Non-ASCII post-`}` bytes would still cause an accept-time crash,
+  // but the model is trained to emit EOS immediately after a closed
+  // object so that path is practically unreachable.
   //
   // Emits, e.g. for budget 16:
   //   trailing   ::= ([\t\n\r -~] trailing1)?

--- a/Pastura/Pastura/LLM/GBNFGrammarBuilder.swift
+++ b/Pastura/Pastura/LLM/GBNFGrammarBuilder.swift
@@ -192,9 +192,8 @@ nonisolated public struct GBNFGrammarBuilder: Sendable {
   //
   // Coverage: tab, CR, LF, space through tilde (0x20-0x7e) —
   // all printable ASCII plus whitespace. Post-`}` tokens from Gemma
-  // are almost always whitespace, chat-template fragments (`<|turn>` /
-  // `<turn|>` — Gemma 4's markers; `<|im_end|>` is a Qwen ChatML one,
-  // absent from Gemma's vocabulary) or EOS; all fit in this range.
+  // are almost always whitespace, chat-template fragments (Gemma 4's
+  // markers are `<|turn>` / `<turn|>`) or EOS; all fit in this range.
   // Non-ASCII post-`}` bytes would still cause an accept-time crash,
   // but the model is trained to emit EOS immediately after a closed
   // object so that path is practically unreachable.

--- a/Pastura/Pastura/LLM/JSONResponseParser.swift
+++ b/Pastura/Pastura/LLM/JSONResponseParser.swift
@@ -22,8 +22,9 @@ nonisolated public struct JSONResponseParser: Sendable {
   )
   // Chat template tokens — truncate everything from first occurrence onwards.
   // Catches hallucinated continuations where the model generates past its own turn.
-  // ChatML-only by construction: correct for Qwen 3, but Gemma 4's markers are
-  // `<|turn>` / `<turn|>`, so a Gemma hallucination is NOT truncated here.
+  // ChatML-only by construction: correct for Qwen 3, but inert for Gemma 4,
+  // whose markers are `<|turn>` / `<turn|>` — see the doc on
+  // `truncateAtChatTemplateToken` for why they cannot arrive as text.
   // Making this per-model is #1422; the false-rationale half was #1417.
   private static let chatTemplateTokenRegex = try? NSRegularExpression(
     pattern: #"<\|im_end\|>.*"#,
@@ -294,9 +295,13 @@ nonisolated public struct JSONResponseParser: Sendable {
   /// regex from capturing content across hallucinated turns.
   ///
   /// - Important: the token is hardcoded, so this is a no-op for a non-ChatML
-  ///   model. Gemma 4 — the default shipped model — writes `<|turn>` /
-  ///   `<turn|>` instead, and its hallucinated continuations are therefore not
-  ///   truncated. Sourcing the marker per-model is tracked in #1422.
+  ///   model. Gemma 4's turn markers are CONTROL tokens (`<|turn>` / `<turn|>`,
+  ///   ids 105/106) that cannot reach this parser as text at all — `special:
+  ///   false` decoding drops 105, and 106 is EOG — and `<|im_end|>` is absent
+  ///   from its vocabulary, so this step is inert for the default shipped
+  ///   model. **Which text a Gemma hallucination would spell out instead is
+  ///   not established**; whatever it is, it would not be truncated here.
+  ///   Sourcing the marker per-model is tracked in #1422.
   private func truncateAtChatTemplateToken(_ text: String) -> String {
     guard let regex = Self.chatTemplateTokenRegex else { return text }
     let range = NSRange(text.startIndex..., in: text)

--- a/Pastura/Pastura/LLM/JSONResponseParser.swift
+++ b/Pastura/Pastura/LLM/JSONResponseParser.swift
@@ -22,9 +22,9 @@ nonisolated public struct JSONResponseParser: Sendable {
   )
   // Chat template tokens — truncate everything from first occurrence onwards.
   // Catches hallucinated continuations where the model generates past its own turn.
-  // ChatML-only by construction: correct for Qwen 3, does nothing for Gemma 4,
-  // whose markers are `<|turn>` / `<turn|>` — see the doc on
-  // `truncateAtChatTemplateToken` for the per-backend detail.
+  // ChatML-only by construction: correct for Qwen 3; for Gemma 4, whose
+  // markers are `<|turn>` / `<turn|>`, it can only fire on a spelled-out
+  // `<|im_end|>` — see the doc on `truncateAtChatTemplateToken`.
   // Making this per-model is #1422; the false-rationale half was #1417.
   private static let chatTemplateTokenRegex = try? NSRegularExpression(
     pattern: #"<\|im_end\|>.*"#,
@@ -294,10 +294,12 @@ nonisolated public struct JSONResponseParser: Sendable {
   /// Discarding everything from the first such token prevents the greedy JSON
   /// regex from capturing content across hallucinated turns.
   ///
-  /// - Important: the token is hardcoded, so this step does nothing for a
-  ///   non-ChatML model. Gemma 4's markers are `<|turn>` / `<turn|>` and
-  ///   `<|im_end|>` is not in its vocabulary, so the literal can only arrive
-  ///   spelled out as ordinary text — possible, but not observed.
+  /// - Important: the token is hardcoded, so for a non-ChatML model this step
+  ///   fires only on a spelled-out `<|im_end|>`. Gemma 4's markers are
+  ///   `<|turn>` / `<turn|>` and `<|im_end|>` is not in its vocabulary, so
+  ///   spelled-out is the only form that could arrive — possible, but not seen.
+  ///   What this step does NOT do for Gemma is truncate a Gemma-shaped
+  ///   continuation.
   ///
   ///   This type is backend-agnostic (`LLMCaller` parses llama.cpp, Ollama and
   ///   Foundation Models output through one instance), so do not assume the

--- a/Pastura/Pastura/LLM/JSONResponseParser.swift
+++ b/Pastura/Pastura/LLM/JSONResponseParser.swift
@@ -22,9 +22,9 @@ nonisolated public struct JSONResponseParser: Sendable {
   )
   // Chat template tokens — truncate everything from first occurrence onwards.
   // Catches hallucinated continuations where the model generates past its own turn.
-  // ChatML-only by construction: correct for Qwen 3, but inert for Gemma 4,
+  // ChatML-only by construction: correct for Qwen 3, does nothing for Gemma 4,
   // whose markers are `<|turn>` / `<turn|>` — see the doc on
-  // `truncateAtChatTemplateToken` for why they cannot arrive as text.
+  // `truncateAtChatTemplateToken` for the per-backend detail.
   // Making this per-model is #1422; the false-rationale half was #1417.
   private static let chatTemplateTokenRegex = try? NSRegularExpression(
     pattern: #"<\|im_end\|>.*"#,
@@ -294,13 +294,21 @@ nonisolated public struct JSONResponseParser: Sendable {
   /// Discarding everything from the first such token prevents the greedy JSON
   /// regex from capturing content across hallucinated turns.
   ///
-  /// - Important: the token is hardcoded, so this is a no-op for a non-ChatML
-  ///   model. Gemma 4's turn markers are CONTROL tokens (`<|turn>` / `<turn|>`,
-  ///   ids 105/106) that cannot reach this parser as text at all — `special:
-  ///   false` decoding drops 105, and 106 is EOG — and `<|im_end|>` is absent
-  ///   from its vocabulary, so this step is inert for the default shipped
-  ///   model. **Which text a Gemma hallucination would spell out instead is
-  ///   not established**; whatever it is, it would not be truncated here.
+  /// - Important: the token is hardcoded, so this step does nothing for a
+  ///   non-ChatML model. Gemma 4's markers are `<|turn>` / `<turn|>` and
+  ///   `<|im_end|>` is not in its vocabulary, so the literal can only arrive
+  ///   spelled out as ordinary text — possible, but not observed.
+  ///
+  ///   This type is backend-agnostic (`LLMCaller` parses llama.cpp, Ollama and
+  ///   Foundation Models output through one instance), so do not assume the
+  ///   llama.cpp guarantee here: under *that* backend a control marker cannot
+  ///   reach decoded text at all (see the canonical note on
+  ///   `LlamaCppService.stopSequence`), but a server-decoding backend offers no
+  ///   such guarantee — cf. `LLMCaller.logChatTemplateLeakage`, which exists
+  ///   because those backends can still emit template tokens.
+  ///
+  ///   **Which text a Gemma hallucination would spell out is not
+  ///   established**; whatever it is, it would not be truncated here.
   ///   Sourcing the marker per-model is tracked in #1422.
   private func truncateAtChatTemplateToken(_ text: String) -> String {
     guard let regex = Self.chatTemplateTokenRegex else { return text }

--- a/Pastura/Pastura/LLM/JSONResponseParser.swift
+++ b/Pastura/Pastura/LLM/JSONResponseParser.swift
@@ -56,8 +56,8 @@ nonisolated public struct JSONResponseParser: Sendable {
   ///
   /// Processing pipeline:
   /// 1. Strip thinking tags (`<think>...`, `<|channel>thought...`)
-  /// 2. Truncate at ChatML chat-template tokens (`<|im_end|>`; no-op for
-  ///    non-ChatML models such as Gemma 4 — see #1422)
+  /// 2. Truncate at ChatML chat-template tokens (`<|im_end|>`; for a
+  ///    non-ChatML model such as Gemma 4 this matches nothing it emits — #1422)
   /// 3. Extract content from markdown code blocks
   /// 4. Extract the first balanced `{...}` object (string-aware), discarding
   ///    any trailing content after its matching close brace
@@ -297,9 +297,9 @@ nonisolated public struct JSONResponseParser: Sendable {
   /// - Important: the token is hardcoded, so for a non-ChatML model this step
   ///   fires only on a spelled-out `<|im_end|>`. Gemma 4's markers are
   ///   `<|turn>` / `<turn|>` and `<|im_end|>` is not in its vocabulary, so
-  ///   spelled-out is the only form that could arrive — possible, but not seen.
-  ///   What this step does NOT do for Gemma is truncate a Gemma-shaped
-  ///   continuation.
+  ///   spelled-out is the only form that could arrive — and it is not the form
+  ///   a Gemma hallucination would reach for. What this step does NOT do for
+  ///   Gemma is truncate a Gemma-shaped continuation.
   ///
   ///   This type is backend-agnostic (`LLMCaller` parses llama.cpp, Ollama and
   ///   Foundation Models output through one instance), so do not assume the

--- a/Pastura/Pastura/LLM/JSONResponseParser.swift
+++ b/Pastura/Pastura/LLM/JSONResponseParser.swift
@@ -22,6 +22,9 @@ nonisolated public struct JSONResponseParser: Sendable {
   )
   // Chat template tokens — truncate everything from first occurrence onwards.
   // Catches hallucinated continuations where the model generates past its own turn.
+  // ChatML-only by construction: correct for Qwen 3, but Gemma 4's markers are
+  // `<|turn>` / `<turn|>`, so a Gemma hallucination is NOT truncated here.
+  // Making this per-model is #1422; the false-rationale half was #1417.
   private static let chatTemplateTokenRegex = try? NSRegularExpression(
     pattern: #"<\|im_end\|>.*"#,
     options: .dotMatchesLineSeparators
@@ -52,7 +55,8 @@ nonisolated public struct JSONResponseParser: Sendable {
   ///
   /// Processing pipeline:
   /// 1. Strip thinking tags (`<think>...`, `<|channel>thought...`)
-  /// 2. Truncate at chat template tokens (`<|im_end|>`)
+  /// 2. Truncate at ChatML chat-template tokens (`<|im_end|>`; no-op for
+  ///    non-ChatML models such as Gemma 4 — see #1422)
   /// 3. Extract content from markdown code blocks
   /// 4. Extract the first balanced `{...}` object (string-aware), discarding
   ///    any trailing content after its matching close brace
@@ -282,12 +286,17 @@ nonisolated public struct JSONResponseParser: Sendable {
     return result
   }
 
-  /// Truncate at the first chat template token (`<|im_end|>`).
+  /// Truncate at the first ChatML chat-template token (`<|im_end|>`).
   ///
-  /// When the model hallucinates past its own turn, it emits `<|im_end|>`
-  /// followed by fabricated user/assistant turns. Discarding everything from
-  /// the first such token prevents the greedy JSON regex from capturing
-  /// content across hallucinated turns.
+  /// When a **ChatML** model hallucinates past its own turn it emits
+  /// `<|im_end|>` as text, followed by fabricated user/assistant turns.
+  /// Discarding everything from the first such token prevents the greedy JSON
+  /// regex from capturing content across hallucinated turns.
+  ///
+  /// - Important: the token is hardcoded, so this is a no-op for a non-ChatML
+  ///   model. Gemma 4 — the default shipped model — writes `<|turn>` /
+  ///   `<turn|>` instead, and its hallucinated continuations are therefore not
+  ///   truncated. Sourcing the marker per-model is tracked in #1422.
   private func truncateAtChatTemplateToken(_ text: String) -> String {
     guard let regex = Self.chatTemplateTokenRegex else { return text }
     let range = NSRange(text.startIndex..., in: text)

--- a/Pastura/Pastura/LLM/JSONResponseParser.swift
+++ b/Pastura/Pastura/LLM/JSONResponseParser.swift
@@ -22,10 +22,7 @@ nonisolated public struct JSONResponseParser: Sendable {
   )
   // Chat template tokens — truncate everything from first occurrence onwards.
   // Catches hallucinated continuations where the model generates past its own turn.
-  // ChatML-only by construction: correct for Qwen 3; for Gemma 4, whose
-  // markers are `<|turn>` / `<turn|>`, it can only fire on a spelled-out
-  // `<|im_end|>` — see the doc on `truncateAtChatTemplateToken`.
-  // Making this per-model is #1422; the false-rationale half was #1417.
+  // ChatML-only — see the doc on `truncateAtChatTemplateToken`.
   private static let chatTemplateTokenRegex = try? NSRegularExpression(
     pattern: #"<\|im_end\|>.*"#,
     options: .dotMatchesLineSeparators
@@ -56,8 +53,8 @@ nonisolated public struct JSONResponseParser: Sendable {
   ///
   /// Processing pipeline:
   /// 1. Strip thinking tags (`<think>...`, `<|channel>thought...`)
-  /// 2. Truncate at ChatML chat-template tokens (`<|im_end|>`; for a
-  ///    non-ChatML model such as Gemma 4 this matches nothing it emits — #1422)
+  /// 2. Truncate at the ChatML chat-template token (`<|im_end|>`) — ChatML
+  ///    models only (#1422)
   /// 3. Extract content from markdown code blocks
   /// 4. Extract the first balanced `{...}` object (string-aware), discarding
   ///    any trailing content after its matching close brace
@@ -294,24 +291,14 @@ nonisolated public struct JSONResponseParser: Sendable {
   /// Discarding everything from the first such token prevents the greedy JSON
   /// regex from capturing content across hallucinated turns.
   ///
-  /// - Important: the token is hardcoded, so for a non-ChatML model this step
-  ///   fires only on a spelled-out `<|im_end|>`. Gemma 4's markers are
-  ///   `<|turn>` / `<turn|>` and `<|im_end|>` is not in its vocabulary, so
-  ///   spelled-out is the only form that could arrive — and it is not the form
-  ///   a Gemma hallucination would reach for. What this step does NOT do for
-  ///   Gemma is truncate a Gemma-shaped continuation.
-  ///
-  ///   This type is backend-agnostic (`LLMCaller` parses llama.cpp, Ollama and
-  ///   Foundation Models output through one instance), so do not assume the
-  ///   llama.cpp guarantee here: under *that* backend a control marker cannot
-  ///   reach decoded text at all (see the canonical note on
-  ///   `LlamaCppService.stopSequence`), but a server-decoding backend offers no
-  ///   such guarantee — cf. `LLMCaller.logChatTemplateLeakage`, which exists
-  ///   because those backends can still emit template tokens.
-  ///
-  ///   **Which text a Gemma hallucination would spell out is not
-  ///   established**; whatever it is, it would not be truncated here.
-  ///   Sourcing the marker per-model is tracked in #1422.
+  /// - Important: the token is hardcoded, so for a non-ChatML model this fires
+  ///   only on a spelled-out `<|im_end|>` — not the form a Gemma hallucination
+  ///   would take (Gemma 4's markers are `<|turn>` / `<turn|>`). This type is
+  ///   also backend-agnostic (`LLMCaller` parses llama.cpp, Ollama and
+  ///   Foundation Models through one instance), so do not import the llama.cpp
+  ///   control-token guarantee (`LlamaCppService.stopSequence`) here: a
+  ///   server-decoding backend offers none, which is why
+  ///   `LLMCaller.logChatTemplateLeakage` exists. Per-model sourcing is #1422.
   private func truncateAtChatTemplateToken(_ text: String) -> String {
     guard let regex = Self.chatTemplateTokenRegex else { return text }
     let range = NSRange(text.startIndex..., in: text)

--- a/Pastura/Pastura/LLM/LlamaCppService.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService.swift
@@ -95,39 +95,27 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
   static let contextSize: UInt32 = 8_192
   static let batchSize: Int = 512
   // Per-instance plaintext stop sentinel (was `static` pre-multi-model).
-  // CANONICAL NOTE for this mechanism — other sites point here rather than
-  // restate it, because the details below are easy to get subtly wrong.
+  // CANONICAL NOTE — other sites point here instead of restating this.
   //
-  // For BOTH descriptors shipped today, only a SPELLED-OUT sentinel can reach
-  // the two match sites (`runGeneration` / `runStreamGeneration` — cited by
-  // name, not line, because a comment's line numbers rot on the next edit
-  // above them). Two independent reasons, one per descriptor — do not state
-  // them as a single conjunction:
-  //   1. Qwen 3's `<|im_end|>` IS a control token (151645), so it never
-  //      decodes into the text: `decodePiece` passes `special: false`, so it
-  //      renders "". Separately, it is also EOG, so `nextContentTokenOrStop`
-  //      returns nil before the piece is appended. Those are two guards, not
-  //      one: Gemma's `<|turn>` (105) is CONTROL but NOT EOG, so a token in
-  //      that position would be covered by the first alone.
-  //   2. Gemma 4's descriptor holds `<|im_end|>`, which is absent from its
-  //      262k vocabulary entirely — no token form exists, so it could only
-  //      ever arrive spelled out.
-  // (A third shape — a sentinel present as a NORMAL-typed token — is not
-  // covered by either and is not measured here; publishers do ship turn
-  // markers mis-flagged that way, see `.claude/rules/engine.md` § "GGUF source
-  // *and variant* matter". The conclusion below survives it regardless.)
-  //
-  // Either way this is a hallucinated-turn guard (sibling of
+  // Matched against decoded text (`runGeneration` / `runStreamGeneration`), so
+  // it catches only a sentinel the model SPELLED OUT. Keyed by the sentinel's
+  // shape, not by which model ships it:
+  //   - a control token never decodes into the text at all (`decodePiece`
+  //     passes `special: false`, so it renders ""); if it is ALSO EOG,
+  //     `nextContentTokenOrStop` returns nil before the append — a second,
+  //     independent guard, not part of the first.
+  //   - a sentinel absent from the vocabulary has no token form to arrive as.
+  // So this is a hallucinated-turn guard (sibling of
   // `JSONResponseParser.truncateAtChatTemplateToken`), NOT what terminates a
-  // normal turn — that is EOG, for every model. It is String-based rather than
-  // token-ID precisely because the spelled-out form has no single token id.
+  // normal turn — that is EOG, for every model. String-based rather than
+  // token-ID because what it must catch is text, which has no single token id.
   //
-  // So for Gemma this fires only if the model spells out a ChatML marker it
-  // was never trained on: possible (every character is printable ASCII), and
-  // never seen to fire in the integration assertions that would catch it, but
-  // not the marker a Gemma hallucination would reach for. Left in place
-  // deliberately rather than guessed at (#1417). Read from the descriptor at
-  // construction time; future models may differ.
+  // Shipped values: Qwen 3's `<|im_end|>` is 151645 (CONTROL, and its EOG).
+  // Gemma 4's descriptor holds that same ChatML string, which is absent from
+  // its 262k vocabulary — its own markers are `<|turn>` (105, CONTROL, NOT
+  // EOG) and `<turn|>` (106, EOG). Left as-is rather than replaced by a guess
+  // at what a Gemma hallucination would spell (#1417; behaviour half #1422).
+  // Read from the descriptor at construction time; future models may differ.
   // TODO: Consider adding `<|im_start|>` if hallucinated turn starts are observed (#65)
   let stopSequence: String
 

--- a/Pastura/Pastura/LLM/LlamaCppService.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService.swift
@@ -104,9 +104,12 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
   // normal turn — that is EOG, for every model.
   // Qwen 3 is ChatML, where the plaintext form is `<|im_end|>`. Gemma 4 is
   // not: its turn markers are `<|turn>` / `<turn|>` (ids 105/106, CONTROL) and
-  // `<|im_end|>` is absent from its 262k vocabulary, so the descriptor value is
-  // inert for Gemma — deliberately left in place (#1417). Read from the
-  // descriptor at construction time; future models may differ.
+  // `<|im_end|>` is absent from its 262k vocabulary. So for Gemma this value
+  // fires only if the model spells out a ChatML marker it was never trained
+  // on — not impossible (any printable ASCII is spellable), but it is not the
+  // marker a Gemma hallucination would reach for. Left in place deliberately
+  // rather than guessed at (#1417). Read from the descriptor at construction
+  // time; future models may differ.
   // TODO: Consider adding `<|im_start|>` if hallucinated turn starts are observed (#65)
   let stopSequence: String
 
@@ -187,9 +190,11 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
   /// `.systemPromptSuffix`). This avoids silently running Qwen with Gemma's
   /// defaults if a call-site forgets to thread the descriptor through.
   /// Test code can construct via a file-scope helper (see
-  /// `LlamaCppServiceTests`) to centralize the test values. Those pin the
-  /// shipped Gemma descriptor, whose `stopSequence` is a ChatML string that
-  /// Gemma never emits — see the `stopSequence` note above (#1417).
+  /// `LlamaCppServiceTests`) to centralize the test values. Those are not a
+  /// pin of the shipped descriptor — the path and identifier are synthetic;
+  /// only the `stopSequence` literal happens to reuse the shipped ChatML one,
+  /// which is inert for Gemma in practice (see the `stopSequence` note above,
+  /// #1417).
   ///
   /// - Parameters:
   ///   - modelPath: Absolute path to the GGUF model file on disk (provided by
@@ -563,9 +568,11 @@ extension LlamaCppService {
 
     // Auto-regressive generation loop with string-based stop detection.
     // Tokens are decoded incrementally so a spelled-out stop sentinel is
-    // detected even when BPE splits it across several subword tokens — which
-    // it always does, since the sentinel is by construction not a token of
-    // this model's vocabulary when it appears as text (see `stopSequence`).
+    // detected even when BPE splits it across several subword tokens. It
+    // necessarily is split whenever the sentinel is a control token of this
+    // model — such a token is not reachable as CONTENT (it decodes to "" and
+    // EOG returns first), so the only form that can arrive here is the
+    // spelled-out one (see `stopSequence`).
     var outputText = ""
     var generatedTokens = 0
 

--- a/Pastura/Pastura/LLM/LlamaCppService.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService.swift
@@ -98,29 +98,36 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
   // CANONICAL NOTE for this mechanism — other sites point here rather than
   // restate it, because the details below are easy to get subtly wrong.
   //
-  // String-based, not token-ID, because the two paths it feeds (`:604`
-  // non-streaming, `:818` streaming) match against DECODED TEXT, and under
-  // this backend only a spelled-out sentinel can appear there. Two separate
-  // reasons, per case — do not state them as one conjunction:
-  //   1. A sentinel that IS a control token of the model never decodes into
-  //      the text: `decodePiece` passes `special: false`, so it renders "".
-  //      Independently, if that token is also EOG, `nextContentTokenOrStop`
-  //      returns nil before the piece is appended. Gemma's `<|turn>` (105) is
-  //      CONTROL but NOT EOG, so for it only the first reason applies.
-  //   2. A sentinel that is not in the vocabulary at all has no token form to
-  //      begin with, so it can only ever arrive spelled out.
+  // For BOTH descriptors shipped today, only a SPELLED-OUT sentinel can reach
+  // the two match sites (`runGeneration` / `runStreamGeneration` — cited by
+  // name, not line, because a comment's line numbers rot on the next edit
+  // above them). Two independent reasons, one per descriptor — do not state
+  // them as a single conjunction:
+  //   1. Qwen 3's `<|im_end|>` IS a control token (151645), so it never
+  //      decodes into the text: `decodePiece` passes `special: false`, so it
+  //      renders "". Separately, it is also EOG, so `nextContentTokenOrStop`
+  //      returns nil before the piece is appended. Those are two guards, not
+  //      one: Gemma's `<|turn>` (105) is CONTROL but NOT EOG, so a token in
+  //      that position would be covered by the first alone.
+  //   2. Gemma 4's descriptor holds `<|im_end|>`, which is absent from its
+  //      262k vocabulary entirely — no token form exists, so it could only
+  //      ever arrive spelled out.
+  // (A third shape — a sentinel present as a NORMAL-typed token — is not
+  // covered by either and is not measured here; publishers do ship turn
+  // markers mis-flagged that way, see `.claude/rules/engine.md` § "GGUF source
+  // *and variant* matter". The conclusion below survives it regardless.)
+  //
   // Either way this is a hallucinated-turn guard (sibling of
   // `JSONResponseParser.truncateAtChatTemplateToken`), NOT what terminates a
-  // normal turn — that is EOG, for every model.
+  // normal turn — that is EOG, for every model. It is String-based rather than
+  // token-ID precisely because the spelled-out form has no single token id.
   //
-  // Qwen 3 is ChatML, where the plaintext form is `<|im_end|>` (151645, also
-  // its EOG). Gemma 4 is not: its markers are `<|turn>` / `<turn|>` (105/106,
-  // CONTROL) and `<|im_end|>` is absent from its 262k vocabulary — case 2. So
-  // for Gemma this fires only if the model spells out a ChatML marker it was
-  // never trained on: possible (every character is printable ASCII), not
-  // observed, and not the marker a Gemma hallucination would reach for. Left
-  // in place deliberately rather than guessed at (#1417). Read from the
-  // descriptor at construction time; future models may differ.
+  // So for Gemma this fires only if the model spells out a ChatML marker it
+  // was never trained on: possible (every character is printable ASCII), and
+  // never seen to fire in the integration assertions that would catch it, but
+  // not the marker a Gemma hallucination would reach for. Left in place
+  // deliberately rather than guessed at (#1417). Read from the descriptor at
+  // construction time; future models may differ.
   // TODO: Consider adding `<|im_start|>` if hallucinated turn starts are observed (#65)
   let stopSequence: String
 

--- a/Pastura/Pastura/LLM/LlamaCppService.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService.swift
@@ -98,24 +98,21 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
   // CANONICAL NOTE — other sites point here instead of restating this.
   //
   // Matched against decoded text (`runGeneration` / `runStreamGeneration`), so
-  // it catches only a sentinel the model SPELLED OUT. Keyed by the sentinel's
-  // shape, not by which model ships it:
-  //   - a control token never decodes into the text at all (`decodePiece`
-  //     passes `special: false`, so it renders ""); if it is ALSO EOG,
-  //     `nextContentTokenOrStop` returns nil before the append — a second,
-  //     independent guard, not part of the first.
-  //   - a sentinel absent from the vocabulary has no token form to arrive as.
-  // So this is a hallucinated-turn guard (sibling of
+  // it catches only a sentinel the model SPELLED OUT: a control token never
+  // decodes into the text at all (`decodePiece` passes `special: false`, so it
+  // renders ""; if it is ALSO EOG, `nextContentTokenOrStop` stops first — a
+  // second, independent guard), and a sentinel absent from the vocabulary has
+  // no token form to arrive as. So this is a hallucinated-turn guard (sibling of
   // `JSONResponseParser.truncateAtChatTemplateToken`), NOT what terminates a
   // normal turn — that is EOG, for every model. String-based rather than
   // token-ID because what it must catch is text, which has no single token id.
   //
   // Shipped values: Qwen 3's `<|im_end|>` is 151645 (CONTROL, and its EOG).
-  // Gemma 4's descriptor holds that same ChatML string, which is absent from
-  // its 262k vocabulary — its own markers are `<|turn>` (105, CONTROL, NOT
-  // EOG) and `<turn|>` (106, EOG). Left as-is rather than replaced by a guess
-  // at what a Gemma hallucination would spell (#1417; behaviour half #1422).
-  // Read from the descriptor at construction time; future models may differ.
+  // Gemma 4's descriptor holds that same ChatML string, absent from its 262k
+  // vocabulary — its own markers are `<|turn>` (105, CONTROL, NOT EOG) and
+  // `<turn|>` (106, EOG). Left as-is rather than replaced by a guess at what a
+  // Gemma hallucination would spell (#1417; behaviour half #1422). Read from
+  // the descriptor at construction time; future models may differ.
   // TODO: Consider adding `<|im_start|>` if hallucinated turn starts are observed (#65)
   let stopSequence: String
 
@@ -196,17 +193,15 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
   /// `.systemPromptSuffix`). This avoids silently running Qwen with Gemma's
   /// defaults if a call-site forgets to thread the descriptor through.
   /// Test code can construct via a file-scope helper (see
-  /// `LlamaCppServiceTests`) to centralize the test values. Those are not a
-  /// pin of the shipped descriptor — the path and identifier are synthetic;
-  /// the `stopSequence` literal reuses the shipped ChatML one (see the
-  /// `stopSequence` note above, #1417).
+  /// `LlamaCppServiceTests`) to centralize the test values. Not a pin of the
+  /// shipped descriptor — the path and identifier are synthetic, while the
+  /// `stopSequence` literal reuses the shipped ChatML one.
   ///
   /// - Parameters:
   ///   - modelPath: Absolute path to the GGUF model file on disk (provided by
   ///     `ModelManager.modelFileURL(for:).path` at the call-site).
-  ///   - stopSequence: Per-model plaintext stop sentinel — matched only against
-  ///     text the model spelled out, never against a control token
-  ///     (e.g., `<|im_end|>` for ChatML models).
+  ///   - stopSequence: Per-model plaintext stop sentinel, matched only against
+  ///     text the model spelled out (e.g., `<|im_end|>` for ChatML models).
   ///   - modelIdentifier: Human-readable label for exports / replay metadata.
   ///   - systemPromptSuffix: Optional suffix appended to the system prompt
   ///     at `applyChatTemplate` (e.g., `/no_think` for Qwen 3).
@@ -573,8 +568,8 @@ extension LlamaCppService {
 
     // Auto-regressive generation loop with string-based stop detection.
     // Tokens are decoded incrementally so a spelled-out stop sentinel is
-    // detected even when BPE splits it across subword tokens. Only the
-    // spelled-out form can arrive here at all — see `stopSequence` for why.
+    // detected even when BPE splits it across subword tokens (see
+    // `stopSequence` for why only the spelled-out form can arrive here).
     var outputText = ""
     var generatedTokens = 0
 

--- a/Pastura/Pastura/LLM/LlamaCppService.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService.swift
@@ -95,21 +95,32 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
   static let contextSize: UInt32 = 8_192
   static let batchSize: Int = 512
   // Per-instance plaintext stop sentinel (was `static` pre-multi-model).
-  // String-based, not token-ID, because the paths it feeds can only match a
-  // sentinel the model spelled out as ORDINARY TEXT: a genuine control token
-  // never reaches them — `decodePiece` passes `special: false` so it decodes
-  // to "", and `nextContentTokenOrStop` returns nil on EOG before the piece is
-  // appended. So this is a hallucinated-turn guard (sibling of
+  // CANONICAL NOTE for this mechanism — other sites point here rather than
+  // restate it, because the details below are easy to get subtly wrong.
+  //
+  // String-based, not token-ID, because the two paths it feeds (`:604`
+  // non-streaming, `:818` streaming) match against DECODED TEXT, and under
+  // this backend only a spelled-out sentinel can appear there. Two separate
+  // reasons, per case — do not state them as one conjunction:
+  //   1. A sentinel that IS a control token of the model never decodes into
+  //      the text: `decodePiece` passes `special: false`, so it renders "".
+  //      Independently, if that token is also EOG, `nextContentTokenOrStop`
+  //      returns nil before the piece is appended. Gemma's `<|turn>` (105) is
+  //      CONTROL but NOT EOG, so for it only the first reason applies.
+  //   2. A sentinel that is not in the vocabulary at all has no token form to
+  //      begin with, so it can only ever arrive spelled out.
+  // Either way this is a hallucinated-turn guard (sibling of
   // `JSONResponseParser.truncateAtChatTemplateToken`), NOT what terminates a
   // normal turn — that is EOG, for every model.
-  // Qwen 3 is ChatML, where the plaintext form is `<|im_end|>`. Gemma 4 is
-  // not: its turn markers are `<|turn>` / `<turn|>` (ids 105/106, CONTROL) and
-  // `<|im_end|>` is absent from its 262k vocabulary. So for Gemma this value
-  // fires only if the model spells out a ChatML marker it was never trained
-  // on — not impossible (any printable ASCII is spellable), but it is not the
-  // marker a Gemma hallucination would reach for. Left in place deliberately
-  // rather than guessed at (#1417). Read from the descriptor at construction
-  // time; future models may differ.
+  //
+  // Qwen 3 is ChatML, where the plaintext form is `<|im_end|>` (151645, also
+  // its EOG). Gemma 4 is not: its markers are `<|turn>` / `<turn|>` (105/106,
+  // CONTROL) and `<|im_end|>` is absent from its 262k vocabulary — case 2. So
+  // for Gemma this fires only if the model spells out a ChatML marker it was
+  // never trained on: possible (every character is printable ASCII), not
+  // observed, and not the marker a Gemma hallucination would reach for. Left
+  // in place deliberately rather than guessed at (#1417). Read from the
+  // descriptor at construction time; future models may differ.
   // TODO: Consider adding `<|im_start|>` if hallucinated turn starts are observed (#65)
   let stopSequence: String
 
@@ -192,9 +203,8 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
   /// Test code can construct via a file-scope helper (see
   /// `LlamaCppServiceTests`) to centralize the test values. Those are not a
   /// pin of the shipped descriptor — the path and identifier are synthetic;
-  /// only the `stopSequence` literal happens to reuse the shipped ChatML one,
-  /// which is inert for Gemma in practice (see the `stopSequence` note above,
-  /// #1417).
+  /// the `stopSequence` literal reuses the shipped ChatML one (see the
+  /// `stopSequence` note above, #1417).
   ///
   /// - Parameters:
   ///   - modelPath: Absolute path to the GGUF model file on disk (provided by
@@ -568,11 +578,8 @@ extension LlamaCppService {
 
     // Auto-regressive generation loop with string-based stop detection.
     // Tokens are decoded incrementally so a spelled-out stop sentinel is
-    // detected even when BPE splits it across several subword tokens. It
-    // necessarily is split whenever the sentinel is a control token of this
-    // model — such a token is not reachable as CONTENT (it decodes to "" and
-    // EOG returns first), so the only form that can arrive here is the
-    // spelled-out one (see `stopSequence`).
+    // detected even when BPE splits it across subword tokens. Only the
+    // spelled-out form can arrive here at all — see `stopSequence` for why.
     var outputText = ""
     var generatedTokens = 0
 

--- a/Pastura/Pastura/LLM/LlamaCppService.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService.swift
@@ -94,11 +94,19 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
   static let repeatPenalty: Float = 1.1
   static let contextSize: UInt32 = 8_192
   static let batchSize: Int = 512
-  // Per-instance stop sequence (was `static` pre-multi-model). String-based,
-  // not token-ID, because Gemma 4 E2B tokenizes `<|im_end|>` into 6 subword
-  // tokens — single-token ID matching is impossible for this model. Gemma
-  // and Qwen 3 both use `<|im_end|>`; future models may differ (read from
-  // descriptor at construction time).
+  // Per-instance plaintext stop sentinel (was `static` pre-multi-model).
+  // String-based, not token-ID, because the paths it feeds can only match a
+  // sentinel the model spelled out as ORDINARY TEXT: a genuine control token
+  // never reaches them — `decodePiece` passes `special: false` so it decodes
+  // to "", and `nextContentTokenOrStop` returns nil on EOG before the piece is
+  // appended. So this is a hallucinated-turn guard (sibling of
+  // `JSONResponseParser.truncateAtChatTemplateToken`), NOT what terminates a
+  // normal turn — that is EOG, for every model.
+  // Qwen 3 is ChatML, where the plaintext form is `<|im_end|>`. Gemma 4 is
+  // not: its turn markers are `<|turn>` / `<turn|>` (ids 105/106, CONTROL) and
+  // `<|im_end|>` is absent from its 262k vocabulary, so the descriptor value is
+  // inert for Gemma — deliberately left in place (#1417). Read from the
+  // descriptor at construction time; future models may differ.
   // TODO: Consider adding `<|im_start|>` if hallucinated turn starts are observed (#65)
   let stopSequence: String
 
@@ -179,12 +187,16 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
   /// `.systemPromptSuffix`). This avoids silently running Qwen with Gemma's
   /// defaults if a call-site forgets to thread the descriptor through.
   /// Test code can construct via a file-scope helper (see
-  /// `LlamaCppServiceTests`) to centralize the Gemma-shaped test values.
+  /// `LlamaCppServiceTests`) to centralize the test values. Those pin the
+  /// shipped Gemma descriptor, whose `stopSequence` is a ChatML string that
+  /// Gemma never emits — see the `stopSequence` note above (#1417).
   ///
   /// - Parameters:
   ///   - modelPath: Absolute path to the GGUF model file on disk (provided by
   ///     `ModelManager.modelFileURL(for:).path` at the call-site).
-  ///   - stopSequence: Per-model stop sentinel (e.g., `<|im_end|>`).
+  ///   - stopSequence: Per-model plaintext stop sentinel — matched only against
+  ///     text the model spelled out, never against a control token
+  ///     (e.g., `<|im_end|>` for ChatML models).
   ///   - modelIdentifier: Human-readable label for exports / replay metadata.
   ///   - systemPromptSuffix: Optional suffix appended to the system prompt
   ///     at `applyChatTemplate` (e.g., `/no_think` for Qwen 3).
@@ -550,8 +562,10 @@ extension LlamaCppService {
     defer { candidateBuffer?.deallocate() }
 
     // Auto-regressive generation loop with string-based stop detection.
-    // Tokens are decoded incrementally so we can detect <|im_end|> even when
-    // the model's tokenizer splits it across multiple subword tokens.
+    // Tokens are decoded incrementally so a spelled-out stop sentinel is
+    // detected even when BPE splits it across several subword tokens — which
+    // it always does, since the sentinel is by construction not a token of
+    // this model's vocabulary when it appears as text (see `stopSequence`).
     var outputText = ""
     var generatedTokens = 0
 
@@ -677,8 +691,8 @@ extension LlamaCppService {
   /// Replaces the default protocol wrap (which yields a single chunk at
   /// completion) with real incremental output. Each decoded token piece
   /// either emits as a new delta or is held back briefly while we wait
-  /// to see if it completes the stop sequence `<|im_end|>` or a
-  /// multi-byte UTF-8 character.
+  /// to see if it completes the plaintext stop sentinel (``stopSequence``)
+  /// or a multi-byte UTF-8 character.
   ///
   /// Contract preserved from ``generate(system:user:)``:
   /// - Sequential access (ADR-002 §6) — concurrent callers serialize via
@@ -686,7 +700,7 @@ extension LlamaCppService {
   ///   not via a runtime trap.
   /// - Cooperative ``SuspendController`` check at each iteration boundary.
   /// - Task cancellation at iteration boundary.
-  /// - Stop-sequence `<|im_end|>` never appears in emitted deltas.
+  /// - The plaintext stop sentinel never appears in emitted deltas.
   /// - Final chunk carries ``LLMStreamChunk/completionTokens`` — llama.cpp
   ///   is one of the few backends that can report this cheaply.
   ///
@@ -909,8 +923,8 @@ extension LlamaCppService {
 
   /// Length of the longest suffix of `decoded` that is also a strict
   /// prefix of ``stopSequence``. Those characters are held back from
-  /// emission until the next token disambiguates whether we are
-  /// actually starting `<|im_end|>`.
+  /// emission until the next token disambiguates whether the model is
+  /// actually spelling out the sentinel.
   ///
   /// Returns 0 when the tail shares nothing with the stop sequence — the
   /// common case, producing immediate emission and zero UX lag. Capped

--- a/Pastura/Pastura/Models/ModelDescriptor.swift
+++ b/Pastura/Pastura/Models/ModelDescriptor.swift
@@ -52,11 +52,9 @@ nonisolated public struct ModelDescriptor: Sendable, Hashable {
   /// Contract for consumers: match this against **decoded text only**. It is
   /// not the tokenizer's end-of-turn token, and a backend must not treat it as
   /// the thing that terminates a normal turn. `"<|im_end|>"` for ChatML models
-  /// such as Qwen 3; for Gemma 4 that string is absent from the vocabulary and
-  /// its own markers are `<|turn>` / `<turn|>`, so the value carries no Gemma
-  /// marker (see #1417). Why a control token can never reach the match is
-  /// backend-specific — for llama.cpp it is documented at
-  /// `LlamaCppService.stopSequence`.
+  /// such as Qwen 3; Gemma 4 carries that same string although its own markers
+  /// are `<|turn>` / `<turn|>` (#1417). Mechanism, and why a control token can
+  /// never reach the match under llama.cpp: `LlamaCppService.stopSequence`.
   public let stopSequence: String
 
   /// Minimum physical RAM required to load and run the model (bytes).

--- a/Pastura/Pastura/Models/ModelDescriptor.swift
+++ b/Pastura/Pastura/Models/ModelDescriptor.swift
@@ -46,8 +46,14 @@ nonisolated public struct ModelDescriptor: Sendable, Hashable {
   /// Lowercase hex SHA-256 digest for integrity verification after download.
   public let sha256: String
 
-  /// Generation stop sentinel appended by the model's tokenizer
-  /// (e.g., `"<|im_end|>"` for Gemma/Llama chat format).
+  /// Plaintext stop sentinel — the literal text that ends generation early when
+  /// the model writes it out as ordinary text (a hallucinated turn boundary).
+  ///
+  /// NOT the tokenizer's end-of-turn token: a genuine control token decodes to
+  /// `""` and the turn terminates on EOG before this is ever consulted. So the
+  /// value only ever matters for models whose chat markers a hallucination is
+  /// likely to spell out. `"<|im_end|>"` for ChatML models such as Qwen 3;
+  /// inert for Gemma 4, whose markers are `<|turn>` / `<turn|>` (see #1417).
   public let stopSequence: String
 
   /// Minimum physical RAM required to load and run the model (bytes).

--- a/Pastura/Pastura/Models/ModelDescriptor.swift
+++ b/Pastura/Pastura/Models/ModelDescriptor.swift
@@ -49,11 +49,14 @@ nonisolated public struct ModelDescriptor: Sendable, Hashable {
   /// Plaintext stop sentinel — the literal text that ends generation early when
   /// the model writes it out as ordinary text (a hallucinated turn boundary).
   ///
-  /// NOT the tokenizer's end-of-turn token: a genuine control token decodes to
-  /// `""` and the turn terminates on EOG before this is ever consulted. So the
-  /// value only ever matters for models whose chat markers a hallucination is
-  /// likely to spell out. `"<|im_end|>"` for ChatML models such as Qwen 3;
-  /// inert for Gemma 4, whose markers are `<|turn>` / `<turn|>` (see #1417).
+  /// Contract for consumers: match this against **decoded text only**. It is
+  /// not the tokenizer's end-of-turn token, and a backend must not treat it as
+  /// the thing that terminates a normal turn. `"<|im_end|>"` for ChatML models
+  /// such as Qwen 3; for Gemma 4 that string is absent from the vocabulary and
+  /// its own markers are `<|turn>` / `<turn|>`, so the value carries no Gemma
+  /// marker (see #1417). Why a control token can never reach the match is
+  /// backend-specific — for llama.cpp it is documented at
+  /// `LlamaCppService.stopSequence`.
   public let stopSequence: String
 
   /// Minimum physical RAM required to load and run the model (bytes).

--- a/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests+Streaming.swift
+++ b/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests+Streaming.swift
@@ -9,7 +9,8 @@ import Testing
 /// Declared as an `extension` of the suite struct rather than a new `@Suite`
 /// on purpose — a second suite would run in parallel with the original and
 /// race it for the single shared GGUF / Metal device. See
-/// `.claude/rules/testing.md` § "Splitting a Suite Across Files".
+/// `.claude/rules/testing.md` § "Splitting a Suite Across Files";
+/// `LlamaCppIntegrationTests+Qwen.swift` is the established precedent.
 /// Suite traits (`.serialized`, `.enabled(if:)`) are inherited from the
 /// declaration in `LlamaCppIntegrationTests.swift`.
 extension LlamaCppIntegrationTests {
@@ -50,11 +51,12 @@ extension LlamaCppIntegrationTests {
       "Final chunk should carry completionTokens"
     )
 
-    // Holdback check for the plaintext stop sentinel. Vacuous against Gemma 4
-    // (this suite's model), whose vocabulary has no `<|im_end|>` — nothing here
-    // constructs a delta that could carry it. Kept because the same suite shape
-    // is reused when onboarding a ChatML model, where the sentinel is a form a
-    // hallucination really does spell out. See #1417.
+    // Holdback check for the plaintext stop sentinel — same single route as
+    // Test 4's leak check: only a spelled-out `<|im_end|>` can reach a delta,
+    // because a control token decodes to "" and EOG returns before append.
+    // Gemma 4 (this suite's model) was never trained on ChatML so that route is
+    // unlikely for it, but this is the guard if it fires. A Gemma-shaped
+    // hallucination (`<|turn>` / `<turn|>`) is NOT covered — see #1417 / #1422.
     for delta in deltas {
       #expect(
         !delta.contains("<|im_end|>"),

--- a/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests+Streaming.swift
+++ b/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests+Streaming.swift
@@ -52,9 +52,9 @@ extension LlamaCppIntegrationTests {
     )
 
     // Holdback check for the plaintext stop sentinel — same single route as
-    // Test 4's leak check: only a spelled-out `<|im_end|>` can reach a delta,
-    // because a control token decodes to "" and EOG returns before append.
-    // Gemma 4 (this suite's model) was never trained on ChatML so that route is
+    // Test 4's leak check: only a spelled-out `<|im_end|>` can reach a delta
+    // (why: the canonical note on `LlamaCppService.stopSequence`). Gemma 4
+    // (this suite's model) was never trained on ChatML so that route is
     // unlikely for it, but this is the guard if it fires. A Gemma-shaped
     // hallucination (`<|turn>` / `<turn|>`) is NOT covered — see #1417 / #1422.
     for delta in deltas {

--- a/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests+Streaming.swift
+++ b/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests+Streaming.swift
@@ -51,12 +51,9 @@ extension LlamaCppIntegrationTests {
       "Final chunk should carry completionTokens"
     )
 
-    // Holdback check — same observation shape as Test 4's leak check: when the
-    // stop path fires, only the text before the sentinel is emitted, so this
-    // passes. It fails only if a spelled-out `<|im_end|>` slips into a delta
-    // uncaught. (Why only a spelled-out one can appear: the canonical note on
-    // `LlamaCppService.stopSequence`.) A Gemma-shaped hallucination
-    // (`<|turn>` / `<turn|>`) is NOT covered — see #1417 / #1422.
+    // Holdback check — same observation shape as Test 4's leak check: it fails
+    // only if a spelled-out `<|im_end|>` slips into a delta uncaught. A
+    // Gemma-shaped hallucination (`<|turn>` / `<turn|>`) is NOT covered (#1422).
     for delta in deltas {
       #expect(
         !delta.contains("<|im_end|>"),

--- a/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests+Streaming.swift
+++ b/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests+Streaming.swift
@@ -51,12 +51,12 @@ extension LlamaCppIntegrationTests {
       "Final chunk should carry completionTokens"
     )
 
-    // Holdback check for the plaintext stop sentinel — same single route as
-    // Test 4's leak check: only a spelled-out `<|im_end|>` can reach a delta
-    // (why: the canonical note on `LlamaCppService.stopSequence`). Gemma 4
-    // (this suite's model) was never trained on ChatML so that route is
-    // unlikely for it, but this is the guard if it fires. A Gemma-shaped
-    // hallucination (`<|turn>` / `<turn|>`) is NOT covered — see #1417 / #1422.
+    // Holdback check — same observation shape as Test 4's leak check: when the
+    // stop path fires, only the text before the sentinel is emitted, so this
+    // passes. It fails only if a spelled-out `<|im_end|>` slips into a delta
+    // uncaught. (Why only a spelled-out one can appear: the canonical note on
+    // `LlamaCppService.stopSequence`.) A Gemma-shaped hallucination
+    // (`<|turn>` / `<turn|>`) is NOT covered — see #1417 / #1422.
     for delta in deltas {
       #expect(
         !delta.contains("<|im_end|>"),

--- a/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests+Streaming.swift
+++ b/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests+Streaming.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+/// Streaming half of ``LlamaCppIntegrationTests``, split out to keep the
+/// original file under swiftlint's 400-line `file_length` cap.
+///
+/// Declared as an `extension` of the suite struct rather than a new `@Suite`
+/// on purpose — a second suite would run in parallel with the original and
+/// race it for the single shared GGUF / Metal device. See
+/// `.claude/rules/testing.md` § "Splitting a Suite Across Files".
+/// Suite traits (`.serialized`, `.enabled(if:)`) are inherited from the
+/// declaration in `LlamaCppIntegrationTests.swift`.
+extension LlamaCppIntegrationTests {
+
+  // MARK: - Test 5a: Streaming yields incremental deltas, isFinal once
+
+  @Test(.timeLimit(.minutes(3)))
+  func streamingYieldsIncrementalDeltas() async throws {
+    let service = makeService()
+    try await service.loadModel()
+    defer { Task { try? await service.unloadModel() } }
+
+    var deltas: [String] = []
+    var finalChunkCount = 0
+    var lastCompletionTokens: Int?
+
+    for try await chunk in service.generateStream(
+      system: """
+        You are a character in a game. Respond ONLY with a JSON object.
+        Required format: {"statement": "your statement here"}
+        """,
+      user: "Introduce yourself briefly."
+    ) {
+      if chunk.isFinal {
+        finalChunkCount += 1
+        lastCompletionTokens = chunk.completionTokens
+      } else {
+        deltas.append(chunk.delta)
+      }
+    }
+
+    // At least two non-final chunks means real streaming happened (rather
+    // than a single-shot fallback).
+    #expect(deltas.count > 1, "Expected multiple chunks, got \(deltas.count)")
+    #expect(finalChunkCount == 1, "Expected exactly one final chunk")
+    #expect(
+      (lastCompletionTokens ?? 0) > 0,
+      "Final chunk should carry completionTokens"
+    )
+
+    // Holdback check for the plaintext stop sentinel. Vacuous against Gemma 4
+    // (this suite's model), whose vocabulary has no `<|im_end|>` — nothing here
+    // constructs a delta that could carry it. Kept because the same suite shape
+    // is reused when onboarding a ChatML model, where the sentinel is a form a
+    // hallucination really does spell out. See #1417.
+    for delta in deltas {
+      #expect(
+        !delta.contains("<|im_end|>"),
+        "Delta leaked <|im_end|>: \(delta)"
+      )
+    }
+
+    // Concatenation of all deltas produces the same final text the
+    // non-streaming `generate` path would return.
+    let streamedText = deltas.joined()
+    let parsed = try JSONResponseParser().parse(streamedText)
+    let statement = parsed.statement ?? ""
+    #expect(!statement.isEmpty, "Streamed text failed to parse. Raw: \(streamedText)")
+  }
+
+  // MARK: - Test 5b: Stream and non-stream produce equivalent text
+
+  @Test(.timeLimit(.minutes(5)))
+  func streamAndGenerateAgreeOnFinalText() async throws {
+    let service = makeService()
+    try await service.loadModel()
+    defer { Task { try? await service.unloadModel() } }
+
+    let system = "Reply with JSON only: {\"echo\": \"ack\"}"
+    let user = "Echo."
+
+    let nonStreamed = try await service.generate(system: system, user: user)
+
+    var streamed = ""
+    for try await chunk in service.generateStream(system: system, user: user)
+    where !chunk.isFinal {
+      streamed += chunk.delta
+    }
+
+    // Don't expect byte-for-byte equality — sampling is stochastic across
+    // runs — but both paths should parse as JSON and have an echo field.
+    let nonStreamedParsed = try JSONResponseParser().parse(nonStreamed)
+    let streamedParsed = try JSONResponseParser().parse(streamed)
+    #expect(nonStreamedParsed.fields["echo"] != nil)
+    #expect(streamedParsed.fields["echo"] != nil)
+  }
+}

--- a/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests.swift
+++ b/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests.swift
@@ -163,17 +163,18 @@ struct LlamaCppIntegrationTests {
       user: "Introduce yourself briefly."
     )
 
-    // ChatML-shaped leak check — it covers ONE route: the model spelling
-    // `<|im_end|>` out as ordinary text. That is the only route there is; why,
-    // is the canonical note on `LlamaCppService.stopSequence`. This suite runs
-    // against Gemma 4 (see `makeService`), which was never trained on ChatML,
-    // so the route is unlikely for it — but not impossible, and this assertion
-    // is the guard if it happens. What it does NOT cover is a Gemma-shaped
-    // hallucination (`<|turn>` / `<turn|>`), which nothing here truncates —
-    // that gap is #1422. Gemma's normal termination is EOG (`<turn|>`, id 106);
-    // the length bound below is only a runaway proxy for it — it would notice
-    // termination failing, but cannot tell EOG from the #907 caught-grammar
-    // stop, nor either from a naturally short answer.
+    // Leak check. Note what it observes: when the stop path FIRES, the sentinel
+    // is truncated before `generate` returns, so this passes. It therefore
+    // fails only on the opposite event — a spelled-out `<|im_end|>` that the
+    // stop path did NOT catch. (Why only a spelled-out one can appear at all:
+    // the canonical note on `LlamaCppService.stopSequence`.)
+    //
+    // Scope: ChatML-shaped only. A Gemma-shaped hallucination (`<|turn>` /
+    // `<turn|>`) is neither matched nor truncated anywhere — that gap is #1422.
+    // Gemma's normal termination is EOG (`<turn|>`, id 106); the length bound
+    // below is only a runaway proxy for it — it would notice termination
+    // failing, but cannot tell EOG from the #907 caught-grammar stop, nor
+    // either from a naturally short answer.
     #expect(
       !result.contains("<|im_end|>"),
       "Raw output contains <|im_end|> — stop token not working. Output: \(result)"

--- a/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests.swift
+++ b/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests.swift
@@ -65,8 +65,8 @@ struct LlamaCppIntegrationTests {
   func makeService() -> LlamaCppService {
     LlamaCppService(
       modelPath: LlamaCppConfig.modelPath,
-      // Mirrors `ModelRegistry.gemma4E2B` — inert for Gemma 4, which has no
-      // `<|im_end|>` in its vocabulary and terminates on EOG instead (#1417).
+      // Mirrors `ModelRegistry.gemma4E2B` — carries no Gemma marker;
+      // `<|im_end|>` is absent from Gemma's vocabulary (#1417).
       stopSequence: "<|im_end|>",
       modelIdentifier: "Gemma 4 E2B (Q4_K_M)",
       systemPromptSuffix: nil
@@ -164,14 +164,14 @@ struct LlamaCppIntegrationTests {
     )
 
     // ChatML-shaped leak check — it covers ONE route: the model spelling
-    // `<|im_end|>` out as ordinary text. A control token cannot reach here
-    // (decodes to "", and EOG returns first), so that route is the only one
-    // there is. This suite runs against Gemma 4 (see `makeService`), which was
-    // never trained on ChatML, so the route is unlikely for it — but not
-    // impossible, and this assertion is the guard if it happens. What it does
-    // NOT cover is a Gemma-shaped hallucination (`<|turn>` / `<turn|>`), which
-    // nothing here truncates — that gap is #1422. Gemma's normal termination
-    // is EOG (`<turn|>`, id 106), which the length bound below is what checks.
+    // `<|im_end|>` out as ordinary text. That is the only route there is; why,
+    // is the canonical note on `LlamaCppService.stopSequence`. This suite runs
+    // against Gemma 4 (see `makeService`), which was never trained on ChatML,
+    // so the route is unlikely for it — but not impossible, and this assertion
+    // is the guard if it happens. What it does NOT cover is a Gemma-shaped
+    // hallucination (`<|turn>` / `<turn|>`), which nothing here truncates —
+    // that gap is #1422. Gemma's normal termination is EOG (`<turn|>`, id 106),
+    // which is what the length bound below checks.
     #expect(
       !result.contains("<|im_end|>"),
       "Raw output contains <|im_end|> — stop token not working. Output: \(result)"

--- a/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests.swift
+++ b/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests.swift
@@ -170,8 +170,10 @@ struct LlamaCppIntegrationTests {
     // so the route is unlikely for it — but not impossible, and this assertion
     // is the guard if it happens. What it does NOT cover is a Gemma-shaped
     // hallucination (`<|turn>` / `<turn|>`), which nothing here truncates —
-    // that gap is #1422. Gemma's normal termination is EOG (`<turn|>`, id 106),
-    // which is what the length bound below checks.
+    // that gap is #1422. Gemma's normal termination is EOG (`<turn|>`, id 106);
+    // the length bound below is only a runaway proxy for it — it would notice
+    // termination failing, but cannot tell EOG from the #907 caught-grammar
+    // stop, nor either from a naturally short answer.
     #expect(
       !result.contains("<|im_end|>"),
       "Raw output contains <|im_end|> — stop token not working. Output: \(result)"

--- a/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests.swift
+++ b/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests.swift
@@ -65,8 +65,7 @@ struct LlamaCppIntegrationTests {
   func makeService() -> LlamaCppService {
     LlamaCppService(
       modelPath: LlamaCppConfig.modelPath,
-      // Mirrors `ModelRegistry.gemma4E2B` — carries no Gemma marker;
-      // `<|im_end|>` is absent from Gemma's vocabulary (#1417).
+      // Mirrors `ModelRegistry.gemma4E2B` — carries no Gemma marker (#1417).
       stopSequence: "<|im_end|>",
       modelIdentifier: "Gemma 4 E2B (Q4_K_M)",
       systemPromptSuffix: nil
@@ -163,18 +162,14 @@ struct LlamaCppIntegrationTests {
       user: "Introduce yourself briefly."
     )
 
-    // Leak check. Note what it observes: when the stop path FIRES, the sentinel
-    // is truncated before `generate` returns, so this passes. It therefore
-    // fails only on the opposite event — a spelled-out `<|im_end|>` that the
-    // stop path did NOT catch. (Why only a spelled-out one can appear at all:
-    // the canonical note on `LlamaCppService.stopSequence`.)
-    //
-    // Scope: ChatML-shaped only. A Gemma-shaped hallucination (`<|turn>` /
-    // `<turn|>`) is neither matched nor truncated anywhere — that gap is #1422.
-    // Gemma's normal termination is EOG (`<turn|>`, id 106); the length bound
-    // below is only a runaway proxy for it — it would notice termination
-    // failing, but cannot tell EOG from the #907 caught-grammar stop, nor
-    // either from a naturally short answer.
+    // Leak check. When the stop path FIRES the sentinel is truncated before
+    // `generate` returns, so this passes; it fails only on a spelled-out
+    // `<|im_end|>` the stop path did NOT catch. ChatML-shaped only — a
+    // Gemma-shaped hallucination (`<|turn>` / `<turn|>`) is matched nowhere
+    // (#1422). Gemma's normal termination is EOG, and the length bound below is
+    // only a runaway proxy for it: it would notice termination failing outright,
+    // but cannot tell EOG from the #907 caught-grammar stop, nor either from a
+    // naturally short answer.
     #expect(
       !result.contains("<|im_end|>"),
       "Raw output contains <|im_end|> — stop token not working. Output: \(result)"

--- a/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests.swift
+++ b/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests.swift
@@ -60,7 +60,7 @@ struct LlamaCppIntegrationTests {
 
   // MARK: - Helpers
 
-  // Not `private`: the sibling `+Streaming.swift` extension calls it
+  // Not `private`: sibling `+*.swift` extensions of this suite call it
   // (`.claude/rules/testing.md` § "Splitting a Suite Across Files").
   func makeService() -> LlamaCppService {
     LlamaCppService(
@@ -163,13 +163,15 @@ struct LlamaCppIntegrationTests {
       user: "Introduce yourself briefly."
     )
 
-    // ChatML-shaped leak check. This suite runs against Gemma 4 (see
-    // `makeService`), whose vocabulary does not contain `<|im_end|>` at all, so
-    // for that model this assertion is vacuously true and constructs nothing —
-    // it is retained because the same suite shape is reused when onboarding a
-    // ChatML model, where it does bite. The load-bearing Gemma guarantee is the
-    // length bound below: termination there is EOG (`<turn|>`, id 106), not the
-    // stop sentinel. See #1417; the per-model sentinel work is #1422.
+    // ChatML-shaped leak check — it covers ONE route: the model spelling
+    // `<|im_end|>` out as ordinary text. A control token cannot reach here
+    // (decodes to "", and EOG returns first), so that route is the only one
+    // there is. This suite runs against Gemma 4 (see `makeService`), which was
+    // never trained on ChatML, so the route is unlikely for it — but not
+    // impossible, and this assertion is the guard if it happens. What it does
+    // NOT cover is a Gemma-shaped hallucination (`<|turn>` / `<turn|>`), which
+    // nothing here truncates — that gap is #1422. Gemma's normal termination
+    // is EOG (`<turn|>`, id 106), which the length bound below is what checks.
     #expect(
       !result.contains("<|im_end|>"),
       "Raw output contains <|im_end|> — stop token not working. Output: \(result)"

--- a/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests.swift
+++ b/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests.swift
@@ -60,9 +60,13 @@ struct LlamaCppIntegrationTests {
 
   // MARK: - Helpers
 
-  private func makeService() -> LlamaCppService {
+  // Not `private`: the sibling `+Streaming.swift` extension calls it
+  // (`.claude/rules/testing.md` § "Splitting a Suite Across Files").
+  func makeService() -> LlamaCppService {
     LlamaCppService(
       modelPath: LlamaCppConfig.modelPath,
+      // Mirrors `ModelRegistry.gemma4E2B` — inert for Gemma 4, which has no
+      // `<|im_end|>` in its vocabulary and terminates on EOG instead (#1417).
       stopSequence: "<|im_end|>",
       modelIdentifier: "Gemma 4 E2B (Q4_K_M)",
       systemPromptSuffix: nil
@@ -143,10 +147,10 @@ struct LlamaCppIntegrationTests {
     #expect(!statement.isEmpty, "Parsed statement is empty. Raw: \(result)")
   }
 
-  // MARK: - Test 4: Generation stops at <|im_end|> token
+  // MARK: - Test 4: Generation terminates cleanly, with no template-token leak
 
   @Test(.timeLimit(.minutes(3)))
-  func generationStopsAtImEnd() async throws {
+  func generationTerminatesWithoutTemplateTokenLeak() async throws {
     let service = makeService()
     try await service.loadModel()
     defer { Task { try? await service.unloadModel() } }
@@ -159,97 +163,23 @@ struct LlamaCppIntegrationTests {
       user: "Introduce yourself briefly."
     )
 
-    // Output should not contain leaked <|im_end|> token
+    // ChatML-shaped leak check. This suite runs against Gemma 4 (see
+    // `makeService`), whose vocabulary does not contain `<|im_end|>` at all, so
+    // for that model this assertion is vacuously true and constructs nothing —
+    // it is retained because the same suite shape is reused when onboarding a
+    // ChatML model, where it does bite. The load-bearing Gemma guarantee is the
+    // length bound below: termination there is EOG (`<turn|>`, id 106), not the
+    // stop sentinel. See #1417; the per-model sentinel work is #1422.
     #expect(
       !result.contains("<|im_end|>"),
       "Raw output contains <|im_end|> — stop token not working. Output: \(result)"
     )
     // Output should be well under maxTokens (1000 tokens ≈ 4000 chars).
-    // A runaway generation hitting maxTokens indicates the stop token failed.
+    // A runaway generation hitting maxTokens indicates termination failed.
     #expect(
       result.count < 2000,
       "Output suspiciously long (\(result.count) chars) — may have hit maxTokens"
     )
-  }
-
-  // MARK: - Test 5a: Streaming yields incremental deltas, isFinal once
-
-  @Test(.timeLimit(.minutes(3)))
-  func streamingYieldsIncrementalDeltas() async throws {
-    let service = makeService()
-    try await service.loadModel()
-    defer { Task { try? await service.unloadModel() } }
-
-    var deltas: [String] = []
-    var finalChunkCount = 0
-    var lastCompletionTokens: Int?
-
-    for try await chunk in service.generateStream(
-      system: """
-        You are a character in a game. Respond ONLY with a JSON object.
-        Required format: {"statement": "your statement here"}
-        """,
-      user: "Introduce yourself briefly."
-    ) {
-      if chunk.isFinal {
-        finalChunkCount += 1
-        lastCompletionTokens = chunk.completionTokens
-      } else {
-        deltas.append(chunk.delta)
-      }
-    }
-
-    // At least two non-final chunks means real streaming happened (rather
-    // than a single-shot fallback).
-    #expect(deltas.count > 1, "Expected multiple chunks, got \(deltas.count)")
-    #expect(finalChunkCount == 1, "Expected exactly one final chunk")
-    #expect(
-      (lastCompletionTokens ?? 0) > 0,
-      "Final chunk should carry completionTokens"
-    )
-
-    // None of the emitted deltas may contain the stop sequence — it must
-    // be detected and trimmed before emission.
-    for delta in deltas {
-      #expect(
-        !delta.contains("<|im_end|>"),
-        "Delta leaked <|im_end|>: \(delta)"
-      )
-    }
-
-    // Concatenation of all deltas produces the same final text the
-    // non-streaming `generate` path would return.
-    let streamedText = deltas.joined()
-    let parsed = try JSONResponseParser().parse(streamedText)
-    let statement = parsed.statement ?? ""
-    #expect(!statement.isEmpty, "Streamed text failed to parse. Raw: \(streamedText)")
-  }
-
-  // MARK: - Test 5b: Stream and non-stream produce equivalent text
-
-  @Test(.timeLimit(.minutes(5)))
-  func streamAndGenerateAgreeOnFinalText() async throws {
-    let service = makeService()
-    try await service.loadModel()
-    defer { Task { try? await service.unloadModel() } }
-
-    let system = "Reply with JSON only: {\"echo\": \"ack\"}"
-    let user = "Echo."
-
-    let nonStreamed = try await service.generate(system: system, user: user)
-
-    var streamed = ""
-    for try await chunk in service.generateStream(system: system, user: user)
-    where !chunk.isFinal {
-      streamed += chunk.delta
-    }
-
-    // Don't expect byte-for-byte equality — sampling is stochastic across
-    // runs — but both paths should parse as JSON and have an echo field.
-    let nonStreamedParsed = try JSONResponseParser().parse(nonStreamed)
-    let streamedParsed = try JSONResponseParser().parse(streamed)
-    #expect(nonStreamedParsed.fields["echo"] != nil)
-    #expect(streamedParsed.fields["echo"] != nil)
   }
 
   // MARK: - Test 6: Multiple sequential generations (KV cache clear)

--- a/docs/decisions/ADR-002.md
+++ b/docs/decisions/ADR-002.md
@@ -253,9 +253,12 @@ Matching OllamaService (ADR-001 §7):
 llama.cpp reads the template from the GGUF metadata and applies it automatically
 via `llama_chat_apply_template()`. `LlamaCppService.generate(system:user:)` passes
 the system and user strings; llama.cpp formats them into the model's own turn
-syntax internally — for Gemma 4 that is `<|turn>user\n...<turn|>` (ids 105/106,
-both CONTROL). (`<start_of_turn>` / `<end_of_turn>` is **Gemma 3** syntax and is
-absent from Gemma 4's vocabulary; corrected per #1417.)
+syntax internally, reading the template from the GGUF's
+`tokenizer.chat_template` metadata. Gemma 4's turn markers are `<|turn>` (id
+105) and `<turn|>` (id 106), both `token_type=3 (CONTROL)`.
+(`<start_of_turn>` / `<end_of_turn>` is **Gemma 3** syntax — both are absent
+from Gemma 4's vocabulary; corrected per #1417. The exact arrangement is
+llama.cpp's business, not this ADR's.)
 
 **JSON output**: Phase 1 MVP uses retry-based `JSONResponseParser` (same as
 OllamaService). Phase 2 adds GBNF grammar-constrained sampling to address
@@ -455,9 +458,10 @@ Contract invariants:
   LiteRT-LM: final-chunk only per shipping API).
 - Deltas never contain the descriptor's plaintext stop sentinel —
   llama.cpp's stream strips it in-place; callers concatenate deltas
-  verbatim. The sentinel is `<|im_end|>` for ChatML models such as Qwen 3;
-  for Gemma 4 that string is absent from the vocabulary and the stream ends
-  on EOG instead, so nothing is stripped there (#1417).
+  verbatim. The strip is a plain substring match on decoded text, so it fires
+  only when the model spells the sentinel out; a normal turn ends on EOG well
+  before that. The sentinel is `<|im_end|>` for ChatML models such as Qwen 3
+  and carries no Gemma marker (#1417).
 
 ### 10.2 Field set is deliberately narrow
 

--- a/docs/decisions/ADR-002.md
+++ b/docs/decisions/ADR-002.md
@@ -254,9 +254,8 @@ llama.cpp reads the template from the GGUF metadata and applies it automatically
 via `llama_chat_apply_template()`. `LlamaCppService.generate(system:user:)` passes
 the system and user strings; llama.cpp formats them into the model's own turn
 syntax internally. Gemma 4's turn markers are `<|turn>` (id 105) and `<turn|>`
-(id 106), both `token_type=3 (CONTROL)`. (`<start_of_turn>` / `<end_of_turn>`
-is **Gemma 3** syntax — both are absent from Gemma 4's vocabulary; corrected
-per #1417. The exact arrangement is llama.cpp's business, not this ADR's.)
+(id 106), both `token_type=3 (CONTROL)` — `<start_of_turn>` / `<end_of_turn>`
+is **Gemma 3** syntax, absent from Gemma 4's vocabulary (#1417).
 
 **JSON output**: Phase 1 MVP uses retry-based `JSONResponseParser` (same as
 OllamaService). Phase 2 adds GBNF grammar-constrained sampling to address
@@ -458,9 +457,7 @@ Contract invariants:
   llama.cpp's stream strips it in-place; callers concatenate deltas
   verbatim. The strip is a plain substring match on decoded text, so it fires
   only when the model spells the sentinel out; a normal turn ends on EOG
-  instead of via this path. The sentinel is `<|im_end|>` for ChatML models such
-  as Qwen 3, and the Gemma descriptor still holds that same ChatML literal even
-  though it is not a Gemma marker (#1417).
+  instead of via this path (#1417).
 
 ### 10.2 Field set is deliberately narrow
 

--- a/docs/decisions/ADR-002.md
+++ b/docs/decisions/ADR-002.md
@@ -253,12 +253,10 @@ Matching OllamaService (ADR-001 §7):
 llama.cpp reads the template from the GGUF metadata and applies it automatically
 via `llama_chat_apply_template()`. `LlamaCppService.generate(system:user:)` passes
 the system and user strings; llama.cpp formats them into the model's own turn
-syntax internally, reading the template from the GGUF's
-`tokenizer.chat_template` metadata. Gemma 4's turn markers are `<|turn>` (id
-105) and `<turn|>` (id 106), both `token_type=3 (CONTROL)`.
-(`<start_of_turn>` / `<end_of_turn>` is **Gemma 3** syntax — both are absent
-from Gemma 4's vocabulary; corrected per #1417. The exact arrangement is
-llama.cpp's business, not this ADR's.)
+syntax internally. Gemma 4's turn markers are `<|turn>` (id 105) and `<turn|>`
+(id 106), both `token_type=3 (CONTROL)`. (`<start_of_turn>` / `<end_of_turn>`
+is **Gemma 3** syntax — both are absent from Gemma 4's vocabulary; corrected
+per #1417. The exact arrangement is llama.cpp's business, not this ADR's.)
 
 **JSON output**: Phase 1 MVP uses retry-based `JSONResponseParser` (same as
 OllamaService). Phase 2 adds GBNF grammar-constrained sampling to address
@@ -459,9 +457,10 @@ Contract invariants:
 - Deltas never contain the descriptor's plaintext stop sentinel —
   llama.cpp's stream strips it in-place; callers concatenate deltas
   verbatim. The strip is a plain substring match on decoded text, so it fires
-  only when the model spells the sentinel out; a normal turn ends on EOG well
-  before that. The sentinel is `<|im_end|>` for ChatML models such as Qwen 3
-  and carries no Gemma marker (#1417).
+  only when the model spells the sentinel out; a normal turn ends on EOG
+  instead of via this path. The sentinel is `<|im_end|>` for ChatML models such
+  as Qwen 3, and the Gemma descriptor still holds that same ChatML literal even
+  though it is not a Gemma marker (#1417).
 
 ### 10.2 Field set is deliberately narrow
 

--- a/docs/decisions/ADR-002.md
+++ b/docs/decisions/ADR-002.md
@@ -252,8 +252,10 @@ Matching OllamaService (ADR-001 §7):
 **Chat template**: Use llama.cpp's built-in chat template application for Gemma 4.
 llama.cpp reads the template from the GGUF metadata and applies it automatically
 via `llama_chat_apply_template()`. `LlamaCppService.generate(system:user:)` passes
-the system and user strings; llama.cpp formats them into Gemma's
-`<start_of_turn>user\n...<end_of_turn>` format internally.
+the system and user strings; llama.cpp formats them into the model's own turn
+syntax internally — for Gemma 4 that is `<|turn>user\n...<turn|>` (ids 105/106,
+both CONTROL). (`<start_of_turn>` / `<end_of_turn>` is **Gemma 3** syntax and is
+absent from Gemma 4's vocabulary; corrected per #1417.)
 
 **JSON output**: Phase 1 MVP uses retry-based `JSONResponseParser` (same as
 OllamaService). Phase 2 adds GBNF grammar-constrained sampling to address
@@ -451,8 +453,11 @@ Contract invariants:
 - `completionTokens` is populated only on the final chunk, and only
   when the backend can cheaply report it (llama.cpp: yes; MediaPipe /
   LiteRT-LM: final-chunk only per shipping API).
-- Deltas never contain the stop sequence `<|im_end|>` — llama.cpp's
-  stream strips it in-place; callers concatenate deltas verbatim.
+- Deltas never contain the descriptor's plaintext stop sentinel —
+  llama.cpp's stream strips it in-place; callers concatenate deltas
+  verbatim. The sentinel is `<|im_end|>` for ChatML models such as Qwen 3;
+  for Gemma 4 that string is absent from the vocabulary and the stream ends
+  on EOG instead, so nothing is stripped there (#1417).
 
 ### 10.2 Field set is deliberately narrow
 

--- a/docs/models/eval-log.md
+++ b/docs/models/eval-log.md
@@ -27,8 +27,10 @@ mirror goes stale the moment a cell is re-sampled.
 `BLOCKED` is a **verdict of its own**, not a flavour of `FAIL`: the candidate
 could not be *evaluated*, so it was never rejected and the outcome is
 retry-gated. Vocabulary and admissibility are canonical in
-`.claude/skills/model-eval/SKILL.md` § "Step 4 — Verdict"; the flow position is
-in [`onboarding.md`](onboarding.md). A `BLOCKED` entry here additionally carries:
+`.claude/skills/model-eval/SKILL.md`
+§ "`blocked` — admissibility and its two enforcement layers"; the flow position
+is in [`onboarding.md`](onboarding.md). A `BLOCKED` entry here additionally
+carries:
 
 - **Unblocked by** — the named condition that would allow a retry.
 - **Retry** — where the retry is tracked. The blocker's own issue is acceptable.
@@ -46,7 +48,15 @@ the mapping is a convention you apply:
 The anti-drift rule above still wants a one-line differentiation in *every*
 entry — `UNASSESSABLE` is how a total block satisfies it without fabricating a
 judgment from zero inferences. `render_section` emits that line for you when the
-gate is `blocked`, so it survives the digest → ledger transcription.
+gate is `blocked` **and no cell completed**, so it survives the digest → ledger
+transcription; a partial block renders its real differentiation instead.
+
+**Heading form.** A blocked entry's heading reads
+`## <model> — <date> — **BLOCKED (<one-line reason>)**` — not `FAIL (BLOCKED …)`,
+which is the pre-#1419 form. Nothing validates this file, so the heading is
+where the vocabulary will drift back first. One pre-#1419 blocked run
+(Sarashina, 2026-07-08) has **no heading of its own** and is grandfathered
+inside the 2026-07-23 entry — see the note there.
 
 **Scope vs. ADR-011.** The [ADR-011](../decisions/ADR-011.md) § "Alternatives
 considered" Candidate A–F table is the committed home for the **6 GB-tier /
@@ -97,8 +107,8 @@ everything else here.
 - **Unblocked by**: the pinned llama.cpp gains shared-KV tail-layer support
   (`mattt/llama.swift` bumped past b8694).
 - **Retry**: #1416 (Gate 1 retry), gated on #1415 (the pin spike).
-- **Disposition**: **not rejected.** Retry is gated on a llama.cpp pin carrying
-  shared-KV tail-layer support → #1415 (spike) then #1416 (Gate 1 retry).
+- **Disposition**: **not rejected** — the retry chain is in *Unblocked by* /
+  *Retry* above, not restated here.
   Pre-cleared for that retry, so it need not be re-derived: ADR-011 **P1**
   non-gated (HF `gated: false`; anonymous resolve 302 → CDN 200) and **P2**
   CONTROL flags (`<|turn>` id 105, `<turn|>` id 106, both `token_type=3`); EOG set
@@ -126,9 +136,11 @@ everything else here.
     entry would add review surface without adding information, since the retry
     it was waiting for already landed and is recorded right here. It is also the
     reason the taxonomy admits a **partial** block: 3 of its 6 cells completed
-    (`ok`), so a "zero `ok` cells" precondition would have made this very shape
-    unrecordable. Unblocked by / Retry, reconstructed: the #751 empty-output
-    path being fixed → PR #1024.
+    (`ok`) — recorded in `tools/harness/Sources/PasturaHarnessKit/ModelProfile.swift`,
+    the `sarashina223B` doc comment, since the run's own digest section is
+    gitignored and per-machine — so a "zero `ok` cells" precondition would have
+    made this very shape unrecordable. Unblocked by / Retry, reconstructed
+    after the fact: the #751 empty-output path being fixed → PR #1024.
 - **Model**: `mmnga/sarashina2.2-3b-instruct-v0.1-gguf` · `Q4_K_M` · MIT,
   non-gated · ~2.07 GB · Stage-0 profile #1016 (`sarashina-2-2-3b-q4-k-m`).
 - **Differentiation**: genuine **native-Japanese creative/humor** — the ja

--- a/docs/models/eval-log.md
+++ b/docs/models/eval-log.md
@@ -44,6 +44,12 @@ the mapping is a convention you apply:
 |---|---|---|
 | none `ok` | `differentiation` **absent** | `**Differentiation**: **UNASSESSABLE**` + why |
 | ≥1 `ok` | `differentiation` **required**, scoped to the completed cells | the same text, stated as partial |
+| ≥1 `ok`, too few to judge | `PARTIAL (n/6 cells) — insufficient to differentiate` | the same, verbatim |
+
+That third row is a sanctioned value, not a rule dodge: `differentiation` asks
+whether the model's *character* earns a catalog slot, and one or two cells
+rarely answers it. Declining explicitly beats stretching thin evidence into a
+verdict.
 
 The anti-drift rule above still wants a one-line differentiation in *every*
 entry — `UNASSESSABLE` is how a total block satisfies it without fabricating a

--- a/docs/models/eval-log.md
+++ b/docs/models/eval-log.md
@@ -44,22 +44,16 @@ the mapping is a convention you apply:
 |---|---|---|
 | none `ok` | `differentiation` **absent** | `**Differentiation**: **UNASSESSABLE**` + why |
 | ≥1 `ok` | `differentiation` **required**, scoped to the completed cells | the same text, stated as partial |
-| ≥1 `ok`, too few to judge | `PARTIAL (n/6 cells) — insufficient to differentiate` | the same, verbatim |
+| ≥1 `ok`, too few to judge | `PARTIAL (n/6 cells) — insufficient to differentiate` (the validator checks only non-emptiness) | the same, verbatim — a sanctioned value, since a couple of cells rarely answers the slot-earning question |
 
-That third row is a sanctioned value, not a rule dodge: `differentiation` asks
-whether the model's *character* earns a catalog slot, and one or two cells
-rarely answers it. Declining explicitly beats stretching thin evidence into a
-verdict.
+`UNASSESSABLE` is how a total block satisfies the anti-drift rule's
+one-line-differentiation requirement without fabricating a judgment from zero
+inferences. `render_section` emits it for you **when no cell completed**, so it
+survives the digest → ledger transcription; a partial block renders its real
+differentiation instead, and must not be relabelled `UNASSESSABLE`.
 
-The anti-drift rule above still wants a one-line differentiation in *every*
-entry — `UNASSESSABLE` is how a total block satisfies it without fabricating a
-judgment from zero inferences. `render_section` emits that line for you when the
-gate is `blocked` **and no cell completed**, so it survives the digest → ledger
-transcription; a partial block renders its real differentiation instead.
-
-**Heading form.** A blocked entry's heading reads
-`## <model> — <date> — **BLOCKED (<one-line reason>)**` — not `FAIL (BLOCKED …)`,
-which is the pre-#1419 form. Nothing validates this file, so the heading is
+**Heading form.** `## <model> — <date> — **BLOCKED (<one-line reason>)**`, not
+the pre-#1419 `FAIL (BLOCKED …)`. Nothing validates this file, so the heading is
 where the vocabulary will drift back first. One pre-#1419 blocked run
 (Sarashina, 2026-07-08) has **no heading of its own** and is grandfathered
 inside the 2026-07-23 entry — see the note there.
@@ -113,9 +107,8 @@ everything else here.
 - **Unblocked by**: the pinned llama.cpp gains shared-KV tail-layer support
   (`mattt/llama.swift` bumped past b8694).
 - **Retry**: #1416 (Gate 1 retry), gated on #1415 (the pin spike).
-- **Disposition**: **not rejected** — the retry chain is in *Unblocked by* /
-  *Retry* above, not restated here.
-  Pre-cleared for that retry, so it need not be re-derived: ADR-011 **P1**
+- **Disposition**: **not rejected.**
+  Pre-cleared for the retry, so it need not be re-derived: ADR-011 **P1**
   non-gated (HF `gated: false`; anonymous resolve 302 → CDN 200) and **P2**
   CONTROL flags (`<|turn>` id 105, `<turn|>` id 106, both `token_type=3`); EOG set
   `{1, 50, 106, 212}` is a **superset** of the incumbent's `{50, 106, 212}`, so
@@ -137,16 +130,15 @@ everything else here.
   blocker was fixed (PR #1024); the original 2026-07-08 run was blocked, not
   cleanly quality-rejected.
   - *Grandfathered (#1419).* That 2026-07-08 run predates the `BLOCKED` verdict
-    and has **no entry of its own** — it exists only as this clause. It is left
-    that way deliberately: there is no heading to retitle, and back-dating an
-    entry would add review surface without adding information, since the retry
-    it was waiting for already landed and is recorded right here. It is also the
-    reason the taxonomy admits a **partial** block: 3 of its 6 cells completed
-    (`ok`) — recorded in `tools/harness/Sources/PasturaHarnessKit/ModelProfile.swift`,
-    the `sarashina223B` doc comment, since the run's own digest section is
-    gitignored and per-machine — so a "zero `ok` cells" precondition would have
-    made this very shape unrecordable. Unblocked by / Retry, reconstructed
-    after the fact: the #751 empty-output path being fixed → PR #1024.
+    and has **no entry of its own** — deliberately, since the retry it waited on
+    already landed and is recorded right here (unblocked by the #751
+    empty-output fix → PR #1024; both fields reconstructed after the fact). It is
+    also why the taxonomy admits a **partial** block: 3 of its 6 cells
+    hard-failed and the rest did not, so some completed — recorded in that
+    direction in the `sarashina223B` doc comment in
+    `tools/harness/Sources/PasturaHarnessKit/ModelProfile.swift`, the digest
+    itself being gitignored. A "zero `ok` cells" precondition would therefore
+    have made this very shape unrecordable.
 - **Model**: `mmnga/sarashina2.2-3b-instruct-v0.1-gguf` · `Q4_K_M` · MIT,
   non-gated · ~2.07 GB · Stage-0 profile #1016 (`sarashina-2-2-3b-q4-k-m`).
 - **Differentiation**: genuine **native-Japanese creative/humor** — the ja

--- a/docs/models/eval-log.md
+++ b/docs/models/eval-log.md
@@ -13,7 +13,7 @@ durable, version-controlled one:
 |---|---|---|
 | `data/models/eval-digest.md` | Raw per-cell scorecard (every axis + tok/s), **script-regenerated** by `/model-eval` | Gitignored, **per-machine** — re-sampling rewrites it |
 | GitHub issue #979 | Rolling **intake queue** — triage, candidate proposals | Comment thread, buries over time |
-| **This file** | The **verdict** (pass/fail + rationale + differentiation) | Committed, PR-reviewed |
+| **This file** | The **verdict** (`pass` / `borderline` / `fail` / `blocked` + rationale + differentiation) | Committed, PR-reviewed |
 
 **Anti-drift rule — entries carry judgment only.** An entry records the verdict,
 date, model id/quant, one-line differentiation, rationale, and an aggregate
@@ -21,6 +21,32 @@ point-in-time snapshot — then **points to `data/models/eval-digest.md` for the
 raw per-cell scores**. Do NOT copy the per-cell score matrix here: it is the
 volatile, script-owned content of the gitignored digest, and a hand-copied
 mirror goes stale the moment a cell is re-sampled.
+
+### `BLOCKED` entries
+
+`BLOCKED` is a **verdict of its own**, not a flavour of `FAIL`: the candidate
+could not be *evaluated*, so it was never rejected and the outcome is
+retry-gated. Vocabulary and admissibility are canonical in
+`.claude/skills/model-eval/SKILL.md` § "Step 4 — Verdict"; the flow position is
+in [`onboarding.md`](onboarding.md). A `BLOCKED` entry here additionally carries:
+
+- **Unblocked by** — the named condition that would allow a retry.
+- **Retry** — where the retry is tracked. The blocker's own issue is acceptable.
+
+**The differentiation field maps across two artifacts, and only one of them is
+validated.** `/model-eval` writes the gitignored digest, where `append_eval.py`
+*enforces* the rule; this ledger is hand-authored and validated by nothing, so
+the mapping is a convention you apply:
+
+| Cells completed | digest JSON (`append_eval.py`, enforced) | this ledger (convention) |
+|---|---|---|
+| none `ok` | `differentiation` **absent** | `**Differentiation**: **UNASSESSABLE**` + why |
+| ≥1 `ok` | `differentiation` **required**, scoped to the completed cells | the same text, stated as partial |
+
+The anti-drift rule above still wants a one-line differentiation in *every*
+entry — `UNASSESSABLE` is how a total block satisfies it without fabricating a
+judgment from zero inferences. `render_section` emits that line for you when the
+gate is `blocked`, so it survives the digest → ledger transcription.
 
 **Scope vs. ADR-011.** The [ADR-011](../decisions/ADR-011.md) § "Alternatives
 considered" Candidate A–F table is the committed home for the **6 GB-tier /
@@ -33,7 +59,7 @@ everything else here.
 
 ---
 
-## Gemma 4 E2B QAT Q4_0 (`google/gemma-4-E2B-it-qat-q4_0-gguf`) — 2026-08-08 — **FAIL (BLOCKED — runtime compatibility, not a quality rejection)**
+## Gemma 4 E2B QAT Q4_0 (`google/gemma-4-E2B-it-qat-q4_0-gguf`) — 2026-08-08 — **BLOCKED (runtime compatibility — not evaluated, therefore not rejected)**
 
 - **Gate**: 1 (Mac filter, `/model-eval`) — **blocked at model load, never
   reached inference.** All 6 battery cells failed in ~0.9 s each, 2 attempts
@@ -68,6 +94,9 @@ everything else here.
   **2.10327.0** (llama.cpp b10327) loads the QAT file *and* the incumbent, while
   b8694 loads only the incumbent — a bump is therefore sufficient *and* the
   wrapper release exists.
+- **Unblocked by**: the pinned llama.cpp gains shared-KV tail-layer support
+  (`mattt/llama.swift` bumped past b8694).
+- **Retry**: #1416 (Gate 1 retry), gated on #1415 (the pin spike).
 - **Disposition**: **not rejected.** Retry is gated on a llama.cpp pin carrying
   shared-KV tail-layer support → #1415 (spike) then #1416 (Gate 1 retry).
   Pre-cleared for that retry, so it need not be re-derived: ADR-011 **P1**
@@ -91,6 +120,15 @@ everything else here.
 - **Gate**: 1 (Mac filter, `/model-eval`) — re-eval after the #751 empty-output
   blocker was fixed (PR #1024); the original 2026-07-08 run was blocked, not
   cleanly quality-rejected.
+  - *Grandfathered (#1419).* That 2026-07-08 run predates the `BLOCKED` verdict
+    and has **no entry of its own** — it exists only as this clause. It is left
+    that way deliberately: there is no heading to retitle, and back-dating an
+    entry would add review surface without adding information, since the retry
+    it was waiting for already landed and is recorded right here. It is also the
+    reason the taxonomy admits a **partial** block: 3 of its 6 cells completed
+    (`ok`), so a "zero `ok` cells" precondition would have made this very shape
+    unrecordable. Unblocked by / Retry, reconstructed: the #751 empty-output
+    path being fixed → PR #1024.
 - **Model**: `mmnga/sarashina2.2-3b-instruct-v0.1-gguf` · `Q4_K_M` · MIT,
   non-gated · ~2.07 GB · Stage-0 profile #1016 (`sarashina-2-2-3b-q4-k-m`).
 - **Differentiation**: genuine **native-Japanese creative/humor** — the ja

--- a/docs/models/onboarding.md
+++ b/docs/models/onboarding.md
@@ -19,9 +19,9 @@ Stage 0  harness ModelProfile PR (new family only)
 Gate 1   /model-eval  — cheap Mac filter (足切り)
    │        ├─ reject ──▶ record candidate + failure mode (stop)
    │        ├─ borderline ──▶ re-sample weak cell(s), re-judge (never reject on one sample)
-   │        ├─ blocked ──▶ record blocker + retry pointer ──┐  (NOT a stop)
-   │        │                                               │
-   │        │      ◀── retry when the blocker clears ───────┘
+   │        └─ blocked ──▶ record blocker + retry pointer ──┐  (NOT a stop)
+   │                                                        │
+   │               ◀── retry when the blocker clears ───────┘
    │        (pass = ADVANCE only; it cannot accept)
    ▼
 Gate 2   ADR-011 real-device PoC — the ONLY accept path
@@ -46,10 +46,13 @@ can produce it; a blocked entry must always name **what would unblock it** and
 The two gates enforce that asymmetrically, and the asymmetry is deliberate:
 
 - **Gate 1** is machine-checked. `/model-eval`'s `append_eval.py` rejects a
-  `blocked` scorecard that lacks an unblock condition or a retry pointer, and
-  refuses a `differentiation` judgment when no cell completed. Admissibility
-  itself (is the failure environmental or the candidate's own?) stays a human
-  call — see `.claude/skills/model-eval/SKILL.md` § "Step 4 — Verdict".
+  `blocked` scorecard that lacks an unblock condition or a retry pointer, or
+  that has no non-`ok` cell; it refuses a `differentiation` judgment when no
+  cell completed, and conversely *requires* one — scoped to the completed
+  cells — when at least one did. Admissibility itself (is the failure
+  environmental or the candidate's own?) stays a human call — see
+  `.claude/skills/model-eval/SKILL.md`
+  § "`blocked` — admissibility and its two enforcement layers".
 - **Gate 2** is **convention-only**. There is no machine-readable Gate-2
   artifact, so nothing validates a real-device blocked outcome; record it in
   [`eval-log.md`](eval-log.md) with the same two fields by hand.

--- a/docs/models/onboarding.md
+++ b/docs/models/onboarding.md
@@ -45,14 +45,16 @@ can produce it; a blocked entry must always name **what would unblock it** and
 
 The two gates enforce that asymmetrically, and the asymmetry is deliberate:
 
-- **Gate 1** is machine-checked. `/model-eval`'s `append_eval.py` rejects a
-  `blocked` scorecard that lacks an unblock condition or a retry pointer, or
-  that has no non-`ok` cell; it refuses a `differentiation` judgment when no
+- **Gate 1** is machine-checked, but only structurally. `/model-eval`'s
+  `append_eval.py` rejects a `blocked` scorecard that lacks an unblock
+  condition or a retry pointer; it refuses a `differentiation` judgment when no
   cell completed, and conversely *requires* one — scoped to the completed
-  cells — when at least one did. Admissibility itself (is the failure
-  environmental or the candidate's own?) stays a human call — see
+  cells, or an explicit "insufficient to differentiate" — when at least one
+  did. Admissibility itself (is the failure environmental or the candidate's
+  own?) is **not** checked by anything and stays a human call — see
   `.claude/skills/model-eval/SKILL.md`
-  § "`blocked` — admissibility and its two enforcement layers".
+  § "`blocked` — admissibility and its two enforcement layers", which also
+  explains why a mechanical proxy was rejected.
 - **Gate 2** is **convention-only**. There is no machine-readable Gate-2
   artifact, so nothing validates a real-device blocked outcome; record it in
   [`eval-log.md`](eval-log.md) with the same two fields by hand.

--- a/docs/models/onboarding.md
+++ b/docs/models/onboarding.md
@@ -18,18 +18,41 @@ Stage 0  harness ModelProfile PR (new family only)
    │
 Gate 1   /model-eval  — cheap Mac filter (足切り)
    │        ├─ reject ──▶ record candidate + failure mode (stop)
-   │        └─ borderline ──▶ re-sample weak cell(s), re-judge (never reject on one sample)
+   │        ├─ borderline ──▶ re-sample weak cell(s), re-judge (never reject on one sample)
+   │        ├─ blocked ──▶ record blocker + retry pointer ──┐  (NOT a stop)
+   │        │                                               │
+   │        │      ◀── retry when the blocker clears ───────┘
    │        (pass = ADVANCE only; it cannot accept)
    ▼
 Gate 2   ADR-011 real-device PoC — the ONLY accept path
-   │        └─ no-go ──▶ record candidate + failure mode (stop)
+   │        ├─ no-go ──▶ record candidate + failure mode (stop)
+   │        └─ blocked ──▶ record blocker + retry pointer ──┐  (NOT a stop)
+   │                                                        │
+   │               ◀── retry when the blocker clears ───────┘
    ▼
 Registration  (/orchestrate: descriptor + mirrors + device QA)
 ```
 
-Gate 1 can **reject** cheaply or return **borderline** (→ re-sample per the
+Gate 1 can **reject** cheaply, return **borderline** (→ re-sample per the
 skill's asymmetric verdict — one unlucky single-run sample must never discard a
-candidate). Gate 2 is the sole gate that can **accept**.
+candidate), or return **blocked**. Gate 2 is the sole gate that can **accept**.
+
+**`blocked` is not a rejection** — it means the candidate could not be
+*evaluated* (a model-load failure, a runtime incompatibility, a known infra
+path), so there is nothing to reject and the outcome is retry-gated. Both gates
+can produce it; a blocked entry must always name **what would unblock it** and
+**where the retry is tracked**.
+
+The two gates enforce that asymmetrically, and the asymmetry is deliberate:
+
+- **Gate 1** is machine-checked. `/model-eval`'s `append_eval.py` rejects a
+  `blocked` scorecard that lacks an unblock condition or a retry pointer, and
+  refuses a `differentiation` judgment when no cell completed. Admissibility
+  itself (is the failure environmental or the candidate's own?) stays a human
+  call — see `.claude/skills/model-eval/SKILL.md` § "Step 4 — Verdict".
+- **Gate 2** is **convention-only**. There is no machine-readable Gate-2
+  artifact, so nothing validates a real-device blocked outcome; record it in
+  [`eval-log.md`](eval-log.md) with the same two fields by hand.
 
 ## Stage 0 — Harness profile (new model family only)
 
@@ -130,6 +153,9 @@ character earns no slot even with decent numbers. Each model also costs
 ## Recording outcomes
 
 - **Pass (through Gate 2)** → the registration PR above.
+- **Blocked (either gate)** → record the blocker + the unblock condition + the
+  retry pointer, on the same three surfaces below. The candidate stays live;
+  do **not** write it up as a rejection.
 - **No-go / reject (either gate)** → record the verdict + failure mode. Three
   committed surfaces, by role:
   - **[`eval-log.md`](eval-log.md)** — the durable verdict ledger; the home for

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
@@ -62,8 +62,12 @@ internal class JSONResponseParser {
          * Chat-template token — truncate everything from the first occurrence.
          *
          * ChatML-only by construction, mirroring the Swift original: correct for
-         * Qwen 3, but Gemma 4's markers are `<|turn>` / `<turn|>`, so a Gemma
-         * hallucinated continuation is NOT truncated. Per-model sourcing is #1422.
+         * Qwen 3, but inert for Gemma 4. Gemma's turn markers are CONTROL tokens
+         * (`<|turn>` / `<turn|>`, ids 105/106) that cannot reach a parser as text
+         * — `special: false` decoding drops 105, and 106 is EOG — and `<|im_end|>`
+         * is absent from its vocabulary. Which text a Gemma hallucination would
+         * spell out instead is **not established**; whatever it is, it would not
+         * be truncated here. Per-model sourcing is #1422.
          */
         val CHAT_TEMPLATE_TOKEN = Regex("""<\|im_end\|>[\s\S]*""")
 

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
@@ -61,18 +61,11 @@ internal class JSONResponseParser {
         /**
          * Chat-template token — truncate everything from the first occurrence.
          *
-         * ChatML-only by construction, mirroring the Swift original: correct for
-         * Qwen 3, and for Gemma 4 it fires only on a spelled-out `<|im_end|>`.
-         * Gemma's markers are `<|turn>` / `<turn|>` and its vocabulary has no
-         * `<|im_end|>`, so spelled-out is the only form that could arrive — and
-         * it is not the form a Gemma hallucination would reach for. What it does
-         * NOT do for Gemma is truncate a Gemma-shaped continuation.
-         *
-         * This type is backend-agnostic, so do not assume the llama.cpp
-         * guarantee here: under that backend a control marker cannot reach
-         * decoded text at all, but a server-decoding backend offers no such
-         * guarantee. Which text a Gemma hallucination would spell out is **not
-         * established**; whatever it is, it would not be truncated here.
+         * ChatML-only, mirroring the Swift original: for a non-ChatML model this
+         * fires only on a spelled-out `<|im_end|>` — not the form a Gemma
+         * hallucination would take (Gemma 4's markers are `<|turn>` / `<turn|>`).
+         * The type is also backend-agnostic, so do not import the llama.cpp
+         * control-token guarantee here: a server-decoding backend offers none.
          * Per-model sourcing is #1422.
          */
         val CHAT_TEMPLATE_TOKEN = Regex("""<\|im_end\|>[\s\S]*""")

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
@@ -62,10 +62,11 @@ internal class JSONResponseParser {
          * Chat-template token — truncate everything from the first occurrence.
          *
          * ChatML-only by construction, mirroring the Swift original: correct for
-         * Qwen 3, but it does nothing for Gemma 4, whose markers are `<|turn>` /
-         * `<turn|>` and whose vocabulary has no `<|im_end|>` — so that literal
-         * can only arrive spelled out as ordinary text, which is possible but
-         * not observed.
+         * Qwen 3, and for Gemma 4 it fires only on a spelled-out `<|im_end|>`.
+         * Gemma's markers are `<|turn>` / `<turn|>` and its vocabulary has no
+         * `<|im_end|>`, so spelled-out is the only form that could arrive —
+         * possible, but not seen. What it does NOT do for Gemma is truncate a
+         * Gemma-shaped continuation.
          *
          * This type is backend-agnostic, so do not assume the llama.cpp
          * guarantee here: under that backend a control marker cannot reach

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
@@ -58,7 +58,13 @@ internal class JSONResponseParser {
         /** Common thinking-model format: `<think>...</think>` (DeepSeek, Qwen). */
         val THINK_TAG = Regex("""<think>[\s\S]*?</think>""")
 
-        /** Chat-template token — truncate everything from the first occurrence. */
+        /**
+         * Chat-template token — truncate everything from the first occurrence.
+         *
+         * ChatML-only by construction, mirroring the Swift original: correct for
+         * Qwen 3, but Gemma 4's markers are `<|turn>` / `<turn|>`, so a Gemma
+         * hallucinated continuation is NOT truncated. Per-model sourcing is #1422.
+         */
         val CHAT_TEMPLATE_TOKEN = Regex("""<\|im_end\|>[\s\S]*""")
 
         val CODE_BLOCK = Regex("""```(?:json)?\s*\n?([\s\S]*?)\n?```""")

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
@@ -64,9 +64,9 @@ internal class JSONResponseParser {
          * ChatML-only by construction, mirroring the Swift original: correct for
          * Qwen 3, and for Gemma 4 it fires only on a spelled-out `<|im_end|>`.
          * Gemma's markers are `<|turn>` / `<turn|>` and its vocabulary has no
-         * `<|im_end|>`, so spelled-out is the only form that could arrive —
-         * possible, but not seen. What it does NOT do for Gemma is truncate a
-         * Gemma-shaped continuation.
+         * `<|im_end|>`, so spelled-out is the only form that could arrive — and
+         * it is not the form a Gemma hallucination would reach for. What it does
+         * NOT do for Gemma is truncate a Gemma-shaped continuation.
          *
          * This type is backend-agnostic, so do not assume the llama.cpp
          * guarantee here: under that backend a control marker cannot reach

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
@@ -62,12 +62,17 @@ internal class JSONResponseParser {
          * Chat-template token — truncate everything from the first occurrence.
          *
          * ChatML-only by construction, mirroring the Swift original: correct for
-         * Qwen 3, but inert for Gemma 4. Gemma's turn markers are CONTROL tokens
-         * (`<|turn>` / `<turn|>`, ids 105/106) that cannot reach a parser as text
-         * — `special: false` decoding drops 105, and 106 is EOG — and `<|im_end|>`
-         * is absent from its vocabulary. Which text a Gemma hallucination would
-         * spell out instead is **not established**; whatever it is, it would not
-         * be truncated here. Per-model sourcing is #1422.
+         * Qwen 3, but it does nothing for Gemma 4, whose markers are `<|turn>` /
+         * `<turn|>` and whose vocabulary has no `<|im_end|>` — so that literal
+         * can only arrive spelled out as ordinary text, which is possible but
+         * not observed.
+         *
+         * This type is backend-agnostic, so do not assume the llama.cpp
+         * guarantee here: under that backend a control marker cannot reach
+         * decoded text at all, but a server-decoding backend offers no such
+         * guarantee. Which text a Gemma hallucination would spell out is **not
+         * established**; whatever it is, it would not be truncated here.
+         * Per-model sourcing is #1422.
          */
         val CHAT_TEMPLATE_TOKEN = Regex("""<\|im_end\|>[\s\S]*""")
 

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMCaller.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMCaller.kt
@@ -567,11 +567,11 @@ internal class LLMCaller(
      * strips a spelled-out `<|im_end|>` before emission, so this primarily catches
      * non-streaming backends where the raw string may still contain template tokens.
      *
-     * ChatML-only, mirroring the Swift original: Gemma 4's markers are `<|turn>` /
-     * `<turn|>`, so this diagnostic never matches for the default shipped model.
-     * Backends that decode server-side — Ollama and Foundation Models — lack
-     * llama.cpp's decode-side guarantee, and are the residual surface here.
-     * Making it model-aware is #1422.
+     * ChatML-only, mirroring the Swift original: for Gemma 4 (markers `<|turn>` /
+     * `<turn|>`) it can match only a spelled-out ChatML token. The `<|im_start|>`
+     * branch stays reachable even under llama.cpp, whose streaming path strips
+     * `stopSequence` — `<|im_end|>` alone — so a spelled-out `<|im_start|>`
+     * survives. Making it model-aware is #1422.
      */
     private fun logChatTemplateLeakage(raw: String) {
         if (raw.contains("<|im_start|>")) {

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMCaller.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMCaller.kt
@@ -568,9 +568,9 @@ internal class LLMCaller(
      * non-streaming backends where the raw string may still contain template tokens.
      *
      * ChatML-only, mirroring the Swift original: Gemma 4's markers are `<|turn>` /
-     * `<turn|>`, so this diagnostic sees nothing for the default shipped model.
-     * The backends named above are exactly the ones without llama.cpp's
-     * decode-side guarantee, which is what makes them the residual surface here.
+     * `<turn|>`, so this diagnostic never matches for the default shipped model.
+     * Backends that decode server-side — Ollama and Foundation Models — lack
+     * llama.cpp's decode-side guarantee, and are the residual surface here.
      * Making it model-aware is #1422.
      */
     private fun logChatTemplateLeakage(raw: String) {

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMCaller.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMCaller.kt
@@ -568,8 +568,10 @@ internal class LLMCaller(
      * non-streaming backends where the raw string may still contain template tokens.
      *
      * ChatML-only, mirroring the Swift original: Gemma 4's markers are `<|turn>` /
-     * `<turn|>`, so this diagnostic is silently blind for the default shipped
-     * model. Making it model-aware is #1422.
+     * `<turn|>`, so this diagnostic sees nothing for the default shipped model.
+     * The backends named above are exactly the ones without llama.cpp's
+     * decode-side guarantee, which is what makes them the residual surface here.
+     * Making it model-aware is #1422.
      */
     private fun logChatTemplateLeakage(raw: String) {
         if (raw.contains("<|im_start|>")) {

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMCaller.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMCaller.kt
@@ -567,11 +567,10 @@ internal class LLMCaller(
      * strips a spelled-out `<|im_end|>` before emission, so this primarily catches
      * non-streaming backends where the raw string may still contain template tokens.
      *
-     * ChatML-only, mirroring the Swift original: for Gemma 4 (markers `<|turn>` /
-     * `<turn|>`) it can match only a spelled-out ChatML token. The `<|im_start|>`
-     * branch stays reachable even under llama.cpp, whose streaming path strips
-     * `stopSequence` — `<|im_end|>` alone — so a spelled-out `<|im_start|>`
-     * survives. Making it model-aware is #1422.
+     * ChatML-only, mirroring the Swift original: a non-ChatML model (Gemma 4) is
+     * not covered — #1422. A spelled-out `<|im_start|>` stays reachable even
+     * under llama.cpp, whose streaming path strips `stopSequence` (`<|im_end|>`)
+     * alone.
      */
     private fun logChatTemplateLeakage(raw: String) {
         if (raw.contains("<|im_start|>")) {

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMCaller.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMCaller.kt
@@ -564,8 +564,12 @@ internal class LLMCaller(
 
     /**
      * Detect chat-template token leakage. The Swift `LlamaCppService` streaming path
-     * strips `<|im_end|>` before emission, so this primarily catches non-streaming
-     * backends where the raw string may still contain template tokens.
+     * strips a spelled-out `<|im_end|>` before emission, so this primarily catches
+     * non-streaming backends where the raw string may still contain template tokens.
+     *
+     * ChatML-only, mirroring the Swift original: Gemma 4's markers are `<|turn>` /
+     * `<turn|>`, so this diagnostic is silently blind for the default shipped
+     * model. Making it model-aware is #1422.
      */
     private fun logChatTemplateLeakage(raw: String) {
         if (raw.contains("<|im_start|>")) {

--- a/tools/harness/Sources/PasturaHarnessKit/ModelProfile.swift
+++ b/tools/harness/Sources/PasturaHarnessKit/ModelProfile.swift
@@ -16,9 +16,10 @@ package struct ModelProfile: Sendable, Equatable {
   ///
   /// Ends generation early only when the model spells it out as ordinary text
   /// (a hallucinated turn boundary); it is not what terminates a *normal*
-  /// turn — that is EOG, for every model. So it never fires for a model whose
-  /// markers a hallucination would not write in that form. The canonical
-  /// mechanism note is on `LlamaCppService.stopSequence` (#1417).
+  /// turn — that is EOG, for every model. For a model whose markers a
+  /// hallucination would not write in that form, it therefore fires only on a
+  /// spelled-out sentinel: possible, but not seen. The canonical mechanism
+  /// note is on `LlamaCppService.stopSequence` (#1417).
   package let stopSequence: String
   /// Optional suffix appended to every system prompt.
   package let systemPromptSuffix: String?

--- a/tools/harness/Sources/PasturaHarnessKit/ModelProfile.swift
+++ b/tools/harness/Sources/PasturaHarnessKit/ModelProfile.swift
@@ -16,10 +16,10 @@ package struct ModelProfile: Sendable, Equatable {
   ///
   /// Ends generation early only when the model spells it out as ordinary text
   /// (a hallucinated turn boundary); it is not what terminates a *normal*
-  /// turn — that is EOG, for every model. For a model whose markers a
-  /// hallucination would not write in that form, it therefore fires only on a
-  /// spelled-out sentinel: possible, but not seen. The canonical mechanism
-  /// note is on `LlamaCppService.stopSequence` (#1417).
+  /// turn — that is EOG, for every model. It therefore fires only on a
+  /// spelled-out sentinel, which for a model whose markers differ from the
+  /// configured value is not the form a hallucination would reach for. The
+  /// canonical mechanism note is on `LlamaCppService.stopSequence` (#1417).
   package let stopSequence: String
   /// Optional suffix appended to every system prompt.
   package let systemPromptSuffix: String?

--- a/tools/harness/Sources/PasturaHarnessKit/ModelProfile.swift
+++ b/tools/harness/Sources/PasturaHarnessKit/ModelProfile.swift
@@ -14,10 +14,10 @@ package struct ModelProfile: Sendable, Equatable {
   package let name: String
   /// Plaintext stop sentinel, mirroring `ModelDescriptor.stopSequence`.
   ///
-  /// NOT what terminates a generation — that is EOG, for every model. This is
-  /// matched only against text the model spelled out itself (a hallucinated
-  /// turn boundary), so it is inert for a model whose markers a hallucination
-  /// would not write in that form. See #1417.
+  /// Ends generation early only when the model spells it out as ordinary text
+  /// (a hallucinated turn boundary); it is not what terminates a *normal*
+  /// turn — that is EOG, for every model. So it carries nothing for a model
+  /// whose markers a hallucination would not write in that form. See #1417.
   package let stopSequence: String
   /// Optional suffix appended to every system prompt.
   package let systemPromptSuffix: String?
@@ -51,9 +51,10 @@ package struct ModelProfile: Sendable, Equatable {
   package static let gemma4E2B = ModelProfile(
     id: "gemma-4-e2b-q4-k-m",
     name: "Gemma 4 E2B (Q4_K_M)",
-    // Inert for Gemma 4, deliberately — mirrors `ModelRegistry.gemma4E2B`, whose
-    // comment carries the measurement. `ModelProfileTests` pins the two equal, so
-    // this value cannot be "fixed" here alone (#1417).
+    // Carries no Gemma marker, deliberately — mirrors `ModelRegistry.gemma4E2B`,
+    // whose comment carries the measurement. The drift guard in
+    // `ModelProfileTests` pins this literal, so it cannot be changed here
+    // alone (#1417).
     stopSequence: "<|im_end|>",
     systemPromptSuffix: nil,
     assistantPrefix: nil,

--- a/tools/harness/Sources/PasturaHarnessKit/ModelProfile.swift
+++ b/tools/harness/Sources/PasturaHarnessKit/ModelProfile.swift
@@ -16,8 +16,9 @@ package struct ModelProfile: Sendable, Equatable {
   ///
   /// Ends generation early only when the model spells it out as ordinary text
   /// (a hallucinated turn boundary); it is not what terminates a *normal*
-  /// turn — that is EOG, for every model. So it carries nothing for a model
-  /// whose markers a hallucination would not write in that form. See #1417.
+  /// turn — that is EOG, for every model. So it never fires for a model whose
+  /// markers a hallucination would not write in that form. The canonical
+  /// mechanism note is on `LlamaCppService.stopSequence` (#1417).
   package let stopSequence: String
   /// Optional suffix appended to every system prompt.
   package let systemPromptSuffix: String?

--- a/tools/harness/Sources/PasturaHarnessKit/ModelProfile.swift
+++ b/tools/harness/Sources/PasturaHarnessKit/ModelProfile.swift
@@ -15,10 +15,7 @@ package struct ModelProfile: Sendable, Equatable {
   /// Plaintext stop sentinel, mirroring `ModelDescriptor.stopSequence`.
   ///
   /// Ends generation early only when the model spells it out as ordinary text
-  /// (a hallucinated turn boundary); it is not what terminates a *normal*
-  /// turn — that is EOG, for every model. It therefore fires only on a
-  /// spelled-out sentinel, which for a model whose markers differ from the
-  /// configured value is not the form a hallucination would reach for. The
+  /// (a hallucinated turn boundary); a *normal* turn ends on EOG instead. The
   /// canonical mechanism note is on `LlamaCppService.stopSequence` (#1417).
   package let stopSequence: String
   /// Optional suffix appended to every system prompt.
@@ -53,10 +50,10 @@ package struct ModelProfile: Sendable, Equatable {
   package static let gemma4E2B = ModelProfile(
     id: "gemma-4-e2b-q4-k-m",
     name: "Gemma 4 E2B (Q4_K_M)",
-    // Carries no Gemma marker, deliberately — mirrors `ModelRegistry.gemma4E2B`,
-    // whose comment carries the measurement. The drift guard in
-    // `ModelProfileTests` pins this literal, so it cannot be changed here
-    // alone (#1417).
+    // Carries no Gemma marker, deliberately — mirrors `ModelRegistry.gemma4E2B`;
+    // the measurement is in the canonical note on `LlamaCppService.stopSequence`.
+    // `ModelProfileTests` pins the literal, so it cannot be changed here alone
+    // (#1417).
     stopSequence: "<|im_end|>",
     systemPromptSuffix: nil,
     assistantPrefix: nil,

--- a/tools/harness/Sources/PasturaHarnessKit/ModelProfile.swift
+++ b/tools/harness/Sources/PasturaHarnessKit/ModelProfile.swift
@@ -12,7 +12,12 @@ package struct ModelProfile: Sendable, Equatable {
   package let id: String
   /// Human-readable model label, used as `LlamaCppService.modelIdentifier`.
   package let name: String
-  /// Stop sequence terminating each generation.
+  /// Plaintext stop sentinel, mirroring `ModelDescriptor.stopSequence`.
+  ///
+  /// NOT what terminates a generation — that is EOG, for every model. This is
+  /// matched only against text the model spelled out itself (a hallucinated
+  /// turn boundary), so it is inert for a model whose markers a hallucination
+  /// would not write in that form. See #1417.
   package let stopSequence: String
   /// Optional suffix appended to every system prompt.
   package let systemPromptSuffix: String?
@@ -46,6 +51,9 @@ package struct ModelProfile: Sendable, Equatable {
   package static let gemma4E2B = ModelProfile(
     id: "gemma-4-e2b-q4-k-m",
     name: "Gemma 4 E2B (Q4_K_M)",
+    // Inert for Gemma 4, deliberately — mirrors `ModelRegistry.gemma4E2B`, whose
+    // comment carries the measurement. `ModelProfileTests` pins the two equal, so
+    // this value cannot be "fixed" here alone (#1417).
     stopSequence: "<|im_end|>",
     systemPromptSuffix: nil,
     assistantPrefix: nil,


### PR DESCRIPTION
Closes #1417
Closes #1419

2つの issue をまとめた PR（メンテナ判断）。両者は独立した論理変更なのでコミットで分離してある。挙動の変更はゼロ — #1417 側はコメントのみ、#1419 側は新しい disposition の追加。

## #1417 — Gemma の stopSequence 根拠コメントが偽

`ModelRegistry.gemma4E2B.stopSequence` は `"<|im_end|>"` だが、この文字列は Gemma 4 の語彙に存在しない。挙動に影響は無い（終端は EOG が担う）が、根拠コメントが「Gemma と Qwen 3 は両方 `<|im_end|>` を使う」と偽の事実を断言していた。**issue の選択肢1**（値は据え置き、コメントのみ訂正）を採用。

出荷 GGUF のヘッダを直接パースして再測定した:

| モデル | `<|im_end|>` | ターンマーカー | `eos_token_id` |
|---|---|---|---|
| Gemma 4 E2B Q4_K_M | **語彙に不在**（262,144件中） | `<|turn>`=105 / `<turn|>`=106（ともに CONTROL） | 106 |
| Qwen 3 4B Q4_K_M | 151645（CONTROL） | ChatML | 151645 |

コードを読んで確定した機構: `decodePiece` は `llama_token_to_piece(..., special: false)` を渡すので CONTROL トークンは空文字にデコードされ、`nextContentTokenOrStop` は EOG で piece を追記する前に `nil` を返す。したがって部分文字列の停止パスは、**モデルがセンチネルを平文として綴った場合にしか到達しえない**。これは Gemma 固有ではなく両モデル共通で、issue が立てた「Qwen では正しく Gemma では誤り」という非対称は、実際には「どちらも正規経路では死んでいて、平文幻覚の起こりやすさに差があるだけ」に弱まる。

**列挙のキー**: 当初 `stopSequence` で列挙して7サイトを得たが、欠陥クラスのキーは `<|im_end|>` の方だった。`rg -n 'im_end'` で再列挙し、`GBNFGrammarBuilder`(Gemma 固有の荷重コメント)・`ADR-002` 2箇所・KMP ミラー2件を追加。次の読み手が再実行できるようキーをここに記録する。

**意図的に触らなかったもの**:
- `Views/ModelSelection/ModelRow.swift:229` — 架空の "Test Bare Model" 用 `#Preview` フィクスチャ。モデルへの帰属を主張していないので誤りが無い
- `ModelProfile.swift` の Sarashina の `</s>` に関するモデル固有記述 — 当該 GGUF がローカルに無く語彙を検証できないため、機構レベルの記述のみ訂正

**KMP ミラーを含めた理由**: ADR-023 §7 の言語間パリティ義務が "standing, not stage-scoped" と明記されており、`kmp-interop.md` Pattern 4 がコメント自体をパリティ成果物として扱っている。Swift だけ直すと移植先が継承する木に偽の記述が生き残る。`shared/**` の変更は KDoc のみ。

**先送り**: 切り詰め(`truncateAtChatTemplateToken`)と診断ログ(`logChatTemplateLeakage`)の ChatML ハードコードは**挙動**の穴で、記述子からセンチネルを引き回す設計判断が要る → **#1422**。ただし「偽と知りつつ残す」ことはせず、4サイト全てに #1422 へのポインタ付きで正確な記述を入れた。

## #1419 — model-eval に blocked disposition が無い

評価不能（推論に到達しなかった）な結果を `fail` として記録するしかなく、終端に読めていた。実際には2件とも再試行待ちだった。gate に第一級の第4トークンとして `blocked` を追加。

**執行の分割** — ここが設計の要点:

| 規則 | 執行者 |
|---|---|
| `unblocked_by` 必須 / `retry` 必須（ブロッカー自身の issue 可） | `append_eval.py` |
| 非 `ok` セルが最低1つ | `append_eval.py` |
| `differentiation` は ok セル0なら禁止、1つ以上なら必須 | `append_eval.py` |
| 非 `ok` セルが全て同一のシナリオ非依存原因で落ちていること | **SKILL.md の散文 — 執行者なし** |

最後の1つは帰属の判断であり `battery[].status` から導出できない。執行できるふりをせず、そう明記した。

**破棄した規則**: 当初案の「`blocked` ⇒ `ok` セル皆無」。Sarashina 2026-07-08（issue が挙げた2事例の一方）は 6セル中3セル完走しており、この規則だと同じ形状が今後**記録できなくなる** — issue が直そうとしている欠陥の再生産。典拠は `tools/harness/.../ModelProfile.swift` の `sarashina223B` doc コメント（当該 digest は gitignore で per-machine のため）。

> ⚠️ **AC 3 からの意図的な逸脱**: #1419 の受け入れ条件3は「blocked エントリは differentiation を**構造的に禁止する**」と無条件に書いている。実装は ok セルが1つ以上ある partial block では逆に**必須**にした — 3セル完走した run から測れた判断を捨てるのは、禁止規則が防ごうとしている捏造とは別の損失だから。あわせて辞退形（`PARTIAL (n/6 cells) — insufficient to differentiate`）を認可し、1セルから無理に判断を書かせる圧力を作らないようにした。**AC 文言のままでは未達に見えるので、意図的な設計判断であることをここに明記する。**

**「非 ok セル最低1つ」は実質的なガードではない**: `fail` にも非 ok セルはあるので blocked を分離しておらず、失敗行だけ記録すれば満たせる（battery の完全性は誰も検査していない）。SKILL.md では*整合性アサート*と明示し、`onboarding.md` の「機械検査される」リストからは外した。

**妥当性判断は原因と発現を区別する**: 「シナリオ非依存の原因」と書いたとき、Sarashina は「短いセルは完走、長いセルは失敗」で表面上シナリオ相関に見える。判定の勘所は「上流の1つの修正で全セルが解消するなら、発現がどう分布していても原因はシナリオ非依存」で、実際 #751 の修正で全セル解消している。SKILL.md に worked example として書いた。

**既存2件**: Gemma QAT 2026-08-08 は **retrofit**（見出しを `BLOCKED` へ、`Unblocked by` / `Retry` 追加）。Sarashina 2026-07-08 は独立エントリを持たず後続エントリ内の一節としてのみ存在するため、**明示的にグランドファザー**した。外部参照（`.claude/rules/engine.md:574`, `ADR-011.md:348`）は `§2026-08-08` と日付キーなので改題に耐えることを確認済み。

**Gate 2 は規約のみ**: `append_eval.py` は Gate 1 専用なので、実機側の blocked を検証するものは存在しない。その非対称を `onboarding.md` に明記した。

## レビュー

`code-reviewer`(Opus) を**4シャードに分割**して実行（app Swift / harness+ADR+KMP / バリデータ+テスト / docs 分類法）。合計19ファイルで `subagent-usage.md` §2 のソフト予算（~8ファイル）を超えるため。継ぎ目は各シャードが自分のファイルに関する本文段落を点検する形にした。

3周回した（上限）。1周目 Critical 3件はいずれも**私の修正コメント自体が過剰主張**だったもの — 「Gemma では空虚に真」「Gemma は決して emit しない」と書いていたが、語彙不在が塞ぐのは制御トークン経路だけで、平文経路は Gemma でも到達可能。直そうとした欠陥クラスの再生産だった。

**分割が実際に効いた例**: `ModelRegistry`（「未実証」）と `JSONResponseParser`（「Gemma は書く」）の矛盾は、シャード A と B が両側から同時に指摘したもので、単一シャードからは見えない。

3周目の Critical 3件を直した `ced0a170` はレビュー予算切れで何も通っていなかったため、追加で **`/risk-review`**（3クラスタ並列）を回した。これが**さらに Critical 2件**を検出した:

1. **「捕えるはずの統合アサーションで発火を見たことがない」が偽** — 停止が発火すると sentinel を切り落としてから返すので、あのアサーションは**発火時に通る**。観測しているのは逆側（漏れ）だった。ガードについて「捕えると主張する状態を構築して発火を確認せよ」に反する主張を、それを是正する PR の中で新規に作っていた
2. **「この診断は既定モデルでは never matches」が第1分岐で偽** — `<|im_start|>` は `stopSequence` に剥がされないので現に届く（#65 の TODO はまさにそのため）

加えて `/risk-review` は #1419 側で、**妥当性判断の文がそれを守る前例を排除している**ことを検出した（上記「原因と発現」参照）。

毎周ごとに新しい偽の主張を1つ作っていたので、最後は**パッチを重ねず削り込む**方針に切り替えた: 正典ノート 35行 → 22行、記述子キー → 形状キー（これで harness の `sarashina223B` も被覆され、支えの弱い NORMAL 型の括弧も不要になった）、支えられない経験的主張は全削除。

**掃き残し検査の方法も直した**: 3周目で使った語句 grep は、同じコミットが新設した `never matches for` を構造上捕まえられない（陽性対照の無い検査）。最終回は絶対表現・経験主張の**クラス**で grep している。

**残る未レビュー**: `f00760b2`（risk-review 対応）自体はレビューを経ていない。

## Test plan

- SwiftLint `--strict` 緑
- 単体スイート **3401 tests / 280 suites** 緑（UI テスト除く）
- harness `swift build` + `swift test` **76 tests** 緑
- `model-eval` self-test 緑。CI "Shell gate tests" **19本**をローカルで全て実行し緑
- **変異制御4本**（緑の腕は「フィクスチャについての発見」でしかないため、いずれもアンカー一致を assert した上で実施）:
  1. 非 ok セルガードを無効化 → ちょうど1本の腕だけが赤
  2. partial block を常に UNASSESSABLE 扱い → 正しい腕が赤
  3. reject 経路で journal を書き込む → journal 不変の腕が赤
  4. （失敗例として記録）無条件書き込みの変異は bootstrap 腕を先に壊し**別の理由で赤くなった**ので、reject 経路だけが書き込む形に鍵を付け直して再実施
- 掃き残し grep: `im_end` / `inert` / `never fires` / `does nothing for` / `sees nothing for` / コメント内 `file:line` 引用 — いずれも残存ゼロ

## Device QA

実機QA不要 — コメント・doc・開発ツール(`.claude/skills/**`)のみの変更で、`#if !targetEnvironment(simulator)` ブロック・Metal/llama.cpp 推論経路・レイアウトのいずれにも触れていない。

## Context-economy

- **Keep**: `LlamaCppService.stopSequence` の正典ノート（この機構は3周にわたり形を変えて誤られ続けたので、1箇所に集約して他を参照にする形が最も安い）／ SKILL.md の執行分割の表（何が機械検査され何がされないかは、次の運用者の判断を直接変える）
- **Drop**: 機構説明の各サイトへの再掲（4通りに分岐して矛盾を生んでいた → 参照に置換）／ ADR-002 の `tokenizer.chat_template` への言及（2行上と重複）／ eval-log.md の retry 連鎖の二重記載
