### PR TITLE
✨ feat: /simplify-doc — diff-scoped なコメント/ドキュメント剪定スキル

### DIFF
--- a/.claude/skills/simplify-doc/SKILL.md
+++ b/.claude/skills/simplify-doc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: simplify-doc
-description: Prune this branch's own added prose — compress or delete self-evident, redundant, or duplicated comments and documentation, gated by the five checks that make a deletion safe (back-references, duplicate claims, mirrors, self-quoted numbers, machine-parsed prose). Use when the user asks to simplify or compress docs or comments, trim what a branch added to .claude/rules, run a Context-economy pass, or 冗長なコメント / ドキュメントを削る.
+description: Prune the prose this branch added — compress or delete self-evident, redundant, or duplicated comments and documentation, behind verification gates that stop a deletion from breaking something load-bearing. Use when asked to simplify or compress docs or comments, trim what a branch added to .claude/rules, run a Context-economy pass, or 冗長なコメント / ドキュメントを削る.
 allowed-tools: Read, Write, Edit, Bash, Agent
 argument-hint: "[base-ref | dry-run]"
 ---
@@ -10,19 +10,22 @@ argument-hint: "[base-ref | dry-run]"
 One prune pass over **what this branch added**: enumerate → classify → verify →
 apply → review → report.
 
-It exists because the generation-side lever does not work. Comment and prose
-volume "tracks the model rather than recency"
-(`.claude/rules/knowledge-layering.md` § "Anti-pattern: a comment written for the
-reviewer"), so thickening the always-loaded rules that ask for restraint has no
-durable effect. The working design is the opposite: let generation be verbose,
-and make pruning an explicit pass with its own verification. What this skill adds
-over an ad-hoc "delete the redundant bits" prompt is **Step 3** — the checks that
-stop a prune from silently breaking something load-bearing.
+It exists because the generation-side lever does not work: prose volume "tracks
+the model rather than recency" (`.claude/rules/knowledge-layering.md`
+§ "Anti-pattern: a comment written for the reviewer"), so thickening the
+always-loaded rules that ask for restraint has no durable effect. Let generation
+be verbose and make pruning an explicit pass instead. What this adds over an
+ad-hoc "delete the redundant bits" prompt is **Step 3** — the checks that stop a
+prune from silently breaking something load-bearing.
 
-Skill files are not always-loaded (`.claude/skills/**` is outside both the
-footprint sum and the trim-nudge pathspec in
-`scripts/hooks/check-claude-md-modified.sh`), so this file costs nothing per
-turn. It is not a compression target for its own campaigns.
+This file's **body** is not always-loaded — `.claude/skills/**` is in neither the
+trim-nudge nor the footprint pathspec of
+`scripts/hooks/check-claude-md-modified.sh` — so it costs nothing per turn and is
+not a compression target for its own campaigns. The frontmatter `description:` is
+the exception, in both directions: it sits in every session's skill listing so it
+*is* paid per turn, and it is the routing surface, where a dropped trigger word
+silently stops the skill being selected and raises no error. Compress it only
+against that trade.
 
 ## What this is not
 
@@ -40,11 +43,9 @@ turn. It is not a compression target for its own campaigns.
 
 On a feature branch, normally just before `/orchestrate` Step 4 so the reviewer
 sees the pruned diff. CLAUDE.md § "Implementation Entry Point" carves this skill
-out of the `/orchestrate`-only rule on structural grounds — it edits prose, runs
-no build, touches none of the shared artifacts worktree isolation exists for,
-creates no branch and pushes nothing. The three revocable guards the carve-out
-names — Step 0's two refusals, and Step 4's explicit-path staging — are the rest
-of the grant, so do not weaken them.
+out of the `/orchestrate`-only rule and states the grounds. The three revocable
+guards the carve-out names — Step 0's two refusals, and Step 4's explicit-path
+staging — are the rest of the grant, so do not weaken them.
 
 ## Step 0 — Preflight (refuse, don't degrade)
 
