### PR TITLE
🐛 fix: pipefail + 早期終了 reader が秘密鍵ゲート・変更分類器・出荷ガードを fail-open させる

### DIFF
--- a/.claude/rules/ci-workflows.md
+++ b/.claude/rules/ci-workflows.md
@@ -65,6 +65,47 @@ $ bash -eo pipefail -c 'false | tee /dev/null || true; echo ${PIPESTATUS[0]}'  #
 
 **Apply:** when adding a pipe to an existing step, check which shape it is before touching its exit handling — and never add pipefail to a `|| true` + PIPESTATUS step without also removing the `|| true`. Motivating incident: the Release-build step followed this rule's *earlier* advice ("just write `cmd | tee log`, GHA defaults to pipefail") and masked a `** BUILD FAILED **` as green; the failure surfaced one step later as a misleading "Expected exactly 1 Release binary, found 0" (#1141).
 
+### Rule 3 — `producer | grep -q` under `pipefail` reports a MATCH as a failure
+
+Sibling of Rule 2, opposite composition: there pipefail was missing, here it is
+present. `grep -q` exits at its **first** match; the producer, still writing,
+takes SIGPIPE and returns 141; `pipefail` promotes that to the pipeline's
+status. So `if ! producer | grep -q PAT` skips **because** the pattern matched.
+
+**Never certify a site safe by comparing an input size to a number.** Pipe
+capacity is a kernel property and differs between the macOS pre-commit hook and
+the ubuntu CI runner, so a threshold you measured on one platform is not a fact
+about the other. The right question is whether the producer can outrun the
+buffer *at all* — `git diff --cached --name-only`, `nm -a` on an app binary and
+any whole-branch file list all can.
+
+**Apply** — capture, then test the captured text:
+
+```bash
+STAGED="$(git diff --cached --name-only)"
+MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
+if [ -z "$MATCHED" ]; then exit 0; fi
+```
+
+Three things that look interchangeable and are not:
+
+- **Assigning to a variable first does NOT fix it.** SIGPIPE just moves from
+  `git` to `printf`. Measured both ways; dropping `-q` is what fixes it.
+- **`|| [ $? -eq 1 ]`, not `|| true`.** `|| true` maps grep's exit ≥2 (broken
+  pattern, read error) onto the same empty string as a real no-match, which
+  reopens the fail-open through a different door. As a bare assignment the
+  group's status reaches `set -e`, so a broken pattern fails loudly.
+- **Do not fold it into `if [ -z "$(… )" ]`.** A command substitution used as an
+  argument to `[` has its status discarded, and the exit-code discrimination is
+  silently lost.
+
+Scope note: a bare `run:` step is `bash -e {0}` with no pipefail (Rule 2), so
+the four `printf … | grep -q` gating steps in `ci.yml` are latent rather than
+live — adding `shell: bash` to one arms it. `scripts/tests/staged-trigger-pipefail-test.sh`
+guards `scripts/*.sh` + `scripts/hooks/*.sh` for zero residuals; it deliberately
+does not parse workflow YAML, so those four are held by this paragraph only.
+Motivating sweep and the per-site fail directions: #1498.
+
 ## Long-lived branch gating — two layers × two directions
 
 For CI on long-lived integration / release-train / spike-staging branches, the gate is **two layers**, each at **two directions**:

--- a/.claude/rules/ci-workflows.md
+++ b/.claude/rules/ci-workflows.md
@@ -107,8 +107,9 @@ Three things that look interchangeable and are not:
 Scope note: a bare `run:` step is `bash -e {0}` with no pipefail (Rule 2), so
 the four `printf … | grep -q` gating steps in `ci.yml` are latent rather than
 live — adding `shell: bash` to one arms it. `scripts/tests/staged-trigger-pipefail-test.sh`
-guards `scripts/*.sh` + `scripts/hooks/*.sh` for zero residuals; it deliberately
-does not parse workflow YAML, so those four are held by this paragraph only.
+guards `scripts/*.sh` + `scripts/hooks/*.sh` + `tools/*/scripts/*.sh` for zero
+residuals; it deliberately does not parse workflow YAML, so those four are held
+by this paragraph only.
 Motivating sweep and the per-site fail directions: #1498.
 
 ## Long-lived branch gating — two layers × two directions

--- a/.claude/rules/ci-workflows.md
+++ b/.claude/rules/ci-workflows.md
@@ -68,7 +68,12 @@ $ bash -eo pipefail -c 'false | tee /dev/null || true; echo ${PIPESTATUS[0]}'  #
 ### Rule 3 — `producer | grep -q` under `pipefail` reports a MATCH as a failure
 
 Sibling of Rule 2, opposite composition: there pipefail was missing, here it is
-present. `grep -q` exits at its **first** match; the producer, still writing,
+present. Filed under this section for that pairing, but note the population is
+inverted too — the live sites are the repo's own `scripts/**` gates under the
+**local pre-commit hook**, and the GHA half is the explicitly-latent case at the
+end of this rule.
+
+`grep -q` exits at its **first** match; the producer, still writing,
 takes SIGPIPE and returns 141; `pipefail` promotes that to the pipeline's
 status. So `if ! producer | grep -q PAT` skips **because** the pattern matched.
 

--- a/.claude/rules/ci-workflows.md
+++ b/.claude/rules/ci-workflows.md
@@ -12,7 +12,7 @@ Ten concern families when editing CI workflow YAML or supporting scripts on this
 
 Target **≤10 min**, up to ~12 min acceptable, **20 min is a blocker** — at 20 min the feedback loop on UI-test-affected PRs is unusable. When adding CI steps (new test targets, matrix builds, coverage passes), estimate wall-clock impact **before** proposing; if a change pushes above ~12 min, surface the trade-off explicitly (drop a redundant test, build-sharing, move to a nightly schedule) rather than shipping a slow suite and fixing later. UI tests especially run several times slower on CI simulators than locally — budget them aggressively.
 
-## Shell scripting gotchas (macOS GHA runners)
+## Shell scripting gotchas (macOS GHA runners and repo scripts)
 
 ### Rule 1 — bash 3.2 on macOS runners: no `mapfile` / `readarray`
 
@@ -65,24 +65,27 @@ $ bash -eo pipefail -c 'false | tee /dev/null || true; echo ${PIPESTATUS[0]}'  #
 
 **Apply:** when adding a pipe to an existing step, check which shape it is before touching its exit handling — and never add pipefail to a `|| true` + PIPESTATUS step without also removing the `|| true`. Motivating incident: the Release-build step followed this rule's *earlier* advice ("just write `cmd | tee log`, GHA defaults to pipefail") and masked a `** BUILD FAILED **` as green; the failure surfaced one step later as a misleading "Expected exactly 1 Release binary, found 0" (#1141).
 
-### Rule 3 — `producer | grep -q` under `pipefail` reports a MATCH as a failure
+### Rule 3 — an early-exiting reader under `pipefail` reports a MATCH as a failure
 
-Sibling of Rule 2, opposite composition: there pipefail was missing, here it is
-present. Filed under this section for that pairing, but note the population is
-inverted too — the live sites are the repo's own `scripts/**` gates under the
-**local pre-commit hook**, and the GHA half is the explicitly-latent case at the
-end of this rule.
+**`pipefail` is not the variable — Rule 2 is right to add it. The variable is
+whether the pipeline's reader can exit before the producer finishes. Fix the
+shape, never the option.** That sentence is the arbitration between these two
+rules; without it they read as pulling opposite ways.
 
-`grep -q` exits at its **first** match; the producer, still writing,
-takes SIGPIPE and returns 141; `pipefail` promotes that to the pipeline's
-status. So `if ! producer | grep -q PAT` skips **because** the pattern matched.
+`grep -q` exits at its **first** match; the producer, still writing, takes
+SIGPIPE and returns 141; `pipefail` promotes that to the pipeline's status. So
+`if ! producer | grep -q PAT` skips **because** the pattern matched. Any
+early-exiting reader does this — `head`, `sed …q`, `awk …exit`, `grep -m N`.
+Both fail directions occur in this tree: `grep -q` fails **open** (a gate
+skips), while `| head` fails **loud** (a bare 141 abort, no message) — see
+`scripts/analyze-streaming-diag.sh` and
+`tools/kmp-gate-spike/scripts/check-b-prime-isolation.sh`.
 
 **Never certify a site safe by comparing an input size to a number.** Pipe
 capacity is a kernel property and differs between the macOS pre-commit hook and
-the ubuntu CI runner, so a threshold you measured on one platform is not a fact
-about the other. The right question is whether the producer can outrun the
-buffer *at all* — `git diff --cached --name-only`, `nm -a` on an app binary and
-any whole-branch file list all can.
+the ubuntu CI runner, so a threshold measured on one platform is not a fact
+about the other. Ask instead whether the producer can outrun the buffer *at
+all*.
 
 **Apply** — capture, then test the captured text:
 
@@ -95,22 +98,30 @@ if [ -z "$MATCHED" ]; then exit 0; fi
 Three things that look interchangeable and are not:
 
 - **Assigning to a variable first does NOT fix it.** SIGPIPE just moves from
-  `git` to `printf`. Measured both ways; dropping `-q` is what fixes it.
+  `git` to `printf`. Dropping `-q` is what fixes it.
 - **`|| [ $? -eq 1 ]`, not `|| true`.** `|| true` maps grep's exit ≥2 (broken
   pattern, read error) onto the same empty string as a real no-match, which
   reopens the fail-open through a different door. As a bare assignment the
-  group's status reaches `set -e`, so a broken pattern fails loudly.
+  group's status reaches `set -e` — **wherever `-e` is actually in effect**;
+  two swept files here run without it (`set -uo pipefail`, and one helper under
+  an explicit `set +e`), where the group is uniformity, not an abort.
 - **Do not fold it into `if [ -z "$(… )" ]`.** A command substitution used as an
   argument to `[` has its status discarded, and the exit-code discrimination is
   silently lost.
+- **`; [ "${PIPESTATUS[1]}" -eq 0 ]` is also correct** and keeps the reader's
+  early exit, which matters when draining the producer is expensive. It is not
+  used in this tree, so the residual guard flags it — teach the guard first.
 
-Scope note: a bare `run:` step is `bash -e {0}` with no pipefail (Rule 2), so
-the four `printf … | grep -q` gating steps in `ci.yml` are latent rather than
-live — adding `shell: bash` to one arms it. `scripts/tests/staged-trigger-pipefail-test.sh`
-guards `scripts/*.sh` + `scripts/hooks/*.sh` + `tools/*/scripts/*.sh` for zero
-residuals; it deliberately does not parse workflow YAML, so those four are held
-by this paragraph only.
-Motivating sweep and the per-site fail directions: #1498.
+Scope note: 18 sites across this repo's gate scripts, the `/release` archive
+check, two Claude Code hooks and one CI step — 14 under the local pre-commit
+hook, the rest not, so this is not a pre-commit-only concern. A bare `run:` step
+is `bash -e {0}` with no pipefail (Rule 2), which makes `ci.yml`'s four
+`printf … | grep -q` gating steps latent rather than live — adding `shell: bash`
+to one arms it, and three of them gate `ios` / `kmp` / `scenarios` on a file
+list that can reach 3000 names. Guarded by
+`scripts/tests/staged-trigger-pipefail-test.sh`, which scans shell scripts for
+the `grep -q` **shape** only: it does not parse workflow YAML, and it does not
+see the other early-exiting readers. Per-site fail directions: #1498.
 
 ## Long-lived branch gating — two layers × two directions
 

--- a/.claude/rules/ci-workflows.md
+++ b/.claude/rules/ci-workflows.md
@@ -69,33 +69,34 @@ $ bash -eo pipefail -c 'false | tee /dev/null || true; echo ${PIPESTATUS[0]}'  #
 
 **`pipefail` is not the variable — Rule 2 is right to add it. The variable is
 whether the pipeline's reader can exit before the producer finishes. Fix the
-shape, never the option.** That sentence is the arbitration between these two
-rules; without it they read as pulling opposite ways.
+shape, never the option.**
 
 `grep -q` exits at its **first** match; the producer, still writing, takes
 SIGPIPE and returns 141; `pipefail` promotes that to the pipeline's status. So
 `if ! producer | grep -q PAT` skips **because** the pattern matched. Any
-early-exiting reader does this — `head`, `sed …q`, `awk …exit`, `grep -m N`.
-Both fail directions occur in this tree: `grep -q` fails **open** (a gate
-skips), while `| head` fails **loud** (a bare 141 abort, no message) — see
-`scripts/analyze-streaming-diag.sh` and
-`tools/kmp-gate-spike/scripts/check-b-prime-isolation.sh`.
+early-exiting reader does this — `head`, `sed …q`, `awk …exit`, `grep -m N` —
+and both fail directions occur in this tree: `grep -q` fails **open** (a gate
+skips), while `| head` fails **loud** (a bare 141 abort, no message — see
+`scripts/analyze-streaming-diag.sh`).
 
 **Never certify a site safe by comparing an input size to a number.** Pipe
-capacity is a kernel property and differs between the macOS pre-commit hook and
-the ubuntu CI runner, so a threshold measured on one platform is not a fact
-about the other. Ask instead whether the producer can outrun the buffer *at
-all*.
+capacity is a kernel property differing between the macOS pre-commit hook and
+the ubuntu CI runner, so a threshold measured on one is not a fact about the
+other. Ask whether the producer can outrun the buffer *at all*.
 
 **Apply** — capture, then test the captured text:
 
 ```bash
-STAGED="$(git diff --cached --name-only)"
+STAGED="$(git -c core.quotepath=false diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
 if [ -z "$MATCHED" ]; then exit 0; fi
 ```
 
-Three things that look interchangeable and are not:
+`core.quotepath=false` is part of the shape, not tidiness: by default git
+octal-escapes a non-ASCII path **and** double-quotes it, so the quotes defeat a
+`^`- or `$`-anchored `TRIGGER` and the file walks past the gate.
+
+Four variants that look interchangeable and are not:
 
 - **Assigning to a variable first does NOT fix it.** SIGPIPE just moves from
   `git` to `printf`. Dropping `-q` is what fixes it.
@@ -112,16 +113,13 @@ Three things that look interchangeable and are not:
   early exit, which matters when draining the producer is expensive. It is not
   used in this tree, so the residual guard flags it — teach the guard first.
 
-Scope note: 18 sites across this repo's gate scripts, the `/release` archive
-check, two Claude Code hooks and one CI step — 14 under the local pre-commit
-hook, the rest not, so this is not a pre-commit-only concern. A bare `run:` step
-is `bash -e {0}` with no pipefail (Rule 2), which makes `ci.yml`'s four
-`printf … | grep -q` gating steps latent rather than live — adding `shell: bash`
-to one arms it, and three of them gate `ios` / `kmp` / `scenarios` on a file
-list that can reach 3000 names. Guarded by
-`scripts/tests/staged-trigger-pipefail-test.sh`, which scans shell scripts for
-the `grep -q` **shape** only: it does not parse workflow YAML, and it does not
-see the other early-exiting readers. Per-site fail directions: #1498.
+Scope: gate scripts, the `/release` archive check, two Claude Code hooks and one
+CI step — most, but not all, under the local pre-commit hook. A bare `run:` step
+has no pipefail (Rule 2), which leaves `ci.yml`'s `printf … | grep -q` gating
+steps latent rather than live — **adding `shell: bash` to one arms it**.
+Guarded by `scripts/tests/staged-trigger-pipefail-test.sh`, which scans shell
+scripts for the `grep -q` **shape** only: no workflow YAML, no other
+early-exiting readers. Per-site fail directions: #1498.
 
 ## Long-lived branch gating — two layers × two directions
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -587,7 +587,7 @@ jobs:
           # "no match", but exit >=2 means the pattern broke, and `|| true`
           # would print "OK: zero ollama symbols" for a check that never ran.
           # The capture (no `-q`) is already correct here and must stay — see
-          # .claude/rules/ci-workflows.md § "A `grep -q` under `pipefail`".
+          # .claude/rules/ci-workflows.md § "Rule 3".
           MATCHES=$(nm -a "$BIN" | xcrun swift-demangle | { grep -i ollama || [ $? -eq 1 ]; })
           if [ -n "$MATCHES" ]; then
             echo "::error::ollama symbols leaked into Release binary (ADR-005 §8)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -581,7 +581,14 @@ jobs:
           # Demangle before grep: failure output stays human-readable and the
           # check catches future helpers like OllamaClient / ollamaBridge that
           # a narrower match would miss. Matches ADR-005 §8.5.
-          MATCHES=$(nm -a "$BIN" | xcrun swift-demangle | grep -i ollama || true)
+          #
+          # `|| [ $? -eq 1 ]` rather than `|| true`, kept identical to the
+          # signed-archive copy in scripts/release.sh: exit 1 is grep's real
+          # "no match", but exit >=2 means the pattern broke, and `|| true`
+          # would print "OK: zero ollama symbols" for a check that never ran.
+          # The capture (no `-q`) is already correct here and must stay — see
+          # .claude/rules/ci-workflows.md § "A `grep -q` under `pipefail`".
+          MATCHES=$(nm -a "$BIN" | xcrun swift-demangle | { grep -i ollama || [ $? -eq 1 ]; })
           if [ -n "$MATCHES" ]; then
             echo "::error::ollama symbols leaked into Release binary (ADR-005 §8)"
             echo "$MATCHES"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,17 +146,15 @@ jobs:
             exit 0
           fi
           echo "Changed paths classified as: '${TOKENS:-<none>}'"
-          # ⚠️ Do NOT add `set -o pipefail` (or `shell: bash`) to this step, and
-          # do not add a workflow-level `defaults: run: shell:`. The absence of
-          # pipefail is LOAD-BEARING for the four `printf … | grep -q` gates in
-          # this job (this one plus `scenarios` and `kmp` below, and the Gradle
-          # one in `kmp-build-test`): with pipefail, `grep -q` exiting on an
-          # early match SIGPIPEs `printf`, the pipeline reports 141, and the
-          # `else` branch runs — here that emits `ios=false`, skipping
+          # ⚠️ Do NOT add `set -o pipefail` / `shell: bash` here, nor a
+          # workflow-level `defaults: run: shell:`. Its absence is LOAD-BEARING
+          # for the four `printf … | grep -q` gates in this job (this one,
+          # `scenarios`, `kmp`, and the Gradle one in `kmp-build-test`): with
+          # pipefail an early match SIGPIPEs `printf`, the pipeline reports 141,
+          # and the `else` branch runs — here emitting `ios=false`, which skips
           # lint-and-test and ui-test with every required check green. `$FILES`
-          # is the PR files API list, up to 3000 names, so it is well past any
-          # pipe buffer. `.claude/rules/ci-workflows.md` § "Rule 3"; the sweep
-          # that fixed the same shape across `scripts/**` is #1498.
+          # holds up to 3000 names, well past any pipe buffer.
+          # `.claude/rules/ci-workflows.md` § "Rule 3" (#1498).
           if printf '%s\n' "$TOKENS" | grep -qw build; then
             echo "ios=true" >> "$GITHUB_OUTPUT"
           else
@@ -593,12 +591,10 @@ jobs:
           # check catches future helpers like OllamaClient / ollamaBridge that
           # a narrower match would miss. Matches ADR-005 §8.5.
           #
-          # `|| [ $? -eq 1 ]` rather than `|| true`, kept identical to the
-          # signed-archive copy in scripts/release.sh: exit 1 is grep's real
-          # "no match", but exit >=2 means the pattern broke, and `|| true`
-          # would print "OK: zero ollama symbols" for a check that never ran.
-          # The capture (no `-q`) is already correct here and must stay — see
-          # .claude/rules/ci-workflows.md § "Rule 3".
+          # `|| [ $? -eq 1 ]` and not `|| true`: exit >=2 (broken pattern) must
+          # fail the step, not print "OK: zero ollama symbols" for a check that
+          # never ran. The capture (no `-q`) must stay; scripts/release.sh
+          # holds the same pair. `.claude/rules/ci-workflows.md` § "Rule 3".
           MATCHES=$(nm -a "$BIN" | xcrun swift-demangle | { grep -i ollama || [ $? -eq 1 ]; })
           if [ -n "$MATCHES" ]; then
             echo "::error::ollama symbols leaked into Release binary (ADR-005 §8)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,17 @@ jobs:
             exit 0
           fi
           echo "Changed paths classified as: '${TOKENS:-<none>}'"
+          # ⚠️ Do NOT add `set -o pipefail` (or `shell: bash`) to this step, and
+          # do not add a workflow-level `defaults: run: shell:`. The absence of
+          # pipefail is LOAD-BEARING for the four `printf … | grep -q` gates in
+          # this job (this one plus `scenarios` and `kmp` below, and the Gradle
+          # one in `kmp-build-test`): with pipefail, `grep -q` exiting on an
+          # early match SIGPIPEs `printf`, the pipeline reports 141, and the
+          # `else` branch runs — here that emits `ios=false`, skipping
+          # lint-and-test and ui-test with every required check green. `$FILES`
+          # is the PR files API list, up to 3000 names, so it is well past any
+          # pipe buffer. `.claude/rules/ci-workflows.md` § "Rule 3"; the sweep
+          # that fixed the same shape across `scripts/**` is #1498.
           if printf '%s\n' "$TOKENS" | grep -qw build; then
             echo "ios=true" >> "$GITHUB_OUTPUT"
           else

--- a/scripts/action-pin-consistency-precommit-gate.sh
+++ b/scripts/action-pin-consistency-precommit-gate.sh
@@ -35,8 +35,10 @@ cd "$ROOT"
 TRIGGER='(^\.github/workflows/.*\.ya?ml$)|(^scripts/check-action-pin-consistency\.py$)'
 
 # Capture, don't `| grep -q`: under `pipefail` an early match makes the
-# still-writing `git` SIGPIPE and the gate skips despite matching (#1498).
-# `|| [ $? -eq 1 ]` keeps exit 1 as "no match" and lets exit >=2 fail loudly.
+# still-writing producer SIGPIPE and the gate skips despite matching (#1498).
+# Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
+# below reinstates the defect on `printf` instead of on `git`. Rationale and
+# the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
 STAGED="$(git diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
 if [ -z "$MATCHED" ]; then

--- a/scripts/action-pin-consistency-precommit-gate.sh
+++ b/scripts/action-pin-consistency-precommit-gate.sh
@@ -34,7 +34,12 @@ cd "$ROOT"
 
 TRIGGER='(^\.github/workflows/.*\.ya?ml$)|(^scripts/check-action-pin-consistency\.py$)'
 
