### PR TITLE
🐛 fix: sim-dest.sh の errexit 採取と、xcodebuild wrapper へのノウハウ機構化

### DIFF
--- a/.claude/rules/build-traps.md
+++ b/.claude/rules/build-traps.md
@@ -8,14 +8,8 @@ paths:
 
 # Build & Lint Traps
 
-Traps that fire from **build configuration rather than from code** — naming a Swift file, placing
-a lint directive, or excluding a block from a build slice. The globs above are the union of the
-three traps' reach. The third lives here rather than in `swiftui-traps.md` because what it is about
-is which slice compiles a block, not a SwiftUI construct: today's `#if !targetEnvironment(simulator)`
-sites are all under `Views/` / `App/`, so both files' globs would reach them, and this file's are the
-superset that still would if one appeared elsewhere. Enumerate before assuming a site is one —
-`git grep -n '#if !targetEnvironment(simulator)'`; the un-negated `#if DEBUG || targetEnvironment(simulator)`
-(e.g. `LLM/OllamaService.swift`) is the opposite condition and not an instance.
+Traps that fire when **adding or naming a Swift file**, in any layer and any target — hence the
+globs above, which are the union of the two traps' reach.
 
 Duplicate base filenames fail the build in **every** Swift target: `swiftc` rejects them outright
 (`filename "Foo.swift" used twice`) and SwiftPM errors on duplicate `.o` producers. The
@@ -56,27 +50,3 @@ declaration that also carries a `///` doc comment — **both** placements fail:
 - `identifier_name` (short domain identifiers like `ja` / `en`) → add a
   **`.swiftlint.yml` `identifier_name.excluded`** entry (ref: the `ja` / `en`
   exclusions consumed by `pickLanguage(_:ja:en:)`), or rename to 3+ chars.
-
-## Compile-checking `#if !targetEnvironment(simulator)` code
-
-Such blocks (today: the `SettingsView` model-management UI, `ModelSettingsRow`,
-and one arm of `AppDependencies`) are excluded from the simulator build, which is
-what `scripts/xcodebuild.sh build` and `scripts/ui-tour.sh` use — so a compile
-error in one survives a green local build. **CI is not blind to them**: `ci.yml`'s
-`release-build` job builds `-sdk iphoneos`, failing every iOS-touching PR — but in
-**Release configuration only**, so a block behind `#if DEBUG` *and*
-`!targetEnvironment(simulator)` would be compiled by no CI job (none exists today).
-
-Compile-check locally without provisioning — signing is skipped and Swift compiles
-before signing, so `** BUILD SUCCEEDED **` confirms the block compiles:
-
-```bash
-scripts/xcodebuild.sh build -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO
-```
-
-The wrapper passes no `-configuration`, so that is a **Debug** device build and it
-does reach a `#if DEBUG` device-only block CI cannot. `-destination` is additive
-rather than last-wins, so this refreshes the simulator slice alongside the device
-one (measured: one invocation rebuilt both `Debug-iphoneos` and
-`Debug-iphonesimulator`). **Layout / visual** still needs a real device — flag
-device-QA explicitly in PRs touching these blocks.

--- a/.claude/rules/build-traps.md
+++ b/.claude/rules/build-traps.md
@@ -8,8 +8,14 @@ paths:
 
 # Build & Lint Traps
 
-Traps that fire when **adding or naming a Swift file**, in any layer and any target — hence the
-globs above, which are the union of the two traps' reach.
+Traps that fire from **build configuration rather than from code** — naming a Swift file, placing
+a lint directive, or excluding a block from a build slice. The globs above are the union of the
+three traps' reach. The third lives here rather than in `swiftui-traps.md` because what it is about
+is which slice compiles a block, not a SwiftUI construct: today's `#if !targetEnvironment(simulator)`
+sites are all under `Views/` / `App/`, so both files' globs would reach them, and this file's are the
+superset that still would if one appeared elsewhere. Enumerate before assuming a site is one —
+`git grep -n '#if !targetEnvironment(simulator)'`; the un-negated `#if DEBUG || targetEnvironment(simulator)`
+(e.g. `LLM/OllamaService.swift`) is the opposite condition and not an instance.
 
 Duplicate base filenames fail the build in **every** Swift target: `swiftc` rejects them outright
 (`filename "Foo.swift" used twice`) and SwiftPM errors on duplicate `.o` producers. The
@@ -50,3 +56,27 @@ declaration that also carries a `///` doc comment — **both** placements fail:
 - `identifier_name` (short domain identifiers like `ja` / `en`) → add a
   **`.swiftlint.yml` `identifier_name.excluded`** entry (ref: the `ja` / `en`
   exclusions consumed by `pickLanguage(_:ja:en:)`), or rename to 3+ chars.
+
+## Compile-checking `#if !targetEnvironment(simulator)` code
+
+Such blocks (today: the `SettingsView` model-management UI, `ModelSettingsRow`,
+and one arm of `AppDependencies`) are excluded from the simulator build, which is
+what `scripts/xcodebuild.sh build` and `scripts/ui-tour.sh` use — so a compile
+error in one survives a green local build. **CI is not blind to them**: `ci.yml`'s
+`release-build` job builds `-sdk iphoneos`, failing every iOS-touching PR — but in
+**Release configuration only**, so a block behind `#if DEBUG` *and*
+`!targetEnvironment(simulator)` would be compiled by no CI job (none exists today).
+
+Compile-check locally without provisioning — signing is skipped and Swift compiles
+before signing, so `** BUILD SUCCEEDED **` confirms the block compiles:
+
+```bash
+scripts/xcodebuild.sh build -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO
+```
+
+The wrapper passes no `-configuration`, so that is a **Debug** device build and it
+does reach a `#if DEBUG` device-only block CI cannot. `-destination` is additive
+rather than last-wins, so this refreshes the simulator slice alongside the device
+one (measured: one invocation rebuilt both `Debug-iphoneos` and
+`Debug-iphonesimulator`). **Layout / visual** still needs a real device — flag
+device-QA explicitly in PRs touching these blocks.

--- a/.claude/rules/ci-workflows.md
+++ b/.claude/rules/ci-workflows.md
@@ -144,9 +144,10 @@ new measurement.
 suppresses errexit for the left operand of `||`, so the call sites written
 `source … || { …; exit 1; }` still depend on that `exit`: deleting the handler
 hands the job back to the restore fix, reducing it to a bare message does not.
-`ci.yml`'s two `run:` steps use the bare form (a `run:` is `bash -e {0}`) and so
-do gain the abort — they previously swallowed a failed source and wrote an empty
-`DEST=` into `$GITHUB_ENV`.
+Bare-form callers do gain the abort — among them `ci.yml`'s two `run:` steps (a
+`run:` is `bash -e {0}`), which previously swallowed a failed source and wrote an
+empty `DEST=` into `$GITHUB_ENV`. Enumerate the callers before claiming a set:
+`grep -rn 'sim-dest\.sh' --include='*.sh' --include='*.yml' .`
 
 ## Long-lived branch gating — two layers × two directions
 

--- a/.claude/rules/ci-workflows.md
+++ b/.claude/rules/ci-workflows.md
@@ -121,6 +121,33 @@ Guarded by `scripts/tests/staged-trigger-pipefail-test.sh`, which scans shell
 scripts for the `grep -q` **shape** only: no workflow YAML, no other
 early-exiting readers. Per-site fail directions: #1498.
 
+### Rule 4 — `$(set +o)` cannot round-trip errexit
+
+A script that snapshots the caller's shell options with `_old=$(set +o)` and
+restores them with `eval "$_old"` **drops a caller's `set -e`**: bash has already
+cleared errexit inside the command substitution, so the snapshot records
+`set +o errexit` whatever the caller's real state was. errexit is the only option
+this hits, and *not* because it is a `$-` letter flag — `nounset` is one too and
+round-trips fine, as does pipefail. That last one is load-bearing rather than
+trivia: `sim-dest.sh` turns pipefail on for itself, so a failure to round-trip it
+would silently promote every caller.
+
+**Apply**: capture errexit separately from `$-` (`case $- in *e*) had=1 ;; esac`)
+and re-apply it on every restore path. `shopt inherit_errexit` (bash 4.4+)
+reverses the whole effect, but macOS ships bash 3.2.
+`scripts/sim-dest.sh` is the worked example and
+`scripts/tests/simdest-errexit-test.sh` pins it, its A7 pinning the letter-flag
+half. The "only option" scope is asserted, not measured — widen it only from a
+new measurement.
+
+**A failing `source` aborts an errexit-on caller only in the bare form.** Bash
+suppresses errexit for the left operand of `||`, so the call sites written
+`source … || { …; exit 1; }` still depend on that `exit`: deleting the handler
+hands the job back to the restore fix, reducing it to a bare message does not.
+`ci.yml`'s two `run:` steps use the bare form (a `run:` is `bash -e {0}`) and so
+do gain the abort — they previously swallowed a failed source and wrote an empty
+`DEST=` into `$GITHUB_ENV`.
+
 ## Long-lived branch gating — two layers × two directions
 
 For CI on long-lived integration / release-train / spike-staging branches, the gate is **two layers**, each at **two directions**:

