### PR TITLE
✨ feat: highlight の phase_index を branch-aware に（conditional シナリオ解禁）

### DIFF
--- a/.claude/skills/scenario-refine/SKILL.md
+++ b/.claude/skills/scenario-refine/SKILL.md
@@ -219,7 +219,12 @@ this, so a proposal that ignores it wastes the curator's time): `agent_output`
 events whose `phase_type` is `speak_all` / `speak_each`, `statement` field
 only, `round` within 1..⌈rounds/2⌉, with no outcome-class phase
 (`vote` / `eliminate` / `score_calc` / `choose` / `summarize`) earlier in that
-same round. Draw only from the **final** attempt — a retried run appends
+same round. On a `conditional`-bearing scenario "that same round" is the
+**branch that ran** (the transcript's `conditional_evaluated` says which), not
+the flattened phase list; a pick after a conditional is judged against both
+branches. Proposing against the flat list there under-counts eligible lines —
+which is the whole reason such scenarios were unexcerptable until #1473. Draw
+only from the **final** attempt — a retried run appends
 attempt 2 to the same JSONL and restarts round numbering. Never propose a later
 round: reaching one needs an audited `window_override`, a curator's call.
 

--- a/Pastura/Pastura/Models/GalleryHighlight.swift
+++ b/Pastura/Pastura/Models/GalleryHighlight.swift
@@ -151,9 +151,15 @@ nonisolated public struct GalleryHighlightExcerptEntry: Codable, Equatable, Send
   /// reason as ``GalleryScenario/phases``.
   public let phase: String
 
-  /// Index of this phase within its round's phase list — the value the
-  /// repo-side gate checks against the entry's `phases` list to enforce
-  /// the within-round spoiler bound.
+  /// Index into the entry's **flattened** `phases` list (`gallery.json` order,
+  /// ADR-020 D2a) — the value the repo-side gate checks to enforce the
+  /// within-round spoiler bound.
+  ///
+  /// Not a position within the round as executed: for a `conditional` scenario
+  /// that list spans BOTH branches, so an utterance in the else branch can be
+  /// index 5 of a nine-entry list while the round ran five phases. The gate
+  /// resolves it back through the scenario's phase tree (#1473). Read that
+  /// before wiring the first rendering consumer — there is none today.
   public let phaseIndex: Int
 
   /// Index of ``agent`` in the scenario's `personas:` list — the value a real

--- a/docs/decisions/ADR-029.md
+++ b/docs/decisions/ADR-029.md
@@ -167,8 +167,8 @@ turn selection into a schema-valid highlight file. Non-negotiable properties:
   extraction — then phase eligibility and the within-round bound
   checked via `phase_index`, against the scenario's phase **tree** where the
   entry has one and its flattened `phases` otherwise — the index must name an
-  eligible phase with no outcome-class phase before it *in its own branch*, nor
-  in either branch of a conditional preceding it, and
+  eligible phase with no outcome-class phase before it *in its own branch*, at
+  top level before it, or in either branch of a conditional preceding it, and
   the round window recomputed from `gallery.json`'s `rounds` honoring
   `window_override`), the entry's denormalized `phases` **re-derived from the
   sibling YAML** and required to match (nothing else on a highlight PR's path

--- a/docs/decisions/ADR-029.md
+++ b/docs/decisions/ADR-029.md
@@ -165,13 +165,14 @@ turn selection into a schema-valid highlight file. Non-negotiable properties:
   mechanics of Decision 3 (its own copy of the ADR-022 tripwire above — an
   `excerpt[].phase` outside the `PhaseType` catalog fails here too, not only at
   extraction — then phase eligibility and the within-round bound
-  checked via `phase_index` against the entry's `phases` list — the index
-  must name an eligible phase with no outcome-class phase before it, and a
-  scenario whose `phases` contains `conditional` is refused as a class, that
-  list flattening both branches in while `phase_path` does not, which leaves
-  `phase_index` underivable until #1473 lands — and
+  checked via `phase_index`, against the scenario's phase **tree** where the
+  entry has one and its flattened `phases` otherwise — the index must name an
+  eligible phase with no outcome-class phase before it *in its own branch*, and
   the round window recomputed from `gallery.json`'s `rounds` honoring
-  `window_override`), `excerpt[].persona_index` cross-checked against the
+  `window_override`), the entry's denormalized `phases` **re-derived from the
+  sibling YAML** and required to match (nothing else on a highlight PR's path
+  re-derives it, and every `phase_index` check reads it),
+  `excerpt[].persona_index` cross-checked against the
   sibling YAML's `personas:` list (Decision 1 — the index must name the
   entry's own `agent`, at that agent's *first* declaration), `source.model`
   against `ModelRegistry.swift`'s descriptor ids (Decision 1 — the gate parses
