### PR TITLE
🐛 fix: state knownTurnMarkers on the gate-spike LLMBackend conformers

### DIFF
--- a/.claude/rules/kmp-interop.md
+++ b/.claude/rules/kmp-interop.md
@@ -10,7 +10,7 @@ Traps of the ADR-023 KMP Engine migration (`shared/models`, `shared/engine`) —
 Kotlin/Native (K/N) ↔ Swift boundary, and inside the Kotlin port itself. Three shapes:
 
 - **Compile-time interop traps (Patterns 1–2)** — surface at the *Swift consumption* site when
-  Swift code imports the generated `PasturaShared` XCFramework. On main that consumer is
+  Swift code imports the generated `PasturaSharedEngine` XCFramework. On main that consumer is
   `tools/kmp-gate-spike/**` (6 Swift files `import PasturaSharedEngine`), which builds **nightly /
   `workflow_dispatch` only, not per-PR** (ADR-023 §6, decision B′); the iOS app (`Pastura/**`) does **not** consume the
   framework yet — that is Phase 3.0-gated. So these two are largely **forward-looking**: they were
@@ -19,7 +19,8 @@ Kotlin/Native (K/N) ↔ Swift boundary, and inside the Kotlin port itself. Three
   Kotlin-side in `commonMain`** (in scope) and the live gate-spike consumer (in scope) is where
   they compile-fail today.
 - **Plan-time shape trap (Pattern 3)** — fires whenever a plan exercises a K/N type shape; fully
-  in-scope for `shared/**` edits.
+  in-scope for `shared/**` edits. One entry in its "Same class of trap" list is the exception —
+  interface-member defaults redden a build, so triage a red nightly there too.
 - **Port-time traps (Pattern 4)** — fire while writing the Kotlin port and its tests, with no Swift
   consumer involved; fully in-scope for `shared/**` edits.
 

--- a/.claude/rules/kmp-interop.md
+++ b/.claude/rules/kmp-interop.md
@@ -19,8 +19,9 @@ Kotlin/Native (K/N) ↔ Swift boundary, and inside the Kotlin port itself. Three
   Kotlin-side in `commonMain`** (in scope) and the live gate-spike consumer (in scope) is where
   they compile-fail today.
 - **Plan-time shape trap (Pattern 3)** — fires whenever a plan exercises a K/N type shape; fully
-  in-scope for `shared/**` edits. One entry in its "Same class of trap" list is the exception —
-  interface-member defaults redden a build, so triage a red nightly there too.
+  in-scope for `shared/**` edits. Its "Same class of trap" list also holds the interface-member
+  default, which a Kotlin-only edit trips with no Swift author present — so triage a red nightly
+  there too.
 - **Port-time traps (Pattern 4)** — fire while writing the Kotlin port and its tests, with no Swift
   consumer involved; fully in-scope for `shared/**` edits.
 
@@ -38,6 +39,12 @@ Kotlin/Native (K/N) ↔ Swift boundary, and inside the Kotlin port itself. Three
 > the mechanical gate is the only guarantee.
 
 ## Pattern 1 — K/N exports carry no Swift `Sendable` conformance
+
+> **Artifact note, Patterns 1–2.** The names below are from the models-only `PasturaShared`
+> umbrella the #478 spike consumed; the live consumer imports the separate `PasturaSharedEngine`
+> one (header `PasturaSharedEngine.h`), and ADR-023 §6 forbids linking both. Reading the header
+> *is* the right instrument for these two — a missing conformance is a fact about the emitted text
+> — unlike Pattern 3's "did the member cross at all?", which only compiling settles.
 
 K/N exports Kotlin classes through Obj-C interop. The generated
 `@interface PasturaSharedFoo : PasturaSharedBase` carries **no `Sendable` conformance** — invisible
@@ -141,11 +148,11 @@ Same class of trap:
 - **Default args don't cross** — Swift exports carry no Kotlin default-arg values; pass `nil`
   explicitly.
 - **Interface member defaults don't cross either** — a defaulted `val`/`fun` on an exported
