### PR TITLE
♿ fix: transcript の A4/A5 行を --ink-2 へ（#1448 batch 2）

### DIFF
--- a/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailView.swift
+++ b/Pastura/Pastura/Views/Community/SharedScenarios/GalleryScenarioDetailView.swift
@@ -256,7 +256,11 @@ struct GalleryScenarioDetailView: View {
       Text(label).foregroundStyle(Color.ink)
       Spacer(minLength: 12)
       Text(value)
-        .foregroundStyle(Color.muted)
+        // `inkSecondary`, not §8's quietude tier: `Est. inferences` is what a
+        // user checks a device against before running (audit class A3). The
+        // read-only disclaimer and the step numerals stay `muted`.
+        // `docs/design/muted-application-audit.md`.
+        .foregroundStyle(Color.inkSecondary)
         .multilineTextAlignment(.trailing)
     }
     .padding(.horizontal, 17)

--- a/Pastura/Pastura/Views/Components/AgentOutputRow.swift
+++ b/Pastura/Pastura/Views/Components/AgentOutputRow.swift
@@ -633,10 +633,12 @@ struct AgentOutputRow: View {
       // used `.frame(minHeight: 44)`, which inflated visible
       // whitespace to ~17pt above and below the glyph and was rolled
       // back in #171. The chevron tint stays `Color.moss` (lighter
-      // accent) — paired with `Color.muted` for the THINKING text,
-      // it mirrors the `BubbleBackground` / `ThoughtLeftRule` palette
-      // (moss for prefixes, muted for body). `mossDark` would read
-      // as a stronger accent than the design intends here.
+      // accent) — paired with `Color.muted` for the THINKING tag, it
+      // mirrors the `BubbleBackground` / `ThoughtLeftRule` palette
+      // (moss for prefixes, muted for the tag). The thought *body* left
+      // that pairing in #1448 batch 2 and reads `inkSecondary`.
+      // `mossDark` would read as a stronger accent than the design
+      // intends here.
       //
       // Sibling overlap: the +16/-16 hit-test region overlaps the
       // primary bubble above by ~10pt and the revealed thought below
@@ -682,7 +684,12 @@ struct AgentOutputRow: View {
     let tail = shouldReserveHiddenTail ? Text(hidden).foregroundStyle(.clear) : Text("")
     return (Text(visible) + tail)
       .textStyle(Typography.thinkingBody)
-      .foregroundStyle(Color.muted)
+      // `inkSecondary`, not §8's quietude tier: the inner monologue is the
+      // product this row exists to show, not metadata about it. The `INNER
+      // VOICE` tag above stays `muted` — a disclosure label is sanctioned even
+      // when what it discloses is not. Audit class A5:
+      // `docs/design/muted-application-audit.md`.
+      .foregroundStyle(Color.inkSecondary)
       .thoughtLeftRule()
       .transition(.opacity.combined(with: .move(edge: .top)))
   }

--- a/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+CodePhaseRows.swift
+++ b/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+CodePhaseRows.swift
@@ -36,7 +36,7 @@ extension ModelDownloadHostView {
       // Mirrors `SimulationView.assignmentEntry`.
       Text(String(format: String(localized: "%@ assigned: %@"), agent, value))
         .textStyle(Typography.metaValue)
-        // Applied together with `SimulationView+LogEntries`: the DL-time demo
+        // Keep in step with `SimulationView+LogEntries`: the DL-time demo
         // mirrors the live log deliberately, so repointing one and not the other
         // diverges them visually while every count still reconciles. A5 carries
         // to the component wherever it is mounted — the rows are primary output

--- a/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+CodePhaseRows.swift
+++ b/Pastura/Pastura/Views/ModelDownload/ModelDownloadHostView+CodePhaseRows.swift
@@ -36,7 +36,13 @@ extension ModelDownloadHostView {
       // Mirrors `SimulationView.assignmentEntry`.
       Text(String(format: String(localized: "%@ assigned: %@"), agent, value))
         .textStyle(Typography.metaValue)
-        .foregroundStyle(Color.muted)
+        // Applied together with `SimulationView+LogEntries`: the DL-time demo
+        // mirrors the live log deliberately, so repointing one and not the other
+        // diverges them visually while every count still reconciles. A5 carries
+        // to the component wherever it is mounted — the rows are primary output
+        // even though this screen exists to download a model.
+        // `docs/design/muted-application-audit.md` § 2.
+        .foregroundStyle(Color.inkSecondary)
     case .sharedAssignment(let value):
       // Mirrors `SimulationView.sharedAssignmentEntry` (#939): the round's
       // premise gets a moss accent rule + clipboard icon + body-weight ink text,
@@ -96,7 +102,7 @@ extension ModelDownloadHostView {
           .textStyle(Typography.metaValue)
       }
     }
-    .foregroundStyle(Color.muted)
+    .foregroundStyle(Color.inkSecondary)
   }
 
   /// Mirrors `SimulationView.scoresSummary`.
@@ -108,7 +114,7 @@ extension ModelDownloadHostView {
           .monospacedDigit()
       }
     }
-    .foregroundStyle(Color.muted)
+    .foregroundStyle(Color.inkSecondary)
   }
 
   /// Mirrors `SimulationView.pairingResultEntry`.
@@ -139,7 +145,7 @@ extension ModelDownloadHostView {
     } else {
       Text(String(localized: "No event this round"))
         .textStyle(Typography.metaValue)
-        .foregroundStyle(Color.muted)
+        .foregroundStyle(Color.inkSecondary)
     }
   }
 

--- a/Pastura/Pastura/Views/Results/ResultDetailView+CodePhaseRows.swift
+++ b/Pastura/Pastura/Views/Results/ResultDetailView+CodePhaseRows.swift
@@ -66,7 +66,11 @@ extension ResultDetailView {
     return Text(String(format: String(localized: "Scores — %@"), pairs))
       .textStyle(Typography.metaValue)
       .monospacedDigit()
-      .foregroundStyle(Color.muted)
+      // Same call as the live transcript in `SimulationView+LogEntries`, on the
+      // past-run mirror: primary output (A5) and degraded-turn narration (A4)
+      // read `inkSecondary`; the `vs` separator stays `muted`.
+      // `docs/design/muted-application-audit.md` § 5.
+      .foregroundStyle(Color.inkSecondary)
   }
 
   private func summaryRow(text: String) -> some View {
@@ -113,7 +117,7 @@ extension ResultDetailView {
           .textStyle(Typography.metaValue)
       }
     }