--- a/.claude/rules/swiftui-traps.md
+++ b/.claude/rules/swiftui-traps.md
@@ -428,3 +428,41 @@ and ADR-028 § Amendment (#1284, #1373, #1378). Reference: `ModelPickerView`,
 
 Sibling of § "Adding a `Color` design token"'s closing note — that one asks the same
 "what does it composite over" question of a *presented surface* rather than an occluder.
+
+## Compile-checking `#if !targetEnvironment(simulator)` code
+
+Here rather than in `build-traps.md` by this file's § Scope rule: every current
+site is entered from a UI-layer file (`git grep -n '#if !targetEnvironment(simulator)'`
+→ `Views/Settings/SettingsView.swift`, `Views/Settings/SettingsView+Models.swift`,
+`App/AppDependencies.swift`). Move the section if one ever appears outside them —
+and when weighing that, do not assume `build-traps.md`'s globs are the wider set:
+its `Pastura/Pastura/**/*.swift` does not match top-level `PasturaApp.swift`
+(git pathspec, measured), which this file lists separately.
+
+Such blocks are excluded from the simulator build, which is what
+`scripts/xcodebuild.sh build` and `scripts/ui-tour.sh` use — so a compile error in
+one survives a green local build. **CI is not blind to them**: `ci.yml`'s
+`release-build` job builds `-sdk iphoneos`, failing every iOS-touching PR — but in
+**Release configuration only**, so a block behind `#if DEBUG` *and*
+`!targetEnvironment(simulator)` would be compiled by no CI job (none exists today).
+
+Compile-check locally without provisioning — signing is skipped and Swift compiles
+before signing, so `** BUILD SUCCEEDED **` confirms the block compiles:
+
+```bash
+scripts/xcodebuild.sh build -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO
+```
+
+The wrapper passes no `-configuration`, so that is a **Debug** device build and it
+does reach a `#if DEBUG` device-only block CI cannot. `-destination` is additive
+rather than last-wins, so this refreshes the simulator slice alongside the device
+one (measured: one invocation rebuilt both `Debug-iphoneos` and
+`Debug-iphonesimulator`). **Layout / visual** still needs a real device — flag
+device-QA explicitly in PRs touching these blocks.
+
+**Don't pattern-match the directive.** `#if DEBUG || targetEnvironment(simulator)`
+(`LLM/OllamaService.swift`, three arms of `AppDependencies`) is a *different*
+condition, not the complement — it is true in the Debug device build the recipe
+above produces. The actual complement is the bare `#if targetEnvironment(simulator)`
+(`PasturaApp.swift`, `GalleryScenarioDetailView+RecommendedModel.swift`). A file
+merely *referenced* from inside a device-only block is not a site either.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -147,10 +147,26 @@ targeting works correctly for.
 `@Suite("SimulationViewCompletionChrome") struct SimulationViewCompletionChromeTests`
 matches only the latter; the display name silently resolves to zero tests and
 still prints `TEST SUCCEEDED`. Confirm the `✔ Test` / `Test run with N tests`
-markers, per `xcodebuild-cli.md` § "\"Executed 0 tests\" in the XCTest stanza is
-cosmetic for Swift-Testing suites".
+markers — see § "`Executed 0 tests` in the XCTest stanza is cosmetic" below.
 
 **Verify:** Always check the test count in the output to confirm tests actually ran.
+
+## `Executed 0 tests` in the XCTest stanza is cosmetic
+
+The XCTest output stanza (`Executed N tests`) counts only `XCTestCase` subclasses,
+so a Swift-Testing-only run always prints `Executed 0 tests` — **cosmetic, not a
+"file not in target" signal**. The real count is in the Swift Testing stanza below
+it (`✔ Test … passed`, `Test run with N tests …`). Most Pastura tests are Swift
+Testing.
+
+**Disambiguate a true zero**: `✔` markers / `Test run with N tests` present →
+normal; absent → real bug (file at the wrong path, not compiled, or the
+`-only-testing` zero-match trap above). When filtering xcodebuild output, keep the
+markers:
+
+```bash
+grep -E "(error:|Test Suite|Executed|passed|failed|✔ Test|Test run)"
+```
 
 ## Duplicate Suite Names Silently Halve `-only-testing`
 

--- a/.claude/rules/xcodebuild-cli.md
+++ b/.claude/rules/xcodebuild-cli.md
@@ -48,48 +48,40 @@ scripts/xcodebuild.sh test …
 | Cap output for context-window budget | `scripts/xcodebuild.sh <cmd> --tail N [args]` |
 | CI full run | `.github/workflows/ci.yml` (bypasses wrapper) |
 
-Skip UI tests with `-skip-testing:PasturaUITests` when the change
-does not touch UI (UI tests are not required for MVP). Integration
-tests (Ollama / Llama) require their `*_INTEGRATION` env var enabled
-**in the scheme** (`LaunchAction > EnvironmentVariables` inherited by
-`TestAction` via `shouldUseLaunchSchemeArgsEnv="YES"`) — a CLI-passed
-one reaches no test runner, and the wrapper warns when it sees one
-exported. Toggle in Xcode UI, or temporarily flip `isEnabled="YES"`
-in the XML before running — revert before commit.
+Skip UI tests with `-skip-testing:PasturaUITests` when the change does not touch
+UI (UI tests are not required for MVP). Integration suites gate on a
+`*_INTEGRATION` env var read by the **test runner**, which inherits nothing from
+the CLI — so a CLI-set one skips the suite and still prints `TEST SUCCEEDED`
+(the wrapper warns if it sees one exported). Set it in the scheme, or flip
+`isEnabled="YES"` in the scheme XML and **revert before commit**; each
+integration suite's doc comment carries the procedure.
 
 ## --tail (built-in, pipefail-safe)
 
-`--tail N` is a wrapper-only flag. xcodebuild uses single-dash flags
-so `--`-prefixed names are unambiguous. Accepted at any position;
-last value wins on duplicates. Use this instead of external `| tail`
-— external tail defeats `pipefail`, masking failed builds as exit 0.
+`--tail N` is a wrapper-only flag, accepted at any position (last value wins).
+Use it instead of an external `| tail`, which defeats `pipefail` and reports a
+**failed build as exit 0**.
 
-External `| grep` is OK for filtering, but the pipe replaces the
-wrapper's exit code with grep's. Verify success by grepping output
-for `** BUILD SUCCEEDED **` / `** TEST SUCCEEDED **` (or the
-corresponding `FAILED` markers), or use caller-side `set -o pipefail`.
-When the SUCCEEDED marker has been trimmed off entirely:
+External `| grep` is fine for filtering, but the pipe replaces the wrapper's exit
+code with grep's — verify by grepping for `** BUILD SUCCEEDED **` /
+`** TEST SUCCEEDED **` (or the `FAILED` markers), or set `pipefail` caller-side.
+When the marker was trimmed off entirely:
 `xcrun xcresulttool get test-results summary --path "$XCRESULT" --format json`.
 
 ## Wrapper behavior
 
-- **`test`**: UDID-pinned simulator + `-parallel-testing-enabled NO`
-  (CI workaround for within-process clone cascade — [#189](https://github.com/tyabu12/pastura/issues/189)).
-- **`build`**: `generic/platform=iOS Simulator`, no UDID booking,
-  exports `PASTURA_SKIP_SIM_WAIT=1` to bypass the simulator gate.
-- **Auto-sync**: runs `xcrun xcstringstool extract` + `sync` against
-  `Pastura/Pastura/Resources/Localizable.xcstrings` before xcodebuild.
-  Opt out with `PASTURA_SKIP_XCSTRINGS_SYNC=1` (already set in the
-  pre-commit hook so commits do not mutate the catalog outside the
-  staging index). Failures write a sentinel at
-  `Pastura/DerivedData/.xcstrings-sync-failed` and return 0 — never
-  blocks build. Stale entries (kept by Apple by design) can be pruned
-  manually via `python3 scripts/xcstrings-prune-stale.py` — read
-  `.claude/rules/i18n-catalog.md` first (path-scoped to the catalog; a
-  script run loads none of it).
-- **DerivedData**: pinned to worktree-local `Pastura/DerivedData/`
-  via `-derivedDataPath "$DERIVED_DATA"`. **Pass with a space, not
-  `=`** — the `=` form is silently ignored (Xcode 15.4+).
+- **`test`**: UDID-pinned simulator + `-parallel-testing-enabled NO` ([#189](https://github.com/tyabu12/pastura/issues/189)).
+- **`build`**: `generic/platform=iOS Simulator`, no UDID booking; it exports
+  `PASTURA_SKIP_SIM_WAIT=1`, so the gate below never applies to a build.
+- **Auto-sync**: both subcommands **mutate** `Localizable.xcstrings`
+  (`xcstringstool extract` + `sync`) before xcodebuild — opt out with
+  `PASTURA_SKIP_XCSTRINGS_SYNC=1` (already set in the pre-commit hook, so a
+  commit does not mutate the catalog outside its staging index). A sync failure
+  is advisory, never a build failure. Pruning stale entries is manual and
+  separate: read `.claude/rules/i18n-catalog.md` first (a script run loads none
+  of it), then `python3 scripts/xcstrings-prune-stale.py`.
+- **DerivedData**: worktree-local `Pastura/DerivedData/`, so
+  `git worktree remove` cleans it.
 
 ## Concurrent-session simulator gate
 
@@ -197,19 +189,17 @@ the block compiles). That one is a **Debug** device build — the wrapper passes
 **Layout/visual** still needs a real device — flag device-QA explicitly in PRs touching
 these blocks.
 
-## Fresh worktree's first build (SPM resolution)
+## A stale SPM resolution reads as a compile error
 
-The wrapper resolves SPM packages itself when this DerivedData holds none, so the
-fresh-worktree failure repairs itself — a first build that would otherwise die at package
-resolution and be reported by the pre-commit hook as
-`Build failed. Fix compile errors before committing.`, sending you after a compile error
-that does not exist.
+The wrapper resolves SPM packages when this DerivedData holds **none**, so a fresh
+worktree repairs itself. A resolution that is *stale* rather than absent (a
+`Package.resolved` bump, a moved revision) is not covered: the pre-flight stays
+quiet and the pre-commit hook reports `Build failed. Fix compile errors before
+committing.` for a compile error that does not exist. Recover, then re-commit:
 
-It does **not** cover a resolution that is *stale* rather than absent (a `Package.resolved`
-bump, a moved revision): identities are present then, the pre-flight stays quiet, and the
-misleading message is back. Recover by hand, then re-commit:
-`xcodebuild -resolvePackageDependencies -project Pastura/Pastura.xcodeproj -scheme Pastura -derivedDataPath Pastura/DerivedData`.
-Distinct from the harness `swift build` entry above (that's the SwiftPM *harness*).
+```bash
+xcodebuild -resolvePackageDependencies -project Pastura/Pastura.xcodeproj -scheme Pastura -derivedDataPath Pastura/DerivedData
+```
 
 ## CI flake catalog
 

--- a/.claude/rules/xcodebuild-cli.md
+++ b/.claude/rules/xcodebuild-cli.md
@@ -47,7 +47,7 @@ entries and hook commands is intentional.
 
 The wrapper supplies `-scheme`, `-project`, `-destination` and
 `-derivedDataPath`, and **rejects a re-pass with a one-line error** before
-xcodebuild can bury its own between the xtrace and a 64-line usage page.
+xcodebuild can bury its own between the xtrace and its full usage page.
 Forward only what the wrapper does not supply — typically `-only-testing` /
 `-skip-testing`, plus the wrapper-only `--tail N`.
 
@@ -57,7 +57,10 @@ Two of those rejections encode something you would not guess, and the guard in
 rejected, and `-destination` is **additive, not last-wins** — a second one runs
 `test` on both devices and a failure on either aborts the run. `build` still
 accepts `-destination`, which is what makes the device compile-check recipe
-below work. To pin a **single** simulator for `test`, export `PASTURA_SIM_NAME`
+below work; additive applies there too, so that recipe builds the simulator
+slice alongside the device one (measured: one invocation refreshed both
+`Debug-iphoneos` and `Debug-iphonesimulator`). To pin a **single** simulator for
+`test`, export `PASTURA_SIM_NAME`
 (honored by `sim-dest.sh`) on its own line — the leading-assignment form
 (`PASTURA_SIM_NAME=… scripts/xcodebuild.sh …`) trips the allowlist approval
 prompt, per § "Canonical invocation":
@@ -157,7 +160,10 @@ pins that with a negative control reproducing the old capture.
 **Apply**: any new save/restore of shell options needs the `$-` capture, not
 `$(set +o)` alone. The `||` handlers and `set -euo pipefail` re-asserts still in
 the sourcing scripts are defence in depth now — not the abort mechanism, and not
-a reason a new call site needs one.
+a reason a new call site needs one. The widest consequence is in `ci.yml`, whose
+two `run:` steps source it bare: a `run:` is `bash -e {0}`, so those steps used
+to swallow a failed source and write an empty `DEST=` into `$GITHUB_ENV`, and
+now abort on sim-dest's own message instead.
 
 ## Agent session guardrails
 

--- a/.claude/rules/xcodebuild-cli.md
+++ b/.claude/rules/xcodebuild-cli.md
@@ -151,18 +151,22 @@ run — see Recovery below.
 
 `sim-dest.sh` snapshotted the caller's options with `$(set +o)` — a command
 substitution, where bash has already cleared errexit — so restoring that
-snapshot dropped a caller's `set -e` (pipefail survived — it is no `$-` letter
-flag). Fixed in #1503 by capturing errexit from `$-`; a failing `source` now
-aborts an errexit-on caller by itself, and `scripts/tests/simdest-errexit-test.sh`
-pins that with a negative control reproducing the old capture.
+snapshot dropped a caller's `set -e`. **errexit is the only option this hits**,
+and not because of letter-flag-ness: measured on bash 3.2.57, `nounset` and
+`xtrace` are `$-` letter flags and round-trip correctly, as does everything
+else. `shopt inherit_errexit` (bash 4.4+) is the knob that reverses it. Fixed in
+#1503 by capturing errexit from `$-`, pinned by
+`scripts/tests/simdest-errexit-test.sh` with a negative control reproducing the
+old capture.
 
 **Apply**: any new save/restore of shell options needs the `$-` capture, not
-`$(set +o)` alone. The `||` handlers and `set -euo pipefail` re-asserts still in
-the sourcing scripts are defence in depth now — not the abort mechanism, and not
-a reason a new call site needs one. The widest consequence is in `ci.yml`, whose
-two `run:` steps source it bare: a `run:` is `bash -e {0}`, so those steps used
-to swallow a failed source and write an empty `DEST=` into `$GITHUB_ENV`, and
-now abort on sim-dest's own message instead.
+`$(set +o)` alone. **A failing `source` aborts an errexit-on caller only in the
+bare form** — bash suppresses errexit for the left operand of `||`, so the three
+sites written `source … || { …; exit 1; }` still depend on that `exit`; deleting
+the whole handler hands the job back to the fix, reducing it to a bare message
+does not. `ci.yml`'s two `run:` steps take the bare form, so they gain the abort:
+a `run:` is `bash -e {0}`, and they used to swallow a failed source and write an
+empty `DEST=` into `$GITHUB_ENV`.
 
 ## Agent session guardrails
 

--- a/.claude/rules/xcodebuild-cli.md
+++ b/.claude/rules/xcodebuild-cli.md
@@ -85,45 +85,22 @@ When the marker was trimmed off entirely:
 
 ## Concurrent-session simulator gate
 
-`sim-dest.sh` blocks at `source` time if another `xcodebuild test`
-with `,id=<UDID>` destination is already running on this machine
-(poll 5s / jitter 1.0–5.0s / 15-min timeout). Build-only invocations
-bypass the gate (`generic/platform=...`, no UDID).
+`test` blocks at `source scripts/sim-dest.sh` while another `xcodebuild test`
+with a `,id=<UDID>` destination runs on this machine — **up to 15 minutes**, so
+size the bash `timeout` for it and do not kill a run that merely looks stuck. It
+announces the wait, naming the busy PIDs and the bypass variable. `build` never
+waits (`generic/platform=…`, no UDID).
 
-Override (rare manual operation, e.g. parallel-suite work or
-`xcrun simctl` / `xcodebuild -showBuildSettings` inspection):
+Manual override for genuine parallelism, or for `simctl` /
+`-showBuildSettings` inspection. This exact form misses the allowlist and
+prompts, by design:
 
 ```bash
 PASTURA_SKIP_SIM_WAIT=1 source scripts/sim-dest.sh
 ```
 
-This exact form does not match the allowlist entry and triggers an
-approval prompt by design.
-
-If the gate consistently times out and you do not recall starting
-another test run, the busy PID is likely a stale
-`xcodebuild`/`testmanagerd`/`XCTRunner` from a prior timeout-killed
-run — see Recovery below.
-
-### Sourcing it no longer clears your `set -e`
-
-`sim-dest.sh` snapshotted the caller's options with `$(set +o)` — a command
-substitution, where bash has already cleared errexit — so restoring that
-snapshot dropped a caller's `set -e`. **errexit is the only option this hits**,
-and *not* because it is a `$-` letter flag. `shopt inherit_errexit` (bash 4.4+)
-reverses the whole effect. Fixed in #1503 by capturing errexit from `$-`;
-`scripts/tests/simdest-errexit-test.sh` pins the fix, and its A7 pins the
-letter-flag half (`nounset` round-trips, errexit does not). The "only option"
-scope itself is asserted, not measured — widen it only from a new measurement.
-
-**Apply**: any new save/restore of shell options needs the `$-` capture, not
-`$(set +o)` alone. **A failing `source` aborts an errexit-on caller only in the
-bare form** — bash suppresses errexit for the left operand of `||`, so the three
-sites written `source … || { …; exit 1; }` still depend on that `exit`; deleting
-the whole handler hands the job back to the fix, reducing it to a bare message
-does not. `ci.yml`'s two `run:` steps take the bare form, so they gain the abort:
-a `run:` is `bash -e {0}`, and they used to swallow a failed source and write an
-empty `DEST=` into `$GITHUB_ENV`.
+A gate that times out when you started no other run is a stale
+`xcodebuild`/`testmanagerd`/`XCTRunner` — see § Agent session guardrails.
 
 ## Agent session guardrails
 

--- a/.claude/rules/xcodebuild-cli.md
+++ b/.claude/rules/xcodebuild-cli.md
@@ -45,6 +45,7 @@ scripts/xcodebuild.sh test …
 | TDD red/green (single class) | `scripts/xcodebuild.sh test -only-testing PasturaTests/<Class>` |
 | Pre-PR full local run | `scripts/xcodebuild.sh test` |
 | Build only (no tests) | `scripts/xcodebuild.sh build` |
+| Compile-check device-only code | `scripts/xcodebuild.sh build -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO` — see `build-traps.md` |
 | Cap output for context-window budget | `scripts/xcodebuild.sh <cmd> --tail N [args]` |
 | CI full run | `.github/workflows/ci.yml` (bypasses wrapper) |
 
@@ -123,43 +124,15 @@ killing anything** — a concurrent worktree's run looks identical. Inspect / ki
 [`docs/ci/xcodebuild-flakes.md`](../../docs/ci/xcodebuild-flakes.md)
 § Recovery / § Local full-suite flake.
 
-## "Executed 0 tests" in the XCTest stanza is cosmetic for Swift-Testing suites
-
-The XCTest output stanza (`Executed N tests`) counts only `XCTestCase` subclasses — for
-Swift-Testing-only files it always prints `Executed 0 tests`, which is **cosmetic, not a
-"file not in target" signal**. The real count is in the Swift Testing stanza below
-(`✔ Test … passed`, `Test run with N tests …`). Most Pastura tests are Swift Testing.
-**Disambiguate a true zero**: `✔` markers / `Test run with N tests` present → normal; absent
-→ real bug (file at wrong path / not compiled — cf. the `-only-testing` zero-match trap in
-`testing.md`). When filtering output keep the markers:
-`grep -E "(error:|Test Suite|Executed|passed|failed|✔ Test|Test run)"`.
-
 ## Engine/Models/`SimulationEvent` changes need local `swift build` (harness)
 
 The ADR-013 harness is a SwiftPM package reusing `Models`/`LLM`/`Engine`, built by
-`swift build` / `swift test` — NOT by `scripts/xcodebuild.sh` or the pre-commit hook (iOS
-app target only). So a change to a `SimulationEvent` case (or any harness-reused Engine/
-Models source) can pass the full xcodebuild suite + pre-commit locally and still break the
-CI "Harness package build" job — `EventLineMapper.swift` has an intentional no-`default:`
-exhaustive switch (compile-time canary). **Apply**: on any such change, run `swift build`
-from the repo root before push and map the new event in `EventLineMapper` (`nil` for
-internal/persistence events). See ADR-013.
-
-## Compile-checking device-only (`#if !targetEnvironment(simulator)`) code
-
-`#if !targetEnvironment(simulator)` blocks (e.g. `SettingsView` model-management UI,
-`ModelSettingsRow`) are excluded from the simulator build, which is what
-`scripts/xcodebuild.sh build` and `scripts/ui-tour.sh` use. **CI is not blind to them**:
-`ci.yml`'s `release-build` job builds `-sdk iphoneos`, so a compile error there fails every
-iOS-touching PR — in **Release configuration only**. A block behind `#if DEBUG` *and*
-`!targetEnvironment(simulator)` would therefore be compiled by no CI job; none exists today.
-Compile-check locally without provisioning:
-`scripts/xcodebuild.sh build -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO`
-(signing is skipped, and Swift compiles before signing, so `** BUILD SUCCEEDED **` confirms
-the block compiles). That one is a **Debug** device build — the wrapper passes no
-`-configuration` — so it does reach a `#if DEBUG` device-only block that CI cannot.
-**Layout/visual** still needs a real device — flag device-QA explicitly in PRs touching
-these blocks.
+`swift build` — **not** by `scripts/xcodebuild.sh` or the pre-commit hook, which
+cover the iOS app target only. So such a change passes the full local suite and
+still breaks CI's "Harness package build". **Apply**: run `swift build` from the
+repo root before push, and map any new `SimulationEvent` case in the harness's
+`EventLineMapper` (`nil` for internal / persistence events) — its switch is
+deliberately `default:`-less as a compile-time canary. See ADR-013.
 
 ## A stale SPM resolution reads as a compile error
 

--- a/.claude/rules/xcodebuild-cli.md
+++ b/.claude/rules/xcodebuild-cli.md
@@ -16,7 +16,7 @@ scripts/xcodebuild.sh <subcommand> [--tail N] [args]
 ```
 
 Allowlist: `Bash(scripts/xcodebuild.sh*)` and `Bash(source scripts/sim-dest.sh)`
-— **exact-prefix literal matches**, so four shapes miss them and raise an
+— **exact-prefix literal matches**, so these shapes miss them and raise an
 approval prompt, which on an unattended run kills that run rather than teaching
 it anything: variable expansion (`"$xcb" …`), `cd … && scripts/xcodebuild.sh …`,
 a leading env-var assignment (`PASTURA_SKIP_XCSTRINGS_SYNC=1 scripts/…`), and an
@@ -30,8 +30,10 @@ shell processes and never reach the permission gate.
 
 Forward only what the wrapper does not supply — typically `-only-testing` /
 `-skip-testing`, plus the wrapper-only `--tail N`. It rejects a re-passed
-`-scheme` / `-project` / `-destination` / `-derivedDataPath` with the reason per
-flag, ahead of the simulator gate. To pin **one** simulator for `test`:
+`-scheme` / `-project` / `-derivedDataPath`, and `-destination` on `test` (where
+xcodebuild treats it as additive, not last-wins) — each with its reason, ahead of
+the simulator gate. **`build -destination` stays accepted**: it is the
+device compile-check row below. To pin **one** simulator for `test`:
 
 ```bash
 export PASTURA_SIM_NAME="iPhone 17 Pro Max"
@@ -45,7 +47,7 @@ scripts/xcodebuild.sh test …
 | TDD red/green (single class) | `scripts/xcodebuild.sh test -only-testing PasturaTests/<Class>` |
 | Pre-PR full local run | `scripts/xcodebuild.sh test` |
 | Build only (no tests) | `scripts/xcodebuild.sh build` |
-| Compile-check device-only code | `scripts/xcodebuild.sh build -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO` — see `build-traps.md` |
+| Compile-check device-only code | `scripts/xcodebuild.sh build -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO` — see `swiftui-traps.md` |
 | Cap output for context-window budget | `scripts/xcodebuild.sh <cmd> --tail N [args]` |
 | CI full run | `.github/workflows/ci.yml` (bypasses wrapper) |
 
@@ -66,6 +68,10 @@ Use it instead of an external `| tail`, which defeats `pipefail` and reports a
 External `| grep` is fine for filtering, but the pipe replaces the wrapper's exit
 code with grep's — verify by grepping for `** BUILD SUCCEEDED **` /
 `** TEST SUCCEEDED **` (or the `FAILED` markers), or set `pipefail` caller-side.
+**`TEST SUCCEEDED` does not mean tests ran**: a Swift-Testing run prints
+`Executed 0 tests` in the XCTest stanza regardless, and a `-only-testing` that
+matches nothing also succeeds. Confirm the `✔ Test` / `Test run with N tests`
+markers — both traps are in `testing.md`.
 When the marker was trimmed off entirely:
 `xcrun xcresulttool get test-results summary --path "$XCRESULT" --format json`.
 
@@ -81,8 +87,9 @@ When the marker was trimmed off entirely:
   is advisory, never a build failure. Pruning stale entries is manual and
   separate: read `.claude/rules/i18n-catalog.md` first (a script run loads none
   of it), then `python3 scripts/xcstrings-prune-stale.py`.
-- **DerivedData**: worktree-local `Pastura/DerivedData/`, so
-  `git worktree remove` cleans it.
+- **DerivedData**: worktree-local `Pastura/DerivedData/`. When you pass
+  `-derivedDataPath` yourself — as the recipe at the end of this file does — use a
+  **space, not `=`**; the `=` form is silently ignored (Xcode 15.4+).
 
 ## Concurrent-session simulator gate
 
@@ -90,7 +97,8 @@ When the marker was trimmed off entirely:
 with a `,id=<UDID>` destination runs on this machine — **up to 15 minutes**, so
 size the bash `timeout` for it and do not kill a run that merely looks stuck. It
 announces the wait, naming the busy PIDs and the bypass variable. `build` never
-waits (`generic/platform=…`, no UDID).
+waits — the wrapper exports the bypass for it; its generic destination is instead
+why a build never makes *other* sessions wait.
 
 Manual override for genuine parallelism, or for `simctl` /
 `-showBuildSettings` inspection. This exact form misses the allowlist and
@@ -100,8 +108,9 @@ prompts, by design:
 PASTURA_SKIP_SIM_WAIT=1 source scripts/sim-dest.sh
 ```
 
-A gate that times out when you started no other run is a stale
-`xcodebuild`/`testmanagerd`/`XCTRunner` — see § Agent session guardrails.
+A gate that times out when you started no other run is **most likely** a stale
+`xcodebuild`/`testmanagerd`/`XCTRunner` — but it can equally be a live sibling
+worktree's, so see § Agent session guardrails before killing anything.
 
 ## Agent session guardrails
 
@@ -137,8 +146,9 @@ deliberately `default:`-less as a compile-time canary. See ADR-013.
 ## A stale SPM resolution reads as a compile error
 
 The wrapper resolves SPM packages when this DerivedData holds **none**, so a fresh
-worktree repairs itself. A resolution that is *stale* rather than absent (a
-`Package.resolved` bump, a moved revision) is not covered: the pre-flight stays
+worktree repairs itself. A resolution that is stale, moved, or **partial** rather
+than absent (a `Package.resolved` bump, a moved revision, some but not all of this
+tree's dependencies resolved) is not covered: the pre-flight stays
 quiet and the pre-commit hook reports `Build failed. Fix compile errors before
 committing.` for a compile error that does not exist. Recover, then re-commit:
 
@@ -150,7 +160,7 @@ xcodebuild -resolvePackageDependencies -project Pastura/Pastura.xcodeproj -schem
 
 CI UI-test failures cluster into known classes — app-launch timeout, runner-init
 Accessibility, and XCUITest idle-stall — auto-retried by
-`.github/workflows/ci-retry.yml`. A fourth, **within-process clone cascade, is
+`.github/workflows/ci-retry.yml` (max 3 attempts on main / 2 on PR). A fourth, **within-process clone cascade, is
 retired**: #1053 made the `ui-test` job serialized, so a recurrence of it (or of
 the contention stall) means `-parallel-testing-enabled NO` was dropped from that
 job, not that a flake came back.

--- a/.claude/rules/xcodebuild-cli.md
+++ b/.claude/rules/xcodebuild-cli.md
@@ -152,12 +152,11 @@ run — see Recovery below.
 `sim-dest.sh` snapshotted the caller's options with `$(set +o)` — a command
 substitution, where bash has already cleared errexit — so restoring that
 snapshot dropped a caller's `set -e`. **errexit is the only option this hits**,
-and not because of letter-flag-ness: measured on bash 3.2.57, `nounset` and
-`xtrace` are `$-` letter flags and round-trip correctly, as does everything
-else. `shopt inherit_errexit` (bash 4.4+) is the knob that reverses it. Fixed in
-#1503 by capturing errexit from `$-`, pinned by
-`scripts/tests/simdest-errexit-test.sh` with a negative control reproducing the
-old capture.
+and *not* because it is a `$-` letter flag. `shopt inherit_errexit` (bash 4.4+)
+reverses the whole effect. Fixed in #1503 by capturing errexit from `$-`;
+`scripts/tests/simdest-errexit-test.sh` pins the fix, and its A7 pins the
+letter-flag half (`nounset` round-trips, errexit does not). The "only option"
+scope itself is asserted, not measured — widen it only from a new measurement.
 
 **Apply**: any new save/restore of shell options needs the `$-` capture, not
 `$(set +o)` alone. **A failing `source` aborts an errexit-on caller only in the

--- a/.claude/rules/xcodebuild-cli.md
+++ b/.claude/rules/xcodebuild-cli.md
@@ -114,18 +114,13 @@ A gate that times out when you started no other run is a stale
 - Narrow scope with `-only-testing PasturaTests/<Suite>` whenever
   possible.
 
-**Recovery (hang or stalled retry)**: a bash `timeout` kills the shell
-wrapper but NOT spawned `xcodebuild` / `testmanagerd` / `XCTRunner` —
-they keep the simulator busy and later runs queue behind them.
-**Read command lines before killing** so you do not clobber a
-concurrent-worktree run: `pgrep -af "xcodebuild|XCTRunner|testmanagerd"`;
-if all are yours, `pkill -f "xcodebuild test"` then
-`xcrun simctl shutdown "$(echo "$DEST" | sed -n 's/.*id=//p')"`. UI-test
-`FBSOpenApplicationServiceErrorDomain Code=1` → `xcrun simctl erase <UDID>`
-+ retry **once** (persistent = real signing / plist / app-state bug).
-A local full-suite UI-test failure at `t = 0.00s` with no `Pastura-*.ips` is
-simulator infrastructure, not the app — re-run rather than diagnose.
-Full walkthrough: [`docs/ci/xcodebuild-flakes.md`](../../docs/ci/xcodebuild-flakes.md)
+**Recovery (hang or stalled retry)**: a bash `timeout` kills the shell wrapper
+but NOT the spawned `xcodebuild` / `testmanagerd` / `XCTRunner`, which keep the
+simulator busy so later runs queue behind them. **Read their command lines before
+killing anything** — a concurrent worktree's run looks identical. Inspect / kill /
+`simctl erase` steps, the UI-test launch-failure marker, and the local
+`t = 0.00s` failure that is simulator infrastructure rather than the app:
+[`docs/ci/xcodebuild-flakes.md`](../../docs/ci/xcodebuild-flakes.md)
 § Recovery / § Local full-suite flake.
 
 ## "Executed 0 tests" in the XCTest stanza is cosmetic for Swift-Testing suites
@@ -180,20 +175,16 @@ xcodebuild -resolvePackageDependencies -project Pastura/Pastura.xcodeproj -schem
 
 ## CI flake catalog
 
-CI UI-test failures cluster into known flake classes — within-process
-clone cascade (retired post-#1053, see below), app-launch timeout,
-runner-init Accessibility, and XCUITest idle-stall — auto-retried by
-`.github/workflows/ci-retry.yml`
-(max 3 attempts on main / 2 on PR, ui-test-failure-gated).
-**Check `run_attempt` on the failed run before intervening**: if 1, let
-auto-retry fire; only after it exhausts do `gh run rerun --failed <run_id>`
-once; escalate to real-bug investigation only when the same message recurs
-at the same stage across reruns (real signing / Info.plist / app-init
-regressions do not self-recover). Flake signatures, distinguishing signals,
-the idle-stall `--ui-test` suppression, and the full escalation tree:
+CI UI-test failures cluster into known classes — app-launch timeout, runner-init
+Accessibility, and XCUITest idle-stall — auto-retried by
+`.github/workflows/ci-retry.yml`. A fourth, **within-process clone cascade, is
+retired**: #1053 made the `ui-test` job serialized, so a recurrence of it (or of
+the contention stall) means `-parallel-testing-enabled NO` was dropped from that
+job, not that a flake came back.
+
+**Check `run_attempt` on the failed run before intervening**: if 1, let auto-retry
+fire; only after it exhausts, `gh run rerun --failed <run_id>` once; escalate to
+real-bug investigation only when the same message recurs at the same stage across
+reruns (signing / Info.plist / app-init regressions do not self-recover).
+Signatures, distinguishing signals and the escalation tree:
 [`docs/ci/xcodebuild-flakes.md`](../../docs/ci/xcodebuild-flakes.md).
-Runner-pressure tracking: [#189](https://github.com/tyabu12/pastura/issues/189).
-Post-#1053 the `ui-test` job runs serialized (`-parallel-testing-enabled NO`,
-like `lint-and-test`), which retires the clone-dependent classes
-(within-process clone cascade + contention stall) — a recurrence of either
-means the flag was dropped, not a new flake.

--- a/.claude/rules/xcodebuild-cli.md
+++ b/.claude/rules/xcodebuild-cli.md
@@ -45,32 +45,20 @@ entries and hook commands is intentional.
 
 ### Re-passing wrapper-supplied flags
 
-The wrapper auto-supplies `-scheme`, `-project`, `-destination`, and
-`-derivedDataPath`. Their override semantics differ:
+The wrapper supplies `-scheme`, `-project`, `-destination` and
+`-derivedDataPath`, and **rejects a re-pass with a one-line error** before
+xcodebuild can bury its own between the xtrace and a 64-line usage page.
+Forward only what the wrapper does not supply — typically `-only-testing` /
+`-skip-testing`, plus the wrapper-only `--tail N`.
 
-| Flag | Re-pass via `[args]`? |
-|------|------------------------|
-| `-scheme` | **Rejected** — `error: option '-scheme' may only be provided once` |
-| `-project` | **Rejected** — same |
-| `-derivedDataPath` | **Rejected** — same |
-| `-destination` | **Accepted but ADDITIVE, not last-wins** — see below |
-
-xcodebuild prints the rejection error followed by its full usage page
-(exit 64). The error line lands between the wrapper's xtrace and the
-usage page, so it is easy to miss — the failure looks like a wrapper
-bug. Forward only what the wrapper does not supply: typically just
-`-only-testing` / `-skip-testing` / `--tail N` (the last is wrapper-only,
-consumed before xcodebuild is invoked).
-
-**`-destination` is additive for `test`, NOT last-wins.** xcodebuild runs
-the suite on **every** `-destination` given. The wrapper already supplies its
-own `-destination` (from `sim-dest.sh`, default iPhone 17 Pro), so appending a
-second one runs the tests on **both** devices — and a failure on the extra
-device aborts the whole run (exit 65). Do **not** re-pass `-destination` to
-"override" the wrapper's simulator. To pin a **single** simulator, set the
-`PASTURA_SIM_NAME` env var (honored by `sim-dest.sh`), which replaces the
-priority list with that one device so the wrapper emits the right lone
-`-destination`. `export` it on its own line — the leading-assignment form
+Two of those rejections encode something you would not guess, and the guard in
+`scripts/xcodebuild.sh` carries the reason per flag: the `=`-joined form
+(`-derivedDataPath=…`) is **silently ignored** by Xcode 15.4+ rather than
+rejected, and `-destination` is **additive, not last-wins** — a second one runs
+`test` on both devices and a failure on either aborts the run. `build` still
+accepts `-destination`, which is what makes the device compile-check recipe
+below work. To pin a **single** simulator for `test`, export `PASTURA_SIM_NAME`
+(honored by `sim-dest.sh`) on its own line — the leading-assignment form
 (`PASTURA_SIM_NAME=… scripts/xcodebuild.sh …`) trips the allowlist approval
 prompt, per § "Canonical invocation":
 
@@ -96,12 +84,10 @@ Skip UI tests with `-skip-testing:PasturaUITests` when the change
 does not touch UI (UI tests are not required for MVP). Integration
 tests (Ollama / Llama) require their `*_INTEGRATION` env var enabled
 **in the scheme** (`LaunchAction > EnvironmentVariables` inherited by
-`TestAction` via `shouldUseLaunchSchemeArgsEnv="YES"`). CLI env vars
-passed to `scripts/xcodebuild.sh test` (or bare `xcodebuild test`) are
-NOT forwarded to the test runner subprocess — that path silently
-skips the suite while xcodebuild still prints `TEST SUCCEEDED`.
-Toggle in Xcode UI, or temporarily flip `isEnabled="YES"` in the XML
-before running — revert before commit.
+`TestAction` via `shouldUseLaunchSchemeArgsEnv="YES"`) — a CLI-passed
+one reaches no test runner, and the wrapper warns when it sees one
+exported. Toggle in Xcode UI, or temporarily flip `isEnabled="YES"`
+in the XML before running — revert before commit.
 
 ## --tail (built-in, pipefail-safe)
 
@@ -159,16 +145,19 @@ another test run, the busy PID is likely a stale
 `xcodebuild`/`testmanagerd`/`XCTRunner` from a prior timeout-killed
 run — see Recovery below.
 
-### Sourcing it in a script clears your `set -e`
+### Sourcing it no longer clears your `set -e`
 
-`sim-dest.sh` saves the caller's shell options on entry and restores that
-saved snapshot on every exit path. In practice this leaves errexit **off**
-after the `source` even if you ran `set -e` before it, so later failures
-keep running instead of aborting. **Re-assert `set -euo pipefail`
-immediately after sourcing.** Only scripts that source `sim-dest.sh`
-directly are at risk — child-process invokers (`ui-tour.sh` →
-`xcodebuild.sh`) are unaffected. Reference re-assert:
-`scripts/motion-capture.sh`.
+`sim-dest.sh` snapshotted the caller's options with `$(set +o)` — a command
+substitution, where bash has already cleared errexit — so restoring that
+snapshot dropped a caller's `set -e` (pipefail survived — it is no `$-` letter
+flag). Fixed in #1503 by capturing errexit from `$-`; a failing `source` now
+aborts an errexit-on caller by itself, and `scripts/tests/simdest-errexit-test.sh`
+pins that with a negative control reproducing the old capture.
+
+**Apply**: any new save/restore of shell options needs the `$-` capture, not
+`$(set +o)` alone. The `||` handlers and `set -euo pipefail` re-asserts still in
+the sourcing scripts are defence in depth now — not the abort mechanism, and not
+a reason a new call site needs one.
 
 ## Agent session guardrails
 
@@ -221,21 +210,30 @@ internal/persistence events). See ADR-013.
 ## Compile-checking device-only (`#if !targetEnvironment(simulator)`) code
 
 `#if !targetEnvironment(simulator)` blocks (e.g. `SettingsView` model-management UI,
-`ModelSettingsRow`) are excluded from the simulator build — which is what
-`scripts/xcodebuild.sh build`, `scripts/ui-tour.sh`, and CI all use, so a compile error OR
-layout regression there ships unseen. Compile-check without provisioning:
+`ModelSettingsRow`) are excluded from the simulator build, which is what
+`scripts/xcodebuild.sh build` and `scripts/ui-tour.sh` use. **CI is not blind to them**:
+`ci.yml`'s `release-build` job builds `-sdk iphoneos`, so a compile error there fails every
+iOS-touching PR — in **Release configuration only**. A block behind `#if DEBUG` *and*
+`!targetEnvironment(simulator)` would therefore be compiled by no CI job; none exists today.
+Compile-check locally without provisioning:
 `scripts/xcodebuild.sh build -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO`
-(wrapper forwards both trailing args; signing is skipped, and Swift compiles before signing
-so `** BUILD SUCCEEDED **` confirms the block compiles). **Layout/visual** still needs a
-real device — flag device-QA explicitly in PRs touching these blocks.
+(signing is skipped, and Swift compiles before signing, so `** BUILD SUCCEEDED **` confirms
+the block compiles). That one is a **Debug** device build — the wrapper passes no
+`-configuration` — so it does reach a `#if DEBUG` device-only block that CI cannot.
+**Layout/visual** still needs a real device — flag device-QA explicitly in PRs touching
+these blocks.
 
-## Fresh worktree's first build can fail SPM resolution (misleading message)
+## Fresh worktree's first build (SPM resolution)
 
-A fresh `/orchestrate` worktree has its own empty `Pastura/DerivedData/`. The first build the
-pre-commit hook triggers (any build-relevant path — `scripts/**` counts per
-`precommit-gate-classify.sh`) can fail at SPM resolution with a trailing
-`Build failed. Fix compile errors before committing.` — **misleading**: the real cause is
-unresolved SPM working copies, not a compile error. Fix once, then re-commit:
+The wrapper resolves SPM packages itself when this DerivedData holds none, so the
+fresh-worktree failure repairs itself — a first build that would otherwise die at package
+resolution and be reported by the pre-commit hook as
+`Build failed. Fix compile errors before committing.`, sending you after a compile error
+that does not exist.
+
+It does **not** cover a resolution that is *stale* rather than absent (a `Package.resolved`
+bump, a moved revision): identities are present then, the pre-flight stays quiet, and the
+misleading message is back. Recover by hand, then re-commit:
 `xcodebuild -resolvePackageDependencies -project Pastura/Pastura.xcodeproj -scheme Pastura -derivedDataPath Pastura/DerivedData`.
 Distinct from the harness `swift build` entry above (that's the SwiftPM *harness*).
 

--- a/.claude/rules/xcodebuild-cli.md
+++ b/.claude/rules/xcodebuild-cli.md
@@ -3,74 +3,40 @@
 Always-loaded — see CLAUDE.md "Context-Specific Rules" for the
 loading-mode rationale.
 
-Local `xcodebuild test` / `build` invocations — including the
-`git commit` pre-commit hook — go through `scripts/xcodebuild.sh`.
-CI bypasses the wrapper (uses `xcodebuild ... -parallel-testing-enabled NO`
-inline; SPM cache key depends on the default `~/Library/...`
-DerivedData path — see [#189](https://github.com/tyabu12/pastura/issues/189)).
+Local `xcodebuild test` / `build` invocations — including the `git commit`
+pre-commit hook — go through `scripts/xcodebuild.sh`. CI bypasses the wrapper
+([#189](https://github.com/tyabu12/pastura/issues/189)).
 
 ## Canonical invocation
 
-**Run from the repository root with the cwd-relative path:**
+**Run from the repository root, bare and cwd-relative:**
 
 ```bash
 scripts/xcodebuild.sh <subcommand> [--tail N] [args]
 ```
 
-Allowlist: `Bash(scripts/xcodebuild.sh*)` and `Bash(source scripts/sim-dest.sh)`.
-Both are exact-prefix literal matches — do **not** introduce variable
-expansion (`"$xcb" ...`), `cd ... && scripts/xcodebuild.sh ...`,
-leading env-var assignments
-(`PASTURA_SKIP_XCSTRINGS_SYNC=1 scripts/xcodebuild.sh ...`), or
-absolute paths in agent invocations. They bypass the allowlist and
-trigger an approval prompt.
+Allowlist: `Bash(scripts/xcodebuild.sh*)` and `Bash(source scripts/sim-dest.sh)`
+— **exact-prefix literal matches**, so four shapes miss them and raise an
+approval prompt, which on an unattended run kills that run rather than teaching
+it anything: variable expansion (`"$xcb" …`), `cd … && scripts/xcodebuild.sh …`,
+a leading env-var assignment (`PASTURA_SKIP_XCSTRINGS_SYNC=1 scripts/…`), and an
+absolute path. The wrapper resolves `REPO_ROOT` itself, so it never needs a `cd`.
+Scope that to these two entries, **not** to the matcher generally — `git -C
+<path> diff` has been observed to run unprompted under an equally bare
+`Bash(git diff*)`. A `$(…)`-bearing form prompts whatever the allowlist says
+([claude-code#31373](https://github.com/anthropics/claude-code/issues/31373),
+OPEN); `.claude/settings.json` hooks keep `$()` on purpose — they run as direct
+shell processes and never reach the permission gate.
 
-`scripts/xcodebuild.sh` resolves `REPO_ROOT` internally so
-subdirectory invocations still produce correct paths — but the
-allowlist match is on the literal command prefix, so always run from
-the repo root in agent sessions.
-
-### Why cwd-relative (#31373)
-
-Claude Code's permission safety heuristic raises an approval dialog
-for any executed command containing `$(...)`, regardless of `allow`
-rules ([anthropics/claude-code#31373](https://github.com/anthropics/claude-code/issues/31373) — OPEN).
-The previous canonical form used `$(git rev-parse --show-toplevel)/scripts/...`;
-the cwd-relative form sidesteps the heuristic.
-
-Hook commands in `.claude/settings.json` continue to use the `$()`
-form because hooks execute as direct shell processes and bypass the
-permission gate (and the heuristic). The asymmetry between allowlist
-entries and hook commands is intentional.
-
-### Re-passing wrapper-supplied flags
-
-The wrapper supplies `-scheme`, `-project`, `-destination` and
-`-derivedDataPath`, and **rejects a re-pass with a one-line error** before
-xcodebuild can bury its own between the xtrace and its full usage page.
 Forward only what the wrapper does not supply — typically `-only-testing` /
-`-skip-testing`, plus the wrapper-only `--tail N`.
-
-Two of those rejections encode something you would not guess, and the guard in
-`scripts/xcodebuild.sh` carries the reason per flag: the `=`-joined form
-(`-derivedDataPath=…`) is **silently ignored** by Xcode 15.4+ rather than
-rejected, and `-destination` is **additive, not last-wins** — a second one runs
-`test` on both devices and a failure on either aborts the run. `build` still
-accepts `-destination`, which is what makes the device compile-check recipe
-below work; additive applies there too, so that recipe builds the simulator
-slice alongside the device one (measured: one invocation refreshed both
-`Debug-iphoneos` and `Debug-iphonesimulator`). To pin a **single** simulator for
-`test`, export `PASTURA_SIM_NAME` (honored by `sim-dest.sh`) on its own line —
-the leading-assignment form (`PASTURA_SIM_NAME=… scripts/xcodebuild.sh …`) trips
-the allowlist approval prompt, per § "Canonical invocation":
+`-skip-testing`, plus the wrapper-only `--tail N`. It rejects a re-passed
+`-scheme` / `-project` / `-destination` / `-derivedDataPath` with the reason per
+flag, ahead of the simulator gate. To pin **one** simulator for `test`:
 
 ```bash
 export PASTURA_SIM_NAME="iPhone 17 Pro Max"
 scripts/xcodebuild.sh test …
 ```
-
-(`scripts/store-shots.sh` uses this `export` form to force the 6.9″ device for
-App Store screenshots.)
 
 ## When to use what
 

--- a/.claude/rules/xcodebuild-cli.md
+++ b/.claude/rules/xcodebuild-cli.md
@@ -60,10 +60,9 @@ accepts `-destination`, which is what makes the device compile-check recipe
 below work; additive applies there too, so that recipe builds the simulator
 slice alongside the device one (measured: one invocation refreshed both
 `Debug-iphoneos` and `Debug-iphonesimulator`). To pin a **single** simulator for
-`test`, export `PASTURA_SIM_NAME`
-(honored by `sim-dest.sh`) on its own line — the leading-assignment form
-(`PASTURA_SIM_NAME=… scripts/xcodebuild.sh …`) trips the allowlist approval
-prompt, per § "Canonical invocation":
+`test`, export `PASTURA_SIM_NAME` (honored by `sim-dest.sh`) on its own line —
+the leading-assignment form (`PASTURA_SIM_NAME=… scripts/xcodebuild.sh …`) trips
+the allowlist approval prompt, per § "Canonical invocation":
 
 ```bash
 export PASTURA_SIM_NAME="iPhone 17 Pro Max"

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -415,7 +415,7 @@ Determine label from the commit prefix (TASK_TYPE or dominant commit type):
 Additionally, if the changes are security-related, add the `security` label alongside the prefix-based label.
 
 **Determine device-QA need.** Manual on-device QA is required when the diff touches a surface the iOS Simulator build cannot exercise:
-- `#if !targetEnvironment(simulator)` blocks (e.g. `SettingsView` model-management UI, `ModelSettingsRow`) — excluded from the simulator build entirely.
+- `#if !targetEnvironment(simulator)` blocks (enumerate them — `git grep -n '#if !targetEnvironment(simulator)'` — rather than recalling filenames) — excluded from the simulator build entirely.
 - Metal / llama.cpp on-device inference (`LlamaCppService`, GGUF model load, GPU paths).
 - Layout / visual regressions inside those device-only blocks (the simulator never renders them).
 - Pattern-6 executor-inheritance UI freezes (`.claude/rules/swift-isolation.md`) — reproduce only on a real device.

--- a/docs/agent-tooling/orchestrate-kit-reconciliation.md
+++ b/docs/agent-tooling/orchestrate-kit-reconciliation.md
@@ -68,7 +68,3 @@ A template *defect* is reported upstream; its entry names the tracking issue and
 - `.claude/agents/code-reviewer.md` runs its own `git diff HEAD` and `head -14 .claude/rules/*.md`
   cwd-relative; the Step 4 prompt roots only the diff. On a branch editing `.claude/rules/**`, a
   reviewer whose cwd resolved to the main checkout would sweep the pre-change rule set.
-- `.claude/rules/xcodebuild-cli.md`'s "the allowlist match is on the literal command prefix" is
-  unscoped and reads as a claim about the matcher generally; `git -C <path> diff` has been observed
-  to run unprompted under an equally bare `Bash(git diff*)`. The narrower "Both are exact-prefix
-  literal matches" a few lines above is correctly bound to its two named entries.

--- a/scripts/hooks/check-claude-md-modified.sh
+++ b/scripts/hooks/check-claude-md-modified.sh
@@ -312,12 +312,14 @@ fi
 # The total was 91,615 bytes at introduction (#1361, 2026-08-05) and had drifted
 # to 98,036 — above the ceiling, so the nudge fired on every PR — until #1442
 # evacuated the kit-mirror rules' depth to docs/agent-tooling/ on 2026-08-13,
-# bringing it to 94,038.
+# bringing it to 94,038. #1503 then compressed xcodebuild-cli.md (14,202 -> 9,088)
+# on 2026-08-20, landing at 91,068.
 #
 # A slim campaign (#1310 / #1315 style) that lands below the ceiling should
 # re-baseline this default in its own PR — otherwise the nudge decays into
 # permanent wallpaper that everyone scrolls past. #1442 discharged that duty by
-# ratcheting 96,000 -> 95,500. The bar it used, recorded so the next campaign
+# ratcheting 96,000 -> 95,500; #1503 by 95,500 -> 92,600 (91,068 + 1,532, the bar
+# below). The bar it used, recorded so the next campaign
 # does not re-derive one: leave about one rule section (~1.5 KB) of headroom, no
 # less. Tighter and the nudge trips on roughly one added rule paragraph —
 # wallpaper from over-firing instead of under-firing. That is why -3,211 bytes
@@ -337,7 +339,7 @@ fi
 # inert (fixtures are kilobytes, and the firing cases pass an explicit ceiling),
 # which is exactly why a re-baseline would forget it — update it anyway so the
 # two never read as disagreeing about the production value.
-FOOTPRINT_CEILING_DEFAULT=95500
+FOOTPRINT_CEILING_DEFAULT=92600
 FOOTPRINT_CEILING="${PASTURA_FOOTPRINT_CEILING:-$FOOTPRINT_CEILING_DEFAULT}"
 # The one external input; a non-numeric value would make the -gt test below
 # spray `[: illegal number` on stderr, so guard it like $added and $n.

--- a/scripts/marketing-shots.sh
+++ b/scripts/marketing-shots.sh
@@ -51,12 +51,15 @@ export PASTURA_SKIP_XCSTRINGS_SYNC=1
 # the same simulator. `scripts/motion-capture.sh` sources with the gate for the
 # same reason. Sourcing used to drop the caller's errexit — sim-dest.sh's own
 # snapshot recorded it as off whatever the caller had set — so neither a failing
-# source nor a later failure aborted. #1503 fixed that inside sim-dest.sh, and a
-# bare `source` now aborts an errexit-on caller by itself. The `||` handler below
-# is kept for its caller-specific message (PASTURA_SIM_NAME is what usually makes
-# resolution fail here), and the re-assert as defence in depth
-# (.claude/rules/xcodebuild-cli.md; deliberately no § anchor — that section is
-# compressible and a named anchor here would dangle).
+# source nor a later failure aborted. #1503 fixed that inside sim-dest.sh, but
+# NOT for the shape written here: bash suppresses errexit for the left operand of
+# `||`, so this handler's `exit 1` is still the only thing that stops a failed
+# resolution (measured). Delete the whole `|| { … }` and #1503's restore takes
+# over — do NOT reduce it to a bare message, which falls through to the
+# `SIM_UDID=` line below with `DEST` unset or, worse, stale from an earlier
+# `source scripts/sim-dest.sh` in the same shell. The re-assert is defence in
+# depth (.claude/rules/xcodebuild-cli.md; deliberately no § anchor — that section
+# is compressible and a named anchor here would dangle).
 # shellcheck source=/dev/null
 source "$REPO_ROOT/scripts/sim-dest.sh" \
   || { echo "ERROR: simulator resolution failed (PASTURA_SIM_NAME=$PASTURA_SIM_NAME)" >&2; exit 1; }

--- a/scripts/marketing-shots.sh
+++ b/scripts/marketing-shots.sh
@@ -49,12 +49,14 @@ export PASTURA_SKIP_XCSTRINGS_SYNC=1
 # writing it must happen inside the concurrent-session gate — skipping the wait
 # would flip the appearance of another session's in-flight `xcodebuild test` on
 # the same simulator. `scripts/motion-capture.sh` sources with the gate for the
-# same reason. Sourcing restores the caller's shell options on exit, which drops
-# errexit — hence both the explicit `||` on the source itself (errexit is
-# provably off at the instant it returns) and the re-assert below
-# (.claude/rules/xcodebuild-cli.md § "Sourcing it in a script clears your
-# `set -e`"; measured by reading $-, not `set -o` inside a command substitution,
-# which reports "off" regardless).
+# same reason. Sourcing used to drop the caller's errexit — sim-dest.sh's own
+# snapshot recorded it as off whatever the caller had set — so neither a failing
+# source nor a later failure aborted. #1503 fixed that inside sim-dest.sh, and a
+# bare `source` now aborts an errexit-on caller by itself. The `||` handler below
+# is kept for its caller-specific message (PASTURA_SIM_NAME is what usually makes
+# resolution fail here), and the re-assert as defence in depth
+# (.claude/rules/xcodebuild-cli.md; deliberately no § anchor — that section is
+# compressible and a named anchor here would dangle).
 # shellcheck source=/dev/null
 source "$REPO_ROOT/scripts/sim-dest.sh" \
   || { echo "ERROR: simulator resolution failed (PASTURA_SIM_NAME=$PASTURA_SIM_NAME)" >&2; exit 1; }

--- a/scripts/marketing-shots.sh
+++ b/scripts/marketing-shots.sh
@@ -49,17 +49,15 @@ export PASTURA_SKIP_XCSTRINGS_SYNC=1
 # writing it must happen inside the concurrent-session gate — skipping the wait
 # would flip the appearance of another session's in-flight `xcodebuild test` on
 # the same simulator. `scripts/motion-capture.sh` sources with the gate for the
-# same reason. Sourcing used to drop the caller's errexit — sim-dest.sh's own
-# snapshot recorded it as off whatever the caller had set — so neither a failing
-# source nor a later failure aborted. #1503 fixed that inside sim-dest.sh, but
-# NOT for the shape written here: bash suppresses errexit for the left operand of
-# `||`, so this handler's `exit 1` is still the only thing that stops a failed
-# resolution (measured). Delete the whole `|| { … }` and #1503's restore takes
-# over — do NOT reduce it to a bare message, which falls through to the
-# `SIM_UDID=` line below with `DEST` unset or, worse, stale from an earlier
-# `source scripts/sim-dest.sh` in the same shell. The re-assert is defence in
-# depth (.claude/rules/xcodebuild-cli.md; deliberately no § anchor — that section
-# is compressible and a named anchor here would dangle).
+# same reason. #1503 made a failing plain `source` abort an errexit-on caller,
+# but NOT this shape: bash suppresses errexit for the left operand of `||`, so
+# this handler's `exit 1` is still the only thing that stops a failed resolution
+# (measured). Deleting the whole `|| { … }` hands the job back to #1503; reducing
+# it to a bare message does NOT — it falls through to the `SIM_UDID=` line below
+# with `DEST` unset or, worse, stale from an earlier source in the same shell.
+# The `set -euo pipefail` below is defence in depth
+# (.claude/rules/xcodebuild-cli.md — no § anchor on purpose: that section is
+# compressible and a named anchor here would dangle).
 # shellcheck source=/dev/null
 source "$REPO_ROOT/scripts/sim-dest.sh" \
   || { echo "ERROR: simulator resolution failed (PASTURA_SIM_NAME=$PASTURA_SIM_NAME)" >&2; exit 1; }

--- a/scripts/marketing-shots.sh
+++ b/scripts/marketing-shots.sh
@@ -56,7 +56,7 @@ export PASTURA_SKIP_XCSTRINGS_SYNC=1
 # it to a bare message does NOT — it falls through to the `SIM_UDID=` line below
 # with `DEST` unset or, worse, stale from an earlier source in the same shell.
 # The `set -euo pipefail` below is defence in depth
-# (.claude/rules/xcodebuild-cli.md — no § anchor on purpose: that section is
+# (.claude/rules/ci-workflows.md — no § anchor on purpose: that section is
 # compressible and a named anchor here would dangle).
 # shellcheck source=/dev/null
 source "$REPO_ROOT/scripts/sim-dest.sh" \

--- a/scripts/motion-capture.sh
+++ b/scripts/motion-capture.sh
@@ -78,8 +78,10 @@ esac
 # concurrent-`xcodebuild test` gate (see .claude/rules/xcodebuild-cli.md).
 # shellcheck source=/dev/null
 source "$REPO_ROOT/scripts/sim-dest.sh"
-# sim-dest.sh restores the *pre-source* shell options on exit, which clears
-# our `set -e`; re-assert it so the rest of the script still fails fast.
+# sim-dest.sh used to clear our `set -e` on the way out (#1503 — its snapshot
+# recorded errexit as off whatever the caller had set). Fixed at the source, so
+# this re-assert is now defence in depth rather than the thing keeping the rest
+# of the script fail-fast.
 set -euo pipefail
 UDID="${DEST##*id=}"
 

--- a/scripts/sim-dest.sh
+++ b/scripts/sim-dest.sh
@@ -28,14 +28,17 @@
 # so the snapshot records `set +o errexit` whatever the caller's real state was.
 # Restoring it therefore *dropped* a caller's `set -e` — the defect #1503 fixed.
 #
-# errexit is the ONLY option affected — that is the whole rule, and it is not
-# about letter-flags: measured on bash 3.2.57, `nounset` and `xtrace` are `$-`
-# letter flags and both round-trip through the snapshot correctly, as does every
-# other option including pipefail (`$-` itself goes `ehuBc` outside a
-# substitution, `huBc` inside). `shopt inherit_errexit` (bash 4.4+) is the knob
-# that reverses this; the capture below is the 3.2-compatible equivalent, and it
-# only ever re-adds errexit that was genuinely on, so it stays a no-op wherever
-# bash already inherits it.
+# errexit is the ONLY option affected, and NOT because it is a `$-` letter flag —
+# `nounset` is one too and round-trips fine, as does pipefail. That last one is
+# load-bearing, not trivia: the `set -euo pipefail` below turns pipefail ON for
+# this file, so if it did NOT round-trip, every caller would come back silently
+# promoted to pipefail. A7 in `scripts/tests/simdest-errexit-test.sh` executes the
+# errexit/`nounset` pair; pipefail is covered only by A5, which needs `xcrun` and
+# so never runs in CI's ubuntu `shell-tests` job. Redden those before rewriting.
+#
+# `shopt inherit_errexit` (bash 4.4+) reverses the whole effect; the capture below
+# is the 3.2-compatible equivalent, and it only re-adds errexit that was genuinely
+# on, so it no-ops wherever bash already inherits it.
 case $- in
   *e*) _simdest_had_errexit=1 ;;
   *) _simdest_had_errexit=0 ;;

--- a/scripts/sim-dest.sh
+++ b/scripts/sim-dest.sh
@@ -22,8 +22,35 @@
 #
 # Update this list when new Xcode versions add newer default simulators.
 # Save caller's shell options so sourcing doesn't permanently alter them.
+#
+# errexit is captured from `$-`, NOT from the `$(set +o)` snapshot below, and
+# that split is load-bearing: bash clears errexit inside a command substitution,
+# so the snapshot records `set +o errexit` whatever the caller's real state was.
+# Restoring it therefore *dropped* a caller's `set -e` — the defect #1503 fixed.
+# pipefail came back correctly through the same snapshot because it is not a
+# `$-` letter flag, which is why only errexit went missing. Measured on bash
+# 3.2.57; `set -o` read inside a substitution reports "off" regardless, so a
+# probe written that way cannot see any of this.
+case $- in
+  *e*) _simdest_had_errexit=1 ;;
+  *) _simdest_had_errexit=0 ;;
+esac
 _simdest_old_opts=$(set +o)
 set -euo pipefail
+
+# Restore the caller's options. Every exit path calls this instead of a bare
+# `eval`, which would re-apply the snapshot's wrong `set +o errexit`. Because
+# the failure paths below restore errexit *before* returning non-zero, a caller
+# running under `set -e` now aborts on a plain `source scripts/sim-dest.sh` —
+# no `|| { …; exit 1; }` handler needed to catch it.
+_simdest_restore_opts() {
+  eval "$_simdest_old_opts"
+  if [ "$_simdest_had_errexit" = 1 ]; then
+    set -e
+  fi
+  unset _simdest_old_opts _simdest_had_errexit
+  unset -f _simdest_restore_opts
+}
 
 # PASTURA_SIM_NAME pins a single simulator by exact name, bypassing the
 # priority list. Used by scripts/store-shots.sh to force the 6.9" device
@@ -75,7 +102,7 @@ if [ -z "$_simdest_result" ]; then
   echo "Error: No available iOS Simulator found. Tried: ${SIMULATOR_NAMES[*]}" >&2
   [ -s "$_simdest_errfile" ] && echo "Details:" >&2 && cat "$_simdest_errfile" >&2
   rm -f "$_simdest_errfile"
-  eval "$_simdest_old_opts"
+  _simdest_restore_opts
   return 1 2>/dev/null || exit 1
 fi
 rm -f "$_simdest_errfile"
@@ -94,7 +121,7 @@ export DEST="platform=iOS Simulator,id=$_simdest_udid"
 # abort the script with pipefail still active in the caller's shell).
 _simdest_repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || {
   echo "Error: scripts/sim-dest.sh must be sourced from inside the git worktree." >&2
-  eval "$_simdest_old_opts"
+  _simdest_restore_opts
   return 1 2>/dev/null || exit 1
 }
 export DERIVED_DATA="$_simdest_repo_root/Pastura/DerivedData"
@@ -166,12 +193,12 @@ _simdest_wait_for_simulator() {
 if ! _simdest_wait_for_simulator; then
   unset _simdest_result _simdest_udid _simdest_name _simdest_os _simdest_errfile _simdest_repo_root
   unset -f _simdest_wait_for_simulator
-  eval "$_simdest_old_opts"
+  _simdest_restore_opts
   return 1 2>/dev/null || exit 1
 fi
 
 unset _simdest_result _simdest_udid _simdest_name _simdest_os _simdest_errfile _simdest_repo_root
 unset -f _simdest_wait_for_simulator
-eval "$_simdest_old_opts"
+_simdest_restore_opts
 # return when sourced, exit when executed directly
 return 0 2>/dev/null || exit 0

--- a/scripts/sim-dest.sh
+++ b/scripts/sim-dest.sh
@@ -27,10 +27,15 @@
 # that split is load-bearing: bash clears errexit inside a command substitution,
 # so the snapshot records `set +o errexit` whatever the caller's real state was.
 # Restoring it therefore *dropped* a caller's `set -e` — the defect #1503 fixed.
-# pipefail came back correctly through the same snapshot because it is not a
-# `$-` letter flag, which is why only errexit went missing. Measured on bash
-# 3.2.57; `set -o` read inside a substitution reports "off" regardless, so a
-# probe written that way cannot see any of this.
+#
+# errexit is the ONLY option affected — that is the whole rule, and it is not
+# about letter-flags: measured on bash 3.2.57, `nounset` and `xtrace` are `$-`
+# letter flags and both round-trip through the snapshot correctly, as does every
+# other option including pipefail (`$-` itself goes `ehuBc` outside a
+# substitution, `huBc` inside). `shopt inherit_errexit` (bash 4.4+) is the knob
+# that reverses this; the capture below is the 3.2-compatible equivalent, and it
+# only ever re-adds errexit that was genuinely on, so it stays a no-op wherever
+# bash already inherits it.
 case $- in
   *e*) _simdest_had_errexit=1 ;;
   *) _simdest_had_errexit=0 ;;
@@ -41,8 +46,10 @@ set -euo pipefail
 # Restore the caller's options. Every exit path calls this instead of a bare
 # `eval`, which would re-apply the snapshot's wrong `set +o errexit`. Because
 # the failure paths below restore errexit *before* returning non-zero, a caller
-# running under `set -e` now aborts on a plain `source scripts/sim-dest.sh` —
-# no `|| { …; exit 1; }` handler needed to catch it.
+# running under `set -e` now aborts on a PLAIN `source scripts/sim-dest.sh`.
+# That does NOT extend to `source … || handler`: bash suppresses errexit for the
+# left operand of `||`, so a caller written that way still aborts only if its
+# handler says `exit` (measured — three call sites here are written that way).
 _simdest_restore_opts() {
   eval "$_simdest_old_opts"
   if [ "$_simdest_had_errexit" = 1 ]; then

--- a/scripts/store-shots.sh
+++ b/scripts/store-shots.sh
@@ -53,17 +53,15 @@ export PASTURA_SKIP_XCSTRINGS_SYNC=1
 # writing it must happen inside the concurrent-session gate — skipping the wait
 # would flip the appearance of another session's in-flight `xcodebuild test` on
 # the same simulator. `scripts/motion-capture.sh` sources with the gate for the
-# same reason. Sourcing used to drop the caller's errexit — sim-dest.sh's own
-# snapshot recorded it as off whatever the caller had set — so neither a failing
-# source nor a later failure aborted. #1503 fixed that inside sim-dest.sh, but
-# NOT for the shape written here: bash suppresses errexit for the left operand of
-# `||`, so this handler's `exit 1` is still the only thing that stops a failed
-# resolution (measured). Delete the whole `|| { … }` and #1503's restore takes
-# over — do NOT reduce it to a bare message, which falls through to the
-# `SIM_UDID=` line below with `DEST` unset or, worse, stale from an earlier
-# `source scripts/sim-dest.sh` in the same shell. The re-assert is defence in
-# depth (.claude/rules/xcodebuild-cli.md; deliberately no § anchor — that section
-# is compressible and a named anchor here would dangle).
+# same reason. #1503 made a failing plain `source` abort an errexit-on caller,
+# but NOT this shape: bash suppresses errexit for the left operand of `||`, so
+# this handler's `exit 1` is still the only thing that stops a failed resolution
+# (measured). Deleting the whole `|| { … }` hands the job back to #1503; reducing
+# it to a bare message does NOT — it falls through to the `SIM_UDID=` line below
+# with `DEST` unset or, worse, stale from an earlier source in the same shell.
+# The `set -euo pipefail` below is defence in depth
+# (.claude/rules/xcodebuild-cli.md — no § anchor on purpose: that section is
+# compressible and a named anchor here would dangle).
 # shellcheck source=/dev/null
 source "$REPO_ROOT/scripts/sim-dest.sh" \
   || { echo "ERROR: simulator resolution failed (PASTURA_SIM_NAME=$PASTURA_SIM_NAME)" >&2; exit 1; }

--- a/scripts/store-shots.sh
+++ b/scripts/store-shots.sh
@@ -55,12 +55,15 @@ export PASTURA_SKIP_XCSTRINGS_SYNC=1
 # the same simulator. `scripts/motion-capture.sh` sources with the gate for the
 # same reason. Sourcing used to drop the caller's errexit — sim-dest.sh's own
 # snapshot recorded it as off whatever the caller had set — so neither a failing
-# source nor a later failure aborted. #1503 fixed that inside sim-dest.sh, and a
-# bare `source` now aborts an errexit-on caller by itself. The `||` handler below
-# is kept for its caller-specific message (PASTURA_SIM_NAME is what usually makes
-# resolution fail here), and the re-assert as defence in depth
-# (.claude/rules/xcodebuild-cli.md; deliberately no § anchor — that section is
-# compressible and a named anchor here would dangle).
+# source nor a later failure aborted. #1503 fixed that inside sim-dest.sh, but
+# NOT for the shape written here: bash suppresses errexit for the left operand of
+# `||`, so this handler's `exit 1` is still the only thing that stops a failed
+# resolution (measured). Delete the whole `|| { … }` and #1503's restore takes
+# over — do NOT reduce it to a bare message, which falls through to the
+# `SIM_UDID=` line below with `DEST` unset or, worse, stale from an earlier
+# `source scripts/sim-dest.sh` in the same shell. The re-assert is defence in
+# depth (.claude/rules/xcodebuild-cli.md; deliberately no § anchor — that section
+# is compressible and a named anchor here would dangle).
 # shellcheck source=/dev/null
 source "$REPO_ROOT/scripts/sim-dest.sh" \
   || { echo "ERROR: simulator resolution failed (PASTURA_SIM_NAME=$PASTURA_SIM_NAME)" >&2; exit 1; }

--- a/scripts/store-shots.sh
+++ b/scripts/store-shots.sh
@@ -53,12 +53,14 @@ export PASTURA_SKIP_XCSTRINGS_SYNC=1
 # writing it must happen inside the concurrent-session gate — skipping the wait
 # would flip the appearance of another session's in-flight `xcodebuild test` on
 # the same simulator. `scripts/motion-capture.sh` sources with the gate for the
-# same reason. Sourcing restores the caller's shell options on exit, which drops
-# errexit — hence both the explicit `||` on the source itself (errexit is
-# provably off at the instant it returns) and the re-assert below
-# (.claude/rules/xcodebuild-cli.md § "Sourcing it in a script clears your
-# `set -e`"; measured by reading $-, not `set -o` inside a command substitution,
-# which reports "off" regardless).
+# same reason. Sourcing used to drop the caller's errexit — sim-dest.sh's own
+# snapshot recorded it as off whatever the caller had set — so neither a failing
+# source nor a later failure aborted. #1503 fixed that inside sim-dest.sh, and a
+# bare `source` now aborts an errexit-on caller by itself. The `||` handler below
+# is kept for its caller-specific message (PASTURA_SIM_NAME is what usually makes
+# resolution fail here), and the re-assert as defence in depth
+# (.claude/rules/xcodebuild-cli.md; deliberately no § anchor — that section is
+# compressible and a named anchor here would dangle).
 # shellcheck source=/dev/null
 source "$REPO_ROOT/scripts/sim-dest.sh" \
   || { echo "ERROR: simulator resolution failed (PASTURA_SIM_NAME=$PASTURA_SIM_NAME)" >&2; exit 1; }

--- a/scripts/store-shots.sh
+++ b/scripts/store-shots.sh
@@ -60,7 +60,7 @@ export PASTURA_SKIP_XCSTRINGS_SYNC=1
 # it to a bare message does NOT — it falls through to the `SIM_UDID=` line below
 # with `DEST` unset or, worse, stale from an earlier source in the same shell.
 # The `set -euo pipefail` below is defence in depth
-# (.claude/rules/xcodebuild-cli.md — no § anchor on purpose: that section is
+# (.claude/rules/ci-workflows.md — no § anchor on purpose: that section is
 # compressible and a named anchor here would dangle).
 # shellcheck source=/dev/null
 source "$REPO_ROOT/scripts/sim-dest.sh" \

--- a/scripts/tests/check-claude-md-modified-test.sh
+++ b/scripts/tests/check-claude-md-modified-test.sh
@@ -132,7 +132,7 @@ RC=0
 run_hook() {
   local out
   set +e
-  out="$( cd "$1" && PASTURA_FOOTPRINT_CEILING="${2:-95500}" bash "$HOOK" )"
+  out="$( cd "$1" && PASTURA_FOOTPRINT_CEILING="${2:-92600}" bash "$HOOK" )"
   RC=$?
   set -e
   printf '%s' "$out"

--- a/scripts/tests/simdest-errexit-test.sh
+++ b/scripts/tests/simdest-errexit-test.sh
@@ -8,7 +8,8 @@
 # caller had set, and restoring it DROPPED a caller's `set -e`. pipefail came
 # back correctly through the same snapshot — it is not a `$-` letter flag —
 # which is why only errexit went missing and the loss stayed invisible for so
-# long. Mechanism: `.claude/rules/xcodebuild-cli.md` § "Sourcing it".
+# long. Mechanism: `.claude/rules/xcodebuild-cli.md` (no § anchor — that section
+# is compressible, and a named one here would dangle).
 #
 # WHAT EACH ARM RUNS. A1, A2 and A6 source the REAL `scripts/sim-dest.sh`; A3
 # and A4 run in-file fixtures. The split is forced by the runner: the CI
@@ -18,6 +19,12 @@
 # OSes — A1 from an errexit-ON caller (must abort), A2 from an errexit-OFF one
 # (must NOT be promoted to on). A5 covers the success path and SKIPS loudly
 # where it cannot run; do not silence that notice.
+#
+# NOT COVERED. sim-dest.sh restores on four paths; the arms below reach two of
+# them (the simulator-resolution failure and, on macOS, the success path). The
+# `git rev-parse` guard and the wait-gate timeout are unexercised — the latter
+# unreachable while every arm exports PASTURA_SKIP_SIM_WAIT=1. Read this file as
+# pinning the capture, not the whole restore contract.
 #
 # A3 IS THE NEGATIVE CONTROL AND IS NOT OPTIONAL. It reproduces the pre-#1503
 # capture and requires errexit to end up OFF. Without it, A1 and A2 would pass
@@ -146,27 +153,40 @@ else
 fi
 
 # --- A5: real script, SUCCESS path (needs a simulator; ubuntu CI cannot) ----
+#
+# The caller deliberately enters with errexit ON and pipefail OFF — the one
+# combination in which BOTH halves discriminate. sim-dest.sh turns pipefail on
+# for itself, so a caller that already had it on would print A5_PIPEFAIL_ON
+# whether or not the restore ever ran; requiring it back OFF is what a no-op
+# restore fails.
 if command -v xcrun > /dev/null 2>&1; then
   cat > "$TMP/a5.sh" <<A5
 export PASTURA_SKIP_SIM_WAIT=1
-set -euo pipefail
+set -eu
+set +o pipefail
 source '$SIMDEST' > /dev/null
 case "\$-" in *e*) echo 'A5_ERREXIT_ON' ;; *) echo 'A5_ERREXIT_OFF' ;; esac
 pf="\$(set -o | { grep '^pipefail' || [ \$? -eq 1 ]; })"
 case "\$pf" in *on*) echo 'A5_PIPEFAIL_ON' ;; *) echo 'A5_PIPEFAIL_OFF' ;; esac
 A5
   run_probe "$TMP/a5.sh"
-  if has 'A5_ERREXIT_ON' "$probe_out" && has 'A5_PIPEFAIL_ON' "$probe_out"; then
-    ok "A5 the success path restores BOTH errexit and pipefail"
+  if has 'A5_ERREXIT_ON' "$probe_out" && has 'A5_PIPEFAIL_OFF' "$probe_out"; then
+    ok "A5 the success path reproduces the caller's options (errexit on, pipefail off)"
   else
-    bad "A5 the success path lost an option (errexit and/or pipefail). This is the path every" \
+    bad "A5 the success path did not reproduce the caller's options. This is the path every" \
         "local xcodebuild run takes. Output: $probe_out"
   fi
 else
   printf '  SKIP: A5 (success path) needs xcrun — not present on this runner\n'
 fi
 
-# --- A6: no namespace leak into the caller ---------------------------------
+# --- A6: the restore helper and its own two variables are cleaned up --------
+#
+# Scoped to what #1503 introduced, NOT to "sim-dest.sh leaks nothing". It does
+# leak: the early-return path measured here leaves `_simdest_errfile` (a temp
+# path) and `SIMULATOR_NAMES` set, because only the success path's `unset` lines
+# clear them. That is pre-existing and out of this fix's scope — named here so
+# the arm cannot be read as certifying it away.
 cat > "$TMP/a6.sh" <<A6
 export PASTURA_SKIP_SIM_WAIT=1
 export PASTURA_SIM_NAME='$NO_SUCH_SIM'
@@ -183,7 +203,8 @@ run_probe "$TMP/a6.sh"
 if has 'A6_DONE' "$probe_out" && ! has 'A6_LEAKED' "$probe_out"; then
   ok "A6 the restore helper and its two state variables are unset before returning"
 else
-  bad "A6 sim-dest.sh leaked internal state into the caller's shell. Output: $probe_out"
+  bad "A6 the restore helper or one of its two state variables survived into the caller's" \
+      "shell. Output: $probe_out"
 fi
 
 if [ "$fail" -ne 0 ]; then

--- a/scripts/tests/simdest-errexit-test.sh
+++ b/scripts/tests/simdest-errexit-test.sh
@@ -5,10 +5,10 @@
 # THE DEFECT. `sim-dest.sh` saved shell options with `$(set +o)`, a command
 # substitution — where bash has already cleared errexit — so the snapshot said
 # `set +o errexit` whatever the caller had set, and restoring it DROPPED the
-# caller's `set -e`. pipefail came back correctly through the same snapshot (no
-# `$-` letter flag), which is why only errexit went missing and stayed
-# invisible. Mechanism: `.claude/rules/xcodebuild-cli.md` (no § anchor — that
-# section is compressible and a named one here would dangle).
+# caller's `set -e`. errexit is the ONLY option affected, which A7 pins: letter-
+# flag-ness is not the discriminator (`nounset` is one and survives). Mechanism:
+# `.claude/rules/xcodebuild-cli.md` (no § anchor — that section is compressible
+# and a named one here would dangle).
 #
 # REAL vs FIXTURE. A1, A2, A6 source the REAL sim-dest.sh; A3, A4 run in-file
 # fixtures. The runner forces the split: CI's ubuntu job has no `xcrun`, so the
@@ -206,6 +206,52 @@ if has 'A6_DONE' "$probe_out" && ! has 'A6_LEAKED' "$probe_out"; then
 else
   bad "A6 the restore helper or one of its two state variables survived into the caller's" \
       "shell. Output: $probe_out"
+fi
+
+# --- A7: the mechanism claim — errexit is the ONLY option `$(set +o)` loses ---
+#
+# A3/A4 control the EFFECT (does errexit survive). This controls the stated
+# CAUSE. The comments used to say pipefail survived "because it is not a `$-`
+# letter flag", which predicts `nounset` — a letter flag — is lost too. It is
+# not. If this arm ever reddens on `nounset`, the rewritten mechanism sentence
+# in sim-dest.sh and the rules file is what needs re-measuring, not this test.
+cat > "$TMP/a7.sh" <<'A7'
+set -o nounset
+snap="$(set +o)"
+case "$snap" in *"set -o nounset"*) echo 'A7_NOUNSET_KEPT' ;; *) echo 'A7_NOUNSET_LOST' ;; esac
+set -o errexit
+snap2="$(set +o)"
+case "$snap2" in *"set -o errexit"*) echo 'A7_ERREXIT_KEPT' ;; *) echo 'A7_ERREXIT_LOST' ;; esac
+A7
+run_probe "$TMP/a7.sh"
+if has 'A7_NOUNSET_KEPT' "$probe_out" && has 'A7_ERREXIT_LOST' "$probe_out"; then
+  ok "A7 control: \`\$(set +o)\` loses errexit and ONLY errexit — \`nounset\` round-trips"
+else
+  bad "A7 the mechanism this fix rests on no longer holds on this bash. If errexit now" \
+      "round-trips the fix is a harmless no-op, but the prose is wrong; if nounset stopped" \
+      "round-tripping the capture is too narrow. Output: $probe_out"
+fi
+
+# --- A8: `source … || handler` still needs its own `exit` -------------------
+#
+# The fix makes a BARE `source` abort an errexit-on caller. It does not extend to
+# the `||` form — bash suppresses errexit for the left operand — and three call
+# sites are written that way. Pinned here because the natural mis-edit is to trim
+# such a handler to a bare message on the grounds that the fix now aborts.
+cat > "$TMP/a8.sh" <<A8
+export PASTURA_SKIP_SIM_WAIT=1
+export PASTURA_SIM_NAME='$NO_SUCH_SIM'
+set -euo pipefail
+source '$SIMDEST' 2>/dev/null || echo 'A8_HANDLER_RAN'
+echo 'A8_FELL_THROUGH'
+A8
+run_probe "$TMP/a8.sh"
+if has 'A8_FELL_THROUGH' "$probe_out"; then
+  ok "A8 a \`|| handler\` without \`exit\` still falls through — those sites keep their \`exit 1\`"
+else
+  bad "A8 the \`||\` form aborted on its own. If bash stopped suppressing errexit for the left" \
+      "operand, the three \`|| { …; exit 1; }\` sites can drop their handlers and the comments" \
+      "there need updating. Output: $probe_out"
 fi
 
 if [ "$fail" -ne 0 ]; then

