### PR TITLE
✨ feat: mechanize build-traps.md — SwiftLint doc-comment rule + duplicate-basename gate

### DIFF
--- a/.claude/rules/build-traps.md
+++ b/.claude/rules/build-traps.md
@@ -1,6 +1,7 @@
 ---
 paths:
   - "Pastura/Pastura/**/*.swift"
+  - "Pastura/Pastura/PasturaApp.swift"
   - "Pastura/PasturaTests/**"
   - "Pastura/PasturaUITests/**"
   - "tools/harness/**"
@@ -12,16 +13,16 @@ paths:
 Traps that fire when **adding or naming a Swift file**, or when writing about
 SwiftLint in a Swift comment — hence the globs above, the union of their reach.
 
-Each gate below names the offending line and why it fails. What no gate can do is
-pick your new filename, remove the *need* for a directive, or read a sentence. That
-residue is all the sections carry.
+Each gate below names what failed and why. What no gate can do is pick your new
+filename, remove the *need* for a directive, or read a sentence. That residue is
+all the sections carry.
 
 | Trap | Gate |
 |---|---|
 | Duplicate base filename within one target | `scripts/duplicate-basename-gate.sh` — pre-commit sub-gate 17, CI shell-tests |
 | Directive inside a `///` doc comment — a silent no-op | `.swiftlint.yml` custom rule `swiftlint_directive_in_doc_comment` |
 | Directive between the doc comment and the declaration | stock `orphaned_doc_comment` |
-| Prose about a directive parsed as one | **none, and it is not reliably loud** |
+| Prose about a directive parsed as one | **none** — silent in some shapes, and not separable from legitimate prose by regex |
 | `swiftlint --path <file>` reads as "clean" | none, deliberately |
 
 ## Duplicate base filename → `.stringsdata` collision
@@ -36,9 +37,8 @@ collided with the Data-layer `ScenarioSummary` → `ScenarioSummaryStrip`.
 
 ## SwiftLint directive placement around a `///` doc comment
 
-Both placements fail: inside the `///` block the directive is a silent no-op,
-between the block and the declaration it detaches the doc comment. So don't
-relocate the directive — remove the need for it:
+Both placements fail (see the roster), so don't relocate the directive — remove
+the need for it:
 
 - `function_body_length` → **extract a helper** so each body stays under the
   threshold. Ref: `BundledDemoReplaySource.loadOne` → `buildSourceOrSkip`.
@@ -53,17 +53,15 @@ directive, don't spell it.
 ## Prose ABOUT a directive is parsed AS one
 
 The comment-command parser scans every `//` comment **and honours a directive
-mid-sentence**, so one sentence quoting a directive's literal text applies it.
+mid-sentence**, so one sentence quoting a directive's literal text applies it —
+the rule really is disabled.
 
-Ungated, and **not reliably loud** — what decides that is the token after the rule
-name (measured on 0.65.0 against a bare-violation control):
-
-- a non-rule word follows → `superfluous_disable_command` names that word, which
-  reads as a problem with the code rather than the sentence (adjacent backticks
-  get swept into the rule name and land here);
-- **the sentence ends at the rule name → the rule is silently disabled on the next
-  line, no diagnostic at all.** The prose changes behaviour, it does not just
-  make noise.
+**Do not count on a diagnostic.** Two unrelated rules happen to catch some
+shapes and neither is about prose (measured on 0.65.0, each variant against a
+bare-violation control): a non-rule word after the rule name draws
+`superfluous_disable_command`; a blanket `disable` never re-enabled draws
+`blanket_disable_command`. Miss both — a `:next` form, or a blanket pair that
+*is* re-enabled — and the suppression is silent.
 
 **Apply**: in a **Swift** comment, name a directive rather than spelling it — "a
 blanket `file_length` disable directive on line 6", not the text itself. The
@@ -76,8 +74,8 @@ quote a directive in a `.swift` file.
 `swiftlint lint --path X` exits with `Error: Unknown option '--path'` (the
 positional form `swiftlint lint [options] [paths...]` is the real one). A probe
 that greps that output for a rule name finds nothing and concludes the rule did
