### PR TITLE
📝 docs: claude-kit のキャップ表 / Output Contract ミラーを再同期

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -10,7 +10,7 @@ You are a senior code reviewer for the Pastura iOS project (Swift 6 / SwiftUI / 
 
 ## Scope Guidance (Hard Constraint)
 
-You run under a per-response output-token cap set by the model you are invoked with (64,000 on Opus 5 / Sonnet 5; 32,000 on Haiku 4.5). Frontmatter cannot raise it — `maxOutputTokens` does not exist — though `CLAUDE_CODE_MAX_OUTPUT_TOKENS` does reach subagents. The budget below is a **review-attention** bound, not a token one, so a raised cap is not license to accept a larger scope.
+The budget below is a **review-attention** bound, not a token one — a bigger model or a raised cap is not license to accept a larger scope. Cap mechanics: `.claude/rules/subagent-usage.md` §1.
 
 - **Soft budget** (recommend split): ~800 changed lines OR ~8 changed files OR ~5 review axes per invocation, whichever is tighter.
 - **Hard split** (always split): >1500 lines, >12 files, or >7 axes — at this size review quality degrades whatever the token budget permits.

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -10,15 +10,15 @@ You are a senior code reviewer for the Pastura iOS project (Swift 6 / SwiftUI / 
 
 ## Scope Guidance (Hard Constraint)
 
-You run under a 32K output-token cap that cannot be raised by frontmatter or env var.
+You run under a per-response output-token cap set by the model you are invoked with (64,000 on Opus 5 / Sonnet 5; 32,000 on Haiku 4.5). Frontmatter cannot raise it — `maxOutputTokens` does not exist — though `CLAUDE_CODE_MAX_OUTPUT_TOKENS` does reach subagents. The budget below is a **review-attention** bound, not a token one, so a raised cap is not license to accept a larger scope.
 
 - **Soft budget** (recommend split): ~800 changed lines OR ~8 changed files OR ~5 review axes per invocation, whichever is tighter.
-- **Hard split** (always split): >1500 lines, >12 files, or >7 axes — at this size the report reliably loses its substance before the run completes.
+- **Hard split** (always split): >1500 lines, >12 files, or >7 axes — at this size review quality degrades whatever the token budget permits.
 
 **Bail-out check (mandatory, before any other tool_use):** Run `git diff <base>...HEAD --stat` (or equivalent) as the very first tool call. If the diff exceeds the soft budget, respond with a single line and stop:
 
 ```
-SCOPE_TOO_LARGE: <X lines / Y files> exceeds soft budget. Please split into <suggested partitions>. See .claude/rules/subagent-usage.md for Sonnet-override constraints.
+SCOPE_TOO_LARGE: <X lines / Y files> exceeds soft budget. Please split into <suggested partitions>. See .claude/rules/subagent-usage.md §2 for the split budget.
 ```
 
 Do NOT begin the Read / Grep cycle after this point — every subsequent tool_use consumes the budget the report body needs. Your Verdict is cheap and comes first; what runs out is the room to substantiate it.

--- a/.claude/rules/automation-output-contract.md
+++ b/.claude/rules/automation-output-contract.md
@@ -42,8 +42,9 @@ nothing of theirs reaches the review queue this contract rations.
    Draft PR.
 2. **Judgment-needed → issue only, never an auto-fix.** Anything whose fix requires a human
    decision is filed as an issue whose body carries a **confidence score** and an explicit
-   **counter-evidence / "why this might be wrong"** section. This applies to every judgment output
-   a generator emits, including recommendations to discard work.
+   **counter-evidence / "why this might be wrong"** section — both produced back at detection, not
+   composed at filing time (rule 6). This applies to every judgment output a generator emits,
+   including recommendations to discard work.
 3. **The auto-fix path edits authoritative-source-computed values only — never free-form prose —
    and splices at the detected token's exact offset, not by free-text replace.** This bound is what
    makes omitting a code-review pass safe (see below). A detector that wants to auto-fix something
@@ -58,11 +59,73 @@ nothing of theirs reaches the review queue this contract rations.
 5. **Manual-first.** Detectors run dry-run by default. Trust the output only after a human has
    eyeballed it for a given repo state — and never let a skill self-register its own schedule;
    scheduling is a separate, deliberate human act.
-6. **Conservative detection wins.** Prefer a miss over a wrong flag. A wrong auto-fix PR, a false
-   issue, a wrong "ready to merge" (which a human may rubber-stamp), or a wrong "discard this"
-   (which destroys queued work) all cost more than a missed finding — they spend reviewer attention
-   *and* erode trust in the generator; a miss only defers work. When evidence is short of decisive,
-   route to the human-judgment bucket rather than up to "ready" or down to "discard".
+6. **Conservative *output*, exhaustive detection — filter at the output stage and account for the
+   drops.** **Changed 2026-08-12**: this rule used to read *"Conservative detection wins. Prefer a
+   miss over a wrong flag"*, putting the filter in the **detection** stage. The precision bias stays
+   — a wrong auto-fix PR, a false issue, a wrong "ready to merge" (which a human may rubber-stamp),
+   or a wrong "discard this" (which destroys queued work) each spend reviewer attention *and* erode
+   trust in the generator, while a miss only defers work. What it must **not** do is move upstream
+   into the detector (§ Why detection must not self-filter). Split the pass in two:
+   - **Detection is for coverage — do not filter here.** Enumerate every candidate; anything routing
+     to rule 2 carries a **confidence**, an **estimated severity** and a **counter-evidence** line
+     from the moment it is found, so the output stage has a rank key and rule 2's fields are the
+     detector's finding rather than an afterthought at filing time. (Rule 1's mechanical lane needs
+     none of them — its value has exactly one correct answer.) A model-driven detector nearing its
+     coverage ceiling **stops and says so** rather than truncating quietly. The only legitimate
+     suppression here is **mechanical**, and each form owes a count of what it removed:
+     - an enumerated **by-design / do-not-flag roster**, handed to the detector verbatim;
+     - an **evidence precondition** — no exact anchor, no concrete before → after ⇒ not a finding;
+     - a **quota**, meaning *rank-then-truncate over an already-enumerated list* — never a cap on
+       generating candidates: a cap that stops the search cannot name what it excluded, and it
+       reduces `found` in the arithmetic below to the cap itself.
+
+     A deterministic detector — a script, not a model — may hold its predicate in code, reviewable
+     at source; that exempts it from the ban on judgment, not from the count. Pastura's one
+     instance is `.claude/skills/consistency-audit/scripts/audit_docs.py`. A near-miss tally is the
+     cheapest evidence there is that a bar sits too tight.
+   - **The output stage filters, conservatively, and leaves a trail.** Vet, dedup and rank here;
+     when evidence is short of decisive, route to the human-judgment bucket rather than up to
+     "ready" or down to "discard". Publish the arithmetic — **found / filtered / deduped /
+     surfaced**, plus whatever was capped or never reached — into a channel the run already writes;
+     never mint an artifact just to carry it. Keep each rejection and its reason where the *next* run
+     can see it. **The medium is project-owned and already differs by generator**: `code-health-audit`
+     uses a local ledger, `consistency-audit` its open-issue set, and `triage-guardian` — which
+     deliberately writes nothing — its run log. A generator that rejects nothing owes nothing. An
+     uncounted drop is indistinguishable from a finding never made: the next run re-derives it, drops
+     it again, and nobody learns the filter is too tight.
+
+**Generator bodies still carrying the pre-2026-08-12 wording** are tracked in
+[#1432](https://github.com/tyabu12/pastura/issues/1432) (`consistency-audit` hard rule 4;
+`ui-refine`'s generation-side quota). Until that lands this rule is the canonical text and their
+duplicates are stale — reconcile them, do not follow them.
+
+### Why detection must not self-filter
+
+Rule 6's split is a model-behaviour fact, not a style preference, and it is recent. Claude 5-series
+models apply a filtering instruction literally. **Sonnet 5's guide, § "Code review harnesses"**, on
+a review prompt that says *"only report high-severity issues"* or *"be conservative"*: the model
+"may investigate the code just as thoroughly, identify the bugs, and then not report findings it
+judges to be below your stated bar. […] Precision typically rises, but measured recall can fall even
+though the model's underlying bug-finding ability has improved." (`[…]` elides one intervening
+sentence.) That section's recommended finding-stage prompt instead asks for coverage, and for "your
+confidence level and an estimated severity so a downstream filter can rank them" — two of the three
+fields rule 6 requires at detection; counter-evidence is this contract's addition, because rule 2
+files on it. **Opus 5's guide** ("Code review and bug-finding") gives the remedy in one line: "ask
+it to report everything and filter in a separate pass instead."
+
+The loss is **invisible** — three surfaced findings look the same whether the detector found three
+or thirty — and it is worst on a harness carried over from an older model, where the conservative
+wording once bought a genuinely shallower pass. A generator that truly has only one pass takes the
+guides' fallback: state the bar as a concrete predicate (their example: any bug that could cause
+incorrect behavior, a test failure, or a misleading result, omitting only nits like pure style or
+naming), never as a qualitative "important".
+
+Verified 2026-08-12 against
+[prompting-claude-opus-5](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-opus-5.md)
+and
+[prompting-claude-sonnet-5](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-sonnet-5.md).
+**This block is dated on purpose** — re-check on a model-generation change: the rule survives a
+stale citation, the citation should not outlive its generation unnoticed.
 
 ### Why an auto-fix PR may skip a code-review pass
 