--- a/scripts/tests/simdest-errexit-test.sh
+++ b/scripts/tests/simdest-errexit-test.sh
@@ -191,14 +191,17 @@ fi
 #
 # Enumerate that residual with `${x+SET}` or a `set` name diff, never `${x:-}`:
 # `_simdest_result` is set-but-EMPTY on this path, so a `:-` probe reports it
-# absent and the list comes back one short (it did, the first time).
+# absent and the list comes back one short (it did, the first time). The arm's
+# own loop below uses `+SET` for the same reason — both variables it checks are
+# structurally non-empty today, so `:-` would not yet lie, but the shape an arm
+# models is the shape the next editor copies.
 cat > "$TMP/a6.sh" <<A6
 export PASTURA_SKIP_SIM_WAIT=1
 export PASTURA_SIM_NAME='$NO_SUCH_SIM'
 set +e
 source '$SIMDEST'
 for v in _simdest_old_opts _simdest_had_errexit; do
-  eval "val=\\\${\$v:-}"
+  eval "val=\\\${\$v+SET}"
   if [ -n "\$val" ]; then echo "A6_LEAKED_\$v"; fi
 done
 if type _simdest_restore_opts > /dev/null 2>&1; then echo 'A6_LEAKED_restore_fn'; fi

--- a/scripts/tests/simdest-errexit-test.sh
+++ b/scripts/tests/simdest-errexit-test.sh
@@ -7,7 +7,7 @@
 # `set +o errexit` whatever the caller had set, and restoring it DROPPED the
 # caller's `set -e`. errexit is the ONLY option affected, which A7 pins: letter-
 # flag-ness is not the discriminator (`nounset` is one and survives). Mechanism:
