### PR TITLE
📝 docs: #1415 の残ドキュメント整合 — rbudget の誤記録とその機構

### DIFF
--- a/.claude/rules/engine.md
+++ b/.claude/rules/engine.md
@@ -421,9 +421,10 @@ on a miss (`LlamaCppService.grammarConstrainedSample`, mirroring llama.cpp's
 `common_sampler_sample`) — see ADR-002 § "Grammar-all-rejected dist
 fallthrough". The retry budget itself is unchanged; the failure is gone at
 the sampler. **Not a b8694 workaround**: at the current b10327 pin the
-upstream function changed only inside a backend-sampler early return Pastura
-never enters, and the two-pass core this mirrors is unchanged — measured at the
-bump, ADR-002 § "Amendment 2026-08-15 — llama.swift pin bumped to 2.10327.0".
+upstream function changed only in a backend-sampler early return Pastura never
+enters and in a `set_logits` hoist above it, and the two-pass core this mirrors
+is byte-identical across the tags — measured at the bump and re-measured in
+#1415, ADR-002 § "Amendment 2026-08-15 — llama.swift pin bumped to 2.10327.0".
 So pin age alone is never a reason to retire the split — re-read the function
 at each bump, per ADR-002 § "Pin Strategy" verification item 2. Diagnostic
 `samplerGrammarResample` (position-0) measures the

