### PR TITLE
📝 docs: orchestrate の re-review を修正 diff 限定に（レビューラウンドのコスト圧縮）

### DIFF
--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -334,8 +334,8 @@ Subagent invocation budget is governed by `.claude/rules/subagent-usage.md` — 
 2. If the code-reviewer returns **FAIL**:
    a. Launch 1 read-only verification agent to check each FAIL item for false positives (e.g., test code flagged for force unwrap, which is exempt).
    b. Build the **Review Action Summary** (see below) and present it to the user.
-   c. Fix all confirmed issues. Skip false positives.
-   d. Re-run the `code-reviewer` subagent on the updated code.
+   c. Capture `FIX_BASE=$(git rev-parse HEAD)`, then fix all confirmed issues. Skip false positives.
+   d. Re-run the `code-reviewer` subagent **scoped to the fix diff**: prompt it with `git diff {FIX_BASE}...HEAD` (the fix commits only) plus the prior FAIL items, instructing it to verify each fix and its immediate blast radius — NOT to re-review the full branch. Fall back to a full-branch re-review only when the fixes touched files outside the set reviewed in the previous iteration.
 3. Hard limit: **3 iterations**. If still FAIL after 3, report remaining issues to the user.
 
 **Review Action Summary** (displayed after each iteration):


### PR DESCRIPTION
Step 4 の review-verify-fix ループ2周目以降が毎回ブランチ全体を再レビューして おり、多ラウンド時のレビューコストを倍増させていた（OTel 分析: 28分で
code-reviewer/critic 18回の事例）。FIX_BASE を修正前に記録し、再レビューは 修正コミットの diff + 前回 FAIL 項目に限定。修正が前回レビュー済みファイル
集合の外に及んだ場合のみ全体再レビューにフォールバック。claude-kit の
テンプレート側にも同変更を適用済み。


Claude-Session: https://claude.ai/code/session_01JbdHS4KRFAxhUcDseRGcPf