-not fire. Measured 2026-08-21 (0.65.0, #1505). Left ungated on purpose: a wrapper
-only protects whoever uses it.
+not fire. Measured 2026-08-21 (0.65.0, #1505); a wrapper would only protect
+whoever used it, hence the roster's "deliberately".
 
 **Apply**: to test whether a rule fires, put the fixture **inside**
 `.swiftlint.yml`'s `included:` tree and run the form the gates run

--- a/.claude/rules/build-traps.md
+++ b/.claude/rules/build-traps.md
@@ -4,46 +4,41 @@ paths:
   - "Pastura/PasturaTests/**"
   - "Pastura/PasturaUITests/**"
   - "tools/harness/**"
+  - "tools/kmp-gate-spike/**"
 ---
 
 # Build & Lint Traps
 
-Traps that fire when **adding or naming a Swift file**, in any layer and any target — hence the
-globs above, which are the union of the two traps' reach.
+Traps that fire when **adding or naming a Swift file**, or when writing about
+SwiftLint in a Swift comment — hence the globs above, the union of their reach.
 
-Duplicate base filenames fail the build in **every** Swift target: `swiftc` rejects them outright
-(`filename "Foo.swift" used twice`) and SwiftPM errors on duplicate `.o` producers. The
-`.stringsdata` wording below is just the app-target surface, where `SWIFT_EMIT_LOC_STRINGS = YES`.
-The SwiftLint trap fires wherever `.swiftlint.yml` `included:` reaches.
+Each gate below names the offending line and why it fails. What no gate can do is
+pick your new filename, remove the *need* for a directive, or read a sentence. That
+residue is all the sections carry.
+
+| Trap | Gate |
+|---|---|
+| Duplicate base filename within one target | `scripts/duplicate-basename-gate.sh` — pre-commit sub-gate 17, CI shell-tests |
+| Directive inside a `///` doc comment — a silent no-op | `.swiftlint.yml` custom rule `swiftlint_directive_in_doc_comment` |
+| Directive between the doc comment and the declaration | stock `orphaned_doc_comment` |
+| Prose about a directive parsed as one | **none, and it is not reliably loud** |
+| `swiftlint --path <file>` reads as "clean" | none, deliberately |
 
 ## Duplicate base filename → `.stringsdata` collision
 
-Two Swift files with the same **base name** in one target fail the build with
-`error: Multiple commands produce '…/<Name>.stringsdata'` (each Swift file emits
-one `<BaseName>.stringsdata`). Easy to hit under Pastura's
-`PBXFileSystemSynchronizedRootGroup` — sync folder groups auto-include every new
-file under `Pastura/`, so a duplicate base name **anywhere** in the tree (even
-cross-layer) collides.
+Pastura's `PBXFileSystemSynchronizedRootGroup` auto-includes every new file under
+`Pastura/`, so the name you pick can collide **cross-layer**, with a file three
+directories away that you never opened.
 
-**Apply**: before adding a file, `find Pastura/Pastura -name '<Name>*.swift'`;
-if taken, pick a distinct name (rename the type too if it also clashes). Case
-study: #759 renamed a new `ScenarioSummary.swift` (Views) that collided with the
-Data-layer `ScenarioSummary` → `ScenarioSummaryStrip`.
+**Apply**: rename to something distinct — and rename the type too if it also
+clashes. Case study: #759 renamed a new `ScenarioSummary.swift` (Views) that
+collided with the Data-layer `ScenarioSummary` → `ScenarioSummaryStrip`.
 
 ## SwiftLint directive placement around a `///` doc comment
 
-A `swiftlint:disable[:next] X` directive can't cleanly suppress a rule on a
-declaration that also carries a `///` doc comment — **both** placements fail:
-
-- **Between the doc comment and the declaration** (a `// swiftlint:disable:next X`
-  line separating `/// …` from the `func`): detaches the doc comment, firing
-  `orphaned_doc_comment`.
-- **Inside the `///` block** (`/// swiftlint:disable:next X`): a **no-op** under
-  `swiftlint --strict` — the comment-command parser recognizes `//`-form only, so
-  the warning upgrades to an error unsuppressed. It looks load-bearing but is
-  untested until the body later crosses the threshold.
-
-**Apply** — don't relocate the directive; remove the need for it:
+Both placements fail: inside the `///` block the directive is a silent no-op,
+between the block and the declaration it detaches the doc comment. So don't
+relocate the directive — remove the need for it:
 
 - `function_body_length` → **extract a helper** so each body stays under the
   threshold. Ref: `BundledDemoReplaySource.loadOne` → `buildSourceOrSkip`.
@@ -51,32 +46,42 @@ declaration that also carries a `///` doc comment — **both** placements fail:
   **`.swiftlint.yml` `identifier_name.excluded`** entry (ref: the `ja` / `en`
   exclusions consumed by `pickLanguage(_:ja:en:)`), or rename to 3+ chars.
 
+Suppressing the doc-comment rule is not an option either: a `disable`/`enable`
+pair inside a block splits it into an `orphaned_doc_comment`. Reword — name the
+directive, don't spell it.
+
 ## Prose ABOUT a directive is parsed AS one
 
-The comment-command parser scans every `//` comment, so quoting a directive's
-literal text while explaining it applies it. Writing `// swiftlint:disable X`
-inside a paragraph about that trap is enough. Loud rather than silent — the
-quote lands as a real command and draws `blanket_disable_command`, plus
-`superfluous_disable_command` if adjacent backticks get swept into the rule
-name — but the diagnostics name the rule you were describing, so they read as a
-problem with the code rather than with the sentence.
+The comment-command parser scans every `//` comment **and honours a directive
+mid-sentence**, so one sentence quoting a directive's literal text applies it.
 
-**Apply**: in a **Swift** comment, name a directive rather than spelling it —
-"a blanket `file_length` disable directive on line 6", not the text itself. The
-example above is spelled out because this file is Markdown, which SwiftLint does
-not scan; that asymmetry is the whole trap, so do not read the example as
-licence to quote it in a `.swift` file.
+Ungated, and **not reliably loud** — what decides that is the token after the rule
+name (measured on 0.65.0 against a bare-violation control):
+
+- a non-rule word follows → `superfluous_disable_command` names that word, which
+  reads as a problem with the code rather than the sentence (adjacent backticks
+  get swept into the rule name and land here);
+- **the sentence ends at the rule name → the rule is silently disabled on the next
+  line, no diagnostic at all.** The prose changes behaviour, it does not just
+  make noise.
+
+**Apply**: in a **Swift** comment, name a directive rather than spelling it — "a
+blanket `file_length` disable directive on line 6", not the text itself. The
+examples here are spelled out because this file is Markdown, which SwiftLint does
+not scan; that asymmetry is the whole trap, so do not read them as licence to
+quote a directive in a `.swift` file.
 
 ## `swiftlint --path <file>` is not an option, and its error reads as "clean"
 
 `swiftlint lint --path X` exits with `Error: Unknown option '--path'` (the
 positional form `swiftlint lint [options] [paths...]` is the real one). A probe
 that greps that output for a rule name finds nothing and concludes the rule did
-not fire. Measured 2026-08-21 (0.65.0, #1505).
+not fire. Measured 2026-08-21 (0.65.0, #1505). Left ungated on purpose: a wrapper
+only protects whoever uses it.
 
 **Apply**: to test whether a rule fires, put the fixture **inside**
 `.swiftlint.yml`'s `included:` tree and run the form the gates run
-(`scripts/git-hooks/pre-commit`, `ci.yml`): `swiftlint lint --strict`. Two
-things genuinely suppress a rule and are easy to mistake for "not enabled" — a
-fixture outside `included:` (path-independent rules still fire there, so the run
-looks live), and a file-level disable directive already in the target file.
+(`scripts/git-hooks/pre-commit`, `ci.yml`): `swiftlint lint --strict`. Two things
+genuinely suppress a rule and are easy to mistake for "not enabled" — a fixture
+outside `included:` (path-independent rules still fire there, so the run looks
+live), and a file-level disable directive already in the target file.

--- a/.claude/rules/context-budget.md
+++ b/.claude/rules/context-budget.md
@@ -22,7 +22,7 @@ Always-loaded files (loaded into every agent session / invocation) — every lin
 The global tier is easy to forget because it is not in this repo — and a global file duplicating a
 project file of the same name is paid **twice**.
 
-Path-scoped files (`paths:` frontmatter) load only when a matching path is read — budget looser there.
+Path-scoped files (`paths:` frontmatter) load on a matching read — **budget them the same**. A glob over the layers you work in is paid most sessions, and widening one is growth.
 
 ## Principle
 

--- a/.claude/rules/knowledge-layering.md
+++ b/.claude/rules/knowledge-layering.md
@@ -43,7 +43,7 @@ Trigger a triage pass on memory **count** or **total content size** (`cat memory
 
 ## Procedure
 
-**Any** rules addition — promoted from memory or not — is drafted at **concept level**: WHY + the invariant + a durable pointer, not the exhaustive HOW (grep blocks, enumerations, step lists). This holds for **path-scoped** targets too, where `context-budget.md`'s always-loaded discipline stops and its "budget looser there" does *not* license a dump; expand a section only when a reviewer shows the omitted detail is load-bearing for the rule to fire.
+**Any** rules addition — promoted from memory or not — is drafted at **concept level**: WHY + the invariant + a durable pointer, not the exhaustive HOW (grep blocks, enumerations, step lists). This holds for **path-scoped** targets too — `context-budget.md` budgets them the same; expand a section only when a reviewer shows the omitted detail is load-bearing for the rule to fire.
 
 Promotion specifically is PROMOTE-only — retirement is memory-direct and needs no PR. Two steps nothing else enforces, so they belong on the rolling issue's checklist: **update every mirror** of the promoted fact in the same PR (the `code-reviewer` trap cheat sheet, a `CLAUDE.md` parenthetical — mirrors drift silently otherwise), and **delete the source memory only after the rule lands**, since a repo PR cannot enforce a per-machine `command rm`. **Read [`docs/agent-tooling/claim-verification.md`](../../docs/agent-tooling/claim-verification.md) § "Promotion mechanics" before starting one** — it has the full sequence, including the provenance-line strip.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1105,6 +1105,22 @@ jobs:
           python3 scripts/check-measurement-transcripts.py --check
           python3 scripts/check-measurement-transcripts.py --census
 
+      # Duplicate Swift base filename check (#1513) — two Swift files sharing a
+      # base name in one target fail the build outright, but the pre-commit
+      # `xcodebuild build` compiles the app scheme only, so a collision in
+      # PasturaTests / PasturaUITests / tools/harness / tools/kmp-gate-spike is
+      # first seen here. Self-test first (detector arms plus the two scan
+      # controls — an empty target root and a partial root list, both of which
+      # would otherwise read as "0 duplicates"), then the real tree.
+      # Unconditional for the same reason as the steps above
+      # (`.claude/rules/ci-workflows.md` § "Required-check-safe path gating").
+      # Defense-in-depth for scripts/duplicate-basename-gate.sh, which the git
+      # pre-commit hook runs self-gated on staged .swift only.
+      - name: Duplicate Swift base filename check
+        run: |
+          bash scripts/duplicate-basename-gate.sh --self-test
+          bash scripts/duplicate-basename-gate.sh --check
+
   gallery-drift:
     name: Gallery drift guard
     runs-on: ubuntu-latest

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -209,3 +209,51 @@ custom_rules:
       - 'Pastura/Pastura/.*\.swift'
     severity: error
     message: "`.borderedProminent` fills from the moss tint with a white system label — ≈3.03:1 light, ≈2.13:1 dark. Use PasturaPrimaryButtonStyle. A destructive-role button is the one exemption — see the rationale at PasturaApp.swift's .databaseRecovery case."
+
+  # Directive inside a `///` doc comment (#1513) — the one SILENT failure among
+  # `.claude/rules/build-traps.md`'s four traps, which is why it gets a rule and
+  # the other three do not. Measured on 0.65.0 against a bare-violation positive
+  # control: the comment-command parser honours a directive ANYWHERE in a `//`
+  # comment, mid-sentence included (that is what makes build-traps.md § "Prose
+  # ABOUT a directive is parsed AS one" true), and sees nothing at all in a `///`
+  # one — no suppression, no `superfluous_disable_command`, no diagnostic. So a
+  # `///` directive looks load-bearing and does nothing until the body it guards
+  # later crosses the threshold.
+  #
+  # DELIBERATELY BROAD — any directive literal on a `///` line, not just a leading
+  # one. `/// - Note: swiftlint:disable:next X` is the same silent no-op (its `//`
+  # form does suppress), so a leading-only regex would miss it. Telling a
+  # would-be-effective mention from a would-be-inert one needs a valid-rule-name
+  # test, which can only enumerate the shapes already seen — the argument
+  # `shadow_color_occluder_family` above makes for preferring an allowlist.
+  #
+  # THE REMEDY IS TO REWORD, NOT SUPPRESS: name the directive instead of spelling
+  # it ("a `file_length` disable directive"). A disable/enable pair around an
+  # offending line inside a doc block splits the block and draws
+  # `orphaned_doc_comment` — the sibling placement failure build-traps.md
+  # documents. Three sites were reworded when this rule landed.
+  #
+  # `[^\n]*`, never `.*`: SwiftLint compiles custom-rule regexes with
+  # `dotMatchesLineSeparators`, so `.*` reaches a directive lines below an
+  # unrelated `///` (measured — fired on line 1 for a directive on line 4). The
+  # same token means the OPPOSITE to `git grep -E`, which reads `[^\n]` as "not
+  # backslash, not the letter n" and silently under-counts; enumerate this rule's
+  # hits with `git grep -P`.
+  #
+  # `excluded_match_kinds`, not `match_kinds`, for the reason spelled out above
+  # `shadow_color_occluder_family`: an allowlist drops a match spanning an
+  # unlisted kind silently. Excluding `string` keeps the rule off a `///`-shaped
+  # line inside a multi-line string literal; `doccomment` must stay OUT, since a
+  # doc comment is the target.
+  #
+  # No `included:`, unlike the five rules above — the trap fires wherever
+  # SwiftLint looks (app, unit tests, UI tests, tools/harness). This file may hold
+  # the directive's literal text because SwiftLint parses `.swift` sources only;
+  # `included:` has nothing to do with that.
+  swiftlint_directive_in_doc_comment:
+    name: "SwiftLint directive inside a doc comment"
+    regex: '^[ \t]*///[^\n]*swiftlint:(disable|enable)'
+    excluded_match_kinds:
+      - string
+    severity: error
+    message: "A swiftlint disable/enable directive in a `///` doc comment is a silent no-op — the comment-command parser reads `//` comments only. Reword to NAME the directive rather than spell it (\"a `file_length` disable directive\"); do not try to suppress this rule from inside the doc block, which draws orphaned_doc_comment. To remove the need for a directive at all, see .claude/rules/build-traps.md § 'SwiftLint directive placement around a `///` doc comment'."

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -210,15 +210,16 @@ custom_rules:
     severity: error
     message: "`.borderedProminent` fills from the moss tint with a white system label — ≈3.03:1 light, ≈2.13:1 dark. Use PasturaPrimaryButtonStyle. A destructive-role button is the one exemption — see the rationale at PasturaApp.swift's .databaseRecovery case."
 
-  # Directive inside a `///` doc comment (#1513) — the one SILENT failure among
-  # `.claude/rules/build-traps.md`'s four traps, which is why it gets a rule and
-  # the other three do not. Measured on 0.65.0 against a bare-violation positive
-  # control: the comment-command parser honours a directive ANYWHERE in a `//`
-  # comment, mid-sentence included (that is what makes build-traps.md § "Prose
-  # ABOUT a directive is parsed AS one" true), and sees nothing at all in a `///`
-  # one — no suppression, no `superfluous_disable_command`, no diagnostic. So a
-  # `///` directive looks load-bearing and does nothing until the body it guards
-  # later crosses the threshold.
+  # Directive inside a `///` doc comment (#1513) — a SILENT failure, and the one
+  # in `.claude/rules/build-traps.md` a regex can separate from legitimate prose.
+  # It is not the only silent one there: § "Prose ABOUT a directive is parsed AS
+  # one" has silent shapes too and stays ungated precisely because telling an
+  # effective mention from an inert one would need a valid-rule-name test.
+  # Measured on 0.65.0 against a bare-violation positive control: the
+  # comment-command parser honours a directive ANYWHERE in a `//` comment,
+  # mid-sentence included, and sees nothing at all in a `///` one — no
+  # suppression, no diagnostic. So a `///` directive looks load-bearing and does
+  # nothing until the body it guards later crosses the threshold.
   #
   # DELIBERATELY BROAD — any directive literal on a `///` line, not just a leading
   # one. `/// - Note: swiftlint:disable:next X` is the same silent no-op (its `//`
@@ -226,6 +227,28 @@ custom_rules:
   # would-be-effective mention from a would-be-inert one needs a valid-rule-name
   # test, which can only enumerate the shapes already seen — the argument
   # `shadow_color_occluder_family` above makes for preferring an allowlist.
+  # `///` only, though: a `/** … */` block doc comment is the same silent no-op
+  # and is NOT matched. The tree holds zero Swift block doc comments today
+  # (`git grep -nE '^[[:space:]]*/\*\*' -- '*.swift'`), so the missed set is
+  # empty; widen the regex if that stops being true.
+  #
+  # NO LIVE INSTANCE, AND NO AUTOMATED ARM. The three sites this was written for
+  # were reworded when it landed, so nothing in the tree matches it. Simplify
+  # `[^\n]*` to `.*`, add `doccomment` to the exclusions, or take an upgrade that
+  # renames the syntax kind, and the rule goes quietly dead with every gate still
+  # green. The shell-tests runner is ubuntu with no SwiftLint, so there is
+  # nowhere cheap to host a real arm — re-run this pair by hand instead, from the
+  # repo root (positional path; `--path` is not an option and its error reads as
+  # "clean" — build-traps.md § "`swiftlint --path <file>`"):
+  #
+  #   d=$(mktemp -d)
+  #   printf 'import Foundation\n/// swiftlint:disable:next line_length\nfunc f() {}\n' > "$d/F.swift"
+  #   printf 'import Foundation\n/// plain doc comment\nfunc g() {}\n'                   > "$d/G.swift"
+  #   swiftlint lint --no-cache --config .swiftlint.yml "$d/F.swift"   # must FIRE
+  #   swiftlint lint --no-cache --config .swiftlint.yml "$d/G.swift"   # must be SILENT
+  #
+  # The fixture may sit outside `included:` because this rule is path-independent
+  # — verified both arms 2026-08-21 before this block was written.
   #
   # THE REMEDY IS TO REWORD, NOT SUPPRESS: name the directive instead of spelling
   # it ("a `file_length` disable directive"). A disable/enable pair around an

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -227,8 +227,11 @@ custom_rules:
   # would-be-effective mention from a would-be-inert one needs a valid-rule-name
   # test, which can only enumerate the shapes already seen — the argument
   # `shadow_color_occluder_family` above makes for preferring an allowlist.
-  # `///` only, though: a `/** … */` block doc comment is the same silent no-op
-  # and is NOT matched. The tree holds zero Swift block doc comments today
+  # `///` only, though, and that IS a gap: a `/** … */` block doc comment is the
+  # same silent no-op — measured with identifier_name (an enabled rule; a probe
+  # keyed on line_length cannot arm, it is in disabled_rules), where the `//`
+  # control suppressed and both the `///` and `/** */` forms did not. The tree
+  # holds zero Swift block doc comments today
   # (`git grep -nE '^[[:space:]]*/\*\*' -- '*.swift'`), so the missed set is
   # empty; widen the regex if that stops being true.
   #

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,7 +266,7 @@ Update with `/plugin`. Install steps: CONTRIBUTING.md § "If you use Claude Code
 
 - `adr-writing.md` — ADR drafting concepts; the once-per-draft grep checklist lives in `docs/decisions/adr-writing-guide.md` — read it before drafting (docs/decisions/)
 - `automation-output-contract.md` — Output Contract binding every unattended generator (Draft-only / never actuate, judgment→issue with counter-evidence, backpressure). Mirrored from claude-kit, one-way. **`paths:` fires when a skill file is read, not on a generator run** — each governed skill carries an imperative read-before-Step-0 pointer instead (`.claude/skills/**`)
-- `build-traps.md` — gate roster for the filename-collision and SwiftLint-directive traps: which gate fires, and what each still leaves you to decide (every Swift target, `.swiftlint.yml`)
+- `build-traps.md` — gate roster for the filename-collision and SwiftLint-directive traps: which gate fires, and what each still leaves you to decide (every Swift target)
 - `ci-workflows.md` — CI workflow / script editing traps: bash 3.2 on macOS runners, required-check-safe path gating, long-lived integration-branch gating (.github/workflows/, scripts/)
 - `engine.md` — Engine + LLM source
 - `i18n.md` — Swift-side localization **callsite** conventions, layer-independent: Form B `String(format: String(localized:))`, the Form A runtime-fallback hazard, partial-conversion orphans, Tier 2 audit planning (any app Swift file, plus the catalog)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,7 +266,7 @@ Update with `/plugin`. Install steps: CONTRIBUTING.md § "If you use Claude Code
 
 - `adr-writing.md` — ADR drafting concepts; the once-per-draft grep checklist lives in `docs/decisions/adr-writing-guide.md` — read it before drafting (docs/decisions/)
 - `automation-output-contract.md` — Output Contract binding every unattended generator (Draft-only / never actuate, judgment→issue with counter-evidence, backpressure). Mirrored from claude-kit, one-way. **`paths:` fires when a skill file is read, not on a generator run** — each governed skill carries an imperative read-before-Step-0 pointer instead (`.claude/skills/**`)
-- `build-traps.md` — filename `.stringsdata` collisions + SwiftLint directive placement around a `///` doc comment. Fires in every Swift target — the § header carries the reach (app, unit tests, UI tests, `tools/harness/`)
+- `build-traps.md` — gate roster for the filename-collision and SwiftLint-directive traps: which gate fires, and what each still leaves you to decide (every Swift target, `.swiftlint.yml`)
 - `ci-workflows.md` — CI workflow / script editing traps: bash 3.2 on macOS runners, required-check-safe path gating, long-lived integration-branch gating (.github/workflows/, scripts/)
 - `engine.md` — Engine + LLM source
 - `i18n.md` — Swift-side localization **callsite** conventions, layer-independent: Form B `String(format: String(localized:))`, the Form A runtime-fallback hazard, partial-conversion orphans, Tier 2 audit planning (any app Swift file, plus the catalog)

--- a/Pastura/Pastura/App/BundledDemoReplaySource.swift
+++ b/Pastura/Pastura/App/BundledDemoReplaySource.swift
@@ -101,8 +101,6 @@ nonisolated public final class BundledDemoReplaySource: ReplaySource {
 
   /// Loads a single demo YAML. Returns nil on any validation failure,
   /// logging the reason.
-  ///
-  /// swiftlint:disable:next function_body_length
   private static func loadOne(
     name: String, contents: String,
     presetResolver: any PresetResolver,

--- a/Pastura/PasturaTests/App/BundledDemoReplaySourceTests.swift
+++ b/Pastura/PasturaTests/App/BundledDemoReplaySourceTests.swift
@@ -594,7 +594,7 @@ struct BundledDemoReplaySourceTests {
   /// The `branch:`-present arm of ``conditionalDiagnostic``. Extracted so that
   /// function stays under SwiftLint's `cyclomatic_complexity` and
   /// `function_body_length` caps — per `.claude/rules/build-traps.md`, the fix
-  /// for those is a helper, not a `swiftlint:disable` directive.
+  /// for those is a helper, not a disable directive.
   ///
   /// Only the curator writes `branch:` (nothing persists it, so
   /// `YAMLReplayExporter` cannot), and it is what makes the leaf-type check

--- a/Pastura/PasturaTests/Engine/SimulationRunnerTests+LanguageMismatch.swift
+++ b/Pastura/PasturaTests/Engine/SimulationRunnerTests+LanguageMismatch.swift
@@ -11,7 +11,8 @@ import os
 /// without bypassing any layer.
 ///
 /// Sibling extension per testing.md's 400-line-cap pattern (the parent
-/// `SimulationRunnerTests` already carries `// swiftlint:disable file_length`).
+/// `SimulationRunnerTests` already carries a file-level `file_length` disable
+/// directive).
 extension SimulationRunnerTests {
   /// Stubbed detector that always returns the canned ISO code, regardless
   /// of input. Mirrors the test fixture in `LLMCallerLanguageAdherenceTests`

--- a/scripts/duplicate-basename-gate.sh
+++ b/scripts/duplicate-basename-gate.sh
@@ -22,13 +22,25 @@
 # `find | sort | uniq -d` reddens on that pair and on the two `Package.swift`
 # manifests. --self-test pins both directions against those real paths.
 #
+# ONE ROW PER TARGET, NEVER PER DIRECTORY. Subdividing a row keeps coverage
+# complete and every population floor satisfied, so nothing below notices —
+# while a pair straddling the two halves stops being compared at all.
+#
 # `.swift` ONLY: Pastura/Pastura/LLM/SafeSampler.swift coexists with
 # LLM/SafeSampler/SafeSampler.{h,mm} in the same target and builds fine.
+# Comparison is byte-exact, so a `Foo.swift` / `foo.swift` pair is out of scope
+# — it cannot exist in a macOS checkout, though it would collide if one landed
+# from a case-sensitive filesystem.
 #
-# `git ls-files`, never `find`: a worktree walk sweeps Pastura/DerivedData/'s
-# SPM checkouts, so it is green on a fresh CI checkout and red on every
-# developer machine — `.claude/rules/ci-workflows.md` § "Gate scripts:
-# `::error file=` is repo-relative, and scope must be tracked-only".
+# `git ls-files`, never `find`: the index is what is about to be committed,
+# while a worktree walk also flags an untracked scratch file that will never
+# reach a build — red on one machine, green everywhere else. Arm A8 is the
+# control, and its fixture has to sit INSIDE a target root or it controls
+# nothing (measured: an earlier version planted it under Pastura/DerivedData/
+# and stayed green under a `find` mutation). Note the DerivedData hazard in
+# `.claude/rules/ci-workflows.md` § "Gate scripts" does not reach this gate at
+# all — Pastura/DerivedData is a sibling of every target root, not a
+# descendant — so do not re-import that reason.
 #
 # Modes:
 #   (default)    self-gate — check only when the staged diff touches a .swift
@@ -50,10 +62,12 @@ cd "$ROOT"
 
 # One entry per BUILD TARGET. The app and test rows are the Xcode project's
 # synchronized root groups; the rest are the `path:` values of the SwiftPM
-# targets in Package.swift and tools/kmp-gate-spike/Package.swift. PasturaCore
-# is deliberately absent — its sources are a strict subset of Pastura/Pastura,
-# so the app row already covers it. A target added LATER is caught by
-# unlisted_swift_files, not by anyone remembering this list.
+# targets in Package.swift and tools/kmp-gate-spike/Package.swift. Two SwiftPM
+# targets are deliberately absent because the app row is a strict superset of
+# each: PasturaCore (`Pastura/Pastura`, sources Models/LLM/Engine) and
+# PasturaSafeSampler (`Pastura/Pastura/LLM/SafeSampler`, which holds no .swift
+# at all). A target added LATER is caught by unlisted_swift_files, not by
+# anyone remembering this list.
 DEFAULT_TARGET_ROOTS='Pastura/Pastura
 Pastura/PasturaTests
 Pastura/PasturaUITests
@@ -64,23 +78,32 @@ tools/kmp-gate-spike/Sources/KMPGateSpike
 tools/kmp-gate-spike/Sources/kmp-gate-bench
 tools/kmp-gate-spike/Tests/KMPGateSpikeTests'
 
-# Overridable so --self-test can perturb the SCAN, not only the detector. Not a
-# bypass: narrowing or emptying it makes unlisted_swift_files report everything
-# it stopped covering, so the two halves fail each other closed.
-TARGET_ROOTS="${PASTURA_DUP_GATE_ROOTS:-$DEFAULT_TARGET_ROOTS}"
+# TEST HOOK, not a production knob. --self-test needs to perturb the SCAN and
+# not just the detector, but an override honoured unconditionally would also
+# reach the pre-commit path, where an exported value in someone's shell profile
+# could subdivide a row (see ONE ROW PER TARGET above) and silently narrow the
+# gate. So it applies only when the self-test asks for it.
+TARGET_ROOTS="$DEFAULT_TARGET_ROOTS"
+if [ "${PASTURA_DUP_GATE_SELFTEST:-}" = "1" ] && [ -n "${PASTURA_DUP_GATE_ROOTS:-}" ]; then
+  TARGET_ROOTS="$PASTURA_DUP_GATE_ROOTS"
+fi
 
 # Tracked .swift belonging to no build target: SwiftPM reads the manifests
 # itself, and the skill fixtures are inert text a drift test diffs.
 NON_TARGET_SWIFT='^Package\.swift$|^tools/kmp-gate-spike/Package\.swift$|^\.claude/skills/scenario-factory/tests/fixtures/[^/]+\.swift$'
 
 TMP="$(mktemp -d)"
-trap 'rm -rf "$TMP"' EXIT
+# A8 plants a fixture inside the working tree, so it needs removing even if the
+# run dies between planting and asserting.
+SCOPE_PROBE=""
+cleanup() { rm -rf "$TMP"; [ -z "$SCOPE_PROBE" ] || rm -rf "$SCOPE_PROBE"; }
+trap cleanup EXIT
 
 # --- primitives -------------------------------------------------------------
 
 # Tracked .swift under one target root. `core.quotepath=false` so a non-ASCII
 # path arrives literally instead of octal-escaped and double-quoted, which
-# would defeat the `/<name>` match in check_tree below.
+# would defeat the basename match in check_tree below.
 list_target_files() {
   git -c core.quotepath=false ls-files -- "$1/*.swift"
 }
@@ -112,7 +135,7 @@ TARGETS_EOF
 # --- check ------------------------------------------------------------------
 
 check_tree() {
-  local rc=0 root files dups name unlisted
+  local rc=0 root files dups name p unlisted
   files="$TMP/files"
   while IFS= read -r root; do
     [ -n "$root" ] || continue
@@ -131,7 +154,14 @@ check_tree() {
     while IFS= read -r name; do
       [ -n "$name" ] || continue
       echo "duplicate-basename gate: '$name' appears more than once in target '$root':" >&2
-      grep -F "/$name" "$files" | sed 's/^/    /' >&2
+      # `case`, not `grep`: a leading-slash pattern would drop a repo-root file
+      # (root `Package.swift` vs `tools/…/Package.swift`), and a `-E` pattern
+      # would misread a `+` in a filename — `SimulationRunnerTests+…` is real.
+      while IFS= read -r p; do
+        case "$p" in
+          */"$name"|"$name") printf '    %s\n' "$p" >&2 ;;
+        esac
+      done < "$files"
       rc=1
     done <<DUPS_EOF
 $dups
@@ -164,9 +194,9 @@ ROOTS_EOF
 # --- self-test --------------------------------------------------------------
 
 self_test() {
-  local fail=0 out
-  bad() { printf 'FAIL: %s\n' "$*" >&2; fail=1; }
-  ok()  { printf '  ok: %s\n' "$*"; }
+  local fail=0 total=0 out
+  bad() { printf 'FAIL: %s\n' "$*" >&2; fail=1; total=$((total + 1)); }
+  ok()  { printf '  ok: %s\n' "$*"; total=$((total + 1)); }
 
   # A1 detector positive control.
   out="$(printf 'a/Foo.swift\nb/Foo.swift\n' | dup_basenames)"
@@ -192,20 +222,25 @@ self_test() {
   # A5 END-TO-END POSITIVE on real tracked paths: scanning the whole repo as one
   # pseudo-target must flag the two cross-target pairs that legitimately
   # coexist. This is the arm that reddens if the per-target split is ever
-  # "simplified" into a repo-wide scan.
-  if out="$(PASTURA_DUP_GATE_ROOTS='.' bash "$SELF" --check 2>&1)"; then
+  # "simplified" into a repo-wide scan. It also asserts BOTH members of the
+  # root-level pair are listed — a report that names a duplicate and prints one
+  # path is how a broken path matcher looks.
+  if out="$(PASTURA_DUP_GATE_SELFTEST=1 PASTURA_DUP_GATE_ROOTS='.' bash "$SELF" --check 2>&1)"; then
     bad "A5 a repo-wide scan passed — the duplicate path never fires"
   else
     case "$out" in
-      *SuspendController.swift*Package.swift*|*Package.swift*SuspendController.swift*)
-        ok "A5 repo-wide scan flags both real cross-target pairs" ;;
+      *SuspendController.swift*Package.swift*|*Package.swift*SuspendController.swift*) ;;
       *) bad "A5 fired but named neither pair: $out" ;;
+    esac
+    case "$out" in
+      *"    Package.swift"*) ok "A5 repo-wide scan flags both pairs, root-level path included" ;;
+      *) bad "A5 omitted the repo-root Package.swift from its own evidence: $out" ;;
     esac
   fi
 
   # A6 SCAN CONTROL — a root matching nothing must trip the population floor
   # rather than read as "0 duplicates".
-  if out="$(PASTURA_DUP_GATE_ROOTS='no/such/target' bash "$SELF" --check 2>&1)"; then
+  if out="$(PASTURA_DUP_GATE_SELFTEST=1 PASTURA_DUP_GATE_ROOTS='no/such/target' bash "$SELF" --check 2>&1)"; then
     bad "A6 a target root matching no file passed"
   else
     case "$out" in
@@ -217,7 +252,7 @@ self_test() {
   # A7 COVERAGE CONTROL — a healthy but PARTIAL root list must be caught by the
   # unlisted sweep. Without it, dropping a row from DEFAULT_TARGET_ROOTS would
   # silently stop scanning that target while every other arm stayed green.
-  if out="$(PASTURA_DUP_GATE_ROOTS='Pastura/PasturaUITests' bash "$SELF" --check 2>&1)"; then
+  if out="$(PASTURA_DUP_GATE_SELFTEST=1 PASTURA_DUP_GATE_ROOTS='Pastura/PasturaUITests' bash "$SELF" --check 2>&1)"; then
     bad "A7 a partial root list passed"
   else
     case "$out" in
@@ -226,11 +261,39 @@ self_test() {
     esac
   fi
 
+  # A8 SCOPE CONTROL — the scan reads the INDEX, not the worktree, so two
+  # same-named UNTRACKED files must not make the gate red on a name nothing is
+  # committing. The fixture must live inside a target root or the arm controls
+  # nothing: an earlier version planted it under Pastura/DerivedData/, which no
+  # root contains, and stayed green under the `find` mutation it claimed to
+  # catch. kmp-gate-spike is the root chosen because it is SwiftPM-only — a
+  # fixture under Pastura/Pastura/ would join the Xcode target the moment a
+  # concurrent build looked.
+  SCOPE_PROBE="tools/kmp-gate-spike/Sources/KMPGateSpike/scope-probe"
+  mkdir -p "$SCOPE_PROBE/a" "$SCOPE_PROBE/b"
+  : > "$SCOPE_PROBE/a/ScopeProbe.swift"
+  : > "$SCOPE_PROBE/b/ScopeProbe.swift"
+  if out="$(bash "$SELF" --check 2>&1)"; then
+    ok "A8 untracked files are out of scope"
+  else
+    bad "A8 the scan reached untracked files: $out"
+  fi
+  rm -rf "$SCOPE_PROBE"
+  SCOPE_PROBE=""
+
+  # A9 the override must NOT reach the production path — otherwise an exported
+  # value narrows the pre-commit gate. Same narrowing as A7, minus the marker.
+  if out="$(PASTURA_DUP_GATE_ROOTS='Pastura/PasturaUITests' bash "$SELF" --check 2>&1)"; then
+    ok "A9 override ignored without the self-test marker"
+  else
+    bad "A9 the override reached the production path: $out"
+  fi
+
   if [ "$fail" -ne 0 ]; then
     echo "duplicate-basename self-test FAILED" >&2
     return 1
   fi
-  echo "duplicate-basename self-test: 7/7 passed"
+  echo "duplicate-basename self-test: $total/$total passed"
 }
 
 # --- modes ------------------------------------------------------------------
@@ -247,6 +310,11 @@ case "${1-}" in
     MATCHED="$(printf '%s\n' "$STAGED" \
       | { grep -E '(\.swift$)|(^scripts/duplicate-basename-gate\.sh$)' || [ $? -eq 1 ]; })"
     [ -n "$MATCHED" ] || exit 0
+    # Editing the gate stages the gate: run its own arms too, or a broken arm
+    # is gated by CI alone. `case`, not another grep — Rule 3 again.
+    case "$MATCHED" in
+      *scripts/duplicate-basename-gate.sh*) self_test ;;
+    esac
     check_tree
     ;;
   *)

--- a/scripts/duplicate-basename-gate.sh
+++ b/scripts/duplicate-basename-gate.sh
@@ -80,9 +80,11 @@ tools/kmp-gate-spike/Tests/KMPGateSpikeTests'
 
 # TEST HOOK, not a production knob. --self-test needs to perturb the SCAN and
 # not just the detector, but an override honoured unconditionally would also
-# reach the pre-commit path, where an exported value in someone's shell profile
-# could subdivide a row (see ONE ROW PER TARGET above) and silently narrow the
-# gate. So it applies only when the self-test asks for it.
+# reach the pre-commit path, where one exported value in a shell profile could
+# subdivide a row (see ONE ROW PER TARGET above) and silently narrow the gate.
+# Requiring the marker makes that take TWO deliberately-named variables rather
+# than one — it raises the bar, it does not close the surface. Passing the roots
+# as an argument would; it is not worth the plumbing at one caller.
 TARGET_ROOTS="$DEFAULT_TARGET_ROOTS"
 if [ "${PASTURA_DUP_GATE_SELFTEST:-}" = "1" ] && [ -n "${PASTURA_DUP_GATE_ROOTS:-}" ]; then
   TARGET_ROOTS="$PASTURA_DUP_GATE_ROOTS"
@@ -283,11 +285,14 @@ self_test() {
 
   # A9 the override must NOT reach the production path — otherwise an exported
   # value narrows the pre-commit gate. Same narrowing as A7, minus the marker.
-  if out="$(PASTURA_DUP_GATE_ROOTS='Pastura/PasturaUITests' bash "$SELF" --check 2>&1)"; then
-    ok "A9 override ignored without the self-test marker"
-  else
-    bad "A9 the override reached the production path: $out"
-  fi
+  # Asserted on A7's marker rather than on the exit code: a genuine duplicate in
+  # the tree would also make this `--check` fail, and blaming that on a bypass
+  # regression would send the next reader hunting the wrong thing.
+  out="$(PASTURA_DUP_GATE_ROOTS='Pastura/PasturaUITests' bash "$SELF" --check 2>&1 || true)"
+  case "$out" in
+    *"belong to no scanned target"*) bad "A9 the override reached the production path: $out" ;;
+    *) ok "A9 override ignored without the self-test marker" ;;
+  esac
 
   if [ "$fail" -ne 0 ]; then
     echo "duplicate-basename self-test FAILED" >&2
@@ -311,7 +316,10 @@ case "${1-}" in
       | { grep -E '(\.swift$)|(^scripts/duplicate-basename-gate\.sh$)' || [ $? -eq 1 ]; })"
     [ -n "$MATCHED" ] || exit 0
     # Editing the gate stages the gate: run its own arms too, or a broken arm
-    # is gated by CI alone. `case`, not another grep — Rule 3 again.
+    # is gated by CI alone. `case`, not another grep — Rule 3 again. Note this
+    # puts A8's untracked fixture in the working tree for the duration of the
+    # commit, so a concurrent session running `git add -A` in that window would
+    # sweep it in — the hazard is brief and only on this one path.
     case "$MATCHED" in
       *scripts/duplicate-basename-gate.sh*) self_test ;;
     esac

--- a/scripts/duplicate-basename-gate.sh
+++ b/scripts/duplicate-basename-gate.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+#
+# scripts/duplicate-basename-gate.sh — Pre-commit + CI gate for duplicate Swift
+# base filenames within one build target (#1513). Replaces the manual
+# `find … -name '<Name>*.swift'` step `.claude/rules/build-traps.md` used to
+# prescribe.
+#
+# WHAT IT BUYS. The failure is already loud — `Multiple commands produce
+# '…/<Name>.stringsdata'` in the app target (SWIFT_EMIT_LOC_STRINGS), swiftc's
+# `filename "<Name>.swift" used twice`, duplicate `.o` producers under SwiftPM.
+# What it is not is early or complete: the pre-commit `xcodebuild build`
+# compiles the app scheme only, so a collision in PasturaTests / PasturaUITests
+# / tools/harness / tools/kmp-gate-spike first shows minutes later in CI with
+# no rename advice attached. Xcode's PBXFileSystemSynchronizedRootGroup makes
+# the app case easy to hit: a new file anywhere under Pastura/Pastura/ joins
+# the target automatically, so the clash can be cross-layer.
+#
+# PER TARGET, NOT REPO-WIDE — load-bearing, not pedantry.
+# `Pastura/Pastura/LLM/SuspendController.swift` and
+# `tools/kmp-gate-spike/Sources/KMPGateSpike/SuspendController.swift` coexist
+# today in different targets and must keep doing so; a repo-wide
+# `find | sort | uniq -d` reddens on that pair and on the two `Package.swift`
+# manifests. --self-test pins both directions against those real paths.
+#
+# `.swift` ONLY: Pastura/Pastura/LLM/SafeSampler.swift coexists with
+# LLM/SafeSampler/SafeSampler.{h,mm} in the same target and builds fine.
+#
+# `git ls-files`, never `find`: a worktree walk sweeps Pastura/DerivedData/'s
+# SPM checkouts, so it is green on a fresh CI checkout and red on every
+# developer machine — `.claude/rules/ci-workflows.md` § "Gate scripts:
+# `::error file=` is repo-relative, and scope must be tracked-only".
+#
+# Modes:
+#   (default)    self-gate — check only when the staged diff touches a .swift
+#                path or this script. Used by the git pre-commit hook.
+#   --check      unconditional. Used by the CI shell-tests job.
+#   --self-test  controls. A scanning guard answers "0 duplicates" both when
+#                the tree is clean and when its own scan is broken, so the arms
+#                cover BOTH halves — the detector, and the population fed to it.
+#
+# bash 3.2 portable — ships to dev macOS via the pre-commit hook. NO
+# mapfile/readarray, declare -A, ${var^^} or <<< here-strings. CI runs ubuntu
+# bash 5 and will NOT catch a 3.2 regression.
+
+set -euo pipefail
+
+SELF="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+# One entry per BUILD TARGET. The app and test rows are the Xcode project's
+# synchronized root groups; the rest are the `path:` values of the SwiftPM
+# targets in Package.swift and tools/kmp-gate-spike/Package.swift. PasturaCore
+# is deliberately absent — its sources are a strict subset of Pastura/Pastura,
+# so the app row already covers it. A target added LATER is caught by
+# unlisted_swift_files, not by anyone remembering this list.
+DEFAULT_TARGET_ROOTS='Pastura/Pastura
+Pastura/PasturaTests
+Pastura/PasturaUITests
+tools/harness/Sources/PasturaHarnessKit
+tools/harness/Sources/pastura-harness
+tools/harness/Tests/PasturaHarnessKitTests
+tools/kmp-gate-spike/Sources/KMPGateSpike
+tools/kmp-gate-spike/Sources/kmp-gate-bench
+tools/kmp-gate-spike/Tests/KMPGateSpikeTests'
+
+# Overridable so --self-test can perturb the SCAN, not only the detector. Not a
+# bypass: narrowing or emptying it makes unlisted_swift_files report everything
+# it stopped covering, so the two halves fail each other closed.
+TARGET_ROOTS="${PASTURA_DUP_GATE_ROOTS:-$DEFAULT_TARGET_ROOTS}"
+
+# Tracked .swift belonging to no build target: SwiftPM reads the manifests
+# itself, and the skill fixtures are inert text a drift test diffs.
+NON_TARGET_SWIFT='^Package\.swift$|^tools/kmp-gate-spike/Package\.swift$|^\.claude/skills/scenario-factory/tests/fixtures/[^/]+\.swift$'
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# --- primitives -------------------------------------------------------------
+
+# Tracked .swift under one target root. `core.quotepath=false` so a non-ASCII
+# path arrives literally instead of octal-escaped and double-quoted, which
+# would defeat the `/<name>` match in check_tree below.
+list_target_files() {
+  git -c core.quotepath=false ls-files -- "$1/*.swift"
+}
+
+# stdin: newline-separated paths. stdout: each base name occurring more than
+# once. Pure text — this is what the detector arms of --self-test exercise.
+dup_basenames() {
+  sed 's|.*/||' | sort | uniq -d
+}
+
+# Tracked .swift covered by no target root and not explicitly excluded.
+unlisted_swift_files() {
+  git -c core.quotepath=false ls-files -- '*.swift' | sort -u > "$TMP/all"
+  : > "$TMP/covered"
+  while IFS= read -r r; do
+    [ -n "$r" ] || continue
+    list_target_files "$r" >> "$TMP/covered"
+  done <<TARGETS_EOF
+$TARGET_ROOTS
+TARGETS_EOF
+  sort -u "$TMP/covered" -o "$TMP/covered"
+  # Capture, never `| grep -q`, and `|| [ $? -eq 1 ]` rather than `|| true`, so
+  # a broken pattern (exit >= 2) aborts instead of reading as "nothing left".
+  # `.claude/rules/ci-workflows.md` § "Rule 3".
+  comm -23 "$TMP/all" "$TMP/covered" \
+    | { grep -Ev "$NON_TARGET_SWIFT" || [ $? -eq 1 ]; }
+}
+
+# --- check ------------------------------------------------------------------
+
+check_tree() {
+  local rc=0 root files dups name unlisted
+  files="$TMP/files"
+  while IFS= read -r root; do
+    [ -n "$root" ] || continue
+    list_target_files "$root" > "$files"
+    # POPULATION FLOOR. A root that lists nothing is a renamed or mistyped
+    # path, and it reports "0 duplicates" exactly like a healthy one — the
+    # fail-open this gate would otherwise ship.
+    if [ ! -s "$files" ]; then
+      echo "duplicate-basename gate: target root '$root' matched no tracked .swift file." >&2
+      echo "  The scan is broken, not the tree. Fix DEFAULT_TARGET_ROOTS in $SELF." >&2
+      rc=1
+      continue
+    fi
+    dups="$(dup_basenames < "$files")"
+    [ -n "$dups" ] || continue
+    while IFS= read -r name; do
+      [ -n "$name" ] || continue
+      echo "duplicate-basename gate: '$name' appears more than once in target '$root':" >&2
+      grep -F "/$name" "$files" | sed 's/^/    /' >&2
+      rc=1
+    done <<DUPS_EOF
+$dups
+DUPS_EOF
+  done <<ROOTS_EOF
+$TARGET_ROOTS
+ROOTS_EOF
+
+  unlisted="$(unlisted_swift_files)"
+  if [ -n "$unlisted" ]; then
+    echo "duplicate-basename gate: tracked .swift files belong to no scanned target:" >&2
+    printf '%s\n' "$unlisted" | sed 's/^/    /' >&2
+    echo "  Add the new target's path to DEFAULT_TARGET_ROOTS in $SELF, or list" >&2
+    echo "  the file in NON_TARGET_SWIFT if nothing compiles it." >&2
+    rc=1
+  fi
+
+  if [ "$rc" -ne 0 ]; then
+    echo "" >&2
+    echo "  Two Swift files sharing a base name in one target fail the build:" >&2
+    echo "  \"Multiple commands produce '…/<Name>.stringsdata'\" (app target)," >&2
+    echo "  'filename \"<Name>.swift\" used twice' (swiftc), or duplicate .o" >&2
+    echo "  producers (SwiftPM). Rename one — and the type too if it clashes." >&2
+    echo "  See .claude/rules/build-traps.md." >&2
+    return 1
+  fi
+  echo "duplicate-basename gate: clean."
+}
+
+# --- self-test --------------------------------------------------------------
+
+self_test() {
+  local fail=0 out
+  bad() { printf 'FAIL: %s\n' "$*" >&2; fail=1; }
+  ok()  { printf '  ok: %s\n' "$*"; }
+
+  # A1 detector positive control.
+  out="$(printf 'a/Foo.swift\nb/Foo.swift\n' | dup_basenames)"
+  if [ "$out" = "Foo.swift" ]; then ok "A1 detector flags a same-name pair"
+  else bad "A1 expected 'Foo.swift', got '$out'"; fi
+
+  # A2 detector negative control.
+  out="$(printf 'a/Foo.swift\nb/Bar.swift\n' | dup_basenames)"
+  if [ -z "$out" ]; then ok "A2 detector silent on distinct names"
+  else bad "A2 expected empty, got '$out'"; fi
+
+  # A3 class control — the producer variants a sloppier detector would smuggle
+  # through: a substring name, and the same name at a different depth.
+  out="$(printf 'a/Foo.swift\na/b/c/FooBar.swift\nx/BarFoo.swift\n' | dup_basenames)"
+  if [ -z "$out" ]; then ok "A3 substring / depth variants are not duplicates"
+  else bad "A3 expected empty, got '$out'"; fi
+
+  # A4 a triple reports its name once, not twice.
+  out="$(printf 'a/Foo.swift\nb/Foo.swift\nc/Foo.swift\n' | dup_basenames)"
+  if [ "$out" = "Foo.swift" ]; then ok "A4 a triple reports once"
+  else bad "A4 expected one line, got '$out'"; fi
+
+  # A5 END-TO-END POSITIVE on real tracked paths: scanning the whole repo as one
+  # pseudo-target must flag the two cross-target pairs that legitimately
+  # coexist. This is the arm that reddens if the per-target split is ever
+  # "simplified" into a repo-wide scan.
+  if out="$(PASTURA_DUP_GATE_ROOTS='.' bash "$SELF" --check 2>&1)"; then
+    bad "A5 a repo-wide scan passed — the duplicate path never fires"
+  else
+    case "$out" in
+      *SuspendController.swift*Package.swift*|*Package.swift*SuspendController.swift*)
+        ok "A5 repo-wide scan flags both real cross-target pairs" ;;
+      *) bad "A5 fired but named neither pair: $out" ;;
+    esac
+  fi
+
+  # A6 SCAN CONTROL — a root matching nothing must trip the population floor
+  # rather than read as "0 duplicates".
+  if out="$(PASTURA_DUP_GATE_ROOTS='no/such/target' bash "$SELF" --check 2>&1)"; then
+    bad "A6 a target root matching no file passed"
+  else
+    case "$out" in
+      *"matched no tracked .swift file"*) ok "A6 empty target root trips the floor" ;;
+      *) bad "A6 failed for the wrong reason: $out" ;;
+    esac
+  fi
+
+  # A7 COVERAGE CONTROL — a healthy but PARTIAL root list must be caught by the
+  # unlisted sweep. Without it, dropping a row from DEFAULT_TARGET_ROOTS would
+  # silently stop scanning that target while every other arm stayed green.
+  if out="$(PASTURA_DUP_GATE_ROOTS='Pastura/PasturaUITests' bash "$SELF" --check 2>&1)"; then
+    bad "A7 a partial root list passed"
+  else
+    case "$out" in
+      *"belong to no scanned target"*) ok "A7 partial root list caught by the unlisted sweep" ;;
+      *) bad "A7 failed for the wrong reason: $out" ;;
+    esac
+  fi
+
+  if [ "$fail" -ne 0 ]; then
+    echo "duplicate-basename self-test FAILED" >&2
+    return 1
+  fi
+  echo "duplicate-basename self-test: 7/7 passed"
+}
+
+# --- modes ------------------------------------------------------------------
+
+case "${1-}" in
+  --check)
+    check_tree
+    ;;
+  --self-test)
+    self_test
+    ;;
+  "")
+    STAGED="$(git -c core.quotepath=false diff --cached --name-only)"
+    MATCHED="$(printf '%s\n' "$STAGED" \
+      | { grep -E '(\.swift$)|(^scripts/duplicate-basename-gate\.sh$)' || [ $? -eq 1 ]; })"
+    [ -n "$MATCHED" ] || exit 0
+    check_tree
+    ;;
+  *)
+    echo "usage: $0 [--check|--self-test]" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -133,3 +133,12 @@ bash ./scripts/mossink-wash-membership-precommit-gate.sh
 # transcribe against the pins the fixture computes them from. Mirrors the CI
 # shell-tests "Measurement transcript check" step locally.
 bash ./scripts/measurement-transcript-precommit-gate.sh