-# `.claude/rules/xcodebuild-cli.md` (no § anchor — that section is compressible
+# `.claude/rules/ci-workflows.md` (no § anchor — that section is compressible
 # and a named one here would dangle).
 #
 # REAL vs FIXTURE. A1, A2, A6 source the REAL sim-dest.sh; A3, A4 run in-file

--- a/scripts/tests/simdest-errexit-test.sh
+++ b/scripts/tests/simdest-errexit-test.sh
@@ -2,40 +2,33 @@
 #
 # scripts/tests/simdest-errexit-test.sh — regression test for #1503.
 #
-# THE DEFECT. `scripts/sim-dest.sh` saved the caller's shell options with
-# `_simdest_old_opts=$(set +o)`. bash clears errexit inside a command
-# substitution, so that snapshot recorded `set +o errexit` no matter what the
-# caller had set, and restoring it DROPPED a caller's `set -e`. pipefail came
-# back correctly through the same snapshot — it is not a `$-` letter flag —
-# which is why only errexit went missing and the loss stayed invisible for so
-# long. Mechanism: `.claude/rules/xcodebuild-cli.md` (no § anchor — that section
-# is compressible, and a named one here would dangle).
+# THE DEFECT. `sim-dest.sh` saved shell options with `$(set +o)`, a command
+# substitution — where bash has already cleared errexit — so the snapshot said
+# `set +o errexit` whatever the caller had set, and restoring it DROPPED the
+# caller's `set -e`. pipefail came back correctly through the same snapshot (no
+# `$-` letter flag), which is why only errexit went missing and stayed
+# invisible. Mechanism: `.claude/rules/xcodebuild-cli.md` (no § anchor — that
+# section is compressible and a named one here would dangle).
 #
