### PR TITLE
📝 docs: QAT 3候補の /model-eval 判定を eval-log に記録する

### DIFF
--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -575,14 +575,15 @@ a drop-in swap for its non-QAT sibling. Descriptor-side procedure:
 
 **Two failure modes, and only one of them is the pin's.** The shared-KV
 gap above is a **loader** gap — pin-relative by construction, and a bump
-past b8694 clears it. **Quant kernel coverage is not**: a build whose
+to **b10327**, the only build measured to load one, clears it (nothing
+between it and b8694 was tested). **Quant kernel coverage is not**: a build whose
 tensors use a type the Metal backend has no kernel for **loads cleanly and
 then SIGSEGVs on the first inference**, because the pipeline lookup returns
 NULL and `ggml_metal_encoder_set_pipeline` dereferences it. Measured on the
 QAT-Mobile `UD-Q2_K_XL` export: llama.cpp ships no `TQ`-family Metal
-kernels, and still did not tens of builds later. So **do not read a pin
-bump as unblocking a whole variant family**, and treat "it loaded" as no
-evidence at all here.
+kernels, and still shipped none at b10375. So **do not read a pin bump as
+unblocking a whole variant family**, and treat "it loaded" as no evidence
+at all here.
 
 **Apply**: before pulling any GGUF using a quant the catalog has not shipped
 before, grep the release xcframework binary for that quant's kernel names —

--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -570,18 +570,17 @@ durable record in ADR-011.)
 unsloth's alike — ship a shared-KV tail layer the pinned llama.cpp cannot
 load (`missing tensor 'blk.15.attn_k.weight'`), so a `-qat-` repo is never
 a drop-in swap for its non-QAT sibling. Descriptor-side procedure:
-`docs/models/onboarding.md`; measurements: `docs/models/eval-log.md`, whose
-2026-08-08 / 08-12 / 08-13 entries carry the QAT family.
+`docs/models/onboarding.md`; measurements: the QAT-family entries in
+`docs/models/eval-log.md`.
 
-**Two failure modes, and only one of them is the pin's.** The shared-KV
-gap above is a **loader** gap — pin-relative by construction, and a bump
-to **b10327**, the only build measured to load one, clears it (nothing
-between it and b8694 was tested). **Quant kernel coverage is not**: a
-build whose
-tensors use a type the Metal backend has no kernel for **loads cleanly and
-then SIGSEGVs on the first inference**, because the pipeline lookup returns
-NULL and `ggml_metal_encoder_set_pipeline` dereferences it. Measured on the
-QAT-Mobile `UD-Q2_K_XL` export: llama.cpp ships no `TQ`-family Metal
+**Two failure modes, and only one is the pin's.** That shared-KV gap is a
+**loader** gap and pin-relative — a bump to **b10327** (the only build
+measured to load one) clears it. **Quant kernel coverage is not
+pin-relative**: a build whose tensors use a type the Metal backend has no
+kernel for **loads cleanly and then SIGSEGVs on the first inference**,
+because the pipeline lookup returns NULL and
+`ggml_metal_encoder_set_pipeline` dereferences it. Measured on the
+QAT-Mobile `UD-Q2_K_XL` export — llama.cpp ships no `TQ`-family Metal
 kernels, and still shipped none at b10375. So **do not read a pin bump as
 unblocking a whole variant family**, and treat "it loaded" as no evidence
 at all here.

--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -576,7 +576,8 @@ a drop-in swap for its non-QAT sibling. Descriptor-side procedure:
 **Two failure modes, and only one of them is the pin's.** The shared-KV
 gap above is a **loader** gap — pin-relative by construction, and a bump
 to **b10327**, the only build measured to load one, clears it (nothing
-between it and b8694 was tested). **Quant kernel coverage is not**: a build whose
+between it and b8694 was tested). **Quant kernel coverage is not**: a
+build whose
 tensors use a type the Metal backend has no kernel for **loads cleanly and
 then SIGSEGVs on the first inference**, because the pipeline lookup returns
 NULL and `ggml_metal_encoder_set_pipeline` dereferences it. Measured on the

--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -570,8 +570,24 @@ durable record in ADR-011.)
 unsloth's alike — ship a shared-KV tail layer the pinned llama.cpp cannot
 load (`missing tensor 'blk.15.attn_k.weight'`), so a `-qat-` repo is never
 a drop-in swap for its non-QAT sibling. Descriptor-side procedure:
