### PR TITLE
📝 docs: How-to-read maps for ADR-002 and ADR-021 (#1462 #1463)

### DIFF
--- a/docs/decisions/ADR-002.md
+++ b/docs/decisions/ADR-002.md
@@ -6,6 +6,35 @@
 > LiteRT-LM Swift SDK is not yet released; its C API lacks iOS GPU support.
 > **Migration trigger:** Fired 2026-06-11 (LiteRT-LM v0.12.0 — Swift SDK + iOS Metal GPU). Decision remains in force pending the migration evaluation (#496). See §8.2.
 
+## How to read this ADR
+
+This file is the 2026-04-08 interim-backend decision (§§1–9) plus everything
+that has happened to it since: the numbered amendment sections §§10–13 and the
+dated `## Amendment …` sections after them, which are most of its lines.
+The **current** answer to almost every question is at the section the map below
+names — reach for an amendment when you need the *why* behind a value, or what
+was tried and dropped. Where the current answer is a live value (the pin, the
+model catalog) it lives in the build or the code, and the map says so rather
+than quoting it here.
+
+| Arriving with | Where the current answer is |
+|---|---|
+| Why llama.cpp rather than LiteRT-LM? | § "1. Why Not LiteRT-LM Today?" — the 2026-04-08 rationale, carrying an inline update on what LiteRT-LM v0.12.0 later changed |
+| Has the migration trigger fired, and what happens next? | § "8.2 Migration trigger fired — evaluation in progress (2026-06-11)" for the trigger; § "8.1 Cross-platform migration sequencing — resolved (2026-04-22; updated 2026-07-10)" for iOS-first vs synchronised; § "8. Migration Path to LiteRT-LM" for the drop-in steps |
+| Which SwiftPM package, and why that one? | § "2. SwiftPM Package Selection" → § "Decision" — the candidate table and the xcframework fallback |
+| What version is pinned right now? | **Not in this file.** `Package.resolved` (root lane and Xcode lane) and `project.pbxproj`'s `exactVersion` requirement are the source of truth |
+| How is a pin bump done? | § "Pin Strategy" — what licenses a bump and the verification bar every bump pays. § "Amendment 2026-08-15 — llama.swift pin bumped to 2.10327.0 (b10327) (#1487)" is the worked example, including the two classes of stale claim no pin-token grep reaches |
+| Which model ships, and what is the QAT variant? | § "3. Model Specification". The live catalog is `App/ModelRegistry.swift`; the rule that a same-model rebuild is added beside the build it replaces is § "Amendment 2026-08-15 — ADD-and-keep for the QAT rebuild (#1487)" |
+| Which devices, and how fast? | § "4. Supported Devices" and § "5. Performance Expectations" — but the Q4_K_M-specific figures there do not transfer to the QAT build; see the note at the head of § 3 |
+| How is `LlamaCppService` structured? | § "6. Architecture: LlamaCppService" — layer placement, concurrency contract, chat template and output format, sampling parameters |
+| What happens on background, foreground, or a memory warning? | § "7. App Lifecycle" |
+| How does token streaming work? | § "10. Streaming Extension (2026-04-17 amendment)" for the protocol surface and the partial-JSON strategy; § "11. Streaming Display Redesign Outcome (2026-04-21 amendment)" for what the on-device measurement settled about the UI treatment |
+| Is GBNF grammar on, and what does it constrain? | § "12. GBNF Grammar Activation (2026-04-24 amendment)" for the activation and the cross-backend schema abstraction; the structure-only rule is § "Amendment 2026-06-14 — `choose` value-enumeration removed (#599)", restated in § 6 § "Chat Template and Output Format" |
+| Why does a grammar-invalid top token no longer empty the output? | § "Amendment 2026-07-09 — Grammar-all-rejected dist fallthrough (#751 sub-class 2)" — the grammar sits outside the sampler chain and is driven two-pass |
+| Why does a sampler abort or a C++ throw not kill the process? | § "12.9 Residual risk: rare accept-time abort in EOG path" (the EOG-guarded accept) and § "12.10 SafeSampler: catching C++ exceptions at the Swift boundary" |
+| Why can two `generate()` calls overlap without crashing? | § "13. Generate Cooperative Wait (2026-04-25 amendment)" |
+| What could still go wrong? | § "9. Risks and Mitigations" |
+
 ## Summary
 
 Use llama.cpp (via Metal GPU) as the interim production LLM backend for TestFlight.
@@ -87,6 +116,13 @@ If mattt/llama.swift becomes unmaintained, download the xcframework directly fro
 local binary SPM target. This is what mattt/llama.swift automates.
 
 ### Pin Strategy
+
+**The pinned version itself is never quoted in this section.** It lives in
+`Package.resolved` (root lane and Xcode lane) and in `project.pbxproj`'s
+`exactVersion` requirement; the two `Package.resolved` lanes carry the same
+version, but their `originHash` fields move independently and that asymmetry is
+expected rather than a missed regeneration. Derivation: § Amendment 2026-08-15 —
+llama.swift pin bumped to 2.10327.0 (b10327) (#1487).
 
 Pin to a **specific release tag** (never the `main` branch), so builds are
 reproducible and any sampler-level regression is attributable to one bump.
@@ -318,6 +354,13 @@ App/
 └── ...
 ```
 
+**The `(unchanged)` annotations above are as of 2026-04-08 and have since
+expired.** `LLMService` gained `generateStream` and a `schema: OutputSchema?`
+parameter, and `LLM/` gained `PartialOutputExtractor`, `GBNFGrammarBuilder`,
+`SafeSampler`, and the `LlamaCppService+Sampler` / `+GrammarSample` /
+`+Lifecycle` extensions. Derivation: §§10.1, 10.3, 12.2, 12.10, 13.3 and
+§ Amendment 2026-07-09.
+
 ### Why ModelManager in App/, not LLM/?
 
 `LLM/` depends on `Models` only (CLAUDE.md dependency rules). `ModelManager` handles:
@@ -343,6 +386,11 @@ Matching OllamaService (ADR-001 §7):
   fired on legitimate cleanup paths (memory warning, user cancel mid-generate).
 - Thread safety for `isModelLoaded` state: `OSAllocatedUnfairLock<Bool>`.
 
+**The `precondition` named in the first bullet no longer exists.** `generate()`
+and `generateStream()` serialize cooperatively too, via an atomic wait-and-claim
+(`acquireGenerateGuard`); the contract is unchanged, only its enforcement
+mechanism. Derivation: §13.
+
 ### Chat Template and Output Format
 
 **Chat template**: Use llama.cpp's built-in chat template application for Gemma 4.
@@ -357,6 +405,17 @@ is **Gemma 3** syntax, absent from Gemma 4's vocabulary (#1417).
 OllamaService). Phase 2 adds GBNF grammar-constrained sampling to address
 residual parse failures observed in TestFlight measurement (issue #194;
 design and cross-backend abstraction in §12 below).
+
+**The grammar constrains JSON structure only** — object shape, keys, commas and
+a shared `string` value production — and never enumerates permitted values;
+value correctness is a runtime concern, not a grammar one. Derivation:
+§ Amendment 2026-06-14 — `choose` value-enumeration removed (#599).
+
+**The grammar is not a member of the sampler chain.** It is applied outside the
+chain in a two-pass sample — a grammar-free pick, then a grammar-first resample
+when that pick is masked — because a grammar mask applied inside the chain after
+`top_k` degenerates llama.cpp's distribution sampler. Derivation: § Amendment
+2026-07-09 — Grammar-all-rejected dist fallthrough (#751 sub-class 2).
 
 ### Sampling Parameters
 
@@ -1072,7 +1131,7 @@ choice.
 - `Pastura/Models/OutputSchema.swift` (abstraction + primary-first factory)
 - `Pastura/LLM/GBNFGrammarBuilder.swift` (pure transformation + validation)
 - `Pastura/LLM/LLMService.swift` (protocol requirements + convenience forms)
-- `Pastura/LLM/LlamaCppService+Sampler.swift` (chain wiring: penalties → top_k → top_p → grammar → temperature → dist)
+- `Pastura/LLM/LlamaCppService+Sampler.swift` (chain wiring: penalties → top_k → top_p → grammar → temperature → dist — grammar was later split **out** of the chain; see § Amendment 2026-07-09)
 - `Pastura/LLM/LlamaCppService.swift` (both `runGeneration` + `runStreamGeneration` wire grammar)
 - `Pastura/LLM/OllamaService.swift` (`format: "json"` when schema non-nil)
 - `Pastura/LLM/MockLLMService.swift` (`capturedSchemas` test helper)

--- a/docs/decisions/ADR-002.md
+++ b/docs/decisions/ADR-002.md
@@ -117,12 +117,13 @@ local binary SPM target. This is what mattt/llama.swift automates.
 
 ### Pin Strategy
 
-**The pinned version itself is never quoted in this section.** It lives in
+**No live pin value is stated in this section.** It lives in
 `Package.resolved` (root lane and Xcode lane) and in `project.pbxproj`'s
 `exactVersion` requirement; the two `Package.resolved` lanes carry the same
 version, but their `originHash` fields move independently and that asymmetry is
-expected rather than a missed regeneration. Derivation: § Amendment 2026-08-15 —
-llama.swift pin bumped to 2.10327.0 (b10327) (#1487).
+expected rather than a missed regeneration. Derivation: § "Amendment 2026-08-15 —
+llama.swift pin bumped to 2.10327.0 (b10327) (#1487)" — the version in that title is
+part of an amendment's name, not a claim about the current pin.
 
 Pin to a **specific release tag** (never the `main` branch), so builds are
 reproducible and any sampler-level regression is attributable to one bump.
@@ -358,7 +359,8 @@ App/
 expired.** `LLMService` gained `generateStream` and a `schema: OutputSchema?`
 parameter, and `LLM/` gained `PartialOutputExtractor`, `GBNFGrammarBuilder`,
 `SafeSampler`, and the `LlamaCppService+Sampler` / `+GrammarSample` /
-`+Lifecycle` extensions. Derivation: §§10.1, 10.3, 12.2, 12.10, 13.3 and
+`+Lifecycle` extensions, among others — `Pastura/Pastura/LLM/` is the source of
+truth, not this listing. Derivation: §§10.1, 10.3, 12.2, 12.10, 13.3 and
 § Amendment 2026-07-09.
 
 ### Why ModelManager in App/, not LLM/?

--- a/docs/decisions/ADR-021.md
+++ b/docs/decisions/ADR-021.md
@@ -4,6 +4,37 @@
 > **Date:** 2026-07-08
 > **Context:** A single LLM-call failure anywhere in a run aborts the whole simulation (#992); runs cost minutes to tens of minutes, and the app is pre-submission with zero install base, so a late-run total loss for a first real user (App Review included) is a launch-critical risk.
 
+## How to read this ADR
+
+This file is the 2026-07-08 per-turn degradation decision — eight lettered
+decisions D1–D8 in § "Decision" — plus two dated amendments, each of which
+changes one of those letters: `Amendment 2026-07-17` reopens D2 for a
+*delivered but unmappable* action, and `Amendment 2026-08-06` reverses D7 for
+an empty *canonical primary* field. Between them the amendments are about half
+the lines here, so the **current** answer to a question is wherever the map
+below says it is — reach for an amendment when you need the *why* behind a
+rule, or what was tried and dropped. Where a lettered decision has been amended
+the body now states its current form inline, with a derivation pointer.
+
+| Arriving with | Where the current answer is |
+|---|---|
+| What does a failed LLM turn do to the run now? | § "Decision" → **D1** — the failure is contained per turn inside the six LLM handlers, through one shared `TurnFailureGate` carried on `PhaseContext` |
+| What gets written (or not) for a skipped turn, per phase? | § "Decision" → **D2** — omission, never fabrication, phase by phase, plus the `lastOutputs` clear-on-skip. Its **current** form for `choose` is the amended one: § "Amendment 2026-07-17 — D2 extended to *delivered but unmappable* actions (#1151)" → § "Decision" |
+| Why is an off-menu action no longer scored as `options[0]`? | § "Amendment 2026-07-17 …" → § "The fabrication" for the defect, § "Decision" for the normalize-then-canonicalize rule and the round-robin-only scope |
+| Which failures degrade the turn and which kill the run? | § "Decision" → **D3** — the transient / systemic / control-flow table, and the typed rethrow at the `LLMCaller` boundary that the gate pattern-matches on |
+| When does a degraded run abort anyway? | § "Decision" → **D4** — the consecutive-skip breaker and its gate mechanics (reference type, `ConditionalHandler` threading). What feeds the counter: § "Amendment 2026-07-17 …" → § "Observability (load-bearing — the drop must not be silent)" (rejections deliberately do not) and § "Amendment 2026-08-06 — D7 reversed for an empty *canonical primary* field (#1290)" → § "Consequences accepted" (empty primaries do) |
+| What does the live log show when a turn is skipped or rejected? | § "Decision" → **D5** for `SimulationEvent.turnSkipped` and the live-only/aggregate split; § "Amendment 2026-07-17 …" → § "Observability (load-bearing — the drop must not be silent)" for `.actionRejected`, why it is a separate case, and why `VoteHandler`'s ballot drop is not folded in |
+| How is a run with gaps stored and displayed? | § "Decision" → **D6** — the five-way `SimulationStatus` is untouched; the signal is the additive `degradedTurnCount` column and the badge |
+| How many retries does a turn get, and what happens when they run out? | § "Decision" → **D7**. The `empty_field` exhaustion half is superseded: the current two-clause rule (retry trigger widened, exhaustion throws for a declared-and-empty canonical primary) is § "Amendment 2026-08-06 …" → § "Decision", with the two narrowings argued in § "Why both narrowings are load-bearing" |
+| Why does an empty statement / ballot now skip the turn? | § "Amendment 2026-08-06 …" → § "The gap" for the honesty argument, § "What this reclassifies" for the per-phase before/after and why `narrate` is excluded |
+| Can a failed run be resumed? | § "Decision" → **D8** for the proposal and § "Implementation staging (multiple PRs, per #992)" (PR 4) for its staging; that it has since shipped is § "Amendment 2026-08-06 …" → § "Consequences accepted" |
+| Why per-turn containment rather than a phase skip or a new status? | § "Options" — the containment-altitude and status-representation tables — and § "Rationale" |
+| What does this make harder? | § "Trade-offs" |
+| What is explicitly *not* in scope? | § "Non-goals" for the original list; § "Amendment 2026-08-06 …" → § "What is deliberately *not* changed" (the parser's all-keys repair guard, `ReflectHandler`'s note guard) and § "Why `language_mismatch` does not move in step" |
+| Does any of this need an `EngineSchemaVersion` bump? | § "Amendment 2026-07-17 …" → § "Why there is still no bump" — the argument the § "Non-goals" annotation defers to, and the one § "Amendment 2026-08-06 …" → § "Consequences accepted" reuses verbatim |
+| How does the Kotlin engine behave here? | § "Amendment 2026-08-06 …" → § "Cross-engine convergence (ADR-023)" — the divergence, why Kotlin converges by deleting its post-parse guard, and the parity negative control that must be re-armed |
+| What does landing this cost, and in what order? | § "Implementation staging (multiple PRs, per #992)" for D1–D8; each amendment's own § "Cost" and § "Rollout" for its sweep and ordering constraints |
+
 ## Context
 
 ### The all-or-nothing failure path today
@@ -148,6 +179,13 @@ non-empty guard: memory persists, decisions don't go stale.
 Downstream tolerance for the resulting absences is the existing, verified behavior catalogued
 in Context ("already half-defensive") — this ADR adds no new downstream defaults.
 
+**The current `choose` rule is the amended one: `validateAction` normalizes and returns the
+canonical option, and a genuine non-membership drops the whole pairing and emits
+`.actionRejected` — an off-menu answer is no longer canonicalized to `options[0]`, and an
+*empty* action never reaches the handler at all.** Derivation: § Amendment 2026-07-17 —
+D2 extended to *delivered but unmappable* actions (#1151), and § Amendment 2026-08-06 —
+D7 reversed for an empty *canonical primary* field (#1290) § "What this reclassifies".
+
 **D3 — Classify failures at the `LLMCaller` boundary into three classes.**
 
 | Class | Members | Gate behavior |
@@ -208,6 +246,10 @@ exist. #992's honesty requirement ("no silent degradation") is met by the live n
 the post-hoc badge; if field usage later shows per-turn post-hoc placement matters, that is
 an additive follow-up (a nullable marker column on `turns`), not a rework.
 
+**`degradedTurnCount` is no longer fed by `.turnSkipped` alone** — `.actionRejected` folds
+into the same aggregate and the same badge, with no new column. Derivation: § Amendment
+2026-07-17 — D2 extended to *delivered but unmappable* actions (#1151) § "Observability".
+
 **D6 — Run status taxonomy unchanged; degradation recorded as metadata.** A run that reaches
 `.simulationCompleted` with skipped turns persists as `SimulationStatus.completed` plus a new
 additive `SimulationRecord` column `degradedTurnCount INTEGER NOT NULL DEFAULT 0`. Results
@@ -229,6 +271,13 @@ exhaustion now throws when the declared schema carries the canonical primary and
 empty; the retry budget itself, and the `language_mismatch` path, are still unchanged. See
 § "Amendment 2026-08-06".
 
+**The current rule has two clauses: the retry trigger scans every field as before, plus a
+declared-but-absent canonical primary; exhaustion throws `retriesExhausted` — routed to
+`.turnSkipped`, so it consumes circuit-breaker budget — iff the phase's declared output
+schema contains the canonical primary and that value is absent, empty, or `"..."`, and
+returns the parsed output otherwise.** Derivation: § Amendment 2026-08-06 — D7 reversed for
+an empty *canonical primary* field (#1290) § "Decision".
+
 **D8 — Resume proposal for failed runs: deferred final increment.** For a `.failed` run
 holding a valid round checkpoint (`stateJSON` + `currentRound`), offer "resume from round
 N+1" in the results UI, reusing the paused-run resume machinery
@@ -236,6 +285,10 @@ N+1" in the results UI, reusing the paused-run resume machinery
 case that D1–D5 deliberately do not contain. It ships last and may be spun off to its own
 issue if, after D1–D6 land, field behavior shows it is rarely reachable — decide at PR4
 planning, not silently.
+
+**D8 was not spun off: the failed-run resume proposal has shipped**, and is the standing
+mitigation for a run the circuit breaker ends. Derivation: § Amendment 2026-08-06 — D7
+reversed for an empty *canonical primary* field (#1290) § "Consequences accepted".
 
 ## Rationale
 
@@ -310,6 +363,10 @@ directive: PRs 1–3 reference #992 without `Closes` (multi-PR split convention)
   **Superseded in part 2026-07-17** — the Amendment below *does* alter the semantics of a
   *successful* turn (a delivered but unmappable action). The conclusion (no bump) survives,
   but on a different argument; see § "Amendment 2026-07-17" → "Why there is still no bump".
+  **The surviving argument is that ADR-020's gate runs in the wrong direction to help:
+  it gates old app + new content, whereas both amendments ship new app + byte-identical
+  content, so no bump could gate them.** Derivation: § Amendment 2026-07-17 — D2 extended to
+  *delivered but unmappable* actions (#1151) § "Why there is still no bump".
 
 ---
 

--- a/docs/decisions/ADR-021.md
+++ b/docs/decisions/ADR-021.md
@@ -7,11 +7,11 @@
 ## How to read this ADR
 
 This file is the 2026-07-08 per-turn degradation decision — eight lettered
-decisions D1–D8 in § "Decision" — plus two dated amendments, each of which
-changes one of those letters: `Amendment 2026-07-17` reopens D2 for a
+decisions D1–D8 in § "Decision" — plus the dated `## Amendment …` sections
+after them, each of which so far changes one of those letters: `Amendment 2026-07-17` reopens D2 for a
 *delivered but unmappable* action, and `Amendment 2026-08-06` reverses D7 for
-an empty *canonical primary* field. Between them the amendments are about half
-the lines here, so the **current** answer to a question is wherever the map
+an empty *canonical primary* field. The amendments are about half the lines
+here, so the **current** answer to a question is wherever the map
 below says it is — reach for an amendment when you need the *why* behind a
 rule, or what was tried and dropped. Where a lettered decision has been amended
 the body now states its current form inline, with a derivation pointer.
@@ -160,8 +160,7 @@ guard let output = try await context.turnGate.attempt(
   delivers nothing to canonicalize.
   **Superseded 2026-07-17** — the boundary drawn here is real, but "untouched" was the wrong
   conclusion: `options[0]` fabricates too (an agent emitting `betray!` is scored as
-  cooperating). `validateAction` now normalizes, returns the canonical option, and drops the
-  pairing on a genuine miss. See § "Amendment 2026-07-17".
+  cooperating). The current `choose` rule is stated once, at the end of D2 below.
 - `choose` (individual) / `reflect`: no write for that agent/turn.
 - `whisper`: a skipped utterance **ends that pair's exchange early** — the remaining
   sub-round turns for that pair are not attempted (a partner "replying" to a missing
@@ -248,7 +247,8 @@ an additive follow-up (a nullable marker column on `turns`), not a rework.
 
 **`degradedTurnCount` is no longer fed by `.turnSkipped` alone** — `.actionRejected` folds
 into the same aggregate and the same badge, with no new column. Derivation: § Amendment
-2026-07-17 — D2 extended to *delivered but unmappable* actions (#1151) § "Observability".
+2026-07-17 — D2 extended to *delivered but unmappable* actions (#1151) § "Observability
+(load-bearing — the drop must not be silent)".
 
 **D6 — Run status taxonomy unchanged; degradation recorded as metadata.** A run that reaches
 `.simulationCompleted` with skipped turns persists as `SimulationStatus.completed` plus a new
@@ -266,10 +266,9 @@ root-cause. The `empty_field` / `language_mismatch` degraded-return paths are al
 semantics for no containment gain).
 **Superseded in part 2026-08-06** — the containment argument holds, but `Amendment 2026-07-17`
 moved this ADR's evaluative axis to honesty, and on that axis an empty *canonical primary*
-returned as a normal `.agentOutput` is the same defect `options[0]` was. `empty_field`
-exhaustion now throws when the declared schema carries the canonical primary and its value is
-empty; the retry budget itself, and the `language_mismatch` path, are still unchanged. See
-§ "Amendment 2026-08-06".
+returned as a normal `.agentOutput` is the same defect `options[0]` was. The retry budget
+itself, and the `language_mismatch` path, are still unchanged; the current rule is stated
+once, directly below.
 
 **The current rule has two clauses: the retry trigger scans every field as before, plus a
 declared-but-absent canonical primary; exhaustion throws `retriesExhausted` — routed to


### PR DESCRIPTION
## Summary

Discharges the two `adr_navigation_missing` findings `/consistency-audit` filed on 2026-08-14, with the `## How to read this ADR` section ADR-028 established rather than a `nav-exempt` marker. Docs only.

- **ADR-002 (#1462)** — 2128 lines today (the issue measured 1788; two #1487 amendments landed since), three quarters of it amendments. The new section maps each arriving question to its section, and for the live values (the llama.swift pin, the model catalog) points at `Package.resolved` / `project.pbxproj` / `App/ModelRegistry.swift` instead of quoting them — `adr-writing.md` §4. Five rules that existed only inside an amendment are now stated once in the body with a derivation pointer: the pin is never quoted in § Pin Strategy; §6's `(unchanged)` annotations have expired; the generate `precondition` became a cooperative wait (§13); the grammar constrains structure only (#599); the grammar sits outside the sampler chain (#751). The §12.7 chain-order bullet gained a pointer to the amendment that superseded it.
- **ADR-021 (#1463)** — 654 lines, half of it two amendments that each change a lettered decision, while the body still stated D2 and D7 in their 2026-07-08 form. The new section maps each question to its section, with the amended letters pointing at the amendment for their current form. Five body one-liners state the current rule where the reader looks first, each with a derivation pointer: D2's normalize-then-canonicalize `choose` rule (#1151 / #1290), D5's `degradedTurnCount` feed (#1151), D7's two-clause retry rule (#1290), D8 having shipped rather than been spun off (#1290), and the surviving no-bump argument under Non-goals (#1151).

Nothing is deleted, trimmed, moved, or renumbered in either ADR; the diff is additions plus the body lines that gained a trailing pointer. The `nav-exempt` route was considered and declined for both: ADR-002 is the document every pin bump and model-onboarding change touches, and ADR-021's body still stated D2 and D7 in their pre-amendment form.

## Test plan

- Docs-only changeset — `scripts/precommit-gate-classify.sh` emits no `build` / `lint` token, so the Swift build, test suite and SwiftLint are skipped (stated per the carve-out).
- `python3 .claude/skills/consistency-audit/scripts/audit_docs.py --repo-root .` — on `main` it reports `nav:ADR-002` and `nav:ADR-021`; on this branch neither appears.
- Every heading and code name the new sections cite was grepped at write time (`adr-writing.md` §1); one pointer the plan suggested (`docs/models/onboarding.md` for the pin) was dropped because the file does not carry it.

## Review

Reviewer: `code-reviewer` on **Opus** — **PASS**, 0 Critical / 2 Warning / 4 Suggestion; all 43 heading citations, every promoted rule, and every code name verified against the source. All six applied in the last commit:

- W1 / W2 — ADR-021's D7 and D2 each had two non-identical statements of the amended rule (the pre-existing inline "Superseded" marker and the new block); the markers now keep only the supersession fact and point at the block.
- S1 — ADR-002's Pin Strategy note said the version is "never quoted" two lines above a heading citation that quotes it → "no live pin value is stated", with the title's version called out as a name, not a claim.
- S2 — the `LLM/` additions list is marked illustrative, with the directory as the source of truth.
- S3 — ADR-021's lead no longer counts the amendments.
- S4 — the D5 derivation pointer cites the Observability heading in full.

Plan critique (`claude-kit:critic`, Opus): no Critical; its "promote pointers and invariants, not values" constraint was written into both implementer prompts and held.

## Device QA

実機QA不要 — documentation only.

Closes #1462, closes #1463.