-  `interface` is emitted as a *required* Obj-C member, so adding one stays source-compatible in
-  Kotlin yet breaks every Swift conformer. Unlike the rest of this list it reddens a build — but
-  only the nightly's, since decision B′ keeps the XCFramework out of per-PR lanes (#1472). Fix the
-  conformers in the same PR, and settle any such question by **compiling** the consumer, never by
-  reading the generated header (cf. Pattern 2).
+  `interface` is emitted as a *required* Obj-C member (both arms measured), so adding one stays
+  source-compatible in Kotlin yet breaks every Swift conformer — with no Swift author present, and
+  decision B′ keeping the XCFramework out of per-PR lanes, so the first signal is a red nightly
+  (#1472). Fix the conformers in the same PR, and settle whether a member crossed by **compiling**
+  the consumer, never by reading the generated header alone (cf. Pattern 2).
 - **`val` is read-only in Swift** — a `data class val` property cannot be mutated in place; use
   `.copy(...)` or whole-instance reassignment.
 - **Sealed-class export shape varies** — class vs enum-like surface differs (see Pattern 2).

--- a/.claude/rules/kmp-interop.md
+++ b/.claude/rules/kmp-interop.md
@@ -19,9 +19,8 @@ Kotlin/Native (K/N) ↔ Swift boundary, and inside the Kotlin port itself. Three
   Kotlin-side in `commonMain`** (in scope) and the live gate-spike consumer (in scope) is where
   they compile-fail today.
 - **Plan-time shape trap (Pattern 3)** — fires whenever a plan exercises a K/N type shape; fully
-  in-scope for `shared/**` edits. Its "Same class of trap" list also holds the interface-member
-  default, which a Kotlin-only edit trips with no Swift author present — so triage a red nightly
-  there too.
+  in-scope for `shared/**` edits. Its "Same class of trap" list also covers the interface-member
+  default a Kotlin-only edit trips — triage a red nightly there too.
 - **Port-time traps (Pattern 4)** — fire while writing the Kotlin port and its tests, with no Swift
   consumer involved; fully in-scope for `shared/**` edits.
 
@@ -42,10 +41,9 @@ Kotlin/Native (K/N) ↔ Swift boundary, and inside the Kotlin port itself. Three
 
 > **Artifact note, Patterns 1–2.** The names below are from the models-only `PasturaShared`
 > umbrella the #478 spike consumed; the live consumer imports the separate `PasturaSharedEngine`
-> one (header `PasturaSharedEngine.h`), and ADR-023 §6 forbids linking both. Reading the header
-> answers Pattern 1's question and Pattern 3's interface-default one — both are facts about the
-> emitted text. Pattern 2 is the shape where it misled, because there the question is what Swift
-> does with what was emitted; compile a consumer for that one.
+> one (header `PasturaSharedEngine.h`), and ADR-023 §6 forbids linking both. The header settles
+> what was *emitted* (Pattern 1's question, and Pattern 3's interface-default one); for what Swift
+> then does with it, compile a consumer — Pattern 2 is where header-reading misled.
 
 K/N exports Kotlin classes through Obj-C interop. The generated
 `@interface PasturaSharedFoo : PasturaSharedBase` carries **no `Sendable` conformance** — invisible
@@ -154,17 +152,14 @@ Same class of trap:
 
 - **Default args don't cross** — Swift exports carry no Kotlin default-arg values; pass `nil`
   explicitly.
-- **Interface member defaults don't cross either** — a defaulted `val`/`fun` on an exported
-  `interface` is emitted as a *required* Obj-C member (both arms measured), so adding one stays
-  source-compatible in Kotlin yet breaks every Swift conformer — with no Swift author present, and
-  decision B′ keeping the XCFramework out of per-PR lanes, so the first signal is a red nightly
-  (#1472). Fix the conformers in the same PR. The header settles *this* question on its own: K/N
-  emits no `@optional` section at all, so every interface member lands under `@required` whether
-  or not Kotlin defaulted it — measured on a `val` and a `fun`, Kotlin 2.3.21
-  (`gradle/libs.versions.toml`), 2026-08-14. **Re-grep `@optional` in the regenerated
-  `PasturaSharedEngine.h` after a Kotlin bump** — an `@optional` section appearing flips this,
-  and that edit loads no rule file. Pattern 2 is the shape where header-reading misled; compile a
-  consumer there.
+- **Interface member defaults don't cross either** — K/N emits no `@optional` section at all, so
+  every member of an exported `interface` lands under `@required` whether or not Kotlin defaulted
+  it (measured on a `val` and a `fun`; Kotlin 2.3.21 per `gradle/libs.versions.toml`, 2026-08-14).
+  Adding a defaulted member therefore stays source-compatible in Kotlin yet breaks every Swift
+  conformer — with no Swift author present, and decision B′ keeping the XCFramework out of per-PR
+  lanes, so the first signal is a red nightly (#1472). Fix the conformers in the same PR.
+  **Re-grep `@optional` in the regenerated `PasturaSharedEngine.h` after a Kotlin bump** — an
+  `@optional` section appearing flips this, and that edit loads no rule file.
 - **`val` is read-only in Swift** — a `data class val` property cannot be mutated in place; use
   `.copy(...)` or whole-instance reassignment.
 - **Sealed-class export shape varies** — class vs enum-like surface differs (see Pattern 2).

--- a/.claude/rules/kmp-interop.md
+++ b/.claude/rules/kmp-interop.md
@@ -11,7 +11,7 @@ Kotlin/Native (K/N) ↔ Swift boundary, and inside the Kotlin port itself. Three
 
 - **Compile-time interop traps (Patterns 1–2)** — surface at the *Swift consumption* site when
   Swift code imports the generated `PasturaShared` XCFramework. On main that consumer is
-  `tools/kmp-gate-spike/**` (6 Swift files `import PasturaShared`), which builds **nightly /
+  `tools/kmp-gate-spike/**` (6 Swift files `import PasturaSharedEngine`), which builds **nightly /
   `workflow_dispatch` only, not per-PR** (ADR-023 §6, decision B′); the iOS app (`Pastura/**`) does **not** consume the
   framework yet — that is Phase 3.0-gated. So these two are largely **forward-looking**: they were
   discovered in the W3 spike (PR #478) and bite again when Phase 3.0 K/N ↔ Swift integration
@@ -139,6 +139,12 @@ Same class of trap:
 
 - **Default args don't cross** — Swift exports carry no Kotlin default-arg values; pass `nil`
   explicitly.
+- **Interface member defaults don't cross either** — a defaulted `val`/`fun` on an exported
+  `interface` is emitted as a *required* Obj-C member, so adding one stays source-compatible in
+  Kotlin yet breaks every Swift conformer. Unlike the rest of this list it reddens a build — but
+  only the nightly's, since decision B′ keeps the XCFramework out of per-PR lanes (#1472). Fix the
+  conformers in the same PR, and settle any such question by **compiling** the consumer, never by
+  reading the generated header (cf. Pattern 2).
 - **`val` is read-only in Swift** — a `data class val` property cannot be mutated in place; use
   `.copy(...)` or whole-instance reassignment.
 - **Sealed-class export shape varies** — class vs enum-like surface differs (see Pattern 2).

--- a/.claude/rules/kmp-interop.md
+++ b/.claude/rules/kmp-interop.md
@@ -124,6 +124,12 @@ Swift then calls the flat `SimulationEventFactory.shared.phaseStarted(phaseType:
 cast via the parent-typed value and check a discriminator field, or add a Swift-friendly `kind`
 enum getter on the parent.
 
+⚠️ **That pattern-matching sentence is contradicted under the engine umbrella** and is left
+uncorrected pending re-measurement: the nightly compiles `as? SimulationEvent.AgentOutput` and
+`is SimulationEvent.SimulationCompleted` (7 sites in `tools/kmp-gate-spike/Tests/`). Everything
+above it — the construction rows — was measured under the models umbrella and is *not*
+re-measured, so do not read this as clearing the whole pattern (#1472).
+
 Source: W3 spike, PR #478 (the planned third type `SimulationEvent.PhaseStarted` was pivoted to
 `TurnOutput` after all three call forms failed; header-only inspection misleadingly suggests the
 `swift_name` annotation works).

--- a/.claude/rules/kmp-interop.md
+++ b/.claude/rules/kmp-interop.md
@@ -43,8 +43,9 @@ Kotlin/Native (K/N) ↔ Swift boundary, and inside the Kotlin port itself. Three
 > **Artifact note, Patterns 1–2.** The names below are from the models-only `PasturaShared`
 > umbrella the #478 spike consumed; the live consumer imports the separate `PasturaSharedEngine`
 > one (header `PasturaSharedEngine.h`), and ADR-023 §6 forbids linking both. Reading the header
-> *is* the right instrument for these two — a missing conformance is a fact about the emitted text
-> — unlike Pattern 3's "did the member cross at all?", which only compiling settles.
+> answers Pattern 1's question and Pattern 3's interface-default one — both are facts about the
+> emitted text. Pattern 2 is the shape where it misled, because there the question is what Swift
+> does with what was emitted; compile a consumer for that one.
 
 K/N exports Kotlin classes through Obj-C interop. The generated
 `@interface PasturaSharedFoo : PasturaSharedBase` carries **no `Sendable` conformance** — invisible
@@ -151,8 +152,10 @@ Same class of trap:
   `interface` is emitted as a *required* Obj-C member (both arms measured), so adding one stays
   source-compatible in Kotlin yet breaks every Swift conformer — with no Swift author present, and
   decision B′ keeping the XCFramework out of per-PR lanes, so the first signal is a red nightly
-  (#1472). Fix the conformers in the same PR, and settle whether a member crossed by **compiling**
-  the consumer, never by reading the generated header alone (cf. Pattern 2).
+  (#1472). Fix the conformers in the same PR. The header settles *this* question on its own: K/N
+  emits no `@optional` section at all, so every interface member lands under `@required` whether
+  or not Kotlin defaulted it — measured on a `val` and a `fun`. Pattern 2 is the shape where
+  header-reading misled; compile a consumer there.
 - **`val` is read-only in Swift** — a `data class val` property cannot be mutated in place; use
   `.copy(...)` or whole-instance reassignment.
 - **Sealed-class export shape varies** — class vs enum-like surface differs (see Pattern 2).

--- a/.claude/rules/kmp-interop.md
+++ b/.claude/rules/kmp-interop.md
@@ -154,8 +154,11 @@ Same class of trap:
   decision B′ keeping the XCFramework out of per-PR lanes, so the first signal is a red nightly
   (#1472). Fix the conformers in the same PR. The header settles *this* question on its own: K/N
   emits no `@optional` section at all, so every interface member lands under `@required` whether
-  or not Kotlin defaulted it — measured on a `val` and a `fun`. Pattern 2 is the shape where
-  header-reading misled; compile a consumer there.
+  or not Kotlin defaulted it — measured on a `val` and a `fun`, Kotlin 2.3.21
+  (`gradle/libs.versions.toml`), 2026-08-14. **Re-grep `@optional` in the regenerated
+  `PasturaSharedEngine.h` after a Kotlin bump** — an `@optional` section appearing flips this,
+  and that edit loads no rule file. Pattern 2 is the shape where header-reading misled; compile a
+  consumer there.
 - **`val` is read-only in Swift** — a `data class val` property cannot be mutated in place; use
   `.copy(...)` or whole-instance reassignment.
 - **Sealed-class export shape varies** — class vs enum-like surface differs (see Pattern 2).

--- a/docs/kmp-migration-status.md
+++ b/docs/kmp-migration-status.md
@@ -33,7 +33,7 @@ _Last updated: 2026-08-14._
 | 2 | Two-boundary vertical slice = GO/NO-GO gate | ✅ **GO** (2026-07-18) | #1063 #1137 #1172 · [ADR-023 §12](decisions/ADR-023.md) |
 | 3 | Bulk port to `commonMain` | 🔄 in progress | ↓ Stage 3 breakdown |
 | 4 | Cross-language parity harness | 🔄 in progress | slice 1a landed ([#1387](https://github.com/tyabu12/pastura/issues/1387), closed); 1b next · [#501](https://github.com/tyabu12/pastura/issues/501) |
-| 5 | iOS consumption switch + code-merge | ⬜ not started | the remaining integration · when writing the Swift `LLMBackend` adapter, confirm whether `knownTurnMarkers`' Kotlin interface default crosses K/N — by compiling the adapter, since a `PasturaShared.h` read alone does not settle it (see that member's KDoc) · ⚠️ en-only `ScenarioValidationMessage.render()` blocks this — [#1464](https://github.com/tyabu12/pastura/issues/1464) |
+| 5 | iOS consumption switch + code-merge | ⬜ not started | the remaining integration · ⚠️ en-only `ScenarioValidationMessage.render()` blocks this — [#1464](https://github.com/tyabu12/pastura/issues/1464) |
 
 Legend: ✅ done · 🔄 in progress · 🟡 partial · ⬜ not started.
 

--- a/docs/kmp-migration-status.md
+++ b/docs/kmp-migration-status.md
@@ -33,7 +33,7 @@ _Last updated: 2026-08-14._
 | 2 | Two-boundary vertical slice = GO/NO-GO gate | ✅ **GO** (2026-07-18) | #1063 #1137 #1172 · [ADR-023 §12](decisions/ADR-023.md) |
 | 3 | Bulk port to `commonMain` | 🔄 in progress | ↓ Stage 3 breakdown |
 | 4 | Cross-language parity harness | 🔄 in progress | slice 1a landed ([#1387](https://github.com/tyabu12/pastura/issues/1387), closed); 1b next · [#501](https://github.com/tyabu12/pastura/issues/501) |
-| 5 | iOS consumption switch + code-merge | ⬜ not started | the remaining integration · ⚠️ en-only `ScenarioValidationMessage.render()` blocks this — [#1464](https://github.com/tyabu12/pastura/issues/1464) |
+| 5 | iOS consumption switch + code-merge | ⬜ not started | the remaining integration · adapter traps: [`kmp-interop.md`](../.claude/rules/kmp-interop.md) · ⚠️ en-only `ScenarioValidationMessage.render()` blocks this — [#1464](https://github.com/tyabu12/pastura/issues/1464) |
 
 Legend: ✅ done · 🔄 in progress · 🟡 partial · ⬜ not started.
 

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMBackend.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMBackend.kt
@@ -87,6 +87,13 @@ public interface LLMBackend {
      * a required Obj-C property, so the Phase 3.0 Swift adapter over `LlamaCppService` must state
      * it explicitly; it cannot inherit ChatML-only. Same for any future defaulted member here:
      * `.claude/rules/kmp-interop.md` Pattern 3.
+     *
+     * The compiler enforces that much. What it does not: this property is read from
+     * `Dispatchers.Default`, and `LLMBackend` imports into Swift as an **unannotated** Obj-C
+     * protocol, so an adapter that omits type-level `nonisolated` under
+     * `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` compiles clean and traps at runtime on the
+     * `@objc` thunk (`.claude/rules/swift-isolation.md` Pattern 7). All three gate-spike
+     * conformers carry it for this reason.
      */
     public val knownTurnMarkers: List<ChatTurnMarkers>
         get() = listOf(ChatTurnMarkers.chatML)

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMBackend.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMBackend.kt
@@ -83,13 +83,10 @@ public interface LLMBackend {
      * backend that cannot name its model keeps the pre-#1422 ChatML-only behaviour. Mirrors
      * Swift's `LLMService.knownTurnMarkers` name-for-name.
      *
-     * ⚠️ **Expected — not verified — that this default does not cross Kotlin/Native.** A Kotlin
-     * interface default implementation may not reach the generated Obj-C protocol as an optional
-     * requirement, which would oblige the Phase 3.0 Swift adapter over `LlamaCppService` to state
-     * this member explicitly rather than inherit ChatML-only. **Confirm by compiling that
-     * adapter, not by reading the generated `PasturaShared.h` alone** —
-     * `.claude/rules/kmp-interop.md` Pattern 2 is the precedent where the header itself misled.
-     * Distinct from Pattern 3's default-**argument** bullet, which settles nothing here.
+     * ⚠️ **This default does not cross Kotlin/Native** — measured, #1472. K/N emits the member as
+     * a required Obj-C property, so the Phase 3.0 Swift adapter over `LlamaCppService` must state
+     * it explicitly; it cannot inherit ChatML-only. Same for any future defaulted member here:
+     * `.claude/rules/kmp-interop.md` Pattern 3.
      */
     public val knownTurnMarkers: List<ChatTurnMarkers>
         get() = listOf(ChatTurnMarkers.chatML)

--- a/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMBackend.kt
+++ b/shared/engine/src/commonMain/kotlin/com/pastura/engine/LLMBackend.kt
@@ -85,8 +85,8 @@ public interface LLMBackend {
      *
      * ⚠️ **This default does not cross Kotlin/Native** — measured, #1472. K/N emits the member as
      * a required Obj-C property, so the Phase 3.0 Swift adapter over `LlamaCppService` must state
-     * it explicitly; it cannot inherit ChatML-only. Same for any future defaulted member here:
-     * `.claude/rules/kmp-interop.md` Pattern 3.
+     * it explicitly rather than inherit ChatML-only — as must any future defaulted member here
+     * (`.claude/rules/kmp-interop.md` Pattern 3).
      *
      * The compiler enforces that much. What it does not: this property is read from
      * `Dispatchers.Default`, and `LLMBackend` imports into Swift as an **unannotated** Obj-C

--- a/tools/kmp-gate-spike/Sources/KMPGateSpike/ScriptedStreamingBackend.swift
+++ b/tools/kmp-gate-spike/Sources/KMPGateSpike/ScriptedStreamingBackend.swift
@@ -131,9 +131,22 @@ nonisolated public final class ScriptedStreamingBackend: LLMBackend, @unchecked 
   ///   Kotlin's retry loop, which can legitimately issue more calls than a
   ///   test anticipated, and a trap there would read as a crash rather than as
   ///   the miscount it is.
-  public init(responses: [ScriptedResponse]) {
+  /// - Parameter knownTurnMarkers: Defaults to the Kotlin companion's ChatML
+  ///   pair — the value `LLMBackend`'s interface default would supply if it
+  ///   crossed K/N, which it does not (#1472). Injectable so a test can give a
+  ///   decorator something other than ChatML to forward; without that, every
+  ///   conformer in the package returns the same value and forwarding is
+  ///   indistinguishable from hardcoding.
+  public init(
+    responses: [ScriptedResponse],
+    knownTurnMarkers: [ChatTurnMarkers] = [ChatTurnMarkers.companion.chatML]
+  ) {
     self.script = Mutex(responses)
+    self.knownTurnMarkers = knownTurnMarkers
   }
+
+  /// The leaf's own pair — see the initializer parameter.
+  public let knownTurnMarkers: [ChatTurnMarkers]
 
   /// Error code reported when the script runs out of responses.
   public static let scriptExhaustedErrorCode = "spike.script_exhausted"

--- a/tools/kmp-gate-spike/Sources/KMPGateSpike/ScriptedStreamingBackend.swift
+++ b/tools/kmp-gate-spike/Sources/KMPGateSpike/ScriptedStreamingBackend.swift
@@ -141,10 +141,10 @@ nonisolated public final class ScriptedStreamingBackend: LLMBackend, @unchecked 
   ///   the miscount it is.
   /// - Parameter knownTurnMarkers: Defaults to the Kotlin companion's ChatML
   ///   pair — the value `LLMBackend`'s interface default would supply if it
-  ///   crossed K/N, which it does not (#1472). Injectable so a test can give a
-  ///   decorator something other than ChatML to forward; without that, every
-  ///   conformer in the package returns the same value and forwarding is
-  ///   indistinguishable from hardcoding.
+  ///   crossed K/N, which it does not (#1472). Injectable so a test can hand a
+  ///   decorator a non-ChatML pair to forward — why that is the only way to
+  ///   tell forwarding from hardcoding is on
+  ///   `BoundaryContractTests.decoratorForwardsKnownTurnMarkers`.
   public init(
     responses: [ScriptedResponse],
     knownTurnMarkers: [ChatTurnMarkers] = [ChatTurnMarkers.companion.chatML]

--- a/tools/kmp-gate-spike/Sources/KMPGateSpike/ScriptedStreamingBackend.swift
+++ b/tools/kmp-gate-spike/Sources/KMPGateSpike/ScriptedStreamingBackend.swift
@@ -124,6 +124,14 @@ nonisolated public final class ScriptedStreamingBackend: LLMBackend, @unchecked 
   private let script: Mutex<[ScriptedResponse]>
   private let counters = Counters()
 
+  /// The leaf's own pair — see the initializer parameter.
+  ///
+  /// Covered by the class's `@unchecked Sendable`, and the only stored member
+  /// here that needs the exemption: a K/N export carries no `Sendable`
+  /// conformance (`kmp-interop.md` Pattern 1), so this stays sound only while
+  /// `ChatTurnMarkers`' two fields remain `val` on the Kotlin side.
+  public let knownTurnMarkers: [ChatTurnMarkers]
+
   /// - Parameter responses: Consumed in order, one per `generateStream` call —
   ///   the `MockLLMService` convention (CLAUDE.md § Testing Strategy). A call
   ///   past the end of the script terminates as `.failed` with
@@ -144,9 +152,6 @@ nonisolated public final class ScriptedStreamingBackend: LLMBackend, @unchecked 
     self.script = Mutex(responses)
     self.knownTurnMarkers = knownTurnMarkers
   }
-
-  /// The leaf's own pair — see the initializer parameter.
-  public let knownTurnMarkers: [ChatTurnMarkers]
 
   /// Error code reported when the script runs out of responses.
   public static let scriptExhaustedErrorCode = "spike.script_exhausted"

--- a/tools/kmp-gate-spike/Sources/KMPGateSpike/SharedEngineRunner.swift
+++ b/tools/kmp-gate-spike/Sources/KMPGateSpike/SharedEngineRunner.swift
@@ -253,10 +253,10 @@ nonisolated private final class SuspensionRelayingBackend: LLMBackend, @unchecke
     self.relayBox = relayBox
   }
 
-  /// Forwarded, not defaulted. Kotlin's interface default for this member does
-  /// not cross K/N (#1472), so every Swift conformer must state it — and a
-  /// transparent decorator that answered with ChatML would mask whatever pair
-  /// the wrapped backend reports, which at Stage 5 is the model's own.
+  /// Forwarded, not defaulted: a transparent decorator answering ChatML would
+  /// mask whatever pair the wrapped backend reports, which at Stage 5 is the
+  /// model's own. (Stated at all because Kotlin's interface default does not
+  /// cross K/N — #1472.)
   ///
   /// Asserted end to end by
   /// `BoundaryContractTests.kotlinTruncatesOnForwardedTurnMarkers`: Kotlin

--- a/tools/kmp-gate-spike/Sources/KMPGateSpike/SharedEngineRunner.swift
+++ b/tools/kmp-gate-spike/Sources/KMPGateSpike/SharedEngineRunner.swift
@@ -253,6 +253,16 @@ nonisolated private final class SuspensionRelayingBackend: LLMBackend, @unchecke
     self.relayBox = relayBox
   }
 
+  /// Forwarded, not defaulted. Kotlin's interface default for this member does
+  /// not cross K/N (#1472), so every Swift conformer must state it — and a
+  /// transparent decorator that answered with ChatML would mask whatever pair
+  /// the wrapped backend reports, which at Stage 5 is the model's own.
+  ///
+  /// Not directly asserted: this type is `private`, so no test constructs it.
+  /// The decorator-transparency arm runs against the sibling shape in
+  /// `BoundaryContractTests.decoratorForwardsKnownTurnMarkers`.
+  var knownTurnMarkers: [ChatTurnMarkers] { wrapped.knownTurnMarkers }
+
   func generateStream(
     request: GenerationRequest,
     callbacks: any StreamCallbacks

--- a/tools/kmp-gate-spike/Sources/KMPGateSpike/SharedEngineRunner.swift
+++ b/tools/kmp-gate-spike/Sources/KMPGateSpike/SharedEngineRunner.swift
@@ -258,9 +258,10 @@ nonisolated private final class SuspensionRelayingBackend: LLMBackend, @unchecke
   /// transparent decorator that answered with ChatML would mask whatever pair
   /// the wrapped backend reports, which at Stage 5 is the model's own.
   ///
-  /// Not directly asserted: this type is `private`, so no test constructs it.
-  /// The decorator-transparency arm runs against the sibling shape in
-  /// `BoundaryContractTests.decoratorForwardsKnownTurnMarkers`.
+  /// Asserted end to end by
+  /// `BoundaryContractTests.kotlinTruncatesOnForwardedTurnMarkers`: Kotlin
+  /// reads this property off *this* object on every inference, so a ChatML
+  /// hardcode here reaches #1422 truncation and reddens there.
   var knownTurnMarkers: [ChatTurnMarkers] { wrapped.knownTurnMarkers }
 
   func generateStream(

--- a/tools/kmp-gate-spike/Tests/KMPGateSpikeTests/BoundaryContractTests.swift
+++ b/tools/kmp-gate-spike/Tests/KMPGateSpikeTests/BoundaryContractTests.swift
@@ -415,11 +415,17 @@ struct BoundaryContractTests {
   /// own pair.
   @Test("a decorator forwards the wrapped backend's turn markers")
   func decoratorForwardsKnownTurnMarkers() {
-    let gemmaShaped = ChatTurnMarkers(start: "<|turn>", end: "<turn|>")
-    let leaf = ScriptedStreamingBackend(responses: [], knownTurnMarkers: [gemmaShaped])
+    // The union form `LLMBackend.knownTurnMarkers` documents — a model's own
+    // pair *plus* ChatML — so the fixture is a value a real backend could
+    // report. Differing from ChatML is all the assertion needs; excluding it
+    // would have discriminated just as well while modelling an illegal one.
+    let pair = [
+      ChatTurnMarkers(start: "<|turn>", end: "<turn|>"), ChatTurnMarkers.companion.chatML
+    ]
+    let leaf = ScriptedStreamingBackend(responses: [], knownTurnMarkers: pair)
     let decorated = ThreadObservingBackend(wrapping: leaf, recordingInto: ThreadObservations())
 
-    #expect(decorated.knownTurnMarkers == [gemmaShaped])
+    #expect(decorated.knownTurnMarkers == pair)
   }
 }
 

--- a/tools/kmp-gate-spike/Tests/KMPGateSpikeTests/BoundaryContractTests.swift
+++ b/tools/kmp-gate-spike/Tests/KMPGateSpikeTests/BoundaryContractTests.swift
@@ -411,12 +411,11 @@ struct BoundaryContractTests {
   /// ChatML instead lets the hallucinated continuation through. Nothing in
   /// Swift observes that; only a run does.
   ///
-  /// Both arms are run here rather than borrowing the outcomes from
+  /// Both arms run here rather than borrowing the outcomes from
   /// `JSONResponseParserTurnMarkerTests`' `fencedHallucination`, which this
-  /// fixture mirrors. That suite is a different language *and* a different CI
-  /// lane, and nothing gates the pair: were its fixture to stop discriminating,
-  /// a borrowed control would leave this test passing while asserting nothing —
-  /// the same silent shape the property itself guards against.
+  /// fixture mirrors: that suite is another language and another CI lane, and
+  /// nothing gates the pair — were its fixture to stop discriminating, a
+  /// borrowed control would leave this test passing while asserting nothing.
   @Test("Kotlin truncates on the markers the relaying decorator forwards")
   func kotlinTruncatesOnForwardedTurnMarkers() async throws {
     let fencedHallucination = """
@@ -470,8 +469,8 @@ struct BoundaryContractTests {
   func decoratorForwardsKnownTurnMarkers() {
     // The union form `LLMBackend.knownTurnMarkers` documents — a model's own
     // pair *plus* ChatML — so the fixture is a value a real backend could
-    // report. Differing from ChatML is all the assertion needs; excluding it
-    // would have discriminated just as well while modelling an illegal one.
+    // report. Dropping ChatML would discriminate just as well but break the
+    // union it documents.
     let pair = [
       ChatTurnMarkers(start: "<|turn>", end: "<turn|>"), ChatTurnMarkers.companion.chatML
     ]

--- a/tools/kmp-gate-spike/Tests/KMPGateSpikeTests/BoundaryContractTests.swift
+++ b/tools/kmp-gate-spike/Tests/KMPGateSpikeTests/BoundaryContractTests.swift
@@ -413,6 +413,47 @@ struct BoundaryContractTests {
   /// indistinguishable from one that forwards — and would go wrong only at
   /// Stage 5, where the leaf becomes `LlamaCppService` and reports its model's
   /// own pair.
+  /// The arm that crosses the boundary. Kotlin reads `knownTurnMarkers` off
+  /// the backend it was handed — `SuspensionRelayingBackend`, the permanent
+  /// §10 adapter — and keys #1422 truncation on it, so a decorator answering
+  /// ChatML instead lets the hallucinated continuation through. Nothing in
+  /// Swift observes that; only a run does.
+  ///
+  /// Fixture byte-identical to `JSONResponseParserTurnMarkerTests`'
+  /// `fencedHallucination`, whose own negative control fixes both outcomes:
+  /// the Gemma pair yields `本物`, ChatML-only yields `偽物`.
+  @Test("Kotlin truncates on the markers the relaying decorator forwards")
+  func kotlinTruncatesOnForwardedTurnMarkers() async throws {
+    let fencedHallucination = """
+      {"statement": "本物", "action": "cooperate"}<turn|>
+      <|turn>user
+      もう一度
+      <turn|>
+      <|turn>model
+      ```json
+      {"statement": "偽物", "action": "betray"}
+      ```
+      """
+    let runner = SharedEngineRunner()
+    let backend = ScriptedStreamingBackend(
+      responses: Array(
+        repeating: ScriptedResponse(
+          deltas: [fencedHallucination], ending: .completed(completionTokens: nil)),
+        count: 2),
+      knownTurnMarkers: [
+        ChatTurnMarkers(start: "<|turn>", end: "<turn|>"), ChatTurnMarkers.companion.chatML
+      ])
+
+    var statements: [String] = []
+    for await event in runner.run(scenario: .oneSpeakAllTurn, backend: backend) {
+      if let agentOutput = event as? SimulationEvent.AgentOutput {
+        statements.append(agentOutput.output.statement ?? "")
+      }
+    }
+
+    #expect(statements == ["本物", "本物"])
+  }
+
   @Test("a decorator forwards the wrapped backend's turn markers")
   func decoratorForwardsKnownTurnMarkers() {
     // The union form `LLMBackend.knownTurnMarkers` documents — a model's own

--- a/tools/kmp-gate-spike/Tests/KMPGateSpikeTests/BoundaryContractTests.swift
+++ b/tools/kmp-gate-spike/Tests/KMPGateSpikeTests/BoundaryContractTests.swift
@@ -404,6 +404,23 @@ struct BoundaryContractTests {
       #expect(handle.log == ["resume", "cancel"])
     }
   }
+
+  /// A decorator must surface the wrapped backend's pair, not the ChatML value
+  /// Kotlin's interface default would have supplied (#1472).
+  ///
+  /// Without the injected pair this assertion could not exist: every conformer
+  /// in the package answers ChatML, so a decorator that hardcoded it would be
+  /// indistinguishable from one that forwards — and would go wrong only at
+  /// Stage 5, where the leaf becomes `LlamaCppService` and reports its model's
+  /// own pair.
+  @Test("a decorator forwards the wrapped backend's turn markers")
+  func decoratorForwardsKnownTurnMarkers() {
+    let gemmaShaped = ChatTurnMarkers(start: "<|turn>", end: "<turn|>")
+    let leaf = ScriptedStreamingBackend(responses: [], knownTurnMarkers: [gemmaShaped])
+    let decorated = ThreadObservingBackend(wrapping: leaf, recordingInto: ThreadObservations())
+
+    #expect(decorated.knownTurnMarkers == [gemmaShaped])
+  }
 }
 
 /// Records what the latch delivers, **in order** — counts alone cannot express

--- a/tools/kmp-gate-spike/Tests/KMPGateSpikeTests/BoundaryContractTests.swift
+++ b/tools/kmp-gate-spike/Tests/KMPGateSpikeTests/BoundaryContractTests.swift
@@ -405,23 +405,18 @@ struct BoundaryContractTests {
     }
   }
 
-  /// A decorator must surface the wrapped backend's pair, not the ChatML value
-  /// Kotlin's interface default would have supplied (#1472).
-  ///
-  /// Without the injected pair this assertion could not exist: every conformer
-  /// in the package answers ChatML, so a decorator that hardcoded it would be
-  /// indistinguishable from one that forwards — and would go wrong only at
-  /// Stage 5, where the leaf becomes `LlamaCppService` and reports its model's
-  /// own pair.
   /// The arm that crosses the boundary. Kotlin reads `knownTurnMarkers` off
   /// the backend it was handed — `SuspensionRelayingBackend`, the permanent
   /// §10 adapter — and keys #1422 truncation on it, so a decorator answering
   /// ChatML instead lets the hallucinated continuation through. Nothing in
   /// Swift observes that; only a run does.
   ///
-  /// Fixture byte-identical to `JSONResponseParserTurnMarkerTests`'
-  /// `fencedHallucination`, whose own negative control fixes both outcomes:
-  /// the Gemma pair yields `本物`, ChatML-only yields `偽物`.
+  /// Both arms are run here rather than borrowing the outcomes from
+  /// `JSONResponseParserTurnMarkerTests`' `fencedHallucination`, which this
+  /// fixture mirrors. That suite is a different language *and* a different CI
+  /// lane, and nothing gates the pair: were its fixture to stop discriminating,
+  /// a borrowed control would leave this test passing while asserting nothing —
+  /// the same silent shape the property itself guards against.
   @Test("Kotlin truncates on the markers the relaying decorator forwards")
   func kotlinTruncatesOnForwardedTurnMarkers() async throws {
     let fencedHallucination = """
@@ -434,26 +429,43 @@ struct BoundaryContractTests {
       {"statement": "偽物", "action": "betray"}
       ```
       """
-    let runner = SharedEngineRunner()
-    let backend = ScriptedStreamingBackend(
-      responses: Array(
+    func script() -> [ScriptedResponse] {
+      Array(
         repeating: ScriptedResponse(
           deltas: [fencedHallucination], ending: .completed(completionTokens: nil)),
-        count: 2),
+        count: 2)
+    }
+    func statements(from backend: ScriptedStreamingBackend) async -> [String] {
+      var collected: [String] = []
+      for await event in SharedEngineRunner().run(
+        scenario: .oneSpeakAllTurn, backend: backend) {
+        if let agentOutput = event as? SimulationEvent.AgentOutput {
+          collected.append(agentOutput.output.statement ?? "")
+        }
+      }
+      return collected
+    }
+
+    let withGemmaPair = ScriptedStreamingBackend(
+      responses: script(),
       knownTurnMarkers: [
         ChatTurnMarkers(start: "<|turn>", end: "<turn|>"), ChatTurnMarkers.companion.chatML
       ])
+    // The control: same fixture, leaf left at the ChatML-only default.
+    let chatMLOnly = ScriptedStreamingBackend(responses: script())
 
-    var statements: [String] = []
-    for await event in runner.run(scenario: .oneSpeakAllTurn, backend: backend) {
-      if let agentOutput = event as? SimulationEvent.AgentOutput {
-        statements.append(agentOutput.output.statement ?? "")
-      }
-    }
-
-    #expect(statements == ["本物", "本物"])
+    #expect(await statements(from: withGemmaPair) == ["本物", "本物"])
+    #expect(await statements(from: chatMLOnly) == ["偽物", "偽物"])
   }
 
+  /// A decorator must surface the wrapped backend's pair, not the ChatML value
+  /// Kotlin's interface default would have supplied (#1472).
+  ///
+  /// Without the injected pair this assertion could not exist: every conformer
+  /// in the package answers ChatML, so a decorator that hardcoded it would be
+  /// indistinguishable from one that forwards — and would go wrong only at
+  /// Stage 5, where the leaf becomes `LlamaCppService` and reports its model's
+  /// own pair.
   @Test("a decorator forwards the wrapped backend's turn markers")
   func decoratorForwardsKnownTurnMarkers() {
     // The union form `LLMBackend.knownTurnMarkers` documents — a model's own

--- a/tools/kmp-gate-spike/Tests/KMPGateSpikeTests/PatternSixProbeTests.swift
+++ b/tools/kmp-gate-spike/Tests/KMPGateSpikeTests/PatternSixProbeTests.swift
@@ -288,6 +288,9 @@ nonisolated final class ThreadObservingBackend: LLMBackend, @unchecked Sendable 
     self.observations = observations
   }
 
+  /// Forwarded for the same reason as `SuspensionRelayingBackend`'s — see there.
+  var knownTurnMarkers: [ChatTurnMarkers] { wrapped.knownTurnMarkers }
+
   func generateStream(
     request: GenerationRequest,
     callbacks: any StreamCallbacks


### PR DESCRIPTION
## Summary

Fixes the red `KMP nightly full-native` ([run 31768010343](https://github.com/tyabu12/pastura/actions/runs/31768010343)).

#1454 added `knownTurnMarkers` to the Kotlin `LLMBackend` interface with a default getter. **That default does not cross Kotlin/Native** — K/N emits the member as a *required* Obj-C property — so every Swift conformer in `tools/kmp-gate-spike` lost conformance. No per-PR lane could catch it: ADR-023 §6 decision B′ keeps the XCFramework out of all of them, which is exactly the gap the nightly exists to cover. It did its job, on the first night.

The KDoc on that very property had predicted this and asked for it to be settled by compiling. This PR settles it and records the result.

### The fix

Three conformers, split by shape:

| Conformer | Kind | Answers |
|---|---|---|
| `ScriptedStreamingBackend` | leaf | the companion's ChatML pair — what the interface default would have supplied |
| `SuspensionRelayingBackend` | transparent decorator (permanent §10 adapter) | forwards `wrapped.knownTurnMarkers` |
| `ThreadObservingBackend` | transparent decorator (test-side) | forwards `wrapped.knownTurnMarkers` |

Hardcoding ChatML into a decorator would mask the wrapped backend's pair and go wrong only at Stage 5, when the leaf becomes `LlamaCppService` and reports its model's own.

### Docs

The KDoc's hedge becomes the measured fact; a sibling bullet lands in `kmp-interop.md` Pattern 3's "Same class of trap" list so the *next* defaulted member is covered at the authoring site; the status board's restatement of the same open question is deleted, keeping a pointer.

Prose delta across those three files: **+41 / −11**. Not the net shrink originally planned — the rule bullet costs more than the KDoc compression saves, and trimming further would drop a load-bearing clause.

**Context-economy: kept 4, compressed 1, dropped 1.** All additions land in `kmp-interop.md`, which is **path-scoped** (`shared/**`, `tools/kmp-gate-spike/**`) — nothing here is charged to every turn. Kept: the interface-default bullet (lead claim + "fix the conformers in the same PR" + measured fact + toolchain stamp), the Pattern 1/2 artifact note (prevents following a name to a header that is not in the tree), the Pattern 3 header routing clause, and the Pattern 2 staleness marker (a factual correction to a row three sentences in this PR cite). Compressed: the bullet lost a comparative clause that turned out to be false. Dropped: the board's 45-word rationale sentence, which violated that file's pointer-only invariant.

## Test plan

Reproduced and verified locally in the shape CI runs (`kmp-nightly.yml:250-255`):

- **Red reproduced** — `stage-framework.sh` → `swift build` exits 1 on the two `Sources/` conformers.
- **Green after** — `swift build` + `swift test --no-parallel` both exit 0, **31 tests / 5 suites**. Re-run after the rebase onto #1471, which moved the XCFramework surface.
- iOS unit suite `** TEST SUCCEEDED **` (3454 tests); `swiftlint --strict` clean; `check-kmp-status.py` reconciles.

Four negative controls, because none of the above discriminates on its own:

1. **The conformer set is 3, and only `grep` can say so.** `swift build --build-tests` still reported 2 — `Sources` aborts before the test target compiles, which is why the CI log listed 2. Fixing those two made `ThreadObservingBackend` appear.
2. **A defaulted `fun` crosses the same way as a `val`.** A throwaway probe on the interface landed under the protocol's `@required` section (the header has no `@optional` section at all) and failed the same two conformers. Both arms of the rule's `val`/`fun` wording are measured.
3. **The decorator arm fails when a decorator hardcodes** — `[<|im_start|>…]` against the union fixture.
4. **The e2e arm fails when the *production* decorator hardcodes.** This one exists because `/code-review` ran the control and found all 30 tests still green: the permanent §10 adapter was the only unguarded conformer, and the comment excusing that was factually wrong (`SharedEngineRunner.run` constructs one on every e2e run).

That arm now carries its own ChatML-only control in-test (`偽物` vs `本物`) rather than importing the outcomes from the Kotlin parser suite — `/risk-review` pointed out that borrowing a control across a language *and* a CI-lane boundary, with no gate on the pair, would let this test pass vacuously the day that fixture stopped discriminating. Which is the exact silent shape the property guards.

## Review

`claude-kit:critic` ×2 (Opus), `code-reviewer` ×2 (Opus), `/code-review high`, `/risk-review` (3 clusters). Each instrument found what the previous missed:

- critic pass 1 — **Critical**: the conformer set was 2, not 3; the plan had inherited the CI log's truncation as an enumeration.
- critic pass 2 — the leaf/decorator distinction, the status-board mirror, and a norm that would have survived nowhere.
- `code-reviewer` — the `val`-only measurement behind a `val`/`fun` claim; a fixture modelling a value no real backend could report.
- `/code-review` — the unguarded production decorator, and that this PR's own "compile, never read the header" norm contradicted this PR's own measurement.
- `/risk-review` — the borrowed negative control above; a measured fact shipped without the toolchain stamp this repo's other rules carry; and that Pattern 2, which this PR newly cites three times, has a row contradicted by 7 sites the nightly compiles.

### Deliberately not in this PR

`/risk-review` also found that the **Pattern 7 half has no carrier that reaches its audience**: `kmp-interop.md` never injects for `Pastura/**`, always-loaded `swift-isolation.md` contains zero Kotlin references, and `engine.md` (which does cover `Pastura/Pastura/LLM/**`) is unused. Same class: the artifact note sits 35 lines from Pattern 2's own examples, and Pattern 1's copyable line is hedged rather than de-literalized. These are knowledge-placement defects whose cost lands at Stage 5 — not started — and fixing them means rewriting rule content this PR did not create. Filed as #1482 rather than grown into here.

**No mechanical gate is added.** Per-PR detection would require an XCFramework dependency, which decision B′ forbids; the nightly already caught this within a day and auto-filed. What was missing was a prompt at the *authoring* site, which is what the rule bullet supplies.

Known gap, stated rather than implied: `ChatTurnMarkers`' `@unchecked Sendable` coverage depends on both Kotlin fields staying `val`; the property doc says so, nothing enforces it.

## Device QA

実機QA不要 — no `Pastura/**` file changed. The diff is the gate-spike SwiftPM package (built by `swift build`, never by the app scheme), Kotlin KDoc, and docs.

Closes #1472
