### PR TITLE
✨ feat: demo-replay schema v2 — phase_path / branch で conditional に対応

### DIFF
--- a/.claude/rules/build-traps.md
+++ b/.claude/rules/build-traps.md
@@ -50,3 +50,34 @@ declaration that also carries a `///` doc comment — **both** placements fail:
 - `identifier_name` (short domain identifiers like `ja` / `en`) → add a
   **`.swiftlint.yml` `identifier_name.excluded`** entry (ref: the `ja` / `en`
   exclusions consumed by `pickLanguage(_:ja:en:)`), or rename to 3+ chars.
+
+## Prose ABOUT a directive is parsed AS one
+
+The comment-command parser scans every `//` comment, so quoting a directive's
+literal text while explaining it applies it. Writing `// swiftlint:disable X`
+inside a paragraph about that trap is enough. Loud rather than silent — the
+quote lands as a real command and draws `blanket_disable_command`, plus
+`superfluous_disable_command` if adjacent backticks get swept into the rule
+name — but the diagnostics name the rule you were describing, so they read as a
+problem with the code rather than with the sentence.
+
+**Apply**: in a **Swift** comment, name a directive rather than spelling it —
+"a blanket `file_length` disable directive on line 6", not the text itself. The
+example above is spelled out because this file is Markdown, which SwiftLint does
+not scan; that asymmetry is the whole trap, so do not read the example as
+licence to quote it in a `.swift` file.
+
+## `swiftlint --path <file>` is not an option, and its error reads as "clean"
+
+`swiftlint lint --path X` exits with `Error: Unknown option '--path'` (the
+positional form `swiftlint lint [options] [paths...]` is the real one). A probe
+that greps that output for a rule name finds nothing and concludes the rule did
+not fire. Measured 2026-08-21 (0.65.0, #1505): it fooled two independent
+attempts to settle whether `file_length` was live, in the same session.
+
+**Apply**: to test whether a rule fires, put the fixture **inside**
+`.swiftlint.yml`'s `included:` tree and run the form the gates run
+(`scripts/git-hooks/pre-commit`, `ci.yml`): `swiftlint lint --strict`. Two
+things genuinely suppress a rule and are easy to mistake for "not enabled" — a
+fixture outside `included:` (path-independent rules still fire there, so the run
+looks live), and a file-level disable directive already in the target file.

--- a/.claude/rules/build-traps.md
+++ b/.claude/rules/build-traps.md
@@ -72,8 +72,7 @@ licence to quote it in a `.swift` file.
 `swiftlint lint --path X` exits with `Error: Unknown option '--path'` (the
 positional form `swiftlint lint [options] [paths...]` is the real one). A probe
 that greps that output for a rule name finds nothing and concludes the rule did
-not fire. Measured 2026-08-21 (0.65.0, #1505): it fooled two independent
-attempts to settle whether `file_length` was live, in the same session.
+not fire. Measured 2026-08-21 (0.65.0, #1505).
 
 **Apply**: to test whether a rule fires, put the fixture **inside**
 `.swiftlint.yml`'s `included:` tree and run the form the gates run

--- a/Pastura/Pastura/App/ReplaySource.swift
+++ b/Pastura/Pastura/App/ReplaySource.swift
@@ -95,8 +95,10 @@ nonisolated public protocol ReplaySource: Sendable {
   /// this array, so two calls must produce equal indexing).
   ///
   /// Events are merged from YAML `turns` and `code_phase_events` sections
-  /// into a single chronological order keyed by `(round, phase_index)`
-  /// with stable secondary ordering by source position. Inside each
+  /// into a single chronological order keyed by `(round, phase_path)` with
+  /// stable secondary ordering by source position. A v1 source has no
+  /// `phase_path`; those entries key on `[phase_index]`, for which the
+  /// lexicographic order is the integer order this contract used to name. Inside each
   /// scenario, the first event of a new round carries a preceding
   /// synthesised `.roundStarted`; the first event of a new phase
   /// (within a round) carries a preceding synthesised `.phaseStarted`.

--- a/Pastura/Pastura/App/ReplaySource.swift
+++ b/Pastura/Pastura/App/ReplaySource.swift
@@ -109,10 +109,17 @@ nonisolated public protocol ReplaySource: Sendable {
   ///   finishing; a synthesised terminator would race with the
   ///   consumer's own end-of-iteration detection.
   ///
-  /// **Known fidelity gap** (matches ``YAMLReplayExporter`` limitation,
-  /// see that type's `resolvePhaseIndices` doc): `.phaseStarted.phasePath`
-  /// is flattened to `[phaseIndex]`. Sub-phases inside a `conditional`
-  /// resolve to the outer conditional's index. Acceptable for Phase 2
-  /// linear presets (Word Wolf, Prisoner's Dilemma).
+  /// `.phaseStarted.phasePath` carries the source's own `phase_path`
+  /// (spec §3.2, schema v2), so a sub-phase inside a `conditional` reaches
+  /// the consumer as `[i, j]`. A v1 source has no such field and resolves
+  /// to `[phase_index]` — exact for a preset with no `conditional`, and
+  /// the flattening this doc used to describe for one that has one.
+  ///
+  /// What the path still cannot say is WHICH branch ran: `then[j]` and
+  /// `else[j]` are the same path, matching `SimulationEvent.phaseStarted`
+  /// itself, whose payload `ConditionalHandler` builds the same way. A
+  /// demo YAML may carry a `branch:` field to disambiguate, but it is not
+  /// surfaced here — no consumer of this array needs it, and no exporter
+  /// can supply it (nothing persists the branch).
   func plannedEvents() -> [PacedEvent]
 }

--- a/Pastura/Pastura/App/YAMLReplayExporter.swift
+++ b/Pastura/Pastura/App/YAMLReplayExporter.swift
@@ -212,7 +212,15 @@ nonisolated struct YAMLReplayExporter {  // swiftlint:disable:this type_body_len
       // `phase_path` (schema v2) is omitted for pre-v6 rows — `turn.phasePath`
       // reads `nil` when `phasePathJSON` was never captured, and the reader
       // falls back to `[phase_index]` for those, which is what v1 always meant.
-      if let path = turn.phasePath {
+      //
+      // `!path.isEmpty` keeps this gated on the SAME value `phaseIndices` was
+      // derived from. `phasePathJSON == "[]"` decodes to a non-nil EMPTY array
+      // (`TurnRecord.phasePath` nils out only on a nil / empty *string*), so
+      // `phasePath?.first` in `resolvePhaseIndices` is nil and the index comes
+      // from the cursor — emitting the empty array here anyway would write
+      // `phase_index` and `phase_path` from two different sources and break
+      // spec §3.2's `phase_index == phase_path[0]`.
+      if let path = turn.phasePath, !path.isEmpty {
         lines.append("    phase_path: \(Self.yamlIntArray(path))")
       }
       lines.append("    phase_type: \(Self.yamlValue(turn.phaseType))")
@@ -246,8 +254,8 @@ nonisolated struct YAMLReplayExporter {  // swiftlint:disable:this type_body_len
       let phaseIndex = phaseIndices[safe: idx] ?? 0
       lines.append("  - round: \(event.roundNumber)")
       lines.append("    phase_index: \(phaseIndex)")
-      // Same pre-v6 omission rationale as `renderTurns` above.
-      if let path = event.phasePath {
+      // Same pre-v6 omission and same-source rationale as `renderTurns`.
+      if let path = event.phasePath, !path.isEmpty {
         lines.append("    phase_path: \(Self.yamlIntArray(path))")
       }
       lines.append("    phase_type: \(Self.yamlValue(event.phaseType))")

--- a/Pastura/Pastura/App/YAMLReplayExporter.swift
+++ b/Pastura/Pastura/App/YAMLReplayExporter.swift
@@ -58,10 +58,11 @@ nonisolated enum YAMLReplayExporterError: Error, LocalizedError, Equatable {
 /// shared schema constants. File writing is thread-safe through
 /// `FileManager`.
 nonisolated struct YAMLReplayExporter {  // swiftlint:disable:this type_body_length
-  /// Current on-disk schema version. Must match ``YAMLReplaySource``'s
-  /// `supportedSchemaVersion` so round-trip works without a version
-  /// negotiation step.
-  static let schemaVersion = 1
+  /// Current on-disk schema version. Must be a MEMBER of
+  /// ``YAMLReplaySource/supportedSchemaVersions`` so round-trip works
+  /// without a version negotiation step — membership, not equality, since
+  /// that set also carries the older versions still readable (spec §3.5).
+  static let schemaVersion = 2
 
   /// Output bundle returned to the caller. Mirrors
   /// ``ResultMarkdownExporter/ExportedResult`` so the Share Sheet
@@ -208,6 +209,12 @@ nonisolated struct YAMLReplayExporter {  // swiftlint:disable:this type_body_len
       let phaseIndex = phaseIndices[safe: idx] ?? 0
       lines.append("  - round: \(turn.roundNumber)")
       lines.append("    phase_index: \(phaseIndex)")
+      // `phase_path` (schema v2) is omitted for pre-v6 rows — `turn.phasePath`
+      // reads `nil` when `phasePathJSON` was never captured, and the reader
+      // falls back to `[phase_index]` for those, which is what v1 always meant.
+      if let path = turn.phasePath {
+        lines.append("    phase_path: \(Self.yamlIntArray(path))")
+      }
       lines.append("    phase_type: \(Self.yamlValue(turn.phaseType))")
       lines.append("    agent: \(Self.yamlValue(agent))")
       let fields = Self.decodeTurnFields(turn, filter: contentFilter)
@@ -239,6 +246,10 @@ nonisolated struct YAMLReplayExporter {  // swiftlint:disable:this type_body_len
       let phaseIndex = phaseIndices[safe: idx] ?? 0
       lines.append("  - round: \(event.roundNumber)")
       lines.append("    phase_index: \(phaseIndex)")
+      // Same pre-v6 omission rationale as `renderTurns` above.
+      if let path = event.phasePath {
+        lines.append("    phase_path: \(Self.yamlIntArray(path))")
+      }
       lines.append("    phase_type: \(Self.yamlValue(event.phaseType))")
       lines.append("    summary: \(Self.yamlValue(summary, indent: 4))")
       lines.append(contentsOf: renderPayloadStanza(payload, filter: contentFilter))
@@ -547,6 +558,14 @@ nonisolated struct YAMLReplayExporter {  // swiftlint:disable:this type_body_len
     if text.contains("\n") { return blockScalar(text, baseIndent: indent) }
     if containsControlChars(text) { return doubleQuoted(text) }
     return singleQuoted(text)
+  }
+
+  /// Renders `[Int]` in YAML flow style on one line (e.g. `[1, 0]`), matching
+  /// the spec §3.2 example. A tiny local join rather than routing through
+  /// `yamlValue` — that helper picks scalar quoting strategies for `String`,
+  /// which an `[Int]` flow sequence has no use for.
+  private static func yamlIntArray(_ values: [Int]) -> String {
+    "[\(values.map(String.init).joined(separator: ", "))]"
   }
 
   private static func singleQuoted(_ text: String) -> String {

--- a/Pastura/Pastura/App/YAMLReplayExporter.swift
+++ b/Pastura/Pastura/App/YAMLReplayExporter.swift
@@ -350,27 +350,25 @@ nonisolated struct YAMLReplayExporter {  // swiftlint:disable:this type_body_len
 
   // MARK: - Phase index resolution
 
-  /// Linear walk through `scenario.phases` to resolve each turn's
-  /// `phase_index`. Advances a per-round cursor each time the observed
-  /// `phaseType` changes.
+  /// Resolves each turn's `phase_index`, preferring the lineage persisted
+  /// in `phasePathJSON` (#143) and falling back to a per-round cursor walk
+  /// over `scenario.phases` for rows that predate it.
   ///
-  /// **Limitations (documented, E1 scope):**
-  /// - Two adjacent phases of the same type within one round collapse to
-  ///   the first matching index — the cursor can't tell them apart.
-  /// - Turns produced by sub-phases inside a `conditional` resolve to
-  ///   the outer conditional's index; the denormalised `phase_type` in
-  ///   the emitted YAML will then mismatch `phases[phase_index].type`
-  ///   and fail a strict consistency check.
+  /// `phase_path[0]` IS `phase_index` by definition (spec §3.2, schema v2),
+  /// so where the column is populated there is nothing to infer. That
+  /// retires both limitations the cursor carried:
   ///
-  /// The `phasePathJSON` column landed in #143 so `TurnRecord.phasePath`
-  /// now carries exact lineage (e.g. `[1, 0]` for a sub-phase). This
-  /// resolver still ignores it because the YAML replay schema's
-  /// `phase_index: Int` is a flat top-level index, not a path — teaching
-  /// the schema to represent nested addresses is a separate piece of
-  /// work. For now, the cursor keeps the Phase 2 presets (Word Wolf,
-  /// Prisoner's Dilemma) round-tripping correctly; conditional-heavy
-  /// scenarios hit the documented limitations. Upgrading the schema and
-  /// switching to `phasePath`-aware resolution is tracked as a follow-up.
+  /// - a sub-phase inside a `conditional` no longer resolves to the outer
+  ///   conditional's index, which used to make the denormalised
+  ///   `phase_type` disagree with `phases[phase_index].type`;
+  /// - two adjacent phases of the same type in one round no longer collapse
+  ///   to the first matching index, because nothing is being matched.
+  ///
+  /// **The cursor is still reachable and still carries both limitations.**
+  /// Migration v6 added `phasePathJSON` as nullable with no backfill, so a
+  /// simulation recorded before it exports through the fallback exactly as
+  /// it did before. Deleting the cursor would not simplify this — it would
+  /// change what those rows export to.
   private static func resolvePhaseIndices(
     scenario: Scenario, turns: [TurnRecord]
   ) -> [Int] {
@@ -378,6 +376,10 @@ nonisolated struct YAMLReplayExporter {  // swiftlint:disable:this type_body_len
     var cursorByRound: [Int: Int] = [:]
     var lastTypeByRound: [Int: String] = [:]
     for turn in turns {
+      if let top = turn.phasePath?.first {
+        result.append(top)
+        continue
+      }
       let round = turn.roundNumber
       var cursor = cursorByRound[round] ?? -1
       let lastType = lastTypeByRound[round]
@@ -392,21 +394,25 @@ nonisolated struct YAMLReplayExporter {  // swiftlint:disable:this type_body_len
     return result
   }
 
+  /// Same preference order as ``resolvePhaseIndices(scenario:turns:)``, for
+  /// code-phase events. Kept a separate function because the fallback
+  /// differs: events have no per-round ordering to walk, so the pre-v6 path
+  /// is a first-matching-type lookup rather than a cursor.
   private static func resolveEventPhaseIndices(
     scenario: Scenario, events: [CodePhaseEventRecord]
   ) -> [Int] {
     events.map { event in
+      if let top = event.phasePath?.first { return top }
       if let idx = scenario.phases.firstIndex(where: {
         $0.type.rawValue == event.phaseType
       }) {
         return idx
       }
-      // Not a top-level phase — the event originated inside a
-      // `conditional`'s branch (e.g. `summarize` used in then/else).
-      // `event.phasePath` (persisted since #143) has the exact inner
-      // location, but the YAML replay schema's `phase_index` is flat,
-      // so we still fall back to the conditional's index here and let
-      // the schema upgrade lift this when it lands.
+      // Pre-v6 row whose type is not a top-level phase — the event came
+      // from inside a `conditional`'s branch (e.g. `summarize` in then /
+      // else) and nothing persisted where. The enclosing conditional is the
+      // closest true statement available; a populated `phasePath` takes the
+      // early return above and never reaches this.
       return conditionalFallbackIndex(in: scenario.phases)
     }
   }

--- a/Pastura/Pastura/App/YAMLReplaySource.swift
+++ b/Pastura/Pastura/App/YAMLReplaySource.swift
@@ -20,7 +20,7 @@ import Yams
 nonisolated public enum YAMLReplaySourceError: Error, Equatable {
   /// The YAML could not be parsed as a mapping.
   case malformedYAML(description: String)
-  /// Present but not equal to ``YAMLReplayExporter/schemaVersion``.
+  /// Present but not a member of ``YAMLReplaySource/supportedSchemaVersions``.
   /// `nil` means the `schema_version` key was missing entirely.
   case unsupportedSchemaVersion(Int?)
   /// A required top-level or per-turn key was missing.
@@ -57,6 +57,13 @@ nonisolated public enum YAMLReplaySourceError: Error, Equatable {
 /// (strict preset-only resolution) and future user-replay (arbitrary
 /// saved scenarios).
 nonisolated public final class YAMLReplaySource: ReplaySource {
+
+  /// `schema_version` values this loader accepts (spec §3.5). A v1 entry
+  /// is read as if `phase_path` were `[phase_index]`, which is exact for
+  /// any preset with no `conditional` phase. Dropping a version from this
+  /// set is a breaking change — it requires re-recording every bundled
+  /// demo still at that version first (spec §3.5 "Breaking").
+  public static let supportedSchemaVersions: Set<Int> = [1, 2]
 
   // MARK: - Compiled plan
 
@@ -125,7 +132,7 @@ nonisolated public final class YAMLReplaySource: ReplaySource {
         description: "Top-level is not a mapping.")
     }
     let schemaValue = root["schema_version"] as? Int
-    guard schemaValue == YAMLReplayExporter.schemaVersion else {
+    guard let schemaValue, Self.supportedSchemaVersions.contains(schemaValue) else {
       throw YAMLReplaySourceError.unsupportedSchemaVersion(schemaValue)
     }
 

--- a/Pastura/Pastura/App/YAMLReplaySource.swift
+++ b/Pastura/Pastura/App/YAMLReplaySource.swift
@@ -78,13 +78,13 @@ nonisolated public final class YAMLReplaySource: ReplaySource {
   }
 
   /// Chronological-merge entry used only during init to build
-  /// ``pacedPlan``. Carries the `(round, phase_index, phase_type)`
+  /// ``pacedPlan``. Carries the `(round, phase_path, phase_type)`
   /// coordinates plus a stable secondary sort key so `turns` /
   /// `code_phase_events` can be merged while preserving within-section
   /// source order.
   private struct ChronologicalEntry: Sendable {
     let round: Int
-    let phaseIndex: Int
+    let phasePath: [Int]
     let phaseType: PhaseType
     let sourceOrder: Int
     let paceKind: PacedEvent.Kind
@@ -146,7 +146,7 @@ nonisolated public final class YAMLReplaySource: ReplaySource {
       plan.append(PlannedEvent(kind: .turn, event: parsed.event))
       chronological.append(
         ChronologicalEntry(
-          round: parsed.round, phaseIndex: parsed.phaseIndex,
+          round: parsed.round, phasePath: parsed.phasePath,
           phaseType: parsed.phaseType, sourceOrder: idx,
           paceKind: .turn, event: parsed.event))
     }
@@ -157,11 +157,11 @@ nonisolated public final class YAMLReplaySource: ReplaySource {
       plan.append(PlannedEvent(kind: .codePhase, event: parsed.event))
       chronological.append(
         ChronologicalEntry(
-          round: parsed.round, phaseIndex: parsed.phaseIndex,
+          round: parsed.round, phasePath: parsed.phasePath,
           phaseType: parsed.phaseType,
           // `+ turns.count` keeps turn source-order strictly below
           // code-event source-order for a stable tie-break when two
-          // entries land at the same (round, phase_index).
+          // entries land at the same (round, phase_path).
           sourceOrder: idx + turns.count,
           paceKind: .codePhase, event: parsed.event))
     }
@@ -212,7 +212,7 @@ nonisolated public final class YAMLReplaySource: ReplaySource {
   // MARK: - Paced plan construction
 
   /// Merges turn + code-phase entries chronologically by
-  /// `(round, phase_index, sourceOrder)` and inserts synthesised
+  /// `(round, phase_path, sourceOrder)` and inserts synthesised
   /// `.roundStarted` / `.phaseStarted` lifecycle markers ahead of the
   /// first event of each new round / phase boundary.
   ///
@@ -223,12 +223,19 @@ nonisolated public final class YAMLReplaySource: ReplaySource {
   ) -> [PacedEvent] {
     let sorted = entries.sorted { lhs, rhs in
       if lhs.round != rhs.round { return lhs.round < rhs.round }
-      if lhs.phaseIndex != rhs.phaseIndex { return lhs.phaseIndex < rhs.phaseIndex }
+      // `[Int]` is not `Comparable`, so the lexicographic order is
+      // explicit. It generalises the old integer compare rather than
+      // replacing it: every v1 entry resolves to a length-1 path, for
+      // which this is pointwise identical — which is why no already-shipped
+      // demo changes order.
+      if lhs.phasePath != rhs.phasePath {
+        return lhs.phasePath.lexicographicallyPrecedes(rhs.phasePath)
+      }
       return lhs.sourceOrder < rhs.sourceOrder
     }
     var result: [PacedEvent] = []
     var lastRound: Int?
-    var lastPhaseIndex: Int?
+    var lastPhasePath: [Int]?
     var lastPhaseType: PhaseType?
     for entry in sorted {
       if lastRound != entry.round {
@@ -240,18 +247,19 @@ nonisolated public final class YAMLReplaySource: ReplaySource {
         // Force a phaseStarted synthesis on round transition even if the
         // phase coordinates happen to match the previous round's last
         // phase — semantically a new round's first phase starts fresh.
-        lastPhaseIndex = nil
+        lastPhasePath = nil
         lastPhaseType = nil
       }
-      if lastPhaseIndex != entry.phaseIndex || lastPhaseType != entry.phaseType {
+      if lastPhasePath != entry.phasePath || lastPhaseType != entry.phaseType {
         result.append(
           PacedEvent(
             kind: .lifecycle,
-            // `phasePath: [phaseIndex]` is flattened per the known
-            // fidelity gap documented in ``ReplaySource/plannedEvents()``
-            // (matches ``YAMLReplayExporter.resolvePhaseIndices`` scope).
-            event: .phaseStarted(phaseType: entry.phaseType, phasePath: [entry.phaseIndex])))
-        lastPhaseIndex = entry.phaseIndex
+            // Emitted verbatim: `phase_path` (spec §3.2, v2) is defined to
+            // mean exactly what this payload means, so a branch sub-phase
+            // now reaches the consumer as `[i, j]` rather than collapsing
+            // to the enclosing conditional's index.
+            event: .phaseStarted(phaseType: entry.phaseType, phasePath: entry.phasePath)))
+        lastPhasePath = entry.phasePath
         lastPhaseType = entry.phaseType
       }
       result.append(PacedEvent(kind: entry.paceKind, event: entry.event))
@@ -289,7 +297,7 @@ extension YAMLReplaySource {
   /// build ``pacedPlan`` alongside the existing ``PlannedEvent``.
   private struct ParsedTurn: Sendable {
     let round: Int
-    let phaseIndex: Int
+    let phasePath: [Int]
     let phaseType: PhaseType
     let event: SimulationEvent
   }
@@ -298,9 +306,28 @@ extension YAMLReplaySource {
   /// ``ParsedTurn``.
   private struct ParsedCodeEvent: Sendable {
     let round: Int
-    let phaseIndex: Int
+    let phasePath: [Int]
     let phaseType: PhaseType
     let event: SimulationEvent
+  }
+
+  /// Resolves an entry's phase lineage. `phase_path` (spec §3.2, added in
+  /// v2) is the full path; a v1 entry — or one whose `phase_path` is
+  /// unusable — falls back to `[phase_index]`, exact for any preset with
+  /// no `conditional`.
+  ///
+  /// Deliberately does NOT check `phase_index == phase_path[0]`, nor that
+  /// either resolves to a phase of the declared `phase_type`. Load-time
+  /// leniency is the standing posture here (spec §3.3 / §7.6: the runtime
+  /// loader validates integrity only and silent-skips), and spec §3.3
+  /// names `BundledDemoReplaySourceTests.assertPhaseAlignment` as that
+  /// invariant's sole owner. Adding a second check here would make this a
+  /// mirror of it with no stated reconcile direction.
+  private static func resolvePhasePath(_ raw: [String: Any]) -> [Int] {
+    guard let path = raw["phase_path"] as? [Int], !path.isEmpty else {
+      return [(raw["phase_index"] as? Int) ?? 0]
+    }
+    return path
   }
 
   private static func parseTurn(
@@ -323,10 +350,9 @@ extension YAMLReplaySource {
     // older-schema YAML still parses — the drift guard and consistency
     // check live at the CI level (spec §3.3), not at load time.
     let round = (raw["round"] as? Int) ?? 0
-    let phaseIndex = (raw["phase_index"] as? Int) ?? 0
     return ParsedTurn(
       round: round,
-      phaseIndex: phaseIndex,
+      phasePath: Self.resolvePhasePath(raw),
       phaseType: phaseType,
       event: .agentOutput(
         agent: agent, output: TurnOutput(fields: fields),
@@ -373,7 +399,6 @@ extension YAMLReplaySource {
   ) throws -> ParsedCodeEvent {
     let summary = (raw["summary"] as? String) ?? ""
     let round = (raw["round"] as? Int) ?? 0
-    let phaseIndex = (raw["phase_index"] as? Int) ?? 0
     // `phase_type` is denormalised on code-phase entries in the YAML
     // (spec §3.2). Unknown values are treated as planning-level drift
     // and rejected via ``unknownPhaseType`` — symmetric with turns.
@@ -400,7 +425,8 @@ extension YAMLReplaySource {
       event = .summary(text: summary)
     }
     return ParsedCodeEvent(
-      round: round, phaseIndex: phaseIndex, phaseType: phaseType, event: event)
+      round: round, phasePath: Self.resolvePhasePath(raw),
+      phaseType: phaseType, event: event)
   }
 
   /// Decodes a `payload:` stanza as emitted by ``YAMLReplayExporter``.

--- a/Pastura/Pastura/App/YAMLReplaySource.swift
+++ b/Pastura/Pastura/App/YAMLReplaySource.swift
@@ -326,6 +326,13 @@ extension YAMLReplaySource {
   /// names `BundledDemoReplaySourceTests.assertPhaseAlignment` as that
   /// invariant's sole owner. Adding a second check here would make this a
   /// mirror of it with no stated reconcile direction.
+  ///
+  /// The cast is lenient on purpose, and `BundledDemoReplaySourceTests`
+  /// keying on the KEY'S PRESENCE rather than on cast success is what keeps
+  /// that from being a hole — a `phase_path: ["1", "0"]` would otherwise be
+  /// invisible on both sides at once. That gate is a test, so it covers
+  /// bundle-resident demos only: a future non-bundled consumer (spec §4.5's
+  /// user replay) would reach this fallback with nothing in front of it.
   private static func resolvePhasePath(_ raw: [String: Any]) -> [Int] {
     guard let path = raw["phase_path"] as? [Int], !path.isEmpty else {
       return [(raw["phase_index"] as? Int) ?? 0]

--- a/Pastura/Pastura/App/YAMLReplaySource.swift
+++ b/Pastura/Pastura/App/YAMLReplaySource.swift
@@ -21,7 +21,10 @@ nonisolated public enum YAMLReplaySourceError: Error, Equatable {
   /// The YAML could not be parsed as a mapping.
   case malformedYAML(description: String)
   /// Present but not a member of ``YAMLReplaySource/supportedSchemaVersions``.
-  /// `nil` means the `schema_version` key was missing entirely.
+  /// `nil` covers two shapes, not one: the key was missing, OR its value is
+  /// not an `Int` (`'2'`, `[1]`, `true`) and so did not survive the cast. The
+  /// offending value is not carried — a reader diagnosing a rejected demo
+  /// needs the YAML, not this payload.
   case unsupportedSchemaVersion(Int?)
   /// A required top-level or per-turn key was missing.
   case missingRequiredField(String)

--- a/Pastura/PasturaTests/App/BundledDemoReplaySourceTests+Alignment.swift
+++ b/Pastura/PasturaTests/App/BundledDemoReplaySourceTests+Alignment.swift
@@ -175,17 +175,36 @@ extension BundledDemoReplaySourceTests {
   // in both places at once — these pin the presence-keyed form instead.
 
   @Test func phasePathOfWrongElementTypeIsCaught() throws {
-    // `[true, 0]` is the mirror of the curator's arm (j): there the guard is
-    // load-bearing because `isinstance(True, int)` is True in Python. Swift's
-    // `as?` does not bridge `Bool` to `Int`, so this should already reject —
-    // measured rather than reasoned from bridging behaviour, matching what
-    // `throwsOnBooleanSchemaVersion` does for the version field.
     for badPath in [["1", "0"] as [Any], [true, 0] as [Any]] {
       let found = try diagnostic([
         "phase_index": 1, "phase_path": badPath, "phase_type": "vote"
       ])
       #expect(found?.contains("not a list of Int") == true, "got: \(found ?? "nil")")
     }
+  }
+
+  @Test func parsedBooleanPhasePathElementIsCaught() throws {
+    // The mirror of the curator's arm (j), where the guard is load-bearing
+    // because `isinstance(True, int)` is True in Python. The Swift question is
+    // NOT whether `[Any]` casts to `[Int]` — the arm above settles that — but
+    // which scalar type the PARSER hands back: a Swift `Bool` fails `as? Int`,
+    // an `NSNumber` would succeed and resolve to phase 1. Every other fixture
+    // in this file is hand-built and so cannot see that boundary, which is why
+    // this one goes through Yams.
+    let demo = """
+      schema_version: 2
+      turns:
+        - round: 1
+          phase_index: 1
+          phase_path: [true, 0]
+          phase_type: vote
+          agent: Alice
+          fields: {}
+      """
+    let raw = try BundledDemoReplaySourceTests.parseYAMLAsDictionary(demo)
+    let entry = try #require((raw["turns"] as? [[String: Any]])?.first)
+    let found = Self.alignmentDiagnostic(entry: entry, phases: try conditionalPhases())
+    #expect(found?.contains("not a list of Int") == true, "got: \(found ?? "nil")")
   }
 
   @Test func explicitlyNullPhasePathIsCaught() throws {

--- a/Pastura/PasturaTests/App/BundledDemoReplaySourceTests+Alignment.swift
+++ b/Pastura/PasturaTests/App/BundledDemoReplaySourceTests+Alignment.swift
@@ -1,0 +1,168 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+// Controls for ``BundledDemoReplaySourceTests/alignmentDiagnostic(entry:phases:)``
+// — the sole owner of the demo-replay phase-coordinate invariant (spec §3.3).
+//
+// Why a fixture rather than a shipped demo: no `Resources/DemoPresets/` preset
+// uses a `conditional`, so the enumeration in the parent file cannot reach the
+// conditional arm at all, and never will until such a preset is promoted to a
+// demo preset. That population stays empty by design; these controls are what
+// the arm has instead. They call the helper directly — the enumeration reads
+// from `Bundle.main`, and there is no seam that would let it see a fixture.
+//
+// Extension + sibling file, NOT a new `@Suite` (`.claude/rules/testing.md`).
+extension BundledDemoReplaySourceTests {
+
+  // MARK: - Fixture
+
+  /// `[0]=speak_all, [1]=conditional{then:[vote], else:[summarize]}, [2]=vote`.
+  ///
+  /// The branches hold DIFFERENT types on purpose: with identical types every
+  /// branch-resolution assertion below would hold for the wrong reason, and the
+  /// `branch:`-aware path would be indistinguishable from the union check it
+  /// replaces. `[2]` repeats `then[0]`'s type so a wrong-level resolution has
+  /// somewhere plausible to land.
+  fileprivate static let conditionalScenarioYAML = """
+    id: cond_align
+    language: ja
+    name: Alignment fixture
+    description: ''
+    agents: 2
+    rounds: 1
+    context: ''
+    personas:
+      - name: Alice
+        description: ''
+      - name: Bob
+        description: ''
+    phases:
+      - type: speak_all
+        prompt: say
+        output:
+          statement: string
+      - type: conditional
+        if: 'x > 0'
+        then:
+          - type: vote
+            prompt: vote
+            candidates: agents
+        else:
+          - type: summarize
+            template: "closing"
+      - type: vote
+        prompt: vote again
+        candidates: agents
+    """
+
+  fileprivate func conditionalPhases() throws -> [Phase] {
+    try ScenarioLoader().load(yaml: Self.conditionalScenarioYAML).phases
+  }
+
+  fileprivate func diagnostic(_ entry: [String: Any]) throws -> String? {
+    Self.alignmentDiagnostic(entry: entry, phases: try conditionalPhases())
+  }
+
+  // MARK: - Positive controls
+
+  @Test func alignedTopLevelEntryProducesNoDiagnostic() throws {
+    #expect(
+      try diagnostic([
+        "phase_index": 0, "phase_path": [0], "phase_type": "speak_all"
+      ]) == nil)
+  }
+
+  @Test func alignedThenBranchEntryProducesNoDiagnostic() throws {
+    #expect(
+      try diagnostic([
+        "phase_index": 1, "phase_path": [1, 0], "branch": "then", "phase_type": "vote"
+      ]) == nil)
+  }
+
+  @Test func alignedElseBranchEntryProducesNoDiagnostic() throws {
+    #expect(
+      try diagnostic([
+        "phase_index": 1, "phase_path": [1, 0], "branch": "else", "phase_type": "summarize"
+      ]) == nil)
+  }
+
+  @Test func v1EntryWithoutPhasePathStillPasses() throws {
+    // Back-compat: the shipped demos are all v1 and carry neither field.
+    #expect(try diagnostic(["phase_index": 2, "phase_type": "vote"]) == nil)
+  }
+
+  // MARK: - Negative controls
+
+  @Test func phasePathDisagreeingWithPhaseIndexIsCaught() throws {
+    // `phase_index` IS `phase_path[0]` (spec §3.2), so this is
+    // self-inconsistent without consulting the scenario at all.
+    let found = try diagnostic([
+      "phase_index": 0, "phase_path": [1, 0], "branch": "then", "phase_type": "vote"
+    ])
+    #expect(found?.contains("but phase_index is 0") == true, "got: \(found ?? "nil")")
+  }
+
+  @Test func wrongBranchIsCaught() throws {
+    // The discriminating case for `branch:`. `[1, 0]` is `vote` in the then
+    // branch and `summarize` in the else branch — identical path, so ONLY the
+    // branch tells them apart. Without `branch:` this exact entry passes (the
+    // test below pins that), which is what makes this a real control rather
+    // than a restatement of the union check.
+    let found = try diagnostic([
+      "phase_index": 1, "phase_path": [1, 0], "branch": "else", "phase_type": "vote"
+    ])
+    #expect(found?.contains("which is summarize") == true, "got: \(found ?? "nil")")
+  }
+
+  @Test func wrongBranchIsNotCaughtWithoutTheBranchField() throws {
+    // Negative control for the control above: the same misalignment is INVISIBLE
+    // when `branch:` is absent, because `vote` is in the union of both branches.
+    // Pinning the gap stops a later reader from believing the union check ever
+    // constrained which branch ran.
+    #expect(
+      try diagnostic([
+        "phase_index": 1, "phase_path": [1, 0], "phase_type": "vote"
+      ]) == nil)
+  }
+
+  @Test func typeAbsentFromBothBranchesIsCaught() throws {
+    let found = try diagnostic([
+      "phase_index": 1, "phase_path": [1, 0], "phase_type": "speak_all"
+    ])
+    #expect(found?.contains("is not present") == true, "got: \(found ?? "nil")")
+  }
+
+  @Test func conditionalNamedAsItsOwnPhaseTypeIsCaught() throws {
+    let found = try diagnostic([
+      "phase_index": 1, "phase_path": [1], "phase_type": "conditional"
+    ])
+    #expect(found?.contains("must name a non-conditional") == true, "got: \(found ?? "nil")")
+  }
+
+  @Test func branchIndexOutOfRangeIsCaught() throws {
+    // `then` holds one phase, so `then[3]` names nothing.
+    let found = try diagnostic([
+      "phase_index": 1, "phase_path": [1, 3], "branch": "then", "phase_type": "vote"
+    ])
+    #expect(found?.contains("that branch has 1 phases") == true, "got: \(found ?? "nil")")
+  }
+
+  @Test func overDeepPhasePathIsCaught() throws {
+    let found = try diagnostic([
+      "phase_index": 1, "phase_path": [1, 0, 0], "branch": "then", "phase_type": "vote"
+    ])
+    #expect(found?.contains("depth-1 rule") == true, "got: \(found ?? "nil")")
+  }
+
+  @Test func outOfRangePhaseIndexIsCaught() throws {
+    let found = try diagnostic(["phase_index": 9, "phase_type": "vote"])
+    #expect(found?.contains("out of range") == true, "got: \(found ?? "nil")")
+  }
+
+  @Test func topLevelTypeMismatchIsCaught() throws {
+    let found = try diagnostic(["phase_index": 0, "phase_path": [0], "phase_type": "vote"])
+    #expect(found?.contains("resolves to speak_all") == true, "got: \(found ?? "nil")")
+  }
+}

--- a/Pastura/PasturaTests/App/BundledDemoReplaySourceTests+Alignment.swift
+++ b/Pastura/PasturaTests/App/BundledDemoReplaySourceTests+Alignment.swift
@@ -146,7 +146,7 @@ extension BundledDemoReplaySourceTests {
     let found = try diagnostic([
       "phase_index": 1, "phase_path": [1, 3], "branch": "then", "phase_type": "vote"
     ])
-    #expect(found?.contains("that branch has 1 phases") == true, "got: \(found ?? "nil")")
+    #expect(found?.contains("that branch holds 1 phase(s)") == true, "got: \(found ?? "nil")")
   }
 
   @Test func overDeepPhasePathIsCaught() throws {
@@ -164,5 +164,74 @@ extension BundledDemoReplaySourceTests {
   @Test func topLevelTypeMismatchIsCaught() throws {
     let found = try diagnostic(["phase_index": 0, "phase_path": [0], "phase_type": "vote"])
     #expect(found?.contains("resolves to speak_all") == true, "got: \(found ?? "nil")")
+  }
+
+  // MARK: - Mistyped optional fields
+  //
+  // Both fields are optional, so the obvious spelling is `if let x = entry[k]
+  // as? T`, which SKIPS the check when the cast fails rather than failing it.
+  // `YAMLReplaySource.resolvePhasePath` fails on the identical cast and falls
+  // back to `[phase_index]`, so a wrong-typed `phase_path` would be invisible
+  // in both places at once — these pin the presence-keyed form instead.
+
+  @Test func phasePathOfWrongElementTypeIsCaught() throws {
+    let found = try diagnostic([
+      "phase_index": 1, "phase_path": ["1", "0"], "phase_type": "vote"
+    ])
+    #expect(found?.contains("not a list of Int") == true, "got: \(found ?? "nil")")
+  }
+
+  @Test func phasePathThatIsNotAListIsCaught() throws {
+    let found = try diagnostic([
+      "phase_index": 1, "phase_path": "1,0", "phase_type": "vote"
+    ])
+    #expect(found?.contains("not a list of Int") == true, "got: \(found ?? "nil")")
+  }
+
+  @Test func branchOfWrongTypeIsCaught() throws {
+    let found = try diagnostic([
+      "phase_index": 1, "phase_path": [1, 0], "branch": 0, "phase_type": "vote"
+    ])
+    #expect(found?.contains("not a String") == true, "got: \(found ?? "nil")")
+  }
+
+  // MARK: - Remaining diagnostics
+  //
+  // Every `return` in `alignmentDiagnostic` / `conditionalDiagnostic` needs a
+  // control, or the ones without are the same unverified-guard defect the
+  // negative controls above exist to prevent.
+
+  @Test func emptyPhasePathIsCaught() throws {
+    let found = try diagnostic([
+      "phase_index": 1, "phase_path": [Int](), "phase_type": "vote"
+    ])
+    #expect(found?.contains("phase_path is empty") == true, "got: \(found ?? "nil")")
+  }
+
+  @Test func branchNamingNeitherThenNorElseIsCaught() throws {
+    let found = try diagnostic([
+      "phase_index": 1, "phase_path": [1, 0], "branch": "maybe", "phase_type": "vote"
+    ])
+    #expect(found?.contains("neither 'then' nor 'else'") == true, "got: \(found ?? "nil")")
+  }
+
+  @Test func branchWithoutANestedPathIsCaught() throws {
+    // Reachable from writer drift, not just from a hand-edit: a curator that
+    // emitted `branch:` while the path stayed top-level lands here.
+    let found = try diagnostic([
+      "phase_index": 1, "phase_path": [1], "branch": "then", "phase_type": "vote"
+    ])
+    #expect(
+      found?.contains("without a nested phase_path") == true, "got: \(found ?? "nil")")
+  }
+
+  @Test func missingPhaseIndexIsCaught() throws {
+    let found = try diagnostic(["phase_type": "vote"])
+    #expect(found?.contains("non-Int phase_index") == true, "got: \(found ?? "nil")")
+  }
+
+  @Test func missingPhaseTypeIsCaught() throws {
+    let found = try diagnostic(["phase_index": 0])
+    #expect(found?.contains("non-String phase_type") == true, "got: \(found ?? "nil")")
   }
 }

--- a/Pastura/PasturaTests/App/BundledDemoReplaySourceTests+Alignment.swift
+++ b/Pastura/PasturaTests/App/BundledDemoReplaySourceTests+Alignment.swift
@@ -116,8 +116,10 @@ extension BundledDemoReplaySourceTests {
     // No nested path at all: the entry says only "somewhere inside this
     // conditional", so membership in the union is all the data supports.
     // `score_calc` rather than `speak_all` — the latter is now in the union
-    // (it is `then[1]`), which is exactly what makes the indexed check above
-    // stronger than this one.
+    // (it is `then[1]`), which is exactly what makes
+    // `typeAbsentFromTheIndexedSubPhaseIsCaught` in `+Branch.swift` stronger
+    // than this one. Named rather than pointed at: a "below"/"above" reference
+    // survives neither a reorder nor the file split that stranded this pair.
     let found = try diagnostic(["phase_index": 1, "phase_type": "score_calc"])
     #expect(found?.contains("is not present") == true, "got: \(found ?? "nil")")
   }
@@ -249,9 +251,13 @@ extension BundledDemoReplaySourceTests {
 
   // MARK: - Remaining diagnostics
   //
-  // Every `return` in `alignmentDiagnostic` / `conditionalDiagnostic` needs a
-  // control, or the ones without are the same unverified-guard defect the
-  // negative controls above exist to prevent.
+  // Every `return` in `alignmentDiagnostic`, `phasePathSelfConsistency`,
+  // `conditionalDiagnostic`, `conditionalAsLeafDiagnostic` and
+  // `branchResolvedDiagnostic` needs a control, or the ones without are the
+  // same unverified-guard defect these exist to prevent. All five, not the two
+  // that existed when this was written — the extractions since then moved
+  // exits out of the named pair, and the branch-arm controls now live in
+  // `+Branch.swift`.
 
   @Test func emptyPhasePathIsCaught() throws {
     let found = try diagnostic([

--- a/Pastura/PasturaTests/App/BundledDemoReplaySourceTests+Alignment.swift
+++ b/Pastura/PasturaTests/App/BundledDemoReplaySourceTests+Alignment.swift
@@ -175,8 +175,25 @@ extension BundledDemoReplaySourceTests {
   // in both places at once — these pin the presence-keyed form instead.
 
   @Test func phasePathOfWrongElementTypeIsCaught() throws {
+    // `[true, 0]` is the mirror of the curator's arm (j): there the guard is
+    // load-bearing because `isinstance(True, int)` is True in Python. Swift's
+    // `as?` does not bridge `Bool` to `Int`, so this should already reject —
+    // measured rather than reasoned from bridging behaviour, matching what
+    // `throwsOnBooleanSchemaVersion` does for the version field.
+    for badPath in [["1", "0"] as [Any], [true, 0] as [Any]] {
+      let found = try diagnostic([
+        "phase_index": 1, "phase_path": badPath, "phase_type": "vote"
+      ])
+      #expect(found?.contains("not a list of Int") == true, "got: \(found ?? "nil")")
+    }
+  }
+
+  @Test func explicitlyNullPhasePathIsCaught() throws {
+    // Yams renders a bare `phase_path:` as `NSNull`, which is PRESENT — so the
+    // presence-keyed check rejects it where the loader would benignly fall
+    // back. Deliberate: a writer that emitted the key meant to say something.
     let found = try diagnostic([
-      "phase_index": 1, "phase_path": ["1", "0"], "phase_type": "vote"
+      "phase_index": 1, "phase_path": NSNull(), "phase_type": "vote"
     ])
     #expect(found?.contains("not a list of Int") == true, "got: \(found ?? "nil")")
   }

--- a/Pastura/PasturaTests/App/BundledDemoReplaySourceTests+Alignment.swift
+++ b/Pastura/PasturaTests/App/BundledDemoReplaySourceTests+Alignment.swift
@@ -18,13 +18,20 @@ extension BundledDemoReplaySourceTests {
 
   // MARK: - Fixture
 
-  /// `[0]=speak_all, [1]=conditional{then:[vote], else:[summarize]}, [2]=vote`.
+  /// `[0]=speak_all, [1]=conditional{then:[vote, speak_all], else:[summarize]},
+  /// [2]=vote`.
   ///
-  /// The branches hold DIFFERENT types on purpose: with identical types every
-  /// branch-resolution assertion below would hold for the wrong reason, and the
-  /// `branch:`-aware path would be indistinguishable from the union check it
-  /// replaces. `[2]` repeats `then[0]`'s type so a wrong-level resolution has
-  /// somewhere plausible to land.
+  /// Three properties are load-bearing, each because a simpler fixture makes
+  /// some assertion below hold for the wrong reason:
+  ///
+  /// - the branches hold DIFFERENT types at index 0, or `branch:`-aware
+  ///   resolution would agree with the branch-blind union check everywhere;
+  /// - `then` holds TWO phases, so `speak_all` is in the union of both
+  ///   branches while NOT being what index 0 names — the only shape that can
+  ///   tell an indexed check from a union check (measured: with one phase per
+  ///   branch, reverting the indexed check to a union broke no test);
+  /// - `[2]` repeats `then[0]`'s type, so a wrong-level resolution has
+  ///   somewhere plausible to land.
   fileprivate static let conditionalScenarioYAML = """
     id: cond_align
     language: ja
@@ -49,6 +56,10 @@ extension BundledDemoReplaySourceTests {
           - type: vote
             prompt: vote
             candidates: agents
+          - type: speak_all
+            prompt: say
+            output:
+              statement: string
         else:
           - type: summarize
             template: "closing"
@@ -127,26 +138,91 @@ extension BundledDemoReplaySourceTests {
       ]) == nil)
   }
 
-  @Test func typeAbsentFromBothBranchesIsCaught() throws {
+  @Test func typeAbsentFromTheIndexedSubPhaseIsCaught() throws {
+    // Nested path, no `branch` — the exporter's shape. `[1, 0]` is `vote` in
+    // then and `summarize` in else, so `speak_all` matches neither — even
+    // though it IS in the union of both branches, as `then[1]`. That gap is
+    // the whole difference between this check and the v1 one below.
     let found = try diagnostic([
       "phase_index": 1, "phase_path": [1, 0], "phase_type": "speak_all"
     ])
+    #expect(
+      found?.contains("across the branches") == true, "got: \(found ?? "nil")")
+  }
+
+  @Test func typeAbsentFromBothBranchesIsCaughtInTheV1Shape() throws {
+    // No nested path at all: the entry says only "somewhere inside this
+    // conditional", so membership in the union is all the data supports.
+    // `score_calc` rather than `speak_all` — the latter is now in the union
+    // (it is `then[1]`), which is exactly what makes the indexed check above
+    // stronger than this one.
+    let found = try diagnostic(["phase_index": 1, "phase_type": "score_calc"])
     #expect(found?.contains("is not present") == true, "got: \(found ?? "nil")")
   }
 
-  @Test func conditionalNamedAsItsOwnPhaseTypeIsCaught() throws {
+  @Test func subPhaseIndexBeyondEveryBranchIsCaughtWithoutBranchField() throws {
+    // Without `branch` the range check used to be skipped entirely — the union
+    // of both branches' TYPES accepts any index. `YAMLReplayExporter` emits a
+    // nested `phase_path` and can never emit `branch`, so that writer's output
+    // was the unowned case.
     let found = try diagnostic([
-      "phase_index": 1, "phase_path": [1], "phase_type": "conditional"
+      "phase_index": 1, "phase_path": [1, 7], "phase_type": "summarize"
     ])
-    #expect(found?.contains("must name a non-conditional") == true, "got: \(found ?? "nil")")
+    #expect(
+      found?.contains("no branch holds that many phases") == true,
+      "got: \(found ?? "nil")")
+  }
+
+  @Test func conditionalAsItsOwnLeafTypeIsAccepted() throws {
+    // Correct by spec §3.2: `phase_type` is the type of the phase AT
+    // `phase_path`, and `[1]` is the conditional. `ConditionalHandler.execute`
+    // emits `evaluation.warnings` as `.summary` before `.conditionalEvaluated`
+    // — i.e. at exactly this coordinate — so a demo of a condition naming a
+    // runtime-absent variable produces this entry. The gate used to reject it,
+    // contradicting the spec it enforces.
+    #expect(
+      try diagnostic([
+        "phase_index": 1, "phase_path": [1], "phase_type": "conditional"
+      ]) == nil)
+  }
+
+  @Test func conditionalNestedInsideABranchIsCaught() throws {
+    // The depth-1 rule: a branch sub-phase can never be a conditional, so at a
+    // NESTED path the type is wrong however the outer phase resolves.
+    let found = try diagnostic([
+      "phase_index": 1, "phase_path": [1, 0], "phase_type": "conditional"
+    ])
+    #expect(
+      found?.contains("depth-1 rule forbids") == true, "got: \(found ?? "nil")")
+  }
+
+  @Test func unknownPhaseTypeUnderAConditionalIsCaught() throws {
+    // Split out of the conditional check above; `PhaseType(rawValue:)` failing
+    // is a different fault from naming the conditional itself.
+    let found = try diagnostic([
+      "phase_index": 1, "phase_path": [1, 0], "phase_type": "not_a_phase"
+    ])
+    #expect(
+      found?.contains("must name a non-conditional") == true, "got: \(found ?? "nil")")
+  }
+
+  @Test func nestedPathUnderANonConditionalPhaseIsCaught() throws {
+    // Only a conditional has sub-phases. `[0, 1]` names one under `speak_all`,
+    // which cannot exist — and the reader would still split it into its own
+    // `.phaseStarted`, inflating the progress denominator.
+    let found = try diagnostic([
+      "phase_index": 0, "phase_path": [0, 1], "phase_type": "speak_all"
+    ])
+    #expect(
+      found?.contains("which has no sub-phases") == true, "got: \(found ?? "nil")")
   }
 
   @Test func branchIndexOutOfRangeIsCaught() throws {
-    // `then` holds one phase, so `then[3]` names nothing.
+    // `then` holds two phases, so `then[3]` names nothing.
     let found = try diagnostic([
       "phase_index": 1, "phase_path": [1, 3], "branch": "then", "phase_type": "vote"
     ])
-    #expect(found?.contains("that branch holds 1 phase(s)") == true, "got: \(found ?? "nil")")
+    #expect(found?.contains("that branch holds 2 phase(s)") == true, "got: \(found ?? "nil")")
   }
 
   @Test func overDeepPhasePathIsCaught() throws {

--- a/Pastura/PasturaTests/App/BundledDemoReplaySourceTests+Alignment.swift
+++ b/Pastura/PasturaTests/App/BundledDemoReplaySourceTests+Alignment.swift
@@ -25,14 +25,25 @@ extension BundledDemoReplaySourceTests {
   /// some assertion below hold for the wrong reason:
   ///
   /// - the branches hold DIFFERENT types at index 0, or `branch:`-aware
-  ///   resolution would agree with the branch-blind union check everywhere;
+  ///   resolution would agree with the branch-blind INDEXED check everywhere;
   /// - `then` holds TWO phases, so `speak_all` is in the union of both
-  ///   branches while NOT being what index 0 names — the only shape that can
-  ///   tell an indexed check from a union check (measured: with one phase per
-  ///   branch, reverting the indexed check to a union broke no test);
+  ///   branches while NOT being what index 0 names. That separates the indexed
+  ///   check from a union check on TYPE, which one phase per branch cannot do:
+  ///   there the candidates at index j always ARE the whole union. It is not
+  ///   the only such shape — `subPhaseIndexBeyondEveryBranchIsCaught…`
+  ///   separates them on RANGE with one phase per branch — but range and type
+  ///   are separate exits and both need a control;
   /// - `[2]` repeats `then[0]`'s type, so a wrong-level resolution has
   ///   somewhere plausible to land.
-  fileprivate static let conditionalScenarioYAML = """
+  ///
+  /// Internal rather than file-scoped: the sibling `+Branch.swift` extension
+  /// reads this and ``diagnostic(_:)``, and file scope does not reach an
+  /// extension in another file (`.claude/rules/testing.md` § "Splitting a
+  /// Suite Across Files" records the same trap for `private`). Folded into
+  /// this `///` block rather than sitting under it as `//` — a plain comment
+  /// between a doc comment and its declaration detaches the doc and trips
+  /// `orphaned_doc_comment` (`.claude/rules/build-traps.md`).
+  static let conditionalScenarioYAML = """
     id: cond_align
     language: ja
     name: Alignment fixture
@@ -68,11 +79,11 @@ extension BundledDemoReplaySourceTests {
         candidates: agents
     """
 
-  fileprivate func conditionalPhases() throws -> [Phase] {
+  func conditionalPhases() throws -> [Phase] {
     try ScenarioLoader().load(yaml: Self.conditionalScenarioYAML).phases
   }
 
-  fileprivate func diagnostic(_ entry: [String: Any]) throws -> String? {
+  func diagnostic(_ entry: [String: Any]) throws -> String? {
     Self.alignmentDiagnostic(entry: entry, phases: try conditionalPhases())
   }
 
@@ -82,20 +93,6 @@ extension BundledDemoReplaySourceTests {
     #expect(
       try diagnostic([
         "phase_index": 0, "phase_path": [0], "phase_type": "speak_all"
-      ]) == nil)
-  }
-
-  @Test func alignedThenBranchEntryProducesNoDiagnostic() throws {
-    #expect(
-      try diagnostic([
-        "phase_index": 1, "phase_path": [1, 0], "branch": "then", "phase_type": "vote"
-      ]) == nil)
-  }
-
-  @Test func alignedElseBranchEntryProducesNoDiagnostic() throws {
-    #expect(
-      try diagnostic([
-        "phase_index": 1, "phase_path": [1, 0], "branch": "else", "phase_type": "summarize"
       ]) == nil)
   }
 
@@ -115,41 +112,6 @@ extension BundledDemoReplaySourceTests {
     #expect(found?.contains("but phase_index is 0") == true, "got: \(found ?? "nil")")
   }
 
-  @Test func wrongBranchIsCaught() throws {
-    // The discriminating case for `branch:`. `[1, 0]` is `vote` in the then
-    // branch and `summarize` in the else branch — identical path, so ONLY the
-    // branch tells them apart. Without `branch:` this exact entry passes (the
-    // test below pins that), which is what makes this a real control rather
-    // than a restatement of the union check.
-    let found = try diagnostic([
-      "phase_index": 1, "phase_path": [1, 0], "branch": "else", "phase_type": "vote"
-    ])
-    #expect(found?.contains("which is summarize") == true, "got: \(found ?? "nil")")
-  }
-
-  @Test func wrongBranchIsNotCaughtWithoutTheBranchField() throws {
-    // Negative control for the control above: the same misalignment is INVISIBLE
-    // when `branch:` is absent, because `vote` is in the union of both branches.
-    // Pinning the gap stops a later reader from believing the union check ever
-    // constrained which branch ran.
-    #expect(
-      try diagnostic([
-        "phase_index": 1, "phase_path": [1, 0], "phase_type": "vote"
-      ]) == nil)
-  }
-
-  @Test func typeAbsentFromTheIndexedSubPhaseIsCaught() throws {
-    // Nested path, no `branch` — the exporter's shape. `[1, 0]` is `vote` in
-    // then and `summarize` in else, so `speak_all` matches neither — even
-    // though it IS in the union of both branches, as `then[1]`. That gap is
-    // the whole difference between this check and the v1 one below.
-    let found = try diagnostic([
-      "phase_index": 1, "phase_path": [1, 0], "phase_type": "speak_all"
-    ])
-    #expect(
-      found?.contains("across the branches") == true, "got: \(found ?? "nil")")
-  }
-
   @Test func typeAbsentFromBothBranchesIsCaughtInTheV1Shape() throws {
     // No nested path at all: the entry says only "somewhere inside this
     // conditional", so membership in the union is all the data supports.
@@ -158,19 +120,6 @@ extension BundledDemoReplaySourceTests {
     // stronger than this one.
     let found = try diagnostic(["phase_index": 1, "phase_type": "score_calc"])
     #expect(found?.contains("is not present") == true, "got: \(found ?? "nil")")
-  }
-
-  @Test func subPhaseIndexBeyondEveryBranchIsCaughtWithoutBranchField() throws {
-    // Without `branch` the range check used to be skipped entirely — the union
-    // of both branches' TYPES accepts any index. `YAMLReplayExporter` emits a
-    // nested `phase_path` and can never emit `branch`, so that writer's output
-    // was the unowned case.
-    let found = try diagnostic([
-      "phase_index": 1, "phase_path": [1, 7], "phase_type": "summarize"
-    ])
-    #expect(
-      found?.contains("no branch holds that many phases") == true,
-      "got: \(found ?? "nil")")
   }
 
   @Test func conditionalAsItsOwnLeafTypeIsAccepted() throws {
@@ -206,6 +155,12 @@ extension BundledDemoReplaySourceTests {
       found?.contains("must name a non-conditional") == true, "got: \(found ?? "nil")")
   }
 
+  @Test func conditionalAsLeafIsAcceptedInTheV1Shape() throws {
+    // The pre-v6 exporter row omits `phase_path` entirely, so this — not the
+    // `[1]` form — is the shipped-data shape of the accept above.
+    #expect(try diagnostic(["phase_index": 1, "phase_type": "conditional"]) == nil)
+  }
+
   @Test func nestedPathUnderANonConditionalPhaseIsCaught() throws {
     // Only a conditional has sub-phases. `[0, 1]` names one under `speak_all`,
     // which cannot exist — and the reader would still split it into its own
@@ -215,14 +170,6 @@ extension BundledDemoReplaySourceTests {
     ])
     #expect(
       found?.contains("which has no sub-phases") == true, "got: \(found ?? "nil")")
-  }
-
-  @Test func branchIndexOutOfRangeIsCaught() throws {
-    // `then` holds two phases, so `then[3]` names nothing.
-    let found = try diagnostic([
-      "phase_index": 1, "phase_path": [1, 3], "branch": "then", "phase_type": "vote"
-    ])
-    #expect(found?.contains("that branch holds 2 phase(s)") == true, "got: \(found ?? "nil")")
   }
 
   @Test func overDeepPhasePathIsCaught() throws {
@@ -300,13 +247,6 @@ extension BundledDemoReplaySourceTests {
     #expect(found?.contains("not a list of Int") == true, "got: \(found ?? "nil")")
   }
 
-  @Test func branchOfWrongTypeIsCaught() throws {
-    let found = try diagnostic([
-      "phase_index": 1, "phase_path": [1, 0], "branch": 0, "phase_type": "vote"
-    ])
-    #expect(found?.contains("not a String") == true, "got: \(found ?? "nil")")
-  }
-
   // MARK: - Remaining diagnostics
   //
   // Every `return` in `alignmentDiagnostic` / `conditionalDiagnostic` needs a
@@ -318,23 +258,6 @@ extension BundledDemoReplaySourceTests {
       "phase_index": 1, "phase_path": [Int](), "phase_type": "vote"
     ])
     #expect(found?.contains("phase_path is empty") == true, "got: \(found ?? "nil")")
-  }
-
-  @Test func branchNamingNeitherThenNorElseIsCaught() throws {
-    let found = try diagnostic([
-      "phase_index": 1, "phase_path": [1, 0], "branch": "maybe", "phase_type": "vote"
-    ])
-    #expect(found?.contains("neither 'then' nor 'else'") == true, "got: \(found ?? "nil")")
-  }
-
-  @Test func branchWithoutANestedPathIsCaught() throws {
-    // Reachable from writer drift, not just from a hand-edit: a curator that
-    // emitted `branch:` while the path stayed top-level lands here.
-    let found = try diagnostic([
-      "phase_index": 1, "phase_path": [1], "branch": "then", "phase_type": "vote"
-    ])
-    #expect(
-      found?.contains("without a nested phase_path") == true, "got: \(found ?? "nil")")
   }
 
   @Test func missingPhaseIndexIsCaught() throws {

--- a/Pastura/PasturaTests/App/BundledDemoReplaySourceTests+Branch.swift
+++ b/Pastura/PasturaTests/App/BundledDemoReplaySourceTests+Branch.swift
@@ -1,0 +1,153 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+// Branch-resolution controls for
+// ``BundledDemoReplaySourceTests/conditionalDiagnostic(entry:phaseTypeRaw:phase:phaseIndex:)``
+// and its two extracted arms.
+//
+// Split from `+Alignment.swift`, which holds the fixture and the
+// coordinate-shape controls, because that file reached SwiftLint's 400-line
+// `file_length` cap — measured: a 502-line file inside `included:` reddens
+// `--strict`. (`swiftlint --path <file>` does not reproduce it, reporting no
+// violation even at 1001 lines; do not conclude the cap is inert from that
+// form.) The fixture and the `diagnostic(_:)` helper stay in `+Alignment.swift`
+// and are reachable here only because this split widened them to internal —
+// file scope does not reach an extension in another file, the same trap
+// `.claude/rules/testing.md` § "Splitting a Suite Across Files" records for
+// `private`. (An earlier draft of this header asserted they were already
+// unscoped; they were not, and the build said so.)
+//
+// Extension + sibling file, NOT a new `@Suite`.
+extension BundledDemoReplaySourceTests {
+
+  @Test func alignedThenBranchEntryProducesNoDiagnostic() throws {
+    #expect(
+      try diagnostic([
+        "phase_index": 1, "phase_path": [1, 0], "branch": "then", "phase_type": "vote"
+      ]) == nil)
+  }
+
+  @Test func alignedElseBranchEntryProducesNoDiagnostic() throws {
+    #expect(
+      try diagnostic([
+        "phase_index": 1, "phase_path": [1, 0], "branch": "else", "phase_type": "summarize"
+      ]) == nil)
+  }
+
+  @Test func wrongBranchIsCaught() throws {
+    // The discriminating case for `branch:`. `[1, 0]` is `vote` in the then
+    // branch and `summarize` in the else branch — identical path, so ONLY the
+    // branch tells them apart. Without `branch:` this exact entry passes (the
+    // test below pins that), which is what makes this a real control rather
+    // than a restatement of the union check.
+    let found = try diagnostic([
+      "phase_index": 1, "phase_path": [1, 0], "branch": "else", "phase_type": "vote"
+    ])
+    #expect(found?.contains("which is summarize") == true, "got: \(found ?? "nil")")
+  }
+
+  @Test func wrongBranchIsNotCaughtWithoutTheBranchField() throws {
+    // Negative control for the control above: the same misalignment is INVISIBLE
+    // when `branch:` is absent, because SOME branch holds `vote` at index 0 —
+    // `then` does — and only `branch:` says which one ran. Pinning the gap
+    // stops a later reader from over-trusting the branch-blind check. (Not the
+    // union check: this path stopped using one when the indexed check landed.)
+    #expect(
+      try diagnostic([
+        "phase_index": 1, "phase_path": [1, 0], "phase_type": "vote"
+      ]) == nil)
+  }
+
+  @Test func branchOfWrongTypeIsCaught() throws {
+    let found = try diagnostic([
+      "phase_index": 1, "phase_path": [1, 0], "branch": 0, "phase_type": "vote"
+    ])
+    #expect(found?.contains("not a String") == true, "got: \(found ?? "nil")")
+  }
+
+  @Test func branchNamingNeitherThenNorElseIsCaught() throws {
+    let found = try diagnostic([
+      "phase_index": 1, "phase_path": [1, 0], "branch": "maybe", "phase_type": "vote"
+    ])
+    #expect(found?.contains("neither 'then' nor 'else'") == true, "got: \(found ?? "nil")")
+  }
+
+  @Test func branchWithoutANestedPathIsCaught() throws {
+    // Reachable from writer drift, not just from a hand-edit: a curator that
+    // emitted `branch:` while the path stayed top-level lands here.
+    let found = try diagnostic([
+      "phase_index": 1, "phase_path": [1], "branch": "then", "phase_type": "vote"
+    ])
+    #expect(
+      found?.contains("without a nested phase_path") == true, "got: \(found ?? "nil")")
+  }
+
+  @Test func branchIndexOutOfRangeIsCaught() throws {
+    // `then` holds two phases, so `then[3]` names nothing.
+    let found = try diagnostic([
+      "phase_index": 1, "phase_path": [1, 3], "branch": "then", "phase_type": "vote"
+    ])
+    #expect(found?.contains("that branch holds 2 phase(s)") == true, "got: \(found ?? "nil")")
+  }
+
+  @Test func subPhaseIndexBeyondEveryBranchIsCaughtWithoutBranchField() throws {
+    // Without `branch` the range check used to be skipped entirely — the union
+    // of both branches' TYPES accepts any index. `YAMLReplayExporter` emits a
+    // nested `phase_path` and can never emit `branch`, so that writer's output
+    // was the unowned case.
+    let found = try diagnostic([
+      "phase_index": 1, "phase_path": [1, 7], "phase_type": "summarize"
+    ])
+    #expect(
+      found?.contains("no branch holds that many phases") == true,
+      "got: \(found ?? "nil")")
+  }
+
+  @Test func typeAbsentFromTheIndexedSubPhaseIsCaught() throws {
+    // Nested path, no `branch` — the exporter's shape. `[1, 0]` is `vote` in
+    // then and `summarize` in else, so `speak_all` matches neither — even
+    // though it IS in the union of both branches, as `then[1]`. That gap is
+    // the whole difference between this check and the v1 one below.
+    let found = try diagnostic([
+      "phase_index": 1, "phase_path": [1, 0], "phase_type": "speak_all"
+    ])
+    #expect(
+      found?.contains("across the branches") == true, "got: \(found ?? "nil")")
+  }
+
+  @Test func branchAlongsideTheConditionalItselfIsCaught() throws {
+    // The exit that accepts `phase_type: conditional` returns early, so
+    // everything below it is skipped — including the whole `branch:` arm. An
+    // earlier revision placed it above that arm, which accepted all four
+    // shapes below outright.
+    for branch in ["then", "else", "maybe"] {
+      let found = try diagnostic([
+        "phase_index": 1, "phase_path": [1], "branch": branch,
+        "phase_type": "conditional"
+      ])
+      #expect(
+        found?.contains("but `branch:` claims") == true,
+        "branch '\(branch)' — got: \(found ?? "nil")")
+    }
+  }
+
+  @Test func nonStringBranchAlongsideTheConditionalItselfIsCaught() throws {
+    // `branch: 0` is the shape that bypassed the presence-not-cast String
+    // check, so it gets its own arm rather than riding the loop above.
+    let found = try diagnostic([
+      "phase_index": 1, "phase_path": [1], "branch": 0, "phase_type": "conditional"
+    ])
+    #expect(found?.contains("but `branch:` claims") == true, "got: \(found ?? "nil")")
+  }
+
+  @Test func branchOnANonConditionalPhaseIsCaught() throws {
+    // Only a conditional has branches. Same fault class as the Critical one
+    // level up: a field the coordinate cannot support, silently ignored.
+    let found = try diagnostic([
+      "phase_index": 0, "phase_path": [0], "branch": "then", "phase_type": "speak_all"
+    ])
+    #expect(found?.contains("which has no branches") == true, "got: \(found ?? "nil")")
+  }
+}

--- a/Pastura/PasturaTests/App/BundledDemoReplaySourceTests+Branch.swift
+++ b/Pastura/PasturaTests/App/BundledDemoReplaySourceTests+Branch.swift
@@ -14,10 +14,17 @@ import Testing
 // argument. Two things DO suppress it, and both misled a measurement of this
 // during review: a probe file placed outside `.swiftlint.yml`'s `included:`
 // scope (path-independent rules still fire there, so the run looks live), and
-// the parent file's own blanket `file_length` disable directive on its first
-// line. (Named, not quoted: SwiftLint parses the directive's literal text
-// wherever it appears, so writing it out here would switch the rule off for
-// THIS file — a comment about a directive must not spell the directive.) The fixture and the `diagnostic(_:)` helper stay in `+Alignment.swift`
+// the blanket `file_length` disable directive near the top of the parent file
+// (line 6).
+//
+// Named, not quoted, because SwiftLint parses a directive's literal text
+// wherever it appears — including inside prose about it. Quoting it here
+// reddened this file with `blanket_disable_command` plus
+// `superfluous_disable_command`, the latter reporting the rule name as invalid
+// because the surrounding backtick was swept into it. So the hazard is LOUD,
+// not a silently-disabled rule: someone who spells it out is told at once.
+//
+// The fixture and the `diagnostic(_:)` helper stay in `+Alignment.swift`
 // and are reachable here only because this split widened them to internal —
 // file scope does not reach an extension in another file, the same trap
 // `.claude/rules/testing.md` § "Splitting a Suite Across Files" records for

--- a/Pastura/PasturaTests/App/BundledDemoReplaySourceTests+Branch.swift
+++ b/Pastura/PasturaTests/App/BundledDemoReplaySourceTests+Branch.swift
@@ -9,10 +9,15 @@ import Testing
 //
 // Split from `+Alignment.swift`, which holds the fixture and the
 // coordinate-shape controls, because that file reached SwiftLint's 400-line
-// `file_length` cap — measured: a 502-line file inside `included:` reddens
-// `--strict`. (`swiftlint --path <file>` does not reproduce it, reporting no
-// violation even at 1001 lines; do not conclude the cap is inert from that
-// form.) The fixture and the `diagnostic(_:)` helper stay in `+Alignment.swift`
+// `file_length` cap — measured: a 502-line file under `Pastura/` reddens
+// `swiftlint lint --strict`, both whole-tree and with the file as a positional
+// argument. Two things DO suppress it, and both misled a measurement of this
+// during review: a probe file placed outside `.swiftlint.yml`'s `included:`
+// scope (path-independent rules still fire there, so the run looks live), and
+// the parent file's own blanket `file_length` disable directive on its first
+// line. (Named, not quoted: SwiftLint parses the directive's literal text
+// wherever it appears, so writing it out here would switch the rule off for
+// THIS file — a comment about a directive must not spell the directive.) The fixture and the `diagnostic(_:)` helper stay in `+Alignment.swift`
 // and are reachable here only because this split widened them to internal —
 // file scope does not reach an extension in another file, the same trap
 // `.claude/rules/testing.md` § "Splitting a Suite Across Files" records for
@@ -41,7 +46,7 @@ extension BundledDemoReplaySourceTests {
     // branch and `summarize` in the else branch — identical path, so ONLY the
     // branch tells them apart. Without `branch:` this exact entry passes (the
     // test below pins that), which is what makes this a real control rather
-    // than a restatement of the union check.
+    // than a restatement of the branch-blind indexed check.
     let found = try diagnostic([
       "phase_index": 1, "phase_path": [1, 0], "branch": "else", "phase_type": "vote"
     ])
@@ -109,7 +114,9 @@ extension BundledDemoReplaySourceTests {
     // Nested path, no `branch` — the exporter's shape. `[1, 0]` is `vote` in
     // then and `summarize` in else, so `speak_all` matches neither — even
     // though it IS in the union of both branches, as `then[1]`. That gap is
-    // the whole difference between this check and the v1 one below.
+    // the whole difference between this check and
+    // `typeAbsentFromBothBranchesIsCaughtInTheV1Shape` in `+Alignment.swift`,
+    // which is where the union check still runs.
     let found = try diagnostic([
       "phase_index": 1, "phase_path": [1, 0], "phase_type": "speak_all"
     ])

--- a/Pastura/PasturaTests/App/BundledDemoReplaySourceTests+Branch.swift
+++ b/Pastura/PasturaTests/App/BundledDemoReplaySourceTests+Branch.swift
@@ -11,25 +11,16 @@ import Testing
 // coordinate-shape controls, because that file reached SwiftLint's 400-line
 // `file_length` cap — measured: a 502-line file under `Pastura/` reddens
 // `swiftlint lint --strict`, both whole-tree and with the file as a positional
-// argument. Two things DO suppress it, and both misled a measurement of this
-// during review: a probe file placed outside `.swiftlint.yml`'s `included:`
-// scope (path-independent rules still fire there, so the run looks live), and
-// the blanket `file_length` disable directive near the top of the parent file
-// (line 6).
-//
-// Named, not quoted, because SwiftLint parses a directive's literal text
-// wherever it appears — including inside prose about it. Quoting it here
-// reddened this file with `blanket_disable_command` plus
-// `superfluous_disable_command`, the latter reporting the rule name as invalid
-// because the surrounding backtick was swept into it. So the hazard is LOUD,
-// not a silently-disabled rule: someone who spells it out is told at once.
+// argument. Two things suppress that rule and made it look unenabled during
+// review; both are in `.claude/rules/build-traps.md`, along with why prose in
+// a `.swift` file must never spell out a disable directive's literal text —
+// SwiftLint parses one wherever it appears, a paragraph about it included.
 //
 // The fixture and the `diagnostic(_:)` helper stay in `+Alignment.swift`
 // and are reachable here only because this split widened them to internal —
 // file scope does not reach an extension in another file, the same trap
 // `.claude/rules/testing.md` § "Splitting a Suite Across Files" records for
-// `private`. (An earlier draft of this header asserted they were already
-// unscoped; they were not, and the build said so.)
+// `private`.
 //
 // Extension + sibling file, NOT a new `@Suite`.
 extension BundledDemoReplaySourceTests {

--- a/Pastura/PasturaTests/App/BundledDemoReplaySourceTests.swift
+++ b/Pastura/PasturaTests/App/BundledDemoReplaySourceTests.swift
@@ -468,8 +468,7 @@ struct BundledDemoReplaySourceTests {
           which has no branches
           """
       }
-    }
-    if resolved == .conditional {
+    } else {
       return conditionalDiagnostic(
         entry: entry, phaseTypeRaw: phaseTypeRaw, phase: phases[phaseIndex],
         phaseIndex: phaseIndex)

--- a/Pastura/PasturaTests/App/BundledDemoReplaySourceTests.swift
+++ b/Pastura/PasturaTests/App/BundledDemoReplaySourceTests.swift
@@ -386,6 +386,40 @@ struct BundledDemoReplaySourceTests {
     Issue.record(Comment(rawValue: "\(label): \(diagnostic)"))
   }
 
+  /// Checks `phase_path` against `phase_index` alone — no scenario needed.
+  ///
+  /// `phase_index` IS `phase_path[0]` by definition (spec §3.2), so a demo
+  /// carrying both and disagreeing is self-inconsistent before any preset is
+  /// consulted; that is why this runs first.
+  ///
+  /// Keyed on the key's PRESENCE, not on cast success. `as? [Int]` inside an
+  /// `if let` would skip the whole block for `phase_path: ["1", "0"]` — and
+  /// `YAMLReplaySource.resolvePhasePath` fails on the identical cast, falling
+  /// back to `[phase_index]`. Two checks that fail on the same predicate detect
+  /// nothing between them, and spec §3.3 makes this the only owner, so nothing
+  /// downstream would catch it either.
+  private static func phasePathSelfConsistency(
+    entry: [String: Any], phaseIndex: Int
+  ) -> String? {
+    guard entry["phase_path"] != nil else { return nil }
+    guard let path = entry["phase_path"] as? [Int] else {
+      return "phase_path is present but is not a list of Int"
+    }
+    guard let top = path.first else {
+      return "phase_path is empty; it must name at least the top-level phase"
+    }
+    guard top == phaseIndex else {
+      return "phase_path \(path) starts at \(top) but phase_index is \(phaseIndex)"
+    }
+    guard path.count <= 2 else {
+      return """
+        phase_path \(path) is \(path.count) deep, but the engine's depth-1 rule \
+        bounds it to 2 (ScenarioLoader.parsePhaseType refuses a nested conditional)
+        """
+    }
+    return nil
+  }
+
   /// Returns nil when `entry`'s phase coordinates are consistent with
   /// `phases`, or a diagnostic naming the first inconsistency found.
   ///
@@ -405,37 +439,25 @@ struct BundledDemoReplaySourceTests {
     guard let phaseTypeRaw = entry["phase_type"] as? String else {
       return "missing or non-String phase_type"
     }
-    // `phase_index` IS `phase_path[0]` by definition (spec §3.2), so a
-    // demo carrying both and disagreeing is self-inconsistent before any
-    // scenario is consulted — checked first for that reason.
-    //
-    // Keyed on PRESENCE, not on cast success. `as? [Int]` inside an `if let`
-    // would skip this whole block for `phase_path: ["1", "0"]` — and
-    // `YAMLReplaySource.resolvePhasePath` fails on the identical cast, falling
-    // back to `[phase_index]`. Two checks that fail on the same predicate
-    // detect nothing between them, and spec §3.3 makes this function the only
-    // owner, so nothing downstream would catch it either.
-    if entry["phase_path"] != nil {
-      guard let path = entry["phase_path"] as? [Int] else {
-        return "phase_path is present but is not a list of Int"
-      }
-      guard let top = path.first else {
-        return "phase_path is empty; it must name at least the top-level phase"
-      }
-      guard top == phaseIndex else {
-        return "phase_path \(path) starts at \(top) but phase_index is \(phaseIndex)"
-      }
-      guard path.count <= 2 else {
-        return """
-          phase_path \(path) is \(path.count) deep, but the engine's depth-1 rule \
-          bounds it to 2 (ScenarioLoader.parsePhaseType refuses a nested conditional)
-          """
-      }
+    if let selfConsistency = phasePathSelfConsistency(entry: entry, phaseIndex: phaseIndex) {
+      return selfConsistency
     }
     guard phases.indices.contains(phaseIndex) else {
       return "phase_index \(phaseIndex) is out of range (scenario has \(phases.count) phases)"
     }
     let resolved = phases[phaseIndex].type
+    // Only a `conditional` has sub-phases, so a nested path anywhere else names
+    // something that cannot exist. Checked here rather than in the `phase_path`
+    // block above because it needs the resolved phase; without it the second
+    // component was simply dropped and `phases[i].type == phase_type` decided
+    // the entry — while the reader still splits it from an adjacent `[i]` into
+    // its own `.phaseStarted`, inflating `phaseProgress`.
+    if resolved != .conditional, let path = entry["phase_path"] as? [Int], path.count > 1 {
+      return """
+        phase_path \(path) is nested, but phase_index \(phaseIndex) is \
+        \(resolved.rawValue), which has no sub-phases
+        """
+    }
     if resolved == .conditional {
       return conditionalDiagnostic(
         entry: entry, phaseTypeRaw: phaseTypeRaw, phase: phases[phaseIndex],
@@ -457,12 +479,28 @@ struct BundledDemoReplaySourceTests {
   /// With `branch:` present (curator-written; `YAMLReplayExporter` cannot
   /// supply it) the exact sub-phase is resolved and a type mismatch is
   /// caught. Without it the check stays as loose as the data allows —
-  /// `then[j]` and `else[j]` share a `phase_path`, so only membership in
-  /// the union of both branches can be asserted.
+  /// `then[j]` and `else[j]` share a `phase_path`, so the assertion is that
+  /// SOME branch holds a phase of that type at index `j`.
   private static func conditionalDiagnostic(
     entry: [String: Any], phaseTypeRaw: String, phase: Phase, phaseIndex: Int
   ) -> String? {
-    if PhaseType(rawValue: phaseTypeRaw).map({ $0 == .conditional }) ?? true {
+    let nested = (entry["phase_path"] as? [Int])?.dropFirst().first
+    if phaseTypeRaw == PhaseType.conditional.rawValue {
+      // Correct-by-spec when the coordinate names the CONDITIONAL ITSELF:
+      // §3.2 defines `phase_type` as the type of the phase at `phase_path`,
+      // and for `[i]` that is the conditional. Reachable, not hypothetical —
+      // `ConditionalHandler.execute` emits each `evaluation.warnings` entry as
+      // a `.summary` BEFORE `.conditionalEvaluated`, i.e. while the current
+      // phase is still the conditional at `[i]`, so a demo of a condition
+      // referencing a runtime-absent variable carries exactly this shape.
+      guard nested != nil else { return nil }
+      return """
+        phase_path names a sub-phase of the conditional at \(phaseIndex), so \
+        phase_type 'conditional' cannot be right — the depth-1 rule forbids a \
+        conditional inside a branch
+        """
+    }
+    guard PhaseType(rawValue: phaseTypeRaw) != nil else {
       return """
         phase_index \(phaseIndex) is a conditional in the preset; demo phase_type \
         '\(phaseTypeRaw)' must name a non-conditional sub-phase type
@@ -471,42 +509,83 @@ struct BundledDemoReplaySourceTests {
     let thenPhases = phase.thenPhases ?? []
     let elsePhases = phase.elsePhases ?? []
     if entry["branch"] != nil {
-      // Same presence-not-cast rule as `phase_path` above: `branch: 0` would
-      // otherwise fall through to the loose union check with no diagnostic.
-      guard let branch = entry["branch"] as? String else {
-        return "branch is present but is not a String"
+      return branchResolvedDiagnostic(
+        entry: entry, phaseTypeRaw: phaseTypeRaw,
+        thenPhases: thenPhases, elsePhases: elsePhases, inner: nested)
+    }
+    // No `branch:` — `YAMLReplayExporter`'s shape, since nothing persists the
+    // branch. When the path IS nested, index each branch at `j` rather than
+    // taking the union of every sub-phase type: the union accepts `[1, 7]`
+    // against a one-phase branch, so the range case would be unowned for that
+    // writer. A type-equivalent pair at the same `j` still passes — both
+    // branches carry that type, so nothing here can tell them apart. That
+    // residue is what `branch:` is for.
+    if let inner = nested {
+      let candidates = [thenPhases, elsePhases].compactMap { branchPhases in
+        branchPhases.indices.contains(inner) ? branchPhases[inner] : nil
       }
-      guard branch == "then" || branch == "else" else {
-        return "branch '\(branch)' is neither 'then' nor 'else'"
-      }
-      let taken = branch == "then" ? thenPhases : elsePhases
-      guard let inner = (entry["phase_path"] as? [Int])?.dropFirst().first else {
-        return "branch '\(branch)' given without a nested phase_path to index into it"
-      }
-      guard taken.indices.contains(inner) else {
+      guard !candidates.isEmpty else {
         return """
-          phase_path names \(branch)[\(inner)], but that branch holds \
-          \(taken.count) phase(s)
+          phase_path names sub-phase \(inner) of the conditional at \(phaseIndex), \
+          but no branch holds that many phases (then: \(thenPhases.count), \
+          else: \(elsePhases.count))
           """
       }
-      guard taken[inner].type.rawValue == phaseTypeRaw else {
+      guard candidates.contains(where: { $0.type.rawValue == phaseTypeRaw }) else {
         return """
-          phase_path names \(branch)[\(inner)], which is \(taken[inner].type.rawValue), \
-          but demo declares phase_type: \(phaseTypeRaw)
+          phase_path names sub-phase \(inner), which is \
+          \(candidates.map { $0.type.rawValue }) across the branches; demo \
+          declares phase_type: \(phaseTypeRaw)
           """
       }
       return nil
     }
-    // No `branch:` — the pre-v2 shape. Catches literal-swap drift (a
-    // curator reorders outer slots so `phase_type` now points at a
-    // conditional whose branches lack that type), but a type-equivalent
-    // reorder within the branches still passes: both carry the same type,
-    // so nothing here can tell them apart. That is what `branch:` is for.
+    // No nested path either — the v1 shape, where the entry says only "somewhere
+    // inside this conditional". Membership in the union is all the data supports.
     let subPhaseTypes = (thenPhases + elsePhases).map { $0.type.rawValue }
     guard subPhaseTypes.contains(phaseTypeRaw) else {
       return """
         phase_index \(phaseIndex) is a conditional whose branches contain \
         \(subPhaseTypes); demo phase_type '\(phaseTypeRaw)' is not present
+        """
+    }
+    return nil
+  }
+
+  /// The `branch:`-present arm of ``conditionalDiagnostic``. Extracted so that
+  /// function stays under SwiftLint's `cyclomatic_complexity` and
+  /// `function_body_length` caps — per `.claude/rules/build-traps.md`, the fix
+  /// for those is a helper, not a `swiftlint:disable` directive.
+  ///
+  /// Only the curator writes `branch:` (nothing persists it, so
+  /// `YAMLReplayExporter` cannot), and it is what makes the leaf-type check
+  /// exact rather than branch-blind.
+  private static func branchResolvedDiagnostic(
+    entry: [String: Any], phaseTypeRaw: String,
+    thenPhases: [Phase], elsePhases: [Phase], inner: Int?
+  ) -> String? {
+    // Same presence-not-cast rule as `phase_path`: `branch: 0` would otherwise
+    // fall through to the branch-blind arm with no diagnostic.
+    guard let branch = entry["branch"] as? String else {
+      return "branch is present but is not a String"
+    }
+    guard branch == "then" || branch == "else" else {
+      return "branch '\(branch)' is neither 'then' nor 'else'"
+    }
+    let taken = branch == "then" ? thenPhases : elsePhases
+    guard let inner else {
+      return "branch '\(branch)' given without a nested phase_path to index into it"
+    }
+    guard taken.indices.contains(inner) else {
+      return """
+        phase_path names \(branch)[\(inner)], but that branch holds \
+        \(taken.count) phase(s)
+        """
+    }
+    guard taken[inner].type.rawValue == phaseTypeRaw else {
+      return """
+        phase_path names \(branch)[\(inner)], which is \(taken[inner].type.rawValue), \
+        but demo declares phase_type: \(phaseTypeRaw)
         """
     }
     return nil

--- a/Pastura/PasturaTests/App/BundledDemoReplaySourceTests.swift
+++ b/Pastura/PasturaTests/App/BundledDemoReplaySourceTests.swift
@@ -452,11 +452,22 @@ struct BundledDemoReplaySourceTests {
     // component was simply dropped and `phases[i].type == phase_type` decided
     // the entry — while the reader still splits it from an adjacent `[i]` into
     // its own `.phaseStarted`, inflating `phaseProgress`.
-    if resolved != .conditional, let path = entry["phase_path"] as? [Int], path.count > 1 {
-      return """
-        phase_path \(path) is nested, but phase_index \(phaseIndex) is \
-        \(resolved.rawValue), which has no sub-phases
-        """
+    if resolved != .conditional {
+      if let path = entry["phase_path"] as? [Int], path.count > 1 {
+        return """
+          phase_path \(path) is nested, but phase_index \(phaseIndex) is \
+          \(resolved.rawValue), which has no sub-phases
+          """
+      }
+      // Only a conditional HAS branches, so `branch:` here describes nothing.
+      // Checked at this level rather than inside `conditionalDiagnostic`,
+      // which a non-conditional entry never reaches.
+      if entry["branch"] != nil {
+        return """
+          branch is set, but phase_index \(phaseIndex) is \(resolved.rawValue), \
+          which has no branches
+          """
+      }
     }
     if resolved == .conditional {
       return conditionalDiagnostic(
@@ -486,19 +497,8 @@ struct BundledDemoReplaySourceTests {
   ) -> String? {
     let nested = (entry["phase_path"] as? [Int])?.dropFirst().first
     if phaseTypeRaw == PhaseType.conditional.rawValue {
-      // Correct-by-spec when the coordinate names the CONDITIONAL ITSELF:
-      // §3.2 defines `phase_type` as the type of the phase at `phase_path`,
-      // and for `[i]` that is the conditional. Reachable, not hypothetical —
-      // `ConditionalHandler.execute` emits each `evaluation.warnings` entry as
-      // a `.summary` BEFORE `.conditionalEvaluated`, i.e. while the current
-      // phase is still the conditional at `[i]`, so a demo of a condition
-      // referencing a runtime-absent variable carries exactly this shape.
-      guard nested != nil else { return nil }
-      return """
-        phase_path names a sub-phase of the conditional at \(phaseIndex), so \
-        phase_type 'conditional' cannot be right — the depth-1 rule forbids a \
-        conditional inside a branch
-        """
+      return conditionalAsLeafDiagnostic(
+        entry: entry, phaseIndex: phaseIndex, nested: nested)
     }
     guard PhaseType(rawValue: phaseTypeRaw) != nil else {
       return """
@@ -550,6 +550,46 @@ struct BundledDemoReplaySourceTests {
         """
     }
     return nil
+  }
+
+  /// The `phase_type == "conditional"` arm of ``conditionalDiagnostic`` —
+  /// the coordinate naming the conditional rather than a phase inside it.
+  ///
+  /// Extracted for the same cap reason as ``branchResolvedDiagnostic``.
+  private static func conditionalAsLeafDiagnostic(
+    entry: [String: Any], phaseIndex: Int, nested: Int?
+  ) -> String? {
+    // `branch:` FIRST. This arm returns for every input, so anything after it
+    // in the caller — including the whole `branch:` arm — is skipped for a
+    // `conditional` phase_type; an earlier revision relied on that ordering
+    // and so accepted `branch: "maybe"` and `branch: 0` outright. Which is the
+    // very fault this function had just been fixed for: a check living inside
+    // one arm leaves another shape unowned.
+    //
+    // Presence alone decides, whatever the value's type: naming the
+    // conditional itself AND claiming a branch ran is contradictory, so there
+    // is nothing a well-formed `branch:` could say here. (The curator never
+    // writes this pair — `branch_cur` is cleared on every top-level
+    // `phase_started` — so it is hand-edit territory.)
+    guard entry["branch"] == nil else {
+      return """
+        phase_type 'conditional' names the conditional at \(phaseIndex) itself, \
+        but `branch:` claims one of its branches ran
+        """
+    }
+    // Correct-by-spec when the coordinate names the CONDITIONAL ITSELF: §3.2
+    // defines `phase_type` as the type of the phase at `phase_path`, and for
+    // `[i]` that is the conditional. Reachable, not hypothetical —
+    // `ConditionalHandler.execute` emits each `evaluation.warnings` entry as a
+    // `.summary` BEFORE `.conditionalEvaluated`, i.e. while the current phase
+    // is still the conditional at `[i]`, so a demo of a condition referencing
+    // a runtime-absent variable carries exactly this shape.
+    guard nested != nil else { return nil }
+    return """
+      phase_path names a sub-phase of the conditional at \(phaseIndex), so \
+      phase_type 'conditional' cannot be right — the depth-1 rule forbids a \
+      conditional inside a branch
+      """
   }
 
   /// The `branch:`-present arm of ``conditionalDiagnostic``. Extracted so that

--- a/Pastura/PasturaTests/App/BundledDemoReplaySourceTests.swift
+++ b/Pastura/PasturaTests/App/BundledDemoReplaySourceTests.swift
@@ -408,7 +408,17 @@ struct BundledDemoReplaySourceTests {
     // `phase_index` IS `phase_path[0]` by definition (spec §3.2), so a
     // demo carrying both and disagreeing is self-inconsistent before any
     // scenario is consulted — checked first for that reason.
-    if let path = entry["phase_path"] as? [Int] {
+    //
+    // Keyed on PRESENCE, not on cast success. `as? [Int]` inside an `if let`
+    // would skip this whole block for `phase_path: ["1", "0"]` — and
+    // `YAMLReplaySource.resolvePhasePath` fails on the identical cast, falling
+    // back to `[phase_index]`. Two checks that fail on the same predicate
+    // detect nothing between them, and spec §3.3 makes this function the only
+    // owner, so nothing downstream would catch it either.
+    if entry["phase_path"] != nil {
+      guard let path = entry["phase_path"] as? [Int] else {
+        return "phase_path is present but is not a list of Int"
+      }
       guard let top = path.first else {
         return "phase_path is empty; it must name at least the top-level phase"
       }
@@ -460,7 +470,12 @@ struct BundledDemoReplaySourceTests {
     }
     let thenPhases = phase.thenPhases ?? []
     let elsePhases = phase.elsePhases ?? []
-    if let branch = entry["branch"] as? String {
+    if entry["branch"] != nil {
+      // Same presence-not-cast rule as `phase_path` above: `branch: 0` would
+      // otherwise fall through to the loose union check with no diagnostic.
+      guard let branch = entry["branch"] as? String else {
+        return "branch is present but is not a String"
+      }
       guard branch == "then" || branch == "else" else {
         return "branch '\(branch)' is neither 'then' nor 'else'"
       }
@@ -469,7 +484,10 @@ struct BundledDemoReplaySourceTests {
         return "branch '\(branch)' given without a nested phase_path to index into it"
       }
       guard taken.indices.contains(inner) else {
-        return "phase_path names \(branch)[\(inner)], but that branch has \(taken.count) phases"
+        return """
+          phase_path names \(branch)[\(inner)], but that branch holds \
+          \(taken.count) phase(s)
+          """
       }
       guard taken[inner].type.rawValue == phaseTypeRaw else {
         return """

--- a/Pastura/PasturaTests/App/BundledDemoReplaySourceTests.swift
+++ b/Pastura/PasturaTests/App/BundledDemoReplaySourceTests.swift
@@ -512,7 +512,10 @@ struct BundledDemoReplaySourceTests {
     return nil
   }
 
-  private static func parseYAMLAsDictionary(_ text: String) throws -> [String: Any] {
+  // Internal, not `private`: the sibling `+Alignment.swift` extension calls it
+  // to drive one fixture through the real parser, and `private` is file-scoped
+  // even for an extension of the same type.
+  static func parseYAMLAsDictionary(_ text: String) throws -> [String: Any] {
     // Reuse Yams indirectly via ScenarioLoader's parse path is overkill
     // — but BundledDemoReplaySource already forwards to YAMLReplaySource
     // for the same parse, and Yams is the project's only YAML lib.

--- a/Pastura/PasturaTests/App/BundledDemoReplaySourceTests.swift
+++ b/Pastura/PasturaTests/App/BundledDemoReplaySourceTests.swift
@@ -307,12 +307,21 @@ struct BundledDemoReplaySourceTests {
   /// UI as wrong phase labels, not as a crash. This test catches that
   /// regression at CI time.
   ///
-  /// **Conditional sub-phase exemption:** `YAMLReplayExporter` flattens
-  /// nested-sub-phase lineage into the outer conditional's index (see
-  /// the comment at `YAMLReplayExporter.swift` ~line 313). When
-  /// `scenario.phases[idx].type == .conditional`, the demo's
-  /// `phase_type` legitimately names a sub-phase type; the alignment
-  /// check accepts any non-`conditional` PhaseType in that slot.
+  /// **Conditional sub-phases (schema v2, #1505).** A branch sub-phase's
+  /// `phase_index` names the enclosing `conditional`, so its `phase_type`
+  /// legitimately does not equal `phases[phase_index].type` — see spec
+  /// §3.2, which makes this asymmetry the definition rather than a
+  /// tolerated flattening. How tightly that is checked depends on what the
+  /// demo carries: with `branch:` the exact sub-phase is resolved; without
+  /// it, `then[j]` and `else[j]` are indistinguishable and any
+  /// non-`conditional` type present in either branch is accepted.
+  ///
+  /// **This test's conditional population is empty and stays that way** —
+  /// no `Resources/DemoPresets/` preset uses a `conditional`, so the arm
+  /// below never fires on a shipped demo. Coverage comes from
+  /// ``alignmentDiagnostic(entry:phases:)``'s own tests, which hand it
+  /// fixtures directly. Nothing this issue could add changes that; only
+  /// promoting a conditional-bearing preset to a demo preset would.
   @Test func bundledDemoPhaseIndicesMatchResolvedScenarioPhaseTypes() throws {
     // Step D (#388): exercise both shipped languages explicitly so the
     // alignment guard catches phase-index drift on either side.
@@ -348,85 +357,141 @@ struct BundledDemoReplaySourceTests {
         let codeEvents = raw["code_phase_events"] as? [[String: Any]] ?? []
 
         for (i, turn) in turns.enumerated() {
-          try Self.assertPhaseAlignment(
+          Self.assertPhaseAlignment(
             entry: turn, label: "\(scenarioId)_demo turns[\(i)]", phases: phases)
         }
         for (i, event) in codeEvents.enumerated() {
-          try Self.assertPhaseAlignment(
+          Self.assertPhaseAlignment(
             entry: event, label: "\(scenarioId)_demo code_phase_events[\(i)]", phases: phases)
         }
       }
     }
   }
 
-  /// Helper for `bundledDemoPhaseIndicesMatchResolvedScenarioPhaseTypes`.
-  /// Static so the suite struct (a value type) can hand itself to the
-  /// closure-bound iteration without capturing self semantics.
+  /// Records any alignment failure `entry` has against `phases`.
+  ///
+  /// Thin wrapper over ``alignmentDiagnostic(entry:phases:)`` so the
+  /// enumeration above keeps reading as an assertion. The split exists
+  /// because this function's every failure path used to be an
+  /// `Issue.record`, which left no way to write a NEGATIVE control: a
+  /// deliberately-misaligned fixture would simply redden the suite rather
+  /// than let a test assert *which* misalignment was detected.
   static func assertPhaseAlignment(
     entry: [String: Any], label: String, phases: [Phase]
-  ) throws {
+  ) {
+    guard let diagnostic = alignmentDiagnostic(entry: entry, phases: phases) else { return }
+    // `Issue.record` rather than `#expect(_:_:)` because Swift Testing's
+    // message slot takes a `Comment` (string literal) — a runtime-built
+    // string cannot be passed there.
+    Issue.record(Comment(rawValue: "\(label): \(diagnostic)"))
+  }
+
+  /// Returns nil when `entry`'s phase coordinates are consistent with
+  /// `phases`, or a diagnostic naming the first inconsistency found.
+  ///
+  /// Static so the suite struct (a value type) can hand itself to the
+  /// closure-bound iteration without capturing self semantics.
+  ///
+  /// Spec §3.3 names this the SOLE owner of the coordinate invariant —
+  /// neither the runtime loader nor `check_demo_replay_drift.py` checks
+  /// it. Adding a second copy elsewhere would need a stated reconcile
+  /// direction; moving it is fine, duplicating it is not.
+  static func alignmentDiagnostic(
+    entry: [String: Any], phases: [Phase]
+  ) -> String? {
     guard let phaseIndex = entry["phase_index"] as? Int else {
-      Issue.record("\(label): missing or non-Int phase_index")
-      return
+      return "missing or non-Int phase_index"
     }
     guard let phaseTypeRaw = entry["phase_type"] as? String else {
-      Issue.record("\(label): missing or non-String phase_type")
-      return
+      return "missing or non-String phase_type"
+    }
+    // `phase_index` IS `phase_path[0]` by definition (spec §3.2), so a
+    // demo carrying both and disagreeing is self-inconsistent before any
+    // scenario is consulted — checked first for that reason.
+    if let path = entry["phase_path"] as? [Int] {
+      guard let top = path.first else {
+        return "phase_path is empty; it must name at least the top-level phase"
+      }
+      guard top == phaseIndex else {
+        return "phase_path \(path) starts at \(top) but phase_index is \(phaseIndex)"
+      }
+      guard path.count <= 2 else {
+        return """
+          phase_path \(path) is \(path.count) deep, but the engine's depth-1 rule \
+          bounds it to 2 (ScenarioLoader.parsePhaseType refuses a nested conditional)
+          """
+      }
     }
     guard phases.indices.contains(phaseIndex) else {
-      Issue.record(
-        "\(label): phase_index \(phaseIndex) is out of range (scenario has \(phases.count) phases)")
-      return
+      return "phase_index \(phaseIndex) is out of range (scenario has \(phases.count) phases)"
     }
     let resolved = phases[phaseIndex].type
-    let demoType = PhaseType(rawValue: phaseTypeRaw)
-
     if resolved == .conditional {
-      // Sub-phase under conditional — exporter legitimately denormalises
-      // to the outer conditional's index. Accept any non-conditional
-      // sub-phase type (depth-1 rule). Use `Issue.record` instead of
-      // `#expect` with a message because Swift Testing only accepts a
-      // `Comment` (string literal) as the second argument; runtime-built
-      // strings can't be passed via `#expect`'s message slot. The string
-      // is built via interpolation rather than `+` so the closure's
-      // expected literal-conversion path stays in scope.
-      if demoType == nil || demoType == .conditional {
-        let message = """
-          \(label): phase_index \(phaseIndex) is a conditional in the preset; \
-          demo phase_type '\(phaseTypeRaw)' must name a non-conditional sub-phase type
-          """
-        Issue.record(Comment(rawValue: message))
-        return
-      }
-      // Verify the named sub-phase actually exists in the conditional's
-      // branches. Catches the literal-swap drift (e.g., curator swaps
-      // outer slots so a demo's phase_type now points at a conditional
-      // whose branches don't contain that type). v1 limitation: a
-      // type-equivalent reorder where both branches happen to contain
-      // the named sub-phase type still passes silently — acceptable
-      // because depth-1 word_wolf-shape branches each hold one
-      // sub-phase, but if branch-attribution becomes load-bearing this
-      // assertion needs to grow a branch_index cross-check.
-      let subPhases =
-        (phases[phaseIndex].thenPhases ?? []) + (phases[phaseIndex].elsePhases ?? [])
-      let subPhaseTypes = subPhases.map { $0.type.rawValue }
-      if !subPhaseTypes.contains(phaseTypeRaw) {
-        let message = """
-          \(label): phase_index \(phaseIndex) is a conditional whose branches \
-          contain \(subPhaseTypes); demo phase_type '\(phaseTypeRaw)' is not present
-          """
-        Issue.record(Comment(rawValue: message))
-      }
-      return
+      return conditionalDiagnostic(
+        entry: entry, phaseTypeRaw: phaseTypeRaw, phase: phases[phaseIndex],
+        phaseIndex: phaseIndex)
     }
-
-    if resolved.rawValue != phaseTypeRaw {
-      let message = """
-        \(label): phase_index \(phaseIndex) resolves to \(resolved.rawValue) \
-        in the preset, but demo declares phase_type: \(phaseTypeRaw)
+    guard resolved.rawValue == phaseTypeRaw else {
+      return """
+        phase_index \(phaseIndex) resolves to \(resolved.rawValue) in the preset, \
+        but demo declares phase_type: \(phaseTypeRaw)
         """
-      Issue.record(Comment(rawValue: message))
     }
+    return nil
+  }
+
+  /// Alignment check for an entry whose `phase_index` names a
+  /// `conditional`. Extracted so ``alignmentDiagnostic(entry:phases:)``
+  /// stays under SwiftLint's `function_body_length` cap.
+  ///
+  /// With `branch:` present (curator-written; `YAMLReplayExporter` cannot
+  /// supply it) the exact sub-phase is resolved and a type mismatch is
+  /// caught. Without it the check stays as loose as the data allows —
+  /// `then[j]` and `else[j]` share a `phase_path`, so only membership in
+  /// the union of both branches can be asserted.
+  private static func conditionalDiagnostic(
+    entry: [String: Any], phaseTypeRaw: String, phase: Phase, phaseIndex: Int
+  ) -> String? {
+    if PhaseType(rawValue: phaseTypeRaw).map({ $0 == .conditional }) ?? true {
+      return """
+        phase_index \(phaseIndex) is a conditional in the preset; demo phase_type \
+        '\(phaseTypeRaw)' must name a non-conditional sub-phase type
+        """
+    }
+    let thenPhases = phase.thenPhases ?? []
+    let elsePhases = phase.elsePhases ?? []
+    if let branch = entry["branch"] as? String {
+      guard branch == "then" || branch == "else" else {
+        return "branch '\(branch)' is neither 'then' nor 'else'"
+      }
+      let taken = branch == "then" ? thenPhases : elsePhases
+      guard let inner = (entry["phase_path"] as? [Int])?.dropFirst().first else {
+        return "branch '\(branch)' given without a nested phase_path to index into it"
+      }
+      guard taken.indices.contains(inner) else {
+        return "phase_path names \(branch)[\(inner)], but that branch has \(taken.count) phases"
+      }
+      guard taken[inner].type.rawValue == phaseTypeRaw else {
+        return """
+          phase_path names \(branch)[\(inner)], which is \(taken[inner].type.rawValue), \
+          but demo declares phase_type: \(phaseTypeRaw)
+          """
+      }
+      return nil
+    }
+    // No `branch:` — the pre-v2 shape. Catches literal-swap drift (a
+    // curator reorders outer slots so `phase_type` now points at a
+    // conditional whose branches lack that type), but a type-equivalent
+    // reorder within the branches still passes: both carry the same type,
+    // so nothing here can tell them apart. That is what `branch:` is for.
+    let subPhaseTypes = (thenPhases + elsePhases).map { $0.type.rawValue }
+    guard subPhaseTypes.contains(phaseTypeRaw) else {
+      return """
+        phase_index \(phaseIndex) is a conditional whose branches contain \
+        \(subPhaseTypes); demo phase_type '\(phaseTypeRaw)' is not present
+        """
+    }
+    return nil
   }
 
   private static func parseYAMLAsDictionary(_ text: String) throws -> [String: Any] {

--- a/Pastura/PasturaTests/App/YAMLReplayExporterTests.swift
+++ b/Pastura/PasturaTests/App/YAMLReplayExporterTests.swift
@@ -512,6 +512,26 @@ struct YAMLReplayExporterTests {  // swiftlint:disable:this type_body_length
     #expect(!result.text.contains("phase_path"))
   }
 
+  @Test func emptyPersistedPathOnCodeEventEmitsNoPhasePathLine() throws {
+    // The same fix landed at two emit sites; without this arm, deleting
+    // `!path.isEmpty` from `renderCodePhaseEvents` alone leaves the suite
+    // green — an unarmed half of the guard this branch added.
+    let exporter = makeExporter()
+    let events = [
+      makeCodePhaseEvent(
+        round: 1, seq: 1, phase: "score_calc",
+        payload: .scoreUpdate(scores: ["Alice": 3]), phasePathJSON: "[]")
+    ]
+
+    let result = try exporter.export(
+      .init(
+        simulation: makeSimulation(), scenario: makeScenario(),
+        turns: [], codePhaseEvents: events))
+
+    #expect(result.text.contains("phase_index:"))
+    #expect(!result.text.contains("phase_path"))
+  }
+
   // MARK: - YAML emitter edge cases (Japanese / multi-line / control chars)
 
   @Test func japaneseStatementUsesSingleQuoted() throws {

--- a/Pastura/PasturaTests/App/YAMLReplayExporterTests.swift
+++ b/Pastura/PasturaTests/App/YAMLReplayExporterTests.swift
@@ -307,6 +307,114 @@ struct YAMLReplayExporterTests {  // swiftlint:disable:this type_body_length
     #expect(voteIndexLines == 2)
   }
 
+  // MARK: - phase_index derivation (persisted path vs cursor fallback)
+
+  /// Two ADJACENT phases of the same type — the shape the cursor cannot
+  /// tell apart, since it only advances when the observed `phaseType`
+  /// changes. Used as a control pair by the two tests below.
+  private static let adjacentSameTypeScenarioYAML = """
+    id: test_scn
+    language: ja
+    name: Test Scenario
+    description: test
+    agents: 2
+    rounds: 2
+    context: ctx
+    personas:
+      - name: Alice
+        description: ''
+      - name: Bob
+        description: ''
+    phases:
+      - type: speak_all
+        prompt: first
+        output:
+          statement: string
+      - type: speak_all
+        prompt: second
+        output:
+          statement: string
+      - type: vote
+        prompt: vote
+        candidates: agents
+    """
+
+  private func phaseIndexLines(_ text: String) -> [String] {
+    text.components(separatedBy: "\n")
+      .map { $0.trimmingCharacters(in: .whitespaces) }
+      .filter { $0.hasPrefix("phase_index:") }
+  }
+
+  @Test func persistedPhasePathOverridesCursorDerivation() throws {
+    // Both turns are `speak_all`, so the cursor holds at 0 for both. The
+    // persisted paths say 0 and 1 — a value the cursor could not have
+    // produced, which is what makes this discriminating rather than
+    // agreeing-by-luck.
+    let exporter = makeExporter()
+    let turns = [
+      makeTurn(
+        round: 1, seq: 1, phase: "speak_all", agent: "Alice",
+        fields: ["statement": "s"], phasePathJSON: "[0]"),
+      makeTurn(
+        round: 1, seq: 2, phase: "speak_all", agent: "Bob",
+        fields: ["statement": "s"], phasePathJSON: "[1]")
+    ]
+
+    let result = try exporter.export(
+      .init(
+        simulation: makeSimulation(),
+        scenario: makeScenario(yaml: Self.adjacentSameTypeScenarioYAML),
+        turns: turns, codePhaseEvents: []))
+
+    #expect(phaseIndexLines(result.text) == ["phase_index: 0", "phase_index: 1"])
+  }
+
+  @Test func preV6RowsStillCollapseViaCursorDerivation() throws {
+    // The control for the test above: identical fixture, `phasePathJSON`
+    // nil. Migration v6 added that column with no backfill, so these rows
+    // must export exactly as they did before schema v2 — collapsed to the
+    // first matching index, limitation and all. A failure here means the
+    // fallback changed, not that the cursor is wrong.
+    let exporter = makeExporter()
+    let turns = [
+      makeTurn(round: 1, seq: 1, phase: "speak_all", agent: "Alice", fields: ["statement": "s"]),
+      makeTurn(round: 1, seq: 2, phase: "speak_all", agent: "Bob", fields: ["statement": "s"])
+    ]
+
+    let result = try exporter.export(
+      .init(
+        simulation: makeSimulation(),
+        scenario: makeScenario(yaml: Self.adjacentSameTypeScenarioYAML),
+        turns: turns, codePhaseEvents: []))
+
+    #expect(phaseIndexLines(result.text) == ["phase_index: 0", "phase_index: 0"])
+  }
+
+  @Test func branchSubPhaseEventResolvesToItsPathNotTheConditional() throws {
+    // `resolveEventPhaseIndices` has its own fallback, so it needs its own
+    // pair. `summarize` is not a top-level phase of the base scenario, so
+    // the pre-v6 lookup would land on `conditionalFallbackIndex` — which,
+    // with no conditional present, is 0.
+    let exporter = makeExporter()
+    let withPath = makeCodePhaseEvent(
+      round: 1, seq: 1, phase: "summarize",
+      payload: .summary(text: "s"), phasePathJSON: "[1, 0]")
+    let withoutPath = makeCodePhaseEvent(
+      round: 1, seq: 1, phase: "summarize", payload: .summary(text: "s"))
+
+    let resolved = try exporter.export(
+      .init(
+        simulation: makeSimulation(), scenario: makeScenario(),
+        turns: [], codePhaseEvents: [withPath]))
+    let fallback = try exporter.export(
+      .init(
+        simulation: makeSimulation(), scenario: makeScenario(),
+        turns: [], codePhaseEvents: [withoutPath]))
+
+    #expect(phaseIndexLines(resolved.text) == ["phase_index: 1"])
+    #expect(phaseIndexLines(fallback.text) == ["phase_index: 0"])
+  }
+
   // MARK: - phase_path emission (schema v2)
 
   @Test func turnWithPhasePathJSONEmitsPhasePathLine() throws {

--- a/Pastura/PasturaTests/App/YAMLReplayExporterTests.swift
+++ b/Pastura/PasturaTests/App/YAMLReplayExporterTests.swift
@@ -490,6 +490,28 @@ struct YAMLReplayExporterTests {  // swiftlint:disable:this type_body_length
     #expect(!result.text.contains("phase_path"))
   }
 
+  @Test func emptyPersistedPathEmitsNoPhasePathLine() throws {
+    // `phasePathJSON: "[]"` decodes to a non-nil EMPTY array — `phasePath`
+    // nils out only on a nil / empty *string*. So `phasePath?.first` is nil and
+    // `phase_index` comes from the cursor; emitting `phase_path: []` alongside
+    // it would write the two fields from different sources and produce a
+    // document violating spec §3.2's `phase_index == phase_path[0]`.
+    let exporter = makeExporter()
+    let turns = [
+      makeTurn(
+        round: 1, seq: 1, phase: "speak_all", agent: "Alice",
+        fields: ["statement": "s"], phasePathJSON: "[]")
+    ]
+
+    let result = try exporter.export(
+      .init(
+        simulation: makeSimulation(), scenario: makeScenario(),
+        turns: turns, codePhaseEvents: []))
+
+    #expect(result.text.contains("phase_index:"))
+    #expect(!result.text.contains("phase_path"))
+  }
+
   // MARK: - YAML emitter edge cases (Japanese / multi-line / control chars)
 
   @Test func japaneseStatementUsesSingleQuoted() throws {

--- a/Pastura/PasturaTests/App/YAMLReplayExporterTests.swift
+++ b/Pastura/PasturaTests/App/YAMLReplayExporterTests.swift
@@ -64,7 +64,8 @@ struct YAMLReplayExporterTests {  // swiftlint:disable:this type_body_length
 
   private func makeTurn(
     round: Int, seq: Int, phase: String,
-    agent: String?, fields: [String: String]
+    agent: String?, fields: [String: String],
+    phasePathJSON: String? = nil
   ) -> TurnRecord {
     let json =
       (try? JSONEncoder().encode(TurnOutput(fields: fields))).flatMap {
@@ -75,12 +76,14 @@ struct YAMLReplayExporterTests {  // swiftlint:disable:this type_body_length
       roundNumber: round, phaseType: phase,
       agentName: agent, rawOutput: json,
       parsedOutputJSON: json, sequenceNumber: seq,
+      phasePathJSON: phasePathJSON,
       createdAt: Date())
   }
 
   private func makeCodePhaseEvent(
     round: Int, seq: Int, phase: String,
-    payload: CodePhaseEventPayload
+    payload: CodePhaseEventPayload,
+    phasePathJSON: String? = nil
   ) -> CodePhaseEventRecord {
     let json =
       (try? JSONEncoder().encode(payload)).flatMap {
@@ -90,6 +93,7 @@ struct YAMLReplayExporterTests {  // swiftlint:disable:this type_body_length
       id: UUID().uuidString, simulationId: "sim1",
       roundNumber: round, phaseType: phase,
       sequenceNumber: seq, payloadJSON: json,
+      phasePathJSON: phasePathJSON,
       createdAt: Date())
   }
 
@@ -108,7 +112,7 @@ struct YAMLReplayExporterTests {  // swiftlint:disable:this type_body_length
         simulation: makeSimulation(), scenario: makeScenario(),
         turns: [], codePhaseEvents: []))
 
-    #expect(result.text.contains("schema_version: 1"))
+    #expect(result.text.contains("schema_version: 2"))
     #expect(result.text.contains("preset_ref:"))
     #expect(result.text.contains("metadata:"))
     #expect(result.text.contains("turns:"))
@@ -301,6 +305,81 @@ struct YAMLReplayExporterTests {  // swiftlint:disable:this type_body_length
       .filter { $0.contains("phase_index: 1") }.count
     #expect(speakAllIndexLines == 2)
     #expect(voteIndexLines == 2)
+  }
+
+  // MARK: - phase_path emission (schema v2)
+
+  @Test func turnWithPhasePathJSONEmitsPhasePathLine() throws {
+    let exporter = makeExporter()
+    let turns = [
+      makeTurn(
+        round: 1, seq: 1, phase: "speak_all", agent: "Alice",
+        fields: ["statement": "s"], phasePathJSON: "[1, 0]")
+    ]
+
+    let result = try exporter.export(
+      .init(
+        simulation: makeSimulation(), scenario: makeScenario(),
+        turns: turns, codePhaseEvents: []))
+
+    #expect(result.text.contains("phase_path: [1, 0]"))
+  }
+
+  @Test func turnWithoutPhasePathJSONOmitsPhasePathLine() throws {
+    // Pre-v6 rows have `phasePathJSON == nil` — the load-bearing case, since
+    // the reader falls back to `[phase_index]` only when the line is absent.
+    let exporter = makeExporter()
+    let turns = [
+      makeTurn(
+        round: 1, seq: 1, phase: "speak_all", agent: "Alice",
+        fields: ["statement": "s"])
+    ]
+
+    let result = try exporter.export(
+      .init(
+        simulation: makeSimulation(), scenario: makeScenario(),
+        turns: turns, codePhaseEvents: []))
+
+    // Paired with a positive assertion on `phase_index:`, which every
+    // rendered entry emits unquoted: a bare `!contains` also passes when the
+    // entry was never rendered, so absence alone is not evidence. (String
+    // fields are single-quoted by `yamlValue`, so `agent: Alice` would not
+    // have matched — measured, not assumed.)
+    #expect(result.text.contains("phase_index:"))
+    #expect(!result.text.contains("phase_path"))
+  }
+
+  @Test func codePhaseEventWithPhasePathJSONEmitsPhasePathLine() throws {
+    let exporter = makeExporter()
+    let events = [
+      makeCodePhaseEvent(
+        round: 1, seq: 1, phase: "score_calc",
+        payload: .scoreUpdate(scores: ["Alice": 3]), phasePathJSON: "[2]")
+    ]
+
+    let result = try exporter.export(
+      .init(
+        simulation: makeSimulation(), scenario: makeScenario(),
+        turns: [], codePhaseEvents: events))
+
+    #expect(result.text.contains("phase_path: [2]"))
+  }
+
+  @Test func codePhaseEventWithoutPhasePathJSONOmitsPhasePathLine() throws {
+    let exporter = makeExporter()
+    let events = [
+      makeCodePhaseEvent(
+        round: 1, seq: 1, phase: "score_calc",
+        payload: .scoreUpdate(scores: ["Alice": 3]))
+    ]
+
+    let result = try exporter.export(
+      .init(
+        simulation: makeSimulation(), scenario: makeScenario(),
+        turns: [], codePhaseEvents: events))
+
+    #expect(result.text.contains("phase_index:"))
+    #expect(!result.text.contains("phase_path"))
   }
 
   // MARK: - YAML emitter edge cases (Japanese / multi-line / control chars)

--- a/Pastura/PasturaTests/App/YAMLReplaySourceTests+PhasePath.swift
+++ b/Pastura/PasturaTests/App/YAMLReplaySourceTests+PhasePath.swift
@@ -1,0 +1,239 @@
+import Foundation
+import Testing
+
+@testable import Pastura
+
+// Tests for schema-v2 `phase_path` resolution in ``YAMLReplaySource``
+// (Issue #1505) — ordering, phase-boundary detection, and the
+// `.phaseStarted` payload, plus the v1 `[phase_index]` fallback.
+//
+// Extension + sibling file, NOT a new `@Suite` — a second suite would race
+// against the original on shared state (see `.claude/rules/testing.md`).
+// Split out rather than appended to `+PlannedEvents.swift` because that
+// file sits at 367 lines against SwiftLint's 400-line `file_length` cap,
+// which `--strict` promotes to an error.
+extension YAMLReplaySourceTests {
+
+  // MARK: - Fixture
+
+  /// One `speak_all`, then a `conditional` whose two branches each hold a
+  /// `summarize`, then a trailing `speak_all`. Real branch structure so the
+  /// `[1, 0]` paths below address something that actually exists — the
+  /// loader itself never resolves a path against the scenario (spec §3.3
+  /// gives that invariant to `BundledDemoReplaySourceTests`), so the shape
+  /// is documentation for the next reader rather than something under test.
+  fileprivate static let conditionalScenarioYAML = """
+    id: cond1
+    language: ja
+    name: Conditional fixture
+    description: ''
+    agents: 2
+    rounds: 2
+    context: ''
+    personas:
+      - name: Alice
+        description: ''
+      - name: Bob
+        description: ''
+    phases:
+      - type: speak_all
+        prompt: say
+        output:
+          statement: string
+      - type: conditional
+        if: 'score_alice > 0'
+        then:
+          - type: summarize
+            template: "then branch"
+        else:
+          - type: summarize
+            template: "else branch"
+      - type: speak_all
+        prompt: say again
+        output:
+          statement: string
+    """
+
+  fileprivate func makeConditionalScenario() throws -> Scenario {
+    try ScenarioLoader().load(yaml: Self.conditionalScenarioYAML)
+  }
+
+  fileprivate func phaseStartedPaths(_ events: [PacedEvent]) -> [[Int]] {
+    events.compactMap { paced in
+      if case .phaseStarted(_, let path) = paced.event { return path }
+      return nil
+    }
+  }
+
+  // MARK: - `.phaseStarted` payload
+
+  @Test func phasePathReachesPhaseStartedVerbatim() throws {
+    let yaml = """
+      schema_version: 2
+      turns:
+        - round: 1
+          phase_index: 1
+          phase_path: [1, 0]
+          branch: then
+          phase_type: summarize
+          agent: Alice
+          fields: { statement: 'from the then branch' }
+      """
+    let source = try YAMLReplaySource(yaml: yaml, scenario: makeConditionalScenario())
+
+    // The v1 shape would have collapsed this to `[1]` — the enclosing
+    // conditional — losing which phase actually spoke.
+    #expect(phaseStartedPaths(source.plannedEvents()) == [[1, 0]])
+  }
+
+  @Test func absentPhasePathFallsBackToPhaseIndex() throws {
+    let yaml = """
+      schema_version: 1
+      turns:
+        - round: 1
+          phase_index: 2
+          phase_type: speak_all
+          agent: Alice
+          fields: { statement: 'v1 entry' }
+      """
+    let source = try YAMLReplaySource(yaml: yaml, scenario: makeConditionalScenario())
+
+    #expect(phaseStartedPaths(source.plannedEvents()) == [[2]])
+  }
+
+  @Test func unusablePhasePathFallsBackToPhaseIndex() throws {
+    // An empty array and a non-Int array both fail `as? [Int]` / the
+    // non-empty check. Falling back keeps the lenient load-time posture
+    // (spec §3.3) rather than throwing on a coordinate the CI gate owns.
+    for badPath in ["[]", "['a']"] {
+      let yaml = """
+        schema_version: 2
+        turns:
+          - round: 1
+            phase_index: 2
+            phase_path: \(badPath)
+            phase_type: speak_all
+            agent: Alice
+            fields: { statement: 'x' }
+        """
+      let source = try YAMLReplaySource(yaml: yaml, scenario: makeConditionalScenario())
+      #expect(phaseStartedPaths(source.plannedEvents()) == [[2]])
+    }
+  }
+
+  // MARK: - Ordering
+
+  @Test func phasePathOrdersLexicographicallyNotByTopLevelIndex() throws {
+    // Source order is scrambled; `[1, 0]` must land between `[0]` and `[2]`.
+    // Under the old integer key the branch entry compared as plain `1`, so
+    // this particular ordering also held — the case that did NOT is the
+    // boundary test below.
+    let yaml = """
+      schema_version: 2
+      turns:
+        - round: 1
+          phase_index: 2
+          phase_path: [2]
+          phase_type: speak_all
+          agent: Alice
+          fields: { statement: 'third' }
+        - round: 1
+          phase_index: 0
+          phase_path: [0]
+          phase_type: speak_all
+          agent: Bob
+          fields: { statement: 'first' }
+        - round: 1
+          phase_index: 1
+          phase_path: [1, 0]
+          branch: else
+          phase_type: summarize
+          agent: Alice
+          fields: { statement: 'second' }
+      """
+    let source = try YAMLReplaySource(yaml: yaml, scenario: makeConditionalScenario())
+
+    let statements = source.plannedEvents().compactMap { paced -> String? in
+      if case .agentOutput(_, let output, _) = paced.event { return output.fields["statement"] }
+      return nil
+    }
+    #expect(statements == ["first", "second", "third"])
+    #expect(phaseStartedPaths(source.plannedEvents()) == [[0], [1, 0], [2]])
+  }
+
+  // MARK: - Boundary detection
+
+  @Test func siblingBranchPhasesOfOneTypeGetSeparatePhaseStarted() throws {
+    // The discriminating case. Two sub-phases of the SAME type under one
+    // conditional differ only in the path's second component, so the old
+    // `(phase_index, phase_type)` boundary key saw one phase and synthesised
+    // a single `.phaseStarted`. `phase_path` splits them.
+    let yaml = """
+      schema_version: 2
+      turns:
+        - round: 1
+          phase_index: 1
+          phase_path: [1, 0]
+          branch: then
+          phase_type: summarize
+          agent: Alice
+          fields: { statement: 'first sub-phase' }
+        - round: 1
+          phase_index: 1
+          phase_path: [1, 1]
+          branch: then
+          phase_type: summarize
+          agent: Bob
+          fields: { statement: 'second sub-phase' }
+      """
+    let source = try YAMLReplaySource(yaml: yaml, scenario: makeConditionalScenario())
+
+    #expect(phaseStartedPaths(source.plannedEvents()) == [[1, 0], [1, 1]])
+  }
+
+  @Test func repeatedPhasePathDoesNotResynthesizePhaseStarted() throws {
+    // Negative control for the test above: identical paths and types must
+    // still collapse to ONE `.phaseStarted`, or the boundary check would be
+    // firing on source position rather than on the coordinate.
+    let yaml = """
+      schema_version: 2
+      turns:
+        - round: 1
+          phase_index: 1
+          phase_path: [1, 0]
+          phase_type: summarize
+          agent: Alice
+          fields: { statement: 'a' }
+        - round: 1
+          phase_index: 1
+          phase_path: [1, 0]
+          phase_type: summarize
+          agent: Bob
+          fields: { statement: 'b' }
+      """
+    let source = try YAMLReplaySource(yaml: yaml, scenario: makeConditionalScenario())
+
+    #expect(phaseStartedPaths(source.plannedEvents()) == [[1, 0]])
+  }
+
+  // MARK: - Code-phase events
+
+  @Test func codePhaseEventsResolvePhasePathToo() throws {
+    // `phase_path` is parsed by both `parseTurn` and `parseCodePhaseEvent`;
+    // covering only turns would leave the second call site unmeasured.
+    let yaml = """
+      schema_version: 2
+      turns: []
+      code_phase_events:
+        - round: 1
+          phase_index: 1
+          phase_path: [1, 0]
+          branch: else
+          phase_type: summarize
+          summary: 'branch summary'
+      """
+    let source = try YAMLReplaySource(yaml: yaml, scenario: makeConditionalScenario())
+
+    #expect(phaseStartedPaths(source.plannedEvents()) == [[1, 0]])
+  }
+}

--- a/Pastura/PasturaTests/App/YAMLReplaySourceTests+PhasePath.swift
+++ b/Pastura/PasturaTests/App/YAMLReplaySourceTests+PhasePath.swift
@@ -9,9 +9,10 @@ import Testing
 //
 // Extension + sibling file, NOT a new `@Suite` — a second suite would race
 // against the original on shared state (see `.claude/rules/testing.md`).
-// Split out rather than appended to `+PlannedEvents.swift` because that
-// file sits at 367 lines against SwiftLint's 400-line `file_length` cap,
-// which `--strict` promotes to an error.
+// Split out rather than appended to a sibling because both were already near
+// SwiftLint's 400-line `file_length` cap, which `--strict` promotes to an
+// error. Deliberately no line count here: it would be a snapshot that rots
+// silently, while the constraint it is evidence for does not.
 extension YAMLReplaySourceTests {
 
   // MARK: - Fixture
@@ -235,5 +236,41 @@ extension YAMLReplaySourceTests {
     let source = try YAMLReplaySource(yaml: yaml, scenario: makeConditionalScenario())
 
     #expect(phaseStartedPaths(source.plannedEvents()) == [[1, 0]])
+  }
+
+  // MARK: - Schema version acceptance
+  //
+  // Here rather than in the parent file, which sits within a couple of
+  // lines of SwiftLint's 400-line `file_length` cap that `--strict`
+  // promotes to an error. Every other fixture there stays at v1, which is
+  // this branch's v1-back-compat coverage — do not sweep them to v2.
+
+  @Test func acceptsSchemaVersion2() throws {
+    let yaml = """
+      schema_version: 2
+      turns: []
+      """
+    let scenario = try makeScenario()
+    // Widened acceptance (spec §3.5) — v2 must not throw, even though no
+    // writer emits it yet. `phase_path` / `branch` parsing is out of scope
+    // for this change; an empty `turns:` is enough to prove acceptance.
+    #expect(throws: Never.self) {
+      _ = try YAMLReplaySource(yaml: yaml, scenario: scenario)
+    }
+  }
+
+  /// `true` must NOT be read as `1`. Python's `True == 1` made the drift
+  /// guard's old `!= 1` check accept `schema_version: true`; this pins the
+  /// Swift side so the claim that the two loaders agree is measured rather
+  /// than reasoned from Yams' bridging behaviour.
+  @Test func throwsOnBooleanSchemaVersion() throws {
+    let yaml = """
+      schema_version: true
+      turns: []
+      """
+    let scenario = try makeScenario()
+    #expect(throws: YAMLReplaySourceError.unsupportedSchemaVersion(nil)) {
+      _ = try YAMLReplaySource(yaml: yaml, scenario: scenario)
+    }
   }
 }

--- a/Pastura/PasturaTests/App/YAMLReplaySourceTests+PhasePath.swift
+++ b/Pastura/PasturaTests/App/YAMLReplaySourceTests+PhasePath.swift
@@ -241,8 +241,8 @@ extension YAMLReplaySourceTests {
   // MARK: - Schema version acceptance
   //
   // Here rather than in the parent file, which runs nearer SwiftLint's
-  // 400-line `file_length` cap. No sizes: two revisions of this comment
-  // carried one and both were wrong by the time they were committed.
+  // 400-line `file_length` cap. No line count here either, per this file's
+  // header.
   // Every other fixture in the parent stays at v1, which is this branch's
   // v1-back-compat coverage — do not sweep them to v2.
 

--- a/Pastura/PasturaTests/App/YAMLReplaySourceTests+PhasePath.swift
+++ b/Pastura/PasturaTests/App/YAMLReplaySourceTests+PhasePath.swift
@@ -240,10 +240,11 @@ extension YAMLReplaySourceTests {
 
   // MARK: - Schema version acceptance
   //
-  // Here rather than in the parent file, which sits within a couple of
-  // lines of SwiftLint's 400-line `file_length` cap that `--strict`
-  // promotes to an error. Every other fixture there stays at v1, which is
-  // this branch's v1-back-compat coverage — do not sweep them to v2.
+  // Here rather than in the parent file: both run near SwiftLint's 400-line
+  // `file_length` cap, which `--strict` promotes to an error. No line count —
+  // this file's own header drops one for the reason that applies here too.
+  // Every other fixture in the parent stays at v1, which is this branch's
+  // v1-back-compat coverage — do not sweep them to v2.
 
   @Test func acceptsSchemaVersion2() throws {
     let yaml = """

--- a/Pastura/PasturaTests/App/YAMLReplaySourceTests+PhasePath.swift
+++ b/Pastura/PasturaTests/App/YAMLReplaySourceTests+PhasePath.swift
@@ -240,9 +240,9 @@ extension YAMLReplaySourceTests {
 
   // MARK: - Schema version acceptance
   //
-  // Here rather than in the parent file: both run near SwiftLint's 400-line
-  // `file_length` cap, which `--strict` promotes to an error. No line count —
-  // this file's own header drops one for the reason that applies here too.
+  // Here rather than in the parent file, which runs nearer SwiftLint's
+  // 400-line `file_length` cap. No sizes: two revisions of this comment
+  // carried one and both were wrong by the time they were committed.
   // Every other fixture in the parent stays at v1, which is this branch's
   // v1-back-compat coverage — do not sweep them to v2.
 

--- a/Pastura/PasturaTests/App/YAMLReplaySourceTests.swift
+++ b/Pastura/PasturaTests/App/YAMLReplaySourceTests.swift
@@ -60,35 +60,6 @@ struct YAMLReplaySourceTests {
     }
   }
 
-  @Test func acceptsSchemaVersion2() throws {
-    let yaml = """
-      schema_version: 2
-      turns: []
-      """
-    let scenario = try makeScenario()
-    // Widened acceptance (spec §3.5) — v2 must not throw, even though no
-    // writer emits it yet. `phase_path` / `branch` parsing is out of scope
-    // for this change; an empty `turns:` is enough to prove acceptance.
-    #expect(throws: Never.self) {
-      _ = try YAMLReplaySource(yaml: yaml, scenario: scenario)
-    }
-  }
-
-  /// `true` must NOT be read as `1`. Python's `True == 1` made the drift
-  /// guard's old `!= 1` check accept `schema_version: true`; this pins the
-  /// Swift side so the claim that the two loaders agree is measured rather
-  /// than reasoned from Yams' bridging behaviour.
-  @Test func throwsOnBooleanSchemaVersion() throws {
-    let yaml = """
-      schema_version: true
-      turns: []
-      """
-    let scenario = try makeScenario()
-    #expect(throws: YAMLReplaySourceError.unsupportedSchemaVersion(nil)) {
-      _ = try YAMLReplaySource(yaml: yaml, scenario: scenario)
-    }
-  }
-
   @Test func throwsOnMissingSchemaVersion() throws {
     let yaml = """
       turns: []

--- a/Pastura/PasturaTests/App/YAMLReplaySourceTests.swift
+++ b/Pastura/PasturaTests/App/YAMLReplaySourceTests.swift
@@ -60,6 +60,35 @@ struct YAMLReplaySourceTests {
     }
   }
 
+  @Test func acceptsSchemaVersion2() throws {
+    let yaml = """
+      schema_version: 2
+      turns: []
+      """
+    let scenario = try makeScenario()
+    // Widened acceptance (spec §3.5) — v2 must not throw, even though no
+    // writer emits it yet. `phase_path` / `branch` parsing is out of scope
+    // for this change; an empty `turns:` is enough to prove acceptance.
+    #expect(throws: Never.self) {
+      _ = try YAMLReplaySource(yaml: yaml, scenario: scenario)
+    }
+  }
+
+  /// `true` must NOT be read as `1`. Python's `True == 1` made the drift
+  /// guard's old `!= 1` check accept `schema_version: true`; this pins the
+  /// Swift side so the claim that the two loaders agree is measured rather
+  /// than reasoned from Yams' bridging behaviour.
+  @Test func throwsOnBooleanSchemaVersion() throws {
+    let yaml = """
+      schema_version: true
+      turns: []
+      """
+    let scenario = try makeScenario()
+    #expect(throws: YAMLReplaySourceError.unsupportedSchemaVersion(nil)) {
+      _ = try YAMLReplaySource(yaml: yaml, scenario: scenario)
+    }
+  }
+
   @Test func throwsOnMissingSchemaVersion() throws {
     let yaml = """
       turns: []

--- a/docs/specs/demo-replay-spec.md
+++ b/docs/specs/demo-replay-spec.md
@@ -366,7 +366,8 @@ to its v1 form apart from the version line, and refused by any already-shipped
 build, whose loader compared for equality against a single constant. That is
 accepted rather than worked around: demo YAMLs ship inside the app binary, so
 the rotation never sees a version it was not built with, and the exporter's
-Share-Sheet output has no import path in the app at all. Making the emitted
+Share-Sheet output has no REPLAY-import path in the app at all (the one
+`fileImporter` that exists ingests scenario YAML into the editor). Making the emitted
 version data-dependent (v1 when no row carries a `phase_path`) would preserve
 old-reader compatibility, and is the change to make if an importer ever lands —
 not before, since a branch nothing exercises is a branch nothing checks.

--- a/docs/specs/demo-replay-spec.md
+++ b/docs/specs/demo-replay-spec.md
@@ -144,7 +144,7 @@ Scenario definition (personas, phases, score rules) is *not* inlined.
 At load time the replay locates its `preset_ref.id` in the already-
 bundled presets and uses that scenario as the render context.
 
-### 3.2 Full schema (v1)
+### 3.2 Full schema (v2)
 
 ```yaml
 schema_version: 2
@@ -288,8 +288,9 @@ zero playable demos.
 the SHA check above, and easy to assume lives beside it: the assertion
 that a demo's `phase_index` / `phase_path` / `branch` actually resolve to
 a phase of type `phase_type` in the shipped preset is enforced by the
-Swift test `BundledDemoReplaySourceTests.bundledDemoPhaseIndicesMatchResolvedScenarioPhaseTypes`
-and its `assertPhaseAlignment` helper — **not** by
+Swift test `BundledDemoReplaySourceTests.bundledDemoPhaseIndicesMatchResolvedScenarioPhaseTypes`,
+whose `assertPhaseAlignment` defers the whole decision to
+`alignmentDiagnostic` — **not** by
 `scripts/check_demo_replay_drift.py`, and **not** by the runtime loader
 (`BundledDemoReplaySource` is integrity-only per the posture above).
 The drift script deliberately does not mirror it: duplicating the check

--- a/docs/specs/demo-replay-spec.md
+++ b/docs/specs/demo-replay-spec.md
@@ -198,6 +198,9 @@ turns:
 code_phase_events:               # optional; present if the preset has score_calc / scenario-gen phases
   - round: 2
     phase_index: 3
+    phase_path: [3]              # same coordinate fields as `turns` — both
+                                 # writers emit them here identically, and the
+                                 # §3.3 gate checks these entries too
     phase_type: score_calc
     summary: "Scores updated: Alice +1, Bob +1"
     payload:                     # optional; discriminated-union — §3.2 note 5
@@ -211,12 +214,12 @@ Notes on field choices:
 
 - **`phase_index`, `phase_path`, `branch` and `phase_type` — a split of
   duties, not four spellings of one thing.**
-  - `phase_index` owns **ordering**: it is the merge key that sorts
-    `turns` against `code_phase_events`, and a change in it is what marks
-    a phase boundary, so it also decides how many `.phaseStarted` events
-    a replay emits — and therefore `ReplayViewModel.phaseProgress`'s
-    numerator and `totalPhaseCount`'s denominator. It never reaches a
-    renderer directly.
+  - `phase_index` is the required **top-level ancestor**, and the v1
+    spelling of the ordering key. Ordering, phase-boundary detection and
+    hence how many `.phaseStarted` events a replay emits — which is
+    `ReplayViewModel.phaseProgress`'s numerator and `totalPhaseCount`'s
+    denominator — are keyed on `phase_path`, falling back to
+    `[phase_index]` when absent. Neither reaches a renderer directly.
   - `phase_path` (v2, optional) is the **full lineage**, byte-identical
     in meaning to `SimulationEvent.phaseStarted(phasePath:)` — `[i]` at
     top level, `[i, j]` for phase `j` of the branch taken by the
@@ -355,6 +358,18 @@ Future changes:
 - **Breaking** (e.g. change `turns` from array-of-entries to per-phase
   grouping): version bump and loader fork; drop an older version from the
   accepted set only after all bundled demos are re-recorded.
+
+**A new writer's output is not required to load in an older build.** The
+exporter emits the current version unconditionally, so a simulation recorded
+before migration v6 exports as v2 with no v2-only field in it — byte-identical
+to its v1 form apart from the version line, and refused by any already-shipped
+build, whose loader compared for equality against a single constant. That is
+accepted rather than worked around: demo YAMLs ship inside the app binary, so
+the rotation never sees a version it was not built with, and the exporter's
+Share-Sheet output has no import path in the app at all. Making the emitted
+version data-dependent (v1 when no row carries a `phase_path`) would preserve
+old-reader compatibility, and is the change to make if an importer ever lands —
+not before, since a branch nothing exercises is a branch nothing checks.
 
 Unknown `schema_version` is treated as drift and results in a silent
 skip at the demo surface (matching §3.3's posture) rather than a fatal

--- a/docs/specs/demo-replay-spec.md
+++ b/docs/specs/demo-replay-spec.md
@@ -301,10 +301,10 @@ in Python would require re-implementing preset branch navigation with no
 stated reconcile direction between the two copies. If that ownership
 ever moves, move it — do not add a second copy.
 
-One consequence worth stating because nothing else does: among **shipped**
-demos that assertion's conditional arm has an empty population, since no
-`Resources/DemoPresets/` preset uses a `conditional`. Its coverage comes
-from fixtures handed to the helper directly. Promoting a
+One consequence, restated here because it bounds what that assertion is
+evidence for: among **shipped** demos its conditional arm has an empty
+population, since no `Resources/DemoPresets/` preset uses a `conditional`.
+Its coverage comes from fixtures handed to the helper directly. Promoting a
 conditional-bearing preset (`word_wolf{,_en}`, `target_score_race{,_en}`)
 to a demo preset is what first gives it live artifacts — and is also when
 `phaseProgress` starts to differ between runs, because the two branches

--- a/docs/specs/demo-replay-spec.md
+++ b/docs/specs/demo-replay-spec.md
@@ -147,7 +147,7 @@ bundled presets and uses that scenario as the render context.
 ### 3.2 Full schema (v1)
 
 ```yaml
-schema_version: 1
+schema_version: 2
 
 preset_ref:
   id: word_wolf              # must match a shipped preset id (Resources/Presets/*.yaml, Resources/DemoPresets/*.yaml, or DB isPreset=true)
@@ -170,8 +170,10 @@ metadata:
 
 turns:
   - round: 1
-    phase_index: 0               # indexes into preset.phases at load time
-    phase_type: speak_all        # denormalised for cheap consistency check
+    phase_index: 0               # top-level ancestor; == phase_path[0]
+    phase_path: [0]              # optional (v2); full lineage, mirrors
+                                 # SimulationEvent.phaseStarted(phasePath:)
+    phase_type: speak_all        # the LEAF phase's type
     agent: Alice                 # must exist in preset.personas
     fields:                      # matches TurnOutput.fields shape
       statement: "I think the word might be 'cat'."
@@ -182,6 +184,15 @@ turns:
     agent: Bob
     fields:
       statement: "…"
+  - round: 2                     # a sub-phase inside a `conditional`
+    phase_index: 1               # the conditional, not the phase that spoke
+    phase_path: [1, 0]           # conditional at 1; phase 0 of its branch
+    branch: then                 # optional (v2); `[1, 0]` alone cannot say
+                                 # which — then[0] and else[0] share it
+    phase_type: vote             # type of then[0], NOT of phases[1]
+    agent: Alice
+    fields:
+      vote: Bob
   # …
 
 code_phase_events:               # optional; present if the preset has score_calc / scenario-gen phases
@@ -198,10 +209,32 @@ code_phase_events:               # optional; present if the preset has score_cal
 
 Notes on field choices:
 
-- **`phase_index` + `phase_type` together.** Index is the source of truth
-  for rendering; `phase_type` is a denormalised safety check caught by
-  the CI guard (§3.3) to detect preset drift that reorders phases without
-  changing sha.
+- **`phase_index`, `phase_path`, `branch` and `phase_type` — a split of
+  duties, not four spellings of one thing.**
+  - `phase_index` owns **ordering**: it is the merge key that sorts
+    `turns` against `code_phase_events`, and a change in it is what marks
+    a phase boundary, so it also decides how many `.phaseStarted` events
+    a replay emits — and therefore `ReplayViewModel.phaseProgress`'s
+    numerator and `totalPhaseCount`'s denominator. It never reaches a
+    renderer directly.
+  - `phase_path` (v2, optional) is the **full lineage**, byte-identical
+    in meaning to `SimulationEvent.phaseStarted(phasePath:)` — `[i]` at
+    top level, `[i, j]` for phase `j` of the branch taken by the
+    `conditional` at `i`. Depth is bounded at 2 (`ScenarioLoader.parsePhaseType`
+    rejects a nested `conditional` at parse time). When present it
+    supersedes `phase_index` for ordering and boundary detection;
+    `phase_index` is then required to equal `phase_path[0]`.
+  - `branch` (v2, optional) is `then` or `else`. `[i, j]` alone cannot
+    say which — `then[j]` and `else[j]` carry the identical path — so
+    without it a sub-phase's leaf type can only be checked against the
+    union of both branches. Only the curator can supply it (from the
+    `conditional_evaluated` event); `YAMLReplayExporter` cannot, because
+    no persisted column records the branch.
+  - `phase_type` owns the **rendered label** and is the type of the phase
+    at `phase_path` — the LEAF. For a branch sub-phase it therefore does
+    NOT equal `phases[phase_index].type`, which names the enclosing
+    `conditional`. That asymmetry is the whole reason `phase_path`
+    exists; see §3.3 for which gate enforces the pair.
 - **`fields` dict, not typed accessors.** Mirrors `TurnOutput.fields:
   [String: String]` so the replay can construct a `TurnOutput` without
   a separate schema layer.
@@ -251,6 +284,28 @@ hashes before the PR containing the preset change merges. §5 sets a
 minimum playable count so drift during a preset change cannot leave
 zero playable demos.
 
+**The phase-coordinate invariant has exactly one owner.** Distinct from
+the SHA check above, and easy to assume lives beside it: the assertion
+that a demo's `phase_index` / `phase_path` / `branch` actually resolve to
+a phase of type `phase_type` in the shipped preset is enforced by the
+Swift test `BundledDemoReplaySourceTests.bundledDemoPhaseIndicesMatchResolvedScenarioPhaseTypes`
+and its `assertPhaseAlignment` helper — **not** by
+`scripts/check_demo_replay_drift.py`, and **not** by the runtime loader
+(`BundledDemoReplaySource` is integrity-only per the posture above).
+The drift script deliberately does not mirror it: duplicating the check
+in Python would require re-implementing preset branch navigation with no
+stated reconcile direction between the two copies. If that ownership
+ever moves, move it — do not add a second copy.
+
+One consequence worth stating because nothing else does: among **shipped**
+demos that assertion's conditional arm has an empty population, since no
+`Resources/DemoPresets/` preset uses a `conditional`. Its coverage comes
+from fixtures handed to the helper directly. Promoting a
+conditional-bearing preset (`word_wolf{,_en}`, `target_score_race{,_en}`)
+to a demo preset is what first gives it live artifacts — and is also when
+`phaseProgress` starts to differ between runs, because the two branches
+need not contain the same number of phases.
+
 ### 3.4 Filter policy: at-record AND at-render
 
 `ContentFilter` is applied on **both sides** of the recording boundary:
@@ -283,14 +338,22 @@ owns the policy-implementation side.
 
 ### 3.5 Schema evolution
 
-`schema_version: 1` is the current shape. Future changes:
+`schema_version: 2` is the current shape (v2 landed with #1505:
+`phase_path` + `branch`, both optional). The loader accepts `{1, 2}`;
+v1 demos keep loading, and a v1 entry is read as if `phase_path` were
+`[phase_index]`, which is exact for any preset with no `conditional`.
+Future changes:
 
-- **v2 additive** (e.g. inline `scenario_def` fallback for self-
-  contained demos, or audio annotation tracks): bump to `2`, loader
-  supports both, older demos keep working.
-- **v2 breaking** (e.g. change `turns` from array-of-entries to
-  per-phase grouping): version bump and loader fork; deprecate v1 only
-  after all bundled demos re-recorded.
+- **Additive** (e.g. inline `scenario_def` fallback for self-contained
+  demos, or audio annotation tracks): bump the version, widen the
+  loader's accepted set to include it, older demos keep working. This is
+  the path v2 took — note that widening the set is half the change, not
+  an implied consequence of the bump: before #1505 the loader compared
+  for equality against a single constant, so a bump alone would have
+  dropped every already-shipped demo from the rotation.
+- **Breaking** (e.g. change `turns` from array-of-entries to per-phase
+  grouping): version bump and loader fork; drop an older version from the
+  accepted set only after all bundled demos are re-recorded.
 
 Unknown `schema_version` is treated as drift and results in a silent
 skip at the demo surface (matching §3.3's posture) rather than a fatal

--- a/scripts/check_demo_replay_drift.py
+++ b/scripts/check_demo_replay_drift.py
@@ -45,7 +45,7 @@ MIN_DEMOS = 3
 MAX_TOTAL_BYTES = 3 * 1024 * 1024
 MAX_PER_FILE_BYTES = 1 * 1024 * 1024
 MIN_TURNS = 6
-REQUIRED_SCHEMA_VERSION = 1
+SUPPORTED_SCHEMA_VERSIONS = {1, 2}
 ALLOWED_LANGUAGES = {"ja", "en"}
 # Mirror BundledDemoReplaySource.demoFilenameSuffix — demos on disk use
 # `<slug>_demo.yaml` so Xcode's synchronized-group flat-bundle copy does
@@ -160,10 +160,17 @@ def validate_demo(
     return errors
 
   schema_version = doc.get("schema_version")
-  if schema_version != REQUIRED_SCHEMA_VERSION:
+  # `isinstance` before the set membership, and `bool` excluded, for two
+  # reasons the previous `!= 1` comparison masked: an unhashable YAML value
+  # (`schema_version: [1]`) raises TypeError inside `in`, turning a named
+  # error into a traceback; and `True == 1` in Python, so `schema_version:
+  # true` used to pass. Yams gives Swift a `Bool` there, which fails
+  # `as? Int` — so this is also what keeps the two loaders agreeing.
+  if not isinstance(schema_version, int) or isinstance(schema_version, bool) \
+      or schema_version not in SUPPORTED_SCHEMA_VERSIONS:
     errors.append(
-      f"{path.name}: schema_version {schema_version!r} != "
-      f"{REQUIRED_SCHEMA_VERSION} (spec §3.2)"
+      f"{path.name}: schema_version {schema_version!r} not in "
+      f"{sorted(SUPPORTED_SCHEMA_VERSIONS)} (spec §3.2)"
     )
 
   preset_ref = doc.get("preset_ref")

--- a/scripts/jsonl_to_demo_replay.py
+++ b/scripts/jsonl_to_demo_replay.py
@@ -6,7 +6,7 @@ plan (demo-replay-spec.md §6): instead of hand-authoring demo YAMLs, run a
 scenario through `pastura-harness` (ADR-013, real local Gemma inference),
 pick the best transcript, and convert it here.
 
-Output schema: demo-replay-spec.md §3.2 (schema_version=1, preset_ref,
+Output schema: demo-replay-spec.md §3.2 (schema_version=2, preset_ref,
 metadata, turns, code_phase_events). Field selection mirrors
 `Pastura/Pastura/App/YAMLReplayExporter.swift`; payload `kind`
 discriminators match `YAMLReplaySource.decodePayloadStanza`.
@@ -23,22 +23,25 @@ Mapping:
   - `summary`       -> `summary`
   - `event_injected`-> `eventInjected`
   - `pairing_result`-> `pairingResult`
-`phase_index` is the most recent `phase_started.phase_path[0]`, an index into
-the scenario's TOP-LEVEL phase list — what the demo schema expects **only while
-the preset's phase list is flat**. A `conditional`'s branch sub-phases are
-reached through a nested `phase_path`, so their top-level index names the
-conditional rather than the phase that spoke, and `BundledDemoReplaySource`
-catches that only when `phases[idx].type` happens not to match the emitted
-`phase_type`. No `Resources/DemoPresets/` preset uses one today; four bundled
-presets do (`word_wolf{,_en}`, `target_score_race{,_en}`), so promoting one
-needs #1505 first.
+Phase coordinates (settled by #1505; spec §3.2 is the authority):
+`phase_path` is written verbatim from `phase_started.phase_path`, `phase_index`
+is `phase_path[0]`, and `phase_type` names the LEAF phase. A branch sub-phase
+therefore records `[i, j]` and a `phase_type` that does NOT equal
+`phases[phase_index].type` — the enclosing `conditional`'s. That asymmetry is
+the point; `BundledDemoReplaySourceTests.assertPhaseAlignment` is the sole owner
+of checking it (spec §3.3), not this script and not the runtime loader.
 
-#1473 fixed the same derivation on the highlight side and deliberately stopped
-there: that schema's `phase_index` names a position in a FLATTENED list, so
-branch-awareness was a derivation fix into a coordinate system that already
-existed. Here the schema says top-level, and what a branch sub-phase should
-record is undesigned — a schema decision, not a derivation bug. Do not port
-`gallery_highlight_extract.annotate`'s resolver across without settling that.
+`branch` is resolved here and only here. `[i, j]` cannot say whether `then[j]`
+or `else[j]` ran — they carry the identical path — so the branch comes from the
+`conditional_evaluated` the harness emits between the conditional's own
+`phase_started` and its branch's. `YAMLReplayExporter` cannot supply it (no
+column persists the branch), which is why the field is optional rather than
+required. The resolver mirrors `gallery_highlight_extract.annotate`, whose
+prose has the fuller derivation; the one deliberate difference is that this
+script reads the open conditional from the transcript's own `phase_type`
+rather than from the scenario's phase tree, because a curator's job here is to
+record what the transcript says and the minimal preset it is handed need not
+carry `phases:` at all.
 
 Recapture workflow (full demo-set swap):
   1. Run each scenario N times through the harness:
@@ -83,6 +86,11 @@ CODE_KIND = {
 #   IGNORED_EVENTS — reaches JSONL but is deliberately dropped from the demo
 #                    (lifecycle / diagnostic events the replay schema has no
 #                    slot for; moving one here is a reviewed diff).
+# NOTE the set means "not EMITTED", not "not READ". `conditional_evaluated` sits
+# in IGNORED_EVENTS and yet drives `branch` resolution below — the demo schema
+# has no slot for the event itself, but the verdict it carries is the only
+# source for which branch ran. Adding a read of an ignored event is fine; what
+# the classification forbids is emitting one without a reviewed diff.
 # An event in NEITHER set is a HARD ERROR at convert time (see the guard in
 # `main`) — previously a silent drop with no failure mode at all. The
 # `scripts/tests/demo-replay-event-coverage-test.sh` shell gate cross-checks
@@ -101,7 +109,7 @@ IGNORED_EVENTS = {
     "relationship_update",  # raw affinity matrix (#910); demo/replay drops it
     "narration",  # live commentary (#909); curated demos don't use narrate yet
     # — teletop demo integration is a follow-up. Reviewed drop per ADR-022 §D4.
-    "conditional_evaluated",
+    "conditional_evaluated",  # read for `branch` (see note above), never emitted
     "simulation_completed",
     "simulation_paused",
     "error",
@@ -190,20 +198,29 @@ def main():
     preset = yaml.safe_load(open(a.preset, encoding="utf-8"))
 
     turns, code = [], []
-    # `phase_idx` starts None, not 0: an event reaching the emit sites below
-    # before the first `phase_started` has no index, and 0 would be the same
-    # invention the `phase_path` guard refuses — removed from one source only,
-    # it would survive here. (`round_no` is left at 0: nothing here has measured
-    # what a round-0 turn does downstream.)
-    round_no, phase_idx, phase_type_cur = 0, None, ""
+    # `phase_path_cur` starts None, not [0]: an event reaching the emit sites
+    # below before the first `phase_started` has no coordinate, and 0 would be
+    # the same invention the `phase_path` guard refuses — removed from one
+    # source only, it would survive here. (`round_no` is left at 0: nothing here
+    # has measured what a round-0 turn does downstream.)
+    round_no, phase_path_cur, phase_type_cur = 0, None, ""
+    branch_cur = None        # "then" / "else" while inside a branch sub-phase
+    open_conditional = None  # top-level index of the conditional in flight
+    pending_branch = None    # (top, "then"/"else") from the last verdict
 
-    def emitted_phase_index():
-        """The current phase index, or refuse. Reads `phase_idx` live."""
-        if phase_idx is None:
+    def emitted_coords():
+        """The current phase's coordinate fields, or refuse. Reads live state."""
+        if phase_path_cur is None:
             raise SystemExit(
                 f"jsonl_to_demo_replay: an event in {a.run} precedes the first "
                 "`phase_started`, so phase_index cannot be derived.")
-        return phase_idx
+        # `phase_index` is `phase_path[0]` BY DEFINITION (spec §3.2) — it is
+        # emitted rather than dropped because it stays required in v2, so a
+        # reader that predates `phase_path` still orders correctly.
+        coords = {"phase_index": phase_path_cur[0], "phase_path": list(phase_path_cur)}
+        if branch_cur is not None:
+            coords["branch"] = branch_cur
+        return coords
 
     for l in lines:
         if l.get("type") != "event":
@@ -220,29 +237,67 @@ def main():
                 "emit surface change?) — see ADR-022 §D4.")
         if e == "round_started":
             round_no = l["round"]
+        elif e == "conditional_evaluated":
+            # Ignored for emission, read for `branch` — see the IGNORED_EVENTS
+            # note. Both refusals below are fatal: an invented branch would be
+            # indistinguishable from a measured one in the shipped demo.
+            if open_conditional is None:
+                raise SystemExit(
+                    f"jsonl_to_demo_replay: a `conditional_evaluated` in {a.run} "
+                    "has no preceding `phase_started` of type `conditional`, so "
+                    "the branch it decides cannot be attributed to a phase.")
+            result = l.get("result")
+            if not isinstance(result, bool):
+                raise SystemExit(
+                    f"jsonl_to_demo_replay: a `conditional_evaluated` in {a.run} "
+                    f"carries result {result!r}, not a boolean; the taken branch "
+                    "cannot be derived from it.")
+            pending_branch = (open_conditional, "then" if result else "else")
         elif e == "phase_started":
-            # Track both the index and the phase_type of the current phase.
-            # Code-phase events (vote_results / score_update / summary /
-            # event_injected) carry NO phase_type of their own, so the demo's
-            # phase_type — which must equal scenario.phases[phase_index].type
-            # (BundledDemoReplaySource rejects the demo otherwise) — has to
+            # Track the path and the phase_type of the current phase. Code-phase
+            # events (vote_results / score_update / summary / event_injected)
+            # carry NO phase_type of their own, so the demo's phase_type has to
             # come from the enclosing phase_started, not the event name.
-            # The index is refused rather than defaulted to 0 — the same
-            # invention removed from `gallery_highlight_extract.annotate`
-            # (#1474). That type equality usually catches a fabricated 0, so it
-            # survives exactly when phases[0] happens to match: the case no
-            # reader would think to check.
             path = l.get("phase_path")
             if not isinstance(path, list) or not path:
                 raise SystemExit(
                     f"jsonl_to_demo_replay: a `phase_started` in {a.run} carries "
                     "no usable `phase_path`, so phase_index cannot be derived.")
-            phase_idx = path[0]
+            if any(not isinstance(x, int) or isinstance(x, bool) for x in path):
+                raise SystemExit(
+                    f"jsonl_to_demo_replay: a `phase_started` in {a.run} carries "
+                    f"`phase_path` {path} with a non-integer element; a bool "
+                    "would resolve as 0/1 and name a phase the run never entered.")
+            if len(path) > 2:
+                raise SystemExit(
+                    f"jsonl_to_demo_replay: a `phase_started` in {a.run} carries "
+                    f"`phase_path` {path}, {len(path)} deep, but the engine's "
+                    "depth-1 rule bounds it to 2 (ScenarioLoader.parsePhaseType "
+                    "refuses a nested `conditional` at parse time). A deeper path "
+                    "means the transcript and that rule disagree.")
             phase_type_cur = l.get("phase_type", "")
+            if len(path) == 1:
+                open_conditional = path[0] if phase_type_cur == "conditional" else None
+                branch_cur = None
+                # Cleared on EVERY top-level phase, conditional included: the
+                # engine re-evaluates the condition once per round, so carrying
+                # the previous round's verdict forward would resolve round N's
+                # branch phases against round N-1's branch instead of failing.
+                pending_branch = None
+            else:
+                if pending_branch is None or pending_branch[0] != path[0]:
+                    raise SystemExit(
+                        f"jsonl_to_demo_replay: a `phase_started` in {a.run} with "
+                        f"`phase_path` {path} is inside a branch, but no "
+                        "`conditional_evaluated` for that conditional precedes it. "
+                        "`then[j]` and `else[j]` share the path, so the branch is "
+                        "what disambiguates them and it cannot be guessed.")
+                branch_cur = pending_branch[1]
+            phase_path_cur = list(path)
         elif e == "agent_output":
             turns.append({
                 "round": round_no,
-                "phase_index": emitted_phase_index(),
+                **emitted_coords(),
                 "phase_type": l["phase_type"],
                 "agent": l["agent"],
                 "fields": ordered_fields(l["fields"]),
@@ -253,7 +308,7 @@ def main():
             value = l.get("value", "")
             code.append({
                 "round": round_no,
-                "phase_index": emitted_phase_index(),
+                **emitted_coords(),
                 "phase_type": phase_type_cur,
                 "summary": value,
                 "payload": {"kind": "sharedAssignment", "value": value},
@@ -265,7 +320,7 @@ def main():
             agent, value = l.get("agent", ""), l.get("value", "")
             code.append({
                 "round": round_no,
-                "phase_index": emitted_phase_index(),
+                **emitted_coords(),
                 "phase_type": phase_type_cur,
                 "summary": f"{agent} assigned: {value}",
                 "payload": {"kind": "assignment", "agent": agent, "value": value},
@@ -273,14 +328,14 @@ def main():
         elif e in CODE_KIND:
             code.append({
                 "round": round_no,
-                "phase_index": emitted_phase_index(),
+                **emitted_coords(),
                 "phase_type": l.get("phase_type") or phase_type_cur,
                 "summary": code_summary(l),
                 "payload": code_payload(l),
             })
 
     doc = {
-        "schema_version": 1,
+        "schema_version": 2,
         "preset_ref": {
             "id": preset["id"],
             "version": "1.0",

--- a/scripts/jsonl_to_demo_replay.py
+++ b/scripts/jsonl_to_demo_replay.py
@@ -37,11 +37,16 @@ or `else[j]` ran — they carry the identical path — so the branch comes from 
 `phase_started` and its branch's. `YAMLReplayExporter` cannot supply it (no
 column persists the branch), which is why the field is optional rather than
 required. The resolver mirrors `gallery_highlight_extract.annotate`, whose
-prose has the fuller derivation; the one deliberate difference is that this
-script reads the open conditional from the transcript's own `phase_type`
-rather than from the scenario's phase tree, because a curator's job here is to
-record what the transcript says and the minimal preset it is handed need not
-carry `phases:` at all.
+prose has the fuller derivation. It diverges where that tool's target
+coordinate system does: `annotate` resolves each path against the scenario's
+phase tree, so it reads the open conditional from `nodes[...].type` AND range-
+checks the branch index. This script emits the path verbatim, so it reads the
+open conditional from the transcript's own `phase_type` — a curator's job is to
+record what the transcript says, and the minimal preset it is handed need not
+carry `phases:` at all — and it range-checks nothing. The range case is not
+unowned: a depth-2 path always carries a `branch` here (the else arm below dies
+without a `pending_branch`), so `conditionalDiagnostic`'s
+`taken.indices.contains(inner)` catches it at the gate.
 
 Recapture workflow (full demo-set swap):
   1. Run each scenario N times through the harness:
@@ -126,6 +131,28 @@ IGNORED_EVENTS = {
 # statement before inner_thought, vote before reason). Unknown keys keep
 # their source order after these.
 FIELD_ORDER = ["statement", "inner_thought", "action", "vote", "reason"]
+
+
+class FlowList(list):
+    """A list rendered inline (`[1, 0]`) rather than as a block sequence.
+
+    Only `phase_path` uses it, so it matches the spec §3.2 example and
+    `YAMLReplayExporter.yamlIntArray` — the shipped demos are curator-produced,
+    so without this the example would describe only the writer whose output
+    never ships. Both renderings parse identically; this is legibility.
+
+    Deliberately NOT `default_flow_style=None` on the dump: that switch reaches
+    every leaf collection, which folds `metadata` and each turn's `fields` into
+    one-line mappings too. `fields.*` is what the spec §3.4 content audit is
+    read against by hand, so that is a real cost for an unrelated gain.
+    """
+
+
+yaml.add_representer(
+    FlowList,
+    lambda dumper, data: dumper.represent_sequence(
+        "tag:yaml.org,2002:seq", data, flow_style=True),
+    Dumper=yaml.SafeDumper)
 
 
 def sha256_hex(path):
@@ -217,7 +244,8 @@ def main():
         # `phase_index` is `phase_path[0]` BY DEFINITION (spec §3.2) — it is
         # emitted rather than dropped because it stays required in v2, so a
         # reader that predates `phase_path` still orders correctly.
-        coords = {"phase_index": phase_path_cur[0], "phase_path": list(phase_path_cur)}
+        coords = {"phase_index": phase_path_cur[0],
+                  "phase_path": FlowList(phase_path_cur)}
         if branch_cur is not None:
             coords["branch"] = branch_cur
         return coords

--- a/scripts/jsonl_to_demo_replay.py
+++ b/scripts/jsonl_to_demo_replay.py
@@ -43,10 +43,13 @@ phase tree, so it reads the open conditional from `nodes[...].type` AND range-
 checks the branch index. This script emits the path verbatim, so it reads the
 open conditional from the transcript's own `phase_type` — a curator's job is to
 record what the transcript says, and the minimal preset it is handed need not
-carry `phases:` at all — and it range-checks nothing. The range case is not
-unowned: a depth-2 path always carries a `branch` here (the else arm below dies
-without a `pending_branch`), so `conditionalDiagnostic`'s
-`taken.indices.contains(inner)` catches it at the gate.
+carry `phases:` at all — and it range-checks nothing. The gate owns that:
+`conditionalDiagnostic` indexes the branch at the path's second component and
+refuses an index no branch holds. Note the ownership is the GATE's, not this
+script's `branch` field — an earlier revision of this paragraph reasoned that a
+depth-2 path always carries a `branch` here and stopped there, which left the
+range case unowned for `YAMLReplayExporter`, the writer that emits a nested
+path and can never emit a branch.
 
 Recapture workflow (full demo-set swap):
   1. Run each scenario N times through the harness:

--- a/scripts/tests/jsonl-to-demo-replay-test.sh
+++ b/scripts/tests/jsonl-to-demo-replay-test.sh
@@ -411,16 +411,35 @@ fi
 # (`default_flow_style=None` on the dump) also folds `metadata` and each turn's
 # `fields` into one-line mappings — and `fields.*` is what the §3.4 content
 # audit is read against by hand.
-if python3 "$CONVERTER" "$TMP/then.jsonl" "$TMP/preset.yaml" "$TMP/out_m.yaml" >/dev/null 2>&1; then
-  if grep -q '^  phase_path: \[1, 0\]$' "$TMP/out_m.yaml"; then
-    if grep -q '^  fields:$' "$TMP/out_m.yaml"; then
-      echo "ok   (m) phase_path renders inline while fields stays block"
+# The fixture carries a code-phase event as well as a turn: both sections take
+# their coordinates from the one `emitted_coords()`, so they cannot diverge
+# today — but the spec §3.2 example now promises they render identically, and a
+# promise about a section no arm reads is the unarmed half all over again.
+cat > "$TMP/render.jsonl" <<'JSONL'
+{"type":"run_start","run_id":"r1","date":"2026-08-14T00:00:00Z","scenario_id":"fixture_v1","language":"ja","model":"Gemma 4 E2B (Q4_K_M)"}
+{"type":"event","t":0.1,"attempt":1,"event":"round_started","round":1,"total_rounds":1}
+{"type":"event","t":0.2,"attempt":1,"event":"phase_started","phase_type":"conditional","phase_path":[1]}
+{"type":"event","t":0.3,"attempt":1,"event":"conditional_evaluated","condition":"x > 0","result":true}
+{"type":"event","t":0.4,"attempt":1,"event":"phase_started","phase_type":"speak_all","phase_path":[1,0]}
+{"type":"event","t":0.5,"attempt":1,"event":"agent_output","agent":"アヤ","phase_type":"speak_all","fields":{"statement":"ひとこと。"}}
+{"type":"event","t":0.6,"attempt":1,"event":"summary","value":"まとめ。"}
+{"type":"run_end","run_id":"r1","status":"ok","attempts":1,"duration_sec":1.0}
+JSONL
+if python3 "$CONVERTER" "$TMP/render.jsonl" "$TMP/preset.yaml" "$TMP/out_m.yaml" >/dev/null 2>&1; then
+  # Two occurrences expected: one in `turns`, one in `code_phase_events`.
+  inline_count="$(grep -c '^  phase_path: \[1, 0\]$' "$TMP/out_m.yaml" || true)"
+  if [ "$inline_count" = "2" ]; then
+    # `fields` and `metadata` are the two mappings a document-wide flow switch
+    # would fold; `fields.*` is what the spec §3.4 content audit is read
+    # against by hand, so the scope of the switch is the assertion here.
+    if grep -q '^  fields:$' "$TMP/out_m.yaml" && grep -q '^metadata:$' "$TMP/out_m.yaml"; then
+      echo "ok   (m) phase_path renders inline in both sections; fields/metadata stay block"
     else
-      echo "FAIL: (m) fields was folded to flow style — the switch is too broad" >&2
-      grep -n 'fields' "$TMP/out_m.yaml" >&2; fail=1
+      echo "FAIL: (m) fields or metadata was folded to flow — the switch is too broad" >&2
+      grep -n '^metadata\|fields' "$TMP/out_m.yaml" >&2; fail=1
     fi
   else
-    echo "FAIL: (m) phase_path did not render inline as '[1, 0]'" >&2
+    echo "FAIL: (m) expected 2 inline 'phase_path: [1, 0]' lines, got $inline_count" >&2
     grep -n 'phase_path' "$TMP/out_m.yaml" >&2; fail=1
   fi
 else

--- a/scripts/tests/jsonl-to-demo-replay-test.sh
+++ b/scripts/tests/jsonl-to-demo-replay-test.sh
@@ -11,7 +11,9 @@
 #   - `phase_index` derivation and its refusals (#1474 — the same invention was
 #     removed from gallery_highlight_extract.annotate, whose arm is C4 in
 #     gallery-highlight-test.sh);
-#   - `branch` resolution for a `conditional`'s sub-phases (#1505).
+#   - `branch` resolution for a `conditional`'s sub-phases (#1505), including
+#     each of its five refusals — an unarmed refusal is what this header's own
+#     rule below forbids, and three of them were unarmed when first written.
 # A guard with no arm is silently unverified, and both are otherwise unreachable
 # from any in-repo test. The `branch` arms matter more than they look: NO shipped
 # demo has a conditional, so the Swift-side alignment gate cannot reach that
@@ -209,6 +211,9 @@ else
       echo "FAIL: (f) refused, but not with the intended message: $out_f" >&2; fail=1 ;;
   esac
 fi
+if [ -e "$TMP/out_f.yaml" ]; then
+  echo "FAIL: (f) wrote an output despite refusing" >&2; fail=1
+fi
 
 # (g) Negative — a non-boolean verdict is refused. `result` decides then-vs-else
 # by truthiness, so a string would silently resolve every non-empty value to
@@ -235,6 +240,9 @@ else
     *)
       echo "FAIL: (g) refused, but not with the intended message: $out_g" >&2; fail=1 ;;
   esac
+fi
+if [ -e "$TMP/out_g.yaml" ]; then
+  echo "FAIL: (g) wrote an output despite refusing" >&2; fail=1
 fi
 
 # (h) A top-level phase clears the branch — otherwise a later top-level turn
@@ -263,6 +271,119 @@ print(';'.join('%s/%s' % (t['phase_path'], t.get('branch')) for t in d['turns'])
   fi
 else
   echo "FAIL: (h) converter rejected a well-formed mixed transcript" >&2; fail=1
+fi
+
+# (i) Negative — a verdict with no conditional in flight. Distinct from (f):
+# there the branch phase had no verdict, here the verdict has no phase to
+# attribute it to, and only this arm reaches that refusal.
+python3 - "$TMP" <<'PY'
+import sys
+src = sys.argv[1] + "/then.jsonl"
+text = open(src, encoding="utf-8").read()
+old = '"phase_type":"conditional","phase_path":[1]'
+assert text.count(old) == 1, f"anchor matched {text.count(old)} times — probe invalid"
+# Retype the opening phase so no conditional is ever in flight; the verdict
+# line that follows is then unattributable.
+open(sys.argv[1] + "/orphanverdict.jsonl", "w", encoding="utf-8").write(
+    text.replace(old, '"phase_type":"speak_all","phase_path":[1]'))
+PY
+set +e
+out_i="$(python3 "$CONVERTER" "$TMP/orphanverdict.jsonl" "$TMP/preset.yaml" "$TMP/out_i.yaml" 2>&1)"
+rc_i=$?
+set -e
+if [ "$rc_i" -eq 0 ]; then
+  echo "FAIL: (i) an orphan conditional_evaluated was accepted: $out_i" >&2; fail=1
+else
+  case "$out_i" in
+    *"has no preceding"*)
+      echo "ok   (i) an orphan conditional_evaluated is refused by name" ;;
+    *)
+      echo "FAIL: (i) refused, but not with the intended message: $out_i" >&2; fail=1 ;;
+  esac
+fi
+
+# (j) Negative — a bool element in `phase_path`. `isinstance(True, int)` is True
+# in Python, so this guard is the only thing between `[true, 0]` and a demo
+# naming phase 1; every other check downstream would see a well-formed int.
+python3 - "$TMP" <<'PY'
+import sys
+src = sys.argv[1] + "/then.jsonl"
+text = open(src, encoding="utf-8").read()
+old = '"phase_path":[1,0]'
+assert text.count(old) == 1, f"anchor matched {text.count(old)} times — probe invalid"
+open(sys.argv[1] + "/boolpath.jsonl", "w", encoding="utf-8").write(
+    text.replace(old, '"phase_path":[true,0]'))
+PY
+set +e
+out_j="$(python3 "$CONVERTER" "$TMP/boolpath.jsonl" "$TMP/preset.yaml" "$TMP/out_j.yaml" 2>&1)"
+rc_j=$?
+set -e
+if [ "$rc_j" -eq 0 ]; then
+  echo "FAIL: (j) a bool phase_path element was accepted: $out_j" >&2; fail=1
+else
+  case "$out_j" in
+    *"a bool"*)
+      echo "ok   (j) a bool phase_path element is refused by name" ;;
+    *)
+      echo "FAIL: (j) refused, but not with the intended message: $out_j" >&2; fail=1 ;;
+  esac
+fi
+
+# (k) Negative — a path deeper than the engine's depth-1 rule allows.
+python3 - "$TMP" <<'PY'
+import sys
+src = sys.argv[1] + "/then.jsonl"
+text = open(src, encoding="utf-8").read()
+old = '"phase_path":[1,0]'
+assert text.count(old) == 1, f"anchor matched {text.count(old)} times — probe invalid"
+open(sys.argv[1] + "/deeppath.jsonl", "w", encoding="utf-8").write(
+    text.replace(old, '"phase_path":[1,0,0]'))
+PY
+set +e
+out_k="$(python3 "$CONVERTER" "$TMP/deeppath.jsonl" "$TMP/preset.yaml" "$TMP/out_k.yaml" 2>&1)"
+rc_k=$?
+set -e
+if [ "$rc_k" -eq 0 ]; then
+  echo "FAIL: (k) an over-deep phase_path was accepted: $out_k" >&2; fail=1
+else
+  case "$out_k" in
+    *"deep, but the engine's"*)
+      echo "ok   (k) an over-deep phase_path is refused by name" ;;
+    *)
+      echo "FAIL: (k) refused, but not with the intended message: $out_k" >&2; fail=1 ;;
+  esac
+fi
+
+# (l) The hazard arm (h)'s comment actually names is MULTI-round: round 2's
+# branch must NOT inherit round 1's verdict. (h) shows the clear happens; only
+# this shows what the clear buys — round 2 has no verdict of its own, so the
+# branch phase must be refused rather than resolved against round 1's.
+cat > "$TMP/tworound.jsonl" <<'JSONL'
+{"type":"run_start","run_id":"r1","date":"2026-08-14T00:00:00Z","scenario_id":"fixture_v1","language":"ja","model":"Gemma 4 E2B (Q4_K_M)"}
+{"type":"event","t":0.1,"attempt":1,"event":"round_started","round":1,"total_rounds":2}
+{"type":"event","t":0.2,"attempt":1,"event":"phase_started","phase_type":"conditional","phase_path":[1]}
+{"type":"event","t":0.3,"attempt":1,"event":"conditional_evaluated","condition":"x > 0","result":true}
+{"type":"event","t":0.4,"attempt":1,"event":"phase_started","phase_type":"speak_all","phase_path":[1,0]}
+{"type":"event","t":0.5,"attempt":1,"event":"agent_output","agent":"アヤ","phase_type":"speak_all","fields":{"statement":"r1."}}
+{"type":"event","t":0.6,"attempt":1,"event":"round_started","round":2,"total_rounds":2}
+{"type":"event","t":0.7,"attempt":1,"event":"phase_started","phase_type":"conditional","phase_path":[1]}
+{"type":"event","t":0.8,"attempt":1,"event":"phase_started","phase_type":"speak_all","phase_path":[1,0]}
+{"type":"event","t":0.9,"attempt":1,"event":"agent_output","agent":"アヤ","phase_type":"speak_all","fields":{"statement":"r2."}}
+{"type":"run_end","run_id":"r1","status":"ok","attempts":1,"duration_sec":1.0}
+JSONL
+set +e
+out_l="$(python3 "$CONVERTER" "$TMP/tworound.jsonl" "$TMP/preset.yaml" "$TMP/out_l.yaml" 2>&1)"
+rc_l=$?
+set -e
+if [ "$rc_l" -eq 0 ]; then
+  echo "FAIL: (l) round 2 inherited round 1's verdict instead of refusing" >&2; fail=1
+else
+  case "$out_l" in
+    *"is inside a branch, but no"*)
+      echo "ok   (l) a later round does not inherit an earlier verdict" ;;
+    *)
+      echo "FAIL: (l) refused, but not with the intended message: $out_l" >&2; fail=1 ;;
+  esac
 fi
 
 if [ "$fail" -eq 0 ]; then

--- a/scripts/tests/jsonl-to-demo-replay-test.sh
+++ b/scripts/tests/jsonl-to-demo-replay-test.sh
@@ -7,10 +7,15 @@
 # converter as a fixture path for the ADR-022 §D4 coverage gate and never
 # executes it. This file executes it.
 #
-# Today it covers one thing: `phase_index` derivation and its refusals (#1474 —
-# the same invention was removed from gallery_highlight_extract.annotate, whose
-# arm is C4 in gallery-highlight-test.sh). A guard with no arm is silently
-# unverified, and this one is otherwise unreachable from any in-repo test.
+# Two things today:
+#   - `phase_index` derivation and its refusals (#1474 — the same invention was
+#     removed from gallery_highlight_extract.annotate, whose arm is C4 in
+#     gallery-highlight-test.sh);
+#   - `branch` resolution for a `conditional`'s sub-phases (#1505).
+# A guard with no arm is silently unverified, and both are otherwise unreachable
+# from any in-repo test. The `branch` arms matter more than they look: NO shipped
+# demo has a conditional, so the Swift-side alignment gate cannot reach that
+# resolver either — this file is the only place it executes at all.
 #
 # CI-wired via the `scripts/tests/*-test.sh` naming convention (the
 # `shell-tests` job, ubuntu / bash 5+). The converter imports PyYAML at module
@@ -124,6 +129,140 @@ else
     *)
       echo "FAIL: (c) refused, but not with the intended message: $out_c" >&2; fail=1 ;;
   esac
+fi
+
+# ---------------------------------------------------------------------------
+# `branch` resolution (#1505). `then[j]` and `else[j]` carry the IDENTICAL
+# `phase_path`, so the two arms below differ only in the `conditional_evaluated`
+# verdict — anything that read the branch off the path instead would return the
+# same answer for both and pass one of them by luck.
+
+# $1 = result literal (true/false), $2 = output filename
+write_branch_run() {
+  cat > "$TMP/$2.jsonl" <<JSONL
+{"type":"run_start","run_id":"r1","date":"2026-08-14T00:00:00Z","scenario_id":"fixture_v1","language":"ja","model":"Gemma 4 E2B (Q4_K_M)"}
+{"type":"event","t":0.1,"attempt":1,"event":"round_started","round":1,"total_rounds":1}
+{"type":"event","t":0.2,"attempt":1,"event":"phase_started","phase_type":"conditional","phase_path":[1]}
+{"type":"event","t":0.3,"attempt":1,"event":"conditional_evaluated","condition":"x > 0","result":$1}
+{"type":"event","t":0.4,"attempt":1,"event":"phase_started","phase_type":"speak_all","phase_path":[1,0]}
+{"type":"event","t":0.5,"attempt":1,"event":"agent_output","agent":"アヤ","phase_type":"speak_all","fields":{"statement":"ひとこと。"}}
+{"type":"run_end","run_id":"r1","status":"ok","attempts":1,"duration_sec":1.0}
+JSONL
+}
+
+read_coords() {
+  python3 -c "
+import yaml, sys
+d = yaml.safe_load(open(sys.argv[1], encoding='utf-8'))
+t = d['turns'][0]
+print('%s|%s|%s|%s' % (d['schema_version'], t['phase_index'],
+                       t['phase_path'], t.get('branch')))" "$1"
+}
+
+# (d) then-branch
+write_branch_run true then
+if python3 "$CONVERTER" "$TMP/then.jsonl" "$TMP/preset.yaml" "$TMP/out_then.yaml" >/dev/null 2>&1; then
+  got_d="$(read_coords "$TMP/out_then.yaml")"
+  if [ "$got_d" = "2|1|[1, 0]|then" ]; then
+    echo "ok   (d) then-branch: v2 + phase_path [1, 0] + branch then"
+  else
+    echo "FAIL: (d) expected '2|1|[1, 0]|then', got '$got_d'" >&2; fail=1
+  fi
+else
+  echo "FAIL: (d) converter rejected a well-formed conditional transcript" >&2; fail=1
+fi
+
+# (e) else-branch — same path, opposite verdict.
+write_branch_run false else
+if python3 "$CONVERTER" "$TMP/else.jsonl" "$TMP/preset.yaml" "$TMP/out_else.yaml" >/dev/null 2>&1; then
+  got_e="$(read_coords "$TMP/out_else.yaml")"
+  if [ "$got_e" = "2|1|[1, 0]|else" ]; then
+    echo "ok   (e) else-branch resolves from the verdict, not the path"
+  else
+    echo "FAIL: (e) expected '2|1|[1, 0]|else', got '$got_e'" >&2; fail=1
+  fi
+else
+  echo "FAIL: (e) converter rejected a well-formed conditional transcript" >&2; fail=1
+fi
+
+# (f) Negative — a branch `phase_started` with no preceding verdict is refused
+# rather than guessed. Built by DELETING the verdict line from (d)'s fixture, so
+# the arm cannot drift away from the positive it is the control for.
+python3 - "$TMP" <<'PY'
+import sys
+src = sys.argv[1] + "/then.jsonl"
+kept = [ln for ln in open(src, encoding="utf-8") if '"conditional_evaluated"' not in ln]
+assert len(kept) == 6, f"expected to drop exactly 1 of 7 lines, kept {len(kept)} — probe invalid"
+open(sys.argv[1] + "/noverdict.jsonl", "w", encoding="utf-8").writelines(kept)
+PY
+set +e
+out_f="$(python3 "$CONVERTER" "$TMP/noverdict.jsonl" "$TMP/preset.yaml" "$TMP/out_f.yaml" 2>&1)"
+rc_f=$?
+set -e
+if [ "$rc_f" -eq 0 ]; then
+  echo "FAIL: (f) a branch phase with no verdict was accepted: $out_f" >&2; fail=1
+else
+  case "$out_f" in
+    *"is inside a branch, but no"*)
+      echo "ok   (f) an unattributed branch is refused by name" ;;
+    *)
+      echo "FAIL: (f) refused, but not with the intended message: $out_f" >&2; fail=1 ;;
+  esac
+fi
+
+# (g) Negative — a non-boolean verdict is refused. `result` decides then-vs-else
+# by truthiness, so a string would silently resolve every non-empty value to
+# `then`; that is a wrong branch recorded as measured fact, not a crash.
+python3 - "$TMP" <<'PY'
+import sys
+src = sys.argv[1] + "/then.jsonl"
+text = open(src, encoding="utf-8").read()
+old = '"result":true'
+assert text.count(old) == 1, f"anchor matched {text.count(old)} times — probe invalid"
+open(sys.argv[1] + "/badresult.jsonl", "w", encoding="utf-8").write(
+    text.replace(old, '"result":"true"'))
+PY
+set +e
+out_g="$(python3 "$CONVERTER" "$TMP/badresult.jsonl" "$TMP/preset.yaml" "$TMP/out_g.yaml" 2>&1)"
+rc_g=$?
+set -e
+if [ "$rc_g" -eq 0 ]; then
+  echo "FAIL: (g) a non-boolean conditional result was accepted: $out_g" >&2; fail=1
+else
+  case "$out_g" in
+    *"not a boolean"*)
+      echo "ok   (g) a non-boolean conditional result is refused by name" ;;
+    *)
+      echo "FAIL: (g) refused, but not with the intended message: $out_g" >&2; fail=1 ;;
+  esac
+fi
+
+# (h) A top-level phase clears the branch — otherwise a later top-level turn
+# would inherit the verdict of a conditional that already closed.
+cat > "$TMP/clears.jsonl" <<'JSONL'
+{"type":"run_start","run_id":"r1","date":"2026-08-14T00:00:00Z","scenario_id":"fixture_v1","language":"ja","model":"Gemma 4 E2B (Q4_K_M)"}
+{"type":"event","t":0.1,"attempt":1,"event":"round_started","round":1,"total_rounds":1}
+{"type":"event","t":0.2,"attempt":1,"event":"phase_started","phase_type":"conditional","phase_path":[1]}
+{"type":"event","t":0.3,"attempt":1,"event":"conditional_evaluated","condition":"x > 0","result":true}
+{"type":"event","t":0.4,"attempt":1,"event":"phase_started","phase_type":"speak_all","phase_path":[1,0]}
+{"type":"event","t":0.5,"attempt":1,"event":"agent_output","agent":"アヤ","phase_type":"speak_all","fields":{"statement":"branch."}}
+{"type":"event","t":0.6,"attempt":1,"event":"phase_started","phase_type":"vote","phase_path":[2]}
+{"type":"event","t":0.7,"attempt":1,"event":"agent_output","agent":"アヤ","phase_type":"vote","fields":{"vote":"ボブ"}}
+{"type":"run_end","run_id":"r1","status":"ok","attempts":1,"duration_sec":1.0}
+JSONL
+if python3 "$CONVERTER" "$TMP/clears.jsonl" "$TMP/preset.yaml" "$TMP/out_h.yaml" >/dev/null 2>&1; then
+  got_h="$(python3 -c "
+import yaml, sys
+d = yaml.safe_load(open(sys.argv[1], encoding='utf-8'))
+print(';'.join('%s/%s' % (t['phase_path'], t.get('branch')) for t in d['turns']))" \
+    "$TMP/out_h.yaml")"
+  if [ "$got_h" = "[1, 0]/then;[2]/None" ]; then
+    echo "ok   (h) a top-level phase clears the pending branch"
+  else
+    echo "FAIL: (h) expected '[1, 0]/then;[2]/None', got '$got_h'" >&2; fail=1
+  fi
+else
+  echo "FAIL: (h) converter rejected a well-formed mixed transcript" >&2; fail=1
 fi
 
 if [ "$fail" -eq 0 ]; then

--- a/scripts/tests/jsonl-to-demo-replay-test.sh
+++ b/scripts/tests/jsonl-to-demo-replay-test.sh
@@ -301,6 +301,9 @@ else
       echo "FAIL: (i) refused, but not with the intended message: $out_i" >&2; fail=1 ;;
   esac
 fi
+if [ -e "$TMP/out_i.yaml" ]; then
+  echo "FAIL: (i) wrote an output despite refusing" >&2; fail=1
+fi
 
 # (j) Negative — a bool element in `phase_path`. `isinstance(True, int)` is True
 # in Python, so this guard is the only thing between `[true, 0]` and a demo
@@ -328,6 +331,9 @@ else
       echo "FAIL: (j) refused, but not with the intended message: $out_j" >&2; fail=1 ;;
   esac
 fi
+if [ -e "$TMP/out_j.yaml" ]; then
+  echo "FAIL: (j) wrote an output despite refusing" >&2; fail=1
+fi
 
 # (k) Negative — a path deeper than the engine's depth-1 rule allows.
 python3 - "$TMP" <<'PY'
@@ -352,6 +358,9 @@ else
     *)
       echo "FAIL: (k) refused, but not with the intended message: $out_k" >&2; fail=1 ;;
   esac
+fi
+if [ -e "$TMP/out_k.yaml" ]; then
+  echo "FAIL: (k) wrote an output despite refusing" >&2; fail=1
 fi
 
 # (l) The hazard arm (h)'s comment actually names is MULTI-round: round 2's
@@ -378,12 +387,44 @@ set -e
 if [ "$rc_l" -eq 0 ]; then
   echo "FAIL: (l) round 2 inherited round 1's verdict instead of refusing" >&2; fail=1
 else
+  # Same matcher string as (f) — the converter raises one message for both
+  # shapes, so what discriminates this arm is the FIXTURE (round 2's branch
+  # phase with round 1's verdict available), not the `case` pattern. If that
+  # message ever splits in two, re-point this one rather than leaving it
+  # matching (f)'s.
   case "$out_l" in
     *"is inside a branch, but no"*)
       echo "ok   (l) a later round does not inherit an earlier verdict" ;;
     *)
       echo "FAIL: (l) refused, but not with the intended message: $out_l" >&2; fail=1 ;;
   esac
+fi
+if [ -e "$TMP/out_l.yaml" ]; then
+  echo "FAIL: (l) wrote an output despite refusing" >&2; fail=1
+fi
+
+# (m) On-disk RENDERING, not the parsed value. Every arm above reads the YAML
+# back through `yaml.safe_load`, which is blind to flow-vs-block style — so
+# `FlowList` would have no arm at all. It exists so `phase_path` matches the
+# spec §3.2 example and `YAMLReplayExporter.yamlIntArray`; the paired negative
+# assertion is that the switch stayed scoped, since the obvious spelling
+# (`default_flow_style=None` on the dump) also folds `metadata` and each turn's
+# `fields` into one-line mappings — and `fields.*` is what the §3.4 content
+# audit is read against by hand.
+if python3 "$CONVERTER" "$TMP/then.jsonl" "$TMP/preset.yaml" "$TMP/out_m.yaml" >/dev/null 2>&1; then
+  if grep -q '^  phase_path: \[1, 0\]$' "$TMP/out_m.yaml"; then
+    if grep -q '^  fields:$' "$TMP/out_m.yaml"; then
+      echo "ok   (m) phase_path renders inline while fields stays block"
+    else
+      echo "FAIL: (m) fields was folded to flow style — the switch is too broad" >&2
+      grep -n 'fields' "$TMP/out_m.yaml" >&2; fail=1
+    fi
+  else
+    echo "FAIL: (m) phase_path did not render inline as '[1, 0]'" >&2
+    grep -n 'phase_path' "$TMP/out_m.yaml" >&2; fail=1
+  fi
+else
+  echo "FAIL: (m) converter rejected a well-formed conditional transcript" >&2; fail=1
 fi
 
 if [ "$fail" -eq 0 ]; then


### PR DESCRIPTION
## Summary

demo-replay スキーマに v2 を追加し、`conditional` のブランチ配下フェーズが正しい座標を記録できるようにする。

- **`phase_path: [Int]`**（optional）— engine 由来の系譜そのもの。`SimulationEvent.phaseStarted(phasePath:)` と同義で、`[i]` または `[i, j]`。深さは engine の depth-1 規則で2に制限される
- **`branch: then|else`**（optional）— `[i, j]` は `then[j]` と `else[j]` を判別できないため。curator のみが供給できる（`YAMLReplayExporter` 側に branch を永続化する列が無い）
- **`phase_index`** は必須のまま、定義を `phase_path[0]` に変更
- **`phase_type`** は `phase_path` の**葉**の型。ブランチ配下では `phases[phase_index].type`（囲っている conditional）と一致しない — この非対称こそが `phase_path` の存在理由
- **loader を `{1, 2}` 受理へ** — spec §3.5 の規定に従った。出荷済み8件の demo は v1 のまま読め、再録も不要

## Issue 本文の前提が誤っていた点

issue は「`BundledDemoReplaySource` が `phases[phase_index].type == phase_type` を検証する」としているが、その loader は整合性（SHA + `schema_version`）のみで、`check_demo_replay_drift.py` にも `phase_index` の参照は無い。**実際の検証は Swift テスト**（`BundledDemoReplaySourceTests`）で、既に branch 許容の conditional アームまで持っていた。その `:404-409` のコメントが「branch 属性が load-bearing になったら `branch_index` 相互チェックが必要」と、まさにこの事象のために書かれていたので、その方向で解消した。

spec §3.3 にこの不変条件の**単一オーナー**を明記し、drift guard が意図的にミラーしないこと（Python 側で preset のブランチ走査を再実装すると、調停方向のないミラー対になる）も記録した。

## 到達可能だったバグ

`ConditionalHandler.execute` は `evaluation.warnings` を `.conditionalEvaluated` より**前**に `.summary` として出す。その時点の座標は `phase_path: [i]` / `phase_type: conditional` で、spec の定義では正しい。ゲートはこれを拒否していたので、条件式が実行時に存在しない変数を参照する conditional 入り demo を初めて出荷しようとした時点で CI が止まる状態だった。

## 新 writer × 旧 reader（spec §3.5 に姿勢を明記）

exporter は無条件に v2 を出すので、v6 以前の行だけの export は中身が v1 と同一なのにバージョン行だけ 2 になり、既出荷ビルド（厳密等値比較）では読めない。demo はバイナリ同梱で、exporter 出力に replay-import 経路が存在しないため受容した。importer が入るならデータ依存のバージョン出力に変える、と spec に残してある。

## Test plan

- ユニット **3546件パス**（`scripts/xcodebuild.sh test -skip-testing:PasturaUITests`）、SwiftLint `--strict` クリーン
- `scripts/tests/jsonl-to-demo-replay-test.sh` **13腕**（元3 → branch 解決の (d)–(m) を追加）
- `check_demo_replay_drift.py` / `check_demo_replay_event_coverage.py` / `demo-replay-event-coverage-test.sh` / #1509 census ゲート
- `swift build`（ADR-013 harness）

**追加・変更したガードは全て変異対照で発火を確認した** — curator 側8変異、alignment ゲート側7変異、reader は旧実装への差し戻し、exporter 2変異。緑のテストは fixture の所見にすぎないので、「そのガードを壊すと対応する腕が実際に赤くなるか」を毎回測っている。

## レビュー

`claude-kit:critic` 2周（Critical 各1件）→ 実装 → `code-reviewer` を read側 / write側 / シーム横断の3シャード → `/code-review high` → ゲート再設計に対して `code-reviewer` 3周。

`/code-review high` は **`code-reviewer` 4周 PASS の後に実欠陥3件**を出した。3件とも「同じ PR が書いた spec と、同じ PR が書いたゲートの不一致」で、規約ゲートは審査対象が自分自身の規範だと上位の規範が無く原理的に見られない類。

## Device QA

実機QA不要 — Swift 側の変更は `App/` のリプレイ座標解決とテストのみで、`#if !targetEnvironment(simulator)` ブロック・Metal / llama.cpp 経路・描画レイアウトのいずれにも触れない。

## 残す note（レビューでの合意事項）

このブランチでは**5コミット連続で、修正が自分の直している欠陥クラスを再生産した**。内訳は、未対照の腕を潰す修正が未対照の腕を4本足した / 行数スナップショットを禁じた2行下で行数スナップショットを書いた（3周連続で誤り）/ 「実測した」と書いた腕が測定対象の境界を跨いでいなかった / 「片方の腕にしか検査が無い」の修正が新しい exit を腕の上に置いて同じ穴を作った / 計測の食い違いを直す修正が未実行の計測主張を持ち込んだ（`swiftlint --path` は存在しないオプションで、usage エラーの終了を「違反なし」と読んでいた）。

最終レビューの所見どおり、原因は不注意より構造的で、**散文の編集にはゲートが一つも無い**（コンパイラも lint もテストも、コメントが誤りになったときに赤くならない）。コードの側は正しいと独立に検証済み。

## `.claude/rules/build-traps.md` への追記

本ブランチで実測した SwiftLint の罠2件を、既存の「directive の配置」節の隣に記録した。

- **散文が directive として解釈される** — 罠を説明するために directive の文字列を引用すると、それが適用される。診断はこちらが説明していたルール名を名指すので、文章でなくコードの問題に見える
- **`swiftlint --path <file>` は存在しないオプション** — usage エラーで終了するため、出力をルール名で grep するプローブは「発火しなかった」と読む。同一セッションで独立に2つの計測を誤らせた

## Follow-up 候補（本 PR の範囲外）

**curator が JSONL の `attempt` を無視する** — `HarnessRunner` はリトライを同じストリームに書くため、試行1の部分転写と試行2が連結して重複ラウンドを生む。ブランチ状態は試行境界で自己回復する（試行2の最初の `phase_started` が top-level でクリアされる）ので誤った branch は記録されないが、`branch` フィールドが入ったことで重複転写が試行ごとの判定を持つようになる。既存の欠陥で本 issue の範囲外。

Closes #1505

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEscKvHM3AZ9RfQ9MFFEBb
