### PR TITLE
♻️ refactor: 台帳 §5 を行ごとの位置照合へ（#1496 判断1 / PR1 of 2）

### DIFF
--- a/docs/design/muted-application-audit.md
+++ b/docs/design/muted-application-audit.md
@@ -166,8 +166,14 @@ runs **2.136–4.152** across them, against §8's single stated calibration of
 Computed by `DesignTokensTests+MutedAsContent`, pinned in its sibling
 `DesignTokensTests+MutedTranscript` as `opaqueGroundPins`, and held equal to this
 table by `scripts/check-measurement-transcripts.py` — edit the table alone and it
-goes red (#1488). Procedure: §8 **of this ledger**. Every other `§8` above — the
-intro paragraph, the table's calibration-point cell — is design-system.md's.
+goes red (#1488). **The rows are also where §5's check learns which dark ground
+answers which light one**: `opaqueGroundPins` is flat and its order differs from
+this table's, so nothing above this table carries that pairing. Exchange the dark
+halves of the three rows §5 names (`screenBackground`, `bubbleBackground`,
+`page`) and 28–67 §5 rows redden; exchange them among the other three and none
+does — that half of the pairing stays unguarded (#1496). Procedure: §8 **of this
+ledger**. Every other `§8` above — the intro paragraph, the table's
+calibration-point cell — is design-system.md's.
 
 ### 3.2 Composited grounds — measured, and separately from the twelve
 
@@ -190,8 +196,11 @@ neither, and was wrong three ways; the record is at ADR-028 § Amendment
 | `HighlightShareCard` model name | `moss@0.14` / `nightMoss@0.10` light leak over the card background — bound at maximum leak | 2.932 | 3.140 |
 
 Same wiring, as `washRowPins` — and the checker holds ADR-028 § Amendment
-2026-08-15's four-row copy to those pins too (#1488). Until then the transcript
-claim above this table was only a claim: `DesignTokensTests+MutedAsContent`'s
+2026-08-15's four-row copy to those pins too (#1488). The `Wash over ground`
+column is read as well: its leading backticked token is what a §5 row joins on,
+so two rows sharing one raises rather than collapsing (#1496). Until then the
+transcript claim above this table was only a claim:
+`DesignTokensTests+MutedAsContent`'s
 arms were all inequalities, orderings and counts, so no ratio was named anywhere
 for a table to be a transcript *of*.
 
@@ -569,9 +578,20 @@ python3 scripts/check-measurement-transcripts.py --residue
 three-decimal ratios, but of a different population (ground-vs-ground contrast,
 per-channel pair gaps), none a copy of these pins.
 
-§5 is the one face that moved from that list into the gate: its per-site
-`light/dark` column is checked for **membership** — every figure there must be
-one the fixture computes somewhere. Not a bijection, because §5 quantifies its
-ground freely ("`screenBackground` or `bubbleBackground`", "same", "worst") and
-deciding which pin a row *ought* to carry is a judgment (#1496). So a row
-carrying another row's value still passes.
+§5 is the one face that moved from that list into the gate, and it is checked
+**row by row**: each row's `light/dark` figures must equal the pin its own
+`Ground` cell names (#1496). A row carrying *another* row's value goes red —
+which membership alone could not see, since every such figure is still a pin.
+
+The mapping is derived, not hand-kept. §3.1 supplies the light↔dark pairing and
+§3.2's `Wash over ground` column the wash join, so perturbing either reddens
+rows here. Dispatch reads the `light/dark` cell first and the `Ground` cell only
+after: `screenBackground` and `bubbleBackground` each carry both a figure pair
+and a `—`, so reading the ground first would redden the three `#Preview` rows
+that name a real ground and measure nothing. The forms that cell may take are
+enumerated in the checker (`LEDGER_5_UNCOMPARED` and its siblings); a new one
+**raises** rather than being skipped.
+
+Membership is still run alongside it, because the two fail on disjoint defects —
+membership on a figure matching no pin at all, the row check on a row carrying
+the wrong pin's.

--- a/docs/design/muted-application-audit.md
+++ b/docs/design/muted-application-audit.md
@@ -168,12 +168,13 @@ Computed by `DesignTokensTests+MutedAsContent`, pinned in its sibling
 table by `scripts/check-measurement-transcripts.py` — edit the table alone and it
 goes red (#1488). **The rows are also where §5's check learns which dark ground
 answers which light one**: `opaqueGroundPins` is flat and its order differs from
-this table's, so nothing above this table carries that pairing. Exchange the dark
+this table's, so nothing above this table carries that pairing. Permute the dark
 halves of the three rows §5 names (`screenBackground`, `bubbleBackground`,
-`page`) and 28–67 §5 rows redden; exchange them among the other three and none
-does — that half of the pairing stays unguarded (#1496). Procedure: §8 **of this
-ledger**. Every other `§8` above — the intro paragraph, the table's
-calibration-point cell — is design-system.md's.
+`page`) and 28–72 §5 rows redden — measured over all five non-identity
+permutations, not the three transpositions alone. Permute them among the other
+three and **none** does; that half of the pairing stays unguarded (#1496).
+Procedure: §8 **of this ledger**. Every other `§8` above — the intro paragraph,
+the table's calibration-point cell — is design-system.md's.
 
 ### 3.2 Composited grounds — measured, and separately from the twelve
 
@@ -200,9 +201,8 @@ Same wiring, as `washRowPins` — and the checker holds ADR-028 § Amendment
 column is read as well: its leading backticked token is what a §5 row joins on,
 so two rows sharing one raises rather than collapsing (#1496). Until then the
 transcript claim above this table was only a claim:
-`DesignTokensTests+MutedAsContent`'s
-arms were all inequalities, orderings and counts, so no ratio was named anywhere
-for a table to be a transcript *of*.
+`DesignTokensTests+MutedAsContent`'s arms were all inequalities, orderings and
+counts, so no ratio was named anywhere for a table to be a transcript *of*.
 
 Corrections beyond the arithmetic, all from reading the sites rather than the
 table:
@@ -592,6 +592,11 @@ that name a real ground and measure nothing. The forms that cell may take are
 enumerated in the checker (`LEDGER_5_UNCOMPARED` and its siblings); a new one
 **raises** rather than being skipped.
 
-Membership is still run alongside it, because the two fail on disjoint defects —
-membership on a figure matching no pin at all, the row check on a row carrying
-the wrong pin's.
+Membership is still run alongside it, but **on today's ledger it is subsumed** —
+measured, after two drafts here claimed otherwise. A figure matching no pin
+cannot equal its own ground's pin either, so both checks redden on one; and a
+drifted sub-table header raises from both. What keeps it wired in is that the
+subsumption belongs to the *form set*: membership reads every decimal in the
+cell, the row check only cells matching a declared compared form, so a future
+unmeasured form that still carries a figure would leave one and stay in the
+other. That set is empty today.

--- a/scripts/check-measurement-transcripts.py
+++ b/scripts/check-measurement-transcripts.py
@@ -16,7 +16,9 @@ Directions differ by face, deliberately:
 - ADR-028's table is a **subset**: four of the five rows (no
   `HighlightShareCard`), worded differently for `ReportSheet`. Every ADR row
   must match a pin; a pin with no ADR row is correct.
-- §5's site column is **membership only** — see `compare_membership`.
+- §5's site column is checked **both ways**: `compare_site_rows` holds each
+  row to the pin its own `Ground` cell names, and `compare_membership` still
+  catches a figure matching no pin at all.
 
 The span sentence is anchored **structurally**: within the section, the block
 that names `DesignTokensTests+MutedTranscript` is the one claiming the fixture
@@ -157,9 +159,10 @@ LEDGER_5_CELLS = 5
 
 # §5's `light/dark` vocabulary — **eight** forms over the shipped 94 rows,
 # enumerated from the ledger rather than assumed. Dispatch reads THIS cell and
-# only then the `Ground` one: six `Ground` values carry two different ratio
-# forms, so a ground-first dispatch reddens rows whose content is correct (a
-# `#Preview` row names a real token ground and measures nothing).
+# only then the `Ground` one: `screenBackground` and `bubbleBackground` each
+# carry BOTH a figure pair and a `—`, so a ground-first dispatch reddens three
+# rows whose content is correct — `DogMark`, `PasturaCard` and `SheepAvatar`
+# name a real token ground and, being `#Preview`, measure nothing.
 #
 # Three forms are compared, `same` inherits, and the four below are the whole of
 # what §5 declines to measure. An unknown ninth **raises** — skipping by default
@@ -712,12 +715,15 @@ def compare_membership(
 ) -> list[str]:
     """Every §5 ratio must be one the fixture computes somewhere.
 
-    **Membership, not a bijection.** §5 quantifies its ground freely
-    ("`screenBackground` or `bubbleBackground`", "same", "worst"), so deciding
-    which pin a row *ought* to carry is a judgment — #1496 holds that open.
-    Membership still catches a figure hand-carried into §5 that no longer matches
-    anything the fixture computes; it does NOT catch a row carrying the wrong
-    pin's value.
+    **Membership, not a bijection**, and no longer §5's only check: which pin a
+    row ought to carry was #1496's judgment 1, and `compare_site_rows` now
+    answers it. The two are kept apart because they fail on disjoint defects —
+    this one on a figure matching **no** pin (a ground retuned and a row not
+    re-recorded), that one on a row carrying **another** row's pin.
+
+    Its table-level anchors are the other reason to keep it: `ledger_site_ratios`
+    is what raises when a sub-table's header drifts or the section empties, and
+    both comparisons would otherwise pass by reading nothing.
     """
     problems = []
     for label, value in sorted(set(found)):
@@ -771,11 +777,11 @@ def compare_site_rows(
     (`wash_row_grounds`). Perturb either and rows here redden — which is the only
     thing holding §3.1's pairing at all.
 
-    **Dispatch reads the ratio cell first.** Six `Ground` values in the shipped
-    ledger carry two different ratio forms, so a ground-first dispatch reddens a
-    `#Preview` row that names a real token ground and measures nothing. It is
+    **Dispatch reads the ratio cell first.** Two token grounds in the shipped
+    ledger carry both a figure pair and a `—`, so a ground-first dispatch reddens
+    the three `#Preview` rows that name a real ground and measure nothing. It is
     also what makes §5's two `muted@0.14` cells safe: one is a wash row, the
-    other `unmeasurable`, and only the second's ratio form separates them.
+    other `unmeasurable`, and only the ratio form separates them.
     """
     problems: list[str] = []
     for table in tables:
@@ -2021,11 +2027,11 @@ def self_test() -> int:
     # --- ledger §5 positional comparison (#1496) ------------------------
     #
     # Dispatch reads the RATIO cell first and the `Ground` cell only after. That
-    # ordering is load-bearing twice over: six `Ground` values in the shipped
-    # ledger carry two different ratio forms (a token ground with a `—` cell is
-    # a real `#Preview` shape), and §5's two `muted@0.14` cells — one a wash,
-    # one `unmeasurable` — share a leading token, so a ground-first dispatch
-    # would have to tell them apart and cannot.
+    # ordering is load-bearing twice over: two token grounds in the shipped
+    # ledger carry both a figure pair and a `—` (three `#Preview` rows), and
+    # §5's two `muted@0.14` cells — one a wash, one `unmeasurable` — share a
+    # leading token, so a ground-first dispatch would have to tell them apart
+    # and cannot.
     def positional_ledger(ledger_5: str = SYNTH_LEDGER_5_POSITIONAL, **kwargs) -> str:
         kwargs.setdefault("opaque", SYNTH_OPAQUE_TABLE_5)
         return synth_ledger(ledger_5=ledger_5, **kwargs)

--- a/scripts/check-measurement-transcripts.py
+++ b/scripts/check-measurement-transcripts.py
@@ -71,6 +71,7 @@ import re
 import subprocess
 import sys
 from pathlib import Path
+from typing import NoReturn
 
 # Repo-relative for display; `_read` resolves against the repo root so a run from
 # a subdirectory reads the right files instead of raising.
@@ -169,9 +170,11 @@ LEDGER_5_CELLS = 5
 # would let a new spelling drop rows out of the comparison silently.
 LEDGER_5_SAME = "same"
 LEDGER_5_UNCOMPARED = frozenset({"—", "unmeasured", "unmeasurable", "mixed"})
-# `worst` is matched BEFORE the plain pair, and is the only thing making a
-# two-ground cell a minimum rather than a qualifier: `moss@0.06` when selected,
-# else `bubbleBackground` also names two grounds and is not one.
+# The `worst` suffix is the only thing making a two-ground cell a minimum rather
+# than a qualifier — `moss@0.06` when selected, else `bubbleBackground` also
+# names two grounds and is not one. (Match order between these two is NOT
+# load-bearing: `LEDGER_5_INTERVAL_PAIR` is `$`-anchored and cannot match a
+# `worst` cell at any ordering. Measured, so nobody restores an inert reason.)
 LEDGER_5_WORST = re.compile(r"^(?P<light>[0-9.]+)\s*/\s*(?P<dark>[0-9.]+)\s+worst$")
 _SIDE = r"[0-9]+\.[0-9]+(?:\s*[–—〜～~-]\s*[0-9]+\.[0-9]+)?"
 LEDGER_5_INTERVAL_PAIR = re.compile(
@@ -716,14 +719,23 @@ def compare_membership(
     """Every §5 ratio must be one the fixture computes somewhere.
 
     **Membership, not a bijection**, and no longer §5's only check: which pin a
-    row ought to carry was #1496's judgment 1, and `compare_site_rows` now
-    answers it. The two are kept apart because they fail on disjoint defects —
-    this one on a figure matching **no** pin (a ground retuned and a row not
-    re-recorded), that one on a row carrying **another** row's pin.
+    row ought to carry was #1496's judgment 1, and `compare_site_rows` answers
+    it.
 
-    Its table-level anchors are the other reason to keep it: `ledger_site_ratios`
-    is what raises when a sub-table's header drifts or the section empties, and
-    both comparisons would otherwise pass by reading nothing.
+    **On today's ledger this check is subsumed, and that was measured, not
+    assumed.** A figure matching no pin cannot equal its own ground's pin either,
+    so both reddened (1 problem each) on the one injected here; and a drifted
+    sub-table header raises identically from both, since `ledger_site_rows`
+    shares `_ledger_5_tables`. Two earlier drafts of this docstring claimed
+    disjoint defects and an exclusive table anchor. Both were false.
+
+    It is kept because the subsumption is a property of the **form set**, not of
+    the two checks: `ledger_site_ratios` reads every decimal in the cell, while
+    `compare_site_rows` reads only cells matching a declared compared form. Add
+    a `LEDGER_5_UNCOMPARED` spelling that still carries a figure — an
+    approximation, a bound, a footnoted value — and those figures leave the row
+    check and stay here. Today that set is empty (measured: 0 rows), so if this
+    check is ever deleted, delete it for that reason and not as duplication.
     """
     problems = []
     for label, value in sorted(set(found)):
@@ -780,8 +792,9 @@ def compare_site_rows(
     **Dispatch reads the ratio cell first.** Two token grounds in the shipped
     ledger carry both a figure pair and a `—`, so a ground-first dispatch reddens
     the three `#Preview` rows that name a real ground and measure nothing. It is
-    also what makes §5's two `muted@0.14` cells safe: one is a wash row, the
-    other `unmeasurable`, and only the ratio form separates them.
+    also what makes §5's two distinct `muted@0.14` ground cells safe — three rows,
+    one reaching its cell through `same`: one is a wash row, the others
+    `unmeasurable`, and only the ratio form separates them.
     """
     problems: list[str] = []
     for table in tables:
@@ -823,12 +836,11 @@ def compare_site_rows(
                         f"names {len(tokens)} ground — a per-appearance minimum needs "
                         "exactly the two grounds it is taken over."
                     )
-                sides = [
-                    _opaque_expectation(token, ratio_pins, pairs, label, where)
-                    if token in ratio_pins
-                    else _unknown_ground(token, label, where)
-                    for token in tokens
-                ]
+                sides = []
+                for token in tokens:
+                    if token not in ratio_pins:
+                        _unknown_ground(token, label, where)
+                    sides.append(_opaque_expectation(token, ratio_pins, pairs, label, where))
                 low_light = min((side[0][0] for side in sides), key=float)
                 low_dark = min((side[1][0] for side in sides), key=float)
                 expected = ((low_light, low_light), (low_dark, low_dark))
@@ -839,6 +851,16 @@ def compare_site_rows(
                         f"{where}: `{label}` carries figures but its ground cell names "
                         f"no `ground` — got {ground!r}."
                     )
+                # **The first token wins, and any later one goes unchecked.**
+                # A qualified cell — `moss@0.06` when selected, else
+                # `bubbleBackground` — states a primary ground and an
+                # alternative, and only the primary is compared. One shipped row
+                # is in this shape (`ModelRow` · vendor · size meta); the other
+                # two-token cell never reaches here, its figures being
+                # `unmeasurable`. Deliberately not asserted `len(tokens) == 1`,
+                # which would redden that row on correct content — but it IS a
+                # hole, recorded rather than closed, like `ledger_opaque_pairs`'
+                # three unguarded pairs. #1496 carries it.
                 named = tokens[0]
                 if named in ratio_pins:
                     expected = _opaque_expectation(named, ratio_pins, pairs, label, where)
@@ -865,7 +887,7 @@ def compare_site_rows(
     return problems
 
 
-def _unknown_ground(token: str, label: str, where: str) -> tuple[Interval, Interval]:
+def _unknown_ground(token: str, label: str, where: str) -> NoReturn:
     raise AnchorError(
         f"{where}: `{label}` names no ground this checker can resolve — `{token}` is "
         "neither one of §3.1's light grounds nor a §3.2 wash. Add and pin the ground, "
@@ -987,10 +1009,10 @@ def collect(
     ):
         problems += compare_span(span_in(lines, where), ratio_pins, where)
 
-    # §5's per-site column, both ways round. `compare_site_rows` holds each row
-    # to the pin its own `Ground` cell names; `compare_membership` still catches
-    # a figure matching no pin at all, and carries the table-level anchors that
-    # stop a sub-table dropping out of either comparison.
+    # §5's per-site column. `compare_site_rows` holds each row to the pin its own
+    # `Ground` cell names; `compare_membership` runs alongside it and is subsumed
+    # on today's form set — its own docstring has the measurement and the one
+    # reason it is still wired in.
     pool = set(ratio_pins.values())
     for light, dark in wash_pins.values():
         pool |= {light[0], light[1], dark[0], dark[1]}
@@ -1325,7 +1347,11 @@ SYNTH_LEDGER_5_POSITIONAL = (
     "| `BetaView` · timestamp | same | same | S | — |\n"
     "| `BetaView` · degraded | same | same | S | — |\n"
     "| `BetaView` · chip | `y@0.45` | 8.300–8.400 / 8.500–8.600 | S | — |\n"
-    "| `BetaView` · sheet | sheet default | unmeasured | U | B4 |\n\n"
+    "| `BetaView` · sheet | sheet default | unmeasured | U | B4 |\n"
+    # A qualified ground: the primary token is compared and the alternative is
+    # not. The shipped ledger has one row in this shape.
+    "| `BetaView` · qualified | `x@0.14` when selected, else `alphaGround` "
+    "| 8.100 / 8.200 | S | — |\n\n"
     "### Tally\n\n"
     "| | count |\n|---|---|\n"
     "| — non-text (WCAG 1.4.11, out of §8's scope) | 16 |\n"
@@ -2029,9 +2055,9 @@ def self_test() -> int:
     # Dispatch reads the RATIO cell first and the `Ground` cell only after. That
     # ordering is load-bearing twice over: two token grounds in the shipped
     # ledger carry both a figure pair and a `—` (three `#Preview` rows), and
-    # §5's two `muted@0.14` cells — one a wash, one `unmeasurable` — share a
-    # leading token, so a ground-first dispatch would have to tell them apart
-    # and cannot.
+    # §5's two distinct `muted@0.14` ground cells — one a wash, one
+    # `unmeasurable` — share a leading token, so a ground-first dispatch would
+    # have to tell them apart and cannot.
     def positional_ledger(ledger_5: str = SYNTH_LEDGER_5_POSITIONAL, **kwargs) -> str:
         kwargs.setdefault("opaque", SYNTH_OPAQUE_TABLE_5)
         return synth_ledger(ledger_5=ledger_5, **kwargs)
@@ -2059,7 +2085,7 @@ def self_test() -> int:
         lambda: [len(table) for table in ledger_site_rows(
             section(positional_ledger(), LEDGER_5, NEXT_SECTION, "ledger §5"), "ledger §5"
         )],
-        [4, 5],
+        [4, 6],
     )
     expect(
         "ledger §5: a clean ledger reports nothing — opaque, wash, range, worst and a 2-chain",
@@ -2123,9 +2149,10 @@ def self_test() -> int:
                 .replace("`TMP`", "`y@0.45`"),
             )
         )),
-        # Four: the wash row, the two `same` rows inheriting its resolved ground,
-        # and the range row that now joins the other site.
-        4,
+        # Five: the wash row, the two `same` rows inheriting its resolved ground,
+        # the qualified row on the same primary token, and the range row that now
+        # joins the other site.
+        5,
     )
     expect_raises(
         "ledger §5: an unknown ratio form must not be skipped into silence",
@@ -2155,6 +2182,44 @@ def self_test() -> int:
                 SYNTH_LEDGER_5_POSITIONAL.replace(
                     "| `BetaView` · pill | `x@0.14` | 8.100 / 8.200 | **M (A4)** | B2 |\n", ""
                 )
+            )
+        ),
+    )
+    # The tokens[0]-wins residual, pinned so it is a recorded behaviour rather
+    # than an accident: the row above is clean against the PRIMARY ground, and
+    # reddens when given the alternative ground's figures.
+    expect(
+        "ledger §5: a qualified ground compares against its primary token only",
+        lambda: len(site_problems(
+            positional_ledger(
+                SYNTH_LEDGER_5_POSITIONAL.replace(
+                    "| `BetaView` · qualified | `x@0.14` when selected, else `alphaGround` "
+                    "| 8.100 / 8.200 |",
+                    "| `BetaView` · qualified | `x@0.14` when selected, else `alphaGround` "
+                    "| 9.111 / 9.777 |",
+                )
+            )
+        )),
+        1,
+    )
+    expect_raises(
+        "ledger §5: a row naming a DARK ground has no light figure to compare",
+        "carries as a DARK ground",
+        lambda: site_problems(
+            positional_ledger(
+                SYNTH_LEDGER_5_POSITIONAL.replace(
+                    "| `AlphaView` · caption | `alphaGround` |",
+                    "| `AlphaView` · caption | `betaGround` |",
+                )
+            )
+        ),
+    )
+    expect_raises(
+        "ledger §5: a wash ground resolving to a site the fixture does not pin",
+        "which the fixture does not pin",
+        lambda: site_problems(
+            positional_ledger(
+                wash=SYNTH_WASH_TABLE.replace("`AlphaSite.pill(.pending)`", "`GammaSite` pill"),
             )
         ),
     )

--- a/scripts/check-measurement-transcripts.py
+++ b/scripts/check-measurement-transcripts.py
@@ -394,21 +394,26 @@ def fixture_wash_pins(text: str) -> dict[str, tuple[tuple[str, str], tuple[str, 
 # --- extraction: the docs ---------------------------------------------------
 
 
-def ledger_opaque_rows(lines: list[str], where: str) -> dict[str, str]:
-    """§3.1's twelve grounds as `{ground name: ratio}`.
+def _opaque_row_cells(lines: list[str], where: str) -> list[tuple[tuple[str, str], ...]]:
+    """§3.1's rows as `((light name, light ratio), (dark name, dark ratio))`.
 
     Each row carries a light pair and a dark pair, and the ratio cells carry
     annotations (`← §8's calibration point`, `**1.234**`), so the first decimal
     in the cell is the figure and the rest is prose.
+
+    Shared by the two public readers so they cannot drift into two parses of one
+    table — and so `ledger_opaque_pairs` inherits every anchor below rather than
+    restating them.
     """
     rows = table_rows(lines, OPAQUE_TABLE_HEADER, where)
-    found: dict[str, str] = {}
+    parsed: list[tuple[tuple[str, str], ...]] = []
     for cells in rows:
         # Exact, not a floor: an inserted column shifts the ratio cells, and a
         # `< 4` floor would then read the wrong cell's figure and blame the
         # figures rather than the columns.
         if len(cells) != 4:
             raise AnchorError(f"{where}: a §3.1 row has {len(cells)} cells, expected 4.")
+        row: list[tuple[str, str]] = []
         for name_cell, ratio_cell in ((cells[0], cells[1]), (cells[2], cells[3])):
             name = BACKTICKED.search(name_cell)
             ratio = DECIMAL.search(ratio_cell)
@@ -417,16 +422,51 @@ def ledger_opaque_rows(lines: list[str], where: str) -> dict[str, str]:
                     f"{where}: a §3.1 row is not `name` + ratio — got "
                     f"{name_cell!r} / {ratio_cell!r}."
                 )
-            found[name.group(1)] = canonical(ratio.group(0))
+            row.append((name.group(1), canonical(ratio.group(0))))
+        parsed.append(tuple(row))
+    return parsed
+
+
+def ledger_opaque_rows(lines: list[str], where: str) -> dict[str, str]:
+    """§3.1's twelve grounds as `{ground name: ratio}`, both columns flattened."""
+    rows = _opaque_row_cells(lines, where)
+    found = {name: ratio for row in rows for name, ratio in row}
     # A repeated ground name would OVERWRITE, and the set-based comparison
     # downstream is blind to a multiset defect — a stale duplicate row above a
-    # correct one would pass. `table_rows` covers the empty case.
+    # correct one would pass. `table_rows` covers the empty case. This also
+    # covers `ledger_opaque_pairs`' disjointness: a name in both columns lands
+    # here as one key for two slots.
     if len(found) != 2 * len(rows):
         raise AnchorError(
             f"{where}: {len(rows)} rows yielded only {len(found)} distinct grounds — "
             "a ground name is repeated, and the duplicate would silently win."
         )
     return found
+
+
+def ledger_opaque_pairs(lines: list[str], where: str) -> dict[str, str]:
+    """§3.1's rows as `{light ground: dark ground}` — the pairing itself.
+
+    **§3.1 is the only source of this pairing**, and that is a residual rather
+    than a choice. `opaqueGroundPins` is a flat `[(name, ratio)]` carrying no
+    pair structure; its order differs from this table's; and reading either by
+    array index is what that array's own doc comment forbids. So nothing above
+    §3.1 can adjudicate *which* dark ground answers a given light one, and this
+    reader asserts nothing beyond `_opaque_row_cells`' anchors.
+
+    What does catch a swapped pairing is §5 consuming it — `compare_site_rows`
+    resolves a §5 row's dark figure through this map, so the three pairs §5
+    names (`screenBackground`, `bubbleBackground`, `page`) redden on a swap and
+    a wholesale column swap raises there as an unknown ground. The other three
+    (`whisperBubble`, `promoBackground`, `mossSoft`) stay unguarded as a
+    pairing; #1496 records that residual rather than closing it.
+    """
+    rows = _opaque_row_cells(lines, where)
+    # Runs `ledger_opaque_rows`' duplicate anchor for its side effect: without
+    # it a name repeated across the two columns would build a pairing that
+    # silently loses a row.
+    ledger_opaque_rows(lines, where)
+    return {light[0]: dark[0] for light, dark in rows}
 
 
 def _interval(cell: str, where: str) -> tuple[str, str]:
@@ -478,6 +518,54 @@ def wash_table_rows(lines: list[str], where: str) -> WashRows:
             "rows share a leading identifier, so one row's figures would never be "
             "compared. Give the table a key the truncation keeps distinct."
         )
+    # Empty-set guard lives in `table_rows` — see `ledger_opaque_rows`.
+    return found
+
+
+def wash_row_grounds(lines: list[str], where: str) -> dict[str, str]:
+    """A wash table's `Wash over ground` column as `{ground token: site key}`.
+
+    The ground token is the first backticked token of `cells[1]` — `mossDark@0.10`
+    out of `` `mossDark@0.10` over `screenBackground` / `nightBackground` ``. That
+    cell is prose past the token (it names the grounds composited under, and one
+    row says "over an unknown ground — see below"), so the token is the only part
+    two faces spell identically.
+
+    Keyed **ground → site**, the direction §5 needs: a §5 row names the wash it
+    sits on, not the §3.2 row label. Site-keyed would be wrong outright — §5 has
+    eight `ResultsView` rows and only one of them is the wash.
+
+    Nothing read this cell before (#1496). Two anchors, both raising: a cell with
+    no backticked token, and two rows sharing a token — the second would collapse
+    onto one entry and send every §5 row on that wash to the surviving row's
+    figures.
+    """
+    rows = table_rows(lines, WASH_TABLE_HEADER, where)
+    found: dict[str, str] = {}
+    for cells in rows:
+        # Exact, not a floor — see `_opaque_row_cells`.
+        if len(cells) != 4:
+            raise AnchorError(f"{where}: a wash row has {len(cells)} cells, expected 4.")
+        site = BACKTICKED.search(cells[0])
+        if not site:
+            raise AnchorError(
+                f"{where}: a wash row's Site cell names no `site` — got {cells[0]!r}."
+            )
+        key = LEADING_IDENTIFIER.match(site.group(1))
+        if not key:
+            raise AnchorError(f"{where}: a wash row's Site token is not identifier-shaped.")
+        ground = BACKTICKED.search(cells[1])
+        if not ground:
+            raise AnchorError(
+                f"{where}: a wash row names no `wash` ground in its ground cell — "
+                f"got {cells[1]!r}. §5 joins on that token."
+            )
+        if ground.group(1) in found:
+            raise AnchorError(
+                f"{where}: two wash rows share a ground token ({ground.group(1)!r}) — "
+                "§5 joins on it, so one row's figures would never be reached."
+            )
+        found[ground.group(1)] = key.group(0)
     # Empty-set guard lives in `table_rows` — see `ledger_opaque_rows`.
     return found
 
@@ -1134,6 +1222,38 @@ def self_test() -> int:
         "ledger §3.1: annotations and bold markers are stripped off the ratios",
         lambda: ledger_opaque_rows(ledger_section(r"^### 3\.1"), "ledger §3.1"),
         {"alphaGround": "9.111", "betaGround": "9.777"},
+    )
+    expect(
+        "ledger §3.1: the row-wise light↔dark pairing, which the flat pins do not carry",
+        lambda: ledger_opaque_pairs(ledger_section(r"^### 3\.1"), "ledger §3.1"),
+        {"alphaGround": "betaGround"},
+    )
+    expect(
+        "ledger §3.2: the ground token of each wash row, keyed to the same site key",
+        lambda: wash_row_grounds(ledger_section(r"^### 3\.2"), "ledger §3.2"),
+        {"x@0.14": "AlphaSite", "y@0.45": "BetaSite"},
+    )
+    expect_raises(
+        "ledger §3.2: a wash row's ground cell lost its backticks",
+        "names no `wash` ground",
+        lambda: wash_row_grounds(
+            ledger_section(
+                r"^### 3\.2",
+                ledger.replace("| `x@0.14` over a ground |", "| over a ground |"),
+            ),
+            "ledger §3.2",
+        ),
+    )
+    expect_raises(
+        "ledger §3.2: two wash rows on the same ground would collapse the §5 lookup",
+        "share a ground token",
+        lambda: wash_row_grounds(
+            ledger_section(
+                r"^### 3\.2",
+                ledger.replace("| `y@0.45` over every ground |", "| `x@0.14` over every ground |"),
+            ),
+            "ledger §3.2",
+        ),
     )
     expect(
         "ledger §3.2: a point row and a range row, keyed by the leading identifier",

--- a/scripts/check-measurement-transcripts.py
+++ b/scripts/check-measurement-transcripts.py
@@ -150,9 +150,30 @@ ADR_OMITS = frozenset({"HighlightShareCard"})
 
 LEDGER_5 = re.compile(r"^## 5\. ")
 LEDGER_5_TABLE = re.compile(r"^\|\s*Site \(file · symbol\)\s*\|")
-# The `light/dark` column, 0-indexed, of the §5 site tables.
+# The `Ground` and `light/dark` columns, 0-indexed, of the §5 site tables.
+LEDGER_5_GROUND_CELL = 1
 LEDGER_5_RATIO_CELL = 2
 LEDGER_5_CELLS = 5
+
+# §5's `light/dark` vocabulary — **eight** forms over the shipped 94 rows,
+# enumerated from the ledger rather than assumed. Dispatch reads THIS cell and
+# only then the `Ground` one: six `Ground` values carry two different ratio
+# forms, so a ground-first dispatch reddens rows whose content is correct (a
+# `#Preview` row names a real token ground and measures nothing).
+#
+# Three forms are compared, `same` inherits, and the four below are the whole of
+# what §5 declines to measure. An unknown ninth **raises** — skipping by default
+# would let a new spelling drop rows out of the comparison silently.
+LEDGER_5_SAME = "same"
+LEDGER_5_UNCOMPARED = frozenset({"—", "unmeasured", "unmeasurable", "mixed"})
+# `worst` is matched BEFORE the plain pair, and is the only thing making a
+# two-ground cell a minimum rather than a qualifier: `moss@0.06` when selected,
+# else `bubbleBackground` also names two grounds and is not one.
+LEDGER_5_WORST = re.compile(r"^(?P<light>[0-9.]+)\s*/\s*(?P<dark>[0-9.]+)\s+worst$")
+_SIDE = r"[0-9]+\.[0-9]+(?:\s*[–—〜～~-]\s*[0-9]+\.[0-9]+)?"
+LEDGER_5_INTERVAL_PAIR = re.compile(
+    r"^(?P<light>" + _SIDE + r")\s*/\s*(?P<dark>" + _SIDE + r")$"
+)
 # Three-digit precision, for deciding whether a §5 table carries *ratios* at all.
 # Plain `DECIMAL` is too loose: the `Tally` table's "WCAG 1.4.11" yields `1.4`
 # and would make it look like an unchecked ratio table. Blind spot: a §5 table
@@ -482,6 +503,8 @@ def _interval(cell: str, where: str) -> tuple[str, str]:
 
 Interval = tuple[str, str]
 WashRows = dict[str, tuple[Interval, Interval]]
+# `(label, ground cell, ratio cell)` — one §5 body row, cells unresolved.
+SiteRow = tuple[str, str, str]
 
 
 def wash_table_rows(lines: list[str], where: str) -> WashRows:
@@ -611,6 +634,27 @@ def ledger_site_ratios(lines: list[str], where: str) -> list[tuple[str, str]]:
     * an empty extraction, so an emptied §5 cannot pass by agreeing with nothing.
     """
     found: list[tuple[str, str]] = []
+    for table in _ledger_5_tables(lines, where):
+        for cells in table:
+            for value in DECIMAL.findall(cells[LEDGER_5_RATIO_CELL]):
+                found.append((cells[0], canonical(value)))
+    if not found:
+        raise AnchorError(
+            f"{where}: no ratio cell yielded a decimal — the column moved, or the "
+            "tables did. An empty extraction must not agree with an empty pin set."
+        )
+    return found
+
+
+def _ledger_5_tables(lines: list[str], where: str) -> list[list[list[str]]]:
+    """§5's site sub-tables, each as a list of body rows' cells.
+
+    Kept as a list of tables rather than one flat list because `same` inherits
+    from the row **above it in its own sub-table** — flattened, a `same` promoted
+    to the head of a sub-table would silently read the previous sub-table's last
+    row instead of raising.
+    """
+    tables: list[list[list[str]]] = []
     unmatched: list[str] = []
     i = 0
     while i < len(lines):
@@ -628,6 +672,7 @@ def ledger_site_ratios(lines: list[str], where: str) -> list[tuple[str, str]]:
             if decimals_here:
                 unmatched.append(header.strip()[:60])
             continue
+        rows: list[list[str]] = []
         for row in body:
             cells = [cell.strip() for cell in row.strip().strip("|").split("|")]
             if all(set(cell) <= set("-: ") for cell in cells):
@@ -637,20 +682,29 @@ def ledger_site_ratios(lines: list[str], where: str) -> list[tuple[str, str]]:
                     f"{where}: a row has {len(cells)} cells, expected {LEDGER_5_CELLS} — "
                     f"a column was inserted or removed: {row.strip()[:60]}"
                 )
-            label = cells[0]
-            for value in DECIMAL.findall(cells[LEDGER_5_RATIO_CELL]):
-                found.append((label, canonical(value)))
+            rows.append(cells)
+        tables.append(rows)
     if unmatched:
         raise AnchorError(
             f"{where}: {len(unmatched)} table(s) carry ratios but their header row no "
             f"longer matches, so they would go unchecked: {unmatched}"
         )
-    if not found:
+    return tables
+
+
+def ledger_site_rows(lines: list[str], where: str) -> list[list[SiteRow]]:
+    """§5's rows as `(label, ground cell, ratio cell)`, grouped per sub-table."""
+    tables = [
+        [(cells[0], cells[LEDGER_5_GROUND_CELL], cells[LEDGER_5_RATIO_CELL]) for cells in table]
+        for table in _ledger_5_tables(lines, where)
+    ]
+    if not any(tables):
         raise AnchorError(
-            f"{where}: no ratio cell yielded a decimal — the column moved, or the "
-            "tables did. An empty extraction must not agree with an empty pin set."
+            f"{where}: no site row was read — the tables moved, or every one of them "
+            "is a header with no body. An empty extraction must not pass by agreeing "
+            "with nothing."
         )
-    return found
+    return tables
 
 
 def compare_membership(
@@ -674,6 +728,143 @@ def compare_membership(
                 "names a ratio nothing computes."
             )
     return problems
+
+
+def _fmt(interval: Interval) -> str:
+    """A point as one figure, a range as `lo–hi` — the spellings §5 itself uses."""
+    return interval[0] if interval[0] == interval[1] else f"{interval[0]}–{interval[1]}"
+
+
+def _opaque_expectation(
+    token: str, ratio_pins: dict[str, str], pairs: dict[str, str], label: str, where: str
+) -> tuple[Interval, Interval]:
+    dark = pairs.get(token)
+    if dark is None:
+        raise AnchorError(
+            f"{where}: `{label}` names `{token}`, which §3.1 carries as a DARK ground. "
+            "§5's rows name the light one and reach the dark through §3.1's pairing, so "
+            "there is no light figure to compare."
+        )
+    return (
+        (ratio_pins[token], ratio_pins[token]),
+        (ratio_pins[dark], ratio_pins[dark]),
+    )
+
+
+def compare_site_rows(
+    tables: list[list[SiteRow]],
+    ratio_pins: dict[str, str],
+    wash_pins: WashRows,
+    pairs: dict[str, str],
+    wash_grounds: dict[str, str],
+    where: str,
+) -> list[str]:
+    """Every §5 row's `light/dark` cell against the pin its `Ground` cell names.
+
+    This is what `compare_membership` cannot do (#1496 judgment 1): a row
+    carrying **another** row's pinned figures is a member of the pin set and
+    passes there. Both are kept — membership still catches a figure matching no
+    pin at all, and its table anchors are what stop a sub-table dropping out.
+
+    Two derivations, neither a new hand-kept copy: the light↔dark pairing comes
+    from §3.1 (`ledger_opaque_pairs`) and the wash join from §3.2's ground column
+    (`wash_row_grounds`). Perturb either and rows here redden — which is the only
+    thing holding §3.1's pairing at all.
+
+    **Dispatch reads the ratio cell first.** Six `Ground` values in the shipped
+    ledger carry two different ratio forms, so a ground-first dispatch reddens a
+    `#Preview` row that names a real token ground and measures nothing. It is
+    also what makes §5's two `muted@0.14` cells safe: one is a wash row, the
+    other `unmeasurable`, and only the second's ratio form separates them.
+    """
+    problems: list[str] = []
+    for table in tables:
+        previous: tuple[str, str] | None = None
+        for label, ground_cell, ratio_cell in table:
+            ground, ratio = ground_cell, ratio_cell
+            if LEDGER_5_SAME in (ground_cell, ratio_cell):
+                if previous is None:
+                    raise AnchorError(
+                        f"{where}: `{label}` reads `same` as the first row of its "
+                        "sub-table, so there is nothing above it to inherit."
+                    )
+                if ground_cell == LEDGER_5_SAME:
+                    ground = previous[0]
+                if ratio_cell == LEDGER_5_SAME:
+                    ratio = previous[1]
+            # The RESOLVED cells, so a chain of `same` rows inherits transitively
+            # rather than the second one reading the literal string.
+            previous = (ground, ratio)
+
+            if ratio in LEDGER_5_UNCOMPARED:
+                continue
+            worst = LEDGER_5_WORST.match(ratio)
+            pair = None if worst else LEDGER_5_INTERVAL_PAIR.match(ratio)
+            match = worst or pair
+            if match is None:
+                raise AnchorError(
+                    f"{where}: `{label}` reads {ratio!r}, which is not one of §5's "
+                    "declared light/dark forms. Give it a comparison, or add the "
+                    "spelling to `LEDGER_5_UNCOMPARED` and say why it is not measured — "
+                    "an unknown form skipped by default is a row that drops out in "
+                    "silence."
+                )
+            tokens = BACKTICKED.findall(ground)
+            if worst:
+                if len(tokens) != 2:
+                    raise AnchorError(
+                        f"{where}: `{label}` reads a `worst` figure but its ground cell "
+                        f"names {len(tokens)} ground — a per-appearance minimum needs "
+                        "exactly the two grounds it is taken over."
+                    )
+                sides = [
+                    _opaque_expectation(token, ratio_pins, pairs, label, where)
+                    if token in ratio_pins
+                    else _unknown_ground(token, label, where)
+                    for token in tokens
+                ]
+                low_light = min((side[0][0] for side in sides), key=float)
+                low_dark = min((side[1][0] for side in sides), key=float)
+                expected = ((low_light, low_light), (low_dark, low_dark))
+                named = " / ".join(tokens) + " (worst)"
+            else:
+                if not tokens:
+                    raise AnchorError(
+                        f"{where}: `{label}` carries figures but its ground cell names "
+                        f"no `ground` — got {ground!r}."
+                    )
+                named = tokens[0]
+                if named in ratio_pins:
+                    expected = _opaque_expectation(named, ratio_pins, pairs, label, where)
+                else:
+                    site = wash_grounds.get(named)
+                    if site is None:
+                        _unknown_ground(named, label, where)
+                    if site not in wash_pins:
+                        raise AnchorError(
+                            f"{where}: `{label}` resolves through §3.2 to `{site}`, which "
+                            "the fixture does not pin."
+                        )
+                    expected = wash_pins[site]
+            got = (
+                _interval(match.group("light"), f"{where} (`{label}`)"),
+                _interval(match.group("dark"), f"{where} (`{label}`)"),
+            )
+            if got != expected:
+                problems.append(
+                    f"{where}: `{label}` on `{named}` reads "
+                    f"{_fmt(got[0])} / {_fmt(got[1])}, but the fixture pins "
+                    f"{_fmt(expected[0])} / {_fmt(expected[1])} for that ground."
+                )
+    return problems
+
+
+def _unknown_ground(token: str, label: str, where: str) -> tuple[Interval, Interval]:
+    raise AnchorError(
+        f"{where}: `{label}` names no ground this checker can resolve — `{token}` is "
+        "neither one of §3.1's light grounds nor a §3.2 wash. Add and pin the ground, "
+        "or fix the name; a ground it cannot resolve is a row it cannot judge."
+    )
 
 
 def compare_ratios(doc: dict[str, str], pins: dict[str, str], where: str) -> list[str]:
@@ -790,14 +981,24 @@ def collect(
     ):
         problems += compare_span(span_in(lines, where), ratio_pins, where)
 
-    # §5's per-site column, checked only for membership — see `compare_membership`
-    # for why the direction is weaker here than on the other faces.
+    # §5's per-site column, both ways round. `compare_site_rows` holds each row
+    # to the pin its own `Ground` cell names; `compare_membership` still catches
+    # a figure matching no pin at all, and carries the table-level anchors that
+    # stop a sub-table dropping out of either comparison.
     pool = set(ratio_pins.values())
     for light, dark in wash_pins.values():
         pool |= {light[0], light[1], dark[0], dark[1]}
     ledger_5 = section(ledger, LEDGER_5, NEXT_SECTION, "ledger §5")
     problems += compare_membership(
         ledger_site_ratios(ledger_5, "ledger §5"), pool, "ledger §5"
+    )
+    problems += compare_site_rows(
+        ledger_site_rows(ledger_5, "ledger §5"),
+        ratio_pins,
+        wash_pins,
+        ledger_opaque_pairs(ledger_31, "ledger §3.1"),
+        wash_row_grounds(ledger_32, "ledger §3.2"),
+        "ledger §5",
     )
     return problems
 
@@ -992,7 +1193,10 @@ def check() -> int:
         for problem in problems:
             print(f"  {problem}", file=sys.stderr)
         return 1
-    print("measurement-transcript gate: clean (4 faces mirrored, ledger §5 within the pin set)")
+    print(
+        "measurement-transcript gate: clean (4 faces mirrored, "
+        "ledger §5 row-by-row against the pin its ground names)"
+    )
     return 0
 
 
@@ -1073,6 +1277,49 @@ SYNTH_LEDGER_5_TABLES = (
     + SYNTH_LEDGER_5_HEADER
     + "| `BetaView` · pill | `x@0.14` | 8.100 / 8.200 | **M (A4)** | B2 |\n"
     "| `BetaView` · timestamp | same | same | S | — |\n\n"
+    "### Tally\n\n"
+    "| | count |\n|---|---|\n"
+    "| — non-text (WCAG 1.4.11, out of §8's scope) | 16 |\n"
+)
+
+
+# --- §5 positional fixtures (#1496) -----------------------------------------
+#
+# A SECOND opaque pair, and a §5 table richer than the membership one. Both are
+# separate rather than folded into the fixtures above so the membership arms keep
+# measuring what they measured: `worst` takes a per-appearance min ACROSS two
+# light grounds, which one pair cannot witness at all.
+SYNTH_FIXTURE_5 = SYNTH_FIXTURE.replace(
+    '    ("betaGround", 9.777)\n',
+    '    ("betaGround", 9.777),\n    ("gammaGround", 9.222),\n    ("deltaGround", 9.555)\n',
+)
+SYNTH_OPAQUE_TABLE_5 = (
+    SYNTH_OPAQUE_TABLE + "| `gammaGround` | 9.222 | `deltaGround` | 9.555 |\n"
+)
+
+# The `worst` row's two appearances take their minimum from DIFFERENT rows —
+# light from `alphaGround` (9.111 < 9.222), dark from `deltaGround`
+# (9.555 < 9.777). A fixture whose min came from one row could not tell a
+# per-appearance minimum from a whole-row one.
+SYNTH_LEDGER_5_POSITIONAL = (
+    "### Components\n\n"
+    + SYNTH_LEDGER_5_HEADER
+    + "| `AlphaView` · caption | `alphaGround` | 9.111 / 9.777 | S | — |\n"
+    # A token ground whose ratio cell is `—`: real (three `#Preview` rows ship
+    # this shape), and the reason dispatch reads the RATIO cell first.
+    "| `AlphaView` · preview | `alphaGround` | — | P | — |\n"
+    "| `AlphaView` · comment | — | — | C | — |\n"
+    "| `AlphaView` · worst-of-two | `alphaGround` or `gammaGround` "
+    "| 9.111 / 9.555 worst | S | — |\n\n"
+    "### Results\n\n"
+    + SYNTH_LEDGER_5_HEADER
+    + "| `BetaView` · pill | `x@0.14` | 8.100 / 8.200 | **M (A4)** | B2 |\n"
+    # A two-long `same` chain: resolving one hop leaves `degraded` reading the
+    # literal string `same`.
+    "| `BetaView` · timestamp | same | same | S | — |\n"
+    "| `BetaView` · degraded | same | same | S | — |\n"
+    "| `BetaView` · chip | `y@0.45` | 8.300–8.400 / 8.500–8.600 | S | — |\n"
+    "| `BetaView` · sheet | sheet default | unmeasured | U | B4 |\n\n"
     "### Tally\n\n"
     "| | count |\n|---|---|\n"
     "| — non-text (WCAG 1.4.11, out of §8's scope) | 16 |\n"
@@ -1769,6 +2016,152 @@ def self_test() -> int:
         "ledger §5: the section heading was renumbered",
         "the section heading is gone",
         lambda: ledger_5_of(ledger.replace("## 5. The ledger", "## 5bis. The ledger")),
+    )
+
+    # --- ledger §5 positional comparison (#1496) ------------------------
+    #
+    # Dispatch reads the RATIO cell first and the `Ground` cell only after. That
+    # ordering is load-bearing twice over: six `Ground` values in the shipped
+    # ledger carry two different ratio forms (a token ground with a `—` cell is
+    # a real `#Preview` shape), and §5's two `muted@0.14` cells — one a wash,
+    # one `unmeasurable` — share a leading token, so a ground-first dispatch
+    # would have to tell them apart and cannot.
+    def positional_ledger(ledger_5: str = SYNTH_LEDGER_5_POSITIONAL, **kwargs) -> str:
+        kwargs.setdefault("opaque", SYNTH_OPAQUE_TABLE_5)
+        return synth_ledger(ledger_5=ledger_5, **kwargs)
+
+    def site_problems(ledger_text: str = "", fixture_text: str = "") -> list[str]:
+        text = ledger_text or positional_ledger()
+        fixture = fixture_text or SYNTH_FIXTURE_5
+        return compare_site_rows(
+            ledger_site_rows(
+                section(text, LEDGER_5, NEXT_SECTION, "ledger §5"), "ledger §5"
+            ),
+            fixture_ratio_pins(fixture),
+            fixture_wash_pins(fixture),
+            ledger_opaque_pairs(
+                section(text, LEDGER_31, NEXT_SUBSECTION, "ledger §3.1"), "ledger §3.1"
+            ),
+            wash_row_grounds(
+                section(text, LEDGER_32, NEXT_SUBSECTION, "ledger §3.2"), "ledger §3.2"
+            ),
+            "ledger §5",
+        )
+
+    expect(
+        "ledger §5: rows are grouped per sub-table, so `same` cannot reach across one",
+        lambda: [len(table) for table in ledger_site_rows(
+            section(positional_ledger(), LEDGER_5, NEXT_SECTION, "ledger §5"), "ledger §5"
+        )],
+        [4, 5],
+    )
+    expect(
+        "ledger §5: a clean ledger reports nothing — opaque, wash, range, worst and a 2-chain",
+        site_problems,
+        [],
+    )
+
+    # The defect membership structurally cannot see: every figure below is a
+    # pin, just not THIS row's. #1496's own worked example.
+    def wrong_pin_report() -> tuple[int, bool, bool, bool]:
+        problems = site_problems(
+            positional_ledger(
+                SYNTH_LEDGER_5_POSITIONAL.replace(
+                    "| `BetaView` · chip | `y@0.45` | 8.300–8.400 / 8.500–8.600 |",
+                    "| `BetaView` · chip | `y@0.45` | 8.100 / 8.200 |",
+                )
+            )
+        )
+        joined = " ".join(problems)
+        return (
+            len(problems),
+            "`BetaView` · chip" in joined,
+            "y@0.45" in joined,
+            "8.100" in joined,
+        )
+
+    expect(
+        "ledger §5: a row carrying ANOTHER row's pinned figures is caught, naming both",
+        wrong_pin_report,
+        (1, True, True, True),
+    )
+    # Witness that `ledger_opaque_pairs` is consumed: the dark column is
+    # reordered, every ground still carries its own ratio (so `compare_ratios`
+    # stays green), and only the pairing moves.
+    # One row, not two. The `worst` row takes a minimum over the two grounds'
+    # dark partners, and a minimum over a SET is invariant under permuting it —
+    # so `worst` is structurally blind to a pairing swap among its own grounds.
+    # Only a row naming a single ground can witness one.
+    expect(
+        "ledger §5: §3.1's dark column reordered — the pairing is what reddens",
+        lambda: [p.split(" on ")[0] for p in site_problems(
+            positional_ledger(
+                opaque=(
+                    "| Light ground | ratio | Dark ground | ratio |\n"
+                    "|---|---|---|---|\n"
+                    "| `alphaGround` | 9.111 | `deltaGround` | 9.555 |\n"
+                    "| `gammaGround` | 9.222 | `betaGround` | **9.777** |\n"
+                ),
+            )
+        )],
+        ["ledger §5: ``AlphaView` · caption`"],
+    )
+    # Witness that `wash_row_grounds` is consumed: §3.2's two ground tokens are
+    # swapped, both rows keep their own figures, and only the join inverts.
+    expect(
+        "ledger §5: §3.2's ground tokens swapped — the wash join is what reddens",
+        lambda: len(site_problems(
+            positional_ledger(
+                wash=SYNTH_WASH_TABLE.replace("`x@0.14`", "`TMP`")
+                .replace("`y@0.45`", "`x@0.14`")
+                .replace("`TMP`", "`y@0.45`"),
+            )
+        )),
+        # Four: the wash row, the two `same` rows inheriting its resolved ground,
+        # and the range row that now joins the other site.
+        4,
+    )
+    expect_raises(
+        "ledger §5: an unknown ratio form must not be skipped into silence",
+        "is not one of §5's declared",
+        lambda: site_problems(
+            positional_ledger(
+                SYNTH_LEDGER_5_POSITIONAL.replace("| 9.111 / 9.777 |", "| probably fine |")
+            )
+        ),
+    )
+    expect_raises(
+        "ledger §5: a ground token neither §3.1 nor §3.2 carries",
+        "names no ground this checker can resolve",
+        lambda: site_problems(
+            positional_ledger(
+                SYNTH_LEDGER_5_POSITIONAL.replace(
+                    "| `BetaView` · chip | `y@0.45` |", "| `BetaView` · chip | `zeta@0.45` |"
+                )
+            )
+        ),
+    )
+    expect_raises(
+        "ledger §5: `same` as a sub-table's first body row has nothing to inherit",
+        "reads `same` as the first row",
+        lambda: site_problems(
+            positional_ledger(
+                SYNTH_LEDGER_5_POSITIONAL.replace(
+                    "| `BetaView` · pill | `x@0.14` | 8.100 / 8.200 | **M (A4)** | B2 |\n", ""
+                )
+            )
+        ),
+    )
+    expect_raises(
+        "ledger §5: `worst` needs both grounds named, not one",
+        "names 1 ground",
+        lambda: site_problems(
+            positional_ledger(
+                SYNTH_LEDGER_5_POSITIONAL.replace(
+                    "| `alphaGround` or `gammaGround` |", "| `alphaGround` |"
+                )
+            )
+        ),
     )
 
     # --- residue classification (#1496) ---------------------------------

--- a/scripts/check-measurement-transcripts.py
+++ b/scripts/check-measurement-transcripts.py
@@ -17,8 +17,9 @@ Directions differ by face, deliberately:
   `HighlightShareCard`), worded differently for `ReportSheet`. Every ADR row
   must match a pin; a pin with no ADR row is correct.
 - §5's site column is checked **both ways**: `compare_site_rows` holds each
-  row to the pin its own `Ground` cell names, and `compare_membership` still
-  catches a figure matching no pin at all.
+  row to the pin its own `Ground` cell names, and `compare_membership` holds
+  every figure to the pin set. The second is subsumed by the first on today's
+  ledger — measured, and why it stays is `compare_membership`'s docstring.
 
 The span sentence is anchored **structurally**: within the section, the block
 that names `DesignTokensTests+MutedTranscript` is the one claiming the fixture
@@ -633,10 +634,14 @@ def ledger_site_ratios(lines: list[str], where: str) -> list[tuple[str, str]]:
     `table_rows`, which stops at the first. Two anchors, both raising:
 
     * a table inside §5 that carries decimals but whose header row does **not**
-      match — a renamed or reordered column would otherwise drop that whole
-      sub-table out of the comparison while the run stayed green. The `Tally`
-      table is exempt by carrying no decimals, which is a property of the text
-      rather than a name this checker has to keep in sync.
+      match — a renamed FIRST column would otherwise drop that whole sub-table
+      out of the comparison while the run stayed green. `LEDGER_5_TABLE` anchors
+      on that cell alone, so renaming a later header is **not** caught (measured:
+      `light/dark` → `contrast` raises nothing). A reordering that keeps five
+      cells is caught only downstream and only for compared rows, where
+      `compare_site_rows` finds no backticked ground. The `Tally` table is exempt
+      by carrying no decimals, which is a property of the text rather than a name
+      this checker has to keep in sync.
     * an empty extraction, so an emptied §5 cannot pass by agreeing with nothing.
     """
     found: list[tuple[str, str]] = []
@@ -734,8 +739,13 @@ def compare_membership(
     `compare_site_rows` reads only cells matching a declared compared form. Add
     a `LEDGER_5_UNCOMPARED` spelling that still carries a figure — an
     approximation, a bound, a footnoted value — and those figures leave the row
-    check and stay here. Today that set is empty (measured: 0 rows), so if this
-    check is ever deleted, delete it for that reason and not as duplication.
+    check and stay here. Today that set is empty (measured: 0 rows).
+
+    **Reaching that state takes an edit to this file, not to the ledger**, since
+    the set is matched as an exact whole cell: a figure-bearing cell nobody
+    declared *raises* rather than being skipped. So do not test the reason by
+    writing one into §5. And if this check is ever deleted, delete it for that
+    reason and not as duplication.
     """
     problems = []
     for label, value in sorted(set(found)):
@@ -781,8 +791,9 @@ def compare_site_rows(
 
     This is what `compare_membership` cannot do (#1496 judgment 1): a row
     carrying **another** row's pinned figures is a member of the pin set and
-    passes there. Both are kept — membership still catches a figure matching no
-    pin at all, and its table anchors are what stop a sub-table dropping out.
+    passes there. Both are still wired in, but not for the reason this docstring
+    used to give — the one surviving reason is in `compare_membership`'s own
+    docstring, with the measurement that retired the other two.
 
     Two derivations, neither a new hand-kept copy: the light↔dark pairing comes
     from §3.1 (`ledger_opaque_pairs`) and the wash join from §3.2's ground column


### PR DESCRIPTION
## Summary

#1496 の判断1（台帳 §5 の行がどの pin を持つべきか）だけを閉じる。**PR1 of 2** —
残る判断2・3・4（散文の写しの disposition inventory / tree-wide census / gate の発火面 /
ADR-028 amendment）は PR2 で、そちらが `Closes #1496` を持つ。

- **§5 を所属チェックから行ごとの位置照合へ。** #1488 の `compare_membership` は
  「その図が pin のどれかであること」しか見ておらず、**ある行が別の行の pin 値を持つ**
  欠陥は素通りしていた（issue が挙げている例そのもの: `ResultsView` の行が
  `ActiveModelChip` の値を持っていても緑）。各行を、その行の `Ground` セルが名指しする
  pin と突き合わせる。
- **分岐は `light/dark` セルの form を先に読み、`Ground` はその後。** 出荷 94 行を数え直すと
  比較可否を決めるのは ratio セルの方だった。`screenBackground` と `bubbleBackground` は
  数値対と `—` の両方を持ち、`DogMark` / `PasturaCard` / `SheepAvatar` の3行は実在の
  トークン地を名指ししたまま `#Preview` で測っていない。ground を先に見る実装だと
  **この3行が内容は正しいまま赤くなる**。この順序は §5 の2つの相異なる `muted@0.14`
  ground セル（3行、1行は `same` 経由。片方はウォッシュ行、他は `unmeasurable`）を
  分ける唯一の手段でもある。
- **ratio セルの語彙は8 form**、列挙は台帳から取った: 数値対 73 / 範囲対 1 / `worst` 合成 1 /
  `same` 2 / `—` 7 / `unmeasured` 5 / `unmeasurable` 4 / `mixed` 1 = 94。9つ目は raise する —
  既定でスキップすると新しい綴りが黙って行を比較から落とす。
- **写像は導出、手写しではない。** §3.1 の行内 light↔dark 対応と §3.2 の
  `Wash over ground` 列を新たに読む。前者は `ledger_opaque_rows` が両列を1つの dict に
  潰していたので捨てられており、後者はどのコードも読んでいなかった。
- ground の join は**先頭 backtick トークンの完全一致**。セル完全一致ではウォッシュ4行が
  1つも当たらない（§5 は `` `mossDark@0.10` ``、§3.2 は
  `` `mossDark@0.10` over `screenBackground` / … `` と綴る）。
- `same` は同一サブ表の直前行の**解決済み**の値を継ぐので推移的に効き、サブ表の先頭行なら
  raise。`worst` は2つの地に対する**外観ごと**の最小。範囲対は §3.2 の `_interval` を
  再利用して区間として比較。

### このPRが閉じずに**記録した**残件

いずれも checker 内に理由つきで明記し、片方は挙動を腕で固定してある。

1. **§3.1 の対応そのものの正本は §3.1 のまま。** `opaqueGroundPins` は平坦で並び順も
   §3.1 と異なり、index 読みはその配列自身の doc コメントが禁じているので、上に置ける
   正本が無い。実測: §5 が名指しする3対の dark 半分を置換すると 28〜72 行が赤くなり
   （非恒等5置換すべて）、残り3対では **0 行**。その半分は未ガード。
2. **2トークンの ground セルは先頭トークンしか照合しない。** 該当は出荷 1 行
   （`ModelRow` の `` `moss@0.06` when selected, else `bubbleBackground` ``）。
   `len(tokens) == 1` を assert すると内容が正しいその行が赤くなるので閉じず、
   「primary で緑・alternative の値なら赤」を self-test 腕で固定した。
3. **`compare_membership` は今日の台帳では包摂されている**（実測）。残しているのは、
   包摂が2つの検査の性質ではなく **form set** の性質だから。この理由に到達するには
   ledger ではなく checker の編集が要る（`LEDGER_5_UNCOMPARED` はセル完全一致なので、
   宣言されていない図付きセルは skip ではなく raise する）ことも明記した。

## Test plan

- `python3 scripts/check-measurement-transcripts.py --self-test` → **80/80**（+16腕）
- `python3 scripts/check-measurement-transcripts.py --check` → clean
- **実台帳での陽性対照**（緑が空虚でないことの確認）: 94行中 **77行が比較対象** / 17行スキップ。
  比較5 form（不透明地 / `worst` / 範囲対 / ウォッシュ点 / 自己ウォッシュ）を1つずつ摂動して
  全て赤、`same` の2連鎖が production データで伝播することも確認
- `scripts/xcodebuild.sh test -skip-testing:PasturaUITests` → **TEST SUCCEEDED**（3496 tests）。
  Swift は1行も触っていないが `precommit-gate-classify.sh` が `scripts/**` を build-relevant と
  分類するため実行。`lint` トークンは出ないので SwiftLint はスキップ

## レビュー経緯（このPRの弱点はここ）

`claude-kit:critic` 2周 + `code-reviewer` 2周。**4周とも「このPRが自分で書いた主張が測ると偽」
という同じクラスの欠陥**を出しており、実装の欠陥は1件も出ていない。

- critic 1周目 Critical 2件: tree-wide census が checker docstring の禁止条項と衝突（→ PR2 へ分離）/
  §5 の列挙対象が `Ground` 列だったが決めるのは `light/dark` 列（→ `#Preview` 3行が誤って赤くなる欠陥を回避）
- critic 2周目 Critical 2件: §3.1 の対応を assert する相手が存在しない（→ 残件1として記録）/
  「セル完全一致」ではウォッシュ4行が1つも join しない（→ 先頭トークン一致へ）
- code-reviewer 1周目 Warning 3件: `compare_membership` を残す理由が2つとも偽 / 2トークン行の穴 /
  「28–67」が3互換のみの範囲（→ 28–72）
- code-reviewer 2周目 Warning 1件: **修正コミット自身が入れたミラー漏れ** — 片側だけ直して
  ファイル内に主張と反証が同居していた

最後の1件を直したあと3周目のレビューは回さず、代わりに**反証済み命題4つの空白正規化 grep
（陽性対照つき）**で残存ゼロを機械的に確認した。見逃しがミラーの片側という形だったので、
その形にはこちらの方が効く。3周目が要ると判断されればマージ前に回せる。

## Device QA

実機QA不要 — Python の checker とドキュメントのみ。Swift ソース・UI・
`#if !targetEnvironment(simulator)` ブロック・Metal / llama.cpp のいずれにも触れていない。

Part of #1496