+
+# 17. Duplicate Swift base filename gate (#1513) — self-gates on any staged
+# .swift or the checker; fails-fast inside. Formerly a manual `find` step in
+# .claude/rules/build-traps.md. The collision is already a hard build error,
+# but step 2 above compiles the app scheme only, so one in PasturaTests /
+# PasturaUITests / tools/harness / tools/kmp-gate-spike would surface in CI
+# minutes later with no rename advice. Mirrors the CI shell-tests
+# "Duplicate Swift base filename check" step locally.
+bash ./scripts/duplicate-basename-gate.sh


### PR DESCRIPTION
## Summary

Moves two `.claude/rules/build-traps.md` traps from prose you have to read into mechanisms that fire whether you read them or not — and shrinks the prose by more than it adds, which is the point of gating a trap.

- **`swiftlint_directive_in_doc_comment`** (`.swiftlint.yml`). A `swiftlint:disable[:next] X` inside a `///` doc comment is a **silent** no-op: measured on 0.65.0 against a bare-violation control, the comment-command parser honours a directive anywhere in a `//` comment, mid-sentence included, and sees nothing at all in a `///` one — no suppression, no diagnostic. It looks load-bearing and does nothing until the body it guards later crosses the threshold. Three live sites swept.
- **`scripts/duplicate-basename-gate.sh`** — pre-commit sub-gate 17 + an unconditional CI `shell-tests` step. Two Swift files sharing a base name in one target already fail the build, so this buys **earliness and coverage**, not a silence fix: the pre-commit `xcodebuild build` compiles the app scheme only, so a collision in `PasturaTests`, `PasturaUITests`, `tools/harness/` or `tools/kmp-gate-spike/` first appeared minutes later in CI with no rename advice attached.
- **`build-traps.md` becomes a gate roster** — the table is the single source for "which gate / gated at all"; the sections keep only what no gate can supply (which filename to pick, how to remove the need for a directive, how to read a sentence). The remedy prose stays: seven in-tree sites cite the file, about four of them for the "extract a helper, don't disable" norm specifically, and a lint rule constrains shape, not remedy.
- **`context-budget.md` stops saying path-scoped budget is "looser"** — that clause is what licensed this branch's own first draft growing `build-traps.md` by 1,586 bytes and widening its globs without either registering as growth.

