### PR TITLE
🔧 chore: 生成スキルを Output Contract の新ルール6（検出段/出力段）に追随させる

### DIFF
--- a/.claude/rules/automation-output-contract.md
+++ b/.claude/rules/automation-output-contract.md
@@ -94,11 +94,6 @@ nothing of theirs reaches the review queue this contract rations.
      uncounted drop is indistinguishable from a finding never made: the next run re-derives it, drops
      it again, and nobody learns the filter is too tight.
 
-**Generator bodies still carrying the pre-2026-08-12 wording** are tracked in
-[#1432](https://github.com/tyabu12/pastura/issues/1432) (`consistency-audit` hard rule 4;
-`ui-refine`'s generation-side quota). Until that lands this rule is the canonical text and their
-duplicates are stale — reconcile them, do not follow them.
-
 ### Why detection must not self-filter
 
 Rule 6's split is a model-behaviour fact, not a style preference, and it is recent. Claude 5-series
@@ -155,9 +150,12 @@ race.
 issues are outside that accounting, and rule 6's exhaustive detection lands its increment precisely
 there. Cap issues per run as well — the number is project-owned by the same test as the ceiling: it
 rests on one maintainer's review attention, so it is *retuned* per repo, never recomputed from
-upstream. **Pastura has not set one** — choosing the value and wiring it in is
-[#1432](https://github.com/tyabu12/pastura/issues/1432). Until it lands, a run that would file an
-unusual number of issues stops and reports instead.
+upstream. **Pastura's is `JUDGMENT_ISSUE_CAP` = 3**, canonical in
+`.claude/skills/consistency-audit/SKILL.md` (§ Constants, with the ranked truncation and the retune
+trigger in Step 4 step 2) — that generator is the only one filing issues unattended, so the cap lives
+in its own skill per rule 4 rather than alongside the Draft-PR ceiling. It bounds the *flow* (issues
+per run); nothing bounds the *stock* of open judgment issues, and that gap is recorded as deliberate
+at the same place.
 
 **The ceiling value (`AUTOMATION_WIP_CEILING`) and the branch predicate that identifies
 automation-origin PRs are project-owned and canonical in

--- a/.claude/rules/automation-output-contract.md
+++ b/.claude/rules/automation-output-contract.md
@@ -150,12 +150,10 @@ race.
 issues are outside that accounting, and rule 6's exhaustive detection lands its increment precisely
 there. Cap issues per run as well — the number is project-owned by the same test as the ceiling: it
 rests on one maintainer's review attention, so it is *retuned* per repo, never recomputed from
-upstream. **Pastura's is `JUDGMENT_ISSUE_CAP` = 3**, canonical in
-`.claude/skills/consistency-audit/SKILL.md` (§ Constants, with the ranked truncation and the retune
-trigger in Step 4 step 2) — that generator is the only one filing issues unattended, so the cap lives
-in its own skill per rule 4 rather than alongside the Draft-PR ceiling. It bounds the *flow* (issues
-per run); nothing bounds the *stock* of open judgment issues, and that gap is recorded as deliberate
-at the same place.
+upstream. **Pastura's is `JUDGMENT_ISSUE_CAP` = 3**, owned per rule 4 by the only generator filing
+issues unattended and canonical in `.claude/skills/consistency-audit/SKILL.md` — § Constants for the
+value, Step 4 step 2 for the ranked truncation, the retune trigger, and the deliberately-unbounded
+*stock* of open judgment issues (this caps the *flow* only).
 
 **The ceiling value (`AUTOMATION_WIP_CEILING`) and the branch predicate that identifies
 automation-origin PRs are project-owned and canonical in

--- a/.claude/skills/consistency-audit/SKILL.md
+++ b/.claude/skills/consistency-audit/SKILL.md
@@ -87,7 +87,11 @@ relaxed, restore the `code-reviewer` pass.
 
 ## Constants
 
-- Detector: `.claude/skills/consistency-audit/scripts/audit_docs.py`
+- Detector: `.claude/skills/consistency-audit/scripts/audit_docs.py`. It reports
+  **no threshold near-miss tally** — considered and declined 2026-08-12; the
+  reasoning lives beside the thresholds themselves (`§ Threshold near-miss
+  reporting: considered, DECLINED`, above `MIRROR_MIN_LINES`), with the
+  condition that re-opens it.
 - Auto-fix PR branch: `audit/docs-<YYYYMMDD>` (collision fallback `-2`, `-3`, …)
 - Auto-fix dedup: **at most one open `audit/*` Draft PR at a time.** A run that
   finds one open skips the auto-fix PR step and reports it pending — all fixes
@@ -307,12 +311,22 @@ For each `needs_judgment` finding (already deduped by `target`):
    3. `target`, lexicographically ascending — the tiebreak that makes the order
       *total*, so two runs over the same repo state truncate identically.
 
-   **Why 3.** Measured steady state on `main` is 2 (`adr_navigation_missing`
-   ×2), so the cap sits one above normal: it does not throttle ordinary passes,
-   and it does stop a burst — an ADR renumbering can fire a dozen
-   `adr_roster_drift` findings in one run. It is below `AUTOMATION_WIP_CEILING`
-   (5) by construction, since a single run should not be able to fill the
-   family's whole review budget on its own.
+   **Why 3.** The cap counts issues *filed*, i.e. what survives step 1's dedup —
+   not what the detector emitted. In steady state that is **0**: the standing
+   findings are already open issues. What the cap has to size against is the
+   burst — an ADR renumbering firing a dozen `adr_roster_drift` findings in one
+   run, or a first run against a fresh state. Three is one above the largest
+   detector output measured 2026-08-12, and it is below
+   `AUTOMATION_WIP_CEILING` (5) by construction: a single run should not be able
+   to spend the family's whole review budget.
+
+   That measurement differs by **where the run executes**, which is worth
+   knowing before reading a report: the main checkout yields 2
+   (`adr_navigation_missing` ×2), while a **fresh worktree — the environment a
+   scheduled run actually uses** (§ Scheduling) — yields 3, because
+   `dead_link ledger.md` fires there too (the gitignored-by-design target absent
+   from every fresh clone, per Non-goals). Neither number is the cap's steady
+   state; both are pre-dedup detector output.
 
    **Capped findings are deferred, not rejected — and that is why nothing is
    lost.** The detector is deterministic: the next run re-enumerates them, and

--- a/.claude/skills/consistency-audit/SKILL.md
+++ b/.claude/skills/consistency-audit/SKILL.md
@@ -92,6 +92,8 @@ relaxed, restore the `code-reviewer` pass.
 - Auto-fix dedup: **at most one open `audit/*` Draft PR at a time.** A run that
   finds one open skips the auto-fix PR step and reports it pending — all fixes
   batch into one PR, so a second would duplicate the first.
+- Judgment-issue cap: **at most 3 issues filed per run** (`JUDGMENT_ISSUE_CAP`).
+  Canonical here; ranked truncation and rationale in Step 4 step 2.
 - Label: `documentation` (for both PRs and issues)
 
 ## Hard rules (non-negotiable)
@@ -223,6 +225,10 @@ Only if `auto_fixable` is non-empty AND Step 2 found no open `audit/*` PR:
 
 ## Step 4 — needs_judgment → issues
 
+**This is the output stage** (Contract rule 6). Detection already enumerated
+everything; this step is the *only* place a finding is dropped, and every drop
+is counted for Step 5.
+
 For each `needs_judgment` finding (already deduped by `target`):
 
 1. **Dedup across runs:** search issues for the target — **`--state all`, then
@@ -280,7 +286,61 @@ For each `needs_judgment` finding (already deduped by `target`):
    `nav:` as a search qualifier. (This predates the newer types:
    `embedded_source_mirror`'s `<docfile>::<sourcepath>` composite has the same
    shape.)
-2. File an issue (`--label documentation`) whose body has:
+2. **Rank the survivors, then truncate to `JUDGMENT_ISSUE_CAP` (3).** This is a
+   *quota* in the Contract's sense — rank-then-truncate over an
+   already-enumerated list, never a cap that stops the search — so `found` in
+   Step 5 stays the detector's count and never collapses to the cap.
+
+   **Rank key**, declared so the truncation is reproducible rather than
+   whatever order the JSON happened to enumerate:
+
+   1. `confidence` — `high` before `medium`. The detector emits **no**
+      `severity` field, so confidence is the only rank signal it carries;
+      adding one would mean inventing a scale no detector currently computes,
+      and the Contract's rank-key requirement is satisfied by a declared total
+      order, not by that specific field name.
+   2. Finding type, in this precedence: `dead_link` → `adr_roster_drift` →
+      `dangling_adr` → `unparsed_adr_reservation` → `embedded_source_mirror` →
+      `adr_navigation_missing`. Ordered by how mechanically checkable the
+      finding is — a link either resolves or does not, whereas a navigation
+      finding is a share a maintainer can reasonably read either way.
+   3. `target`, lexicographically ascending — the tiebreak that makes the order
+      *total*, so two runs over the same repo state truncate identically.
+
+   **Why 3.** Measured steady state on `main` is 2 (`adr_navigation_missing`
+   ×2), so the cap sits one above normal: it does not throttle ordinary passes,
+   and it does stop a burst — an ADR renumbering can fire a dozen
+   `adr_roster_drift` findings in one run. It is below `AUTOMATION_WIP_CEILING`
+   (5) by construction, since a single run should not be able to fill the
+   family's whole review budget on its own.
+
+   **Capped findings are deferred, not rejected — and that is why nothing is
+   lost.** The detector is deterministic: the next run re-enumerates them, and
+   because this run filed the higher-ranked ones, those dedup out (Step 4 step
+   1) and the deferred remainder rises to the top. The backlog drains without
+   any extra bookkeeping. What is *not* self-correcting is the signal that the
+   cap bound at all, so Step 5 must publish it — an uncounted drop is
+   indistinguishable from a finding never made.
+
+   **Retune trigger:** if the cap binds on two consecutive runs with no
+   identifiable burst cause, it is too tight — raise it rather than let a
+   standing backlog drip out three at a time.
+
+   **Canonical home.** The cap lives here, in this generator's own skill, per
+   Contract rule 4 ("each generator's own cap is canonical in that generator's
+   own skill"). It is deliberately **not** in `triage-guardian/SKILL.md`
+   § Backpressure, which is canonical for `AUTOMATION_WIP_CEILING` and the
+   automation-branch predicate: those are inlined literally by three files and
+   carry a same-PR sync rule, and enlisting a single-consumer constant in that
+   set would buy nothing. That section carries a cross-reference here instead.
+
+   **Out of scope, deliberately:** this is a *flow* cap (issues per run).
+   Nothing bounds the *stock* — the total of open judgment issues — so a
+   maintainer who ignores the lane accumulates at up to 3/run. Considered and
+   left open: the per-target dedup already prevents re-filing the same finding,
+   and a stock bound needs a reliable "filed by this skill" predicate that the
+   already-filed issues do not carry.
+3. File an issue (`--label documentation`) whose body has:
    - **Locations**: every `file:line` the target is referenced from.
    - **Confidence**: how sure the detector is this is a real problem.
    - **Counter-evidence / why this might be wrong**: e.g. the target may be an
@@ -309,12 +369,30 @@ Never auto-fix these — the whole point is the fix needs judgment.
 
 ## Step 5 — Report
 
-Summarize to the user / transcript: auto-fix PR url (or "skipped — open audit
-PR #N pending" / "none"), issues filed (or skipped-as-duplicate), and the
-dry-run counts. Point at `/tmp/audit.json` for the raw findings. That summary is
-the whole record — for a scheduled run it is the run history entry, and any
-actual change is durably captured by the Draft PR; the skill leaves nothing
-behind in the working tree.
+Summarize to the user / transcript, and **publish the output-stage arithmetic**
+(Contract rule 6). Every number below is required even when it is zero — a
+missing line is what makes a too-tight filter invisible:
+
+- **found** — the detector's own `auto_fixable` + `needs_judgment` counts,
+  before any filtering. Never the post-cap number.
+- **deduped** — findings skipped in Step 4 step 1, each with the matched issue
+  number and **which branch fired** (`open` / `NOT_PLANNED` / `DUPLICATE`), so a
+  wrong suppression is legible rather than a bare count.
+- **capped** — findings the Step 4 cap deferred, listed by `target` with their
+  rank position, so a reader can see exactly what a higher cap would have
+  surfaced. State the cap value alongside.
+- **surfaced** — issues actually filed, with urls.
+- Auto-fix PR url (or "skipped — open audit PR #N pending" / "none").
+
+The report is the channel; nothing is minted to carry these numbers. The
+**capped** list needs no separate cross-run store because the deterministic
+detector re-enumerates it next run (Step 4 step 2) — what the report preserves
+is the *signal that the cap bound*, which nothing else records.
+
+Point at `/tmp/audit.json` for the raw findings. That summary is the whole record
+— for a scheduled run it is the run history entry, and any actual change is
+durably captured by the Draft PR; the skill leaves nothing behind in the working
+tree.
 
 ## Scheduling (how unattended runs work)
 

--- a/.claude/skills/consistency-audit/SKILL.md
+++ b/.claude/skills/consistency-audit/SKILL.md
@@ -95,9 +95,9 @@ relaxed, restore the `code-reviewer` pass.
 ## Hard rules (non-negotiable)
 
 Rules 1–3 restate Output Contract **rule 0** (never actuate) and rule 4 restates
-**rule 6** (conservative detection), deliberately duplicated here as the
-operational form: these are the hard-stop invariants an unattended run must not
-have to follow a pointer to find.
+**rule 6** (conservative *output*, exhaustive detection), deliberately
+duplicated here as the operational form: these are the hard-stop invariants an
+unattended run must not have to follow a pointer to find.
 
 Canonicality is a three-hop chain, and edits flow down it in order: claude-kit's
 `docs/automation-output-contract.md` owns the generic core → this repo's
@@ -112,8 +112,18 @@ Pastura-specific operational detail starts here.
 2. **PRs are always Draft.** `--draft` is the first flag of `gh pr create`.
    Never run `gh pr ready`.
 3. **Never close an issue.** Closing happens through the human's merge.
-4. **Conservative detection wins.** Prefer a miss over a wrong flag — a wrong
-   auto-fix PR or a false issue is worse than a missed inconsistency.
+4. **Conservative *output*, exhaustive detection — never withhold at the
+   detection stage.** The precision bias is unchanged — a wrong auto-fix PR or a
+   false issue costs more than a missed inconsistency, so where the evidence is
+   short of decisive, route to the human rather than act — but it applies *after*
+   the finding exists, never as a reason to not surface one. Everything the
+   detector emits reaches Step 4; Step 4 is the only filter (dedup, then the
+   per-run cap), and Step 5 publishes the arithmetic. `audit_docs.py` is a
+   *deterministic* detector, so its thresholds are a predicate reviewable at
+   source rather than a judgment call — the Contract's carve-out for that exempts
+   it from the ban on judgment, **not** from the count. **An uncounted drop is
+   banned**: it is indistinguishable from a finding never made, so the next run
+   re-derives it, drops it again, and nobody learns the bar sits too tight.
 
 ## Step 0 — Preflight (abort on any failure)
 

--- a/.claude/skills/consistency-audit/SKILL.md
+++ b/.claude/skills/consistency-audit/SKILL.md
@@ -88,10 +88,9 @@ relaxed, restore the `code-reviewer` pass.
 ## Constants
 
 - Detector: `.claude/skills/consistency-audit/scripts/audit_docs.py`. It reports
-  **no threshold near-miss tally** — considered and declined 2026-08-12; the
-  reasoning lives beside the thresholds themselves (`§ Threshold near-miss
-  reporting: considered, DECLINED`, above `MIRROR_MIN_LINES`), with the
-  condition that re-opens it.
+  **no threshold near-miss tally** — declined 2026-08-12; the reasoning and the
+  condition that re-opens it sit beside the thresholds themselves (the
+  `§ Threshold near-miss reporting` block above `MIRROR_MIN_LINES`).
 - Auto-fix PR branch: `audit/docs-<YYYYMMDD>` (collision fallback `-2`, `-3`, …)
 - Auto-fix dedup: **at most one open `audit/*` Draft PR at a time.** A run that
   finds one open skips the auto-fix PR step and reports it pending — all fixes
@@ -130,8 +129,7 @@ Pastura-specific operational detail starts here.
    *deterministic* detector, so its thresholds are a predicate reviewable at
    source rather than a judgment call — the Contract's carve-out for that exempts
    it from the ban on judgment, **not** from the count. **An uncounted drop is
-   banned**: it is indistinguishable from a finding never made, so the next run
-   re-derives it, drops it again, and nobody learns the bar sits too tight.
+   banned**: it is indistinguishable from a finding never made.
 
 ## Step 0 — Preflight (abort on any failure)
 
@@ -235,7 +233,7 @@ is counted for Step 5.
 
 **Steps 1 and 3 are per-finding; step 2 is not** — it ranks and truncates the
 *whole* surviving set, so it runs once, after step 1 has been applied to every
-`needs_judgment` finding (which the detector has already deduped by `target`).
+`needs_judgment` finding (already deduped by `target` in the detector).
 
 1. **Dedup across runs** — per finding. Search issues for the target — **`--state all`, then
    branch on the close reason**:
@@ -252,23 +250,19 @@ is counted for Step 5.
    | `CLOSED` / `COMPLETED` | **file it** | the drift was *fixed*; its recurrence is a **regression**, not a duplicate |
    | `CLOSED` / `DUPLICATE` | **skip** | folded into another issue, which carries the decision |
 
-   **`COMPLETED` must never suppress** — that is the whole reason this widened
-   past `--state open`. Suppressing on it would silently make every fixed-then-
-   recurring drift permanently invisible: no run would ever re-file it, and the
-   failure would look exactly like a clean pass. `COMPLETED` is also the dominant
-   close reason in this repo, so the wrong branch here disables the skill
-   quietly rather than rarely.
+   **`COMPLETED` must never suppress** — it is the dominant close reason here, so
+   getting that branch wrong makes every fixed-then-recurring drift permanently
+   invisible, and the failure looks exactly like a clean pass.
 
    **Branch on `state` first, then on `stateReason` — and read the latter as a
-   string, not a nullable.** `stateReason` has four values (`COMPLETED`,
-   `NOT_PLANNED`, `DUPLICATE`, `REOPENED`) and is `""`, not `null`, on an issue
-   that was never closed. So a predicate written as
-   `.stateReason == "NOT_PLANNED"` drops the open-issue skip (the load-bearing
-   case), `.stateReason != "COMPLETED"` keeps open issues by luck rather than
-   intent, and either one mishandles a **reopened** issue — which this repo
-   produces deliberately (CLAUDE.md § "Closing issues in multi-PR splits"
-   prescribes `gh issue reopen` as a recovery step). Deciding on `state` first
-   makes all four values fall out correctly.
+   string, not a nullable.** It has four values (`COMPLETED`, `NOT_PLANNED`,
+   `DUPLICATE`, `REOPENED`) and is `""`, not `null`, on an issue that was never
+   closed. So a predicate keyed on `stateReason` alone is either wrong
+   (`== "NOT_PLANNED"` drops the open-issue skip, the load-bearing case) or right
+   only by accident (`!= "COMPLETED"` happens to cover both open and **reopened**
+   issues — and this repo produces reopened ones deliberately, CLAUDE.md
+   § "Closing issues in multi-PR splits"). Deciding on `state` first makes all
+   four values fall out correctly.
 
    Every finding carries a `target` for this — for `dead_link` it is the link path,
    for `dangling_adr` it is the ADR id (`ADR-099`), for `embedded_source_mirror`
@@ -308,12 +302,10 @@ is counted for Step 5.
    1. `confidence` — `high` before `medium`, and **an absent `confidence` sorts
       as `high`**. The field is not universal: `dead_link` emits none (its
       confidence is authored at filing time, per step 3), so without this clause
-      term 1 would be undefined for the very type term 2 ranks first. Sorting it
-      high keeps the two terms agreeing rather than fighting. The detector emits
-      **no** `severity` field at all, so confidence is the only rank signal it
-      carries; inventing a severity scale no detector computes would buy
-      nothing, and the Contract's rank-key requirement is satisfied by a
-      declared *total* order, not by that specific field name.
+      term 1 would be undefined for the very type term 2 ranks first. There is
+      no `severity` field to rank on — the detector emits none, and the
+      Contract's rank-key requirement asks for a declared *total* order, not for
+      that particular field.
    2. Finding type, in this precedence: `dead_link` → `adr_roster_drift` →
       `dangling_adr` → `unparsed_adr_reservation` → `embedded_source_mirror` →
       `adr_navigation_missing`. Ordered by how mechanically checkable the
@@ -322,46 +314,31 @@ is counted for Step 5.
    3. `target`, lexicographically ascending — the tiebreak that makes the order
       *total*, so two runs over the same repo state truncate identically.
 
-   **Why 3.** The cap counts issues *filed*, i.e. what survives step 1's dedup —
-   not what the detector emitted. In steady state that is **0**: the standing
-   findings are already open issues. What the cap has to size against is the
-   burst — an ADR renumbering firing a dozen `adr_roster_drift` findings in one
-   run, or a first run against a state where nothing has been filed yet.
+   **Why 3.** The cap counts issues *filed* — what survives step 1's dedup, not
+   what the detector emitted — so in steady state it sees **0**, the standing
+   findings being already-open issues. It sizes against the burst: an ADR
+   renumbering firing a dozen `adr_roster_drift` findings, or a first run
+   against a state where nothing has been filed yet. Three is exactly the
+   largest detector output measured 2026-08-12, which is also the *full*
+   backlog, so that first run files everything and truncates nothing; and it
+   sits below `AUTOMATION_WIP_CEILING` (5) so one run cannot spend the family's
+   whole review budget.
 
-   Three is **exactly** the largest detector output measured 2026-08-12, which
-   is also the *full* backlog — every standing finding, none of them filed. So a
-   first run against that state files all three and truncates nothing, and only
-   genuinely new drift arriving on top of an unfiled backlog is deferred. It is
-   below `AUTOMATION_WIP_CEILING` (5) by construction: a single run should not
-   be able to spend the family's whole review budget.
-
-   That measurement differs by **where the run executes**, which is worth
-   knowing before reading a report: the main checkout yields 2
-   (`adr_navigation_missing` ×2), while a **fresh worktree — the environment a
-   scheduled run actually uses** (§ Scheduling) — yields 3, because
-   `dead_link ledger.md` fires there too (the gitignored-by-design target absent
-   from every fresh clone, per Non-goals). Neither number is the cap's steady
-   state; both are pre-dedup detector output.
+   That measurement differs by **where the run executes**: the main checkout
+   yields 2 (`adr_navigation_missing` ×2), a **fresh worktree — what a scheduled
+   run actually uses** (§ Scheduling) — yields 3, because `dead_link ledger.md`
+   fires there too (Non-goals). Both are pre-dedup detector output, neither is
+   the cap's steady state.
 
    **Capped findings are deferred, not rejected — and that is why nothing is
-   lost.** The detector is deterministic: the next run re-enumerates them, and
-   because this run filed the higher-ranked ones, those dedup out (Step 4 step
-   1) and the deferred remainder rises to the top. The backlog drains without
-   any extra bookkeeping. What is *not* self-correcting is the signal that the
-   cap bound at all, so Step 5 must publish it — an uncounted drop is
-   indistinguishable from a finding never made.
+   lost.** The detector is deterministic: the next run re-enumerates them, this
+   run's filings dedup out (step 1), and the deferred remainder rises to the
+   top. What is *not* self-correcting is the signal that the cap bound at all,
+   so Step 5 must publish it.
 
    **Retune trigger:** if the cap binds on two consecutive runs with no
    identifiable burst cause, it is too tight — raise it rather than let a
    standing backlog drip out three at a time.
-
-   **Canonical home.** The cap lives here, in this generator's own skill, per
-   Contract rule 4 ("each generator's own cap is canonical in that generator's
-   own skill"). It is deliberately **not** in `triage-guardian/SKILL.md`
-   § Backpressure, which is canonical for `AUTOMATION_WIP_CEILING` and the
-   automation-branch predicate: those are inlined literally by three files and
-   carry a same-PR sync rule, and enlisting a single-consumer constant in that
-   set would buy nothing. That section carries a cross-reference here instead.
 
    **Out of scope, deliberately:** this is a *flow* cap (issues per run).
    Nothing bounds the *stock* — the total of open judgment issues — so a
@@ -426,10 +403,9 @@ These four balance: `found = deduped + capped + surfaced`.
   "none". This lane has no per-finding filter: rule 1 batches every fix into one
   PR, so the count either all ships or all waits.
 
-The report is the channel; nothing is minted to carry these numbers. The
-**capped** list needs no separate cross-run store because the deterministic
-detector re-enumerates it next run (Step 4 step 2) — what the report preserves
-is the *signal that the cap bound*, which nothing else records.
+The report is the channel; nothing is minted to carry these numbers — the
+deterministic detector re-enumerates the **capped** list next run (Step 4
+step 2), so what the report preserves is only the signal that the cap bound.
 
 Point at `/tmp/audit.json` for the raw findings. That summary is the whole record
 — for a scheduled run it is the run history entry, and any actual change is

--- a/.claude/skills/consistency-audit/SKILL.md
+++ b/.claude/skills/consistency-audit/SKILL.md
@@ -233,9 +233,11 @@ Only if `auto_fixable` is non-empty AND Step 2 found no open `audit/*` PR:
 everything; this step is the *only* place a finding is dropped, and every drop
 is counted for Step 5.
 
-For each `needs_judgment` finding (already deduped by `target`):
+**Steps 1 and 3 are per-finding; step 2 is not** — it ranks and truncates the
+*whole* surviving set, so it runs once, after step 1 has been applied to every
+`needs_judgment` finding (which the detector has already deduped by `target`).
 
-1. **Dedup across runs:** search issues for the target — **`--state all`, then
+1. **Dedup across runs** — per finding. Search issues for the target — **`--state all`, then
    branch on the close reason**:
 
    ```bash
@@ -245,7 +247,7 @@ For each `needs_judgment` finding (already deduped by `target`):
 
    | Matched issue | Action | Why |
    |---|---|---|
-   | `OPEN` (`stateReason` is `""`) | **skip** | already filed; a human has it |
+   | `OPEN` — any `stateReason` (`""`, or `REOPENED` after a reopen) | **skip** | already filed; a human has it |
    | `CLOSED` / `NOT_PLANNED` | **skip** | a human declined this finding — that is the rejection memory Contract rule 6 asks be kept where the next run can see it |
    | `CLOSED` / `COMPLETED` | **file it** | the drift was *fixed*; its recurrence is a **regression**, not a duplicate |
    | `CLOSED` / `DUPLICATE` | **skip** | folded into another issue, which carries the decision |
@@ -257,11 +259,16 @@ For each `needs_judgment` finding (already deduped by `target`):
    close reason in this repo, so the wrong branch here disables the skill
    quietly rather than rarely.
 
-   **Read `stateReason` as a string, not a nullable.** An open issue returns
-   `""`, not `null` — a predicate written as `.stateReason == "NOT_PLANNED"`
-   therefore drops the open-issue skip (the load-bearing case), while
-   `.stateReason != "COMPLETED"` keeps open issues by luck rather than by
-   intent. Branch on `state` first, then on `stateReason`.
+   **Branch on `state` first, then on `stateReason` — and read the latter as a
+   string, not a nullable.** `stateReason` has four values (`COMPLETED`,
+   `NOT_PLANNED`, `DUPLICATE`, `REOPENED`) and is `""`, not `null`, on an issue
+   that was never closed. So a predicate written as
+   `.stateReason == "NOT_PLANNED"` drops the open-issue skip (the load-bearing
+   case), `.stateReason != "COMPLETED"` keeps open issues by luck rather than
+   intent, and either one mishandles a **reopened** issue — which this repo
+   produces deliberately (CLAUDE.md § "Closing issues in multi-PR splits"
+   prescribes `gh issue reopen` as a recovery step). Deciding on `state` first
+   makes all four values fall out correctly.
 
    Every finding carries a `target` for this — for `dead_link` it is the link path,
    for `dangling_adr` it is the ADR id (`ADR-099`), for `embedded_source_mirror`
@@ -298,11 +305,15 @@ For each `needs_judgment` finding (already deduped by `target`):
    **Rank key**, declared so the truncation is reproducible rather than
    whatever order the JSON happened to enumerate:
 
-   1. `confidence` — `high` before `medium`. The detector emits **no**
-      `severity` field, so confidence is the only rank signal it carries;
-      adding one would mean inventing a scale no detector currently computes,
-      and the Contract's rank-key requirement is satisfied by a declared total
-      order, not by that specific field name.
+   1. `confidence` — `high` before `medium`, and **an absent `confidence` sorts
+      as `high`**. The field is not universal: `dead_link` emits none (its
+      confidence is authored at filing time, per step 3), so without this clause
+      term 1 would be undefined for the very type term 2 ranks first. Sorting it
+      high keeps the two terms agreeing rather than fighting. The detector emits
+      **no** `severity` field at all, so confidence is the only rank signal it
+      carries; inventing a severity scale no detector computes would buy
+      nothing, and the Contract's rank-key requirement is satisfied by a
+      declared *total* order, not by that specific field name.
    2. Finding type, in this precedence: `dead_link` → `adr_roster_drift` →
       `dangling_adr` → `unparsed_adr_reservation` → `embedded_source_mirror` →
       `adr_navigation_missing`. Ordered by how mechanically checkable the
@@ -315,10 +326,14 @@ For each `needs_judgment` finding (already deduped by `target`):
    not what the detector emitted. In steady state that is **0**: the standing
    findings are already open issues. What the cap has to size against is the
    burst — an ADR renumbering firing a dozen `adr_roster_drift` findings in one
-   run, or a first run against a fresh state. Three is one above the largest
-   detector output measured 2026-08-12, and it is below
-   `AUTOMATION_WIP_CEILING` (5) by construction: a single run should not be able
-   to spend the family's whole review budget.
+   run, or a first run against a state where nothing has been filed yet.
+
+   Three is **exactly** the largest detector output measured 2026-08-12, which
+   is also the *full* backlog — every standing finding, none of them filed. So a
+   first run against that state files all three and truncates nothing, and only
+   genuinely new drift arriving on top of an unfiled backlog is deferred. It is
+   below `AUTOMATION_WIP_CEILING` (5) by construction: a single run should not
+   be able to spend the family's whole review budget.
 
    That measurement differs by **where the run executes**, which is worth
    knowing before reading a report: the main checkout yields 2
@@ -387,8 +402,13 @@ Summarize to the user / transcript, and **publish the output-stage arithmetic**
 (Contract rule 6). Every number below is required even when it is zero — a
 missing line is what makes a too-tight filter invisible:
 
-- **found** — the detector's own `auto_fixable` + `needs_judgment` counts,
-  before any filtering. Never the post-cap number.
+**The arithmetic is per lane** — the two lanes have different dispositions, and
+summing them would balance against nothing. Report each separately.
+
+*Judgment lane* (Step 4):
+
+- **found** — the detector's `needs_judgment` count, before any filtering.
+  Never the post-cap number.
 - **deduped** — findings skipped in Step 4 step 1, each with the matched issue
   number and **which branch fired** (`open` / `NOT_PLANNED` / `DUPLICATE`), so a
   wrong suppression is legible rather than a bare count.
@@ -396,7 +416,15 @@ missing line is what makes a too-tight filter invisible:
   rank position, so a reader can see exactly what a higher cap would have
   surfaced. State the cap value alongside.
 - **surfaced** — issues actually filed, with urls.
-- Auto-fix PR url (or "skipped — open audit PR #N pending" / "none").
+
+These four balance: `found = deduped + capped + surfaced`.
+
+*Auto-fix lane* (Steps 2–3):
+
+- **found** — the detector's `auto_fixable` count.
+- **disposition** — the PR url, or "skipped — open audit PR #N pending", or
+  "none". This lane has no per-finding filter: rule 1 batches every fix into one
+  PR, so the count either all ships or all waits.
 
 The report is the channel; nothing is minted to carry these numbers. The
 **capped** list needs no separate cross-run store because the deterministic

--- a/.claude/skills/consistency-audit/SKILL.md
+++ b/.claude/skills/consistency-audit/SKILL.md
@@ -37,9 +37,11 @@ contract in context.
   here: `dead_link ledger.md` has reported since long before this detector
   existed (a gitignored-by-design target, so it is absent in every fresh clone),
   and `adr_navigation_missing` reports by design on a property a healthy repo
-  can have. So the per-target open-issue dedup in Step 4 step 1 and the
+  can have. So the per-target issue dedup in Step 4 step 1 and the
   `nav-exempt` opt-out are load-bearing, not theoretical — without them a run
-  re-files what a human already answered.)
+  re-files what a human already answered. That dedup reads **closed** issues
+  too, and branches on the close reason: a declined finding stays declined, a
+  *fixed* one is allowed to re-file because its recurrence is a regression.)
 - **No merging, no issue closing.** The human reviews each Draft PR; merging
   closes nothing automatically here.
 - **No parallelism — single writer.** One audit run at a time. Two overlapping
@@ -223,9 +225,35 @@ Only if `auto_fixable` is non-empty AND Step 2 found no open `audit/*` PR:
 
 For each `needs_judgment` finding (already deduped by `target`):
 
-1. **Dedup across runs:** search open issues for the target; skip if one
-   exists. `gh issue list --state open --search "<target> in:title"`. Every
-   finding carries a `target` for this — for `dead_link` it is the link path,
+1. **Dedup across runs:** search issues for the target — **`--state all`, then
+   branch on the close reason**:
+
+   ```bash
+   gh issue list --state all --search '"<target>" in:title' \
+     --json number,title,state,stateReason
+   ```
+
+   | Matched issue | Action | Why |
+   |---|---|---|
+   | `OPEN` (`stateReason` is `""`) | **skip** | already filed; a human has it |
+   | `CLOSED` / `NOT_PLANNED` | **skip** | a human declined this finding — that is the rejection memory Contract rule 6 asks be kept where the next run can see it |
+   | `CLOSED` / `COMPLETED` | **file it** | the drift was *fixed*; its recurrence is a **regression**, not a duplicate |
+   | `CLOSED` / `DUPLICATE` | **skip** | folded into another issue, which carries the decision |
+
+   **`COMPLETED` must never suppress** — that is the whole reason this widened
+   past `--state open`. Suppressing on it would silently make every fixed-then-
+   recurring drift permanently invisible: no run would ever re-file it, and the
+   failure would look exactly like a clean pass. `COMPLETED` is also the dominant
+   close reason in this repo, so the wrong branch here disables the skill
+   quietly rather than rarely.
+
+   **Read `stateReason` as a string, not a nullable.** An open issue returns
+   `""`, not `null` — a predicate written as `.stateReason == "NOT_PLANNED"`
+   therefore drops the open-issue skip (the load-bearing case), while
+   `.stateReason != "COMPLETED"` keeps open issues by luck rather than by
+   intent. Branch on `state` first, then on `stateReason`.
+
+   Every finding carries a `target` for this — for `dead_link` it is the link path,
    for `dangling_adr` it is the ADR id (`ADR-099`), for `embedded_source_mirror`
    it is the `<docfile>::<sourcepath>` composite (so the same source mirrored in
    two docs files two distinct issues), for `unparsed_adr_reservation` it is
@@ -235,14 +263,17 @@ For each `needs_judgment` finding (already deduped by `target`):
 
    **The namespacing on the three ADR-keyed types is load-bearing, and it is
    not sufficient.** The search cannot tell finding types apart, so a bare
-   `ADR-NNN` would be permanently suppressed by the open `dangling_adr` issue
-   it exists to explain — most likely exactly when both fire. The prefix stops
+   `ADR-NNN` would be permanently suppressed by the `dangling_adr` issue it
+   exists to explain — most likely exactly when both fire. The prefix stops
    that, but GitHub also matches on tokens rather than whole strings, and
    every one of these targets names its ADR, so `reservation:ADR-006` and
    `ADR-006` can still surface each other. **Before skipping as a duplicate,
    confirm the matched issue's title actually contains the target verbatim**
    — a match on the bare ADR id when the target is namespaced (or vice versa)
-   is a different finding, and skipping on it drops a real one silently.
+   is a different finding, and skipping on it drops a real one silently. The
+   widened `--state all` search enlarges the pool this confirmation guards: a
+   long-closed issue whose title merely tokenises the same ADR id is now a
+   candidate match too, so run the check on closed hits exactly as on open ones.
 
    Quote the target when it contains a `:` — `--search '"roster:ADR-006" in:title'`,
    and likewise `'"nav:ADR-002" in:title'`. Unquoted, GitHub reads `roster:` /

--- a/.claude/skills/consistency-audit/scripts/audit_docs.py
+++ b/.claude/skills/consistency-audit/scripts/audit_docs.py
@@ -121,6 +121,35 @@ FENCE_DELIM = re.compile(r"^(\s*)(`{3,}|~{3,})(.*)$")
 # detector to `id:`-keyed YAML keeps candidate resolution unambiguous (basename
 # = `<id>.yaml`) and excludes illustrative swift/prose snippets by construction.
 YAML_ID = re.compile(r"^id:\s*([A-Za-z0-9_./-]+)\s*$")
+# --- Threshold near-miss reporting: considered, DECLINED (2026-08-12) --------
+# Output Contract rule 6 calls a near-miss tally "the cheapest evidence there is
+# that a bar sits too tight", and its deterministic-detector carve-out exempts a
+# script's predicate from the ban on judgment but NOT from the count. Declined
+# here anyway, on the specifics of these two gates:
+#
+#  1. Neither threshold is a gate on its own. A mirror must clear MIRROR_MIN_LINES
+#     *and* MIRROR_MIN_COMPLETENESS *and* MIRROR_MIN_RATIO; a navigation finding
+#     must clear NAV_MIN_LINES *and* NAV_MIN_SHARE — and the NAV pair is fitted
+#     together, one degree of freedom (see its comment). So "N candidates fell
+#     just below MIN_LINES" is not evidence about the bar: a 7-line block at 0.1
+#     completeness is nowhere near firing, and counting it overstates suppression.
+#  2. Making the count meaningful means evaluating the *remaining* terms for every
+#     sub-threshold candidate — i.e. running the part of the detector these gates
+#     exist to short-circuit, on everything. That is a structural change, not a
+#     counter, and it prices in per-term "near" bands that are themselves new
+#     unjustified constants.
+#  3. The cheap approximation needs no permanent code and is available on demand:
+#     `wc -l docs/decisions/ADR-*.md` shows the size distribution. Measured
+#     2026-08-12 — three ADRs sit in 500–599 lines (ADR-007 525, ADR-003 518,
+#     ADR-020 502) and none within 50 lines of the 600 bar, so the gate is not
+#     currently sitting on a cluster.
+#
+# Re-open this if a human ever finds drift the detector should have caught: that
+# is the evidence a tally would have been standing in for. Until then the run
+# report's found / deduped / capped / surfaced arithmetic (SKILL.md Step 5) is
+# the accounting rule 6 requires, and it is complete for everything the detector
+# actually emits.
+#
 # A block counts as a mirror only when it is a *near-complete* drifted copy of
 # the resolved source. The primary discriminator is completeness (block length /
 # source length): a real mirror is essentially the whole file (#921's presets.md
@@ -130,9 +159,12 @@ YAML_ID = re.compile(r"^id:\s*([A-Za-z0-9_./-]+)\s*$")
 # margin than an ordered-line similarity ratio would (0.44 vs 0.34 is a knife
 # edge). MIN_LINES kills tiny schema snippets (the 4-line gallery-README `id: … /
 # name: ...`); MIN_RATIO is a secondary anti-coincidence floor so a long block
-# that merely shares a real id but no content stays silent. needs_judgment, so a
-# borderline miss is preferred to a false flag (Output Contract: conservative
-# wins).
+# that merely shares a real id but no content stays silent. needs_judgment, so
+# the predicate is tuned for precision — legitimate here only because this is a
+# *deterministic* detector, which Output Contract rule 6 lets hold its predicate
+# in code, reviewable at source, where a model-driven detector may not
+# self-filter at all. See the near-miss block above for the count that carve-out
+# does not exempt.
 MIRROR_MIN_LINES = 8
 MIRROR_MIN_COMPLETENESS = 0.6
 MIRROR_MIN_RATIO = 0.3
@@ -200,8 +232,11 @@ NAV_EXEMPT = re.compile(r"^<!--\s*nav-exempt:")
 # body is a minority of what a reader scrolls past" — a large ADR whose bulk is
 # *body* (ADR-005: 1479 lines, 8%) is not this problem; 600 is the operator's
 # judgment that ADR-021 is past what a reader can hold, set well below the
-# 2355-line/75% case #1382 actually problematised. Conservative per Output
-# Contract rule 6: prefer a miss.
+# 2355-line/75% case #1382 actually problematised. A precision-first bar, which
+# Output Contract rule 6 permits under its *deterministic-detector* carve-out
+# (predicate in code, reviewable at source) — NOT under its detection-stage rule,
+# which forbids a model filtering this way. Near-miss counting: see the declined
+# block above MIRROR_MIN_LINES.
 #
 # Known false-negative class: ADR-010 records amendments as inline bold
 # (`**Amendment 2026-06-20 …:**`), not as a heading, so it can never fire no
@@ -946,7 +981,8 @@ def mirror_finding(block_lines: list[str], indent: int, open_line: int,
 
     Deliberately silent when the block is identical to the source: an in-sync
     embed is not a current inconsistency, and flagging it would be style-nagging
-    (a false-positive under 'conservative wins'). It surfaces once it drifts."""
+    — a false positive, which the precision-first predicate above exists to
+    avoid. It surfaces once it drifts."""
     block = _dedent_block(block_lines, indent)
     if len(block) < MIRROR_MIN_LINES:
         return None

--- a/.claude/skills/consistency-audit/scripts/audit_docs.py
+++ b/.claude/skills/consistency-audit/scripts/audit_docs.py
@@ -122,10 +122,10 @@ FENCE_DELIM = re.compile(r"^(\s*)(`{3,}|~{3,})(.*)$")
 # = `<id>.yaml`) and excludes illustrative swift/prose snippets by construction.
 YAML_ID = re.compile(r"^id:\s*([A-Za-z0-9_./-]+)\s*$")
 # --- Threshold near-miss reporting: considered, DECLINED (2026-08-12) --------
-# Output Contract rule 6 calls a near-miss tally "the cheapest evidence there is
-# that a bar sits too tight", and its deterministic-detector carve-out exempts a
-# script's predicate from the ban on judgment but NOT from the count. Declined
-# here anyway, on the specifics of these two gates:
+# Output Contract rule 6 wants a near-miss tally as cheap evidence that a bar
+# sits too tight, and its deterministic-detector carve-out exempts a predicate
+# from the ban on judgment but NOT from the count. Declined anyway, on the
+# specifics of these two gates:
 #
 #  1. Neither threshold is a gate on its own. A mirror must clear MIRROR_MIN_LINES
 #     *and* MIRROR_MIN_COMPLETENESS *and* MIRROR_MIN_RATIO; a navigation finding
@@ -138,17 +138,15 @@ YAML_ID = re.compile(r"^id:\s*([A-Za-z0-9_./-]+)\s*$")
 #     exist to short-circuit, on everything. That is a structural change, not a
 #     counter, and it prices in per-term "near" bands that are themselves new
 #     unjustified constants.
-#  3. The cheap approximation needs no permanent code and is available on demand:
-#     `wc -l docs/decisions/ADR-*.md` shows the size distribution. Measured
-#     2026-08-12 — three ADRs sit in 500–599 lines (ADR-007 525, ADR-003 518,
-#     ADR-020 502) and none within 50 lines of the 600 bar, so the gate is not
-#     currently sitting on a cluster.
+#  3. The cheap approximation needs no permanent code: `wc -l
+#     docs/decisions/ADR-*.md`. Measured 2026-08-12 — three ADRs sit in 500–599
+#     lines (ADR-007 525, ADR-003 518, ADR-020 502), none within 50 of the 600
+#     bar, so the gate is not currently sitting on a cluster.
 #
-# Re-open this if a human ever finds drift the detector should have caught: that
-# is the evidence a tally would have been standing in for. Until then the run
-# report's found / deduped / capped / surfaced arithmetic (SKILL.md Step 5) is
-# the accounting rule 6 requires, and it is complete for everything the detector
-# actually emits.
+# Re-open this if a human ever finds drift the detector should have caught — that
+# is the evidence a tally would stand in for. Until then the run report's
+# found / deduped / capped / surfaced arithmetic (SKILL.md Step 5) is the
+# accounting rule 6 requires, over everything the detector actually emits.
 #
 # A block counts as a mirror only when it is a *near-complete* drifted copy of
 # the resolved source. The primary discriminator is completeness (block length /
@@ -160,11 +158,10 @@ YAML_ID = re.compile(r"^id:\s*([A-Za-z0-9_./-]+)\s*$")
 # edge). MIN_LINES kills tiny schema snippets (the 4-line gallery-README `id: … /
 # name: ...`); MIN_RATIO is a secondary anti-coincidence floor so a long block
 # that merely shares a real id but no content stays silent. needs_judgment, so
-# the predicate is tuned for precision — legitimate here only because this is a
-# *deterministic* detector, which Output Contract rule 6 lets hold its predicate
-# in code, reviewable at source, where a model-driven detector may not
-# self-filter at all. See the near-miss block above for the count that carve-out
-# does not exempt.
+# the predicate is tuned for precision — legitimate only under Output Contract
+# rule 6's *deterministic-detector* carve-out (predicate in code, reviewable at
+# source), which a model-driven detector does not get. The carve-out does not
+# exempt the count: see the near-miss block above.
 MIRROR_MIN_LINES = 8
 MIRROR_MIN_COMPLETENESS = 0.6
 MIRROR_MIN_RATIO = 0.3
@@ -232,11 +229,9 @@ NAV_EXEMPT = re.compile(r"^<!--\s*nav-exempt:")
 # body is a minority of what a reader scrolls past" — a large ADR whose bulk is
 # *body* (ADR-005: 1479 lines, 8%) is not this problem; 600 is the operator's
 # judgment that ADR-021 is past what a reader can hold, set well below the
-# 2355-line/75% case #1382 actually problematised. A precision-first bar, which
-# Output Contract rule 6 permits under its *deterministic-detector* carve-out
-# (predicate in code, reviewable at source) — NOT under its detection-stage rule,
-# which forbids a model filtering this way. Near-miss counting: see the declined
-# block above MIRROR_MIN_LINES.
+# 2355-line/75% case #1382 actually problematised. A precision-first bar under
+# the same deterministic-detector carve-out as MIRROR_MIN_LINES above — see there
+# for what the carve-out does and does not exempt.
 #
 # Known false-negative class: ADR-010 records amendments as inline bold
 # (`**Amendment 2026-06-20 …:**`), not as a heading, so it can never fire no

--- a/.claude/skills/consistency-audit/tests/run_tests.sh
+++ b/.claude/skills/consistency-audit/tests/run_tests.sh
@@ -34,12 +34,11 @@ nj_type_len() { echo "$1" | jq --arg t "$2" '[.needs_judgment[] | select(.type==
 # unavoidable while a target names its ADR, and handled in SKILL.md Step 4 by
 # confirming the matched issue before skipping.
 #
-# Also out of reach here: Step 4's `stateReason` branch (a `COMPLETED` close
-# must NOT suppress, a `NOT_PLANNED` one must). That branch is skill prose
-# executed against the live GitHub API, and this harness is deliberately
-# fixture-only and offline — there is no code path to mutate, so a fixture
-# asserting it would be asserting nothing. Named rather than omitted: the next
-# reader should not read this file's silence as coverage.
+# Also out of reach here: Step 4's `stateReason` branch (a `COMPLETED` close must
+# NOT suppress, a `NOT_PLANNED` one must). It is skill prose executed against the
+# live GitHub API, with no code path in this offline fixture-only harness to
+# mutate — a fixture asserting it would assert nothing. Named rather than
+# omitted, so this file's silence is not read as coverage.
 no_target_collision() {
   local n
   n=$(echo "$1" | jq '[.needs_judgment[] | {t:.type, g:.target}] | group_by(.g)

--- a/.claude/skills/consistency-audit/tests/run_tests.sh
+++ b/.claude/skills/consistency-audit/tests/run_tests.sh
@@ -23,16 +23,23 @@ fail() { echo "FAIL: $1" >&2; exit 1; }
 af_len() { echo "$1" | jq '.auto_fixable | length'; }
 nj_len() { echo "$1" | jq '.needs_judgment | length'; }
 nj_type_len() { echo "$1" | jq --arg t "$2" '[.needs_judgment[] | select(.type==$t)] | length'; }
-# The SKILL's Step 4 cross-run dedup is `gh issue list --search "<target>
-# in:title"` — type-blind, so two finding types sharing a target silently
-# suppress each other across runs. Called on every fixture run that yields
-# judgment findings, not just the ones where two types fire today.
+# The SKILL's Step 4 cross-run dedup is `gh issue list --state all --search
+# "<target> in:title"` — type-blind, so two finding types sharing a target
+# silently suppress each other across runs. Called on every fixture run that
+# yields judgment findings, not just the ones where two types fire today.
 #
 # Scope, stated because a guard narrower than its claim proves nothing: this
 # tests EXACT target equality only. GitHub's search also matches on tokens, so
 # `reservation:ADR-006` and `ADR-006` can still match each other's titles —
 # unavoidable while a target names its ADR, and handled in SKILL.md Step 4 by
 # confirming the matched issue before skipping.
+#
+# Also out of reach here: Step 4's `stateReason` branch (a `COMPLETED` close
+# must NOT suppress, a `NOT_PLANNED` one must). That branch is skill prose
+# executed against the live GitHub API, and this harness is deliberately
+# fixture-only and offline — there is no code path to mutate, so a fixture
+# asserting it would be asserting nothing. Named rather than omitted: the next
+# reader should not read this file's silence as coverage.
 no_target_collision() {
   local n
   n=$(echo "$1" | jq '[.needs_judgment[] | {t:.type, g:.target}] | group_by(.g)

--- a/.claude/skills/queue-consumer/SKILL.md
+++ b/.claude/skills/queue-consumer/SKILL.md
@@ -208,7 +208,8 @@ Agent(subagent_type: "code-reviewer", model: "opus",
 - **FAIL** → fix the confirmed findings, re-run the reviewer once. A
   second FAIL = failed attempt (hard rule 4: retry or block).
 - **SCOPE_TOO_LARGE / incomplete** (count mismatch, or no populated
-  `## Dependency Check`) → hard rule 6: block, no PR. Do not shrink the
+  `## Dependency Check`) → **this skill's** hard rule 6 ("No unreviewed PR",
+  § Hard rules above — *not* Output Contract rule 6): block, no PR. Do not shrink the
   review's scope to force a pass.
 
 ## Step 5 — Draft PR + label release (completes the issue)

--- a/.claude/skills/triage-guardian/SKILL.md
+++ b/.claude/skills/triage-guardian/SKILL.md
@@ -234,6 +234,14 @@ WIP=$(gh pr list --state open --draft --json headRefName \
   --jq '[.[] | select(.headRefName | test("^(audit|agent)/"))] | length')
 ```
 
+**Scope: this section bounds the Draft-PR lane only.** The constant and
+predicate above count *open Draft PRs*, so rule-2 judgment **issues** fall
+outside them entirely. That lane has its own per-run cap — `JUDGMENT_ISSUE_CAP`,
+canonical in `.claude/skills/consistency-audit/SKILL.md` (Constants + Step 4
+step 2), since `consistency-audit` is the only generator that files issues
+unattended. It is a cross-reference, not a mirrored literal: it is **not** part
+of the three-file sync rule above, and changing it does not touch this file.
+
 **Why an aggregate ceiling on top of per-generator caps.** Each generator
 already caps its *own* lane (consistency-audit: ≤1 open `audit/*`;
 queue-consumer: QUOTA-2 per run). Nothing watches the *sum*. As more generators

--- a/.claude/skills/triage-guardian/SKILL.md
+++ b/.claude/skills/triage-guardian/SKILL.md
@@ -77,10 +77,12 @@ human, mirroring consistency-audit's Step 1 note.
    judgment" — never up to "Ready" or "Discard".
    This survives Output Contract rule 6's 2026-08-12 change intact, and the
    resemblance to the wording that rule retired is why it says so here:
-   **classification is the output stage.** O enumerates nothing — `gh pr list`
-   hands it the complete Draft set — so being conservative here filters *how a
-   already-enumerated PR is labelled*, never *whether it is looked at*. Rule 6
-   bans the latter only.
+   **classification is the output stage.** O derives no candidates — GitHub
+   hands it the open Draft set, and its one narrowing (the `^(audit|agent)/`
+   branch predicate, Step 1) is mechanical and reports its ambient total, which
+   rule 6's mechanical carve-out expressly permits. So being conservative here
+   filters *how an already-enumerated PR is labelled*, never *whether it is
+   looked at*. Rule 6 bans the latter only.
 3. **Never present a disposition as an action.** "Ready for your merge decision"
    means *nothing blocks a merge; you decide* — it is never "auto-merge
    eligible". O has no merge authority and must not imply it has.

--- a/.claude/skills/triage-guardian/SKILL.md
+++ b/.claude/skills/triage-guardian/SKILL.md
@@ -80,7 +80,8 @@ human, mirroring consistency-audit's Step 1 note.
    **classification is the output stage.** O derives no candidates — GitHub
    hands it the open Draft set, and its one narrowing (the `^(audit|agent)/`
    branch predicate, Step 1) is mechanical and reports its ambient total, which
-   rule 6's mechanical carve-out expressly permits. So being conservative here
+   rule 6's mechanical carve-out permits — it is a do-not-flag roster in
+   predicate form, and it owes the count it pays. So being conservative here
    filters *how an already-enumerated PR is labelled*, never *whether it is
    looked at*. Rule 6 bans the latter only.
 3. **Never present a disposition as an action.** "Ready for your merge decision"

--- a/.claude/skills/triage-guardian/SKILL.md
+++ b/.claude/skills/triage-guardian/SKILL.md
@@ -75,15 +75,15 @@ human, mirroring consistency-audit's Step 1 note.
    bad merge) or a wrong "Discard" (queued work destroyed) is worse than a miss.
    When the evidence is anything short of decisive, route to "Needs your
    judgment" — never up to "Ready" or "Discard".
-   This survives Output Contract rule 6's 2026-08-12 change intact, and the
-   resemblance to the wording that rule retired is why it says so here:
-   **classification is the output stage.** O derives no candidates — GitHub
-   hands it the open Draft set, and its one narrowing (the `^(audit|agent)/`
-   branch predicate, Step 1) is mechanical and reports its ambient total, which
-   rule 6's mechanical carve-out permits — it is a do-not-flag roster in
-   predicate form, and it owes the count it pays. So being conservative here
-   filters *how an already-enumerated PR is labelled*, never *whether it is
-   looked at*. Rule 6 bans the latter only.
+   This survives Output Contract rule 6's 2026-08-12 change intact; it says so
+   here because it resembles the wording that rule retired. **Classification is
+   the output stage.** O enumerates nothing (GitHub hands it the open Draft
+   set), and its
+   one narrowing — the `^(audit|agent)/` predicate, Step 1 — is a do-not-flag
+   roster in predicate form that reports its ambient total, which rule 6's
+   mechanical carve-out permits. Conservatism here filters *how an
+   already-enumerated PR is labelled*, never *whether it is looked at*; rule 6
+   bans the latter only.
 3. **Never present a disposition as an action.** "Ready for your merge decision"
    means *nothing blocks a merge; you decide* — it is never "auto-merge
    eligible". O has no merge authority and must not imply it has.
@@ -248,8 +248,8 @@ predicate above count *open Draft PRs*, so rule-2 judgment **issues** fall
 outside them entirely. That lane has its own per-run cap — `JUDGMENT_ISSUE_CAP`,
 canonical in `.claude/skills/consistency-audit/SKILL.md` (Constants + Step 4
 step 2), since `consistency-audit` is the only generator that files issues
-unattended. It is a cross-reference, not a mirrored literal: it is **not** part
-of the three-file sync rule above, and changing it does not touch this file.
+unattended. Named here as a cross-reference only: it is **not** part of the
+three-file sync rule above, and changing it does not touch this file.
 
 **Why an aggregate ceiling on top of per-generator caps.** Each generator
 already caps its *own* lane (consistency-audit: ≤1 open `audit/*`;

--- a/.claude/skills/triage-guardian/SKILL.md
+++ b/.claude/skills/triage-guardian/SKILL.md
@@ -75,6 +75,12 @@ human, mirroring consistency-audit's Step 1 note.
    bad merge) or a wrong "Discard" (queued work destroyed) is worse than a miss.
    When the evidence is anything short of decisive, route to "Needs your
    judgment" — never up to "Ready" or "Discard".
+   This survives Output Contract rule 6's 2026-08-12 change intact, and the
+   resemblance to the wording that rule retired is why it says so here:
+   **classification is the output stage.** O enumerates nothing — `gh pr list`
+   hands it the complete Draft set — so being conservative here filters *how a
+   already-enumerated PR is labelled*, never *whether it is looked at*. Rule 6
+   bans the latter only.
 3. **Never present a disposition as an action.** "Ready for your merge decision"
    means *nothing blocks a merge; you decide* — it is never "auto-merge
    eligible". O has no merge authority and must not imply it has.

--- a/.claude/skills/ui-refine/SKILL.md
+++ b/.claude/skills/ui-refine/SKILL.md
@@ -7,7 +7,8 @@ allowed-tools: Read, Write, Edit, Grep, Glob, Bash
 # /ui-refine
 
 One UI design-critique cycle: **capture → pick lens → enumerate → adversarial
-filter → dedup → rank &amp; truncate → digest**. The design-layer sibling of `/scenario-refine`: where
+filter → dedup → rank & truncate → digest**.
+The design-layer sibling of `/scenario-refine`: where
 refine evaluates and polishes the existing *scenario* inventory, ui-refine
 evaluates and polishes the existing *UI*. Run from the repository root of the
 **persistent main checkout** (see Safety boundary). Concept + data model:
@@ -279,14 +280,21 @@ rule 6 bans.
   two-section digest (Step 7) groups by kind; it does not raise the ceiling.
 - **Rank key**, declared so the truncation is reproducible rather than
   whatever order the candidates were written in:
-  1. **Kind** — a `compliance-gap` outranks a `design-proposal`. A verified
+  1. **Starvation guard** — a candidate re-derived from a `parked` row already
+     deferred **3 or more times** (`[quota ×N]` in its note, Step 7) outranks
+     *everything*. Without a term above severity, a low-severity proposal parked
+     once is outranked by any fresher higher-severity candidate on every
+     subsequent run, indefinitely — a permanent drop dressed as a deferral,
+     which is exactly what rule 6 forbids. A tiebreak cannot fix that; only a
+     term that eventually wins can.
+  2. **Kind** — a `compliance-gap` outranks a `design-proposal`. A verified
      divergence from a spec-determined value is the higher-confidence finding by
      construction (Step 4 says so already); the quota should never spend its slot
      on judgment while a violation waits.
-  2. **Estimated severity**, then **confidence** (both authored at Step 3).
-  3. **Re-derived from a `parked` row** — a candidate the quota already deferred
-     once wins the tie, so nothing starves at the bottom of the ranking forever.
-  4. Screen name, lexicographically — the tiebreak that makes the order *total*.
+  3. **Estimated severity**, then **confidence** (both authored at Step 3).
+  4. **Re-derived from a `parked` row** (deferred once or twice) — breaks a tie
+     among otherwise equally-ranked candidates.
+  5. Screen name, lexicographically — the tiebreak that makes the order *total*.
 - **Everything below the cut is `parked`, not rejected** — it was never judged
   unworthy, and Step 7 records it as such so the next run can re-rank it.
 
@@ -316,9 +324,14 @@ rule 6 bans.
 
    | Outcome | `status` | `note` prefix | Suppresses future runs? |
    |---|---|---|---|
-   | Surfaced in the digest | `proposed` | `[compliance-gap]` for a gap; none for a design proposal | yes |
+   | Surfaced in the digest | `proposed` | — | yes |
    | Dropped by the Step 4 adversarial filter | `rejected` | `[filter-drop: <failing test>]` | **yes** — it was judged |
-   | Below the Step 6 quota cut | `parked` | `[quota]` | **no** — it was never judged (Step 5 carve-out) |
+   | Below the Step 6 quota cut | `parked` | `[quota ×N]` (`N` = times deferred, starting at 1) | **no** — it was never judged (Step 5 carve-out) |
+
+   `[compliance-gap]` is **orthogonal** and composes with all three — a gap that
+   is filter-dropped or parked keeps it, leading:
+   `[compliance-gap] [quota ×2] …`. It marks the finding *kind*, not the
+   outcome (`ledger.md` § Format).
 
    `parked` is a **machine** status and exists only to hold a deferral; it is
    deliberately distinct from the human-set `deferred`, which does suppress. Do
@@ -327,11 +340,12 @@ rule 6 bans.
 
    **In-place update, narrowly exempted from append-only.** The skill may edit
    exactly one thing: a `parked` row it wrote itself, when a later run
-   re-derives the same concept — refresh its `date`, and flip `status` to
-   `proposed` if it clears the quota this time. This keeps a long-deferred
-   candidate from accreting one duplicate row per rotation. **No other in-place
-   edit is permitted**; every other row, and every human-owned field, stays the
-   human's (README § Ledger lifecycle).
+   re-derives the same concept — refresh its `date`, **increment `N` in
+   `[quota ×N]`** (the counter Step 6's starvation guard reads), and flip
+   `status` to `proposed` if it clears the quota this time. This keeps a
+   long-deferred candidate from accreting one duplicate row per rotation.
+   **No other in-place edit is permitted**; every other row, and every
+   human-owned field, stays the human's (README § Ledger lifecycle).
 
    Keep ids ordered (newest last). **Do not commit or push** — leave the change
    in the working tree for the human (Safety boundary).

--- a/.claude/skills/ui-refine/SKILL.md
+++ b/.claude/skills/ui-refine/SKILL.md
@@ -6,8 +6,8 @@ allowed-tools: Read, Write, Edit, Grep, Glob, Bash
 
 # /ui-refine
 
-One UI design-critique cycle: **capture → pick lens → propose → adversarial
-filter → dedup → digest**. The design-layer sibling of `/scenario-refine`: where
+One UI design-critique cycle: **capture → pick lens → enumerate → adversarial
+filter → dedup → rank &amp; truncate → digest**. The design-layer sibling of `/scenario-refine`: where
 refine evaluates and polishes the existing *scenario* inventory, ui-refine
 evaluates and polishes the existing *UI*. Run from the repository root of the
 **persistent main checkout** (see Safety boundary). Concept + data model:
@@ -55,7 +55,7 @@ Optional args:
 full before Step 0.** It is path-scoped to `.claude/skills/**`, which fires when a
 skill file is *read*, not on this skill's *execution* — a run drives its scripts
 through Bash without reading a skill file, so nothing auto-loads it during a
-run. The two rules that bind a digest-only generator:
+run. The three rules that bind a digest-only generator:
 
 - **Rule 2 — judgment output carries confidence + counter-evidence.** Every
   proposal in the digest carries a confidence and an explicit "why this might be
@@ -63,6 +63,12 @@ run. The two rules that bind a digest-only generator:
   judgment output, so this binds every entry.)
 - **Rule 5 — manual-first.** Trust the digest only after a human has eyeballed
   the output across a full lens rotation at least once.
+- **Rule 6 — conservative *output*, exhaustive detection.** The quota is a
+  **rank-then-truncate over an already-enumerated list** (Step 6), never a cap
+  on generating candidates: a cap that stops the search cannot name what it
+  excluded, and it would reduce `enumerated` in Step 7's arithmetic to the cap
+  itself. Step 3 therefore enumerates without a ceiling; Steps 4–6 are the
+  output stage, and every drop is both counted and given a reason.
 
 The family **WIP ceiling** (`AUTOMATION_WIP_CEILING`, canonical in
 `.claude/skills/triage-guardian/SKILL.md` § Backpressure) is **inert** for this
@@ -170,7 +176,7 @@ Resolve `LENS` to its definition in
 (or use the `lens:` arg if provided). Read that lens's design-system anchors —
 those are the principles a proposal under this lens must cite.
 
-## Step 3 — Generate quota-capped proposals
+## Step 3 — Enumerate candidates (no generation cap)
 
 Read the relevant capture artifacts with vision — the static screenshots (all 14,
 or the `screen:` arg subset) for default lenses, or the motion filmstrip frames
@@ -178,20 +184,39 @@ under `docs/design/motion/<variant>/` for **L4** — read the lens's anchor
 sections in `docs/design/design-system.md`, then generate candidates **strictly
 through today's lens** — do not drift into other lenses' concerns.
 
-- **Quota: at most 1–2 candidates — per run, total across both kinds**
-  (design proposals + compliance gaps), **not per bucket.** The two-section
-  digest (Step 6) groups survivors by kind; it does not raise the ceiling. Force
-  ranking: "if you could change one thing under this lens, what and why." Quality
-  via scarcity.
+- **No ceiling here. Enumerate everything the lens surfaces.** The 1–2 quota
+  used to live at this step, which is exactly the shape Contract rule 6 bans: a
+  cap applied while generating cannot name what it excluded, and the loss is
+  invisible — two surfaced proposals look identical whether the pass found two
+  or twenty. The quota still exists; it moved to **Step 6**, after the filters,
+  where truncation happens over a list that was written down first. Do not
+  re-introduce scarcity here in the name of quality.
+- **If you approach your own coverage ceiling, stop and say so** rather than
+  trimming quietly — an explicit "did not reach screens 09–14" is a finding
+  about the run; a silent short list is not.
 - **Every candidate must carry:** the design-system anchor (or named HIG / WCAG
-  guideline) it advances, the screen(s) it concerns, and a concrete
-  **before → after** — not a vague "make it nicer." A candidate that can't name
-  an anchor or a concrete change is dropped here.
+  guideline) it advances, the screen(s) it concerns, a concrete
+  **before → after** — not a vague "make it nicer" — plus a **confidence**, an
+  **estimated severity**, and a **counter-evidence** line. The last three are
+  the rank key Step 6 truncates on and the fields rule 2 files on: author them
+  now, at detection, not when the digest is written.
+- **The one drop allowed at this step is the evidence precondition**, and it is
+  mechanical, not a judgment: a candidate that cannot name an anchor or state a
+  concrete before → after is not a finding. Count those drops — Step 7 reports
+  them.
 
 ## Step 4 — Adversarial self-filter
 
-For each surviving candidate, switch stance and try to **reject** it. Drop it
-unless it survives every test:
+For each enumerated candidate, switch stance and try to **reject** it. Drop it
+unless it survives every test.
+
+**Every drop here is recorded, not merely discarded** — it becomes a `rejected`
+ledger row with the failing test named (Step 7). This is the rejection memory
+Contract rule 6 requires be kept where the *next* run can see it; without it,
+each rotation re-derives the same candidate, re-rejects it, and nobody learns
+whether the filter is too tight.
+
+Tests:
 
 - **Already by-design?** Does design-system.md or a `.claude/rules/` entry
   already prescribe the current behaviour deliberately?
@@ -206,7 +231,7 @@ unless it survives every test:
     highest-confidence finding — not a design proposal, but never a drop. (The
     dogfood's UR-001 § 5.11 violation is exactly this; the literal "already
     covered → drop" test would have suppressed it.) Route it to the
-    **compliance-gap bucket** (Step 6). It MUST cite the *specific* violated
+    **compliance-gap bucket** (Step 7). It MUST cite the *specific* violated
     anchor **and** the observed-vs-prescribed delta (the same before → after
     rigor Step 3 demands) — a compliance gap that can't show the delta is a
     re-derivation in disguise; drop it.
@@ -222,18 +247,50 @@ unless it survives every test:
 
 Only survivors proceed — *design proposals* and *compliance gaps* alike. Carry
 each survivor's **kind** (`design-proposal` | `compliance-gap`) forward to
-Steps 5–6.
+Steps 5–7.
 
 ## Step 5 — Dedup against the ledger
 
 Read `docs/design/ui-refine/ledger.md`. Drop any survivor that restates an
 existing row's **concept** (match on idea, not exact string) — regardless of that
 row's status (`proposed` / `filed` / `rejected` / `deferred` / `done`). This is
-the linchpin: it stops the same idea resurfacing every rotation. If everything
-dedups away, that is a healthy outcome — write a digest that says "no new
-proposals this run" and append nothing.
+the linchpin: it stops the same idea resurfacing every rotation.
 
-## Step 6 — Write the digest + append the ledger
+**One carve-out: `parked` does not suppress.** A `parked` row is a candidate a
+*previous run's quota* truncated (Step 6) — it was never judged, only deferred,
+so treating it as a duplicate would let the quota do permanently what it is only
+allowed to do for one run. A survivor matching a `parked` row proceeds to Step 6
+and competes for the quota again; note that it is re-derived so Step 6 can break
+ties in its favour. Every other status — including the human-set `deferred` —
+suppresses as before.
+
+If everything dedups away, that is a healthy outcome — write a digest that says
+"no new proposals this run" and append nothing.
+
+## Step 6 — Rank, then truncate to the quota
+
+The quota that used to sit at Step 3. Applied **here**, over a list that has been
+enumerated (Step 3), filtered (Step 4) and deduped (Step 5), it is the
+rank-then-truncate Contract rule 6 permits; applied at generation it was the cap
+rule 6 bans.
+
+- **Quota: at most 1–2 survivors reach the digest — per run, total across both
+  kinds** (design proposals + compliance gaps), **not per bucket.** The
+  two-section digest (Step 7) groups by kind; it does not raise the ceiling.
+- **Rank key**, declared so the truncation is reproducible rather than
+  whatever order the candidates were written in:
+  1. **Kind** — a `compliance-gap` outranks a `design-proposal`. A verified
+     divergence from a spec-determined value is the higher-confidence finding by
+     construction (Step 4 says so already); the quota should never spend its slot
+     on judgment while a violation waits.
+  2. **Estimated severity**, then **confidence** (both authored at Step 3).
+  3. **Re-derived from a `parked` row** — a candidate the quota already deferred
+     once wins the tie, so nothing starves at the bottom of the ranking forever.
+  4. Screen name, lexicographically — the tiebreak that makes the order *total*.
+- **Everything below the cut is `parked`, not rejected** — it was never judged
+  unworthy, and Step 7 records it as such so the next run can re-rank it.
+
+## Step 7 — Write the digest + append the ledger
 
 1. **Digest** — write `docs/design/ui-refine/digests/YYYY-MM-DD-L<n>-<slug>.md`
    (date from `date +%F`). Rank the survivors, grouped into two labeled sections
@@ -248,15 +305,38 @@ proposals this run" and append nothing.
      a concrete before → after, **confidence**, and a **counter-evidence** line
      (Output Contract rule 2 — judgment output carries confidence + counter-evidence).
    Omit a section that is empty; if there are no survivors at all, record that
-   explicitly.
-2. **Ledger** — append one row per survivor to `ledger.md` with the next
-   `UR-NNN` id, today's date, the lens, the screen, a one-line concept summary,
-   status `proposed`, and the rationale in `note`. **Pin the kind in the row:** a
-   compliance gap prefixes its `note` with `[compliance-gap]` (a design proposal
-   needs no prefix), so the kind is visible to dedup (Step 5) and human triage —
-   a digest-only kind would bypass the linchpin dedup memory. Keep ids ordered
-   (newest last). **Do not commit or push** — leave the change in the working
-   tree for the human (Safety boundary).
-3. Report to the user: the digest path, the lens used, how many candidates were
-   generated / filtered / deduped / surfaced, and a reminder that promotion
+   explicitly. Also record, in a short closing section, **what did not reach the
+   digest**: the Step 4 rejections with their failing test, and the Step 6
+   `parked` candidates. The digest is where a human can see the shape of the
+   filter, not just its output.
+2. **Ledger** — append rows to `ledger.md` with the next `UR-NNN` id, today's
+   date, the lens, the screen, a one-line concept summary, and the rationale in
+   `note`. **Three kinds of row, and the status is what distinguishes them for
+   dedup** (Step 5):
+
+   | Outcome | `status` | `note` prefix | Suppresses future runs? |
+   |---|---|---|---|
+   | Surfaced in the digest | `proposed` | `[compliance-gap]` for a gap; none for a design proposal | yes |
+   | Dropped by the Step 4 adversarial filter | `rejected` | `[filter-drop: <failing test>]` | **yes** — it was judged |
+   | Below the Step 6 quota cut | `parked` | `[quota]` | **no** — it was never judged (Step 5 carve-out) |
+
+   `parked` is a **machine** status and exists only to hold a deferral; it is
+   deliberately distinct from the human-set `deferred`, which does suppress. Do
+   not merge the two — the note prefix alone would not be enough, because a
+   human setting `deferred` during promotion is never told to write one.
+
+   **In-place update, narrowly exempted from append-only.** The skill may edit
+   exactly one thing: a `parked` row it wrote itself, when a later run
+   re-derives the same concept — refresh its `date`, and flip `status` to
+   `proposed` if it clears the quota this time. This keeps a long-deferred
+   candidate from accreting one duplicate row per rotation. **No other in-place
+   edit is permitted**; every other row, and every human-owned field, stays the
+   human's (README § Ledger lifecycle).
+
+   Keep ids ordered (newest last). **Do not commit or push** — leave the change
+   in the working tree for the human (Safety boundary).
+3. Report to the user: the digest path, the lens used, the full output-stage
+   arithmetic — **enumerated / precondition-dropped / filtered / deduped /
+   parked / surfaced** (every number, even when zero; a missing line is what
+   makes a too-tight filter invisible) — and a reminder that promotion
    (digest → issue + committing the ledger) is a manual step.

--- a/.claude/skills/ui-refine/SKILL.md
+++ b/.claude/skills/ui-refine/SKILL.md
@@ -186,12 +186,9 @@ sections in `docs/design/design-system.md`, then generate candidates **strictly
 through today's lens** — do not drift into other lenses' concerns.
 
 - **No ceiling here. Enumerate everything the lens surfaces.** The 1–2 quota
-  used to live at this step, which is exactly the shape Contract rule 6 bans: a
-  cap applied while generating cannot name what it excluded, and the loss is
-  invisible — two surfaced proposals look identical whether the pass found two
-  or twenty. The quota still exists; it moved to **Step 6**, after the filters,
-  where truncation happens over a list that was written down first. Do not
-  re-introduce scarcity here in the name of quality.
+  lives at **Step 6**, after the filters, where it truncates a list that was
+  written down first. Do not re-introduce scarcity here in the name of quality:
+  a cap applied while generating cannot name what it excluded (Contract rule 6).
 - **If you approach your own coverage ceiling, stop and say so** rather than
   trimming quietly — an explicit "did not reach screens 09–14" is a finding
   about the run; a silent short list is not.
@@ -271,10 +268,8 @@ If everything dedups away, that is a healthy outcome — write a digest that say
 
 ## Step 6 — Rank, then truncate to the quota
 
-The quota that used to sit at Step 3. Applied **here**, over a list that has been
-enumerated (Step 3), filtered (Step 4) and deduped (Step 5), it is the
-rank-then-truncate Contract rule 6 permits; applied at generation it was the cap
-rule 6 bans.
+Applied here — over a list already enumerated (Step 3), filtered (Step 4) and
+deduped (Step 5) — this is the rank-then-truncate Contract rule 6 permits.
 
 - **Quota: at most 1–2 survivors reach the digest — per run, total across both
   kinds** (design proposals + compliance gaps), **not per bucket.** The
@@ -284,10 +279,9 @@ rule 6 bans.
   1. **Starvation guard** — a candidate re-derived from a `parked` row already
      deferred **3 or more times** (`[quota ×N]` in its note, Step 7) outranks
      *everything*. Without a term above severity, a low-severity proposal parked
-     once is outranked by any fresher higher-severity candidate on every
-     subsequent run, indefinitely — a permanent drop dressed as a deferral,
-     which is exactly what rule 6 forbids. A tiebreak cannot fix that; only a
-     term that eventually wins can.
+     once loses to any fresher higher-severity candidate on every subsequent
+     run, indefinitely — a permanent drop dressed as a deferral. A tiebreak
+     cannot fix that; only a term that eventually wins can.
   2. **Kind** — a `compliance-gap` outranks a `design-proposal`. A verified
      divergence from a spec-determined value is the higher-confidence finding by
      construction (Step 4 says so already); the quota should never spend its slot
@@ -334,10 +328,9 @@ rule 6 bans.
    `[compliance-gap] [quota ×2] …`. It marks the finding *kind*, not the
    outcome (`ledger.md` § Format).
 
-   `parked` is a **machine** status and exists only to hold a deferral; it is
-   deliberately distinct from the human-set `deferred`, which does suppress. Do
-   not merge the two — the note prefix alone would not be enough, because a
-   human setting `deferred` during promotion is never told to write one.
+   `parked` is a **machine** status holding a deferral, deliberately distinct
+   from the human-set `deferred`, which does suppress — do not merge the two
+   (`ledger.md` § Format for why a note prefix cannot stand in for it).
 
    **In-place update, narrowly exempted from append-only.** The skill may edit
    exactly one thing: a `parked` row it wrote itself, when a later run
@@ -346,8 +339,7 @@ rule 6 bans.
    (the counter Step 6's starvation guard reads — the guard is only as real as
    this write); if it clears the quota this time, flip `status` to `proposed`
    and **drop the `[quota ×N]` prefix**, which belongs only to a parked row.
-   This keeps a long-deferred candidate from accreting one duplicate row per
-   rotation. **No other in-place edit is permitted**; every other row, and every
+   **No other in-place edit is permitted**; every other row, and every
    human-owned field, stays the human's (README § Ledger lifecycle).
 
    Keep ids ordered (newest last). **Do not commit or push** — leave the change

--- a/.claude/skills/ui-refine/SKILL.md
+++ b/.claude/skills/ui-refine/SKILL.md
@@ -261,9 +261,10 @@ the linchpin: it stops the same idea resurfacing every rotation.
 *previous run's quota* truncated (Step 6) — it was never judged, only deferred,
 so treating it as a duplicate would let the quota do permanently what it is only
 allowed to do for one run. A survivor matching a `parked` row proceeds to Step 6
-and competes for the quota again; note that it is re-derived so Step 6 can break
-ties in its favour. Every other status — including the human-set `deferred` —
-suppresses as before.
+and competes for the quota again; note that it is re-derived, and carry the
+row's `[quota ×N]` count forward — Step 6 breaks ties in its favour, and once
+`N ≥ 3` ranks it above everything. Every other status — including the human-set
+`deferred` — suppresses as before.
 
 If everything dedups away, that is a healthy outcome — write a digest that says
 "no new proposals this run" and append nothing.
@@ -340,11 +341,13 @@ rule 6 bans.
 
    **In-place update, narrowly exempted from append-only.** The skill may edit
    exactly one thing: a `parked` row it wrote itself, when a later run
-   re-derives the same concept — refresh its `date`, **increment `N` in
-   `[quota ×N]`** (the counter Step 6's starvation guard reads), and flip
-   `status` to `proposed` if it clears the quota this time. This keeps a
-   long-deferred candidate from accreting one duplicate row per rotation.
-   **No other in-place edit is permitted**; every other row, and every
+   re-derives the same concept — refresh its `date`, then take exactly one of
+   two branches: if the quota parks it again, **increment `N` in `[quota ×N]`**
+   (the counter Step 6's starvation guard reads — the guard is only as real as
+   this write); if it clears the quota this time, flip `status` to `proposed`
+   and **drop the `[quota ×N]` prefix**, which belongs only to a parked row.
+   This keeps a long-deferred candidate from accreting one duplicate row per
+   rotation. **No other in-place edit is permitted**; every other row, and every
    human-owned field, stays the human's (README § Ledger lifecycle).
 
    Keep ids ordered (newest last). **Do not commit or push** — leave the change

--- a/docs/design/ui-refine/README.md
+++ b/docs/design/ui-refine/README.md
@@ -28,14 +28,24 @@ open-ended critique pass from drowning the human's review attention — the scar
 resource the whole brush-up family is built to protect:
 
 1. **Proposal ledger** (the linchpin) — [`ledger.md`](ledger.md) records every
-   proposal ever surfaced, with status. Each run dedups against it and never
-   re-proposes a tracked or rejected-with-reason item. This is what kills the
-   daily-repetition flood that a diff gate would otherwise prevent.
+   proposal a run **considered**, not only the ones it surfaced: survivors with
+   status `proposed`, adversarial-filter drops as `rejected`, and quota
+   truncations as `parked`. Each run dedups against it and never re-proposes a
+   tracked or rejected-with-reason item. This is what kills the daily-repetition
+   flood that a diff gate would otherwise prevent. **`parked` is the one status
+   that does not suppress** — a candidate the quota deferred was never judged, so
+   it competes again next rotation rather than being silently buried.
 2. **Rotating lens** — [`lenses.md`](lenses.md) defines seven critique lenses;
    each run uses exactly one, selected deterministically by weekday (`date +%u`).
    Forces depth over breadth and spaces proposals across the week.
-3. **Quota + forced ranking** — at most 1–2 proposals per run. "If you could
-   change one thing under today's lens, what and why."
+3. **Quota + forced ranking** — at most 1–2 proposals reach the digest per run.
+   The quota is applied **after** the filters, as a ranked truncation over a list
+   that was enumerated first — never as a cap on generating candidates. That
+   distinction is Output Contract rule 6 and it is not cosmetic: a cap applied
+   while generating cannot name what it excluded, so the loss is invisible (two
+   surfaced proposals look identical whether the pass found two or twenty). The
+   digest still receives 1–2 items — what changed is that everything below the
+   cut is now named and re-rankable.
 4. **Design-system anchor** — every proposal must cite the
    [design-system](../design-system.md) principle (or a HIG / accessibility
    guideline) it advances, plus a concrete before → after. Vague "make it nicer"
@@ -47,13 +57,17 @@ resource the whole brush-up family is built to protect:
    convention is noise → drop; a screen that **violates** a spec-determined value
    is the highest-value finding → keep it as a **compliance gap** (a code-fix,
    surfaced separately from judgment-based *design proposals*). Only survivors
-   reach the digest.
+   reach the digest — but every drop reaches the **ledger**, with the failing
+   test named, so a filter that is too tight becomes visible instead of just
+   producing quiet runs.
 
 This inherits the brush-up family's shared **Output Contract** (canonical text:
 [`.claude/rules/automation-output-contract.md`](../../../.claude/rules/automation-output-contract.md)).
 The binding rules for a digest-only generator are **rule 2**
-(judgment output carries confidence + counter-evidence) and **rule 5**
-(manual-first: eyeball the output before trusting it).
+(judgment output carries confidence + counter-evidence), **rule 5**
+(manual-first: eyeball the output before trusting it), and **rule 6**
+(conservative *output*, exhaustive detection — mechanisms 1, 3 and 5 above are
+its three moving parts here).
 
 ## Ledger lifecycle (read before scheduling)
 
@@ -65,6 +79,21 @@ mutation. A **human commits the ledger append** — naturally bundled into the
 same step that promotes a digest gem to an issue (see *Promotion*). This keeps
 the skill's "files nothing, pushes nothing" posture intact (matching
 scenario-refine's "a dirty working tree can never reach users" safety model).
+
+**One narrow exception to append-only.** The skill may edit *in place* exactly
+one thing: a `parked` row **it wrote itself**, when a later run re-derives the
+same concept — refreshing its date, and flipping it to `proposed` if it clears
+the quota that run. Without this a long-deferred candidate would accrete one
+duplicate row per rotation. Every other row, and every human-owned field, stays
+the human's; the skill never edits a `proposed` / `filed` / `rejected` /
+`deferred` / `done` row.
+
+**Volume note.** Because drops are now recorded, the ledger grows faster than it
+did when only survivors were written — that is the point (an unrecorded drop is
+indistinguishable from a finding never made), but it is a git-tracked file a
+human commits, so watch it across the first full rotation and prune or archive
+if the file becomes unwieldy. No pruning policy is fixed yet; there is not
+enough data to set one.
 
 **Persistence constraint for the deferred scheduling phase:** because the ledger
 must persist to do its job, ui-refine must run in the **persistent main
@@ -81,7 +110,13 @@ journal. Pin this constraint before any Routine is wired up.
    `filed (#N)`.
 3. For a proposal you decide against, set its row to `rejected` with a one-line
    reason — this is what stops it from resurfacing next rotation.
-4. Commit the `ledger.md` change (and only that) alongside whatever issue/PR work
+4. **A `parked` row needs no action.** It is a machine deferral — the quota cut
+   it, nobody judged it — and the next run re-ranks it automatically. Promote it
+   early by setting it to `filed (#N)` if you want it acted on now, or to
+   `rejected` with a reason to take it out of the rotation for good. Leaving it
+   alone is the correct default; do **not** set it to `deferred` unless you mean
+   the human "considered, not now", which does suppress it.
+5. Commit the `ledger.md` change (and only that) alongside whatever issue/PR work
    the promotion triggered.
 
 ## Known coverage limitations
@@ -135,6 +170,6 @@ in order:
 |------|----------|------|
 | `README.md` | ✅ | This file |
 | `lenses.md` | ✅ | The 7 rotating critique lenses + weekday mapping |
-| `ledger.md` | ✅ | Proposal dedup memory (skill appends, human commits) |
+| `ledger.md` | ✅ | Proposal dedup + rejection memory (skill appends — and may update its own `parked` rows in place; human commits) |
 | `digests/README.md` | ✅ | Explains the digests directory |
 | `digests/*.md` | ❌ gitignored | Per-run digest artifacts |

--- a/docs/design/ui-refine/README.md
+++ b/docs/design/ui-refine/README.md
@@ -40,12 +40,10 @@ resource the whole brush-up family is built to protect:
    Forces depth over breadth and spaces proposals across the week.
 3. **Quota + forced ranking** — at most 1–2 proposals reach the digest per run.
    The quota is applied **after** the filters, as a ranked truncation over a list
-   that was enumerated first — never as a cap on generating candidates. That
-   distinction is Output Contract rule 6 and it is not cosmetic: a cap applied
-   while generating cannot name what it excluded, so the loss is invisible (two
-   surfaced proposals look identical whether the pass found two or twenty). The
-   digest still receives 1–2 items — what changed is that everything below the
-   cut is now named and re-rankable.
+   that was enumerated first — never as a cap on generating candidates, which
+   could not name what it excluded (Output Contract rule 6). The digest receives
+   1–2 items either way; the difference is that everything below the cut is named
+   and re-rankable.
 4. **Design-system anchor** — every proposal must cite the
    [design-system](../design-system.md) principle (or a HIG / accessibility
    guideline) it advances, plus a concrete before → after. Vague "make it nicer"
@@ -80,22 +78,18 @@ same step that promotes a digest gem to an issue (see *Promotion*). This keeps
 the skill's "files nothing, pushes nothing" posture intact (matching
 scenario-refine's "a dirty working tree can never reach users" safety model).
 
-**One narrow exception to append-only.** The skill may edit *in place* exactly
-one thing: a `parked` row **it wrote itself**, when a later run re-derives the
-same concept — refreshing its date, then either incrementing `N` in its
-`[quota ×N]` prefix (parked again) or flipping it to `proposed` and dropping
-that prefix (it cleared the quota). Without this a long-deferred candidate would
-accrete one duplicate row per rotation, and the starvation guard that reads `N`
-would never fire. Every other row, and every human-owned field, stays
-the human's; the skill never edits a `proposed` / `filed` / `rejected` /
-`deferred` / `done` row.
+**One narrow exception to append-only:** a `parked` row **the skill wrote
+itself** may be updated in place when a later run re-derives the same concept
+(mechanics in [`ledger.md`](ledger.md) § Format) — without it, a long-deferred
+candidate accretes one duplicate row per rotation and the starvation guard that
+reads `[quota ×N]` never fires. Every other row, and every human-owned field,
+stays the human's.
 
-**Volume note.** Because drops are now recorded, the ledger grows faster than it
-did when only survivors were written — that is the point (an unrecorded drop is
+**Volume note.** Recording drops makes the ledger grow faster than it did when
+only survivors were written — that is the point (an unrecorded drop is
 indistinguishable from a finding never made), but it is a git-tracked file a
-human commits, so watch it across the first full rotation and prune or archive
-if the file becomes unwieldy. No pruning policy is fixed yet; there is not
-enough data to set one.
+human commits, so watch it across the first full rotation and prune or archive if
+it becomes unwieldy. No pruning policy yet; not enough data to set one.
 
 **Persistence constraint for the deferred scheduling phase:** because the ledger
 must persist to do its job, ui-refine must run in the **persistent main
@@ -112,25 +106,22 @@ journal. Pin this constraint before any Routine is wired up.
    `filed (#N)`.
 3. For a proposal you decide against, set its row to `rejected` with a one-line
    reason — this is what stops it from resurfacing next rotation.
-4. **A `parked` row needs no action.** It is a machine deferral — the quota cut
-   it, nobody judged it — and the next run re-ranks it automatically, with a
-   starvation guard that eventually forces it to the top. Promote it early by
-   setting it to `filed (#N)` if you want it acted on now, or to `rejected` with
-   a reason to take it out of the rotation for good — in either case drop the
-   `[quota ×N]` prefix, which belongs only to a `parked` row. Leaving it alone is the
-   correct default; do **not** set it to `deferred` unless you mean the human
+4. **A `parked` row needs no action** — leaving it alone is the correct default.
+   The quota cut it, nobody judged it, and the next run re-ranks it with a
+   starvation guard that eventually forces it to the top. Promote it early with
+   `filed (#N)`, or take it out of the rotation for good with `rejected` + a
+   reason — in either case drop the `[quota ×N]` prefix, which belongs only to a
+   `parked` row. Do **not** set it to `deferred` unless you mean the human
    "considered, not now", which does suppress it.
 5. **A machine-written `rejected` row is final — and you are the only way back.**
    Unlike `parked`, it *was* judged: the adversarial filter applied a named test
-   and the row records which one (`[filter-drop: <test>]`). Suppressing it
-   permanently is what the Output Contract asks for (a rejection kept where the
-   next run can see it), so the skill will never revisit it on its own.
-   **The caveat is that those tests read the current state** — "already
-   by-design?" and "already covered?" are answered against the design system as
-   it stands. So when a design-system convention changes, grep `ledger.md` for
-   `[filter-drop:]` rows citing the test that relied on it and un-reject the ones
-   whose basis moved (set them back to `proposed`, or delete the row). Nothing
-   automates this; the prefix exists so the sweep is a grep rather than a reread.
+   and the row records which one (`[filter-drop: <test>]`), so the skill never
+   revisits it. **The caveat is that those tests read the current state** —
+   "already by-design?" and "already covered?" are answered against the design
+   system as it stands. So when a design-system convention changes, grep
+   `ledger.md` for `[filter-drop:]` rows citing the test that relied on it and
+   un-reject the ones whose basis moved (back to `proposed`, or delete the row).
+   Nothing automates this; the prefix exists so the sweep is a grep.
 6. Commit the `ledger.md` change (and only that) alongside whatever issue/PR work
    the promotion triggered.
 

--- a/docs/design/ui-refine/README.md
+++ b/docs/design/ui-refine/README.md
@@ -111,12 +111,24 @@ journal. Pin this constraint before any Routine is wired up.
 3. For a proposal you decide against, set its row to `rejected` with a one-line
    reason — this is what stops it from resurfacing next rotation.
 4. **A `parked` row needs no action.** It is a machine deferral — the quota cut
-   it, nobody judged it — and the next run re-ranks it automatically. Promote it
-   early by setting it to `filed (#N)` if you want it acted on now, or to
-   `rejected` with a reason to take it out of the rotation for good. Leaving it
-   alone is the correct default; do **not** set it to `deferred` unless you mean
-   the human "considered, not now", which does suppress it.
-5. Commit the `ledger.md` change (and only that) alongside whatever issue/PR work
+   it, nobody judged it — and the next run re-ranks it automatically, with a
+   starvation guard that eventually forces it to the top. Promote it early by
+   setting it to `filed (#N)` if you want it acted on now, or to `rejected` with
+   a reason to take it out of the rotation for good. Leaving it alone is the
+   correct default; do **not** set it to `deferred` unless you mean the human
+   "considered, not now", which does suppress it.
+5. **A machine-written `rejected` row is final — and you are the only way back.**
+   Unlike `parked`, it *was* judged: the adversarial filter applied a named test
+   and the row records which one (`[filter-drop: <test>]`). Suppressing it
+   permanently is what the Output Contract asks for (a rejection kept where the
+   next run can see it), so the skill will never revisit it on its own.
+   **The caveat is that those tests read the current state** — "already
+   by-design?" and "already covered?" are answered against the design system as
+   it stands. So when a design-system convention changes, grep `ledger.md` for
+   `[filter-drop:]` rows citing the test that relied on it and un-reject the ones
+   whose basis moved (set them back to `proposed`, or delete the row). Nothing
+   automates this; the prefix exists so the sweep is a grep rather than a reread.
+6. Commit the `ledger.md` change (and only that) alongside whatever issue/PR work
    the promotion triggered.
 
 ## Known coverage limitations

--- a/docs/design/ui-refine/README.md
+++ b/docs/design/ui-refine/README.md
@@ -116,7 +116,8 @@ journal. Pin this constraint before any Routine is wired up.
    it, nobody judged it — and the next run re-ranks it automatically, with a
    starvation guard that eventually forces it to the top. Promote it early by
    setting it to `filed (#N)` if you want it acted on now, or to `rejected` with
-   a reason to take it out of the rotation for good. Leaving it alone is the
+   a reason to take it out of the rotation for good — in either case drop the
+   `[quota ×N]` prefix, which belongs only to a `parked` row. Leaving it alone is the
    correct default; do **not** set it to `deferred` unless you mean the human
    "considered, not now", which does suppress it.
 5. **A machine-written `rejected` row is final — and you are the only way back.**

--- a/docs/design/ui-refine/README.md
+++ b/docs/design/ui-refine/README.md
@@ -82,9 +82,11 @@ scenario-refine's "a dirty working tree can never reach users" safety model).
 
 **One narrow exception to append-only.** The skill may edit *in place* exactly
 one thing: a `parked` row **it wrote itself**, when a later run re-derives the
-same concept — refreshing its date, and flipping it to `proposed` if it clears
-the quota that run. Without this a long-deferred candidate would accrete one
-duplicate row per rotation. Every other row, and every human-owned field, stays
+same concept — refreshing its date, then either incrementing `N` in its
+`[quota ×N]` prefix (parked again) or flipping it to `proposed` and dropping
+that prefix (it cleared the quota). Without this a long-deferred candidate would
+accrete one duplicate row per rotation, and the starvation guard that reads `N`
+would never fire. Every other row, and every human-owned field, stays
 the human's; the skill never edits a `proposed` / `filed` / `rejected` /
 `deferred` / `done` row.
 

--- a/docs/design/ui-refine/ledger.md
+++ b/docs/design/ui-refine/ledger.md
@@ -71,7 +71,7 @@ with the kind prefix above:
 |---|---|---|
 | `[compliance-gap]` | any status | the finding kind (above) |
 | `[filter-drop: <test>]` | `rejected` | which adversarial-filter test rejected it (SKILL § Step 4). A machine rejection is **final** — the skill never revisits it; only a human can, and § Promotion step 5 in [README](README.md) says when to sweep |
-| `[quota ×N]` | `parked` | truncated by the run's quota (SKILL § Step 6), not judged. `N` counts how many runs have deferred it — incremented on an in-place refresh **that parks it again**, and dropped with the prefix when the row flips to `proposed`; at `N ≥ 3` Step 6's starvation guard ranks it above everything |
+| `[quota ×N]` | `parked` (dropped whenever the row leaves `parked` — by the skill, or by a human at promotion) | truncated by the run's quota (SKILL § Step 6), not judged. `N` counts how many runs have deferred it — incremented on an in-place refresh **that parks it again**, and dropped with the prefix when the row flips to `proposed`; at `N ≥ 3` Step 6's starvation guard ranks it above everything |
 
 ## Ledger
 

--- a/docs/design/ui-refine/ledger.md
+++ b/docs/design/ui-refine/ledger.md
@@ -1,33 +1,57 @@
 # ui-refine — proposal ledger
 
-The cross-run dedup memory. Every proposal that survives a run's adversarial
-filter is appended here. Before proposing, a run reads this ledger and **must
-not re-surface** any proposal already recorded — regardless of status. This is
-mechanism 1 (the linchpin) in [README](README.md); without it, a periodic
-critique pass against a static UI repeats itself every rotation.
+The cross-run dedup **and rejection** memory. Every candidate a run *considered*
+is appended here — not only the ones it surfaced. Before proposing, a run reads
+this ledger and **must not re-surface** any proposal already recorded, with one
+exception (`parked`, below). This is mechanism 1 (the linchpin) in
+[README](README.md); without it, a periodic critique pass against a static UI
+repeats itself every rotation.
 
 **Lifecycle:** the skill *appends* rows but never commits or pushes. A human
 commits the append, bundled with promoting a digest item to an issue (see
-[README](README.md) § Promotion / § Ledger lifecycle).
+[README](README.md) § Promotion / § Ledger lifecycle). The skill's **one**
+in-place exception is a `parked` row it wrote itself (§ Format).
 
 ## Format
 
-One row per proposal, append-only. Columns:
+One row per candidate, append-only (see the `parked` exception below). Columns:
 
 | Column | Meaning |
 |--------|---------|
 | `id` | `UR-NNN`, monotonically increasing (next id = highest existing + 1, zero-padded to 3). |
-| `date` | `YYYY-MM-DD` of the run that surfaced it. |
+| `date` | `YYYY-MM-DD` of the run that recorded it. |
 | `lens` | `L1`…`L7` (the lens active that run). |
 | `screen` | The tour screen it concerns (e.g. `01-home`), or `cross` for cross-screen. |
 | `proposal` | One-line summary — enough to dedup against, not the full digest entry. |
-| `status` | `proposed` (in a digest, awaiting triage) · `filed (#N)` · `rejected` · `deferred` · `done`. |
+| `status` | `proposed` (in a digest, awaiting triage) · `filed (#N)` · `rejected` · `parked` · `deferred` · `done`. |
 | `note` | Rationale for `proposed`, or the rejection/deferral reason. Empty for `filed`/`done`. |
 
-A new run appends rows with status `proposed`. The human later edits the
-`status`/`note` of existing rows during promotion. **Dedup matches on the
-*concept*, not the exact string** — if a new candidate restates an existing
-row's idea (any status), it is a duplicate and must be dropped.
+**Statuses split by who set them, and that split decides dedup:**
+
+| `status` | Set by | Means | Suppresses a re-derived concept? |
+|---|---|---|---|
+| `proposed` | skill | surfaced in a digest, awaiting triage | yes |
+| `rejected` | skill (adversarial filter) or human | judged and declined; `note` names the failing test | yes |
+| `parked` | **skill only** | below the run's quota cut — **never judged**, only deferred | **no** |
+| `filed (#N)` / `deferred` / `done` | human | promotion outcomes | yes |
+
+**`parked` is the machine deferral and is deliberately NOT `deferred`.** They
+would otherwise collide: `deferred` is a human "considered, not now" — a
+judgment, so it suppresses — while `parked` records only that a quota ran out of
+room that run. Distinguishing them by a `note` prefix alone would not work, since
+a human setting `deferred` during promotion is never told to write one.
+
+**In-place exception.** The skill may edit a `parked` row **it wrote itself**
+when a later run re-derives the same concept: refresh `date`, and flip `status`
+to `proposed` if it clears the quota that time. This keeps one deferred candidate
+from accreting a duplicate row per rotation. No other row and no human-owned
+field is ever machine-edited.
+
+A new run appends rows with status `proposed`, `rejected` or `parked`. The human
+later edits the `status`/`note` of existing rows during promotion. **Dedup
+matches on the *concept*, not the exact string** — if a new candidate restates an
+existing row's idea, it is a duplicate and must be dropped, unless that row is
+`parked`.
 
 **Finding kind (orthogonal to `status`).** A survivor is either a *design
 proposal* (judgment) or a *compliance gap* — a verified divergence from a
@@ -37,6 +61,15 @@ moves through it like any other finding. Record the kind in the row by prefixing
 its `note` with `[compliance-gap]` (a design proposal needs no prefix), so the
 kind stays visible to dedup and human triage instead of living only in the
 gitignored digest.
+
+**Note prefixes** are how a row says *why* it holds its status, and they compose
+with the kind prefix above:
+
+| Prefix | On | Meaning |
+|---|---|---|
+| `[compliance-gap]` | any status | the finding kind (above) |
+| `[filter-drop: <test>]` | `rejected` | which adversarial-filter test rejected it (SKILL § Step 4) |
+| `[quota]` | `parked` | truncated by the run's quota (SKILL § Step 6), not judged |
 
 ## Ledger
 

--- a/docs/design/ui-refine/ledger.md
+++ b/docs/design/ui-refine/ledger.md
@@ -35,19 +35,19 @@ One row per candidate, append-only (see the `parked` exception below). Columns:
 | `parked` | **skill only** | below the run's quota cut — **never judged**, only deferred | **no** |
 | `filed (#N)` / `deferred` / `done` | human | promotion outcomes | yes |
 
-**`parked` is the machine deferral and is deliberately NOT `deferred`.** They
-would otherwise collide: `deferred` is a human "considered, not now" — a
-judgment, so it suppresses — while `parked` records only that a quota ran out of
-room that run. Distinguishing them by a `note` prefix alone would not work, since
-a human setting `deferred` during promotion is never told to write one.
+**`parked` is the machine deferral and is deliberately NOT `deferred`.**
+`deferred` is a human "considered, not now" — a judgment, so it suppresses —
+while `parked` records only that a quota ran out of room that run. A shared
+status distinguished by a `note` prefix would not work: a human setting
+`deferred` during promotion is never told to write one.
 
 **In-place exception.** The skill may edit a `parked` row **it wrote itself**
 when a later run re-derives the same concept: refresh `date`; then either
 **increment `N` in `[quota ×N]`** if it is parked again, or flip `status` to
-`proposed` and drop the `[quota ×N]` prefix if it clears the quota that time.
-The increment is load-bearing — Step 6's starvation guard is only as real as
-that write. This keeps one deferred candidate from accreting a duplicate row per
-rotation. No other row and no human-owned field is ever machine-edited.
+`proposed` and drop the prefix if it clears the quota that time. The increment
+is load-bearing — Step 6's starvation guard is only as real as that write — and
+the update keeps one deferred candidate from accreting a row per rotation. No
+other row and no human-owned field is ever machine-edited.
 
 A new run appends rows with status `proposed`, `rejected` or `parked`. The human
 later edits the `status`/`note` of existing rows during promotion. **Dedup
@@ -71,7 +71,7 @@ with the kind prefix above:
 |---|---|---|
 | `[compliance-gap]` | any status | the finding kind (above) |
 | `[filter-drop: <test>]` | `rejected` | which adversarial-filter test rejected it (SKILL § Step 4). A machine rejection is **final** — the skill never revisits it; only a human can, and § Promotion step 5 in [README](README.md) says when to sweep |
-| `[quota ×N]` | `parked` (dropped whenever the row leaves `parked` — by the skill, or by a human at promotion) | truncated by the run's quota (SKILL § Step 6), not judged. `N` counts how many runs have deferred it — incremented on an in-place refresh **that parks it again**, and dropped with the prefix when the row flips to `proposed`; at `N ≥ 3` Step 6's starvation guard ranks it above everything |
+| `[quota ×N]` | `parked` only — dropped whenever the row leaves it, by the skill or by a human at promotion | truncated by the run's quota (SKILL § Step 6), not judged. `N` counts how many runs have deferred it (incremented per the in-place exception above); at `N ≥ 3` Step 6's starvation guard ranks it above everything |
 
 ## Ledger
 

--- a/docs/design/ui-refine/ledger.md
+++ b/docs/design/ui-refine/ledger.md
@@ -42,10 +42,12 @@ room that run. Distinguishing them by a `note` prefix alone would not work, sinc
 a human setting `deferred` during promotion is never told to write one.
 
 **In-place exception.** The skill may edit a `parked` row **it wrote itself**
-when a later run re-derives the same concept: refresh `date`, and flip `status`
-to `proposed` if it clears the quota that time. This keeps one deferred candidate
-from accreting a duplicate row per rotation. No other row and no human-owned
-field is ever machine-edited.
+when a later run re-derives the same concept: refresh `date`; then either
+**increment `N` in `[quota ×N]`** if it is parked again, or flip `status` to
+`proposed` and drop the `[quota ×N]` prefix if it clears the quota that time.
+The increment is load-bearing — Step 6's starvation guard is only as real as
+that write. This keeps one deferred candidate from accreting a duplicate row per
+rotation. No other row and no human-owned field is ever machine-edited.
 
 A new run appends rows with status `proposed`, `rejected` or `parked`. The human
 later edits the `status`/`note` of existing rows during promotion. **Dedup
@@ -69,7 +71,7 @@ with the kind prefix above:
 |---|---|---|
 | `[compliance-gap]` | any status | the finding kind (above) |
 | `[filter-drop: <test>]` | `rejected` | which adversarial-filter test rejected it (SKILL § Step 4). A machine rejection is **final** — the skill never revisits it; only a human can, and § Promotion step 5 in [README](README.md) says when to sweep |
-| `[quota ×N]` | `parked` | truncated by the run's quota (SKILL § Step 6), not judged. `N` counts how many runs have deferred it, incremented on each in-place refresh; at `N ≥ 3` Step 6's starvation guard ranks it above everything |
+| `[quota ×N]` | `parked` | truncated by the run's quota (SKILL § Step 6), not judged. `N` counts how many runs have deferred it — incremented on an in-place refresh **that parks it again**, and dropped with the prefix when the row flips to `proposed`; at `N ≥ 3` Step 6's starvation guard ranks it above everything |
 
 ## Ledger
 

--- a/docs/design/ui-refine/ledger.md
+++ b/docs/design/ui-refine/ledger.md
@@ -68,8 +68,8 @@ with the kind prefix above:
 | Prefix | On | Meaning |
 |---|---|---|
 | `[compliance-gap]` | any status | the finding kind (above) |
-| `[filter-drop: <test>]` | `rejected` | which adversarial-filter test rejected it (SKILL § Step 4) |
-| `[quota]` | `parked` | truncated by the run's quota (SKILL § Step 6), not judged |
+| `[filter-drop: <test>]` | `rejected` | which adversarial-filter test rejected it (SKILL § Step 4). A machine rejection is **final** — the skill never revisits it; only a human can, and § Promotion step 5 in [README](README.md) says when to sweep |
+| `[quota ×N]` | `parked` | truncated by the run's quota (SKILL § Step 6), not judged. `N` counts how many runs have deferred it, incremented on each in-place refresh; at `N ≥ 3` Step 6's starvation guard ranks it above everything |
 
 ## Ledger
 


### PR DESCRIPTION
## Summary

Output Contract rule 6 の2段構成化（検出段は網羅／出力段で保守的に絞り、落とした分を勘定する）に、生成スキル側の復唱と実装を追随させる。3ホップ正本連鎖（kit → ミラー → スキルの復唱）の3ホップ目。

- **`consistency-audit` hard rule 4** を出力段の規定に差し替え。精度バイアスは残すが、適用箇所が変わった（発見を surface しない理由には使えない）。決定論的検出器の carve-out は judgment の禁止を免じるが件数の公表は免じない、という区別も明記
- **cross-run dedup を `--state all` へ拡張し `stateReason` で分岐**。`NOT_PLANNED` / `DUPLICATE` は抑制、**`COMPLETED` は抑制しない**（修正済みドリフトの再発は重複ではなく regression）。無分岐で広げると逆向きの取りこぼしが出て、しかも clean run と見分けが付かない
- **判断lane に起票上限 `JUDGMENT_ISSUE_CAP` = 3 を新設**。backpressure の既存2つの上限はどちらも開いている Draft PR を数えており、rule 2 の issue は勘定の外だった。列挙済みリストへの rank-then-truncate として実装し、rank key を全順序として明文化。Step 5 で found / deduped / capped / surfaced を lane 別に公表（判断lane は `found = deduped + capped + surfaced` で閉じる）
- **`ui-refine` を 列挙 → 敵対的フィルタ → dedup → 順位付け → truncate に組み替え**。quota は消さず Step 6 へ移した。digest に届く件数は 1–2 件のままで、変わったのは切り落としが名指しできること。ledger は棄却を2種で記録（`rejected`+`[filter-drop]` は抑制する／`parked`+`[quota ×N]` は抑制しない）。`N ≥ 3` の starvation guard 付き
- **`audit_docs.py`** の退役ルール引用3箇所を修正（うち1箇所はルール6を番号で引用しており、現行本文を辿ると正反対に着く）。near-miss 集計は却下し、理由と再開条件を閾値定義の隣に記録
- **ミラーの暫定記述2つを畳む** — § Backpressure の「Pastura has not set one」と rule 6 直後の追随トラッキング段落。どちらも kit `origin/main` に存在しない Pastura 固有の追記であることを確認済み

Closes #1432

## 完了条件の言い換え（原文はそのままでは達成不能）

issue の `grep -rn "Conservative detection\|Prefer a miss" .claude/` → 0件 は、ミラー L63 が退役文言を**意図的に日付付きの歴史記述として引用**しているため達成不能。2段の検査に厳格化し、最終コミット上で実行した実出力を以下に引く:

```
$ grep -rni "conservative detection\|prefer a miss" .claude/ docs/
.claude/rules/automation-output-contract.md:63:   drops.** **Changed 2026-08-12**: this rule used to read *"Conservative detection wins. Prefer a

$ grep -rnE "Output Contract.*conservative|rule 6.*miss" .claude/ docs/
.claude/skills/consistency-audit/scripts/audit_docs.py:125:# Output Contract rule 6 calls a near-miss tally "the cheapest evidence there is
```

残る2ヒットはどちらも意図通り。(1) はミラーの歴史記述そのもの。(2) は本 PR で新規に書いた行で、**現行**ルール6を正しく引用している（`rule 6.*miss` が "near-miss" に当たった検査側の粗さ）。生成スキル本体に旧文言の*規定*も*引用*も残っていない。

## Test plan

- `bash .claude/skills/consistency-audit/tests/run_tests.sh` → ALL TESTS PASSED
- `bash scripts/tests/skill-harness-wiring-test.sh` → ALL TESTS PASSED
- `python3 .claude/skills/consistency-audit/scripts/audit_docs.py --repo-root .` → 変更前後で同一（検出器への編集はコメントのみ）
- `code-reviewer` (Opus) 3ラウンド → PASS（Critical 0 / Warning 0）

検証した実測クレーム: `IssueStateReason` は4値（`REOPENED` 含む）／`dead_link` は `confidence` を出さない（`null`）ため rank key に欠損時規定が必要だった／ADR 行数分布は 500–599 が3本・600 の 50 行以内はゼロ／ミラーから消した2段落は kit `origin/main` に不在。

## Context-economy: agent-instruction ファイル +390 / −73（7ファイル）

**Keep**

- `consistency-audit` hard rule 4 と Step 4 の上限・rank key — 無人 run がポインタを辿らずに読める形が要件そのもの（旧 rule 4 が hard rule だった理由と同じ）。rank key は「再現可能な truncate 順」を主張する以上、順位規則を書かないと主張が空になる
- `stateReason` の分岐表 — `COMPLETED` を抑制する実装は静かにスキルを無効化するので、分岐が読めることが安全性そのもの
- `ui-refine` の `parked` / `[filter-drop]` の区別と starvation guard — どちらも「落としたものが恒久的に消えない」ための機構で、片方だけ実装すると rule 6 違反に戻る

**Drop / relocate 候補（今回は残した）**

- Step 4 の「なぜ 3 か」+ 測定環境の差（約20行）— reviewer も最有力の Drop 候補と指摘。**残した理由**: 上限値は運用で retune される定数で、実測環境（main checkout 2 / fresh worktree 3）を落とすと次に触る人が同じ取り違えを繰り返す。ここは path-scoped（`.claude/skills/**`）で always-loaded ではないため、per-turn コストは掛からない
- `audit_docs.py` の near-miss 却下ブロック（約25行）— コメントであり context 予算には乗らない。閾値 rationale が既に住んでいる場所に置くのが `knowledge-layering.md` の指示

いずれも always-loaded 層（`CLAUDE.md` / `paths:` なし rule）には1行も足していない。

## Device QA

実機QA不要 — スキル定義・ルール・設計ドキュメントのみで、`Pastura/` 配下のソースを一切触っていない（検出器 `audit_docs.py` への編集もコメントのみ）。
