### PR TITLE
🐛 fix: key hallucinated-turn truncation on per-model chat markers

### DIFF
--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -568,15 +568,13 @@ durable record in ADR-011.)
 
 **This mis-flagging is also the only route by which a turn marker reaches
 decoded text**, so it is what makes the per-model truncation in
-`JSONResponseParser+Truncate.swift` live rather than dead code (#1422). A
-genuine CONTROL marker decodes to `""` and an EOG one returns before its piece
-is appended, so a *correctly* exported model can only produce a marker as a
-plaintext hallucination — which no shipped model has been observed doing
-(`docs/models/eval-log.md` § "Spelled-out chat-template markers"). Read that
-negative as a statement about **the files measured**, not the models: a
-re-export flipping CONTROL → NORMAL makes the markers decode normally, and then
-`turnMarkers` is what keeps a fabricated turn out of the payload. Do not
-"simplify" the truncation away on the strength of a corpus zero.
+`JSONResponseParser+Truncate.swift` live rather than dead code (#1422). Why a
+correctly-exported model cannot produce one except as a plaintext hallucination
+is stated once, on `ChatTurnMarkers` (§ "Contract for consumers"). No shipped
+model has been observed doing so — `docs/models/eval-log.md` § "Spelled-out
+chat-template markers" — but read that negative as a statement about **the files
+measured**, not the models. **Do not "simplify" the truncation away on the
+strength of a corpus zero.**
 
 **Variant, not just publisher.** Gemma 4 **QAT** exports — Google's and
 unsloth's alike — ship a shared-KV tail layer the pinned llama.cpp cannot

--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -570,7 +570,8 @@ durable record in ADR-011.)
 decoded text**, so it is what makes the per-model truncation in
 `JSONResponseParser+Truncate.swift` live rather than dead code (#1422). Why a
 correctly-exported model cannot produce one except as a plaintext hallucination
-is stated once, on `ChatTurnMarkers` (§ "Contract for consumers"). No shipped
+is stated in full on `Pastura/Pastura/Models/ChatTurnMarkers.swift`
+§ "Contract for consumers" (its Kotlin mirror carries the same section). No shipped
 model has been observed doing so — `docs/models/eval-log.md` § "Spelled-out
 chat-template markers" — but read that negative as a statement about **the files
 measured**, not the models. **Do not "simplify" the truncation away on the

--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -566,10 +566,12 @@ unsloth exports are unaffected **by #5070** and the existing Gemma 4 E2B
 descriptor stays on unsloth. (PR #480, closed — Gemma 3 1B no-go;
 durable record in ADR-011.)
 
-**This mis-flagging is also the only route by which a turn marker reaches
-decoded text**, so it is what makes the per-model truncation in
+**This mis-flagging is the route that makes a turn marker reach decoded text
+*systematically*** — the other is the model spelling the marker out as a
+plaintext hallucination, which is per-response rather than per-export. Either way
+it is what makes the per-model truncation in
 `JSONResponseParser+Truncate.swift` live rather than dead code (#1422). Why a
-correctly-exported model cannot produce one except as a plaintext hallucination
+correctly-exported model cannot produce one *except* by that hallucination
 is stated in full on `Pastura/Pastura/Models/ChatTurnMarkers.swift`
 § "Contract for consumers" (its Kotlin mirror carries the same section). No shipped
 model has been observed doing so — `docs/models/eval-log.md` § "Spelled-out

--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -566,6 +566,18 @@ unsloth exports are unaffected **by #5070** and the existing Gemma 4 E2B
 descriptor stays on unsloth. (PR #480, closed — Gemma 3 1B no-go;
 durable record in ADR-011.)
 
+**This mis-flagging is also the only route by which a turn marker reaches
+decoded text**, so it is what makes the per-model truncation in
+`JSONResponseParser+Truncate.swift` live rather than dead code (#1422). A
+genuine CONTROL marker decodes to `""` and an EOG one returns before its piece
+is appended, so a *correctly* exported model can only produce a marker as a
+plaintext hallucination — which no shipped model has been observed doing
+(`docs/models/eval-log.md` § "Spelled-out chat-template markers"). Read that
+negative as a statement about **the files measured**, not the models: a
+re-export flipping CONTROL → NORMAL makes the markers decode normally, and then
+`turnMarkers` is what keeps a fabricated turn out of the payload. Do not
+"simplify" the truncation away on the strength of a corpus zero.
+
 **Variant, not just publisher.** Gemma 4 **QAT** exports — Google's and
 unsloth's alike — ship a shared-KV tail layer the pinned llama.cpp cannot
 load (`missing tensor 'blk.15.attn_k.weight'`), so a `-qat-` repo is never

--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -567,17 +567,14 @@ descriptor stays on unsloth. (PR #480, closed — Gemma 3 1B no-go;
 durable record in ADR-011.)
 
 **This mis-flagging is the route that makes a turn marker reach decoded text
-*systematically*** — the other is the model spelling the marker out as a
-plaintext hallucination, which is per-response rather than per-export. Either way
-it is what makes the per-model truncation in
-`JSONResponseParser+Truncate.swift` live rather than dead code (#1422). Why a
-correctly-exported model cannot produce one *except* by that hallucination
-is stated in full on `Pastura/Pastura/Models/ChatTurnMarkers.swift`
-§ "Contract for consumers" (its Kotlin mirror carries the same section). No shipped
-model has been observed doing so — `docs/models/eval-log.md` § "Spelled-out
-chat-template markers" — but read that negative as a statement about **the files
-measured**, not the models. **Do not "simplify" the truncation away on the
-strength of a corpus zero.**
+*systematically*** — the other is a plaintext hallucination, per-response rather
+than per-export. Either way it keeps the per-model truncation in
+`JSONResponseParser+Truncate.swift` live, not dead code (#1422) — see
+`ChatTurnMarkers.swift` § "Contract for consumers" for why a correctly-exported
+model can't otherwise produce one. No shipped model has done so —
+`docs/models/eval-log.md` § "Spelled-out chat-template markers" — but that zero
+is about **the files measured**, not the models. **Do not "simplify" the
+truncation away on the strength of a corpus zero.**
 
 **Variant, not just publisher.** Gemma 4 **QAT** exports — Google's and
 unsloth's alike — ship a shared-KV tail layer the pinned llama.cpp cannot

--- a/.claude/rules/swift-isolation.md
+++ b/.claude/rules/swift-isolation.md
@@ -29,13 +29,12 @@ extension LLMService {
 ```
 
 **The escaping closure is sufficient, not necessary — the discriminator is
-sync-vs-`async`.** A *synchronous* default impl needs `nonisolated` even with no
-closure anywhere: `LLMService.knownTurnMarkers` is a plain computed property and
-still breaks every `nonisolated` conformer without it (measured by dropping the
-annotation, #1422), while the `async` members on the same extension
-(`generateWithMetrics`, `attachSuspendController`) carry none. `generateStream`
-satisfies both conditions at once, so it cannot tell them apart. Read this before
-deleting a closure-free `nonisolated` here as redundant.
+sync-vs-`async`.** `LLMService.knownTurnMarkers`, a plain synchronous computed
+property, still breaks every `nonisolated` conformer without `nonisolated`
+(measured by dropping the annotation, #1422), while the `async` members on the
+same extension carry none. `generateStream` satisfies both conditions, so it
+can't tell them apart — read this before deleting a closure-free `nonisolated`
+here as redundant.
 
 Reference: `Pastura/Pastura/LLM/LLMService.swift`.
 

--- a/.claude/rules/swift-isolation.md
+++ b/.claude/rules/swift-isolation.md
@@ -28,6 +28,15 @@ extension LLMService {
 }
 ```
 
+**The escaping closure is sufficient, not necessary — the discriminator is
+sync-vs-`async`.** A *synchronous* default impl needs `nonisolated` even with no
+closure anywhere: `LLMService.knownTurnMarkers` is a plain computed property and
+still breaks every `nonisolated` conformer without it (measured by dropping the
+annotation, #1422), while the `async` members on the same extension
+(`generateWithMetrics`, `attachSuspendController`) carry none. `generateStream`
+satisfies both conditions at once, so it cannot tell them apart. Read this before
+deleting a closure-free `nonisolated` here as redundant.
+
 Reference: `Pastura/Pastura/LLM/LLMService.swift`.
 
 ## Pattern 2 — Value type with custom witness

--- a/Package.swift
+++ b/Package.swift
@@ -108,8 +108,8 @@ let package = Package(
       name: "PasturaHarnessKitTests",
       // `PasturaCore` is declared because the tests `import` it directly
       // (`ModelProfileTests` asserts on `ChatTurnMarkers`). Without the row it
-      // resolves only by SwiftPM search-path luck, matching `pastura-harness`
-      // above, which lists both.
+      // resolves only by SwiftPM search-path luck. `pastura-harness` above
+      // already lists both.
       dependencies: ["PasturaHarnessKit", "PasturaCore"],
       path: "tools/harness/Tests/PasturaHarnessKitTests",
       swiftSettings: [

--- a/Package.swift
+++ b/Package.swift
@@ -106,10 +106,8 @@ let package = Package(
     ),
     .testTarget(
       name: "PasturaHarnessKitTests",
-      // `PasturaCore` is declared because the tests `import` it directly
-      // (`ModelProfileTests` asserts on `ChatTurnMarkers`). Without the row it
-      // resolves only by SwiftPM search-path luck. `pastura-harness` above
-      // already lists both.
+      // `PasturaCore` is declared because `ModelProfileTests` imports it
+      // directly — without the row it resolves only by search-path luck.
       dependencies: ["PasturaHarnessKit", "PasturaCore"],
       path: "tools/harness/Tests/PasturaHarnessKitTests",
       swiftSettings: [

--- a/Package.swift
+++ b/Package.swift
@@ -106,7 +106,11 @@ let package = Package(
     ),
     .testTarget(
       name: "PasturaHarnessKitTests",
-      dependencies: ["PasturaHarnessKit"],
+      // `PasturaCore` is declared because the tests `import` it directly
+      // (`ModelProfileTests` asserts on `ChatTurnMarkers`). Without the row it
+      // resolves only by SwiftPM search-path luck, matching `pastura-harness`
+      // above, which lists both.
+      dependencies: ["PasturaHarnessKit", "PasturaCore"],
       path: "tools/harness/Tests/PasturaHarnessKitTests",
       swiftSettings: [
         .swiftLanguageMode(.v6)

--- a/Pastura/Pastura/App/AppDependencies.swift
+++ b/Pastura/Pastura/App/AppDependencies.swift
@@ -214,6 +214,7 @@ final class AppDependencies: @unchecked Sendable {
       let newService = LlamaCppService(
         modelPath: modelManager.modelFileURL(for: descriptor).path,
         stopSequence: descriptor.stopSequence,
+        turnMarkers: descriptor.turnMarkers,
         modelIdentifier: descriptor.displayName,
         systemPromptSuffix: descriptor.systemPromptSuffix,
         assistantPrefix: descriptor.assistantPrefix

--- a/Pastura/Pastura/App/ModelRegistry.swift
+++ b/Pastura/Pastura/App/ModelRegistry.swift
@@ -60,10 +60,17 @@ enum ModelRegistry {
     // inert here — which is what lets a spelled-out `<turn|>` survive to the
     // parser and reach `turnMarkers` below. Repointing it would activate a
     // behaviour on an assumption; deferred to #1451 (#1417).
+    // Canonical note: `LlamaCppService.stopSequence`. This rationale is
+    // restated across production, the harness profile, and both test pins, and
+    // #1451 has to change all of them (`grep -rn '#1451\|#1417'` enumerates
+    // them) — so keep this pointer; a copy that loses it is the one left behind.
     stopSequence: "<|im_end|>",
     // Measured from the GGUF header of the exact file pinned above: `<|turn>`
     // id 105 / `<turn|>` id 106, both `token_type=3` (CONTROL), `eos = 106`,
-    // vocab 262,144. Neither ChatML string occurs anywhere in that vocabulary.
+    // vocab 262,144. Neither ChatML string occurs anywhere in that vocabulary
+    // — the one claim here a reader cannot re-derive from the ids above; the
+    // vocabulary sweep that establishes it is `docs/models/onboarding.md`
+    // § "Stage 0 — Harness profile".
     turnMarkers: ChatTurnMarkers(start: "<|turn>", end: "<turn|>"),
     minRAM: 6_500_000_000,
     modelInfoURL: unsafeURL("https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF"),
@@ -86,7 +93,8 @@ enum ModelRegistry {
     stopSequence: "<|im_end|>",
     // Qwen 3 genuinely is ChatML: `<|im_start|>` 151644 / `<|im_end|>` 151645,
     // both CONTROL, and `eos = 151645`. The pre-#1422 hardcoded literal was
-    // correct here and only here.
+    // correct here and only here. Procedure that produces these ids:
+    // `docs/models/onboarding.md` § "Stage 0 — Harness profile".
     turnMarkers: .chatML,
     minRAM: 6_500_000_000,
     modelInfoURL: unsafeURL("https://huggingface.co/Qwen/Qwen3-4B-GGUF"),

--- a/Pastura/Pastura/App/ModelRegistry.swift
+++ b/Pastura/Pastura/App/ModelRegistry.swift
@@ -61,16 +61,22 @@ enum ModelRegistry {
     // parser and reach `turnMarkers` below. Repointing it would activate a
     // behaviour on an assumption; deferred to #1451 (#1417).
     // Canonical note: `LlamaCppService.stopSequence`. This rationale is
-    // restated across production, the harness profile, and both test pins, and
-    // #1451 has to change all of them (`grep -rn '#1451\|#1417'` enumerates
-    // them) — so keep this pointer; a copy that loses it is the one left behind.
+    // restated at production, harness, test and doc sites, and #1451 has to
+    // change all of them — `grep -rn '#1451\|#1417'` is the enumeration, so no
+    // count is asserted here. Keep this pointer; a copy that loses it is the
+    // one left behind.
     stopSequence: "<|im_end|>",
     // Measured from the GGUF header of the exact file pinned above: `<|turn>`
     // id 105 / `<turn|>` id 106, both `token_type=3` (CONTROL), `eos = 106`,
-    // vocab 262,144. Neither ChatML string occurs anywhere in that vocabulary
-    // — the one claim here a reader cannot re-derive from the ids above; the
-    // vocabulary sweep that establishes it is `docs/models/onboarding.md`
-    // § "Stage 0 — Harness profile".
+    // vocab 262,144. The ids and `token_type`s come from the GGUF header-read
+    // step in `docs/models/onboarding.md` § "Stage 0 — Harness profile".
+    // The trailing claim — that neither ChatML string occurs anywhere in that
+    // vocabulary — is the one a reader cannot re-derive from those ids, and no
+    // document records the sweep behind it: it is carried as an assertion on
+    // `LlamaCppService.stopSequence` (and ADR-002 for the Gemma 3 syntax). Note
+    // that Stage 0's own "marker sweep" counts markers in **transcripts**,
+    // which is a different claim from vocabulary membership — do not cite it
+    // for this one.
     turnMarkers: ChatTurnMarkers(start: "<|turn>", end: "<turn|>"),
     minRAM: 6_500_000_000,
     modelInfoURL: unsafeURL("https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF"),
@@ -93,8 +99,8 @@ enum ModelRegistry {
     stopSequence: "<|im_end|>",
     // Qwen 3 genuinely is ChatML: `<|im_start|>` 151644 / `<|im_end|>` 151645,
     // both CONTROL, and `eos = 151645`. The pre-#1422 hardcoded literal was
-    // correct here and only here. Procedure that produces these ids:
-    // `docs/models/onboarding.md` § "Stage 0 — Harness profile".
+    // correct here and only here. Header-read procedure that produces these
+    // ids: `docs/models/onboarding.md` § "Stage 0 — Harness profile".
     turnMarkers: .chatML,
     minRAM: 6_500_000_000,
     modelInfoURL: unsafeURL("https://huggingface.co/Qwen/Qwen3-4B-GGUF"),

--- a/Pastura/Pastura/App/ModelRegistry.swift
+++ b/Pastura/Pastura/App/ModelRegistry.swift
@@ -57,26 +57,18 @@ enum ModelRegistry {
     sha256: "ac0069ebccd39925d836f24a88c0f0c858d20578c29b21ab7cedce66ee576845",
     // Carries no Gemma marker, deliberately: `<|im_end|>` is a ChatML sentinel
     // absent from this model's vocabulary, so this generation-side path is
-    // inert here — which is what lets a spelled-out `<turn|>` survive to the
-    // parser and reach `turnMarkers` below. Repointing it would activate a
-    // behaviour on an assumption; deferred to #1451 (#1417).
-    // Canonical note: `LlamaCppService.stopSequence`. This rationale is
-    // restated at production, harness, test and doc sites, and #1451 has to
-    // change all of them — `grep -rn '#1451\|#1417'` is the enumeration, so no
-    // count is asserted here. Keep this pointer; a copy that loses it is the
-    // one left behind.
+    // inert here — which is what lets a spelled-out `<turn|>` reach the parser,
+    // keyed on the `turnMarkers` below. Repointing it would activate a behaviour
+    // on an assumption; deferred to #1451, which must change every site
+    // (`grep -rn '#1451'`) (#1417). Canonical note: `LlamaCppService.stopSequence`.
     stopSequence: "<|im_end|>",
     // Measured from the GGUF header of the exact file pinned above: `<|turn>`
     // id 105 / `<turn|>` id 106, both `token_type=3` (CONTROL), `eos = 106`,
-    // vocab 262,144. The ids and `token_type`s come from the GGUF header-read
-    // step in `docs/models/onboarding.md` § "Stage 0 — Harness profile".
-    // The trailing claim — that neither ChatML string occurs anywhere in that
-    // vocabulary — is the one a reader cannot re-derive from those ids, and no
-    // document records the sweep behind it: it is carried as an assertion on
-    // `LlamaCppService.stopSequence` (and ADR-002 for the Gemma 3 syntax). Note
-    // that Stage 0's own "marker sweep" counts markers in **transcripts**,
-    // which is a different claim from vocabulary membership — do not cite it
-    // for this one.
+    // vocab 262,144. Header-read step: `docs/models/onboarding.md`
+    // § "Stage 0 — Harness profile". The claim that neither ChatML string
+    // occurs in that vocabulary is not re-derivable from these ids — it's
+    // carried as an assertion on `LlamaCppService.stopSequence`, and is
+    // distinct from Stage 0's transcript marker sweep.
     turnMarkers: ChatTurnMarkers(start: "<|turn>", end: "<turn|>"),
     minRAM: 6_500_000_000,
     modelInfoURL: unsafeURL("https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF"),
@@ -98,9 +90,8 @@ enum ModelRegistry {
     sha256: "7485fe6f11af29433bc51cab58009521f205840f5b4ae3a32fa7f92e8534fdf5",
     stopSequence: "<|im_end|>",
     // Qwen 3 genuinely is ChatML: `<|im_start|>` 151644 / `<|im_end|>` 151645,
-    // both CONTROL, and `eos = 151645`. The pre-#1422 hardcoded literal was
-    // correct here and only here. Header-read procedure that produces these
-    // ids: `docs/models/onboarding.md` § "Stage 0 — Harness profile".
+    // both CONTROL, `eos = 151645`. Header-read: `docs/models/onboarding.md`
+    // § "Stage 0 — Harness profile".
     turnMarkers: .chatML,
     minRAM: 6_500_000_000,
     modelInfoURL: unsafeURL("https://huggingface.co/Qwen/Qwen3-4B-GGUF"),

--- a/Pastura/Pastura/App/ModelRegistry.swift
+++ b/Pastura/Pastura/App/ModelRegistry.swift
@@ -56,10 +56,15 @@ enum ModelRegistry {
     fileSize: 3_106_735_776,
     sha256: "ac0069ebccd39925d836f24a88c0f0c858d20578c29b21ab7cedce66ee576845",
     // Carries no Gemma marker, deliberately: `<|im_end|>` is a ChatML sentinel
-    // absent from this model's vocabulary, and replacing it would mean guessing
-    // what text a Gemma hallucination spells out. See the canonical note on
-    // `LlamaCppService.stopSequence` (#1417; behaviour half #1422).
+    // absent from this model's vocabulary, so this generation-side path is
+    // inert here — which is what lets a spelled-out `<turn|>` survive to the
+    // parser and reach `turnMarkers` below. Repointing it would activate a
+    // behaviour on an assumption; deferred to #1451 (#1417).
     stopSequence: "<|im_end|>",
+    // Measured from the GGUF header of the exact file pinned above: `<|turn>`
+    // id 105 / `<turn|>` id 106, both `token_type=3` (CONTROL), `eos = 106`,
+    // vocab 262,144. Neither ChatML string occurs anywhere in that vocabulary.
+    turnMarkers: ChatTurnMarkers(start: "<|turn>", end: "<turn|>"),
     minRAM: 6_500_000_000,
     modelInfoURL: unsafeURL("https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF"),
     systemPromptSuffix: nil,
@@ -79,6 +84,10 @@ enum ModelRegistry {
     fileSize: 2_497_280_256,
     sha256: "7485fe6f11af29433bc51cab58009521f205840f5b4ae3a32fa7f92e8534fdf5",
     stopSequence: "<|im_end|>",
+    // Qwen 3 genuinely is ChatML: `<|im_start|>` 151644 / `<|im_end|>` 151645,
+    // both CONTROL, and `eos = 151645`. The pre-#1422 hardcoded literal was
+    // correct here and only here.
+    turnMarkers: .chatML,
     minRAM: 6_500_000_000,
     modelInfoURL: unsafeURL("https://huggingface.co/Qwen/Qwen3-4B-GGUF"),
     systemPromptSuffix: "/no_think",

--- a/Pastura/Pastura/Engine/LLMCaller+Logging.swift
+++ b/Pastura/Pastura/Engine/LLMCaller+Logging.swift
@@ -1,8 +1,11 @@
 import Foundation
 
-// Log-emission helpers factored out of `LLMCaller` so the core file stays
+// Diagnostics helpers factored out of `LLMCaller` so the core file stays
 // under SwiftLint's `file_length` budget (mirrors `LLMCaller+StreamFailure`).
-// These build the fully-rendered message and route it through the injected
+// Mostly log emission, but `parseAndLog` also *parses* and returns a
+// `TurnOutput` — it lives here because the turn-marker set has to be read once
+// and shared with `logChatTemplateLeakage`.
+// The log-emitting members build the fully-rendered message and route it through the injected
 // ``EngineLogger`` seam (#501 S0.2) — the OSLog `category`, message wire
 // format, level, and privacy are preserved so `scripts/analyze-streaming-diag.sh`
 // keeps parsing the same lines.
@@ -106,22 +109,32 @@ nonisolated extension LLMCaller {
   /// what the #65 TODO on `LlamaCppService.stopSequence` is about.
   ///
   /// Severity split is preserved from the pre-#1422 shape: a start marker is
-  /// a fabricated next turn (`.warning`), a lone end marker is the ordinary
-  /// trailing-sentinel case (`.debug`).
+  /// the more suspicious of the two (`.warning`), a lone end marker is the
+  /// ordinary trailing-sentinel case (`.debug`). Suspicion, not a verdict —
+  /// this predicate is a bare substring test and cannot tell a fabricated next
+  /// turn from a header echo or from marker text inside a string value.
   ///
   /// - Parameters:
   ///   - raw: The backend's raw text, before parsing.
   ///   - markers: `LLMService.knownTurnMarkers` for the backend that produced
   ///     `raw`.
   func logChatTemplateLeakage(in raw: String, markers: [ChatTurnMarkers]) {
+    // Both `first(where:)` calls pick the first marker in **array order**, not
+    // the one occurring earliest in `raw`. Only one line is emitted either
+    // way, so with a multi-pair set the reported marker is set-order
+    // arbitrary — read the line as "some marker is present", never as "this
+    // one came first".
     if let marker = markers.first(where: { !$0.start.isEmpty && raw.contains($0.start) }) {
-      // Deliberately does NOT claim the continuation was truncated: the
-      // parser's start arm cuts only after the first structural `{`, so a
-      // leading template-header echo is detected here and left in place
-      // (`JSONResponseParser.truncateAtTurnMarkers`).
+      // The message states presence only, with no claim about what the model
+      // did or what the parser then did. `raw.contains` is a plain substring
+      // test, so it also fires on a leading template-header echo (which the
+      // parser's start arm deliberately leaves in place) and on a marker
+      // spelled inside a JSON string value (fixture:
+      // `JSONResponseParserTests+TurnMarkers.startMarker_insideStringValue…`).
+      // Neither is the model writing past its turn.
       logger.log(
         .warning, category: Self.logCategory,
-        "Turn-start marker \(marker.start) leaked into output — model wrote past its turn",
+        "Turn-start marker \(marker.start) present in raw output",
         privacy: .public)
     } else if let marker = markers.first(where: { !$0.end.isEmpty && raw.contains($0.end) }) {
       logger.log(

--- a/Pastura/Pastura/Engine/LLMCaller+Logging.swift
+++ b/Pastura/Pastura/Engine/LLMCaller+Logging.swift
@@ -129,9 +129,10 @@ nonisolated extension LLMCaller {
       // did or what the parser then did. `raw.contains` is a plain substring
       // test, so it also fires on a leading template-header echo (which the
       // parser's start arm deliberately leaves in place) and on a marker
-      // spelled inside a JSON string value (fixture:
-      // `JSONResponseParserTests+TurnMarkers.startMarker_insideStringValue…`).
-      // Neither is the model writing past its turn.
+      // spelled inside a JSON string value. Neither is the model writing past
+      // its turn. The string-value shape has a fixture — a *parser* test, so it
+      // demonstrates the input reaching this predicate, not the warning firing:
+      // `JSONResponseParserTests.startMarker_insideStringValue_isNotATurnBoundary`.
       logger.log(
         .warning, category: Self.logCategory,
         "Turn-start marker \(marker.start) present in raw output",

--- a/Pastura/Pastura/Engine/LLMCaller+Logging.swift
+++ b/Pastura/Pastura/Engine/LLMCaller+Logging.swift
@@ -65,27 +65,68 @@ nonisolated extension LLMCaller {
     )
   }
 
-  /// Detect chat template token leakage and hallucinated continuations.
-  /// `LlamaCppService`'s streaming path strips a spelled-out `<|im_end|>`
+  /// Parse `raw` with the backend's own turn markers, and emit the two
+  /// diagnostics that belong to a *successful* parse.
+  ///
+  /// Extracted from `call` so that body stays under the 50-line
+  /// `function_body_length` cap, and so the marker set is read once and used
+  /// by both consumers — the parser and the leakage diagnostic — with no way
+  /// for them to drift onto different sets.
+  ///
+  /// `knownTurnMarkers` is read from the live backend, so truncation keys on
+  /// the loaded model's own sentinels (#1422). The read goes through
+  /// `any LLMService`, which is exactly why that requirement is declared in
+  /// the protocol body rather than an extension — see its doc comment.
+  ///
+  /// - Returns: the parsed output, or `nil` when the parse failed (the caller
+  ///   owns the retry / `retriesExhausted` decision).
+  func parseAndLog(
+    raw: String, expectedKeys: Set<String>, llm: any LLMService, agent: String
+  ) -> TurnOutput? {
+    let markers = llm.knownTurnMarkers
+    guard
+      let result = try? parser.parse(
+        raw, expectedKeys: expectedKeys, turnMarkers: markers)
+    else { return nil }
+    logRepairIfNeeded(agent: agent, kind: result.repairKind)
+    logChatTemplateLeakage(in: raw, markers: markers)
+    return result.0
+  }
+
+  /// Detect chat template token leakage and hallucinated continuations,
+  /// against the loaded model's own markers rather than a ChatML literal
+  /// (#1422 — before that, this was silently blind for Gemma 4, the default
+  /// shipped model).
+  ///
+  /// `LlamaCppService`'s streaming path strips a spelled-out `stopSequence`
   /// before emission, so this primarily catches non-streaming backends (Mock
   /// wrap path, Ollama) where the raw string may still contain template
-  /// tokens.
+  /// tokens. A spelled-out **start** marker stays reachable even under
+  /// llama.cpp, whose streaming path strips `stopSequence` alone — that is
+  /// what the #65 TODO on `LlamaCppService.stopSequence` is about.
   ///
-  /// - Important: ChatML-only, so a non-ChatML model (Gemma 4) is not covered
-  ///   — #1422. A spelled-out `<|im_start|>` stays reachable even under
-  ///   llama.cpp, whose streaming path strips `stopSequence` (`<|im_end|>`)
-  ///   alone; that is what the #65 TODO on `LlamaCppService.stopSequence` is
-  ///   about.
-  func logChatTemplateLeakage(in raw: String) {
-    if raw.contains("<|im_start|>") {
+  /// Severity split is preserved from the pre-#1422 shape: a start marker is
+  /// a fabricated next turn (`.warning`), a lone end marker is the ordinary
+  /// trailing-sentinel case (`.debug`).
+  ///
+  /// - Parameters:
+  ///   - raw: The backend's raw text, before parsing.
+  ///   - markers: `LLMService.knownTurnMarkers` for the backend that produced
+  ///     `raw`.
+  func logChatTemplateLeakage(in raw: String, markers: [ChatTurnMarkers]) {
+    if let marker = markers.first(where: { !$0.start.isEmpty && raw.contains($0.start) }) {
+      // Deliberately does NOT claim the continuation was truncated: the
+      // parser's start arm cuts only after the first structural `{`, so a
+      // leading template-header echo is detected here and left in place
+      // (`JSONResponseParser.truncateAtTurnMarkers`).
       logger.log(
         .warning, category: Self.logCategory,
-        "Model hallucinated past its turn — continuation truncated at <|im_end|>",
+        "Turn-start marker \(marker.start) leaked into output — model wrote past its turn",
         privacy: .public)
-    } else if raw.contains("<|im_end|>") {
+    } else if let marker = markers.first(where: { !$0.end.isEmpty && raw.contains($0.end) }) {
       logger.log(
         .debug, category: Self.logCategory,
-        "Trailing <|im_end|> token stripped from output", privacy: .public)
+        "Trailing \(marker.end) token stripped from output", privacy: .public)
     }
   }
 

--- a/Pastura/Pastura/Engine/LLMCaller+Logging.swift
+++ b/Pastura/Pastura/Engine/LLMCaller+Logging.swift
@@ -2,13 +2,11 @@ import Foundation
 
 // Diagnostics helpers factored out of `LLMCaller` so the core file stays
 // under SwiftLint's `file_length` budget (mirrors `LLMCaller+StreamFailure`).
-// Mostly log emission, but `parseAndLog` also *parses* and returns a
-// `TurnOutput` — it lives here because the turn-marker set has to be read once
-// and shared with `logChatTemplateLeakage`.
-// The log-emitting members build the fully-rendered message and route it through the injected
-// ``EngineLogger`` seam (#501 S0.2) — the OSLog `category`, message wire
-// format, level, and privacy are preserved so `scripts/analyze-streaming-diag.sh`
-// keeps parsing the same lines.
+// Mostly log emission, but `parseAndLog` also parses (returns `TurnOutput`) —
+// the marker set is read once and shared with `logChatTemplateLeakage`. The
+// log-emitting members route through the injected ``EngineLogger`` seam
+// (#501 S0.2); category, format, level, privacy stay so
+// `scripts/analyze-streaming-diag.sh` keeps parsing.
 //
 // `nonisolated` on the extension is required because `LLMCaller` is a
 // `nonisolated` Engine type split across sibling files (a plain `extension`
@@ -68,21 +66,16 @@ nonisolated extension LLMCaller {
     )
   }
 
-  /// Parse `raw` with the backend's own turn markers, and emit the two
-  /// diagnostics that belong to a *successful* parse.
+  /// Parse `raw` with the backend's own turn markers, then emit the two
+  /// success-path diagnostics.
   ///
-  /// Extracted from `call` so that body stays under the 50-line
-  /// `function_body_length` cap, and so the marker set is read once and used
-  /// by both consumers — the parser and the leakage diagnostic — with no way
-  /// for them to drift onto different sets.
+  /// Extracted from `call` to stay under the 50-line `function_body_length`
+  /// cap, and so the marker set is read once and shared by the parser and
+  /// the leakage diagnostic (#1422) — see `LLMService.knownTurnMarkers`'s
+  /// doc for why the read goes through `any LLMService`.
   ///
-  /// `knownTurnMarkers` is read from the live backend, so truncation keys on
-  /// the loaded model's own sentinels (#1422). The read goes through
-  /// `any LLMService`, which is exactly why that requirement is declared in
-  /// the protocol body rather than an extension — see its doc comment.
-  ///
-  /// - Returns: the parsed output, or `nil` when the parse failed (the caller
-  ///   owns the retry / `retriesExhausted` decision).
+  /// - Returns: the parsed output, or `nil` on parse failure (caller owns
+  ///   the retry / `retriesExhausted` decision).
   func parseAndLog(
     raw: String, expectedKeys: Set<String>, llm: any LLMService, agent: String
   ) -> TurnOutput? {
@@ -96,42 +89,31 @@ nonisolated extension LLMCaller {
     return result.0
   }
 
-  /// Detect chat template token leakage and hallucinated continuations,
-  /// against the loaded model's own markers rather than a ChatML literal
-  /// (#1422 — before that, this was silently blind for Gemma 4, the default
-  /// shipped model).
+  /// Detect chat template token leakage against the loaded model's own
+  /// markers, not a ChatML literal — before #1422 this was silently blind
+  /// for Gemma 4, the default shipped model.
   ///
   /// `LlamaCppService`'s streaming path strips a spelled-out `stopSequence`
-  /// before emission, so this primarily catches non-streaming backends (Mock
-  /// wrap path, Ollama) where the raw string may still contain template
-  /// tokens. A spelled-out **start** marker stays reachable even under
-  /// llama.cpp, whose streaming path strips `stopSequence` alone — that is
-  /// what the #65 TODO on `LlamaCppService.stopSequence` is about.
+  /// before emission, so this mainly catches non-streaming backends (Mock
+  /// wrap, Ollama). A spelled-out **start** marker still reaches here even
+  /// under llama.cpp, since streaming only strips `stopSequence` — the #65
+  /// TODO on `LlamaCppService.stopSequence`.
   ///
-  /// Severity split is preserved from the pre-#1422 shape: a start marker is
-  /// the more suspicious of the two (`.warning`), a lone end marker is the
-  /// ordinary trailing-sentinel case (`.debug`). Suspicion, not a verdict —
-  /// this predicate is a bare substring test and cannot tell a fabricated next
-  /// turn from a header echo or from marker text inside a string value.
+  /// Severity mirrors the pre-#1422 shape: start marker = `.warning` (more
+  /// suspicious), end marker alone = `.debug` (ordinary trailing sentinel).
+  /// Suspicion, not a verdict: this is a bare substring test and can't tell
+  /// a fabricated next turn from a header echo or from marker text inside a
+  /// string value.
   ///
   /// - Parameters:
   ///   - raw: The backend's raw text, before parsing.
   ///   - markers: `LLMService.knownTurnMarkers` for the backend that produced
   ///     `raw`.
   func logChatTemplateLeakage(in raw: String, markers: [ChatTurnMarkers]) {
-    // Both `first(where:)` calls pick the first marker in **array order**, not
-    // the one occurring earliest in `raw`. Only one line is emitted either
-    // way, so with a multi-pair set the reported marker is set-order
-    // arbitrary — read the line as "some marker is present", never as "this
-    // one came first".
+    // `first(where:)` picks the first marker in **array order**, not the
+    // earliest occurrence in `raw` — read as "some marker present," not "first".
     if let marker = markers.first(where: { !$0.start.isEmpty && raw.contains($0.start) }) {
-      // The message states presence only, with no claim about what the model
-      // did or what the parser then did. `raw.contains` is a plain substring
-      // test, so it also fires on a leading template-header echo (which the
-      // parser's start arm deliberately leaves in place) and on a marker
-      // spelled inside a JSON string value. Neither is the model writing past
-      // its turn. The string-value shape has a fixture — a *parser* test, so it
-      // demonstrates the input reaching this predicate, not the warning firing:
+      // String-value fixture (parser-side, not this warning):
       // `JSONResponseParserTests.startMarker_insideStringValue_isNotATurnBoundary`.
       logger.log(
         .warning, category: Self.logCategory,

--- a/Pastura/Pastura/Engine/LLMCaller.swift
+++ b/Pastura/Pastura/Engine/LLMCaller.swift
@@ -14,7 +14,9 @@ nonisolated struct LLMCaller: Sendable {
 
   // `internal` so the sibling `LLMCaller+StreamFailure` extension can read it.
   static let maxRetries = 2
-  private let parser = JSONResponseParser()
+  /// `internal` (not `private`) so the sibling `LLMCaller+Logging` extension's
+  /// `parseAndLog` can reach it — same reason as `logger` below.
+  let parser = JSONResponseParser()
   private let extractor = PartialOutputExtractor()
 
   /// Injected logging seam. Replaces the former two `os.Logger` instances so
@@ -142,11 +144,10 @@ nonisolated struct LLMCaller: Sendable {
 
       let raw = streamResult.rawText
 
-      // Try to parse JSON, with optional A2 repair pipeline gated by the
-      // schema-aware guard (#194 PR#a Item 2). On successful repair, emit
-      // a `StreamingDiag` line so `scripts/analyze-streaming-diag.sh` can
-      // bucket repair effects against pre-PR baselines.
-      guard let parseResult = try? parser.parse(raw, expectedKeys: expectedKeys)
+      // Parse + its two success-path diagnostics — see `parseAndLog`.
+      guard
+        let output = parseAndLog(
+          raw: raw, expectedKeys: expectedKeys, llm: llm, agent: agentName)
       else {
         logParseFailure(agent: agentName, raw: raw, attempt: attempt)
         if attempt < Self.maxRetries {
@@ -155,9 +156,6 @@ nonisolated struct LLMCaller: Sendable {
         }
         throw SimulationError.retriesExhausted
       }
-      let output = parseResult.0
-      logRepairIfNeeded(agent: agentName, kind: parseResult.repairKind)
-      logChatTemplateLeakage(in: raw)
 
       // Empty-field retry, and the ADR-021 § Amendment 2026-08-06 skip when the
       // declared canonical primary is what came back missing. Throws there;

--- a/Pastura/Pastura/Engine/LLMCaller.swift
+++ b/Pastura/Pastura/Engine/LLMCaller.swift
@@ -14,8 +14,7 @@ nonisolated struct LLMCaller: Sendable {
 
   // `internal` so the sibling `LLMCaller+StreamFailure` extension can read it.
   static let maxRetries = 2
-  /// `internal` (not `private`) so the sibling `LLMCaller+Logging` extension's
-  /// `parseAndLog` can reach it — same reason as `logger` below.
+  /// `internal` so `LLMCaller+Logging`'s `parseAndLog` can reach it (see `logger` below).
   let parser = JSONResponseParser()
   private let extractor = PartialOutputExtractor()
 
@@ -200,8 +199,8 @@ nonisolated struct LLMCaller: Sendable {
   // `logRepairIfNeeded`, `parseAndLog`, `logChatTemplateLeakage`,
   // `logEmptyFields`, `emitLangCheckSkipped`) live in
   // `LLMCaller+Logging.swift` to keep this file under SwiftLint's
-  // `file_length` budget. `parseAndLog` is the one that is not pure log
-  // emission — it parses and returns a `TurnOutput` (#1422).
+  // `file_length` budget. `parseAndLog` also parses — it is the sole
+  // production caller of `JSONResponseParser.parse` (#1422).
 
   // `hasEmptyFields`, `canonicalPrimaryIsMissing` and `shouldRetryEmptyFields`
   // live in `LLMCaller+EmptyPrimary.swift` to keep this file under SwiftLint's

--- a/Pastura/Pastura/Engine/LLMCaller.swift
+++ b/Pastura/Pastura/Engine/LLMCaller.swift
@@ -196,10 +196,12 @@ nonisolated struct LLMCaller: Sendable {
     let completionTokens: Int?
   }
 
-  // Log-emission helpers (`logParseFailure`, `emitRetryCause`,
-  // `logRepairIfNeeded`, `logChatTemplateLeakage`, `logEmptyFields`,
-  // `emitLangCheckSkipped`) live in `LLMCaller+Logging.swift` to keep this
-  // file under SwiftLint's `file_length` budget.
+  // Diagnostics helpers (`logParseFailure`, `emitRetryCause`,
+  // `logRepairIfNeeded`, `parseAndLog`, `logChatTemplateLeakage`,
+  // `logEmptyFields`, `emitLangCheckSkipped`) live in
+  // `LLMCaller+Logging.swift` to keep this file under SwiftLint's
+  // `file_length` budget. `parseAndLog` is the one that is not pure log
+  // emission — it parses and returns a `TurnOutput` (#1422).
 
   // `hasEmptyFields`, `canonicalPrimaryIsMissing` and `shouldRetryEmptyFields`
   // live in `LLMCaller+EmptyPrimary.swift` to keep this file under SwiftLint's

--- a/Pastura/Pastura/LLM/JSONResponseParser+Truncate.swift
+++ b/Pastura/Pastura/LLM/JSONResponseParser+Truncate.swift
@@ -53,10 +53,21 @@ nonisolated extension JSONResponseParser {
     let chars = Array(text)
     var cut = chars.count
 
-    // End arm — unguarded and string-blind. String-blindness is a known,
-    // accepted gap (a marker spelled inside a JSON string value cuts
-    // mid-string): closing it would change behaviour for ChatML backends,
-    // which this change holds fixed. See the PR body for #1422.
+    // End arm — unguarded and string-blind. Both properties are accepted
+    // gaps, kept because closing either would change behaviour for ChatML
+    // backends, which this change holds fixed. The list is exhaustive:
+    //
+    // 1. String-blind — a marker spelled inside a JSON string value cuts
+    //    mid-string. Not a clean parse failure: the cut leaves an unclosed
+    //    string, the repair pipeline closes the quote and the brace, and the
+    //    silently-truncated value parses and persists (#1422 PR body).
+    // 2. Leading end marker — one occurring before the first structural `{`
+    //    cuts at that index and destroys the entire payload, so a model that
+    //    opens by echoing its own turn-close sentinel loses the object it
+    //    then writes → parse_failed → retry. Deliberately unchanged; the
+    //    obvious `> firstBrace` guard is not strictly safer, because it makes
+    //    `<|im_end|>{"fake":1}` an accepted fabricated object where today it
+    //    fails and retries. Tracked in #1452.
     for marker in markers where !marker.end.isEmpty {
       if let index = Self.firstIndex(of: marker.end, in: chars, from: 0) {
         cut = min(cut, index)

--- a/Pastura/Pastura/LLM/JSONResponseParser+Truncate.swift
+++ b/Pastura/Pastura/LLM/JSONResponseParser+Truncate.swift
@@ -55,7 +55,7 @@ nonisolated extension JSONResponseParser {
 
     // End arm — unguarded and string-blind. Both properties are accepted
     // gaps, kept because closing either would change behaviour for ChatML
-    // backends, which this change holds fixed. The list is exhaustive:
+    // backends, which this change holds fixed. The two known gaps:
     //
     // 1. String-blind — a marker spelled inside a JSON string value cuts
     //    mid-string. Not a clean parse failure: the cut leaves an unclosed

--- a/Pastura/Pastura/LLM/JSONResponseParser+Truncate.swift
+++ b/Pastura/Pastura/LLM/JSONResponseParser+Truncate.swift
@@ -19,9 +19,14 @@ nonisolated extension JSONResponseParser {
   /// both would be wrong in one direction or the other.
   ///
   /// - **End marker** — a turn boundary wherever it occurs: everything after it
-  ///   belongs to a turn that is not this one. Cut unguarded, from the first
-  ///   occurrence to end-of-string. This is the pre-#1422 behaviour, generalized
-  ///   from one hardcoded string to a set, so a ChatML backend is byte-identical.
+  ///   belongs to a turn that is not this one. Cut with no `firstBrace` gate,
+  ///   from the first occurrence to end-of-string. String-aware for every end
+  ///   marker **except ChatML's own**, which stays blind so a ChatML backend is
+  ///   byte-identical to pre-#1422 — the one exception the acceptance criterion
+  ///   requires, and the reason the check is keyed on `.chatML.end` by literal.
+  ///   Everything else is guarded, because a mid-value cut does not fail loudly:
+  ///   the repair pipeline closes the quote and brace and persists a truncated
+  ///   value.
   ///
   /// - **Start marker** — cut **only** at an occurrence after the first
   ///   structural `{`. A *leading* start marker is the model echoing its own
@@ -53,50 +58,90 @@ nonisolated extension JSONResponseParser {
     let chars = Array(text)
     var cut = chars.count
 
-    // End arm — unguarded and string-blind. Both properties are accepted
-    // gaps, kept because closing either would change behaviour for ChatML
-    // backends, which this change holds fixed. The two known gaps:
+    // Both arms may need string context. Pay for the scan only when something
+    // actually calls for it: any start marker present, or any *non-ChatML* end
+    // marker present (the ChatML end marker stays string-blind — see below).
+    let needsStringScan =
+      markers.contains(where: { !$0.start.isEmpty && text.contains($0.start) })
+      || markers.contains(where: {
+        !$0.end.isEmpty && $0.end != ChatTurnMarkers.chatML.end && text.contains($0.end)
+      })
+    let machine = needsStringScan ? StringStateMachine(text) : nil
+
+    // End arm — no `firstBrace` gate (accepted gap 2 below), and string-aware
+    // for every end marker EXCEPT ChatML's own.
     //
-    // 1. String-blind — a marker spelled inside a JSON string value cuts
-    //    mid-string. Not a clean parse failure: the cut leaves an unclosed
-    //    string, the repair pipeline closes the quote and the brace, and the
-    //    silently-truncated value parses and persists (#1422 PR body).
-    // 2. Leading end marker — one occurring before the first structural `{`
-    //    cuts at that index and destroys the entire payload, so a model that
-    //    opens by echoing its own turn-close sentinel loses the object it
-    //    then writes → parse_failed → retry. Deliberately unchanged; the
-    //    obvious `> firstBrace` guard is not strictly safer, because it makes
-    //    `<|im_end|>{"fake":1}` an accepted fabricated object where today it
-    //    fails and retries. Tracked in #1452.
+    // The asymmetry is not cosmetic. String-blindness corrupts silently: the cut
+    // lands mid-value, the repair pipeline closes the quote and the brace, and
+    // the truncated value parses and persists as the agent's answer. Measured on
+    // `{"note": "… <turn|> …"}` — accepted, repair `unclosed_string+unclosed_brace`.
+    // It is reachable for a *newly* added marker because `stopSequence` still
+    // strips only `<|im_end|>` (#1451), so `<turn|>` is the first end marker that
+    // survives generation. Guarding it is provably ChatML-neutral, which is the
+    // whole reason the exception is keyed on the literal rather than on "the
+    // first marker" or "the descriptor's own": ChatML backends must stay
+    // byte-identical, and `.chatML.end` is exactly the value that was already
+    // shipping blind.
+    //
+    // Two accepted gaps remain, both ChatML-only by construction now:
+    //
+    // 1. `<|im_end|>` inside a string value still cuts mid-value. Pre-existing
+    //    and left alone: closing it would move ChatML behaviour, which #1422
+    //    holds fixed. Worth closing on its own merits, separately.
+    // 2. A *leading* end marker (before the first structural `{`) cuts at that
+    //    index and destroys the entire payload → parse_failed → retry.
+    //    Deliberately unchanged: the obvious `> firstBrace` guard is not
+    //    strictly safer, because it makes `<|im_end|>{"fake":1}` an accepted
+    //    fabricated object where today it fails and retries. Tracked in #1452.
     for marker in markers where !marker.end.isEmpty {
-      if let index = Self.firstIndex(of: marker.end, in: chars, from: 0) {
+      let index: Int? =
+        if marker.end == ChatTurnMarkers.chatML.end || machine == nil {
+          Self.firstIndex(of: marker.end, in: chars, from: 0)
+        } else if let machine {
+          Self.firstIndex(of: marker.end, in: chars, from: 0, outsideStringsOf: machine)
+        } else {
+          nil
+        }
+      if let index {
         cut = min(cut, index)
       }
     }
 
-    // Start arm — needs string context, so pay for the scan only if some
-    // start marker actually occurs at all.
-    if markers.contains(where: { !$0.start.isEmpty && text.contains($0.start) }) {
-      let machine = StringStateMachine(text)
-      if let firstBrace = chars.indices.first(where: {
+    // Start arm — cuts only after the first structural `{`, and skips markers
+    // inside string literals.
+    if let machine,
+      markers.contains(where: { !$0.start.isEmpty && text.contains($0.start) }),
+      let firstBrace = chars.indices.first(where: {
         chars[$0] == "{" && !machine.isInsideString(at: $0)
       }) {
-        for marker in markers where !marker.start.isEmpty {
-          var searchFrom = firstBrace + 1
-          while let index = Self.firstIndex(of: marker.start, in: chars, from: searchFrom) {
-            // A marker inside a string literal is payload content, not a turn
-            // boundary — skip past it and keep looking.
-            if !machine.isInsideString(at: index) {
-              cut = min(cut, index)
-              break
-            }
-            searchFrom = index + 1
-          }
+      for marker in markers where !marker.start.isEmpty {
+        if let index = Self.firstIndex(
+          of: marker.start, in: chars, from: firstBrace + 1, outsideStringsOf: machine) {
+          cut = min(cut, index)
         }
       }
     }
 
     return cut == chars.count ? text : String(chars[..<cut])
+  }
+
+  /// First index at or after `from` where `needle` matches **outside** a JSON
+  /// string literal. An occurrence inside one is payload content, not a turn
+  /// boundary, so it is skipped and the scan continues past it.
+  ///
+  /// Deliberately a distinct name rather than a defaulted parameter on
+  /// ``firstIndex(of:in:from:)``: a default would make every existing 3-argument
+  /// call ambiguous.
+  private static func firstIndex(
+    of needle: String, in chars: [Character], from: Int,
+    outsideStringsOf machine: StringStateMachine
+  ) -> Int? {
+    var searchFrom = from
+    while let index = firstIndex(of: needle, in: chars, from: searchFrom) {
+      if !machine.isInsideString(at: index) { return index }
+      searchFrom = index + 1
+    }
+    return nil
   }
 
   /// First index in `chars` at or after `from` where `needle`'s characters

--- a/Pastura/Pastura/LLM/JSONResponseParser+Truncate.swift
+++ b/Pastura/Pastura/LLM/JSONResponseParser+Truncate.swift
@@ -1,52 +1,49 @@
 import Foundation
 
-/// Hallucinated-turn truncation, split out of `JSONResponseParser.swift`
-/// (which sits at the `file_length` cap the pre-commit `swiftlint --strict`
-/// treats as fatal).
+/// Hallucinated-turn truncation, split out of `JSONResponseParser.swift` (which sits at the
+/// `file_length` cap `swiftlint --strict` treats as fatal).
 ///
-/// `nonisolated` on the **extension** is load-bearing, not decoration: a plain
-/// sibling-file extension of a `nonisolated` type inherits MainActor under
-/// `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, and the diagnostic then fires
-/// at the *call site* in the main file rather than here
-/// (`.claude/rules/swift-isolation.md` Pattern 3).
+/// `nonisolated` on the **extension** is load-bearing: a plain sibling-file extension of a
+/// `nonisolated` type inherits MainActor, and the diagnostic then fires at the *call site*
+/// in the main file rather than here (`.claude/rules/swift-isolation.md` Pattern 3).
 nonisolated extension JSONResponseParser {
-  /// Truncate at the first hallucinated turn boundary, keying on the loaded
-  /// model's own markers rather than a hardcoded ChatML literal (#1422).
+  /// Truncate at the first hallucinated turn boundary, keying on the loaded model's own
+  /// markers rather than a hardcoded ChatML literal (#1422).
   ///
   /// ### The two arms are deliberately asymmetric
   ///
-  /// The markers mean different things where they appear, so one predicate for
-  /// both would be wrong in one direction or the other.
+  /// The markers mean different things where they appear, so one predicate for both would
+  /// be wrong in one direction or the other.
   ///
-  /// - **End marker** — a turn boundary wherever it occurs: everything after it
-  ///   belongs to a turn that is not this one. Cut with no `firstBrace` gate,
-  ///   from the first occurrence to end-of-string. String-aware for every end
-  ///   marker **except ChatML's own**, which stays blind so a ChatML backend is
-  ///   byte-identical to pre-#1422 — the one exception the acceptance criterion
-  ///   requires, and the reason the check is keyed on `.chatML.end` by literal.
-  ///   Everything else is guarded, because a mid-value cut does not fail loudly:
-  ///   the repair pipeline closes the quote and brace and persists a truncated
-  ///   value.
+  /// - **End marker** — a boundary wherever it occurs: cut from the first occurrence to
+  ///   end-of-string, no `firstBrace` gate. String-aware for every end marker **except
+  ///   `.chatML.end`**, keyed on that literal so a ChatML backend stays byte-identical to
+  ///   pre-#1422. Everything else is guarded because a mid-value cut fails silently: the
+  ///   repair pipeline closes the quote and brace and persists a truncated value.
   ///
-  /// - **Start marker** — cut **only** at an occurrence after the first
-  ///   structural `{`. A *leading* start marker is the model echoing its own
-  ///   template header with the real payload still behind it; cutting there
-  ///   deletes the payload, and deterministically so (the backend's template
-  ///   config reproduces on every retry) → `parse_failed` → `retriesExhausted`
-  ///   → an ADR-021 turn skip. One *after* the first `{` is a fabricated next
-  ///   turn, and leaving it uncovered is not benign: `extractFromCodeBlock`
-  ///   runs **before** the balanced-brace scan and takes `firstMatch`
-  ///   unconditionally, so a fenced fabricated continuation is extracted and
-  ///   accepted silently.
+  /// - **Start marker** — cut **only** after the first structural `{`. A *leading* one is
+  ///   a template-header echo with the payload still behind it; cutting there deletes the
+  ///   payload deterministically (the template config reproduces on every retry) →
+  ///   `parse_failed` → `retriesExhausted` → an ADR-021 turn skip. One after the `{` is a
+  ///   fabricated next turn, and leaving *it* uncovered would not be benign:
+  ///   `extractFromCodeBlock` runs **before** the balanced-brace scan and takes `firstMatch`
+  ///   unconditionally, so a fenced continuation would be accepted silently.
+  ///
+  /// Two accepted gaps remain, both ChatML-only by construction:
+  ///
+  /// 1. `<|im_end|>` inside a string value still cuts mid-value. Pre-existing; closing it
+  ///    would move ChatML behaviour, which #1422 holds fixed.
+  /// 2. A *leading* end marker cuts at that index and destroys the payload →
+  ///    `parse_failed` → retry. Left as-is: a `> firstBrace` guard is not strictly safer,
+  ///    because it makes `<|im_end|>{"fake":1}` an accepted fabricated object where today
+  ///    it fails and retries. Tracked in #1452.
   ///
   /// ### Substring search, not regex
   ///
-  /// Interpolating a descriptor value into a pattern is a live trap rather than
-  /// a style question: Gemma's `<|turn>` contains a bare `|`, which compiles as
-  /// the alternation `<` **or** `turn>` and would cut at the first `<` anywhere
-  /// in the output — mass payload destruction for the default shipped model.
-  /// The trailing `.*` of the old pattern also does nothing a prefix slice does
-  /// not.
+  /// Interpolating a descriptor value into a pattern is a live trap: Gemma's `<|turn>`
+  /// contains a bare `|`, which compiles as `<` **or** `turn>` and would cut at the first
+  /// `<` anywhere in the output — mass payload destruction for the default shipped model.
+  /// The old pattern's trailing `.*` also does nothing a prefix slice does not.
   ///
   /// - Parameters:
   ///   - text: Output text, already stripped of thinking tags.
@@ -68,31 +65,11 @@ nonisolated extension JSONResponseParser {
       })
     let machine = needsStringScan ? StringStateMachine(text) : nil
 
-    // End arm — no `firstBrace` gate (accepted gap 2 below), and string-aware
-    // for every end marker EXCEPT ChatML's own.
-    //
-    // The asymmetry is not cosmetic. String-blindness corrupts silently: the cut
-    // lands mid-value, the repair pipeline closes the quote and the brace, and
-    // the truncated value parses and persists as the agent's answer. Measured on
-    // `{"note": "… <turn|> …"}` — accepted, repair `unclosed_string+unclosed_brace`.
-    // It is reachable for a *newly* added marker because `stopSequence` still
-    // strips only `<|im_end|>` (#1451), so `<turn|>` is the first end marker that
-    // survives generation. Guarding it is provably ChatML-neutral, which is the
-    // whole reason the exception is keyed on the literal rather than on "the
-    // first marker" or "the descriptor's own": ChatML backends must stay
-    // byte-identical, and `.chatML.end` is exactly the value that was already
-    // shipping blind.
-    //
-    // Two accepted gaps remain, both ChatML-only by construction now:
-    //
-    // 1. `<|im_end|>` inside a string value still cuts mid-value. Pre-existing
-    //    and left alone: closing it would move ChatML behaviour, which #1422
-    //    holds fixed. Worth closing on its own merits, separately.
-    // 2. A *leading* end marker (before the first structural `{`) cuts at that
-    //    index and destroys the entire payload → parse_failed → retry.
-    //    Deliberately unchanged: the obvious `> firstBrace` guard is not
-    //    strictly safer, because it makes `<|im_end|>{"fake":1}` an accepted
-    //    fabricated object where today it fails and retries. Tracked in #1452.
+    // End arm — see the doc comment for the asymmetry and the two accepted gaps.
+    // String-blindness measured on `{"note": "… <turn|> …"}`: accepted, repair
+    // `unclosed_string+unclosed_brace`. Reachable for a *newly* added marker because
+    // `stopSequence` still strips only `<|im_end|>` (#1451), so `<turn|>` is the first
+    // end marker that survives generation.
     for marker in markers where !marker.end.isEmpty {
       let index: Int? =
         if marker.end == ChatTurnMarkers.chatML.end || machine == nil {
@@ -129,9 +106,8 @@ nonisolated extension JSONResponseParser {
   /// string literal. An occurrence inside one is payload content, not a turn
   /// boundary, so it is skipped and the scan continues past it.
   ///
-  /// Deliberately a distinct name rather than a defaulted parameter on
-  /// ``firstIndex(of:in:from:)``: a default would make every existing 3-argument
-  /// call ambiguous.
+  /// A distinct name rather than a defaulted parameter on ``firstIndex(of:in:from:)``,
+  /// which would make every existing 3-argument call ambiguous.
   private static func firstIndex(
     of needle: String, in chars: [Character], from: Int,
     outsideStringsOf machine: StringStateMachine

--- a/Pastura/Pastura/LLM/JSONResponseParser+Truncate.swift
+++ b/Pastura/Pastura/LLM/JSONResponseParser+Truncate.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+/// Hallucinated-turn truncation, split out of `JSONResponseParser.swift`
+/// (which sits at the `file_length` cap the pre-commit `swiftlint --strict`
+/// treats as fatal).
+///
+/// `nonisolated` on the **extension** is load-bearing, not decoration: a plain
+/// sibling-file extension of a `nonisolated` type inherits MainActor under
+/// `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, and the diagnostic then fires
+/// at the *call site* in the main file rather than here
+/// (`.claude/rules/swift-isolation.md` Pattern 3).
+nonisolated extension JSONResponseParser {
+  /// Truncate at the first hallucinated turn boundary, keying on the loaded
+  /// model's own markers rather than a hardcoded ChatML literal (#1422).
+  ///
+  /// ### The two arms are deliberately asymmetric
+  ///
+  /// The markers mean different things where they appear, so one predicate for
+  /// both would be wrong in one direction or the other.
+  ///
+  /// - **End marker** — a turn boundary wherever it occurs: everything after it
+  ///   belongs to a turn that is not this one. Cut unguarded, from the first
+  ///   occurrence to end-of-string. This is the pre-#1422 behaviour, generalized
+  ///   from one hardcoded string to a set, so a ChatML backend is byte-identical.
+  ///
+  /// - **Start marker** — cut **only** at an occurrence after the first
+  ///   structural `{`. A *leading* start marker is the model echoing its own
+  ///   template header with the real payload still behind it; cutting there
+  ///   deletes the payload, and deterministically so (the backend's template
+  ///   config reproduces on every retry) → `parse_failed` → `retriesExhausted`
+  ///   → an ADR-021 turn skip. One *after* the first `{` is a fabricated next
+  ///   turn, and leaving it uncovered is not benign: `extractFromCodeBlock`
+  ///   runs **before** the balanced-brace scan and takes `firstMatch`
+  ///   unconditionally, so a fenced fabricated continuation is extracted and
+  ///   accepted silently.
+  ///
+  /// ### Substring search, not regex
+  ///
+  /// Interpolating a descriptor value into a pattern is a live trap rather than
+  /// a style question: Gemma's `<|turn>` contains a bare `|`, which compiles as
+  /// the alternation `<` **or** `turn>` and would cut at the first `<` anywhere
+  /// in the output — mass payload destruction for the default shipped model.
+  /// The trailing `.*` of the old pattern also does nothing a prefix slice does
+  /// not.
+  ///
+  /// - Parameters:
+  ///   - text: Output text, already stripped of thinking tags.
+  ///   - markers: The effective set, from `LLMService.knownTurnMarkers`.
+  /// - Returns: `text` up to the earliest qualifying cut point, or `text`
+  ///   unchanged when no marker qualifies.
+  func truncateAtTurnMarkers(_ text: String, markers: [ChatTurnMarkers]) -> String {
+    guard !markers.isEmpty, !text.isEmpty else { return text }
+    let chars = Array(text)
+    var cut = chars.count
+
+    // End arm — unguarded and string-blind. String-blindness is a known,
+    // accepted gap (a marker spelled inside a JSON string value cuts
+    // mid-string): closing it would change behaviour for ChatML backends,
+    // which this change holds fixed. See the PR body for #1422.
+    for marker in markers where !marker.end.isEmpty {
+      if let index = Self.firstIndex(of: marker.end, in: chars, from: 0) {
+        cut = min(cut, index)
+      }
+    }
+
+    // Start arm — needs string context, so pay for the scan only if some
+    // start marker actually occurs at all.
+    if markers.contains(where: { !$0.start.isEmpty && text.contains($0.start) }) {
+      let machine = StringStateMachine(text)
+      if let firstBrace = chars.indices.first(where: {
+        chars[$0] == "{" && !machine.isInsideString(at: $0)
+      }) {
+        for marker in markers where !marker.start.isEmpty {
+          var searchFrom = firstBrace + 1
+          while let index = Self.firstIndex(of: marker.start, in: chars, from: searchFrom) {
+            // A marker inside a string literal is payload content, not a turn
+            // boundary — skip past it and keep looking.
+            if !machine.isInsideString(at: index) {
+              cut = min(cut, index)
+              break
+            }
+            searchFrom = index + 1
+          }
+        }
+      }
+    }
+
+    return cut == chars.count ? text : String(chars[..<cut])
+  }
+
+  /// First index in `chars` at or after `from` where `needle`'s characters
+  /// match. Character-offset based so results line up with
+  /// ``StringStateMachine/insideStringFlags``, which is indexed the same way.
+  private static func firstIndex(
+    of needle: String, in chars: [Character], from: Int
+  ) -> Int? {
+    let pattern = Array(needle)
+    guard !pattern.isEmpty, from >= 0, chars.count >= pattern.count else { return nil }
+    let last = chars.count - pattern.count
+    guard from <= last else { return nil }
+    for start in from...last
+    where chars[start..<(start + pattern.count)].elementsEqual(pattern) {
+      return start
+    }
+    return nil
+  }
+}

--- a/Pastura/Pastura/LLM/JSONResponseParser.swift
+++ b/Pastura/Pastura/LLM/JSONResponseParser.swift
@@ -38,8 +38,9 @@ nonisolated public struct JSONResponseParser: Sendable {
   ///   - text: The raw text response from the LLM.
   ///   - turnMarkers: Turn-boundary sentinels to truncate hallucinated turns at
   ///     — pass `LLMService.knownTurnMarkers` from the call site. Defaults to
-  ///     ChatML only, the pre-#1422 behaviour, so replay and test callers that
-  ///     have no backend in scope are unchanged.
+  ///     ChatML only, the pre-#1422 behaviour, so test callers that have no
+  ///     backend in scope are unchanged. (No production path reaches this
+  ///     overload: `LLMCaller` uses the `expectedKeys` one below.)
   /// - Returns: A ``TurnOutput`` with all values normalized to `String`.
   /// - Throws: ``LLMError/invalidResponse(raw:)`` if no valid JSON can be extracted.
   public func parse(
@@ -56,8 +57,8 @@ nonisolated public struct JSONResponseParser: Sendable {
   /// 2. Truncate at a hallucinated turn boundary, keyed on `turnMarkers` —
   ///    asymmetric per arm, see `truncateAtTurnMarkers(_:markers:)` in
   ///    `JSONResponseParser+Truncate.swift` (#1422). Plain code span, not a
-  ///    DocC link: that member is internal, so a `` `` link from this public
-  ///    symbol does not resolve.
+  ///    DocC symbol link: that member is internal, so a symbol link from this
+  ///    public symbol does not resolve.
   /// 3. Extract content from markdown code blocks
   /// 4. Extract the first balanced `{...}` object (string-aware), discarding
   ///    any trailing content after its matching close brace
@@ -93,8 +94,8 @@ nonisolated public struct JSONResponseParser: Sendable {
   ///     at. **Engine call sites must pass `LLMService.knownTurnMarkers`
   ///     explicitly** — this is the overload `LLMCaller` uses, and taking the
   ///     default there is the #1422 bug (ChatML literals, inert for Gemma).
-  ///     The default exists only for callers with no backend in scope, namely
-  ///     replay and tests, whose pre-#1422 behaviour it preserves.
+  ///     The default exists for callers with no backend in scope — today that
+  ///     is tests only, and it preserves their pre-#1422 behaviour.
   /// - Returns: tuple of the parsed ``TurnOutput`` plus the applied repair
   ///   kind (`"unclosed_string"` / `"unclosed_brace"`, or `+`-joined for
   ///   the composite). `nil` repair kind means the input parsed cleanly

--- a/Pastura/Pastura/LLM/JSONResponseParser.swift
+++ b/Pastura/Pastura/LLM/JSONResponseParser.swift
@@ -54,7 +54,10 @@ nonisolated public struct JSONResponseParser: Sendable {
   /// Processing pipeline:
   /// 1. Strip thinking tags (`<think>...`, `<|channel>thought...`)
   /// 2. Truncate at a hallucinated turn boundary, keyed on `turnMarkers` —
-  ///    asymmetric per arm, see ``truncateAtTurnMarkers(_:markers:)`` (#1422)
+  ///    asymmetric per arm, see `truncateAtTurnMarkers(_:markers:)` in
+  ///    `JSONResponseParser+Truncate.swift` (#1422). Plain code span, not a
+  ///    DocC link: that member is internal, so a `` `` link from this public
+  ///    symbol does not resolve.
   /// 3. Extract content from markdown code blocks
   /// 4. Extract the first balanced `{...}` object (string-aware), discarding
   ///    any trailing content after its matching close brace
@@ -83,6 +86,15 @@ nonisolated public struct JSONResponseParser: Sendable {
   /// JSON missing any of those keys is rejected — preserves the original
   /// throw rather than fabricating a `TurnOutput` (#194 PR#a Item 2d).
   ///
+  /// - Parameters:
+  ///   - text: The raw text response from the LLM.
+  ///   - expectedKeys: Schema keys a repaired parse must all carry.
+  ///   - turnMarkers: Turn-boundary sentinels to truncate hallucinated turns
+  ///     at. **Engine call sites must pass `LLMService.knownTurnMarkers`
+  ///     explicitly** — this is the overload `LLMCaller` uses, and taking the
+  ///     default there is the #1422 bug (ChatML literals, inert for Gemma).
+  ///     The default exists only for callers with no backend in scope, namely
+  ///     replay and tests, whose pre-#1422 behaviour it preserves.
   /// - Returns: tuple of the parsed ``TurnOutput`` plus the applied repair
   ///   kind (`"unclosed_string"` / `"unclosed_brace"`, or `+`-joined for
   ///   the composite). `nil` repair kind means the input parsed cleanly

--- a/Pastura/Pastura/LLM/JSONResponseParser.swift
+++ b/Pastura/Pastura/LLM/JSONResponseParser.swift
@@ -30,9 +30,8 @@ nonisolated public struct JSONResponseParser: Sendable {
   /// Parse raw LLM output text into a ``TurnOutput``.
   ///
   /// Thin wrapper over ``parse(_:expectedKeys:)`` with no schema-aware
-  /// repair guard. Existing callers that don't have ``Phase/outputSchema``
-  /// in scope (most tests, replay paths) keep the same `TurnOutput`-only
-  /// return shape.
+  /// repair guard. Callers that don't have ``Phase/outputSchema`` in scope
+  /// (today: tests only) keep the same `TurnOutput`-only return shape.
   ///
   /// - Parameters:
   ///   - text: The raw text response from the LLM.

--- a/Pastura/Pastura/LLM/JSONResponseParser.swift
+++ b/Pastura/Pastura/LLM/JSONResponseParser.swift
@@ -20,13 +20,6 @@ nonisolated public struct JSONResponseParser: Sendable {
     pattern: #"<think>.*?</think>"#,
     options: .dotMatchesLineSeparators
   )
-  // Chat template tokens — truncate everything from first occurrence onwards.
-  // Catches hallucinated continuations where the model generates past its own turn.
-  // ChatML-only — see the doc on `truncateAtChatTemplateToken`.
-  private static let chatTemplateTokenRegex = try? NSRegularExpression(
-    pattern: #"<\|im_end\|>.*"#,
-    options: .dotMatchesLineSeparators
-  )
   private static let codeBlockRegex = try? NSRegularExpression(
     pattern: #"```(?:json)?\s*\n?(.*?)\n?```"#,
     options: .dotMatchesLineSeparators
@@ -41,11 +34,18 @@ nonisolated public struct JSONResponseParser: Sendable {
   /// in scope (most tests, replay paths) keep the same `TurnOutput`-only
   /// return shape.
   ///
-  /// - Parameter text: The raw text response from the LLM.
+  /// - Parameters:
+  ///   - text: The raw text response from the LLM.
+  ///   - turnMarkers: Turn-boundary sentinels to truncate hallucinated turns at
+  ///     — pass `LLMService.knownTurnMarkers` from the call site. Defaults to
+  ///     ChatML only, the pre-#1422 behaviour, so replay and test callers that
+  ///     have no backend in scope are unchanged.
   /// - Returns: A ``TurnOutput`` with all values normalized to `String`.
   /// - Throws: ``LLMError/invalidResponse(raw:)`` if no valid JSON can be extracted.
-  public func parse(_ text: String) throws -> TurnOutput {
-    let (output, _) = try parse(text, expectedKeys: [])
+  public func parse(
+    _ text: String, turnMarkers: [ChatTurnMarkers] = [.chatML]
+  ) throws -> TurnOutput {
+    let (output, _) = try parse(text, expectedKeys: [], turnMarkers: turnMarkers)
     return output
   }
 
@@ -53,8 +53,8 @@ nonisolated public struct JSONResponseParser: Sendable {
   ///
   /// Processing pipeline:
   /// 1. Strip thinking tags (`<think>...`, `<|channel>thought...`)
-  /// 2. Truncate at the ChatML chat-template token (`<|im_end|>`) — ChatML
-  ///    models only (#1422)
+  /// 2. Truncate at a hallucinated turn boundary, keyed on `turnMarkers` —
+  ///    asymmetric per arm, see ``truncateAtTurnMarkers(_:markers:)`` (#1422)
   /// 3. Extract content from markdown code blocks
   /// 4. Extract the first balanced `{...}` object (string-aware), discarding
   ///    any trailing content after its matching close brace
@@ -90,9 +90,10 @@ nonisolated public struct JSONResponseParser: Sendable {
   /// - Throws: ``LLMError/invalidResponse(raw:)`` when no repair attempt
   ///   yields parseable JSON satisfying the schema guard.
   public func parse(
-    _ text: String, expectedKeys: Set<String>
+    _ text: String, expectedKeys: Set<String>,
+    turnMarkers: [ChatTurnMarkers] = [.chatML]
   ) throws -> (TurnOutput, repairKind: String?) {
-    let cleaned = applyCleanupPipeline(text)
+    let cleaned = applyCleanupPipeline(text, turnMarkers: turnMarkers)
 
     // Try as-is — happy path, no repair needed.
     if let output = tryParse(cleaned, originalText: text) {
@@ -102,7 +103,8 @@ nonisolated public struct JSONResponseParser: Sendable {
     // Schema-guarded multi-object salvage (#907) — recovers a complete-but-
     // followed-by-junk first object before the repair pipeline runs.
     if !expectedKeys.isEmpty {
-      let salvaged = applyCleanupPipeline(text, allowObjectResidue: true)
+      let salvaged = applyCleanupPipeline(
+        text, turnMarkers: turnMarkers, allowObjectResidue: true)
       if let output = tryParse(salvaged, originalText: text),
         hasAllExpectedKeys(output, expectedKeys: expectedKeys) {
         return (output, "multi_object_salvage")
@@ -173,11 +175,11 @@ nonisolated public struct JSONResponseParser: Sendable {
   }
 
   private func applyCleanupPipeline(
-    _ text: String, allowObjectResidue: Bool = false
+    _ text: String, turnMarkers: [ChatTurnMarkers], allowObjectResidue: Bool = false
   ) -> String {
     var cleaned = text.trimmingCharacters(in: .whitespacesAndNewlines)
     cleaned = stripThinkingTags(cleaned)
-    cleaned = truncateAtChatTemplateToken(cleaned)
+    cleaned = truncateAtTurnMarkers(cleaned, markers: turnMarkers)
     cleaned = extractFromCodeBlock(cleaned)
     cleaned = cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
     // Always extract: a `{`/`}`-framed string is NOT proof of a clean single
@@ -282,27 +284,6 @@ nonisolated public struct JSONResponseParser: Sendable {
     }
 
     return result
-  }
-
-  /// Truncate at the first ChatML chat-template token (`<|im_end|>`).
-  ///
-  /// When a **ChatML** model hallucinates past its own turn it emits
-  /// `<|im_end|>` as text, followed by fabricated user/assistant turns.
-  /// Discarding everything from the first such token prevents the greedy JSON
-  /// regex from capturing content across hallucinated turns.
-  ///
-  /// - Important: the token is hardcoded, so for a non-ChatML model this fires
-  ///   only on a spelled-out `<|im_end|>` — not the form a Gemma hallucination
-  ///   would take (Gemma 4's markers are `<|turn>` / `<turn|>`). This type is
-  ///   also backend-agnostic (`LLMCaller` parses llama.cpp, Ollama and
-  ///   Foundation Models through one instance), so do not import the llama.cpp
-  ///   control-token guarantee (`LlamaCppService.stopSequence`) here: a
-  ///   server-decoding backend offers none, which is why
-  ///   `LLMCaller.logChatTemplateLeakage` exists. Per-model sourcing is #1422.
-  private func truncateAtChatTemplateToken(_ text: String) -> String {
-    guard let regex = Self.chatTemplateTokenRegex else { return text }
-    let range = NSRange(text.startIndex..., in: text)
-    return regex.stringByReplacingMatches(in: text, range: range, withTemplate: "")
   }
 
   /// Extract content from markdown code blocks: `` ```json ... ``` `` or `` ``` ... ``` ``

--- a/Pastura/Pastura/LLM/JSONResponseParser.swift
+++ b/Pastura/Pastura/LLM/JSONResponseParser.swift
@@ -35,11 +35,8 @@ nonisolated public struct JSONResponseParser: Sendable {
   ///
   /// - Parameters:
   ///   - text: The raw text response from the LLM.
-  ///   - turnMarkers: Turn-boundary sentinels to truncate hallucinated turns at
-  ///     — pass `LLMService.knownTurnMarkers` from the call site. Defaults to
-  ///     ChatML only, the pre-#1422 behaviour, so test callers that have no
-  ///     backend in scope are unchanged. (No production path reaches this
-  ///     overload: `LLMCaller` uses the `expectedKeys` one below.)
+  ///   - turnMarkers: Turn-boundary sentinels to truncate hallucinated turns at; defaults
+  ///     to ChatML only (pre-#1422 behaviour). No production path reaches this overload.
   /// - Returns: A ``TurnOutput`` with all values normalized to `String`.
   /// - Throws: ``LLMError/invalidResponse(raw:)`` if no valid JSON can be extracted.
   public func parse(
@@ -55,9 +52,7 @@ nonisolated public struct JSONResponseParser: Sendable {
   /// 1. Strip thinking tags (`<think>...`, `<|channel>thought...`)
   /// 2. Truncate at a hallucinated turn boundary, keyed on `turnMarkers` —
   ///    asymmetric per arm, see `truncateAtTurnMarkers(_:markers:)` in
-  ///    `JSONResponseParser+Truncate.swift` (#1422). Plain code span, not a
-  ///    DocC symbol link: that member is internal, so a symbol link from this
-  ///    public symbol does not resolve.
+  ///    `JSONResponseParser+Truncate.swift` (#1422)
   /// 3. Extract content from markdown code blocks
   /// 4. Extract the first balanced `{...}` object (string-aware), discarding
   ///    any trailing content after its matching close brace
@@ -89,12 +84,11 @@ nonisolated public struct JSONResponseParser: Sendable {
   /// - Parameters:
   ///   - text: The raw text response from the LLM.
   ///   - expectedKeys: Schema keys a repaired parse must all carry.
-  ///   - turnMarkers: Turn-boundary sentinels to truncate hallucinated turns
-  ///     at. **Engine call sites must pass `LLMService.knownTurnMarkers`
-  ///     explicitly** — this is the overload `LLMCaller` uses, and taking the
-  ///     default there is the #1422 bug (ChatML literals, inert for Gemma).
-  ///     The default exists for callers with no backend in scope — today that
-  ///     is tests only, and it preserves their pre-#1422 behaviour.
+  ///   - turnMarkers: Turn-boundary sentinels to truncate hallucinated turns at.
+  ///     **Engine call sites must pass `LLMService.knownTurnMarkers` explicitly** — this
+  ///     is the overload `LLMCaller` uses, and taking the default there is the #1422 bug
+  ///     (ChatML literals, inert for Gemma). The default serves callers with no backend
+  ///     in scope (today tests only), preserving their pre-#1422 behaviour.
   /// - Returns: tuple of the parsed ``TurnOutput`` plus the applied repair
   ///   kind (`"unclosed_string"` / `"unclosed_brace"`, or `+`-joined for
   ///   the composite). `nil` repair kind means the input parsed cleanly

--- a/Pastura/Pastura/LLM/LLMService.swift
+++ b/Pastura/Pastura/LLM/LLMService.swift
@@ -97,6 +97,24 @@ nonisolated public protocol LLMService: Sendable {
   /// metadata — **not** a stable parse key.
   var backendIdentifier: String { get }
 
+  /// Every turn-marker pair whose **plaintext** form could plausibly appear in
+  /// this backend's decoded output, for consumers that must recognize a
+  /// hallucinated turn boundary (``JSONResponseParser`` truncation, the
+  /// `LLMCaller` chat-template leakage diagnostic).
+  ///
+  /// The set is the loaded model's own pair **unioned with**
+  /// ``ChatTurnMarkers/chatML``, so a backend that cannot name its model
+  /// (``OllamaService``, ``MockLLMService``) keeps the pre-#1422 ChatML-only
+  /// behaviour via the default implementation, and a ChatML model does not
+  /// grow a second, redundant entry.
+  ///
+  /// - Important: Declared **in the protocol body**, not only in an extension.
+  ///   An extension-only declaration is statically dispatched through
+  ///   `any LLMService`, so ``LlamaCppService``'s override would be silently
+  ///   ignored at the `LLMCaller` call site — with no diagnostic, and with the
+  ///   exact failure this requirement exists to remove.
+  var knownTurnMarkers: [ChatTurnMarkers] { get }
+
   /// Generate a completion as a sequence of incremental chunks.
   ///
   /// Backends that can deliver tokens as they are sampled (currently
@@ -155,6 +173,18 @@ extension LLMService {
   /// support cooperative suspend (currently only ``LlamaCppService``) override
   /// this method.
   public func attachSuspendController(_ controller: SuspendController?) async {}
+
+  /// Default: ChatML only — the pre-#1422 hardcoded behaviour, now stated as a
+  /// value rather than baked into each consumer. Backends that know which
+  /// model is loaded override this (currently only ``LlamaCppService``).
+  ///
+  /// Explicitly `nonisolated` for the same reason as `generateStream` below:
+  /// under `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` this default impl
+  /// otherwise inherits MainActor and blocks every `nonisolated` conformer.
+  /// Not defensive — measured by dropping the annotation, which fails the
+  /// build with `conformance of 'MockLLMService' to protocol 'LLMService'
+  /// crosses into main actor-isolated code` (and the same for `OllamaService`).
+  nonisolated public var knownTurnMarkers: [ChatTurnMarkers] { [.chatML] }
 
   /// Default `generateStream` implementation: runs the existing
   /// `generateWithMetrics` and yields a single terminal chunk carrying

--- a/Pastura/Pastura/LLM/LLMService.swift
+++ b/Pastura/Pastura/LLM/LLMService.swift
@@ -178,9 +178,15 @@ extension LLMService {
   /// value rather than baked into each consumer. Backends that know which
   /// model is loaded override this (currently only ``LlamaCppService``).
   ///
-  /// Explicitly `nonisolated` for the same reason as `generateStream` below:
-  /// under `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` this default impl
-  /// otherwise inherits MainActor and blocks every `nonisolated` conformer.
+  /// Explicitly `nonisolated` because this is a **synchronous** member: under
+  /// `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` a sync default impl inherits
+  /// MainActor and then blocks every `nonisolated` conformer. The `async`
+  /// members on this same extension — `generateWithMetrics`,
+  /// `attachSuspendController` — carry no annotation and compile fine, which
+  /// is what isolates sync-ness as the cause. (Not the escaping-closure
+  /// mechanism `generateStream` below cites; that one is `nonisolated` for
+  /// both reasons at once, so it cannot tell the two apart.)
+  ///
   /// Not defensive — measured by dropping the annotation, which fails the
   /// build with `conformance of 'MockLLMService' to protocol 'LLMService'
   /// crosses into main actor-isolated code` (and the same for `OllamaService`).

--- a/Pastura/Pastura/LLM/LLMService.swift
+++ b/Pastura/Pastura/LLM/LLMService.swift
@@ -102,17 +102,13 @@ nonisolated public protocol LLMService: Sendable {
   /// hallucinated turn boundary (``JSONResponseParser`` truncation, the
   /// `LLMCaller` chat-template leakage diagnostic).
   ///
-  /// The set is the loaded model's own pair **unioned with**
-  /// ``ChatTurnMarkers/chatML``, so a backend that cannot name its model
-  /// (``OllamaService``, ``MockLLMService``) keeps the pre-#1422 ChatML-only
-  /// behaviour via the default implementation, and a ChatML model does not
-  /// grow a second, redundant entry.
+  /// The set is the loaded model's own pair **unioned with** ``ChatTurnMarkers/chatML``, so a
+  /// backend that cannot name its model (``OllamaService``, ``MockLLMService``) keeps the
+  /// pre-#1422 ChatML-only behaviour via the default implementation.
   ///
-  /// - Important: Declared **in the protocol body**, not only in an extension.
-  ///   An extension-only declaration is statically dispatched through
-  ///   `any LLMService`, so ``LlamaCppService``'s override would be silently
-  ///   ignored at the `LLMCaller` call site — with no diagnostic, and with the
-  ///   exact failure this requirement exists to remove.
+  /// - Important: Declared **in the protocol body**, not only in an extension. An
+  ///   extension-only declaration is statically dispatched through `any LLMService`, so
+  ///   ``LlamaCppService``'s override would be silently ignored at the `LLMCaller` call site.
   var knownTurnMarkers: [ChatTurnMarkers] { get }
 
   /// Generate a completion as a sequence of incremental chunks.
@@ -178,18 +174,10 @@ extension LLMService {
   /// value rather than baked into each consumer. Backends that know which
   /// model is loaded override this (currently only ``LlamaCppService``).
   ///
-  /// Explicitly `nonisolated` because this is a **synchronous** member: under
-  /// `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` a sync default impl inherits
-  /// MainActor and then blocks every `nonisolated` conformer. The `async`
-  /// members on this same extension — `generateWithMetrics`,
-  /// `attachSuspendController` — carry no annotation and compile fine, which
-  /// is what isolates sync-ness as the cause. (Not the escaping-closure
-  /// mechanism `generateStream` below cites; that one is `nonisolated` for
-  /// both reasons at once, so it cannot tell the two apart.)
-  ///
-  /// Not defensive — measured by dropping the annotation, which fails the
-  /// build with `conformance of 'MockLLMService' to protocol 'LLMService'
-  /// crosses into main actor-isolated code` (and the same for `OllamaService`).
+  /// `nonisolated` because a **synchronous** default impl inherits MainActor under
+  /// `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` and then breaks every `nonisolated`
+  /// conformer. Measured, not defensive: dropping it fails the build on `MockLLMService`
+  /// and `OllamaService` (`.claude/rules/swift-isolation.md` Pattern 1).
   nonisolated public var knownTurnMarkers: [ChatTurnMarkers] { [.chatML] }
 
   /// Default `generateStream` implementation: runs the existing

--- a/Pastura/Pastura/LLM/LlamaCppService.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService.swift
@@ -113,8 +113,18 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
   // `<turn|>` (106, EOG). Left as-is rather than replaced by a guess at what a
   // Gemma hallucination would spell (#1417; behaviour half #1422). Read from
   // the descriptor at construction time; future models may differ.
-  // TODO: Consider adding `<|im_start|>` if hallucinated turn starts are observed (#65)
+  // TODO: A generation-side stop on the turn-START marker would end a
+  // hallucinated next turn at its first token instead of burning the remaining
+  // budget on it (#65). Parser-side truncation (#1422) does NOT supersede this:
+  // it discards the fabricated turn after the fact, so the tokens are still
+  // spent. What #1422 does change is that the marker is now per-model — read
+  // `turnMarkers.start`, never a ChatML literal.
   let stopSequence: String
+
+  /// This model's own plaintext turn-boundary sentinels, threaded from
+  /// `ModelDescriptor.turnMarkers`. Surfaced to consumers through
+  /// ``knownTurnMarkers``; see that property for the union rule.
+  let turnMarkers: ChatTurnMarkers
 
   /// Optional suffix appended to the system prompt at chat-template assembly.
   /// Used for models that require prompt-level mode control (e.g., Qwen's
@@ -188,10 +198,12 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
 
   /// Creates a llama.cpp service.
   ///
-  /// All parameters are required — callers must provide explicit per-descriptor
-  /// values (via `ModelDescriptor.stopSequence` / `.displayName` /
-  /// `.systemPromptSuffix`). This avoids silently running Qwen with Gemma's
-  /// defaults if a call-site forgets to thread the descriptor through.
+  /// The generation-affecting parameters are required — callers must provide
+  /// explicit per-descriptor values (via `ModelDescriptor.stopSequence` /
+  /// `.displayName` / `.systemPromptSuffix`). This avoids silently running Qwen
+  /// with Gemma's defaults if a call-site forgets to thread the descriptor
+  /// through. `turnMarkers` is the exception and is defaulted — see its
+  /// parameter note.
   /// Test code can construct via a file-scope helper (see
   /// `LlamaCppServiceTests`) to centralize the test values. Not a pin of the
   /// shipped descriptor — the path and identifier are synthetic, while the
@@ -202,6 +214,12 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
   ///     `ModelManager.modelFileURL(for:).path` at the call-site).
   ///   - stopSequence: Per-model plaintext stop sentinel, matched only against
   ///     text the model spelled out (e.g., `<|im_end|>` for ChatML models).
+  ///   - turnMarkers: This model's own plaintext turn-boundary sentinels
+  ///     (`ModelDescriptor.turnMarkers`). Defaulted to ``ChatTurnMarkers/chatML``
+  ///     — unlike the parameters above — because it changes only *recognition*
+  ///     of a hallucinated boundary, never generation. A test fixture or
+  ///     harness run that omits it therefore behaves exactly as it did before
+  ///     #1422, whereas an omitted `stopSequence` would alter generation.
   ///   - modelIdentifier: Human-readable label for exports / replay metadata.
   ///   - systemPromptSuffix: Optional suffix appended to the system prompt
   ///     at `applyChatTemplate` (e.g., `/no_think` for Qwen 3).
@@ -211,12 +229,14 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
   public init(
     modelPath: String,
     stopSequence: String,
+    turnMarkers: ChatTurnMarkers = .chatML,
     modelIdentifier: String,
     systemPromptSuffix: String?,
     assistantPrefix: String? = nil
   ) {
     self.modelPath = modelPath
     self.stopSequence = stopSequence
+    self.turnMarkers = turnMarkers
     self.modelIdentifier = modelIdentifier
     self.systemPromptSuffix = systemPromptSuffix
     self.assistantPrefix = assistantPrefix
@@ -426,6 +446,21 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
   /// YAML replay) — not a stable parse key.
   public let modelIdentifier: String
   public let backendIdentifier = "llama.cpp"
+
+  /// The loaded model's own pair, unioned with the ChatML baseline (#1422).
+  ///
+  /// Keeping ChatML in the set for every model is deliberate: a hallucinated
+  /// marker is by definition text the model was not supposed to emit, and
+  /// instruction-tuned models are trained on corpora containing ChatML, so a
+  /// non-ChatML model spelling `<|im_end|>` is not excluded by its vocabulary.
+  /// Recognizing one costs nothing; the union is also what keeps Qwen's
+  /// behaviour byte-identical to pre-#1422.
+  ///
+  /// Deduped so a ChatML model yields one entry rather than two identical ones
+  /// — consumers iterate this set per parse.
+  public var knownTurnMarkers: [ChatTurnMarkers] {
+    turnMarkers == .chatML ? [.chatML] : [turnMarkers, .chatML]
+  }
 
   /// Maps a non-zero `llama_decode` result to either ``LLMError/suspended``
   /// (when an external suspend was requested — usually because iOS denied

--- a/Pastura/Pastura/LLM/LlamaCppService.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService.swift
@@ -103,7 +103,7 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
   // renders ""; if it is ALSO EOG, `nextContentTokenOrStop` stops first — a
   // second, independent guard), and a sentinel absent from the vocabulary has
   // no token form to arrive as. So this is a hallucinated-turn guard (sibling of
-  // `JSONResponseParser.truncateAtChatTemplateToken`), NOT what terminates a
+  // `JSONResponseParser.truncateAtTurnMarkers`), NOT what terminates a
   // normal turn — that is EOG, for every model. String-based rather than
   // token-ID because what it must catch is text, which has no single token id.
   //
@@ -113,17 +113,14 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
   // `<turn|>` (106, EOG). Left as-is rather than replaced by a guess at what a
   // Gemma hallucination would spell (#1417; behaviour half #1422). Read from
   // the descriptor at construction time; future models may differ.
-  // TODO: A generation-side stop on the turn-START marker would end a
-  // hallucinated next turn at its first token instead of burning the remaining
-  // budget on it (#65). Parser-side truncation (#1422) does NOT supersede this:
-  // it discards the fabricated turn after the fact, so the tokens are still
-  // spent. What #1422 does change is that the marker is now per-model — read
-  // `turnMarkers.start`, never a ChatML literal.
+  // TODO: A generation-side stop on the turn-START marker would end a hallucinated next
+  // turn at its first token instead of burning the remaining budget (#65). Parser-side
+  // truncation (#1422) does NOT supersede this — it discards the turn after the fact, so
+  // the tokens are still spent. Read `turnMarkers.start`, never a ChatML literal.
   let stopSequence: String
 
-  /// This model's own plaintext turn-boundary sentinels, threaded from
-  /// `ModelDescriptor.turnMarkers`. Surfaced to consumers through
-  /// ``knownTurnMarkers``; see that property for the union rule.
+  /// This model's own plaintext turn-boundary sentinels, from `ModelDescriptor.turnMarkers`.
+  /// Surfaced through ``knownTurnMarkers``; see there for the union rule.
   let turnMarkers: ChatTurnMarkers
 
   /// Optional suffix appended to the system prompt at chat-template assembly.
@@ -198,16 +195,10 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
 
   /// Creates a llama.cpp service.
   ///
-  /// The generation-affecting parameters are required — callers must provide
-  /// explicit per-descriptor values (via `ModelDescriptor.stopSequence` /
-  /// `.displayName` / `.systemPromptSuffix`). This avoids silently running Qwen
-  /// with Gemma's defaults if a call-site forgets to thread the descriptor
-  /// through. `turnMarkers` is required for the same reason: it is the one place
-  /// the descriptor→runtime hand-off can actually be dropped, and
-  /// `ModelDescriptor.turnMarkers` / `ModelProfile.turnMarkers` are non-defaulted
-  /// precisely so a wrong pair cannot be inherited in silence. A default here
-  /// would break that chain at its weakest link with nothing to catch it — the
-  /// #1422 bug, one call site at a time.
+  /// The per-model parameters are required — callers must provide explicit descriptor
+  /// values (via `ModelDescriptor.stopSequence` / `.turnMarkers` / `.displayName` /
+  /// `.systemPromptSuffix`). This avoids silently running Qwen with Gemma's
+  /// defaults if a call-site forgets to thread the descriptor through.
   /// Test code can construct via a file-scope helper (see
   /// `LlamaCppServiceTests`) to centralize the test values. Not a pin of the
   /// shipped descriptor — the path and identifier are synthetic, while the
@@ -219,11 +210,9 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
   ///   - stopSequence: Per-model plaintext stop sentinel, matched only against
   ///     text the model spelled out (e.g., `<|im_end|>` for ChatML models).
   ///   - turnMarkers: This model's own plaintext turn-boundary sentinels
-  ///     (`ModelDescriptor.turnMarkers`). **Required**, no default: wrong
-  ///     *recognition* is exactly the #1422 bug, so "it only affects
-  ///     recognition" is a reason to enforce it rather than to relax it. Pass
-  ///     ``ChatTurnMarkers/chatML`` explicitly where that is genuinely the
-  ///     intent.
+  ///     (`ModelDescriptor.turnMarkers`). **No default**: a wrong pair inherited in
+  ///     silence is exactly the #1422 bug. Pass ``ChatTurnMarkers/chatML`` explicitly
+  ///     where that is genuinely the intent.
   ///   - modelIdentifier: Human-readable label for exports / replay metadata.
   ///   - systemPromptSuffix: Optional suffix appended to the system prompt
   ///     at `applyChatTemplate` (e.g., `/no_think` for Qwen 3).
@@ -453,15 +442,12 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
 
   /// The loaded model's own pair, unioned with the ChatML baseline (#1422).
   ///
-  /// Keeping ChatML in the set for every model is deliberate: a hallucinated
-  /// marker is by definition text the model was not supposed to emit, and
-  /// instruction-tuned models are trained on corpora containing ChatML, so a
-  /// non-ChatML model spelling `<|im_end|>` is not excluded by its vocabulary.
-  /// Recognizing one costs nothing; the union is also what keeps Qwen's
-  /// behaviour byte-identical to pre-#1422.
+  /// Keeping ChatML in the set for every model is deliberate: instruction-tuned models are
+  /// trained on corpora containing ChatML, so a non-ChatML model spelling `<|im_end|>` is
+  /// not excluded by its vocabulary. Recognizing one costs nothing, and the union is what
+  /// keeps Qwen byte-identical to pre-#1422.
   ///
-  /// Deduped so a ChatML model yields one entry rather than two identical ones
-  /// — consumers iterate this set per parse.
+  /// Deduped so a ChatML model yields one entry, not two — consumers iterate this per parse.
   public var knownTurnMarkers: [ChatTurnMarkers] {
     turnMarkers == .chatML ? [.chatML] : [turnMarkers, .chatML]
   }

--- a/Pastura/Pastura/LLM/LlamaCppService.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService.swift
@@ -202,8 +202,12 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
   /// explicit per-descriptor values (via `ModelDescriptor.stopSequence` /
   /// `.displayName` / `.systemPromptSuffix`). This avoids silently running Qwen
   /// with Gemma's defaults if a call-site forgets to thread the descriptor
-  /// through. `turnMarkers` is the exception and is defaulted — see its
-  /// parameter note.
+  /// through. `turnMarkers` is required for the same reason: it is the one place
+  /// the descriptor→runtime hand-off can actually be dropped, and
+  /// `ModelDescriptor.turnMarkers` / `ModelProfile.turnMarkers` are non-defaulted
+  /// precisely so a wrong pair cannot be inherited in silence. A default here
+  /// would break that chain at its weakest link with nothing to catch it — the
+  /// #1422 bug, one call site at a time.
   /// Test code can construct via a file-scope helper (see
   /// `LlamaCppServiceTests`) to centralize the test values. Not a pin of the
   /// shipped descriptor — the path and identifier are synthetic, while the
@@ -215,11 +219,11 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
   ///   - stopSequence: Per-model plaintext stop sentinel, matched only against
   ///     text the model spelled out (e.g., `<|im_end|>` for ChatML models).
   ///   - turnMarkers: This model's own plaintext turn-boundary sentinels
-  ///     (`ModelDescriptor.turnMarkers`). Defaulted to ``ChatTurnMarkers/chatML``
-  ///     — unlike the parameters above — because it changes only *recognition*
-  ///     of a hallucinated boundary, never generation. A test fixture or
-  ///     harness run that omits it therefore behaves exactly as it did before
-  ///     #1422, whereas an omitted `stopSequence` would alter generation.
+  ///     (`ModelDescriptor.turnMarkers`). **Required**, no default: wrong
+  ///     *recognition* is exactly the #1422 bug, so "it only affects
+  ///     recognition" is a reason to enforce it rather than to relax it. Pass
+  ///     ``ChatTurnMarkers/chatML`` explicitly where that is genuinely the
+  ///     intent.
   ///   - modelIdentifier: Human-readable label for exports / replay metadata.
   ///   - systemPromptSuffix: Optional suffix appended to the system prompt
   ///     at `applyChatTemplate` (e.g., `/no_think` for Qwen 3).
@@ -229,7 +233,7 @@ nonisolated public final class LlamaCppService: LLMService, @unchecked Sendable 
   public init(
     modelPath: String,
     stopSequence: String,
-    turnMarkers: ChatTurnMarkers = .chatML,
+    turnMarkers: ChatTurnMarkers,
     modelIdentifier: String,
     systemPromptSuffix: String?,
     assistantPrefix: String? = nil

--- a/Pastura/Pastura/Models/ChatTurnMarkers.swift
+++ b/Pastura/Pastura/Models/ChatTurnMarkers.swift
@@ -3,35 +3,31 @@
 ///
 /// ### Contract for consumers
 ///
-/// Match these against **decoded text only**. They are not the tokenizer's
-/// turn-boundary *tokens*: under llama.cpp a genuine CONTROL token decodes to
-/// the empty string (`llama_token_to_piece(..., special: false)`) and an
-/// end-of-generation token returns before its piece is appended, so a marker
-/// can only ever reach a text match when the model **hallucinates it as
-/// ordinary characters**. A backend must not treat either value as the thing
-/// that terminates a normal turn.
+/// Match these against **decoded text only**; never as the thing that terminates a
+/// normal turn. Under llama.cpp a genuine CONTROL token decodes to the empty string
+/// (`llama_token_to_piece(..., special: false)`) and an end-of-generation token returns
+/// before its piece is appended — so a marker reaches a text match only when the model
+/// **hallucinates it as ordinary characters**.
 ///
 /// ### Why per-model
 ///
-/// The values are tokenizer-specific and share no convention across families.
-/// ChatML models (Qwen 3) use `<|im_start|>` / `<|im_end|>`; Gemma 4 uses
-/// `<|turn>` / `<turn|>` and carries neither ChatML string anywhere in its
-/// 262,144-token vocabulary. Hardcoding the ChatML pair — as this project did
-/// until #1422 — leaves every mechanism keyed on it silently inert for the
-/// default shipped model.
+/// The values are tokenizer-specific with no cross-family convention: ChatML (Qwen 3)
+/// uses `<|im_start|>` / `<|im_end|>`, while Gemma 4 uses `<|turn>` / `<turn|>` and
+/// carries neither ChatML string in its 262,144-token vocabulary. Hardcoding the ChatML
+/// pair — as this project did until #1422 — leaves every mechanism keyed on it silently
+/// inert for the default shipped model.
 nonisolated public struct ChatTurnMarkers: Sendable, Hashable {
   /// Plaintext sentinel that opens a turn (e.g. `"<|im_start|>"`).
   ///
-  /// An occurrence *after* a response's first structural `{` is a hallucinated
-  /// next turn; a *leading* one is the model echoing its own template header
-  /// with the payload still behind it. Consumers that truncate must tell those
-  /// two apart — see `JSONResponseParser.truncateAtTurnMarkers`.
+  /// Position decides: one after the response's first structural `{` is a hallucinated next
+  /// turn, while a *leading* one is the model echoing its own template header with the
+  /// payload still behind it — see `JSONResponseParser.truncateAtTurnMarkers`.
   public let start: String
 
   /// Plaintext sentinel that closes a turn (e.g. `"<|im_end|>"`).
   ///
-  /// Unlike ``start``, an occurrence anywhere is a turn boundary: everything
-  /// after it belongs to a turn that is not this one.
+  /// Unlike ``start``, an occurrence *anywhere* is a turn boundary: everything after it
+  /// belongs to a turn that is not this one.
   public let end: String
 
   /// Creates a marker pair.
@@ -44,11 +40,10 @@ nonisolated public struct ChatTurnMarkers: Sendable, Hashable {
     self.end = end
   }
 
-  /// The ChatML pair (`<|im_start|>` / `<|im_end|>`) — Qwen 3 and the wider
-  /// ChatML family.
+  /// The ChatML pair (`<|im_start|>` / `<|im_end|>`) — Qwen 3 and the wider ChatML family.
   ///
-  /// Also the baseline every consumer keeps in its effective set regardless of
-  /// which model is loaded, so backends with no descriptor to consult (Ollama,
-  /// `MockLLMService`, FoundationModels) retain the pre-#1422 behaviour.
+  /// Also the baseline every consumer keeps in its effective set, so backends with no
+  /// descriptor to consult (Ollama, `MockLLMService`, FoundationModels) keep pre-#1422
+  /// behaviour.
   public static let chatML = ChatTurnMarkers(start: "<|im_start|>", end: "<|im_end|>")
 }

--- a/Pastura/Pastura/Models/ChatTurnMarkers.swift
+++ b/Pastura/Pastura/Models/ChatTurnMarkers.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// The turn-boundary sentinels a model's chat template writes around one turn,
+/// **as plaintext**.
+///
+/// ### Contract for consumers
+///
+/// Match these against **decoded text only**. They are not the tokenizer's
+/// turn-boundary *tokens*: under llama.cpp a genuine CONTROL token decodes to
+/// the empty string (`llama_token_to_piece(..., special: false)`) and an
+/// end-of-generation token returns before its piece is appended, so a marker
+/// can only ever reach a text match when the model **hallucinates it as
+/// ordinary characters**. A backend must not treat either value as the thing
+/// that terminates a normal turn.
+///
+/// ### Why per-model
+///
+/// The values are tokenizer-specific and share no convention across families.
+/// ChatML models (Qwen 3) use `<|im_start|>` / `<|im_end|>`; Gemma 4 uses
+/// `<|turn>` / `<turn|>` and carries neither ChatML string anywhere in its
+/// 262,144-token vocabulary. Hardcoding the ChatML pair — as this project did
+/// until #1422 — leaves every mechanism keyed on it silently inert for the
+/// default shipped model.
+nonisolated public struct ChatTurnMarkers: Sendable, Hashable {
+  /// Plaintext sentinel that opens a turn (e.g. `"<|im_start|>"`).
+  ///
+  /// An occurrence *after* a response's first structural `{` is a hallucinated
+  /// next turn; a *leading* one is the model echoing its own template header
+  /// with the payload still behind it. Consumers that truncate must tell those
+  /// two apart — see `JSONResponseParser.truncateAtTurnMarkers`.
+  public let start: String
+
+  /// Plaintext sentinel that closes a turn (e.g. `"<|im_end|>"`).
+  ///
+  /// Unlike ``start``, an occurrence anywhere is a turn boundary: everything
+  /// after it belongs to a turn that is not this one.
+  public let end: String
+
+  /// Creates a marker pair.
+  ///
+  /// - Parameters:
+  ///   - start: Plaintext turn-open sentinel.
+  ///   - end: Plaintext turn-close sentinel.
+  public init(start: String, end: String) {
+    self.start = start
+    self.end = end
+  }
+
+  /// The ChatML pair (`<|im_start|>` / `<|im_end|>`) — Qwen 3 and the wider
+  /// ChatML family.
+  ///
+  /// Also the baseline every consumer keeps in its effective set regardless of
+  /// which model is loaded, so backends with no descriptor to consult (Ollama,
+  /// `MockLLMService`, FoundationModels) retain the pre-#1422 behaviour.
+  public static let chatML = ChatTurnMarkers(start: "<|im_start|>", end: "<|im_end|>")
+}

--- a/Pastura/Pastura/Models/ChatTurnMarkers.swift
+++ b/Pastura/Pastura/Models/ChatTurnMarkers.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// The turn-boundary sentinels a model's chat template writes around one turn,
 /// **as plaintext**.
 ///

--- a/Pastura/Pastura/Models/ModelDescriptor.swift
+++ b/Pastura/Pastura/Models/ModelDescriptor.swift
@@ -51,11 +51,30 @@ nonisolated public struct ModelDescriptor: Sendable, Hashable {
   ///
   /// Contract for consumers: match this against **decoded text only**. It is
   /// not the tokenizer's end-of-turn token, and a backend must not treat it as
-  /// the thing that terminates a normal turn. `"<|im_end|>"` for ChatML models
-  /// such as Qwen 3; Gemma 4 carries that same string although its own markers
-  /// are `<|turn>` / `<turn|>` (#1417). Mechanism, and why a control token can
-  /// never reach the match under llama.cpp: `LlamaCppService.stopSequence`.
+  /// the thing that terminates a normal turn. Mechanism, and why a control
+  /// token can never reach the match under llama.cpp:
+  /// `LlamaCppService.stopSequence`.
+  ///
+  /// `"<|im_end|>"` for ChatML models such as Qwen 3. Gemma 4 carries that same
+  /// string even though ``turnMarkers`` states its real pair — so this path is
+  /// inert for Gemma, which is what keeps a spelled-out `<turn|>` reaching the
+  /// parser. Repointing it is deferred to #1451, not an oversight (#1417).
   public let stopSequence: String
+
+  /// This model's plaintext turn-boundary sentinels, consumed by parser-side
+  /// hallucinated-turn truncation and by the chat-template leakage diagnostic.
+  ///
+  /// **Deliberately has no default value**: a new descriptor must state its
+  /// markers, because the failure mode of an inherited wrong pair is silence —
+  /// the mechanisms keyed on it simply stop firing, with nothing to observe
+  /// (#1422). `docs/models/onboarding.md` carries the collection step.
+  ///
+  /// Distinct from ``stopSequence`` on purpose, and the two currently
+  /// **disagree** for Gemma 4: repointing the generation-side sentinel would
+  /// newly *activate* a behaviour on an assumption rather than a demonstration,
+  /// so it is deferred to #1451. `ModelRegistryTurnMarkerDivergenceTests` pins
+  /// the divergence so a silent "consistency fix" reddens.
+  public let turnMarkers: ChatTurnMarkers
 
   /// Minimum physical RAM required to load and run the model (bytes).
   public let minRAM: UInt64
@@ -120,6 +139,7 @@ nonisolated public struct ModelDescriptor: Sendable, Hashable {
     fileSize: Int64,
     sha256: String,
     stopSequence: String,
+    turnMarkers: ChatTurnMarkers,
     minRAM: UInt64,
     modelInfoURL: URL,
     systemPromptSuffix: String?,
@@ -140,6 +160,7 @@ nonisolated public struct ModelDescriptor: Sendable, Hashable {
     self.fileSize = fileSize
     self.sha256 = sha256
     self.stopSequence = stopSequence
+    self.turnMarkers = turnMarkers
     self.minRAM = minRAM
     self.modelInfoURL = modelInfoURL
     self.systemPromptSuffix = systemPromptSuffix

--- a/Pastura/Pastura/Models/ModelDescriptor.swift
+++ b/Pastura/Pastura/Models/ModelDescriptor.swift
@@ -55,25 +55,22 @@ nonisolated public struct ModelDescriptor: Sendable, Hashable {
   /// token can never reach the match under llama.cpp:
   /// `LlamaCppService.stopSequence`.
   ///
-  /// `"<|im_end|>"` for ChatML models such as Qwen 3. Gemma 4 carries that same
-  /// string even though ``turnMarkers`` states its real pair — so this path is
-  /// inert for Gemma, which is what keeps a spelled-out `<turn|>` reaching the
-  /// parser. Repointing it is deferred to #1451, not an oversight (#1417).
+  /// `"<|im_end|>"` for ChatML models such as Qwen 3; Gemma 4 carries that same string
+  /// (#1417). It diverges from ``turnMarkers`` deliberately — see there.
   public let stopSequence: String
 
   /// This model's plaintext turn-boundary sentinels, consumed by parser-side
   /// hallucinated-turn truncation and by the chat-template leakage diagnostic.
   ///
-  /// **Deliberately has no default value**: a new descriptor must state its
-  /// markers, because the failure mode of an inherited wrong pair is silence —
-  /// the mechanisms keyed on it simply stop firing, with nothing to observe
-  /// (#1422). `docs/models/onboarding.md` carries the collection step.
+  /// **Deliberately no default**: an inherited wrong pair fails in silence — the
+  /// mechanisms keyed on it simply stop firing, with nothing to observe (#1422).
+  /// `docs/models/onboarding.md` carries the collection step.
   ///
-  /// Distinct from ``stopSequence`` on purpose, and the two currently
-  /// **disagree** for Gemma 4: repointing the generation-side sentinel would
-  /// newly *activate* a behaviour on an assumption rather than a demonstration,
-  /// so it is deferred to #1451. `ModelRegistryTurnMarkerDivergenceTests` pins
-  /// the divergence so a silent "consistency fix" reddens.
+  /// For Gemma 4 this and ``stopSequence`` **disagree** on purpose: repointing the
+  /// generation-side sentinel would newly *activate* a behaviour on an assumption rather
+  /// than a demonstration, so it is deferred to #1451.
+  /// `ModelRegistryTurnMarkerDivergenceTests` pins the divergence so a silent
+  /// "consistency fix" reddens.
   public let turnMarkers: ChatTurnMarkers
 
   /// Minimum physical RAM required to load and run the model (bytes).

--- a/Pastura/Pastura/PasturaApp.swift
+++ b/Pastura/Pastura/PasturaApp.swift
@@ -677,13 +677,14 @@ private struct RootView: View {
 
   /// Builds the on-device `LlamaCppService` from a model path + descriptor.
   /// Extracted so the migration-recovery path (#546) rebuilds it from the
-  /// same five descriptor fields as `finalizeInit`, with no drift.
+  /// same descriptor fields as `finalizeInit`, with no drift.
   private func makeLlamaCppService(
     modelPath: String, descriptor: ModelDescriptor
   ) -> LlamaCppService {
     LlamaCppService(
       modelPath: modelPath,
       stopSequence: descriptor.stopSequence,
+      turnMarkers: descriptor.turnMarkers,
       modelIdentifier: descriptor.displayName,
       systemPromptSuffix: descriptor.systemPromptSuffix,
       assistantPrefix: descriptor.assistantPrefix

--- a/Pastura/Pastura/Views/ModelSelection/ModelRow.swift
+++ b/Pastura/Pastura/Views/ModelSelection/ModelRow.swift
@@ -227,6 +227,7 @@ struct ModelRow: View {
     fileSize: 1_000_000_000,
     sha256: "",
     stopSequence: "<|im_end|>",
+    turnMarkers: .chatML,
     minRAM: 6_500_000_000,
     modelInfoURL: URL(string: "https://example.com")!,
     systemPromptSuffix: nil

--- a/Pastura/PasturaTests/App/ModelManagerTests.swift
+++ b/Pastura/PasturaTests/App/ModelManagerTests.swift
@@ -75,6 +75,7 @@ struct ModelManagerTests {
       fileSize: fileSize,
       sha256: sha256,
       stopSequence: "<|im_end|>",
+      turnMarkers: .chatML,
       minRAM: 6_500_000_000,
       modelInfoURL: URL(string: "https://example.com")!,
       systemPromptSuffix: systemPromptSuffix

--- a/Pastura/PasturaTests/App/ModelRegistryTests.swift
+++ b/Pastura/PasturaTests/App/ModelRegistryTests.swift
@@ -118,6 +118,7 @@ struct ModelRegistryTests {
       fileSize: ModelRegistry.qwen34B.fileSize,
       sha256: ModelRegistry.qwen34B.sha256,
       stopSequence: ModelRegistry.qwen34B.stopSequence,
+      turnMarkers: ModelRegistry.qwen34B.turnMarkers,
       minRAM: ModelRegistry.qwen34B.minRAM,
       modelInfoURL: ModelRegistry.qwen34B.modelInfoURL,
       systemPromptSuffix: ModelRegistry.qwen34B.systemPromptSuffix

--- a/Pastura/PasturaTests/App/ModelRegistryTurnMarkerDivergenceTests.swift
+++ b/Pastura/PasturaTests/App/ModelRegistryTurnMarkerDivergenceTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+/// Pins the per-model turn markers in `ModelRegistry`, and the one place where
+/// they **deliberately disagree** with the older `stopSequence` field (#1422).
+///
+/// Its own suite rather than an extension of `ModelRegistryTests`: the subject
+/// is a cross-field invariant that a reader looking for "why do these two
+/// disagree?" should be able to find by name. Safe to run alongside that suite
+/// — `ModelRegistry` is immutable static data, so there is no shared mutable
+/// state to race on (`.claude/rules/testing.md` § "Splitting a Suite Across
+/// Files").
+@Suite(.timeLimit(.minutes(1)))
+struct ModelRegistryTurnMarkerDivergenceTests {
+  /// The bug #1422 fixes, stated as an assertion: before the fix, every
+  /// mechanism keyed on turn markers used the ChatML pair unconditionally, so
+  /// for the **default shipped model** it matched nothing. Reverting Gemma's
+  /// descriptor to `.chatML` reddens here.
+  ///
+  /// Values are from the GGUF header of the exact file `gemma4E2B` pins:
+  /// `<|turn>` id 105 / `<turn|>` id 106, both CONTROL, `eos = 106`.
+  @Test func gemma_carriesItsOwnMarkers_notChatML() {
+    let markers = ModelRegistry.gemma4E2B.turnMarkers
+    #expect(markers.start == "<|turn>")
+    #expect(markers.end == "<turn|>")
+    #expect(markers != .chatML)
+  }
+
+  /// Qwen 3 genuinely is a ChatML model, so the pre-#1422 hardcoded literal
+  /// was correct for it. This is the "Qwen behaviour unchanged" half of the
+  /// issue's acceptance criteria at the descriptor level.
+  @Test func qwen_isChatML() {
+    #expect(ModelRegistry.qwen34B.turnMarkers == .chatML)
+  }
+
+  /// **Deliberate divergence, deferred to #1451.** `stopSequence` is the
+  /// generation-side early-stop sentinel; for Gemma it is a ChatML string
+  /// absent from the model's 262,144-token vocabulary, so that path is inert.
+  /// Repointing it to `turnMarkers.end` would newly *activate* a behaviour on
+  /// an assumption rather than a demonstration — and a false positive there
+  /// truncates a real payload mid-generation, which is strictly worse than
+  /// today's no-op.
+  ///
+  /// A failure here is **not** automatically a bug: it means someone made the
+  /// two agree. Read #1451 and confirm the evidence exists before updating
+  /// this expectation.
+  @Test func gemma_stopSequenceDeliberatelyDisagreesWithTurnMarkers() {
+    let descriptor = ModelRegistry.gemma4E2B
+    #expect(descriptor.stopSequence != descriptor.turnMarkers.end)
+    #expect(descriptor.stopSequence == ChatTurnMarkers.chatML.end)
+  }
+
+  /// Every catalog entry must state a usable pair. `turnMarkers` has no default
+  /// value precisely so this cannot be reached by omission — but a descriptor
+  /// could still pass empty strings, which would make the truncation predicate
+  /// match at every index.
+  @Test func everyCatalogEntryHasNonEmptyMarkers() {
+    for descriptor in ModelRegistry.catalog {
+      #expect(!descriptor.turnMarkers.start.isEmpty, "\(descriptor.id) start")
+      #expect(!descriptor.turnMarkers.end.isEmpty, "\(descriptor.id) end")
+    }
+  }
+}

--- a/Pastura/PasturaTests/App/ModelRegistryTurnMarkerDivergenceTests.swift
+++ b/Pastura/PasturaTests/App/ModelRegistryTurnMarkerDivergenceTests.swift
@@ -6,21 +6,16 @@ import Testing
 /// Pins the per-model turn markers in `ModelRegistry`, and the one place where
 /// they **deliberately disagree** with the older `stopSequence` field (#1422).
 ///
-/// Its own suite rather than an extension of `ModelRegistryTests`: the subject
-/// is a cross-field invariant that a reader looking for "why do these two
-/// disagree?" should be able to find by name. Safe to run alongside that suite
-/// — `ModelRegistry` is immutable static data, so there is no shared mutable
-/// state to race on (`.claude/rules/testing.md` § "Splitting a Suite Across
-/// Files").
+/// Own suite, not a `ModelRegistryTests` extension: the subject is a
+/// cross-field invariant, findable by name. Safe alongside that suite since
+/// `ModelRegistry` is immutable static data
+/// (`.claude/rules/testing.md` § "Splitting a Suite Across Files").
 @Suite(.timeLimit(.minutes(1)))
 struct ModelRegistryTurnMarkerDivergenceTests {
-  /// The bug #1422 fixes, stated as an assertion: before the fix, every
-  /// mechanism keyed on turn markers used the ChatML pair unconditionally, so
-  /// for the **default shipped model** it matched nothing. Reverting Gemma's
-  /// descriptor to `.chatML` reddens here.
-  ///
-  /// Values are from the GGUF header of the exact file `gemma4E2B` pins:
-  /// `<|turn>` id 105 / `<turn|>` id 106, both CONTROL, `eos = 106`.
+  /// **Regression.** Pre-#1422, every marker-keyed mechanism used ChatML
+  /// unconditionally, matching nothing for the default model. Reverting
+  /// Gemma's descriptor to `.chatML` reddens here. Values from the GGUF
+  /// header of `gemma4E2B`'s pinned file: `<|turn>` id 105 / `<turn|>` id 106.
   @Test func gemma_carriesItsOwnMarkers_notChatML() {
     let markers = ModelRegistry.gemma4E2B.turnMarkers
     #expect(markers.start == "<|turn>")
@@ -28,41 +23,30 @@ struct ModelRegistryTurnMarkerDivergenceTests {
     #expect(markers != .chatML)
   }
 
-  /// Qwen 3 genuinely is a ChatML model, so the pre-#1422 hardcoded literal
-  /// was correct for it. This is the "Qwen behaviour unchanged" half of the
-  /// issue's acceptance criteria at the descriptor level.
+  /// **Control.** Qwen 3 genuinely is ChatML — the "Qwen unchanged" half of
+  /// #1422's acceptance criteria at the descriptor level.
   @Test func qwen_isChatML() {
     #expect(ModelRegistry.qwen34B.turnMarkers == .chatML)
   }
 
-  /// **Deliberate divergence, deferred to #1451.** `stopSequence` is the
-  /// generation-side early-stop sentinel; for Gemma it is a ChatML string
-  /// absent from the model's 262,144-token vocabulary, so that path is inert.
-  /// Repointing it to `turnMarkers.end` would newly *activate* a behaviour on
-  /// an assumption rather than a demonstration — and a false positive there
-  /// truncates a real payload mid-generation, which is strictly worse than
-  /// today's no-op.
+  /// **Deliberate divergence, deferred to #1451.** For Gemma, `stopSequence`
+  /// is a ChatML string absent from the vocabulary, so it's inert; repointing
+  /// it would activate a behaviour on an assumption, and a false positive
+  /// there truncates a real payload — worse than today's no-op.
   ///
-  /// A failure here is **not** automatically a bug: it means someone made the
-  /// two agree. Read #1451 and confirm the evidence exists before updating
-  /// this expectation.
+  /// A failure here is **not** automatically a bug: read #1451 before
+  /// updating this expectation.
   @Test func gemma_stopSequenceDeliberatelyDisagreesWithTurnMarkers() {
     let descriptor = ModelRegistry.gemma4E2B
     #expect(descriptor.stopSequence != descriptor.turnMarkers.end)
     #expect(descriptor.stopSequence == ChatTurnMarkers.chatML.end)
   }
 
-  /// Every catalog entry must state a usable pair. `turnMarkers` has no default
-  /// value precisely so this cannot be reached by omission — but a descriptor
-  /// could still pass empty strings, and the failure mode is **silence, not
-  /// over-matching**: `truncateAtTurnMarkers` guards an empty marker string at
-  /// every arm — both loops' `where` clauses, the start arm's entry check, and
-  /// `firstIndex`'s own `guard` — so an empty pair never matches and the
-  /// truncation simply stops existing for that model, which is #1422's bug
-  /// reintroduced one descriptor at a time.
-  /// That silence is why this has to be asserted at the catalog rather than
-  /// left to the truncator, whose graceful degradation is itself pinned by
-  /// `JSONResponseParserTests.emptyMarkerStrings_areIgnored`.
+  /// A descriptor could pass empty strings even though `turnMarkers` has no
+  /// default. Failure mode is **silence, not over-matching** — an empty pair
+  /// goes inert, quietly reintroducing #1422's bug — so it must be asserted
+  /// here, not left to the truncator (see
+  /// `JSONResponseParserTests.emptyMarkerStrings_areIgnored`).
   @Test func everyCatalogEntryHasNonEmptyMarkers() {
     for descriptor in ModelRegistry.catalog {
       #expect(!descriptor.turnMarkers.start.isEmpty, "\(descriptor.id) start")

--- a/Pastura/PasturaTests/App/ModelRegistryTurnMarkerDivergenceTests.swift
+++ b/Pastura/PasturaTests/App/ModelRegistryTurnMarkerDivergenceTests.swift
@@ -55,10 +55,11 @@ struct ModelRegistryTurnMarkerDivergenceTests {
   /// Every catalog entry must state a usable pair. `turnMarkers` has no default
   /// value precisely so this cannot be reached by omission — but a descriptor
   /// could still pass empty strings, and the failure mode is **silence, not
-  /// over-matching**: `truncateAtTurnMarkers` guards `isEmpty` three times (the
-  /// two `where` clauses on the arm loops and `firstIndex`'s own `guard`), so
-  /// an empty pair never matches and the truncation simply stops existing for
-  /// that model — which is #1422's bug, reintroduced one descriptor at a time.
+  /// over-matching**: `truncateAtTurnMarkers` guards an empty marker string at
+  /// every arm — both loops' `where` clauses, the start arm's entry check, and
+  /// `firstIndex`'s own `guard` — so an empty pair never matches and the
+  /// truncation simply stops existing for that model, which is #1422's bug
+  /// reintroduced one descriptor at a time.
   /// That silence is why this has to be asserted at the catalog rather than
   /// left to the truncator, whose graceful degradation is itself pinned by
   /// `JSONResponseParserTests.emptyMarkerStrings_areIgnored`.

--- a/Pastura/PasturaTests/App/ModelRegistryTurnMarkerDivergenceTests.swift
+++ b/Pastura/PasturaTests/App/ModelRegistryTurnMarkerDivergenceTests.swift
@@ -54,8 +54,14 @@ struct ModelRegistryTurnMarkerDivergenceTests {
 
   /// Every catalog entry must state a usable pair. `turnMarkers` has no default
   /// value precisely so this cannot be reached by omission — but a descriptor
-  /// could still pass empty strings, which would make the truncation predicate
-  /// match at every index.
+  /// could still pass empty strings, and the failure mode is **silence, not
+  /// over-matching**: `truncateAtTurnMarkers` guards `isEmpty` three times (the
+  /// two `where` clauses on the arm loops and `firstIndex`'s own `guard`), so
+  /// an empty pair never matches and the truncation simply stops existing for
+  /// that model — which is #1422's bug, reintroduced one descriptor at a time.
+  /// That silence is why this has to be asserted at the catalog rather than
+  /// left to the truncator, whose graceful degradation is itself pinned by
+  /// `JSONResponseParserTests.emptyMarkerStrings_areIgnored`.
   @Test func everyCatalogEntryHasNonEmptyMarkers() {
     for descriptor in ModelRegistry.catalog {
       #expect(!descriptor.turnMarkers.start.isEmpty, "\(descriptor.id) start")

--- a/Pastura/PasturaTests/Engine/LLMCallerTests+TurnMarkers.swift
+++ b/Pastura/PasturaTests/Engine/LLMCallerTests+TurnMarkers.swift
@@ -116,11 +116,16 @@ extension LLMCallerTests {
   /// shipped model. Pins the delta rather than merely the fixed behaviour.
   ///
   /// Asserts the absence of **any** `.warning`, not the absence of the string
-  /// `<|turn>`: a substring probe passes on pre-#1422 code for the trivial
-  /// reason that no line is emitted at all, and it also silently couples the
-  /// control to the message wording. Not vacuous — `leakageDiagnosticWarnsOn
-  /// BackendStartMarker` above drives the same raw text to a `.warning`, so
-  /// warnings are reachable on this input and only the marker set differs.
+  /// `<|turn>`. Two reasons, neither of them "the substring probe passed
+  /// pre-fix" — it did, but so does this one, since pre-#1422 emitted no line at
+  /// all for this input: (1) a substring probe couples the control to the
+  /// message wording, which this PR then changed; (2) it would miss a
+  /// *differently-worded* warning on this path — a `logParseFailure` line, say —
+  /// which is exactly the kind of noise a silence control should catch.
+  ///
+  /// Not vacuous: `leakageDiagnosticWarnsOnBackendStartMarker` above drives the
+  /// same raw text to a `.warning`, so warnings are reachable on this input and
+  /// only the marker set differs.
   @Test func leakageDiagnosticIsSilentForNonMatchingMarkers() async throws {
     let mock = MockLLMService(responses: [Self.gemmaHallucination])
     try await mock.loadModel()
@@ -136,7 +141,10 @@ extension LLMCallerTests {
     #expect(!spy.entries.contains { $0.level == .warning })
   }
 
-  /// **Regression.** A ChatML backend keeps the pre-#1422 diagnostic behaviour verbatim.
+  /// **Regression.** A ChatML backend keeps the pre-#1422 severity split and
+  /// marker detection. Not the wording — this PR deliberately reworded the
+  /// message to drop its overclaim (see `logChatTemplateLeakage`), and the
+  /// substring asserted below appears only in the post-#1422 text.
   @Test func leakageDiagnosticStillWarnsOnChatMLStartMarker() async throws {
     let raw = """
       {"statement": "hello"}<|im_end|>

--- a/Pastura/PasturaTests/Engine/LLMCallerTests+TurnMarkers.swift
+++ b/Pastura/PasturaTests/Engine/LLMCallerTests+TurnMarkers.swift
@@ -3,13 +3,9 @@ import Testing
 
 @testable import Pastura
 
-/// A backend that behaves exactly like ``MockLLMService`` but reports a
-/// non-ChatML marker pair, so `LLMCaller` can be driven down the per-model
-/// path (#1422).
-///
-/// Deliberately a wrapper rather than a `MockLLMService` subclass: the point
-/// under test is that `LLMCaller` reads `knownTurnMarkers` **through the
-/// existential**, so the stub must be a distinct conforming type.
+/// A backend reporting a non-ChatML marker pair, so `LLMCaller` can be driven
+/// down the per-model path (#1422). Wrapper, not a `MockLLMService` subclass:
+/// `LLMCaller` must read `knownTurnMarkers` through the existential.
 nonisolated final class GemmaMarkerLLMService: LLMService, @unchecked Sendable {
   private let inner: MockLLMService
 
@@ -38,9 +34,8 @@ nonisolated final class GemmaMarkerLLMService: LLMService, @unchecked Sendable {
 /// End-to-end threading of the per-model markers through `LLMCaller` (#1422).
 ///
 /// Each test is labelled **Regression** (fails if the fix is reverted) or
-/// **Control** (passes both before and after — it exists to give a Regression
-/// test its contrast). Three of the five are regression tests; do not read the
-/// file's length as five independent guards.
+/// **Control** (passes both before and after — gives a Regression test its
+/// contrast).
 extension LLMCallerTests {
   /// The raw shape that actually loses the payload: a **fenced** fabricated
   /// continuation, which `extractFromCodeBlock` lifts out ahead of the
@@ -56,10 +51,9 @@ extension LLMCallerTests {
     ```
     """
 
-  /// **Regression.** `LLMCaller` must read the marker set from the live backend. This is the
-  /// integration half of the D2 dynamic-dispatch pin: the caller holds
-  /// `any LLMService`, so a statically-dispatched declaration would silently
-  /// fall back to ChatML here.
+  /// **Regression.** `LLMCaller` must read the marker set from the live backend —
+  /// the integration half of the D2 dynamic-dispatch pin: a statically-dispatched
+  /// declaration would silently fall back to ChatML here.
   @Test func usesBackendTurnMarkersWhenParsing() async throws {
     let gemma = GemmaMarkerLLMService(responses: [Self.gemmaHallucination])
     try await gemma.loadModel()
@@ -74,10 +68,9 @@ extension LLMCallerTests {
     #expect(result.statement == "本物")
   }
 
-  /// **Control.** Negative control on the identical response: a ChatML-only backend takes
-  /// the fabricated continuation. This is the bug #1422 fixes, so it must be
-  /// demonstrated rather than asserted — without it, the test above could pass
-  /// for reasons unrelated to the marker set.
+  /// **Control.** Same response, ChatML-only backend: takes the fabricated
+  /// continuation — the bug #1422 fixes, demonstrated rather than asserted so
+  /// the test above can't pass for an unrelated reason.
   @Test func chatMLOnlyBackendStillTakesTheFabricatedContinuation() async throws {
     let mock = MockLLMService(responses: [Self.gemmaHallucination])
     try await mock.loadModel()
@@ -92,8 +85,8 @@ extension LLMCallerTests {
     #expect(result.statement == "偽物")
   }
 
-  /// **Regression.** The leakage diagnostic is model-aware: a Gemma turn-start marker now
-  /// raises the `.warning`, where before #1422 it raised nothing at all.
+  /// **Regression.** The leakage diagnostic is model-aware: a Gemma turn-start
+  /// marker now raises `.warning`, where pre-#1422 it raised nothing.
   @Test func leakageDiagnosticWarnsOnBackendStartMarker() async throws {
     let gemma = GemmaMarkerLLMService(responses: [Self.gemmaHallucination])
     try await gemma.loadModel()
@@ -111,26 +104,14 @@ extension LLMCallerTests {
     #expect(warnings.allSatisfy { $0.privacy == .public })
   }
 
-  /// **Control.** The same raw text through a ChatML-only backend raises **no**
-  /// warning — the silence that made this diagnostic useless for the default
-  /// shipped model. Pins the delta rather than merely the fixed behaviour.
-  ///
-  /// Asserts the absence of **any** `.warning`, not the absence of the string
-  /// `<|turn>`. Two reasons, neither of them "the substring probe passed
-  /// pre-fix" — it did, but so does this one, since pre-#1422 emitted no line at
-  /// all for this input: (1) a substring probe couples the control to the
-  /// message wording, which this PR then changed; (2) it would miss a
-  /// *differently-worded* warning on this path — a `logParseFailure` line, say.
-  /// Reason (2) is **forward-looking, not instantiated**: no warning of any kind
-  /// fires on this input today, since
-  /// `chatMLOnlyBackendStillTakesTheFabricatedContinuation` shows this raw text
-  /// parses successfully, so `logParseFailure` — the only other `.warning` site —
-  /// never runs either. It is the shape a silence control should have, not a
-  /// failure it currently catches.
+  /// **Control.** Same raw text through a ChatML-only backend raises no warning —
+  /// the silence that made this diagnostic useless for the default shipped
+  /// model. Asserts the absence of **any** `.warning`, not of the substring
+  /// `<|turn>`, so it isn't coupled to the message wording (which this PR
+  /// changed).
   ///
   /// Not vacuous: `leakageDiagnosticWarnsOnBackendStartMarker` above drives the
-  /// same raw text to a `.warning`, so warnings are reachable on this input and
-  /// only the marker set differs.
+  /// same raw text to a `.warning`, so only the marker set differs here.
   @Test func leakageDiagnosticIsSilentForNonMatchingMarkers() async throws {
     let mock = MockLLMService(responses: [Self.gemmaHallucination])
     try await mock.loadModel()
@@ -147,9 +128,8 @@ extension LLMCallerTests {
   }
 
   /// **Regression.** A ChatML backend keeps the pre-#1422 severity split and
-  /// marker detection. Not the wording — this PR deliberately reworded the
-  /// message to drop its overclaim (see `logChatTemplateLeakage`), and the
-  /// substring asserted below appears only in the post-#1422 text.
+  /// marker detection — not the wording, which this PR reworded (see
+  /// `logChatTemplateLeakage`); the substring below appears only post-#1422.
   @Test func leakageDiagnosticStillWarnsOnChatMLStartMarker() async throws {
     let raw = """
       {"statement": "hello"}<|im_end|>

--- a/Pastura/PasturaTests/Engine/LLMCallerTests+TurnMarkers.swift
+++ b/Pastura/PasturaTests/Engine/LLMCallerTests+TurnMarkers.swift
@@ -120,8 +120,11 @@ extension LLMCallerTests {
   /// pre-fix" — it did, but so does this one, since pre-#1422 emitted no line at
   /// all for this input: (1) a substring probe couples the control to the
   /// message wording, which this PR then changed; (2) it would miss a
-  /// *differently-worded* warning on this path — a `logParseFailure` line, say —
-  /// which is exactly the kind of noise a silence control should catch.
+  /// *differently-worded* warning on this path — a `logParseFailure` line, say.
+  /// Reason (2) is **forward-looking, not instantiated**: no warning of any kind
+  /// fires on this input today, since the sibling control below shows this raw
+  /// text parses successfully. It is the shape a silence control should have,
+  /// not a failure it currently catches.
   ///
   /// Not vacuous: `leakageDiagnosticWarnsOnBackendStartMarker` above drives the
   /// same raw text to a `.warning`, so warnings are reachable on this input and

--- a/Pastura/PasturaTests/Engine/LLMCallerTests+TurnMarkers.swift
+++ b/Pastura/PasturaTests/Engine/LLMCallerTests+TurnMarkers.swift
@@ -36,6 +36,11 @@ nonisolated final class GemmaMarkerLLMService: LLMService, @unchecked Sendable {
 }
 
 /// End-to-end threading of the per-model markers through `LLMCaller` (#1422).
+///
+/// Each test is labelled **Regression** (fails if the fix is reverted) or
+/// **Control** (passes both before and after — it exists to give a Regression
+/// test its contrast). Three of the five are regression tests; do not read the
+/// file's length as five independent guards.
 extension LLMCallerTests {
   /// The raw shape that actually loses the payload: a **fenced** fabricated
   /// continuation, which `extractFromCodeBlock` lifts out ahead of the
@@ -51,7 +56,7 @@ extension LLMCallerTests {
     ```
     """
 
-  /// `LLMCaller` must read the marker set from the live backend. This is the
+  /// **Regression.** `LLMCaller` must read the marker set from the live backend. This is the
   /// integration half of the D2 dynamic-dispatch pin: the caller holds
   /// `any LLMService`, so a statically-dispatched declaration would silently
   /// fall back to ChatML here.
@@ -69,7 +74,7 @@ extension LLMCallerTests {
     #expect(result.statement == "本物")
   }
 
-  /// Negative control on the identical response: a ChatML-only backend takes
+  /// **Control.** Negative control on the identical response: a ChatML-only backend takes
   /// the fabricated continuation. This is the bug #1422 fixes, so it must be
   /// demonstrated rather than asserted — without it, the test above could pass
   /// for reasons unrelated to the marker set.
@@ -87,7 +92,7 @@ extension LLMCallerTests {
     #expect(result.statement == "偽物")
   }
 
-  /// The leakage diagnostic is model-aware: a Gemma turn-start marker now
+  /// **Regression.** The leakage diagnostic is model-aware: a Gemma turn-start marker now
   /// raises the `.warning`, where before #1422 it raised nothing at all.
   @Test func leakageDiagnosticWarnsOnBackendStartMarker() async throws {
     let gemma = GemmaMarkerLLMService(responses: [Self.gemmaHallucination])
@@ -106,9 +111,16 @@ extension LLMCallerTests {
     #expect(warnings.allSatisfy { $0.privacy == .public })
   }
 
-  /// The same raw text through a ChatML-only backend raises **no** warning —
-  /// the silence that made this diagnostic useless for the default shipped
-  /// model. Pins the delta rather than merely the fixed behaviour.
+  /// **Control.** The same raw text through a ChatML-only backend raises **no**
+  /// warning — the silence that made this diagnostic useless for the default
+  /// shipped model. Pins the delta rather than merely the fixed behaviour.
+  ///
+  /// Asserts the absence of **any** `.warning`, not the absence of the string
+  /// `<|turn>`: a substring probe passes on pre-#1422 code for the trivial
+  /// reason that no line is emitted at all, and it also silently couples the
+  /// control to the message wording. Not vacuous — `leakageDiagnosticWarnsOn
+  /// BackendStartMarker` above drives the same raw text to a `.warning`, so
+  /// warnings are reachable on this input and only the marker set differs.
   @Test func leakageDiagnosticIsSilentForNonMatchingMarkers() async throws {
     let mock = MockLLMService(responses: [Self.gemmaHallucination])
     try await mock.loadModel()
@@ -121,10 +133,10 @@ extension LLMCallerTests {
       suspendController: SuspendController(),
       emitter: collector.emit)
 
-    #expect(!spy.entries.contains { $0.message.contains("<|turn>") })
+    #expect(!spy.entries.contains { $0.level == .warning })
   }
 
-  /// A ChatML backend keeps the pre-#1422 diagnostic behaviour verbatim.
+  /// **Regression.** A ChatML backend keeps the pre-#1422 diagnostic behaviour verbatim.
   @Test func leakageDiagnosticStillWarnsOnChatMLStartMarker() async throws {
     let raw = """
       {"statement": "hello"}<|im_end|>

--- a/Pastura/PasturaTests/Engine/LLMCallerTests+TurnMarkers.swift
+++ b/Pastura/PasturaTests/Engine/LLMCallerTests+TurnMarkers.swift
@@ -122,9 +122,11 @@ extension LLMCallerTests {
   /// message wording, which this PR then changed; (2) it would miss a
   /// *differently-worded* warning on this path — a `logParseFailure` line, say.
   /// Reason (2) is **forward-looking, not instantiated**: no warning of any kind
-  /// fires on this input today, since the sibling control below shows this raw
-  /// text parses successfully. It is the shape a silence control should have,
-  /// not a failure it currently catches.
+  /// fires on this input today, since
+  /// `chatMLOnlyBackendStillTakesTheFabricatedContinuation` shows this raw text
+  /// parses successfully, so `logParseFailure` — the only other `.warning` site —
+  /// never runs either. It is the shape a silence control should have, not a
+  /// failure it currently catches.
   ///
   /// Not vacuous: `leakageDiagnosticWarnsOnBackendStartMarker` above drives the
   /// same raw text to a `.warning`, so warnings are reachable on this input and

--- a/Pastura/PasturaTests/Engine/LLMCallerTests+TurnMarkers.swift
+++ b/Pastura/PasturaTests/Engine/LLMCallerTests+TurnMarkers.swift
@@ -1,0 +1,150 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+/// A backend that behaves exactly like ``MockLLMService`` but reports a
+/// non-ChatML marker pair, so `LLMCaller` can be driven down the per-model
+/// path (#1422).
+///
+/// Deliberately a wrapper rather than a `MockLLMService` subclass: the point
+/// under test is that `LLMCaller` reads `knownTurnMarkers` **through the
+/// existential**, so the stub must be a distinct conforming type.
+nonisolated final class GemmaMarkerLLMService: LLMService, @unchecked Sendable {
+  private let inner: MockLLMService
+
+  init(responses: [String]) {
+    inner = MockLLMService(responses: responses)
+  }
+
+  var knownTurnMarkers: [ChatTurnMarkers] {
+    [ChatTurnMarkers(start: "<|turn>", end: "<turn|>"), .chatML]
+  }
+
+  func loadModel() async throws { try await inner.loadModel() }
+  func unloadModel() async throws { try await inner.unloadModel() }
+  var isModelLoaded: Bool { inner.isModelLoaded }
+  var modelIdentifier: String { "gemma-stub" }
+  var backendIdentifier: String { "mock" }
+
+  func generate(
+    system: String, user: String, schema: OutputSchema?, antiRepetitionSeeds: [String]
+  ) async throws -> String {
+    try await inner.generate(
+      system: system, user: user, schema: schema, antiRepetitionSeeds: antiRepetitionSeeds)
+  }
+}
+
+/// End-to-end threading of the per-model markers through `LLMCaller` (#1422).
+extension LLMCallerTests {
+  /// The raw shape that actually loses the payload: a **fenced** fabricated
+  /// continuation, which `extractFromCodeBlock` lifts out ahead of the
+  /// balanced-brace scan.
+  private static let gemmaHallucination = """
+    {"statement": "本物", "inner_thought": "考え中"}<turn|>
+    <|turn>user
+    もう一度
+    <turn|>
+    <|turn>model
+    ```json
+    {"statement": "偽物", "inner_thought": "別"}
+    ```
+    """
+
+  /// `LLMCaller` must read the marker set from the live backend. This is the
+  /// integration half of the D2 dynamic-dispatch pin: the caller holds
+  /// `any LLMService`, so a statically-dispatched declaration would silently
+  /// fall back to ChatML here.
+  @Test func usesBackendTurnMarkersWhenParsing() async throws {
+    let gemma = GemmaMarkerLLMService(responses: [Self.gemmaHallucination])
+    try await gemma.loadModel()
+
+    let collector = EventCollector()
+    let result = try await caller.call(
+      llm: gemma, system: "sys", user: "usr", agentName: "Alice",
+      phaseType: .speakAll,
+      suspendController: SuspendController(),
+      emitter: collector.emit)
+
+    #expect(result.statement == "本物")
+  }
+
+  /// Negative control on the identical response: a ChatML-only backend takes
+  /// the fabricated continuation. This is the bug #1422 fixes, so it must be
+  /// demonstrated rather than asserted — without it, the test above could pass
+  /// for reasons unrelated to the marker set.
+  @Test func chatMLOnlyBackendStillTakesTheFabricatedContinuation() async throws {
+    let mock = MockLLMService(responses: [Self.gemmaHallucination])
+    try await mock.loadModel()
+
+    let collector = EventCollector()
+    let result = try await caller.call(
+      llm: mock, system: "sys", user: "usr", agentName: "Alice",
+      phaseType: .speakAll,
+      suspendController: SuspendController(),
+      emitter: collector.emit)
+
+    #expect(result.statement == "偽物")
+  }
+
+  /// The leakage diagnostic is model-aware: a Gemma turn-start marker now
+  /// raises the `.warning`, where before #1422 it raised nothing at all.
+  @Test func leakageDiagnosticWarnsOnBackendStartMarker() async throws {
+    let gemma = GemmaMarkerLLMService(responses: [Self.gemmaHallucination])
+    try await gemma.loadModel()
+    let spy = SpyEngineLogger()
+
+    let collector = EventCollector()
+    _ = try await LLMCaller(logger: spy).call(
+      llm: gemma, system: "sys", user: "usr", agentName: "Alice",
+      phaseType: .speakAll,
+      suspendController: SuspendController(),
+      emitter: collector.emit)
+
+    let warnings = spy.entries.filter { $0.level == .warning }
+    #expect(warnings.contains { $0.message.contains("<|turn>") })
+    #expect(warnings.allSatisfy { $0.privacy == .public })
+  }
+
+  /// The same raw text through a ChatML-only backend raises **no** warning —
+  /// the silence that made this diagnostic useless for the default shipped
+  /// model. Pins the delta rather than merely the fixed behaviour.
+  @Test func leakageDiagnosticIsSilentForNonMatchingMarkers() async throws {
+    let mock = MockLLMService(responses: [Self.gemmaHallucination])
+    try await mock.loadModel()
+    let spy = SpyEngineLogger()
+
+    let collector = EventCollector()
+    _ = try await LLMCaller(logger: spy).call(
+      llm: mock, system: "sys", user: "usr", agentName: "Alice",
+      phaseType: .speakAll,
+      suspendController: SuspendController(),
+      emitter: collector.emit)
+
+    #expect(!spy.entries.contains { $0.message.contains("<|turn>") })
+  }
+
+  /// A ChatML backend keeps the pre-#1422 diagnostic behaviour verbatim.
+  @Test func leakageDiagnosticStillWarnsOnChatMLStartMarker() async throws {
+    let raw = """
+      {"statement": "hello"}<|im_end|>
+      <|im_start|>user
+      again
+      """
+    let mock = MockLLMService(responses: [raw])
+    try await mock.loadModel()
+    let spy = SpyEngineLogger()
+
+    let collector = EventCollector()
+    _ = try await LLMCaller(logger: spy).call(
+      llm: mock, system: "sys", user: "usr", agentName: "Alice",
+      phaseType: .speakAll,
+      suspendController: SuspendController(),
+      emitter: collector.emit)
+
+    #expect(
+      spy.entries.contains {
+        $0.level == .warning && $0.message.contains("<|im_start|>")
+      })
+  }
+}

--- a/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests+Qwen.swift
+++ b/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests+Qwen.swift
@@ -73,8 +73,7 @@ extension LlamaCppIntegrationTests {
       modelPath: QwenConfig.modelPath,
       stopSequence: "<|im_end|>",
       // Stated rather than defaulted, even though `.chatML` is the value Qwen
-      // wants: a real-GGUF site that inherits the default stops tracking the
-      // descriptor it claims to mirror (#1422).
+      // wants: a defaulted site stops tracking the descriptor it mirrors (#1422).
       turnMarkers: .chatML,
       modelIdentifier: "Qwen 3 4B (Q4_K_M)",
       systemPromptSuffix: "/no_think",

--- a/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests+Qwen.swift
+++ b/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests+Qwen.swift
@@ -72,6 +72,10 @@ extension LlamaCppIntegrationTests {
     LlamaCppService(
       modelPath: QwenConfig.modelPath,
       stopSequence: "<|im_end|>",
+      // Stated rather than defaulted, even though `.chatML` is the value Qwen
+      // wants: a real-GGUF site that inherits the default stops tracking the
+      // descriptor it claims to mirror (#1422).
+      turnMarkers: .chatML,
       modelIdentifier: "Qwen 3 4B (Q4_K_M)",
       systemPromptSuffix: "/no_think",
       assistantPrefix: "<think>\n\n</think>\n\n"

--- a/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests.swift
+++ b/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests.swift
@@ -67,10 +67,8 @@ struct LlamaCppIntegrationTests {
       modelPath: LlamaCppConfig.modelPath,
       // Mirrors `ModelRegistry.gemma4E2B` — carries no Gemma marker (#1417).
       stopSequence: "<|im_end|>",
-      // Stated, not defaulted. This suite drives the real Gemma GGUF, so the
-      // `.chatML` default would have it parse under different markers than
-      // production — exactly the descriptor/runtime divergence #1422 is about,
-      // and invisible here because the suite asserts on parsed output.
+      // Stated, not defaulted (#1422): a real-GGUF site inheriting the default
+      // would parse under different markers than production.
       turnMarkers: ChatTurnMarkers(start: "<|turn>", end: "<turn|>"),
       modelIdentifier: "Gemma 4 E2B (Q4_K_M)",
       systemPromptSuffix: nil

--- a/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests.swift
+++ b/Pastura/PasturaTests/Integration/LlamaCppIntegrationTests.swift
@@ -67,6 +67,11 @@ struct LlamaCppIntegrationTests {
       modelPath: LlamaCppConfig.modelPath,
       // Mirrors `ModelRegistry.gemma4E2B` — carries no Gemma marker (#1417).
       stopSequence: "<|im_end|>",
+      // Stated, not defaulted. This suite drives the real Gemma GGUF, so the
+      // `.chatML` default would have it parse under different markers than
+      // production — exactly the descriptor/runtime divergence #1422 is about,
+      // and invisible here because the suite asserts on parsed output.
+      turnMarkers: ChatTurnMarkers(start: "<|turn>", end: "<turn|>"),
       modelIdentifier: "Gemma 4 E2B (Q4_K_M)",
       systemPromptSuffix: nil
     )

--- a/Pastura/PasturaTests/LLM/JSONResponseParserTests+TurnMarkers.swift
+++ b/Pastura/PasturaTests/LLM/JSONResponseParserTests+TurnMarkers.swift
@@ -157,11 +157,15 @@ extension JSONResponseParserTests {
 
   // MARK: - Degenerate inputs
 
-  /// An empty marker string must never match — absent the `isEmpty` guards in
-  /// `truncateAtTurnMarkers` it would cut at index 0 and destroy every
-  /// response. Counterfactual: with those guards in place an empty pair does
-  /// not over-match, it goes **inert**, which is what
-  /// `ModelRegistryTurnMarkerDivergenceTests` asserts at the catalog.
+  /// An empty marker string must never match. The counterfactual is worth
+  /// stating precisely: it is `firstIndex`'s own `guard !pattern.isEmpty` that
+  /// stops the index-0 cut, so deleting only the three `isEmpty` checks inside
+  /// `truncateAtTurnMarkers` destroys nothing — all four together are what
+  /// hold. With them in place an empty pair does not over-match, it goes
+  /// **inert**, and that inertness is *why*
+  /// `ModelRegistryTurnMarkerDivergenceTests` asserts non-empty markers at the
+  /// catalog — the mechanism is silent, so the catalog is the only place it can
+  /// be caught.
   @Test func emptyMarkerStrings_areIgnored() throws {
     let input = #"{"statement": "hello"}"#
     let output = try parser.parse(

--- a/Pastura/PasturaTests/LLM/JSONResponseParserTests+TurnMarkers.swift
+++ b/Pastura/PasturaTests/LLM/JSONResponseParserTests+TurnMarkers.swift
@@ -7,10 +7,9 @@ import Testing
 /// § "Splitting a Suite Across Files".
 ///
 /// Every test that asserts the fix also runs the **same input** through the
-/// pre-#1422 ChatML-only set as a negative control — without one, a test that
+/// pre-#1422 ChatML-only set as a negative control — otherwise a test that
 /// happens to pass for an unrelated reason (the balanced-brace scan already
-/// discards trailing prose, so most hallucination shapes parse correctly with
-/// no truncation at all) would read as proof that truncation fired.
+/// discards trailing prose) would read as proof truncation fired.
 extension JSONResponseParserTests {
   private var gemma: [ChatTurnMarkers] {
     [ChatTurnMarkers(start: "<|turn>", end: "<turn|>"), .chatML]
@@ -18,10 +17,9 @@ extension JSONResponseParserTests {
 
   // MARK: - End arm
 
-  /// A fenced fabricated continuation is the shape that actually loses the
-  /// payload: `extractFromCodeBlock` runs **before** the balanced-brace scan
-  /// and takes `firstMatch` unconditionally, so it lifts the fabricated object
-  /// out of the fence and the real (unfenced) answer is discarded silently.
+  /// A fenced fabricated continuation loses the payload: `extractFromCodeBlock`
+  /// runs before the balanced-brace scan and takes `firstMatch`
+  /// unconditionally, discarding the real unfenced answer.
   @Test func endMarker_truncatesFencedFabricatedContinuation() throws {
     let input = """
       {"statement": "本物", "action": "cooperate"}<turn|>
@@ -43,19 +41,15 @@ extension JSONResponseParserTests {
     #expect(unfixed.fields["statement"] == "偽物")
   }
 
-  /// **A pin on an accepted trade-off, not an assertion of desired behaviour.**
-  /// Read [#1452](https://github.com/tyabu12/pastura/issues/1452) before
-  /// changing it — a failure here means the end arm's unguarded cut moved, and
-  /// the question is whether #1452 was decided, not whether this expectation is
-  /// stale.
+  /// **A pin on an accepted trade-off, not desired behaviour.** Read
+  /// [#1452](https://github.com/tyabu12/pastura/issues/1452) before changing —
+  /// a failure means the unguarded cut moved, not that this is stale.
   ///
-  /// The end arm cuts at the first occurrence with no `firstBrace` guard, so a
-  /// *leading* end marker discards the whole payload the model then writes.
-  /// The symmetric-looking fix — reuse the start arm's `> firstBrace` gate —
-  /// is not strictly safer, which is the second `#expect` below: today
-  /// `<|im_end|>{"fake":1}` fails and retries; under that gate the fabricated
-  /// object would be accepted as the turn's answer. Both arms stay as they are
-  /// until #1452 picks a side.
+  /// The end arm cuts at the first occurrence with no `firstBrace` gate, so a *leading*
+  /// end marker discards the whole payload the model then writes.
+  /// The symmetric-looking fix — reusing the start arm's `> firstBrace` gate —
+  /// is not strictly safer: the second `#expect` shows `<|im_end|>{"fake":1}`
+  /// would then be accepted rather than failing and retrying.
   @Test func endMarker_leadingMarkerDestroysPayload_acceptedGap() throws {
     let leadingEcho = """
       <turn|>
@@ -70,15 +64,10 @@ extension JSONResponseParserTests {
     }
   }
 
-  /// **Regression.** A non-ChatML end marker inside a JSON string value is
-  /// payload content, not a turn boundary. Without the guard the cut lands
-  /// mid-value, the repair pipeline closes the quote and brace, and a truncated
-  /// value is persisted as the agent's answer — measured before the fix as
-  /// `["statement": "テンプレートは"]` with `action` gone entirely.
-  ///
-  /// Reachable specifically because `stopSequence` still strips only
-  /// `<|im_end|>` (#1451), so `<turn|>` is the first end marker that survives
-  /// generation and arrives here un-stripped.
+  /// **Regression.** A non-ChatML end marker inside a string value is payload,
+  /// not a boundary — pre-fix measured as `["statement": "テンプレートは"]` with
+  /// `action` gone. Reachable because `stopSequence` strips only `<|im_end|>`
+  /// (#1451), so `<turn|>` survives un-stripped.
   @Test func endMarker_insideStringValue_isNotATurnBoundary() throws {
     let input = #"{"statement": "テンプレートは <turn|> で終わる", "action": "cooperate"}"#
 
@@ -87,15 +76,10 @@ extension JSONResponseParserTests {
     #expect(output.fields["action"] == "cooperate")
   }
 
-  /// **Control — the byte-identical-for-ChatML criterion.** The same shape with
-  /// ChatML's *own* end marker still cuts string-blind, because guarding it
-  /// would move shipped ChatML behaviour and #1422 holds that fixed. So the
-  /// guard above is keyed on `.chatML.end` by literal, and this test is what
-  /// pins the exception rather than letting it drift into "all end markers".
-  ///
-  /// A failure here means someone widened the guard. That may well be the right
-  /// call on its own merits — but it is a separate decision from #1422, and it
-  /// changes Qwen.
+  /// **Control — byte-identical-for-ChatML criterion.** ChatML's own end
+  /// marker still cuts string-blind (keyed on `.chatML.end` by literal). A
+  /// failure means someone widened the guard — a separate decision from
+  /// #1422, and it changes Qwen.
   @Test func endMarker_chatMLInsideStringValue_stillCutsBlind() throws {
     let input = #"{"note": "テンプレートは <|im_end|> で終わる"}"#
 
@@ -107,9 +91,8 @@ extension JSONResponseParserTests {
 
   // MARK: - Start arm
 
-  /// A start marker **after** the first structural `{` is a fabricated next
-  /// turn, so it truncates — covering the hallucination shape that emits no
-  /// end marker at all.
+  /// A start marker after the first structural `{` is a fabricated next turn,
+  /// so it truncates — covers the hallucination shape with no end marker.
   @Test func startMarker_afterFirstBrace_truncates() throws {
     let input = """
       {"statement": "本物"}
@@ -123,15 +106,12 @@ extension JSONResponseParserTests {
     #expect(try parser.parse(input, turnMarkers: [.chatML]).fields["statement"] == "偽物")
   }
 
-  /// **The asymmetry's load-bearing half.** A *leading* start marker is the
-  /// model echoing its own template header with the payload still behind it.
-  /// Truncating there deletes the payload — and deterministically, since the
-  /// backend's template config reproduces on every retry, so the run walks
-  /// `parse_failed` → `retriesExhausted` → an ADR-021 turn skip rather than
-  /// recovering.
+  /// **The asymmetry's load-bearing half.** A leading start marker is the
+  /// model echoing its own template header; truncating there deterministically
+  /// deletes the payload.
   ///
   /// Revert the `firstBrace + 1` search origin to `0` and this test throws
-  /// while every other test in this file still passes.
+  /// while every other test here still passes.
   @Test func startMarker_leadingHeaderEcho_isNotATurnBoundary() throws {
     let input = """
       <|turn>model
@@ -143,11 +123,9 @@ extension JSONResponseParserTests {
     #expect(output.fields["action"] == "cooperate")
   }
 
-  /// The start arm is string-aware: a marker spelled inside a JSON string
-  /// value is payload content, not a turn boundary. Without the check the cut
-  /// lands mid-string, the repair pipeline closes the quote and brace, and a
-  /// silently-truncated field value is persisted as if it were the model's
-  /// answer.
+  /// The start arm is string-aware: a marker inside a JSON string value is
+  /// payload content, not a turn boundary. Without the check the cut lands
+  /// mid-string and a silently-truncated value is persisted as the answer.
   @Test func startMarker_insideStringValue_isNotATurnBoundary() throws {
     let input = #"{"statement": "テンプレートは <|im_start|> から始まる", "action": "cooperate"}"#
 
@@ -159,9 +137,8 @@ extension JSONResponseParserTests {
   // MARK: - Qwen / ChatML equivalence
 
   /// The end arm is byte-identical for every backend, and the start arm is a
-  /// no-op on inputs that carry no post-`{` start marker — which is every
-  /// input in the shipped corpus. Demonstrated on the trailing-prose residue
-  /// shape, the one the balanced-brace scan handles on its own.
+  /// no-op on inputs with no post-`{` start marker — every input in the
+  /// shipped corpus. Demonstrated on the trailing-prose residue shape.
   @Test func markerFreeInput_parsesIdenticallyUnderEitherSet() throws {
     let input = """
       {"statement": "hello", "action": "cooperate"}
@@ -192,15 +169,12 @@ extension JSONResponseParserTests {
 
   // MARK: - Degenerate inputs
 
-  /// An empty marker string must never match. The counterfactual is worth
-  /// stating precisely: it is `firstIndex`'s own `guard !pattern.isEmpty` that
-  /// stops the index-0 cut, so deleting only the three `isEmpty` checks inside
-  /// `truncateAtTurnMarkers` destroys nothing — all four together are what
-  /// hold. With them in place an empty pair does not over-match, it goes
-  /// **inert**, and that inertness is *why*
-  /// `ModelRegistryTurnMarkerDivergenceTests` asserts non-empty markers at the
-  /// catalog — the mechanism is silent, so the catalog is the only place it can
-  /// be caught.
+  /// An empty marker string must never match. It's `firstIndex`'s own
+  /// `guard !pattern.isEmpty` that stops the index-0 cut, so deleting only the
+  /// three `isEmpty` checks inside `truncateAtTurnMarkers` destroys nothing —
+  /// all four together are what hold. An empty pair goes **inert** rather than
+  /// over-matching, which is why `ModelRegistryTurnMarkerDivergenceTests`
+  /// asserts non-empty markers at the catalog instead.
   @Test func emptyMarkerStrings_areIgnored() throws {
     let input = #"{"statement": "hello"}"#
     let output = try parser.parse(

--- a/Pastura/PasturaTests/LLM/JSONResponseParserTests+TurnMarkers.swift
+++ b/Pastura/PasturaTests/LLM/JSONResponseParserTests+TurnMarkers.swift
@@ -43,6 +43,33 @@ extension JSONResponseParserTests {
     #expect(unfixed.fields["statement"] == "偽物")
   }
 
+  /// **A pin on an accepted trade-off, not an assertion of desired behaviour.**
+  /// Read [#1452](https://github.com/tyabu12/pastura/issues/1452) before
+  /// changing it — a failure here means the end arm's unguarded cut moved, and
+  /// the question is whether #1452 was decided, not whether this expectation is
+  /// stale.
+  ///
+  /// The end arm cuts at the first occurrence with no `firstBrace` guard, so a
+  /// *leading* end marker discards the whole payload the model then writes.
+  /// The symmetric-looking fix — reuse the start arm's `> firstBrace` gate —
+  /// is not strictly safer, which is the second `#expect` below: today
+  /// `<|im_end|>{"fake":1}` fails and retries; under that gate the fabricated
+  /// object would be accepted as the turn's answer. Both arms stay as they are
+  /// until #1452 picks a side.
+  @Test func endMarker_leadingMarkerDestroysPayload_acceptedGap() throws {
+    let leadingEcho = """
+      <turn|>
+      {"statement": "本物", "action": "cooperate"}
+      """
+    #expect(throws: LLMError.self) { try parser.parse(leadingEcho, turnMarkers: gemma) }
+
+    // The counter-example that blocks the `> firstBrace` gate: gating the end
+    // arm would turn this throw into an accepted fabricated object.
+    #expect(throws: LLMError.self) {
+      try parser.parse(#"<|im_end|>{"fake":1}"#, turnMarkers: [.chatML])
+    }
+  }
+
   // MARK: - Start arm
 
   /// A start marker **after** the first structural `{` is a fabricated next

--- a/Pastura/PasturaTests/LLM/JSONResponseParserTests+TurnMarkers.swift
+++ b/Pastura/PasturaTests/LLM/JSONResponseParserTests+TurnMarkers.swift
@@ -1,0 +1,147 @@
+import Testing
+
+@testable import Pastura
+
+/// Per-model hallucinated-turn truncation (#1422). Sibling extension of the
+/// existing suite rather than a new one, per `.claude/rules/testing.md`
+/// § "Splitting a Suite Across Files".
+///
+/// Every test that asserts the fix also runs the **same input** through the
+/// pre-#1422 ChatML-only set as a negative control — without one, a test that
+/// happens to pass for an unrelated reason (the balanced-brace scan already
+/// discards trailing prose, so most hallucination shapes parse correctly with
+/// no truncation at all) would read as proof that truncation fired.
+extension JSONResponseParserTests {
+  private var gemma: [ChatTurnMarkers] {
+    [ChatTurnMarkers(start: "<|turn>", end: "<turn|>"), .chatML]
+  }
+
+  // MARK: - End arm
+
+  /// A fenced fabricated continuation is the shape that actually loses the
+  /// payload: `extractFromCodeBlock` runs **before** the balanced-brace scan
+  /// and takes `firstMatch` unconditionally, so it lifts the fabricated object
+  /// out of the fence and the real (unfenced) answer is discarded silently.
+  @Test func endMarker_truncatesFencedFabricatedContinuation() throws {
+    let input = """
+      {"statement": "本物", "action": "cooperate"}<turn|>
+      <|turn>user
+      もう一度
+      <turn|>
+      <|turn>model
+      ```json
+      {"statement": "偽物", "action": "betray"}
+      ```
+      """
+
+    let output = try parser.parse(input, turnMarkers: gemma)
+    #expect(output.fields["statement"] == "本物")
+    #expect(output.fields["action"] == "cooperate")
+
+    // Negative control — the pre-#1422 behaviour on the identical input.
+    let unfixed = try parser.parse(input, turnMarkers: [.chatML])
+    #expect(unfixed.fields["statement"] == "偽物")
+  }
+
+  // MARK: - Start arm
+
+  /// A start marker **after** the first structural `{` is a fabricated next
+  /// turn, so it truncates — covering the hallucination shape that emits no
+  /// end marker at all.
+  @Test func startMarker_afterFirstBrace_truncates() throws {
+    let input = """
+      {"statement": "本物"}
+      <|turn>model
+      ```json
+      {"statement": "偽物"}
+      ```
+      """
+
+    #expect(try parser.parse(input, turnMarkers: gemma).fields["statement"] == "本物")
+    #expect(try parser.parse(input, turnMarkers: [.chatML]).fields["statement"] == "偽物")
+  }
+
+  /// **The asymmetry's load-bearing half.** A *leading* start marker is the
+  /// model echoing its own template header with the payload still behind it.
+  /// Truncating there deletes the payload — and deterministically, since the
+  /// backend's template config reproduces on every retry, so the run walks
+  /// `parse_failed` → `retriesExhausted` → an ADR-021 turn skip rather than
+  /// recovering.
+  ///
+  /// Revert the `firstBrace + 1` search origin to `0` and this test throws
+  /// while every other test in this file still passes.
+  @Test func startMarker_leadingHeaderEcho_isNotATurnBoundary() throws {
+    let input = """
+      <|turn>model
+      {"statement": "本物", "action": "cooperate"}
+      """
+
+    let output = try parser.parse(input, turnMarkers: gemma)
+    #expect(output.fields["statement"] == "本物")
+    #expect(output.fields["action"] == "cooperate")
+  }
+
+  /// The start arm is string-aware: a marker spelled inside a JSON string
+  /// value is payload content, not a turn boundary. Without the check the cut
+  /// lands mid-string, the repair pipeline closes the quote and brace, and a
+  /// silently-truncated field value is persisted as if it were the model's
+  /// answer.
+  @Test func startMarker_insideStringValue_isNotATurnBoundary() throws {
+    let input = #"{"statement": "テンプレートは <|im_start|> から始まる", "action": "cooperate"}"#
+
+    let output = try parser.parse(input, turnMarkers: [.chatML])
+    #expect(output.fields["statement"] == "テンプレートは <|im_start|> から始まる")
+    #expect(output.fields["action"] == "cooperate")
+  }
+
+  // MARK: - Qwen / ChatML equivalence
+
+  /// The end arm is byte-identical for every backend, and the start arm is a
+  /// no-op on inputs that carry no post-`{` start marker — which is every
+  /// input in the shipped corpus. Demonstrated on the trailing-prose residue
+  /// shape, the one the balanced-brace scan handles on its own.
+  @Test func markerFreeInput_parsesIdenticallyUnderEitherSet() throws {
+    let input = """
+      {"statement": "hello", "action": "cooperate"}
+      That is my answer for this round.
+      """
+
+    let chatML = try parser.parse(input, turnMarkers: [.chatML])
+    let withGemma = try parser.parse(input, turnMarkers: gemma)
+    #expect(chatML.fields == withGemma.fields)
+    #expect(chatML.fields["statement"] == "hello")
+  }
+
+  /// A ChatML model's own hallucination shape is unaffected by the widened
+  /// set — the extra Gemma pair simply never matches.
+  @Test func chatMLHallucination_unchangedWhenGemmaPairIsAlsoPresent() throws {
+    let input = """
+      {"inner_thought": "考え中", "statement": "こんにちは"}<|im_end|>
+      <|im_start|>user
+      サクラ: 別の発言"}
+      <|im_end|>
+      """
+
+    let baseline = try parser.parse(input, turnMarkers: [.chatML])
+    let widened = try parser.parse(input, turnMarkers: gemma)
+    #expect(baseline.fields == widened.fields)
+    #expect(widened.fields["statement"] == "こんにちは")
+  }
+
+  // MARK: - Degenerate inputs
+
+  /// An empty marker string must never match — it would otherwise cut at index
+  /// 0 and destroy every response.
+  @Test func emptyMarkerStrings_areIgnored() throws {
+    let input = #"{"statement": "hello"}"#
+    let output = try parser.parse(
+      input, turnMarkers: [ChatTurnMarkers(start: "", end: "")])
+    #expect(output.fields["statement"] == "hello")
+  }
+
+  @Test func emptyMarkerSet_leavesTextUntouched() throws {
+    let input = #"{"statement": "hello"}<|im_end|>garbage"#
+    let output = try parser.parse(input, turnMarkers: [])
+    #expect(output.fields["statement"] == "hello")
+  }
+}

--- a/Pastura/PasturaTests/LLM/JSONResponseParserTests+TurnMarkers.swift
+++ b/Pastura/PasturaTests/LLM/JSONResponseParserTests+TurnMarkers.swift
@@ -70,6 +70,41 @@ extension JSONResponseParserTests {
     }
   }
 
+  /// **Regression.** A non-ChatML end marker inside a JSON string value is
+  /// payload content, not a turn boundary. Without the guard the cut lands
+  /// mid-value, the repair pipeline closes the quote and brace, and a truncated
+  /// value is persisted as the agent's answer — measured before the fix as
+  /// `["statement": "テンプレートは"]` with `action` gone entirely.
+  ///
+  /// Reachable specifically because `stopSequence` still strips only
+  /// `<|im_end|>` (#1451), so `<turn|>` is the first end marker that survives
+  /// generation and arrives here un-stripped.
+  @Test func endMarker_insideStringValue_isNotATurnBoundary() throws {
+    let input = #"{"statement": "テンプレートは <turn|> で終わる", "action": "cooperate"}"#
+
+    let output = try parser.parse(input, turnMarkers: gemma)
+    #expect(output.fields["statement"] == "テンプレートは <turn|> で終わる")
+    #expect(output.fields["action"] == "cooperate")
+  }
+
+  /// **Control — the byte-identical-for-ChatML criterion.** The same shape with
+  /// ChatML's *own* end marker still cuts string-blind, because guarding it
+  /// would move shipped ChatML behaviour and #1422 holds that fixed. So the
+  /// guard above is keyed on `.chatML.end` by literal, and this test is what
+  /// pins the exception rather than letting it drift into "all end markers".
+  ///
+  /// A failure here means someone widened the guard. That may well be the right
+  /// call on its own merits — but it is a separate decision from #1422, and it
+  /// changes Qwen.
+  @Test func endMarker_chatMLInsideStringValue_stillCutsBlind() throws {
+    let input = #"{"note": "テンプレートは <|im_end|> で終わる"}"#
+
+    let (output, repair) = try parser.parse(
+      input, expectedKeys: ["note"], turnMarkers: [.chatML])
+    #expect(output.fields["note"] == "テンプレートは")
+    #expect(repair == "unclosed_string+unclosed_brace")
+  }
+
   // MARK: - Start arm
 
   /// A start marker **after** the first structural `{` is a fabricated next

--- a/Pastura/PasturaTests/LLM/JSONResponseParserTests+TurnMarkers.swift
+++ b/Pastura/PasturaTests/LLM/JSONResponseParserTests+TurnMarkers.swift
@@ -157,8 +157,11 @@ extension JSONResponseParserTests {
 
   // MARK: - Degenerate inputs
 
-  /// An empty marker string must never match — it would otherwise cut at index
-  /// 0 and destroy every response.
+  /// An empty marker string must never match — absent the `isEmpty` guards in
+  /// `truncateAtTurnMarkers` it would cut at index 0 and destroy every
+  /// response. Counterfactual: with those guards in place an empty pair does
+  /// not over-match, it goes **inert**, which is what
+  /// `ModelRegistryTurnMarkerDivergenceTests` asserts at the catalog.
   @Test func emptyMarkerStrings_areIgnored() throws {
     let input = #"{"statement": "hello"}"#
     let output = try parser.parse(

--- a/Pastura/PasturaTests/LLM/LlamaCppServiceChatTemplateTests.swift
+++ b/Pastura/PasturaTests/LLM/LlamaCppServiceChatTemplateTests.swift
@@ -75,6 +75,9 @@ struct LlamaCppServiceChatTemplateTests {
     LlamaCppService(
       modelPath: "",
       stopSequence: "<|im_end|>",
+      // Stated because the init has no default (#1422). Irrelevant to
+      // `applyChatTemplate`, which never consults it.
+      turnMarkers: .chatML,
       modelIdentifier: "ChatTemplate Test Service",
       systemPromptSuffix: nil,
       assistantPrefix: assistantPrefix

--- a/Pastura/PasturaTests/LLM/LlamaCppServiceChatTemplateTests.swift
+++ b/Pastura/PasturaTests/LLM/LlamaCppServiceChatTemplateTests.swift
@@ -75,8 +75,7 @@ struct LlamaCppServiceChatTemplateTests {
     LlamaCppService(
       modelPath: "",
       stopSequence: "<|im_end|>",
-      // Stated because the init has no default (#1422). Irrelevant to
-      // `applyChatTemplate`, which never consults it.
+      // Stated because the init has no default (#1422).
       turnMarkers: .chatML,
       modelIdentifier: "ChatTemplate Test Service",
       systemPromptSuffix: nil,

--- a/Pastura/PasturaTests/LLM/LlamaCppServiceTests+TurnMarkers.swift
+++ b/Pastura/PasturaTests/LLM/LlamaCppServiceTests+TurnMarkers.swift
@@ -16,9 +16,8 @@ extension LlamaCppServiceTests {
     )
   }
 
-  /// A non-ChatML model surfaces **both** its own pair and the ChatML baseline
-  /// — the union rule (#1422 D3). Order is load-bearing only in that the
-  /// model's own pair must be present at all.
+  /// A non-ChatML model surfaces both its own pair and the ChatML baseline —
+  /// the union rule (#1422 D3).
   @Test func knownTurnMarkers_unionsModelPairWithChatMLBaseline() {
     let markers = gemmaShapedService().knownTurnMarkers
     #expect(markers.contains(ChatTurnMarkers(start: "<|turn>", end: "<turn|>")))
@@ -34,13 +33,12 @@ extension LlamaCppServiceTests {
   }
 
   /// **The D2 regression test.** `knownTurnMarkers` is declared in the
-  /// `LLMService` protocol *body*, so it dispatches dynamically; moving the
-  /// declaration into an extension would statically dispatch through
-  /// `any LLMService` and silently return the default `[.chatML]` at the
-  /// `LLMCaller` call site — which is exactly how the caller holds its backend.
+  /// `LLMService` protocol body so it dispatches dynamically; moving it to an
+  /// extension would statically dispatch through `any LLMService` and
+  /// silently return `[.chatML]` at the `LLMCaller` call site.
   ///
-  /// Revert the declaration to extension-only and this test fails while the
-  /// two above still pass, because they hold a concrete `LlamaCppService`.
+  /// Revert to extension-only and this test fails while the two above still
+  /// pass, since they hold a concrete `LlamaCppService`.
   @Test func knownTurnMarkers_dispatchesDynamicallyThroughExistential() {
     let service: any LLMService = gemmaShapedService()
     #expect(service.knownTurnMarkers.contains(ChatTurnMarkers(start: "<|turn>", end: "<turn|>")))

--- a/Pastura/PasturaTests/LLM/LlamaCppServiceTests+TurnMarkers.swift
+++ b/Pastura/PasturaTests/LLM/LlamaCppServiceTests+TurnMarkers.swift
@@ -1,0 +1,56 @@
+import Testing
+
+@testable import Pastura
+
+/// `knownTurnMarkers` coverage (#1422). Sibling extension rather than a new
+/// suite, per `.claude/rules/testing.md` § "Splitting a Suite Across Files" —
+/// `LlamaCppServiceTests` is `.serialized` and near the 400-line cap.
+extension LlamaCppServiceTests {
+  private func gemmaShapedService() -> LlamaCppService {
+    LlamaCppService(
+      modelPath: "/nonexistent.gguf",
+      stopSequence: "<|im_end|>",
+      turnMarkers: ChatTurnMarkers(start: "<|turn>", end: "<turn|>"),
+      modelIdentifier: "test-gemma",
+      systemPromptSuffix: nil
+    )
+  }
+
+  /// A non-ChatML model surfaces **both** its own pair and the ChatML baseline
+  /// — the union rule (#1422 D3). Order is load-bearing only in that the
+  /// model's own pair must be present at all.
+  @Test func knownTurnMarkers_unionsModelPairWithChatMLBaseline() {
+    let markers = gemmaShapedService().knownTurnMarkers
+    #expect(markers.contains(ChatTurnMarkers(start: "<|turn>", end: "<turn|>")))
+    #expect(markers.contains(.chatML))
+    #expect(markers.count == 2)
+  }
+
+  /// A ChatML model must not grow a duplicate entry — consumers iterate this
+  /// set per parse, and a doubled pair would do the same work twice.
+  @Test func knownTurnMarkers_dedupesWhenModelIsChatML() {
+    let service = makeTestService()
+    #expect(service.knownTurnMarkers == [.chatML])
+  }
+
+  /// **The D2 regression test.** `knownTurnMarkers` is declared in the
+  /// `LLMService` protocol *body*, so it dispatches dynamically; moving the
+  /// declaration into an extension would statically dispatch through
+  /// `any LLMService` and silently return the default `[.chatML]` at the
+  /// `LLMCaller` call site — which is exactly how the caller holds its backend.
+  ///
+  /// Revert the declaration to extension-only and this test fails while the
+  /// two above still pass, because they hold a concrete `LlamaCppService`.
+  @Test func knownTurnMarkers_dispatchesDynamicallyThroughExistential() {
+    let service: any LLMService = gemmaShapedService()
+    #expect(service.knownTurnMarkers.contains(ChatTurnMarkers(start: "<|turn>", end: "<turn|>")))
+    #expect(service.knownTurnMarkers != [.chatML])
+  }
+
+  /// Backends that cannot name their model keep the pre-#1422 ChatML-only
+  /// behaviour through the protocol-extension default.
+  @Test func knownTurnMarkers_defaultsToChatMLForBackendsWithoutADescriptor() {
+    let mock: any LLMService = MockLLMService(responses: [])
+    #expect(mock.knownTurnMarkers == [.chatML])
+  }
+}

--- a/Pastura/PasturaTests/LLM/LlamaCppServiceTests.swift
+++ b/Pastura/PasturaTests/LLM/LlamaCppServiceTests.swift
@@ -13,6 +13,9 @@ func makeTestService(modelPath: String = "/nonexistent.gguf") -> LlamaCppService
   LlamaCppService(
     modelPath: modelPath,
     stopSequence: "<|im_end|>",
+    // Stated because the init has no default (#1422). ChatML is the right value
+    // for a synthetic fixture — it is what a marker-agnostic test expects.
+    turnMarkers: .chatML,
     modelIdentifier: "test-model",
     systemPromptSuffix: nil
   )

--- a/Pastura/PasturaTests/LLM/LlamaCppServiceTests.swift
+++ b/Pastura/PasturaTests/LLM/LlamaCppServiceTests.swift
@@ -13,8 +13,7 @@ func makeTestService(modelPath: String = "/nonexistent.gguf") -> LlamaCppService
   LlamaCppService(
     modelPath: modelPath,
     stopSequence: "<|im_end|>",
-    // Stated because the init has no default (#1422). ChatML is the right value
-    // for a synthetic fixture — it is what a marker-agnostic test expects.
+    // Stated because the init has no default (#1422).
     turnMarkers: .chatML,
     modelIdentifier: "test-model",
     systemPromptSuffix: nil

--- a/Pastura/PasturaTests/Localization/LanguageAdherenceBenchmark.swift
+++ b/Pastura/PasturaTests/Localization/LanguageAdherenceBenchmark.swift
@@ -191,6 +191,11 @@ struct LanguageAdherenceBenchmark {
     LlamaCppService(
       modelPath: BenchmarkConfig.modelPath,
       stopSequence: "<|im_end|>",
+      // Stated rather than defaulted, even though `.chatML` is the value Qwen
+      // wants: a real-GGUF site that inherits the default stops tracking the
+      // descriptor it claims to mirror (#1422). Load-bearing for a benchmark —
+      // `parseOK` is the metric, and truncation is upstream of it.
+      turnMarkers: .chatML,
       modelIdentifier: "Qwen 3 4B (Q4_K_M)",
       systemPromptSuffix: "/no_think",
       assistantPrefix: "<think>\n\n</think>\n\n"

--- a/Pastura/PasturaTests/Localization/LanguageAdherenceBenchmark.swift
+++ b/Pastura/PasturaTests/Localization/LanguageAdherenceBenchmark.swift
@@ -192,9 +192,9 @@ struct LanguageAdherenceBenchmark {
       modelPath: BenchmarkConfig.modelPath,
       stopSequence: "<|im_end|>",
       // Stated rather than defaulted, even though `.chatML` is the value Qwen
-      // wants: a real-GGUF site that inherits the default stops tracking the
-      // descriptor it claims to mirror (#1422). Load-bearing for a benchmark —
-      // `parseOK` is the metric, and truncation is upstream of it.
+      // wants: a defaulted site stops tracking the descriptor it mirrors (#1422).
+      // Load-bearing for a benchmark — `parseOK` is the metric, and truncation
+      // is upstream of it.
       turnMarkers: .chatML,
       modelIdentifier: "Qwen 3 4B (Q4_K_M)",
       systemPromptSuffix: "/no_think",

--- a/Pastura/PasturaTests/Models/ChatTurnMarkersTests.swift
+++ b/Pastura/PasturaTests/Models/ChatTurnMarkersTests.swift
@@ -6,10 +6,8 @@ import Testing
 @Suite(.timeLimit(.minutes(1)))
 struct ChatTurnMarkersTests {
   /// `.chatML` is the baseline every consumer unions into its effective set,
-  /// so backends with no descriptor to consult (Ollama, `MockLLMService`,
-  /// FoundationModels) keep their pre-#1422 behaviour. Pinning the literals
-  /// here means a reword of either one shows up as a deliberate edit rather
-  /// than as a silently-widened or silently-narrowed match set.
+  /// so backends with no descriptor (Ollama, `MockLLMService`,
+  /// FoundationModels) keep pre-#1422 behaviour.
   @Test func chatML_carriesTheChatMLPair() {
     #expect(ChatTurnMarkers.chatML.start == "<|im_start|>")
     #expect(ChatTurnMarkers.chatML.end == "<|im_end|>")
@@ -30,12 +28,11 @@ struct ChatTurnMarkersTests {
     #expect(lhs.hashValue == rhs.hashValue)
   }
 
-  /// Equality must discriminate on **both** fields. The effective-set union
-  /// does not hash — `LlamaCppService.knownTurnMarkers` decides with a single
-  /// `turnMarkers == .chatML` ternary — so an `==` that ignored `end` would
-  /// collapse a descriptor sharing ChatML's `start` but carrying a distinct
-  /// `end` into the bare `[.chatML]` arm, silently dropping that `end` from
-  /// the set the truncator iterates.
+  /// Equality must discriminate on **both** fields: `LlamaCppService.knownTurnMarkers`
+  /// decides its union with a `turnMarkers == .chatML` ternary, so an `==`
+  /// ignoring `end` would collapse a descriptor sharing ChatML's `start` into
+  /// the bare `[.chatML]` arm, silently dropping its `end` from the set the
+  /// truncator iterates.
   @Test func hashable_discriminatesOnEachField() {
     let base = ChatTurnMarkers(start: "<a>", end: "</a>")
     #expect(base != ChatTurnMarkers(start: "<b>", end: "</a>"))

--- a/Pastura/PasturaTests/Models/ChatTurnMarkersTests.swift
+++ b/Pastura/PasturaTests/Models/ChatTurnMarkersTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+@Suite(.timeLimit(.minutes(1)))
+struct ChatTurnMarkersTests {
+  /// `.chatML` is the baseline every consumer unions into its effective set,
+  /// so backends with no descriptor to consult (Ollama, `MockLLMService`,
+  /// FoundationModels) keep their pre-#1422 behaviour. Pinning the literals
+  /// here means a reword of either one shows up as a deliberate edit rather
+  /// than as a silently-widened or silently-narrowed match set.
+  @Test func chatML_carriesTheChatMLPair() {
+    #expect(ChatTurnMarkers.chatML.start == "<|im_start|>")
+    #expect(ChatTurnMarkers.chatML.end == "<|im_end|>")
+  }
+
+  @Test func init_storesBothMarkers() {
+    let markers = ChatTurnMarkers(start: "<|turn>", end: "<turn|>")
+    #expect(markers.start == "<|turn>")
+    #expect(markers.end == "<turn|>")
+  }
+
+  // MARK: - Hashable
+
+  @Test func hashable_equalPairsHashEqual() {
+    let lhs = ChatTurnMarkers(start: "<a>", end: "</a>")
+    let rhs = ChatTurnMarkers(start: "<a>", end: "</a>")
+    #expect(lhs == rhs)
+    #expect(lhs.hashValue == rhs.hashValue)
+  }
+
+  /// Equality must discriminate on **both** fields — the effective-set union
+  /// in `LLMService.knownTurnMarkers` dedupes by `Hashable`, so a pair that
+  /// compared equal on `start` alone would silently drop a distinct `end`.
+  @Test func hashable_discriminatesOnEachField() {
+    let base = ChatTurnMarkers(start: "<a>", end: "</a>")
+    #expect(base != ChatTurnMarkers(start: "<b>", end: "</a>"))
+    #expect(base != ChatTurnMarkers(start: "<a>", end: "</b>"))
+  }
+}

--- a/Pastura/PasturaTests/Models/ChatTurnMarkersTests.swift
+++ b/Pastura/PasturaTests/Models/ChatTurnMarkersTests.swift
@@ -30,9 +30,12 @@ struct ChatTurnMarkersTests {
     #expect(lhs.hashValue == rhs.hashValue)
   }
 
-  /// Equality must discriminate on **both** fields — the effective-set union
-  /// in `LLMService.knownTurnMarkers` dedupes by `Hashable`, so a pair that
-  /// compared equal on `start` alone would silently drop a distinct `end`.
+  /// Equality must discriminate on **both** fields. The effective-set union
+  /// does not hash — `LlamaCppService.knownTurnMarkers` decides with a single
+  /// `turnMarkers == .chatML` ternary — so an `==` that ignored `end` would
+  /// collapse a descriptor sharing ChatML's `start` but carrying a distinct
+  /// `end` into the bare `[.chatML]` arm, silently dropping that `end` from
+  /// the set the truncator iterates.
   @Test func hashable_discriminatesOnEachField() {
     let base = ChatTurnMarkers(start: "<a>", end: "</a>")
     #expect(base != ChatTurnMarkers(start: "<b>", end: "</a>"))

--- a/Pastura/PasturaTests/Models/ModelDescriptorTests.swift
+++ b/Pastura/PasturaTests/Models/ModelDescriptorTests.swift
@@ -19,6 +19,7 @@ struct ModelDescriptorTests {
       fileSize: 3_100_000_000,
       sha256: "abc123def456",
       stopSequence: "<|im_end|>",
+      turnMarkers: .chatML,
       minRAM: 6_000_000_000,
       modelInfoURL: URL(string: "https://huggingface.co/google/gemma-4-e2b")!,
       systemPromptSuffix: nil
@@ -66,6 +67,7 @@ struct ModelDescriptorTests {
       fileSize: 3_100_000_000,
       sha256: "abc123def456",
       stopSequence: "<|im_end|>",
+      turnMarkers: ChatTurnMarkers(start: "<|turn>", end: "<turn|>"),
       minRAM: 6_000_000_000,
       modelInfoURL: modelInfoURL,
       systemPromptSuffix: "/no_think",
@@ -83,6 +85,8 @@ struct ModelDescriptorTests {
     #expect(descriptor.fileSize == 3_100_000_000)
     #expect(descriptor.sha256 == "abc123def456")
     #expect(descriptor.stopSequence == "<|im_end|>")
+    #expect(descriptor.turnMarkers.start == "<|turn>")
+    #expect(descriptor.turnMarkers.end == "<turn|>")
     #expect(descriptor.minRAM == 6_000_000_000)
     #expect(descriptor.modelInfoURL == modelInfoURL)
     #expect(descriptor.systemPromptSuffix == "/no_think")

--- a/Pastura/PasturaTests/Views/ModelRowAccessibilityTests.swift
+++ b/Pastura/PasturaTests/Views/ModelRowAccessibilityTests.swift
@@ -34,6 +34,7 @@ struct ModelRowAccessibilityTests {
       fileSize: 1_000_000_000,
       sha256: "",
       stopSequence: "<|im_end|>",
+      turnMarkers: .chatML,
       minRAM: 6_500_000_000,
       modelInfoURL: URL(string: "https://example.com")!,
       systemPromptSuffix: nil

--- a/docs/kmp-migration-status.md
+++ b/docs/kmp-migration-status.md
@@ -33,7 +33,7 @@ _Last updated: 2026-08-13._
 | 2 | Two-boundary vertical slice = GO/NO-GO gate | ✅ **GO** (2026-07-18) | #1063 #1137 #1172 · [ADR-023 §12](decisions/ADR-023.md) |
 | 3 | Bulk port to `commonMain` | 🔄 in progress | ↓ Stage 3 breakdown |
 | 4 | Cross-language parity harness | 🔄 in progress | slice 1a landed ([#1387](https://github.com/tyabu12/pastura/issues/1387), closed); 1b next · [#501](https://github.com/tyabu12/pastura/issues/501) |
-| 5 | iOS consumption switch + code-merge | ⬜ not started | the remaining integration · when writing the Swift `LLMBackend` adapter, confirm in the generated `PasturaShared.h` whether `knownTurnMarkers`' Kotlin interface default crosses K/N (its KDoc states the expectation as unverified) |
+| 5 | iOS consumption switch + code-merge | ⬜ not started | the remaining integration · when writing the Swift `LLMBackend` adapter, confirm whether `knownTurnMarkers`' Kotlin interface default crosses K/N — by compiling the adapter, since a `PasturaShared.h` read alone does not settle it (see that member's KDoc) |
 
 Legend: ✅ done · 🔄 in progress · 🟡 partial · ⬜ not started.
 

--- a/docs/kmp-migration-status.md
+++ b/docs/kmp-migration-status.md
@@ -22,7 +22,7 @@ At-a-glance progress for the KMP Engine migration (ADR-023 / [#501](https://gith
 > other section is hand-maintained; refresh it when a KMP PR merges (see
 > [`.claude/rules/kmp-interop.md`](../.claude/rules/kmp-interop.md)).
 
-_Last updated: 2026-08-06._
+_Last updated: 2026-08-13._
 
 ## Stages
 

--- a/docs/kmp-migration-status.md
+++ b/docs/kmp-migration-status.md
@@ -33,7 +33,7 @@ _Last updated: 2026-08-06._
 | 2 | Two-boundary vertical slice = GO/NO-GO gate | ✅ **GO** (2026-07-18) | #1063 #1137 #1172 · [ADR-023 §12](decisions/ADR-023.md) |
 | 3 | Bulk port to `commonMain` | 🔄 in progress | ↓ Stage 3 breakdown |
 | 4 | Cross-language parity harness | 🔄 in progress | slice 1a landed ([#1387](https://github.com/tyabu12/pastura/issues/1387), closed); 1b next · [#501](https://github.com/tyabu12/pastura/issues/501) |
-| 5 | iOS consumption switch + code-merge | ⬜ not started | the remaining integration |
+| 5 | iOS consumption switch + code-merge | ⬜ not started | the remaining integration · when writing the Swift `LLMBackend` adapter, confirm in the generated `PasturaShared.h` whether `knownTurnMarkers`' Kotlin interface default crosses K/N (its KDoc states the expectation as unverified) |
 
 Legend: ✅ done · 🔄 in progress · 🟡 partial · ⬜ not started.
 

--- a/docs/models/eval-log.md
+++ b/docs/models/eval-log.md
@@ -4,6 +4,11 @@ Durable, committed ledger of model-candidate **evaluation verdicts** — the
 judgment that a `/model-eval` (Gate 1) or real-device (Gate 2) pass produced,
 so a verdict survives after the intake issue's comment is buried.
 
+It carries one other record class: **corpus observations** — cross-candidate
+measurements over the accumulated harness transcripts, which are gitignored and
+per-machine and so have nowhere else durable to live. They are not verdicts and
+gate nothing; see § "Corpus observations (not candidate verdicts)".
+
 ## What lives where (three record surfaces)
 
 A verdict is recorded in three places with distinct roles — this file is the
@@ -13,7 +18,7 @@ durable, version-controlled one:
 |---|---|---|
 | `data/models/eval-digest.md` | Raw per-cell scorecard (every axis + tok/s), **script-regenerated** by `/model-eval` | Gitignored, **per-machine** — re-sampling rewrites it |
 | GitHub issue #979 | Rolling **intake queue** — triage, candidate proposals | Comment thread, buries over time |
-| **This file** | The **verdict** (`pass` / `borderline` / `fail` / `blocked` + rationale + differentiation) | Committed, PR-reviewed |
+| **This file** | The **verdict** (`pass` / `borderline` / `fail` / `blocked` + rationale + differentiation), plus **corpus observations** (non-gate, § below) | Committed, PR-reviewed |
 
 **Anti-drift rule — entries carry judgment only.** An entry records the verdict,
 date, model id/quant, one-line differentiation, rationale, and an aggregate
@@ -74,7 +79,8 @@ everything else here.
 Cross-candidate measurements over the accumulated harness transcripts. Kept here
 because the transcripts themselves are gitignored and per-machine, so a
 measurement over them is otherwise unrecoverable — but they are **not** verdicts,
-so they carry no gate and use this section rather than a `##` entry heading.
+so they carry no gate and live under `###` subheadings here rather than as
+`## <model> — <date> — **VERDICT**` entries.
 
 ### Spelled-out chat-template markers — 2026-08-13
 

--- a/docs/models/eval-log.md
+++ b/docs/models/eval-log.md
@@ -102,12 +102,15 @@ payload (2026-07-08 and 2026-07-23 runs).
 
 **What it does and does not license.** It says *Gemma spelling its own markers is
 unobserved as of this date* — nothing stronger. It is **not** grounds to drop the
-per-model truncation (#1422): a genuine CONTROL token never decodes into text, so
-the only route to a match is a re-export mis-flagging the markers as
-NORMAL/USER_DEFINED — which actually happened to Gemma 3 (unslothai/unsloth#5070,
-see `.claude/rules/engine.md` § "GGUF source *and variant* matter"). That is a
-property of the **file**, not of the model, so a corpus negative taken on today's
-GGUF cannot generalize to tomorrow's.
+per-model truncation (#1422). A genuine CONTROL token never decodes into text, so
+a match needs the model to write the marker's *characters* — either as the
+per-response hallucination this table measures as unobserved, or systematically,
+via a re-export mis-flagging the markers as NORMAL/USER_DEFINED. The second
+actually happened to Gemma 3 (unslothai/unsloth#5070, see
+`.claude/rules/engine.md` § "GGUF source *and variant* matter"), and it is a
+property of the **file**, not of the model — so a corpus negative taken on
+today's GGUF cannot generalize to tomorrow's. This table bounds only the first
+route, and only for the files measured.
 
 Re-run this at each onboarding rather than copying the numbers forward — the step
 lives in [`onboarding.md`](onboarding.md) § "Stage 0".

--- a/docs/models/eval-log.md
+++ b/docs/models/eval-log.md
@@ -4,10 +4,8 @@ Durable, committed ledger of model-candidate **evaluation verdicts** — the
 judgment that a `/model-eval` (Gate 1) or real-device (Gate 2) pass produced,
 so a verdict survives after the intake issue's comment is buried.
 
-It carries one other record class: **corpus observations** — cross-candidate
-measurements over the accumulated harness transcripts, which are gitignored and
-per-machine and so have nowhere else durable to live. They are not verdicts and
-gate nothing; see § "Corpus observations (not candidate verdicts)".
+It also carries **corpus observations** (non-gate; § "Corpus observations
+(not candidate verdicts)").
 
 ## What lives where (three record surfaces)
 
@@ -101,16 +99,15 @@ single occurrence. Sarashina's 99 are all trailing `<|im_end|>` after a complete
 payload (2026-07-08 and 2026-07-23 runs).
 
 **What it does and does not license.** It says *Gemma spelling its own markers is
-unobserved as of this date* — nothing stronger. It is **not** grounds to drop the
-per-model truncation (#1422). A genuine CONTROL token never decodes into text, so
-a match needs the model to write the marker's *characters* — either as the
-per-response hallucination this table measures as unobserved, or systematically,
-via a re-export mis-flagging the markers as NORMAL/USER_DEFINED. The second
-actually happened to Gemma 3 (unslothai/unsloth#5070, see
-`.claude/rules/engine.md` § "GGUF source *and variant* matter"), and it is a
-property of the **file**, not of the model — so a corpus negative taken on
-today's GGUF cannot generalize to tomorrow's. This table bounds only the first
-route, and only for the files measured.
+unobserved as of this date* — nothing stronger, and **not** grounds to drop the
+per-model truncation (#1422). A genuine CONTROL token never decodes into text, so a
+match needs the marker's *characters* written out: either as a per-response
+hallucination (what this table measures) or systematically, via a re-export
+mis-flagging the markers as NORMAL/USER_DEFINED — which actually happened
+to Gemma 3 (unslothai/unsloth#5070, see `.claude/rules/engine.md` § "GGUF source
+*and variant* matter"). That second route is a property of the **file**, not the
+model, so this table bounds only the first route, for the files measured — a
+negative today does not generalize to tomorrow's GGUF.
 
 Re-run this at each onboarding rather than copying the numbers forward — the step
 lives in [`onboarding.md`](onboarding.md) § "Stage 0".

--- a/docs/models/eval-log.md
+++ b/docs/models/eval-log.md
@@ -69,6 +69,45 @@ everything else here.
 
 ---
 
+## Corpus observations (not candidate verdicts)
+
+Cross-candidate measurements over the accumulated harness transcripts. Kept here
+because the transcripts themselves are gitignored and per-machine, so a
+measurement over them is otherwise unrecoverable — but they are **not** verdicts,
+so they carry no gate and use this section rather than a `##` entry heading.
+
+### Spelled-out chat-template markers — 2026-08-13
+
+**Scope**: every `data/models/eval-runs/**/*.jsonl` harness transcript on the
+maintainer's machine as of this date. Fixed-string (`grep -F`) counts, transcripts
+only — `.stderr.log` mirrors and our own analyst prose in `eval-digest.md` are
+excluded, and the latter is the sole reason `<|turn>` appears in `data/` at all.
+
+| Marker | Sarashina 2.2 3B | Gemma 4 E2B (all variants) | Qwen 3 4B |
+|---|---|---|---|
+| `<\|im_end\|>` | 99 | 0 | 0 |
+| `<\|im_start\|>` | 0 | 0 | 0 |
+| `<\|turn>` / `<turn\|>` | 0 | 0 | 0 |
+
+**The zeros are real negatives, not an empty set**: the 2026-08-12 runs contribute
+6 full Gemma transcripts and 6 full Qwen transcripts, and neither contributes a
+single occurrence. Sarashina's 99 are all trailing `<|im_end|>` after a completed
+payload (2026-07-08 and 2026-07-23 runs).
+
+**What it does and does not license.** It says *Gemma spelling its own markers is
+unobserved as of this date* — nothing stronger. It is **not** grounds to drop the
+per-model truncation (#1422): a genuine CONTROL token never decodes into text, so
+the only route to a match is a re-export mis-flagging the markers as
+NORMAL/USER_DEFINED — which actually happened to Gemma 3 (unslothai/unsloth#5070,
+see `.claude/rules/engine.md` § "GGUF source *and variant* matter"). That is a
+property of the **file**, not of the model, so a corpus negative taken on today's
+GGUF cannot generalize to tomorrow's.
+
+Re-run this at each onboarding rather than copying the numbers forward — the step
+lives in [`onboarding.md`](onboarding.md) § "Stage 0".
+
+---
+
 ## Gemma 4 E2B QAT `UD-Q4_K_XL` (`unsloth/gemma-4-E2B-it-qat-GGUF`) — 2026-08-13 — **PASS (Mac filter only — advances to the ADR-011 real-device PoC, never an adoption)**
 
 - **Gate**: 1 (Mac filter, `/model-eval`) — 6/6 cells `ok`, `attempts_mean` 1.00,

--- a/docs/models/onboarding.md
+++ b/docs/models/onboarding.md
@@ -63,13 +63,36 @@ The two gates enforce that asymmetrically, and the asymmetry is deliberate:
 
 A candidate from a family not already in `ModelProfile.all` (today: `gemma` /
 `qwen`) needs a prior `tools/harness` PR — landed through `/orchestrate` — adding
-a `ModelProfile` static plus its pin test. The profile mirrors **7** load-bearing
+a `ModelProfile` static plus its pin test. The profile mirrors **8** load-bearing
 registry values under its own field names (`id`, `name`, `stopSequence`,
-`systemPromptSuffix`, `assistantPrefix`, `expectedFileName`, `expectedSHA256`;
-`name` / `expectedFileName` / `expectedSHA256` map to the registry's
-`displayName` / `fileName` / `sha256`); `ModelProfileTests`
+`turnMarkers`, `systemPromptSuffix`, `assistantPrefix`, `expectedFileName`,
+`expectedSHA256`; `name` / `expectedFileName` / `expectedSHA256` map to the
+registry's `displayName` / `fileName` / `sha256`); `ModelProfileTests`
 pins them against the future/planned `ModelRegistry` values so the harness and
 app never drift.
+
+**`turnMarkers` is collected, not copied.** Read the candidate's own turn-start /
+turn-end strings out of the GGUF header (they are tokenizer-specific and share no
+convention across families — Gemma 4's `<|turn>` / `<turn|>` vs ChatML's
+`<|im_start|>` / `<|im_end|>`), and record their `token_type` alongside. Then
+**re-run the marker sweep over the accumulated transcripts** rather than carrying
+forward the last recorded numbers:
+
+```sh
+for m in '<|im_end|>' '<|im_start|>' '<|turn>' '<turn|>' '<the candidate pair>'; do
+  printf '%s\t' "$m"; grep -rhoF "$m" --include='*.jsonl' data/models/eval-runs/ | wc -l
+done
+```
+
+Append the result to [`eval-log.md`](eval-log.md) § "Spelled-out chat-template
+markers" with the date and scope. Two things make the re-run load-bearing rather
+than ceremonial: a spelled-out marker is a property of the **GGUF export** (a
+re-export can mis-flag a CONTROL marker as NORMAL, and then it decodes into
+text — unslothai/unsloth#5070), so a negative taken on one file says nothing
+about the next; and the sweep is only meaningful against transcripts that
+**exist**, so note which models the corpus actually covers before reading a zero
+as evidence. Both fields feed the same silent-failure mode: a wrong pair makes
+the truncation and leakage mechanisms inert with nothing to observe (#1422).
 
 Budget **one** investigation round per new family for prompt-template traps.
 llama.cpp's `llama_chat_apply_template` reads the GGUF-embedded chat template, so

--- a/docs/models/onboarding.md
+++ b/docs/models/onboarding.md
@@ -82,30 +82,28 @@ Run from **the primary checkout, not an `/orchestrate` worktree** —
 `data/models/eval-runs/` is gitignored, so it exists only where the harness ran,
 and the path below is relative to that checkout's root.
 
-**There are two ways to record a false zero here, and only one of them has a
-mechanical guard:**
+**A row of zeros here is only evidence if the sweep actually read transcripts.**
+Known ways to get a false zero — not a closed list, so treat the row as suspect
+until you have positively confirmed otherwise:
 
-- **A missing corpus** — *guarded.* `grep -r` over an absent directory writes to
-  stderr while the pipeline still prints `0` for every marker, indistinguishable
-  from a real negative. The `[ -d … ]` check below skips the loop instead.
+- **No transcripts to read** — *guarded.* An absent directory, or one holding no
+  `*.jsonl` (pruned to `.stderr.log`, or a differently-named export), makes
+  `grep -r` match nothing while the pipeline still prints `0` for every marker.
+  The precondition below requires at least one `*.jsonl` and skips the loop
+  otherwise, so this route emits no row at all.
 - **A placeholder left in** — *not guarded, your responsibility.* Replace the two
   `<candidate …>` operands with the candidate's actual marker strings first;
   left as-is the loop counts the literal text and reports `0`. Nothing detects
-  this, which makes it the likelier of the two.
-
-Both *would* produce the exact failure this paragraph exists to warn about;
-since the corpus check emits no row at all, only the placeholder route can still
-reach it. So treat a row of zeros as suspect until you have confirmed the
-placeholders were replaced.
+  this, which makes it the likeliest route.
 
 ```sh
-if [ -d data/models/eval-runs ]; then
+if [ -n "$(find data/models/eval-runs -name '*.jsonl' -print -quit 2>/dev/null)" ]; then
   for m in '<|im_end|>' '<|im_start|>' '<|turn>' '<turn|>' \
            '<candidate turn-start>' '<candidate turn-end>'; do
     printf '%s\t' "$m"; grep -rhoF "$m" --include='*.jsonl' data/models/eval-runs/ | wc -l
   done
 else
-  echo 'corpus absent — run from the primary checkout, not a worktree' >&2
+  echo 'no *.jsonl transcripts found — run from the primary checkout, not a worktree' >&2
 fi
 ```
 

--- a/docs/models/onboarding.md
+++ b/docs/models/onboarding.md
@@ -78,15 +78,25 @@ convention across families — Gemma 4's `<|turn>` / `<turn|>` vs ChatML's
 **re-run the marker sweep over the accumulated transcripts** rather than carrying
 forward the last recorded numbers:
 
-Run from the repository root (the corpus path below is repo-relative), and
-**replace the two placeholder operands with the candidate's actual marker
-strings before running** — left as-is the loop counts the literal text
-`<candidate turn-start>`, returns `0`, and that zero is indistinguishable from a
-real negative once it is appended to the log. That is the failure this very
-paragraph warns about, so it is worth being blunt: a placeholder left in is the
-most likely way to record a false zero.
+Run from **the primary checkout, not an `/orchestrate` worktree** —
+`data/models/eval-runs/` is gitignored, so it exists only where the harness ran,
+and the path below is relative to that checkout's root.
+
+**There are two ways to record a false zero here, and the loop guards against
+both:**
+
+- **A placeholder left in.** Replace the two `<candidate …>` operands with the
+  candidate's actual marker strings first; left as-is the loop counts the
+  literal text and reports `0`.
+- **A missing corpus.** `grep -r` over an absent directory writes to stderr and
+  the pipeline still prints `0` for every marker — indistinguishable from a real
+  negative. Hence the precondition on the first line.
+
+Both produce the exact failure this paragraph exists to warn about, so treat a
+row of zeros as suspect until the precondition has passed.
 
 ```sh
+[ -d data/models/eval-runs ] || { echo 'corpus absent — use the primary checkout' >&2; exit 1; }
 for m in '<|im_end|>' '<|im_start|>' '<|turn>' '<turn|>' \
          '<candidate turn-start>' '<candidate turn-end>'; do
   printf '%s\t' "$m"; grep -rhoF "$m" --include='*.jsonl' data/models/eval-runs/ | wc -l

--- a/docs/models/onboarding.md
+++ b/docs/models/onboarding.md
@@ -72,11 +72,11 @@ pins them against the future/planned `ModelRegistry` values so the harness and
 app never drift.
 
 **`turnMarkers` is collected, not copied.** Read the candidate's own turn-start /
-turn-end strings out of the GGUF header (they are tokenizer-specific and share no
-convention across families — Gemma 4's `<|turn>` / `<turn|>` vs ChatML's
-`<|im_start|>` / `<|im_end|>`), and record their `token_type` alongside. Then
-**re-run the marker sweep over the accumulated transcripts** rather than carrying
-forward the last recorded numbers:
+turn-end strings out of the GGUF header (tokenizer-specific, no shared convention
+across families — Gemma 4's `<|turn>` / `<turn|>` vs ChatML's `<|im_start|>` /
+`<|im_end|>`), and record their `token_type` alongside. Then **re-run the marker
+sweep over the accumulated transcripts** rather than carrying forward the last
+recorded numbers:
 
 Run from **the primary checkout, not an `/orchestrate` worktree** —
 `data/models/eval-runs/` is gitignored, so it exists only where the harness ran,
@@ -87,14 +87,13 @@ Known ways to get a false zero — not a closed list, so treat the row as suspec
 until you have positively confirmed otherwise:
 
 - **No transcripts to read** — *guarded.* An absent directory, or one holding no
-  `*.jsonl` (pruned to `.stderr.log`, or a differently-named export), makes
-  `grep -r` match nothing while the pipeline still prints `0` for every marker.
-  The precondition below requires at least one `*.jsonl` and skips the loop
-  otherwise, so this route emits no row at all.
+  `*.jsonl` (pruned to `.stderr.log`, or a differently-named export), would make
+  `grep -r` match nothing while still printing `0` for every marker — but the
+  precondition below skips the loop in that case, so this route emits no row at all.
 - **A placeholder left in** — *not guarded, your responsibility.* Replace the two
-  `<candidate …>` operands with the candidate's actual marker strings first;
-  left as-is the loop counts the literal text and reports `0`. Nothing detects
-  this, which makes it the likeliest route.
+  `<candidate …>` operands with the candidate's actual marker strings first, or
+  the loop counts the literal text and reports `0`. Nothing detects this — the
+  likeliest false-zero route.
 
 ```sh
 if [ -n "$(find data/models/eval-runs -name '*.jsonl' -print -quit 2>/dev/null)" ]; then
@@ -108,14 +107,10 @@ fi
 ```
 
 Append the result to [`eval-log.md`](eval-log.md) § "Spelled-out chat-template
-markers" with the date and scope. Two things make the re-run load-bearing rather
-than ceremonial: a spelled-out marker is a property of the **GGUF export** (a
-re-export can mis-flag a CONTROL marker as NORMAL, and then it decodes into
-text — unslothai/unsloth#5070), so a negative taken on one file says nothing
-about the next; and the sweep is only meaningful against transcripts that
-**exist**, so note which models the corpus actually covers before reading a zero
-as evidence. Both fields feed the same silent-failure mode: a wrong pair makes
-the truncation and leakage mechanisms inert with nothing to observe (#1422).
+markers" with the date and scope. Re-run rather than copy forward: a spelled-out
+marker is a property of the GGUF **export**, not the model (see that section for
+why), so a negative on one file says nothing about the next. A wrong pair fails
+silently (#1422).
 
 Budget **one** investigation round per new family for prompt-template traps.
 llama.cpp's `llama_chat_apply_template` reads the GGUF-embedded chat template, so

--- a/docs/models/onboarding.md
+++ b/docs/models/onboarding.md
@@ -78,8 +78,17 @@ convention across families — Gemma 4's `<|turn>` / `<turn|>` vs ChatML's
 **re-run the marker sweep over the accumulated transcripts** rather than carrying
 forward the last recorded numbers:
 
+Run from the repository root (the corpus path below is repo-relative), and
+**replace the two placeholder operands with the candidate's actual marker
+strings before running** — left as-is the loop counts the literal text
+`<candidate turn-start>`, returns `0`, and that zero is indistinguishable from a
+real negative once it is appended to the log. That is the failure this very
+paragraph warns about, so it is worth being blunt: a placeholder left in is the
+most likely way to record a false zero.
+
 ```sh
-for m in '<|im_end|>' '<|im_start|>' '<|turn>' '<turn|>' '<the candidate pair>'; do
+for m in '<|im_end|>' '<|im_start|>' '<|turn>' '<turn|>' \
+         '<candidate turn-start>' '<candidate turn-end>'; do
   printf '%s\t' "$m"; grep -rhoF "$m" --include='*.jsonl' data/models/eval-runs/ | wc -l
 done
 ```

--- a/docs/models/onboarding.md
+++ b/docs/models/onboarding.md
@@ -82,25 +82,30 @@ Run from **the primary checkout, not an `/orchestrate` worktree** —
 `data/models/eval-runs/` is gitignored, so it exists only where the harness ran,
 and the path below is relative to that checkout's root.
 
-**There are two ways to record a false zero here, and the loop guards against
-both:**
+**There are two ways to record a false zero here, and only one of them has a
+mechanical guard:**
 
-- **A placeholder left in.** Replace the two `<candidate …>` operands with the
-  candidate's actual marker strings first; left as-is the loop counts the
-  literal text and reports `0`.
-- **A missing corpus.** `grep -r` over an absent directory writes to stderr and
-  the pipeline still prints `0` for every marker — indistinguishable from a real
-  negative. Hence the precondition on the first line.
+- **A missing corpus** — *guarded.* `grep -r` over an absent directory writes to
+  stderr while the pipeline still prints `0` for every marker, indistinguishable
+  from a real negative. The `[ -d … ]` check below skips the loop instead.
+- **A placeholder left in** — *not guarded, your responsibility.* Replace the two
+  `<candidate …>` operands with the candidate's actual marker strings first;
+  left as-is the loop counts the literal text and reports `0`. Nothing detects
+  this, which makes it the likelier of the two.
 
 Both produce the exact failure this paragraph exists to warn about, so treat a
-row of zeros as suspect until the precondition has passed.
+row of zeros as suspect until the corpus check has passed **and** the
+placeholders are replaced.
 
 ```sh
-[ -d data/models/eval-runs ] || { echo 'corpus absent — use the primary checkout' >&2; exit 1; }
-for m in '<|im_end|>' '<|im_start|>' '<|turn>' '<turn|>' \
-         '<candidate turn-start>' '<candidate turn-end>'; do
-  printf '%s\t' "$m"; grep -rhoF "$m" --include='*.jsonl' data/models/eval-runs/ | wc -l
-done
+if [ -d data/models/eval-runs ]; then
+  for m in '<|im_end|>' '<|im_start|>' '<|turn>' '<turn|>' \
+           '<candidate turn-start>' '<candidate turn-end>'; do
+    printf '%s\t' "$m"; grep -rhoF "$m" --include='*.jsonl' data/models/eval-runs/ | wc -l
+  done
+else
+  echo 'corpus absent — run from the primary checkout, not a worktree' >&2
+fi
 ```
 
 Append the result to [`eval-log.md`](eval-log.md) § "Spelled-out chat-template

--- a/docs/models/onboarding.md
+++ b/docs/models/onboarding.md
@@ -93,9 +93,10 @@ mechanical guard:**
   left as-is the loop counts the literal text and reports `0`. Nothing detects
   this, which makes it the likelier of the two.
 
-Both produce the exact failure this paragraph exists to warn about, so treat a
-row of zeros as suspect until the corpus check has passed **and** the
-placeholders are replaced.
+Both *would* produce the exact failure this paragraph exists to warn about;
+since the corpus check emits no row at all, only the placeholder route can still
+reach it. So treat a row of zeros as suspect until you have confirmed the
+placeholders were replaced.
 
 ```sh
 if [ -d data/models/eval-runs ]; then

--- a/shared/adr-023-port-ledger.tsv
+++ b/shared/adr-023-port-ledger.tsv
@@ -82,6 +82,7 @@ Pastura/Pastura/LLM/GenerationResult.swift	REPLACED	LLMBackend.kt streaming desi
 Pastura/Pastura/LLM/GPUAcceleration.swift	STAY
 Pastura/Pastura/LLM/JSONResponseParser.swift	PORT
 Pastura/Pastura/LLM/JSONResponseParser+Normalize.swift	PORT
+Pastura/Pastura/LLM/JSONResponseParser+Truncate.swift	PORT
 Pastura/Pastura/LLM/LanguageDetector.swift	PORT
 Pastura/Pastura/LLM/LlamaCppService.swift	STAY
 Pastura/Pastura/LLM/LlamaCppService+ChatTemplate.swift	STAY

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
@@ -166,9 +166,22 @@ internal class JSONResponseParser {
      * same trap as in the Swift original, and identical in the Kotlin `Regex`
      * constructor.
      *
-     * **Known gap, matching Swift:** the end arm is string-blind, so a marker
-     * spelled inside a JSON string value cuts mid-string. Closing it would move
-     * ChatML behaviour, which #1422 holds fixed.
+     * **Known gaps, matching Swift** — the enumeration is maintained on the
+     * Swift original's end arm (`JSONResponseParser+Truncate.swift`); keep the
+     * two in step, since no gate compares them:
+     *
+     * 1. The end arm is string-blind, so a marker spelled inside a JSON string
+     *    value cuts mid-string — and Swift's repair pipeline then closes the
+     *    quote and brace, persisting a silently-truncated value. (This port has
+     *    no repair pipeline yet — Stage-3 freight per the class doc — so here
+     *    the same cut merely fails the parse. The **gap** is shared; its
+     *    consequence is not, until that port lands.)
+     * 2. A *leading* end marker cuts at index 0 and destroys the whole payload
+     *    (#1452). Deliberately unchanged on both engines; the obvious
+     *    `> firstBrace` gate is not strictly safer — read #1452 before adding
+     *    one here.
+     *
+     * Closing either would move ChatML behaviour, which #1422 holds fixed.
      */
     private fun truncateAtTurnMarkers(text: String, markers: List<ChatTurnMarkers>): String {
         if (markers.isEmpty() || text.isEmpty()) return text
@@ -177,11 +190,15 @@ internal class JSONResponseParser {
         for (marker in markers) {
             // These `isEmpty()` guards carry more weight here than their Swift
             // counterparts: `String.indexOf("")` returns `startIndex`, so an
-            // empty marker would cut at index 0 and destroy every response.
-            // Swift's helper has a third backstop (`firstIndex` returns `nil`
-            // on an empty pattern); Kotlin's `indexOf` has none, so this
-            // `continue` and its sibling in the start arm are the whole
-            // defence, and the two engines agree only because they are here.
+            // empty marker string would cut at index 0 and destroy every
+            // response. Swift has a third backstop (`firstIndex` returns `nil`
+            // on an empty pattern); Kotlin's `indexOf` has none, so against an
+            // empty *marker string* this `continue` and its sibling in the
+            // start arm are the only **per-marker** defence — the function's
+            // opening `markers.isEmpty()` guard covers an empty *set*, and the
+            // start arm's outer `any { it.start.isNotEmpty() … }` only skips
+            // the arm when *every* start is empty, so neither catches one empty
+            // marker in a mixed set. The two engines agree because these are here.
             if (marker.end.isEmpty()) continue
             val index = text.indexOf(marker.end)
             if (index >= 0 && index < cut) cut = index

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
@@ -196,9 +196,9 @@ internal class JSONResponseParser {
             // empty *marker string* this `continue` and its sibling in the
             // start arm are the only **per-marker** defence — the function's
             // opening `markers.isEmpty()` guard covers an empty *set*, and the
-            // start arm's outer `any { it.start.isNotEmpty() … }` only skips
-            // the arm when *every* start is empty, so neither catches one empty
-            // marker in a mixed set. The two engines agree because these are here.
+            // start arm's outer `any { … }` skips the arm only when no start
+            // both is non-empty and occurs in the text. Neither catches one
+            // empty marker in a mixed set. The engines agree because these are here.
             if (marker.end.isEmpty()) continue
             val index = text.indexOf(marker.end)
             if (index >= 0 && index < cut) cut = index

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
@@ -170,12 +170,13 @@ internal class JSONResponseParser {
      * Swift original's end arm (`JSONResponseParser+Truncate.swift`); keep the
      * two in step, since no gate compares them:
      *
-     * 1. The end arm is string-blind, so a marker spelled inside a JSON string
-     *    value cuts mid-string — and Swift's repair pipeline then closes the
-     *    quote and brace, persisting a silently-truncated value. (This port has
-     *    no repair pipeline yet — Stage-3 freight per the class doc — so here
-     *    the same cut merely fails the parse. The **gap** is shared; its
-     *    consequence is not, until that port lands.)
+     * 1. The end arm is string-blind **for ChatML's own end marker only**. Every
+     *    other end marker is string-aware, because a mid-value cut is the silent
+     *    kind: on Swift the repair pipeline closes the quote and brace and
+     *    persists a truncated value. (This port has no repair pipeline yet —
+     *    Stage-3 freight per the class doc — so the same cut merely fails the
+     *    parse here. The **predicate** is mirrored regardless, so the engines
+     *    stay comparable when that port lands.)
      * 2. A *leading* end marker cuts at index 0 and destroys the whole payload
      *    (#1452). Deliberately unchanged on both engines; the obvious
      *    `> firstBrace` gate is not strictly safer — read #1452 before adding
@@ -186,6 +187,19 @@ internal class JSONResponseParser {
     private fun truncateAtTurnMarkers(text: String, markers: List<ChatTurnMarkers>): String {
         if (markers.isEmpty() || text.isEmpty()) return text
         var cut = text.length
+
+        // Both arms may need string context — computed once, and only when
+        // something calls for it: any start marker present, or any *non-ChatML*
+        // end marker present (ChatML's own end stays string-blind, mirroring
+        // Swift).
+        val needsStringScan =
+            markers.any { it.start.isNotEmpty() && text.contains(it.start) } ||
+                markers.any {
+                    it.end.isNotEmpty() &&
+                        it.end != ChatTurnMarkers.chatML.end &&
+                        text.contains(it.end)
+                }
+        val insideString = if (needsStringScan) mapStringSpans(text) else null
 
         for (marker in markers) {
             // These `isEmpty()` guards carry more weight here than their Swift
@@ -200,33 +214,55 @@ internal class JSONResponseParser {
             // both non-empty and present in the text. Neither catches one empty
             // marker in a mixed set. The engines agree because these are here.
             if (marker.end.isEmpty()) continue
-            val index = text.indexOf(marker.end)
+            // String-aware for every end marker except ChatML's own, which stays
+            // blind so ChatML backends are byte-identical to pre-#1422. See the
+            // Swift original's end arm for why the exception is keyed on the
+            // literal value.
+            val index =
+                if (marker.end == ChatTurnMarkers.chatML.end || insideString == null) {
+                    text.indexOf(marker.end)
+                } else {
+                    indexOfOutsideStrings(text, marker.end, 0, insideString)
+                }
             if (index >= 0 && index < cut) cut = index
         }
 
-        if (markers.any { it.start.isNotEmpty() && text.contains(it.start) }) {
-            val insideString = mapStringSpans(text)
+        if (insideString != null && markers.any { it.start.isNotEmpty() && text.contains(it.start) }) {
             val firstBrace = text.indices.firstOrNull { text[it] == '{' && !insideString[it] }
             if (firstBrace != null) {
                 for (marker in markers) {
                     if (marker.start.isEmpty()) continue
-                    var searchFrom = firstBrace + 1
-                    while (true) {
-                        val index = text.indexOf(marker.start, startIndex = searchFrom)
-                        if (index < 0) break
-                        // A marker inside a string literal is payload content,
-                        // not a turn boundary — skip past it and keep looking.
-                        if (!insideString[index]) {
-                            if (index < cut) cut = index
-                            break
-                        }
-                        searchFrom = index + 1
-                    }
+                    val index =
+                        indexOfOutsideStrings(text, marker.start, firstBrace + 1, insideString)
+                    if (index >= 0 && index < cut) cut = index
                 }
             }
         }
 
         return if (cut == text.length) text else text.substring(0, cut)
+    }
+
+    /**
+     * First index at or after [from] where [needle] occurs **outside** a JSON
+     * string literal, or `-1`. An occurrence inside one is payload content, not
+     * a turn boundary, so it is skipped and the scan continues past it.
+     *
+     * Returns `-1` rather than `null` to match `String.indexOf`, which both call
+     * sites compare against with `>= 0`.
+     */
+    private fun indexOfOutsideStrings(
+        text: String,
+        needle: String,
+        from: Int,
+        insideString: BooleanArray,
+    ): Int {
+        var searchFrom = from
+        while (true) {
+            val index = text.indexOf(needle, startIndex = searchFrom)
+            if (index < 0) return -1
+            if (!insideString[index]) return index
+            searchFrom = index + 1
+        }
     }
 
     private fun extractFromCodeBlock(text: String): String {

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
@@ -136,53 +136,26 @@ internal class JSONResponseParser {
      * Truncate at the first hallucinated turn boundary, keying on the loaded
      * model's own markers rather than a hardcoded ChatML literal (#1422).
      *
-     * Port of `JSONResponseParser+Truncate.swift`; the two must agree on the
-     * same inputs, and **no gate enforces that** — `check-prompt-literal-parity.py`
-     * covers `pickLanguage` literals only. The crafted-string fixtures in
-     * `JSONResponseParserTurnMarkerTests` are deliberately the same on both
-     * sides so a divergence shows up as a failing test rather than a drift.
+     * Port of `JSONResponseParser+Truncate.swift`; the two must agree on the same inputs, and
+     * **no gate enforces that** — `check-prompt-literal-parity.py` covers `pickLanguage` only —
+     * so the crafted-string fixtures in `JSONResponseParserTurnMarkerTests` are the guard.
      *
-     * ### The two arms are deliberately asymmetric
+     * - **End marker**: cut unguarded from the first occurrence anywhere. Pre-#1422 behaviour
+     *   generalized from one literal to a set. See the Swift original for why.
+     * - **Start marker**: cut only after the first structural `{`, outside a string literal —
+     *   a leading one is a template-header echo, not a boundary. See the Swift original.
      *
-     * - **End marker** — a turn boundary wherever it occurs. Cut unguarded from
-     *   the first occurrence. This is the pre-#1422 behaviour generalized from
-     *   one hardcoded string to a set, so a ChatML backend is unchanged.
-     * - **Start marker** — cut **only** at an occurrence after the first
-     *   structural `{`, and only outside a string literal. A *leading* start
-     *   marker is the model echoing its own template header with the payload
-     *   still behind it; cutting there deletes the payload, deterministically,
-     *   so the run walks parse-failure → `RetriesExhausted` → an ADR-021 turn
-     *   skip rather than recovering. One *after* the first `{` is a fabricated
-     *   next turn, and [extractFromCodeBlock] runs **before** the balanced scan
-     *   and takes the first match unconditionally — so a fenced fabricated
-     *   continuation would otherwise be extracted and accepted silently.
+     * **`indexOf`, not `Regex`**: Gemma's `<|turn>` contains a bare `|`, which as a `Regex`
+     * compiles to the alternation `<` **or** `turn>` and cuts at the first `<` anywhere in the
+     * output. Same trap as the Swift original, identical in Kotlin's `Regex` constructor.
      *
-     * ### `indexOf`, not `Regex`
-     *
-     * Interpolating a marker into a `Regex` is a live trap, not a style
-     * preference: Gemma's `<|turn>` contains a bare `|`, which compiles as the
-     * alternation `<` **or** `turn>` and would cut at the first `<` anywhere in
-     * the output — mass payload destruction for the default shipped model. The
-     * same trap as in the Swift original, and identical in the Kotlin `Regex`
-     * constructor.
-     *
-     * **Known gaps, matching Swift** — the enumeration is maintained on the
-     * Swift original's end arm (`JSONResponseParser+Truncate.swift`); keep the
-     * two in step, since no gate compares them:
-     *
-     * 1. The end arm is string-blind **for ChatML's own end marker only**. Every
-     *    other end marker is string-aware, because a mid-value cut is the silent
-     *    kind: on Swift the repair pipeline closes the quote and brace and
-     *    persists a truncated value. (This port has no repair pipeline yet —
-     *    Stage-3 freight per the class doc — so the same cut merely fails the
-     *    parse here. The **predicate** is mirrored regardless, so the engines
-     *    stay comparable when that port lands.)
-     * 2. A *leading* end marker cuts at index 0 and destroys the whole payload
-     *    (#1452). Deliberately unchanged on both engines; the obvious
-     *    `> firstBrace` gate is not strictly safer — read #1452 before adding
-     *    one here.
-     *
-     * Closing either would move ChatML behaviour, which #1422 holds fixed.
+     * **Known gaps, matching Swift** (enumerated on `JSONResponseParser+Truncate.swift`'s end
+     * arm — keep in step, no gate compares them): (1) the end arm is string-blind for ChatML's
+     * own end marker only, because a mid-value cut is the *silent* kind — on Swift the repair
+     * pipeline closes the quote and brace and persists a truncated value. This port has no
+     * repair pipeline yet (Stage-3 freight), so the same cut merely fails the parse here; the
+     * predicate stays mirrored for when that port lands. (2) a leading end marker cuts at
+     * index 0 and destroys the payload (#1452), deliberately unchanged on both engines.
      */
     private fun truncateAtTurnMarkers(text: String, markers: List<ChatTurnMarkers>): String {
         if (markers.isEmpty() || text.isEmpty()) return text
@@ -202,22 +175,13 @@ internal class JSONResponseParser {
         val insideString = if (needsStringScan) mapStringSpans(text) else null
 
         for (marker in markers) {
-            // These `isEmpty()` guards carry more weight here than their Swift
-            // counterparts: `String.indexOf("")` returns `startIndex`, so an
-            // empty marker string would cut at index 0 and destroy every
-            // response. Swift has a third backstop (`firstIndex` returns `nil`
-            // on an empty pattern); Kotlin's `indexOf` has none, so against an
-            // empty *marker string* this `continue` and its sibling in the
-            // start arm are the only **per-marker** defence — the function's
-            // opening `markers.isEmpty()` guard covers an empty *set*, and the
-            // start arm's outer `any { … }` skips the arm only when no start is
-            // both non-empty and present in the text. Neither catches one empty
-            // marker in a mixed set. The engines agree because these are here.
+            // `String.indexOf("")` returns 0, so an empty marker string would cut at index 0 and
+            // destroy every response. Swift has a third backstop (`firstIndex` on an empty
+            // pattern); Kotlin's `indexOf` has none, so this `continue` (and its start-arm
+            // sibling) is the only per-marker defence against one empty marker in a mixed set.
             if (marker.end.isEmpty()) continue
-            // String-aware for every end marker except ChatML's own, which stays
-            // blind so ChatML backends are byte-identical to pre-#1422. See the
-            // Swift original's end arm for why the exception is keyed on the
-            // literal value.
+            // String-aware for every end marker except ChatML's own — kept blind for byte parity
+            // with pre-#1422. See the Swift original's end arm for why.
             val index =
                 if (marker.end == ChatTurnMarkers.chatML.end || insideString == null) {
                     text.indexOf(marker.end)
@@ -243,11 +207,9 @@ internal class JSONResponseParser {
     }
 
     /**
-     * First index at or after [from] where [needle] occurs **outside** a JSON
-     * string literal, or `-1`. An occurrence inside one is payload content, not
-     * a turn boundary, so it is skipped and the scan continues past it.
-     *
-     * Returns `-1` rather than `null` to match `String.indexOf`, which both call
+     * First index at or after [from] where [needle] occurs **outside** a JSON string literal,
+     * or `-1` — an inside-string occurrence is payload content, not a turn boundary, so the scan
+     * skips past it. Returns `-1` rather than `null` to match `String.indexOf`, which both call
      * sites compare against with `>= 0`.
      */
     private fun indexOfOutsideStrings(

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
@@ -175,6 +175,13 @@ internal class JSONResponseParser {
         var cut = text.length
 
         for (marker in markers) {
+            // These `isEmpty()` guards carry more weight here than their Swift
+            // counterparts: `String.indexOf("")` returns `startIndex`, so an
+            // empty marker would cut at index 0 and destroy every response.
+            // Swift's helper has a third backstop (`firstIndex` returns `nil`
+            // on an empty pattern); Kotlin's `indexOf` has none, so this
+            // `continue` and its sibling in the start arm are the whole
+            // defence, and the two engines agree only because they are here.
             if (marker.end.isEmpty()) continue
             val index = text.indexOf(marker.end)
             if (index >= 0 && index < cut) cut = index

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
@@ -1,5 +1,6 @@
 package com.pastura.engine
 
+import com.pastura.models.ChatTurnMarkers
 import com.pastura.models.SimulationError
 import com.pastura.models.TurnOutput
 import kotlinx.serialization.ExperimentalSerializationApi
@@ -58,18 +59,6 @@ internal class JSONResponseParser {
         /** Common thinking-model format: `<think>...</think>` (DeepSeek, Qwen). */
         val THINK_TAG = Regex("""<think>[\s\S]*?</think>""")
 
-        /**
-         * Chat-template token — truncate everything from the first occurrence.
-         *
-         * ChatML-only, mirroring the Swift original: for a non-ChatML model this
-         * fires only on a spelled-out `<|im_end|>` — not the form a Gemma
-         * hallucination would take (Gemma 4's markers are `<|turn>` / `<turn|>`).
-         * The type is also backend-agnostic, so do not import the llama.cpp
-         * control-token guarantee here: a server-decoding backend offers none.
-         * Per-model sourcing is #1422.
-         */
-        val CHAT_TEMPLATE_TOKEN = Regex("""<\|im_end\|>[\s\S]*""")
-
         val CODE_BLOCK = Regex("""```(?:json)?\s*\n?([\s\S]*?)\n?```""")
 
         /**
@@ -95,7 +84,10 @@ internal class JSONResponseParser {
      * @throws SimulationException wrapping [SimulationError.JsonParseFailed] when
      *   no valid JSON can be extracted.
      */
-    fun parse(text: String): TurnOutput = parse(text, expectedKeys = emptySet()).first
+    fun parse(
+        text: String,
+        turnMarkers: List<ChatTurnMarkers> = listOf(ChatTurnMarkers.chatML),
+    ): TurnOutput = parse(text, expectedKeys = emptySet(), turnMarkers = turnMarkers).first
 
     /**
      * Parse the happy path. No schema guard runs here — see [expectedKeys].
@@ -118,22 +110,99 @@ internal class JSONResponseParser {
      * @throws SimulationException wrapping [SimulationError.JsonParseFailed].
      */
     @Suppress("UNUSED_PARAMETER")
-    fun parse(text: String, expectedKeys: Set<String>): Pair<TurnOutput, String?> {
-        val cleaned = applyCleanupPipeline(text)
+    fun parse(
+        text: String,
+        expectedKeys: Set<String>,
+        turnMarkers: List<ChatTurnMarkers> = listOf(ChatTurnMarkers.chatML),
+    ): Pair<TurnOutput, String?> {
+        val cleaned = applyCleanupPipeline(text, turnMarkers)
         val output = tryParse(cleaned) ?: throw SimulationException(SimulationError.JsonParseFailed(raw = text))
         return output to null
     }
 
     // MARK: - Pipeline
 
-    private fun applyCleanupPipeline(text: String): String {
+    private fun applyCleanupPipeline(text: String, turnMarkers: List<ChatTurnMarkers>): String {
         var cleaned = text.trim()
         cleaned = CHANNEL_THINKING.replace(cleaned, "")
         cleaned = THINK_TAG.replace(cleaned, "")
-        cleaned = CHAT_TEMPLATE_TOKEN.replace(cleaned, "")
+        cleaned = truncateAtTurnMarkers(cleaned, turnMarkers)
         cleaned = extractFromCodeBlock(cleaned)
         cleaned = cleaned.trim()
         return extractFirstJsonObject(cleaned)
+    }
+
+    /**
+     * Truncate at the first hallucinated turn boundary, keying on the loaded
+     * model's own markers rather than a hardcoded ChatML literal (#1422).
+     *
+     * Port of `JSONResponseParser+Truncate.swift`; the two must agree on the
+     * same inputs, and **no gate enforces that** — `check-prompt-literal-parity.py`
+     * covers `pickLanguage` literals only. The crafted-string fixtures in
+     * `JSONResponseParserTurnMarkerTests` are deliberately the same on both
+     * sides so a divergence shows up as a failing test rather than a drift.
+     *
+     * ### The two arms are deliberately asymmetric
+     *
+     * - **End marker** — a turn boundary wherever it occurs. Cut unguarded from
+     *   the first occurrence. This is the pre-#1422 behaviour generalized from
+     *   one hardcoded string to a set, so a ChatML backend is unchanged.
+     * - **Start marker** — cut **only** at an occurrence after the first
+     *   structural `{`, and only outside a string literal. A *leading* start
+     *   marker is the model echoing its own template header with the payload
+     *   still behind it; cutting there deletes the payload, deterministically,
+     *   so the run walks parse-failure → `RetriesExhausted` → an ADR-021 turn
+     *   skip rather than recovering. One *after* the first `{` is a fabricated
+     *   next turn, and [extractFromCodeBlock] runs **before** the balanced scan
+     *   and takes the first match unconditionally — so a fenced fabricated
+     *   continuation would otherwise be extracted and accepted silently.
+     *
+     * ### `indexOf`, not `Regex`
+     *
+     * Interpolating a marker into a `Regex` is a live trap, not a style
+     * preference: Gemma's `<|turn>` contains a bare `|`, which compiles as the
+     * alternation `<` **or** `turn>` and would cut at the first `<` anywhere in
+     * the output — mass payload destruction for the default shipped model. The
+     * same trap as in the Swift original, and identical in the Kotlin `Regex`
+     * constructor.
+     *
+     * **Known gap, matching Swift:** the end arm is string-blind, so a marker
+     * spelled inside a JSON string value cuts mid-string. Closing it would move
+     * ChatML behaviour, which #1422 holds fixed.
+     */
+    private fun truncateAtTurnMarkers(text: String, markers: List<ChatTurnMarkers>): String {
+        if (markers.isEmpty() || text.isEmpty()) return text
+        var cut = text.length
+
+        for (marker in markers) {
+            if (marker.end.isEmpty()) continue
+            val index = text.indexOf(marker.end)
+            if (index >= 0 && index < cut) cut = index
+        }
+
+        if (markers.any { it.start.isNotEmpty() && text.contains(it.start) }) {
+            val insideString = mapStringSpans(text)
+            val firstBrace = text.indices.firstOrNull { text[it] == '{' && !insideString[it] }
+            if (firstBrace != null) {
+                for (marker in markers) {
+                    if (marker.start.isEmpty()) continue
+                    var searchFrom = firstBrace + 1
+                    while (true) {
+                        val index = text.indexOf(marker.start, startIndex = searchFrom)
+                        if (index < 0) break
+                        // A marker inside a string literal is payload content,
+                        // not a turn boundary — skip past it and keep looking.
+                        if (!insideString[index]) {
+                            if (index < cut) cut = index
+                            break
+                        }
+                        searchFrom = index + 1
+                    }
+                }
+            }
+        }
+
+        return if (cut == text.length) text else text.substring(0, cut)
     }
 
     private fun extractFromCodeBlock(text: String): String {

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/JSONResponseParser.kt
@@ -196,9 +196,9 @@ internal class JSONResponseParser {
             // empty *marker string* this `continue` and its sibling in the
             // start arm are the only **per-marker** defence — the function's
             // opening `markers.isEmpty()` guard covers an empty *set*, and the
-            // start arm's outer `any { … }` skips the arm only when no start
-            // both is non-empty and occurs in the text. Neither catches one
-            // empty marker in a mixed set. The engines agree because these are here.
+            // start arm's outer `any { … }` skips the arm only when no start is
+            // both non-empty and present in the text. Neither catches one empty
+            // marker in a mixed set. The engines agree because these are here.
             if (marker.end.isEmpty()) continue
             val index = text.indexOf(marker.end)
             if (index >= 0 && index < cut) cut = index

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMBackend.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMBackend.kt
@@ -86,13 +86,18 @@ public interface LLMBackend {
      * name-for-name, including where the union is computed, so the two seams
      * stay comparable.
      *
-     * ⚠️ **This default does not cross Kotlin/Native.** A Kotlin interface's
-     * default implementation is not carried into the generated Obj-C protocol
-     * as an optional requirement, so the future Swift adapter over
-     * `LlamaCppService` must state this member explicitly — it will **not**
-     * silently inherit ChatML-only. Same asymmetry class as the default-args
-     * one in `.claude/rules/kmp-interop.md` Pattern 3. That is the safe
-     * direction (the compiler asks), but do not plan around inheritance.
+     * ⚠️ **Expected — not verified — that this default does not cross
+     * Kotlin/Native.** A Kotlin interface's default implementation is not
+     * expected to reach the generated Obj-C protocol as an optional
+     * requirement, which would oblige the Phase 3.0 Swift adapter over
+     * `LlamaCppService` to state this member explicitly rather than inherit
+     * ChatML-only. **Confirm it against the generated `PasturaShared.h` when
+     * that adapter is written** — both Pattern 1 and Pattern 2 in
+     * `.claude/rules/kmp-interop.md` are cases where reasoning from Kotlin
+     * source alone turned out wrong and only the header settled it. No
+     * analogy to Pattern 3 is intended: that asymmetry is silent, whereas an
+     * unimplemented protocol requirement is compiler-caught, so the cost of
+     * this expectation being wrong is a build error, not a wrong default.
      */
     public val knownTurnMarkers: List<ChatTurnMarkers>
         get() = listOf(ChatTurnMarkers.chatML)

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMBackend.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMBackend.kt
@@ -98,9 +98,9 @@ public interface LLMBackend {
      * warning, where the header *itself* misled ("header-only inspection
      * misleadingly suggests the `swift_name` annotation works") and only an
      * actual Swift compile settled it. So: read the header, then build the
-     * adapter. No analogy to Pattern 3 is intended — that one is about default
-     * *arguments*, a different surface from an interface's default
-     * *implementation*.
+     * adapter. No analogy to Pattern 3's *"default args don't cross"* bullet is
+     * intended — that one is about default **arguments**, a different surface
+     * from an interface's default **implementation**.
      */
     public val knownTurnMarkers: List<ChatTurnMarkers>
         get() = listOf(ChatTurnMarkers.chatML)

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMBackend.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMBackend.kt
@@ -74,33 +74,22 @@ public interface LLMBackend {
     public fun generateStream(request: GenerationRequest, callbacks: StreamCallbacks): StreamHandle
 
     /**
-     * Every turn-marker pair whose **plaintext** form could plausibly appear in
-     * this backend's decoded output, for consumers that must recognize a
-     * hallucinated turn boundary — [JSONResponseParser] truncation and the
-     * [LLMCaller] chat-template leakage diagnostic (#1422).
+     * Every turn-marker pair whose **plaintext** form could plausibly appear in this backend's
+     * decoded output, for consumers that must recognize a hallucinated turn boundary —
+     * [JSONResponseParser] truncation and the [LLMCaller] chat-template leakage diagnostic
+     * (#1422).
      *
-     * The set is the loaded model's own pair **unioned with**
-     * [ChatTurnMarkers.chatML], so a backend that cannot name its model keeps
-     * the pre-#1422 ChatML-only behaviour, and a ChatML model does not grow a
-     * second, redundant entry. Mirrors Swift's `LLMService.knownTurnMarkers`
-     * name-for-name, including where the union is computed, so the two seams
-     * stay comparable.
+     * The set is the loaded model's own pair **unioned with** [ChatTurnMarkers.chatML], so a
+     * backend that cannot name its model keeps the pre-#1422 ChatML-only behaviour. Mirrors
+     * Swift's `LLMService.knownTurnMarkers` name-for-name.
      *
-     * ⚠️ **Expected — not verified — that this default does not cross
-     * Kotlin/Native.** A Kotlin interface's default implementation is not
-     * expected to reach the generated Obj-C protocol as an optional
-     * requirement, which would oblige the Phase 3.0 Swift adapter over
-     * `LlamaCppService` to state this member explicitly rather than inherit
-     * ChatML-only. **Confirm it when that adapter is written, and confirm it by
-     * compiling — not by reading alone.** `.claude/rules/kmp-interop.md`
-     * Pattern 1 is a case where reasoning from Kotlin source was wrong and only
-     * the generated `PasturaShared.h` settled it; Pattern 2 is the sharper
-     * warning, where the header *itself* misled ("header-only inspection
-     * misleadingly suggests the `swift_name` annotation works") and only an
-     * actual Swift compile settled it. So: read the header, then build the
-     * adapter. No analogy to Pattern 3's *"default args don't cross"* bullet is
-     * intended — that one is about default **arguments**, a different surface
-     * from an interface's default **implementation**.
+     * ⚠️ **Expected — not verified — that this default does not cross Kotlin/Native.** A Kotlin
+     * interface default implementation may not reach the generated Obj-C protocol as an optional
+     * requirement, which would oblige the Phase 3.0 Swift adapter over `LlamaCppService` to state
+     * this member explicitly rather than inherit ChatML-only. **Confirm by compiling that
+     * adapter, not by reading the generated `PasturaShared.h` alone** —
+     * `.claude/rules/kmp-interop.md` Pattern 2 is the precedent where the header itself misled.
+     * Distinct from Pattern 3's default-**argument** bullet, which settles nothing here.
      */
     public val knownTurnMarkers: List<ChatTurnMarkers>
         get() = listOf(ChatTurnMarkers.chatML)

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMBackend.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMBackend.kt
@@ -91,13 +91,16 @@ public interface LLMBackend {
      * expected to reach the generated Obj-C protocol as an optional
      * requirement, which would oblige the Phase 3.0 Swift adapter over
      * `LlamaCppService` to state this member explicitly rather than inherit
-     * ChatML-only. **Confirm it against the generated `PasturaShared.h` when
-     * that adapter is written** — both Pattern 1 and Pattern 2 in
-     * `.claude/rules/kmp-interop.md` are cases where reasoning from Kotlin
-     * source alone turned out wrong and only the header settled it. No
-     * analogy to Pattern 3 is intended: that asymmetry is silent, whereas an
-     * unimplemented protocol requirement is compiler-caught, so the cost of
-     * this expectation being wrong is a build error, not a wrong default.
+     * ChatML-only. **Confirm it when that adapter is written, and confirm it by
+     * compiling — not by reading alone.** `.claude/rules/kmp-interop.md`
+     * Pattern 1 is a case where reasoning from Kotlin source was wrong and only
+     * the generated `PasturaShared.h` settled it; Pattern 2 is the sharper
+     * warning, where the header *itself* misled ("header-only inspection
+     * misleadingly suggests the `swift_name` annotation works") and only an
+     * actual Swift compile settled it. So: read the header, then build the
+     * adapter. No analogy to Pattern 3 is intended — that one is about default
+     * *arguments*, a different surface from an interface's default
+     * *implementation*.
      */
     public val knownTurnMarkers: List<ChatTurnMarkers>
         get() = listOf(ChatTurnMarkers.chatML)

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMBackend.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMBackend.kt
@@ -1,5 +1,6 @@
 package com.pastura.engine
 
+import com.pastura.models.ChatTurnMarkers
 import com.pastura.models.OutputSchema
 
 /**
@@ -71,6 +72,30 @@ public interface LLMBackend {
      * @return A handle for cancelling this call.
      */
     public fun generateStream(request: GenerationRequest, callbacks: StreamCallbacks): StreamHandle
+
+    /**
+     * Every turn-marker pair whose **plaintext** form could plausibly appear in
+     * this backend's decoded output, for consumers that must recognize a
+     * hallucinated turn boundary — [JSONResponseParser] truncation and the
+     * [LLMCaller] chat-template leakage diagnostic (#1422).
+     *
+     * The set is the loaded model's own pair **unioned with**
+     * [ChatTurnMarkers.chatML], so a backend that cannot name its model keeps
+     * the pre-#1422 ChatML-only behaviour, and a ChatML model does not grow a
+     * second, redundant entry. Mirrors Swift's `LLMService.knownTurnMarkers`
+     * name-for-name, including where the union is computed, so the two seams
+     * stay comparable.
+     *
+     * ⚠️ **This default does not cross Kotlin/Native.** A Kotlin interface's
+     * default implementation is not carried into the generated Obj-C protocol
+     * as an optional requirement, so the future Swift adapter over
+     * `LlamaCppService` must state this member explicitly — it will **not**
+     * silently inherit ChatML-only. Same asymmetry class as the default-args
+     * one in `.claude/rules/kmp-interop.md` Pattern 3. That is the safe
+     * direction (the compiler asks), but do not plan around inheritance.
+     */
+    public val knownTurnMarkers: List<ChatTurnMarkers>
+        get() = listOf(ChatTurnMarkers.chatML)
 }
 
 /**

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMCaller.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMCaller.kt
@@ -161,10 +161,17 @@ internal class LLMCaller(
                 // Named, not positional: the two `parse` overloads differ in
                 // what their second positional argument means (2-arg:
                 // `turnMarkers`; 3-arg: `expectedKeys`), and Kotlin has no
-                // argument labels to catch a mix-up. `expectedKeys` is
-                // Stage-3-reserved and currently unused, so its eventual
-                // removal would silently rebind this call to the 2-arg
-                // overload with `turnMarkers` in the wrong slot.
+                // argument labels to distinguish them at a glance.
+                //
+                // This documents intent; it is not guarding a silent failure.
+                // Every way of getting it wrong is compile-caught: the two types
+                // don't convert (`List<ChatTurnMarkers>` is not a `Set<String>`),
+                // the 2-arg overload returns a bare `TurnOutput` with no `.first`
+                // for the destructuring below, and dropping `expectedKeys` from
+                // the 3-arg signature would collide with the 2-arg one. What the
+                // named form buys is that a future signature change fails *here*,
+                // at the call that meant something specific, rather than at
+                // whichever call site the compiler happens to reach first.
                 parser.parse(result.rawText, expectedKeys = expectedKeys, turnMarkers = turnMarkers)
             } catch (_: SimulationException) {
                 logParseFailure(agentName, result.rawText, attempt)

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMCaller.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMCaller.kt
@@ -167,7 +167,7 @@ internal class LLMCaller(
                 // Every way of getting it wrong is compile-caught: the two types
                 // don't convert (`List<ChatTurnMarkers>` is not a `Set<String>`),
                 // the 2-arg overload returns a bare `TurnOutput` with no `.first`
-                // for the destructuring below, and dropping `expectedKeys` from
+                // for the property reads below, and dropping `expectedKeys` from
                 // the 3-arg signature would collide with the 2-arg one. What the
                 // named form buys is that a future signature change fails *here*,
                 // at the call that meant something specific, rather than at

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMCaller.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMCaller.kt
@@ -158,7 +158,14 @@ internal class LLMCaller(
             // consumers below, so they cannot drift onto different sets.
             val turnMarkers = backend.knownTurnMarkers
             val parseResult = try {
-                parser.parse(result.rawText, expectedKeys, turnMarkers)
+                // Named, not positional: the two `parse` overloads differ in
+                // what their second positional argument means (2-arg:
+                // `turnMarkers`; 3-arg: `expectedKeys`), and Kotlin has no
+                // argument labels to catch a mix-up. `expectedKeys` is
+                // Stage-3-reserved and currently unused, so its eventual
+                // removal would silently rebind this call to the 2-arg
+                // overload with `turnMarkers` in the wrong slot.
+                parser.parse(result.rawText, expectedKeys = expectedKeys, turnMarkers = turnMarkers)
             } catch (_: SimulationException) {
                 logParseFailure(agentName, result.rawText, attempt)
                 if (attempt < MAX_RETRIES) {
@@ -578,20 +585,28 @@ internal class LLMCaller(
      * spelled-out **start** marker stays reachable even under llama.cpp, whose
      * streaming path strips `stopSequence` alone.
      *
-     * Severity split preserved from the pre-#1422 shape: a start marker is a
-     * fabricated next turn (WARNING), a lone end marker is the ordinary
-     * trailing-sentinel case (DEBUG).
+     * Severity split preserved from the pre-#1422 shape: a start marker is the
+     * more suspicious of the two (WARNING), a lone end marker is the ordinary
+     * trailing-sentinel case (DEBUG). Suspicion, not a verdict — this predicate
+     * is a bare substring test and cannot tell a fabricated next turn from a
+     * header echo or from marker text inside a string value.
      */
     private fun logChatTemplateLeakage(raw: String, markers: List<ChatTurnMarkers>) {
+        // `firstOrNull` picks the first marker in **list order**, not the one
+        // occurring earliest in `raw`, and only one line is emitted either way.
         val startMarker = markers.firstOrNull { it.start.isNotEmpty() && raw.contains(it.start) }
         if (startMarker != null) {
-            // Deliberately does NOT claim the continuation was truncated: the
-            // parser's start arm cuts only after the first structural `{`, so a
-            // leading template-header echo is detected here and left in place.
+            // The message states presence only, with no claim about what the
+            // model did or what the parser then did. `raw.contains` also fires
+            // on a leading template-header echo (which the parser's start arm
+            // deliberately leaves in place) and on a marker spelled inside a
+            // JSON string value. Neither is the model writing past its turn.
+            // Kept byte-identical to the Swift `logChatTemplateLeakage`; no
+            // gate compares log messages across the two engines.
             logger.log(
                 EngineLogLevel.WARNING,
                 LOG_CATEGORY,
-                "Turn-start marker ${startMarker.start} leaked into output — model wrote past its turn",
+                "Turn-start marker ${startMarker.start} present in raw output",
                 EngineLogPrivacy.PUBLIC,
             )
             return

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMCaller.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMCaller.kt
@@ -153,25 +153,14 @@ internal class LLMCaller(
             }
             emitInferenceCompleted(agentName, startMark, result.completionTokens, emitter)
 
-            // Read from the live backend so truncation keys on the loaded
-            // model's own sentinels (#1422). Read once and used by both
-            // consumers below, so they cannot drift onto different sets.
+            // Read once from the live backend so truncation keys on the loaded model's own
+            // sentinels (#1422), and both consumers below share the same set.
             val turnMarkers = backend.knownTurnMarkers
             val parseResult = try {
-                // Named, not positional: the two `parse` overloads differ in
-                // what their second positional argument means (2-arg:
-                // `turnMarkers`; 3-arg: `expectedKeys`), and Kotlin has no
-                // argument labels to distinguish them at a glance.
-                //
-                // This documents intent; it is not guarding a silent failure.
-                // Every way of getting it wrong is compile-caught: the two types
-                // don't convert (`List<ChatTurnMarkers>` is not a `Set<String>`),
-                // the 2-arg overload returns a bare `TurnOutput` with no `.first`
-                // for the property reads below, and dropping `expectedKeys` from
-                // the 3-arg signature would collide with the 2-arg one. What the
-                // named form buys is that a future signature change fails *here*,
-                // at the call that meant something specific, rather than at
-                // whichever call site the compiler happens to reach first.
+                // Named, not positional: the two `parse` overloads differ in what their second
+                // positional argument means, and Kotlin has no argument labels to disambiguate at
+                // a glance. Every way of getting it wrong is compile-caught, so this documents
+                // intent rather than guarding a silent failure.
                 parser.parse(result.rawText, expectedKeys = expectedKeys, turnMarkers = turnMarkers)
             } catch (_: SimulationException) {
                 logParseFailure(agentName, result.rawText, attempt)
@@ -582,34 +571,25 @@ internal class LLMCaller(
     }
 
     /**
-     * Detect chat-template token leakage, against the loaded model's own
-     * markers rather than a ChatML literal (#1422 — before that, this was
-     * silently blind for Gemma 4, the default shipped model).
+     * Detect chat-template token leakage against the loaded model's own markers, rather than a
+     * ChatML literal (#1422 — before that, this was silently blind for Gemma 4, the default
+     * shipped model).
      *
-     * The Swift `LlamaCppService` streaming path strips a spelled-out
-     * `stopSequence` before emission, so this primarily catches non-streaming
-     * backends where the raw string may still contain template tokens. A
-     * spelled-out **start** marker stays reachable even under llama.cpp, whose
-     * streaming path strips `stopSequence` alone.
+     * The Swift `LlamaCppService` streaming path strips a spelled-out `stopSequence` before
+     * emission, so this primarily catches non-streaming backends; a spelled-out **start** marker
+     * stays reachable even under llama.cpp.
      *
-     * Severity split preserved from the pre-#1422 shape: a start marker is the
-     * more suspicious of the two (WARNING), a lone end marker is the ordinary
-     * trailing-sentinel case (DEBUG). Suspicion, not a verdict — this predicate
-     * is a bare substring test and cannot tell a fabricated next turn from a
-     * header echo or from marker text inside a string value.
+     * Severity split preserved from the pre-#1422 shape: a start marker is WARNING, a lone end
+     * marker is DEBUG. See the Swift original's `logChatTemplateLeakage` for why this is
+     * suspicion, not a verdict.
      */
     private fun logChatTemplateLeakage(raw: String, markers: List<ChatTurnMarkers>) {
         // `firstOrNull` picks the first marker in **list order**, not the one
         // occurring earliest in `raw`, and only one line is emitted either way.
         val startMarker = markers.firstOrNull { it.start.isNotEmpty() && raw.contains(it.start) }
         if (startMarker != null) {
-            // The message states presence only, with no claim about what the
-            // model did or what the parser then did. `raw.contains` also fires
-            // on a leading template-header echo (which the parser's start arm
-            // deliberately leaves in place) and on a marker spelled inside a
-            // JSON string value. Neither is the model writing past its turn.
-            // Kept byte-identical to the Swift `logChatTemplateLeakage`; no
-            // gate compares log messages across the two engines.
+            // Kept byte-identical to the Swift `logChatTemplateLeakage`; no gate compares log
+            // messages across the two engines.
             logger.log(
                 EngineLogLevel.WARNING,
                 LOG_CATEGORY,

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMCaller.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMCaller.kt
@@ -1,5 +1,6 @@
 package com.pastura.engine
 
+import com.pastura.models.ChatTurnMarkers
 import com.pastura.models.OutputSchema
 import com.pastura.models.PhaseType
 import com.pastura.models.ScenarioConventions
@@ -152,8 +153,12 @@ internal class LLMCaller(
             }
             emitInferenceCompleted(agentName, startMark, result.completionTokens, emitter)
 
+            // Read from the live backend so truncation keys on the loaded
+            // model's own sentinels (#1422). Read once and used by both
+            // consumers below, so they cannot drift onto different sets.
+            val turnMarkers = backend.knownTurnMarkers
             val parseResult = try {
-                parser.parse(result.rawText, expectedKeys)
+                parser.parse(result.rawText, expectedKeys, turnMarkers)
             } catch (_: SimulationException) {
                 logParseFailure(agentName, result.rawText, attempt)
                 if (attempt < MAX_RETRIES) {
@@ -164,7 +169,7 @@ internal class LLMCaller(
             }
             val output = parseResult.first
             logRepairIfNeeded(agentName, parseResult.second)
-            logChatTemplateLeakage(result.rawText)
+            logChatTemplateLeakage(result.rawText, turnMarkers)
 
             // Empty-field retry, and the ADR-021 § Amendment 2026-08-06 skip when
             // the declared canonical primary is what came back missing. Throws
@@ -563,28 +568,40 @@ internal class LLMCaller(
     }
 
     /**
-     * Detect chat-template token leakage. The Swift `LlamaCppService` streaming path
-     * strips a spelled-out `<|im_end|>` before emission, so this primarily catches
-     * non-streaming backends where the raw string may still contain template tokens.
+     * Detect chat-template token leakage, against the loaded model's own
+     * markers rather than a ChatML literal (#1422 — before that, this was
+     * silently blind for Gemma 4, the default shipped model).
      *
-     * ChatML-only, mirroring the Swift original: a non-ChatML model (Gemma 4) is
-     * not covered — #1422. A spelled-out `<|im_start|>` stays reachable even
-     * under llama.cpp, whose streaming path strips `stopSequence` (`<|im_end|>`)
-     * alone.
+     * The Swift `LlamaCppService` streaming path strips a spelled-out
+     * `stopSequence` before emission, so this primarily catches non-streaming
+     * backends where the raw string may still contain template tokens. A
+     * spelled-out **start** marker stays reachable even under llama.cpp, whose
+     * streaming path strips `stopSequence` alone.
+     *
+     * Severity split preserved from the pre-#1422 shape: a start marker is a
+     * fabricated next turn (WARNING), a lone end marker is the ordinary
+     * trailing-sentinel case (DEBUG).
      */
-    private fun logChatTemplateLeakage(raw: String) {
-        if (raw.contains("<|im_start|>")) {
+    private fun logChatTemplateLeakage(raw: String, markers: List<ChatTurnMarkers>) {
+        val startMarker = markers.firstOrNull { it.start.isNotEmpty() && raw.contains(it.start) }
+        if (startMarker != null) {
+            // Deliberately does NOT claim the continuation was truncated: the
+            // parser's start arm cuts only after the first structural `{`, so a
+            // leading template-header echo is detected here and left in place.
             logger.log(
                 EngineLogLevel.WARNING,
                 LOG_CATEGORY,
-                "Model hallucinated past its turn — continuation truncated at <|im_end|>",
+                "Turn-start marker ${startMarker.start} leaked into output — model wrote past its turn",
                 EngineLogPrivacy.PUBLIC,
             )
-        } else if (raw.contains("<|im_end|>")) {
+            return
+        }
+        val endMarker = markers.firstOrNull { it.end.isNotEmpty() && raw.contains(it.end) }
+        if (endMarker != null) {
             logger.log(
                 EngineLogLevel.DEBUG,
                 LOG_CATEGORY,
-                "Trailing <|im_end|> token stripped from output",
+                "Trailing ${endMarker.end} token stripped from output",
                 EngineLogPrivacy.PUBLIC,
             )
         }

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/JSONResponseParserTurnMarkerTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/JSONResponseParserTurnMarkerTests.kt
@@ -12,17 +12,16 @@ import kotlin.test.assertTrue
 /**
  * Per-model hallucinated-turn truncation (#1422) — the Kotlin half.
  *
- * **The fixtures are deliberately byte-identical to the Swift
- * `JSONResponseParserTests+TurnMarkers.swift` ones.** No gate enforces
- * Swift↔Kotlin parser parity (`check-prompt-literal-parity.py` covers
- * `pickLanguage` literals only), so a shared fixture set is what makes a
- * divergence in the truncation predicate show up as a failing test rather than
- * as silent drift.
+ * **Fixtures are deliberately byte-identical to the Swift
+ * `JSONResponseParserTests+TurnMarkers.swift` ones** — no gate enforces
+ * Swift↔Kotlin parser parity (`check-prompt-literal-parity.py` covers only
+ * `pickLanguage`), so a shared fixture set turns a predicate divergence into
+ * a failing test instead of silent drift.
  *
  * Every test that asserts the fix also runs the **same input** through the
- * pre-#1422 ChatML-only set as a negative control — without one, a test that
- * happens to pass for an unrelated reason (the balanced-brace scan already
- * discards trailing prose) would read as proof that truncation fired.
+ * pre-#1422 ChatML-only set as a negative control — otherwise a test passing
+ * for an unrelated reason (the balanced-brace scan discards trailing prose)
+ * would read as proof truncation fired.
  */
 class JSONResponseParserTurnMarkerTests {
 
@@ -32,9 +31,8 @@ class JSONResponseParserTurnMarkerTests {
     private val chatMLOnly = listOf(ChatTurnMarkers.chatML)
 
     /**
-     * A fenced fabricated continuation is the shape that actually loses the
-     * payload: `extractFromCodeBlock` runs before the balanced-brace scan and
-     * takes the first match unconditionally.
+     * A fenced fabricated continuation loses the payload: `extractFromCodeBlock`
+     * runs before the balanced-brace scan and takes the first match unconditionally.
      */
     private val fencedHallucination = """
         {"statement": "本物", "action": "cooperate"}<turn|>
@@ -58,19 +56,11 @@ class JSONResponseParserTurnMarkerTests {
     }
 
     /**
-     * **A pin on an accepted trade-off, not an assertion of desired
-     * behaviour** — the Kotlin half of Swift's
-     * `endMarker_leadingMarkerDestroysPayload_acceptedGap`. Read
-     * [#1452](https://github.com/tyabu12/pastura/issues/1452) before changing
-     * it: a failure means the end arm's unguarded cut moved, and the question
-     * is whether #1452 was decided, not whether this expectation is stale.
-     *
-     * The end arm cuts at the first occurrence with no `firstBrace` guard, so a
-     * *leading* end marker discards the whole payload the model then writes.
-     * The symmetric-looking fix — reusing the start arm's `> firstBrace` gate —
-     * is not strictly safer, which is the second assertion: today
-     * `<|im_end|>{"fake":1}` throws; under that gate the fabricated object
-     * would be accepted as the turn's answer.
+     * **A pin on an accepted trade-off, not desired behaviour** — Kotlin half of
+     * Swift's `endMarker_leadingMarkerDestroysPayload_acceptedGap`. Read
+     * [#1452](https://github.com/tyabu12/pastura/issues/1452) before changing.
+     * The symmetric-looking fix — the start arm's `> firstBrace` gate — is not
+     * strictly safer: it would accept `<|im_end|>{"fake":1}` instead of throwing.
      */
     @Test
     fun endMarkerLeadingMarkerDestroysPayloadAcceptedGap() {
@@ -78,10 +68,8 @@ class JSONResponseParserTurnMarkerTests {
             <turn|>
             {"statement": "本物", "action": "cooperate"}
         """.trimIndent()
-        // `assertIs` on the payload, per the sibling suite's idiom: a bare
-        // `assertFailsWith` would keep passing if the throw site ever moved to a
-        // different `SimulationException`, which is the drift a #1452 pin exists
-        // to detect.
+        // `assertIs` on the payload — a bare `assertFailsWith` would pass even if
+        // the throw site moved to a different `SimulationException`.
         val leading = assertFailsWith<SimulationException> {
             parser.parse(leadingEcho, turnMarkers = gemma)
         }
@@ -95,11 +83,9 @@ class JSONResponseParserTurnMarkerTests {
     }
 
     /**
-     * A non-ChatML end marker inside a JSON string value is payload content, not
-     * a turn boundary. Mirrors Swift's
-     * `endMarker_insideStringValue_isNotATurnBoundary`; on Swift the unguarded
-     * cut is silently *persisted* via the repair pipeline, which this port does
-     * not have yet — the predicate is mirrored so the engines stay comparable.
+     * A non-ChatML end marker inside a JSON string value is payload content,
+     * not a turn boundary. Mirrors Swift's
+     * `endMarker_insideStringValue_isNotATurnBoundary`.
      */
     @Test
     fun endMarkerInsideStringValueIsNotATurnBoundary() {
@@ -111,11 +97,9 @@ class JSONResponseParserTurnMarkerTests {
     }
 
     /**
-     * **Control — the byte-identical-for-ChatML criterion.** ChatML's *own* end
-     * marker still cuts string-blind, so the guard stays keyed on
-     * `ChatTurnMarkers.chatML.end` by literal rather than applying to every end
-     * marker. Swift's counterpart additionally pins the repair kind, which this
-     * port has no pipeline for; here the same cut fails the parse.
+     * **Control — byte-identical-for-ChatML criterion.** ChatML's own end marker
+     * still cuts string-blind (keyed on `.chatML.end` by literal); this port has
+     * no repair pipeline, so the cut just fails the parse.
      */
     @Test
     fun endMarkerChatMLInsideStringValueStillCutsBlind() {
@@ -142,9 +126,8 @@ class JSONResponseParserTurnMarkerTests {
     }
 
     /**
-     * The asymmetry's load-bearing half: a *leading* start marker is the model
-     * echoing its own template header with the payload still behind it, so
-     * cutting there would delete the payload deterministically.
+     * The asymmetry's load-bearing half: a leading start marker is the model
+     * echoing its own template header, so cutting there deletes the payload.
      *
      * Change the start-arm search origin from `firstBrace + 1` to `0` and this
      * test fails while every other test here still passes.

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/JSONResponseParserTurnMarkerTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/JSONResponseParserTurnMarkerTests.kt
@@ -94,6 +94,39 @@ class JSONResponseParserTurnMarkerTests {
         assertIs<SimulationError.JsonParseFailed>(fabricated.error)
     }
 
+    /**
+     * A non-ChatML end marker inside a JSON string value is payload content, not
+     * a turn boundary. Mirrors Swift's
+     * `endMarker_insideStringValue_isNotATurnBoundary`; on Swift the unguarded
+     * cut is silently *persisted* via the repair pipeline, which this port does
+     * not have yet — the predicate is mirrored so the engines stay comparable.
+     */
+    @Test
+    fun endMarkerInsideStringValueIsNotATurnBoundary() {
+        val input = """{"statement": "テンプレートは <turn|> で終わる", "action": "cooperate"}"""
+
+        val output = parser.parse(input, turnMarkers = gemma)
+        assertEquals("テンプレートは <turn|> で終わる", output.fields["statement"])
+        assertEquals("cooperate", output.fields["action"])
+    }
+
+    /**
+     * **Control — the byte-identical-for-ChatML criterion.** ChatML's *own* end
+     * marker still cuts string-blind, so the guard stays keyed on
+     * `ChatTurnMarkers.chatML.end` by literal rather than applying to every end
+     * marker. Swift's counterpart additionally pins the repair kind, which this
+     * port has no pipeline for; here the same cut fails the parse.
+     */
+    @Test
+    fun endMarkerChatMLInsideStringValueStillCutsBlind() {
+        val input = """{"note": "テンプレートは <|im_end|> で終わる"}"""
+
+        val error = assertFailsWith<SimulationException> {
+            parser.parse(input, turnMarkers = chatMLOnly)
+        }
+        assertIs<SimulationError.JsonParseFailed>(error.error)
+    }
+
     @Test
     fun startMarkerAfterFirstBraceTruncates() {
         val input = """

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/JSONResponseParserTurnMarkerTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/JSONResponseParserTurnMarkerTests.kt
@@ -3,6 +3,7 @@ package com.pastura.engine
 import com.pastura.models.ChatTurnMarkers
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -52,6 +53,35 @@ class JSONResponseParserTurnMarkerTests {
 
         // Negative control — the pre-#1422 behaviour on the identical input.
         assertEquals("偽物", parser.parse(fencedHallucination, turnMarkers = chatMLOnly).fields["statement"])
+    }
+
+    /**
+     * **A pin on an accepted trade-off, not an assertion of desired
+     * behaviour** — the Kotlin half of Swift's
+     * `endMarker_leadingMarkerDestroysPayload_acceptedGap`. Read
+     * [#1452](https://github.com/tyabu12/pastura/issues/1452) before changing
+     * it: a failure means the end arm's unguarded cut moved, and the question
+     * is whether #1452 was decided, not whether this expectation is stale.
+     *
+     * The end arm cuts at the first occurrence with no `firstBrace` guard, so a
+     * *leading* end marker discards the whole payload the model then writes.
+     * The symmetric-looking fix — reusing the start arm's `> firstBrace` gate —
+     * is not strictly safer, which is the second assertion: today
+     * `<|im_end|>{"fake":1}` throws; under that gate the fabricated object
+     * would be accepted as the turn's answer.
+     */
+    @Test
+    fun endMarkerLeadingMarkerDestroysPayloadAcceptedGap() {
+        val leadingEcho = """
+            <turn|>
+            {"statement": "本物", "action": "cooperate"}
+        """.trimIndent()
+        assertFailsWith<SimulationException> { parser.parse(leadingEcho, turnMarkers = gemma) }
+
+        // The counter-example that blocks the `> firstBrace` gate.
+        assertFailsWith<SimulationException> {
+            parser.parse("""<|im_end|>{"fake":1}""", turnMarkers = chatMLOnly)
+        }
     }
 
     @Test

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/JSONResponseParserTurnMarkerTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/JSONResponseParserTurnMarkerTests.kt
@@ -1,0 +1,177 @@
+package com.pastura.engine
+
+import com.pastura.models.ChatTurnMarkers
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Per-model hallucinated-turn truncation (#1422) — the Kotlin half.
+ *
+ * **The fixtures are deliberately byte-identical to the Swift
+ * `JSONResponseParserTests+TurnMarkers.swift` ones.** No gate enforces
+ * Swift↔Kotlin parser parity (`check-prompt-literal-parity.py` covers
+ * `pickLanguage` literals only), so a shared fixture set is what makes a
+ * divergence in the truncation predicate show up as a failing test rather than
+ * as silent drift.
+ *
+ * Every test that asserts the fix also runs the **same input** through the
+ * pre-#1422 ChatML-only set as a negative control — without one, a test that
+ * happens to pass for an unrelated reason (the balanced-brace scan already
+ * discards trailing prose) would read as proof that truncation fired.
+ */
+class JSONResponseParserTurnMarkerTests {
+
+    private val parser = JSONResponseParser()
+
+    private val gemma = listOf(ChatTurnMarkers(start = "<|turn>", end = "<turn|>"), ChatTurnMarkers.chatML)
+    private val chatMLOnly = listOf(ChatTurnMarkers.chatML)
+
+    /**
+     * A fenced fabricated continuation is the shape that actually loses the
+     * payload: `extractFromCodeBlock` runs before the balanced-brace scan and
+     * takes the first match unconditionally.
+     */
+    private val fencedHallucination = """
+        {"statement": "本物", "action": "cooperate"}<turn|>
+        <|turn>user
+        もう一度
+        <turn|>
+        <|turn>model
+        ```json
+        {"statement": "偽物", "action": "betray"}
+        ```
+    """.trimIndent()
+
+    @Test
+    fun endMarkerTruncatesFencedFabricatedContinuation() {
+        val output = parser.parse(fencedHallucination, gemma)
+        assertEquals("本物", output.fields["statement"])
+        assertEquals("cooperate", output.fields["action"])
+
+        // Negative control — the pre-#1422 behaviour on the identical input.
+        assertEquals("偽物", parser.parse(fencedHallucination, chatMLOnly).fields["statement"])
+    }
+
+    @Test
+    fun startMarkerAfterFirstBraceTruncates() {
+        val input = """
+            {"statement": "本物"}
+            <|turn>model
+            ```json
+            {"statement": "偽物"}
+            ```
+        """.trimIndent()
+
+        assertEquals("本物", parser.parse(input, gemma).fields["statement"])
+        assertEquals("偽物", parser.parse(input, chatMLOnly).fields["statement"])
+    }
+
+    /**
+     * The asymmetry's load-bearing half: a *leading* start marker is the model
+     * echoing its own template header with the payload still behind it, so
+     * cutting there would delete the payload deterministically.
+     *
+     * Change the start-arm search origin from `firstBrace + 1` to `0` and this
+     * test fails while every other test here still passes.
+     */
+    @Test
+    fun startMarkerLeadingHeaderEchoIsNotATurnBoundary() {
+        val input = """
+            <|turn>model
+            {"statement": "本物", "action": "cooperate"}
+        """.trimIndent()
+
+        val output = parser.parse(input, gemma)
+        assertEquals("本物", output.fields["statement"])
+        assertEquals("cooperate", output.fields["action"])
+    }
+
+    /**
+     * The start arm is string-aware: a marker inside a JSON string value is
+     * payload content, not a turn boundary.
+     */
+    @Test
+    fun startMarkerInsideStringValueIsNotATurnBoundary() {
+        val input = """{"statement": "テンプレートは <|im_start|> から始まる", "action": "cooperate"}"""
+
+        val output = parser.parse(input, chatMLOnly)
+        assertEquals("テンプレートは <|im_start|> から始まる", output.fields["statement"])
+        assertEquals("cooperate", output.fields["action"])
+    }
+
+    @Test
+    fun markerFreeInputParsesIdenticallyUnderEitherSet() {
+        val input = """
+            {"statement": "hello", "action": "cooperate"}
+            That is my answer for this round.
+        """.trimIndent()
+
+        val chatML = parser.parse(input, chatMLOnly)
+        val withGemma = parser.parse(input, gemma)
+        assertEquals(chatML.fields, withGemma.fields)
+        assertEquals("hello", chatML.fields["statement"])
+    }
+
+    @Test
+    fun chatMLHallucinationUnchangedWhenGemmaPairIsAlsoPresent() {
+        val input = """
+            {"inner_thought": "考え中", "statement": "こんにちは"}<|im_end|>
+            <|im_start|>user
+            サクラ: 別の発言"}
+            <|im_end|>
+        """.trimIndent()
+
+        val baseline = parser.parse(input, chatMLOnly)
+        val widened = parser.parse(input, gemma)
+        assertEquals(baseline.fields, widened.fields)
+        assertEquals("こんにちは", widened.fields["statement"])
+    }
+
+    /**
+     * An empty marker string must never match — it would otherwise cut at index
+     * 0 and destroy every response.
+     */
+    @Test
+    fun emptyMarkerStringsAreIgnored() {
+        val output = parser.parse(
+            """{"statement": "hello"}""",
+            listOf(ChatTurnMarkers(start = "", end = "")),
+        )
+        assertEquals("hello", output.fields["statement"])
+    }
+
+    @Test
+    fun emptyMarkerSetLeavesTextUntouched() {
+        val output = parser.parse("""{"statement": "hello"}<|im_end|>garbage""", emptyList())
+        assertEquals("hello", output.fields["statement"])
+    }
+
+    /**
+     * The default parameter reproduces the pre-#1422 ChatML-only behaviour for
+     * callers with no backend in scope.
+     */
+    @Test
+    fun defaultMarkerSetIsChatMLOnly() {
+        val input = """{"statement": "hello"}<|im_end|> trailing"""
+        assertEquals(parser.parse(input, chatMLOnly).fields, parser.parse(input).fields)
+    }
+
+    /**
+     * The backend seam's default is ChatML-only, matching Swift's
+     * `LLMService.knownTurnMarkers` protocol-extension default.
+     */
+    @Test
+    fun backendDefaultKnownTurnMarkersIsChatMLOnly() {
+        val backend = object : LLMBackend {
+            override fun generateStream(
+                request: GenerationRequest,
+                callbacks: StreamCallbacks,
+            ): StreamHandle = throw UnsupportedOperationException("not used")
+        }
+        assertEquals(listOf(ChatTurnMarkers.chatML), backend.knownTurnMarkers)
+        assertTrue(backend.knownTurnMarkers.none { it.start == "<|turn>" })
+        assertFalse(backend.knownTurnMarkers.isEmpty())
+    }
+}

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/JSONResponseParserTurnMarkerTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/JSONResponseParserTurnMarkerTests.kt
@@ -46,12 +46,12 @@ class JSONResponseParserTurnMarkerTests {
 
     @Test
     fun endMarkerTruncatesFencedFabricatedContinuation() {
-        val output = parser.parse(fencedHallucination, gemma)
+        val output = parser.parse(fencedHallucination, turnMarkers = gemma)
         assertEquals("本物", output.fields["statement"])
         assertEquals("cooperate", output.fields["action"])
 
         // Negative control — the pre-#1422 behaviour on the identical input.
-        assertEquals("偽物", parser.parse(fencedHallucination, chatMLOnly).fields["statement"])
+        assertEquals("偽物", parser.parse(fencedHallucination, turnMarkers = chatMLOnly).fields["statement"])
     }
 
     @Test
@@ -64,8 +64,8 @@ class JSONResponseParserTurnMarkerTests {
             ```
         """.trimIndent()
 
-        assertEquals("本物", parser.parse(input, gemma).fields["statement"])
-        assertEquals("偽物", parser.parse(input, chatMLOnly).fields["statement"])
+        assertEquals("本物", parser.parse(input, turnMarkers = gemma).fields["statement"])
+        assertEquals("偽物", parser.parse(input, turnMarkers = chatMLOnly).fields["statement"])
     }
 
     /**
@@ -83,7 +83,7 @@ class JSONResponseParserTurnMarkerTests {
             {"statement": "本物", "action": "cooperate"}
         """.trimIndent()
 
-        val output = parser.parse(input, gemma)
+        val output = parser.parse(input, turnMarkers = gemma)
         assertEquals("本物", output.fields["statement"])
         assertEquals("cooperate", output.fields["action"])
     }
@@ -96,7 +96,7 @@ class JSONResponseParserTurnMarkerTests {
     fun startMarkerInsideStringValueIsNotATurnBoundary() {
         val input = """{"statement": "テンプレートは <|im_start|> から始まる", "action": "cooperate"}"""
 
-        val output = parser.parse(input, chatMLOnly)
+        val output = parser.parse(input, turnMarkers = chatMLOnly)
         assertEquals("テンプレートは <|im_start|> から始まる", output.fields["statement"])
         assertEquals("cooperate", output.fields["action"])
     }
@@ -108,8 +108,8 @@ class JSONResponseParserTurnMarkerTests {
             That is my answer for this round.
         """.trimIndent()
 
-        val chatML = parser.parse(input, chatMLOnly)
-        val withGemma = parser.parse(input, gemma)
+        val chatML = parser.parse(input, turnMarkers = chatMLOnly)
+        val withGemma = parser.parse(input, turnMarkers = gemma)
         assertEquals(chatML.fields, withGemma.fields)
         assertEquals("hello", chatML.fields["statement"])
     }
@@ -123,8 +123,8 @@ class JSONResponseParserTurnMarkerTests {
             <|im_end|>
         """.trimIndent()
 
-        val baseline = parser.parse(input, chatMLOnly)
-        val widened = parser.parse(input, gemma)
+        val baseline = parser.parse(input, turnMarkers = chatMLOnly)
+        val widened = parser.parse(input, turnMarkers = gemma)
         assertEquals(baseline.fields, widened.fields)
         assertEquals("こんにちは", widened.fields["statement"])
     }
@@ -137,14 +137,14 @@ class JSONResponseParserTurnMarkerTests {
     fun emptyMarkerStringsAreIgnored() {
         val output = parser.parse(
             """{"statement": "hello"}""",
-            listOf(ChatTurnMarkers(start = "", end = "")),
+            turnMarkers = listOf(ChatTurnMarkers(start = "", end = "")),
         )
         assertEquals("hello", output.fields["statement"])
     }
 
     @Test
     fun emptyMarkerSetLeavesTextUntouched() {
-        val output = parser.parse("""{"statement": "hello"}<|im_end|>garbage""", emptyList())
+        val output = parser.parse("""{"statement": "hello"}<|im_end|>garbage""", turnMarkers = emptyList())
         assertEquals("hello", output.fields["statement"])
     }
 
@@ -155,7 +155,7 @@ class JSONResponseParserTurnMarkerTests {
     @Test
     fun defaultMarkerSetIsChatMLOnly() {
         val input = """{"statement": "hello"}<|im_end|> trailing"""
-        assertEquals(parser.parse(input, chatMLOnly).fields, parser.parse(input).fields)
+        assertEquals(parser.parse(input, turnMarkers = chatMLOnly).fields, parser.parse(input).fields)
     }
 
     /**

--- a/shared/engine/src/commonTest/kotlin/com/pastura/engine/JSONResponseParserTurnMarkerTests.kt
+++ b/shared/engine/src/commonTest/kotlin/com/pastura/engine/JSONResponseParserTurnMarkerTests.kt
@@ -1,10 +1,12 @@
 package com.pastura.engine
 
 import com.pastura.models.ChatTurnMarkers
+import com.pastura.models.SimulationError
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 /**
@@ -76,12 +78,20 @@ class JSONResponseParserTurnMarkerTests {
             <turn|>
             {"statement": "本物", "action": "cooperate"}
         """.trimIndent()
-        assertFailsWith<SimulationException> { parser.parse(leadingEcho, turnMarkers = gemma) }
+        // `assertIs` on the payload, per the sibling suite's idiom: a bare
+        // `assertFailsWith` would keep passing if the throw site ever moved to a
+        // different `SimulationException`, which is the drift a #1452 pin exists
+        // to detect.
+        val leading = assertFailsWith<SimulationException> {
+            parser.parse(leadingEcho, turnMarkers = gemma)
+        }
+        assertIs<SimulationError.JsonParseFailed>(leading.error)
 
         // The counter-example that blocks the `> firstBrace` gate.
-        assertFailsWith<SimulationException> {
+        val fabricated = assertFailsWith<SimulationException> {
             parser.parse("""<|im_end|>{"fake":1}""", turnMarkers = chatMLOnly)
         }
+        assertIs<SimulationError.JsonParseFailed>(fabricated.error)
     }
 
     @Test

--- a/shared/models/src/commonMain/kotlin/com/pastura/models/ChatTurnMarkers.kt
+++ b/shared/models/src/commonMain/kotlin/com/pastura/models/ChatTurnMarkers.kt
@@ -1,0 +1,46 @@
+package com.pastura.models
+
+/**
+ * The turn-boundary sentinels a model's chat template writes around one turn,
+ * **as plaintext**.
+ *
+ * Kotlin port of `Pastura/Pastura/Models/ChatTurnMarkers.swift` (#1422).
+ *
+ * ### Contract for consumers
+ *
+ * Match these against **decoded text only**. They are not the tokenizer's
+ * turn-boundary *tokens*: under llama.cpp a genuine CONTROL token decodes to
+ * the empty string and an end-of-generation token returns before its piece is
+ * appended, so a marker can only ever reach a text match when the model
+ * **hallucinates it as ordinary characters**.
+ *
+ * ### Why per-model
+ *
+ * The values are tokenizer-specific and share no convention across families.
+ * ChatML models (Qwen 3) use `<|im_start|>` / `<|im_end|>`; Gemma 4 uses
+ * `<|turn>` / `<turn|>` and carries neither ChatML string anywhere in its
+ * 262,144-token vocabulary. Hardcoding the ChatML pair — as both engines did
+ * until #1422 — leaves every mechanism keyed on it silently inert for the
+ * default shipped model.
+ *
+ * **Deliberately not `@Serializable`.** It is a runtime parameter of the parse
+ * path, never a persisted or K/N-serialized payload, so it does not cross
+ * ADR-023 §5.2 and needs no golden entry (§12 condition 2). Behaviour parity
+ * with Swift is covered by the ported truncation tests instead.
+ *
+ * @property start Plaintext sentinel that opens a turn (e.g. `"<|im_start|>"`).
+ * @property end   Plaintext sentinel that closes a turn (e.g. `"<|im_end|>"`).
+ */
+public data class ChatTurnMarkers(
+    val start: String,
+    val end: String,
+) {
+    public companion object {
+        /**
+         * The ChatML pair — Qwen 3 and the wider ChatML family, and the
+         * baseline every consumer keeps in its effective set regardless of
+         * which model is loaded.
+         */
+        public val chatML: ChatTurnMarkers = ChatTurnMarkers(start = "<|im_start|>", end = "<|im_end|>")
+    }
+}

--- a/shared/models/src/commonMain/kotlin/com/pastura/models/ChatTurnMarkers.kt
+++ b/shared/models/src/commonMain/kotlin/com/pastura/models/ChatTurnMarkers.kt
@@ -8,20 +8,15 @@ package com.pastura.models
  *
  * ### Contract for consumers
  *
- * Match these against **decoded text only**. They are not the tokenizer's
- * turn-boundary *tokens*: under llama.cpp a genuine CONTROL token decodes to
- * the empty string and an end-of-generation token returns before its piece is
- * appended, so a marker can only ever reach a text match when the model
- * **hallucinates it as ordinary characters**.
+ * Match these against **decoded text only**, never the tokenizer's turn-boundary tokens — a
+ * genuine CONTROL token never decodes to visible text. See the Swift original for the full
+ * argument.
  *
  * ### Why per-model
  *
- * The values are tokenizer-specific and share no convention across families.
- * ChatML models (Qwen 3) use `<|im_start|>` / `<|im_end|>`; Gemma 4 uses
- * `<|turn>` / `<turn|>` and carries neither ChatML string anywhere in its
- * 262,144-token vocabulary. Hardcoding the ChatML pair — as both engines did
- * until #1422 — leaves every mechanism keyed on it silently inert for the
- * default shipped model.
+ * Values are tokenizer-specific with no shared convention: ChatML (Qwen 3) uses
+ * `<|im_start|>`/`<|im_end|>`, Gemma 4 uses `<|turn>`/`<turn|>`. Hardcoding the ChatML pair, as
+ * both engines did until #1422, left every consumer silently inert for the default shipped model.
  *
  * **Deliberately not `@Serializable`.** It is a runtime parameter of the parse
  * path, never a persisted or K/N-serialized payload, so it does not cross

--- a/shared/models/src/commonTest/kotlin/com/pastura/models/ChatTurnMarkersTests.kt
+++ b/shared/models/src/commonTest/kotlin/com/pastura/models/ChatTurnMarkersTests.kt
@@ -5,14 +5,15 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
 /**
- * Coverage in the module that **owns** the type. `shared/engine`'s
+ * Coverage for [ChatTurnMarkers] in the module that **owns** it. `shared/engine`'s
  * `JSONResponseParserTurnMarkerTests` exercises these literals only as
  * fixtures, so a reword there would land as a truncation-behaviour failure in a
  * sibling module rather than as an edit to the pair itself.
  *
  * Values pinned byte-for-byte against Swift's `ChatTurnMarkers.chatML` — the
  * two engines share no gate on this type (its KDoc explains why it carries no
- * golden entry), so these literals are the parity anchor.
+ * golden entry), so these literals are the parity anchor, symmetric with
+ * `Pastura/PasturaTests/Models/ChatTurnMarkersTests.swift`.
  */
 class ChatTurnMarkersTests {
 
@@ -23,10 +24,17 @@ class ChatTurnMarkersTests {
     }
 
     /**
-     * `data class` equality must discriminate on **both** fields: consumers
-     * decide set membership with a single `== ChatTurnMarkers.chatML`, so a
-     * pair matching ChatML's `start` alone must not collapse into it and lose
-     * its distinct `end`.
+     * Guards the **structural** `equals` the `data class` modifier synthesizes.
+     * Nothing here reverts to redden it, so read it as a change-detector, not a
+     * regression test: what it catches is a `data class` → `class` demotion or a
+     * hand-written `equals`, either of which would silently break
+     * `JSONResponseParserTurnMarkerTests`' `assertEquals(listOf(chatML),
+     * backend.knownTurnMarkers)` in the sibling module.
+     *
+     * Note the asymmetry with Swift, where the equivalent test guards a live
+     * consumer: `LlamaCppService.knownTurnMarkers` decides its union with a
+     * whole-pair `== .chatML` ternary. This module has no such consumer yet —
+     * the Phase 3.0 adapter is where one would appear.
      */
     @Test
     fun equalityDiscriminatesOnEachField() {

--- a/shared/models/src/commonTest/kotlin/com/pastura/models/ChatTurnMarkersTests.kt
+++ b/shared/models/src/commonTest/kotlin/com/pastura/models/ChatTurnMarkersTests.kt
@@ -6,13 +6,12 @@ import kotlin.test.assertNotEquals
 
 /**
  * Coverage for [ChatTurnMarkers] in the module that **owns** it. `shared/engine`'s
- * `JSONResponseParserTurnMarkerTests` exercises these literals only as
- * fixtures, so a reword there would land as a truncation-behaviour failure in a
- * sibling module rather than as an edit to the pair itself.
+ * `JSONResponseParserTurnMarkerTests` exercises these literals only as fixtures,
+ * so a reword there lands as a truncation-behaviour failure, not an edit to the
+ * pair itself.
  *
- * Values pinned byte-for-byte against Swift's `ChatTurnMarkers.chatML` — the
- * two engines share no gate on this type (its KDoc explains why it carries no
- * golden entry), so these literals are the parity anchor, symmetric with
+ * Values pinned byte-for-byte against Swift's `ChatTurnMarkers.chatML` — no gate
+ * enforces parity, so these literals are the anchor, symmetric with
  * `Pastura/PasturaTests/Models/ChatTurnMarkersTests.swift`.
  */
 class ChatTurnMarkersTests {
@@ -24,25 +23,16 @@ class ChatTurnMarkersTests {
     }
 
     /**
-     * Guards the **structural** `equals` the `data class` modifier synthesizes.
-     * A change-detector, not a regression test: what it catches is a
-     * `data class` → `class` demotion or a hand-written `equals`.
+     * Guards the **structural** `equals` the `data class` modifier synthesizes —
+     * a change-detector for a `data class` → `class` demotion or a hand-written
+     * `equals`.
      *
-     * **It is the only thing that catches one** — measured, not assumed.
-     * Demoting the type to `class` and running both modules reddens exactly this
-     * test; `:shared:engine:jvmTest` passes in full. In particular
-     * `JSONResponseParserTurnMarkerTests`' `assertEquals(listOf(chatML),
-     * backend.knownTurnMarkers)` is **not** a dependant: both sides name the same
-     * companion singleton, so element-wise `List.equals` resolves to
-     * `chatML == chatML` on one reference and `Any.equals` identity answers it
-     * without any structural `equals`. A hand-written `equals` comparing only
-     * `start` would pass it too.
-     *
-     * So no Kotlin consumer relies on structural equality today — the asymmetry
-     * with Swift, where `LlamaCppService.knownTurnMarkers` decides its union
-     * with a whole-pair `== .chatML` ternary and the equivalent test therefore
-     * guards a live consumer. The Phase 3.0 adapter is where one would appear
-     * here.
+     * **Measured, not assumed: it is the only thing that catches one.** Demoting
+     * to `class` reddens exactly this test; `:shared:engine:jvmTest` passes in
+     * full, since no Kotlin consumer relies on structural equality today — the
+     * asymmetry with Swift, where `LlamaCppService.knownTurnMarkers` decides its
+     * union with a whole-pair `== .chatML` ternary and the equivalent test
+     * guards a live consumer.
      */
     @Test
     fun equalityDiscriminatesOnEachField() {

--- a/shared/models/src/commonTest/kotlin/com/pastura/models/ChatTurnMarkersTests.kt
+++ b/shared/models/src/commonTest/kotlin/com/pastura/models/ChatTurnMarkersTests.kt
@@ -25,16 +25,24 @@ class ChatTurnMarkersTests {
 
     /**
      * Guards the **structural** `equals` the `data class` modifier synthesizes.
-     * Nothing here reverts to redden it, so read it as a change-detector, not a
-     * regression test: what it catches is a `data class` → `class` demotion or a
-     * hand-written `equals`, either of which would silently break
-     * `JSONResponseParserTurnMarkerTests`' `assertEquals(listOf(chatML),
-     * backend.knownTurnMarkers)` in the sibling module.
+     * A change-detector, not a regression test: what it catches is a
+     * `data class` → `class` demotion or a hand-written `equals`.
      *
-     * Note the asymmetry with Swift, where the equivalent test guards a live
-     * consumer: `LlamaCppService.knownTurnMarkers` decides its union with a
-     * whole-pair `== .chatML` ternary. This module has no such consumer yet —
-     * the Phase 3.0 adapter is where one would appear.
+     * **It is the only thing that catches one** — measured, not assumed.
+     * Demoting the type to `class` and running both modules reddens exactly this
+     * test; `:shared:engine:jvmTest` passes in full. In particular
+     * `JSONResponseParserTurnMarkerTests`' `assertEquals(listOf(chatML),
+     * backend.knownTurnMarkers)` is **not** a dependant: both sides name the same
+     * companion singleton, so element-wise `List.equals` resolves to
+     * `chatML == chatML` on one reference and `Any.equals` identity answers it
+     * without any structural `equals`. A hand-written `equals` comparing only
+     * `start` would pass it too.
+     *
+     * So no Kotlin consumer relies on structural equality today — the asymmetry
+     * with Swift, where `LlamaCppService.knownTurnMarkers` decides its union
+     * with a whole-pair `== .chatML` ternary and the equivalent test therefore
+     * guards a live consumer. The Phase 3.0 adapter is where one would appear
+     * here.
      */
     @Test
     fun equalityDiscriminatesOnEachField() {

--- a/shared/models/src/commonTest/kotlin/com/pastura/models/ChatTurnMarkersTests.kt
+++ b/shared/models/src/commonTest/kotlin/com/pastura/models/ChatTurnMarkersTests.kt
@@ -1,0 +1,38 @@
+package com.pastura.models
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+/**
+ * Coverage in the module that **owns** the type. `shared/engine`'s
+ * `JSONResponseParserTurnMarkerTests` exercises these literals only as
+ * fixtures, so a reword there would land as a truncation-behaviour failure in a
+ * sibling module rather than as an edit to the pair itself.
+ *
+ * Values pinned byte-for-byte against Swift's `ChatTurnMarkers.chatML` — the
+ * two engines share no gate on this type (its KDoc explains why it carries no
+ * golden entry), so these literals are the parity anchor.
+ */
+class ChatTurnMarkersTests {
+
+    @Test
+    fun chatMLCarriesTheChatMLPair() {
+        assertEquals("<|im_start|>", ChatTurnMarkers.chatML.start)
+        assertEquals("<|im_end|>", ChatTurnMarkers.chatML.end)
+    }
+
+    /**
+     * `data class` equality must discriminate on **both** fields: consumers
+     * decide set membership with a single `== ChatTurnMarkers.chatML`, so a
+     * pair matching ChatML's `start` alone must not collapse into it and lose
+     * its distinct `end`.
+     */
+    @Test
+    fun equalityDiscriminatesOnEachField() {
+        val base = ChatTurnMarkers(start = "<a>", end = "</a>")
+        assertEquals(base, ChatTurnMarkers(start = "<a>", end = "</a>"))
+        assertNotEquals(base, ChatTurnMarkers(start = "<b>", end = "</a>"))
+        assertNotEquals(base, ChatTurnMarkers(start = "<a>", end = "</b>"))
+    }
+}

--- a/tools/harness/Sources/PasturaHarnessKit/ModelProfile.swift
+++ b/tools/harness/Sources/PasturaHarnessKit/ModelProfile.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PasturaCore
 
 /// Inference-parameter profile for a GGUF model the harness can drive.
 ///
@@ -18,6 +19,17 @@ package struct ModelProfile: Sendable, Equatable {
   /// (a hallucinated turn boundary); a *normal* turn ends on EOG instead. The
   /// canonical mechanism note is on `LlamaCppService.stopSequence` (#1417).
   package let stopSequence: String
+  /// This model's plaintext turn-boundary sentinels, mirroring
+  /// `ModelDescriptor.turnMarkers` (#1422).
+  ///
+  /// Distinct from ``stopSequence``, and for Gemma the two deliberately
+  /// **disagree** — see the app-side note; repointing the generation-side
+  /// sentinel is deferred to #1451.
+  ///
+  /// No default, mirroring the app descriptor: a wrong inherited pair fails
+  /// silently, so a new profile must state it. `docs/models/onboarding.md`
+  /// carries the collection step.
+  package let turnMarkers: ChatTurnMarkers
   /// Optional suffix appended to every system prompt.
   package let systemPromptSuffix: String?
   /// Optional assistant-turn prefill. Gemma needs none — the
@@ -34,12 +46,14 @@ package struct ModelProfile: Sendable, Equatable {
   package let expectedSHA256: String
 
   package init(
-    id: String, name: String, stopSequence: String, systemPromptSuffix: String?,
+    id: String, name: String, stopSequence: String, turnMarkers: ChatTurnMarkers,
+    systemPromptSuffix: String?,
     assistantPrefix: String?, expectedFileName: String, expectedSHA256: String
   ) {
     self.id = id
     self.name = name
     self.stopSequence = stopSequence
+    self.turnMarkers = turnMarkers
     self.systemPromptSuffix = systemPromptSuffix
     self.assistantPrefix = assistantPrefix
     self.expectedFileName = expectedFileName
@@ -55,6 +69,10 @@ package struct ModelProfile: Sendable, Equatable {
     // `ModelProfileTests` pins the literal, so it cannot be changed here alone
     // (#1417).
     stopSequence: "<|im_end|>",
+    // Measured from the GGUF header of the pinned file: `<|turn>` id 105 /
+    // `<turn|>` id 106, both `token_type=3` (CONTROL), `eos = 106`, vocab
+    // 262,144. Neither ChatML string occurs in that vocabulary at all.
+    turnMarkers: ChatTurnMarkers(start: "<|turn>", end: "<turn|>"),
     systemPromptSuffix: nil,
     assistantPrefix: nil,
     expectedFileName: "gemma-4-E2B-it-Q4_K_M.gguf",
@@ -66,6 +84,9 @@ package struct ModelProfile: Sendable, Equatable {
     id: "qwen-3-4b-q4-k-m",
     name: "Qwen 3 4B (Q4_K_M)",
     stopSequence: "<|im_end|>",
+    // Qwen 3 genuinely is ChatML: `<|im_start|>` 151644 / `<|im_end|>` 151645,
+    // both CONTROL, `eos = 151645`.
+    turnMarkers: .chatML,
     systemPromptSuffix: "/no_think",
     // Prefill the assistant turn with the empty-thinking marker so Qwen 3
     // bypasses thinking mode entirely. Issue #366 — without this, Qwen
@@ -106,6 +127,17 @@ package struct ModelProfile: Sendable, Equatable {
     // `/no_think` suffix nor a `<think>` assistant prefill. The stop sequence
     // is the plain eos `</s>`; suffix and prefix are nil.
     stopSequence: "</s>",
+    // Derived from the turn format already recorded on `stopSequence` above,
+    // NOT from a fresh GGUF header read — this candidate is NO-GO and has no
+    // registry entry, so re-reading it was not worth a download. Re-verify at
+    // Gate-2 registration if it is ever revived (`docs/models/onboarding.md`
+    // § "Stage 0"). Sarashina wraps turns in `<|system|>` / `<|user|>` /
+    // `<|assistant|>` with `</s>` closing each; the start marker is per-role,
+    // so there is no single pair, and `<|assistant|>` is the one whose
+    // appearance mid-output means a fabricated next turn. Note this is also
+    // the one model empirically observed to spell ChatML markers out
+    // (`docs/models/eval-log.md`), which the ChatML baseline already covers.
+    turnMarkers: ChatTurnMarkers(start: "<|assistant|>", end: "</s>"),
     systemPromptSuffix: nil,
     assistantPrefix: nil,
     expectedFileName: "sarashina2.2-3b-instruct-v0.1-Q4_K_M.gguf",

--- a/tools/harness/Sources/PasturaHarnessKit/ModelProfile.swift
+++ b/tools/harness/Sources/PasturaHarnessKit/ModelProfile.swift
@@ -20,15 +20,8 @@ package struct ModelProfile: Sendable, Equatable {
   /// canonical mechanism note is on `LlamaCppService.stopSequence` (#1417).
   package let stopSequence: String
   /// This model's plaintext turn-boundary sentinels, mirroring
-  /// `ModelDescriptor.turnMarkers` (#1422).
-  ///
-  /// Distinct from ``stopSequence``, and for Gemma the two deliberately
-  /// **disagree** — see the app-side note; repointing the generation-side
-  /// sentinel is deferred to #1451.
-  ///
-  /// No default, mirroring the app descriptor: a wrong inherited pair fails
-  /// silently, so a new profile must state it. `docs/models/onboarding.md`
-  /// carries the collection step.
+  /// `ModelDescriptor.turnMarkers` (#1422). No default — a wrong inherited
+  /// pair fails silently, same reason as there; see that doc for #1451.
   package let turnMarkers: ChatTurnMarkers
   /// Optional suffix appended to every system prompt.
   package let systemPromptSuffix: String?
@@ -70,8 +63,7 @@ package struct ModelProfile: Sendable, Equatable {
     // (#1417).
     stopSequence: "<|im_end|>",
     // Measured from the GGUF header of the pinned file: `<|turn>` id 105 /
-    // `<turn|>` id 106, both `token_type=3` (CONTROL), `eos = 106`, vocab
-    // 262,144. Neither ChatML string occurs in that vocabulary at all.
+    // `<turn|>` id 106, both `token_type=3` (CONTROL), `eos = 106`, vocab 262,144.
     turnMarkers: ChatTurnMarkers(start: "<|turn>", end: "<turn|>"),
     systemPromptSuffix: nil,
     assistantPrefix: nil,
@@ -127,16 +119,11 @@ package struct ModelProfile: Sendable, Equatable {
     // `/no_think` suffix nor a `<think>` assistant prefill. The stop sequence
     // is the plain eos `</s>`; suffix and prefix are nil.
     stopSequence: "</s>",
-    // Derived from the turn format already recorded on `stopSequence` above,
-    // NOT from a fresh GGUF header read — this candidate is NO-GO and has no
-    // registry entry, so re-reading it was not worth a download. Re-verify at
-    // Gate-2 registration if it is ever revived (`docs/models/onboarding.md`
-    // § "Stage 0"). Sarashina wraps turns in `<|system|>` / `<|user|>` /
-    // `<|assistant|>` with `</s>` closing each; the start marker is per-role,
-    // so there is no single pair, and `<|assistant|>` is the one whose
-    // appearance mid-output means a fabricated next turn. Note this is also
-    // the one model empirically observed to spell ChatML markers out
-    // (`docs/models/eval-log.md`), which the ChatML baseline already covers.
+    // Derived from the turn format on `stopSequence` above, NOT a fresh GGUF
+    // header read — NO-GO candidate, no registry entry; re-verify at Gate-2
+    // registration if revived (`docs/models/onboarding.md` § "Stage 0").
+    // Start markers are per-role (no single pair); `<|assistant|>` mid-output
+    // is the one signaling a fabricated next turn.
     turnMarkers: ChatTurnMarkers(start: "<|assistant|>", end: "</s>"),
     systemPromptSuffix: nil,
     assistantPrefix: nil,

--- a/tools/harness/Sources/pastura-harness/Main.swift
+++ b/tools/harness/Sources/pastura-harness/Main.swift
@@ -212,6 +212,7 @@ enum Main {
         LlamaCppService(
           modelPath: modelPath,
           stopSequence: profile.stopSequence,
+          turnMarkers: profile.turnMarkers,
           modelIdentifier: profile.name,
           systemPromptSuffix: profile.systemPromptSuffix,
           assistantPrefix: profile.assistantPrefix)

--- a/tools/harness/Tests/PasturaHarnessKitTests/ModelProfileTests.swift
+++ b/tools/harness/Tests/PasturaHarnessKitTests/ModelProfileTests.swift
@@ -1,3 +1,4 @@
+import PasturaCore
 import Testing
 
 @testable import PasturaHarnessKit
@@ -12,6 +13,11 @@ struct ModelProfileTests {
     let profile = ModelProfile.gemma4E2B
     #expect(profile.id == "gemma-4-e2b-q4-k-m")
     #expect(profile.stopSequence == "<|im_end|>")
+    #expect(profile.turnMarkers == ChatTurnMarkers(start: "<|turn>", end: "<turn|>"))
+    // Same deliberate divergence the app registry carries: the generation-side
+    // sentinel is a ChatML string absent from Gemma's vocabulary, so that path
+    // is inert; repointing it is deferred to #1451, not an oversight (#1422).
+    #expect(profile.stopSequence != profile.turnMarkers.end)
     #expect(profile.systemPromptSuffix == nil)
     // Gemma needs no assistant prefill — `<think>...` is Qwen-only.
     #expect(profile.assistantPrefix == nil)
@@ -31,6 +37,7 @@ struct ModelProfileTests {
     #expect(profile.id == "qwen-3-4b-q4-k-m")
     #expect(profile.name == "Qwen 3 4B (Q4_K_M)")
     #expect(profile.stopSequence == "<|im_end|>")
+    #expect(profile.turnMarkers == .chatML)
     #expect(profile.systemPromptSuffix == "/no_think")
     #expect(profile.assistantPrefix == "<think>\n\n</think>\n\n")
     #expect(profile.expectedFileName == "Qwen3-4B-Q4_K_M.gguf")
@@ -51,6 +58,7 @@ struct ModelProfileTests {
     #expect(profile.name == "Sarashina 2.2 3B (Q4_K_M)")
     // Plain eos stop; no thinking-mode workaround (contrast Qwen #366).
     #expect(profile.stopSequence == "</s>")
+    #expect(profile.turnMarkers == ChatTurnMarkers(start: "<|assistant|>", end: "</s>"))
     #expect(profile.systemPromptSuffix == nil)
     #expect(profile.assistantPrefix == nil)
     #expect(profile.expectedFileName == "sarashina2.2-3b-instruct-v0.1-Q4_K_M.gguf")


### PR DESCRIPTION
## Summary

Hallucinated-turn truncation was keyed on a hardcoded ChatML literal
(`<|im_start|>` / `<|im_end|>`). Gemma 4 E2B — the **default shipped model** —
uses `<|turn>` / `<turn|>` and carries neither ChatML string anywhere in its
262,144-token vocabulary, so every mechanism keyed on that literal was silently
inert for it. The KMP engine mirror had the same bug.

The markers are now a per-model value carried on the descriptor and read from
the live backend:

- `ChatTurnMarkers` (`Models/`) — a `start` / `end` pair, plus the `.chatML`
  baseline. Matched against **decoded text only**: a genuine CONTROL token
  decodes to `""` and an EOG token returns before its piece is appended, so a
  marker reaches a text match only as a plaintext hallucination.
- `ModelDescriptor.turnMarkers` — **no default**, so a new model cannot inherit
  the wrong pair by omission.
- `LLMService.knownTurnMarkers` — the seam. Defaults to ChatML only, so backends
  with no descriptor to consult (Ollama, `MockLLMService`, FoundationModels) keep
  pre-#1422 behaviour. `LlamaCppService` overrides it with the loaded model's pair
  **unioned with** ChatML — instruction-tuned models are trained on ChatML
  corpora, so a non-ChatML model spelling `<|im_end|>` is not excluded by its
  vocabulary, and the union is also what keeps Qwen byte-identical.
- `truncateAtTurnMarkers` — the two arms are **deliberately asymmetric**. An end
  marker is a turn boundary wherever it occurs, so it cuts with no `firstBrace`
  gate. A start marker cuts only **after** the first structural `{`; a leading one
  is the model echoing its own template header with the payload still behind it,
  and cutting there would delete it deterministically. Both arms skip markers
  inside JSON string literals — with one deliberate exception, ChatML's own end
  marker, which stays string-blind so ChatML backends are byte-identical to
  pre-#1422 (see "A corruption path this PR made reachable" below).
- Substring search, not regex: Gemma's `<|turn>` contains a bare `|`, which as a
  pattern compiles to the alternation `<` **or** `turn>` and would cut at the
  first `<` anywhere in the output — mass payload destruction for the default
  model.

Mirrored into `shared/engine` (ADR-023) and the ADR-013 harness `ModelProfile`.

## Deviations from the plan, and why

1. **`stopSequence` stays deliberately mismatched with `turnMarkers.end` for
   Gemma** → split to #1451. It holds a ChatML string absent from Gemma's
   vocabulary, so that generation-side path is inert; repointing it would newly
   *activate* a behaviour on an assumption, and a false positive there truncates
   a real payload mid-generation — strictly worse than today's no-op. Pinned by
   `ModelRegistryTurnMarkerDivergenceTests`.
2. **The leading-end-marker gap is left as-is** → split to #1452. A leading end
   marker cuts at index 0 and destroys the whole payload. The symmetric-looking
   fix (reuse the start arm's `> firstBrace` gate) is **not strictly safer**:
   `<|im_end|>{"fake":1}` currently fails and retries, but under that gate the
   fabricated object would be *accepted* as the turn's answer. That violates the
   byte-identical-for-ChatML acceptance criterion, so both engines document and
   pin the gap instead.
3. **The KMP seam is named `knownTurnMarkers: List<ChatTurnMarkers>`**, not the
   plan's singular `turnMarkers` — matching Swift name-for-name and putting the
   ChatML union on the same side of the boundary in both engines.
4. **Plan item 4 was promoted 🎵 → 🎭** and implemented directly (two call sites
   plus one function; delegation would have cost more than the work).
5. **The corpus numbers were re-measured, not carried forward.** The plan's
   "Sarashina 51" was wrong; the measured count is **99**. Gemma's and Qwen's
   zeros are real negatives, not an empty set — the 2026-08-12 runs contribute
   six full transcripts each.

## A corruption path this PR made reachable (found late, fixed here)

An official `/code-review` pass caught what four convention-review rounds did not.
The end arm was string-blind, so a marker inside a JSON string value cut
mid-value; the repair pipeline then closed the quote and brace and the truncated
value was **persisted as the agent's answer**. Measured:

| input | markers | result |
|---|---|---|
| `{"statement":"… <turn\|> …","action":"cooperate"}` | Gemma | `statement` truncated, **`action` gone** |
| same | ChatML only | both fields intact |
| `{"note":"… <turn\|> …"}`, single-field schema | Gemma | accepted + persisted truncated |
| `{"note":"… <\|im_end\|> …"}` | ChatML only | also truncated — so the gap is **pre-existing** |

That last row is the important one: the gap is not new. What this PR changed is
**reachability** — `stopSequence` stays `<|im_end|>` by the #1451 decision, so
`<turn|>` is the first end marker that survives generation and arrives
un-stripped. Single-field schemas (`reflect {note}`, `narrate {commentary}`)
persist the truncated value; multi-field ones burn the retry budget.

Fixed here rather than split off, because deferring would leave `main` in a
*less safe* state than before this PR — the project's stated rule for exactly
this case. The guard is keyed on `.chatML.end` **by literal**, so ChatML stays
byte-identical and #1452 is untouched, and a **control test** pins that
exception so it cannot quietly widen into "all end markers" (which would change
Qwen and is a separate decision). Mirrored predicate-for-predicate into
`shared/engine`; the *consequence* does not mirror yet, since that port has no
repair pipeline and the same cut merely fails the parse there.

Also from that pass: `LlamaCppService.init` no longer defaults `turnMarkers`. The
descriptor and harness profile are deliberately non-defaulted so a wrong pair
can't be inherited silently, and the init default broke that chain at the one
place the hand-off can actually be dropped. Its old justification — "changes only
recognition, never generation" — inverts: wrong *recognition* is the #1422 bug.

## Review findings folded in

Four review shards on the implementation (0 Critical), then **four** re-review
rounds on the fixes. Most findings were
**comments that were factually wrong about their own mechanism**, which matters
here because the whole change is about a mechanism that fails silently. The
substantive ones:

- The `nonisolated` on `knownTurnMarkers` was justified by the escaping-closure
  mechanism (`generateStream`, Pattern 1). The actual discriminator is
  **sync-vs-`async`** — the `async` members on the same extension carry no
  annotation. `.claude/rules/swift-isolation.md` Pattern 1 now records this, so a
  reader following that rule does not delete a closure-free `nonisolated`.
- `everyCatalogEntryHasNonEmptyMarkers` claimed an empty pair "matches at every
  index". The opposite: it is guarded at every arm, so truncation goes **silently
  inert** — #1422's own bug, which is the stronger reason for the test.
- The leakage `.warning` asserted "model wrote past its turn". `raw.contains` also
  fires on a header echo and on marker text inside a JSON string value, so the
  message now states presence only — on **both** engines (the Kotlin copy still
  carried the overclaim; no gate compares log messages across the two).
- Three real-GGUF `LlamaCppService` sites took the `.chatML` default while running
  a real model. The review named two; enumerating found a third (`+Qwen`).
- `PasturaHarnessKitTests` `import PasturaCore` without declaring it — resolving
  on SwiftPM search-path luck.
- `docs/models/onboarding.md`'s marker sweep had **two** false-zero routes: an
  unsubstituted `'<the candidate pair>'` placeholder, and — since the corpus is
  gitignored and absent in any worktree — `grep -r` over a missing directory
  printing `0` for every marker. Both now guarded; the precondition was observed
  firing rather than assumed.

### Reviewer note: every correction round carried its own false claim

Worth flagging, since it is the same failure mode the PR is about. Rounds 1–3
each shipped a fix whose *replacement* text was wrong: an off-by-one guard count;
a citation pointing at a section that did not establish the claim; kmp-interop
Pattern 2 cited as "the header settled it" when there the header *misled*;
"stated once" when it was stated three times; a "silent rebind" that is
compile-caught three ways; and a test-coverage dependency that resolves on
reference identity and therefore does not exist. Round 4 found an inverted
cross-reference — a doc pointing "below" at a test that contradicts it.

Two consequences for how this diff reads:

- **Where an exact count was not worth asserting, it was replaced by the
  enumerating command** (`grep -rn '#1451\|#1417'`) rather than a number a reader
  can falsify.
- **The one claim that mattered most was measured, not argued.**
  `ChatTurnMarkersTests.kt` now records that demoting `ChatTurnMarkers` to a
  plain `class` reddens exactly one test — its own — while the whole engine suite
  passes. That was run and reverted; it is why the honest justification (this
  test is the *sole* detector) replaced a false one (a sibling test that never
  depended on structural equality).

Round 4 ran past the review loop's documented 3-iteration limit deliberately: at
3-for-3 on corrections carrying errors, one more narrow pass over an 80-line diff
was cheap next to shipping another false comment. Its own fixes are wording plus
the inverted reference, verified but not themselves re-reviewed — stated here
rather than implied to be clean.

## Test plan

- iOS full suite + UI tests — `** TEST SUCCEEDED **`
- SwiftLint `--strict` — clean
- `swift build` + `swift test` (harness package, 76 tests) — pass
- `:shared:models:jvmTest :shared:engine:jvmTest` + `compileCommonMainKotlinMetadata`
  for both modules — pass
- Device-target compile: `scripts/xcodebuild.sh build -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO`
  — required because `AppDependencies.switchActiveModel` sits inside
  `#if !targetEnvironment(simulator)`
- The documented shell snippet parsed with `bash -n`, and its new corpus-absent
  guard observed firing in a worktree (exit 1, no zero-row)
- New coverage: Swift + Kotlin pins for the #1452 accepted gap; the end-arm
  string-value regression **plus its ChatML byte-identity control** on both
  engines; per-engine truncation suites with negative controls on every
  assertion; catalog-level marker assertions; and `ChatTurnMarkersTests` in
  **both** modules that own the type
- Counts after the late fix: iOS unit 3,431 tests / 282 suites; Kotlin
  turn-marker suite 13; harness 76
- No rebase: zero file overlap with the one upstream commit (`e6f07e52`), verified
  by set intersection rather than inspection

## Device QA

Required — `AppDependencies.switchActiveModel` is inside
`#if !targetEnvironment(simulator)`, so the simulator build never compiles or
renders it.

1. Install on a real device (6.5 GB+ RAM tier — see `ModelRegistry.minRAM`).
2. Settings → model management → switch the active model **Gemma 4 E2B ⇄ Qwen 3 4B**.
3. After each switch, start a simulation and confirm it runs to completion with
   agent output parsing normally.
4. Repeat once in the reverse order, to catch a stale service being reused.

**The truncation firing is not reproducible by device QA**, and that is expected:
no shipped model has been observed spelling its own markers as plaintext
(`docs/models/eval-log.md` § "Spelled-out chat-template markers"). What QA covers
is that threading the markers through did not break the model-switch path. The
truncation itself is covered by the unit pins on both engines.

Closes #1422
