### PR TITLE
📝 docs: pin the probe/target gap to compile stage (ADR-028, Pattern 8)

### DIFF
--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -94,7 +94,7 @@ set matters more than the pattern: the doc's § "The rule-assertion case".
 One discipline, three moments where a claim becomes load-bearing and nobody downstream will check it — the author is the only one positioned to run it.
 
 - **Rule-commit** — a `.claude/rules/` or `CLAUDE.md` addition carrying an **executable assertion** (an asserted grep hit count, a cited `file:line`, a `(PR #N)` claim, a cross-doc heading anchor, **or a self-quoted byte/line delta** — re-measure that one on the *final* commit) is run against current main state **before commit**. Dispositions: § "Dispositions when an assertion diverges".
-- **Plan-lock** — every load-bearing claim a plan leans on is verified against its authoritative source **before** Step 1b. **Read the doc's § "The claim table"** — it maps each claim shape to the source that settles it, and the shapes are not guessable (a defect framed with `would`; two UI surfaces called "the same metric"; a subagent verdict that *dismisses* a risk).
+- **Plan-lock** — every load-bearing claim a plan leans on is verified against its authoritative source **before** Step 1b. **Read the doc's § "The claim table"** — it maps each claim shape to the source that settles it, and the shapes are not guessable (a defect framed with `would`; two UI surfaces called "the same metric"; a subagent verdict that *dismisses* a risk; a claim **inherited from existing text**, where the source you cite agrees by construction and a retraction elsewhere stays invisible).
 - **Authoring** — a why-comment, guard, count, or gap list *you write* asserts behaviour that nobody executes. § "Claims you author are assertions too".
 
 ### Dispositions when an assertion diverges

--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -94,7 +94,7 @@ set matters more than the pattern: the doc's § "The rule-assertion case".
 One discipline, three moments where a claim becomes load-bearing and nobody downstream will check it — the author is the only one positioned to run it.
 
 - **Rule-commit** — a `.claude/rules/` or `CLAUDE.md` addition carrying an **executable assertion** (an asserted grep hit count, a cited `file:line`, a `(PR #N)` claim, a cross-doc heading anchor, **or a self-quoted byte/line delta** — re-measure that one on the *final* commit) is run against current main state **before commit**. Dispositions: § "Dispositions when an assertion diverges".
-- **Plan-lock** — every load-bearing claim a plan leans on is verified against its authoritative source **before** Step 1b. **Read the doc's § "The claim table"** — it maps each claim shape to the source that settles it, and the shapes are not guessable (a defect framed with `would`; two UI surfaces called "the same metric"; a subagent verdict that *dismisses* a risk; a claim **inherited from existing text**, where the source you cite agrees by construction and a retraction elsewhere stays invisible).
+- **Plan-lock** — every load-bearing claim a plan leans on is verified against its authoritative source **before** Step 1b. **Read the doc's § "The claim table"** — it maps each claim shape to the source that settles it, and the shapes are not guessable (a defect framed with `would`; two UI surfaces called "the same metric"; a subagent verdict that *dismisses* a risk; a claim **inherited from existing text**).
 - **Authoring** — a why-comment, guard, count, or gap list *you write* asserts behaviour that nobody executes. § "Claims you author are assertions too".
 
 ### Dispositions when an assertion diverges

--- a/.claude/rules/swift-isolation.md
+++ b/.claude/rules/swift-isolation.md
@@ -230,11 +230,17 @@ removable to the next reader.
 Reference: `PasturaDynamicColor` in
 `Pastura/Pastura/Views/DesignTokens+DynamicColor.swift`; ADR-028 § Consequences.
 
