### PR TITLE
🧹 chore: swiftui-traps.md を COMPACT-in-place で圧縮（-970、acceptance 再ベースライン）

### DIFF
--- a/.claude/rules/swiftui-traps.md
+++ b/.claude/rules/swiftui-traps.md
@@ -252,8 +252,8 @@ the gate silently (each file's own header says so). See ADR-028.
 
 **Choosing the value: a token-pair ratio is not a prediction about a *presented* surface.** For a
 sheet / overlay fill the comparand is the **composited** backdrop, which presentation dimming moves
-independently of the palette — and can move it far enough to flip the sign. Judge such a value against a device
-screenshot, not the pair. Derivation: ADR-028 § Amendment 2026-08-05 (#1336). Sibling of
+independently of the palette — and can move it far enough to flip the sign. Judge such a value
+against a device screenshot, not the pair. Derivation: ADR-028 § Amendment 2026-08-05 (#1336). Sibling of
 § "An occlusion layer ... must be darker than every ground it covers" below — same question asked of
 a surface rather than an occluder; keep the two pointing at each other.
 
@@ -304,7 +304,7 @@ survives; the same badge renders fine in a `LazyVStack` or `List`/`Form`.
    stopped reproducing within a day and shipped with no code workaround. Before investing in
    one, confirm the repro on the **exact OS build AND a real device** (the sim misleads both
    ways). Candidate workarounds in order, if it resurfaces: extract the row into a
-   concrete `View` struct → `.compositingGroup()` → `LazyVStack` → drop the
+   concrete `View` struct → `.compositingGroup()` on the row → `LazyVStack` → drop the
    enumerated-`\.offset` `ForEach` shape → bisect the container
    `.background(...ignoresSafeArea())` half the fault stack names → `.geometryGroup()`.
    Full diagnostic write-up: #901.

--- a/.claude/rules/swiftui-traps.md
+++ b/.claude/rules/swiftui-traps.md
@@ -233,9 +233,8 @@ locally:
 `scripts/check_design_tokens_css.py` is the source of truth for the mirror check (hex vs `rgba`
 form, `EXCEPTIONS` exemptions) — but it is a **substring match on the hex** over the raw file, so a
 token whose value already appears under another name (`inkOnAccent` #FFFFFF vs `--bubble-bg`) has
-**no automated detector for its step-5 row**: delete that row and the job still exits 0. Steps 1–3,
-*when done*, still assert the token's value — but nothing enforces that they were. Verify by diff
-(#1299).
+**no automated detector for its step-5 row**: delete that row and the job still exits 0. Nothing
+enforces that steps 1–3 were done either. Verify by diff (#1299).
 
 **Adding a dark *counterpart* to an existing token is a different, 6th-file shape** — the five
 steps above assume a brand-new value. A dark pair adds the `night*` raw token in
@@ -248,24 +247,22 @@ pair still passes; and the CSS gate keys off `PasturaColorValue(hex:)` literals,
 pairing files (`+DynamicColor.swift`, the mechanism; `+DynamicPalette.swift`, the table) are
 inert to it — only the new `night*` hex needs a `tokens.css` row. Keep every
 `DesignTokens+*` filename inside `check_design_tokens_css.py`'s glob; renaming one out blinds
-the gate silently (each file's own header says so). See ADR-028.
+the gate silently. See ADR-028.
 
 **Choosing the value: a token-pair ratio is not a prediction about a *presented* surface.** For a
-sheet / overlay fill, the comparand is the **composited** backdrop — the presentation dims what is
-behind and not the surface itself, which can flip the sign, so a pair designed to sit *below* its
-ground can render *above* its own backdrop. Judge such a value against a device screenshot, not the
-pair. ADR-028 § Amendment 2026-08-05 (#1336). Sibling of
-§ "An occlusion layer ... must be darker than every ground it covers" below — same "what does it
-actually composite over" question, asked of a surface rather than an occluder; keep the two
-pointing at each other.
+sheet / overlay fill the comparand is the **composited** backdrop, which presentation dimming moves
+independently of the palette — far enough to flip the sign. Judge such a value against a device
+screenshot, not the pair. Derivation: ADR-028 § Amendment 2026-08-05 (#1336). Sibling of
+§ "An occlusion layer ... must be darker than every ground it covers" below — same question asked of
+a surface rather than an occluder; keep the two pointing at each other.
 
 **Measure a contrast ratio with the guard's own helpers** (`composite` /
 `contrastRatio`, `DesignTokensTests+NightPalette.swift`) — an ad-hoc script that
 quantizes the composited ground back to 0–255 lands off by enough to make a doc
 comment disagree with the test asserting the same value. And **state which ground
 each figure uses**: mixing per-site and worst-case grounds lets an aggregate
-"before → after" range draw its two ends from different sites, which cannot be true.
-ADR-028 § Amendment 2026-08-08.
+"before → after" range draw its two ends from different sites, which cannot be true
+(ADR-028 § Amendment 2026-08-08).
 
 ## `.sheet(item:)` — pass `Optional<Model>`, never `Int: Identifiable`
 
@@ -356,27 +353,23 @@ without injecting. Real-device dark-mode QA is still required; the simulator
 misleads.
 
 **Read `PasturaPalette.<token>.color`, never the `Color.*` alias, and treat that
-as unconditional** — not belt-and-braces. Under an injection an alias does
-resolve to the requested appearance *today*, but that was measured on one device
-and one OS minor, and the raw read is what keeps the export off a behaviour an
-SDK change can alter. It also costs the choice you just threaded: a palette
-building **both** its families from aliases collapses them into one, since both
-resolve against the same injected scheme. Do not treat a specific alias as fixed
-without checking `PasturaDynamicPalette`, whose doc comment carries the current
-membership.
+as unconditional** — not belt-and-braces. Under an injection an alias resolves to
+the requested appearance *today*, but the raw read is what keeps the export off a
+behaviour an SDK change can alter. It also costs the choice you just threaded: a
+palette building **both** its families from aliases collapses them into one, since
+both resolve against the same injected scheme. Check `PasturaDynamicPalette`'s doc
+comment for current membership before treating an alias as fixed.
 
-**What the gate does not cover.** It guards the injection half only. The token
-tests assert `PasturaPalette` components *and* the aliases' own resolution, but
-ADR-009 rules out snapshots, so any *new* fixed-appearance consumer needs its own
-pin **on the alias half** — and nothing detects that pin's absence; three
-mechanical guards for it were designed and refused (ADR-028 § "Revisit trigger"
-bullet 1).
-Today's pins are `HighlightShareCardPaletteTests` and `SheepAvatarPaletteTests`,
-whose *invariance* arm derives its slots by **reflection** rather than a hand
-list, so a stored property added later reading a paired alias reddens. Two pins
-keep the reflection honest: an expected slot count (a computed-property refactor
-would otherwise make it vacuous) and `colors.count == childCount` (a slot typed
-`AnyShapeStyle` / `LinearGradient` / `UIColor` is invisible to `as? Color`).
+**What the gate does not cover.** It guards the injection half only, and ADR-009
+rules out snapshots, so any *new* fixed-appearance consumer needs its own pin **on
+the alias half** — and nothing detects that pin's absence (three mechanical guards
+were designed and refused, ADR-028 § "Revisit trigger" bullet 1). Today's pins are
+`HighlightShareCardPaletteTests` and `SheepAvatarPaletteTests`, whose *invariance*
+arm derives its slots by **reflection**, so a stored property added later reading a
+paired alias reddens. Two pins keep the reflection honest: an expected slot count
+(a computed-property refactor would otherwise make it vacuous) and
+`colors.count == childCount` (a slot typed `AnyShapeStyle` / `LinearGradient` /
+`UIColor` is invisible to `as? Color`).
 
 Measurement, arms and controls: ADR-028 § Amendment 2026-08-06 (#1337).
 Reference: `HighlightCardImageRenderer.render`, `HighlightShareCard`,
@@ -417,20 +410,14 @@ full-bleed fill: does it occlude, or is it a surface?
 
 Enforced by the `shadow_color_occluder_family` custom SwiftLint rule — an
 allowlist (a shadow tint must name `PasturaOccluderShadows` or `PasturaShadows`),
-and **for the shadow half only**.
+and **for the shadow half only**. **A green run still does not mean "this shadow
+is dark enough"**: the rule matches a family **name**, so a member added to either
+family with a too-light tint passes it, and the scrim shape has no lint guard at
+all. `SimulationScrimStyleTests`, `PasturaOccluderShadowsTests` and
+`PasturaShadowsTests` carry what lint cannot, asserting the requirement against
+**hand-maintained** ground lists — which is the residual weakness.
 
-**A green run still does not mean "this shadow is dark enough."** The rule
-matches a family **name**, so a member added to either family with a too-light
-tint passes it — which is what `PasturaShadows` itself was until #1378, and what
-the next addition could be. The scrim shape has no lint guard at all: one
-instance, no stable syntax to key on, so a rule would be over-fitted. Tests carry
-what lint cannot — `SimulationScrimStyleTests`, `PasturaOccluderShadowsTests` and
-`PasturaShadowsTests` each assert the darker-than-every-ground requirement
-against a **hand-maintained** ground list, which is the residual weakness: a
-night ground added later and darker than the occluder value would not be covered
-automatically.
-
-Values, arithmetic and the measurements behind each revision: design-system §4.3
+Values, arithmetic, and the residual-weakness derivation: design-system §4.3
 and ADR-028 § Amendment (#1284, #1373, #1378). Reference: `ModelPickerView`,
 `InFlightSimulationIndicator`, `SimulationScrimStyle`, `PasturaOccluderShadows`,
 `PasturaShadows`.

--- a/.claude/rules/swiftui-traps.md
+++ b/.claude/rules/swiftui-traps.md
@@ -9,7 +9,9 @@ paths:
 
 Aggregation point for SwiftUI footguns and Swift 6 isolation quirks that surface during Pastura UI development. Loaded when a file in the UI layers is read (an edit reads it first).
 
-**Scope** — the globs above are **identical to `navigation.md`'s**, deliberately: every trap here is *entered from* a UI-layer file, and `PasturaApp.swift` is the only file outside `Views/` / `App/` that imports SwiftUI (`grep -rl "import SwiftUI" Pastura/Pastura --include='*.swift'`). Not every one is a *SwiftUI* trap: § "Adding a `Color` design token = 5 files; the 5th fails silently (workflow trap, not SwiftUI)" has later steps landing in a test file and `docs/design/**` — it stays here because its entry point is `DesignTokens+*.swift`. Traps with no UI entry point at all — filename collisions, SwiftLint directive placement — live in `build-traps.md`, whose globs are the union of the two traps' differing reach. `navigation.md` carries AppRouter / `PasturaBackButton` mechanics: this file is the trap catalog, that one is the navigation pattern.
+**Scope** — globs **identical to `navigation.md`'s**, deliberately: every trap here is *entered from* a UI-layer file, and `PasturaApp.swift` is the only file outside `Views/` / `App/` that imports SwiftUI. Not every one is a *SwiftUI* trap — the `Color`-token workflow trap stays here because its entry point is `DesignTokens+*.swift`. Traps with no UI entry point live in `build-traps.md`; `navigation.md` carries the navigation pattern, this file is the trap catalog.
+
+**Do not relocate the occlusion / `ImageRenderer` / `Color`-token sections to `docs/`** on a byte-count audit — ADR-028 (`:380` / `:391` / `:1946`) names this file their *operational form*, and `docs/qa/dark-mode-qa.md:8` points back here, so the move is circular (#1429 comment 1).
 
 ## Toolbar-hide API matrix (iOS 17 → 26)
 
@@ -20,7 +22,7 @@ Aggregation point for SwiftUI footguns and Swift 6 isolation quirks that surface
 | `.navigationBarBackButtonHidden(true)` | No (bar stays) | No (button hidden) | iOS 17–18: yes / **iOS 26: NO** |
 | `.toolbarBackground(.hidden, for: .navigationBar)` | No (bar stays) | Yes | Yes |
 
-Root cause for the iOS 26 regression on `.navigationBarBackButtonHidden(true)`: SwiftUI sees "no back affordance" and disables `interactivePopGestureRecognizer` system-wide. Contradicts older web articles claiming only `.toolbar(.hidden)` does this.
+Root cause for the iOS 26 regression on `.navigationBarBackButtonHidden(true)`: SwiftUI sees "no back affordance" and disables `interactivePopGestureRecognizer` system-wide.
 
 **Apply**:
 
@@ -43,9 +45,7 @@ distinction is erased.
 symbol name carry the fill toggle. The modifier is LOAD-BEARING —
 removing it silently re-fills every tab.
 
-Reference impl + full rationale (including why `magnifyingglass`, which
-has no `.fill` variant, was the only tab where the symptom was
-diagnosable): the LOAD-BEARING comment in
+Reference impl + full rationale: the LOAD-BEARING comment in
 `Pastura/Pastura/App/RootTabView.swift` (`symbolName(for:isActive:)`).
 
 The a11y modifiers on that same `tabIcon` `Image` are separately unreliable
@@ -58,10 +58,9 @@ adding another identifier there fixes nothing. See `uitest-traps.md`
 Replacing the **top route in place** in a `NavigationStack` path
 (`AppRouter.replaceTop`, used by the ScenarioDetail cross-language toggle)
 is NOT a push, and trips two **device-only** traps (neither reproduces in
-simulator reasoning). Why replace at all: ja/en variants are distinct
-`scenarioId`s = distinct `Route`s, so a plain push grows the stack
-unboundedly on repeated toggling and `pushIfOnTop` can't dedupe them —
-`replaceTop` keeps stack depth constant.
+simulator reasoning). Why replace rather than push: ja/en variants are
+distinct `Route`s, so pushing grows the stack unboundedly on repeated
+toggling and `pushIfOnTop` cannot dedupe them.
 
 1. **Leaf identity is reused by stack position, not by `Route` value.** A
    load-once view (`.task { guard viewModel == nil }`) keeps showing the
@@ -84,9 +83,7 @@ Reference impls: `AppRouter.replaceTop`, `ScenarioDetailView.scenarioContent`.
 
 When introducing a **production-only side-effecting service** (LLM-output detector, telemetry analyzer, content-rewriting filter, on-the-fly classifier, A/B-flag injector), inject it at the **View boundary**, NOT as a default value on the VM's `init()` signature.
 
-### Why
-
-VM `init()` default arguments run **in tests too**. Fixture-driven tests that pre-load `MockLLMService(responses: [...])` queues construct the VM via the no-arg overload (`SimulationViewModel(simulationRepository: …, …)`). If the VM's `init()` defaults to `SimulationRunner(detector: NLLanguageDetector())`, the detector fires on every output → consumes the mock queue unexpectedly → cascading "Mock exhausted" errors.
+**Why**: VM `init()` default arguments run **in tests too**. A fixture-driven test constructing the VM via the no-arg overload silently gets the production service — a default `SimulationRunner(detector: NLLanguageDetector())` fires on every output, consuming the pre-loaded `MockLLMService` queue → cascading "Mock exhausted" errors.
 
 ### Apply
 
@@ -107,11 +104,10 @@ hover feedback is silent. macOS works correctly. `DropDelegate.dropEntered`
 / `dropExited` are reported to work in `List` but empirically also failed
 in `Form` rows on iOS 26 simulator.
 
-Apple's `.onMove(perform:)` is **deliberately single-`ForEach` only** —
-moving items between two `ForEach` instances is not supported by design
-([Apple Dev Forums thread/674393](https://developer.apple.com/forums/thread/674393)).
-HIG has no cross-collection drag pattern; Apple's documented alternative
-is the **context-menu "Move to X" action**.
+Apple's `.onMove(perform:)` is **deliberately single-`ForEach` only** — moving items
+between two `ForEach` instances is unsupported by design, HIG has no cross-collection
+drag pattern, and Apple's documented alternative is the **context-menu "Move to X"
+action**.
 
 ### Apply
 
@@ -123,8 +119,8 @@ Answer first, before designing:
   iOS. Switch to `ScrollView` + `LazyVStack` (loses List chrome) or drop the
   indicator requirement.
 
-FB numbers, Apple sources, and the workflow lesson "research platform support
-BEFORE plan / critic, not after a full PR cycle": #144 and its comments.
+FB numbers, Apple sources (HIG + forum thread), and the "research platform support
+BEFORE plan / critic" workflow lesson: #144 and its comments.
 
 ## `.accessibilityIdentifier` ordering around `.safeAreaInset`
 
@@ -197,14 +193,12 @@ loci don't drift.
 
 ## Swift 6 makes accessibility env keypaths read-only
 
-Pre-Swift-6, `.environment(\.accessibilityReduceMotion, true)` inside a `#Preview`
-overrode the value for visual testing. Under the project's Swift 6 mode, the system
-accessibility env keypath resolves as `any KeyPath<EnvironmentValues, Bool> & Sendable`,
-NOT `WritableKeyPath`, so `.environment(_:_:)` no longer accepts it (compile error:
-`cannot convert ... to expected argument type 'WritableKeyPath<...>'`). Affects
-`accessibilityReduceMotion`,
-`accessibilityReduceTransparency`, and the other system-set (app-read) accessibility env
-values.
+Under the project's Swift 6 mode a system accessibility env keypath resolves as
+`any KeyPath<EnvironmentValues, Bool> & Sendable`, NOT `WritableKeyPath`, so the
+`#Preview` override `.environment(\.accessibilityReduceMotion, true)` no longer compiles
+(`cannot convert ... to expected argument type 'WritableKeyPath<...>'`). Affects
+`accessibilityReduceMotion`, `accessibilityReduceTransparency`, and the other system-set
+(app-read) accessibility env values.
 
 **Pattern**: extract animation timing into a `nonisolated enum` of pure functions taking
 `reduceMotion: Bool` (see `ModelSelectionAnimations`); the View reads
@@ -311,11 +305,10 @@ survives; the same badge renders fine in a `LazyVStack` or `List`/`Form`.
 2. **These AttributeGraph crashes can be OS-build-specific and self-resolve** — this one
    stopped reproducing within a day and shipped with no code workaround. Before investing in
    one, confirm the repro on the **exact OS build AND a real device** (the sim misleads both
-   ways). If it resurfaces, the candidate workarounds in order: extract the row into a
-   concrete `View` struct → `.compositingGroup()` on the row → `LazyVStack` → drop the
-   enumerated-`\.offset` `ForEach` shape → bisect the container
-   `.background(...ignoresSafeArea())` half the fault stack names → `.geometryGroup()`.
-   Full diagnostic write-up: #901.
+   ways). Candidate workarounds in order, if it resurfaces: concrete `View` struct →
+   `.compositingGroup()` → `LazyVStack` → drop the enumerated-`\.offset` shape → bisect
+   the container `.background(...ignoresSafeArea())` → `.geometryGroup()`. Full
+   diagnostic write-up: #901.
 
 ## Re-projection resets `@State` — put run-scoped display state on the VM
 

--- a/.claude/rules/swiftui-traps.md
+++ b/.claude/rules/swiftui-traps.md
@@ -9,9 +9,9 @@ paths:
 
 Aggregation point for SwiftUI footguns and Swift 6 isolation quirks that surface during Pastura UI development. Loaded when a file in the UI layers is read (an edit reads it first).
 
-**Scope** — globs **identical to `navigation.md`'s**, deliberately: every trap here is *entered from* a UI-layer file, and `PasturaApp.swift` is the only file outside `Views/` / `App/` that imports SwiftUI. Not every one is a *SwiftUI* trap — the `Color`-token workflow trap stays here because its entry point is `DesignTokens+*.swift`. Traps with no UI entry point live in `build-traps.md`; `navigation.md` carries the navigation pattern, this file is the trap catalog.
+**Scope** — globs **identical to `navigation.md`'s**, deliberately: every trap here is *entered from* a UI-layer file, and `PasturaApp.swift` is the only file outside `Views/` / `App/` that imports SwiftUI (`grep -rl "import SwiftUI" Pastura/Pastura --include='*.swift'`). Not every one is a *SwiftUI* trap — the `Color`-token workflow trap stays here because its entry point is `DesignTokens+*.swift`. Traps with no UI entry point live in `build-traps.md`; `navigation.md` carries the navigation pattern, this file is the trap catalog.
 
-**Do not relocate the occlusion / `ImageRenderer` / `Color`-token sections to `docs/`** on a byte-count audit — ADR-028 (`:380` / `:391` / `:1946`) names this file their *operational form*, and `docs/qa/dark-mode-qa.md:8` points back here, so the move is circular (#1429 comment 1).
+**Do not relocate the occlusion / `ImageRenderer` / `Color`-token sections to `docs/`** on a byte-count audit — ADR-028 names this file their *operational form* (`:380`, `:391`) and records the promotion (`:1946`), and `docs/qa/dark-mode-qa.md:8` points back here, so the move is circular (#1429 comment 1).
 
 ## Toolbar-hide API matrix (iOS 17 → 26)
 
@@ -233,8 +233,9 @@ locally:
 `scripts/check_design_tokens_css.py` is the source of truth for the mirror check (hex vs `rgba`
 form, `EXCEPTIONS` exemptions) — but it is a **substring match on the hex** over the raw file, so a
 token whose value already appears under another name (`inkOnAccent` #FFFFFF vs `--bubble-bg`) has
-**no automated detector for its step-5 row**: delete that row and the job still exits 0. Nothing
-enforces that steps 1–3 were done either. Verify by diff (#1299).
+**no automated detector for its step-5 row**: delete that row and the job still exits 0. Steps 1–3,
+*when done*, still assert the token's value — but nothing enforces that they were. Verify by diff
+(#1299).
 
 **Adding a dark *counterpart* to an existing token is a different, 6th-file shape** — the five
 steps above assume a brand-new value. A dark pair adds the `night*` raw token in
@@ -247,11 +248,11 @@ pair still passes; and the CSS gate keys off `PasturaColorValue(hex:)` literals,
 pairing files (`+DynamicColor.swift`, the mechanism; `+DynamicPalette.swift`, the table) are
 inert to it — only the new `night*` hex needs a `tokens.css` row. Keep every
 `DesignTokens+*` filename inside `check_design_tokens_css.py`'s glob; renaming one out blinds
-the gate silently. See ADR-028.
+the gate silently (each file's own header says so). See ADR-028.
 
 **Choosing the value: a token-pair ratio is not a prediction about a *presented* surface.** For a
 sheet / overlay fill the comparand is the **composited** backdrop, which presentation dimming moves
-independently of the palette — far enough to flip the sign. Judge such a value against a device
+independently of the palette — and can move it far enough to flip the sign. Judge such a value against a device
 screenshot, not the pair. Derivation: ADR-028 § Amendment 2026-08-05 (#1336). Sibling of
 § "An occlusion layer ... must be darker than every ground it covers" below — same question asked of
 a surface rather than an occluder; keep the two pointing at each other.
@@ -302,10 +303,11 @@ survives; the same badge renders fine in a `LazyVStack` or `List`/`Form`.
 2. **These AttributeGraph crashes can be OS-build-specific and self-resolve** — this one
    stopped reproducing within a day and shipped with no code workaround. Before investing in
    one, confirm the repro on the **exact OS build AND a real device** (the sim misleads both
-   ways). Candidate workarounds in order, if it resurfaces: concrete `View` struct →
-   `.compositingGroup()` → `LazyVStack` → drop the enumerated-`\.offset` shape → bisect
-   the container `.background(...ignoresSafeArea())` → `.geometryGroup()`. Full
-   diagnostic write-up: #901.
+   ways). Candidate workarounds in order, if it resurfaces: extract the row into a
+   concrete `View` struct → `.compositingGroup()` → `LazyVStack` → drop the
+   enumerated-`\.offset` `ForEach` shape → bisect the container
+   `.background(...ignoresSafeArea())` half the fault stack names → `.geometryGroup()`.
+   Full diagnostic write-up: #901.
 
 ## Re-projection resets `@State` — put run-scoped display state on the VM
 
@@ -360,7 +362,8 @@ palette building **both** its families from aliases collapses them into one, sin
 both resolve against the same injected scheme. Check `PasturaDynamicPalette`'s doc
 comment for current membership before treating an alias as fixed.
 
-**What the gate does not cover.** It guards the injection half only, and ADR-009
+**What the gate does not cover.** It guards the injection half only. The token tests
+assert `PasturaPalette` components *and* the aliases' own resolution, but ADR-009
 rules out snapshots, so any *new* fixed-appearance consumer needs its own pin **on
 the alias half** — and nothing detects that pin's absence (three mechanical guards
 were designed and refused, ADR-028 § "Revisit trigger" bullet 1). Today's pins are
@@ -415,7 +418,8 @@ is dark enough"**: the rule matches a family **name**, so a member added to eith
 family with a too-light tint passes it, and the scrim shape has no lint guard at
 all. `SimulationScrimStyleTests`, `PasturaOccluderShadowsTests` and
 `PasturaShadowsTests` carry what lint cannot, asserting the requirement against
-**hand-maintained** ground lists — which is the residual weakness.
+**hand-maintained** ground lists — the residual weakness: a night ground added
+later and darker than #0B0C0A is not covered automatically, so add it by hand.
 
 Values, arithmetic, and the residual-weakness derivation: design-system §4.3
 and ADR-028 § Amendment (#1284, #1373, #1378). Reference: `ModelPickerView`,


### PR DESCRIPTION
## Summary

Compacts `.claude/rules/swiftui-traps.md` in place. **28,153 → 27,183 bytes (−970)**; the
View-work path-scoped injection bundle goes **74,877 → 73,907**.

**The issue body is stale and its two comments conflict — read this before the diff.**

- The body proposed **relocating** the occlusion and `ImageRenderer` sections to `docs/`,
  targeting `<= 19,000`.
- [Comment 1](https://github.com/tyabu12/pastura/issues/1429#issuecomment-5259837804) reversed
  that: `docs/decisions/ADR-028.md:380` / `:391` explicitly name this rule as the **Operational
  form** of those sections, so relocating reverses a recorded knowledge-layering promote
  judgment — and `docs/qa/dark-mode-qa.md:8` points back here, making the move circular.
- [Comment 2](https://github.com/tyabu12/pastura/issues/1429#issuecomment-5275149647)
  re-baselined the numbers and found that **#1437 already compacted the top four sections**, so
  no section trips `context-budget.md` § Classifier's "3× the median" trigger any more (largest
  is now 2.6×). It then re-suggested the relocations without addressing comment 1.

This PR takes **COMPACT-in-place only**, and re-baselines the acceptance criteria against the
post-#1437 file. § Scope now carries an explicit anti-RELOCATE sentence so a fourth round of
this proposal stops at the file itself.

## What changed

Only `context-budget.md` § Classifier **Drop** classes were cut — meta-discussion, anecdotal
incident detail, external URLs available at a cited issue, historical framing, and prose
duplicated at a verified destination. Every section keeps its lead claim **and** its
detection/apply step.

## The byte target was missed, deliberately

The re-baselined target was `<= 25,500` — declared in the plan as a **target, not a gate**, with
"don't lose a firing condition" and "verify before deleting" dominant. Actual: **−970**. The
gap is the point of the record below:

- **~820 B could not be cut.** The plan asserted three passages were safe because their content
  already lived at a pointer destination. `grep` says **two of the three are false** — the
  `Color`-token quantization lesson and the `ImageRenderer` slot-count / `colors.count ==
  childCount` pins have **no** counterpart in ADR-028 or design-system. Both retained. The
  review gate independently re-ran those greps and confirmed cutting either would have been
  Critical.
- **+426 B was given back at review.** Three cuts had removed a section's *apply* half while
  keeping its description — the exact silent-degradation class this issue warns about — plus
  five smaller precision losses. All restored.

Cutting further would have to come out of load-bearing prose, so it stops here.

## Test plan

Documentation-only; no Swift source touched, so the pre-commit classifier correctly skipped
SwiftLint and `xcodebuild build`, and the iOS test suite is not in play. Verification is
structural instead:

- All 17 `##` headings **byte-identical** to `main` (`diff` of `grep '^## '`). Load-bearing: 16
  main-tree lines cite a heading by name, and `.swiftlint.yml:185` embeds the occlusion heading
  verbatim in a user-visible lint message.
- Every inbound citation that delegates a claim into this file still resolves — including the
  two **non-heading quoted phrases** the review gate found were outside both checks.
- Every DROP/COMPACT justification re-run as a grep against its destination, listed below.
- `claude-kit:critic` at plan time (4 Warnings, all adopted); `code-reviewer` twice (full branch,
  then scoped to the fix diff) — final verdict PASS, 0 Critical, 0 Warning.

## Device QA

実機QA不要 — エージェント指示ファイル1本のみの変更で、アプリのコード・リソース・ビルド設定に一切触れていない。

## Context-economy: per-cut Keep/Drop record

`swiftui-traps.md` **28,153 → 27,183 bytes (−970)**. View-work injection bundle
**74,877 → 73,907 (−970)**.

Acceptance criterion 1 declared `<= 25,500` a **target, not a gate**, with criteria 3/4
dominant. The honest yield is **−970**, well short of the −2,653 the target implied. Two
reasons, both recorded rather than cut around:

1. Criterion 4's grep found **no counterpart** at the destination for two passages the plan
   had assumed were free (the two **KEEP** rows below, ~820 B). Verified independently by the
   review gate, which confirmed cutting either would have been Critical.
2. The Step-4 review found three cuts that removed a section's *apply* half while keeping its
   description — the exact silent-degradation class #1429 warns about — plus five smaller
   precision losses. All were **restored (+426 B)**. Correctness over byte count.

| passage | pre bytes | verdict | destination verified by |
|---|---:|---|---|
| preamble § Scope glob-justification | 867 | COMPACT | `CLAUDE.md:277` (build-traps boundary), `navigation.md:28` (glob history). The `import SwiftUI` grep was **restored** after review — it has no destination and is the executable backing for the three-glob claim. Net ≈0: the saving funded criterion 7's anti-RELOCATE sentence |
| `### Why` walkthrough (Production-side-effecting service) | 436 | COMPACT | in-place prose tightening; no destination claimed |
| AttributeGraph workaround enumeration | 648 | COMPACT | `gh issue view 901` L42–43 carries the modifier list. The ordering selectors ("extract the row into", `ForEach`, "half the fault stack names") are **not** at #901 and were **restored** after review |
| drag & drop Apple forum URL | 349 | DROP | `gh api …/issues/144/comments` → `developer.apple.com/forums/thread/674393` + `…/human-interface-guidelines/drag-and-drop` present |
| drag & drop sources line | 151 | COMPACT | pointer retained, now names "HIG + forum thread" |
| Toolbar-hide "contradicts older web articles" | ~90 | DROP | anecdotal; `context-budget.md` § Classifier Drop class |
| TabView `magnifyingglass` parenthetical | ~110 | DROP | anecdotal incident detail; same class |
| `replaceTop` "why replace at all" rationale | ~200 | COMPACT | design rationale, not a firing condition; `navigation.md` § AppRouter scope carries `replaceTop` |
| Swift 6 a11y "Pre-Swift-6 …" framing | ~90 | COMPACT | historical framing; the compile error + affected keypaths retained |
| `Color` token composited-backdrop para | ~570 | COMPACT | `ADR-028.md:1943-1944`. The modal ("**can** flip the sign") was **restored** after review — `:1949-1951` limits the finding to one device / one iOS version / one scenario, so a flat assertion over-claims relative to its own source |
| `Color` token steps-1–3 mitigating clause | ~70 | **RESTORED** | merging it lost "steps 1–3, *when done*, still assert the value", over-stating the hole |
| `Color` token "(each file's own header says so)" | ~35 | **RESTORED** | `DesignTokens+ExtendedPalette.swift:15` does carry it; dropping the pointer made the claim unverifiable without a hunt |
| `Color` token **quantization / guard's-own-helpers lesson** | ~490 | **KEEP** | `grep -n 'quantiz\|contrastRatio' ADR-028.md design-system.md` → only `ADR-028.md:1382`, an unrelated on-accent control; `quantiz` has **0 hits** repo-wide. **No counterpart — not free** |
| `ImageRenderer` "one device / one OS minor" justification | ~200 | COMPACT | rationale for a conclusion retained verbatim (`unconditional`) |
| `ImageRenderer` "token tests assert … *and* the aliases' own resolution" | ~90 | **RESTORED** | without the what-*is*-covered contrast, "guards the injection half only" reads as a non-sequitur |
| `ImageRenderer` **slot-count + `colors.count == childCount` pins** | ~330 | **KEEP** | `grep -n 'slot count\|colors.count\|childCount\|AnyShapeStyle' ADR-028.md design-system.md` → **0 hits** (`:1755` carries only the reflection fact). **No counterpart — not free** |
| `ImageRenderer` alias-half pin requirement | — | **KEEP** | `view-testing.md:61` delegates its "fixed-appearance exception" here (criterion 5) |
| occlusion residual-weakness elaboration | 985 | COMPACT | `ADR-028.md:2085-2092` (under `## Amendment 2026-08-05 … (#1373)`, inside the cited set). The firing condition — *a night ground darker than #0B0C0A added later is not covered; add it by hand* — was **restored** after review: the first cut left the label without the apply step |

### Criterion 2 — heading identity

All 17 `##` headings **byte-identical** to `main` (`diff` of `grep '^## '` output). Load-bearing
because 16 main-tree lines cite a heading by name and `.swiftlint.yml:185` embeds the occlusion
heading verbatim in a user-visible lint message.

### Criterion 5 — inbound-citation survival

`grep -rn 'swiftui-traps'` over the main tree returns ~30 hits. Criterion 2 covers every hit that
cites a **heading**. The rows below are the hits that delegate a **specific claim** instead, which
criterion 2 does not reach — including the two **non-heading quoted phrases** the review gate
identified as outside both criteria (last two rows), now checked explicitly as a third class.

| citing file | delegated claim | still resolves |
|---|---|---|
| `.claude/rules/view-testing.md:61` | "fixed-appearance exception" | ✅ `:365` |
| `Pastura/PasturaUITests/GalleryHighlightRenderTests.swift:6` | container shape stays green under build + unit suite | ✅ `:296` |
| `docs/ci/xcodebuild-flakes.md:58` | `.ips` crash frames | ✅ `:301` |
| `docs/design/design-system.md:754` | Apple's context-menu alternative to cross-collection drag | ✅ `:109` |
| `docs/decisions/ADR-028.md:380` / `:391` / `:1946` | operational form of occlusion / `ImageRenderer` / `Color`-token | ✅ sections intact; § Scope now states this explicitly |
| `Pastura/PasturaUITests/SimulationFocusModeTests.swift:18` | verbatim prose `"simulator-only QA is not load-bearing"` | ✅ `:31` |
| `Pastura/Pastura/Views/DesignTokens+ExtendedPalette.swift:22` | where the token workflow puts a new raw token | ✅ `:227` (step 1) |
Closes #1429

**Context-economy: kept 3 paragraphs (2 KEEP rows with no counterpart at their destination + 1 delegated-claim row), compressed 11, dropped 3, restored 8 at review — net −970 bytes on a path-scoped file. Per-paragraph classifier results in the table above.**
