### PR TITLE
♻️ refactor: §2.9 ペア数のリテラルをサイズガードへ一本化

### DIFF
--- a/Pastura/Pastura/Views/Components/HighlightShareCard.swift
+++ b/Pastura/Pastura/Views/Components/HighlightShareCard.swift
@@ -20,7 +20,7 @@ import SwiftUI
 /// 1. `ImageRenderer` renders its content in a *default* environment and does
 ///    NOT inherit the ambient color scheme — an unset card would always
 ///    rasterize light regardless of the device.
-/// 2. The app's `Color.*` aliases are trait-resolving for the 69 paired §2.9
+/// 2. The app's `Color.*` aliases are trait-resolving for the paired §2.9
 ///    tokens (ADR-028 gate 1, closed by slice 4). Reading them here would
 ///    resolve against reason 1's injected scheme — #1337 measured that, so the
 ///    families would render the *requested* appearance — but `light` and `dark`

--- a/Pastura/Pastura/Views/DesignTokens+DynamicPalette.swift
+++ b/Pastura/Pastura/Views/DesignTokens+DynamicPalette.swift
@@ -24,15 +24,17 @@ import SwiftUI
 ///
 /// ``all`` below is the registry; its size is pinned by
 /// `DesignTokensTests+DarkMode`'s count guard, which is the only place in the
-/// Swift sources that states the number. Which slice contributed which pair is
-/// recorded once, in ADR-028 § "The eight pairs" — not restated here.
+/// Swift sources that states the number — a numeral anywhere else in Swift is a
+/// stale mirror. Which slice contributed which pair is recorded in ADR-028
+/// § "The eight pairs" (which covers all of them, not only the original eight),
+/// not restated here.
 ///
-/// That provenance list is not a partition. The two **role tokens**,
-/// `mossOnWash` (#1327) and `inkOnWash` (#1408), were added *after* gate 1
-/// closed and for a different reason than any slice: not a light token owed a
-/// dark half, but a new light token that had to exist at all, born paired
-/// because §2.9 is now how the palette works. So "which slice is it from?" has
-/// no answer for either.
+/// That record is a provenance list, not a partition of ``all``: two entries
+/// belong to no slice. They are the **role tokens**, `mossOnWash` (#1327) and
+/// `inkOnWash` (#1408), added *after* gate 1 closed and for a different reason
+/// than any slice — not a light token owed a dark half, but a new light token
+/// that had to exist at all, born paired because §2.9 is now how the palette
+/// works. So "which slice is it from?" has no answer for either.
 ///
 /// Exactly **one** light token remains unpaired, and gate 1 owes an answer for
 /// **none**. `headerMetaSubdued` is that one: slice 2 recorded it as fixed in

--- a/Pastura/Pastura/Views/DesignTokens+DynamicPalette.swift
+++ b/Pastura/Pastura/Views/DesignTokens+DynamicPalette.swift
@@ -22,20 +22,17 @@ import SwiftUI
 
 /// The light↔dark token pairs wired into the app's `Color.*` aliases.
 ///
-/// **69 pairs.** The original eight (ADR-028), plus the §2.6 alert family and
-/// §2.7 interactive states from slice 1 of gate 1 (#1282), plus the §2.4 meta
-/// presets and two of the three §2.12 header slots from slice 2 (#1313), plus
-/// the §2.5 character palette from slice 3 (#1319), plus the §2.1/§2.3/§2.8
-/// remainder and `inkOnAccent` from slice 4 — the last one, which **closed
-/// gate 1**.
+/// ``all`` below is the registry; its size is pinned by
+/// `DesignTokensTests+DarkMode`'s count guard, which is the only place in the
+/// Swift sources that states the number. Which slice contributed which pair is
+/// recorded once, in ADR-028 § "The eight pairs" — not restated here.
 ///
-/// The slices account for 67 of those. The remaining two are the **role
-/// tokens**, `mossOnWash` (#1327) and `inkOnWash` (#1408), both added *after*
-/// gate 1 closed and for a different reason than any slice: not a light token
-/// owed a dark half, but a new light token that had to exist at all, born
-/// paired because §2.9 is now how the palette works. So "which slice is it
-/// from?" has no answer for either, and the enumeration above is a provenance
-/// list rather than a partition of the count.
+/// That provenance list is not a partition. The two **role tokens**,
+/// `mossOnWash` (#1327) and `inkOnWash` (#1408), were added *after* gate 1
+/// closed and for a different reason than any slice: not a light token owed a
+/// dark half, but a new light token that had to exist at all, born paired
+/// because §2.9 is now how the palette works. So "which slice is it from?" has
+/// no answer for either.
 ///
 /// Exactly **one** light token remains unpaired, and gate 1 owes an answer for
 /// **none**. `headerMetaSubdued` is that one: slice 2 recorded it as fixed in
