### PR TITLE
✨ feat: DRY サンプラの構築を harness から観測可能にする（#1415 の positive control）

### DIFF
--- a/.claude/skills/model-eval/SKILL.md
+++ b/.claude/skills/model-eval/SKILL.md
@@ -171,7 +171,7 @@ from its second round on:
 | `samplerDrySeeded` **zero** in `prisoners_dilemma` / `bokete` | **correct, not a defect.** Neither preset has a `speak_each` phase, so 4 of the 6 cells emit only `reason=no-seeds` |
 | `reason=disabled` in a plain battery | DRY is off — `PASTURA_DRY_MULTIPLIER` leaked into the environment; the arm is invalid, re-run |
 | `reason=null-init` or `reason=no-model` | never expected; either is a defect worth an issue |
-| fewer markers than the cell's generations | a **throwing** exit — grammar parse failure (#194) or grammar-without-vocab — which emits no marker and whose own error goes to OSLog only, so the sidecar shows neither. Check `run_end.status` / `attempts`, not the sweep alone |
+| fewer markers than the cell's generations | a **throwing** exit, which emits no marker and whose own error goes to OSLog only, so the sidecar shows neither. The two grammar ones (parse failure #194, grammar-without-vocab) are run-fatal, so `run_end.status` catches them; a NULL `chain_init` only degrades the turn, and the short count is the sole signal |
 | **no `samplerDry*` line at all** | the one unambiguous instrument failure — every non-throwing `createSampler` exit emits exactly one |
 
 **Do not reconcile the `samplerDry*` total against `inference_completed`** —

