### PR TITLE
🧹 chore: kit ミラーを再同期し、深さを docs/agent-tooling/ へ退避する

### DIFF
--- a/.claude/rules/adr-writing.md
+++ b/.claude/rules/adr-writing.md
@@ -26,7 +26,7 @@ Before committing a fact-claim line:
 
 The 5–10 minute investment per commit prevents the kind of 3-review-round cycle that landed 4 fact-errors in ADR-010 body (see #370).
 
-Pairs with `knowledge-layering.md` § "Verify before you lock it" — different surface, same shape: execute every load-bearing assertion before commit. An ADR draft sits at that section's **Plan-lock** moment.
+Pairs with `knowledge-layering.md` § "Verify before you lock it" — different surface, same shape: execute every load-bearing assertion before commit. An ADR draft hits **both** of that section's first two moments: Plan-lock for the claims the decision rests on, and Rule-commit for the draft's own cited `file:line` / `(#N)` / delta lines — including its re-measure-on-the-final-commit clause.
 
 ## 2. Mechanism contract over pinned model thresholds
 

--- a/.claude/rules/adr-writing.md
+++ b/.claude/rules/adr-writing.md
@@ -26,7 +26,7 @@ Before committing a fact-claim line:
 
 The 5–10 minute investment per commit prevents the kind of 3-review-round cycle that landed 4 fact-errors in ADR-010 body (see #370).
 
-Pairs with `knowledge-layering.md` § "Rule-writing self-check" — different surface, same shape: execute every load-bearing assertion before commit.
+Pairs with `knowledge-layering.md` § "Verify before you lock it" — different surface, same shape: execute every load-bearing assertion before commit. An ADR draft sits at that section's **Plan-lock** moment.
 
 ## 2. Mechanism contract over pinned model thresholds
 

--- a/.claude/rules/adr-writing.md
+++ b/.claude/rules/adr-writing.md
@@ -26,7 +26,7 @@ Before committing a fact-claim line:
 
 The 5–10 minute investment per commit prevents the kind of 3-review-round cycle that landed 4 fact-errors in ADR-010 body (see #370).
 
-Pairs with `knowledge-layering.md` § "Verify before you lock it" — different surface, same shape: execute every load-bearing assertion before commit. An ADR draft hits **both** of that section's first two moments: Plan-lock for the claims the decision rests on, and Rule-commit for the draft's own cited `file:line` / `(#N)` / delta lines — including its re-measure-on-the-final-commit clause.
+Pairs with `knowledge-layering.md` § "Verify before you lock it" — different surface, same shape: execute every load-bearing assertion before commit. An ADR draft hits **both** of that section's first two moments: Plan-lock for the claims the decision rests on, and the Rule-commit *shape* for the draft's own cited `file:line` / `(#N)` / delta lines — including its re-measure-on-the-final-commit clause. (That bullet names `.claude/rules/` and `CLAUDE.md` as its subject; an ADR is neither, which is why the shape and not the bullet's scope is what carries over.)
 
 ## 2. Mechanism contract over pinned model thresholds
 

--- a/.claude/rules/adr-writing.md
+++ b/.claude/rules/adr-writing.md
@@ -26,7 +26,7 @@ Before committing a fact-claim line:
 
 The 5–10 minute investment per commit prevents the kind of 3-review-round cycle that landed 4 fact-errors in ADR-010 body (see #370).
 
-Pairs with `knowledge-layering.md` § "Verify before you lock it" — different surface, same shape: execute every load-bearing assertion before commit. An ADR draft hits **both** of that section's first two moments: Plan-lock for the claims the decision rests on, and the Rule-commit *shape* for the draft's own cited `file:line` / `(#N)` / delta lines — including its re-measure-on-the-final-commit clause. (That bullet names `.claude/rules/` and `CLAUDE.md` as its subject; an ADR is neither, which is why the shape and not the bullet's scope is what carries over.)
+Pairs with `knowledge-layering.md` § "Verify before you lock it" — different surface, same shape: execute every load-bearing assertion before commit. An ADR draft hits **both** of that section's first two moments — Plan-lock for the claims the decision rests on, and the Rule-commit *shape* (including re-measure-on-the-final-commit) for the draft's own cited `file:line` / `(#N)` / delta lines. That bullet's stated subject is `.claude/rules/` / `CLAUDE.md`, so it is the shape, not the bullet's scope, that carries over to an ADR.
 
 ## 2. Mechanism contract over pinned model thresholds
 

--- a/.claude/rules/context-budget.md
+++ b/.claude/rules/context-budget.md
@@ -1,9 +1,9 @@
 # Context Budget — Always-Loaded Files
 
 > Derived from [claude-kit](https://github.com/tyabu12/claude-kit) `rules/context-budget.md` —
-> the generic core is canonical there; reconcile one-way (kit → Pastura). Concept level — no
-> volatile facts to keep numerically in sync, and no paired kit `docs/` file, so this one
-> reconciles rule-to-rule. Pastura-specific content lives only in this copy.
+> the generic core is canonical there; reconcile one-way (kit → Pastura) — rule-to-rule here, since
+> this one is concept level with no volatile facts and no paired kit `docs/` file. Pastura-specific
+> content lives only in this copy.
 
 Always-loaded — see `CLAUDE.md` `## Context-Specific Rules` for the
 loading-mode rationale. This rule applies to itself. Pairs with `knowledge-layering.md` (location choice across memory / rules / `CLAUDE.md` / `docs/**`); this rule covers content discipline within always-loaded files.

--- a/.claude/rules/context-budget.md
+++ b/.claude/rules/context-budget.md
@@ -1,8 +1,9 @@
 # Context Budget — Always-Loaded Files
 
 > Derived from [claude-kit](https://github.com/tyabu12/claude-kit) `rules/context-budget.md` —
-> the generic core is canonical there; reconcile one-way (kit → Pastura). Pastura-specific
-> content lives only in this copy.
+> the generic core is canonical there; reconcile one-way (kit → Pastura). Concept level — no
+> volatile facts to keep numerically in sync, and no paired kit `docs/` file, so this one
+> reconciles rule-to-rule. Pastura-specific content lives only in this copy.
 
 Always-loaded — see `CLAUDE.md` `## Context-Specific Rules` for the
 loading-mode rationale. This rule applies to itself. Pairs with `knowledge-layering.md` (location choice across memory / rules / `CLAUDE.md` / `docs/**`); this rule covers content discipline within always-loaded files.
@@ -22,7 +23,7 @@ Path-scoped files (`paths:` frontmatter) load only when a matching path is read 
 
 ## Principle
 
-Each addition must support the agent's **next decision**, not serve as reference material for a human debugging an issue. Reference material belongs in on-demand docs (`docs/**`), script header doc-comments, or PR history.
+Each addition must support the agent's **next decision**, not serve as reference material for a human debugging an issue. Reference material belongs on-demand: `docs/**`, script header doc-comments, PR / issue history.
 
 ## Classifier
 
@@ -33,8 +34,8 @@ Before adding, classify each paragraph:
 
 If a cheat-sheet entry balloons to 3× surrounding entries — or if it would fire correctly with just lead claim + actionable command + pointer — compact it.
 
-## `(#NNN)` historical attribution
+## `(#NNN)` / issue attribution
 
-- **Drop**: bare parentheticals tagging *which PR introduced something* (e.g., `before xcodebuild ([#293])`).
-- **Keep**: pointers directing the next reader *where to find missing context* (e.g., `see #N for the design discussion`).
+- **Drop**: bare parentheticals tagging *which PR or issue introduced something* (e.g., `before xcodebuild ([#293])`).
+- **Keep**: pointers directing the next reader *where to find missing context* (`see #N for the design discussion`, `ADR-007`).
 - Do NOT treat existing inline-`(#NNN)` as precedent. Apply the rule to the new addition AND sweep neighboring violations if cheap.

--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -1,13 +1,12 @@
 # Knowledge Layering & Promotion
 
 > Derived from [claude-kit](https://github.com/tyabu12/claude-kit) `rules/knowledge-layering.md` —
-> the generic core is canonical there; reconcile one-way (kit → Pastura). **Since kit#24 the kit's
-> rules carry firing conditions only, with the depth evacuated to the kit's `docs/` — so reconcile
-> rule + doc as a pair.** Diffing the kit's rule alone reads relocated depth as deletions. This
-> mirror's kit-side pair is `docs/claim-verification.md` (backs § "Verify before you lock it"),
-> plus `docs/code-review-path-scoped-rules.md` for the mid-session non-injection probes — that one
-> gets no Pastura counterpart doc on purpose, #1312 holds this repo's. Pastura-specific
-> content lives only in this copy.
+> the generic core is canonical there; reconcile one-way (kit → Pastura) **rule + doc as a pair**:
+> since kit#24 the kit's rules carry firing conditions only, so diffing one alone reads relocated
+> depth as deletions. Kit-side pair: `docs/claim-verification.md` (backs § "Verify before you lock
+> it"), plus `docs/code-review-path-scoped-rules.md` for the mid-session non-injection probes — that
+> one gets no Pastura counterpart on purpose, #1312 holds this repo's. Pastura-specific content
+> lives only in this copy.
 
 Always-loaded — see `CLAUDE.md` `## Context-Specific Rules`. Pairs with `context-budget.md` (content discipline within always-loaded files); this rule covers location choice across all storage tiers.
 
@@ -67,15 +66,12 @@ repo needs to carry itself.
 acceptable **only** in never-committed places (`~/.claude/CLAUDE.md`,
 conversational scratch).
 
-**Detection** — new code must not add hits. A recursive search answers "which
-files lie here" while the rule asks "which are **repo-tracked**", and it misses
-in one direction or the other depending on the searcher: a gitignore-respecting
-one (`rg`) skips a tracked file staged under an ignored directory — and skips
-dot-dirs entirely without `--hidden`, which is how `.claude/**` went unscanned
-for a while — while a plain `grep -r` flags ignored scratch the enumeration
-below deliberately excludes. Enumerate, don't recurse. `-H` is required:
-without it `grep` drops the filename on a single match and the `file:line`
-breaks.
+**Detection** — new code must not add hits. Enumerate, don't recurse: a
+recursive search answers "which files lie here", not "which are
+**repo-tracked**", and misses either way depending on the searcher (`rg` skips
+dot-dirs without `--hidden` — how `.claude/**` went unscanned — and tracked
+files staged under an ignored directory; plain `grep -r` flags ignored scratch).
+`-H` is required, or `grep` drops the filename on a single match.
 
 ```sh
 git ls-files -z --cached --others --exclude-standard \
@@ -95,7 +91,7 @@ set matters more than the pattern: the doc's § "The rule-assertion case".
 
 ## Verify before you lock it
 
-One discipline, three moments where a claim becomes load-bearing and nobody downstream will check it. A reviewer evaluates a rule's *content*, not the check the rule prescribes; the Step 1b `claude-kit:critic` tests internal consistency, not external truth. The author is the only one positioned to run it.
+One discipline, three moments where a claim becomes load-bearing and nobody downstream will check it — the author is the only one positioned to run it.
 
 - **Rule-commit** — a `.claude/rules/` or `CLAUDE.md` addition carrying an **executable assertion** (an asserted grep hit count, a cited `file:line`, a `(PR #N)` claim, a cross-doc heading anchor, **or a self-quoted byte/line delta** — re-measure that one on the *final* commit) is run against current main state **before commit**. Dispositions: § "Dispositions when an assertion diverges".
 - **Plan-lock** — every load-bearing claim a plan leans on is verified against its authoritative source **before** Step 1b. **Read the doc's § "The claim table"** — it maps each claim shape to the source that settles it, and the shapes are not guessable (a defect framed with `would`; two UI surfaces called "the same metric"; a subagent verdict that *dismisses* a risk).
@@ -122,7 +118,7 @@ A why-comment, guard, count or gap list asserts behaviour as the reason a mechan
 
 **A probe's outcome gets misread in both directions.** Assert that the mutation's anchor matched — a `replace` that silently no-ops reads as verified. And treat a **green** probe as a finding about the *fixtures*, not a redundant guard. When a check is too expensive to run, say the cause was not isolated: a reader can act on an acknowledged gap; a wrong cause they can only inherit.
 
-**Before writing a guard, a negative control, or a why-comment you cannot cheaply test, read the doc's § "Authored claims — the four shapes in full" and § "Reading a probe's outcome".** Each shape has an elaboration that is where it actually goes wrong — the sibling arm that reddens a control for the wrong reason, the concessive clause that marks an already-broken category, the two sets that read as a partition.
+**Before writing a guard, a negative control, or a why-comment you cannot cheaply test, read the doc's § "Authored claims — the four shapes in full" and § "Reading a probe's outcome".** Each shape's elaboration — the sibling arm that reddens a control for the wrong reason, the concessive clause marking an already-broken category, two sets that read as a partition — is where it actually goes wrong.
 
 ### A rules file created mid-session never injects in that session
 

--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -44,7 +44,9 @@ Trigger a triage pass on memory **count** or **total content size** (`cat memory
 
 ## Procedure
 
-PROMOTE only — retirement is memory-direct and needs no PR. Two steps nothing else enforces, so they belong on the rolling issue's checklist: **update every mirror** of the promoted fact in the same PR (the `code-reviewer` trap cheat sheet, a `CLAUDE.md` parenthetical — mirrors drift silently otherwise), and **delete the source memory only after the rule lands**, since a repo PR cannot enforce a per-machine `command rm`. **Read [`docs/agent-tooling/claim-verification.md`](../../docs/agent-tooling/claim-verification.md) § "Promotion mechanics" before starting one** — it has the full sequence, including the concept-level drafting bar and the provenance-line strip.
+**Any** rules addition — promoted from memory or not — is drafted at **concept level**: WHY + the invariant + a durable pointer, not the exhaustive HOW (grep blocks, enumerations, step lists). This holds for **path-scoped** targets too, where `context-budget.md`'s always-loaded discipline stops and its "budget looser there" does *not* license a dump; expand a section only when a reviewer shows the omitted detail is load-bearing for the rule to fire.
+
+Promotion specifically is PROMOTE-only — retirement is memory-direct and needs no PR. Two steps nothing else enforces, so they belong on the rolling issue's checklist: **update every mirror** of the promoted fact in the same PR (the `code-reviewer` trap cheat sheet, a `CLAUDE.md` parenthetical — mirrors drift silently otherwise), and **delete the source memory only after the rule lands**, since a repo PR cannot enforce a per-machine `command rm`. **Read [`docs/agent-tooling/claim-verification.md`](../../docs/agent-tooling/claim-verification.md) § "Promotion mechanics" before starting one** — it has the full sequence, including the provenance-line strip.
 
 ## Anti-pattern: memory refs in repo-tracked files
 
@@ -65,11 +67,13 @@ repo needs to carry itself.
 acceptable **only** in never-committed places (`~/.claude/CLAUDE.md`,
 conversational scratch).
 
-**Detection** — new code must not add hits. A recursive grep answers "which
+**Detection** — new code must not add hits. A recursive search answers "which
 files lie here" while the rule asks "which are **repo-tracked**", and the two
-diverge both ways (dot-dirs like `.claude/` go unscanned; tracked-but-ignored
-files are missed) — so enumerate, don't recurse. `-H` is required: without it
-`grep` drops the filename on a single match and the `file:line` breaks.
+diverge in both directions: a tracked file under an ignored directory is
+missed, never-committed scratch is falsely flagged (and `rg` specifically also
+skips dot-dirs, so `.claude/**` went unscanned for a while). Enumerate, don't
+recurse. `-H` is required: without it `grep` drops the filename on a single
+match and the `file:line` breaks.
 
 ```sh
 git ls-files -z --cached --others --exclude-standard \

--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -1,7 +1,12 @@
 # Knowledge Layering & Promotion
 
 > Derived from [claude-kit](https://github.com/tyabu12/claude-kit) `rules/knowledge-layering.md` —
-> the generic core is canonical there; reconcile one-way (kit → Pastura). Pastura-specific
+> the generic core is canonical there; reconcile one-way (kit → Pastura). **Since kit#24 the kit's
+> rules carry firing conditions only, with the depth evacuated to the kit's `docs/` — so reconcile
+> rule + doc as a pair.** Diffing the kit's rule alone reads relocated depth as deletions. This
+> mirror's kit-side pair is `docs/claim-verification.md` (backs § "Verify before you lock it"),
+> plus `docs/code-review-path-scoped-rules.md` for the mid-session non-injection probes — that one
+> gets no Pastura counterpart doc on purpose, #1312 holds this repo's. Pastura-specific
 > content lives only in this copy.
 
 Always-loaded — see `CLAUDE.md` `## Context-Specific Rules`. Pairs with `context-budget.md` (content discipline within always-loaded files); this rule covers location choice across all storage tiers.

--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -32,30 +32,19 @@ Memory `feedback_*` / `project_*` / `reference_*` entries belong in a rules file
   - a lesson true across *all my projects* (a tool's quirk, a personal workflow rule) → **global `~/.claude/rules/`**, not this repo — writing it here burdens Pastura contributors with a rule that is not about Pastura.
   - a lesson specific to *this project* → Pastura's `.claude/rules/` (path-scoped if domain-specific), or `CLAUDE.md` when it is project-wide.
 
-  A global rule **adds** a personal baseline, never **replaces** what a shared repo must carry — § "Anti-pattern" below.
+  A global rule **adds** a personal baseline, never **replaces** what a shared repo must carry — § "Anti-pattern: memory refs in repo-tracked files" below.
 
 **User-preference carve-out**: feedback flavored as personal preference (e.g., "this user wants critic limited to 2/PR") stays in memory regardless of Pastura-specificity — it's `user_*`-flavored even when the trigger event was project work.
 
 ## Promotion & retirement
 
-Three triggers for a triage pass (promotion **and** retirement), ordered by fire-rate reliability:
+Trigger a triage pass on memory **count** or **total content size** (`cat memory/*.md | wc -c`) — >80 files or >~250KB, or every several months. Never wait for the built-in MEMORY.md *index*-size warning: index lines are one-liners, so it badly understates true content and fires far too late. Two cheaper triggers ride along: during `/orchestrate`, if this session created feedback memories and the PR already touches `.claude/rules/`, bundle the rule addition in; and at memory-save time, apply the quick test above and prefer opening the rules PR alongside the entry.
 
-1. **Periodic triage** (most reliable, user-initiated) — run a full triage when total memory files >80 or total memory content >~250KB (`cat memory/*.md | wc -c`; the built-in MEMORY.md *index*-size warning fires far too late — index lines are one-liners, so it badly understates true content — don't wait for it), or every several months. Top-N largest memories → promotion candidates; SHIPPED trackers → retire candidates. A persistent `feedback_*>40` signals a *promotion* backlog specifically (retirement never deletes `feedback_*`).
-2. **During `/orchestrate`** (rule-aware bundling) — if the current session created new feedback memories and the active PR is already touching `.claude/rules/`, bundle the rule addition in. Cheaper than a separate cleanup PR.
-3. **At memory-save time** (best-effort nudge, expect drift) — for new `feedback_*` saves, apply the quick test above. If it routes to rules, prefer creating a `.claude/rules/` PR alongside (and optionally instead of) the memory entry. The memory is the rapid-capture form; the rule is the durable form.
-
-**Retire, don't only promote.** A triage pass also *removes* memory. A `project_*` tracker whose work has fully SHIPPED — no open follow-ups, outcome now derivable from code/git/docs — is **DELETED**; one with a shipped bulk plus a few live items is **TRIMMED** to the open-tracking stub. Promotion and retirement compose: run the quick test **first** to promote any durable lesson, then delete/trim the residue — a memory can be promoted *and* deleted the same round. **Prefer deletion**: when promoting, or when tracked work completes, actively check whether the memory can go rather than keeping it. (Operational classification: `/claude-kit:promote-memories` § "Step 1: Triage" — the plugin-provided skill; Pastura keeps no local copy.)
+**Retire, don't only promote.** A pass *removes* memory as well. A `project_*` tracker whose work has fully SHIPPED — no open follow-ups, outcome derivable from code/git/docs — is **DELETED**; one with a shipped bulk plus a few live items is **TRIMMED** to its open-tracking stub. The two compose: run the quick test first to promote any durable lesson, then delete or trim the residue — the same memory can be promoted *and* retired in one round. **Prefer deletion.** A persistent `feedback_*>40` signals a *promotion* backlog specifically (retirement never deletes `feedback_*`). Dispositions and the approval flow: the `claude-kit:promote-memories` skill (plugin-provided; Pastura keeps no local copy).
 
 ## Procedure
 
-This procedure is for **PROMOTE**; retirement (DELETE / TRIM) is memory-direct and needs no PR.
-
-File a rolling tracking issue collecting candidate sections, then `/orchestrate` a PR that:
-
-1. Lands additions to `.claude/rules/` (or `CLAUDE.md` for project-wide rules), drafted at **concept level** — WHY + the invariant + a durable pointer, not the exhaustive HOW (grep blocks, enumerations, step lists). This holds for **path-scoped** targets too, where `context-budget.md`'s always-loaded discipline stops; expand a section only when a reviewer shows the omitted detail is load-bearing for the rule to fire.
-2. Strips `Source memory: feedback_*` provenance lines from drafts before commit — repo-tracked files referring to per-user memory by name are dead links for other contributors.
-3. If the promoted content is mirrored elsewhere — the code-reviewer trap cheat sheet (`.claude/agents/code-reviewer.md`), a CLAUDE.md summary parenthetical — update every mirror in the same PR. Mirrors drift silently otherwise (e.g., swift-isolation gained Pattern 5 while two "4 traps" enumerations stayed behind).
-4. After PR merges, locally `command rm ~/.claude/projects/.../memory/<source>.md` — the PR can't enforce memory deletion (it's per-user / per-machine); track via the rolling issue checklist.
+PROMOTE only — retirement is memory-direct and needs no PR. Two steps nothing else enforces, so they belong on the rolling issue's checklist: **update every mirror** of the promoted fact in the same PR (the `code-reviewer` trap cheat sheet, a `CLAUDE.md` parenthetical — mirrors drift silently otherwise), and **delete the source memory only after the rule lands**, since a repo PR cannot enforce a per-machine `command rm`. **Read [`docs/agent-tooling/claim-verification.md`](../../docs/agent-tooling/claim-verification.md) § "Promotion mechanics" before starting one** — it has the full sequence, including the concept-level drafting bar and the provenance-line strip.
 
 ## Anti-pattern: memory refs in repo-tracked files
 
@@ -94,57 +83,40 @@ Known carve-outs (where inline rationale would be too dense to migrate):
 - `Pastura/PasturaTests/App/LaunchPhaseCoordinatorTests.swift` —
   CI wallclock test bound rationale
 
-See PR #420 for the motivating incident. Long-term, both carve-outs
-should migrate to inline rationale or a public doc home.
+See PR #420 for the motivating incident. Why the prose example above is
+written with a `<name>` placeholder rather than carved out, and why the file
+set matters more than the pattern: the doc's § "The rule-assertion case".
 
 ## Verify before you lock it
 
 One discipline, three moments where a claim becomes load-bearing and nobody downstream will check it. A reviewer evaluates a rule's *content*, not the check the rule prescribes; the Step 1b `claude-kit:critic` tests internal consistency, not external truth. The author is the only one positioned to run it.
 
-- **Rule-commit** — a `.claude/rules/` or `CLAUDE.md` addition carrying an **executable assertion** (an asserted grep hit count, a cited `file:line`, a `(PR #N)` claim, a cross-doc heading anchor, **or a self-quoted byte/line delta** — re-measure that one on the *final* commit) is run against current main state **before commit**. Dispositions: § "Apply (verification table)".
-- **Plan-lock** — every load-bearing claim a plan leans on is verified against its authoritative source **before** Step 1b. The critic's axes are codebase-internal (dependency rules, phase scope, integration risk), so an externally-false but internally-plausible claim passes it and surfaces only at code-review or in production. Per-shape checks: the table below.
+- **Rule-commit** — a `.claude/rules/` or `CLAUDE.md` addition carrying an **executable assertion** (an asserted grep hit count, a cited `file:line`, a `(PR #N)` claim, a cross-doc heading anchor, **or a self-quoted byte/line delta** — re-measure that one on the *final* commit) is run against current main state **before commit**. Dispositions: § "Dispositions when an assertion diverges".
+- **Plan-lock** — every load-bearing claim a plan leans on is verified against its authoritative source **before** Step 1b. **Read the doc's § "The claim table"** — it maps each claim shape to the source that settles it, and the shapes are not guessable (a defect framed with `would`; two UI surfaces called "the same metric"; a subagent verdict that *dismisses* a risk).
 - **Authoring** — a why-comment, guard, count, or gap list *you write* asserts behaviour that nobody executes. § "Claims you author are assertions too".
 
-| Claim a plan leans on | Verify by |
-|---|---|
-| A header/doc comment asserting cross-file structure ("defined in M", "consumable by Y") | grep the actual symbol/type — comments can be aspirational, not descriptive |
-| A `§"Heading"` cross-doc reference | grep the target for the exact heading **and read under it** to confirm the content matches; add a named heading if absent |
-| "band-aid / hack / dead code" framing of a change | grep ALL producers + consumers across layers (esp. Engine/runtime), not just the layer the issue scopes — the target may be load-bearing |
-| A documented defect framed as **live** ("X `would` flow into Y — i.e. fabrication") | grep every **writer** of the value, not just the reader — an upstream guard may already make it unreachable, in which case the comment is that guard's rationale, not a bug report. Subjunctive mood is the tell (#1151) |
-| Two UI surfaces asserted to show "the same metric" | grep both value sources before claiming equivalence — layout/label similarity ≠ value identity; a static estimate and a measured count can read as "matching" yet diverge silently |
-| An external standard (SEO, RFC, sitemap/robots, OAuth, HTTP semantics) | WebSearch + WebFetch the authority (Google Search Central, the RFC, MDN); verbatim-cite before critic |
-| Vendor feature availability (free/paid/plan tier) | WebFetch the canonical docs; verbatim-quote the "Who can use this feature" box — never infer from search snippets |
-| A subagent's verdict on an external platform fact (SDK annotation, threading contract, API availability) | Re-derive it yourself — a verdict that *dismisses* a risk ends inquiry and is the expensive one to get wrong. Then run the prescribed check against a **known-positive control**; `swift-isolation.md` § Pattern 7 is the worked instance |
+### Dispositions when an assertion diverges
 
-### Apply (verification table)
+Run the command from the current worktree, compare against what the draft asserts, then reconcile one of three ways — never leave the divergence:
 
-For each load-bearing assertion in the draft:
+- **Sweep** — fix the violations in this PR if cheap.
+- **Reframe** — change the assertion to match observed state. § "Anti-pattern: memory refs in repo-tracked files" above is itself an example: "new code must not add hits" + a carve-out list, rather than "should return 0 hits".
+- **Inline carve-out** — enumerate existing violations with `file:line`.
 
-1. Paste the command (`rg`, `find`, `gh pr view`) into Bash from the current worktree.
-2. Compare observed output to what the rule asserts.
-3. Reconcile divergence one of three ways:
-   - **Sweep** — fix the violations in this PR if cheap.
-   - **Reframe** — change the assertion to match observed state. The "Anti-pattern: memory refs" section above is itself an example: "new code must not add hits" + an inline carve-out list, rather than "should return 0 hits".
-   - **Inline carve-out** — enumerate existing violations with `file:line`.
-
-This applies to **non-grep claims** too: cited file paths (`find` to confirm existence), `(PR #N)` claims about PR body content (`gh pr view N` to verify), heading anchors in cross-doc refs (`grep` for the exact heading).
-
-A 30-second self-check prevents 1–2 extra critic / code-reviewer rounds. Motivating incident: PR #462 round-3 critic.
+Non-grep claims count too: cited paths (`find`), `(PR #N)` claims about PR body content (`gh pr view N`), heading anchors (`grep` for the exact heading).
 
 ### Claims you author are assertions too
 
-A **why-comment you write** asserts runtime or library behaviour as the reason a mechanism exists — the same kind of claim as the table's, but authored at implementation *or review-fix* time and executed by nobody. Reviewers check whether the *code* is correct, not whether the *stated reason* is true, so a false one ships and the next reader inherits it as fact. Four shapes, none expressible as a `Verify by` lookup:
+A why-comment, guard, count or gap list asserts behaviour as the reason a mechanism exists — the same kind of claim the Plan-lock table covers, but authored at implementation *or review-fix* time, so no `Verify by` lookup applies and nobody executes it. Four shapes:
 
 - **Why-comment on a mechanism** → delete the mechanism and run the tests. Green means the claim is false, or the tests never covered it.
-- **A detector / guard / gate** → construct the thing it claims to catch and confirm it fires. A guard's success case proves nothing; only a negative control does. Scope it to the claim it defends: a check narrower than that claim (a files-only loop behind a files-and-directories completeness claim), or one that silently skips its exemptions instead of declaring them, passes by construction. And a control whose fixture a **sibling arm** can also reach reddens for the wrong reason — read *which* message fired, not the exit code, and re-key the fixture until only the guard can reach it.
-- **A classification or count built on an earlier claim** → when you fix that claim, grep what cited it. Fixing one authored claim can *invalidate* another you authored earlier, and nothing points back at it; a concessive clause propping up a category ("it belongs here, just differently") is the tell that it already broke.
-- **A gap list — and the remedy you prescribe for it** → each is an enumeration, inheriting the blind spot of whatever it was drawn from. A residue record drawn from the section naming one *kind* of gap cannot see the other kinds, and "re-run §X" is unpayable when §X never listed half the items. Re-derive from what changed, then check the remedy actually reaches it. Two sets written in sequence also read as a **partition** — state the overlap, or the reader does the arithmetic wrong, in the direction that understates residue.
+- **A detector / guard / gate** → construct what it claims to catch and confirm it fires. A guard's success case proves nothing; only a negative control does, and it must sit in the claim's *habitat*, not merely match its pattern.
+- **A classification or count built on an earlier claim** → when you fix that claim, grep what cited it. Nothing points back at the dependent one.
+- **A gap list — and the remedy you prescribe for it** → an enumeration inherits the blind spot of whatever it was drawn from. Re-derive from what changed, then check the remedy actually reaches it.
 
-**A probe's outcome gets misread in both directions.** Assert that the mutation's anchor matched — a `replace` that silently no-ops leaves the original behaviour and reads as verified. And treat a probe that stays **green** as a finding about the *fixtures*, not a redundant guard: a suite only reddens on states its fixtures build, so name the state the guard defends and confirm something constructs it before concluding anything.
+**A probe's outcome gets misread in both directions.** Assert that the mutation's anchor matched — a `replace` that silently no-ops reads as verified. And treat a **green** probe as a finding about the *fixtures*, not a redundant guard. When a check is too expensive to run, say the cause was not isolated: a reader can act on an acknowledged gap; a wrong cause they can only inherit.
 
-When a check is too expensive to run, say the cause was not isolated. A reader can act on an acknowledged gap; a wrong cause they can only inherit.
-
-Motivating incidents: PR #1152 round-1 review; PR #1299 rounds 1–3; #1312 rounds 1–4; PR #1303 rounds 1–3; PR #1314; PR #1334; PR #1365 / #1370.
+**Before writing a guard, a negative control, or a why-comment you cannot cheaply test, read the doc's § "Authored claims — the four shapes in full" and § "Reading a probe's outcome".** Each shape has an elaboration that is where it actually goes wrong — the sibling arm that reddens a control for the wrong reason, the concessive clause that marks an already-broken category, the two sets that read as a partition.
 
 ### A rules file created mid-session never injects in that session
 

--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -55,7 +55,7 @@ File a rolling tracking issue collecting candidate sections, then `/orchestrate`
 ## Anti-pattern: memory refs in repo-tracked files
 
 Auto-memory at `~/.claude/projects/<workspace>/memory/` is **per-user /
-per-machine**. Any reference of the form `` memory `foo.md` `` inside a
+per-machine**. Any reference of the form `` memory `<name>.md` `` inside a
 repo-tracked file (CLAUDE.md, CONTRIBUTING.md, ADRs, source comments,
 script header docs) is a **dead link** for everyone except the
 maintainer who wrote the memory.
@@ -71,10 +71,15 @@ repo needs to carry itself.
 acceptable **only** in never-committed places (`~/.claude/CLAUDE.md`,
 conversational scratch).
 
-**Detection** — new code must not add hits to this grep:
+**Detection** — new code must not add hits. A recursive grep answers "which
+files lie here" while the rule asks "which are **repo-tracked**", and the two
+diverge both ways (dot-dirs like `.claude/` go unscanned; tracked-but-ignored
+files are missed) — so enumerate, don't recurse. `-H` is required: without it
+`grep` drops the filename on a single match and the `file:line` breaks.
 
-```
-rg -n 'memory `[a-z_]+\.md`' --glob '!**/memory/**' --glob '!.git/**'
+```sh
+git ls-files -z --cached --others --exclude-standard \
+  | xargs -0 grep -nHE 'memory `[a-z_]+\.md`'
 ```
 
 Known carve-outs (where inline rationale would be too dense to migrate):

--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -92,13 +92,13 @@ Known carve-outs (where inline rationale would be too dense to migrate):
 See PR #420 for the motivating incident. Long-term, both carve-outs
 should migrate to inline rationale or a public doc home.
 
-## Rule-writing self-check
+## Verify before you lock it
 
-When adding a `.claude/rules/` section (or `CLAUDE.md` content) that includes an **executable assertion** — a grep command with an asserted hit count, a cited `file:line`, a `(PR #N)` claim, a cross-doc heading anchor, **or a self-quoted byte/line delta** (re-measure on the *final* commit) — execute it against current main state **before commit**.
+One discipline, three moments where a claim becomes load-bearing and nobody downstream will check it. A reviewer evaluates a rule's *content*, not the check the rule prescribes; the Step 1b `claude-kit:critic` tests internal consistency, not external truth. The author is the only one positioned to run it.
 
-Pre-impl critic and code-reviewer reviews have repeatedly missed this class: they evaluate the *content* of the rule but rarely run the *check* the rule itself prescribes. The writer is the only one who reliably can.
-
-The same "verify before you lock it" discipline extends past rule assertions to **any load-bearing claim a plan leans on**, checked **before plan-lock (Step 1b `claude-kit:critic`)**. The critic's axes are codebase-internal (dependency rules, phase scope, integration risk), so a claim that is *externally* false but internally plausible passes critic and surfaces only at code-review or in production — the plan author is the one positioned to check. Verify each against its authoritative source:
+- **Rule-commit** — a `.claude/rules/` or `CLAUDE.md` addition carrying an **executable assertion** (an asserted grep hit count, a cited `file:line`, a `(PR #N)` claim, a cross-doc heading anchor, **or a self-quoted byte/line delta** — re-measure that one on the *final* commit) is run against current main state **before commit**. Dispositions: § "Apply (verification table)".
+- **Plan-lock** — every load-bearing claim a plan leans on is verified against its authoritative source **before** Step 1b. The critic's axes are codebase-internal (dependency rules, phase scope, integration risk), so an externally-false but internally-plausible claim passes it and surfaces only at code-review or in production. Per-shape checks: the table below.
+- **Authoring** — a why-comment, guard, count, or gap list *you write* asserts behaviour that nobody executes. § "Claims you author are assertions too".
 
 | Claim a plan leans on | Verify by |
 |---|---|

--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -68,12 +68,14 @@ acceptable **only** in never-committed places (`~/.claude/CLAUDE.md`,
 conversational scratch).
 
 **Detection** — new code must not add hits. A recursive search answers "which
-files lie here" while the rule asks "which are **repo-tracked**", and the two
-diverge in both directions: a tracked file under an ignored directory is
-missed, never-committed scratch is falsely flagged (and `rg` specifically also
-skips dot-dirs, so `.claude/**` went unscanned for a while). Enumerate, don't
-recurse. `-H` is required: without it `grep` drops the filename on a single
-match and the `file:line` breaks.
+files lie here" while the rule asks "which are **repo-tracked**", and it misses
+in one direction or the other depending on the searcher: a gitignore-respecting
+one (`rg`) skips a tracked file staged under an ignored directory — and skips
+dot-dirs entirely without `--hidden`, which is how `.claude/**` went unscanned
+for a while — while a plain `grep -r` flags ignored scratch the enumeration
+below deliberately excludes. Enumerate, don't recurse. `-H` is required:
+without it `grep` drops the filename on a single match and the `file:line`
+breaks.
 
 ```sh
 git ls-files -z --cached --others --exclude-standard \

--- a/.claude/rules/subagent-usage.md
+++ b/.claude/rules/subagent-usage.md
@@ -69,8 +69,9 @@ escape from an over-scoped call — see **§3**.
 
 **These numbers are review-attention bounds, NOT cap-derived** — a cap-table
 change in §1 leaves them untouched unless it drops a cap *below* them, and they
-are kit-canonical rather than a per-project knob. Go **tighter** at the call site when the diff is dense; never
-looser. **Before revising them, or before arguing a call is an exception, read
+are kit-canonical rather than a per-project knob. Go **tighter** at the call
+site when the diff is dense; never looser. **Before revising them, or before
+arguing a call is an exception, read
 the doc's § "Why the split thresholds are not cap-derived"** — the only valid
 evidence is about review quality, not about tokens.
 
@@ -131,12 +132,12 @@ A cost-driven downgrade is still bounded by the same sensitivity rules
 ## 4. Agent self-defense
 
 The two defend asymmetrically. `code-reviewer.md` restates §2's line/file
-numbers and bails with `SCOPE_TOO_LARGE` **before any tool_use**;
-`claude-kit:critic` carries an axis-only budget (≤5 axes, triage above 7) and
-acts *during* the run, stopping to report at ~15 tool_use calls. **Keep
-`code-reviewer.md`'s copy in sync with §2** — critic's is kit-owned and
-one-way. Do not delete either as redundant: the doc's § "Why the agents
-duplicate the budget" has the reason.
+numbers and bails with `SCOPE_TOO_LARGE` after its one mandatory
+`git diff --stat` call, before any other tool_use; `claude-kit:critic` carries
+an axis-only budget (≤5 axes, triage above 7) and acts *during* the run,
+stopping to report at ~15 tool_use calls. **Keep `code-reviewer.md`'s copy in
+sync with §2** — critic's is kit-owned and one-way. Do not delete either as
+redundant: the doc's § "Why the agents duplicate the budget" has the reason.
 
 ## 5. Official `/code-review` vs the custom agents
 

--- a/.claude/rules/subagent-usage.md
+++ b/.claude/rules/subagent-usage.md
@@ -68,8 +68,8 @@ When numbers fall between soft and hard, prefer splitting. Model choice is no
 escape from an over-scoped call — see **§3**.
 
 **These numbers are review-attention bounds, NOT cap-derived** — a cap-table
-change in §1 must leave them untouched, and they are kit-canonical rather than a
-per-project knob. Go **tighter** at the call site when the diff is dense; never
+change in §1 leaves them untouched unless it drops a cap *below* them, and they
+are kit-canonical rather than a per-project knob. Go **tighter** at the call site when the diff is dense; never
 looser. **Before revising them, or before arguing a call is an exception, read
 the doc's § "Why the split thresholds are not cap-derived"** — the only valid
 evidence is about review quality, not about tokens.
@@ -130,11 +130,13 @@ A cost-driven downgrade is still bounded by the same sensitivity rules
 
 ## 4. Agent self-defense
 
-Both review agents restate §2's budget in their own definitions and act on it
-before any tool_use — `code-reviewer.md` bails with `SCOPE_TOO_LARGE`,
-`claude-kit:critic` triages instead. **Keep those copies in sync with §2**, and
-do not delete one as redundant: the doc's § "Why the agents duplicate the
-budget" has the reason.
+The two defend asymmetrically. `code-reviewer.md` restates §2's line/file
+numbers and bails with `SCOPE_TOO_LARGE` **before any tool_use**;
+`claude-kit:critic` carries an axis-only budget (≤5 axes, triage above 7) and
+acts *during* the run, stopping to report at ~15 tool_use calls. **Keep
+`code-reviewer.md`'s copy in sync with §2** — critic's is kit-owned and
+one-way. Do not delete either as redundant: the doc's § "Why the agents
+duplicate the budget" has the reason.
 
 ## 5. Official `/code-review` vs the custom agents
 

--- a/.claude/rules/subagent-usage.md
+++ b/.claude/rules/subagent-usage.md
@@ -1,7 +1,12 @@
 # Subagent Usage Rules
 
 > Derived from [claude-kit](https://github.com/tyabu12/claude-kit) `rules/subagent-usage.md` —
-> the generic core is canonical there; reconcile one-way (kit → Pastura). Everything numeric — the
+> the generic core is canonical there; reconcile one-way (kit → Pastura). **Since kit#24 the kit's
+> rules carry firing conditions only, with the depth evacuated to the kit's `docs/` — so reconcile
+> rule + doc as a pair.** Diffing the kit's rule alone reads relocated depth as deletions. This
+> mirror's kit-side pair set is `docs/subagent-output-cap.md` (backs §1–§2) and
+> `docs/code-review-path-scoped-rules.md` (backs §5's path-scoped-invisibility claim); the latter
+> gets no Pastura counterpart doc on purpose — #1312 holds this repo's probes. Everything numeric — the
 > cap table, the `#24055` status, the 800/8/5 and 1500/12/7 split thresholds — is kit-canonical, but
 > the two kinds age differently. The **cap table** is Claude Code's platform limit — recomputed on
 > upgrade, never retuned (§1). The **split thresholds** are a *review-attention* bound, **NOT**
@@ -96,9 +101,13 @@ maximum.` The report usually survives with a **seam** where the cut happened —
 but if every resume also overflows, the run fails outright with that error and
 returns nothing.
 
-The tell is *not* a missing summary: review agents are built to emit their
-verdict/summary **first** under cap pressure, so it survives exactly when the
-run is truncated. Look instead for **detail missing behind a present summary**,
+The tell is *not* a missing summary: the Output Format puts `## Review Summary`
+first, so a cut lands in the body and leaves the header over-claiming. Note what
+this does **not** guarantee — the self-monitoring nudge that makes an agent stop
+investigating and emit the report is *conditional* on it noticing
+(`code-reviewer.md` fires it "near 20+ `tool_use` calls"), so a run that
+exhausts before noticing never reaches the format at all. Look for **detail
+missing behind a present summary**,
 which is mechanically checkable as a **count mismatch** — the summary claims
 more issues, axes, or findings than the body actually writes out, or names them
 with no evidence attached. Corroborate with intermediate tool output present
@@ -108,8 +117,8 @@ short, and needs nothing. In Pastura the check is arithmetic rather than
 a prose judgement: `code-reviewer`'s summary emits per-severity counts
 (`- **Critical**: N issues`) to compare the body against.
 
-**A second failure shape: no verdict at all**, contradicting the guarantee
-above — the run returns only its opening sentence, leaving the count-mismatch
+**A second failure shape: no verdict at all** — the conditional above not
+firing — the run returns only its opening sentence, leaving the count-mismatch
 detector no summary to check a body against. Seen on broad **multi-axis verification** prompts, not on large diffs
 (#1410). **Apply**: treat it as "re-run narrower" rather than as a finding, and
 cut what the prompt asks the agent to *verify*, not how many files it sees.
@@ -180,9 +189,10 @@ Swift-6-concurrency / secrets sections to "defer to `/code-review`".**
 `code-reviewer` is the *sole* review gate on the unattended path
 (`/queue-consumer` overnight); `/code-review` is a foreground
 interactive skill never wired into a subagent slot, so on that path
-nothing else runs. The official skill also leaves two gaps by design
-(per its plugin definition): it reads `CLAUDE.md` only — never
-`.claude/rules/`, so the trap cheat sheet is invisible to it — and its
+nothing else runs. The official skill also leaves two gaps: it names
+`CLAUDE.md` as its convention source and path-scoped rules are **measured**
+not to reach it, so the trap cheat sheet is invisible — the *cause* of that
+is open, so do not reason forward from a mechanism for it — and its
 false-positive rule discards generic code-quality / security /
 test-coverage findings unless `CLAUDE.md` demands them. So Dependency
 Rules (in `CLAUDE.md`) may surface via either gate, but `.claude/rules/`

--- a/.claude/rules/subagent-usage.md
+++ b/.claude/rules/subagent-usage.md
@@ -1,20 +1,12 @@
 # Subagent Usage Rules
 
 > Derived from [claude-kit](https://github.com/tyabu12/claude-kit) `rules/subagent-usage.md` —
-> the generic core is canonical there; reconcile one-way (kit → Pastura). **Since kit#24 the kit's
-> rules carry firing conditions only, with the depth evacuated to the kit's `docs/` — so reconcile
-> rule + doc as a pair.** Diffing the kit's rule alone reads relocated depth as deletions. This
-> mirror's kit-side pair set is `docs/subagent-output-cap.md` (backs §1–§2) and
-> `docs/code-review-path-scoped-rules.md` (backs §5's path-scoped-invisibility claim); the latter
-> gets no Pastura counterpart doc on purpose — #1312 holds this repo's probes. Everything numeric — the
-> cap table, the `#24055` status, the 800/8/5 and 1500/12/7 split thresholds — is kit-canonical, but
-> the two kinds age differently. The **cap table** is Claude Code's platform limit — recomputed on
-> upgrade, never retuned (§1). The **split thresholds** are a *review-attention* bound, **NOT**
-> cap-derived (§2): they rest on a *subagent's* attention at a given scope — identical for every kit
-> installation — so a cap move never retunes them. The one lever a caller controls is report density
-> per changed line — generated fixtures report far shorter than dense source — and it licenses
-> bounding a call **tighter at the call site, never looser**: split smaller rather than edit §2's
-> numbers or any agent copy of them (today `.claude/agents/code-reviewer.md`).
+> the generic core is canonical there; reconcile one-way (kit → Pastura), **rule + doc as a pair**:
+> since kit#24 both sides carry firing conditions here and depth in a paired doc, so diffing rules
+> alone reads relocated depth as deletions. Pastura's doc is
+> [`docs/agent-tooling/subagent-output-cap.md`](../../docs/agent-tooling/subagent-output-cap.md);
+> the kit's are `docs/subagent-output-cap.md` (§1–§2) and `docs/code-review-path-scoped-rules.md`
+> (§5) — the latter gets no Pastura counterpart on purpose, #1312 holds this repo's probes.
 > Pastura-specific content lives only in this copy.
 
 Always-loaded — see `CLAUDE.md` `## Context-Specific Rules` for the
@@ -26,11 +18,9 @@ this rule must stay visible regardless of which file is being edited.
 
 Every subagent (anything launched via the `Agent` tool, including custom
 `code-reviewer` / `claude-kit:critic` / `Explore` / `Plan`) runs under an
-**output-token cap per response**. It is the *model's* cap, not a
-subagent-specific one: the request builder has no main/subagent branch and the
-`Agent` tool passes no override. Raising frontmatter `maxTurns` does not help —
-the cap is per response, not per run — and `maxOutputTokens` does not exist as
-a frontmatter key.
+**output-token cap per response** — the *model's* cap, with no subagent-specific
+variant. Neither frontmatter knob helps: `maxTurns` raises turns, not the
+per-response cap, and `maxOutputTokens` is not a frontmatter key at all.
 
 | Model | Cap | Ceiling via `CLAUDE_CODE_MAX_OUTPUT_TOKENS` |
 |-------|-----|---------------------------------------------|
@@ -39,22 +29,18 @@ a frontmatter key.
 | Fable 5 | **64,000** † | 128,000 † |
 | Haiku 4.5 | **32,000** | 64,000 † |
 
-Measured 2026-08-12 on Claude Code **2.1.228**. Pre-5 generations vary either
-way — Opus 4.6-4.8 also sat at 64,000, Sonnet 4.x at 32,000, Haiku 3.5 at
-8,192 — so **do not extrapolate backwards**. **† = read from the shipped model
-catalog, not behaviourally verified**; only the unmarked caps were observed in
-a live run. Read any model's live cap in about two seconds, without having to
-provoke a truncation:
+Measured 2026-08-12 on Claude Code **2.1.228**; `†` = catalog-read, not observed.
+**Do not extrapolate to another generation in either direction** — the spread is
+not uniform by family. On a Claude Code upgrade, re-read the live cap and
+update the table; before trusting a pre-5 figure, read the doc's
+§ "The cap table's provenance".
 
 ```sh
 claude -p --model opus --output-format json "ok" | jq '.modelUsage[].maxOutputTokens'
 ```
 
 `CLAUDE_CODE_MAX_OUTPUT_TOKENS` is the only real budget lever, and it **does**
-reach subagents — contrary to what this rule claimed before, and confirmed by
-forcing it to 1,200 and finding the subagent's own responses capped at exactly
-that number. Tracked upstream in
-[anthropics/claude-code#24055](https://github.com/anthropics/claude-code/issues/24055) (OPEN).
+reach subagents (evidence: doc § "The env-var lever reaches subagents").
 
 **Model pins in this repo**: `code-reviewer.md` keeps `model: opus`
 deliberately — for Opus-class review *judgement*, not for a token budget (§2's
@@ -81,64 +67,49 @@ When invoking a subagent, bound the work so the reviewer's **attention** holds
 When numbers fall between soft and hard, prefer splitting. Model choice is no
 escape from an over-scoped call — see **§3**.
 
-### Why the thresholds are not cap-derived
-
-They used to be, pinned to a cap no spawnable model ever had. The cap was never
-the binding constraint at these scopes; what they buy is **review attention**,
-which does not scale with a model's `max_tokens`. So revise them on
-review-quality evidence, **not** by recomputing when a cap moves — a cap-table
-update (§1) must leave the numbers above untouched.
+**These numbers are review-attention bounds, NOT cap-derived** — a cap-table
+change in §1 must leave them untouched, and they are kit-canonical rather than a
+per-project knob. Go **tighter** at the call site when the diff is dense; never
+looser. **Before revising them, or before arguing a call is an exception, read
+the doc's § "Why the split thresholds are not cap-derived"** — the only valid
+evidence is about review quality, not about tokens.
 
 **A split leaves a seam no shard owns.** Each invocation sees only its own
 slice, so anything spanning the split — a mirrored count, a cross-reference,
 a claim one shard makes about another's files — is unreviewed by
 construction. Name the seam's owner, or add a final pass over the whole.
 
-**What a cap hit looks like.** It is **no longer silent**: Claude Code detects
-`stop_reason: max_tokens`, nudges the agent to resume, and retries up to
-**3** times before surfacing an `API Error: … exceeded the N output token
-maximum.` The report usually survives with a **seam** where the cut happened —
-but if every resume also overflows, the run fails outright with that error and
-returns nothing.
+**Spotting a cap hit.** A hit is not silent — Claude Code retries the response,
+so what usually survives is a **seam** mid-report rather than a silent loss. The
+tell is a **count mismatch**: the summary claims more issues, axes, or findings
+than the body writes out, or names them with no evidence attached. Corroborate
+with intermediate tool output present and no `SCOPE_TOO_LARGE`, then **split and
+re-run**. In Pastura the check is arithmetic, not a prose judgement:
+`code-reviewer`'s summary emits per-severity counts (`- **Critical**: N issues`)
+to compare the body against. A report that is short *and internally consistent*
+is just short — except in two shapes that leave no count to mismatch:
 
-The tell is *not* a missing summary: the Output Format puts `## Review Summary`
-first, so a cut lands in the body and leaves the header over-claiming. Note what
-this does **not** guarantee — the self-monitoring nudge that makes an agent stop
-investigating and emit the report is *conditional* on it noticing
-(`code-reviewer.md` fires it "near 20+ `tool_use` calls"), so a run that
-exhausts before noticing never reaches the format at all. Look for **detail
-missing behind a present summary**,
-which is mechanically checkable as a **count mismatch** — the summary claims
-more issues, axes, or findings than the body actually writes out, or names them
-with no evidence attached. Corroborate with intermediate tool output present
-and no `SCOPE_TOO_LARGE`. That combination is the signal to **split and
-re-run** — a report that is short *and internally consistent* is just
-short, and needs nothing. In Pastura the check is arithmetic rather than
-a prose judgement: `code-reviewer`'s summary emits per-severity counts
-(`- **Critical**: N issues`) to compare the body against.
+- **No verdict at all** — the run returns only its opening sentence. Seen on
+  broad **multi-axis verification** prompts, not on large diffs (#1410). Treat
+  it as "re-run narrower", not as a finding: cut what the prompt asks the agent
+  to *verify*, not how many files it sees. Requesting the verdict in the first
+  message is cheap insurance.
+- **A zero-issue report** — a summary claiming nothing cannot mismatch, so a cut
+  landing right after it reads as consistent. Closing that needs a structural
+  check against a pinned Output Format; `queue-consumer` hard rule 6 carries one
+  for the unattended path.
 
-**A second failure shape: no verdict at all** — the conditional above not
-firing — the run returns only its opening sentence, leaving the count-mismatch
-detector no summary to check a body against. Seen on broad **multi-axis verification** prompts, not on large diffs
-(#1410). **Apply**: treat it as "re-run narrower" rather than as a finding, and
-cut what the prompt asks the agent to *verify*, not how many files it sees.
-Requesting the verdict in the first message is cheap insurance.
-
-**Blind spot**: a summary claiming nothing cannot mismatch, so a
-zero-issue report truncated right after it reads as consistent. Closing
-that needs a structural check against a pinned Output Format — see
-`queue-consumer` hard rule 6, which carries one for the unattended path.
+Both shapes trace to one conditional in the agent definitions. **When a report
+looks truncated and you are deciding whether to re-run, read the doc's § "How a cap hit behaves"** before concluding the run was fine.
 
 ## 3. Model choice is a cost lever, not a budget lever
 
-`Agent(model: "sonnet")` no longer buys headroom — Opus 5 and Sonnet 5 are
-both **64,000** — so the "Sonnet override" that used to sit here as a budget
-escape valve no longer exists. Pick the model for **capability and cost**,
-never to escape a budget. The one budget-relevant asymmetry is **Haiku at
-half** (32,000): do not hand it a report-heavy task on the assumption every
-model carries the same load. When work genuinely needs more room than the model
-has, **split the scope**. Raising `CLAUDE_CODE_MAX_OUTPUT_TOKENS` (§1) buys
-tokens, not attention, and is never a substitute for splitting.
+`Agent(model: "sonnet")` buys no headroom — Opus 5 and Sonnet 5 are both
+**64,000**. Pick the model for **capability and cost**, never to escape a
+budget. The one budget-relevant asymmetry is **Haiku at half** (32,000): do not
+hand it a report-heavy task assuming every model carries the same load. When
+work genuinely needs more room, **split the scope** — raising
+`CLAUDE_CODE_MAX_OUTPUT_TOKENS` (§1) buys tokens, not attention.
 
 A cost-driven downgrade is still bounded by the same sensitivity rules
 `/orchestrate` applies:
@@ -152,31 +123,24 @@ A cost-driven downgrade is still bounded by the same sensitivity rules
   dependency-rule boundaries, ADR/spec edits, etc.
 - **`critic` non-recommendation** (`critic` in prose = the
   `claude-kit:critic` plugin agent — invoke it by that namespaced name):
-  `critic` makes judgement calls
-  (pre-mortem axis generation, bias rebuttal). For plan critique on
-  architectural decisions, prefer **Opus + scope-split** over a cheaper
-  model. Sonnet's reasoning depth is acceptable for routine
+  `critic` makes judgement calls (pre-mortem axis generation, bias rebuttal).
+  For plan critique on architectural decisions, prefer **Opus + scope-split**
+  over a cheaper model. Sonnet's reasoning depth is acceptable for routine
   reviews but not for the cases where `critic` is most valuable.
 
 ## 4. Agent self-defense
 
-`code-reviewer.md` carries an inline `Scope Guidance` section that bails
-with `SCOPE_TOO_LARGE` before any tool_use when the soft budget is
-exceeded. The kit-provided `claude-kit:critic` self-defends differently
-(its `Output Discipline & Scope` section triages: highest-risk axes
-first, explicit deferrals instead of a bail-out). Defense in depth:
-a cap hit usually shows up as nothing louder than a seam mid-report, so
-duplicating §2's budget in the agents' own bail-out is intentional.
-For what exhaustion actually looks like, see §2 — the detector lives
-there, with the caller-side heuristics it corroborates.
+Both review agents restate §2's budget in their own definitions and act on it
+before any tool_use — `code-reviewer.md` bails with `SCOPE_TOO_LARGE`,
+`claude-kit:critic` triages instead. **Keep those copies in sync with §2**, and
+do not delete one as redundant: the doc's § "Why the agents duplicate the
+budget" has the reason.
 
 ## 5. Official `/code-review` vs the custom agents
 
 The official `/code-review` skill does **not** replace `code-reviewer`
-or `critic` — the three occupy non-overlapping slots. (For the
-`code-reviewer`-vs-`critic` split itself, see §3's `critic`
-non-recommendation note; this section covers only the official-skill
-axis.)
+or `critic` — the three occupy non-overlapping slots (for the
+`code-reviewer`-vs-`critic` split itself, see §3).
 
 | Tool | Reviews | Runs as | Convention source |
 |------|---------|---------|-------------------|
@@ -187,16 +151,10 @@ axis.)
 **Load-bearing: do NOT slim `code-reviewer`'s general-quality /
 Swift-6-concurrency / secrets sections to "defer to `/code-review`".**
 `code-reviewer` is the *sole* review gate on the unattended path
-(`/queue-consumer` overnight); `/code-review` is a foreground
-interactive skill never wired into a subagent slot, so on that path
-nothing else runs. The official skill also leaves two gaps: it names
-`CLAUDE.md` as its convention source and path-scoped rules are **measured**
-not to reach it, so the trap cheat sheet is invisible — the *cause* of that
-is open, so do not reason forward from a mechanism for it — and its
-false-positive rule discards generic code-quality / security /
-test-coverage findings unless `CLAUDE.md` demands them. So Dependency
-Rules (in `CLAUDE.md`) may surface via either gate, but `.claude/rules/`
-traps and generic secrets/coverage surface only through `code-reviewer`.
+(`/queue-consumer` overnight), and the official skill misses `.claude/rules/`
+traps and generic secrets/coverage findings entirely. **Before acting on any
+proposal to consolidate the two, read the doc's § "Why `/code-review` cannot substitute"** — the two gaps are load-bearing and one of them has an open
+cause that must not be reasoned forward from.
 
 Reach for `/code-review` (e.g. `/code-review high`) as a **complement** —
 deeper generic bug-hunting or `--fix` auto-apply *on top of* the

--- a/.claude/rules/subagent-usage.md
+++ b/.claude/rules/subagent-usage.md
@@ -1,9 +1,9 @@
 # Subagent Usage Rules
 
 > Derived from [claude-kit](https://github.com/tyabu12/claude-kit) `rules/subagent-usage.md` —
-> the generic core is canonical there; reconcile one-way (kit → Pastura), **rule + doc as a pair**:
-> since kit#24 both sides carry firing conditions here and depth in a paired doc, so diffing rules
-> alone reads relocated depth as deletions. Pastura's doc is
+> the generic core is canonical there; reconcile one-way (kit → Pastura) **rule + doc as a pair**:
+> since kit#24 depth lives in a paired doc, so diffing rules alone reads it as deletions.
+> Pastura's doc is
 > [`docs/agent-tooling/subagent-output-cap.md`](../../docs/agent-tooling/subagent-output-cap.md);
 > the kit's are `docs/subagent-output-cap.md` (§1–§2) and `docs/code-review-path-scoped-rules.md`
 > (§5) — the latter gets no Pastura counterpart on purpose, #1312 holds this repo's probes.
@@ -90,11 +90,10 @@ re-run**. In Pastura the check is arithmetic, not a prose judgement:
 to compare the body against. A report that is short *and internally consistent*
 is just short — except in two shapes that leave no count to mismatch:
 
-- **No verdict at all** — the run returns only its opening sentence. Seen on
-  broad **multi-axis verification** prompts, not on large diffs (#1410). Treat
-  it as "re-run narrower", not as a finding: cut what the prompt asks the agent
-  to *verify*, not how many files it sees. Requesting the verdict in the first
-  message is cheap insurance.
+- **No verdict at all** — only the opening sentence returns. Seen on broad
+  **multi-axis verification** prompts, not on large diffs (#1410): re-run
+  narrower by cutting what the prompt asks the agent to *verify*, not how many
+  files it sees. Asking for the verdict up front is cheap insurance.
 - **A zero-issue report** — a summary claiming nothing cannot mismatch, so a cut
   landing right after it reads as consistent. Closing that needs a structural
   check against a pinned Output Format; `queue-consumer` hard rule 6 carries one
@@ -131,13 +130,11 @@ A cost-driven downgrade is still bounded by the same sensitivity rules
 
 ## 4. Agent self-defense
 
-The two defend asymmetrically. `code-reviewer.md` restates §2's line/file
-numbers and bails with `SCOPE_TOO_LARGE` after its one mandatory
-`git diff --stat` call, before any other tool_use; `claude-kit:critic` carries
-an axis-only budget (≤5 axes, triage above 7) and acts *during* the run,
-stopping to report at ~15 tool_use calls. **Keep `code-reviewer.md`'s copy in
-sync with §2** — critic's is kit-owned and one-way. Do not delete either as
-redundant: the doc's § "Why the agents duplicate the budget" has the reason.
+The two defend asymmetrically: `code-reviewer.md` bails with `SCOPE_TOO_LARGE`
+right after its one mandatory `git diff --stat`; `claude-kit:critic` triages
+axes *during* the run. **Keep `code-reviewer.md`'s copy of §2's numbers in
+sync** — critic's is kit-owned and one-way. Do not delete either as redundant:
+the doc's § "Why the agents duplicate the budget" has the reason.
 
 ## 5. Official `/code-review` vs the custom agents
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -283,9 +283,9 @@ Update with `/plugin`. Install steps: CONTRIBUTING.md § "If you use Claude Code
 
 - `swift-isolation.md` — `nonisolated` annotation traps under default-MainActor isolation. Always-loaded because the diagnostic fires at the use site, not the declaration — and the silent runtime-trap patterns fire none at all.
 - `xcodebuild-cli.md` — xcodebuild CLI playbook (test commands, DerivedData layout, timeout/recovery). Always-loaded because the gotchas surface during worktree switches and CI debugging, not only when editing tests.
-- `subagent-usage.md` — Subagent output-cap discipline (per-model output cap, review-attention scope budget, model choice = cost lever, never a budget escape). Always-loaded because subagent calls originate from any layer.
+- `subagent-usage.md` — Subagent output-cap discipline (per-model output cap, review-attention scope budget, model choice = cost lever, never a budget escape). Always-loaded because subagent calls originate from any layer. Depth in `docs/agent-tooling/subagent-output-cap.md` — **reconcile the pair**, never the rule alone.
 - `context-budget.md` — Content discipline for always-loaded files. Self-applying — route additions to CLAUDE.md / agent docs / any no-`paths:` rule through its classifier first.
-- `knowledge-layering.md` — Which tier knowledge belongs in (memory / `CLAUDE.md` / `.claude/rules/` / `docs/**`) and how to promote memory → rules. Pairs with `context-budget.md`.
+- `knowledge-layering.md` — Which tier knowledge belongs in (memory / `CLAUDE.md` / `.claude/rules/` / `docs/**`) and how to promote memory → rules. Pairs with `context-budget.md`. Depth in `docs/agent-tooling/claim-verification.md` — **reconcile the pair**, never the rule alone.
 
 ## File Naming
 
@@ -337,6 +337,8 @@ same change:
 | `docs/qa/navigation-qa.md`            | Navigation manual QA walkthroughs (numbered scenarios; extracted from `.claude/rules/navigation.md`) |
 | `docs/qa/dark-mode-qa.md`             | Dark-appearance manual QA walkthrough (ADR-028 gates 4/5; the six risk classes no test can reach — fixed tokens, materials, fixed-appearance exports, non-SwiftUI surfaces, occlusion layers, a rendered state with no ground behind it) |
 | `docs/ci/xcodebuild-flakes.md`        | CI + local UI-test flake catalog + hang/stall session-recovery walkthrough (extracted from `.claude/rules/xcodebuild-cli.md`) |
+| `docs/agent-tooling/subagent-output-cap.md` | Depth paired with `.claude/rules/subagent-usage.md` — cap provenance, why the split thresholds are not cap-derived, how a cap hit behaves. Reconcile rule + doc as a pair |
+| `docs/agent-tooling/claim-verification.md` | Depth paired with `.claude/rules/knowledge-layering.md` § "Verify before you lock it" — the claim table, authored-claim shapes in full, promotion mechanics. Reconcile rule + doc as a pair |
 | `docs/prototype/among_them_prototype.py` | Python prototype (reference implementation) |
 
 ### ADR roster

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,7 +285,7 @@ Update with `/plugin`. Install steps: CONTRIBUTING.md § "If you use Claude Code
 - `xcodebuild-cli.md` — xcodebuild CLI playbook (test commands, DerivedData layout, timeout/recovery). Always-loaded because the gotchas surface during worktree switches and CI debugging, not only when editing tests.
 - `subagent-usage.md` — Subagent output-cap discipline (per-model output cap, review-attention scope budget, model choice = cost lever, never a budget escape). Always-loaded because subagent calls originate from any layer. Depth in `docs/agent-tooling/subagent-output-cap.md` — **reconcile the pair**, never the rule alone.
 - `context-budget.md` — Content discipline for always-loaded files. Self-applying — route additions to CLAUDE.md / agent docs / any no-`paths:` rule through its classifier first.
-- `knowledge-layering.md` — Which tier knowledge belongs in (memory / `CLAUDE.md` / `.claude/rules/` / `docs/**`) and how to promote memory → rules. Pairs with `context-budget.md`. Depth in `docs/agent-tooling/claim-verification.md` — **reconcile the pair**, never the rule alone.
+- `knowledge-layering.md` — Two halves: which tier knowledge belongs in (memory / `CLAUDE.md` / `.claude/rules/` / `docs/**`) and how to promote memory → rules; **and § "Verify before you lock it"** — executing a load-bearing claim before a rule-commit, a plan-lock, or a why-comment you author. Pairs with `context-budget.md`. Depth in `docs/agent-tooling/claim-verification.md` — **reconcile the pair**, never the rule alone.
 
 ## File Naming
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -337,8 +337,8 @@ same change:
 | `docs/qa/navigation-qa.md`            | Navigation manual QA walkthroughs (numbered scenarios; extracted from `.claude/rules/navigation.md`) |
 | `docs/qa/dark-mode-qa.md`             | Dark-appearance manual QA walkthrough (ADR-028 gates 4/5; the six risk classes no test can reach — fixed tokens, materials, fixed-appearance exports, non-SwiftUI surfaces, occlusion layers, a rendered state with no ground behind it) |
 | `docs/ci/xcodebuild-flakes.md`        | CI + local UI-test flake catalog + hang/stall session-recovery walkthrough (extracted from `.claude/rules/xcodebuild-cli.md`) |
-| `docs/agent-tooling/subagent-output-cap.md` | Depth paired with `.claude/rules/subagent-usage.md` — cap provenance, why the split thresholds are not cap-derived, how a cap hit behaves. Reconcile rule + doc as a pair |
-| `docs/agent-tooling/claim-verification.md` | Depth paired with `.claude/rules/knowledge-layering.md` § "Verify before you lock it" — the claim table, authored-claim shapes in full, promotion mechanics. Reconcile rule + doc as a pair |
+| `docs/agent-tooling/subagent-output-cap.md` | Depth paired with `.claude/rules/subagent-usage.md` — cap provenance, why the split thresholds are not cap-derived, how a cap hit behaves |
+| `docs/agent-tooling/claim-verification.md` | Depth paired with `.claude/rules/knowledge-layering.md` § "Verify before you lock it" — the claim table, authored-claim shapes in full, promotion mechanics |
 | `docs/prototype/among_them_prototype.py` | Python prototype (reference implementation) |
 
 ### ADR roster

--- a/docs/agent-tooling/claim-verification.md
+++ b/docs/agent-tooling/claim-verification.md
@@ -1,0 +1,149 @@
+# Claim verification — which source settles which claim
+
+Paired with the always-loaded rule `.claude/rules/knowledge-layering.md` § "Verify before you lock
+it", which carries the discipline and the three moments it fires at. This file carries the per-shape
+checks, the worked failures, and the promotion mechanics.
+
+**Reconcile as a pair.** The kit counterpart is [claude-kit](https://github.com/tyabu12/claude-kit)
+`docs/claim-verification.md`; its rule is `rules/knowledge-layering.md`. Diffing either half alone
+reads relocated depth as a deletion. Nothing here is version-dependent, so there is no
+re-measurement trigger — it accretes as new failure shapes appear.
+
+**Why this is a doc and not a `paths:`-scoped rule.** A path-scoped rule would also leave the
+always-loaded budget, but it injects only on a `Read` matching its globs — and the Authoring moment
+fires in *any* file: Swift, a script, an ADR, a rule. No glob covers "any". So the trigger stays in
+the always-loaded rule and the evidence lives here; the cost is that this file loads only when
+something reads it, which is why the rule's pointers to it are imperative rather than "see also".
+
+## Why the author is the only checker
+
+**A claim is checked by whoever authors it, or by nobody.** A reviewer checks whether the code is
+correct and whether a rule's content is sensible — not whether the check a rule prescribes actually
+passes, and not whether the stated reason for a mechanism is true. A plan critique tests internal
+consistency, not external truth: `claude-kit:critic`'s axes are codebase-internal (dependency rules,
+phase scope, integration risk), so a claim that is externally false but internally plausible passes
+it and surfaces only at code-review or in production.
+
+A 30-second self-check prevents 1–2 extra critic / code-reviewer rounds.
+
+## The claim table
+
+Verify each against its authoritative source *before* the plan locks.
+
+| Claim a plan leans on | Verify by |
+|---|---|
+| A header/doc comment asserting cross-file structure ("defined in M", "consumable by Y") | grep the actual symbol/type — comments can be aspirational, not descriptive |
+| A `§"Heading"` cross-doc reference | grep the target for the exact heading **and read under it** to confirm the content matches; add a named heading if absent |
+| "band-aid / hack / dead code" framing of a change | grep ALL producers + consumers across layers (esp. Engine/runtime), not just the layer the issue scopes — the target may be load-bearing |
+| A documented defect framed as **live** ("X `would` flow into Y — i.e. fabrication") | grep every **writer** of the value, not just the reader — an upstream guard may already make it unreachable, in which case the comment is that guard's rationale, not a bug report. Subjunctive mood is the tell (#1151) |
+| Two UI surfaces asserted to show "the same metric" | grep both value sources before claiming equivalence — layout/label similarity ≠ value identity; a static estimate and a measured count can read as "matching" yet diverge silently |
+| An external standard (SEO, RFC, sitemap/robots, OAuth, HTTP semantics) | WebSearch + WebFetch the authority (Google Search Central, the RFC, MDN); verbatim-cite before critic |
+| Vendor feature availability (free/paid/plan tier) | WebFetch the canonical docs; verbatim-quote the "Who can use this feature" box — never infer from search snippets |
+| A subagent's verdict on an external platform fact (SDK annotation, threading contract, API availability) | Re-derive it yourself — a verdict that *dismisses* a risk ends inquiry and is the expensive one to get wrong. Then run the prescribed check against a **known-positive control**; `.claude/rules/swift-isolation.md` § Pattern 7 is the worked instance |
+
+This applies to **non-grep claims** too: cited file paths (`find` to confirm existence), `(PR #N)`
+claims about PR body content (`gh pr view N` to verify), heading anchors in cross-doc refs (`grep`
+for the exact heading).
+
+## Authored claims — the four shapes in full
+
+Authored at implementation *or review-fix* time, and executed by nobody. The rule carries the
+one-line version of each; the elaborations are what get missed.
+
+- **Why-comment on a mechanism** → delete the mechanism and run the tests. Green means the claim is
+  false, or the tests never covered it.
+- **A detector / guard / gate** → construct the thing it claims to catch and confirm it fires. A
+  guard's success case proves nothing; only a negative control does. Scope it to the claim it
+  defends: a check narrower than that claim (a files-only loop behind a files-and-directories
+  completeness claim), or one that silently skips its exemptions instead of declaring them, passes
+  by construction. And a control whose fixture a **sibling arm** can also reach reddens for the
+  wrong reason — read *which* message fired, not the exit code, and re-key the fixture until only
+  the guard can reach it.
+- **A classification or count built on an earlier claim** → when you fix that claim, grep what cited
+  it. Fixing one authored claim can *invalidate* another you authored earlier, and nothing points
+  back at it; a concessive clause propping up a category ("it belongs here, just differently") is
+  the tell that it already broke.
+- **A gap list — and the remedy you prescribe for it** → each is an enumeration, inheriting the
+  blind spot of whatever it was drawn from. A residue record drawn from the section naming one
+  *kind* of gap cannot see the other kinds, and "re-run §X" is unpayable when §X never listed half
+  the items. Re-derive from what changed, then check the remedy actually reaches it. Two sets
+  written in sequence also read as a **partition** — state the overlap, or the reader does the
+  arithmetic wrong, in the direction that understates residue.
+
+When a check is too expensive to run, say the cause was not isolated. A reader can act on an
+acknowledged gap; a wrong cause they can only inherit.
+
+## Reading a probe's outcome
+
+It gets misread in both directions.
+
+**Assert that the mutation's anchor matched.** A `replace` that silently no-ops leaves the original
+behaviour and reads as verified. Make the script fail loudly on a miss rather than reporting
+success — during this repo's own evacuation work, an anchor-asserting replace caught a pointer
+rewrite whose search string had drifted by a line break, which a plain `replace` would have skipped
+while printing nothing.
+
+**Treat a probe that stays green as a finding about the *fixtures*, not a redundant guard.** A suite
+only reddens on states its fixtures build, so name the state the guard defends and confirm something
+constructs it before concluding anything.
+
+## The rule-assertion case
+
+A rule file is where authored claims concentrate, because a rule *is* a set of assertions about the
+repo — and unlike a why-comment, the next reader runs them. Two consequences behind the rule's
+one-line version: a self-quoted byte/line delta is re-measured on the **final** commit because
+review fixes move it, and a diverged assertion left silently in place is the one wrong answer,
+because the reader who finds it is the one relying on it.
+
+A detector a rule *ships* is the sharpest case, because it runs against the file that defines it.
+The memory-ref detector in § "Anti-pattern: memory refs in repo-tracked files" flags that section's
+own prose example of the banned form — the *form being defined*, not a reference. The three
+dispositions are not equally cheap here: an inline carve-out adds a line to an **always-loaded**
+file *and* is itself a `file:line` assertion that re-breaks whenever the line moves, and narrowing
+the pattern to dodge one example is brittle by construction. Rewriting the example with a `<name>`
+placeholder takes the detector to zero without weakening it. If a later edit writes a concrete
+lowercase filename back in, the grep fires and the next editor picks a disposition again — the
+mechanism working, not a regression.
+
+**The file set matters more than the pattern.** The detector's first form recursed with `rg`, which
+skips hidden directories, so `.claude/**` — rules, skills, agents — went unscanned. `--hidden` closes
+that one instance and leaves the class open: a recursive grep answers "which files lie here" while
+the rule asks "which are repo-tracked", and the two diverge both ways (a tracked file under an
+ignored directory is missed; never-committed scratch is falsely flagged). Enumerating with
+`git ls-files --cached --others --exclude-standard` is what actually matches the claim. Measured in
+this repo when the final form landed: the `rg` version returned 2 hits, the enumerating version 3 —
+the third being the prose example above. **When a detector's file set is not the claim's file set,
+no flag fixes it.**
+
+Scope the negative control to the claim's *habitat*, not just its pattern: a control placed at the
+repo root sits inside the old detector's existing reach and reddens without testing the question.
+The control that settles it puts the violation inside `.claude/`.
+
+## Promotion mechanics
+
+The rule carries the triggers and the two steps nothing else enforces. The full sequence:
+
+1. File a rolling tracking issue collecting candidate sections.
+2. `/orchestrate` a PR landing the additions to `.claude/rules/` (or `CLAUDE.md` for project-wide
+   rules), drafted at **concept level** — WHY + the invariant + a durable pointer, not the
+   exhaustive HOW (grep blocks, enumerations, step lists). This holds for **path-scoped** targets
+   too, where `context-budget.md`'s always-loaded discipline stops; expand a section only when a
+   reviewer shows the omitted detail is load-bearing for the rule to fire.
+3. Strip `Source memory: feedback_*` provenance lines from drafts before commit — a repo-tracked
+   file referring to per-user memory by name is a dead link for other contributors.
+4. Update **every mirror** of the promoted fact in the same PR — the `code-reviewer` trap cheat
+   sheet (`.claude/agents/code-reviewer.md`), a `CLAUDE.md` summary parenthetical. Mirrors drift
+   silently otherwise: `swift-isolation.md` gained Pattern 5 while two "4 traps" enumerations
+   stayed behind.
+5. After the PR merges, locally `command rm ~/.claude/projects/.../memory/<source>.md`. A repo PR
+   cannot enforce a per-machine deletion, so it belongs on the rolling issue's checklist.
+
+Dispositions and the approval flow for the triage itself: the `claude-kit:promote-memories` skill,
+§ "Step 1: Triage".
+
+## Motivating incidents
+
+PR #420 (memory refs in repo-tracked files); PR #462 round-3 critic (rule self-check); PR #1152
+round-1 review; PR #1299 rounds 1–3; #1312 rounds 1–4; PR #1303 rounds 1–3; PR #1314; PR #1334;
+PR #1365 / #1370 (authored-claim shapes); tyabu12/claude-kit#30 / #32 / #33 (the detector's file
+set).

--- a/docs/agent-tooling/claim-verification.md
+++ b/docs/agent-tooling/claim-verification.md
@@ -125,10 +125,9 @@ The rule carries the triggers and the two steps nothing else enforces. The full 
 
 1. File a rolling tracking issue collecting candidate sections.
 2. `/orchestrate` a PR landing the additions to `.claude/rules/` (or `CLAUDE.md` for project-wide
-   rules), drafted at **concept level** — WHY + the invariant + a durable pointer, not the
-   exhaustive HOW (grep blocks, enumerations, step lists). This holds for **path-scoped** targets
-   too, where `context-budget.md`'s always-loaded discipline stops; expand a section only when a
-   reviewer shows the omitted detail is load-bearing for the rule to fire.
+   rules), at the concept-level drafting bar. That bar is **not** promotion-specific — it governs
+   any rules addition — so it lives in the rule itself (`knowledge-layering.md` § "Procedure"),
+   not here. One copy on purpose.
 3. Strip `Source memory: feedback_*` provenance lines from drafts before commit — a repo-tracked
    file referring to per-user memory by name is a dead link for other contributors.
 4. Update **every mirror** of the promoted fact in the same PR — the `code-reviewer` trap cheat

--- a/docs/agent-tooling/claim-verification.md
+++ b/docs/agent-tooling/claim-verification.md
@@ -96,12 +96,12 @@ review fixes move it, and a diverged assertion left silently in place is the one
 because the reader who finds it is the one relying on it.
 
 A detector a rule *ships* is the sharpest case, because it runs against the file that defines it.
-The memory-ref detector in § "Anti-pattern: memory refs in repo-tracked files" flags that section's
-own prose example of the banned form — the *form being defined*, not a reference. The three
+The memory-ref detector in § "Anti-pattern: memory refs in repo-tracked files" flagged that
+section's own prose example of the banned form — the *form being defined*, not a reference. The three
 dispositions are not equally cheap here: an inline carve-out adds a line to an **always-loaded**
 file *and* is itself a `file:line` assertion that re-breaks whenever the line moves, and narrowing
 the pattern to dodge one example is brittle by construction. Rewriting the example with a `<name>`
-placeholder takes the detector to zero without weakening it. If a later edit writes a concrete
+placeholder takes the detector back to its carve-out baseline without weakening it. If a later edit writes a concrete
 lowercase filename back in, the grep fires and the next editor picks a disposition again — the
 mechanism working, not a regression.
 
@@ -111,9 +111,9 @@ that one instance and leaves the class open: a recursive grep answers "which fil
 the rule asks "which are repo-tracked", and the two diverge both ways (a tracked file under an
 ignored directory is missed; never-committed scratch is falsely flagged). Enumerating with
 `git ls-files --cached --others --exclude-standard` is what actually matches the claim. Measured in
-this repo when the final form landed: the `rg` version returned 2 hits, the enumerating version 3 —
-the third being the prose example above. **When a detector's file set is not the claim's file set,
-no flag fixes it.**
+this repo before the placeholder rewrite: the `rg` version returned 2 hits, the enumerating version
+3 — the third being the rule's own prose example. **When a detector's file set is not the claim's
+file set, no flag fixes it.**
 
 Scope the negative control to the claim's *habitat*, not just its pattern: a control placed at the
 repo root sits inside the old detector's existing reach and reddens without testing the question.

--- a/docs/agent-tooling/subagent-output-cap.md
+++ b/docs/agent-tooling/subagent-output-cap.md
@@ -9,12 +9,9 @@ which of them move on what trigger.
 `docs/subagent-output-cap.md`; its rule is `rules/subagent-usage.md`. Diffing either half alone
 reads relocated depth as a deletion.
 
-**Why this is a doc and not a `paths:`-scoped rule.** A path-scoped rule injects on a `Read` whose
-path matches its globs, so it would still leave the always-loaded budget. It was not chosen because
-the moment this content is needed — sizing a subagent call — happens in *any* file, and no glob
-covers "any". Keeping the trigger in the always-loaded rule and the evidence here is the honest
-split. The cost, accepted: this file loads only when something reads it, so the rule's pointers to
-it are written as instructions, not as "see also".
+**Why this is a doc and not a `paths:`-scoped rule.** Same reasoning as the identically-titled note
+in [`claim-verification.md`](claim-verification.md): the moment this content is needed — sizing a
+subagent call — happens in *any* file, and no glob covers "any".
 
 ## The cap table's provenance
 

--- a/docs/agent-tooling/subagent-output-cap.md
+++ b/docs/agent-tooling/subagent-output-cap.md
@@ -1,0 +1,119 @@
+# Subagent output caps — the depth behind `subagent-usage.md`
+
+Paired with the always-loaded rule `.claude/rules/subagent-usage.md`, which carries the firing
+conditions — the numbers, the budgets, and the decision each one drives. This file carries the
+*why* and the *evidence*: how the numbers were obtained, what they do and do not establish, and
+which of them move on what trigger.
+
+**Reconcile as a pair.** The kit counterpart is [claude-kit](https://github.com/tyabu12/claude-kit)
+`docs/subagent-output-cap.md`; its rule is `rules/subagent-usage.md`. Diffing either half alone
+reads relocated depth as a deletion.
+
+**Why this is a doc and not a `paths:`-scoped rule.** A path-scoped rule injects on a `Read` whose
+path matches its globs, so it would still leave the always-loaded budget. It was not chosen because
+the moment this content is needed — sizing a subagent call — happens in *any* file, and no glob
+covers "any". Keeping the trigger in the always-loaded rule and the evidence here is the honest
+split. The cost, accepted: this file loads only when something reads it, so the rule's pointers to
+it are written as instructions, not as "see also".
+
+## The cap table's provenance
+
+Measured **2026-08-12 on Claude Code 2.1.228**. The `†` markers in the rule's table mean
+*read from the shipped model catalog, not behaviourally verified*; only the unmarked caps were
+observed in a live run. Re-read the live value on a Claude Code upgrade — it takes seconds and
+needs no truncation to be provoked:
+
+```sh
+claude -p --model opus --output-format json "ok" | jq '.modelUsage[].maxOutputTokens'
+```
+
+**Do not extrapolate across generations in either direction.** The spread is not uniform by family:
+Opus 4.6-4.8 already sat at 64,000 while Sonnet 4.x was at 32,000 and Haiku 3.5 at 8,192. A new
+generation means re-reading the catalog, not scaling the numbers you have.
+
+## The env-var lever reaches subagents
+
+The rule used to claim the opposite. It was corrected by forcing the variable to 1,200 and finding
+the subagent's own responses capped at exactly that number — so the variable is not
+main-session-only, and it is the one real budget lever. Model choice is not one (see below).
+
+Tracked upstream at
+[anthropics/claude-code#24055](https://github.com/anthropics/claude-code/issues/24055), **open** as
+of 2026-08-12: it asks for the cap to be configurable per subagent.
+
+## Why the split thresholds are not cap-derived
+
+They used to be presented as derived, pinned to a cap no spawnable model ever had. Two things
+follow from that being wrong.
+
+First, the cap was never the binding constraint at these scopes — a threshold that would not have
+changed had the cap been right was not really derived from it. What the thresholds buy is **review
+attention**, which does not scale with a model's `max_tokens`.
+
+Second, and this is the consequence for future edits: revise them on evidence about *review
+quality* — a reviewer that misses things at 800 changed lines, or does fine at 1,500 — and never by
+recomputing when a cap moves. A cap-table update leaves the thresholds untouched.
+
+That is also why they stay **kit-canonical** rather than becoming a per-project knob: the attention
+being bounded is a *subagent's* at a given scope, identical for every installation of the kit. The
+one lever a caller genuinely controls is report density per changed line — 800 lines of generated
+fixtures report far shorter than 800 lines of dense source — and it licenses bounding a call
+**tighter at the call site, never looser**. Split smaller instead of editing the numbers, in the
+rule or in any agent copy of them (today `.claude/agents/code-reviewer.md`).
+
+## How a cap hit behaves
+
+A hit is **not silent**. Claude Code detects `stop_reason: max_tokens`, nudges the agent to resume,
+and retries up to **3** times before surfacing `API Error: … exceeded the N output token maximum.`
+The report usually survives with a **seam** where the cut happened; only if every resume also
+overflows does the run fail outright and return nothing.
+
+The count-mismatch heuristic works because of how the review agents are written, not because of
+anything the platform does. `code-reviewer.md`'s Output Format puts `## Review Summary` first, so
+the summary is written before the body it summarises and a cut lands in the body — leaving the
+header over-claiming. An agent that summarised *last* would give no such tell.
+
+**What that does not guarantee.** The instruction that makes an agent stop investigating and emit
+the report early is *conditional* on the agent noticing its own budget: `code-reviewer.md` fires it
+"near 20+ `tool_use` calls". A run that exhausts before noticing never reaches the Output Format at
+all. That is the mechanism behind both escape shapes the rule lists:
+
+- **No verdict at all** — the conditional never fires and the run returns only its opening
+  sentence, leaving the count-mismatch check no summary to work from. Observed on broad
+  **multi-axis verification** prompts rather than on large diffs (#1410), which is why the remedy
+  is to cut what the prompt asks the agent to *verify* rather than how many files it sees — and why
+  asking for the verdict in the first message helps: it makes the instruction unconditional.
+- **A zero-issue report** — a summary claiming nothing has no count to under-deliver on, so a cut
+  landing right after it stays internally consistent and passes the check. Closing this needs a
+  structural check against a pinned Output Format: the caller confirming every mandatory section is
+  present, not just the Verdict line. Pastura closes it for the unattended path in
+  `queue-consumer` hard rule 6; the remedy is bound to a project-owned output contract, which is
+  why the kit records it as an open gap instead of carrying one.
+
+## Why the agents duplicate the budget
+
+`code-reviewer.md` bails with `SCOPE_TOO_LARGE` before any `tool_use` when the soft budget is
+exceeded; the kit-provided `claude-kit:critic` triages instead (highest-risk axes first, explicit
+deferrals). Restating the caller-side budget inside the agents looks redundant and is not: a cap hit
+usually shows up as nothing louder than a seam mid-report, so a second line of defense that fires
+*before* the work starts is worth its duplication.
+
+## Why `/code-review` cannot substitute
+
+`code-reviewer` is the *sole* review gate on the unattended path (`/queue-consumer` overnight).
+`/code-review` is a foreground interactive skill, never wired into a subagent slot, so on that path
+nothing else runs at all.
+
+Beyond wiring, the official skill leaves two gaps:
+
+1. It names `CLAUDE.md` as its convention source, and path-scoped rules are **measured** not to
+   reach it — so the `.claude/rules/` trap cheat sheet is invisible to it. The *cause* of that
+   non-arrival is open (see the kit's `docs/code-review-path-scoped-rules.md`, and #1312 for this
+   repo's own injection probes); do not reason forward from a mechanism for it.
+2. Its false-positive rule discards generic code-quality / security / test-coverage findings unless
+   `CLAUDE.md` demands them.
+
+So Dependency Rules, which live in `CLAUDE.md`, may surface through either gate — but
+`.claude/rules/` traps and generic secrets/coverage findings surface only through `code-reviewer`.
+That asymmetry is why its general-quality, Swift-6-concurrency and secrets sections must not be
+slimmed to "defer to `/code-review`".

--- a/docs/agent-tooling/subagent-output-cap.md
+++ b/docs/agent-tooling/subagent-output-cap.md
@@ -49,10 +49,13 @@ follow from that being wrong.
 First, the cap was never the binding constraint at these scopes — a threshold that would not have
 changed had the cap been right was not really derived from it. What the thresholds buy is **review
 attention**, which does not scale with a model's `max_tokens`. *That premise is measured, but not
-here*: the kit's `docs/subagent-output-cap.md` backs it with a scan of local transcripts predating
-the work, which found no response anywhere near a cap and zero `stop_reason: max_tokens`. Pastura
-has not re-run that scan — treat the premise as inherited evidence, and go read the kit doc before
-leaning on it for a new decision.
+here*: `docs/subagent-output-cap.md` **in the kit repository linked above** backs it with a scan of
+local transcripts predating the work, which found no response anywhere near a cap and zero
+`stop_reason: max_tokens`. Pastura has not re-run that scan — treat the premise as inherited
+evidence and read the kit's copy before leaning on it for a new decision. (The kit also installs
+that file to a per-user path; this doc deliberately cites the repository instead, because a
+`~/.claude/...` path in a repo-tracked file is the dead link § "Anti-pattern: memory refs in
+repo-tracked files" of `knowledge-layering.md` forbids.)
 
 Second, and this is the consequence for future edits: revise them on evidence about *review
 quality* — a reviewer that misses things at 800 changed lines, or does fine at 1,500 — and never by
@@ -96,11 +99,14 @@ all. That is the mechanism behind both escape shapes the rule lists:
 
 ## Why the agents duplicate the budget
 
-`code-reviewer.md` bails with `SCOPE_TOO_LARGE` before any `tool_use` when the soft budget is
-exceeded; the kit-provided `claude-kit:critic` triages instead (highest-risk axes first, explicit
-deferrals). Restating the caller-side budget inside the agents looks redundant and is not: a cap hit
-usually shows up as nothing louder than a seam mid-report, so a second line of defense that fires
-*before* the work starts is worth its duplication.
+`code-reviewer.md` restates this rule's line/file numbers and bails with `SCOPE_TOO_LARGE` after its
+one mandatory `git diff --stat` call and before any other `tool_use`. `claude-kit:critic` does
+something different: an axis-only budget (≤5 axes, triage above 7) that it applies *during* the run,
+plus a stop-and-report at ~15 `tool_use` calls. Restating a budget inside the agents looks redundant
+and is not: a cap hit usually shows up as nothing louder than a seam mid-report, so a second line of
+defense inside the agent — pre-work for `code-reviewer`, mid-run for critic — is worth its
+duplication. Only `code-reviewer.md`'s copy is ours to keep in sync; critic's definition ships with
+the plugin and reconciles one-way.
 
 ## Why `/code-review` cannot substitute
 

--- a/docs/agent-tooling/subagent-output-cap.md
+++ b/docs/agent-tooling/subagent-output-cap.md
@@ -48,7 +48,11 @@ follow from that being wrong.
 
 First, the cap was never the binding constraint at these scopes — a threshold that would not have
 changed had the cap been right was not really derived from it. What the thresholds buy is **review
-attention**, which does not scale with a model's `max_tokens`.
+attention**, which does not scale with a model's `max_tokens`. *That premise is measured, but not
+here*: the kit's `docs/subagent-output-cap.md` backs it with a scan of local transcripts predating
+the work, which found no response anywhere near a cap and zero `stop_reason: max_tokens`. Pastura
+has not re-run that scan — treat the premise as inherited evidence, and go read the kit doc before
+leaning on it for a new decision.
 
 Second, and this is the consequence for future edits: revise them on evidence about *review
 quality* — a reviewer that misses things at 800 changed lines, or does fine at 1,500 — and never by

--- a/scripts/hooks/check-claude-md-modified.sh
+++ b/scripts/hooks/check-claude-md-modified.sh
@@ -260,28 +260,38 @@ fi
 
 # --- 4. always-loaded footprint nudge (#1361 proposal B) --------------------
 # The total was 91,615 bytes when this was introduced (#1361, 2026-08-05); it
-# had drifted to 98,036 — above the then-96,000 ceiling — by 2026-08-13, when
-# #1442 evacuated the kit-mirror rules' depth to docs/agent-tooling/ and brought
-# it to 94,640 (measured on that PR's final commit — the mid-review figure was
-# 890 bytes lower, which is why this is re-derived rather than quoted forward).
+# had drifted to 98,036 — above the ceiling, so the nudge was firing on every
+# PR — by 2026-08-13, when #1442 evacuated the kit-mirror rules' depth to
+# docs/agent-tooling/ and brought it to 94,825, back under.
+#
 # A slim campaign (#1310 / #1315 style) that lands below the ceiling should
 # re-baseline this default in its own PR — otherwise the nudge decays into
-# permanent wallpaper that everyone scrolls past. Ratchet it DOWN to just above
-# the new total so the campaign's gain is held. The headroom below is ~0.9%,
-# deliberately far tighter than the 4.8% this started with: the observed drift
-# rate (+6,400 bytes in 8 days) makes a loose ceiling silent for months. The
-# accepted cost is the symmetric failure — at this tightness roughly one added
-# rule paragraph trips it. That is tolerable only because the nudge is
-# non-blocking `additionalContext`, so the remedy is a one-line Context-economy
-# record in the PR body, not a blocked commit. The env var exists so the test
-# harness can force the firing branch.
+# permanent wallpaper that everyone scrolls past. #1442 discharged that duty by
+# measuring and deciding NOT to move it, which needs recording or the next
+# campaign re-derives it: a ratchet down to just-above-94,825 leaves under 1%
+# headroom, so the nudge trips on roughly one added rule paragraph and becomes
+# wallpaper from over-firing instead of under-firing. Reduction big enough to
+# ratchet means clearing headroom worth about one rule section (~1.5 KB) below
+# the ceiling; -3,211 bytes did not. At 94,825 the existing 96,000 already sits
+# ~1.2% above the total, which is a live constraint, not a dead one.
 #
-# Held in one variable because the value is needed twice (the `:-` default and
-# the malformed-input fallback). Nothing exercises the fallback branch — it runs
-# only on non-numeric env input — so two literals would let a future re-baseline
-# update one and diverge silently, which is the same drift class #1442 was
-# cleaning up when it set this value.
-FOOTPRINT_CEILING_DEFAULT=95500
+# So: re-measure on your campaign's FINAL commit and move this only if the new
+# total clears that ~1.5 KB. Measuring early is the trap — #1442's figure moved
+# twice during code review (93,750 -> 94,640 -> 94,825) as review fixes landed,
+# and two of those rounds had already been written into this comment.
+#
+# The env var exists so the test harness can force the firing branch.
+#
+# Held in one variable because the value is needed twice in this script (the
+# `:-` default and the malformed-input fallback). Nothing exercises the fallback
+# branch — it runs only on non-numeric env input — so two literals would let a
+# future re-baseline update one and diverge silently, which is the same drift
+# class #1442 was cleaning up when it set this value. A THIRD copy lives outside
+# this script, in scripts/tests/check-claude-md-modified-test.sh's `run_hook`
+# default; it is inert (fixtures are kilobytes, and the firing cases pass an
+# explicit ceiling), which is exactly why a re-baseline would forget it — update
+# it anyway so the two never read as disagreeing about the production value.
+FOOTPRINT_CEILING_DEFAULT=96000
 FOOTPRINT_CEILING="${PASTURA_FOOTPRINT_CEILING:-$FOOTPRINT_CEILING_DEFAULT}"
 # The one external input; a non-numeric value would make the -gt test below
 # spray `[: illegal number` on stderr, so guard it like $added and $n.

--- a/scripts/hooks/check-claude-md-modified.sh
+++ b/scripts/hooks/check-claude-md-modified.sh
@@ -259,39 +259,35 @@ if [ "$AL_ADD" -ge "$AL_TRIM_THRESHOLD" ] || [ "$PS_ADD" -ge "$PS_TRIM_THRESHOLD
 fi
 
 # --- 4. always-loaded footprint nudge (#1361 proposal B) --------------------
-# The total was 91,615 bytes when this was introduced (#1361, 2026-08-05); it
-# had drifted to 98,036 — above the ceiling, so the nudge was firing on every
-# PR — by 2026-08-13, when #1442 evacuated the kit-mirror rules' depth to
-# docs/agent-tooling/ and brought it to 94,825, back under.
+# The total was 91,615 bytes at introduction (#1361, 2026-08-05) and had drifted
+# to 98,036 — above the ceiling, so the nudge fired on every PR — until #1442
+# evacuated the kit-mirror rules' depth to docs/agent-tooling/ on 2026-08-13,
+# bringing it to 94,038.
 #
 # A slim campaign (#1310 / #1315 style) that lands below the ceiling should
 # re-baseline this default in its own PR — otherwise the nudge decays into
 # permanent wallpaper that everyone scrolls past. #1442 discharged that duty by
-# measuring and deciding NOT to move it, which needs recording or the next
-# campaign re-derives it: a ratchet down to just-above-94,825 leaves under 1%
-# headroom, so the nudge trips on roughly one added rule paragraph and becomes
-# wallpaper from over-firing instead of under-firing. Reduction big enough to
-# ratchet means clearing headroom worth about one rule section (~1.5 KB) below
-# the ceiling; -3,211 bytes did not. At 94,825 the existing 96,000 already sits
-# ~1.2% above the total, which is a live constraint, not a dead one.
+# ratcheting 96,000 -> 95,500. The bar it used, recorded so the next campaign
+# does not re-derive one: leave about one rule section (~1.5 KB) of headroom, no
+# less. Tighter and the nudge trips on roughly one added rule paragraph —
+# wallpaper from over-firing instead of under-firing. That is why -3,211 bytes
+# alone (to 94,825, a mere 1,175 under 96,000) licensed no move, while the
+# further -787 did.
 #
-# So: re-measure on your campaign's FINAL commit and move this only if the new
-# total clears that ~1.5 KB. Measuring early is the trap — #1442's figure moved
-# twice during code review (93,750 -> 94,640 -> 94,825) as review fixes landed,
-# and two of those rounds had already been written into this comment.
+# Re-measure on your campaign's FINAL commit. Measuring early is the trap —
+# #1442's figure moved three times during code review before settling, and the
+# superseded ones had already been written into this comment.
 #
-# The env var exists so the test harness can force the firing branch.
-#
-# Held in one variable because the value is needed twice in this script (the
-# `:-` default and the malformed-input fallback). Nothing exercises the fallback
-# branch — it runs only on non-numeric env input — so two literals would let a
-# future re-baseline update one and diverge silently, which is the same drift
-# class #1442 was cleaning up when it set this value. A THIRD copy lives outside
-# this script, in scripts/tests/check-claude-md-modified-test.sh's `run_hook`
-# default; it is inert (fixtures are kilobytes, and the firing cases pass an
-# explicit ceiling), which is exactly why a re-baseline would forget it — update
-# it anyway so the two never read as disagreeing about the production value.
-FOOTPRINT_CEILING_DEFAULT=96000
+# The env var exists so the test harness can force the firing branch. The
+# default is held in a variable because it is needed twice below (the `:-` and
+# the malformed-input fallback, which nothing exercises — it runs only on
+# non-numeric env input, so two literals would let a re-baseline update one and
+# diverge silently). A THIRD copy lives outside this script, in
+# scripts/tests/check-claude-md-modified-test.sh's `run_hook` default; it is
+# inert (fixtures are kilobytes, and the firing cases pass an explicit ceiling),
+# which is exactly why a re-baseline would forget it — update it anyway so the
+# two never read as disagreeing about the production value.
+FOOTPRINT_CEILING_DEFAULT=95500
 FOOTPRINT_CEILING="${PASTURA_FOOTPRINT_CEILING:-$FOOTPRINT_CEILING_DEFAULT}"
 # The one external input; a non-numeric value would make the -gt test below
 # spray `[: illegal number` on stderr, so guard it like $added and $n.

--- a/scripts/hooks/check-claude-md-modified.sh
+++ b/scripts/hooks/check-claude-md-modified.sh
@@ -259,16 +259,21 @@ if [ "$AL_ADD" -ge "$AL_TRIM_THRESHOLD" ] || [ "$PS_ADD" -ge "$PS_TRIM_THRESHOLD
 fi
 
 # --- 4. always-loaded footprint nudge (#1361 proposal B) --------------------
-# The total was 91,615 bytes when this was introduced (#1361, 2026-08-05). A
-# slim campaign (#1310 / #1315 style) that lands below the ceiling should
-# re-baseline this default in its own PR — otherwise the nudge decays into
-# permanent wallpaper that everyone scrolls past. The env var exists so the
-# test harness can force the firing branch.
-FOOTPRINT_CEILING="${PASTURA_FOOTPRINT_CEILING:-96000}"
+# The total was 91,615 bytes when this was introduced (#1361, 2026-08-05); it
+# had drifted to 98,036 — above the then-96,000 ceiling — by 2026-08-13, when
+# #1442 evacuated the kit-mirror rules' depth to docs/agent-tooling/ and brought
+# it to 93,750. A slim campaign (#1310 / #1315 style) that lands below the
+# ceiling should re-baseline this default in its own PR — otherwise the nudge
+# decays into permanent wallpaper that everyone scrolls past. Ratchet it DOWN to
+# just above the new total so the campaign's gain is held; the headroom below is
+# ~1.3%, deliberately tighter than the 4.8% this started with, because the
+# observed drift rate makes a loose ceiling silent for months. The env var
+# exists so the test harness can force the firing branch.
+FOOTPRINT_CEILING="${PASTURA_FOOTPRINT_CEILING:-95000}"
 # The one external input; a non-numeric value would make the -gt test below
 # spray `[: illegal number` on stderr, so guard it like $added and $n.
 case "$FOOTPRINT_CEILING" in
-  ''|*[!0-9]*) FOOTPRINT_CEILING=96000 ;;
+  ''|*[!0-9]*) FOOTPRINT_CEILING=95000 ;;
 esac
 
 # echoes the total byte size of every tracked always-loaded instruction file,

--- a/scripts/hooks/check-claude-md-modified.sh
+++ b/scripts/hooks/check-claude-md-modified.sh
@@ -262,18 +262,31 @@ fi
 # The total was 91,615 bytes when this was introduced (#1361, 2026-08-05); it
 # had drifted to 98,036 — above the then-96,000 ceiling — by 2026-08-13, when
 # #1442 evacuated the kit-mirror rules' depth to docs/agent-tooling/ and brought
-# it to 93,750. A slim campaign (#1310 / #1315 style) that lands below the
-# ceiling should re-baseline this default in its own PR — otherwise the nudge
-# decays into permanent wallpaper that everyone scrolls past. Ratchet it DOWN to
-# just above the new total so the campaign's gain is held; the headroom below is
-# ~1.3%, deliberately tighter than the 4.8% this started with, because the
-# observed drift rate makes a loose ceiling silent for months. The env var
-# exists so the test harness can force the firing branch.
-FOOTPRINT_CEILING="${PASTURA_FOOTPRINT_CEILING:-95000}"
+# it to 94,640 (measured on that PR's final commit — the mid-review figure was
+# 890 bytes lower, which is why this is re-derived rather than quoted forward).
+# A slim campaign (#1310 / #1315 style) that lands below the ceiling should
+# re-baseline this default in its own PR — otherwise the nudge decays into
+# permanent wallpaper that everyone scrolls past. Ratchet it DOWN to just above
+# the new total so the campaign's gain is held. The headroom below is ~0.9%,
+# deliberately far tighter than the 4.8% this started with: the observed drift
+# rate (+6,400 bytes in 8 days) makes a loose ceiling silent for months. The
+# accepted cost is the symmetric failure — at this tightness roughly one added
+# rule paragraph trips it. That is tolerable only because the nudge is
+# non-blocking `additionalContext`, so the remedy is a one-line Context-economy
+# record in the PR body, not a blocked commit. The env var exists so the test
+# harness can force the firing branch.
+#
+# Held in one variable because the value is needed twice (the `:-` default and
+# the malformed-input fallback). Nothing exercises the fallback branch — it runs
+# only on non-numeric env input — so two literals would let a future re-baseline
+# update one and diverge silently, which is the same drift class #1442 was
+# cleaning up when it set this value.
+FOOTPRINT_CEILING_DEFAULT=95500
+FOOTPRINT_CEILING="${PASTURA_FOOTPRINT_CEILING:-$FOOTPRINT_CEILING_DEFAULT}"
 # The one external input; a non-numeric value would make the -gt test below
 # spray `[: illegal number` on stderr, so guard it like $added and $n.
 case "$FOOTPRINT_CEILING" in
-  ''|*[!0-9]*) FOOTPRINT_CEILING=95000 ;;
+  ''|*[!0-9]*) FOOTPRINT_CEILING="$FOOTPRINT_CEILING_DEFAULT" ;;
 esac
 
 # echoes the total byte size of every tracked always-loaded instruction file,

--- a/scripts/tests/check-claude-md-modified-test.sh
+++ b/scripts/tests/check-claude-md-modified-test.sh
@@ -132,7 +132,7 @@ RC=0
 run_hook() {
   local out
   set +e
-  out="$( cd "$1" && PASTURA_FOOTPRINT_CEILING="${2:-96000}" bash "$HOOK" )"
+  out="$( cd "$1" && PASTURA_FOOTPRINT_CEILING="${2:-95000}" bash "$HOOK" )"
   RC=$?
   set -e
   printf '%s' "$out"

--- a/scripts/tests/check-claude-md-modified-test.sh
+++ b/scripts/tests/check-claude-md-modified-test.sh
@@ -132,7 +132,7 @@ RC=0
 run_hook() {
   local out
   set +e
-  out="$( cd "$1" && PASTURA_FOOTPRINT_CEILING="${2:-96000}" bash "$HOOK" )"
+  out="$( cd "$1" && PASTURA_FOOTPRINT_CEILING="${2:-95500}" bash "$HOOK" )"
   RC=$?
   set -e
   printf '%s' "$out"

--- a/scripts/tests/check-claude-md-modified-test.sh
+++ b/scripts/tests/check-claude-md-modified-test.sh
@@ -132,7 +132,7 @@ RC=0
 run_hook() {
   local out
   set +e
-  out="$( cd "$1" && PASTURA_FOOTPRINT_CEILING="${2:-95500}" bash "$HOOK" )"
+  out="$( cd "$1" && PASTURA_FOOTPRINT_CEILING="${2:-96000}" bash "$HOOK" )"
   RC=$?
   set -e
   printf '%s' "$out"

--- a/scripts/tests/check-claude-md-modified-test.sh
+++ b/scripts/tests/check-claude-md-modified-test.sh
@@ -132,7 +132,7 @@ RC=0
 run_hook() {
   local out
   set +e
-  out="$( cd "$1" && PASTURA_FOOTPRINT_CEILING="${2:-95000}" bash "$HOOK" )"
+  out="$( cd "$1" && PASTURA_FOOTPRINT_CEILING="${2:-95500}" bash "$HOOK" )"
   RC=$?
   set -e
   printf '%s' "$out"

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/RelationshipUpdateHandlerTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/RelationshipUpdateHandlerTests.kt
@@ -31,7 +31,7 @@ import kotlin.test.assertTrue
  * Beyond the 9 Swift cases, [placementDiagnosticFiresWhenNoSignal] /
  * [placementDiagnosticSilentWhenSignalPresent] are a negative control on the no-signal
  * `.debug` diagnostic — the Swift suite only asserts the empty matrix, never that the
- * guard actually fires (see `knowledge-layering.md` § "A detector / guard / gate").
+ * guard actually fires (see `knowledge-layering.md` § "Claims you author are assertions too").
  *
  * Ported for the ADR-023 Stage-3 code-phase port (#501).
  */


### PR DESCRIPTION
## Summary

claude-kit#24 の再同期（#1438）と、同じ構造への移行（#1442）を1本で。kit は「ルールは発火条件だけ・深さはペアの doc」へ移行済みで、Pastura は深さをインラインで抱えたままだった。**kit slim ↔ Pastura fat** で機械的な diff が取れず、このミラー3ファイルの再同期 issue は #1179 / #1183 / #1371 / #1372 / #1425 / #1438 と6本になっていた。これが根本原因。

コミットは**同期を先・退避を後**に分離した。圧縮は書き直しなので、先に本文を正しくしてから動かさないと既存の検証台帳が二度効かない。

### 同期（#1438）

- 検出器を kit#33 の最終形（`git ls-files` 列挙）へ + 節自身の散文例示を `` `<name>.md` `` プレースホルダ化。**セットで**入れないとベースラインが 2→3 に上がり "new code must not *add* hits" の読み方が壊れる
- 節名 `Rule-writing self-check` → `Verify before you lock it` + 3モーメント枠（rule-commit / plan-lock / authoring）。`adr-writing.md:29` の `§"見出し"` 参照を同一コミットで追随
- 両ミラーのヘッダに「kit は rule + doc のペア、**ペア単位で照合**」を明記。ペア相手は3本（`subagent-output-cap` / `claim-verification` / `code-review-path-scoped-rules`）で、3本目に Pastura 側 doc を作らない判断も残した（この repo の probe は #1312）
- `context-budget.md` も主張単位で同期。「compact だから対象外」は evacuation の理由であって sync の理由になっていなかった
- §2 の自己矛盾を解消。「review agent は verdict を先に出す」を保証形で書いた直後に「verdict が出ない形がこれに反する」と書いていた。実体は Output Format の節順で、報告に到達させる自己監視は**条件付き**（`code-reviewer.md` は「20+ tool_use 付近」）

### 退避（#1442）

`docs/agent-tooling/` に2本新設し、深さを移した。ルールに残したのは発火条件（cap 表、soft/hard 予算、検出器と2つの逃げ形、3モーメント、divergence の三択、authored-claim 4形の1行版、carve-out）。doc へ出したのは why と証拠。

**`docs/**` を選び path-scoped rule を選ばなかった理由**: `paths:` を持つルールも常時ロード計測からは外れるのでバイト削減だけなら達成できる。それでも docs にしたのは、claim-verification の規律が発火すべき「Authoring」の瞬間が**任意のファイル**（Swift / スクリプト / ADR / ルール）で起きるからで、どの glob でも覆えない。代償——明示 Read のときしかロードされない——は受容し、各ルールのポインタを "see also" ではなく**命令形**にした。

## 実測（マージ時点の最終コミット `d88fdb1d`）

| | before | after |
|---|---:|---:|
| `subagent-usage.md` | 11,228 | 9,283 |
| `knowledge-layering.md` | 14,286 | 11,362 |
| `context-budget.md` | 2,394 | 2,512 |
| **常時ロード総量** | **98,036** | **94,038**（−3,998） |

**見積りは −13,000 だった。実績はその 1/3 弱。** 見積りは「Pastura 計 27,908 と kit 計 11,693 の差はすべて退避可能な深さ」という前提で立てたが、差の大半は **kit に対応物のない Pastura 固有の発火条件**だった（この repo の model pin、orchestrate の感度リスト、§5 の3者比較表、queue-consumer の remedy、carve-out 一覧）。退避すれば発火条件の喪失になるので残した。C を採った判断自体は維持（再同期がペア対ペアになる根本効果は達成）だが、**削減量を根拠にした部分は見積りが甘かった**。

`FOOTPRINT_CEILING` は最終的に **96,000 → 95,500**（余裕 1,462 B）。経緯自体が「早く測るのが罠」の実例で、総量は 93,750 → 94,640 → 94,825 → 94,038 と4回動いた。途中で一度 95,000 / 95,500 へ下げたあと 96,000 据え置きに戻し、最後の重複圧縮（−787）で据え置き判断が置いた ratchet 条件（~1.5KB の余裕が空くこと）を満たしたので改めて下げている。判断基準はスクリプトのコメントに記録済み。重複リテラルの `FOOTPRINT_CEILING_DEFAULT` 化は独立した改善。

Context-economy: 常時ロードから 4 段落相当を `docs/agent-tooling/` へ退避、10 段落超を圧縮（うち終盤の1コミットは、退避先の doc が既に持つ記述の**言い直し**をルール側から除去 −787 B）、発火条件は全保持。レビューで1件の取りこぼし（concept-level 起草基準）を検出して戻した。正味 **−3,998 B**。

## Test plan

- `git ls-files -z --cached --others --exclude-standard | xargs -0 grep -nHE 'memory \`[a-z_]+\.md\`'` → carve-out 2件のみ
- 陰性対照: `.claude/rules/` に違反形を置くと新検出器が捕捉、除去でベースライン復帰。旧 `rg` 形はリポジトリルート再帰で `.claude/` を取りこぼす（2件 vs 3件）
- 誤検出方向の対照: `Pastura/DerivedData/`（gitignore 済み）に違反形を置くと列挙形は除外・`grep -r` は拾う
- `§` 参照の機械照合: ルール↔doc の全 `§"見出し"` が実在の見出しへ解決（誤った doc を渡すと全件 BROKEN で exit 1 になることを確認）。この照合で**短縮形の壊れた参照2件**（うち1件は既存）を検出・修正
- §番号 citation 8件（`code-reviewer.md` ×2 / `orchestrate` / `queue-consumer` / `ADR-028` ×3 / `prune-stale-worktrees-test.sh`）は §1–§5 の番号凍結で無変更、全件について引用先の主張が該当節に残ることを内容照合
- `grep 'Rule-writing self-check'` repo 全体で 0 件
- ceiling 対照: `PASTURA_FOOTPRINT_CEILING=94000` で 94,825 が発火、既定 96,000 で沈黙
- `scripts/tests/*-test.sh` 19本すべて pass / iOS build pass（pre-commit）
- マージ直前の重複圧縮コミットでは、各カットについて「移設先の doc に実在するか」を本文で確認してから実施（「あるはず」で切らない）。cross-doc 見出し17件の解決を再確認し、1件（`##` ではなく太字見出しだったもの）の参照文言を修正

## Review

Opus の `code-reviewer` を3回: シャードA（rules + 新設 docs、6ファイル）/ シャードB（CLAUDE.md + hook + test + .kt、4ファイル）/ fix diff スコープの再レビュー。**全て PASS、Critical 0。** ファイル数が soft budget(8) 超・hard(12) 未満だったため分割し、seam は最終の横断チェックが持った。指摘は Warning 5 / Suggestion 12 すべて反映。重いものは2件——圧縮の過程で `claude-kit:critic` について**偽の主張**を作っていた（インストール済み 0.4.6 は軸だけの予算で、停止も pre-tool_use ではない）ことと、concept-level の起草基準という**発火条件を1つ落としていた**こと。

## Device QA

実機QA不要 — エージェント指示ファイル・ドキュメント・シェルフックのみで、アプリのコードパスに変更なし。

Closes #1438
Closes #1442