-**A `swiftc -typecheck` probe under-approximates the real target here — build the
-target instead.** A standalone probe of the pair type above passed while the real
-build failed. The tempting explanation (the probe built its token values inline
-rather than reading a MainActor-isolated static) is **wrong** — a probe that does
-read from such a static still passes. The operative difference was not isolated;
-what is established is that a probe can be clean while the target errors, so for
-isolation questions in this family treat `swiftc -typecheck` as a existence check
-for API and `scripts/xcodebuild.sh build` as the verdict.
+**A `swiftc -typecheck` probe under-approximates the real target here — the
+operative variable is the compilation *stage*.** This family's diagnostics split
+across two: `main actor-isolated default value in a nonisolated context` fires
+during type checking, so `-typecheck` sees it, but `[#IsolatedConformances]`
+(Pattern 5's shape) is emitted at SIL generation, which `-typecheck` never
+reaches. **Compile, don't typecheck** — `swiftc -c -o /dev/null` (add `-wmo` for
+a multi-file probe) reddens with the target's verbatim diagnostic. Pattern 7's
+recipe stays `-typecheck` on purpose: a *printed type* is a type-check-stage
+answer. Measured 2026-08-13, Xcode 26.6 / Swift 6.3.3 (#1439) — the dependency
+shape (inline values vs a MainActor-static read), a file split, a use site, and
+the three `-enable-upcoming-feature` flags the target passes all leave the
+outcome unchanged; the first of those was named as the cause by an earlier
+revision and is falsified. `scripts/xcodebuild.sh build` stays the verdict for
+anything a probe cannot state.

--- a/.claude/rules/swift-isolation.md
+++ b/.claude/rules/swift-isolation.md
@@ -233,14 +233,18 @@ Reference: `PasturaDynamicColor` in
 **A `swiftc -typecheck` probe under-approximates the real target here — the
 operative variable is the compilation *stage*.** This family's diagnostics split
 across two: `main actor-isolated default value in a nonisolated context` fires
-during type checking, so `-typecheck` sees it, but `[#IsolatedConformances]`
-(Pattern 5's shape) is emitted at SIL generation, which `-typecheck` never
-reaches. **Compile, don't typecheck** — `swiftc -c -o /dev/null` (add `-wmo` for
-a multi-file probe) reddens with the target's verbatim diagnostic. Pattern 7's
-recipe stays `-typecheck` on purpose: a *printed type* is a type-check-stage
-answer. Measured 2026-08-13, Xcode 26.6 / Swift 6.3.3 (#1439) — the dependency
-shape (inline values vs a MainActor-static read), a file split, a use site, and
-the three `-enable-upcoming-feature` flags the target passes all leave the
-outcome unchanged; the first of those was named as the cause by an earlier
-revision and is falsified. `scripts/xcodebuild.sh build` stays the verdict for
-anything a probe cannot state.
+during type checking, so `-typecheck` sees it, while the isolated-conformance
+error of § "Same cause, two non-test shapes" row 1 is emitted at SIL generation,
+which `-typecheck` never reaches — it prints with **no source location**
+(`<unknown>:0: … [#IsolatedConformances]`), which is the recognition cue.
+**Compile, don't typecheck** — swap `-typecheck` for `-c -o /dev/null` in
+Pattern 7's recipe above (add `-wmo` for a multi-file probe) and it reddens with
+the target's verbatim diagnostic; that recipe's other flags, `-default-isolation
+MainActor` especially, stay load-bearing. Pattern 7 itself keeps `-typecheck` on
+purpose: a *printed type* is a type-check-stage answer. Measured 2026-08-13,
+Xcode 26.6 / Swift 6.3.3 (#1439) — the dependency shape (inline values vs a
+MainActor-static read), a file split, a use site, and the target's
+`-enable-upcoming-feature` flags all leave the outcome unchanged; earlier
+revisions of this paragraph and of ADR-028 named the first as the cause, so do
+not restore it. `scripts/xcodebuild.sh build` stays the verdict for anything a
+probe cannot state.

--- a/.claude/rules/swift-isolation.md
+++ b/.claude/rules/swift-isolation.md
@@ -231,13 +231,15 @@ Reference: `PasturaDynamicColor` in
 `Pastura/Pastura/Views/DesignTokens+DynamicColor.swift`; ADR-028 § Consequences.
 
 **A `swiftc -typecheck` probe under-approximates the real target here — the
-operative variable is the compilation *stage*.** This family's diagnostics split
-across two: `main actor-isolated default value in a nonisolated context` fires
-during type checking, so `-typecheck` sees it, while the isolated-conformance
-error of § "Same cause, two non-test shapes" row 1 is emitted at SIL generation,
-which `-typecheck` never reaches — it prints with **no source location**
-(`<unknown>:0: … [#IsolatedConformances]`), which is the recognition cue —
-measured for that row; Pattern 5's test shape does carry a use-site location.
+operative variable is the compilation *stage*.** `main actor-isolated default
+value in a nonisolated context` fires during type checking, so `-typecheck` sees
+it. `[#IsolatedConformances]` falls on **both** sides, split by how the isolated
+conformance is reached: used **from source** (an explicit `==`, Pattern 5's test
+shape) it is diagnosed during type checking and carries a source location, but
+reached only through a **compiler-synthesized** witness — row 1 of § "Same cause,
+two non-test shapes" — it is realized at SIL generation and prints at
+`<unknown>:0`. Both measured. A location-less diagnostic is the cue that no
+`-typecheck` probe could have caught it.
 **Compile, don't typecheck** — reuse Pattern 7's *flags* (`-default-isolation
 MainActor` especially, without which nothing is isolated and the probe is green)
 but `-c -o /dev/null` in place of `-typecheck`, `-wmo` for a multi-file probe,
@@ -246,8 +248,8 @@ not this error, so it returns empty and reads as green. The probe source is your
 own type, not Pattern 7's. Pattern 7 itself keeps `-typecheck`: a *printed type*
 is a type-check-stage answer. Measured 2026-08-13,
 Xcode 26.6 / Swift 6.3.3 (#1439) — the dependency shape (inline values vs a
-MainActor-static read), a file split, a use site, and the target's
-`-enable-upcoming-feature` flags all leave the outcome unchanged; an earlier
-revision of ADR-028 named the first as the cause and this paragraph then recorded
-it as unexplained, so restore neither. `scripts/xcodebuild.sh build` stays the verdict for anything a
-probe cannot state.
+MainActor-static read), a file split, a use site of the *synthesized* `==`, and
+the target's `-enable-upcoming-feature` flags all leave the outcome unchanged; an
+earlier revision of ADR-028 named the first as the cause and this paragraph then
+recorded it as unexplained, so restore neither. `scripts/xcodebuild.sh build`
+stays the verdict for anything a probe cannot state.

--- a/.claude/rules/swift-isolation.md
+++ b/.claude/rules/swift-isolation.md
@@ -238,8 +238,9 @@ conformance is reached: used **from source** (an explicit `==`, Pattern 5's test
 shape) it is diagnosed during type checking and carries a source location, but
 reached only through a **compiler-synthesized** witness — row 1 of § "Same cause,
 two non-test shapes" — it is realized at SIL generation and prints at
-`<unknown>:0`. Both measured. A location-less diagnostic is the cue that no
-`-typecheck` probe could have caught it.
+`<unknown>:0`. Both measured, as a one-toggle control in a single program. A
+location-less diagnostic is the cue that no `-typecheck` probe could have caught
+it.
 **Compile, don't typecheck** — reuse Pattern 7's *flags* (`-default-isolation
 MainActor` especially, without which nothing is isolated and the probe is green)
 but `-c -o /dev/null` in place of `-typecheck`, `-wmo` for a multi-file probe,

--- a/.claude/rules/swift-isolation.md
+++ b/.claude/rules/swift-isolation.md
@@ -235,22 +235,21 @@ operative variable is the compilation *stage*.** `main actor-isolated default
 value in a nonisolated context` fires during type checking, so `-typecheck` sees
 it. `[#IsolatedConformances]` falls on **both** sides, split by how the isolated
 conformance is reached: used **from source** (an explicit `==`, Pattern 5's test
-shape) it is diagnosed during type checking and carries a source location, but
-reached only through a **compiler-synthesized** witness — row 1 of § "Same cause,
-two non-test shapes" — it is realized at SIL generation and prints at
-`<unknown>:0`. Both measured, as a one-toggle control in a single program. A
-location-less diagnostic is the cue that no `-typecheck` probe could have caught
-it.
+shape) it is type-checked and carries a source location; reached only through a
+**compiler-synthesized** witness — row 1 of § "Same cause, two non-test shapes" —
+it is realized at SIL generation and prints at `<unknown>:0`. Both measured, as a
+one-toggle control in a single program: a location-less diagnostic is the cue
+that no `-typecheck` probe could have caught it.
 **Compile, don't typecheck** — reuse Pattern 7's *flags* (`-default-isolation
 MainActor` especially, without which nothing is isolated and the probe is green)
 but `-c -o /dev/null` in place of `-typecheck`, `-wmo` for a multi-file probe,
 and **drop its `| grep "cannot convert"`**: that filter matches a printed type,
