### PR TITLE
📝 docs: /orchestrate Step 1b の強調スタックを減圧する（ゲートは維持）

### DIFF
--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -121,7 +121,7 @@ After user approval, proceed to Step 1b (mandatory critic review).
 
 ## Step 1b: Plan Critique (REQUIRED)
 
-**⚠️ MANDATORY (unless `RESUMING=true`): You MUST complete this step before proceeding to Step 2.**
+This step is a review gate: complete it before Step 2. Skipped only when `RESUMING=true`.
 
 After the user approves the plan (G1), launch a `claude-kit:critic` subagent via the Agent tool to review the plan for blind spots. The agent comes from the claude-kit plugin (`enabledPlugins` in `.claude/settings.json` — Pastura keeps no local copy); it carries no model pin, so **pass `model: opus` explicitly** at invocation. If the agent type is unavailable (plugin not yet trusted/installed on this machine), stop and surface that instead of silently skipping the critique.
 


### PR DESCRIPTION
## Summary

- `/orchestrate` Step 1b 冒頭の強調スタック行（`⚠️ MANDATORY` + `You MUST`）を、意味を落とさない平文に置き換え（1ファイル1行）。
- Claude 5 系は指示を字義通り適用するため、理由の伴わない強調スタックは旧世代向けの注意喚起ブースターとして過剰に効く。見出しが既に `(REQUIRED)` を含み、直後の段落が実際のフェイルモードと理由（plugin 不在なら黙ってスキップせず停止して報告）を述べているので、この行は情報を足していなかった。

```diff
-**⚠️ MANDATORY (unless `RESUMING=true`): You MUST complete this step before proceeding to Step 2.**
+This step is a review gate: complete it before Step 2. Skipped only when `RESUMING=true`.
```

`a gate` ではなく `a review gate` としたのは、本ファイルが `Gate G1` / `Gate G2` を人間確認ゲートの意味で使っているため（critic 提案）。

**Step 1b というゲート自体は維持**。5 系ガイドが撤去を勧めているのは「モデル自身に自己検証を指示する scaffolding」であり、別エージェントによる構造的レビューゲートは意図的な設計。

## Test plan

Swift ソースはゼロ差分（`.claude/skills/**` のマークダウン1行のみ）。`precommit-gate-classify.sh` の分類どおり swiftlint / xcodebuild はスキップ。検証は issue の完了条件に対する差分照合で行い、Opus code-reviewer が独立に再確認（PASS / Critical 0 / Warning 0）:

- [x] `RESUMING=true` の除外が残っている（置換行 + 無変更の L147 / L151 で三重に保持）
- [x] 「Step 2 の前」という順序制約が残っている（置換行 + Step 2 の Precondition L151）
- [x] 直後の「agent 不在なら停止して報告」の記述が無傷（差分は1行のみ）
- [x] ゲートとしての強制力が読み取れる — 独立した強制シグナルが5つ残存（見出しの `(REQUIRED)` / L120 / 置換行 / L132 / L151）。`Skipped only when` は許可ではなく唯一の例外の明示なので、`RESUMING=true` セッションにも G1・G2 結合フローにも新たなバイパス経路は生じない
- [x] 削除した文言への機械的依存者ゼロ（`⚠️ MANDATORY` / `You MUST complete this step` ともリポジトリ全体で他に0ヒット。`CLAUDE.md:247` と `CONTRIBUTING.md:182` の参照は文言ではなくゲートの性質に対するもので、いずれも引き続き正しい）

## Device QA

実機QA不要 — エージェント向けスキル定義のマークダウン1行変更で、アプリのコードにもリソースにも一切触れていない。

## スコープ外（別 issue 候補）

計画時の critic が挙げた、本 PR では触らない2件:

1. `scripts/hooks/check-claude-md-modified.sh:99` の agent-instruction 判定（`^CLAUDE\.md$|^\.claude/(rules|agents)/`）に `.claude/skills/` が含まれず、本 PR 作成時に convention nudge が発火する。本変更は規約を追加・改変しないため CLAUDE.md / `.claude/rules/` への追記は行っていない。
2. Step 1 item 6（結合 G1/G2 は critic の後に確認を出す）と L120（承認後に Step 1b へ）の既存の軽い緊張関係。1行 docs PR を挙動仕様の変更に化けさせないため未着手。

Closes #1426