--- a/.claude/skills/model-eval/SKILL.md
+++ b/.claude/skills/model-eval/SKILL.md
@@ -172,12 +172,11 @@ candidate model.
 Read the DRY markers (#1483) **against the cell's phase shape**, never as a
 bare count. `speak_each` is the only phase in Engine that seeds DRY (canonical:
 `.claude/rules/engine.md` § "The chain's `penalties` cannot reach across a
-`generate()`"; predicate: `Engine/Phases/SpeakEachHandler.swift`) — and it seeds
-an agent once that agent has a non-empty prior `lastOutputs` entry, **not** "from
-round 2 on". `lastOutputs` survives across phases, so a second `speak_each` seeds
-from its first round: `word_wolf` yields 10 seeded of 26, not 5. If a second
-seeding phase is ever added, this table goes stale — it sits outside
-`engine.md`'s path scope and nothing will prompt you.
+`generate()`"; predicate: `Engine/Phases/SpeakEachHandler.swift`). The seeding
+rule and its round-index trap are on `DryUnavailableReason.noSeeds`; measured
+per-scenario counts are in `docs/models/eval-log.md` § "DRY sampler
+construction". If a second seeding phase is ever added, this table goes stale —
+it sits outside `engine.md`'s path scope and nothing will prompt you.
 
 | observation | reading |
 |---|---|
@@ -191,9 +190,8 @@ seeding phase is ever added, this table goes stale — it sits outside
 
 **`samplerDry*` totals do not equal `inference_completed`** — but the offset is
 computable, and it is the *only* detector for a sampler throw in a `narrate`
-turn (`NarrateHandler` swallows that failure with no `.narration`, no
-`.turnSkipped` and a no-op emitter, so neither `run_end.status` nor the event
-stream shows it). Expected total, from the JSONL the cell already produced:
+turn (the row above; derivation in `docs/models/eval-log.md` § "DRY sampler
+construction"). Expected total, from the JSONL the cell already produced:
 
 ```bash
 python3 - "$JSONL" <<'PY'
@@ -213,9 +211,8 @@ It scales with rounds — a 3-round scenario with one `narrate` offsets by 3, no
 1. `LLMCaller` retries shift both sides together, so they cancel here (
 `emitInferenceCompleted` sits inside the `for attempt` loop on the success and
 failure paths alike); a *harness* rerun does not — see the doubling row above.
-Measured on `word_wolf` ja at the b8694 pin, both A/B arms, `attempts: 1`: 26
-markers vs 25 `inference_completed` + 1 narrate phase
-(`docs/models/eval-log.md` § "DRY sampler construction").
+A worked `word_wolf` ja reconciliation at the b8694 pin is in
+`docs/models/eval-log.md` § "DRY sampler construction".
 
 ## Step 3 — Judge each `ok` cell in-session
 

--- a/.claude/skills/model-eval/SKILL.md
+++ b/.claude/skills/model-eval/SKILL.md
@@ -171,13 +171,19 @@ from its second round on:
 | `samplerDrySeeded` **zero** in `prisoners_dilemma` / `bokete` | **correct, not a defect.** Neither preset has a `speak_each` phase, so 4 of the 6 cells emit only `reason=no-seeds` |
 | `reason=disabled` in a plain battery | DRY is off — `PASTURA_DRY_MULTIPLIER` leaked into the environment; the arm is invalid, re-run |
 | `reason=null-init` or `reason=no-model` | never expected; either is a defect worth an issue |
-| **no `samplerDry*` line at all** | the one unambiguous instrument failure — every `createSampler` exit emits exactly one |
+| fewer markers than the cell's generations | a **throwing** exit — grammar parse failure (#194) or grammar-without-vocab — which emits no marker and whose own error goes to OSLog only, so the sidecar shows neither. Check `run_end.status` / `attempts`, not the sweep alone |
+| **no `samplerDry*` line at all** | the one unambiguous instrument failure — every non-throwing `createSampler` exit emits exactly one |
 
-**Do not reconcile the `samplerDry*` total against `inference_completed`** — it
-is legitimately higher. `narrate` hands `LLMCaller` a no-op emitter, so its
-inference emits no events at all. Measured on `word_wolf` ja at the b8694 pin:
-26 markers vs 25 `inference_completed`, the difference being that one narrate
-turn (`docs/models/eval-log.md` § "DRY sampler construction").
+**Do not reconcile the `samplerDry*` total against `inference_completed`** —
+the two count different things and drift in *both* directions. `narrate` hands
+`LLMCaller` a no-op emitter, so its inference emits no events and pushes markers
+**up**; a generation that throws at or before sampler construction pushes them
+**down**. Retries do not enter: `emitInferenceCompleted` sits inside
+`LLMCaller`'s `for attempt` loop on both the success and failure paths, so an
+extra attempt increments both sides. Measured on `word_wolf` ja at the b8694
+pin, in both A/B arms: 26 markers vs 25 `inference_completed`, the difference
+being that one narrate turn (`docs/models/eval-log.md` § "DRY sampler
+construction").
 
 ## Step 3 — Judge each `ok` cell in-session
 

--- a/.claude/skills/model-eval/SKILL.md
+++ b/.claude/skills/model-eval/SKILL.md
@@ -157,13 +157,27 @@ Then sweep the **stderr sidecars** for the sampler markers. The analyzer reads
 the JSONL only, and none of these reach it:
 
 ```bash
-grep -oE 'samplerDrySeeded|samplerDryUnavailable reason=[a-z-]+|samplerGrammarResample|samplerMaskedSelection|samplerCrashCaught' \
+ls data/models/eval-runs/<DATE>/*.stderr.log | wc -l   # expect 6; a missing sidecar reads as an absent row below
+grep -hoE 'samplerDrySeeded|samplerDryUnavailable reason=[a-z-]+|samplerGrammarResample|samplerMaskedSelection|samplerCrashCaught' \
   data/models/eval-runs/<DATE>/*.stderr.log | sort | uniq -c
+grep -HoE 'samplerDrySeeded|samplerDryUnavailable reason=[a-z-]+' \
+  data/models/eval-runs/<DATE>/*.stderr.log | sort | uniq -c   # per-cell; -H survives a single-file glob
 ```
 
+**Diagnostic only** — nothing here feeds Step 4's verdict or Step 5's schema.
+Run it anyway: a DRY handle that silently stopped constructing shows up in the
+rubric as a repetition/`breakdown_free` loss and would be misattributed to the
+candidate model.
+
 Read the DRY markers (#1483) **against the cell's phase shape**, never as a
-bare count — `speak_each` is the only phase in Engine that seeds DRY, and only
-from its second round on:
+bare count. `speak_each` is the only phase in Engine that seeds DRY (canonical:
+`.claude/rules/engine.md` § "The chain's `penalties` cannot reach across a
+`generate()`"; predicate: `Engine/Phases/SpeakEachHandler.swift`) — and it seeds
+an agent once that agent has a non-empty prior `lastOutputs` entry, **not** "from
+round 2 on". `lastOutputs` survives across phases, so a second `speak_each` seeds
+from its first round: `word_wolf` yields 10 seeded of 26, not 5. If a second
+seeding phase is ever added, this table goes stale — it sits outside
+`engine.md`'s path scope and nothing will prompt you.
 
 | observation | reading |
 |---|---|
@@ -172,18 +186,36 @@ from its second round on:
 | `reason=disabled` in a plain battery | DRY is off — `PASTURA_DRY_MULTIPLIER` leaked into the environment; the arm is invalid, re-run |
 | `reason=null-init` or `reason=no-model` | never expected; either is a defect worth an issue |
 | fewer markers than the cell's generations | a **throwing** exit, which emits no marker. The two grammar ones (parse failure #194, grammar-without-vocab) are run-fatal → `run_end.status`; a NULL `chain_init` only degrades the turn → a `turn_skipped` JSONL line names the cause. A short count with **neither** points at the ungated `narrate` turn, whose failure `NarrateHandler` swallows silently |
-| **no `samplerDry*` line at all** | the one unambiguous instrument failure — every non-throwing `createSampler` exit emits exactly one |
+| roughly **twice** the expected total | the cell reran. `HarnessRunner` retries in-process while the sidecar is truncated once per wrapper call, and unlike `StderrEngineLogger`'s `DiagLine.attempt` these markers carry no attempt field — so the two passes cannot be split. Check the analyzer's `attempts`; read DRY counts only from an `attempts == 1` cell |
+| **no `samplerDry*` line at all** | the one unambiguous instrument failure — every non-throwing `createSampler` exit emits exactly one. Note this renders as an **absent row**, not a zero, which is what the sidecar count above is for |
 
-**Do not reconcile the `samplerDry*` total against `inference_completed`** —
-the two count different things and drift in *both* directions. `narrate` hands
-`LLMCaller` a no-op emitter, so its inference emits no events and pushes markers
-**up**; a generation that throws at or before sampler construction pushes them
-**down**. Retries do not enter: `emitInferenceCompleted` sits inside
-`LLMCaller`'s `for attempt` loop on both the success and failure paths, so an
-extra attempt increments both sides. Measured on `word_wolf` ja at the b8694
-pin, in both A/B arms: 26 markers vs 25 `inference_completed`, the difference
-being that one narrate turn (`docs/models/eval-log.md` § "DRY sampler
-construction").
+**`samplerDry*` totals do not equal `inference_completed`** — but the offset is
+computable, and it is the *only* detector for a sampler throw in a `narrate`
+turn (`NarrateHandler` swallows that failure with no `.narration`, no
+`.turnSkipped` and a no-op emitter, so neither `run_end.status` nor the event
+stream shows it). Expected total, from the JSONL the cell already produced:
+
+```bash
+python3 - "$JSONL" <<'PY'
+import json, sys
+inf = nar = 0
+for line in open(sys.argv[1]):
+    try: d = json.loads(line)
+    except ValueError: continue
+    if d.get("type") != "event": continue
+    if d.get("event") == "inference_completed": inf += 1
+    elif d.get("event") == "phase_started" and d.get("phase_type") == "narrate": nar += 1
+print("expected samplerDry* markers:", inf + nar)
+PY
+```
+
+It scales with rounds — a 3-round scenario with one `narrate` offsets by 3, not
+1. `LLMCaller` retries shift both sides together, so they cancel here (
+`emitInferenceCompleted` sits inside the `for attempt` loop on the success and
+failure paths alike); a *harness* rerun does not — see the doubling row above.
+Measured on `word_wolf` ja at the b8694 pin, both A/B arms, `attempts: 1`: 26
+markers vs 25 `inference_completed` + 1 narrate phase
+(`docs/models/eval-log.md` § "DRY sampler construction").
 
 ## Step 3 — Judge each `ok` cell in-session
 

--- a/.claude/skills/model-eval/SKILL.md
+++ b/.claude/skills/model-eval/SKILL.md
@@ -153,6 +153,32 @@ none) — battery completeness comes from the 6 wrapper status lines, not from
 `runs_total == 6`. Read this object; it feeds the scorecard's per-cell metrics
 and the verdict.
 
+Then sweep the **stderr sidecars** for the sampler markers. The analyzer reads
+the JSONL only, and none of these reach it:
+
+```bash
+grep -oE 'samplerDrySeeded|samplerDryUnavailable reason=[a-z-]+|samplerGrammarResample|samplerMaskedSelection|samplerCrashCaught' \
+  data/models/eval-runs/<DATE>/*.stderr.log | sort | uniq -c
+```
+
+Read the DRY markers (#1483) **against the cell's phase shape**, never as a
+bare count — `speak_each` is the only phase in Engine that seeds DRY, and only
+from its second round on:
+
+| observation | reading |
+|---|---|
+| `samplerDrySeeded` in `word_wolf` ja/en | expected — the only battery cells with a `speak_each` phase |
+| `samplerDrySeeded` **zero** in `prisoners_dilemma` / `bokete` | **correct, not a defect.** Neither preset has a `speak_each` phase, so 4 of the 6 cells emit only `reason=no-seeds` |
+| `reason=disabled` in a plain battery | DRY is off — `PASTURA_DRY_MULTIPLIER` leaked into the environment; the arm is invalid, re-run |
+| `reason=null-init` or `reason=no-model` | never expected; either is a defect worth an issue |
+| **no `samplerDry*` line at all** | the one unambiguous instrument failure — every `createSampler` exit emits exactly one |
+
+**Do not reconcile the `samplerDry*` total against `inference_completed`** — it
+is legitimately higher. `narrate` hands `LLMCaller` a no-op emitter, so its
+inference emits no events at all. Measured on `word_wolf` ja at the b8694 pin:
+26 markers vs 25 `inference_completed`, the difference being that one narrate
+turn (`docs/models/eval-log.md` § "DRY sampler construction").
+
 ## Step 3 — Judge each `ok` cell in-session
 
 For each cell with `status == ok`:

--- a/.claude/skills/model-eval/SKILL.md
+++ b/.claude/skills/model-eval/SKILL.md
@@ -171,7 +171,7 @@ from its second round on:
 | `samplerDrySeeded` **zero** in `prisoners_dilemma` / `bokete` | **correct, not a defect.** Neither preset has a `speak_each` phase, so 4 of the 6 cells emit only `reason=no-seeds` |
 | `reason=disabled` in a plain battery | DRY is off — `PASTURA_DRY_MULTIPLIER` leaked into the environment; the arm is invalid, re-run |
 | `reason=null-init` or `reason=no-model` | never expected; either is a defect worth an issue |
-| fewer markers than the cell's generations | a **throwing** exit, which emits no marker and whose own error goes to OSLog only, so the sidecar shows neither. The two grammar ones (parse failure #194, grammar-without-vocab) are run-fatal, so `run_end.status` catches them; a NULL `chain_init` only degrades the turn, and the short count is the sole signal |
+| fewer markers than the cell's generations | a **throwing** exit, which emits no marker. The two grammar ones (parse failure #194, grammar-without-vocab) are run-fatal → `run_end.status`; a NULL `chain_init` only degrades the turn → a `turn_skipped` JSONL line names the cause. A short count with **neither** points at the ungated `narrate` turn, whose failure `NarrateHandler` swallows silently |
 | **no `samplerDry*` line at all** | the one unambiguous instrument failure — every non-throwing `createSampler` exit emits exactly one |
 
 **Do not reconcile the `samplerDry*` total against `inference_completed`** —

--- a/Pastura/Pastura/LLM/LlamaCppService+DrySampler.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService+DrySampler.swift
@@ -82,34 +82,29 @@ nonisolated struct DryConfig {
 
 /// Why a generation ran without a DRY sampler (#1483).
 ///
-/// Each case maps to exactly one exit path, and together with
-/// `samplerDrySeeded` they cover every **non-throwing** way `createSampler`
-/// can finish — so a harness run that emits **no** `samplerDry*` line at all
-/// means the sampler path was never reached, which is a different fact from
-/// "DRY was off". A single "DRY unavailable" marker could not make that
-/// distinction.
+/// One case per exit path; with `samplerDrySeeded` they cover every
+/// **non-throwing** exit of `createSampler`. So a run emitting **no**
+/// `samplerDry*` line means the sampler path was never reached — a different
+/// fact from "DRY was off".
 ///
-/// **Not covered: the three throwing exits** (`chain_init` NULL, grammar
-/// without vocab, `init_grammar` NULL — the #194 path). Those leave no marker,
-/// so a marker counts *generations that reached sampler construction*, never
-/// *generations attempted*. `prepareGeneration` can also throw upstream of
-/// `createSampler`. A short count is therefore a real signal, not necessarily
-/// a broken instrument — read `run_end.status` alongside the sweep.
+/// **The three throwing exits carry no marker** (`chain_init` NULL, grammar
+/// without vocab, `init_grammar` NULL — #194); `prepareGeneration` can throw
+/// upstream too. A marker counts generations that *reached sampler
+/// construction*, never *attempted*, so read `run_end.status` alongside the
+/// sweep before calling a short count a broken instrument.
 ///
-/// The raw values are the join key for the `.stderr.log` sweep in
-/// `.claude/skills/model-eval/SKILL.md` § Step 2, whose expectations are
-/// written per reason; `DrySamplerConfigTests` pins the set so a rename or a
-/// sixth non-throwing path cannot land without updating both.
+/// Raw values join to the `.stderr.log` sweep in `/model-eval` § Step 2;
+/// `DrySamplerConfigTests` pins the set.
 nonisolated enum DryUnavailableReason: String, CaseIterable, Sendable {
   /// `DryConfig.resolve()` returned nil — the harness A/B base arm
   /// (`PASTURA_DRY_MULTIPLIER=0`). Never reached in TestFlight / Release.
   case disabled
   /// The caller passed no prior text. Structural, not a fault: `speak_each` is
-  /// the only seeding phase in Engine, and it seeds an agent only once that
-  /// agent has a non-empty prior `lastOutputs` entry. **That is not the same as
-  /// "round 2 onward"** — `lastOutputs` persists across phases, so a *second*
-  /// `speak_each` in the same scenario seeds from its first round. Measured:
-  /// `word_wolf` emits 10 seeded, not 5 (`docs/models/eval-log.md`).
+  /// the only seeding phase in Engine, and it seeds an agent once that agent
+  /// has a non-empty prior `lastOutputs` entry — **not** "round 2 onward",
+  /// since `lastOutputs` persists across phases, so a *second* `speak_each`
+  /// seeds from its first round. Per-scenario counts:
+  /// `docs/models/eval-log.md` § "DRY sampler construction".
   case noSeeds = "no-seeds"
   /// No model pointer, so `n_ctx_train` is unreadable.
   case noModel = "no-model"
@@ -147,13 +142,11 @@ nonisolated extension LlamaCppService {
   /// Emit one diagnostic line to OSLog **and** to stderr.
   ///
   /// The stderr mirror is the only channel the ADR-013 harness can read: it
-  /// captures stderr to a `.stderr.log` sidecar, and does not retain `.debug`
-  /// OSLog records at all — which is why the pre-#1483 `.debug` success line
-  /// was invisible to it, and why #1415's spike had to record this call path as
-  /// behaviourally unverified. That spike measured the OSLog retention window;
-  /// nothing in this repo reads OSLog, so it is not re-derivable here. The LLM
-  /// layer cannot use the harness's `EngineLogger` seam instead: that protocol
-  /// lives in `Engine/`, and `LLM/` must not depend on it.
+  /// captures stderr to a `.stderr.log` sidecar and retains no `.debug` OSLog
+  /// records at all (measured in #1415; nothing in this repo reads OSLog, so it
+  /// is not re-derivable here). `LLM/` cannot use the harness's `EngineLogger`
+  /// seam instead — that protocol lives in `Engine/`, and the dependency rule
+  /// forbids the import.
   ///
   /// `anomalous` keeps the pre-#1483 OSLog severity on the two paths that had
   /// it (NULL init, zero tokens seeded) without splitting the stderr channel.
@@ -173,9 +166,8 @@ nonisolated extension LlamaCppService {
     fputs(line + "\n", stderr)
   }
 
-  /// Emit the unavailable marker for `reason`. Wrapped so each `guard` in
-  /// ``buildAndSeedDrySampler(vocab:model:seeds:)`` stays one statement rather
-  /// than a two-line emit repeated at every exit.
+  /// Emit the unavailable marker for `reason`. `.nullInit` is the only one that
+  /// raises OSLog severity — the rest are expected states, not faults.
   func emitDryUnavailable(_ reason: DryUnavailableReason) {
     emitDryDiagnostic(
       Self.dryUnavailableLine(reason: reason, model: modelIdentifier),
@@ -206,10 +198,9 @@ nonisolated extension LlamaCppService {
   func buildAndSeedDrySampler(
     vocab: OpaquePointer, model: OpaquePointer?, seeds: [String]
   ) -> UnsafeMutablePointer<llama_sampler>? {
-    // Split into one guard per precondition (#1483): the merged form could
-    // only report "no DRY", and the three causes want different readings —
-    // `disabled` is the harness base arm, `no-seeds` is structural for every
-    // phase but `speak_each`, `no-model` would be a wiring bug.
+    // One guard per precondition, and do not re-merge them: each exit needs its
+    // own marker, or three distinguishable states collapse into "no DRY". The
+    // readings are on `DryUnavailableReason`'s cases.
     guard let config = DryConfig.resolve() else {
       emitDryUnavailable(.disabled)
       return nil
@@ -249,8 +240,7 @@ nonisolated extension LlamaCppService {
   }
 
   /// Feed `seeds` to `dry` content-only and return the token count actually
-  /// accepted. Extracted from ``buildAndSeedDrySampler(vocab:model:seeds:)``
-  /// so that function reads as its guard ladder plus one seeding call.
+  /// accepted.
   ///
   /// `llama_sampler_accept` on a DRY sampler is a ring-buffer push (no grammar
   /// member → no #253 crash risk); safe for any token, so no EOG/catch

--- a/Pastura/Pastura/LLM/LlamaCppService+DrySampler.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService+DrySampler.swift
@@ -145,12 +145,11 @@ nonisolated extension LlamaCppService {
   /// The stderr mirror is the only channel the ADR-013 harness can read: it
   /// captures stderr to a `.stderr.log` sidecar, and does not retain `.debug`
   /// OSLog records at all — which is why the pre-#1483 `.debug` success line
-  /// was invisible to it, and why #1415's spike had to record this call path
-  /// as behaviourally unverified. (That spike is also where the window was
-  /// measured; nothing in this repo reads OSLog, so it is not re-derivable
-  /// here.) The LLM layer cannot use the harness's `EngineLogger` seam
-  /// instead: that protocol lives in `Engine/`, and `LLM/` must not depend
-  /// on it.
+  /// was invisible to it, and why #1415's spike — which is also where the
+  /// retained-record window was measured, nothing in this repo reading OSLog —
+  /// had to record this call path as behaviourally unverified. The LLM layer
+  /// cannot use the harness's `EngineLogger` seam instead: that protocol lives
+  /// in `Engine/`, and `LLM/` must not depend on it.
   ///
   /// `anomalous` keeps the pre-#1483 OSLog severity on the two paths that had
   /// it (NULL init, zero tokens seeded) without splitting the stderr channel.

--- a/Pastura/Pastura/LLM/LlamaCppService+DrySampler.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService+DrySampler.swift
@@ -145,11 +145,11 @@ nonisolated extension LlamaCppService {
   /// The stderr mirror is the only channel the ADR-013 harness can read: it
   /// captures stderr to a `.stderr.log` sidecar, and does not retain `.debug`
   /// OSLog records at all — which is why the pre-#1483 `.debug` success line
-  /// was invisible to it, and why #1415's spike — which is also where the
-  /// retained-record window was measured, nothing in this repo reading OSLog —
-  /// had to record this call path as behaviourally unverified. The LLM layer
-  /// cannot use the harness's `EngineLogger` seam instead: that protocol lives
-  /// in `Engine/`, and `LLM/` must not depend on it.
+  /// was invisible to it, and why #1415's spike had to record this call path as
+  /// behaviourally unverified. That spike measured the OSLog retention window;
+  /// nothing in this repo reads OSLog, so it is not re-derivable here. The LLM
+  /// layer cannot use the harness's `EngineLogger` seam instead: that protocol
+  /// lives in `Engine/`, and `LLM/` must not depend on it.
   ///
   /// `anomalous` keeps the pre-#1483 OSLog severity on the two paths that had
   /// it (NULL init, zero tokens seeded) without splitting the stderr channel.

--- a/Pastura/Pastura/LLM/LlamaCppService+DrySampler.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService+DrySampler.swift
@@ -104,8 +104,12 @@ nonisolated enum DryUnavailableReason: String, CaseIterable, Sendable {
   /// `DryConfig.resolve()` returned nil — the harness A/B base arm
   /// (`PASTURA_DRY_MULTIPLIER=0`). Never reached in TestFlight / Release.
   case disabled
-  /// The caller passed no prior text. Structural, not a fault: `speak_each`
-  /// is the only seeding phase in Engine, and it seeds nothing in round 1.
+  /// The caller passed no prior text. Structural, not a fault: `speak_each` is
+  /// the only seeding phase in Engine, and it seeds an agent only once that
+  /// agent has a non-empty prior `lastOutputs` entry. **That is not the same as
+  /// "round 2 onward"** — `lastOutputs` persists across phases, so a *second*
+  /// `speak_each` in the same scenario seeds from its first round. Measured:
+  /// `word_wolf` emits 10 seeded, not 5 (`docs/models/eval-log.md`).
   case noSeeds = "no-seeds"
   /// No model pointer, so `n_ctx_train` is unreadable.
   case noModel = "no-model"

--- a/Pastura/Pastura/LLM/LlamaCppService+DrySampler.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService+DrySampler.swift
@@ -80,7 +80,93 @@ nonisolated struct DryConfig {
   }
 }
 
+/// Why a generation ran without a DRY sampler (#1483).
+///
+/// Each case maps to exactly one exit path, and together with
+/// `samplerDrySeeded` they cover every way `createSampler` can finish — so a
+/// harness run that emits **no** `samplerDry*` line at all means the sampler
+/// path was never reached, which is a different fact from "DRY was off". A
+/// single "DRY unavailable" marker could not make that distinction.
+///
+/// The raw values are the join key for the `.stderr.log` sweep in
+/// `.claude/skills/model-eval/SKILL.md` § Step 2, whose expectations are
+/// written per reason; `DrySamplerConfigTests` pins the set so a rename or a
+/// sixth path cannot land without updating both.
+nonisolated enum DryUnavailableReason: String, CaseIterable, Sendable {
+  /// `DryConfig.resolve()` returned nil — the harness A/B base arm
+  /// (`PASTURA_DRY_MULTIPLIER=0`). Never reached in TestFlight / Release.
+  case disabled
+  /// The caller passed no prior text. Structural, not a fault: `speak_each`
+  /// is the only seeding phase in Engine, and it seeds nothing in round 1.
+  case noSeeds = "no-seeds"
+  /// No model pointer, so `n_ctx_train` is unreadable.
+  case noModel = "no-model"
+  /// `llama_sampler_init_dry` returned NULL.
+  case nullInit = "null-init"
+  /// `createSampler` returned before reaching the builder at all — no
+  /// grammar (`schema == nil`), so DRY is gated off upstream.
+  case noGrammar = "no-grammar"
+}
+
 nonisolated extension LlamaCppService {
+  /// The line emitted once per generation that installs a DRY sampler.
+  ///
+  /// `nCtxTrain` is on the line deliberately: llama.cpp b10327 **drops** that
+  /// argument from `llama_sampler_init_dry`, so recording what the pinned
+  /// b8694 build passes is what makes a harness run a baseline the bump can
+  /// be diffed against, rather than a mere liveness check (#1415).
+  ///
+  /// Pure and `static` so the format is unit-testable without inference — the
+  /// seeding path itself needs a real model (PR #463).
+  static func drySeededLine(
+    seededTokenCount: Int, seedCount: Int, nCtxTrain: Int32,
+    config: DryConfig, model: String
+  ) -> String {
+    "samplerDrySeeded seededTokens=\(seededTokenCount) seeds=\(seedCount) "
+      + "nCtxTrain=\(nCtxTrain) mult=\(config.multiplier) base=\(config.base) "
+      + "allowed=\(config.allowedLength) lastN=\(config.penaltyLastN) model=\(model)"
+  }
+
+  /// The line emitted once per generation that runs without a DRY sampler.
+  static func dryUnavailableLine(reason: DryUnavailableReason, model: String) -> String {
+    "samplerDryUnavailable reason=\(reason.rawValue) model=\(model)"
+  }
+
+  /// Emit one diagnostic line to OSLog **and** to stderr.
+  ///
+  /// The stderr mirror is the only channel the ADR-013 harness can read: it
+  /// captures stderr to a `.stderr.log` sidecar, while the OSLog window holds
+  /// 250 `info` + 5 `error` records and no `debug` records at all — which is
+  /// why the pre-#1483 `.debug` success line was invisible to it, and why
+  /// #1415's spike had to record this call path as behaviourally unverified.
+  /// The LLM layer cannot use the harness's `EngineLogger` seam instead:
+  /// that protocol lives in `Engine/`, and `LLM/` must not depend on it.
+  ///
+  /// `anomalous` keeps the pre-#1483 OSLog severity on the two paths that had
+  /// it (NULL init, zero tokens seeded) without splitting the stderr channel.
+  /// Interpolated `.public` because the line carries only model metadata and
+  /// numbers — never seeds, which are agent output (CLAUDE.md Logger privacy).
+  func emitDryDiagnostic(_ line: String, anomalous: Bool = false) {
+    if anomalous {
+      logger.warning("\(line, privacy: .public)")
+    } else {
+      logger.debug("\(line, privacy: .public)")
+    }
+    // Same rationale as `emitGrammarResampleDiagnostic`'s mirror: CLI os.Logger
+    // output is not reliably queryable via `log show`. Invisible on iOS.
+    fputs(line + "\n", stderr)
+  }
+
+  /// Emit the unavailable marker for `reason`. Wrapped so each `guard` in
+  /// ``buildAndSeedDrySampler(vocab:model:seeds:)`` stays one statement — the
+  /// body sits close enough to SwiftLint's 50-line `function_body_length` that
+  /// inlining the two-line emit at every exit would trip `--strict`.
+  func emitDryUnavailable(_ reason: DryUnavailableReason) {
+    emitDryDiagnostic(
+      Self.dryUnavailableLine(reason: reason, model: modelIdentifier),
+      anomalous: reason == .nullInit)
+  }
+
   /// Build a DRY sampler (`llama_sampler_init_dry`) seeded content-only with
   /// `seeds`, or `nil` when disabled. Non-throwing: DRY is an optional quality
   /// enhancement, so any missing precondition (the explicit base arm
@@ -105,23 +191,58 @@ nonisolated extension LlamaCppService {
   func buildAndSeedDrySampler(
     vocab: OpaquePointer, model: OpaquePointer?, seeds: [String]
   ) -> UnsafeMutablePointer<llama_sampler>? {
-    guard let config = DryConfig.resolve(), !seeds.isEmpty, let model
-    else { return nil }
+    // Split into one guard per precondition (#1483): the merged form could
+    // only report "no DRY", and the three causes want different readings —
+    // `disabled` is the harness base arm, `no-seeds` is structural for every
+    // phase but `speak_each`, `no-model` would be a wiring bug.
+    guard let config = DryConfig.resolve() else {
+      emitDryUnavailable(.disabled)
+      return nil
+    }
+    guard !seeds.isEmpty else {
+      emitDryUnavailable(.noSeeds)
+      return nil
+    }
+    guard let model else {
+      emitDryUnavailable(.noModel)
+      return nil
+    }
 
+    let nCtxTrain = llama_model_n_ctx_train(model)
     let dry = withArrayOfCStrings(config.seqBreakers) { breakerPtrs in
       llama_sampler_init_dry(
-        vocab, llama_model_n_ctx_train(model), config.multiplier, config.base,
+        vocab, nCtxTrain, config.multiplier, config.base,
         config.allowedLength, config.penaltyLastN,
         breakerPtrs.baseAddress, breakerPtrs.count)
     }
     guard let dry else {
-      logger.warning("DRY sampler init returned NULL — proceeding without it (#1105)")
+      emitDryUnavailable(.nullInit)
       return nil
     }
 
-    // Seed content-only. `llama_sampler_accept` on a DRY sampler is a
-    // ring-buffer push (no grammar member → no #253 crash risk); safe for
-    // any token, so no EOG/catch handling is needed here.
+    let seededTokenCount = seedTokens(into: dry, vocab: vocab, seeds: seeds)
+    // `seededTokenCount == 0` is reached with a non-empty `seeds` (guarded
+    // above) yet nothing seeded — every seed failed to tokenize. The handle
+    // stays valid but degrades to a within-generation-only penalty, silently
+    // defeating the cross-turn purpose of #1105, so raise the OSLog severity.
+    emitDryDiagnostic(
+      Self.drySeededLine(
+        seededTokenCount: seededTokenCount, seedCount: seeds.count,
+        nCtxTrain: nCtxTrain, config: config, model: modelIdentifier),
+      anomalous: seededTokenCount == 0)
+    return dry
+  }
+
+  /// Feed `seeds` to `dry` content-only and return the token count actually
+  /// accepted. Extracted from ``buildAndSeedDrySampler(vocab:model:seeds:)``
+  /// to keep that body inside SwiftLint's `function_body_length`.
+  ///
+  /// `llama_sampler_accept` on a DRY sampler is a ring-buffer push (no grammar
+  /// member → no #253 crash risk); safe for any token, so no EOG/catch
+  /// handling is needed here.
+  private func seedTokens(
+    into dry: UnsafeMutablePointer<llama_sampler>, vocab: OpaquePointer, seeds: [String]
+  ) -> Int {
     var seededTokenCount = 0
     for seed in seeds {
       guard let tokens = try? tokenize(vocab: vocab, text: seed, addSpecial: false) else {
@@ -132,25 +253,7 @@ nonisolated extension LlamaCppService {
         seededTokenCount += 1
       }
     }
-    if seededTokenCount == 0 {
-      // Reached with a non-empty `seeds` (guarded above) yet nothing seeded —
-      // every seed failed to tokenize. The handle stays valid but degrades to
-      // a within-generation-only penalty, silently defeating the cross-turn
-      // purpose of #1105, so surface it above `.debug`.
-      logger.warning(
-        """
-        DRY seeded 0 tokens from \(seeds.count, privacy: .public) non-empty \
-        seed(s) (#1105) — all tokenized empty; cross-turn penalty inert this turn
-        """)
-    }
-    logger.debug(
-      """
-      DRY seeded (#1105): \(seededTokenCount, privacy: .public) tokens from \
-      \(seeds.count, privacy: .public) seed(s) — mult=\(config.multiplier, privacy: .public) \
-      base=\(config.base, privacy: .public) allowed=\(config.allowedLength, privacy: .public) \
-      lastN=\(config.penaltyLastN, privacy: .public)
-      """)
-    return dry
+    return seededTokenCount
   }
 
   /// Call `body` with a C `const char **` view of `strings`, valid only for

--- a/Pastura/Pastura/LLM/LlamaCppService+DrySampler.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService+DrySampler.swift
@@ -83,15 +83,23 @@ nonisolated struct DryConfig {
 /// Why a generation ran without a DRY sampler (#1483).
 ///
 /// Each case maps to exactly one exit path, and together with
-/// `samplerDrySeeded` they cover every way `createSampler` can finish — so a
-/// harness run that emits **no** `samplerDry*` line at all means the sampler
-/// path was never reached, which is a different fact from "DRY was off". A
-/// single "DRY unavailable" marker could not make that distinction.
+/// `samplerDrySeeded` they cover every **non-throwing** way `createSampler`
+/// can finish — so a harness run that emits **no** `samplerDry*` line at all
+/// means the sampler path was never reached, which is a different fact from
+/// "DRY was off". A single "DRY unavailable" marker could not make that
+/// distinction.
+///
+/// **Not covered: the three throwing exits** (`chain_init` NULL, grammar
+/// without vocab, `init_grammar` NULL — the #194 path). Those leave no marker,
+/// so a marker counts *generations that reached sampler construction*, never
+/// *generations attempted*. `prepareGeneration` can also throw upstream of
+/// `createSampler`. A short count is therefore a real signal, not necessarily
+/// a broken instrument — read `run_end.status` alongside the sweep.
 ///
 /// The raw values are the join key for the `.stderr.log` sweep in
 /// `.claude/skills/model-eval/SKILL.md` § Step 2, whose expectations are
 /// written per reason; `DrySamplerConfigTests` pins the set so a rename or a
-/// sixth path cannot land without updating both.
+/// sixth non-throwing path cannot land without updating both.
 nonisolated enum DryUnavailableReason: String, CaseIterable, Sendable {
   /// `DryConfig.resolve()` returned nil — the harness A/B base arm
   /// (`PASTURA_DRY_MULTIPLIER=0`). Never reached in TestFlight / Release.
@@ -135,12 +143,14 @@ nonisolated extension LlamaCppService {
   /// Emit one diagnostic line to OSLog **and** to stderr.
   ///
   /// The stderr mirror is the only channel the ADR-013 harness can read: it
-  /// captures stderr to a `.stderr.log` sidecar, while the OSLog window holds
-  /// 250 `info` + 5 `error` records and no `debug` records at all — which is
-  /// why the pre-#1483 `.debug` success line was invisible to it, and why
-  /// #1415's spike had to record this call path as behaviourally unverified.
-  /// The LLM layer cannot use the harness's `EngineLogger` seam instead:
-  /// that protocol lives in `Engine/`, and `LLM/` must not depend on it.
+  /// captures stderr to a `.stderr.log` sidecar, and does not retain `.debug`
+  /// OSLog records at all — which is why the pre-#1483 `.debug` success line
+  /// was invisible to it, and why #1415's spike had to record this call path
+  /// as behaviourally unverified. (That spike is also where the window was
+  /// measured; nothing in this repo reads OSLog, so it is not re-derivable
+  /// here.) The LLM layer cannot use the harness's `EngineLogger` seam
+  /// instead: that protocol lives in `Engine/`, and `LLM/` must not depend
+  /// on it.
   ///
   /// `anomalous` keeps the pre-#1483 OSLog severity on the two paths that had
   /// it (NULL init, zero tokens seeded) without splitting the stderr channel.
@@ -154,13 +164,15 @@ nonisolated extension LlamaCppService {
     }
     // Same rationale as `emitGrammarResampleDiagnostic`'s mirror: CLI os.Logger
     // output is not reliably queryable via `log show`. Invisible on iOS.
+    // Volume profile differs from that sibling, though — do not carry its
+    // "rare path" framing across: this fires once per generation, not once per
+    // event. ~120 B against seconds of inference, so still negligible.
     fputs(line + "\n", stderr)
   }
 
   /// Emit the unavailable marker for `reason`. Wrapped so each `guard` in
-  /// ``buildAndSeedDrySampler(vocab:model:seeds:)`` stays one statement — the
-  /// body sits close enough to SwiftLint's 50-line `function_body_length` that
-  /// inlining the two-line emit at every exit would trip `--strict`.
+  /// ``buildAndSeedDrySampler(vocab:model:seeds:)`` stays one statement rather
+  /// than a two-line emit repeated at every exit.
   func emitDryUnavailable(_ reason: DryUnavailableReason) {
     emitDryDiagnostic(
       Self.dryUnavailableLine(reason: reason, model: modelIdentifier),
@@ -235,7 +247,7 @@ nonisolated extension LlamaCppService {
 
   /// Feed `seeds` to `dry` content-only and return the token count actually
   /// accepted. Extracted from ``buildAndSeedDrySampler(vocab:model:seeds:)``
-  /// to keep that body inside SwiftLint's `function_body_length`.
+  /// so that function reads as its guard ladder plus one seeding call.
   ///
   /// `llama_sampler_accept` on a DRY sampler is a ring-buffer push (no grammar
   /// member → no #253 crash risk); safe for any token, so no EOG/catch

--- a/Pastura/Pastura/LLM/LlamaCppService+Sampler.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService+Sampler.swift
@@ -125,6 +125,11 @@ extension LlamaCppService {
       // marker here a whole run could emit zero `samplerDry*` lines for a
       // healthy reason — indistinguishable from an instrument that never
       // fired (#1483).
+      //
+      // Keep the emit ABOVE `initGrammarCapturingStderr` below: that helper
+      // dup2s fd 2 for the width of one C call, so a marker moved under it
+      // would be swallowed into the grammar-parse capture instead of the
+      // harness sidecar. Nothing tests this ordering.
       emitDryUnavailable(.noGrammar)
       return SamplerHandles(chain: chain, grammar: nil, dry: nil)
     }

--- a/Pastura/Pastura/LLM/LlamaCppService+Sampler.swift
+++ b/Pastura/Pastura/LLM/LlamaCppService+Sampler.swift
@@ -120,6 +120,12 @@ extension LlamaCppService {
       // `llama_sampler_sample`, which builds `cur_p` internally with no seam
       // to apply a separate DRY handle — and no seeded caller reaches it
       // (seeds flow only from schema-bearing LLM phases). See #1105.
+      //
+      // This return is upstream of `buildAndSeedDrySampler`, so without a
+      // marker here a whole run could emit zero `samplerDry*` lines for a
+      // healthy reason — indistinguishable from an instrument that never
+      // fired (#1483).
+      emitDryUnavailable(.noGrammar)
       return SamplerHandles(chain: chain, grammar: nil, dry: nil)
     }
     guard let vocab else {

--- a/Pastura/PasturaTests/LLM/DrySamplerConfigTests.swift
+++ b/Pastura/PasturaTests/LLM/DrySamplerConfigTests.swift
@@ -4,12 +4,15 @@ import Testing
 
 /// Unit tests for the simulator-runnable, inference-free parts of the #1105
 /// DRY anti-repetition sampler: `DryConfig.resolve(environment:)` (the shipped
-/// default + harness A/B override logic) and `withArrayOfCStrings` (the
-/// C-string pointer-lifetime helper that feeds `llama_sampler_init_dry`).
+/// default + harness A/B override logic), `withArrayOfCStrings` (the
+/// C-string pointer-lifetime helper that feeds `llama_sampler_init_dry`), and
+/// the #1483 diagnostic line shapes.
 ///
 /// The seeding + apply paths (`buildAndSeedDrySampler`, `fillApplyAndSelect`)
 /// require real inference and are unrunnable on the simulator (PR #463) — they
 /// are validated on device / via the pastura-harness A/B (#1105), not here.
+/// What #1483 made testable is only the *line format* those paths emit: the
+/// emission itself still needs a harness run to observe.
 @Suite(.timeLimit(.minutes(1)))
 struct DrySamplerConfigTests {
 
@@ -84,5 +87,55 @@ struct DrySamplerConfigTests {
     let service = makeTestService()
     let count = service.withArrayOfCStrings([]) { $0.count }
     #expect(count == 0)
+  }
+
+  // MARK: - Harness-observable diagnostic lines (#1483)
+
+  /// The `reason=` vocabulary is the join key for the `.stderr.log` sweep in
+  /// `/model-eval` Step 2, whose expectations are written per reason. Pinning
+  /// the exact set means a rename — or a sixth exit path — fails here instead
+  /// of silently emitting a marker the sweep has no expectation for.
+  @Test func dryUnavailableReasonsArePinnedAndDistinct() {
+    let raws = DryUnavailableReason.allCases.map(\.rawValue)
+    // A copy-pasted raw value would make two exit paths indistinguishable in
+    // the sweep — the exact confusion the per-path markers exist to prevent.
+    #expect(Set(raws).count == raws.count)
+    #expect(Set(raws) == ["disabled", "no-seeds", "no-model", "null-init", "no-grammar"])
+  }
+
+  /// `nCtxTrain` is the load-bearing field: llama.cpp b10327 **drops** that
+  /// argument from `llama_sampler_init_dry`, so recording the value the pinned
+  /// b8694 build passes is what makes this a baseline rather than a liveness
+  /// check (#1415). Dropping it from the line must fail a test.
+  @Test func drySeededLineCarriesEveryField() throws {
+    let config = try #require(DryConfig.resolve(environment: [:]))
+    let line = LlamaCppService.drySeededLine(
+      seededTokenCount: 42, seedCount: 3, nCtxTrain: 8192,
+      config: config, model: "test-model")
+
+    #expect(line.hasPrefix("samplerDrySeeded "))
+    #expect(line.contains("seededTokens=42"))
+    #expect(line.contains("seeds=3"))
+    #expect(line.contains("nCtxTrain=8192"))
+    #expect(line.contains("mult=0.8"))
+    #expect(line.contains("base=1.75"))
+    #expect(line.contains("allowed=3"))
+    #expect(line.contains("lastN=512"))
+    #expect(line.contains("model=test-model"))
+    // The sweep is line-oriented; an embedded newline would let one event
+    // inflate a `grep -c` into two.
+    #expect(!line.contains("\n"))
+  }
+
+  @Test func dryUnavailableLineCarriesReasonAndModel() {
+    for reason in DryUnavailableReason.allCases {
+      let line = LlamaCppService.dryUnavailableLine(reason: reason, model: "test-model")
+      #expect(line.hasPrefix("samplerDryUnavailable reason=\(reason.rawValue)"))
+      #expect(line.contains("model=test-model"))
+      #expect(!line.contains("\n"))
+      // Neither marker may contain the other, or a per-marker `grep -c`
+      // silently counts both and the two exit classes stop being separable.
+      #expect(!line.contains("samplerDrySeeded"))
+    }
   }
 }

--- a/Pastura/PasturaTests/LLM/DrySamplerConfigTests.swift
+++ b/Pastura/PasturaTests/LLM/DrySamplerConfigTests.swift
@@ -13,6 +13,11 @@ import Testing
 /// are validated on device / via the pastura-harness A/B (#1105), not here.
 /// What #1483 made testable is only the *line format* those paths emit: the
 /// emission itself still needs a harness run to observe.
+///
+/// Specifically **not** pinned here: which `guard` emits which reason. Swapping
+/// `.noSeeds` and `.noModel` between two guards would pass everything below and
+/// silently mislabel every harness sweep. Closing that needs an injectable emit
+/// sink; until then the guard→reason mapping is code-review-gated.
 @Suite(.timeLimit(.minutes(1)))
 struct DrySamplerConfigTests {
 

--- a/Pastura/PasturaTests/LLM/DrySamplerConfigTests.swift
+++ b/Pastura/PasturaTests/LLM/DrySamplerConfigTests.swift
@@ -11,8 +11,7 @@ import Testing
 /// The seeding + apply paths (`buildAndSeedDrySampler`, `fillApplyAndSelect`)
 /// require real inference and are unrunnable on the simulator (PR #463) — they
 /// are validated on device / via the pastura-harness A/B (#1105), not here.
-/// What #1483 made testable is only the *line format* those paths emit: the
-/// emission itself still needs a harness run to observe.
+/// Only the *line format* is testable; the emission still needs a harness run.
 ///
 /// Specifically **not** pinned here: which `guard` emits which reason. Swapping
 /// `.noSeeds` and `.noModel` between two guards would pass everything below and
@@ -96,10 +95,9 @@ struct DrySamplerConfigTests {
 
   // MARK: - Harness-observable diagnostic lines (#1483)
 
-  /// The `reason=` vocabulary is the join key for the `.stderr.log` sweep in
-  /// `/model-eval` Step 2, whose expectations are written per reason. Pinning
-  /// the exact set means a rename — or a sixth exit path — fails here instead
-  /// of silently emitting a marker the sweep has no expectation for.
+  /// Pinning the exact set means a rename — or a sixth exit path — fails here
+  /// instead of silently emitting a marker the `/model-eval` sweep has no
+  /// expectation for. Why the vocabulary is load-bearing: `DryUnavailableReason`.
   @Test func dryUnavailableReasonsArePinnedAndDistinct() {
     let raws = DryUnavailableReason.allCases.map(\.rawValue)
     // A copy-pasted raw value would make two exit paths indistinguishable in
@@ -108,10 +106,8 @@ struct DrySamplerConfigTests {
     #expect(Set(raws) == ["disabled", "no-seeds", "no-model", "null-init", "no-grammar"])
   }
 
-  /// `nCtxTrain` is the load-bearing field: llama.cpp b10327 **drops** that
-  /// argument from `llama_sampler_init_dry`, so recording the value the pinned
-  /// b8694 build passes is what makes this a baseline rather than a liveness
-  /// check (#1415). Dropping it from the line must fail a test.
+  /// `nCtxTrain` is the load-bearing field — dropping it from the line must
+  /// fail a test. Why it is load-bearing: `drySeededLine`'s doc comment.
   @Test func drySeededLineCarriesEveryField() throws {
     let config = try #require(DryConfig.resolve(environment: [:]))
     let line = LlamaCppService.drySeededLine(

--- a/docs/models/eval-log.md
+++ b/docs/models/eval-log.md
@@ -112,6 +112,44 @@ negative today does not generalize to tomorrow's GGUF.
 Re-run this at each onboarding rather than copying the numbers forward — the step
 lives in [`onboarding.md`](onboarding.md) § "Stage 0".
 
+### DRY sampler construction — 2026-08-15 (b8694 baseline)
+
+**Scope**: two `word_wolf.yaml` (ja) harness runs on the incumbent
+`gemma-4-E2B-it-Q4_K_M.gguf`, at the **pinned `llama.swift` 2.8694.0
+(llama.cpp b8694)**, differing only in `PASTURA_DRY_MULTIPLIER`. Recorded here
+because this is the reading a future pin bump is diffed against, and the run
+logs themselves are gitignored. Instrument: the #1483 `samplerDry*` markers.
+
+| arm | `samplerDrySeeded` | `reason=no-seeds` | `reason=disabled` | total |
+|---|---|---|---|---|
+| default (`mult=0.8`) | **10** | 16 | 0 | 26 |
+| `PASTURA_DRY_MULTIPLIER=0` | 0 | 0 | **26** | 26 |
+
+Seeded turns carried **16–31 tokens** each (`seeds=1` throughout — `speak_each`
+seeds one prior statement) and `nCtxTrain=131072`.
+
+**26 markers against 25 `inference_completed`** in the same run, in both arms.
+The markers are right and the JSONL undercounts: `NarrateHandler` hands
+`LLMCaller` a no-op emitter, so the narrate turn's inference emits no events.
+So one marker per LLM generation holds — but the JSONL is the wrong denominator
+to check it with, by exactly the narrate-phase count.
+
+**Why the pair, not just the first arm.** A marker that appears is not evidence
+the instrument discriminates; the disabled arm flipping all 26 lines is. It also
+settles a second thing #1415 left unverified — that the `PASTURA_DRY_MULTIPLIER`
+A/B lever reaches the sampler at all.
+
+**`nCtxTrain=131072` is the load-bearing figure.** b10327 removes that argument
+from `llama_sampler_init_dry`, so a post-bump run showing the field gone — with
+`seededTokens` unchanged — is what distinguishes "the signature migration was
+correct" from "DRY silently stopped constructing".
+
+**Three exit paths stayed unexercised**: `no-model`, `null-init` and
+`no-grammar` are zero in both arms (every `word_wolf` LLM phase carries an
+output schema, and nothing failed). Their line *format* is unit-tested; their
+*emission* is not, so read a future zero on them as "still unexercised", not as
+a measured negative.
+
 ---
 
 ## Gemma 4 E2B QAT `UD-Q4_K_XL` (`unsloth/gemma-4-E2B-it-qat-GGUF`) — 2026-08-13 — **PASS (Mac filter only — advances to the ADR-011 real-device PoC, never an adoption)**

--- a/docs/models/eval-log.md
+++ b/docs/models/eval-log.md
@@ -198,11 +198,10 @@ output schema, and nothing failed). Their line *format* is unit-tested; their
 *emission* is not, so read a future zero on them as "still unexercised", not as
 a measured negative.
 
-**And three exits carry no marker at all** — `createSampler`'s throwing paths
-(`chain_init` NULL, grammar without vocab, `init_grammar` NULL). So the
-partition is 6 marker paths (the five `reason=` values plus `samplerDrySeeded`)
-+ 3 silent ones, and the count above measures *generations that reached sampler
-construction*.
+**And `createSampler`'s three throwing exits carry no marker at all**
+(enumerated on `DryUnavailableReason`). So the partition is 6 marker paths — the
+five `reason=` values plus `samplerDrySeeded` — plus 3 silent ones, and the
+count above measures *generations that reached sampler construction*.
 
 Three different signals rule them out, and the run status is only one of them.
 The two `init_grammar` / vocab exits throw `LLMError.invalidGrammar`, which
@@ -212,10 +211,11 @@ leave the run finishing `ok` (and `run_end.attempts` is the harness's own
 run-level retry count, not `LLMCaller`'s per-turn one) — but for a **gated**
 phase the skip emits `.turnSkipped`, which reaches the JSONL as a `turn_skipped`
 line naming the cause, so that is the direct signal. What the **26 = 25 + 1
-reconciliation** uniquely covers is the ungated `narrate` turn: `NarrateHandler`
-swallows its own failure with no `.narration`, no `.turnSkipped` and a no-op
-emitter, so a sampler throw there is invisible to both the run status and the
-event stream. A post-bump short count with no `turn_skipped` line is that case.
+reconciliation** uniquely covers is the ungated `narrate` turn: the same no-op
+emitter that produces the offset above also swallows a *failure* there — no
+`.narration`, no `.turnSkipped` — so a sampler throw is invisible to both the
+run status and the event stream. A post-bump short count with no `turn_skipped`
+line is that case.
 
 ---
 

--- a/docs/models/eval-log.md
+++ b/docs/models/eval-log.md
@@ -153,10 +153,18 @@ a measured negative.
 
 **And three exits carry no marker at all** — `createSampler`'s throwing paths
 (`chain_init` NULL, grammar without vocab, `init_grammar` NULL). So the
-partition is 5 marker paths + 3 silent ones, and the count above measures
-*generations that reached sampler construction*. Both runs ended `status: ok`
-with `attempts: 1`, so none of the three fired here; a post-bump run showing a
-short count should be read as a throw, not as DRY going missing.
+partition is 6 marker paths (the five `reason=` values plus `samplerDrySeeded`)
++ 3 silent ones, and the count above measures *generations that reached sampler
+construction*.
+
+What rules those three out here is the **26 = 25 + 1 reconciliation**, not the
+run status. The two `init_grammar` / vocab exits throw `LLMError.invalidGrammar`,
+which `streamFailureError` returns typed and run-fatal, so `status: ok` does
+exclude them — but `chain_init` NULL throws `.generationFailed`, which is wrapped
+as turn-degradable and would leave the run finishing `ok`, and `run_end.attempts`
+counts the harness's own run-level retries, not `LLMCaller`'s per-turn ones. Only
+the marker total matching every generation excludes that third path. A post-bump
+run showing a short count should be read as a throw, not as DRY going missing.
 
 ---
 

--- a/docs/models/eval-log.md
+++ b/docs/models/eval-log.md
@@ -120,13 +120,32 @@ lives in [`onboarding.md`](onboarding.md) § "Stage 0".
 because this is the reading a future pin bump is diffed against, and the run
 logs themselves are gitignored. Instrument: the #1483 `samplerDry*` markers.
 
-| arm | `samplerDrySeeded` | `reason=no-seeds` | `reason=disabled` | total |
-|---|---|---|---|---|
-| default (`mult=0.8`) | **10** | 16 | 0 | 26 |
-| `PASTURA_DRY_MULTIPLIER=0` | 0 | 0 | **26** | 26 |
+| arm | `samplerDrySeeded` | `reason=no-seeds` | `reason=disabled` | total | `attempts` |
+|---|---|---|---|---|---|
+| default (`mult=0.8`) | **10** | 16 | 0 | 26 | 1 |
+| `PASTURA_DRY_MULTIPLIER=0` | 0 | 0 | **26** | 26 | 1 |
 
 Seeded turns carried **16–31 tokens** each (`seeds=1` throughout — `speak_each`
 seeds one prior statement) and `nCtxTrain=131072`.
+
+**The counts are structural, so they are the comparable part.** `word_wolf` is
+5 agents × 1 round: `speak_each`(rounds 2) 10 + `reflect` 5 + `speak_each`
+(rounds 1) 5 + `narrate` 1 + `vote` 5 = 26 generations. Seeded = 10 because an
+agent is seeded once it has a non-empty prior `lastOutputs` entry — round 2 of
+the first `speak_each`, then **both** rounds of the second, since `lastOutputs`
+persists across phases. (`event_inject probability: 0.5` gates only a template
+`summarize`, so it does not move the generation count.)
+
+**What is stable across runs, and what is not** — the comparison a post-bump run
+should make:
+
+- **Stable**: the three counts, the arm flip to 100 % `disabled`, `nCtxTrain`
+  (per model), and zero `null-init` / `no-model`. A shift here is a real signal.
+- **Not stable**: `seededTokens`. It is the tokenized length of the agent's own
+  previous statement, so 16–31 is generation-length variance over 10 samples in
+  one run — do **not** read a shifted range as a regression.
+- `attempts` must be 1. A harness rerun doubles every count and the markers
+  carry no attempt discriminator.
 
 **26 markers against 25 `inference_completed`** in the same run, in both arms.
 The markers are right and the JSONL undercounts: `NarrateHandler` hands
@@ -140,10 +159,38 @@ the instrument discriminates; the disabled arm flipping all 26 lines is. It also
 settles a second thing #1415 left unverified — that the `PASTURA_DRY_MULTIPLIER`
 A/B lever reaches the sampler at all.
 
-**`nCtxTrain=131072` is the load-bearing figure.** b10327 removes that argument
-from `llama_sampler_init_dry`, so a post-bump run showing the field gone — with
-`seededTokens` unchanged — is what distinguishes "the signature migration was
-correct" from "DRY silently stopped constructing".
+**What this instrument can and cannot settle.** It shows DRY still *constructs
+and seeds* after the bump — the thing #1415 could not observe at all. It does
+**not** show it was constructed with the right *parameters*: the line echoes the
+Swift-side `DryConfig`, never the values llama.cpp received, so transposing the
+adjacent `multiplier`/`base` floats or `allowedLength`/`penaltyLastN` int32s
+compiles, returns non-NULL, seeds the same token count, and emits a
+byte-identical line while DRY is inert. Argument order stays code-review-gated,
+like the guard→reason mapping. `nCtxTrain` is on the line because it is the
+argument b10327 removes, but its disappearance is produced by the bumper's own
+edit — treat it as a checklist item, not as evidence.
+
+**Coupled edits when the bump lands**, none of which any gate enforces: drop
+`nCtxTrain` from `LlamaCppService.drySeededLine` **and** from
+`drySeededLineCarriesEveryField`; if the now-unused `model` precondition goes
+too (#1415), remove `.noModel` from `DryUnavailableReason`, from the pinned set
+in `dryUnavailableReasonsArePinnedAndDistinct`, and from the reading table in
+`.claude/skills/model-eval/SKILL.md`. Note also that `PASTURA_DRY_LAST_N=-1`
+flips meaning at b10327 (whole training context → disabled) and the marker
+records only the resolved `lastN`, so an override arm looks unchanged.
+
+**Reproduce** (from the repo root; the sidecar lands at `${OUT%.jsonl}.stderr.log`):
+
+```bash
+.claude/skills/scenario-factory/scripts/run_scenario.sh \
+  Pastura/Pastura/Resources/Presets/word_wolf.yaml \
+  ~/Models/gemma-4-E2B-it-Q4_K_M.gguf /tmp/dry-pos.jsonl 600 gemma-4-e2b-q4-k-m
+PASTURA_DRY_MULTIPLIER=0 .claude/skills/scenario-factory/scripts/run_scenario.sh \
+  Pastura/Pastura/Resources/Presets/word_wolf.yaml \
+  ~/Models/gemma-4-E2B-it-Q4_K_M.gguf /tmp/dry-neg.jsonl 600 gemma-4-e2b-q4-k-m
+grep -HoE 'samplerDrySeeded|samplerDryUnavailable reason=[a-z-]+' /tmp/dry-*.stderr.log \
+  | sort | uniq -c   # -H, or the two arms merge into one unattributed count
+```
 
 **Three marker paths stayed unexercised**: `no-model`, `null-init` and
 `no-grammar` are zero in both arms (every `word_wolf` LLM phase carries an

--- a/docs/models/eval-log.md
+++ b/docs/models/eval-log.md
@@ -157,14 +157,18 @@ partition is 6 marker paths (the five `reason=` values plus `samplerDrySeeded`)
 + 3 silent ones, and the count above measures *generations that reached sampler
 construction*.
 
-What rules those three out here is the **26 = 25 + 1 reconciliation**, not the
-run status. The two `init_grammar` / vocab exits throw `LLMError.invalidGrammar`,
-which `streamFailureError` returns typed and run-fatal, so `status: ok` does
-exclude them — but `chain_init` NULL throws `.generationFailed`, which is wrapped
-as turn-degradable and would leave the run finishing `ok`, and `run_end.attempts`
-counts the harness's own run-level retries, not `LLMCaller`'s per-turn ones. Only
-the marker total matching every generation excludes that third path. A post-bump
-run showing a short count should be read as a throw, not as DRY going missing.
+Three different signals rule them out, and the run status is only one of them.
+The two `init_grammar` / vocab exits throw `LLMError.invalidGrammar`, which
+`streamFailureError` returns typed and run-fatal, so `status: ok` excludes them.
+`chain_init` NULL throws `.generationFailed`, which is turn-degradable and can
+leave the run finishing `ok` (and `run_end.attempts` is the harness's own
+run-level retry count, not `LLMCaller`'s per-turn one) — but for a **gated**
+phase the skip emits `.turnSkipped`, which reaches the JSONL as a `turn_skipped`
+line naming the cause, so that is the direct signal. What the **26 = 25 + 1
+reconciliation** uniquely covers is the ungated `narrate` turn: `NarrateHandler`
+swallows its own failure with no `.narration`, no `.turnSkipped` and a no-op
+emitter, so a sampler throw there is invisible to both the run status and the
+event stream. A post-bump short count with no `turn_skipped` line is that case.
 
 ---
 

--- a/docs/models/eval-log.md
+++ b/docs/models/eval-log.md
@@ -131,8 +131,9 @@ seeds one prior statement) and `nCtxTrain=131072`.
 **26 markers against 25 `inference_completed`** in the same run, in both arms.
 The markers are right and the JSONL undercounts: `NarrateHandler` hands
 `LLMCaller` a no-op emitter, so the narrate turn's inference emits no events.
-So one marker per LLM generation holds — but the JSONL is the wrong denominator
-to check it with, by exactly the narrate-phase count.
+One marker per **non-throwing** generation holds — the JSONL is the wrong
+denominator to check it with, by exactly the narrate-phase count. Retries do
+not enter it (they increment both sides).
 
 **Why the pair, not just the first arm.** A marker that appears is not evidence
 the instrument discriminates; the disabled arm flipping all 26 lines is. It also
@@ -144,11 +145,18 @@ from `llama_sampler_init_dry`, so a post-bump run showing the field gone — wit
 `seededTokens` unchanged — is what distinguishes "the signature migration was
 correct" from "DRY silently stopped constructing".
 
-**Three exit paths stayed unexercised**: `no-model`, `null-init` and
+**Three marker paths stayed unexercised**: `no-model`, `null-init` and
 `no-grammar` are zero in both arms (every `word_wolf` LLM phase carries an
 output schema, and nothing failed). Their line *format* is unit-tested; their
 *emission* is not, so read a future zero on them as "still unexercised", not as
 a measured negative.
+
+**And three exits carry no marker at all** — `createSampler`'s throwing paths
+(`chain_init` NULL, grammar without vocab, `init_grammar` NULL). So the
+partition is 5 marker paths + 3 silent ones, and the count above measures
+*generations that reached sampler construction*. Both runs ended `status: ok`
+with `attempts: 1`, so none of the three fired here; a post-bump run showing a
+short count should be read as a throw, not as DRY going missing.
 
 ---
 


### PR DESCRIPTION
## Summary

Makes the #1105 DRY sampler's construction observable from the ADR-013 harness,
and takes the b8694 baseline reading a future llama.cpp pin bump can be diffed
against. **The pin is not moved** — `main` stays at `llama.swift 2.8694.0`.

Why now: #1415's spike found `llama_sampler_init_dry` is the *only* call
signature a b10327 bump rewrites (it drops `int32_t n_ctx_train`), and had to
record that same call as **behaviourally unverified** — the success path logged
at `.debug`, which the harness's OSLog window does not retain, and the NULL /
zero-seeded paths had no stderr mirror, so "no warning appeared" was not
evidence the handle constructed.

- **Markers on every non-throwing exit** — `samplerDrySeeded` and
  `samplerDryUnavailable reason=disabled|no-seeds|no-model|null-init|no-grammar`,
  emitted as OSLog + `fputs(stderr)` exactly like `emitGrammarResampleDiagnostic`.
  `LLM/` cannot use the harness's `EngineLogger` seam — that protocol lives in
  `Engine/` and the dependency rule forbids the import.
- **One reason per exit, not one "DRY off" marker**, so a run emitting *nothing*
  is distinguishable from DRY being legitimately disabled. The `no-grammar` case
  sits in `createSampler`, upstream of the builder, for the same reason.
- **`nCtxTrain` on the line** — the argument b10327 removes. Without it a
  post-bump run cannot separate "the signature migration was correct" from "DRY
  silently stopped constructing".
- **`/model-eval` Step 2 sweeps the stderr sidecars**, with expectations written
  per *cell shape*: `speak_each` is Engine's only DRY seeder, and only
  `word_wolf` has one, so a zero in `prisoners_dilemma` / `bokete` is correct.
  Without that, the sweep would manufacture four permanent false positives.
- **b8694 baseline recorded** in `docs/models/eval-log.md` § "Corpus
  observations" — `eval-runs/` is gitignored, so this is the only committed home.

## Test plan

Full iOS suite (**3467 tests, 0 failures**, 21 skipped — the env-gated
integration suites), `swiftlint lint --strict` clean, `swift build` (harness
package, which compiles `LLM/` in place) clean,
`.claude/skills/model-eval/tests/run_tests.sh` passing.

**Two real-inference harness runs** on `word_wolf.yaml` ja with the incumbent
Gemma 4 E2B Q4_K_M GGUF, at the pinned b8694:

| arm | `samplerDrySeeded` | `no-seeds` | `disabled` | total |
|---|---|---|---|---|
| default (`mult=0.8`) | **10** (16–31 tokens each) | 16 | 0 | 26 |
| `PASTURA_DRY_MULTIPLIER=0` | 0 | 0 | **26** | 26 |

The negative arm is the load-bearing half: a marker appearing proves nothing
about whether the instrument *discriminates*; all 26 lines flipping does. It
also settles a second thing #1415 left open — that the `PASTURA_DRY_MULTIPLIER`
A/B lever reaches the sampler at all.

**Negative control on the unit test too**: deleting the `nCtxTrain=` field from
the line builder was confirmed to turn `drySeededLineCarriesEveryField` red,
then reverted. The doc comment claims that; it was executed rather than asserted.

### Measured while verifying, and recorded

- **26 markers vs 25 `inference_completed`** in both arms. The markers are
  right: `NarrateHandler` hands `LLMCaller` a no-op emitter, so the narrate turn
  emits no events. Retries do not enter — `emitInferenceCompleted` sits inside
  `LLMCaller`'s `for attempt` loop on both the success and failure paths, so an
  extra attempt increments both sides.
- **Three exits carry no marker at all** — `createSampler`'s throwing paths. An
  earlier revision of this branch asserted "every exit emits exactly one"; that
  was false and is now scoped to non-throwing exits in all three places, with the
  short-count case given its own row in the reading table.
- **Three marker paths stayed unexercised** (`no-model`, `null-init`,
  `no-grammar`). Their line *format* is unit-tested; their *emission* is not, and
  the eval-log says so — a future zero on them is "still unexercised", not a
  measured negative.

## Review

`/risk-review` (3 parallel `critic` clusters: Opus ×2, Sonnet ×1) on top of the
`code-reviewer` rounds below. It found the one defect neither the convention
gate nor three code-review rounds could see — **a claim this PR contradicted
with its own data**: `SKILL.md` said `speak_each` seeds "only from its second
round on", which predicts 5 `samplerDrySeeded` for `word_wolf`, while the
baseline this same PR recorded measured **10**. The real predicate is a
non-empty prior `lastOutputs` entry, and `lastOutputs` persists across phases,
so a *second* `speak_each` seeds from its first round. The wrong framing was
inherited from `SpeakEachHandler`'s own inline comment ("first round"), which is
accurate for the first such phase and reads as a general rule. Fixed in both the
skill and the Swift doc comment.

Four more findings, all applied:

- **The instrument's reach was overstated.** The marker echoes the Swift-side
  `DryConfig`, not what llama.cpp received — transposing the adjacent
  `multiplier`/`base` floats compiles, returns non-NULL, seeds the same count and
  emits a byte-identical line while DRY is inert. Now scoped to "construction and
  seeding are observable; argument correctness is not", with the bump's coupled
  edit set listed.
- **A harness rerun doubles every count.** `HarnessRunner` retries in-process
  while the sidecar is truncated once per wrapper call, and unlike
  `StderrEngineLogger`'s `DiagLine.attempt` these markers carry no attempt
  discriminator. Added a table row and recorded `attempts: 1` for both baseline
  arms.
- **"Do not reconcile against `inference_completed`" contradicted the eval-log's
  claim that the reconciliation is the only detector for a `narrate`-turn throw.**
  Replaced with a computable expectation (`inference_completed` + narrate
  `phase_started` count), which also scales with rounds — the "+1" was a property
  of this one scenario.
- **The sweep hid its own flagship failure.** "No marker at all" renders as an
  absent row, not a zero, and `grep` drops filenames on a single-file glob.
  Added `-H` and a sidecar-count check.

The dup2 stderr-capture axis came back **OK** — the `no-grammar` emit returns
before `initGrammarCapturingStderr` is reached and the DRY emits fire after fd 2
is restored; same-instance generations are serialized by `acquireGenerateGuard`,
and Darwin's stderr is unbuffered so a line cannot interleave. That ordering is
now stated in the emit's why-comment, since nothing tests it.

Every command published in the two docs was executed verbatim before commit; the
expectation script returns 26 against the measured 26.

`code-reviewer` (Opus) ×3 rounds. Round 1 found a Critical — the
"every exit emits exactly one line" invariant was false against three throwing
exits in `createSampler`. Rounds 2 and 3 then found defects **only in the
previous round's own fix prose**: an off-by-one in the path partition, and two
over-broad exclusivity claims (`status: ok` does not exclude the turn-degradable
`chain_init` exit; the short count is not the "sole signal", because a gated
phase emits a `turn_skipped` line naming the cause — that reconciliation is
uniquely needed only for the ungated `narrate` turn). All applied; each round's
code-path claims were independently re-derived from source before editing.

One round-2 finding was assessed as a **false positive** and not applied as
written: that retries contribute to the marker/`inference_completed` excess.
They do not, per the loop placement above; the text states the two directions it
actually drifts in instead. The round-3 reviewer concurred.

The loop hit its 3-iteration limit, so **round 3's fixes are not themselves
covered by a further review pass** — they are prose-accuracy edits to two docs
and one doc comment, with no code change.

## Device QA

実機QA不要 — the diff adds a stderr/OSLog diagnostic in the LLM layer plus docs.
No `#if !targetEnvironment(simulator)` block, no Metal or model-load path, no UI.
The behaviour that *is* device-relevant (one `fputs` per generation) is inert on
iOS, and the change was exercised end-to-end on the macOS harness with real
llama.cpp inference, which is the surface it exists for.

## Follow-up not taken

The `guard`→`reason` mapping is not pinned by a test: swapping `.noSeeds` and
`.noModel` between two guards would pass everything and silently mislabel every
sweep. Closing it needs an injectable emit sink. Recorded as an explicit
non-guarantee in the test suite's doc comment rather than left implicit; worth
an issue if these markers become load-bearing for the pin-bump verdict itself.

Closes #1483
See #1415, #1105