--- a/docs/decisions/ADR-002.md
+++ b/docs/decisions/ADR-002.md
@@ -1953,25 +1953,33 @@ b10327.** Sources fetched per tag from `ggml-org/llama.cpp`
 `Package.resolved` revision is a llama.swift commit and does not reach them).
 
 - **`llama_sampler_dist_apply`** (`src/llama-sampler.cpp:1042-1112` at b10327,
-  `:1036-1106` at b8694) — **body byte-identical**, including the
-  `if (!cur_p->sorted)` guard that is the entire #751 sub-class 2 mechanism:
-  with `sorted == true` the softmax takes `max_l` from `data[0]` alone, so a
-  masked top candidate poisons every probability. It lives in
+  `src/llama-sampler.cpp:1036-1106` at b8694) — **body byte-identical**,
+  including the `if (!cur_p->sorted)` guard that is the entire #751 sub-class 2
+  mechanism: with `sorted == true` the softmax takes `max_l` from `data[0]`
+  alone, so a masked top candidate poisons every probability. It lives in
   `src/llama-sampler.cpp`, not `llama-sampling.cpp`, which is why #1415's
   `llama-grammar.cpp` diff had not covered it.
 - **`llama_sampler_sample`** (`src/llama-sampler.cpp:810-877` at b10327,
-  `:806-873` at b8694) — **body byte-identical**. This is what `safeSample`'s
-  apply/accept split replicates, so its "sampling distribution is unchanged"
-  guarantee carries over unaltered.
-- **`common_sampler_sample`** (`common/sampling.cpp:574` at b10327, `:526` at
-  b8694) — **changed**, but only inside the `llama_get_sampled_token_ith`
-  backend-sampler early return, which Pastura never enters (it reimplements the
-  strategy in Swift and uses no backend sampler). The mirrored two-pass core is
-  unchanged: chain → single-element grammar probe on the pick → on `-inf`,
-  resample with the grammar applied first. **One new divergence to know about**:
-  upstream now applies a reasoning-budget sampler (`rbudget`) ahead of the
-  grammar in both passes. Pastura has no counterpart because it has no such
-  feature — a gap to revisit only if one is added.
+  `src/llama-sampler.cpp:806-873` at b8694) — **body byte-identical**. This is
+  what `safeSample`'s apply/accept split replicates, so its "sampling
+  distribution is unchanged" guarantee carries over unaltered.
+- **`common_sampler_sample`** (`common/sampling.cpp:574-656` at b10327,
+  `common/sampling.cpp:526-606` at b8694) — **changed in exactly two hunks**:
+  the `llama_get_sampled_token_ith` backend-sampler early return's internals,
+  and the `set_logits` call, hoisted from below that block to above it. Pastura
+  reaches neither — it reimplements the strategy in Swift
+  (`LlamaCppService.grammarConstrainedSample`) and uses no backend sampler.
+  The region below that block — reasoning budget → grammar when `grammar_first`
+  → chain → single-element grammar probe on the pick → on `-inf`, resample with
+  the grammar applied first — is **byte-identical** across the two tags, so the
+  two-pass strategy the Swift mirrors is unchanged.
+  **Corrected 2026-08-19 (#1415).** The reading recorded at the bump called
+  upstream's reasoning-budget stage (`rbudget`) a divergence *new* at b10327.
+  It is not: b8694 applies it ahead of the grammar in both passes too, in the
+  byte-identical region above. Pastura having no reasoning-budget counterpart is
+  a **pre-existing** divergence, to revisit only if such a feature is added —
+  and reading a first-sighting as a change is the mechanism bar item 2's
+  cross-tag diff now guards.
 
 So the two-pass grammar split, `SafeSampler`, and the EOG-skip are **not b8694
 workarounds** and must survive this and any future bump; the why-comments naming

--- a/docs/decisions/ADR-002.md
+++ b/docs/decisions/ADR-002.md
@@ -1976,7 +1976,7 @@ b10327.** Sources fetched per tag from `ggml-org/llama.cpp`
   From the `// apply reasoning budget first` comment to the closing brace —
   reasoning budget → grammar when `grammar_first` → chain → single-element
   grammar probe on the pick → on `-inf`, resample with the grammar applied
-  first — the body is **byte-identical** across the two tags, so the two-pass
+  first — that region is **byte-identical** across the two tags, so the two-pass
   strategy the Swift mirrors is unchanged.
   **Corrected 2026-08-19 (#1415).** The reading recorded at the bump called
   upstream's reasoning-budget stage (`rbudget`) a divergence *new* at b10327.

--- a/docs/decisions/ADR-002.md
+++ b/docs/decisions/ADR-002.md
@@ -143,6 +143,10 @@ that pairs with this lives in
    and re-anchor the comment to what the new build actually does. A comment
    naming the old build reads as historical after a bump and invites retiring
    the workaround it justifies — even when the mechanism is unchanged.
+   **Diff the body across both tags, don't just read it at the new one**:
+   seeing a stage for the first time at the new tag is not evidence it is new,
+   and reading it as new is how this bump recorded upstream's `rbudget` as a
+   divergence it had introduced (#1415).
 3. **Build both lanes**: `scripts/xcodebuild.sh build` (iOS) **and**
    `swift build` (the ADR-013 harness). The pre-commit hook never runs SwiftPM,
    so a commit can be green on iOS with the harness broken.

--- a/docs/decisions/ADR-002.md
+++ b/docs/decisions/ADR-002.md
@@ -1973,17 +1973,16 @@ b10327.** Sources fetched per tag from `ggml-org/llama.cpp`
   and the `set_logits` call, hoisted from below that block to above it. Pastura
   reaches neither — it reimplements the strategy in Swift
   (`LlamaCppService.grammarConstrainedSample`) and uses no backend sampler.
-  The region below that block — reasoning budget → grammar when `grammar_first`
-  → chain → single-element grammar probe on the pick → on `-inf`, resample with
-  the grammar applied first — is **byte-identical** across the two tags, so the
-  two-pass strategy the Swift mirrors is unchanged.
+  From the `// apply reasoning budget first` comment to the closing brace —
+  reasoning budget → grammar when `grammar_first` → chain → single-element
+  grammar probe on the pick → on `-inf`, resample with the grammar applied
+  first — the body is **byte-identical** across the two tags, so the two-pass
+  strategy the Swift mirrors is unchanged.
   **Corrected 2026-08-19 (#1415).** The reading recorded at the bump called
   upstream's reasoning-budget stage (`rbudget`) a divergence *new* at b10327.
   It is not: b8694 applies it ahead of the grammar in both passes too, in the
   byte-identical region above. Pastura having no reasoning-budget counterpart is
-  a **pre-existing** divergence, to revisit only if such a feature is added —
-  and reading a first-sighting as a change is the mechanism bar item 2's
-  cross-tag diff now guards.
+  a **pre-existing** divergence, to revisit only if such a feature is added.
 
 So the two-pass grammar split, `SafeSampler`, and the EOG-skip are **not b8694
 workarounds** and must survive this and any future bump; the why-comments naming

--- a/docs/models/eval-log.md
+++ b/docs/models/eval-log.md
@@ -486,10 +486,10 @@ Reproduce: identical to the baseline's block above.
   build measured to load a 541-tensor QAT file, so nothing is known about the
   builds between it and b8694. This does **not** revive *this* candidate: per
   § "`BLOCKED` entries" the row names the condition allowing a **retry**, that
-  retry already ran (§2026-08-12), and it was a clean NO-GO. The live
-  *adoption* candidate is `UD-Q4_K_XL` — §2026-08-13 carries its current
-  status, do not restate it here; QAT-Mobile `UD-Q2_K_XL` (§2026-08-13) stays
-  BLOCKED on its own, pin-independent blocker.
+  retry already ran (§2026-08-12), and it was a clean NO-GO. The adoption that
+  did land is `UD-Q4_K_XL` — §2026-08-13 carries its state, do not restate it
+  here; QAT-Mobile `UD-Q2_K_XL` (§2026-08-13) stays BLOCKED on its own,
+  pin-independent blocker.
 - **Retry**: **ran** inside the #1415 spike — the 2026-08-12 entry above, a clean
   NO-GO. Follow that entry, not #1416, which has since been repointed at the
   QAT-Mobile retry. This entry stays a `BLOCKED` record of 2026-08-08 rather than
@@ -503,9 +503,9 @@ Reproduce: identical to the baseline's block above.
   `<turn|>` terminates generation on both builds and there is no runaway-generation
   risk. Both unsloth re-exports — `UD-Q4_K_XL`, flagged here, and the QAT-Mobile one
   this entry missed — have since been measured; see their 2026-08-13 entries above.
-  **P3–P5 remain untouched for this candidate** (Gate 2) *— true of the Google
-  QAT `Q4_0` file this entry is about, which never left Gate 1; the two
-  re-exports named above carry their own P3–P5 state in their own entries*.
+  **P3–P5 remain untouched** (Gate 2) *— this entry's Google QAT `Q4_0` file
+  never left Gate 1; the two re-exports named above carry their own P3–P5 state
+  in their own entries*.
 - **Pointers**: raw scorecard → `data/models/eval-digest.md` §2026-08-08 ·
   gemma-4-e2b-q4-k-m (gitignored, and replaced by key `(date, profile_id)` — which
   here is the *incumbent's* id, so treat it as volatile) · intake → #979 · pin

--- a/docs/models/eval-log.md
+++ b/docs/models/eval-log.md
@@ -487,9 +487,9 @@ Reproduce: identical to the baseline's block above.
   builds between it and b8694. This does **not** revive *this* candidate: per
   § "`BLOCKED` entries" the row names the condition allowing a **retry**, that
   retry already ran (§2026-08-12), and it was a clean NO-GO. The live
-  *adoption* candidate is `UD-Q4_K_XL` (§2026-08-13), still gated on ADR-011
-  P3–P5 device QA; QAT-Mobile `UD-Q2_K_XL` (§2026-08-13) stays BLOCKED on its
-  own, pin-independent blocker.
+  *adoption* candidate is `UD-Q4_K_XL` — §2026-08-13 carries its current
+  status, do not restate it here; QAT-Mobile `UD-Q2_K_XL` (§2026-08-13) stays
+  BLOCKED on its own, pin-independent blocker.
 - **Retry**: **ran** inside the #1415 spike — the 2026-08-12 entry above, a clean
   NO-GO. Follow that entry, not #1416, which has since been repointed at the
   QAT-Mobile retry. This entry stays a `BLOCKED` record of 2026-08-08 rather than
@@ -503,7 +503,9 @@ Reproduce: identical to the baseline's block above.
   `<turn|>` terminates generation on both builds and there is no runaway-generation
   risk. Both unsloth re-exports — `UD-Q4_K_XL`, flagged here, and the QAT-Mobile one
   this entry missed — have since been measured; see their 2026-08-13 entries above.
-  **P3–P5 remain untouched** (Gate 2).
+  **P3–P5 remain untouched for this candidate** (Gate 2) *— true of the Google
+  QAT `Q4_0` file this entry is about, which never left Gate 1; the two
+  re-exports named above carry their own P3–P5 state in their own entries*.
 - **Pointers**: raw scorecard → `data/models/eval-digest.md` §2026-08-08 ·
   gemma-4-e2b-q4-k-m (gitignored, and replaced by key `(date, profile_id)` — which
   here is the *incumbent's* id, so treat it as volatile) · intake → #979 · pin


### PR DESCRIPTION
## Summary

Residual documentation drift left behind by the llama.swift pin bump (#1489, merged
2026-08-16). Three prose corrections, no code, no behaviour change — this is the last
open work on #1415.

### 1. `common_sampler_sample` was recorded wrong at the bump, and the mirror with it

PR #1489's final reviewer flagged an internal contradiction in ADR-002 bar item 2 —
"**changed**, but only inside the backend-sampler early return … The mirrored two-pass
core is unchanged" sitting beside "**One new divergence**: upstream now applies a
reasoning-budget sampler (`rbudget`) ahead of the grammar in both passes" — and left it
out of scope. It is resolved here by **measuring** rather than re-reading: both tags
fetched from `raw.githubusercontent.com/ggml-org/llama.cpp/<tag>/common/sampling.cpp`
and `diff -u`'d.

**The false half is "new".** `rbudget` is applied ahead of the grammar in both passes at
**b8694 too**, inside a region that is byte-identical across the tags. Pastura having no
reasoning-budget counterpart is a **pre-existing** divergence, not one this bump
introduced — so with "new" retracted, "the mirrored two-pass core is unchanged" is true
and the contradiction dissolves.

Two further corrections fell out of the same measurement:

- **The changed region was understated.** The diff is *two* hunks: the
  `llama_get_sampled_token_ith` early return's internals, **and** the `set_logits` call,
  hoisted from below that block to above it. Pastura reaches neither.
- **Function extents measured**: `common/sampling.cpp:574-656` (b10327),
  `common/sampling.cpp:526-606` (b8694) — replacing a bare start-line citation.

`.claude/rules/engine.md` is the one mirror of this claim (it says "changed **only**
inside a backend-sampler early return" and cites ADR-002 as its source), swept in the
same commit.

### 2. The mechanism that produced the error

Bar item 2 said "**re-read** the upstream body of any function a why-comment reasons
about" — which is how a stage present at b8694 got recorded as new at b10327. The two
sibling bullets under the same bar, which *did* diff across tags, both came out right.
One clause added: diff the body across **both** tags; a first sighting at the new tag is
not evidence of a change. No new numbered item — the bar stays at 6.

### 3. `eval-log.md` §2026-08-08 — two P3–P5 statements, split by provenance

`git blame` separates what looked like one defect:

- `:490-491` was authored by `8bf34195` (2026-08-16) — *after* the 2026-08-15 device PASS
  it contradicts ("`UD-Q4_K_XL` … still gated on ADR-011 P3–P5 device QA"). **Born
  wrong**, so rewritten — and rewritten to *route* to §2026-08-13 rather than restate a
  status, which would only re-stale at the next supersede.
- `:506` was authored by `1adb2bd1` (2026-08-13) and was true when written; only its
  attribution is ambiguous, because the preceding sentence names the two unsloth
  re-exports. Annotated and scoped in the file's own idiom (cf. `:316`) rather than
  rewritten.

## Verification

- **The load-bearing claim is not re-derivable from this repo** — the resolved llama.swift
  xcframework ships headers only, not `common/sampling.cpp`. Both tags were fetched and
  diffed this session; the reviewer was handed the measurements explicitly rather than
  being left to plausibility-check them.
- **Citation greps, differential**: `src/llama-sampler.cpp:806-873`,
  `common/sampling.cpp:526-606`, `common/sampling.cpp:574-656` each went 0 → 1 hit, and
  `src/llama-sampler.cpp:1036-1106` 1 → 2 — i.e. three anchors that ADR-002's own bar
  item 6 requires to be greppable were **not**, because the b8694 half wrapped away from
  its filename. The two sibling bullets in the same paragraph are fixed with it.
- **Population re-derived from the authoring commit, not from a token grep**: every line
  `8bf34195` added under `docs/`, `README.md`, `CONTRIBUTING.md` and `.claude/` swept for
  present-tense gating/newness claims. Exactly one born-wrong site, the one fixed here.
  (A `P3–P5`-keyed grep alone could not have proved that — it cannot reach a claim phrased
  without the token.)
- **No SwiftLint / xcodebuild run**: `scripts/precommit-gate-classify.sh` emits neither a
  `build` nor a `lint` token for this changeset, so both gates are skipped by design —
  and CI path-gating uses the same script.
- **Review**: `code-reviewer` (Opus) — first pass PASS with 2 Warnings + 2 Suggestions,
  all fixed; re-review scoped to the fix diff returned PASS with 1 Suggestion, also fixed.
  Notably it caught that the corrected text had **itself** mis-anchored the byte-identical
  region ("below that block" — which at b8694 *starts* with the changed `set_logits`); it
  is now anchored to the `// apply reasoning budget first` landmark, which is also
  greppable at the next bump. Plan review: `claude-kit:critic` (Opus), 6 axes, no Critical
  — its warnings are what added the `engine.md` mirror sweep, the bar item 2 clause, and
  the provenance split to the plan.

## Test plan

Documentation only — no test suite is reachable by this diff. Verification is the grep
differentials and the two review rounds above.

## Device QA

実機QA不要 — 3ファイルとも Markdown。`#if !targetEnvironment(simulator)` ブロック、
Metal / 推論パス、レイアウトのいずれにも触れていない。

Closes #1415
