### PR TITLE
♿ fix: eliminated rows and the countdown to --ink-2 (#1448 batch 3)

### DIFF
--- a/Pastura/Pastura/Views/Components/SimulationResultCard.swift
+++ b/Pastura/Pastura/Views/Components/SimulationResultCard.swift
@@ -149,7 +149,10 @@ struct SimulationResultCard: View {
       Text(entry.name)
         .textStyle(Typography.bodyBubble)
         .strikethrough(entry.isEliminated)
-        .foregroundStyle(entry.isEliminated ? Color.muted : Color.ink)
+        // Eliminated rows keep the strikethrough + xmark dot as the state cue;
+        // the name itself is act-on content (class A3) and reads `inkSecondary`
+        // since #1448 batch 3 — `docs/design/muted-application-audit.md` §5.
+        .foregroundStyle(entry.isEliminated ? Color.inkSecondary : Color.ink)
       Spacer(minLength: Spacing.xs)
       valueText(entry)
       statusDot(entry)
@@ -169,7 +172,10 @@ struct SimulationResultCard: View {
       Text(formattedValue(value, kind: entry.valueKind))
         .textStyle(Typography.bodyBubble)
         .monospacedDigit()
-        .foregroundStyle(entry.isEliminated ? Color.muted : Color.inkSecondary)
+        // Both arms converged in #1448 batch 3: the eliminated tally is act-on
+        // content (class A3) like the live one, so the ternary that once dimmed
+        // it to the quietude tier is gone — `muted-application-audit.md` §5.
+        .foregroundStyle(Color.inkSecondary)
     }
   }
 
@@ -181,7 +187,9 @@ struct SimulationResultCard: View {
   }
 
   private func nameColor(_ entry: Entry, isWinner: Bool) -> Color {
-    if entry.isEliminated { return Color.muted }
+    // Eliminated names are act-on content (class A3), not ambience — the
+    // strikethrough carries the state. #1448 batch 3; `muted-application-audit.md` §5.
+    if entry.isEliminated { return Color.inkSecondary }
     return isWinner ? Color.mossInk : Color.ink
   }
 

--- a/Pastura/Pastura/Views/Simulation/ScoreboardSheet.swift
+++ b/Pastura/Pastura/Views/Simulation/ScoreboardSheet.swift
@@ -18,17 +18,23 @@ struct ScoreboardSheet: View {
               .monospacedDigit()
               .frame(width: 30, alignment: .trailing)
 
+            // Eliminated name + score read `inkSecondary` (#1448 batch 3, class
+            // A3): the strikethrough and the xmark already carry the state, and
+            // the number is what the user opened the sheet to compare. The ground
+            // is the system sheet surface — outside the twelve-ground fixture —
+            // so the repoint is argued by direction, not by a measured ratio:
+            // `docs/design/muted-application-audit.md` §3.3.
             Text(entry.name)
               .textStyle(Typography.bodyBubble)
               .strikethrough(entry.isEliminated)
-              .foregroundStyle(entry.isEliminated ? Color.muted : Color.ink)
+              .foregroundStyle(entry.isEliminated ? Color.inkSecondary : Color.ink)
 
             Spacer()
 
             Text(String(format: String(localized: "%lld pts"), entry.score))
               .textStyle(Typography.bodyBubble)
               .monospacedDigit()
-              .foregroundStyle(entry.isEliminated ? Color.muted : Color.ink)
+              .foregroundStyle(entry.isEliminated ? Color.inkSecondary : Color.ink)
 
             if entry.isEliminated {
               Image(systemName: "xmark.circle.fill")

--- a/Pastura/Pastura/Views/Simulation/ViewerPredictionSheet.swift
+++ b/Pastura/Pastura/Views/Simulation/ViewerPredictionSheet.swift
@@ -56,9 +56,13 @@ struct ViewerPredictionSheet: View {
         .font(.title3.weight(.semibold))
         .foregroundStyle(Color.ink)
         .multilineTextAlignment(.center)
+      // The countdown is a deadline the user acts against (class A3) — the
+      // sheet auto-skips at zero — so it reads `inkSecondary` since #1448
+      // batch 3; the eyebrow above stays on the quietude tier as a category
+      // label. `docs/design/muted-application-audit.md` §5.
       Text(String(format: String(localized: "%lld s left"), remaining))
         .font(.caption.monospacedDigit())
-        .foregroundStyle(Color.muted)
+        .foregroundStyle(Color.inkSecondary)
         .accessibilityIdentifier("prediction.countdown")
     }
   }

--- a/Pastura/PasturaTests/Views/DesignTokensTests+MutedAsContent.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+MutedAsContent.swift
@@ -34,7 +34,7 @@ extension DesignTokensTests {
   /// **floor** speak for named labels and could carry the fields — it is that
   /// the streak sub-label is `.caption.weight(.medium)`, a weight with no WCAG
   /// half assigned yet.
-  private static let contentTextBar = 4.5
+  static let contentTextBar = 4.5
 
   /// Every opaque ground the app ships that `muted` is or could be drawn on, per
   /// appearance. Hand-written rather than derived from

--- a/Pastura/PasturaTests/Views/DesignTokensTests+MutedAsContent.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+MutedAsContent.swift
@@ -21,8 +21,8 @@ import Testing
 //
 // This half is the tighter of the two against `file_length` (400, SwiftLint's
 // default; `--strict` promotes the warning), and the split is what keeps it
-// under without a lint directive. So a new arm belongs in the sibling unless it
-// is genuinely about computing a ground.
+// under without a lint directive. So a new arm belongs in the sibling — even
+// one that computes a ground, while this file sits within a few lines of the cap.
 extension DesignTokensTests {
 
   /// WCAG 1.4.3 normal-text bar. Both #1427 labels are `caption`-class (~12pt),
@@ -34,7 +34,7 @@ extension DesignTokensTests {
   /// **floor** speak for named labels and could carry the fields — it is that
   /// the streak sub-label is `.caption.weight(.medium)`, a weight with no WCAG
   /// half assigned yet.
-  static let contentTextBar = 4.5
+  static let contentTextBar = 4.5  // internal: `+MutedTranscript`'s `page` arm reads it
 
   /// Every opaque ground the app ships that `muted` is or could be drawn on, per
   /// appearance. Hand-written rather than derived from

--- a/Pastura/PasturaTests/Views/DesignTokensTests+MutedTranscript.swift
+++ b/Pastura/PasturaTests/Views/DesignTokensTests+MutedTranscript.swift
@@ -172,9 +172,11 @@ extension DesignTokensTests {
     computed: [(name: String, ratio: Double)], pins: [(name: String, ratio: Double)]
   ) -> [String] {
     computed.compactMap { entry in
-      guard let pin = pins.first(where: { $0.name == entry.name }), rounded3(entry.ratio) < pin.ratio
+      guard let pin = pins.first(where: { $0.name == entry.name }),
+        rounded3(entry.ratio) < pin.ratio
       else { return nil }
-      return "    \(entry.name): \(printed3(entry.ratio)) — was \(String(format: "%.3f", pin.ratio))"
+      return
+        "    \(entry.name): \(printed3(entry.ratio)) — was \(String(format: "%.3f", pin.ratio))"
     }
   }
 
@@ -291,5 +293,22 @@ extension DesignTokensTests {
     let ratios = Self.opaqueGroundPins.map(\.ratio)
     #expect(ratios.min() == 2.136)
     #expect(ratios.max() == 4.152)
+  }
+
+  // MARK: - Batch 3 after-figure (#1448)
+
+  /// `ViewerPredictionSheet`'s countdown is the one batch-3 repoint whose
+  /// ground (`page`) no other arm pins `inkSecondary` on — `bubbleBackground`
+  /// is covered by ``bothPredictionBadgeRepointsClearTheBar``, and the
+  /// `ScoreboardSheet` rows sit on the system sheet surface, which has no
+  /// fixture ground at all (ledger §3.3: argued by direction). An inequality,
+  /// not a pinned figure, so it leaves no transcript for `--census` to track.
+  /// Lives here rather than in the sibling because that file is at SwiftLint's
+  /// `file_length` ceiling — its header nominates this one.
+  @Test func inkSecondaryClearsTheBarOnPage() {
+    let light = contrastRatio(PasturaPalette.inkSecondary, PasturaPalette.page)
+    #expect(light >= Self.contentTextBar, "light page: \(light)")
+    let dark = contrastRatio(PasturaPalette.nightInkSecondary, PasturaPalette.nightPage)
+    #expect(dark >= Self.contentTextBar, "dark nightPage: \(dark)")
   }
 }

--- a/Pastura/PasturaTests/Views/MutedSweepLedgerTests+BatchThree.swift
+++ b/Pastura/PasturaTests/Views/MutedSweepLedgerTests+BatchThree.swift
@@ -3,7 +3,6 @@
 // (#1448). An extension of `MutedSweepLedgerTests`, never a second
 // `@Suite`; the site type and the checker live in `+BatchTwo`.
 
-import Foundation
 import Testing
 
 extension MutedSweepLedgerTests {

--- a/Pastura/PasturaTests/Views/MutedSweepLedgerTests+BatchThree.swift
+++ b/Pastura/PasturaTests/Views/MutedSweepLedgerTests+BatchThree.swift
@@ -1,0 +1,71 @@
+// Batch 3's applied-site pin — the eliminated-player rows in
+// `SimulationResultCard` / `ScoreboardSheet` and the prediction countdown
+// (#1448). An extension of `MutedSweepLedgerTests`, never a second
+// `@Suite`; the site type and the checker live in `+BatchTwo`.
+
+import Foundation
+import Testing
+
+extension MutedSweepLedgerTests {
+
+  /// The six sites the ledger § 5 marks `B3`, in § 5's order.
+  ///
+  /// Anchors are the nearest preceding line unique among the file's
+  /// non-comment lines, and every window holds exactly one `Color.` styling
+  /// line — the site. Two windows are worth a word: the `survivalRow` window
+  /// is five lines, wider than any in batch 2, because the row's `Text`
+  /// carries three modifiers before its `.foregroundStyle` and no nearer line
+  /// is unique (`Text(entry.name)` and `.strikethrough(entry.isEliminated)`
+  /// both also appear in `rankedRow`); it still holds a single `Color.` line.
+  /// The `nameColor` window is **one** line on purpose — the next line is
+  /// `return isWinner ? Color.mossInk : Color.ink`, and a window reaching it
+  /// would pass with the site reverted.
+  ///
+  /// `.strikethrough(entry.isEliminated)` is unique in `ScoreboardSheet` even
+  /// though it appears twice in `SimulationResultCard`; uniqueness is per
+  /// file, which is what the control checks.
+  ///
+  /// The `%lld s left` window reaches its site at two lines, and the eyebrow's
+  /// surviving quietude-tier line sits *before* the anchor, so the
+  /// no-`Color.muted`-in-window check cannot be tripped by a site that is
+  /// meant to stay.
+  private static let batchThreeSites: [AppliedSite] = [
+    .init(
+      "Views/Components/SimulationResultCard.swift",
+      "private func survivalRow(_ entry: Entry) -> some View {", window: 5),
+    .init(
+      "Views/Components/SimulationResultCard.swift",
+      "Text(formattedValue(value, kind: entry.valueKind))", window: 3),
+    .init(
+      "Views/Components/SimulationResultCard.swift",
+      "private func nameColor(_ entry: Entry, isWinner: Bool) -> Color {", window: 1),
+    .init(
+      "Views/Simulation/ScoreboardSheet.swift",
+      ".strikethrough(entry.isEliminated)", window: 1),
+    .init(
+      "Views/Simulation/ScoreboardSheet.swift",
+      #"Text(String(format: String(localized: "%lld pts"), entry.score))"#, window: 3),
+    .init(
+      "Views/Simulation/ViewerPredictionSheet.swift",
+      #"Text(String(format: String(localized: "%lld s left"), remaining))"#, window: 2)
+  ]
+
+  /// Batch 3's pin, same three assertions per site as
+  /// ``batchTwoSitesStillReadInkSecondary`` via the shared checker; the count
+  /// is the control that the table was not trimmed.
+  @Test func batchThreeSitesStillReadInkSecondary() throws {
+    #expect(Self.batchThreeSites.count == 6, "the ledger § 5 marks six rows `B3`")
+
+    let failures = try Self.appliedSiteFailures(Self.batchThreeSites)
+
+    #expect(
+      failures.isEmpty,
+      """
+      Batch 3's repointed sites no longer read `Color.inkSecondary`. An anchor \
+      that stopped resolving is a rename — re-anchor it and keep the window \
+      holding one `Color.` line. A token that changed is a design decision: \
+      re-adjudicate the site against `muted-application-audit.md` § 2 first.
+      \(failures.joined(separator: "\n"))
+      """)
+  }
+}

--- a/Pastura/PasturaTests/Views/MutedSweepLedgerTests+BatchTwo.swift
+++ b/Pastura/PasturaTests/Views/MutedSweepLedgerTests+BatchTwo.swift
@@ -3,19 +3,22 @@ import Testing
 
 // Batch 2's applied-site pin, split out of `MutedSweepLedgerTests.swift` at
 // SwiftLint's 400-line ceiling (`testing.md` § "Splitting a Suite Across
-// Files") — an extension of that suite, never a second `@Suite`.
+// Files") — an extension of that suite, never a second `@Suite`. It also
+// hosts the shared ``AppliedSite`` / ``appliedSiteFailures(_:)`` checker that
+// later batches' pin files reuse.
 
 extension MutedSweepLedgerTests {
 
-  /// One batch-2 (#1448) repointed site, anchored by a literal that is unique
-  /// among its file's **non-comment** lines. The repointed `.foregroundStyle`
-  /// sits within `window` non-comment lines after that anchor.
+  /// One repointed site of an applied batch (#1448 batch 2 onward), anchored
+  /// by a literal that is unique among its file's **non-comment** lines. The
+  /// repointed `.foregroundStyle` sits within `window` non-comment lines
+  /// after that anchor.
   ///
   /// Comment lines are dropped before the window is measured, so inserting or
   /// growing a why-comment cannot slide a site out of its own window — which
   /// batch 2 did to all eight files. A line-anchored table could not have
   /// survived its own commit.
-  private struct BatchTwoSite {
+  struct AppliedSite {
     let path: String
     let anchor: String
     let window: Int
@@ -37,7 +40,7 @@ extension MutedSweepLedgerTests {
   /// site reverted. The three `.monospacedDigit()` anchors are the same spelling
   /// in three different files, each unique within its own; that is fine, since
   /// uniqueness is what the control arm checks and it checks it per file.
-  private static let batchTwoSites: [BatchTwoSite] = [
+  private static let batchTwoSites: [AppliedSite] = [
     .init(
       "Views/Components/AgentOutputRow.swift",
       ".textStyle(Typography.thinkingBody)", window: 1),
@@ -98,21 +101,14 @@ extension MutedSweepLedgerTests {
       "Text(value)", window: 1)
   ]
 
-  /// Batch 2's counterpart, anchored per site rather than per file — see
-  /// ``expectedAppliedInkSecondary`` for why the shapes differ.
-  ///
-  /// Three assertions per site, and the **first is the control**: the anchor
-  /// must match exactly one non-comment line. A rename, a deletion, or a second
-  /// copy of the anchored line all land there and name the site, so the two
-  /// content checks below can never pass by scanning nothing. The window then
-  /// has to contain `Color.inkSecondary` and must not contain `Color.muted`;
-  /// the second is what catches a revert, and the first what catches a slide to
-  /// `Color.ink` or a raw hex that the census would wave through.
-  @Test func batchTwoSitesStillReadInkSecondary() throws {
-    #expect(Self.batchTwoSites.count == 19, "the ledger § 5 marks nineteen rows `B2`")
-
+  /// Runs the three per-site assertions of an applied-batch pin — see
+  /// ``batchTwoSitesStillReadInkSecondary`` for what each one catches — and
+  /// returns one line per failure, empty when every site still reads
+  /// `Color.inkSecondary`. Shared by every batch's pin arm so the checker has
+  /// one definition; a batch contributes only its table.
+  static func appliedSiteFailures(_ sites: [AppliedSite]) throws -> [String] {
     var failures: [String] = []
-    for site in Self.batchTwoSites {
+    for site in sites {
       let url = SourceTreeProbe.appSourceRoot.appending(path: site.path)
       let code = try String(contentsOf: url, encoding: .utf8)
         .split(separator: "\n", omittingEmptySubsequences: false)
@@ -135,6 +131,24 @@ extension MutedSweepLedgerTests {
         failures.append("  \(site.path): `Color.muted` came back at \(site.anchor)")
       }
     }
+    return failures
+  }
+
+  /// Batch 2's counterpart, anchored per site rather than per file — see
+  /// ``expectedAppliedInkSecondary`` for why the shapes differ.
+  ///
+  /// Three assertions per site, and the **first is the control**: the anchor
+  /// must match exactly one non-comment line. A rename, a deletion, or a second
+  /// copy of the anchored line all land there and name the site, so the two
+  /// content checks below can never pass by scanning nothing. The window then
+  /// has to contain `Color.inkSecondary` and must not contain `Color.muted`;
+  /// the second is what catches a revert, and the first what catches a slide to
+  /// `Color.ink` or a raw hex that the census would wave through. The loop
+  /// itself is ``appliedSiteFailures(_:)``, shared with later batches.
+  @Test func batchTwoSitesStillReadInkSecondary() throws {
+    #expect(Self.batchTwoSites.count == 19, "the ledger § 5 marks nineteen rows `B2`")
+
+    let failures = try Self.appliedSiteFailures(Self.batchTwoSites)
 
     #expect(
       failures.isEmpty,

--- a/Pastura/PasturaTests/Views/MutedSweepLedgerTests.swift
+++ b/Pastura/PasturaTests/Views/MutedSweepLedgerTests.swift
@@ -13,7 +13,7 @@ import Testing
 /// they take opposite remedies**: a rename or a deletion means re-anchor the
 /// row by symbol rather than dropping it; an **applied batch** means the row
 /// stays put with its `B` marker bolded and the entry here is dropped, which is
-/// what batches 1, 5 and 2 did. Read the file's § 5 rows before choosing.
+/// what batches 1, 5, 2 and 3 did. Read the file's § 5 rows before choosing.
 ///
 /// **It fires on an addition too**, which is the half prose cannot do. The
 /// expectation is a whole-map comparison, so a new file reaching for
@@ -39,8 +39,11 @@ struct MutedSweepLedgerTests {
   /// Batch 1 (#1486) removed eight occurrences and emptied three files, batch 5
   /// (#1510) removed three more and emptied three more, and batch 2 repointed
   /// nineteen sites for a net **eighteen** occurrences — the nineteenth kept
-  /// the spelling on the glyph above — and emptied none. So this table is the
-  /// post-batch-2 population, not § 1's `9a40565a` baseline.
+  /// the spelling on the glyph above — and emptied none. Batch 3 repointed six
+  /// sites in three files — the eliminated rows in `SimulationResultCard` /
+  /// `ScoreboardSheet` and the prediction countdown — and emptied none either.
+  /// So this table is the post-batch-3 population, not § 1's `9a40565a`
+  /// baseline.
   private static let expectedMutedOccurrences: [String: Int] = [
     "Views/Community/SharedScenarios/GalleryCatalogRow.swift": 1,
     "Views/Community/SharedScenarios/GalleryScenarioDetailView+Highlight.swift": 2,
@@ -55,7 +58,7 @@ struct MutedSweepLedgerTests {
     "Views/Components/PasturaRowLabel.swift": 1,
     "Views/Components/PersonaDetailSheet.swift": 1,
     "Views/Components/SheepAvatar.swift": 4,
-    "Views/Components/SimulationResultCard.swift": 5,
+    "Views/Components/SimulationResultCard.swift": 2,
     "Views/Editor/PhaseBlockRow.swift": 1,
     "Views/Editor/PhaseEditorSheet+ConditionalSection.swift": 1,
     "Views/Editor/ScenarioEditorView.swift": 2,
@@ -74,11 +77,11 @@ struct MutedSweepLedgerTests {
     "Views/Settings/SettingsView+PastResults.swift": 1,
     "Views/Settings/SettingsView.swift": 2,
     "Views/Simulation/HighlightCandidatesSection.swift": 2,
-    "Views/Simulation/ScoreboardSheet.swift": 3,
+    "Views/Simulation/ScoreboardSheet.swift": 1,
     "Views/Simulation/SimulationView+Background.swift": 1,
     "Views/Simulation/SimulationView+LogEntries.swift": 3,
     "Views/Simulation/SimulationView.swift": 2,
-    "Views/Simulation/ViewerPredictionSheet.swift": 2
+    "Views/Simulation/ViewerPredictionSheet.swift": 1
   ]
 
   /// Reads of the raw `muted` / `nightMuted` palette values that do **not** go

--- a/docs/design/muted-application-audit.md
+++ b/docs/design/muted-application-audit.md
@@ -629,7 +629,7 @@ titles, not subordinate labels.
 | **B1** | Blocked-state reasons, the tap-to-proceed instruction, and act-on numbers, in Settings / model management / gallery | 8 | **applied (#1448)** |
 | **B2** | A3 + A4 + A5 — the simulation transcript and past-run detail rows: assignments, tallies, score summaries, degraded-turn narration, the scenario description, and the gallery detail values (the one A3 here) | 19 | **applied (#1448)** |
 | **B3** | Eliminated-player rows (`ScoreboardSheet`, `SimulationResultCard`) and the prediction countdown — all A3; the two `ScoreboardSheet` rows are the first **U** rows to move, by §3.3's direction argument | 6 | **applied (#1448)** |
-| **B4** | Composited and material grounds as one question — the self-wash pills, `ActiveModelChip`, `ModelRow`, `ReportSheet`, `GameHeaderStatus` — plus §6.1's routing fix | 2 misapplications + 1 routing, over 8 rows carrying 7 of the 9 **U** flags | open |
+| **B4** | Composited and material grounds as one question — the self-wash pills, `ActiveModelChip`, `ModelRow`, `ReportSheet`, `GameHeaderStatus`, the sites whose target token is undecided (a direction-argued repoint is outside this gate, §3.3) — plus §6.1's routing fix | 2 misapplications + 1 routing, over 8 rows carrying 7 of the 9 **U** flags | open |
 | **B5** | §6.3's §2.2 alignment — the `PasturaSection` header plus 2 hand-rolled ones: 3 repointed call sites, 5 screens repainted | 3 | **applied (#1485)** |
 | **B6** | §6.3's open question — system `Form` / `List` section headers still on `secondaryLabel`. **Not a `Color.muted` batch**: these sites carry no token at all, so nothing in §1, §5 or the census counts them — and unlike B2–B4, no unprompted guard ever routes an editor here. It therefore **outlives its own umbrella**: #1448 closes when the `Color.muted` census reads done, which B6 contributes nothing to. So — **do not close #1448 while this row is open; spin B6 out as its own issue at #1448-close time.** Needs the substrate decision before any site moves | 21 over 9 files | open — undecided |
 
@@ -668,8 +668,10 @@ say what a *material or otherwise unmeasurable* ground routes to before any
 of **its** sites moves — the routing for a merely-composited one is already in
 §8's `*-on-wash` bullet, so stating the gate that way would leave it already
 satisfied. A direction-argued repoint on a §3.3 ground is **outside** that
-gate, and two batches have made one: B1's `DLCompleteOverlay` and B3's two
-`ScoreboardSheet` rows. Neither claims a ratio, and both land on the token
+gate, and two batches have made one: B1's `DLCompleteOverlay` (which carries no
+**U** — its ground is a material, not merely unmeasured, so B3's rows are still
+the first **U** rows to move) and B3's two `ScoreboardSheet` rows. Neither
+claims a ratio, and both land on the token
 §8's neutral-ground bullet already names; what B4 owes §8 is the answer for the
 sites where the token might *not* be `--ink-2` — the self-wash pills and the
 moss-washed chips, whose role is ambient and whose ground is tinted; B5

--- a/docs/design/muted-application-audit.md
+++ b/docs/design/muted-application-audit.md
@@ -9,7 +9,7 @@ examples in `PredictionOutcomeBadge`.
 **This file is the sweep's ledger, not its rule.** §8 remains normative; what is
 recorded here is the per-site *application* of §8 across the population, plus the
 adjudications that were judgement calls. The sweep runs in batches — batches 1,
-2 and 5 are applied; every other row still ships as written.
+2, 3 and 5 are applied; every other row still ships as written.
 
 ## 1. Population
 
@@ -41,8 +41,10 @@ Discipline).
 
 Batch 1 removed eight occurrences and emptied three files; batch 5 (#1485)
 removed three more and emptied three more; batch 2 repointed nineteen sites for
-a net eighteen occurrences and emptied none. So the population as it ships today
-is **70 lines · 4 doc-comment mentions · 66 code sites across 37 files**.
+a net eighteen occurrences and emptied none; batch 3 repointed six — the
+eliminated rows in `SimulationResultCard` / `ScoreboardSheet` and the prediction
+countdown — and emptied none either. So the population as it ships today is
+**64 lines · 4 doc-comment mentions · 60 code sites across 37 files**.
 `MutedSweepLedgerTests` pins the per-file breakdown — §8.
 
 The mentions went 3 → 4 because batch 2's why-comment in `ResultDetailView`
@@ -282,6 +284,10 @@ weaker than a measurement and is labelled as such wherever it is used.
 Two further grounds are **sheet defaults** — `ScoreboardSheet`, `ReportSheet`,
 `PersonaDetailSheet`, and `PhaseEditorSheet` set no Pastura background token at
 all, so they render on the system sheet surface. Also outside the fixture.
+Batch 3 moved `ScoreboardSheet`'s two eliminated rows on this ground by the
+direction argument above — the first sheet-default rows to move, labelled as
+direction-argued in the file's own why-comment, and pinned by symbol in
+`MutedSweepLedgerTests+BatchThree` rather than by any ratio.
 
 ## 4. Recorded refusal — retuning `muted` itself
 
@@ -305,8 +311,8 @@ Verdicts: **S** sanctioned · **M** misapplication (class in brackets) ·
 **U** unmeasured ground, exemption cannot be cited · **N** non-text (1.4.11,
 out of §8's scope) · **P** `#Preview`, never ships · **C** comment mention.
 
-`B` names the batch. `B1`, `B2` and `B5` are applied; everything else still ships as
-written. An applied row is **kept**, not deleted — the adjudication is what §5
+`B` names the batch. `B1`, `B2`, `B3` and `B5` are applied; everything else still
+ships as written. An applied row is **kept**, not deleted — the adjudication is what §5
 records, and the bolded batch marker is what says the repoint landed.
 
 ### Components
@@ -330,10 +336,10 @@ records, and the bolded batch marker is what says the repoint landed.
 | `PersonaDetailSheet` · `PEEK AT THEIR SECRET` | sheet default | unmeasured | S — toggle affordance; the secret renders at `ink` | — |
 | `SheepAvatar` · size captions ×4 | `screenBackground` | — | P | — |
 | `SimulationResultCard` · rank ordinal | `bubbleBackground` | 3.475 / 3.021 | S — derivable from row order | — |
-| `SimulationResultCard` · `survivalRow` name (eliminated) | `bubbleBackground` | 3.475 / 3.021 | **M (A3)** — restrictive control | B3 |
+| `SimulationResultCard` · `survivalRow` name (eliminated) | `bubbleBackground` | 3.475 / 3.021 | **M (A3)** — restrictive control | **B3** |
 | `SimulationResultCard` · `groupHeader` | `bubbleBackground` | 3.475 / 3.021 | S — redundant with per-row strikethrough + dot | — |
-| `SimulationResultCard` · `valueText` (eliminated) | `bubbleBackground` | 3.475 / 3.021 | **M (A3)** — the card's final tally | B3 |
-| `SimulationResultCard` · `nameColor` (eliminated) | `bubbleBackground` | 3.475 / 3.021 | **M (A3)** — `.ranking`/`.pairing` sibling of the row above | B3 |
+| `SimulationResultCard` · `valueText` (eliminated) | `bubbleBackground` | 3.475 / 3.021 | **M (A3)** — the card's final tally | **B3** |
+| `SimulationResultCard` · `nameColor` (eliminated) | `bubbleBackground` | 3.475 / 3.021 | **M (A3)** — `.ranking`/`.pairing` sibling of the row above | **B3** |
 
 The eliminated-row verdicts split from the state cue deliberately: **the
 elimination is redundantly encoded** (strikethrough + `xmark.circle.fill`), so
@@ -347,8 +353,8 @@ what the reader came to compare.
 | `HighlightCandidatesSection` · section caption | `bubbleBackground` | 3.475 / 3.021 | S — explains the section above it | — |
 | `HighlightCandidatesSection` · share glyph | `bubbleBackground` | 3.475 / 3.021 | N | — |
 | `ScoreboardSheet` · rank numeral | sheet default | unmeasured | S — derivable from order | — |
-| `ScoreboardSheet` · name (eliminated) | sheet default | unmeasured | **M (A3)** + U — restrictive control | B3 |
-| `ScoreboardSheet` · score (eliminated) | sheet default | unmeasured | **M (A3)** + U — restrictive control | B3 |
+| `ScoreboardSheet` · name (eliminated) | sheet default | unmeasured | **M (A3)** + U — restrictive control | **B3** |
+| `ScoreboardSheet` · score (eliminated) | sheet default | unmeasured | **M (A3)** + U — restrictive control | **B3** |
 | `SimulationView` · `%@ is thinking…` | `screenBackground` | 3.329 / 3.779 | S — transient, superseded when the agent speaks | — |
 | `SimulationView` · scrim-label comment | — | — | C | — |
 | `SimulationView` · loading-scrim subtitle | `.regularMaterial` | unmeasurable | S + U — elaborates a title already at `ink` | B4 |
@@ -363,7 +369,7 @@ what the reader came to compare.
 | `SimulationView+LogEntries` · `actionRejectedEntry` text | `screenBackground` | 3.329 / 3.779 | **M (A4)** — ADR-021 D5 | **B2** |
 | `SimulationView+LogEntries` · `scoresSummary` | `screenBackground` | 3.329 / 3.779 | **M (A5)** | **B2** |
 | `ViewerPredictionSheet` · eyebrow | `page` | 3.030 / 4.152 | S — category label | — |
-| `ViewerPredictionSheet` · `%lld s left` | `page` | 3.030 / 4.152 | **M (A3)** — a deadline the user acts against; the sheet auto-skips at zero | B3 |
+| `ViewerPredictionSheet` · `%lld s left` | `page` | 3.030 / 4.152 | **M (A3)** — a deadline the user acts against; the sheet auto-skips at zero | **B3** |
 | `ReportSheet` · `ID: %@` chip | `rule@0.45` | 2.300–3.018 / 2.520–3.503 | S + U — the ID is embedded in the report URL anyway | B4 |
 
 ### Results · Home · ScenarioDetail
@@ -622,7 +628,7 @@ titles, not subordinate labels.
 |---|---|---|---|
 | **B1** | Blocked-state reasons, the tap-to-proceed instruction, and act-on numbers, in Settings / model management / gallery | 8 | **applied (#1448)** |
 | **B2** | A3 + A4 + A5 — the simulation transcript and past-run detail rows: assignments, tallies, score summaries, degraded-turn narration, the scenario description, and the gallery detail values (the one A3 here) | 19 | **applied (#1448)** |
-| **B3** | Eliminated-player rows (`ScoreboardSheet`, `SimulationResultCard`) and the prediction countdown | 6 | open |
+| **B3** | Eliminated-player rows (`ScoreboardSheet`, `SimulationResultCard`) and the prediction countdown — all A3; the two `ScoreboardSheet` rows are the first **U** rows to move, by §3.3's direction argument | 6 | **applied (#1448)** |
 | **B4** | Composited and material grounds as one question — the self-wash pills, `ActiveModelChip`, `ModelRow`, `ReportSheet`, `GameHeaderStatus` — plus §6.1's routing fix | 2 misapplications + 1 routing, over 8 rows carrying 7 of the 9 **U** flags | open |
 | **B5** | §6.3's §2.2 alignment — the `PasturaSection` header plus 2 hand-rolled ones: 3 repointed call sites, 5 screens repainted | 3 | **applied (#1485)** |
 | **B6** | §6.3's open question — system `Form` / `List` section headers still on `secondaryLabel`. **Not a `Color.muted` batch**: these sites carry no token at all, so nothing in §1, §5 or the census counts them — and unlike B2–B4, no unprompted guard ever routes an editor here. It therefore **outlives its own umbrella**: #1448 closes when the `Color.muted` census reads done, which B6 contributes nothing to. So — **do not close #1448 while this row is open; spin B6 out as its own issue at #1448-close time.** Needs the substrate decision before any site moves | 21 over 9 files | open — undecided |
@@ -645,15 +651,29 @@ roughly half of that token predates the batch, so a per-file total there cannot
 attribute a revert to a site. The figures are in the doc comment on
 `MutedSweepLedgerTests.expectedAppliedInkSecondary`, the one place they are kept.
 
+B3 is pinned the same way (`MutedSweepLedgerTests+BatchThree`, sharing B2's
+checker), and it is the batch where the *state cue* rather than a count is what
+QA has to look at: an eliminated row kept its strikethrough and its xmark while
+its name and tally rose one tier, so the row now differs from a survivor by one
+ink step instead of two. Whether it still reads as *out* is the question
+`docs/qa/dark-mode-qa.md` § 2 records, together with the countdown's — a
+deadline that now outranks the eyebrow above it.
+
 Batches are ordered by how settled the judgement is, not by size. B2 and B3 are
 straightforward applications of §2 once B1 establishes the shape — with the
 caveat B2 turned up: a site whose token sits on a `Label` or any other
 multi-slot call cannot be repointed without changing the call's shape, and that
 is a decision, not a swap (§5's added glyph row); B4 needs §8 to
 say what a *material or otherwise unmeasurable* ground routes to before any
-site moves — the routing for a merely-composited one is already in §8's
-`*-on-wash` bullet, so stating the gate that way would leave it already
-satisfied; B5 repoints three call sites but repaints five screens, because one
+of **its** sites moves — the routing for a merely-composited one is already in
+§8's `*-on-wash` bullet, so stating the gate that way would leave it already
+satisfied. A direction-argued repoint on a §3.3 ground is **outside** that
+gate, and two batches have made one: B1's `DLCompleteOverlay` and B3's two
+`ScoreboardSheet` rows. Neither claims a ratio, and both land on the token
+§8's neutral-ground bullet already names; what B4 owes §8 is the answer for the
+sites where the token might *not* be `--ink-2` — the self-wash pills and the
+moss-washed chips, whose role is ambient and whose ground is tinted; B5
+repoints three call sites but repaints five screens, because one
 of the three is a shared component — §6.3 separates that figure from the three the
 blast radius actually has.
 

--- a/docs/qa/dark-mode-qa.md
+++ b/docs/qa/dark-mode-qa.md
@@ -193,6 +193,48 @@ the two slots apart; confirm its icon gap still matches what shipped.
 
 Derivation: `muted-application-audit` §2 (classes A3/A4/A5) and §5.
 
+### Eliminated rows and the countdown on `--ink-2` — two questions (#1448 batch 3)
+
+Batch 3 moved the six rows the ledger marks A3 in this area: an eliminated
+player's name and tally in `SimulationResultCard` and `ScoreboardSheet`, and the
+prediction sheet's `N s left`. The elimination cue did **not** move — the
+strikethrough and the `xmark.circle.fill` dot stay — so an eliminated row now
+differs from a survivor by one ink step (`--ink-2` against `--ink`) where it used
+to differ by two. Legibility rose on every one and is not the question; the
+after-figures for the opaque grounds live in `DesignTokensTests+MutedAsContent`
+/ `+MutedTranscript`, and the `ScoreboardSheet` ground has none — it is the
+system sheet surface, argued by direction only (ledger §3.3), which makes it the
+one surface here where a device is the *only* measurement.
+
+**Does an eliminated row still read as *out*?** Strikethrough + dot + one ink
+step, beside a survivor on `--ink`, in both appearances — and in dark, where the
+step between `--ink` and `--ink-2` is the narrower of the two.
+
+- [ ] **Simulation** — priority. Finish a run with at least one elimination
+      (any vote + eliminate preset): the result card's `Eliminated` group under
+      `Survived`, then tap the card for the **Scoreboard sheet**, where the same
+      row sits on the system sheet ground with its rank numeral still `--muted`.
+- [ ] **Demo replay** (model-download host) — the same result card, mounted by
+      `ModelDownloadHostView+ChatStream`; it is the first place a new install
+      sees an eliminated row.
+- [ ] **Results detail** — the past-run mirror of both: the card, and the
+      Scoreboard sheet it opens.
+
+**Does the countdown read as a deadline rather than a caption?** `N s left` is
+now `--ink-2` beneath a `Make your prediction` eyebrow that stays `--muted`, so
+the hierarchy inside the header flipped: the deadline outranks the label above
+it. Getting the sheet on screen has four preconditions and a 15-second window —
+follow § 7 and judge from the screenshot.
+
+- [ ] **Prediction sheet** — the header's three lines, top to bottom:
+      eyebrow (`--muted`), question (`--ink`), countdown (`--ink-2`).
+
+The store-screenshot capture (`StoreScreenshotTests`, anchored on
+`scoreboard.list`) draws an eliminated row in both locales, so the shipped
+`04-scoreboard` image is one repoint behind the build until the next recapture.
+
+Derivation: `muted-application-audit` §2 (class A3), §3.3 and §5.
+
 ### The walk
 
 - [ ] **Home** — cards, `ActiveModelChip` (including its warning / danger states


### PR DESCRIPTION
## Summary

`muted` 適用監査（#1448）の **batch 3**。台帳 §5 が `B3` と裁定した 6 サイト — すべて
**A3**（ユーザーが行動の対象にする数値・識別子）— を `Color.muted` から
`Color.inkSecondary` へ repoint する。

**コントラストの修理ではなく §8 の適用。** 脱落したプレイヤーの名前とスコアは、その画面を
開いた理由そのもの（順位を比べる）であり、`%lld s left` はシートが 0 で自動スキップする
締切。脱落という**状態**は strikethrough + `xmark.circle.fill` で冗長に符号化されているので
そちらは動かさず、名前と数値だけを 1 段上げる。同じファイルの順位数字・`groupHeader`・
eyebrow は S 裁定のまま据え置き。

- **3 ファイル・6 サイト** — `SimulationResultCard`（`survivalRow` / `valueText` /
  `nameColor`、`bubbleBackground`）、`ScoreboardSheet`（名前・スコア、**システムのシート地
  = 未測定 U**）、`ViewerPredictionSheet`（カウントダウン、`page`）
- **`ScoreboardSheet` の 2 行は台帳 §3.3 の方向論証で動かした**（B1 の `DLCompleteOverlay`
  と同型）。比を主張せず、fixture に新しい地も足していない。§7 の B4 ゲート文がこれを
  禁じているように読めたので、「方向論証の repoint はゲートの外」と明示する書き換えを入れた
- **`page` 地の after-figure** — `inkSecondary` on `page` / `nightPage` を pin する arm を
  `DesignTokensTests+MutedTranscript` に追加（`+MutedAsContent` は `file_length` 400 の
  天井にいるので、そのヘッダーが指名する隣へ）。不等式なので `--census` の写しは増えない
- **常設ガードに B3 のアーム** `MutedSweepLedgerTests+BatchThree` — B2 の checker を
  `AppliedSite` / `appliedSiteFailures(_:)` として共有化し（独立の ♻️ コミット）、B3 は
  6 行のテーブルだけを持つ
- **台帳・実機 QA** を更新。ADR-028 は編集なし（B2 がバッチ在庫を §7 へのポインタに
  置き換え済みで、決定の変更もない）

**規範テキストの変更はない**（§8 / §2 / ADR-028 の決定は不変）ので `/risk-review` は
実施していない — B2 と同じ条件。

batch 4（合成地・マテリアル地 + §6.1 の routing）は未着手、B6 は #1448 クローズ時に
単独 issue へ切り出す（台帳 §7）。

## Test plan

- `scripts/xcodebuild.sh test -skip-testing:PasturaUITests` — **3550 tests / 286 suites
  passed**（known issue 1、既存）
- `swiftlint lint --quiet --strict` — clean
- `check-measurement-transcripts.py --check --census` — clean（QA 節は比率を写していない）
- 母集団を最終コミットで再導出: `grep -rn "Color\.muted" Pastura/Pastura --include="*.swift"`
  → **64 行 · 4 mention · 60 サイト · 37 ファイル**（空になるファイルなし）。why コメントは
  `Color.muted` リテラルを含まないので mention 数は 4 のまま
- **実機ビルドは不要** — 触れた 3 ファイルに `#if !targetEnvironment(simulator)` は無い

### ガードが実際に発火することを mutation で確認

1. **密ファイルのドリフト**: `SimulationResultCard.nameColor` を `Color.ink` に変異 →
   **新アームだけ**が `nameColor` のシグネチャを名指しで落ち
   （`no Color.inkSecondary within 1 lines of private func nameColor…`）、census は緑。
   窓を 1 行に絞ってあるのは、2 行目の `return isWinner ? Color.mossInk : Color.ink` を
   窓に入れると差し戻しで通ってしまうため
2. **差し戻し**: `ScoreboardSheet` の名前・スコアを `Color.muted` に戻す → 新アームと
   census の**両方**が落ちる。2 つのアームは互いを subsume しない

## Review

`code-reviewer`（Opus）、1 シャード（+237 / 10 files）。**PASS / Critical 0**、Warning 1 +
Suggestion 6 のうち **5 件を反映、2 件を却下**。レビュアーは母集団の数値・6 本の anchor の
一意性と窓の中身・`contentTextBar` の可視性変更の副作用・U フラグ 9 本の内訳（B3 の 2 + B4 の
7）・`--census` を機械的に再検証している。

反映:

- **[W] `+MutedAsContent` のヘッダーの配置規則が新 arm と矛盾**（「地を計算する arm は
  ここ」と書きながら、地を計算する `inkSecondaryClearsTheBarOnPage` を隣に置いた）→
  天井優先に書き換え（行数は 396 のまま）
- `contentTextBar` を `internal` にした理由を宣言行に残す（次の整理で `private` に戻される
  のを防ぐ）
- `+BatchThree` の未使用 `import Foundation` を削除
- 台帳 §7 の B4 行 Scope と、同節の新しい散文（「ターゲットのトークンが未定のサイト」）を
  一致させる
- `DLCompleteOverlay` は **U** を持たない（地がマテリアル）ことを明記し、「B3 が最初の U
  行」と「方向論証は B1 と B3」の 2 文が矛盾して読めないようにする

却下:

- `+MutedTranscript` の whitespace reflow が `874135a8` に同乗 — PostToolUse の swift-format
  フックが Edit のたびに強制するもので、分離するには履歴の書き換えが要る
- `survivalRow` のインライン三項演算子を `nameColor(entry, isWinner: false)` に統一する案 —
  anchor 対象の 2 サイトが 1 つに潰れ、§5 の行と B3 テーブルを切り直す別変更になる。
  両方とも `+BatchThree` が pin しているので今日のドリフトは検出される

`/risk-review` は**実施していない** — §8 / §2 / ADR-028 の決定に変更がなく、審査対象が
規約自身になる条件（#1486 / #1510）に当たらない。§7 のゲート文の書き換えは台帳側
（規則ではなく台帳 — 台帳冒頭の宣言どおり）。

## Device QA

ADR-028 gate 4/5、**両外観**。`docs/qa/dark-mode-qa.md` §2 に専用の節を追加済み
（`### Eliminated rows and the countdown on --ink-2`）。反証可能な問いは「読めるか」ではなく:

1. **脱落行はまだ「脱落」として読めるか** — strikethrough + xmark + `--ink-2` が、`--ink`
   の生存者の隣で、2 段ではなく 1 段の差になった。ダークのほうが `--ink` / `--ink-2` の
   段差が狭い。Simulation の結果カード → タップで Scoreboard シート（システムのシート地。
   **ここだけは実機が唯一の測定**）、Demo replay の結果カード、Results 詳細のカード + シート
2. **カウントダウンは締切として読めるか** — `--muted` のままの eyebrow の下で `N s left` が
   `--ink-2` になり、ヘッダー内の階層が反転した。§7 の 4 前提条件 + 15 秒窓なので、
   出現時にスクリーンショットを撮って判断

**ストア用スクリーンショット**: `StoreScreenshotTests` の `04-scoreboard`（anchor
`scoreboard.list`、ja/en とも脱落行を 1 つ含む）は本 PR で 1 repoint 分古くなる。1.2 で
予定している ja/en 再撮影に乗せる（本 PR では撮り直さない）。

Part of #1448