@@ -227,7 +228,18 @@ eliminate, summarize, conditional, event_inject, relationship_update, narrate.
      phase precedes it in that round's phase list. Dialogue *reacting to* an
      in-round outcome is how outcomes leak even when the outcome event itself
      is excluded (`detective_scene_v1`'s post-vote `speak_each` is the live
-     case).
+     case). Under a `conditional` the round's phase list is a **branch**, not
+     the flattened one: an utterance inside a branch is judged against that
+     branch's own preceding phases, which is what makes a conditional scenario
+     excerptable at all (#1473). A pick sitting **after** a conditional is
+     judged against **both** branches unioned — an excerpt records no branch,
+     so not even an honest one can say which ran in the round it came from, and
+     the fail-safe reading is the only one available. What neither rule
+     defends is a `phase_index` that misnames its own position: the gate reads
+     no transcript, so it verifies the claimed coordinate's *consistency*, not
+     its truth (`_check_position`'s docstring has the exposure, which is not
+     conditional-specific). Truth is anchored by the extractor's derivation and
+     Decision 2's human sign-off instead.
   2. **Across rounds**: default window is rounds 1 through ⌈N/2⌉. The
      extractor accepts later-round utterances only behind an explicit
      override flag, which is recorded in the file as

--- a/docs/decisions/ADR-029.md
+++ b/docs/decisions/ADR-029.md
@@ -167,7 +167,8 @@ turn selection into a schema-valid highlight file. Non-negotiable properties:
   extraction — then phase eligibility and the within-round bound
   checked via `phase_index`, against the scenario's phase **tree** where the
   entry has one and its flattened `phases` otherwise — the index must name an
-  eligible phase with no outcome-class phase before it *in its own branch*, and
+  eligible phase with no outcome-class phase before it *in its own branch*, nor
+  in either branch of a conditional preceding it, and
   the round window recomputed from `gallery.json`'s `rounds` honoring
   `window_override`), the entry's denormalized `phases` **re-derived from the
   sibling YAML** and required to match (nothing else on a highlight PR's path

--- a/docs/decisions/ADR-029.md
+++ b/docs/decisions/ADR-029.md
@@ -43,9 +43,11 @@ One JSON file per gallery entry: `docs/gallery/highlights/<id>.json`.
   "excerpt": [ { "agent": "...", "round": 2, "phase": "speak_each",
                  "phase_index": 0, "persona_index": 3,
                  "source_field": "statement", "text": "..." } ],
-  // phase_index = position in the scenario's phases list; it disambiguates
-  // repeated phase names so the gate can check the within-round bound
-  // mechanically (Decision 3), not just the phase's class
+  // phase_index = position in the entry's flattened `phases` list — which for
+  // a `conditional` scenario includes both branches' sub-phases, so it is NOT
+  // the transcript's top-level `phase_path[0]`; it disambiguates repeated phase
+  // names so the gate can check the within-round bound mechanically
+  // (Decision 3), not just the phase's class
   // persona_index = the speaker's position in the scenario's `personas:` list,
   // which is what both consumers resolve the avatar colour slot from
   "yaml_hook": { "kind": "persona", "fragment": "...", "caption": "..." },
@@ -54,6 +56,12 @@ One JSON file per gallery entry: `docs/gallery/highlights/<id>.json`.
   // (§ Amendment 2026-08-08)
   "teaser": "...",                                          // one line, ending withheld
   "window_override": false,                                 // true iff Decision 3's late-round flag was used
+  // schema_version was deliberately NOT bumped for #1473, which changed
+  // `phase_index`'s *semantics* for a conditional entry without adding or
+  // removing a key. The rule above is keyed on keys added; a bump would have
+  // blanked every highlight on the site, since ScenarioLanding.astro rejects
+  // `schema_version !== 1` outright. A future semantics-only change should be
+  // decided here rather than by omission.
   "content_filter_applied": true                            // audit attestation (Decision 2)
 }
 ```
@@ -241,6 +249,22 @@ eliminate, summarize, conditional, event_inject, relationship_update, narrate.
      its truth (`_check_position`'s docstring has the exposure, which is not
      conditional-specific). Truth is anchored by the extractor's derivation and
      Decision 2's human sign-off instead.
+
+     **The union is a schema consequence, not an information limit.** The
+     extractor *does* know which branch ran — it reads `conditional_evaluated`
+     — and discards that when it writes `phase_index`. Recording the branch on
+     the excerpt entry was the cheap alternative and is **rejected for a
+     different reason than #1473's sketch gave**: that sketch cited ripple into
+     ADR-020 D2a's capability gate, `GallerySeedYAMLTests.galleryPhasesMatchYAML`
+     and the Browse art-tile glyph, but all three read `gallery.json`'s `phases`
+     — none reads the highlight file, so an added optional key there is inert on
+     both consumers. The real reason is that a branch recorded in the file is
+     **self-attested**: the gate reads no transcript, so it would extend exactly
+     the unverifiable surface the paragraph above describes, and unlike the
+     union it could be relaxed by a hand-edit. The cost is a designed rejection
+     class — a top-level pick after a fork whose non-taken branch holds an
+     outcome phase. No shipped scenario has that shape; a curator who hits it
+     should read it as intended, not as a bug.
   2. **Across rounds**: default window is rounds 1 through ⌈N/2⌉. The
      extractor accepts later-round utterances only behind an explicit
      override flag, which is recorded in the file as

--- a/docs/decisions/ADR-029.md
+++ b/docs/decisions/ADR-029.md
@@ -251,20 +251,18 @@ eliminate, summarize, conditional, event_inject, relationship_update, narrate.
      Decision 2's human sign-off instead.
 
      **The union is a schema consequence, not an information limit.** The
-     extractor *does* know which branch ran — it reads `conditional_evaluated`
-     — and discards that when it writes `phase_index`. Recording the branch on
-     the excerpt entry was the cheap alternative and is **rejected for a
-     different reason than #1473's sketch gave**: that sketch cited ripple into
-     ADR-020 D2a's capability gate, `GallerySeedYAMLTests.galleryPhasesMatchYAML`
-     and the Browse art-tile glyph, but all three read `gallery.json`'s `phases`
-     — none reads the highlight file, so an added optional key there is inert on
-     both consumers. The real reason is that a branch recorded in the file is
-     **self-attested**: the gate reads no transcript, so it would extend exactly
-     the unverifiable surface the paragraph above describes, and unlike the
-     union it could be relaxed by a hand-edit. The cost is a designed rejection
-     class — a top-level pick after a fork whose non-taken branch holds an
-     outcome phase. No shipped scenario has that shape; a curator who hits it
-     should read it as intended, not as a bug.
+     extractor knows which branch ran — it reads `conditional_evaluated` — and
+     discards that when it writes `phase_index`. Recording the branch in the
+     file is rejected not for the ripple #1473's sketch cited (ADR-020 D2a's
+     gate, `GallerySeedYAMLTests.galleryPhasesMatchYAML` and the Browse
+     art-tile glyph all read `gallery.json`'s `phases`, never the highlight
+     file, so an optional key there reaches none of them) but because it
+     would be **self-attested**: the gate reads no transcript, so it extends
+     the unverifiable surface above and, unlike the union, is relaxable by a
+     hand-edit. The cost is a designed rejection class — a top-level pick after
+     a fork whose non-taken branch holds an outcome phase. No shipped scenario
+     has that shape; a curator who hits it should read it as intended, not as a
+     bug.
   2. **Across rounds**: default window is rounds 1 through ⌈N/2⌉. The
      extractor accepts later-round utterances only behind an explicit
      override flag, which is recorded in the file as

--- a/docs/gallery/README.md
+++ b/docs/gallery/README.md
@@ -381,7 +381,12 @@ covers the workflow and the taste calls the gate cannot make.
 2. **Read the transcript and choose the lines yourself.** Eligible lines are
    `agent_output` events from `speak_all` / `speak_each`, `statement` field,
    in rounds 1 through ⌈rounds/2⌉, with no outcome-class phase earlier in the
-   same round. A retried run appends a second attempt to the same file and
+   same round. Under a `conditional`, "the same round" is the **branch that
+   ran**, not the flattened phase list — read the transcript's
+   `conditional_evaluated` to see which one, and judge a pick against that
+   branch's own earlier phases. A pick *after* a conditional is judged against
+   both branches, since the excerpt records neither (ADR-029 Decision 3).
+   A retried run appends a second attempt to the same file and
    restarts round numbering, so only the final attempt is pickable. A later
    round is reachable, but only by passing `--window-override` at extraction,
    which records `window_override: true` in the file for the reviewer to weigh.

--- a/scripts/gallery_highlight_extract.py
+++ b/scripts/gallery_highlight_extract.py
@@ -37,8 +37,8 @@ Hard-fails (each with a distinct, greppable message):
   - the scenario YAML declares the `secret:` mechanism (ADR-029 Decision 2 —
     the spoiler rules are unvalidated for it);
   - a scenario whose `phases:` tree cannot be flattened — a `conditional`
-    with neither branch, or one nested inside a branch (both refused by
-    `ScenarioValidator` too);
+    with neither branch, one nested inside a branch (both refused by
+    `ScenarioValidator` too), or any other malformed `phases:` shape;
   - a `phase_started` line carrying no usable `phase_path`, one deeper than
     the engine's depth-1 rule allows, or one naming a phase / branch position
     the pinned YAML does not have;
@@ -129,6 +129,15 @@ def annotate(lines, nodes):
 
     Every failure here is fatal rather than a fallback: an invented coordinate
     reads as measured fact to every downstream check.
+
+    A retried run appends a second attempt to the same file and this walks both,
+    including the discarded one that `build_excerpt` rejects wholesale — so a
+    truncated early attempt can abort extraction even though no pick touches it.
+    That is the safe direction. The branch state carried across an attempt
+    boundary is fail-closed for the same reason: attempt 2 opens with a
+    top-level `phase_started`, which clears it, and if that ever stopped holding
+    a branch path would die on the missing `conditional_evaluated` rather than
+    resolve against the previous attempt's verdict.
     """
     by_top = {}
     by_branch = {}
@@ -152,12 +161,12 @@ def annotate(lines, nodes):
             round_no = obj.get("round")
         elif event == "conditional_evaluated":
             if open_conditional is None:
-                die(f"line {lineno} — `conditional_evaluated` with no preceding "
+                die(f"conditional_evaluated — line {lineno} has no preceding "
                     "`phase_started` of type `conditional`, so the branch it "
                     "decides cannot be attributed to a phase")
             result = obj.get("result")
             if not isinstance(result, bool):
-                die(f"line {lineno} — `conditional_evaluated.result` is "
+                die(f"conditional_evaluated — line {lineno} carries result "
                     f"{result!r}, not a boolean; the taken branch cannot be "
                     "derived from it")
             pending_branch = (open_conditional, "then" if result else "else")
@@ -168,11 +177,16 @@ def annotate(lines, nodes):
             # a fallback would assert "top-level phase 0" on the excerpt's
             # behalf, which every downstream check then reads as measured fact.
             if not isinstance(path, list) or not path:
-                die(f"line {lineno} — `phase_started` carries no usable "
-                    "`phase_path`, so phase_index cannot be derived for any pick "
-                    "in this phase")
+                die(f"phase_path missing — line {lineno} `phase_started` carries "
+                    "no usable `phase_path`, so phase_index cannot be derived for "
+                    "any pick in this phase")
+            if any(not isinstance(x, int) or isinstance(x, bool) for x in path):
+                die(f"phase_path element — line {lineno} `phase_path` {path} has a "
+                    "non-integer element; a bool would resolve as 0/1 and name a "
+                    "phase the run never entered")
             if len(path) > 2:
-                die(f"line {lineno} — `phase_path` {path} is {len(path)} deep, but "
+                die(f"phase_path depth — line {lineno} `phase_path` {path} is "
+                    f"{len(path)} deep, but "
                     "the engine's depth-1 rule bounds it to 2 (ScenarioValidator "
                     "blocks a nested `conditional` at load; ConditionalHandler "
                     "registers no sub-handler for one at run time). A deeper path "
@@ -180,7 +194,8 @@ def annotate(lines, nodes):
                     "would need a branch decision this tool cannot make.")
             if len(path) == 1:
                 if path[0] not in by_top:
-                    die(f"line {lineno} — `phase_path` {path} names top-level phase "
+                    die(f"phase_path unknown — line {lineno} `phase_path` {path} "
+                        f"names top-level phase "
                         f"{path[0]}, which the scenario's `phases:` does not have "
                         f"(it has {len(by_top)}). The transcript and the pinned "
                         "YAML disagree — check that the run used this exact "
@@ -196,14 +211,16 @@ def annotate(lines, nodes):
             else:
                 top, inner = path[0], path[1]
                 if pending_branch is None or pending_branch[0] != top:
-                    die(f"line {lineno} — `phase_path` {path} is inside a branch, but "
+                    die(f"branch unattributed — line {lineno} `phase_path` {path} is "
+                        "inside a branch, but "
                         "no `conditional_evaluated` for that conditional precedes "
                         "it. `then[j]` and `else[j]` share the path, so the branch "
                         "is what disambiguates them and it cannot be guessed.")
                 branch = pending_branch[1]
                 key = (top, branch, inner)
                 if key not in by_branch:
-                    die(f"line {lineno} — `phase_path` {path} names position {inner} "
+                    die(f"phase_path unknown — line {lineno} `phase_path` {path} "
+                        f"names position {inner} "
                         f"of the `{branch}` branch at top-level phase {top}, which "
                         f"has {branch_len[(top, branch)]} phase(s). The transcript "
                         "and the pinned YAML disagree — check that the run used "
@@ -471,7 +488,7 @@ def main():
     failures = ghv.check_content(
         doc, entry, blocklist, f"[{args.id}]",
         personas=(persona_names, None), allowed_model_ids=allowed_model_ids,
-        phase_tree=ghv.flatten_phase_tree(scenario))
+        phase_tree=(nodes, tree_reason))
     if failures:
         for line in failures:
             print(line, file=sys.stderr)

--- a/scripts/gallery_highlight_extract.py
+++ b/scripts/gallery_highlight_extract.py
@@ -388,7 +388,7 @@ def main():
     failures = ghv.check_content(
         doc, entry, blocklist, f"[{args.id}]",
         personas=(persona_names, None), allowed_model_ids=allowed_model_ids,
-        yaml_has_conditional=ghv.scenario_declares_conditional(scenario))
+        phase_tree=ghv.flatten_phase_tree(scenario))
     if failures:
         for line in failures:
             print(line, file=sys.stderr)

--- a/scripts/gallery_highlight_extract.py
+++ b/scripts/gallery_highlight_extract.py
@@ -37,8 +37,9 @@ Hard-fails (each with a distinct, greppable message):
   - the scenario YAML declares the `secret:` mechanism (ADR-029 Decision 2 —
     the spoiler rules are unvalidated for it);
   - a scenario whose `phases:` tree cannot be flattened — a `conditional`
-    with neither branch, one nested inside a branch (both refused by
-    `ScenarioValidator` too), or any other malformed `phases:` shape;
+    with neither branch (which `ScenarioValidator` refuses, post-load), one
+    nested inside a branch (which `ScenarioLoader` refuses earlier, at parse
+    time), or any other malformed `phases:` shape;
   - a `phase_started` line carrying no usable `phase_path`, one deeper than
     the engine's depth-1 rule allows, or one naming a phase / branch position
     the pinned YAML does not have;
@@ -186,12 +187,13 @@ def annotate(lines, nodes):
                     "phase the run never entered")
             if len(path) > 2:
                 die(f"phase_path depth — line {lineno} `phase_path` {path} is "
-                    f"{len(path)} deep, but "
-                    "the engine's depth-1 rule bounds it to 2 (ScenarioValidator "
-                    "blocks a nested `conditional` at load; ConditionalHandler "
-                    "registers no sub-handler for one at run time). A deeper path "
-                    "means the transcript and that rule disagree — resolving it "
-                    "would need a branch decision this tool cannot make.")
+                    f"{len(path)} deep, but the engine's depth-1 rule bounds it "
+                    "to 2 (ScenarioLoader.parsePhaseType refuses a nested "
+                    "`conditional` at parse time, so such a scenario never "
+                    "loads; ConditionalHandler registers no sub-handler for one "
+                    "at run time). A deeper path means the transcript and that "
+                    "rule disagree — resolving it would need a branch decision "
+                    "this tool cannot make.")
             if len(path) == 1:
                 if path[0] not in by_top:
                     die(f"phase_path unknown — line {lineno} `phase_path` {path} "

--- a/scripts/gallery_highlight_extract.py
+++ b/scripts/gallery_highlight_extract.py
@@ -105,6 +105,13 @@ def read_transcript(path):
                 run_start = obj
     if run_start is None:
         die(f"no run_start line in {path} — is this a pastura-harness transcript?")
+    # Checked here rather than where it first breaks: `build_excerpt`'s
+    # `max(...)` over the attempt numbers raises a bare `ValueError` on an empty
+    # iterable, which reaches the curator as a traceback instead of one of this
+    # tool's named failures.
+    if not any(o.get("type") == "event" for o in lines.values()):
+        die(f"no event lines in {path} — the transcript carries a run_start but "
+            "no events, so no line is excerpt-eligible")
     return lines, run_start
 
 
@@ -147,9 +154,6 @@ def annotate(lines, nodes):
             by_top[node.top] = flat_idx
         else:
             by_branch[(node.top, node.branch, node.inner)] = flat_idx
-    branch_len = collections.Counter(
-        (n.top, n.branch) for n in nodes if n.branch is not None)
-
     context, round_no, phase_idx = {}, None, None
     pending_branch = None   # (top, "then"/"else") from the last conditional_evaluated
     open_conditional = None  # top-level index of the conditional currently in flight
@@ -224,7 +228,8 @@ def annotate(lines, nodes):
                     die(f"phase_path unknown — line {lineno} `phase_path` {path} "
                         f"names position {inner} "
                         f"of the `{branch}` branch at top-level phase {top}, which "
-                        f"has {branch_len[(top, branch)]} phase(s). The transcript "
+                        f"has {sum(1 for n in nodes if (n.top, n.branch) == (top, branch))} "
+                        "phase(s). The transcript "
                         "and the pinned YAML disagree — check that the run used "
                         "this exact scenario file.")
                 phase_idx = by_branch[key]

--- a/scripts/gallery_highlight_extract.py
+++ b/scripts/gallery_highlight_extract.py
@@ -36,10 +36,14 @@ Usage:
 Hard-fails (each with a distinct, greppable message):
   - the scenario YAML declares the `secret:` mechanism (ADR-029 Decision 2 —
     the spoiler rules are unvalidated for it);
-  - the scenario uses a `conditional` phase, whose `phase_index` cannot be
-    derived (#1473) — raised by the shared `_check_position`, so the gate
-    refuses the same class;
-  - a `phase_started` line carrying no usable `phase_path`;
+  - a scenario whose `phases:` tree cannot be flattened — a `conditional`
+    with neither branch, or one nested inside a branch (both refused by
+    `ScenarioValidator` too);
+  - a `phase_started` line carrying no usable `phase_path`, one deeper than
+    the engine's depth-1 rule allows, or one naming a phase / branch position
+    the pinned YAML does not have;
+  - a branch `phase_path` with no preceding `conditional_evaluated` to say
+    which branch was taken (`then[j]` and `else[j]` share the path);
   - a transcript phase name outside the `PhaseType` catalog (a new phase type
     landed; classify it in ADR-029 Decision 3 first);
   - a pick that is not an `agent_output` line, or whose phase / source_field /
@@ -55,6 +59,7 @@ convenience and share their implementation with the gate
 (`scripts/gallery_highlight_validate.py`).
 """
 import argparse
+import collections
 import datetime
 import json
 import os
@@ -102,18 +107,42 @@ def read_transcript(path):
     return lines, run_start
 
 
-def annotate(lines):
+def annotate(lines, nodes):
     """Carry `round` and `phase_index` forward onto every event line.
 
     `agent_output` lines carry no `round` (ADR-029 Decision 2's mechanical
-    note) — it comes from the preceding `round_started`. `phase_index` comes
-    from the enclosing `phase_started.phase_path[0]`, which indexes the
-    scenario's TOP-LEVEL phase list — equal to the index into the entry's
-    `phases` only while the scenario has no `conditional`. What keeps the first
-    path element meaningful here is that `_check_position` refuses that whole
-    scenario class (#1473); its comment has the skew.
+    note) — it comes from the preceding `round_started`.
+
+    `phase_index` indexes the entry's flattened `phases`, while a transcript's
+    `phase_path` is a TREE path (`[i]`, or `[i, j]` inside a branch). Those
+    coincide only for a scenario with no `conditional`, so the path is resolved
+    against `nodes` — `flatten_phase_tree`'s node list, in the same order
+    `gallery.json` stores.
+
+    `[i, j]` alone does not say WHICH branch: `then[j]` and `else[j]` carry the
+    identical path. The branch comes from the `conditional_evaluated` the
+    harness emits between the conditional's own `phase_started` and its
+    branch's (`ConditionalHandler.execute` evaluates, then runs the branch).
+    That event carries no `phase_path` of its own, so it is attributed to the
+    most recent `phase_started` whose type is `conditional` — sound because the
+    engine's depth-1 rule means at most one conditional is ever in flight.
+
+    Every failure here is fatal rather than a fallback: an invented coordinate
+    reads as measured fact to every downstream check.
     """
+    by_top = {}
+    by_branch = {}
+    for flat_idx, node in enumerate(nodes):
+        if node.branch is None:
+            by_top[node.top] = flat_idx
+        else:
+            by_branch[(node.top, node.branch, node.inner)] = flat_idx
+    branch_len = collections.Counter(
+        (n.top, n.branch) for n in nodes if n.branch is not None)
+
     context, round_no, phase_idx = {}, None, None
+    pending_branch = None   # (top, "then"/"else") from the last conditional_evaluated
+    open_conditional = None  # top-level index of the conditional currently in flight
     for lineno in sorted(lines):
         obj = lines[lineno]
         if obj.get("type") != "event":
@@ -121,6 +150,17 @@ def annotate(lines):
         event = obj.get("event")
         if event == "round_started":
             round_no = obj.get("round")
+        elif event == "conditional_evaluated":
+            if open_conditional is None:
+                die(f"line {lineno} — `conditional_evaluated` with no preceding "
+                    "`phase_started` of type `conditional`, so the branch it "
+                    "decides cannot be attributed to a phase")
+            result = obj.get("result")
+            if not isinstance(result, bool):
+                die(f"line {lineno} — `conditional_evaluated.result` is "
+                    f"{result!r}, not a boolean; the taken branch cannot be "
+                    "derived from it")
+            pending_branch = (open_conditional, "then" if result else "else")
         elif event == "phase_started":
             path = obj.get("phase_path")
             # Refuse rather than default to 0. The harness always writes this
@@ -131,7 +171,44 @@ def annotate(lines):
                 die(f"line {lineno} — `phase_started` carries no usable "
                     "`phase_path`, so phase_index cannot be derived for any pick "
                     "in this phase")
-            phase_idx = path[0]
+            if len(path) > 2:
+                die(f"line {lineno} — `phase_path` {path} is {len(path)} deep, but "
+                    "the engine's depth-1 rule bounds it to 2 (ScenarioValidator "
+                    "blocks a nested `conditional` at load; ConditionalHandler "
+                    "registers no sub-handler for one at run time). A deeper path "
+                    "means the transcript and that rule disagree — resolving it "
+                    "would need a branch decision this tool cannot make.")
+            if len(path) == 1:
+                if path[0] not in by_top:
+                    die(f"line {lineno} — `phase_path` {path} names top-level phase "
+                        f"{path[0]}, which the scenario's `phases:` does not have "
+                        f"(it has {len(by_top)}). The transcript and the pinned "
+                        "YAML disagree — check that the run used this exact "
+                        "scenario file.")
+                phase_idx = by_top[path[0]]
+                open_conditional = (
+                    path[0] if nodes[phase_idx].type == "conditional" else None)
+                # Cleared on EVERY top-level phase, conditional included: the
+                # engine re-evaluates the condition once per round, so carrying
+                # the previous round's verdict forward would resolve round N's
+                # branch phases against round N-1's branch instead of failing.
+                pending_branch = None
+            else:
+                top, inner = path[0], path[1]
+                if pending_branch is None or pending_branch[0] != top:
+                    die(f"line {lineno} — `phase_path` {path} is inside a branch, but "
+                        "no `conditional_evaluated` for that conditional precedes "
+                        "it. `then[j]` and `else[j]` share the path, so the branch "
+                        "is what disambiguates them and it cannot be guessed.")
+                branch = pending_branch[1]
+                key = (top, branch, inner)
+                if key not in by_branch:
+                    die(f"line {lineno} — `phase_path` {path} names position {inner} "
+                        f"of the `{branch}` branch at top-level phase {top}, which "
+                        f"has {branch_len[(top, branch)]} phase(s). The transcript "
+                        "and the pinned YAML disagree — check that the run used "
+                        "this exact scenario file.")
+                phase_idx = by_branch[key]
         context[lineno] = (round_no, phase_idx)
     return context
 
@@ -344,9 +421,15 @@ def main():
             "the speaker's index into that list (ADR-029 Decision 1), so it "
             "cannot be derived.")
 
+    nodes, tree_reason = ghv.flatten_phase_tree(scenario)
+    if nodes is None:
+        die(f"unreadable phases — {tree_reason}. Every excerpt entry pins a "
+            "`phase_index` into the flattened phase list, so it cannot be "
+            "derived.")
+
     lines, run_start = read_transcript(args.run)
     check_phase_catalog(lines, args.run)
-    context = annotate(lines)
+    context = annotate(lines, nodes)
     selection = load_selection(args)
     excerpt = build_excerpt(
         selection["picks"], lines, context, args.run, persona_names)

--- a/scripts/gallery_highlight_extract.py
+++ b/scripts/gallery_highlight_extract.py
@@ -60,7 +60,6 @@ convenience and share their implementation with the gate
 (`scripts/gallery_highlight_validate.py`).
 """
 import argparse
-import collections
 import datetime
 import json
 import os
@@ -425,7 +424,9 @@ def main():
     yaml_path = os.path.join(args.gallery_dir, os.path.basename(entry.get("yaml_url", "")))
     if not os.path.isfile(yaml_path):
         die(f"sibling YAML not found: {yaml_path}")
-    scenario = yaml.safe_load(open(yaml_path, encoding="utf-8"))
+    scenario, scenario_reason = ghv._read_scenario(yaml_path)
+    if scenario_reason is not None:
+        die(f"unreadable scenario — {scenario_reason}")
     if declares_secret(scenario):
         die(f"secret mechanism — {yaml_path} declares `secret:` persona fields. "
             "ADR-029 Decision 2 refuses this branch: the spoiler rules are "

--- a/scripts/gallery_highlight_validate.py
+++ b/scripts/gallery_highlight_validate.py
@@ -29,6 +29,7 @@ line on stdout prefixed `highlight: <check> — …` so the bash gate can
 aggregate them and a reader can grep a specific class.
 """
 import argparse
+import collections
 import hashlib
 import json
 import math
@@ -462,7 +463,7 @@ def _check_yaml_hook_fragment(doc, where):
     return failures
 
 
-def _check_position(doc, entry, where, yaml_has_conditional):
+def _check_position(doc, entry, where, phase_tree):
     """Decision 3's two-part position rule, against the index entry.
 
     Also the home of the `conditional`-scenario refusal: the rule is stated in
@@ -495,9 +496,14 @@ def _check_position(doc, entry, where, yaml_has_conditional):
     #
     # Either source alone triggers the refusal: a drifted index could otherwise
     # disable the guard (nothing on a highlight PR's path re-derives `phases` —
-    # see `scenario_declares_conditional`), while keying on the YAML alone would
+    # see `flatten_phase_tree`), while keying on the YAML alone would
     # miss an index claiming a conditional the YAML no longer has. Disagreement
     # between them is itself a reason not to publish.
+    nodes, _reason = phase_tree
+    # Tri-state, as before: `None` = the tree could not be derived, so the
+    # scenario's own answer is unknown and only the index's claim is left.
+    yaml_has_conditional = (
+        None if nodes is None else any(n.type == "conditional" for n in nodes))
     if "conditional" in phases or yaml_has_conditional:
         source = ("the entry's `phases` list" if "conditional" in phases
                   else "the sibling scenario YAML's `phases:`")
@@ -631,31 +637,111 @@ def scenario_persona_names(scenario):
     return names
 
 
-def scenario_declares_conditional(scenario):
-    """-> True / False from the scenario YAML's TOP-LEVEL `phases:`, or None.
+PhaseNode = collections.namedtuple("PhaseNode", "type top branch inner")
+"""One entry of the flattened phase list.
 
-    Read from the YAML rather than from `gallery.json`'s denormalized `phases`
-    because nothing on a highlight PR's path re-derives that field: the gate
-    never reads it against the YAML, and its only cross-check
-    (`GallerySeedYAMLTests.galleryPhasesMatchYAML`) sits in the iOS suite, which
+`top` is the index into the scenario's TOP-LEVEL `phases:`. `branch` is
+`None` for a top-level phase, else `"then"` / `"else"`; `inner` is the
+position within that branch (`None` at top level). Together they carry the
+tree structure the flat list drops — which is what makes a `conditional`
+scenario's `phase_index` resolvable in both directions (#1473).
+"""
+
+
+def flatten_phase_tree(scenario):
+    """-> ([PhaseNode], None) in `gallery.json` `phases` order, or (None, reason).
+
+    Three implementations of this depth-first order exist and must agree:
+    `add-gallery-entry.sh`'s inline `flat()` (which WRITES the denormalized
+    `gallery.json` `phases`), `GallerySeedYAMLTests.flattenPhaseKinds` (Swift),
+    and this one. The Swift copy runs in the iOS suite, which
     `precommit-gate-classify.sh` skips for a `docs/`-only changeset — the shape
-    every highlight batch has. A `phases` list that lost its `conditional`
-    would otherwise disable the refusal silently.
+    every highlight batch has — so it is not a gate on this path. Hence
+    `_check_phase_tree` below: it re-derives the list here and compares, making
+    this the first gate-side drift check on that field for flat entries too.
 
-    `None` means the list could not be read at all; the caller treats that as
-    "cannot verify" rather than "no conditional".
+    The reason string travels back so the failure text can name the actual
+    cause, as `_read_persona_names` does: on a machine without PyYAML the fix
+    is an install, and a message blaming the scenario would send the curator to
+    the wrong file.
+
+    Rejects two shapes the engine also rejects, so a fixture the loader would
+    refuse cannot reach the position rule:
+
+    - a `conditional` with neither branch populated (`ScenarioValidator`'s
+      `validateConditionalPhase`: at least one of `then:` / `else:` must be
+      non-empty);
+    - a `conditional` nested inside a branch (the depth-1 rule, enforced twice
+      upstream — `ScenarioValidator` blocks `depth > 0`, and
+      `ConditionalHandler.subHandlers` deliberately omits `.conditional`).
+      That upstream guarantee is what bounds a transcript `phase_path` to
+      length 2, which the extractor's resolver relies on.
     """
     if not isinstance(scenario, dict):
-        return None
+        return None, "the sibling scenario YAML is not a mapping"
     phases = scenario.get("phases")
     if not isinstance(phases, list) or not phases:
-        return None
-    for phase in phases:
+        return None, ("the sibling scenario YAML has no non-empty `phases:` "
+                      "list, so its phase tree cannot be derived")
+    nodes = []
+    for top, phase in enumerate(phases):
         if not isinstance(phase, dict) or not isinstance(phase.get("type"), str):
-            return None
-        if phase["type"] == "conditional":
-            return True
-    return False
+            return None, (f"the sibling scenario YAML's `phases:`[{top}] is not a "
+                          "mapping carrying a string `type`")
+        nodes.append(PhaseNode(phase["type"], top, None, None))
+        if phase["type"] != "conditional":
+            continue
+        populated = 0
+        for branch in ("then", "else"):
+            sub = phase.get(branch)
+            if sub is None:
+                continue
+            if not isinstance(sub, list):
+                return None, (f"the sibling scenario YAML's `phases:`[{top}].{branch} "
+                              "is not a list")
+            populated += len(sub)
+            for inner, child in enumerate(sub):
+                if not isinstance(child, dict) or not isinstance(child.get("type"), str):
+                    return None, (f"the sibling scenario YAML's `phases:`[{top}]."
+                                  f"{branch}[{inner}] is not a mapping carrying a "
+                                  "string `type`")
+                if child["type"] == "conditional":
+                    return None, (f"the sibling scenario YAML nests a `conditional` at "
+                                  f"`phases:`[{top}].{branch}[{inner}], which the "
+                                  "engine's depth-1 rule refuses (ScenarioValidator "
+                                  "blocks depth > 0; ConditionalHandler registers no "
+                                  "sub-handler for it)")
+                nodes.append(PhaseNode(child["type"], top, branch, inner))
+        if populated == 0:
+            return None, (f"the sibling scenario YAML's `conditional` at "
+                          f"`phases:`[{top}] populates neither `then:` nor `else:`, "
+                          "which the engine refuses (ScenarioValidator requires at "
+                          "least one non-empty branch)")
+    return nodes, None
+
+
+def _check_phase_tree(entry, phase_tree, where):
+    """`gallery.json`'s denormalized `phases` must equal the YAML-derived tree.
+
+    Nothing else on a highlight PR's path re-derives that field (see
+    `flatten_phase_tree`), and every check stated in terms of `phase_index`
+    reads it — so a drifted list would silently move what the position rule
+    measures against. Failing here rather than inside `_check_position` keeps
+    the drift reported as drift, not as a mismatched excerpt.
+    """
+    nodes, reason = phase_tree
+    phases = entry.get("phases")
+    if nodes is None:
+        return [f"highlight: phase tree — {where} cannot be re-derived because "
+                f"{reason}, so `phases` is unverified and every `phase_index` "
+                "check reads an unchecked list"]
+    derived = [n.type for n in nodes]
+    if not isinstance(phases, list) or derived != phases:
+        return [f"highlight: phase tree — {where} gallery.json `phases` is "
+                f"{phases!r} but the sibling scenario YAML flattens to {derived!r}. "
+                "Regenerate the entry (scripts/add-gallery-entry.sh --update); the "
+                "denormalized list is what every `phase_index` check reads."]
+    return []
 
 
 def _check_persona_index(doc, personas, where):
@@ -713,7 +799,7 @@ def _check_persona_index(doc, personas, where):
 
 
 def check_content(doc, entry, blocklist, where, personas, allowed_model_ids,
-                  yaml_has_conditional):
+                  phase_tree):
     """Every rule derivable from the highlight doc + its index entry.
 
     Shared by the extractor (fail-fast) and the gate (enforcement). Excludes
@@ -731,8 +817,8 @@ def check_content(doc, entry, blocklist, where, personas, allowed_model_ids,
 
     `personas` is ``_read_persona_names``'s `(names, reason)` pair;
     `allowed_model_ids` is ``registry_model_ids`` ∪ ``RETIRED_MODEL_IDS``;
-    `yaml_has_conditional` is ``scenario_declares_conditional``'s tri-state read
-    of the sibling YAML (`None` = unreadable). All three are required rather
+    `phase_tree` is ``flatten_phase_tree``'s `(nodes, reason)` pair over the
+    sibling YAML (`nodes is None` = unreadable). All three are required rather
     than defaulted, so a caller cannot skip a check by omission — the gate is
     the only place any of these failures would surface.
     """
@@ -742,7 +828,8 @@ def check_content(doc, entry, blocklist, where, personas, allowed_model_ids,
     failures += _check_source_model(doc, allowed_model_ids, where)
     failures += _check_yaml_hook_secret(doc, where)
     failures += _check_yaml_hook_fragment(doc, where)
-    failures += _check_position(doc, entry, where, yaml_has_conditional)
+    failures += _check_phase_tree(entry, phase_tree, where)
+    failures += _check_position(doc, entry, where, phase_tree)
     failures += check_blocklist(doc, blocklist, where)
     return failures
 
@@ -759,9 +846,9 @@ def _read_scenario(yaml_path):
     """-> the parsed sibling scenario YAML, or None if it cannot be read.
 
     Separate from `_read_persona_names`, which parses the same file again: that
-    one returns names plus a *reason* string its failure text needs, while the
-    conditional refusal wants the document itself and has only a tri-state to
-    report through. Same catch set, so the two agree on what "unreadable" means.
+    one returns names, while ``flatten_phase_tree`` wants the document itself
+    and derives the whole phase tree from it. Same catch set, so the two agree
+    on what "unreadable" means.
     """
     if yaml is None:
         return None
@@ -893,9 +980,9 @@ def validate_repo(gallery_json, gallery_dir, blocklist_path, registry_swift):
         yaml_path = os.path.join(gallery_dir, os.path.basename(entry.get("yaml_url", "")))
         personas = (None, f"the sibling scenario YAML {yaml_path} is missing")
         # Bound here, like `personas`, so the missing-YAML path below does not
-        # leave it unbound. `None` = cannot verify; that path already fails the
-        # highlight on the persona check, so it never ships unverified.
-        yaml_has_conditional = None
+        # leave it unbound. A `None` node list = cannot verify; that path already
+        # fails the highlight on the persona check, so it never ships unverified.
+        phase_tree = (None, f"the sibling scenario YAML {yaml_path} is missing")
         if not os.path.isfile(yaml_path):
             failures.append(
                 f"highlight: yaml_sha256 mismatch — id={entry_id} sibling YAML "
@@ -910,13 +997,12 @@ def validate_repo(gallery_json, gallery_dir, blocklist_path, registry_swift):
                     f"YAML bytes hash to {yaml_sha}. Regenerate or delete the highlight "
                     "(ADR-029 Decision 1: highlights are pinned snapshots)")
             personas = _read_persona_names(yaml_path)
-            yaml_has_conditional = scenario_declares_conditional(
-                _read_scenario(yaml_path))
+            phase_tree = flatten_phase_tree(_read_scenario(yaml_path))
 
         failures += check_content(
             doc, entry, blocklist, where,
             personas=personas, allowed_model_ids=allowed_model_ids,
-            yaml_has_conditional=yaml_has_conditional)
+            phase_tree=phase_tree)
 
     for path in sorted(on_disk - referenced):
         rel = os.path.relpath(path, os.path.dirname(gallery_dir))

--- a/scripts/gallery_highlight_validate.py
+++ b/scripts/gallery_highlight_validate.py
@@ -482,6 +482,11 @@ def _preceding_in_round(nodes, idx):
 
     What this does NOT do is defend against a `phase_index` that names the
     wrong branch — see `_check_position`'s note on what the gate can verify.
+    Nor does it look at the condition itself: a `conditional` whose expression
+    reads outcome state (a score threshold, a vote winner) makes *branch
+    membership* a weak outcome signal for an utterance inside it. Decision 3's
+    rule is stated over phase types, so that is out of scope by construction —
+    recorded here so the next curator does not re-derive it as a gap.
     """
     node = nodes[idx]
     out = [n.type for n in nodes if n.top < node.top]
@@ -699,10 +704,13 @@ def flatten_phase_tree(scenario):
       `validateConditionalPhase`: at least one of `then:` / `else:` must be
       non-empty);
     - a `conditional` nested inside a branch (the depth-1 rule, enforced twice
-      upstream — `ScenarioValidator` blocks `depth > 0`, and
-      `ConditionalHandler.subHandlers` deliberately omits `.conditional`).
-      That upstream guarantee is what bounds a transcript `phase_path` to
-      length 2, which the extractor's resolver relies on.
+      upstream — `ScenarioValidator.validateBranch` throws
+      `.branchNestedConditional` at load, and `ConditionalHandler.subHandlers`
+      deliberately omits `.conditional` at run time). Cite those two and not
+      `validateConditionalPhase`'s `depth > 0`: that arm is unreachable, since
+      the function has a single callsite passing `depth: 0` and `validateBranch`
+      never recurses into it. The upstream guarantee is what bounds a transcript
+      `phase_path` to length 2, which the extractor's resolver relies on.
     """
     if not isinstance(scenario, dict):
         return None, "the sibling scenario YAML is not a mapping"
@@ -735,9 +743,10 @@ def flatten_phase_tree(scenario):
                 if child["type"] == "conditional":
                     return None, (f"the sibling scenario YAML nests a `conditional` at "
                                   f"`phases:`[{top}].{branch}[{inner}], which the "
-                                  "engine's depth-1 rule refuses (ScenarioValidator "
-                                  "blocks depth > 0; ConditionalHandler registers no "
-                                  "sub-handler for it)")
+                                  "engine's depth-1 rule refuses "
+                                  "(ScenarioValidator.validateBranch throws "
+                                  "`.branchNestedConditional`; ConditionalHandler "
+                                  "registers no sub-handler for it)")
                 nodes.append(PhaseNode(child["type"], top, branch, inner))
         if populated == 0:
             return None, (f"the sibling scenario YAML's `conditional` at "
@@ -870,20 +879,26 @@ def _entry_index(gallery_json):
 
 
 def _read_scenario(yaml_path):
-    """-> the parsed sibling scenario YAML, or None if it cannot be read.
+    """-> (parsed sibling scenario YAML, None), or (None, reason).
 
     Separate from `_read_persona_names`, which parses the same file again: that
     one returns names, while ``flatten_phase_tree`` wants the document itself
     and derives the whole phase tree from it. Same catch set, so the two agree
-    on what "unreadable" means.
+    on what "unreadable" means — and the same `(value, reason)` shape, so a
+    caller cannot report "the YAML is not a mapping" for what was really a
+    missing PyYAML. `flatten_phase_tree` can only see a `None` document, so the
+    true cause has to travel separately or it is lost here.
     """
     if yaml is None:
-        return None
+        return None, ("PyYAML is not installed, so the sibling scenario YAML "
+                      "cannot be parsed (python3 -m pip install 'pyyaml>=6,<7')")
     try:
         with open(yaml_path, encoding="utf-8") as f:
-            return yaml.safe_load(f)
-    except (OSError, UnicodeDecodeError, yaml.YAMLError, RecursionError):
-        return None
+            return yaml.safe_load(f), None
+    except (OSError, UnicodeDecodeError) as exc:
+        return None, f"the sibling scenario YAML could not be read ({exc})"
+    except (yaml.YAMLError, RecursionError) as exc:
+        return None, f"the sibling scenario YAML does not parse ({type(exc).__name__})"
 
 
 def _read_persona_names(yaml_path):
@@ -1024,7 +1039,12 @@ def validate_repo(gallery_json, gallery_dir, blocklist_path, registry_swift):
                     f"YAML bytes hash to {yaml_sha}. Regenerate or delete the highlight "
                     "(ADR-029 Decision 1: highlights are pinned snapshots)")
             personas = _read_persona_names(yaml_path)
-            phase_tree = flatten_phase_tree(_read_scenario(yaml_path))
+            scenario, scenario_reason = _read_scenario(yaml_path)
+            # `_read_scenario`'s reason wins when there is one: it names the
+            # real cause (no PyYAML, unreadable file, malformed YAML), which
+            # `flatten_phase_tree` cannot recover from a bare `None`.
+            phase_tree = ((None, scenario_reason) if scenario_reason
+                          else flatten_phase_tree(scenario))
 
         failures += check_content(
             doc, entry, blocklist, where,

--- a/scripts/gallery_highlight_validate.py
+++ b/scripts/gallery_highlight_validate.py
@@ -701,8 +701,10 @@ def flatten_phase_tree(scenario):
     refuse cannot reach the position rule:
 
     - a `conditional` with neither branch populated (`ScenarioValidator`'s
-      `validateConditionalPhase`: at least one of `then:` / `else:` must be
-      non-empty);
+      `validateConditionalPhase` throws `.conditionalEmptyBranches`: at least
+      one of `then:` / `else:` must be non-empty). Note the stage: `ScenarioLoader`
+      does NOT check this, so such a file loads and is refused afterwards —
+      the opposite of the nested case below, which never loads at all;
     - a `conditional` nested inside a branch (the depth-1 rule). Three guards
       enforce it upstream, and only one of them is on this input's path:
       `ScenarioLoader.parsePhaseType` rejects at PARSE time, which is what a

--- a/scripts/gallery_highlight_validate.py
+++ b/scripts/gallery_highlight_validate.py
@@ -463,15 +463,54 @@ def _check_yaml_hook_fragment(doc, where):
     return failures
 
 
+def _preceding_in_round(nodes, idx):
+    """-> phase types that can precede ``nodes[idx]`` within one round.
+
+    Two contributions, and they differ in kind:
+
+    - **Every node at a smaller top-level index.** For a *preceding*
+      `conditional` that pulls in BOTH branches. Deliberate and conservative:
+      an excerpt records no branch, so not even an honest one can say which
+      branch a preceding conditional took in the round it came from. The union
+      is the only fail-safe reading, and it is the reason a scenario that
+      continues past its conditional is handled here rather than refused.
+    - **Siblings before it inside its own branch.** Here the flattened index
+      does identify the branch, so this part is exact.
+
+    The containing `conditional` is the pick's parent, not something preceding
+    it, so it contributes nothing (and is not outcome-class either way).
+
+    What this does NOT do is defend against a `phase_index` that names the
+    wrong branch — see `_check_position`'s note on what the gate can verify.
+    """
+    node = nodes[idx]
+    out = [n.type for n in nodes if n.top < node.top]
+    if node.branch is not None:
+        out += [n.type for n in nodes
+                if n.top == node.top and n.branch == node.branch
+                and n.inner is not None and n.inner < node.inner]
+    return out
+
+
 def _check_position(doc, entry, where, phase_tree):
     """Decision 3's two-part position rule, against the index entry.
 
-    Also the home of the `conditional`-scenario refusal: the rule is stated in
-    terms of `phase_index`, so the scenario class whose `phase_index` cannot be
-    derived is refused where that index is read, not at an unrelated callsite.
-    Being here means the extractor inherits it too — `check_content` dispatches
-    this function for both callers, so the two cannot disagree about which
-    highlights are publishable.
+    `check_content` dispatches this for both the extractor and the gate, so the
+    two cannot disagree about which highlights are publishable.
+
+    **What the gate verifies is the claimed coordinate's CONSISTENCY, not its
+    truth.** It never reads the transcript (by design — a hand-edited highlight
+    never runs the extractor), so a `phase_index` that names a different
+    same-typed position than the utterance actually came from passes: the phase
+    check still matches and the preceding set is then computed over the wrong
+    range. That exposure is not specific to `conditional` — it is live on flat
+    entries today (`hitsuji_kaigi_v1` / `ijin_kaigi_v1` are
+    `[speak_each, reflect, speak_each, choose, speak_each, summarize]`, where
+    labelling a post-`choose` utterance `phase_index: 0` passes). Truth is
+    anchored upstream instead: the extractor derives the index from the
+    transcript, and ADR-029 Decision 2 requires human sign-off. Narrowing only
+    the conditional arm of this would close nothing and cost real rejections —
+    do not add it (#1473).
     """
     failures = []
     phases = entry.get("phases")
@@ -479,41 +518,25 @@ def _check_position(doc, entry, where, phase_tree):
     if not isinstance(phases, list) or not phases:
         return [f"highlight: schema — {where} gallery.json entry has no `phases` list "
                 "to check the within-round bound against"]
-    # Refused as a class, deliberately wider than the broken cases — the failure
-    # message says so. `phases` is the FULLY-FLATTENED depth-first list (the
-    # `conditional`, then its then-branch, then its else-branch) while a
-    # transcript's `phase_path` indexes the TOP-LEVEL list, so the outcome-phase
-    # prefix `phases[:idx]` spans branches that never ran together in one round.
-    # Telling a sound pick from a skewed one needs the branch structure this
-    # function does not have, which is #1473's work.
-    #
-    # Picks at or inside the conditional fail loudly today only because no
-    # shipped scenario continues past its conditional; one that did could match
-    # `phases[idx]` by coincidence and evaluate that prefix over the wrong range,
-    # silently. Returning early keeps such speculation out of the report, and
-    # drops the round-window arms too — derivable, but worth nothing on a
-    # highlight that cannot ship.
-    #
-    # Either source alone triggers the refusal: a drifted index could otherwise
-    # disable the guard (nothing on a highlight PR's path re-derives `phases` —
-    # see `flatten_phase_tree`), while keying on the YAML alone would
-    # miss an index claiming a conditional the YAML no longer has. Disagreement
-    # between them is itself a reason not to publish.
-    nodes, _reason = phase_tree
-    # Tri-state, as before: `None` = the tree could not be derived, so the
-    # scenario's own answer is unknown and only the index's claim is left.
-    yaml_has_conditional = (
-        None if nodes is None else any(n.type == "conditional" for n in nodes))
-    if "conditional" in phases or yaml_has_conditional:
-        source = ("the entry's `phases` list" if "conditional" in phases
-                  else "the sibling scenario YAML's `phases:`")
-        return [f"highlight: conditional scenario — {where} {source} contains "
-                "`conditional`, whose branch sub-phases are flattened into the "
-                "index's list. `phase_index` is not branch-aware, so neither the "
-                "index nor the within-round bound can be derived correctly (#1473). "
-                "Highlights are refused for this scenario class until that lands — "
-                "including a pick before the conditional, which is sound but not "
-                "distinguishable here."]
+    # Branch-aware only when the tree was derivable AND agrees with the
+    # denormalized list `phase_index` actually indexes into. `_check_phase_tree`
+    # reports either divergence in its own words; re-testing the pair here keeps
+    # THIS function's verdict from resting on an unchecked correspondence.
+    nodes, reason = phase_tree
+    tree = (nodes if nodes is not None and [n.type for n in nodes] == phases
+            else None)
+    if tree is None and "conditional" in phases:
+        # Fail-closed residue of the class-wide refusal this replaces. Without
+        # the tree, `phases` is all there is — a fully-flattened depth-first
+        # list in which the outcome-phase prefix `phases[:idx]` spans branches
+        # that never ran together in one round. Flat entries need no such
+        # residue: for them the flat prefix IS the round's phase list.
+        return [f"highlight: conditional scenario — {where} the entry's `phases` "
+                "list contains `conditional`, but its branch structure is "
+                f"unavailable ({reason or 'it disagrees with the sibling scenario YAML'}). "
+                "The flattened list interleaves both branches, so the within-round "
+                "bound cannot be evaluated — fix the scenario YAML or the entry and "
+                "re-run rather than publishing an unchecked position."]
     if not isinstance(rounds, int) or isinstance(rounds, bool) or rounds < 1:
         return [f"highlight: schema — {where} gallery.json entry has no usable "
                 "`rounds` value to compute the round window"]
@@ -529,7 +552,11 @@ def _check_position(doc, entry, where, phase_tree):
                 failures.append(
                     f"highlight: phase_index mismatch — {loc}.phase_index={idx} names "
                     f"phases[{idx}]={phases[idx]!r} but phase={ex.get('phase')!r}")
-            preceding = [p for p in phases[:idx] if p in OUTCOME_PHASES]
+            # `phases[:idx]` is correct for a flat scenario and only for one;
+            # with a tree, the round's real preceding set is branch-aware.
+            candidates = (_preceding_in_round(tree, idx) if tree is not None
+                          else phases[:idx])
+            preceding = [p for p in candidates if p in OUTCOME_PHASES]
             if preceding:
                 failures.append(
                     f"highlight: within-round bound — {loc}.phase_index={idx} is "

--- a/scripts/gallery_highlight_validate.py
+++ b/scripts/gallery_highlight_validate.py
@@ -703,13 +703,17 @@ def flatten_phase_tree(scenario):
     - a `conditional` with neither branch populated (`ScenarioValidator`'s
       `validateConditionalPhase`: at least one of `then:` / `else:` must be
       non-empty);
-    - a `conditional` nested inside a branch (the depth-1 rule, enforced twice
-      upstream — `ScenarioValidator.validateBranch` throws
-      `.branchNestedConditional` at load, and `ConditionalHandler.subHandlers`
-      deliberately omits `.conditional` at run time). Cite those two and not
-      `validateConditionalPhase`'s `depth > 0`: that arm is unreachable, since
-      the function has a single callsite passing `depth: 0` and `validateBranch`
-      never recurses into it. The upstream guarantee is what bounds a transcript
+    - a `conditional` nested inside a branch (the depth-1 rule). Three guards
+      enforce it upstream, and only one of them is on this input's path:
+      `ScenarioLoader.parsePhaseType` rejects at PARSE time, which is what a
+      curator's YAML actually hits — `ScenarioValidator` is constructed only
+      after loading, so a nested conditional never becomes a `Scenario` for it
+      to see. `ScenarioValidator.validateBranch`'s `.branchNestedConditional`
+      covers a programmatically-built `Scenario`, and
+      `ConditionalHandler.subHandlers` omits `.conditional` as a run-time
+      backstop. Do NOT cite `validateConditionalPhase`'s `depth > 0`: that arm
+      is unreachable, its function having a single callsite passing `depth: 0`
+      with no recursion back into it. Together they bound a transcript
       `phase_path` to length 2, which the extractor's resolver relies on.
     """
     if not isinstance(scenario, dict):
@@ -743,10 +747,10 @@ def flatten_phase_tree(scenario):
                 if child["type"] == "conditional":
                     return None, (f"the sibling scenario YAML nests a `conditional` at "
                                   f"`phases:`[{top}].{branch}[{inner}], which the "
-                                  "engine's depth-1 rule refuses "
-                                  "(ScenarioValidator.validateBranch throws "
-                                  "`.branchNestedConditional`; ConditionalHandler "
-                                  "registers no sub-handler for it)")
+                                  "engine's depth-1 rule refuses — this file would "
+                                  "not load at all (ScenarioLoader.parsePhaseType "
+                                  "throws `.nestedConditionalNotAllowed` at parse "
+                                  "time)")
                 nodes.append(PhaseNode(child["type"], top, branch, inner))
         if populated == 0:
             return None, (f"the sibling scenario YAML's `conditional` at "

--- a/scripts/gallery_highlight_validate.py
+++ b/scripts/gallery_highlight_validate.py
@@ -257,8 +257,8 @@ def _check_excerpt_shape(doc, where):
 def _persona_entries(parsed):
     """-> the entry list for either accepted persona-fragment shape, else None.
 
-    ADR-029 Decision 1 pins two: a bare block sequence of mappings (what both
-    shipped hooks use — PyYAML parses one at any indent without dedenting) or a
+    ADR-029 Decision 1 pins two: a bare block sequence of mappings (what every
+    shipped hook uses — PyYAML parses one at any indent without dedenting) or a
     `personas:`-keyed mapping holding one.
     """
     if isinstance(parsed, list):
@@ -425,9 +425,15 @@ def _check_yaml_hook_fragment(doc, where):
         # `RecursionError` is not a `YAMLError`, and PyYAML's parser recurses —
         # ~500 levels of nesting raises it here. Reported as unparseable (which
         # it effectively is) rather than escaping as a traceback.
+        # Whitespace-collapsed: PyYAML's `str(exc)` spans several lines (the
+        # snippet and its caret), and `check-gallery-entry.sh` calls `fail` once
+        # per output line — so the raw form turns one parse error into four gate
+        # failures, three of them without the `highlight:` prefix this file's
+        # header promises every failure carries.
+        detail = " ".join(str(exc).split())
         return [
             f"highlight: yaml_hook fragment — {where} kind=persona but the fragment is "
-            f"not parseable YAML: {type(exc).__name__}: {exc}"]
+            f"not parseable YAML: {type(exc).__name__}: {detail}"]
 
     entries = _persona_entries(parsed)
     if not entries:
@@ -508,14 +514,23 @@ def _check_position(doc, entry, where, phase_tree):
     never runs the extractor), so a `phase_index` that names a different
     same-typed position than the utterance actually came from passes: the phase
     check still matches and the preceding set is then computed over the wrong
-    range. That exposure is not specific to `conditional` — it is live on flat
-    entries today (`hitsuji_kaigi_v1` / `ijin_kaigi_v1` are
+    range.
+
+    The exposure predates `conditional`: any flat entry with two same-typed
+    eligible phases has it — `hitsuji_kaigi_v1` / `ijin_kaigi_v1` are
     `[speak_each, reflect, speak_each, choose, speak_each, summarize]`, where
-    labelling a post-`choose` utterance `phase_index: 0` passes). Truth is
-    anchored upstream instead: the extractor derives the index from the
-    transcript, and ADR-029 Decision 2 requires human sign-off. Narrowing only
-    the conditional arm of this would close nothing and cost real rejections —
-    do not add it (#1473).
+    labelling a post-`choose` utterance `phase_index: 0` passes. Neither carries
+    a highlight, and each of the six that do has exactly one eligible phase
+    type, so no shipped highlight can express it — latent there, not live.
+
+    A conditional makes it **more** reachable, not equal: `hissatsu_naming_v1`'s
+    two branches are type-identical, so index 1 and 5 are indistinguishable here
+    by construction rather than by coincidence. Adding a conditional-only check
+    is still the wrong answer — applied consistently the same principle unions
+    every same-typed position and empties `hitsuji_kaigi`'s eligible set — but
+    it is a real widening, not a null one. The guard is elsewhere: the extractor
+    derives the index from the transcript, and ADR-029 Decision 2 requires human
+    sign-off on each excerpt (#1473).
     """
     failures = []
     phases = entry.get("phases")
@@ -813,9 +828,12 @@ def _check_persona_index(doc, personas, where):
         loc = f"{where} excerpt[{i}]"
         idx = ex.get("persona_index")
         if not isinstance(idx, int) or isinstance(idx, bool) or idx < 0:
-            # NOT a guard — `_check_excerpt_shape` already fails all of these
-            # (measured: removing this line leaves the suite green). It only
-            # avoids double-reporting. Do not describe it as catching anything.
+            # Skips the shapes `_check_excerpt_shape` already reports, so they
+            # are not double-reported — but it is ALSO load-bearing: without the
+            # `isinstance(idx, int)` test a `null` or omitted index reaches
+            # `idx >= len(persona_names)` and raises `TypeError`, which escapes
+            # `check_content` and `validate_repo` so the gate prints a traceback
+            # instead of the accumulated failure list. Do not remove it.
             continue
         agent = ex.get("agent")
         if idx >= len(persona_names):
@@ -830,7 +848,8 @@ def _check_persona_index(doc, personas, where):
         elif idx >= 0 and persona_names.index(agent) != idx:
             # Name-match alone is too weak when a scenario declares the same
             # name twice: either index would satisfy it, while the app resolves
-            # the slot with `firstIndex(of:)` and so uses the first. Requiring
+            # the slot with `firstIndex { $0.name == agent }` and so uses the
+            # first (`SimulationView.personaItem(for:)`). Requiring
             # the first keeps the excerpt's colours equal to the run's.
             failures.append(
                 f"highlight: persona_index — {loc}.persona_index={idx} is a later "
@@ -912,20 +931,18 @@ def _read_persona_names(yaml_path):
 
     The reason travels back so the failure text can name the actual cause: on a
     machine without PyYAML the fix is an install, and a message blaming the YAML
-    would send the curator to the wrong file. `RecursionError` is caught
-    alongside `YAMLError` for the reason the sibling checks here document — it
-    is not a `YAMLError`, so deep nesting escapes as a traceback otherwise.
+    would send the curator to the wrong file.
+
+    Reads through ``_read_scenario`` rather than parsing again. The two used to
+    carry identical read-and-catch bodies with a docstring apiece pinning "same
+    catch set" as a hand-maintained invariant — which is the drift they exist to
+    prevent: adding a catch to one and not the other would make the two checks
+    disagree about why the same file is unreadable, sending the curator to the
+    wrong file. Delegating also halves the parses per highlighted entry.
     """
-    if yaml is None:
-        return None, ("PyYAML is not installed, so the sibling scenario YAML "
-                      "cannot be parsed (python3 -m pip install 'pyyaml>=6,<7')")
-    try:
-        with open(yaml_path, encoding="utf-8") as f:
-            parsed = yaml.safe_load(f)
-    except (OSError, UnicodeDecodeError) as exc:
-        return None, f"the sibling scenario YAML could not be read ({exc})"
-    except (yaml.YAMLError, RecursionError) as exc:
-        return None, f"the sibling scenario YAML does not parse ({type(exc).__name__})"
+    parsed, reason = _read_scenario(yaml_path)
+    if reason is not None:
+        return None, reason
     names = scenario_persona_names(parsed)
     if names is None:
         return None, ("the sibling scenario YAML has no `personas:` list of "

--- a/scripts/gallery_highlight_validate.py
+++ b/scripts/gallery_highlight_validate.py
@@ -707,10 +707,8 @@ def flatten_phase_tree(scenario):
     `_check_phase_tree` below: it re-derives the list here and compares, making
     this the first gate-side drift check on that field for flat entries too.
 
-    The reason string travels back so the failure text can name the actual
-    cause, as `_read_persona_names` does: on a machine without PyYAML the fix
-    is an install, and a message blaming the scenario would send the curator to
-    the wrong file.
+    The reason string travels back because the failure text must name the
+    actual cause — ``_read_scenario`` documents the coupling that applies here.
 
     Rejects two shapes the engine also rejects, so a fixture the loader would
     refuse cannot reach the position rule:
@@ -906,12 +904,13 @@ def _entry_index(gallery_json):
 def _read_scenario(yaml_path):
     """-> (parsed sibling scenario YAML, None), or (None, reason).
 
-    Separate from `_read_persona_names`, which parses the same file again: that
+    Separate from `_read_persona_names`, which reads through this one: that
     one returns names, while ``flatten_phase_tree`` wants the document itself
-    and derives the whole phase tree from it. Same catch set, so the two agree
-    on what "unreadable" means — and the same `(value, reason)` shape, since
-    `flatten_phase_tree` can only see a `None` document and would otherwise
-    report "not a mapping" for what was really a missing PyYAML.
+    and derives the whole phase tree from it. One catch set rather than two
+    kept in step, so they cannot disagree on what "unreadable" means — and it
+    hands back the same `(value, reason)` shape, since `flatten_phase_tree`
+    can only see a `None` document and would otherwise report "not a mapping"
+    for what was really a missing PyYAML.
 
     The pair shape alone does not buy that: an empty or comments-only document
     parses to `None` with NO reason, so `(None, None)` is returnable. What
@@ -938,12 +937,11 @@ def _read_persona_names(yaml_path):
     machine without PyYAML the fix is an install, and a message blaming the YAML
     would send the curator to the wrong file.
 
-    Reads through ``_read_scenario`` rather than parsing again. The two used to
-    carry identical read-and-catch bodies with a docstring apiece pinning "same
-    catch set" as a hand-maintained invariant — which is the drift they exist to
-    prevent: adding a catch to one and not the other would make the two checks
-    disagree about why the same file is unreadable, sending the curator to the
-    wrong file. Delegating also halves the parses per highlighted entry.
+    Reads through ``_read_scenario`` rather than keeping a second copy of the
+    read-and-catch body, so the catch set cannot drift: two copies disagreeing
+    about why one file is unreadable is the same wrong-file failure. It buys
+    no parse: `validate_repo` calls `_read_scenario` again for the phase tree,
+    so the count per entry is 2 either way (measured).
     """
     parsed, reason = _read_scenario(yaml_path)
     if reason is not None:

--- a/scripts/gallery_highlight_validate.py
+++ b/scripts/gallery_highlight_validate.py
@@ -909,10 +909,15 @@ def _read_scenario(yaml_path):
     Separate from `_read_persona_names`, which parses the same file again: that
     one returns names, while ``flatten_phase_tree`` wants the document itself
     and derives the whole phase tree from it. Same catch set, so the two agree
-    on what "unreadable" means — and the same `(value, reason)` shape, so a
-    caller cannot report "the YAML is not a mapping" for what was really a
-    missing PyYAML. `flatten_phase_tree` can only see a `None` document, so the
-    true cause has to travel separately or it is lost here.
+    on what "unreadable" means — and the same `(value, reason)` shape, since
+    `flatten_phase_tree` can only see a `None` document and would otherwise
+    report "not a mapping" for what was really a missing PyYAML.
+
+    The pair shape alone does not buy that: an empty or comments-only document
+    parses to `None` with NO reason, so `(None, None)` is returnable. What
+    closes it is the caller short-circuiting on a non-`None` reason (see
+    `validate_repo`) and letting `flatten_phase_tree` re-derive its own for the
+    rest — for an empty document "not a mapping" is the accurate answer.
     """
     if yaml is None:
         return None, ("PyYAML is not installed, so the sibling scenario YAML "

--- a/scripts/jsonl_to_demo_replay.py
+++ b/scripts/jsonl_to_demo_replay.py
@@ -31,7 +31,14 @@ conditional rather than the phase that spoke, and `BundledDemoReplaySource`
 catches that only when `phases[idx].type` happens not to match the emitted
 `phase_type`. No `Resources/DemoPresets/` preset uses one today; four bundled
 presets do (`word_wolf{,_en}`, `target_score_race{,_en}`), so promoting one
-needs #1473's branch-aware derivation, not just a re-capture.
+needs #1505 first.
+
+#1473 fixed the same derivation on the highlight side and deliberately stopped
+there: that schema's `phase_index` names a position in a FLATTENED list, so
+branch-awareness was a derivation fix into a coordinate system that already
+existed. Here the schema says top-level, and what a branch sub-phase should
+record is undesigned — a schema decision, not a derivation bug. Do not port
+`gallery_highlight_extract.annotate`'s resolver across without settling that.
 
 Recapture workflow (full demo-set swap):
   1. Run each scenario N times through the harness:

--- a/scripts/tests/gallery-highlight-test.sh
+++ b/scripts/tests/gallery-highlight-test.sh
@@ -928,6 +928,26 @@ mk_run_cond2() {
 JSONL
 }
 
+# A RETRIED run: attempt 1 takes ELSE, attempt 2 restarts round numbering and
+# takes THEN. Only the final attempt is pickable (`build_excerpt`'s max_attempt
+# rule), so the pick at line 11 belongs to attempt 2.
+mk_run_cond_retry() {
+  cat > "$2" <<'JSONL'
+{"type":"run_start","run_id":"run-1","date":"2026-08-05","scenario_id":"cond_v1","scenario_name":"T","language":"ja","model":"Gemma 4 E2B (Q4_K_M)","timeout_sec":900,"estimated_inferences":12}
+{"type":"event","t":0.1,"attempt":1,"event":"round_started","round":1,"total_rounds":2}
+{"type":"event","t":0.2,"attempt":1,"event":"phase_started","phase_type":"conditional","phase_path":[0]}
+{"type":"event","t":0.3,"attempt":1,"event":"conditional_evaluated","condition":"current_round == total_rounds","result":false}
+{"type":"event","t":0.4,"attempt":1,"event":"phase_started","phase_type":"speak_all","phase_path":[0,0]}
+{"type":"event","t":0.5,"attempt":1,"event":"agent_output","agent":"アヤ","phase_type":"speak_all","fields":{"statement":"一回目の試行。"}}
+{"type":"event","t":0.6,"attempt":2,"event":"round_started","round":1,"total_rounds":2}
+{"type":"event","t":0.7,"attempt":2,"event":"phase_started","phase_type":"conditional","phase_path":[0]}
+{"type":"event","t":0.8,"attempt":2,"event":"conditional_evaluated","condition":"current_round == total_rounds","result":true}
+{"type":"event","t":0.9,"attempt":2,"event":"phase_started","phase_type":"speak_all","phase_path":[0,0]}
+{"type":"event","t":1.0,"attempt":2,"event":"agent_output","agent":"アヤ","phase_type":"speak_all","fields":{"statement":"二回目の試行。"}}
+{"type":"event","t":1.1,"attempt":2,"event":"run_end","run_id":"run-1","status":"ok","attempts":2,"duration_sec":9.0}
+JSONL
+}
+
 mk_selection_cond() {  # repo path
   cat > "$2" <<'JSON'
 {
@@ -1285,12 +1305,12 @@ runc "$R" python3 scripts/gallery_highlight_extract.py --run run.jsonl --id cond
 expect_fail "C3c a branch position the YAML does not have is refused"
 expect_out "which has 4 phase(s)" "C3c names the branch's real length"
 
-# C3d — the branch verdict does not survive a round boundary. Round 1 takes
-# ELSE and round 2 takes THEN through the IDENTICAL `phase_path` [0,0], so a
-# resolver that kept the previous round's verdict would silently place round 2's
-# utterance in the else branch (index 5) instead of the then branch (index 1).
-# Nothing else in this suite has two rounds, so without this arm the per-round
-# reset is unasserted.
+# C3d — accept direction across a round boundary: round 1 takes ELSE and round 2
+# takes THEN through the IDENTICAL `phase_path` [0,0], and both resolve to their
+# own branch's index. It is NOT the arm for the per-round reset — measured: with
+# `pending_branch = None` removed, this fixture still yields "5\t1", because
+# round 2's own `conditional_evaluated` overwrites the stale verdict before the
+# branch `phase_started` is read. C3e below is the discriminator.
 R="$(new_repo)"; init_index "$R"
 mk_scenario_tree "$R" cond_v1 "$TREE_HISSATSU" 4
 mk_run_cond2 "$R" "$R/run.jsonl"
@@ -1307,10 +1327,11 @@ expect_ok "C3d the extractor accepts a two-round conditional run"
 runc "$R" jq -r '[.excerpt[].phase_index] | @tsv' docs/gallery/highlights/cond_v1.json
 expect_eq "5	1" "C3d round 1 resolves to else and round 2 to then, same phase_path"
 
-# C3e — and when round 2's `conditional_evaluated` is missing, the run dies
-# rather than reusing round 1's verdict. Distinct from C3c: there a conditional
-# was NEVER evaluated, so a resolver with no reset would fail anyway. Here one
-# was, which is what makes this the discriminating case.
+# C3e — the per-round reset's only asserter. When round 2's
+# `conditional_evaluated` is missing, the run dies rather than reusing round 1's
+# verdict. Distinct from C3c: there a conditional was NEVER evaluated, so a
+# resolver with no reset would fail anyway. Here one was — which is what makes
+# this the case that reddens when the reset is removed.
 R="$(new_repo)"; init_index "$R"
 mk_scenario_tree "$R" cond_v1 "$TREE_HISSATSU" 4
 mk_run_cond2 "$R" "$R/run.jsonl"
@@ -1327,6 +1348,44 @@ PY
 runc "$R" python3 scripts/gallery_highlight_extract.py --run run.jsonl --id cond_v1 --selection sel.json
 expect_fail "C3e a round whose conditional_evaluated is missing is refused"
 expect_out "branch unattributed" "C3e refuses rather than reusing the previous round's branch"
+
+# C3g — the same reset across an ATTEMPT boundary, which the resolver's
+# docstring asserts and nothing else exercises. A retried run appends attempt 2
+# to the same file and restarts round numbering; only the final attempt is
+# pickable. Attempt 1 took ELSE, attempt 2 takes THEN, and the pick resolves to
+# the then branch — then, with attempt 2's `conditional_evaluated` deleted, dies
+# rather than inheriting attempt 1's verdict. As with C3d/C3e, only the second
+# sub-arm discriminates: attempt 2's own verdict overwrites the stale one, so
+# the accept direction passes with or without the reset.
+R="$(new_repo)"; init_index "$R"
+mk_scenario_tree "$R" cond_v1 "$TREE_HISSATSU" 2
+mk_run_cond_retry "$R" "$R/run.jsonl"
+cat > "$R/sel.json" <<'JSON'
+{
+  "picks": [11],
+  "yaml_hook": { "kind": "raw", "fragment": "phases:\n  - type: conditional", "caption": "この一行が分岐を生む" },
+  "teaser": "最後の一言は、まだ言われていない。"
+}
+JSON
+runc "$R" python3 scripts/gallery_highlight_extract.py --run run.jsonl --id cond_v1 \
+  --selection sel.json --generated-at 2026-08-05
+expect_ok "C3g the extractor accepts a retried conditional run"
+runc "$R" jq -r '.excerpt[0].phase_index' docs/gallery/highlights/cond_v1.json
+expect_eq "1" "C3g the final attempt resolves to its own branch"
+
+mk_run_cond_retry "$R" "$R/run.jsonl"
+python3 - "$R" <<'PY'
+import io, sys
+p = sys.argv[1] + "/run.jsonl"
+lines = io.open(p, encoding="utf-8").read().splitlines()
+hits = [i for i, l in enumerate(lines) if '"result":true' in l]
+assert len(hits) == 1, f"anchor matched {len(hits)} lines — probe invalid"
+del lines[hits[0]]
+io.open(p, "w", encoding="utf-8").write("\n".join(lines) + "\n")
+PY
+runc "$R" python3 scripts/gallery_highlight_extract.py --run run.jsonl --id cond_v1 --selection sel.json
+expect_fail "C3g an attempt whose conditional_evaluated is missing is refused"
+expect_out "branch unattributed" "C3g refuses rather than inheriting attempt 1's branch"
 
 # C3f — a non-integer `phase_path` element is refused. Python treats `True` as
 # 1, so without the guard a bool silently names a phase the run never entered.
@@ -1459,11 +1518,18 @@ expect_out "highlight: round window" "C8 names the round window"
 #     emptiness reddens whenever a developer runs the suite mid-work on a
 #     highlight-ADDING PR (staged entries under that path) — the very PR shape
 #     that most needs this arm.
-#   - `check_highlights` is a documented no-op when the repo carries no
-#     highlights (check-gallery-entry.sh, and H0 above covers that path), so a
-#     glob regression that stopped finding them would leave the gate arm green.
-#     Count them first, or this measures nothing.
-HL_COUNT="$(find "$REAL_ROOT/docs/gallery/highlights" -name '*.json' | wc -l | tr -d ' ')"
+#   - `check_highlights` is a documented no-op when the repo has neither a
+#     highlights/ directory nor a paired index field (check-gallery-entry.sh;
+#     H0 above covers that path deliberately), so if the directory ever went
+#     missing the gate arm below would pass having checked nothing. Count first.
+#     The `-d` test is not decoration: under this file's `set -euo pipefail` a
+#     `find` on a missing directory exits non-zero and would abort the suite
+#     before reaching the `bad` branch written for exactly that case.
+if [ -d "$REAL_ROOT/docs/gallery/highlights" ]; then
+  HL_COUNT="$(find "$REAL_ROOT/docs/gallery/highlights" -name '*.json' | wc -l | tr -d ' ')"
+else
+  HL_COUNT=0
+fi
 if [ "$HL_COUNT" -gt 0 ]; then PASS=$((PASS + 1)); else
   bad "C9 the repo carries no shipped highlights, so the gate arm below is vacuous"
 fi

--- a/scripts/tests/gallery-highlight-test.sh
+++ b/scripts/tests/gallery-highlight-test.sh
@@ -52,6 +52,10 @@ expect_out()  { case "$OUT" in *"$1"*) PASS=$((PASS + 1));; *) bad "$2 (missing 
 # on 10 or on an error string containing a 1 — a substring match cannot assert
 # that a derived number is the RIGHT number.
 expect_eq()   { if [ "$OUT" = "$1" ]; then PASS=$((PASS + 1)); else bad "$2 (expected '$1', got '$OUT')"; fi; }
+# Asserts a message is ABSENT. Only meaningful next to an arm that proves the
+# same run reddens for something else — on its own it also "passes" when the
+# tool never ran at all.
+expect_no_out() { case "$OUT" in *"$1"*) bad "$2 (unexpected '$1'): $OUT";; *) PASS=$((PASS + 1));; esac; }
 
 # --- Scaffold --------------------------------------------------------------
 
@@ -138,6 +142,72 @@ YAML
   s="$(sha "$d/docs/gallery/$id.yaml")"
   jq --arg id "$id" --arg sha "$s" --argjson phases "$phases" \
      --argjson rounds "$rounds" \
+     '.scenarios += [{id: $id, title: ("T " + $id), rounds: $rounds,
+                      phases: $phases, language: "ja",
+                      yaml_url: ($id + ".yaml"), yaml_sha256: $sha}]' \
+     "$d/docs/gallery/gallery.json" > "$d/docs/gallery/gallery.json.tmp"
+  mv "$d/docs/gallery/gallery.json.tmp" "$d/docs/gallery/gallery.json"
+}
+
+# mk_scenario_tree <repo> <id> <tree-json> [rounds] [extra-personas]
+# Like mk_scenario, but `tree-json` mirrors the YAML `phases:` shape so a
+# `conditional`'s branches are real:
+#   '[{"type":"speak_each"},
+#     {"type":"conditional","then":[{"type":"summarize"}],
+#                           "else":[{"type":"speak_each"},{"type":"summarize"}]}]'
+# mk_scenario cannot express this — it writes `- type: X` lines only, so its
+# `conditional` has no branches at all and every branch-aware arm would be
+# measuring the empty case.
+#
+# The `phases` it denormalizes into gallery.json is flattened depth-first, the
+# order add-gallery-entry.sh's `flat()` writes. That copy is deliberate: a
+# fixture must be a known-good pair by construction, or a `flat()` regression
+# would redden every arm here instead of the one that measures it (T1).
+mk_scenario_tree() {
+  local d="$1" id="$2" tree="$3" rounds="${4:-4}" extra_personas="${5:-}"
+  cat > "$d/docs/gallery/$id.yaml" <<YAML
+id: $id
+language: ja
+name: Name of $id
+agents: 3
+rounds: $rounds
+description: card description
+personas:
+  - name: アヤ
+    description: aa
+YAML
+  if [ -n "$extra_personas" ]; then
+    printf '%b\n' "$extra_personas" >> "$d/docs/gallery/$id.yaml"
+  fi
+  local flat
+  flat="$(python3 - "$tree" "$d/docs/gallery/$id.yaml" <<'PY'
+import json, sys
+tree = json.loads(sys.argv[1])
+lines = []
+def emit(ps, ind):
+    for p in ps:
+        lines.append("%s- type: %s" % (" " * ind, p["type"]))
+        for br in ("then", "else"):
+            if br in p:
+                lines.append("%s  %s:" % (" " * ind, br))
+                emit(p[br], ind + 4)
+emit(tree, 2)
+with open(sys.argv[2], "a", encoding="utf-8") as f:
+    f.write("phases:\n" + "\n".join(lines) + "\n")
+def flat(ps):
+    out = []
+    for p in ps:
+        out.append(p["type"])
+        if p["type"] == "conditional":
+            for br in ("then", "else"):
+                out += flat(p.get(br) or [])
+    return out
+print(json.dumps(flat(tree)))
+PY
+)"
+  local s
+  s="$(sha "$d/docs/gallery/$id.yaml")"
+  jq --arg id "$id" --arg sha "$s" --argjson phases "$flat" --argjson rounds "$rounds" \
      '.scenarios += [{id: $id, title: ("T " + $id), rounds: $rounds,
                       phases: $phases, language: "ja",
                       yaml_url: ($id + ".yaml"), yaml_sha256: $sha}]' \
@@ -1110,6 +1180,94 @@ jq '.scenarios |= map(if .id == "cond_v1" then .phases = ["speak_each","summariz
 mk_highlight "$R" cond_v1 "$EX_OK"; link_highlight "$R" cond_v1
 gate "$R"; expect_fail "C5 a drifted phases list cannot disable the refusal"
 expect_out "sibling scenario YAML" "C5 names the YAML as the source that caught it"
+
+# --- phase tree: flattening + gallery.json cross-check (#1473) -------------
+#
+# `gallery.json`'s `phases` is denormalized, and every check stated in terms of
+# `phase_index` reads it. Three implementations of the flattening exist —
+# add-gallery-entry.sh's `flat()` (which WRITES the field),
+# GallerySeedYAMLTests.flattenPhaseKinds (Swift), and
+# gallery_highlight_validate.flatten_phase_tree (which re-derives it here).
+#
+# T1 asserts the first against the third by running the REAL add-gallery-entry.sh.
+# The Swift copy cannot be asserted here: this suite runs in the ubuntu
+# `shell-tests` job with no Swift toolchain. It is pinned transitively instead —
+# `galleryPhasesMatchYAML` compares it against the same `gallery.json` field T1
+# compares against, so a divergence in any one of the three reddens somewhere.
+
+TREE_NESTED='[{"type":"speak_each"},{"type":"conditional","then":[{"type":"summarize"}],"else":[{"type":"speak_all"},{"type":"summarize"}]}]'
+
+# T1 — add-gallery-entry.sh's `flat()` and flatten_phase_tree agree on a nested
+# scenario. Asymmetric branches (1 vs 2) on purpose: with equal-length branches
+# a walker that ignored the then-branch length would still land on the right
+# index, so the arm would pass while measuring nothing.
+R="$(new_repo)"; init_index "$R"
+mk_scenario_tree "$R" tree_v1 "$TREE_NESTED"
+cp "$SRC_SCRIPTS/add-gallery-entry.sh" "$R/scripts/"
+# Drop the fixture's own entry so the real script writes `phases` from scratch.
+jq '.scenarios = []' "$R/docs/gallery/gallery.json" > "$R/t" && mv "$R/t" "$R/docs/gallery/gallery.json"
+runc "$R" bash scripts/add-gallery-entry.sh docs/gallery/tree_v1.yaml --non-interactive \
+  --category creative --description "card" --author tester \
+  --recommended-model gemma-4-e2b-q4-k-m --estimated-inferences 8
+expect_ok "T1 add-gallery-entry.sh accepts a nested-conditional scenario"
+runc "$R" python3 -c '
+import json, sys
+sys.path.insert(0, "scripts")
+import gallery_highlight_validate as ghv
+nodes, reason = ghv.flatten_phase_tree(ghv._read_scenario("docs/gallery/tree_v1.yaml"))
+assert nodes is not None, reason
+written = json.load(open("docs/gallery/gallery.json"))["scenarios"][0]["phases"]
+print("agree" if [n.type for n in nodes] == written else
+      "DIVERGE %r != %r" % ([n.type for n in nodes], written))'
+expect_eq "agree" "T1 flatten_phase_tree matches the phases add-gallery-entry.sh wrote"
+
+# T2 — a `phases` list that drifted from its YAML is caught at the gate. This is
+# the property C5 measured through the conditional refusal; it now has its own
+# check, so it survives the refusal being lifted.
+R="$(new_repo)"; init_index "$R"
+mk_scenario_tree "$R" tree_v1 "$TREE_NESTED"
+jq '.scenarios |= map(if .id == "tree_v1" then .phases = ["speak_each","summarize"] else . end)' \
+  "$R/docs/gallery/gallery.json" > "$R/t" && mv "$R/t" "$R/docs/gallery/gallery.json"
+mk_highlight "$R" tree_v1 "$EX_OK"; link_highlight "$R" tree_v1
+gate "$R"; expect_fail "T2 a drifted phases list fails the tree cross-check"
+expect_out "highlight: phase tree" "T2 names the tree check"
+expect_out "the sibling scenario YAML flattens to" \
+  "T2 names the YAML as the source that caught it"
+
+# T3 — control for T2: the same fixture undrifted does NOT emit the tree message.
+# `gate` still reddens here (the conditional refusal is a separate check), so
+# expect_fail is the honest assertion and expect_no_out is what discriminates.
+R="$(new_repo)"; init_index "$R"
+mk_scenario_tree "$R" tree_v1 "$TREE_NESTED"
+mk_highlight "$R" tree_v1 "$EX_OK"; link_highlight "$R" tree_v1
+gate "$R"; expect_no_out "highlight: phase tree" "T3 an undrifted phases list clears the tree check"
+
+# T4 — shapes the engine refuses are refused here too, so no fixture the loader
+# would reject can reach the position rule. One probe, with its own positive
+# control: a well-formed tree must still resolve, or a flattener broken outright
+# would "pass" both rejection arms.
+runc "$REAL_ROOT" python3 -c '
+import sys
+sys.path.insert(0, "scripts")
+import gallery_highlight_validate as ghv
+
+def reason(doc):
+    nodes, why = ghv.flatten_phase_tree(doc)
+    return "OK/%d" % len(nodes) if nodes is not None else why
+
+# positive control — a legal one-branch conditional resolves (3 nodes)
+print(reason({"phases": [{"type": "conditional", "else": [{"type": "speak_all"}]},
+                         {"type": "summarize"}]}))
+# neither branch populated (ScenarioValidator requires at least one)
+print(reason({"phases": [{"type": "conditional"}]}))
+print(reason({"phases": [{"type": "conditional", "then": [], "else": []}]}))
+# nested conditional (the depth-1 rule)
+print(reason({"phases": [{"type": "conditional",
+                          "then": [{"type": "conditional",
+                                    "then": [{"type": "speak_all"}]}]}]}))'
+expect_out "OK/3" "T4 control: a legal one-branch conditional flattens"
+expect_out "populates neither" "T4 a branchless conditional is refused"
+expect_out "depth-1 rule" "T4 a nested conditional is refused"
 
 echo "gallery-highlight-test: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/scripts/tests/gallery-highlight-test.sh
+++ b/scripts/tests/gallery-highlight-test.sh
@@ -1424,13 +1424,14 @@ expect_out "highlight: phase tree" "T2 names the tree check"
 expect_out "the sibling scenario YAML flattens to" \
   "T2 names the YAML as the source that caught it"
 
-# T3 — control for T2: the same fixture undrifted does NOT emit the tree message.
-# `gate` still reddens here (the conditional refusal is a separate check), so
-# expect_fail is the honest assertion and expect_no_out is what discriminates.
+# T3 — control for T2: the same fixture undrifted passes outright. Keeping the
+# expect_no_out alongside expect_ok is not redundant — it is what still
+# discriminates if some unrelated check starts reddening this fixture.
 R="$(new_repo)"; init_index "$R"
 mk_scenario_tree "$R" tree_v1 "$TREE_NESTED"
 mk_highlight "$R" tree_v1 "$EX_OK"; link_highlight "$R" tree_v1
-gate "$R"; expect_no_out "highlight: phase tree" "T3 an undrifted phases list clears the tree check"
+gate "$R"; expect_ok "T3 an undrifted nested scenario passes the gate"
+expect_no_out "highlight: phase tree" "T3 an undrifted phases list clears the tree check"
 
 # T4 — shapes the engine refuses are refused here too, so no fixture the loader
 # would reject can reach the position rule. One probe, with its own positive

--- a/scripts/tests/gallery-highlight-test.sh
+++ b/scripts/tests/gallery-highlight-test.sh
@@ -10,7 +10,9 @@
 # <tmp>/scripts/, a minimal docs/gallery/ + a fixture ContentBlocklist.json,
 # `git init`) and runs the tools from inside it. check-gallery-entry.sh
 # resolves its root via `git rev-parse --show-toplevel`, so the real
-# docs/gallery/ is never touched and cases are parallel-safe.
+# docs/gallery/ is never touched and cases are parallel-safe. Two arms are
+# deliberate exceptions and run against $REAL_ROOT, both read-only: C9 (the
+# shipped-highlight regression) and T4 (a pure-function probe).
 #
 # CI-wired via the `scripts/tests/*-test.sh` naming convention (the
 # `shell-tests` job, ubuntu / bash 5+). The scripts under test also ship to
@@ -909,6 +911,23 @@ mk_run_cond() {
 JSONL
 }
 
+mk_run_cond2() {
+  cat > "$2" <<'JSONL'
+{"type":"run_start","run_id":"run-1","date":"2026-08-05","scenario_id":"cond_v1","scenario_name":"T","language":"ja","model":"Gemma 4 E2B (Q4_K_M)","timeout_sec":900,"estimated_inferences":12}
+{"type":"event","t":0.1,"attempt":1,"event":"round_started","round":1,"total_rounds":4}
+{"type":"event","t":0.2,"attempt":1,"event":"phase_started","phase_type":"conditional","phase_path":[0]}
+{"type":"event","t":0.3,"attempt":1,"event":"conditional_evaluated","condition":"current_round == total_rounds","result":false}
+{"type":"event","t":0.4,"attempt":1,"event":"phase_started","phase_type":"speak_all","phase_path":[0,0]}
+{"type":"event","t":0.5,"attempt":1,"event":"agent_output","agent":"アヤ","phase_type":"speak_all","fields":{"statement":"一周目の発言。"}}
+{"type":"event","t":0.6,"attempt":1,"event":"round_started","round":2,"total_rounds":4}
+{"type":"event","t":0.7,"attempt":1,"event":"phase_started","phase_type":"conditional","phase_path":[0]}
+{"type":"event","t":0.8,"attempt":1,"event":"conditional_evaluated","condition":"current_round == total_rounds","result":true}
+{"type":"event","t":0.9,"attempt":1,"event":"phase_started","phase_type":"speak_all","phase_path":[0,0]}
+{"type":"event","t":1.0,"attempt":1,"event":"agent_output","agent":"アヤ","phase_type":"speak_all","fields":{"statement":"二周目の発言。"}}
+{"type":"event","t":1.1,"attempt":1,"event":"run_end","run_id":"run-1","status":"ok","attempts":1,"duration_sec":9.0}
+JSONL
+}
+
 mk_selection_cond() {  # repo path
   cat > "$2" <<'JSON'
 {
@@ -1146,7 +1165,10 @@ expect_out "Pass --model with the registry id" "E15 names the escape hatch"
 #
 # The rule lives in `_check_position`, which `check_content` dispatches for BOTH
 # the gate and the extractor — so it is asserted on both, not on whichever one
-# happens to be convenient.
+# happens to be convenient. Read that precisely: post-lift the extractor side is
+# asserted in the ACCEPT direction (C3) plus its transcript-level refusals
+# (C3c), while the branch-aware REJECTIONS are gate-side. E3 is what keeps the
+# shared dispatch pinned on the extractor.
 #
 # Every arm here needs a REAL `then:`/`else:` tree, so they use mk_scenario_tree.
 # mk_scenario cannot nest: it writes `- type: X` lines only, which is why the
@@ -1171,8 +1193,10 @@ mk_scenario_tree "$R" cond_v1 "$TREE_HISSATSU" 2
 mk_highlight "$R" cond_v1 "$EX_ELSE_BRANCH"; link_highlight "$R" cond_v1
 gate "$R"; expect_ok "C1 an else-branch pick passes on a conditional-only scenario"
 
-# C2 — control: the same fixture without any conditional still passes. Without
-# it, C1 would also pass if the position rule had stopped rejecting anything.
+# C2 — control: a scenario with no conditional at all still passes, so C1's
+# green means "this branch is sound", not "the rule now rejects every scenario".
+# (It is NOT the fail-open control — C1 and C2 are both expect_ok. What guards
+# against a rule that stopped rejecting anything is C6/C7/C8.)
 R="$(new_repo)"; init_index "$R"
 mk_scenario "$R" cond_v1 '["speak_each","summarize"]'
 mk_highlight "$R" cond_v1 "$EX_OK"; link_highlight "$R" cond_v1
@@ -1261,6 +1285,68 @@ runc "$R" python3 scripts/gallery_highlight_extract.py --run run.jsonl --id cond
 expect_fail "C3c a branch position the YAML does not have is refused"
 expect_out "which has 4 phase(s)" "C3c names the branch's real length"
 
+# C3d — the branch verdict does not survive a round boundary. Round 1 takes
+# ELSE and round 2 takes THEN through the IDENTICAL `phase_path` [0,0], so a
+# resolver that kept the previous round's verdict would silently place round 2's
+# utterance in the else branch (index 5) instead of the then branch (index 1).
+# Nothing else in this suite has two rounds, so without this arm the per-round
+# reset is unasserted.
+R="$(new_repo)"; init_index "$R"
+mk_scenario_tree "$R" cond_v1 "$TREE_HISSATSU" 4
+mk_run_cond2 "$R" "$R/run.jsonl"
+cat > "$R/sel.json" <<'JSON'
+{
+  "picks": [6, 11],
+  "yaml_hook": { "kind": "raw", "fragment": "phases:\n  - type: conditional", "caption": "この一行が分岐を生む" },
+  "teaser": "最後の一言は、まだ言われていない。"
+}
+JSON
+runc "$R" python3 scripts/gallery_highlight_extract.py --run run.jsonl --id cond_v1 \
+  --selection sel.json --generated-at 2026-08-05
+expect_ok "C3d the extractor accepts a two-round conditional run"
+runc "$R" jq -r '[.excerpt[].phase_index] | @tsv' docs/gallery/highlights/cond_v1.json
+expect_eq "5	1" "C3d round 1 resolves to else and round 2 to then, same phase_path"
+
+# C3e — and when round 2's `conditional_evaluated` is missing, the run dies
+# rather than reusing round 1's verdict. Distinct from C3c: there a conditional
+# was NEVER evaluated, so a resolver with no reset would fail anyway. Here one
+# was, which is what makes this the discriminating case.
+R="$(new_repo)"; init_index "$R"
+mk_scenario_tree "$R" cond_v1 "$TREE_HISSATSU" 4
+mk_run_cond2 "$R" "$R/run.jsonl"
+mk_selection_cond "$R" "$R/sel.json"
+python3 - "$R" <<'PY'
+import io, sys
+p = sys.argv[1] + "/run.jsonl"
+lines = io.open(p, encoding="utf-8").read().splitlines()
+hits = [i for i, l in enumerate(lines) if '"result":true' in l]
+assert len(hits) == 1, f"anchor matched {len(hits)} lines — probe invalid"
+del lines[hits[0]]
+io.open(p, "w", encoding="utf-8").write("\n".join(lines) + "\n")
+PY
+runc "$R" python3 scripts/gallery_highlight_extract.py --run run.jsonl --id cond_v1 --selection sel.json
+expect_fail "C3e a round whose conditional_evaluated is missing is refused"
+expect_out "branch unattributed" "C3e refuses rather than reusing the previous round's branch"
+
+# C3f — a non-integer `phase_path` element is refused. Python treats `True` as
+# 1, so without the guard a bool silently names a phase the run never entered.
+# Unreachable from the Swift harness ([Int]), asserted because nothing else in
+# this resolver invents a coordinate either.
+R="$(new_repo)"; init_index "$R"
+mk_scenario_tree "$R" cond_v1 "$TREE_HISSATSU" 2
+mk_run_cond "$R" "$R/run.jsonl"; mk_selection_cond "$R" "$R/sel.json"
+python3 - "$R" <<'PY'
+import io, sys
+p = sys.argv[1] + "/run.jsonl"
+text = io.open(p, encoding="utf-8").read()
+old = '"phase_path":[0,0]'
+assert text.count(old) == 1, f"anchor matched {text.count(old)} times — probe invalid"
+io.open(p, "w", encoding="utf-8").write(text.replace(old, '"phase_path":[0,true]'))
+PY
+runc "$R" python3 scripts/gallery_highlight_extract.py --run run.jsonl --id cond_v1 --selection sel.json
+expect_fail "C3f a non-integer phase_path element is refused"
+expect_out "non-integer element" "C3f names the element type, not a downstream mismatch"
+
 # C4 — a `phase_started` with no `phase_path` is refused rather than defaulted
 # to top-level index 0. The earlier `or [0]` fallback asserted a position the
 # transcript never stated, and every downstream check read it as measured.
@@ -1306,6 +1392,11 @@ repin_yaml "$R" cond_v1
 mk_highlight "$R" cond_v1 "$EX_ELSE_BRANCH"; link_highlight "$R" cond_v1
 gate "$R"; expect_fail "C5 an underivable tree refuses a conditional entry"
 expect_out "branch structure is unavailable" "C5 names the residue, not the lifted class refusal"
+# The residue fires for a None tree AND for a tree that disagrees with `phases`
+# (the `reason or ...` fallback). Pin which one, or a regression that made
+# flatten_phase_tree ACCEPT the nested conditional would keep this arm green:
+# the derived tree would then merely disagree with the untouched `phases`.
+expect_out "nests a \`conditional\` at" "C5 fired on the underivable tree, not on drift"
 
 # C6 — negative control: a pick genuinely preceded by an outcome phase INSIDE
 # its own branch is still rejected. Without this, C1 would be satisfied by a
@@ -1319,7 +1410,7 @@ mk_highlight "$R" cond_v1 \
   '[{"agent":"アヤ","round":1,"phase":"speak_all","phase_index":3,"source_field":"statement","text":"私はBだと思う。"}]'
 link_highlight "$R" cond_v1
 gate "$R"; expect_fail "C6 an in-branch pick after an outcome phase is rejected"
-expect_out "within-round bound" "C6 names the position rule"
+expect_out "highlight: within-round bound" "C6 names the position rule"
 # C6b — control on the SAME tree: the sibling branch's pick, whose own preceding
 # set is empty, passes. This is what shows C6 measured the branch and not the
 # scenario.
@@ -1341,7 +1432,7 @@ mk_highlight "$R" cond_v1 \
   '[{"agent":"アヤ","round":1,"phase":"speak_each","phase_index":3,"source_field":"statement","text":"私はBだと思う。"}]'
 link_highlight "$R" cond_v1
 gate "$R"; expect_fail "C7 a pick after a conditional sees the non-taken branch's outcome phase"
-expect_out "within-round bound" "C7 names the position rule"
+expect_out "highlight: within-round bound" "C7 names the position rule"
 # C7b — control: the same shape with no outcome phase in either branch passes,
 # so C7 reddens on the `vote` rather than on "sits after a conditional".
 TREE_AFTER_COND_CLEAN='[{"type":"conditional","then":[{"type":"speak_all"}],"else":[{"type":"speak_all"}]},{"type":"speak_each"}]'
@@ -1360,16 +1451,27 @@ mk_highlight "$R" cond_v1 \
   '[{"agent":"アヤ","round":2,"phase":"speak_all","phase_index":5,"source_field":"statement","text":"私はBだと思う。"}]'
 link_highlight "$R" cond_v1
 gate "$R"; expect_fail "C8 a late-round pick on a conditional entry hits the round window"
-expect_out "round window" "C8 names the round window"
+expect_out "highlight: round window" "C8 names the round window"
 
-# C9 — regression: the shipped highlights still validate. The gate rewrites
-# nothing, so the assertion is "zero failures AND the files are untouched" —
-# a `git status` check, because a gate that passed after silently normalising a
-# file would look identical here.
+# C9 — regression: the shipped highlights still validate and the gate rewrites
+# none of them. Two things this arm has to get right:
+#   - "byte-identical" is a BEFORE/AFTER comparison, not `== ""`. Asserting
+#     emptiness reddens whenever a developer runs the suite mid-work on a
+#     highlight-ADDING PR (staged entries under that path) — the very PR shape
+#     that most needs this arm.
+#   - `check_highlights` is a documented no-op when the repo carries no
+#     highlights (check-gallery-entry.sh, and H0 above covers that path), so a
+#     glob regression that stopped finding them would leave the gate arm green.
+#     Count them first, or this measures nothing.
+HL_COUNT="$(find "$REAL_ROOT/docs/gallery/highlights" -name '*.json' | wc -l | tr -d ' ')"
+if [ "$HL_COUNT" -gt 0 ]; then PASS=$((PASS + 1)); else
+  bad "C9 the repo carries no shipped highlights, so the gate arm below is vacuous"
+fi
+HL_STATUS_BEFORE="$(git -C "$REAL_ROOT" status --porcelain -- docs/gallery/highlights)"
 runc "$REAL_ROOT" bash scripts/check-gallery-entry.sh --all
-expect_ok "C9 the repo's own gallery still passes the gate"
+expect_ok "C9 the repo's own gallery still passes the gate ($HL_COUNT highlights)"
 runc "$REAL_ROOT" git status --porcelain -- docs/gallery/highlights
-expect_eq "" "C9 the gate left every shipped highlight byte-identical"
+expect_eq "$HL_STATUS_BEFORE" "C9 the gate rewrote no shipped highlight"
 
 # --- phase tree: flattening + gallery.json cross-check (#1473) -------------
 #
@@ -1404,7 +1506,9 @@ runc "$R" python3 -c '
 import json, sys
 sys.path.insert(0, "scripts")
 import gallery_highlight_validate as ghv
-nodes, reason = ghv.flatten_phase_tree(ghv._read_scenario("docs/gallery/tree_v1.yaml"))
+doc, read_reason = ghv._read_scenario("docs/gallery/tree_v1.yaml")
+assert doc is not None, read_reason
+nodes, reason = ghv.flatten_phase_tree(doc)
 assert nodes is not None, reason
 written = json.load(open("docs/gallery/gallery.json"))["scenarios"][0]["phases"]
 print("agree" if [n.type for n in nodes] == written else
@@ -1437,28 +1541,39 @@ expect_no_out "highlight: phase tree" "T3 an undrifted phases list clears the tr
 # would reject can reach the position rule. One probe, with its own positive
 # control: a well-formed tree must still resolve, or a flattener broken outright
 # would "pass" both rejection arms.
+# One `expect_eq` over a tag per case rather than three `expect_out`s: the two
+# branchless shapes emit a BYTE-IDENTICAL message, so a substring assertion
+# cannot tell which of them produced it and a regression in one would hide
+# behind the other. An unrecognised message tags as `other`, which fails too.
 runc "$REAL_ROOT" python3 -c '
 import sys
 sys.path.insert(0, "scripts")
 import gallery_highlight_validate as ghv
 
-def reason(doc):
+def tag(doc):
     nodes, why = ghv.flatten_phase_tree(doc)
-    return "OK/%d" % len(nodes) if nodes is not None else why
+    if nodes is not None:
+        return "OK/%d" % len(nodes)
+    if "populates neither" in why:
+        return "neither"
+    if "depth-1 rule" in why:
+        return "depth1"
+    return "other"
 
-# positive control — a legal one-branch conditional resolves (3 nodes)
-print(reason({"phases": [{"type": "conditional", "else": [{"type": "speak_all"}]},
-                         {"type": "summarize"}]}))
-# neither branch populated (ScenarioValidator requires at least one)
-print(reason({"phases": [{"type": "conditional"}]}))
-print(reason({"phases": [{"type": "conditional", "then": [], "else": []}]}))
-# nested conditional (the depth-1 rule)
-print(reason({"phases": [{"type": "conditional",
-                          "then": [{"type": "conditional",
-                                    "then": [{"type": "speak_all"}]}]}]}))'
-expect_out "OK/3" "T4 control: a legal one-branch conditional flattens"
-expect_out "populates neither" "T4 a branchless conditional is refused"
-expect_out "depth-1 rule" "T4 a nested conditional is refused"
+print("|".join([
+    # positive control — a legal one-branch conditional resolves (3 nodes)
+    tag({"phases": [{"type": "conditional", "else": [{"type": "speak_all"}]},
+                    {"type": "summarize"}]}),
+    # neither branch populated, two ways (ScenarioValidator requires one)
+    tag({"phases": [{"type": "conditional"}]}),
+    tag({"phases": [{"type": "conditional", "then": [], "else": []}]}),
+    # nested conditional (the depth-1 rule)
+    tag({"phases": [{"type": "conditional",
+                     "then": [{"type": "conditional",
+                               "then": [{"type": "speak_all"}]}]}]}),
+]))'
+expect_eq "OK/3|neither|neither|depth1" \
+  "T4 control flattens; both branchless shapes and the nested one are refused"
 
 echo "gallery-highlight-test: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/scripts/tests/gallery-highlight-test.sh
+++ b/scripts/tests/gallery-highlight-test.sh
@@ -1327,11 +1327,12 @@ expect_ok "C3d the extractor accepts a two-round conditional run"
 runc "$R" jq -r '[.excerpt[].phase_index] | @tsv' docs/gallery/highlights/cond_v1.json
 expect_eq "5	1" "C3d round 1 resolves to else and round 2 to then, same phase_path"
 
-# C3e — the per-round reset's only asserter. When round 2's
-# `conditional_evaluated` is missing, the run dies rather than reusing round 1's
-# verdict. Distinct from C3c: there a conditional was NEVER evaluated, so a
-# resolver with no reset would fail anyway. Here one was — which is what makes
-# this the case that reddens when the reset is removed.
+# C3e — the reset on the ROUND axis (C3g covers the ATTEMPT axis; both redden on
+# the same `pending_branch = None` statement, so neither is the sole asserter).
+# When round 2's `conditional_evaluated` is missing, the run dies rather than
+# reusing round 1's verdict. Distinct from C3c: there a conditional was NEVER
+# evaluated, so a resolver with no reset would fail anyway. Here one was — which
+# is what makes this the case that reddens when the reset is removed.
 R="$(new_repo)"; init_index "$R"
 mk_scenario_tree "$R" cond_v1 "$TREE_HISSATSU" 4
 mk_run_cond2 "$R" "$R/run.jsonl"
@@ -1383,6 +1384,17 @@ assert len(hits) == 1, f"anchor matched {len(hits)} lines — probe invalid"
 del lines[hits[0]]
 io.open(p, "w", encoding="utf-8").write("\n".join(lines) + "\n")
 PY
+# Re-point the pick: deleting line 9 shifts the utterance from 11 to 10. Leaving
+# it at 11 would name `run_end`, and the arm would then pass on a pick-type error
+# whenever `annotate` stopped dying first. `expect_out` is what discriminates
+# here — `expect_fail` alone cannot tell a refusal from an unrelated failure.
+cat > "$R/sel.json" <<'JSON'
+{
+  "picks": [10],
+  "yaml_hook": { "kind": "raw", "fragment": "phases:\n  - type: conditional", "caption": "この一行が分岐を生む" },
+  "teaser": "最後の一言は、まだ言われていない。"
+}
+JSON
 runc "$R" python3 scripts/gallery_highlight_extract.py --run run.jsonl --id cond_v1 --selection sel.json
 expect_fail "C3g an attempt whose conditional_evaluated is missing is refused"
 expect_out "branch unattributed" "C3g refuses rather than inheriting attempt 1's branch"
@@ -1432,9 +1444,10 @@ expect_out "no usable \`phase_path\`" "C4 names the missing field"
 # says `conditional` never reaches the position rule on the YAML's silence.
 R="$(new_repo)"; init_index "$R"
 mk_scenario_tree "$R" cond_v1 "$TREE_HISSATSU" 2
-# Nest a conditional inside a branch — legal YAML, refused by the flattener
-# (and by ScenarioValidator), so the tree comes back None while `phases` is
-# untouched and still contains `conditional`.
+# Nest a conditional inside a branch — legal YAML, refused by the flattener (and
+# upstream by ScenarioLoader at parse time, not by ScenarioValidator: such a
+# file never loads), so the tree comes back None while `phases` is untouched and
+# still contains `conditional`.
 python3 - "$R" <<'PY'
 import io, sys
 p = sys.argv[1] + "/docs/gallery/cond_v1.yaml"
@@ -1518,10 +1531,12 @@ expect_out "highlight: round window" "C8 names the round window"
 #     emptiness reddens whenever a developer runs the suite mid-work on a
 #     highlight-ADDING PR (staged entries under that path) — the very PR shape
 #     that most needs this arm.
-#   - `check_highlights` is a documented no-op when the repo has neither a
-#     highlights/ directory nor a paired index field (check-gallery-entry.sh;
-#     H0 above covers that path deliberately), so if the directory ever went
-#     missing the gate arm below would pass having checked nothing. Count first.
+#   - `check_highlights` is a documented no-op only when BOTH are absent — no
+#     highlights/ directory AND no paired index field (check-gallery-entry.sh;
+#     H0 above covers that path deliberately). With the directory gone but
+#     `gallery.json` still carrying highlight_url, the validator runs and fails
+#     loudly; it is the both-gone case that would pass having checked nothing,
+#     and that is what the count guards. Count first.
 #     The `-d` test is not decoration: under this file's `set -euo pipefail` a
 #     `find` on a missing directory exits non-zero and would abort the suite
 #     before reaching the `bad` branch written for exactly that case.

--- a/scripts/tests/gallery-highlight-test.sh
+++ b/scripts/tests/gallery-highlight-test.sh
@@ -158,8 +158,9 @@ YAML
 #     {"type":"conditional","then":[{"type":"summarize"}],
 #                           "else":[{"type":"speak_each"},{"type":"summarize"}]}]'
 # mk_scenario cannot express this — it writes `- type: X` lines only, so its
-# `conditional` has no branches at all and every branch-aware arm would be
-# measuring the empty case.
+# `conditional` carries no branches, a shape `flatten_phase_tree` refuses
+# outright (asserted by T4). Such a fixture never reaches the branch-aware
+# logic at all; it is rejected before it, not measured as an empty case.
 #
 # The `phases` it denormalizes into gallery.json is flattened depth-first, the
 # order add-gallery-entry.sh's `flat()` writes. That copy is deliberate: a
@@ -684,7 +685,8 @@ expect_out "persona_index must be an integer" "H26b names the persona_index sche
 # H26c/H26d — the SCHEMA `persona_index` guards (`isinstance(…, bool)` and
 # `< 0`), which H26/H26b do not reach. Measured: dropping either clause from
 # `_check_excerpt_shape` reddens the matching arm here. (`_check_persona_index`'s
-# own skip is not a guard — dropping it leaves the suite green.)
+# own skip additionally keeps a `null`/omitted index from raising TypeError
+# there — measured; it is not merely a de-duplicator.)
 #
 # `True` IS an `int` in Python, so the agent here is ケン at index 1: with the
 # schema clause gone, `persona_names[True]` resolves and PASSES, rather than
@@ -1203,8 +1205,9 @@ TREE_HISSATSU='[{"type":"conditional",
   "else":[{"type":"speak_all"},{"type":"vote"},{"type":"score_calc"},{"type":"summarize"}]}]'
 EX_ELSE_BRANCH='[{"agent":"アヤ","round":1,"phase":"speak_all","phase_index":5,"source_field":"statement","text":"私はBだと思う。"}]'
 
-# C1 — the acceptance criterion: an else-branch pick passes the gate. This is
-# the arm that discriminates the branch-aware rule from the flat one. Under
+# C1 — the acceptance criterion: an else-branch pick passes the gate. An arm
+# that discriminates the branch-aware rule from the flat one — C3 covers the
+# same property end-to-end through the extractor, and both redden together. Under
 # `phases[:5]` the prefix is [conditional, speak_all, vote, score_calc,
 # summarize] and the pick is rejected; under the tree the else branch's own
 # preceding set is empty and it is sound. No --window-override (round 1 ≤ 1).
@@ -1515,8 +1518,8 @@ mk_highlight "$R" cond_v1 \
 link_highlight "$R" cond_v1
 gate "$R"; expect_ok "C7b the same shape with clean branches passes"
 
-# C8 — the round-window arms now run for a conditional entry. The class refusal
-# returned before reaching them, so nothing has ever exercised this pairing.
+# C8 — the round-window arms run for a conditional entry, which no other arm
+# pairs with a branch-resolved `phase_index`.
 R="$(new_repo)"; init_index "$R"
 mk_scenario_tree "$R" cond_v1 "$TREE_HISSATSU" 2
 mk_highlight "$R" cond_v1 \
@@ -1536,7 +1539,10 @@ expect_out "highlight: round window" "C8 names the round window"
 #     H0 above covers that path deliberately). With the directory gone but
 #     `gallery.json` still carrying highlight_url, the validator runs and fails
 #     loudly; it is the both-gone case that would pass having checked nothing,
-#     and that is what the count guards. Count first.
+#     and that is what the count guards. Note the count asserts that highlight
+#     FILES exist, not that the validator examined an entry — files present with
+#     no paired `highlight_url` is caught by the orphan check (cf. H4), so
+#     non-vacuity rests on the count and `expect_ok` together. Count first.
 #     The `-d` test is not decoration: under this file's `set -euo pipefail` a
 #     `find` on a missing directory exits non-zero and would abort the suite
 #     before reaching the `bad` branch written for exactly that case.
@@ -1571,9 +1577,11 @@ expect_eq "$HL_STATUS_BEFORE" "C9 the gate rewrote no shipped highlight"
 TREE_NESTED='[{"type":"speak_each"},{"type":"conditional","then":[{"type":"summarize"}],"else":[{"type":"speak_all"},{"type":"summarize"}]}]'
 
 # T1 — add-gallery-entry.sh's `flat()` and flatten_phase_tree agree on a nested
-# scenario. Asymmetric branches (1 vs 2) on purpose: with equal-length branches
-# a walker that ignored the then-branch length would still land on the right
-# index, so the arm would pass while measuring nothing.
+# scenario. Asymmetric branches (1 vs 2) on purpose, and for branch ORDER rather
+# than index arithmetic: this arm compares type lists, so with equal-length
+# identical branches a then/else emission-order swap would produce byte-identical
+# lists and go unnoticed. Measured: swapping the order in `flat()` reddens T1
+# alone.
 R="$(new_repo)"; init_index "$R"
 mk_scenario_tree "$R" tree_v1 "$TREE_NESTED"
 cp "$SRC_SCRIPTS/add-gallery-entry.sh" "$R/scripts/"
@@ -1616,6 +1624,10 @@ R="$(new_repo)"; init_index "$R"
 mk_scenario_tree "$R" tree_v1 "$TREE_NESTED"
 mk_highlight "$R" tree_v1 "$EX_OK"; link_highlight "$R" tree_v1
 gate "$R"; expect_ok "T3 an undrifted nested scenario passes the gate"
+# Diagnostic, not a second discriminator: check-gallery-entry.sh surfaces the
+# validator's output only when it exits non-zero, so this string cannot appear
+# while the arm above is green. Its value is that when the fixture DOES redden,
+# a green line here says the tree check was not the cause.
 expect_no_out "highlight: phase tree" "T3 an undrifted phases list clears the tree check"
 
 # T4 — shapes the engine refuses are refused here too, so no fixture the loader

--- a/scripts/tests/gallery-highlight-test.sh
+++ b/scripts/tests/gallery-highlight-test.sh
@@ -1178,17 +1178,88 @@ mk_scenario "$R" cond_v1 '["speak_each","summarize"]'
 mk_highlight "$R" cond_v1 "$EX_OK"; link_highlight "$R" cond_v1
 gate "$R"; expect_ok 'C2 a flat scenario still passes'
 
-# C3 — the extractor's own derivation is NOT branch-aware yet: annotate() still
-# reads phase_path[0], so a branch utterance reports the conditional's top-level
-# index and the shared phase check catches the disagreement. Asserted rather
-# than left silent — this is precisely what the next commit replaces, and an
-# unasserted gap here would let a half-finished resolver look finished.
+# C3 — the acceptance criterion end-to-end: the extractor resolves a round-1
+# else-branch utterance to flattened index 5 and the gate accepts what it wrote,
+# with no --window-override. `expect_eq 5` rather than expect_out: a substring
+# match would also pass on 15, or on an error string containing a 5.
 R="$(new_repo)"; init_index "$R"
 mk_scenario_tree "$R" cond_v1 "$TREE_HISSATSU" 2
 mk_run_cond "$R" "$R/run.jsonl"; mk_selection_cond "$R" "$R/sel.json"
+runc "$R" python3 scripts/gallery_highlight_extract.py --run run.jsonl --id cond_v1 \
+  --selection sel.json --generated-at 2026-08-05
+expect_ok "C3 the extractor accepts a conditional scenario"
+runc "$R" jq -r '.excerpt[0].phase_index' docs/gallery/highlights/cond_v1.json
+expect_eq "5" "C3 resolves the else branch to its flattened index, not the conditional's 0"
+runc "$R" jq -r '.window_override' docs/gallery/highlights/cond_v1.json
+expect_eq "false" "C3 needs no window override"
+link_highlight "$R" cond_v1
+gate "$R"; expect_ok "C3 the extractor's own output passes the gate"
+
+# C3b — control on the SAME transcript: flip the condition to true and the
+# identical `phase_path` [0,0] must resolve to the THEN branch's index 1. This
+# is what shows C3 read the branch rather than a constant.
+R="$(new_repo)"; init_index "$R"
+mk_scenario_tree "$R" cond_v1 "$TREE_HISSATSU" 2
+mk_run_cond "$R" "$R/run.jsonl"; mk_selection_cond "$R" "$R/sel.json"
+python3 - "$R" <<'PY'
+import io, sys
+p = sys.argv[1] + "/run.jsonl"
+text = io.open(p, encoding="utf-8").read()
+old = '"event":"conditional_evaluated","condition":"current_round == total_rounds","result":false'
+assert text.count(old) == 1, f"anchor matched {text.count(old)} times — probe invalid"
+io.open(p, "w", encoding="utf-8").write(text.replace(old, old[:-5] + "true"))
+PY
+runc "$R" python3 scripts/gallery_highlight_extract.py --run run.jsonl --id cond_v1 \
+  --selection sel.json --generated-at 2026-08-05
+expect_ok "C3b the extractor accepts the then-branch run"
+runc "$R" jq -r '.excerpt[0].phase_index' docs/gallery/highlights/cond_v1.json
+expect_eq "1" "C3b the same phase_path resolves to the then branch"
+
+# C3c — the branch is what disambiguates `[i, j]`, so its absence is fatal
+# rather than guessed. Also the depth guard, and a path the pinned YAML cannot
+# place. One repo, three mutations of its transcript.
+R="$(new_repo)"; init_index "$R"
+mk_scenario_tree "$R" cond_v1 "$TREE_HISSATSU" 2
+mk_selection_cond "$R" "$R/sel.json"
+mk_run_cond "$R" "$R/run.jsonl"
+python3 - "$R" <<'PY'
+import io, sys
+p = sys.argv[1] + "/run.jsonl"
+text = io.open(p, encoding="utf-8").read()
+keep = [l for l in text.splitlines() if '"conditional_evaluated"' not in l]
+assert len(keep) == len(text.splitlines()) - 1, "probe removed the wrong number of lines"
+io.open(p, "w", encoding="utf-8").write("\n".join(keep) + "\n")
+PY
 runc "$R" python3 scripts/gallery_highlight_extract.py --run run.jsonl --id cond_v1 --selection sel.json
-expect_fail "C3 the extractor cannot yet derive a branch index"
-expect_out "phase_index mismatch" "C3 the shared phase check catches the top-level index"
+expect_fail "C3c a branch path with no conditional_evaluated is refused"
+expect_out "no \`conditional_evaluated\` for that conditional precedes" \
+  "C3c names the missing branch decision"
+
+mk_run_cond "$R" "$R/run.jsonl"
+python3 - "$R" <<'PY'
+import io, sys
+p = sys.argv[1] + "/run.jsonl"
+text = io.open(p, encoding="utf-8").read()
+old = '"phase_path":[0,0]'
+assert text.count(old) == 1, f"anchor matched {text.count(old)} times — probe invalid"
+io.open(p, "w", encoding="utf-8").write(text.replace(old, '"phase_path":[0,0,0]'))
+PY
+runc "$R" python3 scripts/gallery_highlight_extract.py --run run.jsonl --id cond_v1 --selection sel.json
+expect_fail "C3c a phase_path deeper than the depth-1 rule is refused"
+expect_out "depth-1 rule bounds it to 2" "C3c cites the upstream invariant"
+
+mk_run_cond "$R" "$R/run.jsonl"
+python3 - "$R" <<'PY'
+import io, sys
+p = sys.argv[1] + "/run.jsonl"
+text = io.open(p, encoding="utf-8").read()
+old = '"phase_path":[0,0]'
+assert text.count(old) == 1, f"anchor matched {text.count(old)} times — probe invalid"
+io.open(p, "w", encoding="utf-8").write(text.replace(old, '"phase_path":[0,9]'))
+PY
+runc "$R" python3 scripts/gallery_highlight_extract.py --run run.jsonl --id cond_v1 --selection sel.json
+expect_fail "C3c a branch position the YAML does not have is refused"
+expect_out "which has 4 phase(s)" "C3c names the branch's real length"
 
 # C4 — a `phase_started` with no `phase_path` is refused rather than defaulted
 # to top-level index 0. The earlier `or [0]` fallback asserted a position the
@@ -1290,6 +1361,15 @@ mk_highlight "$R" cond_v1 \
 link_highlight "$R" cond_v1
 gate "$R"; expect_fail "C8 a late-round pick on a conditional entry hits the round window"
 expect_out "round window" "C8 names the round window"
+
+# C9 — regression: the shipped highlights still validate. The gate rewrites
+# nothing, so the assertion is "zero failures AND the files are untouched" —
+# a `git status` check, because a gate that passed after silently normalising a
+# file would look identical here.
+runc "$REAL_ROOT" bash scripts/check-gallery-entry.sh --all
+expect_ok "C9 the repo's own gallery still passes the gate"
+runc "$REAL_ROOT" git status --porcelain -- docs/gallery/highlights
+expect_eq "" "C9 the gate left every shipped highlight byte-identical"
 
 # --- phase tree: flattening + gallery.json cross-check (#1473) -------------
 #

--- a/scripts/tests/gallery-highlight-test.sh
+++ b/scripts/tests/gallery-highlight-test.sh
@@ -892,6 +892,33 @@ mk_selection() {  # repo path
 JSON
 }
 
+# A run over TREE_HISSATSU: round 1 evaluates the condition false and takes the
+# ELSE branch, so its utterance's phase_path is [0, 0] with a `conditional_evaluated`
+# result of false in front of it. Shaped from a real harness transcript —
+# `conditional_evaluated` carries no phase_path of its own.
+mk_run_cond() {
+  cat > "$2" <<'JSONL'
+{"type":"run_start","run_id":"run-1","date":"2026-08-05","scenario_id":"cond_v1","scenario_name":"T","language":"ja","model":"Gemma 4 E2B (Q4_K_M)","timeout_sec":900,"estimated_inferences":12}
+{"type":"event","t":0.1,"attempt":1,"event":"round_started","round":1,"total_rounds":2}
+{"type":"event","t":0.2,"attempt":1,"event":"phase_started","phase_type":"conditional","phase_path":[0]}
+{"type":"event","t":0.3,"attempt":1,"event":"conditional_evaluated","condition":"current_round == total_rounds","result":false}
+{"type":"event","t":0.4,"attempt":1,"event":"phase_started","phase_type":"speak_all","phase_path":[0,0]}
+{"type":"event","t":0.5,"attempt":1,"event":"agent_output","agent":"アヤ","phase_type":"speak_all","fields":{"statement":"私はBだと思う。","inner_thought":"本当はCかも。"}}
+{"type":"event","t":0.6,"attempt":1,"event":"phase_started","phase_type":"vote","phase_path":[0,1]}
+{"type":"event","t":0.7,"attempt":1,"event":"run_end","run_id":"run-1","status":"ok","attempts":1,"duration_sec":9.0}
+JSONL
+}
+
+mk_selection_cond() {  # repo path
+  cat > "$2" <<'JSON'
+{
+  "picks": [6],
+  "yaml_hook": { "kind": "raw", "fragment": "phases:\n  - type: conditional", "caption": "この一行が分岐を生む" },
+  "teaser": "最後の一言は、まだ言われていない。"
+}
+JSON
+}
+
 # E1 — end-to-end: extractor writes a file the gate then accepts.
 R="$(new_repo)"; init_index "$R"; mk_scenario "$R" demo_v1 '["speak_each","summarize"]'
 mk_run "$R" "$R/run.jsonl"; mk_selection "$R" "$R/sel.json"
@@ -1115,44 +1142,58 @@ expect_out "Pass --model with the registry id" "E15 names the escape hatch"
 # lost its `^\s*` anchor. This is the control for that anchoring — an unrelated
 # string would be rejected under either anchor, i.e. would measure nothing.
 
-# --- conditional-scenario refusal (#1473) ---------------------------------
+# --- conditional scenarios: branch-aware position rule (#1473) -------------
 #
-# The refusal lives in `_check_position`, which `check_content` dispatches for
-# BOTH the gate and the extractor — so it is asserted on both, not on whichever
-# one happens to be convenient.
+# The rule lives in `_check_position`, which `check_content` dispatches for BOTH
+# the gate and the extractor — so it is asserted on both, not on whichever one
+# happens to be convenient.
 #
-# The fixture YAML writes `- type: conditional` with no `then:`/`else:` branch,
-# which a real scenario would never do. Deliberate: the check reads the entry's
-# flattened `phases`, never the tree, and mk_scenario cannot nest. An arm that
-# needs the tree belongs with #1473's branch-aware work, not here.
+# Every arm here needs a REAL `then:`/`else:` tree, so they use mk_scenario_tree.
+# mk_scenario cannot nest: it writes `- type: X` lines only, which is why the
+# refusal-era arms this block replaces used a branchless `conditional` — a shape
+# flatten_phase_tree now rejects outright (T4).
 
-# C1 — a conditional-bearing scenario is refused at the gate.
+# `hissatsu_naming_v1`'s real shape: the only top-level phase is a conditional
+# whose branches are identical. rounds=2 → window=1, and round 1 takes the ELSE
+# branch, so the sole eligible utterance sits at flattened index 5.
+TREE_HISSATSU='[{"type":"conditional",
+  "then":[{"type":"speak_all"},{"type":"vote"},{"type":"score_calc"},{"type":"summarize"}],
+  "else":[{"type":"speak_all"},{"type":"vote"},{"type":"score_calc"},{"type":"summarize"}]}]'
+EX_ELSE_BRANCH='[{"agent":"アヤ","round":1,"phase":"speak_all","phase_index":5,"source_field":"statement","text":"私はBだと思う。"}]'
+
+# C1 — the acceptance criterion: an else-branch pick passes the gate. This is
+# the arm that discriminates the branch-aware rule from the flat one. Under
+# `phases[:5]` the prefix is [conditional, speak_all, vote, score_calc,
+# summarize] and the pick is rejected; under the tree the else branch's own
+# preceding set is empty and it is sound. No --window-override (round 1 ≤ 1).
 R="$(new_repo)"; init_index "$R"
-mk_scenario "$R" cond_v1 '["speak_each","conditional","summarize"]'
-mk_highlight "$R" cond_v1 "$EX_OK"; link_highlight "$R" cond_v1
-gate "$R"; expect_fail "C1 gate refuses a conditional-bearing scenario"
-expect_out "highlight: conditional scenario" "C1 names the refused class"
-expect_out "#1473" "C1 points at the follow-up that lifts it"
+mk_scenario_tree "$R" cond_v1 "$TREE_HISSATSU" 2
+mk_highlight "$R" cond_v1 "$EX_ELSE_BRANCH"; link_highlight "$R" cond_v1
+gate "$R"; expect_ok "C1 an else-branch pick passes on a conditional-only scenario"
 
-# C2 — control: the same fixture without the `conditional` entry passes. Without
-# this, C1 would also pass if the refusal fired on every scenario.
+# C2 — control: the same fixture without any conditional still passes. Without
+# it, C1 would also pass if the position rule had stopped rejecting anything.
 R="$(new_repo)"; init_index "$R"
 mk_scenario "$R" cond_v1 '["speak_each","summarize"]'
 mk_highlight "$R" cond_v1 "$EX_OK"; link_highlight "$R" cond_v1
-gate "$R"; expect_ok 'C2 the same fixture minus the conditional entry still passes'
+gate "$R"; expect_ok 'C2 a flat scenario still passes'
 
-# C3 — and the extractor refuses it too, from the shared dispatch rather than a
-# second copy of the predicate.
+# C3 — the extractor's own derivation is NOT branch-aware yet: annotate() still
+# reads phase_path[0], so a branch utterance reports the conditional's top-level
+# index and the shared phase check catches the disagreement. Asserted rather
+# than left silent — this is precisely what the next commit replaces, and an
+# unasserted gap here would let a half-finished resolver look finished.
 R="$(new_repo)"; init_index "$R"
-mk_scenario "$R" cond_v1 '["speak_each","conditional","summarize"]'
-mk_run "$R" "$R/run.jsonl"; mk_selection "$R" "$R/sel.json"
+mk_scenario_tree "$R" cond_v1 "$TREE_HISSATSU" 2
+mk_run_cond "$R" "$R/run.jsonl"; mk_selection_cond "$R" "$R/sel.json"
 runc "$R" python3 scripts/gallery_highlight_extract.py --run run.jsonl --id cond_v1 --selection sel.json
-expect_fail "C3 extractor refuses a conditional-bearing scenario"
-expect_out "highlight: conditional scenario" "C3 names the same class as the gate"
+expect_fail "C3 the extractor cannot yet derive a branch index"
+expect_out "phase_index mismatch" "C3 the shared phase check catches the top-level index"
 
 # C4 — a `phase_started` with no `phase_path` is refused rather than defaulted
 # to top-level index 0. The earlier `or [0]` fallback asserted a position the
 # transcript never stated, and every downstream check read it as measured.
+# Untouched by the lift: it is about a missing field, not about branches.
 R="$(new_repo)"; init_index "$R"; mk_scenario "$R" demo_v1 '["speak_each","summarize"]'
 mk_run "$R" "$R/run.jsonl"; mk_selection "$R" "$R/sel.json"
 python3 - "$R" <<'PY'
@@ -1168,18 +1209,87 @@ runc "$R" python3 scripts/gallery_highlight_extract.py --run run.jsonl --id demo
 expect_fail "C4 a phase_started without phase_path is refused"
 expect_out "no usable \`phase_path\`" "C4 names the missing field"
 
-# C5 — a `phases` list that DRIFTED from its YAML cannot disable the refusal.
-# Nothing on a highlight PR's path re-derives that denormalized field (why:
-# `scenario_declares_conditional`'s docstring), so the refusal reads the YAML
-# too — this arm is what proves that side live rather than decorative.
+# C5 — fail-closed residue. When the tree cannot be derived at all, a
+# conditional entry is refused rather than checked against the flattened list,
+# which interleaves branches. This is what survives of the class-wide refusal,
+# and it is the successor to the old C5's property: an entry whose `phases`
+# says `conditional` never reaches the position rule on the YAML's silence.
 R="$(new_repo)"; init_index "$R"
-mk_scenario "$R" cond_v1 '["speak_each","conditional","summarize"]'
-# Drop `conditional` from the INDEX only; the YAML still declares it.
-jq '.scenarios |= map(if .id == "cond_v1" then .phases = ["speak_each","summarize"] else . end)' \
-  "$R/docs/gallery/gallery.json" > "$R/t" && mv "$R/t" "$R/docs/gallery/gallery.json"
-mk_highlight "$R" cond_v1 "$EX_OK"; link_highlight "$R" cond_v1
-gate "$R"; expect_fail "C5 a drifted phases list cannot disable the refusal"
-expect_out "sibling scenario YAML" "C5 names the YAML as the source that caught it"
+mk_scenario_tree "$R" cond_v1 "$TREE_HISSATSU" 2
+# Nest a conditional inside a branch — legal YAML, refused by the flattener
+# (and by ScenarioValidator), so the tree comes back None while `phases` is
+# untouched and still contains `conditional`.
+python3 - "$R" <<'PY'
+import io, sys
+p = sys.argv[1] + "/docs/gallery/cond_v1.yaml"
+text = io.open(p, encoding="utf-8").read()
+# mk_scenario_tree emits branch children at 6 spaces (top level 2, `then:`/`else:`
+# at 4). Anchor on that exact indent and assert the hit count, or a silent
+# no-op replace would leave the tree derivable and C5 would pass vacuously.
+old = "      - type: speak_all\n"
+assert text.count(old) == 2, f"anchor matched {text.count(old)} times — probe invalid"
+io.open(p, "w", encoding="utf-8").write(
+    text.replace(old, "      - type: conditional\n        then:\n          - type: speak_all\n", 1))
+PY
+repin_yaml "$R" cond_v1
+mk_highlight "$R" cond_v1 "$EX_ELSE_BRANCH"; link_highlight "$R" cond_v1
+gate "$R"; expect_fail "C5 an underivable tree refuses a conditional entry"
+expect_out "branch structure is unavailable" "C5 names the residue, not the lifted class refusal"
+
+# C6 — negative control: a pick genuinely preceded by an outcome phase INSIDE
+# its own branch is still rejected. Without this, C1 would be satisfied by a
+# rule that had simply stopped looking at branches.
+TREE_DIRTY_BRANCH='[{"type":"conditional",
+  "then":[{"type":"speak_all"}],
+  "else":[{"type":"vote"},{"type":"speak_all"}]}]'
+R="$(new_repo)"; init_index "$R"
+mk_scenario_tree "$R" cond_v1 "$TREE_DIRTY_BRANCH" 2
+mk_highlight "$R" cond_v1 \
+  '[{"agent":"アヤ","round":1,"phase":"speak_all","phase_index":3,"source_field":"statement","text":"私はBだと思う。"}]'
+link_highlight "$R" cond_v1
+gate "$R"; expect_fail "C6 an in-branch pick after an outcome phase is rejected"
+expect_out "within-round bound" "C6 names the position rule"
+# C6b — control on the SAME tree: the sibling branch's pick, whose own preceding
+# set is empty, passes. This is what shows C6 measured the branch and not the
+# scenario.
+R="$(new_repo)"; init_index "$R"
+mk_scenario_tree "$R" cond_v1 "$TREE_DIRTY_BRANCH" 2
+mk_highlight "$R" cond_v1 \
+  '[{"agent":"アヤ","round":1,"phase":"speak_all","phase_index":1,"source_field":"statement","text":"私はBだと思う。"}]'
+link_highlight "$R" cond_v1
+gate "$R"; expect_ok "C6b the clean branch's pick on the same tree passes"
+
+# C7 — the both-branch union for a PRECEDING conditional. A top-level pick after
+# a conditional is judged against BOTH branches, because the excerpt records no
+# branch and so cannot say which one ran in its round. No shipped scenario has
+# this shape; the arm exists so one cannot arrive and leak silently.
+TREE_AFTER_COND='[{"type":"conditional","then":[{"type":"speak_all"}],"else":[{"type":"vote"}]},{"type":"speak_each"}]'
+R="$(new_repo)"; init_index "$R"
+mk_scenario_tree "$R" cond_v1 "$TREE_AFTER_COND" 2
+mk_highlight "$R" cond_v1 \
+  '[{"agent":"アヤ","round":1,"phase":"speak_each","phase_index":3,"source_field":"statement","text":"私はBだと思う。"}]'
+link_highlight "$R" cond_v1
+gate "$R"; expect_fail "C7 a pick after a conditional sees the non-taken branch's outcome phase"
+expect_out "within-round bound" "C7 names the position rule"
+# C7b — control: the same shape with no outcome phase in either branch passes,
+# so C7 reddens on the `vote` rather than on "sits after a conditional".
+TREE_AFTER_COND_CLEAN='[{"type":"conditional","then":[{"type":"speak_all"}],"else":[{"type":"speak_all"}]},{"type":"speak_each"}]'
+R="$(new_repo)"; init_index "$R"
+mk_scenario_tree "$R" cond_v1 "$TREE_AFTER_COND_CLEAN" 2
+mk_highlight "$R" cond_v1 \
+  '[{"agent":"アヤ","round":1,"phase":"speak_each","phase_index":3,"source_field":"statement","text":"私はBだと思う。"}]'
+link_highlight "$R" cond_v1
+gate "$R"; expect_ok "C7b the same shape with clean branches passes"
+
+# C8 — the round-window arms now run for a conditional entry. The class refusal
+# returned before reaching them, so nothing has ever exercised this pairing.
+R="$(new_repo)"; init_index "$R"
+mk_scenario_tree "$R" cond_v1 "$TREE_HISSATSU" 2
+mk_highlight "$R" cond_v1 \
+  '[{"agent":"アヤ","round":2,"phase":"speak_all","phase_index":5,"source_field":"statement","text":"私はBだと思う。"}]'
+link_highlight "$R" cond_v1
+gate "$R"; expect_fail "C8 a late-round pick on a conditional entry hits the round window"
+expect_out "round window" "C8 names the round window"
 
 # --- phase tree: flattening + gallery.json cross-check (#1473) -------------
 #

--- a/scripts/tests/gallery-highlight-test.sh
+++ b/scripts/tests/gallery-highlight-test.sh
@@ -1421,6 +1421,83 @@ runc "$R" python3 scripts/gallery_highlight_extract.py --run run.jsonl --id cond
 expect_fail "C3f a non-integer phase_path element is refused"
 expect_out "non-integer element" "C3f names the element type, not a downstream mismatch"
 
+# C3h — a transcript carrying a `run_start` but no `event` lines is refused by
+# name. Real input, not hypothetical: `HarnessRunner.execute` writes `run_start`
+# unconditionally, so two attempts that both fail at model load produce exactly
+# this file. Before the guard it reached `build_excerpt`'s `max()` over an empty
+# iterable and surfaced as a bare `ValueError` traceback. The event-bearing
+# fixture immediately below (C4, and every extractor arm above) is the positive
+# control — this pair is what stops a typo'd predicate from reading as green.
+R="$(new_repo)"; init_index "$R"; mk_scenario "$R" demo_v1 '["speak_each","summarize"]'
+mk_selection "$R" "$R/sel.json"
+cat > "$R/run.jsonl" <<'JSONL'
+{"type":"run_start","run_id":"run-1","date":"2026-08-05","scenario_id":"demo_v1","scenario_name":"T","language":"ja","model":"Gemma 4 E2B (Q4_K_M)","timeout_sec":900,"estimated_inferences":12}
+{"type":"run_end","run_id":"run-1","status":"failed","attempts":2,"duration_sec":1.0}
+JSONL
+runc "$R" python3 scripts/gallery_highlight_extract.py --run run.jsonl --id demo_v1 --selection sel.json
+expect_fail "C3h a transcript with no event lines is refused"
+expect_out "no event lines" "C3h names the missing events, not a downstream crash"
+expect_no_out "Traceback" "C3h fails by name rather than by traceback"
+
+# C3i — the OTHER unblocked shape, end-to-end. `detective_scene_v1` and
+# `kasei_sanso_touban_v1` put the conditional LAST, so their only eligible pick
+# is the top-level utterance BEFORE it — a case the branch resolver contributes
+# nothing to (they are unblocked by the class-refusal lift, not by it). Every
+# other extractor arm here picks a branch-interior line, so without this one
+# that shape is asserted only by direct `_check_position` calls, never through
+# the extractor. Modelled on kasei down to the `event_inject` branch child,
+# which no other fixture in this file exercises.
+TREE_KASEI='[{"type":"speak_all"},{"type":"vote"},{"type":"score_calc"},
+  {"type":"conditional","then":[{"type":"summarize"}],
+   "else":[{"type":"event_inject"},{"type":"speak_all"}]}]'
+R="$(new_repo)"; init_index "$R"
+mk_scenario_tree "$R" cond_v1 "$TREE_KASEI" 2
+cat > "$R/run.jsonl" <<'JSONL'
+{"type":"run_start","run_id":"run-1","date":"2026-08-05","scenario_id":"cond_v1","scenario_name":"T","language":"ja","model":"Gemma 4 E2B (Q4_K_M)","timeout_sec":900,"estimated_inferences":12}
+{"type":"event","t":0.1,"attempt":1,"event":"round_started","round":1,"total_rounds":2}
+{"type":"event","t":0.2,"attempt":1,"event":"phase_started","phase_type":"speak_all","phase_path":[0]}
+{"type":"event","t":0.3,"attempt":1,"event":"agent_output","agent":"アヤ","phase_type":"speak_all","fields":{"statement":"conditional の手前の発言。"}}
+{"type":"event","t":0.4,"attempt":1,"event":"phase_started","phase_type":"vote","phase_path":[1]}
+{"type":"event","t":0.5,"attempt":1,"event":"phase_started","phase_type":"score_calc","phase_path":[2]}
+{"type":"event","t":0.6,"attempt":1,"event":"phase_started","phase_type":"conditional","phase_path":[3]}
+{"type":"event","t":0.7,"attempt":1,"event":"conditional_evaluated","condition":"current_round == total_rounds","result":false}
+{"type":"event","t":0.8,"attempt":1,"event":"phase_started","phase_type":"event_inject","phase_path":[3,0]}
+{"type":"event","t":0.9,"attempt":1,"event":"event_injected","value":"事件発生"}
+{"type":"event","t":1.0,"attempt":1,"event":"phase_started","phase_type":"speak_all","phase_path":[3,1]}
+{"type":"event","t":1.1,"attempt":1,"event":"agent_output","agent":"アヤ","phase_type":"speak_all","fields":{"statement":"分岐の中の発言。"}}
+{"type":"event","t":1.2,"attempt":1,"event":"run_end","run_id":"run-1","status":"ok","attempts":1,"duration_sec":9.0}
+JSONL
+cat > "$R/sel.json" <<'JSON'
+{
+  "picks": [4],
+  "yaml_hook": { "kind": "raw", "fragment": "phases:\n  - type: conditional", "caption": "この一行が分岐を生む" },
+  "teaser": "最後の一言は、まだ言われていない。"
+}
+JSON
+runc "$R" python3 scripts/gallery_highlight_extract.py --run run.jsonl --id cond_v1 \
+  --selection sel.json --generated-at 2026-08-05
+expect_ok "C3i a pre-conditional top-level pick extracts"
+runc "$R" jq -r '.excerpt[0].phase_index' docs/gallery/highlights/cond_v1.json
+expect_eq "0" "C3i resolves the pre-conditional pick to top-level index 0"
+link_highlight "$R" cond_v1
+gate "$R"; expect_ok "C3i the gate accepts it"
+
+# C3i-b — control on the SAME transcript: the else-branch `speak_all` (flat
+# index 6) IS preceded by `vote`/`score_calc` at top level, so it must be
+# rejected. Without this, C3i's green would also be produced by a rule that had
+# stopped looking at anything preceding a branch pick.
+python3 - "$R" <<'PY'
+import io, sys
+p = sys.argv[1] + "/sel.json"
+text = io.open(p, encoding="utf-8").read()
+old = '"picks": [4]'
+assert text.count(old) == 1, f"anchor matched {text.count(old)} times — probe invalid"
+io.open(p, "w", encoding="utf-8").write(text.replace(old, '"picks": [12]'))
+PY
+runc "$R" python3 scripts/gallery_highlight_extract.py --run run.jsonl --id cond_v1 --selection sel.json
+expect_fail "C3i-b the in-branch pick after top-level vote/score_calc is rejected"
+expect_out "highlight: within-round bound" "C3i-b names the position rule"
+
 # C4 — a `phase_started` with no `phase_path` is refused rather than defaulted
 # to top-level index 0. The earlier `or [0]` fallback asserted a position the
 # transcript never stated, and every downstream check read it as measured.

--- a/scripts/tests/gallery-highlight-test.sh
+++ b/scripts/tests/gallery-highlight-test.sh
@@ -1606,23 +1606,20 @@ gate "$R"; expect_fail "C8 a late-round pick on a conditional entry hits the rou
 expect_out "highlight: round window" "C8 names the round window"
 
 # C9 — regression: the shipped highlights still validate and the gate rewrites
-# none of them. Two things this arm has to get right:
-#   - "byte-identical" is a BEFORE/AFTER comparison, not `== ""`. Asserting
-#     emptiness reddens whenever a developer runs the suite mid-work on a
-#     highlight-ADDING PR (staged entries under that path) — the very PR shape
-#     that most needs this arm.
-#   - `check_highlights` is a documented no-op only when BOTH are absent — no
-#     highlights/ directory AND no paired index field (check-gallery-entry.sh;
-#     H0 above covers that path deliberately). With the directory gone but
-#     `gallery.json` still carrying highlight_url, the validator runs and fails
-#     loudly; it is the both-gone case that would pass having checked nothing,
-#     and that is what the count guards. Note the count asserts that highlight
-#     FILES exist, not that the validator examined an entry — files present with
-#     no paired `highlight_url` is caught by the orphan check (cf. H4), so
-#     non-vacuity rests on the count and `expect_ok` together. Count first.
-#     The `-d` test is not decoration: under this file's `set -euo pipefail` a
-#     `find` on a missing directory exits non-zero and would abort the suite
-#     before reaching the `bad` branch written for exactly that case.
+# none of them. Three things this arm has to get right:
+#   - "byte-identical" is a BEFORE/AFTER comparison, not `== ""`, which would
+#     redden mid-work on a highlight-ADDING PR (staged entries under that
+#     path) — the shape that most needs this arm.
+#   - The count guards non-vacuity: `check_highlights` (check-gallery-entry.sh)
+#     is a documented no-op only when the highlights/ directory AND the paired
+#     index field are both absent — H0 covers that path deliberately. The count
+#     asserts highlight FILES exist, not that the validator examined an entry;
+#     files present with no paired `highlight_url` is the orphan check's
+#     (cf. H4), so non-vacuity rests on the count and `expect_ok` together.
+#     Count first.
+#   - The `-d` test is load-bearing: under this file's `set -euo pipefail` a
+#     `find` on a missing directory aborts the suite before the `bad` branch
+#     written for exactly that case.
 if [ -d "$REAL_ROOT/docs/gallery/highlights" ]; then
   HL_COUNT="$(find "$REAL_ROOT/docs/gallery/highlights" -name '*.json' | wc -l | tr -d ' ')"
 else


### PR DESCRIPTION
## Summary

`conditional` を含む gallery シナリオは highlight を作れず、`_check_position` にクラス単位の refusal が立っていた。本PRはその原因を両層で直し、refusal を撤去する。**ツール解禁のみ** — 6エントリ分の highlight 実生成は ADR-029 Decision 2 の人間サインオフが要るため batch 3 として分離する。

原因は2つの index 体系のずれ:

- `gallery.json` の `phases` は `conditional` の `then:`/`else:` を含む**完全平坦化・深さ優先**リスト（`add-gallery-entry.sh` の `flat()`）
- transcript の `phase_started.phase_path` は**木のパス**（`[i]` または `[i, j]`）

`annotate()` は `phase_path[0]` しか読まず、`_check_position` の前置き集合 `phases[:idx]` は両分岐を跨いでいた。`hissatsu_naming_v1` は唯一のトップレベル phase が conditional なので、全発話が `[0, j]` を報告して一律 0 に潰れ、かつ else 分岐の pick に then 分岐の outcome phase が前置きとして混入していた。

## 変更

1. **`flatten_phase_tree`** — YAML から木構造付きノード列（`type` / `top` / `branch` / `inner`）を再導出。エンジンが拒否する2形も拒否する（枝なし conditional / 枝内の conditional）。
2. **`_check_phase_tree`** — `gallery.json` の `phases` を YAML と突き合わせる。この分野には平坦化の実装が3つあり（`flat()` / `GallerySeedYAMLTests.flattenPhaseKinds` / 本体）、Swift 側は docs-only changeset で `precommit-gate-classify.sh` にスキップされるため、これが **flat エントリにとっても初のゲート側 drift チェック**になる。
3. **`_preceding_in_round`** — 前置き集合を木から導出。クラス refusal を撤去し、木が導出不能な conditional エントリのみ fail-closed で拒否。
4. **抽出器の `annotate()`** — `phase_path` を平坦 index に解決。`[i, j]` は `then[j]` と `else[j]` で同一なので、分岐は直前の `conditional_evaluated` から取る（この event は自身の `phase_path` を持たないため、直近の `phase_type == "conditional"` の `phase_started` に帰属。深さ1規則より同時 in-flight は高々1つ）。

## 設計判断

**先行 conditional は両分岐を union**（保守的）。excerpt は分岐を記録しないので、ファイルだけを見る限りどちらが走ったかは言えない。

ただしこれは**スキーマの帰結であって情報理論的な限界ではない** — 抽出器は `conditional_evaluated` を読んでいて分岐を知っており、`phase_index` を書く時に捨てている。「excerpt に分岐を記録する」案の却下理由は、issue #1473 のスケッチが挙げた「ADR-020 D2a / `galleryPhasesMatchYAML` / Browse art-tile glyph への波及」**ではない** — その3つはいずれも `gallery.json` の `phases` を読んでおり highlight ファイルを読まないので、任意キー追加は両 consumer に対して無害。実際の理由は、ファイルに書かれた分岐は **self-attested** でゲートが検証できず、union と違って手編集で緩められること。ADR-029 に代替案と正しい却下理由、および設計上の拒否クラス（fork の後ろのトップレベル pick で、走らなかった枝が outcome phase を持つ場合）を記録した。

**手編集された `phase_index` への防御は追加しない。** ゲートは transcript を読まない設計なので、主張座標の *整合性* は検証できても *真偽* は検証できない。

この露出は conditional 固有ではなく、**同じ型の適格 phase を2つ持つ flat エントリ**にも存在する（`hitsuji_kaigi_v1` / `ijin_kaigi_v1` は `[speak_each, reflect, speak_each, choose, speak_each, summarize]` で、`choose` 後の発話を `phase_index: 0` と書けばゲートを通る）。ただし両者は highlight を持たず、出荷済み6件はいずれも適格 phase 型を1つしか持たないので表現できない — **latent であって live ではない**。

一方で conditional は露出を**広げる**。`hissatsu_naming_v1` は両分岐が型として同一なので、index 1 と 5 は偶然ではなく**構造的に**区別不能。それでもチェックを足さないのは、原理を一貫適用すると同じ型の位置をすべて union することになり `hitsuji_kaigi` の適格集合が消えるため。真偽は抽出器の導出と Decision 2 の人間サインオフが担保する。

**深さ ≥3 は「非対応」ではなく hard-fail ガード。** 上流で二重に不可能（`ScenarioLoader.parsePhaseType` が parse 時に拒否、`ConditionalHandler.subHandlers` が `.conditional` を持たない）。かつ `conditional_evaluated` が `phase_path` を持たない以上、「直近の result」では深さ3を正しく解けない。

## 解禁される6エントリ（curation 向けの期待値）

| エントリ | 使える pick |
|---|---|
| `hissatsu_naming_v1` (ja/en) | **分岐内** — round 1 = else 分岐、平坦 index 5 |
| `detective_scene_v1` (ja/en) | conditional **手前**のみ（分岐内は `vote`/`score_calc` が前置き） |
| `kasei_sanso_touban_v1` (ja/en) | conditional **手前**のみ（同上） |

**解禁の機構は2種類ある**: `hissatsu_naming_v1` だけが branch resolver によって解禁され、残る4件は **class refusal の撤去だけ**で解禁される（唯一の適格 pick が conditional の手前にあるため、分岐解決は寄与しない）。両方を extractor 経由の end-to-end アームで表明している（C3 / C3i）。C3i は kasei の実形をそのまま使っており、枝の `event_inject` も含む — この phase 型は既存 fixture のどれにも入っていなかった。

## 検証

- **実データ**: `data/factory/audit-runs/2026-08-08/hissatsu_naming_v1.jsonl`（手書きでない実 harness transcript）が round 1 → else 分岐 index 5 / round 2 → then 分岐 index 1 に解決。受け入れ条件を `--window-override` 無しで満たす
- **変異テスト 14件**: 追加した全ガードを個別に無効化し、意図したアームが赤くなることを確認。ガード1つにつき腕1つ
- **ADR-029 の feasibility を再導出**: 「24 of 27 ja / 40 of 45」と除外5件は branch-aware 規則下でも完全一致 → 無修正。この数値は flat 模型で算出され conditional シナリオを excerptable と数えていたので、**今回初めてツールの実態と一致した**
- `gallery-highlight-test.sh` 201/201（bash 5 / bash 3.2 両方）、`gallery-scripts-test.sh` 48/48、`jsonl-to-demo-replay-test.sh`、`demo-replay-event-coverage-test.sh`、`consistency-audit-test.sh` すべて通過
- `check-gallery-entry.sh --all` 通過、既存6件の highlight はゲート後も無変更
- iOS ユニットスイート 3496 tests 通過（Swift は無変更だが `scripts/**` は `precommit-gate-classify.sh` が build 相当に分類するため実行）

## Test plan

```
bash scripts/tests/gallery-highlight-test.sh      # 201/201
/bin/bash scripts/tests/gallery-highlight-test.sh # bash 3.2
bash scripts/check-gallery-entry.sh --all
```

## Device QA

実機QA不要 — Swift の変更は `GalleryHighlight.phaseIndex` の doc コメント1箇所のみで、コードパスも表示面も変わらない。残りは `scripts/**` と `docs/**`。

## 同PRに含めた既存コードの訂正

最終ラウンドの claim audit が、**本ブランチが触っていない既存コード**に偽の主張2件と欠陥1件を表面化させた。いずれも同じファイル内の小さな訂正なので同梱している:

- `_check_persona_index` のスキップに「NOT a guard — 消してもスイートは緑。何かを捕捉していると書くな」とあったが偽。対照付きで実測したところ、外すと `persona_index` が `null` / キー欠落のとき `TypeError` を送出し、ゲートが**蓄積した失敗一覧の代わりに traceback を印字**する。コメントが将来の編集者に live な crash guard の削除を指示していたため優先して訂正した。
- モジュール docstring が「失敗は1行、`highlight:` 接頭辞つき」を約束するのに、`_check_yaml_hook_fragment` が PyYAML 例外の複数行 `str()` をそのまま埋めていた。`check-gallery-entry.sh` は1行ごとに `fail` を呼ぶので、1件の parse エラーが4件のゲート失敗になり3行は接頭辞なしだった。
- `run_start` はあるが event 行が無い transcript で `build_excerpt` の `max()` が空 iterable に当たり `ValueError` の traceback になっていた。
- 抽出器の `yaml.safe_load` が素で、gallery YAML が壊れていると traceback になっていた（`_read_scenario` 経由に変更）。上の1件を1ファイル隣で潰しておきながら同クラスを残していた掃引漏れ。

## レビュアーへの申し送り

レビューは規約ゲート3周 → claim audit 2シャード → 公式 `/code-review high` → `/risk-review`（3クラスタ）の順に回した。**ロジックの欠陥はどの層も出していない**（`/code-review` は fixture が覆っていない形 — conditional がリストの中間にあり後続 phase を持つ2ラウンド構成 — でも独立に検証して correctness bug ゼロ）。規約ゲート2周目・3周目の Critical はいずれも**前周の修正が入れた prose 欠陥**で、これは既知のループパターン。最終ラウンドを「前周の出力を渡さない claim audit」に切り替えて初めて既存コードの偽の主張が出たので、**prose 側を重点的に**見てほしい。

`/risk-review` が固有に出したのは、**他のどの層も出さなかった3種**だった:

- **継承した根拠の誤り** — union の却下理由を issue 本文からそのまま引き継いでいた（上記「設計判断」参照）。
- **掃引の母集団の誤り** — refusal の文言は掃いたが、**位置規則そのものを平坦前提で述べている curator 向け記述**（`docs/gallery/README.md`、`scenario-refine` SKILL.md）を入れていなかった。`hissatsu_naming_v1` を読んだ curator が「適格行なし」と誤結論する状態で、本PRが直す当の誤りをドキュメントが再生産していた。
- **主張の粒度** — 「6件解禁」は真だが、うち4件は resolver ではなく refusal 撤去で解禁されており、しかも extractor 経由の end-to-end 検証が無かった。

`Pastura/Pastura/Engine/ScenarioValidator.swift:155-157` の docstring が `depth > 0` の分岐を「non-YAML construction を守る」と説明しているが、この分岐は到達不能（同関数の callsite は `depth: 0` の1箇所、`validateBranch` は再帰せず直接 throw）。本PRの範囲外なので手を入れていない。

Closes #1473
Follow-up: #1505（demo-replay の `phase_index` は *top-level* index と定義され、分岐 sub-phase が何を記録すべきかは未設計 — 導出のバグではなくスキーマ判断）
