### PR TITLE
🐛 fix: #1519 PR 4 — stale pointers and a SwiftLint gate for Hard Rule 1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -845,7 +845,7 @@ jobs:
       # runs JVM tests + single-target klib compile-only (full-native on main is
       # owned by the nightly workflow, #501 PR-3).
       #
-      # Decided HERE at STEP level, never via `on.<event>.paths`: a job-level
+      # Decided HERE at STEP level, never via `on.<event>.paths`: a trigger-level
       # path filter leaves a required status check stuck "Pending" forever when
       # the paths do not match (ci-workflows.md "Required-check-safe path gating").
       # Conservative-by-inversion (ci-workflows.md invariant 1): an unresolved /

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -847,7 +847,7 @@ jobs:
       #
       # Decided HERE at STEP level, never via `on.<event>.paths`: a job-level
       # path filter leaves a required status check stuck "Pending" forever when
-      # the paths do not match (ci-workflows.md "Long-lived branch gating").
+      # the paths do not match (ci-workflows.md "Required-check-safe path gating").
       # Conservative-by-inversion (ci-workflows.md invariant 1): an unresolved /
       # errored PR file list PROMOTES rather than under-builds.
       - name: Classify KMP build-config touch

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -31,6 +31,9 @@ opt_in_rules:
   - contains_over_filter_count
   - fatal_error_message
   - first_where
+  # CLAUDE.md Hard Rule 1 ("No force unwrap"). Test targets are exempt via
+  # the nested Pastura/PasturaTests/.swiftlint.yml and PasturaUITests/.swiftlint.yml.
+  - force_unwrapping
   - modifier_order
   - overridden_super_call
   - private_action

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -31,8 +31,9 @@ opt_in_rules:
   - contains_over_filter_count
   - fatal_error_message
   - first_where
-  # CLAUDE.md Hard Rule 1 ("No force unwrap"). Test targets are exempt via
-  # the nested Pastura/PasturaTests/.swiftlint.yml and PasturaUITests/.swiftlint.yml.
+  # CLAUDE.md Hard Rule 1 ("No force unwrap"). Test code is exempt via the
+  # nested .swiftlint.yml in Pastura/PasturaTests, Pastura/PasturaUITests and
+  # tools/harness/Tests.
   - force_unwrapping
   - modifier_order
   - overridden_super_call

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ README.md and CONTRIBUTING.md mirror Architecture, Hard Rules, Dependency Rules,
 
 ## Hard Rules
 
-1. **No force unwrap (`!`)** — `guard let`, `if let`, or `?`. Test code is exempt.
+1. **No force unwrap (`!`)** — `guard let`, `if let`, or `?`. Test code is exempt (SwiftLint `force_unwrapping`; nested configs exempt the test trees).
 2. **No Engine → Data import** — Engine communicates via emitter closures; the App layer bridges.
 3. **Doc comments on public protocols and types.**
 