-if ! git diff --cached --name-only | grep -qE "$TRIGGER"; then
+# Capture, don't `| grep -q`: under `pipefail` an early match makes the
+# still-writing `git` SIGPIPE and the gate skips despite matching (#1498).
+# `|| [ $? -eq 1 ]` keeps exit 1 as "no match" and lets exit >=2 fail loudly.
+STAGED="$(git diff --cached --name-only)"
+MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
+if [ -z "$MATCHED" ]; then
   exit 0
 fi
 

--- a/scripts/action-pin-consistency-precommit-gate.sh
+++ b/scripts/action-pin-consistency-precommit-gate.sh
@@ -39,7 +39,7 @@ TRIGGER='(^\.github/workflows/.*\.ya?ml$)|(^scripts/check-action-pin-consistency
 # Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
 # below reinstates the defect on `printf` instead of on `git`. Rationale and
 # the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
-STAGED="$(git diff --cached --name-only)"
+STAGED="$(git -c core.quotepath=false diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
 if [ -z "$MATCHED" ]; then
   exit 0

--- a/scripts/action-pin-consistency-precommit-gate.sh
+++ b/scripts/action-pin-consistency-precommit-gate.sh
@@ -34,11 +34,9 @@ cd "$ROOT"
 
 TRIGGER='(^\.github/workflows/.*\.ya?ml$)|(^scripts/check-action-pin-consistency\.py$)'
 
-# Capture, don't `| grep -q`: under `pipefail` an early match makes the
-# still-writing producer SIGPIPE and the gate skips despite matching (#1498).
-# Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
-# below reinstates the defect on `printf` instead of on `git`. Rationale and
-# the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
+# Capture, don't `| grep -q` — `-q` exits early, the still-writing producer
+# SIGPIPEs, and `pipefail` turns a MATCH into a skip (#1498).
+# `.claude/rules/ci-workflows.md` § "Rule 3".
 STAGED="$(git -c core.quotepath=false diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
 if [ -z "$MATCHED" ]; then

--- a/scripts/adr023-port-coverage-precommit-gate.sh
+++ b/scripts/adr023-port-coverage-precommit-gate.sh
@@ -28,11 +28,9 @@ cd "$ROOT"
 
 TRIGGER='(^Pastura/Pastura/(Engine|LLM)/.*\.swift$)|(^shared/adr-023-port-ledger\.tsv$)|(^scripts/check-adr023-port-coverage\.py$)'
 
-# Capture, don't `| grep -q`: under `pipefail` an early match makes the
-# still-writing producer SIGPIPE and the gate skips despite matching (#1498).
-# Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
-# below reinstates the defect on `printf` instead of on `git`. Rationale and
-# the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
+# Capture, don't `| grep -q` — `-q` exits early, the still-writing producer
+# SIGPIPEs, and `pipefail` turns a MATCH into a skip (#1498).
+# `.claude/rules/ci-workflows.md` § "Rule 3".
 STAGED="$(git -c core.quotepath=false diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
 if [ -z "$MATCHED" ]; then

--- a/scripts/adr023-port-coverage-precommit-gate.sh
+++ b/scripts/adr023-port-coverage-precommit-gate.sh
@@ -28,7 +28,12 @@ cd "$ROOT"
 
 TRIGGER='(^Pastura/Pastura/(Engine|LLM)/.*\.swift$)|(^shared/adr-023-port-ledger\.tsv$)|(^scripts/check-adr023-port-coverage\.py$)'
 
-if ! git diff --cached --name-only | grep -qE "$TRIGGER"; then
+# Capture, don't `| grep -q`: under `pipefail` an early match makes the
+# still-writing `git` SIGPIPE and the gate skips despite matching (#1498).
+# `|| [ $? -eq 1 ]` keeps exit 1 as "no match" and lets exit >=2 fail loudly.
+STAGED="$(git diff --cached --name-only)"
+MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
+if [ -z "$MATCHED" ]; then
   exit 0
 fi
 

--- a/scripts/adr023-port-coverage-precommit-gate.sh
+++ b/scripts/adr023-port-coverage-precommit-gate.sh
@@ -29,8 +29,10 @@ cd "$ROOT"
 TRIGGER='(^Pastura/Pastura/(Engine|LLM)/.*\.swift$)|(^shared/adr-023-port-ledger\.tsv$)|(^scripts/check-adr023-port-coverage\.py$)'
 
 # Capture, don't `| grep -q`: under `pipefail` an early match makes the
-# still-writing `git` SIGPIPE and the gate skips despite matching (#1498).
-# `|| [ $? -eq 1 ]` keeps exit 1 as "no match" and lets exit >=2 fail loudly.
+# still-writing producer SIGPIPE and the gate skips despite matching (#1498).
+# Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
+# below reinstates the defect on `printf` instead of on `git`. Rationale and
+# the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
 STAGED="$(git diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
 if [ -z "$MATCHED" ]; then

--- a/scripts/adr023-port-coverage-precommit-gate.sh
+++ b/scripts/adr023-port-coverage-precommit-gate.sh
@@ -33,7 +33,7 @@ TRIGGER='(^Pastura/Pastura/(Engine|LLM)/.*\.swift$)|(^shared/adr-023-port-ledger
 # Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
 # below reinstates the defect on `printf` instead of on `git`. Rationale and
 # the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
-STAGED="$(git diff --cached --name-only)"
+STAGED="$(git -c core.quotepath=false diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
 if [ -z "$MATCHED" ]; then
   exit 0