Reading cost, versus `main`:

| tier | delta |
|---|---|
| always-loaded (`CLAUDE.md`, `context-budget.md`, `knowledge-layering.md`) | **−49 B** |
| path-scoped (`build-traps.md`) | **−39 B** |
| gate script (never read — it runs) | +14.5 KB |

## What the gate does and does not decide

**Per target, not repo-wide**, and that is load-bearing: `SuspendController.swift` and `Package.swift` each legitimately exist twice across targets today, so a repo-wide `find | sort | uniq -d` reddens on both. Arm A5 pins that against those real paths.

Nine target roots, not six — `tools/kmp-gate-spike/` contributes three SwiftPM targets the first enumeration missed. `PasturaCore` and `PasturaSafeSampler` are omitted deliberately (the app row is a strict superset of each).

A scanning guard answers "0 duplicates" both when the tree is clean and when its own scan is broken, so both fail-open holes are closed **and controlled**: a per-root population floor (A6), an unlisted-file sweep over every tracked `.swift` (A7), and a tracked-vs-untracked scope control (A8). Every arm is pinned by a mutation — break the guard, and the named arm reddens. Verified for all six mutations; **A8 initially did not move at all** and its fixture had to be relocated inside a target root, which is recorded in the script header so the next editor does not repeat it.

