### PR TITLE
📝 docs: "Why" comments 規約に天井を足し、レビューゲートにも入れる

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -87,10 +87,10 @@ Utilities/ -> depends on nothing
 
 ### Code Quality (Warning/Suggestion)
 - "Why" comments on non-obvious implementation choices
-- Comment blocks address the next editor. Flag a block only when **no** sentence in it states a
-  constraint, invariant, or pointer that outlives this change, or when its only content is a figure
-  whose owning site the comment itself names. A load-bearing remainder always wins — never propose
-  cutting a clause (`keeps Qwen byte-identical to pre-#1422` is an invariant, stays).
+- Comment blocks address the next editor. In a non-doc (`//`) block only — `///` is Hard Rule 3's —
+  flag when no sentence states a constraint, invariant or pointer outliving this change, and ask for
+  a forward-looking rewrite, not a cut: `lives in X, which owns the default this file used to apply`
+  keeps the pointer and drops the history; `keeps Qwen byte-identical to pre-#1422` already stays.
 - No duplicated code
 - Proper error handling with layer-specific error types
 - Test coverage for new public types/functions

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -87,6 +87,10 @@ Utilities/ -> depends on nothing
 
 ### Code Quality (Warning/Suggestion)
 - "Why" comments on non-obvious implementation choices
+- Comment blocks address the next editor. Flag a block only when **no** sentence in it states a
+  constraint, invariant, or pointer that outlives this change, or when its only content is a figure
+  whose owning site the comment itself names. A load-bearing remainder always wins — never propose
+  cutting a clause (`keeps Qwen byte-identical to pre-#1422` is an invariant, stays).
 - No duplicated code
 - Proper error handling with layer-specific error types
 - Test coverage for new public types/functions

--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -92,15 +92,16 @@ set matters more than the pattern: the doc's § "The rule-assertion case".
 ## Anti-pattern: a comment written for the reviewer
 
 Same misfiling, one tier down. A comment is read by the **next editor**, so a
