### PR TITLE
📝 docs: 判断lane の起票上限を #1432 のスコープに入れて参照を戻す

### DIFF
--- a/.claude/rules/automation-output-contract.md
+++ b/.claude/rules/automation-output-contract.md
@@ -155,8 +155,9 @@ race.
 issues are outside that accounting, and rule 6's exhaustive detection lands its increment precisely
 there. Cap issues per run as well — the number is project-owned by the same test as the ceiling: it
 rests on one maintainer's review attention, so it is *retuned* per repo, never recomputed from
-upstream. **Pastura has not set one** — until it is set, a run that would file an unusual number of
-issues stops and reports instead.
+upstream. **Pastura has not set one** — choosing the value and wiring it in is
+[#1432](https://github.com/tyabu12/pastura/issues/1432). Until it lands, a run that would file an
+unusual number of issues stops and reports instead.
 
 **The ceiling value (`AUTOMATION_WIP_CEILING`) and the branch predicate that identifies
 automation-origin PRs are project-owned and canonical in


### PR DESCRIPTION
前コミットで「#1432 が追跡している」を誤りとして外したが、調べ直すと
#1432 が正しい置き場所だった。対象が consistency-audit Step 4 の1箇所に 閉じ（無人 run でルール2の issue を起票するのはこれだけ。triage-guardian は hard rule 1 で gh issue create を禁止、code-health-audit は gh を叩かず issue 化は手動、ui-refine / queue-consumer は起票しない）、それは #1432 が すでに触る節そのもの。因果的にも #1432 の「検出段を網羅にする」変更が
増分を作る側なので、片方だけ入れると lane が無防備な期間ができる。

#1432 側に項目4（上限の決定と配線）・項目8（着地後にこのミラーを更新）・
対象1の3点目・完了条件・及ばない3件の根拠を追記し、agent-ready 評価の
分割案を consistency-audit(2+3+4) / ui-refine+audit_docs.py(5+6) に 振り直した上で、ここの参照を復帰。


Claude-Session: https://claude.ai/code/session_013NB2cPENBgUT8eqZCggxLz