### PR TITLE
✨ feat: ADR-029 highlights バッチ2 + conditional シナリオの refuse

### DIFF
--- a/docs/decisions/ADR-029.md
+++ b/docs/decisions/ADR-029.md
@@ -166,7 +166,10 @@ turn selection into a schema-valid highlight file. Non-negotiable properties:
   `excerpt[].phase` outside the `PhaseType` catalog fails here too, not only at
   extraction — then phase eligibility and the within-round bound
   checked via `phase_index` against the entry's `phases` list — the index
-  must name an eligible phase with no outcome-class phase before it — and
+  must name an eligible phase with no outcome-class phase before it, and a
+  scenario whose `phases` contains `conditional` is refused as a class, that
+  list flattening both branches in while `phase_path` does not, which leaves
+  `phase_index` underivable until #1473 lands — and
   the round window recomputed from `gallery.json`'s `rounds` honoring
   `window_override`), `excerpt[].persona_index` cross-checked against the
   sibling YAML's `personas:` list (Decision 1 — the index must name the

--- a/docs/gallery/README.md
+++ b/docs/gallery/README.md
@@ -401,7 +401,7 @@ covers the workflow and the taste calls the gate cannot make.
 ### Curation norms
 
 The gate checks structure. Whether a highlight is worth publishing is a taste
-call, and these four are what the first two batches taught.
+call, and these are what the batches so far have taught.
 
 - **Scenario fitness varies, and it is the biggest factor.** Scenarios whose
   product *is* the utterance (comedy, improv, one-liners) excerpt well.
@@ -424,6 +424,26 @@ call, and these four are what the first two batches taught.
   (「この抜粋を生んだ4人のうち、特にクセの強い2人の設定。」),
   `asch_conformity_v1` only implies it
   (「サクラ4人の"後"に答えさせられるナオキの設定。」), and both are accepted.
+- **An `eliminate` scenario leaks its outcome through the excerpt's speaker
+  set.** Quoting N speakers in round *k* and N−1 of those same speakers in
+  round *k+1* identifies the eliminated speaker by omission. ADR-029's
+  position rule is keyed to phase visibility within a round, so it cannot see
+  this — it is purely a curation trap. More weakly, *any* round *k+1* quote
+  proves that speaker survived round *k*. `oogiri_knockout_v1`'s batch-2
+  excerpt is round 1 only, because its round-1 eliminee
+  (`理屈っぽい教授モドキ`) was precisely the speaker a two-round excerpt would
+  have dropped. The safe fallback is a single-round excerpt, which carries no
+  elimination-order information at all.
+- **Check a pick against the speaking persona's own `例:`.** A persona
+  description's `例:` lines are part of the prompt, so when one of them
+  happens to be an ideal answer to the topic, the model reproduces it
+  verbatim rather than inventing anything. `oogiri_knockout_v1`'s
+  `一言必殺のゼロ次` emitted its example line unchanged in two independent
+  draws, so it is in neither the excerpt nor the hook fragment. Publishing
+  such a line would show the flagship "real run" quoting its own prompt — and
+  the full YAML is one tap away in the app, so a reader can see it. This bites
+  hardest for a `yaml_hook` persona slice, since the excerpt and the `例:`
+  would then render on the same screen.
 
 **Excerpt** and **hook fragment** are different things. The excerpt is the
 quoted conversation; the hook fragment is the slice of YAML shown beneath it.

--- a/docs/gallery/gallery.json
+++ b/docs/gallery/gallery.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-08-08T00:00:00Z",
+  "updated_at": "2026-08-14T00:00:00Z",
   "scenarios": [
     {
       "id": "asch_conformity_v1",
@@ -134,6 +134,8 @@
       "language": "ja",
       "yaml_url": "kinku_bokete_v1.yaml",
       "yaml_sha256": "6c880ebdad761f953251b4f2c623fa8139e3dd0b011825dff08378e2418215a7",
+      "highlight_url": "highlights/kinku_bokete_v1.json",
+      "highlight_sha256": "a5d7f7c877465225c69da46e2bef9e597499bcb2ba839f89e103a07ffb176342",
       "added_at": "2026-06-13"
     },
     {
@@ -178,6 +180,8 @@
       "language": "ja",
       "yaml_url": "oogiri_knockout_v1.yaml",
       "yaml_sha256": "9675bfa9cda85c848cfed97dbdc568280ddeebc06c466f4cbd24cbb8393cd5b3",
+      "highlight_url": "highlights/oogiri_knockout_v1.json",
+      "highlight_sha256": "2321c040840a0796e769a07f506814c33dcaa2ebd99ff11b71dd1a44bfb459b7",
       "added_at": "2026-06-13"
     },
     {

--- a/docs/gallery/highlights/kinku_bokete_v1.json
+++ b/docs/gallery/highlights/kinku_bokete_v1.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "scenario_ref": {
+    "id": "kinku_bokete_v1",
+    "yaml_sha256": "6c880ebdad761f953251b4f2c623fa8139e3dd0b011825dff08378e2418215a7"
+  },
+  "source": {
+    "model": "gemma-4-e2b-q4-k-m",
+    "run_id": "20260814-095314-58a6",
+    "generated_at": "2026-08-14"
+  },
+  "excerpt": [
+    {
+      "agent": "理屈屋ロジ子",
+      "round": 1,
+      "phase": "speak_all",
+      "phase_index": 1,
+      "persona_index": 0,
+      "source_field": "statement",
+      "text": "この状況における体温調節の最適化を図るには、着ぐるみ内部の熱伝導率を再計算すべきでしょう。"
+    },
+    {
+      "agent": "比喩王メタ夫",
+      "round": 1,
+      "phase": "speak_all",
+      "phase_index": 1,
+      "persona_index": 1,
+      "source_field": "statement",
+      "text": "これはまるで、人類が最後の文明を築いた時の孤独な聖域だな。"
+    },
+    {
+      "agent": "当事者ヅラ子",
+      "round": 1,
+      "phase": "speak_all",
+      "phase_index": 1,
+      "persona_index": 3,
+      "source_field": "statement",
+      "text": "この着ぐるみの中、実は一番のファンなんですわよ。汗だくになっても、その熱意は冷めませんわ。"
+    }
+  ],
+  "yaml_hook": {
+    "kind": "persona",
+    "fragment": "  - name: 比喩王メタ夫\n    description: >\n      【立場】何でも壮大な比喩に変換する詩人気取り\n      【目的】しょうもない状況を神話や歴史級のスケールで例えて笑いを取る。\n      例:「これが現代のノアの方舟か」「人類が火を手にした日と同じ顔だ」\n  - name: 当事者ヅラ子\n    description: >\n      【立場】写真の中の人物に勝手になりきる一人称芸人\n      【目的】写っている本人の心の声として語ることで笑いを取る。\n      例:「私だってこうなる予定じゃなかった」「母さん、見てるか」",
+    "caption": "片方は写真の外まで話を広げ、片方は写真の中に入り込む。禁じられた一言を避ける道は、どちらへ逃げるかで変わる。"
+  },
+  "teaser": "誰もが真っ先に言いたくなる一言だけが、封じられている。残った回り道の選び方が、そのまま芸風になる。",
+  "window_override": false,
+  "content_filter_applied": true
+}

--- a/docs/gallery/highlights/oogiri_knockout_v1.json
+++ b/docs/gallery/highlights/oogiri_knockout_v1.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "scenario_ref": {
+    "id": "oogiri_knockout_v1",
+    "yaml_sha256": "9675bfa9cda85c848cfed97dbdc568280ddeebc06c466f4cbd24cbb8393cd5b3"
+  },
+  "source": {
+    "model": "gemma-4-e2b-q4-k-m",
+    "run_id": "20260814-093449-bccc",
+    "generated_at": "2026-08-14"
+  },
+  "excerpt": [
+    {
+      "agent": "不謹慎すれすれ黒岩",
+      "round": 1,
+      "phase": "speak_all",
+      "phase_index": 1,
+      "persona_index": 1,
+      "source_field": "statement",
+      "text": "夕飯出るなら押すしかなくない？"
+    },
+    {
+      "agent": "ほのぼの天然のなぎ",
+      "round": 1,
+      "phase": "speak_all",
+      "phase_index": 1,
+      "persona_index": 2,
+      "source_field": "statement",
+      "text": "ボタン押す前に、夕飯のメニューを教えてください。"
+    },
+    {
+      "agent": "理屈っぽい教授モドキ",
+      "round": 1,
+      "phase": "speak_all",
+      "phase_index": 1,
+      "persona_index": 3,
+      "source_field": "statement",
+      "text": "世界が終わる確率と夕飯の満足度、どちらがより非合理的な選択なのかというパラドックスだ。"
+    }
+  ],
+  "yaml_hook": {
+    "kind": "persona",
+    "fragment": "  - name: ほのぼの天然のなぎ\n    description: >\n      【立場】本気でズレた発言をする素の天然。\n      【目的】悪気なく的外れなことを言って和ませる。\n      例:「夕飯、私カレーがいいな。」\n  - name: 理屈っぽい教授モドキ\n    description: >\n      【立場】何でも小難しく分析したがる自称インテリ。\n      【目的】大げさな理屈で一言をこじらせる。\n      例:「これは選択の不可能性、いわば現代の実存的ジレンマだ。」",
+    "caption": "片方は何も考えずに即答し、片方は考えているうちに答えを見失う。毎ラウンド一人ずつ消える場では、この差がそのまま明暗になる。"
+  },
+  "teaser": "一言だけで戦って、面白くなかった者から消えていく。最後の一人になるまでの3ラウンドをアプリで。",
+  "window_override": false,
+  "content_filter_applied": true
+}