--- a/scripts/analyze-streaming-diag.sh
+++ b/scripts/analyze-streaming-diag.sh
@@ -190,7 +190,7 @@ summarise() {
   if [ "$rcancelled_count" != "0" ]; then
     echo ""
     echo "  ⚠️  (d) is non-zero — investigate. First 5 occurrences:"
-    awk '
+    occ="$(awk '
       /streamTargetChange/ && /taskCancelled=true/ {
         for (i = 1; i <= NF; i++) {
           if ($i ~ /^visibleChars=/) { split($i, a, "="); vc = a[2] + 0 }
@@ -198,9 +198,23 @@ summarise() {
         }
         if (vc < nt) print
       }
-    ' "$log" | head -5 |
-      sed -E 's/^.*\[app\.pastura\.Pastura:StreamingDiag\] //' |
-      sed 's/^/    /'
+    ' "$log")"
+    # Capture, then `sed -n '1,5p'` — never `| head -5`. `head` closes the pipe
+    # after 5 lines, the still-writing `awk` takes SIGPIPE, and `set -o pipefail`
+    # (line 21) promotes that 141 to the pipeline's status, so this report
+    # aborted with a bare 141 and no message EXACTLY when the cancel-race it
+    # hunts reproduced heavily enough to fill the pipe buffer. Measured: 5000
+    # matching lines abort, 3 do not. Same class as #1498 with a different
+    # early-exiting reader; `tools/kmp-gate-spike/scripts/check-b-prime-isolation.sh`
+    # carries the other in-tree instance, and the residual guard in
+    # `scripts/tests/staged-trigger-pipefail-test.sh` scans for `grep -q` only,
+    # so it cannot see this shape — `.claude/rules/ci-workflows.md` § "Rule 3"
+    # is what covers the class. `sed -n` reads to EOF, so nothing SIGPIPEs.
+    if [ -n "$occ" ]; then
+      printf '%s\n' "$occ" | sed -n '1,5p' |
+        sed -E 's/^.*\[app\.pastura\.Pastura:StreamingDiag\] //' |
+        sed 's/^/    /'
+    fi
     echo "  → B5 residual: REPRODUCED (cancel-race surface still exercised)"
   else
     echo "  → B5 residual: clean (cancel-race surface not triggered this session)"

--- a/scripts/analyze-streaming-diag.sh
+++ b/scripts/analyze-streaming-diag.sh
@@ -199,17 +199,12 @@ summarise() {
         if (vc < nt) print
       }
     ' "$log")"
-    # Capture, then `sed -n '1,5p'` — never `| head -5`. `head` closes the pipe
-    # after 5 lines, the still-writing `awk` takes SIGPIPE, and `set -o pipefail`
-    # (line 21) promotes that 141 to the pipeline's status, so this report
-    # aborted with a bare 141 and no message EXACTLY when the cancel-race it
-    # hunts reproduced heavily enough to fill the pipe buffer. Measured: 5000
-    # matching lines abort, 3 do not. Same class as #1498 with a different
-    # early-exiting reader; `tools/kmp-gate-spike/scripts/check-b-prime-isolation.sh`
-    # carries the other in-tree instance, and the residual guard in
-    # `scripts/tests/staged-trigger-pipefail-test.sh` scans for `grep -q` only,
-    # so it cannot see this shape — `.claude/rules/ci-workflows.md` § "Rule 3"
-    # is what covers the class. `sed -n` reads to EOF, so nothing SIGPIPEs.
+    # Capture, then `sed -n '1,5p'` — never `| head -5`: `head` closes the pipe,
+    # the still-writing `awk` SIGPIPEs, and `pipefail` aborts this report with a
+    # bare 141 exactly when the cancel-race it hunts reproduced heavily. `sed -n`
+    # reads to EOF instead. The `grep -q` residual guard in
+    # `scripts/tests/staged-trigger-pipefail-test.sh` cannot see this reader;
+    # `.claude/rules/ci-workflows.md` § "Rule 3" covers the class (#1498).
     if [ -n "$occ" ]; then
       printf '%s\n' "$occ" | sed -n '1,5p' |
         sed -E 's/^.*\[app\.pastura\.Pastura:StreamingDiag\] //' |

--- a/scripts/blocklist-precommit-gate.sh
+++ b/scripts/blocklist-precommit-gate.sh
@@ -14,7 +14,12 @@ set -euo pipefail
 ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
 
-if ! git diff --cached --name-only | grep -qE '^(docs/blocklist/source[.]json|Pastura/Pastura/Resources/ContentBlocklist[.]json)$'; then
+# Capture, don't `| grep -q`: under `pipefail` an early match makes the
+# still-writing `git` SIGPIPE and the gate skips despite matching (#1498).
+# `|| [ $? -eq 1 ]` keeps exit 1 as "no match" and lets exit >=2 fail loudly.
+STAGED="$(git diff --cached --name-only)"
+MATCHED="$(printf '%s\n' "$STAGED" | { grep -E '^(docs/blocklist/source[.]json|Pastura/Pastura/Resources/ContentBlocklist[.]json)$' || [ $? -eq 1 ]; })"
+if [ -z "$MATCHED" ]; then
   exit 0
 fi
 

--- a/scripts/blocklist-precommit-gate.sh
+++ b/scripts/blocklist-precommit-gate.sh
@@ -15,8 +15,10 @@ ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
 
 # Capture, don't `| grep -q`: under `pipefail` an early match makes the
-# still-writing `git` SIGPIPE and the gate skips despite matching (#1498).
-# `|| [ $? -eq 1 ]` keeps exit 1 as "no match" and lets exit >=2 fail loudly.
+# still-writing producer SIGPIPE and the gate skips despite matching (#1498).
+# Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
+# below reinstates the defect on `printf` instead of on `git`. Rationale and
+# the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
 STAGED="$(git diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E '^(docs/blocklist/source[.]json|Pastura/Pastura/Resources/ContentBlocklist[.]json)$' || [ $? -eq 1 ]; })"
 if [ -z "$MATCHED" ]; then

--- a/scripts/blocklist-precommit-gate.sh
+++ b/scripts/blocklist-precommit-gate.sh
@@ -19,7 +19,7 @@ cd "$ROOT"
 # Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
 # below reinstates the defect on `printf` instead of on `git`. Rationale and
 # the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
-STAGED="$(git diff --cached --name-only)"
+STAGED="$(git -c core.quotepath=false diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E '^(docs/blocklist/source[.]json|Pastura/Pastura/Resources/ContentBlocklist[.]json)$' || [ $? -eq 1 ]; })"
 if [ -z "$MATCHED" ]; then
   exit 0

--- a/scripts/blocklist-precommit-gate.sh
+++ b/scripts/blocklist-precommit-gate.sh
@@ -14,11 +14,9 @@ set -euo pipefail
 ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
 
-# Capture, don't `| grep -q`: under `pipefail` an early match makes the
-# still-writing producer SIGPIPE and the gate skips despite matching (#1498).
-# Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
-# below reinstates the defect on `printf` instead of on `git`. Rationale and
-# the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
+# Capture, don't `| grep -q` — `-q` exits early, the still-writing producer
+# SIGPIPEs, and `pipefail` turns a MATCH into a skip (#1498).
+# `.claude/rules/ci-workflows.md` § "Rule 3".
 STAGED="$(git -c core.quotepath=false diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E '^(docs/blocklist/source[.]json|Pastura/Pastura/Resources/ContentBlocklist[.]json)$' || [ $? -eq 1 ]; })"
 if [ -z "$MATCHED" ]; then

--- a/scripts/gallery-precommit-gate.sh
+++ b/scripts/gallery-precommit-gate.sh
@@ -29,7 +29,7 @@ cd "$ROOT"
 # Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
 # below reinstates the defect on `printf` instead of on `git`. Rationale and
 # the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
-STAGED="$(git diff --cached --name-only)"
+STAGED="$(git -c core.quotepath=false diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E '^docs/gallery/.*\.(yaml|json)$' || [ $? -eq 1 ]; })"
 if [ -z "$MATCHED" ]; then
   exit 0

--- a/scripts/gallery-precommit-gate.sh
+++ b/scripts/gallery-precommit-gate.sh
@@ -24,7 +24,12 @@ cd "$ROOT"
 # docs/gallery/ now triggers; check-gallery-entry.sh ignores irrelevant
 # siblings. Non-manifest siblings (README.md,
 # shared-scenario-reports.md) stay untriggered — they are not .yaml/.json.
-if ! git diff --cached --name-only | grep -qE '^docs/gallery/.*\.(yaml|json)$'; then
+# Capture, don't `| grep -q`: under `pipefail` an early match makes the
+# still-writing `git` SIGPIPE and the gate skips despite matching (#1498).
+# `|| [ $? -eq 1 ]` keeps exit 1 as "no match" and lets exit >=2 fail loudly.
+STAGED="$(git diff --cached --name-only)"
+MATCHED="$(printf '%s\n' "$STAGED" | { grep -E '^docs/gallery/.*\.(yaml|json)$' || [ $? -eq 1 ]; })"
+if [ -z "$MATCHED" ]; then
   exit 0
 fi
 

--- a/scripts/gallery-precommit-gate.sh
+++ b/scripts/gallery-precommit-gate.sh
@@ -24,11 +24,9 @@ cd "$ROOT"
 # docs/gallery/ now triggers; check-gallery-entry.sh ignores irrelevant
 # siblings. Non-manifest siblings (README.md,
 # shared-scenario-reports.md) stay untriggered — they are not .yaml/.json.
-# Capture, don't `| grep -q`: under `pipefail` an early match makes the
-# still-writing producer SIGPIPE and the gate skips despite matching (#1498).
-# Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
-# below reinstates the defect on `printf` instead of on `git`. Rationale and
-# the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
+# Capture, don't `| grep -q` — `-q` exits early, the still-writing producer
+# SIGPIPEs, and `pipefail` turns a MATCH into a skip (#1498).
+# `.claude/rules/ci-workflows.md` § "Rule 3".
 STAGED="$(git -c core.quotepath=false diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E '^docs/gallery/.*\.(yaml|json)$' || [ $? -eq 1 ]; })"
 if [ -z "$MATCHED" ]; then

--- a/scripts/gallery-precommit-gate.sh
+++ b/scripts/gallery-precommit-gate.sh
@@ -25,8 +25,10 @@ cd "$ROOT"
 # siblings. Non-manifest siblings (README.md,
 # shared-scenario-reports.md) stay untriggered — they are not .yaml/.json.
 # Capture, don't `| grep -q`: under `pipefail` an early match makes the
-# still-writing `git` SIGPIPE and the gate skips despite matching (#1498).
-# `|| [ $? -eq 1 ]` keeps exit 1 as "no match" and lets exit >=2 fail loudly.
+# still-writing producer SIGPIPE and the gate skips despite matching (#1498).
+# Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
+# below reinstates the defect on `printf` instead of on `git`. Rationale and
+# the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
 STAGED="$(git diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E '^docs/gallery/.*\.(yaml|json)$' || [ $? -eq 1 ]; })"
 if [ -z "$MATCHED" ]; then

--- a/scripts/hooks/check-claude-md-modified.sh
+++ b/scripts/hooks/check-claude-md-modified.sh
@@ -81,6 +81,15 @@
 # to "no section", every other external command is guarded with
 # `2>/dev/null` / `|| true`, and the script ends on an unconditional `exit 0`.
 #
+# ONE deliberate exception since #1498: `changed_matches()` lets grep's exit >=2
+# (a broken pattern, not a no-match) reach `set -e` and abort. It is the only
+# path here that can exit non-zero. The trade is deliberate — the alternative,
+# `|| true`, maps a broken pattern onto "nothing matched", and section 1 then
+# emits "no agent-instruction file changed" and suppresses every later nudge,
+# which is the failure this hook exists to prevent. Reachability is near-nil:
+# both callers pass compile-time-literal patterns, and the `-Fx` caller cannot
+# produce a pattern error at all.
+#
 # Reads no stdin. Reference: PR #406/#407; .claude/rules/ in #1026;
 # trim + footprint sections in #1361.
 
@@ -341,11 +350,16 @@ always_loaded_bytes() {
     [ -n "$f" ] || continue
     case "$f" in
       .claude/rules/*)
-        # Capture rather than `| grep -q`, matching the rest of this file. Here
-        # the producer is bounded (`head -n 14` of a markdown frontmatter never
-        # fills a pipe buffer) so this one was not reachable, but leaving the
-        # shape behind would mean the #1498 residual guard needs an allow-list
-        # entry — and an allow-list is the thing that rots.
+        # Capture rather than `| grep -q`, as elsewhere in this file — but
+        # WITHOUT the `|| [ $? -eq 1 ]` group the other sites carry, because
+        # there is nothing for it to do here: this function runs under an
+        # explicit `set +e`, so grep's exit >=2 cannot abort anything, and it
+        # falls through to `fm=""` => the file counts as always-loaded, the
+        # conservative tier. The producer is bounded too (`head -n 14` of a
+        # markdown frontmatter never fills a pipe buffer), so this site was
+        # never reachable; it is swept only so the #1498 residual guard can
+        # assert a clean zero instead of carrying an allow-list entry — and an
+        # allow-list is the thing that rots.
         local fm
         fm=$(head -n 14 "$f" 2>/dev/null | grep '^paths:')
         [ -z "$fm" ] || continue

--- a/scripts/hooks/check-claude-md-modified.sh
+++ b/scripts/hooks/check-claude-md-modified.sh
@@ -90,13 +90,34 @@ cd "$(git rev-parse --show-toplevel)"
 
 CHANGED=$(git diff main...HEAD --name-only 2>/dev/null || true)
 
+# `$CHANGED` is a whole-branch file list, so it can outrun the pipe buffer.
+# Every match against it therefore CAPTURES rather than testing a `| grep -q`
+# pipeline's status: `grep -q` exits at its first hit, the still-writing
+# `printf` takes SIGPIPE, and `pipefail` (set above) promotes that to the
+# pipeline's status — an early match then reads exactly like no match (#1498).
+#
+# The two users below fall OPPOSITE ways, so neither direction is the safe one
+# to leave alone: section 1 would take its early-emit path and suppress every
+# later nudge, while section 2 would nudge about a mirror that was in fact
+# updated. Both are fixed the same way.
+#
+# `|| [ $? -eq 1 ]` and not `|| true`: exit 1 is grep's real "no match", exit
+# >=2 means the pattern broke. Under `set -e` the caller's assignment then
+# aborts the hook, which is loud, instead of reading as "nothing matched",
+# which is silent. The EMIT CONTRACT holds either way — every emit site is
+# downstream of these, so an abort produces no JSON rather than a partial one.
+changed_matches() { # $@ = grep args; echoes matching lines, empty when none
+  printf '%s\n' "$CHANGED" | { grep "$@" || [ $? -eq 1 ]; }
+}
+
 # --- 1. convention nudge ----------------------------------------------------
 # Early emit + exit. Mutually exclusive with sections 2-4 by construction: no
 # agent-instruction file changed => no mirror-relevant CLAUDE.md edit and zero
 # instruction growth, so nothing below could have fired anyway. Anchored to
 # match section 3's root-exact pathspec — a stray `docs/foo/CLAUDE.md` must
 # not silence this nudge while contributing nothing to the tier sums.
-if ! printf '%s\n' "$CHANGED" | grep -qE '^CLAUDE\.md$|^\.claude/(rules|agents)/'; then
+agent_instruction_files="$(changed_matches -E '^CLAUDE\.md$|^\.claude/(rules|agents)/')"
+if [ -z "$agent_instruction_files" ]; then
   jq -n '{
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
@@ -171,7 +192,8 @@ mirror_targets() {
 }
 
 MIRROR_MSG=""
-if printf '%s\n' "$CHANGED" | grep -Fxq 'CLAUDE.md'; then
+claude_md_changed="$(changed_matches -Fx 'CLAUDE.md')"
+if [ -n "$claude_md_changed" ]; then
   TARGETS=$(mirror_targets || true)
   TARGETS=$(printf '%s' "$TARGETS" | tr -s ' ' | sed 's/^ //; s/ $//')
   # Subtract mirror files already updated on this branch. A dual-mirror
@@ -181,7 +203,8 @@ if printf '%s\n' "$CHANGED" | grep -Fxq 'CLAUDE.md'; then
   # miss exactly the drift this hook exists to catch.
   REMAIN=""
   for f in $TARGETS; do
-    if ! printf '%s\n' "$CHANGED" | grep -Fxq "$f"; then
+    mirror_synced="$(changed_matches -Fx "$f")"
+    if [ -z "$mirror_synced" ]; then
       REMAIN="${REMAIN:+$REMAIN }$f"
     fi
   done
@@ -230,7 +253,17 @@ while IFS=$'\t' read -r added _removed path; do
       # we fail open to the stricter (always-loaded) tier — harmless, since a
       # deletion contributes 0 ADDED lines and the footprint gate below arms
       # only on added > 0.
-      if git show "HEAD:$path" 2>/dev/null | head -n 14 | grep -q '^paths:'; then
+      #
+      # `head -n 14` closes the pipe after 14 lines, so `git show` takes
+      # SIGPIPE on any rule file bigger than the pipe buffer — and under
+      # `pipefail` that would become the pipeline's status. Dropping `grep -q`
+      # is NOT what covers this: the `|| true` spanning the whole substitution
+      # is, and it also carries the deleted-path fail-open described above.
+      # Today no rule file is close (largest is ~41 KB), so this is hardening,
+      # not a live bug — but the margin shrinks as rules grow (#1498).
+      frontmatter="$(git show "HEAD:$path" 2>/dev/null | head -n 14 || true)"
+      paths_line="$(printf '%s\n' "$frontmatter" | { grep '^paths:' || [ $? -eq 1 ]; })"
+      if [ -n "$paths_line" ]; then
         tier="scoped"
       fi
       ;;
@@ -308,7 +341,14 @@ always_loaded_bytes() {
     [ -n "$f" ] || continue
     case "$f" in
       .claude/rules/*)
-        head -n 14 "$f" 2>/dev/null | grep -q '^paths:' && continue
+        # Capture rather than `| grep -q`, matching the rest of this file. Here
+        # the producer is bounded (`head -n 14` of a markdown frontmatter never
+        # fills a pipe buffer) so this one was not reachable, but leaving the
+        # shape behind would mean the #1498 residual guard needs an allow-list
+        # entry — and an allow-list is the thing that rots.
+        local fm
+        fm=$(head -n 14 "$f" 2>/dev/null | grep '^paths:')
+        [ -z "$fm" ] || continue
         ;;
     esac
     local n

--- a/scripts/hooks/check-claude-md-modified.sh
+++ b/scripts/hooks/check-claude-md-modified.sh
@@ -106,10 +106,14 @@ CHANGED=$(git diff main...HEAD --name-only 2>/dev/null || true)
 # `printf` takes SIGPIPE, and `pipefail` (set above) promotes that to the
 # pipeline's status — an early match then reads exactly like no match (#1498).
 #
-# The two users below fall OPPOSITE ways, so neither direction is the safe one
+# The two sections below fall OPPOSITE ways, so neither direction is the safe one
 # to leave alone: section 1 would take its early-emit path and suppress every
 # later nudge, while section 2 would nudge about a mirror that was in fact
 # updated. Both are fixed the same way.
+#
+# Dropping `-q` is what fixes it, NOT capturing into a variable first — the
+# producer here was already `printf`, and re-adding `-q` inside the helper
+# reinstates the defect unchanged. `.claude/rules/ci-workflows.md` § "Rule 3".
 #
 # `|| [ $? -eq 1 ]` and not `|| true`: exit 1 is grep's real "no match", exit
 # >=2 means the pattern broke. Under `set -e` the caller's assignment then

--- a/scripts/hooks/check-claude-md-modified.sh
+++ b/scripts/hooks/check-claude-md-modified.sh
@@ -82,14 +82,11 @@
 # `2>/dev/null` / `|| true`, and the script ends on an unconditional `exit 0`.
 #
 # ONE deliberate exception since #1498: `changed_matches()` lets grep's exit >=2
-# (a broken pattern, not a no-match) reach `set -e` and abort. It is the only
-# path here that can exit non-zero. The trade is deliberate — the alternative,
-# `|| true`, maps a broken pattern onto "nothing matched", and section 1 then
-# emits "no agent-instruction file changed" and suppresses every later nudge,
-# which is the failure this hook exists to prevent. Reachability is near-nil:
-# of the three callers, one passes a literal `-E` pattern and the other two use
-# `-Fx`, where no string is a bad pattern — which covers the one caller whose
-# pattern is runtime-derived (`$f`, from `mirror_targets`).
+# (a broken pattern) reach `set -e` and abort — the only path here that can exit
+# non-zero. `|| true` instead would map it onto "nothing matched", and section 1
+# would then suppress every later nudge, which is the failure this hook exists to
+# prevent. Reachability is near-nil: the one caller with a runtime-derived
+# pattern uses `-Fx`, where no string is a bad pattern.
 #
 # Reads no stdin. Reference: PR #406/#407; .claude/rules/ in #1026;
 # trim + footprint sections in #1361.
@@ -100,26 +97,18 @@ cd "$(git rev-parse --show-toplevel)"
 
 CHANGED=$(git diff main...HEAD --name-only 2>/dev/null || true)
 
-# `$CHANGED` is a whole-branch file list, so it can outrun the pipe buffer.
-# Every match against it therefore CAPTURES rather than testing a `| grep -q`
-# pipeline's status: `grep -q` exits at its first hit, the still-writing
-# `printf` takes SIGPIPE, and `pipefail` (set above) promotes that to the
-# pipeline's status — an early match then reads exactly like no match (#1498).
+# `$CHANGED` is a whole-branch file list, so it can outrun the pipe buffer:
+# every match against it CAPTURES, never `| grep -q`, since `-q` exits early,
+# the still-writing `printf` SIGPIPEs, and `pipefail` turns a MATCH into no
+# match. The two sections below fall OPPOSITE ways — section 1 would suppress
+# every later nudge, section 2 would nudge about an already-updated mirror — so
+# neither direction is the safe one to leave alone.
+# `.claude/rules/ci-workflows.md` § "Rule 3" (#1498).
 #
-# The two sections below fall OPPOSITE ways, so neither direction is the safe one
-# to leave alone: section 1 would take its early-emit path and suppress every
-# later nudge, while section 2 would nudge about a mirror that was in fact
-# updated. Both are fixed the same way.
-#
-# Dropping `-q` is what fixes it, NOT capturing into a variable first — the
-# producer here was already `printf`, and re-adding `-q` inside the helper
-# reinstates the defect unchanged. `.claude/rules/ci-workflows.md` § "Rule 3".
-#
-# `|| [ $? -eq 1 ]` and not `|| true`: exit 1 is grep's real "no match", exit
-# >=2 means the pattern broke. Under `set -e` the caller's assignment then
-# aborts the hook, which is loud, instead of reading as "nothing matched",
-# which is silent. The EMIT CONTRACT holds either way — every emit site is
-# downstream of these, so an abort produces no JSON rather than a partial one.
+# `|| [ $? -eq 1 ]` and not `|| true`: exit >=2 (broken pattern) aborts the hook
+# loudly rather than reading as "nothing matched". The EMIT CONTRACT holds
+# either way — every emit site is downstream, so an abort produces no JSON
+# rather than a partial one.
 changed_matches() { # $@ = grep args; echoes matching lines, empty when none
   printf '%s\n' "$CHANGED" | { grep "$@" || [ $? -eq 1 ]; }
 }
@@ -268,13 +257,11 @@ while IFS=$'\t' read -r added _removed path; do
       # deletion contributes 0 ADDED lines and the footprint gate below arms
       # only on added > 0.
       #
-      # `head -n 14` closes the pipe after 14 lines, so `git show` takes
-      # SIGPIPE on any rule file bigger than the pipe buffer — and under
-      # `pipefail` that would become the pipeline's status. Dropping `grep -q`
-      # is NOT what covers this: the `|| true` spanning the whole substitution
-      # is, and it also carries the deleted-path fail-open described above.
-      # Today no rule file is close (largest is ~41 KB), so this is hardening,
-      # not a live bug — but the margin shrinks as rules grow (#1498).
+      # `head -n 14` closes the pipe, so `git show` SIGPIPEs on a rule file
+      # bigger than the pipe buffer. What covers it is the `|| true` spanning
+      # the whole substitution (which also carries the deleted-path fail-open
+      # above), not the dropped `grep -q`. Hardening, not a live bug — no rule
+      # file is close today — but the margin shrinks as rules grow (#1498).
       frontmatter="$(git show "HEAD:$path" 2>/dev/null | head -n 14 || true)"
       paths_line="$(printf '%s\n' "$frontmatter" | { grep '^paths:' || [ $? -eq 1 ]; })"
       if [ -n "$paths_line" ]; then
@@ -355,16 +342,12 @@ always_loaded_bytes() {
     [ -n "$f" ] || continue
     case "$f" in
       .claude/rules/*)
-        # Capture rather than `| grep -q`, as elsewhere in this file — but
-        # WITHOUT the `|| [ $? -eq 1 ]` group the other sites carry, because
-        # there is nothing for it to do here: this function runs under an
-        # explicit `set +e`, so grep's exit >=2 cannot abort anything, and it
-        # falls through to `fm=""` => the file counts as always-loaded, the
-        # conservative tier. The producer is bounded too (`head -n 14` of a
-        # markdown frontmatter never fills a pipe buffer), so this site was
-        # never reachable; it is swept only so the #1498 residual guard can
-        # assert a clean zero instead of carrying an allow-list entry — and an
-        # allow-list is the thing that rots.
+        # Capture rather than `| grep -q`, as elsewhere here — but WITHOUT the
+        # `|| [ $? -eq 1 ]` group: this function runs under an explicit
+        # `set +e`, so exit >=2 aborts nothing and falls through to `fm=""`,
+        # i.e. the conservative always-loaded tier. The producer is bounded
+        # (`head -n 14`), so this site was never reachable; swept only so the
+        # #1498 residual guard needs no allow-list entry.
         local fm
         fm=$(head -n 14 "$f" 2>/dev/null | grep '^paths:')
         [ -z "$fm" ] || continue

--- a/scripts/hooks/check-claude-md-modified.sh
+++ b/scripts/hooks/check-claude-md-modified.sh
@@ -87,8 +87,9 @@
 # `|| true`, maps a broken pattern onto "nothing matched", and section 1 then
 # emits "no agent-instruction file changed" and suppresses every later nudge,
 # which is the failure this hook exists to prevent. Reachability is near-nil:
-# both callers pass compile-time-literal patterns, and the `-Fx` caller cannot
-# produce a pattern error at all.
+# of the three callers, one passes a literal `-E` pattern and the other two use
+# `-Fx`, where no string is a bad pattern — which covers the one caller whose
+# pattern is runtime-derived (`$f`, from `mirror_targets`).
 #
 # Reads no stdin. Reference: PR #406/#407; .claude/rules/ in #1026;
 # trim + footprint sections in #1361.

--- a/scripts/imagerenderer-injection-precommit-gate.sh
+++ b/scripts/imagerenderer-injection-precommit-gate.sh
@@ -34,11 +34,9 @@ cd "$ROOT"
 
 TRIGGER='(^Pastura/Pastura/.*\.swift$)|(^scripts/check_imagerenderer_injection\.py$)'
 
-# Capture, don't `| grep -q`: under `pipefail` an early match makes the
-# still-writing producer SIGPIPE and the gate skips despite matching (#1498).
-# Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
-# below reinstates the defect on `printf` instead of on `git`. Rationale and
-# the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
+# Capture, don't `| grep -q` — `-q` exits early, the still-writing producer
+# SIGPIPEs, and `pipefail` turns a MATCH into a skip (#1498).
+# `.claude/rules/ci-workflows.md` § "Rule 3".
 STAGED="$(git -c core.quotepath=false diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
 if [ -z "$MATCHED" ]; then

--- a/scripts/imagerenderer-injection-precommit-gate.sh
+++ b/scripts/imagerenderer-injection-precommit-gate.sh
@@ -34,7 +34,12 @@ cd "$ROOT"
 
 TRIGGER='(^Pastura/Pastura/.*\.swift$)|(^scripts/check_imagerenderer_injection\.py$)'
 
-if ! git diff --cached --name-only | grep -qE "$TRIGGER"; then
+# Capture, don't `| grep -q`: under `pipefail` an early match makes the
+# still-writing `git` SIGPIPE and the gate skips despite matching (#1498).
+# `|| [ $? -eq 1 ]` keeps exit 1 as "no match" and lets exit >=2 fail loudly.
+STAGED="$(git diff --cached --name-only)"
+MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
+if [ -z "$MATCHED" ]; then
   exit 0
 fi
 

--- a/scripts/imagerenderer-injection-precommit-gate.sh
+++ b/scripts/imagerenderer-injection-precommit-gate.sh
@@ -35,8 +35,10 @@ cd "$ROOT"
 TRIGGER='(^Pastura/Pastura/.*\.swift$)|(^scripts/check_imagerenderer_injection\.py$)'
 
 # Capture, don't `| grep -q`: under `pipefail` an early match makes the
-# still-writing `git` SIGPIPE and the gate skips despite matching (#1498).
-# `|| [ $? -eq 1 ]` keeps exit 1 as "no match" and lets exit >=2 fail loudly.
+# still-writing producer SIGPIPE and the gate skips despite matching (#1498).
+# Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
+# below reinstates the defect on `printf` instead of on `git`. Rationale and
+# the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
 STAGED="$(git diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
 if [ -z "$MATCHED" ]; then

--- a/scripts/imagerenderer-injection-precommit-gate.sh
+++ b/scripts/imagerenderer-injection-precommit-gate.sh
@@ -39,7 +39,7 @@ TRIGGER='(^Pastura/Pastura/.*\.swift$)|(^scripts/check_imagerenderer_injection\.
 # Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
 # below reinstates the defect on `printf` instead of on `git`. Rationale and
 # the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
-STAGED="$(git diff --cached --name-only)"
+STAGED="$(git -c core.quotepath=false diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
 if [ -z "$MATCHED" ]; then
   exit 0

--- a/scripts/kmp-status-precommit-gate.sh
+++ b/scripts/kmp-status-precommit-gate.sh
@@ -32,7 +32,12 @@ cd "$ROOT"
 
 TRIGGER='(^docs/kmp-migration-status\.md$)|(^shared/adr-023-port-ledger\.tsv$)|(^shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/.*\.kt$)|(^scripts/check-kmp-status\.py$)'
 
-if ! git diff --cached --name-only | grep -qE "$TRIGGER"; then
+# Capture, don't `| grep -q`: under `pipefail` an early match makes the
+# still-writing `git` SIGPIPE and the gate skips despite matching (#1498).
+# `|| [ $? -eq 1 ]` keeps exit 1 as "no match" and lets exit >=2 fail loudly.
+STAGED="$(git diff --cached --name-only)"
+MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
+if [ -z "$MATCHED" ]; then
   exit 0
 fi
 

--- a/scripts/kmp-status-precommit-gate.sh
+++ b/scripts/kmp-status-precommit-gate.sh
@@ -33,8 +33,10 @@ cd "$ROOT"
 TRIGGER='(^docs/kmp-migration-status\.md$)|(^shared/adr-023-port-ledger\.tsv$)|(^shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/.*\.kt$)|(^scripts/check-kmp-status\.py$)'
 
 # Capture, don't `| grep -q`: under `pipefail` an early match makes the
-# still-writing `git` SIGPIPE and the gate skips despite matching (#1498).
-# `|| [ $? -eq 1 ]` keeps exit 1 as "no match" and lets exit >=2 fail loudly.
+# still-writing producer SIGPIPE and the gate skips despite matching (#1498).
+# Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
+# below reinstates the defect on `printf` instead of on `git`. Rationale and
+# the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
 STAGED="$(git diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
 if [ -z "$MATCHED" ]; then

--- a/scripts/kmp-status-precommit-gate.sh
+++ b/scripts/kmp-status-precommit-gate.sh
@@ -32,11 +32,9 @@ cd "$ROOT"
 
 TRIGGER='(^docs/kmp-migration-status\.md$)|(^shared/adr-023-port-ledger\.tsv$)|(^shared/engine/src/commonMain/kotlin/com/pastura/engine/Phases/.*\.kt$)|(^scripts/check-kmp-status\.py$)'
 
-# Capture, don't `| grep -q`: under `pipefail` an early match makes the
-# still-writing producer SIGPIPE and the gate skips despite matching (#1498).
-# Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
-# below reinstates the defect on `printf` instead of on `git`. Rationale and
-# the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
+# Capture, don't `| grep -q` — `-q` exits early, the still-writing producer
+# SIGPIPEs, and `pipefail` turns a MATCH into a skip (#1498).
+# `.claude/rules/ci-workflows.md` § "Rule 3".
 STAGED="$(git -c core.quotepath=false diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
 if [ -z "$MATCHED" ]; then

--- a/scripts/kmp-status-precommit-gate.sh
+++ b/scripts/kmp-status-precommit-gate.sh
@@ -37,7 +37,7 @@ TRIGGER='(^docs/kmp-migration-status\.md$)|(^shared/adr-023-port-ledger\.tsv$)|(
 # Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
 # below reinstates the defect on `printf` instead of on `git`. Rationale and
 # the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
-STAGED="$(git diff --cached --name-only)"
+STAGED="$(git -c core.quotepath=false diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
 if [ -z "$MATCHED" ]; then
   exit 0

--- a/scripts/mossink-wash-membership-precommit-gate.sh
+++ b/scripts/mossink-wash-membership-precommit-gate.sh
@@ -34,7 +34,7 @@ TRIGGER='(^docs/design/design-system\.md$)|(^Pastura/PasturaTests/Views/DesignTo
 # Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
 # below reinstates the defect on `printf` instead of on `git`. Rationale and
 # the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
-STAGED="$(git diff --cached --name-only)"
+STAGED="$(git -c core.quotepath=false diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
 if [ -z "$MATCHED" ]; then
   exit 0

--- a/scripts/mossink-wash-membership-precommit-gate.sh
+++ b/scripts/mossink-wash-membership-precommit-gate.sh
@@ -30,8 +30,10 @@ cd "$ROOT"
 TRIGGER='(^docs/design/design-system\.md$)|(^Pastura/PasturaTests/Views/DesignTokensTests\+MossInkAsWashLabel\.swift$)|(^scripts/check-mossink-wash-membership\.py$)'
 
 # Capture, don't `| grep -q`: under `pipefail` an early match makes the
-# still-writing `git` SIGPIPE and the gate skips despite matching (#1498).
-# `|| [ $? -eq 1 ]` keeps exit 1 as "no match" and lets exit >=2 fail loudly.
+# still-writing producer SIGPIPE and the gate skips despite matching (#1498).
+# Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
+# below reinstates the defect on `printf` instead of on `git`. Rationale and
+# the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
 STAGED="$(git diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
 if [ -z "$MATCHED" ]; then

--- a/scripts/mossink-wash-membership-precommit-gate.sh
+++ b/scripts/mossink-wash-membership-precommit-gate.sh
@@ -29,7 +29,12 @@ cd "$ROOT"
 
 TRIGGER='(^docs/design/design-system\.md$)|(^Pastura/PasturaTests/Views/DesignTokensTests\+MossInkAsWashLabel\.swift$)|(^scripts/check-mossink-wash-membership\.py$)'
 
-if ! git diff --cached --name-only | grep -qE "$TRIGGER"; then
+# Capture, don't `| grep -q`: under `pipefail` an early match makes the
+# still-writing `git` SIGPIPE and the gate skips despite matching (#1498).
+# `|| [ $? -eq 1 ]` keeps exit 1 as "no match" and lets exit >=2 fail loudly.
+STAGED="$(git diff --cached --name-only)"
+MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
+if [ -z "$MATCHED" ]; then
   exit 0
 fi
 

--- a/scripts/mossink-wash-membership-precommit-gate.sh
+++ b/scripts/mossink-wash-membership-precommit-gate.sh
@@ -29,11 +29,9 @@ cd "$ROOT"
 
 TRIGGER='(^docs/design/design-system\.md$)|(^Pastura/PasturaTests/Views/DesignTokensTests\+MossInkAsWashLabel\.swift$)|(^scripts/check-mossink-wash-membership\.py$)'
 
-# Capture, don't `| grep -q`: under `pipefail` an early match makes the
-# still-writing producer SIGPIPE and the gate skips despite matching (#1498).
-# Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
-# below reinstates the defect on `printf` instead of on `git`. Rationale and
-# the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
+# Capture, don't `| grep -q` — `-q` exits early, the still-writing producer
+# SIGPIPEs, and `pipefail` turns a MATCH into a skip (#1498).
+# `.claude/rules/ci-workflows.md` § "Rule 3".
 STAGED="$(git -c core.quotepath=false diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
 if [ -z "$MATCHED" ]; then

--- a/scripts/navigation-map-precommit-gate.sh
+++ b/scripts/navigation-map-precommit-gate.sh
@@ -45,7 +45,12 @@ cd "$ROOT"
 # that directory is intentionally flat, this one is not.
 TRIGGER='(^Pastura/Pastura/(Views|App)/.*\.swift$)|(^Pastura/PasturaUITests/ScreenshotTourTests\.swift$)|(^scripts/generate-navigation-map\.py$)|(^docs/design/navigation-map\.md$)'
 
-if ! git diff --cached --name-only | grep -qE "$TRIGGER"; then
+# Capture, don't `| grep -q`: under `pipefail` an early match makes the
+# still-writing `git` SIGPIPE and the gate skips despite matching (#1498).
+# `|| [ $? -eq 1 ]` keeps exit 1 as "no match" and lets exit >=2 fail loudly.
+STAGED="$(git diff --cached --name-only)"
+MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
+if [ -z "$MATCHED" ]; then
   exit 0
 fi
 

--- a/scripts/navigation-map-precommit-gate.sh
+++ b/scripts/navigation-map-precommit-gate.sh
@@ -45,11 +45,9 @@ cd "$ROOT"
 # that directory is intentionally flat, this one is not.
 TRIGGER='(^Pastura/Pastura/(Views|App)/.*\.swift$)|(^Pastura/PasturaUITests/ScreenshotTourTests\.swift$)|(^scripts/generate-navigation-map\.py$)|(^docs/design/navigation-map\.md$)'
 
-# Capture, don't `| grep -q`: under `pipefail` an early match makes the
-# still-writing producer SIGPIPE and the gate skips despite matching (#1498).
-# Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
-# below reinstates the defect on `printf` instead of on `git`. Rationale and
-# the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
+# Capture, don't `| grep -q` — `-q` exits early, the still-writing producer
+# SIGPIPEs, and `pipefail` turns a MATCH into a skip (#1498).
+# `.claude/rules/ci-workflows.md` § "Rule 3".
 STAGED="$(git -c core.quotepath=false diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
 if [ -z "$MATCHED" ]; then

--- a/scripts/navigation-map-precommit-gate.sh
+++ b/scripts/navigation-map-precommit-gate.sh
@@ -50,7 +50,7 @@ TRIGGER='(^Pastura/Pastura/(Views|App)/.*\.swift$)|(^Pastura/PasturaUITests/Scre
 # Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
 # below reinstates the defect on `printf` instead of on `git`. Rationale and
 # the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
-STAGED="$(git diff --cached --name-only)"
+STAGED="$(git -c core.quotepath=false diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
 if [ -z "$MATCHED" ]; then
   exit 0

--- a/scripts/navigation-map-precommit-gate.sh
+++ b/scripts/navigation-map-precommit-gate.sh
@@ -46,8 +46,10 @@ cd "$ROOT"
 TRIGGER='(^Pastura/Pastura/(Views|App)/.*\.swift$)|(^Pastura/PasturaUITests/ScreenshotTourTests\.swift$)|(^scripts/generate-navigation-map\.py$)|(^docs/design/navigation-map\.md$)'
 
 # Capture, don't `| grep -q`: under `pipefail` an early match makes the
-# still-writing `git` SIGPIPE and the gate skips despite matching (#1498).
-# `|| [ $? -eq 1 ]` keeps exit 1 as "no match" and lets exit >=2 fail loudly.
+# still-writing producer SIGPIPE and the gate skips despite matching (#1498).
+# Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
+# below reinstates the defect on `printf` instead of on `git`. Rationale and
+# the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
 STAGED="$(git diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
 if [ -z "$MATCHED" ]; then

--- a/scripts/outputschema-serialization-precommit-gate.sh
+++ b/scripts/outputschema-serialization-precommit-gate.sh
@@ -39,7 +39,7 @@ TRIGGER='(^Pastura/Pastura/.*\.swift$)|(^shared/.*\.kt$)|(^scripts/check-outputs
 # Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
 # below reinstates the defect on `printf` instead of on `git`. Rationale and
 # the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
-STAGED="$(git diff --cached --name-only)"
+STAGED="$(git -c core.quotepath=false diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
 if [ -z "$MATCHED" ]; then
   exit 0

--- a/scripts/outputschema-serialization-precommit-gate.sh
+++ b/scripts/outputschema-serialization-precommit-gate.sh
@@ -34,11 +34,9 @@ cd "$ROOT"
 # safer than trying to reproduce the *Main source-set glob in a regex.
 TRIGGER='(^Pastura/Pastura/.*\.swift$)|(^shared/.*\.kt$)|(^scripts/check-outputschema-serialization-gate\.py$)'
 
-# Capture, don't `| grep -q`: under `pipefail` an early match makes the
-# still-writing producer SIGPIPE and the gate skips despite matching (#1498).
-# Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
-# below reinstates the defect on `printf` instead of on `git`. Rationale and
-# the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
+# Capture, don't `| grep -q` — `-q` exits early, the still-writing producer
+# SIGPIPEs, and `pipefail` turns a MATCH into a skip (#1498).
+# `.claude/rules/ci-workflows.md` § "Rule 3".
 STAGED="$(git -c core.quotepath=false diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
 if [ -z "$MATCHED" ]; then

--- a/scripts/outputschema-serialization-precommit-gate.sh
+++ b/scripts/outputschema-serialization-precommit-gate.sh
@@ -34,7 +34,12 @@ cd "$ROOT"
 # safer than trying to reproduce the *Main source-set glob in a regex.
 TRIGGER='(^Pastura/Pastura/.*\.swift$)|(^shared/.*\.kt$)|(^scripts/check-outputschema-serialization-gate\.py$)'
 
-if ! git diff --cached --name-only | grep -qE "$TRIGGER"; then
+# Capture, don't `| grep -q`: under `pipefail` an early match makes the
+# still-writing `git` SIGPIPE and the gate skips despite matching (#1498).
+# `|| [ $? -eq 1 ]` keeps exit 1 as "no match" and lets exit >=2 fail loudly.
+STAGED="$(git diff --cached --name-only)"
+MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
+if [ -z "$MATCHED" ]; then
   exit 0
 fi
 

--- a/scripts/outputschema-serialization-precommit-gate.sh
+++ b/scripts/outputschema-serialization-precommit-gate.sh
@@ -35,8 +35,10 @@ cd "$ROOT"
 TRIGGER='(^Pastura/Pastura/.*\.swift$)|(^shared/.*\.kt$)|(^scripts/check-outputschema-serialization-gate\.py$)'
 
 # Capture, don't `| grep -q`: under `pipefail` an early match makes the
-# still-writing `git` SIGPIPE and the gate skips despite matching (#1498).
-# `|| [ $? -eq 1 ]` keeps exit 1 as "no match" and lets exit >=2 fail loudly.
+# still-writing producer SIGPIPE and the gate skips despite matching (#1498).
+# Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
+# below reinstates the defect on `printf` instead of on `git`. Rationale and
+# the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
 STAGED="$(git diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
 if [ -z "$MATCHED" ]; then

--- a/scripts/p8-precommit-gate.sh
+++ b/scripts/p8-precommit-gate.sh
@@ -24,11 +24,17 @@ cd "$ROOT"
 # repo root. A key under keys/ or fastlane/ must still be caught.
 #
 # Capture the match; never `| grep -q`. `grep -q` exits at its first hit, the
-# still-writing `git` takes SIGPIPE and returns 141, and `pipefail` (set above)
+# still-writing producer takes SIGPIPE and returns 141 (in the pre-fix shape
+# that producer was `git`; it is `printf` now), and `pipefail` (set above)
 # promotes that to the pipeline's status — so a key staged alongside enough
 # other paths to outrun the pipe buffer read as "no key" and this gate exited
 # 0. Measured: a 91,710-byte staged list with the key sorted first let the key
 # through, while the same key on a short list was caught (#1498).
+#
+# Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
+# below reinstates the defect on `printf` instead of on `git`. The other gates
+# carry a short form of this note; `.claude/rules/ci-workflows.md` § "Rule 3"
+# is the canonical account.
 #
 # `|| [ $? -eq 1 ]` and not `|| true`: exit 1 is grep's real "no match", but
 # exit >=2 means the pattern itself broke, and a blanket `|| true` would map

--- a/scripts/p8-precommit-gate.sh
+++ b/scripts/p8-precommit-gate.sh
@@ -23,31 +23,19 @@ cd "$ROOT"
 # repo-relative paths, so anchor the regex to the extension, not the
 # repo root. A key under keys/ or fastlane/ must still be caught.
 #
-# Capture the match; never `| grep -q`. `grep -q` exits at its first hit, the
-# still-writing producer takes SIGPIPE and returns 141, and `pipefail` (set
-# above) promotes that to the pipeline's status — so a key staged alongside enough
-# other paths to outrun the pipe buffer read as "no key" and this gate exited
-# 0. Measured: a 91,710-byte staged list with the key sorted first let the key
-# through, while the same key on a short list was caught (#1498).
+# Capture, don't `| grep -q` — `-q` exits early, the still-writing producer
+# SIGPIPEs, and `pipefail` turns a MATCH into a skip, so a key staged behind
+# enough other paths committed silently (#1498).
+# `.claude/rules/ci-workflows.md` § "Rule 3".
 #
-# Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
-# below reinstates the defect on `printf` instead of on `git`. The other gates
-# carry a short form of this note; `.claude/rules/ci-workflows.md` § "Rule 3"
-# is the canonical account.
+# `|| [ $? -eq 1 ]` and not `|| true`: exit >=2 (broken pattern) must refuse
+# the commit, not map back onto "no key".
 #
-# `|| [ $? -eq 1 ]` and not `|| true`: exit 1 is grep's real "no match", but
-# exit >=2 means the pattern itself broke, and a blanket `|| true` would map
-# that back to "no key" — reopening this same silent skip through a different
-# door. Letting it fail the assignment under `set -e` refuses the commit
-# instead, which is the safe direction for a secret gate.
-#
-# `-c core.quotepath=false` is load-bearing, not tidiness — a second fail-open
-# of the same shape sits at this one line. With the default, git octal-escapes
-# a non-ASCII path AND wraps it in double quotes, so the trailing `"` defeats
-# the `\.p8$` anchor and a key named in any non-ASCII script walks past this
-# gate. `scripts/git-hooks/pre-commit` passes the same flag at its own call
-# site for the mirror-image reason (a `^`-anchored prefix). All 13 staged-list
-# producers in scripts/ carry it; A13 in the regression test is the arm.
+# `-c core.quotepath=false` is load-bearing — a second fail-open at this same
+# line. By default git octal-escapes a non-ASCII path AND double-quotes it, so
+# the trailing `"` defeats the `\.p8$` anchor. `scripts/git-hooks/pre-commit`
+# passes it for the mirror-image reason (a `^`-anchored prefix); arm A13 in the
+# regression test covers it.
 STAGED="$(git -c core.quotepath=false diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E '\.p8$' || [ $? -eq 1 ]; })"
 if [ -n "$MATCHED" ]; then

--- a/scripts/p8-precommit-gate.sh
+++ b/scripts/p8-precommit-gate.sh
@@ -24,9 +24,8 @@ cd "$ROOT"
 # repo root. A key under keys/ or fastlane/ must still be caught.
 #
 # Capture the match; never `| grep -q`. `grep -q` exits at its first hit, the
-# still-writing producer takes SIGPIPE and returns 141 (in the pre-fix shape
-# that producer was `git`; it is `printf` now), and `pipefail` (set above)
-# promotes that to the pipeline's status — so a key staged alongside enough
+# still-writing producer takes SIGPIPE and returns 141, and `pipefail` (set
+# above) promotes that to the pipeline's status — so a key staged alongside enough
 # other paths to outrun the pipe buffer read as "no key" and this gate exited
 # 0. Measured: a 91,710-byte staged list with the key sorted first let the key
 # through, while the same key on a short list was caught (#1498).

--- a/scripts/p8-precommit-gate.sh
+++ b/scripts/p8-precommit-gate.sh
@@ -40,7 +40,15 @@ cd "$ROOT"
 # that back to "no key" — reopening this same silent skip through a different
 # door. Letting it fail the assignment under `set -e` refuses the commit
 # instead, which is the safe direction for a secret gate.
-STAGED="$(git diff --cached --name-only)"
+#
+# `-c core.quotepath=false` is load-bearing, not tidiness — a second fail-open
+# of the same shape sits at this one line. With the default, git octal-escapes
+# a non-ASCII path AND wraps it in double quotes, so the trailing `"` defeats
+# the `\.p8$` anchor and a key named in any non-ASCII script walks past this
+# gate. `scripts/git-hooks/pre-commit` passes the same flag at its own call
+# site for the mirror-image reason (a `^`-anchored prefix). All 13 staged-list
+# producers in scripts/ carry it; A13 in the regression test is the arm.
+STAGED="$(git -c core.quotepath=false diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E '\.p8$' || [ $? -eq 1 ]; })"
 if [ -n "$MATCHED" ]; then
   {

--- a/scripts/p8-precommit-gate.sh
+++ b/scripts/p8-precommit-gate.sh
@@ -22,7 +22,22 @@ cd "$ROOT"
 # Match `.p8` at any path depth — `git diff --cached --name-only` emits
 # repo-relative paths, so anchor the regex to the extension, not the
 # repo root. A key under keys/ or fastlane/ must still be caught.
-if git diff --cached --name-only | grep -qE '\.p8$'; then
+#
+# Capture the match; never `| grep -q`. `grep -q` exits at its first hit, the
+# still-writing `git` takes SIGPIPE and returns 141, and `pipefail` (set above)
+# promotes that to the pipeline's status — so a key staged alongside enough
+# other paths to outrun the pipe buffer read as "no key" and this gate exited
+# 0. Measured: a 91,710-byte staged list with the key sorted first let the key
+# through, while the same key on a short list was caught (#1498).
+#
+# `|| [ $? -eq 1 ]` and not `|| true`: exit 1 is grep's real "no match", but
+# exit >=2 means the pattern itself broke, and a blanket `|| true` would map
+# that back to "no key" — reopening this same silent skip through a different
+# door. Letting it fail the assignment under `set -e` refuses the commit
+# instead, which is the safe direction for a secret gate.
+STAGED="$(git diff --cached --name-only)"
+MATCHED="$(printf '%s\n' "$STAGED" | { grep -E '\.p8$' || [ $? -eq 1 ]; })"
+if [ -n "$MATCHED" ]; then
   {
     echo 'Refusing to commit a *.p8 file — App Store Connect / APNs private'
     echo 'keys must never enter the repo. Store the key outside the tree'

--- a/scripts/precommit-gate-classify.sh
+++ b/scripts/precommit-gate-classify.sh
@@ -36,6 +36,14 @@ set -euo pipefail
 # Drop blank lines so an empty changeset (a lone trailing newline) does
 # not read as a single empty, non-safe path. `|| true` absorbs grep's
 # exit-1 on all-blank input under `set -e`.
+#
+# `|| true` and not the `|| [ $? -eq 1 ]` group the two classifications below
+# use — deliberate, and the difference is not stylistic. This grep has no `-q`,
+# so it drains stdin and nothing can SIGPIPE; and `'^[[:space:]]*$'` is a fixed
+# literal that cannot become a bad pattern, so there is no exit >=2 to
+# discriminate. What `|| true` would hide here is a read error on stdin, which
+# the caller already owns: the pre-commit hook feeds this from a variable it
+# captured itself, and ci.yml wraps the whole call in `if ! TOKENS=$(...)`.
 staged="$(grep -v '^[[:space:]]*$' || true)"
 
 tokens=""

--- a/scripts/precommit-gate-classify.sh
+++ b/scripts/precommit-gate-classify.sh
@@ -37,42 +37,25 @@ set -euo pipefail
 # not read as a single empty, non-safe path. `|| true` absorbs grep's
 # exit-1 on all-blank input under `set -e`.
 #
-# `|| true` and not the `|| [ $? -eq 1 ]` group the two classifications below
-# use — deliberate, and the difference is not stylistic. This grep has no `-q`,
-# so it drains stdin and nothing can SIGPIPE; and `'^[[:space:]]*$'` is a fixed
-# literal that cannot become a bad pattern, so there is no exit >=2 to
-# discriminate. What `|| true` would hide here is a read error on stdin, which
-# the caller already owns: the pre-commit hook feeds this from a variable it
-# captured itself, and ci.yml wraps the whole call in `if ! TOKENS=$(...)`.
+# `|| true` here, not the `|| [ $? -eq 1 ]` group the classifications below use:
+# this grep has no `-q` so nothing can SIGPIPE, and its pattern is a fixed
+# literal that cannot produce grep's exit >=2.
 staged="$(grep -v '^[[:space:]]*$' || true)"
 
 tokens=""
 
-# Both classifications below capture the match instead of testing a `grep -q`
-# pipeline's status, and the difference is load-bearing rather than stylistic.
-# `grep -q` exits at its first hit; the still-writing `printf` takes SIGPIPE and
-# returns 141; `pipefail` (set above) promotes that to the pipeline's status.
-# So on a changeset whose name list outruns the pipe buffer, with a matching
-# path near the front, BOTH tokens silently dropped: measured, a 92,623-byte
-# list led by a .swift file classified as `` where a short list of the same
-# shape classified as `lint build` (#1498).
+# Both classifications below capture, never `| grep -q` — `-q` exits early, the
+# still-writing `printf` SIGPIPEs, and `pipefail` turns a MATCH into no match.
+# Dropping every token is this script's worst case reached from inside: it
+# disarms `swiftlint --strict` + `xcodebuild build` in the pre-commit hook and,
+# via ci.yml's `changes` job deriving `ios` from `build`, skips lint-and-test
+# and ui-test with every required check green. Neither fail-safe ci.yml
+# documents catches it — the file list is not empty, and this script exits 0,
+# it just prints nothing. `.claude/rules/ci-workflows.md` § "Rule 3" (#1498).
 #
-# That is the "worst case" this script's header names, reached from inside. It
-# disarms `swiftlint --strict` and `xcodebuild build` in the pre-commit hook,
-# and — because .github/workflows/ci.yml's `changes` job derives `ios` from the
-# `build` token — skips lint-and-test and ui-test on CI with every required
-# check green. Both fail-safes ci.yml documents miss it: the file list is not
-# empty, and this script exits 0, it just prints nothing.
-#
-# Dropping `-q` is what fixes it, NOT capturing into a variable first — the
-# producer here was already `printf`, and re-adding `-q` below reinstates the
-# defect unchanged. `.claude/rules/ci-workflows.md` § "Rule 3".
-#
-# `|| [ $? -eq 1 ]` and not `|| true`: exit 1 is grep's real "no match", exit
-# >=2 means the pattern broke. `|| true` would map a broken pattern to "no
-# match" — i.e. to no tokens — which is the same silent disarming. Failing the
-# assignment under `set -e` instead makes ci.yml's `if ! TOKENS=$(...)`
-# fail-safe fire and default to the full suite.
+# `|| [ $? -eq 1 ]` and not `|| true`: on exit >=2 (broken pattern) the failed
+# assignment fires ci.yml's `if ! TOKENS=$(...)` fail-safe and defaults to the
+# full suite, instead of silently emitting no tokens.
 
 # `lint`: any Swift source, or the SwiftLint config (at any depth).
 lint_match="$(printf '%s\n' "$staged" | { grep -E '(\.swift$|(^|/)\.swiftlint\.yml$)' || [ $? -eq 1 ]; })"

--- a/scripts/precommit-gate-classify.sh
+++ b/scripts/precommit-gate-classify.sh
@@ -40,8 +40,31 @@ staged="$(grep -v '^[[:space:]]*$' || true)"
 
 tokens=""
 
+# Both classifications below capture the match instead of testing a `grep -q`
+# pipeline's status, and the difference is load-bearing rather than stylistic.
+# `grep -q` exits at its first hit; the still-writing `printf` takes SIGPIPE and
+# returns 141; `pipefail` (set above) promotes that to the pipeline's status.
+# So on a changeset whose name list outruns the pipe buffer, with a matching
+# path near the front, BOTH tokens silently dropped: measured, a 92,623-byte
+# list led by a .swift file classified as `` where a short list of the same
+# shape classified as `lint build` (#1498).
+#
+# That is the "worst case" this script's header names, reached from inside. It
+# disarms `swiftlint --strict` and `xcodebuild build` in the pre-commit hook,
+# and — because .github/workflows/ci.yml's `changes` job derives `ios` from the
+# `build` token — skips lint-and-test and ui-test on CI with every required
+# check green. Both fail-safes ci.yml documents miss it: the file list is not
+# empty, and this script exits 0, it just prints nothing.
+#
+# `|| [ $? -eq 1 ]` and not `|| true`: exit 1 is grep's real "no match", exit
+# >=2 means the pattern broke. `|| true` would map a broken pattern to "no
+# match" — i.e. to no tokens — which is the same silent disarming. Failing the
+# assignment under `set -e` instead makes ci.yml's `if ! TOKENS=$(...)`
+# fail-safe fire and default to the full suite.
+
 # `lint`: any Swift source, or the SwiftLint config (at any depth).
-if printf '%s\n' "$staged" | grep -qE '(\.swift$|(^|/)\.swiftlint\.yml$)'; then
+lint_match="$(printf '%s\n' "$staged" | { grep -E '(\.swift$|(^|/)\.swiftlint\.yml$)' || [ $? -eq 1 ]; })"
+if [ -n "$lint_match" ]; then
   tokens="lint"
 fi
 
@@ -62,7 +85,9 @@ fi
 # generated-Kotlin drift guards see a PR that hand-edits one of those files.
 # scripts/tests/precommit-gate-classify-test.sh pins that case.
 SAFE='(^(web/|docs/|\.github/|\.claude/))|(\.md$)|(^(\.gitignore|\.gitattributes|\.editorconfig|LICENSE)$)'
-if [ -n "$staged" ] && printf '%s\n' "$staged" | grep -qvE "$SAFE"; then
+# Capture, don't `grep -qv` — see the note above the `lint` classification.
+unsafe_match="$(printf '%s\n' "$staged" | { grep -vE "$SAFE" || [ $? -eq 1 ]; })"
+if [ -n "$staged" ] && [ -n "$unsafe_match" ]; then
   tokens="${tokens:+$tokens }build"
 fi
 

--- a/scripts/precommit-gate-classify.sh
+++ b/scripts/precommit-gate-classify.sh
@@ -56,6 +56,10 @@ tokens=""
 # check green. Both fail-safes ci.yml documents miss it: the file list is not
 # empty, and this script exits 0, it just prints nothing.
 #
+# Dropping `-q` is what fixes it, NOT capturing into a variable first — the
+# producer here was already `printf`, and re-adding `-q` below reinstates the
+# defect unchanged. `.claude/rules/ci-workflows.md` § "Rule 3".
+#
 # `|| [ $? -eq 1 ]` and not `|| true`: exit 1 is grep's real "no match", exit
 # >=2 means the pattern broke. `|| true` would map a broken pattern to "no
 # match" — i.e. to no tokens — which is the same silent disarming. Failing the

--- a/scripts/prompt-literal-parity-precommit-gate.sh
+++ b/scripts/prompt-literal-parity-precommit-gate.sh
@@ -37,8 +37,10 @@ cd "$ROOT"
 TRIGGER='(^Pastura/Pastura/(Engine|LLM)/.*\.swift$)|(^shared/engine/src/commonMain/.*\.kt$)|(^shared/prompt-literal-parity-allowlist\.tsv$)|(^scripts/check-prompt-literal-parity\.py$)'
 
 # Capture, don't `| grep -q`: under `pipefail` an early match makes the
-# still-writing `git` SIGPIPE and the gate skips despite matching (#1498).
-# `|| [ $? -eq 1 ]` keeps exit 1 as "no match" and lets exit >=2 fail loudly.
+# still-writing producer SIGPIPE and the gate skips despite matching (#1498).
+# Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
+# below reinstates the defect on `printf` instead of on `git`. Rationale and
+# the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
 STAGED="$(git diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
 if [ -z "$MATCHED" ]; then

--- a/scripts/prompt-literal-parity-precommit-gate.sh
+++ b/scripts/prompt-literal-parity-precommit-gate.sh
@@ -36,11 +36,9 @@ cd "$ROOT"
 
 TRIGGER='(^Pastura/Pastura/(Engine|LLM)/.*\.swift$)|(^shared/engine/src/commonMain/.*\.kt$)|(^shared/prompt-literal-parity-allowlist\.tsv$)|(^scripts/check-prompt-literal-parity\.py$)'
 
-# Capture, don't `| grep -q`: under `pipefail` an early match makes the
-# still-writing producer SIGPIPE and the gate skips despite matching (#1498).
-# Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
-# below reinstates the defect on `printf` instead of on `git`. Rationale and
-# the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
+# Capture, don't `| grep -q` — `-q` exits early, the still-writing producer
+# SIGPIPEs, and `pipefail` turns a MATCH into a skip (#1498).
+# `.claude/rules/ci-workflows.md` § "Rule 3".
 STAGED="$(git -c core.quotepath=false diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
 if [ -z "$MATCHED" ]; then

--- a/scripts/prompt-literal-parity-precommit-gate.sh
+++ b/scripts/prompt-literal-parity-precommit-gate.sh
@@ -36,7 +36,12 @@ cd "$ROOT"
 
 TRIGGER='(^Pastura/Pastura/(Engine|LLM)/.*\.swift$)|(^shared/engine/src/commonMain/.*\.kt$)|(^shared/prompt-literal-parity-allowlist\.tsv$)|(^scripts/check-prompt-literal-parity\.py$)'
 
-if ! git diff --cached --name-only | grep -qE "$TRIGGER"; then
+# Capture, don't `| grep -q`: under `pipefail` an early match makes the
+# still-writing `git` SIGPIPE and the gate skips despite matching (#1498).
+# `|| [ $? -eq 1 ]` keeps exit 1 as "no match" and lets exit >=2 fail loudly.
+STAGED="$(git diff --cached --name-only)"
+MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
+if [ -z "$MATCHED" ]; then
   exit 0
 fi
 

--- a/scripts/prompt-literal-parity-precommit-gate.sh
+++ b/scripts/prompt-literal-parity-precommit-gate.sh
@@ -41,7 +41,7 @@ TRIGGER='(^Pastura/Pastura/(Engine|LLM)/.*\.swift$)|(^shared/engine/src/commonMa
 # Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
 # below reinstates the defect on `printf` instead of on `git`. Rationale and
 # the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
-STAGED="$(git diff --cached --name-only)"
+STAGED="$(git -c core.quotepath=false diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
 if [ -z "$MATCHED" ]; then
   exit 0

--- a/scripts/prune-stale-worktrees.sh
+++ b/scripts/prune-stale-worktrees.sh
@@ -389,17 +389,12 @@ evaluate() {
 
   # (b) unnamed (Docker-style auto-generated) worktrees only
   #
-  # Capture rather than `| grep -Eq`, matching the rest of the tree. This site
-  # was never reachable — the producer is one short worktree name, nowhere near
-  # a pipe buffer — and it already failed CLOSED (a SIGPIPE keeps the worktree
-  # rather than deleting it). It is swept anyway so the #1498 residual guard
-  # can assert a clean zero instead of carrying an allow-list.
-  #
-  # Note this file sets `set -uo pipefail`, NOT `-e`, so the `|| [ $? -eq 1 ]`
-  # group aborts nothing here — unlike at the other #1498 sites. A broken
-  # pattern lands as an empty `name_match` and keeps the worktree, which is
-  # the safe direction for a destructive script; the group is here for
-  # uniformity, not for an abort that cannot happen.
+  # Capture rather than `| grep -Eq` (`.claude/rules/ci-workflows.md` § "Rule 3")
+  # so the #1498 residual guard needs no allow-list entry — this producer is one
+  # short worktree name, so the defect was never reachable here. This file sets
+  # `set -uo pipefail`, NOT `-e`, so the `|| [ $? -eq 1 ]` group aborts nothing:
+  # a broken pattern keeps the worktree, the safe direction for a destructive
+  # script.
   name_match="$(printf '%s' "$name" | { grep -E '^[a-z]+-[a-z]+-[0-9a-f]{6}$' || [ $? -eq 1 ]; })"
   if [ -z "$name_match" ]; then
     [ "$VERBOSE" -eq 1 ] && say "keep  $name — named worktree (not auto-generated)"

--- a/scripts/prune-stale-worktrees.sh
+++ b/scripts/prune-stale-worktrees.sh
@@ -388,10 +388,17 @@ evaluate() {
   name="${wt##*/}"
 
   # (b) unnamed (Docker-style auto-generated) worktrees only
-  printf '%s' "$name" | grep -Eq '^[a-z]+-[a-z]+-[0-9a-f]{6}$' || {
+  #
+  # Capture rather than `| grep -Eq`, matching the rest of the tree. This site
+  # was never reachable — the producer is one short worktree name, nowhere near
+  # a pipe buffer — and it already failed CLOSED (a SIGPIPE keeps the worktree
+  # rather than deleting it). It is swept anyway so the #1498 residual guard
+  # can assert a clean zero instead of carrying an allow-list (#1498).
+  name_match="$(printf '%s' "$name" | { grep -E '^[a-z]+-[a-z]+-[0-9a-f]{6}$' || [ $? -eq 1 ]; })"
+  if [ -z "$name_match" ]; then
     [ "$VERBOSE" -eq 1 ] && say "keep  $name — named worktree (not auto-generated)"
     return 0
-  }
+  fi
 
   [ -d "$wt" ] || return 0
 

--- a/scripts/prune-stale-worktrees.sh
+++ b/scripts/prune-stale-worktrees.sh
@@ -393,7 +393,13 @@ evaluate() {
   # was never reachable — the producer is one short worktree name, nowhere near
   # a pipe buffer — and it already failed CLOSED (a SIGPIPE keeps the worktree
   # rather than deleting it). It is swept anyway so the #1498 residual guard
-  # can assert a clean zero instead of carrying an allow-list (#1498).
+  # can assert a clean zero instead of carrying an allow-list.
+  #
+  # Note this file sets `set -uo pipefail`, NOT `-e`, so the `|| [ $? -eq 1 ]`
+  # group aborts nothing here — unlike at the other #1498 sites. A broken
+  # pattern lands as an empty `name_match` and keeps the worktree, which is
+  # the safe direction for a destructive script; the group is here for
+  # uniformity, not for an abort that cannot happen.
   name_match="$(printf '%s' "$name" | { grep -E '^[a-z]+-[a-z]+-[0-9a-f]{6}$' || [ $? -eq 1 ]; })"
   if [ -z "$name_match" ]; then
     [ "$VERBOSE" -eq 1 ] && say "keep  $name — named worktree (not auto-generated)"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -233,25 +233,15 @@ APP_BIN=""
 while IFS= read -r -d '' f; do APP_BIN="$f"; done \
   < <(find "$ARCHIVE/Products/Applications" -type f -path "*/$APP_NAME.app/$APP_NAME" -print0)
 [ -n "$APP_BIN" ] || die "archived app binary not found under $ARCHIVE"
-# Capture the matches; never `| grep -iq`. `grep -q` exits at its first hit,
-# the still-writing upstream takes SIGPIPE and returns 141, and `pipefail` (set
-# at the top of this script) promotes that to the pipeline's status — so this
-# guard passed exactly when it should have fired. `nm -a` on the app binary is
-# megabytes, far past any pipe buffer, and the leak this guard exists to catch
-# is a symbol *in* that stream: measured on a 1.5 MB fixture, an `ollama`
-# symbol early in the dump slipped through while the same symbol late in the
-# dump was caught. The guard was working on symbol ordering, not on the check
-# (#1498). The CI sibling at .github/workflows/ci.yml (§ "Verify ADR-005 §8 —
-# OllamaService excluded") already had the capture shape; this is the copy that
-# runs against the *signed archive*, which is what actually ships.
+# Capture, don't `| grep -iq` — `-q` exits early, the still-writing upstream
+# SIGPIPEs, and `pipefail` turns a MATCH into a pass, so this guard was working
+# on symbol ordering rather than on the check (#1498). `nm -a` on the app
+# binary is megabytes, far past any pipe buffer.
+# `.claude/rules/ci-workflows.md` § "Rule 3".
 #
-# Dropping `-q` is what fixes it, NOT capturing into a variable first — the
-# upstream is a pipeline either way, and re-adding `-q` below reinstates the
-# defect unchanged. `.claude/rules/ci-workflows.md` § "Rule 3".
-#
-# `|| [ $? -eq 1 ]` and not `|| true`: exit 1 is grep's real "no match", exit
-# >=2 means the pattern broke, and `|| true` would report a broken pattern as
-# a clean binary. Under `set -e` the assignment aborts the release instead.
+# `|| [ $? -eq 1 ]` and not `|| true`: exit >=2 (broken pattern) must abort the
+# release, not report a clean binary. The CI sibling in .github/workflows/ci.yml
+# checks the unsigned build; this copy is the one that gates what ships.
 LEAKED="$(nm -a "$APP_BIN" | xcrun swift-demangle | { grep -i ollama || [ $? -eq 1 ]; })"
 if [ -n "$LEAKED" ]; then
   printf '%s\n' "$LEAKED" >&2

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -245,6 +245,10 @@ while IFS= read -r -d '' f; do APP_BIN="$f"; done \
 # OllamaService excluded") already had the capture shape; this is the copy that
 # runs against the *signed archive*, which is what actually ships.
 #
+# Dropping `-q` is what fixes it, NOT capturing into a variable first — the
+# upstream is a pipeline either way, and re-adding `-q` below reinstates the
+# defect unchanged. `.claude/rules/ci-workflows.md` § "Rule 3".
+#
 # `|| [ $? -eq 1 ]` and not `|| true`: exit 1 is grep's real "no match", exit
 # >=2 means the pattern broke, and `|| true` would report a broken pattern as
 # a clean binary. Under `set -e` the assignment aborts the release instead.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -233,7 +233,24 @@ APP_BIN=""
 while IFS= read -r -d '' f; do APP_BIN="$f"; done \
   < <(find "$ARCHIVE/Products/Applications" -type f -path "*/$APP_NAME.app/$APP_NAME" -print0)
 [ -n "$APP_BIN" ] || die "archived app binary not found under $ARCHIVE"
-if nm -a "$APP_BIN" | xcrun swift-demangle | grep -iq ollama; then
+# Capture the matches; never `| grep -iq`. `grep -q` exits at its first hit,
+# the still-writing upstream takes SIGPIPE and returns 141, and `pipefail` (set
+# at the top of this script) promotes that to the pipeline's status — so this
+# guard passed exactly when it should have fired. `nm -a` on the app binary is
+# megabytes, far past any pipe buffer, and the leak this guard exists to catch
+# is a symbol *in* that stream: measured on a 1.5 MB fixture, an `ollama`
+# symbol early in the dump slipped through while the same symbol late in the
+# dump was caught. The guard was working on symbol ordering, not on the check
+# (#1498). The CI sibling at .github/workflows/ci.yml (§ "Verify ADR-005 §8 —
+# OllamaService excluded") already had the capture shape; this is the copy that
+# runs against the *signed archive*, which is what actually ships.
+#
+# `|| [ $? -eq 1 ]` and not `|| true`: exit 1 is grep's real "no match", exit
+# >=2 means the pattern broke, and `|| true` would report a broken pattern as
+# a clean binary. Under `set -e` the assignment aborts the release instead.
+LEAKED="$(nm -a "$APP_BIN" | xcrun swift-demangle | { grep -i ollama || [ $? -eq 1 ]; })"
+if [ -n "$LEAKED" ]; then
+  printf '%s\n' "$LEAKED" >&2
   die "Ollama symbols leaked into the Release archive (ADR-005 §8.5)."
 fi
 log "  ✓ zero Ollama symbols"

--- a/scripts/scenario-editor-funnel-gate.sh
+++ b/scripts/scenario-editor-funnel-gate.sh
@@ -57,7 +57,12 @@ fi
 
 # Self-gate: in default (pre-commit) mode, skip unless a VM file is staged.
 if [ "$CHECK_ALL" -eq 0 ]; then
-  if ! git diff --cached --name-only | grep -qE "$VM_TRIGGER"; then
+  # Capture, don't `| grep -q`: under `pipefail` an early match makes the
+  # still-writing `git` SIGPIPE and the gate skips despite matching (#1498).
+  # `|| [ $? -eq 1 ]` keeps exit 1 as "no match" and lets exit >=2 fail loudly.
+  STAGED="$(git diff --cached --name-only)"
+  MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$VM_TRIGGER" || [ $? -eq 1 ]; })"
+  if [ -z "$MATCHED" ]; then
     exit 0
   fi
 fi

--- a/scripts/scenario-editor-funnel-gate.sh
+++ b/scripts/scenario-editor-funnel-gate.sh
@@ -62,7 +62,7 @@ if [ "$CHECK_ALL" -eq 0 ]; then
   # Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
   # below reinstates the defect on `printf` instead of on `git`. Rationale and
   # the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
-  STAGED="$(git diff --cached --name-only)"
+  STAGED="$(git -c core.quotepath=false diff --cached --name-only)"
   MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$VM_TRIGGER" || [ $? -eq 1 ]; })"
   if [ -z "$MATCHED" ]; then
     exit 0

--- a/scripts/scenario-editor-funnel-gate.sh
+++ b/scripts/scenario-editor-funnel-gate.sh
@@ -58,8 +58,10 @@ fi
 # Self-gate: in default (pre-commit) mode, skip unless a VM file is staged.
 if [ "$CHECK_ALL" -eq 0 ]; then
   # Capture, don't `| grep -q`: under `pipefail` an early match makes the
-  # still-writing `git` SIGPIPE and the gate skips despite matching (#1498).
-  # `|| [ $? -eq 1 ]` keeps exit 1 as "no match" and lets exit >=2 fail loudly.
+  # still-writing producer SIGPIPE and the gate skips despite matching (#1498).
+  # Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
+  # below reinstates the defect on `printf` instead of on `git`. Rationale and
+  # the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
   STAGED="$(git diff --cached --name-only)"
   MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$VM_TRIGGER" || [ $? -eq 1 ]; })"
   if [ -z "$MATCHED" ]; then

--- a/scripts/scenario-editor-funnel-gate.sh
+++ b/scripts/scenario-editor-funnel-gate.sh
@@ -57,11 +57,9 @@ fi
 
 # Self-gate: in default (pre-commit) mode, skip unless a VM file is staged.
 if [ "$CHECK_ALL" -eq 0 ]; then
-  # Capture, don't `| grep -q`: under `pipefail` an early match makes the
-  # still-writing producer SIGPIPE and the gate skips despite matching (#1498).
-  # Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
-  # below reinstates the defect on `printf` instead of on `git`. Rationale and
-  # the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
+  # Capture, don't `| grep -q` — `-q` exits early, the still-writing producer
+  # SIGPIPEs, and `pipefail` turns a MATCH into a skip (#1498).
+  # `.claude/rules/ci-workflows.md` § "Rule 3".
   STAGED="$(git -c core.quotepath=false diff --cached --name-only)"
   MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$VM_TRIGGER" || [ $? -eq 1 ]; })"
   if [ -z "$MATCHED" ]; then

--- a/scripts/scenario-format-coverage-precommit-gate.sh
+++ b/scripts/scenario-format-coverage-precommit-gate.sh
@@ -27,7 +27,12 @@ cd "$ROOT"
 
 TRIGGER='(^Pastura/Pastura/Models/PhaseType\.swift$)|(^Pastura/Pastura/Models/ScoreCalcLogic\.swift$)|(^web/src/content/scenario-format\.(en|ja)\.md$)|(^scripts/check-scenario-format-coverage\.py$)'
 
-if ! git diff --cached --name-only | grep -qE "$TRIGGER"; then
+# Capture, don't `| grep -q`: under `pipefail` an early match makes the
+# still-writing `git` SIGPIPE and the gate skips despite matching (#1498).
+# `|| [ $? -eq 1 ]` keeps exit 1 as "no match" and lets exit >=2 fail loudly.
+STAGED="$(git diff --cached --name-only)"
+MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
+if [ -z "$MATCHED" ]; then
   exit 0
 fi
 

--- a/scripts/scenario-format-coverage-precommit-gate.sh
+++ b/scripts/scenario-format-coverage-precommit-gate.sh
@@ -32,7 +32,7 @@ TRIGGER='(^Pastura/Pastura/Models/PhaseType\.swift$)|(^Pastura/Pastura/Models/Sc
 # Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
 # below reinstates the defect on `printf` instead of on `git`. Rationale and
 # the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
-STAGED="$(git diff --cached --name-only)"
+STAGED="$(git -c core.quotepath=false diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
 if [ -z "$MATCHED" ]; then
   exit 0

--- a/scripts/scenario-format-coverage-precommit-gate.sh
+++ b/scripts/scenario-format-coverage-precommit-gate.sh
@@ -28,8 +28,10 @@ cd "$ROOT"
 TRIGGER='(^Pastura/Pastura/Models/PhaseType\.swift$)|(^Pastura/Pastura/Models/ScoreCalcLogic\.swift$)|(^web/src/content/scenario-format\.(en|ja)\.md$)|(^scripts/check-scenario-format-coverage\.py$)'
 
 # Capture, don't `| grep -q`: under `pipefail` an early match makes the
-# still-writing `git` SIGPIPE and the gate skips despite matching (#1498).
-# `|| [ $? -eq 1 ]` keeps exit 1 as "no match" and lets exit >=2 fail loudly.
+# still-writing producer SIGPIPE and the gate skips despite matching (#1498).
+# Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
+# below reinstates the defect on `printf` instead of on `git`. Rationale and
+# the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
 STAGED="$(git diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
 if [ -z "$MATCHED" ]; then

--- a/scripts/scenario-format-coverage-precommit-gate.sh
+++ b/scripts/scenario-format-coverage-precommit-gate.sh
@@ -27,11 +27,9 @@ cd "$ROOT"
 
 TRIGGER='(^Pastura/Pastura/Models/PhaseType\.swift$)|(^Pastura/Pastura/Models/ScoreCalcLogic\.swift$)|(^web/src/content/scenario-format\.(en|ja)\.md$)|(^scripts/check-scenario-format-coverage\.py$)'
 
-# Capture, don't `| grep -q`: under `pipefail` an early match makes the
-# still-writing producer SIGPIPE and the gate skips despite matching (#1498).
-# Dropping `-q` is what fixes it, NOT the `STAGED=` capture — re-adding `-q`
-# below reinstates the defect on `printf` instead of on `git`. Rationale and
-# the `|| [ $? -eq 1 ]` contract: `.claude/rules/ci-workflows.md` § "Rule 3".
+# Capture, don't `| grep -q` — `-q` exits early, the still-writing producer
+# SIGPIPEs, and `pipefail` turns a MATCH into a skip (#1498).
+# `.claude/rules/ci-workflows.md` § "Rule 3".
 STAGED="$(git -c core.quotepath=false diff --cached --name-only)"
 MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
 if [ -z "$MATCHED" ]; then

--- a/scripts/tests/staged-trigger-pipefail-test.sh
+++ b/scripts/tests/staged-trigger-pipefail-test.sh
@@ -225,6 +225,46 @@ else
       "this also means bash 5 does not abort the assignment the way bash 3.2 does."
 fi
 
+# --- A11: the three-stage symbol-guard shape (scripts/release.sh) ----------
+# release.sh's ADR-005 §8.5 guard is `nm -a "$BIN" | xcrun swift-demangle |
+# grep -i ollama`. It cannot be driven end-to-end here (it needs a signed
+# archive), so the *shape* is pinned instead, on a fixture that models what
+# makes the real one dangerous: an `nm` dump far larger than any pipe buffer
+# with the leaked symbol near the front. Two stages upstream, not one — with
+# `-q` the SIGPIPE can land on either, and only the last stage's status is the
+# one `pipefail` would otherwise hide behind.
+#
+# The old-shape half is the negative control, same role as A4: it must MISS,
+# or the fixture is not modelling the hazard and the new-shape half proves
+# nothing. That the real guard was passing on symbol *ordering* rather than on
+# the check is exactly this pair of results.
+awk 'BEGIN {
+  print "0000000100000000 T _$s7Pastura13OllamaServiceCN"
+  for (i = 0; i < 40000; i++) printf "00000001000%05d T _symbol_filler_%d\n", i, i
+}' > "$TMP/nm-dump.txt"
+
+cat > "$TMP/symbol-guard.sh" <<'SYMBOL_GUARD'
+set -euo pipefail
+if [ "$2" = "old" ]; then
+  if cat "$1" | cat | grep -iq ollama; then echo CAUGHT; else echo MISSED; fi
+else
+  LEAKED="$(cat "$1" | cat | { grep -i ollama || [ $? -eq 1 ]; })"
+  if [ -n "$LEAKED" ]; then echo CAUGHT; else echo MISSED; fi
+fi
+SYMBOL_GUARD
+
+old_v="$(bash "$TMP/symbol-guard.sh" "$TMP/nm-dump.txt" old)"
+new_v="$(bash "$TMP/symbol-guard.sh" "$TMP/nm-dump.txt" new)"
+if [ "$old_v" = "MISSED" ] && [ "$new_v" = "CAUGHT" ]; then
+  ok "A11 symbol-guard shape: old MISSED / new CAUGHT on a $(wc -c < "$TMP/nm-dump.txt" | tr -d ' ')-byte dump"
+elif [ "$old_v" = "CAUGHT" ]; then
+  bad "A11 the old shape caught the leak — the fixture no longer models the hazard," \
+      "so the new-shape half is vacuous. Fix the fixture, not this arm."
+else
+  bad "A11 capture shape MISSED an ollama symbol in a large nm dump — scripts/release.sh" \
+      "would ship a leaking archive (ADR-005 §8.5)"
+fi
+
 if [ "$fail" -ne 0 ]; then
   echo "staged-trigger-pipefail-test: FAILED" >&2
   exit 1

--- a/scripts/tests/staged-trigger-pipefail-test.sh
+++ b/scripts/tests/staged-trigger-pipefail-test.sh
@@ -291,11 +291,14 @@ fi
 # read as wider than it is:
 #   - `|| [ $? -eq 1 ]` relaxed back to `|| true` at a fixed site. That loses
 #     the exit->=2 discrimination without reintroducing the SIGPIPE fail-open,
-#     and it cannot be pattern-guarded here: legitimate `grep … || true` uses
-#     already outnumber the guarded sites' worth of noise it would add. Count
-#     them rather than trusting a figure — the answer moves with both the
-#     enumeration below and how much of the line the pattern may span:
-#       xargs grep -hE 'grep.*\|\|[[:space:]]*true' < <enumerated files>
+#     and it cannot be pattern-guarded here: `grep … || true` is a legitimate,
+#     widely-used idiom in these same scripts (capturing output where a
+#     no-match is an ordinary answer), so such a pattern would fire on code
+#     that is fine and the guard would be noise. Count rather than trust a
+#     figure — the answer moves with how much of the line the pattern may
+#     span, which is the 15-vs-18 fork between these two:
+#       xargs grep -hE 'grep[^|]*\|\|[[:space:]]*true' < "$TMP/prod-scripts.txt" | wc -l
+#       xargs grep -hE 'grep.*\|\|[[:space:]]*true'    < "$TMP/prod-scripts.txt" | wc -l
 #     A8 pins the shape's semantics; it is not a guard over the tree.
 #   - a pipeline wrapped across lines (`producer |` at EOL, `grep -q …` on the
 #     next). `scan` is line-bound, the same blind spot ci-workflows.md §

--- a/scripts/tests/staged-trigger-pipefail-test.sh
+++ b/scripts/tests/staged-trigger-pipefail-test.sh
@@ -3,44 +3,34 @@
 # scripts/tests/staged-trigger-pipefail-test.sh — regression test for #1498.
 #
 # THE DEFECT. Under `set -o pipefail`, `producer | grep -q PATTERN` reports the
-# pipeline as FAILED when the pattern matches early: `grep -q` exits at its
-# first match, the producer takes SIGPIPE and returns 141, and pipefail
-# promotes that to the pipeline's status. So a *matching* input is
-# indistinguishable from a non-matching one — and every consumer of the shape
-# in this repo reads that status as "no match" and skips. A gate that wrongly
-# RUNS gets noticed; one that wrongly SKIPS is silent.
+# pipeline as FAILED when the pattern matches early — so a *matching* input is
+# indistinguishable from a non-matching one, and every consumer of the shape in
+# this repo reads that as "no match" and skips. Mechanism and the alternatives
+# that do NOT fix it: `.claude/rules/ci-workflows.md` § "Rule 3".
 #
-# Guarded here, both by exit code:
-#   - scripts/p8-precommit-gate.sh        a staged ASC / APNs key would be committed
-#   - scripts/precommit-gate-classify.sh  `lint` + `build` tokens vanish, so swiftlint
-#                                         and the iOS build are skipped locally, AND
-#                                         ci.yml's `changes` job emits ios=false, which
-#                                         skips lint-and-test / ui-test with every
-#                                         required check green
+# Guarded here by exit code: scripts/p8-precommit-gate.sh (a staged ASC / APNs
+# key would be committed) and scripts/precommit-gate-classify.sh (`lint` +
+# `build` vanish, so swiftlint and the iOS build are skipped locally AND
+# ci.yml's `changes` job emits ios=false, skipping lint-and-test / ui-test with
+# every required check green).
 #
 # WHY THE SIBLING TESTS CANNOT CATCH THIS. p8-precommit-gate-test.sh and
-# precommit-gate-classify-test.sh both stage a handful of paths, so the whole
-# name list fits inside the pipe buffer, the producer never blocks, and the
-# defect never arms. Size is the entire variable, which is why this file exists
-# separately rather than as extra cases in those.
+# precommit-gate-classify-test.sh stage a handful of paths, which fits inside
+# the pipe buffer, so the producer never blocks and the defect never arms. Size
+# is the entire variable — hence a separate file rather than cases in those.
 #
-# READING THE ARMS. Arm A4 runs an INLINED COPY of the old shape against the
-# same fixture and requires it to SKIP. That is not redundant with A1: it is
-# what proves the fixture is still large enough (and the key still sorted early
-# enough) to arm the defect at all. If A4 ever starts firing, A1 has gone
-# vacuous — it would pass against unfixed code — and A4 fails loudly to say so.
-# Do not "simplify" A4 away, and do not borrow it from a sibling suite: a
-# control that lives elsewhere stops discriminating on the day the lender
-# changes, without reddening anything here (#1481).
+# READING THE ARMS. A4 and A11 run INLINED COPIES of the old shape and require
+# it to MISS: that is what proves each fixture still arms the defect at all. If
+# either starts catching, its paired arm has gone vacuous — it would pass
+# against unfixed code. Do not "simplify" them away, and do not borrow a control
+# from a sibling suite: it stops discriminating on the day the lender changes,
+# without reddening anything here (#1481).
 #
-# Arm A8 pins that the capture SHAPE aborts on grep exit >=2 (broken regex,
-# read error) instead of falling through with an empty match — it runs a
-# heredoc copy, so it fixes the semantics of the idiom and is NOT a guard over
-# the tree: a site relaxed back to `|| true` would still pass it. See A12's
-# header for why that shape cannot be pattern-guarded. It is also the bash-5
-# canary, which is A8's load-bearing job here: the fix shape was
-# measured on bash 3.2 (what the macOS pre-commit hook runs); this arm is what
-# reddens if bash 5 on the ubuntu CI runner treats the construct differently.
+# A8 pins that the capture SHAPE aborts on grep exit >=2 rather than reading
+# empty. It runs a heredoc copy, so it fixes the idiom's semantics and is NOT a
+# guard over the tree (a site relaxed to `|| true` still passes it — see A12 for
+# why that cannot be pattern-guarded). It doubles as the bash-5 canary: the fix
+# was measured on bash 3.2, what the macOS pre-commit hook runs.
 #
 # CI-wired: the `*-test.sh` naming convention makes this a gate under
 # .github/workflows/ci.yml ("Run scripts/tests/*-test.sh"). Run manually:
@@ -60,11 +50,10 @@ bad() { printf 'FAIL: %s\n' "$*" >&2; fail=1; }
 ok()  { printf '  ok: %s\n' "$*"; }
 
 # --- fixture ---------------------------------------------------------------
-# Sized an ORDER OF MAGNITUDE above any pipe capacity rather than "just over"
-# a constant: the capacity that arms this differs between the macOS pre-commit
-# hook and the ubuntu CI runner, so a fixture tuned to one number is not
-# provably armed on the other platform. A9 asserts the size that actually
-# resulted, so a later edit to the generator cannot quietly shrink it.
+# Sized an ORDER OF MAGNITUDE above any pipe capacity rather than "just over" a
+# constant: that capacity differs between the macOS pre-commit hook and the
+# ubuntu CI runner. A9 asserts the size that actually resulted, so a later edit
+# to the generator cannot quietly shrink it.
 PAD="$(awk 'BEGIN{ for (i = 0; i < 190; i++) printf "x" }')"
 
 # Tail paths start `zz/` so they sort AFTER the `keys/` and `Pastura/` heads
@@ -105,13 +94,10 @@ make_repo "$TMP/p8-clean"  "$TMP/list-clean-big.txt"
 make_repo "$TMP/p8-small"  "$TMP/list-p8-small.txt"
 
 # --- A9 / A10: the fixture's own preconditions ------------------------------
-# These gate every other arm. Assert them before reading any verdict, or a
-# shrunken fixture turns the suite green while measuring nothing.
-#
-# Redirect to a file rather than piping into `wc`/`head`: `git … | head -1` is
-# the defect under test, and the first draft of this file killed itself with it
-# (exit 141) before reaching a single verdict. Any early-exiting reader will do
-# it — reading the list once, then measuring the file, is the shape to copy.
+# These gate every other arm: a shrunken fixture would turn the suite green
+# while measuring nothing. Redirect to a file rather than piping into
+# `wc`/`head` — `git … | head -1` is the defect under test, and the first draft
+# of this file killed itself with it (exit 141) before any verdict.
 git -C "$TMP/p8-big" diff --cached --name-only > "$TMP/staged-p8-big.txt"
 
 size="$(wc -c < "$TMP/staged-p8-big.txt" | tr -d ' ')"
@@ -228,18 +214,12 @@ else
 fi
 
 # --- A11: the three-stage symbol-guard shape (scripts/release.sh) ----------
-# release.sh's ADR-005 §8.5 guard is `nm -a "$BIN" | xcrun swift-demangle |
-# grep -i ollama`. It cannot be driven end-to-end here (it needs a signed
-# archive), so the *shape* is pinned instead, on a fixture that models what
-# makes the real one dangerous: an `nm` dump far larger than any pipe buffer
-# with the leaked symbol near the front. Two stages upstream, not one — with
-# `-q` the SIGPIPE can land on either, and only the last stage's status is the
-# one `pipefail` would otherwise hide behind.
-#
-# The old-shape half is the negative control, same role as A4: it must MISS,
-# or the fixture is not modelling the hazard and the new-shape half proves
-# nothing. That the real guard was passing on symbol *ordering* rather than on
-# the check is exactly this pair of results.
+# release.sh's ADR-005 §8.5 guard needs a signed archive, so the *shape* is
+# pinned instead on a fixture modelling what makes the real one dangerous: an
+# `nm` dump far past any pipe buffer with the leaked symbol near the front. Two
+# stages upstream, not one — with `-q` the SIGPIPE can land on either, and only
+# the last stage's status is the one `pipefail` would otherwise hide behind.
+# The old-shape half is the negative control (see A4 in the header).
 awk 'BEGIN {
   print "0000000100000000 T _$s7Pastura13OllamaServiceCN"
   for (i = 0; i < 40000; i++) printf "00000001000%05d T _symbol_filler_%d\n", i, i
@@ -268,17 +248,12 @@ else
 fi
 
 # --- A13: a non-ASCII staged path must not walk past an anchored TRIGGER ----
-# A second fail-open of the same family, found at the same lines: with the
-# default `core.quotepath`, git octal-escapes a non-ASCII path AND wraps it in
-# double quotes, so the leading `"` defeats a `^`-anchored prefix and the
-# trailing `"` defeats a `$`-anchored extension. Measured before the fix: the
-# real navigation-map gate exited 0 for a lone staged
-# `Pastura/Pastura/Views/日本語View.swift`.
-#
-# Driven through the p8 gate because it is the one whose verdict is an exit
-# code — and because a key is the worst thing to let through. The ASCII arm is
-# the positive control: if it ever stops rejecting, this arm's non-ASCII
-# result says nothing about quoting.
+# A second fail-open of the same family, at the same lines: with the default
+# `core.quotepath`, git octal-escapes a non-ASCII path AND double-quotes it, so
+# the leading `"` defeats a `^`-anchored prefix and the trailing `"` a
+# `$`-anchored extension. Driven through the p8 gate because its verdict is an
+# exit code, and a key is the worst thing to let through. The ASCII arm is the
+# positive control: without it a non-ASCII pass says nothing about quoting.
 for variant in "keys/AuthKey_日本語.p8:non-ASCII" "keys/AuthKey_ASCII.p8:ASCII control"; do
   path="${variant%%:*}"; label="${variant#*:}"
   repo="$TMP/nonascii-$(printf '%s' "$label" | tr -cd 'A-Za-z')"
@@ -299,87 +274,65 @@ done
 
 # --- A12: no `| grep -q` left in the production scripts --------------------
 # THIS ARM GUARDS ONE SHAPE, NOT THE CLASS. It scans for `grep -q` behind a
-# pipe. The defect is broader — ANY early-exiting reader (`head`, `sed …q`,
-# `awk …exit`, `grep -m N`) does the same thing to its producer under
-# `pipefail`. `scripts/analyze-streaming-diag.sh` was a live instance of the
-# `head` variant, inside this very pathspec, that this scan could not see; it
-# is fixed on the same branch. `.claude/rules/ci-workflows.md` § "Rule 3" is
-# what covers the class. Extending `scan` to the other readers would need its
-# own C-controls and would fire on many correct `| head` uses, so the split is
-# deliberate: mechanical guard for the shape, rule text for the class.
+# pipe; ANY early-exiting reader (`head`, `sed …q`, `awk …exit`, `grep -m N`)
+# has the same defect. `scripts/analyze-streaming-diag.sh` was a live `head`
+# instance inside this very pathspec that this scan could not see, fixed on the
+# same branch. Extending `scan` to those readers would need its own C-controls
+# and would fire on many correct `| head` uses, so the split is deliberate:
+# mechanical guard for the shape, `.claude/rules/ci-workflows.md` § "Rule 3"
+# for the class.
 #
 # Scope is the executable production surface — `scripts/*.sh`,
 # `scripts/hooks/*.sh`, `scripts/git-hooks/*` and `tools/*/scripts/*.sh`,
-# tracked files only. Deliberately NOT a pathspec over everything, because the
-# precondition is "does a `pipefail` reach this site", not "where does the file
-# live". Four areas were checked and are out of scope for that reason, not by
-# omission — none of them is excluded by an input-size argument, which § Rule 3
-# forbids:
-#   - scripts/tests/**        structural, not size: these are not shipped
-#                             gates, so a false pass here fails the tests it
-#                             guards rather than production. This file's own
-#                             A4 / A11 negative controls are literal old-shape
-#                             copies and MUST stay in any case.
-#   - .claude/skills/**       every site there is outside a `pipefail` scope —
-#                             the `run_tests.sh` harnesses and
-#                             `scenario-factory/scripts/run_scenario.sh` use
-#                             `set -eu`, and `release/SKILL.md`'s snippet is
-#                             run ad hoc in a shell with pipefail off.
-#   - .github/workflows/**    a bare `run:` is `bash -e {0}`, no pipefail
-#                             (ci-workflows.md Rule 2). Latent, not live: a
-#                             later `shell: bash` on one of those steps arms
-#                             all four. Noted in the rule and inline at the
-#                             steps, rather than guarded here, because guarding
-#                             it would need this file to parse YAML step
-#                             options to stay honest.
-#   - docs/**                 two documented snippets. `ADR-028.md`'s
-#                             regeneration loop cannot exit early at all — its
-#                             `tr '\n' ' '` leaves the stream newline-free, so
-#                             grep must reach EOF before any line can match.
-#                             `security/release-checklist.md`'s `curl -sI |
-#                             head -1` runs interactively without pipefail.
+# tracked files only. The predicate is "does a `pipefail` reach this site", not
+# "where does the file live", which is why four areas are out of scope by
+# argument rather than by omission — none of them by an input-size claim, which
+# § Rule 3 forbids:
+#   - scripts/tests/**      not shipped gates, so a false pass here fails the
+#                           tests it guards rather than production. A4 / A11
+#                           are literal old-shape copies and MUST stay.
+#   - .claude/skills/**     every site is outside a `pipefail` scope (`set -eu`
+#                           harnesses; release/SKILL.md's snippet is ad hoc).
+#   - .github/workflows/**  a bare `run:` is `bash -e {0}`, no pipefail — latent,
+#                           not live. Guarding it would mean parsing YAML step
+#                           options; it is covered inline and in § Rule 3.
+#   - docs/**               two documented snippets: ADR-028's cannot exit early
+#                           at all (its `tr '\n' ' '` leaves the stream with no
+#                           line to match), and release-checklist.md's runs
+#                           interactively, without pipefail.
 #
 # Two regression shapes this arm does NOT catch, stated so the coverage is not
 # read as wider than it is:
-#   - `|| [ $? -eq 1 ]` relaxed back to `|| true` at a fixed site. That loses
-#     the exit->=2 discrimination without reintroducing the SIGPIPE fail-open,
-#     and it cannot be pattern-guarded here: `grep … || true` is a legitimate,
-#     widely-used idiom in these same scripts (capturing output where a
-#     no-match is an ordinary answer), so such a pattern would fire on code
-#     that is fine and the guard would be noise. Count rather than trust a
-#     figure — the answer moves with how much of the line the pattern may
-#     span, which is the 15-vs-18 fork between these two:
+#   - `|| [ $? -eq 1 ]` relaxed back to `|| true`. That loses the exit->=2
+#     discrimination without reintroducing the SIGPIPE fail-open, and cannot be
+#     pattern-guarded: `grep … || true` is a legitimate idiom in these same
+#     scripts, so the guard would be noise. A8 pins the shape's semantics
+#     instead. Count rather than trust a figure — the answer moves with how much
+#     of the line the pattern may span:
 #       xargs grep -hE 'grep[^|]*\|\|[[:space:]]*true' < "$TMP/prod-scripts.txt" | wc -l
-#       xargs grep -hE 'grep.*\|\|[[:space:]]*true'    < "$TMP/prod-scripts.txt" | wc -l
-#     A8 pins the shape's semantics; it is not a guard over the tree.
-#   - a pipeline wrapped across lines (`producer |` at EOL, `grep -q …` on the
-#     next). `scan` is line-bound, the same blind spot ci-workflows.md §
-#     "`grep` is line-bound" documents for this repo's other call-shape guards.
-#     Zero such sites today. A trailing comment on a code line goes the other
-#     way and false-positives, which is loud rather than silent.
+#   - a pipeline wrapped across lines (`producer |` at EOL, `grep -q …` next).
+#     `scan` is line-bound, the blind spot ci-workflows.md § "`grep` is
+#     line-bound" documents for this repo's other call-shape guards. Zero such
+#     sites today. A trailing comment on a code line false-positives instead,
+#     which is loud rather than silent.
 #
-# Comment lines are stripped before matching. That is load-bearing and it is
-# also the guard's own weak point: every site fixed for #1498 carries a comment
-# that quotes the banned shape, so without stripping this arm reports its own
-# documentation, and with over-eager stripping it reports nothing at all. C1-C8
-# below pin both directions before the real scan is trusted.
+# Comment lines are stripped before matching — load-bearing, and the guard's own
+# weak point: every site fixed for #1498 carries a comment quoting the banned
+# shape, so without stripping this arm reports its own documentation, and with
+# over-eager stripping it reports nothing. C1-C8 pin both directions.
 #
-# The controls are not ceremony. Two separate drafts of this pattern failed to
-# compile under BWK awk (the macOS default) — first over `\{?`, then over a
-# `-v`-mangled leading `|` — and on BOTH runs the scan still printed "no
-# `| grep -q` remains", because a pattern that never compiles matches nothing
-# and an empty result is exactly what a clean tree looks like. The controls are
-# the only reason either was caught.
+# The controls are not ceremony. Two drafts of this pattern failed to compile
+# under BWK awk (the macOS default) and BOTH still printed "no `| grep -q`
+# remains": a pattern that never compiles matches nothing, and an empty result
+# is exactly what a clean tree looks like.
 #
-# `[^|]*` on both sides of `grep` keeps the match inside ONE pipeline stage,
-# so `| { grep -E "$T" || [ $? -eq 1 ]; }` — the shape this whole PR moves to —
-# does not self-report: the `-E "$T" ` between `grep` and the `||` carries no
-# `q`, and `[^|]*` cannot reach past the `||` to find one. C5 pins that.
+# `[^|]*` on both sides of `grep` keeps the match inside ONE pipeline stage, so
+# the fixed shape `| { grep -E "$T" || [ $? -eq 1 ]; }` does not self-report —
+# `[^|]*` cannot reach past the `||` to find a `q`. C5 pins that.
 #
-# The pattern is written LITERALLY in the awk program, never passed via `-v`.
-# `-v` runs escape processing first, so `\|` arrives as a bare `|`, the regex
-# then starts with an empty alternation, and BWK awk rejects it as an illegal
-# primary — see the note above for what that failure looks like from outside.
+# The pattern is written LITERALLY in the awk program, never passed via `-v`:
+# `-v` runs escape processing first, so `\|` arrives bare, the regex starts with
+# an empty alternation, and BWK awk rejects it as an illegal primary.
 scan() { # $@ = files; echoes offending "file:line: text"
   awk '
     { probe = $0; sub(/^[[:space:]]+/, "", probe) }
@@ -391,11 +344,10 @@ scan() { # $@ = files; echoes offending "file:line: text"
 }
 
 # C1-C8: a CLASS control, not a self-match. C1/C2/C6 are the three producers the
-# defect actually appears behind in this tree (`git`, `printf`, and a multi-stage
-# pipe ending in `head`) — a pattern narrowed to one of them reads clean over
-# live instances of the others, which is exactly how the original enumeration
-# for this issue came up short by two sites. C7 guards the other direction: a
-# stray `q` inside an unrelated argument must not be read as the `-q` flag.
+# defect appears behind in this tree (`git`, `printf`, a multi-stage pipe ending
+# in `head`) — a pattern narrowed to one reads clean over live instances of the
+# others, which is how the original enumeration came up two sites short. C7
+# guards the other direction: a stray `q` in an unrelated argument is not `-q`.
 cat > "$TMP/control.sh" <<'CONTROL'
 if ! git diff --cached --name-only | grep -qE "$T"; then exit 0; fi
   if printf '%s\n' "$X" | grep -q foo; then echo hi; fi
@@ -426,18 +378,12 @@ fi
 
 # `:(glob)` is required, not decoration: a plain `scripts/*.sh` pathspec uses
 # git's wildmatch, where `*` crosses `/`, so it silently pulls in
-# scripts/tests/*.sh — including THIS file and its two deliberate old-shape
-# controls. Measured: 55 files without the magic, 34 with it (scripts/ only).
+# scripts/tests/*.sh — including THIS file and its deliberate old-shape controls.
 #
-# `tools/*/scripts/*.sh` is in scope for the same reason scripts/ is, not as an
-# afterthought: all four kmp-gate-spike scripts run `set -euo pipefail`, two are
-# `ci.yml` gates (check-b-prime-isolation, check-suspendcontroller-drift) and a
-# third runs in `kmp-nightly.yml` (stage-framework). Zero hits there today.
-#
-# `scripts/git-hooks/*` needs its own entry because the files there are
-# EXTENSIONLESS — `pre-commit` is not `*.sh`, so no amount of `scripts/*`
-# globbing reaches it. It sets `set -euo pipefail` and orchestrates all 15
-# gates, so it satisfies the scope predicate as squarely as anything here.
+# `tools/*/scripts/*.sh` qualifies for the same reason scripts/ does: those
+# scripts run `set -euo pipefail` and three are CI gates. `scripts/git-hooks/*`
+# needs its own entry because those files are EXTENSIONLESS — `pre-commit` is
+# not `*.sh`, so no `scripts/*` glob reaches it.
 git -C "$ROOT" ls-files -- ':(glob)scripts/*.sh' ':(glob)scripts/hooks/*.sh' \
                            ':(glob)scripts/git-hooks/*' \
                            ':(glob)tools/*/scripts/*.sh' \

--- a/scripts/tests/staged-trigger-pipefail-test.sh
+++ b/scripts/tests/staged-trigger-pipefail-test.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+#
+# scripts/tests/staged-trigger-pipefail-test.sh — regression test for #1498.
+#
+# THE DEFECT. Under `set -o pipefail`, `producer | grep -q PATTERN` reports the
+# pipeline as FAILED when the pattern matches early: `grep -q` exits at its
+# first match, the producer takes SIGPIPE and returns 141, and pipefail
+# promotes that to the pipeline's status. So a *matching* input is
+# indistinguishable from a non-matching one — and every consumer of the shape
+# in this repo reads that status as "no match" and skips. A gate that wrongly
+# RUNS gets noticed; one that wrongly SKIPS is silent.
+#
+# Guarded here, both by exit code:
+#   - scripts/p8-precommit-gate.sh        a staged ASC / APNs key would be committed
+#   - scripts/precommit-gate-classify.sh  `lint` + `build` tokens vanish, so swiftlint
+#                                         and the iOS build are skipped locally, AND
+#                                         ci.yml's `changes` job emits ios=false, which
+#                                         skips lint-and-test / ui-test with every
+#                                         required check green
+#
+# WHY THE SIBLING TESTS CANNOT CATCH THIS. p8-precommit-gate-test.sh and
+# precommit-gate-classify-test.sh both stage a handful of paths, so the whole
+# name list fits inside the pipe buffer, the producer never blocks, and the
+# defect never arms. Size is the entire variable, which is why this file exists
+# separately rather than as extra cases in those.
+#
+# READING THE ARMS. Arm A4 runs an INLINED COPY of the old shape against the
+# same fixture and requires it to SKIP. That is not redundant with A1: it is
+# what proves the fixture is still large enough (and the key still sorted early
+# enough) to arm the defect at all. If A4 ever starts firing, A1 has gone
+# vacuous — it would pass against unfixed code — and A4 fails loudly to say so.
+# Do not "simplify" A4 away, and do not borrow it from a sibling suite: a
+# control that lives elsewhere stops discriminating on the day the lender
+# changes, without reddening anything here (#1481).
+#
+# Arm A8 pins that the capture shape ABORTS on grep exit >=2 (broken regex,
+# read error) instead of falling through with an empty match. Without it a
+# future edit that breaks a TRIGGER pattern re-opens the identical fail-open
+# through a different door. It is also the bash-5 canary: the fix shape was
+# measured on bash 3.2 (what the macOS pre-commit hook runs); this arm is what
+# reddens if bash 5 on the ubuntu CI runner treats the construct differently.
+#
+# CI-wired: the `*-test.sh` naming convention makes this a gate under
+# .github/workflows/ci.yml ("Run scripts/tests/*-test.sh"). Run manually:
+#   bash scripts/tests/staged-trigger-pipefail-test.sh
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+P8_GATE="$ROOT/scripts/p8-precommit-gate.sh"
+CLASSIFY="$ROOT/scripts/precommit-gate-classify.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail=0
+bad() { printf 'FAIL: %s\n' "$*" >&2; fail=1; }
+ok()  { printf '  ok: %s\n' "$*"; }
+
+# --- fixture ---------------------------------------------------------------
+# Sized an ORDER OF MAGNITUDE above any pipe capacity rather than "just over"
+# a constant: the capacity that arms this differs between the macOS pre-commit
+# hook and the ubuntu CI runner, so a fixture tuned to one number is not
+# provably armed on the other platform. A9 asserts the size that actually
+# resulted, so a later edit to the generator cannot quietly shrink it.
+PAD="$(awk 'BEGIN{ for (i = 0; i < 190; i++) printf "x" }')"
+
+# Tail paths start `zz/` so they sort AFTER the `keys/` and `Pastura/` heads
+# below. `git diff --cached --name-only` emits in sorted order, so the head is
+# what `grep -q` matches — it exits on line 1 with ~all of the list unwritten,
+# which is the condition that arms the defect. A10 asserts that ordering.
+awk -v pad="$PAD" 'BEGIN{ for (i = 0; i < 3000; i++) printf "zz/%s_%05d.txt\n", pad, i }' \
+  > "$TMP/tail.txt"
+
+P8_PATH='keys/AuthKey_TEST123.p8'
+SWIFT_PATH='Pastura/Pastura/Engine/Fixture.swift'
+
+{ echo "$P8_PATH"; cat "$TMP/tail.txt"; }    > "$TMP/list-p8-big.txt"
+{ cat "$TMP/tail.txt"; }                      > "$TMP/list-clean-big.txt"
+{ echo "$P8_PATH"; }                          > "$TMP/list-p8-small.txt"
+{ echo "$SWIFT_PATH"; cat "$TMP/tail.txt"; } > "$TMP/list-swift-big.txt"
+{ echo "$SWIFT_PATH"; }                       > "$TMP/list-swift-small.txt"
+# All-SAFE: `docs/` is on the classifier's build-irrelevant denylist, so the
+# correct answer is the empty token set. Distinguishes "correctly quiet" from
+# "silently disarmed", which look identical in the classifier's output.
+awk -v pad="$PAD" 'BEGIN{ for (i = 0; i < 3000; i++) printf "docs/%s_%05d.md\n", pad, i }' \
+  > "$TMP/list-safe-big.txt"
+
+# Stage a path list into a throwaway repo via `update-index --index-info`
+# against one empty blob — no working-tree files, so the fixture costs a single
+# git call instead of thousands of creat()s.
+make_repo() { # $1 = repo dir, $2 = path list
+  git init -q "$1"
+  git -C "$1" config user.email test@example.com
+  git -C "$1" config user.name test
+  blob="$(printf '' | git -C "$1" hash-object -w --stdin)"
+  awk -v b="$blob" '{ printf "100644 %s\t%s\n", b, $0 }' "$2" > "$TMP/index-info"
+  git -C "$1" update-index --index-info < "$TMP/index-info"
+}
+
+make_repo "$TMP/p8-big"    "$TMP/list-p8-big.txt"
+make_repo "$TMP/p8-clean"  "$TMP/list-clean-big.txt"
+make_repo "$TMP/p8-small"  "$TMP/list-p8-small.txt"
+
+# --- A9 / A10: the fixture's own preconditions ------------------------------
+# These gate every other arm. Assert them before reading any verdict, or a
+# shrunken fixture turns the suite green while measuring nothing.
+#
+# Redirect to a file rather than piping into `wc`/`head`: `git … | head -1` is
+# the defect under test, and the first draft of this file killed itself with it
+# (exit 141) before reaching a single verdict. Any early-exiting reader will do
+# it — reading the list once, then measuring the file, is the shape to copy.
+git -C "$TMP/p8-big" diff --cached --name-only > "$TMP/staged-p8-big.txt"
+
+size="$(wc -c < "$TMP/staged-p8-big.txt" | tr -d ' ')"
+if [ "$size" -gt 262144 ]; then
+  ok "A9 staged name list is $size bytes (> 256 KiB)"
+else
+  bad "A9 staged name list is only $size bytes — too small to arm the defect;" \
+      "every other arm below is now vacuous"
+fi
+
+first="$(head -1 "$TMP/staged-p8-big.txt")"
+if [ "$first" = "$P8_PATH" ]; then
+  ok "A10 the .p8 sorts first, so grep -q would exit on line 1"
+else
+  bad "A10 first staged path is '$first', expected '$P8_PATH' — the key no longer" \
+      "sorts early, so the producer finishes before grep exits and A1 goes vacuous"
+fi
+
+# --- A4: negative control — the OLD shape must still fail open --------------
+cat > "$TMP/old-shape.sh" <<'OLD_SHAPE'
+set -euo pipefail
+if git diff --cached --name-only | grep -qE '\.p8$'; then
+  exit 1
+fi
+exit 0
+OLD_SHAPE
+set +e
+( cd "$TMP/p8-big" && bash "$TMP/old-shape.sh" ) >/dev/null 2>&1
+old_rc=$?
+set -e
+if [ "$old_rc" -eq 0 ]; then
+  ok "A4 the old shape skips on this fixture (defect is armed — A1 is meaningful)"
+else
+  bad "A4 the old shape caught the .p8 (rc=$old_rc) — the fixture no longer arms the" \
+      "defect, so A1 would pass against unfixed code. Fix the fixture, not this arm."
+fi
+
+# --- A1 / A2 / A3: the real p8 secret gate ---------------------------------
+set +e
+( cd "$TMP/p8-big" && bash "$P8_GATE" ) >/dev/null 2>&1
+rc=$?
+set -e
+if [ "$rc" -ne 0 ]; then
+  ok "A1 p8 gate rejects a staged key behind a huge staged list"
+else
+  bad "A1 p8 gate ACCEPTED a staged .p8 behind a huge staged list — an App Store" \
+      "Connect / APNs private key would be committed (#1498)"
+fi
+
+set +e
+( cd "$TMP/p8-clean" && bash "$P8_GATE" ) >/dev/null 2>&1
+rc=$?
+set -e
+if [ "$rc" -eq 0 ]; then
+  ok "A2 p8 gate passes a huge staged list with no key"
+else
+  bad "A2 p8 gate rejected a huge staged list containing no .p8 (rc=$rc)"
+fi
+
+set +e
+( cd "$TMP/p8-small" && bash "$P8_GATE" ) >/dev/null 2>&1
+rc=$?
+set -e
+if [ "$rc" -ne 0 ]; then
+  ok "A3 p8 gate rejects a staged key on a small list (positive control)"
+else
+  bad "A3 p8 gate accepted a staged .p8 on a SMALL list (rc=$rc) — the gate is broken" \
+      "outright, independently of #1498"
+fi
+
+# --- A5 / A6 / A7: the changeset classifier --------------------------------
+# `build` is the load-bearing token: ci.yml's `changes` job maps its absence to
+# ios=false, skipping lint-and-test and ui-test with all required checks green.
+out="$(bash "$CLASSIFY" < "$TMP/list-swift-big.txt")"
+if [ "$out" = "lint build" ]; then
+  ok "A5 classifier emits 'lint build' for a huge Swift-bearing changeset"
+else
+  bad "A5 classifier emitted '$out' (expected 'lint build') for a huge Swift-bearing" \
+      "changeset — swiftlint and the iOS build are skipped locally and ios=false on CI"
+fi
+
+out="$(bash "$CLASSIFY" < "$TMP/list-swift-small.txt")"
+if [ "$out" = "lint build" ]; then
+  ok "A6 classifier emits 'lint build' for a small Swift changeset (positive control)"
+else
+  bad "A6 classifier emitted '$out' (expected 'lint build') on a SMALL changeset — the" \
+      "classifier is broken outright, independently of #1498"
+fi
+
+out="$(bash "$CLASSIFY" < "$TMP/list-safe-big.txt")"
+if [ -z "$out" ]; then
+  ok "A7 classifier stays quiet for a huge all-docs changeset (negative control)"
+else
+  bad "A7 classifier emitted '$out' for an all-docs changeset (expected empty)"
+fi
+
+# --- A8: the capture shape must abort on grep exit >= 2 ---------------------
+cat > "$TMP/rc-shape.sh" <<'RC_SHAPE'
+set -euo pipefail
+STAGED="$(cat "$1")"
+MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$2" || [ $? -eq 1 ]; })"
+printf 'reached-end:%s\n' "${MATCHED:+matched}"
+RC_SHAPE
+set +e
+bash "$TMP/rc-shape.sh" "$TMP/list-p8-big.txt" '\.p8\' >/dev/null 2>&1
+rc=$?
+set -e
+if [ "$rc" -ne 0 ]; then
+  ok "A8 capture shape aborts on a broken pattern (grep rc>=2) instead of reading empty"
+else
+  bad "A8 capture shape swallowed a broken pattern and continued — grep rc>=2 is being" \
+      "read as 'no match', which is the same fail-open #1498 fixes. On the ubuntu runner" \
+      "this also means bash 5 does not abort the assignment the way bash 3.2 does."
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "staged-trigger-pipefail-test: FAILED" >&2
+  exit 1
+fi
+echo "staged-trigger-pipefail-test: all arms passed"

--- a/scripts/tests/staged-trigger-pipefail-test.sh
+++ b/scripts/tests/staged-trigger-pipefail-test.sh
@@ -33,10 +33,12 @@
 # control that lives elsewhere stops discriminating on the day the lender
 # changes, without reddening anything here (#1481).
 #
-# Arm A8 pins that the capture shape ABORTS on grep exit >=2 (broken regex,
-# read error) instead of falling through with an empty match. Without it a
-# future edit that breaks a TRIGGER pattern re-opens the identical fail-open
-# through a different door. It is also the bash-5 canary: the fix shape was
+# Arm A8 pins that the capture SHAPE aborts on grep exit >=2 (broken regex,
+# read error) instead of falling through with an empty match — it runs a
+# heredoc copy, so it fixes the semantics of the idiom and is NOT a guard over
+# the tree: a site relaxed back to `|| true` would still pass it. See A12's
+# header for why that shape cannot be pattern-guarded. It is also the bash-5
+# canary, which is A8's load-bearing job here: the fix shape was
 # measured on bash 3.2 (what the macOS pre-commit hook runs); this arm is what
 # reddens if bash 5 on the ubuntu CI runner treats the construct differently.
 #
@@ -266,24 +268,37 @@ else
 fi
 
 # --- A12: no `| grep -q` left in the production scripts --------------------
-# Scope is the executable production surface — `scripts/*.sh` and
-# `scripts/hooks/*.sh`, tracked files only. Deliberately NOT a pathspec over
-# everything, because the precondition is "does a `pipefail` reach this site",
-# not "where does the file live". Three areas were checked and are out of
-# scope for that reason, not by omission:
+# Scope is the executable production surface — `scripts/*.sh`,
+# `scripts/hooks/*.sh` and `tools/*/scripts/*.sh`, tracked files only.
+# Deliberately NOT a pathspec over everything, because the precondition is
+# "does a `pipefail` reach this site", not "where does the file live". Three
+# areas were checked and are out of scope for that reason, not by omission:
 #   - scripts/tests/**        this file's own A4 / A11 negative controls are
 #                             literal old-shape copies and MUST stay; the other
 #                             harnesses feed short strings
-#   - .claude/skills/**       the two run_tests.sh harnesses use `set -eu` with
-#                             no pipefail; release/SKILL.md's documented
-#                             snippet reads a 3 KB Swift file in a shell that
-#                             has pipefail off
+#   - .claude/skills/**       the run_tests.sh harnesses that carry the shape
+#                             all use `set -eu` with no pipefail;
+#                             release/SKILL.md's documented snippet reads a
+#                             3 KB Swift file in a shell that has pipefail off
 #   - .github/workflows/**    a bare `run:` is `bash -e {0}`, no pipefail
 #                             (ci-workflows.md Rule 2). Latent, not live: a
 #                             later `shell: bash` on one of those steps arms
 #                             all four. Noted in the rule rather than guarded,
 #                             because guarding it here would need this file to
 #                             parse YAML step options to stay honest.
+#
+# Two regression shapes this arm does NOT catch, stated so the coverage is not
+# read as wider than it is:
+#   - `|| [ $? -eq 1 ]` relaxed back to `|| true` at a fixed site. That loses
+#     the exit->=2 discrimination without reintroducing the SIGPIPE fail-open,
+#     and it cannot be pattern-guarded here: 15 legitimate `grep … || true`
+#     uses already exist across the enumerated scripts, so the pattern would be
+#     noise. A8 pins the shape's semantics; it is not a guard over the tree.
+#   - a pipeline wrapped across lines (`producer |` at EOL, `grep -q …` on the
+#     next). `scan` is line-bound, the same blind spot ci-workflows.md §
+#     "`grep` is line-bound" documents for this repo's other call-shape guards.
+#     Zero such sites today. A trailing comment on a code line goes the other
+#     way and false-positives, which is loud rather than silent.
 #
 # Comment lines are stripped before matching. That is load-bearing and it is
 # also the guard's own weak point: every site fixed for #1498 carries a comment
@@ -354,11 +369,16 @@ fi
 # `:(glob)` is required, not decoration: a plain `scripts/*.sh` pathspec uses
 # git's wildmatch, where `*` crosses `/`, so it silently pulls in
 # scripts/tests/*.sh — including THIS file and its two deliberate old-shape
-# controls. Measured: 55 files without the magic, 34 with it.
+# controls. Measured: 55 files without the magic, 34 with it (scripts/ only).
+#
+# `tools/*/scripts/*.sh` is in scope for the same reason scripts/ is, not as an
+# afterthought: all four kmp-gate-spike scripts run `set -euo pipefail` and two
+# of them are CI gates. Zero hits there today.
 git -C "$ROOT" ls-files -- ':(glob)scripts/*.sh' ':(glob)scripts/hooks/*.sh' \
+                           ':(glob)tools/*/scripts/*.sh' \
   > "$TMP/prod-scripts.txt"
 n_files="$(wc -l < "$TMP/prod-scripts.txt" | tr -d ' ')"
-if [ "$n_files" -lt 25 ]; then
+if [ "$n_files" -lt 30 ]; then
   bad "A12 only $n_files production scripts enumerated — the ls-files pathspec stopped" \
       "matching, so a clean scan would prove nothing"
 else
@@ -374,7 +394,7 @@ while IFS= read -r f; do
 done < "$TMP/prod-scripts.txt"
 
 if [ -z "$residual" ]; then
-  ok "A12 no \`| grep -q\` remains in scripts/*.sh or scripts/hooks/*.sh"
+  ok "A12 no \`| grep -q\` remains in scripts/*.sh, scripts/hooks/*.sh or tools/*/scripts/*.sh"
 else
   bad "A12 \`| grep -q\` under pipefail still present — each of these skips silently when" \
       "its producer outruns the pipe buffer (#1498):"

--- a/scripts/tests/staged-trigger-pipefail-test.sh
+++ b/scripts/tests/staged-trigger-pipefail-test.sh
@@ -267,25 +267,77 @@ else
       "would ship a leaking archive (ADR-005 §8.5)"
 fi
 
+# --- A13: a non-ASCII staged path must not walk past an anchored TRIGGER ----
+# A second fail-open of the same family, found at the same lines: with the
+# default `core.quotepath`, git octal-escapes a non-ASCII path AND wraps it in
+# double quotes, so the leading `"` defeats a `^`-anchored prefix and the
+# trailing `"` defeats a `$`-anchored extension. Measured before the fix: the
+# real navigation-map gate exited 0 for a lone staged
+# `Pastura/Pastura/Views/日本語View.swift`.
+#
+# Driven through the p8 gate because it is the one whose verdict is an exit
+# code — and because a key is the worst thing to let through. The ASCII arm is
+# the positive control: if it ever stops rejecting, this arm's non-ASCII
+# result says nothing about quoting.
+for variant in "keys/AuthKey_日本語.p8:non-ASCII" "keys/AuthKey_ASCII.p8:ASCII control"; do
+  path="${variant%%:*}"; label="${variant#*:}"
+  repo="$TMP/nonascii-$(printf '%s' "$label" | tr -cd 'A-Za-z')"
+  printf '%s\n' "$path" > "$TMP/one-path.txt"
+  make_repo "$repo" "$TMP/one-path.txt"
+  set +e
+  ( cd "$repo" && bash "$P8_GATE" ) >/dev/null 2>&1
+  rc=$?
+  set -e
+  if [ "$rc" -ne 0 ]; then
+    ok "A13 p8 gate rejects a staged key named in $label"
+  else
+    bad "A13 p8 gate ACCEPTED a staged .p8 named in $label — git quotes and" \
+        "octal-escapes such a path, so the trailing quote defeats the \`\\.p8\$\`" \
+        "anchor. The producer needs \`-c core.quotepath=false\` (#1498)."
+  fi
+done
+
 # --- A12: no `| grep -q` left in the production scripts --------------------
+# THIS ARM GUARDS ONE SHAPE, NOT THE CLASS. It scans for `grep -q` behind a
+# pipe. The defect is broader — ANY early-exiting reader (`head`, `sed …q`,
+# `awk …exit`, `grep -m N`) does the same thing to its producer under
+# `pipefail`. `scripts/analyze-streaming-diag.sh` was a live instance of the
+# `head` variant, inside this very pathspec, that this scan could not see; it
+# is fixed on the same branch. `.claude/rules/ci-workflows.md` § "Rule 3" is
+# what covers the class. Extending `scan` to the other readers would need its
+# own C-controls and would fire on many correct `| head` uses, so the split is
+# deliberate: mechanical guard for the shape, rule text for the class.
+#
 # Scope is the executable production surface — `scripts/*.sh`,
-# `scripts/hooks/*.sh` and `tools/*/scripts/*.sh`, tracked files only.
-# Deliberately NOT a pathspec over everything, because the precondition is
-# "does a `pipefail` reach this site", not "where does the file live". Three
-# areas were checked and are out of scope for that reason, not by omission:
-#   - scripts/tests/**        this file's own A4 / A11 negative controls are
-#                             literal old-shape copies and MUST stay; the other
-#                             harnesses feed short strings
-#   - .claude/skills/**       the run_tests.sh harnesses that carry the shape
-#                             all use `set -eu` with no pipefail;
-#                             release/SKILL.md's documented snippet reads a
-#                             3 KB Swift file in a shell that has pipefail off
+# `scripts/hooks/*.sh`, `scripts/git-hooks/*` and `tools/*/scripts/*.sh`,
+# tracked files only. Deliberately NOT a pathspec over everything, because the
+# precondition is "does a `pipefail` reach this site", not "where does the file
+# live". Four areas were checked and are out of scope for that reason, not by
+# omission — none of them is excluded by an input-size argument, which § Rule 3
+# forbids:
+#   - scripts/tests/**        structural, not size: these are not shipped
+#                             gates, so a false pass here fails the tests it
+#                             guards rather than production. This file's own
+#                             A4 / A11 negative controls are literal old-shape
+#                             copies and MUST stay in any case.
+#   - .claude/skills/**       every site there is outside a `pipefail` scope —
+#                             the `run_tests.sh` harnesses and
+#                             `scenario-factory/scripts/run_scenario.sh` use
+#                             `set -eu`, and `release/SKILL.md`'s snippet is
+#                             run ad hoc in a shell with pipefail off.
 #   - .github/workflows/**    a bare `run:` is `bash -e {0}`, no pipefail
 #                             (ci-workflows.md Rule 2). Latent, not live: a
 #                             later `shell: bash` on one of those steps arms
-#                             all four. Noted in the rule rather than guarded,
-#                             because guarding it here would need this file to
-#                             parse YAML step options to stay honest.
+#                             all four. Noted in the rule and inline at the
+#                             steps, rather than guarded here, because guarding
+#                             it would need this file to parse YAML step
+#                             options to stay honest.
+#   - docs/**                 two documented snippets. `ADR-028.md`'s
+#                             regeneration loop cannot exit early at all — its
+#                             `tr '\n' ' '` leaves the stream newline-free, so
+#                             grep must reach EOF before any line can match.
+#                             `security/release-checklist.md`'s `curl -sI |
+#                             head -1` runs interactively without pipefail.
 #
 # Two regression shapes this arm does NOT catch, stated so the coverage is not
 # read as wider than it is:
@@ -381,7 +433,13 @@ fi
 # afterthought: all four kmp-gate-spike scripts run `set -euo pipefail`, two are
 # `ci.yml` gates (check-b-prime-isolation, check-suspendcontroller-drift) and a
 # third runs in `kmp-nightly.yml` (stage-framework). Zero hits there today.
+#
+# `scripts/git-hooks/*` needs its own entry because the files there are
+# EXTENSIONLESS — `pre-commit` is not `*.sh`, so no amount of `scripts/*`
+# globbing reaches it. It sets `set -euo pipefail` and orchestrates all 15
+# gates, so it satisfies the scope predicate as squarely as anything here.
 git -C "$ROOT" ls-files -- ':(glob)scripts/*.sh' ':(glob)scripts/hooks/*.sh' \
+                           ':(glob)scripts/git-hooks/*' \
                            ':(glob)tools/*/scripts/*.sh' \
   > "$TMP/prod-scripts.txt"
 n_files="$(wc -l < "$TMP/prod-scripts.txt" | tr -d ' ')"
@@ -395,16 +453,31 @@ fi
 residual=""
 while IFS= read -r f; do
   [ -n "$f" ] || continue
-  hit="$(scan "$ROOT/$f" || true)"
+  # No `|| true` on the scan: an awk that cannot read the file would otherwise
+  # return empty, which is byte-identical to "this file is clean". The whole
+  # point of C1-C8 is that a silent zero is the failure mode here.
+  set +e
+  hit="$(scan "$ROOT/$f")"
+  scan_rc=$?
+  set -e
+  if [ "$scan_rc" -ne 0 ]; then
+    bad "A12 scan failed on $f (awk rc=$scan_rc) — a failed scan reads as a clean" \
+        "file, so treat this as unscanned rather than passing"
+  fi
   [ -z "$hit" ] || residual="${residual}${hit}
 "
 done < "$TMP/prod-scripts.txt"
 
 if [ -z "$residual" ]; then
-  ok "A12 no \`| grep -q\` remains in scripts/*.sh, scripts/hooks/*.sh or tools/*/scripts/*.sh"
+  ok "A12 no \`| grep -q\` remains in any of the $n_files enumerated production scripts"
 else
   bad "A12 \`| grep -q\` under pipefail still present — each of these skips silently when" \
-      "its producer outruns the pipe buffer (#1498):"
+      "its producer outruns the pipe buffer. There is no exemption: rewrite it to capture," \
+      "per .claude/rules/ci-workflows.md § \"Rule 3\", which also explains why an" \
+      "intermediate variable alone does NOT fix it. If the producer genuinely must not be" \
+      "drained, \`; [ \"\${PIPESTATUS[1]}\" -eq 0 ]\` is correct too — but teach it to \`scan\`" \
+      "and give it a C-control before using it, or this arm will keep calling it a defect" \
+      "(#1498). Offending lines:"
   printf '%s' "$residual" >&2
 fi
 

--- a/scripts/tests/staged-trigger-pipefail-test.sh
+++ b/scripts/tests/staged-trigger-pipefail-test.sh
@@ -291,9 +291,12 @@ fi
 # read as wider than it is:
 #   - `|| [ $? -eq 1 ]` relaxed back to `|| true` at a fixed site. That loses
 #     the exit->=2 discrimination without reintroducing the SIGPIPE fail-open,
-#     and it cannot be pattern-guarded here: 15 legitimate `grep … || true`
-#     uses already exist across the enumerated scripts, so the pattern would be
-#     noise. A8 pins the shape's semantics; it is not a guard over the tree.
+#     and it cannot be pattern-guarded here: legitimate `grep … || true` uses
+#     already outnumber the guarded sites' worth of noise it would add. Count
+#     them rather than trusting a figure — the answer moves with both the
+#     enumeration below and how much of the line the pattern may span:
+#       xargs grep -hE 'grep.*\|\|[[:space:]]*true' < <enumerated files>
+#     A8 pins the shape's semantics; it is not a guard over the tree.
 #   - a pipeline wrapped across lines (`producer |` at EOL, `grep -q …` on the
 #     next). `scan` is line-bound, the same blind spot ci-workflows.md §
 #     "`grep` is line-bound" documents for this repo's other call-shape guards.
@@ -372,8 +375,9 @@ fi
 # controls. Measured: 55 files without the magic, 34 with it (scripts/ only).
 #
 # `tools/*/scripts/*.sh` is in scope for the same reason scripts/ is, not as an
-# afterthought: all four kmp-gate-spike scripts run `set -euo pipefail` and two
-# of them are CI gates. Zero hits there today.
+# afterthought: all four kmp-gate-spike scripts run `set -euo pipefail`, two are
+# `ci.yml` gates (check-b-prime-isolation, check-suspendcontroller-drift) and a
+# third runs in `kmp-nightly.yml` (stage-framework). Zero hits there today.
 git -C "$ROOT" ls-files -- ':(glob)scripts/*.sh' ':(glob)scripts/hooks/*.sh' \
                            ':(glob)tools/*/scripts/*.sh' \
   > "$TMP/prod-scripts.txt"

--- a/scripts/tests/staged-trigger-pipefail-test.sh
+++ b/scripts/tests/staged-trigger-pipefail-test.sh
@@ -265,6 +265,122 @@ else
       "would ship a leaking archive (ADR-005 §8.5)"
 fi
 
+# --- A12: no `| grep -q` left in the production scripts --------------------
+# Scope is the executable production surface — `scripts/*.sh` and
+# `scripts/hooks/*.sh`, tracked files only. Deliberately NOT a pathspec over
+# everything, because the precondition is "does a `pipefail` reach this site",
+# not "where does the file live". Three areas were checked and are out of
+# scope for that reason, not by omission:
+#   - scripts/tests/**        this file's own A4 / A11 negative controls are
+#                             literal old-shape copies and MUST stay; the other
+#                             harnesses feed short strings
+#   - .claude/skills/**       the two run_tests.sh harnesses use `set -eu` with
+#                             no pipefail; release/SKILL.md's documented
+#                             snippet reads a 3 KB Swift file in a shell that
+#                             has pipefail off
+#   - .github/workflows/**    a bare `run:` is `bash -e {0}`, no pipefail
+#                             (ci-workflows.md Rule 2). Latent, not live: a
+#                             later `shell: bash` on one of those steps arms
+#                             all four. Noted in the rule rather than guarded,
+#                             because guarding it here would need this file to
+#                             parse YAML step options to stay honest.
+#
+# Comment lines are stripped before matching. That is load-bearing and it is
+# also the guard's own weak point: every site fixed for #1498 carries a comment
+# that quotes the banned shape, so without stripping this arm reports its own
+# documentation, and with over-eager stripping it reports nothing at all. C1-C8
+# below pin both directions before the real scan is trusted.
+#
+# The controls are not ceremony. Two separate drafts of this pattern failed to
+# compile under BWK awk (the macOS default) — first over `\{?`, then over a
+# `-v`-mangled leading `|` — and on BOTH runs the scan still printed "no
+# `| grep -q` remains", because a pattern that never compiles matches nothing
+# and an empty result is exactly what a clean tree looks like. The controls are
+# the only reason either was caught.
+#
+# `[^|]*` on both sides of `grep` keeps the match inside ONE pipeline stage,
+# so `| { grep -E "$T" || [ $? -eq 1 ]; }` — the shape this whole PR moves to —
+# does not self-report: the `-E "$T" ` between `grep` and the `||` carries no
+# `q`, and `[^|]*` cannot reach past the `||` to find one. C5 pins that.
+#
+# The pattern is written LITERALLY in the awk program, never passed via `-v`.
+# `-v` runs escape processing first, so `\|` arrives as a bare `|`, the regex
+# then starts with an empty alternation, and BWK awk rejects it as an illegal
+# primary — see the note above for what that failure looks like from outside.
+scan() { # $@ = files; echoes offending "file:line: text"
+  awk '
+    { probe = $0; sub(/^[[:space:]]+/, "", probe) }
+    substr(probe, 1, 1) == "#" { next }
+    probe ~ /\|[^|]*grep[[:space:]][^|]*(-[A-Za-z]*q|--quiet)/ {
+      print FILENAME ":" FNR ": " $0
+    }
+  ' "$@"
+}
+
+# C1-C8: a CLASS control, not a self-match. C1/C2/C6 are the three producers the
+# defect actually appears behind in this tree (`git`, `printf`, and a multi-stage
+# pipe ending in `head`) — a pattern narrowed to one of them reads clean over
+# live instances of the others, which is exactly how the original enumeration
+# for this issue came up short by two sites. C7 guards the other direction: a
+# stray `q` inside an unrelated argument must not be read as the `-q` flag.
+cat > "$TMP/control.sh" <<'CONTROL'
+if ! git diff --cached --name-only | grep -qE "$T"; then exit 0; fi
+  if printf '%s\n' "$X" | grep -q foo; then echo hi; fi
+# Capture, don't `| grep -q`: this comment must NOT be reported.
+   # indented comment quoting `| grep -qE "$T"` must NOT be reported either.
+MATCHED="$(printf '%s\n' "$S" | { grep -E "$T" || [ $? -eq 1 ]; })"
+if git show "HEAD:$p" 2>/dev/null | head -n 14 | grep -q '^paths:'; then :; fi
+cat x | sed -e 's/seq//' | grep -E 'foo'
+LEAKED="$(nm -a "$B" | xcrun swift-demangle | { grep -i ollama || [ $? -eq 1 ]; })"
+CONTROL
+ctl="$(scan "$TMP/control.sh" || true)"
+must_hit=""
+must_miss=""
+for n in 1 2 6; do
+  case "$ctl" in *":$n: "*) : ;; *) must_hit="${must_hit}C$n " ;; esac
+done
+for n in 3 4 5 7 8; do
+  case "$ctl" in *":$n: "*) must_miss="${must_miss}C$n " ;; esac
+done
+if [ -z "$must_hit" ] && [ -z "$must_miss" ]; then
+  ok "A12 control: catches git-fed / printf-fed / head-fed old shapes; ignores comments," \
+     "both fixed shapes, and an unrelated 'seq' argument"
+else
+  bad "A12 control failed — missed: [${must_hit:-none}] false-positive: [${must_miss:-none}]." \
+      "The scan below cannot be trusted: a pattern that stops compiling or stops matching" \
+      "reports zero hits, which is indistinguishable from a clean tree. Reported lines:" "$ctl"
+fi
+
+# `:(glob)` is required, not decoration: a plain `scripts/*.sh` pathspec uses
+# git's wildmatch, where `*` crosses `/`, so it silently pulls in
+# scripts/tests/*.sh — including THIS file and its two deliberate old-shape
+# controls. Measured: 55 files without the magic, 34 with it.
+git -C "$ROOT" ls-files -- ':(glob)scripts/*.sh' ':(glob)scripts/hooks/*.sh' \
+  > "$TMP/prod-scripts.txt"
+n_files="$(wc -l < "$TMP/prod-scripts.txt" | tr -d ' ')"
+if [ "$n_files" -lt 25 ]; then
+  bad "A12 only $n_files production scripts enumerated — the ls-files pathspec stopped" \
+      "matching, so a clean scan would prove nothing"
+else
+  ok "A12 scanning $n_files tracked production scripts"
+fi
+
+residual=""
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  hit="$(scan "$ROOT/$f" || true)"
+  [ -z "$hit" ] || residual="${residual}${hit}
+"
+done < "$TMP/prod-scripts.txt"
+
+if [ -z "$residual" ]; then
+  ok "A12 no \`| grep -q\` remains in scripts/*.sh or scripts/hooks/*.sh"
+else
+  bad "A12 \`| grep -q\` under pipefail still present — each of these skips silently when" \
+      "its producer outruns the pipe buffer (#1498):"
+  printf '%s' "$residual" >&2
+fi
+
 if [ "$fail" -ne 0 ]; then
   echo "staged-trigger-pipefail-test: FAILED" >&2
   exit 1


