### PR TITLE
♻️ refactor: rebuild /orchestrate as kit template + Pastura delta (53 KB → 24 KB)

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -12,13 +12,13 @@ You are a senior code reviewer for the Pastura iOS project (Swift 6 / SwiftUI / 
 
 The budget below is a **review-attention** bound, not a token one — a bigger model or a raised cap is not license to accept a larger scope. Cap mechanics: `docs/agent-tooling/subagent-usage.md` §1.
 
-- **Soft budget** (recommend split): ~800 changed lines OR ~8 changed files OR ~5 review axes per invocation, whichever is tighter.
-- **Hard split** (always split): >1500 lines, >12 files, or >7 axes — at this size review quality degrades whatever the token budget permits.
+- **Soft budget** (recommend split): ~800 **added** lines OR ~8 changed files OR ~5 review axes per invocation, whichever is tighter. Deleted lines are not counted — a deletion-heavy PR needs no more attention than its additions.
+- **Hard split** (always split): >1500 added lines, >12 files, or >7 axes — at this size review quality degrades whatever the token budget permits.
 
-**Bail-out check (mandatory, before any other tool_use):** Run `git diff <base>...HEAD --stat` (or equivalent) as the very first tool call. If the diff exceeds the soft budget, respond with a single line and stop:
+**Bail-out check (mandatory, before any other tool_use):** Run `git diff <base>...HEAD --numstat` as the very first tool call and sum the first column (insertions; `-` for binary counts as 0). If the diff exceeds the soft budget, respond with a single line and stop:
 
 ```
-SCOPE_TOO_LARGE: <X lines / Y files> exceeds soft budget. Please split into <suggested partitions>. See docs/agent-tooling/subagent-usage.md §2 for the split budget.
+SCOPE_TOO_LARGE: <X added lines / Y files> exceeds soft budget. Please split into <suggested partitions>. See docs/agent-tooling/subagent-usage.md §2 for the split budget.
 ```
 
 Do NOT begin the Read / Grep cycle after this point — every subsequent tool_use consumes the budget the report body needs. Your Verdict is cheap and comes first; what runs out is the room to substantiate it.

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -12,7 +12,7 @@ You are a senior code reviewer for the Pastura iOS project (Swift 6 / SwiftUI / 
 
 The budget below is a **review-attention** bound, not a token one — a bigger model or a raised cap is not license to accept a larger scope. Cap mechanics: `docs/agent-tooling/subagent-usage.md` §1.
 
-- **Soft budget** (recommend split): ~800 **added** lines OR ~8 changed files OR ~5 review axes per invocation, whichever is tighter. Deleted lines are not counted — a deletion-heavy PR needs no more attention than its additions.
+- **Soft budget** (recommend split): ~800 **added** lines OR ~8 changed files OR ~5 review axes per invocation, whichever is tighter. The count bounds what you must newly comprehend; deleted lines are still read in full (a dropped field or entry is a finding too) but do not count toward the budget.
 - **Hard split** (always split): >1500 added lines, >12 files, or >7 axes — at this size review quality degrades whatever the token budget permits.
 
 **Bail-out check (mandatory, before any other tool_use):** Run `git diff <base>...HEAD --numstat` as the very first tool call and sum the first column (insertions; `-` for binary counts as 0). If the diff exceeds the soft budget, respond with a single line and stop:

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -5,192 +5,180 @@ allowed-tools: Read, Grep, Glob, Bash, Agent, Write, Edit, EnterWorktree, ExitWo
 argument-hint: "[description | issue-number | phase N]"
 ---
 
-<!-- generated-from: claude-kit skills/orchestrate-creator/orchestrate-template.md sha256:1fbc1aadc87e reconciled:2026-08-13 -->
+<!-- generated-from: claude-kit skills/orchestrate-creator/orchestrate-template.md sha256:1fbc1aadc87e reconciled:2026-08-21 -->
 
 # /orchestrate
 
-Orchestrate the full development workflow: plan → issue → worktree → TDD implementation → review → PR.
+Orchestrate the full development workflow for Pastura: plan → issue → worktree → TDD implementation
+→ review → PR.
 
-> **Project-owned file, hand-reconciled against the claude-kit template — not generated from it.**
-> Edit it freely; kit updates never touch it. Step U-4 rewrites the stamp line on an upgrade, so
-> nothing durable belongs in it. **"Up to date" from Step U means *no template change since the
-> reconcile*, not that this file matches the template** — it deliberately does not, and a back-port
-> proposal must be judged on its merits.
-> Before accepting one, read
+> **Project-owned file, hand-reconciled against the claude-kit template.** Edit it freely; kit updates
+> never touch it. Before accepting a back-port from `/claude-kit:orchestrate-creator`, read
 > [`docs/agent-tooling/orchestrate-kit-reconciliation.md`](../../../docs/agent-tooling/orchestrate-kit-reconciliation.md)
-> — the ledger of divergences an upgrade could silently undo, and why each is correct here (#1453).
+> — the divergences an upgrade would silently undo. The traps behind the shorter wording here live in
+> [`docs/agent-tooling/orchestrate-traps.md`](../../../docs/agent-tooling/orchestrate-traps.md).
 
 ## Constants
 
-- `PLAN_MARKER`: `<!-- pastura-plan -->` — machine-readable marker embedded in Issue plan comments for detection during resumption. **Project-unique by construction** — never change it to a generic name: a marker shared with another skill or repo makes resumption pick up foreign plans.
-- `OWNER_REPO`: derived at runtime via `gh repo view --json nameWithOwner -q '.nameWithOwner'`. Resolve early in Step 0 (before any `gh api` calls) — but **after** pre-flight check 1, which decides whether `gh` is usable at all and therefore runs before every `gh`-dependent step, including the ones written earlier than it. In degraded mode `OWNER_REPO` is unavailable and every `gh` step is skipped.
+- `PLAN_MARKER`: `<!-- pastura-plan -->` — machine-readable marker embedded in issue plan comments
+  for resumption detection. Project-unique by construction; never change it to a generic name.
+- `OWNER_REPO`: `gh repo view --json nameWithOwner -q '.nameWithOwner'`. Resolve in Step 0, after
+  pre-flight check 1 (which decides whether `gh` is usable at all).
+
+## Project parameters
+
+| Parameter | Value |
+|---|---|
+| Test command | `scripts/xcodebuild.sh test [-only-testing PasturaTests/<Class>]` — bare and cwd-relative, never behind `cd … &&`, an env-var prefix, or an absolute path (`.claude/rules/xcodebuild-cli.md`) |
+| Lint command | `swiftlint lint --quiet --strict` |
+| Commit-time gate | pre-commit hook (`scripts/*-gate.sh`, SwiftLint, build when the changeset needs it) |
+| TDD | required — Engine / LLM test-first; Data / UI implement-then-test (CLAUDE.md § Testing Strategy) |
+| Plan-critique agent | `claude-kit:critic`, passed `model: opus` (it carries no pin) |
+| Review agent | `code-reviewer` (`.claude/agents/code-reviewer.md`) |
+
+**Commit-gate note:** the pre-commit hook enforces quality at commit time — after a subagent's
+changes, a diff spot-check suffices before committing; the hook is the gate.
 
 ## Step 0: Input Detection & Pre-flight
 
 Interpret `$ARGUMENTS`:
-- **`#N`** (digits after `#`): Fetch issue via `gh issue view N`, use title/body as task spec. Then check for an existing plan (see **Resumption Detection** below). In degraded mode (unauthenticated — see pre-flight check 1 below), `#N` cannot be fetched and resumption is unavailable; the task spec must come from the user inline instead.
-- **`phase N`** (e.g., `phase 1`, `phase 2`): Read ONLY that Phase section from `docs/ROADMAP.md`.
-- **(empty)**: Ask user what to implement.
+- **`#N`**: Fetch issue via `gh issue view N`, use title/body as task spec. Check for an existing
+  plan (Resumption Detection below).
+- **`phase N`**: Read ONLY that Phase section of `docs/ROADMAP.md`.
+- **(empty)**: Ask what to implement.
 - **Other text**: Use as inline task description.
 
-Derive from the task spec:
-- `TASK_TYPE`: `feat` or `fix` (infer from content, default `feat`)
-- `SLUG`: kebab-case, **must match `^[a-z0-9][a-z0-9-]{0,36}$`**. If not, sanitize or ask user.
+Derive: `TASK_TYPE` (`feat`/`fix`, default `feat`); `SLUG` (kebab-case, `^[a-z0-9][a-z0-9-]{0,36}$`;
+sanitize or ask if it doesn't match).
 
-### Resumption Detection (for `#N` input only)
+### Resumption Detection (`#N` only)
 
-After fetching the issue, check for an existing plan comment:
-1. Fetch issue comments and search for `PLAN_MARKER`:
+1. Fetch issue comments, find `PLAN_MARKER`:
    ```bash
    gh api "repos/${OWNER_REPO}/issues/N/comments" --jq '.[] | select(.body | contains("<!-- pastura-plan -->")) | {id, body}' | tail -1
    ```
-   Use the **last** matching comment (handles multiple plan comments from retries).
-2. If a plan comment is found:
-   - Set `RESUMING=true`, `ISSUE_NUMBER=N`, and capture `COMMENT_ID`.
-   - Parse checkboxes: count `- [x]` (done) vs `- [ ]` (remaining). Identify `NEXT_ITEM` (first unchecked item number).
-   - Extract `TASK_TYPE`, branch name, and `REVIEWER_MODEL` from the `## Metadata` section in the comment. **Normalize `REVIEWER_MODEL` to lowercase** (`opus` / `sonnet`) when binding — Metadata records it title-case (`Opus` / `Sonnet`) for readability, but downstream Agent calls use lowercase. If `Reviewer` is absent from Metadata (e.g., older plan comment pre-dating this field), default `REVIEWER_MODEL=opus`.
-   - Extract `SESSION_MODEL` from `## Metadata` the same way — normalize to lowercase (`opus` / `sonnet`) — and capture its `(reason: …)` tail as `SESSION_RATIONALE` for the Step 2b resume prompt. If `Session` is absent (older plan comment pre-dating this field), default `SESSION_MODEL=opus` (the safe fallback — orchestrator stays on Opus); `SESSION_RATIONALE` is then unused (the resume prompt is Sonnet-gated).
-   - Extract `Routing` from `## Metadata`. It records which label semantics the comment was written under and governs **the locus only** — which Step 3 branch a resumed item takes; the Coupling predicates below need no version-conditioning, since a pre-split comment carries no `🧠`. `v2` ⇒ current semantics (`🎭` dispatches to an Opus subagent, `🧠` is in-session). **Absent, or any value this skill does not recognize** ⇒ **fail closed to legacy**: every `🎭` item in that comment is in-session, its pre-split meaning — never guess forward from a higher version number. Fail-closed is the safe direction: legacy locus costs more but is never less reviewed. It does **not** touch `SESSION_MODEL` — the Coupling re-check below handles a legacy `🎭`, and overwriting `Session` would cost every pre-v2 all-🎵 plan its Sonnet lever on resumption.
-   - Derive `SLUG` from the branch name.
-   - **Coupling re-check**: if the resumed plan contains any Opus-tier item (`🎭` or `🧠`) but `REVIEWER_MODEL=sonnet` **or** `SESSION_MODEL=sonnet` (e.g., from a post-plan Metadata edit that bypassed the Step 1 coupling rule), warn the user and offer to upgrade the affected model(s) to Opus before continuing — that is, before proceeding to Step 2 in the normal flow, or before the Step 4 review when all items are already complete. Reason: Opus-tier work must never be implemented or reviewed on Sonnet — `🧠` runs in the session itself, `🎭` dispatches to an Opus subagent, and both need an Opus reviewer. When `SESSION_MODEL` resolves to (or is upgraded to) `opus`, ensure the running session is actually on Opus (`/model opus`) before resuming implementation.
-   - **All-Sonnet-tier re-check**: the Opus-tier predicate above (`🎭` or `🧠`) cannot fire on a plan whose every item is Sonnet-tier — `🎵`, `🎵 (tb)`, `🎵 (main)` in any mix. But Sonnet-tier does not certify simplicity: Step 1.3's Q1 deferral also admits *specifiable but merely hard* items, marked `🎵 (tb)` at plan time. A resumed session has no conversation context to re-derive that classification itself — don't try. Instead, when every item is Sonnet-tier **and** `REVIEWER_MODEL=sonnet`: grep the plan comment for `🎵 (tb)`. Any hit ⇒ offer to upgrade `REVIEWER_MODEL` to Opus (the reviewer only — unlike the re-check above, which covers both models). **Fail closed on a zero-hit grep too**: a plan comment predating this marker carries no route information at all, and is indistinguishable by grep from a plan that legitimately used zero tie-breaker items — so treat "no `(tb)` found" as inconclusive, not confirmed-safe, and offer the same upgrade. `SESSION_MODEL=sonnet` stays — the cost lever survives an Opus reviewer.
-   - If **all items are already checked**: do **not** silently proceed to review. A fully-checked *last* plan usually means its PR already merged — and on an **umbrella issue** that accumulates several historical plan comments, the `tail -1` in the resumption command above lands on that finished plan, so auto-proceeding would re-review completed work instead of planning the new work the user actually wants. Ask the user: "#N's last plan is complete (its PR likely merged) — resume-review it, or start a NEW plan for new work on #N?" Only ensure you are on the feature branch or in the correct worktree and **skip to Step 4** directly on an explicit "resume-review" answer; otherwise treat it as a fresh task and fall through to Step 1 (which then also runs Step 1b, since `RESUMING` no longer applies to this path).
-   - Report to user: "Found existing plan on issue #N. {DONE}/{TOTAL} items complete. Resuming from item {NEXT_ITEM}."
-   - **Skip Step 1 and Step 1b entirely** → proceed to Step 2.
-3. If no plan comment found: proceed normally (Step 1 creates the plan, Step 2 attaches it).
+   Use the **last** match.
+2. If found: set `RESUMING=true`, `ISSUE_NUMBER=N`, capture `COMMENT_ID`. Parse checkboxes
+   (`- [x]` done vs `- [ ]` remaining), identify `NEXT_ITEM`. Extract `TASK_TYPE`, branch,
+   `REVIEWER_MODEL`, `SESSION_MODEL` from the `## Metadata` block (normalize to lowercase
+   `opus`/`sonnet`; default `opus` if a field is absent). Derive `SLUG` from the branch.
+   - **Coupling re-check:** if the resumed plan has any Opus-tier item (`🎭` or `🧠`) but
+     `REVIEWER_MODEL=sonnet` or `SESSION_MODEL=sonnet`, warn and offer to upgrade to Opus before
+     continuing. If it is all Sonnet-tier with `REVIEWER_MODEL=sonnet`, re-confirm each item is
+     strictly within the 🎵 simple criteria — a `🎵 (tb)` item is not, and the label alone does not
+     establish it (Step 1.3) — and offer the same upgrade.
+   - If **all items checked**: do **not** silently proceed to review. A fully-checked *last* plan
+     usually means its PR already merged — and on an **umbrella issue** that accumulates several
+     historical plan comments, `tail -1` lands on that finished plan, so auto-proceeding re-reviews
+     completed work instead of planning the new work the user actually wants. Ask: *"#N's last plan
+     is complete (its PR likely merged) — resume-review it, or start a NEW plan for new work on
+     #N?"* Only ensure you are on the branch/worktree and **skip to Step 4** on explicit
+     "resume-review"; otherwise treat as a fresh task (fall through to Step 1).
+   - Report "Found plan on #N. {DONE}/{TOTAL} complete. Resuming from item {NEXT_ITEM}." **Skip
+     Steps 1 and 1b** → go to Step 2.
+3. If no plan: proceed normally.
 
-**Pre-flight checks** (run in order):
-1. `gh auth status` — **run this first, before the `#N` fetch and Resumption Detection above**, since both make `gh` calls that depend on its verdict. If unauthenticated, run in **degraded mode** and say so explicitly rather than silently skipping: no issue, no checkpoint sync, no resumption, and every `gh` step in this skill skipped — including the ones written earlier than this line (`OWNER_REPO`'s `gh repo view`, the `#N` fetch, Resumption Detection's `gh api`). The plan lives only in-session.
-2. `git status` — warn if uncommitted changes exist.
-3. Verify on default branch (skip if `RESUMING=true`):
-   - `DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q '.defaultBranchRef.name')` — this value still feeds Step 4's `git fetch origin {DEFAULT_BRANCH}`, `git rev-list … origin/{DEFAULT_BRANCH}`, and check 4's `git pull`, so degraded mode needs a fallback yielding a **bare branch name**, not a ref: `DEFAULT_BRANCH=$(git symbolic-ref --short refs/remotes/origin/HEAD | sed 's|^origin/||')`. Plain `git symbolic-ref refs/remotes/origin/HEAD` returns `refs/remotes/origin/main` and `--short` alone returns `origin/main` — either shape breaks every consumer above except the two `diff {DEFAULT_BRANCH}...HEAD` uses, which accept a full ref by luck. If `origin/HEAD` is unset (common in a fresh clone), recover with `git remote set-head origin -a`.
-   - If current branch != `DEFAULT_BRANCH`, warn and offer `git switch "$DEFAULT_BRANCH"`.
-4. `git pull --ff-only origin "$DEFAULT_BRANCH"` — warn on failure, don't block. Skip if `RESUMING=true`.
-5. If already in a worktree, warn and suggest `ExitWorktree` first (unless `RESUMING=true` and the worktree matches the expected branch).
+**Pre-flight** (in order):
+1. `gh auth status` — if unauthenticated, run in **degraded mode**: no issue, no checkpoint sync,
+   **no resumption** (say so explicitly). Skip all `gh` steps; the plan lives only in-session.
+2. `git status` — warn on uncommitted changes.
+3. Verify on default branch (skip if `RESUMING`): `DEFAULT_BRANCH=$(gh repo view --json
+   defaultBranchRef -q '.defaultBranchRef.name')`. Degraded-mode fallback must yield a **bare branch
+   name**: `git symbolic-ref --short refs/remotes/origin/HEAD | sed 's|^origin/||'` (if `origin/HEAD`
+   is unset, `git remote set-head origin -a` first). If not on it, offer `git switch`.
+4. `git pull --ff-only origin "$DEFAULT_BRANCH"` — warn on failure, don't block. Skip if `RESUMING`.
+5. If already in a worktree, suggest `ExitWorktree` first (unless resuming into the matching one).
 
 ## Step 1: Plan — Gate G1
 
-1. Read `CLAUDE.md` for current phase and conventions.
-2. If phase-related, read ONLY the relevant Phase section from `docs/ROADMAP.md`.
-3. Format the plan as a numbered checkbox list (each item = one planned commit).
-   Assign a **routing label** to each item. The label is the *outcome* of two independent questions — **tier** (which model) and **locus** (main session or subagent) — never one judgement. Icons: 🎵 Sonnet subagent, 🎭 Opus subagent, 🧠 Opus in the main session.
-   - **Q1 — tier, by the nature of the work.** Matches a **🎭 criterion** — new design patterns, actor isolation / Sendable design decisions, changes spanning multiple layers, work near dependency rule boundaries (Engine ↔ Data), or any item requiring non-obvious architectural judgment → **Opus tier**. Else matches a **🎵 criterion** — existing pattern reuse (e.g., a new Handler mirroring an existing one), test-only changes following an existing test pattern, type/error case additions, doc comments, minor fixes → **Sonnet tier**. Neither → **deferred**, resolved by Q3.
-   - **The 🎭 criteria win outright.** They name the *nature* of the work, not its difficulty, so an item matching one stays Opus-tier however settled its spec is. **That is a claim about the tier, not about the locus** — nature picks the model; it never forces the work into the main session (#1515 measured what conflating the two costs).
-   - **Q2 — locus, by specifiability.** Not "too hard for Sonnet?": difficulty or size alone does not pull an item into the main session. A subagent inherits none of this conversation, so ask: can you fill the Step 3 delegation prompt slots *now* without a new design decision — target file(s), plus an existing pattern to mirror or an acceptance condition? **Yes, even if hard → subagent.** No, or you can't tell whether the slots are fillable → **main session** (that specific uncertainty — not general unease). Also route to the main session when delegation prompt + verify overhead exceeds the implementation itself — single-line edits, short doc tweaks. This disjunct applies at any tier, deferral included.
-   - **Q3 — resolve.** Read the pair off this table. Nothing here overrides Q1's tier.
+1. Read `CLAUDE.md` and (if phase work) the relevant `docs/ROADMAP.md` section.
+2. Format the plan as a numbered checkbox list, one item = one planned commit. Label each item with
+   the outcome of two independent questions — **tier** (which model) and **locus** (main session or
+   subagent):
+   - **Q1 — tier, by the nature of the work.** A **🎭 criterion** — new design patterns, actor
+     isolation / `Sendable` decisions, changes spanning layers, work near a dependency-rule boundary
+     (Engine ↔ Data), anything needing non-obvious architectural judgment → Opus tier. A **🎵
+     criterion** — existing-pattern reuse (a new Handler mirroring an existing one), test-only
+     changes following an existing test pattern, type/error-case additions, doc comments, minor
+     fixes → Sonnet tier. Neither → deferred. The 🎭 criteria name the *nature* of the work, so a
+     matching item stays Opus-tier however settled its spec is — that decides the model, never the
+     locus.
+   - **Q2 — locus, by specifiability.** Not "too hard for Sonnet?": difficulty or size alone does
+     not pull an item into the main session. A subagent inherits none of this conversation, so ask:
+     can you fill the Step 3 prompt slots *now* without a new design decision — target file(s), plus
+     an existing pattern to mirror or an acceptance condition? Yes, even if hard → subagent. No, or
+     you can't tell → main session (that specific uncertainty — not general unease). Also route to
+     the main session when delegation prompt + verify overhead exceeds the work itself (single-line
+     edits, short doc tweaks).
+   - **Q3 — resolve:**
 
      | Q1 tier | Q2 locus | Label |
      |---|---|---|
-     | Opus (🎭 criterion) | subagent | `🎭` |
-     | Opus (🎭 criterion) | main session | `🧠` |
-     | Sonnet (🎵 criterion) | subagent | `🎵` |
-     | Sonnet (🎵 criterion) | main session | `🎵 (main)` |
-     | deferred (neither) | subagent | `🎵 (tb)` |
-     | deferred (neither) | main session | `🧠` |
-
-     Two rows carry a decision, not a derivation. **A deferred item routed to the main session is Opus-tier**: deferral means the classification is unresolved, and no subagent will verify it. **`🎵 (main)` keeps its Sonnet tier** and so does *not* force an Opus reviewer or session through the Coupling rules below — who types a one-line doc tweak does not change which criteria it matches.
-   - **`(tb)` marks the deferred-to-subagent row, and only that row.** Without it nothing downstream can tell criteria-🎵 apart from merely-hard-🎵, and both the Sonnet-reviewer-acceptable test (Step 1.4) and the Step 0 resumption re-check depend on that distinction.
-   - **Do not add a blanket "when in doubt, go up a tier."** It was removed deliberately: Claude 5 applies such a booster literally, so it fires far harder than it was tuned for (claude-kit#19; landed here as #1453) and cancels Step 1.5's cost lever. Promotion must name its trigger — a 🎭 criterion, an unfillable prompt slot, or the overhead clause — never a bare feeling of unease. **The same bar applies to the locus**: routing an item to the main session names an unfillable slot or the overhead clause, never unease.
+     | Opus | subagent | `🎭` |
+     | Opus | main session | `🧠` |
+     | Sonnet | subagent | `🎵` |
+     | Sonnet | main session | `🎵 (main)` — keeps its Sonnet tier |
+     | deferred | subagent | `🎵 (tb)` — specifiable but unclassified |
+     | deferred | main session | `🧠` — unresolved and unverified by anyone else ⇒ Opus |
 
    ```
    - [ ] 1. 🎵 <description> (`<primary-file-path>`)
-   - [ ] 2. 🎵 (tb) <description> (`<primary-file-path>`)
-   - [ ] 3. 🎵 (main) <description> (`<primary-file-path>`)
-   - [ ] 4. 🎭 <description> (`<primary-file-path>`)
-   - [ ] 5. 🧠 <description> (`<primary-file-path>`)
-   ...
+   - [ ] 2. 🧠 <description> (`<primary-file-path>`)
    ```
-   Present this plan to the user. Store internally as `PLAN_BODY` for Issue attachment in Step 2.
-4. **Assign a reviewer model** for the PR as a whole (single choice, not per-item). This determines which model runs the `code-reviewer` subagent at Step 4. Criteria:
+   Present to the user; store as `PLAN_BODY`.
+3. **Assign a reviewer model** (single choice for the whole PR). Force **Opus** if any item touches
+   the **sensitive base**: dependency-rule boundaries; actor isolation / `Sendable` design; public
+   protocol signatures or access modifiers; `AppRouter` / `Route` / navigation; `App/` code touching
+   BG execution or `SimulationViewModel`; ADRs and `docs/specs/**`; `.github/workflows/**`,
+   `scripts/**`, `CLAUDE.md`, `.claude/**`; content safety (`ContentFilter`,
+   `PrivacyInfo.xcprivacy`, `Info.plist`); `Data/DatabaseManager+Migrations.swift`; integrity /
+   crypto (`App/ReplayHashing.swift`, the GGUF SHA-256 check in `App/ModelManager.swift`); LLM
+   backend code or prompt templates; design-system foundations (`docs/design/design-system.md`,
+   `DesignTokens*.swift`).
+   Otherwise **Sonnet** is acceptable only if every item is strictly within the 🎵 simple criteria —
+   new `@Test` cases in an existing suite, docs under `docs/**`, a single-file refactor inside one
+   layer, applying an existing design token to an existing view, a fix whose cause is already
+   localized. **Test that independently — a 🎵 label does not certify it**, and a `🎵 (tb)` item
+   never passes it (keep `Session: Sonnet` there — the cost lever survives an Opus reviewer).
+   **Coupling rule:** any Opus-tier item (`🎭` or `🧠`) ⇒ reviewer MUST be Opus. Record in
+   `## Metadata` as `- **Reviewer**: Opus (reason: …)`; store the reason tail as `REVIEWER_RATIONALE`.
+4. **Assign a session model** (label-driven only): any Opus-tier item → `Session: Opus` (the
+   orchestrator spot-checks and commits every `🎭` diff, so key on tier, not locus); every item
+   Sonnet-tier (`🎵`, `🎵 (tb)`, `🎵 (main)` in any mix) → `Session: Sonnet` (recommended — the cost
+   lever; the reviewer is set by step 3's own test, not by this choice). Record as
+   `- **Session**: Sonnet (reason: every item is Sonnet-tier)`; store `SESSION_RATIONALE`. A Sonnet
+   override is rejected when any item is Opus-tier (warn, keep Opus). `effort` is not recorded —
+   it stays at the session default.
+5. **Ask: "Proceed with this plan, reviewer-model, session-model?"**
+   For single-commit changes, combine G1 and G2, but still run Step 1b first.
 
-   **Opus required if any plan item touches:**
-   - Dependency rule boundaries (Engine ↔ LLM ↔ Data ↔ Models interrelations)
-   - Actor isolation / `Sendable` / `@MainActor` / `nonisolated` design
-   - Public protocol signatures or access modifier changes
-   - AppRouter / navigation routing (`Route` enum, `router.push` callsites)
-   - `App/` layer changes touching BG execution, `SimulationViewModel`, or `AppRouter`
-   - Decision records (`docs/decisions/ADR-*.md`) or architectural specs (`docs/specs/**`)
-   - CI / build infrastructure (`.github/workflows/**`, `scripts/**`)
-   - Project tooling (`CLAUDE.md`, `.claude/{skills,agents,rules}/**`)
-   - Content safety surface (ADR-005 related: `ContentFilter`, `PrivacyInfo.xcprivacy`, `Info.plist`)
-   - Database schema migrations (`Data/DatabaseManager+Migrations.swift`) — a defect here corrupts existing users' data irreversibly, and no test on a fresh database reaches it
-   - Integrity / crypto surfaces (`App/ReplayHashing.swift`, the model SHA-256 verification in `App/ModelManager.swift`) — a weakened check fails open, silently accepting a corrupt or substituted GGUF
-   - LLM backend code or prompt templates
-   - Design system foundations (`docs/design/design-system.md`, `DesignTokens*.swift`)
+## Step 1b: Plan Critique (REQUIRED unless `RESUMING`)
 
-   **Sonnet reviewer acceptable** — the change must be strictly a subset of the 🎵 criteria above (existing pattern reuse, test-only changes following an existing pattern, type/error case additions, doc comments, minor fixes), AND none of the items match the Opus-required list. **Test that independently — a 🎵 label does not certify it.** Step 1.3's Q1 deferral also routes *specifiable but merely hard* items to the Sonnet tier — they carry `(tb)` — and those are not strictly simple: if the plan has one, the reviewer is Opus. Keep `Session: Sonnet` there — the cost lever survives an Opus reviewer. Concretely, the most common Sonnet-acceptable shapes are:
-   - New `@Test` cases in an **existing** suite following the file's existing pattern (not new suites, new helpers, or trait changes like `.timeLimit` / `.serialized`)
-   - Documentation updates (`docs/ROADMAP.md`, `docs/examples/**`, `docs/gallery/**`, `docs/prototype/**`, doc comments)
-   - Simple refactor within a single file without crossing layer boundaries
-   - Design token **application** (existing token to existing View only — new token additions are Opus-required) — the ShapeStyle-vs-`Color` trap lives right at this bullet: `.foregroundStyle(.muted)` reads as trivial token application but is wrong when `.muted` is a `Color` extension rather than a `ShapeStyle` one; check `.claude/agents/code-reviewer.md`'s trap cheat sheet before calling it Sonnet-acceptable
-   - Fix-only PRs where the cause is already diagnosed and localized
+Launch `Agent(subagent_type: "claude-kit:critic", model: "opus", …)` to review the plan for blind
+spots. If the agent type does not resolve (plugin not installed or trusted), stop and surface that
+rather than skipping silently.
 
-   **Coupling rule:** If **any** plan item is Opus-tier (`🎭` or `🧠`), the reviewer MUST be Opus — even if the target paths look Sonnet-eligible. This prevents the "all-🎵-plus-Sonnet-reviewer" configuration from putting Opus-tier work through a Sonnet review.
-
-   The subtle convention traps that used to justify a blanket "when in doubt, pick Opus" here (ShapeStyle+Color tokens, `nonisolated` gaps, i18n `String(localized:)` omissions, missing `@Suite(.timeLimit(.minutes(1)))`) are carried by `.claude/agents/code-reviewer.md`'s trap cheat sheet and the always-loaded `.claude/rules/swift-isolation.md`, which reach the reviewer at either tier. Their absence from this section is deliberate — the three rules above are what decides the tier.
-
-   Record the decision in the `## Metadata` block of the plan comment (see Step 2a) as:
-   ```
-   - **Reviewer**: Opus (reason: touches Engine/ dependency boundary)
-   ```
-   Store the rationale string as `REVIEWER_RATIONALE` (the `(reason: ...)` tail) for use in the Step 2a template. The user may override at G1. Resumed sessions recover the decision from `## Metadata` (see Step 0).
-5. **Assign a session model** for the implementation phase (Step 3 onward). This is the model the orchestrator itself runs as — the user switches it manually via `/model` at G2 (or the combined single-commit gate), since the orchestrator cannot change its own session model. Derivation is **label-driven only** (unlike the reviewer, which also has path-based Opus triggers):
-
-   - **Any plan item is Opus-tier (`🎭` or `🧠`)** → `Session`: **Opus**. Keyed on the tier, not the locus: the orchestrator spot-checks and commits every `🎭` subagent's diff, so a `🧠`-only predicate would put a Sonnet pre-commit check on Opus-tier work. Do not simplify it to `🧠`.
-   - **Every item is Sonnet-tier** — `🎵`, `🎵 (tb)`, `🎵 (main)` in any mix → `Session`: **Sonnet** (recommended). The orchestrator's remaining work is dispatch, diff spot-check, commit, and PR mechanics, plus typing any `🎵 (main)` item itself. This is the primary cost lever: the long implementation tail runs at Sonnet rates.
-
-   **Why review quality is unaffected:** the reviewer is assigned independently of the *session model* — not of the label, which Step 1.4 tests separately. The Step 1b critic runs at Opus (`claude-kit:critic` carries no model pin, so Step 1b passes `model: opus` explicitly — no override), and the Step 4 `code-reviewer` runs at `REVIEWER_MODEL` (which the path-based Coupling rule already forces to Opus on sensitive paths). A Sonnet session changes who *dispatches and commits*, not who *reviews*.
-
-   **Accepted risk (all-Sonnet-tier on a Sonnet-eligible path):** when both session and reviewer are Sonnet, the Step 3 pre-commit spot-check runs on Sonnet, and a `🎵 (main)` item is *written* on Sonnet too — no Opus touches the tail except the pre-code Step 1b critic. What licenses that is **Step 1.4's strictly-simple test having passed independently**, not the 🎵 labels: an item that reached the Sonnet tier through Q1's deferral rather than a clean 🎵-criteria match carries `(tb)` and has already floored the reviewer at Opus, so this configuration is unreachable for it. G1 remains the human gate — bump `Session` to Opus if a sensitive-but-Sonnet-tier change warrants it.
-
-   Record in `## Metadata` (Step 2a) as `- **Session**: Sonnet (reason: every item is Sonnet-tier)`, and store the rationale tail as `SESSION_RATIONALE`. **`effort` is not recorded** — it stays at the session default (`high`) per operator convention; model is the cost lever, not effort. Resumed sessions recover the decision from `## Metadata` (see Step 0).
-
-   **Override constraint (Coupling):** the user may override `Session` at G1, but **a Sonnet override is rejected when any item is Opus-tier (`🎭` or `🧠`)** — warn and keep Opus. Opus-tier work, whether implemented directly (`🧠`) or dispatched (`🎭`), must be at the Opus tier. (Mirrors the reviewer Coupling rule; re-checked on resume — see Step 0.)
-6. **Ask: "Proceed with this plan, reviewer-model, and session-model choice?"** — present the plan checkboxes plus the proposed `Reviewer:` and `Session:` decisions so the user can override either at G1. For single-commit changes, combine G1 and G2 into one confirmation, but still run Step 1b (critic review) before creating the worktree; when the combined gate applies and `Session: Sonnet`, surface the `/model sonnet` recommendation at that same confirmation (after the critic, which stays on Opus).
-
-After user approval, proceed to Step 1b (mandatory critic review).
-
-## Step 1b: Plan Critique (REQUIRED)
-
-This step is a review gate: complete it before Step 2. Skipped only when `RESUMING=true`.
-
-After the user approves the plan (G1), launch a `claude-kit:critic` subagent via the Agent tool to review the plan for blind spots. The agent comes from the claude-kit plugin (`enabledPlugins` in `.claude/settings.json` — Pastura keeps no local copy); it carries no model pin, so **pass `model: opus` explicitly** at invocation. If the agent type is unavailable (plugin not yet trusted/installed on this machine), stop and surface that instead of silently skipping the critique.
-
-```
-Agent(subagent_type: "claude-kit:critic", model: "opus", description: "...", prompt: "...")
-```
-
-The literal block (mirroring Step 4) makes the Opus pin mechanical rather than prose-recalled — an omitted `model` would silently inherit a Sonnet session (the all-🎵 lever, Step 1) and downgrade this mandatory gate.
-
-> **Agent prompt:** "Review the following implementation plan for the Pastura project. Focus on: scope creep beyond current phase, dependency rule violations in the planned file locations, missing edge cases, integration risks with existing modules, and assumptions not validated against the codebase. If the plan declares a reviewer-model choice, include an axis evaluating whether that choice matches the actual sensitivity of the touched paths — and within that same axis, evaluate each item's routing label — 🎵 / `🎵 (tb)` / `🎵 (main)` / 🎭 / 🧠, which encode a **tier** and a **locus** separately — and the `Session` choice against the work the item actually describes. Check both axes: a label that names the right model can still pin the work in the main session for no stated reason. You are the only reviewer in this loop running at Opus with no cost incentive to route work to a subagent, so this is the structural check the routing rules otherwise lack.
->
+> **Prompt:** "Review this implementation plan for the Pastura project. Focus on: scope creep beyond
+> the current phase, dependency-rule violations in the planned file locations, missing edge cases,
+> integration risks with existing modules, and assumptions not validated against the codebase. If the
+> plan declares a reviewer-model choice, add an axis evaluating whether it matches the sensitivity of
+> the touched paths, and whether each item's label (tier and locus) matches the work it describes.
+> Read the repo's `CLAUDE.md` and `docs/ROADMAP.md` for context.
 > Task: {TASK_DESCRIPTION}
->
-> Plan:
-> {PLAN_BODY}
->
-> Read `CLAUDE.md` and `docs/ROADMAP.md` for project context. Output your full two-stage evaluation (Stage 1 axes, Stage 2 evaluation, Summary Table, Top Actions)."
+> Plan: {PLAN_BODY}
+> Output your full two-stage evaluation (axes, evaluation, summary table, top actions)."
 
-Handle the critic's output:
-- **Any Critical verdict**: Present the full critic report. **Ask: "Critic found critical issues — revise the plan, or proceed anyway?"** If revise → return to Step 1, regenerate plan, then re-run Step 1b. If proceed → continue to Step 2.
-- **Only OK / Warning verdicts**: Present the summary table as informational context, then proceed to Step 2 without an additional gate.
-
-*Skipped when `RESUMING=true`* (plan was already approved and critiqued in a prior session).
+- **Any Critical verdict:** present the report, **ask "revise or proceed?"**. Revise → back to
+  Step 1, regenerate, re-run 1b.
+- **OK/Warning only:** present the summary as context, proceed to Step 2.
 
 ## Step 2: Issue + Worktree — Gate G2
 
-**Precondition:** Step 1b critic review completed (or `RESUMING=true`).
-
 ### 2a: Issue & Plan Comment
 
-**If `RESUMING=true`** (plan already exists on issue `#N`):
-- Skip issue creation and plan attachment entirely.
-
-**Degraded mode (unauthenticated):**
-- Skip issue creation and plan attachment; keep the plan in-session (no resumption).
-
-**If from `#N`** (existing issue, no plan yet):
-- Post the plan as a comment on issue `#N`:
+- **`RESUMING`:** skip.
+- **Degraded mode (unauthenticated):** skip; keep the plan in-session (no resumption).
+- **From `#N`:** post the plan as a comment on `#N`:
   ```bash
   COMMENT_ID=$(gh api "repos/${OWNER_REPO}/issues/N/comments" \
     -f body="$(cat <<'PASTURA_PLAN'
@@ -204,304 +192,194 @@ Handle the critic's output:
   - **Branch**: `{TASK_TYPE}/{SLUG}`
   - **Reviewer**: {REVIEWER_MODEL} (reason: {REVIEWER_RATIONALE})
   - **Session**: {SESSION_MODEL} (reason: {SESSION_RATIONALE})
-  - **Routing**: v2
   PASTURA_PLAN
   )" --jq '.id')
   ```
-  Set `ISSUE_NUMBER=N`. When emitting `{REVIEWER_MODEL}` and `{SESSION_MODEL}` into Metadata, title-case the values (`Opus` / `Sonnet`) for readability — Step 0's parser normalizes back to lowercase on read.
-
-**Otherwise** (new task — create an issue whenever authenticated, because checkpoint sync and resumption require a `COMMENT_ID` on a real Issue; in degraded mode this step is already skipped above):
-- Determine `LABEL` from `TASK_TYPE` using the label mapping table in Step 5.
-- Create a new issue:
-  ```bash
-  ISSUE_URL=$(gh issue create \
-    --title "{EMOJI} {TASK_TYPE}: {TITLE}" \
-    --assignee "@me" \
-    --label "$LABEL" \
-    --body "$(cat <<'PASTURA_ISSUE'
-  ## Summary
-  {1-3 sentence summary from plan}
-
-  **Branch**: \`{TASK_TYPE}/{SLUG}\`
-
-  See first comment for implementation checklist.
-  PASTURA_ISSUE
-  )")
-  ```
-  Extract `ISSUE_NUMBER` from the URL.
-  **Label fallback:** if `--label "$LABEL"` fails (the label doesn't exist in the repo), retry the command without `--label` (or offer to create the label first) — never block issue creation on a missing label.
-- Post the plan as the first comment (same format as the `#N` case above). **Capture `COMMENT_ID` from the response** (`--jq '.id'`) — it is required for checkpoint sync in Step 3.
+  Title-case model names in Metadata; Step 0 normalizes on read.
+- **Otherwise (new task):** create an issue (`gh issue create --title "{EMOJI} {TASK_TYPE}: {TITLE}"
+  --assignee "@me" [--label "$LABEL"] --body …`), extract `ISSUE_NUMBER`, then post the plan as the
+  first comment (capture `COMMENT_ID`). **Label fallback:** if `--label` fails (label absent in the
+  repo), retry without it (or offer to create the label) — never block on a missing label.
 
 ### 2b: Worktree Setup
 
-**If `RESUMING=true`**:
-1. Check for existing worktree: `git worktree list | grep {SLUG}`.
-2. If found → `EnterWorktree` with the existing worktree name.
-3. If not found but branch exists remotely → fetch the branch and create a new worktree from it.
-4. If nothing exists → create a new worktree (normal flow).
-5. **If `SESSION_MODEL=sonnet`**, prompt the user to switch first: "This plan recommends a **Sonnet** session ({SESSION_RATIONALE}). Run `/model sonnet` now, then confirm." Then **Ask: "Resume from item {NEXT_ITEM}/{TOTAL}?"**
+- **`RESUMING`:** find existing worktree (`git worktree list | grep {SLUG}`) → `EnterWorktree`; else
+  recreate from the remote branch; else fresh. If `SESSION_MODEL=sonnet`, prompt `/model sonnet`
+  first, then **ask "Resume from item {NEXT_ITEM}/{TOTAL}?"**
+- **Normal:**
+  1. "Issue #{ISSUE_NUMBER} created. Branch: `{TASK_TYPE}/{SLUG}`" (or, degraded, just the branch).
+  2. If `SESSION_MODEL=sonnet`, tell the user to run `/model sonnet` now (or keep Opus). Then **ask
+     "Create worktree and start?"**
+  3. `EnterWorktree` with `name: "{TASK_TYPE}/{SLUG}"` (on collision, check `git ls-remote --heads
+     origin <branch>`, append `-2`).
+  4. Rename to conventional format: `git branch -m "$(git branch --show-current)" "{TASK_TYPE}/{SLUG}"`.
+  5. Verify: `git branch --show-current`.
 
-**Otherwise** (normal flow):
-1. Display: "Issue #{ISSUE_NUMBER} created. Branch: `{TASK_TYPE}/{SLUG}`" — in degraded mode 2a was skipped and `ISSUE_NUMBER` is unbound, so report the branch alone.
-2. **If `SESSION_MODEL=sonnet`**, tell the user to switch before implementation begins: "Session recommendation: **Sonnet** ({SESSION_RATIONALE}). Run `/model sonnet` now (or keep Opus by ignoring), then confirm below." Then **Ask: "Create worktree and start?"**
-3. Call `EnterWorktree` with `name: "{TASK_TYPE}/{SLUG}"`.
-   - On failure: suggest alternative name or cleanup. Check `git ls-remote --heads origin <branch>` for remote collisions too; append `-2` suffix if needed.
-4. Rename the branch to the conventional format (EnterWorktree sanitizes `/` to `+` and prepends `worktree-`):
-   ```bash
-   git branch -m "$(git branch --show-current)" "{TASK_TYPE}/{SLUG}"
-   ```
-5. Verify: `git branch --show-current`.
-6. **Worktree path hygiene** (holds for the rest of the session): the main checkout at `/Users/tyabu12/Work/pastura` stays on another branch, so a tool that resolves to it instead of this worktree acts on the wrong tree silently.
-   - Every absolute Edit/Write path must contain `/worktrees/<name>/` — invalidate any carried over from a *pre-worktree* tool result before reusing it.
-   - Non-isolation subagents (Step 3 `claude-kit:implementer`, Step 4 reviewer) inherit this worktree's cwd — but cwd inheritance for a non-isolation subagent is **not documented as guaranteed**, and it has resolved to the *original* checkout in practice, yielding an empty phantom diff that reads as a false FAIL. So don't rely on it: capture the root once with `WORKTREE_ROOT=$(git rev-parse --show-toplevel)` and **embed `git -C {WORKTREE_ROOT}`** into every subagent prompt that runs git — never a bare `git` the subagent resolves against its own cwd, never a `$(…)` it re-runs, and never a reused pre-worktree path.
+**Worktree path hygiene** (holds for the rest of the session): the original checkout stays on another
+branch, so a tool that resolves to it instead of this worktree acts on the wrong tree silently.
+cwd inheritance for a non-isolation subagent is **not guaranteed** (it has resolved to the *original*
+checkout in practice, yielding an empty phantom diff that reads as a false FAIL). So capture the root
+once with `WORKTREE_ROOT=$(git rev-parse --show-toplevel)` and **embed `git -C {WORKTREE_ROOT}`** into
+every subagent prompt that runs git — never a bare `git` the subagent resolves against its own cwd,
+never a `$(…)` it re-runs, never a reused pre-worktree path. Same rule for absolute Edit/Write paths:
+resolve them under `{WORKTREE_ROOT}`, and invalidate any carried over from a *pre-worktree* result.
+`-C` is git-only: `scripts/xcodebuild.sh` stays bare (Project parameters), so have a delegated
+implementer **report `pwd`** — the wrapper resolves its root from cwd, and a run that landed in the
+main checkout returns a green for the wrong tree.
 
-## Step 3: Implementation (TDD)
+## Step 3: Implementation
 
-Follow the plan from Step 1 (or the resumed plan from the Issue). **If `RESUMING=true`**, start from item `NEXT_ITEM` — skip already-checked items.
-
-For each unit of work (let `K` = the current plan item number), check the item's routing label and take the matching branch:
+Follow the plan. If `RESUMING`, start from `NEXT_ITEM`. Per item (`K` = plan item number), branch on
+the label:
 
 | Label | Branch |
 |---|---|
-| `🧠` | **🧠 Opus-tier, in the main session** — the orchestrator implements it |
-| `🎭` | **🎭 Opus-tier, delegated** — dispatch `claude-kit:implementer` at Opus |
-| `🎵` / `🎵 (tb)` | **🎵 Sonnet-tier, delegated** — dispatch a Sonnet subagent |
-| `🎵 (main)` | the **🧠** branch, run at the session model — it is in-session because delegation overhead exceeded the work, not because it needs Opus |
+| `🧠` | in-session — the orchestrator implements it |
+| `🎭` | `Agent(subagent_type: "claude-kit:implementer", model: "opus")` |
+| `🎵` / `🎵 (tb)` | `Agent(model: "sonnet")` |
+| `🎵 (main)` | the in-session branch, at the session model |
 
-**Resumed plans**: when Step 0 resolved `Routing` to legacy — absent or unrecognized — a `🎭` item takes the **🧠** branch instead, because pre-split `🎭` meant in-session.
+### In-session — orchestrator implements directly
 
-> **Per-item commit hazard:** the pre-commit `swiftlint --strict` lints the **whole worktree**, not just the staged set — so an unstaged edit to a *later* item's file (e.g. one that trips a length cap) fails the *current* item's commit. Don't pre-edit a later item while committing the current one; if unavoidable, `git stash push -- <later-item-files>` before the focused commit, then pop.
-
-### 🧠 Opus-tier, in the main session — orchestrator implements directly
-
-1. Write test first (TDD mandatory per CLAUDE.md). Skip for documentation-only or test-only items (mirrors the 🎵 branch's escape at the Sonnet prompt below).
-2. Run targeted tests — confirm failure:
-   ```bash
-   scripts/xcodebuild.sh test -only-testing PasturaTests/<CurrentTestClass>
-   ```
-   Run from the repo root — the wrapper supplies `-scheme` / `-project` / `-destination` / `-derivedDataPath` and the simulator gate internally (see `.claude/rules/xcodebuild-cli.md`). Use `-only-testing` for the specific test class being developed — full suite per red/green cycle is too slow.
-3. Write implementation.
-4. Run targeted tests — confirm pass (same command as step 2).
+1. Write the test first — TDD is required in this project. Skip only for docs-only / test-only items.
+2. Run `scripts/xcodebuild.sh test -only-testing PasturaTests/<Class>` — confirm red.
+3. Write the implementation.
+4. Run the same command — confirm green.
 5. Commit (Conventional Commits + emoji per CLAUDE.md).
-6. **Sync checkpoint to GitHub Issue** (skip in degraded mode) — update the plan comment to check off the completed item:
+6. **Checkpoint sync** (skip in degraded mode) — check off item `K` in the plan comment:
    ```bash
    BODY=$(gh api "repos/${OWNER_REPO}/issues/comments/${COMMENT_ID}" --jq '.body')
    UPDATED=$(echo "$BODY" | sed "s/^- \[ \] ${K}\./- [x] ${K}./")
    gh api "repos/${OWNER_REPO}/issues/comments/${COMMENT_ID}" -X PATCH -f body="$UPDATED" --jq '.url'
    ```
-   If `gh` fails, **warn and continue** — never block implementation on a sync failure.
+   On `gh` failure, **warn and continue** — never block on a sync failure.
 
-**Delegate the legwork, keep the judgment.** In-session does not mean every tool call happens here. The enumerate-every-instance and grep-the-OLD-shape sweeps (docs/agent-tooling/knowledge-layering.md § "Scope & Completeness Discipline") and the claim executions of `docs/agent-tooling/knowledge-layering.md` § "Verify before you lock it" are what fill the main context, not the deciding. Hand them to a read-only subagent (`Explore`, or a `general-purpose` one) and have it return **the command it ran, its exit status, and the hits — a zero-hit run reported explicitly**, so a broken pattern cannot come back wearing a verified face. One limit: **delegation finds sites; it never certifies counts.** Any number destined for a commit message, PR body, rule, comment, or gap list is re-run **here**, by you, before it is committed — a returned list is not the population. The saving is search traffic, not the final count.
+### Delegated — `🎭` Opus implementer or `🎵` Sonnet subagent
 
-### 🎭 Opus-tier, delegated — dispatch an Opus subagent
+Launch **without `isolation`** (shares the worktree). Subagents run **sequentially**, never in
+parallel. Give a `🎵` subagent `Read, Grep, Glob, Bash, Write, Edit` — NOT `EnterWorktree` /
+`ExitWorktree`. `claude-kit:implementer` declares no `tools:` key and pins `effort: medium`, so the
+`🎭` prompt adds the two lines marked below. If the agent type does not resolve, stop and surface
+that — never quietly implement the item in-session instead. Bound the delegated scope so the item
+stays reviewable in one pass (split budget: `.claude/agents/code-reviewer.md`).
 
-Launch `Agent(subagent_type: "claude-kit:implementer", model: "opus")` **without `isolation`** (shares the orchestrator's worktree), sequentially like the 🎵 branch. If the agent type does not resolve — plugin not installed or not trusted on this machine — **stop and surface that**, as Step 1b does for `claude-kit:critic`. Do not quietly implement the item in-session instead: a silent fallback degrades every 🎭 item back to pre-split behaviour with no signal that routing stopped working.
+> **Prompt template:** "You are implementing item {K} of a plan for the Pastura iOS project.
+> Work inside `{WORKTREE_ROOT}` — treat every path below as rooted there and run git via
+> `git -C {WORKTREE_ROOT}`; run `scripts/xcodebuild.sh` bare from that directory, never behind `cd`,
+> an env-var prefix, or an absolute path; do not rely on inherited cwd. Run `pwd` first and confirm
+> it is `{WORKTREE_ROOT}`.
+> **Read the repo's `CLAUDE.md` first** — follow all its conventions.
+> **Task:** {ITEM_DESCRIPTION}. **Target file(s):** {PRIMARY_FILE_PATH}.
+> **Reference:** {existing similar file to mirror, if any}.
+> Procedure: if implementation, write/adjust the test in `PasturaTests/`, run
+> `scripts/xcodebuild.sh test -only-testing PasturaTests/{TestClass}`, confirm it fails, implement,
+> run again, confirm it passes. If docs-only or test-only, make the change directly. **Do NOT
+> commit** — leave changes unstaged; the orchestrator reviews and commits. If tests still fail after
+> your best effort, return a summary of what you tried and the error output.
+> *(🎭 only)* Do not call `EnterWorktree`, `ExitWorktree`, or `Agent`. End your report with one line:
+> `OUTCOME: done | design-decision | scope-refusal | failed`, and state whether you left modified or
+> new files in the worktree."
 
-Two properties of `claude-kit:implementer` shape the prompt below, and neither is fixable at the call site: it declares **no `tools:` key**, so it inherits `EnterWorktree` / `ExitWorktree` and the exclusion the 🎵 branch gets by construction can only be restated as a soft instruction; and it pins **`effort: medium`** (`Agent` has no `effort` parameter), so a 🎭 item runs at Opus/medium — the accepted trade for moving fully-specified work off the main context. Escalation is the 🎵 fallback's ladder below: a general Opus subagent at session effort.
+**After the subagent returns:**
+1. `git status` — verify expected changes only.
+2. Read `git diff` fully before writing the commit message. Where the item removes or changes a
+   shape, grep the file for the OLD shape — the prompt bounded what was *asked*, not what the item
+   *mandates*.
+3. **Gate:** a convention spot-check suffices — the pre-commit hook enforces the rest.
+4. Commit.
+5. Checkpoint sync (same PATCH as above; skip in degraded mode).
 
-> **Agent prompt template:** the 🎵 template below, with these changes.
->
-> **Keep verbatim** — the `{WORKTREE_ROOT}` rooting sentence, `Read CLAUDE.md first`, the Key-rules block, the TDD procedure, and **"Do NOT commit — leave changes unstaged."** `claude-kit:implementer` carries no commit prohibition of its own; if it commits, the Conventional-Commit message, the per-item commit hazard above, and the checkpoint sync are all bypassed at once.
->
-> **Add** — "Run `pwd` first and confirm it is `{WORKTREE_ROOT}`." Step 2b's residual risk bites hardest on the branch that writes files: `scripts/xcodebuild.sh` resolves `REPO_ROOT` from cwd, so a run that landed in the main checkout returns a green that reads as success.
->
-> **Add** — "Do not call `EnterWorktree`, `ExitWorktree`, or `Agent`."
->
-> **Add** — "End your report with one line: `OUTCOME: done | design-decision | scope-refusal | failed`, and state explicitly whether you left modified or new files in the worktree." The outcomes below carry *opposite* stash instructions, so they must not be inferred from free prose.
+**`🎭` outcomes other than `done`:** `design-decision` — settle it yourself and finish the item
+in-session; keep the partial work (no stash). `scope-refusal` — no partial work exists; re-split the
+item and dispatch the pieces. `failed` — the fallback below.
 
-**Four return outcomes.** Read the report; do not infer success from the absence of an error.
+**Fallback (subagent could not make tests pass):** take over immediately — do not retry the same
+tier. `git stash -u` to save partial work, then escalate **by session model**: `SESSION_MODEL=opus`
+→ orchestrator finishes it in-session; `SESSION_MODEL=sonnet` → delegate to
+`Agent(subagent_type: "claude-kit:implementer", model: "opus")` (no `isolation`) with the item spec +
+the error output; on return, review the diff and commit. If Opus also fails, report and offer
+`/model opus` + retry directly.
 
-1. **Done** (`done`) → the 🎵 post-return flow below: verify `git status`, read the full diff, spot-check, commit, checkpoint.
-2. **Stopped on a design decision the plan did not cover** (`design-decision`) — its standing rule is to report rather than decide. Settle the decision yourself, then finish the item on the 🧠 branch. **Do not `git stash -u`**: the partial work is wanted, and it stopped precisely so as not to guess. If this outcome fires often, Q2's specifiability test is mis-calibrated rather than the agent — say so in the PR body.
-3. **Refused to start on scope** (`scope-refusal`) — its rules decline a change likely to exceed ~800 lines, or one whose report would be very long. **No partial work exists, so there is nothing to stash.** The remedy is to re-split the plan item and dispatch the pieces, not to take it over whole.
-4. **Failed** (`failed`) — tried and could not finish. Take over via the 🎵 fallback below, `git stash -u` included, on its **`SESSION_MODEL=opus` arm**. If the session is still Sonnet (the user declined Step 0's upgrade offer), escalate to the user or to a high-effort general Opus subagent — never re-dispatch `claude-kit:implementer`, which would answer a failed delegation with a second one.
+**After all items,** run full verification from the main session: `scripts/xcodebuild.sh test
+--tail 80` (the wrapper's pipefail-safe cap — no external `| tail`), then `swiftlint lint --quiet
+--strict`. On failure, fix, verify locally, commit with `🐛 fix:`, re-run. **Hard limit: 3
+iterations** — if still failing, report and ask whether to proceed to Step 4.
 
-### 🎵 Sonnet-tier, delegated — dispatch a Sonnet subagent
-
-Launch a subagent via `Agent(model: "sonnet")` **without `isolation`** (shares the orchestrator's worktree). Subagents execute **sequentially, one at a time** — never in parallel. The subagent should have access to: `Read, Grep, Glob, Bash, Write, Edit` — do NOT include `EnterWorktree` or `ExitWorktree`.
-
-Subagent invocation budget is governed by `docs/agent-tooling/subagent-usage.md` — bound delegated items per its soft-budget heuristics.
-
-> **Agent prompt template:**
->
-> "You are implementing item {K} of a plan for the Pastura iOS project.
->
-> Work inside `{WORKTREE_ROOT}` — treat every path in this prompt as rooted there; do not rely on inherited cwd.
->
-> **IMPORTANT: Read `CLAUDE.md` first** — it contains all project conventions you must follow.
->
-> Key rules (also in CLAUDE.md — read it for the full list):
-> - No force unwrap (`!`) — use `guard let`, `if let`, or `?`
-> - All types in Models/, LLM/, Engine/, Data/ MUST be marked `nonisolated` at the type level
-> - Access modifiers: protocol definitions are `public`, types in Models/ are `public`, internal implementation uses default
-> - Dependency rules: {include the relevant subset for the target layer}
-> - Doc comments required on public protocols and types
->
-> **Task:** {ITEM_DESCRIPTION}
-> **Target file(s):** {PRIMARY_FILE_PATH} (and test file if applicable)
-> **Reference:** {path to an existing similar file to follow as pattern, if applicable}
->
-> **Procedure:**
-> - If the task involves implementation changes, follow TDD:
->   1. Write the test first in `PasturaTests/`
->   2. Run the test — confirm it fails (from the repo root; the wrapper supplies scheme / destination / DerivedData internally):
->      ```bash
->      scripts/xcodebuild.sh test -only-testing PasturaTests/{TestClass}
->      ```
->   3. Write the implementation
->   4. Run the test again — confirm it passes (same command)
-> - If the task is documentation-only (doc comments) or test-only (no implementation needed), make the changes directly — skip TDD.
-> - **Do NOT commit** — leave changes unstaged. The orchestrator will review and commit.
->
-> If tests still fail after your best effort, return with a summary of what you tried and the error output."
-
-**`-C {WORKTREE_ROOT}` applies to `git` only** — `scripts/xcodebuild.sh` invocations inside the prompt above must stay a **bare, cwd-relative** command. Reason, per `.claude/rules/xcodebuild-cli.md` § "Canonical invocation": a `cd … &&` prefix, an absolute path, or a leading env-var assignment misses the allowlist entry and stalls the delegated subagent on an approval prompt, and the wrapper has no `-C` — it resolves `REPO_ROOT` internally. **Do not generalize that into a claim about how the matcher works**: the git allowlist entries are equally bare (`Bash(git diff*)`, …), yet `git -C <path> diff` has been observed to run unprompted, so the two are not the same case and only the xcodebuild one is measured.
-
-> **Residual risk this carve-out does not close.** Because the wrapper resolves `REPO_ROOT` from cwd, a subagent whose cwd landed in the main checkout — the very failure the `-C` mandate exists for — builds and tests **that** tree and returns `** TEST SUCCEEDED **` on unrelated code. Unlike the phantom-diff case, this one reads as success. The path-rooting sentence in the prompt is a soft instruction, not a guarantee, so before trusting a delegated green, confirm the subagent worked here: have it report `pwd`, or compare `git -C {WORKTREE_ROOT} status` against what it claims to have changed. The main-session full-suite re-run at the end of Step 3 is the backstop.
-
-**After the Sonnet subagent returns:**
-1. Verify `git status` shows expected changes (no unexpected files).
-2. Read the full diff (`git diff`) to understand the changes before composing the commit message.
-3. Spot-check for convention violations against what the changed file itself governs: for Swift changes, `nonisolated`, access modifiers, dependency imports; for non-Swift changes (docs, rules, scripts, config), the conventions the changed file itself asserts. Where the item introduces or changes a rule, grep the whole file for the OLD shape before committing — the prompt's acceptance conditions bound what the subagent was *asked*, not what the item *mandates* (docs/agent-tooling/knowledge-layering.md § "Scope & Completeness Discipline"). #1453's own item 2 is the worked example: a delegated item satisfied all five of its acceptance conditions and still left one instance of the shape it was removing.
-4. Commit (Conventional Commits + emoji per CLAUDE.md) — the commit-time gate is the pre-commit hook, not a per-commit approval prompt.
-5. Sync checkpoint to GitHub Issue (same `gh api` PATCH as the 🧠 flow above; skip in degraded mode).
-
-**Fallback:** If the Sonnet subagent reports test failure (could not make tests pass), **take over immediately** — do not retry with Sonnet. Read the Sonnet error output to understand what was attempted, then:
-1. Run `git stash -u` to save all of Sonnet's partial work including untracked new files (recoverable via `git stash pop` if needed later), giving the recovery a clean start.
-2. **Escalate by session model:**
-   - `SESSION_MODEL=opus` → the orchestrator completes the item directly using the **🧠 in-session flow** — *not* the 🎭 branch, which since the tier/locus split dispatches another subagent and would answer a failed delegation with a second one.
-   - `SESSION_MODEL=sonnet` → the orchestrator is itself Sonnet, so it must **not** implement judgment-heavy recovery. Delegate to `Agent(subagent_type: "claude-kit:implementer", model: "opus")` **without `isolation`** (shares the worktree), passing the item spec, the Sonnet subagent's error output, **and the same `{WORKTREE_ROOT}` rooting the 🎵 prompt carries** — this is the subagent that writes files, so an inherited cwd landing in the main checkout is the worst case, not the mildest. On return, the orchestrator reviews the diff and commits (same as the 🎵 post-return flow above). If the Opus implementer also fails, report to the user and offer to switch the session to Opus (`/model opus`) and retry directly. (`claude-kit:implementer` pins `effort: medium`; if recovery underperforms, note it and escalate to a high-effort general Opus subagent.)
-
-Note: `git commit` is allowlisted (since #411); the commit-time gate is the git pre-commit hook (`swiftlint --strict` + build + blocklist/gallery gates per CLAUDE.md), which runs on every commit — not a per-commit approval prompt.
-
-After all implementation, run full verification directly from the main session:
-
-1. Run the full test suite:
-   ```bash
-   scripts/xcodebuild.sh test --tail 80
-   ```
-   `--tail 80` is the wrapper's pipefail-safe output cap — do NOT use external `| tail`, which
-   masks failed builds as exit 0 (see `.claude/rules/xcodebuild-cli.md`). If failures need more
-   detail, re-run with `-only-testing PasturaTests/<FailingTestClass>` for the specific class (no `--tail`).
-
-2. Handle the result:
-   - **PASS** (`** TEST SUCCEEDED **`) → run `swiftlint lint --quiet --strict` directly. Fix any lint issues before proceeding.
-   - **FAIL** (`** TEST FAILED **`) → fix the failing tests, verify the fix passes targeted tests locally, then commit with `🐛 fix:` prefix (no checkpoint sync needed — these are not plan items) and re-run the full suite.
-   - **Hard limit: 3 iterations.** If still failing after 3, report remaining failures to the user and ask whether to proceed to Step 4.
-
-> **Carve-out — build-irrelevant branches:** the skip predicate is not a judgement call — it is
-> `scripts/precommit-gate-classify.sh`, whose header doc-comment is its authoritative account (per
-> CLAUDE.md); read that before relying on this. Feed it the **branch's** changed paths, not just the
-> last commit's — the script reads whatever set it's given:
+> **Carve-out — build-irrelevant branches:** the skip predicate is mechanical:
 > `git -C {WORKTREE_ROOT} diff --name-only {DEFAULT_BRANCH}...HEAD | scripts/precommit-gate-classify.sh`
-> (cwd-relative, and unlike the wrapper **not** allowlisted — expect one approval prompt). No `build`
-> token in its output means every changed path matched its build-irrelevant denylist, so the app
-> target is never compiled and the suite cannot be affected — skip step 1 entirely; no `lint` token
-> means the same for step 2's `swiftlint lint --quiet --strict`. **CI is not a backstop here** — easy
-> to assume otherwise, and not in the script header: `.github/workflows/ci.yml` reuses this same
-> script for its PR path-gating, so a build-irrelevant PR skips `lint-and-test` and `ui-test` on CI
-> too. What does cover the post-merge state is that a push to `{DEFAULT_BRANCH}` runs the full iOS
-> suite regardless of paths (`ci.yml` short-circuits every non-`pull_request` event to `ios=true`) —
-> that lives in the workflow, not the script header. When skipping, state the one-line reason in the
-> PR body (Step 5).
+> (expect one approval prompt). No `build` token ⇒ skip the suite; no `lint` token ⇒ skip SwiftLint.
+> CI's PR path-gating reuses the same script, so it is not a backstop — state the skip in the PR body.
 
 ## Step 4: Review — Gate G3
 
-**Before launching the reviewer,** `git fetch origin {DEFAULT_BRANCH}` and check `git rev-list --count HEAD..origin/{DEFAULT_BRANCH}` — a long session (research → critic → multi-commit implementation) can span hours during which `{DEFAULT_BRANCH}` advances. If the count is non-zero, offer a rebase before review; **mandatory** when the diff touches large generated / data files (xcstrings, lockfiles), where a rebase or non-conflicting auto-merge can drop upstream entries without surfacing a conflict.
+**Before launching the reviewer,** `git fetch origin {DEFAULT_BRANCH}` and check `git rev-list --count
+HEAD..origin/{DEFAULT_BRANCH}`. If non-zero, offer a rebase before review; treat it as **mandatory**
+when the diff touches large generated / data files (`Localizable.xcstrings`, lockfiles), where a
+rebase or non-conflicting auto-merge can drop upstream entries without surfacing a conflict.
 
-Launch a `code-reviewer` subagent via the Agent tool to review all changes on the feature branch. Pass `model: $REVIEWER_MODEL` (resolved from the plan's `## Metadata` — via Step 0 on resumption, or via Step 1 on a fresh run; defaults to Opus if absent). The Agent tool's `model` parameter takes precedence over the agent frontmatter's `model: opus`. The agent's checklist carries a Pastura-specific trap cheat sheet to keep the Sonnet-reviewer path safe. The reviewer **MUST emit** a `**Verdict**: PASS | FAIL` line — the review-verify-fix loop below parses it, and a reviewer that omits it breaks the gate.
+Launch `Agent(subagent_type: "code-reviewer", model: "$REVIEWER_MODEL", …)` (lowercase
+`opus`/`sonnet`, from Metadata; defaults Opus). The reviewer MUST emit a `**Verdict**: PASS | FAIL`
+line — the gate below parses it. Its scope budget counts **added** lines; if it returns
+`SCOPE_TOO_LARGE`, split by added lines (per area or per axis) — never downgrade `REVIEWER_MODEL`
+to fit a diff.
 
-```
-Agent(subagent_type: "code-reviewer", model: "$REVIEWER_MODEL", description: "...", prompt: "...")
-```
+> **Prompt:** "Review all changes on this feature branch. Run **`git -C {WORKTREE_ROOT} diff
+> {DEFAULT_BRANCH}...HEAD`** for the full diff (all commits since branching) — use the `-C` path, do
+> not rely on cwd; a bare `git` can resolve to the original checkout and show an empty phantom diff.
+> Read every changed file in full. Evaluate against your complete checklist. Output your review in
+> your standard format, including a `**Verdict**: PASS | FAIL` line."
 
-`$REVIEWER_MODEL` is the lowercase form (`opus` / `sonnet`) bound at Step 0 / Step 1 — the surrounding quotes match the Step 3 Sonnet-delegation convention (`Agent(model: "sonnet")`).
-
-Subagent invocation budget is governed by `docs/agent-tooling/subagent-usage.md` — large PR diffs may need splitting (per axis or per area) to avoid `SCOPE_TOO_LARGE` early returns from the reviewer. **Splitting is the only remedy** — a cheaper model buys no headroom (§3 there), so never downgrade `REVIEWER_MODEL` to fit a diff.
-
-> **Agent prompt:** "Review all code changes on this feature branch. Run **`git -C {WORKTREE_ROOT} diff {DEFAULT_BRANCH}...HEAD`** for the full diff (all commits since branching, not just uncommitted changes) — use the `-C` path, not cwd; a bare `git` can resolve to the original checkout and show an empty phantom diff. Read every changed file in full for context. Evaluate against your complete checklist (Hard Rules, Dependency Rules, Access Modifiers, Swift 6 Concurrency, Code Quality). Output your review in your standard format."
-
-**Review-verify-fix loop:**
-1. If the code-reviewer returns **PASS** → proceed directly to Step 5 (PR creation).
-2. If the code-reviewer returns **FAIL**:
-   a. Launch 1 read-only verification agent to check each FAIL item for false positives (e.g., test code flagged for force unwrap, which is exempt). Root its prompt at `{WORKTREE_ROOT}` and give it `git -C {WORKTREE_ROOT}` like any other subagent — Step 2b's mandate binds ad-hoc prompts too, not just the templated ones.
-   b. Build the **Review Action Summary** (see below) and present it to the user.
-   c. Capture `FIX_BASE=$(git rev-parse HEAD)`, then fix all confirmed issues. Skip false positives.
-   d. Re-run the `code-reviewer` subagent **scoped to the fix diff**: prompt it with `git -C {WORKTREE_ROOT} diff {FIX_BASE}...HEAD` (the fix commits only — same `-C` rule as the first-pass prompt) plus the prior FAIL items, instructing it to verify each fix and its immediate blast radius — NOT to re-review the full branch. Fall back to a full-branch re-review only when the fixes touched files outside the set reviewed in the previous iteration.
-3. Hard limit: **3 iterations**. If still FAIL after 3, report remaining issues to the user.
-
-**Review Action Summary** (displayed after each iteration):
-```
-## Review Iteration N
-
-| # | Issue | Severity | Verification | Action | Reason |
-|---|-------|----------|-------------|--------|--------|
-| 1 | No doc comment on `FooProtocol` | Critical | Confirmed | Fixed | Added doc comment |
-| 2 | Force unwrap in line 42 | Critical | False positive | Skipped | Test file (exempt) |
-| 3 | Missing Sendable on `Bar` | Warning | Confirmed | Fixed | Added Sendable conformance |
-```
-
-Show the final review report, then proceed to Step 5 (PR creation).
+**One round.** The review is input to the orchestrator's judgment, not a loop:
+1. **PASS** → Step 5.
+2. **FAIL** → triage every finding **in the main session** — no verification subagent. For each:
+   *apply*, or *reject with a one-line reason* (false positive, out of scope, or a disagreement you
+   will stand behind in the PR). Capture `FIX_BASE=$(git rev-parse HEAD)`, apply the accepted
+   findings, commit `🐛 fix:`.
+3. **Re-review at most once, and only the fix diff** (`git -C {WORKTREE_ROOT} diff
+   {FIX_BASE}...HEAD` plus the prior findings) — and only when a fix introduced new logic rather
+   than applying the reviewer's own suggestion. Findings from that pass are triaged the same way;
+   there is no third round.
+4. Every rejected or unfixed finding goes into the PR body's `## Review` section (Step 5). A
+   residual Critical the user should weigh is stated there, not silently dropped.
 
 ## Step 5: PR Creation
 
-**Degraded mode:** skip PR creation entirely — report that the branch is ready to push / PR manually, and stop.
+Degraded mode: skip — report the branch is ready to push/PR manually, stop.
 
-Derive base branch: `gh repo view --json defaultBranchRef -q '.defaultBranchRef.name'`
+Base branch: `gh repo view --json defaultBranchRef -q '.defaultBranchRef.name'`. Label from the
+dominant commit prefix (`feat→enhancement`, `fix→bug`, `docs→documentation`, `refactor→refactor`,
+`test→testing`, `chore→chore`, `ci→ci`, `perf→performance`); add `security` if security-related.
+**If the label doesn't exist in the repo, drop it** (same fallback as Step 2a).
 
-Determine label from the commit prefix (TASK_TYPE or dominant commit type):
+Present the PR draft (informational; created automatically, no gate):
+- Title: emoji prefix + Conventional format, < 70 chars.
+- Body: `## Summary`, `## Test plan` (name any skipped suite and why), `## Review` (reviewer model;
+  findings applied / rejected with reasons), `## Device QA`, and the issue link (omit in degraded
+  mode). Use `Closes #N` **only when this PR completes the issue**; for a non-final PR of a
+  multi-PR / umbrella issue, use `Part of #N`.
+- `## Device QA` — on-device steps are required when the diff touches a surface the simulator cannot
+  exercise: `#if !targetEnvironment(simulator)` blocks (enumerate with `git grep`), Metal / llama.cpp
+  inference paths (`LlamaCppService`, GGUF load), or a Pattern-6 executor freeze
+  (`.claude/rules/swift-isolation.md`). List the concrete steps; otherwise a single `実機QA不要` line
+  with the one-line reason.
 
-| Commit prefix | Label |
-|---------------|-------|
-| `feat` | `enhancement` |
-| `fix` | `bug` |
-| `docs` | `documentation` |
-| `refactor` | `refactor` |
-| `test` | `testing` |
-| `chore` | `chore` |
-| `ci` | `ci` |
-| `perf` | `performance` |
-
-Additionally, if the changes are security-related, add the `security` label alongside the prefix-based label.
-
-**Determine device-QA need.** Manual on-device QA is required when the diff touches a surface the iOS Simulator build cannot exercise:
-- `#if !targetEnvironment(simulator)` blocks (enumerate them — `git grep -n '#if !targetEnvironment(simulator)'` — rather than recalling filenames) — excluded from the simulator build entirely.
-- Metal / llama.cpp on-device inference (`LlamaCppService`, GGUF model load, GPU paths).
-- Layout / visual regressions inside those device-only blocks (the simulator never renders them).
-- Pattern-6 executor-inheritance UI freezes (`.claude/rules/swift-isolation.md`) — reproduce only on a real device.
-
-Config / docs / shell / test-only changes with no such surface do **not** need device QA.
-
-Present the PR draft (title + body + label) for visibility — this is informational; the PR is created automatically, with no confirmation gate:
-- Title: Emoji prefix + Conventional format, under 70 chars (same emoji convention as CLAUDE.md commits)
-- Body: Summary bullets + test plan + a `## Device QA` section + an issue reference (omit the issue reference in degraded mode — there is no issue). Use `Closes #N` only when this PR completes the issue; for a non-final PR of a multi-PR or umbrella issue, use `Part of #N` instead so merging it does not prematurely auto-close the issue (see CLAUDE.md § "Git Conventions" → "Closing issues in multi-PR splits"). The `## Device QA` section lists the concrete on-device steps a reviewer must run, or a single `実機QA不要` line with the one-line reason when none apply.
-- Label: from the table above
-
-Push the branch first as its **own** Bash tool call: `git push -u origin <branch>`. Then create the PR as a **separate** call — never combine the two with `&&`, or the `gh pr create --base`-gated PreToolUse (`check-claude-md`) and PostToolUse (`pr-created-reflection`) hooks won't fire (their prefix gate is anchored at position 0, so a leading `git push` breaks the match):
-
+Compose the body in a file and pass `--body-file` (an inline heredoc trips the push-protection hook's
+body scan). **Push and create as two separate Bash calls** — never combine with `&&` (a leading
+`git push` breaks the `gh pr create --base`-anchored PR hooks):
 ```bash
-gh pr create --base "$BASE_BRANCH" --assignee "@me" --label "$LABEL" \
-  --title "..." --body "$(cat <<'IMPLEMENT_PR_BODY'
-## Summary
-...
-## Test plan
-...
-## Device QA
-<concrete on-device steps, or `実機QA不要` + one-line reason>
-IMPLEMENT_PR_BODY
-)"
+git push -u origin <branch>
 ```
-
-**Label fallback:** same as Step 2a — if `--label "$LABEL"` fails, retry without it rather than blocking PR creation.
-
-After creation:
-- Print the PR URL.
-- "Wait for all required status checks to pass, then **merge manually**."
+```bash
+gh pr create --base "$BASE_BRANCH" --assignee "@me" [--label "$LABEL"] --title "..." --body-file <path>
+```
+After creation: print the PR URL; "wait for required checks, then merge manually."
 
 ## Step 6: Cleanup
 
-**After merge** (guidance only — do NOT auto-execute):
-1. `ExitWorktree` with action `"remove"`
-2. `git switch <default-branch> && git pull`
+**After merge** (guidance only — do NOT auto-execute): `ExitWorktree` action `"remove"`;
+`git switch <default-branch> && git pull`.
 
-> **Post-merge `remove` may refuse:** squash / rebase merge gives the merged commit a **new SHA**, so the worktree's local commits read as unmerged by ancestry and `ExitWorktree(action: "remove")` refuses — as it also can *before* the post-merge `pull`, when local `main` doesn't yet contain the merge. Once the user confirms the merge landed, re-invoke with `discard_changes: true`. (Pastura defaults to squash, so a post-merge `remove` refuses by default.)
+> **Post-merge `remove` may refuse:** Pastura squash-merges, so the merged commit has a **new SHA** and
+> the worktree's local commits read as unmerged by ancestry — `ExitWorktree(action: "remove")`
+> refuses, as it also can *before* the post-merge `pull`. Once the user confirms the merge landed,
+> re-invoke with `discard_changes: true`.

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -43,7 +43,7 @@ changes, a diff spot-check suffices before committing; the hook is the gate.
 
 Interpret `$ARGUMENTS`:
 - **`#N`**: Fetch issue via `gh issue view N`, use title/body as task spec. Check for an existing
-  plan (Resumption Detection below).
+  plan (Resumption Detection below). Unauthenticated ⇒ ask the user for the spec inline.
 - **`phase N`**: Read ONLY that Phase section of `docs/ROADMAP.md`.
 - **(empty)**: Ask what to implement.
 - **Other text**: Use as inline task description.
@@ -64,9 +64,9 @@ sanitize or ask if it doesn't match).
    `opus`/`sonnet`; default `opus` if a field is absent). Derive `SLUG` from the branch.
    - **Coupling re-check:** if the resumed plan has any Opus-tier item (`🎭` or `🧠`) but
      `REVIEWER_MODEL=sonnet` or `SESSION_MODEL=sonnet`, warn and offer to upgrade to Opus before
-     continuing. If it is all Sonnet-tier with `REVIEWER_MODEL=sonnet`, re-confirm each item is
-     strictly within the 🎵 simple criteria — a `🎵 (tb)` item is not, and the label alone does not
-     establish it (Step 1.3) — and offer the same upgrade.
+     continuing. If it is all Sonnet-tier with `REVIEWER_MODEL=sonnet`, grep the comment for
+     `🎵 (tb)` — a deferred item is not strictly simple (Step 1.3) — and on any hit offer the Opus
+     reviewer upgrade. Do not re-derive the classification: a resumed session lacks the context.
    - If **all items checked**: do **not** silently proceed to review. A fully-checked *last* plan
      usually means its PR already merged — and on an **umbrella issue** that accumulates several
      historical plan comments, `tail -1` lands on that finished plan, so auto-proceeding re-reviews
@@ -197,7 +197,7 @@ rather than skipping silently.
   ```
   Title-case model names in Metadata; Step 0 normalizes on read.
 - **Otherwise (new task):** create an issue (`gh issue create --title "{EMOJI} {TASK_TYPE}: {TITLE}"
-  --assignee "@me" [--label "$LABEL"] --body …`), extract `ISSUE_NUMBER`, then post the plan as the
+  --assignee "@me" [--label "$LABEL"] --body …`; label mapping in Step 5), extract `ISSUE_NUMBER`, then post the plan as the
   first comment (capture `COMMENT_ID`). **Label fallback:** if `--label` fails (label absent in the
   repo), retry without it (or offer to create the label) — never block on a missing label.
 
@@ -212,7 +212,8 @@ rather than skipping silently.
      "Create worktree and start?"**
   3. `EnterWorktree` with `name: "{TASK_TYPE}/{SLUG}"` (on collision, check `git ls-remote --heads
      origin <branch>`, append `-2`).
-  4. Rename to conventional format: `git branch -m "$(git branch --show-current)" "{TASK_TYPE}/{SLUG}"`.
+  4. Rename to conventional format — `EnterWorktree` sanitizes `/` to `+` and prepends `worktree-`:
+     `git branch -m "$(git branch --show-current)" "{TASK_TYPE}/{SLUG}"`.
   5. Verify: `git branch --show-current`.
 
 **Worktree path hygiene** (holds for the rest of the session): the original checkout stays on another

--- a/docs/agent-tooling/orchestrate-kit-reconciliation.md
+++ b/docs/agent-tooling/orchestrate-kit-reconciliation.md
@@ -46,7 +46,9 @@ undo. The entries below are the ones a plausible-sounding back-port *would* undo
    Opus. This diverges from a deliberate upstream design (kit#19/#23), not a defect; if the
    template ever adopts a split, reconcile against it rather than deleting. The template has no
    `(tb)` marker, so adopting its Step 1 wording disarms the two gates that consume it (Step 1.3's
-   strictly-simple reviewer test and Step 0's all-Sonnet-tier re-check).
+   strictly-simple reviewer test and Step 0's all-Sonnet-tier re-check). Reject any back-port that
+   adds a blanket "when in doubt, go up a tier": Claude 5 applies it literally and it cancels the
+   `Session: Sonnet` lever (kit#19).
 
    Two accepted consequences: `claude-kit:implementer` pins `effort: medium`, so a `🎭` item runs
    at Opus/medium (escalate to a general Opus subagent if fix rounds rise); and `🎵 (main)` keeps
@@ -59,13 +61,14 @@ undo. The entries below are the ones a plausible-sounding back-port *would* undo
    the `🧠` share is still ≥ 80% and implementer calls ≈ 0, revert Step 1.2 to the template's
    two-icon label by deleting the table — add no prose.
 
-   **Break-even.** A delegation's fixed cost is ≈ 52k tokens (2026-08-21: one-turn, zero-tool Haiku
-   subagent, harness included; measured before #1520 cut always-loaded 91 → 29 KB, so re-measure).
-   An in-session item instead leaves its tool output `X` in the main context, re-read from cache on
-   every later turn. At ~10% cache-read pricing and ~20 remaining turns, in-session costs ≈ 3X and
-   delegation ≈ 52k + X, so delegation is cheaper in tokens only when X ≳ 25k — about three or four
-   mid-size Swift files read plus a test run. Below that, `🎵 (main)` / `🧠` is cheaper; what
-   delegation buys there is peak-context headroom, not dollars.
+   **Break-even.** A delegation's fixed cost was ≈ 52k tokens on 2026-08-21 (one-turn, zero-tool
+   Haiku subagent, harness included), measured before #1520 cut always-loaded 91 → 29 KB — about
+   16k tokens less, so ≈ 36k until re-measured. An in-session item instead leaves its tool output
+   `X` in the main context, re-read from cache on every later turn. At ~10% cache-read pricing and
+   ~20 remaining turns, in-session costs ≈ 3X and delegation ≈ fixed + X, so delegation is cheaper
+   in tokens only when X ≳ 18–26k — roughly ten mid-size Swift files read (p75 ≈ 9 KB each), or an
+   untailed full test log. Below that, `🎵 (main)` / `🧠` is cheaper; what delegation buys there is
+   peak-context headroom, not dollars.
 
 ### Corrections — delete the entry once upstream lands
 

--- a/docs/agent-tooling/orchestrate-kit-reconciliation.md
+++ b/docs/agent-tooling/orchestrate-kit-reconciliation.md
@@ -1,105 +1,79 @@
 # `/orchestrate` ↔ claude-kit template — reconciliation ledger
 
 Paired with the `generated-from:` stamp at the top of
-[`.claude/skills/orchestrate/SKILL.md`](../../.claude/skills/orchestrate/SKILL.md). The skill keeps
-the stamp and a short pointer; the enumeration lives here so it is not paid on every `/orchestrate`
-invocation (`docs/agent-tooling/context-budget.md`). It fires at one moment: when
-`/claude-kit:orchestrate-creator` proposes a back-port.
+[`.claude/skills/orchestrate/SKILL.md`](../../.claude/skills/orchestrate/SKILL.md). It is read at one
+moment: when `/claude-kit:orchestrate-creator` proposes a back-port.
 
 ## Why the stamp exists
 
-Pastura's `/orchestrate` predates `/claude-kit:orchestrate-creator` and was never generated from its
-template. Without a stamp, Step U-1 classifies the file as hand-written and only reports, so no
-template improvement can ever reach it — which is why the routing redesign (kit#19/#23) sat
-unapplied for a generation: kit leaves *suboptimal-but-not-wrong* changes to ride along on a
-project's next upgrade run, and Pastura's never fired. The stamp records the template revision the
-content was last *reconciled* with — a reconcile, not a generation — so a re-run reaches Step U-3's
-principle-level proposals. Background: #1453.
-
-Two consequences. **Step U-4 rewrites the stamp line on every upgrade**, so nothing that must
-survive can live in it. And Step U compares hashes first, so its "up to date" means *no template
-change since the reconcile* — **not** that this file matches the template. It deliberately does not.
+Pastura's `/orchestrate` predates the creator and was never generated from its template. Without a
+stamp, Step U-1 classifies the file as hand-written and only reports, so no template improvement
+could reach it. The stamp records the template revision the content was last *reconciled* with.
+**Step U-4 rewrites the stamp line on every upgrade**, so nothing durable lives in it; and Step U
+compares hashes first, so its "up to date" means *no template change since the reconcile* — not that
+the file matches the template. It deliberately does not.
 
 ## The ledger
 
-**Hand-maintained, and nothing prompts an author to append to it** — no hook fires on
-`.claude/skills/orchestrate/SKILL.md`, no `/consistency-audit` detector reads the stamp, no test
-asserts these entries. An entry may also be stale: a *correction* goes false the moment upstream
-fixes the defect. So judge a back-port proposal on its merits; this list's silence is not evidence
-that a change is safe.
-
-Most divergences are **additions**, which an upgrade proposal cannot silently undo. The entries
-below are the ones a plausible-sounding back-port *would* undo.
+Hand-maintained; no hook or audit reads it, so judge a back-port on its merits — silence here is not
+evidence that a change is safe. Most divergences are additions, which a proposal cannot silently
+undo. The entries below are the ones a plausible-sounding back-port *would* undo.
 
 ### Adaptations — stable, no retirement condition
 
-1. **Step 1.3's "do not add a blanket 'when in doubt, go up a tier'" guardrail is not in the
-   template's Step 1.** Being a *negative* instruction, nothing around it looks wrong once it is
-   gone — and it is the direct fix for the defect this file was reconciled to repair. Reject any
-   proposal to adopt the template's Step 1 wording that drops it.
-2. **The Step 4 reviewer prompt omits the template's selective `.claude/rules/*.md` read.**
-   `.claude/agents/code-reviewer.md`'s Review Process step 3 owns that logic here — do not add it in
-   both places. But if that agent ever loses it, this prompt must gain it, or path-scoped review
-   coverage vanishes silently.
-3. **The Step 3 🎵 prompt roots paths at `{WORKTREE_ROOT}` without adopting the template's "run
-   tests/git via `-C {WORKTREE_ROOT}` (or `cd` there first)".** `-C` is git-only;
-   `scripts/xcodebuild.sh` must stay a bare cwd-relative call, or the delegated subagent stalls on
-   an approval prompt (`.claude/rules/xcodebuild-cli.md` § "Canonical invocation"). The template's
-   stronger-sounding wording would reintroduce that stall. Reasoning is inline in the skill next to
-   the 🎵 prompt.
-4. **The template's inlined subagent output-cap / split-budget note is omitted, and its "Project
-   parameters (baked at generation)" table has no counterpart.** the split budget already lives in
-   `.claude/agents/code-reviewer.md` (kept in sync with `docs/agent-tooling/subagent-usage.md` §2),
-   so inlining it here would be a third copy to keep in sync; and
-   this file's parameters are inline at each step and richer than the table's cells.
-5. **Step 1.3 routes on two independent axes — *tier* (`🎵` Sonnet / `🎭` `🧠` Opus) and *locus*
-   (`🎵` `🎵 (tb)` `🎭` delegated / `🎵 (main)` `🧠` in the main session) — where the template keeps
-   one two-icon label whose `🎭` decides both at once.** Step 3 gains a `🎭` branch dispatching
-   `claude-kit:implementer` at Opus, and Step 2a emits `Routing: v2` so Step 0 reads a pre-split
-   plan comment under its original semantics. This diverges from a **deliberate** upstream design
-   (kit#19/#23, live in the template today), not a defect — so it stays out of Corrections and no
-   upstream fix retires it; if the template ever adopts a tier/locus split, reconcile against it
-   rather than deleting. The template carries no `(tb)` marker at all, so a back-port adopting its
-   Step 1 wording drops `(tb)` and silently disarms the two gates that consume it — Step 1.4's
-   strictly-simple reviewer test and Step 0's all-Sonnet-tier resumption re-check.
+1. **The Step 4 reviewer prompt omits the template's selective `.claude/rules/*.md` read.**
+   `.claude/agents/code-reviewer.md` Review Process step 3 owns that logic here — do not add it in
+   both places. If that agent ever loses it, this prompt must gain it, or path-scoped review coverage
+   vanishes silently.
+2. **The Step 3 prompt roots paths at `{WORKTREE_ROOT}` but does not adopt the template's "run
+   tests/git via `-C {WORKTREE_ROOT}` (or `cd` there first)".** `-C` is git-only; a `cd` prefix
+   takes `scripts/xcodebuild.sh` off the allowlist and stalls the subagent on an approval prompt
+   (`.claude/rules/xcodebuild-cli.md`).
+3. **The template's inlined subagent output-cap / split-budget note is omitted.** The budget lives
+   in `.claude/agents/code-reviewer.md` (mirrored from `docs/agent-tooling/subagent-usage.md` §2),
+   and Pastura's counts **added** lines where the template counts changed lines — adopting the
+   template's note would reintroduce changed-line counting and re-shard deletion-heavy PRs.
+4. **Step 4 is one review round, not the template's review-verify-fix loop** (verify agent + scoped
+   re-review × 3). Reviewer → main-session triage → one fix → at most one fix-diff re-review; no
+   verification subagent; rejected findings go to the PR body's `## Review`. Decided in #1519: a
+   round ≥ 2 on self-authored prose attacks the previous round's fix prose at ~100k tokens a round.
+   A back-port of the template's Step 4 reinstates the loop.
+5. **Step 5 passes the PR body with `--body-file`, never the template's inline heredoc** — the
+   push-protection hook's body scan trips on an inline heredoc (CLAUDE.md § Git Conventions).
+6. **Step 1 routes on two axes — *tier* (`🎵` Sonnet / `🎭` `🧠` Opus) and *locus* (`🎵`
+   `🎵 (tb)` `🎭` delegated / `🎵 (main)` `🧠` in-session) — where the template's one two-icon
+   label decides both at once.** Step 3 gains a `🎭` branch dispatching `claude-kit:implementer` at
+   Opus. This diverges from a deliberate upstream design (kit#19/#23), not a defect; if the
+   template ever adopts a split, reconcile against it rather than deleting. The template has no
+   `(tb)` marker, so adopting its Step 1 wording disarms the two gates that consume it (Step 1.3's
+   strictly-simple reviewer test and Step 0's all-Sonnet-tier re-check).
 
-   Motivating baseline: of 250 plan items across the 52 `<!-- pastura-plan -->` comments in the
-   then-last 70 issues, 221 (88%) were `🎭`, 37 of 52 plans were 100% `🎭`, and `Session: Opus`
-   held 57 of 57 — the all-🎵 cost lever had never fired. Re-derive rather than trust it: for each
-   recent issue, `gh api repos/tyabu12/pastura/issues/<N>/comments --jq '.[].body'`, keep the
-   bodies containing the plan marker, then count `- [ ]` / `- [x]` item lines per icon (count each
-   icon with its own `grep -o -F` — an alternation over these emoji miscounts).
+   Two accepted consequences: `claude-kit:implementer` pins `effort: medium`, so a `🎭` item runs
+   at Opus/medium (escalate to a general Opus subagent if fix rounds rise); and `🎵 (main)` keeps
+   its Sonnet tier where the template promotes in-session work to `🎭`.
 
-   **That 88% is retired, not a comparand**: `🎭` now means *delegated*, so an unchanged 88% would
-   mean everything is delegated — complete success. What tracks the defect is the `🧠` share (work
-   still pinned to the main session), the delegated share (`🎭` + `🎵` + `🎵 (tb)`), and the
-   `claude-kit:implementer` invocation count, which was ~0 before.
+   **Sunset clause.** The split exists to move work off the main context; before it, 88% of plan
+   items were in-session. After ~10 `/orchestrate` runs from 2026-08-21, count labels across those
+   plan comments (`gh api repos/tyabu12/pastura/issues/<N>/comments --jq '.[].body'`, keep bodies
+   with the plan marker, `grep -o -F` per icon) and `claude-kit:implementer` invocations (OTel). If
+   the `🧠` share is still ≥ 80% and implementer calls ≈ 0, revert Step 1.2 to the template's
+   two-icon label by deleting the table — add no prose.
 
-   Two accepted consequences. `claude-kit:implementer` pins `effort: medium` and `Agent` has no
-   `effort` parameter, so a `🎭` item runs at Opus/medium where the template's in-session `🎭` ran
-   at the session's Opus/high — accepted because Step 1.3's Q2 already requires the item to be
-   fully specifiable, the condition that agent is built for; if fix rounds rise, escalate to a
-   general Opus subagent at session effort (the ladder the `🎵` fallback documents) or bump the
-   pin. And `🎵 (main)` — Sonnet-tier work not worth a delegation prompt — **keeps its Sonnet
-   tier**, where the template promotes it to `🎭` and so forces an Opus reviewer and session.
-   Pastura's own pre-split Step 1.3 — reconciled from that wording — spelled the promotion's reason
-   out as "intended since the orchestrator implements the item directly": a locus-based
-   justification for a tier decision, the same conflation in miniature. The template states the
-   promotion without that clause, so the reason is Pastura's, not upstream's; do not re-attribute
-   it. Template claims here were checked against `skills/orchestrate-creator/` at kit 0.4.7 — the
-   promotion is at `orchestrate-template.md` "Also promote a 🎵 to 🎭 when subagent + verify
-   overhead exceeds the work itself", and `(tb)` appears zero times in that directory.
+   **Break-even.** A delegation's fixed cost is ≈ 52k tokens (2026-08-21: one-turn, zero-tool Haiku
+   subagent, harness included; measured before #1520 cut always-loaded 91 → 29 KB, so re-measure).
+   An in-session item instead leaves its tool output `X` in the main context, re-read from cache on
+   every later turn. At ~10% cache-read pricing and ~20 remaining turns, in-session costs ≈ 3X and
+   delegation ≈ 52k + X, so delegation is cheaper in tokens only when X ≳ 25k — about three or four
+   mid-size Swift files read plus a test run. Below that, `🎵 (main)` / `🧠` is cheaper; what
+   delegation buys there is peak-context headroom, not dollars.
 
 ### Corrections — delete the entry once upstream lands
 
-A template *defect* is reported upstream; its entry names the tracking issue and dies with it.
-
-6. **Pre-flight check 3's degraded-mode `DEFAULT_BRANCH` fallback deliberately differs from the
-   template's.** The template's `git symbolic-ref refs/remotes/origin/HEAD` yields a full ref, not a
-   branch name, which breaks the `git fetch`, `git rev-list`, `git pull`, and `git switch` that
-   consume it (the shapes are spelled out inline at that check). Do not adopt the template's shorter
-   form. **Upstream: [claude-kit#34](https://github.com/tyabu12/claude-kit/issues/34) — delete this
-   entry once that lands and the template is re-reconciled.**
+7. **Pre-flight check 3's degraded-mode `DEFAULT_BRANCH` fallback differs from the template's.**
+   The template's `git symbolic-ref refs/remotes/origin/HEAD` yields a full ref, which breaks the
+   `git fetch` / `rev-list` / `pull` / `switch` that consume it. **Upstream:
+   [claude-kit#34](https://github.com/tyabu12/claude-kit/issues/34) — delete this entry once it
+   lands and the template is re-reconciled.**
 
 ## Known gaps, tracked elsewhere
 

--- a/docs/agent-tooling/orchestrate-traps.md
+++ b/docs/agent-tooling/orchestrate-traps.md
@@ -1,0 +1,70 @@
+# `/orchestrate` — traps behind the short wording
+
+On-demand companion to [`.claude/skills/orchestrate/SKILL.md`](../../.claude/skills/orchestrate/SKILL.md).
+The skill states each rule once; this file keeps the mechanism, so the rule can be re-derived when it
+looks removable. Nothing here is loaded per invocation.
+
+## Worktree and cwd
+
+- **Non-isolation subagents do not reliably inherit the worktree cwd.** A reviewer whose bare `git`
+  resolved to the main checkout returned an empty diff, which reads as a false FAIL. Hence
+  `git -C {WORKTREE_ROOT}` in every subagent prompt, captured once — never a `$(…)` the subagent
+  re-runs.
+- **The same failure reads as success for the implementer.** `scripts/xcodebuild.sh` resolves its
+  repo root from cwd, so a run that landed in the main checkout builds and tests *that* tree and
+  prints `** TEST SUCCEEDED **` for unrelated code. The path-rooting sentence in the prompt is a soft
+  instruction, so the prompt also asks for `pwd`; the main-session full-suite run at the end of
+  Step 3 is the backstop.
+- **`-C` is git-only.** The wrapper has no `-C`, and the allowlist entry for it is an exact-prefix
+  literal: a `cd … &&` prefix, an absolute path, or a leading env-var assignment raises an approval
+  prompt that stalls an unattended subagent. The git allowlist entries are equally bare, yet
+  `git -C <path> diff` has run unprompted — the two are not the same case, and only the xcodebuild
+  one is measured, so do not generalize either way.
+- **Absolute Edit/Write paths carried over from a pre-worktree tool result point at the main
+  checkout.** Invalidate them after `EnterWorktree`.
+- **Post-merge `ExitWorktree(action: "remove")` refuses on a squash merge** — the merged commit has
+  a new SHA, so local commits read as unmerged by ancestry. `discard_changes: true` after the user
+  confirms the merge landed.
+
+## Commits
+
+- **The pre-commit SwiftLint step lints the whole worktree, not the staged set.** An unstaged edit
+  to a *later* item's file (one that trips a length cap, say) fails the *current* item's commit.
+  `git stash push -- <later-item-files>` before the focused commit, then pop.
+- **A delegated item can satisfy every acceptance condition and still leave an instance of the
+  shape it was removing** — the prompt bounds what was *asked*, not what the item *mandates*. Grep
+  the whole file for the OLD shape before committing (#1453 item 2 is the worked example).
+
+## Delegation
+
+- **`claude-kit:implementer` declares no `tools:` key** (it inherits `EnterWorktree` /
+  `ExitWorktree`, so the exclusion can only be a prompt instruction) **and pins `effort: medium`**
+  (`Agent` has no `effort` parameter). A `🎭` item therefore runs at Opus/medium; if fix rounds rise,
+  escalate to a general Opus subagent at session effort rather than re-dispatching the implementer.
+- **The four `OUTCOME` values carry opposite stash instructions** — `design-decision` wants the
+  partial work kept, `failed` wants it stashed, `scope-refusal` has none — so the outcome is a
+  literal line, never inferred from prose.
+- **A silent in-session fallback when the plugin agent is missing** degrades every `🎭` item back to
+  pre-split behaviour with no signal that routing stopped working. Stop and surface it.
+
+## Review and verification
+
+- **CI is not a backstop for the build-irrelevant carve-out.** `.github/workflows/ci.yml` reuses
+  `scripts/precommit-gate-classify.sh` for PR path-gating, so a build-irrelevant PR skips
+  `lint-and-test` and `ui-test` on CI too. What covers the post-merge state is that a push to `main`
+  runs the full iOS suite regardless of paths — in the workflow, not the script.
+- **A rebase or non-conflicting auto-merge can drop upstream entries from `Localizable.xcstrings`**
+  without surfacing a conflict, which is why the Step 4 rebase check is mandatory for generated /
+  data files.
+- **Round ≥ 2 on self-authored prose has negative expected value.** In #1516, every round-2
+  Critical and Warning attacked round-1's fix prose; each round mints new attackable claims at
+  ~100k tokens. Step 4 is one round by design (#1519) — residuals go to the PR body, not a loop.
+
+## Degraded mode (no `gh`)
+
+- `gh auth status` runs first, before the `#N` fetch and Resumption Detection, because both depend
+  on its verdict.
+- `git symbolic-ref refs/remotes/origin/HEAD` returns `refs/remotes/origin/main` and `--short`
+  alone returns `origin/main`; both break the `git fetch` / `rev-list` / `pull` / `switch`
+  consumers of `DEFAULT_BRANCH`. Only `--short … | sed 's|^origin/||'` yields a bare branch name
+  (upstream: claude-kit#34).

--- a/docs/agent-tooling/orchestrate-traps.md
+++ b/docs/agent-tooling/orchestrate-traps.md
@@ -1,70 +1,61 @@
-# `/orchestrate` — traps behind the short wording
+# `/orchestrate` — the mechanisms behind its rules
 
 On-demand companion to [`.claude/skills/orchestrate/SKILL.md`](../../.claude/skills/orchestrate/SKILL.md).
-The skill states each rule once; this file keeps the mechanism, so the rule can be re-derived when it
-looks removable. Nothing here is loaded per invocation.
+The skill states each rule; this file keeps only *why*, so a rule can be re-derived when it looks
+removable. Nothing here is loaded per invocation.
 
 ## Worktree and cwd
 
-- **Non-isolation subagents do not reliably inherit the worktree cwd.** A reviewer whose bare `git`
-  resolved to the main checkout returned an empty diff, which reads as a false FAIL. Hence
-  `git -C {WORKTREE_ROOT}` in every subagent prompt, captured once — never a `$(…)` the subagent
-  re-runs.
-- **The same failure reads as success for the implementer.** `scripts/xcodebuild.sh` resolves its
-  repo root from cwd, so a run that landed in the main checkout builds and tests *that* tree and
-  prints `** TEST SUCCEEDED **` for unrelated code. The path-rooting sentence in the prompt is a soft
-  instruction, so the prompt also asks for `pwd`; the main-session full-suite run at the end of
-  Step 3 is the backstop.
-- **`-C` is git-only.** The wrapper has no `-C`, and the allowlist entry for it is an exact-prefix
-  literal: a `cd … &&` prefix, an absolute path, or a leading env-var assignment raises an approval
-  prompt that stalls an unattended subagent. The git allowlist entries are equally bare, yet
-  `git -C <path> diff` has run unprompted — the two are not the same case, and only the xcodebuild
-  one is measured, so do not generalize either way.
-- **Absolute Edit/Write paths carried over from a pre-worktree tool result point at the main
-  checkout.** Invalidate them after `EnterWorktree`.
-- **Post-merge `ExitWorktree(action: "remove")` refuses on a squash merge** — the merged commit has
-  a new SHA, so local commits read as unmerged by ancestry. `discard_changes: true` after the user
-  confirms the merge landed.
+- **`git -C {WORKTREE_ROOT}` in every subagent prompt:** a non-isolation subagent's cwd has resolved
+  to the main checkout in practice. For a reviewer that yields an empty diff — a false FAIL. For an
+  implementer it is worse: `scripts/xcodebuild.sh` resolves its repo root from cwd, so the run tests
+  the *wrong* tree and prints `** TEST SUCCEEDED **` — a false green. Hence the `pwd` request; the
+  main-session full-suite run at the end of Step 3 is the backstop.
+- **`scripts/xcodebuild.sh` stays bare while git takes `-C`:** the wrapper has no `-C`, and its
+  allowlist entry is an exact-prefix literal, so a `cd` prefix raises an approval prompt that stalls
+  an unattended subagent. The git entries are equally bare yet `git -C <path> diff` has run
+  unprompted — only the xcodebuild case is measured, so do not generalize either way.
+- **Absolute Edit/Write paths from a pre-worktree tool result** point at the main checkout.
+- **Post-merge `ExitWorktree(action: "remove")` refuses** because a squash merge gives the merged
+  commit a new SHA, so local commits read as unmerged by ancestry.
 
 ## Commits
 
 - **The pre-commit SwiftLint step lints the whole worktree, not the staged set.** An unstaged edit
   to a *later* item's file (one that trips a length cap, say) fails the *current* item's commit.
   `git stash push -- <later-item-files>` before the focused commit, then pop.
-- **A delegated item can satisfy every acceptance condition and still leave an instance of the
-  shape it was removing** — the prompt bounds what was *asked*, not what the item *mandates*. Grep
-  the whole file for the OLD shape before committing (#1453 item 2 is the worked example).
+- **"Grep for the OLD shape before committing":** a delegated item has satisfied every acceptance
+  condition and still left an instance of the shape it was removing — the prompt bounds what was
+  *asked*, not what the item *mandates* (#1453 item 2).
 
 ## Delegation
 
-- **`claude-kit:implementer` declares no `tools:` key** (it inherits `EnterWorktree` /
-  `ExitWorktree`, so the exclusion can only be a prompt instruction) **and pins `effort: medium`**
-  (`Agent` has no `effort` parameter). A `🎭` item therefore runs at Opus/medium; if fix rounds rise,
-  escalate to a general Opus subagent at session effort rather than re-dispatching the implementer.
-- **The four `OUTCOME` values carry opposite stash instructions** — `design-decision` wants the
-  partial work kept, `failed` wants it stashed, `scope-refusal` has none — so the outcome is a
-  literal line, never inferred from prose.
-- **A silent in-session fallback when the plugin agent is missing** degrades every `🎭` item back to
-  pre-split behaviour with no signal that routing stopped working. Stop and surface it.
+- **Why the `🎭` prompt restates tool exclusions and asks for an `OUTCOME` line:**
+  `claude-kit:implementer` declares no `tools:` key (so it inherits `EnterWorktree` / `ExitWorktree`)
+  and pins `effort: medium` (`Agent` has no `effort` parameter). The four outcomes carry opposite
+  stash instructions — `design-decision` keeps the partial work, `failed` stashes it,
+  `scope-refusal` has none — so the outcome must be a literal line, not inferred from prose.
+- **Why a missing plugin agent stops the run instead of falling back in-session:** a silent
+  fallback degrades every `🎭` item to pre-split behaviour with no signal that routing stopped
+  working.
 
 ## Review and verification
 
-- **CI is not a backstop for the build-irrelevant carve-out.** `.github/workflows/ci.yml` reuses
+- **Why CI is not a backstop for the build-irrelevant carve-out:** `.github/workflows/ci.yml` reuses
   `scripts/precommit-gate-classify.sh` for PR path-gating, so a build-irrelevant PR skips
-  `lint-and-test` and `ui-test` on CI too. What covers the post-merge state is that a push to `main`
-  runs the full iOS suite regardless of paths — in the workflow, not the script.
-- **A rebase or non-conflicting auto-merge can drop upstream entries from `Localizable.xcstrings`**
-  without surfacing a conflict, which is why the Step 4 rebase check is mandatory for generated /
-  data files.
-- **Round ≥ 2 on self-authored prose has negative expected value.** In #1516, every round-2
-  Critical and Warning attacked round-1's fix prose; each round mints new attackable claims at
-  ~100k tokens. Step 4 is one round by design (#1519) — residuals go to the PR body, not a loop.
+  `lint-and-test` and `ui-test` on CI too. A push to `main` runs the full iOS suite regardless of
+  paths — in the workflow, not the script.
+- **Why the Step 4 rebase check is mandatory for generated / data files:** a rebase or
+  non-conflicting auto-merge has dropped upstream `Localizable.xcstrings` entries without a conflict.
+- **Why Step 4 is one round:** in #1516 every round-2 Critical and Warning attacked round-1's fix
+  prose; each round mints new attackable claims at ~100k tokens (#1519). Residuals go to the PR
+  body, not a loop.
 
 ## Degraded mode (no `gh`)
 
-- `gh auth status` runs first, before the `#N` fetch and Resumption Detection, because both depend
-  on its verdict.
-- `git symbolic-ref refs/remotes/origin/HEAD` returns `refs/remotes/origin/main` and `--short`
-  alone returns `origin/main`; both break the `git fetch` / `rev-list` / `pull` / `switch`
-  consumers of `DEFAULT_BRANCH`. Only `--short … | sed 's|^origin/||'` yields a bare branch name
-  (upstream: claude-kit#34).
+- **Why `gh auth status` runs first:** the `#N` fetch and Resumption Detection both depend on its
+  verdict.
+- **Why the `DEFAULT_BRANCH` fallback is `--short … | sed 's|^origin/||'`:** `git symbolic-ref
+  refs/remotes/origin/HEAD` returns `refs/remotes/origin/main` and `--short` alone returns
+  `origin/main`; both break the `git fetch` / `rev-list` / `pull` / `switch` consumers (upstream:
+  claude-kit#34).

--- a/docs/agent-tooling/subagent-output-cap.md
+++ b/docs/agent-tooling/subagent-output-cap.md
@@ -55,12 +55,12 @@ that file to a per-user path; this doc deliberately cites the repository instead
 repo-tracked files" of `knowledge-layering.md` forbids.)
 
 Second, and this is the consequence for future edits: revise them on evidence about *review
-quality* — a reviewer that misses things at 800 changed lines, or does fine at 1,500 — and never by
+quality* — a reviewer that misses things at 800 added lines, or does fine at 1,500 — and never by
 recomputing when a cap moves. A cap-table update leaves the thresholds untouched.
 
 That is also why they stay **kit-canonical** rather than becoming a per-project knob: the attention
 being bounded is a *subagent's* at a given scope, identical for every installation of the kit. The
-one lever a caller genuinely controls is report density per changed line — 800 lines of generated
+one lever a caller genuinely controls is report density per added line — 800 lines of generated
 fixtures report far shorter than 800 lines of dense source — and it licenses bounding a call
 **tighter at the call site, never looser**. Split smaller instead of editing the numbers, in the
 rule or in any agent copy of them (today `.claude/agents/code-reviewer.md`).

--- a/docs/agent-tooling/subagent-usage.md
+++ b/docs/agent-tooling/subagent-usage.md
@@ -59,9 +59,10 @@ When invoking a subagent, bound the work so the reviewer's **attention** holds
 — not so the report fits the cap; at these sizes it fits comfortably:
 
 - **Soft budget** (split if over): ~800 **added** lines OR ~8 changed
-  files OR ~5 review axes per invocation, whichever is tighter. Deleted
-  lines do not count — a deletion-heavy PR needs no more attention than
-  its additions, and counting them made reduction PRs shard (#1520).
+  files OR ~5 review axes per invocation, whichever is tighter. The count
+  bounds what the reviewer must newly comprehend; deleted lines are still
+  read in full but do not count — counting them made reduction PRs shard
+  (#1520).
 - **Hard split** (always split): >1500 added lines, >12 files, or
   >7 axes — at this size review quality degrades whatever the token
   budget permits.

--- a/docs/agent-tooling/subagent-usage.md
+++ b/docs/agent-tooling/subagent-usage.md
@@ -58,9 +58,11 @@ Docs: [sub-agents](https://code.claude.com/docs/en/sub-agents.md),
 When invoking a subagent, bound the work so the reviewer's **attention** holds
 — not so the report fits the cap; at these sizes it fits comfortably:
 
-- **Soft budget** (split if over): ~800 changed lines OR ~8 changed
-  files OR ~5 review axes per invocation, whichever is tighter.
-- **Hard split** (always split): >1500 changed lines, >12 files, or
+- **Soft budget** (split if over): ~800 **added** lines OR ~8 changed
+  files OR ~5 review axes per invocation, whichever is tighter. Deleted
+  lines do not count — a deletion-heavy PR needs no more attention than
+  its additions, and counting them made reduction PRs shard (#1520).
+- **Hard split** (always split): >1500 added lines, >12 files, or
   >7 axes — at this size review quality degrades whatever the token
   budget permits.
 
@@ -131,7 +133,7 @@ A cost-driven downgrade is still bounded by the same sensitivity rules
 ## 4. Agent self-defense
 
 The two defend asymmetrically: `code-reviewer.md` bails with `SCOPE_TOO_LARGE`
-right after its one mandatory `git diff --stat`; `claude-kit:critic` triages
+right after its one mandatory `git diff --numstat`; `claude-kit:critic` triages
 axes *during* the run. **Keep `code-reviewer.md`'s copy of §2's numbers in
 sync** — critic's is kit-owned and one-way. Do not delete either as redundant:
 the doc's § "Why the agents duplicate the budget" has the reason.


### PR DESCRIPTION
## Summary

PR 2 of #1519 — `/orchestrate` rebuilt as **the claude-kit template + a Pastura delta**, under the issue's criteria (nothing a gate already enforces; only rules whose violation is silent; no rules-about-rules, in-file proofs, or incident history).

| File | Before | After |
|---|---|---|
| `.claude/skills/orchestrate/SKILL.md` | 53,045 B | **24,258 B** (kit template 22,243 B + ~2 KB delta) |
| `docs/agent-tooling/orchestrate-traps.md` | — | new, 3.9 KB — the mechanisms behind the shortened rules, read on demand |
| `docs/agent-tooling/orchestrate-kit-reconciliation.md` | 8.0 KB | 6.1 KB — entries re-aligned; sunset clause + break-even added |
| `.claude/agents/code-reviewer.md` / `subagent-usage.md` §2 | budget counted changed lines | counts **added** lines (`--numstat` insertions) |

What changed in behaviour:

- **Step 4 is one round.** Reviewer → main-session triage (apply / reject with a reason) → one fix commit → at most one fix-diff re-review, only when a fix introduced new logic. No verification subagent, no 3-iteration loop, no Review Action Summary table. Rejected findings go to the PR body's `## Review` section — this PR's own section below is the first instance.
- **Reviewer budget counts added lines.** #1520's 926-line reduction diff sharded into two reviews although it added little.
- **`Routing: v2` legacy handling is deleted.** No open issue carries an unfinished pre-split plan comment (checked all 36 open issues: 5 have plan comments, none with an unchecked item), so the fail-closed branch had nothing left to protect.
- **Tier × locus routing stays** (it is #1516's design, one week old), compressed to the Q1/Q2/Q3 table; #1517 item 5 lands in the ledger: a **sunset clause** (after ~10 runs, `🧠` share ≥ 80% and implementer calls ≈ 0 ⇒ revert to the template's two-icon label by deletion) and a **break-even** (52k-token fixed cost per delegation ⇒ delegation is cheaper only when the item would otherwise add ≳ 25k tokens of tool output to the main context; below that, in-session).
- **Dropped without a new home** (criterion 3): the explicit "do not add a blanket 'when in doubt, go up a tier'" sentence (the template's own Q2 wording — "that specific uncertainty, not general unease" — carries it; ledger entry retired), the "Delegate the legwork, keep the judgment" paragraph, the per-item SwiftLint commit hazard (the hook names the file), `Routing` metadata, the in-file derivation of the 88% baseline, and every `#NNNN` citation inside the skill.
- **Adopted from the template** that Pastura previously diverged on: the `## Project parameters` table, the combined 🎭/🎵 prompt template, the shorter Step 0 / Step 2 wording. Kept as deliberate divergences (ledger): bare `scripts/xcodebuild.sh` (no `cd`), the `--body-file` PR body, the bare-branch-name `DEFAULT_BRANCH` fallback (kit#34 still open), the selective-rules read owned by `code-reviewer.md`.

## Test plan

- Creator negative controls on the rebuilt skill: `grep -cE '\{\{|CREATOR:'` = 0; plan marker present at all 3 sites (Constants, the `--jq contains(…)` filter, the Step 2a heredoc).
- `git diff --name-only origin/main...HEAD | scripts/precommit-gate-classify.sh` emits neither `build` nor `lint` — no Swift touched, suite and SwiftLint skipped (the carve-out the skill documents; CI's PR path-gating makes the same call).
- Stale-pointer sweep: no file outside the skill cited the removed Step 4 machinery (`verification agent`, `Review Action Summary`, `3 iterations`); CONTRIBUTING's two `/orchestrate` statements (entry point; stops at Step 1b without the plugin) remain true.

## Review

`code-reviewer` (Opus), one round as the rebuilt Step 4 prescribes: 13 findings, triaged in the main session, one fix commit, no verification subagent, no re-review (every applied fix is the reviewer's own wording or number). The first launch bailed `SCOPE_TOO_LARGE` under the *old* changed-line budget (956 lines) because the session had loaded `main`'s agent definition — the second launch was told the branch's added-line figure (440) and reviewed in one pass. The reviewer's own observation about the first bail is the motivating case for the budget change.

Applied (9): the break-even illustration was off ~2.5× (the reviewer measured Swift file sizes: median 4.7 KB, p75 9.2 KB) and its threshold now reads 18–26k pending re-measure; the "no blanket 'when in doubt, go up a tier'" back-port guard returns as one sentence in ledger entry 6; the added-line rule's justification is restated as read-cost with "deletions are still read in full"; `subagent-output-cap.md` now uses the same unit; `#N` in degraded mode asks for the spec inline; the resumption re-check greps for `(tb)` instead of re-deriving a classification the session cannot see; `$LABEL` points at Step 5; the `git branch -m` step keeps its reason (`EnterWorktree` sanitizes `/` → `+`, prepends `worktree-`); the traps doc was trimmed to mechanism-only where the skill already states the rule.

Not applied, on the record:

- **Critical 1 — `Routing: v2` removal reinterprets pre-split plans.** Rejected on evidence: all 36 open issues were scanned; 5 carry plan comments and none has an unchecked item, so no unfinished pre-split plan exists to resume. The umbrella-issue path the reviewer cites ("resume-review" on a fully-checked plan) skips straight to Step 4 and dispatches nothing; a new plan on such an issue is labelled under current semantics. A closed issue reopened with a half-finished pre-#1516 plan would send its `🎭` items to an Opus implementer instead of the Opus session — same tier, delegated — and that is the trade the tier × locus split already makes for every `🎭` item.
- **Suggestion 2 — pointer to the per-item SwiftLint commit hazard.** The pre-commit hook names the offending file; criterion 1 (machine-enforced ⇒ no prose). The mechanism stays in the traps doc.
- **Suggestion 4 — plan comment via inline heredoc.** The push-protection hook gates `gh pr create`, not `gh api …/comments`; the heredoc is the template's shape and has worked on every plan posted to date.
- **Suggestion 5 — the "delegation finds sites, never certifies counts" rule.** Owned by `docs/agent-tooling/knowledge-layering.md` § Scope & Completeness Discipline; re-stating or pointing at it from the skill is the rules-about-rules shape criterion 3 excludes.

## Device QA

実機QA不要 — agent-instruction files and docs only; no app code.

Context-economy: rewrite, not an addition — `/orchestrate` −29 KB per invocation; `code-reviewer.md` +0 net (4/4 lines). Nothing always-loaded changed.

Part of #1519