-`docs/models/onboarding.md`; measurement + retry gating:
-`docs/models/eval-log.md` §2026-08-08 (#1415).
+`docs/models/onboarding.md`; measurements: `docs/models/eval-log.md`, whose
+2026-08-08 / 08-12 / 08-13 entries carry the QAT family.
+
+**Two failure modes, and only one of them is the pin's.** The shared-KV
+gap above is a **loader** gap — pin-relative by construction, and a bump
+past b8694 clears it. **Quant kernel coverage is not**: a build whose
+tensors use a type the Metal backend has no kernel for **loads cleanly and
+then SIGSEGVs on the first inference**, because the pipeline lookup returns
+NULL and `ggml_metal_encoder_set_pipeline` dereferences it. Measured on the
+QAT-Mobile `UD-Q2_K_XL` export: llama.cpp ships no `TQ`-family Metal
+kernels, and still did not tens of builds later. So **do not read a pin
+bump as unblocking a whole variant family**, and treat "it loaded" as no
+evidence at all here.
+
+**Apply**: before pulling any GGUF using a quant the catalog has not shipped
+before, grep the release xcframework binary for that quant's kernel names —
+**with a known-present kernel in the same grep as a positive control**, since
+a pattern that matches nothing looks identical to a genuine absence.
 
 When pinning a new descriptor, the HF resolve-URL headers
 `X-Linked-Size` / `X-Linked-ETag` give authoritative `fileSize` /

--- a/docs/decisions/ADR-011.md
+++ b/docs/decisions/ADR-011.md
@@ -348,12 +348,20 @@ sequel decision, not a 6 GB tier catalog addition. Out of scope.
   and `docs/models/eval-log.md` §2026-08-08, plus P1 above.
   **All three legs are still pending** — the pin has not moved — but
   the sweep is no longer a pure rewording: the QAT candidates were
-  measured on a throwaway bumped pin (#1445), so the eval-log now
+  measured on a throwaway bumped pin (see #1416), so the eval-log now
   carries dated 08-12 / 08-13 entries the sweep should cite rather
   than re-derive, and engine.md gained a **pin-independent** caveat
   (Metal quant-kernel coverage) that sits beside the pin-relative
-  wording and must survive the sweep rather than be swept with it
-- Issue #1416 — Gemma 4 E2B QAT Gate 1 retry, blocked on #1415
+  wording and must survive the sweep rather than be swept with it.
+  A **fourth** leg has appeared with them: eval-log §2026-08-13's
+  `UD-Q4_K_XL` entry is dated-snapshot text gating adoption on that
+  bump, so a merged bump must revisit it too
+- Issue #1416 — the Gate 1 retry it was filed for **ran** (eval-log
+  §2026-08-12). It is now the retry pointer for the QAT-Mobile
+  candidate instead (eval-log §2026-08-13), which is blocked not on
+  #1415 but on Metal `TQ2_0` kernel coverage upstream — so read its
+  title and body, still written to the original scope, with that in
+  mind
 - PR #480 — implementation + PoC; to be closed unmerged when this
   ADR lands, with the investigation chain captured in commit
   messages and this ADR. Key commits: `3237e7a` (descriptor add),

--- a/docs/decisions/ADR-011.md
+++ b/docs/decisions/ADR-011.md
@@ -343,25 +343,20 @@ sequel decision, not a 6 GB tier catalog addition. Out of scope.
 
 - Issue #477 — 6 GB RAM tier device support (original tracking)
 - Issue #1415 — llama.cpp pin bump spike (shared-KV tail-layer
-  support); a merged bump must sweep the pin-relative wording in
-  `.claude/rules/engine.md` § "GGUF source *and variant* matter"
-  and `docs/models/eval-log.md` §2026-08-08, plus P1 above.
-  **All of these are still pending** — the pin has not moved — but
-  the sweep is no longer a pure rewording: the QAT candidates were
-  measured on a throwaway bumped pin (see #1416), so the eval-log now
-  carries dated 08-12 / 08-13 entries the sweep should cite rather
-  than re-derive, and engine.md gained a **pin-independent** caveat
-  (Metal quant-kernel coverage) that sits beside the pin-relative
-  wording and must survive the sweep rather than be swept with it.
-  A **fourth** leg has appeared with them: eval-log §2026-08-13's
-  `UD-Q4_K_XL` entry is dated-snapshot text gating adoption on that
-  bump, so a merged bump must revisit it too
-- Issue #1416 — the Gate 1 retry it was filed for **ran** (eval-log
-  §2026-08-12). It is now the retry pointer for the QAT-Mobile
-  candidate instead (eval-log §2026-08-13), which is blocked not on
-  #1415 but on Metal `TQ2_0` kernel coverage upstream — so read its
-  title and body, still written to the original scope, with that in
-  mind
+  support). Still pending; the QAT candidates were measured on a
+  throwaway bumped pin instead. A merged bump must sweep four
+  places: the pin-relative wording in `.claude/rules/engine.md`
+  § "GGUF source *and variant* matter" — whose **pin-independent**
+  Metal quant-kernel caveat must survive that sweep rather than be
+  swept with it — `docs/models/eval-log.md` §2026-08-08, P1 above,
+  and eval-log §2026-08-13's `UD-Q4_K_XL` entry, whose adoption is
+  gated on the bump. Cite the dated 08-12 / 08-13 entries rather
+  than re-deriving them
+- Issue #1416 — filed as the Gate 1 retry; that retry **ran**
+  (eval-log §2026-08-12) and the issue now tracks the QAT-Mobile
+  candidate instead (eval-log §2026-08-13), blocked on upstream
+  Metal `TQ2_0` kernel coverage rather than on #1415. Its title and
+  body still read to the original scope
 - PR #480 — implementation + PoC; to be closed unmerged when this
   ADR lands, with the investigation chain captured in commit
   messages and this ADR. Key commits: `3237e7a` (descriptor add),

--- a/docs/decisions/ADR-011.md
+++ b/docs/decisions/ADR-011.md
@@ -345,7 +345,14 @@ sequel decision, not a 6 GB tier catalog addition. Out of scope.
 - Issue #1415 — llama.cpp pin bump spike (shared-KV tail-layer
   support); a merged bump must sweep the pin-relative wording in
   `.claude/rules/engine.md` § "GGUF source *and variant* matter"
-  and `docs/models/eval-log.md` §2026-08-08, plus P1 above
+  and `docs/models/eval-log.md` §2026-08-08, plus P1 above.
+  **All three legs are still pending** — the pin has not moved — but
+  the sweep is no longer a pure rewording: the QAT candidates were
+  measured on a throwaway bumped pin (#1445), so the eval-log now
+  carries dated 08-12 / 08-13 entries the sweep should cite rather
+  than re-derive, and engine.md gained a **pin-independent** caveat
+  (Metal quant-kernel coverage) that sits beside the pin-relative
+  wording and must survive the sweep rather than be swept with it
 - Issue #1416 — Gemma 4 E2B QAT Gate 1 retry, blocked on #1415
 - PR #480 — implementation + PoC; to be closed unmerged when this
   ADR lands, with the investigation chain captured in commit

--- a/docs/decisions/ADR-011.md
+++ b/docs/decisions/ADR-011.md
@@ -346,7 +346,7 @@ sequel decision, not a 6 GB tier catalog addition. Out of scope.
   support); a merged bump must sweep the pin-relative wording in
   `.claude/rules/engine.md` § "GGUF source *and variant* matter"
   and `docs/models/eval-log.md` §2026-08-08, plus P1 above.