### PR DESCRIPTION
## Summary

Under `set -o pipefail`, `producer | grep -q PATTERN` reports the pipeline as **failed when the pattern matches**: `grep -q` exits at its first hit, the still-writing producer takes SIGPIPE and returns 141, and `pipefail` promotes that to the pipeline's status. Every consumer of the shape in this tree reads that as "no match" and skips. A gate that wrongly *runs* gets noticed; one that wrongly *skips* is silent.

`#1498` reported this for 13 pre-commit sub-gates. **Re-deriving the population by mechanism rather than by the issue's pattern shape found two more sites, both worse than anything on the original list** — the issue's `git grep` is anchored on `git` as the producer, so it misses every `printf`-fed pipe, and it also misses the inverted-polarity form.

### The three tier-1 sites

| site | what it lets through |
|---|---|
| `scripts/precommit-gate-classify.sh` (2) | `lint` + `build` tokens vanish: swiftlint and the iOS build skip locally, and `ci.yml`'s `changes` job emits `ios=false`, skipping `lint-and-test` + `ui-test` with **every required check green** |
| `scripts/release.sh` | Ollama symbols ship in the signed Release archive (ADR-005 §8.5) |
| `scripts/p8-precommit-gate.sh` | a staged App Store Connect / APNs private key gets committed |