--- a/scripts/gallery_highlight_extract.py
+++ b/scripts/gallery_highlight_extract.py
@@ -390,7 +390,8 @@ def main():
     blocklist = ghv.load_blocklist(args.blocklist)
     failures = ghv.check_content(
         doc, entry, blocklist, f"[{args.id}]",
-        personas=(persona_names, None), allowed_model_ids=allowed_model_ids)
+        personas=(persona_names, None), allowed_model_ids=allowed_model_ids,
+        yaml_has_conditional=ghv.scenario_declares_conditional(scenario))
     if failures:
         for line in failures:
             print(line, file=sys.stderr)

--- a/scripts/gallery_highlight_extract.py
+++ b/scripts/gallery_highlight_extract.py
@@ -36,10 +36,9 @@ Usage:
 Hard-fails (each with a distinct, greppable message):
   - the scenario YAML declares the `secret:` mechanism (ADR-029 Decision 2 —
     the spoiler rules are unvalidated for it);
-  - the scenario uses a `conditional` phase — its branch sub-phases are
-    flattened into the entry's `phases` while `phase_path` is not, so
-    `phase_index` cannot be derived (#1473). Raised by the shared
-    `_check_position`, so the gate refuses the same class;
+  - the scenario uses a `conditional` phase, whose `phase_index` cannot be
+    derived (#1473) — raised by the shared `_check_position`, so the gate
+    refuses the same class;
   - a `phase_started` line carrying no usable `phase_path`;
   - a transcript phase name outside the `PhaseType` catalog (a new phase type
     landed; classify it in ADR-029 Decision 3 first);
@@ -109,11 +108,10 @@ def annotate(lines):
     `agent_output` lines carry no `round` (ADR-029 Decision 2's mechanical
     note) — it comes from the preceding `round_started`. `phase_index` comes
     from the enclosing `phase_started.phase_path[0]`, which indexes the
-    scenario's TOP-LEVEL phase list. That equals the index into the entry's
-    `phases` only while the scenario has no `conditional` — a branch's
-    sub-phases are flattened into `phases` but reached via a nested
-    `phase_path`. `_check_position` refuses that whole scenario class (#1473),
-    which is what keeps the first path element meaningful here.
+    scenario's TOP-LEVEL phase list — equal to the index into the entry's
+    `phases` only while the scenario has no `conditional`. What keeps the first
+    path element meaningful here is that `_check_position` refuses that whole
+    scenario class (#1473); its comment has the skew.
     """
     context, round_no, phase_idx = {}, None, None
     for lineno in sorted(lines):
@@ -126,10 +124,9 @@ def annotate(lines):
         elif event == "phase_started":
             path = obj.get("phase_path")
             # Refuse rather than default to 0. The harness always writes this
-            # field, so a missing one means the log is not what it claims; a
-            # fallback would assert "top-level phase 0" on the excerpt's behalf,
-            # and every downstream check would then read that invention as
-            # measured fact.
+            # field, so a missing one means the log is not what it claims — and
+            # a fallback would assert "top-level phase 0" on the excerpt's
+            # behalf, which every downstream check then reads as measured fact.
             if not isinstance(path, list) or not path:
                 die(f"line {lineno} — `phase_started` carries no usable "
                     "`phase_path`, so phase_index cannot be derived for any pick "

--- a/scripts/gallery_highlight_extract.py
+++ b/scripts/gallery_highlight_extract.py
@@ -36,6 +36,11 @@ Usage:
 Hard-fails (each with a distinct, greppable message):
   - the scenario YAML declares the `secret:` mechanism (ADR-029 Decision 2 —
     the spoiler rules are unvalidated for it);
+  - the scenario uses a `conditional` phase — its branch sub-phases are
+    flattened into the entry's `phases` while `phase_path` is not, so
+    `phase_index` cannot be derived (#1473). Raised by the shared
+    `_check_position`, so the gate refuses the same class;
+  - a `phase_started` line carrying no usable `phase_path`;
   - a transcript phase name outside the `PhaseType` catalog (a new phase type
     landed; classify it in ADR-029 Decision 3 first);
   - a pick that is not an `agent_output` line, or whose phase / source_field /
@@ -103,8 +108,12 @@ def annotate(lines):
 
     `agent_output` lines carry no `round` (ADR-029 Decision 2's mechanical
     note) — it comes from the preceding `round_started`. `phase_index` comes
-    from the enclosing `phase_started.phase_path[0]`; gallery scenarios have
-    flat phase lists, so the first path element is the index into `phases`.
+    from the enclosing `phase_started.phase_path[0]`, which indexes the
+    scenario's TOP-LEVEL phase list. That equals the index into the entry's
+    `phases` only while the scenario has no `conditional` — a branch's
+    sub-phases are flattened into `phases` but reached via a nested
+    `phase_path`. `_check_position` refuses that whole scenario class (#1473),
+    which is what keeps the first path element meaningful here.
     """
     context, round_no, phase_idx = {}, None, None
     for lineno in sorted(lines):
@@ -115,7 +124,17 @@ def annotate(lines):
         if event == "round_started":
             round_no = obj.get("round")
         elif event == "phase_started":
-            phase_idx = (obj.get("phase_path") or [0])[0]
+            path = obj.get("phase_path")
+            # Refuse rather than default to 0. The harness always writes this
+            # field, so a missing one means the log is not what it claims; a
+            # fallback would assert "top-level phase 0" on the excerpt's behalf,
+            # and every downstream check would then read that invention as
+            # measured fact.
+            if not isinstance(path, list) or not path:
+                die(f"line {lineno} — `phase_started` carries no usable "
+                    "`phase_path`, so phase_index cannot be derived for any pick "
+                    "in this phase")
+            phase_idx = path[0]
         context[lineno] = (round_no, phase_idx)
     return context
 

--- a/scripts/gallery_highlight_validate.py
+++ b/scripts/gallery_highlight_validate.py
@@ -462,7 +462,7 @@ def _check_yaml_hook_fragment(doc, where):
     return failures
 
 
-def _check_position(doc, entry, where):
+def _check_position(doc, entry, where, yaml_has_conditional):
     """Decision 3's two-part position rule, against the index entry.
 
     Also the home of the `conditional`-scenario refusal: the rule is stated in
@@ -497,13 +497,23 @@ def _check_position(doc, entry, where):
     # the remaining phase-index checks read an index this entry cannot supply
     # meaningfully. It also skips the round-window arms, which would have been
     # derivable; they are worth nothing on a highlight that cannot ship.
-    if "conditional" in phases:
-        return [f"highlight: conditional scenario — {where} the entry's `phases` list "
-                "contains `conditional`, whose branch sub-phases are flattened into "
-                "it. `phase_index` is not branch-aware, so neither the index nor the "
-                "within-round bound can be derived correctly (#1473). Highlights are "
-                "refused for this scenario class until that lands — including a pick "
-                "before the conditional, which is sound but not distinguishable here."]
+    #
+    # Both sources are consulted, and either one alone triggers the refusal. The
+    # index's `phases` is denormalized from the YAML and nothing on a highlight
+    # PR's path re-derives it (see `scenario_declares_conditional`), so keying on
+    # it alone leaves a drifted index able to disable the guard; keying on the
+    # YAML alone would miss an index that claims a conditional the YAML no longer
+    # has. Disagreement between them is itself a reason not to publish.
+    if "conditional" in phases or yaml_has_conditional:
+        source = ("the entry's `phases` list" if "conditional" in phases
+                  else "the sibling scenario YAML's `phases:`")
+        return [f"highlight: conditional scenario — {where} {source} contains "
+                "`conditional`, whose branch sub-phases are flattened into the "
+                "index's list. `phase_index` is not branch-aware, so neither the "
+                "index nor the within-round bound can be derived correctly (#1473). "
+                "Highlights are refused for this scenario class until that lands — "
+                "including a pick before the conditional, which is sound but not "
+                "distinguishable here."]
     if not isinstance(rounds, int) or isinstance(rounds, bool) or rounds < 1:
         return [f"highlight: schema — {where} gallery.json entry has no usable "
                 "`rounds` value to compute the round window"]
@@ -627,6 +637,33 @@ def scenario_persona_names(scenario):
     return names
 
 
+def scenario_declares_conditional(scenario):
+    """-> True / False from the scenario YAML's TOP-LEVEL `phases:`, or None.
+
+    Read from the YAML rather than from `gallery.json`'s denormalized `phases`
+    because nothing on a highlight PR's path re-derives that field: the gate
+    never reads it against the YAML, and its only cross-check
+    (`GallerySeedYAMLTests.galleryPhasesMatchYAML`) sits in the iOS suite, which
+    `precommit-gate-classify.sh` skips for a `docs/`-only changeset — the shape
+    every highlight batch has. A `phases` list that lost its `conditional`
+    would otherwise disable the refusal silently.
+
+    `None` means the list could not be read at all; the caller treats that as
+    "cannot verify" rather than "no conditional".
+    """
+    if not isinstance(scenario, dict):
+        return None
+    phases = scenario.get("phases")
+    if not isinstance(phases, list) or not phases:
+        return None
+    for phase in phases:
+        if not isinstance(phase, dict) or not isinstance(phase.get("type"), str):
+            return None
+        if phase["type"] == "conditional":
+            return True
+    return False
+
+
 def _check_persona_index(doc, personas, where):
     """Cross-reference `excerpt[].persona_index` against the sibling YAML.
 
@@ -681,7 +718,8 @@ def _check_persona_index(doc, personas, where):
     return failures
 
 
-def check_content(doc, entry, blocklist, where, personas, allowed_model_ids):
+def check_content(doc, entry, blocklist, where, personas, allowed_model_ids,
+                  yaml_has_conditional):
     """Every rule derivable from the highlight doc + its index entry.
 
     Shared by the extractor (fail-fast) and the gate (enforcement). Excludes
@@ -698,9 +736,11 @@ def check_content(doc, entry, blocklist, where, personas, allowed_model_ids):
     once excluded a member the vagueness had covered. Widen, do not enumerate.
 
     `personas` is ``_read_persona_names``'s `(names, reason)` pair;
-    `allowed_model_ids` is ``registry_model_ids`` ∪ ``RETIRED_MODEL_IDS``. Both
-    are required rather than defaulted, so a caller cannot skip a check by
-    omission — the gate is the only place either failure would surface.
+    `allowed_model_ids` is ``registry_model_ids`` ∪ ``RETIRED_MODEL_IDS``;
+    `yaml_has_conditional` is ``scenario_declares_conditional``'s tri-state read
+    of the sibling YAML (`None` = unreadable). All three are required rather
+    than defaulted, so a caller cannot skip a check by omission — the gate is
+    the only place any of these failures would surface.
     """
     failures = _check_schema(doc, where)
     failures += _check_excerpt_shape(doc, where)
@@ -708,7 +748,7 @@ def check_content(doc, entry, blocklist, where, personas, allowed_model_ids):
     failures += _check_source_model(doc, allowed_model_ids, where)
     failures += _check_yaml_hook_secret(doc, where)
     failures += _check_yaml_hook_fragment(doc, where)
-    failures += _check_position(doc, entry, where)
+    failures += _check_position(doc, entry, where, yaml_has_conditional)
     failures += check_blocklist(doc, blocklist, where)
     return failures
 
@@ -719,6 +759,21 @@ def check_content(doc, entry, blocklist, where, personas, allowed_model_ids):
 def _entry_index(gallery_json):
     with open(gallery_json, encoding="utf-8") as f:
         return json.load(f).get("scenarios") or []
+
+
+def _read_scenario(yaml_path):
+    """-> the parsed sibling scenario YAML, or None if it cannot be read.
+
+    Both `_read_persona_names` and the conditional refusal need the same file;
+    parsing it once here keeps them from disagreeing about what it says.
+    """
+    if yaml is None:
+        return None
+    try:
+        with open(yaml_path, encoding="utf-8") as f:
+            return yaml.safe_load(f)
+    except (OSError, UnicodeDecodeError, yaml.YAMLError, RecursionError):
+        return None
 
 
 def _read_persona_names(yaml_path):
@@ -841,6 +896,10 @@ def validate_repo(gallery_json, gallery_dir, blocklist_path, registry_swift):
 
         yaml_path = os.path.join(gallery_dir, os.path.basename(entry.get("yaml_url", "")))
         personas = (None, f"the sibling scenario YAML {yaml_path} is missing")
+        # Bound here, like `personas`, so the missing-YAML path below does not
+        # leave it unbound. `None` = cannot verify; that path already fails the
+        # highlight on the persona check, so it never ships unverified.
+        yaml_has_conditional = None
         if not os.path.isfile(yaml_path):
             failures.append(
                 f"highlight: yaml_sha256 mismatch — id={entry_id} sibling YAML "
@@ -855,10 +914,13 @@ def validate_repo(gallery_json, gallery_dir, blocklist_path, registry_swift):
                     f"YAML bytes hash to {yaml_sha}. Regenerate or delete the highlight "
                     "(ADR-029 Decision 1: highlights are pinned snapshots)")
             personas = _read_persona_names(yaml_path)
+            yaml_has_conditional = scenario_declares_conditional(
+                _read_scenario(yaml_path))
 
         failures += check_content(
             doc, entry, blocklist, where,
-            personas=personas, allowed_model_ids=allowed_model_ids)
+            personas=personas, allowed_model_ids=allowed_model_ids,
+            yaml_has_conditional=yaml_has_conditional)
 
     for path in sorted(on_disk - referenced):
         rel = os.path.relpath(path, os.path.dirname(gallery_dir))

--- a/scripts/gallery_highlight_validate.py
+++ b/scripts/gallery_highlight_validate.py
@@ -463,13 +463,37 @@ def _check_yaml_hook_fragment(doc, where):
 
 
 def _check_position(doc, entry, where):
-    """Decision 3's two-part position rule, against the index entry."""
+    """Decision 3's two-part position rule, against the index entry.
+
+    Also the home of the `conditional`-scenario refusal: the rule is stated in
+    terms of `phase_index`, so the scenario class whose `phase_index` cannot be
+    derived is refused where that index is read, not at an unrelated callsite.
+    Being here means the extractor inherits it too — `check_content` dispatches
+    this function for both callers, so the two cannot disagree about which
+    highlights are publishable.
+    """
     failures = []
     phases = entry.get("phases")
     rounds = entry.get("rounds")
     if not isinstance(phases, list) or not phases:
         return [f"highlight: schema — {where} gallery.json entry has no `phases` list "
                 "to check the within-round bound against"]
+    # Refused as a class, not merely unsupported. `phases` is the FULLY-FLATTENED
+    # depth-first list (the `conditional`'s own entry, then its then-branch, then
+    # its else-branch), while a transcript's `phase_path` indexes the TOP-LEVEL
+    # list — so `phase_index` means different things on the two sides, and the
+    # prefix below spans branches that never ran together in one round. Both
+    # halves fail loudly today, but only because no shipped scenario continues
+    # past its conditional; one that did could match `phases[idx]` by coincidence
+    # and evaluate the spoiler prefix over the wrong range, silently. Returning
+    # early keeps that speculation out of the report: every later check here
+    # reads an index this entry cannot supply meaningfully.
+    if "conditional" in phases:
+        return [f"highlight: conditional scenario — {where} the entry's `phases` list "
+                "contains `conditional`, whose branch sub-phases are flattened into "
+                "it. `phase_index` is not branch-aware, so neither the index nor the "
+                "within-round bound can be derived correctly (#1473). Highlights are "
+                "refused for this scenario class until that lands."]
     if not isinstance(rounds, int) or isinstance(rounds, bool) or rounds < 1:
         return [f"highlight: schema — {where} gallery.json entry has no usable "
                 "`rounds` value to compute the round window"]

--- a/scripts/gallery_highlight_validate.py
+++ b/scripts/gallery_highlight_validate.py
@@ -478,32 +478,26 @@ def _check_position(doc, entry, where, yaml_has_conditional):
     if not isinstance(phases, list) or not phases:
         return [f"highlight: schema — {where} gallery.json entry has no `phases` list "
                 "to check the within-round bound against"]
-    # Refused as a class, and deliberately wider than the broken cases. `phases`
-    # is the FULLY-FLATTENED depth-first list (the `conditional`'s own entry,
-    # then its then-branch, then its else-branch), while a transcript's
-    # `phase_path` indexes the TOP-LEVEL list — so `phase_index` means different
-    # things on the two sides, and the prefix below spans branches that never ran
-    # together in one round.
+    # Refused as a class, deliberately wider than the broken cases — the failure
+    # message says so. `phases` is the FULLY-FLATTENED depth-first list (the
+    # `conditional`, then its then-branch, then its else-branch) while a
+    # transcript's `phase_path` indexes the TOP-LEVEL list, so the outcome-phase
+    # prefix `phases[:idx]` spans branches that never ran together in one round.
+    # Telling a sound pick from a skewed one needs the branch structure this
+    # function does not have, which is #1473's work.
     #
-    # A pick BEFORE the conditional in the top-level list is unaffected by the
-    # skew and validates correctly on pre-refusal code; every shipped conditional
-    # scenario has its conditional last, so that is the only shape a curator can
-    # hit here today. It is refused anyway: telling the two apart needs the
-    # branch structure this function does not have, which is #1473's work.
-    # Picks at or inside the conditional fail loudly today, but only because no
+    # Picks at or inside the conditional fail loudly today only because no
     # shipped scenario continues past its conditional; one that did could match
-    # `phases[idx]` by coincidence and evaluate the spoiler prefix over the wrong
-    # range, silently. Returning early keeps that speculation out of the report —
-    # the remaining phase-index checks read an index this entry cannot supply
-    # meaningfully. It also skips the round-window arms, which would have been
-    # derivable; they are worth nothing on a highlight that cannot ship.
+    # `phases[idx]` by coincidence and evaluate that prefix over the wrong range,
+    # silently. Returning early keeps such speculation out of the report, and
+    # drops the round-window arms too — derivable, but worth nothing on a
+    # highlight that cannot ship.
     #
-    # Both sources are consulted, and either one alone triggers the refusal. The
-    # index's `phases` is denormalized from the YAML and nothing on a highlight
-    # PR's path re-derives it (see `scenario_declares_conditional`), so keying on
-    # it alone leaves a drifted index able to disable the guard; keying on the
-    # YAML alone would miss an index that claims a conditional the YAML no longer
-    # has. Disagreement between them is itself a reason not to publish.
+    # Either source alone triggers the refusal: a drifted index could otherwise
+    # disable the guard (nothing on a highlight PR's path re-derives `phases` —
+    # see `scenario_declares_conditional`), while keying on the YAML alone would
+    # miss an index claiming a conditional the YAML no longer has. Disagreement
+    # between them is itself a reason not to publish.
     if "conditional" in phases or yaml_has_conditional:
         source = ("the entry's `phases` list" if "conditional" in phases
                   else "the sibling scenario YAML's `phases:`")
@@ -764,8 +758,10 @@ def _entry_index(gallery_json):
 def _read_scenario(yaml_path):
     """-> the parsed sibling scenario YAML, or None if it cannot be read.
 
-    Both `_read_persona_names` and the conditional refusal need the same file;
-    parsing it once here keeps them from disagreeing about what it says.
+    Separate from `_read_persona_names`, which parses the same file again: that
+    one returns names plus a *reason* string its failure text needs, while the
+    conditional refusal wants the document itself and has only a tri-state to
+    report through. Same catch set, so the two agree on what "unreadable" means.
     """
     if yaml is None:
         return None

--- a/scripts/gallery_highlight_validate.py
+++ b/scripts/gallery_highlight_validate.py
@@ -478,22 +478,32 @@ def _check_position(doc, entry, where):
     if not isinstance(phases, list) or not phases:
         return [f"highlight: schema — {where} gallery.json entry has no `phases` list "
                 "to check the within-round bound against"]
-    # Refused as a class, not merely unsupported. `phases` is the FULLY-FLATTENED
-    # depth-first list (the `conditional`'s own entry, then its then-branch, then
-    # its else-branch), while a transcript's `phase_path` indexes the TOP-LEVEL
-    # list — so `phase_index` means different things on the two sides, and the
-    # prefix below spans branches that never ran together in one round. Both
-    # halves fail loudly today, but only because no shipped scenario continues
-    # past its conditional; one that did could match `phases[idx]` by coincidence
-    # and evaluate the spoiler prefix over the wrong range, silently. Returning
-    # early keeps that speculation out of the report: every later check here
-    # reads an index this entry cannot supply meaningfully.
+    # Refused as a class, and deliberately wider than the broken cases. `phases`
+    # is the FULLY-FLATTENED depth-first list (the `conditional`'s own entry,
+    # then its then-branch, then its else-branch), while a transcript's
+    # `phase_path` indexes the TOP-LEVEL list — so `phase_index` means different
+    # things on the two sides, and the prefix below spans branches that never ran
+    # together in one round.
+    #
+    # A pick BEFORE the conditional in the top-level list is unaffected by the
+    # skew and validates correctly on pre-refusal code; every shipped conditional
+    # scenario has its conditional last, so that is the only shape a curator can
+    # hit here today. It is refused anyway: telling the two apart needs the
+    # branch structure this function does not have, which is #1473's work.
+    # Picks at or inside the conditional fail loudly today, but only because no
+    # shipped scenario continues past its conditional; one that did could match
+    # `phases[idx]` by coincidence and evaluate the spoiler prefix over the wrong
+    # range, silently. Returning early keeps that speculation out of the report —
+    # the remaining phase-index checks read an index this entry cannot supply
+    # meaningfully. It also skips the round-window arms, which would have been
+    # derivable; they are worth nothing on a highlight that cannot ship.
     if "conditional" in phases:
         return [f"highlight: conditional scenario — {where} the entry's `phases` list "
                 "contains `conditional`, whose branch sub-phases are flattened into "
                 "it. `phase_index` is not branch-aware, so neither the index nor the "
                 "within-round bound can be derived correctly (#1473). Highlights are "
-                "refused for this scenario class until that lands."]
+                "refused for this scenario class until that lands — including a pick "
+                "before the conditional, which is sound but not distinguishable here."]
     if not isinstance(rounds, int) or isinstance(rounds, bool) or rounds < 1:
         return [f"highlight: schema — {where} gallery.json entry has no usable "
                 "`rounds` value to compute the round window"]

--- a/scripts/jsonl_to_demo_replay.py
+++ b/scripts/jsonl_to_demo_replay.py
@@ -23,16 +23,15 @@ Mapping:
   - `summary`       -> `summary`
   - `event_injected`-> `eventInjected`
   - `pairing_result`-> `pairingResult`
-`phase_index` is taken from the most recent `phase_started.phase_path[0]`,
-which indexes the scenario's TOP-LEVEL phase list. That is the index the demo
-schema expects **only while the preset's phase list is flat**: a `conditional`
-reaches its branch sub-phases through a nested `phase_path`, so their
-top-level index names the conditional rather than the phase that spoke.
-No preset under `Resources/DemoPresets/` uses one today, but four bundled
-presets do (`word_wolf{,_en}`, `target_score_race{,_en}`) — promoting one here
-needs the branch-aware derivation tracked in #1473, not just a re-capture.
-`BundledDemoReplaySource` catches the mismatch only when
-`phases[idx].type` happens not to match the emitted `phase_type`.
+`phase_index` is the most recent `phase_started.phase_path[0]`, an index into
+the scenario's TOP-LEVEL phase list — what the demo schema expects **only while
+the preset's phase list is flat**. A `conditional`'s branch sub-phases are
+reached through a nested `phase_path`, so their top-level index names the
+conditional rather than the phase that spoke, and `BundledDemoReplaySource`
+catches that only when `phases[idx].type` happens not to match the emitted
+`phase_type`. No `Resources/DemoPresets/` preset uses one today; four bundled
+presets do (`word_wolf{,_en}`, `target_score_race{,_en}`), so promoting one
+needs #1473's branch-aware derivation, not just a re-capture.
 
 Recapture workflow (full demo-set swap):
   1. Run each scenario N times through the harness:
@@ -186,10 +185,9 @@ def main():
     turns, code = [], []
     # `phase_idx` starts None, not 0: an event reaching the emit sites below
     # before the first `phase_started` has no index, and 0 would be the same
-    # invention the `phase_path` guard exists to stop — removed from one source
-    # only, it would survive here. (`round_no` is left at 0; this guard is about
-    # `phase_index`, and nothing here has measured what a round-0 turn does
-    # downstream.)
+    # invention the `phase_path` guard refuses — removed from one source only,
+    # it would survive here. (`round_no` is left at 0: nothing here has measured
+    # what a round-0 turn does downstream.)
     round_no, phase_idx, phase_type_cur = 0, None, ""
 
     def emitted_phase_index():
@@ -222,12 +220,11 @@ def main():
             # phase_type — which must equal scenario.phases[phase_index].type
             # (BundledDemoReplaySource rejects the demo otherwise) — has to
             # come from the enclosing phase_started, not the event name.
-            # Refuse rather than default to 0 — the same invention removed from
-            # `gallery_highlight_extract.annotate` (#1474). A fabricated index 0
-            # is usually caught downstream, since the emitted `phase_type` must
-            # equal `scenario.phases[phase_index].type` or BundledDemoReplaySource
-            # rejects the demo; it survives exactly when phases[0] happens to
-            # match, which is the case no reader would think to check.
+            # The index is refused rather than defaulted to 0 — the same
+            # invention removed from `gallery_highlight_extract.annotate`
+            # (#1474). That type equality usually catches a fabricated 0, so it
+            # survives exactly when phases[0] happens to match: the case no
+            # reader would think to check.
             path = l.get("phase_path")
             if not isinstance(path, list) or not path:
                 raise SystemExit(

--- a/scripts/jsonl_to_demo_replay.py
+++ b/scripts/jsonl_to_demo_replay.py
@@ -23,9 +23,16 @@ Mapping:
   - `summary`       -> `summary`
   - `event_injected`-> `eventInjected`
   - `pairing_result`-> `pairingResult`
-`phase_index` is taken from the most recent `phase_started.phase_path[0]`
-(these scenarios have flat phase lists, so the first path element is the
-phase index the demo schema expects).
+`phase_index` is taken from the most recent `phase_started.phase_path[0]`,
+which indexes the scenario's TOP-LEVEL phase list. That is the index the demo
+schema expects **only while the preset's phase list is flat**: a `conditional`
+reaches its branch sub-phases through a nested `phase_path`, so their
+top-level index names the conditional rather than the phase that spoke.
+No preset under `Resources/DemoPresets/` uses one today, but four bundled
+presets do (`word_wolf{,_en}`, `target_score_race{,_en}`) — promoting one here
+needs the branch-aware derivation tracked in #1473, not just a re-capture.
+`BundledDemoReplaySource` catches the mismatch only when
+`phases[idx].type` happens not to match the emitted `phase_type`.
 
 Recapture workflow (full demo-set swap):
   1. Run each scenario N times through the harness:
@@ -177,7 +184,22 @@ def main():
     preset = yaml.safe_load(open(a.preset, encoding="utf-8"))
 
     turns, code = [], []
-    round_no, phase_idx, phase_type_cur = 0, 0, ""
+    # `phase_idx` starts None, not 0: an event reaching the emit sites below
+    # before the first `phase_started` has no index, and 0 would be the same
+    # invention the `phase_path` guard exists to stop — removed from one source
+    # only, it would survive here. (`round_no` is left at 0; this guard is about
+    # `phase_index`, and nothing here has measured what a round-0 turn does
+    # downstream.)
+    round_no, phase_idx, phase_type_cur = 0, None, ""
+
+    def emitted_phase_index():
+        """The current phase index, or refuse. Reads `phase_idx` live."""
+        if phase_idx is None:
+            raise SystemExit(
+                f"jsonl_to_demo_replay: an event in {a.run} precedes the first "
+                "`phase_started`, so phase_index cannot be derived.")
+        return phase_idx
+
     for l in lines:
         if l.get("type") != "event":
             continue
@@ -216,7 +238,7 @@ def main():
         elif e == "agent_output":
             turns.append({
                 "round": round_no,
-                "phase_index": phase_idx,
+                "phase_index": emitted_phase_index(),
                 "phase_type": l["phase_type"],
                 "agent": l["agent"],
                 "fields": ordered_fields(l["fields"]),
@@ -227,7 +249,7 @@ def main():
             value = l.get("value", "")
             code.append({
                 "round": round_no,
-                "phase_index": phase_idx,
+                "phase_index": emitted_phase_index(),
                 "phase_type": phase_type_cur,
                 "summary": value,
                 "payload": {"kind": "sharedAssignment", "value": value},
@@ -239,7 +261,7 @@ def main():
             agent, value = l.get("agent", ""), l.get("value", "")
             code.append({
                 "round": round_no,
-                "phase_index": phase_idx,
+                "phase_index": emitted_phase_index(),
                 "phase_type": phase_type_cur,
                 "summary": f"{agent} assigned: {value}",
                 "payload": {"kind": "assignment", "agent": agent, "value": value},
@@ -247,7 +269,7 @@ def main():
         elif e in CODE_KIND:
             code.append({
                 "round": round_no,
-                "phase_index": phase_idx,
+                "phase_index": emitted_phase_index(),
                 "phase_type": l.get("phase_type") or phase_type_cur,
                 "summary": code_summary(l),
                 "payload": code_payload(l),

--- a/scripts/jsonl_to_demo_replay.py
+++ b/scripts/jsonl_to_demo_replay.py
@@ -200,7 +200,18 @@ def main():
             # phase_type — which must equal scenario.phases[phase_index].type
             # (BundledDemoReplaySource rejects the demo otherwise) — has to
             # come from the enclosing phase_started, not the event name.
-            phase_idx = (l.get("phase_path") or [0])[0]
+            # Refuse rather than default to 0 — the same invention removed from
+            # `gallery_highlight_extract.annotate` (#1474). A fabricated index 0
+            # is usually caught downstream, since the emitted `phase_type` must
+            # equal `scenario.phases[phase_index].type` or BundledDemoReplaySource
+            # rejects the demo; it survives exactly when phases[0] happens to
+            # match, which is the case no reader would think to check.
+            path = l.get("phase_path")
+            if not isinstance(path, list) or not path:
+                raise SystemExit(
+                    f"jsonl_to_demo_replay: a `phase_started` in {a.run} carries "
+                    "no usable `phase_path`, so phase_index cannot be derived.")
+            phase_idx = path[0]
             phase_type_cur = l.get("phase_type", "")
         elif e == "agent_output":
             turns.append({

--- a/scripts/tests/gallery-highlight-test.sh
+++ b/scripts/tests/gallery-highlight-test.sh
@@ -1100,5 +1100,20 @@ runc "$R" python3 scripts/gallery_highlight_extract.py --run run.jsonl --id demo
 expect_fail "C4 a phase_started without phase_path is refused"
 expect_out "no usable \`phase_path\`" "C4 names the missing field"
 
+# C5 — a `phases` list that DRIFTED from its YAML cannot disable the refusal.
+# gallery.json's `phases` is denormalized and nothing on a highlight PR's path
+# re-derives it: this gate never reads it against the YAML, and the iOS-side
+# `GallerySeedYAMLTests.galleryPhasesMatchYAML` is skipped for a `docs/`-only
+# changeset — the shape every highlight batch has. So the refusal reads the YAML
+# too, and this arm is what proves the YAML side is live rather than decorative.
+R="$(new_repo)"; init_index "$R"
+mk_scenario "$R" cond_v1 '["speak_each","conditional","summarize"]'
+# Drop `conditional` from the INDEX only; the YAML still declares it.
+jq '.scenarios |= map(if .id == "cond_v1" then .phases = ["speak_each","summarize"] else . end)' \
+  "$R/docs/gallery/gallery.json" > "$R/t" && mv "$R/t" "$R/docs/gallery/gallery.json"
+mk_highlight "$R" cond_v1 "$EX_OK"; link_highlight "$R" cond_v1
+gate "$R"; expect_fail "C5 a drifted phases list cannot disable the refusal"
+expect_out "sibling scenario YAML" "C5 names the YAML as the source that caught it"
+
 echo "gallery-highlight-test: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/scripts/tests/gallery-highlight-test.sh
+++ b/scripts/tests/gallery-highlight-test.sh
@@ -1049,9 +1049,7 @@ expect_out "Pass --model with the registry id" "E15 names the escape hatch"
 #
 # The refusal lives in `_check_position`, which `check_content` dispatches for
 # BOTH the gate and the extractor — so it is asserted on both, not on whichever
-# one happens to be convenient. C1/C2 are a matched pair: identical fixtures
-# apart from the `conditional` entry itself, so a pass in C2 is what shows C1
-# reddens on that token rather than on anything else the fixture carries.
+# one happens to be convenient.
 #
 # The fixture YAML writes `- type: conditional` with no `then:`/`else:` branch,
 # which a real scenario would never do. Deliberate: the check reads the entry's
@@ -1101,11 +1099,9 @@ expect_fail "C4 a phase_started without phase_path is refused"
 expect_out "no usable \`phase_path\`" "C4 names the missing field"
 
 # C5 — a `phases` list that DRIFTED from its YAML cannot disable the refusal.
-# gallery.json's `phases` is denormalized and nothing on a highlight PR's path
-# re-derives it: this gate never reads it against the YAML, and the iOS-side
-# `GallerySeedYAMLTests.galleryPhasesMatchYAML` is skipped for a `docs/`-only
-# changeset — the shape every highlight batch has. So the refusal reads the YAML
-# too, and this arm is what proves the YAML side is live rather than decorative.
+# Nothing on a highlight PR's path re-derives that denormalized field (why:
+# `scenario_declares_conditional`'s docstring), so the refusal reads the YAML
+# too — this arm is what proves that side live rather than decorative.
 R="$(new_repo)"; init_index "$R"
 mk_scenario "$R" cond_v1 '["speak_each","conditional","summarize"]'
 # Drop `conditional` from the INDEX only; the YAML still declares it.

--- a/scripts/tests/gallery-highlight-test.sh
+++ b/scripts/tests/gallery-highlight-test.sh
@@ -1045,5 +1045,60 @@ expect_out "Pass --model with the registry id" "E15 names the escape hatch"
 # lost its `^\s*` anchor. This is the control for that anchoring — an unrelated
 # string would be rejected under either anchor, i.e. would measure nothing.
 
+# --- conditional-scenario refusal (#1473) ---------------------------------
+#
+# The refusal lives in `_check_position`, which `check_content` dispatches for
+# BOTH the gate and the extractor — so it is asserted on both, not on whichever
+# one happens to be convenient. C1/C2 are a matched pair: identical fixtures
+# apart from the `conditional` entry itself, so a pass in C2 is what shows C1
+# reddens on that token rather than on anything else the fixture carries.
+#
+# The fixture YAML writes `- type: conditional` with no `then:`/`else:` branch,
+# which a real scenario would never do. Deliberate: the check reads the entry's
+# flattened `phases`, never the tree, and mk_scenario cannot nest. An arm that
+# needs the tree belongs with #1473's branch-aware work, not here.
+
+# C1 — a conditional-bearing scenario is refused at the gate.
+R="$(new_repo)"; init_index "$R"
+mk_scenario "$R" cond_v1 '["speak_each","conditional","summarize"]'
+mk_highlight "$R" cond_v1 "$EX_OK"; link_highlight "$R" cond_v1
+gate "$R"; expect_fail "C1 gate refuses a conditional-bearing scenario"
+expect_out "highlight: conditional scenario" "C1 names the refused class"
+expect_out "#1473" "C1 points at the follow-up that lifts it"
+
+# C2 — control: the same fixture without the `conditional` entry passes. Without
+# this, C1 would also pass if the refusal fired on every scenario.
+R="$(new_repo)"; init_index "$R"
+mk_scenario "$R" cond_v1 '["speak_each","summarize"]'
+mk_highlight "$R" cond_v1 "$EX_OK"; link_highlight "$R" cond_v1
+gate "$R"; expect_ok 'C2 the same fixture minus the conditional entry still passes'
+
+# C3 — and the extractor refuses it too, from the shared dispatch rather than a
+# second copy of the predicate.
+R="$(new_repo)"; init_index "$R"
+mk_scenario "$R" cond_v1 '["speak_each","conditional","summarize"]'
+mk_run "$R" "$R/run.jsonl"; mk_selection "$R" "$R/sel.json"
+runc "$R" python3 scripts/gallery_highlight_extract.py --run run.jsonl --id cond_v1 --selection sel.json
+expect_fail "C3 extractor refuses a conditional-bearing scenario"
+expect_out "highlight: conditional scenario" "C3 names the same class as the gate"
+
+# C4 — a `phase_started` with no `phase_path` is refused rather than defaulted
+# to top-level index 0. The earlier `or [0]` fallback asserted a position the
+# transcript never stated, and every downstream check read it as measured.
+R="$(new_repo)"; init_index "$R"; mk_scenario "$R" demo_v1 '["speak_each","summarize"]'
+mk_run "$R" "$R/run.jsonl"; mk_selection "$R" "$R/sel.json"
+python3 - "$R" <<'PY'
+import sys
+p = sys.argv[1] + "/run.jsonl"
+text = open(p, encoding="utf-8").read()
+old = '"phase_type":"speak_each","phase_path":[0]'
+assert text.count(old) == 2, f"anchor matched {text.count(old)} times — probe invalid"
+open(p, "w", encoding="utf-8").write(
+    text.replace(old, '"phase_type":"speak_each"'))
+PY
+runc "$R" python3 scripts/gallery_highlight_extract.py --run run.jsonl --id demo_v1 --selection sel.json
+expect_fail "C4 a phase_started without phase_path is refused"
+expect_out "no usable \`phase_path\`" "C4 names the missing field"
+
 echo "gallery-highlight-test: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/scripts/tests/jsonl-to-demo-replay-test.sh
+++ b/scripts/tests/jsonl-to-demo-replay-test.sh
@@ -103,6 +103,31 @@ if [ -e "$TMP/out2.yaml" ]; then
   echo "FAIL: (b) wrote an output despite refusing" >&2; fail=1
 fi
 
+# (c) Negative — an event BEFORE the first `phase_started` is refused too. The
+# missing-`phase_path` guard (b) covers only one of the two ways the index can
+# be absent; the other was the `phase_idx = 0` initializer, which invented the
+# same index the guard exists to stop.
+cat > "$TMP/early.jsonl" <<'JSONL'
+{"type":"run_start","run_id":"r1","date":"2026-08-14T00:00:00Z","scenario_id":"fixture_v1","language":"ja","model":"Gemma 4 E2B (Q4_K_M)"}
+{"type":"event","t":0.1,"attempt":1,"event":"round_started","round":1,"total_rounds":1}
+{"type":"event","t":0.2,"attempt":1,"event":"agent_output","agent":"アヤ","phase_type":"speak_all","fields":{"statement":"ひとこと。"}}
+{"type":"run_end","run_id":"r1","status":"ok","attempts":1,"duration_sec":1.0}
+JSONL
+set +e
+out_c="$(python3 "$CONVERTER" "$TMP/early.jsonl" "$TMP/preset.yaml" "$TMP/out3.yaml" 2>&1)"
+rc_c=$?
+set -e
+if [ "$rc_c" -eq 0 ]; then
+  echo "FAIL: (c) an event before the first phase_started was accepted: $out_c" >&2; fail=1
+else
+  case "$out_c" in
+    *"precedes the first"*)
+      echo "ok   (c) an event before the first phase_started is refused by name" ;;
+    *)
+      echo "FAIL: (c) refused, but not with the intended message: $out_c" >&2; fail=1 ;;
+  esac
+fi
+
 if [ "$fail" -eq 0 ]; then
   echo "jsonl-to-demo-replay-test: all arms passed"
 else

--- a/scripts/tests/jsonl-to-demo-replay-test.sh
+++ b/scripts/tests/jsonl-to-demo-replay-test.sh
@@ -7,12 +7,10 @@
 # converter as a fixture path for the ADR-022 §D4 coverage gate and never
 # executes it. This file executes it.
 #
-# Today it covers one thing: `phase_index` is derived from the transcript's
-# `phase_started.phase_path[0]` and a missing `phase_path` is refused rather
-# than defaulted to 0 (#1474 — the same invention was removed from
-# gallery_highlight_extract.annotate, whose arm is C4 in
-# gallery-highlight-test.sh). A guard with no arm is silently unverified, and
-# this one is otherwise unreachable from any in-repo test.
+# Today it covers one thing: `phase_index` derivation and its refusals (#1474 —
+# the same invention was removed from gallery_highlight_extract.annotate, whose
+# arm is C4 in gallery-highlight-test.sh). A guard with no arm is silently
+# unverified, and this one is otherwise unreachable from any in-repo test.
 #
 # CI-wired via the `scripts/tests/*-test.sh` naming convention (the
 # `shell-tests` job, ubuntu / bash 5+). The converter imports PyYAML at module
@@ -97,8 +95,8 @@ else
       echo "FAIL: (b) refused, but not with the intended message: $out" >&2; fail=1 ;;
   esac
 fi
-# Spelled as an `if` rather than `[ … ] && { … }`: under `set -e` the latter's
-# status when the test is false is a subtlety this file should not lean on.
+# An `if`, not `[ … ] && { … }` — under `set -e` the latter's false-test status
+# is a subtlety this file should not lean on.
 if [ -e "$TMP/out2.yaml" ]; then
   echo "FAIL: (b) wrote an output despite refusing" >&2; fail=1
 fi

--- a/scripts/tests/jsonl-to-demo-replay-test.sh
+++ b/scripts/tests/jsonl-to-demo-replay-test.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# scripts/tests/jsonl-to-demo-replay-test.sh — runtime arms for
+# scripts/jsonl_to_demo_replay.py.
+#
+# Distinct from demo-replay-event-coverage-test.sh, which only *locates* the
+# converter as a fixture path for the ADR-022 §D4 coverage gate and never
+# executes it. This file executes it.
+#
+# Today it covers one thing: `phase_index` is derived from the transcript's
+# `phase_started.phase_path[0]` and a missing `phase_path` is refused rather
+# than defaulted to 0 (#1474 — the same invention was removed from
+# gallery_highlight_extract.annotate, whose arm is C4 in
+# gallery-highlight-test.sh). A guard with no arm is silently unverified, and
+# this one is otherwise unreachable from any in-repo test.
+#
+# CI-wired via the `scripts/tests/*-test.sh` naming convention (the
+# `shell-tests` job, ubuntu / bash 5+). The converter imports PyYAML at module
+# level, which that job pre-installs. Also runs under macOS /bin/bash 3.2.
+set -euo pipefail
+
+command -v python3 >/dev/null 2>&1 || { echo "ERROR: python3 missing" >&2; exit 1; }
+python3 -c "import yaml" 2>/dev/null || {
+  echo "ERROR: PyYAML not available — 'python3 -m pip install pyyaml'" >&2; exit 1; }
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+CONVERTER="$REPO_ROOT/scripts/jsonl_to_demo_replay.py"
+[ -f "$CONVERTER" ] || {
+  echo "FAIL: converter missing at $CONVERTER (renamed? update CONVERTER)" >&2; exit 1; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+fail=0
+
+# `id` is the only key the converter requires of the preset; everything else it
+# reads through `.get()`. Keeping the fixture minimal is deliberate — an arm
+# that borrowed a real gallery YAML would redden when that scenario is edited.
+cat > "$TMP/preset.yaml" <<'YAML'
+id: fixture_v1
+name: Fixture
+description: fixture preset
+YAML
+
+# `phase_path` is [2], NOT [0]: the removed fallback invented 0, so a fixture
+# sitting at 0 could not tell derivation from invention.
+cat > "$TMP/run.jsonl" <<'JSONL'
+{"type":"run_start","run_id":"r1","date":"2026-08-14T00:00:00Z","scenario_id":"fixture_v1","language":"ja","model":"Gemma 4 E2B (Q4_K_M)"}
+{"type":"event","t":0.1,"attempt":1,"event":"round_started","round":1,"total_rounds":1}
+{"type":"event","t":0.2,"attempt":1,"event":"phase_started","phase_type":"speak_all","phase_path":[2]}
+{"type":"event","t":0.3,"attempt":1,"event":"agent_output","agent":"アヤ","phase_type":"speak_all","fields":{"statement":"ひとこと。"}}
+{"type":"run_end","run_id":"r1","status":"ok","attempts":1,"duration_sec":1.0}
+JSONL
+# `run_end` is a LIFECYCLE line (`type: run_end`), not an event — the converter's
+# `type != "event"` filter skips it before the ADR-022 §D4 unknown-event guard.
+# Writing it as `type: event` (as gallery-highlight-test.sh's mk_run does, where
+# no such guard exists) makes this fixture fail for a reason the arm is not about.
+
+# (a) Positive — converts, and the turn carries the index the transcript stated.
+if python3 "$CONVERTER" "$TMP/run.jsonl" "$TMP/preset.yaml" "$TMP/out.yaml" >/dev/null 2>&1; then
+  got="$(python3 -c "
+import yaml, sys
+d = yaml.safe_load(open(sys.argv[1], encoding='utf-8'))
+print(','.join(str(t['phase_index']) for t in d['turns']))" "$TMP/out.yaml")"
+  if [ "$got" = "2" ]; then
+    echo "ok   (a) phase_index derived from phase_path"
+  else
+    echo "FAIL: (a) expected phase_index '2', got '$got'" >&2; fail=1
+  fi
+else
+  echo "FAIL: (a) converter rejected a well-formed transcript" >&2; fail=1
+fi
+
+# (b) Negative — a `phase_started` with no `phase_path` is refused. The anchor
+# assertion is what stops a silently-no-op edit from reading as a pass here.
+python3 - "$TMP" <<'PY'
+import sys
+p = sys.argv[1] + "/run.jsonl"
+text = open(p, encoding="utf-8").read()
+old = ',"phase_path":[2]'
+assert text.count(old) == 1, f"anchor matched {text.count(old)} times — probe invalid"
+open(sys.argv[1] + "/nopath.jsonl", "w", encoding="utf-8").write(text.replace(old, ""))
+PY
+set +e
+out="$(python3 "$CONVERTER" "$TMP/nopath.jsonl" "$TMP/preset.yaml" "$TMP/out2.yaml" 2>&1)"
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  echo "FAIL: (b) a missing phase_path was accepted (rc=0): $out" >&2; fail=1
+else
+  case "$out" in
+    *"no usable \`phase_path\`"*)
+      echo "ok   (b) a missing phase_path is refused by name" ;;
+    *)
+      # A NameError or a TypeError also exits non-zero, so rc alone cannot tell
+      # "refused" from "crashed" — the first cut of this guard referenced two
+      # out-of-scope identifiers and would have failed exactly that way.
+      echo "FAIL: (b) refused, but not with the intended message: $out" >&2; fail=1 ;;
+  esac
+fi
+# Spelled as an `if` rather than `[ … ] && { … }`: under `set -e` the latter's
+# status when the test is false is a subtlety this file should not lean on.
+if [ -e "$TMP/out2.yaml" ]; then
+  echo "FAIL: (b) wrote an output despite refusing" >&2; fail=1
+fi
+
+if [ "$fail" -eq 0 ]; then
+  echo "jsonl-to-demo-replay-test: all arms passed"
+else
+  echo "jsonl-to-demo-replay-test: FAILED" >&2
+fi
+exit "$fail"


### PR DESCRIPTION
## Summary

ADR-029 gallery highlights バッチ2。`kinku_bokete_v1` と `oogiri_knockout_v1` の抜粋を公開し、抽出器が index を誤るシナリオクラスを refuse する。

- **highlight 2本** — いずれも Gemma 4 E2B (Q4_K_M) の実走行から、ラウンド1・`speak_all`・`statement` のみ。`window_override` なし。抜粋・キャプション・ティーザーは human sign-off 済み
- **conditional シナリオの refuse** — `gallery.json` の `phases` は conditional の then/else を depth-first で完全フラット化したリストだが、transcript の `phase_path` はトップレベルリストを指す。両者の index 体系が食い違うため `phase_index` を導出できない
- **curation norm 2件** — このバッチが教えた、ゲートが機械判定できない taste call
- **`phase_path` fallback の撤去** — 2箇所。欠落時に「トップレベル index 0」を無言で捏造していた

`hissatsu_naming_v1` はバッチ候補だったが**入っていない**。conditional 保有シナリオなので上記の理由で抽出できず、それが #1473。

## conditional の何が壊れているか（実測）

`hissatsu_naming_v1` はトップレベルが conditional 1個だけで、全フェーズがその then/else に入る。probe transcript で実測:

```
highlight: phase_index mismatch — phase_index=0 names phases[0]='conditional' but phase='speak_all'
```

正しいフラット index を直接 `_check_position()` に与えても通らない:

| `phase_index` | 中身 | 結果 |
|---|---|---|
| 1 | then枝の `speak_all` | PASS |
| 5 | else枝の `speak_all` | FAIL — `preceded ... by outcome-class phase(s) ['vote','score_calc','summarize']` |

その3フェーズは **then 枝のもので、そのラウンドには実行されていない**。フラットな prefix が両枝を混ぜるための偽陽性。しかも `rounds: 2` で窓はラウンド1のみ、ラウンド1は条件偽で else 枝 — 唯一取れるはずの抜粋がちょうどこの偽陽性に当たる。つまり抽出器と validator の両方が枝構造を必要とする。

**潜在的な静かな穴**: conditional の後ろにトップレベルフェーズがあり `phases[top_idx]` の型が偶然一致すると、誤った index のまま通過し、ネタバレ prefix が誤った範囲で評価される。今日の gallery には該当形なし（conditional 保有3本はいずれも conditional が末尾）。

## refuse の置き場所

`_check_position` に置いた。`check_content` が dispatch するので**ゲートと抽出器の両方**で走り、どの highlight が公開可能かについて二者が食い違えない（`validate_repo` 側に置くと抽出器は成功しゲートだけ落ちる）。

判定は `gallery.json` の**フラット化された `phases`** と**シナリオ YAML のトップレベル `phases:`** の両方を見て、どちらか一方でも conditional を declare していれば refuse する。index 側だけでは迂回路が残るため — このフィールドは非正規化で、YAML と突き合わせる検査は iOS 側の `GallerySeedYAMLTests.galleryPhasesMatchYAML` だけ。`precommit-gate-classify.sh` は `docs/` のみの変更を build 非関連に分類するので macOS ジョブごとスキップされ、それは**highlight バッチそのものの形**（実測: docs のみのファイルリストで classifier の出力は空）。両者の不一致自体も公開しない理由になる。

**意図的に過剰 refuse**している: conditional より前のトップレベル pick は skew の影響を受けず今でも正しく通るが、それを区別するには枝構造が要る。コメントとユーザー向けメッセージの両方にその旨を書いた。

`check_content` の docstring がここへのチェック追加時に ADR-029 Decision 2 の掃きを要求しているので追従した（同 docstring の "Widen, do not enumerate" に従い、カテゴリを列挙し直さず既存の節を広げた）。

## 抜粋の判断

`oogiri_knockout_v1` は**ラウンド1のみ**。ラウンド2に跨らせると、ラウンド1の脱落者（`理屈っぽい教授モドキ`）がちょうどラウンド2で消える形になり、欠落によって脱落者を特定できてしまう。ADR-029 の position rule はラウンド内のフェーズ可視性で判定するのでこの漏洩を見ない。norm として README に記録した。

`一言必殺のゼロ次` は抜粋にもフックにも入れていない。ペルソナ定義の `例:「押すわ。」` がラウンド1のお題の模範解答になっていて、独立2ドローとも逐語再現したため（シナリオ側の問題として #1475）。

お題は両者とも `assign` 由来なので caption / teaser には一切書いていない。抜粋から読者が推測するのは README の norm が明示的に許容する範囲。

## Test plan

- `bash scripts/check-gallery-entry.sh --all` → OK（既存4本 + 新規2本）
- `scripts/tests/*-test.sh` 全20スイート green（`gallery-highlight-test.sh` は 155 pass）。`scripts/` を触るので必須（CI の "Shell gate tests" でしか走らず、pre-commit は通ってしまう）
- 編集した2スイートは macOS `/bin/bash` 3.2 でも green（CI は ubuntu bash 5）
- `scripts/xcodebuild.sh test -skip-testing:PasturaUITests` → 3454 tests / 285 suites passed
- `python3 scripts/check_demo_replay_drift.py` → OK

**変異プローブでアームが空虚でないことを確認**:

| 潰したガード | 赤くなったアーム | 対照 |
|---|---|---|
| conditional refuse | C1（3アサーション）+ C3（2） | C2 は緑のまま（fixture が conditional 要素のみ異なる対照ペア） |
| refuse の YAML 側の読み | C5 のみ | C1〜C3 は緑のまま＝狙った経路だけを測っている |
| 抽出器の `phase_path` | C4 の `expect_out` | `expect_fail` は Traceback でも通るため判別していない |
| 変換器の `phase_path` | (b) の「意図メッセージ不一致」分岐 | (a) は影響を受けず緑 |

変換器ガードの初版は存在しない識別子 `src` / `i` を参照しており、**発火時のみ NameError** になる状態だった（成功パスでは検出不能）。負の対照で捕まえて修正済み。同型の未束縛が `validate_repo` の YAML 欠落パスにも生じうるため、`personas` と同じく既定値で束縛してある。

実 transcript での回帰も確認（変換器: 18 turns / `phase_index [1,2]` / 12 code events）。

## Device QA

実機QA不要 — Swift は1行も変更していない。Python / bash / ドキュメント / 生成 JSON のみで、`#if !targetEnvironment(simulator)` ブロックにも Metal / llama.cpp 経路にも触れない。

## フォローアップ

- #1473 branch-aware `phase_index`（この refuse を解除し `hissatsu_naming_v1` を解禁）
- #1475 `oogiri_knockout_v1` のペルソナ例文衝突。**YAML を直すと highlight の `yaml_sha256` が変わる**ので再生成とセット
- #1476 `kinku_bokete_v1` の「即失格」ルールが投票側で未執行（＋ミニマリスト省吾の字数仕様逸脱を併記）

Fable のレビューで挙がった `JSONResponseParser` の疑いは**不発**だった。`raw_text` を確認したところ JSON 自体は妥当で、閉じ括弧はモデルが `statement` の中身として書いたもの。パーサの欠陥ではないので issue を立てていない。

Closes #1474