-not this error, so it returns empty and reads as green. The probe source is your
-own type, not Pattern 7's. Pattern 7 itself keeps `-typecheck`: a *printed type*
-is a type-check-stage answer. Measured 2026-08-13,
-Xcode 26.6 / Swift 6.3.3 (#1439) — the dependency shape (inline values vs a
-MainActor-static read), a file split, a use site of the *synthesized* `==`, and
-the target's `-enable-upcoming-feature` flags all leave the outcome unchanged; an
-earlier revision of ADR-028 named the first as the cause and this paragraph then
-recorded it as unexplained, so restore neither. `scripts/xcodebuild.sh build`
-stays the verdict for anything a probe cannot state.
+not this error, so it returns empty and reads as green. Probe your own type, not
+Pattern 7's — which keeps `-typecheck` on purpose: a *printed type* is a
+type-check-stage answer. Measured 2026-08-13, Xcode 26.6 / Swift 6.3.3 (#1439);
+null results — the dependency shape (inline values vs a MainActor-static read), a
+file split, a use site of the *synthesized* `==`, the target's
+`-enable-upcoming-feature` flags. An earlier ADR-028 revision named the dependency
+shape as the cause and this paragraph then called the gap unexplained: restore
+neither.
+`scripts/xcodebuild.sh build` stays the verdict for anything a probe cannot state.

--- a/.claude/rules/swift-isolation.md
+++ b/.claude/rules/swift-isolation.md
@@ -236,15 +236,18 @@ across two: `main actor-isolated default value in a nonisolated context` fires
 during type checking, so `-typecheck` sees it, while the isolated-conformance
 error of § "Same cause, two non-test shapes" row 1 is emitted at SIL generation,
 which `-typecheck` never reaches — it prints with **no source location**
-(`<unknown>:0: … [#IsolatedConformances]`), which is the recognition cue.
-**Compile, don't typecheck** — swap `-typecheck` for `-c -o /dev/null` in
-Pattern 7's recipe above (add `-wmo` for a multi-file probe) and it reddens with
-the target's verbatim diagnostic; that recipe's other flags, `-default-isolation
-MainActor` especially, stay load-bearing. Pattern 7 itself keeps `-typecheck` on
-purpose: a *printed type* is a type-check-stage answer. Measured 2026-08-13,
+(`<unknown>:0: … [#IsolatedConformances]`), which is the recognition cue —
+measured for that row; Pattern 5's test shape does carry a use-site location.
+**Compile, don't typecheck** — reuse Pattern 7's *flags* (`-default-isolation
+MainActor` especially, without which nothing is isolated and the probe is green)
+but `-c -o /dev/null` in place of `-typecheck`, `-wmo` for a multi-file probe,
+and **drop its `| grep "cannot convert"`**: that filter matches a printed type,
+not this error, so it returns empty and reads as green. The probe source is your
+own type, not Pattern 7's. Pattern 7 itself keeps `-typecheck`: a *printed type*
+is a type-check-stage answer. Measured 2026-08-13,
 Xcode 26.6 / Swift 6.3.3 (#1439) — the dependency shape (inline values vs a
 MainActor-static read), a file split, a use site, and the target's
-`-enable-upcoming-feature` flags all leave the outcome unchanged; earlier
-revisions of this paragraph and of ADR-028 named the first as the cause, so do
-not restore it. `scripts/xcodebuild.sh build` stays the verdict for anything a
+`-enable-upcoming-feature` flags all leave the outcome unchanged; an earlier
+revision of ADR-028 named the first as the cause and this paragraph then recorded
+it as unexplained, so restore neither. `scripts/xcodebuild.sh build` stays the verdict for anything a
 probe cannot state.

--- a/Pastura/Pastura/Views/DesignTokens+DynamicColor.swift
+++ b/Pastura/Pastura/Views/DesignTokens+DynamicColor.swift
@@ -52,12 +52,14 @@ import UIKit
 /// non-test shapes" for the two build-error shapes this file also hits.
 /// Deliberately NOT `Equatable`, unlike ``PasturaColorValue``: a synthesized
 /// `==` would need `PasturaColorValue`'s own `Equatable` conformance from this
-/// `nonisolated` context, and that conformance is MainActor-isolated (the target
-/// sets `SWIFT_APPROACHABLE_CONCURRENCY = YES`, which enables
-/// `InferIsolatedConformances`) — `swift-isolation.md` Pattern 5. Observed, not
-/// predicted: with the conformance present the build fails with "main actor-isolated
-/// conformance of 'PasturaColorValue' to 'Equatable' cannot be used in nonisolated
-/// context".
+/// `nonisolated` context, and that conformance is MainActor-isolated because
+/// ``PasturaColorValue`` takes the target's default isolation
+/// (`SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`) — `swift-isolation.md` Pattern 5.
+/// Observed, not predicted: with the conformance present the build fails with
+/// "main actor-isolated conformance of 'PasturaColorValue' to 'Equatable' cannot be
+/// used in nonisolated context". Not `SWIFT_APPROACHABLE_CONCURRENCY`, which an
+/// earlier revision credited — measured, the error survives disabling
+/// `InferIsolatedConformances` (ADR-028 § Consequences).
 /// Compare `.light` / `.dark` individually from a MainActor context instead. Do
 /// not "restore" the conformance without also marking `PasturaColorValue`
 /// `nonisolated`, which Pattern 5 reserves for ≥2 nonisolated call sites.

--- a/Pastura/Pastura/Views/DesignTokens+DynamicColor.swift
+++ b/Pastura/Pastura/Views/DesignTokens+DynamicColor.swift
@@ -56,11 +56,9 @@ import UIKit
 /// ``PasturaColorValue`` takes the target's default isolation
 /// (`SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`) — `swift-isolation.md` Pattern 5.
 /// Observed, not predicted: with the conformance present the build fails with
-/// "main actor-isolated conformance of 'PasturaColorValue' to 'Equatable' cannot be
-/// used in nonisolated context". Not `SWIFT_APPROACHABLE_CONCURRENCY`, which an
-/// earlier revision credited — measured, the error reproduces with that setting's
-/// feature flags absent and stops only when `-default-isolation MainActor` is
-/// dropped (ADR-028 § Consequences).
+/// "main actor-isolated conformance of 'PasturaColorValue' to 'Equatable' cannot
+/// be used in nonisolated context". Not `SWIFT_APPROACHABLE_CONCURRENCY`, which
+/// an earlier revision credited (measured; ADR-028 § Consequences).
 /// Compare `.light` / `.dark` individually from a MainActor context instead. Do
 /// not "restore" the conformance without also marking `PasturaColorValue`
 /// `nonisolated`, which Pattern 5 reserves for ≥2 nonisolated call sites.

--- a/Pastura/Pastura/Views/DesignTokens+DynamicColor.swift
+++ b/Pastura/Pastura/Views/DesignTokens+DynamicColor.swift
@@ -58,8 +58,9 @@ import UIKit
 /// Observed, not predicted: with the conformance present the build fails with
 /// "main actor-isolated conformance of 'PasturaColorValue' to 'Equatable' cannot be
 /// used in nonisolated context". Not `SWIFT_APPROACHABLE_CONCURRENCY`, which an
-/// earlier revision credited — measured, the error survives passing
-/// `-disable-upcoming-feature InferIsolatedConformances` (ADR-028 § Consequences).
+/// earlier revision credited — measured, the error reproduces with that setting's
+/// feature flags absent and stops only when `-default-isolation MainActor` is
+/// dropped (ADR-028 § Consequences).
 /// Compare `.light` / `.dark` individually from a MainActor context instead. Do
 /// not "restore" the conformance without also marking `PasturaColorValue`
 /// `nonisolated`, which Pattern 5 reserves for ≥2 nonisolated call sites.

--- a/Pastura/Pastura/Views/DesignTokens+DynamicColor.swift
+++ b/Pastura/Pastura/Views/DesignTokens+DynamicColor.swift
@@ -58,8 +58,8 @@ import UIKit
 /// Observed, not predicted: with the conformance present the build fails with
 /// "main actor-isolated conformance of 'PasturaColorValue' to 'Equatable' cannot be
 /// used in nonisolated context". Not `SWIFT_APPROACHABLE_CONCURRENCY`, which an
-/// earlier revision credited — measured, the error survives disabling
-/// `InferIsolatedConformances` (ADR-028 § Consequences).
+/// earlier revision credited — measured, the error survives passing
+/// `-disable-upcoming-feature InferIsolatedConformances` (ADR-028 § Consequences).
 /// Compare `.light` / `.dark` individually from a MainActor context instead. Do
 /// not "restore" the conformance without also marking `PasturaColorValue`
 /// `nonisolated`, which Pattern 5 reserves for ≥2 nonisolated call sites.

--- a/docs/agent-tooling/claim-verification.md
+++ b/docs/agent-tooling/claim-verification.md
@@ -40,6 +40,7 @@ Verify each against its authoritative source *before* the plan locks.
 | An external standard (SEO, RFC, sitemap/robots, OAuth, HTTP semantics) | WebSearch + WebFetch the authority (Google Search Central, the RFC, MDN); verbatim-cite before critic |
 | Vendor feature availability (free/paid/plan tier) | WebFetch the canonical docs; verbatim-quote the "Who can use this feature" box — never infer from search snippets |
 | A subagent's verdict on an external platform fact (SDK annotation, threading contract, API availability) | Re-derive it yourself — a verdict that *dismisses* a risk ends inquiry and is the expensive one to get wrong. Then run the prescribed check against a **known-positive control**; `.claude/rules/swift-isolation.md` § Pattern 7 is the worked instance |
+| A claim **inherited from existing text** — carried into a new file, summary, or INDEX entry from a doc/rule/ADR that already states it | grep the always-loaded `.claude/rules/**` for a **retraction**, not only the source you copied from. Checking the source agrees *by construction*, so that check cannot see that another document has since withdrawn the claim — and it returns a confident "verified". #1439 is the worked instance: a probe-methodology cause was carried out of ADR-028 while Pattern 8 had already retracted it |
 
 This applies to **non-grep claims** too: cited file paths (`find` to confirm existence), `(PR #N)`
 claims about PR body content (`gh pr view N` to verify), heading anchors in cross-doc refs (`grep`

--- a/docs/decisions/ADR-028.md
+++ b/docs/decisions/ADR-028.md
@@ -350,9 +350,15 @@ token count is the cheaper path.
     capturing it would be equally safe.
   - `PasturaDynamicColor` is **not** `Equatable`. A synthesized `==` needs
     `PasturaColorValue`'s `Equatable` conformance from a `nonisolated` context,
-    and that conformance is MainActor-isolated (the target builds with
-    `SWIFT_APPROACHABLE_CONCURRENCY = YES`, which enables
-    `InferIsolatedConformances`) — Pattern 5, which fails the build with
+    and that conformance is MainActor-isolated because `PasturaColorValue` takes
+    the target's default isolation (`SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`).
+    An earlier revision credited `SWIFT_APPROACHABLE_CONCURRENCY = YES` /
+    `InferIsolatedConformances` instead; measured 2026-08-13 (#1439), the error
+    reproduces with those flags absent **and** with the feature explicitly
+    disabled, and stops reproducing only when `-default-isolation MainActor` is
+    dropped. Whether that feature is baseline in this toolchain was not isolated;
+    what is established is that the build setting is not what isolates the
+    conformance. This is Pattern 5, which fails the build with
     `main actor-isolated conformance of 'PasturaColorValue' to 'Equatable'
     cannot be used in nonisolated context`.
   - Conversely `PasturaDynamicPalette` is deliberately **not** `nonisolated`:
@@ -360,16 +366,19 @@ token count is the cheaper path.
     Marking it `nonisolated` fails with `Main actor-isolated default value in a
     nonisolated context`. The isolation that matters is on the closure.
 - **A compile-only probe was insufficient, and the operative variable is the
-  compilation *stage*** — not the dependency shape, which two earlier revisions
-  of this bullet named as the cause and then as unisolated. `[#IsolatedConformances]`
-  is emitted at SIL generation, which `swiftc -typecheck` never reaches, so the
+  compilation *stage*** — not the dependency shape, which this bullet originally
+  named as the cause and which `swift-isolation.md` § Pattern 8 then recorded as
+  unexplained. `[#IsolatedConformances]` is emitted at SIL generation and prints
+  with no source location; `swiftc -typecheck` never reaches that stage, so the
   probe stayed clean while the target errored. Re-measured 2026-08-13 on Xcode
-  26.6 / Swift 6.3.3 (#1439): `swiftc -c -o /dev/null` reddens the probe with the
-  target's verbatim diagnostic, while replicating the dependency shape (reading
-  from MainActor-isolated statics instead of building values inline), splitting
-  the type across files, adding a use site, and passing the three
-  `-enable-upcoming-feature` flags the target sets **all** leave `-typecheck`
-  green. Operational form: `swift-isolation.md` § Pattern 8.
+  26.6 / Swift 6.3.3 (#1439): swapping `-typecheck` for `-c -o /dev/null` reddens
+  the probe with the target's verbatim diagnostic — a multi-file probe also needs
+  `-wmo`, or `-o` fails with "cannot specify -o when generating multiple output
+  files". Replicating the dependency shape (reading from MainActor-isolated
+  statics instead of building values inline), splitting the type across files,
+  adding a use site, and passing the target's `-enable-upcoming-feature` flags
+  **all** leave `-typecheck` green. Operational form: `swift-isolation.md`
+  § Pattern 8.
 
 ### Standing invariants the pairing created
 

--- a/docs/decisions/ADR-028.md
+++ b/docs/decisions/ADR-028.md
@@ -351,17 +351,16 @@ token count is the cheaper path.
   - `PasturaDynamicColor` is **not** `Equatable`. A synthesized `==` needs
     `PasturaColorValue`'s `Equatable` conformance from a `nonisolated` context,
     and that conformance is MainActor-isolated because `PasturaColorValue` takes
-    the target's default isolation (`SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`).
-    An earlier revision credited `SWIFT_APPROACHABLE_CONCURRENCY = YES` /
-    `InferIsolatedConformances` instead; measured 2026-08-13 (#1439), the error
+    the target's default isolation (`SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`) —
+    not `SWIFT_APPROACHABLE_CONCURRENCY = YES` / `InferIsolatedConformances`,
+    which an earlier revision credited: measured 2026-08-13 (#1439), the error
     reproduces with those flags absent **and** with the feature explicitly
-    disabled, and stops reproducing only when `-default-isolation MainActor` is
-    dropped. Whether that feature is baseline in this toolchain was not isolated;
-    what is established is that the build setting is not what isolates the
-    conformance. This is Pattern 5 § "Same cause, two non-test shapes" row 1 —
-    the synthesized-witness side of that pattern, not its located test shape —
-    which fails the build with
-    `main actor-isolated conformance of 'PasturaColorValue' to 'Equatable'
+    disabled, and stops only when `-default-isolation MainActor` is dropped.
+    (Whether that feature is baseline in this toolchain was not isolated; what is
+    established is that the build setting is not what isolates the conformance.)
+    This is Pattern 5 § "Same cause, two non-test shapes" row 1 — the
+    synthesized-witness side, not its located test shape — which fails the build
+    with `main actor-isolated conformance of 'PasturaColorValue' to 'Equatable'
     cannot be used in nonisolated context`.
   - Conversely `PasturaDynamicPalette` is deliberately **not** `nonisolated`:
     its static initializers read MainActor-isolated `PasturaPalette` statics.
@@ -375,17 +374,15 @@ token count is the cheaper path.
   compiler-**synthesized** witness, as it is here; `swiftc -typecheck` never
   reaches that stage, so the probe stayed clean while the target errored. (Used
   **from source** the same error is a located type-check-stage diagnostic — both
-  measured, as a one-toggle control in a single program;
-  `swift-isolation.md` § Pattern 8 carries the split.)
-  Re-measured 2026-08-13 on Xcode 26.6 / Swift 6.3.3 (#1439): swapping
-  `-typecheck` for `-c -o /dev/null` reddens the probe with the target's
-  verbatim diagnostic — a multi-file probe also needs
-  `-wmo`, or `-o` fails with "cannot specify -o when generating multiple output
-  files". Replicating the dependency shape (reading from MainActor-isolated
-  statics instead of building values inline), splitting the type across files,
-  adding a use site of the *synthesized* `==`, and passing the target's
-  `-enable-upcoming-feature` flags **all** leave `-typecheck` green.
-  Operational form: `swift-isolation.md` § Pattern 8.
+  measured, as a one-toggle control in a single program.) Re-measured 2026-08-13
+  on Xcode 26.6 / Swift 6.3.3 (#1439): compiling (`-c -o /dev/null`, plus `-wmo`
+  for a multi-file probe) rather than type-checking reddens the probe with the
+  target's verbatim diagnostic, while replicating the dependency shape (reading
+  from MainActor-isolated statics instead of building values inline), splitting
+  the type across files, adding a use site of the *synthesized* `==`, and passing
+  the target's `-enable-upcoming-feature` flags **all** leave `-typecheck` green.
+  Recipe, and the location cue that recognizes this family: `swift-isolation.md`
+  § Pattern 8.
 
 ### Standing invariants the pairing created
 

--- a/docs/decisions/ADR-028.md
+++ b/docs/decisions/ADR-028.md
@@ -368,9 +368,12 @@ token count is the cheaper path.
 - **A compile-only probe was insufficient, and the operative variable is the
   compilation *stage*** — not the dependency shape, which this bullet originally
   named as the cause and which `swift-isolation.md` § Pattern 8 then recorded as
-  unexplained. `[#IsolatedConformances]` is emitted at SIL generation and prints
-  with no source location; `swiftc -typecheck` never reaches that stage, so the
-  probe stayed clean while the target errored. Re-measured 2026-08-13 on Xcode
+  unexplained. `[#IsolatedConformances]` reaches SIL generation — and prints with
+  no source location — when the isolated conformance is used only through a
+  compiler-**synthesized** witness, as it is here; `swiftc -typecheck` never
+  reaches that stage, so the probe stayed clean while the target errored. (Used
+  **from source** the same error is a located type-check-stage diagnostic — both
+  measured; `swift-isolation.md` § Pattern 8 carries the split.) Re-measured 2026-08-13 on Xcode
   26.6 / Swift 6.3.3 (#1439): swapping `-typecheck` for `-c -o /dev/null` reddens
   the probe with the target's verbatim diagnostic — a multi-file probe also needs
   `-wmo`, or `-o` fails with "cannot specify -o when generating multiple output

--- a/docs/decisions/ADR-028.md
+++ b/docs/decisions/ADR-028.md
@@ -359,11 +359,17 @@ token count is the cheaper path.
     its static initializers read MainActor-isolated `PasturaPalette` statics.
     Marking it `nonisolated` fails with `Main actor-isolated default value in a
     nonisolated context`. The isolation that matters is on the closure.
-- **A compile-only probe was insufficient** and this is the generalizable
-  lesson: a `swiftc -typecheck` probe that constructed `PasturaColorValue`s
-  *inline* passed, while the real code — which reads them from
-  `PasturaPalette`'s MainActor statics — failed. A probe must replicate the
-  dependency shape, not just the API shape, or it measures nothing.
+- **A compile-only probe was insufficient, and the operative variable is the
+  compilation *stage*** — not the dependency shape, which two earlier revisions
+  of this bullet named as the cause and then as unisolated. `[#IsolatedConformances]`
+  is emitted at SIL generation, which `swiftc -typecheck` never reaches, so the
+  probe stayed clean while the target errored. Re-measured 2026-08-13 on Xcode
+  26.6 / Swift 6.3.3 (#1439): `swiftc -c -o /dev/null` reddens the probe with the
+  target's verbatim diagnostic, while replicating the dependency shape (reading
+  from MainActor-isolated statics instead of building values inline), splitting
+  the type across files, adding a use site, and passing the three
+  `-enable-upcoming-feature` flags the target sets **all** leave `-typecheck`
+  green. Operational form: `swift-isolation.md` § Pattern 8.
 
 ### Standing invariants the pairing created
 

--- a/docs/decisions/ADR-028.md
+++ b/docs/decisions/ADR-028.md
@@ -358,7 +358,9 @@ token count is the cheaper path.
     disabled, and stops reproducing only when `-default-isolation MainActor` is
     dropped. Whether that feature is baseline in this toolchain was not isolated;
     what is established is that the build setting is not what isolates the
-    conformance. This is Pattern 5, which fails the build with
+    conformance. This is Pattern 5 § "Same cause, two non-test shapes" row 1 —
+    the synthesized-witness side of that pattern, not its located test shape —
+    which fails the build with
     `main actor-isolated conformance of 'PasturaColorValue' to 'Equatable'
     cannot be used in nonisolated context`.
   - Conversely `PasturaDynamicPalette` is deliberately **not** `nonisolated`:
@@ -373,15 +375,17 @@ token count is the cheaper path.
   compiler-**synthesized** witness, as it is here; `swiftc -typecheck` never
   reaches that stage, so the probe stayed clean while the target errored. (Used
   **from source** the same error is a located type-check-stage diagnostic — both
-  measured; `swift-isolation.md` § Pattern 8 carries the split.) Re-measured 2026-08-13 on Xcode
-  26.6 / Swift 6.3.3 (#1439): swapping `-typecheck` for `-c -o /dev/null` reddens
-  the probe with the target's verbatim diagnostic — a multi-file probe also needs
+  measured, as a one-toggle control in a single program;
+  `swift-isolation.md` § Pattern 8 carries the split.)
+  Re-measured 2026-08-13 on Xcode 26.6 / Swift 6.3.3 (#1439): swapping
+  `-typecheck` for `-c -o /dev/null` reddens the probe with the target's
+  verbatim diagnostic — a multi-file probe also needs
   `-wmo`, or `-o` fails with "cannot specify -o when generating multiple output
   files". Replicating the dependency shape (reading from MainActor-isolated
   statics instead of building values inline), splitting the type across files,
-  adding a use site, and passing the target's `-enable-upcoming-feature` flags
-  **all** leave `-typecheck` green. Operational form: `swift-isolation.md`
-  § Pattern 8.
+  adding a use site of the *synthesized* `==`, and passing the target's
+  `-enable-upcoming-feature` flags **all** leave `-typecheck` green.
+  Operational form: `swift-isolation.md` § Pattern 8.
 
 ### Standing invariants the pairing created
 


### PR DESCRIPTION
## Summary

ADR-028 § Consequences and `.claude/rules/swift-isolation.md` § Pattern 8 stated **contradictory causes** for the same observation — why a `swiftc -typecheck` probe of the design-token pair type passed while the real target's build failed. Both landed in #1281; Pattern 8 is always-loaded, so its "cause unexplained" reached every session while the ADR's claim reached only its own readers.

Re-measured rather than argued. **Both explanations turned out to be wrong**, and so did the flag-gap hypothesis this PR's own plan opened with.

### The measurement

Xcode 26.6 (17F113) / Swift 6.3.3, `arm64-apple-ios18.0-simulator`. Probes lived outside the repo (anything under `Pastura/Pastura/` auto-joins the target via `PBXFileSystemSynchronizedRootGroup`).

| cell | `-typecheck` | `-c` / `-emit-sil` |
|---|---|---|
| values built inline | **FAIL (ii)** | — |
| values read from a MainActor-isolated static | **FAIL (ii)** | — |
| `Equatable` conformance, no feature flags | PASS | **FAIL (i)** |
| `Equatable` conformance, the target's flags | PASS | **FAIL (i)** |
| ↑ plus a use site | PASS | — |
| ↑ value type split into a sibling file | PASS | **FAIL (i)**, via `-wmo` |
| negative control — same, minus the conformance | — | PASS |
| **real target**, `: Equatable` added, `scripts/xcodebuild.sh build` | — | **FAIL (i)**, verbatim |

- **(i)** `main actor-isolated conformance of 'X' to 'Equatable' cannot be used in nonisolated context [#IsolatedConformances]` — printed with **no source location** (`<unknown>:0`) in both the probe and the real build.
- **(ii)** `main actor-isolated default value in a nonisolated context`.

**The operative variable is the compilation stage.** (i) is emitted at SIL generation, which `-typecheck` never reaches; (ii) is a type-check-stage diagnostic a probe *does* reproduce. The dependency shape moves neither — the inline probe fails too — so ADR-028's stated cause is falsified and Pattern 8's "not isolated" is now isolated.

**(i) then turned out to fall on both sides of that split**, measured in review after iteration 3 flagged the contrast as asserted-but-unmeasured. A later pass flagged the reconciliation itself as inference, so it was re-run as a **one-toggle control in a single program** — both use sites in one file, one error:

| how the isolated conformance is reached | stage | location |
|---|---|---|
| explicit `==` **from source** | type check | **yes** (`probe_eq_inner.swift:35:5`) |
| only via a **compiler-synthesized** witness (this ADR's shape) | SIL generation | **no** (`<unknown>:0`) |

That resolves an apparent conflict inside the table above: the "plus a use site" cell stayed green because its use site exercises the *synthesized* `==`, not the isolated conformance directly — the compiler's behaviour, not a relabel the text needed. A location-less diagnostic is therefore the cue that no `-typecheck` probe could have caught it — a recognition rule rather than a caveat. Both control lines print `[#IsolatedConformances]`; only their locations differ.

The three `-enable-upcoming-feature` flags the target passes were **derived from the real `swiftc` invocation in the build log**, not hand-listed (`MemberImportVisibility`, `InferIsolatedConformances`, `NonisolatedNonsendingByDefault`). They change nothing for this diagnostic — recorded so the next reader does not chase them, since this PR's plan did.

### A second stale mirror, found by the same measurement

One bullet **above** the corrected one — and its copy in `DesignTokens+DynamicColor.swift`'s doc comment — credited the MainActor-isolated conformance to `SWIFT_APPROACHABLE_CONCURRENCY = YES` / `InferIsolatedConformances`. Measured: the error reproduces with those flags absent **and** with `-disable-upcoming-feature InferIsolatedConformances`, and stops only when `-default-isolation MainActor` is dropped. The cause is `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`.

Whether `InferIsolatedConformances` is baseline in this toolchain was **not** isolated — passing `-disable-…` for an already-baseline feature is a no-op. Both loci say so rather than converting a null result into a second cause.

This was scope added during review, not planned. Leaving it would have reproduced the exact defect class the PR exists to fix.

### The detection gap (issue's part 2)

#1433's verification pass **did** re-check every claim it carried into `INDEX.md` against the ADR it came from — and this one passed, because ADR-028 says exactly what was copied. The retraction lived in a different file. A check that reads the citation source **agrees by construction**, so it cannot see a withdrawal elsewhere, and it reports "verified" while doing so.

New row in `docs/agent-tooling/claim-verification.md` § "The claim table"; `knowledge-layering.md`'s Plan-lock bullet gains the trigger phrase only, because the reader this shape fails is the one who believes the check is already complete and therefore never opens the doc.

The issue asked for the row in `knowledge-layering.md` § "Rule-writing self-check". **That section no longer exists** — #1433 / PR #1437 relocated the table to the paired doc; `grep -rn "Rule-writing self-check"` is empty in this repo.

### Deliberate non-changes

- **Pattern 7's recipe stays `-typecheck`.** Its question is a *printed requirement type* — a type-check-stage answer. Re-derived on this toolchain under both flagless and full-flag recipes: `UIActivityItemSource` still prints `(UIActivityViewController) -> Any`, the control `UIScrollViewDelegate.scrollViewDidScroll` still prints `(@MainActor (UIScrollView) -> Void)?`. So `ShareCaptionItemSource.swift`'s production `nonisolated`, which rests on that verdict, is unaffected and no recipe citer needed a sweep.
- **`docs/decisions/INDEX.md` not synced** — its ADR-028 entry references Pattern 8 for the isolation constraints, not for this claim.

### Review

Three `code-reviewer` iterations — the skill's limit. **Every fix commit introduced a fresh defect while fixing the reported ones**, each of the same kind the PR is about:

1. The corrected command was published without Pattern 7's flags — and `-default-isolation MainActor` is load-bearing, so a verbatim run is green and returns a false "verified".
2. The fix for that pointed at Pattern 7's recipe wholesale, inheriting its trailing `| grep "cannot convert"` — a filter that does not match the conformance error, so a verbatim run prints nothing and reads as green. Same false green, moved from the flags to the filter.
3. The fix for *that* asserted an unmeasured contrast about where Pattern 5's diagnostic prints, inferred from text about what *triggers* it. Measured instead — which produced the location split above, so this one improved the rule rather than merely repairing it.
4. And that commit qualified the split in the ADR's **prose** while leaving its invariance **list** unqualified — a self-contradiction six lines apart, in the half a reader acts on. Caught as Critical by a fourth pass (run on the then-unreviewed final commit), fixed in `0fb3665b`, together with measuring the reclassification the fix rested on. (An earlier revision of this section cited `2d92a4e6` for that fix — a hash amended away and no longer on the branch.)

A fifth commit, `18876387`, is a **prose-compression pass, not a defect fix**: the same finding was stated at three sites, so the overlap was trimmed. Every claim survives at ≥1 site — the one fact dropped repo-wide is the `-o` multi-file error transcript, whose actionable half (`-wmo` for a multi-file probe) is kept in both the rule and the ADR. ADR-028's probe bullet had been pointing at § Pattern 8 twice.

⚠️ **The last two commits (`0fb3665b`, `18876387`) have had no reviewer pass.** Four passes ran; every one found something in the commit before it, and the compression commit is self-reviewed only. That is the residual risk here, and it is worth one more pass before merge rather than assuming the streak broke on its own.

### Context economy

Always-loaded footprint measured with `scripts/hooks/check-claude-md-modified.sh`'s own `always_loaded_bytes()` predicate, re-run on the final commit: **92,933 bytes** against the **95,500** ceiling — **+1,142** over the branch base (`swift-isolation.md` +1,100, `knowledge-layering.md` +42). Each increment bought a guard against one of the false greens above, and the cheaper wordings are precisely what produced them.

**Context-economy: kept 1 paragraph (rewritten in place, then compressed), compressed 2, dropped 0** — Pattern 8's closing paragraph is the one that grew: an always-loaded paragraph that said "cause unknown" now carries a runnable command that reddens, verified against a negative control so a green run is not vacuous, plus the two guards that stop it returning a false green. `knowledge-layering.md`'s addition was compressed to a name-only trigger phrase after review found it running ~3× its siblings, per `context-budget.md`'s own classifier; its explanation lives in the paired doc, which is not always-loaded. `18876387` then compressed the Pattern 8 paragraph itself (−50 bytes always-loaded, guards and null results intact) along with the ADR and doc-comment copies, which are not always-loaded.

### Follow-up

The claim-table row is **generic, not Pastura-specific** — a claude-kit promotion candidate (`knowledge-layering.md` reconcile is one-way kit→Pastura, so it is not actioned here).

## Test plan

- `swiftlint lint --quiet --strict` + `xcodebuild build` + every pre-commit sub-gate — green on all four Swift-touching commits (nav-map, serialization, `imagerenderer-injection` self-tests all passed)
- The unit suite was **not** run: the only Swift change is a doc comment (`git diff` filtered to non-`///` lines returns zero), verified independently by the reviewer
- Probe matrix + real-target cell as tabled above; the cell-(c) source mutation was reverted and `git status` confirmed clean before each commit
- Recipe validated with **both** controls: it reddens on the bad shape and passes on the same shape minus the conformance

## Device QA

実機QA不要 — documentation and one doc comment; no runtime, layout, or appearance surface is touched.

Closes #1439