--- a/Pastura/Pastura/App/ReplaySource.swift
+++ b/Pastura/Pastura/App/ReplaySource.swift
@@ -56,8 +56,8 @@ nonisolated public struct PacedEvent: Sendable, Equatable {
 /// project's `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` would otherwise
 /// infer MainActor for the ``events()`` closure body — which builds an
 /// `AsyncStream` + `Task` + `onTermination` and therefore breaks
-/// `Sendable` conformance. See `.claude/rules/llm.md` for the diagnostic
-/// and the same pattern at ``LLMService/generateStream(system:user:)``.
+/// `Sendable` conformance. See `docs/swift-isolation-compile-time-patterns.md`
+/// (Pattern 1) and the same pattern at ``LLMService/generateStream(system:user:)``.
 nonisolated public protocol ReplaySource: Sendable {
   /// Scenario this replay renders against. Supplies persona names, phase
   /// structure, and score-display context to the view layer.

--- a/Pastura/Pastura/App/YAMLReplayExporter.swift
+++ b/Pastura/Pastura/App/YAMLReplayExporter.swift
@@ -53,8 +53,9 @@ nonisolated enum YAMLReplayExporterError: Error, LocalizedError, Equatable {
 /// reserves the `true` value for curators to set after **manual audit**.
 /// Automated ContentFilter application is not sufficient to flip it.
 ///
-/// Marked `nonisolated` so ``YAMLReplaySource`` (also nonisolated, for
-/// actor-isolation reasons in `.claude/rules/llm.md`) can reference the
+/// Marked `nonisolated` so ``YAMLReplaySource`` (also nonisolated, for the
+/// actor-isolation reasons in `docs/swift-isolation-compile-time-patterns.md`,
+/// Pattern 1) can reference the
 /// shared schema constants. File writing is thread-safe through
 /// `FileManager`.
 nonisolated struct YAMLReplayExporter {  // swiftlint:disable:this type_body_length

--- a/Pastura/Pastura/App/YAMLReplaySource.swift
+++ b/Pastura/Pastura/App/YAMLReplaySource.swift
@@ -49,8 +49,8 @@ nonisolated public enum YAMLReplaySourceError: Error, Equatable {
 /// project uses `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, which would
 /// otherwise infer MainActor for the `AsyncStream` closure body in
 /// ``events()`` and break `Sendable` conformance on ``ReplaySource``.
-/// See `.claude/rules/llm.md` and the same pattern at
-/// ``LLMService/generateStream(system:user:)``.
+/// See `docs/swift-isolation-compile-time-patterns.md` (Pattern 1) and the
+/// same pattern at ``LLMService/generateStream(system:user:)``.
 ///
 /// **Scenario resolution is caller's concern.** This type accepts a
 /// pre-resolved ``Scenario`` in its initialiser. Resolving a

--- a/Pastura/Pastura/Engine/ConditionEvaluator+Parser.swift
+++ b/Pastura/Pastura/Engine/ConditionEvaluator+Parser.swift
@@ -13,8 +13,8 @@ import Foundation
 // `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, an unmarked extension on a
 // `nonisolated public struct` would still infer MainActor for its
 // members, breaking the call from the main file's nonisolated public
-// `evaluate(_:state:scenario:)` / `parse(_:)` API. See `.claude/rules/llm.md`
-// and the memory note on `nonisolated` for the same trap.
+// `evaluate(_:state:scenario:)` / `parse(_:)` API. See
+// `docs/swift-isolation-compile-time-patterns.md` (Pattern 3).
 nonisolated extension ConditionEvaluator {
 
   // MARK: - Tokenizer

--- a/Pastura/Pastura/Views/ModelSelection/ModelPickerView.swift
+++ b/Pastura/Pastura/Views/ModelSelection/ModelPickerView.swift
@@ -329,7 +329,9 @@ struct ModelPickerView: View {
 /// `UserDefaults` so previews don't pollute the simulator's domain.
 @MainActor
 private func previewManager(catalog: [ModelDescriptor] = ModelRegistry.catalog) -> ModelManager {
-  let defaults = UserDefaults(suiteName: "ModelPickerPreview-\(UUID().uuidString)")!
+  // `init(suiteName:)` returns nil only for the bundle identifier or the
+  // global domain — never for a UUID suite — so the fallback is unreachable.
+  let defaults = UserDefaults(suiteName: "ModelPickerPreview-\(UUID().uuidString)") ?? .standard
   return ModelManager(
     physicalMemory: 8 * 1024 * 1024 * 1024,
     userDefaults: defaults,

--- a/Pastura/Pastura/Views/ModelSelection/ModelPickerView.swift
+++ b/Pastura/Pastura/Views/ModelSelection/ModelPickerView.swift
@@ -331,6 +331,8 @@ struct ModelPickerView: View {
 private func previewManager(catalog: [ModelDescriptor] = ModelRegistry.catalog) -> ModelManager {
   // `init(suiteName:)` returns nil only for the bundle identifier or the
   // global domain — never for a UUID suite — so the fallback is unreachable.
+  // Were it ever reached, previews would write to the standard domain this
+  // helper exists to avoid; keep the suite name UUID-based.
   let defaults = UserDefaults(suiteName: "ModelPickerPreview-\(UUID().uuidString)") ?? .standard
   return ModelManager(
     physicalMemory: 8 * 1024 * 1024 * 1024,

--- a/Pastura/PasturaTests/.swiftlint.yml
+++ b/Pastura/PasturaTests/.swiftlint.yml
@@ -1,0 +1,4 @@
+# Nested config — merged into the root .swiftlint.yml for files under this
+# directory. CLAUDE.md Hard Rule 1 ("No force unwrap") exempts test code.
+disabled_rules:
+  - force_unwrapping

--- a/Pastura/PasturaUITests/.swiftlint.yml
+++ b/Pastura/PasturaUITests/.swiftlint.yml
@@ -1,0 +1,4 @@
+# Nested config — merged into the root .swiftlint.yml for files under this
+# directory. CLAUDE.md Hard Rule 1 ("No force unwrap") exempts test code.
+disabled_rules:
+  - force_unwrapping

--- a/scripts/scenario-editor-funnel-gate.sh
+++ b/scripts/scenario-editor-funnel-gate.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 #
 # scripts/scenario-editor-funnel-gate.sh — Pre-commit + CI tripwire for
-# the ScenarioEditor funnel invariant (#338, formerly a manual PR-review
-# grep documented in .claude/rules/scenario-editor.md).
+# the ScenarioEditor funnel invariant (#338; replaces the manual PR-review
+# grep it started as — the invariant itself is in
+# .claude/rules/scenario-editor.md).
 #
 # `ScenarioEditorViewModel` holds a dual buffer (visual fields + yamlText);
 # both reconcile only via the private `currentScenario()` funnel. A new

--- a/tools/harness/Tests/.swiftlint.yml
+++ b/tools/harness/Tests/.swiftlint.yml
@@ -1,0 +1,4 @@
+# Nested config — merged into the root .swiftlint.yml for files under this
+# directory. CLAUDE.md Hard Rule 1 ("No force unwrap") exempts test code.
+disabled_rules:
+  - force_unwrapping


### PR DESCRIPTION
## Summary

PR 4 of #1519 — the four follow-ups deferred in #1522 "Known / deferred". One commit per item.

1. **`ci.yml:850`** — the comment cited `ci-workflows.md` "Long-lived branch gating", which #1522 relocated to `docs/ci/gha-branch-gating.md`; the claim it actually cites (a job-level path filter leaves a required check Pending) lives in § "Required-check-safe path gating", which also holds the "invariant 1" cited on the next line. Retargeted.
2. **`scripts/scenario-editor-funnel-gate.sh`** — header no longer says the grep is "documented in `.claude/rules/scenario-editor.md`" (the gate replaced it; the rule states the invariant only).
3. **Four Swift comments** cited a never-existing `.claude/rules/llm.md`. `ReplaySource` / `YAMLReplaySource` / `YAMLReplayExporter` now point at `docs/swift-isolation-compile-time-patterns.md` Pattern 1 (escaping-closure body on a `nonisolated` protocol), `ConditionEvaluator+Parser` at Pattern 3 (sibling-file extension). The "memory note" reference is gone.
4. **Hard Rule 1 gets machine backing** — `force_unwrapping` is opted in at the root `.swiftlint.yml`; the two test targets (exempt per CLAUDE.md) disable it via nested `Pastura/PasturaTests/.swiftlint.yml` and `Pastura/PasturaUITests/.swiftlint.yml`. Probe on `main`: 42 hits = 41 in tests + 1 production, the `ModelPickerView` preview helper's `UserDefaults(suiteName:)!` — replaced with `?? .standard` and a why-comment (nil only for the bundle ID / global domain, never for a UUID suite).

Not done here: CLAUDE.md Hard Rule 1 stays as prose even though it is now enforced — it is mirrored into README / CONTRIBUTING as a product rule, and one line is cheaper than the mirror edit. Flagging in case the "machine-enforced → don't write" criterion should win.

## Test plan

- `swiftlint lint --quiet --strict` from the worktree root: clean (exit 0, no output).
- Nested-config positive control: `swiftlint lint --quiet Pastura/PasturaTests/LLM/OllamaServiceTests.swift` (the edit-hook single-file shape) reports 0 `force_unwrapping`; the same file with `--config .swiftlint.yml` (bypasses nested configs) reports 7. The nested file is what exempts tests.
- Pre-commit ran SwiftLint + `xcodebuild build` on the `scripts/` and Swift commits.
- `scripts/xcodebuild.sh test -skip-testing:PasturaUITests`: 3,547 tests in 286 suites passed (1 known issue, pre-existing). UI tests skipped — no UI code changed.
- CI `lint` job runs `swiftlint lint --strict` from the repo root, so it picks up the nested configs the same way.

## Review

Reviewer: Opus `code-reviewer`, one round, **PASS** (Critical 0 / Warning 2 / Suggestion 5). No re-review — every applied fix is the reviewer's own wording.

- **Applied (4)** — W1 `ci.yml:848` said a "job-level" path filter strands a required check, the opposite of the rule it cites → "trigger-level". W2 `tools/harness/Tests/` is a third test tree under `included:` with no exemption → same nested config, root comment lists all three. S3 the `?? .standard` comment now owns the pollution trade-off with the docstring above it. S4 CLAUDE.md Hard Rule 1 names its enforcer so the next corpus-trim pass does not re-litigate it (CONTRIBUTING mirrors Hard Rules by link, no mirror edit).
- **Rejected (1)** — S1 "Pattern 1 is approximately right: its body describes a protocol-extension default impl, these three are concrete conformers". The doc's own Pattern 1 text says the escaping closure is sufficient, not necessary, and the discriminator is sync-vs-`async`; each comment already states its own code shape, so the pointer lands on the right diagnostic family. Left as is.
- **No action (2)** — S2 dropping "the memory note" was deliberate (not fetchable by a human editor). S5 CI's unpinned `brew install swiftlint` is pre-existing; noted as the drift channel for `superfluous_disable_command` behaviour.
- Reviewer verified: `superfluous_disable_command` does not fire on `OllamaServiceTests.swift:248` under the nested config (the rule leaves the effective set, so the directive degrades to a no-op); CI and the pre-commit hook both run `swiftlint` from the root without `--config`, so both see nested configs; `precommit-gate-classify.sh`'s `(^|/)\.swiftlint\.yml$` matches nested configs, so a future edit to one still arms the lint/build tokens.

## Device QA

実機QA不要 — comments, a preview-only helper, and lint config; no runtime code path changed.

Part of #1519

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Q9zND6f2Fvb3j6T4mrGVA
