### PR TITLE
♻️ refactor: 自動起動不要な7スキルの description を毎ターン一覧から外す

### DIFF
--- a/.claude/rules/context-budget.md
+++ b/.claude/rules/context-budget.md
@@ -14,7 +14,10 @@ Always-loaded files (loaded into every agent session / invocation) — every lin
 
 - `~/.claude/CLAUDE.md` and `~/.claude/rules/*.md` **without** `paths:` frontmatter (global — per-user, yet charged to *this* project's every session)
 - `CLAUDE.md` (project top-level) and `.claude/rules/*.md` **without** `paths:`
-- `~/.claude/agents/*.md` and project `.claude/agents/*.md`
+- `agents/*.md` (personal or project) — the `description:` only; the body is paid per spawn, not
+  per turn
+- `skills/*/SKILL.md` (personal or project) — likewise `description:` only, and `disable-model-invocation: true` drops
+  even that from the model's listing (giving up auto-invocation)
 
 The global tier is easy to forget because it is not in this repo — and a global file duplicating a
 project file of the same name is paid **twice**.

--- a/.claude/skills/code-health-audit/SKILL.md
+++ b/.claude/skills/code-health-audit/SKILL.md
@@ -2,6 +2,7 @@
 name: code-health-audit
 description: Run one code-health-audit cycle — sweep a code layer (Engine/LLM) with category-weighted read-only finders, Vet each finding, and write a ranked digest (files no issues, schedules nothing). Use when the user asks to run code-health-audit, audit code health, or sweep for latent code-quality issues a diff review can't see.
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash, Agent
+disable-model-invocation: true
 ---
 
 # /code-health-audit

--- a/.claude/skills/consistency-audit/SKILL.md
+++ b/.claude/skills/consistency-audit/SKILL.md
@@ -2,6 +2,7 @@
 name: consistency-audit
 description: Detect mechanically-verifiable documentation/ADR drift and act on it — open a docs-fix Draft PR for fixes whose value is uniquely determined by an authoritative source, or file an issue (with confidence + counter-evidence) for drift that needs human judgment. Use when the user asks to run the consistency audit, audit the docs, check for doc/ADR drift, or run the nightly brush-up consistency pass.
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash
+disable-model-invocation: true
 ---
 
 # /consistency-audit

--- a/.claude/skills/queue-consumer/SKILL.md
+++ b/.claude/skills/queue-consumer/SKILL.md
@@ -2,6 +2,7 @@
 name: queue-consumer
 description: Consume agent-ready GitHub issues into Draft PRs — one overnight queue run. Fetches open agent-ready issues oldest-first, implements each on an agent/issue-<N> branch, tests, passes a mandatory code review, opens a Draft PR, and appends the run digest. Use when the user asks to run the issue queue, consume agent-ready issues, process the overnight queue, work through queued agent tasks, or run the queue consumer.
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash, Agent
+disable-model-invocation: true
 ---
 
 # /queue-consumer

--- a/.claude/skills/scenario-factory/SKILL.md
+++ b/.claude/skills/scenario-factory/SKILL.md
@@ -2,6 +2,7 @@
 name: scenario-factory
 description: Run one scenario-factory cycle — generate 3 fresh scenario YAMLs, execute each on pastura-harness with real local-LLM inference, judge the transcripts in-session, and append the local digest. Use when the user asks to run the scenario factory, run a factory cycle, generate and field-test new scenarios, or dogfood scenarios overnight.
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash
+disable-model-invocation: true
 ---
 
 # /scenario-factory
@@ -398,7 +399,10 @@ human-driven `/orchestrate` PR — same pattern as scenario promotion. The PR:
     section (date-idempotent append).
   - **Permission mode**: **`acceptEdits`** (not `bypassPermissions`) —
     auto-accepts in-session file writes (generated YAMLs); least-privilege.
-  - **Instructions**: `Run the /scenario-factory skill for tonight's cycle.`
+  - **Instructions**: `/scenario-factory` — the slash must be **leading**, so
+    the harness expands it as a slash command. Prose around it ("Run the
+    /scenario-factory skill…") needs model invocation, which this skill's
+    `disable-model-invocation: true` frontmatter blocks.
 - **No settings.json change.** The skill writes only gitignored local files
   (digest, scenarios, runs) and makes no `git push` / `gh` calls, so no
   allowlist additions are needed.

--- a/.claude/skills/scenario-refine/SKILL.md
+++ b/.claude/skills/scenario-refine/SKILL.md
@@ -2,6 +2,7 @@
 name: scenario-refine
 description: Run one scenario-refine cycle — evaluate a rotating slice of the EXISTING shipped scenario inventory (bundled presets + gallery) on pastura-harness with real local-LLM inference, judge each against a category-aware rubric with regression detection, auto-generate and A/B-test v2 improvement candidates for low scorers, and append the local audit journal. Use when the user asks to run scenario-refine, evaluate or polish existing scenarios, audit the scenario inventory, or check for scenario quality regressions.
 allowed-tools: Read, Write, Grep, Glob, Bash
+disable-model-invocation: true
 ---
 
 # /scenario-refine
@@ -371,7 +372,10 @@ can never auto-ship.
     auto-accepts the in-session writes (v2 candidate YAMLs under
     `data/factory/improvements/`); least-privilege. The safety boundary (only
     `data/factory/` is written) is what makes `acceptEdits` safe here.
-  - **Instructions**: `Run the /scenario-refine skill for tonight's cycle.`
+  - **Instructions**: `/scenario-refine` — the slash must be **leading**, so
+    the harness expands it as a slash command. Prose around it ("Run the
+    /scenario-refine skill…") needs model invocation, which this skill's
+    `disable-model-invocation: true` frontmatter blocks.
 - **No settings.json change.** The skill writes only gitignored local files
   and makes no `git push` / `gh` calls, so no allowlist additions are needed.
 - **Environment prerequisites**: AC power, machine awake (non-sleep), idle at

--- a/.claude/skills/triage-guardian/SKILL.md
+++ b/.claude/skills/triage-guardian/SKILL.md
@@ -2,6 +2,7 @@
 name: triage-guardian
 description: Triage automation-origin open Draft PRs into a conservative merge / discard / judgment report, and surface aggregate WIP backpressure — read-only, never merges or closes. Use when the user asks to triage the Draft PR queue, run the triage guardian, prep a review session, check the brush-up automation backlog, or see whether the generators should throttle.
 allowed-tools: Read, Grep, Glob, Bash
+disable-model-invocation: true
 ---
 
 # /triage-guardian

--- a/.claude/skills/ui-refine/SKILL.md
+++ b/.claude/skills/ui-refine/SKILL.md
@@ -2,6 +2,7 @@
 name: ui-refine
 description: Run one ui-refine cycle — capture the current app UI via ui-tour, critique it through today's rotating lens, adversarially filter the proposals against the proposal ledger and the design system, and write a ranked digest (files no issues, schedules nothing). Use when the user asks to run ui-refine, propose UI improvements, critique the current UI design, polish the UI, or run the UI design-refine pass.
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash
+disable-model-invocation: true
 ---
 
 # /ui-refine


### PR DESCRIPTION
## 何を

運用者が明示的に `/name` で叩く brush-up 系 7 スキルに `disable-model-invocation: true` を付け、`description:` を毎ターンのモデル向けスキル一覧から落とす。

対象: `code-health-audit` / `consistency-audit` / `queue-consumer` / `scenario-factory` / `scenario-refine` / `triage-guardian` / `ui-refine`

## なぜ

Skill の `description:` は body と違い**毎ターン**課金される。上記 7 スキルはいずれも manual-first か Routine 起動で、モデルの自動起動（auto-invocation）を必要としない。一覧から外しても運用経路は `/name` のスラッシュコマンドで残る。

## 効果（実測）

| | バイト |
|---|---|
| 一覧から消える description 計 | **-2,859** |
| `context-budget.md` の追記 | +236 |
| **差引** | **約 -2.6 KB / ターン** |

効果はフラグ適用状態のセッションで確認済み: 7 件が skills 一覧から消え、フラグ無しの `model-eval` / `orchestrate` / `release` / `simplify-doc` は残存している（陽性対照）。

## 副作用と、その手当て

`scenario-factory` / `scenario-refine` の Routine レシピは Instructions が

```
Run the /scenario-factory skill for tonight's cycle.
```

と**先頭スラッシュでない**ため、スラッシュコマンドとして展開されずモデル起動経路に依存していた。この PR がその経路を閉じるので、両レシピを先頭スラッシュ形へ修正し、次の編集者が散文形に戻さないよう理由を添えた。他の 5 スキルは Routine レシピ未記載のため影響なし。

`Skill` ツール経由で他スキルからこの 7 件を呼ぶ箇所は無いことを確認済み（参照はすべて散文か `scripts/` パス）。

## `context-budget.md` の追記について

これは **claude-kit からの一方向 reconcile**（kit → Pastura）。kit の `origin/main:rules/context-budget.md` L17-20 とバイト一致を確認済みで、Pastura 側の独自分岐ではない。

## 天井のラチェットを行わない理由

`scripts/hooks/check-claude-md-modified.sh` の `always_loaded_bytes` は `CLAUDE.md` / `.claude/agents/*.md` / `.claude/rules/*.md` **のみ**を数えるため、今回の削減（skill description）は集計対象外。総計はむしろ 91,068 → **91,304** と微増する（天井 92,600 の下で、フックは発火しない）。

削減キャンペーンは自分の PR で天井を下げる義務があるが、**今回はフックが数える対象に原資が無い**ため、ラチェットは行わない。

## Context-economy

Context-economy: kept 1 paragraph, compressed/dropped 0 — `context-budget.md` への +4 行はフラグの存在と代償（auto-invocation を捨てる）を記録するもので、この PR 自身が根拠とする規範。差引では always-loaded 課金を 2.6 KB/ターン削減している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BU8Q25V6c2dPsByQeqGFUk