-    .foregroundStyle(Color.muted)
+    .foregroundStyle(Color.inkSecondary)
   }
 
   private func pairingRow(
@@ -130,7 +134,7 @@ extension ResultDetailView {
   private func assignmentRow(agent: String, value: String) -> some View {
     Text(String(format: String(localized: "%@ assigned: %@"), filtered(agent), filtered(value)))
       .textStyle(Typography.metaValue)
-      .foregroundStyle(Color.muted)
+      .foregroundStyle(Color.inkSecondary)
   }
 
   // Shared お題 assigned to every agent (#939). Mirrors
@@ -167,7 +171,7 @@ extension ResultDetailView {
     } else {
       Text(String(localized: "No event this round"))
         .textStyle(Typography.metaValue)
-        .foregroundStyle(Color.muted)
+        .foregroundStyle(Color.inkSecondary)
     }
   }
 

--- a/Pastura/Pastura/Views/Results/ResultDetailView.swift
+++ b/Pastura/Pastura/Views/Results/ResultDetailView.swift
@@ -259,13 +259,12 @@ struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
         if let skipped = DegradedRunBadge.skippedTurnCount(
           status: simulation?.simulationStatus,
           degradedTurnCount: simulation?.degradedTurnCount ?? 0) {
-          // Tinted per slot in #1448 batch 2, not on the `Label`: the text
-          // narrates a degraded run (class A4, ADR-021 D5) → `inkSecondary`;
-          // the glyph is non-text and stays on §8's quietude tier, as the two
-          // triangles in `SimulationView+LogEntries` do. A single
-          // `.foregroundStyle` could not have split them. That leaves a
-          // `Color.muted` here with no `9a40565a` ledger row — the batch
-          // created it; see audit § 5.
+          // Tinted per slot, not on the `Label` — one `.foregroundStyle` cannot
+          // split them: the text narrates a degraded run (class A4, ADR-021 D5)
+          // → `inkSecondary`; the glyph is non-text and stays `muted`, as the two
+          // triangles in `SimulationView+LogEntries` do. The glyph's
+          // `Color.muted` is the row the audit § 5 marks *added by B2*: the
+          // `9a40565a` baseline census never adjudicated it.
           Label {
             Text(String(format: String(localized: "Turns skipped ×%lld"), skipped))
               .foregroundStyle(Color.inkSecondary)

--- a/Pastura/Pastura/Views/Results/ResultDetailView.swift
+++ b/Pastura/Pastura/Views/Results/ResultDetailView.swift
@@ -253,18 +253,26 @@ struct ResultDetailView: View {  // swiftlint:disable:this type_body_length
         // valid round checkpoint offers "resume from round N+1". Mutually
         // exclusive with the DegradedRunBadge below (`.failed` vs `.completed`).
         resumeBanner
-        // Degraded-run annotation (ADR-021 D6) — a muted summary banner when
-        // this completed run omitted one or more LLM turns. Gated to
-        // completed + count > 0 by `DegradedRunBadge`.
+        // Degraded-run annotation (ADR-021 D6) — a summary banner when this
+        // completed run omitted one or more LLM turns. Gated to completed +
+        // count > 0 by `DegradedRunBadge`.
         if let skipped = DegradedRunBadge.skippedTurnCount(
           status: simulation?.simulationStatus,
           degradedTurnCount: simulation?.degradedTurnCount ?? 0) {
-          Label(
-            String(format: String(localized: "Turns skipped ×%lld"), skipped),
-            systemImage: "exclamationmark.triangle"
-          )
+          // Tinted per slot in #1448 batch 2, not on the `Label`: the text
+          // narrates a degraded run (class A4, ADR-021 D5) → `inkSecondary`;
+          // the glyph is non-text and stays on §8's quietude tier, as the two
+          // triangles in `SimulationView+LogEntries` do. A single
+          // `.foregroundStyle` could not have split them. That leaves a
+          // `Color.muted` here with no `9a40565a` ledger row — the batch
+          // created it; see audit § 5.
+          Label {
+            Text(String(format: String(localized: "Turns skipped ×%lld"), skipped))
+              .foregroundStyle(Color.inkSecondary)
+          } icon: {
+            Image(systemName: "exclamationmark.triangle").foregroundStyle(Color.muted)
+          }
           .font(.caption)
-          .foregroundStyle(Color.muted)
           .accessibilityIdentifier("resultDetail.degradedBadge")
         }
         ForEach(items) { item in

--- a/Pastura/Pastura/Views/Results/ResultsView.swift
+++ b/Pastura/Pastura/Views/Results/ResultsView.swift
@@ -277,7 +277,11 @@ struct ResultsView: View {
       status: item.simulationStatus, degradedTurnCount: item.degradedTurnCount) {
       Text(String(format: String(localized: "Turns skipped ×%lld"), skipped))
         .font(.caption)
-        .foregroundStyle(Color.muted)
+        // `inkSecondary`, not §8's quietude tier: this is the row's only notice
+        // that the run omitted turns (audit class A4, ADR-021 D5). The row's
+        // category caption and timestamp above stay `muted` — those are §8's own
+        // sanctioned list-caption shape. `docs/design/muted-application-audit.md`.
+        .foregroundStyle(Color.inkSecondary)
     }
   }
 

--- a/Pastura/Pastura/Views/Results/ResultsView.swift
+++ b/Pastura/Pastura/Views/Results/ResultsView.swift
@@ -278,9 +278,9 @@ struct ResultsView: View {
       Text(String(format: String(localized: "Turns skipped ×%lld"), skipped))
         .font(.caption)
         // `inkSecondary`, not §8's quietude tier: this is the row's only notice
-        // that the run omitted turns (audit class A4, ADR-021 D5). The row's
-        // category caption and timestamp above stay `muted` — those are §8's own
-        // sanctioned list-caption shape. `docs/design/muted-application-audit.md`.
+        // that the run omitted turns (audit class A4, ADR-021 D5). The category
+        // caption below it and the timestamp stay `muted` — §8's own sanctioned
+        // list-caption shape. `docs/design/muted-application-audit.md`.
         .foregroundStyle(Color.inkSecondary)
     }
   }

--- a/Pastura/Pastura/Views/ScenarioDetail/ScenarioDetailView+Sections.swift
+++ b/Pastura/Pastura/Views/ScenarioDetail/ScenarioDetailView+Sections.swift
@@ -56,7 +56,11 @@ extension ScenarioDetailView {
       if !scenario.description.isEmpty {
         Text(scenario.description)
           .font(.subheadline)
-          .foregroundStyle(Color.muted)
+          // `inkSecondary`, not §8's quietude tier: the description is what this
+          // screen exists to show before a run (audit class A5), not metadata
+          // about it. The phase ordinals below stay `muted` — derivable from row
+          // order. `docs/design/muted-application-audit.md`.
+          .foregroundStyle(Color.inkSecondary)
       }
     }
     .frame(maxWidth: .infinity, alignment: .leading)

--- a/Pastura/Pastura/Views/Simulation/SimulationView+LogEntries.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView+LogEntries.swift
@@ -22,10 +22,17 @@ extension SimulationView {
     }
   }
 
+  // The six repoints in this file read `inkSecondary`, not §8's quietude tier:
+  // a transcript row is either the simulation's primary output (A5) or the
+  // narration of a turn that degraded (A4 — ADR-021 D5 requires the transcript
+  // to stay self-explanatory *at the gap*, and a gap narrated illegibly is not
+  // narrated). The `vs` separator and the two `exclamationmark.triangle` glyphs
+  // stay `muted`: a separator is sanctioned, and a glyph is outside §8's text
+  // bar. `docs/design/muted-application-audit.md` § 5.
   func assignmentEntry(agent: String, value: String) -> some View {
     Text(String(format: String(localized: "%@ assigned: %@"), agent, value))
       .textStyle(Typography.metaValue)
-      .foregroundStyle(Color.muted)
+      .foregroundStyle(Color.inkSecondary)
   }
 
   // Shared お題 assigned to every agent (`assign` target: all, #939). Styled as
@@ -85,7 +92,7 @@ extension SimulationView {
           .textStyle(Typography.metaValue)
       }
     }
-    .foregroundStyle(Color.muted)
+    .foregroundStyle(Color.inkSecondary)
   }
 
   func pairingResultEntry(
@@ -117,7 +124,7 @@ extension SimulationView {
     } else {
       Text(String(localized: "No event this round"))
         .textStyle(Typography.metaValue)
-        .foregroundStyle(Color.muted)
+        .foregroundStyle(Color.inkSecondary)
     }
   }
 
@@ -144,7 +151,7 @@ extension SimulationView {
           agent, PhaseDisplayName.label(for: phaseType))
       )
       .textStyle(Typography.metaValue)
-      .foregroundStyle(Color.muted)
+      .foregroundStyle(Color.inkSecondary)
     }
   }
 
@@ -165,7 +172,7 @@ extension SimulationView {
           agent, raw)
       )
       .textStyle(Typography.metaValue)
-      .foregroundStyle(Color.muted)
+      .foregroundStyle(Color.inkSecondary)
     }
   }
 
@@ -205,6 +212,6 @@ extension SimulationView {
           .monospacedDigit()
       }
     }
-    .foregroundStyle(Color.muted)
+    .foregroundStyle(Color.inkSecondary)
   }
 }

--- a/Pastura/Pastura/Views/Simulation/SimulationView+LogEntries.swift
+++ b/Pastura/Pastura/Views/Simulation/SimulationView+LogEntries.swift
@@ -22,7 +22,7 @@ extension SimulationView {
     }
   }
 
-  // The six repoints in this file read `inkSecondary`, not §8's quietude tier:
+  // The rows #1448 batch 2 repointed to `inkSecondary` are not on §8's tier:
   // a transcript row is either the simulation's primary output (A5) or the
   // narration of a turn that degraded (A4 — ADR-021 D5 requires the transcript
   // to stay self-explanatory *at the gap*, and a gap narrated illegibly is not