-# WHAT EACH ARM RUNS. A1, A2 and A6 source the REAL `scripts/sim-dest.sh`; A3
-# and A4 run in-file fixtures. The split is forced by the runner: the CI
-# "Shell gate tests" job is ubuntu with no `xcrun`, so the real script's
-# SUCCESS path cannot execute there. Its FAILURE path can, and it restores
-# options through the same helper, so A1/A2 still bind the real file on both
-# OSes — A1 from an errexit-ON caller (must abort), A2 from an errexit-OFF one
-# (must NOT be promoted to on). A5 covers the success path and SKIPS loudly
-# where it cannot run; do not silence that notice.
+# REAL vs FIXTURE. A1, A2, A6 source the REAL sim-dest.sh; A3, A4 run in-file
+# fixtures. The runner forces the split: CI's ubuntu job has no `xcrun`, so the
+# real SUCCESS path cannot run there — but its FAILURE path can, through the
+# same helper, so A1 (errexit-ON caller must abort) and A2 (errexit-OFF must not
+# be promoted) bind the real file on both OSes. A5 covers the success path and
+# SKIPS loudly where it cannot run; do not silence that notice.
 #
-# NOT COVERED. sim-dest.sh restores on four paths; the arms below reach two of
-# them (the simulator-resolution failure and, on macOS, the success path). The
-# `git rev-parse` guard and the wait-gate timeout are unexercised — the latter
-# unreachable while every arm exports PASTURA_SKIP_SIM_WAIT=1. Read this file as
-# pinning the capture, not the whole restore contract.
+# A3 IS THE NEGATIVE CONTROL AND IS NOT OPTIONAL: it reproduces the pre-#1503
+# capture and requires errexit to end up OFF, without which A1/A2 would pass
+# against a sim-dest.sh that restores nothing. A4 is its positive twin, so a
+# fixture harness that stopped executing anything cannot read as green. Both are
+# fixtures on purpose — a control borrowed from the file under test stops
+# discriminating the day that file changes (#1481).
 #