@@ -282,11 +279,11 @@ enum PasturaDynamicPalette {
   ///
   /// Consumed by `DesignTokensTests+DarkMode`'s count assertion. Note what that
   /// does and does not catch: the registry is hand-maintained, so declaring a
-  /// 70th pair and *not* appending it here leaves `all.count == 69` and passes.
-  /// The count guards this list against its own documented size, nothing more —
-  /// the real per-alias coverage is the wiring tests in
-  /// `DesignTokensTests+DarkModeWiring`, which resolve each of the 69 `Color.*`
-  /// aliases under both schemes.
+  /// new pair and *not* appending it here leaves `all.count` unchanged and
+  /// passes. The count guards this list against its own documented size,
+  /// nothing more — the real per-alias coverage is the wiring tests in
+  /// `DesignTokensTests+DarkModeWiring`, which resolve every `Color.*` alias
+  /// under both schemes.
   static let all: [(name: String, pair: PasturaDynamicColor)] = [
     ("screenBackground", screenBackground),
     ("bubbleBackground", bubbleBackground),

--- a/Pastura/Pastura/Views/DesignTokens+SwiftUI.swift
+++ b/Pastura/Pastura/Views/DesignTokens+SwiftUI.swift
@@ -9,7 +9,7 @@ import SwiftUI
 // MARK: - Color extension (SwiftUI-facing aliases)
 
 extension Color {
-  // The 69 aliases sourced from `PasturaDynamicPalette` resolve light/dark
+  // The aliases sourced from `PasturaDynamicPalette` resolve light/dark
   // against the ambient interface style (§2.9 — ADR-028's original eight, the
   // §2.6/§2.7 slice in #1282, the §2.4 meta presets plus two §2.12 header
   // slots in #1313, the §2.5 character palette in #1319, the §2.1/§2.3/§2.8
@@ -19,13 +19,16 @@ extension Color {
   // light token is left in pairing scope and it is resolved, not pending**:
   // `headerMetaSubdued`, fixed in both appearances by decision — see
   // `DesignTokens+NightPalette`'s §2.12 MARK. The remaining aliases below are
-  // outside that scope entirely: the 69 §2.9 `night*` ones are the dark halves
-  // themselves (note `night` alone is §2.10, not one of them — grepping the
-  // prefix returns 70), and §2.10 time-of-day / §2.11 chart are decorative
-  // reservations that were never candidates for pairing. `Info.plist`'s
-  // `UIUserInterfaceStyle` lock has been removed (ADR-028 gates 4/5), so every
-  // half-dark surface now renders on a device set to dark appearance — nothing
-  // missing holds it back, since slice 4 already closed gate 1.
+  // outside that scope entirely: the §2.9 `night*` ones are the dark halves
+  // themselves (note `night` alone is §2.10, not one of them — so
+  // `grep -c '^  static let night' DesignTokens+SwiftUI.swift` returns one more
+  // than the pair count, never the pair count itself; the leading anchor is what
+  // keeps this very line out of its own count), and §2.10 time-of-day /
+  // §2.11 chart are decorative reservations that were never candidates for
+  // pairing. `Info.plist`'s `UIUserInterfaceStyle` lock has been removed
+  // (ADR-028 gates 4/5), so every half-dark surface now renders on a device set
+  // to dark appearance — nothing missing holds it back, since slice 4 already
+  // closed gate 1.
   //
   // Need a specific appearance regardless of the device — e.g. an
   // `ImageRenderer` export, which does not inherit the ambient environment?

--- a/Pastura/Pastura/Views/DesignTokens+SwiftUI.swift
+++ b/Pastura/Pastura/Views/DesignTokens+SwiftUI.swift
@@ -10,25 +10,20 @@ import SwiftUI
 
 extension Color {
   // The aliases sourced from `PasturaDynamicPalette` resolve light/dark
-  // against the ambient interface style (§2.9 — ADR-028's original eight, the
-  // §2.6/§2.7 slice in #1282, the §2.4 meta presets plus two §2.12 header
-  // slots in #1313, the §2.5 character palette in #1319, the §2.1/§2.3/§2.8
-  // remainder plus `inkOnAccent` in slice 4, which closed gate 1, and then the
-  // two post-gate-1 role tokens `mossOnWash` in #1327 and `inkOnWash` in
-  // #1408). **Exactly one
-  // light token is left in pairing scope and it is resolved, not pending**:
-  // `headerMetaSubdued`, fixed in both appearances by decision — see
+  // against the ambient interface style (§2.9 — per-slice provenance in
+  // ADR-028 § "The eight pairs"). **Exactly one light token is left in
+  // pairing scope and it is resolved, not pending**: `headerMetaSubdued`,
+  // fixed in both appearances by decision — see
   // `DesignTokens+NightPalette`'s §2.12 MARK. The remaining aliases below are
   // outside that scope entirely: the §2.9 `night*` ones are the dark halves
-  // themselves (note `night` alone is §2.10, not one of them — so
-  // `grep -c '^  static let night' DesignTokens+SwiftUI.swift` returns one more
-  // than the pair count, never the pair count itself; the leading anchor is what
-  // keeps this very line out of its own count), and §2.10 time-of-day /
-  // §2.11 chart are decorative reservations that were never candidates for
-  // pairing. `Info.plist`'s `UIUserInterfaceStyle` lock has been removed
-  // (ADR-028 gates 4/5), so every half-dark surface now renders on a device set
-  // to dark appearance — nothing missing holds it back, since slice 4 already
-  // closed gate 1.
+  // themselves — `night` alone is §2.10, not a pair, so
+  // `grep -c '^  static let night' Pastura/Pastura/Views/DesignTokens+SwiftUI.swift`
+  // returns the pair count plus that one (keep the leading anchor, or the count
+  // includes this comment). §2.10 time-of-day / §2.11 chart are decorative
+  // reservations that were never candidates for pairing. `Info.plist`'s
+  // `UIUserInterfaceStyle` lock has been removed (ADR-028 gates 4/5), so every
+  // half-dark surface now renders on a device set to dark appearance — nothing
+  // missing holds it back, since slice 4 already closed gate 1.
   //
   // Need a specific appearance regardless of the device — e.g. an
   // `ImageRenderer` export, which does not inherit the ambient environment?

--- a/Pastura/PasturaTests/Views/DesignTokensTests+DarkMode.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+DarkMode.swift
@@ -6,7 +6,7 @@ import UIKit
 
 // §2.9 dark-mode token-pair tests. Protects ADR-028's mechanism decision:
 // `PasturaDynamicColor` resolves a light/dark pair through a `UIColor` dynamic
-// provider, and the 69 paired `Color.*` aliases are actually wired to it.
+// provider, and the paired `Color.*` aliases are actually wired to it.
 //
 // Sibling-file extension of `DesignTokensTests` per `.claude/rules/testing.md`
 // § "Splitting a Suite Across Files" — a fresh `@Suite` would run in parallel

--- a/Pastura/PasturaTests/Views/HighlightShareCardPaletteTests.swift
+++ b/Pastura/PasturaTests/Views/HighlightShareCardPaletteTests.swift
@@ -7,7 +7,7 @@ import Testing
 /// values (ADR-028).
 ///
 /// Why this suite exists: `HighlightShareCard` is the only sanctioned
-/// fixed-appearance consumer in the app, and 69 `Color.*` aliases are now
+/// fixed-appearance consumer in the app, and the §2.9 `Color.*` aliases are now
 /// trait-resolving. If one creeps back into this palette, both families collapse
 /// to whatever the render environment resolved — and nothing else would notice,
 /// because `ImageRenderer` output is asserted nowhere and ADR-009 rules out

--- a/Pastura/PasturaUITests/MarketingShotTests.swift
+++ b/Pastura/PasturaUITests/MarketingShotTests.swift
@@ -12,9 +12,10 @@ import XCTest
 /// CI-skipped via `-skip-testing PasturaUITests/MarketingShotTests` in
 /// `ci.yml` — same class as `StoreScreenshotTests`. **ja / light only**, but
 /// light is now enforced rather than inherent: #1284 removed `Info.plist`'s
-/// `UIUserInterfaceStyle`, so the app follows the device and all 69 ADR-028
-/// pairs resolve. `scripts/marketing-shots.sh` pins the simulator's appearance
-/// to light before the run; a dark marketing set is deferred, not impossible.
+/// `UIUserInterfaceStyle`, so the app follows the device and every §2.9 pair
+/// in `PasturaDynamicPalette.all` resolves. `scripts/marketing-shots.sh` pins
+/// the simulator's appearance to light before the run; a dark marketing set is
+/// deferred, not impossible.
 @MainActor
 final class MarketingShotTests: XCTestCase {
   private static let jaArgs = ["-AppleLanguages", "(ja)", "-AppleLocale", "ja_JP"]


### PR DESCRIPTION
## Summary

The §2.9 dynamic-palette pair count was hand-mirrored as a prose literal across six files, so every
token-pair addition needed an edit in each and nothing failed when one was missed. Eleven
restatements across six files are removed. The count now lives only in
`DesignTokensTests+DarkMode.swift`'s size guard, where the literal is what keeps the assertion
non-vacuous — rewriting it as `all.count` would make it tautological, which is why the issue's
"Do NOT touch" carve-out is honoured exactly.

Ten of the eleven were the sites the issue enumerated. The eleventh —
`PasturaUITests/MarketingShotTests.swift` — sat outside the issue's six-file glob and was found by
the review pass; it is included because this PR's own new comment asserts the guard is the only
Swift site stating the number, and that claim has to be true rather than hedged.

Two sites kept an argument the number was carrying, restated without it:

- **`DesignTokens+DynamicPalette.swift`** — the slice-vs-role-token distinction survives as *"that
  record is a provenance list, not a partition of `all`: two entries belong to no slice"*, which is
  the forward-looking half. The provenance enumeration itself is folded into a pointer to
  ADR-028 § "The eight pairs", of which it was a near-verbatim mirror.
- **`DesignTokens+SwiftUI.swift`** — the `night*` prefix grep returns one more than the pair count
  (bare `night` is §2.10, not a pair). Restated as that decomposition, with the counting command
  inline so the relation stays checkable now that the literal is gone. **The command's leading
  `^  ` anchor is load-bearing**: without it the documenting line matches its own predicate and the
  count reads 71. That is stated in the comment so the next editor does not "simplify" it away.

`DesignTokens+SwiftUI.swift`'s comment block ends two lines shorter than it was before this branch:
the second copy of the slice provenance is gone, and what replaced the bare numeral is a runnable
command rather than more prose.

Comments only; no behavioural change, no token added or removed.

## Scope notes

- **`exactlySixtyNinePairsAreWired` is deliberately untouched.** The identifier encodes the count
  spelled out, so the issue's regex structurally cannot see it. ADR-028:1483-1489 already
  adjudicated this: the identifier carries the count by design and is renamed on every increment
  (`…FiftySeven…` → `…SixtyEight…` → `…SixtyNine…`), with the standing instruction to "search the
  count *shape*, not a number, and not a name that embeds one". It is not stale today. The
  cross-file prose reference at `DesignTokensTests+NightMeta.swift:205` renames with it.
- **Four live restatements remain under `docs/`** — `design-system.md:279`,
  `ds/colors-reserved.html:32`, `screenshots/README.md:92`, `qa/dark-mode-qa.md:21`. Out of scope
  here (the issue's acceptance constrains the Swift glob) and tracked in #1492. This is exactly why
  the new comment says "the only place in **the Swift sources**" rather than "in the repo" — the
  broader claim would have been false on arrival.
- **ADR-028's own numerals stay.** They are dated decision records, not mirrors that should track
  the current count.
- **Two Swift comments now depend on the ADR-028 heading `### The eight pairs`** (`:162`). Renaming
  that heading requires sweeping both; noted in #1492.

## Test plan

- `scripts/xcodebuild.sh test -skip-testing:PasturaUITests` — **3488 tests / 286 suites passed**
  (the UI-test target still compiles; `MarketingShotTests.swift` is in it).
- `swiftlint lint --quiet --strict` — clean.
- Acceptance criterion, verified by count rather than by eye — the issue's enumeration command
  returns **exactly 4** lines, all of them the untouchable guard
  (`DesignTokensTests+DarkMode.swift:113,114,118,119`):

  ```sh
  git grep -nE '(^|[^0-9.])(67|69|70)(th)?([^0-9.]|$)' -- \
    'Pastura/Pastura/Views/DesignTokens*' \
    'Pastura/Pastura/Views/Components/HighlightShareCard.swift' \
    'Pastura/PasturaTests/Views/DesignTokens*' \
    'Pastura/PasturaTests/Views/HighlightShareCard*' | grep -v '0x' | wc -l
  ```

- Every claim the new comments author was executed rather than asserted:
  - the printed command, run verbatim from the repo root → **70**; `PasturaDynamicPalette.all` →
    **69**; so "the pair count plus that one" holds.
  - negative control for the anchor claim: `grep -c 'static let night' …` → **71**, and the extra
    line is the documenting comment itself. The `^  ` anchor is what excludes it.
  - repo-wide `*.swift` sweep confirms no numeral outside the guard states the pair count.
  - `### The eight pairs` exists at `ADR-028.md:162`, so both new pointers resolve.

## Device QA

実機QA不要 — コメントのみの変更で、`#if !targetEnvironment(simulator)` ブロック・Metal / llama.cpp 経路・
描画コードのいずれにも触れていない。ビルド生成物は同一。

Closes #1477