-  **All three legs are still pending** — the pin has not moved — but
+  **All of these are still pending** — the pin has not moved — but
   the sweep is no longer a pure rewording: the QAT candidates were
   measured on a throwaway bumped pin (see #1416), so the eval-log now
   carries dated 08-12 / 08-13 entries the sweep should cite rather

--- a/docs/models/eval-log.md
+++ b/docs/models/eval-log.md
@@ -85,8 +85,8 @@ everything else here.
   No Stage-0 profile of its own; a throwaway candidate profile was used so the run
   logs self-describe.
 - **Differentiation**: **not a new catalog character — the question is
-  REPLACE-the-build, not earn-a-new-slot.** This is the *same* Gemma 4 E2B at a
-  different quantisation, so character is indistinguishable from the incumbent by
+  REPLACE-the-build, not earn-a-new-slot.** Same Gemma 4 E2B at a different
+  quantisation, so character is indistinguishable from the incumbent by
   construction; that is the point. Against a same-session control it is not merely
   non-regressive: it converts two cells where the incumbent's premise never fired
   (`prisoners_dilemma` ja collapsed to an all-cooperate five-way tie;
@@ -95,34 +95,31 @@ everything else here.
   It is **weaker than the incumbent on `bokete` in both languages**, where it
   produced self-votes the incumbent did not.
 - **Snapshot** (point-in-time; raw scores in the digest): rubric **121** against a
-  **same-session** incumbent control arm at **107**. The control was re-run today
-  rather than compared against the recorded 2026-07-08 numbers, because cross-session
-  judge drift has been measured at up to −17 points on a single model — so **do not
-  compare this figure to any other dated entry.** n=1 per cell, one judge, one
-  session, and the gap leans on `prisoners_dilemma` ja: its control cell was the
-  outlier driving most of the margin, so that cell alone was re-sampled (11 → 18;
-  point-in-time — the digest holds only the re-sample, since `append_eval.py`
-  replaces by key, so **both** samples survive only in the issue comment) and against
-  the first sample the control totals 100.
-  Only the control was re-sampled, which can only move the comparison in the
-  incumbent's favour. Treat +14 as a screening signal, not a measured delta.
+  **same-session** incumbent control arm at **107** — a control re-run rather than
+  the recorded 2026-07-08 numbers, since cross-session judge drift has measured up
+  to −17 points on a single model. **Do not compare this figure to any other dated
+  entry.** n=1 per cell, one judge, one session, and the margin leans on one outlier
+  control cell (`prisoners_dilemma` ja), re-sampled 11 → 18; against its first sample
+  the control totals 100. Re-sampling touched only the control, which can only move
+  the comparison in the incumbent's favour, so treat +14 as a screening signal, not a
+  measured delta. (The digest holds only the re-sample — `append_eval.py` replaces by
+  key — so **both** samples survive only in the issue comment.)
   ADR-011 **P1** (non-gated, Apache-2.0, anonymous resolve 302 → CDN 200) and **P2**
   (`<|turn>` id 105 / `<turn|>` id 106 both `token_type=3`) verified for this
   re-export; **P3–P5 untouched**.
 - **Rationale**: the Mac filter cannot accept, only reject — and there is nothing
   here to reject on. Mechanical floor clean, no measured quality regression, and the
   largest download saving of any QAT build that actually runs.
-- **Disposition**: **advances to the ADR-011 real-device PoC (P3–P5). This is not an
+- **Disposition**: **advances to the ADR-011 real-device PoC (P3–P5) — not an
   adoption**, and two costs sit outside the −0.49 GB headline. (1) It cannot run at
   all on `main`'s pin, so adoption is gated on the #1415 bump landing first — whose
   device-only risk (Metal behaviour, the 8 GB minimum-RAM sizing in ADR-002
   § "Supported Devices", binary size) is entirely unmeasured, as is the DRY sampler
-  that bump rewrites.
-  (2) Swapping a build is not an in-place update: per `ModelRegistry`'s supersede
-  convention it means a new `id` **and** `fileName` with the old entry removed, so
-  **existing users re-download 2.62 GB** and the superseded 3.11 GB file becomes an
-  orphan they must delete by hand (ADR-015 / #548) — the saving accrues to *new*
-  installs. The retired id must move into `RETIRED_MODEL_IDS` in
+  that bump rewrites. (2) Swapping a build is not an in-place update: per
+  `ModelRegistry`'s supersede convention it means a new `id` **and** `fileName` with
+  the old entry removed, so **existing users re-download 2.62 GB** and the superseded
+  3.11 GB file orphans until deleted by hand (ADR-015 / #548) — the saving accrues to
+  *new* installs, and the retired id must move into `RETIRED_MODEL_IDS` in
   `scripts/gallery_highlight_validate.py` in the same PR (ADR-029).
 - **Pointers**: raw scorecard → `data/models/eval-digest.md` §2026-08-13 ·
   `gemma-4-e2b-qat-q4-k-xl`, with the control arm under `gemma-4-e2b-q4-k-m` of the
@@ -169,8 +166,8 @@ everything else here.
 - **Unblocked by**: llama.cpp's Metal backend gaining `TQ2_0` kernels — at minimum
   `kernel_mul_mm_tq2_0_f32` — **and** a `llama.swift` release at that build. Stated
   as text deliberately, so the gate survives the retry issue being renamed or closed.
-  Cheap re-check before downloading anything: grep the release xcframework binary for
-  `tq2_0` kernel names, keeping a known-present kernel in the same grep as a control.
+  Cheap re-check before downloading anything: the kernel-name grep in
+  `.claude/rules/engine.md` § "GGUF source *and variant* matter".
 - **Retry**: #1416.
 - **Disposition**: **not rejected.** At −29.6 % it remains the largest download
   saving in the family and is worth re-testing if that upstream gap closes.
@@ -195,14 +192,13 @@ everything else here.
   beats the incumbent on `prisoners_dilemma` ja only because that particular
   incumbent run drifted into Korean.
 - **Snapshot** (point-in-time): rubric **103** against **113** for the incumbent on
-  the *same* pin. ⚠️ **Neither number is in the digest.** The spike deliberately did
-  not run `append_eval.py` — its `(date, profile_id)` section key carries no pin or
-  GGUF dimension, so the incumbent and the candidate (same family, same day) would
-  have overwritten each other. The durable record is the [#1415 spike
-  comment][spike-20260812].
-  ⚠️ **Not comparable to the 2026-08-13 entries above** (121 / 107): those were
-  scored in a different session, and this pair's own incumbent leg (113) sits 6
-  points above the 2026-08-13 control (107) on the *same build* — which is the
+  the *same* pin. ⚠️ **Neither number is in the digest** — the spike deliberately
+  skipped `append_eval.py`, whose `(date, profile_id)` section key carries no pin or
+  GGUF dimension, so incumbent and candidate (same family, same day) would have
+  overwritten each other. The durable record is the [#1415 spike
+  comment][spike-20260812]. ⚠️ **Not comparable to the 2026-08-13 entries above**
+  (121 / 107), scored in a different session: this pair's own incumbent leg (113)
+  sits 6 points above the 2026-08-13 control (107) on the *same build* — the
   cross-session judge drift both sessions took a control arm to defend against.
 - **Rationale**: the motivating upside is now measured and it is negative — **−10
   against the incumbent on the same pin**, while the file is **+7.8 % larger**
@@ -251,28 +247,22 @@ everything else here.
   **2.10327.0** (llama.cpp b10327) loads the QAT file *and* the incumbent, while
   b8694 loads only the incumbent — a bump is therefore sufficient *and* the
   wrapper release exists.
-- **Unblocked by**: the pinned llama.cpp gains shared-KV tail-layer support — as
-  understood here, "bumped past b8694". In the event the condition was met at
-  **b10327**, the only build measured to load a 541-tensor QAT file; nothing between
-  the two was ever tested, so do not read the original phrasing as a promise about
-  intermediate builds.
-- **Retry**: tracked as #1416, and it **ran** — recorded as the 2026-08-12 entry
-  above; the unblock condition was met inside the #1415 spike and the candidate
-  scored a clean NO-GO. (This pointer is spent: #1416 now serves as the QAT-Mobile
-  retry pointer instead, so follow the entry, not the issue, for *this* candidate's
-  outcome.)
-  This entry stays a `BLOCKED` record of 2026-08-08 rather than being relabelled: on
-  that date zero inferences ran, so a rejection cannot be dated to it.
+- **Unblocked by**: the pinned llama.cpp gains shared-KV tail-layer support. Met at
+  **b10327** — the only build measured to load a 541-tensor QAT file, so nothing is
+  known about the builds between it and b8694.
+- **Retry**: **ran** inside the #1415 spike — the 2026-08-12 entry above, a clean
+  NO-GO. Follow that entry, not #1416, which has since been repointed at the
+  QAT-Mobile retry. This entry stays a `BLOCKED` record of 2026-08-08 rather than
+  being relabelled: zero inferences ran that day, so a rejection cannot be dated
+  to it.
 - **Disposition**: **not rejected.**
   Pre-cleared for the retry, so it need not be re-derived: ADR-011 **P1**
   non-gated (HF `gated: false`; anonymous resolve 302 → CDN 200) and **P2**
   CONTROL flags (`<|turn>` id 105, `<turn|>` id 106, both `token_type=3`); EOG set
   `{1, 50, 106, 212}` is a **superset** of the incumbent's `{50, 106, 212}`, so
   `<turn|>` terminates generation on both builds and there is no runaway-generation
-  risk. The unsloth QAT re-export this entry flagged as worth evaluating alongside —
-  and the QAT-Mobile re-export that #1415's scope correction later added, which this
-  entry had **missed** — have since been measured; both carry their own 2026-08-13
-  entries above.
+  risk. Both unsloth re-exports — `UD-Q4_K_XL`, flagged here, and the QAT-Mobile one
+  this entry missed — have since been measured; see their 2026-08-13 entries above.
   **P3–P5 remain untouched** (Gate 2).
 - **Pointers**: raw scorecard → `data/models/eval-digest.md` §2026-08-08 ·
   gemma-4-e2b-q4-k-m (gitignored, and replaced by key `(date, profile_id)` — which

--- a/docs/models/eval-log.md
+++ b/docs/models/eval-log.md
@@ -251,12 +251,16 @@ everything else here.
   **2.10327.0** (llama.cpp b10327) loads the QAT file *and* the incumbent, while
   b8694 loads only the incumbent — a bump is therefore sufficient *and* the
   wrapper release exists.
-- **Unblocked by**: the pinned llama.cpp gains shared-KV tail-layer support
-  (`mattt/llama.swift` bumped past b8694).
+- **Unblocked by**: the pinned llama.cpp gains shared-KV tail-layer support — as
+  understood here, "bumped past b8694". In the event the condition was met at
+  **b10327**, the only build measured to load a 541-tensor QAT file; nothing between
+  the two was ever tested, so do not read the original phrasing as a promise about
+  intermediate builds.
 - **Retry**: tracked as #1416, and it **ran** — recorded as the 2026-08-12 entry
   above; the unblock condition was met inside the #1415 spike and the candidate
-  scored a clean NO-GO. (#1416 now carries the QAT-Mobile retry as well, so follow
-  the entry, not the issue, for *this* candidate's outcome.)
+  scored a clean NO-GO. (This pointer is spent: #1416 now serves as the QAT-Mobile
+  retry pointer instead, so follow the entry, not the issue, for *this* candidate's
+  outcome.)
   This entry stays a `BLOCKED` record of 2026-08-08 rather than being relabelled: on
   that date zero inferences ran, so a rejection cannot be dated to it.
 - **Disposition**: **not rejected.**

--- a/docs/models/eval-log.md
+++ b/docs/models/eval-log.md
@@ -69,6 +69,155 @@ everything else here.
 
 ---
 
+## Gemma 4 E2B QAT `UD-Q4_K_XL` (`unsloth/gemma-4-E2B-it-qat-GGUF`) — 2026-08-13 — **PASS (Mac filter only — advances to the ADR-011 real-device PoC, never an adoption)**
+
+- **Gate**: 1 (Mac filter, `/model-eval`) — 6/6 cells `ok`, `attempts_mean` 1.00,
+  `language_mismatch_total` 0, no crash. Run on a **bumped pin** (`llama.swift`
+  2.10327.0 / llama.cpp b10327) in a throwaway worktree; `main` stays at 2.8694.0
+  and no pin change came out of this eval.
+- **Model**: `unsloth/gemma-4-E2B-it-qat-GGUF` · `gemma-4-E2B-it-qat-UD-Q4_K_XL.gguf`
+  · Apache-2.0, non-gated · 2,620,370,976 B · sha256 `e5310072…6889` (both matching
+  the HF resolve `X-Linked-Size` / `X-Linked-ETag`) — **−15.7 %** against the shipped
+  Q4_K_M's 3,106,735,776 B. **Despite the name the quantisation is not K-quant**: the
+  tensor spread is `Q4_0`×278 / `F32`×263 and `general.name` reads *"smart Q4_0,
+  QAT-lossless"* — which is also why it has Metal kernels where the mobile sibling
+  below does not. 541-tensor shared-KV layout, so **b10327+ is a hard prerequisite**.
+  No Stage-0 profile of its own; a throwaway candidate profile was used so the run
+  logs self-describe.
+- **Differentiation**: **not a new catalog character — the question is
+  REPLACE-the-build, not earn-a-new-slot.** This is the *same* Gemma 4 E2B at a
+  different quantisation, so character is indistinguishable from the incumbent by
+  construction; that is the point. Against a same-session control it is not merely
+  non-regressive: it converts two cells where the incumbent's premise never fired
+  (`prisoners_dilemma` ja collapsed to an all-cooperate five-way tie;
+  `word_wolf` ja missed an explicit citrus leak) into runs where the mechanic
+  engages — cross-round adaptation, whisper-as-deception, a correctly-detected wolf.
+  It is **weaker than the incumbent on `bokete` in both languages**, where it
+  produced self-votes the incumbent did not.
+- **Snapshot** (point-in-time; raw scores in the digest): rubric **121** against a
+  **same-session** incumbent control arm at **107**. The control was re-run today
+  rather than compared against the recorded 2026-07-08 numbers, because cross-session
+  judge drift has been measured at up to −17 points on a single model — so **do not
+  compare this figure to any other dated entry.** n=1 per cell, one judge, one
+  session, and the gap leans on `prisoners_dilemma` ja: its control cell was the
+  outlier driving most of the margin, so that cell alone was re-sampled (11 → 18) and
+  **both** samples are recorded; against the first sample the control totals 100.
+  Only the control was re-sampled, which can only move the comparison in the
+  incumbent's favour. Treat +14 as a screening signal, not a measured delta.
+  ADR-011 **P1** (non-gated, Apache-2.0, anonymous resolve 302 → CDN 200) and **P2**
+  (`<|turn>` id 105 / `<turn|>` id 106 both `token_type=3`) verified for this
+  re-export; **P3–P5 untouched**.
+- **Rationale**: the Mac filter cannot accept, only reject — and there is nothing
+  here to reject on. Mechanical floor clean, no measured quality regression, and the
+  largest download saving of any QAT build that actually runs.
+- **Disposition**: **advances to the ADR-011 real-device PoC (P3–P5). This is not an
+  adoption**, and two costs sit outside the −0.49 GB headline. (1) It cannot run at
+  all on `main`'s pin, so adoption is gated on the #1415 bump landing first — whose
+  device-only risk (Metal behaviour, the 8 GB minimum-RAM sizing in ADR-002
+  § "Supported Devices", binary size) is entirely unmeasured, as is the DRY sampler
+  that bump rewrites.
+  (2) Swapping a build is not an in-place update: per `ModelRegistry`'s supersede
+  convention it means a new `id` **and** `fileName` with the old entry removed, so
+  **existing users re-download 2.62 GB** and the superseded 3.11 GB file becomes an
+  orphan they must delete by hand (ADR-015 / #548) — the saving accrues to *new*
+  installs. The retired id must move into `RETIRED_MODEL_IDS` in
+  `scripts/gallery_highlight_validate.py` in the same PR (ADR-029).
+- **Pointers**: raw scorecard → `data/models/eval-digest.md` §2026-08-13 ·
+  `gemma-4-e2b-qat-q4-k-xl`, with the control arm under `gemma-4-e2b-q4-k-m` of the
+  same date (gitignored, per-machine — the **durable** backing is the issue comment
+  next) · full derivation → [#1416 comment][eval-20260813] · pin-bump implications →
+  [#1415 comment][eval-20260812] · intake → #979.
+
+[eval-20260813]: https://github.com/tyabu12/pastura/issues/1416#issuecomment-5275995869
+[eval-20260812]: https://github.com/tyabu12/pastura/issues/1415#issuecomment-5275999544
+
+---
+
+## Gemma 4 E2B QAT Mobile `UD-Q2_K_XL` (`unsloth/gemma-4-E2B-it-qat-mobile-GGUF`) — 2026-08-13 — **BLOCKED (backend kernel coverage — not evaluated, therefore not rejected)**
+
+- **Gate**: 1 (Mac filter, `/model-eval`) — **crashed on the first inference, so no
+  quality judgment exists.** Exactly **one** cell was run (`word_wolf` ja); the
+  remaining five were **not attempted**, because the cause is scenario-independent.
+  Read the snapshot as 0 ok / 1 run, **not** 0 / 6.
+- **Model**: `unsloth/gemma-4-E2B-it-qat-mobile-GGUF` ·
+  `gemma-4-E2B-it-qat-UD-Q2_K_XL.gguf` · Apache-2.0, non-gated · 2,186,186,784 B ·
+  sha256 `0a5bbc20…da28` (both matching the HF `X-Linked-Size` / `X-Linked-ETag`) —
+  **−29.6 %** against the shipped Q4_K_M, the largest saving anywhere in this family.
+  A GGUF conversion of Google's [QAT Mobile][qat-mobile] line, which publishes no
+  GGUF itself; its `wNa8o8` scheme reads concretely from the header as `TQ2_0`×61 /
+  `Q8_0`×70 / `Q4_0`×146 / `F32`×263.
+- **Differentiation**: **UNASSESSABLE** — zero inferences completed, so the
+  2-bit-decoder-layer quality question is *untested*, not answered.
+- **Snapshot**: 1 cell run, 0 `ok`, **0 inferences**; no rubric scores exist. The
+  process died with `SIGSEGV` (exit 139) *after* a clean model load — `run_start`
+  emitted and the `assign` phase completed, so the 2026-08-08 shared-KV loader
+  blocker **is** cleared by b10327. ADR-011 **P1** and **P2** both **PASS** for this
+  re-export (`<|turn>` id 105 / `<turn|>` id 106 are both `token_type=3 (CONTROL)`,
+  identical to the incumbent — the unsloth #5070 NORMAL-flag trap is *not* present
+  here), so a retry need not re-derive them.
+- **Rationale**: a **second, deeper** gap sits behind the shared-KV one, and it is
+  not the same kind of problem. llama.cpp's Metal backend ships **no kernels at all**
+  for the `TQ` (ternary) family, so the pipeline lookup returns NULL and
+  `ggml_metal_encoder_set_pipeline` dereferences it:
+  `"Function kernel_mul_mm_tq2_0_f32 was not found in the library"`
+  (`MTLLibraryErrorDomain` Code=5) → `EXC_BAD_ACCESS address=0x0`. Confirmed by
+  grepping the shipped framework binary **with a known-present kernel as positive
+  control** — `kernel_mul_mm_q4_0` / `q8_0` / `q4_K` all resolve, every `tq1_0` /
+  `tq2_0` kernel is absent (`tq2_0` survives only as a block-struct name).
+  **Unlike the loader gap, this one is not pin-relative**: it is equally absent at
+  b10375, ~48 builds newer. Upstream also appears not to reflect the missing kernel
+  in its op-support check, so it crashes rather than falling back to CPU.
+- **Unblocked by**: llama.cpp's Metal backend gaining `TQ2_0` kernels — at minimum
+  `kernel_mul_mm_tq2_0_f32` — **and** a `llama.swift` release at that build. Stated
+  as text deliberately, so the gate survives the retry issue being renamed or closed.
+  Cheap re-check before downloading anything: grep the release xcframework binary for
+  `tq2_0` kernel names, keeping a known-present kernel in the same grep as a control.
+- **Retry**: #1416.
+- **Disposition**: **not rejected.** At −29.6 % it remains the largest download
+  saving in the family and is worth re-testing if that upstream gap closes.
+- **Pointers**: raw scorecard → `data/models/eval-digest.md` §2026-08-13 ·
+  `gemma-4-e2b-qat-mobile-q2-k-xl` (gitignored, per-machine) · full derivation,
+  including the lldb trace and the kernel sweep →
+  [#1416 comment][eval-20260813] · intake → #979.
+
+[qat-mobile]: https://huggingface.co/collections/google/gemma-4-qat-mobile
+
+---
+
+## Gemma 4 E2B QAT Q4_0 (`google/gemma-4-E2B-it-qat-q4_0-gguf`) — 2026-08-12 — **FAIL (NO-GO)**
+
+- **Gate**: 1 (Mac filter, `/model-eval`) — the retry the 2026-08-08 **BLOCKED**
+  entry below was waiting on. Run inside the #1415 pin spike on `llama.swift`
+  2.10327.0 (b10327), which unblocked the load; all 6 cells then completed.
+- **Model**: as recorded in the 2026-08-08 entry below (`gemma-4-E2B_q4_0-it.gguf`,
+  3,349,516,256 B, sha256 `fa401b55…6634`) — unchanged file, so its P1 / P2 / EOG
+  pre-clearances carry over.
+- **Differentiation**: earns no slot. Its two weak cells are **substantive, not
+  stylistic** — `word_wolf` ja states the secret word outright and produces two
+  self-votes; `word_wolf` en collapses into four agents echoing one sentence. It
+  beats the incumbent on `prisoners_dilemma` ja only because that particular
+  incumbent run drifted into Korean.
+- **Snapshot** (point-in-time): rubric **103** against **113** for the incumbent on
+  the *same* pin. ⚠️ **Neither number is in the digest.** The spike deliberately did
+  not run `append_eval.py` — its `(date, profile_id)` section key carries no pin or
+  GGUF dimension, so the incumbent and the candidate (same family, same day) would
+  have overwritten each other. The durable record is the #1415 comment below.
+  ⚠️ **Not comparable to the 2026-08-13 entries above** (121 / 107): those were
+  scored in a different session, and this pair's own incumbent leg (113) sits 6
+  points above the 2026-08-13 control (107) on the *same build* — which is the
+  cross-session judge drift both sessions took a control arm to defend against.
+- **Rationale**: the motivating upside is now measured and it is negative — **−10
+  against the incumbent on the same pin**, while the file is **+7.8 % larger**
+  (3.35 vs 3.11 GB), the wrong direction for the ADR-011 6 GB tier. Nothing here
+  earns a catalog slot, and it supplies no reason to bump the pin.
+- **Disposition**: does **not** advance to the ADR-011 real-device PoC. The QAT
+  *family* is not rejected by this: it is a fact about the `Q4_0` build only, and the
+  two unsloth re-exports were evaluated separately above.
+- **Pointers**: spike result, with the full method and the same-session control arms
+  → [#1415 comment][eval-20260812] · pin spike → #1415 · intake → #979.
+
+---
+
 ## Gemma 4 E2B QAT Q4_0 (`google/gemma-4-E2B-it-qat-q4_0-gguf`) — 2026-08-08 — **BLOCKED (runtime compatibility — not evaluated, therefore not rejected)**
 
 - **Gate**: 1 (Mac filter, `/model-eval`) — **blocked at model load, never
@@ -106,21 +255,24 @@ everything else here.
   wrapper release exists.
 - **Unblocked by**: the pinned llama.cpp gains shared-KV tail-layer support
   (`mattt/llama.swift` bumped past b8694).
-- **Retry**: #1416 (Gate 1 retry), gated on #1415 (the pin spike).
+- **Retry**: **ran, and is recorded as the 2026-08-12 entry above** — the unblock
+  condition was met inside the #1415 spike and the candidate scored a clean NO-GO.
+  This entry stays a `BLOCKED` record of 2026-08-08 rather than being relabelled: on
+  that date zero inferences ran, so a rejection cannot be dated to it.
 - **Disposition**: **not rejected.**
   Pre-cleared for the retry, so it need not be re-derived: ADR-011 **P1**
   non-gated (HF `gated: false`; anonymous resolve 302 → CDN 200) and **P2**
   CONTROL flags (`<|turn>` id 105, `<turn|>` id 106, both `token_type=3`); EOG set
   `{1, 50, 106, 212}` is a **superset** of the incumbent's `{50, 106, 212}`, so
   `<turn|>` terminates generation on both builds and there is no runaway-generation
-  risk. Worth evaluating alongside the unsloth QAT file above, which is ~0.49 GB
-  *smaller* than the shipped Q4_K_M (2.62 vs 3.11 GB). **P3–P5 remain untouched**
-  (Gate 2).
+  risk. The two unsloth QAT re-exports this entry flagged as worth evaluating
+  alongside have since been measured — both carry their own 2026-08-13 entries above.
+  **P3–P5 remain untouched** (Gate 2).
 - **Pointers**: raw scorecard → `data/models/eval-digest.md` §2026-08-08 ·
   gemma-4-e2b-q4-k-m (gitignored, and replaced by key `(date, profile_id)` — which
   here is the *incumbent's* id, so treat it as volatile) · intake → #979 · pin
-  spike → #1415 · retry → #1416 · dead `stopSequence` + false rationale comment
-  surfaced during this eval → #1417.
+  spike → #1415 · retry outcome → the 2026-08-12 entry above · dead `stopSequence` +
+  false rationale comment surfaced during this eval → #1417.
 
 ---
 

--- a/docs/models/eval-log.md
+++ b/docs/models/eval-log.md
@@ -100,8 +100,10 @@ everything else here.
   judge drift has been measured at up to −17 points on a single model — so **do not
   compare this figure to any other dated entry.** n=1 per cell, one judge, one
   session, and the gap leans on `prisoners_dilemma` ja: its control cell was the
-  outlier driving most of the margin, so that cell alone was re-sampled (11 → 18) and
-  **both** samples are recorded; against the first sample the control totals 100.
+  outlier driving most of the margin, so that cell alone was re-sampled (11 → 18;
+  point-in-time — the digest holds only the re-sample, since `append_eval.py`
+  replaces by key, so **both** samples survive only in the issue comment) and against
+  the first sample the control totals 100.
   Only the control was re-sampled, which can only move the comparison in the
   incumbent's favour. Treat +14 as a screening signal, not a measured delta.
   ADR-011 **P1** (non-gated, Apache-2.0, anonymous resolve 302 → CDN 200) and **P2**
@@ -126,10 +128,7 @@ everything else here.
   `gemma-4-e2b-qat-q4-k-xl`, with the control arm under `gemma-4-e2b-q4-k-m` of the
   same date (gitignored, per-machine — the **durable** backing is the issue comment
   next) · full derivation → [#1416 comment][eval-20260813] · pin-bump implications →
-  [#1415 comment][eval-20260812] · intake → #979.
-
-[eval-20260813]: https://github.com/tyabu12/pastura/issues/1416#issuecomment-5275995869
-[eval-20260812]: https://github.com/tyabu12/pastura/issues/1415#issuecomment-5275999544
+  [#1415 comment][payoff-20260813] · intake → #979.
 
 ---
 
@@ -145,7 +144,7 @@ everything else here.
   **−29.6 %** against the shipped Q4_K_M, the largest saving anywhere in this family.
   A GGUF conversion of Google's [QAT Mobile][qat-mobile] line, which publishes no
   GGUF itself; its `wNa8o8` scheme reads concretely from the header as `TQ2_0`×61 /
-  `Q8_0`×70 / `Q4_0`×146 / `F32`×263.
+  `Q8_0`×70 / `Q4_0`×146 / `F32`×263 / `F16`×1 — 541, matching the shared-KV count.
 - **Differentiation**: **UNASSESSABLE** — zero inferences completed, so the
   2-bit-decoder-layer quality question is *untested*, not answered.
 - **Snapshot**: 1 cell run, 0 `ok`, **0 inferences**; no rubric scores exist. The
@@ -180,8 +179,6 @@ everything else here.
   including the lldb trace and the kernel sweep →
   [#1416 comment][eval-20260813] · intake → #979.
 
-[qat-mobile]: https://huggingface.co/collections/google/gemma-4-qat-mobile
-
 ---
 
 ## Gemma 4 E2B QAT Q4_0 (`google/gemma-4-E2B-it-qat-q4_0-gguf`) — 2026-08-12 — **FAIL (NO-GO)**
@@ -201,7 +198,8 @@ everything else here.
   the *same* pin. ⚠️ **Neither number is in the digest.** The spike deliberately did
   not run `append_eval.py` — its `(date, profile_id)` section key carries no pin or
   GGUF dimension, so the incumbent and the candidate (same family, same day) would
-  have overwritten each other. The durable record is the #1415 comment below.
+  have overwritten each other. The durable record is the [#1415 spike
+  comment][spike-20260812].
   ⚠️ **Not comparable to the 2026-08-13 entries above** (121 / 107): those were
   scored in a different session, and this pair's own incumbent leg (113) sits 6
   points above the 2026-08-13 control (107) on the *same build* — which is the
@@ -214,7 +212,7 @@ everything else here.
   *family* is not rejected by this: it is a fact about the `Q4_0` build only, and the
   two unsloth re-exports were evaluated separately above.
 - **Pointers**: spike result, with the full method and the same-session control arms
-  → [#1415 comment][eval-20260812] · pin spike → #1415 · intake → #979.
+  → [#1415 comment][spike-20260812] · pin spike → #1415 · intake → #979.
 
 ---
 
@@ -255,8 +253,10 @@ everything else here.
   wrapper release exists.
 - **Unblocked by**: the pinned llama.cpp gains shared-KV tail-layer support
   (`mattt/llama.swift` bumped past b8694).
-- **Retry**: **ran, and is recorded as the 2026-08-12 entry above** — the unblock
-  condition was met inside the #1415 spike and the candidate scored a clean NO-GO.
+- **Retry**: tracked as #1416, and it **ran** — recorded as the 2026-08-12 entry
+  above; the unblock condition was met inside the #1415 spike and the candidate
+  scored a clean NO-GO. (#1416 now carries the QAT-Mobile retry as well, so follow
+  the entry, not the issue, for *this* candidate's outcome.)
   This entry stays a `BLOCKED` record of 2026-08-08 rather than being relabelled: on
   that date zero inferences ran, so a rejection cannot be dated to it.
 - **Disposition**: **not rejected.**
@@ -265,8 +265,10 @@ everything else here.
   CONTROL flags (`<|turn>` id 105, `<turn|>` id 106, both `token_type=3`); EOG set
   `{1, 50, 106, 212}` is a **superset** of the incumbent's `{50, 106, 212}`, so
   `<turn|>` terminates generation on both builds and there is no runaway-generation
-  risk. The two unsloth QAT re-exports this entry flagged as worth evaluating
-  alongside have since been measured — both carry their own 2026-08-13 entries above.
+  risk. The unsloth QAT re-export this entry flagged as worth evaluating alongside —
+  and the QAT-Mobile re-export that #1415's scope correction later added, which this
+  entry had **missed** — have since been measured; both carry their own 2026-08-13
+  entries above.
   **P3–P5 remain untouched** (Gate 2).
 - **Pointers**: raw scorecard → `data/models/eval-digest.md` §2026-08-08 ·
   gemma-4-e2b-q4-k-m (gitignored, and replaced by key `(date, profile_id)` — which
@@ -316,3 +318,14 @@ everything else here.
 - **Pointers**: raw scorecard → `data/models/eval-digest.md` §2026-07-23
   (gitignored) · intake → #979 · harness `language_mismatch`-detector bug
   surfaced during this eval → #1234.
+
+---
+
+<!-- Reference-link definitions. Kept file-scoped rather than inside an entry:
+     entries are appended newest-first and older ones get pruned, which would
+     silently break a label another entry still uses. -->
+
+[eval-20260813]: https://github.com/tyabu12/pastura/issues/1416#issuecomment-5275995869
+[payoff-20260813]: https://github.com/tyabu12/pastura/issues/1415#issuecomment-5275999544
+[spike-20260812]: https://github.com/tyabu12/pastura/issues/1415#issuecomment-5259871611
+[qat-mobile]: https://huggingface.co/collections/google/gemma-4-qat-mobile


### PR DESCRIPTION
## Summary

Records three QAT-family `/model-eval` verdicts that had no entry in the committed ledger, and
keeps the two cross-references that go stale alongside them accurate.

- **2026-08-13 `UD-Q4_K_XL` — PASS (Mac filter only).** −15.7 % file size with no measured quality
  regression against a same-session control (121 vs 107). Framed as **REPLACE-the-build, not
  earn-a-new-slot** — it is the same Gemma 4 E2B at a different quantisation.
- **2026-08-13 QAT-Mobile `UD-Q2_K_XL` — BLOCKED.** The b10327 pin *does* clear the 2026-08-08
  shared-KV loader gate, but a second, **pin-independent** gap sits behind it: llama.cpp's Metal
  backend ships no `TQ`-family kernels, so the build loads cleanly and then SIGSEGVs on its first
  inference. Still absent at b10375.
- **2026-08-12 google `Q4_0` — FAIL.** The retry the 2026-08-08 **BLOCKED** entry was waiting on;
  it ran inside the #1415 spike and scored 103 against that session's 113 incumbent, with a file
  7.8 % *larger*.

### Why the retry is a new entry rather than an edit

Folding the retry outcome into the 2026-08-08 entry would date a rejection to a day on which
**zero inferences ran**, and would invert that entry's `Disposition: **not rejected**`. `BLOCKED`
is a verdict of its own, and the file's one precedent (Sarashina 2026-07-08 → 2026-07-23) records
the retry as a separate dated entry. So 2026-08-08 keeps its verdict, snapshot and disposition
verbatim; only its `Retry` line and its "worth evaluating alongside" pointer change, both now
answered.

### Why the two non-ledger files are in scope

`docs/decisions/ADR-011.md` § Related defines a sweep a merged pin bump must perform, listing
`.claude/rules/engine.md` § "GGUF source *and variant* matter", `docs/models/eval-log.md`
§2026-08-08, and P1. **None of those legs is applied here** — the pin has not moved — but two of
them no longer mean what they meant when the list was written, and one has gained a member. That
is recorded so a future sweeper does not re-derive it or sweep away the wrong thing.

`engine.md` framed the QAT blocker as purely pin-relative. Still true at `main`'s b8694, but it now
invites a specific wrong inference — that bumping the pin unblocks the whole QAT family. It does
not. The section gains that distinction plus the pre-check that would have caught it before a
2.19 GB download, **including its positive control**: a kernel-name grep that matches nothing looks
identical to a genuine absence.

## Not in this PR

- **No pin change.** `main` stays at `llama.swift` 2.8694.0; the measurements came from a discarded
  worktree.
- **No adoption.** A Gate 1 pass only advances a candidate to the ADR-011 real-device PoC (P3–P5).
  The `UD-Q4_K_XL` entry additionally names the supersede cost, which the −0.49 GB headline hides:
  existing users re-download 2.62 GB and the superseded 3.11 GB file becomes a manual-cleanup
  orphan, so the saving accrues to *new* installs.
- **#1416 stays open** — the QAT-Mobile entry names it as its retry pointer.

Context-economy: kept 2 paragraphs, compressed 1, dropped 0 — the only agent-instruction file
touched is `.claude/rules/engine.md` (path-scoped to Engine/LLM source, so not always-loaded).
Both kept paragraphs pass `context-budget.md`'s classifier: the first is lead claim + the
distinguishing mechanism + the invariant it exists to defend ("do not read a pin bump as
unblocking a whole variant family"), the second is an `Apply` with an actionable command and its
positive control. One paragraph was compressed mid-draft — the tensor-count breakdown, the build
arithmetic and the lldb frame name are drop-class reference detail and live in the ledger entry
instead, which the section already points at.

## Test plan

No code paths touched, so no test suite applies. What was verified instead:

- Every byte count, sha256 prefix, percentage and rubric total **recomputed**, not copied — and
  cross-checked against `data/models/eval-digest.md` §2026-08-13 (gitignored) plus the two issue
  comments that are the durable backing.
- Every cited section, heading and symbol confirmed to exist and to say what the diff claims:
  `RETIRED_MODEL_IDS` in `scripts/gallery_highlight_validate.py`, the supersede convention in
  `ModelRegistry.swift`, ADR-002 § "Supported Devices", ADR-011 § Related and its P1.
- Two review rounds (`code-reviewer`, Opus). Round 1 returned FAIL on 5 Warnings — all of them
  claims that were **wrong**, not prose that was unclear, most sharply a "the durable record is the
  #1415 comment" sentence that linked the wrong comment and so left 103/113 with no reachable
  source. Round 2 verified the fixes and returned PASS.
- One error the reviewer did not raise was caught and fixed in the same round: the fix commit had
  asserted that #1416 "has since been refocused", which is a post-merge follow-up that has not
  happened. Both files now state only what is true today.

## Device QA

実機QA不要 — documentation only (`docs/**`, `.claude/rules/**`). No Swift source, no
`#if !targetEnvironment(simulator)` block, no Metal or llama.cpp code path is touched.

## Follow-ups (GitHub-only, after merge)

- Re-scope #1416 onto the QAT-Mobile variant, as its own scope-correction comment proposed.
- Post the #979 intake comment `docs/models/onboarding.md` § "Recording outcomes" requires.
- Consider a Gate-1-`pass`-not-yet-at-Gate-2 row in that same section — this PR sets the file's
  first PASS precedent, and the procedure doc has no row for it. Deferred as a fourth file.

Closes #1445
See #1416, #1415, #979