@@ -87,6 +150,16 @@ open Draft" assumes a single writer; two overlapping runs can each observe zero 
 Either serialize runs (never schedule a generator so it can overlap itself) or re-check after
 acting — push the branch, re-query for a sibling, and abandon without opening a PR if one won the
 race.
+
+**The judgment lane is the one nothing here bounds.** Both caps count open Draft PRs; rule 2's
+issues are outside that accounting, and rule 6's exhaustive detection lands its increment precisely
+there. Cap issues per run as well — the number is project-owned by the same test that makes the
+ceiling project-owned: it rests on one maintainer's review attention, which differs per repo and per
+maintainer, so it is *retuned* here rather than recomputed from anything upstream. **Pastura has not
+set it yet**: choosing the value and wiring it into the generators is
+[#1432](https://github.com/tyabu12/pastura/issues/1432). Until then the judgment lane has no
+mechanical bound, so a run that would file an unusual number of issues should stop and report
+instead.
 
 **The ceiling value (`AUTOMATION_WIP_CEILING`) and the branch predicate that identifies
 automation-origin PRs are project-owned and canonical in

--- a/.claude/rules/automation-output-contract.md
+++ b/.claude/rules/automation-output-contract.md
@@ -153,13 +153,10 @@ race.
 
 **The judgment lane is the one nothing here bounds.** Both caps count open Draft PRs; rule 2's
 issues are outside that accounting, and rule 6's exhaustive detection lands its increment precisely
-there. Cap issues per run as well — the number is project-owned by the same test that makes the
-ceiling project-owned: it rests on one maintainer's review attention, which differs per repo and per
-maintainer, so it is *retuned* here rather than recomputed from anything upstream. **Pastura has not
-set it yet**: choosing the value and wiring it into the generators is
-[#1432](https://github.com/tyabu12/pastura/issues/1432). Until then the judgment lane has no
-mechanical bound, so a run that would file an unusual number of issues should stop and report
-instead.
+there. Cap issues per run as well — the number is project-owned by the same test as the ceiling: it
+rests on one maintainer's review attention, so it is *retuned* per repo, never recomputed from
+upstream. **Pastura has not set one** — until it is set, a run that would file an unusual number of
+issues stops and reports instead.
 
 **The ceiling value (`AUTOMATION_WIP_CEILING`) and the branch predicate that identifies
 automation-origin PRs are project-owned and canonical in

--- a/.claude/rules/context-budget.md
+++ b/.claude/rules/context-budget.md
@@ -11,12 +11,12 @@ loading-mode rationale. This rule applies to itself. Pairs with `knowledge-layer
 
 Always-loaded files (loaded into every agent session / invocation) — every line is paid on every turn:
 
-- `~/.claude/CLAUDE.md` and `~/.claude/rules/*.md` **without** `paths:` frontmatter (global — per-user, but charged to *this* project's every session too)
+- `~/.claude/CLAUDE.md` and `~/.claude/rules/*.md` **without** `paths:` frontmatter (global — per-user, yet charged to *this* project's every session)
 - `CLAUDE.md` (project top-level) and `.claude/rules/*.md` **without** `paths:`
 - `~/.claude/agents/*.md` and project `.claude/agents/*.md`
 
-The global tier is easy to forget precisely because it is not in this repo. It is charged all the
-same, and a global file that duplicates a project file of the same name is paid twice.
+The global tier is easy to forget because it is not in this repo — and a global file duplicating a
+project file of the same name is paid **twice**.
 
 Path-scoped files (`paths:` frontmatter) load only when a matching path is read — budget looser there.
 

--- a/.claude/rules/context-budget.md
+++ b/.claude/rules/context-budget.md
@@ -9,11 +9,14 @@ loading-mode rationale. This rule applies to itself. Pairs with `knowledge-layer
 
 ## Scope
 
-Always-loaded files (loaded into every agent session / invocation):
+Always-loaded files (loaded into every agent session / invocation) — every line is paid on every turn:
 
-- `CLAUDE.md` (project top-level)
-- `.claude/rules/*.md` **without** `paths:` frontmatter
-- `.claude/agents/*.md`
+- `~/.claude/CLAUDE.md` and `~/.claude/rules/*.md` **without** `paths:` frontmatter (global — per-user, but charged to *this* project's every session too)
+- `CLAUDE.md` (project top-level) and `.claude/rules/*.md` **without** `paths:`
+- `~/.claude/agents/*.md` and project `.claude/agents/*.md`
+
+The global tier is easy to forget precisely because it is not in this repo. It is charged all the
+same, and a global file that duplicates a project file of the same name is paid twice.
 
 Path-scoped files (`paths:` frontmatter) load only when a matching path is read — budget looser there.
 

--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -8,21 +8,26 @@ Always-loaded — see `CLAUDE.md` `## Context-Specific Rules`. Pairs with `conte
 
 ## Where knowledge belongs
 
-Knowledge can live in 4 places. Choose by **who needs to read it** and **how stable it is**:
+Knowledge can live in 5 places. Choose by **who needs to read it** and **how stable it is**:
 
 | Location | Audience | Edit cycle |
 |---|---|---|
 | `~/.claude/projects/.../memory/` | This user, this machine | Per-session writable by Claude |
+| `~/.claude/CLAUDE.md` + `~/.claude/rules/*.md` | This user, **every project** on this machine | Hand-edited in dotfiles, versioned |
 | `CLAUDE.md` | All contributors, every session | PR-reviewed |
 | `.claude/rules/*.md` | All contributors, scoped sessions | PR-reviewed |
 | `docs/**` | All contributors, on-demand reading | PR-reviewed |
 
-Memory `feedback_*` / `project_*` / `reference_*` entries belong in `.claude/rules/` (path-scoped if domain-specific) or `CLAUDE.md` (project-wide) when the lesson is **non-obvious and won't be re-derived**. Memory `user_*` always stays in memory.
+Memory `feedback_*` / `project_*` / `reference_*` entries belong in a rules file when the lesson is **non-obvious and won't be re-derived**. Memory `user_*` always stays in memory.
 
 **Quick test before saving a memory**: *"Would a new contributor with no prior context reliably arrive at the same advice from first principles?"*
 
 - **Yes** → memory (rapid-capture only — the lesson is derivable from code / docs / tooling on demand)
-- **No** → `.claude/rules/` or `CLAUDE.md` (the advice is non-obvious and needs to be loaded into context to fire correctly)
+- **No** → a rules file. **Then pick the tier by audience**, which is the branch this copy used to omit:
+  - a lesson true across *all my projects* (a tool's quirk, a personal workflow rule) → **global `~/.claude/rules/`**, not this repo. Writing it here makes every other project re-derive it, and burdens Pastura contributors with a rule that is not about Pastura.
+  - a lesson specific to *this project* → Pastura's `.claude/rules/` (path-scoped if domain-specific), or `CLAUDE.md` when it is project-wide.
+
+  A global rule **adds** a personal baseline; it never **replaces** what a shared repo must carry itself — see § "Anti-pattern" below.
 
 **User-preference carve-out**: feedback flavored as personal preference (e.g., "this user wants critic limited to 2/PR") stays in memory regardless of Pastura-specificity — it's `user_*`-flavored even when the trigger event was project work.
 

--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -23,11 +23,11 @@ Memory `feedback_*` / `project_*` / `reference_*` entries belong in a rules file
 **Quick test before saving a memory**: *"Would a new contributor with no prior context reliably arrive at the same advice from first principles?"*
 
 - **Yes** → memory (rapid-capture only — the lesson is derivable from code / docs / tooling on demand)
-- **No** → a rules file. **Then pick the tier by audience**, which is the branch this copy used to omit:
-  - a lesson true across *all my projects* (a tool's quirk, a personal workflow rule) → **global `~/.claude/rules/`**, not this repo. Writing it here makes every other project re-derive it, and burdens Pastura contributors with a rule that is not about Pastura.
+- **No** → a rules file. **Then pick the tier by audience**:
+  - a lesson true across *all my projects* (a tool's quirk, a personal workflow rule) → **global `~/.claude/rules/`**, not this repo — writing it here burdens Pastura contributors with a rule that is not about Pastura.
   - a lesson specific to *this project* → Pastura's `.claude/rules/` (path-scoped if domain-specific), or `CLAUDE.md` when it is project-wide.
 
-  A global rule **adds** a personal baseline; it never **replaces** what a shared repo must carry itself — see § "Anti-pattern" below.
+  A global rule **adds** a personal baseline, never **replaces** what a shared repo must carry — § "Anti-pattern" below.
 
 **User-preference carve-out**: feedback flavored as personal preference (e.g., "this user wants critic limited to 2/PR") stays in memory regardless of Pastura-specificity — it's `user_*`-flavored even when the trigger event was project work.
 

--- a/.claude/rules/subagent-usage.md
+++ b/.claude/rules/subagent-usage.md
@@ -53,8 +53,11 @@ that number. Tracked upstream in
 [anthropics/claude-code#24055](https://github.com/anthropics/claude-code/issues/24055) (OPEN).
 
 **Model pins in this repo**: `code-reviewer.md` keeps `model: opus`
-deliberately — §2 / §4 are calibrated for Opus-class review judgement, not for
-a token budget. The kit-provided `claude-kit:critic` carries no pin, so callers
+deliberately — for Opus-class review *judgement*, not for a token budget. §2's
+numbers are model-independent, so the pin buys the quality of the reading, not
+the size of the budget. `fable` is likewise a valid `Agent(model:)` / frontmatter
+alias: a quality lever, never a budget one.
+The kit-provided `claude-kit:critic` carries no pin, so callers
 pass `model: opus` explicitly (as `/orchestrate` Step 1b does). Skills omit
 `model:` and inherit the session model (a pin would downgrade the main loop;
 re-pin only if the session model ever drops below Opus-class).
@@ -127,8 +130,8 @@ escape valve no longer exists. Pick the model for **capability and cost**,
 never to escape a budget. The one budget-relevant asymmetry is **Haiku at
 half** (32,000): do not hand it a report-heavy task on the assumption every
 model carries the same load. When work genuinely needs more room than the model
-has, **split the scope** — or raise `CLAUDE_CODE_MAX_OUTPUT_TOKENS` (§1), which
-is the only real budget lever and does reach subagents.
+has, **split the scope**. Raising `CLAUDE_CODE_MAX_OUTPUT_TOKENS` (§1) buys
+tokens, not attention, and is never a substitute for splitting.
 
 A cost-driven downgrade is still bounded by the same sensitivity rules
 `/orchestrate` applies:

--- a/.claude/rules/subagent-usage.md
+++ b/.claude/rules/subagent-usage.md
@@ -2,9 +2,12 @@
 
 > Derived from [claude-kit](https://github.com/tyabu12/claude-kit) `rules/subagent-usage.md` —
 > the generic core is canonical there; reconcile one-way (kit → Pastura). Everything numeric — the
-> cap table, the `#24055` status, the 800/8/5 and 1500/12/7 split thresholds — is kit-canonical:
-> the thresholds are *derived* from the cap table (smallest practical budget, prose-dense report),
-> so they are recomputed upstream, never retuned here. The one lever a caller controls is report
+> cap table, the `#24055` status, the 800/8/5 and 1500/12/7 split thresholds — is kit-canonical, but
+> two kinds of number live here and they age differently. The **cap table** is Claude Code's
+> platform limit: recomputed when the platform changes, never retuned. The **split thresholds** are
+> a *review-attention* bound and are **NOT** cap-derived — they rest on a *subagent's* attention at
+> a given scope, identical for everyone who installs the kit, so they are revised on review-quality
+> evidence and never by recomputing when a cap moves (§2). The one lever a caller controls is report
 > density per changed line — generated fixtures report far shorter than dense source — and it
 > licenses bounding a call **tighter at the call site, never looser**: split smaller rather than
 > edit §2's numbers or any agent copy of them (today `.claude/agents/code-reviewer.md`).
@@ -17,64 +20,88 @@ this rule must stay visible regardless of which file is being edited.
 
 ## 1. Background
 
-Claude Code subagents (anything launched via the `Agent` tool, including
-custom `code-reviewer` / `claude-kit:critic` / `Explore` / `Plan`) run under a hard
-**output-token cap**. The cap is NOT configurable via frontmatter
-(`maxOutputTokens` does not exist) nor via `CLAUDE_CODE_MAX_OUTPUT_TOKENS`
-(env var applies only to the main session, not subagent API calls).
+Every subagent (anything launched via the `Agent` tool, including custom
+`code-reviewer` / `claude-kit:critic` / `Explore` / `Plan`) runs under an
+**output-token cap per response**. It is the *model's* cap, not a
+subagent-specific one: the request builder has no main/subagent branch and the
+`Agent` tool passes no override. Raising frontmatter `maxTurns` does not help —
+the cap is per response, not per run — and `maxOutputTokens` does not exist as
+a frontmatter key.
 
-Tracked upstream in [anthropics/claude-code#24055](https://github.com/anthropics/claude-code/issues/24055) (OPEN) — revalidate the heuristics below when it ships.
+| Model | Cap | Ceiling via `CLAUDE_CODE_MAX_OUTPUT_TOKENS` |
+|-------|-----|---------------------------------------------|
+| Opus 5 | **64,000** | 128,000 † |
+| Sonnet 5 | **64,000** | 128,000 † |
+| Fable 5 | **64,000** † | 128,000 † |
+| Haiku 4.5 | **32,000** | 64,000 † |
 
-Per-model output cap:
+Measured 2026-08-12 on Claude Code **2.1.228**. Pre-5 generations vary either
+way — Opus 4.6-4.8 also sat at 64,000, Sonnet 4.x at 32,000, Haiku 3.5 at
+8,192 — so **do not extrapolate backwards**. **† = read from the shipped model
+catalog, not behaviourally verified**; only the unmarked caps were observed in
+a live run. Read any model's live cap in about two seconds, without having to
+provoke a truncation:
 
-| Model | Max output tokens |
-|-------|-------------------|
-| Opus 4.x | **32,000** |
-| Sonnet 4.x / 5 | **64,000** |
-| Haiku 4.x | 8,192 |
-| Fable 5 | **undocumented** — see note below |
+```sh
+claude -p --model opus --output-format json "ok" | jq '.modelUsage[].maxOutputTokens'
+```
 
-Raising frontmatter `maxTurns` does not help — the cap is on output tokens, not turns.
+`CLAUDE_CODE_MAX_OUTPUT_TOKENS` is the only real budget lever, and it **does**
+reach subagents — contrary to what this rule claimed before, and confirmed by
+forcing it to 1,200 and finding the subagent's own responses capped at exactly
+that number. Tracked upstream in
+[anthropics/claude-code#24055](https://github.com/anthropics/claude-code/issues/24055) (OPEN).
 
-**Fable 5 note**: `fable` is a valid `Agent(model:)` / frontmatter
-alias, but its subagent cap is undocumented (2026-06-11) — treat a
-`fable` override as a quality lever; Sonnet 64K stays the only known
-**budget** escape valve (§3). `code-reviewer.md` keeps `model: opus`
-deliberately (§2 / §4 are 32K-calibrated); the kit-provided
-`claude-kit:critic` carries no pin, so callers pass `model: opus`
-explicitly (as `/orchestrate` Step 1b does). Skills omit
-`model:` and inherit the session model (a pin would downgrade the main
-loop; re-pin only if the session model ever drops below Opus-class).
+**Model pins in this repo**: `code-reviewer.md` keeps `model: opus`
+deliberately — §2 / §4 are calibrated for Opus-class review judgement, not for
+a token budget. The kit-provided `claude-kit:critic` carries no pin, so callers
+pass `model: opus` explicitly (as `/orchestrate` Step 1b does). Skills omit
+`model:` and inherit the session model (a pin would downgrade the main loop;
+re-pin only if the session model ever drops below Opus-class).
 Docs: [sub-agents](https://code.claude.com/docs/en/sub-agents.md),
 [model-config](https://code.claude.com/docs/en/model-config.md).
 
 ## 2. Caller-side scope discipline
 
-When invoking a subagent, bound the work so the final report fits the
-budget (derived — tighten at the call site, don't edit; see the header):
+When invoking a subagent, bound the work so the reviewer's **attention** holds
+— not so the report fits the cap; at these sizes it fits comfortably:
 
 - **Soft budget** (split if over): ~800 changed lines OR ~8 changed
   files OR ~5 review axes per invocation, whichever is tighter.
 - **Hard split** (always split): >1500 changed lines, >12 files, or
-  >7 axes — at this size the report reliably loses its substance
-  before the run completes.
+  >7 axes — at this size review quality degrades whatever the token
+  budget permits.
 
-When numbers fall between soft and hard, prefer splitting. If splitting
-is impractical, see **§3. Sonnet override**.
+When numbers fall between soft and hard, prefer splitting. Model choice is no
+escape from an over-scoped call — see **§3**.
+
+### Why the thresholds are not cap-derived
+
+They used to be, pinned to a cap no spawnable model ever had. The cap was never
+the binding constraint at these scopes; what they buy is **review attention**,
+which does not scale with a model's `max_tokens`. So revise them on
+review-quality evidence, **not** by recomputing when a cap moves — a cap-table
+update (§1) must leave the numbers above untouched.
 
 **A split leaves a seam no shard owns.** Each invocation sees only its own
 slice, so anything spanning the split — a mirrored count, a cross-reference,
 a claim one shard makes about another's files — is unreviewed by
 construction. Name the seam's owner, or add a final pass over the whole.
 
-**What exhaustion looks like.** *Not* a missing summary: review agents
-are built to emit their verdict/summary **first** under cap pressure, so
-it survives exactly when the run is truncated. Look instead for **detail
-missing behind a present summary**, which is mechanically checkable as a
-**count mismatch** — the summary claims more issues, axes, or findings
-than the body actually writes out, or names them with no evidence
-attached. Corroborate with intermediate tool output present and no
-`SCOPE_TOO_LARGE`. That combination is the signal to **split and
+**What a cap hit looks like.** It is **no longer silent**: Claude Code detects
+`stop_reason: max_tokens`, nudges the agent to resume, and retries up to
+**3** times before surfacing an `API Error: … exceeded the N output token
+maximum.` The report usually survives with a **seam** where the cut happened —
+but if every resume also overflows, the run fails outright with that error and
+returns nothing.
+
+The tell is *not* a missing summary: review agents are built to emit their
+verdict/summary **first** under cap pressure, so it survives exactly when the
+run is truncated. Look instead for **detail missing behind a present summary**,
+which is mechanically checkable as a **count mismatch** — the summary claims
+more issues, axes, or findings than the body actually writes out, or names them
+with no evidence attached. Corroborate with intermediate tool output present
+and no `SCOPE_TOO_LARGE`. That combination is the signal to **split and
 re-run** — a report that is short *and internally consistent* is just
 short, and needs nothing. In Pastura the check is arithmetic rather than
 a prose judgement: `code-reviewer`'s summary emits per-severity counts
@@ -92,10 +119,19 @@ zero-issue report truncated right after it reads as consistent. Closing
 that needs a structural check against a pinned Output Format — see
 `queue-consumer` hard rule 6, which carries one for the unattended path.
 
-## 3. Sonnet override (escape valve)
+## 3. Model choice is a cost lever, not a budget lever
 
-`Agent(model: "sonnet")` overrides the agent's frontmatter `model: opus`
-default and unlocks the 64K Sonnet budget. Use sparingly:
+`Agent(model: "sonnet")` no longer buys headroom — Opus 5 and Sonnet 5 are
+both **64,000** — so the "Sonnet override" that used to sit here as a budget
+escape valve no longer exists. Pick the model for **capability and cost**,
+never to escape a budget. The one budget-relevant asymmetry is **Haiku at
+half** (32,000): do not hand it a report-heavy task on the assumption every
+model carries the same load. When work genuinely needs more room than the model
+has, **split the scope** — or raise `CLAUDE_CODE_MAX_OUTPUT_TOKENS` (§1), which
+is the only real budget lever and does reach subagents.
+
+A cost-driven downgrade is still bounded by the same sensitivity rules
+`/orchestrate` applies:
 
 - **Acceptable**: scope-bound mechanical-checklist work that orchestrate's
   Coupling rule does NOT mark Opus-required. Example: a code review
@@ -108,8 +144,8 @@ default and unlocks the 64K Sonnet budget. Use sparingly:
   `claude-kit:critic` plugin agent — invoke it by that namespaced name):
   `critic` makes judgement calls
   (pre-mortem axis generation, bias rebuttal). For plan critique on
-  architectural decisions, prefer **Opus + scope-split** over Sonnet
-  override. Sonnet's reasoning depth is acceptable for routine
+  architectural decisions, prefer **Opus + scope-split** over a cheaper
+  model. Sonnet's reasoning depth is acceptable for routine
   reviews but not for the cases where `critic` is most valuable.
 
 ## 4. Agent self-defense
@@ -119,8 +155,8 @@ with `SCOPE_TOO_LARGE` before any tool_use when the soft budget is
 exceeded. The kit-provided `claude-kit:critic` self-defends differently
 (its `Output Discipline & Scope` section triages: highest-risk axes
 first, explicit deferrals instead of a bail-out). Defense in depth:
-budget exhaustion is silent, so duplicating §2's budget in the agents'
-own bail-out is intentional.
+a cap hit usually shows up as nothing louder than a seam mid-report, so
+duplicating §2's budget in the agents' own bail-out is intentional.
 For what exhaustion actually looks like, see §2 — the detector lives
 there, with the caller-side heuristics it corroborates.
 

--- a/.claude/rules/subagent-usage.md
+++ b/.claude/rules/subagent-usage.md
@@ -3,14 +3,13 @@
 > Derived from [claude-kit](https://github.com/tyabu12/claude-kit) `rules/subagent-usage.md` —
 > the generic core is canonical there; reconcile one-way (kit → Pastura). Everything numeric — the
 > cap table, the `#24055` status, the 800/8/5 and 1500/12/7 split thresholds — is kit-canonical, but
-> two kinds of number live here and they age differently. The **cap table** is Claude Code's
-> platform limit: recomputed when the platform changes, never retuned. The **split thresholds** are
-> a *review-attention* bound and are **NOT** cap-derived — they rest on a *subagent's* attention at
-> a given scope, identical for everyone who installs the kit, so they are revised on review-quality
-> evidence and never by recomputing when a cap moves (§2). The one lever a caller controls is report
-> density per changed line — generated fixtures report far shorter than dense source — and it
-> licenses bounding a call **tighter at the call site, never looser**: split smaller rather than
-> edit §2's numbers or any agent copy of them (today `.claude/agents/code-reviewer.md`).
+> the two kinds age differently. The **cap table** is Claude Code's platform limit — recomputed on
+> upgrade, never retuned (§1). The **split thresholds** are a *review-attention* bound, **NOT**
+> cap-derived (§2): they rest on a *subagent's* attention at a given scope — identical for every kit
+> installation — so a cap move never retunes them. The one lever a caller controls is report density
+> per changed line — generated fixtures report far shorter than dense source — and it licenses
+> bounding a call **tighter at the call site, never looser**: split smaller rather than edit §2's
+> numbers or any agent copy of them (today `.claude/agents/code-reviewer.md`).
 > Pastura-specific content lives only in this copy.
 
 Always-loaded — see `CLAUDE.md` `## Context-Specific Rules` for the
@@ -53,14 +52,13 @@ that number. Tracked upstream in
 [anthropics/claude-code#24055](https://github.com/anthropics/claude-code/issues/24055) (OPEN).
 
 **Model pins in this repo**: `code-reviewer.md` keeps `model: opus`
-deliberately — for Opus-class review *judgement*, not for a token budget. §2's
-numbers are model-independent, so the pin buys the quality of the reading, not
-the size of the budget. The kit-provided `claude-kit:critic` carries no pin, so
-callers pass `model: opus` explicitly (as `/orchestrate` Step 1b does). `fable`
-is a valid `Agent(model:)` / frontmatter value too — also a quality lever, never
-a budget one. Skills omit `model:` and inherit the session model (a pin would
-downgrade the main loop; re-pin only if the session model ever drops below
-Opus-class).
+deliberately — for Opus-class review *judgement*, not for a token budget (§2's
+numbers are model-independent). The kit-provided `claude-kit:critic` carries no
+pin, so callers pass `model: opus` explicitly (as `/orchestrate` Step 1b does).
+`fable` is a valid `Agent(model:)` / frontmatter value too — also a quality
+lever, never a budget one. Skills omit `model:` and inherit the session model (a
+pin would downgrade the main loop; re-pin only if the session model ever drops
+below Opus-class).
 Docs: [sub-agents](https://code.claude.com/docs/en/sub-agents.md),
 [model-config](https://code.claude.com/docs/en/model-config.md).
 

--- a/.claude/rules/subagent-usage.md
+++ b/.claude/rules/subagent-usage.md
@@ -55,12 +55,12 @@ that number. Tracked upstream in
 **Model pins in this repo**: `code-reviewer.md` keeps `model: opus`
 deliberately — for Opus-class review *judgement*, not for a token budget. §2's
 numbers are model-independent, so the pin buys the quality of the reading, not
-the size of the budget. `fable` is likewise a valid `Agent(model:)` / frontmatter
-alias: a quality lever, never a budget one.
-The kit-provided `claude-kit:critic` carries no pin, so callers
-pass `model: opus` explicitly (as `/orchestrate` Step 1b does). Skills omit
-`model:` and inherit the session model (a pin would downgrade the main loop;
-re-pin only if the session model ever drops below Opus-class).
+the size of the budget. The kit-provided `claude-kit:critic` carries no pin, so
+callers pass `model: opus` explicitly (as `/orchestrate` Step 1b does). `fable`
+is a valid `Agent(model:)` / frontmatter value too — also a quality lever, never
+a budget one. Skills omit `model:` and inherit the session model (a pin would
+downgrade the main loop; re-pin only if the session model ever drops below
+Opus-class).
 Docs: [sub-agents](https://code.claude.com/docs/en/sub-agents.md),
 [model-config](https://code.claude.com/docs/en/model-config.md).
 

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -250,7 +250,7 @@ For each unit of work (let `K` = the current plan item number), check the item's
 
 Launch a subagent via `Agent(model: "sonnet")` **without `isolation`** (shares the orchestrator's worktree). Subagents execute **sequentially, one at a time** — never in parallel. The subagent should have access to: `Read, Grep, Glob, Bash, Write, Edit` — do NOT include `EnterWorktree` or `ExitWorktree`.
 
-Subagent invocation budget is governed by `.claude/rules/subagent-usage.md` — bound delegated items per its soft-budget heuristics. The budget is a *review-attention* bound, not a token one: the output cap is the model's (64,000 on Opus 5 / Sonnet 5), and the report fits comfortably at these scopes.
+Subagent invocation budget is governed by `.claude/rules/subagent-usage.md` — bound delegated items per its soft-budget heuristics.
 
 > **Agent prompt template:**
 >
@@ -325,7 +325,7 @@ Agent(subagent_type: "code-reviewer", model: "$REVIEWER_MODEL", description: "..
 
 `$REVIEWER_MODEL` is the lowercase form (`opus` / `sonnet`) bound at Step 0 / Step 1 — the surrounding quotes match the Step 3 Sonnet-delegation convention (`Agent(model: "sonnet")`).
 
-Subagent invocation budget is governed by `.claude/rules/subagent-usage.md` — large PR diffs may need splitting (per axis or per area) to avoid `SCOPE_TOO_LARGE` early returns from the reviewer. **Splitting is the only remedy**: a cheaper model buys no headroom (Opus 5 and Sonnet 5 are both 64,000), so never downgrade `REVIEWER_MODEL` to fit a diff.
+Subagent invocation budget is governed by `.claude/rules/subagent-usage.md` — large PR diffs may need splitting (per axis or per area) to avoid `SCOPE_TOO_LARGE` early returns from the reviewer. **Splitting is the only remedy** — a cheaper model buys no headroom (§3 there), so never downgrade `REVIEWER_MODEL` to fit a diff.
 
 > **Agent prompt:** "Review all code changes on this feature branch. Run `git diff {DEFAULT_BRANCH}...HEAD` to see the full diff (all commits since branching, not just uncommitted changes). Read every changed file in full for context. Evaluate against your complete checklist (Hard Rules, Dependency Rules, Access Modifiers, Swift 6 Concurrency, Code Quality). Output your review in your standard format."
 

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -250,7 +250,7 @@ For each unit of work (let `K` = the current plan item number), check the item's
 
 Launch a subagent via `Agent(model: "sonnet")` **without `isolation`** (shares the orchestrator's worktree). Subagents execute **sequentially, one at a time** — never in parallel. The subagent should have access to: `Read, Grep, Glob, Bash, Write, Edit` — do NOT include `EnterWorktree` or `ExitWorktree`.
 
-Subagent invocation budget is governed by `.claude/rules/subagent-usage.md` — bound delegated items per its soft-budget heuristics so the subagent's investigation + final commit message fit the 32K output cap.
+Subagent invocation budget is governed by `.claude/rules/subagent-usage.md` — bound delegated items per its soft-budget heuristics. The budget is a *review-attention* bound, not a token one: the output cap is the model's (64,000 on Opus 5 / Sonnet 5), and the report fits comfortably at these scopes.
 
 > **Agent prompt template:**
 >
@@ -325,7 +325,7 @@ Agent(subagent_type: "code-reviewer", model: "$REVIEWER_MODEL", description: "..
 
 `$REVIEWER_MODEL` is the lowercase form (`opus` / `sonnet`) bound at Step 0 / Step 1 — the surrounding quotes match the Step 3 Sonnet-delegation convention (`Agent(model: "sonnet")`).
 
-Subagent invocation budget is governed by `.claude/rules/subagent-usage.md` — large PR diffs may need splitting (per axis or per area) or Sonnet override (where the Coupling rule allows) to avoid `SCOPE_TOO_LARGE` early returns from the reviewer.
+Subagent invocation budget is governed by `.claude/rules/subagent-usage.md` — large PR diffs may need splitting (per axis or per area) to avoid `SCOPE_TOO_LARGE` early returns from the reviewer. **Splitting is the only remedy**: a cheaper model buys no headroom (Opus 5 and Sonnet 5 are both 64,000), so never downgrade `REVIEWER_MODEL` to fit a diff.
 
 > **Agent prompt:** "Review all code changes on this feature branch. Run `git diff {DEFAULT_BRANCH}...HEAD` to see the full diff (all commits since branching, not just uncommitted changes). Read every changed file in full for context. Evaluate against your complete checklist (Hard Rules, Dependency Rules, Access Modifiers, Swift 6 Concurrency, Code Quality). Output your review in your standard format."
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,7 +282,7 @@ Update with `/plugin`. Install steps: CONTRIBUTING.md § "If you use Claude Code
 
 - `swift-isolation.md` — `nonisolated` annotation traps under default-MainActor isolation. Always-loaded because the diagnostic fires at the use site, not the declaration — and the silent runtime-trap patterns fire none at all.
 - `xcodebuild-cli.md` — xcodebuild CLI playbook (test commands, DerivedData layout, timeout/recovery). Always-loaded because the gotchas surface during worktree switches and CI debugging, not only when editing tests.
-- `subagent-usage.md` — Subagent output-cap discipline (32K cap, scope budget, Sonnet override). Always-loaded because subagent calls originate from any layer.
+- `subagent-usage.md` — Subagent output-cap discipline (per-model output cap, review-attention scope budget, model choice as a cost lever not a budget one). Always-loaded because subagent calls originate from any layer.
 - `context-budget.md` — Content discipline for always-loaded files. Self-applying — route additions to CLAUDE.md / agent docs / any no-`paths:` rule through its classifier first.
 - `knowledge-layering.md` — Which tier knowledge belongs in (memory / `CLAUDE.md` / `.claude/rules/` / `docs/**`) and how to promote memory → rules. Pairs with `context-budget.md`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,7 +282,7 @@ Update with `/plugin`. Install steps: CONTRIBUTING.md § "If you use Claude Code
 
 - `swift-isolation.md` — `nonisolated` annotation traps under default-MainActor isolation. Always-loaded because the diagnostic fires at the use site, not the declaration — and the silent runtime-trap patterns fire none at all.
 - `xcodebuild-cli.md` — xcodebuild CLI playbook (test commands, DerivedData layout, timeout/recovery). Always-loaded because the gotchas surface during worktree switches and CI debugging, not only when editing tests.
-- `subagent-usage.md` — Subagent output-cap discipline (per-model output cap, review-attention scope budget, model choice as a cost lever not a budget one). Always-loaded because subagent calls originate from any layer.
+- `subagent-usage.md` — Subagent output-cap discipline (per-model output cap, review-attention scope budget, model choice = cost lever, never a budget escape). Always-loaded because subagent calls originate from any layer.
 - `context-budget.md` — Content discipline for always-loaded files. Self-applying — route additions to CLAUDE.md / agent docs / any no-`paths:` rule through its classifier first.
 - `knowledge-layering.md` — Which tier knowledge belongs in (memory / `CLAUDE.md` / `.claude/rules/` / `docs/**`) and how to promote memory → rules. Pairs with `context-budget.md`.
 


### PR DESCRIPTION
## Summary

claude-kit の正本（`origin/main`）から一方向でミラーを再同期する。kit#18 / kit#20 が
CLOSED、kit PR #25 が merged になり #1425 が unblocked になったのを受けたもの。

**#1425 の「対象」リストはキャップ表の数値ミラー5箇所に限定されていたが、同じファイルに
数値を含まない偽主張が4つ残っていた。** issue の完了確認コマンド
`grep -rn "32,000\|32K" .claude/ CLAUDE.md` はそれらを構造上検出できない（散文なので）。
本 PR はそこまで含む。

### 1. `.claude/rules/subagent-usage.md` — 全面再同期

| | 旧（誤） | 新（kit 正本） |
|---|---|---|
| キャップ表 | Opus 4.x = 32,000 / Haiku 4.x = 8,192 | Opus 5・Sonnet 5・Fable 5 = **64,000**、Haiku 4.5 = **32,000**（+ `CLAUDE_CODE_MAX_OUTPUT_TOKENS` 天井列） |
| 閾値の由来 | 「cap 表から*導出*され、upstream で再計算される」 | **cap 由来ではない**。レビュー注意力の限界で、cap が動いても再計算しない。改訂はレビュー品質の証拠に基づく |
| env var | 「main session にしか効かない」 | **サブエージェントにも届く**（1,200 に強制して応答が正確に 1,200 で頭打ちになることで確認済み） |
| exhaustion | 「silent」 | **もう silent ではない**。`stop_reason: max_tokens` を検知して3回まで再開を促し `API Error` を出す |
| §3 | 「Sonnet override (escape valve)」 | 「**Model choice is a cost lever, not a budget lever**」。Opus 5 = Sonnet 5 = 64,000 なので逃がしても増えない。予算的非対称は Haiku が半分であることだけ |

生の cap を読むコマンドも追加した（下の Test plan で実行して裏を取っている）。

### 2. 下流の一行ミラー3ファイル

`.claude/agents/code-reviewer.md` / `.claude/skills/orchestrate/SKILL.md` / `CLAUDE.md`。

`code-reviewer.md:13` の「cannot be raised by frontmatter or env var」は**両半分とも誤り
ではない** — frontmatter 側（`maxOutputTokens` は存在しない）は今も真で、反転したのは
env var 側だけ。ここを一括で「両方誤り」と直すと新しい偽主張を作るので分けて扱った。

### 3. `.claude/rules/automation-output-contract.md` — ルール6の2段化（kit PR #25）

ルール6は全面書き換え（検出段は網羅／出力段で保守的に絞り、落とした分を会計する）。
`### Why detection must not self-filter` を新設 — Claude 5 系は絞り込み指示を字義通り適用し、
**調査の深さは変わらないまま報告件数だけ落ちる**ため、損失が不可視になるという根拠。
ルール2 に検出段への逆参照、§Backpressure に judgment レーンの段落。

### 4. 知識の宛先にグローバル階層（spec §2 + レビュー由来）

`knowledge-layering.md` の Quick Test「No →」分岐が `.claude/rules/` か `CLAUDE.md` の
2択で、**全プロジェクトに効く教訓が Pastura のリポジトリに書かれてしまう**形だった。
読者で振り分ける分岐と tier 表のグローバル行を追加。

`context-budget.md` の § Scope にも同一クラスの欠落があった（当初「差分ゼロ」と判断していたが、
事前 critic が実測で否定した）。

## スコープ外（理由付き）

- **run 当たり issue 上限の値** — kit の新 §Backpressure が要求するが project-owned。値だけ先に
  宣言しても守る generator が居ないので、配線とセットで #1432（[スコープ追記済み](https://github.com/tyabu12/pastura/issues/1432#issuecomment-5267472623)）
- **generator skill 本体の追随**（`consistency-audit` hard rule 4 / `ui-refine` quota）— 3ホップ目、#1432
- **常時ロード −17,731 B の `claudeMdExcludes`** — `.claude/settings.local.json` は gitignore 対象で
  PR に乗らない。マージ後にローカル適用する
- **Pastura 固有知見の kit への逆昇格** — 一方向 reconcile の逆流なので別途 kit 側 issue

## Test plan

Swift に一切触れないので、検証は**主張の照合**。

- [x] `.claude/rules/` に追記したコマンドを実際に実行 → `claude -p --model opus --output-format json "ok" | jq '.modelUsage[].maxOutputTokens'` が **`64000`** を返し、コマンドが動くことと表の Opus 5 = 64,000 の両方を実測で確認
- [x] A1〜A6 の目視チェックリスト（issue の grep では A2/A3/A5 を検出できないため）
  - A1 閾値が cap 由来でないと言えているか → `subagent-usage.md:8, 78`
  - A2 env var がサブエージェントに届くと言えているか → `subagent-usage.md:50`
  - A3 exhaustion がもう silent でないと言えているか → `subagent-usage.md:91`
  - A4 キャップ表 → kit `origin/main` と値・世代ラベル・† 印まで一致（reviewer が独立に照合）
  - A5 §3 が「コストのレバー」になっているか
  - A6 実測コマンドの存在
- [x] 残存確認（**`--exclude-dir=worktrees` 必須** — 別ブランチの live worktree がリポジトリ内にあり、無しだと同じ5箇所を二重に拾う）
  ```
  grep -rn "32,000\|32K\|Sonnet override\|exhaustion is silent" --exclude-dir=worktrees .claude/ CLAUDE.md
  ```
  残るヒットはすべて正当（Haiku 4.5 の実キャップ／後方外挿の注記／撤廃の告知文／`orchestrate:117` のセッションモデル tier）
- [x] §番号の凍結 — `subagent-usage.md` は §1〜§5 が外部から番号で引用されている
  (`ADR-028.md:505,1565` と `queue-consumer/SKILL.md:68` が §2、`ADR-028.md:1588` が §4)。
  新節は §2 配下の `###` に入れて番号を動かしていない
- [x] kit 内部パス（`docs/subagent-output-cap.md`）を写していない — repo-tracked なルールから
  kit path を指すと他コントリビュータと CI で dead link になる
- [x] `python3 .claude/skills/consistency-audit/scripts/audit_docs.py` → `auto_fixable: 0`。
  `needs_judgment` 3件はすべて既存で本 diff の対象外（ADR-002/021 のナビ欠落、`docs/code-health/` の dead link）
- [x] 事前 critic（Opus）— Critical 1 / Warning 5。Critical は運用判断で解消、Warning 5件は反映
- [x] code-reviewer（Opus）— PASS。指摘 Warning 3件を修正コミットで解消し、修正 diff 限定で再レビュー

## Context-economy

**Context-economy: Keep 6 / Drop 1（`code-reviewer.md:13` の4文をリード1文＋ポインタへ圧縮）
— 正味は増えるが、増分は「どのモデルに何を任せるか」という次の判断に直接効く事実に限定した。**

`.claude/agents/*.md` と `paths:` 無しの `.claude/rules/*.md` は常時ロードなので、
`context-budget.md` の分類器を自己適用した。

- **Keep**: キャップ表（次の判断＝どのモデルに何を任せるかに直接効く）／閾値がレビュー注意力の
  限界であること（cap 更新のたびに再計算されるのを止める）／実測コマンド（実行可能）／
  「5系より前に外挿するな」（記憶で表を"直される"のを防ぐ）
- **Drop**: `code-reviewer.md:13` の4文をリード1文＋`subagent-usage.md` §1 へのポインタへ圧縮。
  キャップの数値・frontmatter の事実・env var の事実はどれも当エージェントの
  bail 判断に効かず、その判断は下の行数/ファイル数/軸数の予算だけで決まる

## Device QA

実機QA不要 — エージェント指示ファイルのみの変更で、アプリのコード・リソース・ビルド設定に一切触れない。

Closes #1425