Measured end-to-end against the real scripts:

```
p8 gate            91,710 B staged list, key sorted first  -> exit 0   (commit ALLOWED)
p8 gate            small staged list, same key             -> exit 1   (positive control)

classifier         92,623 B list led by a .swift           -> ""            (no tokens)
classifier         small list, same .swift                 -> "lint build"  (positive control)

release.sh shape   1.5 MB nm dump, ollama symbol EARLY     -> guard passes (leak would ship)
release.sh shape   1.5 MB nm dump, ollama symbol LATE      -> guard fires
release.sh shape   small input, ollama present             -> guard fires  (positive control)
release.sh shape   1.5 MB, no ollama                       -> guard passes (correct)
```

The classifier case is the widest, and it bypasses **both** fail-safes `ci.yml` documents: `[ -z "$FILES" ]` does not fire (the list is non-empty) and `if ! TOKENS=$(...)` does not fire (the classifier exits 0, it just prints nothing). The release guard was working on symbol *ordering*, not on the check.

### Two more, found by `/risk-review` after the convention gate had passed

Both are the same class reached by a different mechanism, so a convention review could not see them:

- **A non-ASCII path defeats every anchored TRIGGER.** With the default `core.quotepath`, git octal-escapes such a path *and* wraps it in double quotes — the leading `"` kills a `^` anchor, the trailing `"` kills `\.swift$` / `\.p8$`. Measured: staging only `Pastura/Pastura/Views/日本語View.swift` makes the real navigation-map gate **exit 0**. `scripts/git-hooks/pre-commit` already passes `-c core.quotepath=false` at its own call site and documents why; the 13 gates it calls did not. Fixed at all 13, including the secret gate. Arm A13 covers it, with the ASCII case as positive control.
- **A live `head` instance inside the guard's own pathspec.** `scripts/analyze-streaming-diag.sh` ran `awk … | head -5 | sed …` under `set -euo pipefail`: `head` closes the pipe after 5 lines, `awk` SIGPIPEs, and the report aborts with a bare 141 and no message — **exactly when the cancel-race it hunts reproduces heavily**. Measured: 5000 matching lines abort, 3 do not. Now captures then `sed -n '1,5p'`. The A12 guard scans this file and could not see it, because it matches `grep -q` only.