-# A3 IS THE NEGATIVE CONTROL AND IS NOT OPTIONAL. It reproduces the pre-#1503
-# capture and requires errexit to end up OFF. Without it, A1 and A2 would pass
-# against a sim-dest.sh that never restores anything, and nothing here would
-# say so. A4 is its positive twin — same harness, corrected capture — so a
-# fixture harness that stopped executing anything at all cannot read as green.
-# Both are fixtures on purpose: a control borrowed from the file under test
-# stops discriminating the moment that file changes (#1481).
+# NOT COVERED: two of sim-dest.sh's four restore paths — the `git rev-parse`
+# guard, and the wait-gate timeout (unreachable while every arm exports
+# PASTURA_SKIP_SIM_WAIT=1). This pins the capture, not the whole contract.
 #
-# CI-wired: the `*-test.sh` naming convention makes this a gate under
-# .github/workflows/ci.yml ("Run scripts/tests/*-test.sh"). Run manually:
+# CI-wired by the `*-test.sh` name. Run manually:
 #   bash scripts/tests/simdest-errexit-test.sh
 
 set -euo pipefail

--- a/scripts/tests/simdest-errexit-test.sh
+++ b/scripts/tests/simdest-errexit-test.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+#
+# scripts/tests/simdest-errexit-test.sh — regression test for #1503.
+#
+# THE DEFECT. `scripts/sim-dest.sh` saved the caller's shell options with
+# `_simdest_old_opts=$(set +o)`. bash clears errexit inside a command
+# substitution, so that snapshot recorded `set +o errexit` no matter what the
+# caller had set, and restoring it DROPPED a caller's `set -e`. pipefail came
+# back correctly through the same snapshot — it is not a `$-` letter flag —
+# which is why only errexit went missing and the loss stayed invisible for so
+# long. Mechanism: `.claude/rules/xcodebuild-cli.md` § "Sourcing it".
+#
+# WHAT EACH ARM RUNS. A1, A2 and A6 source the REAL `scripts/sim-dest.sh`; A3
+# and A4 run in-file fixtures. The split is forced by the runner: the CI
+# "Shell gate tests" job is ubuntu with no `xcrun`, so the real script's
+# SUCCESS path cannot execute there. Its FAILURE path can, and it restores
+# options through the same helper, so A1/A2 still bind the real file on both
+# OSes — A1 from an errexit-ON caller (must abort), A2 from an errexit-OFF one
+# (must NOT be promoted to on). A5 covers the success path and SKIPS loudly
+# where it cannot run; do not silence that notice.
+#
+# A3 IS THE NEGATIVE CONTROL AND IS NOT OPTIONAL. It reproduces the pre-#1503
+# capture and requires errexit to end up OFF. Without it, A1 and A2 would pass
+# against a sim-dest.sh that never restores anything, and nothing here would
+# say so. A4 is its positive twin — same harness, corrected capture — so a
+# fixture harness that stopped executing anything at all cannot read as green.
+# Both are fixtures on purpose: a control borrowed from the file under test
+# stops discriminating the moment that file changes (#1481).
+#
+# CI-wired: the `*-test.sh` naming convention makes this a gate under
+# .github/workflows/ci.yml ("Run scripts/tests/*-test.sh"). Run manually:
+#   bash scripts/tests/simdest-errexit-test.sh
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+SIMDEST="$ROOT/scripts/sim-dest.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail=0
+bad() { printf 'FAIL: %s\n' "$*" >&2; fail=1; }
+ok()  { printf '  ok: %s\n' "$*"; }
+
+# Runs a probe script and reports its combined output plus exit status through
+# two globals. `|| true` is required: several arms probe an ABORT, and this
+# suite itself runs under `set -e`.
+probe_out=""
+probe_rc=0
+run_probe() { # $1 = script path
+  # The status is carried out INSIDE the substitution: `x="$(cmd)" || true`
+  # would leave `$?` holding `true`'s status, and without some `|| true` this
+  # suite's own `set -e` aborts on the arms that probe a deliberate failure.
+  probe_out="$(/bin/bash "$1" 2>&1; printf '__RC__%s' "$?")"
+  probe_rc="${probe_out##*__RC__}"
+  probe_out="${probe_out%__RC__*}"
+}
+
+has() { # $1 = needle, $2 = haystack
+  case "$2" in *"$1"*) return 0 ;; *) return 1 ;; esac
+}
+
+# A nonexistent device name drives the real script down its "No available iOS
+# Simulator found" path on macOS. On ubuntu it lands there anyway (no `xcrun`),
+# so both runners exercise the same restore-then-return-1 code.
+NO_SUCH_SIM='__pastura_no_such_simulator__'
+
+# --- A1: real script, errexit-ON caller, failure path ----------------------
+cat > "$TMP/a1.sh" <<A1
+export PASTURA_SKIP_SIM_WAIT=1
+export PASTURA_SIM_NAME='$NO_SUCH_SIM'
+set -euo pipefail
+source '$SIMDEST'
+echo 'A1_REACHED_AFTER_FAILED_SOURCE'
+A1
+run_probe "$TMP/a1.sh"
+if [ "$probe_rc" != "0" ] && ! has 'A1_REACHED_AFTER_FAILED_SOURCE' "$probe_out"; then
+  ok "A1 a failing plain \`source\` aborts an errexit-on caller (no \`||\` handler needed)"
+else
+  bad "A1 the caller survived a failing \`source\` (rc=$probe_rc). errexit was not" \
+      "restored before sim-dest.sh returned 1. Output: $probe_out"
+fi
+
+# --- A2: real script, errexit-OFF caller, failure path ---------------------
+cat > "$TMP/a2.sh" <<A2
+export PASTURA_SKIP_SIM_WAIT=1
+export PASTURA_SIM_NAME='$NO_SUCH_SIM'
+set +e
+source '$SIMDEST'
+case "\$-" in *e*) echo 'A2_ERREXIT_ON' ;; *) echo 'A2_ERREXIT_OFF' ;; esac
+A2
+run_probe "$TMP/a2.sh"
+if has 'A2_ERREXIT_OFF' "$probe_out"; then
+  ok "A2 an errexit-off caller is not promoted to errexit-on by sourcing"
+else
+  bad "A2 sourcing turned errexit ON for a caller that had it off — the restore" \
+      "is unconditional rather than reproducing the caller's state. Output: $probe_out"
+fi
+
+# --- A3: NEGATIVE CONTROL — the pre-#1503 capture must still lose errexit ---
+cat > "$TMP/broken-lib.sh" <<'BROKEN'
+_old=$(set +o)
+set -euo pipefail
+eval "$_old"
+BROKEN
+cat > "$TMP/a3.sh" <<A3
+set -euo pipefail
+source '$TMP/broken-lib.sh'
+case "\$-" in *e*) echo 'A3_ERREXIT_ON' ;; *) echo 'A3_ERREXIT_OFF' ;; esac
+A3
+run_probe "$TMP/a3.sh"
+if has 'A3_ERREXIT_OFF' "$probe_out"; then
+  ok "A3 control: the old \`\$(set +o)\`-only capture still drops errexit, so A1/A2 discriminate"
+else
+  bad "A3 control did NOT lose errexit. Either this bash no longer clears errexit inside a" \
+      "command substitution — in which case #1503's premise changed and every arm here is" \
+      "vacuous — or the fixture stopped running. Output: $probe_out"
+fi
+
+# --- A4: positive twin of A3 — the corrected capture keeps errexit ---------
+cat > "$TMP/fixed-lib.sh" <<'FIXED'
+case $- in
+  *e*) _had=1 ;;
+  *) _had=0 ;;
+esac
+_old=$(set +o)
+set -euo pipefail
+eval "$_old"
+if [ "$_had" = 1 ]; then
+  set -e
+fi
+unset _old _had
+FIXED
+cat > "$TMP/a4.sh" <<A4
+set -euo pipefail
+source '$TMP/fixed-lib.sh'
+case "\$-" in *e*) echo 'A4_ERREXIT_ON' ;; *) echo 'A4_ERREXIT_OFF' ;; esac
+A4
+run_probe "$TMP/a4.sh"
+if has 'A4_ERREXIT_ON' "$probe_out"; then
+  ok "A4 control: the corrected capture restores errexit, so A3 is measuring the capture"
+else
+  bad "A4 the corrected capture failed to restore errexit — the fixture harness is broken," \
+      "which makes A3's 'off' result uninformative. Output: $probe_out"
+fi
+
+# --- A5: real script, SUCCESS path (needs a simulator; ubuntu CI cannot) ----
+if command -v xcrun > /dev/null 2>&1; then
+  cat > "$TMP/a5.sh" <<A5
+export PASTURA_SKIP_SIM_WAIT=1
+set -euo pipefail
+source '$SIMDEST' > /dev/null
+case "\$-" in *e*) echo 'A5_ERREXIT_ON' ;; *) echo 'A5_ERREXIT_OFF' ;; esac
+pf="\$(set -o | { grep '^pipefail' || [ \$? -eq 1 ]; })"
+case "\$pf" in *on*) echo 'A5_PIPEFAIL_ON' ;; *) echo 'A5_PIPEFAIL_OFF' ;; esac
+A5
+  run_probe "$TMP/a5.sh"
+  if has 'A5_ERREXIT_ON' "$probe_out" && has 'A5_PIPEFAIL_ON' "$probe_out"; then
+    ok "A5 the success path restores BOTH errexit and pipefail"
+  else
+    bad "A5 the success path lost an option (errexit and/or pipefail). This is the path every" \
+        "local xcodebuild run takes. Output: $probe_out"
+  fi
+else
+  printf '  SKIP: A5 (success path) needs xcrun — not present on this runner\n'
+fi
+
+# --- A6: no namespace leak into the caller ---------------------------------
+cat > "$TMP/a6.sh" <<A6
+export PASTURA_SKIP_SIM_WAIT=1
+export PASTURA_SIM_NAME='$NO_SUCH_SIM'
+set +e
+source '$SIMDEST'
+for v in _simdest_old_opts _simdest_had_errexit; do
+  eval "val=\\\${\$v:-}"
+  if [ -n "\$val" ]; then echo "A6_LEAKED_\$v"; fi
+done
+if type _simdest_restore_opts > /dev/null 2>&1; then echo 'A6_LEAKED_restore_fn'; fi
+echo 'A6_DONE'
+A6
+run_probe "$TMP/a6.sh"
+if has 'A6_DONE' "$probe_out" && ! has 'A6_LEAKED' "$probe_out"; then
+  ok "A6 the restore helper and its two state variables are unset before returning"
+else
+  bad "A6 sim-dest.sh leaked internal state into the caller's shell. Output: $probe_out"
+fi
+
+if [ "$fail" -ne 0 ]; then
+  printf '\nsimdest-errexit-test.sh: FAILED\n' >&2
+  exit 1
+fi
+printf '\nsimdest-errexit-test.sh: all arms passed\n'

--- a/scripts/tests/simdest-errexit-test.sh
+++ b/scripts/tests/simdest-errexit-test.sh
@@ -154,11 +154,12 @@ fi
 
 # --- A5: real script, SUCCESS path (needs a simulator; ubuntu CI cannot) ----
 #
-# The caller deliberately enters with errexit ON and pipefail OFF — the one
-# combination in which BOTH halves discriminate. sim-dest.sh turns pipefail on
-# for itself, so a caller that already had it on would print A5_PIPEFAIL_ON
-# whether or not the restore ever ran; requiring it back OFF is what a no-op
-# restore fails.
+# The caller enters with errexit ON and pipefail OFF so that each half catches a
+# different mutant. Measured against both: a no-op restore keeps pipefail ON
+# (sim-dest.sh sets it for itself) and fails the pipefail half; the pre-#1503
+# snapshot-only restore comes back errexit OFF and fails the errexit half. Enter
+# with pipefail already ON — as this arm originally did — and the pipefail half
+# passes whether or not the restore ran at all.
 if command -v xcrun > /dev/null 2>&1; then
   cat > "$TMP/a5.sh" <<A5
 export PASTURA_SKIP_SIM_WAIT=1
@@ -183,10 +184,14 @@ fi
 # --- A6: the restore helper and its own two variables are cleaned up --------
 #
 # Scoped to what #1503 introduced, NOT to "sim-dest.sh leaks nothing". It does
-# leak: the early-return path measured here leaves `_simdest_errfile` (a temp
-# path) and `SIMULATOR_NAMES` set, because only the success path's `unset` lines
-# clear them. That is pre-existing and out of this fix's scope — named here so
-# the arm cannot be read as certifying it away.
+# leak: the early-return path measured here leaves `_simdest_errfile`,
+# `_simdest_result` and `SIMULATOR_NAMES` set, because only the success path's
+# `unset` lines clear them. Pre-existing and out of this fix's scope — named
+# here so the arm cannot be read as certifying it away.
+#
+# Enumerate that residual with `${x+SET}` or a `set` name diff, never `${x:-}`:
+# `_simdest_result` is set-but-EMPTY on this path, so a `:-` probe reports it
+# absent and the list comes back one short (it did, the first time).
 cat > "$TMP/a6.sh" <<A6
 export PASTURA_SKIP_SIM_WAIT=1
 export PASTURA_SIM_NAME='$NO_SUCH_SIM'

--- a/scripts/ui-tour.sh
+++ b/scripts/ui-tour.sh
@@ -70,8 +70,10 @@ export PASTURA_SKIP_XCSTRINGS_SYNC=1
 # later anyway. Sourced WITH the concurrent-session gate: appearance is
 # device-global, so writing it while another session holds the simulator would
 # flip that run's appearance mid-suite. Sourcing used to drop errexit (#1503,
-# fixed inside sim-dest.sh), so the `||` handler and the re-assert below are now
-# a message and defence in depth respectively, not the abort mechanism
+# fixed inside sim-dest.sh) — but not for this shape: bash suppresses errexit for
+# the left operand of `||`, so the handler's `exit 1` below is still the only
+# thing that aborts a failed resolution (measured). Delete the whole `|| { … }`
+# and the fix takes over; do NOT reduce it to a bare message
 # (.claude/rules/xcodebuild-cli.md).
 # shellcheck source=/dev/null
 source "$REPO_ROOT/scripts/sim-dest.sh" \

--- a/scripts/ui-tour.sh
+++ b/scripts/ui-tour.sh
@@ -69,8 +69,10 @@ export PASTURA_SKIP_XCSTRINGS_SYNC=1
 # (CoreSimulator error 405 on Shutdown); xcodebuild boots the same one moments
 # later anyway. Sourced WITH the concurrent-session gate: appearance is
 # device-global, so writing it while another session holds the simulator would
-# flip that run's appearance mid-suite. Sourcing drops errexit, hence both the
-# explicit `||` and the re-assert (.claude/rules/xcodebuild-cli.md).
+# flip that run's appearance mid-suite. Sourcing used to drop errexit (#1503,
+# fixed inside sim-dest.sh), so the `||` handler and the re-assert below are now
+# a message and defence in depth respectively, not the abort mechanism
+# (.claude/rules/xcodebuild-cli.md).
 # shellcheck source=/dev/null
 source "$REPO_ROOT/scripts/sim-dest.sh" \
   || { echo "ERROR: simulator resolution failed" >&2; exit 1; }

