### PR TITLE
🧪 test: wash fixture の large-text 閾値を実行可能にする (#1468)

### DIFF
--- a/Pastura/PasturaTests/Views/DesignTokensTests+InkOnWash.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+InkOnWash.swift
@@ -50,7 +50,8 @@ extension DesignTokensTests {
       // `.textStyle(Typography.tagPhase)`
       InkWashSite(
         "PhaseTypeLabel", alpha: 0.15,
-        pointSize: Double(Typography.tagPhase.size), weight: .semibold),
+        pointSize: Double(Typography.tagPhase.size),
+        weight: WashLabelWeight(Typography.tagPhase.weight)),
       // `.font(.caption)` + `.fontWeight(.semibold)` — one `resultPill` helper
       // renders this and `+MossInkAsWashLabel`'s `ResultsView.completed`.
       InkWashSite(
@@ -64,9 +65,11 @@ extension DesignTokensTests {
   /// content size.
   ///
   /// Executed since #1468 — the rows carry their type size and
-  /// ``inkOnWashClearsAAOnEverySelfWashItIsUsedOn`` rejects a large-text row
-  /// before applying this bar to it; ``WashLabelWeight`` owns the threshold and
-  /// the `.semibold` half.
+  /// ``inkOnWashClearsAAOnEverySelfWashItIsUsedOn`` checks the criterion per
+  /// row; ``WashLabelWeight`` owns the threshold and the `.semibold` half.
+  /// `#expect` does not short-circuit, so a large-text row is flagged and then
+  /// measured at 4.5 anyway, and belongs where 3:1 is measured — see the "Large
+  /// text is out" bullet in `DesignTokensTests+MossInkAsWashLabel.swift`.
   ///
   /// Pinning 4.5 stays conservative at accessibility sizes: the semantic-font
   /// rows scale past their weight's threshold there and the 3:1 large-text bar
@@ -78,11 +81,9 @@ extension DesignTokensTests {
   /// **No type-size extreme of a fixture is restated in any of the three wash
   /// files.** (Not in the suite at large — `+MossSoftGround.swift`'s still
   /// stands; see ``DesignTokensTests/inkWashSiteRejectsLargeTextLabels``' file
-  /// header.) The old advice was
-  /// "re-derive this fixture's own extreme, never cite a sibling's" — this
-  /// paragraph *was* a citation of `+MossOnWash`'s `~11pt` until #1459
-  /// falsified it there. Recording the size per row retires the advice along
-  /// with the hazard: there is no longer an extreme to quote or to keep true.
+  /// header.) The old advice — "re-derive this fixture's own extreme, never
+  /// cite a sibling's" — is retired along with the hazard it managed: with the
+  /// size recorded per row there is no extreme left to quote or to keep true.
   private static let inkTextBar = 4.5
 
   /// "Clears the bar" and "has margin above it" are different claims, and this
@@ -303,13 +304,15 @@ struct InkWashSite {
   let name: String
   let alpha: Double
 
-  /// The label's point size at the default `.large` content size. Both regimes
-  /// this field spans, and why a wrong transcription is caught by nothing:
-  /// ``MossWashSite/pointSize``, which states them once for both row types.
+  /// The label's point size at the default `.large` content size. The two
+  /// regimes this field spans, and why a wrong transcription is caught by
+  /// nothing: ``WashLabelSemanticSize``, which states them once for both row
+  /// types.
   let pointSize: Double
 
   /// Which WCAG large-text half the label's weight selects — see
-  /// ``WashLabelWeight`` for the `.semibold` decision.
+  /// ``WashLabelWeight`` for the `.semibold` decision, and ``WashLabelWeight/init(_:)``
+  /// for deriving this from a token rather than transcribing it.
   let weight: WashLabelWeight
 
   init(_ name: String, alpha: Double, pointSize: Double, weight: WashLabelWeight) {

--- a/Pastura/PasturaTests/Views/DesignTokensTests+InkOnWash.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+InkOnWash.swift
@@ -36,27 +36,50 @@ extension DesignTokensTests {
   /// three; nothing mechanical will find a fifth.
   static var inkWashSites: [InkWashSite] {
     [
-      InkWashSite("PhaseEditorSheet.fieldPill", alpha: 0.16),
-      InkWashSite("ScenarioBadgeStyle.secondary", alpha: 0.15),
-      InkWashSite("PhaseTypeLabel", alpha: 0.15),
-      InkWashSite("ResultsView.paused", alpha: 0.12)
+      // `.caption2.weight(.semibold)` — one `fieldPill` helper serves this and
+      // `+MossOnWash`'s row of the same name, so the two share a font.
+      InkWashSite(
+        "PhaseEditorSheet.fieldPill", alpha: 0.16,
+        pointSize: WashLabelSemanticSize.caption2, weight: .semibold),
+      // `.caption2.bold()`, via `GalleryCatalogRow.badgeView` — the app's only
+      // `ScenarioBadge` renderer since #1296, which is what gives this row a
+      // single well-defined font.
+      InkWashSite(
+        "ScenarioBadgeStyle.secondary", alpha: 0.15,
+        pointSize: WashLabelSemanticSize.caption2, weight: .bold),
+      // `.textStyle(Typography.tagPhase)`
+      InkWashSite(
+        "PhaseTypeLabel", alpha: 0.15,
+        pointSize: Double(Typography.tagPhase.size), weight: .semibold),
+      // `.font(.caption)` + `.fontWeight(.semibold)` — one `resultPill` helper
+      // renders this and `+MossInkAsWashLabel`'s `ResultsView.completed`.
+      InkWashSite(
+        "ResultsView.paused", alpha: 0.12,
+        pointSize: WashLabelSemanticSize.caption, weight: .semibold)
     ]
   }
 
-  /// WCAG 1.4.3 normal-text bar. Every one of these labels is under the "large
-  /// text" threshold (≥14pt bold / ≥18pt regular) — the largest is
-  /// `ResultsView`'s pill at `.caption` + `.semibold`, i.e. **12pt**, and the
-  /// smallest is `PhaseTypeLabel` at `Typography.tagPhase`'s 9.5pt — so 3:1
-  /// never applies to any of them at default Dynamic Type. At accessibility
-  /// sizes `.caption` scales past 14pt and the large-text 3:1 bar *would* apply,
-  /// which only **relaxes** the requirement — so pinning 4.5 stays conservative.
-  /// Do not "correct" this in the other direction.
+  /// WCAG 1.4.3 normal-text bar, and it is the right bar only because every
+  /// label in the fixture is under the "large text" threshold at the default
+  /// content size.
   ///
-  /// **Re-derived here, never cited from a sibling wash fixture.** Each site
-  /// set is its own, so a superlative quoted across files is a mirror with
-  /// nothing keeping it true — this paragraph *was* one, citing `+MossOnWash`'s
-  /// `~11pt`, until #1459 falsified it there. State this fixture's own extreme
-  /// and stop.
+  /// Executed since #1468 — the rows carry their type size and
+  /// ``inkOnWashClearsAAOnEverySelfWashItIsUsedOn`` rejects a large-text row
+  /// before applying this bar to it; ``WashLabelWeight`` owns the threshold and
+  /// the `.semibold` half.
+  ///
+  /// Pinning 4.5 stays conservative at accessibility sizes: the semantic-font
+  /// rows scale past their weight's threshold there and the 3:1 large-text bar
+  /// *would* apply, which only **relaxes** the requirement. Do not "correct"
+  /// this in the other direction — and note the threshold to compare against is
+  /// the row's own, not a flat 14: every semantic-font row here is `.semibold`
+  /// or `.bold`, which take different halves.
+  ///
+  /// **No superlative is restated, here or anywhere.** The old advice was
+  /// "re-derive this fixture's own extreme, never cite a sibling's" — this
+  /// paragraph *was* a citation of `+MossOnWash`'s `~11pt` until #1459
+  /// falsified it there. Recording the size per row retires the advice along
+  /// with the hazard: there is no longer an extreme to quote or to keep true.
   private static let inkTextBar = 4.5
 
   /// "Clears the bar" and "has margin above it" are different claims, and this
@@ -105,6 +128,13 @@ extension DesignTokensTests {
     #expect(Self.inkWashSites.count == 4)
 
     for site in Self.inkWashSites {
+      // The admission criterion the bar below depends on — see `inkTextBar`.
+      // Prose until #1468, over a row type that stored no font.
+      #expect(
+        site.isNormalText,
+        "\(site.name) is large text (\(site.pointSize)pt \(site.weight)) and does not belong in a normal-text fixture"
+      )
+
       let lightGround = composite(
         PasturaPalette.inkSecondary, over: PasturaPalette.screenBackground, alpha: site.alpha)
       let light = contrastRatio(PasturaPalette.inkOnWash, lightGround)
@@ -257,12 +287,13 @@ extension DesignTokensTests {
 // MARK: - Helpers
 
 /// One shipped self-wash consumer: a site painting `inkSecondary` as both its
-/// label and its capsule fill, and the alpha it fills at.
+/// label and its capsule fill, the alpha it fills at, and the type size of the
+/// label on it.
 ///
-/// A struct rather than a tuple for consistency with ``MossWashSite``, whose
-/// four members exceed swiftlint's `large_tuple` cap. This one carries only two
-/// — every row fills with the same token, and none of them re-base the alpha per
-/// appearance — so the wash token is not stored.
+/// A struct rather than a tuple because swiftlint's `large_tuple` caps tuples
+/// at two members. It carries four rather than ``MossWashSite``'s six: every row
+/// fills with the same token and none re-bases the alpha per appearance, so
+/// neither the wash nor a second alpha is stored.
 ///
 /// File scope per `.claude/rules/testing.md` § "Splitting a Suite Across Files":
 /// helpers in a sibling file live outside the suite struct.
@@ -270,8 +301,26 @@ struct InkWashSite {
   let name: String
   let alpha: Double
 
-  init(_ name: String, alpha: Double) {
+  /// The label's point size at the default `.large` content size. Both regimes
+  /// this field spans, and why a wrong transcription is caught by nothing:
+  /// ``MossWashSite/pointSize``, which states them once for both row types.
+  let pointSize: Double
+
+  /// Which WCAG large-text half the label's weight selects — see
+  /// ``WashLabelWeight`` for the `.semibold` decision.
+  let weight: WashLabelWeight
+
+  init(_ name: String, alpha: Double, pointSize: Double, weight: WashLabelWeight) {
     self.name = name
     self.alpha = alpha
+    self.pointSize = pointSize
+    self.weight = weight
   }
+
+  /// Whether this row's label is still WCAG **normal** text, i.e. whether the
+  /// 4.5:1 bar the fixture pins is the bar it actually answers to.
+  ///
+  /// Both parameters are required at construction, so a row cannot join without
+  /// declaring a font.
+  var isNormalText: Bool { weight.admitsAsNormalText(pointSize: pointSize) }
 }

--- a/Pastura/PasturaTests/Views/DesignTokensTests+InkOnWash.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+InkOnWash.swift
@@ -75,10 +75,10 @@ extension DesignTokensTests {
   /// the row's own, not a flat 14: every semantic-font row here is `.semibold`
   /// or `.bold`, which take different halves.
   ///
-  /// **No superlative is restated in any of the three wash fixtures.** (Not in
-  /// the suite at large — `+MossSoftGround.swift`'s still stands; see
-  /// ``DesignTokensTests/inkWashSiteRejectsLargeTextLabels``' file header.) The
-  /// old advice was
+  /// **No type-size extreme of a fixture is restated in any of the three wash
+  /// files.** (Not in the suite at large — `+MossSoftGround.swift`'s still
+  /// stands; see ``DesignTokensTests/inkWashSiteRejectsLargeTextLabels``' file
+  /// header.) The old advice was
   /// "re-derive this fixture's own extreme, never cite a sibling's" — this
   /// paragraph *was* a citation of `+MossOnWash`'s `~11pt` until #1459
   /// falsified it there. Recording the size per row retires the advice along

--- a/Pastura/PasturaTests/Views/DesignTokensTests+InkOnWash.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+InkOnWash.swift
@@ -75,7 +75,10 @@ extension DesignTokensTests {
   /// the row's own, not a flat 14: every semantic-font row here is `.semibold`
   /// or `.bold`, which take different halves.
   ///
-  /// **No superlative is restated, here or anywhere.** The old advice was
+  /// **No superlative is restated in any of the three wash fixtures.** (Not in
+  /// the suite at large — `+MossSoftGround.swift`'s still stands; see
+  /// ``DesignTokensTests/inkWashSiteRejectsLargeTextLabels``' file header.) The
+  /// old advice was
   /// "re-derive this fixture's own extreme, never cite a sibling's" — this
   /// paragraph *was* a citation of `+MossOnWash`'s `~11pt` until #1459
   /// falsified it there. Recording the size per row retires the advice along
@@ -132,8 +135,7 @@ extension DesignTokensTests {
       // Prose until #1468, over a row type that stored no font.
       #expect(
         site.isNormalText,
-        "\(site.name) is large text (\(site.pointSize)pt \(site.weight)) and does not belong in a normal-text fixture"
-      )
+        "\(largeTextRejection(site.name, pointSize: site.pointSize, weight: site.weight))")
 
       let lightGround = composite(
         PasturaPalette.inkSecondary, over: PasturaPalette.screenBackground, alpha: site.alpha)

--- a/Pastura/PasturaTests/Views/DesignTokensTests+InkOnWash.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+InkOnWash.swift
@@ -41,9 +41,8 @@ extension DesignTokensTests {
       InkWashSite(
         "PhaseEditorSheet.fieldPill", alpha: 0.16,
         pointSize: WashLabelSemanticSize.caption2, weight: .semibold),
-      // `.caption2.bold()`, via `GalleryCatalogRow.badgeView` — the app's only
-      // `ScenarioBadge` renderer since #1296, which is what gives this row a
-      // single well-defined font.
+      // `.caption2.bold()`, via `GalleryCatalogRow.badgeView` — the only
+      // `ScenarioBadge` renderer (#1296), so the row has one well-defined font.
       InkWashSite(
         "ScenarioBadgeStyle.secondary", alpha: 0.15,
         pointSize: WashLabelSemanticSize.caption2, weight: .bold),
@@ -62,28 +61,17 @@ extension DesignTokensTests {
 
   /// WCAG 1.4.3 normal-text bar, and it is the right bar only because every
   /// label in the fixture is under the "large text" threshold at the default
-  /// content size.
-  ///
-  /// Executed since #1468 — the rows carry their type size and
-  /// ``inkOnWashClearsAAOnEverySelfWashItIsUsedOn`` checks the criterion per
-  /// row; ``WashLabelWeight`` owns the threshold and the `.semibold` half.
-  /// `#expect` does not short-circuit, so a large-text row is flagged and then
-  /// measured at 4.5 anyway, and belongs where 3:1 is measured — see the "Large
-  /// text is out" bullet in `DesignTokensTests+MossInkAsWashLabel.swift`.
+  /// content size. Executed since #1468 —
+  /// ``inkOnWashClearsAAOnEverySelfWashItIsUsedOn`` checks that per row against
+  /// ``WashLabelWeight``, which owns the threshold and the `.semibold` half.
   ///
   /// Pinning 4.5 stays conservative at accessibility sizes: the semantic-font
   /// rows scale past their weight's threshold there and the 3:1 large-text bar
   /// *would* apply, which only **relaxes** the requirement. Do not "correct"
-  /// this in the other direction — and note the threshold to compare against is
-  /// the row's own, not a flat 14: every semantic-font row here is `.semibold`
-  /// or `.bold`, which take different halves.
+  /// this in the other direction.
   ///
-  /// **No type-size extreme of a fixture is restated in any of the three wash
-  /// files.** (Not in the suite at large — `+MossSoftGround.swift`'s still
-  /// stands; see ``DesignTokensTests/inkWashSiteRejectsLargeTextLabels``' file
-  /// header.) The old advice — "re-derive this fixture's own extreme, never
-  /// cite a sibling's" — is retired along with the hazard it managed: with the
-  /// size recorded per row there is no extreme left to quote or to keep true.
+  /// No type-size extreme is restated here: with the size recorded per row
+  /// there is none left to quote, which is the mirror shape #1466 falsified.
   private static let inkTextBar = 4.5
 
   /// "Clears the bar" and "has margin above it" are different claims, and this
@@ -132,8 +120,7 @@ extension DesignTokensTests {
     #expect(Self.inkWashSites.count == 4)
 
     for site in Self.inkWashSites {
-      // The admission criterion the bar below depends on — see `inkTextBar`.
-      // Prose until #1468, over a row type that stored no font.
+      // The admission criterion `inkTextBar` depends on.
       #expect(
         site.isNormalText,
         "\(largeTextRejection(site.name, pointSize: site.pointSize, weight: site.weight))")
@@ -304,15 +291,13 @@ struct InkWashSite {
   let name: String
   let alpha: Double
 
-  /// The label's point size at the default `.large` content size. The two
-  /// regimes this field spans, and why a wrong transcription is caught by
-  /// nothing: ``WashLabelSemanticSize``, which states them once for both row
-  /// types.
+  /// The label's point size at the default `.large` content size — the two
+  /// regimes it spans, and why a wrong transcription is caught by nothing:
+  /// ``WashLabelSemanticSize``.
   let pointSize: Double
 
-  /// Which WCAG large-text half the label's weight selects — see
-  /// ``WashLabelWeight`` for the `.semibold` decision, and ``WashLabelWeight/init(_:)``
-  /// for deriving this from a token rather than transcribing it.
+  /// Which WCAG large-text half the label's weight selects — the `.semibold`
+  /// decision, and the token-derived form: ``WashLabelWeight``.
   let weight: WashLabelWeight
 
   init(_ name: String, alpha: Double, pointSize: Double, weight: WashLabelWeight) {
@@ -323,9 +308,7 @@ struct InkWashSite {
   }
 
   /// Whether this row's label is still WCAG **normal** text, i.e. whether the
-  /// 4.5:1 bar the fixture pins is the bar it actually answers to.
-  ///
-  /// Both parameters are required at construction, so a row cannot join without
-  /// declaring a font.
+  /// 4.5:1 bar the fixture pins is the bar it actually answers to. Both fields
+  /// are required at construction, so a row cannot join without declaring a font.
   var isNormalText: Bool { weight.admitsAsNormalText(pointSize: pointSize) }
 }

--- a/Pastura/PasturaTests/Views/DesignTokensTests+MossInkAsWashLabel.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+MossInkAsWashLabel.swift
@@ -88,19 +88,30 @@ extension DesignTokensTests {
   /// §2.3 assigns `--moss-ink`. That is the shape a future row can take again.
   static var mossInkWashSites: [MossWashSite] {
     [
-      MossWashSite("GameHeader.statusPill", wash: .mossDark, light: 0.14, dark: 0.14),
-      MossWashSite("ResultsView.completed", wash: .moss, light: 0.16, dark: 0.16)
+      // `.textStyle(Typography.pillStatus)`
+      MossWashSite(
+        "GameHeader.statusPill", wash: .mossDark, light: 0.14, dark: 0.14,
+        pointSize: Double(Typography.pillStatus.size), weight: .semibold),
+      // `.font(.caption)` + `.fontWeight(.semibold)` — one `resultPill` helper
+      // renders both this and `+InkOnWash`'s `ResultsView.paused`, so the two
+      // genuinely share a font.
+      MossWashSite(
+        "ResultsView.completed", wash: .moss, light: 0.16, dark: 0.16,
+        pointSize: WashLabelSemanticSize.caption, weight: .semibold)
     ]
   }
 
   /// WCAG 1.4.3 normal-text bar. Every label in the fixture is under the "large
-  /// text" threshold (≥14pt bold / ≥18pt regular) at default Dynamic Type — the
-  /// status pill is `Typography.pillStatus` at 9pt and the results pill is
-  /// `.caption` + `.semibold` at 12pt — so 3:1 never applies. That is
-  /// the fixture's admission criterion, not an incidental property: a same-shaped
-  /// site above the threshold is excluded (the large-text bullet above). Pinning
-  /// 4.5 stays conservative at accessibility sizes for the reason `+InkOnWash`'s
-  /// `inkTextBar` gives — do not "correct" it in the other direction.
+  /// text" threshold at the default content size, which is the fixture's
+  /// **admission criterion** rather than an incidental property: a same-shaped
+  /// site above the threshold is excluded (the large-text bullet above).
+  ///
+  /// Executed since #1468 — the rows carry their type size and
+  /// ``mossInkClearsAAOnEveryMossWashItLabels`` rejects a large-text row before
+  /// applying this bar to it, so the per-row sizes are not restated here.
+  /// Pinning 4.5 stays conservative at accessibility sizes for the reason
+  /// `+InkOnWash`'s `inkTextBar` gives — do not "correct" it in the other
+  /// direction.
   private static let mossInkTextBar = 4.5
 
   /// Grounds are the **worst case per appearance** — the convention
@@ -121,6 +132,15 @@ extension DesignTokensTests {
     #expect(Self.mossInkWashSites.count == 2)
 
     for site in Self.mossInkWashSites {
+      // The admission criterion the bar below depends on — see
+      // `mossInkTextBar`. `MossWashSite`'s negative control lives in
+      // `DesignTokensTests+WashLabelTypeSize.swift`; this fixture shares the
+      // row type, so it shares that control.
+      #expect(
+        site.isNormalText,
+        "\(site.name) is large text (\(site.pointSize)pt \(site.weight)) and does not belong in a normal-text fixture"
+      )
+
       let lightGround = composite(
         site.lightToken, over: PasturaPalette.screenBackground, alpha: site.lightAlpha)
       let light = contrastRatio(PasturaPalette.mossInk, lightGround)

--- a/Pastura/PasturaTests/Views/DesignTokensTests+MossInkAsWashLabel.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+MossInkAsWashLabel.swift
@@ -138,8 +138,7 @@ extension DesignTokensTests {
       // row type, so it shares that control.
       #expect(
         site.isNormalText,
-        "\(site.name) is large text (\(site.pointSize)pt \(site.weight)) and does not belong in a normal-text fixture"
-      )
+        "\(largeTextRejection(site.name, pointSize: site.pointSize, weight: site.weight))")
 
       let lightGround = composite(
         site.lightToken, over: PasturaPalette.screenBackground, alpha: site.lightAlpha)

--- a/Pastura/PasturaTests/Views/DesignTokensTests+MossInkAsWashLabel.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+MossInkAsWashLabel.swift
@@ -107,14 +107,10 @@ extension DesignTokensTests {
   /// **admission criterion** rather than an incidental property: a same-shaped
   /// site above the threshold is excluded (the large-text bullet above).
   ///
-  /// Executed since #1468 — the rows carry their type size and
-  /// ``mossInkClearsAAOnEveryMossWashItLabels`` checks the criterion per row, so
-  /// the per-row sizes are not restated here. `#expect` does not short-circuit,
-  /// so a large-text row is flagged and then measured at 4.5 anyway; where it
-  /// belongs instead is the "Large text is out" bullet above.
-  /// Pinning 4.5 stays conservative at accessibility sizes for the reason
-  /// `+InkOnWash`'s `inkTextBar` gives — do not "correct" it in the other
-  /// direction.
+  /// Executed since #1468 — ``mossInkClearsAAOnEveryMossWashItLabels`` checks
+  /// that per row, so the per-row sizes are not restated here. Pinning 4.5 stays
+  /// conservative at accessibility sizes for the reason `+InkOnWash`'s
+  /// `inkTextBar` gives — do not "correct" it in the other direction.
   private static let mossInkTextBar = 4.5
 
   /// Grounds are the **worst case per appearance** — the convention
@@ -135,10 +131,8 @@ extension DesignTokensTests {
     #expect(Self.mossInkWashSites.count == 2)
 
     for site in Self.mossInkWashSites {
-      // The admission criterion the bar below depends on — see
-      // `mossInkTextBar`. `MossWashSite`'s negative control lives in
-      // `DesignTokensTests+WashLabelTypeSize.swift`; this fixture shares the
-      // row type, so it shares that control.
+      // The admission criterion `mossInkTextBar` depends on — its negative
+      // control is `MossWashSite`'s, in `DesignTokensTests+WashLabelTypeSize.swift`.
       #expect(
         site.isNormalText,
         "\(largeTextRejection(site.name, pointSize: site.pointSize, weight: site.weight))")

--- a/Pastura/PasturaTests/Views/DesignTokensTests+MossInkAsWashLabel.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+MossInkAsWashLabel.swift
@@ -91,7 +91,8 @@ extension DesignTokensTests {
       // `.textStyle(Typography.pillStatus)`
       MossWashSite(
         "GameHeader.statusPill", wash: .mossDark, light: 0.14, dark: 0.14,
-        pointSize: Double(Typography.pillStatus.size), weight: .semibold),
+        pointSize: Double(Typography.pillStatus.size),
+        weight: WashLabelWeight(Typography.pillStatus.weight)),
       // `.font(.caption)` + `.fontWeight(.semibold)` — one `resultPill` helper
       // renders both this and `+InkOnWash`'s `ResultsView.paused`, so the two
       // genuinely share a font.
@@ -107,8 +108,10 @@ extension DesignTokensTests {
   /// site above the threshold is excluded (the large-text bullet above).
   ///
   /// Executed since #1468 — the rows carry their type size and
-  /// ``mossInkClearsAAOnEveryMossWashItLabels`` rejects a large-text row before
-  /// applying this bar to it, so the per-row sizes are not restated here.
+  /// ``mossInkClearsAAOnEveryMossWashItLabels`` checks the criterion per row, so
+  /// the per-row sizes are not restated here. `#expect` does not short-circuit,
+  /// so a large-text row is flagged and then measured at 4.5 anyway; where it
+  /// belongs instead is the "Large text is out" bullet above.
   /// Pinning 4.5 stays conservative at accessibility sizes for the reason
   /// `+InkOnWash`'s `inkTextBar` gives — do not "correct" it in the other
   /// direction.

--- a/Pastura/PasturaTests/Views/DesignTokensTests+MossOnWash.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+MossOnWash.swift
@@ -20,10 +20,12 @@ import Testing
 // shares.** #1459 added `HomePausedCard.progress` on **routing** grounds — it
 // read `mossInk` and cleared at 8.807 light, but §2.3 gives the Ink step no
 // round-readout role — so it is the first member that was not already failing.
-// Nothing below can tell the two motives apart: ``MossWashSite`` stores only
-// the wash and its alphas, and every arm derives from those. So do not read a
-// row as evidence that its site was once sub-AA, and do not read the fixture as
-// observing anything else about a label either (see ``textBar`` on fonts).
+// Nothing below can tell the two motives apart: ``MossWashSite`` records the
+// wash, its alphas and the label's type size, and none of those is why a row
+// joined. So do not read a row as evidence that its site was once sub-AA. The
+// type size is the one property of a label the fixture does observe (#1468),
+// and it observes it as an **admission criterion** — the reason `textBar` is
+// 4.5 — not as a motive.
 //
 // Sibling-file extension of `DesignTokensTests` per `.claude/rules/testing.md`
 // § "Splitting a Suite Across Files" — a fresh `@Suite` would run in parallel
@@ -71,38 +73,66 @@ extension DesignTokensTests {
   /// what covers the gap; do not read this row as a bound the way the others are.
   static var mossWashSites: [MossWashSite] {
     [
-      MossWashSite("GalleryCatalogRow.badgeView", wash: .moss, light: 0.20, dark: 0.20),
-      MossWashSite("GalleryCatalogRow.categoryChip", wash: .moss, light: 0.18, dark: 0.24),
-      MossWashSite("PhaseTypeLabel", wash: .moss, light: 0.15, dark: 0.15),
-      MossWashSite("ModelRow.recommendedTag", wash: .moss, light: 0.12, dark: 0.12),
-      MossWashSite("HomePausedCard.eyebrow", wash: .moss, light: 0.16, dark: 0.16),
-      MossWashSite("HomePausedCard.progress", wash: .moss, light: 0.16, dark: 0.16),
-      MossWashSite("PhaseEditorSheet.fieldPill", wash: .mossDark, light: 0.16, dark: 0.16),
+      // `.caption2.bold()`
       MossWashSite(
-        "GalleryHighlightRunFigure.recordedPill", wash: .mossDark, light: 0.14, dark: 0.14),
-      MossWashSite("GameHeaderStatus.active", wash: .moss, light: 0.14, dark: 0.14)
+        "GalleryCatalogRow.badgeView", wash: .moss, light: 0.20, dark: 0.20,
+        pointSize: WashLabelSemanticSize.caption2, weight: .bold),
+      // `.caption2.weight(.semibold)`
+      MossWashSite(
+        "GalleryCatalogRow.categoryChip", wash: .moss, light: 0.18, dark: 0.24,
+        pointSize: WashLabelSemanticSize.caption2, weight: .semibold),
+      // `.textStyle(Typography.tagPhase)`
+      MossWashSite(
+        "PhaseTypeLabel", wash: .moss, light: 0.15, dark: 0.15,
+        pointSize: Double(Typography.tagPhase.size), weight: .semibold),
+      // The one row whose view **inlines** its size rather than reading a token
+      // — `.font(.system(size: 9.5, weight: .semibold, design: .monospaced))`.
+      // `recommendedTagInlinesTheSizeItsDocClaimsToReuse` executes the "reuses
+      // tagPhase" claim that view's own doc comment makes.
+      MossWashSite(
+        "ModelRow.recommendedTag", wash: .moss, light: 0.12, dark: 0.12,
+        pointSize: 9.5, weight: .semibold),
+      // `.font(.system(size: HomeHeroLayout.eyebrowFontSize, weight: .semibold, …))`
+      MossWashSite(
+        "HomePausedCard.eyebrow", wash: .moss, light: 0.16, dark: 0.16,
+        pointSize: Double(HomeHeroLayout.eyebrowFontSize), weight: .semibold),
+      // `.font(.system(size: HomeHeroLayout.progressFontSize, design: .monospaced))`
+      // — no `weight:`, so regular. The largest row in the fixture, and the one
+      // whose 12pt falsified `textBar`'s old superlative (#1466).
+      MossWashSite(
+        "HomePausedCard.progress", wash: .moss, light: 0.16, dark: 0.16,
+        pointSize: Double(HomeHeroLayout.progressFontSize), weight: .regular),
+      // `.caption2.weight(.semibold)` — one helper serves this and the ink
+      // fixture's row of the same name, so the two genuinely share a font.
+      MossWashSite(
+        "PhaseEditorSheet.fieldPill", wash: .mossDark, light: 0.16, dark: 0.16,
+        pointSize: WashLabelSemanticSize.caption2, weight: .semibold),
+      // `.textStyle(Typography.pillStatus)`
+      MossWashSite(
+        "GalleryHighlightRunFigure.recordedPill", wash: .mossDark, light: 0.14, dark: 0.14,
+        pointSize: Double(Typography.pillStatus.size), weight: .semibold),
+      // `.textStyle(Typography.pillStatus)`, via `GameHeader.statusPill`
+      MossWashSite(
+        "GameHeaderStatus.active", wash: .moss, light: 0.14, dark: 0.14,
+        pointSize: Double(Typography.pillStatus.size), weight: .semibold)
     ]
   }
 
-  /// WCAG 1.4.3 normal-text bar. Every one of these labels is under the "large
-  /// text" threshold (≥14pt bold / ≥18pt regular) at default Dynamic Type, and
-  /// the two halves bind different rows — which is why the extreme has to be
-  /// read per half, not per point size. The largest overall is
-  /// `HomePausedCard.progress` at `HomeHeroLayout.progressFontSize`, 12pt
-  /// **regular**, so it answers to ≥18pt; the emphasised rows top out at
-  /// `.caption2` 11pt bold against the lower ≥14pt half. Both clear, so 3:1
-  /// never applies to any of them — but a new row has to re-check the half its
-  /// weight selects, not just compare point sizes.
+  /// WCAG 1.4.3 normal-text bar, and it is the right bar only because every
+  /// label in the fixture is under the "large text" threshold at the default
+  /// content size.
   ///
-  /// **`.semibold` takes the ≥18pt half**, decided here so it is not re-guessed
-  /// per row: WCAG's "bold" is conventionally ≥700 and `.semibold` is 600, so
-  /// the ≥14pt half would be the more permissive reading of a weight WCAG does
-  /// not call bold. Nothing turns on it while every `.semibold` row is ≤11pt;
-  /// it is written down for the case that would (a 14–17pt one).
+  /// That is now a **guard rather than a convention** (#1468): each row carries
+  /// its point size and weight, and
+  /// ``mossOnWashClearsAAOnEveryWashItIsUsedOn`` rejects a row that is large
+  /// text before it applies this bar to it. ``WashLabelWeight`` owns the
+  /// threshold and the `.semibold` half; a large-text row is *excluded*, not
+  /// relaxed to 3:1, because no site in this family is meant to be one.
   ///
-  /// **Convention, not guard** — no arm can observe a font (see the header), so
-  /// a large-text row would be held to 4.5 regardless, which is the safe
-  /// direction but unenforced. Making it executable: #1468.
+  /// **No superlative is restated here.** The rows are the authority on which
+  /// is largest, and a prose extreme is precisely the mirror that went stale in
+  /// #1466 — it survived until a 12pt row falsified it, and a second claim
+  /// citing it from `+InkOnWash.swift` died at the same moment.
   private static let textBar = 4.5
 
   /// The grounds are deliberately the **worst case per appearance**, not the
@@ -125,6 +155,15 @@ extension DesignTokensTests {
     #expect(Self.mossWashSites.count == 9)
 
     for site in Self.mossWashSites {
+      // The admission criterion, applied before the bar it licenses: `textBar`
+      // is 4.5 rather than 3.0 only because this label is WCAG normal text. A
+      // large-text row would answer to 3:1, and until #1468 nothing observed
+      // the difference — the row type stored no font.
+      #expect(
+        site.isNormalText,
+        "\(site.name) is large text (\(site.pointSize)pt \(site.weight)) and does not belong in a normal-text fixture"
+      )
+
       let lightGround = composite(
         site.lightToken, over: PasturaPalette.screenBackground, alpha: site.lightAlpha)
       let light = contrastRatio(PasturaPalette.mossOnWash, lightGround)
@@ -135,6 +174,22 @@ extension DesignTokensTests {
       let dark = contrastRatio(PasturaPalette.nightMossOnWash, darkGround)
       #expect(dark >= Self.textBar, "dark \(site.name): \(dark)")
     }
+  }
+
+  /// `ModelRow.recommendedTag` is the only row whose point size is a literal:
+  /// its view inlines `.system(size: 9.5, …)` instead of reading a token, so the
+  /// fixture has nothing to reference live. What it *does* have is that view's
+  /// own doc comment, which claims the tag "reuses the existing `tagPhase`
+  /// typography token" — a claim two files now depend on and neither executes.
+  ///
+  /// This is the executable form of that claim. A red here means the token and
+  /// the inlined literal have diverged: fix the **view** (or its doc comment)
+  /// first and the row second — updating the literal alone would preserve the
+  /// fixture's arithmetic while leaving the view's doc lying.
+  @Test func recommendedTagInlinesTheSizeItsDocClaimsToReuse() {
+    let tag = Self.mossWashSites.first { $0.name == "ModelRow.recommendedTag" }
+    #expect(tag?.pointSize == Double(Typography.tagPhase.size))
+    #expect(tag?.weight == .semibold)
   }
 
   /// The negative control, and the whole reason the token exists.
@@ -231,13 +286,13 @@ extension DesignTokensTests {
 
 // MARK: - Helpers
 
-/// One shipped consumer of the moss wash: which token fills its capsule, and at
-/// what alpha in each appearance.
+/// One shipped consumer of the moss wash: which token fills its capsule, at
+/// what alpha in each appearance, and the type size of the label on it.
 ///
 /// A struct rather than a tuple because swiftlint's `large_tuple` caps tuples at
-/// two members and this row needs four — the fifth field (the dark token) is
-/// derived from `wash` rather than stored, since the light and dark halves of a
-/// wash are always a registered §2.9 pair.
+/// two members and this row needs six — the dark token stays **derived** from
+/// `wash` rather than stored, since the light and dark halves of a wash are
+/// always a registered §2.9 pair.
 ///
 /// File scope per `.claude/rules/testing.md` § "Splitting a Suite Across Files":
 /// helpers in a sibling file live outside the suite struct.
@@ -257,12 +312,48 @@ struct MossWashSite {
   let lightAlpha: Double
   let darkAlpha: Double
 
-  init(_ name: String, wash: Wash, light: Double, dark: Double) {
+  /// The label's point size at the default `.large` content size.
+  ///
+  /// **Two regimes share this field.** A row whose view reads a `Typography.*`
+  /// token references that token's `size` live, and those are fixed-size by
+  /// design (``PasturaTextStyle/font``) — the value is the size at every content
+  /// size. A row on a semantic SwiftUI font (`.caption` / `.caption2`) names a
+  /// ``WashLabelSemanticSize`` constant instead, and that one is the size *at
+  /// the default*: it scales, and at accessibility sizes such a label crosses
+  /// into large text, which only **relaxes** the bar the fixture applies. So
+  /// this field decides admission at the default and nothing else.
+  ///
+  /// **Hand-recorded against the view, and a wrong transcription is caught by
+  /// nothing.** Live references and
+  /// ``DesignTokensTests/semanticLabelSizesMatchUIKitAtTheDefaultContentSize``
+  /// remove the guesswork from every figure that has a source, but which figure
+  /// a row *takes* is still a reader's judgement — same standing as the grounds
+  /// the arms below pin. A reviewer has to open the view when a row is added.
+  let pointSize: Double
+
+  /// Which WCAG large-text half the label's weight selects — see
+  /// ``WashLabelWeight`` for the `.semibold` decision.
+  let weight: WashLabelWeight
+
+  init(
+    _ name: String, wash: Wash, light: Double, dark: Double, pointSize: Double,
+    weight: WashLabelWeight
+  ) {
     self.name = name
     self.wash = wash
     self.lightAlpha = light
     self.darkAlpha = dark
+    self.pointSize = pointSize
+    self.weight = weight
   }
+
+  /// Whether this row's label is still WCAG **normal** text, i.e. whether the
+  /// 4.5:1 bar the fixtures pin is the bar it actually answers to.
+  ///
+  /// Both parameters are required at construction, so a row cannot join a
+  /// fixture without declaring a font — which is the half of #1466's failure
+  /// this closes.
+  var isNormalText: Bool { weight.admitsAsNormalText(pointSize: pointSize) }
 
   /// `@MainActor` for the reason in `.claude/rules/swift-isolation.md` Pattern 5
   /// § "Cross-module corollary": the `let`-read exemption for a global-actor

--- a/Pastura/PasturaTests/Views/DesignTokensTests+MossOnWash.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+MossOnWash.swift
@@ -22,10 +22,9 @@ import Testing
 // round-readout role — so it is the first member that was not already failing.
 // Nothing below can tell the two motives apart: ``MossWashSite`` records the
 // wash, its alphas and the label's type size, and none of those is why a row
-// joined. So do not read a row as evidence that its site was once sub-AA. The
-// type size is the one property of a label the fixture does observe (#1468),
-// and it observes it as an **admission criterion** — the reason `textBar` is
-// 4.5 — not as a motive.
+// joined. So do not read a row as evidence that its site was once sub-AA — the
+// type size is observed as an **admission criterion** (the reason `textBar` is
+// 4.5), not as a motive.
 //
 // Sibling-file extension of `DesignTokensTests` per `.claude/rules/testing.md`
 // § "Splitting a Suite Across Files" — a fresh `@Suite` would run in parallel
@@ -89,8 +88,7 @@ extension DesignTokensTests {
       // The one row whose view **inlines** its size rather than reading a token
       // — `.font(.system(size: 9.5, weight: .semibold, design: .monospaced))`.
       // `recommendedTagRowMatchesTheTokenItsViewDocClaimsToReuse` ties this
-      // transcription to `tagPhase`, which is what that view's doc claims it
-      // reuses.
+      // transcription to `tagPhase`.
       MossWashSite(
         "ModelRow.recommendedTag", wash: .moss, light: 0.12, dark: 0.12,
         pointSize: 9.5, weight: .semibold),
@@ -126,19 +124,11 @@ extension DesignTokensTests {
   /// label in the fixture is under the "large text" threshold at the default
   /// content size.
   ///
-  /// That is now a **guard rather than a convention** (#1468): each row carries
+  /// That is a **guard rather than a convention** since #1468: each row carries
   /// its point size and weight, and ``mossOnWashClearsAAOnEveryWashItIsUsedOn``
   /// checks the criterion per row. ``WashLabelWeight`` owns the threshold and
-  /// the `.semibold` half.
-  ///
-  /// `#expect` does not short-circuit, so a large-text row is **flagged and then
-  /// measured at 4.5 anyway** — two reds, which is the safe order: the row is
-  /// named as not belonging here, and the number it would have been judged on is
-  /// still reported. A row that genuinely is large text belongs where 3:1 is
-  /// measured, per the "Large text is out" bullet in
-  /// `DesignTokensTests+MossInkAsWashLabel.swift` (which names the shipped
-  /// precedent, `ModelPickerView`'s 26pt-bold title) — not here with its
-  /// recorded size edited down.
+  /// the `.semibold` half; ``largeTextRejection`` owns what happens to a row
+  /// that fails it, and where such a row belongs instead.
   ///
   /// **No superlative is restated here.** The rows are the authority on which
   /// is largest, and a prose extreme is precisely the mirror that went stale in
@@ -167,9 +157,7 @@ extension DesignTokensTests {
 
     for site in Self.mossWashSites {
       // The admission criterion, applied before the bar it licenses: `textBar`
-      // is 4.5 rather than 3.0 only because this label is WCAG normal text. A
-      // large-text row would answer to 3:1, and until #1468 nothing observed
-      // the difference — the row type stored no font.
+      // is 4.5 rather than 3.0 only because this label is WCAG normal text.
       #expect(
         site.isNormalText,
         "\(largeTextRejection(site.name, pointSize: site.pointSize, weight: site.weight))")
@@ -186,23 +174,21 @@ extension DesignTokensTests {
     }
   }
 
-  /// `ModelRow.recommendedTag` is the only row whose point size is a literal:
-  /// its view inlines `.system(size: 9.5, …)` instead of reading a token, so the
-  /// fixture has nothing to reference live. What that view's own doc comment
-  /// claims is that the tag "reuses the existing `tagPhase` typography token",
-  /// which is why the fixture's transcription is 9.5 rather than some other
-  /// number.
+  /// `ModelRow.recommendedTag` is the only row whose point size is a literal —
+  /// its view inlines `.system(size: 9.5, …)` — so the fixture has nothing to
+  /// reference live. That view's own doc claims the tag "reuses the existing
+  /// `tagPhase` typography token", which is why the transcription is 9.5.
   ///
   /// **What this observes is the fixture's transcription against the token —
-  /// not the view.** A red means `tagPhase` moved and the row did not, which is
-  /// the cue to open `ModelRow` and decide whether the tag was meant to follow;
-  /// fix the view (or its doc comment) before the row, since updating the
-  /// literal alone would restore the arithmetic while leaving that doc lying.
+  /// not the view.** A red means `tagPhase` moved and the row did not: open
+  /// `ModelRow` and fix the view (or its doc comment) before the row, since
+  /// updating the literal alone restores the arithmetic while leaving that doc
+  /// lying.
   ///
   /// **Residual**: the view's own literal is read by nothing here. Retype it as
   /// 11 without touching the fixture and this stays green — the
-  /// hand-transcription hazard ``MossWashSite/pointSize`` admits is caught by
-  /// nothing, and this arm narrows it rather than closing it.
+  /// hand-transcription hazard ``MossWashSite/pointSize`` admits is narrowed by
+  /// this arm, not closed.
   @Test func recommendedTagRowMatchesTheTokenItsViewDocClaimsToReuse() {
     let tag = Self.mossWashSites.first { $0.name == "ModelRow.recommendedTag" }
     #expect(tag?.pointSize == Double(Typography.tagPhase.size))
@@ -331,15 +317,13 @@ struct MossWashSite {
   let lightAlpha: Double
   let darkAlpha: Double
 
-  /// The label's point size at the default `.large` content size. The two
-  /// regimes this field spans, and why a wrong transcription is caught by
-  /// nothing: ``WashLabelSemanticSize``, which states them once for both row
-  /// types.
+  /// The label's point size at the default `.large` content size — the two
+  /// regimes it spans, and why a wrong transcription is caught by nothing:
+  /// ``WashLabelSemanticSize``.
   let pointSize: Double
 
-  /// Which WCAG large-text half the label's weight selects — see
-  /// ``WashLabelWeight`` for the `.semibold` decision, and ``WashLabelWeight/init(_:)``
-  /// for deriving this from a token rather than transcribing it.
+  /// Which WCAG large-text half the label's weight selects — the `.semibold`
+  /// decision, and the token-derived form: ``WashLabelWeight``.
   let weight: WashLabelWeight
 
   init(
@@ -355,11 +339,8 @@ struct MossWashSite {
   }
 
   /// Whether this row's label is still WCAG **normal** text, i.e. whether the
-  /// 4.5:1 bar the fixtures pin is the bar it actually answers to.
-  ///
-  /// Both parameters are required at construction, so a row cannot join a
-  /// fixture without declaring a font — which is the half of #1466's failure
-  /// this closes.
+  /// 4.5:1 bar the fixtures pin is the bar it actually answers to. Both fields
+  /// are required at construction, so a row cannot join without declaring a font.
   var isNormalText: Bool { weight.admitsAsNormalText(pointSize: pointSize) }
 
   /// `@MainActor` for the reason in `.claude/rules/swift-isolation.md` Pattern 5

--- a/Pastura/PasturaTests/Views/DesignTokensTests+MossOnWash.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+MossOnWash.swift
@@ -98,8 +98,8 @@ extension DesignTokensTests {
         "HomePausedCard.eyebrow", wash: .moss, light: 0.16, dark: 0.16,
         pointSize: Double(HomeHeroLayout.eyebrowFontSize), weight: .semibold),
       // `.font(.system(size: HomeHeroLayout.progressFontSize, design: .monospaced))`
-      // — no `weight:`, so regular. The largest row in the fixture, and the one
-      // whose 12pt falsified `textBar`'s old superlative (#1466).
+      // — no `weight:`, so regular. Its 12pt is what falsified `textBar`'s old
+      // superlative (#1466).
       MossWashSite(
         "HomePausedCard.progress", wash: .moss, light: 0.16, dark: 0.16,
         pointSize: Double(HomeHeroLayout.progressFontSize), weight: .regular),

--- a/Pastura/PasturaTests/Views/DesignTokensTests+MossOnWash.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+MossOnWash.swift
@@ -84,7 +84,8 @@ extension DesignTokensTests {
       // `.textStyle(Typography.tagPhase)`
       MossWashSite(
         "PhaseTypeLabel", wash: .moss, light: 0.15, dark: 0.15,
-        pointSize: Double(Typography.tagPhase.size), weight: .semibold),
+        pointSize: Double(Typography.tagPhase.size),
+        weight: WashLabelWeight(Typography.tagPhase.weight)),
       // The one row whose view **inlines** its size rather than reading a token
       // — `.font(.system(size: 9.5, weight: .semibold, design: .monospaced))`.
       // `recommendedTagRowMatchesTheTokenItsViewDocClaimsToReuse` ties this
@@ -111,11 +112,13 @@ extension DesignTokensTests {
       // `.textStyle(Typography.pillStatus)`
       MossWashSite(
         "GalleryHighlightRunFigure.recordedPill", wash: .mossDark, light: 0.14, dark: 0.14,
-        pointSize: Double(Typography.pillStatus.size), weight: .semibold),
+        pointSize: Double(Typography.pillStatus.size),
+        weight: WashLabelWeight(Typography.pillStatus.weight)),
       // `.textStyle(Typography.pillStatus)`, via `GameHeader.statusPill`
       MossWashSite(
         "GameHeaderStatus.active", wash: .moss, light: 0.14, dark: 0.14,
-        pointSize: Double(Typography.pillStatus.size), weight: .semibold)
+        pointSize: Double(Typography.pillStatus.size),
+        weight: WashLabelWeight(Typography.pillStatus.weight))
     ]
   }
 
@@ -124,11 +127,18 @@ extension DesignTokensTests {
   /// content size.
   ///
   /// That is now a **guard rather than a convention** (#1468): each row carries
-  /// its point size and weight, and
-  /// ``mossOnWashClearsAAOnEveryWashItIsUsedOn`` rejects a row that is large
-  /// text before it applies this bar to it. ``WashLabelWeight`` owns the
-  /// threshold and the `.semibold` half; a large-text row is *excluded*, not
-  /// relaxed to 3:1, because no site in this family is meant to be one.
+  /// its point size and weight, and ``mossOnWashClearsAAOnEveryWashItIsUsedOn``
+  /// checks the criterion per row. ``WashLabelWeight`` owns the threshold and
+  /// the `.semibold` half.
+  ///
+  /// `#expect` does not short-circuit, so a large-text row is **flagged and then
+  /// measured at 4.5 anyway** — two reds, which is the safe order: the row is
+  /// named as not belonging here, and the number it would have been judged on is
+  /// still reported. A row that genuinely is large text belongs where 3:1 is
+  /// measured, per the "Large text is out" bullet in
+  /// `DesignTokensTests+MossInkAsWashLabel.swift` (which names the shipped
+  /// precedent, `ModelPickerView`'s 26pt-bold title) — not here with its
+  /// recorded size edited down.
   ///
   /// **No superlative is restated here.** The rows are the authority on which
   /// is largest, and a prose extreme is precisely the mirror that went stale in
@@ -196,7 +206,9 @@ extension DesignTokensTests {
   @Test func recommendedTagRowMatchesTheTokenItsViewDocClaimsToReuse() {
     let tag = Self.mossWashSites.first { $0.name == "ModelRow.recommendedTag" }
     #expect(tag?.pointSize == Double(Typography.tagPhase.size))
-    #expect(tag?.weight == .semibold)
+    // Token-derived on both sides, like every other token-backed row — a
+    // literal-vs-literal weight check would assert nothing about `tagPhase`.
+    #expect(tag?.weight == WashLabelWeight(Typography.tagPhase.weight))
   }
 
   /// The negative control, and the whole reason the token exists.
@@ -319,33 +331,15 @@ struct MossWashSite {
   let lightAlpha: Double
   let darkAlpha: Double
 
-  /// The label's point size at the default `.large` content size.
-  ///
-  /// **Two regimes share this field**, and the split is fixed-size vs scaling
-  /// rather than which expression the view wrote.
-  ///
-  /// *Fixed size* covers every `.system(size:)` label — whether it comes from a
-  /// `Typography.*` token (referenced live via the token's `size`, and
-  /// fixed-size by design per ``PasturaTextStyle/font``), from a layout constant
-  /// read live (`HomeHeroLayout.*FontSize`), or from a literal the view inlines.
-  /// For those the value is the size at every content size.
-  ///
-  /// *Scaling* covers the semantic SwiftUI fonts (`.caption` / `.caption2`),
-  /// which name a ``WashLabelSemanticSize`` constant: that is the size **at the
-  /// default**, and at accessibility sizes such a label crosses into large text
-  /// — which only **relaxes** the bar the fixture applies. So this field decides
-  /// admission at the default and nothing else.
-  ///
-  /// **Hand-recorded against the view, and a wrong transcription is caught by
-  /// nothing.** Live references and
-  /// ``DesignTokensTests/semanticLabelSizesMatchUIKitAtTheDefaultContentSize``
-  /// remove the guesswork from every figure that has a source, but which figure
-  /// a row *takes* is still a reader's judgement — same standing as the grounds
-  /// the arms below pin. A reviewer has to open the view when a row is added.
+  /// The label's point size at the default `.large` content size. The two
+  /// regimes this field spans, and why a wrong transcription is caught by
+  /// nothing: ``WashLabelSemanticSize``, which states them once for both row
+  /// types.
   let pointSize: Double
 
   /// Which WCAG large-text half the label's weight selects — see
-  /// ``WashLabelWeight`` for the `.semibold` decision.
+  /// ``WashLabelWeight`` for the `.semibold` decision, and ``WashLabelWeight/init(_:)``
+  /// for deriving this from a token rather than transcribing it.
   let weight: WashLabelWeight
 
   init(

--- a/Pastura/PasturaTests/Views/DesignTokensTests+MossOnWash.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+MossOnWash.swift
@@ -87,8 +87,9 @@ extension DesignTokensTests {
         pointSize: Double(Typography.tagPhase.size), weight: .semibold),
       // The one row whose view **inlines** its size rather than reading a token
       // — `.font(.system(size: 9.5, weight: .semibold, design: .monospaced))`.
-      // `recommendedTagInlinesTheSizeItsDocClaimsToReuse` executes the "reuses
-      // tagPhase" claim that view's own doc comment makes.
+      // `recommendedTagRowMatchesTheTokenItsViewDocClaimsToReuse` ties this
+      // transcription to `tagPhase`, which is what that view's doc claims it
+      // reuses.
       MossWashSite(
         "ModelRow.recommendedTag", wash: .moss, light: 0.12, dark: 0.12,
         pointSize: 9.5, weight: .semibold),
@@ -161,8 +162,7 @@ extension DesignTokensTests {
       // the difference — the row type stored no font.
       #expect(
         site.isNormalText,
-        "\(site.name) is large text (\(site.pointSize)pt \(site.weight)) and does not belong in a normal-text fixture"
-      )
+        "\(largeTextRejection(site.name, pointSize: site.pointSize, weight: site.weight))")
 
       let lightGround = composite(
         site.lightToken, over: PasturaPalette.screenBackground, alpha: site.lightAlpha)
@@ -178,15 +178,22 @@ extension DesignTokensTests {
 
   /// `ModelRow.recommendedTag` is the only row whose point size is a literal:
   /// its view inlines `.system(size: 9.5, …)` instead of reading a token, so the
-  /// fixture has nothing to reference live. What it *does* have is that view's
-  /// own doc comment, which claims the tag "reuses the existing `tagPhase`
-  /// typography token" — a claim two files now depend on and neither executes.
+  /// fixture has nothing to reference live. What that view's own doc comment
+  /// claims is that the tag "reuses the existing `tagPhase` typography token",
+  /// which is why the fixture's transcription is 9.5 rather than some other
+  /// number.
   ///
-  /// This is the executable form of that claim. A red here means the token and
-  /// the inlined literal have diverged: fix the **view** (or its doc comment)
-  /// first and the row second — updating the literal alone would preserve the
-  /// fixture's arithmetic while leaving the view's doc lying.
-  @Test func recommendedTagInlinesTheSizeItsDocClaimsToReuse() {
+  /// **What this observes is the fixture's transcription against the token —
+  /// not the view.** A red means `tagPhase` moved and the row did not, which is
+  /// the cue to open `ModelRow` and decide whether the tag was meant to follow;
+  /// fix the view (or its doc comment) before the row, since updating the
+  /// literal alone would restore the arithmetic while leaving that doc lying.
+  ///
+  /// **Residual**: the view's own literal is read by nothing here. Retype it as
+  /// 11 without touching the fixture and this stays green — the
+  /// hand-transcription hazard ``MossWashSite/pointSize`` admits is caught by
+  /// nothing, and this arm narrows it rather than closing it.
+  @Test func recommendedTagRowMatchesTheTokenItsViewDocClaimsToReuse() {
     let tag = Self.mossWashSites.first { $0.name == "ModelRow.recommendedTag" }
     #expect(tag?.pointSize == Double(Typography.tagPhase.size))
     #expect(tag?.weight == .semibold)
@@ -314,14 +321,20 @@ struct MossWashSite {
 
   /// The label's point size at the default `.large` content size.
   ///
-  /// **Two regimes share this field.** A row whose view reads a `Typography.*`
-  /// token references that token's `size` live, and those are fixed-size by
-  /// design (``PasturaTextStyle/font``) — the value is the size at every content
-  /// size. A row on a semantic SwiftUI font (`.caption` / `.caption2`) names a
-  /// ``WashLabelSemanticSize`` constant instead, and that one is the size *at
-  /// the default*: it scales, and at accessibility sizes such a label crosses
-  /// into large text, which only **relaxes** the bar the fixture applies. So
-  /// this field decides admission at the default and nothing else.
+  /// **Two regimes share this field**, and the split is fixed-size vs scaling
+  /// rather than which expression the view wrote.
+  ///
+  /// *Fixed size* covers every `.system(size:)` label — whether it comes from a
+  /// `Typography.*` token (referenced live via the token's `size`, and
+  /// fixed-size by design per ``PasturaTextStyle/font``), from a layout constant
+  /// read live (`HomeHeroLayout.*FontSize`), or from a literal the view inlines.
+  /// For those the value is the size at every content size.
+  ///
+  /// *Scaling* covers the semantic SwiftUI fonts (`.caption` / `.caption2`),
+  /// which name a ``WashLabelSemanticSize`` constant: that is the size **at the
+  /// default**, and at accessibility sizes such a label crosses into large text
+  /// — which only **relaxes** the bar the fixture applies. So this field decides
+  /// admission at the default and nothing else.
   ///
   /// **Hand-recorded against the view, and a wrong transcription is caught by
   /// nothing.** Live references and

--- a/Pastura/PasturaTests/Views/DesignTokensTests+MossSoftGround.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+MossSoftGround.swift
@@ -49,11 +49,10 @@ extension DesignTokensTests {
   ///
   /// ⚠️ **Prose, observed by nothing** — `mossSoftTextSites` is a `[String]`,
   /// so neither that claim nor the superlative inside it can redden when a
-  /// fifth label arrives. This is the shape #1466 falsified in
-  /// `DesignTokensTests+MossOnWash.swift`; #1468 made it executable for the
-  /// three *wash* fixtures via ``WashLabelWeight``, and #1495 tracks bringing
-  /// this one along. Do not re-derive the superlative by hand when adding a row
-  /// — promote the list instead.
+  /// fifth label arrives. This is the shape #1466 falsified; ``WashLabelWeight``
+  /// made the criterion executable for the *wash* fixtures and #1495 tracks
+  /// bringing this one along. When adding a row, promote the list to a row type
+  /// rather than re-deriving the superlative by hand.
   private static let textBar = 4.5
 
   /// The ground is the token itself, not a composite: unlike the wash sites,

--- a/Pastura/PasturaTests/Views/DesignTokensTests+MossSoftGround.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+MossSoftGround.swift
@@ -46,6 +46,14 @@ extension DesignTokensTests {
   /// WCAG 1.4.3 normal-text bar. All four labels are under the "large text"
   /// threshold (≥14pt bold / ≥18pt regular) — the largest is `caption`-class at
   /// ~12pt and the chip is 10pt bold — so 3:1 never applies to any of them.
+  ///
+  /// ⚠️ **Prose, observed by nothing** — `mossSoftTextSites` is a `[String]`,
+  /// so neither that claim nor the superlative inside it can redden when a
+  /// fifth label arrives. This is the shape #1466 falsified in
+  /// `DesignTokensTests+MossOnWash.swift`; #1468 made it executable for the
+  /// three *wash* fixtures via ``WashLabelWeight``, and #1495 tracks bringing
+  /// this one along. Do not re-derive the superlative by hand when adding a row
+  /// — promote the list instead.
   private static let textBar = 4.5
 
   /// The ground is the token itself, not a composite: unlike the wash sites,

--- a/Pastura/PasturaTests/Views/DesignTokensTests+MutedAsContent.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+MutedAsContent.swift
@@ -20,6 +20,14 @@ extension DesignTokensTests {
 
   /// WCAG 1.4.3 normal-text bar. Both #1427 labels are `caption`-class (~12pt),
   /// under the "large text" threshold, so 3:1 never applies to either.
+  ///
+  /// ⚠️ **Prose, observed by nothing.** #1468 made this criterion executable
+  /// for the three *wash* fixtures via ``WashLabelWeight``; #1495 tracks this
+  /// one. The two arms that use this bar as a **floor** speak for named labels
+  /// (the miss arm and the streak sub-label) and could carry the fields, so the
+  /// obstacle is not the fixture's ground-oriented shape — it is that the
+  /// streak label is `.caption.weight(.medium)`, and `.medium` has no WCAG half
+  /// assigned yet.
   private static let contentTextBar = 4.5
 
   /// Every opaque ground the app ships that `muted` is or could be drawn on,

--- a/Pastura/PasturaTests/Views/DesignTokensTests+MutedAsContent.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+MutedAsContent.swift
@@ -21,13 +21,12 @@ extension DesignTokensTests {
   /// WCAG 1.4.3 normal-text bar. Both #1427 labels are `caption`-class (~12pt),
   /// under the "large text" threshold, so 3:1 never applies to either.
   ///
-  /// ⚠️ **Prose, observed by nothing.** #1468 made this criterion executable
-  /// for the three *wash* fixtures via ``WashLabelWeight``; #1495 tracks this
-  /// one. The two arms that use this bar as a **floor** speak for named labels
-  /// (the miss arm and the streak sub-label) and could carry the fields, so the
-  /// obstacle is not the fixture's ground-oriented shape — it is that the
-  /// streak label is `.caption.weight(.medium)`, and `.medium` has no WCAG half
-  /// assigned yet.
+  /// ⚠️ **Prose, observed by nothing.** ``WashLabelWeight`` made this criterion
+  /// executable for the *wash* fixtures; #1495 tracks this one. The obstacle is
+  /// not the fixture's ground-oriented shape — the two arms using this bar as a
+  /// **floor** speak for named labels and could carry the fields — it is that
+  /// the streak sub-label is `.caption.weight(.medium)`, a weight with no WCAG
+  /// half assigned yet.
   private static let contentTextBar = 4.5
 
   /// Every opaque ground the app ships that `muted` is or could be drawn on,

--- a/Pastura/PasturaTests/Views/DesignTokensTests+WashLabelTypeSize.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+WashLabelTypeSize.swift
@@ -20,18 +20,16 @@ import UIKit
 // swiftlint's 400-line `file_length` error under `--strict`.
 //
 // **Two sibling fixtures in this suite still carry the unexecuted form, and the
-// class is not closed** (#1495). `DesignTokensTests+MossSoftGround.swift`'s
-// `textBar` pins 4.5 over a `[String]` site list and keeps a superlative on top
-// of it — the exact state #1466 falsified — and
-// `DesignTokensTests+MutedAsContent.swift`'s `contentTextBar` carries the
-// shorter form. They are excluded here rather than overlooked, and **one
-// obstacle is common to both**: `PredictionOutcomeBadge`'s streak sub-label is
-// `.caption.weight(.medium)`, and both fixtures speak for it — so either would
-// force a fourth ``WashLabelWeight`` case, i.e. a WCAG judgement call this
-// branch had no occasion to make. On top of that the first needs its `[String]`
-// list promoted to a row type, and the second's remaining claim is entangled
-// with the occupancy question it explicitly defers to #1448. Do not read the
-// criterion below as covering either.
+// class is not closed** (#1495): `DesignTokensTests+MossSoftGround.swift`'s
+// `textBar` pins 4.5 over a `[String]` site list with a superlative on top — the
+// exact state #1466 falsified — and `DesignTokensTests+MutedAsContent.swift`'s
+// `contentTextBar` carries the shorter form. They are excluded deliberately, and
+// **one obstacle is common to both**: `PredictionOutcomeBadge`'s streak
+// sub-label is `.caption.weight(.medium)`, and both speak for it, so either
+// would force a fourth ``WashLabelWeight`` case — a WCAG judgement call this
+// branch had no occasion to make. `+MutedAsContent` has a second obstacle: its
+// remaining claim is entangled with the occupancy question it defers to #1448.
+// Do not read the criterion below as covering either.
 //
 // Sibling-file extension of `DesignTokensTests` per `.claude/rules/testing.md`
 // § "Splitting a Suite Across Files" — a fresh `@Suite` would run in parallel
@@ -50,14 +48,11 @@ extension DesignTokensTests {
   /// typed as 20 would pass every arm in the repo.
   ///
   /// **This table is the sole arbiter for both controls, so editing a row to
-  /// green a red disarms them together.** That is the failure to guard against
-  /// — not sabotage, just the ordinary red-test reflex: someone re-deciding a
-  /// half edits ``WashLabelWeight/largeTextThreshold``, sees three reds, and
-  /// "fixes" the expectations. No shipped row would redden alongside, since all
-  /// of them sit far from either threshold.
+  /// green a red disarms them together** — the ordinary red-test reflex rather
+  /// than sabotage, and no shipped row would redden alongside to warn you.
   /// ``everyWeightHalfIsPinnedFromBothSidesInTheTable`` is what makes a *lost*
-  /// pin visible; a row *moved* (18 → 19) still passes it, and the count pin
-  /// below survives any same-cardinality swap.
+  /// pin visible; a row merely *moved* (18 → 19) still passes it, and the count
+  /// pin below survives any same-cardinality swap.
   static let washLabelBoundaryCases: [WashLabelBoundaryCase] = [
     WashLabelBoundaryCase(14, .bold, isNormalText: false),
     WashLabelBoundaryCase(13.9, .bold, isNormalText: true),
@@ -69,9 +64,7 @@ extension DesignTokensTests {
   ]
 
   /// The two semantic sizes are the only figures in any wash fixture with no
-  /// token to reference, so they are measured rather than asserted in prose —
-  /// a literal plus "iOS default Large" in a doc comment would be the same
-  /// shape of claim #1468 is retiring.
+  /// token to reference, so they are measured rather than asserted in prose.
   ///
   /// `compatibleWith:` pins the content-size category explicitly: without it
   /// `preferredFont` reads the runner's ambient setting, and the arm would
@@ -87,9 +80,9 @@ extension DesignTokensTests {
   }
 
   /// Coverage over the boundary table, which its own count pin cannot give:
-  /// `count == 7` survives a same-cardinality swap, and says nothing at all
-  /// about a **fourth** ``WashLabelWeight`` case, which would ship with zero
-  /// control rows while both negative controls stayed green.
+  /// `count == 7` survives a same-cardinality swap and says nothing about a
+  /// **fourth** ``WashLabelWeight`` case, which would ship with zero control
+  /// rows while both negative controls stayed green.
   ///
   /// Deliberately structural, not value-derived: it asks that each case be
   /// pinned on both sides of its threshold without saying where that threshold
@@ -107,12 +100,9 @@ extension DesignTokensTests {
   /// weight live instead of transcribing it, so this pins both halves of that
   /// initializer: the mappings the fixtures rely on, and — through
   /// `withKnownIssue` — that an unmodelled weight is *recorded* rather than
-  /// quietly folded into `.regular`.
-  ///
-  /// The second half is the one that matters. Defaulting silently would still
-  /// be the over-strict direction, so no arm would ever redden to reveal it,
-  /// and the "a fourth weight is a decision" property would be gone with
-  /// nothing to show for it.
+  /// quietly folded into `.regular`. The second half is the one that matters:
+  /// silent defaulting is the over-strict direction, so nothing else would ever
+  /// redden to reveal it.
   @Test func tokenWeightsMapToHalvesAndUnmodelledOnesAreRecorded() {
     #expect(WashLabelWeight(.regular) == .regular)
     #expect(WashLabelWeight(.semibold) == .semibold)
@@ -131,10 +121,6 @@ extension DesignTokensTests {
   /// to a threshold twice as large, or to the wrong field — a guard's passing
   /// case proves nothing. This constructs the rows the guard claims to reject
   /// and confirms it does.
-  ///
-  /// Deliberately **not** shared with the ink control: each row type stores and
-  /// forwards its own two fields, and a control borrowed from a sibling type
-  /// stops discriminating the moment that sibling is the one wired correctly.
   @Test func mossWashSiteRejectsLargeTextLabels() {
     #expect(Self.washLabelBoundaryCases.count == 7)
 
@@ -149,13 +135,11 @@ extension DesignTokensTests {
   }
 
   /// The negative control for ``InkWashSite/isNormalText``, and deliberately a
-  /// second one rather than a reuse of the moss control above.
-  ///
-  /// The two row types forward the same two fields to the same
-  /// ``WashLabelWeight`` method, so a shared control would look sufficient —
-  /// but what each type can get wrong is its own wiring, and a control run
-  /// through a sibling that happens to be correct passes without observing this
-  /// one at all.
+  /// second one rather than a reuse of the moss control above: the two row types
+  /// forward the same fields to the same ``WashLabelWeight`` method, so sharing
+  /// would look sufficient — but what each type can get wrong is its own wiring,
+  /// and a control run through a sibling that happens to be correct passes
+  /// without observing this one at all.
   @Test func inkWashSiteRejectsLargeTextLabels() {
     #expect(Self.washLabelBoundaryCases.count == 7)
 
@@ -181,26 +165,23 @@ extension DesignTokensTests {
 /// **`.semibold` takes the ≥18pt half, decided here rather than per row.**
 /// WCAG's "bold" is conventionally ≥700 and `.semibold` is 600, so the ≥14pt
 /// half would be the more permissive reading of a weight WCAG does not call
-/// bold. #1466 settled that as a convention in prose; this is where it became
-/// executable — ``DesignTokensTests/mossWashSiteRejectsLargeTextLabels``
-/// separates it from `.bold` *and* pins the value, which a lone `14pt semibold`
-/// case could not.
+/// bold. #1466 settled that as a convention in prose;
+/// ``DesignTokensTests/mossWashSiteRejectsLargeTextLabels`` is where it became
+/// executable, separating it from `.bold` *and* pinning the value.
 ///
 /// **What makes the choice safe is a property, not a preference**: the fixtures
 /// pin one bar, the strictest available, and a row failing the criterion is a
 /// red rather than a silent drop. So *every* misclassification this type can
-/// produce errs toward over-strictness — a row wrongly on the ≥18 half is held
-/// to 4.5 where WCAG would allow 3:1, and one wrongly on ≥14 reddens and gets
-/// looked at. No misclassification routes a label to a *looser* bar, because no
-/// looser bar exists in these files.
+/// produce errs toward over-strictness — none routes a label to a *looser* bar,
+/// because no looser bar exists in these files.
 ///
-/// Only the three weights the fixtures use are modelled, and a fourth is a
-/// decision rather than a mechanical addition — it has to choose a half. Both
-/// the `largeTextThreshold` switch and ``init(_:)`` are written so that a new
-/// weight cannot arrive without one being made (the first by having no
-/// `default:`, the second by recording an issue). A live case in the tree
-/// waiting on that decision: `PredictionOutcomeBadge`'s streak sub-label is
-/// `.caption.weight(.medium)` (#1495).
+/// Only the three weights the fixtures use are modelled, and a fourth has to
+/// choose a half rather than being a mechanical addition. Both the
+/// `largeTextThreshold` switch and ``init(_:)`` are written so a new weight
+/// cannot arrive without that decision — the first by having no `default:`, the
+/// second by recording an issue. The live case waiting on it:
+/// `PredictionOutcomeBadge`'s streak sub-label, `.caption.weight(.medium)`
+/// (#1495).
 ///
 /// File scope per `.claude/rules/testing.md` § "Splitting a Suite Across Files":
 /// helpers in a sibling file live outside the suite struct.
@@ -214,10 +195,8 @@ enum WashLabelWeight: CaseIterable {
   /// both of its figures live, the way it already takes `size`.
   ///
   /// Records an issue rather than folding an unmodelled weight into `.regular`:
-  /// silently defaulting would be the over-strict direction and therefore safe
-  /// in outcome, but it would erase the "a fourth weight is a decision"
-  /// property this type exists to hold. `.medium` is the case that would hit it
-  /// today.
+  /// silently defaulting is safe in outcome but erases the "a fourth weight is a
+  /// decision" property this type exists to hold.
   init(_ weight: Font.Weight) {
     switch weight {
     case .bold, .heavy, .black: self = .bold
@@ -247,16 +226,16 @@ enum WashLabelWeight: CaseIterable {
 
 /// The failure message the three wash fixtures share when a row is large text.
 ///
-/// One wording in one place: the criterion lives here, so a message that drifts
-/// per fixture is the plausible failure — three byte-identical string literals
-/// across files are a mirror like any other.
+/// One wording in one place: three byte-identical string literals across files
+/// would be a mirror like any other.
 ///
 /// **It carries the repair direction because the cheapest repair is wrong.**
-/// A rejected row reddens twice (this arm, then the 4.5 assertions it is not
-/// exempt from), and both `pointSize` and `weight` are recorded by hand — so
-/// editing the record is the path of least resistance out of the red, and
-/// nothing would catch it. `DesignTokensTests+MossInkAsWashLabel.swift`'s
-/// "Large text is out" bullet is where a genuinely large-text site goes.
+/// `#expect` does not short-circuit, so a rejected row reddens twice — here,
+/// then on the 4.5 assertions it is not exempt from — and both `pointSize` and
+/// `weight` are recorded by hand, so editing the record is the path of least
+/// resistance out of the red and nothing would catch it.
+/// `DesignTokensTests+MossInkAsWashLabel.swift`'s "Large text is out" bullet is
+/// where a genuinely large-text site goes instead.
 func largeTextRejection(_ name: String, pointSize: Double, weight: WashLabelWeight) -> String {
   """
   \(name) is large text (\(pointSize)pt \(weight)) and does not belong in a normal-text fixture \
@@ -271,25 +250,23 @@ func largeTextRejection(_ name: String, pointSize: Double, weight: WashLabelWeig
 /// ``InkWashSite``.
 ///
 /// **The split is fixed-size vs scaling, not which expression the view wrote.**
-///
 /// *Fixed size* covers every `.system(size:)` label — from a `Typography.*`
 /// token (referenced live via the token's `size`, and fixed-size by design per
-/// ``PasturaTextStyle/font``), from a layout constant read live
-/// (`HomeHeroLayout.*FontSize`), or from a literal the view inlines. For those
-/// the recorded value is the size at every content size.
-///
-/// *Scaling* covers the two constants below. Their value is the size **at the
-/// default**: at accessibility sizes such a label crosses into large text,
-/// which only **relaxes** the bar the fixtures apply. So a row's `pointSize`
-/// decides admission at the default and nothing else.
+/// ``PasturaTextStyle/font``), a layout constant read live
+/// (`HomeHeroLayout.*FontSize`), or a literal the view inlines; for those the
+/// recorded value is the size at every content size. *Scaling* covers the two
+/// constants below, whose value is the size **at the default**: at accessibility
+/// sizes such a label crosses into large text, which only **relaxes** the bar
+/// the fixtures apply. So a row's `pointSize` decides admission at the default
+/// and nothing else.
 ///
 /// **Hand-recorded against the view, and a wrong transcription is caught by
 /// nothing.** Live references, ``WashLabelWeight/init(_:)`` and
 /// ``DesignTokensTests/semanticLabelSizesMatchUIKitAtTheDefaultContentSize``
 /// remove the guesswork from every figure that has a source — which is why
 /// these two are measured here rather than written down. But *which* figure a
-/// row takes is still a reader's judgement, the same standing the fixtures give
-/// their grounds. A reviewer has to open the view when a row is added.
+/// row takes is still a reader's judgement: a reviewer has to open the view
+/// when a row is added.
 enum WashLabelSemanticSize {
   static let caption = 12.0
   static let caption2 = 11.0

--- a/Pastura/PasturaTests/Views/DesignTokensTests+WashLabelTypeSize.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+WashLabelTypeSize.swift
@@ -1,0 +1,167 @@
+import SwiftUI
+import Testing
+import UIKit
+
+@testable import Pastura
+
+// The WCAG large-text admission criterion the wash-contrast fixtures apply,
+// made executable (#1468).
+//
+// `DesignTokensTests+MossOnWash.swift`, `+MossInkAsWashLabel.swift` and
+// `+InkOnWash.swift` each pin a 4.5:1 bar, and each is only the right bar
+// because every label in its fixture is WCAG **normal** text. Until #1468 that
+// was a prose claim over row types storing no font, so no arm observed it and a
+// large-text row would have been admitted silently. #1466 is the demonstration:
+// a superlative in `textBar`'s doc survived until a new 12pt row falsified it,
+// and only a hand census of all nine rows caught that — while a second claim
+// citing it in `+InkOnWash.swift` went stale at the same moment.
+//
+// This file owns the criterion and the negative controls for it; the fixtures
+// own their rows. That split is deliberate: the controls exercise
+// ``WashLabelWeight`` and each row type's `isNormalText`, which is what lives
+// here, and it keeps the controls off the two fixture files closest to
+// swiftlint's 400-line `file_length` error under `--strict`.
+//
+// Sibling-file extension of `DesignTokensTests` per `.claude/rules/testing.md`
+// § "Splitting a Suite Across Files" — a fresh `@Suite` would run in parallel
+// with the parent and is explicitly forbidden. Inherits the parent's
+// `@MainActor` and `.timeLimit(.minutes(1))`.
+extension DesignTokensTests {
+
+  /// The boundary table both negative controls run. Written as expectations
+  /// rather than derived from ``WashLabelWeight``, so a mapping that moved has
+  /// something independent to disagree with.
+  ///
+  /// Each half is pinned from **both** sides, and `.semibold` needs three rows
+  /// rather than two: `14 / .semibold` admitted is what separates it from
+  /// `.bold`, while `18` rejected and `17.9` admitted are what say the half it
+  /// takes is ≥18 rather than merely >14. With only the first, a threshold
+  /// typed as 20 would pass every arm in the repo.
+  static let washLabelBoundaryCases: [WashLabelBoundaryCase] = [
+    WashLabelBoundaryCase(14, .bold, isNormalText: false),
+    WashLabelBoundaryCase(13.9, .bold, isNormalText: true),
+    WashLabelBoundaryCase(14, .semibold, isNormalText: true),
+    WashLabelBoundaryCase(18, .semibold, isNormalText: false),
+    WashLabelBoundaryCase(17.9, .semibold, isNormalText: true),
+    WashLabelBoundaryCase(18, .regular, isNormalText: false),
+    WashLabelBoundaryCase(17.9, .regular, isNormalText: true)
+  ]
+
+  /// The two semantic sizes are the only figures in any wash fixture with no
+  /// token to reference, so they are measured rather than asserted in prose —
+  /// a literal plus "iOS default Large" in a doc comment would be the same
+  /// shape of claim #1468 is retiring.
+  ///
+  /// `compatibleWith:` pins the content-size category explicitly: without it
+  /// `preferredFont` reads the runner's ambient setting, and the arm would
+  /// measure whatever the simulator happened to be configured for rather than
+  /// the default this fixture's rows are recorded at.
+  @Test func semanticLabelSizesMatchUIKitAtTheDefaultContentSize() {
+    let large = UITraitCollection(preferredContentSizeCategory: .large)
+    // SwiftUI's `.caption` is UIKit's `.caption1`.
+    let caption = UIFont.preferredFont(forTextStyle: .caption1, compatibleWith: large)
+    let caption2 = UIFont.preferredFont(forTextStyle: .caption2, compatibleWith: large)
+    #expect(Double(caption.pointSize) == WashLabelSemanticSize.caption)
+    #expect(Double(caption2.pointSize) == WashLabelSemanticSize.caption2)
+  }
+
+  /// The negative control for ``MossWashSite/isNormalText``.
+  ///
+  /// The per-row assertion in `mossOnWashClearsAAOnEveryWashItIsUsedOn` passes
+  /// on every shipped row and would go on passing if `isNormalText` were wired
+  /// to a threshold twice as large, or to the wrong field — a guard's passing
+  /// case proves nothing. This constructs the rows the guard claims to reject
+  /// and confirms it does.
+  ///
+  /// Deliberately **not** shared with the ink control: each row type stores and
+  /// forwards its own two fields, and a control borrowed from a sibling type
+  /// stops discriminating the moment that sibling is the one wired correctly.
+  @Test func mossWashSiteRejectsLargeTextLabels() {
+    #expect(Self.washLabelBoundaryCases.count == 7)
+
+    for probe in Self.washLabelBoundaryCases {
+      let row = MossWashSite(
+        "probe", wash: .moss, light: 0.20, dark: 0.20,
+        pointSize: probe.pointSize, weight: probe.weight)
+      #expect(
+        row.isNormalText == probe.isNormalText,
+        "\(probe.pointSize)pt \(probe.weight): expected isNormalText == \(probe.isNormalText)")
+    }
+  }
+}
+
+// MARK: - Helpers
+
+/// The WCAG 1.4.3 weight halves, as the wash fixtures record them.
+///
+/// "Large text" is a two-valued threshold — ≥14pt **bold**, ≥18pt otherwise —
+/// so a row's point size alone cannot decide which bar applies to it. This is
+/// the other half of that decision, and the reason the fixtures store a weight
+/// rather than a point size on its own.
+///
+/// **`.semibold` takes the ≥18pt half, decided here rather than per row.**
+/// WCAG's "bold" is conventionally ≥700 and `.semibold` is 600, so the ≥14pt
+/// half would be the more permissive reading of a weight WCAG does not call
+/// bold; the ≥18pt half holds a semibold row to the stricter 4.5:1 bar for
+/// longer. #1466 settled that as a convention in prose; this is where it became
+/// executable — ``DesignTokensTests/mossWashSiteRejectsLargeTextLabels``
+/// separates it from `.bold` *and* pins the value, which a lone `14pt semibold`
+/// case could not.
+///
+/// Only the three weights the fixtures actually use are modelled. A fourth
+/// (`.heavy`, `.medium`, ...) is a decision rather than a mechanical addition —
+/// it has to choose a half — so it belongs in this switch, not at a call site.
+///
+/// File scope per `.claude/rules/testing.md` § "Splitting a Suite Across Files":
+/// helpers in a sibling file live outside the suite struct.
+enum WashLabelWeight {
+  case regular
+  case semibold
+  case bold
+
+  /// The point size **at or above which** a label of this weight is WCAG large
+  /// text, i.e. answers to the 3:1 bar instead of 4.5:1.
+  var largeTextThreshold: Double {
+    switch self {
+    case .bold: 14
+    case .regular, .semibold: 18
+    }
+  }
+
+  /// Whether a label at `pointSize` is still normal text under this weight.
+  ///
+  /// Strict `<`: WCAG's thresholds are inclusive, so a 14pt bold label *is*
+  /// large text and must not be admitted to a normal-text fixture.
+  func admitsAsNormalText(pointSize: Double) -> Bool { pointSize < largeTextThreshold }
+}
+
+/// Point sizes of the semantic SwiftUI text styles the wash fixtures use, at
+/// the default `.large` content size.
+///
+/// Rows whose view reads a `Typography.*` token reference that token's `size`
+/// live instead — those are fixed-size by design (``PasturaTextStyle/font``'s
+/// doc comment) so the value is the size, full stop. These two have no such
+/// value to read, which is why they are named here and measured by
+/// ``DesignTokensTests/semanticLabelSizesMatchUIKitAtTheDefaultContentSize``
+/// rather than written down.
+enum WashLabelSemanticSize {
+  static let caption = 12.0
+  static let caption2 = 11.0
+}
+
+/// One boundary case for the ``WashLabelWeight`` halves: a point size, a
+/// weight, and whether the pair is still normal text.
+///
+/// A struct rather than a tuple because swiftlint's `large_tuple` caps tuples
+/// at two members. Same reason as ``MossWashSite``.
+struct WashLabelBoundaryCase {
+  let pointSize: Double
+  let weight: WashLabelWeight
+  let isNormalText: Bool
+
+  init(_ pointSize: Double, _ weight: WashLabelWeight, isNormalText: Bool) {
+    self.pointSize = pointSize
+    self.weight = weight
+    self.isNormalText = isNormalText
+  }
+}

--- a/Pastura/PasturaTests/Views/DesignTokensTests+WashLabelTypeSize.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+WashLabelTypeSize.swift
@@ -22,6 +22,17 @@ import UIKit
 // here, and it keeps the controls off the two fixture files closest to
 // swiftlint's 400-line `file_length` error under `--strict`.
 //
+// **Two sibling fixtures in this suite still carry the unexecuted form, and the
+// class is not closed** (#1495). `DesignTokensTests+MossSoftGround.swift`'s
+// `textBar` pins 4.5 over a `[String]` site list and keeps a superlative on top
+// of it — the exact state #1466 falsified — and
+// `DesignTokensTests+MutedAsContent.swift`'s `contentTextBar` carries the
+// shorter form. They are excluded here rather than overlooked, and for
+// different reasons: the first would need its list promoted to a row type, and
+// the second stores **grounds** rather than labels, so there is no row for a
+// font to hang on and its claim needs a fixture that does not exist yet. Do not
+// read the criterion below as covering either.
+//
 // Sibling-file extension of `DesignTokensTests` per `.claude/rules/testing.md`
 // § "Splitting a Suite Across Files" — a fresh `@Suite` would run in parallel
 // with the parent and is explicitly forbidden. Inherits the parent's
@@ -155,13 +166,23 @@ enum WashLabelWeight {
   func admitsAsNormalText(pointSize: Double) -> Bool { pointSize < largeTextThreshold }
 }
 
+/// The failure message the three wash fixtures share when a row is large text.
+///
+/// One wording in one place: the criterion lives here, so a message that drifts
+/// per fixture is the plausible failure — three byte-identical string literals
+/// across files are a mirror like any other.
+func largeTextRejection(_ name: String, pointSize: Double, weight: WashLabelWeight) -> String {
+  "\(name) is large text (\(pointSize)pt \(weight)) and does not belong in a normal-text fixture"
+}
+
 /// Point sizes of the semantic SwiftUI text styles the wash fixtures use, at
 /// the default `.large` content size.
 ///
-/// Rows whose view reads a `Typography.*` token reference that token's `size`
-/// live instead — those are fixed-size by design (``PasturaTextStyle/font``'s
-/// doc comment) so the value is the size, full stop. These two have no such
-/// value to read, which is why they are named here and measured by
+/// Rows on a `.system(size:)` label carry that size instead — from a
+/// `Typography.*` token, a layout constant, or a literal the view inlines — and
+/// those are fixed-size by design (``PasturaTextStyle/font``'s doc comment), so
+/// the value is the size, full stop. These two have no such value to read,
+/// which is why they are named here and measured by
 /// ``DesignTokensTests/semanticLabelSizesMatchUIKitAtTheDefaultContentSize``
 /// rather than written down.
 enum WashLabelSemanticSize {

--- a/Pastura/PasturaTests/Views/DesignTokensTests+WashLabelTypeSize.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+WashLabelTypeSize.swift
@@ -11,10 +11,7 @@ import UIKit
 // `+InkOnWash.swift` each pin a 4.5:1 bar, and each is only the right bar
 // because every label in its fixture is WCAG **normal** text. Until #1468 that
 // was a prose claim over row types storing no font, so no arm observed it and a
-// large-text row would have been admitted silently. #1466 is the demonstration:
-// a superlative in `textBar`'s doc survived until a new 12pt row falsified it,
-// and only a hand census of all nine rows caught that — while a second claim
-// citing it in `+InkOnWash.swift` went stale at the same moment.
+// large-text row would have been admitted silently (#1466).
 //
 // This file owns the criterion and the negative controls for it; the fixtures
 // own their rows. That split is deliberate: the controls exercise
@@ -27,11 +24,14 @@ import UIKit
 // `textBar` pins 4.5 over a `[String]` site list and keeps a superlative on top
 // of it — the exact state #1466 falsified — and
 // `DesignTokensTests+MutedAsContent.swift`'s `contentTextBar` carries the
-// shorter form. They are excluded here rather than overlooked, and for
-// different reasons: the first would need its list promoted to a row type, and
-// the second stores **grounds** rather than labels, so there is no row for a
-// font to hang on and its claim needs a fixture that does not exist yet. Do not
-// read the criterion below as covering either.
+// shorter form. They are excluded here rather than overlooked, and **one
+// obstacle is common to both**: `PredictionOutcomeBadge`'s streak sub-label is
+// `.caption.weight(.medium)`, and both fixtures speak for it — so either would
+// force a fourth ``WashLabelWeight`` case, i.e. a WCAG judgement call this
+// branch had no occasion to make. On top of that the first needs its `[String]`
+// list promoted to a row type, and the second's remaining claim is entangled
+// with the occupancy question it explicitly defers to #1448. Do not read the
+// criterion below as covering either.
 //
 // Sibling-file extension of `DesignTokensTests` per `.claude/rules/testing.md`
 // § "Splitting a Suite Across Files" — a fresh `@Suite` would run in parallel
@@ -48,6 +48,16 @@ extension DesignTokensTests {
   /// `.bold`, while `18` rejected and `17.9` admitted are what say the half it
   /// takes is ≥18 rather than merely >14. With only the first, a threshold
   /// typed as 20 would pass every arm in the repo.
+  ///
+  /// **This table is the sole arbiter for both controls, so editing a row to
+  /// green a red disarms them together.** That is the failure to guard against
+  /// — not sabotage, just the ordinary red-test reflex: someone re-deciding a
+  /// half edits ``WashLabelWeight/largeTextThreshold``, sees three reds, and
+  /// "fixes" the expectations. No shipped row would redden alongside, since all
+  /// of them sit far from either threshold.
+  /// ``everyWeightHalfIsPinnedFromBothSidesInTheTable`` is what makes a *lost*
+  /// pin visible; a row *moved* (18 → 19) still passes it, and the count pin
+  /// below survives any same-cardinality swap.
   static let washLabelBoundaryCases: [WashLabelBoundaryCase] = [
     WashLabelBoundaryCase(14, .bold, isNormalText: false),
     WashLabelBoundaryCase(13.9, .bold, isNormalText: true),
@@ -74,6 +84,44 @@ extension DesignTokensTests {
     let caption2 = UIFont.preferredFont(forTextStyle: .caption2, compatibleWith: large)
     #expect(Double(caption.pointSize) == WashLabelSemanticSize.caption)
     #expect(Double(caption2.pointSize) == WashLabelSemanticSize.caption2)
+  }
+
+  /// Coverage over the boundary table, which its own count pin cannot give:
+  /// `count == 7` survives a same-cardinality swap, and says nothing at all
+  /// about a **fourth** ``WashLabelWeight`` case, which would ship with zero
+  /// control rows while both negative controls stayed green.
+  ///
+  /// Deliberately structural, not value-derived: it asks that each case be
+  /// pinned on both sides of its threshold without saying where that threshold
+  /// is, so the table stays an independent statement rather than a restatement
+  /// of the implementation.
+  @Test func everyWeightHalfIsPinnedFromBothSidesInTheTable() {
+    for weight in WashLabelWeight.allCases {
+      let rows = Self.washLabelBoundaryCases.filter { $0.weight == weight }
+      #expect(rows.contains { $0.isNormalText }, "no admitted boundary row for \(weight)")
+      #expect(rows.contains { !$0.isNormalText }, "no rejected boundary row for \(weight)")
+    }
+  }
+
+  /// ``WashLabelWeight/init(_:)`` is what lets a token-backed row take its
+  /// weight live instead of transcribing it, so this pins both halves of that
+  /// initializer: the mappings the fixtures rely on, and — through
+  /// `withKnownIssue` — that an unmodelled weight is *recorded* rather than
+  /// quietly folded into `.regular`.
+  ///
+  /// The second half is the one that matters. Defaulting silently would still
+  /// be the over-strict direction, so no arm would ever redden to reveal it,
+  /// and the "a fourth weight is a decision" property would be gone with
+  /// nothing to show for it.
+  @Test func tokenWeightsMapToHalvesAndUnmodelledOnesAreRecorded() {
+    #expect(WashLabelWeight(.regular) == .regular)
+    #expect(WashLabelWeight(.semibold) == .semibold)
+    #expect(WashLabelWeight(.bold) == .bold)
+    #expect(WashLabelWeight(.heavy) == .bold)
+
+    withKnownIssue("an unmodelled weight must record an issue, not default silently") {
+      _ = WashLabelWeight(.medium)
+    }
   }
 
   /// The negative control for ``MossWashSite/isNormalText``.
@@ -133,22 +181,53 @@ extension DesignTokensTests {
 /// **`.semibold` takes the ≥18pt half, decided here rather than per row.**
 /// WCAG's "bold" is conventionally ≥700 and `.semibold` is 600, so the ≥14pt
 /// half would be the more permissive reading of a weight WCAG does not call
-/// bold; the ≥18pt half holds a semibold row to the stricter 4.5:1 bar for
-/// longer. #1466 settled that as a convention in prose; this is where it became
+/// bold. #1466 settled that as a convention in prose; this is where it became
 /// executable — ``DesignTokensTests/mossWashSiteRejectsLargeTextLabels``
 /// separates it from `.bold` *and* pins the value, which a lone `14pt semibold`
 /// case could not.
 ///
-/// Only the three weights the fixtures actually use are modelled. A fourth
-/// (`.heavy`, `.medium`, ...) is a decision rather than a mechanical addition —
-/// it has to choose a half — so it belongs in this switch, not at a call site.
+/// **What makes the choice safe is a property, not a preference**: the fixtures
+/// pin one bar, the strictest available, and a row failing the criterion is a
+/// red rather than a silent drop. So *every* misclassification this type can
+/// produce errs toward over-strictness — a row wrongly on the ≥18 half is held
+/// to 4.5 where WCAG would allow 3:1, and one wrongly on ≥14 reddens and gets
+/// looked at. No misclassification routes a label to a *looser* bar, because no
+/// looser bar exists in these files.
+///
+/// Only the three weights the fixtures use are modelled, and a fourth is a
+/// decision rather than a mechanical addition — it has to choose a half. Both
+/// the `largeTextThreshold` switch and ``init(_:)`` are written so that a new
+/// weight cannot arrive without one being made (the first by having no
+/// `default:`, the second by recording an issue). A live case in the tree
+/// waiting on that decision: `PredictionOutcomeBadge`'s streak sub-label is
+/// `.caption.weight(.medium)` (#1495).
 ///
 /// File scope per `.claude/rules/testing.md` § "Splitting a Suite Across Files":
 /// helpers in a sibling file live outside the suite struct.
-enum WashLabelWeight {
+enum WashLabelWeight: CaseIterable {
   case regular
   case semibold
   case bold
+
+  /// The half a design-token weight selects, **derived rather than
+  /// transcribed** — so a row whose view reads a `Typography.*` token can take
+  /// both of its figures live, the way it already takes `size`.
+  ///
+  /// Records an issue rather than folding an unmodelled weight into `.regular`:
+  /// silently defaulting would be the over-strict direction and therefore safe
+  /// in outcome, but it would erase the "a fourth weight is a decision"
+  /// property this type exists to hold. `.medium` is the case that would hit it
+  /// today.
+  init(_ weight: Font.Weight) {
+    switch weight {
+    case .bold, .heavy, .black: self = .bold
+    case .semibold: self = .semibold
+    case .regular, .light, .thin, .ultraLight: self = .regular
+    default:
+      Issue.record("unmodelled Font.Weight — decide its WCAG half in WashLabelWeight")
+      self = .regular
+    }
+  }
 
   /// The point size **at or above which** a label of this weight is WCAG large
   /// text, i.e. answers to the 3:1 bar instead of 4.5:1.
@@ -171,20 +250,46 @@ enum WashLabelWeight {
 /// One wording in one place: the criterion lives here, so a message that drifts
 /// per fixture is the plausible failure — three byte-identical string literals
 /// across files are a mirror like any other.
+///
+/// **It carries the repair direction because the cheapest repair is wrong.**
+/// A rejected row reddens twice (this arm, then the 4.5 assertions it is not
+/// exempt from), and both `pointSize` and `weight` are recorded by hand — so
+/// editing the record is the path of least resistance out of the red, and
+/// nothing would catch it. `DesignTokensTests+MossInkAsWashLabel.swift`'s
+/// "Large text is out" bullet is where a genuinely large-text site goes.
 func largeTextRejection(_ name: String, pointSize: Double, weight: WashLabelWeight) -> String {
-  "\(name) is large text (\(pointSize)pt \(weight)) and does not belong in a normal-text fixture"
+  """
+  \(name) is large text (\(pointSize)pt \(weight)) and does not belong in a normal-text fixture \
+  — measure it at WCAG 1.4.11's 3:1 or exclude it deliberately; do not adjust the recorded \
+  size/weight to clear this
+  """
 }
 
 /// Point sizes of the semantic SwiftUI text styles the wash fixtures use, at
-/// the default `.large` content size.
+/// the default `.large` content size — and the reference for what a row's
+/// `pointSize` means in either regime, for both ``MossWashSite`` and
+/// ``InkWashSite``.
 ///
-/// Rows on a `.system(size:)` label carry that size instead — from a
-/// `Typography.*` token, a layout constant, or a literal the view inlines — and
-/// those are fixed-size by design (``PasturaTextStyle/font``'s doc comment), so
-/// the value is the size, full stop. These two have no such value to read,
-/// which is why they are named here and measured by
+/// **The split is fixed-size vs scaling, not which expression the view wrote.**
+///
+/// *Fixed size* covers every `.system(size:)` label — from a `Typography.*`
+/// token (referenced live via the token's `size`, and fixed-size by design per
+/// ``PasturaTextStyle/font``), from a layout constant read live
+/// (`HomeHeroLayout.*FontSize`), or from a literal the view inlines. For those
+/// the recorded value is the size at every content size.
+///
+/// *Scaling* covers the two constants below. Their value is the size **at the
+/// default**: at accessibility sizes such a label crosses into large text,
+/// which only **relaxes** the bar the fixtures apply. So a row's `pointSize`
+/// decides admission at the default and nothing else.
+///
+/// **Hand-recorded against the view, and a wrong transcription is caught by
+/// nothing.** Live references, ``WashLabelWeight/init(_:)`` and
 /// ``DesignTokensTests/semanticLabelSizesMatchUIKitAtTheDefaultContentSize``
-/// rather than written down.
+/// remove the guesswork from every figure that has a source — which is why
+/// these two are measured here rather than written down. But *which* figure a
+/// row takes is still a reader's judgement, the same standing the fixtures give
+/// their grounds. A reviewer has to open the view when a row is added.
 enum WashLabelSemanticSize {
   static let caption = 12.0
   static let caption2 = 11.0

--- a/Pastura/PasturaTests/Views/DesignTokensTests+WashLabelTypeSize.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+WashLabelTypeSize.swift
@@ -88,6 +88,26 @@ extension DesignTokensTests {
         "\(probe.pointSize)pt \(probe.weight): expected isNormalText == \(probe.isNormalText)")
     }
   }
+
+  /// The negative control for ``InkWashSite/isNormalText``, and deliberately a
+  /// second one rather than a reuse of the moss control above.
+  ///
+  /// The two row types forward the same two fields to the same
+  /// ``WashLabelWeight`` method, so a shared control would look sufficient —
+  /// but what each type can get wrong is its own wiring, and a control run
+  /// through a sibling that happens to be correct passes without observing this
+  /// one at all.
+  @Test func inkWashSiteRejectsLargeTextLabels() {
+    #expect(Self.washLabelBoundaryCases.count == 7)
+
+    for probe in Self.washLabelBoundaryCases {
+      let row = InkWashSite(
+        "probe", alpha: 0.15, pointSize: probe.pointSize, weight: probe.weight)
+      #expect(
+        row.isNormalText == probe.isNormalText,
+        "\(probe.pointSize)pt \(probe.weight): expected isNormalText == \(probe.isNormalText)")
+    }
+  }
 }
 
 // MARK: - Helpers


### PR DESCRIPTION
## Summary

`textBar` / `mossInkTextBar` / `inkTextBar` が 3.0 ではなく 4.5 である根拠は「fixture のどのラベルも WCAG の large-text 閾値未満」という主張だったが、`MossWashSite` / `InkWashSite` は font を保持しておらず、この主張を観測する arm が存在しなかった。#1466 がその故障を実演している — `textBar` の最上級表現は 12pt の行が追加されるまで生き延び、全9行の手作業の点検でしか捕まらず、それを引用していた `+InkOnWash.swift` 側の主張も同時に陳腐化した。

- **`WashLabelWeight`** を新設し、`.semibold` がどちらの half を取るか（≥18pt）を散文ではなく型の中で決める。WCAG の "bold" は慣例上 ≥700、`.semibold` は 600。
- **`MossWashSite` / `InkWashSite` に `pointSize` / `weight` / `isNormalText`。** 両方とも必須引数なので、font を宣言せずに行を追加することはできない — これが #1466 の故障のうち本 PR が閉じる半分。
- **`mossOnWashClearsAAOnEveryWashItIsUsedOn` / `mossInkClearsAAOnEveryMossWashItLabels` / `inkOnWashClearsAAOnEverySelfWashItIsUsedOn`** が行ごとに判定基準を検査する。
- **陰性対照は行型ごとに独立。** 境界表 7 ケースで各 half を両側から固定。`.semibold` は 3 行必要 — `14 → 許可` が `.bold` との差を、`18 → 拒否` / `17.9 → 許可` が「取る half が >14 ではなく ≥18」であることを示す。前者だけでは閾値を 20 と書いても全 arm が緑のままになる。
- **`WashLabelWeight.init(Font.Weight)`** で token 由来の行は weight も live 導出。未モデルの weight（`.medium` 等）は `.regular` に黙って畳まず `Issue.record` する — 畳んでも「厳しい側」なのでどの arm も赤くならず、「4 番目の weight は判断である」という性質だけが消えるため。
- **境界表のカバレッジ arm**（`CaseIterable`）で、`count == 7` が素通りさせる同数入替と 4 番目 case のブラインドを塞ぐ。

### なぜ「拒否」で正しいか

バーが 4.5 一本で、拒否は赤（黙って落とすのではない）。したがって**この型が生む誤分類はすべて厳しい側**に倒れる — ≥18 half に誤って乗った行は WCAG が 3:1 を許す場面で 4.5 を課され、≥14 half に誤って乗った行は赤くなって人が見る。緩いバーへ逃がす経路は、そもそもこれらのファイルに緩いバーが無いので存在しない。

`#expect` は短絡しないので、large-text の行は**指摘されたうえで 4.5 でも測られる**（赤 2 つ）。これが安全な順序。本当に large-text の site は `+MossInkAsWashLabel` の "Large text is out" 方針（`ModelPickerView` の 26pt bold という既存の先例つき）が行き先で、失敗メッセージ自体がそう案内する — 赤 2 つからの最短経路は手記録の書き換えで、それは何も捕まえないため。

### 数値の出所（「測定済みに見える誤った数字」対策）

issue の "Watch out" が「ここで数字を間違えるのはフィールドが無いより悪い」と書いている通り、転記の余地を可能な限り潰した:

| 種類 | 扱い |
|---|---|
| view が token を読む行 | size も weight も **live 参照**（`Typography.tagPhase.size` / `.weight`、`pillStatus` 同様、`HomeHeroLayout.*FontSize`） |
| semantic font (`.caption` / `.caption2`) | 参照先が無いので `UIFont.preferredFont(forTextStyle:compatibleWith:)` に `.large` を明示して**実測で照合**（散文で「iOS 既定 Large」と書けば、それは本 PR が畳もうとしている形の主張そのものになる） |
| view が literal を持つ唯一の行 (`ModelRow.recommendedTag`) | literal + size / weight とも `tagPhase` との一致を assert。その view の doc が「tagPhase を再利用」と主張しているため |

**残余は明記した**: どの数字を*取る*かは依然として読み手の判断で、view 側の literal を書き換えても fixture は緑のまま。`WashLabelSemanticSize` の doc が両 row 型ぶんまとめてそう書いている。

### スコープ判断

- `MossWashSite` は `+MossInkAsWashLabel.swift` の `mossInkWashSites` でも使われるため、そちらの 2 行と arm も**構造上**含まれる（issue は 2 ファイルしか挙げていなかった）。
- `inkWashSites` は issue が「明示的に決めろ」と書いていた件 — **含める**。除外は #1466 が刺さった跨ファイル非対称の再導入になる。
- **クラスは閉じていない。** 同じ suite の `+MossSoftGround.swift` / `+MutedAsContent.swift` が未実行の同型主張を持つ。**両者に共通の障害**は `PredictionOutcomeBadge` の streak sub-label が `.caption.weight(.medium)` であること — `.medium` に WCAG half を割り当てる判断が要る。除外理由とともに新規ファイルのヘッダに名指しし、**その 2 ファイル自身の当該 doc にも #1495 への指し示しを入れた**（残余がヘッダにしか無いと、そこを編集する人は見ない）。#1495 で追跡。

## Test plan

- `scripts/xcodebuild.sh test -skip-testing:PasturaUITests` — **3494 tests / 286 suites 全通過**（`DesignTokensTests` は 132 → 135）。
- `swiftlint lint --quiet --strict` — clean。最長ファイルは 382 行で 400 行 cap 以下。
- **ミューテーション probe でガードの発火を計 4 回確認**（緑のテストでは失敗パスが未実行なので、配線を変えるたびに取り直した）:
  - `PhaseTypeLabel` の行を 18pt regular に → `mossOnWashClearsAAOnEveryWashItIsUsedOn` が当該 assert で赤くなる。
  - メッセージを `largeTextRejection` に集約した後、`ResultsView.paused` を 20pt bold に → 集約後も正しく出る。
  - 修理方針を追記した後、`ResultsView.completed` を 22pt bold に → `… — measure it at WCAG 1.4.11's 3:1 or exclude it deliberately; do not adjust the recorded size/weight to clear this`。
  - 境界表を**同数のまま**入れ替えて `.regular` の拒否側を落とす → カバレッジ arm のみ赤、`count == 7` は緑のまま（＝count pin では塞げないことの確認）。
- `withKnownIssue` で `WashLabelWeight(.medium)` が黙って `.regular` にならず記録されることを確認。
- 全 15 行の `pointSize` / `weight` は `code-reviewer` と `/risk-review` の 2 者が view 側と**独立に**照合し一致を確認済み。

## Device QA

実機QA不要 — テストターゲットのみの変更で、production ソースにも `#if !targetEnvironment(simulator)` ブロックにも触れていない。

## Review

`claude-kit:critic`（プラン、Opus）: Critical 0 / Warning 6 → Top Actions を全採用（item 統合、対照を共有ファイルへ、`.semibold` の上側境界追加、semantic size の実測化、閾値テーブル pin テストの廃止）。

`code-reviewer`（Opus、2 周）: 1 周目 PASS / Warning 3 + Suggestion 2 → 全対応。2 周目 PASS / Warning 1 — **絞ったはずの主張を、同じコミットで自分が書いた最上級表現が反証していた**（`+MossOnWash.swift` の `HomePausedCard.progress` 行コメント「fixture 中で最大の行」）。判定基準が実行可能になった今、極値を維持する消費者は無いので削除した。

`/risk-review`（3 クラスタ並列、Opus×2 + Sonnet×1、軸 8 本）: Critical 0。`.semibold` の半分割と UIKit 実測 arm は OK。Warning は上記の weight 手打ち・短絡の誤記述・境界表の脆さ・#1495 の見積り誤り・散文の由来の尾で、いずれも対応済み。

Closes #1468

Follow-up: #1495（同じクラスの未着手 2 fixture。本 PR がそのために何かを進めるわけではないので close 指示は付けない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzDDmQ75W7dyWRtEANhrhb