--- a/Pastura/PasturaTests/Views/MutedSweepLedgerTests+BatchTwo.swift
+++ b/Pastura/PasturaTests/Views/MutedSweepLedgerTests+BatchTwo.swift
@@ -1,0 +1,147 @@
+import Foundation
+import Testing
+
+// Batch 2's applied-site pin, split out of `MutedSweepLedgerTests.swift` at
+// SwiftLint's 400-line ceiling (`testing.md` § "Splitting a Suite Across
+// Files") — an extension of that suite, never a second `@Suite`.
+
+extension MutedSweepLedgerTests {
+
+  /// One batch-2 (#1448) repointed site, anchored by a literal that is unique
+  /// among its file's **non-comment** lines. The repointed `.foregroundStyle`
+  /// sits within `window` non-comment lines after that anchor.
+  ///
+  /// Comment lines are dropped before the window is measured, so inserting or
+  /// growing a why-comment cannot slide a site out of its own window — which
+  /// batch 2 did to all eight files. A line-anchored table could not have
+  /// survived its own commit.
+  private struct BatchTwoSite {
+    let path: String
+    let anchor: String
+    let window: Int
+
+    init(_ path: String, _ anchor: String, window: Int) {
+      self.path = path
+      self.anchor = anchor
+      self.window = window
+    }
+  }
+
+  /// The nineteen sites the ledger § 5 marks `B2`, in § 5's order.
+  ///
+  /// Anchors are the nearest preceding unique line, so each window is one to
+  /// four lines and holds exactly one `Color.` styling line: the site itself.
+  /// That is what makes a failure name the site rather than a file. Keep it
+  /// that way when re-anchoring — a window wide enough to catch a *neighbouring*
+  /// `inkSecondary` passes with the site reverted.
+  private static let batchTwoSites: [BatchTwoSite] = [
+    .init(
+      "Views/Components/AgentOutputRow.swift",
+      ".textStyle(Typography.thinkingBody)", window: 1),
+    .init(
+      "Views/Simulation/SimulationView+LogEntries.swift",
+      #"Text(String(format: String(localized: "%@ assigned: %@"), agent, value))"#, window: 2),
+    .init(
+      "Views/Simulation/SimulationView+LogEntries.swift",
+      #"Text(String(format: String(localized: "  %@: %lld votes"), name, count))"#, window: 4),
+    .init(
+      "Views/Simulation/SimulationView+LogEntries.swift",
+      #"Text(String(localized: "No event this round"))"#, window: 2),
+    .init(
+      "Views/Simulation/SimulationView+LogEntries.swift",
+      #"format: String(localized: "%@'s turn was skipped (%@)"),"#, window: 4),
+    .init(
+      "Views/Simulation/SimulationView+LogEntries.swift",
+      #"format: String(localized: "%@'s choice \"%@\" wasn't an option"),"#, window: 4),
+    .init(
+      "Views/Simulation/SimulationView+LogEntries.swift",
+      "func scoresSummary(_ scores: [String: Int]) -> some View {", window: 8),
+    .init(
+      "Views/Results/ResultDetailView.swift",
+      #"Text(String(format: String(localized: "Turns skipped ×%lld"), skipped))"#, window: 1),
+    .init(
+      "Views/Results/ResultDetailView+CodePhaseRows.swift",
+      ".monospacedDigit()", window: 1),
+    .init(
+      "Views/Results/ResultDetailView+CodePhaseRows.swift",
+      #"Text(String(format: String(localized: "  %@ → %@"), filtered(voter), filtered(target)))"#,
+      window: 4),
+    .init(
+      "Views/Results/ResultDetailView+CodePhaseRows.swift",
+      #"Text(String(format: String(localized: "%@ assigned: %@"), filtered(agent), filtered(value)))"#,
+      window: 2),
+    .init(
+      "Views/Results/ResultDetailView+CodePhaseRows.swift",
+      #"Text(String(localized: "No event this round"))"#, window: 2),
+    .init(
+      "Views/Results/ResultsView.swift",
+      #"Text(String(format: String(localized: "Turns skipped ×%lld"), skipped))"#, window: 2),
+    .init(
+      "Views/ScenarioDetail/ScenarioDetailView+Sections.swift",
+      "Text(scenario.description)", window: 2),
+    .init(
+      "Views/ModelDownload/ModelDownloadHostView+CodePhaseRows.swift",
+      #"Text(String(format: String(localized: "%@ assigned: %@"), agent, value))"#, window: 2),
+    .init(
+      "Views/ModelDownload/ModelDownloadHostView+CodePhaseRows.swift",
+      #"Text(String(format: String(localized: "  %@: %lld votes"), name, count))"#, window: 4),
+    .init(
+      "Views/ModelDownload/ModelDownloadHostView+CodePhaseRows.swift",
+      "private func scoresContent(_ scores: [String: Int]) -> some View {", window: 8),
+    .init(
+      "Views/ModelDownload/ModelDownloadHostView+CodePhaseRows.swift",
+      #"Text(String(localized: "No event this round"))"#, window: 2),
+    .init(
+      "Views/Community/SharedScenarios/GalleryScenarioDetailView.swift",
+      "Text(value)", window: 1)
+  ]
+
+  /// Batch 2's counterpart, anchored per site rather than per file — see
+  /// ``expectedAppliedInkSecondary`` for why the shapes differ.
+  ///
+  /// Three assertions per site, and the **first is the control**: the anchor
+  /// must match exactly one non-comment line. A rename, a deletion, or a second
+  /// copy of the anchored line all land there and name the site, so the two
+  /// content checks below can never pass by scanning nothing. The window then
+  /// has to contain `Color.inkSecondary` and must not contain `Color.muted`;
+  /// the second is what catches a revert, and the first what catches a slide to
+  /// `Color.ink` or a raw hex that the census would wave through.
+  @Test func batchTwoSitesStillReadInkSecondary() throws {
+    #expect(Self.batchTwoSites.count == 19, "the ledger § 5 marks nineteen rows `B2`")
+
+    var failures: [String] = []
+    for site in Self.batchTwoSites {
+      let url = SourceTreeProbe.appSourceRoot.appending(path: site.path)
+      let code = try String(contentsOf: url, encoding: .utf8)
+        .split(separator: "\n", omittingEmptySubsequences: false)
+        .map { $0.trimmingCharacters(in: .whitespaces) }
+        .filter { !$0.isEmpty && !$0.hasPrefix("//") }
+
+      let hits = code.indices.filter { code[$0].contains(site.anchor) }
+      guard hits.count == 1, let start = hits.first else {
+        failures.append(
+          "  \(site.path): anchor matched \(hits.count) lines, expected 1 — \(site.anchor)")
+        continue
+      }
+      let window = code[start...min(start + site.window, code.count - 1)]
+      if !window.contains(where: { $0.contains("Color.inkSecondary") }) {
+        failures.append(
+          "  \(site.path): no `Color.inkSecondary` within \(site.window) lines of "
+            + "\(site.anchor)")
+      }
+      if window.contains(where: { $0.contains("Color.muted") }) {
+        failures.append("  \(site.path): `Color.muted` came back at \(site.anchor)")
+      }
+    }
+
+    #expect(
+      failures.isEmpty,
+      """
+      Batch 2's repointed sites no longer read `Color.inkSecondary`. An anchor \
+      that stopped resolving is a rename — re-anchor it and keep the window \
+      holding one `Color.` line. A token that changed is a design decision: \
+      re-adjudicate the site against `muted-application-audit.md` § 2 first.
+      \(failures.joined(separator: "\n"))
+      """)
+  }
+}

--- a/Pastura/PasturaTests/Views/MutedSweepLedgerTests+BatchTwo.swift
+++ b/Pastura/PasturaTests/Views/MutedSweepLedgerTests+BatchTwo.swift
@@ -31,9 +31,12 @@ extension MutedSweepLedgerTests {
   ///
   /// Anchors are the nearest preceding unique line, so each window is one to
   /// four lines and holds exactly one `Color.` styling line: the site itself.
-  /// That is what makes a failure name the site rather than a file. Keep it
-  /// that way when re-anchoring — a window wide enough to catch a *neighbouring*
-  /// `inkSecondary` passes with the site reverted.
+  /// That is what makes a failure name the site rather than a file. Keep both
+  /// properties when re-anchoring, and the second is the load-bearing one — a
+  /// window wide enough to reach a *neighbouring* `inkSecondary` passes with the
+  /// site reverted. The three `.monospacedDigit()` anchors are the same spelling
+  /// in three different files, each unique within its own; that is fine, since
+  /// uniqueness is what the control arm checks and it checks it per file.
   private static let batchTwoSites: [BatchTwoSite] = [
     .init(
       "Views/Components/AgentOutputRow.swift",
@@ -54,8 +57,7 @@ extension MutedSweepLedgerTests {
       "Views/Simulation/SimulationView+LogEntries.swift",
       #"format: String(localized: "%@'s choice \"%@\" wasn't an option"),"#, window: 4),
     .init(
-      "Views/Simulation/SimulationView+LogEntries.swift",
-      "func scoresSummary(_ scores: [String: Int]) -> some View {", window: 8),
+      "Views/Simulation/SimulationView+LogEntries.swift", ".monospacedDigit()", window: 3),
     .init(
       "Views/Results/ResultDetailView.swift",
       #"Text(String(format: String(localized: "Turns skipped ×%lld"), skipped))"#, window: 1),
@@ -87,7 +89,7 @@ extension MutedSweepLedgerTests {
       #"Text(String(format: String(localized: "  %@: %lld votes"), name, count))"#, window: 4),
     .init(
       "Views/ModelDownload/ModelDownloadHostView+CodePhaseRows.swift",
-      "private func scoresContent(_ scores: [String: Int]) -> some View {", window: 8),
+      ".monospacedDigit()", window: 3),
     .init(
       "Views/ModelDownload/ModelDownloadHostView+CodePhaseRows.swift",
       #"Text(String(localized: "No event this round"))"#, window: 2),

--- a/Pastura/PasturaTests/Views/MutedSweepLedgerTests.swift
+++ b/Pastura/PasturaTests/Views/MutedSweepLedgerTests.swift
@@ -13,7 +13,7 @@ import Testing
 /// they take opposite remedies**: a rename or a deletion means re-anchor the
 /// row by symbol rather than dropping it; an **applied batch** means the row
 /// stays put with its `B` marker bolded and the entry here is dropped, which is
-/// what batches 1 and 5 did. Read the file's § 5 rows before choosing.
+/// what batches 1, 5 and 2 did. Read the file's § 5 rows before choosing.
 ///
 /// **It fires on an addition too**, which is the half prose cannot do. The
 /// expectation is a whole-map comparison, so a new file reaching for
@@ -30,18 +30,24 @@ struct MutedSweepLedgerTests {
 
   /// Non-comment `Color.muted` occurrences per file, keyed relative to
   /// `Pastura/Pastura`. Reproduce with the ledger § 8 command; every entry is
-  /// a row (or group of rows) in § 5.
+  /// a row (or group of rows) in § 5 — with **one exception, created by batch
+  /// 2**: `ResultDetailView`'s degraded banner was a single `Label` tint at the
+  /// baseline census, and splitting it left a glyph occurrence that no
+  /// `9a40565a` row could have anticipated. The ledger records it as an added
+  /// row; § 5's tally deliberately does not move.
   ///
-  /// Batch 1 (#1448) removed eight occurrences and emptied three files, and
-  /// batch 5 (#1485) removed three more and emptied three more, so this table
-  /// is the post-batch-5 population, not § 1's `9a40565a` baseline.
+  /// Batch 1 (#1486) removed eight occurrences and emptied three files, batch 5
+  /// (#1510) removed three more and emptied three more, and batch 2 repointed
+  /// nineteen sites for a net **eighteen** occurrences — the nineteenth kept
+  /// the spelling on the glyph above — and emptied none. So this table is the
+  /// post-batch-2 population, not § 1's `9a40565a` baseline.
   private static let expectedMutedOccurrences: [String: Int] = [
     "Views/Community/SharedScenarios/GalleryCatalogRow.swift": 1,
     "Views/Community/SharedScenarios/GalleryScenarioDetailView+Highlight.swift": 2,
-    "Views/Community/SharedScenarios/GalleryScenarioDetailView.swift": 4,
+    "Views/Community/SharedScenarios/GalleryScenarioDetailView.swift": 3,
     "Views/Community/SharedScenarios/SharedScenariosListView.swift": 1,
     "Views/Components/ActiveModelChip.swift": 2,
-    "Views/Components/AgentOutputRow.swift": 3,
+    "Views/Components/AgentOutputRow.swift": 2,
     "Views/Components/DogMark.swift": 2,
     "Views/Components/GameHeaderStatus.swift": 2,
     "Views/Components/IdleFriendlyProgressView.swift": 1,
@@ -54,23 +60,23 @@ struct MutedSweepLedgerTests {
     "Views/Editor/PhaseEditorSheet+ConditionalSection.swift": 1,
     "Views/Editor/ScenarioEditorView.swift": 2,
     "Views/Home/HomeCompactScenarioRow.swift": 2,
-    "Views/ModelDownload/ModelDownloadHostView+CodePhaseRows.swift": 5,
+    "Views/ModelDownload/ModelDownloadHostView+CodePhaseRows.swift": 1,
     "Views/ModelSelection/ModelPickerView.swift": 2,
     "Views/ModelSelection/ModelRow.swift": 1,
     "Views/Report/ReportSheet.swift": 1,
-    "Views/Results/ResultDetailView+CodePhaseRows.swift": 5,
+    "Views/Results/ResultDetailView+CodePhaseRows.swift": 1,
     "Views/Results/ResultDetailView+RowLayout.swift": 1,
     "Views/Results/ResultDetailView.swift": 1,
     "Views/Results/ResultsView+Timeline.swift": 1,
-    "Views/Results/ResultsView.swift": 6,
-    "Views/ScenarioDetail/ScenarioDetailView+Sections.swift": 2,
+    "Views/Results/ResultsView.swift": 5,
+    "Views/ScenarioDetail/ScenarioDetailView+Sections.swift": 1,
     "Views/Settings/ModelSettingsRow.swift": 1,
     "Views/Settings/SettingsView+PastResults.swift": 1,
     "Views/Settings/SettingsView.swift": 2,
     "Views/Simulation/HighlightCandidatesSection.swift": 2,
     "Views/Simulation/ScoreboardSheet.swift": 3,
     "Views/Simulation/SimulationView+Background.swift": 1,
-    "Views/Simulation/SimulationView+LogEntries.swift": 9,
+    "Views/Simulation/SimulationView+LogEntries.swift": 3,
     "Views/Simulation/SimulationView.swift": 2,
     "Views/Simulation/ViewerPredictionSheet.swift": 2
   ]
@@ -162,24 +168,24 @@ struct MutedSweepLedgerTests {
   ///
   /// **The negative arm is the one carrying discriminating power.** The
   /// positive arm cannot fail alone — `expectedMutedOccurrences` already pins
-  /// that file at 9, so an always-zero predicate reddens the census first. It
+  /// that file at 3, so an always-zero predicate reddens the census first. It
   /// is kept because it fails *locally*, naming the predicate rather than
   /// printing a forty-row diff; the census map is the real positive control.
   @Test func theProbeIsStillMeasuringSomething() throws {
     let swiftFiles = SourceTreeProbe.swiftFiles(under: SourceTreeProbe.appSourceRoot)
     #expect(!swiftFiles.isEmpty, "scanned no app sources — the source root did not resolve")
 
-    // Positive: a file this sweep has NOT touched still matches, so the
-    // counting predicate has not been narrowed into always-zero. It survives
-    // its own batch too — three of its nine § 5 rows carry no batch marker
-    // (`vs`, and the turn-skipped / action-rejected icons), so B2 takes it
-    // 9 -> 3, not to zero. Pick a replacement on that property, not on
-    // "not swept yet", if this file ever does empty.
-    let unswept = "Views/Simulation/SimulationView+LogEntries.swift"
+    // Positive: a file the sweep does not empty still matches, so the
+    // counting predicate has not been narrowed into always-zero. Batch 2
+    // took this file 9 -> 3; the three survivors are the § 5 rows that carry
+    // no batch marker (`vs`, and the turn-skipped / action-rejected icons),
+    // so no later batch empties it either. Pick a replacement on that
+    // property, not on "not swept yet", if it ever does.
+    let partiallySwept = "Views/Simulation/SimulationView+LogEntries.swift"
     let observed = Self.census(of: ["Color.muted"], excludingDesignTokens: false)
     #expect(
-      (observed[unswept] ?? 0) > 0,
-      "\(unswept) stopped matching — the predicate, not the file, is the likely cause")
+      (observed[partiallySwept] ?? 0) > 0,
+      "\(partiallySwept) stopped matching — the predicate, not the file, is the likely cause")
 
     // Negative: a file whose only occurrence is a doc comment must count zero
     // while still containing the raw needle. A comment filter that did nothing

--- a/Pastura/PasturaTests/Views/MutedSweepLedgerTests.swift
+++ b/Pastura/PasturaTests/Views/MutedSweepLedgerTests.swift
@@ -121,10 +121,10 @@ struct MutedSweepLedgerTests {
   /// which is why the two applied batches are pinned differently. It works
   /// because these three files hold 1 / 1 / 2 `Color.inkSecondary` in total: a
   /// reverted header shows up as an off-by-one. Batch 2's files hold 1 to 13,
-  /// and in the three densest (13 / 11 / 10) almost all of them predate the
-  /// batch, so a revert there hides inside the total unless an unrelated edit
-  /// happens to move it the other way — the same dilution this comment's `> 0`
-  /// argument warns about, one step further along.
+  /// and in the three densest (13 / 11 / 10) roughly half predate the batch
+  /// (7 / 7 / 6), so a revert there hides inside the total unless an unrelated
+  /// edit happens to move it the other way — the same dilution this comment's
+  /// `> 0` argument warns about, one step further along.
   /// ``batchTwoSitesStillReadInkSecondary`` anchors by symbol for that reason.
   private static let expectedAppliedInkSecondary: [String: Int] = [
     "Views/Components/PasturaSection.swift": 1,

--- a/Pastura/PasturaTests/Views/MutedSweepLedgerTests.swift
+++ b/Pastura/PasturaTests/Views/MutedSweepLedgerTests.swift
@@ -120,10 +120,11 @@ struct MutedSweepLedgerTests {
   /// **A per-file count is the right shape here and the wrong one for batch 2**,
   /// which is why the two applied batches are pinned differently. It works
   /// because these three files hold 1 / 1 / 2 `Color.inkSecondary` in total: a
-  /// reverted header shows up as an off-by-one. Batch 2's files carry 4 to 13
-  /// each, most of them predating the batch, so a revert there hides inside the
-  /// total unless an unrelated edit happens to move it the other way — the same
-  /// dilution this comment's `> 0` argument warns about, one step further along.
+  /// reverted header shows up as an off-by-one. Batch 2's files hold 1 to 13,
+  /// and in the three densest (13 / 11 / 10) almost all of them predate the
+  /// batch, so a revert there hides inside the total unless an unrelated edit
+  /// happens to move it the other way — the same dilution this comment's `> 0`
+  /// argument warns about, one step further along.
   /// ``batchTwoSitesStillReadInkSecondary`` anchors by symbol for that reason.
   private static let expectedAppliedInkSecondary: [String: Int] = [
     "Views/Components/PasturaSection.swift": 1,

--- a/Pastura/PasturaTests/Views/MutedSweepLedgerTests.swift
+++ b/Pastura/PasturaTests/Views/MutedSweepLedgerTests.swift
@@ -116,6 +116,15 @@ struct MutedSweepLedgerTests {
   /// `> 0` check there would pass with the header reverted. Scoped to these
   /// three files on purpose — this is a pin on B5's applied rows, not a second
   /// app-wide census.
+  ///
+  /// **A per-file count is the right shape here and the wrong one for batch 2**,
+  /// which is why the two applied batches are pinned differently. It works
+  /// because these three files hold 1 / 1 / 2 `Color.inkSecondary` in total: a
+  /// reverted header shows up as an off-by-one. Batch 2's files carry 4 to 13
+  /// each, most of them predating the batch, so a revert there hides inside the
+  /// total unless an unrelated edit happens to move it the other way — the same
+  /// dilution this comment's `> 0` argument warns about, one step further along.
+  /// ``batchTwoSitesStillReadInkSecondary`` anchors by symbol for that reason.
   private static let expectedAppliedInkSecondary: [String: Int] = [
     "Views/Components/PasturaSection.swift": 1,
     "Views/Home/HomeView.swift": 1,

--- a/docs/decisions/ADR-028.md
+++ b/docs/decisions/ADR-028.md
@@ -2966,10 +2966,11 @@ move them: `GameHeaderStatus`'s **seven enum arms** in § Amendment 2026-08-13
 § Amendment 2026-08-13 (#1427) established that §8's `muted` exemption is
 ground-relative and named the app-wide sweep as #1448. That sweep's **first
 batch** lands here, together with its ledger and the decisions it was chartered
-to make; batches 2–5 are open and every remaining site still ships as written.
-**No new token; no change to §8's decision.** What changes is
-what §8 can be *cited* for, and whether the population it governs is tracked by
-anything but prose.
+to make. **Which batches have since applied is not recorded here** — that is a
+moving inventory, and `adr-writing.md` § 4 forbids mirroring one into an ADR;
+the ledger's § 7 table is the single source. **No new token; no change to §8's
+decision.** What changes is what §8 can be *cited* for, and whether the
+population it governs is tracked by anything but prose.
 
 ### The washes are a second unmeasured ground, not a new floor
 

--- a/docs/decisions/ADR-028.md
+++ b/docs/decisions/ADR-028.md
@@ -2966,9 +2966,11 @@ move them: `GameHeaderStatus`'s **seven enum arms** in § Amendment 2026-08-13
 § Amendment 2026-08-13 (#1427) established that §8's `muted` exemption is
 ground-relative and named the app-wide sweep as #1448. That sweep's **first
 batch** lands here, together with its ledger and the decisions it was chartered
-to make. **Which batches have since applied is not recorded here** — that is a
+to make. **Which of B2–B6 have since applied is not tracked here** — that is a
 moving inventory, and `adr-writing.md` § 4 forbids mirroring one into an ADR;
-the ledger's § 7 table is the single source. **No new token; no change to §8's
+the ledger's § 7 table is the single source. (An amendment that *lands* a batch
+still says so in its own record, as the #1485 one below does — what is barred is
+a running tally of the ones it does not own.) **No new token; no change to §8's
 decision.** What changes is what §8 can be *cited* for, and whether the
 population it governs is tracked by anything but prose.
 

--- a/docs/design/muted-application-audit.md
+++ b/docs/design/muted-application-audit.md
@@ -46,10 +46,10 @@ is **70 lines · 4 doc-comment mentions · 66 code sites across 37 files**.
 `MutedSweepLedgerTests` pins the per-file breakdown — §8.
 
 The mentions went 3 → 4 because batch 2's why-comment in `ResultDetailView`
-names the token it left behind. **A comment mention is not a site** — the §8
-command subtracts them, and the guard's own predicate skips comment lines — but
-the raw line count moves, so a reader diffing the first figure alone would read
-a repoint that removed eighteen occurrences as having removed seventeen.
+names the token it left behind. **A comment mention is not a site** — §8's
+command and the guard both skip comment lines, but the raw line count above
+counts them, so it moved by seventeen while the occurrence count moved by
+eighteen.
 
 **Nineteen sites, eighteen occurrences: the gap is `ResultDetailView`.** Its
 degraded banner was one `Label` carrying a single `.foregroundStyle`, so moving
@@ -473,12 +473,12 @@ above opens two of its own rows with `` | ` ``.
 `9a40565a` census of adjudications; §1 carries the population as it *ships*.
 The difference between the two is exactly the applied batches.
 
-**A batch can still add a row, and batch 2 did** — that is a different event from
-a batch *applying*, and it is why the glyph row above is marked rather than
-folded in. A repoint that changes a call's **shape** can mint an occurrence the
-baseline census never adjudicated, so §5 has to be able to carry a row that its
-own tally does not count. Expect this whenever a batch splits one styling call
-into two; a plain token swap cannot cause it.
+**A batch can also add a row** — a different event from *applying*, which is why
+the glyph row above is marked rather than folded in. A repoint that changes a
+call's **shape** mints an occurrence the baseline census never adjudicated, so
+§5 must be able to carry a row its own tally does not count. Expect it whenever
+a batch splits one styling call into two or makes any other multi-slot move; a
+plain token swap cannot cause it.
 
 ## 6. Decisions this sweep was chartered to make
 
@@ -640,10 +640,10 @@ is written into `docs/qa/dark-mode-qa.md` § 2 so a later edit to one of them ha
 somewhere to be checked against.
 
 **`MutedSweepLedgerTests+BatchTwo` pins B2's applied sites by symbol**, not by
-per-file `Color.inkSecondary` count the way B5's arm does. B2's files hold one
-to thirteen of that token each; in the three densest (13 / 11 / 10) roughly half
-predate the batch (7 / 7 / 6), so a per-file total there cannot attribute a
-revert to a site — one reverted site hides in a total that size either way. Its doc comment carries the derivation.
+per-file `Color.inkSecondary` count the way B5's arm does: in B2's densest files
+roughly half of that token predates the batch, so a per-file total there cannot
+attribute a revert to a site. The figures are in the doc comment on
+`MutedSweepLedgerTests.expectedAppliedInkSecondary`, the one place they are kept.
 
 Batches are ordered by how settled the judgement is, not by size. B2 and B3 are
 straightforward applications of §2 once B1 establishes the shape — with the

--- a/docs/design/muted-application-audit.md
+++ b/docs/design/muted-application-audit.md
@@ -463,9 +463,10 @@ both `ScoreboardSheet` rows), five otherwise sanctioned or non-text
 separately: they need no repoint, but §8 cannot currently be *cited* for them
 either.
 
-These counts are re-derivable from the tables — count `| \`` lines, expand the
-two `×N` rows, and drop the row marked **added by B2** — rather than maintained
-by hand.
+These counts are re-derivable from the tables — count `| \`` lines **above this
+`### Tally` heading**, expand the two `×N` rows, and drop the row marked **added
+by B2** — rather than maintained by hand. The bound matters: the table just
+above opens two of its own rows with `` | ` ``.
 
 **They do not move when a batch applies**, and the gap that opens is not drift.
 §5 keeps an applied row, so the row set — and this tally with it — stays the
@@ -640,9 +641,9 @@ somewhere to be checked against.
 
 **`MutedSweepLedgerTests+BatchTwo` pins B2's applied sites by symbol**, not by
 per-file `Color.inkSecondary` count the way B5's arm does. B2's files hold one
-to thirteen of that token each; in the three densest (13 / 11 / 10) almost all
-of them predate the batch, so a per-file total there cannot attribute a revert
-to a site. Its doc comment carries the derivation.
+to thirteen of that token each; in the three densest (13 / 11 / 10) roughly half
+predate the batch (7 / 7 / 6), so a per-file total there cannot attribute a
+revert to a site — one reverted site hides in a total that size either way. Its doc comment carries the derivation.
 
 Batches are ordered by how settled the judgement is, not by size. B2 and B3 are
 straightforward applications of §2 once B1 establishes the shape — with the

--- a/docs/design/muted-application-audit.md
+++ b/docs/design/muted-application-audit.md
@@ -8,8 +8,8 @@ examples in `PredictionOutcomeBadge`.
 
 **This file is the sweep's ledger, not its rule.** §8 remains normative; what is
 recorded here is the per-site *application* of §8 across the population, plus the
-adjudications that were judgement calls. The sweep runs in batches — batches 1
-and 5 are applied; every other row still ships as written.
+adjudications that were judgement calls. The sweep runs in batches — batches 1,
+2 and 5 are applied; every other row still ships as written.
 
 ## 1. Population
 
@@ -40,9 +40,22 @@ sibling `+Feature.swift` split: cross-check against
 Discipline).
 
 Batch 1 removed eight occurrences and emptied three files; batch 5 (#1485)
-removed three more and emptied three more, so the population as it ships today
-is **87 lines · 3 doc-comment mentions · 84 code sites across 37 files**.
+removed three more and emptied three more; batch 2 repointed nineteen sites for
+a net eighteen occurrences and emptied none. So the population as it ships today
+is **70 lines · 4 doc-comment mentions · 66 code sites across 37 files**.
 `MutedSweepLedgerTests` pins the per-file breakdown — §8.
+
+The mentions went 3 → 4 because batch 2's why-comment in `ResultDetailView`
+names the token it left behind. **A comment mention is not a site** — the §8
+command subtracts them, and the guard's own predicate skips comment lines — but
+the raw line count moves, so a reader diffing the first figure alone would read
+a repoint that removed eighteen occurrences as having removed seventeen.
+
+**Nineteen sites, eighteen occurrences: the gap is `ResultDetailView`.** Its
+degraded banner was one `Label` carrying a single `.foregroundStyle`, so moving
+the text off `muted` meant tinting the two slots separately, and the glyph kept
+the spelling. That occurrence is an **addition this sweep made**, not a survivor
+— see the second `ResultDetailView` row in §5.
 
 ### 1.1 One rendering site outside the `Color.muted` spelling
 
@@ -292,7 +305,7 @@ Verdicts: **S** sanctioned · **M** misapplication (class in brackets) ·
 **U** unmeasured ground, exemption cannot be cited · **N** non-text (1.4.11,
 out of §8's scope) · **P** `#Preview`, never ships · **C** comment mention.
 
-`B` names the batch. `B1` and `B5` are applied; everything else still ships as
+`B` names the batch. `B1`, `B2` and `B5` are applied; everything else still ships as
 written. An applied row is **kept**, not deleted — the adjudication is what §5
 records, and the bolded batch marker is what says the repoint landed.
 
@@ -306,7 +319,7 @@ records, and the bolded batch marker is what says the repoint landed.
 | `AgentOutputRow` · share glyph | `screenBackground` | 3.329 / 3.779 | N | — |
 | `AgentOutputRow` · `INNER VOICE` tag | `screenBackground` | 3.329 / 3.779 | S — discloser label, not the disclosed | — |
 | `AgentOutputRow` · rationale comment | — | — | C | — |
-| `AgentOutputRow` · `thoughtBody` | `screenBackground` | 3.329 / 3.779 | **M (A5)** — the model's inner monologue is product, not metadata | B2 |
+| `AgentOutputRow` · `thoughtBody` | `screenBackground` | 3.329 / 3.779 | **M (A5)** — the model's inner monologue is product, not metadata | **B2** |
 | `DogMark` · `26 pt` / `44 pt` captions ×2 | `screenBackground` | — | P | — |
 | `GameHeaderStatus` · `foreground` (paused/cancelled/error) | `muted@0.14` self-wash over `screenBackground@0.78` | unmeasurable | **M (A1)** + U — the run-state pill is the header's reason to exist | B4 |
 | `GameHeaderStatus` · `washToken` | same | unmeasurable | N | — |
@@ -340,15 +353,15 @@ what the reader came to compare.
 | `SimulationView` · scrim-label comment | — | — | C | — |
 | `SimulationView` · loading-scrim subtitle | `.regularMaterial` | unmeasurable | S + U — elaborates a title already at `ink` | B4 |
 | `SimulationView+Background` · BG-continuation glyph | `screenBackground` | 3.329 / 3.779 | N | — |
-| `SimulationView+LogEntries` · `assignmentEntry` | `screenBackground` | 3.329 / 3.779 | **M (A5)** | B2 |
-| `SimulationView+LogEntries` · `voteResultsEntry` | `screenBackground` | 3.329 / 3.779 | **M (A5)** | B2 |
+| `SimulationView+LogEntries` · `assignmentEntry` | `screenBackground` | 3.329 / 3.779 | **M (A5)** | **B2** |
+| `SimulationView+LogEntries` · `voteResultsEntry` | `screenBackground` | 3.329 / 3.779 | **M (A5)** | **B2** |
 | `SimulationView+LogEntries` · `pairingResultEntry` `vs` | `screenBackground` | 3.329 / 3.779 | S — separator | — |
-| `SimulationView+LogEntries` · `eventInjectedEntry` miss | `screenBackground` | 3.329 / 3.779 | **M (A4)** | B2 |
+| `SimulationView+LogEntries` · `eventInjectedEntry` miss | `screenBackground` | 3.329 / 3.779 | **M (A4)** | **B2** |
 | `SimulationView+LogEntries` · `turnSkippedEntry` icon | `screenBackground` | 3.329 / 3.779 | N | — |
-| `SimulationView+LogEntries` · `turnSkippedEntry` text | `screenBackground` | 3.329 / 3.779 | **M (A4)** — ADR-021 D5 | B2 |
+| `SimulationView+LogEntries` · `turnSkippedEntry` text | `screenBackground` | 3.329 / 3.779 | **M (A4)** — ADR-021 D5 | **B2** |
 | `SimulationView+LogEntries` · `actionRejectedEntry` icon | `screenBackground` | 3.329 / 3.779 | N | — |
-| `SimulationView+LogEntries` · `actionRejectedEntry` text | `screenBackground` | 3.329 / 3.779 | **M (A4)** — ADR-021 D5 | B2 |
-| `SimulationView+LogEntries` · `scoresSummary` | `screenBackground` | 3.329 / 3.779 | **M (A5)** | B2 |
+| `SimulationView+LogEntries` · `actionRejectedEntry` text | `screenBackground` | 3.329 / 3.779 | **M (A4)** — ADR-021 D5 | **B2** |
+| `SimulationView+LogEntries` · `scoresSummary` | `screenBackground` | 3.329 / 3.779 | **M (A5)** | **B2** |
 | `ViewerPredictionSheet` · eyebrow | `page` | 3.030 / 4.152 | S — category label | — |
 | `ViewerPredictionSheet` · `%lld s left` | `page` | 3.030 / 4.152 | **M (A3)** — a deadline the user acts against; the sheet auto-skips at zero | B3 |
 | `ReportSheet` · `ID: %@` chip | `rule@0.45` | 2.300–3.018 / 2.520–3.503 | S + U — the ID is embedded in the report URL anyway | B4 |
@@ -357,24 +370,25 @@ what the reader came to compare.
 
 | Site (file · symbol) | Ground | light/dark | Verdict | B |
 |---|---|---|---|---|
-| `ResultDetailView` · turns-skipped banner | `screenBackground` | 3.329 / 3.779 | **M (A4)** | B2 |
-| `ResultDetailView+CodePhaseRows` · `scoreUpdateRow` | `screenBackground` | 3.329 / 3.779 | **M (A5)** | B2 |
-| `ResultDetailView+CodePhaseRows` · `voteResultsRow` | `screenBackground` | 3.329 / 3.779 | **M (A5)** | B2 |
+| `ResultDetailView` · turns-skipped banner text | `screenBackground` | 3.329 / 3.779 | **M (A4)** | **B2** |
+| `ResultDetailView` · turns-skipped banner glyph | `screenBackground` | 3.329 / 3.779 | N — **added by B2**, see below | — |
+| `ResultDetailView+CodePhaseRows` · `scoreUpdateRow` | `screenBackground` | 3.329 / 3.779 | **M (A5)** | **B2** |
+| `ResultDetailView+CodePhaseRows` · `voteResultsRow` | `screenBackground` | 3.329 / 3.779 | **M (A5)** | **B2** |
 | `ResultDetailView+CodePhaseRows` · `vs` | `screenBackground` | 3.329 / 3.779 | S — separator | — |
-| `ResultDetailView+CodePhaseRows` · `assignmentRow` | `screenBackground` | 3.329 / 3.779 | **M (A5)** | B2 |
-| `ResultDetailView+CodePhaseRows` · `eventInjectedRow` | `screenBackground` | 3.329 / 3.779 | **M (A4)** | B2 |
+| `ResultDetailView+CodePhaseRows` · `assignmentRow` | `screenBackground` | 3.329 / 3.779 | **M (A5)** | **B2** |
+| `ResultDetailView+CodePhaseRows` · `eventInjectedRow` | `screenBackground` | 3.329 / 3.779 | **M (A4)** | **B2** |
 | `ResultDetailView+RowLayout` · `↳ sub-phase` | `screenBackground` | 3.329 / 3.779 | S — nesting marker | — |
 | `ResultsView` · row chevron | `screenBackground` | 3.329 / 3.779 | N | — |
 | `ResultsView` · `categoryCaption` | `screenBackground` or `bubbleBackground` | 3.329 / 3.021 worst | S — list caption, §8's named shape | — |
 | `ResultsView` · timestamp | same | same | S — list caption | — |
-| `ResultsView` · `degradedRunCaption` | same | same | **M (A4)** | B2 |
+| `ResultsView` · `degradedRunCaption` | same | same | **M (A4)** | **B2** |
 | `ResultsView` · `pillForeground(.pending)` | `muted@0.14` self-wash | 2.895 / 3.239 | S on role + **U** — see §6.2 | B4 |
 | `ResultsView` · `pillBackground(.pending)` | row ground | — | N | — |
 | `ResultsView+Timeline` · `N records` | `screenBackground` | 3.329 / 3.779 | S — count of the list below it | — |
 | `HomeView` · `Scenarios` header | `screenBackground` | 3.329 / 3.779 | S on contrast — routing → `--ink-2`, see §6.3 | **B5** |
 | `HomeCompactScenarioRow` · chevron | `screenBackground` | 3.329 / 3.779 | N | — |
 | `HomeCompactScenarioRow` · `caption` | `screenBackground` | 3.329 / 3.779 | **S — permissive control** | — |
-| `ScenarioDetailView+Sections` · description | `screenBackground` | 3.329 / 3.779 | **M (A5)** — the scenario's own description | B2 |
+| `ScenarioDetailView+Sections` · description | `screenBackground` | 3.329 / 3.779 | **M (A5)** — the scenario's own description | **B2** |
 | `ScenarioDetailView+Sections` · phase ordinal | `bubbleBackground` | 3.475 / 3.021 | S — derivable from order | — |
 
 ### Settings · ModelSelection · ModelDownload
@@ -395,11 +409,11 @@ what the reader came to compare.
 | `ModelPickerView` · `PASTURA · SETUP` | `screenBackground` | 3.329 / 3.779 | S — branding eyebrow | — |
 | `ModelPickerView` · add-later reassurance | `screenBackground` | 3.329 / 3.779 | S — footnote | — |
 | `ModelRow` · vendor · size meta | `moss@0.06` when selected, else `bubbleBackground` | 3.287 / 2.693 | **M (A3)** + U — bundles the file size | B4 |
-| `ModelDownloadHostView+CodePhaseRows` · `codePhaseContent` `.assignment` arm | `screenBackground` | 3.329 / 3.779 | **M (A5)** | B2 |
-| `ModelDownloadHostView+CodePhaseRows` · `voteResultsContent` | `screenBackground` | 3.329 / 3.779 | **M (A5)** | B2 |
-| `ModelDownloadHostView+CodePhaseRows` · `scoresContent` | `screenBackground` | 3.329 / 3.779 | **M (A5)** | B2 |
+| `ModelDownloadHostView+CodePhaseRows` · `codePhaseContent` `.assignment` arm | `screenBackground` | 3.329 / 3.779 | **M (A5)** | **B2** |
+| `ModelDownloadHostView+CodePhaseRows` · `voteResultsContent` | `screenBackground` | 3.329 / 3.779 | **M (A5)** | **B2** |
+| `ModelDownloadHostView+CodePhaseRows` · `scoresContent` | `screenBackground` | 3.329 / 3.779 | **M (A5)** | **B2** |
 | `ModelDownloadHostView+CodePhaseRows` · `vs` | `screenBackground` | 3.329 / 3.779 | S — separator | — |
-| `ModelDownloadHostView+CodePhaseRows` · `eventInjectedContent` | `screenBackground` | 3.329 / 3.779 | **M (A4)** | B2 |
+| `ModelDownloadHostView+CodePhaseRows` · `eventInjectedContent` | `screenBackground` | 3.329 / 3.779 | **M (A4)** | **B2** |
 | `DLCompleteOverlay` · `Tap anywhere to begin` | `.ultraThinMaterial` | unmeasurable | **M (A2)** — the overlay is tap-gated | **B1** |
 
 ### Community · Editor
@@ -410,7 +424,7 @@ what the reader came to compare.
 | `GalleryScenarioDetailView` · external-link glyph | `screenBackground` | 3.329 / 3.779 | N | — |
 | `GalleryScenarioDetailView` · step numeral | `bubbleBackground` | 3.475 / 3.021 | S — derivable from order | — |
 | `GalleryScenarioDetailView` · read-only disclaimer | `screenBackground` | 3.329 / 3.779 | S — footnote | — |
-| `GalleryScenarioDetailView` · detail-row values | `bubbleBackground` | 3.475 / 3.021 | **M (A3)** — `Est. inferences` is what a user checks a device against before running | B2 |
+| `GalleryScenarioDetailView` · detail-row values | `bubbleBackground` | 3.475 / 3.021 | **M (A3)** — `Est. inferences` is what a user checks a device against before running | **B2** |
 | `GalleryScenarioDetailView+Highlight` · `hook.caption` | `bubbleBackground` | 3.475 / 3.021 | S — footnote on the excerpt | — |
 | `GalleryScenarioDetailView+Highlight` · edit invitation | `bubbleBackground` | 3.475 / 3.021 | S — the CTA is the button | — |
 | `GalleryScenarioDetailView+RecommendedModel` · switch-blocked reason | `bubbleBackground` | 3.475 / 3.021 | **M (A1)** | **B1** |
@@ -422,8 +436,12 @@ what the reader came to compare.
 
 ### Tally
 
-The tables above print **94** lines for **98** sites — two rows collapse repeats
-(`DogMark` ×2, `SheepAvatar` ×4), both `#Preview`. Expanded:
+The tables above print **95** lines for **98** sites. Two collapse repeats
+(`DogMark` ×2, `SheepAvatar` ×4), both `#Preview`, and **one is not a baseline
+row at all** — `ResultDetailView`'s banner glyph, which batch 2 created by
+splitting a single `Label` tint into two. It is marked in place and excluded
+from every figure below; the arithmetic is over the 94 rows the `9a40565a`
+census had. Expanded:
 
 | | count |
 |---|---|
@@ -445,13 +463,21 @@ both `ScoreboardSheet` rows), five otherwise sanctioned or non-text
 separately: they need no repoint, but §8 cannot currently be *cited* for them
 either.
 
-These counts are re-derivable from the tables — count `| \`` lines and expand the
-two `×N` rows — rather than maintained by hand.
+These counts are re-derivable from the tables — count `| \`` lines, expand the
+two `×N` rows, and drop the row marked **added by B2** — rather than maintained
+by hand.
 
 **They do not move when a batch applies**, and the gap that opens is not drift.
 §5 keeps an applied row, so the row set — and this tally with it — stays the
 `9a40565a` census of adjudications; §1 carries the population as it *ships*.
 The difference between the two is exactly the applied batches.
+
+**A batch can still add a row, and batch 2 did** — that is a different event from
+a batch *applying*, and it is why the glyph row above is marked rather than
+folded in. A repoint that changes a call's **shape** can mint an occurrence the
+baseline census never adjudicated, so §5 has to be able to carry a row that its
+own tally does not count. Expect this whenever a batch splits one styling call
+into two; a plain token swap cannot cause it.
 
 ## 6. Decisions this sweep was chartered to make
 
@@ -594,23 +620,35 @@ titles, not subordinate labels.
 | | Scope | Sites | State |
 |---|---|---|---|
 | **B1** | Blocked-state reasons, the tap-to-proceed instruction, and act-on numbers, in Settings / model management / gallery | 8 | **applied (#1448)** |
-| **B2** | A4 + A5 — the simulation transcript and past-run detail rows: assignments, tallies, score summaries, degraded-turn narration, the scenario description, the gallery detail rows | 19 | open — **ADR-028 gate 4/5 device QA required** |
+| **B2** | A3 + A4 + A5 — the simulation transcript and past-run detail rows: assignments, tallies, score summaries, degraded-turn narration, the scenario description, and the gallery detail values (the one A3 here) | 19 | **applied (#1448)** |
 | **B3** | Eliminated-player rows (`ScoreboardSheet`, `SimulationResultCard`) and the prediction countdown | 6 | open |
 | **B4** | Composited and material grounds as one question — the self-wash pills, `ActiveModelChip`, `ModelRow`, `ReportSheet`, `GameHeaderStatus` — plus §6.1's routing fix | 2 misapplications + 1 routing, over 8 rows carrying 7 of the 9 **U** flags | open |
 | **B5** | §6.3's §2.2 alignment — the `PasturaSection` header plus 2 hand-rolled ones: 3 repointed call sites, 5 screens repainted | 3 | **applied (#1485)** |
 | **B6** | §6.3's open question — system `Form` / `List` section headers still on `secondaryLabel`. **Not a `Color.muted` batch**: these sites carry no token at all, so nothing in §1, §5 or the census counts them — and unlike B2–B4, no unprompted guard ever routes an editor here. It therefore **outlives its own umbrella**: #1448 closes when the `Color.muted` census reads done, which B6 contributes nothing to. So — **do not close #1448 while this row is open; spin B6 out as its own issue at #1448-close time.** Needs the substrate decision before any site moves | 21 over 9 files | open — undecided |
 
-B2 is the larger visual change of the two batches carrying a QA note — nineteen
+B2 was the larger visual change of the two batches carrying a QA note — nineteen
 sites across the transcript and past-run detail, moving in the raise-contrast
 direction on the app's core reading surfaces. It is also the batch where a test
-cannot see the risk: `SimulationView+LogEntries` and
+could not see the risk: `SimulationView+LogEntries` and
 `ModelDownloadHostView+CodePhaseRows` are a **byte-for-byte duplicated pair**
 (the DL-time demo mirrors the live log deliberately), so applying one and not
 the other diverges the two visually while every count in `MutedSweepLedgerTests`
-still reconciles.
+still reconciles. They were applied in one commit, and comparing the two screens
+row-for-row is a **device-QA** step rather than something the diff settles — it
+is written into `docs/qa/dark-mode-qa.md` § 2 so a later edit to one of them has
+somewhere to be checked against.
+
+**`MutedSweepLedgerTests+BatchTwo` pins B2's applied sites by symbol**, not by
+per-file `Color.inkSecondary` count the way B5's arm does. B2's files hold one
+to thirteen of that token each; in the three densest (13 / 11 / 10) almost all
+of them predate the batch, so a per-file total there cannot attribute a revert
+to a site. Its doc comment carries the derivation.
 
 Batches are ordered by how settled the judgement is, not by size. B2 and B3 are
-straightforward applications of §2 once B1 establishes the shape; B4 needs §8 to
+straightforward applications of §2 once B1 establishes the shape — with the
+caveat B2 turned up: a site whose token sits on a `Label` or any other
+multi-slot call cannot be repointed without changing the call's shape, and that
+is a decision, not a swap (§5's added glyph row); B4 needs §8 to
 say what a *material or otherwise unmeasurable* ground routes to before any
 site moves — the routing for a merely-composited one is already in §8's
 `*-on-wash` bullet, so stating the gate that way would leave it already

--- a/docs/qa/dark-mode-qa.md
+++ b/docs/qa/dark-mode-qa.md
@@ -140,11 +140,12 @@ If it reads wrong, the fix is one change to `PasturaSection`'s header treatment
 the token table, not from any one screen. Derivation: `muted-application-audit`
 §6.3.
 
-### Transcript rows on `--ink-2` — one question, asked on six screens (#1448 batch 2)
+### Transcript rows on `--ink-2` — three questions (#1448 batch 2)
 
 Batch 2 moved nineteen transcript and past-run rows off `--muted` onto
 `--ink-2` — assignments, vote tallies, score summaries, degraded-turn
-narration, the scenario description, the gallery detail values. §2.2 assigns
+narration, the agent's revealed thought body, the scenario description, the
+gallery detail values. §2.2 assigns
 `--ink-2` to subtext, and the vote header already read it, so a code-phase row
 now shares its colour with the line above it and differs from the agent
 utterances only by `--ink` vs `--ink-2`. **Does a code-phase row still read
@@ -167,9 +168,21 @@ unmeasurable is the hierarchy.
 - [ ] **ScenarioDetail** — the scenario description, now `--ink-2`, above phase
       ordinals that stay `--muted`.
 - [ ] **Gallery detail** — the detail-row values (`Est. inferences`) against
-      their `--ink` labels, with the read-only disclaimer still `--muted`.
+      their `--ink` labels, with the read-only disclaimer still `--muted`. The
+      `A glimpse of a real run` figure mounts `AgentOutputRow`, so the thought
+      question below is asked here too.
 
-**The second question is the ⚠️ glyph.** The degraded-turn warning symbol stays
+**The second question is the thought body**, and it is not a code-phase row —
+so the question above does not reach it. `AgentOutputRow`'s revealed inner
+monologue moved to `--ink-2` while the `INNER VOICE` tag above it stays
+`--muted`, and the same batch's comment in that file records that the body has
+**left** the moss-prefix / muted-body pairing the `ThoughtLeftRule` was drawn
+around. **Does the disclosed thought still read as an aside rather than as
+speech?** Ask it on all four surfaces that mount the row: Simulation live, Demo
+replay, Results detail, and the Gallery-detail highlight figure. The tag-vs-body
+split is the thing to look at — they no longer share a colour.
+
+**The third question is the ⚠️ glyph.** The degraded-turn warning symbol stays
 on `--muted` while its label moved, on the two screens that draw it — Simulation
 live and Results detail. (The Results-list caption carries no glyph, which is
 why its row above asks a different question.) §8 is a text bar and glyphs answer
@@ -179,6 +192,8 @@ kept its `Label` and moved to the title/icon closure form, the only way to tint
 the two slots apart; confirm its icon gap still matches what shipped.
 
 Derivation: `muted-application-audit` §2 (classes A3/A4/A5) and §5.
+
+### The walk
 
 - [ ] **Home** — cards, `ActiveModelChip` (including its warning / danger states
       if reachable), scenario rows. Avatars invert through

--- a/docs/qa/dark-mode-qa.md
+++ b/docs/qa/dark-mode-qa.md
@@ -140,6 +140,46 @@ If it reads wrong, the fix is one change to `PasturaSection`'s header treatment
 the token table, not from any one screen. Derivation: `muted-application-audit`
 §6.3.
 
+### Transcript rows on `--ink-2` — one question, asked on six screens (#1448 batch 2)
+
+Batch 2 moved nineteen transcript and past-run rows off `--muted` onto
+`--ink-2` — assignments, vote tallies, score summaries, degraded-turn
+narration, the scenario description, the gallery detail values. §2.2 assigns
+`--ink-2` to subtext, and the vote header already read it, so a code-phase row
+now shares its colour with the line above it and differs from the agent
+utterances only by `--ink` vs `--ink-2`. **Does a code-phase row still read
+*subordinate* to the utterances it sits between?** Not "is it legible" — the
+ratio rose on every one of these, and the after-figures live in
+`DesignTokensTests+MutedAsContent` rather than being copied here. What is
+unmeasurable is the hierarchy.
+
+- [ ] **Simulation (live)** — priority. Run a scenario that produces an
+      assignment, a vote tally, a score summary, an event miss, and at least one
+      skipped or rejected turn. All five kinds sit between chat bubbles.
+- [ ] **Demo replay** (model-download host) — the same five rows, byte-for-byte
+      mirrored from the live log by design. **Compare the two screens
+      row-for-row**: this is the pairing no count can see, since applying one
+      file and not the other leaves every census green.
+- [ ] **Results detail** — the same rows again on the past-run mirror, plus the
+      degraded-run banner.
+- [ ] **Results list** — the degraded-run caption under a row whose category
+      caption and timestamp are still `--muted`. Three tiers in one row.
+- [ ] **ScenarioDetail** — the scenario description, now `--ink-2`, above phase
+      ordinals that stay `--muted`.
+- [ ] **Gallery detail** — the detail-row values (`Est. inferences`) against
+      their `--ink` labels, with the read-only disclaimer still `--muted`.
+
+**The second question is the ⚠️ glyph.** The degraded-turn warning symbol stays
+on `--muted` while its label moved, on the two screens that draw it — Simulation
+live and Results detail. (The Results-list caption carries no glyph, which is
+why its row above asks a different question.) §8 is a text bar and glyphs answer
+to WCAG 1.4.11 instead, so the split is deliberate — but the pair has to read as
+**one annotation**, not as a faded icon beside live text. The Results-detail one
+kept its `Label` and moved to the title/icon closure form, the only way to tint
+the two slots apart; confirm its icon gap still matches what shipped.
+
+Derivation: `muted-application-audit` §2 (classes A3/A4/A5) and §5.
+
 - [ ] **Home** — cards, `ActiveModelChip` (including its warning / danger states
       if reachable), scenario rows. Avatars invert through
       `SheepAvatarPalette.resolved(colorScheme:)`, not through a token alias.


### PR DESCRIPTION
## Summary

`muted` 適用監査（#1448）の **batch 2**。台帳 §5 が `B2` と裁定した19サイトを
`Color.muted` から `Color.inkSecondary` へ repoint する。

**コントラストの修理ではなく §8 の適用。** transcript 行はシミュレーションの一次出力
(A5)、劣化したターンのナレーション (A4 / ADR-021 D5)、あるいはユーザーが行動の対象に
する数値 (A3) で、いずれも §8 が quietude ティアに置くことを禁じている情報にあたる。
同じファイルに残る `vs` 区切り・グリフ・一覧キャプションは S/N 裁定のまま据え置く。
19サイトの地はすべて不透明（`screenBackground` / `bubbleBackground`）なので、§8 の
「中立なカード面なら `--ink-2`」が適用される段。

- **8ファイル・19サイト** — assignments / vote tallies / score summaries / 劣化ターンの
  ナレーション / thought body / シナリオ説明 / gallery の detail 値
- **常設ガードに B2 のアーム** `MutedSweepLedgerTests+BatchTwo` — サイト単位の
  anchor + 窓で pin
- **台帳・ADR-028・実機QA** を更新

batch 3 / 4 は未着手、B6 は #1448 クローズ時に単独 issue へ切り出す（台帳 §7）。

## 計画からの逸脱 — 19サイトだが減った occurrence は18

`ResultDetailView` の劣化バナーは **1つの `Label` に `.foregroundStyle` が1つ**乗る形
だった。テキストだけを動かすにはスロット別に色を付けるほかなく、`Label` の title/icon
closure 形式へ書き換えてグリフを `muted` に残した（`SimulationView+LogEntries` の2つの
三角と揃う。§8 はテキストのバーで、グリフは WCAG 1.4.11 側）。

結果として**この掃引が occurrence を1つ作った**。台帳 `9a40565a` の census にはこの行が
無いので、§5 に「added by B2」と明示した行を足し、tally は94行基準のまま据え置いた
（applied で動かない、という §5 の規約と同じ理由で、**追加**でも動かさない）。
§7 に一般化を残してある: トークンの入れ替えでは call の**形**は変わらないが、
multi-slot な call に乗ったトークンは形を変えずに repoint できず、それは swap ではなく
判断になる。B3/B4 が同じ形に当たったときの前置き。

副次的に doc-comment mention が 3 → 4 に増えた（上のグリフを説明する why コメントが
トークン名を含むため）。site ではないので §8 のコマンドは引くが、生の行数は動く。

## なぜガードの形が B5 と違うのか

census が縛るのは `Color.muted` の**不在**だけで、repoint 後に残る検出力は「旧トークンへの
差し戻し」の一方向しかない。B5 はファイル別 `Color.inkSecondary` 件数で塞いだが、その形が
効くのは対象3ファイルが計 1/1/2 しか持たないから。**B2 のファイルは 1〜13 件**あり、
密な3ファイル（13/11/10）では約半分（7/7/6）がバッチ以前のものなので、1件の差し戻しが
合計の中に隠れる。

そこで B2 は**サイト単位**で pin する。各行は「ファイル内の非コメント行で一意なアンカー」
+「そこから何行以内に repoint した `.foregroundStyle` があるか」で、窓は 1〜4行・`Color.`
の行をちょうど1つだけ含む。**窓の測定前にコメント行を落とす**ので、why コメントの挿入で
サイトが窓から滑り出ることはない — 本ブランチ自身が8ファイル全部にコメントを入れており、
行番号アンカーなら自分のコミットを越えられなかった。

3つの assertion のうち**最初が対照**: アンカーは非コメント行にちょうど1回だけ一致する
こと。rename・削除・二重化はすべてここで、サイト名つきで落ちる。

## Test plan

- `scripts/xcodebuild.sh test -skip-testing:PasturaUITests` — **3548 tests / 286 suites
  passed**（known issue 1、既存）
- `swiftlint lint --quiet --strict` — clean
- `check-measurement-transcripts.py` `--self-test` / `--check` / `--census` — 全て clean
  （`--census` は CI の `shell-tests` でしか走らないのでローカルで実行。QA 節に比率を
  写しかけて発火したので、B5 の QA 節の先例どおり数値は書かず fixture を指すだけにした）
- **実機ビルドは不要** — 触れた8ファイルに `#if !targetEnvironment(simulator)` は無い
  （batch 1 は `SettingsView+Models` が丸ごと device-only だったため必要だった）

### ガードが実際に発火することを mutation で確認（成功パスは何も証明しないため）

1. **密ファイルのドリフト**: `SimulationView+LogEntries.scoresSummary`（同ファイルに
   `inkSecondary` 13件）を `Color.ink` に変異 → **新アームだけ**が `scoresSummary` を
   名指しで落ち、census は緑。ファイル別件数の pin では出せなかった検出力
2. **疎ファイルの差し戻し**: `AgentOutputRow.thoughtBody` を `Color.muted` に戻す →
   新アームと census の**両方**が落ちる。2つのアームは互いを subsume しない
3. **再アンカー後の再確認**（レビュー修正）: `ModelDownloadHostView.scoresContent` を
   `Color.ink` に変異 → 詰めた窓（3行）でも当該サイトを名指しで落ちる

## Review

`code-reviewer`（Opus）を **2シャードに分割**（375 added / 13 files が
`subagent-usage.md` §2 の soft budget 超過）。**両シャードとも PASS / Critical 0**、
Warning 4 + Suggestion 5 のうち **8件を反映、1件を却下**。

反映した主なもの:

- **測ると再現しない数値**を2箇所書いていた。「密なファイルでは `inkSecondary` の
  ほぼすべてがバッチ以前」は実測すると**約半分**（13/11/10 のうち 7/7/6）。結論は
  7/13 でも変わらないが、台帳は「木に対して再導出せよ」と書いている側なので、
  再導出で再現しない数値を置いてはいけない
- **QA が19サイトのうち1つを落としていた。** `AgentOutputRow` の thought body は
  code-phase 行ではないので、節の唯一の問いが届いていなかった。`INNER VOICE` タグが
  `--muted` のまま本文だけ `--ink-2` になり、`ThoughtLeftRule` が前提にしていた
  moss/muted のペアリングを本文が抜ける。独立の問いとして追加し、`AgentOutputRow` を
  mount する4面で聞くようにした — 5つ目の面 `GalleryHighlightRunFigure` は
  どの bullet も名指していなかった
- **ガードの窓が2つだけ8行**で、doc が主張する「1〜4行」を満たしていなかった。
  より近い `.monospacedDigit()` が両ファイルで一意なのでそちらへ再アンカー（窓3）
- `ResultsView` の why コメントが category caption を「above」と書いていたが実際には下
- 台帳 §5 tally の再導出レシピが1多く数える（Tally 表自身の行も `` | ` `` で始まる）
- ADR-028 の削除文が絶対的に読めた点を narrow（バッチを**着地させた** amendment は
  自分の記録でそう言ってよい。禁じているのは、自分が持たないバッチの走行集計）

**却下1件**: `BatchTwoSite` を extension 内の入れ子から file scope へ出す案。
`testing.md` の「helpers at file scope」は extension に入れられない自由関数を指しており、
型の入れ子はコンパイルもスコープも正しい。

`/risk-review` は**実施していない**。§8 / §2 / ADR-028 の**決定**は触っておらず、審査
対象が規約自身になる #1486 / #1510 の条件に当たらないため（本 PR の ADR-028 編集は
在庫の写しの削除で、決定の変更ではない）。

## Device QA

ADR-028 gate 4/5、**両外観**。`docs/qa/dark-mode-qa.md` §2 に専用の節を追加済み
（`### Transcript rows on --ink-2`）。反証可能な問いは「読めるか」ではなく:

1. **code-phase 行は、その間に挟まる発言（`--ink`）に対して従属して読めるか。**
   §2.2 は `--ink-2` をサブテキストにも割り当てており、vote ヘッダーは既にそれを
   読んでいたので、行は直上と同色になり、発言との差は `--ink` / `--ink-2` だけになる
   — Simulation live / Demo replay / Results 詳細 / Results 一覧 / ScenarioDetail /
   Gallery 詳細
2. **開示された思考は、発話ではなく傍白として読めるか** — `AgentOutputRow` を mount
   する4面。タグと本文が同色でなくなった点を見る
3. **⚠️ グリフ（`--muted` のまま）は `--ink-2` のラベルと1つの注記として読めるか** —
   Simulation live と Results 詳細。Results 詳細のものは `Label` の closure 形式に
   変わっているので、アイコンの間隔が出荷時と一致することも確認

**複製ペアの確認が最重要**: `SimulationView+LogEntries` と
`ModelDownloadHostView+CodePhaseRows` は byte-for-byte の複製で、片方だけ適用すると
視覚的に乖離するのに `MutedSweepLedgerTests` の件数はすべて整合する。1コミットで
両方に適用してあるが、**行単位で見比べる**のは diff では担保できない。

Part of #1448