--- a/scripts/ui-tour.sh
+++ b/scripts/ui-tour.sh
@@ -74,7 +74,7 @@ export PASTURA_SKIP_XCSTRINGS_SYNC=1
 # the left operand of `||`, so the handler's `exit 1` below is still the only
 # thing that aborts a failed resolution (measured). Delete the whole `|| { … }`
 # and the fix takes over; do NOT reduce it to a bare message
-# (.claude/rules/xcodebuild-cli.md).
+# (.claude/rules/ci-workflows.md).
 # shellcheck source=/dev/null
 source "$REPO_ROOT/scripts/sim-dest.sh" \
   || { echo "ERROR: simulator resolution failed" >&2; exit 1; }

--- a/scripts/xcodebuild.sh
+++ b/scripts/xcodebuild.sh
@@ -141,12 +141,19 @@ set -- ${forwarded[@]+"${forwarded[@]}"}
 #
 # Per flag, because xcodebuild's own handling differs. `-scheme` / `-project` /
 # `-derivedDataPath`: it rejects these too, but between the xtrace and a full
-# usage page, which reads like a wrapper bug. The `=`-joined form: SILENTLY
-# IGNORED (Xcode 15.4+), landing the build in ~/Library while looking correct —
-# checked for all three, since none of them takes `=` here. A second
-# `-destination`: ADDITIVE, so `test` would run on both devices with either
-# failure aborting; `build` must keep accepting it for the device compile-check
-# recipe below.
+# usage page, which reads like a wrapper bug.
+#
+# The `=`-joined form is the one worth a guard: xcodebuild takes it, exits 0, and
+# DROPS the flag. Measured on Xcode 26.6 — `-showBuildSettings … -derivedDataPath=/tmp/x`
+# reports `BUILD_DIR = ~/Library/Developer/Xcode/DerivedData/…` while the
+# space-separated control reports `/tmp/x/Build/Products`. Here the wrapper
+# supplies its own value anyway, so a caller's `=` copy is merely inert — the
+# relocation hazard is the one the wrapper's own space-separated flag already
+# avoids. `-destination=` is where inert turns dangerous; see its arm below.
+#
+# A second bare `-destination` is ADDITIVE, so `test` would run on both devices
+# with either failure aborting; `build` keeps accepting the space form for the
+# device compile-check recipe.
 for _arg in "$@"; do
   case "$_arg" in
     -scheme|-project|-derivedDataPath)
@@ -158,7 +165,18 @@ for _arg in "$@"; do
       echo "  It is also supplied by this wrapper already — drop the flag." >&2
       exit 2
       ;;
-    -destination|-destination=*)
+    -destination=*)
+      # Rejected for BOTH subcommands, unlike the bare form below. The `=` shape
+      # is dropped here too, and `build` is where it bites: the documented device
+      # compile-check recipe IS a `build -destination …`, so an `=` there silently
+      # loses the device slice, builds the simulator one, and still prints
+      # `** BUILD SUCCEEDED **` — the exact false green that recipe exists to
+      # prevent.
+      echo "-destination takes a SPACE-separated value; the \`=\` form is silently dropped." >&2
+      echo "  On \`build\` that loses the device slice while still printing BUILD SUCCEEDED." >&2
+      exit 2
+      ;;
+    -destination)
       if [[ "$cmd" == "test" ]]; then
         echo "-destination is additive for \`test\`: xcodebuild would run the suite on the" >&2
         echo "  wrapper's simulator AND yours, and a failure on either aborts the run." >&2
@@ -228,11 +246,18 @@ fi
 # with empty `artifacts`/`dependencies` and no `"identity"` anywhere, so keying
 # on existence would skip the retry of the very case this exists for (measured
 # in #1503 — that failure happened here, with the file already present). It does
-# NOT cover a resolution that is stale rather than absent (a `Package.resolved`
-# bump, a moved revision): identities are present then, the pre-flight stays
-# quiet, and the build fails as it does today — widen it only with a case that
+# NOT cover a resolution that is stale or PARTIAL rather than absent (a
+# `Package.resolved` bump, a moved revision, or 2 of this tree's 3 dependencies
+# resolving): an identity is present in all of those, the pre-flight stays quiet,
+# and the build fails as it does today — widen it only with a case that
 # reproduces. Cost: a grep over one small file on a warm tree; ~23 s once on a
 # cold one, which the build was going to spend on resolution anyway.
+#
+# Rot direction, should Apple stop emitting `"identity"`: every invocation
+# resolves. That is the loud failure (~23 s per TDD cycle, and the stderr line
+# below prints every time) rather than the silent one, which is the right way
+# round. Its only CI consumer is `.github/workflows/codeql.yml`, which is
+# cron-only — so a regression here surfaces on an unwatched nightly, not on a PR.
 _spm_state="$DERIVED_DATA/SourcePackages/workspace-state.json"
 _spm_resolved=""
 if [[ -f "$_spm_state" ]]; then

--- a/scripts/xcodebuild.sh
+++ b/scripts/xcodebuild.sh
@@ -250,8 +250,9 @@ if [[ -f "$_spm_state" ]]; then
   # `|| [ $? -eq 1 ]` because errexit is in force: grep's exit 1 is the "no
   # identities, resolve now" answer, not a failure. It stays narrower than
   # `|| true` so a real grep error (exit >= 2) still aborts rather than being
-  # read as "unresolved". No pipeline here, so the SIGPIPE hazard that governs
-  # the `env | grep` capture below does NOT apply — don't generalize this one.
+  # read as "unresolved". No pipeline here, so the SIGPIPE hazard behind the
+  # `_integration_vars` capture (the `env | grep` one, earlier in this file) does
+  # NOT apply — don't generalize this site into a rule about pipefail.
   _spm_resolved="$({ grep '"identity"' "$_spm_state" || [ $? -eq 1 ]; })"
 fi
 if [[ -z "$_spm_resolved" ]]; then

--- a/scripts/xcodebuild.sh
+++ b/scripts/xcodebuild.sh
@@ -139,17 +139,17 @@ set -- ${forwarded[@]+"${forwarded[@]}"}
 # this point `test` sources sim-dest.sh, whose gate polls up to 900 s, so a
 # rejection placed later costs a quarter-hour before printing one line.
 #
-# Per flag, because xcodebuild's own handling differs. `-scheme` / `-project` /
-# `-derivedDataPath`: it rejects these too, but between the xtrace and a full
-# usage page, which reads like a wrapper bug.
+# Arms are per-flag because xcodebuild's own handling differs. It rejects a
+# repeated `-scheme` / `-project` / `-derivedDataPath` itself, but between the
+# xtrace and a full usage page, which reads like a wrapper bug.
 #
 # The `=`-joined form is the one worth a guard: xcodebuild takes it, exits 0, and
-# DROPS the flag. Measured on Xcode 26.6 — `-showBuildSettings … -derivedDataPath=/tmp/x`
-# reports `BUILD_DIR = ~/Library/Developer/Xcode/DerivedData/…` while the
-# space-separated control reports `/tmp/x/Build/Products`. Here the wrapper
-# supplies its own value anyway, so a caller's `=` copy is merely inert — the
-# relocation hazard is the one the wrapper's own space-separated flag already
-# avoids. `-destination=` is where inert turns dangerous; see its arm below.
+# DROPS the flag. Measured on Xcode 26.6 for `-derivedDataPath=` alone and pinned
+# by no test here, so re-run the pair on a new Xcode rather than trusting this:
+# `-showBuildSettings … -derivedDataPath=/tmp/x` reports BUILD_DIR under
+# ~/Library/…/DerivedData, the space-separated control /tmp/x/Build/Products.
+# For the three above the drop is merely inert — the wrapper supplies its own
+# value anyway; `-destination=` is where inert turns dangerous, see its arm below.
 #
 # A second bare `-destination` is ADDITIVE, so `test` would run on both devices
 # with either failure aborting; `build` keeps accepting the space form for the
@@ -236,22 +236,21 @@ fi
 
 # Resolve SPM dependencies up front when this DerivedData has none. A fresh
 # worktree gets an empty Pastura/DerivedData/, and the first xcodebuild there
-# dies at package resolution ("Could not resolve package dependencies: Couldn't
-# check out revision …") — which the pre-commit hook then reports as
+# dies at package resolution — which the pre-commit hook then reports as
 # `Build failed. Fix compile errors before committing.`, sending the reader
 # after a compile error that does not exist.
 #
 # The predicate is "nothing was ever resolved into this DerivedData", not "the
-# state file is missing": a FAILED resolve still writes workspace-state.json,
-# with empty `artifacts`/`dependencies` and no `"identity"` anywhere, so keying
-# on existence would skip the retry of the very case this exists for (measured
-# in #1503 — that failure happened here, with the file already present). It does
-# NOT cover a resolution that is stale or PARTIAL rather than absent (a
-# `Package.resolved` bump, a moved revision, or 2 of this tree's 3 dependencies
-# resolving): an identity is present in all of those, the pre-flight stays quiet,
-# and the build fails as it does today — widen it only with a case that
-# reproduces. Cost: a grep over one small file on a warm tree; ~23 s once on a
-# cold one, which the build was going to spend on resolution anyway.
+# state file is missing": a FAILED resolve still writes workspace-state.json with
+# no `"identity"` anywhere, so keying on existence would skip the retry of the
+# very case this exists for (measured in #1503 — that failure happened here, with
+# the file already present). It does NOT cover a resolution that is stale or
+# PARTIAL rather than absent (a `Package.resolved` bump, a moved revision, some
+# but not all of this tree's dependencies resolving): an identity is present in
+# all of those, the pre-flight stays quiet, and the build fails as it does today
+# — widen it only with a case that reproduces. Cost: a grep over one small file
+# on a warm tree; ~23 s once on a cold one, which the build was going to spend on
+# resolution anyway.
 #
 # Rot direction, should Apple stop emitting `"identity"`: every invocation
 # resolves. That is the loud failure (~23 s per TDD cycle, and the stderr line

--- a/scripts/xcodebuild.sh
+++ b/scripts/xcodebuild.sh
@@ -178,6 +178,28 @@ done
 case "$cmd" in
   test)
     extra_flags=(-parallel-testing-enabled NO)
+    # Integration suites (Ollama, llama.cpp) gate on an env var read by the TEST
+    # RUNNER, and a runner is a separate process that does NOT inherit what was
+    # exported here — the suite skips while xcodebuild still prints
+    # `** TEST SUCCEEDED **`. Nothing else says so, hence this line. The scheme's
+    # LaunchAction > EnvironmentVariables is the surface that works.
+    #
+    # ADVISORY, not a gate: `|| [ $? -eq 1 ]` keeps grep's no-match (exit 1,
+    # the common case) from aborting under errexit while still letting a real
+    # grep error (exit >= 2) abort. A gate would want the opposite — a broken
+    # pattern there must never read as "nothing found". Capture, never
+    # `grep -q`: an early-exiting reader under `pipefail` turns a match into a
+    # failure. `env` lists exported variables only, which is exactly the set
+    # that could have been meant for the runner.
+    _integration_vars="$(env | { grep -E '^[A-Za-z_][A-Za-z0-9_]*_INTEGRATION=' || [ $? -eq 1 ]; })"
+    if [[ -n "$_integration_vars" ]]; then
+      {
+        echo "warning: *_INTEGRATION set in this shell, but CLI env vars do NOT reach the"
+        echo "  test runner — the suite will skip and still report TEST SUCCEEDED."
+        printf '%s\n' "$_integration_vars" | sed 's/^/    /'
+        echo "  Enable it in the scheme instead (LaunchAction > EnvironmentVariables)."
+      } >&2
+    fi
     ;;
   build)
     extra_flags=()

--- a/scripts/xcodebuild.sh
+++ b/scripts/xcodebuild.sh
@@ -18,14 +18,14 @@
 # Caller passthrough / flag override:
 #
 # Subcommand maps directly to xcodebuild's; remaining args forward
-# verbatim via "$@". xcodebuild honors the last value for many repeated
-# single-value flags, so caller passthrough wins on duplicates (e.g.
-# override the destination: `... test -destination 'platform=iOS Simulator,name=...'`).
-# Note: `-scheme`, `-project`, and `-derivedDataPath` are exceptions —
-# xcodebuild rejects duplicates with `error: option 'X' may only be
-# provided once`. Re-pass only `-destination` from the wrapper-supplied
-# set; see `.claude/rules/xcodebuild-cli.md` §"Re-passing wrapper-supplied
-# flags" for the full table.
+# verbatim via "$@". The wrapper supplies `-scheme`, `-project`,
+# `-derivedDataPath` and `-destination` itself, and re-passing any of them is
+# now REJECTED up front rather than documented — see the guard above
+# `case "$cmd"`, which carries the reason per flag. The one exception is
+# `-destination` on `build`, still accepted so the device compile-check recipe
+# works: `scripts/xcodebuild.sh build -destination 'generic/platform=iOS'
+# CODE_SIGNING_ALLOWED=NO`. To pin a single simulator for `test`, export
+# PASTURA_SIM_NAME.
 #
 # Mode-specific behavior:
 #
@@ -134,6 +134,46 @@ done
 # expansion mirrors `extra_flags` below — bare `"${arr[@]}"` would trip
 # `set -u` on macOS bash 3.2 when forwarded[] is empty.
 set -- ${forwarded[@]+"${forwarded[@]}"}
+
+# Reject flags the wrapper already supplies, BEFORE anything slow runs. Position
+# is load-bearing: below this point `test` sources sim-dest.sh, whose
+# concurrent-session gate polls for up to 900 s, so a rejection placed after it
+# would make the operator wait a quarter of an hour for a one-line message.
+#
+# `-scheme` / `-project` / `-derivedDataPath` — xcodebuild rejects duplicates
+# itself, but with `error: option '-X' may only be provided once` buried above a
+# 64-line usage page, which reads like a wrapper bug. Say it in one line instead.
+#
+# `-derivedDataPath=…` — the `=`-joined form is SILENTLY IGNORED (Xcode 15.4+),
+# so the build lands in the default ~/Library DerivedData while looking correct.
+# Rejecting it is the only way it is ever noticed. Checked for all three flags
+# since none of them accepts `=` here.
+#
+# `-destination` on `test` — multiple `-destination` are ADDITIVE, not
+# last-wins: the suite runs on the wrapper's simulator AND yours, and a failure
+# on either aborts the run. `build` must keep accepting it — the device
+# compile-check recipe below passes `generic/platform=iOS` on purpose.
+for _arg in "$@"; do
+  case "$_arg" in
+    -scheme|-project|-derivedDataPath)
+      echo "$_arg is supplied by this wrapper — drop it (xcodebuild accepts it only once)." >&2
+      exit 2
+      ;;
+    -scheme=*|-project=*|-derivedDataPath=*)
+      echo "${_arg%%=*} takes a SPACE-separated value; the \`=\` form is silently ignored." >&2
+      echo "  It is also supplied by this wrapper already — drop the flag." >&2
+      exit 2
+      ;;
+    -destination|-destination=*)
+      if [[ "$cmd" == "test" ]]; then
+        echo "-destination is additive for \`test\`: xcodebuild would run the suite on the" >&2
+        echo "  wrapper's simulator AND yours, and a failure on either aborts the run." >&2
+        echo "  To pin ONE simulator:  export PASTURA_SIM_NAME=\"iPhone 17 Pro Max\"" >&2
+        exit 2
+      fi
+      ;;
+  esac
+done
 
 case "$cmd" in
   test)

--- a/scripts/xcodebuild.sh
+++ b/scripts/xcodebuild.sh
@@ -135,25 +135,18 @@ done
 # `set -u` on macOS bash 3.2 when forwarded[] is empty.
 set -- ${forwarded[@]+"${forwarded[@]}"}
 
-# Reject flags the wrapper already supplies, BEFORE anything slow runs. Position
-# is load-bearing: below this point `test` sources sim-dest.sh, whose
-# concurrent-session gate polls for up to 900 s, so a rejection placed after it
-# would make the operator wait a quarter of an hour for a one-line message.
+# Reject flags the wrapper already supplies, BEFORE anything slow runs: below
+# this point `test` sources sim-dest.sh, whose gate polls up to 900 s, so a
+# rejection placed later costs a quarter-hour before printing one line.
 #
-# `-scheme` / `-project` / `-derivedDataPath` — xcodebuild rejects duplicates
-# itself, but with `error: option '-X' may only be provided once` buried between
-# the wrapper's xtrace and its own full usage page, which reads like a wrapper
-# bug. Say it in one line instead.
-#
-# `-derivedDataPath=…` — the `=`-joined form is SILENTLY IGNORED (Xcode 15.4+),
-# so the build lands in the default ~/Library DerivedData while looking correct.
-# Rejecting it is the only way it is ever noticed. Checked for all three flags
-# since none of them accepts `=` here.
-#
-# `-destination` on `test` — multiple `-destination` are ADDITIVE, not
-# last-wins: the suite runs on the wrapper's simulator AND yours, and a failure
-# on either aborts the run. `build` must keep accepting it — the device
-# compile-check recipe below passes `generic/platform=iOS` on purpose.
+# Per flag, because xcodebuild's own handling differs. `-scheme` / `-project` /
+# `-derivedDataPath`: it rejects these too, but between the xtrace and a full
+# usage page, which reads like a wrapper bug. The `=`-joined form: SILENTLY
+# IGNORED (Xcode 15.4+), landing the build in ~/Library while looking correct —
+# checked for all three, since none of them takes `=` here. A second
+# `-destination`: ADDITIVE, so `test` would run on both devices with either
+# failure aborting; `build` must keep accepting it for the device compile-check
+# recipe below.
 for _arg in "$@"; do
   case "$_arg" in
     -scheme|-project|-derivedDataPath)
@@ -230,20 +223,16 @@ fi
 # `Build failed. Fix compile errors before committing.`, sending the reader
 # after a compile error that does not exist.
 #