`paths:` gains `tools/kmp-gate-spike/**` (three SwiftPM targets the gate now covers) and `Pastura/Pastura/PasturaApp.swift`. Verified by effect with fresh single-`Read` subagents: the rule injects on `PasturaApp.swift`, and does not on `web/astro.config.mjs` — a live negative control, since an earlier probe that batched three reads into one turn aggregated the reminders and "confirmed" injection everywhere. What is **not** measured is the counterfactual: whether `Pastura/Pastura/**/*.swift` alone would already have matched. `swiftui-traps.md` records that it does not, but qualifies that as a **git pathspec** measurement, and `paths:` is resolved by a different matcher — so the explicit entry is belt-and-braces, not a demonstrated gap.

## Two findings recorded here rather than in a rule

Both came out of building the gate, both are measured, and neither is in scope for a `.claude/rules/` addition:

1. **A new pre-commit sub-gate may not run on its own branch.** Which hook a worktree commit runs turns on the *form* of `core.hooksPath`: the relative value `scripts/setup.sh` writes resolves per worktree, while an absolute one — which a hand-edit or an older setup leaves behind, and which this machine currently carries — sends every worktree to the primary checkout's hooks. Sub-gate 17 was therefore never exercised by this branch's own commits; it was exercised by hand instead (a planted `Pastura/Pastura/Engine/SafeSampler.swift`, correctly reported and removed).
2. **`git grep -E` reads `[^\n]` as "not backslash, not `n`"** — the opposite of BSD `grep -E` and of SwiftLint's own engine, all three measured against one discriminating line. It reported this PR's sweep as 1 site when there were 3. Use `git grep -P`.