@@ -115,16 +116,11 @@ bar than to a genuinely always-loaded file.
 `.claude/rules/knowledge-layering.md` (§ "Anti-pattern: a comment written for the
 reviewer", § "Where knowledge belongs") own the criteria, and both are
 always-loaded — they are already in your context, so read them there rather than
-re-deriving them. Singled out below are the three they carry that this pass needs
-most often, because they are the ones a prune gets wrong:
-
-- **Volume is the commoner defect, and it is spread across how many blocks you
-  write as well as how long each is.** Count before length.
-- Past ~10 lines, rewrite once at half length; **the rewrite wins** unless it
-  dropped a forward-looking fact.
-- A block where *no* sentence states a durable claim — only provenance, the
-  diff's own argument, or a figure a canonical site already states — belongs in
-  the PR body, not the file.
+re-deriving them. Weight three of theirs highest, because they are the ones a
+prune gets wrong: count-before-length, the half-length rewrite past ~10 lines,
+and the "no durable claim" test. Read those three at the source, not off this
+sentence — each carries an exception that licenses a **Keep**, and an abbreviated
+restatement here drops exactly those.
 
 Produce a table before touching anything: file, block anchor, verdict
 (Keep / Compress / Drop / Relocate), and one line of why. Present it. On
@@ -132,8 +128,9 @@ Produce a table before touching anything: file, block anchor, verdict
 
 ## Step 3 — Verify before deleting
 
-The checks below are the reason this skill exists. Each one has cost a real
-incident; none is optional, and a zero result from any of them is only
+The checks below are the reason this skill exists — back-references, duplicate
+claims, mirrors, self-quoted numbers, machine-parsed prose. Each one has cost a
+real incident; none is optional, and a zero result from any of them is only
 trustworthy after its control has reddened.
 
 ### A. Back-references — grep a token that cannot be line-wrapped

--- a/.claude/skills/simplify-doc/SKILL.md
+++ b/.claude/skills/simplify-doc/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: simplify-doc
-description: Prune this branch's own added prose — compress or delete self-evident, redundant, or duplicated comments and documentation, with the back-reference, duplicate-claim, and mirror checks that make a deletion safe. Use when the user asks to simplify or compress docs or comments, trim a .claude/rules addition, run a Context-economy pass, or 冗長なコメント / ドキュメントを削る.
-allowed-tools: Read, Write, Edit, Grep, Glob, Bash, Agent
+description: Prune this branch's own added prose — compress or delete self-evident, redundant, or duplicated comments and documentation, with the back-reference, duplicate-claim, and mirror checks that make a deletion safe. Use when the user asks to simplify or compress docs or comments, trim what a branch added to .claude/rules, run a Context-economy pass, or 冗長なコメント / ドキュメントを削る.
+allowed-tools: Read, Write, Edit, Bash, Agent
 argument-hint: "[base-ref | dry-run]"
 ---
 
@@ -31,7 +31,7 @@ turn. It is not a compression target for its own campaigns.
   They compose; neither substitutes.
 - **Not a review gate.** `/code-review` and the `code-reviewer` subagent judge a
   diff against conventions. This judges whether prose earns its place.
-- **Not a zero-base sweep.** See Step 1.
+- **Not a zero-base sweep.** See Step 0.5 and Step 1.
 - **Not an unattended generator**, so `.claude/rules/automation-output-contract.md`
   does not bind: a human invokes this, watches it, and reviews the commit. It
   queues no artifact into anyone's review backlog.
@@ -40,8 +40,10 @@ turn. It is not a compression target for its own campaigns.
 
 On a feature branch, normally just before `/orchestrate` Step 4 so the reviewer
 sees the pruned diff. CLAUDE.md § "Implementation Entry Point" carves this skill
-out of the `/orchestrate`-only rule; Step 0's guards are what earn that carve-out,
-so do not weaken them.
+out of the `/orchestrate`-only rule on structural grounds — it edits prose, runs
+no build, touches none of the shared artifacts worktree isolation exists for,
+creates no branch and pushes nothing. Step 0's guards are the additional layer,
+and the carve-out names them, so do not weaken them.
 
 ## Step 0 — Preflight (refuse, don't degrade)
 
@@ -51,10 +53,18 @@ so do not weaken them.
 2. **Working tree clean.** `git status --porcelain` must be empty. Uncommitted
    changes may belong to a concurrent session in another worktree; a prune that
    commits them attributes another session's work to this one. Abort and report
-   what is dirty rather than stashing it.
-3. **Resolve the base**: `BASE=$(git merge-base origin/main HEAD)` (or the
-   `base-ref` argument). `git fetch origin main` first if the branch is old.
+   what is dirty rather than stashing it. This is a point measurement — Step 6
+   re-checks before staging.
+3. **Resolve the base**: `BASE=$(git merge-base origin/main HEAD)`, after
+   `git fetch origin main`. Any argument that is not the literal `dry-run` is a
+   base-ref: validate it with `git rev-parse --verify "$ARG^{commit}"` and abort
+   on failure, so a typo fails here rather than as a raw git error in Step 1.
 4. If the argument is `dry-run`, stop after Step 2 and report the table.
+5. **If the request reads as zero-base** — "make `.claude/rules` carry only what
+   it needs", or it names files this branch never touched — say so *before*
+   starting, and offer the choice: diff-scoped now, diff-scoped plus a named
+   follow-up campaign, or stop. Silently narrowing the ask is the failure mode
+   here; the maintainer's habitual phrasing for this task often reads zero-base.
 
 ## Step 1 — Enumerate the population, then scope
 
@@ -70,6 +80,15 @@ Everything with a non-zero added count is a candidate; nothing else is in scope.
 is obviously worse than what you are pruning — that is a separate, deliberate
 campaign, and mixing the two makes the diff unreviewable.
 
+Two boundaries the diff alone will not settle:
+
+- A `+`/`-` pair with **identical** content is a reflow — not new prose, leave
+  it. A pair whose content **changed** is a rewrite, and its substance predates
+  this branch: out of scope unless the branch authored the claim it now makes.
+- A **whole new file** gets a file-level verdict first — does this belong in
+  this tier at all (`knowledge-layering.md` § "Where knowledge belongs")? Check A
+  is vacuous for one: nothing can cite what did not exist.
+
 Split the candidates into three classes and enumerate each:
 
 ```bash
@@ -84,16 +103,18 @@ git diff -U0 "$BASE"...HEAD -- '*.swift' '*.kt' '*.sh' '*.py' \
 git diff --numstat "$BASE"...HEAD -- docs README.md CONTRIBUTING.md
 ```
 
-A comment that a reformat merely **reflowed** appears as a `+`/`-` pair with the
-same content. It is not new prose; leave it alone.
+`.claude/skills/**` is in the first list so a prune can see it, but it is
+budgeted per *invocation*, not per turn — apply the classifier there at a looser
+bar than to a genuinely always-loaded file.
 
 ## Step 2 — Classify each candidate block
 
 `.claude/rules/context-budget.md` (Keep / Drop / relocate) and
 `.claude/rules/knowledge-layering.md` (§ "Anti-pattern: a comment written for the
-reviewer", § "Where knowledge belongs") own the criteria. **Both are
-always-loaded, so they are already in your context** — apply them, do not re-read
-or restate them here. Three points they make that this pass most often needs:
+reviewer", § "Where knowledge belongs") own the criteria, and both are
+always-loaded — they are already in your context, so read them there rather than
+re-deriving them. Singled out below are the three they carry that this pass needs
+most often, because they are the ones a prune gets wrong:
 
 - **Volume is the commoner defect, and it is spread across how many blocks you
   write as well as how long each is.** Count before length.
@@ -115,26 +136,32 @@ trustworthy after its control has reddened.
 
 ### A. Back-references — grep a token that cannot be line-wrapped
 
-Before deleting anything **named** — a section heading, a file path, an
-identifier, a table row shape, a marker string — find who cites it. Grep a
-**space-free token**: a bare filename, an identifier, an ADR number, or a single
-rare word. Never a quoted phrase or a full heading.
+Before deleting **or renaming** anything named — a section heading, a file path,
+an identifier, a table row shape, a marker string — find who cites it. A rename
+is a deletion plus an addition, so run this check on the **old** name; a retitled
+heading breaks every back-reference while never looking like a deletion.
 
-This is not a style preference. Measured in this repo: `git grep 'Verify before
-you lock it' -- '*.md'` finds three files and **misses the real citation** in
-`docs/agent-tooling/claim-verification.md`, because the phrase is hard-wrapped
-across two lines. Normalizing whitespace does not fix it either — the
-continuation line starts with a `> ` blockquote marker, so a `tr '\n' ' '` pass
-still misses it. A space-free token cannot be split across a line break, so the
-whole failure mode disappears: `git grep -lw lock` finds every citing file.
-Accept the noise. A superset you triage by hand beats a false green on a
-deletion.
+Grep a **space-free token**: a bare filename, an identifier, an ADR number, or a
+single rare word. Never a quoted phrase or a full heading. Measured in this repo:
+`git grep -l 'Verify before you lock it' -- '*.md'` does **not** list
+`docs/agent-tooling/claim-verification.md`, which cites that section — the phrase
+is hard-wrapped there. Normalizing whitespace (`tr '\n' ' '`) recovers that one
+but not a wrap whose continuation line carries a `> ` blockquote marker, as
+`knowledge-layering.md:6-7` does. A space-free token needs neither pass:
+`git grep -lw lock` lists every citing file.
 
-**Run a positive control before trusting any zero result.** Use the same command
-shape against a string you know is cited. If the control does not produce hits,
-your command is broken and the zero means nothing —
-`.claude/rules/ci-workflows.md` § "`grep` is line-bound" records the same class
-of failure from the other direction.
+**Pick the rarest space-free token, not the first, and enumerate the result.**
+Noise is the cost of the technique: `-lw lock` returns tens of files for a
+heading with two real citers, and for one whose distinctive words are all common
+(`reviewer`) it is worse. **If the result set is too large to enumerate, that IS
+the verdict: Keep**, or narrow with a second token. Never delete against a
+superset you did not read. Same shape as check B — unproven ⇒ Keep.
+
+**Run a positive control before trusting any zero result, and put the control in
+the target's habitat**: a string cited from the same file class, in the wrapped
+form you are worried about. A control that merely matches the pattern proves your
+command has no typo and nothing else. `.claude/rules/ci-workflows.md` § "`grep`
+is line-bound" records the same class of failure from the other direction.
 
 ### B. "This is a duplicate" is a claim, not an observation
 
@@ -154,9 +181,10 @@ this claim is usually false.** Unproven ⇒ Keep.
 
   Reconciliation is one-way kit → Pastura, so compressing the shared core here
   makes the next reconcile read relocated text as deletions. CONTRIBUTING.md
-  already states the norm: "Fix those upstream in claude-kit, never in the
-  mirror." Lines *this branch* added to such a file are in scope only if the
-  branch is not itself a reconcile — check its commits before assuming.
+  § "The claude-kit plugin" already states the norm: fix those upstream in
+  `claude-kit`, never in the mirror. Lines *this branch* added to such a file are
+  in scope only if the commit that added them is not itself a reconcile; resolve
+  that per commit, not per branch.
 - **Rule ↔ paired doc.** `subagent-usage.md` ↔
   `docs/agent-tooling/subagent-output-cap.md`, `knowledge-layering.md` ↔
   `docs/agent-tooling/claim-verification.md`. Each pair says to reconcile the
@@ -170,7 +198,28 @@ this claim is usually false.** Unproven ⇒ Keep.
 If a file you compressed quotes its own size, line count, or a count of
 something this pass changed, **re-measure on the final commit**
 (`.claude/rules/knowledge-layering.md` § "Verify before you lock it"). The figure
-you measured mid-pass is stale by construction.
+you measured mid-pass is stale by construction — and a sentence that documents a
+grep can itself satisfy that grep, so pin such a count with a self-excluding
+pathspec or omit the number entirely.
+
+### E. Some prose is parsed
+
+Treat these as code, not prose. Each fails **open**, so breaking one costs no
+error — only silence:
+
+- **`CLAUDE.md`'s ADR roster** must stay one line alone in its paragraph, and the
+  ADR-006 reservation row needs all three conjuncts of its table row. Both are
+  read by `.claude/skills/consistency-audit/scripts/audit_docs.py`; a reflowed
+  roster makes it skip per-ADR drift detection entirely.
+- **A `.claude/rules/*.md` `paths:` block.** Compressing it changes what the rule
+  fires on, *and* re-tiers the file in the trim nudge and footprint sum — both
+  decide always-loaded vs path-scoped purely on whether the frontmatter carries a
+  `^paths:` line. A rules file whose frontmatter is touched also needs re-probing
+  (`knowledge-layering.md` § "A rules file created mid-session never injects in
+  that session").
+
+`/consistency-audit` catches roster damage only after the fact — it is a
+generator, not a gate.
 
 ## Step 4 — Apply
 
@@ -194,9 +243,10 @@ you measured mid-pass is stale by construction.
 
 Round 1: `code-reviewer` on the branch diff.
 
-**If the pass touched `CLAUDE.md`, `.claude/rules/**`, `.claude/agents/**`, or
-`.claude/skills/**`, `code-reviewer` alone is not enough.** A conventions gate
-has no higher convention to judge against when the artifact under review *is* the
+**If the pass touched `CLAUDE.md`, `.claude/rules/**`, `.claude/agents/**`,
+`.claude/skills/**`, or any file whose comments guard a test assertion or a gate
+(`scripts/**`), `code-reviewer` alone is not enough.** A conventions gate has no
+higher convention to judge against when the artifact under review *is* the
 conventions — a structural blind spot, not a quality one. Add
 `/claude-kit:risk-review` (preferred; confirm the namespaced name resolves), or
 fall back to `claude-kit:critic` — which CLAUDE.md § "Agent Tooling Dependency"
@@ -210,6 +260,8 @@ already declares as a hard dependency — with these axes stated explicitly:
 4. Is a mirrored pair now inconsistent?
 5. Did the pass delete backward-looking prose that was making a forward rule
    intelligible?
+6. Did a deletion remove the only warning protecting a fragile coupling? Check A
+   protects what is *cited*; a comment nobody cites is invisible to it.
 
 **Round 2 runs as a fresh subagent whose prompt carries only the diff and the
 file paths — never round 1's output.** A second round that can see the first
@@ -220,14 +272,19 @@ opening a third.
 
 ## Step 6 — Commit and report
 
-Commit with `📝 docs:` (or `♻️ refactor:` when the pass restructures rather than
-removes), staging explicit paths only.
+Immediately before staging, re-run `git status --porcelain` and confirm every
+dirty path is one this pass edited — Step 0's check was a point measurement and a
+concurrent session can dirty the tree mid-run. Then read `git diff --cached` and
+confirm the staged content is what the Step 2 table approved. Commit with
+`📝 docs:` (or `♻️ refactor:` when the pass restructures rather than removes),
+staging explicit paths only.
 
 Report:
 
 - **The arithmetic**: enumerated / kept / compressed / dropped / relocated. An
   uncounted drop is indistinguishable from a candidate never examined.
-- **What was not examined** — every file class skipped and why.
+- **What was not examined** — every file class skipped, and anything the request
+  asked for that Step 0.5 put out of scope.
 - **A ready-to-paste `Context-economy:` line** for the PR body, in the form the
   `gh pr create` nudge asks for:
   `Context-economy: kept N paragraphs, compressed/dropped M — <one-line rationale>`.

--- a/.claude/skills/simplify-doc/SKILL.md
+++ b/.claude/skills/simplify-doc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: simplify-doc
-description: Prune this branch's own added prose — compress or delete self-evident, redundant, or duplicated comments and documentation, with the back-reference, duplicate-claim, and mirror checks that make a deletion safe. Use when the user asks to simplify or compress docs or comments, trim what a branch added to .claude/rules, run a Context-economy pass, or 冗長なコメント / ドキュメントを削る.
+description: Prune this branch's own added prose — compress or delete self-evident, redundant, or duplicated comments and documentation, gated by the five checks that make a deletion safe (back-references, duplicate claims, mirrors, self-quoted numbers, machine-parsed prose). Use when the user asks to simplify or compress docs or comments, trim what a branch added to .claude/rules, run a Context-economy pass, or 冗長なコメント / ドキュメントを削る.
 allowed-tools: Read, Write, Edit, Bash, Agent
 argument-hint: "[base-ref | dry-run]"
 ---
@@ -31,7 +31,7 @@ turn. It is not a compression target for its own campaigns.
   They compose; neither substitutes.
 - **Not a review gate.** `/code-review` and the `code-reviewer` subagent judge a
   diff against conventions. This judges whether prose earns its place.
-- **Not a zero-base sweep.** See Step 0.5 and Step 1.
+- **Not a zero-base sweep.** See Step 0 item 5 and Step 1.
 - **Not an unattended generator**, so `.claude/rules/automation-output-contract.md`
   does not bind: a human invokes this, watches it, and reviews the commit. It
   queues no artifact into anyone's review backlog.
@@ -42,8 +42,9 @@ On a feature branch, normally just before `/orchestrate` Step 4 so the reviewer
 sees the pruned diff. CLAUDE.md § "Implementation Entry Point" carves this skill
 out of the `/orchestrate`-only rule on structural grounds — it edits prose, runs
 no build, touches none of the shared artifacts worktree isolation exists for,
-creates no branch and pushes nothing. Step 0's guards are the additional layer,
-and the carve-out names them, so do not weaken them.
+creates no branch and pushes nothing. The three revocable guards the carve-out
+names — Step 0's two refusals, and Step 4's explicit-path staging — are the rest
+of the grant, so do not weaken them.
 
 ## Step 0 — Preflight (refuse, don't degrade)
 
@@ -55,10 +56,11 @@ and the carve-out names them, so do not weaken them.
    commits them attributes another session's work to this one. Abort and report
    what is dirty rather than stashing it. This is a point measurement — Step 6
    re-checks before staging.
-3. **Resolve the base**: `BASE=$(git merge-base origin/main HEAD)`, after
-   `git fetch origin main`. Any argument that is not the literal `dry-run` is a
-   base-ref: validate it with `git rev-parse --verify "$ARG^{commit}"` and abort
-   on failure, so a typo fails here rather than as a raw git error in Step 1.
+3. **Resolve the base.** Any argument that is not the literal `dry-run` is a
+   base-ref and becomes `BASE`; with no argument, `git fetch origin main` then
+   `BASE=$(git merge-base origin/main HEAD)`. Either way validate before using
+   it — `git rev-parse --verify "$BASE^{commit}"` — and abort on failure, so a
+   typo fails here rather than as a raw git error in Step 1.
 4. If the argument is `dry-run`, stop after Step 2 and report the table.
 5. **If the request reads as zero-base** — "make `.claude/rules` carry only what
    it needs", or it names files this branch never touched — say so *before*
@@ -152,7 +154,7 @@ but not a wrap whose continuation line carries a `> ` blockquote marker, as
 
 **Pick the rarest space-free token, not the first, and enumerate the result.**
 Noise is the cost of the technique: `-lw lock` returns tens of files for a
-heading with two real citers, and for one whose distinctive words are all common
+heading cited from a handful, and for one whose distinctive words are all common
 (`reviewer`) it is worse. **If the result set is too large to enumerate, that IS
 the verdict: Keep**, or narrow with a second token. Never delete against a
 superset you did not read. Same shape as check B — unproven ⇒ Keep.
@@ -213,8 +215,10 @@ error — only silence:
   roster makes it skip per-ADR drift detection entirely.
 - **A `.claude/rules/*.md` `paths:` block.** Compressing it changes what the rule
   fires on, *and* re-tiers the file in the trim nudge and footprint sum — both
-  decide always-loaded vs path-scoped purely on whether the frontmatter carries a
-  `^paths:` line. A rules file whose frontmatter is touched also needs re-probing
+  decide always-loaded vs path-scoped by looking for a `^paths:` line in the
+  file's **first 14 lines only**, so padding the frontmatter past that window
+  re-tiers the file as surely as deleting the block. A rules file whose
+  frontmatter is touched also needs re-probing
   (`knowledge-layering.md` § "A rules file created mid-session never injects in
   that session").
 
@@ -284,7 +288,7 @@ Report:
 - **The arithmetic**: enumerated / kept / compressed / dropped / relocated. An
   uncounted drop is indistinguishable from a candidate never examined.
 - **What was not examined** — every file class skipped, and anything the request
-  asked for that Step 0.5 put out of scope.
+  asked for that Step 0 item 5 put out of scope.
 - **A ready-to-paste `Context-economy:` line** for the PR body, in the form the
   `gh pr create` nudge asks for:
   `Context-economy: kept N paragraphs, compressed/dropped M — <one-line rationale>`.

--- a/.claude/skills/simplify-doc/SKILL.md
+++ b/.claude/skills/simplify-doc/SKILL.md
@@ -59,9 +59,13 @@ staging — are the rest of the grant, so do not weaken them.
    re-checks before staging.
 3. **Resolve the base.** Any argument that is not the literal `dry-run` is a
    base-ref and becomes `BASE`; with no argument, `git fetch origin main` then
-   `BASE=$(git merge-base origin/main HEAD)`. Either way validate before using
-   it — `git rev-parse --verify "$BASE^{commit}"` — and abort on failure, so a
-   typo fails here rather than as a raw git error in Step 1.
+   `BASE=$(git merge-base origin/main HEAD)`. **Abort if the fetch fails** — a
+   stale `origin/main` passes every later check while moving the merge-base
+   back, so the population silently gains prose other branches already merged
+   to main: exactly the scope creep Step 1 forbids, in its quietest form.
+   Either way validate the result before using it —
+   `git rev-parse --verify "$BASE^{commit}"` — and abort on failure, so a typo
+   fails here rather than as a raw git error in Step 1.
 4. If the argument is `dry-run`, stop after Step 2 and report the table.
 5. **If the request reads as zero-base** — "make `.claude/rules` carry only what
    it needs", or it names files this branch never touched — say so *before*
@@ -105,6 +109,13 @@ git diff -U0 "$BASE"...HEAD -- '*.swift' '*.kt' '*.sh' '*.py' \
 # prose
 git diff --numstat "$BASE"...HEAD -- docs README.md CONTRIBUTING.md
 ```
+
+**The three classes are pathspecs, so they do not partition the population.**
+Compute the remainder — every file the Step 1 `--numstat` names that none of
+the three class commands matched (a YAML comment under `Resources/`, `web/`
+prose, a CI workflow) — and carry it **by name** into Step 6's "not examined"
+report. Without this a candidate in no class is invisible: it is not a skipped
+file class, because it was never in one.
 
 `.claude/skills/**` is in the first list so a prune can see it, but it is
 budgeted per *invocation*, not per turn — apply the classifier there at a looser
@@ -284,8 +295,9 @@ Report:
 
 - **The arithmetic**: enumerated / kept / compressed / dropped / relocated. An
   uncounted drop is indistinguishable from a candidate never examined.
-- **What was not examined** — every file class skipped, and anything the request
-  asked for that Step 0 item 5 put out of scope.
+- **What was not examined** — every file class skipped, Step 1's class
+  remainder, and anything the request asked for that Step 0 item 5 put out of
+  scope.
 - **A ready-to-paste `Context-economy:` line** for the PR body, in the form the
   `gh pr create` nudge asks for:
   `Context-economy: kept N paragraphs, compressed/dropped M — <one-line rationale>`.

--- a/.claude/skills/simplify-doc/SKILL.md
+++ b/.claude/skills/simplify-doc/SKILL.md
@@ -1,0 +1,238 @@
+---
+name: simplify-doc
+description: Prune this branch's own added prose — compress or delete self-evident, redundant, or duplicated comments and documentation, with the back-reference, duplicate-claim, and mirror checks that make a deletion safe. Use when the user asks to simplify or compress docs or comments, trim a .claude/rules addition, run a Context-economy pass, or 冗長なコメント / ドキュメントを削る.
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash, Agent
+argument-hint: "[base-ref | dry-run]"
+---
+
+# /simplify-doc
+
+One prune pass over **what this branch added**: enumerate → classify → verify →
+apply → review → report.
+
+It exists because the generation-side lever does not work. Comment and prose
+volume "tracks the model rather than recency"
+(`.claude/rules/knowledge-layering.md` § "Anti-pattern: a comment written for the
+reviewer"), so thickening the always-loaded rules that ask for restraint has no
+durable effect. The working design is the opposite: let generation be verbose,
+and make pruning an explicit pass with its own verification. What this skill adds
+over an ad-hoc "delete the redundant bits" prompt is **Step 3** — the checks that
+stop a prune from silently breaking something load-bearing.
+
+Skill files are not always-loaded (`.claude/skills/**` is outside both the
+footprint sum and the trim-nudge pathspec in
+`scripts/hooks/check-claude-md-modified.sh`), so this file costs nothing per
+turn. It is not a compression target for its own campaigns.
+
+## What this is not
+
+- **Not the official `/simplify`.** That one reworks *code* for reuse and
+  simplification. This one touches prose only — comments, doc comments, markdown.
+  They compose; neither substitutes.
+- **Not a review gate.** `/code-review` and the `code-reviewer` subagent judge a
+  diff against conventions. This judges whether prose earns its place.
+- **Not a zero-base sweep.** See Step 1.
+- **Not an unattended generator**, so `.claude/rules/automation-output-contract.md`
+  does not bind: a human invokes this, watches it, and reviews the commit. It
+  queues no artifact into anyone's review backlog.
+
+## Where it runs
+
+On a feature branch, normally just before `/orchestrate` Step 4 so the reviewer
+sees the pruned diff. CLAUDE.md § "Implementation Entry Point" carves this skill
+out of the `/orchestrate`-only rule; Step 0's guards are what earn that carve-out,
+so do not weaken them.
+
+## Step 0 — Preflight (refuse, don't degrade)
+
+1. **Not on the default branch.** `git branch --show-current` must differ from the
+   default branch. Abort otherwise — this skill never edits the branch `main`
+   protection exists to protect.
+2. **Working tree clean.** `git status --porcelain` must be empty. Uncommitted
+   changes may belong to a concurrent session in another worktree; a prune that
+   commits them attributes another session's work to this one. Abort and report
+   what is dirty rather than stashing it.
+3. **Resolve the base**: `BASE=$(git merge-base origin/main HEAD)` (or the
+   `base-ref` argument). `git fetch origin main` first if the branch is old.
+4. If the argument is `dry-run`, stop after Step 2 and report the table.
+
+## Step 1 — Enumerate the population, then scope
+
+Do not name files from memory or from what you happen to have open. Enumerate
+first — a tool's output is a by-product of what you asked, not the population.
+
+```bash
+git diff --numstat "$BASE"...HEAD          # every file with added lines
+```
+
+Everything with a non-zero added count is a candidate; nothing else is in scope.
+**Only lines this branch ADDED.** Pre-existing prose is out of scope even when it
+is obviously worse than what you are pruning — that is a separate, deliberate
+campaign, and mixing the two makes the diff unreviewable.
+
+Split the candidates into three classes and enumerate each:
+
+```bash
+# agent-instruction files (strictest budget)
+git diff --numstat "$BASE"...HEAD -- CLAUDE.md .claude/rules .claude/agents .claude/skills
+
+# code comments — list them with their file/hunk context
+git diff -U0 "$BASE"...HEAD -- '*.swift' '*.kt' '*.sh' '*.py' \
+  | grep -E '^(\+\+\+|@@|\+[[:space:]]*(///|//|#|\*))'
+
+# prose
+git diff --numstat "$BASE"...HEAD -- docs README.md CONTRIBUTING.md
+```
+
+A comment that a reformat merely **reflowed** appears as a `+`/`-` pair with the
+same content. It is not new prose; leave it alone.
+
+## Step 2 — Classify each candidate block
+
+`.claude/rules/context-budget.md` (Keep / Drop / relocate) and
+`.claude/rules/knowledge-layering.md` (§ "Anti-pattern: a comment written for the
+reviewer", § "Where knowledge belongs") own the criteria. **Both are
+always-loaded, so they are already in your context** — apply them, do not re-read
+or restate them here. Three points they make that this pass most often needs:
+
+- **Volume is the commoner defect, and it is spread across how many blocks you
+  write as well as how long each is.** Count before length.
+- Past ~10 lines, rewrite once at half length; **the rewrite wins** unless it
+  dropped a forward-looking fact.
+- A block where *no* sentence states a durable claim — only provenance, the
+  diff's own argument, or a figure a canonical site already states — belongs in
+  the PR body, not the file.
+
+Produce a table before touching anything: file, block anchor, verdict
+(Keep / Compress / Drop / Relocate), and one line of why. Present it. On
+`dry-run`, stop here.
+
+## Step 3 — Verify before deleting
+
+The checks below are the reason this skill exists. Each one has cost a real
+incident; none is optional, and a zero result from any of them is only
+trustworthy after its control has reddened.
+
+### A. Back-references — grep a token that cannot be line-wrapped
+
+Before deleting anything **named** — a section heading, a file path, an
+identifier, a table row shape, a marker string — find who cites it. Grep a
+**space-free token**: a bare filename, an identifier, an ADR number, or a single
+rare word. Never a quoted phrase or a full heading.
+
+This is not a style preference. Measured in this repo: `git grep 'Verify before
+you lock it' -- '*.md'` finds three files and **misses the real citation** in
+`docs/agent-tooling/claim-verification.md`, because the phrase is hard-wrapped
+across two lines. Normalizing whitespace does not fix it either — the
+continuation line starts with a `> ` blockquote marker, so a `tr '\n' ' '` pass
+still misses it. A space-free token cannot be split across a line break, so the
+whole failure mode disappears: `git grep -lw lock` finds every citing file.
+Accept the noise. A superset you triage by hand beats a false green on a
+deletion.
+
+**Run a positive control before trusting any zero result.** Use the same command
+shape against a string you know is cited. If the control does not produce hits,
+your command is broken and the zero means nothing —
+`.claude/rules/ci-workflows.md` § "`grep` is line-bound" records the same class
+of failure from the other direction.
+
+### B. "This is a duplicate" is a claim, not an observation
+
+Any verdict resting on "this already lives in X", "this is covered by Y", or
+"this is redundant with Z" must be proven: `git grep` a space-free token from the
+supposed other site, and confirm it actually says what you claim. **Historically
+this claim is usually false.** Unproven ⇒ Keep.
+
+### C. Mirrors and pairs
+
+- **claude-kit mirrors — their shared core is out of scope entirely.** Enumerate
+  them; do not work from a remembered list:
+
+  ```bash
+  git grep -l 'Derived from \[claude-kit\]'
+  ```
+
+  Reconciliation is one-way kit → Pastura, so compressing the shared core here
+  makes the next reconcile read relocated text as deletions. CONTRIBUTING.md
+  already states the norm: "Fix those upstream in claude-kit, never in the
+  mirror." Lines *this branch* added to such a file are in scope only if the
+  branch is not itself a reconcile — check its commits before assuming.
+- **Rule ↔ paired doc.** `subagent-usage.md` ↔
+  `docs/agent-tooling/subagent-output-cap.md`, `knowledge-layering.md` ↔
+  `docs/agent-tooling/claim-verification.md`. Each pair says to reconcile the
+  two together; compressing one side alone makes them disagree.
+- **CLAUDE.md ↔ README / CONTRIBUTING**, per CLAUDE.md § "Reference Documents".
+  Note that § Development Workflow is **not** in the hook's mirrored-section
+  list, so no nudge fires for it — check by hand.
+
+### D. Numbers a file states about itself
+
+If a file you compressed quotes its own size, line count, or a count of
+something this pass changed, **re-measure on the final commit**
+(`.claude/rules/knowledge-layering.md` § "Verify before you lock it"). The figure
+you measured mid-pass is stale by construction.
+
+## Step 4 — Apply
+
+- **Move whole blocks, never clauses.** A backward-looking sentence is routinely
+  what makes the forward rule intelligible; deleting it alone leaves a rule
+  nobody can act on.
+- **Compression is rewriting, so the old ledger stops applying.** After
+  rewriting a block, re-check its own claims — an assertion that survived the
+  rewrite in shortened form is a new assertion.
+- **Grep the old shape after any bulk substitution** (CLAUDE.md § "Scope &
+  Completeness Discipline"). A byte-exact multi-site replace silently skips
+  occurrences differing only in indentation, and still reports success.
+- **Stage explicit paths. Never `git add -A` or `git add -u`** — a concurrent
+  Xcode session re-serializes `*.xcstrings`, and a broad add commits phantom keys
+  under this pass's name.
+- **Record a shortfall; never invent cuts to reach a number.** The realistic
+  landing is far below what a first read makes it look like. "Examined 14 blocks,
+  kept 11" is a complete and successful outcome.
+
+## Step 5 — Review
+
+Round 1: `code-reviewer` on the branch diff.
+
+**If the pass touched `CLAUDE.md`, `.claude/rules/**`, `.claude/agents/**`, or
+`.claude/skills/**`, `code-reviewer` alone is not enough.** A conventions gate
+has no higher convention to judge against when the artifact under review *is* the
+conventions — a structural blind spot, not a quality one. Add
+`/claude-kit:risk-review` (preferred; confirm the namespaced name resolves), or
+fall back to `claude-kit:critic` — which CLAUDE.md § "Agent Tooling Dependency"
+already declares as a hard dependency — with these axes stated explicitly:
+
+1. Did a deletion remove the **only** statement of a norm, or its only worked
+   example?
+2. Does any surviving text now cite something this pass deleted?
+3. Did a compression change what a rule **fires on** while appearing only to
+   shorten it?
+4. Is a mirrored pair now inconsistent?
+5. Did the pass delete backward-looking prose that was making a forward rule
+   intelligible?
+
+**Round 2 runs as a fresh subagent whose prompt carries only the diff and the
+file paths — never round 1's output.** A second round that can see the first
+reads its own prose instead of the files, and this repo has recorded runs where
+three or four consecutive rounds found nothing but errors in text they had
+themselves written. **Cap: 2 rounds.** Report what is unresolved rather than
+opening a third.
+
+## Step 6 — Commit and report
+
+Commit with `📝 docs:` (or `♻️ refactor:` when the pass restructures rather than
+removes), staging explicit paths only.
+
+Report:
+
+- **The arithmetic**: enumerated / kept / compressed / dropped / relocated. An
+  uncounted drop is indistinguishable from a candidate never examined.
+- **What was not examined** — every file class skipped and why.
+- **A ready-to-paste `Context-economy:` line** for the PR body, in the form the
+  `gh pr create` nudge asks for:
+  `Context-economy: kept N paragraphs, compressed/dropped M — <one-line rationale>`.
+- If the pass shrank always-loaded files, the resulting total from
+  `scripts/hooks/check-claude-md-modified.sh` § 4's measurement, so the operator
+  can judge it. **Do not re-baseline `FOOTPRINT_CEILING_DEFAULT`** — that is a
+  slim-campaign duty, and a diff-scoped prune only returns the branch toward its
+  own starting point.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,11 +163,13 @@ is also exempt: a tag ref is not branch-protected, edits no tracked files, and
 is gated behind the skill's mandatory confirmation. Any *code* change a release
 needs (a `MARKETING_VERSION` bump) still goes through `/orchestrate`.
 
-`/simplify-doc` is exempt for its **edit + commit** because its preflight
-discharges both reasons above: it refuses on the default branch (push
-protection) and on a dirty working tree, staging explicit paths only
-(concurrent-session collision). It creates no branch and pushes nothing —
-weakening either guard removes the exemption.
+`/simplify-doc` is exempt for its **edit + commit**, on structural grounds like
+`/release`'s: it edits prose only and runs no build, so it never touches the
+shared artifacts the collision reason names, and it creates no branch and pushes
+nothing, so review still happens at the PR. Its preflight adds two revocable
+guards — refuse on the default branch, refuse on a dirty tree, stage explicit
+paths — which is why weakening them is a change to *this exemption*, not to the
+skill alone.
 
 ### TDD Approach
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,13 +163,13 @@ is also exempt: a tag ref is not branch-protected, edits no tracked files, and
 is gated behind the skill's mandatory confirmation. Any *code* change a release
 needs (a `MARKETING_VERSION` bump) still goes through `/orchestrate`.
 
-`/simplify-doc` is exempt for its **edit + commit**, on structural grounds like
-`/release`'s: it edits prose only and runs no build, so it never touches the
-shared artifacts the collision reason names, and it creates no branch and pushes
-nothing, so review still happens at the PR. Its preflight adds two revocable
-guards — refuse on the default branch, refuse on a dirty tree, stage explicit
-paths — which is why weakening them is a change to *this exemption*, not to the
-skill alone.
+`/simplify-doc` is exempt for its **edit + commit**. Structurally it edits prose
+only and runs no build, so it never touches the shared artifacts the collision
+reason names, and it creates no branch and pushes nothing, so review still
+happens at the PR. Three revocable guards close the rest: its preflight refuses
+on the default branch and on a dirty tree, and it stages explicit paths rather
+than `-A` / `-u`. Those are part of the grant — weaken one and this exemption
+narrows with it.
 
 ### TDD Approach
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,12 @@ is also exempt: a tag ref is not branch-protected, edits no tracked files, and
 is gated behind the skill's mandatory confirmation. Any *code* change a release
 needs (a `MARKETING_VERSION` bump) still goes through `/orchestrate`.
 
+`/simplify-doc` is exempt for its **edit + commit** because its preflight
+discharges both reasons above: it refuses on the default branch (push
+protection) and on a dirty working tree, staging explicit paths only
+(concurrent-session collision). It creates no branch and pushes nothing —
+weakening either guard removes the exemption.
+
 ### TDD Approach
 
 Engine and LLM layer: test-first (write failing test → minimal implementation → refactor).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,13 +163,11 @@ is also exempt: a tag ref is not branch-protected, edits no tracked files, and
 is gated behind the skill's mandatory confirmation. Any *code* change a release
 needs (a `MARKETING_VERSION` bump) still goes through `/orchestrate`.
 
-`/simplify-doc` is exempt for its **edit + commit**. Structurally it edits prose
-only and runs no build, so it never touches the shared artifacts the collision
-reason names, and it creates no branch and pushes nothing, so review still
-happens at the PR. Three revocable guards close the rest: its preflight refuses
-on the default branch and on a dirty tree, and it stages explicit paths rather
-than `-A` / `-u`. Those are part of the grant — weaken one and this exemption
-narrows with it.
+`/simplify-doc` is exempt for its **edit + commit**: it edits prose only, runs no
+build, and so never touches the shared artifacts the collision reason names, and
+it creates no branch and pushes nothing. Three revocable guards close the rest —
+it refuses on the default branch and on a dirty tree, and stages explicit paths —
+and weakening one narrows this exemption with it.
 
 ### TDD Approach
 

--- a/scripts/hooks/check-claude-md-modified.sh
+++ b/scripts/hooks/check-claude-md-modified.sh
@@ -42,8 +42,14 @@
 #
 #   3. Trim nudge — if the branch's ADDED lines across agent-instruction files
 #      cross a per-tier threshold, ask for a `context-budget.md` Keep/Drop
-#      pass recorded as a `Context-economy:` line in the PR body. Size is a
-#      trigger, not a verdict. Threshold rationale: #1361.
+#      pass recorded as a `Context-economy:` line in the PR body, and name
+#      `/simplify-doc` as the skill that runs it. Size is a trigger, not a
+#      verdict. Threshold rationale: #1361.
+#      The nudge stays advisory: a hook CAN refuse the `gh pr create` outright
+#      (`permissionDecision: deny`, which is unrelated to the exit-code
+#      fail-open below), and deliberately does not — a size threshold is not
+#      evidence that anything needs cutting. Text is the ceiling for anything
+#      stronger: hooks cannot invoke a skill on the operator's behalf.
 #
 #   4. Footprint nudge — if the branch ADDED lines to any ALWAYS-LOADED
 #      instruction file and the repo-wide always-loaded byte total exceeds a
@@ -289,7 +295,14 @@ if [ "$AL_ADD" -ge "$AL_TRIM_THRESHOLD" ] || [ "$PS_ADD" -ge "$PS_TRIM_THRESHOLD
   # The `Context-economy:` token is fixed on purpose: it makes compliance
   # grep-able from `gh pr list` later, which is the data source for the
   # deferred reflection-hook-backstop decision (#1361).
-  TRIM_MSG="This branch adds +${AL_ADD} always-loaded / +${PS_ADD} path-scoped lines to agent-instruction files (nudge thresholds: ${AL_TRIM_THRESHOLD} always-loaded / ${PS_TRIM_THRESHOLD} path-scoped). Size is a trigger, not a verdict: apply .claude/rules/context-budget.md's Keep/Drop classifier to each added paragraph, compress what fails it, and record the outcome in the PR body as a 'Context-economy:' line (e.g. 'Context-economy: kept N paragraphs, compressed/dropped M — one-line rationale')."
+  #
+  # APPEND ONLY. The opening sentence's `+N always-loaded / +N path-scoped`
+  # phrasing is asserted verbatim by both tier-classification positive controls
+  # (`scripts/tests/check-claude-md-modified-test.sh` cases (l) and (q) —
+  # measured by perturbing it, which reddens exactly those two). Reword it and
+  # the honest-looking fix is to loosen those assertions, retiring the only
+  # tests that prove a file was classified into the right tier.
+  TRIM_MSG="This branch adds +${AL_ADD} always-loaded / +${PS_ADD} path-scoped lines to agent-instruction files (nudge thresholds: ${AL_TRIM_THRESHOLD} always-loaded / ${PS_TRIM_THRESHOLD} path-scoped). Size is a trigger, not a verdict: apply .claude/rules/context-budget.md's Keep/Drop classifier to each added paragraph, compress what fails it, and record the outcome in the PR body as a 'Context-economy:' line (e.g. 'Context-economy: kept N paragraphs, compressed/dropped M — one-line rationale'). /simplify-doc runs that pass: it is scoped to the lines this branch added, verifies each deletion against the back-reference, duplicate-claim and mirror checks, and emits the 'Context-economy:' line for you."
 fi
 
 # --- 4. always-loaded footprint nudge (#1361 proposal B) --------------------

--- a/scripts/hooks/check-claude-md-modified.sh
+++ b/scripts/hooks/check-claude-md-modified.sh
@@ -297,12 +297,15 @@ if [ "$AL_ADD" -ge "$AL_TRIM_THRESHOLD" ] || [ "$PS_ADD" -ge "$PS_TRIM_THRESHOLD
   # deferred reflection-hook-backstop decision (#1361).
   #
   # APPEND ONLY. The opening sentence's `+N always-loaded / +N path-scoped`
-  # phrasing is asserted verbatim by both tier-classification positive controls
-  # (`scripts/tests/check-claude-md-modified-test.sh` cases (l) and (q) —
-  # measured by perturbing it, which reddens exactly those two). Reword it and
-  # the honest-looking fix is to loosen those assertions, retiring the only
-  # tests that prove a file was classified into the right tier.
-  TRIM_MSG="This branch adds +${AL_ADD} always-loaded / +${PS_ADD} path-scoped lines to agent-instruction files (nudge thresholds: ${AL_TRIM_THRESHOLD} always-loaded / ${PS_TRIM_THRESHOLD} path-scoped). Size is a trigger, not a verdict: apply .claude/rules/context-budget.md's Keep/Drop classifier to each added paragraph, compress what fails it, and record the outcome in the PR body as a 'Context-economy:' line (e.g. 'Context-economy: kept N paragraphs, compressed/dropped M — one-line rationale'). /simplify-doc runs that pass: it is scoped to the lines this branch added, verifies each deletion against the back-reference, duplicate-claim and mirror checks, and emits the 'Context-economy:' line for you."
+  # phrasing is asserted verbatim by all three tier-classification controls in
+  # `scripts/tests/check-claude-md-modified-test.sh`: (l) and (q) on the
+  # always-loaded half, (m) on the path-scoped half. Perturbing the
+  # always-loaded half reddens (l) and (q) only — so a perturbation test proves
+  # less than the enumeration does; read both halves. Reword either and the
+  # honest-looking fix is to loosen those assertions, retiring the only tests
+  # that prove a file was classified into the right tier.
+  # The `/simplify-doc` tail is asserted by case (s).
+  TRIM_MSG="This branch adds +${AL_ADD} always-loaded / +${PS_ADD} path-scoped lines to agent-instruction files (nudge thresholds: ${AL_TRIM_THRESHOLD} always-loaded / ${PS_TRIM_THRESHOLD} path-scoped). Size is a trigger, not a verdict: apply .claude/rules/context-budget.md's Keep/Drop classifier to each added paragraph, compress what fails it, and record the outcome in the PR body as a 'Context-economy:' line (e.g. 'Context-economy: kept N paragraphs, compressed/dropped M — one-line rationale'). /simplify-doc runs that pass over the lines this branch added and emits the line for you — run it before review rather than after this PR opens."
 fi
 
 # --- 4. always-loaded footprint nudge (#1361 proposal B) --------------------

--- a/scripts/tests/check-claude-md-modified-test.sh
+++ b/scripts/tests/check-claude-md-modified-test.sh
@@ -378,6 +378,19 @@ assert_rc0 r
 assert_contains r "$out" "$TRIM"
 assert_absent r "$out" "$FOOT"
 
+# --- (s) the trim nudge names the skill that runs the pass ------------------
+# The $TRIM marker predates the /simplify-doc tail and cannot discriminate it,
+# so without this case the tail could be dropped or corrupted by a later edit
+# with nothing going red. Reuses (q)'s always-loaded firing shape; asserts the
+# tail only, since the opening sentence already has three controls.
+d="$TMP/s"; new_repo "$d"
+( cd "$d"
+  for i in 1 2 3 4 5 6 7 8 9 10; do printf 'unscoped rule line %d\n' "$i" >> .claude/rules/foo.md; done
+  git commit -qam "unscoped rule growth" )
+out="$(run_hook "$d")"
+assert_rc0 s
+assert_contains s "$out" "/simplify-doc"
+
 if [ "$fail" -eq 0 ]; then
   echo "check-claude-md-modified: all cases passed"
 else


### PR DESCRIPTION
## Summary

PR の終盤で毎回手書きしていた「origin/main との差分から、自明・冗長・重複したコメント / ドキュメント記載を削除・圧縮する」パスを `/simplify-doc` スキルとして固定する。

生成側（`context-budget.md` / `knowledge-layering.md` の記載強化）で抑える方針は効かなかった。`knowledge-layering.md` § "Anti-pattern: a comment written for the reviewer" が書いているとおり、コメント量は「最近の指示」ではなくモデル特性に追随するため。よって「生成させてから刈る」を正規工程として受け入れ、**刈る側の手順と検証**を固定する。

アドホックなプロンプトに対する付加価値は **Step 3 の検査群**（過去の圧縮 PR で実際に踏んだ失敗モード）:

- **A. 後方参照** — 削除／**リネーム**の前に、**空白を含まないトークン**で引用元を grep する。行折り返しが構造的に起きえないため。最も稀なトークンを選び結果を列挙し、**列挙できない上位集合に対しては削除しない（それ自体が Keep 判定）**。ゼロ結果は生息域に置いた陽性対照が発火してから信用する
- **B. 「重複だから削る」は主張** — 移設先を grep で実在確認。未証明なら Keep
- **C. ミラー** — kit ミラーの共通核は対象外（一方向 reconcile が壊れる）、rule↔paired doc、CLAUDE.md↔README/CONTRIBUTING
- **D. ファイルが自分について述べる数** — 最終コミットで再計測
- **E. 機械可読な散文** — ADR roster の1行段落、ADR-006 行の3 conjunct、`.claude/rules/*.md` の `paths:`。いずれも fail-open なので壊しても沈黙になる

`CLAUDE.md` の `/orchestrate` エントリポイント規則に carve-out を追加し、`gh pr create` の trim nudge から `/simplify-doc` を名指しする。

### 自動発火について（確定）

公式ドキュメントで確認済み: *"Command hooks communicate through stdout, stderr, and exit codes only. They can't trigger `/` commands or tool calls."*（[hooks-guide](https://code.claude.com/docs/en/hooks-guide.md)）。全イベントにスキル起動の口はなく、フック以外の event-triggered 起動機構も存在しない。**テキスト注入が上限**。`permissionDecision: deny` はより強い結合として利用可能だが、サイズ閾値は「何かを削る必要がある」証拠ではないので意図的に採らない — スクリプトヘッダに記録した。

## Test plan

- `scripts/tests/check-claude-md-modified-test.sh` — 新規 case (s) を含め全ケース green
- シェルゲート全 22 スイート green（`scripts/*.sh` を触ったため、`.claude/rules/ci-workflows.md` の要求どおり）
- **摂動テスト2回**（緑は証拠にならないので、壊したら赤くなることを確認）:
  - `TRIM_MSG` 冒頭文を崩す → case (l) と (q) が赤 → 復元して green。`+N always-loaded / +N path-scoped` が tier 分類の陽性対照であることを実証。追記のみに制約し、その理由を `TRIM_MSG` 直上に固定
  - `/simplify-doc` の追記末尾を削除 → **case (s) のみ**が赤 → 復元して green。既存の `$TRIM` マーカーでは判別できない領域を case (s) が実際に縛っていることを実証
- iOS ビルドは pre-commit hook 経由（`scripts/**` が build-relevant）

## Review

`code-reviewer`（Opus）2周 + `/risk-review`（3クラスタ並列）。規約ゲートは審査対象が規約自身だと原理的に見られない（#1480 / #1498）ため、両方を回した。

- 1周目: Critical 1 + Warning 13。**Critical は check A の根拠が2つの別事例を混同していた** — `tr '\n' ' '` の正規化は `claim-verification.md` の折り返し引用を拾える（拾えないのは継続行に `> ` が付く形）。全指摘を実測で裏取りしてから反映
- 2周目（差分とファイルのみを渡したフレッシュな reviewer、前周の自作散文は不可視）: Critical 0 + Warning 4 で、**4件とも1周目の修正が新たに入れた欠陥**（「実引用2件」が実は4件 / CLAUDE.md が「2つのガード」と書いて3つ挙げる / `Step 0.5` への参照がどこも指していない / base-ref を検証して使っていない）
- レビューは上限2周で打ち切り。見送った提案1件（case (s) を case (q) に畳む）は理由をコミットに記録

2クラスタで carve-out の判定が OK / Warning に割れた。両者とも「実際に効いているのは構造的事実」で一致していたため、上位側（構造的根拠を主、撤回可能なガードを従）に寄せた。

## Device QA

実機QA不要 — スキル定義・エージェント指示・シェルフックのみで、アプリのコードパスに触れない。

Context-economy: CLAUDE.md に always-loaded +8行（carve-out のみ、trim nudge 閾値10未満なので自己発火せず）。スキル本体 299 行は `.claude/skills/**` で always-loaded 集計の対象外 — フックの numstat pathspec にも footprint sum にも含まれない。レビュー指摘で削ったもの: 自己言及で腐る数値2件、`TRIM_MSG` 追記の列挙的内訳（`context-budget.md` の Drop 分類に該当）、Step 2 の重複した再掲の言い訳。

Closes #1501