-# The predicate is "no dependency was ever resolved into this DerivedData", not
-# "the state file is missing": a FAILED resolve still writes
-# workspace-state.json, with empty `artifacts`/`dependencies` arrays and no
-# `"identity"` key anywhere, so keying on the file's existence would skip the
-# retry of the exact case this exists for (measured while writing #1503 — the
-# failure above happened in this worktree, and the file was already there).
-#
-# What it does NOT cover: a resolution that is stale rather than absent (a
-# `Package.resolved` bump, a revision that moved). Identities are present then,
-# so the pre-flight stays out of the way and the build fails as it does today.
-# Widen the predicate only with a case that reproduces.
-#
-# Cost: nothing on a warm tree (predicate is a grep over one small file); ~23 s
-# once on a cold one, which the build was going to spend on resolution anyway.
+# The predicate is "nothing was ever resolved into this DerivedData", not "the
+# state file is missing": a FAILED resolve still writes workspace-state.json,
+# with empty `artifacts`/`dependencies` and no `"identity"` anywhere, so keying
+# on existence would skip the retry of the very case this exists for (measured
+# in #1503 — that failure happened here, with the file already present). It does
+# NOT cover a resolution that is stale rather than absent (a `Package.resolved`
+# bump, a moved revision): identities are present then, the pre-flight stays
+# quiet, and the build fails as it does today — widen it only with a case that
+# reproduces. Cost: a grep over one small file on a warm tree; ~23 s once on a
+# cold one, which the build was going to spend on resolution anyway.
 _spm_state="$DERIVED_DATA/SourcePackages/workspace-state.json"
 _spm_resolved=""
 if [[ -f "$_spm_state" ]]; then

--- a/scripts/xcodebuild.sh
+++ b/scripts/xcodebuild.sh
@@ -160,6 +160,54 @@ else
   destination="$DEST"
 fi
 
+# Resolve SPM dependencies up front when this DerivedData has none. A fresh
+# worktree gets an empty Pastura/DerivedData/, and the first xcodebuild there
+# dies at package resolution ("Could not resolve package dependencies: Couldn't
+# check out revision …") — which the pre-commit hook then reports as
+# `Build failed. Fix compile errors before committing.`, sending the reader
+# after a compile error that does not exist.
+#
+# The predicate is "no dependency was ever resolved into this DerivedData", not
+# "the state file is missing": a FAILED resolve still writes
+# workspace-state.json, with empty `artifacts`/`dependencies` arrays and no
+# `"identity"` key anywhere, so keying on the file's existence would skip the
+# retry of the exact case this exists for (measured while writing #1503 — the
+# failure above happened in this worktree, and the file was already there).
+#
+# What it does NOT cover: a resolution that is stale rather than absent (a
+# `Package.resolved` bump, a revision that moved). Identities are present then,
+# so the pre-flight stays out of the way and the build fails as it does today.
+# Widen the predicate only with a case that reproduces.
+#
+# Cost: nothing on a warm tree (predicate is a grep over one small file); ~23 s
+# once on a cold one, which the build was going to spend on resolution anyway.
+_spm_state="$DERIVED_DATA/SourcePackages/workspace-state.json"
+_spm_resolved=""
+if [[ -f "$_spm_state" ]]; then
+  # Capture rather than `grep -q`: an early-exiting reader under `pipefail`
+  # turns a match into a failure. `|| [ $? -eq 1 ]` keeps a real grep error
+  # (exit >= 2) distinguishable from "no match", which `|| true` would flatten.
+  _spm_resolved="$({ grep '"identity"' "$_spm_state" || [ $? -eq 1 ]; })"
+fi
+if [[ -z "$_spm_resolved" ]]; then
+  echo "pre-flight: no resolved SPM packages in $DERIVED_DATA — resolving first." >&2
+  # Explicit `if !` rather than a bare call: errexit is in force here, and a
+  # resolve failure must stay advisory. Letting the build run anyway keeps this
+  # from adding a failure path of its own — and the build's own error is what
+  # the operator needs to see, now with the real cause named above it.
+  if ! xcodebuild -resolvePackageDependencies \
+      -project "$REPO_ROOT/Pastura/Pastura.xcodeproj" \
+      -scheme Pastura \
+      -derivedDataPath "$DERIVED_DATA" \
+      -quiet; then
+    {
+      echo "warning: -resolvePackageDependencies failed."
+      echo "  If the build below dies at 'Could not resolve package dependencies',"
+      echo "  that is a DEPENDENCY RESOLUTION failure, not a compile error."
+    } >&2
+  fi
+fi
+
 # Auto-sync Localizable.xcstrings before xcodebuild runs. Xcode IDE's
 # Build action extracts `String(localized:)` keys into the catalog
 # automatically; `xcodebuild build` from CLI does not (Apple has no

--- a/scripts/xcodebuild.sh
+++ b/scripts/xcodebuild.sh
@@ -141,8 +141,9 @@ set -- ${forwarded[@]+"${forwarded[@]}"}
 # would make the operator wait a quarter of an hour for a one-line message.
 #
 # `-scheme` / `-project` / `-derivedDataPath` — xcodebuild rejects duplicates
-# itself, but with `error: option '-X' may only be provided once` buried above a
-# 64-line usage page, which reads like a wrapper bug. Say it in one line instead.
+# itself, but with `error: option '-X' may only be provided once` buried between
+# the wrapper's xtrace and its own full usage page, which reads like a wrapper
+# bug. Say it in one line instead.
 #
 # `-derivedDataPath=…` — the `=`-joined form is SILENTLY IGNORED (Xcode 15.4+),
 # so the build lands in the default ~/Library DerivedData while looking correct.
@@ -246,9 +247,11 @@ fi
 _spm_state="$DERIVED_DATA/SourcePackages/workspace-state.json"
 _spm_resolved=""
 if [[ -f "$_spm_state" ]]; then
-  # Capture rather than `grep -q`: an early-exiting reader under `pipefail`
-  # turns a match into a failure. `|| [ $? -eq 1 ]` keeps a real grep error
-  # (exit >= 2) distinguishable from "no match", which `|| true` would flatten.
+  # `|| [ $? -eq 1 ]` because errexit is in force: grep's exit 1 is the "no
+  # identities, resolve now" answer, not a failure. It stays narrower than
+  # `|| true` so a real grep error (exit >= 2) still aborts rather than being
+  # read as "unresolved". No pipeline here, so the SIGPIPE hazard that governs
+  # the `env | grep` capture below does NOT apply — don't generalize this one.
   _spm_resolved="$({ grep '"identity"' "$_spm_state" || [ $? -eq 1 ]; })"
 fi
 if [[ -z "$_spm_resolved" ]]; then


### PR DESCRIPTION
## Summary

`.claude/rules/xcodebuild-cli.md` は always-loaded で、全行が毎ターン課金される。そこに散文でしか存在しなかったノウハウのうち4件を、`scripts/xcodebuild.sh` と CI 配線済みの回帰テストに移した。

調査の途中で、`set -e` の節が特定できていなかった**根本原因**が判明した。`scripts/sim-dest.sh` はシェルオプションを `_simdest_old_opts=$(set +o)` で採取していたが、これはコマンド置換のサブシェル内で走り、bash はそこで errexit を既に落としている。つまりスナップショットは caller の実際の状態に関わらず常に `set +o errexit` を記録しており、**復元が忠実だったのに採取が壊れていた**。pipefail は `$-` の文字フラグではないので同じスナップショットから正しく戻る — 「errexit だけ失われて pipefail は残る」という非対称はこれで説明がつく。

/bin/bash 3.2.57 での実測:

| caller | source 後（修正前 → 修正後） |
|---|---|
| errexit ON | **OFF** → **ON** |
| errexit OFF | OFF → OFF（誤って有効化しない） |
| sim-dest 失敗パス | そのまま継続 → **素の `source` でも caller が中断** |

影響は7サイト。うち `ci.yml` の2つの `run:` ステップは `bash -e {0}` で pipefail が無いため errexit が唯一の防御であり、これまでは失敗した source を飲み込んで空の `DEST=` を `$GITHUB_ENV` に書いていた。

### 変更内容

1. **`sim-dest.sh` の errexit 採取を修正** + 6アームの回帰テスト（`scripts/tests/simdest-errexit-test.sh`、`*-test.sh` 命名で shell-tests に自動配線）。実物を source するアームと、修正前の採取形を再現する**テスト内の陰性対照**の両方を持つ。
2. **4サイトの why コメントを訂正** — 機構の記述が誤りだったため。`||` ハンドラと再宣言は残すが、役割が「abort 機構」から「メッセージ」「二重防御」に変わったことを書く。
3. **SPM 解決の pre-flight** — フレッシュ worktree の初回ビルドが解決で死に、pre-commit フックがそれを `Build failed. Fix compile errors before committing.` と報告する件を wrapper が自動修復する。このPRの作業中に実際に踏んだ。
4. **供給済みフラグの再渡しを一行で拒否** — `-derivedDataPath=` の黙殺、`test` への追加 `-destination` の additive 挙動を含む。挿入位置は同時実行ゲートの**手前**（後ろだと拒否まで最大900秒待たされる）。
5. **`*_INTEGRATION` の空振り警告** — CLI env var はテストランナーに届かず、スイートは黙ってスキップしたまま `TEST SUCCEEDED` が出る。
6. **ルール記述の圧縮と訂正**。

### 見積り未達の記録

事前見積りは `-3〜4KB` だったが、最終実測は **13,490 → 14,189 バイト（+699）**。表と手順の圧縮で取れた分を、(a) 誤りだった節の訂正（set-e の機構は**2度**訂正した — 下記）、(b) レビューで判明して追記した実測事実（`build` の `-destination` も additive、`ci.yml` の2ステップへの波及、`||` 形の例外）が上回った。数値に合わせるための追加削除はしていない。

見積りが外れた原因は方法にある。「冗長に見える量」から見積もったが、実際に削れるのは「他所に実在する量」であり、圧縮対象の4節のうち2節は冗長なのではなく**誤っていた** — 誤りの訂正は縮まない。

## レビューが出した実欠陥

`code-reviewer` (Opus) 3周は規約面 PASS。その後の `/risk-review` が、規約ゲートには原理的に見えない軸で**実欠陥3件**を出した。

1. **`-destination=` が `build` で素通りしていた** — このPRが追加したガード自身が、それが防ぐはずの偽グリーンを再生産していた。実測: `=` 形は rc=0 で黙殺される（`-derivedDataPath=/tmp/x` → `BUILD_DIR = ~/Library/…`、スペース形の対照 → `/tmp/x/Build/Products`）。デバイス compile-check レシピを `=` で打つと、デバイススライスを落としたまま `BUILD SUCCEEDED` が出る。
2. **「`||` ハンドラは今や二重防御」が3サイトで偽** — bash は `||` の左オペランドに対して errexit を抑止するので、`source … || { …; exit 1; }` と書かれた3サイトでは今も `exit 1` が唯一の中断機構。コメントは逆を書き、「メッセージだけに削ってよい」を含意していた。
3. **機構の説明が反証された** — 「pipefail は `$-` の文字フラグでないから戻る」は誤り。`nounset` は文字フラグだが正しく往復する（`$-` は substitution 外 `ehuBc` → 内 `huBc`）。正しくは「bash は errexit **だけ**をコマンド置換内でクリアする」。3ファイルに波及していた。

2 と 3 はテストアーム A8 / A7 で固定した（A3/A4 が効果の対照、A7 が原因の対照）。

### `Compile-checking device-only` 節の訂正

「compile error がそのまま出荷される」は CI については古い記述だった。`ci.yml` の `release-build` が `-sdk iphoneos` でビルドしているので、**Release 構成では** CI が捕捉している。逆に、同じ節が残すローカルレシピは wrapper が `-configuration` を渡さないため **Debug** の実機ビルドで、`#if DEBUG` + device-only ブロック（CI が届かない範囲）を実際にコンパイルする。その組み合わせのブロックが今日存在しないことは、tracked な app Swift 全ファイルの `#if` ネストを数えて確認した（5サイト、`#if DEBUG` 内包ゼロ）。

## Test plan

- `scripts/tests/simdest-errexit-test.sh` — 8アーム全通過。**発火することも確認**: 修正を戻すと A1（ubuntu でも走る）と A5 が落ち、`A5_ERREXIT_OFF` / `A5_PIPEFAIL_ON` と上記の非対称をそのまま報告する。no-op 復元・`unset` 削除の各変異でも該当アームが発火。
- `for t in scripts/tests/*-test.sh` — 23件全通過。
- `scripts/xcodebuild.sh test -skip-testing:PasturaUITests` — 286スイート 3496テスト通過。
- フラグガードのスモーク4形: `build -quiet`（pre-commit の実物形）/ `build -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO` / `test -only-testing … --tail 12` はいずれも成功、`test -destination …` と `build -derivedDataPath=…` は rc=2。
- SPM pre-flight 両極性: 解決済みでない状態 → 発火して解決しビルド成功 / 解決済み → 非発火。
- `*_INTEGRATION` 両極性: 未設定 → 警告なし・中断なし / 設定時 → 変数名込みで警告、実行継続。

- フラグガードのスモーク: `build -destination='generic/platform=iOS'` は rc=2、スペース形は BUILD SUCCEEDED。
- `/simplify-doc` 後も全ゲート再実行済み。

## 積み残し（フォローアップ）

- `scripts/xcodebuild.sh` のガード発火パスを CI で固定するテストが無い。pre-commit フックが通すのは成功パス（`build -quiet`）だけで、拒否パスも pre-flight パスも走らない。手動スモークはしているが、ガードの発火パスは成功パスでは測れない。
- `sim-dest.sh` の4つの復元経路のうち2つ（`git rev-parse` ガード、900秒の wait ゲート）がテスト未到達。前者は安価に足せる。

Context-economy (コメント剪定パス): kept 9 paragraphs, compressed 3 — 母集団8ファイル・ブロック12件を分類し、~10行を超えた3ブロックのみ圧縮（フラグガード 20→12、SPM pre-flight 18→10、テストヘッダ 37→28）。Keep のうち3件は半分長にすると前向きの事実が落ちるため据え置き、理由をコミットに記録。

## 追加スコープ: `xcodebuild-cli.md` の always-loaded 圧縮

このブランチが always-loaded 総計を天井超え（96,182 / 天井 95,500）に押し上げたので、同じ PR で回収する。

**14,202 → 9,088 バイト（−36%）。always-loaded 総計 96,182 → 91,068（−5,114）。**

判定の原則は「他所が既に持っているものを二重払いしない」。削除の根拠は (b) 道具が実行時に理由付きで教える、(c) `docs/ci/xcodebuild-flakes.md` / スクリプトヘッダ / path-scoped rule に既在、のいずれか。(b) は**実行して確かめた**（下の Test plan）。

| 節 | 操作 |
|---|---|
| Canonical invocation | 圧縮。allowlist を素通しする4形は**逐語で維持**（承認プロンプトは無人ランを殺すので、道具が実行時に教えられない唯一のクラス） |
| When to use what / --tail / Wrapper behavior / SPM | 圧縮。`--tail` の pipefail 主張と `xcresulttool` フォールバックは維持（無人経路の無音失敗ハザード） |
| Concurrent-session gate | 圧縮。errexit 小節を `ci-workflows.md` § Rule 4 へ移設（規則が効くのはシェルスクリプトを**書くとき**なので `scripts/**` の Read で足りる） |
| Agent guardrails / CI flake catalog | 判断行＋ポインタに圧縮。Prevention の timeout 指針は逐語で維持（Bash 呼び出しの**前**にしか効かない） |
| "Executed 0 tests" | `testing.md` へ移設。always-loaded 側は § --tail に「`TEST SUCCEEDED` が空虚になる3ケース」1行を残す |
| device-only コンパイル確認 | `swiftui-traps.md` へ移設（同 § Scope の規定に従う）。`xcodebuild-cli` 側は表の1行 |
| harness `swift build` | **移設せず**現地圧縮。`Package.swift` と ADR-013/021/022/023 の5箇所が名指しで、ADR-022 は見出し文字列を引用 |

**天井のラチェット**: フック自身のコメントが「天井を下回った削減キャンペーンは自分の PR で再ベースラインしろ」と義務づけ、基準（1.5KB のヘッドルーム）と「最終コミットで測れ」も記録している。95,500 → **92,600**（91,068 + 1,532）。3つ目のコピー（テストハーネスの `run_hook` デフォルト）も同時更新。

### レビューで撤回した主張

`code-reviewer` と `/risk-review` 3クラスタが互いに素な欠陥を出した。

- **自己矛盾（3層とも独立に検出）**: 圧縮した文が「ラッパーは `-destination` の再渡しを拒否する」と書いたが、arm は `cmd == test` 条件付きで、`build` は device compile-check レシピのために意図的に通す。同じファイルの13行下でそのレシピを打てと指示していた。前セッションの陽性対照 `build -only-testing Foo` はどの arm にも当たらず構造的に検出不能だった → 文書が処方する当のコマンドで取り直し
- **列挙の誤り**: `ModelSettingsRow.swift` に `#if` は0件。元の `e.g.`（例示）を `today:`（列挙）に格上げして中身が間違っていた。同じ誤りが `orchestrate/SKILL.md` にもあったので掃引
- **置き場所の再判断**: device-only 節の宛先を `build-traps.md` → `swiftui-traps.md` に変更。`Pastura/Pastura/**/*.swift` はトップレベルの `PasturaApp.swift` に当たらず「上位集合」が偽だった
- **掃引漏れ**: errexit ポインタは4サイトあり3件しか付け替えていなかった（`scripts/ui-tour.sh`）。critic の挙げた3件をそのまま母集団にしたため

### Test plan（追加スコープ）

いずれも陰性対照つき。

- `*_INTEGRATION` 警告: 未 export → 無音 / `OLLAMA_INTEGRATION=1` → scheme を名指しした4行の警告
- 並走ゲート: argv 一致のデコイを立てると `Another xcodebuild test detected (pids: N); waiting up to 900s. Set PASTURA_SKIP_SIM_WAIT=1 to bypass.`（900秒タイムアウト側の4行は**未実測** — ソースを読んだだけ）
- SPM pre-flight: `workspace-state.json` を退避 → `pre-flight: no resolved SPM packages … — resolving first.` → GRDB/Yams/llama.swift を解決。※1回目の probe は壊れていた（`dependencies` を空にしても `"identity"` が別箇所に残り「発火せず」という偽陰性を返した）
- `build -destination`: `scripts/xcodebuild.sh build -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO` → `** BUILD SUCCEEDED **`, rc=0
- 天井: デフォルト 92,600 のまま → 不発 / `PASTURA_FOOTPRINT_CEILING=91000` → 発火し、フック自身が **91068 バイト**と報告（手計測と一致）。`scripts/tests/check-claude-md-modified-test.sh` 全ケース緑
- 被引用の掃引: `git grep -nI 'xcodebuild-cli' -- .` 全件と、削除した見出し6本の残存ゼロを確認

Context-economy (always-loaded 圧縮): kept 4 sections, compressed 7, relocated 3 — 11節を `context-budget.md` の分類器にかけ、Keep 4（`--tail` 全体 / Prevention の timeout 指針 / allowlist 素通し4形 / xcstrings 変異＋DerivedData）。**見積り未達を明示**: 起草時の目標は約6KB / 総計約88KB、着地は 9,088B / 91,068B。数値合わせの追加削りはしていない。

## Device QA

実機QA不要 — シェルスクリプトと Markdown のみで、Swift の変更はゼロ。

Closes #1503