-block saying *only* what this change did — provenance, the diff's own argument,
-a figure a canonical site already states — belongs in the PR body or an ADR.
-Move the whole block, never a clause: a backward-looking
-sentence is routinely what makes the forward rule intelligible. **Length** is
-the commoner defect, and its remedy is rewriting shorter rather than moving —
-but it separates only as a cohort median, not per commit and not per model, so
-no threshold belongs here and none is given. False-flag rates, the per-commit
-gate that was built and refuted, and the tool that measures a cohort: the doc's
-§ "A comment written for the reviewer".
+block where *no* sentence states a durable claim — only provenance, the diff's
+own argument, a figure a canonical site already states — belongs in the PR body
+or an ADR. Move the whole block, never a clause: a backward-looking sentence is
+routinely what makes the forward rule intelligible. But **volume** is the
+commoner defect, tracks the model rather than recency, and is fixed by
+rewriting shorter, not deleting — so watch the count before the length. Past
+~10 lines (the concise baseline's top tenth) rewrite once at half length and
+**the rewrite wins**, unless it dropped a forward-looking fact, which a `///`
+block of measured values usually would. Rates, three refuted gate designs, the
+duplicated-figure grep: the doc's § "A comment written for the reviewer".
 
 ## Verify before you lock it
 

--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -94,15 +94,13 @@ set matters more than the pattern: the doc's § "The rule-assertion case".
 Same misfiling, one tier down. A comment is read by the **next editor**, so a
 block saying *only* what this change did — provenance, the diff's own argument,
 a figure a canonical site already states — belongs in the PR body or an ADR.
-**When flagging that**, move the whole block, never a clause: a
-backward-looking sentence is routinely what makes the forward rule
-intelligible. But expect **length**, not misfiling, to be the defect you
-actually find — current models state the same content markedly longer, and the
-remedy there is rewriting the block shorter, a different act from deleting one.
-So when *writing* one: a block past ~6 lines (the concise generation sat at
-5.5) gets one rewrite at half the length, and **the rewrite wins** unless it
-dropped a forward-looking fact. False-flag rates, why the duplicated-figure
-shape needs a repo-side grep: the doc's § "A comment written for the reviewer".
+Move the whole block, never a clause: a backward-looking
+sentence is routinely what makes the forward rule intelligible. **Length** is
+the commoner defect, and its remedy is rewriting shorter rather than moving —
+but it separates only as a cohort median, not per commit and not per model, so
+no threshold belongs here and none is given. False-flag rates, the per-commit
+gate that was built and refuted, and the tool that measures a cohort: the doc's
+§ "A comment written for the reviewer".
 
 ## Verify before you lock it
 

--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -94,11 +94,15 @@ set matters more than the pattern: the doc's § "The rule-assertion case".
 Same misfiling, one tier down. A comment is read by the **next editor**, so a
 block saying *only* what this change did — provenance, the diff's own argument,
 a figure a canonical site already states — belongs in the PR body or an ADR.
-Act on the **whole block**, never a clause: a backward-looking sentence is
-routinely what makes the forward rule intelligible. And expect **length**, not
-misfiling, to be the defect you actually find — current models state the same
-content markedly longer. False-flag rates and the duplicated-figure grep: the
-doc's § "A comment written for the reviewer".
+**When flagging that**, move the whole block, never a clause: a
+backward-looking sentence is routinely what makes the forward rule
+intelligible. But expect **length**, not misfiling, to be the defect you
+actually find — current models state the same content markedly longer, and the
+remedy there is rewriting the block shorter, a different act from deleting one.
+So when *writing* one: a block past ~6 lines (the concise generation sat at
+5.5) gets one rewrite at half the length, and **the rewrite wins** unless it
+dropped a forward-looking fact. False-flag rates, why the duplicated-figure
+shape needs a repo-side grep: the doc's § "A comment written for the reviewer".
 
 ## Verify before you lock it
 

--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -97,7 +97,8 @@ own argument, a figure a canonical site already states — belongs in the PR bod
 or an ADR. Move the whole block, never a clause: a backward-looking sentence is
 routinely what makes the forward rule intelligible. But **volume** is the
 commoner defect, tracks the model rather than recency, and is fixed by
-rewriting shorter, not deleting — so watch the count before the length. Past
+rewriting shorter, not deleting — and it is spread over how many blocks you
+write and how long each is, so watch both. Past
 ~10 lines (the concise baseline's top tenth) rewrite once at half length and
 **the rewrite wins**, unless it dropped a forward-looking fact, which a `///`
 block of measured values usually would. Rates, three refuted gate designs, the

--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -89,6 +89,17 @@ See PR #420 for the motivating incident. Why the prose example above is
 written with a `<name>` placeholder rather than carved out, and why the file
 set matters more than the pattern: the doc's § "The rule-assertion case".
 
+## Anti-pattern: a comment written for the reviewer
+
+Same misfiling, one tier down. A comment is read by the **next editor**, so a
+block saying *only* what this change did — provenance, the diff's own argument,
+a figure a canonical site already states — belongs in the PR body or an ADR.
+Act on the **whole block**, never a clause: a backward-looking sentence is
+routinely what makes the forward rule intelligible. And expect **length**, not
+misfiling, to be the defect you actually find — current models state the same
+content markedly longer. False-flag rates and the duplicated-figure grep: the
+doc's § "A comment written for the reviewer".
+
 ## Verify before you lock it
 
 One discipline, three moments where a claim becomes load-bearing and nobody downstream will check it — the author is the only one positioned to run it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,8 +97,8 @@ Utilities/ → depends on nothing
   at all — are catalogued in the always-loaded `.claude/rules/swift-isolation.md`.
 - **"Why" comments:** Non-obvious choices must have a comment explaining **why**, not what — at the
   length the constraint needs, and addressed to the next editor. A block saying *only* what this
-  change did belongs in the PR body; judge the whole block, never a clause. Why no length threshold
-  exists: `.claude/rules/knowledge-layering.md` § "Anti-pattern: a comment written for the reviewer".
+  change did belongs in the PR body; judge the whole block, never a clause. Count before length, and
+  why: `.claude/rules/knowledge-layering.md` § "Anti-pattern: a comment written for the reviewer".
 - **Observable bridge for non-`@Observable` state:** When an `@Observable` class exposes
   a computed property that reads mutable state from a `nonisolated` class / actor,
   bridge observation manually — `access(keyPath: \.prop)` in the getter and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,9 @@ Utilities/ → depends on nothing
   `Views/` and `App/` use the default (MainActor).
   The isolation traps this creates — including the ones that raise no diagnostic
   at all — are catalogued in the always-loaded `.claude/rules/swift-isolation.md`.
-- **"Why" comments:** Non-obvious choices must have a comment explaining **why**, not what.
+- **"Why" comments:** Non-obvious choices must have a comment explaining **why**, not what — at the
+  length the constraint needs, and addressed to the next editor. A block saying *only* what this
+  change did belongs in the PR body; judge the whole block, never a clause.
 - **Observable bridge for non-`@Observable` state:** When an `@Observable` class exposes
   a computed property that reads mutable state from a `nonisolated` class / actor,
   bridge observation manually — `access(keyPath: \.prop)` in the getter and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,8 @@ Utilities/ → depends on nothing
   at all — are catalogued in the always-loaded `.claude/rules/swift-isolation.md`.
 - **"Why" comments:** Non-obvious choices must have a comment explaining **why**, not what — at the
   length the constraint needs, and addressed to the next editor. A block saying *only* what this
-  change did belongs in the PR body; judge the whole block, never a clause.
+  change did belongs in the PR body; judge the whole block, never a clause. Why no length threshold
+  exists: `.claude/rules/knowledge-layering.md` § "Anti-pattern: a comment written for the reviewer".
 - **Observable bridge for non-`@Observable` state:** When an `@Observable` class exposes
   a computed property that reads mutable state from a `nonisolated` class / actor,
   bridge observation manually — `access(keyPath: \.prop)` in the getter and

--- a/docs/agent-tooling/claim-verification.md
+++ b/docs/agent-tooling/claim-verification.md
@@ -104,6 +104,15 @@ negative control shows why the block is the unit: three were unambiguous keeps, 
 from a true instance by a following sentence turning the history into a live constraint, **a
 payload, not a tense**.
 
+**Word the trigger as an absence, and state precedence.** Running the drafted `code-reviewer` bullet
+over six real blocks caught two more defects, both invisible on re-reading. "Flag when *every*
+sentence merely reports" cannot be audited — an agent cannot point at what convinced it — whereas
+"flag when *no* sentence states a durable claim" makes the saving sentence citable, and a one-
+sentence block silently degenerates under the first form since clause and block coincide. And a rule
+carrying both a trigger and a "never cut a load-bearing clause" safeguard must say which wins, or a
+block that fires the trigger while holding a live pointer yields either a deleted pointer or an
+unactionable finding.
+
 The duplicated-figure shape needs a **repo-side grep**, not a review agent. `code-reviewer` bails
 `SCOPE_TOO_LARGE` above ~800 lines or ~8 files, and every commit that motivated this rule exceeded
 the file bound — so the diff gets split and no shard sees all the sites. Frame it as *new code must

--- a/docs/agent-tooling/claim-verification.md
+++ b/docs/agent-tooling/claim-verification.md
@@ -52,7 +52,8 @@ Authored at implementation *or review-fix* time, and executed by nobody. The rul
 one-line version of each; the elaborations are what get missed.
 
 - **Why-comment on a mechanism** → delete the mechanism and run the tests. Green means the claim is
-  false, or the tests never covered it.
+  false, or the tests never covered it. Its *destination* is a separate question — see § "A comment
+  written for the reviewer" below.
 - **A detector / guard / gate** → construct the thing it claims to catch and confirm it fires. A
   guard's success case proves nothing; only a negative control does. Scope it to the claim it
   defends: a check narrower than that claim (a files-only loop behind a files-and-directories
@@ -73,6 +74,45 @@ one-line version of each; the elaborations are what get missed.
 
 When a check is too expensive to run, say the cause was not isolated. A reader can act on an
 acknowledged gap; a wrong cause they can only inherit.
+
+## A comment written for the reviewer
+
+Backs the rule's § "Anti-pattern: a comment written for the reviewer". A comment whose only content
+is what *this* change did addresses the reviewer, not the next editor.
+
+**The form that survived a negative control**: flag a block only when *every* sentence in it is a
+backward-looking report, or when it restates a figure with a canonical site elsewhere. Over 169
+comment blocks from two model generations of this repo's own history (#1479), that caught every true
+instance with no false positives.
+
+**Do not key it on wording instead.** Tense is the tempting discriminator — "must stay identical to
+X" constrains, "was left identical to X" reports — and on that corpus it had to decide 17 blocks and
+got 4 wrong. It reads the grammatical head, not the payload:
+
+- `GameHeader.swift`'s "…lives in `LeafIcon.swift`, which owns the default this file used to apply"
+  (stale move record) and `LLMCaller.swift`'s "…live in `LLMCaller+Logging.swift` to keep this file
+  under SwiftLint's `file_length` budget" (live breadcrumb) have identical grammar.
+- Duplication is invisible to it — a measured GGUF figure copy-pasted from `ModelRegistry.swift`
+  into the harness's `ModelProfile.swift` is the defect, and every word of it is a legitimate
+  present-tense fact.
+- It strips backward-looking clauses a forward rule depends on (`GalleryHighlight.swift`'s "any
+  required key added *after that* bumps the version").
+
+Per-clause flagging misfires on ~7% of load-bearing blocks, worst on the longest. The four-site
+negative control shows why the block is the unit: three were unambiguous keeps, and the fourth
+(`PlaybackSpeed.swift:9`) is a keep whose cited line *alone* reads as a move record — it differs
+from a true instance by a following sentence turning the history into a live constraint, **a
+payload, not a tense**.
+
+The duplicated-figure shape needs a **repo-side grep**, not a review agent. `code-reviewer` bails
+`SCOPE_TOO_LARGE` above ~800 lines or ~8 files, and every commit that motivated this rule exceeded
+the file bound — so the diff gets split and no shard sees all the sites. Frame it as *new code must
+not add hits*, existing count as an acknowledged baseline (the *reframe* disposition); #1477 is the
+open instance.
+
+**Length is the commoner defect.** In that corpus one generation wrote ~45% more comment lines per
+block and ~50% more blocks per commit at an unchanged A/B/C/D distribution — same content, longer.
+Compressing it loses nothing, and is safer than any rule that deletes a category of content.
 
 ## Reading a probe's outcome
 

--- a/docs/agent-tooling/claim-verification.md
+++ b/docs/agent-tooling/claim-verification.md
@@ -141,11 +141,22 @@ median of 3.0 lines, and a ≥12-line trigger fires on 7.8% of concise blocks ag
 ones. A gate at any of those rates teaches its reader to ignore it, so claude-kit's
 `comment-density.py` ships as cohort measurement only.
 
-That calibration also moved the claim: what separates the cohorts is **count, not length** — 16 → 26
-blocks per commit (+63%) against 4.3 → 5.9 lines per block (+37%), over a shared median. A
-length-keyed mechanism aims at the smaller half of its own defect, which is why the rule leads with
-the count. And Fable 5 sits below both cohorts (3.4 lines per block), so recency is the wrong axis:
-it is per model, and re-measuring is the only way to know which one you are on.
+**A block count is only as good as its denominator, so lead with the measures that carry their own.**
+Over `1f8836ef..9a40565a`, comment share of added lines runs 43.0% → 55.0% and lines per block 4.31 →
+5.68 (+32%) — each a ratio by construction. The block *count* moves with whatever you divide it by:
++31% per 100 added code lines, +10% per Swift file touched, +63% per commit. It moves with the
+counting rule too — the per-file figure above lands flat (2.98 vs 3.03) counting `//` and `///`
+separately, where kit's tool counts them together. Both dimensions rise and neither dominates, so
+the rule watches both rather than ordering them.
+
+kit briefly read that +63% as "count, not length" before catching the same confound this section
+already names above: the verbose cohort's commits add 108 → 179 code lines, so a per-commit count
+banks commit size as a comment habit. Fable 5 is the check — most concise on every self-normalizing
+measure (32.1% share, 3.35 lines per block, 14.1 blocks per 100 lines) and *least* concise on both
+raw ones (24 per commit against 16, 3.57 per file against 3.08), because it writes 39.8 lines per
+file against 22.4. A metric that ranks the most concise model as the most verbose is measuring its
+denominator. Recency is the wrong axis too: it is per model, and re-measuring is the only way to
+know which one you are on.
 
 Compression is still the safe remedy — it cannot delete a category of content the way moving a block
 can. What has no support is a per-commit threshold.

--- a/docs/agent-tooling/claim-verification.md
+++ b/docs/agent-tooling/claim-verification.md
@@ -133,16 +133,22 @@ excluded dark-mode commits have *short* blocks (4.19, 4.21) — the same asymmet
 C-class claim above, with the sign reversed. Unfiltered `///` blocks show no generation difference
 at all (5.65 vs 5.63); the effect lives in plain `//` comments.
 
-**So do not gate a commit on it.** A per-commit gate was built and calibrated against the concise
-cohort, and the calibration killed it: every ratio/block-length pair catching 80–96% of the verbose
-cohort also flagged 33–71% of the concise one, and a gate at that false-positive rate teaches its
-reader to ignore it. Per-commit variance swamps the medians. The same run put Fable 5 *below* both
-cohorts at 3.6 lines per block, so "current models are verbose" is the wrong unit — it is per model,
-and re-measuring is the only way to know which one you are on. `comment-density.py` in claude-kit
-reports cohort medians over a revision range, grouped by the `Co-Authored-By` trailer.
+**So do not gate on it — three designs were built and refuted.** Calibrating each against the
+concise cohort killed it. Per-commit on either threshold, catching 80–96% of the verbose cohort also
+flagged 52–79% of the concise one; on both thresholds, false flags drop to 12–22% but detection
+collapses to 32–48%. Per *block* — the unit this rule's own trigger uses — the cohorts share a
+median of 3.0 lines, and a ≥12-line trigger fires on 7.8% of concise blocks against 11.4% of verbose
+ones. A gate at any of those rates teaches its reader to ignore it, so claude-kit's
+`comment-density.py` ships as cohort measurement only.
+
+That calibration also moved the claim: what separates the cohorts is **count, not length** — 16 → 26
+blocks per commit (+63%) against 4.3 → 5.9 lines per block (+37%), over a shared median. A
+length-keyed mechanism aims at the smaller half of its own defect, which is why the rule leads with
+the count. And Fable 5 sits below both cohorts (3.4 lines per block), so recency is the wrong axis:
+it is per model, and re-measuring is the only way to know which one you are on.
 
 Compression is still the safe remedy — it cannot delete a category of content the way moving a block
-can. What has no support is a number.
+can. What has no support is a per-commit threshold.
 
 **Whether an always-loaded line changes anything here is itself untested.** In the session that
 drafted this, a live instruction to restructure a draft shortened it (25%, against 14% for "compress

--- a/docs/agent-tooling/claim-verification.md
+++ b/docs/agent-tooling/claim-verification.md
@@ -123,9 +123,32 @@ the file bound — so the diff gets split and no shard sees all the sites. Frame
 not add hits*, existing count as an acknowledged baseline (the *reframe* disposition); #1477 is the
 open instance.
 
-**Length is the commoner defect.** In that corpus one generation wrote ~45% more comment lines per
-block and ~47% more blocks per commit at an unchanged A/B/C/D distribution — same content, longer.
-Compressing it loses nothing, and is safer than any rule that deletes a category of content.
+**Length is the commoner defect — and the one number that survived scrutiny is a cohort median.**
+The first pass reported one generation writing ~45% more comment lines per block and ~47% more
+blocks per commit at an unchanged A/B/C/D distribution. Re-measured over 23 vs 145 commits instead
+of 4 vs 3, lines per block is **+21%**, and the blocks-per-commit gap **disappears** once normalized
+by Swift files touched (2.98 vs 3.03) — it was commit size. The ~45% reproduces only under a
+topic filter that removes 259 of 453 blocks from one arm and 0 of 2,114 from the other, because the
+excluded dark-mode commits have *short* blocks (4.19, 4.21) — the same asymmetry that refuted the
+C-class claim above, with the sign reversed. Unfiltered `///` blocks show no generation difference
+at all (5.65 vs 5.63); the effect lives in plain `//` comments.
+
+**So do not gate a commit on it.** A per-commit gate was built and calibrated against the concise
+cohort, and the calibration killed it: every ratio/block-length pair catching 80–96% of the verbose
+cohort also flagged 33–71% of the concise one, and a gate at that false-positive rate teaches its
+reader to ignore it. Per-commit variance swamps the medians. The same run put Fable 5 *below* both
+cohorts at 3.6 lines per block, so "current models are verbose" is the wrong unit — it is per model,
+and re-measuring is the only way to know which one you are on. `comment-density.py` in claude-kit
+reports cohort medians over a revision range, grouped by the `Co-Authored-By` trailer.
+
+Compression is still the safe remedy — it cannot delete a category of content the way moving a block
+can. What has no support is a number.
+
+**Whether an always-loaded line changes anything here is itself untested.** In the session that
+drafted this, a live instruction to restructure a draft shortened it (25%, against 14% for "compress
+this"), while the rule sat in the same context and three verbose drafts were written under it. So
+treat the always-loaded half as a hypothesis: re-measure the cohort, and if it does not move, the
+mechanism belongs at review or commit time and these lines should come back out.
 
 ## Reading a probe's outcome
 

--- a/docs/agent-tooling/claim-verification.md
+++ b/docs/agent-tooling/claim-verification.md
@@ -144,10 +144,12 @@ ones. A gate at any of those rates teaches its reader to ignore it, so claude-ki
 **A block count is only as good as its denominator, so lead with the measures that carry their own.**
 Over `1f8836ef..9a40565a`, comment share of added lines runs 43.0% → 55.0% and lines per block 4.31 →
 5.68 (+32%) — each a ratio by construction. The block *count* moves with whatever you divide it by:
-+31% per 100 added code lines, +10% per Swift file touched, +63% per commit. It moves with the
-counting rule too — the per-file figure above lands flat (2.98 vs 3.03) counting `//` and `///`
-separately, where kit's tool counts them together. Both dimensions rise and neither dominates, so
-the rule watches both rather than ordering them.
++31% per 100 added code lines, +10% per Swift file touched, +63% per commit. The per-file figure
+above lands flat instead (2.98 vs 3.03), and the cause is *not* isolated: that pass counted `//` and
+`///` separately over 23 vs 145 commits on a sliding range, where kit's tool merges them over a
+pinned 26 vs 123 — counting rule and sample both differ. The same gap sits under lines per block,
++21% there against +32% here. Both dimensions rise and neither dominates, so the rule watches both
+rather than ordering them.
 
 kit briefly read that +63% as "count, not length" before catching the same confound this section
 already names above: the verbose cohort's commits add 108 → 179 code lines, so a per-commit count

--- a/docs/agent-tooling/claim-verification.md
+++ b/docs/agent-tooling/claim-verification.md
@@ -143,7 +143,9 @@ ones. A gate at any of those rates teaches its reader to ignore it, so claude-ki
 
 **A block count is only as good as its denominator, so lead with the measures that carry their own.**
 Over `1f8836ef..9a40565a`, comment share of added lines runs 43.0% → 55.0% and lines per block 4.31 →
-5.68 (+32%) — each a ratio by construction. The block *count* moves with whatever you divide it by:
+5.68 (+32%) — each a ratio by construction. That buys immunity to cohort *size* only, not to what
+each cohort was working on — the confound that refuted the C-class claim above, and one a pinned
+range does not touch. The block *count* moves with whatever you divide it by:
 +31% per 100 added code lines, +10% per Swift file touched, +63% per commit. The per-file figure
 above lands flat instead (2.98 vs 3.03), and the cause is *not* isolated: that pass counted `//` and
 `///` separately over 23 vs 145 commits on a sliding range, where kit's tool merges them over a
@@ -153,12 +155,18 @@ rather than ordering them.
 
 kit briefly read that +63% as "count, not length" before catching the same confound this section
 already names above: the verbose cohort's commits add 108 → 179 code lines, so a per-commit count
-banks commit size as a comment habit. Fable 5 is the check — most concise on every self-normalizing
-measure (32.1% share, 3.35 lines per block, 14.1 blocks per 100 lines) and *least* concise on both
-raw ones (24 per commit against 16, 3.57 per file against 3.08), because it writes 39.8 lines per
-file against 22.4. A metric that ranks the most concise model as the most verbose is measuring its
-denominator. Recency is the wrong axis too: it is per model, and re-measuring is the only way to
-know which one you are on.
+banks commit size as a comment habit. Fable 5 is the check — n=16, so read it as a direction rather
+than a magnitude, but most concise on every self-normalizing measure (32.1% share, 3.35 lines per
+block, 14.1 blocks per 100 lines) and *least* concise on both raw ones (24 per commit against 16,
+3.57 per file against 3.08), because it writes 39.8 lines per file against 22.4. A metric that ranks
+the most concise model as the most verbose is measuring its denominator. Recency is the wrong axis
+too: it is per model, and re-measuring is the only way to know which one you are on. A further 72
+eligible commits in that range carry no model trailer and sit in none of the cohorts.
+
+Three corrections have now landed on this one diagnosis — topic-skewed sample, blocks merged across
+diff hunks, commit size — and it is worth reading the shape wider than any of them: what recurs is a
+covariate that differs between the cohorts and went unchecked. A denominator is only the kind that
+is easy to name.
 
 Compression is still the safe remedy — it cannot delete a category of content the way moving a block
 can. What has no support is a per-commit threshold.

--- a/docs/agent-tooling/claim-verification.md
+++ b/docs/agent-tooling/claim-verification.md
@@ -83,26 +83,29 @@ is what *this* change did addresses the reviewer, not the next editor.
 **The form that survived a negative control**: flag a block only when *every* sentence in it is a
 backward-looking report, or when it restates a figure with a canonical site elsewhere. Over 169
 comment blocks from two model generations of this repo's own history (#1479), that caught every true
-instance with no false positives.
+instance with no false positives. **`code-reviewer` ships the second arm narrower** — only when the
+comment *itself* names the owning site — for the split-review reason below, so the zero-false-
+positive figure covers the form measured here, not the predicate that gate applies.
 
 **Do not key it on wording instead.** Tense is the tempting discriminator — "must stay identical to
 X" constrains, "was left identical to X" reports — and on that corpus it had to decide 17 blocks and
 got 4 wrong. It reads the grammatical head, not the payload:
 
-- `GameHeader.swift`'s "…lives in `LeafIcon.swift`, which owns the default this file used to apply"
-  (stale move record) and `LLMCaller.swift`'s "…live in `LLMCaller+Logging.swift` to keep this file
-  under SwiftLint's `file_length` budget" (live breadcrumb) have identical grammar.
+- `GameHeader.swift`'s "…lives in `LeafIcon.swift`, which owns the 9pt default this file used to
+  apply" (stale move record) and `LLMCaller.swift`'s "…live in `LLMCaller+Logging.swift` to keep
+  this file under SwiftLint's `file_length` budget" (live breadcrumb) have identical grammar.
 - Duplication is invisible to it — a measured GGUF figure copy-pasted from `ModelRegistry.swift`
   into the harness's `ModelProfile.swift` is the defect, and every word of it is a legitimate
   present-tense fact.
 - It strips backward-looking clauses a forward rule depends on (`GalleryHighlight.swift`'s "any
   required key added *after that* bumps the version").
 
-Per-clause flagging misfires on ~7% of load-bearing blocks, worst on the longest. The four-site
-negative control shows why the block is the unit: three were unambiguous keeps, and the fourth
-(`PlaybackSpeed.swift:9`) is a keep whose cited line *alone* reads as a move record — it differs
-from a true instance by a following sentence turning the history into a live constraint, **a
-payload, not a tense**.
+Those 4 outright wrong answers are the floor, not the cost: per-clause flagging *misfires* on ~7% of
+the corpus's load-bearing blocks — a wider set, since a block also breaks when a correct flag is
+acted on clause-wise — and worst on the longest. The four-site negative control shows why the block
+is the unit: three were unambiguous keeps, and the fourth (`PlaybackSpeed.swift:8-9`) is a keep
+whose cited sentence *alone* reads as a move record — it differs from a true instance by a following
+sentence turning the history into a live constraint, **a payload, not a tense**.
 
 **Word the trigger as an absence, and state precedence.** Running the drafted `code-reviewer` bullet
 over six real blocks caught two more defects, both invisible on re-reading. "Flag when *every*
@@ -111,7 +114,8 @@ sentence merely reports" cannot be audited — an agent cannot point at what con
 sentence block silently degenerates under the first form since clause and block coincide. And a rule
 carrying both a trigger and a "never cut a load-bearing clause" safeguard must say which wins, or a
 block that fires the trigger while holding a live pointer yields either a deleted pointer or an
-unactionable finding.
+unactionable finding. Both trials — the four control sites and the six blocks, per site and per
+verdict — are the ledger comment on #1479.
 
 The duplicated-figure shape needs a **repo-side grep**, not a review agent. `code-reviewer` bails
 `SCOPE_TOO_LARGE` above ~800 lines or ~8 files, and every commit that motivated this rule exceeded

--- a/docs/agent-tooling/claim-verification.md
+++ b/docs/agent-tooling/claim-verification.md
@@ -124,7 +124,7 @@ not add hits*, existing count as an acknowledged baseline (the *reframe* disposi
 open instance.
 
 **Length is the commoner defect.** In that corpus one generation wrote ~45% more comment lines per
-block and ~50% more blocks per commit at an unchanged A/B/C/D distribution — same content, longer.
+block and ~47% more blocks per commit at an unchanged A/B/C/D distribution — same content, longer.
 Compressing it loses nothing, and is safer than any rule that deletes a category of content.
 
 ## Reading a probe's outcome


### PR DESCRIPTION
## Summary

`CLAUDE.md` の `"Why" comments` 規約は床（非自明なら why を書け）しか定めておらず、`code-reviewer` の `### Code Quality` も why コメントの**存在**しか見ていなかった。どちらもコメントを増やす方向にしか効かない。天井側を足す。

- `CLAUDE.md:98` — 「必要な長さで、次の編集者に向けて書く。この変更が何をしたかだけを述べるブロックは PR body へ。節ではなくブロック単位で判断する」
- `.claude/rules/knowledge-layering.md` — § "Anti-pattern: a comment written for the reviewer"（claude-kit からの一方向ミラー）。**書く側の手順もここ**: 超過は本数と長さに同程度に出ているので両方を見る。10行を超えたら半分の長さで1回書き直し、前向きな事実を落としていなければ書き直しを採る。閾値は簡潔な側の**上位1割**から取っている（平均ではない）。測定値を持つ `///` ブロックは Hard Rule 3 の管轄なので除外 — これは Pastura 固有の追加
- `docs/agent-tooling/claim-verification.md` — 対の depth。採用しなかった判別基準とその実測、および「重複数値は repo 側 grep に回す」理由
- `.claude/agents/code-reviewer.md` — 無人経路に届くゲート側の逆観点

## 診断を途中で訂正している

当初は「Opus 5 が C クラス（レビュアー宛て・diff の弁護）のコメントを増やした」と結論していた。**これは誤りで、PR 途中で反証した。** 最初の分類サンプル4件のうち3件がダークモード/WCAG 系の測定作業で、題材と世代が交絡していた。

ダークモード以外の Opus 5 コミット4件で取り直した結果:

| 群 | ブロック数 | A(縛る) | B(ナレーション) | C(diff弁護) | D(空虚な doc) |
|---|---|---|---|---|---|
| Opus 5・ダークモード以外 | 112 | 103 | 2 | 3 | 4 |
| Opus 4.8・通常機能開発 | 57 | 55 | 0 | 0 | 2 |

C は 2.7% vs 0%、3ブロックのみでノイズの範囲。B（自明なナレーション）は両群ともほぼゼロで、why コメント文化自体は健全。

残ったのは**量**の差。ただし初出の数値（1ブロック 5.5 → 8.0行 = +45%、コミットあたり 19 → 28ブロック）は後述の `/risk-review` でほぼ全部崩れた。

**さらにその後、較正し直した「長さより本数」も撤回している**（kit#37、本PR `4104af6a` 以降）。コミット単位の生カウントを、単位の大きさが違うコホート同士で比べていた。固定範囲 `1f8836ef..9a40565a` での最終的な姿:

| 指標 | Opus 4.8 (n=123) | Opus 5 (n=26) | Fable 5 (n=16) |
|---|---|---|---|
| コメント比（追加行あたり） | 43.0% | 55.0% | **32.1%** |
| 行/ブロック | 4.31 | 5.68 (+32%) | **3.35** |
| blk/100 コード行 | 16.0 | 21.0 (+31%) | **14.1** |
| blk/ファイル | 3.08 | 3.38 (+10%) | 3.57 |
| blk/コミット | 16 | 26 (+63%) | 24 |

**本数と長さは同程度に上がっており、どちらも支配的ではない。** ブロック数は割り算する対象で答えが変わるので、分母を持つ上2行を先に読む。ブロック長の中央値が両世代とも 3.0 なのは変わらない。

Fable 5 が判定材料 — 自己正規化された指標では全部最少なのに、生のコミット単位でもファイル単位でも最多になる（1ファイル 39.8 行書くため）。軸は世代ではなく**モデル**。Anthropic の Opus 5 プロンプトガイド（"Response length and verbosity" / "Written deliverable length"）とは方向が一致する。

なお比率が買うのはコホートの**大きさ**への免疫だけで、題材構成には無防備 — 上の C クラス撤回がまさにその形。この診断への訂正は計3回で、共通形は「コホート間で揃っていない共変量を確かめずに比較した」。

## 却下した2つの形と、その根拠

**文言の形で検出する案** — `byte-identical to pre-#N` 等。既存ツリーに同形が78箇所あり、大半が `keeps existing call sites (pre-#92 constructors) working` のような**将来の編集を縛る不変条件**だった。ゲートに載せれば load-bearing なコメントを大量に誤爆する。

**時制で判別する案** — 「〜のままでなければならない」(残す) vs 「この変更は〜のままにした」(移設)。169ブロックで検証して17件が要判定・4件で誤答。A ブロック全体の約7%に誤爆し、誤爆先は体系的に最も長いブロック、つまり規約が守ろうとしている当のもの。陰性対照4件でも、`PlaybackSpeed.swift:9` が「ブロック単位では残す・引用行単体では移設に読める」形で同じ弱点を再現した。真の事例との差は時制ではなく**後続文が履歴を生きた制約に変えているかどうか**だった。

採用した**ブロック単位**の形は、同じコーパスで真の C を偽陽性ゼロで捕捉している。

## ゲート文言は書いた後に走らせて直している

`code-reviewer` の bullet を実在するコメント6件（真の C 2件 / 残すべき A 4件、うち2件は引っかけ）に当てたところ、読み返しでは見えない欠陥が2件出た:

1. **「全文が報告なら fire」は監査できない。** 何が決め手だったかをエージェントが指せない。「durable な主張がどの文にも無ければ fire」なら救った文を引用できる。前者は1文ブロックで黙って退化する（節=ブロックになり、混在した1文が純粋な報告として採点される）
2. **トリガーと安全弁の優先順位が未定義だった。** 生きたポインタを持つブロックがトリガーを引くと、「ポインタを消す」か「同じ bullet が修正を禁じる指摘を出す」かのどちらかになる

さらに、当初の bullet は**この PR 自身の doc と矛盾していた** — doc には「重複数値はレビューエージェントではなく repo 側 grep」と書きながら、bullet には横断的な数値トリガーを残していた。分割レビューではどのシャードも全サイトを見ないので判定不能で、誤爆すると注釈とポインタを持つ**正典側**を削りうる。ゲートからは落とし、`#1477` が実例。

## /risk-review が主張の中核を撤回させた

3クラスタ（軸8本）を並列で回した結果、**Critical 2件**が出た。どちらも私の入れた欠陥で、以下は撤回・修正の記録。

**閾値 `~6行` と `5.5` は撤回した。** `5.5` は再現しない — 同じ3コミットでもブロックの定義次第で 3.42 / 4.20 / 5.5 の3通りになり、定義は公開されていなかった。しかも `~6行` はツリーのコメントブロックの 22%（1,113件）を捕らえ、その82%は Hard Rule 3 が必須とする `///` doc コメント。実例として `PasturaPrimaryButtonStyle.swift` の49行ブロックがあり、全段落が前向きなので半分にすれば測定値が落ちる。

**ゲートは狙った対象に発火していなかった。** 動機となった2件を実読した結果、GameHeader はポインタを述べるので発火せず、ModelProfile は所有サイトを名指ししないので発火しない — **2件とも KEEP**。一方で1行の記述的 `///` 716件には字義通り発火し、Hard Rule 3（Critical）と衝突していた。`//` ブロックに限定し、「削る」ではなく「前向きに書き直す」を求める形に変えた。

**長さの所見も較正で崩れた。** 無フィルタでは +21%（+45% ではない）。「コミットあたり +47%」は変更ファイル数で正規化すると消える（2.98 vs 3.03）。題材フィルタは Opus 5 側から 259/453 を除き Opus 4.8 側から 0/2114 しか除かない — **反証済みの兄弟所見とまったく同じ非対称性**。最終的に claude-kit 側で per-commit / per-block のゲート設計を3通り較正してすべて反証し（冗長側を80-96%捕らえる設定は簡潔側を52-79%誤爆、両閾値だと検出が32-48%に崩壊、ブロック単位では中央値が両者3.0で同じ）、道具はコホート測定専用として出荷することにした。閾値は平均ではなく**簡潔側の上位1割**から取り直して ~10行に。

**「常時ロードに置けば効く」自体が未検証**という記録も doc に残した。この規則を書いたセッションで、規則が文脈にありながら冗長な草稿が3本書かれ、実際に短くしたのは live な指示のほうだった（25% vs 14%）。効かなければ review/commit 時に移し、この行は引き上げる、と明記してある。

## Context-economy

Keep 3 / compressed 3 / dropped 1。常時ロードは **93,421 → 95,042 バイト**（+1,621、+22行 / -1行、ceiling 95,500 に対し残り 458）。

- **Keep**: `CLAUDE.md` の1句 + ポインタ（+308B）— 既存 bullet が床のみで読者を誤らせる。同節の他の bullet が全て採っているポインタ形式に揃えた。`.claude/rules/` の節（+908B）— 発火条件と書く側の閾値。`code-reviewer` の bullet（+405B）— 無人経路に届く唯一の経路で、両側の worked example を持つ
- **Compressed**: rule から測定値・例・陰性対照を `docs/**`（常時ロード外）へ。撤回後に rule を再圧縮（数値は doc にあるので rule からは落とした）
- **Dropped**: rule 内の相互ポインタ（指し先も常時ロードで同時に文脈にある）、および `~6行` の閾値そのもの

残り 458B は薄い。次に常時ロードへ足すときは、先に `#1430` 型の slim を検討すべき水準。

## Test plan

- 相互参照アンカーを両方向 grep で検証: rule → doc § "A comment written for the reviewer"、doc → rule § "Anti-pattern: a comment written for the reviewer"、いずれも1件
- doc 内の `file:line` 引用6件（`GameHeader.swift:304`, `LLMCaller.swift:198`, `ModelProfile.swift:65` と `ModelRegistry.swift:65`, `GalleryHighlight.swift`, `PlaybackSpeed.swift:9`, `LlamaCppService.swift:448`）を実行して照合済み
- `SCOPE_TOO_LARGE` の閾値（~800行 / ~8ファイル）を `code-reviewer.md` 本文で確認。証拠コミット5件はいずれも8ファイル超で、分割が前提になることも確認済み
- 常時ロード数値はフックの `always_loaded_bytes()` と同じ手順で再計算

## Device QA

実機QA不要 — エージェント指示ファイルとドキュメントのみで、アプリのコードもリソースも変更していない。

## 依存

**tyabu12/claude-kit#36 のマージが先。** `.claude/rules/knowledge-layering.md` と `docs/agent-tooling/claim-verification.md` は kit からの一方向ミラーで、kit 側が canonical。

Closes #1479

