### PR TITLE
♿ fix: PredictionOutcomeBadge の muted 2ラベルを AA 適合トークンへ

### DIFF
--- a/.claude/rules/view-testing.md
+++ b/.claude/rules/view-testing.md
@@ -61,6 +61,16 @@ value* it carries to `DesignTokensTests`. Probe + the fixed-appearance exception
 `ScenarioBadgeStyleTokenTests` (#1296) and `swiftui-traps.md` § "`ImageRenderer`
 does not inherit the ambient environment".
 
+**Extracting a View's inline colours to make them pinnable leaves the pin blind
+to `body`.** Before the extraction one place decides the colour; after it there
+are two, and a pin reading the accessor stays green when `body` re-inlines a
+token. The pin cannot carry the claim it rests on. Keep `body` free of `Color.`
+references so the divergence is a grep rather than a device-only surprise, and
+state that where the extraction lives — ADR-009 rules out the snapshot that
+would close it mechanically. Worked instance: `PredictionOutcomeBadge` +
+`PredictionOutcomeBadgeTokenTests` (#1427). `ContradictionBadge` is the same
+shape, not yet extracted, and stays code-review-gated until it is.
+
 Canonical example: `LanguageDriftToastLayout` + `LanguageDriftToastLayoutTests`
 (the `.languageMismatch` drift toast; #456 / ADR-009 § Amendment 2026-06-23).
 

--- a/.claude/rules/view-testing.md
+++ b/.claude/rules/view-testing.md
@@ -61,15 +61,13 @@ value* it carries to `DesignTokensTests`. Probe + the fixed-appearance exception
 `ScenarioBadgeStyleTokenTests` (#1296) and `swiftui-traps.md` § "`ImageRenderer`
 does not inherit the ambient environment".
 
-**Extracting a View's inline colours to make them pinnable leaves the pin blind
-to `body`.** Before the extraction one place decides the colour; after it there
-are two, and a pin reading the accessor stays green when `body` re-inlines a
-token. The pin cannot carry the claim it rests on. Keep `body` free of `Color.`
-references so the divergence is a grep rather than a device-only surprise, and
-state that where the extraction lives — ADR-009 rules out the snapshot that
-would close it mechanically. Worked instance: `PredictionOutcomeBadge` +
-`PredictionOutcomeBadgeTokenTests` (#1427). `ContradictionBadge` is the same
-shape, not yet extracted, and stays code-review-gated until it is.
+**Extracting a View's inline colours into accessors so a pin can read them leaves
+the pin blind to `body`**: two places now decide the colour, and a `body` that
+re-inlines a token diverges while the accessor pin stays green. ADR-009 rules out
+the snapshot that would close it mechanically, so keep `body` free of `Color.`
+references — the divergence is then a grep — and say so where the extraction
+lives. `PredictionOutcomeBadge` + `PredictionOutcomeBadgeTokenTests` (#1427);
+`ContradictionBadge` is the same shape, still inline and code-review-gated.
 
 Canonical example: `LanguageDriftToastLayout` + `LanguageDriftToastLayoutTests`
 (the `.languageMismatch` drift toast; #456 / ADR-009 § Amendment 2026-06-23).

--- a/Pastura/Pastura/Views/Components/PredictionOutcomeBadge.swift
+++ b/Pastura/Pastura/Views/Components/PredictionOutcomeBadge.swift
@@ -37,48 +37,28 @@ struct PredictionOutcomeBadge: View {
 
 extension PredictionOutcomeBadge {
 
-  /// Capsule fill: the §2.6-shaped `mossSoft` on a hit, the neutral card
-  /// surface on a miss.
   var fillToken: Color {
     isHit ? Color.mossSoft : Color.bubbleBackground
   }
 
-  /// Icon + primary label foreground.
-  ///
-  /// The hit arm takes `mossInk` for the opaque `mossSoft` capsule — the §2.6
-  /// `<family>Soft` + `<family>Ink` pairing, 6.537 light / 6.505 dark (#1407,
-  /// derivation in `ContradictionBadge`).
-  ///
-  /// The miss arm reads `inkSecondary` on `bubbleBackground` at 6.934 / 5.975,
-  /// replacing `muted`'s 3.475 / 3.021 — sub-AA in *both* appearances (#1427).
-  /// `metaBaseL3` would also clear the bar (8.577 / 8.161) and is what
-  /// design-system §8 names for must-read meta info, but it is rejected here on
-  /// **hierarchy**: at 8.6 the failure state would out-shout the hit arm's 6.5,
-  /// and ADR-028 records that a supporting element must not become the loudest
-  /// thing in the row. `inkSecondary` lands at parity instead.
+  /// Icon + primary label. Hit: §2.6's `<family>Soft` + `<family>Ink` pairing on
+  /// the opaque capsule, 6.537 light / 6.505 dark (#1407). Miss: `inkSecondary`
+  /// on `bubbleBackground`, 6.934 / 5.975, replacing `muted`'s sub-AA
+  /// 3.475 / 3.021. `metaBaseL3` clears the bar too, but at 8.6 the *failure*
+  /// state would out-shout the hit arm — rejection derived in ADR-028
+  /// § Amendment 2026-08-13 (#1427).
   var labelToken: Color {
     isHit ? Color.mossInk : Color.inkSecondary
   }
 
-  /// Streak sub-label foreground. Only rendered on the hit arm, so the ground is
-  /// always the opaque `mossSoft` capsule — which makes this the same §2.6
-  /// pairing as ``labelToken``'s hit arm, at 6.537 light / 6.505 dark. Replaces
-  /// `muted`, which measured 2.136 / 2.413 there — the worst `muted` instance in
-  /// the app (#1427).
+  /// Streak sub-label. Rendered on the hit arm only, so the ground is always the
+  /// opaque `mossSoft` capsule and the answer is ``labelToken``'s hit pairing.
+  /// The two quieter candidates were refused — `inkSecondary` reaches only 4.262
+  /// in light, `metaBaseL3` is a §2.4 rung — ADR-028 § Amendment 2026-08-13.
   ///
-  /// **Two quieter candidates were rejected on measurement, not taste.**
-  /// `inkSecondary` does not rescue this ground (4.262 light, though it *does*
-  /// pass at 4.772 in dark — the rejection is light-only). `metaBaseL3` clears it
-  /// at 5.272 / 6.518 and would have preserved colour subordination, but it is a
-  /// §2.4 DL-progress ladder rung: ADR-028 § "Three narrower rejections" refuses
-  /// borrowing one ("borrowing it would couple two families"), and
-  /// `DesignTokens+ExtendedPalette.swift` minted `headerMetaInk` at the *same
-  /// hex* rather than collapse the two. §8's binding requirement is the ratio;
-  /// the family that owns the ground supplies the token.
-  ///
-  /// **Accepted cost:** this is the same token as the hit label, so subordination
-  /// to "Correct!" rides on weight (`.medium` vs `.semibold`), not colour. Gated
-  /// on ADR-028 gate 4 device QA in both appearances.
+  /// **Accepted cost:** same token as the hit label, so subordination to
+  /// "Correct!" rides on weight, not colour. Pending ADR-028 gate 4 device QA in
+  /// both appearances.
   var streakToken: Color {
     Color.mossInk
   }

--- a/Pastura/Pastura/Views/Components/PredictionOutcomeBadge.swift
+++ b/Pastura/Pastura/Views/Components/PredictionOutcomeBadge.swift
@@ -5,6 +5,12 @@ import SwiftUI
 /// Shows the consecutive-hit streak when `streak >= 2` on a hit — the immediate
 /// end-of-run card passes it (the reward moment); the Past Results list omits it
 /// (`streak == nil`) for a quieter row.
+///
+/// Colours live in the accessors below rather than inline in `body`, so
+/// ``PredictionOutcomeBadgeTokenTests`` can pin which token each role reads
+/// (`.claude/rules/view-testing.md` § "Change-detector tripwire"). Keep `body`
+/// free of `Color.` references — a colour decided in both places can drift in
+/// one of them while the pin stays green.
 struct PredictionOutcomeBadge: View {
   let isHit: Bool
   var streak: Int?
@@ -18,22 +24,62 @@ struct PredictionOutcomeBadge: View {
       if isHit, let streak, streak >= 2 {
         Text(String(format: String(localized: "%lld in a row"), streak))
           .font(.caption.weight(.medium))
-          .foregroundStyle(Color.muted)
+          .foregroundStyle(streakToken)
       }
     }
-    // Hit arm takes `mossInk` for the opaque `mossSoft` capsule below — see
-    // `ContradictionBadge` for the derivation (#1407).
-    //
-    // The miss arm's `muted` is a separate, still-open gap — `muted` on
-    // `bubbleBackground` is 3.475 light / 3.021 dark, and the streak label
-    // above is `muted` on `mossSoft` at 2.136 / 2.413. Neither is reachable by
-    // a moss-family change; tracked in #1427.
-    .foregroundStyle(isHit ? Color.mossInk : Color.muted)
+    .foregroundStyle(labelToken)
     .padding(.horizontal, 10)
     .padding(.vertical, 5)
-    .background(
-      Capsule().fill(isHit ? Color.mossSoft : Color.bubbleBackground)
-    )
+    .background(Capsule().fill(fillToken))
     .accessibilityElement(children: .combine)
+  }
+}
+
+extension PredictionOutcomeBadge {
+
+  /// Capsule fill: the §2.6-shaped `mossSoft` on a hit, the neutral card
+  /// surface on a miss.
+  var fillToken: Color {
+    isHit ? Color.mossSoft : Color.bubbleBackground
+  }
+
+  /// Icon + primary label foreground.
+  ///
+  /// The hit arm takes `mossInk` for the opaque `mossSoft` capsule — the §2.6
+  /// `<family>Soft` + `<family>Ink` pairing, 6.537 light / 6.505 dark (#1407,
+  /// derivation in `ContradictionBadge`).
+  ///
+  /// The miss arm reads `inkSecondary` on `bubbleBackground` at 6.934 / 5.975,
+  /// replacing `muted`'s 3.475 / 3.021 — sub-AA in *both* appearances (#1427).
+  /// `metaBaseL3` would also clear the bar (8.577 / 8.161) and is what
+  /// design-system §8 names for must-read meta info, but it is rejected here on
+  /// **hierarchy**: at 8.6 the failure state would out-shout the hit arm's 6.5,
+  /// and ADR-028 records that a supporting element must not become the loudest
+  /// thing in the row. `inkSecondary` lands at parity instead.
+  var labelToken: Color {
+    isHit ? Color.mossInk : Color.inkSecondary
+  }
+
+  /// Streak sub-label foreground. Only rendered on the hit arm, so the ground is
+  /// always the opaque `mossSoft` capsule — which makes this the same §2.6
+  /// pairing as ``labelToken``'s hit arm, at 6.537 light / 6.505 dark. Replaces
+  /// `muted`, which measured 2.136 / 2.413 there — the worst `muted` instance in
+  /// the app (#1427).
+  ///
+  /// **Two quieter candidates were rejected on measurement, not taste.**
+  /// `inkSecondary` does not rescue this ground (4.262 light, though it *does*
+  /// pass at 4.772 in dark — the rejection is light-only). `metaBaseL3` clears it
+  /// at 5.272 / 6.518 and would have preserved colour subordination, but it is a
+  /// §2.4 DL-progress ladder rung: ADR-028 § "Three narrower rejections" refuses
+  /// borrowing one ("borrowing it would couple two families"), and
+  /// `DesignTokens+ExtendedPalette.swift` minted `headerMetaInk` at the *same
+  /// hex* rather than collapse the two. §8's binding requirement is the ratio;
+  /// the family that owns the ground supplies the token.
+  ///
+  /// **Accepted cost:** this is the same token as the hit label, so subordination
+  /// to "Correct!" rides on weight (`.medium` vs `.semibold`), not colour. Gated
+  /// on ADR-028 gate 4 device QA in both appearances.
+  var streakToken: Color {
+    Color.mossInk
   }
 }

--- a/Pastura/PasturaTests/Views/DesignTokensTests+MossSoftGround.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+MossSoftGround.swift
@@ -26,18 +26,16 @@ extension DesignTokensTests {
   /// token's ten callsites as seven line/border jobs plus three tinted fills
   /// under `mossInk` text.
   ///
-  /// **That corroboration is about grounds, and this list is about labels** —
-  /// four entries against three fills, because `PredictionOutcomeBadge`'s hit
-  /// capsule carries two of them. Do not "reconcile" the counts; they measure
-  /// different things.
+  /// **That corroboration counts grounds, this list counts labels** — four
+  /// entries against three fills, because `PredictionOutcomeBadge`'s hit capsule
+  /// carries two. Do not "reconcile" them.
   ///
-  /// The blind spot the two share is structural and outlives the count: both
-  /// start from `mossSoft` **fill** sites, so neither can see a label drawn on
-  /// this ground by a token from another family. There was one until #1427 —
-  /// the streak sub-label below was `muted` at 2.136 light / 2.413 dark — and
-  /// there is none today, which is a fact about the current tree rather than a
-  /// property of this fixture. So still do not read this guard as "every label
-  /// on `mossSoft` clears AA"; it says the moss-family ones do.
+  /// The blind spot they share outlives the count: both start from `mossSoft`
+  /// **fill** sites, so neither sees a label drawn on this ground by another
+  /// family's token. #1427 repointed the last one (the streak sub-label, `muted`
+  /// at 2.136 / 2.413), but that is a fact about today's tree, not a property of
+  /// this fixture — so still read this guard as "the moss-family labels clear
+  /// AA", never "every label on `mossSoft` does".
   static let mossSoftTextSites = [
     "ContradictionBadge",
     "PredictionOutcomeBadge.hitArm",
@@ -45,7 +43,7 @@ extension DesignTokensTests {
     "HighlightCandidatesSection.revealedChip"
   ]
 
-  /// WCAG 1.4.3 normal-text bar. All three labels are under the "large text"
+  /// WCAG 1.4.3 normal-text bar. All four labels are under the "large text"
   /// threshold (≥14pt bold / ≥18pt regular) — the largest is `caption`-class at
   /// ~12pt and the chip is 10pt bold — so 3:1 never applies to any of them.
   private static let textBar = 4.5
@@ -100,12 +98,10 @@ extension DesignTokensTests {
   /// *differ* can never fire while either side is a `PasturaDynamicColor`-backed
   /// pair, since those compare by provider instance.
   ///
-  /// `PredictionOutcomeBadge` is no longer the gap this comment used to record:
-  /// #1427 extracted its colours out of `body` into accessors, and
-  /// ``PredictionOutcomeBadgeTokenTests`` pins both of its labels there. That
-  /// leaves `ContradictionBadge`, which still builds its colours inline with no
-  /// extractable style type and stays code-review-gated; the same extraction is
-  /// the way to close it, and is not done here.
+  /// `PredictionOutcomeBadge` has its own pin since #1427 extracted its colours
+  /// into accessors (``PredictionOutcomeBadgeTokenTests``). That leaves
+  /// `ContradictionBadge`, still inline with no extractable style type and so
+  /// code-review-gated; the same extraction would close it.
   @Test func revealedChipReadsMossInk() {
     let style = HighlightCandidatesSection.ChipStyle(reason: .revealed)
     #expect(style.textColor == Color.mossInk)

--- a/Pastura/PasturaTests/Views/DesignTokensTests+MossSoftGround.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+MossSoftGround.swift
@@ -16,26 +16,32 @@ import Testing
 // lives at the foot of `DesignTokensTests+NightPalette.swift`.
 extension DesignTokensTests {
 
-  /// The three shipped views that lay text directly on an opaque `mossSoft`
+  /// The shipped **labels** that lay text directly on an opaque `mossSoft`
   /// capsule. Hand-written against the views rather than derived, so a view
   /// changing its ground does **not** silently update the expectation — the row
   /// goes stale and a reviewer has to look.
   ///
-  /// Exhaustive as of #1407 **for moss-family text**, and corroborated rather
+  /// Exhaustive as of #1427 **for moss-family text**, and corroborated rather
   /// than merely grepped: `nightMossSoft`'s own doc comment partitions the
-  /// token's ten callsites as seven line/border jobs plus exactly these three
-  /// text grounds.
+  /// token's ten callsites as seven line/border jobs plus three tinted fills
+  /// under `mossInk` text.
   ///
-  /// That corroboration shares this list's blind spot, though — both enumerate
-  /// `mossSoft` **fill** sites, so neither can see a label drawn on this ground
-  /// by a token from another family. **There is one, and it fails the bar**:
-  /// `PredictionOutcomeBadge`'s streak sub-label is `muted` *inside* the same
-  /// hit-arm capsule, at 2.136 light / 2.413 dark (#1427). So do not read this
-  /// guard as "every label on `mossSoft` clears AA" — it says the moss-family
-  /// ones do.
+  /// **That corroboration is about grounds, and this list is about labels** —
+  /// four entries against three fills, because `PredictionOutcomeBadge`'s hit
+  /// capsule carries two of them. Do not "reconcile" the counts; they measure
+  /// different things.
+  ///
+  /// The blind spot the two share is structural and outlives the count: both
+  /// start from `mossSoft` **fill** sites, so neither can see a label drawn on
+  /// this ground by a token from another family. There was one until #1427 —
+  /// the streak sub-label below was `muted` at 2.136 light / 2.413 dark — and
+  /// there is none today, which is a fact about the current tree rather than a
+  /// property of this fixture. So still do not read this guard as "every label
+  /// on `mossSoft` clears AA"; it says the moss-family ones do.
   static let mossSoftTextSites = [
     "ContradictionBadge",
     "PredictionOutcomeBadge.hitArm",
+    "PredictionOutcomeBadge.streak",
     "HighlightCandidatesSection.revealedChip"
   ]
 
@@ -52,7 +58,7 @@ extension DesignTokensTests {
     // list wouldn't make them vacuous — it would silently drop the record of
     // which views this guard speaks for. Residual: it catches a row added or
     // removed, never one *renamed* to a view that no longer draws on this ground.
-    #expect(Self.mossSoftTextSites.count == 3)
+    #expect(Self.mossSoftTextSites.count == 4)
 
     let light = contrastRatio(PasturaPalette.mossInk, PasturaPalette.mossSoft)
     #expect(light >= Self.textBar, "light: \(light)")
@@ -94,10 +100,12 @@ extension DesignTokensTests {
   /// *differ* can never fire while either side is a `PasturaDynamicColor`-backed
   /// pair, since those compare by provider instance.
   ///
-  /// Only the chip is reachable: `ContradictionBadge` and
-  /// `PredictionOutcomeBadge` build their colours inline in `body` with no
-  /// extractable style type, so they stay code-review-gated. Extracting a style
-  /// struct for them would be the way to close that, and is not done here.
+  /// `PredictionOutcomeBadge` is no longer the gap this comment used to record:
+  /// #1427 extracted its colours out of `body` into accessors, and
+  /// ``PredictionOutcomeBadgeTokenTests`` pins both of its labels there. That
+  /// leaves `ContradictionBadge`, which still builds its colours inline with no
+  /// extractable style type and stays code-review-gated; the same extraction is
+  /// the way to close it, and is not done here.
   @Test func revealedChipReadsMossInk() {
     let style = HighlightCandidatesSection.ChipStyle(reason: .revealed)
     #expect(style.textColor == Color.mossInk)

--- a/Pastura/PasturaTests/Views/DesignTokensTests+MutedAsContent.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+MutedAsContent.swift
@@ -5,19 +5,13 @@ import Testing
 
 // Contrast guard for `muted` used as **content** text (#1427).
 //
-// The token's value is not the defect. design-system §8 records `muted` as a
-// deliberately sub-AA "quietude" tier, exempt from the 4.5:1 bar, with a
-// standing instruction not to place must-read information there. What this file
-// pins is the *shape* of that exemption: §8 justifies it with one measurement,
-// «#FCFAF4 上で ≈ 3.3:1» — the `screenBackground` ground — and the token degrades
-// well past that figure on the other grounds the app ships. A label that is
-// legitimately ambient on the page ground can be sitting at 2.136 on a tinted
-// capsule while still reading as sanctioned.
-//
-// So these arms are not "muted is broken, fix it". They are the record that the
-// exemption is ground-relative, so a future reader repointing a `muted` label
-// can see which grounds the §8 figure does and does not speak for. The
-// app-wide sweep of the remaining sites is #1448.
+// The token's value is not the defect: design-system §8 makes `muted` a
+// deliberately sub-AA "quietude" tier, exempt from the 4.5:1 bar. What these arms
+// pin is the *shape* of that exemption — §8 justifies it with one measurement
+// («#FCFAF4 上で ≈ 3.3:1», the `screenBackground` ground), and the token degrades
+// well past it on the other grounds the app ships, so a label legitimately
+// ambient on the page ground can sit at 2.136 on a tinted capsule and still read
+// as sanctioned. The app-wide sweep of the remaining sites is #1448.
 //
 // Sibling-file extension rather than a fresh `@Suite`, per
 // `.claude/rules/testing.md` § "Splitting a Suite Across Files". `contrastRatio`
@@ -33,17 +27,12 @@ extension DesignTokensTests {
   /// `PasturaDynamicPalette.all`, which would sweep in fills that never carry
   /// text.
   ///
-  /// Deliberately **not** "grounds `muted` is drawn on today". After #1427 no
-  /// `muted` label sits on `mossSoft` at all — `DesignTokensTests+MossSoftGround`
-  /// says so in as many words — and which of the others still carry one is the
-  /// per-site question #1448 answers. The bar applies to the ground either way,
-  /// so scoping this fixture to current occupancy would make it churn on every
-  /// unrelated repoint.
+  /// Deliberately **not** "grounds `muted` is drawn on today" — occupancy is the
+  /// per-site question #1448 answers, and scoping to it would churn this fixture
+  /// on every unrelated repoint. The bar applies to the ground either way.
   ///
-  /// The two lists are deliberately symmetric — six against six. An earlier
-  /// draft of #1427 enumerated five dark grounds, omitting `nightPromoBackground`,
-  /// and reported a "worst case" that was accordingly wrong; the count pins below
-  /// are what make that shape visible instead of silent.
+  /// The two lists are symmetric, six against six, and the count pins below are
+  /// what keep an omission from silently skewing a "worst case".
   private static let mutedLightGrounds: [(name: String, ratio: Double)] = [
     ("screenBackground", contrastRatio(PasturaPalette.muted, PasturaPalette.screenBackground)),
     ("page", contrastRatio(PasturaPalette.muted, PasturaPalette.page)),
@@ -68,15 +57,12 @@ extension DesignTokensTests {
     ("nightMossSoft", contrastRatio(PasturaPalette.nightMuted, PasturaPalette.nightMossSoft))
   ]
 
-  /// `muted` clears the bar on **no** ground the app ships, in either appearance.
-  ///
-  /// This is the arm that makes §8's exemption legible: it is not "close enough
-  /// everywhere", it is 2.1–4.2 against a 4.5 bar. Anything placed in this tier
-  /// is being placed below AA deliberately.
+  /// `muted` clears the bar on **no** ground the app ships, in either appearance:
+  /// not "close enough everywhere" but 2.1–4.2 against a 4.5 bar, so anything
+  /// placed in this tier is placed below AA deliberately.
   @Test func mutedIsSubAAOnEveryGroundItShipsOn() {
     // Anti-vacuity: the loops iterate these literals, so an emptied array would
-    // pass silently. Six per appearance — see the fixture's doc comment for why
-    // the symmetry is load-bearing.
+    // pass silently.
     #expect(Self.mutedLightGrounds.count == 6)
     #expect(Self.mutedDarkGrounds.count == 6)
 
@@ -88,15 +74,13 @@ extension DesignTokensTests {
     }
   }
 
-  /// The narrowest margin, pinned **by name** rather than as a range.
+  /// The narrowest margin, pinned **by name** rather than as a range — a range
+  /// reads as a safety claim while hiding which ground is nearest the bar, and
+  /// goes stale the moment a ground is added or retuned.
   ///
-  /// A range ("2.1–4.2, all sub-AA") reads as a safety claim while hiding which
-  /// ground is nearest the bar, and it is exactly what goes stale when a ground
-  /// is added or retuned. `nightMuted` on `nightPage` sits **7.7%** below 4.5,
-  /// where the narrowest *light* margin — `muted` on `bubbleBackground` at
-  /// 3.475 — is **22.8%**. So a modest retune of either token flips this ground
-  /// first, and it is the one to re-measure. Both narrowest grounds are
-  /// asserted by name below rather than left to the prose.
+  /// `nightMuted` on `nightPage` sits **7.7%** below 4.5 against **22.8%** for
+  /// the narrowest light ground (`bubbleBackground`, 3.475), so a modest retune
+  /// of either token flips `nightPage` first and that is the one to re-measure.
   @Test func nightPageIsTheGroundNearestTheBar() {
     let worst = Self.mutedDarkGrounds.max(by: { $0.ratio < $1.ratio })
     #expect(worst?.name == "nightPage", "narrowest dark margin moved to \(worst?.name ?? "nil")")
@@ -109,12 +93,9 @@ extension DesignTokensTests {
     #expect((worst?.ratio ?? 0) < Self.contentTextBar, "nightPage: \(worst?.ratio ?? 0)")
   }
 
-  /// The two repoints #1427 shipped, on their real grounds.
-  ///
-  /// `PredictionOutcomeBadge`'s miss arm takes `inkSecondary` on the neutral card
-  /// surface; its streak sub-label takes `mossInk` on the opaque `mossSoft`
-  /// capsule — the §2.6 `<family>Soft` + `<family>Ink` pairing that #1407 already
-  /// applied to the same badge's hit arm.
+  /// The two repoints #1427 shipped, on their real grounds: `PredictionOutcomeBadge`'s
+  /// miss arm on the neutral card surface, its streak sub-label on the opaque
+  /// `mossSoft` capsule (the §2.6 pairing #1407 gave the same badge's hit arm).
   @Test func bothPredictionBadgeRepointsClearTheBar() {
     let missLight = contrastRatio(PasturaPalette.inkSecondary, PasturaPalette.bubbleBackground)
     #expect(missLight >= Self.contentTextBar, "miss light: \(missLight)")
@@ -128,18 +109,14 @@ extension DesignTokensTests {
   }
 
   /// Negative control for the streak ground — **light only**, and the asymmetry
-  /// is the point.
+  /// is the point. `inkSecondary` is the obvious quieter candidate and the token
+  /// the miss arm above *does* ship; it simply does not reach here, at 4.262 in
+  /// light while **dark** clears at 4.772. A symmetric "inkSecondary fails here"
+  /// would be false in one appearance.
   ///
-  /// `inkSecondary` is the obvious candidate for a quieter sub-label, and it is
-  /// the token the miss arm above *does* ship. It simply does not reach on this
-  /// ground: 4.262 in light. In **dark** it clears at 4.772, so a symmetric
-  /// "inkSecondary fails here" claim would be false in one appearance — the same
-  /// per-appearance care ADR-028 takes over #1407 (light-only) versus #1408
-  /// (dark-only).
-  ///
-  /// Read together with ``bothPredictionBadgeRepointsClearTheBar``: the same
-  /// token is shipped on `bubbleBackground` and rejected on `mossSoft`, in one
-  /// PR. That is a statement about grounds, not about the token.
+  /// Read with ``bothPredictionBadgeRepointsClearTheBar``: one token shipped on
+  /// `bubbleBackground` and refused on `mossSoft` is a statement about grounds,
+  /// not about the token.
   @Test func inkSecondaryDoesNotRescueTheStreakOnMossSoftInLight() {
     let light = contrastRatio(PasturaPalette.inkSecondary, PasturaPalette.mossSoft)
     #expect(light < Self.contentTextBar, "expected sub-AA in light, got \(light)")
@@ -148,19 +125,14 @@ extension DesignTokensTests {
     #expect(dark >= Self.contentTextBar, "dark was supposed to be passing already: \(dark)")
   }
 
-  /// `metaBaseL3` **would** have worked, and was rejected on convention.
+  /// `metaBaseL3` **would** have worked (5.272 / 6.518 on the streak ground) and
+  /// would have kept the colour-based subordination `mossInk` gives up. Pinned so
+  /// the next reader does not "discover" it as an unmeasured option: it is
+  /// refused as a §2.4 DL-progress rung, per ADR-028 § "Three narrower
+  /// rejections".
   ///
-  /// Pinned so the next reader does not "discover" it as an unmeasured option.
-  /// It clears the bar on the streak ground (5.272 / 6.518) and would have kept
-  /// colour-based subordination to "Correct!", which `mossInk` gives up. It is
-  /// refused because it is a §2.4 DL-progress ladder rung: ADR-028 § "Three
-  /// narrower rejections" declines to borrow one ("borrowing it would couple two
-  /// families"), and `DesignTokens+ExtendedPalette.swift` minted `headerMetaInk`
-  /// at the *same hex* rather than collapse the two roles.
-  ///
-  /// **So a failure here means the ratio moved, not that the decision changed.**
-  /// If this arm ever drops below the bar, `metaBaseL3` or `mossSoft` was
-  /// retuned — the §2.4 coupling argument is unaffected either way.
+  /// **A failure here means the ratio moved, not that the decision changed** —
+  /// the §2.4 coupling argument is unaffected either way.
   @Test func metaBaseL3ClearsTheStreakGroundButIsARungNotARole() {
     let light = contrastRatio(PasturaPalette.metaBaseL3, PasturaPalette.mossSoft)
     #expect(light >= Self.contentTextBar, "metaBaseL3 light: \(light)")

--- a/Pastura/PasturaTests/Views/DesignTokensTests+MutedAsContent.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+MutedAsContent.swift
@@ -1,0 +1,161 @@
+import SwiftUI
+import Testing
+
+@testable import Pastura
+
+// Contrast guard for `muted` used as **content** text (#1427).
+//
+// The token's value is not the defect. design-system §8 records `muted` as a
+// deliberately sub-AA "quietude" tier, exempt from the 4.5:1 bar, with a
+// standing instruction not to place must-read information there. What this file
+// pins is the *shape* of that exemption: §8 justifies it with one measurement,
+// «#FCFAF4 上で ≈ 3.3:1» — the `screenBackground` ground — and the token degrades
+// well past that figure on the other grounds the app ships. A label that is
+// legitimately ambient on the page ground can be sitting at 2.136 on a tinted
+// capsule while still reading as sanctioned.
+//
+// So these arms are not "muted is broken, fix it". They are the record that the
+// exemption is ground-relative, so a future reader repointing a `muted` label
+// can see which grounds the §8 figure does and does not speak for. The
+// app-wide sweep of the remaining sites is #1448.
+//
+// Sibling-file extension rather than a fresh `@Suite`, per
+// `.claude/rules/testing.md` § "Splitting a Suite Across Files". `contrastRatio`
+// lives at the foot of `DesignTokensTests+NightPalette.swift`.
+extension DesignTokensTests {
+
+  /// WCAG 1.4.3 normal-text bar. Both #1427 labels are `caption`-class (~12pt),
+  /// under the "large text" threshold, so 3:1 never applies to either.
+  private static let contentTextBar = 4.5
+
+  /// Every opaque ground `muted` is drawn on, per appearance. Hand-written
+  /// against the palette rather than derived from `PasturaDynamicPalette.all`,
+  /// which would sweep in fills that never carry text.
+  ///
+  /// The two lists are deliberately symmetric — six against six. An earlier
+  /// draft of #1427 enumerated five dark grounds, omitting `nightPromoBackground`,
+  /// and reported a "worst case" that was accordingly wrong; the count pins below
+  /// are what make that shape visible instead of silent.
+  private static let mutedLightGrounds: [(name: String, ratio: Double)] = [
+    ("screenBackground", contrastRatio(PasturaPalette.muted, PasturaPalette.screenBackground)),
+    ("page", contrastRatio(PasturaPalette.muted, PasturaPalette.page)),
+    ("bubbleBackground", contrastRatio(PasturaPalette.muted, PasturaPalette.bubbleBackground)),
+    ("whisperBubble", contrastRatio(PasturaPalette.muted, PasturaPalette.whisperBubble)),
+    ("promoBackground", contrastRatio(PasturaPalette.muted, PasturaPalette.promoBackground)),
+    ("mossSoft", contrastRatio(PasturaPalette.muted, PasturaPalette.mossSoft))
+  ]
+
+  private static let mutedDarkGrounds: [(name: String, ratio: Double)] = [
+    ("nightBackground", contrastRatio(PasturaPalette.nightMuted, PasturaPalette.nightBackground)),
+    ("nightPage", contrastRatio(PasturaPalette.nightMuted, PasturaPalette.nightPage)),
+    ("nightBubble", contrastRatio(PasturaPalette.nightMuted, PasturaPalette.nightBubble)),
+    (
+      "nightWhisperBubble",
+      contrastRatio(PasturaPalette.nightMuted, PasturaPalette.nightWhisperBubble)
+    ),
+    (
+      "nightPromoBackground",
+      contrastRatio(PasturaPalette.nightMuted, PasturaPalette.nightPromoBackground)
+    ),
+    ("nightMossSoft", contrastRatio(PasturaPalette.nightMuted, PasturaPalette.nightMossSoft))
+  ]
+
+  /// `muted` clears the bar on **no** ground the app ships, in either appearance.
+  ///
+  /// This is the arm that makes §8's exemption legible: it is not "close enough
+  /// everywhere", it is 2.1–4.2 against a 4.5 bar. Anything placed in this tier
+  /// is being placed below AA deliberately.
+  @Test func mutedIsSubAAOnEveryGroundItShipsOn() {
+    // Anti-vacuity: the loops iterate these literals, so an emptied array would
+    // pass silently. Six per appearance — see the fixture's doc comment for why
+    // the symmetry is load-bearing.
+    #expect(Self.mutedLightGrounds.count == 6)
+    #expect(Self.mutedDarkGrounds.count == 6)
+
+    for ground in Self.mutedLightGrounds {
+      #expect(ground.ratio < Self.contentTextBar, "light \(ground.name): \(ground.ratio)")
+    }
+    for ground in Self.mutedDarkGrounds {
+      #expect(ground.ratio < Self.contentTextBar, "dark \(ground.name): \(ground.ratio)")
+    }
+  }
+
+  /// The narrowest margin, pinned **by name** rather than as a range.
+  ///
+  /// A range ("2.1–4.2, all sub-AA") reads as a safety claim while hiding which
+  /// ground is nearest the bar, and it is exactly what goes stale when a ground
+  /// is added or retuned. `nightMuted` on `nightPage` sits **8%** below 4.5, not
+  /// the ~19% the light figures alone would suggest — so a modest retune of
+  /// either token flips this ground first, and it is the one to re-measure.
+  @Test func nightPageIsTheGroundNearestTheBar() {
+    let worst = Self.mutedDarkGrounds.max(by: { $0.ratio < $1.ratio })
+    #expect(worst?.name == "nightPage", "narrowest dark margin moved to \(worst?.name ?? "nil")")
+
+    let lightWorst = Self.mutedLightGrounds.max(by: { $0.ratio < $1.ratio })
+    #expect(lightWorst?.name == "bubbleBackground", "narrowest light margin moved")
+
+    // Still sub-AA — if this ever passes the bar, §8's framing needs re-deriving
+    // before anything here is "fixed".
+    #expect((worst?.ratio ?? 0) < Self.contentTextBar, "nightPage: \(worst?.ratio ?? 0)")
+  }
+
+  /// The two repoints #1427 shipped, on their real grounds.
+  ///
+  /// `PredictionOutcomeBadge`'s miss arm takes `inkSecondary` on the neutral card
+  /// surface; its streak sub-label takes `mossInk` on the opaque `mossSoft`
+  /// capsule — the §2.6 `<family>Soft` + `<family>Ink` pairing that #1407 already
+  /// applied to the same badge's hit arm.
+  @Test func bothPredictionBadgeRepointsClearTheBar() {
+    let missLight = contrastRatio(PasturaPalette.inkSecondary, PasturaPalette.bubbleBackground)
+    #expect(missLight >= Self.contentTextBar, "miss light: \(missLight)")
+    let missDark = contrastRatio(PasturaPalette.nightInkSecondary, PasturaPalette.nightBubble)
+    #expect(missDark >= Self.contentTextBar, "miss dark: \(missDark)")
+
+    let streakLight = contrastRatio(PasturaPalette.mossInk, PasturaPalette.mossSoft)
+    #expect(streakLight >= Self.contentTextBar, "streak light: \(streakLight)")
+    let streakDark = contrastRatio(PasturaPalette.nightMossInk, PasturaPalette.nightMossSoft)
+    #expect(streakDark >= Self.contentTextBar, "streak dark: \(streakDark)")
+  }
+
+  /// Negative control for the streak ground — **light only**, and the asymmetry
+  /// is the point.
+  ///
+  /// `inkSecondary` is the obvious candidate for a quieter sub-label, and it is
+  /// the token the miss arm above *does* ship. It simply does not reach on this
+  /// ground: 4.262 in light. In **dark** it clears at 4.772, so a symmetric
+  /// "inkSecondary fails here" claim would be false in one appearance — the same
+  /// per-appearance care ADR-028 takes over #1407 (light-only) versus #1408
+  /// (dark-only).
+  ///
+  /// Read together with ``bothPredictionBadgeRepointsClearTheBar``: the same
+  /// token is shipped on `bubbleBackground` and rejected on `mossSoft`, in one
+  /// PR. That is a statement about grounds, not about the token.
+  @Test func inkSecondaryDoesNotRescueTheStreakOnMossSoftInLight() {
+    let light = contrastRatio(PasturaPalette.inkSecondary, PasturaPalette.mossSoft)
+    #expect(light < Self.contentTextBar, "expected sub-AA in light, got \(light)")
+
+    let dark = contrastRatio(PasturaPalette.nightInkSecondary, PasturaPalette.nightMossSoft)
+    #expect(dark >= Self.contentTextBar, "dark was supposed to be passing already: \(dark)")
+  }
+
+  /// `metaBaseL3` **would** have worked, and was rejected on convention.
+  ///
+  /// Pinned so the next reader does not "discover" it as an unmeasured option.
+  /// It clears the bar on the streak ground (5.272 / 6.518) and would have kept
+  /// colour-based subordination to "Correct!", which `mossInk` gives up. It is
+  /// refused because it is a §2.4 DL-progress ladder rung: ADR-028 § "Three
+  /// narrower rejections" declines to borrow one ("borrowing it would couple two
+  /// families"), and `DesignTokens+ExtendedPalette.swift` minted `headerMetaInk`
+  /// at the *same hex* rather than collapse the two roles.
+  ///
+  /// **So a failure here means the ratio moved, not that the decision changed.**
+  /// If this arm ever drops below the bar, `metaBaseL3` or `mossSoft` was
+  /// retuned — the §2.4 coupling argument is unaffected either way.
+  @Test func metaBaseL3ClearsTheStreakGroundButIsARungNotARole() {
+    let light = contrastRatio(PasturaPalette.metaBaseL3, PasturaPalette.mossSoft)
+    #expect(light >= Self.contentTextBar, "metaBaseL3 light: \(light)")
+
+    let dark = contrastRatio(PasturaPalette.nightMetaBaseL3, PasturaPalette.nightMossSoft)
+    #expect(dark >= Self.contentTextBar, "metaBaseL3 dark: \(dark)")
+  }
+}

--- a/Pastura/PasturaTests/Views/DesignTokensTests+MutedAsContent.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+MutedAsContent.swift
@@ -28,9 +28,17 @@ extension DesignTokensTests {
   /// under the "large text" threshold, so 3:1 never applies to either.
   private static let contentTextBar = 4.5
 
-  /// Every opaque ground `muted` is drawn on, per appearance. Hand-written
-  /// against the palette rather than derived from `PasturaDynamicPalette.all`,
-  /// which would sweep in fills that never carry text.
+  /// Every opaque ground the app ships that `muted` is or could be drawn on,
+  /// per appearance. Hand-written against the palette rather than derived from
+  /// `PasturaDynamicPalette.all`, which would sweep in fills that never carry
+  /// text.
+  ///
+  /// Deliberately **not** "grounds `muted` is drawn on today". After #1427 no
+  /// `muted` label sits on `mossSoft` at all — `DesignTokensTests+MossSoftGround`
+  /// says so in as many words — and which of the others still carry one is the
+  /// per-site question #1448 answers. The bar applies to the ground either way,
+  /// so scoping this fixture to current occupancy would make it churn on every
+  /// unrelated repoint.
   ///
   /// The two lists are deliberately symmetric — six against six. An earlier
   /// draft of #1427 enumerated five dark grounds, omitting `nightPromoBackground`,
@@ -84,9 +92,11 @@ extension DesignTokensTests {
   ///
   /// A range ("2.1–4.2, all sub-AA") reads as a safety claim while hiding which
   /// ground is nearest the bar, and it is exactly what goes stale when a ground
-  /// is added or retuned. `nightMuted` on `nightPage` sits **8%** below 4.5, not
-  /// the ~19% the light figures alone would suggest — so a modest retune of
-  /// either token flips this ground first, and it is the one to re-measure.
+  /// is added or retuned. `nightMuted` on `nightPage` sits **7.7%** below 4.5,
+  /// where the narrowest *light* margin — `muted` on `bubbleBackground` at
+  /// 3.475 — is **22.8%**. So a modest retune of either token flips this ground
+  /// first, and it is the one to re-measure. Both narrowest grounds are
+  /// asserted by name below rather than left to the prose.
   @Test func nightPageIsTheGroundNearestTheBar() {
     let worst = Self.mutedDarkGrounds.max(by: { $0.ratio < $1.ratio })
     #expect(worst?.name == "nightPage", "narrowest dark margin moved to \(worst?.name ?? "nil")")

--- a/Pastura/PasturaTests/Views/PredictionOutcomeBadgeTokenTests.swift
+++ b/Pastura/PasturaTests/Views/PredictionOutcomeBadgeTokenTests.swift
@@ -7,34 +7,25 @@ import Testing
 /// (`.claude/rules/view-testing.md` § "Change-detector tripwire for
 /// code-review-gated tokens").
 ///
-/// **Why this is not tautological.** The badge is a purely visual surface with
-/// no logic to assert and no automated visual coverage — ADR-009 rules out
-/// snapshot tests. Until #1427 it was not pinnable at all: it built its colours
-/// inline in `body` with no extractable style type, which
-/// `DesignTokensTests+MossSoftGround` recorded as the reason only the
-/// `HighlightCandidatesSection` chip carried a consumer pin. The accessors this
-/// suite reads exist to close that.
+/// **Not tautological**: the badge is a purely visual surface with no logic to
+/// assert and no automated visual coverage (ADR-009 rules out snapshots). Until
+/// #1427 its colours were inline in `body` and could not be pinned at all.
 ///
-/// **A failure here is not a bug.** It means a code-review-gated token drifted —
-/// most likely in an unrelated refactor or an ADR-028 pairing slice. Confirm the
-/// change was intended and passed review, then update the expectation.
+/// **A failure here is not a bug** — a code-review-gated token drifted, most
+/// likely in an unrelated refactor or an ADR-028 pairing slice. Confirm the
+/// change passed review, then update the expectation.
 ///
-/// **What this suite cannot see.** It reads the accessors, not `body`. If a
-/// future edit re-inlines a colour in `body`, the accessor and the rendered
-/// value diverge and these pins stay green while the app ships wrong. That gap
-/// is held by the badge's own doc comment ("keep `body` free of `Color.`
-/// references") and by review, not by this file — a snapshot is the only
-/// mechanical closure and ADR-009 refuses it.
+/// **What it cannot see**: `body`. Re-inlining a colour there diverges from the
+/// accessor with these pins still green — held by the badge's doc comment and by
+/// review, per `.claude/rules/view-testing.md`.
 ///
-/// **Why assert the alias, not the hex.** Every token read here is
-/// trait-resolving (`PasturaDynamicPalette`), so an alias comparison pins *which
-/// token* the badge reads and leaves *what value* it carries to
-/// `DesignTokensTests`. Asserting two aliases **differ** would be structurally
-/// blind — see `ScenarioBadgeStyleTokenTests`' closing note for the probe.
+/// Aliases are asserted rather than hex values: every token here is
+/// trait-resolving, so this pins *which token* the badge reads and leaves *what
+/// value* it carries to `DesignTokensTests`. Asserting two aliases **differ**
+/// would be structurally blind (`ScenarioBadgeStyleTokenTests`' closing note).
 ///
-/// `@MainActor` is required because the suite reads `Color.*` statics and the
-/// accessors are themselves MainActor-isolated (`.claude/rules/swift-isolation.md`
-/// Pattern 5, fix order 1).
+/// `@MainActor` because the accessors and `Color.*` statics are MainActor-isolated
+/// (`.claude/rules/swift-isolation.md` Pattern 5, fix order 1).
 @MainActor
 @Suite(.timeLimit(.minutes(1)))
 struct PredictionOutcomeBadgeTokenTests {
@@ -48,26 +39,21 @@ struct PredictionOutcomeBadgeTokenTests {
   }
 
   /// `inkSecondary` on `bubbleBackground` = 6.934 / 5.975, replacing `muted`'s
-  /// 3.475 / 3.021 (sub-AA in both appearances, #1427). Not `metaBaseL3`
-  /// (8.577 / 8.161): that clears the bar but out-shouts the hit arm's 6.5, and
-  /// ADR-028 holds that a supporting element must not become the loudest thing
-  /// in the row.
+  /// sub-AA 3.475 / 3.021 (#1427). Not `metaBaseL3` (8.577 / 8.161) — it clears
+  /// the bar but out-shouts the hit arm's 6.5.
   @Test func missArmReadsInkSecondaryOnTheNeutralGround() {
     let badge = PredictionOutcomeBadge(isHit: false)
     #expect(badge.fillToken == Color.bubbleBackground)
     #expect(badge.labelToken == Color.inkSecondary)
   }
 
-  /// The streak sub-label renders only on the hit arm, so its ground is always
-  /// the opaque `mossSoft` capsule — same pairing as the hit label, 6.537 /
-  /// 6.505, replacing `muted`'s 2.136 / 2.413.
+  /// Ground is always the opaque `mossSoft` capsule, so this is the hit label's
+  /// pairing again (6.537 / 6.505), replacing `muted`'s 2.136 / 2.413.
   ///
-  /// Reading the *same* token as ``PredictionOutcomeBadge/labelToken``'s hit arm
-  /// is deliberate, not an oversight to be "fixed" by reaching for a quieter
-  /// one: the two rejected candidates are pinned as still-failing in
-  /// `DesignTokensTests+MutedAsContent`, and the §2.4 rung that would have
-  /// worked is refused by ADR-028 § "Three narrower rejections". Subordination
-  /// to "Correct!" is carried by weight (`.medium` vs `.semibold`).
+  /// Sharing ``PredictionOutcomeBadge/labelToken``'s token is deliberate, not an
+  /// oversight to "fix" with a quieter one — the rejected candidates are pinned
+  /// as still-failing in `DesignTokensTests+MutedAsContent`, and subordination
+  /// rides on weight instead.
   @Test func streakSubLabelTakesTheSameMossInkAsItsGroundRequires() {
     let badge = PredictionOutcomeBadge(isHit: true, streak: 3)
     #expect(badge.streakToken == Color.mossInk)

--- a/Pastura/PasturaTests/Views/PredictionOutcomeBadgeTokenTests.swift
+++ b/Pastura/PasturaTests/Views/PredictionOutcomeBadgeTokenTests.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+import Testing
+
+@testable import Pastura
+
+/// Change-detector for `PredictionOutcomeBadge`'s colour contract
+/// (`.claude/rules/view-testing.md` § "Change-detector tripwire for
+/// code-review-gated tokens").
+///
+/// **Why this is not tautological.** The badge is a purely visual surface with
+/// no logic to assert and no automated visual coverage — ADR-009 rules out
+/// snapshot tests. Until #1427 it was not pinnable at all: it built its colours
+/// inline in `body` with no extractable style type, which
+/// `DesignTokensTests+MossSoftGround` recorded as the reason only the
+/// `HighlightCandidatesSection` chip carried a consumer pin. The accessors this
+/// suite reads exist to close that.
+///
+/// **A failure here is not a bug.** It means a code-review-gated token drifted —
+/// most likely in an unrelated refactor or an ADR-028 pairing slice. Confirm the
+/// change was intended and passed review, then update the expectation.
+///
+/// **What this suite cannot see.** It reads the accessors, not `body`. If a
+/// future edit re-inlines a colour in `body`, the accessor and the rendered
+/// value diverge and these pins stay green while the app ships wrong. That gap
+/// is held by the badge's own doc comment ("keep `body` free of `Color.`
+/// references") and by review, not by this file — a snapshot is the only
+/// mechanical closure and ADR-009 refuses it.
+///
+/// **Why assert the alias, not the hex.** Every token read here is
+/// trait-resolving (`PasturaDynamicPalette`), so an alias comparison pins *which
+/// token* the badge reads and leaves *what value* it carries to
+/// `DesignTokensTests`. Asserting two aliases **differ** would be structurally
+/// blind — see `ScenarioBadgeStyleTokenTests`' closing note for the probe.
+///
+/// `@MainActor` is required because the suite reads `Color.*` statics and the
+/// accessors are themselves MainActor-isolated (`.claude/rules/swift-isolation.md`
+/// Pattern 5, fix order 1).
+@MainActor
+@Suite(.timeLimit(.minutes(1)))
+struct PredictionOutcomeBadgeTokenTests {
+
+  /// The §2.6 `<family>Soft` + `<family>Ink` pairing, 6.537 light / 6.505 dark
+  /// — the shape #1407 established for text on an opaque `mossSoft` ground.
+  @Test func hitArmReadsTheMossSoftInkPairing() {
+    let badge = PredictionOutcomeBadge(isHit: true)
+    #expect(badge.fillToken == Color.mossSoft)
+    #expect(badge.labelToken == Color.mossInk)
+  }
+
+  /// `inkSecondary` on `bubbleBackground` = 6.934 / 5.975, replacing `muted`'s
+  /// 3.475 / 3.021 (sub-AA in both appearances, #1427). Not `metaBaseL3`
+  /// (8.577 / 8.161): that clears the bar but out-shouts the hit arm's 6.5, and
+  /// ADR-028 holds that a supporting element must not become the loudest thing
+  /// in the row.
+  @Test func missArmReadsInkSecondaryOnTheNeutralGround() {
+    let badge = PredictionOutcomeBadge(isHit: false)
+    #expect(badge.fillToken == Color.bubbleBackground)
+    #expect(badge.labelToken == Color.inkSecondary)
+  }
+
+  /// The streak sub-label renders only on the hit arm, so its ground is always
+  /// the opaque `mossSoft` capsule — same pairing as the hit label, 6.537 /
+  /// 6.505, replacing `muted`'s 2.136 / 2.413.
+  ///
+  /// Reading the *same* token as ``PredictionOutcomeBadge/labelToken``'s hit arm
+  /// is deliberate, not an oversight to be "fixed" by reaching for a quieter
+  /// one: the two rejected candidates are pinned as still-failing in
+  /// `DesignTokensTests+MutedAsContent`, and the §2.4 rung that would have
+  /// worked is refused by ADR-028 § "Three narrower rejections". Subordination
+  /// to "Correct!" is carried by weight (`.medium` vs `.semibold`).
+  @Test func streakSubLabelTakesTheSameMossInkAsItsGroundRequires() {
+    let badge = PredictionOutcomeBadge(isHit: true, streak: 3)
+    #expect(badge.streakToken == Color.mossInk)
+  }
+
+  /// The streak accessor is ground-determined, not streak-value-determined —
+  /// it must not quietly acquire a branch on `streak`, which would put a
+  /// colour decision somewhere this suite's other arms do not look.
+  @Test func streakTokenDoesNotVaryWithTheStreakValue() {
+    #expect(PredictionOutcomeBadge(isHit: true, streak: 2).streakToken == Color.mossInk)
+    #expect(PredictionOutcomeBadge(isHit: true, streak: 99).streakToken == Color.mossInk)
+  }
+}

--- a/docs/decisions/ADR-028.md
+++ b/docs/decisions/ADR-028.md
@@ -32,7 +32,7 @@ week. Regenerate it rather than hand-editing:
 # Column: is this amendment referenced from outside the ADR at all?
 # Whitespace-normalized so hard-wrapped citations count; no extension filter,
 # because every one tried so far lost a file type.
-for n in 1283 1282 1313 1319 1325 1284 1336 1373 1378 1337 1327 1407; do
+for n in 1283 1282 1313 1319 1325 1284 1336 1373 1378 1337 1327 1407 1427; do
   c=0
   for f in $(git ls-files | grep -v '^docs/decisions/ADR-028.md'); do
     [ -f "$f" ] || continue
@@ -56,7 +56,8 @@ done
 | 2026-08-05 (#1378) | `PasturaShadows.tight`/`.soft` take #0B0C0A too, at α 0.03/0.13; pairing rejected, so §4.3.1's exception is dropped | ✓ |
 | 2026-08-06 (#1337) | The hazard is an omitted `colorScheme` injection, not an alias read — so the proposed A/B probe is **not shipped**, and a pre-commit/CI injection check is | ✓ |
 | 2026-08-08 (#1327) | `mossOnWash` #535D40 / `nightMossOnWash` #BDC6A4 — a **role token**, not a fifth §2.3 rung, solved by arm 3; the 0.400 ladder agreement is **not** an independent control, because #1325 constructed it | ✓ |
-| 2026-08-12 (#1407) | An **opaque** `mossSoft` fill takes `mossInk`, i.e. §2.6's Soft+Ink pairing — **no new token**, so the count stays 68. A pair-level assertion naming three views **stayed green** when those views repointed | — |
+| 2026-08-12 (#1407) | An **opaque** `mossSoft` fill takes `mossInk`, i.e. §2.6's Soft+Ink pairing — **no new token**, so the count stays 68. A pair-level assertion naming three views **stayed green** when those views repointed | ✓ |
+| 2026-08-13 (#1427) | §8's `muted` exemption is **ground-relative** — justified on one ground (≈3.3:1 on `screenBackground`) but 2.136–4.152 across the twelve shipped ones. The badge's last two `muted` labels take `inkSecondary` / `mossInk`, **no new token**; a §2.4 rung that measured fine was refused on the family-coupling rule | ✓ |
 
 **The "historical record you could delete" hypothesis does not hold, and that was
 measured rather than assumed.** #1382 proposed sorting these into what a reader
@@ -2572,13 +2573,87 @@ the value arms for exactly that reason — verified by mutation, where reverting
 the chip to `mossDark` reddens the consumer pin while all three value arms stay
 green.
 
-**Residue.** `PredictionOutcomeBadge` clears the bar on its hit *label* only. The
-same capsule's streak sub-label is `muted` on `mossSoft` (2.136 light / 2.413
-dark) and the miss arm is `muted` on `bubbleBackground` (3.475 / 3.021) — a
-different token family, unreachable by any moss-family change, tracked in #1427.
-The new guard's site enumeration is scoped accordingly — it is exhaustive for
-*moss-family* text on this ground, and that streak label is the standing
-counter-example to reading it as "every label on `mossSoft` clears the bar".
+**Residue — closed by #1427, § Amendment 2026-08-13.** `PredictionOutcomeBadge`
+cleared the bar on its hit *label* only: the same capsule's streak sub-label was
+`muted` on `mossSoft` (2.136 light / 2.413 dark) and the miss arm `muted` on
+`bubbleBackground` (3.475 / 3.021) — a different token family, unreachable by any
+moss-family change. The site enumeration this amendment added has since gained
+the streak label, so the counter-example it named to "every label on `mossSoft`
+clears the bar" is gone; the enumeration remains exhaustive for *moss-family*
+text on this ground, and its blind spot for other families is structural.
 
 This amendment retires the badge-control claims in § Amendment 2026-07-30
 (#1325), marked at that section's head.
+
+## Amendment 2026-08-13 — the quietude tier is ground-relative (#1427)
+
+`PredictionOutcomeBadge`'s last two `muted` labels move to tokens that clear the
+bar: the miss arm to `inkSecondary` on `bubbleBackground` (3.475 / 3.021 →
+**6.934 / 5.975**), and the streak sub-label to `mossInk` on the opaque
+`mossSoft` capsule (2.136 / 2.413 → **6.537 / 6.505**). No new value — the pair
+count stays **68**.
+
+**The defect was the application, not the token.** design-system §8 records
+`muted` as a deliberately sub-AA quietude tier, exempt from 4.5:1, with a
+standing instruction not to place must-read information there. Both labels were
+must-read: "Missed" is the badge's only label in that state, and a streak count
+appears nowhere else on the screen.
+
+**What §8 did not say, and now does.** Its exemption is justified with one
+measurement — «#FCFAF4 上で ≈ 3.3:1», the `screenBackground` ground — but `muted`
+runs 2.136–4.152 across the twelve grounds the app actually ships (six per
+appearance). So the tier is **ground-relative**: a label legitimately ambient on
+the page ground can sit at 2.136 on a tinted capsule and still read as
+sanctioned. `DesignTokensTests+MutedAsContent` pins all twelve, and pins the
+narrowest margin **by name** (`nightMuted`/`nightPage` at 4.152, 8% under the
+bar) rather than as a range that hides which ground moves first. The app-wide
+sweep of the remaining ~93 sites is #1448.
+
+**Why not §8's own remedy.** §8 routes must-read meta info to the §2.4 L3
+preset, and `metaBaseL3` does clear the streak ground (5.272 / 6.518) while
+keeping colour-based subordination that `mossInk` gives up. It is refused on the
+rule § "Three narrower rejections" already states for `metaStrongL1`: a §2.4 rung
+has a DL-progress job and borrowing it couples two families.
+`DesignTokens+ExtendedPalette.swift` is the precedent — when a non-DL slot needed
+exactly #4A4E3D it minted `headerMetaInk` at the same hex rather than collapse
+the roles. **§8's binding requirement is the ratio; the family that owns the
+ground supplies the token.** On an opaque `mossSoft` fill that is §2.3's
+`mossInk` pairing, the same answer § Amendment 2026-08-12 reached for #1407.
+
+The miss arm is a hierarchy call rather than a convention one. `metaBaseL3`
+would clear it too, at 8.577 / 8.161 — but that puts the *failure* state above
+the hit arm's 6.5, and § "Why not `mossInk`, when a shipped pill already uses it
+on a moss wash" holds that a supporting element must not become the loudest
+thing in the row. `inkSecondary` lands at parity instead.
+
+### The accepted cost, and the one thing device QA decides
+
+Streak and hit label are now the same token, so subordination rides on weight
+(`.caption.weight(.medium)` vs `.semibold`), not colour. The recorded rule
+forbids a supporting element being *louder*, not *equal*, so this is inside it —
+but "equal contrast still reads as subordinate" is a visual claim no test holds.
+Gate 4 QA in **both** appearances decides it, against a falsifiable criterion:
+*the streak must still read as secondary to "Correct!", with weight alone
+distinguishing them.* If it reads as a co-equal second label, the remedy is to
+re-ground it off the capsule onto `bubbleBackground` with `inkSecondary`
+(6.934 / 5.975) — deliberately **not** carried as an in-PR fallback, because it
+is a layout change to a shipped component and would land after review without
+its own critique.
+
+### Two verifications worth carrying
+
+The badge's colours moved out of `body` into accessors so
+`PredictionOutcomeBadgeTokenTests` can pin them — closing the gap
+`DesignTokensTests+MossSoftGround` recorded, where only the
+`HighlightCandidatesSection` chip was reachable. **That extraction creates its
+own failure mode**: accessor and `body` can diverge, and the pin cannot see
+`body`. It is held by keeping `body` free of `Color.` references, checkable by
+grep, not by the pin.
+
+Both new guards were verified by mutation rather than by their success case.
+Reverting either accessor to `Color.muted` reddens exactly the three pins for the
+repointed roles while the untouched hit-arm pin stays green; dropping `nightPage`
+from the ground fixture reddens the count pin *and* the by-name margin
+assertion. The second is not hypothetical — an earlier draft of this change
+enumerated five dark grounds, omitted `nightPromoBackground`, and reported a
+worst case that was wrong as a result.

--- a/docs/decisions/ADR-028.md
+++ b/docs/decisions/ADR-028.md
@@ -2607,7 +2607,10 @@ the page ground can sit at 2.136 on a tinted capsule and still read as
 sanctioned. `DesignTokensTests+MutedAsContent` pins all twelve, and pins the
 narrowest margin **by name** (`nightMuted`/`nightPage` at 4.152, 8% under the
 bar) rather than as a range that hides which ground moves first. The app-wide
-sweep of the remaining ~93 sites is #1448.
+sweep of the remaining sites is #1448 — **94 `Color.muted` references across 44
+files** after this change, counting code only (`grep -rn "Color\.muted"
+Pastura/Pastura --include="*.swift"` returns 97 lines, three of them
+doc-comment mentions).
 
 **Why not §8's own remedy.** §8 routes must-read meta info to the §2.4 L3
 preset, and `metaBaseL3` does clear the streak ground (5.272 / 6.518) while

--- a/docs/decisions/ADR-028.md
+++ b/docs/decisions/ADR-028.md
@@ -2573,14 +2573,12 @@ the value arms for exactly that reason — verified by mutation, where reverting
 the chip to `mossDark` reddens the consumer pin while all three value arms stay
 green.
 
-**Residue — closed by #1427, § Amendment 2026-08-13.** `PredictionOutcomeBadge`
-cleared the bar on its hit *label* only: the same capsule's streak sub-label was
-`muted` on `mossSoft` (2.136 light / 2.413 dark) and the miss arm `muted` on
-`bubbleBackground` (3.475 / 3.021) — a different token family, unreachable by any
-moss-family change. The site enumeration this amendment added has since gained
-the streak label, so the counter-example it named to "every label on `mossSoft`
-clears the bar" is gone; the enumeration remains exhaustive for *moss-family*
-text on this ground, and its blind spot for other families is structural.
+**Residue — closed by #1427, § Amendment 2026-08-13.** This amendment left the
+badge's two `muted` labels sub-AA (a different token family, unreachable by any
+moss-family change) and named the streak one as the counter-example to reading
+its site enumeration as "every label on `mossSoft` clears the bar". Both are
+repointed now and the enumeration covers the streak label; it stays exhaustive
+for *moss-family* text only, and that blind spot is structural.
 
 This amendment retires the badge-control claims in § Amendment 2026-07-30
 (#1325), marked at that section's head.

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -159,9 +159,13 @@ closure being inferred `@MainActor` while UIKit may invoke it off-main
 half stays armed at § Revisit trigger's stated thresholds; several fixes
 post-date the device pass that closed gates 4 and 5 and so head
 `docs/qa/dark-mode-qa.md`'s re-run list, one of them partially re-checked with
-its gaps stated (§ Amendment 2026-07-31 → "What is NOT confirmed"); the
+its gaps stated (§ Amendment 2026-07-31 → "What is NOT confirmed"); and the
 `inkSecondary` dark-side gap (§ Amendment 2026-08-08 → "What is not covered",
-#1408); and the residual sub-AA badge labels (§ Amendment 2026-08-12, #1427)
+#1408). **A token's contrast exemption is scoped to the grounds it was measured
+on** — design-system §8 exempts `muted` from the 4.5:1 bar on the strength of one
+ground, so a label ambient there can be far below the bar on a tinted fill; the
+family that owns the ground supplies the replacement, never a §2.4 preset rung
+(§ Amendment 2026-08-13, whose app-wide sweep is #1448)
 (Status: Accepted; #1274)
 
 ## ADR-029 — Shared-scenario highlights (static curated excerpts)

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -841,7 +841,9 @@ Sim 画面に限った2つの例外的コンポーネント。Source: `Simulatio
 
 - 本文の最小コントラスト比: 7:1（AAA）を目標に `--ink` と `--screen-bg` の組み合わせで達成
 - **判読が要るメタ情報**（DL 進捗・ステータス等、確実に読ませる必要があるもの）は § 2.4 の L3 コントラストプリセット（`--meta-base` #4A4E3D ≈ 8:1）で 4.5:1 以上を確保する
-- **`--muted`（#8A8A83）quietude 階層は意図的に sub-AA**（#FCFAF4 上で ≈ 3.3:1）。一覧キャプション（`provenance · N agents · N rounds`）・脚注・アンビエントなラベル（`DEMO中` など）に使う、§1 の「静謐・観察」を体現する控えめなティアで、上の 4.5:1 要件の対象外とする意図的な判断。これにより § 2.2（`--muted` をメタ情報・脚注に割り当て）と本節の整合を取る。判読が要る情報をこのティアに置かないこと（その場合は上の L3 プリセットへ）
+- **`--muted`（#8A8A83）quietude 階層は意図的に sub-AA**（#FCFAF4 上で ≈ 3.3:1）。一覧キャプション（`provenance · N agents · N rounds`）・脚注・アンビエントなラベル（`DEMO中` など）に使う、§1 の「静謐・観察」を体現する控えめなティアで、上の 4.5:1 要件の対象外とする意図的な判断。これにより § 2.2（`--muted` をメタ情報・脚注に割り当て）と本節の整合を取る。判読が要る情報をこのティアに置かないこと
+- ⚠️ **上の免除は「測った地」にしか及ばない。** ≈ 3.3:1 は `screen-bg` 上の値で、`muted` は出荷している12の地（両外観 6 ずつ）で **2.136〜4.152** に散る。最悪は `--moss-soft` 上の 2.136、ダークで最もバーに近いのが `night-page` 上の 4.152（バーの 8% 下）。**ページ地で正当にアンビエントなラベルが、色付きの塗りの上では大きく下回っていても「§8 公認」に見える** — 地を変えたら測り直すこと。12組は `DesignTokensTests+MutedAsContent` が pin しており、残りサイトのアプリ全体掃引は #1448
+- **置き換えるトークンは「地を所有するファミリ」が供給する。** §8 が縛るのは**比**であって特定のトークンではない。不透明な `--moss-soft` 上なら §2.3/§2.6 の Soft+Ink ペアリングで `--moss-ink`、中立なカード面なら `--ink-2`（`PasturaApp` の DB 移行失敗文が先例）。**§2.4 の L3 プリセットの段を借りないこと** — 値が合っても §2.4 は DL 進捗の役割を持つ梯子で、借りると2つのファミリが結合する（ADR-028 § "Three narrower rejections"）。同じ #4A4E3D が別の役割で要るとき、このリポジトリは `--header-meta-ink` を**別トークンとして起こした**（§2.12）。L3 が正解なのは §2.4 自身のメタ面。導出は ADR-028 § Amendment 2026-08-13（#1427）
 - DL 進捗は `role="status" aria-live="polite"` / SwiftUI は `.accessibilityAddTraits(.updatesFrequently)`
 - アバター・犬マークは `aria-hidden="true"` / `.accessibilityHidden(true)`（飾りだから）
 - タップ領域は 44pt 未満の要素（THINKING トグル等）でも 44pt 確保。SwiftUI では `.padding(.vertical, N).contentShape(Rectangle()).onTapGesture{...}.padding(.vertical, -N)` の **negative-padding トリック**で、視覚上のサイズを変えずヒット判定だけ拡張する（`.contentShape(Rectangle())` 単独では view 自身の bounds までしか広がらない）


### PR DESCRIPTION
## Summary

`PredictionOutcomeBadge`'s two `Color.muted` labels sat under WCAG AA 4.5:1 in
**both** appearances. Both move to tokens that clear it, with **no new token** —
so §2.9's pair count stays 68 and #1408 still takes the 69th.

| Site | Ground | Before | After | Light | Dark |
|---|---|---|---|---|---|
| miss arm (`xmark` + "Missed") | `bubbleBackground` | `muted` 3.475 / 3.021 | **`inkSecondary`** | **6.934** | **5.975** |
| streak sub-label (`"%lld in a row"`) | opaque `mossSoft` | `muted` 2.136 / 2.413 | **`mossInk`** | **6.537** | **6.505** |

### The issue's framing needed one correction

`muted` is not a defective value. design-system §8 records it as a *deliberately*
sub-AA quietude tier, **exempt** from the 4.5:1 bar, with a standing instruction
not to place must-read information there. Both of these labels were must-read —
"Missed" is the badge's only label in that state, and a streak count appears
nowhere else on the screen. So the defect is the application, not the token.

**What §8 did not say, and now does.** Its exemption is justified with one
measurement (≈3.3:1 on `screenBackground`), but `muted` runs **2.136–4.152**
across the twelve grounds the app ships. A label legitimately ambient on the page
ground can sit at 2.136 on a tinted capsule and still read as sanctioned. That
invariant is now in §8; the app-wide sweep of the remaining ~93 sites is #1448.

### Why not §8's own named remedy

§8 routes must-read meta info to the §2.4 L3 preset, and an earlier draft of this
PR took it — `metaBaseL3` clears the streak ground at 5.272 / 6.518 and would
have kept colour-based subordination. **Withdrawn in plan review.** A §2.4 rung
has a DL-progress job, and two recorded decisions refuse borrowing one:

- ADR-028 § "Three narrower rejections" — "borrowing it would couple two families"
- `DesignTokens+ExtendedPalette.swift:179-188` — when a non-DL slot needed
  *exactly* #4A4E3D, this repo minted `headerMetaInk` at the same hex rather than
  collapse the roles: "do NOT collapse to a single token"

§8's binding requirement is the **ratio**; the family that owns the ground
supplies the token. On an opaque `mossSoft` fill that is §2.3/§2.6's `mossInk`
pairing — the same answer #1407 reached, already shipped on this badge's hit arm.

The miss arm is a hierarchy call rather than a convention one: `metaBaseL3` clears
it too (8.577 / 8.161), but that puts the *failure* state above the hit arm's 6.5,
and ADR-028 holds that a supporting element must not become the loudest thing in
the row. `inkSecondary` lands at parity.

### Accepted cost

Streak and hit label are now the same token, so subordination rides on weight
(`.medium` vs `.semibold`), not colour. The recorded rule forbids a supporting
element being *louder*, not *equal* — but "equal contrast still reads as
subordinate" is a visual claim no test holds. See Device QA below.

## Test plan

- Full suite `** TEST SUCCEEDED **` — 3,422 tests, 3,401 passed / 0 failed /
  21 skipped (unit + UI).
- `DesignTokensTests` — 114 (109 + 5 new arms). `PredictionOutcomeBadgeTokenTests`
  (new) — 4 consumer pins.
- `swiftlint --strict` clean; `check_design_tokens_css.py` clean (no new hex).

**Both new guards were verified by mutation, not by their success case:**

| Mutation | Expected | Observed |
|---|---|---|
| both accessors → `Color.muted` | the 3 pins for the repointed roles redden; untouched hit-arm pin stays green | exactly that — so the probe is targeted, not blanket breakage |
| drop `nightPage` from the ground fixture | count pin **and** by-name margin assertion redden | exactly that; other 3 arms green |

The second is not hypothetical — an earlier draft of this PR enumerated five dark
grounds, omitted `nightPromoBackground`, and reported a worst case that was wrong
as a result. The guard now catches that shape.

**A gap this PR does not close.** The consumer pins read the accessors, not
`body`. If a future edit re-inlines a colour in `body`, accessor and rendered
value diverge and the pins stay green. That is held by keeping `body` free of
`Color.` references — checkable by grep — not by a test; ADR-009 rules out the
snapshot that would close it mechanically. Review raised that stating this in the
badge's own doc comment does not reach the next person doing the same extraction
(`ContradictionBadge`, which both test files nominate and which still builds its
colours inline), so the invariant is promoted into
`.claude/rules/view-testing.md` § "Change-detector tripwire", which already owns
the sibling rule about pinning *which token* rather than *what value*.

### Stale-claim sweep

`git ls-files -z | xargs -0 grep -nHE "PredictionOutcomeBadge|#1427"` → 13 hits /
7 files, all reconciled. (A bare `grep -rn` returns 1,757, of which 1,744 are
`DerivedData` — enumerate, don't recurse.)

Two things the sweep caught that a hand-named list would not have:

- **`docs/decisions/INDEX.md`** still listed these labels as open.
- **ADR-028's "Cited externally" column moved on a row I was not editing.**
  Regenerating it flipped **#1407 from `—` to `✓`**, because the new
  `DesignTokensTests+MutedAsContent.swift` names ADR-028 and #1407 within the
  predicate's window. Verified against unmodified `main` (0 hits there), so this
  PR caused the flip rather than inheriting a stale cell.

`nightMossSoft`'s doc comment needed **no** change: with the streak on `mossInk`
the capsule's text is uniform, so "three tinted fills under `mossInk` text" became
*more* accurate.

## Device QA

Required — ADR-028 gate 4. This fails in both appearances, so both need a look.
Simulator is not load-bearing for appearance work.

1. **Both appearances**, end-of-run card (`SimulationView`) with a **hit**
   prediction and `streak >= 2`, and the Past Results list (`ResultsView`) with a
   **miss**.
2. Falsifiable criterion for the accepted cost above:

   > The streak sub-label must still read as **secondary** to "Correct!", with
   > weight alone distinguishing them. If it reads as a co-equal second label,
   > this fails.

3. On failure, the remedy is re-grounding the streak off the capsule onto
   `bubbleBackground` with `inkSecondary` (6.934 / 5.975). Deliberately **not**
   carried as an in-PR fallback: it is a layout change to a shipped component
   (the streak `Text` sits inside the capsule-backed `HStack` and its
   `.accessibilityElement(children: .combine)` grouping) and should not land
   after review without its own critique.

Closes #1427