That second one is why the test now states plainly that **A12 guards one shape, not the class** — `head`, `sed …q`, `awk …exit` and `grep -m N` all do the same thing to a producer, and Rule 3's text is what covers them.

### The fix

```bash
STAGED="$(git diff --cached --name-only)"
MATCHED="$(printf '%s\n' "$STAGED" | { grep -E "$TRIGGER" || [ $? -eq 1 ]; })"
if [ -z "$MATCHED" ]; then exit 0; fi
```

Three things that look interchangeable and are not, each measured:

- **Assigning to a variable first does NOT fix it.** SIGPIPE just moves from `git` to `printf`. Dropping `-q` is the fix.
- **`|| [ $? -eq 1 ]`, not `|| true`.** Exit 1 is grep's real "no match"; exit ≥2 means the pattern broke, and `|| true` maps that back onto "no match" — the same fail-open through a different door.
- **Do not fold it into `if [ -z "$(…)" ]`.** A command substitution used as an argument to `[` has its status discarded, silently losing that discrimination.

### Population

18 guarded sites across 17 production scripts, plus the CI sibling — 14 under the local pre-commit hook, the rest in `/release`, two Claude Code hooks and one CI step. Four areas were checked and are **out of scope for a stated reason, not by omission**, and none of them is excluded by an input-size argument (which Rule 3 forbids): `scripts/tests/**` (structural — not shipped gates), `.claude/skills/**` (every site outside a `pipefail` scope), `docs/**` (two snippets; ADR-028's cannot exit early at all because `tr '\n' ' '` leaves the stream newline-free), and `.github/workflows/**` — a bare `run:` is `bash -e {0}` with no pipefail (`ci-workflows.md` Rule 2), so its four `printf … | grep -q` steps are **latent, not live**. Adding `shell: bash` to one arms them, and three gate `ios` / `kmp` / `scenarios` on a file list of up to 3000 names, so an inline `⚠️` now sits at the step alongside the rule.

### Two corrections to the issue

- `scripts/measurement-transcript-precommit-gate.sh` and `scripts/tests/measurement-transcript-gate-test.sh` **do not exist**, and #1488 is an open, unimplemented refactor about measured values mirrored across `docs/**`. There is no in-repo precedent; the fix shape rests on the measurements above. (`ci.yml`'s existing Ollama guard turned out to be a real precedent — it already captured correctly.)
- The population is not 13.

## Test plan

- **New**: `scripts/tests/staged-trigger-pipefail-test.sh` — 16 assertions, CI-wired by the `*-test.sh` convention. Drives the **real** p8 gate and the **real** classifier end-to-end on a 612 KB staged fixture.
  - A9/A10 assert the fixture's own preconditions (byte size, and that the `.p8` sorts first) — without them every later arm goes vacuous on fixture drift.
  - **A4 and A11 are inlined copies of the old shape, required to MISS.** They are what proves the fixture still arms the defect; if either starts firing, the arm it guards would pass against unfixed code and it says so loudly.
  - A8 pins that the capture shape aborts on grep exit ≥2. It is also the bash-5 canary: the shape was measured on bash 3.2 (what the macOS pre-commit hook runs), no bash 5 was available locally, so the ubuntu `shell-tests` job is where bash 5 gets measured.
  - A12 is the zero-residual guard over 39 tracked production scripts — `scripts/*.sh`, `scripts/hooks/*.sh`, `scripts/git-hooks/*` (extensionless, so no `*.sh` glob reaches it) and `tools/*/scripts/*.sh` — with C1–C8 class controls.
  - A13 covers the non-ASCII path case on the p8 gate, ASCII as positive control.
- Full unit suite: `** TEST SUCCEEDED **`, 3494 tests / 286 suites. (The branch touches zero Swift files, so this cannot have moved since.)
- All 21 `scripts/tests/*-test.sh`: pass.
- Every numeric claim in the added comments re-measured against the final commit.

### Two things worth knowing about the guard

**The test's first draft killed itself with the defect under test** — it was written with `git diff --cached --name-only | head -1`, exited 141, and reached no verdict.

**A12's pattern failed to compile twice, and both times the scan printed a clean result.** First over `\{?`, then over a `-v`-mangled leading `|`. A pattern that never compiles matches nothing, and an empty result is indistinguishable from a clean tree — the C1/C2/C6 class controls are the only reason either was caught. A habitat negative control was also run for each scope: reintroducing the old shape into a real `scripts/` gate and into a real `tools/` script, confirming the guard reddens with a `file:line` citation in both.

## Device QA

実機QA不要 — shell scripts, one workflow step body, and one path-scoped rule. No Swift source, no UI surface, no `#if !targetEnvironment(simulator)` block, no Metal / llama.cpp path.

## Context-economy

**Context-economy: kept 6 paragraphs, compressed/dropped 3** — `.claude/rules/ci-workflows.md` gains +47 path-scoped lines (0 always-loaded). Applying `context-budget.md`'s classifier: KEPT the mechanism claim, the `Apply` snippet, the three-way discriminator list (each encodes the next decision), the arbitration sentence, and the scope note's live/latent split. DROPPED a 5-line paragraph that only explained why the rule was filed under its section — the section header was retitled instead. COMPRESSED the "never certify by input size" rationale and the pathspec restatement that mirrored the test file's own header (an unenforced mirror that rots on any pathspec edit). The single `#1498` reference is a pointer to per-site fail directions that live only in the issue, not a bare provenance tag; there are no bare `(#NNN)` tags in the rule.

## Review

Reviewed in two shards (19 files exceeds `subagent-usage.md` §2's >12-file hard split), both Opus:

- **A** — the tier-1 sites, the hook, the test, the guard, the rule (8 files)
- **B** — the mechanical 12-gate sweep (12 files)
- **Seam owner: A** — "does the guard cover every site B swept". Reported **COVERED**: all 12 appear in A12's enumeration, B's pre-image is shape-identical to control C1 (must-hit) and its post-image to C5 (must-miss).

Both shards returned PASS with zero Critical. Three fix iterations followed; **every finding across all three rounds was an authored-claim error in comment prose — a count, a scope note, or a mis-named cause — and none was a behaviour defect.** Notably round 2 caught that the round-1 sweep had been scoped to "the files I happened to have edited" and so skipped `p8-precommit-gate.sh`, the 13th site and the secret gate.

The review loop stopped at its 3-iteration limit. `/risk-review` then ran 8 axes across 3 `critic` clusters and returned **zero Critical** — but two Warnings were real behaviour defects the convention gate is structurally unable to see, both described above. Three review layers each surfaced a disjoint defect class: `code-reviewer` found authored-claim errors, `/risk-review` found same-class defects reached by a different mechanism, and the habitat controls found that two of my own guards were green while measuring nothing.

Closes #1498