## Kit reconciliation — needs a follow-up

`context-budget.md` and `knowledge-layering.md` are claude-kit-derived and their headers declare the generic core canonical in the kit, reconciled one-way. This PR edits that core, and `claude-kit/rules/context-budget.md:22` still reads "the budget is looser there", so **a future reconcile silently reverts the change**. A matching kit commit is queued.

## Test plan

- `bash scripts/duplicate-basename-gate.sh --self-test` → 9/9, on bash 5 and on macOS bash 3.2.
- Mutation harness over six single-guard breakages → each reddens its own arm (A1, A5, A6, A7, A8, A9).
- Habitat positive control: a real duplicate staged under `Pastura/Pastura/Engine/` is reported with both paths and the rename advice, exit 1; removed afterwards.
- `swiftlint lint --strict --config .swiftlint.yml` clean; the custom rule fired on exactly 3 sites before the sweep and 0 after (`git grep -P`).
- `.swiftlint.yml`'s pasted probe pair run before being pasted: positive fires, negative silent. The `/** … */` blind spot re-measured with `identifier_name` (an enabled rule — a probe keyed on `line_length` cannot arm here, it is in `disabled_rules`): `//` suppresses, `///` and `/** */` both do not.
- Rule-injection probe, two fresh subagents, one `Read` each: `PasturaApp.swift` → injected; `web/astro.config.mjs` → not injected, no rules at all.
- `for t in scripts/tests/*-test.sh` → 23/23 PASS, `staged-trigger-pipefail-test.sh` included.
- `scripts/xcodebuild.sh test` → xcresult summary `Passed`, 3557 tests, 0 failed, 21 skipped, 1 expected failure.
- `/consistency-audit` adds no finding versus `main`.

## Device QA

実機QA不要 — no `#if !targetEnvironment(simulator)` block, no Metal / llama.cpp path, no UI surface. The three Swift edits are a comment-only deletion and two doc-comment rewordings.

Closes #1513
